### PR TITLE
Ruby: Improve performance of flow through (hash) splats

### DIFF
--- a/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
+++ b/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
@@ -886,8 +886,6 @@ module API {
       )
       or
       implicitCallEdge(pred, succ)
-      or
-      exists(DataFlow::HashLiteralNode splat | hashSplatEdge(splat, pred, succ))
     }
 
     /**
@@ -983,29 +981,6 @@ module API {
       exists(DataFlow::Node node |
         pred = getBackwardEndNode(node) and
         succ = getBackwardStartNode(node.asCallable())
-      )
-    }
-
-    pragma[nomagic]
-    private DataFlow::Node getHashSplatArgument(DataFlow::HashLiteralNode literal) {
-      result = DataFlowPrivate::TSynthHashSplatArgumentNode(literal.asExpr())
-    }
-
-    /**
-     * Holds if the epsilon edge `pred -> succ` should be generated to account for the members of a hash literal.
-     *
-     * This currently exists because hash literals are desugared to `Hash.[]` calls, whose summary relies on `WithContent`.
-     * However, `contentEdge` does not currently generate edges for `WithContent` steps.
-     */
-    bindingset[literal]
-    pragma[inline_late]
-    private predicate hashSplatEdge(DataFlow::HashLiteralNode literal, ApiNode pred, ApiNode succ) {
-      exists(TypeTracker t |
-        pred = Impl::MkForwardNode(getALocalSourceStrict(getHashSplatArgument(literal)), t) and
-        succ = Impl::MkForwardNode(pragma[only_bind_out](literal), pragma[only_bind_out](t))
-        or
-        succ = Impl::MkBackwardNode(getALocalSourceStrict(getHashSplatArgument(literal)), t) and
-        pred = Impl::MkBackwardNode(pragma[only_bind_out](literal), pragma[only_bind_out](t))
       )
     }
 

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
@@ -437,6 +437,7 @@ private module Cached {
       FlowSummaryImplSpecific::ParsePositions::isParsedKeywordParameterPosition(_, name)
     } or
     THashSplatArgumentPosition() or
+    TSynthHashSplatArgumentPosition() or
     TSplatArgumentPosition(int pos) { exists(Call c | c.getArgument(pos) instanceof SplatExpr) } or
     TSynthSplatArgumentPosition() or
     TAnyArgumentPosition() or
@@ -461,14 +462,10 @@ private module Cached {
       FlowSummaryImplSpecific::ParsePositions::isParsedKeywordArgumentPosition(_, name)
     } or
     THashSplatParameterPosition() or
-    // To get flow from a hash-splat argument to a keyword parameter, we add a read-step
-    // from a synthetic hash-splat parameter. We need this separate synthetic ParameterNode,
-    // since we clear content of the normal hash-splat parameter for the names that
-    // correspond to normal keyword parameters. Since we cannot re-use the same parameter
-    // position for multiple parameter nodes in the same callable, we introduce this
-    // synthetic parameter position.
     TSynthHashSplatParameterPosition() or
     TSplatParameterPosition(int pos) {
+      pos = 0
+      or
       exists(Parameter p | p.getPosition() = pos and p instanceof SplatParameter)
     } or
     TSynthSplatParameterPosition() or
@@ -1297,11 +1294,14 @@ class ParameterPosition extends TParameterPosition {
   /** Holds if this position represents a hash-splat parameter. */
   predicate isHashSplat() { this = THashSplatParameterPosition() }
 
+  /** Holds if this position represents a synthetic hash-splat parameter. */
   predicate isSynthHashSplat() { this = TSynthHashSplatParameterPosition() }
 
-  predicate isSynthSplat() { this = TSynthSplatParameterPosition() }
-
+  /** Holds if this position represents a splat parameter at position `n`. */
   predicate isSplat(int n) { this = TSplatParameterPosition(n) }
+
+  /** Holds if this position represents a synthetic splat parameter. */
+  predicate isSynthSplat() { this = TSynthSplatParameterPosition() }
 
   /**
    * Holds if this position represents any parameter, except `self` parameters. This
@@ -1334,9 +1334,9 @@ class ParameterPosition extends TParameterPosition {
     or
     this.isAnyNamed() and result = "any-named"
     or
-    this.isSynthSplat() and result = "synthetic *"
-    or
     exists(int pos | this.isSplat(pos) and result = "* (position " + pos + ")")
+    or
+    this.isSynthSplat() and result = "synthetic *"
   }
 }
 
@@ -1366,14 +1366,16 @@ class ArgumentPosition extends TArgumentPosition {
   /** Holds if this position represents any positional parameter. */
   predicate isAnyNamed() { this = TAnyKeywordArgumentPosition() }
 
-  /**
-   * Holds if this position represents a synthesized argument containing all keyword
-   * arguments wrapped in a hash.
-   */
+  /** Holds if this position represents a hash-splat argument. */
   predicate isHashSplat() { this = THashSplatArgumentPosition() }
 
+  /** Holds if this position represents a synthetic hash-splat argument. */
+  predicate isSynthHashSplat() { this = TSynthHashSplatArgumentPosition() }
+
+  /** Holds if this position represents a splat argument at position `n`. */
   predicate isSplat(int n) { this = TSplatArgumentPosition(n) }
 
+  /** Holds if this position represents a synthetic splat argument. */
   predicate isSynthSplat() { this = TSynthSplatArgumentPosition() }
 
   /** Gets a textual representation of this position. */
@@ -1394,9 +1396,11 @@ class ArgumentPosition extends TArgumentPosition {
     or
     this.isHashSplat() and result = "**"
     or
-    this.isSynthSplat() and result = "synthetic *"
+    this.isSynthHashSplat() and result = "synthetic **"
     or
     exists(int pos | this.isSplat(pos) and result = "* (position " + pos + ")")
+    or
+    this.isSynthSplat() and result = "synthetic *"
   }
 }
 
@@ -1429,17 +1433,21 @@ predicate parameterMatch(ParameterPosition ppos, ArgumentPosition apos) {
   or
   exists(string name | ppos.isKeyword(name) and apos.isKeyword(name))
   or
-  ppos.isHashSplat() and apos.isHashSplat()
+  (ppos.isHashSplat() or ppos.isSynthHashSplat()) and
+  (apos.isHashSplat() or apos.isSynthHashSplat())
   or
-  ppos.isSynthHashSplat() and apos.isHashSplat()
-  or
-  ppos.isSplat(0) and apos.isSynthSplat()
-  or
-  ppos.isSynthSplat() and
-  (apos.isSynthSplat() or apos.isSplat(0))
-  or
-  // Exact splat match
-  exists(int n | apos.isSplat(n) and ppos.isSplat(n))
+  exists(int pos |
+    (
+      ppos.isSplat(pos)
+      or
+      ppos.isSynthSplat() and pos = 0
+    ) and
+    (
+      apos.isSplat(pos)
+      or
+      apos.isSynthSplat() and pos = 0
+    )
+  )
   or
   ppos.isAny() and argumentPositionIsNotSelf(apos)
   or

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -128,6 +128,9 @@ SummaryComponent interpretComponentSpecific(AccessPathToken c) {
     or
     arg = "hash-splat" and
     ppos.isHashSplat()
+    or
+    arg = "splat" and
+    ppos.isSplat(0)
   )
   or
   result = interpretElementArg(c.getAnArgument("Element"))
@@ -229,6 +232,9 @@ string getParameterPosition(ParameterPosition pos) {
   or
   pos.isHashSplat() and
   result = "hash-splat"
+  or
+  pos.isSplat(0) and
+  result = "splat"
 }
 
 /** Gets the textual representation of an argument position in the format used for flow summaries. */

--- a/ruby/ql/lib/codeql/ruby/frameworks/core/Array.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/core/Array.qll
@@ -47,11 +47,11 @@ module Array {
     override MethodCall getACallSimple() { result = getAStaticArrayCall("[]") }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      exists(ArrayIndex i |
-        input = "Argument[" + i + "]" and
-        output = "ReturnValue.Element[" + i + "]" and
-        preservesValue = true
-      )
+      // we make use of the special `splat` argument kind, which contains all positional
+      // arguments wrapped in an implicit array, as well as explicit splat arguments
+      input = "Argument[splat]" and
+      output = "ReturnValue" and
+      preservesValue = true
     }
   }
 

--- a/ruby/ql/lib/codeql/ruby/frameworks/core/Hash.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/core/Hash.qll
@@ -34,7 +34,7 @@ module Hash {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       // we make use of the special `hash-splat` argument kind, which contains all keyword
       // arguments wrapped in an implicit hash, as well as explicit hash splat arguments
-      input = "Argument[hash-splat].WithElement[any]" and
+      input = "Argument[hash-splat]" and
       output = "ReturnValue" and
       preservesValue = true
     }

--- a/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
@@ -333,16 +333,14 @@ predicate basicLoadStoreStep(
 predicate readStoreStepIntoSourceNode(
   Node nodeFrom, Node nodeTo, DataFlow::ContentSet loadContent, DataFlow::ContentSet storeContent
 ) {
-  exists(DataFlowPrivate::SynthSplatParameterElementNode mid |
-    nodeFrom.(DataFlowPrivate::SynthSplatParameterNode).isParameterOf(mid.getEnclosingCallable(), _) and
-    loadContent = DataFlowPrivate::getPositionalContent(mid.getReadPosition()) and
-    nodeTo = mid.getSplatParameterNode(_) and
-    storeContent = DataFlowPrivate::getPositionalContent(mid.getStorePosition())
+  exists(DataFlowPrivate::SynthSplatParameterShiftNode shift |
+    shift.readFrom(nodeFrom, loadContent) and
+    shift.storeInto(nodeTo, storeContent)
   )
   or
-  exists(DataFlowPrivate::SynthSplatArgumentElementNode mid |
-    DataFlowPrivate::synthSplatArgumentElementReadStep(nodeFrom, loadContent, mid) and
-    DataFlowPrivate::synthSplatArgumentElementStoreStep(mid, storeContent, nodeTo)
+  exists(DataFlowPrivate::SynthSplatArgumentShiftNode shift |
+    shift.readFrom(nodeFrom, loadContent) and
+    shift.storeInto(nodeTo, storeContent)
   )
 }
 

--- a/ruby/ql/test/library-tests/dataflow/barrier-guards/barrier-guards.expected
+++ b/ruby/ql/test/library-tests/dataflow/barrier-guards/barrier-guards.expected
@@ -1,6 +1,6 @@
 WARNING: Type BarrierGuard has been deprecated and may be removed in future (barrier-guards.ql:10,3-15)
-failures
 testFailures
+failures
 oldStyleBarrierGuards
 | barrier-guards.rb:3:4:3:15 | ... == ... | barrier-guards.rb:4:5:4:7 | foo | barrier-guards.rb:3:4:3:6 | foo | true |
 | barrier-guards.rb:3:4:3:15 | ... == ... | barrier-guards.rb:4:5:4:7 | foo | barrier-guards.rb:3:11:3:15 | "foo" | true |

--- a/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.expected
+++ b/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.expected
@@ -74,14 +74,14 @@ edges
 | semantics.rb:60:5:60:5 | a | semantics.rb:66:14:66:15 | &... |
 | semantics.rb:60:9:60:18 | call to source | semantics.rb:60:5:60:5 | a |
 | semantics.rb:60:9:60:18 | call to source | semantics.rb:60:5:60:5 | a |
-| semantics.rb:61:10:61:15 | call to s10 [element 0] | semantics.rb:61:10:61:15 | call to s10 |
+| semantics.rb:61:10:61:15 | call to s10 [splat position 0] | semantics.rb:61:10:61:15 | call to s10 |
 | semantics.rb:61:14:61:14 | a | semantics.rb:61:10:61:15 | call to s10 |
 | semantics.rb:61:14:61:14 | a | semantics.rb:61:10:61:15 | call to s10 |
-| semantics.rb:61:14:61:14 | a | semantics.rb:61:10:61:15 | call to s10 [element 0] |
-| semantics.rb:62:10:62:18 | call to s10 [element 1] | semantics.rb:62:10:62:18 | call to s10 |
+| semantics.rb:61:14:61:14 | a | semantics.rb:61:10:61:15 | call to s10 [splat position 0] |
+| semantics.rb:62:10:62:18 | call to s10 [splat position 1] | semantics.rb:62:10:62:18 | call to s10 |
 | semantics.rb:62:17:62:17 | a | semantics.rb:62:10:62:18 | call to s10 |
 | semantics.rb:62:17:62:17 | a | semantics.rb:62:10:62:18 | call to s10 |
-| semantics.rb:62:17:62:17 | a | semantics.rb:62:10:62:18 | call to s10 [element 1] |
+| semantics.rb:62:17:62:17 | a | semantics.rb:62:10:62:18 | call to s10 [splat position 1] |
 | semantics.rb:63:19:63:19 | a | semantics.rb:63:10:63:20 | call to s10 |
 | semantics.rb:63:19:63:19 | a | semantics.rb:63:10:63:20 | call to s10 |
 | semantics.rb:64:27:64:27 | a | semantics.rb:64:10:64:28 | call to s10 |
@@ -132,11 +132,22 @@ edges
 | semantics.rb:99:16:99:16 | [post] y | semantics.rb:102:10:102:10 | y |
 | semantics.rb:99:24:99:24 | [post] z | semantics.rb:103:10:103:10 | z |
 | semantics.rb:99:24:99:24 | [post] z | semantics.rb:103:10:103:10 | z |
-| semantics.rb:107:5:107:5 | a | semantics.rb:109:14:109:16 | ** ... |
-| semantics.rb:107:5:107:5 | a | semantics.rb:110:28:110:30 | ** ... |
+| semantics.rb:107:5:107:5 | a | semantics.rb:109:19:109:19 | a |
+| semantics.rb:107:5:107:5 | a | semantics.rb:109:19:109:19 | a |
 | semantics.rb:107:9:107:18 | call to source | semantics.rb:107:5:107:5 | a |
-| semantics.rb:109:14:109:16 | ** ... | semantics.rb:109:10:109:17 | call to s15 |
-| semantics.rb:110:28:110:30 | ** ... | semantics.rb:110:10:110:31 | call to s15 |
+| semantics.rb:107:9:107:18 | call to source | semantics.rb:107:5:107:5 | a |
+| semantics.rb:108:5:108:5 | b | semantics.rb:110:27:110:27 | b |
+| semantics.rb:108:5:108:5 | b | semantics.rb:110:27:110:27 | b |
+| semantics.rb:108:9:108:18 | call to source | semantics.rb:108:5:108:5 | b |
+| semantics.rb:108:9:108:18 | call to source | semantics.rb:108:5:108:5 | b |
+| semantics.rb:109:10:109:28 | call to s15 [hash-splat position :foo] | semantics.rb:109:10:109:34 | ...[...] |
+| semantics.rb:109:10:109:28 | call to s15 [hash-splat position :foo] | semantics.rb:109:10:109:34 | ...[...] |
+| semantics.rb:109:19:109:19 | a | semantics.rb:109:10:109:28 | call to s15 [hash-splat position :foo] |
+| semantics.rb:109:19:109:19 | a | semantics.rb:109:10:109:28 | call to s15 [hash-splat position :foo] |
+| semantics.rb:110:10:110:28 | call to s15 [hash-splat position :bar] | semantics.rb:110:10:110:34 | ...[...] |
+| semantics.rb:110:10:110:28 | call to s15 [hash-splat position :bar] | semantics.rb:110:10:110:34 | ...[...] |
+| semantics.rb:110:27:110:27 | b | semantics.rb:110:10:110:28 | call to s15 [hash-splat position :bar] |
+| semantics.rb:110:27:110:27 | b | semantics.rb:110:10:110:28 | call to s15 [hash-splat position :bar] |
 | semantics.rb:114:5:114:5 | a | semantics.rb:116:14:116:14 | a |
 | semantics.rb:114:5:114:5 | a | semantics.rb:116:14:116:14 | a |
 | semantics.rb:114:5:114:5 | a | semantics.rb:119:17:119:17 | a |
@@ -165,872 +176,914 @@ edges
 | semantics.rb:121:20:121:22 | ** ... [element :a] | semantics.rb:121:10:121:23 | call to s16 |
 | semantics.rb:121:22:121:22 | h [element :a] | semantics.rb:121:20:121:22 | ** ... [element :a] |
 | semantics.rb:121:22:121:22 | h [element :a] | semantics.rb:121:20:121:22 | ** ... [element :a] |
-| semantics.rb:125:5:125:5 | a | semantics.rb:126:9:126:9 | a |
-| semantics.rb:125:5:125:5 | a | semantics.rb:126:9:126:9 | a |
+| semantics.rb:125:5:125:5 | a | semantics.rb:127:14:127:14 | a |
+| semantics.rb:125:5:125:5 | a | semantics.rb:128:14:128:14 | a |
+| semantics.rb:125:5:125:5 | a | semantics.rb:128:14:128:14 | a |
 | semantics.rb:125:9:125:18 | call to source | semantics.rb:125:5:125:5 | a |
 | semantics.rb:125:9:125:18 | call to source | semantics.rb:125:5:125:5 | a |
-| semantics.rb:126:9:126:9 | a | semantics.rb:126:12:126:14 | [post] ** ... |
-| semantics.rb:126:9:126:9 | a | semantics.rb:126:12:126:14 | [post] ** ... |
-| semantics.rb:126:12:126:14 | [post] ** ... | semantics.rb:127:10:127:10 | h |
-| semantics.rb:126:12:126:14 | [post] ** ... | semantics.rb:127:10:127:10 | h |
-| semantics.rb:141:5:141:5 | b | semantics.rb:145:5:145:5 | [post] h [element] |
-| semantics.rb:141:5:141:5 | b | semantics.rb:145:5:145:5 | [post] h [element] |
-| semantics.rb:141:9:141:18 | call to source | semantics.rb:141:5:141:5 | b |
-| semantics.rb:141:9:141:18 | call to source | semantics.rb:141:5:141:5 | b |
-| semantics.rb:145:5:145:5 | [post] h [element] | semantics.rb:147:14:147:14 | h [element] |
-| semantics.rb:145:5:145:5 | [post] h [element] | semantics.rb:147:14:147:14 | h [element] |
-| semantics.rb:147:14:147:14 | h [element] | semantics.rb:147:10:147:15 | call to s19 |
-| semantics.rb:147:14:147:14 | h [element] | semantics.rb:147:10:147:15 | call to s19 |
-| semantics.rb:151:5:151:5 | a | semantics.rb:152:13:152:13 | a |
-| semantics.rb:151:5:151:5 | a | semantics.rb:152:13:152:13 | a |
-| semantics.rb:151:9:151:18 | call to source | semantics.rb:151:5:151:5 | a |
-| semantics.rb:151:9:151:18 | call to source | semantics.rb:151:5:151:5 | a |
-| semantics.rb:152:5:152:5 | x [element] | semantics.rb:153:10:153:10 | x [element] |
-| semantics.rb:152:5:152:5 | x [element] | semantics.rb:153:10:153:10 | x [element] |
-| semantics.rb:152:5:152:5 | x [element] | semantics.rb:154:10:154:10 | x [element] |
-| semantics.rb:152:5:152:5 | x [element] | semantics.rb:154:10:154:10 | x [element] |
-| semantics.rb:152:9:152:14 | call to s20 [element] | semantics.rb:152:5:152:5 | x [element] |
-| semantics.rb:152:9:152:14 | call to s20 [element] | semantics.rb:152:5:152:5 | x [element] |
-| semantics.rb:152:13:152:13 | a | semantics.rb:152:9:152:14 | call to s20 [element] |
-| semantics.rb:152:13:152:13 | a | semantics.rb:152:9:152:14 | call to s20 [element] |
-| semantics.rb:153:10:153:10 | x [element] | semantics.rb:153:10:153:13 | ...[...] |
-| semantics.rb:153:10:153:10 | x [element] | semantics.rb:153:10:153:13 | ...[...] |
+| semantics.rb:126:5:126:5 | b | semantics.rb:127:17:127:17 | b |
+| semantics.rb:126:5:126:5 | b | semantics.rb:129:17:129:17 | b |
+| semantics.rb:126:5:126:5 | b | semantics.rb:129:17:129:17 | b |
+| semantics.rb:126:9:126:18 | call to source | semantics.rb:126:5:126:5 | b |
+| semantics.rb:126:9:126:18 | call to source | semantics.rb:126:5:126:5 | b |
+| semantics.rb:127:10:127:18 | call to s17 [splat position 0] | semantics.rb:127:10:127:18 | call to s17 |
+| semantics.rb:127:10:127:18 | call to s17 [splat position 1] | semantics.rb:127:10:127:18 | call to s17 |
+| semantics.rb:127:14:127:14 | a | semantics.rb:127:10:127:18 | call to s17 [splat position 0] |
+| semantics.rb:127:17:127:17 | b | semantics.rb:127:10:127:18 | call to s17 [splat position 1] |
+| semantics.rb:128:10:128:18 | call to s17 [splat position 0] | semantics.rb:128:10:128:21 | ...[...] |
+| semantics.rb:128:10:128:18 | call to s17 [splat position 0] | semantics.rb:128:10:128:21 | ...[...] |
+| semantics.rb:128:14:128:14 | a | semantics.rb:128:10:128:18 | call to s17 [splat position 0] |
+| semantics.rb:128:14:128:14 | a | semantics.rb:128:10:128:18 | call to s17 [splat position 0] |
+| semantics.rb:129:10:129:18 | call to s17 [splat position 1] | semantics.rb:129:10:129:21 | ...[...] |
+| semantics.rb:129:10:129:18 | call to s17 [splat position 1] | semantics.rb:129:10:129:21 | ...[...] |
+| semantics.rb:129:17:129:17 | b | semantics.rb:129:10:129:18 | call to s17 [splat position 1] |
+| semantics.rb:129:17:129:17 | b | semantics.rb:129:10:129:18 | call to s17 [splat position 1] |
+| semantics.rb:133:5:133:5 | a | semantics.rb:135:12:135:12 | a |
+| semantics.rb:133:5:133:5 | a | semantics.rb:135:12:135:12 | a |
+| semantics.rb:133:5:133:5 | a | semantics.rb:137:14:137:14 | a |
+| semantics.rb:133:5:133:5 | a | semantics.rb:137:14:137:14 | a |
+| semantics.rb:133:9:133:18 | call to source | semantics.rb:133:5:133:5 | a |
+| semantics.rb:133:9:133:18 | call to source | semantics.rb:133:5:133:5 | a |
+| semantics.rb:134:5:134:5 | b | semantics.rb:135:15:135:15 | b |
+| semantics.rb:134:5:134:5 | b | semantics.rb:135:15:135:15 | b |
+| semantics.rb:134:9:134:18 | call to source | semantics.rb:134:5:134:5 | b |
+| semantics.rb:134:9:134:18 | call to source | semantics.rb:134:5:134:5 | b |
+| semantics.rb:135:5:135:7 | arr [element 0] | semantics.rb:136:15:136:17 | arr [element 0] |
+| semantics.rb:135:5:135:7 | arr [element 0] | semantics.rb:136:15:136:17 | arr [element 0] |
+| semantics.rb:135:5:135:7 | arr [element 1] | semantics.rb:136:15:136:17 | arr [element 1] |
+| semantics.rb:135:5:135:7 | arr [element 1] | semantics.rb:136:15:136:17 | arr [element 1] |
+| semantics.rb:135:12:135:12 | a | semantics.rb:135:5:135:7 | arr [element 0] |
+| semantics.rb:135:12:135:12 | a | semantics.rb:135:5:135:7 | arr [element 0] |
+| semantics.rb:135:15:135:15 | b | semantics.rb:135:5:135:7 | arr [element 1] |
+| semantics.rb:135:15:135:15 | b | semantics.rb:135:5:135:7 | arr [element 1] |
+| semantics.rb:136:14:136:17 | * ... [element 0] | semantics.rb:136:10:136:18 | call to s18 |
+| semantics.rb:136:14:136:17 | * ... [element 0] | semantics.rb:136:10:136:18 | call to s18 |
+| semantics.rb:136:14:136:17 | * ... [element 1] | semantics.rb:136:10:136:18 | call to s18 |
+| semantics.rb:136:14:136:17 | * ... [element 1] | semantics.rb:136:10:136:18 | call to s18 |
+| semantics.rb:136:15:136:17 | arr [element 0] | semantics.rb:136:14:136:17 | * ... [element 0] |
+| semantics.rb:136:15:136:17 | arr [element 0] | semantics.rb:136:14:136:17 | * ... [element 0] |
+| semantics.rb:136:15:136:17 | arr [element 1] | semantics.rb:136:14:136:17 | * ... [element 1] |
+| semantics.rb:136:15:136:17 | arr [element 1] | semantics.rb:136:14:136:17 | * ... [element 1] |
+| semantics.rb:137:14:137:14 | a | semantics.rb:137:10:137:15 | call to s18 |
+| semantics.rb:137:14:137:14 | a | semantics.rb:137:10:137:15 | call to s18 |
+| semantics.rb:142:5:142:5 | b | semantics.rb:146:5:146:5 | [post] h [element] |
+| semantics.rb:142:5:142:5 | b | semantics.rb:146:5:146:5 | [post] h [element] |
+| semantics.rb:142:9:142:18 | call to source | semantics.rb:142:5:142:5 | b |
+| semantics.rb:142:9:142:18 | call to source | semantics.rb:142:5:142:5 | b |
+| semantics.rb:146:5:146:5 | [post] h [element] | semantics.rb:148:14:148:14 | h [element] |
+| semantics.rb:146:5:146:5 | [post] h [element] | semantics.rb:148:14:148:14 | h [element] |
+| semantics.rb:148:14:148:14 | h [element] | semantics.rb:148:10:148:15 | call to s19 |
+| semantics.rb:148:14:148:14 | h [element] | semantics.rb:148:10:148:15 | call to s19 |
+| semantics.rb:152:5:152:5 | a | semantics.rb:153:13:153:13 | a |
+| semantics.rb:152:5:152:5 | a | semantics.rb:153:13:153:13 | a |
+| semantics.rb:152:9:152:18 | call to source | semantics.rb:152:5:152:5 | a |
+| semantics.rb:152:9:152:18 | call to source | semantics.rb:152:5:152:5 | a |
+| semantics.rb:153:5:153:5 | x [element] | semantics.rb:154:10:154:10 | x [element] |
+| semantics.rb:153:5:153:5 | x [element] | semantics.rb:154:10:154:10 | x [element] |
+| semantics.rb:153:5:153:5 | x [element] | semantics.rb:155:10:155:10 | x [element] |
+| semantics.rb:153:5:153:5 | x [element] | semantics.rb:155:10:155:10 | x [element] |
+| semantics.rb:153:9:153:14 | call to s20 [element] | semantics.rb:153:5:153:5 | x [element] |
+| semantics.rb:153:9:153:14 | call to s20 [element] | semantics.rb:153:5:153:5 | x [element] |
+| semantics.rb:153:13:153:13 | a | semantics.rb:153:9:153:14 | call to s20 [element] |
+| semantics.rb:153:13:153:13 | a | semantics.rb:153:9:153:14 | call to s20 [element] |
 | semantics.rb:154:10:154:10 | x [element] | semantics.rb:154:10:154:13 | ...[...] |
 | semantics.rb:154:10:154:10 | x [element] | semantics.rb:154:10:154:13 | ...[...] |
-| semantics.rb:158:5:158:5 | a | semantics.rb:162:5:162:5 | [post] h [element 0] |
-| semantics.rb:158:5:158:5 | a | semantics.rb:162:5:162:5 | [post] h [element 0] |
-| semantics.rb:158:9:158:18 | call to source | semantics.rb:158:5:158:5 | a |
-| semantics.rb:158:9:158:18 | call to source | semantics.rb:158:5:158:5 | a |
-| semantics.rb:159:5:159:5 | b | semantics.rb:163:5:163:5 | [post] h [element] |
-| semantics.rb:159:5:159:5 | b | semantics.rb:163:5:163:5 | [post] h [element] |
-| semantics.rb:159:9:159:18 | call to source | semantics.rb:159:5:159:5 | b |
-| semantics.rb:159:9:159:18 | call to source | semantics.rb:159:5:159:5 | b |
-| semantics.rb:162:5:162:5 | [post] h [element 0] | semantics.rb:165:14:165:14 | h [element 0] |
-| semantics.rb:162:5:162:5 | [post] h [element 0] | semantics.rb:165:14:165:14 | h [element 0] |
-| semantics.rb:163:5:163:5 | [post] h [element] | semantics.rb:165:14:165:14 | h [element] |
-| semantics.rb:163:5:163:5 | [post] h [element] | semantics.rb:165:14:165:14 | h [element] |
-| semantics.rb:165:14:165:14 | h [element 0] | semantics.rb:165:10:165:15 | call to s21 |
-| semantics.rb:165:14:165:14 | h [element 0] | semantics.rb:165:10:165:15 | call to s21 |
-| semantics.rb:165:14:165:14 | h [element] | semantics.rb:165:10:165:15 | call to s21 |
-| semantics.rb:165:14:165:14 | h [element] | semantics.rb:165:10:165:15 | call to s21 |
-| semantics.rb:169:5:169:5 | a | semantics.rb:170:13:170:13 | a |
-| semantics.rb:169:5:169:5 | a | semantics.rb:170:13:170:13 | a |
-| semantics.rb:169:9:169:18 | call to source | semantics.rb:169:5:169:5 | a |
-| semantics.rb:169:9:169:18 | call to source | semantics.rb:169:5:169:5 | a |
-| semantics.rb:170:5:170:5 | x [element] | semantics.rb:171:10:171:10 | x [element] |
-| semantics.rb:170:5:170:5 | x [element] | semantics.rb:171:10:171:10 | x [element] |
-| semantics.rb:170:5:170:5 | x [element] | semantics.rb:172:10:172:10 | x [element] |
-| semantics.rb:170:5:170:5 | x [element] | semantics.rb:172:10:172:10 | x [element] |
-| semantics.rb:170:9:170:14 | call to s22 [element] | semantics.rb:170:5:170:5 | x [element] |
-| semantics.rb:170:9:170:14 | call to s22 [element] | semantics.rb:170:5:170:5 | x [element] |
-| semantics.rb:170:13:170:13 | a | semantics.rb:170:9:170:14 | call to s22 [element] |
-| semantics.rb:170:13:170:13 | a | semantics.rb:170:9:170:14 | call to s22 [element] |
-| semantics.rb:171:10:171:10 | x [element] | semantics.rb:171:10:171:13 | ...[...] |
-| semantics.rb:171:10:171:10 | x [element] | semantics.rb:171:10:171:13 | ...[...] |
+| semantics.rb:155:10:155:10 | x [element] | semantics.rb:155:10:155:13 | ...[...] |
+| semantics.rb:155:10:155:10 | x [element] | semantics.rb:155:10:155:13 | ...[...] |
+| semantics.rb:159:5:159:5 | a | semantics.rb:163:5:163:5 | [post] h [element 0] |
+| semantics.rb:159:5:159:5 | a | semantics.rb:163:5:163:5 | [post] h [element 0] |
+| semantics.rb:159:9:159:18 | call to source | semantics.rb:159:5:159:5 | a |
+| semantics.rb:159:9:159:18 | call to source | semantics.rb:159:5:159:5 | a |
+| semantics.rb:160:5:160:5 | b | semantics.rb:164:5:164:5 | [post] h [element] |
+| semantics.rb:160:5:160:5 | b | semantics.rb:164:5:164:5 | [post] h [element] |
+| semantics.rb:160:9:160:18 | call to source | semantics.rb:160:5:160:5 | b |
+| semantics.rb:160:9:160:18 | call to source | semantics.rb:160:5:160:5 | b |
+| semantics.rb:163:5:163:5 | [post] h [element 0] | semantics.rb:166:14:166:14 | h [element 0] |
+| semantics.rb:163:5:163:5 | [post] h [element 0] | semantics.rb:166:14:166:14 | h [element 0] |
+| semantics.rb:164:5:164:5 | [post] h [element] | semantics.rb:166:14:166:14 | h [element] |
+| semantics.rb:164:5:164:5 | [post] h [element] | semantics.rb:166:14:166:14 | h [element] |
+| semantics.rb:166:14:166:14 | h [element 0] | semantics.rb:166:10:166:15 | call to s21 |
+| semantics.rb:166:14:166:14 | h [element 0] | semantics.rb:166:10:166:15 | call to s21 |
+| semantics.rb:166:14:166:14 | h [element] | semantics.rb:166:10:166:15 | call to s21 |
+| semantics.rb:166:14:166:14 | h [element] | semantics.rb:166:10:166:15 | call to s21 |
+| semantics.rb:170:5:170:5 | a | semantics.rb:171:13:171:13 | a |
+| semantics.rb:170:5:170:5 | a | semantics.rb:171:13:171:13 | a |
+| semantics.rb:170:9:170:18 | call to source | semantics.rb:170:5:170:5 | a |
+| semantics.rb:170:9:170:18 | call to source | semantics.rb:170:5:170:5 | a |
+| semantics.rb:171:5:171:5 | x [element] | semantics.rb:172:10:172:10 | x [element] |
+| semantics.rb:171:5:171:5 | x [element] | semantics.rb:172:10:172:10 | x [element] |
+| semantics.rb:171:5:171:5 | x [element] | semantics.rb:173:10:173:10 | x [element] |
+| semantics.rb:171:5:171:5 | x [element] | semantics.rb:173:10:173:10 | x [element] |
+| semantics.rb:171:9:171:14 | call to s22 [element] | semantics.rb:171:5:171:5 | x [element] |
+| semantics.rb:171:9:171:14 | call to s22 [element] | semantics.rb:171:5:171:5 | x [element] |
+| semantics.rb:171:13:171:13 | a | semantics.rb:171:9:171:14 | call to s22 [element] |
+| semantics.rb:171:13:171:13 | a | semantics.rb:171:9:171:14 | call to s22 [element] |
 | semantics.rb:172:10:172:10 | x [element] | semantics.rb:172:10:172:13 | ...[...] |
 | semantics.rb:172:10:172:10 | x [element] | semantics.rb:172:10:172:13 | ...[...] |
-| semantics.rb:176:5:176:5 | a | semantics.rb:179:5:179:5 | [post] h [element 0] |
-| semantics.rb:176:5:176:5 | a | semantics.rb:179:5:179:5 | [post] h [element 0] |
-| semantics.rb:176:9:176:18 | call to source | semantics.rb:176:5:176:5 | a |
-| semantics.rb:176:9:176:18 | call to source | semantics.rb:176:5:176:5 | a |
-| semantics.rb:179:5:179:5 | [post] h [element 0] | semantics.rb:180:5:180:5 | h [element 0] |
-| semantics.rb:179:5:179:5 | [post] h [element 0] | semantics.rb:180:5:180:5 | h [element 0] |
-| semantics.rb:180:5:180:5 | [post] h [element 0] | semantics.rb:181:14:181:14 | h [element 0] |
-| semantics.rb:180:5:180:5 | [post] h [element 0] | semantics.rb:181:14:181:14 | h [element 0] |
-| semantics.rb:180:5:180:5 | h [element 0] | semantics.rb:180:5:180:5 | [post] h [element 0] |
-| semantics.rb:180:5:180:5 | h [element 0] | semantics.rb:180:5:180:5 | [post] h [element 0] |
-| semantics.rb:181:14:181:14 | h [element 0] | semantics.rb:181:10:181:15 | call to s23 |
-| semantics.rb:181:14:181:14 | h [element 0] | semantics.rb:181:10:181:15 | call to s23 |
-| semantics.rb:185:5:185:5 | a | semantics.rb:186:13:186:13 | a |
-| semantics.rb:185:5:185:5 | a | semantics.rb:186:13:186:13 | a |
-| semantics.rb:185:9:185:18 | call to source | semantics.rb:185:5:185:5 | a |
-| semantics.rb:185:9:185:18 | call to source | semantics.rb:185:5:185:5 | a |
-| semantics.rb:186:5:186:5 | x [element 0] | semantics.rb:187:10:187:10 | x [element 0] |
-| semantics.rb:186:5:186:5 | x [element 0] | semantics.rb:187:10:187:10 | x [element 0] |
-| semantics.rb:186:5:186:5 | x [element 0] | semantics.rb:189:10:189:10 | x [element 0] |
-| semantics.rb:186:5:186:5 | x [element 0] | semantics.rb:189:10:189:10 | x [element 0] |
-| semantics.rb:186:9:186:14 | call to s24 [element 0] | semantics.rb:186:5:186:5 | x [element 0] |
-| semantics.rb:186:9:186:14 | call to s24 [element 0] | semantics.rb:186:5:186:5 | x [element 0] |
-| semantics.rb:186:13:186:13 | a | semantics.rb:186:9:186:14 | call to s24 [element 0] |
-| semantics.rb:186:13:186:13 | a | semantics.rb:186:9:186:14 | call to s24 [element 0] |
-| semantics.rb:187:10:187:10 | x [element 0] | semantics.rb:187:10:187:13 | ...[...] |
-| semantics.rb:187:10:187:10 | x [element 0] | semantics.rb:187:10:187:13 | ...[...] |
-| semantics.rb:189:10:189:10 | x [element 0] | semantics.rb:189:10:189:13 | ...[...] |
-| semantics.rb:189:10:189:10 | x [element 0] | semantics.rb:189:10:189:13 | ...[...] |
-| semantics.rb:193:5:193:5 | a | semantics.rb:196:5:196:5 | [post] h [element 0] |
-| semantics.rb:193:5:193:5 | a | semantics.rb:196:5:196:5 | [post] h [element 0] |
-| semantics.rb:193:9:193:18 | call to source | semantics.rb:193:5:193:5 | a |
-| semantics.rb:193:9:193:18 | call to source | semantics.rb:193:5:193:5 | a |
-| semantics.rb:196:5:196:5 | [post] h [element 0] | semantics.rb:197:5:197:5 | h [element 0] |
-| semantics.rb:196:5:196:5 | [post] h [element 0] | semantics.rb:197:5:197:5 | h [element 0] |
-| semantics.rb:197:5:197:5 | [post] h [element 0] | semantics.rb:198:14:198:14 | h [element 0] |
-| semantics.rb:197:5:197:5 | [post] h [element 0] | semantics.rb:198:14:198:14 | h [element 0] |
-| semantics.rb:197:5:197:5 | h [element 0] | semantics.rb:197:5:197:5 | [post] h [element 0] |
-| semantics.rb:197:5:197:5 | h [element 0] | semantics.rb:197:5:197:5 | [post] h [element 0] |
-| semantics.rb:198:14:198:14 | h [element 0] | semantics.rb:198:10:198:15 | call to s25 |
-| semantics.rb:198:14:198:14 | h [element 0] | semantics.rb:198:10:198:15 | call to s25 |
-| semantics.rb:202:5:202:5 | a | semantics.rb:203:13:203:13 | a |
-| semantics.rb:202:5:202:5 | a | semantics.rb:203:13:203:13 | a |
-| semantics.rb:202:9:202:18 | call to source | semantics.rb:202:5:202:5 | a |
-| semantics.rb:202:9:202:18 | call to source | semantics.rb:202:5:202:5 | a |
-| semantics.rb:203:5:203:5 | x [element 0] | semantics.rb:204:10:204:10 | x [element 0] |
-| semantics.rb:203:5:203:5 | x [element 0] | semantics.rb:204:10:204:10 | x [element 0] |
-| semantics.rb:203:5:203:5 | x [element 0] | semantics.rb:206:10:206:10 | x [element 0] |
-| semantics.rb:203:5:203:5 | x [element 0] | semantics.rb:206:10:206:10 | x [element 0] |
-| semantics.rb:203:9:203:14 | call to s26 [element 0] | semantics.rb:203:5:203:5 | x [element 0] |
-| semantics.rb:203:9:203:14 | call to s26 [element 0] | semantics.rb:203:5:203:5 | x [element 0] |
-| semantics.rb:203:13:203:13 | a | semantics.rb:203:9:203:14 | call to s26 [element 0] |
-| semantics.rb:203:13:203:13 | a | semantics.rb:203:9:203:14 | call to s26 [element 0] |
-| semantics.rb:204:10:204:10 | x [element 0] | semantics.rb:204:10:204:13 | ...[...] |
-| semantics.rb:204:10:204:10 | x [element 0] | semantics.rb:204:10:204:13 | ...[...] |
-| semantics.rb:206:10:206:10 | x [element 0] | semantics.rb:206:10:206:13 | ...[...] |
-| semantics.rb:206:10:206:10 | x [element 0] | semantics.rb:206:10:206:13 | ...[...] |
-| semantics.rb:211:5:211:5 | b | semantics.rb:217:5:217:5 | [post] h [element 1] |
-| semantics.rb:211:5:211:5 | b | semantics.rb:217:5:217:5 | [post] h [element 1] |
-| semantics.rb:211:9:211:18 | call to source | semantics.rb:211:5:211:5 | b |
-| semantics.rb:211:9:211:18 | call to source | semantics.rb:211:5:211:5 | b |
-| semantics.rb:212:5:212:5 | c | semantics.rb:218:5:218:5 | [post] h [element 2] |
-| semantics.rb:212:5:212:5 | c | semantics.rb:218:5:218:5 | [post] h [element 2] |
-| semantics.rb:212:9:212:18 | call to source | semantics.rb:212:5:212:5 | c |
-| semantics.rb:212:9:212:18 | call to source | semantics.rb:212:5:212:5 | c |
-| semantics.rb:213:5:213:5 | d | semantics.rb:219:5:219:5 | [post] h [element] |
-| semantics.rb:213:5:213:5 | d | semantics.rb:219:5:219:5 | [post] h [element] |
-| semantics.rb:213:9:213:18 | call to source | semantics.rb:213:5:213:5 | d |
-| semantics.rb:213:9:213:18 | call to source | semantics.rb:213:5:213:5 | d |
-| semantics.rb:217:5:217:5 | [post] h [element 1] | semantics.rb:218:5:218:5 | h [element 1] |
-| semantics.rb:217:5:217:5 | [post] h [element 1] | semantics.rb:218:5:218:5 | h [element 1] |
-| semantics.rb:218:5:218:5 | [post] h [element 1] | semantics.rb:221:14:221:14 | h [element 1] |
-| semantics.rb:218:5:218:5 | [post] h [element 1] | semantics.rb:221:14:221:14 | h [element 1] |
-| semantics.rb:218:5:218:5 | [post] h [element 2] | semantics.rb:221:14:221:14 | h [element 2] |
-| semantics.rb:218:5:218:5 | [post] h [element 2] | semantics.rb:221:14:221:14 | h [element 2] |
-| semantics.rb:218:5:218:5 | h [element 1] | semantics.rb:218:5:218:5 | [post] h [element 1] |
-| semantics.rb:218:5:218:5 | h [element 1] | semantics.rb:218:5:218:5 | [post] h [element 1] |
-| semantics.rb:219:5:219:5 | [post] h [element] | semantics.rb:221:14:221:14 | h [element] |
-| semantics.rb:219:5:219:5 | [post] h [element] | semantics.rb:221:14:221:14 | h [element] |
-| semantics.rb:221:14:221:14 | h [element 1] | semantics.rb:221:10:221:15 | call to s27 |
-| semantics.rb:221:14:221:14 | h [element 1] | semantics.rb:221:10:221:15 | call to s27 |
-| semantics.rb:221:14:221:14 | h [element 2] | semantics.rb:221:10:221:15 | call to s27 |
-| semantics.rb:221:14:221:14 | h [element 2] | semantics.rb:221:10:221:15 | call to s27 |
-| semantics.rb:221:14:221:14 | h [element] | semantics.rb:221:10:221:15 | call to s27 |
-| semantics.rb:221:14:221:14 | h [element] | semantics.rb:221:10:221:15 | call to s27 |
-| semantics.rb:225:5:225:5 | a | semantics.rb:226:13:226:13 | a |
-| semantics.rb:225:5:225:5 | a | semantics.rb:226:13:226:13 | a |
-| semantics.rb:225:9:225:18 | call to source | semantics.rb:225:5:225:5 | a |
-| semantics.rb:225:9:225:18 | call to source | semantics.rb:225:5:225:5 | a |
-| semantics.rb:226:5:226:5 | x [element] | semantics.rb:227:10:227:10 | x [element] |
-| semantics.rb:226:5:226:5 | x [element] | semantics.rb:227:10:227:10 | x [element] |
-| semantics.rb:226:5:226:5 | x [element] | semantics.rb:228:10:228:10 | x [element] |
-| semantics.rb:226:5:226:5 | x [element] | semantics.rb:228:10:228:10 | x [element] |
-| semantics.rb:226:5:226:5 | x [element] | semantics.rb:229:10:229:10 | x [element] |
-| semantics.rb:226:5:226:5 | x [element] | semantics.rb:229:10:229:10 | x [element] |
-| semantics.rb:226:5:226:5 | x [element] | semantics.rb:230:10:230:10 | x [element] |
-| semantics.rb:226:5:226:5 | x [element] | semantics.rb:230:10:230:10 | x [element] |
-| semantics.rb:226:9:226:14 | call to s28 [element] | semantics.rb:226:5:226:5 | x [element] |
-| semantics.rb:226:9:226:14 | call to s28 [element] | semantics.rb:226:5:226:5 | x [element] |
-| semantics.rb:226:13:226:13 | a | semantics.rb:226:9:226:14 | call to s28 [element] |
-| semantics.rb:226:13:226:13 | a | semantics.rb:226:9:226:14 | call to s28 [element] |
-| semantics.rb:227:10:227:10 | x [element] | semantics.rb:227:10:227:13 | ...[...] |
-| semantics.rb:227:10:227:10 | x [element] | semantics.rb:227:10:227:13 | ...[...] |
+| semantics.rb:173:10:173:10 | x [element] | semantics.rb:173:10:173:13 | ...[...] |
+| semantics.rb:173:10:173:10 | x [element] | semantics.rb:173:10:173:13 | ...[...] |
+| semantics.rb:177:5:177:5 | a | semantics.rb:180:5:180:5 | [post] h [element 0] |
+| semantics.rb:177:5:177:5 | a | semantics.rb:180:5:180:5 | [post] h [element 0] |
+| semantics.rb:177:9:177:18 | call to source | semantics.rb:177:5:177:5 | a |
+| semantics.rb:177:9:177:18 | call to source | semantics.rb:177:5:177:5 | a |
+| semantics.rb:180:5:180:5 | [post] h [element 0] | semantics.rb:181:5:181:5 | h [element 0] |
+| semantics.rb:180:5:180:5 | [post] h [element 0] | semantics.rb:181:5:181:5 | h [element 0] |
+| semantics.rb:181:5:181:5 | [post] h [element 0] | semantics.rb:182:14:182:14 | h [element 0] |
+| semantics.rb:181:5:181:5 | [post] h [element 0] | semantics.rb:182:14:182:14 | h [element 0] |
+| semantics.rb:181:5:181:5 | h [element 0] | semantics.rb:181:5:181:5 | [post] h [element 0] |
+| semantics.rb:181:5:181:5 | h [element 0] | semantics.rb:181:5:181:5 | [post] h [element 0] |
+| semantics.rb:182:14:182:14 | h [element 0] | semantics.rb:182:10:182:15 | call to s23 |
+| semantics.rb:182:14:182:14 | h [element 0] | semantics.rb:182:10:182:15 | call to s23 |
+| semantics.rb:186:5:186:5 | a | semantics.rb:187:13:187:13 | a |
+| semantics.rb:186:5:186:5 | a | semantics.rb:187:13:187:13 | a |
+| semantics.rb:186:9:186:18 | call to source | semantics.rb:186:5:186:5 | a |
+| semantics.rb:186:9:186:18 | call to source | semantics.rb:186:5:186:5 | a |
+| semantics.rb:187:5:187:5 | x [element 0] | semantics.rb:188:10:188:10 | x [element 0] |
+| semantics.rb:187:5:187:5 | x [element 0] | semantics.rb:188:10:188:10 | x [element 0] |
+| semantics.rb:187:5:187:5 | x [element 0] | semantics.rb:190:10:190:10 | x [element 0] |
+| semantics.rb:187:5:187:5 | x [element 0] | semantics.rb:190:10:190:10 | x [element 0] |
+| semantics.rb:187:9:187:14 | call to s24 [element 0] | semantics.rb:187:5:187:5 | x [element 0] |
+| semantics.rb:187:9:187:14 | call to s24 [element 0] | semantics.rb:187:5:187:5 | x [element 0] |
+| semantics.rb:187:13:187:13 | a | semantics.rb:187:9:187:14 | call to s24 [element 0] |
+| semantics.rb:187:13:187:13 | a | semantics.rb:187:9:187:14 | call to s24 [element 0] |
+| semantics.rb:188:10:188:10 | x [element 0] | semantics.rb:188:10:188:13 | ...[...] |
+| semantics.rb:188:10:188:10 | x [element 0] | semantics.rb:188:10:188:13 | ...[...] |
+| semantics.rb:190:10:190:10 | x [element 0] | semantics.rb:190:10:190:13 | ...[...] |
+| semantics.rb:190:10:190:10 | x [element 0] | semantics.rb:190:10:190:13 | ...[...] |
+| semantics.rb:194:5:194:5 | a | semantics.rb:197:5:197:5 | [post] h [element 0] |
+| semantics.rb:194:5:194:5 | a | semantics.rb:197:5:197:5 | [post] h [element 0] |
+| semantics.rb:194:9:194:18 | call to source | semantics.rb:194:5:194:5 | a |
+| semantics.rb:194:9:194:18 | call to source | semantics.rb:194:5:194:5 | a |
+| semantics.rb:197:5:197:5 | [post] h [element 0] | semantics.rb:198:5:198:5 | h [element 0] |
+| semantics.rb:197:5:197:5 | [post] h [element 0] | semantics.rb:198:5:198:5 | h [element 0] |
+| semantics.rb:198:5:198:5 | [post] h [element 0] | semantics.rb:199:14:199:14 | h [element 0] |
+| semantics.rb:198:5:198:5 | [post] h [element 0] | semantics.rb:199:14:199:14 | h [element 0] |
+| semantics.rb:198:5:198:5 | h [element 0] | semantics.rb:198:5:198:5 | [post] h [element 0] |
+| semantics.rb:198:5:198:5 | h [element 0] | semantics.rb:198:5:198:5 | [post] h [element 0] |
+| semantics.rb:199:14:199:14 | h [element 0] | semantics.rb:199:10:199:15 | call to s25 |
+| semantics.rb:199:14:199:14 | h [element 0] | semantics.rb:199:10:199:15 | call to s25 |
+| semantics.rb:203:5:203:5 | a | semantics.rb:204:13:204:13 | a |
+| semantics.rb:203:5:203:5 | a | semantics.rb:204:13:204:13 | a |
+| semantics.rb:203:9:203:18 | call to source | semantics.rb:203:5:203:5 | a |
+| semantics.rb:203:9:203:18 | call to source | semantics.rb:203:5:203:5 | a |
+| semantics.rb:204:5:204:5 | x [element 0] | semantics.rb:205:10:205:10 | x [element 0] |
+| semantics.rb:204:5:204:5 | x [element 0] | semantics.rb:205:10:205:10 | x [element 0] |
+| semantics.rb:204:5:204:5 | x [element 0] | semantics.rb:207:10:207:10 | x [element 0] |
+| semantics.rb:204:5:204:5 | x [element 0] | semantics.rb:207:10:207:10 | x [element 0] |
+| semantics.rb:204:9:204:14 | call to s26 [element 0] | semantics.rb:204:5:204:5 | x [element 0] |
+| semantics.rb:204:9:204:14 | call to s26 [element 0] | semantics.rb:204:5:204:5 | x [element 0] |
+| semantics.rb:204:13:204:13 | a | semantics.rb:204:9:204:14 | call to s26 [element 0] |
+| semantics.rb:204:13:204:13 | a | semantics.rb:204:9:204:14 | call to s26 [element 0] |
+| semantics.rb:205:10:205:10 | x [element 0] | semantics.rb:205:10:205:13 | ...[...] |
+| semantics.rb:205:10:205:10 | x [element 0] | semantics.rb:205:10:205:13 | ...[...] |
+| semantics.rb:207:10:207:10 | x [element 0] | semantics.rb:207:10:207:13 | ...[...] |
+| semantics.rb:207:10:207:10 | x [element 0] | semantics.rb:207:10:207:13 | ...[...] |
+| semantics.rb:212:5:212:5 | b | semantics.rb:218:5:218:5 | [post] h [element 1] |
+| semantics.rb:212:5:212:5 | b | semantics.rb:218:5:218:5 | [post] h [element 1] |
+| semantics.rb:212:9:212:18 | call to source | semantics.rb:212:5:212:5 | b |
+| semantics.rb:212:9:212:18 | call to source | semantics.rb:212:5:212:5 | b |
+| semantics.rb:213:5:213:5 | c | semantics.rb:219:5:219:5 | [post] h [element 2] |
+| semantics.rb:213:5:213:5 | c | semantics.rb:219:5:219:5 | [post] h [element 2] |
+| semantics.rb:213:9:213:18 | call to source | semantics.rb:213:5:213:5 | c |
+| semantics.rb:213:9:213:18 | call to source | semantics.rb:213:5:213:5 | c |
+| semantics.rb:214:5:214:5 | d | semantics.rb:220:5:220:5 | [post] h [element] |
+| semantics.rb:214:5:214:5 | d | semantics.rb:220:5:220:5 | [post] h [element] |
+| semantics.rb:214:9:214:18 | call to source | semantics.rb:214:5:214:5 | d |
+| semantics.rb:214:9:214:18 | call to source | semantics.rb:214:5:214:5 | d |
+| semantics.rb:218:5:218:5 | [post] h [element 1] | semantics.rb:219:5:219:5 | h [element 1] |
+| semantics.rb:218:5:218:5 | [post] h [element 1] | semantics.rb:219:5:219:5 | h [element 1] |
+| semantics.rb:219:5:219:5 | [post] h [element 1] | semantics.rb:222:14:222:14 | h [element 1] |
+| semantics.rb:219:5:219:5 | [post] h [element 1] | semantics.rb:222:14:222:14 | h [element 1] |
+| semantics.rb:219:5:219:5 | [post] h [element 2] | semantics.rb:222:14:222:14 | h [element 2] |
+| semantics.rb:219:5:219:5 | [post] h [element 2] | semantics.rb:222:14:222:14 | h [element 2] |
+| semantics.rb:219:5:219:5 | h [element 1] | semantics.rb:219:5:219:5 | [post] h [element 1] |
+| semantics.rb:219:5:219:5 | h [element 1] | semantics.rb:219:5:219:5 | [post] h [element 1] |
+| semantics.rb:220:5:220:5 | [post] h [element] | semantics.rb:222:14:222:14 | h [element] |
+| semantics.rb:220:5:220:5 | [post] h [element] | semantics.rb:222:14:222:14 | h [element] |
+| semantics.rb:222:14:222:14 | h [element 1] | semantics.rb:222:10:222:15 | call to s27 |
+| semantics.rb:222:14:222:14 | h [element 1] | semantics.rb:222:10:222:15 | call to s27 |
+| semantics.rb:222:14:222:14 | h [element 2] | semantics.rb:222:10:222:15 | call to s27 |
+| semantics.rb:222:14:222:14 | h [element 2] | semantics.rb:222:10:222:15 | call to s27 |
+| semantics.rb:222:14:222:14 | h [element] | semantics.rb:222:10:222:15 | call to s27 |
+| semantics.rb:222:14:222:14 | h [element] | semantics.rb:222:10:222:15 | call to s27 |
+| semantics.rb:226:5:226:5 | a | semantics.rb:227:13:227:13 | a |
+| semantics.rb:226:5:226:5 | a | semantics.rb:227:13:227:13 | a |
+| semantics.rb:226:9:226:18 | call to source | semantics.rb:226:5:226:5 | a |
+| semantics.rb:226:9:226:18 | call to source | semantics.rb:226:5:226:5 | a |
+| semantics.rb:227:5:227:5 | x [element] | semantics.rb:228:10:228:10 | x [element] |
+| semantics.rb:227:5:227:5 | x [element] | semantics.rb:228:10:228:10 | x [element] |
+| semantics.rb:227:5:227:5 | x [element] | semantics.rb:229:10:229:10 | x [element] |
+| semantics.rb:227:5:227:5 | x [element] | semantics.rb:229:10:229:10 | x [element] |
+| semantics.rb:227:5:227:5 | x [element] | semantics.rb:230:10:230:10 | x [element] |
+| semantics.rb:227:5:227:5 | x [element] | semantics.rb:230:10:230:10 | x [element] |
+| semantics.rb:227:5:227:5 | x [element] | semantics.rb:231:10:231:10 | x [element] |
+| semantics.rb:227:5:227:5 | x [element] | semantics.rb:231:10:231:10 | x [element] |
+| semantics.rb:227:9:227:14 | call to s28 [element] | semantics.rb:227:5:227:5 | x [element] |
+| semantics.rb:227:9:227:14 | call to s28 [element] | semantics.rb:227:5:227:5 | x [element] |
+| semantics.rb:227:13:227:13 | a | semantics.rb:227:9:227:14 | call to s28 [element] |
+| semantics.rb:227:13:227:13 | a | semantics.rb:227:9:227:14 | call to s28 [element] |
 | semantics.rb:228:10:228:10 | x [element] | semantics.rb:228:10:228:13 | ...[...] |
 | semantics.rb:228:10:228:10 | x [element] | semantics.rb:228:10:228:13 | ...[...] |
 | semantics.rb:229:10:229:10 | x [element] | semantics.rb:229:10:229:13 | ...[...] |
 | semantics.rb:229:10:229:10 | x [element] | semantics.rb:229:10:229:13 | ...[...] |
 | semantics.rb:230:10:230:10 | x [element] | semantics.rb:230:10:230:13 | ...[...] |
 | semantics.rb:230:10:230:10 | x [element] | semantics.rb:230:10:230:13 | ...[...] |
-| semantics.rb:235:5:235:5 | b | semantics.rb:240:5:240:5 | [post] h [element 1] |
-| semantics.rb:235:5:235:5 | b | semantics.rb:240:5:240:5 | [post] h [element 1] |
-| semantics.rb:235:9:235:18 | call to source | semantics.rb:235:5:235:5 | b |
-| semantics.rb:235:9:235:18 | call to source | semantics.rb:235:5:235:5 | b |
-| semantics.rb:236:5:236:5 | c | semantics.rb:241:5:241:5 | [post] h [element 2] |
-| semantics.rb:236:5:236:5 | c | semantics.rb:241:5:241:5 | [post] h [element 2] |
-| semantics.rb:236:9:236:18 | call to source | semantics.rb:236:5:236:5 | c |
-| semantics.rb:236:9:236:18 | call to source | semantics.rb:236:5:236:5 | c |
-| semantics.rb:240:5:240:5 | [post] h [element 1] | semantics.rb:241:5:241:5 | h [element 1] |
-| semantics.rb:240:5:240:5 | [post] h [element 1] | semantics.rb:241:5:241:5 | h [element 1] |
-| semantics.rb:241:5:241:5 | [post] h [element 1] | semantics.rb:244:14:244:14 | h [element 1] |
-| semantics.rb:241:5:241:5 | [post] h [element 1] | semantics.rb:244:14:244:14 | h [element 1] |
-| semantics.rb:241:5:241:5 | [post] h [element 2] | semantics.rb:244:14:244:14 | h [element 2] |
-| semantics.rb:241:5:241:5 | [post] h [element 2] | semantics.rb:244:14:244:14 | h [element 2] |
-| semantics.rb:241:5:241:5 | h [element 1] | semantics.rb:241:5:241:5 | [post] h [element 1] |
-| semantics.rb:241:5:241:5 | h [element 1] | semantics.rb:241:5:241:5 | [post] h [element 1] |
-| semantics.rb:244:14:244:14 | h [element 1] | semantics.rb:244:10:244:15 | call to s29 |
-| semantics.rb:244:14:244:14 | h [element 1] | semantics.rb:244:10:244:15 | call to s29 |
-| semantics.rb:244:14:244:14 | h [element 2] | semantics.rb:244:10:244:15 | call to s29 |
-| semantics.rb:244:14:244:14 | h [element 2] | semantics.rb:244:10:244:15 | call to s29 |
-| semantics.rb:248:5:248:5 | a | semantics.rb:249:13:249:13 | a |
-| semantics.rb:248:5:248:5 | a | semantics.rb:249:13:249:13 | a |
-| semantics.rb:248:9:248:18 | call to source | semantics.rb:248:5:248:5 | a |
-| semantics.rb:248:9:248:18 | call to source | semantics.rb:248:5:248:5 | a |
-| semantics.rb:249:5:249:5 | x [element] | semantics.rb:250:10:250:10 | x [element] |
-| semantics.rb:249:5:249:5 | x [element] | semantics.rb:250:10:250:10 | x [element] |
-| semantics.rb:249:5:249:5 | x [element] | semantics.rb:251:10:251:10 | x [element] |
-| semantics.rb:249:5:249:5 | x [element] | semantics.rb:251:10:251:10 | x [element] |
-| semantics.rb:249:5:249:5 | x [element] | semantics.rb:252:10:252:10 | x [element] |
-| semantics.rb:249:5:249:5 | x [element] | semantics.rb:252:10:252:10 | x [element] |
-| semantics.rb:249:5:249:5 | x [element] | semantics.rb:253:10:253:10 | x [element] |
-| semantics.rb:249:5:249:5 | x [element] | semantics.rb:253:10:253:10 | x [element] |
-| semantics.rb:249:9:249:14 | call to s30 [element] | semantics.rb:249:5:249:5 | x [element] |
-| semantics.rb:249:9:249:14 | call to s30 [element] | semantics.rb:249:5:249:5 | x [element] |
-| semantics.rb:249:13:249:13 | a | semantics.rb:249:9:249:14 | call to s30 [element] |
-| semantics.rb:249:13:249:13 | a | semantics.rb:249:9:249:14 | call to s30 [element] |
-| semantics.rb:250:10:250:10 | x [element] | semantics.rb:250:10:250:13 | ...[...] |
-| semantics.rb:250:10:250:10 | x [element] | semantics.rb:250:10:250:13 | ...[...] |
+| semantics.rb:231:10:231:10 | x [element] | semantics.rb:231:10:231:13 | ...[...] |
+| semantics.rb:231:10:231:10 | x [element] | semantics.rb:231:10:231:13 | ...[...] |
+| semantics.rb:236:5:236:5 | b | semantics.rb:241:5:241:5 | [post] h [element 1] |
+| semantics.rb:236:5:236:5 | b | semantics.rb:241:5:241:5 | [post] h [element 1] |
+| semantics.rb:236:9:236:18 | call to source | semantics.rb:236:5:236:5 | b |
+| semantics.rb:236:9:236:18 | call to source | semantics.rb:236:5:236:5 | b |
+| semantics.rb:237:5:237:5 | c | semantics.rb:242:5:242:5 | [post] h [element 2] |
+| semantics.rb:237:5:237:5 | c | semantics.rb:242:5:242:5 | [post] h [element 2] |
+| semantics.rb:237:9:237:18 | call to source | semantics.rb:237:5:237:5 | c |
+| semantics.rb:237:9:237:18 | call to source | semantics.rb:237:5:237:5 | c |
+| semantics.rb:241:5:241:5 | [post] h [element 1] | semantics.rb:242:5:242:5 | h [element 1] |
+| semantics.rb:241:5:241:5 | [post] h [element 1] | semantics.rb:242:5:242:5 | h [element 1] |
+| semantics.rb:242:5:242:5 | [post] h [element 1] | semantics.rb:245:14:245:14 | h [element 1] |
+| semantics.rb:242:5:242:5 | [post] h [element 1] | semantics.rb:245:14:245:14 | h [element 1] |
+| semantics.rb:242:5:242:5 | [post] h [element 2] | semantics.rb:245:14:245:14 | h [element 2] |
+| semantics.rb:242:5:242:5 | [post] h [element 2] | semantics.rb:245:14:245:14 | h [element 2] |
+| semantics.rb:242:5:242:5 | h [element 1] | semantics.rb:242:5:242:5 | [post] h [element 1] |
+| semantics.rb:242:5:242:5 | h [element 1] | semantics.rb:242:5:242:5 | [post] h [element 1] |
+| semantics.rb:245:14:245:14 | h [element 1] | semantics.rb:245:10:245:15 | call to s29 |
+| semantics.rb:245:14:245:14 | h [element 1] | semantics.rb:245:10:245:15 | call to s29 |
+| semantics.rb:245:14:245:14 | h [element 2] | semantics.rb:245:10:245:15 | call to s29 |
+| semantics.rb:245:14:245:14 | h [element 2] | semantics.rb:245:10:245:15 | call to s29 |
+| semantics.rb:249:5:249:5 | a | semantics.rb:250:13:250:13 | a |
+| semantics.rb:249:5:249:5 | a | semantics.rb:250:13:250:13 | a |
+| semantics.rb:249:9:249:18 | call to source | semantics.rb:249:5:249:5 | a |
+| semantics.rb:249:9:249:18 | call to source | semantics.rb:249:5:249:5 | a |
+| semantics.rb:250:5:250:5 | x [element] | semantics.rb:251:10:251:10 | x [element] |
+| semantics.rb:250:5:250:5 | x [element] | semantics.rb:251:10:251:10 | x [element] |
+| semantics.rb:250:5:250:5 | x [element] | semantics.rb:252:10:252:10 | x [element] |
+| semantics.rb:250:5:250:5 | x [element] | semantics.rb:252:10:252:10 | x [element] |
+| semantics.rb:250:5:250:5 | x [element] | semantics.rb:253:10:253:10 | x [element] |
+| semantics.rb:250:5:250:5 | x [element] | semantics.rb:253:10:253:10 | x [element] |
+| semantics.rb:250:5:250:5 | x [element] | semantics.rb:254:10:254:10 | x [element] |
+| semantics.rb:250:5:250:5 | x [element] | semantics.rb:254:10:254:10 | x [element] |
+| semantics.rb:250:9:250:14 | call to s30 [element] | semantics.rb:250:5:250:5 | x [element] |
+| semantics.rb:250:9:250:14 | call to s30 [element] | semantics.rb:250:5:250:5 | x [element] |
+| semantics.rb:250:13:250:13 | a | semantics.rb:250:9:250:14 | call to s30 [element] |
+| semantics.rb:250:13:250:13 | a | semantics.rb:250:9:250:14 | call to s30 [element] |
 | semantics.rb:251:10:251:10 | x [element] | semantics.rb:251:10:251:13 | ...[...] |
 | semantics.rb:251:10:251:10 | x [element] | semantics.rb:251:10:251:13 | ...[...] |
 | semantics.rb:252:10:252:10 | x [element] | semantics.rb:252:10:252:13 | ...[...] |
 | semantics.rb:252:10:252:10 | x [element] | semantics.rb:252:10:252:13 | ...[...] |
 | semantics.rb:253:10:253:10 | x [element] | semantics.rb:253:10:253:13 | ...[...] |
 | semantics.rb:253:10:253:10 | x [element] | semantics.rb:253:10:253:13 | ...[...] |
-| semantics.rb:257:5:257:5 | [post] h [element :foo] | semantics.rb:258:5:258:5 | h [element :foo] |
-| semantics.rb:257:5:257:5 | [post] h [element :foo] | semantics.rb:258:5:258:5 | h [element :foo] |
-| semantics.rb:257:15:257:25 | call to source | semantics.rb:257:5:257:5 | [post] h [element :foo] |
-| semantics.rb:257:15:257:25 | call to source | semantics.rb:257:5:257:5 | [post] h [element :foo] |
+| semantics.rb:254:10:254:10 | x [element] | semantics.rb:254:10:254:13 | ...[...] |
+| semantics.rb:254:10:254:10 | x [element] | semantics.rb:254:10:254:13 | ...[...] |
 | semantics.rb:258:5:258:5 | [post] h [element :foo] | semantics.rb:259:5:259:5 | h [element :foo] |
 | semantics.rb:258:5:258:5 | [post] h [element :foo] | semantics.rb:259:5:259:5 | h [element :foo] |
-| semantics.rb:258:5:258:5 | h [element :foo] | semantics.rb:258:5:258:5 | [post] h [element :foo] |
-| semantics.rb:258:5:258:5 | h [element :foo] | semantics.rb:258:5:258:5 | [post] h [element :foo] |
-| semantics.rb:259:5:259:5 | [post] h [element :foo] | semantics.rb:262:14:262:14 | h [element :foo] |
-| semantics.rb:259:5:259:5 | [post] h [element :foo] | semantics.rb:262:14:262:14 | h [element :foo] |
+| semantics.rb:258:15:258:25 | call to source | semantics.rb:258:5:258:5 | [post] h [element :foo] |
+| semantics.rb:258:15:258:25 | call to source | semantics.rb:258:5:258:5 | [post] h [element :foo] |
+| semantics.rb:259:5:259:5 | [post] h [element :foo] | semantics.rb:260:5:260:5 | h [element :foo] |
+| semantics.rb:259:5:259:5 | [post] h [element :foo] | semantics.rb:260:5:260:5 | h [element :foo] |
 | semantics.rb:259:5:259:5 | h [element :foo] | semantics.rb:259:5:259:5 | [post] h [element :foo] |
 | semantics.rb:259:5:259:5 | h [element :foo] | semantics.rb:259:5:259:5 | [post] h [element :foo] |
-| semantics.rb:260:5:260:5 | [post] h [element] | semantics.rb:262:14:262:14 | h [element] |
-| semantics.rb:260:5:260:5 | [post] h [element] | semantics.rb:262:14:262:14 | h [element] |
-| semantics.rb:260:12:260:22 | call to source | semantics.rb:260:5:260:5 | [post] h [element] |
-| semantics.rb:260:12:260:22 | call to source | semantics.rb:260:5:260:5 | [post] h [element] |
-| semantics.rb:262:14:262:14 | h [element :foo] | semantics.rb:262:10:262:15 | call to s31 |
-| semantics.rb:262:14:262:14 | h [element :foo] | semantics.rb:262:10:262:15 | call to s31 |
-| semantics.rb:262:14:262:14 | h [element] | semantics.rb:262:10:262:15 | call to s31 |
-| semantics.rb:262:14:262:14 | h [element] | semantics.rb:262:10:262:15 | call to s31 |
-| semantics.rb:267:5:267:5 | [post] h [element foo] | semantics.rb:268:5:268:5 | h [element foo] |
-| semantics.rb:267:5:267:5 | [post] h [element foo] | semantics.rb:268:5:268:5 | h [element foo] |
-| semantics.rb:267:16:267:26 | call to source | semantics.rb:267:5:267:5 | [post] h [element foo] |
-| semantics.rb:267:16:267:26 | call to source | semantics.rb:267:5:267:5 | [post] h [element foo] |
+| semantics.rb:260:5:260:5 | [post] h [element :foo] | semantics.rb:263:14:263:14 | h [element :foo] |
+| semantics.rb:260:5:260:5 | [post] h [element :foo] | semantics.rb:263:14:263:14 | h [element :foo] |
+| semantics.rb:260:5:260:5 | h [element :foo] | semantics.rb:260:5:260:5 | [post] h [element :foo] |
+| semantics.rb:260:5:260:5 | h [element :foo] | semantics.rb:260:5:260:5 | [post] h [element :foo] |
+| semantics.rb:261:5:261:5 | [post] h [element] | semantics.rb:263:14:263:14 | h [element] |
+| semantics.rb:261:5:261:5 | [post] h [element] | semantics.rb:263:14:263:14 | h [element] |
+| semantics.rb:261:12:261:22 | call to source | semantics.rb:261:5:261:5 | [post] h [element] |
+| semantics.rb:261:12:261:22 | call to source | semantics.rb:261:5:261:5 | [post] h [element] |
+| semantics.rb:263:14:263:14 | h [element :foo] | semantics.rb:263:10:263:15 | call to s31 |
+| semantics.rb:263:14:263:14 | h [element :foo] | semantics.rb:263:10:263:15 | call to s31 |
+| semantics.rb:263:14:263:14 | h [element] | semantics.rb:263:10:263:15 | call to s31 |
+| semantics.rb:263:14:263:14 | h [element] | semantics.rb:263:10:263:15 | call to s31 |
 | semantics.rb:268:5:268:5 | [post] h [element foo] | semantics.rb:269:5:269:5 | h [element foo] |
 | semantics.rb:268:5:268:5 | [post] h [element foo] | semantics.rb:269:5:269:5 | h [element foo] |
-| semantics.rb:268:5:268:5 | h [element foo] | semantics.rb:268:5:268:5 | [post] h [element foo] |
-| semantics.rb:268:5:268:5 | h [element foo] | semantics.rb:268:5:268:5 | [post] h [element foo] |
-| semantics.rb:269:5:269:5 | [post] h [element foo] | semantics.rb:272:14:272:14 | h [element foo] |
-| semantics.rb:269:5:269:5 | [post] h [element foo] | semantics.rb:272:14:272:14 | h [element foo] |
+| semantics.rb:268:16:268:26 | call to source | semantics.rb:268:5:268:5 | [post] h [element foo] |
+| semantics.rb:268:16:268:26 | call to source | semantics.rb:268:5:268:5 | [post] h [element foo] |
+| semantics.rb:269:5:269:5 | [post] h [element foo] | semantics.rb:270:5:270:5 | h [element foo] |
+| semantics.rb:269:5:269:5 | [post] h [element foo] | semantics.rb:270:5:270:5 | h [element foo] |
 | semantics.rb:269:5:269:5 | h [element foo] | semantics.rb:269:5:269:5 | [post] h [element foo] |
 | semantics.rb:269:5:269:5 | h [element foo] | semantics.rb:269:5:269:5 | [post] h [element foo] |
-| semantics.rb:270:5:270:5 | [post] h [element] | semantics.rb:272:14:272:14 | h [element] |
-| semantics.rb:270:5:270:5 | [post] h [element] | semantics.rb:272:14:272:14 | h [element] |
-| semantics.rb:270:12:270:22 | call to source | semantics.rb:270:5:270:5 | [post] h [element] |
-| semantics.rb:270:12:270:22 | call to source | semantics.rb:270:5:270:5 | [post] h [element] |
-| semantics.rb:272:14:272:14 | h [element foo] | semantics.rb:272:10:272:15 | call to s32 |
-| semantics.rb:272:14:272:14 | h [element foo] | semantics.rb:272:10:272:15 | call to s32 |
-| semantics.rb:272:14:272:14 | h [element] | semantics.rb:272:10:272:15 | call to s32 |
-| semantics.rb:272:14:272:14 | h [element] | semantics.rb:272:10:272:15 | call to s32 |
-| semantics.rb:280:5:280:5 | [post] h [element] | semantics.rb:281:5:281:5 | h [element] |
-| semantics.rb:280:5:280:5 | [post] h [element] | semantics.rb:281:5:281:5 | h [element] |
-| semantics.rb:280:12:280:22 | call to source | semantics.rb:280:5:280:5 | [post] h [element] |
-| semantics.rb:280:12:280:22 | call to source | semantics.rb:280:5:280:5 | [post] h [element] |
-| semantics.rb:281:5:281:5 | [post] h [element nil] | semantics.rb:282:5:282:5 | h [element nil] |
-| semantics.rb:281:5:281:5 | [post] h [element nil] | semantics.rb:282:5:282:5 | h [element nil] |
+| semantics.rb:270:5:270:5 | [post] h [element foo] | semantics.rb:273:14:273:14 | h [element foo] |
+| semantics.rb:270:5:270:5 | [post] h [element foo] | semantics.rb:273:14:273:14 | h [element foo] |
+| semantics.rb:270:5:270:5 | h [element foo] | semantics.rb:270:5:270:5 | [post] h [element foo] |
+| semantics.rb:270:5:270:5 | h [element foo] | semantics.rb:270:5:270:5 | [post] h [element foo] |
+| semantics.rb:271:5:271:5 | [post] h [element] | semantics.rb:273:14:273:14 | h [element] |
+| semantics.rb:271:5:271:5 | [post] h [element] | semantics.rb:273:14:273:14 | h [element] |
+| semantics.rb:271:12:271:22 | call to source | semantics.rb:271:5:271:5 | [post] h [element] |
+| semantics.rb:271:12:271:22 | call to source | semantics.rb:271:5:271:5 | [post] h [element] |
+| semantics.rb:273:14:273:14 | h [element foo] | semantics.rb:273:10:273:15 | call to s32 |
+| semantics.rb:273:14:273:14 | h [element foo] | semantics.rb:273:10:273:15 | call to s32 |
+| semantics.rb:273:14:273:14 | h [element] | semantics.rb:273:10:273:15 | call to s32 |
+| semantics.rb:273:14:273:14 | h [element] | semantics.rb:273:10:273:15 | call to s32 |
 | semantics.rb:281:5:281:5 | [post] h [element] | semantics.rb:282:5:282:5 | h [element] |
 | semantics.rb:281:5:281:5 | [post] h [element] | semantics.rb:282:5:282:5 | h [element] |
-| semantics.rb:281:5:281:5 | h [element] | semantics.rb:281:5:281:5 | [post] h [element] |
-| semantics.rb:281:5:281:5 | h [element] | semantics.rb:281:5:281:5 | [post] h [element] |
-| semantics.rb:281:14:281:24 | call to source | semantics.rb:281:5:281:5 | [post] h [element nil] |
-| semantics.rb:281:14:281:24 | call to source | semantics.rb:281:5:281:5 | [post] h [element nil] |
+| semantics.rb:281:12:281:22 | call to source | semantics.rb:281:5:281:5 | [post] h [element] |
+| semantics.rb:281:12:281:22 | call to source | semantics.rb:281:5:281:5 | [post] h [element] |
 | semantics.rb:282:5:282:5 | [post] h [element nil] | semantics.rb:283:5:283:5 | h [element nil] |
 | semantics.rb:282:5:282:5 | [post] h [element nil] | semantics.rb:283:5:283:5 | h [element nil] |
-| semantics.rb:282:5:282:5 | [post] h [element true] | semantics.rb:283:5:283:5 | h [element true] |
-| semantics.rb:282:5:282:5 | [post] h [element true] | semantics.rb:283:5:283:5 | h [element true] |
 | semantics.rb:282:5:282:5 | [post] h [element] | semantics.rb:283:5:283:5 | h [element] |
 | semantics.rb:282:5:282:5 | [post] h [element] | semantics.rb:283:5:283:5 | h [element] |
-| semantics.rb:282:5:282:5 | h [element nil] | semantics.rb:282:5:282:5 | [post] h [element nil] |
-| semantics.rb:282:5:282:5 | h [element nil] | semantics.rb:282:5:282:5 | [post] h [element nil] |
 | semantics.rb:282:5:282:5 | h [element] | semantics.rb:282:5:282:5 | [post] h [element] |
 | semantics.rb:282:5:282:5 | h [element] | semantics.rb:282:5:282:5 | [post] h [element] |
-| semantics.rb:282:15:282:25 | call to source | semantics.rb:282:5:282:5 | [post] h [element true] |
-| semantics.rb:282:15:282:25 | call to source | semantics.rb:282:5:282:5 | [post] h [element true] |
-| semantics.rb:283:5:283:5 | [post] h [element false] | semantics.rb:285:14:285:14 | h [element false] |
-| semantics.rb:283:5:283:5 | [post] h [element false] | semantics.rb:285:14:285:14 | h [element false] |
-| semantics.rb:283:5:283:5 | [post] h [element nil] | semantics.rb:285:14:285:14 | h [element nil] |
-| semantics.rb:283:5:283:5 | [post] h [element nil] | semantics.rb:285:14:285:14 | h [element nil] |
-| semantics.rb:283:5:283:5 | [post] h [element true] | semantics.rb:285:14:285:14 | h [element true] |
-| semantics.rb:283:5:283:5 | [post] h [element true] | semantics.rb:285:14:285:14 | h [element true] |
-| semantics.rb:283:5:283:5 | [post] h [element] | semantics.rb:285:14:285:14 | h [element] |
-| semantics.rb:283:5:283:5 | [post] h [element] | semantics.rb:285:14:285:14 | h [element] |
+| semantics.rb:282:14:282:24 | call to source | semantics.rb:282:5:282:5 | [post] h [element nil] |
+| semantics.rb:282:14:282:24 | call to source | semantics.rb:282:5:282:5 | [post] h [element nil] |
+| semantics.rb:283:5:283:5 | [post] h [element nil] | semantics.rb:284:5:284:5 | h [element nil] |
+| semantics.rb:283:5:283:5 | [post] h [element nil] | semantics.rb:284:5:284:5 | h [element nil] |
+| semantics.rb:283:5:283:5 | [post] h [element true] | semantics.rb:284:5:284:5 | h [element true] |
+| semantics.rb:283:5:283:5 | [post] h [element true] | semantics.rb:284:5:284:5 | h [element true] |
+| semantics.rb:283:5:283:5 | [post] h [element] | semantics.rb:284:5:284:5 | h [element] |
+| semantics.rb:283:5:283:5 | [post] h [element] | semantics.rb:284:5:284:5 | h [element] |
 | semantics.rb:283:5:283:5 | h [element nil] | semantics.rb:283:5:283:5 | [post] h [element nil] |
 | semantics.rb:283:5:283:5 | h [element nil] | semantics.rb:283:5:283:5 | [post] h [element nil] |
-| semantics.rb:283:5:283:5 | h [element true] | semantics.rb:283:5:283:5 | [post] h [element true] |
-| semantics.rb:283:5:283:5 | h [element true] | semantics.rb:283:5:283:5 | [post] h [element true] |
 | semantics.rb:283:5:283:5 | h [element] | semantics.rb:283:5:283:5 | [post] h [element] |
 | semantics.rb:283:5:283:5 | h [element] | semantics.rb:283:5:283:5 | [post] h [element] |
-| semantics.rb:283:16:283:26 | call to source | semantics.rb:283:5:283:5 | [post] h [element false] |
-| semantics.rb:283:16:283:26 | call to source | semantics.rb:283:5:283:5 | [post] h [element false] |
-| semantics.rb:285:14:285:14 | h [element false] | semantics.rb:285:10:285:15 | call to s33 |
-| semantics.rb:285:14:285:14 | h [element false] | semantics.rb:285:10:285:15 | call to s33 |
-| semantics.rb:285:14:285:14 | h [element nil] | semantics.rb:285:10:285:15 | call to s33 |
-| semantics.rb:285:14:285:14 | h [element nil] | semantics.rb:285:10:285:15 | call to s33 |
-| semantics.rb:285:14:285:14 | h [element true] | semantics.rb:285:10:285:15 | call to s33 |
-| semantics.rb:285:14:285:14 | h [element true] | semantics.rb:285:10:285:15 | call to s33 |
-| semantics.rb:285:14:285:14 | h [element] | semantics.rb:285:10:285:15 | call to s33 |
-| semantics.rb:285:14:285:14 | h [element] | semantics.rb:285:10:285:15 | call to s33 |
-| semantics.rb:289:5:289:5 | x [element :foo] | semantics.rb:290:10:290:10 | x [element :foo] |
-| semantics.rb:289:5:289:5 | x [element :foo] | semantics.rb:290:10:290:10 | x [element :foo] |
-| semantics.rb:289:5:289:5 | x [element :foo] | semantics.rb:292:10:292:10 | x [element :foo] |
-| semantics.rb:289:5:289:5 | x [element :foo] | semantics.rb:292:10:292:10 | x [element :foo] |
-| semantics.rb:289:9:289:24 | call to s35 [element :foo] | semantics.rb:289:5:289:5 | x [element :foo] |
-| semantics.rb:289:9:289:24 | call to s35 [element :foo] | semantics.rb:289:5:289:5 | x [element :foo] |
-| semantics.rb:289:13:289:23 | call to source | semantics.rb:289:9:289:24 | call to s35 [element :foo] |
-| semantics.rb:289:13:289:23 | call to source | semantics.rb:289:9:289:24 | call to s35 [element :foo] |
-| semantics.rb:290:10:290:10 | x [element :foo] | semantics.rb:290:10:290:16 | ...[...] |
-| semantics.rb:290:10:290:10 | x [element :foo] | semantics.rb:290:10:290:16 | ...[...] |
-| semantics.rb:292:10:292:10 | x [element :foo] | semantics.rb:292:10:292:13 | ...[...] |
-| semantics.rb:292:10:292:10 | x [element :foo] | semantics.rb:292:10:292:13 | ...[...] |
-| semantics.rb:296:5:296:5 | x [element foo] | semantics.rb:298:10:298:10 | x [element foo] |
-| semantics.rb:296:5:296:5 | x [element foo] | semantics.rb:298:10:298:10 | x [element foo] |
-| semantics.rb:296:5:296:5 | x [element foo] | semantics.rb:300:10:300:10 | x [element foo] |
-| semantics.rb:296:5:296:5 | x [element foo] | semantics.rb:300:10:300:10 | x [element foo] |
-| semantics.rb:296:9:296:24 | call to s36 [element foo] | semantics.rb:296:5:296:5 | x [element foo] |
-| semantics.rb:296:9:296:24 | call to s36 [element foo] | semantics.rb:296:5:296:5 | x [element foo] |
-| semantics.rb:296:13:296:23 | call to source | semantics.rb:296:9:296:24 | call to s36 [element foo] |
-| semantics.rb:296:13:296:23 | call to source | semantics.rb:296:9:296:24 | call to s36 [element foo] |
-| semantics.rb:298:10:298:10 | x [element foo] | semantics.rb:298:10:298:17 | ...[...] |
-| semantics.rb:298:10:298:10 | x [element foo] | semantics.rb:298:10:298:17 | ...[...] |
-| semantics.rb:300:10:300:10 | x [element foo] | semantics.rb:300:10:300:13 | ...[...] |
-| semantics.rb:300:10:300:10 | x [element foo] | semantics.rb:300:10:300:13 | ...[...] |
-| semantics.rb:304:5:304:5 | x [element true] | semantics.rb:306:10:306:10 | x [element true] |
-| semantics.rb:304:5:304:5 | x [element true] | semantics.rb:306:10:306:10 | x [element true] |
-| semantics.rb:304:5:304:5 | x [element true] | semantics.rb:308:10:308:10 | x [element true] |
-| semantics.rb:304:5:304:5 | x [element true] | semantics.rb:308:10:308:10 | x [element true] |
-| semantics.rb:304:9:304:24 | call to s37 [element true] | semantics.rb:304:5:304:5 | x [element true] |
-| semantics.rb:304:9:304:24 | call to s37 [element true] | semantics.rb:304:5:304:5 | x [element true] |
-| semantics.rb:304:13:304:23 | call to source | semantics.rb:304:9:304:24 | call to s37 [element true] |
-| semantics.rb:304:13:304:23 | call to source | semantics.rb:304:9:304:24 | call to s37 [element true] |
-| semantics.rb:306:10:306:10 | x [element true] | semantics.rb:306:10:306:16 | ...[...] |
-| semantics.rb:306:10:306:10 | x [element true] | semantics.rb:306:10:306:16 | ...[...] |
-| semantics.rb:308:10:308:10 | x [element true] | semantics.rb:308:10:308:13 | ...[...] |
-| semantics.rb:308:10:308:10 | x [element true] | semantics.rb:308:10:308:13 | ...[...] |
-| semantics.rb:312:5:312:5 | [post] h [element foo] | semantics.rb:315:14:315:14 | h [element foo] |
-| semantics.rb:312:5:312:5 | [post] h [element foo] | semantics.rb:315:14:315:14 | h [element foo] |
-| semantics.rb:312:16:312:26 | call to source | semantics.rb:312:5:312:5 | [post] h [element foo] |
-| semantics.rb:312:16:312:26 | call to source | semantics.rb:312:5:312:5 | [post] h [element foo] |
-| semantics.rb:315:14:315:14 | h [element foo] | semantics.rb:315:10:315:15 | call to s38 |
-| semantics.rb:315:14:315:14 | h [element foo] | semantics.rb:315:10:315:15 | call to s38 |
-| semantics.rb:319:5:319:5 | x [element :foo] | semantics.rb:321:10:321:10 | x [element :foo] |
-| semantics.rb:319:5:319:5 | x [element :foo] | semantics.rb:321:10:321:10 | x [element :foo] |
-| semantics.rb:319:5:319:5 | x [element :foo] | semantics.rb:322:10:322:10 | x [element :foo] |
-| semantics.rb:319:5:319:5 | x [element :foo] | semantics.rb:322:10:322:10 | x [element :foo] |
-| semantics.rb:319:9:319:24 | call to s39 [element :foo] | semantics.rb:319:5:319:5 | x [element :foo] |
-| semantics.rb:319:9:319:24 | call to s39 [element :foo] | semantics.rb:319:5:319:5 | x [element :foo] |
-| semantics.rb:319:13:319:23 | call to source | semantics.rb:319:9:319:24 | call to s39 [element :foo] |
-| semantics.rb:319:13:319:23 | call to source | semantics.rb:319:9:319:24 | call to s39 [element :foo] |
-| semantics.rb:321:10:321:10 | x [element :foo] | semantics.rb:321:10:321:16 | ...[...] |
-| semantics.rb:321:10:321:10 | x [element :foo] | semantics.rb:321:10:321:16 | ...[...] |
-| semantics.rb:322:10:322:10 | x [element :foo] | semantics.rb:322:10:322:13 | ...[...] |
-| semantics.rb:322:10:322:10 | x [element :foo] | semantics.rb:322:10:322:13 | ...[...] |
-| semantics.rb:327:5:327:5 | [post] x [@foo] | semantics.rb:329:14:329:14 | x [@foo] |
-| semantics.rb:327:5:327:5 | [post] x [@foo] | semantics.rb:329:14:329:14 | x [@foo] |
-| semantics.rb:327:13:327:23 | call to source | semantics.rb:327:5:327:5 | [post] x [@foo] |
-| semantics.rb:327:13:327:23 | call to source | semantics.rb:327:5:327:5 | [post] x [@foo] |
-| semantics.rb:329:14:329:14 | x [@foo] | semantics.rb:329:10:329:15 | call to s40 |
-| semantics.rb:329:14:329:14 | x [@foo] | semantics.rb:329:10:329:15 | call to s40 |
-| semantics.rb:333:5:333:5 | x [@foo] | semantics.rb:334:10:334:10 | x [@foo] |
-| semantics.rb:333:5:333:5 | x [@foo] | semantics.rb:334:10:334:10 | x [@foo] |
-| semantics.rb:333:9:333:24 | call to s41 [@foo] | semantics.rb:333:5:333:5 | x [@foo] |
-| semantics.rb:333:9:333:24 | call to s41 [@foo] | semantics.rb:333:5:333:5 | x [@foo] |
-| semantics.rb:333:13:333:23 | call to source | semantics.rb:333:9:333:24 | call to s41 [@foo] |
-| semantics.rb:333:13:333:23 | call to source | semantics.rb:333:9:333:24 | call to s41 [@foo] |
-| semantics.rb:334:10:334:10 | x [@foo] | semantics.rb:334:10:334:14 | call to foo |
-| semantics.rb:334:10:334:10 | x [@foo] | semantics.rb:334:10:334:14 | call to foo |
-| semantics.rb:339:5:339:5 | [post] h [element 0] | semantics.rb:342:13:342:13 | h [element 0] |
-| semantics.rb:339:5:339:5 | [post] h [element 0] | semantics.rb:342:13:342:13 | h [element 0] |
-| semantics.rb:339:12:339:22 | call to source | semantics.rb:339:5:339:5 | [post] h [element 0] |
-| semantics.rb:339:12:339:22 | call to source | semantics.rb:339:5:339:5 | [post] h [element 0] |
-| semantics.rb:340:5:340:5 | [post] h [element] | semantics.rb:342:13:342:13 | h [element] |
-| semantics.rb:340:5:340:5 | [post] h [element] | semantics.rb:342:13:342:13 | h [element] |
-| semantics.rb:340:12:340:22 | call to source | semantics.rb:340:5:340:5 | [post] h [element] |
-| semantics.rb:340:12:340:22 | call to source | semantics.rb:340:5:340:5 | [post] h [element] |
-| semantics.rb:342:5:342:5 | x [element 0] | semantics.rb:344:10:344:10 | x [element 0] |
-| semantics.rb:342:5:342:5 | x [element 0] | semantics.rb:344:10:344:10 | x [element 0] |
-| semantics.rb:342:5:342:5 | x [element 0] | semantics.rb:346:10:346:10 | x [element 0] |
-| semantics.rb:342:5:342:5 | x [element 0] | semantics.rb:346:10:346:10 | x [element 0] |
-| semantics.rb:342:5:342:5 | x [element] | semantics.rb:344:10:344:10 | x [element] |
-| semantics.rb:342:5:342:5 | x [element] | semantics.rb:344:10:344:10 | x [element] |
-| semantics.rb:342:5:342:5 | x [element] | semantics.rb:345:10:345:10 | x [element] |
-| semantics.rb:342:5:342:5 | x [element] | semantics.rb:345:10:345:10 | x [element] |
-| semantics.rb:342:5:342:5 | x [element] | semantics.rb:346:10:346:10 | x [element] |
-| semantics.rb:342:5:342:5 | x [element] | semantics.rb:346:10:346:10 | x [element] |
-| semantics.rb:342:9:342:14 | call to s42 [element 0] | semantics.rb:342:5:342:5 | x [element 0] |
-| semantics.rb:342:9:342:14 | call to s42 [element 0] | semantics.rb:342:5:342:5 | x [element 0] |
-| semantics.rb:342:9:342:14 | call to s42 [element] | semantics.rb:342:5:342:5 | x [element] |
-| semantics.rb:342:9:342:14 | call to s42 [element] | semantics.rb:342:5:342:5 | x [element] |
-| semantics.rb:342:13:342:13 | h [element 0] | semantics.rb:342:9:342:14 | call to s42 [element 0] |
-| semantics.rb:342:13:342:13 | h [element 0] | semantics.rb:342:9:342:14 | call to s42 [element 0] |
-| semantics.rb:342:13:342:13 | h [element] | semantics.rb:342:9:342:14 | call to s42 [element] |
-| semantics.rb:342:13:342:13 | h [element] | semantics.rb:342:9:342:14 | call to s42 [element] |
-| semantics.rb:344:10:344:10 | x [element 0] | semantics.rb:344:10:344:13 | ...[...] |
-| semantics.rb:344:10:344:10 | x [element 0] | semantics.rb:344:10:344:13 | ...[...] |
-| semantics.rb:344:10:344:10 | x [element] | semantics.rb:344:10:344:13 | ...[...] |
-| semantics.rb:344:10:344:10 | x [element] | semantics.rb:344:10:344:13 | ...[...] |
+| semantics.rb:283:15:283:25 | call to source | semantics.rb:283:5:283:5 | [post] h [element true] |
+| semantics.rb:283:15:283:25 | call to source | semantics.rb:283:5:283:5 | [post] h [element true] |
+| semantics.rb:284:5:284:5 | [post] h [element false] | semantics.rb:286:14:286:14 | h [element false] |
+| semantics.rb:284:5:284:5 | [post] h [element false] | semantics.rb:286:14:286:14 | h [element false] |
+| semantics.rb:284:5:284:5 | [post] h [element nil] | semantics.rb:286:14:286:14 | h [element nil] |
+| semantics.rb:284:5:284:5 | [post] h [element nil] | semantics.rb:286:14:286:14 | h [element nil] |
+| semantics.rb:284:5:284:5 | [post] h [element true] | semantics.rb:286:14:286:14 | h [element true] |
+| semantics.rb:284:5:284:5 | [post] h [element true] | semantics.rb:286:14:286:14 | h [element true] |
+| semantics.rb:284:5:284:5 | [post] h [element] | semantics.rb:286:14:286:14 | h [element] |
+| semantics.rb:284:5:284:5 | [post] h [element] | semantics.rb:286:14:286:14 | h [element] |
+| semantics.rb:284:5:284:5 | h [element nil] | semantics.rb:284:5:284:5 | [post] h [element nil] |
+| semantics.rb:284:5:284:5 | h [element nil] | semantics.rb:284:5:284:5 | [post] h [element nil] |
+| semantics.rb:284:5:284:5 | h [element true] | semantics.rb:284:5:284:5 | [post] h [element true] |
+| semantics.rb:284:5:284:5 | h [element true] | semantics.rb:284:5:284:5 | [post] h [element true] |
+| semantics.rb:284:5:284:5 | h [element] | semantics.rb:284:5:284:5 | [post] h [element] |
+| semantics.rb:284:5:284:5 | h [element] | semantics.rb:284:5:284:5 | [post] h [element] |
+| semantics.rb:284:16:284:26 | call to source | semantics.rb:284:5:284:5 | [post] h [element false] |
+| semantics.rb:284:16:284:26 | call to source | semantics.rb:284:5:284:5 | [post] h [element false] |
+| semantics.rb:286:14:286:14 | h [element false] | semantics.rb:286:10:286:15 | call to s33 |
+| semantics.rb:286:14:286:14 | h [element false] | semantics.rb:286:10:286:15 | call to s33 |
+| semantics.rb:286:14:286:14 | h [element nil] | semantics.rb:286:10:286:15 | call to s33 |
+| semantics.rb:286:14:286:14 | h [element nil] | semantics.rb:286:10:286:15 | call to s33 |
+| semantics.rb:286:14:286:14 | h [element true] | semantics.rb:286:10:286:15 | call to s33 |
+| semantics.rb:286:14:286:14 | h [element true] | semantics.rb:286:10:286:15 | call to s33 |
+| semantics.rb:286:14:286:14 | h [element] | semantics.rb:286:10:286:15 | call to s33 |
+| semantics.rb:286:14:286:14 | h [element] | semantics.rb:286:10:286:15 | call to s33 |
+| semantics.rb:290:5:290:5 | x [element :foo] | semantics.rb:291:10:291:10 | x [element :foo] |
+| semantics.rb:290:5:290:5 | x [element :foo] | semantics.rb:291:10:291:10 | x [element :foo] |
+| semantics.rb:290:5:290:5 | x [element :foo] | semantics.rb:293:10:293:10 | x [element :foo] |
+| semantics.rb:290:5:290:5 | x [element :foo] | semantics.rb:293:10:293:10 | x [element :foo] |
+| semantics.rb:290:9:290:24 | call to s35 [element :foo] | semantics.rb:290:5:290:5 | x [element :foo] |
+| semantics.rb:290:9:290:24 | call to s35 [element :foo] | semantics.rb:290:5:290:5 | x [element :foo] |
+| semantics.rb:290:13:290:23 | call to source | semantics.rb:290:9:290:24 | call to s35 [element :foo] |
+| semantics.rb:290:13:290:23 | call to source | semantics.rb:290:9:290:24 | call to s35 [element :foo] |
+| semantics.rb:291:10:291:10 | x [element :foo] | semantics.rb:291:10:291:16 | ...[...] |
+| semantics.rb:291:10:291:10 | x [element :foo] | semantics.rb:291:10:291:16 | ...[...] |
+| semantics.rb:293:10:293:10 | x [element :foo] | semantics.rb:293:10:293:13 | ...[...] |
+| semantics.rb:293:10:293:10 | x [element :foo] | semantics.rb:293:10:293:13 | ...[...] |
+| semantics.rb:297:5:297:5 | x [element foo] | semantics.rb:299:10:299:10 | x [element foo] |
+| semantics.rb:297:5:297:5 | x [element foo] | semantics.rb:299:10:299:10 | x [element foo] |
+| semantics.rb:297:5:297:5 | x [element foo] | semantics.rb:301:10:301:10 | x [element foo] |
+| semantics.rb:297:5:297:5 | x [element foo] | semantics.rb:301:10:301:10 | x [element foo] |
+| semantics.rb:297:9:297:24 | call to s36 [element foo] | semantics.rb:297:5:297:5 | x [element foo] |
+| semantics.rb:297:9:297:24 | call to s36 [element foo] | semantics.rb:297:5:297:5 | x [element foo] |
+| semantics.rb:297:13:297:23 | call to source | semantics.rb:297:9:297:24 | call to s36 [element foo] |
+| semantics.rb:297:13:297:23 | call to source | semantics.rb:297:9:297:24 | call to s36 [element foo] |
+| semantics.rb:299:10:299:10 | x [element foo] | semantics.rb:299:10:299:17 | ...[...] |
+| semantics.rb:299:10:299:10 | x [element foo] | semantics.rb:299:10:299:17 | ...[...] |
+| semantics.rb:301:10:301:10 | x [element foo] | semantics.rb:301:10:301:13 | ...[...] |
+| semantics.rb:301:10:301:10 | x [element foo] | semantics.rb:301:10:301:13 | ...[...] |
+| semantics.rb:305:5:305:5 | x [element true] | semantics.rb:307:10:307:10 | x [element true] |
+| semantics.rb:305:5:305:5 | x [element true] | semantics.rb:307:10:307:10 | x [element true] |
+| semantics.rb:305:5:305:5 | x [element true] | semantics.rb:309:10:309:10 | x [element true] |
+| semantics.rb:305:5:305:5 | x [element true] | semantics.rb:309:10:309:10 | x [element true] |
+| semantics.rb:305:9:305:24 | call to s37 [element true] | semantics.rb:305:5:305:5 | x [element true] |
+| semantics.rb:305:9:305:24 | call to s37 [element true] | semantics.rb:305:5:305:5 | x [element true] |
+| semantics.rb:305:13:305:23 | call to source | semantics.rb:305:9:305:24 | call to s37 [element true] |
+| semantics.rb:305:13:305:23 | call to source | semantics.rb:305:9:305:24 | call to s37 [element true] |
+| semantics.rb:307:10:307:10 | x [element true] | semantics.rb:307:10:307:16 | ...[...] |
+| semantics.rb:307:10:307:10 | x [element true] | semantics.rb:307:10:307:16 | ...[...] |
+| semantics.rb:309:10:309:10 | x [element true] | semantics.rb:309:10:309:13 | ...[...] |
+| semantics.rb:309:10:309:10 | x [element true] | semantics.rb:309:10:309:13 | ...[...] |
+| semantics.rb:313:5:313:5 | [post] h [element foo] | semantics.rb:316:14:316:14 | h [element foo] |
+| semantics.rb:313:5:313:5 | [post] h [element foo] | semantics.rb:316:14:316:14 | h [element foo] |
+| semantics.rb:313:16:313:26 | call to source | semantics.rb:313:5:313:5 | [post] h [element foo] |
+| semantics.rb:313:16:313:26 | call to source | semantics.rb:313:5:313:5 | [post] h [element foo] |
+| semantics.rb:316:14:316:14 | h [element foo] | semantics.rb:316:10:316:15 | call to s38 |
+| semantics.rb:316:14:316:14 | h [element foo] | semantics.rb:316:10:316:15 | call to s38 |
+| semantics.rb:320:5:320:5 | x [element :foo] | semantics.rb:322:10:322:10 | x [element :foo] |
+| semantics.rb:320:5:320:5 | x [element :foo] | semantics.rb:322:10:322:10 | x [element :foo] |
+| semantics.rb:320:5:320:5 | x [element :foo] | semantics.rb:323:10:323:10 | x [element :foo] |
+| semantics.rb:320:5:320:5 | x [element :foo] | semantics.rb:323:10:323:10 | x [element :foo] |
+| semantics.rb:320:9:320:24 | call to s39 [element :foo] | semantics.rb:320:5:320:5 | x [element :foo] |
+| semantics.rb:320:9:320:24 | call to s39 [element :foo] | semantics.rb:320:5:320:5 | x [element :foo] |
+| semantics.rb:320:13:320:23 | call to source | semantics.rb:320:9:320:24 | call to s39 [element :foo] |
+| semantics.rb:320:13:320:23 | call to source | semantics.rb:320:9:320:24 | call to s39 [element :foo] |
+| semantics.rb:322:10:322:10 | x [element :foo] | semantics.rb:322:10:322:16 | ...[...] |
+| semantics.rb:322:10:322:10 | x [element :foo] | semantics.rb:322:10:322:16 | ...[...] |
+| semantics.rb:323:10:323:10 | x [element :foo] | semantics.rb:323:10:323:13 | ...[...] |
+| semantics.rb:323:10:323:10 | x [element :foo] | semantics.rb:323:10:323:13 | ...[...] |
+| semantics.rb:328:5:328:5 | [post] x [@foo] | semantics.rb:330:14:330:14 | x [@foo] |
+| semantics.rb:328:5:328:5 | [post] x [@foo] | semantics.rb:330:14:330:14 | x [@foo] |
+| semantics.rb:328:13:328:23 | call to source | semantics.rb:328:5:328:5 | [post] x [@foo] |
+| semantics.rb:328:13:328:23 | call to source | semantics.rb:328:5:328:5 | [post] x [@foo] |
+| semantics.rb:330:14:330:14 | x [@foo] | semantics.rb:330:10:330:15 | call to s40 |
+| semantics.rb:330:14:330:14 | x [@foo] | semantics.rb:330:10:330:15 | call to s40 |
+| semantics.rb:334:5:334:5 | x [@foo] | semantics.rb:335:10:335:10 | x [@foo] |
+| semantics.rb:334:5:334:5 | x [@foo] | semantics.rb:335:10:335:10 | x [@foo] |
+| semantics.rb:334:9:334:24 | call to s41 [@foo] | semantics.rb:334:5:334:5 | x [@foo] |
+| semantics.rb:334:9:334:24 | call to s41 [@foo] | semantics.rb:334:5:334:5 | x [@foo] |
+| semantics.rb:334:13:334:23 | call to source | semantics.rb:334:9:334:24 | call to s41 [@foo] |
+| semantics.rb:334:13:334:23 | call to source | semantics.rb:334:9:334:24 | call to s41 [@foo] |
+| semantics.rb:335:10:335:10 | x [@foo] | semantics.rb:335:10:335:14 | call to foo |
+| semantics.rb:335:10:335:10 | x [@foo] | semantics.rb:335:10:335:14 | call to foo |
+| semantics.rb:340:5:340:5 | [post] h [element 0] | semantics.rb:343:13:343:13 | h [element 0] |
+| semantics.rb:340:5:340:5 | [post] h [element 0] | semantics.rb:343:13:343:13 | h [element 0] |
+| semantics.rb:340:12:340:22 | call to source | semantics.rb:340:5:340:5 | [post] h [element 0] |
+| semantics.rb:340:12:340:22 | call to source | semantics.rb:340:5:340:5 | [post] h [element 0] |
+| semantics.rb:341:5:341:5 | [post] h [element] | semantics.rb:343:13:343:13 | h [element] |
+| semantics.rb:341:5:341:5 | [post] h [element] | semantics.rb:343:13:343:13 | h [element] |
+| semantics.rb:341:12:341:22 | call to source | semantics.rb:341:5:341:5 | [post] h [element] |
+| semantics.rb:341:12:341:22 | call to source | semantics.rb:341:5:341:5 | [post] h [element] |
+| semantics.rb:343:5:343:5 | x [element 0] | semantics.rb:345:10:345:10 | x [element 0] |
+| semantics.rb:343:5:343:5 | x [element 0] | semantics.rb:345:10:345:10 | x [element 0] |
+| semantics.rb:343:5:343:5 | x [element 0] | semantics.rb:347:10:347:10 | x [element 0] |
+| semantics.rb:343:5:343:5 | x [element 0] | semantics.rb:347:10:347:10 | x [element 0] |
+| semantics.rb:343:5:343:5 | x [element] | semantics.rb:345:10:345:10 | x [element] |
+| semantics.rb:343:5:343:5 | x [element] | semantics.rb:345:10:345:10 | x [element] |
+| semantics.rb:343:5:343:5 | x [element] | semantics.rb:346:10:346:10 | x [element] |
+| semantics.rb:343:5:343:5 | x [element] | semantics.rb:346:10:346:10 | x [element] |
+| semantics.rb:343:5:343:5 | x [element] | semantics.rb:347:10:347:10 | x [element] |
+| semantics.rb:343:5:343:5 | x [element] | semantics.rb:347:10:347:10 | x [element] |
+| semantics.rb:343:9:343:14 | call to s42 [element 0] | semantics.rb:343:5:343:5 | x [element 0] |
+| semantics.rb:343:9:343:14 | call to s42 [element 0] | semantics.rb:343:5:343:5 | x [element 0] |
+| semantics.rb:343:9:343:14 | call to s42 [element] | semantics.rb:343:5:343:5 | x [element] |
+| semantics.rb:343:9:343:14 | call to s42 [element] | semantics.rb:343:5:343:5 | x [element] |
+| semantics.rb:343:13:343:13 | h [element 0] | semantics.rb:343:9:343:14 | call to s42 [element 0] |
+| semantics.rb:343:13:343:13 | h [element 0] | semantics.rb:343:9:343:14 | call to s42 [element 0] |
+| semantics.rb:343:13:343:13 | h [element] | semantics.rb:343:9:343:14 | call to s42 [element] |
+| semantics.rb:343:13:343:13 | h [element] | semantics.rb:343:9:343:14 | call to s42 [element] |
+| semantics.rb:345:10:345:10 | x [element 0] | semantics.rb:345:10:345:13 | ...[...] |
+| semantics.rb:345:10:345:10 | x [element 0] | semantics.rb:345:10:345:13 | ...[...] |
 | semantics.rb:345:10:345:10 | x [element] | semantics.rb:345:10:345:13 | ...[...] |
 | semantics.rb:345:10:345:10 | x [element] | semantics.rb:345:10:345:13 | ...[...] |
-| semantics.rb:346:10:346:10 | x [element 0] | semantics.rb:346:10:346:13 | ...[...] |
-| semantics.rb:346:10:346:10 | x [element 0] | semantics.rb:346:10:346:13 | ...[...] |
 | semantics.rb:346:10:346:10 | x [element] | semantics.rb:346:10:346:13 | ...[...] |
 | semantics.rb:346:10:346:10 | x [element] | semantics.rb:346:10:346:13 | ...[...] |
-| semantics.rb:350:5:350:5 | [post] h [element 0] | semantics.rb:353:13:353:13 | h [element 0] |
-| semantics.rb:350:5:350:5 | [post] h [element 0] | semantics.rb:353:13:353:13 | h [element 0] |
-| semantics.rb:350:12:350:22 | call to source | semantics.rb:350:5:350:5 | [post] h [element 0] |
-| semantics.rb:350:12:350:22 | call to source | semantics.rb:350:5:350:5 | [post] h [element 0] |
-| semantics.rb:353:5:353:5 | x [element 0] | semantics.rb:355:10:355:10 | x [element 0] |
-| semantics.rb:353:5:353:5 | x [element 0] | semantics.rb:355:10:355:10 | x [element 0] |
-| semantics.rb:353:5:353:5 | x [element 0] | semantics.rb:357:10:357:10 | x [element 0] |
-| semantics.rb:353:5:353:5 | x [element 0] | semantics.rb:357:10:357:10 | x [element 0] |
-| semantics.rb:353:9:353:14 | call to s43 [element 0] | semantics.rb:353:5:353:5 | x [element 0] |
-| semantics.rb:353:9:353:14 | call to s43 [element 0] | semantics.rb:353:5:353:5 | x [element 0] |
-| semantics.rb:353:13:353:13 | h [element 0] | semantics.rb:353:9:353:14 | call to s43 [element 0] |
-| semantics.rb:353:13:353:13 | h [element 0] | semantics.rb:353:9:353:14 | call to s43 [element 0] |
-| semantics.rb:355:10:355:10 | x [element 0] | semantics.rb:355:10:355:13 | ...[...] |
-| semantics.rb:355:10:355:10 | x [element 0] | semantics.rb:355:10:355:13 | ...[...] |
-| semantics.rb:357:10:357:10 | x [element 0] | semantics.rb:357:10:357:13 | ...[...] |
-| semantics.rb:357:10:357:10 | x [element 0] | semantics.rb:357:10:357:13 | ...[...] |
-| semantics.rb:362:5:362:5 | [post] h [element 1] | semantics.rb:365:9:365:9 | h [element 1] |
-| semantics.rb:362:5:362:5 | [post] h [element 1] | semantics.rb:365:9:365:9 | h [element 1] |
-| semantics.rb:362:12:362:22 | call to source | semantics.rb:362:5:362:5 | [post] h [element 1] |
-| semantics.rb:362:12:362:22 | call to source | semantics.rb:362:5:362:5 | [post] h [element 1] |
-| semantics.rb:365:9:365:9 | [post] h [element 1] | semantics.rb:368:10:368:10 | h [element 1] |
-| semantics.rb:365:9:365:9 | [post] h [element 1] | semantics.rb:368:10:368:10 | h [element 1] |
-| semantics.rb:365:9:365:9 | [post] h [element 1] | semantics.rb:369:10:369:10 | h [element 1] |
-| semantics.rb:365:9:365:9 | [post] h [element 1] | semantics.rb:369:10:369:10 | h [element 1] |
-| semantics.rb:365:9:365:9 | h [element 1] | semantics.rb:365:9:365:9 | [post] h [element 1] |
-| semantics.rb:365:9:365:9 | h [element 1] | semantics.rb:365:9:365:9 | [post] h [element 1] |
-| semantics.rb:368:10:368:10 | h [element 1] | semantics.rb:368:10:368:13 | ...[...] |
-| semantics.rb:368:10:368:10 | h [element 1] | semantics.rb:368:10:368:13 | ...[...] |
+| semantics.rb:347:10:347:10 | x [element 0] | semantics.rb:347:10:347:13 | ...[...] |
+| semantics.rb:347:10:347:10 | x [element 0] | semantics.rb:347:10:347:13 | ...[...] |
+| semantics.rb:347:10:347:10 | x [element] | semantics.rb:347:10:347:13 | ...[...] |
+| semantics.rb:347:10:347:10 | x [element] | semantics.rb:347:10:347:13 | ...[...] |
+| semantics.rb:351:5:351:5 | [post] h [element 0] | semantics.rb:354:13:354:13 | h [element 0] |
+| semantics.rb:351:5:351:5 | [post] h [element 0] | semantics.rb:354:13:354:13 | h [element 0] |
+| semantics.rb:351:12:351:22 | call to source | semantics.rb:351:5:351:5 | [post] h [element 0] |
+| semantics.rb:351:12:351:22 | call to source | semantics.rb:351:5:351:5 | [post] h [element 0] |
+| semantics.rb:354:5:354:5 | x [element 0] | semantics.rb:356:10:356:10 | x [element 0] |
+| semantics.rb:354:5:354:5 | x [element 0] | semantics.rb:356:10:356:10 | x [element 0] |
+| semantics.rb:354:5:354:5 | x [element 0] | semantics.rb:358:10:358:10 | x [element 0] |
+| semantics.rb:354:5:354:5 | x [element 0] | semantics.rb:358:10:358:10 | x [element 0] |
+| semantics.rb:354:9:354:14 | call to s43 [element 0] | semantics.rb:354:5:354:5 | x [element 0] |
+| semantics.rb:354:9:354:14 | call to s43 [element 0] | semantics.rb:354:5:354:5 | x [element 0] |
+| semantics.rb:354:13:354:13 | h [element 0] | semantics.rb:354:9:354:14 | call to s43 [element 0] |
+| semantics.rb:354:13:354:13 | h [element 0] | semantics.rb:354:9:354:14 | call to s43 [element 0] |
+| semantics.rb:356:10:356:10 | x [element 0] | semantics.rb:356:10:356:13 | ...[...] |
+| semantics.rb:356:10:356:10 | x [element 0] | semantics.rb:356:10:356:13 | ...[...] |
+| semantics.rb:358:10:358:10 | x [element 0] | semantics.rb:358:10:358:13 | ...[...] |
+| semantics.rb:358:10:358:10 | x [element 0] | semantics.rb:358:10:358:13 | ...[...] |
+| semantics.rb:363:5:363:5 | [post] h [element 1] | semantics.rb:366:9:366:9 | h [element 1] |
+| semantics.rb:363:5:363:5 | [post] h [element 1] | semantics.rb:366:9:366:9 | h [element 1] |
+| semantics.rb:363:12:363:22 | call to source | semantics.rb:363:5:363:5 | [post] h [element 1] |
+| semantics.rb:363:12:363:22 | call to source | semantics.rb:363:5:363:5 | [post] h [element 1] |
+| semantics.rb:366:9:366:9 | [post] h [element 1] | semantics.rb:369:10:369:10 | h [element 1] |
+| semantics.rb:366:9:366:9 | [post] h [element 1] | semantics.rb:369:10:369:10 | h [element 1] |
+| semantics.rb:366:9:366:9 | [post] h [element 1] | semantics.rb:370:10:370:10 | h [element 1] |
+| semantics.rb:366:9:366:9 | [post] h [element 1] | semantics.rb:370:10:370:10 | h [element 1] |
+| semantics.rb:366:9:366:9 | h [element 1] | semantics.rb:366:9:366:9 | [post] h [element 1] |
+| semantics.rb:366:9:366:9 | h [element 1] | semantics.rb:366:9:366:9 | [post] h [element 1] |
 | semantics.rb:369:10:369:10 | h [element 1] | semantics.rb:369:10:369:13 | ...[...] |
 | semantics.rb:369:10:369:10 | h [element 1] | semantics.rb:369:10:369:13 | ...[...] |
-| semantics.rb:373:5:373:5 | [post] h [element 0] | semantics.rb:374:5:374:5 | h [element 0] |
-| semantics.rb:373:5:373:5 | [post] h [element 0] | semantics.rb:374:5:374:5 | h [element 0] |
-| semantics.rb:373:12:373:22 | call to source | semantics.rb:373:5:373:5 | [post] h [element 0] |
-| semantics.rb:373:12:373:22 | call to source | semantics.rb:373:5:373:5 | [post] h [element 0] |
-| semantics.rb:374:5:374:5 | [post] h [element 0] | semantics.rb:377:10:377:10 | h [element 0] |
-| semantics.rb:374:5:374:5 | [post] h [element 0] | semantics.rb:377:10:377:10 | h [element 0] |
-| semantics.rb:374:5:374:5 | [post] h [element 0] | semantics.rb:379:10:379:10 | h [element 0] |
-| semantics.rb:374:5:374:5 | [post] h [element 0] | semantics.rb:379:10:379:10 | h [element 0] |
-| semantics.rb:374:5:374:5 | [post] h [element 1] | semantics.rb:378:10:378:10 | h [element 1] |
-| semantics.rb:374:5:374:5 | [post] h [element 1] | semantics.rb:378:10:378:10 | h [element 1] |
-| semantics.rb:374:5:374:5 | [post] h [element 1] | semantics.rb:379:10:379:10 | h [element 1] |
-| semantics.rb:374:5:374:5 | [post] h [element 1] | semantics.rb:379:10:379:10 | h [element 1] |
-| semantics.rb:374:5:374:5 | [post] h [element 1] | semantics.rb:381:9:381:9 | h [element 1] |
-| semantics.rb:374:5:374:5 | [post] h [element 1] | semantics.rb:381:9:381:9 | h [element 1] |
-| semantics.rb:374:5:374:5 | h [element 0] | semantics.rb:374:5:374:5 | [post] h [element 0] |
-| semantics.rb:374:5:374:5 | h [element 0] | semantics.rb:374:5:374:5 | [post] h [element 0] |
-| semantics.rb:374:12:374:22 | call to source | semantics.rb:374:5:374:5 | [post] h [element 1] |
-| semantics.rb:374:12:374:22 | call to source | semantics.rb:374:5:374:5 | [post] h [element 1] |
-| semantics.rb:375:5:375:5 | [post] h [element] | semantics.rb:377:10:377:10 | h [element] |
-| semantics.rb:375:5:375:5 | [post] h [element] | semantics.rb:377:10:377:10 | h [element] |
-| semantics.rb:375:5:375:5 | [post] h [element] | semantics.rb:378:10:378:10 | h [element] |
-| semantics.rb:375:5:375:5 | [post] h [element] | semantics.rb:378:10:378:10 | h [element] |
-| semantics.rb:375:5:375:5 | [post] h [element] | semantics.rb:379:10:379:10 | h [element] |
-| semantics.rb:375:5:375:5 | [post] h [element] | semantics.rb:379:10:379:10 | h [element] |
-| semantics.rb:375:5:375:5 | [post] h [element] | semantics.rb:381:9:381:9 | h [element] |
-| semantics.rb:375:5:375:5 | [post] h [element] | semantics.rb:381:9:381:9 | h [element] |
-| semantics.rb:375:12:375:22 | call to source | semantics.rb:375:5:375:5 | [post] h [element] |
-| semantics.rb:375:12:375:22 | call to source | semantics.rb:375:5:375:5 | [post] h [element] |
-| semantics.rb:377:10:377:10 | h [element 0] | semantics.rb:377:10:377:13 | ...[...] |
-| semantics.rb:377:10:377:10 | h [element 0] | semantics.rb:377:10:377:13 | ...[...] |
-| semantics.rb:377:10:377:10 | h [element] | semantics.rb:377:10:377:13 | ...[...] |
-| semantics.rb:377:10:377:10 | h [element] | semantics.rb:377:10:377:13 | ...[...] |
-| semantics.rb:378:10:378:10 | h [element 1] | semantics.rb:378:10:378:13 | ...[...] |
-| semantics.rb:378:10:378:10 | h [element 1] | semantics.rb:378:10:378:13 | ...[...] |
+| semantics.rb:370:10:370:10 | h [element 1] | semantics.rb:370:10:370:13 | ...[...] |
+| semantics.rb:370:10:370:10 | h [element 1] | semantics.rb:370:10:370:13 | ...[...] |
+| semantics.rb:374:5:374:5 | [post] h [element 0] | semantics.rb:375:5:375:5 | h [element 0] |
+| semantics.rb:374:5:374:5 | [post] h [element 0] | semantics.rb:375:5:375:5 | h [element 0] |
+| semantics.rb:374:12:374:22 | call to source | semantics.rb:374:5:374:5 | [post] h [element 0] |
+| semantics.rb:374:12:374:22 | call to source | semantics.rb:374:5:374:5 | [post] h [element 0] |
+| semantics.rb:375:5:375:5 | [post] h [element 0] | semantics.rb:378:10:378:10 | h [element 0] |
+| semantics.rb:375:5:375:5 | [post] h [element 0] | semantics.rb:378:10:378:10 | h [element 0] |
+| semantics.rb:375:5:375:5 | [post] h [element 0] | semantics.rb:380:10:380:10 | h [element 0] |
+| semantics.rb:375:5:375:5 | [post] h [element 0] | semantics.rb:380:10:380:10 | h [element 0] |
+| semantics.rb:375:5:375:5 | [post] h [element 1] | semantics.rb:379:10:379:10 | h [element 1] |
+| semantics.rb:375:5:375:5 | [post] h [element 1] | semantics.rb:379:10:379:10 | h [element 1] |
+| semantics.rb:375:5:375:5 | [post] h [element 1] | semantics.rb:380:10:380:10 | h [element 1] |
+| semantics.rb:375:5:375:5 | [post] h [element 1] | semantics.rb:380:10:380:10 | h [element 1] |
+| semantics.rb:375:5:375:5 | [post] h [element 1] | semantics.rb:382:9:382:9 | h [element 1] |
+| semantics.rb:375:5:375:5 | [post] h [element 1] | semantics.rb:382:9:382:9 | h [element 1] |
+| semantics.rb:375:5:375:5 | h [element 0] | semantics.rb:375:5:375:5 | [post] h [element 0] |
+| semantics.rb:375:5:375:5 | h [element 0] | semantics.rb:375:5:375:5 | [post] h [element 0] |
+| semantics.rb:375:12:375:22 | call to source | semantics.rb:375:5:375:5 | [post] h [element 1] |
+| semantics.rb:375:12:375:22 | call to source | semantics.rb:375:5:375:5 | [post] h [element 1] |
+| semantics.rb:376:5:376:5 | [post] h [element] | semantics.rb:378:10:378:10 | h [element] |
+| semantics.rb:376:5:376:5 | [post] h [element] | semantics.rb:378:10:378:10 | h [element] |
+| semantics.rb:376:5:376:5 | [post] h [element] | semantics.rb:379:10:379:10 | h [element] |
+| semantics.rb:376:5:376:5 | [post] h [element] | semantics.rb:379:10:379:10 | h [element] |
+| semantics.rb:376:5:376:5 | [post] h [element] | semantics.rb:380:10:380:10 | h [element] |
+| semantics.rb:376:5:376:5 | [post] h [element] | semantics.rb:380:10:380:10 | h [element] |
+| semantics.rb:376:5:376:5 | [post] h [element] | semantics.rb:382:9:382:9 | h [element] |
+| semantics.rb:376:5:376:5 | [post] h [element] | semantics.rb:382:9:382:9 | h [element] |
+| semantics.rb:376:12:376:22 | call to source | semantics.rb:376:5:376:5 | [post] h [element] |
+| semantics.rb:376:12:376:22 | call to source | semantics.rb:376:5:376:5 | [post] h [element] |
+| semantics.rb:378:10:378:10 | h [element 0] | semantics.rb:378:10:378:13 | ...[...] |
+| semantics.rb:378:10:378:10 | h [element 0] | semantics.rb:378:10:378:13 | ...[...] |
 | semantics.rb:378:10:378:10 | h [element] | semantics.rb:378:10:378:13 | ...[...] |
 | semantics.rb:378:10:378:10 | h [element] | semantics.rb:378:10:378:13 | ...[...] |
-| semantics.rb:379:10:379:10 | h [element 0] | semantics.rb:379:10:379:13 | ...[...] |
-| semantics.rb:379:10:379:10 | h [element 0] | semantics.rb:379:10:379:13 | ...[...] |
 | semantics.rb:379:10:379:10 | h [element 1] | semantics.rb:379:10:379:13 | ...[...] |
 | semantics.rb:379:10:379:10 | h [element 1] | semantics.rb:379:10:379:13 | ...[...] |
 | semantics.rb:379:10:379:10 | h [element] | semantics.rb:379:10:379:13 | ...[...] |
 | semantics.rb:379:10:379:10 | h [element] | semantics.rb:379:10:379:13 | ...[...] |
-| semantics.rb:381:9:381:9 | [post] h [element 1] | semantics.rb:384:10:384:10 | h [element 1] |
-| semantics.rb:381:9:381:9 | [post] h [element 1] | semantics.rb:384:10:384:10 | h [element 1] |
-| semantics.rb:381:9:381:9 | [post] h [element 1] | semantics.rb:385:10:385:10 | h [element 1] |
-| semantics.rb:381:9:381:9 | [post] h [element 1] | semantics.rb:385:10:385:10 | h [element 1] |
-| semantics.rb:381:9:381:9 | [post] h [element] | semantics.rb:383:10:383:10 | h [element] |
-| semantics.rb:381:9:381:9 | [post] h [element] | semantics.rb:383:10:383:10 | h [element] |
-| semantics.rb:381:9:381:9 | [post] h [element] | semantics.rb:384:10:384:10 | h [element] |
-| semantics.rb:381:9:381:9 | [post] h [element] | semantics.rb:384:10:384:10 | h [element] |
-| semantics.rb:381:9:381:9 | [post] h [element] | semantics.rb:385:10:385:10 | h [element] |
-| semantics.rb:381:9:381:9 | [post] h [element] | semantics.rb:385:10:385:10 | h [element] |
-| semantics.rb:381:9:381:9 | h [element 1] | semantics.rb:381:9:381:9 | [post] h [element 1] |
-| semantics.rb:381:9:381:9 | h [element 1] | semantics.rb:381:9:381:9 | [post] h [element 1] |
-| semantics.rb:381:9:381:9 | h [element] | semantics.rb:381:9:381:9 | [post] h [element] |
-| semantics.rb:381:9:381:9 | h [element] | semantics.rb:381:9:381:9 | [post] h [element] |
-| semantics.rb:383:10:383:10 | h [element] | semantics.rb:383:10:383:13 | ...[...] |
-| semantics.rb:383:10:383:10 | h [element] | semantics.rb:383:10:383:13 | ...[...] |
-| semantics.rb:384:10:384:10 | h [element 1] | semantics.rb:384:10:384:13 | ...[...] |
-| semantics.rb:384:10:384:10 | h [element 1] | semantics.rb:384:10:384:13 | ...[...] |
+| semantics.rb:380:10:380:10 | h [element 0] | semantics.rb:380:10:380:13 | ...[...] |
+| semantics.rb:380:10:380:10 | h [element 0] | semantics.rb:380:10:380:13 | ...[...] |
+| semantics.rb:380:10:380:10 | h [element 1] | semantics.rb:380:10:380:13 | ...[...] |
+| semantics.rb:380:10:380:10 | h [element 1] | semantics.rb:380:10:380:13 | ...[...] |
+| semantics.rb:380:10:380:10 | h [element] | semantics.rb:380:10:380:13 | ...[...] |
+| semantics.rb:380:10:380:10 | h [element] | semantics.rb:380:10:380:13 | ...[...] |
+| semantics.rb:382:9:382:9 | [post] h [element 1] | semantics.rb:385:10:385:10 | h [element 1] |
+| semantics.rb:382:9:382:9 | [post] h [element 1] | semantics.rb:385:10:385:10 | h [element 1] |
+| semantics.rb:382:9:382:9 | [post] h [element 1] | semantics.rb:386:10:386:10 | h [element 1] |
+| semantics.rb:382:9:382:9 | [post] h [element 1] | semantics.rb:386:10:386:10 | h [element 1] |
+| semantics.rb:382:9:382:9 | [post] h [element] | semantics.rb:384:10:384:10 | h [element] |
+| semantics.rb:382:9:382:9 | [post] h [element] | semantics.rb:384:10:384:10 | h [element] |
+| semantics.rb:382:9:382:9 | [post] h [element] | semantics.rb:385:10:385:10 | h [element] |
+| semantics.rb:382:9:382:9 | [post] h [element] | semantics.rb:385:10:385:10 | h [element] |
+| semantics.rb:382:9:382:9 | [post] h [element] | semantics.rb:386:10:386:10 | h [element] |
+| semantics.rb:382:9:382:9 | [post] h [element] | semantics.rb:386:10:386:10 | h [element] |
+| semantics.rb:382:9:382:9 | h [element 1] | semantics.rb:382:9:382:9 | [post] h [element 1] |
+| semantics.rb:382:9:382:9 | h [element 1] | semantics.rb:382:9:382:9 | [post] h [element 1] |
+| semantics.rb:382:9:382:9 | h [element] | semantics.rb:382:9:382:9 | [post] h [element] |
+| semantics.rb:382:9:382:9 | h [element] | semantics.rb:382:9:382:9 | [post] h [element] |
 | semantics.rb:384:10:384:10 | h [element] | semantics.rb:384:10:384:13 | ...[...] |
 | semantics.rb:384:10:384:10 | h [element] | semantics.rb:384:10:384:13 | ...[...] |
 | semantics.rb:385:10:385:10 | h [element 1] | semantics.rb:385:10:385:13 | ...[...] |
 | semantics.rb:385:10:385:10 | h [element 1] | semantics.rb:385:10:385:13 | ...[...] |
 | semantics.rb:385:10:385:10 | h [element] | semantics.rb:385:10:385:13 | ...[...] |
 | semantics.rb:385:10:385:10 | h [element] | semantics.rb:385:10:385:13 | ...[...] |
-| semantics.rb:389:5:389:5 | [post] h [element 0] | semantics.rb:390:5:390:5 | h [element 0] |
-| semantics.rb:389:5:389:5 | [post] h [element 0] | semantics.rb:390:5:390:5 | h [element 0] |
-| semantics.rb:389:12:389:22 | call to source | semantics.rb:389:5:389:5 | [post] h [element 0] |
-| semantics.rb:389:12:389:22 | call to source | semantics.rb:389:5:389:5 | [post] h [element 0] |
-| semantics.rb:390:5:390:5 | [post] h [element 0] | semantics.rb:393:10:393:10 | h [element 0] |
-| semantics.rb:390:5:390:5 | [post] h [element 0] | semantics.rb:393:10:393:10 | h [element 0] |
-| semantics.rb:390:5:390:5 | [post] h [element 0] | semantics.rb:395:10:395:10 | h [element 0] |
-| semantics.rb:390:5:390:5 | [post] h [element 0] | semantics.rb:395:10:395:10 | h [element 0] |
-| semantics.rb:390:5:390:5 | [post] h [element 1] | semantics.rb:394:10:394:10 | h [element 1] |
-| semantics.rb:390:5:390:5 | [post] h [element 1] | semantics.rb:394:10:394:10 | h [element 1] |
-| semantics.rb:390:5:390:5 | [post] h [element 1] | semantics.rb:395:10:395:10 | h [element 1] |
-| semantics.rb:390:5:390:5 | [post] h [element 1] | semantics.rb:395:10:395:10 | h [element 1] |
-| semantics.rb:390:5:390:5 | [post] h [element 1] | semantics.rb:397:13:397:13 | h [element 1] |
-| semantics.rb:390:5:390:5 | [post] h [element 1] | semantics.rb:397:13:397:13 | h [element 1] |
-| semantics.rb:390:5:390:5 | h [element 0] | semantics.rb:390:5:390:5 | [post] h [element 0] |
-| semantics.rb:390:5:390:5 | h [element 0] | semantics.rb:390:5:390:5 | [post] h [element 0] |
-| semantics.rb:390:12:390:22 | call to source | semantics.rb:390:5:390:5 | [post] h [element 1] |
-| semantics.rb:390:12:390:22 | call to source | semantics.rb:390:5:390:5 | [post] h [element 1] |
-| semantics.rb:391:5:391:5 | [post] h [element] | semantics.rb:393:10:393:10 | h [element] |
-| semantics.rb:391:5:391:5 | [post] h [element] | semantics.rb:393:10:393:10 | h [element] |
-| semantics.rb:391:5:391:5 | [post] h [element] | semantics.rb:394:10:394:10 | h [element] |
-| semantics.rb:391:5:391:5 | [post] h [element] | semantics.rb:394:10:394:10 | h [element] |
-| semantics.rb:391:5:391:5 | [post] h [element] | semantics.rb:395:10:395:10 | h [element] |
-| semantics.rb:391:5:391:5 | [post] h [element] | semantics.rb:395:10:395:10 | h [element] |
-| semantics.rb:391:12:391:22 | call to source | semantics.rb:391:5:391:5 | [post] h [element] |
-| semantics.rb:391:12:391:22 | call to source | semantics.rb:391:5:391:5 | [post] h [element] |
-| semantics.rb:393:10:393:10 | h [element 0] | semantics.rb:393:10:393:13 | ...[...] |
-| semantics.rb:393:10:393:10 | h [element 0] | semantics.rb:393:10:393:13 | ...[...] |
-| semantics.rb:393:10:393:10 | h [element] | semantics.rb:393:10:393:13 | ...[...] |
-| semantics.rb:393:10:393:10 | h [element] | semantics.rb:393:10:393:13 | ...[...] |
-| semantics.rb:394:10:394:10 | h [element 1] | semantics.rb:394:10:394:13 | ...[...] |
-| semantics.rb:394:10:394:10 | h [element 1] | semantics.rb:394:10:394:13 | ...[...] |
+| semantics.rb:386:10:386:10 | h [element 1] | semantics.rb:386:10:386:13 | ...[...] |
+| semantics.rb:386:10:386:10 | h [element 1] | semantics.rb:386:10:386:13 | ...[...] |
+| semantics.rb:386:10:386:10 | h [element] | semantics.rb:386:10:386:13 | ...[...] |
+| semantics.rb:386:10:386:10 | h [element] | semantics.rb:386:10:386:13 | ...[...] |
+| semantics.rb:390:5:390:5 | [post] h [element 0] | semantics.rb:391:5:391:5 | h [element 0] |
+| semantics.rb:390:5:390:5 | [post] h [element 0] | semantics.rb:391:5:391:5 | h [element 0] |
+| semantics.rb:390:12:390:22 | call to source | semantics.rb:390:5:390:5 | [post] h [element 0] |
+| semantics.rb:390:12:390:22 | call to source | semantics.rb:390:5:390:5 | [post] h [element 0] |
+| semantics.rb:391:5:391:5 | [post] h [element 0] | semantics.rb:394:10:394:10 | h [element 0] |
+| semantics.rb:391:5:391:5 | [post] h [element 0] | semantics.rb:394:10:394:10 | h [element 0] |
+| semantics.rb:391:5:391:5 | [post] h [element 0] | semantics.rb:396:10:396:10 | h [element 0] |
+| semantics.rb:391:5:391:5 | [post] h [element 0] | semantics.rb:396:10:396:10 | h [element 0] |
+| semantics.rb:391:5:391:5 | [post] h [element 1] | semantics.rb:395:10:395:10 | h [element 1] |
+| semantics.rb:391:5:391:5 | [post] h [element 1] | semantics.rb:395:10:395:10 | h [element 1] |
+| semantics.rb:391:5:391:5 | [post] h [element 1] | semantics.rb:396:10:396:10 | h [element 1] |
+| semantics.rb:391:5:391:5 | [post] h [element 1] | semantics.rb:396:10:396:10 | h [element 1] |
+| semantics.rb:391:5:391:5 | [post] h [element 1] | semantics.rb:398:13:398:13 | h [element 1] |
+| semantics.rb:391:5:391:5 | [post] h [element 1] | semantics.rb:398:13:398:13 | h [element 1] |
+| semantics.rb:391:5:391:5 | h [element 0] | semantics.rb:391:5:391:5 | [post] h [element 0] |
+| semantics.rb:391:5:391:5 | h [element 0] | semantics.rb:391:5:391:5 | [post] h [element 0] |
+| semantics.rb:391:12:391:22 | call to source | semantics.rb:391:5:391:5 | [post] h [element 1] |
+| semantics.rb:391:12:391:22 | call to source | semantics.rb:391:5:391:5 | [post] h [element 1] |
+| semantics.rb:392:5:392:5 | [post] h [element] | semantics.rb:394:10:394:10 | h [element] |
+| semantics.rb:392:5:392:5 | [post] h [element] | semantics.rb:394:10:394:10 | h [element] |
+| semantics.rb:392:5:392:5 | [post] h [element] | semantics.rb:395:10:395:10 | h [element] |
+| semantics.rb:392:5:392:5 | [post] h [element] | semantics.rb:395:10:395:10 | h [element] |
+| semantics.rb:392:5:392:5 | [post] h [element] | semantics.rb:396:10:396:10 | h [element] |
+| semantics.rb:392:5:392:5 | [post] h [element] | semantics.rb:396:10:396:10 | h [element] |
+| semantics.rb:392:12:392:22 | call to source | semantics.rb:392:5:392:5 | [post] h [element] |
+| semantics.rb:392:12:392:22 | call to source | semantics.rb:392:5:392:5 | [post] h [element] |
+| semantics.rb:394:10:394:10 | h [element 0] | semantics.rb:394:10:394:13 | ...[...] |
+| semantics.rb:394:10:394:10 | h [element 0] | semantics.rb:394:10:394:13 | ...[...] |
 | semantics.rb:394:10:394:10 | h [element] | semantics.rb:394:10:394:13 | ...[...] |
 | semantics.rb:394:10:394:10 | h [element] | semantics.rb:394:10:394:13 | ...[...] |
-| semantics.rb:395:10:395:10 | h [element 0] | semantics.rb:395:10:395:13 | ...[...] |
-| semantics.rb:395:10:395:10 | h [element 0] | semantics.rb:395:10:395:13 | ...[...] |
 | semantics.rb:395:10:395:10 | h [element 1] | semantics.rb:395:10:395:13 | ...[...] |
 | semantics.rb:395:10:395:10 | h [element 1] | semantics.rb:395:10:395:13 | ...[...] |
 | semantics.rb:395:10:395:10 | h [element] | semantics.rb:395:10:395:13 | ...[...] |
 | semantics.rb:395:10:395:10 | h [element] | semantics.rb:395:10:395:13 | ...[...] |
-| semantics.rb:397:5:397:5 | x [element 1] | semantics.rb:400:10:400:10 | x [element 1] |
-| semantics.rb:397:5:397:5 | x [element 1] | semantics.rb:400:10:400:10 | x [element 1] |
-| semantics.rb:397:5:397:5 | x [element 1] | semantics.rb:401:10:401:10 | x [element 1] |
-| semantics.rb:397:5:397:5 | x [element 1] | semantics.rb:401:10:401:10 | x [element 1] |
-| semantics.rb:397:9:397:14 | call to s46 [element 1] | semantics.rb:397:5:397:5 | x [element 1] |
-| semantics.rb:397:9:397:14 | call to s46 [element 1] | semantics.rb:397:5:397:5 | x [element 1] |
-| semantics.rb:397:13:397:13 | h [element 1] | semantics.rb:397:9:397:14 | call to s46 [element 1] |
-| semantics.rb:397:13:397:13 | h [element 1] | semantics.rb:397:9:397:14 | call to s46 [element 1] |
-| semantics.rb:400:10:400:10 | x [element 1] | semantics.rb:400:10:400:13 | ...[...] |
-| semantics.rb:400:10:400:10 | x [element 1] | semantics.rb:400:10:400:13 | ...[...] |
+| semantics.rb:396:10:396:10 | h [element 0] | semantics.rb:396:10:396:13 | ...[...] |
+| semantics.rb:396:10:396:10 | h [element 0] | semantics.rb:396:10:396:13 | ...[...] |
+| semantics.rb:396:10:396:10 | h [element 1] | semantics.rb:396:10:396:13 | ...[...] |
+| semantics.rb:396:10:396:10 | h [element 1] | semantics.rb:396:10:396:13 | ...[...] |
+| semantics.rb:396:10:396:10 | h [element] | semantics.rb:396:10:396:13 | ...[...] |
+| semantics.rb:396:10:396:10 | h [element] | semantics.rb:396:10:396:13 | ...[...] |
+| semantics.rb:398:5:398:5 | x [element 1] | semantics.rb:401:10:401:10 | x [element 1] |
+| semantics.rb:398:5:398:5 | x [element 1] | semantics.rb:401:10:401:10 | x [element 1] |
+| semantics.rb:398:5:398:5 | x [element 1] | semantics.rb:402:10:402:10 | x [element 1] |
+| semantics.rb:398:5:398:5 | x [element 1] | semantics.rb:402:10:402:10 | x [element 1] |
+| semantics.rb:398:9:398:14 | call to s46 [element 1] | semantics.rb:398:5:398:5 | x [element 1] |
+| semantics.rb:398:9:398:14 | call to s46 [element 1] | semantics.rb:398:5:398:5 | x [element 1] |
+| semantics.rb:398:13:398:13 | h [element 1] | semantics.rb:398:9:398:14 | call to s46 [element 1] |
+| semantics.rb:398:13:398:13 | h [element 1] | semantics.rb:398:9:398:14 | call to s46 [element 1] |
 | semantics.rb:401:10:401:10 | x [element 1] | semantics.rb:401:10:401:13 | ...[...] |
 | semantics.rb:401:10:401:10 | x [element 1] | semantics.rb:401:10:401:13 | ...[...] |
-| semantics.rb:405:5:405:5 | [post] h [element :foo] | semantics.rb:406:5:406:5 | h [element :foo] |
-| semantics.rb:405:5:405:5 | [post] h [element :foo] | semantics.rb:406:5:406:5 | h [element :foo] |
-| semantics.rb:405:15:405:25 | call to source | semantics.rb:405:5:405:5 | [post] h [element :foo] |
-| semantics.rb:405:15:405:25 | call to source | semantics.rb:405:5:405:5 | [post] h [element :foo] |
-| semantics.rb:406:5:406:5 | [post] h [element :bar] | semantics.rb:410:10:410:10 | h [element :bar] |
-| semantics.rb:406:5:406:5 | [post] h [element :bar] | semantics.rb:410:10:410:10 | h [element :bar] |
-| semantics.rb:406:5:406:5 | [post] h [element :bar] | semantics.rb:412:13:412:13 | h [element :bar] |
-| semantics.rb:406:5:406:5 | [post] h [element :bar] | semantics.rb:412:13:412:13 | h [element :bar] |
-| semantics.rb:406:5:406:5 | [post] h [element :foo] | semantics.rb:409:10:409:10 | h [element :foo] |
-| semantics.rb:406:5:406:5 | [post] h [element :foo] | semantics.rb:409:10:409:10 | h [element :foo] |
-| semantics.rb:406:5:406:5 | h [element :foo] | semantics.rb:406:5:406:5 | [post] h [element :foo] |
-| semantics.rb:406:5:406:5 | h [element :foo] | semantics.rb:406:5:406:5 | [post] h [element :foo] |
-| semantics.rb:406:15:406:25 | call to source | semantics.rb:406:5:406:5 | [post] h [element :bar] |
-| semantics.rb:406:15:406:25 | call to source | semantics.rb:406:5:406:5 | [post] h [element :bar] |
-| semantics.rb:407:5:407:5 | [post] h [element] | semantics.rb:409:10:409:10 | h [element] |
-| semantics.rb:407:5:407:5 | [post] h [element] | semantics.rb:409:10:409:10 | h [element] |
-| semantics.rb:407:5:407:5 | [post] h [element] | semantics.rb:410:10:410:10 | h [element] |
-| semantics.rb:407:5:407:5 | [post] h [element] | semantics.rb:410:10:410:10 | h [element] |
-| semantics.rb:407:12:407:22 | call to source | semantics.rb:407:5:407:5 | [post] h [element] |
-| semantics.rb:407:12:407:22 | call to source | semantics.rb:407:5:407:5 | [post] h [element] |
-| semantics.rb:409:10:409:10 | h [element :foo] | semantics.rb:409:10:409:16 | ...[...] |
-| semantics.rb:409:10:409:10 | h [element :foo] | semantics.rb:409:10:409:16 | ...[...] |
-| semantics.rb:409:10:409:10 | h [element] | semantics.rb:409:10:409:16 | ...[...] |
-| semantics.rb:409:10:409:10 | h [element] | semantics.rb:409:10:409:16 | ...[...] |
-| semantics.rb:410:10:410:10 | h [element :bar] | semantics.rb:410:10:410:16 | ...[...] |
-| semantics.rb:410:10:410:10 | h [element :bar] | semantics.rb:410:10:410:16 | ...[...] |
+| semantics.rb:402:10:402:10 | x [element 1] | semantics.rb:402:10:402:13 | ...[...] |
+| semantics.rb:402:10:402:10 | x [element 1] | semantics.rb:402:10:402:13 | ...[...] |
+| semantics.rb:406:5:406:5 | [post] h [element :foo] | semantics.rb:407:5:407:5 | h [element :foo] |
+| semantics.rb:406:5:406:5 | [post] h [element :foo] | semantics.rb:407:5:407:5 | h [element :foo] |
+| semantics.rb:406:15:406:25 | call to source | semantics.rb:406:5:406:5 | [post] h [element :foo] |
+| semantics.rb:406:15:406:25 | call to source | semantics.rb:406:5:406:5 | [post] h [element :foo] |
+| semantics.rb:407:5:407:5 | [post] h [element :bar] | semantics.rb:411:10:411:10 | h [element :bar] |
+| semantics.rb:407:5:407:5 | [post] h [element :bar] | semantics.rb:411:10:411:10 | h [element :bar] |
+| semantics.rb:407:5:407:5 | [post] h [element :bar] | semantics.rb:413:13:413:13 | h [element :bar] |
+| semantics.rb:407:5:407:5 | [post] h [element :bar] | semantics.rb:413:13:413:13 | h [element :bar] |
+| semantics.rb:407:5:407:5 | [post] h [element :foo] | semantics.rb:410:10:410:10 | h [element :foo] |
+| semantics.rb:407:5:407:5 | [post] h [element :foo] | semantics.rb:410:10:410:10 | h [element :foo] |
+| semantics.rb:407:5:407:5 | h [element :foo] | semantics.rb:407:5:407:5 | [post] h [element :foo] |
+| semantics.rb:407:5:407:5 | h [element :foo] | semantics.rb:407:5:407:5 | [post] h [element :foo] |
+| semantics.rb:407:15:407:25 | call to source | semantics.rb:407:5:407:5 | [post] h [element :bar] |
+| semantics.rb:407:15:407:25 | call to source | semantics.rb:407:5:407:5 | [post] h [element :bar] |
+| semantics.rb:408:5:408:5 | [post] h [element] | semantics.rb:410:10:410:10 | h [element] |
+| semantics.rb:408:5:408:5 | [post] h [element] | semantics.rb:410:10:410:10 | h [element] |
+| semantics.rb:408:5:408:5 | [post] h [element] | semantics.rb:411:10:411:10 | h [element] |
+| semantics.rb:408:5:408:5 | [post] h [element] | semantics.rb:411:10:411:10 | h [element] |
+| semantics.rb:408:12:408:22 | call to source | semantics.rb:408:5:408:5 | [post] h [element] |
+| semantics.rb:408:12:408:22 | call to source | semantics.rb:408:5:408:5 | [post] h [element] |
+| semantics.rb:410:10:410:10 | h [element :foo] | semantics.rb:410:10:410:16 | ...[...] |
+| semantics.rb:410:10:410:10 | h [element :foo] | semantics.rb:410:10:410:16 | ...[...] |
 | semantics.rb:410:10:410:10 | h [element] | semantics.rb:410:10:410:16 | ...[...] |
 | semantics.rb:410:10:410:10 | h [element] | semantics.rb:410:10:410:16 | ...[...] |
-| semantics.rb:412:5:412:5 | x [element :bar] | semantics.rb:415:10:415:10 | x [element :bar] |
-| semantics.rb:412:5:412:5 | x [element :bar] | semantics.rb:415:10:415:10 | x [element :bar] |
-| semantics.rb:412:9:412:14 | call to s47 [element :bar] | semantics.rb:412:5:412:5 | x [element :bar] |
-| semantics.rb:412:9:412:14 | call to s47 [element :bar] | semantics.rb:412:5:412:5 | x [element :bar] |
-| semantics.rb:412:13:412:13 | h [element :bar] | semantics.rb:412:9:412:14 | call to s47 [element :bar] |
-| semantics.rb:412:13:412:13 | h [element :bar] | semantics.rb:412:9:412:14 | call to s47 [element :bar] |
-| semantics.rb:415:10:415:10 | x [element :bar] | semantics.rb:415:10:415:16 | ...[...] |
-| semantics.rb:415:10:415:10 | x [element :bar] | semantics.rb:415:10:415:16 | ...[...] |
-| semantics.rb:419:5:419:5 | [post] h [element :foo] | semantics.rb:420:5:420:5 | h [element :foo] |
-| semantics.rb:419:5:419:5 | [post] h [element :foo] | semantics.rb:420:5:420:5 | h [element :foo] |
-| semantics.rb:419:15:419:25 | call to source | semantics.rb:419:5:419:5 | [post] h [element :foo] |
-| semantics.rb:419:15:419:25 | call to source | semantics.rb:419:5:419:5 | [post] h [element :foo] |
-| semantics.rb:420:5:420:5 | [post] h [element :bar] | semantics.rb:424:10:424:10 | h [element :bar] |
-| semantics.rb:420:5:420:5 | [post] h [element :bar] | semantics.rb:424:10:424:10 | h [element :bar] |
-| semantics.rb:420:5:420:5 | [post] h [element :bar] | semantics.rb:426:13:426:13 | h [element :bar] |
-| semantics.rb:420:5:420:5 | [post] h [element :bar] | semantics.rb:426:13:426:13 | h [element :bar] |
-| semantics.rb:420:5:420:5 | [post] h [element :foo] | semantics.rb:423:10:423:10 | h [element :foo] |
-| semantics.rb:420:5:420:5 | [post] h [element :foo] | semantics.rb:423:10:423:10 | h [element :foo] |
-| semantics.rb:420:5:420:5 | h [element :foo] | semantics.rb:420:5:420:5 | [post] h [element :foo] |
-| semantics.rb:420:5:420:5 | h [element :foo] | semantics.rb:420:5:420:5 | [post] h [element :foo] |
-| semantics.rb:420:15:420:25 | call to source | semantics.rb:420:5:420:5 | [post] h [element :bar] |
-| semantics.rb:420:15:420:25 | call to source | semantics.rb:420:5:420:5 | [post] h [element :bar] |
-| semantics.rb:421:5:421:5 | [post] h [element] | semantics.rb:423:10:423:10 | h [element] |
-| semantics.rb:421:5:421:5 | [post] h [element] | semantics.rb:423:10:423:10 | h [element] |
-| semantics.rb:421:5:421:5 | [post] h [element] | semantics.rb:424:10:424:10 | h [element] |
-| semantics.rb:421:5:421:5 | [post] h [element] | semantics.rb:424:10:424:10 | h [element] |
-| semantics.rb:421:12:421:22 | call to source | semantics.rb:421:5:421:5 | [post] h [element] |
-| semantics.rb:421:12:421:22 | call to source | semantics.rb:421:5:421:5 | [post] h [element] |
-| semantics.rb:423:10:423:10 | h [element :foo] | semantics.rb:423:10:423:16 | ...[...] |
-| semantics.rb:423:10:423:10 | h [element :foo] | semantics.rb:423:10:423:16 | ...[...] |
-| semantics.rb:423:10:423:10 | h [element] | semantics.rb:423:10:423:16 | ...[...] |
-| semantics.rb:423:10:423:10 | h [element] | semantics.rb:423:10:423:16 | ...[...] |
-| semantics.rb:424:10:424:10 | h [element :bar] | semantics.rb:424:10:424:16 | ...[...] |
-| semantics.rb:424:10:424:10 | h [element :bar] | semantics.rb:424:10:424:16 | ...[...] |
+| semantics.rb:411:10:411:10 | h [element :bar] | semantics.rb:411:10:411:16 | ...[...] |
+| semantics.rb:411:10:411:10 | h [element :bar] | semantics.rb:411:10:411:16 | ...[...] |
+| semantics.rb:411:10:411:10 | h [element] | semantics.rb:411:10:411:16 | ...[...] |
+| semantics.rb:411:10:411:10 | h [element] | semantics.rb:411:10:411:16 | ...[...] |
+| semantics.rb:413:5:413:5 | x [element :bar] | semantics.rb:416:10:416:10 | x [element :bar] |
+| semantics.rb:413:5:413:5 | x [element :bar] | semantics.rb:416:10:416:10 | x [element :bar] |
+| semantics.rb:413:9:413:14 | call to s47 [element :bar] | semantics.rb:413:5:413:5 | x [element :bar] |
+| semantics.rb:413:9:413:14 | call to s47 [element :bar] | semantics.rb:413:5:413:5 | x [element :bar] |
+| semantics.rb:413:13:413:13 | h [element :bar] | semantics.rb:413:9:413:14 | call to s47 [element :bar] |
+| semantics.rb:413:13:413:13 | h [element :bar] | semantics.rb:413:9:413:14 | call to s47 [element :bar] |
+| semantics.rb:416:10:416:10 | x [element :bar] | semantics.rb:416:10:416:16 | ...[...] |
+| semantics.rb:416:10:416:10 | x [element :bar] | semantics.rb:416:10:416:16 | ...[...] |
+| semantics.rb:420:5:420:5 | [post] h [element :foo] | semantics.rb:421:5:421:5 | h [element :foo] |
+| semantics.rb:420:5:420:5 | [post] h [element :foo] | semantics.rb:421:5:421:5 | h [element :foo] |
+| semantics.rb:420:15:420:25 | call to source | semantics.rb:420:5:420:5 | [post] h [element :foo] |
+| semantics.rb:420:15:420:25 | call to source | semantics.rb:420:5:420:5 | [post] h [element :foo] |
+| semantics.rb:421:5:421:5 | [post] h [element :bar] | semantics.rb:425:10:425:10 | h [element :bar] |
+| semantics.rb:421:5:421:5 | [post] h [element :bar] | semantics.rb:425:10:425:10 | h [element :bar] |
+| semantics.rb:421:5:421:5 | [post] h [element :bar] | semantics.rb:427:13:427:13 | h [element :bar] |
+| semantics.rb:421:5:421:5 | [post] h [element :bar] | semantics.rb:427:13:427:13 | h [element :bar] |
+| semantics.rb:421:5:421:5 | [post] h [element :foo] | semantics.rb:424:10:424:10 | h [element :foo] |
+| semantics.rb:421:5:421:5 | [post] h [element :foo] | semantics.rb:424:10:424:10 | h [element :foo] |
+| semantics.rb:421:5:421:5 | h [element :foo] | semantics.rb:421:5:421:5 | [post] h [element :foo] |
+| semantics.rb:421:5:421:5 | h [element :foo] | semantics.rb:421:5:421:5 | [post] h [element :foo] |
+| semantics.rb:421:15:421:25 | call to source | semantics.rb:421:5:421:5 | [post] h [element :bar] |
+| semantics.rb:421:15:421:25 | call to source | semantics.rb:421:5:421:5 | [post] h [element :bar] |
+| semantics.rb:422:5:422:5 | [post] h [element] | semantics.rb:424:10:424:10 | h [element] |
+| semantics.rb:422:5:422:5 | [post] h [element] | semantics.rb:424:10:424:10 | h [element] |
+| semantics.rb:422:5:422:5 | [post] h [element] | semantics.rb:425:10:425:10 | h [element] |
+| semantics.rb:422:5:422:5 | [post] h [element] | semantics.rb:425:10:425:10 | h [element] |
+| semantics.rb:422:12:422:22 | call to source | semantics.rb:422:5:422:5 | [post] h [element] |
+| semantics.rb:422:12:422:22 | call to source | semantics.rb:422:5:422:5 | [post] h [element] |
+| semantics.rb:424:10:424:10 | h [element :foo] | semantics.rb:424:10:424:16 | ...[...] |
+| semantics.rb:424:10:424:10 | h [element :foo] | semantics.rb:424:10:424:16 | ...[...] |
 | semantics.rb:424:10:424:10 | h [element] | semantics.rb:424:10:424:16 | ...[...] |
 | semantics.rb:424:10:424:10 | h [element] | semantics.rb:424:10:424:16 | ...[...] |
-| semantics.rb:426:5:426:5 | x [element :bar] | semantics.rb:429:10:429:10 | x [element :bar] |
-| semantics.rb:426:5:426:5 | x [element :bar] | semantics.rb:429:10:429:10 | x [element :bar] |
-| semantics.rb:426:9:426:14 | call to s48 [element :bar] | semantics.rb:426:5:426:5 | x [element :bar] |
-| semantics.rb:426:9:426:14 | call to s48 [element :bar] | semantics.rb:426:5:426:5 | x [element :bar] |
-| semantics.rb:426:13:426:13 | h [element :bar] | semantics.rb:426:9:426:14 | call to s48 [element :bar] |
-| semantics.rb:426:13:426:13 | h [element :bar] | semantics.rb:426:9:426:14 | call to s48 [element :bar] |
-| semantics.rb:429:10:429:10 | x [element :bar] | semantics.rb:429:10:429:16 | ...[...] |
-| semantics.rb:429:10:429:10 | x [element :bar] | semantics.rb:429:10:429:16 | ...[...] |
-| semantics.rb:433:5:433:5 | [post] h [element :foo] | semantics.rb:434:5:434:5 | h [element :foo] |
-| semantics.rb:433:5:433:5 | [post] h [element :foo] | semantics.rb:434:5:434:5 | h [element :foo] |
-| semantics.rb:433:15:433:25 | call to source | semantics.rb:433:5:433:5 | [post] h [element :foo] |
-| semantics.rb:433:15:433:25 | call to source | semantics.rb:433:5:433:5 | [post] h [element :foo] |
-| semantics.rb:434:5:434:5 | [post] h [element :bar] | semantics.rb:438:10:438:10 | h [element :bar] |
-| semantics.rb:434:5:434:5 | [post] h [element :bar] | semantics.rb:438:10:438:10 | h [element :bar] |
-| semantics.rb:434:5:434:5 | [post] h [element :bar] | semantics.rb:440:13:440:13 | h [element :bar] |
-| semantics.rb:434:5:434:5 | [post] h [element :bar] | semantics.rb:440:13:440:13 | h [element :bar] |
-| semantics.rb:434:5:434:5 | [post] h [element :foo] | semantics.rb:437:10:437:10 | h [element :foo] |
-| semantics.rb:434:5:434:5 | [post] h [element :foo] | semantics.rb:437:10:437:10 | h [element :foo] |
-| semantics.rb:434:5:434:5 | h [element :foo] | semantics.rb:434:5:434:5 | [post] h [element :foo] |
-| semantics.rb:434:5:434:5 | h [element :foo] | semantics.rb:434:5:434:5 | [post] h [element :foo] |
-| semantics.rb:434:15:434:25 | call to source | semantics.rb:434:5:434:5 | [post] h [element :bar] |
-| semantics.rb:434:15:434:25 | call to source | semantics.rb:434:5:434:5 | [post] h [element :bar] |
-| semantics.rb:435:5:435:5 | [post] h [element] | semantics.rb:437:10:437:10 | h [element] |
-| semantics.rb:435:5:435:5 | [post] h [element] | semantics.rb:437:10:437:10 | h [element] |
-| semantics.rb:435:5:435:5 | [post] h [element] | semantics.rb:438:10:438:10 | h [element] |
-| semantics.rb:435:5:435:5 | [post] h [element] | semantics.rb:438:10:438:10 | h [element] |
-| semantics.rb:435:5:435:5 | [post] h [element] | semantics.rb:440:13:440:13 | h [element] |
-| semantics.rb:435:5:435:5 | [post] h [element] | semantics.rb:440:13:440:13 | h [element] |
-| semantics.rb:435:12:435:22 | call to source | semantics.rb:435:5:435:5 | [post] h [element] |
-| semantics.rb:435:12:435:22 | call to source | semantics.rb:435:5:435:5 | [post] h [element] |
-| semantics.rb:437:10:437:10 | h [element :foo] | semantics.rb:437:10:437:16 | ...[...] |
-| semantics.rb:437:10:437:10 | h [element :foo] | semantics.rb:437:10:437:16 | ...[...] |
-| semantics.rb:437:10:437:10 | h [element] | semantics.rb:437:10:437:16 | ...[...] |
-| semantics.rb:437:10:437:10 | h [element] | semantics.rb:437:10:437:16 | ...[...] |
-| semantics.rb:438:10:438:10 | h [element :bar] | semantics.rb:438:10:438:16 | ...[...] |
-| semantics.rb:438:10:438:10 | h [element :bar] | semantics.rb:438:10:438:16 | ...[...] |
+| semantics.rb:425:10:425:10 | h [element :bar] | semantics.rb:425:10:425:16 | ...[...] |
+| semantics.rb:425:10:425:10 | h [element :bar] | semantics.rb:425:10:425:16 | ...[...] |
+| semantics.rb:425:10:425:10 | h [element] | semantics.rb:425:10:425:16 | ...[...] |
+| semantics.rb:425:10:425:10 | h [element] | semantics.rb:425:10:425:16 | ...[...] |
+| semantics.rb:427:5:427:5 | x [element :bar] | semantics.rb:430:10:430:10 | x [element :bar] |
+| semantics.rb:427:5:427:5 | x [element :bar] | semantics.rb:430:10:430:10 | x [element :bar] |
+| semantics.rb:427:9:427:14 | call to s48 [element :bar] | semantics.rb:427:5:427:5 | x [element :bar] |
+| semantics.rb:427:9:427:14 | call to s48 [element :bar] | semantics.rb:427:5:427:5 | x [element :bar] |
+| semantics.rb:427:13:427:13 | h [element :bar] | semantics.rb:427:9:427:14 | call to s48 [element :bar] |
+| semantics.rb:427:13:427:13 | h [element :bar] | semantics.rb:427:9:427:14 | call to s48 [element :bar] |
+| semantics.rb:430:10:430:10 | x [element :bar] | semantics.rb:430:10:430:16 | ...[...] |
+| semantics.rb:430:10:430:10 | x [element :bar] | semantics.rb:430:10:430:16 | ...[...] |
+| semantics.rb:434:5:434:5 | [post] h [element :foo] | semantics.rb:435:5:435:5 | h [element :foo] |
+| semantics.rb:434:5:434:5 | [post] h [element :foo] | semantics.rb:435:5:435:5 | h [element :foo] |
+| semantics.rb:434:15:434:25 | call to source | semantics.rb:434:5:434:5 | [post] h [element :foo] |
+| semantics.rb:434:15:434:25 | call to source | semantics.rb:434:5:434:5 | [post] h [element :foo] |
+| semantics.rb:435:5:435:5 | [post] h [element :bar] | semantics.rb:439:10:439:10 | h [element :bar] |
+| semantics.rb:435:5:435:5 | [post] h [element :bar] | semantics.rb:439:10:439:10 | h [element :bar] |
+| semantics.rb:435:5:435:5 | [post] h [element :bar] | semantics.rb:441:13:441:13 | h [element :bar] |
+| semantics.rb:435:5:435:5 | [post] h [element :bar] | semantics.rb:441:13:441:13 | h [element :bar] |
+| semantics.rb:435:5:435:5 | [post] h [element :foo] | semantics.rb:438:10:438:10 | h [element :foo] |
+| semantics.rb:435:5:435:5 | [post] h [element :foo] | semantics.rb:438:10:438:10 | h [element :foo] |
+| semantics.rb:435:5:435:5 | h [element :foo] | semantics.rb:435:5:435:5 | [post] h [element :foo] |
+| semantics.rb:435:5:435:5 | h [element :foo] | semantics.rb:435:5:435:5 | [post] h [element :foo] |
+| semantics.rb:435:15:435:25 | call to source | semantics.rb:435:5:435:5 | [post] h [element :bar] |
+| semantics.rb:435:15:435:25 | call to source | semantics.rb:435:5:435:5 | [post] h [element :bar] |
+| semantics.rb:436:5:436:5 | [post] h [element] | semantics.rb:438:10:438:10 | h [element] |
+| semantics.rb:436:5:436:5 | [post] h [element] | semantics.rb:438:10:438:10 | h [element] |
+| semantics.rb:436:5:436:5 | [post] h [element] | semantics.rb:439:10:439:10 | h [element] |
+| semantics.rb:436:5:436:5 | [post] h [element] | semantics.rb:439:10:439:10 | h [element] |
+| semantics.rb:436:5:436:5 | [post] h [element] | semantics.rb:441:13:441:13 | h [element] |
+| semantics.rb:436:5:436:5 | [post] h [element] | semantics.rb:441:13:441:13 | h [element] |
+| semantics.rb:436:12:436:22 | call to source | semantics.rb:436:5:436:5 | [post] h [element] |
+| semantics.rb:436:12:436:22 | call to source | semantics.rb:436:5:436:5 | [post] h [element] |
+| semantics.rb:438:10:438:10 | h [element :foo] | semantics.rb:438:10:438:16 | ...[...] |
+| semantics.rb:438:10:438:10 | h [element :foo] | semantics.rb:438:10:438:16 | ...[...] |
 | semantics.rb:438:10:438:10 | h [element] | semantics.rb:438:10:438:16 | ...[...] |
 | semantics.rb:438:10:438:10 | h [element] | semantics.rb:438:10:438:16 | ...[...] |
-| semantics.rb:440:5:440:5 | x [element :bar] | semantics.rb:443:10:443:10 | x [element :bar] |
-| semantics.rb:440:5:440:5 | x [element :bar] | semantics.rb:443:10:443:10 | x [element :bar] |
-| semantics.rb:440:5:440:5 | x [element] | semantics.rb:442:10:442:10 | x [element] |
-| semantics.rb:440:5:440:5 | x [element] | semantics.rb:442:10:442:10 | x [element] |
-| semantics.rb:440:5:440:5 | x [element] | semantics.rb:443:10:443:10 | x [element] |
-| semantics.rb:440:5:440:5 | x [element] | semantics.rb:443:10:443:10 | x [element] |
-| semantics.rb:440:9:440:14 | call to s49 [element :bar] | semantics.rb:440:5:440:5 | x [element :bar] |
-| semantics.rb:440:9:440:14 | call to s49 [element :bar] | semantics.rb:440:5:440:5 | x [element :bar] |
-| semantics.rb:440:9:440:14 | call to s49 [element] | semantics.rb:440:5:440:5 | x [element] |
-| semantics.rb:440:9:440:14 | call to s49 [element] | semantics.rb:440:5:440:5 | x [element] |
-| semantics.rb:440:13:440:13 | h [element :bar] | semantics.rb:440:9:440:14 | call to s49 [element :bar] |
-| semantics.rb:440:13:440:13 | h [element :bar] | semantics.rb:440:9:440:14 | call to s49 [element :bar] |
-| semantics.rb:440:13:440:13 | h [element] | semantics.rb:440:9:440:14 | call to s49 [element] |
-| semantics.rb:440:13:440:13 | h [element] | semantics.rb:440:9:440:14 | call to s49 [element] |
-| semantics.rb:442:10:442:10 | x [element] | semantics.rb:442:10:442:16 | ...[...] |
-| semantics.rb:442:10:442:10 | x [element] | semantics.rb:442:10:442:16 | ...[...] |
-| semantics.rb:443:10:443:10 | x [element :bar] | semantics.rb:443:10:443:16 | ...[...] |
-| semantics.rb:443:10:443:10 | x [element :bar] | semantics.rb:443:10:443:16 | ...[...] |
+| semantics.rb:439:10:439:10 | h [element :bar] | semantics.rb:439:10:439:16 | ...[...] |
+| semantics.rb:439:10:439:10 | h [element :bar] | semantics.rb:439:10:439:16 | ...[...] |
+| semantics.rb:439:10:439:10 | h [element] | semantics.rb:439:10:439:16 | ...[...] |
+| semantics.rb:439:10:439:10 | h [element] | semantics.rb:439:10:439:16 | ...[...] |
+| semantics.rb:441:5:441:5 | x [element :bar] | semantics.rb:444:10:444:10 | x [element :bar] |
+| semantics.rb:441:5:441:5 | x [element :bar] | semantics.rb:444:10:444:10 | x [element :bar] |
+| semantics.rb:441:5:441:5 | x [element] | semantics.rb:443:10:443:10 | x [element] |
+| semantics.rb:441:5:441:5 | x [element] | semantics.rb:443:10:443:10 | x [element] |
+| semantics.rb:441:5:441:5 | x [element] | semantics.rb:444:10:444:10 | x [element] |
+| semantics.rb:441:5:441:5 | x [element] | semantics.rb:444:10:444:10 | x [element] |
+| semantics.rb:441:9:441:14 | call to s49 [element :bar] | semantics.rb:441:5:441:5 | x [element :bar] |
+| semantics.rb:441:9:441:14 | call to s49 [element :bar] | semantics.rb:441:5:441:5 | x [element :bar] |
+| semantics.rb:441:9:441:14 | call to s49 [element] | semantics.rb:441:5:441:5 | x [element] |
+| semantics.rb:441:9:441:14 | call to s49 [element] | semantics.rb:441:5:441:5 | x [element] |
+| semantics.rb:441:13:441:13 | h [element :bar] | semantics.rb:441:9:441:14 | call to s49 [element :bar] |
+| semantics.rb:441:13:441:13 | h [element :bar] | semantics.rb:441:9:441:14 | call to s49 [element :bar] |
+| semantics.rb:441:13:441:13 | h [element] | semantics.rb:441:9:441:14 | call to s49 [element] |
+| semantics.rb:441:13:441:13 | h [element] | semantics.rb:441:9:441:14 | call to s49 [element] |
 | semantics.rb:443:10:443:10 | x [element] | semantics.rb:443:10:443:16 | ...[...] |
 | semantics.rb:443:10:443:10 | x [element] | semantics.rb:443:10:443:16 | ...[...] |
-| semantics.rb:447:5:447:5 | [post] h [element :foo] | semantics.rb:448:5:448:5 | h [element :foo] |
-| semantics.rb:447:5:447:5 | [post] h [element :foo] | semantics.rb:448:5:448:5 | h [element :foo] |
-| semantics.rb:447:15:447:25 | call to source | semantics.rb:447:5:447:5 | [post] h [element :foo] |
-| semantics.rb:447:15:447:25 | call to source | semantics.rb:447:5:447:5 | [post] h [element :foo] |
-| semantics.rb:448:5:448:5 | [post] h [element :bar] | semantics.rb:452:10:452:10 | h [element :bar] |
-| semantics.rb:448:5:448:5 | [post] h [element :bar] | semantics.rb:452:10:452:10 | h [element :bar] |
-| semantics.rb:448:5:448:5 | [post] h [element :bar] | semantics.rb:454:9:454:9 | h [element :bar] |
-| semantics.rb:448:5:448:5 | [post] h [element :bar] | semantics.rb:454:9:454:9 | h [element :bar] |
-| semantics.rb:448:5:448:5 | [post] h [element :foo] | semantics.rb:451:10:451:10 | h [element :foo] |
-| semantics.rb:448:5:448:5 | [post] h [element :foo] | semantics.rb:451:10:451:10 | h [element :foo] |
-| semantics.rb:448:5:448:5 | h [element :foo] | semantics.rb:448:5:448:5 | [post] h [element :foo] |
-| semantics.rb:448:5:448:5 | h [element :foo] | semantics.rb:448:5:448:5 | [post] h [element :foo] |
-| semantics.rb:448:15:448:25 | call to source | semantics.rb:448:5:448:5 | [post] h [element :bar] |
-| semantics.rb:448:15:448:25 | call to source | semantics.rb:448:5:448:5 | [post] h [element :bar] |
-| semantics.rb:449:5:449:5 | [post] h [element] | semantics.rb:451:10:451:10 | h [element] |
-| semantics.rb:449:5:449:5 | [post] h [element] | semantics.rb:451:10:451:10 | h [element] |
-| semantics.rb:449:5:449:5 | [post] h [element] | semantics.rb:452:10:452:10 | h [element] |
-| semantics.rb:449:5:449:5 | [post] h [element] | semantics.rb:452:10:452:10 | h [element] |
-| semantics.rb:449:12:449:22 | call to source | semantics.rb:449:5:449:5 | [post] h [element] |
-| semantics.rb:449:12:449:22 | call to source | semantics.rb:449:5:449:5 | [post] h [element] |
-| semantics.rb:451:10:451:10 | h [element :foo] | semantics.rb:451:10:451:16 | ...[...] |
-| semantics.rb:451:10:451:10 | h [element :foo] | semantics.rb:451:10:451:16 | ...[...] |
-| semantics.rb:451:10:451:10 | h [element] | semantics.rb:451:10:451:16 | ...[...] |
-| semantics.rb:451:10:451:10 | h [element] | semantics.rb:451:10:451:16 | ...[...] |
-| semantics.rb:452:10:452:10 | h [element :bar] | semantics.rb:452:10:452:16 | ...[...] |
-| semantics.rb:452:10:452:10 | h [element :bar] | semantics.rb:452:10:452:16 | ...[...] |
+| semantics.rb:444:10:444:10 | x [element :bar] | semantics.rb:444:10:444:16 | ...[...] |
+| semantics.rb:444:10:444:10 | x [element :bar] | semantics.rb:444:10:444:16 | ...[...] |
+| semantics.rb:444:10:444:10 | x [element] | semantics.rb:444:10:444:16 | ...[...] |
+| semantics.rb:444:10:444:10 | x [element] | semantics.rb:444:10:444:16 | ...[...] |
+| semantics.rb:448:5:448:5 | [post] h [element :foo] | semantics.rb:449:5:449:5 | h [element :foo] |
+| semantics.rb:448:5:448:5 | [post] h [element :foo] | semantics.rb:449:5:449:5 | h [element :foo] |
+| semantics.rb:448:15:448:25 | call to source | semantics.rb:448:5:448:5 | [post] h [element :foo] |
+| semantics.rb:448:15:448:25 | call to source | semantics.rb:448:5:448:5 | [post] h [element :foo] |
+| semantics.rb:449:5:449:5 | [post] h [element :bar] | semantics.rb:453:10:453:10 | h [element :bar] |
+| semantics.rb:449:5:449:5 | [post] h [element :bar] | semantics.rb:453:10:453:10 | h [element :bar] |
+| semantics.rb:449:5:449:5 | [post] h [element :bar] | semantics.rb:455:9:455:9 | h [element :bar] |
+| semantics.rb:449:5:449:5 | [post] h [element :bar] | semantics.rb:455:9:455:9 | h [element :bar] |
+| semantics.rb:449:5:449:5 | [post] h [element :foo] | semantics.rb:452:10:452:10 | h [element :foo] |
+| semantics.rb:449:5:449:5 | [post] h [element :foo] | semantics.rb:452:10:452:10 | h [element :foo] |
+| semantics.rb:449:5:449:5 | h [element :foo] | semantics.rb:449:5:449:5 | [post] h [element :foo] |
+| semantics.rb:449:5:449:5 | h [element :foo] | semantics.rb:449:5:449:5 | [post] h [element :foo] |
+| semantics.rb:449:15:449:25 | call to source | semantics.rb:449:5:449:5 | [post] h [element :bar] |
+| semantics.rb:449:15:449:25 | call to source | semantics.rb:449:5:449:5 | [post] h [element :bar] |
+| semantics.rb:450:5:450:5 | [post] h [element] | semantics.rb:452:10:452:10 | h [element] |
+| semantics.rb:450:5:450:5 | [post] h [element] | semantics.rb:452:10:452:10 | h [element] |
+| semantics.rb:450:5:450:5 | [post] h [element] | semantics.rb:453:10:453:10 | h [element] |
+| semantics.rb:450:5:450:5 | [post] h [element] | semantics.rb:453:10:453:10 | h [element] |
+| semantics.rb:450:12:450:22 | call to source | semantics.rb:450:5:450:5 | [post] h [element] |
+| semantics.rb:450:12:450:22 | call to source | semantics.rb:450:5:450:5 | [post] h [element] |
+| semantics.rb:452:10:452:10 | h [element :foo] | semantics.rb:452:10:452:16 | ...[...] |
+| semantics.rb:452:10:452:10 | h [element :foo] | semantics.rb:452:10:452:16 | ...[...] |
 | semantics.rb:452:10:452:10 | h [element] | semantics.rb:452:10:452:16 | ...[...] |
 | semantics.rb:452:10:452:10 | h [element] | semantics.rb:452:10:452:16 | ...[...] |
-| semantics.rb:454:9:454:9 | [post] h [element :bar] | semantics.rb:457:10:457:10 | h [element :bar] |
-| semantics.rb:454:9:454:9 | [post] h [element :bar] | semantics.rb:457:10:457:10 | h [element :bar] |
-| semantics.rb:454:9:454:9 | h [element :bar] | semantics.rb:454:9:454:9 | [post] h [element :bar] |
-| semantics.rb:454:9:454:9 | h [element :bar] | semantics.rb:454:9:454:9 | [post] h [element :bar] |
-| semantics.rb:457:10:457:10 | h [element :bar] | semantics.rb:457:10:457:16 | ...[...] |
-| semantics.rb:457:10:457:10 | h [element :bar] | semantics.rb:457:10:457:16 | ...[...] |
-| semantics.rb:461:5:461:5 | [post] h [element :foo] | semantics.rb:462:5:462:5 | h [element :foo] |
-| semantics.rb:461:5:461:5 | [post] h [element :foo] | semantics.rb:462:5:462:5 | h [element :foo] |
-| semantics.rb:461:15:461:25 | call to source | semantics.rb:461:5:461:5 | [post] h [element :foo] |
-| semantics.rb:461:15:461:25 | call to source | semantics.rb:461:5:461:5 | [post] h [element :foo] |
-| semantics.rb:462:5:462:5 | [post] h [element :bar] | semantics.rb:466:10:466:10 | h [element :bar] |
-| semantics.rb:462:5:462:5 | [post] h [element :bar] | semantics.rb:466:10:466:10 | h [element :bar] |
-| semantics.rb:462:5:462:5 | [post] h [element :bar] | semantics.rb:468:9:468:9 | h [element :bar] |
-| semantics.rb:462:5:462:5 | [post] h [element :bar] | semantics.rb:468:9:468:9 | h [element :bar] |
-| semantics.rb:462:5:462:5 | [post] h [element :foo] | semantics.rb:465:10:465:10 | h [element :foo] |
-| semantics.rb:462:5:462:5 | [post] h [element :foo] | semantics.rb:465:10:465:10 | h [element :foo] |
-| semantics.rb:462:5:462:5 | h [element :foo] | semantics.rb:462:5:462:5 | [post] h [element :foo] |
-| semantics.rb:462:5:462:5 | h [element :foo] | semantics.rb:462:5:462:5 | [post] h [element :foo] |
-| semantics.rb:462:15:462:25 | call to source | semantics.rb:462:5:462:5 | [post] h [element :bar] |
-| semantics.rb:462:15:462:25 | call to source | semantics.rb:462:5:462:5 | [post] h [element :bar] |
-| semantics.rb:463:5:463:5 | [post] h [element] | semantics.rb:465:10:465:10 | h [element] |
-| semantics.rb:463:5:463:5 | [post] h [element] | semantics.rb:465:10:465:10 | h [element] |
-| semantics.rb:463:5:463:5 | [post] h [element] | semantics.rb:466:10:466:10 | h [element] |
-| semantics.rb:463:5:463:5 | [post] h [element] | semantics.rb:466:10:466:10 | h [element] |
-| semantics.rb:463:5:463:5 | [post] h [element] | semantics.rb:468:9:468:9 | h [element] |
-| semantics.rb:463:5:463:5 | [post] h [element] | semantics.rb:468:9:468:9 | h [element] |
-| semantics.rb:463:12:463:22 | call to source | semantics.rb:463:5:463:5 | [post] h [element] |
-| semantics.rb:463:12:463:22 | call to source | semantics.rb:463:5:463:5 | [post] h [element] |
-| semantics.rb:465:10:465:10 | h [element :foo] | semantics.rb:465:10:465:16 | ...[...] |
-| semantics.rb:465:10:465:10 | h [element :foo] | semantics.rb:465:10:465:16 | ...[...] |
-| semantics.rb:465:10:465:10 | h [element] | semantics.rb:465:10:465:16 | ...[...] |
-| semantics.rb:465:10:465:10 | h [element] | semantics.rb:465:10:465:16 | ...[...] |
-| semantics.rb:466:10:466:10 | h [element :bar] | semantics.rb:466:10:466:16 | ...[...] |
-| semantics.rb:466:10:466:10 | h [element :bar] | semantics.rb:466:10:466:16 | ...[...] |
+| semantics.rb:453:10:453:10 | h [element :bar] | semantics.rb:453:10:453:16 | ...[...] |
+| semantics.rb:453:10:453:10 | h [element :bar] | semantics.rb:453:10:453:16 | ...[...] |
+| semantics.rb:453:10:453:10 | h [element] | semantics.rb:453:10:453:16 | ...[...] |
+| semantics.rb:453:10:453:10 | h [element] | semantics.rb:453:10:453:16 | ...[...] |
+| semantics.rb:455:9:455:9 | [post] h [element :bar] | semantics.rb:458:10:458:10 | h [element :bar] |
+| semantics.rb:455:9:455:9 | [post] h [element :bar] | semantics.rb:458:10:458:10 | h [element :bar] |
+| semantics.rb:455:9:455:9 | h [element :bar] | semantics.rb:455:9:455:9 | [post] h [element :bar] |
+| semantics.rb:455:9:455:9 | h [element :bar] | semantics.rb:455:9:455:9 | [post] h [element :bar] |
+| semantics.rb:458:10:458:10 | h [element :bar] | semantics.rb:458:10:458:16 | ...[...] |
+| semantics.rb:458:10:458:10 | h [element :bar] | semantics.rb:458:10:458:16 | ...[...] |
+| semantics.rb:462:5:462:5 | [post] h [element :foo] | semantics.rb:463:5:463:5 | h [element :foo] |
+| semantics.rb:462:5:462:5 | [post] h [element :foo] | semantics.rb:463:5:463:5 | h [element :foo] |
+| semantics.rb:462:15:462:25 | call to source | semantics.rb:462:5:462:5 | [post] h [element :foo] |
+| semantics.rb:462:15:462:25 | call to source | semantics.rb:462:5:462:5 | [post] h [element :foo] |
+| semantics.rb:463:5:463:5 | [post] h [element :bar] | semantics.rb:467:10:467:10 | h [element :bar] |
+| semantics.rb:463:5:463:5 | [post] h [element :bar] | semantics.rb:467:10:467:10 | h [element :bar] |
+| semantics.rb:463:5:463:5 | [post] h [element :bar] | semantics.rb:469:9:469:9 | h [element :bar] |
+| semantics.rb:463:5:463:5 | [post] h [element :bar] | semantics.rb:469:9:469:9 | h [element :bar] |
+| semantics.rb:463:5:463:5 | [post] h [element :foo] | semantics.rb:466:10:466:10 | h [element :foo] |
+| semantics.rb:463:5:463:5 | [post] h [element :foo] | semantics.rb:466:10:466:10 | h [element :foo] |
+| semantics.rb:463:5:463:5 | h [element :foo] | semantics.rb:463:5:463:5 | [post] h [element :foo] |
+| semantics.rb:463:5:463:5 | h [element :foo] | semantics.rb:463:5:463:5 | [post] h [element :foo] |
+| semantics.rb:463:15:463:25 | call to source | semantics.rb:463:5:463:5 | [post] h [element :bar] |
+| semantics.rb:463:15:463:25 | call to source | semantics.rb:463:5:463:5 | [post] h [element :bar] |
+| semantics.rb:464:5:464:5 | [post] h [element] | semantics.rb:466:10:466:10 | h [element] |
+| semantics.rb:464:5:464:5 | [post] h [element] | semantics.rb:466:10:466:10 | h [element] |
+| semantics.rb:464:5:464:5 | [post] h [element] | semantics.rb:467:10:467:10 | h [element] |
+| semantics.rb:464:5:464:5 | [post] h [element] | semantics.rb:467:10:467:10 | h [element] |
+| semantics.rb:464:5:464:5 | [post] h [element] | semantics.rb:469:9:469:9 | h [element] |
+| semantics.rb:464:5:464:5 | [post] h [element] | semantics.rb:469:9:469:9 | h [element] |
+| semantics.rb:464:12:464:22 | call to source | semantics.rb:464:5:464:5 | [post] h [element] |
+| semantics.rb:464:12:464:22 | call to source | semantics.rb:464:5:464:5 | [post] h [element] |
+| semantics.rb:466:10:466:10 | h [element :foo] | semantics.rb:466:10:466:16 | ...[...] |
+| semantics.rb:466:10:466:10 | h [element :foo] | semantics.rb:466:10:466:16 | ...[...] |
 | semantics.rb:466:10:466:10 | h [element] | semantics.rb:466:10:466:16 | ...[...] |
 | semantics.rb:466:10:466:10 | h [element] | semantics.rb:466:10:466:16 | ...[...] |
-| semantics.rb:468:9:468:9 | [post] h [element :bar] | semantics.rb:471:10:471:10 | h [element :bar] |
-| semantics.rb:468:9:468:9 | [post] h [element :bar] | semantics.rb:471:10:471:10 | h [element :bar] |
-| semantics.rb:468:9:468:9 | [post] h [element] | semantics.rb:470:10:470:10 | h [element] |
-| semantics.rb:468:9:468:9 | [post] h [element] | semantics.rb:470:10:470:10 | h [element] |
-| semantics.rb:468:9:468:9 | [post] h [element] | semantics.rb:471:10:471:10 | h [element] |
-| semantics.rb:468:9:468:9 | [post] h [element] | semantics.rb:471:10:471:10 | h [element] |
-| semantics.rb:468:9:468:9 | h [element :bar] | semantics.rb:468:9:468:9 | [post] h [element :bar] |
-| semantics.rb:468:9:468:9 | h [element :bar] | semantics.rb:468:9:468:9 | [post] h [element :bar] |
-| semantics.rb:468:9:468:9 | h [element] | semantics.rb:468:9:468:9 | [post] h [element] |
-| semantics.rb:468:9:468:9 | h [element] | semantics.rb:468:9:468:9 | [post] h [element] |
-| semantics.rb:470:10:470:10 | h [element] | semantics.rb:470:10:470:16 | ...[...] |
-| semantics.rb:470:10:470:10 | h [element] | semantics.rb:470:10:470:16 | ...[...] |
-| semantics.rb:471:10:471:10 | h [element :bar] | semantics.rb:471:10:471:16 | ...[...] |
-| semantics.rb:471:10:471:10 | h [element :bar] | semantics.rb:471:10:471:16 | ...[...] |
+| semantics.rb:467:10:467:10 | h [element :bar] | semantics.rb:467:10:467:16 | ...[...] |
+| semantics.rb:467:10:467:10 | h [element :bar] | semantics.rb:467:10:467:16 | ...[...] |
+| semantics.rb:467:10:467:10 | h [element] | semantics.rb:467:10:467:16 | ...[...] |
+| semantics.rb:467:10:467:10 | h [element] | semantics.rb:467:10:467:16 | ...[...] |
+| semantics.rb:469:9:469:9 | [post] h [element :bar] | semantics.rb:472:10:472:10 | h [element :bar] |
+| semantics.rb:469:9:469:9 | [post] h [element :bar] | semantics.rb:472:10:472:10 | h [element :bar] |
+| semantics.rb:469:9:469:9 | [post] h [element] | semantics.rb:471:10:471:10 | h [element] |
+| semantics.rb:469:9:469:9 | [post] h [element] | semantics.rb:471:10:471:10 | h [element] |
+| semantics.rb:469:9:469:9 | [post] h [element] | semantics.rb:472:10:472:10 | h [element] |
+| semantics.rb:469:9:469:9 | [post] h [element] | semantics.rb:472:10:472:10 | h [element] |
+| semantics.rb:469:9:469:9 | h [element :bar] | semantics.rb:469:9:469:9 | [post] h [element :bar] |
+| semantics.rb:469:9:469:9 | h [element :bar] | semantics.rb:469:9:469:9 | [post] h [element :bar] |
+| semantics.rb:469:9:469:9 | h [element] | semantics.rb:469:9:469:9 | [post] h [element] |
+| semantics.rb:469:9:469:9 | h [element] | semantics.rb:469:9:469:9 | [post] h [element] |
 | semantics.rb:471:10:471:10 | h [element] | semantics.rb:471:10:471:16 | ...[...] |
 | semantics.rb:471:10:471:10 | h [element] | semantics.rb:471:10:471:16 | ...[...] |
-| semantics.rb:475:5:475:5 | [post] h [element :foo] | semantics.rb:476:5:476:5 | h [element :foo] |
-| semantics.rb:475:5:475:5 | [post] h [element :foo] | semantics.rb:476:5:476:5 | h [element :foo] |
-| semantics.rb:475:15:475:25 | call to source | semantics.rb:475:5:475:5 | [post] h [element :foo] |
-| semantics.rb:475:15:475:25 | call to source | semantics.rb:475:5:475:5 | [post] h [element :foo] |
-| semantics.rb:476:5:476:5 | [post] h [element :bar] | semantics.rb:480:10:480:10 | h [element :bar] |
-| semantics.rb:476:5:476:5 | [post] h [element :bar] | semantics.rb:480:10:480:10 | h [element :bar] |
-| semantics.rb:476:5:476:5 | [post] h [element :bar] | semantics.rb:482:5:482:5 | h [element :bar] |
-| semantics.rb:476:5:476:5 | [post] h [element :bar] | semantics.rb:482:5:482:5 | h [element :bar] |
-| semantics.rb:476:5:476:5 | [post] h [element :foo] | semantics.rb:479:10:479:10 | h [element :foo] |
-| semantics.rb:476:5:476:5 | [post] h [element :foo] | semantics.rb:479:10:479:10 | h [element :foo] |
-| semantics.rb:476:5:476:5 | h [element :foo] | semantics.rb:476:5:476:5 | [post] h [element :foo] |
-| semantics.rb:476:5:476:5 | h [element :foo] | semantics.rb:476:5:476:5 | [post] h [element :foo] |
-| semantics.rb:476:15:476:25 | call to source | semantics.rb:476:5:476:5 | [post] h [element :bar] |
-| semantics.rb:476:15:476:25 | call to source | semantics.rb:476:5:476:5 | [post] h [element :bar] |
-| semantics.rb:477:5:477:5 | [post] h [element] | semantics.rb:479:10:479:10 | h [element] |
-| semantics.rb:477:5:477:5 | [post] h [element] | semantics.rb:479:10:479:10 | h [element] |
-| semantics.rb:477:5:477:5 | [post] h [element] | semantics.rb:480:10:480:10 | h [element] |
-| semantics.rb:477:5:477:5 | [post] h [element] | semantics.rb:480:10:480:10 | h [element] |
-| semantics.rb:477:12:477:22 | call to source | semantics.rb:477:5:477:5 | [post] h [element] |
-| semantics.rb:477:12:477:22 | call to source | semantics.rb:477:5:477:5 | [post] h [element] |
-| semantics.rb:479:10:479:10 | h [element :foo] | semantics.rb:479:10:479:16 | ...[...] |
-| semantics.rb:479:10:479:10 | h [element :foo] | semantics.rb:479:10:479:16 | ...[...] |
-| semantics.rb:479:10:479:10 | h [element] | semantics.rb:479:10:479:16 | ...[...] |
-| semantics.rb:479:10:479:10 | h [element] | semantics.rb:479:10:479:16 | ...[...] |
-| semantics.rb:480:10:480:10 | h [element :bar] | semantics.rb:480:10:480:16 | ...[...] |
-| semantics.rb:480:10:480:10 | h [element :bar] | semantics.rb:480:10:480:16 | ...[...] |
+| semantics.rb:472:10:472:10 | h [element :bar] | semantics.rb:472:10:472:16 | ...[...] |
+| semantics.rb:472:10:472:10 | h [element :bar] | semantics.rb:472:10:472:16 | ...[...] |
+| semantics.rb:472:10:472:10 | h [element] | semantics.rb:472:10:472:16 | ...[...] |
+| semantics.rb:472:10:472:10 | h [element] | semantics.rb:472:10:472:16 | ...[...] |
+| semantics.rb:476:5:476:5 | [post] h [element :foo] | semantics.rb:477:5:477:5 | h [element :foo] |
+| semantics.rb:476:5:476:5 | [post] h [element :foo] | semantics.rb:477:5:477:5 | h [element :foo] |
+| semantics.rb:476:15:476:25 | call to source | semantics.rb:476:5:476:5 | [post] h [element :foo] |
+| semantics.rb:476:15:476:25 | call to source | semantics.rb:476:5:476:5 | [post] h [element :foo] |
+| semantics.rb:477:5:477:5 | [post] h [element :bar] | semantics.rb:481:10:481:10 | h [element :bar] |
+| semantics.rb:477:5:477:5 | [post] h [element :bar] | semantics.rb:481:10:481:10 | h [element :bar] |
+| semantics.rb:477:5:477:5 | [post] h [element :bar] | semantics.rb:483:5:483:5 | h [element :bar] |
+| semantics.rb:477:5:477:5 | [post] h [element :bar] | semantics.rb:483:5:483:5 | h [element :bar] |
+| semantics.rb:477:5:477:5 | [post] h [element :foo] | semantics.rb:480:10:480:10 | h [element :foo] |
+| semantics.rb:477:5:477:5 | [post] h [element :foo] | semantics.rb:480:10:480:10 | h [element :foo] |
+| semantics.rb:477:5:477:5 | h [element :foo] | semantics.rb:477:5:477:5 | [post] h [element :foo] |
+| semantics.rb:477:5:477:5 | h [element :foo] | semantics.rb:477:5:477:5 | [post] h [element :foo] |
+| semantics.rb:477:15:477:25 | call to source | semantics.rb:477:5:477:5 | [post] h [element :bar] |
+| semantics.rb:477:15:477:25 | call to source | semantics.rb:477:5:477:5 | [post] h [element :bar] |
+| semantics.rb:478:5:478:5 | [post] h [element] | semantics.rb:480:10:480:10 | h [element] |
+| semantics.rb:478:5:478:5 | [post] h [element] | semantics.rb:480:10:480:10 | h [element] |
+| semantics.rb:478:5:478:5 | [post] h [element] | semantics.rb:481:10:481:10 | h [element] |
+| semantics.rb:478:5:478:5 | [post] h [element] | semantics.rb:481:10:481:10 | h [element] |
+| semantics.rb:478:12:478:22 | call to source | semantics.rb:478:5:478:5 | [post] h [element] |
+| semantics.rb:478:12:478:22 | call to source | semantics.rb:478:5:478:5 | [post] h [element] |
+| semantics.rb:480:10:480:10 | h [element :foo] | semantics.rb:480:10:480:16 | ...[...] |
+| semantics.rb:480:10:480:10 | h [element :foo] | semantics.rb:480:10:480:16 | ...[...] |
 | semantics.rb:480:10:480:10 | h [element] | semantics.rb:480:10:480:16 | ...[...] |
 | semantics.rb:480:10:480:10 | h [element] | semantics.rb:480:10:480:16 | ...[...] |
-| semantics.rb:482:5:482:5 | [post] h [element :bar] | semantics.rb:485:10:485:10 | h [element :bar] |
-| semantics.rb:482:5:482:5 | [post] h [element :bar] | semantics.rb:485:10:485:10 | h [element :bar] |
-| semantics.rb:482:5:482:5 | h [element :bar] | semantics.rb:482:5:482:5 | [post] h [element :bar] |
-| semantics.rb:482:5:482:5 | h [element :bar] | semantics.rb:482:5:482:5 | [post] h [element :bar] |
-| semantics.rb:485:10:485:10 | h [element :bar] | semantics.rb:485:10:485:16 | ...[...] |
-| semantics.rb:485:10:485:10 | h [element :bar] | semantics.rb:485:10:485:16 | ...[...] |
-| semantics.rb:489:5:489:5 | [post] h [element :foo] | semantics.rb:490:5:490:5 | h [element :foo] |
-| semantics.rb:489:5:489:5 | [post] h [element :foo] | semantics.rb:490:5:490:5 | h [element :foo] |
-| semantics.rb:489:15:489:25 | call to source | semantics.rb:489:5:489:5 | [post] h [element :foo] |
-| semantics.rb:489:15:489:25 | call to source | semantics.rb:489:5:489:5 | [post] h [element :foo] |
-| semantics.rb:490:5:490:5 | [post] h [element :bar] | semantics.rb:494:10:494:10 | h [element :bar] |
-| semantics.rb:490:5:490:5 | [post] h [element :bar] | semantics.rb:494:10:494:10 | h [element :bar] |
-| semantics.rb:490:5:490:5 | [post] h [element :bar] | semantics.rb:496:9:496:9 | h [element :bar] |
-| semantics.rb:490:5:490:5 | [post] h [element :bar] | semantics.rb:496:9:496:9 | h [element :bar] |
-| semantics.rb:490:5:490:5 | [post] h [element :foo] | semantics.rb:493:10:493:10 | h [element :foo] |
-| semantics.rb:490:5:490:5 | [post] h [element :foo] | semantics.rb:493:10:493:10 | h [element :foo] |
-| semantics.rb:490:5:490:5 | h [element :foo] | semantics.rb:490:5:490:5 | [post] h [element :foo] |
-| semantics.rb:490:5:490:5 | h [element :foo] | semantics.rb:490:5:490:5 | [post] h [element :foo] |
-| semantics.rb:490:15:490:25 | call to source | semantics.rb:490:5:490:5 | [post] h [element :bar] |
-| semantics.rb:490:15:490:25 | call to source | semantics.rb:490:5:490:5 | [post] h [element :bar] |
-| semantics.rb:491:5:491:5 | [post] h [element] | semantics.rb:493:10:493:10 | h [element] |
-| semantics.rb:491:5:491:5 | [post] h [element] | semantics.rb:493:10:493:10 | h [element] |
-| semantics.rb:491:5:491:5 | [post] h [element] | semantics.rb:494:10:494:10 | h [element] |
-| semantics.rb:491:5:491:5 | [post] h [element] | semantics.rb:494:10:494:10 | h [element] |
-| semantics.rb:491:12:491:22 | call to source | semantics.rb:491:5:491:5 | [post] h [element] |
-| semantics.rb:491:12:491:22 | call to source | semantics.rb:491:5:491:5 | [post] h [element] |
-| semantics.rb:493:10:493:10 | h [element :foo] | semantics.rb:493:10:493:16 | ...[...] |
-| semantics.rb:493:10:493:10 | h [element :foo] | semantics.rb:493:10:493:16 | ...[...] |
-| semantics.rb:493:10:493:10 | h [element] | semantics.rb:493:10:493:16 | ...[...] |
-| semantics.rb:493:10:493:10 | h [element] | semantics.rb:493:10:493:16 | ...[...] |
-| semantics.rb:494:10:494:10 | h [element :bar] | semantics.rb:494:10:494:16 | ...[...] |
-| semantics.rb:494:10:494:10 | h [element :bar] | semantics.rb:494:10:494:16 | ...[...] |
+| semantics.rb:481:10:481:10 | h [element :bar] | semantics.rb:481:10:481:16 | ...[...] |
+| semantics.rb:481:10:481:10 | h [element :bar] | semantics.rb:481:10:481:16 | ...[...] |
+| semantics.rb:481:10:481:10 | h [element] | semantics.rb:481:10:481:16 | ...[...] |
+| semantics.rb:481:10:481:10 | h [element] | semantics.rb:481:10:481:16 | ...[...] |
+| semantics.rb:483:5:483:5 | [post] h [element :bar] | semantics.rb:486:10:486:10 | h [element :bar] |
+| semantics.rb:483:5:483:5 | [post] h [element :bar] | semantics.rb:486:10:486:10 | h [element :bar] |
+| semantics.rb:483:5:483:5 | h [element :bar] | semantics.rb:483:5:483:5 | [post] h [element :bar] |
+| semantics.rb:483:5:483:5 | h [element :bar] | semantics.rb:483:5:483:5 | [post] h [element :bar] |
+| semantics.rb:486:10:486:10 | h [element :bar] | semantics.rb:486:10:486:16 | ...[...] |
+| semantics.rb:486:10:486:10 | h [element :bar] | semantics.rb:486:10:486:16 | ...[...] |
+| semantics.rb:490:5:490:5 | [post] h [element :foo] | semantics.rb:491:5:491:5 | h [element :foo] |
+| semantics.rb:490:5:490:5 | [post] h [element :foo] | semantics.rb:491:5:491:5 | h [element :foo] |
+| semantics.rb:490:15:490:25 | call to source | semantics.rb:490:5:490:5 | [post] h [element :foo] |
+| semantics.rb:490:15:490:25 | call to source | semantics.rb:490:5:490:5 | [post] h [element :foo] |
+| semantics.rb:491:5:491:5 | [post] h [element :bar] | semantics.rb:495:10:495:10 | h [element :bar] |
+| semantics.rb:491:5:491:5 | [post] h [element :bar] | semantics.rb:495:10:495:10 | h [element :bar] |
+| semantics.rb:491:5:491:5 | [post] h [element :bar] | semantics.rb:497:9:497:9 | h [element :bar] |
+| semantics.rb:491:5:491:5 | [post] h [element :bar] | semantics.rb:497:9:497:9 | h [element :bar] |
+| semantics.rb:491:5:491:5 | [post] h [element :foo] | semantics.rb:494:10:494:10 | h [element :foo] |
+| semantics.rb:491:5:491:5 | [post] h [element :foo] | semantics.rb:494:10:494:10 | h [element :foo] |
+| semantics.rb:491:5:491:5 | h [element :foo] | semantics.rb:491:5:491:5 | [post] h [element :foo] |
+| semantics.rb:491:5:491:5 | h [element :foo] | semantics.rb:491:5:491:5 | [post] h [element :foo] |
+| semantics.rb:491:15:491:25 | call to source | semantics.rb:491:5:491:5 | [post] h [element :bar] |
+| semantics.rb:491:15:491:25 | call to source | semantics.rb:491:5:491:5 | [post] h [element :bar] |
+| semantics.rb:492:5:492:5 | [post] h [element] | semantics.rb:494:10:494:10 | h [element] |
+| semantics.rb:492:5:492:5 | [post] h [element] | semantics.rb:494:10:494:10 | h [element] |
+| semantics.rb:492:5:492:5 | [post] h [element] | semantics.rb:495:10:495:10 | h [element] |
+| semantics.rb:492:5:492:5 | [post] h [element] | semantics.rb:495:10:495:10 | h [element] |
+| semantics.rb:492:12:492:22 | call to source | semantics.rb:492:5:492:5 | [post] h [element] |
+| semantics.rb:492:12:492:22 | call to source | semantics.rb:492:5:492:5 | [post] h [element] |
+| semantics.rb:494:10:494:10 | h [element :foo] | semantics.rb:494:10:494:16 | ...[...] |
+| semantics.rb:494:10:494:10 | h [element :foo] | semantics.rb:494:10:494:16 | ...[...] |
 | semantics.rb:494:10:494:10 | h [element] | semantics.rb:494:10:494:16 | ...[...] |
 | semantics.rb:494:10:494:10 | h [element] | semantics.rb:494:10:494:16 | ...[...] |
-| semantics.rb:496:5:496:5 | x [element :bar] | semantics.rb:499:10:499:10 | x [element :bar] |
-| semantics.rb:496:5:496:5 | x [element :bar] | semantics.rb:499:10:499:10 | x [element :bar] |
-| semantics.rb:496:9:496:9 | h [element :bar] | semantics.rb:496:9:496:15 | call to s53 [element :bar] |
-| semantics.rb:496:9:496:9 | h [element :bar] | semantics.rb:496:9:496:15 | call to s53 [element :bar] |
-| semantics.rb:496:9:496:15 | call to s53 [element :bar] | semantics.rb:496:5:496:5 | x [element :bar] |
-| semantics.rb:496:9:496:15 | call to s53 [element :bar] | semantics.rb:496:5:496:5 | x [element :bar] |
-| semantics.rb:499:10:499:10 | x [element :bar] | semantics.rb:499:10:499:16 | ...[...] |
-| semantics.rb:499:10:499:10 | x [element :bar] | semantics.rb:499:10:499:16 | ...[...] |
-| semantics.rb:501:10:501:20 | call to source | semantics.rb:501:10:501:26 | call to s53 |
-| semantics.rb:501:10:501:20 | call to source | semantics.rb:501:10:501:26 | call to s53 |
-| semantics.rb:505:5:505:5 | [post] h [element :foo] | semantics.rb:506:5:506:5 | h [element :foo] |
-| semantics.rb:505:5:505:5 | [post] h [element :foo] | semantics.rb:506:5:506:5 | h [element :foo] |
-| semantics.rb:505:15:505:25 | call to source | semantics.rb:505:5:505:5 | [post] h [element :foo] |
-| semantics.rb:505:15:505:25 | call to source | semantics.rb:505:5:505:5 | [post] h [element :foo] |
-| semantics.rb:506:5:506:5 | [post] h [element :bar] | semantics.rb:510:10:510:10 | h [element :bar] |
-| semantics.rb:506:5:506:5 | [post] h [element :bar] | semantics.rb:510:10:510:10 | h [element :bar] |
-| semantics.rb:506:5:506:5 | [post] h [element :bar] | semantics.rb:512:9:512:9 | h [element :bar] |
-| semantics.rb:506:5:506:5 | [post] h [element :bar] | semantics.rb:512:9:512:9 | h [element :bar] |
-| semantics.rb:506:5:506:5 | [post] h [element :foo] | semantics.rb:509:10:509:10 | h [element :foo] |
-| semantics.rb:506:5:506:5 | [post] h [element :foo] | semantics.rb:509:10:509:10 | h [element :foo] |
-| semantics.rb:506:5:506:5 | h [element :foo] | semantics.rb:506:5:506:5 | [post] h [element :foo] |
-| semantics.rb:506:5:506:5 | h [element :foo] | semantics.rb:506:5:506:5 | [post] h [element :foo] |
-| semantics.rb:506:15:506:25 | call to source | semantics.rb:506:5:506:5 | [post] h [element :bar] |
-| semantics.rb:506:15:506:25 | call to source | semantics.rb:506:5:506:5 | [post] h [element :bar] |
-| semantics.rb:507:5:507:5 | [post] h [element] | semantics.rb:509:10:509:10 | h [element] |
-| semantics.rb:507:5:507:5 | [post] h [element] | semantics.rb:509:10:509:10 | h [element] |
-| semantics.rb:507:5:507:5 | [post] h [element] | semantics.rb:510:10:510:10 | h [element] |
-| semantics.rb:507:5:507:5 | [post] h [element] | semantics.rb:510:10:510:10 | h [element] |
-| semantics.rb:507:12:507:22 | call to source | semantics.rb:507:5:507:5 | [post] h [element] |
-| semantics.rb:507:12:507:22 | call to source | semantics.rb:507:5:507:5 | [post] h [element] |
-| semantics.rb:509:10:509:10 | h [element :foo] | semantics.rb:509:10:509:16 | ...[...] |
-| semantics.rb:509:10:509:10 | h [element :foo] | semantics.rb:509:10:509:16 | ...[...] |
-| semantics.rb:509:10:509:10 | h [element] | semantics.rb:509:10:509:16 | ...[...] |
-| semantics.rb:509:10:509:10 | h [element] | semantics.rb:509:10:509:16 | ...[...] |
-| semantics.rb:510:10:510:10 | h [element :bar] | semantics.rb:510:10:510:16 | ...[...] |
-| semantics.rb:510:10:510:10 | h [element :bar] | semantics.rb:510:10:510:16 | ...[...] |
+| semantics.rb:495:10:495:10 | h [element :bar] | semantics.rb:495:10:495:16 | ...[...] |
+| semantics.rb:495:10:495:10 | h [element :bar] | semantics.rb:495:10:495:16 | ...[...] |
+| semantics.rb:495:10:495:10 | h [element] | semantics.rb:495:10:495:16 | ...[...] |
+| semantics.rb:495:10:495:10 | h [element] | semantics.rb:495:10:495:16 | ...[...] |
+| semantics.rb:497:5:497:5 | x [element :bar] | semantics.rb:500:10:500:10 | x [element :bar] |
+| semantics.rb:497:5:497:5 | x [element :bar] | semantics.rb:500:10:500:10 | x [element :bar] |
+| semantics.rb:497:9:497:9 | h [element :bar] | semantics.rb:497:9:497:15 | call to s53 [element :bar] |
+| semantics.rb:497:9:497:9 | h [element :bar] | semantics.rb:497:9:497:15 | call to s53 [element :bar] |
+| semantics.rb:497:9:497:15 | call to s53 [element :bar] | semantics.rb:497:5:497:5 | x [element :bar] |
+| semantics.rb:497:9:497:15 | call to s53 [element :bar] | semantics.rb:497:5:497:5 | x [element :bar] |
+| semantics.rb:500:10:500:10 | x [element :bar] | semantics.rb:500:10:500:16 | ...[...] |
+| semantics.rb:500:10:500:10 | x [element :bar] | semantics.rb:500:10:500:16 | ...[...] |
+| semantics.rb:502:10:502:20 | call to source | semantics.rb:502:10:502:26 | call to s53 |
+| semantics.rb:502:10:502:20 | call to source | semantics.rb:502:10:502:26 | call to s53 |
+| semantics.rb:506:5:506:5 | [post] h [element :foo] | semantics.rb:507:5:507:5 | h [element :foo] |
+| semantics.rb:506:5:506:5 | [post] h [element :foo] | semantics.rb:507:5:507:5 | h [element :foo] |
+| semantics.rb:506:15:506:25 | call to source | semantics.rb:506:5:506:5 | [post] h [element :foo] |
+| semantics.rb:506:15:506:25 | call to source | semantics.rb:506:5:506:5 | [post] h [element :foo] |
+| semantics.rb:507:5:507:5 | [post] h [element :bar] | semantics.rb:511:10:511:10 | h [element :bar] |
+| semantics.rb:507:5:507:5 | [post] h [element :bar] | semantics.rb:511:10:511:10 | h [element :bar] |
+| semantics.rb:507:5:507:5 | [post] h [element :bar] | semantics.rb:513:9:513:9 | h [element :bar] |
+| semantics.rb:507:5:507:5 | [post] h [element :bar] | semantics.rb:513:9:513:9 | h [element :bar] |
+| semantics.rb:507:5:507:5 | [post] h [element :foo] | semantics.rb:510:10:510:10 | h [element :foo] |
+| semantics.rb:507:5:507:5 | [post] h [element :foo] | semantics.rb:510:10:510:10 | h [element :foo] |
+| semantics.rb:507:5:507:5 | h [element :foo] | semantics.rb:507:5:507:5 | [post] h [element :foo] |
+| semantics.rb:507:5:507:5 | h [element :foo] | semantics.rb:507:5:507:5 | [post] h [element :foo] |
+| semantics.rb:507:15:507:25 | call to source | semantics.rb:507:5:507:5 | [post] h [element :bar] |
+| semantics.rb:507:15:507:25 | call to source | semantics.rb:507:5:507:5 | [post] h [element :bar] |
+| semantics.rb:508:5:508:5 | [post] h [element] | semantics.rb:510:10:510:10 | h [element] |
+| semantics.rb:508:5:508:5 | [post] h [element] | semantics.rb:510:10:510:10 | h [element] |
+| semantics.rb:508:5:508:5 | [post] h [element] | semantics.rb:511:10:511:10 | h [element] |
+| semantics.rb:508:5:508:5 | [post] h [element] | semantics.rb:511:10:511:10 | h [element] |
+| semantics.rb:508:12:508:22 | call to source | semantics.rb:508:5:508:5 | [post] h [element] |
+| semantics.rb:508:12:508:22 | call to source | semantics.rb:508:5:508:5 | [post] h [element] |
+| semantics.rb:510:10:510:10 | h [element :foo] | semantics.rb:510:10:510:16 | ...[...] |
+| semantics.rb:510:10:510:10 | h [element :foo] | semantics.rb:510:10:510:16 | ...[...] |
 | semantics.rb:510:10:510:10 | h [element] | semantics.rb:510:10:510:16 | ...[...] |
 | semantics.rb:510:10:510:10 | h [element] | semantics.rb:510:10:510:16 | ...[...] |
-| semantics.rb:512:5:512:5 | x [element :bar] | semantics.rb:515:10:515:10 | x [element :bar] |
-| semantics.rb:512:5:512:5 | x [element :bar] | semantics.rb:515:10:515:10 | x [element :bar] |
-| semantics.rb:512:9:512:9 | h [element :bar] | semantics.rb:512:9:512:15 | call to s54 [element :bar] |
-| semantics.rb:512:9:512:9 | h [element :bar] | semantics.rb:512:9:512:15 | call to s54 [element :bar] |
-| semantics.rb:512:9:512:15 | call to s54 [element :bar] | semantics.rb:512:5:512:5 | x [element :bar] |
-| semantics.rb:512:9:512:15 | call to s54 [element :bar] | semantics.rb:512:5:512:5 | x [element :bar] |
-| semantics.rb:515:10:515:10 | x [element :bar] | semantics.rb:515:10:515:16 | ...[...] |
-| semantics.rb:515:10:515:10 | x [element :bar] | semantics.rb:515:10:515:16 | ...[...] |
+| semantics.rb:511:10:511:10 | h [element :bar] | semantics.rb:511:10:511:16 | ...[...] |
+| semantics.rb:511:10:511:10 | h [element :bar] | semantics.rb:511:10:511:16 | ...[...] |
+| semantics.rb:511:10:511:10 | h [element] | semantics.rb:511:10:511:16 | ...[...] |
+| semantics.rb:511:10:511:10 | h [element] | semantics.rb:511:10:511:16 | ...[...] |
+| semantics.rb:513:5:513:5 | x [element :bar] | semantics.rb:516:10:516:10 | x [element :bar] |
+| semantics.rb:513:5:513:5 | x [element :bar] | semantics.rb:516:10:516:10 | x [element :bar] |
+| semantics.rb:513:9:513:9 | h [element :bar] | semantics.rb:513:9:513:15 | call to s54 [element :bar] |
+| semantics.rb:513:9:513:9 | h [element :bar] | semantics.rb:513:9:513:15 | call to s54 [element :bar] |
+| semantics.rb:513:9:513:15 | call to s54 [element :bar] | semantics.rb:513:5:513:5 | x [element :bar] |
+| semantics.rb:513:9:513:15 | call to s54 [element :bar] | semantics.rb:513:5:513:5 | x [element :bar] |
+| semantics.rb:516:10:516:10 | x [element :bar] | semantics.rb:516:10:516:16 | ...[...] |
+| semantics.rb:516:10:516:10 | x [element :bar] | semantics.rb:516:10:516:16 | ...[...] |
 nodes
 | semantics.rb:2:5:2:5 | a | semmle.label | a |
 | semantics.rb:2:5:2:5 | a | semmle.label | a |
@@ -1122,12 +1175,12 @@ nodes
 | semantics.rb:60:9:60:18 | call to source | semmle.label | call to source |
 | semantics.rb:61:10:61:15 | call to s10 | semmle.label | call to s10 |
 | semantics.rb:61:10:61:15 | call to s10 | semmle.label | call to s10 |
-| semantics.rb:61:10:61:15 | call to s10 [element 0] | semmle.label | call to s10 [element 0] |
+| semantics.rb:61:10:61:15 | call to s10 [splat position 0] | semmle.label | call to s10 [splat position 0] |
 | semantics.rb:61:14:61:14 | a | semmle.label | a |
 | semantics.rb:61:14:61:14 | a | semmle.label | a |
 | semantics.rb:62:10:62:18 | call to s10 | semmle.label | call to s10 |
 | semantics.rb:62:10:62:18 | call to s10 | semmle.label | call to s10 |
-| semantics.rb:62:10:62:18 | call to s10 [element 1] | semmle.label | call to s10 [element 1] |
+| semantics.rb:62:10:62:18 | call to s10 [splat position 1] | semmle.label | call to s10 [splat position 1] |
 | semantics.rb:62:17:62:17 | a | semmle.label | a |
 | semantics.rb:62:17:62:17 | a | semmle.label | a |
 | semantics.rb:63:10:63:20 | call to s10 | semmle.label | call to s10 |
@@ -1193,11 +1246,25 @@ nodes
 | semantics.rb:103:10:103:10 | z | semmle.label | z |
 | semantics.rb:103:10:103:10 | z | semmle.label | z |
 | semantics.rb:107:5:107:5 | a | semmle.label | a |
+| semantics.rb:107:5:107:5 | a | semmle.label | a |
 | semantics.rb:107:9:107:18 | call to source | semmle.label | call to source |
-| semantics.rb:109:10:109:17 | call to s15 | semmle.label | call to s15 |
-| semantics.rb:109:14:109:16 | ** ... | semmle.label | ** ... |
-| semantics.rb:110:10:110:31 | call to s15 | semmle.label | call to s15 |
-| semantics.rb:110:28:110:30 | ** ... | semmle.label | ** ... |
+| semantics.rb:107:9:107:18 | call to source | semmle.label | call to source |
+| semantics.rb:108:5:108:5 | b | semmle.label | b |
+| semantics.rb:108:5:108:5 | b | semmle.label | b |
+| semantics.rb:108:9:108:18 | call to source | semmle.label | call to source |
+| semantics.rb:108:9:108:18 | call to source | semmle.label | call to source |
+| semantics.rb:109:10:109:28 | call to s15 [hash-splat position :foo] | semmle.label | call to s15 [hash-splat position :foo] |
+| semantics.rb:109:10:109:28 | call to s15 [hash-splat position :foo] | semmle.label | call to s15 [hash-splat position :foo] |
+| semantics.rb:109:10:109:34 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:109:10:109:34 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:109:19:109:19 | a | semmle.label | a |
+| semantics.rb:109:19:109:19 | a | semmle.label | a |
+| semantics.rb:110:10:110:28 | call to s15 [hash-splat position :bar] | semmle.label | call to s15 [hash-splat position :bar] |
+| semantics.rb:110:10:110:28 | call to s15 [hash-splat position :bar] | semmle.label | call to s15 [hash-splat position :bar] |
+| semantics.rb:110:10:110:34 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:110:10:110:34 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:110:27:110:27 | b | semmle.label | b |
+| semantics.rb:110:27:110:27 | b | semmle.label | b |
 | semantics.rb:114:5:114:5 | a | semmle.label | a |
 | semantics.rb:114:5:114:5 | a | semmle.label | a |
 | semantics.rb:114:9:114:18 | call to source | semmle.label | call to source |
@@ -1232,184 +1299,225 @@ nodes
 | semantics.rb:125:5:125:5 | a | semmle.label | a |
 | semantics.rb:125:9:125:18 | call to source | semmle.label | call to source |
 | semantics.rb:125:9:125:18 | call to source | semmle.label | call to source |
-| semantics.rb:126:9:126:9 | a | semmle.label | a |
-| semantics.rb:126:9:126:9 | a | semmle.label | a |
-| semantics.rb:126:12:126:14 | [post] ** ... | semmle.label | [post] ** ... |
-| semantics.rb:126:12:126:14 | [post] ** ... | semmle.label | [post] ** ... |
-| semantics.rb:127:10:127:10 | h | semmle.label | h |
-| semantics.rb:127:10:127:10 | h | semmle.label | h |
-| semantics.rb:141:5:141:5 | b | semmle.label | b |
-| semantics.rb:141:5:141:5 | b | semmle.label | b |
-| semantics.rb:141:9:141:18 | call to source | semmle.label | call to source |
-| semantics.rb:141:9:141:18 | call to source | semmle.label | call to source |
-| semantics.rb:145:5:145:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:145:5:145:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:147:10:147:15 | call to s19 | semmle.label | call to s19 |
-| semantics.rb:147:10:147:15 | call to s19 | semmle.label | call to s19 |
-| semantics.rb:147:14:147:14 | h [element] | semmle.label | h [element] |
-| semantics.rb:147:14:147:14 | h [element] | semmle.label | h [element] |
-| semantics.rb:151:5:151:5 | a | semmle.label | a |
-| semantics.rb:151:5:151:5 | a | semmle.label | a |
-| semantics.rb:151:9:151:18 | call to source | semmle.label | call to source |
-| semantics.rb:151:9:151:18 | call to source | semmle.label | call to source |
-| semantics.rb:152:5:152:5 | x [element] | semmle.label | x [element] |
-| semantics.rb:152:5:152:5 | x [element] | semmle.label | x [element] |
-| semantics.rb:152:9:152:14 | call to s20 [element] | semmle.label | call to s20 [element] |
-| semantics.rb:152:9:152:14 | call to s20 [element] | semmle.label | call to s20 [element] |
-| semantics.rb:152:13:152:13 | a | semmle.label | a |
-| semantics.rb:152:13:152:13 | a | semmle.label | a |
-| semantics.rb:153:10:153:10 | x [element] | semmle.label | x [element] |
-| semantics.rb:153:10:153:10 | x [element] | semmle.label | x [element] |
-| semantics.rb:153:10:153:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:153:10:153:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:126:5:126:5 | b | semmle.label | b |
+| semantics.rb:126:5:126:5 | b | semmle.label | b |
+| semantics.rb:126:9:126:18 | call to source | semmle.label | call to source |
+| semantics.rb:126:9:126:18 | call to source | semmle.label | call to source |
+| semantics.rb:127:10:127:18 | call to s17 | semmle.label | call to s17 |
+| semantics.rb:127:10:127:18 | call to s17 [splat position 0] | semmle.label | call to s17 [splat position 0] |
+| semantics.rb:127:10:127:18 | call to s17 [splat position 1] | semmle.label | call to s17 [splat position 1] |
+| semantics.rb:127:14:127:14 | a | semmle.label | a |
+| semantics.rb:127:17:127:17 | b | semmle.label | b |
+| semantics.rb:128:10:128:18 | call to s17 [splat position 0] | semmle.label | call to s17 [splat position 0] |
+| semantics.rb:128:10:128:18 | call to s17 [splat position 0] | semmle.label | call to s17 [splat position 0] |
+| semantics.rb:128:10:128:21 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:128:10:128:21 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:128:14:128:14 | a | semmle.label | a |
+| semantics.rb:128:14:128:14 | a | semmle.label | a |
+| semantics.rb:129:10:129:18 | call to s17 [splat position 1] | semmle.label | call to s17 [splat position 1] |
+| semantics.rb:129:10:129:18 | call to s17 [splat position 1] | semmle.label | call to s17 [splat position 1] |
+| semantics.rb:129:10:129:21 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:129:10:129:21 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:129:17:129:17 | b | semmle.label | b |
+| semantics.rb:129:17:129:17 | b | semmle.label | b |
+| semantics.rb:133:5:133:5 | a | semmle.label | a |
+| semantics.rb:133:5:133:5 | a | semmle.label | a |
+| semantics.rb:133:9:133:18 | call to source | semmle.label | call to source |
+| semantics.rb:133:9:133:18 | call to source | semmle.label | call to source |
+| semantics.rb:134:5:134:5 | b | semmle.label | b |
+| semantics.rb:134:5:134:5 | b | semmle.label | b |
+| semantics.rb:134:9:134:18 | call to source | semmle.label | call to source |
+| semantics.rb:134:9:134:18 | call to source | semmle.label | call to source |
+| semantics.rb:135:5:135:7 | arr [element 0] | semmle.label | arr [element 0] |
+| semantics.rb:135:5:135:7 | arr [element 0] | semmle.label | arr [element 0] |
+| semantics.rb:135:5:135:7 | arr [element 1] | semmle.label | arr [element 1] |
+| semantics.rb:135:5:135:7 | arr [element 1] | semmle.label | arr [element 1] |
+| semantics.rb:135:12:135:12 | a | semmle.label | a |
+| semantics.rb:135:12:135:12 | a | semmle.label | a |
+| semantics.rb:135:15:135:15 | b | semmle.label | b |
+| semantics.rb:135:15:135:15 | b | semmle.label | b |
+| semantics.rb:136:10:136:18 | call to s18 | semmle.label | call to s18 |
+| semantics.rb:136:10:136:18 | call to s18 | semmle.label | call to s18 |
+| semantics.rb:136:14:136:17 | * ... [element 0] | semmle.label | * ... [element 0] |
+| semantics.rb:136:14:136:17 | * ... [element 0] | semmle.label | * ... [element 0] |
+| semantics.rb:136:14:136:17 | * ... [element 1] | semmle.label | * ... [element 1] |
+| semantics.rb:136:14:136:17 | * ... [element 1] | semmle.label | * ... [element 1] |
+| semantics.rb:136:15:136:17 | arr [element 0] | semmle.label | arr [element 0] |
+| semantics.rb:136:15:136:17 | arr [element 0] | semmle.label | arr [element 0] |
+| semantics.rb:136:15:136:17 | arr [element 1] | semmle.label | arr [element 1] |
+| semantics.rb:136:15:136:17 | arr [element 1] | semmle.label | arr [element 1] |
+| semantics.rb:137:10:137:15 | call to s18 | semmle.label | call to s18 |
+| semantics.rb:137:10:137:15 | call to s18 | semmle.label | call to s18 |
+| semantics.rb:137:14:137:14 | a | semmle.label | a |
+| semantics.rb:137:14:137:14 | a | semmle.label | a |
+| semantics.rb:142:5:142:5 | b | semmle.label | b |
+| semantics.rb:142:5:142:5 | b | semmle.label | b |
+| semantics.rb:142:9:142:18 | call to source | semmle.label | call to source |
+| semantics.rb:142:9:142:18 | call to source | semmle.label | call to source |
+| semantics.rb:146:5:146:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:146:5:146:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:148:10:148:15 | call to s19 | semmle.label | call to s19 |
+| semantics.rb:148:10:148:15 | call to s19 | semmle.label | call to s19 |
+| semantics.rb:148:14:148:14 | h [element] | semmle.label | h [element] |
+| semantics.rb:148:14:148:14 | h [element] | semmle.label | h [element] |
+| semantics.rb:152:5:152:5 | a | semmle.label | a |
+| semantics.rb:152:5:152:5 | a | semmle.label | a |
+| semantics.rb:152:9:152:18 | call to source | semmle.label | call to source |
+| semantics.rb:152:9:152:18 | call to source | semmle.label | call to source |
+| semantics.rb:153:5:153:5 | x [element] | semmle.label | x [element] |
+| semantics.rb:153:5:153:5 | x [element] | semmle.label | x [element] |
+| semantics.rb:153:9:153:14 | call to s20 [element] | semmle.label | call to s20 [element] |
+| semantics.rb:153:9:153:14 | call to s20 [element] | semmle.label | call to s20 [element] |
+| semantics.rb:153:13:153:13 | a | semmle.label | a |
+| semantics.rb:153:13:153:13 | a | semmle.label | a |
 | semantics.rb:154:10:154:10 | x [element] | semmle.label | x [element] |
 | semantics.rb:154:10:154:10 | x [element] | semmle.label | x [element] |
 | semantics.rb:154:10:154:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:154:10:154:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:158:5:158:5 | a | semmle.label | a |
-| semantics.rb:158:5:158:5 | a | semmle.label | a |
-| semantics.rb:158:9:158:18 | call to source | semmle.label | call to source |
-| semantics.rb:158:9:158:18 | call to source | semmle.label | call to source |
-| semantics.rb:159:5:159:5 | b | semmle.label | b |
-| semantics.rb:159:5:159:5 | b | semmle.label | b |
+| semantics.rb:155:10:155:10 | x [element] | semmle.label | x [element] |
+| semantics.rb:155:10:155:10 | x [element] | semmle.label | x [element] |
+| semantics.rb:155:10:155:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:155:10:155:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:159:5:159:5 | a | semmle.label | a |
+| semantics.rb:159:5:159:5 | a | semmle.label | a |
 | semantics.rb:159:9:159:18 | call to source | semmle.label | call to source |
 | semantics.rb:159:9:159:18 | call to source | semmle.label | call to source |
-| semantics.rb:162:5:162:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:162:5:162:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:163:5:163:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:163:5:163:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:165:10:165:15 | call to s21 | semmle.label | call to s21 |
-| semantics.rb:165:10:165:15 | call to s21 | semmle.label | call to s21 |
-| semantics.rb:165:14:165:14 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:165:14:165:14 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:165:14:165:14 | h [element] | semmle.label | h [element] |
-| semantics.rb:165:14:165:14 | h [element] | semmle.label | h [element] |
-| semantics.rb:169:5:169:5 | a | semmle.label | a |
-| semantics.rb:169:5:169:5 | a | semmle.label | a |
-| semantics.rb:169:9:169:18 | call to source | semmle.label | call to source |
-| semantics.rb:169:9:169:18 | call to source | semmle.label | call to source |
-| semantics.rb:170:5:170:5 | x [element] | semmle.label | x [element] |
-| semantics.rb:170:5:170:5 | x [element] | semmle.label | x [element] |
-| semantics.rb:170:9:170:14 | call to s22 [element] | semmle.label | call to s22 [element] |
-| semantics.rb:170:9:170:14 | call to s22 [element] | semmle.label | call to s22 [element] |
-| semantics.rb:170:13:170:13 | a | semmle.label | a |
-| semantics.rb:170:13:170:13 | a | semmle.label | a |
-| semantics.rb:171:10:171:10 | x [element] | semmle.label | x [element] |
-| semantics.rb:171:10:171:10 | x [element] | semmle.label | x [element] |
-| semantics.rb:171:10:171:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:171:10:171:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:160:5:160:5 | b | semmle.label | b |
+| semantics.rb:160:5:160:5 | b | semmle.label | b |
+| semantics.rb:160:9:160:18 | call to source | semmle.label | call to source |
+| semantics.rb:160:9:160:18 | call to source | semmle.label | call to source |
+| semantics.rb:163:5:163:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
+| semantics.rb:163:5:163:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
+| semantics.rb:164:5:164:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:164:5:164:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:166:10:166:15 | call to s21 | semmle.label | call to s21 |
+| semantics.rb:166:10:166:15 | call to s21 | semmle.label | call to s21 |
+| semantics.rb:166:14:166:14 | h [element 0] | semmle.label | h [element 0] |
+| semantics.rb:166:14:166:14 | h [element 0] | semmle.label | h [element 0] |
+| semantics.rb:166:14:166:14 | h [element] | semmle.label | h [element] |
+| semantics.rb:166:14:166:14 | h [element] | semmle.label | h [element] |
+| semantics.rb:170:5:170:5 | a | semmle.label | a |
+| semantics.rb:170:5:170:5 | a | semmle.label | a |
+| semantics.rb:170:9:170:18 | call to source | semmle.label | call to source |
+| semantics.rb:170:9:170:18 | call to source | semmle.label | call to source |
+| semantics.rb:171:5:171:5 | x [element] | semmle.label | x [element] |
+| semantics.rb:171:5:171:5 | x [element] | semmle.label | x [element] |
+| semantics.rb:171:9:171:14 | call to s22 [element] | semmle.label | call to s22 [element] |
+| semantics.rb:171:9:171:14 | call to s22 [element] | semmle.label | call to s22 [element] |
+| semantics.rb:171:13:171:13 | a | semmle.label | a |
+| semantics.rb:171:13:171:13 | a | semmle.label | a |
 | semantics.rb:172:10:172:10 | x [element] | semmle.label | x [element] |
 | semantics.rb:172:10:172:10 | x [element] | semmle.label | x [element] |
 | semantics.rb:172:10:172:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:172:10:172:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:176:5:176:5 | a | semmle.label | a |
-| semantics.rb:176:5:176:5 | a | semmle.label | a |
-| semantics.rb:176:9:176:18 | call to source | semmle.label | call to source |
-| semantics.rb:176:9:176:18 | call to source | semmle.label | call to source |
-| semantics.rb:179:5:179:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:179:5:179:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
+| semantics.rb:173:10:173:10 | x [element] | semmle.label | x [element] |
+| semantics.rb:173:10:173:10 | x [element] | semmle.label | x [element] |
+| semantics.rb:173:10:173:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:173:10:173:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:177:5:177:5 | a | semmle.label | a |
+| semantics.rb:177:5:177:5 | a | semmle.label | a |
+| semantics.rb:177:9:177:18 | call to source | semmle.label | call to source |
+| semantics.rb:177:9:177:18 | call to source | semmle.label | call to source |
 | semantics.rb:180:5:180:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
 | semantics.rb:180:5:180:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:180:5:180:5 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:180:5:180:5 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:181:10:181:15 | call to s23 | semmle.label | call to s23 |
-| semantics.rb:181:10:181:15 | call to s23 | semmle.label | call to s23 |
-| semantics.rb:181:14:181:14 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:181:14:181:14 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:185:5:185:5 | a | semmle.label | a |
-| semantics.rb:185:5:185:5 | a | semmle.label | a |
-| semantics.rb:185:9:185:18 | call to source | semmle.label | call to source |
-| semantics.rb:185:9:185:18 | call to source | semmle.label | call to source |
-| semantics.rb:186:5:186:5 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:186:5:186:5 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:186:9:186:14 | call to s24 [element 0] | semmle.label | call to s24 [element 0] |
-| semantics.rb:186:9:186:14 | call to s24 [element 0] | semmle.label | call to s24 [element 0] |
-| semantics.rb:186:13:186:13 | a | semmle.label | a |
-| semantics.rb:186:13:186:13 | a | semmle.label | a |
-| semantics.rb:187:10:187:10 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:187:10:187:10 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:187:10:187:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:187:10:187:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:189:10:189:10 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:189:10:189:10 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:189:10:189:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:189:10:189:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:193:5:193:5 | a | semmle.label | a |
-| semantics.rb:193:5:193:5 | a | semmle.label | a |
-| semantics.rb:193:9:193:18 | call to source | semmle.label | call to source |
-| semantics.rb:193:9:193:18 | call to source | semmle.label | call to source |
-| semantics.rb:196:5:196:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:196:5:196:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
+| semantics.rb:181:5:181:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
+| semantics.rb:181:5:181:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
+| semantics.rb:181:5:181:5 | h [element 0] | semmle.label | h [element 0] |
+| semantics.rb:181:5:181:5 | h [element 0] | semmle.label | h [element 0] |
+| semantics.rb:182:10:182:15 | call to s23 | semmle.label | call to s23 |
+| semantics.rb:182:10:182:15 | call to s23 | semmle.label | call to s23 |
+| semantics.rb:182:14:182:14 | h [element 0] | semmle.label | h [element 0] |
+| semantics.rb:182:14:182:14 | h [element 0] | semmle.label | h [element 0] |
+| semantics.rb:186:5:186:5 | a | semmle.label | a |
+| semantics.rb:186:5:186:5 | a | semmle.label | a |
+| semantics.rb:186:9:186:18 | call to source | semmle.label | call to source |
+| semantics.rb:186:9:186:18 | call to source | semmle.label | call to source |
+| semantics.rb:187:5:187:5 | x [element 0] | semmle.label | x [element 0] |
+| semantics.rb:187:5:187:5 | x [element 0] | semmle.label | x [element 0] |
+| semantics.rb:187:9:187:14 | call to s24 [element 0] | semmle.label | call to s24 [element 0] |
+| semantics.rb:187:9:187:14 | call to s24 [element 0] | semmle.label | call to s24 [element 0] |
+| semantics.rb:187:13:187:13 | a | semmle.label | a |
+| semantics.rb:187:13:187:13 | a | semmle.label | a |
+| semantics.rb:188:10:188:10 | x [element 0] | semmle.label | x [element 0] |
+| semantics.rb:188:10:188:10 | x [element 0] | semmle.label | x [element 0] |
+| semantics.rb:188:10:188:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:188:10:188:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:190:10:190:10 | x [element 0] | semmle.label | x [element 0] |
+| semantics.rb:190:10:190:10 | x [element 0] | semmle.label | x [element 0] |
+| semantics.rb:190:10:190:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:190:10:190:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:194:5:194:5 | a | semmle.label | a |
+| semantics.rb:194:5:194:5 | a | semmle.label | a |
+| semantics.rb:194:9:194:18 | call to source | semmle.label | call to source |
+| semantics.rb:194:9:194:18 | call to source | semmle.label | call to source |
 | semantics.rb:197:5:197:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
 | semantics.rb:197:5:197:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:197:5:197:5 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:197:5:197:5 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:198:10:198:15 | call to s25 | semmle.label | call to s25 |
-| semantics.rb:198:10:198:15 | call to s25 | semmle.label | call to s25 |
-| semantics.rb:198:14:198:14 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:198:14:198:14 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:202:5:202:5 | a | semmle.label | a |
-| semantics.rb:202:5:202:5 | a | semmle.label | a |
-| semantics.rb:202:9:202:18 | call to source | semmle.label | call to source |
-| semantics.rb:202:9:202:18 | call to source | semmle.label | call to source |
-| semantics.rb:203:5:203:5 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:203:5:203:5 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:203:9:203:14 | call to s26 [element 0] | semmle.label | call to s26 [element 0] |
-| semantics.rb:203:9:203:14 | call to s26 [element 0] | semmle.label | call to s26 [element 0] |
-| semantics.rb:203:13:203:13 | a | semmle.label | a |
-| semantics.rb:203:13:203:13 | a | semmle.label | a |
-| semantics.rb:204:10:204:10 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:204:10:204:10 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:204:10:204:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:204:10:204:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:206:10:206:10 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:206:10:206:10 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:206:10:206:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:206:10:206:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:211:5:211:5 | b | semmle.label | b |
-| semantics.rb:211:5:211:5 | b | semmle.label | b |
-| semantics.rb:211:9:211:18 | call to source | semmle.label | call to source |
-| semantics.rb:211:9:211:18 | call to source | semmle.label | call to source |
-| semantics.rb:212:5:212:5 | c | semmle.label | c |
-| semantics.rb:212:5:212:5 | c | semmle.label | c |
+| semantics.rb:198:5:198:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
+| semantics.rb:198:5:198:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
+| semantics.rb:198:5:198:5 | h [element 0] | semmle.label | h [element 0] |
+| semantics.rb:198:5:198:5 | h [element 0] | semmle.label | h [element 0] |
+| semantics.rb:199:10:199:15 | call to s25 | semmle.label | call to s25 |
+| semantics.rb:199:10:199:15 | call to s25 | semmle.label | call to s25 |
+| semantics.rb:199:14:199:14 | h [element 0] | semmle.label | h [element 0] |
+| semantics.rb:199:14:199:14 | h [element 0] | semmle.label | h [element 0] |
+| semantics.rb:203:5:203:5 | a | semmle.label | a |
+| semantics.rb:203:5:203:5 | a | semmle.label | a |
+| semantics.rb:203:9:203:18 | call to source | semmle.label | call to source |
+| semantics.rb:203:9:203:18 | call to source | semmle.label | call to source |
+| semantics.rb:204:5:204:5 | x [element 0] | semmle.label | x [element 0] |
+| semantics.rb:204:5:204:5 | x [element 0] | semmle.label | x [element 0] |
+| semantics.rb:204:9:204:14 | call to s26 [element 0] | semmle.label | call to s26 [element 0] |
+| semantics.rb:204:9:204:14 | call to s26 [element 0] | semmle.label | call to s26 [element 0] |
+| semantics.rb:204:13:204:13 | a | semmle.label | a |
+| semantics.rb:204:13:204:13 | a | semmle.label | a |
+| semantics.rb:205:10:205:10 | x [element 0] | semmle.label | x [element 0] |
+| semantics.rb:205:10:205:10 | x [element 0] | semmle.label | x [element 0] |
+| semantics.rb:205:10:205:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:205:10:205:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:207:10:207:10 | x [element 0] | semmle.label | x [element 0] |
+| semantics.rb:207:10:207:10 | x [element 0] | semmle.label | x [element 0] |
+| semantics.rb:207:10:207:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:207:10:207:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:212:5:212:5 | b | semmle.label | b |
+| semantics.rb:212:5:212:5 | b | semmle.label | b |
 | semantics.rb:212:9:212:18 | call to source | semmle.label | call to source |
 | semantics.rb:212:9:212:18 | call to source | semmle.label | call to source |
-| semantics.rb:213:5:213:5 | d | semmle.label | d |
-| semantics.rb:213:5:213:5 | d | semmle.label | d |
+| semantics.rb:213:5:213:5 | c | semmle.label | c |
+| semantics.rb:213:5:213:5 | c | semmle.label | c |
 | semantics.rb:213:9:213:18 | call to source | semmle.label | call to source |
 | semantics.rb:213:9:213:18 | call to source | semmle.label | call to source |
-| semantics.rb:217:5:217:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
-| semantics.rb:217:5:217:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
+| semantics.rb:214:5:214:5 | d | semmle.label | d |
+| semantics.rb:214:5:214:5 | d | semmle.label | d |
+| semantics.rb:214:9:214:18 | call to source | semmle.label | call to source |
+| semantics.rb:214:9:214:18 | call to source | semmle.label | call to source |
 | semantics.rb:218:5:218:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
 | semantics.rb:218:5:218:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
-| semantics.rb:218:5:218:5 | [post] h [element 2] | semmle.label | [post] h [element 2] |
-| semantics.rb:218:5:218:5 | [post] h [element 2] | semmle.label | [post] h [element 2] |
-| semantics.rb:218:5:218:5 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:218:5:218:5 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:219:5:219:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:219:5:219:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:221:10:221:15 | call to s27 | semmle.label | call to s27 |
-| semantics.rb:221:10:221:15 | call to s27 | semmle.label | call to s27 |
-| semantics.rb:221:14:221:14 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:221:14:221:14 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:221:14:221:14 | h [element 2] | semmle.label | h [element 2] |
-| semantics.rb:221:14:221:14 | h [element 2] | semmle.label | h [element 2] |
-| semantics.rb:221:14:221:14 | h [element] | semmle.label | h [element] |
-| semantics.rb:221:14:221:14 | h [element] | semmle.label | h [element] |
-| semantics.rb:225:5:225:5 | a | semmle.label | a |
-| semantics.rb:225:5:225:5 | a | semmle.label | a |
-| semantics.rb:225:9:225:18 | call to source | semmle.label | call to source |
-| semantics.rb:225:9:225:18 | call to source | semmle.label | call to source |
-| semantics.rb:226:5:226:5 | x [element] | semmle.label | x [element] |
-| semantics.rb:226:5:226:5 | x [element] | semmle.label | x [element] |
-| semantics.rb:226:9:226:14 | call to s28 [element] | semmle.label | call to s28 [element] |
-| semantics.rb:226:9:226:14 | call to s28 [element] | semmle.label | call to s28 [element] |
-| semantics.rb:226:13:226:13 | a | semmle.label | a |
-| semantics.rb:226:13:226:13 | a | semmle.label | a |
-| semantics.rb:227:10:227:10 | x [element] | semmle.label | x [element] |
-| semantics.rb:227:10:227:10 | x [element] | semmle.label | x [element] |
-| semantics.rb:227:10:227:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:227:10:227:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:219:5:219:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
+| semantics.rb:219:5:219:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
+| semantics.rb:219:5:219:5 | [post] h [element 2] | semmle.label | [post] h [element 2] |
+| semantics.rb:219:5:219:5 | [post] h [element 2] | semmle.label | [post] h [element 2] |
+| semantics.rb:219:5:219:5 | h [element 1] | semmle.label | h [element 1] |
+| semantics.rb:219:5:219:5 | h [element 1] | semmle.label | h [element 1] |
+| semantics.rb:220:5:220:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:220:5:220:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:222:10:222:15 | call to s27 | semmle.label | call to s27 |
+| semantics.rb:222:10:222:15 | call to s27 | semmle.label | call to s27 |
+| semantics.rb:222:14:222:14 | h [element 1] | semmle.label | h [element 1] |
+| semantics.rb:222:14:222:14 | h [element 1] | semmle.label | h [element 1] |
+| semantics.rb:222:14:222:14 | h [element 2] | semmle.label | h [element 2] |
+| semantics.rb:222:14:222:14 | h [element 2] | semmle.label | h [element 2] |
+| semantics.rb:222:14:222:14 | h [element] | semmle.label | h [element] |
+| semantics.rb:222:14:222:14 | h [element] | semmle.label | h [element] |
+| semantics.rb:226:5:226:5 | a | semmle.label | a |
+| semantics.rb:226:5:226:5 | a | semmle.label | a |
+| semantics.rb:226:9:226:18 | call to source | semmle.label | call to source |
+| semantics.rb:226:9:226:18 | call to source | semmle.label | call to source |
+| semantics.rb:227:5:227:5 | x [element] | semmle.label | x [element] |
+| semantics.rb:227:5:227:5 | x [element] | semmle.label | x [element] |
+| semantics.rb:227:9:227:14 | call to s28 [element] | semmle.label | call to s28 [element] |
+| semantics.rb:227:9:227:14 | call to s28 [element] | semmle.label | call to s28 [element] |
+| semantics.rb:227:13:227:13 | a | semmle.label | a |
+| semantics.rb:227:13:227:13 | a | semmle.label | a |
 | semantics.rb:228:10:228:10 | x [element] | semmle.label | x [element] |
 | semantics.rb:228:10:228:10 | x [element] | semmle.label | x [element] |
 | semantics.rb:228:10:228:13 | ...[...] | semmle.label | ...[...] |
@@ -1422,42 +1530,42 @@ nodes
 | semantics.rb:230:10:230:10 | x [element] | semmle.label | x [element] |
 | semantics.rb:230:10:230:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:230:10:230:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:235:5:235:5 | b | semmle.label | b |
-| semantics.rb:235:5:235:5 | b | semmle.label | b |
-| semantics.rb:235:9:235:18 | call to source | semmle.label | call to source |
-| semantics.rb:235:9:235:18 | call to source | semmle.label | call to source |
-| semantics.rb:236:5:236:5 | c | semmle.label | c |
-| semantics.rb:236:5:236:5 | c | semmle.label | c |
+| semantics.rb:231:10:231:10 | x [element] | semmle.label | x [element] |
+| semantics.rb:231:10:231:10 | x [element] | semmle.label | x [element] |
+| semantics.rb:231:10:231:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:231:10:231:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:236:5:236:5 | b | semmle.label | b |
+| semantics.rb:236:5:236:5 | b | semmle.label | b |
 | semantics.rb:236:9:236:18 | call to source | semmle.label | call to source |
 | semantics.rb:236:9:236:18 | call to source | semmle.label | call to source |
-| semantics.rb:240:5:240:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
-| semantics.rb:240:5:240:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
+| semantics.rb:237:5:237:5 | c | semmle.label | c |
+| semantics.rb:237:5:237:5 | c | semmle.label | c |
+| semantics.rb:237:9:237:18 | call to source | semmle.label | call to source |
+| semantics.rb:237:9:237:18 | call to source | semmle.label | call to source |
 | semantics.rb:241:5:241:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
 | semantics.rb:241:5:241:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
-| semantics.rb:241:5:241:5 | [post] h [element 2] | semmle.label | [post] h [element 2] |
-| semantics.rb:241:5:241:5 | [post] h [element 2] | semmle.label | [post] h [element 2] |
-| semantics.rb:241:5:241:5 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:241:5:241:5 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:244:10:244:15 | call to s29 | semmle.label | call to s29 |
-| semantics.rb:244:10:244:15 | call to s29 | semmle.label | call to s29 |
-| semantics.rb:244:14:244:14 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:244:14:244:14 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:244:14:244:14 | h [element 2] | semmle.label | h [element 2] |
-| semantics.rb:244:14:244:14 | h [element 2] | semmle.label | h [element 2] |
-| semantics.rb:248:5:248:5 | a | semmle.label | a |
-| semantics.rb:248:5:248:5 | a | semmle.label | a |
-| semantics.rb:248:9:248:18 | call to source | semmle.label | call to source |
-| semantics.rb:248:9:248:18 | call to source | semmle.label | call to source |
-| semantics.rb:249:5:249:5 | x [element] | semmle.label | x [element] |
-| semantics.rb:249:5:249:5 | x [element] | semmle.label | x [element] |
-| semantics.rb:249:9:249:14 | call to s30 [element] | semmle.label | call to s30 [element] |
-| semantics.rb:249:9:249:14 | call to s30 [element] | semmle.label | call to s30 [element] |
-| semantics.rb:249:13:249:13 | a | semmle.label | a |
-| semantics.rb:249:13:249:13 | a | semmle.label | a |
-| semantics.rb:250:10:250:10 | x [element] | semmle.label | x [element] |
-| semantics.rb:250:10:250:10 | x [element] | semmle.label | x [element] |
-| semantics.rb:250:10:250:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:250:10:250:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:242:5:242:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
+| semantics.rb:242:5:242:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
+| semantics.rb:242:5:242:5 | [post] h [element 2] | semmle.label | [post] h [element 2] |
+| semantics.rb:242:5:242:5 | [post] h [element 2] | semmle.label | [post] h [element 2] |
+| semantics.rb:242:5:242:5 | h [element 1] | semmle.label | h [element 1] |
+| semantics.rb:242:5:242:5 | h [element 1] | semmle.label | h [element 1] |
+| semantics.rb:245:10:245:15 | call to s29 | semmle.label | call to s29 |
+| semantics.rb:245:10:245:15 | call to s29 | semmle.label | call to s29 |
+| semantics.rb:245:14:245:14 | h [element 1] | semmle.label | h [element 1] |
+| semantics.rb:245:14:245:14 | h [element 1] | semmle.label | h [element 1] |
+| semantics.rb:245:14:245:14 | h [element 2] | semmle.label | h [element 2] |
+| semantics.rb:245:14:245:14 | h [element 2] | semmle.label | h [element 2] |
+| semantics.rb:249:5:249:5 | a | semmle.label | a |
+| semantics.rb:249:5:249:5 | a | semmle.label | a |
+| semantics.rb:249:9:249:18 | call to source | semmle.label | call to source |
+| semantics.rb:249:9:249:18 | call to source | semmle.label | call to source |
+| semantics.rb:250:5:250:5 | x [element] | semmle.label | x [element] |
+| semantics.rb:250:5:250:5 | x [element] | semmle.label | x [element] |
+| semantics.rb:250:9:250:14 | call to s30 [element] | semmle.label | call to s30 [element] |
+| semantics.rb:250:9:250:14 | call to s30 [element] | semmle.label | call to s30 [element] |
+| semantics.rb:250:13:250:13 | a | semmle.label | a |
+| semantics.rb:250:13:250:13 | a | semmle.label | a |
 | semantics.rb:251:10:251:10 | x [element] | semmle.label | x [element] |
 | semantics.rb:251:10:251:10 | x [element] | semmle.label | x [element] |
 | semantics.rb:251:10:251:13 | ...[...] | semmle.label | ...[...] |
@@ -1470,76 +1578,66 @@ nodes
 | semantics.rb:253:10:253:10 | x [element] | semmle.label | x [element] |
 | semantics.rb:253:10:253:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:253:10:253:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:257:5:257:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:257:5:257:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:257:15:257:25 | call to source | semmle.label | call to source |
-| semantics.rb:257:15:257:25 | call to source | semmle.label | call to source |
+| semantics.rb:254:10:254:10 | x [element] | semmle.label | x [element] |
+| semantics.rb:254:10:254:10 | x [element] | semmle.label | x [element] |
+| semantics.rb:254:10:254:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:254:10:254:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:258:5:258:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
 | semantics.rb:258:5:258:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:258:5:258:5 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:258:5:258:5 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:258:15:258:25 | call to source | semmle.label | call to source |
+| semantics.rb:258:15:258:25 | call to source | semmle.label | call to source |
 | semantics.rb:259:5:259:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
 | semantics.rb:259:5:259:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
 | semantics.rb:259:5:259:5 | h [element :foo] | semmle.label | h [element :foo] |
 | semantics.rb:259:5:259:5 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:260:5:260:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:260:5:260:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:260:12:260:22 | call to source | semmle.label | call to source |
-| semantics.rb:260:12:260:22 | call to source | semmle.label | call to source |
-| semantics.rb:262:10:262:15 | call to s31 | semmle.label | call to s31 |
-| semantics.rb:262:10:262:15 | call to s31 | semmle.label | call to s31 |
-| semantics.rb:262:14:262:14 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:262:14:262:14 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:262:14:262:14 | h [element] | semmle.label | h [element] |
-| semantics.rb:262:14:262:14 | h [element] | semmle.label | h [element] |
-| semantics.rb:267:5:267:5 | [post] h [element foo] | semmle.label | [post] h [element foo] |
-| semantics.rb:267:5:267:5 | [post] h [element foo] | semmle.label | [post] h [element foo] |
-| semantics.rb:267:16:267:26 | call to source | semmle.label | call to source |
-| semantics.rb:267:16:267:26 | call to source | semmle.label | call to source |
+| semantics.rb:260:5:260:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:260:5:260:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:260:5:260:5 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:260:5:260:5 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:261:5:261:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:261:5:261:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:261:12:261:22 | call to source | semmle.label | call to source |
+| semantics.rb:261:12:261:22 | call to source | semmle.label | call to source |
+| semantics.rb:263:10:263:15 | call to s31 | semmle.label | call to s31 |
+| semantics.rb:263:10:263:15 | call to s31 | semmle.label | call to s31 |
+| semantics.rb:263:14:263:14 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:263:14:263:14 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:263:14:263:14 | h [element] | semmle.label | h [element] |
+| semantics.rb:263:14:263:14 | h [element] | semmle.label | h [element] |
 | semantics.rb:268:5:268:5 | [post] h [element foo] | semmle.label | [post] h [element foo] |
 | semantics.rb:268:5:268:5 | [post] h [element foo] | semmle.label | [post] h [element foo] |
-| semantics.rb:268:5:268:5 | h [element foo] | semmle.label | h [element foo] |
-| semantics.rb:268:5:268:5 | h [element foo] | semmle.label | h [element foo] |
+| semantics.rb:268:16:268:26 | call to source | semmle.label | call to source |
+| semantics.rb:268:16:268:26 | call to source | semmle.label | call to source |
 | semantics.rb:269:5:269:5 | [post] h [element foo] | semmle.label | [post] h [element foo] |
 | semantics.rb:269:5:269:5 | [post] h [element foo] | semmle.label | [post] h [element foo] |
 | semantics.rb:269:5:269:5 | h [element foo] | semmle.label | h [element foo] |
 | semantics.rb:269:5:269:5 | h [element foo] | semmle.label | h [element foo] |
-| semantics.rb:270:5:270:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:270:5:270:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:270:12:270:22 | call to source | semmle.label | call to source |
-| semantics.rb:270:12:270:22 | call to source | semmle.label | call to source |
-| semantics.rb:272:10:272:15 | call to s32 | semmle.label | call to s32 |
-| semantics.rb:272:10:272:15 | call to s32 | semmle.label | call to s32 |
-| semantics.rb:272:14:272:14 | h [element foo] | semmle.label | h [element foo] |
-| semantics.rb:272:14:272:14 | h [element foo] | semmle.label | h [element foo] |
-| semantics.rb:272:14:272:14 | h [element] | semmle.label | h [element] |
-| semantics.rb:272:14:272:14 | h [element] | semmle.label | h [element] |
-| semantics.rb:280:5:280:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:280:5:280:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:280:12:280:22 | call to source | semmle.label | call to source |
-| semantics.rb:280:12:280:22 | call to source | semmle.label | call to source |
-| semantics.rb:281:5:281:5 | [post] h [element nil] | semmle.label | [post] h [element nil] |
-| semantics.rb:281:5:281:5 | [post] h [element nil] | semmle.label | [post] h [element nil] |
+| semantics.rb:270:5:270:5 | [post] h [element foo] | semmle.label | [post] h [element foo] |
+| semantics.rb:270:5:270:5 | [post] h [element foo] | semmle.label | [post] h [element foo] |
+| semantics.rb:270:5:270:5 | h [element foo] | semmle.label | h [element foo] |
+| semantics.rb:270:5:270:5 | h [element foo] | semmle.label | h [element foo] |
+| semantics.rb:271:5:271:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:271:5:271:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:271:12:271:22 | call to source | semmle.label | call to source |
+| semantics.rb:271:12:271:22 | call to source | semmle.label | call to source |
+| semantics.rb:273:10:273:15 | call to s32 | semmle.label | call to s32 |
+| semantics.rb:273:10:273:15 | call to s32 | semmle.label | call to s32 |
+| semantics.rb:273:14:273:14 | h [element foo] | semmle.label | h [element foo] |
+| semantics.rb:273:14:273:14 | h [element foo] | semmle.label | h [element foo] |
+| semantics.rb:273:14:273:14 | h [element] | semmle.label | h [element] |
+| semantics.rb:273:14:273:14 | h [element] | semmle.label | h [element] |
 | semantics.rb:281:5:281:5 | [post] h [element] | semmle.label | [post] h [element] |
 | semantics.rb:281:5:281:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:281:5:281:5 | h [element] | semmle.label | h [element] |
-| semantics.rb:281:5:281:5 | h [element] | semmle.label | h [element] |
-| semantics.rb:281:14:281:24 | call to source | semmle.label | call to source |
-| semantics.rb:281:14:281:24 | call to source | semmle.label | call to source |
+| semantics.rb:281:12:281:22 | call to source | semmle.label | call to source |
+| semantics.rb:281:12:281:22 | call to source | semmle.label | call to source |
 | semantics.rb:282:5:282:5 | [post] h [element nil] | semmle.label | [post] h [element nil] |
 | semantics.rb:282:5:282:5 | [post] h [element nil] | semmle.label | [post] h [element nil] |
-| semantics.rb:282:5:282:5 | [post] h [element true] | semmle.label | [post] h [element true] |
-| semantics.rb:282:5:282:5 | [post] h [element true] | semmle.label | [post] h [element true] |
 | semantics.rb:282:5:282:5 | [post] h [element] | semmle.label | [post] h [element] |
 | semantics.rb:282:5:282:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:282:5:282:5 | h [element nil] | semmle.label | h [element nil] |
-| semantics.rb:282:5:282:5 | h [element nil] | semmle.label | h [element nil] |
 | semantics.rb:282:5:282:5 | h [element] | semmle.label | h [element] |
 | semantics.rb:282:5:282:5 | h [element] | semmle.label | h [element] |
-| semantics.rb:282:15:282:25 | call to source | semmle.label | call to source |
-| semantics.rb:282:15:282:25 | call to source | semmle.label | call to source |
-| semantics.rb:283:5:283:5 | [post] h [element false] | semmle.label | [post] h [element false] |
-| semantics.rb:283:5:283:5 | [post] h [element false] | semmle.label | [post] h [element false] |
+| semantics.rb:282:14:282:24 | call to source | semmle.label | call to source |
+| semantics.rb:282:14:282:24 | call to source | semmle.label | call to source |
 | semantics.rb:283:5:283:5 | [post] h [element nil] | semmle.label | [post] h [element nil] |
 | semantics.rb:283:5:283:5 | [post] h [element nil] | semmle.label | [post] h [element nil] |
 | semantics.rb:283:5:283:5 | [post] h [element true] | semmle.label | [post] h [element true] |
@@ -1548,224 +1646,232 @@ nodes
 | semantics.rb:283:5:283:5 | [post] h [element] | semmle.label | [post] h [element] |
 | semantics.rb:283:5:283:5 | h [element nil] | semmle.label | h [element nil] |
 | semantics.rb:283:5:283:5 | h [element nil] | semmle.label | h [element nil] |
-| semantics.rb:283:5:283:5 | h [element true] | semmle.label | h [element true] |
-| semantics.rb:283:5:283:5 | h [element true] | semmle.label | h [element true] |
 | semantics.rb:283:5:283:5 | h [element] | semmle.label | h [element] |
 | semantics.rb:283:5:283:5 | h [element] | semmle.label | h [element] |
-| semantics.rb:283:16:283:26 | call to source | semmle.label | call to source |
-| semantics.rb:283:16:283:26 | call to source | semmle.label | call to source |
-| semantics.rb:285:10:285:15 | call to s33 | semmle.label | call to s33 |
-| semantics.rb:285:10:285:15 | call to s33 | semmle.label | call to s33 |
-| semantics.rb:285:14:285:14 | h [element false] | semmle.label | h [element false] |
-| semantics.rb:285:14:285:14 | h [element false] | semmle.label | h [element false] |
-| semantics.rb:285:14:285:14 | h [element nil] | semmle.label | h [element nil] |
-| semantics.rb:285:14:285:14 | h [element nil] | semmle.label | h [element nil] |
-| semantics.rb:285:14:285:14 | h [element true] | semmle.label | h [element true] |
-| semantics.rb:285:14:285:14 | h [element true] | semmle.label | h [element true] |
-| semantics.rb:285:14:285:14 | h [element] | semmle.label | h [element] |
-| semantics.rb:285:14:285:14 | h [element] | semmle.label | h [element] |
-| semantics.rb:289:5:289:5 | x [element :foo] | semmle.label | x [element :foo] |
-| semantics.rb:289:5:289:5 | x [element :foo] | semmle.label | x [element :foo] |
-| semantics.rb:289:9:289:24 | call to s35 [element :foo] | semmle.label | call to s35 [element :foo] |
-| semantics.rb:289:9:289:24 | call to s35 [element :foo] | semmle.label | call to s35 [element :foo] |
-| semantics.rb:289:13:289:23 | call to source | semmle.label | call to source |
-| semantics.rb:289:13:289:23 | call to source | semmle.label | call to source |
-| semantics.rb:290:10:290:10 | x [element :foo] | semmle.label | x [element :foo] |
-| semantics.rb:290:10:290:10 | x [element :foo] | semmle.label | x [element :foo] |
-| semantics.rb:290:10:290:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:290:10:290:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:292:10:292:10 | x [element :foo] | semmle.label | x [element :foo] |
-| semantics.rb:292:10:292:10 | x [element :foo] | semmle.label | x [element :foo] |
-| semantics.rb:292:10:292:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:292:10:292:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:296:5:296:5 | x [element foo] | semmle.label | x [element foo] |
-| semantics.rb:296:5:296:5 | x [element foo] | semmle.label | x [element foo] |
-| semantics.rb:296:9:296:24 | call to s36 [element foo] | semmle.label | call to s36 [element foo] |
-| semantics.rb:296:9:296:24 | call to s36 [element foo] | semmle.label | call to s36 [element foo] |
-| semantics.rb:296:13:296:23 | call to source | semmle.label | call to source |
-| semantics.rb:296:13:296:23 | call to source | semmle.label | call to source |
-| semantics.rb:298:10:298:10 | x [element foo] | semmle.label | x [element foo] |
-| semantics.rb:298:10:298:10 | x [element foo] | semmle.label | x [element foo] |
-| semantics.rb:298:10:298:17 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:298:10:298:17 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:300:10:300:10 | x [element foo] | semmle.label | x [element foo] |
-| semantics.rb:300:10:300:10 | x [element foo] | semmle.label | x [element foo] |
-| semantics.rb:300:10:300:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:300:10:300:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:304:5:304:5 | x [element true] | semmle.label | x [element true] |
-| semantics.rb:304:5:304:5 | x [element true] | semmle.label | x [element true] |
-| semantics.rb:304:9:304:24 | call to s37 [element true] | semmle.label | call to s37 [element true] |
-| semantics.rb:304:9:304:24 | call to s37 [element true] | semmle.label | call to s37 [element true] |
-| semantics.rb:304:13:304:23 | call to source | semmle.label | call to source |
-| semantics.rb:304:13:304:23 | call to source | semmle.label | call to source |
-| semantics.rb:306:10:306:10 | x [element true] | semmle.label | x [element true] |
-| semantics.rb:306:10:306:10 | x [element true] | semmle.label | x [element true] |
-| semantics.rb:306:10:306:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:306:10:306:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:308:10:308:10 | x [element true] | semmle.label | x [element true] |
-| semantics.rb:308:10:308:10 | x [element true] | semmle.label | x [element true] |
-| semantics.rb:308:10:308:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:308:10:308:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:312:5:312:5 | [post] h [element foo] | semmle.label | [post] h [element foo] |
-| semantics.rb:312:5:312:5 | [post] h [element foo] | semmle.label | [post] h [element foo] |
-| semantics.rb:312:16:312:26 | call to source | semmle.label | call to source |
-| semantics.rb:312:16:312:26 | call to source | semmle.label | call to source |
-| semantics.rb:315:10:315:15 | call to s38 | semmle.label | call to s38 |
-| semantics.rb:315:10:315:15 | call to s38 | semmle.label | call to s38 |
-| semantics.rb:315:14:315:14 | h [element foo] | semmle.label | h [element foo] |
-| semantics.rb:315:14:315:14 | h [element foo] | semmle.label | h [element foo] |
-| semantics.rb:319:5:319:5 | x [element :foo] | semmle.label | x [element :foo] |
-| semantics.rb:319:5:319:5 | x [element :foo] | semmle.label | x [element :foo] |
-| semantics.rb:319:9:319:24 | call to s39 [element :foo] | semmle.label | call to s39 [element :foo] |
-| semantics.rb:319:9:319:24 | call to s39 [element :foo] | semmle.label | call to s39 [element :foo] |
-| semantics.rb:319:13:319:23 | call to source | semmle.label | call to source |
-| semantics.rb:319:13:319:23 | call to source | semmle.label | call to source |
-| semantics.rb:321:10:321:10 | x [element :foo] | semmle.label | x [element :foo] |
-| semantics.rb:321:10:321:10 | x [element :foo] | semmle.label | x [element :foo] |
-| semantics.rb:321:10:321:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:321:10:321:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:283:15:283:25 | call to source | semmle.label | call to source |
+| semantics.rb:283:15:283:25 | call to source | semmle.label | call to source |
+| semantics.rb:284:5:284:5 | [post] h [element false] | semmle.label | [post] h [element false] |
+| semantics.rb:284:5:284:5 | [post] h [element false] | semmle.label | [post] h [element false] |
+| semantics.rb:284:5:284:5 | [post] h [element nil] | semmle.label | [post] h [element nil] |
+| semantics.rb:284:5:284:5 | [post] h [element nil] | semmle.label | [post] h [element nil] |
+| semantics.rb:284:5:284:5 | [post] h [element true] | semmle.label | [post] h [element true] |
+| semantics.rb:284:5:284:5 | [post] h [element true] | semmle.label | [post] h [element true] |
+| semantics.rb:284:5:284:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:284:5:284:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:284:5:284:5 | h [element nil] | semmle.label | h [element nil] |
+| semantics.rb:284:5:284:5 | h [element nil] | semmle.label | h [element nil] |
+| semantics.rb:284:5:284:5 | h [element true] | semmle.label | h [element true] |
+| semantics.rb:284:5:284:5 | h [element true] | semmle.label | h [element true] |
+| semantics.rb:284:5:284:5 | h [element] | semmle.label | h [element] |
+| semantics.rb:284:5:284:5 | h [element] | semmle.label | h [element] |
+| semantics.rb:284:16:284:26 | call to source | semmle.label | call to source |
+| semantics.rb:284:16:284:26 | call to source | semmle.label | call to source |
+| semantics.rb:286:10:286:15 | call to s33 | semmle.label | call to s33 |
+| semantics.rb:286:10:286:15 | call to s33 | semmle.label | call to s33 |
+| semantics.rb:286:14:286:14 | h [element false] | semmle.label | h [element false] |
+| semantics.rb:286:14:286:14 | h [element false] | semmle.label | h [element false] |
+| semantics.rb:286:14:286:14 | h [element nil] | semmle.label | h [element nil] |
+| semantics.rb:286:14:286:14 | h [element nil] | semmle.label | h [element nil] |
+| semantics.rb:286:14:286:14 | h [element true] | semmle.label | h [element true] |
+| semantics.rb:286:14:286:14 | h [element true] | semmle.label | h [element true] |
+| semantics.rb:286:14:286:14 | h [element] | semmle.label | h [element] |
+| semantics.rb:286:14:286:14 | h [element] | semmle.label | h [element] |
+| semantics.rb:290:5:290:5 | x [element :foo] | semmle.label | x [element :foo] |
+| semantics.rb:290:5:290:5 | x [element :foo] | semmle.label | x [element :foo] |
+| semantics.rb:290:9:290:24 | call to s35 [element :foo] | semmle.label | call to s35 [element :foo] |
+| semantics.rb:290:9:290:24 | call to s35 [element :foo] | semmle.label | call to s35 [element :foo] |
+| semantics.rb:290:13:290:23 | call to source | semmle.label | call to source |
+| semantics.rb:290:13:290:23 | call to source | semmle.label | call to source |
+| semantics.rb:291:10:291:10 | x [element :foo] | semmle.label | x [element :foo] |
+| semantics.rb:291:10:291:10 | x [element :foo] | semmle.label | x [element :foo] |
+| semantics.rb:291:10:291:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:291:10:291:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:293:10:293:10 | x [element :foo] | semmle.label | x [element :foo] |
+| semantics.rb:293:10:293:10 | x [element :foo] | semmle.label | x [element :foo] |
+| semantics.rb:293:10:293:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:293:10:293:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:297:5:297:5 | x [element foo] | semmle.label | x [element foo] |
+| semantics.rb:297:5:297:5 | x [element foo] | semmle.label | x [element foo] |
+| semantics.rb:297:9:297:24 | call to s36 [element foo] | semmle.label | call to s36 [element foo] |
+| semantics.rb:297:9:297:24 | call to s36 [element foo] | semmle.label | call to s36 [element foo] |
+| semantics.rb:297:13:297:23 | call to source | semmle.label | call to source |
+| semantics.rb:297:13:297:23 | call to source | semmle.label | call to source |
+| semantics.rb:299:10:299:10 | x [element foo] | semmle.label | x [element foo] |
+| semantics.rb:299:10:299:10 | x [element foo] | semmle.label | x [element foo] |
+| semantics.rb:299:10:299:17 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:299:10:299:17 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:301:10:301:10 | x [element foo] | semmle.label | x [element foo] |
+| semantics.rb:301:10:301:10 | x [element foo] | semmle.label | x [element foo] |
+| semantics.rb:301:10:301:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:301:10:301:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:305:5:305:5 | x [element true] | semmle.label | x [element true] |
+| semantics.rb:305:5:305:5 | x [element true] | semmle.label | x [element true] |
+| semantics.rb:305:9:305:24 | call to s37 [element true] | semmle.label | call to s37 [element true] |
+| semantics.rb:305:9:305:24 | call to s37 [element true] | semmle.label | call to s37 [element true] |
+| semantics.rb:305:13:305:23 | call to source | semmle.label | call to source |
+| semantics.rb:305:13:305:23 | call to source | semmle.label | call to source |
+| semantics.rb:307:10:307:10 | x [element true] | semmle.label | x [element true] |
+| semantics.rb:307:10:307:10 | x [element true] | semmle.label | x [element true] |
+| semantics.rb:307:10:307:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:307:10:307:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:309:10:309:10 | x [element true] | semmle.label | x [element true] |
+| semantics.rb:309:10:309:10 | x [element true] | semmle.label | x [element true] |
+| semantics.rb:309:10:309:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:309:10:309:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:313:5:313:5 | [post] h [element foo] | semmle.label | [post] h [element foo] |
+| semantics.rb:313:5:313:5 | [post] h [element foo] | semmle.label | [post] h [element foo] |
+| semantics.rb:313:16:313:26 | call to source | semmle.label | call to source |
+| semantics.rb:313:16:313:26 | call to source | semmle.label | call to source |
+| semantics.rb:316:10:316:15 | call to s38 | semmle.label | call to s38 |
+| semantics.rb:316:10:316:15 | call to s38 | semmle.label | call to s38 |
+| semantics.rb:316:14:316:14 | h [element foo] | semmle.label | h [element foo] |
+| semantics.rb:316:14:316:14 | h [element foo] | semmle.label | h [element foo] |
+| semantics.rb:320:5:320:5 | x [element :foo] | semmle.label | x [element :foo] |
+| semantics.rb:320:5:320:5 | x [element :foo] | semmle.label | x [element :foo] |
+| semantics.rb:320:9:320:24 | call to s39 [element :foo] | semmle.label | call to s39 [element :foo] |
+| semantics.rb:320:9:320:24 | call to s39 [element :foo] | semmle.label | call to s39 [element :foo] |
+| semantics.rb:320:13:320:23 | call to source | semmle.label | call to source |
+| semantics.rb:320:13:320:23 | call to source | semmle.label | call to source |
 | semantics.rb:322:10:322:10 | x [element :foo] | semmle.label | x [element :foo] |
 | semantics.rb:322:10:322:10 | x [element :foo] | semmle.label | x [element :foo] |
-| semantics.rb:322:10:322:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:322:10:322:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:327:5:327:5 | [post] x [@foo] | semmle.label | [post] x [@foo] |
-| semantics.rb:327:5:327:5 | [post] x [@foo] | semmle.label | [post] x [@foo] |
-| semantics.rb:327:13:327:23 | call to source | semmle.label | call to source |
-| semantics.rb:327:13:327:23 | call to source | semmle.label | call to source |
-| semantics.rb:329:10:329:15 | call to s40 | semmle.label | call to s40 |
-| semantics.rb:329:10:329:15 | call to s40 | semmle.label | call to s40 |
-| semantics.rb:329:14:329:14 | x [@foo] | semmle.label | x [@foo] |
-| semantics.rb:329:14:329:14 | x [@foo] | semmle.label | x [@foo] |
-| semantics.rb:333:5:333:5 | x [@foo] | semmle.label | x [@foo] |
-| semantics.rb:333:5:333:5 | x [@foo] | semmle.label | x [@foo] |
-| semantics.rb:333:9:333:24 | call to s41 [@foo] | semmle.label | call to s41 [@foo] |
-| semantics.rb:333:9:333:24 | call to s41 [@foo] | semmle.label | call to s41 [@foo] |
-| semantics.rb:333:13:333:23 | call to source | semmle.label | call to source |
-| semantics.rb:333:13:333:23 | call to source | semmle.label | call to source |
-| semantics.rb:334:10:334:10 | x [@foo] | semmle.label | x [@foo] |
-| semantics.rb:334:10:334:10 | x [@foo] | semmle.label | x [@foo] |
-| semantics.rb:334:10:334:14 | call to foo | semmle.label | call to foo |
-| semantics.rb:334:10:334:14 | call to foo | semmle.label | call to foo |
-| semantics.rb:339:5:339:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:339:5:339:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:339:12:339:22 | call to source | semmle.label | call to source |
-| semantics.rb:339:12:339:22 | call to source | semmle.label | call to source |
-| semantics.rb:340:5:340:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:340:5:340:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:322:10:322:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:322:10:322:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:323:10:323:10 | x [element :foo] | semmle.label | x [element :foo] |
+| semantics.rb:323:10:323:10 | x [element :foo] | semmle.label | x [element :foo] |
+| semantics.rb:323:10:323:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:323:10:323:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:328:5:328:5 | [post] x [@foo] | semmle.label | [post] x [@foo] |
+| semantics.rb:328:5:328:5 | [post] x [@foo] | semmle.label | [post] x [@foo] |
+| semantics.rb:328:13:328:23 | call to source | semmle.label | call to source |
+| semantics.rb:328:13:328:23 | call to source | semmle.label | call to source |
+| semantics.rb:330:10:330:15 | call to s40 | semmle.label | call to s40 |
+| semantics.rb:330:10:330:15 | call to s40 | semmle.label | call to s40 |
+| semantics.rb:330:14:330:14 | x [@foo] | semmle.label | x [@foo] |
+| semantics.rb:330:14:330:14 | x [@foo] | semmle.label | x [@foo] |
+| semantics.rb:334:5:334:5 | x [@foo] | semmle.label | x [@foo] |
+| semantics.rb:334:5:334:5 | x [@foo] | semmle.label | x [@foo] |
+| semantics.rb:334:9:334:24 | call to s41 [@foo] | semmle.label | call to s41 [@foo] |
+| semantics.rb:334:9:334:24 | call to s41 [@foo] | semmle.label | call to s41 [@foo] |
+| semantics.rb:334:13:334:23 | call to source | semmle.label | call to source |
+| semantics.rb:334:13:334:23 | call to source | semmle.label | call to source |
+| semantics.rb:335:10:335:10 | x [@foo] | semmle.label | x [@foo] |
+| semantics.rb:335:10:335:10 | x [@foo] | semmle.label | x [@foo] |
+| semantics.rb:335:10:335:14 | call to foo | semmle.label | call to foo |
+| semantics.rb:335:10:335:14 | call to foo | semmle.label | call to foo |
+| semantics.rb:340:5:340:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
+| semantics.rb:340:5:340:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
 | semantics.rb:340:12:340:22 | call to source | semmle.label | call to source |
 | semantics.rb:340:12:340:22 | call to source | semmle.label | call to source |
-| semantics.rb:342:5:342:5 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:342:5:342:5 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:342:5:342:5 | x [element] | semmle.label | x [element] |
-| semantics.rb:342:5:342:5 | x [element] | semmle.label | x [element] |
-| semantics.rb:342:9:342:14 | call to s42 [element 0] | semmle.label | call to s42 [element 0] |
-| semantics.rb:342:9:342:14 | call to s42 [element 0] | semmle.label | call to s42 [element 0] |
-| semantics.rb:342:9:342:14 | call to s42 [element] | semmle.label | call to s42 [element] |
-| semantics.rb:342:9:342:14 | call to s42 [element] | semmle.label | call to s42 [element] |
-| semantics.rb:342:13:342:13 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:342:13:342:13 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:342:13:342:13 | h [element] | semmle.label | h [element] |
-| semantics.rb:342:13:342:13 | h [element] | semmle.label | h [element] |
-| semantics.rb:344:10:344:10 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:344:10:344:10 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:344:10:344:10 | x [element] | semmle.label | x [element] |
-| semantics.rb:344:10:344:10 | x [element] | semmle.label | x [element] |
-| semantics.rb:344:10:344:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:344:10:344:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:341:5:341:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:341:5:341:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:341:12:341:22 | call to source | semmle.label | call to source |
+| semantics.rb:341:12:341:22 | call to source | semmle.label | call to source |
+| semantics.rb:343:5:343:5 | x [element 0] | semmle.label | x [element 0] |
+| semantics.rb:343:5:343:5 | x [element 0] | semmle.label | x [element 0] |
+| semantics.rb:343:5:343:5 | x [element] | semmle.label | x [element] |
+| semantics.rb:343:5:343:5 | x [element] | semmle.label | x [element] |
+| semantics.rb:343:9:343:14 | call to s42 [element 0] | semmle.label | call to s42 [element 0] |
+| semantics.rb:343:9:343:14 | call to s42 [element 0] | semmle.label | call to s42 [element 0] |
+| semantics.rb:343:9:343:14 | call to s42 [element] | semmle.label | call to s42 [element] |
+| semantics.rb:343:9:343:14 | call to s42 [element] | semmle.label | call to s42 [element] |
+| semantics.rb:343:13:343:13 | h [element 0] | semmle.label | h [element 0] |
+| semantics.rb:343:13:343:13 | h [element 0] | semmle.label | h [element 0] |
+| semantics.rb:343:13:343:13 | h [element] | semmle.label | h [element] |
+| semantics.rb:343:13:343:13 | h [element] | semmle.label | h [element] |
+| semantics.rb:345:10:345:10 | x [element 0] | semmle.label | x [element 0] |
+| semantics.rb:345:10:345:10 | x [element 0] | semmle.label | x [element 0] |
 | semantics.rb:345:10:345:10 | x [element] | semmle.label | x [element] |
 | semantics.rb:345:10:345:10 | x [element] | semmle.label | x [element] |
 | semantics.rb:345:10:345:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:345:10:345:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:346:10:346:10 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:346:10:346:10 | x [element 0] | semmle.label | x [element 0] |
 | semantics.rb:346:10:346:10 | x [element] | semmle.label | x [element] |
 | semantics.rb:346:10:346:10 | x [element] | semmle.label | x [element] |
 | semantics.rb:346:10:346:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:346:10:346:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:350:5:350:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:350:5:350:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:350:12:350:22 | call to source | semmle.label | call to source |
-| semantics.rb:350:12:350:22 | call to source | semmle.label | call to source |
-| semantics.rb:353:5:353:5 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:353:5:353:5 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:353:9:353:14 | call to s43 [element 0] | semmle.label | call to s43 [element 0] |
-| semantics.rb:353:9:353:14 | call to s43 [element 0] | semmle.label | call to s43 [element 0] |
-| semantics.rb:353:13:353:13 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:353:13:353:13 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:355:10:355:10 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:355:10:355:10 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:355:10:355:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:355:10:355:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:357:10:357:10 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:357:10:357:10 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:357:10:357:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:357:10:357:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:362:5:362:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
-| semantics.rb:362:5:362:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
-| semantics.rb:362:12:362:22 | call to source | semmle.label | call to source |
-| semantics.rb:362:12:362:22 | call to source | semmle.label | call to source |
-| semantics.rb:365:9:365:9 | [post] h [element 1] | semmle.label | [post] h [element 1] |
-| semantics.rb:365:9:365:9 | [post] h [element 1] | semmle.label | [post] h [element 1] |
-| semantics.rb:365:9:365:9 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:365:9:365:9 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:368:10:368:10 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:368:10:368:10 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:368:10:368:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:368:10:368:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:347:10:347:10 | x [element 0] | semmle.label | x [element 0] |
+| semantics.rb:347:10:347:10 | x [element 0] | semmle.label | x [element 0] |
+| semantics.rb:347:10:347:10 | x [element] | semmle.label | x [element] |
+| semantics.rb:347:10:347:10 | x [element] | semmle.label | x [element] |
+| semantics.rb:347:10:347:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:347:10:347:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:351:5:351:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
+| semantics.rb:351:5:351:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
+| semantics.rb:351:12:351:22 | call to source | semmle.label | call to source |
+| semantics.rb:351:12:351:22 | call to source | semmle.label | call to source |
+| semantics.rb:354:5:354:5 | x [element 0] | semmle.label | x [element 0] |
+| semantics.rb:354:5:354:5 | x [element 0] | semmle.label | x [element 0] |
+| semantics.rb:354:9:354:14 | call to s43 [element 0] | semmle.label | call to s43 [element 0] |
+| semantics.rb:354:9:354:14 | call to s43 [element 0] | semmle.label | call to s43 [element 0] |
+| semantics.rb:354:13:354:13 | h [element 0] | semmle.label | h [element 0] |
+| semantics.rb:354:13:354:13 | h [element 0] | semmle.label | h [element 0] |
+| semantics.rb:356:10:356:10 | x [element 0] | semmle.label | x [element 0] |
+| semantics.rb:356:10:356:10 | x [element 0] | semmle.label | x [element 0] |
+| semantics.rb:356:10:356:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:356:10:356:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:358:10:358:10 | x [element 0] | semmle.label | x [element 0] |
+| semantics.rb:358:10:358:10 | x [element 0] | semmle.label | x [element 0] |
+| semantics.rb:358:10:358:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:358:10:358:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:363:5:363:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
+| semantics.rb:363:5:363:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
+| semantics.rb:363:12:363:22 | call to source | semmle.label | call to source |
+| semantics.rb:363:12:363:22 | call to source | semmle.label | call to source |
+| semantics.rb:366:9:366:9 | [post] h [element 1] | semmle.label | [post] h [element 1] |
+| semantics.rb:366:9:366:9 | [post] h [element 1] | semmle.label | [post] h [element 1] |
+| semantics.rb:366:9:366:9 | h [element 1] | semmle.label | h [element 1] |
+| semantics.rb:366:9:366:9 | h [element 1] | semmle.label | h [element 1] |
 | semantics.rb:369:10:369:10 | h [element 1] | semmle.label | h [element 1] |
 | semantics.rb:369:10:369:10 | h [element 1] | semmle.label | h [element 1] |
 | semantics.rb:369:10:369:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:369:10:369:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:373:5:373:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:373:5:373:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:373:12:373:22 | call to source | semmle.label | call to source |
-| semantics.rb:373:12:373:22 | call to source | semmle.label | call to source |
+| semantics.rb:370:10:370:10 | h [element 1] | semmle.label | h [element 1] |
+| semantics.rb:370:10:370:10 | h [element 1] | semmle.label | h [element 1] |
+| semantics.rb:370:10:370:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:370:10:370:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:374:5:374:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
 | semantics.rb:374:5:374:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:374:5:374:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
-| semantics.rb:374:5:374:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
-| semantics.rb:374:5:374:5 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:374:5:374:5 | h [element 0] | semmle.label | h [element 0] |
 | semantics.rb:374:12:374:22 | call to source | semmle.label | call to source |
 | semantics.rb:374:12:374:22 | call to source | semmle.label | call to source |
-| semantics.rb:375:5:375:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:375:5:375:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:375:5:375:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
+| semantics.rb:375:5:375:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
+| semantics.rb:375:5:375:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
+| semantics.rb:375:5:375:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
+| semantics.rb:375:5:375:5 | h [element 0] | semmle.label | h [element 0] |
+| semantics.rb:375:5:375:5 | h [element 0] | semmle.label | h [element 0] |
 | semantics.rb:375:12:375:22 | call to source | semmle.label | call to source |
 | semantics.rb:375:12:375:22 | call to source | semmle.label | call to source |
-| semantics.rb:377:10:377:10 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:377:10:377:10 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:377:10:377:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:377:10:377:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:377:10:377:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:377:10:377:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:378:10:378:10 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:378:10:378:10 | h [element 1] | semmle.label | h [element 1] |
+| semantics.rb:376:5:376:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:376:5:376:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:376:12:376:22 | call to source | semmle.label | call to source |
+| semantics.rb:376:12:376:22 | call to source | semmle.label | call to source |
+| semantics.rb:378:10:378:10 | h [element 0] | semmle.label | h [element 0] |
+| semantics.rb:378:10:378:10 | h [element 0] | semmle.label | h [element 0] |
 | semantics.rb:378:10:378:10 | h [element] | semmle.label | h [element] |
 | semantics.rb:378:10:378:10 | h [element] | semmle.label | h [element] |
 | semantics.rb:378:10:378:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:378:10:378:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:379:10:379:10 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:379:10:379:10 | h [element 0] | semmle.label | h [element 0] |
 | semantics.rb:379:10:379:10 | h [element 1] | semmle.label | h [element 1] |
 | semantics.rb:379:10:379:10 | h [element 1] | semmle.label | h [element 1] |
 | semantics.rb:379:10:379:10 | h [element] | semmle.label | h [element] |
 | semantics.rb:379:10:379:10 | h [element] | semmle.label | h [element] |
 | semantics.rb:379:10:379:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:379:10:379:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:381:9:381:9 | [post] h [element 1] | semmle.label | [post] h [element 1] |
-| semantics.rb:381:9:381:9 | [post] h [element 1] | semmle.label | [post] h [element 1] |
-| semantics.rb:381:9:381:9 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:381:9:381:9 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:381:9:381:9 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:381:9:381:9 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:381:9:381:9 | h [element] | semmle.label | h [element] |
-| semantics.rb:381:9:381:9 | h [element] | semmle.label | h [element] |
-| semantics.rb:383:10:383:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:383:10:383:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:383:10:383:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:383:10:383:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:384:10:384:10 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:384:10:384:10 | h [element 1] | semmle.label | h [element 1] |
+| semantics.rb:380:10:380:10 | h [element 0] | semmle.label | h [element 0] |
+| semantics.rb:380:10:380:10 | h [element 0] | semmle.label | h [element 0] |
+| semantics.rb:380:10:380:10 | h [element 1] | semmle.label | h [element 1] |
+| semantics.rb:380:10:380:10 | h [element 1] | semmle.label | h [element 1] |
+| semantics.rb:380:10:380:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:380:10:380:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:380:10:380:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:380:10:380:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:382:9:382:9 | [post] h [element 1] | semmle.label | [post] h [element 1] |
+| semantics.rb:382:9:382:9 | [post] h [element 1] | semmle.label | [post] h [element 1] |
+| semantics.rb:382:9:382:9 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:382:9:382:9 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:382:9:382:9 | h [element 1] | semmle.label | h [element 1] |
+| semantics.rb:382:9:382:9 | h [element 1] | semmle.label | h [element 1] |
+| semantics.rb:382:9:382:9 | h [element] | semmle.label | h [element] |
+| semantics.rb:382:9:382:9 | h [element] | semmle.label | h [element] |
 | semantics.rb:384:10:384:10 | h [element] | semmle.label | h [element] |
 | semantics.rb:384:10:384:10 | h [element] | semmle.label | h [element] |
 | semantics.rb:384:10:384:13 | ...[...] | semmle.label | ...[...] |
@@ -1776,378 +1882,384 @@ nodes
 | semantics.rb:385:10:385:10 | h [element] | semmle.label | h [element] |
 | semantics.rb:385:10:385:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:385:10:385:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:389:5:389:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:389:5:389:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:389:12:389:22 | call to source | semmle.label | call to source |
-| semantics.rb:389:12:389:22 | call to source | semmle.label | call to source |
+| semantics.rb:386:10:386:10 | h [element 1] | semmle.label | h [element 1] |
+| semantics.rb:386:10:386:10 | h [element 1] | semmle.label | h [element 1] |
+| semantics.rb:386:10:386:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:386:10:386:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:386:10:386:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:386:10:386:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:390:5:390:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
 | semantics.rb:390:5:390:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:390:5:390:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
-| semantics.rb:390:5:390:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
-| semantics.rb:390:5:390:5 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:390:5:390:5 | h [element 0] | semmle.label | h [element 0] |
 | semantics.rb:390:12:390:22 | call to source | semmle.label | call to source |
 | semantics.rb:390:12:390:22 | call to source | semmle.label | call to source |
-| semantics.rb:391:5:391:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:391:5:391:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:391:5:391:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
+| semantics.rb:391:5:391:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
+| semantics.rb:391:5:391:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
+| semantics.rb:391:5:391:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
+| semantics.rb:391:5:391:5 | h [element 0] | semmle.label | h [element 0] |
+| semantics.rb:391:5:391:5 | h [element 0] | semmle.label | h [element 0] |
 | semantics.rb:391:12:391:22 | call to source | semmle.label | call to source |
 | semantics.rb:391:12:391:22 | call to source | semmle.label | call to source |
-| semantics.rb:393:10:393:10 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:393:10:393:10 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:393:10:393:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:393:10:393:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:393:10:393:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:393:10:393:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:394:10:394:10 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:394:10:394:10 | h [element 1] | semmle.label | h [element 1] |
+| semantics.rb:392:5:392:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:392:5:392:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:392:12:392:22 | call to source | semmle.label | call to source |
+| semantics.rb:392:12:392:22 | call to source | semmle.label | call to source |
+| semantics.rb:394:10:394:10 | h [element 0] | semmle.label | h [element 0] |
+| semantics.rb:394:10:394:10 | h [element 0] | semmle.label | h [element 0] |
 | semantics.rb:394:10:394:10 | h [element] | semmle.label | h [element] |
 | semantics.rb:394:10:394:10 | h [element] | semmle.label | h [element] |
 | semantics.rb:394:10:394:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:394:10:394:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:395:10:395:10 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:395:10:395:10 | h [element 0] | semmle.label | h [element 0] |
 | semantics.rb:395:10:395:10 | h [element 1] | semmle.label | h [element 1] |
 | semantics.rb:395:10:395:10 | h [element 1] | semmle.label | h [element 1] |
 | semantics.rb:395:10:395:10 | h [element] | semmle.label | h [element] |
 | semantics.rb:395:10:395:10 | h [element] | semmle.label | h [element] |
 | semantics.rb:395:10:395:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:395:10:395:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:397:5:397:5 | x [element 1] | semmle.label | x [element 1] |
-| semantics.rb:397:5:397:5 | x [element 1] | semmle.label | x [element 1] |
-| semantics.rb:397:9:397:14 | call to s46 [element 1] | semmle.label | call to s46 [element 1] |
-| semantics.rb:397:9:397:14 | call to s46 [element 1] | semmle.label | call to s46 [element 1] |
-| semantics.rb:397:13:397:13 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:397:13:397:13 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:400:10:400:10 | x [element 1] | semmle.label | x [element 1] |
-| semantics.rb:400:10:400:10 | x [element 1] | semmle.label | x [element 1] |
-| semantics.rb:400:10:400:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:400:10:400:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:396:10:396:10 | h [element 0] | semmle.label | h [element 0] |
+| semantics.rb:396:10:396:10 | h [element 0] | semmle.label | h [element 0] |
+| semantics.rb:396:10:396:10 | h [element 1] | semmle.label | h [element 1] |
+| semantics.rb:396:10:396:10 | h [element 1] | semmle.label | h [element 1] |
+| semantics.rb:396:10:396:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:396:10:396:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:396:10:396:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:396:10:396:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:398:5:398:5 | x [element 1] | semmle.label | x [element 1] |
+| semantics.rb:398:5:398:5 | x [element 1] | semmle.label | x [element 1] |
+| semantics.rb:398:9:398:14 | call to s46 [element 1] | semmle.label | call to s46 [element 1] |
+| semantics.rb:398:9:398:14 | call to s46 [element 1] | semmle.label | call to s46 [element 1] |
+| semantics.rb:398:13:398:13 | h [element 1] | semmle.label | h [element 1] |
+| semantics.rb:398:13:398:13 | h [element 1] | semmle.label | h [element 1] |
 | semantics.rb:401:10:401:10 | x [element 1] | semmle.label | x [element 1] |
 | semantics.rb:401:10:401:10 | x [element 1] | semmle.label | x [element 1] |
 | semantics.rb:401:10:401:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:401:10:401:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:405:5:405:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:405:5:405:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:405:15:405:25 | call to source | semmle.label | call to source |
-| semantics.rb:405:15:405:25 | call to source | semmle.label | call to source |
-| semantics.rb:406:5:406:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:406:5:406:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
+| semantics.rb:402:10:402:10 | x [element 1] | semmle.label | x [element 1] |
+| semantics.rb:402:10:402:10 | x [element 1] | semmle.label | x [element 1] |
+| semantics.rb:402:10:402:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:402:10:402:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:406:5:406:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
 | semantics.rb:406:5:406:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:406:5:406:5 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:406:5:406:5 | h [element :foo] | semmle.label | h [element :foo] |
 | semantics.rb:406:15:406:25 | call to source | semmle.label | call to source |
 | semantics.rb:406:15:406:25 | call to source | semmle.label | call to source |
-| semantics.rb:407:5:407:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:407:5:407:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:407:12:407:22 | call to source | semmle.label | call to source |
-| semantics.rb:407:12:407:22 | call to source | semmle.label | call to source |
-| semantics.rb:409:10:409:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:409:10:409:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:409:10:409:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:409:10:409:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:409:10:409:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:409:10:409:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:410:10:410:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:410:10:410:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:407:5:407:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
+| semantics.rb:407:5:407:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
+| semantics.rb:407:5:407:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:407:5:407:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:407:5:407:5 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:407:5:407:5 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:407:15:407:25 | call to source | semmle.label | call to source |
+| semantics.rb:407:15:407:25 | call to source | semmle.label | call to source |
+| semantics.rb:408:5:408:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:408:5:408:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:408:12:408:22 | call to source | semmle.label | call to source |
+| semantics.rb:408:12:408:22 | call to source | semmle.label | call to source |
+| semantics.rb:410:10:410:10 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:410:10:410:10 | h [element :foo] | semmle.label | h [element :foo] |
 | semantics.rb:410:10:410:10 | h [element] | semmle.label | h [element] |
 | semantics.rb:410:10:410:10 | h [element] | semmle.label | h [element] |
 | semantics.rb:410:10:410:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:410:10:410:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:412:5:412:5 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:412:5:412:5 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:412:9:412:14 | call to s47 [element :bar] | semmle.label | call to s47 [element :bar] |
-| semantics.rb:412:9:412:14 | call to s47 [element :bar] | semmle.label | call to s47 [element :bar] |
-| semantics.rb:412:13:412:13 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:412:13:412:13 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:415:10:415:10 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:415:10:415:10 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:415:10:415:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:415:10:415:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:419:5:419:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:419:5:419:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:419:15:419:25 | call to source | semmle.label | call to source |
-| semantics.rb:419:15:419:25 | call to source | semmle.label | call to source |
-| semantics.rb:420:5:420:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:420:5:420:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
+| semantics.rb:411:10:411:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:411:10:411:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:411:10:411:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:411:10:411:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:411:10:411:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:411:10:411:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:413:5:413:5 | x [element :bar] | semmle.label | x [element :bar] |
+| semantics.rb:413:5:413:5 | x [element :bar] | semmle.label | x [element :bar] |
+| semantics.rb:413:9:413:14 | call to s47 [element :bar] | semmle.label | call to s47 [element :bar] |
+| semantics.rb:413:9:413:14 | call to s47 [element :bar] | semmle.label | call to s47 [element :bar] |
+| semantics.rb:413:13:413:13 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:413:13:413:13 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:416:10:416:10 | x [element :bar] | semmle.label | x [element :bar] |
+| semantics.rb:416:10:416:10 | x [element :bar] | semmle.label | x [element :bar] |
+| semantics.rb:416:10:416:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:416:10:416:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:420:5:420:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
 | semantics.rb:420:5:420:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:420:5:420:5 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:420:5:420:5 | h [element :foo] | semmle.label | h [element :foo] |
 | semantics.rb:420:15:420:25 | call to source | semmle.label | call to source |
 | semantics.rb:420:15:420:25 | call to source | semmle.label | call to source |
-| semantics.rb:421:5:421:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:421:5:421:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:421:12:421:22 | call to source | semmle.label | call to source |
-| semantics.rb:421:12:421:22 | call to source | semmle.label | call to source |
-| semantics.rb:423:10:423:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:423:10:423:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:423:10:423:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:423:10:423:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:423:10:423:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:423:10:423:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:424:10:424:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:424:10:424:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:421:5:421:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
+| semantics.rb:421:5:421:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
+| semantics.rb:421:5:421:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:421:5:421:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:421:5:421:5 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:421:5:421:5 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:421:15:421:25 | call to source | semmle.label | call to source |
+| semantics.rb:421:15:421:25 | call to source | semmle.label | call to source |
+| semantics.rb:422:5:422:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:422:5:422:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:422:12:422:22 | call to source | semmle.label | call to source |
+| semantics.rb:422:12:422:22 | call to source | semmle.label | call to source |
+| semantics.rb:424:10:424:10 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:424:10:424:10 | h [element :foo] | semmle.label | h [element :foo] |
 | semantics.rb:424:10:424:10 | h [element] | semmle.label | h [element] |
 | semantics.rb:424:10:424:10 | h [element] | semmle.label | h [element] |
 | semantics.rb:424:10:424:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:424:10:424:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:426:5:426:5 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:426:5:426:5 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:426:9:426:14 | call to s48 [element :bar] | semmle.label | call to s48 [element :bar] |
-| semantics.rb:426:9:426:14 | call to s48 [element :bar] | semmle.label | call to s48 [element :bar] |
-| semantics.rb:426:13:426:13 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:426:13:426:13 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:429:10:429:10 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:429:10:429:10 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:429:10:429:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:429:10:429:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:433:5:433:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:433:5:433:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:433:15:433:25 | call to source | semmle.label | call to source |
-| semantics.rb:433:15:433:25 | call to source | semmle.label | call to source |
-| semantics.rb:434:5:434:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:434:5:434:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
+| semantics.rb:425:10:425:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:425:10:425:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:425:10:425:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:425:10:425:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:425:10:425:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:425:10:425:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:427:5:427:5 | x [element :bar] | semmle.label | x [element :bar] |
+| semantics.rb:427:5:427:5 | x [element :bar] | semmle.label | x [element :bar] |
+| semantics.rb:427:9:427:14 | call to s48 [element :bar] | semmle.label | call to s48 [element :bar] |
+| semantics.rb:427:9:427:14 | call to s48 [element :bar] | semmle.label | call to s48 [element :bar] |
+| semantics.rb:427:13:427:13 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:427:13:427:13 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:430:10:430:10 | x [element :bar] | semmle.label | x [element :bar] |
+| semantics.rb:430:10:430:10 | x [element :bar] | semmle.label | x [element :bar] |
+| semantics.rb:430:10:430:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:430:10:430:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:434:5:434:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
 | semantics.rb:434:5:434:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:434:5:434:5 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:434:5:434:5 | h [element :foo] | semmle.label | h [element :foo] |
 | semantics.rb:434:15:434:25 | call to source | semmle.label | call to source |
 | semantics.rb:434:15:434:25 | call to source | semmle.label | call to source |
-| semantics.rb:435:5:435:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:435:5:435:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:435:12:435:22 | call to source | semmle.label | call to source |
-| semantics.rb:435:12:435:22 | call to source | semmle.label | call to source |
-| semantics.rb:437:10:437:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:437:10:437:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:437:10:437:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:437:10:437:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:437:10:437:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:437:10:437:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:438:10:438:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:438:10:438:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:435:5:435:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
+| semantics.rb:435:5:435:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
+| semantics.rb:435:5:435:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:435:5:435:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:435:5:435:5 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:435:5:435:5 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:435:15:435:25 | call to source | semmle.label | call to source |
+| semantics.rb:435:15:435:25 | call to source | semmle.label | call to source |
+| semantics.rb:436:5:436:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:436:5:436:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:436:12:436:22 | call to source | semmle.label | call to source |
+| semantics.rb:436:12:436:22 | call to source | semmle.label | call to source |
+| semantics.rb:438:10:438:10 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:438:10:438:10 | h [element :foo] | semmle.label | h [element :foo] |
 | semantics.rb:438:10:438:10 | h [element] | semmle.label | h [element] |
 | semantics.rb:438:10:438:10 | h [element] | semmle.label | h [element] |
 | semantics.rb:438:10:438:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:438:10:438:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:440:5:440:5 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:440:5:440:5 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:440:5:440:5 | x [element] | semmle.label | x [element] |
-| semantics.rb:440:5:440:5 | x [element] | semmle.label | x [element] |
-| semantics.rb:440:9:440:14 | call to s49 [element :bar] | semmle.label | call to s49 [element :bar] |
-| semantics.rb:440:9:440:14 | call to s49 [element :bar] | semmle.label | call to s49 [element :bar] |
-| semantics.rb:440:9:440:14 | call to s49 [element] | semmle.label | call to s49 [element] |
-| semantics.rb:440:9:440:14 | call to s49 [element] | semmle.label | call to s49 [element] |
-| semantics.rb:440:13:440:13 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:440:13:440:13 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:440:13:440:13 | h [element] | semmle.label | h [element] |
-| semantics.rb:440:13:440:13 | h [element] | semmle.label | h [element] |
-| semantics.rb:442:10:442:10 | x [element] | semmle.label | x [element] |
-| semantics.rb:442:10:442:10 | x [element] | semmle.label | x [element] |
-| semantics.rb:442:10:442:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:442:10:442:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:443:10:443:10 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:443:10:443:10 | x [element :bar] | semmle.label | x [element :bar] |
+| semantics.rb:439:10:439:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:439:10:439:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:439:10:439:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:439:10:439:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:439:10:439:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:439:10:439:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:441:5:441:5 | x [element :bar] | semmle.label | x [element :bar] |
+| semantics.rb:441:5:441:5 | x [element :bar] | semmle.label | x [element :bar] |
+| semantics.rb:441:5:441:5 | x [element] | semmle.label | x [element] |
+| semantics.rb:441:5:441:5 | x [element] | semmle.label | x [element] |
+| semantics.rb:441:9:441:14 | call to s49 [element :bar] | semmle.label | call to s49 [element :bar] |
+| semantics.rb:441:9:441:14 | call to s49 [element :bar] | semmle.label | call to s49 [element :bar] |
+| semantics.rb:441:9:441:14 | call to s49 [element] | semmle.label | call to s49 [element] |
+| semantics.rb:441:9:441:14 | call to s49 [element] | semmle.label | call to s49 [element] |
+| semantics.rb:441:13:441:13 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:441:13:441:13 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:441:13:441:13 | h [element] | semmle.label | h [element] |
+| semantics.rb:441:13:441:13 | h [element] | semmle.label | h [element] |
 | semantics.rb:443:10:443:10 | x [element] | semmle.label | x [element] |
 | semantics.rb:443:10:443:10 | x [element] | semmle.label | x [element] |
 | semantics.rb:443:10:443:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:443:10:443:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:447:5:447:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:447:5:447:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:447:15:447:25 | call to source | semmle.label | call to source |
-| semantics.rb:447:15:447:25 | call to source | semmle.label | call to source |
-| semantics.rb:448:5:448:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:448:5:448:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
+| semantics.rb:444:10:444:10 | x [element :bar] | semmle.label | x [element :bar] |
+| semantics.rb:444:10:444:10 | x [element :bar] | semmle.label | x [element :bar] |
+| semantics.rb:444:10:444:10 | x [element] | semmle.label | x [element] |
+| semantics.rb:444:10:444:10 | x [element] | semmle.label | x [element] |
+| semantics.rb:444:10:444:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:444:10:444:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:448:5:448:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
 | semantics.rb:448:5:448:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:448:5:448:5 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:448:5:448:5 | h [element :foo] | semmle.label | h [element :foo] |
 | semantics.rb:448:15:448:25 | call to source | semmle.label | call to source |
 | semantics.rb:448:15:448:25 | call to source | semmle.label | call to source |
-| semantics.rb:449:5:449:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:449:5:449:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:449:12:449:22 | call to source | semmle.label | call to source |
-| semantics.rb:449:12:449:22 | call to source | semmle.label | call to source |
-| semantics.rb:451:10:451:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:451:10:451:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:451:10:451:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:451:10:451:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:451:10:451:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:451:10:451:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:452:10:452:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:452:10:452:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:449:5:449:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
+| semantics.rb:449:5:449:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
+| semantics.rb:449:5:449:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:449:5:449:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:449:5:449:5 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:449:5:449:5 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:449:15:449:25 | call to source | semmle.label | call to source |
+| semantics.rb:449:15:449:25 | call to source | semmle.label | call to source |
+| semantics.rb:450:5:450:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:450:5:450:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:450:12:450:22 | call to source | semmle.label | call to source |
+| semantics.rb:450:12:450:22 | call to source | semmle.label | call to source |
+| semantics.rb:452:10:452:10 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:452:10:452:10 | h [element :foo] | semmle.label | h [element :foo] |
 | semantics.rb:452:10:452:10 | h [element] | semmle.label | h [element] |
 | semantics.rb:452:10:452:10 | h [element] | semmle.label | h [element] |
 | semantics.rb:452:10:452:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:452:10:452:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:454:9:454:9 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:454:9:454:9 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:454:9:454:9 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:454:9:454:9 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:457:10:457:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:457:10:457:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:457:10:457:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:457:10:457:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:461:5:461:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:461:5:461:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:461:15:461:25 | call to source | semmle.label | call to source |
-| semantics.rb:461:15:461:25 | call to source | semmle.label | call to source |
-| semantics.rb:462:5:462:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:462:5:462:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
+| semantics.rb:453:10:453:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:453:10:453:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:453:10:453:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:453:10:453:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:453:10:453:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:453:10:453:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:455:9:455:9 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
+| semantics.rb:455:9:455:9 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
+| semantics.rb:455:9:455:9 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:455:9:455:9 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:458:10:458:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:458:10:458:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:458:10:458:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:458:10:458:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:462:5:462:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
 | semantics.rb:462:5:462:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:462:5:462:5 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:462:5:462:5 | h [element :foo] | semmle.label | h [element :foo] |
 | semantics.rb:462:15:462:25 | call to source | semmle.label | call to source |
 | semantics.rb:462:15:462:25 | call to source | semmle.label | call to source |
-| semantics.rb:463:5:463:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:463:5:463:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:463:12:463:22 | call to source | semmle.label | call to source |
-| semantics.rb:463:12:463:22 | call to source | semmle.label | call to source |
-| semantics.rb:465:10:465:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:465:10:465:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:465:10:465:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:465:10:465:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:465:10:465:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:465:10:465:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:466:10:466:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:466:10:466:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:463:5:463:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
+| semantics.rb:463:5:463:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
+| semantics.rb:463:5:463:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:463:5:463:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:463:5:463:5 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:463:5:463:5 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:463:15:463:25 | call to source | semmle.label | call to source |
+| semantics.rb:463:15:463:25 | call to source | semmle.label | call to source |
+| semantics.rb:464:5:464:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:464:5:464:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:464:12:464:22 | call to source | semmle.label | call to source |
+| semantics.rb:464:12:464:22 | call to source | semmle.label | call to source |
+| semantics.rb:466:10:466:10 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:466:10:466:10 | h [element :foo] | semmle.label | h [element :foo] |
 | semantics.rb:466:10:466:10 | h [element] | semmle.label | h [element] |
 | semantics.rb:466:10:466:10 | h [element] | semmle.label | h [element] |
 | semantics.rb:466:10:466:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:466:10:466:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:468:9:468:9 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:468:9:468:9 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:468:9:468:9 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:468:9:468:9 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:468:9:468:9 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:468:9:468:9 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:468:9:468:9 | h [element] | semmle.label | h [element] |
-| semantics.rb:468:9:468:9 | h [element] | semmle.label | h [element] |
-| semantics.rb:470:10:470:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:470:10:470:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:470:10:470:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:470:10:470:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:471:10:471:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:471:10:471:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:467:10:467:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:467:10:467:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:467:10:467:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:467:10:467:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:467:10:467:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:467:10:467:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:469:9:469:9 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
+| semantics.rb:469:9:469:9 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
+| semantics.rb:469:9:469:9 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:469:9:469:9 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:469:9:469:9 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:469:9:469:9 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:469:9:469:9 | h [element] | semmle.label | h [element] |
+| semantics.rb:469:9:469:9 | h [element] | semmle.label | h [element] |
 | semantics.rb:471:10:471:10 | h [element] | semmle.label | h [element] |
 | semantics.rb:471:10:471:10 | h [element] | semmle.label | h [element] |
 | semantics.rb:471:10:471:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:471:10:471:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:475:5:475:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:475:5:475:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:475:15:475:25 | call to source | semmle.label | call to source |
-| semantics.rb:475:15:475:25 | call to source | semmle.label | call to source |
-| semantics.rb:476:5:476:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:476:5:476:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
+| semantics.rb:472:10:472:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:472:10:472:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:472:10:472:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:472:10:472:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:472:10:472:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:472:10:472:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:476:5:476:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
 | semantics.rb:476:5:476:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:476:5:476:5 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:476:5:476:5 | h [element :foo] | semmle.label | h [element :foo] |
 | semantics.rb:476:15:476:25 | call to source | semmle.label | call to source |
 | semantics.rb:476:15:476:25 | call to source | semmle.label | call to source |
-| semantics.rb:477:5:477:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:477:5:477:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:477:12:477:22 | call to source | semmle.label | call to source |
-| semantics.rb:477:12:477:22 | call to source | semmle.label | call to source |
-| semantics.rb:479:10:479:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:479:10:479:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:479:10:479:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:479:10:479:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:479:10:479:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:479:10:479:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:480:10:480:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:480:10:480:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:477:5:477:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
+| semantics.rb:477:5:477:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
+| semantics.rb:477:5:477:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:477:5:477:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:477:5:477:5 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:477:5:477:5 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:477:15:477:25 | call to source | semmle.label | call to source |
+| semantics.rb:477:15:477:25 | call to source | semmle.label | call to source |
+| semantics.rb:478:5:478:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:478:5:478:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:478:12:478:22 | call to source | semmle.label | call to source |
+| semantics.rb:478:12:478:22 | call to source | semmle.label | call to source |
+| semantics.rb:480:10:480:10 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:480:10:480:10 | h [element :foo] | semmle.label | h [element :foo] |
 | semantics.rb:480:10:480:10 | h [element] | semmle.label | h [element] |
 | semantics.rb:480:10:480:10 | h [element] | semmle.label | h [element] |
 | semantics.rb:480:10:480:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:480:10:480:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:482:5:482:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:482:5:482:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:482:5:482:5 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:482:5:482:5 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:485:10:485:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:485:10:485:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:485:10:485:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:485:10:485:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:489:5:489:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:489:5:489:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:489:15:489:25 | call to source | semmle.label | call to source |
-| semantics.rb:489:15:489:25 | call to source | semmle.label | call to source |
-| semantics.rb:490:5:490:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:490:5:490:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
+| semantics.rb:481:10:481:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:481:10:481:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:481:10:481:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:481:10:481:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:481:10:481:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:481:10:481:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:483:5:483:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
+| semantics.rb:483:5:483:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
+| semantics.rb:483:5:483:5 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:483:5:483:5 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:486:10:486:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:486:10:486:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:486:10:486:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:486:10:486:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:490:5:490:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
 | semantics.rb:490:5:490:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:490:5:490:5 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:490:5:490:5 | h [element :foo] | semmle.label | h [element :foo] |
 | semantics.rb:490:15:490:25 | call to source | semmle.label | call to source |
 | semantics.rb:490:15:490:25 | call to source | semmle.label | call to source |
-| semantics.rb:491:5:491:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:491:5:491:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:491:12:491:22 | call to source | semmle.label | call to source |
-| semantics.rb:491:12:491:22 | call to source | semmle.label | call to source |
-| semantics.rb:493:10:493:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:493:10:493:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:493:10:493:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:493:10:493:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:493:10:493:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:493:10:493:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:494:10:494:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:494:10:494:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:491:5:491:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
+| semantics.rb:491:5:491:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
+| semantics.rb:491:5:491:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:491:5:491:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:491:5:491:5 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:491:5:491:5 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:491:15:491:25 | call to source | semmle.label | call to source |
+| semantics.rb:491:15:491:25 | call to source | semmle.label | call to source |
+| semantics.rb:492:5:492:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:492:5:492:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:492:12:492:22 | call to source | semmle.label | call to source |
+| semantics.rb:492:12:492:22 | call to source | semmle.label | call to source |
+| semantics.rb:494:10:494:10 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:494:10:494:10 | h [element :foo] | semmle.label | h [element :foo] |
 | semantics.rb:494:10:494:10 | h [element] | semmle.label | h [element] |
 | semantics.rb:494:10:494:10 | h [element] | semmle.label | h [element] |
 | semantics.rb:494:10:494:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:494:10:494:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:496:5:496:5 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:496:5:496:5 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:496:9:496:9 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:496:9:496:9 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:496:9:496:15 | call to s53 [element :bar] | semmle.label | call to s53 [element :bar] |
-| semantics.rb:496:9:496:15 | call to s53 [element :bar] | semmle.label | call to s53 [element :bar] |
-| semantics.rb:499:10:499:10 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:499:10:499:10 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:499:10:499:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:499:10:499:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:501:10:501:20 | call to source | semmle.label | call to source |
-| semantics.rb:501:10:501:20 | call to source | semmle.label | call to source |
-| semantics.rb:501:10:501:26 | call to s53 | semmle.label | call to s53 |
-| semantics.rb:501:10:501:26 | call to s53 | semmle.label | call to s53 |
-| semantics.rb:505:5:505:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:505:5:505:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:505:15:505:25 | call to source | semmle.label | call to source |
-| semantics.rb:505:15:505:25 | call to source | semmle.label | call to source |
-| semantics.rb:506:5:506:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:506:5:506:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
+| semantics.rb:495:10:495:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:495:10:495:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:495:10:495:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:495:10:495:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:495:10:495:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:495:10:495:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:497:5:497:5 | x [element :bar] | semmle.label | x [element :bar] |
+| semantics.rb:497:5:497:5 | x [element :bar] | semmle.label | x [element :bar] |
+| semantics.rb:497:9:497:9 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:497:9:497:9 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:497:9:497:15 | call to s53 [element :bar] | semmle.label | call to s53 [element :bar] |
+| semantics.rb:497:9:497:15 | call to s53 [element :bar] | semmle.label | call to s53 [element :bar] |
+| semantics.rb:500:10:500:10 | x [element :bar] | semmle.label | x [element :bar] |
+| semantics.rb:500:10:500:10 | x [element :bar] | semmle.label | x [element :bar] |
+| semantics.rb:500:10:500:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:500:10:500:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:502:10:502:20 | call to source | semmle.label | call to source |
+| semantics.rb:502:10:502:20 | call to source | semmle.label | call to source |
+| semantics.rb:502:10:502:26 | call to s53 | semmle.label | call to s53 |
+| semantics.rb:502:10:502:26 | call to s53 | semmle.label | call to s53 |
 | semantics.rb:506:5:506:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
 | semantics.rb:506:5:506:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:506:5:506:5 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:506:5:506:5 | h [element :foo] | semmle.label | h [element :foo] |
 | semantics.rb:506:15:506:25 | call to source | semmle.label | call to source |
 | semantics.rb:506:15:506:25 | call to source | semmle.label | call to source |
-| semantics.rb:507:5:507:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:507:5:507:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:507:12:507:22 | call to source | semmle.label | call to source |
-| semantics.rb:507:12:507:22 | call to source | semmle.label | call to source |
-| semantics.rb:509:10:509:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:509:10:509:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:509:10:509:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:509:10:509:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:509:10:509:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:509:10:509:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:510:10:510:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:510:10:510:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:507:5:507:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
+| semantics.rb:507:5:507:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
+| semantics.rb:507:5:507:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:507:5:507:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:507:5:507:5 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:507:5:507:5 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:507:15:507:25 | call to source | semmle.label | call to source |
+| semantics.rb:507:15:507:25 | call to source | semmle.label | call to source |
+| semantics.rb:508:5:508:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:508:5:508:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:508:12:508:22 | call to source | semmle.label | call to source |
+| semantics.rb:508:12:508:22 | call to source | semmle.label | call to source |
+| semantics.rb:510:10:510:10 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:510:10:510:10 | h [element :foo] | semmle.label | h [element :foo] |
 | semantics.rb:510:10:510:10 | h [element] | semmle.label | h [element] |
 | semantics.rb:510:10:510:10 | h [element] | semmle.label | h [element] |
 | semantics.rb:510:10:510:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:510:10:510:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:512:5:512:5 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:512:5:512:5 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:512:9:512:9 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:512:9:512:9 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:512:9:512:15 | call to s54 [element :bar] | semmle.label | call to s54 [element :bar] |
-| semantics.rb:512:9:512:15 | call to s54 [element :bar] | semmle.label | call to s54 [element :bar] |
-| semantics.rb:515:10:515:10 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:515:10:515:10 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:515:10:515:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:515:10:515:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:511:10:511:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:511:10:511:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:511:10:511:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:511:10:511:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:511:10:511:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:511:10:511:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:513:5:513:5 | x [element :bar] | semmle.label | x [element :bar] |
+| semantics.rb:513:5:513:5 | x [element :bar] | semmle.label | x [element :bar] |
+| semantics.rb:513:9:513:9 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:513:9:513:9 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:513:9:513:15 | call to s54 [element :bar] | semmle.label | call to s54 [element :bar] |
+| semantics.rb:513:9:513:15 | call to s54 [element :bar] | semmle.label | call to s54 [element :bar] |
+| semantics.rb:516:10:516:10 | x [element :bar] | semmle.label | x [element :bar] |
+| semantics.rb:516:10:516:10 | x [element :bar] | semmle.label | x [element :bar] |
+| semantics.rb:516:10:516:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:516:10:516:16 | ...[...] | semmle.label | ...[...] |
 subpaths

--- a/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.ql
+++ b/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.ql
@@ -203,24 +203,24 @@ private class S16 extends Summary {
 }
 
 /**
- * `Argument[hash-splat]` (output) 1
+ * `Argument[splat]` (input) 1
  */
 private class S17 extends Summary {
   S17() { this = "s17" }
 
   override predicate propagates(string input, string output) {
-    input = "Argument[0]" and output = "Argument[hash-splat]"
+    input = "Argument[splat]" and output = "ReturnValue"
   }
 }
 
 /**
- * `Argument[hash-splat]` (output) 2
+ * `Argument[splat]` (input) 2
  */
 private class S18 extends Summary {
   S18() { this = "s18" }
 
   override predicate propagates(string input, string output) {
-    input = "Argument[0]" and output = "Argument[hash-splat].Element[:foo]"
+    input = "Argument[splat].Element[any]" and output = "ReturnValue"
   }
 }
 

--- a/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.rb
+++ b/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.rb
@@ -103,11 +103,11 @@ def m14(w, x, y, z)
     sink z # $ hasValueFlow=a
 end
 
-def  m15
+def m15
     a = source "a"
     b = source "b"
-    sink s15(**a) # $ SPURIOUS: hasTaintFlow=a MISSING: hasValueFlow=a
-    sink s15(0, 1, foo: b, **a) # $ SPURIOUS: hasTaintFlow=a MISSING: hasValueFlow=a
+    sink s15(foo: a, bar: b)[:foo] # $ hasValueFlow=a
+    sink s15(foo: a, bar: b)[:bar] # $ hasValueFlow=b
 end
 
 def m16
@@ -121,19 +121,20 @@ def m16
     sink s16(b: b, **h) # $ hasValueFlow=a hasValueFlow=b
 end
 
-def m17(h, x)
+def m17
     a = source "a"
-    s17(a, **h, foo: x)
-    sink h # $ hasValueFlow=a
-    sink x
+    b = source "b"
+    sink s17(a, b) # $ hasTaintFlow=a $ hasTaintFlow=b
+    sink s17(a, b)[0] # $ hasValueFlow=a
+    sink s17(a, b)[1] # $ hasValueFlow=b
 end
 
-def m18(x)
+def m18
     a = source "a"
-    s18(a, **h, foo: x)
-    sink h
-    sink h[:foo] # $ MISSING: hasValueFlow=a
-    sink x # $ MISSING: hasValueFlow=a
+    b = source "b"
+    arr = [a, b]
+    sink s18(*arr) # $ hasValueFlow=a $ hasValueFlow=b
+    sink s18(a) # $ hasValueFlow=a
 end
 
 def m19(i)

--- a/ruby/ql/test/library-tests/dataflow/hash-flow/hash-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/hash-flow/hash-flow.expected
@@ -42,10 +42,10 @@ edges
 | hash_flow.rb:44:10:44:13 | hash [element 0] | hash_flow.rb:44:10:44:16 | ...[...] |
 | hash_flow.rb:46:10:46:13 | hash [element :a] | hash_flow.rb:46:10:46:17 | ...[...] |
 | hash_flow.rb:48:10:48:13 | hash [element a] | hash_flow.rb:48:10:48:18 | ...[...] |
-| hash_flow.rb:55:5:55:9 | hash1 [element :a] | hash_flow.rb:56:10:56:14 | hash1 [element :a] |
-| hash_flow.rb:55:13:55:37 | ...[...] [element :a] | hash_flow.rb:55:5:55:9 | hash1 [element :a] |
-| hash_flow.rb:55:21:55:30 | call to taint | hash_flow.rb:55:13:55:37 | ...[...] [element :a] |
-| hash_flow.rb:56:10:56:14 | hash1 [element :a] | hash_flow.rb:56:10:56:18 | ...[...] |
+| hash_flow.rb:55:5:55:9 | hash1 [hash-splat position :a] | hash_flow.rb:56:10:56:14 | hash1 [hash-splat position :a] |
+| hash_flow.rb:55:13:55:37 | ...[...] [hash-splat position :a] | hash_flow.rb:55:5:55:9 | hash1 [hash-splat position :a] |
+| hash_flow.rb:55:21:55:30 | call to taint | hash_flow.rb:55:13:55:37 | ...[...] [hash-splat position :a] |
+| hash_flow.rb:56:10:56:14 | hash1 [hash-splat position :a] | hash_flow.rb:56:10:56:18 | ...[...] |
 | hash_flow.rb:59:5:59:5 | x [element :a] | hash_flow.rb:60:18:60:18 | x [element :a] |
 | hash_flow.rb:59:13:59:22 | call to taint | hash_flow.rb:59:5:59:5 | x [element :a] |
 | hash_flow.rb:60:5:60:9 | hash2 [element :a] | hash_flow.rb:61:10:61:14 | hash2 [element :a] |
@@ -62,10 +62,10 @@ edges
 | hash_flow.rb:68:13:68:39 | ...[...] [element :a] | hash_flow.rb:68:5:68:9 | hash4 [element :a] |
 | hash_flow.rb:68:22:68:31 | call to taint | hash_flow.rb:68:13:68:39 | ...[...] [element :a] |
 | hash_flow.rb:69:10:69:14 | hash4 [element :a] | hash_flow.rb:69:10:69:18 | ...[...] |
-| hash_flow.rb:72:5:72:9 | hash5 [element a] | hash_flow.rb:73:10:73:14 | hash5 [element a] |
-| hash_flow.rb:72:13:72:45 | ...[...] [element a] | hash_flow.rb:72:5:72:9 | hash5 [element a] |
-| hash_flow.rb:72:25:72:34 | call to taint | hash_flow.rb:72:13:72:45 | ...[...] [element a] |
-| hash_flow.rb:73:10:73:14 | hash5 [element a] | hash_flow.rb:73:10:73:19 | ...[...] |
+| hash_flow.rb:72:5:72:9 | hash5 [hash-splat position a] | hash_flow.rb:73:10:73:14 | hash5 [hash-splat position a] |
+| hash_flow.rb:72:13:72:45 | ...[...] [hash-splat position a] | hash_flow.rb:72:5:72:9 | hash5 [hash-splat position a] |
+| hash_flow.rb:72:25:72:34 | call to taint | hash_flow.rb:72:13:72:45 | ...[...] [hash-splat position a] |
+| hash_flow.rb:73:10:73:14 | hash5 [hash-splat position a] | hash_flow.rb:73:10:73:19 | ...[...] |
 | hash_flow.rb:76:5:76:9 | hash6 [element a] | hash_flow.rb:77:10:77:14 | hash6 [element a] |
 | hash_flow.rb:76:13:76:47 | ...[...] [element a] | hash_flow.rb:76:5:76:9 | hash6 [element a] |
 | hash_flow.rb:76:26:76:35 | call to taint | hash_flow.rb:76:13:76:47 | ...[...] [element a] |
@@ -1015,10 +1015,10 @@ nodes
 | hash_flow.rb:46:10:46:17 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:48:10:48:13 | hash [element a] | semmle.label | hash [element a] |
 | hash_flow.rb:48:10:48:18 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:55:5:55:9 | hash1 [element :a] | semmle.label | hash1 [element :a] |
-| hash_flow.rb:55:13:55:37 | ...[...] [element :a] | semmle.label | ...[...] [element :a] |
+| hash_flow.rb:55:5:55:9 | hash1 [hash-splat position :a] | semmle.label | hash1 [hash-splat position :a] |
+| hash_flow.rb:55:13:55:37 | ...[...] [hash-splat position :a] | semmle.label | ...[...] [hash-splat position :a] |
 | hash_flow.rb:55:21:55:30 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:56:10:56:14 | hash1 [element :a] | semmle.label | hash1 [element :a] |
+| hash_flow.rb:56:10:56:14 | hash1 [hash-splat position :a] | semmle.label | hash1 [hash-splat position :a] |
 | hash_flow.rb:56:10:56:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:59:5:59:5 | x [element :a] | semmle.label | x [element :a] |
 | hash_flow.rb:59:13:59:22 | call to taint | semmle.label | call to taint |
@@ -1039,10 +1039,10 @@ nodes
 | hash_flow.rb:68:22:68:31 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:69:10:69:14 | hash4 [element :a] | semmle.label | hash4 [element :a] |
 | hash_flow.rb:69:10:69:18 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:72:5:72:9 | hash5 [element a] | semmle.label | hash5 [element a] |
-| hash_flow.rb:72:13:72:45 | ...[...] [element a] | semmle.label | ...[...] [element a] |
+| hash_flow.rb:72:5:72:9 | hash5 [hash-splat position a] | semmle.label | hash5 [hash-splat position a] |
+| hash_flow.rb:72:13:72:45 | ...[...] [hash-splat position a] | semmle.label | ...[...] [hash-splat position a] |
 | hash_flow.rb:72:25:72:34 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:73:10:73:14 | hash5 [element a] | semmle.label | hash5 [element a] |
+| hash_flow.rb:73:10:73:14 | hash5 [hash-splat position a] | semmle.label | hash5 [hash-splat position a] |
 | hash_flow.rb:73:10:73:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:76:5:76:9 | hash6 [element a] | semmle.label | hash6 [element a] |
 | hash_flow.rb:76:13:76:47 | ...[...] [element a] | semmle.label | ...[...] [element a] |

--- a/ruby/ql/test/library-tests/dataflow/hash-flow/type-tracking-hash-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/hash-flow/type-tracking-hash-flow.expected
@@ -1,4 +1,3 @@
-failures
 testFailures
 | hash_flow.rb:65:21:65:40 | # $ hasValueFlow=3.3 | Missing result:hasValueFlow=3.3 |
 | hash_flow.rb:66:21:66:49 | # $ SPURIOUS hasValueFlow=3.3 | Missing result:hasValueFlow=3.3 |
@@ -39,3 +38,4 @@ testFailures
 | hash_flow.rb:935:22:935:42 | # $ hasValueFlow=51.4 | Missing result:hasValueFlow=51.4 |
 | hash_flow.rb:963:22:963:42 | # $ hasValueFlow=52.3 | Missing result:hasValueFlow=52.3 |
 | hash_flow.rb:965:22:965:42 | # $ hasValueFlow=52.4 | Missing result:hasValueFlow=52.4 |
+failures

--- a/ruby/ql/test/library-tests/dataflow/local/DataflowStep.expected
+++ b/ruby/ql/test/library-tests/dataflow/local/DataflowStep.expected
@@ -2425,6 +2425,7 @@
 | local_dataflow.rb:9:1:9:5 | array | local_dataflow.rb:10:14:10:18 | array |
 | local_dataflow.rb:9:9:9:15 | call to [] | local_dataflow.rb:9:1:9:5 | array |
 | local_dataflow.rb:9:9:9:15 | call to [] | local_dataflow.rb:9:1:9:15 | ... = ... |
+| local_dataflow.rb:9:9:9:15 | synthetic splat argument | local_dataflow.rb:9:9:9:15 | call to [] |
 | local_dataflow.rb:10:5:13:3 | ... | local_dataflow.rb:10:1:13:3 | ... = ... |
 | local_dataflow.rb:10:5:13:3 | <captured entry> self | local_dataflow.rb:11:1:11:2 | self |
 | local_dataflow.rb:10:5:13:3 | <captured exit> x | local_dataflow.rb:15:5:15:5 | x |
@@ -2487,6 +2488,7 @@
 | local_dataflow.rb:50:18:50:18 | [post] x | local_dataflow.rb:51:20:51:20 | x |
 | local_dataflow.rb:50:18:50:18 | x | local_dataflow.rb:51:20:51:20 | x |
 | local_dataflow.rb:51:9:51:15 | "break" | local_dataflow.rb:51:3:51:15 | break |
+| local_dataflow.rb:55:5:55:13 | synthetic splat argument | local_dataflow.rb:55:5:55:13 | call to [] |
 | local_dataflow.rb:60:1:90:3 | self (test_case) | local_dataflow.rb:78:12:78:20 | self |
 | local_dataflow.rb:60:1:90:3 | self in test_case | local_dataflow.rb:60:1:90:3 | self (test_case) |
 | local_dataflow.rb:60:15:60:15 | x | local_dataflow.rb:60:15:60:15 | x |
@@ -2545,6 +2547,7 @@
 | local_dataflow.rb:81:16:81:16 | e | local_dataflow.rb:84:12:84:12 | e |
 | local_dataflow.rb:81:20:84:33 | then ... | local_dataflow.rb:78:7:88:5 | case ... |
 | local_dataflow.rb:81:25:84:14 | call to [] | local_dataflow.rb:81:20:84:33 | then ... |
+| local_dataflow.rb:81:25:84:14 | synthetic splat argument | local_dataflow.rb:81:25:84:14 | call to [] |
 | local_dataflow.rb:82:7:82:13 | [post] self | local_dataflow.rb:83:7:83:13 | self |
 | local_dataflow.rb:82:7:82:13 | self | local_dataflow.rb:83:7:83:13 | self |
 | local_dataflow.rb:83:7:83:13 | [post] self | local_dataflow.rb:84:7:84:13 | self |

--- a/ruby/ql/test/library-tests/dataflow/local/Nodes.expected
+++ b/ruby/ql/test/library-tests/dataflow/local/Nodes.expected
@@ -24,1535 +24,1535 @@ ret
 | local_dataflow.rb:132:3:149:5 | if ... |
 arg
 | UseUseExplosion.rb:20:13:20:17 | @prop | UseUseExplosion.rb:20:13:20:23 | ... > ... | self |
-| UseUseExplosion.rb:20:13:20:23 | * | UseUseExplosion.rb:20:13:20:23 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:13:20:23 | synthetic splat argument | UseUseExplosion.rb:20:13:20:23 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:21:20:23 | 100 | UseUseExplosion.rb:20:13:20:23 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:35:20:39 | @prop | UseUseExplosion.rb:20:35:20:44 | ... > ... | self |
-| UseUseExplosion.rb:20:35:20:44 | * | UseUseExplosion.rb:20:35:20:44 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:35:20:44 | synthetic splat argument | UseUseExplosion.rb:20:35:20:44 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:43:20:44 | 99 | UseUseExplosion.rb:20:35:20:44 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:56:20:60 | @prop | UseUseExplosion.rb:20:56:20:65 | ... > ... | self |
-| UseUseExplosion.rb:20:56:20:65 | * | UseUseExplosion.rb:20:56:20:65 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:56:20:65 | synthetic splat argument | UseUseExplosion.rb:20:56:20:65 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:64:20:65 | 98 | UseUseExplosion.rb:20:56:20:65 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:77:20:81 | @prop | UseUseExplosion.rb:20:77:20:86 | ... > ... | self |
-| UseUseExplosion.rb:20:77:20:86 | * | UseUseExplosion.rb:20:77:20:86 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:77:20:86 | synthetic splat argument | UseUseExplosion.rb:20:77:20:86 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:85:20:86 | 97 | UseUseExplosion.rb:20:77:20:86 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:98:20:102 | @prop | UseUseExplosion.rb:20:98:20:107 | ... > ... | self |
-| UseUseExplosion.rb:20:98:20:107 | * | UseUseExplosion.rb:20:98:20:107 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:98:20:107 | synthetic splat argument | UseUseExplosion.rb:20:98:20:107 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:106:20:107 | 96 | UseUseExplosion.rb:20:98:20:107 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:119:20:123 | @prop | UseUseExplosion.rb:20:119:20:128 | ... > ... | self |
-| UseUseExplosion.rb:20:119:20:128 | * | UseUseExplosion.rb:20:119:20:128 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:119:20:128 | synthetic splat argument | UseUseExplosion.rb:20:119:20:128 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:127:20:128 | 95 | UseUseExplosion.rb:20:119:20:128 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:140:20:144 | @prop | UseUseExplosion.rb:20:140:20:149 | ... > ... | self |
-| UseUseExplosion.rb:20:140:20:149 | * | UseUseExplosion.rb:20:140:20:149 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:140:20:149 | synthetic splat argument | UseUseExplosion.rb:20:140:20:149 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:148:20:149 | 94 | UseUseExplosion.rb:20:140:20:149 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:161:20:165 | @prop | UseUseExplosion.rb:20:161:20:170 | ... > ... | self |
-| UseUseExplosion.rb:20:161:20:170 | * | UseUseExplosion.rb:20:161:20:170 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:161:20:170 | synthetic splat argument | UseUseExplosion.rb:20:161:20:170 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:169:20:170 | 93 | UseUseExplosion.rb:20:161:20:170 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:182:20:186 | @prop | UseUseExplosion.rb:20:182:20:191 | ... > ... | self |
-| UseUseExplosion.rb:20:182:20:191 | * | UseUseExplosion.rb:20:182:20:191 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:182:20:191 | synthetic splat argument | UseUseExplosion.rb:20:182:20:191 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:190:20:191 | 92 | UseUseExplosion.rb:20:182:20:191 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:203:20:207 | @prop | UseUseExplosion.rb:20:203:20:212 | ... > ... | self |
-| UseUseExplosion.rb:20:203:20:212 | * | UseUseExplosion.rb:20:203:20:212 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:203:20:212 | synthetic splat argument | UseUseExplosion.rb:20:203:20:212 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:211:20:212 | 91 | UseUseExplosion.rb:20:203:20:212 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:224:20:228 | @prop | UseUseExplosion.rb:20:224:20:233 | ... > ... | self |
-| UseUseExplosion.rb:20:224:20:233 | * | UseUseExplosion.rb:20:224:20:233 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:224:20:233 | synthetic splat argument | UseUseExplosion.rb:20:224:20:233 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:232:20:233 | 90 | UseUseExplosion.rb:20:224:20:233 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:245:20:249 | @prop | UseUseExplosion.rb:20:245:20:254 | ... > ... | self |
-| UseUseExplosion.rb:20:245:20:254 | * | UseUseExplosion.rb:20:245:20:254 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:245:20:254 | synthetic splat argument | UseUseExplosion.rb:20:245:20:254 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:253:20:254 | 89 | UseUseExplosion.rb:20:245:20:254 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:266:20:270 | @prop | UseUseExplosion.rb:20:266:20:275 | ... > ... | self |
-| UseUseExplosion.rb:20:266:20:275 | * | UseUseExplosion.rb:20:266:20:275 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:266:20:275 | synthetic splat argument | UseUseExplosion.rb:20:266:20:275 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:274:20:275 | 88 | UseUseExplosion.rb:20:266:20:275 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:287:20:291 | @prop | UseUseExplosion.rb:20:287:20:296 | ... > ... | self |
-| UseUseExplosion.rb:20:287:20:296 | * | UseUseExplosion.rb:20:287:20:296 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:287:20:296 | synthetic splat argument | UseUseExplosion.rb:20:287:20:296 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:295:20:296 | 87 | UseUseExplosion.rb:20:287:20:296 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:308:20:312 | @prop | UseUseExplosion.rb:20:308:20:317 | ... > ... | self |
-| UseUseExplosion.rb:20:308:20:317 | * | UseUseExplosion.rb:20:308:20:317 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:308:20:317 | synthetic splat argument | UseUseExplosion.rb:20:308:20:317 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:316:20:317 | 86 | UseUseExplosion.rb:20:308:20:317 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:329:20:333 | @prop | UseUseExplosion.rb:20:329:20:338 | ... > ... | self |
-| UseUseExplosion.rb:20:329:20:338 | * | UseUseExplosion.rb:20:329:20:338 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:329:20:338 | synthetic splat argument | UseUseExplosion.rb:20:329:20:338 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:337:20:338 | 85 | UseUseExplosion.rb:20:329:20:338 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:350:20:354 | @prop | UseUseExplosion.rb:20:350:20:359 | ... > ... | self |
-| UseUseExplosion.rb:20:350:20:359 | * | UseUseExplosion.rb:20:350:20:359 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:350:20:359 | synthetic splat argument | UseUseExplosion.rb:20:350:20:359 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:358:20:359 | 84 | UseUseExplosion.rb:20:350:20:359 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:371:20:375 | @prop | UseUseExplosion.rb:20:371:20:380 | ... > ... | self |
-| UseUseExplosion.rb:20:371:20:380 | * | UseUseExplosion.rb:20:371:20:380 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:371:20:380 | synthetic splat argument | UseUseExplosion.rb:20:371:20:380 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:379:20:380 | 83 | UseUseExplosion.rb:20:371:20:380 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:392:20:396 | @prop | UseUseExplosion.rb:20:392:20:401 | ... > ... | self |
-| UseUseExplosion.rb:20:392:20:401 | * | UseUseExplosion.rb:20:392:20:401 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:392:20:401 | synthetic splat argument | UseUseExplosion.rb:20:392:20:401 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:400:20:401 | 82 | UseUseExplosion.rb:20:392:20:401 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:413:20:417 | @prop | UseUseExplosion.rb:20:413:20:422 | ... > ... | self |
-| UseUseExplosion.rb:20:413:20:422 | * | UseUseExplosion.rb:20:413:20:422 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:413:20:422 | synthetic splat argument | UseUseExplosion.rb:20:413:20:422 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:421:20:422 | 81 | UseUseExplosion.rb:20:413:20:422 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:434:20:438 | @prop | UseUseExplosion.rb:20:434:20:443 | ... > ... | self |
-| UseUseExplosion.rb:20:434:20:443 | * | UseUseExplosion.rb:20:434:20:443 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:434:20:443 | synthetic splat argument | UseUseExplosion.rb:20:434:20:443 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:442:20:443 | 80 | UseUseExplosion.rb:20:434:20:443 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:455:20:459 | @prop | UseUseExplosion.rb:20:455:20:464 | ... > ... | self |
-| UseUseExplosion.rb:20:455:20:464 | * | UseUseExplosion.rb:20:455:20:464 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:455:20:464 | synthetic splat argument | UseUseExplosion.rb:20:455:20:464 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:463:20:464 | 79 | UseUseExplosion.rb:20:455:20:464 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:476:20:480 | @prop | UseUseExplosion.rb:20:476:20:485 | ... > ... | self |
-| UseUseExplosion.rb:20:476:20:485 | * | UseUseExplosion.rb:20:476:20:485 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:476:20:485 | synthetic splat argument | UseUseExplosion.rb:20:476:20:485 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:484:20:485 | 78 | UseUseExplosion.rb:20:476:20:485 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:497:20:501 | @prop | UseUseExplosion.rb:20:497:20:506 | ... > ... | self |
-| UseUseExplosion.rb:20:497:20:506 | * | UseUseExplosion.rb:20:497:20:506 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:497:20:506 | synthetic splat argument | UseUseExplosion.rb:20:497:20:506 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:505:20:506 | 77 | UseUseExplosion.rb:20:497:20:506 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:518:20:522 | @prop | UseUseExplosion.rb:20:518:20:527 | ... > ... | self |
-| UseUseExplosion.rb:20:518:20:527 | * | UseUseExplosion.rb:20:518:20:527 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:518:20:527 | synthetic splat argument | UseUseExplosion.rb:20:518:20:527 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:526:20:527 | 76 | UseUseExplosion.rb:20:518:20:527 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:539:20:543 | @prop | UseUseExplosion.rb:20:539:20:548 | ... > ... | self |
-| UseUseExplosion.rb:20:539:20:548 | * | UseUseExplosion.rb:20:539:20:548 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:539:20:548 | synthetic splat argument | UseUseExplosion.rb:20:539:20:548 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:547:20:548 | 75 | UseUseExplosion.rb:20:539:20:548 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:560:20:564 | @prop | UseUseExplosion.rb:20:560:20:569 | ... > ... | self |
-| UseUseExplosion.rb:20:560:20:569 | * | UseUseExplosion.rb:20:560:20:569 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:560:20:569 | synthetic splat argument | UseUseExplosion.rb:20:560:20:569 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:568:20:569 | 74 | UseUseExplosion.rb:20:560:20:569 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:581:20:585 | @prop | UseUseExplosion.rb:20:581:20:590 | ... > ... | self |
-| UseUseExplosion.rb:20:581:20:590 | * | UseUseExplosion.rb:20:581:20:590 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:581:20:590 | synthetic splat argument | UseUseExplosion.rb:20:581:20:590 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:589:20:590 | 73 | UseUseExplosion.rb:20:581:20:590 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:602:20:606 | @prop | UseUseExplosion.rb:20:602:20:611 | ... > ... | self |
-| UseUseExplosion.rb:20:602:20:611 | * | UseUseExplosion.rb:20:602:20:611 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:602:20:611 | synthetic splat argument | UseUseExplosion.rb:20:602:20:611 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:610:20:611 | 72 | UseUseExplosion.rb:20:602:20:611 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:623:20:627 | @prop | UseUseExplosion.rb:20:623:20:632 | ... > ... | self |
-| UseUseExplosion.rb:20:623:20:632 | * | UseUseExplosion.rb:20:623:20:632 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:623:20:632 | synthetic splat argument | UseUseExplosion.rb:20:623:20:632 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:631:20:632 | 71 | UseUseExplosion.rb:20:623:20:632 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:644:20:648 | @prop | UseUseExplosion.rb:20:644:20:653 | ... > ... | self |
-| UseUseExplosion.rb:20:644:20:653 | * | UseUseExplosion.rb:20:644:20:653 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:644:20:653 | synthetic splat argument | UseUseExplosion.rb:20:644:20:653 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:652:20:653 | 70 | UseUseExplosion.rb:20:644:20:653 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:665:20:669 | @prop | UseUseExplosion.rb:20:665:20:674 | ... > ... | self |
-| UseUseExplosion.rb:20:665:20:674 | * | UseUseExplosion.rb:20:665:20:674 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:665:20:674 | synthetic splat argument | UseUseExplosion.rb:20:665:20:674 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:673:20:674 | 69 | UseUseExplosion.rb:20:665:20:674 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:686:20:690 | @prop | UseUseExplosion.rb:20:686:20:695 | ... > ... | self |
-| UseUseExplosion.rb:20:686:20:695 | * | UseUseExplosion.rb:20:686:20:695 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:686:20:695 | synthetic splat argument | UseUseExplosion.rb:20:686:20:695 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:694:20:695 | 68 | UseUseExplosion.rb:20:686:20:695 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:707:20:711 | @prop | UseUseExplosion.rb:20:707:20:716 | ... > ... | self |
-| UseUseExplosion.rb:20:707:20:716 | * | UseUseExplosion.rb:20:707:20:716 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:707:20:716 | synthetic splat argument | UseUseExplosion.rb:20:707:20:716 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:715:20:716 | 67 | UseUseExplosion.rb:20:707:20:716 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:728:20:732 | @prop | UseUseExplosion.rb:20:728:20:737 | ... > ... | self |
-| UseUseExplosion.rb:20:728:20:737 | * | UseUseExplosion.rb:20:728:20:737 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:728:20:737 | synthetic splat argument | UseUseExplosion.rb:20:728:20:737 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:736:20:737 | 66 | UseUseExplosion.rb:20:728:20:737 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:749:20:753 | @prop | UseUseExplosion.rb:20:749:20:758 | ... > ... | self |
-| UseUseExplosion.rb:20:749:20:758 | * | UseUseExplosion.rb:20:749:20:758 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:749:20:758 | synthetic splat argument | UseUseExplosion.rb:20:749:20:758 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:757:20:758 | 65 | UseUseExplosion.rb:20:749:20:758 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:770:20:774 | @prop | UseUseExplosion.rb:20:770:20:779 | ... > ... | self |
-| UseUseExplosion.rb:20:770:20:779 | * | UseUseExplosion.rb:20:770:20:779 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:770:20:779 | synthetic splat argument | UseUseExplosion.rb:20:770:20:779 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:778:20:779 | 64 | UseUseExplosion.rb:20:770:20:779 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:791:20:795 | @prop | UseUseExplosion.rb:20:791:20:800 | ... > ... | self |
-| UseUseExplosion.rb:20:791:20:800 | * | UseUseExplosion.rb:20:791:20:800 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:791:20:800 | synthetic splat argument | UseUseExplosion.rb:20:791:20:800 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:799:20:800 | 63 | UseUseExplosion.rb:20:791:20:800 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:812:20:816 | @prop | UseUseExplosion.rb:20:812:20:821 | ... > ... | self |
-| UseUseExplosion.rb:20:812:20:821 | * | UseUseExplosion.rb:20:812:20:821 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:812:20:821 | synthetic splat argument | UseUseExplosion.rb:20:812:20:821 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:820:20:821 | 62 | UseUseExplosion.rb:20:812:20:821 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:833:20:837 | @prop | UseUseExplosion.rb:20:833:20:842 | ... > ... | self |
-| UseUseExplosion.rb:20:833:20:842 | * | UseUseExplosion.rb:20:833:20:842 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:833:20:842 | synthetic splat argument | UseUseExplosion.rb:20:833:20:842 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:841:20:842 | 61 | UseUseExplosion.rb:20:833:20:842 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:854:20:858 | @prop | UseUseExplosion.rb:20:854:20:863 | ... > ... | self |
-| UseUseExplosion.rb:20:854:20:863 | * | UseUseExplosion.rb:20:854:20:863 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:854:20:863 | synthetic splat argument | UseUseExplosion.rb:20:854:20:863 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:862:20:863 | 60 | UseUseExplosion.rb:20:854:20:863 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:875:20:879 | @prop | UseUseExplosion.rb:20:875:20:884 | ... > ... | self |
-| UseUseExplosion.rb:20:875:20:884 | * | UseUseExplosion.rb:20:875:20:884 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:875:20:884 | synthetic splat argument | UseUseExplosion.rb:20:875:20:884 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:883:20:884 | 59 | UseUseExplosion.rb:20:875:20:884 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:896:20:900 | @prop | UseUseExplosion.rb:20:896:20:905 | ... > ... | self |
-| UseUseExplosion.rb:20:896:20:905 | * | UseUseExplosion.rb:20:896:20:905 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:896:20:905 | synthetic splat argument | UseUseExplosion.rb:20:896:20:905 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:904:20:905 | 58 | UseUseExplosion.rb:20:896:20:905 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:917:20:921 | @prop | UseUseExplosion.rb:20:917:20:926 | ... > ... | self |
-| UseUseExplosion.rb:20:917:20:926 | * | UseUseExplosion.rb:20:917:20:926 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:917:20:926 | synthetic splat argument | UseUseExplosion.rb:20:917:20:926 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:925:20:926 | 57 | UseUseExplosion.rb:20:917:20:926 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:938:20:942 | @prop | UseUseExplosion.rb:20:938:20:947 | ... > ... | self |
-| UseUseExplosion.rb:20:938:20:947 | * | UseUseExplosion.rb:20:938:20:947 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:938:20:947 | synthetic splat argument | UseUseExplosion.rb:20:938:20:947 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:946:20:947 | 56 | UseUseExplosion.rb:20:938:20:947 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:959:20:963 | @prop | UseUseExplosion.rb:20:959:20:968 | ... > ... | self |
-| UseUseExplosion.rb:20:959:20:968 | * | UseUseExplosion.rb:20:959:20:968 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:959:20:968 | synthetic splat argument | UseUseExplosion.rb:20:959:20:968 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:967:20:968 | 55 | UseUseExplosion.rb:20:959:20:968 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:980:20:984 | @prop | UseUseExplosion.rb:20:980:20:989 | ... > ... | self |
-| UseUseExplosion.rb:20:980:20:989 | * | UseUseExplosion.rb:20:980:20:989 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:980:20:989 | synthetic splat argument | UseUseExplosion.rb:20:980:20:989 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:988:20:989 | 54 | UseUseExplosion.rb:20:980:20:989 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1001:20:1005 | @prop | UseUseExplosion.rb:20:1001:20:1010 | ... > ... | self |
-| UseUseExplosion.rb:20:1001:20:1010 | * | UseUseExplosion.rb:20:1001:20:1010 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1001:20:1010 | synthetic splat argument | UseUseExplosion.rb:20:1001:20:1010 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1009:20:1010 | 53 | UseUseExplosion.rb:20:1001:20:1010 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1022:20:1026 | @prop | UseUseExplosion.rb:20:1022:20:1031 | ... > ... | self |
-| UseUseExplosion.rb:20:1022:20:1031 | * | UseUseExplosion.rb:20:1022:20:1031 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1022:20:1031 | synthetic splat argument | UseUseExplosion.rb:20:1022:20:1031 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1030:20:1031 | 52 | UseUseExplosion.rb:20:1022:20:1031 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1043:20:1047 | @prop | UseUseExplosion.rb:20:1043:20:1052 | ... > ... | self |
-| UseUseExplosion.rb:20:1043:20:1052 | * | UseUseExplosion.rb:20:1043:20:1052 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1043:20:1052 | synthetic splat argument | UseUseExplosion.rb:20:1043:20:1052 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1051:20:1052 | 51 | UseUseExplosion.rb:20:1043:20:1052 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1064:20:1068 | @prop | UseUseExplosion.rb:20:1064:20:1073 | ... > ... | self |
-| UseUseExplosion.rb:20:1064:20:1073 | * | UseUseExplosion.rb:20:1064:20:1073 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1064:20:1073 | synthetic splat argument | UseUseExplosion.rb:20:1064:20:1073 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1072:20:1073 | 50 | UseUseExplosion.rb:20:1064:20:1073 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1085:20:1089 | @prop | UseUseExplosion.rb:20:1085:20:1094 | ... > ... | self |
-| UseUseExplosion.rb:20:1085:20:1094 | * | UseUseExplosion.rb:20:1085:20:1094 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1085:20:1094 | synthetic splat argument | UseUseExplosion.rb:20:1085:20:1094 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1093:20:1094 | 49 | UseUseExplosion.rb:20:1085:20:1094 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1106:20:1110 | @prop | UseUseExplosion.rb:20:1106:20:1115 | ... > ... | self |
-| UseUseExplosion.rb:20:1106:20:1115 | * | UseUseExplosion.rb:20:1106:20:1115 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1106:20:1115 | synthetic splat argument | UseUseExplosion.rb:20:1106:20:1115 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1114:20:1115 | 48 | UseUseExplosion.rb:20:1106:20:1115 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1127:20:1131 | @prop | UseUseExplosion.rb:20:1127:20:1136 | ... > ... | self |
-| UseUseExplosion.rb:20:1127:20:1136 | * | UseUseExplosion.rb:20:1127:20:1136 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1127:20:1136 | synthetic splat argument | UseUseExplosion.rb:20:1127:20:1136 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1135:20:1136 | 47 | UseUseExplosion.rb:20:1127:20:1136 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1148:20:1152 | @prop | UseUseExplosion.rb:20:1148:20:1157 | ... > ... | self |
-| UseUseExplosion.rb:20:1148:20:1157 | * | UseUseExplosion.rb:20:1148:20:1157 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1148:20:1157 | synthetic splat argument | UseUseExplosion.rb:20:1148:20:1157 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1156:20:1157 | 46 | UseUseExplosion.rb:20:1148:20:1157 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1169:20:1173 | @prop | UseUseExplosion.rb:20:1169:20:1178 | ... > ... | self |
-| UseUseExplosion.rb:20:1169:20:1178 | * | UseUseExplosion.rb:20:1169:20:1178 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1169:20:1178 | synthetic splat argument | UseUseExplosion.rb:20:1169:20:1178 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1177:20:1178 | 45 | UseUseExplosion.rb:20:1169:20:1178 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1190:20:1194 | @prop | UseUseExplosion.rb:20:1190:20:1199 | ... > ... | self |
-| UseUseExplosion.rb:20:1190:20:1199 | * | UseUseExplosion.rb:20:1190:20:1199 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1190:20:1199 | synthetic splat argument | UseUseExplosion.rb:20:1190:20:1199 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1198:20:1199 | 44 | UseUseExplosion.rb:20:1190:20:1199 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1211:20:1215 | @prop | UseUseExplosion.rb:20:1211:20:1220 | ... > ... | self |
-| UseUseExplosion.rb:20:1211:20:1220 | * | UseUseExplosion.rb:20:1211:20:1220 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1211:20:1220 | synthetic splat argument | UseUseExplosion.rb:20:1211:20:1220 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1219:20:1220 | 43 | UseUseExplosion.rb:20:1211:20:1220 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1232:20:1236 | @prop | UseUseExplosion.rb:20:1232:20:1241 | ... > ... | self |
-| UseUseExplosion.rb:20:1232:20:1241 | * | UseUseExplosion.rb:20:1232:20:1241 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1232:20:1241 | synthetic splat argument | UseUseExplosion.rb:20:1232:20:1241 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1240:20:1241 | 42 | UseUseExplosion.rb:20:1232:20:1241 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1253:20:1257 | @prop | UseUseExplosion.rb:20:1253:20:1262 | ... > ... | self |
-| UseUseExplosion.rb:20:1253:20:1262 | * | UseUseExplosion.rb:20:1253:20:1262 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1253:20:1262 | synthetic splat argument | UseUseExplosion.rb:20:1253:20:1262 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1261:20:1262 | 41 | UseUseExplosion.rb:20:1253:20:1262 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1274:20:1278 | @prop | UseUseExplosion.rb:20:1274:20:1283 | ... > ... | self |
-| UseUseExplosion.rb:20:1274:20:1283 | * | UseUseExplosion.rb:20:1274:20:1283 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1274:20:1283 | synthetic splat argument | UseUseExplosion.rb:20:1274:20:1283 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1282:20:1283 | 40 | UseUseExplosion.rb:20:1274:20:1283 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1295:20:1299 | @prop | UseUseExplosion.rb:20:1295:20:1304 | ... > ... | self |
-| UseUseExplosion.rb:20:1295:20:1304 | * | UseUseExplosion.rb:20:1295:20:1304 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1295:20:1304 | synthetic splat argument | UseUseExplosion.rb:20:1295:20:1304 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1303:20:1304 | 39 | UseUseExplosion.rb:20:1295:20:1304 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1316:20:1320 | @prop | UseUseExplosion.rb:20:1316:20:1325 | ... > ... | self |
-| UseUseExplosion.rb:20:1316:20:1325 | * | UseUseExplosion.rb:20:1316:20:1325 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1316:20:1325 | synthetic splat argument | UseUseExplosion.rb:20:1316:20:1325 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1324:20:1325 | 38 | UseUseExplosion.rb:20:1316:20:1325 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1337:20:1341 | @prop | UseUseExplosion.rb:20:1337:20:1346 | ... > ... | self |
-| UseUseExplosion.rb:20:1337:20:1346 | * | UseUseExplosion.rb:20:1337:20:1346 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1337:20:1346 | synthetic splat argument | UseUseExplosion.rb:20:1337:20:1346 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1345:20:1346 | 37 | UseUseExplosion.rb:20:1337:20:1346 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1358:20:1362 | @prop | UseUseExplosion.rb:20:1358:20:1367 | ... > ... | self |
-| UseUseExplosion.rb:20:1358:20:1367 | * | UseUseExplosion.rb:20:1358:20:1367 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1358:20:1367 | synthetic splat argument | UseUseExplosion.rb:20:1358:20:1367 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1366:20:1367 | 36 | UseUseExplosion.rb:20:1358:20:1367 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1379:20:1383 | @prop | UseUseExplosion.rb:20:1379:20:1388 | ... > ... | self |
-| UseUseExplosion.rb:20:1379:20:1388 | * | UseUseExplosion.rb:20:1379:20:1388 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1379:20:1388 | synthetic splat argument | UseUseExplosion.rb:20:1379:20:1388 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1387:20:1388 | 35 | UseUseExplosion.rb:20:1379:20:1388 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1400:20:1404 | @prop | UseUseExplosion.rb:20:1400:20:1409 | ... > ... | self |
-| UseUseExplosion.rb:20:1400:20:1409 | * | UseUseExplosion.rb:20:1400:20:1409 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1400:20:1409 | synthetic splat argument | UseUseExplosion.rb:20:1400:20:1409 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1408:20:1409 | 34 | UseUseExplosion.rb:20:1400:20:1409 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1421:20:1425 | @prop | UseUseExplosion.rb:20:1421:20:1430 | ... > ... | self |
-| UseUseExplosion.rb:20:1421:20:1430 | * | UseUseExplosion.rb:20:1421:20:1430 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1421:20:1430 | synthetic splat argument | UseUseExplosion.rb:20:1421:20:1430 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1429:20:1430 | 33 | UseUseExplosion.rb:20:1421:20:1430 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1442:20:1446 | @prop | UseUseExplosion.rb:20:1442:20:1451 | ... > ... | self |
-| UseUseExplosion.rb:20:1442:20:1451 | * | UseUseExplosion.rb:20:1442:20:1451 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1442:20:1451 | synthetic splat argument | UseUseExplosion.rb:20:1442:20:1451 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1450:20:1451 | 32 | UseUseExplosion.rb:20:1442:20:1451 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1463:20:1467 | @prop | UseUseExplosion.rb:20:1463:20:1472 | ... > ... | self |
-| UseUseExplosion.rb:20:1463:20:1472 | * | UseUseExplosion.rb:20:1463:20:1472 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1463:20:1472 | synthetic splat argument | UseUseExplosion.rb:20:1463:20:1472 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1471:20:1472 | 31 | UseUseExplosion.rb:20:1463:20:1472 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1484:20:1488 | @prop | UseUseExplosion.rb:20:1484:20:1493 | ... > ... | self |
-| UseUseExplosion.rb:20:1484:20:1493 | * | UseUseExplosion.rb:20:1484:20:1493 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1484:20:1493 | synthetic splat argument | UseUseExplosion.rb:20:1484:20:1493 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1492:20:1493 | 30 | UseUseExplosion.rb:20:1484:20:1493 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1505:20:1509 | @prop | UseUseExplosion.rb:20:1505:20:1514 | ... > ... | self |
-| UseUseExplosion.rb:20:1505:20:1514 | * | UseUseExplosion.rb:20:1505:20:1514 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1505:20:1514 | synthetic splat argument | UseUseExplosion.rb:20:1505:20:1514 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1513:20:1514 | 29 | UseUseExplosion.rb:20:1505:20:1514 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1526:20:1530 | @prop | UseUseExplosion.rb:20:1526:20:1535 | ... > ... | self |
-| UseUseExplosion.rb:20:1526:20:1535 | * | UseUseExplosion.rb:20:1526:20:1535 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1526:20:1535 | synthetic splat argument | UseUseExplosion.rb:20:1526:20:1535 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1534:20:1535 | 28 | UseUseExplosion.rb:20:1526:20:1535 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1547:20:1551 | @prop | UseUseExplosion.rb:20:1547:20:1556 | ... > ... | self |
-| UseUseExplosion.rb:20:1547:20:1556 | * | UseUseExplosion.rb:20:1547:20:1556 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1547:20:1556 | synthetic splat argument | UseUseExplosion.rb:20:1547:20:1556 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1555:20:1556 | 27 | UseUseExplosion.rb:20:1547:20:1556 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1568:20:1572 | @prop | UseUseExplosion.rb:20:1568:20:1577 | ... > ... | self |
-| UseUseExplosion.rb:20:1568:20:1577 | * | UseUseExplosion.rb:20:1568:20:1577 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1568:20:1577 | synthetic splat argument | UseUseExplosion.rb:20:1568:20:1577 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1576:20:1577 | 26 | UseUseExplosion.rb:20:1568:20:1577 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1589:20:1593 | @prop | UseUseExplosion.rb:20:1589:20:1598 | ... > ... | self |
-| UseUseExplosion.rb:20:1589:20:1598 | * | UseUseExplosion.rb:20:1589:20:1598 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1589:20:1598 | synthetic splat argument | UseUseExplosion.rb:20:1589:20:1598 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1597:20:1598 | 25 | UseUseExplosion.rb:20:1589:20:1598 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1610:20:1614 | @prop | UseUseExplosion.rb:20:1610:20:1619 | ... > ... | self |
-| UseUseExplosion.rb:20:1610:20:1619 | * | UseUseExplosion.rb:20:1610:20:1619 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1610:20:1619 | synthetic splat argument | UseUseExplosion.rb:20:1610:20:1619 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1618:20:1619 | 24 | UseUseExplosion.rb:20:1610:20:1619 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1631:20:1635 | @prop | UseUseExplosion.rb:20:1631:20:1640 | ... > ... | self |
-| UseUseExplosion.rb:20:1631:20:1640 | * | UseUseExplosion.rb:20:1631:20:1640 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1631:20:1640 | synthetic splat argument | UseUseExplosion.rb:20:1631:20:1640 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1639:20:1640 | 23 | UseUseExplosion.rb:20:1631:20:1640 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1652:20:1656 | @prop | UseUseExplosion.rb:20:1652:20:1661 | ... > ... | self |
-| UseUseExplosion.rb:20:1652:20:1661 | * | UseUseExplosion.rb:20:1652:20:1661 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1652:20:1661 | synthetic splat argument | UseUseExplosion.rb:20:1652:20:1661 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1660:20:1661 | 22 | UseUseExplosion.rb:20:1652:20:1661 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1673:20:1677 | @prop | UseUseExplosion.rb:20:1673:20:1682 | ... > ... | self |
-| UseUseExplosion.rb:20:1673:20:1682 | * | UseUseExplosion.rb:20:1673:20:1682 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1673:20:1682 | synthetic splat argument | UseUseExplosion.rb:20:1673:20:1682 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1681:20:1682 | 21 | UseUseExplosion.rb:20:1673:20:1682 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1694:20:1698 | @prop | UseUseExplosion.rb:20:1694:20:1703 | ... > ... | self |
-| UseUseExplosion.rb:20:1694:20:1703 | * | UseUseExplosion.rb:20:1694:20:1703 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1694:20:1703 | synthetic splat argument | UseUseExplosion.rb:20:1694:20:1703 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1702:20:1703 | 20 | UseUseExplosion.rb:20:1694:20:1703 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1715:20:1719 | @prop | UseUseExplosion.rb:20:1715:20:1724 | ... > ... | self |
-| UseUseExplosion.rb:20:1715:20:1724 | * | UseUseExplosion.rb:20:1715:20:1724 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1715:20:1724 | synthetic splat argument | UseUseExplosion.rb:20:1715:20:1724 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1723:20:1724 | 19 | UseUseExplosion.rb:20:1715:20:1724 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1736:20:1740 | @prop | UseUseExplosion.rb:20:1736:20:1745 | ... > ... | self |
-| UseUseExplosion.rb:20:1736:20:1745 | * | UseUseExplosion.rb:20:1736:20:1745 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1736:20:1745 | synthetic splat argument | UseUseExplosion.rb:20:1736:20:1745 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1744:20:1745 | 18 | UseUseExplosion.rb:20:1736:20:1745 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1757:20:1761 | @prop | UseUseExplosion.rb:20:1757:20:1766 | ... > ... | self |
-| UseUseExplosion.rb:20:1757:20:1766 | * | UseUseExplosion.rb:20:1757:20:1766 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1757:20:1766 | synthetic splat argument | UseUseExplosion.rb:20:1757:20:1766 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1765:20:1766 | 17 | UseUseExplosion.rb:20:1757:20:1766 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1778:20:1782 | @prop | UseUseExplosion.rb:20:1778:20:1787 | ... > ... | self |
-| UseUseExplosion.rb:20:1778:20:1787 | * | UseUseExplosion.rb:20:1778:20:1787 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1778:20:1787 | synthetic splat argument | UseUseExplosion.rb:20:1778:20:1787 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1786:20:1787 | 16 | UseUseExplosion.rb:20:1778:20:1787 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1799:20:1803 | @prop | UseUseExplosion.rb:20:1799:20:1808 | ... > ... | self |
-| UseUseExplosion.rb:20:1799:20:1808 | * | UseUseExplosion.rb:20:1799:20:1808 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1799:20:1808 | synthetic splat argument | UseUseExplosion.rb:20:1799:20:1808 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1807:20:1808 | 15 | UseUseExplosion.rb:20:1799:20:1808 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1820:20:1824 | @prop | UseUseExplosion.rb:20:1820:20:1829 | ... > ... | self |
-| UseUseExplosion.rb:20:1820:20:1829 | * | UseUseExplosion.rb:20:1820:20:1829 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1820:20:1829 | synthetic splat argument | UseUseExplosion.rb:20:1820:20:1829 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1828:20:1829 | 14 | UseUseExplosion.rb:20:1820:20:1829 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1841:20:1845 | @prop | UseUseExplosion.rb:20:1841:20:1850 | ... > ... | self |
-| UseUseExplosion.rb:20:1841:20:1850 | * | UseUseExplosion.rb:20:1841:20:1850 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1841:20:1850 | synthetic splat argument | UseUseExplosion.rb:20:1841:20:1850 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1849:20:1850 | 13 | UseUseExplosion.rb:20:1841:20:1850 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1862:20:1866 | @prop | UseUseExplosion.rb:20:1862:20:1871 | ... > ... | self |
-| UseUseExplosion.rb:20:1862:20:1871 | * | UseUseExplosion.rb:20:1862:20:1871 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1862:20:1871 | synthetic splat argument | UseUseExplosion.rb:20:1862:20:1871 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1870:20:1871 | 12 | UseUseExplosion.rb:20:1862:20:1871 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1883:20:1887 | @prop | UseUseExplosion.rb:20:1883:20:1892 | ... > ... | self |
-| UseUseExplosion.rb:20:1883:20:1892 | * | UseUseExplosion.rb:20:1883:20:1892 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1883:20:1892 | synthetic splat argument | UseUseExplosion.rb:20:1883:20:1892 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1891:20:1892 | 11 | UseUseExplosion.rb:20:1883:20:1892 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1904:20:1908 | @prop | UseUseExplosion.rb:20:1904:20:1913 | ... > ... | self |
-| UseUseExplosion.rb:20:1904:20:1913 | * | UseUseExplosion.rb:20:1904:20:1913 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1904:20:1913 | synthetic splat argument | UseUseExplosion.rb:20:1904:20:1913 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1912:20:1913 | 10 | UseUseExplosion.rb:20:1904:20:1913 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1925:20:1929 | @prop | UseUseExplosion.rb:20:1925:20:1933 | ... > ... | self |
-| UseUseExplosion.rb:20:1925:20:1933 | * | UseUseExplosion.rb:20:1925:20:1933 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1925:20:1933 | synthetic splat argument | UseUseExplosion.rb:20:1925:20:1933 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1933:20:1933 | 9 | UseUseExplosion.rb:20:1925:20:1933 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1945:20:1949 | @prop | UseUseExplosion.rb:20:1945:20:1953 | ... > ... | self |
-| UseUseExplosion.rb:20:1945:20:1953 | * | UseUseExplosion.rb:20:1945:20:1953 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1945:20:1953 | synthetic splat argument | UseUseExplosion.rb:20:1945:20:1953 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1953:20:1953 | 8 | UseUseExplosion.rb:20:1945:20:1953 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1965:20:1969 | @prop | UseUseExplosion.rb:20:1965:20:1973 | ... > ... | self |
-| UseUseExplosion.rb:20:1965:20:1973 | * | UseUseExplosion.rb:20:1965:20:1973 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1965:20:1973 | synthetic splat argument | UseUseExplosion.rb:20:1965:20:1973 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1973:20:1973 | 7 | UseUseExplosion.rb:20:1965:20:1973 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:1985:20:1989 | @prop | UseUseExplosion.rb:20:1985:20:1993 | ... > ... | self |
-| UseUseExplosion.rb:20:1985:20:1993 | * | UseUseExplosion.rb:20:1985:20:1993 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:1985:20:1993 | synthetic splat argument | UseUseExplosion.rb:20:1985:20:1993 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:1993:20:1993 | 6 | UseUseExplosion.rb:20:1985:20:1993 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:2005:20:2009 | @prop | UseUseExplosion.rb:20:2005:20:2013 | ... > ... | self |
-| UseUseExplosion.rb:20:2005:20:2013 | * | UseUseExplosion.rb:20:2005:20:2013 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:2005:20:2013 | synthetic splat argument | UseUseExplosion.rb:20:2005:20:2013 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:2013:20:2013 | 5 | UseUseExplosion.rb:20:2005:20:2013 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:2025:20:2029 | @prop | UseUseExplosion.rb:20:2025:20:2033 | ... > ... | self |
-| UseUseExplosion.rb:20:2025:20:2033 | * | UseUseExplosion.rb:20:2025:20:2033 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:2025:20:2033 | synthetic splat argument | UseUseExplosion.rb:20:2025:20:2033 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:2033:20:2033 | 4 | UseUseExplosion.rb:20:2025:20:2033 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:2045:20:2049 | @prop | UseUseExplosion.rb:20:2045:20:2053 | ... > ... | self |
-| UseUseExplosion.rb:20:2045:20:2053 | * | UseUseExplosion.rb:20:2045:20:2053 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:2045:20:2053 | synthetic splat argument | UseUseExplosion.rb:20:2045:20:2053 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:2053:20:2053 | 3 | UseUseExplosion.rb:20:2045:20:2053 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:2065:20:2069 | @prop | UseUseExplosion.rb:20:2065:20:2073 | ... > ... | self |
-| UseUseExplosion.rb:20:2065:20:2073 | * | UseUseExplosion.rb:20:2065:20:2073 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:2065:20:2073 | synthetic splat argument | UseUseExplosion.rb:20:2065:20:2073 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:2073:20:2073 | 2 | UseUseExplosion.rb:20:2065:20:2073 | ... > ... | position 0 |
 | UseUseExplosion.rb:20:2085:20:2089 | @prop | UseUseExplosion.rb:20:2085:20:2093 | ... > ... | self |
-| UseUseExplosion.rb:20:2085:20:2093 | * | UseUseExplosion.rb:20:2085:20:2093 | ... > ... | synthetic * |
+| UseUseExplosion.rb:20:2085:20:2093 | synthetic splat argument | UseUseExplosion.rb:20:2085:20:2093 | ... > ... | synthetic * |
 | UseUseExplosion.rb:20:2093:20:2093 | 1 | UseUseExplosion.rb:20:2085:20:2093 | ... > ... | position 0 |
-| UseUseExplosion.rb:20:2107:20:2112 | * | UseUseExplosion.rb:20:2107:20:2112 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2107:20:2112 | self | UseUseExplosion.rb:20:2107:20:2112 | call to use | self |
+| UseUseExplosion.rb:20:2107:20:2112 | synthetic splat argument | UseUseExplosion.rb:20:2107:20:2112 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2111:20:2111 | x | UseUseExplosion.rb:20:2107:20:2112 | call to use | position 0 |
-| UseUseExplosion.rb:20:2123:20:2128 | * | UseUseExplosion.rb:20:2123:20:2128 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2123:20:2128 | self | UseUseExplosion.rb:20:2123:20:2128 | call to use | self |
+| UseUseExplosion.rb:20:2123:20:2128 | synthetic splat argument | UseUseExplosion.rb:20:2123:20:2128 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2127:20:2127 | x | UseUseExplosion.rb:20:2123:20:2128 | call to use | position 0 |
-| UseUseExplosion.rb:20:2139:20:2144 | * | UseUseExplosion.rb:20:2139:20:2144 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2139:20:2144 | self | UseUseExplosion.rb:20:2139:20:2144 | call to use | self |
+| UseUseExplosion.rb:20:2139:20:2144 | synthetic splat argument | UseUseExplosion.rb:20:2139:20:2144 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2143:20:2143 | x | UseUseExplosion.rb:20:2139:20:2144 | call to use | position 0 |
-| UseUseExplosion.rb:20:2155:20:2160 | * | UseUseExplosion.rb:20:2155:20:2160 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2155:20:2160 | self | UseUseExplosion.rb:20:2155:20:2160 | call to use | self |
+| UseUseExplosion.rb:20:2155:20:2160 | synthetic splat argument | UseUseExplosion.rb:20:2155:20:2160 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2159:20:2159 | x | UseUseExplosion.rb:20:2155:20:2160 | call to use | position 0 |
-| UseUseExplosion.rb:20:2171:20:2176 | * | UseUseExplosion.rb:20:2171:20:2176 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2171:20:2176 | self | UseUseExplosion.rb:20:2171:20:2176 | call to use | self |
+| UseUseExplosion.rb:20:2171:20:2176 | synthetic splat argument | UseUseExplosion.rb:20:2171:20:2176 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2175:20:2175 | x | UseUseExplosion.rb:20:2171:20:2176 | call to use | position 0 |
-| UseUseExplosion.rb:20:2187:20:2192 | * | UseUseExplosion.rb:20:2187:20:2192 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2187:20:2192 | self | UseUseExplosion.rb:20:2187:20:2192 | call to use | self |
+| UseUseExplosion.rb:20:2187:20:2192 | synthetic splat argument | UseUseExplosion.rb:20:2187:20:2192 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2191:20:2191 | x | UseUseExplosion.rb:20:2187:20:2192 | call to use | position 0 |
-| UseUseExplosion.rb:20:2203:20:2208 | * | UseUseExplosion.rb:20:2203:20:2208 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2203:20:2208 | self | UseUseExplosion.rb:20:2203:20:2208 | call to use | self |
+| UseUseExplosion.rb:20:2203:20:2208 | synthetic splat argument | UseUseExplosion.rb:20:2203:20:2208 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2207:20:2207 | x | UseUseExplosion.rb:20:2203:20:2208 | call to use | position 0 |
-| UseUseExplosion.rb:20:2219:20:2224 | * | UseUseExplosion.rb:20:2219:20:2224 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2219:20:2224 | self | UseUseExplosion.rb:20:2219:20:2224 | call to use | self |
+| UseUseExplosion.rb:20:2219:20:2224 | synthetic splat argument | UseUseExplosion.rb:20:2219:20:2224 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2223:20:2223 | x | UseUseExplosion.rb:20:2219:20:2224 | call to use | position 0 |
-| UseUseExplosion.rb:20:2235:20:2240 | * | UseUseExplosion.rb:20:2235:20:2240 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2235:20:2240 | self | UseUseExplosion.rb:20:2235:20:2240 | call to use | self |
+| UseUseExplosion.rb:20:2235:20:2240 | synthetic splat argument | UseUseExplosion.rb:20:2235:20:2240 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2239:20:2239 | x | UseUseExplosion.rb:20:2235:20:2240 | call to use | position 0 |
-| UseUseExplosion.rb:20:2251:20:2256 | * | UseUseExplosion.rb:20:2251:20:2256 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2251:20:2256 | self | UseUseExplosion.rb:20:2251:20:2256 | call to use | self |
+| UseUseExplosion.rb:20:2251:20:2256 | synthetic splat argument | UseUseExplosion.rb:20:2251:20:2256 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2255:20:2255 | x | UseUseExplosion.rb:20:2251:20:2256 | call to use | position 0 |
-| UseUseExplosion.rb:20:2267:20:2272 | * | UseUseExplosion.rb:20:2267:20:2272 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2267:20:2272 | self | UseUseExplosion.rb:20:2267:20:2272 | call to use | self |
+| UseUseExplosion.rb:20:2267:20:2272 | synthetic splat argument | UseUseExplosion.rb:20:2267:20:2272 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2271:20:2271 | x | UseUseExplosion.rb:20:2267:20:2272 | call to use | position 0 |
-| UseUseExplosion.rb:20:2283:20:2288 | * | UseUseExplosion.rb:20:2283:20:2288 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2283:20:2288 | self | UseUseExplosion.rb:20:2283:20:2288 | call to use | self |
+| UseUseExplosion.rb:20:2283:20:2288 | synthetic splat argument | UseUseExplosion.rb:20:2283:20:2288 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2287:20:2287 | x | UseUseExplosion.rb:20:2283:20:2288 | call to use | position 0 |
-| UseUseExplosion.rb:20:2299:20:2304 | * | UseUseExplosion.rb:20:2299:20:2304 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2299:20:2304 | self | UseUseExplosion.rb:20:2299:20:2304 | call to use | self |
+| UseUseExplosion.rb:20:2299:20:2304 | synthetic splat argument | UseUseExplosion.rb:20:2299:20:2304 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2303:20:2303 | x | UseUseExplosion.rb:20:2299:20:2304 | call to use | position 0 |
-| UseUseExplosion.rb:20:2315:20:2320 | * | UseUseExplosion.rb:20:2315:20:2320 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2315:20:2320 | self | UseUseExplosion.rb:20:2315:20:2320 | call to use | self |
+| UseUseExplosion.rb:20:2315:20:2320 | synthetic splat argument | UseUseExplosion.rb:20:2315:20:2320 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2319:20:2319 | x | UseUseExplosion.rb:20:2315:20:2320 | call to use | position 0 |
-| UseUseExplosion.rb:20:2331:20:2336 | * | UseUseExplosion.rb:20:2331:20:2336 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2331:20:2336 | self | UseUseExplosion.rb:20:2331:20:2336 | call to use | self |
+| UseUseExplosion.rb:20:2331:20:2336 | synthetic splat argument | UseUseExplosion.rb:20:2331:20:2336 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2335:20:2335 | x | UseUseExplosion.rb:20:2331:20:2336 | call to use | position 0 |
-| UseUseExplosion.rb:20:2347:20:2352 | * | UseUseExplosion.rb:20:2347:20:2352 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2347:20:2352 | self | UseUseExplosion.rb:20:2347:20:2352 | call to use | self |
+| UseUseExplosion.rb:20:2347:20:2352 | synthetic splat argument | UseUseExplosion.rb:20:2347:20:2352 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2351:20:2351 | x | UseUseExplosion.rb:20:2347:20:2352 | call to use | position 0 |
-| UseUseExplosion.rb:20:2363:20:2368 | * | UseUseExplosion.rb:20:2363:20:2368 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2363:20:2368 | self | UseUseExplosion.rb:20:2363:20:2368 | call to use | self |
+| UseUseExplosion.rb:20:2363:20:2368 | synthetic splat argument | UseUseExplosion.rb:20:2363:20:2368 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2367:20:2367 | x | UseUseExplosion.rb:20:2363:20:2368 | call to use | position 0 |
-| UseUseExplosion.rb:20:2379:20:2384 | * | UseUseExplosion.rb:20:2379:20:2384 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2379:20:2384 | self | UseUseExplosion.rb:20:2379:20:2384 | call to use | self |
+| UseUseExplosion.rb:20:2379:20:2384 | synthetic splat argument | UseUseExplosion.rb:20:2379:20:2384 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2383:20:2383 | x | UseUseExplosion.rb:20:2379:20:2384 | call to use | position 0 |
-| UseUseExplosion.rb:20:2395:20:2400 | * | UseUseExplosion.rb:20:2395:20:2400 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2395:20:2400 | self | UseUseExplosion.rb:20:2395:20:2400 | call to use | self |
+| UseUseExplosion.rb:20:2395:20:2400 | synthetic splat argument | UseUseExplosion.rb:20:2395:20:2400 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2399:20:2399 | x | UseUseExplosion.rb:20:2395:20:2400 | call to use | position 0 |
-| UseUseExplosion.rb:20:2411:20:2416 | * | UseUseExplosion.rb:20:2411:20:2416 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2411:20:2416 | self | UseUseExplosion.rb:20:2411:20:2416 | call to use | self |
+| UseUseExplosion.rb:20:2411:20:2416 | synthetic splat argument | UseUseExplosion.rb:20:2411:20:2416 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2415:20:2415 | x | UseUseExplosion.rb:20:2411:20:2416 | call to use | position 0 |
-| UseUseExplosion.rb:20:2427:20:2432 | * | UseUseExplosion.rb:20:2427:20:2432 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2427:20:2432 | self | UseUseExplosion.rb:20:2427:20:2432 | call to use | self |
+| UseUseExplosion.rb:20:2427:20:2432 | synthetic splat argument | UseUseExplosion.rb:20:2427:20:2432 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2431:20:2431 | x | UseUseExplosion.rb:20:2427:20:2432 | call to use | position 0 |
-| UseUseExplosion.rb:20:2443:20:2448 | * | UseUseExplosion.rb:20:2443:20:2448 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2443:20:2448 | self | UseUseExplosion.rb:20:2443:20:2448 | call to use | self |
+| UseUseExplosion.rb:20:2443:20:2448 | synthetic splat argument | UseUseExplosion.rb:20:2443:20:2448 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2447:20:2447 | x | UseUseExplosion.rb:20:2443:20:2448 | call to use | position 0 |
-| UseUseExplosion.rb:20:2459:20:2464 | * | UseUseExplosion.rb:20:2459:20:2464 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2459:20:2464 | self | UseUseExplosion.rb:20:2459:20:2464 | call to use | self |
+| UseUseExplosion.rb:20:2459:20:2464 | synthetic splat argument | UseUseExplosion.rb:20:2459:20:2464 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2463:20:2463 | x | UseUseExplosion.rb:20:2459:20:2464 | call to use | position 0 |
-| UseUseExplosion.rb:20:2475:20:2480 | * | UseUseExplosion.rb:20:2475:20:2480 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2475:20:2480 | self | UseUseExplosion.rb:20:2475:20:2480 | call to use | self |
+| UseUseExplosion.rb:20:2475:20:2480 | synthetic splat argument | UseUseExplosion.rb:20:2475:20:2480 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2479:20:2479 | x | UseUseExplosion.rb:20:2475:20:2480 | call to use | position 0 |
-| UseUseExplosion.rb:20:2491:20:2496 | * | UseUseExplosion.rb:20:2491:20:2496 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2491:20:2496 | self | UseUseExplosion.rb:20:2491:20:2496 | call to use | self |
+| UseUseExplosion.rb:20:2491:20:2496 | synthetic splat argument | UseUseExplosion.rb:20:2491:20:2496 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2495:20:2495 | x | UseUseExplosion.rb:20:2491:20:2496 | call to use | position 0 |
-| UseUseExplosion.rb:20:2507:20:2512 | * | UseUseExplosion.rb:20:2507:20:2512 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2507:20:2512 | self | UseUseExplosion.rb:20:2507:20:2512 | call to use | self |
+| UseUseExplosion.rb:20:2507:20:2512 | synthetic splat argument | UseUseExplosion.rb:20:2507:20:2512 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2511:20:2511 | x | UseUseExplosion.rb:20:2507:20:2512 | call to use | position 0 |
-| UseUseExplosion.rb:20:2523:20:2528 | * | UseUseExplosion.rb:20:2523:20:2528 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2523:20:2528 | self | UseUseExplosion.rb:20:2523:20:2528 | call to use | self |
+| UseUseExplosion.rb:20:2523:20:2528 | synthetic splat argument | UseUseExplosion.rb:20:2523:20:2528 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2527:20:2527 | x | UseUseExplosion.rb:20:2523:20:2528 | call to use | position 0 |
-| UseUseExplosion.rb:20:2539:20:2544 | * | UseUseExplosion.rb:20:2539:20:2544 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2539:20:2544 | self | UseUseExplosion.rb:20:2539:20:2544 | call to use | self |
+| UseUseExplosion.rb:20:2539:20:2544 | synthetic splat argument | UseUseExplosion.rb:20:2539:20:2544 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2543:20:2543 | x | UseUseExplosion.rb:20:2539:20:2544 | call to use | position 0 |
-| UseUseExplosion.rb:20:2555:20:2560 | * | UseUseExplosion.rb:20:2555:20:2560 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2555:20:2560 | self | UseUseExplosion.rb:20:2555:20:2560 | call to use | self |
+| UseUseExplosion.rb:20:2555:20:2560 | synthetic splat argument | UseUseExplosion.rb:20:2555:20:2560 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2559:20:2559 | x | UseUseExplosion.rb:20:2555:20:2560 | call to use | position 0 |
-| UseUseExplosion.rb:20:2571:20:2576 | * | UseUseExplosion.rb:20:2571:20:2576 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2571:20:2576 | self | UseUseExplosion.rb:20:2571:20:2576 | call to use | self |
+| UseUseExplosion.rb:20:2571:20:2576 | synthetic splat argument | UseUseExplosion.rb:20:2571:20:2576 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2575:20:2575 | x | UseUseExplosion.rb:20:2571:20:2576 | call to use | position 0 |
-| UseUseExplosion.rb:20:2587:20:2592 | * | UseUseExplosion.rb:20:2587:20:2592 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2587:20:2592 | self | UseUseExplosion.rb:20:2587:20:2592 | call to use | self |
+| UseUseExplosion.rb:20:2587:20:2592 | synthetic splat argument | UseUseExplosion.rb:20:2587:20:2592 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2591:20:2591 | x | UseUseExplosion.rb:20:2587:20:2592 | call to use | position 0 |
-| UseUseExplosion.rb:20:2603:20:2608 | * | UseUseExplosion.rb:20:2603:20:2608 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2603:20:2608 | self | UseUseExplosion.rb:20:2603:20:2608 | call to use | self |
+| UseUseExplosion.rb:20:2603:20:2608 | synthetic splat argument | UseUseExplosion.rb:20:2603:20:2608 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2607:20:2607 | x | UseUseExplosion.rb:20:2603:20:2608 | call to use | position 0 |
-| UseUseExplosion.rb:20:2619:20:2624 | * | UseUseExplosion.rb:20:2619:20:2624 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2619:20:2624 | self | UseUseExplosion.rb:20:2619:20:2624 | call to use | self |
+| UseUseExplosion.rb:20:2619:20:2624 | synthetic splat argument | UseUseExplosion.rb:20:2619:20:2624 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2623:20:2623 | x | UseUseExplosion.rb:20:2619:20:2624 | call to use | position 0 |
-| UseUseExplosion.rb:20:2635:20:2640 | * | UseUseExplosion.rb:20:2635:20:2640 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2635:20:2640 | self | UseUseExplosion.rb:20:2635:20:2640 | call to use | self |
+| UseUseExplosion.rb:20:2635:20:2640 | synthetic splat argument | UseUseExplosion.rb:20:2635:20:2640 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2639:20:2639 | x | UseUseExplosion.rb:20:2635:20:2640 | call to use | position 0 |
-| UseUseExplosion.rb:20:2651:20:2656 | * | UseUseExplosion.rb:20:2651:20:2656 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2651:20:2656 | self | UseUseExplosion.rb:20:2651:20:2656 | call to use | self |
+| UseUseExplosion.rb:20:2651:20:2656 | synthetic splat argument | UseUseExplosion.rb:20:2651:20:2656 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2655:20:2655 | x | UseUseExplosion.rb:20:2651:20:2656 | call to use | position 0 |
-| UseUseExplosion.rb:20:2667:20:2672 | * | UseUseExplosion.rb:20:2667:20:2672 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2667:20:2672 | self | UseUseExplosion.rb:20:2667:20:2672 | call to use | self |
+| UseUseExplosion.rb:20:2667:20:2672 | synthetic splat argument | UseUseExplosion.rb:20:2667:20:2672 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2671:20:2671 | x | UseUseExplosion.rb:20:2667:20:2672 | call to use | position 0 |
-| UseUseExplosion.rb:20:2683:20:2688 | * | UseUseExplosion.rb:20:2683:20:2688 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2683:20:2688 | self | UseUseExplosion.rb:20:2683:20:2688 | call to use | self |
+| UseUseExplosion.rb:20:2683:20:2688 | synthetic splat argument | UseUseExplosion.rb:20:2683:20:2688 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2687:20:2687 | x | UseUseExplosion.rb:20:2683:20:2688 | call to use | position 0 |
-| UseUseExplosion.rb:20:2699:20:2704 | * | UseUseExplosion.rb:20:2699:20:2704 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2699:20:2704 | self | UseUseExplosion.rb:20:2699:20:2704 | call to use | self |
+| UseUseExplosion.rb:20:2699:20:2704 | synthetic splat argument | UseUseExplosion.rb:20:2699:20:2704 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2703:20:2703 | x | UseUseExplosion.rb:20:2699:20:2704 | call to use | position 0 |
-| UseUseExplosion.rb:20:2715:20:2720 | * | UseUseExplosion.rb:20:2715:20:2720 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2715:20:2720 | self | UseUseExplosion.rb:20:2715:20:2720 | call to use | self |
+| UseUseExplosion.rb:20:2715:20:2720 | synthetic splat argument | UseUseExplosion.rb:20:2715:20:2720 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2719:20:2719 | x | UseUseExplosion.rb:20:2715:20:2720 | call to use | position 0 |
-| UseUseExplosion.rb:20:2731:20:2736 | * | UseUseExplosion.rb:20:2731:20:2736 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2731:20:2736 | self | UseUseExplosion.rb:20:2731:20:2736 | call to use | self |
+| UseUseExplosion.rb:20:2731:20:2736 | synthetic splat argument | UseUseExplosion.rb:20:2731:20:2736 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2735:20:2735 | x | UseUseExplosion.rb:20:2731:20:2736 | call to use | position 0 |
-| UseUseExplosion.rb:20:2747:20:2752 | * | UseUseExplosion.rb:20:2747:20:2752 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2747:20:2752 | self | UseUseExplosion.rb:20:2747:20:2752 | call to use | self |
+| UseUseExplosion.rb:20:2747:20:2752 | synthetic splat argument | UseUseExplosion.rb:20:2747:20:2752 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2751:20:2751 | x | UseUseExplosion.rb:20:2747:20:2752 | call to use | position 0 |
-| UseUseExplosion.rb:20:2763:20:2768 | * | UseUseExplosion.rb:20:2763:20:2768 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2763:20:2768 | self | UseUseExplosion.rb:20:2763:20:2768 | call to use | self |
+| UseUseExplosion.rb:20:2763:20:2768 | synthetic splat argument | UseUseExplosion.rb:20:2763:20:2768 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2767:20:2767 | x | UseUseExplosion.rb:20:2763:20:2768 | call to use | position 0 |
-| UseUseExplosion.rb:20:2779:20:2784 | * | UseUseExplosion.rb:20:2779:20:2784 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2779:20:2784 | self | UseUseExplosion.rb:20:2779:20:2784 | call to use | self |
+| UseUseExplosion.rb:20:2779:20:2784 | synthetic splat argument | UseUseExplosion.rb:20:2779:20:2784 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2783:20:2783 | x | UseUseExplosion.rb:20:2779:20:2784 | call to use | position 0 |
-| UseUseExplosion.rb:20:2795:20:2800 | * | UseUseExplosion.rb:20:2795:20:2800 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2795:20:2800 | self | UseUseExplosion.rb:20:2795:20:2800 | call to use | self |
+| UseUseExplosion.rb:20:2795:20:2800 | synthetic splat argument | UseUseExplosion.rb:20:2795:20:2800 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2799:20:2799 | x | UseUseExplosion.rb:20:2795:20:2800 | call to use | position 0 |
-| UseUseExplosion.rb:20:2811:20:2816 | * | UseUseExplosion.rb:20:2811:20:2816 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2811:20:2816 | self | UseUseExplosion.rb:20:2811:20:2816 | call to use | self |
+| UseUseExplosion.rb:20:2811:20:2816 | synthetic splat argument | UseUseExplosion.rb:20:2811:20:2816 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2815:20:2815 | x | UseUseExplosion.rb:20:2811:20:2816 | call to use | position 0 |
-| UseUseExplosion.rb:20:2827:20:2832 | * | UseUseExplosion.rb:20:2827:20:2832 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2827:20:2832 | self | UseUseExplosion.rb:20:2827:20:2832 | call to use | self |
+| UseUseExplosion.rb:20:2827:20:2832 | synthetic splat argument | UseUseExplosion.rb:20:2827:20:2832 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2831:20:2831 | x | UseUseExplosion.rb:20:2827:20:2832 | call to use | position 0 |
-| UseUseExplosion.rb:20:2843:20:2848 | * | UseUseExplosion.rb:20:2843:20:2848 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2843:20:2848 | self | UseUseExplosion.rb:20:2843:20:2848 | call to use | self |
+| UseUseExplosion.rb:20:2843:20:2848 | synthetic splat argument | UseUseExplosion.rb:20:2843:20:2848 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2847:20:2847 | x | UseUseExplosion.rb:20:2843:20:2848 | call to use | position 0 |
-| UseUseExplosion.rb:20:2859:20:2864 | * | UseUseExplosion.rb:20:2859:20:2864 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2859:20:2864 | self | UseUseExplosion.rb:20:2859:20:2864 | call to use | self |
+| UseUseExplosion.rb:20:2859:20:2864 | synthetic splat argument | UseUseExplosion.rb:20:2859:20:2864 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2863:20:2863 | x | UseUseExplosion.rb:20:2859:20:2864 | call to use | position 0 |
-| UseUseExplosion.rb:20:2875:20:2880 | * | UseUseExplosion.rb:20:2875:20:2880 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2875:20:2880 | self | UseUseExplosion.rb:20:2875:20:2880 | call to use | self |
+| UseUseExplosion.rb:20:2875:20:2880 | synthetic splat argument | UseUseExplosion.rb:20:2875:20:2880 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2879:20:2879 | x | UseUseExplosion.rb:20:2875:20:2880 | call to use | position 0 |
-| UseUseExplosion.rb:20:2891:20:2896 | * | UseUseExplosion.rb:20:2891:20:2896 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2891:20:2896 | self | UseUseExplosion.rb:20:2891:20:2896 | call to use | self |
+| UseUseExplosion.rb:20:2891:20:2896 | synthetic splat argument | UseUseExplosion.rb:20:2891:20:2896 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2895:20:2895 | x | UseUseExplosion.rb:20:2891:20:2896 | call to use | position 0 |
-| UseUseExplosion.rb:20:2907:20:2912 | * | UseUseExplosion.rb:20:2907:20:2912 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2907:20:2912 | self | UseUseExplosion.rb:20:2907:20:2912 | call to use | self |
+| UseUseExplosion.rb:20:2907:20:2912 | synthetic splat argument | UseUseExplosion.rb:20:2907:20:2912 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2911:20:2911 | x | UseUseExplosion.rb:20:2907:20:2912 | call to use | position 0 |
-| UseUseExplosion.rb:20:2923:20:2928 | * | UseUseExplosion.rb:20:2923:20:2928 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2923:20:2928 | self | UseUseExplosion.rb:20:2923:20:2928 | call to use | self |
+| UseUseExplosion.rb:20:2923:20:2928 | synthetic splat argument | UseUseExplosion.rb:20:2923:20:2928 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2927:20:2927 | x | UseUseExplosion.rb:20:2923:20:2928 | call to use | position 0 |
-| UseUseExplosion.rb:20:2939:20:2944 | * | UseUseExplosion.rb:20:2939:20:2944 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2939:20:2944 | self | UseUseExplosion.rb:20:2939:20:2944 | call to use | self |
+| UseUseExplosion.rb:20:2939:20:2944 | synthetic splat argument | UseUseExplosion.rb:20:2939:20:2944 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2943:20:2943 | x | UseUseExplosion.rb:20:2939:20:2944 | call to use | position 0 |
-| UseUseExplosion.rb:20:2955:20:2960 | * | UseUseExplosion.rb:20:2955:20:2960 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2955:20:2960 | self | UseUseExplosion.rb:20:2955:20:2960 | call to use | self |
+| UseUseExplosion.rb:20:2955:20:2960 | synthetic splat argument | UseUseExplosion.rb:20:2955:20:2960 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2959:20:2959 | x | UseUseExplosion.rb:20:2955:20:2960 | call to use | position 0 |
-| UseUseExplosion.rb:20:2971:20:2976 | * | UseUseExplosion.rb:20:2971:20:2976 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2971:20:2976 | self | UseUseExplosion.rb:20:2971:20:2976 | call to use | self |
+| UseUseExplosion.rb:20:2971:20:2976 | synthetic splat argument | UseUseExplosion.rb:20:2971:20:2976 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2975:20:2975 | x | UseUseExplosion.rb:20:2971:20:2976 | call to use | position 0 |
-| UseUseExplosion.rb:20:2987:20:2992 | * | UseUseExplosion.rb:20:2987:20:2992 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2987:20:2992 | self | UseUseExplosion.rb:20:2987:20:2992 | call to use | self |
+| UseUseExplosion.rb:20:2987:20:2992 | synthetic splat argument | UseUseExplosion.rb:20:2987:20:2992 | call to use | synthetic * |
 | UseUseExplosion.rb:20:2991:20:2991 | x | UseUseExplosion.rb:20:2987:20:2992 | call to use | position 0 |
-| UseUseExplosion.rb:20:3003:20:3008 | * | UseUseExplosion.rb:20:3003:20:3008 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3003:20:3008 | self | UseUseExplosion.rb:20:3003:20:3008 | call to use | self |
+| UseUseExplosion.rb:20:3003:20:3008 | synthetic splat argument | UseUseExplosion.rb:20:3003:20:3008 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3007:20:3007 | x | UseUseExplosion.rb:20:3003:20:3008 | call to use | position 0 |
-| UseUseExplosion.rb:20:3019:20:3024 | * | UseUseExplosion.rb:20:3019:20:3024 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3019:20:3024 | self | UseUseExplosion.rb:20:3019:20:3024 | call to use | self |
+| UseUseExplosion.rb:20:3019:20:3024 | synthetic splat argument | UseUseExplosion.rb:20:3019:20:3024 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3023:20:3023 | x | UseUseExplosion.rb:20:3019:20:3024 | call to use | position 0 |
-| UseUseExplosion.rb:20:3035:20:3040 | * | UseUseExplosion.rb:20:3035:20:3040 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3035:20:3040 | self | UseUseExplosion.rb:20:3035:20:3040 | call to use | self |
+| UseUseExplosion.rb:20:3035:20:3040 | synthetic splat argument | UseUseExplosion.rb:20:3035:20:3040 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3039:20:3039 | x | UseUseExplosion.rb:20:3035:20:3040 | call to use | position 0 |
-| UseUseExplosion.rb:20:3051:20:3056 | * | UseUseExplosion.rb:20:3051:20:3056 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3051:20:3056 | self | UseUseExplosion.rb:20:3051:20:3056 | call to use | self |
+| UseUseExplosion.rb:20:3051:20:3056 | synthetic splat argument | UseUseExplosion.rb:20:3051:20:3056 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3055:20:3055 | x | UseUseExplosion.rb:20:3051:20:3056 | call to use | position 0 |
-| UseUseExplosion.rb:20:3067:20:3072 | * | UseUseExplosion.rb:20:3067:20:3072 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3067:20:3072 | self | UseUseExplosion.rb:20:3067:20:3072 | call to use | self |
+| UseUseExplosion.rb:20:3067:20:3072 | synthetic splat argument | UseUseExplosion.rb:20:3067:20:3072 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3071:20:3071 | x | UseUseExplosion.rb:20:3067:20:3072 | call to use | position 0 |
-| UseUseExplosion.rb:20:3083:20:3088 | * | UseUseExplosion.rb:20:3083:20:3088 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3083:20:3088 | self | UseUseExplosion.rb:20:3083:20:3088 | call to use | self |
+| UseUseExplosion.rb:20:3083:20:3088 | synthetic splat argument | UseUseExplosion.rb:20:3083:20:3088 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3087:20:3087 | x | UseUseExplosion.rb:20:3083:20:3088 | call to use | position 0 |
-| UseUseExplosion.rb:20:3099:20:3104 | * | UseUseExplosion.rb:20:3099:20:3104 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3099:20:3104 | self | UseUseExplosion.rb:20:3099:20:3104 | call to use | self |
+| UseUseExplosion.rb:20:3099:20:3104 | synthetic splat argument | UseUseExplosion.rb:20:3099:20:3104 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3103:20:3103 | x | UseUseExplosion.rb:20:3099:20:3104 | call to use | position 0 |
-| UseUseExplosion.rb:20:3115:20:3120 | * | UseUseExplosion.rb:20:3115:20:3120 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3115:20:3120 | self | UseUseExplosion.rb:20:3115:20:3120 | call to use | self |
+| UseUseExplosion.rb:20:3115:20:3120 | synthetic splat argument | UseUseExplosion.rb:20:3115:20:3120 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3119:20:3119 | x | UseUseExplosion.rb:20:3115:20:3120 | call to use | position 0 |
-| UseUseExplosion.rb:20:3131:20:3136 | * | UseUseExplosion.rb:20:3131:20:3136 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3131:20:3136 | self | UseUseExplosion.rb:20:3131:20:3136 | call to use | self |
+| UseUseExplosion.rb:20:3131:20:3136 | synthetic splat argument | UseUseExplosion.rb:20:3131:20:3136 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3135:20:3135 | x | UseUseExplosion.rb:20:3131:20:3136 | call to use | position 0 |
-| UseUseExplosion.rb:20:3147:20:3152 | * | UseUseExplosion.rb:20:3147:20:3152 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3147:20:3152 | self | UseUseExplosion.rb:20:3147:20:3152 | call to use | self |
+| UseUseExplosion.rb:20:3147:20:3152 | synthetic splat argument | UseUseExplosion.rb:20:3147:20:3152 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3151:20:3151 | x | UseUseExplosion.rb:20:3147:20:3152 | call to use | position 0 |
-| UseUseExplosion.rb:20:3163:20:3168 | * | UseUseExplosion.rb:20:3163:20:3168 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3163:20:3168 | self | UseUseExplosion.rb:20:3163:20:3168 | call to use | self |
+| UseUseExplosion.rb:20:3163:20:3168 | synthetic splat argument | UseUseExplosion.rb:20:3163:20:3168 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3167:20:3167 | x | UseUseExplosion.rb:20:3163:20:3168 | call to use | position 0 |
-| UseUseExplosion.rb:20:3179:20:3184 | * | UseUseExplosion.rb:20:3179:20:3184 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3179:20:3184 | self | UseUseExplosion.rb:20:3179:20:3184 | call to use | self |
+| UseUseExplosion.rb:20:3179:20:3184 | synthetic splat argument | UseUseExplosion.rb:20:3179:20:3184 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3183:20:3183 | x | UseUseExplosion.rb:20:3179:20:3184 | call to use | position 0 |
-| UseUseExplosion.rb:20:3195:20:3200 | * | UseUseExplosion.rb:20:3195:20:3200 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3195:20:3200 | self | UseUseExplosion.rb:20:3195:20:3200 | call to use | self |
+| UseUseExplosion.rb:20:3195:20:3200 | synthetic splat argument | UseUseExplosion.rb:20:3195:20:3200 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3199:20:3199 | x | UseUseExplosion.rb:20:3195:20:3200 | call to use | position 0 |
-| UseUseExplosion.rb:20:3211:20:3216 | * | UseUseExplosion.rb:20:3211:20:3216 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3211:20:3216 | self | UseUseExplosion.rb:20:3211:20:3216 | call to use | self |
+| UseUseExplosion.rb:20:3211:20:3216 | synthetic splat argument | UseUseExplosion.rb:20:3211:20:3216 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3215:20:3215 | x | UseUseExplosion.rb:20:3211:20:3216 | call to use | position 0 |
-| UseUseExplosion.rb:20:3227:20:3232 | * | UseUseExplosion.rb:20:3227:20:3232 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3227:20:3232 | self | UseUseExplosion.rb:20:3227:20:3232 | call to use | self |
+| UseUseExplosion.rb:20:3227:20:3232 | synthetic splat argument | UseUseExplosion.rb:20:3227:20:3232 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3231:20:3231 | x | UseUseExplosion.rb:20:3227:20:3232 | call to use | position 0 |
-| UseUseExplosion.rb:20:3243:20:3248 | * | UseUseExplosion.rb:20:3243:20:3248 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3243:20:3248 | self | UseUseExplosion.rb:20:3243:20:3248 | call to use | self |
+| UseUseExplosion.rb:20:3243:20:3248 | synthetic splat argument | UseUseExplosion.rb:20:3243:20:3248 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3247:20:3247 | x | UseUseExplosion.rb:20:3243:20:3248 | call to use | position 0 |
-| UseUseExplosion.rb:20:3259:20:3264 | * | UseUseExplosion.rb:20:3259:20:3264 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3259:20:3264 | self | UseUseExplosion.rb:20:3259:20:3264 | call to use | self |
+| UseUseExplosion.rb:20:3259:20:3264 | synthetic splat argument | UseUseExplosion.rb:20:3259:20:3264 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3263:20:3263 | x | UseUseExplosion.rb:20:3259:20:3264 | call to use | position 0 |
-| UseUseExplosion.rb:20:3275:20:3280 | * | UseUseExplosion.rb:20:3275:20:3280 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3275:20:3280 | self | UseUseExplosion.rb:20:3275:20:3280 | call to use | self |
+| UseUseExplosion.rb:20:3275:20:3280 | synthetic splat argument | UseUseExplosion.rb:20:3275:20:3280 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3279:20:3279 | x | UseUseExplosion.rb:20:3275:20:3280 | call to use | position 0 |
-| UseUseExplosion.rb:20:3291:20:3296 | * | UseUseExplosion.rb:20:3291:20:3296 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3291:20:3296 | self | UseUseExplosion.rb:20:3291:20:3296 | call to use | self |
+| UseUseExplosion.rb:20:3291:20:3296 | synthetic splat argument | UseUseExplosion.rb:20:3291:20:3296 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3295:20:3295 | x | UseUseExplosion.rb:20:3291:20:3296 | call to use | position 0 |
-| UseUseExplosion.rb:20:3307:20:3312 | * | UseUseExplosion.rb:20:3307:20:3312 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3307:20:3312 | self | UseUseExplosion.rb:20:3307:20:3312 | call to use | self |
+| UseUseExplosion.rb:20:3307:20:3312 | synthetic splat argument | UseUseExplosion.rb:20:3307:20:3312 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3311:20:3311 | x | UseUseExplosion.rb:20:3307:20:3312 | call to use | position 0 |
-| UseUseExplosion.rb:20:3323:20:3328 | * | UseUseExplosion.rb:20:3323:20:3328 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3323:20:3328 | self | UseUseExplosion.rb:20:3323:20:3328 | call to use | self |
+| UseUseExplosion.rb:20:3323:20:3328 | synthetic splat argument | UseUseExplosion.rb:20:3323:20:3328 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3327:20:3327 | x | UseUseExplosion.rb:20:3323:20:3328 | call to use | position 0 |
-| UseUseExplosion.rb:20:3339:20:3344 | * | UseUseExplosion.rb:20:3339:20:3344 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3339:20:3344 | self | UseUseExplosion.rb:20:3339:20:3344 | call to use | self |
+| UseUseExplosion.rb:20:3339:20:3344 | synthetic splat argument | UseUseExplosion.rb:20:3339:20:3344 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3343:20:3343 | x | UseUseExplosion.rb:20:3339:20:3344 | call to use | position 0 |
-| UseUseExplosion.rb:20:3355:20:3360 | * | UseUseExplosion.rb:20:3355:20:3360 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3355:20:3360 | self | UseUseExplosion.rb:20:3355:20:3360 | call to use | self |
+| UseUseExplosion.rb:20:3355:20:3360 | synthetic splat argument | UseUseExplosion.rb:20:3355:20:3360 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3359:20:3359 | x | UseUseExplosion.rb:20:3355:20:3360 | call to use | position 0 |
-| UseUseExplosion.rb:20:3371:20:3376 | * | UseUseExplosion.rb:20:3371:20:3376 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3371:20:3376 | self | UseUseExplosion.rb:20:3371:20:3376 | call to use | self |
+| UseUseExplosion.rb:20:3371:20:3376 | synthetic splat argument | UseUseExplosion.rb:20:3371:20:3376 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3375:20:3375 | x | UseUseExplosion.rb:20:3371:20:3376 | call to use | position 0 |
-| UseUseExplosion.rb:20:3387:20:3392 | * | UseUseExplosion.rb:20:3387:20:3392 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3387:20:3392 | self | UseUseExplosion.rb:20:3387:20:3392 | call to use | self |
+| UseUseExplosion.rb:20:3387:20:3392 | synthetic splat argument | UseUseExplosion.rb:20:3387:20:3392 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3391:20:3391 | x | UseUseExplosion.rb:20:3387:20:3392 | call to use | position 0 |
-| UseUseExplosion.rb:20:3403:20:3408 | * | UseUseExplosion.rb:20:3403:20:3408 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3403:20:3408 | self | UseUseExplosion.rb:20:3403:20:3408 | call to use | self |
+| UseUseExplosion.rb:20:3403:20:3408 | synthetic splat argument | UseUseExplosion.rb:20:3403:20:3408 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3407:20:3407 | x | UseUseExplosion.rb:20:3403:20:3408 | call to use | position 0 |
-| UseUseExplosion.rb:20:3419:20:3424 | * | UseUseExplosion.rb:20:3419:20:3424 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3419:20:3424 | self | UseUseExplosion.rb:20:3419:20:3424 | call to use | self |
+| UseUseExplosion.rb:20:3419:20:3424 | synthetic splat argument | UseUseExplosion.rb:20:3419:20:3424 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3423:20:3423 | x | UseUseExplosion.rb:20:3419:20:3424 | call to use | position 0 |
-| UseUseExplosion.rb:20:3435:20:3440 | * | UseUseExplosion.rb:20:3435:20:3440 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3435:20:3440 | self | UseUseExplosion.rb:20:3435:20:3440 | call to use | self |
+| UseUseExplosion.rb:20:3435:20:3440 | synthetic splat argument | UseUseExplosion.rb:20:3435:20:3440 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3439:20:3439 | x | UseUseExplosion.rb:20:3435:20:3440 | call to use | position 0 |
-| UseUseExplosion.rb:20:3451:20:3456 | * | UseUseExplosion.rb:20:3451:20:3456 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3451:20:3456 | self | UseUseExplosion.rb:20:3451:20:3456 | call to use | self |
+| UseUseExplosion.rb:20:3451:20:3456 | synthetic splat argument | UseUseExplosion.rb:20:3451:20:3456 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3455:20:3455 | x | UseUseExplosion.rb:20:3451:20:3456 | call to use | position 0 |
-| UseUseExplosion.rb:20:3467:20:3472 | * | UseUseExplosion.rb:20:3467:20:3472 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3467:20:3472 | self | UseUseExplosion.rb:20:3467:20:3472 | call to use | self |
+| UseUseExplosion.rb:20:3467:20:3472 | synthetic splat argument | UseUseExplosion.rb:20:3467:20:3472 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3471:20:3471 | x | UseUseExplosion.rb:20:3467:20:3472 | call to use | position 0 |
-| UseUseExplosion.rb:20:3483:20:3488 | * | UseUseExplosion.rb:20:3483:20:3488 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3483:20:3488 | self | UseUseExplosion.rb:20:3483:20:3488 | call to use | self |
+| UseUseExplosion.rb:20:3483:20:3488 | synthetic splat argument | UseUseExplosion.rb:20:3483:20:3488 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3487:20:3487 | x | UseUseExplosion.rb:20:3483:20:3488 | call to use | position 0 |
-| UseUseExplosion.rb:20:3499:20:3504 | * | UseUseExplosion.rb:20:3499:20:3504 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3499:20:3504 | self | UseUseExplosion.rb:20:3499:20:3504 | call to use | self |
+| UseUseExplosion.rb:20:3499:20:3504 | synthetic splat argument | UseUseExplosion.rb:20:3499:20:3504 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3503:20:3503 | x | UseUseExplosion.rb:20:3499:20:3504 | call to use | position 0 |
-| UseUseExplosion.rb:20:3515:20:3520 | * | UseUseExplosion.rb:20:3515:20:3520 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3515:20:3520 | self | UseUseExplosion.rb:20:3515:20:3520 | call to use | self |
+| UseUseExplosion.rb:20:3515:20:3520 | synthetic splat argument | UseUseExplosion.rb:20:3515:20:3520 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3519:20:3519 | x | UseUseExplosion.rb:20:3515:20:3520 | call to use | position 0 |
-| UseUseExplosion.rb:20:3531:20:3536 | * | UseUseExplosion.rb:20:3531:20:3536 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3531:20:3536 | self | UseUseExplosion.rb:20:3531:20:3536 | call to use | self |
+| UseUseExplosion.rb:20:3531:20:3536 | synthetic splat argument | UseUseExplosion.rb:20:3531:20:3536 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3535:20:3535 | x | UseUseExplosion.rb:20:3531:20:3536 | call to use | position 0 |
-| UseUseExplosion.rb:20:3547:20:3552 | * | UseUseExplosion.rb:20:3547:20:3552 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3547:20:3552 | self | UseUseExplosion.rb:20:3547:20:3552 | call to use | self |
+| UseUseExplosion.rb:20:3547:20:3552 | synthetic splat argument | UseUseExplosion.rb:20:3547:20:3552 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3551:20:3551 | x | UseUseExplosion.rb:20:3547:20:3552 | call to use | position 0 |
-| UseUseExplosion.rb:20:3563:20:3568 | * | UseUseExplosion.rb:20:3563:20:3568 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3563:20:3568 | self | UseUseExplosion.rb:20:3563:20:3568 | call to use | self |
+| UseUseExplosion.rb:20:3563:20:3568 | synthetic splat argument | UseUseExplosion.rb:20:3563:20:3568 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3567:20:3567 | x | UseUseExplosion.rb:20:3563:20:3568 | call to use | position 0 |
-| UseUseExplosion.rb:20:3579:20:3584 | * | UseUseExplosion.rb:20:3579:20:3584 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3579:20:3584 | self | UseUseExplosion.rb:20:3579:20:3584 | call to use | self |
+| UseUseExplosion.rb:20:3579:20:3584 | synthetic splat argument | UseUseExplosion.rb:20:3579:20:3584 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3583:20:3583 | x | UseUseExplosion.rb:20:3579:20:3584 | call to use | position 0 |
-| UseUseExplosion.rb:20:3595:20:3600 | * | UseUseExplosion.rb:20:3595:20:3600 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3595:20:3600 | self | UseUseExplosion.rb:20:3595:20:3600 | call to use | self |
+| UseUseExplosion.rb:20:3595:20:3600 | synthetic splat argument | UseUseExplosion.rb:20:3595:20:3600 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3599:20:3599 | x | UseUseExplosion.rb:20:3595:20:3600 | call to use | position 0 |
-| UseUseExplosion.rb:20:3611:20:3616 | * | UseUseExplosion.rb:20:3611:20:3616 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3611:20:3616 | self | UseUseExplosion.rb:20:3611:20:3616 | call to use | self |
+| UseUseExplosion.rb:20:3611:20:3616 | synthetic splat argument | UseUseExplosion.rb:20:3611:20:3616 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3615:20:3615 | x | UseUseExplosion.rb:20:3611:20:3616 | call to use | position 0 |
-| UseUseExplosion.rb:20:3627:20:3632 | * | UseUseExplosion.rb:20:3627:20:3632 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3627:20:3632 | self | UseUseExplosion.rb:20:3627:20:3632 | call to use | self |
+| UseUseExplosion.rb:20:3627:20:3632 | synthetic splat argument | UseUseExplosion.rb:20:3627:20:3632 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3631:20:3631 | x | UseUseExplosion.rb:20:3627:20:3632 | call to use | position 0 |
-| UseUseExplosion.rb:20:3643:20:3648 | * | UseUseExplosion.rb:20:3643:20:3648 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3643:20:3648 | self | UseUseExplosion.rb:20:3643:20:3648 | call to use | self |
+| UseUseExplosion.rb:20:3643:20:3648 | synthetic splat argument | UseUseExplosion.rb:20:3643:20:3648 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3647:20:3647 | x | UseUseExplosion.rb:20:3643:20:3648 | call to use | position 0 |
-| UseUseExplosion.rb:20:3659:20:3664 | * | UseUseExplosion.rb:20:3659:20:3664 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3659:20:3664 | self | UseUseExplosion.rb:20:3659:20:3664 | call to use | self |
+| UseUseExplosion.rb:20:3659:20:3664 | synthetic splat argument | UseUseExplosion.rb:20:3659:20:3664 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3663:20:3663 | x | UseUseExplosion.rb:20:3659:20:3664 | call to use | position 0 |
-| UseUseExplosion.rb:20:3675:20:3680 | * | UseUseExplosion.rb:20:3675:20:3680 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3675:20:3680 | self | UseUseExplosion.rb:20:3675:20:3680 | call to use | self |
+| UseUseExplosion.rb:20:3675:20:3680 | synthetic splat argument | UseUseExplosion.rb:20:3675:20:3680 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3679:20:3679 | x | UseUseExplosion.rb:20:3675:20:3680 | call to use | position 0 |
-| UseUseExplosion.rb:20:3691:20:3696 | * | UseUseExplosion.rb:20:3691:20:3696 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3691:20:3696 | self | UseUseExplosion.rb:20:3691:20:3696 | call to use | self |
+| UseUseExplosion.rb:20:3691:20:3696 | synthetic splat argument | UseUseExplosion.rb:20:3691:20:3696 | call to use | synthetic * |
 | UseUseExplosion.rb:20:3695:20:3695 | x | UseUseExplosion.rb:20:3691:20:3696 | call to use | position 0 |
 | UseUseExplosion.rb:21:13:21:17 | @prop | UseUseExplosion.rb:21:13:21:23 | ... > ... | self |
-| UseUseExplosion.rb:21:13:21:23 | * | UseUseExplosion.rb:21:13:21:23 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:13:21:23 | synthetic splat argument | UseUseExplosion.rb:21:13:21:23 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:21:21:23 | 100 | UseUseExplosion.rb:21:13:21:23 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:35:21:39 | @prop | UseUseExplosion.rb:21:35:21:44 | ... > ... | self |
-| UseUseExplosion.rb:21:35:21:44 | * | UseUseExplosion.rb:21:35:21:44 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:35:21:44 | synthetic splat argument | UseUseExplosion.rb:21:35:21:44 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:43:21:44 | 99 | UseUseExplosion.rb:21:35:21:44 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:56:21:60 | @prop | UseUseExplosion.rb:21:56:21:65 | ... > ... | self |
-| UseUseExplosion.rb:21:56:21:65 | * | UseUseExplosion.rb:21:56:21:65 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:56:21:65 | synthetic splat argument | UseUseExplosion.rb:21:56:21:65 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:64:21:65 | 98 | UseUseExplosion.rb:21:56:21:65 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:77:21:81 | @prop | UseUseExplosion.rb:21:77:21:86 | ... > ... | self |
-| UseUseExplosion.rb:21:77:21:86 | * | UseUseExplosion.rb:21:77:21:86 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:77:21:86 | synthetic splat argument | UseUseExplosion.rb:21:77:21:86 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:85:21:86 | 97 | UseUseExplosion.rb:21:77:21:86 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:98:21:102 | @prop | UseUseExplosion.rb:21:98:21:107 | ... > ... | self |
-| UseUseExplosion.rb:21:98:21:107 | * | UseUseExplosion.rb:21:98:21:107 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:98:21:107 | synthetic splat argument | UseUseExplosion.rb:21:98:21:107 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:106:21:107 | 96 | UseUseExplosion.rb:21:98:21:107 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:119:21:123 | @prop | UseUseExplosion.rb:21:119:21:128 | ... > ... | self |
-| UseUseExplosion.rb:21:119:21:128 | * | UseUseExplosion.rb:21:119:21:128 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:119:21:128 | synthetic splat argument | UseUseExplosion.rb:21:119:21:128 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:127:21:128 | 95 | UseUseExplosion.rb:21:119:21:128 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:140:21:144 | @prop | UseUseExplosion.rb:21:140:21:149 | ... > ... | self |
-| UseUseExplosion.rb:21:140:21:149 | * | UseUseExplosion.rb:21:140:21:149 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:140:21:149 | synthetic splat argument | UseUseExplosion.rb:21:140:21:149 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:148:21:149 | 94 | UseUseExplosion.rb:21:140:21:149 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:161:21:165 | @prop | UseUseExplosion.rb:21:161:21:170 | ... > ... | self |
-| UseUseExplosion.rb:21:161:21:170 | * | UseUseExplosion.rb:21:161:21:170 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:161:21:170 | synthetic splat argument | UseUseExplosion.rb:21:161:21:170 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:169:21:170 | 93 | UseUseExplosion.rb:21:161:21:170 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:182:21:186 | @prop | UseUseExplosion.rb:21:182:21:191 | ... > ... | self |
-| UseUseExplosion.rb:21:182:21:191 | * | UseUseExplosion.rb:21:182:21:191 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:182:21:191 | synthetic splat argument | UseUseExplosion.rb:21:182:21:191 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:190:21:191 | 92 | UseUseExplosion.rb:21:182:21:191 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:203:21:207 | @prop | UseUseExplosion.rb:21:203:21:212 | ... > ... | self |
-| UseUseExplosion.rb:21:203:21:212 | * | UseUseExplosion.rb:21:203:21:212 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:203:21:212 | synthetic splat argument | UseUseExplosion.rb:21:203:21:212 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:211:21:212 | 91 | UseUseExplosion.rb:21:203:21:212 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:224:21:228 | @prop | UseUseExplosion.rb:21:224:21:233 | ... > ... | self |
-| UseUseExplosion.rb:21:224:21:233 | * | UseUseExplosion.rb:21:224:21:233 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:224:21:233 | synthetic splat argument | UseUseExplosion.rb:21:224:21:233 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:232:21:233 | 90 | UseUseExplosion.rb:21:224:21:233 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:245:21:249 | @prop | UseUseExplosion.rb:21:245:21:254 | ... > ... | self |
-| UseUseExplosion.rb:21:245:21:254 | * | UseUseExplosion.rb:21:245:21:254 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:245:21:254 | synthetic splat argument | UseUseExplosion.rb:21:245:21:254 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:253:21:254 | 89 | UseUseExplosion.rb:21:245:21:254 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:266:21:270 | @prop | UseUseExplosion.rb:21:266:21:275 | ... > ... | self |
-| UseUseExplosion.rb:21:266:21:275 | * | UseUseExplosion.rb:21:266:21:275 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:266:21:275 | synthetic splat argument | UseUseExplosion.rb:21:266:21:275 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:274:21:275 | 88 | UseUseExplosion.rb:21:266:21:275 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:287:21:291 | @prop | UseUseExplosion.rb:21:287:21:296 | ... > ... | self |
-| UseUseExplosion.rb:21:287:21:296 | * | UseUseExplosion.rb:21:287:21:296 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:287:21:296 | synthetic splat argument | UseUseExplosion.rb:21:287:21:296 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:295:21:296 | 87 | UseUseExplosion.rb:21:287:21:296 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:308:21:312 | @prop | UseUseExplosion.rb:21:308:21:317 | ... > ... | self |
-| UseUseExplosion.rb:21:308:21:317 | * | UseUseExplosion.rb:21:308:21:317 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:308:21:317 | synthetic splat argument | UseUseExplosion.rb:21:308:21:317 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:316:21:317 | 86 | UseUseExplosion.rb:21:308:21:317 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:329:21:333 | @prop | UseUseExplosion.rb:21:329:21:338 | ... > ... | self |
-| UseUseExplosion.rb:21:329:21:338 | * | UseUseExplosion.rb:21:329:21:338 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:329:21:338 | synthetic splat argument | UseUseExplosion.rb:21:329:21:338 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:337:21:338 | 85 | UseUseExplosion.rb:21:329:21:338 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:350:21:354 | @prop | UseUseExplosion.rb:21:350:21:359 | ... > ... | self |
-| UseUseExplosion.rb:21:350:21:359 | * | UseUseExplosion.rb:21:350:21:359 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:350:21:359 | synthetic splat argument | UseUseExplosion.rb:21:350:21:359 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:358:21:359 | 84 | UseUseExplosion.rb:21:350:21:359 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:371:21:375 | @prop | UseUseExplosion.rb:21:371:21:380 | ... > ... | self |
-| UseUseExplosion.rb:21:371:21:380 | * | UseUseExplosion.rb:21:371:21:380 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:371:21:380 | synthetic splat argument | UseUseExplosion.rb:21:371:21:380 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:379:21:380 | 83 | UseUseExplosion.rb:21:371:21:380 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:392:21:396 | @prop | UseUseExplosion.rb:21:392:21:401 | ... > ... | self |
-| UseUseExplosion.rb:21:392:21:401 | * | UseUseExplosion.rb:21:392:21:401 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:392:21:401 | synthetic splat argument | UseUseExplosion.rb:21:392:21:401 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:400:21:401 | 82 | UseUseExplosion.rb:21:392:21:401 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:413:21:417 | @prop | UseUseExplosion.rb:21:413:21:422 | ... > ... | self |
-| UseUseExplosion.rb:21:413:21:422 | * | UseUseExplosion.rb:21:413:21:422 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:413:21:422 | synthetic splat argument | UseUseExplosion.rb:21:413:21:422 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:421:21:422 | 81 | UseUseExplosion.rb:21:413:21:422 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:434:21:438 | @prop | UseUseExplosion.rb:21:434:21:443 | ... > ... | self |
-| UseUseExplosion.rb:21:434:21:443 | * | UseUseExplosion.rb:21:434:21:443 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:434:21:443 | synthetic splat argument | UseUseExplosion.rb:21:434:21:443 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:442:21:443 | 80 | UseUseExplosion.rb:21:434:21:443 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:455:21:459 | @prop | UseUseExplosion.rb:21:455:21:464 | ... > ... | self |
-| UseUseExplosion.rb:21:455:21:464 | * | UseUseExplosion.rb:21:455:21:464 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:455:21:464 | synthetic splat argument | UseUseExplosion.rb:21:455:21:464 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:463:21:464 | 79 | UseUseExplosion.rb:21:455:21:464 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:476:21:480 | @prop | UseUseExplosion.rb:21:476:21:485 | ... > ... | self |
-| UseUseExplosion.rb:21:476:21:485 | * | UseUseExplosion.rb:21:476:21:485 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:476:21:485 | synthetic splat argument | UseUseExplosion.rb:21:476:21:485 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:484:21:485 | 78 | UseUseExplosion.rb:21:476:21:485 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:497:21:501 | @prop | UseUseExplosion.rb:21:497:21:506 | ... > ... | self |
-| UseUseExplosion.rb:21:497:21:506 | * | UseUseExplosion.rb:21:497:21:506 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:497:21:506 | synthetic splat argument | UseUseExplosion.rb:21:497:21:506 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:505:21:506 | 77 | UseUseExplosion.rb:21:497:21:506 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:518:21:522 | @prop | UseUseExplosion.rb:21:518:21:527 | ... > ... | self |
-| UseUseExplosion.rb:21:518:21:527 | * | UseUseExplosion.rb:21:518:21:527 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:518:21:527 | synthetic splat argument | UseUseExplosion.rb:21:518:21:527 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:526:21:527 | 76 | UseUseExplosion.rb:21:518:21:527 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:539:21:543 | @prop | UseUseExplosion.rb:21:539:21:548 | ... > ... | self |
-| UseUseExplosion.rb:21:539:21:548 | * | UseUseExplosion.rb:21:539:21:548 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:539:21:548 | synthetic splat argument | UseUseExplosion.rb:21:539:21:548 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:547:21:548 | 75 | UseUseExplosion.rb:21:539:21:548 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:560:21:564 | @prop | UseUseExplosion.rb:21:560:21:569 | ... > ... | self |
-| UseUseExplosion.rb:21:560:21:569 | * | UseUseExplosion.rb:21:560:21:569 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:560:21:569 | synthetic splat argument | UseUseExplosion.rb:21:560:21:569 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:568:21:569 | 74 | UseUseExplosion.rb:21:560:21:569 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:581:21:585 | @prop | UseUseExplosion.rb:21:581:21:590 | ... > ... | self |
-| UseUseExplosion.rb:21:581:21:590 | * | UseUseExplosion.rb:21:581:21:590 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:581:21:590 | synthetic splat argument | UseUseExplosion.rb:21:581:21:590 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:589:21:590 | 73 | UseUseExplosion.rb:21:581:21:590 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:602:21:606 | @prop | UseUseExplosion.rb:21:602:21:611 | ... > ... | self |
-| UseUseExplosion.rb:21:602:21:611 | * | UseUseExplosion.rb:21:602:21:611 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:602:21:611 | synthetic splat argument | UseUseExplosion.rb:21:602:21:611 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:610:21:611 | 72 | UseUseExplosion.rb:21:602:21:611 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:623:21:627 | @prop | UseUseExplosion.rb:21:623:21:632 | ... > ... | self |
-| UseUseExplosion.rb:21:623:21:632 | * | UseUseExplosion.rb:21:623:21:632 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:623:21:632 | synthetic splat argument | UseUseExplosion.rb:21:623:21:632 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:631:21:632 | 71 | UseUseExplosion.rb:21:623:21:632 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:644:21:648 | @prop | UseUseExplosion.rb:21:644:21:653 | ... > ... | self |
-| UseUseExplosion.rb:21:644:21:653 | * | UseUseExplosion.rb:21:644:21:653 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:644:21:653 | synthetic splat argument | UseUseExplosion.rb:21:644:21:653 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:652:21:653 | 70 | UseUseExplosion.rb:21:644:21:653 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:665:21:669 | @prop | UseUseExplosion.rb:21:665:21:674 | ... > ... | self |
-| UseUseExplosion.rb:21:665:21:674 | * | UseUseExplosion.rb:21:665:21:674 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:665:21:674 | synthetic splat argument | UseUseExplosion.rb:21:665:21:674 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:673:21:674 | 69 | UseUseExplosion.rb:21:665:21:674 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:686:21:690 | @prop | UseUseExplosion.rb:21:686:21:695 | ... > ... | self |
-| UseUseExplosion.rb:21:686:21:695 | * | UseUseExplosion.rb:21:686:21:695 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:686:21:695 | synthetic splat argument | UseUseExplosion.rb:21:686:21:695 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:694:21:695 | 68 | UseUseExplosion.rb:21:686:21:695 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:707:21:711 | @prop | UseUseExplosion.rb:21:707:21:716 | ... > ... | self |
-| UseUseExplosion.rb:21:707:21:716 | * | UseUseExplosion.rb:21:707:21:716 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:707:21:716 | synthetic splat argument | UseUseExplosion.rb:21:707:21:716 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:715:21:716 | 67 | UseUseExplosion.rb:21:707:21:716 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:728:21:732 | @prop | UseUseExplosion.rb:21:728:21:737 | ... > ... | self |
-| UseUseExplosion.rb:21:728:21:737 | * | UseUseExplosion.rb:21:728:21:737 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:728:21:737 | synthetic splat argument | UseUseExplosion.rb:21:728:21:737 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:736:21:737 | 66 | UseUseExplosion.rb:21:728:21:737 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:749:21:753 | @prop | UseUseExplosion.rb:21:749:21:758 | ... > ... | self |
-| UseUseExplosion.rb:21:749:21:758 | * | UseUseExplosion.rb:21:749:21:758 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:749:21:758 | synthetic splat argument | UseUseExplosion.rb:21:749:21:758 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:757:21:758 | 65 | UseUseExplosion.rb:21:749:21:758 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:770:21:774 | @prop | UseUseExplosion.rb:21:770:21:779 | ... > ... | self |
-| UseUseExplosion.rb:21:770:21:779 | * | UseUseExplosion.rb:21:770:21:779 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:770:21:779 | synthetic splat argument | UseUseExplosion.rb:21:770:21:779 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:778:21:779 | 64 | UseUseExplosion.rb:21:770:21:779 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:791:21:795 | @prop | UseUseExplosion.rb:21:791:21:800 | ... > ... | self |
-| UseUseExplosion.rb:21:791:21:800 | * | UseUseExplosion.rb:21:791:21:800 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:791:21:800 | synthetic splat argument | UseUseExplosion.rb:21:791:21:800 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:799:21:800 | 63 | UseUseExplosion.rb:21:791:21:800 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:812:21:816 | @prop | UseUseExplosion.rb:21:812:21:821 | ... > ... | self |
-| UseUseExplosion.rb:21:812:21:821 | * | UseUseExplosion.rb:21:812:21:821 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:812:21:821 | synthetic splat argument | UseUseExplosion.rb:21:812:21:821 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:820:21:821 | 62 | UseUseExplosion.rb:21:812:21:821 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:833:21:837 | @prop | UseUseExplosion.rb:21:833:21:842 | ... > ... | self |
-| UseUseExplosion.rb:21:833:21:842 | * | UseUseExplosion.rb:21:833:21:842 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:833:21:842 | synthetic splat argument | UseUseExplosion.rb:21:833:21:842 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:841:21:842 | 61 | UseUseExplosion.rb:21:833:21:842 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:854:21:858 | @prop | UseUseExplosion.rb:21:854:21:863 | ... > ... | self |
-| UseUseExplosion.rb:21:854:21:863 | * | UseUseExplosion.rb:21:854:21:863 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:854:21:863 | synthetic splat argument | UseUseExplosion.rb:21:854:21:863 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:862:21:863 | 60 | UseUseExplosion.rb:21:854:21:863 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:875:21:879 | @prop | UseUseExplosion.rb:21:875:21:884 | ... > ... | self |
-| UseUseExplosion.rb:21:875:21:884 | * | UseUseExplosion.rb:21:875:21:884 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:875:21:884 | synthetic splat argument | UseUseExplosion.rb:21:875:21:884 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:883:21:884 | 59 | UseUseExplosion.rb:21:875:21:884 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:896:21:900 | @prop | UseUseExplosion.rb:21:896:21:905 | ... > ... | self |
-| UseUseExplosion.rb:21:896:21:905 | * | UseUseExplosion.rb:21:896:21:905 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:896:21:905 | synthetic splat argument | UseUseExplosion.rb:21:896:21:905 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:904:21:905 | 58 | UseUseExplosion.rb:21:896:21:905 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:917:21:921 | @prop | UseUseExplosion.rb:21:917:21:926 | ... > ... | self |
-| UseUseExplosion.rb:21:917:21:926 | * | UseUseExplosion.rb:21:917:21:926 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:917:21:926 | synthetic splat argument | UseUseExplosion.rb:21:917:21:926 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:925:21:926 | 57 | UseUseExplosion.rb:21:917:21:926 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:938:21:942 | @prop | UseUseExplosion.rb:21:938:21:947 | ... > ... | self |
-| UseUseExplosion.rb:21:938:21:947 | * | UseUseExplosion.rb:21:938:21:947 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:938:21:947 | synthetic splat argument | UseUseExplosion.rb:21:938:21:947 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:946:21:947 | 56 | UseUseExplosion.rb:21:938:21:947 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:959:21:963 | @prop | UseUseExplosion.rb:21:959:21:968 | ... > ... | self |
-| UseUseExplosion.rb:21:959:21:968 | * | UseUseExplosion.rb:21:959:21:968 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:959:21:968 | synthetic splat argument | UseUseExplosion.rb:21:959:21:968 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:967:21:968 | 55 | UseUseExplosion.rb:21:959:21:968 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:980:21:984 | @prop | UseUseExplosion.rb:21:980:21:989 | ... > ... | self |
-| UseUseExplosion.rb:21:980:21:989 | * | UseUseExplosion.rb:21:980:21:989 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:980:21:989 | synthetic splat argument | UseUseExplosion.rb:21:980:21:989 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:988:21:989 | 54 | UseUseExplosion.rb:21:980:21:989 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1001:21:1005 | @prop | UseUseExplosion.rb:21:1001:21:1010 | ... > ... | self |
-| UseUseExplosion.rb:21:1001:21:1010 | * | UseUseExplosion.rb:21:1001:21:1010 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1001:21:1010 | synthetic splat argument | UseUseExplosion.rb:21:1001:21:1010 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1009:21:1010 | 53 | UseUseExplosion.rb:21:1001:21:1010 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1022:21:1026 | @prop | UseUseExplosion.rb:21:1022:21:1031 | ... > ... | self |
-| UseUseExplosion.rb:21:1022:21:1031 | * | UseUseExplosion.rb:21:1022:21:1031 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1022:21:1031 | synthetic splat argument | UseUseExplosion.rb:21:1022:21:1031 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1030:21:1031 | 52 | UseUseExplosion.rb:21:1022:21:1031 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1043:21:1047 | @prop | UseUseExplosion.rb:21:1043:21:1052 | ... > ... | self |
-| UseUseExplosion.rb:21:1043:21:1052 | * | UseUseExplosion.rb:21:1043:21:1052 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1043:21:1052 | synthetic splat argument | UseUseExplosion.rb:21:1043:21:1052 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1051:21:1052 | 51 | UseUseExplosion.rb:21:1043:21:1052 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1064:21:1068 | @prop | UseUseExplosion.rb:21:1064:21:1073 | ... > ... | self |
-| UseUseExplosion.rb:21:1064:21:1073 | * | UseUseExplosion.rb:21:1064:21:1073 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1064:21:1073 | synthetic splat argument | UseUseExplosion.rb:21:1064:21:1073 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1072:21:1073 | 50 | UseUseExplosion.rb:21:1064:21:1073 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1085:21:1089 | @prop | UseUseExplosion.rb:21:1085:21:1094 | ... > ... | self |
-| UseUseExplosion.rb:21:1085:21:1094 | * | UseUseExplosion.rb:21:1085:21:1094 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1085:21:1094 | synthetic splat argument | UseUseExplosion.rb:21:1085:21:1094 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1093:21:1094 | 49 | UseUseExplosion.rb:21:1085:21:1094 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1106:21:1110 | @prop | UseUseExplosion.rb:21:1106:21:1115 | ... > ... | self |
-| UseUseExplosion.rb:21:1106:21:1115 | * | UseUseExplosion.rb:21:1106:21:1115 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1106:21:1115 | synthetic splat argument | UseUseExplosion.rb:21:1106:21:1115 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1114:21:1115 | 48 | UseUseExplosion.rb:21:1106:21:1115 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1127:21:1131 | @prop | UseUseExplosion.rb:21:1127:21:1136 | ... > ... | self |
-| UseUseExplosion.rb:21:1127:21:1136 | * | UseUseExplosion.rb:21:1127:21:1136 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1127:21:1136 | synthetic splat argument | UseUseExplosion.rb:21:1127:21:1136 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1135:21:1136 | 47 | UseUseExplosion.rb:21:1127:21:1136 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1148:21:1152 | @prop | UseUseExplosion.rb:21:1148:21:1157 | ... > ... | self |
-| UseUseExplosion.rb:21:1148:21:1157 | * | UseUseExplosion.rb:21:1148:21:1157 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1148:21:1157 | synthetic splat argument | UseUseExplosion.rb:21:1148:21:1157 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1156:21:1157 | 46 | UseUseExplosion.rb:21:1148:21:1157 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1169:21:1173 | @prop | UseUseExplosion.rb:21:1169:21:1178 | ... > ... | self |
-| UseUseExplosion.rb:21:1169:21:1178 | * | UseUseExplosion.rb:21:1169:21:1178 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1169:21:1178 | synthetic splat argument | UseUseExplosion.rb:21:1169:21:1178 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1177:21:1178 | 45 | UseUseExplosion.rb:21:1169:21:1178 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1190:21:1194 | @prop | UseUseExplosion.rb:21:1190:21:1199 | ... > ... | self |
-| UseUseExplosion.rb:21:1190:21:1199 | * | UseUseExplosion.rb:21:1190:21:1199 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1190:21:1199 | synthetic splat argument | UseUseExplosion.rb:21:1190:21:1199 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1198:21:1199 | 44 | UseUseExplosion.rb:21:1190:21:1199 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1211:21:1215 | @prop | UseUseExplosion.rb:21:1211:21:1220 | ... > ... | self |
-| UseUseExplosion.rb:21:1211:21:1220 | * | UseUseExplosion.rb:21:1211:21:1220 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1211:21:1220 | synthetic splat argument | UseUseExplosion.rb:21:1211:21:1220 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1219:21:1220 | 43 | UseUseExplosion.rb:21:1211:21:1220 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1232:21:1236 | @prop | UseUseExplosion.rb:21:1232:21:1241 | ... > ... | self |
-| UseUseExplosion.rb:21:1232:21:1241 | * | UseUseExplosion.rb:21:1232:21:1241 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1232:21:1241 | synthetic splat argument | UseUseExplosion.rb:21:1232:21:1241 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1240:21:1241 | 42 | UseUseExplosion.rb:21:1232:21:1241 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1253:21:1257 | @prop | UseUseExplosion.rb:21:1253:21:1262 | ... > ... | self |
-| UseUseExplosion.rb:21:1253:21:1262 | * | UseUseExplosion.rb:21:1253:21:1262 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1253:21:1262 | synthetic splat argument | UseUseExplosion.rb:21:1253:21:1262 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1261:21:1262 | 41 | UseUseExplosion.rb:21:1253:21:1262 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1274:21:1278 | @prop | UseUseExplosion.rb:21:1274:21:1283 | ... > ... | self |
-| UseUseExplosion.rb:21:1274:21:1283 | * | UseUseExplosion.rb:21:1274:21:1283 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1274:21:1283 | synthetic splat argument | UseUseExplosion.rb:21:1274:21:1283 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1282:21:1283 | 40 | UseUseExplosion.rb:21:1274:21:1283 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1295:21:1299 | @prop | UseUseExplosion.rb:21:1295:21:1304 | ... > ... | self |
-| UseUseExplosion.rb:21:1295:21:1304 | * | UseUseExplosion.rb:21:1295:21:1304 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1295:21:1304 | synthetic splat argument | UseUseExplosion.rb:21:1295:21:1304 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1303:21:1304 | 39 | UseUseExplosion.rb:21:1295:21:1304 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1316:21:1320 | @prop | UseUseExplosion.rb:21:1316:21:1325 | ... > ... | self |
-| UseUseExplosion.rb:21:1316:21:1325 | * | UseUseExplosion.rb:21:1316:21:1325 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1316:21:1325 | synthetic splat argument | UseUseExplosion.rb:21:1316:21:1325 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1324:21:1325 | 38 | UseUseExplosion.rb:21:1316:21:1325 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1337:21:1341 | @prop | UseUseExplosion.rb:21:1337:21:1346 | ... > ... | self |
-| UseUseExplosion.rb:21:1337:21:1346 | * | UseUseExplosion.rb:21:1337:21:1346 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1337:21:1346 | synthetic splat argument | UseUseExplosion.rb:21:1337:21:1346 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1345:21:1346 | 37 | UseUseExplosion.rb:21:1337:21:1346 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1358:21:1362 | @prop | UseUseExplosion.rb:21:1358:21:1367 | ... > ... | self |
-| UseUseExplosion.rb:21:1358:21:1367 | * | UseUseExplosion.rb:21:1358:21:1367 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1358:21:1367 | synthetic splat argument | UseUseExplosion.rb:21:1358:21:1367 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1366:21:1367 | 36 | UseUseExplosion.rb:21:1358:21:1367 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1379:21:1383 | @prop | UseUseExplosion.rb:21:1379:21:1388 | ... > ... | self |
-| UseUseExplosion.rb:21:1379:21:1388 | * | UseUseExplosion.rb:21:1379:21:1388 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1379:21:1388 | synthetic splat argument | UseUseExplosion.rb:21:1379:21:1388 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1387:21:1388 | 35 | UseUseExplosion.rb:21:1379:21:1388 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1400:21:1404 | @prop | UseUseExplosion.rb:21:1400:21:1409 | ... > ... | self |
-| UseUseExplosion.rb:21:1400:21:1409 | * | UseUseExplosion.rb:21:1400:21:1409 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1400:21:1409 | synthetic splat argument | UseUseExplosion.rb:21:1400:21:1409 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1408:21:1409 | 34 | UseUseExplosion.rb:21:1400:21:1409 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1421:21:1425 | @prop | UseUseExplosion.rb:21:1421:21:1430 | ... > ... | self |
-| UseUseExplosion.rb:21:1421:21:1430 | * | UseUseExplosion.rb:21:1421:21:1430 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1421:21:1430 | synthetic splat argument | UseUseExplosion.rb:21:1421:21:1430 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1429:21:1430 | 33 | UseUseExplosion.rb:21:1421:21:1430 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1442:21:1446 | @prop | UseUseExplosion.rb:21:1442:21:1451 | ... > ... | self |
-| UseUseExplosion.rb:21:1442:21:1451 | * | UseUseExplosion.rb:21:1442:21:1451 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1442:21:1451 | synthetic splat argument | UseUseExplosion.rb:21:1442:21:1451 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1450:21:1451 | 32 | UseUseExplosion.rb:21:1442:21:1451 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1463:21:1467 | @prop | UseUseExplosion.rb:21:1463:21:1472 | ... > ... | self |
-| UseUseExplosion.rb:21:1463:21:1472 | * | UseUseExplosion.rb:21:1463:21:1472 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1463:21:1472 | synthetic splat argument | UseUseExplosion.rb:21:1463:21:1472 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1471:21:1472 | 31 | UseUseExplosion.rb:21:1463:21:1472 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1484:21:1488 | @prop | UseUseExplosion.rb:21:1484:21:1493 | ... > ... | self |
-| UseUseExplosion.rb:21:1484:21:1493 | * | UseUseExplosion.rb:21:1484:21:1493 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1484:21:1493 | synthetic splat argument | UseUseExplosion.rb:21:1484:21:1493 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1492:21:1493 | 30 | UseUseExplosion.rb:21:1484:21:1493 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1505:21:1509 | @prop | UseUseExplosion.rb:21:1505:21:1514 | ... > ... | self |
-| UseUseExplosion.rb:21:1505:21:1514 | * | UseUseExplosion.rb:21:1505:21:1514 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1505:21:1514 | synthetic splat argument | UseUseExplosion.rb:21:1505:21:1514 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1513:21:1514 | 29 | UseUseExplosion.rb:21:1505:21:1514 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1526:21:1530 | @prop | UseUseExplosion.rb:21:1526:21:1535 | ... > ... | self |
-| UseUseExplosion.rb:21:1526:21:1535 | * | UseUseExplosion.rb:21:1526:21:1535 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1526:21:1535 | synthetic splat argument | UseUseExplosion.rb:21:1526:21:1535 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1534:21:1535 | 28 | UseUseExplosion.rb:21:1526:21:1535 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1547:21:1551 | @prop | UseUseExplosion.rb:21:1547:21:1556 | ... > ... | self |
-| UseUseExplosion.rb:21:1547:21:1556 | * | UseUseExplosion.rb:21:1547:21:1556 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1547:21:1556 | synthetic splat argument | UseUseExplosion.rb:21:1547:21:1556 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1555:21:1556 | 27 | UseUseExplosion.rb:21:1547:21:1556 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1568:21:1572 | @prop | UseUseExplosion.rb:21:1568:21:1577 | ... > ... | self |
-| UseUseExplosion.rb:21:1568:21:1577 | * | UseUseExplosion.rb:21:1568:21:1577 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1568:21:1577 | synthetic splat argument | UseUseExplosion.rb:21:1568:21:1577 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1576:21:1577 | 26 | UseUseExplosion.rb:21:1568:21:1577 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1589:21:1593 | @prop | UseUseExplosion.rb:21:1589:21:1598 | ... > ... | self |
-| UseUseExplosion.rb:21:1589:21:1598 | * | UseUseExplosion.rb:21:1589:21:1598 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1589:21:1598 | synthetic splat argument | UseUseExplosion.rb:21:1589:21:1598 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1597:21:1598 | 25 | UseUseExplosion.rb:21:1589:21:1598 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1610:21:1614 | @prop | UseUseExplosion.rb:21:1610:21:1619 | ... > ... | self |
-| UseUseExplosion.rb:21:1610:21:1619 | * | UseUseExplosion.rb:21:1610:21:1619 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1610:21:1619 | synthetic splat argument | UseUseExplosion.rb:21:1610:21:1619 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1618:21:1619 | 24 | UseUseExplosion.rb:21:1610:21:1619 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1631:21:1635 | @prop | UseUseExplosion.rb:21:1631:21:1640 | ... > ... | self |
-| UseUseExplosion.rb:21:1631:21:1640 | * | UseUseExplosion.rb:21:1631:21:1640 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1631:21:1640 | synthetic splat argument | UseUseExplosion.rb:21:1631:21:1640 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1639:21:1640 | 23 | UseUseExplosion.rb:21:1631:21:1640 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1652:21:1656 | @prop | UseUseExplosion.rb:21:1652:21:1661 | ... > ... | self |
-| UseUseExplosion.rb:21:1652:21:1661 | * | UseUseExplosion.rb:21:1652:21:1661 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1652:21:1661 | synthetic splat argument | UseUseExplosion.rb:21:1652:21:1661 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1660:21:1661 | 22 | UseUseExplosion.rb:21:1652:21:1661 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1673:21:1677 | @prop | UseUseExplosion.rb:21:1673:21:1682 | ... > ... | self |
-| UseUseExplosion.rb:21:1673:21:1682 | * | UseUseExplosion.rb:21:1673:21:1682 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1673:21:1682 | synthetic splat argument | UseUseExplosion.rb:21:1673:21:1682 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1681:21:1682 | 21 | UseUseExplosion.rb:21:1673:21:1682 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1694:21:1698 | @prop | UseUseExplosion.rb:21:1694:21:1703 | ... > ... | self |
-| UseUseExplosion.rb:21:1694:21:1703 | * | UseUseExplosion.rb:21:1694:21:1703 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1694:21:1703 | synthetic splat argument | UseUseExplosion.rb:21:1694:21:1703 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1702:21:1703 | 20 | UseUseExplosion.rb:21:1694:21:1703 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1715:21:1719 | @prop | UseUseExplosion.rb:21:1715:21:1724 | ... > ... | self |
-| UseUseExplosion.rb:21:1715:21:1724 | * | UseUseExplosion.rb:21:1715:21:1724 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1715:21:1724 | synthetic splat argument | UseUseExplosion.rb:21:1715:21:1724 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1723:21:1724 | 19 | UseUseExplosion.rb:21:1715:21:1724 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1736:21:1740 | @prop | UseUseExplosion.rb:21:1736:21:1745 | ... > ... | self |
-| UseUseExplosion.rb:21:1736:21:1745 | * | UseUseExplosion.rb:21:1736:21:1745 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1736:21:1745 | synthetic splat argument | UseUseExplosion.rb:21:1736:21:1745 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1744:21:1745 | 18 | UseUseExplosion.rb:21:1736:21:1745 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1757:21:1761 | @prop | UseUseExplosion.rb:21:1757:21:1766 | ... > ... | self |
-| UseUseExplosion.rb:21:1757:21:1766 | * | UseUseExplosion.rb:21:1757:21:1766 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1757:21:1766 | synthetic splat argument | UseUseExplosion.rb:21:1757:21:1766 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1765:21:1766 | 17 | UseUseExplosion.rb:21:1757:21:1766 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1778:21:1782 | @prop | UseUseExplosion.rb:21:1778:21:1787 | ... > ... | self |
-| UseUseExplosion.rb:21:1778:21:1787 | * | UseUseExplosion.rb:21:1778:21:1787 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1778:21:1787 | synthetic splat argument | UseUseExplosion.rb:21:1778:21:1787 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1786:21:1787 | 16 | UseUseExplosion.rb:21:1778:21:1787 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1799:21:1803 | @prop | UseUseExplosion.rb:21:1799:21:1808 | ... > ... | self |
-| UseUseExplosion.rb:21:1799:21:1808 | * | UseUseExplosion.rb:21:1799:21:1808 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1799:21:1808 | synthetic splat argument | UseUseExplosion.rb:21:1799:21:1808 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1807:21:1808 | 15 | UseUseExplosion.rb:21:1799:21:1808 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1820:21:1824 | @prop | UseUseExplosion.rb:21:1820:21:1829 | ... > ... | self |
-| UseUseExplosion.rb:21:1820:21:1829 | * | UseUseExplosion.rb:21:1820:21:1829 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1820:21:1829 | synthetic splat argument | UseUseExplosion.rb:21:1820:21:1829 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1828:21:1829 | 14 | UseUseExplosion.rb:21:1820:21:1829 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1841:21:1845 | @prop | UseUseExplosion.rb:21:1841:21:1850 | ... > ... | self |
-| UseUseExplosion.rb:21:1841:21:1850 | * | UseUseExplosion.rb:21:1841:21:1850 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1841:21:1850 | synthetic splat argument | UseUseExplosion.rb:21:1841:21:1850 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1849:21:1850 | 13 | UseUseExplosion.rb:21:1841:21:1850 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1862:21:1866 | @prop | UseUseExplosion.rb:21:1862:21:1871 | ... > ... | self |
-| UseUseExplosion.rb:21:1862:21:1871 | * | UseUseExplosion.rb:21:1862:21:1871 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1862:21:1871 | synthetic splat argument | UseUseExplosion.rb:21:1862:21:1871 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1870:21:1871 | 12 | UseUseExplosion.rb:21:1862:21:1871 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1883:21:1887 | @prop | UseUseExplosion.rb:21:1883:21:1892 | ... > ... | self |
-| UseUseExplosion.rb:21:1883:21:1892 | * | UseUseExplosion.rb:21:1883:21:1892 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1883:21:1892 | synthetic splat argument | UseUseExplosion.rb:21:1883:21:1892 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1891:21:1892 | 11 | UseUseExplosion.rb:21:1883:21:1892 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1904:21:1908 | @prop | UseUseExplosion.rb:21:1904:21:1913 | ... > ... | self |
-| UseUseExplosion.rb:21:1904:21:1913 | * | UseUseExplosion.rb:21:1904:21:1913 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1904:21:1913 | synthetic splat argument | UseUseExplosion.rb:21:1904:21:1913 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1912:21:1913 | 10 | UseUseExplosion.rb:21:1904:21:1913 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1925:21:1929 | @prop | UseUseExplosion.rb:21:1925:21:1933 | ... > ... | self |
-| UseUseExplosion.rb:21:1925:21:1933 | * | UseUseExplosion.rb:21:1925:21:1933 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1925:21:1933 | synthetic splat argument | UseUseExplosion.rb:21:1925:21:1933 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1933:21:1933 | 9 | UseUseExplosion.rb:21:1925:21:1933 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1945:21:1949 | @prop | UseUseExplosion.rb:21:1945:21:1953 | ... > ... | self |
-| UseUseExplosion.rb:21:1945:21:1953 | * | UseUseExplosion.rb:21:1945:21:1953 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1945:21:1953 | synthetic splat argument | UseUseExplosion.rb:21:1945:21:1953 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1953:21:1953 | 8 | UseUseExplosion.rb:21:1945:21:1953 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1965:21:1969 | @prop | UseUseExplosion.rb:21:1965:21:1973 | ... > ... | self |
-| UseUseExplosion.rb:21:1965:21:1973 | * | UseUseExplosion.rb:21:1965:21:1973 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1965:21:1973 | synthetic splat argument | UseUseExplosion.rb:21:1965:21:1973 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1973:21:1973 | 7 | UseUseExplosion.rb:21:1965:21:1973 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:1985:21:1989 | @prop | UseUseExplosion.rb:21:1985:21:1993 | ... > ... | self |
-| UseUseExplosion.rb:21:1985:21:1993 | * | UseUseExplosion.rb:21:1985:21:1993 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:1985:21:1993 | synthetic splat argument | UseUseExplosion.rb:21:1985:21:1993 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:1993:21:1993 | 6 | UseUseExplosion.rb:21:1985:21:1993 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:2005:21:2009 | @prop | UseUseExplosion.rb:21:2005:21:2013 | ... > ... | self |
-| UseUseExplosion.rb:21:2005:21:2013 | * | UseUseExplosion.rb:21:2005:21:2013 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:2005:21:2013 | synthetic splat argument | UseUseExplosion.rb:21:2005:21:2013 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:2013:21:2013 | 5 | UseUseExplosion.rb:21:2005:21:2013 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:2025:21:2029 | @prop | UseUseExplosion.rb:21:2025:21:2033 | ... > ... | self |
-| UseUseExplosion.rb:21:2025:21:2033 | * | UseUseExplosion.rb:21:2025:21:2033 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:2025:21:2033 | synthetic splat argument | UseUseExplosion.rb:21:2025:21:2033 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:2033:21:2033 | 4 | UseUseExplosion.rb:21:2025:21:2033 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:2045:21:2049 | @prop | UseUseExplosion.rb:21:2045:21:2053 | ... > ... | self |
-| UseUseExplosion.rb:21:2045:21:2053 | * | UseUseExplosion.rb:21:2045:21:2053 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:2045:21:2053 | synthetic splat argument | UseUseExplosion.rb:21:2045:21:2053 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:2053:21:2053 | 3 | UseUseExplosion.rb:21:2045:21:2053 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:2065:21:2069 | @prop | UseUseExplosion.rb:21:2065:21:2073 | ... > ... | self |
-| UseUseExplosion.rb:21:2065:21:2073 | * | UseUseExplosion.rb:21:2065:21:2073 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:2065:21:2073 | synthetic splat argument | UseUseExplosion.rb:21:2065:21:2073 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:2073:21:2073 | 2 | UseUseExplosion.rb:21:2065:21:2073 | ... > ... | position 0 |
 | UseUseExplosion.rb:21:2085:21:2089 | @prop | UseUseExplosion.rb:21:2085:21:2093 | ... > ... | self |
-| UseUseExplosion.rb:21:2085:21:2093 | * | UseUseExplosion.rb:21:2085:21:2093 | ... > ... | synthetic * |
+| UseUseExplosion.rb:21:2085:21:2093 | synthetic splat argument | UseUseExplosion.rb:21:2085:21:2093 | ... > ... | synthetic * |
 | UseUseExplosion.rb:21:2093:21:2093 | 1 | UseUseExplosion.rb:21:2085:21:2093 | ... > ... | position 0 |
-| UseUseExplosion.rb:21:2107:21:2112 | * | UseUseExplosion.rb:21:2107:21:2112 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2107:21:2112 | self | UseUseExplosion.rb:21:2107:21:2112 | call to use | self |
+| UseUseExplosion.rb:21:2107:21:2112 | synthetic splat argument | UseUseExplosion.rb:21:2107:21:2112 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2111:21:2111 | x | UseUseExplosion.rb:21:2107:21:2112 | call to use | position 0 |
-| UseUseExplosion.rb:21:2123:21:2128 | * | UseUseExplosion.rb:21:2123:21:2128 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2123:21:2128 | self | UseUseExplosion.rb:21:2123:21:2128 | call to use | self |
+| UseUseExplosion.rb:21:2123:21:2128 | synthetic splat argument | UseUseExplosion.rb:21:2123:21:2128 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2127:21:2127 | x | UseUseExplosion.rb:21:2123:21:2128 | call to use | position 0 |
-| UseUseExplosion.rb:21:2139:21:2144 | * | UseUseExplosion.rb:21:2139:21:2144 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2139:21:2144 | self | UseUseExplosion.rb:21:2139:21:2144 | call to use | self |
+| UseUseExplosion.rb:21:2139:21:2144 | synthetic splat argument | UseUseExplosion.rb:21:2139:21:2144 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2143:21:2143 | x | UseUseExplosion.rb:21:2139:21:2144 | call to use | position 0 |
-| UseUseExplosion.rb:21:2155:21:2160 | * | UseUseExplosion.rb:21:2155:21:2160 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2155:21:2160 | self | UseUseExplosion.rb:21:2155:21:2160 | call to use | self |
+| UseUseExplosion.rb:21:2155:21:2160 | synthetic splat argument | UseUseExplosion.rb:21:2155:21:2160 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2159:21:2159 | x | UseUseExplosion.rb:21:2155:21:2160 | call to use | position 0 |
-| UseUseExplosion.rb:21:2171:21:2176 | * | UseUseExplosion.rb:21:2171:21:2176 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2171:21:2176 | self | UseUseExplosion.rb:21:2171:21:2176 | call to use | self |
+| UseUseExplosion.rb:21:2171:21:2176 | synthetic splat argument | UseUseExplosion.rb:21:2171:21:2176 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2175:21:2175 | x | UseUseExplosion.rb:21:2171:21:2176 | call to use | position 0 |
-| UseUseExplosion.rb:21:2187:21:2192 | * | UseUseExplosion.rb:21:2187:21:2192 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2187:21:2192 | self | UseUseExplosion.rb:21:2187:21:2192 | call to use | self |
+| UseUseExplosion.rb:21:2187:21:2192 | synthetic splat argument | UseUseExplosion.rb:21:2187:21:2192 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2191:21:2191 | x | UseUseExplosion.rb:21:2187:21:2192 | call to use | position 0 |
-| UseUseExplosion.rb:21:2203:21:2208 | * | UseUseExplosion.rb:21:2203:21:2208 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2203:21:2208 | self | UseUseExplosion.rb:21:2203:21:2208 | call to use | self |
+| UseUseExplosion.rb:21:2203:21:2208 | synthetic splat argument | UseUseExplosion.rb:21:2203:21:2208 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2207:21:2207 | x | UseUseExplosion.rb:21:2203:21:2208 | call to use | position 0 |
-| UseUseExplosion.rb:21:2219:21:2224 | * | UseUseExplosion.rb:21:2219:21:2224 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2219:21:2224 | self | UseUseExplosion.rb:21:2219:21:2224 | call to use | self |
+| UseUseExplosion.rb:21:2219:21:2224 | synthetic splat argument | UseUseExplosion.rb:21:2219:21:2224 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2223:21:2223 | x | UseUseExplosion.rb:21:2219:21:2224 | call to use | position 0 |
-| UseUseExplosion.rb:21:2235:21:2240 | * | UseUseExplosion.rb:21:2235:21:2240 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2235:21:2240 | self | UseUseExplosion.rb:21:2235:21:2240 | call to use | self |
+| UseUseExplosion.rb:21:2235:21:2240 | synthetic splat argument | UseUseExplosion.rb:21:2235:21:2240 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2239:21:2239 | x | UseUseExplosion.rb:21:2235:21:2240 | call to use | position 0 |
-| UseUseExplosion.rb:21:2251:21:2256 | * | UseUseExplosion.rb:21:2251:21:2256 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2251:21:2256 | self | UseUseExplosion.rb:21:2251:21:2256 | call to use | self |
+| UseUseExplosion.rb:21:2251:21:2256 | synthetic splat argument | UseUseExplosion.rb:21:2251:21:2256 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2255:21:2255 | x | UseUseExplosion.rb:21:2251:21:2256 | call to use | position 0 |
-| UseUseExplosion.rb:21:2267:21:2272 | * | UseUseExplosion.rb:21:2267:21:2272 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2267:21:2272 | self | UseUseExplosion.rb:21:2267:21:2272 | call to use | self |
+| UseUseExplosion.rb:21:2267:21:2272 | synthetic splat argument | UseUseExplosion.rb:21:2267:21:2272 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2271:21:2271 | x | UseUseExplosion.rb:21:2267:21:2272 | call to use | position 0 |
-| UseUseExplosion.rb:21:2283:21:2288 | * | UseUseExplosion.rb:21:2283:21:2288 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2283:21:2288 | self | UseUseExplosion.rb:21:2283:21:2288 | call to use | self |
+| UseUseExplosion.rb:21:2283:21:2288 | synthetic splat argument | UseUseExplosion.rb:21:2283:21:2288 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2287:21:2287 | x | UseUseExplosion.rb:21:2283:21:2288 | call to use | position 0 |
-| UseUseExplosion.rb:21:2299:21:2304 | * | UseUseExplosion.rb:21:2299:21:2304 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2299:21:2304 | self | UseUseExplosion.rb:21:2299:21:2304 | call to use | self |
+| UseUseExplosion.rb:21:2299:21:2304 | synthetic splat argument | UseUseExplosion.rb:21:2299:21:2304 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2303:21:2303 | x | UseUseExplosion.rb:21:2299:21:2304 | call to use | position 0 |
-| UseUseExplosion.rb:21:2315:21:2320 | * | UseUseExplosion.rb:21:2315:21:2320 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2315:21:2320 | self | UseUseExplosion.rb:21:2315:21:2320 | call to use | self |
+| UseUseExplosion.rb:21:2315:21:2320 | synthetic splat argument | UseUseExplosion.rb:21:2315:21:2320 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2319:21:2319 | x | UseUseExplosion.rb:21:2315:21:2320 | call to use | position 0 |
-| UseUseExplosion.rb:21:2331:21:2336 | * | UseUseExplosion.rb:21:2331:21:2336 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2331:21:2336 | self | UseUseExplosion.rb:21:2331:21:2336 | call to use | self |
+| UseUseExplosion.rb:21:2331:21:2336 | synthetic splat argument | UseUseExplosion.rb:21:2331:21:2336 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2335:21:2335 | x | UseUseExplosion.rb:21:2331:21:2336 | call to use | position 0 |
-| UseUseExplosion.rb:21:2347:21:2352 | * | UseUseExplosion.rb:21:2347:21:2352 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2347:21:2352 | self | UseUseExplosion.rb:21:2347:21:2352 | call to use | self |
+| UseUseExplosion.rb:21:2347:21:2352 | synthetic splat argument | UseUseExplosion.rb:21:2347:21:2352 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2351:21:2351 | x | UseUseExplosion.rb:21:2347:21:2352 | call to use | position 0 |
-| UseUseExplosion.rb:21:2363:21:2368 | * | UseUseExplosion.rb:21:2363:21:2368 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2363:21:2368 | self | UseUseExplosion.rb:21:2363:21:2368 | call to use | self |
+| UseUseExplosion.rb:21:2363:21:2368 | synthetic splat argument | UseUseExplosion.rb:21:2363:21:2368 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2367:21:2367 | x | UseUseExplosion.rb:21:2363:21:2368 | call to use | position 0 |
-| UseUseExplosion.rb:21:2379:21:2384 | * | UseUseExplosion.rb:21:2379:21:2384 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2379:21:2384 | self | UseUseExplosion.rb:21:2379:21:2384 | call to use | self |
+| UseUseExplosion.rb:21:2379:21:2384 | synthetic splat argument | UseUseExplosion.rb:21:2379:21:2384 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2383:21:2383 | x | UseUseExplosion.rb:21:2379:21:2384 | call to use | position 0 |
-| UseUseExplosion.rb:21:2395:21:2400 | * | UseUseExplosion.rb:21:2395:21:2400 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2395:21:2400 | self | UseUseExplosion.rb:21:2395:21:2400 | call to use | self |
+| UseUseExplosion.rb:21:2395:21:2400 | synthetic splat argument | UseUseExplosion.rb:21:2395:21:2400 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2399:21:2399 | x | UseUseExplosion.rb:21:2395:21:2400 | call to use | position 0 |
-| UseUseExplosion.rb:21:2411:21:2416 | * | UseUseExplosion.rb:21:2411:21:2416 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2411:21:2416 | self | UseUseExplosion.rb:21:2411:21:2416 | call to use | self |
+| UseUseExplosion.rb:21:2411:21:2416 | synthetic splat argument | UseUseExplosion.rb:21:2411:21:2416 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2415:21:2415 | x | UseUseExplosion.rb:21:2411:21:2416 | call to use | position 0 |
-| UseUseExplosion.rb:21:2427:21:2432 | * | UseUseExplosion.rb:21:2427:21:2432 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2427:21:2432 | self | UseUseExplosion.rb:21:2427:21:2432 | call to use | self |
+| UseUseExplosion.rb:21:2427:21:2432 | synthetic splat argument | UseUseExplosion.rb:21:2427:21:2432 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2431:21:2431 | x | UseUseExplosion.rb:21:2427:21:2432 | call to use | position 0 |
-| UseUseExplosion.rb:21:2443:21:2448 | * | UseUseExplosion.rb:21:2443:21:2448 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2443:21:2448 | self | UseUseExplosion.rb:21:2443:21:2448 | call to use | self |
+| UseUseExplosion.rb:21:2443:21:2448 | synthetic splat argument | UseUseExplosion.rb:21:2443:21:2448 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2447:21:2447 | x | UseUseExplosion.rb:21:2443:21:2448 | call to use | position 0 |
-| UseUseExplosion.rb:21:2459:21:2464 | * | UseUseExplosion.rb:21:2459:21:2464 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2459:21:2464 | self | UseUseExplosion.rb:21:2459:21:2464 | call to use | self |
+| UseUseExplosion.rb:21:2459:21:2464 | synthetic splat argument | UseUseExplosion.rb:21:2459:21:2464 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2463:21:2463 | x | UseUseExplosion.rb:21:2459:21:2464 | call to use | position 0 |
-| UseUseExplosion.rb:21:2475:21:2480 | * | UseUseExplosion.rb:21:2475:21:2480 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2475:21:2480 | self | UseUseExplosion.rb:21:2475:21:2480 | call to use | self |
+| UseUseExplosion.rb:21:2475:21:2480 | synthetic splat argument | UseUseExplosion.rb:21:2475:21:2480 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2479:21:2479 | x | UseUseExplosion.rb:21:2475:21:2480 | call to use | position 0 |
-| UseUseExplosion.rb:21:2491:21:2496 | * | UseUseExplosion.rb:21:2491:21:2496 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2491:21:2496 | self | UseUseExplosion.rb:21:2491:21:2496 | call to use | self |
+| UseUseExplosion.rb:21:2491:21:2496 | synthetic splat argument | UseUseExplosion.rb:21:2491:21:2496 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2495:21:2495 | x | UseUseExplosion.rb:21:2491:21:2496 | call to use | position 0 |
-| UseUseExplosion.rb:21:2507:21:2512 | * | UseUseExplosion.rb:21:2507:21:2512 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2507:21:2512 | self | UseUseExplosion.rb:21:2507:21:2512 | call to use | self |
+| UseUseExplosion.rb:21:2507:21:2512 | synthetic splat argument | UseUseExplosion.rb:21:2507:21:2512 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2511:21:2511 | x | UseUseExplosion.rb:21:2507:21:2512 | call to use | position 0 |
-| UseUseExplosion.rb:21:2523:21:2528 | * | UseUseExplosion.rb:21:2523:21:2528 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2523:21:2528 | self | UseUseExplosion.rb:21:2523:21:2528 | call to use | self |
+| UseUseExplosion.rb:21:2523:21:2528 | synthetic splat argument | UseUseExplosion.rb:21:2523:21:2528 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2527:21:2527 | x | UseUseExplosion.rb:21:2523:21:2528 | call to use | position 0 |
-| UseUseExplosion.rb:21:2539:21:2544 | * | UseUseExplosion.rb:21:2539:21:2544 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2539:21:2544 | self | UseUseExplosion.rb:21:2539:21:2544 | call to use | self |
+| UseUseExplosion.rb:21:2539:21:2544 | synthetic splat argument | UseUseExplosion.rb:21:2539:21:2544 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2543:21:2543 | x | UseUseExplosion.rb:21:2539:21:2544 | call to use | position 0 |
-| UseUseExplosion.rb:21:2555:21:2560 | * | UseUseExplosion.rb:21:2555:21:2560 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2555:21:2560 | self | UseUseExplosion.rb:21:2555:21:2560 | call to use | self |
+| UseUseExplosion.rb:21:2555:21:2560 | synthetic splat argument | UseUseExplosion.rb:21:2555:21:2560 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2559:21:2559 | x | UseUseExplosion.rb:21:2555:21:2560 | call to use | position 0 |
-| UseUseExplosion.rb:21:2571:21:2576 | * | UseUseExplosion.rb:21:2571:21:2576 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2571:21:2576 | self | UseUseExplosion.rb:21:2571:21:2576 | call to use | self |
+| UseUseExplosion.rb:21:2571:21:2576 | synthetic splat argument | UseUseExplosion.rb:21:2571:21:2576 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2575:21:2575 | x | UseUseExplosion.rb:21:2571:21:2576 | call to use | position 0 |
-| UseUseExplosion.rb:21:2587:21:2592 | * | UseUseExplosion.rb:21:2587:21:2592 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2587:21:2592 | self | UseUseExplosion.rb:21:2587:21:2592 | call to use | self |
+| UseUseExplosion.rb:21:2587:21:2592 | synthetic splat argument | UseUseExplosion.rb:21:2587:21:2592 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2591:21:2591 | x | UseUseExplosion.rb:21:2587:21:2592 | call to use | position 0 |
-| UseUseExplosion.rb:21:2603:21:2608 | * | UseUseExplosion.rb:21:2603:21:2608 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2603:21:2608 | self | UseUseExplosion.rb:21:2603:21:2608 | call to use | self |
+| UseUseExplosion.rb:21:2603:21:2608 | synthetic splat argument | UseUseExplosion.rb:21:2603:21:2608 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2607:21:2607 | x | UseUseExplosion.rb:21:2603:21:2608 | call to use | position 0 |
-| UseUseExplosion.rb:21:2619:21:2624 | * | UseUseExplosion.rb:21:2619:21:2624 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2619:21:2624 | self | UseUseExplosion.rb:21:2619:21:2624 | call to use | self |
+| UseUseExplosion.rb:21:2619:21:2624 | synthetic splat argument | UseUseExplosion.rb:21:2619:21:2624 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2623:21:2623 | x | UseUseExplosion.rb:21:2619:21:2624 | call to use | position 0 |
-| UseUseExplosion.rb:21:2635:21:2640 | * | UseUseExplosion.rb:21:2635:21:2640 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2635:21:2640 | self | UseUseExplosion.rb:21:2635:21:2640 | call to use | self |
+| UseUseExplosion.rb:21:2635:21:2640 | synthetic splat argument | UseUseExplosion.rb:21:2635:21:2640 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2639:21:2639 | x | UseUseExplosion.rb:21:2635:21:2640 | call to use | position 0 |
-| UseUseExplosion.rb:21:2651:21:2656 | * | UseUseExplosion.rb:21:2651:21:2656 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2651:21:2656 | self | UseUseExplosion.rb:21:2651:21:2656 | call to use | self |
+| UseUseExplosion.rb:21:2651:21:2656 | synthetic splat argument | UseUseExplosion.rb:21:2651:21:2656 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2655:21:2655 | x | UseUseExplosion.rb:21:2651:21:2656 | call to use | position 0 |
-| UseUseExplosion.rb:21:2667:21:2672 | * | UseUseExplosion.rb:21:2667:21:2672 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2667:21:2672 | self | UseUseExplosion.rb:21:2667:21:2672 | call to use | self |
+| UseUseExplosion.rb:21:2667:21:2672 | synthetic splat argument | UseUseExplosion.rb:21:2667:21:2672 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2671:21:2671 | x | UseUseExplosion.rb:21:2667:21:2672 | call to use | position 0 |
-| UseUseExplosion.rb:21:2683:21:2688 | * | UseUseExplosion.rb:21:2683:21:2688 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2683:21:2688 | self | UseUseExplosion.rb:21:2683:21:2688 | call to use | self |
+| UseUseExplosion.rb:21:2683:21:2688 | synthetic splat argument | UseUseExplosion.rb:21:2683:21:2688 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2687:21:2687 | x | UseUseExplosion.rb:21:2683:21:2688 | call to use | position 0 |
-| UseUseExplosion.rb:21:2699:21:2704 | * | UseUseExplosion.rb:21:2699:21:2704 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2699:21:2704 | self | UseUseExplosion.rb:21:2699:21:2704 | call to use | self |
+| UseUseExplosion.rb:21:2699:21:2704 | synthetic splat argument | UseUseExplosion.rb:21:2699:21:2704 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2703:21:2703 | x | UseUseExplosion.rb:21:2699:21:2704 | call to use | position 0 |
-| UseUseExplosion.rb:21:2715:21:2720 | * | UseUseExplosion.rb:21:2715:21:2720 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2715:21:2720 | self | UseUseExplosion.rb:21:2715:21:2720 | call to use | self |
+| UseUseExplosion.rb:21:2715:21:2720 | synthetic splat argument | UseUseExplosion.rb:21:2715:21:2720 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2719:21:2719 | x | UseUseExplosion.rb:21:2715:21:2720 | call to use | position 0 |
-| UseUseExplosion.rb:21:2731:21:2736 | * | UseUseExplosion.rb:21:2731:21:2736 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2731:21:2736 | self | UseUseExplosion.rb:21:2731:21:2736 | call to use | self |
+| UseUseExplosion.rb:21:2731:21:2736 | synthetic splat argument | UseUseExplosion.rb:21:2731:21:2736 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2735:21:2735 | x | UseUseExplosion.rb:21:2731:21:2736 | call to use | position 0 |
-| UseUseExplosion.rb:21:2747:21:2752 | * | UseUseExplosion.rb:21:2747:21:2752 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2747:21:2752 | self | UseUseExplosion.rb:21:2747:21:2752 | call to use | self |
+| UseUseExplosion.rb:21:2747:21:2752 | synthetic splat argument | UseUseExplosion.rb:21:2747:21:2752 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2751:21:2751 | x | UseUseExplosion.rb:21:2747:21:2752 | call to use | position 0 |
-| UseUseExplosion.rb:21:2763:21:2768 | * | UseUseExplosion.rb:21:2763:21:2768 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2763:21:2768 | self | UseUseExplosion.rb:21:2763:21:2768 | call to use | self |
+| UseUseExplosion.rb:21:2763:21:2768 | synthetic splat argument | UseUseExplosion.rb:21:2763:21:2768 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2767:21:2767 | x | UseUseExplosion.rb:21:2763:21:2768 | call to use | position 0 |
-| UseUseExplosion.rb:21:2779:21:2784 | * | UseUseExplosion.rb:21:2779:21:2784 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2779:21:2784 | self | UseUseExplosion.rb:21:2779:21:2784 | call to use | self |
+| UseUseExplosion.rb:21:2779:21:2784 | synthetic splat argument | UseUseExplosion.rb:21:2779:21:2784 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2783:21:2783 | x | UseUseExplosion.rb:21:2779:21:2784 | call to use | position 0 |
-| UseUseExplosion.rb:21:2795:21:2800 | * | UseUseExplosion.rb:21:2795:21:2800 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2795:21:2800 | self | UseUseExplosion.rb:21:2795:21:2800 | call to use | self |
+| UseUseExplosion.rb:21:2795:21:2800 | synthetic splat argument | UseUseExplosion.rb:21:2795:21:2800 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2799:21:2799 | x | UseUseExplosion.rb:21:2795:21:2800 | call to use | position 0 |
-| UseUseExplosion.rb:21:2811:21:2816 | * | UseUseExplosion.rb:21:2811:21:2816 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2811:21:2816 | self | UseUseExplosion.rb:21:2811:21:2816 | call to use | self |
+| UseUseExplosion.rb:21:2811:21:2816 | synthetic splat argument | UseUseExplosion.rb:21:2811:21:2816 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2815:21:2815 | x | UseUseExplosion.rb:21:2811:21:2816 | call to use | position 0 |
-| UseUseExplosion.rb:21:2827:21:2832 | * | UseUseExplosion.rb:21:2827:21:2832 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2827:21:2832 | self | UseUseExplosion.rb:21:2827:21:2832 | call to use | self |
+| UseUseExplosion.rb:21:2827:21:2832 | synthetic splat argument | UseUseExplosion.rb:21:2827:21:2832 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2831:21:2831 | x | UseUseExplosion.rb:21:2827:21:2832 | call to use | position 0 |
-| UseUseExplosion.rb:21:2843:21:2848 | * | UseUseExplosion.rb:21:2843:21:2848 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2843:21:2848 | self | UseUseExplosion.rb:21:2843:21:2848 | call to use | self |
+| UseUseExplosion.rb:21:2843:21:2848 | synthetic splat argument | UseUseExplosion.rb:21:2843:21:2848 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2847:21:2847 | x | UseUseExplosion.rb:21:2843:21:2848 | call to use | position 0 |
-| UseUseExplosion.rb:21:2859:21:2864 | * | UseUseExplosion.rb:21:2859:21:2864 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2859:21:2864 | self | UseUseExplosion.rb:21:2859:21:2864 | call to use | self |
+| UseUseExplosion.rb:21:2859:21:2864 | synthetic splat argument | UseUseExplosion.rb:21:2859:21:2864 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2863:21:2863 | x | UseUseExplosion.rb:21:2859:21:2864 | call to use | position 0 |
-| UseUseExplosion.rb:21:2875:21:2880 | * | UseUseExplosion.rb:21:2875:21:2880 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2875:21:2880 | self | UseUseExplosion.rb:21:2875:21:2880 | call to use | self |
+| UseUseExplosion.rb:21:2875:21:2880 | synthetic splat argument | UseUseExplosion.rb:21:2875:21:2880 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2879:21:2879 | x | UseUseExplosion.rb:21:2875:21:2880 | call to use | position 0 |
-| UseUseExplosion.rb:21:2891:21:2896 | * | UseUseExplosion.rb:21:2891:21:2896 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2891:21:2896 | self | UseUseExplosion.rb:21:2891:21:2896 | call to use | self |
+| UseUseExplosion.rb:21:2891:21:2896 | synthetic splat argument | UseUseExplosion.rb:21:2891:21:2896 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2895:21:2895 | x | UseUseExplosion.rb:21:2891:21:2896 | call to use | position 0 |
-| UseUseExplosion.rb:21:2907:21:2912 | * | UseUseExplosion.rb:21:2907:21:2912 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2907:21:2912 | self | UseUseExplosion.rb:21:2907:21:2912 | call to use | self |
+| UseUseExplosion.rb:21:2907:21:2912 | synthetic splat argument | UseUseExplosion.rb:21:2907:21:2912 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2911:21:2911 | x | UseUseExplosion.rb:21:2907:21:2912 | call to use | position 0 |
-| UseUseExplosion.rb:21:2923:21:2928 | * | UseUseExplosion.rb:21:2923:21:2928 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2923:21:2928 | self | UseUseExplosion.rb:21:2923:21:2928 | call to use | self |
+| UseUseExplosion.rb:21:2923:21:2928 | synthetic splat argument | UseUseExplosion.rb:21:2923:21:2928 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2927:21:2927 | x | UseUseExplosion.rb:21:2923:21:2928 | call to use | position 0 |
-| UseUseExplosion.rb:21:2939:21:2944 | * | UseUseExplosion.rb:21:2939:21:2944 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2939:21:2944 | self | UseUseExplosion.rb:21:2939:21:2944 | call to use | self |
+| UseUseExplosion.rb:21:2939:21:2944 | synthetic splat argument | UseUseExplosion.rb:21:2939:21:2944 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2943:21:2943 | x | UseUseExplosion.rb:21:2939:21:2944 | call to use | position 0 |
-| UseUseExplosion.rb:21:2955:21:2960 | * | UseUseExplosion.rb:21:2955:21:2960 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2955:21:2960 | self | UseUseExplosion.rb:21:2955:21:2960 | call to use | self |
+| UseUseExplosion.rb:21:2955:21:2960 | synthetic splat argument | UseUseExplosion.rb:21:2955:21:2960 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2959:21:2959 | x | UseUseExplosion.rb:21:2955:21:2960 | call to use | position 0 |
-| UseUseExplosion.rb:21:2971:21:2976 | * | UseUseExplosion.rb:21:2971:21:2976 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2971:21:2976 | self | UseUseExplosion.rb:21:2971:21:2976 | call to use | self |
+| UseUseExplosion.rb:21:2971:21:2976 | synthetic splat argument | UseUseExplosion.rb:21:2971:21:2976 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2975:21:2975 | x | UseUseExplosion.rb:21:2971:21:2976 | call to use | position 0 |
-| UseUseExplosion.rb:21:2987:21:2992 | * | UseUseExplosion.rb:21:2987:21:2992 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2987:21:2992 | self | UseUseExplosion.rb:21:2987:21:2992 | call to use | self |
+| UseUseExplosion.rb:21:2987:21:2992 | synthetic splat argument | UseUseExplosion.rb:21:2987:21:2992 | call to use | synthetic * |
 | UseUseExplosion.rb:21:2991:21:2991 | x | UseUseExplosion.rb:21:2987:21:2992 | call to use | position 0 |
-| UseUseExplosion.rb:21:3003:21:3008 | * | UseUseExplosion.rb:21:3003:21:3008 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3003:21:3008 | self | UseUseExplosion.rb:21:3003:21:3008 | call to use | self |
+| UseUseExplosion.rb:21:3003:21:3008 | synthetic splat argument | UseUseExplosion.rb:21:3003:21:3008 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3007:21:3007 | x | UseUseExplosion.rb:21:3003:21:3008 | call to use | position 0 |
-| UseUseExplosion.rb:21:3019:21:3024 | * | UseUseExplosion.rb:21:3019:21:3024 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3019:21:3024 | self | UseUseExplosion.rb:21:3019:21:3024 | call to use | self |
+| UseUseExplosion.rb:21:3019:21:3024 | synthetic splat argument | UseUseExplosion.rb:21:3019:21:3024 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3023:21:3023 | x | UseUseExplosion.rb:21:3019:21:3024 | call to use | position 0 |
-| UseUseExplosion.rb:21:3035:21:3040 | * | UseUseExplosion.rb:21:3035:21:3040 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3035:21:3040 | self | UseUseExplosion.rb:21:3035:21:3040 | call to use | self |
+| UseUseExplosion.rb:21:3035:21:3040 | synthetic splat argument | UseUseExplosion.rb:21:3035:21:3040 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3039:21:3039 | x | UseUseExplosion.rb:21:3035:21:3040 | call to use | position 0 |
-| UseUseExplosion.rb:21:3051:21:3056 | * | UseUseExplosion.rb:21:3051:21:3056 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3051:21:3056 | self | UseUseExplosion.rb:21:3051:21:3056 | call to use | self |
+| UseUseExplosion.rb:21:3051:21:3056 | synthetic splat argument | UseUseExplosion.rb:21:3051:21:3056 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3055:21:3055 | x | UseUseExplosion.rb:21:3051:21:3056 | call to use | position 0 |
-| UseUseExplosion.rb:21:3067:21:3072 | * | UseUseExplosion.rb:21:3067:21:3072 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3067:21:3072 | self | UseUseExplosion.rb:21:3067:21:3072 | call to use | self |
+| UseUseExplosion.rb:21:3067:21:3072 | synthetic splat argument | UseUseExplosion.rb:21:3067:21:3072 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3071:21:3071 | x | UseUseExplosion.rb:21:3067:21:3072 | call to use | position 0 |
-| UseUseExplosion.rb:21:3083:21:3088 | * | UseUseExplosion.rb:21:3083:21:3088 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3083:21:3088 | self | UseUseExplosion.rb:21:3083:21:3088 | call to use | self |
+| UseUseExplosion.rb:21:3083:21:3088 | synthetic splat argument | UseUseExplosion.rb:21:3083:21:3088 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3087:21:3087 | x | UseUseExplosion.rb:21:3083:21:3088 | call to use | position 0 |
-| UseUseExplosion.rb:21:3099:21:3104 | * | UseUseExplosion.rb:21:3099:21:3104 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3099:21:3104 | self | UseUseExplosion.rb:21:3099:21:3104 | call to use | self |
+| UseUseExplosion.rb:21:3099:21:3104 | synthetic splat argument | UseUseExplosion.rb:21:3099:21:3104 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3103:21:3103 | x | UseUseExplosion.rb:21:3099:21:3104 | call to use | position 0 |
-| UseUseExplosion.rb:21:3115:21:3120 | * | UseUseExplosion.rb:21:3115:21:3120 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3115:21:3120 | self | UseUseExplosion.rb:21:3115:21:3120 | call to use | self |
+| UseUseExplosion.rb:21:3115:21:3120 | synthetic splat argument | UseUseExplosion.rb:21:3115:21:3120 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3119:21:3119 | x | UseUseExplosion.rb:21:3115:21:3120 | call to use | position 0 |
-| UseUseExplosion.rb:21:3131:21:3136 | * | UseUseExplosion.rb:21:3131:21:3136 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3131:21:3136 | self | UseUseExplosion.rb:21:3131:21:3136 | call to use | self |
+| UseUseExplosion.rb:21:3131:21:3136 | synthetic splat argument | UseUseExplosion.rb:21:3131:21:3136 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3135:21:3135 | x | UseUseExplosion.rb:21:3131:21:3136 | call to use | position 0 |
-| UseUseExplosion.rb:21:3147:21:3152 | * | UseUseExplosion.rb:21:3147:21:3152 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3147:21:3152 | self | UseUseExplosion.rb:21:3147:21:3152 | call to use | self |
+| UseUseExplosion.rb:21:3147:21:3152 | synthetic splat argument | UseUseExplosion.rb:21:3147:21:3152 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3151:21:3151 | x | UseUseExplosion.rb:21:3147:21:3152 | call to use | position 0 |
-| UseUseExplosion.rb:21:3163:21:3168 | * | UseUseExplosion.rb:21:3163:21:3168 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3163:21:3168 | self | UseUseExplosion.rb:21:3163:21:3168 | call to use | self |
+| UseUseExplosion.rb:21:3163:21:3168 | synthetic splat argument | UseUseExplosion.rb:21:3163:21:3168 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3167:21:3167 | x | UseUseExplosion.rb:21:3163:21:3168 | call to use | position 0 |
-| UseUseExplosion.rb:21:3179:21:3184 | * | UseUseExplosion.rb:21:3179:21:3184 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3179:21:3184 | self | UseUseExplosion.rb:21:3179:21:3184 | call to use | self |
+| UseUseExplosion.rb:21:3179:21:3184 | synthetic splat argument | UseUseExplosion.rb:21:3179:21:3184 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3183:21:3183 | x | UseUseExplosion.rb:21:3179:21:3184 | call to use | position 0 |
-| UseUseExplosion.rb:21:3195:21:3200 | * | UseUseExplosion.rb:21:3195:21:3200 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3195:21:3200 | self | UseUseExplosion.rb:21:3195:21:3200 | call to use | self |
+| UseUseExplosion.rb:21:3195:21:3200 | synthetic splat argument | UseUseExplosion.rb:21:3195:21:3200 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3199:21:3199 | x | UseUseExplosion.rb:21:3195:21:3200 | call to use | position 0 |
-| UseUseExplosion.rb:21:3211:21:3216 | * | UseUseExplosion.rb:21:3211:21:3216 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3211:21:3216 | self | UseUseExplosion.rb:21:3211:21:3216 | call to use | self |
+| UseUseExplosion.rb:21:3211:21:3216 | synthetic splat argument | UseUseExplosion.rb:21:3211:21:3216 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3215:21:3215 | x | UseUseExplosion.rb:21:3211:21:3216 | call to use | position 0 |
-| UseUseExplosion.rb:21:3227:21:3232 | * | UseUseExplosion.rb:21:3227:21:3232 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3227:21:3232 | self | UseUseExplosion.rb:21:3227:21:3232 | call to use | self |
+| UseUseExplosion.rb:21:3227:21:3232 | synthetic splat argument | UseUseExplosion.rb:21:3227:21:3232 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3231:21:3231 | x | UseUseExplosion.rb:21:3227:21:3232 | call to use | position 0 |
-| UseUseExplosion.rb:21:3243:21:3248 | * | UseUseExplosion.rb:21:3243:21:3248 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3243:21:3248 | self | UseUseExplosion.rb:21:3243:21:3248 | call to use | self |
+| UseUseExplosion.rb:21:3243:21:3248 | synthetic splat argument | UseUseExplosion.rb:21:3243:21:3248 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3247:21:3247 | x | UseUseExplosion.rb:21:3243:21:3248 | call to use | position 0 |
-| UseUseExplosion.rb:21:3259:21:3264 | * | UseUseExplosion.rb:21:3259:21:3264 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3259:21:3264 | self | UseUseExplosion.rb:21:3259:21:3264 | call to use | self |
+| UseUseExplosion.rb:21:3259:21:3264 | synthetic splat argument | UseUseExplosion.rb:21:3259:21:3264 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3263:21:3263 | x | UseUseExplosion.rb:21:3259:21:3264 | call to use | position 0 |
-| UseUseExplosion.rb:21:3275:21:3280 | * | UseUseExplosion.rb:21:3275:21:3280 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3275:21:3280 | self | UseUseExplosion.rb:21:3275:21:3280 | call to use | self |
+| UseUseExplosion.rb:21:3275:21:3280 | synthetic splat argument | UseUseExplosion.rb:21:3275:21:3280 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3279:21:3279 | x | UseUseExplosion.rb:21:3275:21:3280 | call to use | position 0 |
-| UseUseExplosion.rb:21:3291:21:3296 | * | UseUseExplosion.rb:21:3291:21:3296 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3291:21:3296 | self | UseUseExplosion.rb:21:3291:21:3296 | call to use | self |
+| UseUseExplosion.rb:21:3291:21:3296 | synthetic splat argument | UseUseExplosion.rb:21:3291:21:3296 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3295:21:3295 | x | UseUseExplosion.rb:21:3291:21:3296 | call to use | position 0 |
-| UseUseExplosion.rb:21:3307:21:3312 | * | UseUseExplosion.rb:21:3307:21:3312 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3307:21:3312 | self | UseUseExplosion.rb:21:3307:21:3312 | call to use | self |
+| UseUseExplosion.rb:21:3307:21:3312 | synthetic splat argument | UseUseExplosion.rb:21:3307:21:3312 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3311:21:3311 | x | UseUseExplosion.rb:21:3307:21:3312 | call to use | position 0 |
-| UseUseExplosion.rb:21:3323:21:3328 | * | UseUseExplosion.rb:21:3323:21:3328 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3323:21:3328 | self | UseUseExplosion.rb:21:3323:21:3328 | call to use | self |
+| UseUseExplosion.rb:21:3323:21:3328 | synthetic splat argument | UseUseExplosion.rb:21:3323:21:3328 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3327:21:3327 | x | UseUseExplosion.rb:21:3323:21:3328 | call to use | position 0 |
-| UseUseExplosion.rb:21:3339:21:3344 | * | UseUseExplosion.rb:21:3339:21:3344 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3339:21:3344 | self | UseUseExplosion.rb:21:3339:21:3344 | call to use | self |
+| UseUseExplosion.rb:21:3339:21:3344 | synthetic splat argument | UseUseExplosion.rb:21:3339:21:3344 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3343:21:3343 | x | UseUseExplosion.rb:21:3339:21:3344 | call to use | position 0 |
-| UseUseExplosion.rb:21:3355:21:3360 | * | UseUseExplosion.rb:21:3355:21:3360 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3355:21:3360 | self | UseUseExplosion.rb:21:3355:21:3360 | call to use | self |
+| UseUseExplosion.rb:21:3355:21:3360 | synthetic splat argument | UseUseExplosion.rb:21:3355:21:3360 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3359:21:3359 | x | UseUseExplosion.rb:21:3355:21:3360 | call to use | position 0 |
-| UseUseExplosion.rb:21:3371:21:3376 | * | UseUseExplosion.rb:21:3371:21:3376 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3371:21:3376 | self | UseUseExplosion.rb:21:3371:21:3376 | call to use | self |
+| UseUseExplosion.rb:21:3371:21:3376 | synthetic splat argument | UseUseExplosion.rb:21:3371:21:3376 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3375:21:3375 | x | UseUseExplosion.rb:21:3371:21:3376 | call to use | position 0 |
-| UseUseExplosion.rb:21:3387:21:3392 | * | UseUseExplosion.rb:21:3387:21:3392 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3387:21:3392 | self | UseUseExplosion.rb:21:3387:21:3392 | call to use | self |
+| UseUseExplosion.rb:21:3387:21:3392 | synthetic splat argument | UseUseExplosion.rb:21:3387:21:3392 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3391:21:3391 | x | UseUseExplosion.rb:21:3387:21:3392 | call to use | position 0 |
-| UseUseExplosion.rb:21:3403:21:3408 | * | UseUseExplosion.rb:21:3403:21:3408 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3403:21:3408 | self | UseUseExplosion.rb:21:3403:21:3408 | call to use | self |
+| UseUseExplosion.rb:21:3403:21:3408 | synthetic splat argument | UseUseExplosion.rb:21:3403:21:3408 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3407:21:3407 | x | UseUseExplosion.rb:21:3403:21:3408 | call to use | position 0 |
-| UseUseExplosion.rb:21:3419:21:3424 | * | UseUseExplosion.rb:21:3419:21:3424 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3419:21:3424 | self | UseUseExplosion.rb:21:3419:21:3424 | call to use | self |
+| UseUseExplosion.rb:21:3419:21:3424 | synthetic splat argument | UseUseExplosion.rb:21:3419:21:3424 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3423:21:3423 | x | UseUseExplosion.rb:21:3419:21:3424 | call to use | position 0 |
-| UseUseExplosion.rb:21:3435:21:3440 | * | UseUseExplosion.rb:21:3435:21:3440 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3435:21:3440 | self | UseUseExplosion.rb:21:3435:21:3440 | call to use | self |
+| UseUseExplosion.rb:21:3435:21:3440 | synthetic splat argument | UseUseExplosion.rb:21:3435:21:3440 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3439:21:3439 | x | UseUseExplosion.rb:21:3435:21:3440 | call to use | position 0 |
-| UseUseExplosion.rb:21:3451:21:3456 | * | UseUseExplosion.rb:21:3451:21:3456 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3451:21:3456 | self | UseUseExplosion.rb:21:3451:21:3456 | call to use | self |
+| UseUseExplosion.rb:21:3451:21:3456 | synthetic splat argument | UseUseExplosion.rb:21:3451:21:3456 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3455:21:3455 | x | UseUseExplosion.rb:21:3451:21:3456 | call to use | position 0 |
-| UseUseExplosion.rb:21:3467:21:3472 | * | UseUseExplosion.rb:21:3467:21:3472 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3467:21:3472 | self | UseUseExplosion.rb:21:3467:21:3472 | call to use | self |
+| UseUseExplosion.rb:21:3467:21:3472 | synthetic splat argument | UseUseExplosion.rb:21:3467:21:3472 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3471:21:3471 | x | UseUseExplosion.rb:21:3467:21:3472 | call to use | position 0 |
-| UseUseExplosion.rb:21:3483:21:3488 | * | UseUseExplosion.rb:21:3483:21:3488 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3483:21:3488 | self | UseUseExplosion.rb:21:3483:21:3488 | call to use | self |
+| UseUseExplosion.rb:21:3483:21:3488 | synthetic splat argument | UseUseExplosion.rb:21:3483:21:3488 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3487:21:3487 | x | UseUseExplosion.rb:21:3483:21:3488 | call to use | position 0 |
-| UseUseExplosion.rb:21:3499:21:3504 | * | UseUseExplosion.rb:21:3499:21:3504 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3499:21:3504 | self | UseUseExplosion.rb:21:3499:21:3504 | call to use | self |
+| UseUseExplosion.rb:21:3499:21:3504 | synthetic splat argument | UseUseExplosion.rb:21:3499:21:3504 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3503:21:3503 | x | UseUseExplosion.rb:21:3499:21:3504 | call to use | position 0 |
-| UseUseExplosion.rb:21:3515:21:3520 | * | UseUseExplosion.rb:21:3515:21:3520 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3515:21:3520 | self | UseUseExplosion.rb:21:3515:21:3520 | call to use | self |
+| UseUseExplosion.rb:21:3515:21:3520 | synthetic splat argument | UseUseExplosion.rb:21:3515:21:3520 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3519:21:3519 | x | UseUseExplosion.rb:21:3515:21:3520 | call to use | position 0 |
-| UseUseExplosion.rb:21:3531:21:3536 | * | UseUseExplosion.rb:21:3531:21:3536 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3531:21:3536 | self | UseUseExplosion.rb:21:3531:21:3536 | call to use | self |
+| UseUseExplosion.rb:21:3531:21:3536 | synthetic splat argument | UseUseExplosion.rb:21:3531:21:3536 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3535:21:3535 | x | UseUseExplosion.rb:21:3531:21:3536 | call to use | position 0 |
-| UseUseExplosion.rb:21:3547:21:3552 | * | UseUseExplosion.rb:21:3547:21:3552 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3547:21:3552 | self | UseUseExplosion.rb:21:3547:21:3552 | call to use | self |
+| UseUseExplosion.rb:21:3547:21:3552 | synthetic splat argument | UseUseExplosion.rb:21:3547:21:3552 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3551:21:3551 | x | UseUseExplosion.rb:21:3547:21:3552 | call to use | position 0 |
-| UseUseExplosion.rb:21:3563:21:3568 | * | UseUseExplosion.rb:21:3563:21:3568 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3563:21:3568 | self | UseUseExplosion.rb:21:3563:21:3568 | call to use | self |
+| UseUseExplosion.rb:21:3563:21:3568 | synthetic splat argument | UseUseExplosion.rb:21:3563:21:3568 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3567:21:3567 | x | UseUseExplosion.rb:21:3563:21:3568 | call to use | position 0 |
-| UseUseExplosion.rb:21:3579:21:3584 | * | UseUseExplosion.rb:21:3579:21:3584 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3579:21:3584 | self | UseUseExplosion.rb:21:3579:21:3584 | call to use | self |
+| UseUseExplosion.rb:21:3579:21:3584 | synthetic splat argument | UseUseExplosion.rb:21:3579:21:3584 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3583:21:3583 | x | UseUseExplosion.rb:21:3579:21:3584 | call to use | position 0 |
-| UseUseExplosion.rb:21:3595:21:3600 | * | UseUseExplosion.rb:21:3595:21:3600 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3595:21:3600 | self | UseUseExplosion.rb:21:3595:21:3600 | call to use | self |
+| UseUseExplosion.rb:21:3595:21:3600 | synthetic splat argument | UseUseExplosion.rb:21:3595:21:3600 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3599:21:3599 | x | UseUseExplosion.rb:21:3595:21:3600 | call to use | position 0 |
-| UseUseExplosion.rb:21:3611:21:3616 | * | UseUseExplosion.rb:21:3611:21:3616 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3611:21:3616 | self | UseUseExplosion.rb:21:3611:21:3616 | call to use | self |
+| UseUseExplosion.rb:21:3611:21:3616 | synthetic splat argument | UseUseExplosion.rb:21:3611:21:3616 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3615:21:3615 | x | UseUseExplosion.rb:21:3611:21:3616 | call to use | position 0 |
-| UseUseExplosion.rb:21:3627:21:3632 | * | UseUseExplosion.rb:21:3627:21:3632 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3627:21:3632 | self | UseUseExplosion.rb:21:3627:21:3632 | call to use | self |
+| UseUseExplosion.rb:21:3627:21:3632 | synthetic splat argument | UseUseExplosion.rb:21:3627:21:3632 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3631:21:3631 | x | UseUseExplosion.rb:21:3627:21:3632 | call to use | position 0 |
-| UseUseExplosion.rb:21:3643:21:3648 | * | UseUseExplosion.rb:21:3643:21:3648 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3643:21:3648 | self | UseUseExplosion.rb:21:3643:21:3648 | call to use | self |
+| UseUseExplosion.rb:21:3643:21:3648 | synthetic splat argument | UseUseExplosion.rb:21:3643:21:3648 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3647:21:3647 | x | UseUseExplosion.rb:21:3643:21:3648 | call to use | position 0 |
-| UseUseExplosion.rb:21:3659:21:3664 | * | UseUseExplosion.rb:21:3659:21:3664 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3659:21:3664 | self | UseUseExplosion.rb:21:3659:21:3664 | call to use | self |
+| UseUseExplosion.rb:21:3659:21:3664 | synthetic splat argument | UseUseExplosion.rb:21:3659:21:3664 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3663:21:3663 | x | UseUseExplosion.rb:21:3659:21:3664 | call to use | position 0 |
-| UseUseExplosion.rb:21:3675:21:3680 | * | UseUseExplosion.rb:21:3675:21:3680 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3675:21:3680 | self | UseUseExplosion.rb:21:3675:21:3680 | call to use | self |
+| UseUseExplosion.rb:21:3675:21:3680 | synthetic splat argument | UseUseExplosion.rb:21:3675:21:3680 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3679:21:3679 | x | UseUseExplosion.rb:21:3675:21:3680 | call to use | position 0 |
-| UseUseExplosion.rb:21:3691:21:3696 | * | UseUseExplosion.rb:21:3691:21:3696 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3691:21:3696 | self | UseUseExplosion.rb:21:3691:21:3696 | call to use | self |
+| UseUseExplosion.rb:21:3691:21:3696 | synthetic splat argument | UseUseExplosion.rb:21:3691:21:3696 | call to use | synthetic * |
 | UseUseExplosion.rb:21:3695:21:3695 | x | UseUseExplosion.rb:21:3691:21:3696 | call to use | position 0 |
-| local_dataflow.rb:3:8:3:10 | * | local_dataflow.rb:3:8:3:10 | call to p | synthetic * |
 | local_dataflow.rb:3:8:3:10 | self | local_dataflow.rb:3:8:3:10 | call to p | self |
+| local_dataflow.rb:3:8:3:10 | synthetic splat argument | local_dataflow.rb:3:8:3:10 | call to p | synthetic * |
 | local_dataflow.rb:3:10:3:10 | a | local_dataflow.rb:3:8:3:10 | call to p | position 0 |
 | local_dataflow.rb:6:8:6:8 | a | local_dataflow.rb:6:10:6:11 | ... + ... | self |
-| local_dataflow.rb:6:10:6:11 | * | local_dataflow.rb:6:10:6:11 | ... + ... | synthetic * |
+| local_dataflow.rb:6:10:6:11 | synthetic splat argument | local_dataflow.rb:6:10:6:11 | ... + ... | synthetic * |
 | local_dataflow.rb:6:13:6:13 | b | local_dataflow.rb:6:10:6:11 | ... + ... | position 0 |
-| local_dataflow.rb:9:9:9:15 | * | local_dataflow.rb:9:9:9:15 | call to [] | synthetic * |
 | local_dataflow.rb:9:9:9:15 | Array | local_dataflow.rb:9:9:9:15 | call to [] | self |
+| local_dataflow.rb:9:9:9:15 | synthetic splat argument | local_dataflow.rb:9:9:9:15 | call to [] | synthetic * |
 | local_dataflow.rb:9:10:9:10 | 1 | local_dataflow.rb:9:9:9:15 | call to [] | position 0 |
 | local_dataflow.rb:9:12:9:12 | 2 | local_dataflow.rb:9:9:9:15 | call to [] | position 1 |
 | local_dataflow.rb:9:14:9:14 | 3 | local_dataflow.rb:9:9:9:15 | call to [] | position 2 |
-| local_dataflow.rb:10:5:13:3 | * | local_dataflow.rb:10:5:13:3 | call to each | synthetic * |
+| local_dataflow.rb:10:5:13:3 | synthetic splat argument | local_dataflow.rb:10:5:13:3 | call to each | synthetic * |
 | local_dataflow.rb:10:5:13:3 | { ... } | local_dataflow.rb:10:5:13:3 | call to each | block |
-| local_dataflow.rb:10:9:10:9 | * | local_dataflow.rb:10:9:10:9 | [false] ! ... | synthetic * |
-| local_dataflow.rb:10:9:10:9 | * | local_dataflow.rb:10:9:10:9 | [true] ! ... | synthetic * |
-| local_dataflow.rb:10:9:10:9 | * | local_dataflow.rb:10:9:10:9 | defined? ... | synthetic * |
 | local_dataflow.rb:10:9:10:9 | defined? ... | local_dataflow.rb:10:9:10:9 | [false] ! ... | self |
 | local_dataflow.rb:10:9:10:9 | defined? ... | local_dataflow.rb:10:9:10:9 | [true] ! ... | self |
+| local_dataflow.rb:10:9:10:9 | synthetic splat argument | local_dataflow.rb:10:9:10:9 | [false] ! ... | synthetic * |
+| local_dataflow.rb:10:9:10:9 | synthetic splat argument | local_dataflow.rb:10:9:10:9 | [true] ! ... | synthetic * |
+| local_dataflow.rb:10:9:10:9 | synthetic splat argument | local_dataflow.rb:10:9:10:9 | defined? ... | synthetic * |
 | local_dataflow.rb:10:9:10:9 | x | local_dataflow.rb:10:9:10:9 | defined? ... | self |
 | local_dataflow.rb:10:14:10:18 | array | local_dataflow.rb:10:5:13:3 | call to each | self |
-| local_dataflow.rb:11:1:11:2 | * | local_dataflow.rb:11:1:11:2 | call to do | synthetic * |
 | local_dataflow.rb:11:1:11:2 | self | local_dataflow.rb:11:1:11:2 | call to do | self |
-| local_dataflow.rb:12:3:12:5 | * | local_dataflow.rb:12:3:12:5 | call to p | synthetic * |
+| local_dataflow.rb:11:1:11:2 | synthetic splat argument | local_dataflow.rb:11:1:11:2 | call to do | synthetic * |
 | local_dataflow.rb:12:3:12:5 | self | local_dataflow.rb:12:3:12:5 | call to p | self |
+| local_dataflow.rb:12:3:12:5 | synthetic splat argument | local_dataflow.rb:12:3:12:5 | call to p | synthetic * |
 | local_dataflow.rb:12:5:12:5 | x | local_dataflow.rb:12:3:12:5 | call to p | position 0 |
-| local_dataflow.rb:15:1:17:3 | * | local_dataflow.rb:15:1:17:3 | call to each | synthetic * |
+| local_dataflow.rb:15:1:17:3 | synthetic splat argument | local_dataflow.rb:15:1:17:3 | call to each | synthetic * |
 | local_dataflow.rb:15:1:17:3 | { ... } | local_dataflow.rb:15:1:17:3 | call to each | block |
-| local_dataflow.rb:15:5:15:5 | * | local_dataflow.rb:15:5:15:5 | [false] ! ... | synthetic * |
-| local_dataflow.rb:15:5:15:5 | * | local_dataflow.rb:15:5:15:5 | [true] ! ... | synthetic * |
-| local_dataflow.rb:15:5:15:5 | * | local_dataflow.rb:15:5:15:5 | defined? ... | synthetic * |
 | local_dataflow.rb:15:5:15:5 | defined? ... | local_dataflow.rb:15:5:15:5 | [false] ! ... | self |
 | local_dataflow.rb:15:5:15:5 | defined? ... | local_dataflow.rb:15:5:15:5 | [true] ! ... | self |
+| local_dataflow.rb:15:5:15:5 | synthetic splat argument | local_dataflow.rb:15:5:15:5 | [false] ! ... | synthetic * |
+| local_dataflow.rb:15:5:15:5 | synthetic splat argument | local_dataflow.rb:15:5:15:5 | [true] ! ... | synthetic * |
+| local_dataflow.rb:15:5:15:5 | synthetic splat argument | local_dataflow.rb:15:5:15:5 | defined? ... | synthetic * |
 | local_dataflow.rb:15:5:15:5 | x | local_dataflow.rb:15:5:15:5 | defined? ... | self |
 | local_dataflow.rb:15:10:15:14 | array | local_dataflow.rb:15:1:17:3 | call to each | self |
-| local_dataflow.rb:19:1:21:3 | * | local_dataflow.rb:19:1:21:3 | call to each | synthetic * |
+| local_dataflow.rb:19:1:21:3 | synthetic splat argument | local_dataflow.rb:19:1:21:3 | call to each | synthetic * |
 | local_dataflow.rb:19:1:21:3 | { ... } | local_dataflow.rb:19:1:21:3 | call to each | block |
-| local_dataflow.rb:19:5:19:5 | * | local_dataflow.rb:19:5:19:5 | [false] ! ... | synthetic * |
-| local_dataflow.rb:19:5:19:5 | * | local_dataflow.rb:19:5:19:5 | [true] ! ... | synthetic * |
-| local_dataflow.rb:19:5:19:5 | * | local_dataflow.rb:19:5:19:5 | defined? ... | synthetic * |
 | local_dataflow.rb:19:5:19:5 | defined? ... | local_dataflow.rb:19:5:19:5 | [false] ! ... | self |
 | local_dataflow.rb:19:5:19:5 | defined? ... | local_dataflow.rb:19:5:19:5 | [true] ! ... | self |
+| local_dataflow.rb:19:5:19:5 | synthetic splat argument | local_dataflow.rb:19:5:19:5 | [false] ! ... | synthetic * |
+| local_dataflow.rb:19:5:19:5 | synthetic splat argument | local_dataflow.rb:19:5:19:5 | [true] ! ... | synthetic * |
+| local_dataflow.rb:19:5:19:5 | synthetic splat argument | local_dataflow.rb:19:5:19:5 | defined? ... | synthetic * |
 | local_dataflow.rb:19:5:19:5 | x | local_dataflow.rb:19:5:19:5 | defined? ... | self |
 | local_dataflow.rb:19:10:19:14 | array | local_dataflow.rb:19:1:21:3 | call to each | self |
 | local_dataflow.rb:20:6:20:6 | x | local_dataflow.rb:20:6:20:10 | ... > ... | self |
-| local_dataflow.rb:20:6:20:10 | * | local_dataflow.rb:20:6:20:10 | ... > ... | synthetic * |
+| local_dataflow.rb:20:6:20:10 | synthetic splat argument | local_dataflow.rb:20:6:20:10 | ... > ... | synthetic * |
 | local_dataflow.rb:20:10:20:10 | 1 | local_dataflow.rb:20:6:20:10 | ... > ... | position 0 |
 | local_dataflow.rb:35:6:35:6 | x | local_dataflow.rb:35:6:35:11 | ... == ... | self |
-| local_dataflow.rb:35:6:35:11 | * | local_dataflow.rb:35:6:35:11 | ... == ... | synthetic * |
+| local_dataflow.rb:35:6:35:11 | synthetic splat argument | local_dataflow.rb:35:6:35:11 | ... == ... | synthetic * |
 | local_dataflow.rb:35:11:35:11 | 4 | local_dataflow.rb:35:6:35:11 | ... == ... | position 0 |
 | local_dataflow.rb:42:6:42:6 | x | local_dataflow.rb:42:6:42:11 | ... == ... | self |
-| local_dataflow.rb:42:6:42:11 | * | local_dataflow.rb:42:6:42:11 | ... == ... | synthetic * |
+| local_dataflow.rb:42:6:42:11 | synthetic splat argument | local_dataflow.rb:42:6:42:11 | ... == ... | synthetic * |
 | local_dataflow.rb:42:11:42:11 | 4 | local_dataflow.rb:42:6:42:11 | ... == ... | position 0 |
-| local_dataflow.rb:49:1:53:3 | * | local_dataflow.rb:49:1:53:3 | call to m | synthetic * |
 | local_dataflow.rb:49:1:53:3 | self | local_dataflow.rb:49:1:53:3 | call to m | self |
+| local_dataflow.rb:49:1:53:3 | synthetic splat argument | local_dataflow.rb:49:1:53:3 | call to m | synthetic * |
 | local_dataflow.rb:49:3:53:3 | do ... end | local_dataflow.rb:49:1:53:3 | call to m | block |
 | local_dataflow.rb:50:18:50:18 | x | local_dataflow.rb:50:18:50:22 | ... < ... | self |
-| local_dataflow.rb:50:18:50:22 | * | local_dataflow.rb:50:18:50:22 | ... < ... | synthetic * |
+| local_dataflow.rb:50:18:50:22 | synthetic splat argument | local_dataflow.rb:50:18:50:22 | ... < ... | synthetic * |
 | local_dataflow.rb:50:22:50:22 | 4 | local_dataflow.rb:50:18:50:22 | ... < ... | position 0 |
 | local_dataflow.rb:51:20:51:20 | x | local_dataflow.rb:51:20:51:24 | ... < ... | self |
-| local_dataflow.rb:51:20:51:24 | * | local_dataflow.rb:51:20:51:24 | ... < ... | synthetic * |
+| local_dataflow.rb:51:20:51:24 | synthetic splat argument | local_dataflow.rb:51:20:51:24 | ... < ... | synthetic * |
 | local_dataflow.rb:51:24:51:24 | 9 | local_dataflow.rb:51:20:51:24 | ... < ... | position 0 |
-| local_dataflow.rb:55:1:55:14 | * | local_dataflow.rb:55:1:55:14 | call to foo | synthetic * |
 | local_dataflow.rb:55:1:55:14 | self | local_dataflow.rb:55:1:55:14 | call to foo | self |
-| local_dataflow.rb:55:5:55:13 | * | local_dataflow.rb:55:5:55:13 | call to [] | synthetic * |
+| local_dataflow.rb:55:1:55:14 | synthetic splat argument | local_dataflow.rb:55:1:55:14 | call to foo | synthetic * |
 | local_dataflow.rb:55:5:55:13 | Array | local_dataflow.rb:55:5:55:13 | call to [] | self |
 | local_dataflow.rb:55:5:55:13 | call to [] | local_dataflow.rb:55:1:55:14 | call to foo | position 0 |
+| local_dataflow.rb:55:5:55:13 | synthetic splat argument | local_dataflow.rb:55:5:55:13 | call to [] | synthetic * |
 | local_dataflow.rb:55:6:55:6 | 1 | local_dataflow.rb:55:5:55:13 | call to [] | position 0 |
 | local_dataflow.rb:55:9:55:9 | 2 | local_dataflow.rb:55:5:55:13 | call to [] | position 1 |
 | local_dataflow.rb:55:12:55:12 | 3 | local_dataflow.rb:55:5:55:13 | call to [] | position 2 |
-| local_dataflow.rb:78:12:78:20 | * | local_dataflow.rb:78:12:78:20 | call to source | synthetic * |
 | local_dataflow.rb:78:12:78:20 | self | local_dataflow.rb:78:12:78:20 | call to source | self |
+| local_dataflow.rb:78:12:78:20 | synthetic splat argument | local_dataflow.rb:78:12:78:20 | call to source | synthetic * |
 | local_dataflow.rb:78:19:78:19 | 1 | local_dataflow.rb:78:12:78:20 | call to source | position 0 |
-| local_dataflow.rb:79:20:79:26 | * | local_dataflow.rb:79:20:79:26 | call to sink | synthetic * |
 | local_dataflow.rb:79:20:79:26 | self | local_dataflow.rb:79:20:79:26 | call to sink | self |
+| local_dataflow.rb:79:20:79:26 | synthetic splat argument | local_dataflow.rb:79:20:79:26 | call to sink | synthetic * |
 | local_dataflow.rb:79:25:79:25 | b | local_dataflow.rb:79:20:79:26 | call to sink | position 0 |
 | local_dataflow.rb:80:13:80:13 | a | local_dataflow.rb:80:13:80:17 | ... > ... | self |
-| local_dataflow.rb:80:13:80:17 | * | local_dataflow.rb:80:13:80:17 | ... > ... | synthetic * |
+| local_dataflow.rb:80:13:80:17 | synthetic splat argument | local_dataflow.rb:80:13:80:17 | ... > ... | synthetic * |
 | local_dataflow.rb:80:17:80:17 | 0 | local_dataflow.rb:80:13:80:17 | ... > ... | position 0 |
-| local_dataflow.rb:80:24:80:30 | * | local_dataflow.rb:80:24:80:30 | call to sink | synthetic * |
 | local_dataflow.rb:80:24:80:30 | self | local_dataflow.rb:80:24:80:30 | call to sink | self |
+| local_dataflow.rb:80:24:80:30 | synthetic splat argument | local_dataflow.rb:80:24:80:30 | call to sink | synthetic * |
 | local_dataflow.rb:80:29:80:29 | a | local_dataflow.rb:80:24:80:30 | call to sink | position 0 |
-| local_dataflow.rb:81:25:84:14 | * | local_dataflow.rb:81:25:84:14 | call to [] | synthetic * |
 | local_dataflow.rb:81:25:84:14 | Array | local_dataflow.rb:81:25:84:14 | call to [] | self |
-| local_dataflow.rb:82:7:82:13 | * | local_dataflow.rb:82:7:82:13 | call to sink | synthetic * |
+| local_dataflow.rb:81:25:84:14 | synthetic splat argument | local_dataflow.rb:81:25:84:14 | call to [] | synthetic * |
 | local_dataflow.rb:82:7:82:13 | call to sink | local_dataflow.rb:81:25:84:14 | call to [] | position 0 |
 | local_dataflow.rb:82:7:82:13 | self | local_dataflow.rb:82:7:82:13 | call to sink | self |
+| local_dataflow.rb:82:7:82:13 | synthetic splat argument | local_dataflow.rb:82:7:82:13 | call to sink | synthetic * |
 | local_dataflow.rb:82:12:82:12 | c | local_dataflow.rb:82:7:82:13 | call to sink | position 0 |
-| local_dataflow.rb:83:7:83:13 | * | local_dataflow.rb:83:7:83:13 | call to sink | synthetic * |
 | local_dataflow.rb:83:7:83:13 | call to sink | local_dataflow.rb:81:25:84:14 | call to [] | position 1 |
 | local_dataflow.rb:83:7:83:13 | self | local_dataflow.rb:83:7:83:13 | call to sink | self |
+| local_dataflow.rb:83:7:83:13 | synthetic splat argument | local_dataflow.rb:83:7:83:13 | call to sink | synthetic * |
 | local_dataflow.rb:83:12:83:12 | d | local_dataflow.rb:83:7:83:13 | call to sink | position 0 |
-| local_dataflow.rb:84:7:84:13 | * | local_dataflow.rb:84:7:84:13 | call to sink | synthetic * |
 | local_dataflow.rb:84:7:84:13 | call to sink | local_dataflow.rb:81:25:84:14 | call to [] | position 2 |
 | local_dataflow.rb:84:7:84:13 | self | local_dataflow.rb:84:7:84:13 | call to sink | self |
+| local_dataflow.rb:84:7:84:13 | synthetic splat argument | local_dataflow.rb:84:7:84:13 | call to sink | synthetic * |
 | local_dataflow.rb:84:12:84:12 | e | local_dataflow.rb:84:7:84:13 | call to sink | position 0 |
-| local_dataflow.rb:85:22:85:28 | * | local_dataflow.rb:85:22:85:28 | call to sink | synthetic * |
 | local_dataflow.rb:85:22:85:28 | self | local_dataflow.rb:85:22:85:28 | call to sink | self |
+| local_dataflow.rb:85:22:85:28 | synthetic splat argument | local_dataflow.rb:85:22:85:28 | call to sink | synthetic * |
 | local_dataflow.rb:85:27:85:27 | f | local_dataflow.rb:85:22:85:28 | call to sink | position 0 |
-| local_dataflow.rb:86:28:86:34 | * | local_dataflow.rb:86:28:86:34 | call to sink | synthetic * |
 | local_dataflow.rb:86:28:86:34 | self | local_dataflow.rb:86:28:86:34 | call to sink | self |
+| local_dataflow.rb:86:28:86:34 | synthetic splat argument | local_dataflow.rb:86:28:86:34 | call to sink | synthetic * |
 | local_dataflow.rb:86:33:86:33 | g | local_dataflow.rb:86:28:86:34 | call to sink | position 0 |
-| local_dataflow.rb:87:20:87:26 | * | local_dataflow.rb:87:20:87:26 | call to sink | synthetic * |
 | local_dataflow.rb:87:20:87:26 | self | local_dataflow.rb:87:20:87:26 | call to sink | self |
+| local_dataflow.rb:87:20:87:26 | synthetic splat argument | local_dataflow.rb:87:20:87:26 | call to sink | synthetic * |
 | local_dataflow.rb:87:25:87:25 | x | local_dataflow.rb:87:20:87:26 | call to sink | position 0 |
-| local_dataflow.rb:89:3:89:9 | * | local_dataflow.rb:89:3:89:9 | call to sink | synthetic * |
 | local_dataflow.rb:89:3:89:9 | self | local_dataflow.rb:89:3:89:9 | call to sink | self |
+| local_dataflow.rb:89:3:89:9 | synthetic splat argument | local_dataflow.rb:89:3:89:9 | call to sink | synthetic * |
 | local_dataflow.rb:89:8:89:8 | z | local_dataflow.rb:89:3:89:9 | call to sink | position 0 |
-| local_dataflow.rb:93:7:93:15 | * | local_dataflow.rb:93:7:93:15 | call to source | synthetic * |
 | local_dataflow.rb:93:7:93:15 | call to source | local_dataflow.rb:93:7:93:28 | ... \|\| ... | self |
 | local_dataflow.rb:93:7:93:15 | self | local_dataflow.rb:93:7:93:15 | call to source | self |
-| local_dataflow.rb:93:7:93:28 | * | local_dataflow.rb:93:7:93:28 | ... \|\| ... | synthetic * |
+| local_dataflow.rb:93:7:93:15 | synthetic splat argument | local_dataflow.rb:93:7:93:15 | call to source | synthetic * |
+| local_dataflow.rb:93:7:93:28 | synthetic splat argument | local_dataflow.rb:93:7:93:28 | ... \|\| ... | synthetic * |
 | local_dataflow.rb:93:14:93:14 | 1 | local_dataflow.rb:93:7:93:15 | call to source | position 0 |
-| local_dataflow.rb:93:20:93:28 | * | local_dataflow.rb:93:20:93:28 | call to source | synthetic * |
 | local_dataflow.rb:93:20:93:28 | call to source | local_dataflow.rb:93:7:93:28 | ... \|\| ... | position 0 |
 | local_dataflow.rb:93:20:93:28 | self | local_dataflow.rb:93:20:93:28 | call to source | self |
+| local_dataflow.rb:93:20:93:28 | synthetic splat argument | local_dataflow.rb:93:20:93:28 | call to source | synthetic * |
 | local_dataflow.rb:93:27:93:27 | 2 | local_dataflow.rb:93:20:93:28 | call to source | position 0 |
-| local_dataflow.rb:94:3:94:9 | * | local_dataflow.rb:94:3:94:9 | call to sink | synthetic * |
 | local_dataflow.rb:94:3:94:9 | self | local_dataflow.rb:94:3:94:9 | call to sink | self |
+| local_dataflow.rb:94:3:94:9 | synthetic splat argument | local_dataflow.rb:94:3:94:9 | call to sink | synthetic * |
 | local_dataflow.rb:94:8:94:8 | a | local_dataflow.rb:94:3:94:9 | call to sink | position 0 |
-| local_dataflow.rb:95:8:95:16 | * | local_dataflow.rb:95:8:95:16 | call to source | synthetic * |
 | local_dataflow.rb:95:8:95:16 | call to source | local_dataflow.rb:95:8:95:29 | ... or ... | self |
 | local_dataflow.rb:95:8:95:16 | self | local_dataflow.rb:95:8:95:16 | call to source | self |
-| local_dataflow.rb:95:8:95:29 | * | local_dataflow.rb:95:8:95:29 | ... or ... | synthetic * |
+| local_dataflow.rb:95:8:95:16 | synthetic splat argument | local_dataflow.rb:95:8:95:16 | call to source | synthetic * |
+| local_dataflow.rb:95:8:95:29 | synthetic splat argument | local_dataflow.rb:95:8:95:29 | ... or ... | synthetic * |
 | local_dataflow.rb:95:15:95:15 | 1 | local_dataflow.rb:95:8:95:16 | call to source | position 0 |
-| local_dataflow.rb:95:21:95:29 | * | local_dataflow.rb:95:21:95:29 | call to source | synthetic * |
 | local_dataflow.rb:95:21:95:29 | call to source | local_dataflow.rb:95:8:95:29 | ... or ... | position 0 |
 | local_dataflow.rb:95:21:95:29 | self | local_dataflow.rb:95:21:95:29 | call to source | self |
+| local_dataflow.rb:95:21:95:29 | synthetic splat argument | local_dataflow.rb:95:21:95:29 | call to source | synthetic * |
 | local_dataflow.rb:95:28:95:28 | 2 | local_dataflow.rb:95:21:95:29 | call to source | position 0 |
-| local_dataflow.rb:96:3:96:9 | * | local_dataflow.rb:96:3:96:9 | call to sink | synthetic * |
 | local_dataflow.rb:96:3:96:9 | self | local_dataflow.rb:96:3:96:9 | call to sink | self |
+| local_dataflow.rb:96:3:96:9 | synthetic splat argument | local_dataflow.rb:96:3:96:9 | call to sink | synthetic * |
 | local_dataflow.rb:96:8:96:8 | b | local_dataflow.rb:96:3:96:9 | call to sink | position 0 |
-| local_dataflow.rb:98:7:98:15 | * | local_dataflow.rb:98:7:98:15 | call to source | synthetic * |
 | local_dataflow.rb:98:7:98:15 | call to source | local_dataflow.rb:98:7:98:28 | ... && ... | self |
 | local_dataflow.rb:98:7:98:15 | self | local_dataflow.rb:98:7:98:15 | call to source | self |
-| local_dataflow.rb:98:7:98:28 | * | local_dataflow.rb:98:7:98:28 | ... && ... | synthetic * |
+| local_dataflow.rb:98:7:98:15 | synthetic splat argument | local_dataflow.rb:98:7:98:15 | call to source | synthetic * |
+| local_dataflow.rb:98:7:98:28 | synthetic splat argument | local_dataflow.rb:98:7:98:28 | ... && ... | synthetic * |
 | local_dataflow.rb:98:14:98:14 | 1 | local_dataflow.rb:98:7:98:15 | call to source | position 0 |
-| local_dataflow.rb:98:20:98:28 | * | local_dataflow.rb:98:20:98:28 | call to source | synthetic * |
 | local_dataflow.rb:98:20:98:28 | call to source | local_dataflow.rb:98:7:98:28 | ... && ... | position 0 |
 | local_dataflow.rb:98:20:98:28 | self | local_dataflow.rb:98:20:98:28 | call to source | self |
+| local_dataflow.rb:98:20:98:28 | synthetic splat argument | local_dataflow.rb:98:20:98:28 | call to source | synthetic * |
 | local_dataflow.rb:98:27:98:27 | 2 | local_dataflow.rb:98:20:98:28 | call to source | position 0 |
-| local_dataflow.rb:99:3:99:9 | * | local_dataflow.rb:99:3:99:9 | call to sink | synthetic * |
 | local_dataflow.rb:99:3:99:9 | self | local_dataflow.rb:99:3:99:9 | call to sink | self |
+| local_dataflow.rb:99:3:99:9 | synthetic splat argument | local_dataflow.rb:99:3:99:9 | call to sink | synthetic * |
 | local_dataflow.rb:99:8:99:8 | a | local_dataflow.rb:99:3:99:9 | call to sink | position 0 |
-| local_dataflow.rb:100:8:100:16 | * | local_dataflow.rb:100:8:100:16 | call to source | synthetic * |
 | local_dataflow.rb:100:8:100:16 | call to source | local_dataflow.rb:100:8:100:30 | ... and ... | self |
 | local_dataflow.rb:100:8:100:16 | self | local_dataflow.rb:100:8:100:16 | call to source | self |
-| local_dataflow.rb:100:8:100:30 | * | local_dataflow.rb:100:8:100:30 | ... and ... | synthetic * |
+| local_dataflow.rb:100:8:100:16 | synthetic splat argument | local_dataflow.rb:100:8:100:16 | call to source | synthetic * |
+| local_dataflow.rb:100:8:100:30 | synthetic splat argument | local_dataflow.rb:100:8:100:30 | ... and ... | synthetic * |
 | local_dataflow.rb:100:15:100:15 | 1 | local_dataflow.rb:100:8:100:16 | call to source | position 0 |
-| local_dataflow.rb:100:22:100:30 | * | local_dataflow.rb:100:22:100:30 | call to source | synthetic * |
 | local_dataflow.rb:100:22:100:30 | call to source | local_dataflow.rb:100:8:100:30 | ... and ... | position 0 |
 | local_dataflow.rb:100:22:100:30 | self | local_dataflow.rb:100:22:100:30 | call to source | self |
+| local_dataflow.rb:100:22:100:30 | synthetic splat argument | local_dataflow.rb:100:22:100:30 | call to source | synthetic * |
 | local_dataflow.rb:100:29:100:29 | 2 | local_dataflow.rb:100:22:100:30 | call to source | position 0 |
-| local_dataflow.rb:101:3:101:9 | * | local_dataflow.rb:101:3:101:9 | call to sink | synthetic * |
 | local_dataflow.rb:101:3:101:9 | self | local_dataflow.rb:101:3:101:9 | call to sink | self |
+| local_dataflow.rb:101:3:101:9 | synthetic splat argument | local_dataflow.rb:101:3:101:9 | call to sink | synthetic * |
 | local_dataflow.rb:101:8:101:8 | b | local_dataflow.rb:101:3:101:9 | call to sink | position 0 |
-| local_dataflow.rb:103:7:103:15 | * | local_dataflow.rb:103:7:103:15 | call to source | synthetic * |
 | local_dataflow.rb:103:7:103:15 | self | local_dataflow.rb:103:7:103:15 | call to source | self |
+| local_dataflow.rb:103:7:103:15 | synthetic splat argument | local_dataflow.rb:103:7:103:15 | call to source | synthetic * |
 | local_dataflow.rb:103:14:103:14 | 5 | local_dataflow.rb:103:7:103:15 | call to source | position 0 |
 | local_dataflow.rb:104:3:104:3 | a | local_dataflow.rb:104:5:104:7 | ... \|\| ... | self |
-| local_dataflow.rb:104:5:104:7 | * | local_dataflow.rb:104:5:104:7 | ... \|\| ... | synthetic * |
-| local_dataflow.rb:104:9:104:17 | * | local_dataflow.rb:104:9:104:17 | call to source | synthetic * |
+| local_dataflow.rb:104:5:104:7 | synthetic splat argument | local_dataflow.rb:104:5:104:7 | ... \|\| ... | synthetic * |
 | local_dataflow.rb:104:9:104:17 | call to source | local_dataflow.rb:104:5:104:7 | ... \|\| ... | position 0 |
 | local_dataflow.rb:104:9:104:17 | self | local_dataflow.rb:104:9:104:17 | call to source | self |
+| local_dataflow.rb:104:9:104:17 | synthetic splat argument | local_dataflow.rb:104:9:104:17 | call to source | synthetic * |
 | local_dataflow.rb:104:16:104:16 | 6 | local_dataflow.rb:104:9:104:17 | call to source | position 0 |
-| local_dataflow.rb:105:3:105:9 | * | local_dataflow.rb:105:3:105:9 | call to sink | synthetic * |
 | local_dataflow.rb:105:3:105:9 | self | local_dataflow.rb:105:3:105:9 | call to sink | self |
+| local_dataflow.rb:105:3:105:9 | synthetic splat argument | local_dataflow.rb:105:3:105:9 | call to sink | synthetic * |
 | local_dataflow.rb:105:8:105:8 | a | local_dataflow.rb:105:3:105:9 | call to sink | position 0 |
-| local_dataflow.rb:106:7:106:15 | * | local_dataflow.rb:106:7:106:15 | call to source | synthetic * |
 | local_dataflow.rb:106:7:106:15 | self | local_dataflow.rb:106:7:106:15 | call to source | self |
+| local_dataflow.rb:106:7:106:15 | synthetic splat argument | local_dataflow.rb:106:7:106:15 | call to source | synthetic * |
 | local_dataflow.rb:106:14:106:14 | 7 | local_dataflow.rb:106:7:106:15 | call to source | position 0 |
 | local_dataflow.rb:107:3:107:3 | b | local_dataflow.rb:107:5:107:7 | ... && ... | self |
-| local_dataflow.rb:107:5:107:7 | * | local_dataflow.rb:107:5:107:7 | ... && ... | synthetic * |
-| local_dataflow.rb:107:9:107:17 | * | local_dataflow.rb:107:9:107:17 | call to source | synthetic * |
+| local_dataflow.rb:107:5:107:7 | synthetic splat argument | local_dataflow.rb:107:5:107:7 | ... && ... | synthetic * |
 | local_dataflow.rb:107:9:107:17 | call to source | local_dataflow.rb:107:5:107:7 | ... && ... | position 0 |
 | local_dataflow.rb:107:9:107:17 | self | local_dataflow.rb:107:9:107:17 | call to source | self |
+| local_dataflow.rb:107:9:107:17 | synthetic splat argument | local_dataflow.rb:107:9:107:17 | call to source | synthetic * |
 | local_dataflow.rb:107:16:107:16 | 8 | local_dataflow.rb:107:9:107:17 | call to source | position 0 |
-| local_dataflow.rb:108:3:108:9 | * | local_dataflow.rb:108:3:108:9 | call to sink | synthetic * |
 | local_dataflow.rb:108:3:108:9 | self | local_dataflow.rb:108:3:108:9 | call to sink | self |
+| local_dataflow.rb:108:3:108:9 | synthetic splat argument | local_dataflow.rb:108:3:108:9 | call to sink | synthetic * |
 | local_dataflow.rb:108:8:108:8 | b | local_dataflow.rb:108:3:108:9 | call to sink | position 0 |
-| local_dataflow.rb:112:3:112:21 | * | local_dataflow.rb:112:3:112:21 | call to sink | synthetic * |
 | local_dataflow.rb:112:3:112:21 | self | local_dataflow.rb:112:3:112:21 | call to sink | self |
-| local_dataflow.rb:112:8:112:16 | * | local_dataflow.rb:112:8:112:16 | call to source | synthetic * |
+| local_dataflow.rb:112:3:112:21 | synthetic splat argument | local_dataflow.rb:112:3:112:21 | call to sink | synthetic * |
 | local_dataflow.rb:112:8:112:16 | call to source | local_dataflow.rb:112:8:112:20 | call to dup | self |
 | local_dataflow.rb:112:8:112:16 | self | local_dataflow.rb:112:8:112:16 | call to source | self |
-| local_dataflow.rb:112:8:112:20 | * | local_dataflow.rb:112:8:112:20 | call to dup | synthetic * |
+| local_dataflow.rb:112:8:112:16 | synthetic splat argument | local_dataflow.rb:112:8:112:16 | call to source | synthetic * |
 | local_dataflow.rb:112:8:112:20 | call to dup | local_dataflow.rb:112:3:112:21 | call to sink | position 0 |
+| local_dataflow.rb:112:8:112:20 | synthetic splat argument | local_dataflow.rb:112:8:112:20 | call to dup | synthetic * |
 | local_dataflow.rb:112:15:112:15 | 1 | local_dataflow.rb:112:8:112:16 | call to source | position 0 |
-| local_dataflow.rb:113:3:113:25 | * | local_dataflow.rb:113:3:113:25 | call to sink | synthetic * |
 | local_dataflow.rb:113:3:113:25 | self | local_dataflow.rb:113:3:113:25 | call to sink | self |
-| local_dataflow.rb:113:8:113:16 | * | local_dataflow.rb:113:8:113:16 | call to source | synthetic * |
+| local_dataflow.rb:113:3:113:25 | synthetic splat argument | local_dataflow.rb:113:3:113:25 | call to sink | synthetic * |
 | local_dataflow.rb:113:8:113:16 | call to source | local_dataflow.rb:113:8:113:20 | call to dup | self |
 | local_dataflow.rb:113:8:113:16 | self | local_dataflow.rb:113:8:113:16 | call to source | self |
-| local_dataflow.rb:113:8:113:20 | * | local_dataflow.rb:113:8:113:20 | call to dup | synthetic * |
+| local_dataflow.rb:113:8:113:16 | synthetic splat argument | local_dataflow.rb:113:8:113:16 | call to source | synthetic * |
 | local_dataflow.rb:113:8:113:20 | call to dup | local_dataflow.rb:113:8:113:24 | call to dup | self |
-| local_dataflow.rb:113:8:113:24 | * | local_dataflow.rb:113:8:113:24 | call to dup | synthetic * |
+| local_dataflow.rb:113:8:113:20 | synthetic splat argument | local_dataflow.rb:113:8:113:20 | call to dup | synthetic * |
 | local_dataflow.rb:113:8:113:24 | call to dup | local_dataflow.rb:113:3:113:25 | call to sink | position 0 |
+| local_dataflow.rb:113:8:113:24 | synthetic splat argument | local_dataflow.rb:113:8:113:24 | call to dup | synthetic * |
 | local_dataflow.rb:113:15:113:15 | 1 | local_dataflow.rb:113:8:113:16 | call to source | position 0 |
-| local_dataflow.rb:117:3:117:24 | * | local_dataflow.rb:117:3:117:24 | call to sink | synthetic * |
 | local_dataflow.rb:117:3:117:24 | self | local_dataflow.rb:117:3:117:24 | call to sink | self |
-| local_dataflow.rb:117:8:117:16 | * | local_dataflow.rb:117:8:117:16 | call to source | synthetic * |
+| local_dataflow.rb:117:3:117:24 | synthetic splat argument | local_dataflow.rb:117:3:117:24 | call to sink | synthetic * |
 | local_dataflow.rb:117:8:117:16 | call to source | local_dataflow.rb:117:8:117:23 | call to tap | self |
 | local_dataflow.rb:117:8:117:16 | self | local_dataflow.rb:117:8:117:16 | call to source | self |
-| local_dataflow.rb:117:8:117:23 | * | local_dataflow.rb:117:8:117:23 | call to tap | synthetic * |
+| local_dataflow.rb:117:8:117:16 | synthetic splat argument | local_dataflow.rb:117:8:117:16 | call to source | synthetic * |
 | local_dataflow.rb:117:8:117:23 | call to tap | local_dataflow.rb:117:3:117:24 | call to sink | position 0 |
+| local_dataflow.rb:117:8:117:23 | synthetic splat argument | local_dataflow.rb:117:8:117:23 | call to tap | synthetic * |
 | local_dataflow.rb:117:15:117:15 | 1 | local_dataflow.rb:117:8:117:16 | call to source | position 0 |
 | local_dataflow.rb:117:22:117:23 | { ... } | local_dataflow.rb:117:8:117:23 | call to tap | block |
-| local_dataflow.rb:118:3:118:11 | * | local_dataflow.rb:118:3:118:11 | call to source | synthetic * |
 | local_dataflow.rb:118:3:118:11 | call to source | local_dataflow.rb:118:3:118:31 | call to tap | self |
 | local_dataflow.rb:118:3:118:11 | self | local_dataflow.rb:118:3:118:11 | call to source | self |
-| local_dataflow.rb:118:3:118:31 | * | local_dataflow.rb:118:3:118:31 | call to tap | synthetic * |
+| local_dataflow.rb:118:3:118:11 | synthetic splat argument | local_dataflow.rb:118:3:118:11 | call to source | synthetic * |
+| local_dataflow.rb:118:3:118:31 | synthetic splat argument | local_dataflow.rb:118:3:118:31 | call to tap | synthetic * |
 | local_dataflow.rb:118:10:118:10 | 1 | local_dataflow.rb:118:3:118:11 | call to source | position 0 |
 | local_dataflow.rb:118:17:118:31 | { ... } | local_dataflow.rb:118:3:118:31 | call to tap | block |
-| local_dataflow.rb:118:23:118:29 | * | local_dataflow.rb:118:23:118:29 | call to sink | synthetic * |
 | local_dataflow.rb:118:23:118:29 | self | local_dataflow.rb:118:23:118:29 | call to sink | self |
+| local_dataflow.rb:118:23:118:29 | synthetic splat argument | local_dataflow.rb:118:23:118:29 | call to sink | synthetic * |
 | local_dataflow.rb:118:28:118:28 | x | local_dataflow.rb:118:23:118:29 | call to sink | position 0 |
-| local_dataflow.rb:119:3:119:31 | * | local_dataflow.rb:119:3:119:31 | call to sink | synthetic * |
 | local_dataflow.rb:119:3:119:31 | self | local_dataflow.rb:119:3:119:31 | call to sink | self |
-| local_dataflow.rb:119:8:119:16 | * | local_dataflow.rb:119:8:119:16 | call to source | synthetic * |
+| local_dataflow.rb:119:3:119:31 | synthetic splat argument | local_dataflow.rb:119:3:119:31 | call to sink | synthetic * |
 | local_dataflow.rb:119:8:119:16 | call to source | local_dataflow.rb:119:8:119:23 | call to tap | self |
 | local_dataflow.rb:119:8:119:16 | self | local_dataflow.rb:119:8:119:16 | call to source | self |
-| local_dataflow.rb:119:8:119:23 | * | local_dataflow.rb:119:8:119:23 | call to tap | synthetic * |
+| local_dataflow.rb:119:8:119:16 | synthetic splat argument | local_dataflow.rb:119:8:119:16 | call to source | synthetic * |
 | local_dataflow.rb:119:8:119:23 | call to tap | local_dataflow.rb:119:8:119:30 | call to tap | self |
-| local_dataflow.rb:119:8:119:30 | * | local_dataflow.rb:119:8:119:30 | call to tap | synthetic * |
+| local_dataflow.rb:119:8:119:23 | synthetic splat argument | local_dataflow.rb:119:8:119:23 | call to tap | synthetic * |
 | local_dataflow.rb:119:8:119:30 | call to tap | local_dataflow.rb:119:3:119:31 | call to sink | position 0 |
+| local_dataflow.rb:119:8:119:30 | synthetic splat argument | local_dataflow.rb:119:8:119:30 | call to tap | synthetic * |
 | local_dataflow.rb:119:15:119:15 | 1 | local_dataflow.rb:119:8:119:16 | call to source | position 0 |
 | local_dataflow.rb:119:22:119:23 | { ... } | local_dataflow.rb:119:8:119:23 | call to tap | block |
 | local_dataflow.rb:119:29:119:30 | { ... } | local_dataflow.rb:119:8:119:30 | call to tap | block |
-| local_dataflow.rb:123:3:123:50 | * | local_dataflow.rb:123:3:123:50 | call to sink | synthetic * |
 | local_dataflow.rb:123:3:123:50 | self | local_dataflow.rb:123:3:123:50 | call to sink | self |
-| local_dataflow.rb:123:8:123:16 | * | local_dataflow.rb:123:8:123:16 | call to source | synthetic * |
+| local_dataflow.rb:123:3:123:50 | synthetic splat argument | local_dataflow.rb:123:3:123:50 | call to sink | synthetic * |
 | local_dataflow.rb:123:8:123:16 | call to source | local_dataflow.rb:123:8:123:20 | call to dup | self |
 | local_dataflow.rb:123:8:123:16 | self | local_dataflow.rb:123:8:123:16 | call to source | self |
-| local_dataflow.rb:123:8:123:20 | * | local_dataflow.rb:123:8:123:20 | call to dup | synthetic * |
+| local_dataflow.rb:123:8:123:16 | synthetic splat argument | local_dataflow.rb:123:8:123:16 | call to source | synthetic * |
 | local_dataflow.rb:123:8:123:20 | call to dup | local_dataflow.rb:123:8:123:45 | call to tap | self |
-| local_dataflow.rb:123:8:123:45 | * | local_dataflow.rb:123:8:123:45 | call to tap | synthetic * |
+| local_dataflow.rb:123:8:123:20 | synthetic splat argument | local_dataflow.rb:123:8:123:20 | call to dup | synthetic * |
 | local_dataflow.rb:123:8:123:45 | call to tap | local_dataflow.rb:123:8:123:49 | call to dup | self |
-| local_dataflow.rb:123:8:123:49 | * | local_dataflow.rb:123:8:123:49 | call to dup | synthetic * |
+| local_dataflow.rb:123:8:123:45 | synthetic splat argument | local_dataflow.rb:123:8:123:45 | call to tap | synthetic * |
 | local_dataflow.rb:123:8:123:49 | call to dup | local_dataflow.rb:123:3:123:50 | call to sink | position 0 |
+| local_dataflow.rb:123:8:123:49 | synthetic splat argument | local_dataflow.rb:123:8:123:49 | call to dup | synthetic * |
 | local_dataflow.rb:123:15:123:15 | 1 | local_dataflow.rb:123:8:123:16 | call to source | position 0 |
 | local_dataflow.rb:123:26:123:45 | { ... } | local_dataflow.rb:123:8:123:45 | call to tap | block |
-| local_dataflow.rb:123:32:123:43 | * | local_dataflow.rb:123:32:123:43 | call to puts | synthetic * |
 | local_dataflow.rb:123:32:123:43 | self | local_dataflow.rb:123:32:123:43 | call to puts | self |
+| local_dataflow.rb:123:32:123:43 | synthetic splat argument | local_dataflow.rb:123:32:123:43 | call to puts | synthetic * |
 | local_dataflow.rb:123:37:123:43 | "hello" | local_dataflow.rb:123:32:123:43 | call to puts | position 0 |
-| local_dataflow.rb:127:3:127:8 | * | local_dataflow.rb:127:3:127:8 | call to rand | synthetic * |
 | local_dataflow.rb:127:3:127:8 | self | local_dataflow.rb:127:3:127:8 | call to rand | self |
-| local_dataflow.rb:132:6:132:11 | * | local_dataflow.rb:132:6:132:11 | call to use | synthetic * |
+| local_dataflow.rb:127:3:127:8 | synthetic splat argument | local_dataflow.rb:127:3:127:8 | call to rand | synthetic * |
 | local_dataflow.rb:132:6:132:11 | self | local_dataflow.rb:132:6:132:11 | call to use | self |
+| local_dataflow.rb:132:6:132:11 | synthetic splat argument | local_dataflow.rb:132:6:132:11 | call to use | synthetic * |
 | local_dataflow.rb:132:10:132:10 | x | local_dataflow.rb:132:6:132:11 | call to use | position 0 |
-| local_dataflow.rb:133:8:133:13 | * | local_dataflow.rb:133:8:133:13 | call to use | synthetic * |
 | local_dataflow.rb:133:8:133:13 | call to use | local_dataflow.rb:133:8:133:23 | [false] ... \|\| ... | self |
 | local_dataflow.rb:133:8:133:13 | call to use | local_dataflow.rb:133:8:133:23 | [true] ... \|\| ... | self |
 | local_dataflow.rb:133:8:133:13 | self | local_dataflow.rb:133:8:133:13 | call to use | self |
-| local_dataflow.rb:133:8:133:23 | * | local_dataflow.rb:133:8:133:23 | [false] ... \|\| ... | synthetic * |
-| local_dataflow.rb:133:8:133:23 | * | local_dataflow.rb:133:8:133:23 | [true] ... \|\| ... | synthetic * |
+| local_dataflow.rb:133:8:133:13 | synthetic splat argument | local_dataflow.rb:133:8:133:13 | call to use | synthetic * |
+| local_dataflow.rb:133:8:133:23 | synthetic splat argument | local_dataflow.rb:133:8:133:23 | [false] ... \|\| ... | synthetic * |
+| local_dataflow.rb:133:8:133:23 | synthetic splat argument | local_dataflow.rb:133:8:133:23 | [true] ... \|\| ... | synthetic * |
 | local_dataflow.rb:133:12:133:12 | x | local_dataflow.rb:133:8:133:13 | call to use | position 0 |
-| local_dataflow.rb:133:18:133:23 | * | local_dataflow.rb:133:18:133:23 | call to use | synthetic * |
 | local_dataflow.rb:133:18:133:23 | call to use | local_dataflow.rb:133:8:133:23 | [false] ... \|\| ... | position 0 |
 | local_dataflow.rb:133:18:133:23 | call to use | local_dataflow.rb:133:8:133:23 | [true] ... \|\| ... | position 0 |
 | local_dataflow.rb:133:18:133:23 | self | local_dataflow.rb:133:18:133:23 | call to use | self |
+| local_dataflow.rb:133:18:133:23 | synthetic splat argument | local_dataflow.rb:133:18:133:23 | call to use | synthetic * |
 | local_dataflow.rb:133:22:133:22 | x | local_dataflow.rb:133:18:133:23 | call to use | position 0 |
-| local_dataflow.rb:134:7:134:12 | * | local_dataflow.rb:134:7:134:12 | call to use | synthetic * |
 | local_dataflow.rb:134:7:134:12 | self | local_dataflow.rb:134:7:134:12 | call to use | self |
+| local_dataflow.rb:134:7:134:12 | synthetic splat argument | local_dataflow.rb:134:7:134:12 | call to use | synthetic * |
 | local_dataflow.rb:134:11:134:11 | x | local_dataflow.rb:134:7:134:12 | call to use | position 0 |
-| local_dataflow.rb:136:7:136:12 | * | local_dataflow.rb:136:7:136:12 | call to use | synthetic * |
 | local_dataflow.rb:136:7:136:12 | self | local_dataflow.rb:136:7:136:12 | call to use | self |
+| local_dataflow.rb:136:7:136:12 | synthetic splat argument | local_dataflow.rb:136:7:136:12 | call to use | synthetic * |
 | local_dataflow.rb:136:11:136:11 | x | local_dataflow.rb:136:7:136:12 | call to use | position 0 |
-| local_dataflow.rb:137:10:137:15 | * | local_dataflow.rb:137:10:137:15 | call to use | synthetic * |
 | local_dataflow.rb:137:10:137:15 | call to use | local_dataflow.rb:137:10:137:26 | [false] ... && ... | self |
 | local_dataflow.rb:137:10:137:15 | call to use | local_dataflow.rb:137:10:137:26 | [true] ... && ... | self |
 | local_dataflow.rb:137:10:137:15 | self | local_dataflow.rb:137:10:137:15 | call to use | self |
-| local_dataflow.rb:137:10:137:26 | * | local_dataflow.rb:137:10:137:26 | [false] ... && ... | synthetic * |
-| local_dataflow.rb:137:10:137:26 | * | local_dataflow.rb:137:10:137:26 | [true] ... && ... | synthetic * |
+| local_dataflow.rb:137:10:137:15 | synthetic splat argument | local_dataflow.rb:137:10:137:15 | call to use | synthetic * |
+| local_dataflow.rb:137:10:137:26 | synthetic splat argument | local_dataflow.rb:137:10:137:26 | [false] ... && ... | synthetic * |
+| local_dataflow.rb:137:10:137:26 | synthetic splat argument | local_dataflow.rb:137:10:137:26 | [true] ... && ... | synthetic * |
 | local_dataflow.rb:137:14:137:14 | x | local_dataflow.rb:137:10:137:15 | call to use | position 0 |
-| local_dataflow.rb:137:20:137:26 | * | local_dataflow.rb:137:20:137:26 | [false] ! ... | synthetic * |
-| local_dataflow.rb:137:20:137:26 | * | local_dataflow.rb:137:20:137:26 | [true] ! ... | synthetic * |
 | local_dataflow.rb:137:20:137:26 | [false] ! ... | local_dataflow.rb:137:10:137:26 | [false] ... && ... | position 0 |
 | local_dataflow.rb:137:20:137:26 | [true] ! ... | local_dataflow.rb:137:10:137:26 | [true] ... && ... | position 0 |
-| local_dataflow.rb:137:21:137:26 | * | local_dataflow.rb:137:21:137:26 | call to use | synthetic * |
+| local_dataflow.rb:137:20:137:26 | synthetic splat argument | local_dataflow.rb:137:20:137:26 | [false] ! ... | synthetic * |
+| local_dataflow.rb:137:20:137:26 | synthetic splat argument | local_dataflow.rb:137:20:137:26 | [true] ! ... | synthetic * |
 | local_dataflow.rb:137:21:137:26 | call to use | local_dataflow.rb:137:20:137:26 | [false] ! ... | self |
 | local_dataflow.rb:137:21:137:26 | call to use | local_dataflow.rb:137:20:137:26 | [true] ! ... | self |
 | local_dataflow.rb:137:21:137:26 | self | local_dataflow.rb:137:21:137:26 | call to use | self |
+| local_dataflow.rb:137:21:137:26 | synthetic splat argument | local_dataflow.rb:137:21:137:26 | call to use | synthetic * |
 | local_dataflow.rb:137:25:137:25 | x | local_dataflow.rb:137:21:137:26 | call to use | position 0 |
-| local_dataflow.rb:141:8:141:14 | * | local_dataflow.rb:141:8:141:14 | [false] ! ... | synthetic * |
-| local_dataflow.rb:141:8:141:14 | * | local_dataflow.rb:141:8:141:14 | [true] ! ... | synthetic * |
 | local_dataflow.rb:141:8:141:14 | [false] ! ... | local_dataflow.rb:141:8:141:37 | [false] ... \|\| ... | self |
 | local_dataflow.rb:141:8:141:14 | [false] ! ... | local_dataflow.rb:141:8:141:37 | [true] ... \|\| ... | self |
 | local_dataflow.rb:141:8:141:14 | [true] ! ... | local_dataflow.rb:141:8:141:37 | [true] ... \|\| ... | self |
-| local_dataflow.rb:141:8:141:37 | * | local_dataflow.rb:141:8:141:37 | [false] ... \|\| ... | synthetic * |
-| local_dataflow.rb:141:8:141:37 | * | local_dataflow.rb:141:8:141:37 | [true] ... \|\| ... | synthetic * |
-| local_dataflow.rb:141:9:141:14 | * | local_dataflow.rb:141:9:141:14 | call to use | synthetic * |
+| local_dataflow.rb:141:8:141:14 | synthetic splat argument | local_dataflow.rb:141:8:141:14 | [false] ! ... | synthetic * |
+| local_dataflow.rb:141:8:141:14 | synthetic splat argument | local_dataflow.rb:141:8:141:14 | [true] ! ... | synthetic * |
+| local_dataflow.rb:141:8:141:37 | synthetic splat argument | local_dataflow.rb:141:8:141:37 | [false] ... \|\| ... | synthetic * |
+| local_dataflow.rb:141:8:141:37 | synthetic splat argument | local_dataflow.rb:141:8:141:37 | [true] ... \|\| ... | synthetic * |
 | local_dataflow.rb:141:9:141:14 | call to use | local_dataflow.rb:141:8:141:14 | [false] ! ... | self |
 | local_dataflow.rb:141:9:141:14 | call to use | local_dataflow.rb:141:8:141:14 | [true] ! ... | self |
 | local_dataflow.rb:141:9:141:14 | self | local_dataflow.rb:141:9:141:14 | call to use | self |
+| local_dataflow.rb:141:9:141:14 | synthetic splat argument | local_dataflow.rb:141:9:141:14 | call to use | synthetic * |
 | local_dataflow.rb:141:13:141:13 | x | local_dataflow.rb:141:9:141:14 | call to use | position 0 |
 | local_dataflow.rb:141:19:141:37 | [false] ( ... ) | local_dataflow.rb:141:8:141:37 | [false] ... \|\| ... | position 0 |
 | local_dataflow.rb:141:19:141:37 | [true] ( ... ) | local_dataflow.rb:141:8:141:37 | [true] ... \|\| ... | position 0 |
-| local_dataflow.rb:141:20:141:25 | * | local_dataflow.rb:141:20:141:25 | call to use | synthetic * |
 | local_dataflow.rb:141:20:141:25 | call to use | local_dataflow.rb:141:20:141:36 | [false] ... && ... | self |
 | local_dataflow.rb:141:20:141:25 | call to use | local_dataflow.rb:141:20:141:36 | [true] ... && ... | self |
 | local_dataflow.rb:141:20:141:25 | self | local_dataflow.rb:141:20:141:25 | call to use | self |
-| local_dataflow.rb:141:20:141:36 | * | local_dataflow.rb:141:20:141:36 | [false] ... && ... | synthetic * |
-| local_dataflow.rb:141:20:141:36 | * | local_dataflow.rb:141:20:141:36 | [true] ... && ... | synthetic * |
+| local_dataflow.rb:141:20:141:25 | synthetic splat argument | local_dataflow.rb:141:20:141:25 | call to use | synthetic * |
+| local_dataflow.rb:141:20:141:36 | synthetic splat argument | local_dataflow.rb:141:20:141:36 | [false] ... && ... | synthetic * |
+| local_dataflow.rb:141:20:141:36 | synthetic splat argument | local_dataflow.rb:141:20:141:36 | [true] ... && ... | synthetic * |
 | local_dataflow.rb:141:24:141:24 | x | local_dataflow.rb:141:20:141:25 | call to use | position 0 |
-| local_dataflow.rb:141:30:141:36 | * | local_dataflow.rb:141:30:141:36 | [false] ! ... | synthetic * |
-| local_dataflow.rb:141:30:141:36 | * | local_dataflow.rb:141:30:141:36 | [true] ! ... | synthetic * |
 | local_dataflow.rb:141:30:141:36 | [false] ! ... | local_dataflow.rb:141:20:141:36 | [false] ... && ... | position 0 |
 | local_dataflow.rb:141:30:141:36 | [true] ! ... | local_dataflow.rb:141:20:141:36 | [true] ... && ... | position 0 |
-| local_dataflow.rb:141:31:141:36 | * | local_dataflow.rb:141:31:141:36 | call to use | synthetic * |
+| local_dataflow.rb:141:30:141:36 | synthetic splat argument | local_dataflow.rb:141:30:141:36 | [false] ! ... | synthetic * |
+| local_dataflow.rb:141:30:141:36 | synthetic splat argument | local_dataflow.rb:141:30:141:36 | [true] ! ... | synthetic * |
 | local_dataflow.rb:141:31:141:36 | call to use | local_dataflow.rb:141:30:141:36 | [false] ! ... | self |
 | local_dataflow.rb:141:31:141:36 | call to use | local_dataflow.rb:141:30:141:36 | [true] ! ... | self |
 | local_dataflow.rb:141:31:141:36 | self | local_dataflow.rb:141:31:141:36 | call to use | self |
+| local_dataflow.rb:141:31:141:36 | synthetic splat argument | local_dataflow.rb:141:31:141:36 | call to use | synthetic * |
 | local_dataflow.rb:141:35:141:35 | x | local_dataflow.rb:141:31:141:36 | call to use | position 0 |
-| local_dataflow.rb:143:11:143:16 | * | local_dataflow.rb:143:11:143:16 | call to use | synthetic * |
 | local_dataflow.rb:143:11:143:16 | call to use | local_dataflow.rb:143:11:143:26 | [false] ... \|\| ... | self |
 | local_dataflow.rb:143:11:143:16 | call to use | local_dataflow.rb:143:11:143:26 | [true] ... \|\| ... | self |
 | local_dataflow.rb:143:11:143:16 | self | local_dataflow.rb:143:11:143:16 | call to use | self |
-| local_dataflow.rb:143:11:143:26 | * | local_dataflow.rb:143:11:143:26 | [false] ... \|\| ... | synthetic * |
-| local_dataflow.rb:143:11:143:26 | * | local_dataflow.rb:143:11:143:26 | [true] ... \|\| ... | synthetic * |
+| local_dataflow.rb:143:11:143:16 | synthetic splat argument | local_dataflow.rb:143:11:143:16 | call to use | synthetic * |
+| local_dataflow.rb:143:11:143:26 | synthetic splat argument | local_dataflow.rb:143:11:143:26 | [false] ... \|\| ... | synthetic * |
+| local_dataflow.rb:143:11:143:26 | synthetic splat argument | local_dataflow.rb:143:11:143:26 | [true] ... \|\| ... | synthetic * |
 | local_dataflow.rb:143:15:143:15 | x | local_dataflow.rb:143:11:143:16 | call to use | position 0 |
-| local_dataflow.rb:143:21:143:26 | * | local_dataflow.rb:143:21:143:26 | call to use | synthetic * |
 | local_dataflow.rb:143:21:143:26 | call to use | local_dataflow.rb:143:11:143:26 | [false] ... \|\| ... | position 0 |
 | local_dataflow.rb:143:21:143:26 | call to use | local_dataflow.rb:143:11:143:26 | [true] ... \|\| ... | position 0 |
 | local_dataflow.rb:143:21:143:26 | self | local_dataflow.rb:143:21:143:26 | call to use | self |
+| local_dataflow.rb:143:21:143:26 | synthetic splat argument | local_dataflow.rb:143:21:143:26 | call to use | synthetic * |
 | local_dataflow.rb:143:25:143:25 | x | local_dataflow.rb:143:21:143:26 | call to use | position 0 |
-| local_dataflow.rb:144:11:144:16 | * | local_dataflow.rb:144:11:144:16 | call to use | synthetic * |
 | local_dataflow.rb:144:11:144:16 | self | local_dataflow.rb:144:11:144:16 | call to use | self |
+| local_dataflow.rb:144:11:144:16 | synthetic splat argument | local_dataflow.rb:144:11:144:16 | call to use | synthetic * |
 | local_dataflow.rb:144:15:144:15 | x | local_dataflow.rb:144:11:144:16 | call to use | position 0 |
-| local_dataflow.rb:147:5:147:10 | * | local_dataflow.rb:147:5:147:10 | call to use | synthetic * |
 | local_dataflow.rb:147:5:147:10 | self | local_dataflow.rb:147:5:147:10 | call to use | self |
+| local_dataflow.rb:147:5:147:10 | synthetic splat argument | local_dataflow.rb:147:5:147:10 | call to use | synthetic * |
 | local_dataflow.rb:147:9:147:9 | x | local_dataflow.rb:147:5:147:10 | call to use | position 0 |
-| local_dataflow.rb:148:5:148:10 | * | local_dataflow.rb:148:5:148:10 | call to use | synthetic * |
 | local_dataflow.rb:148:5:148:10 | self | local_dataflow.rb:148:5:148:10 | call to use | self |
+| local_dataflow.rb:148:5:148:10 | synthetic splat argument | local_dataflow.rb:148:5:148:10 | call to use | synthetic * |
 | local_dataflow.rb:148:9:148:9 | x | local_dataflow.rb:148:5:148:10 | call to use | position 0 |

--- a/ruby/ql/test/library-tests/dataflow/local/TaintStep.expected
+++ b/ruby/ql/test/library-tests/dataflow/local/TaintStep.expected
@@ -2796,7 +2796,7 @@
 | UseUseExplosion.rb:21:3675:21:3680 | call to use | UseUseExplosion.rb:21:3670:21:3680 | else ... |
 | UseUseExplosion.rb:21:3686:21:3696 | else ... | UseUseExplosion.rb:21:9:21:3700 | if ... |
 | UseUseExplosion.rb:21:3691:21:3696 | call to use | UseUseExplosion.rb:21:3686:21:3696 | else ... |
-| UseUseExplosion.rb:24:5:25:7 | synthetic *args | UseUseExplosion.rb:24:13:24:13 | i |
+| UseUseExplosion.rb:24:5:25:7 | synthetic splat parameter | UseUseExplosion.rb:24:13:24:13 | i |
 | UseUseExplosion.rb:24:5:25:7 | use | UseUseExplosion.rb:1:1:26:3 | C |
 | file://:0:0:0:0 | [summary param] position 0 in & | file://:0:0:0:0 | [summary] read: Argument[0].Element[any] in & |
 | file://:0:0:0:0 | [summary param] position 0 in + | file://:0:0:0:0 | [summary] read: Argument[0].Element[any] in + |
@@ -2841,7 +2841,7 @@
 | file://:0:0:0:0 | [summary] read: Argument[0].Element[any] in Hash[] | file://:0:0:0:0 | [summary] read: Argument[0].Element[any].Element[1] in Hash[] |
 | local_dataflow.rb:1:1:7:3 | self (foo) | local_dataflow.rb:3:8:3:10 | self |
 | local_dataflow.rb:1:1:7:3 | self in foo | local_dataflow.rb:1:1:7:3 | self (foo) |
-| local_dataflow.rb:1:1:7:3 | synthetic *args | local_dataflow.rb:1:9:1:9 | a |
+| local_dataflow.rb:1:1:7:3 | synthetic splat parameter | local_dataflow.rb:1:9:1:9 | a |
 | local_dataflow.rb:1:1:150:3 | <uninitialized> | local_dataflow.rb:10:9:10:9 | x |
 | local_dataflow.rb:1:1:150:3 | self (local_dataflow.rb) | local_dataflow.rb:49:1:53:3 | self |
 | local_dataflow.rb:1:9:1:9 | a | local_dataflow.rb:1:9:1:9 | a |
@@ -2871,6 +2871,7 @@
 | local_dataflow.rb:9:9:9:15 | Array | local_dataflow.rb:9:9:9:15 | call to [] |
 | local_dataflow.rb:9:9:9:15 | call to [] | local_dataflow.rb:9:1:9:5 | array |
 | local_dataflow.rb:9:9:9:15 | call to [] | local_dataflow.rb:9:1:9:15 | ... = ... |
+| local_dataflow.rb:9:9:9:15 | synthetic splat argument | local_dataflow.rb:9:9:9:15 | call to [] |
 | local_dataflow.rb:10:5:13:3 | ... | local_dataflow.rb:10:1:13:3 | ... = ... |
 | local_dataflow.rb:10:5:13:3 | <captured entry> self | local_dataflow.rb:11:1:11:2 | self |
 | local_dataflow.rb:10:5:13:3 | <captured exit> x | local_dataflow.rb:15:5:15:5 | x |
@@ -2879,7 +2880,7 @@
 | local_dataflow.rb:10:5:13:3 | __synth__0__1 | local_dataflow.rb:10:5:13:3 | __synth__0__1 |
 | local_dataflow.rb:10:5:13:3 | __synth__0__1 | local_dataflow.rb:10:9:10:9 | x |
 | local_dataflow.rb:10:5:13:3 | call to each | local_dataflow.rb:10:5:13:3 | ... |
-| local_dataflow.rb:10:5:13:3 | synthetic *args | local_dataflow.rb:10:5:13:3 | __synth__0__1 |
+| local_dataflow.rb:10:5:13:3 | synthetic splat parameter | local_dataflow.rb:10:5:13:3 | __synth__0__1 |
 | local_dataflow.rb:10:9:10:9 | ... = ... | local_dataflow.rb:10:9:10:9 | if ... |
 | local_dataflow.rb:10:9:10:9 | defined? ... | local_dataflow.rb:10:9:10:9 | [false] ! ... |
 | local_dataflow.rb:10:9:10:9 | defined? ... | local_dataflow.rb:10:9:10:9 | [true] ! ... |
@@ -2898,7 +2899,7 @@
 | local_dataflow.rb:15:1:17:3 | __synth__0__1 | local_dataflow.rb:15:1:17:3 | __synth__0__1 |
 | local_dataflow.rb:15:1:17:3 | __synth__0__1 | local_dataflow.rb:15:5:15:5 | x |
 | local_dataflow.rb:15:1:17:3 | call to each | local_dataflow.rb:15:1:17:3 | ... |
-| local_dataflow.rb:15:1:17:3 | synthetic *args | local_dataflow.rb:15:1:17:3 | __synth__0__1 |
+| local_dataflow.rb:15:1:17:3 | synthetic splat parameter | local_dataflow.rb:15:1:17:3 | __synth__0__1 |
 | local_dataflow.rb:15:5:15:5 | ... = ... | local_dataflow.rb:15:5:15:5 | if ... |
 | local_dataflow.rb:15:5:15:5 | defined? ... | local_dataflow.rb:15:5:15:5 | [false] ! ... |
 | local_dataflow.rb:15:5:15:5 | defined? ... | local_dataflow.rb:15:5:15:5 | [true] ! ... |
@@ -2914,7 +2915,7 @@
 | local_dataflow.rb:19:1:21:3 | __synth__0__1 | local_dataflow.rb:19:1:21:3 | __synth__0__1 |
 | local_dataflow.rb:19:1:21:3 | __synth__0__1 | local_dataflow.rb:19:5:19:5 | x |
 | local_dataflow.rb:19:1:21:3 | call to each | local_dataflow.rb:19:1:21:3 | ... |
-| local_dataflow.rb:19:1:21:3 | synthetic *args | local_dataflow.rb:19:1:21:3 | __synth__0__1 |
+| local_dataflow.rb:19:1:21:3 | synthetic splat parameter | local_dataflow.rb:19:1:21:3 | __synth__0__1 |
 | local_dataflow.rb:19:5:19:5 | ... = ... | local_dataflow.rb:19:5:19:5 | if ... |
 | local_dataflow.rb:19:5:19:5 | defined? ... | local_dataflow.rb:19:5:19:5 | [false] ! ... |
 | local_dataflow.rb:19:5:19:5 | defined? ... | local_dataflow.rb:19:5:19:5 | [true] ! ... |
@@ -2933,13 +2934,13 @@
 | local_dataflow.rb:30:14:30:20 | "class" | local_dataflow.rb:30:5:30:24 | C |
 | local_dataflow.rb:32:5:32:25 | bar | local_dataflow.rb:32:1:32:1 | x |
 | local_dataflow.rb:32:5:32:25 | bar | local_dataflow.rb:32:1:32:25 | ... = ... |
-| local_dataflow.rb:34:1:39:3 | synthetic *args | local_dataflow.rb:34:7:34:7 | x |
+| local_dataflow.rb:34:1:39:3 | synthetic splat parameter | local_dataflow.rb:34:7:34:7 | x |
 | local_dataflow.rb:34:7:34:7 | x | local_dataflow.rb:34:7:34:7 | x |
 | local_dataflow.rb:34:7:34:7 | x | local_dataflow.rb:35:6:35:6 | x |
 | local_dataflow.rb:35:6:35:6 | x | local_dataflow.rb:35:6:35:11 | ... == ... |
 | local_dataflow.rb:35:11:35:11 | 4 | local_dataflow.rb:35:6:35:11 | ... == ... |
 | local_dataflow.rb:36:13:36:13 | 7 | local_dataflow.rb:36:6:36:13 | return |
-| local_dataflow.rb:41:1:47:3 | synthetic *args | local_dataflow.rb:41:7:41:7 | x |
+| local_dataflow.rb:41:1:47:3 | synthetic splat parameter | local_dataflow.rb:41:7:41:7 | x |
 | local_dataflow.rb:41:7:41:7 | x | local_dataflow.rb:41:7:41:7 | x |
 | local_dataflow.rb:41:7:41:7 | x | local_dataflow.rb:42:6:42:6 | x |
 | local_dataflow.rb:42:6:42:6 | x | local_dataflow.rb:42:6:42:11 | ... == ... |
@@ -2958,10 +2959,11 @@
 | local_dataflow.rb:51:20:51:20 | x | local_dataflow.rb:51:20:51:24 | ... < ... |
 | local_dataflow.rb:51:24:51:24 | 9 | local_dataflow.rb:51:20:51:24 | ... < ... |
 | local_dataflow.rb:55:5:55:13 | Array | local_dataflow.rb:55:5:55:13 | call to [] |
-| local_dataflow.rb:57:1:58:3 | synthetic *args | local_dataflow.rb:57:9:57:9 | x |
+| local_dataflow.rb:55:5:55:13 | synthetic splat argument | local_dataflow.rb:55:5:55:13 | call to [] |
+| local_dataflow.rb:57:1:58:3 | synthetic splat parameter | local_dataflow.rb:57:9:57:9 | x |
 | local_dataflow.rb:60:1:90:3 | self (test_case) | local_dataflow.rb:78:12:78:20 | self |
 | local_dataflow.rb:60:1:90:3 | self in test_case | local_dataflow.rb:60:1:90:3 | self (test_case) |
-| local_dataflow.rb:60:1:90:3 | synthetic *args | local_dataflow.rb:60:15:60:15 | x |
+| local_dataflow.rb:60:1:90:3 | synthetic splat parameter | local_dataflow.rb:60:15:60:15 | x |
 | local_dataflow.rb:60:15:60:15 | x | local_dataflow.rb:60:15:60:15 | x |
 | local_dataflow.rb:60:15:60:15 | x | local_dataflow.rb:61:12:61:12 | x |
 | local_dataflow.rb:61:7:68:5 | SSA phi read(x) | local_dataflow.rb:69:12:69:12 | x |
@@ -3029,6 +3031,7 @@
 | local_dataflow.rb:81:20:84:33 | then ... | local_dataflow.rb:78:7:88:5 | case ... |
 | local_dataflow.rb:81:25:84:14 | Array | local_dataflow.rb:81:25:84:14 | call to [] |
 | local_dataflow.rb:81:25:84:14 | call to [] | local_dataflow.rb:81:20:84:33 | then ... |
+| local_dataflow.rb:81:25:84:14 | synthetic splat argument | local_dataflow.rb:81:25:84:14 | call to [] |
 | local_dataflow.rb:82:7:82:13 | [post] self | local_dataflow.rb:83:7:83:13 | self |
 | local_dataflow.rb:82:7:82:13 | self | local_dataflow.rb:83:7:83:13 | self |
 | local_dataflow.rb:83:7:83:13 | [post] self | local_dataflow.rb:84:7:84:13 | self |
@@ -3134,7 +3137,7 @@
 | local_dataflow.rb:118:3:118:11 | call to source | local_dataflow.rb:118:3:118:31 | call to tap |
 | local_dataflow.rb:118:3:118:11 | self | local_dataflow.rb:119:3:119:31 | self |
 | local_dataflow.rb:118:17:118:31 | <captured entry> self | local_dataflow.rb:118:23:118:29 | self |
-| local_dataflow.rb:118:17:118:31 | synthetic *args | local_dataflow.rb:118:20:118:20 | x |
+| local_dataflow.rb:118:17:118:31 | synthetic splat parameter | local_dataflow.rb:118:20:118:20 | x |
 | local_dataflow.rb:118:20:118:20 | x | local_dataflow.rb:118:20:118:20 | x |
 | local_dataflow.rb:118:20:118:20 | x | local_dataflow.rb:118:28:118:28 | x |
 | local_dataflow.rb:119:3:119:31 | [post] self | local_dataflow.rb:119:8:119:16 | self |
@@ -3149,10 +3152,10 @@
 | local_dataflow.rb:123:8:123:20 | call to dup | local_dataflow.rb:123:8:123:45 | call to tap |
 | local_dataflow.rb:123:8:123:45 | call to tap | local_dataflow.rb:123:8:123:49 | call to dup |
 | local_dataflow.rb:123:26:123:45 | <captured entry> self | local_dataflow.rb:123:32:123:43 | self |
-| local_dataflow.rb:123:26:123:45 | synthetic *args | local_dataflow.rb:123:29:123:29 | x |
+| local_dataflow.rb:123:26:123:45 | synthetic splat parameter | local_dataflow.rb:123:29:123:29 | x |
 | local_dataflow.rb:126:1:128:3 | self (use) | local_dataflow.rb:127:3:127:8 | self |
 | local_dataflow.rb:126:1:128:3 | self in use | local_dataflow.rb:126:1:128:3 | self (use) |
-| local_dataflow.rb:126:1:128:3 | synthetic *args | local_dataflow.rb:126:9:126:9 | x |
+| local_dataflow.rb:126:1:128:3 | synthetic splat parameter | local_dataflow.rb:126:9:126:9 | x |
 | local_dataflow.rb:130:1:150:3 | self (use_use_madness) | local_dataflow.rb:132:6:132:11 | self |
 | local_dataflow.rb:130:1:150:3 | self in use_use_madness | local_dataflow.rb:130:1:150:3 | self (use_use_madness) |
 | local_dataflow.rb:131:3:131:3 | x | local_dataflow.rb:132:10:132:10 | x |

--- a/ruby/ql/test/library-tests/dataflow/params/TypeTracker.expected
+++ b/ruby/ql/test/library-tests/dataflow/params/TypeTracker.expected
@@ -1,7 +1,7 @@
 track
 | params_flow.rb:1:1:3:3 | &block | type tracker without call steps | params_flow.rb:1:1:3:3 | &block |
 | params_flow.rb:1:1:3:3 | self in taint | type tracker without call steps | params_flow.rb:1:1:3:3 | self in taint |
-| params_flow.rb:1:1:3:3 | synthetic *args | type tracker without call steps | params_flow.rb:1:1:3:3 | synthetic *args |
+| params_flow.rb:1:1:3:3 | synthetic splat parameter | type tracker without call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:1:1:3:3 | taint | type tracker without call steps | params_flow.rb:1:1:3:3 | taint |
 | params_flow.rb:1:1:137:45 | self (params_flow.rb) | type tracker with call steps | params_flow.rb:1:1:3:3 | self in taint |
 | params_flow.rb:1:1:137:45 | self (params_flow.rb) | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
@@ -28,7 +28,6 @@ track
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:29:11:29:21 | ...[...] |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:49:13:49:14 | p1 |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:52:11:52:20 | ...[...] |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:65:10:65:13 | ...[...] |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:69:14:69:14 | x |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:69:17:69:17 | y |
@@ -46,81 +45,92 @@ track
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:108:44:108:44 | c |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:110:10:110:13 | ...[...] |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:134:10:134:16 | ...[...] |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element | params_flow.rb:9:1:12:3 | synthetic *args |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:9:1:12:3 | synthetic *args |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:11:5:11:11 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:26:5:26:11 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:27:5:27:22 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:28:5:28:22 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:29:5:29:22 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:50:5:50:11 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:51:5:51:21 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:52:5:52:21 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:65:5:65:13 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:69:1:76:3 | synthetic *args |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:70:5:70:10 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:71:5:71:10 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:74:5:74:10 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:75:5:75:10 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:83:1:91:3 | synthetic *args |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:84:5:84:10 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:85:5:85:10 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:86:5:86:10 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:87:5:87:10 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:88:5:88:10 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:89:5:89:10 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:98:1:103:3 | synthetic *args |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:99:5:99:10 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:102:5:102:10 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:108:1:112:3 | synthetic *args |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:108:40:108:41 | *b |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:109:5:109:10 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:110:5:110:13 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:111:5:111:10 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:134:5:134:16 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 or unknown | params_flow.rb:9:1:12:3 | synthetic *args |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 or unknown | params_flow.rb:49:1:53:3 | synthetic *args |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 or unknown | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:133:14:133:18 | *args |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 or unknown | params_flow.rb:64:16:64:17 | *x |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 or unknown | params_flow.rb:83:1:91:3 | synthetic *args |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 or unknown | params_flow.rb:133:14:133:18 | *args |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 | params_flow.rb:9:1:12:3 | synthetic *args |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 | params_flow.rb:49:1:53:3 | synthetic *args |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 | params_flow.rb:69:1:76:3 | synthetic *args |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 | params_flow.rb:83:1:91:3 | synthetic *args |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 | params_flow.rb:98:1:103:3 | synthetic *args |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 | params_flow.rb:108:1:112:3 | synthetic *args |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 | params_flow.rb:108:40:108:41 | *b |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 or unknown | params_flow.rb:9:1:12:3 | synthetic *args |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 or unknown | params_flow.rb:49:1:53:3 | synthetic *args |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 or unknown | params_flow.rb:83:1:91:3 | synthetic *args |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 or unknown | params_flow.rb:133:14:133:18 | *args |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 2 | params_flow.rb:69:1:76:3 | synthetic *args |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 2 | params_flow.rb:83:1:91:3 | synthetic *args |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 2 | params_flow.rb:98:1:103:3 | synthetic *args |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 2 or unknown | params_flow.rb:133:14:133:18 | *args |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 3 | params_flow.rb:69:1:76:3 | synthetic *args |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 3 | params_flow.rb:83:1:91:3 | synthetic *args |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 4 | params_flow.rb:69:1:76:3 | synthetic *args |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 4 | params_flow.rb:83:1:91:3 | synthetic *args |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 5 | params_flow.rb:83:1:91:3 | synthetic *args |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element :c | params_flow.rb:108:1:112:3 | **kwargs |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element :p1 | params_flow.rb:16:1:19:3 | **kwargs |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element :p1 | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 | params_flow.rb:133:14:133:18 | *args |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 2 | params_flow.rb:133:14:133:18 | *args |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element :p1 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element :p1 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element :p1 | params_flow.rb:25:17:25:24 | **kwargs |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element :p2 | params_flow.rb:16:1:19:3 | **kwargs |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element :p2 | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element :p2 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element :p2 | params_flow.rb:25:17:25:24 | **kwargs |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element :p3 | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element :p3 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element :p3 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content hash-splat position :c | params_flow.rb:108:1:112:3 | synthetic hash-splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content hash-splat position :p3 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content hash-splat position :p3 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:26:5:26:11 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:27:5:27:22 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:28:5:28:22 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:29:5:29:22 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:65:5:65:13 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:70:5:70:10 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:74:5:74:10 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:75:5:75:10 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:84:5:84:10 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:85:5:85:10 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:86:5:86:10 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:87:5:87:10 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:88:5:88:10 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:89:5:89:10 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:99:5:99:10 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:102:5:102:10 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:108:1:112:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:109:5:109:10 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:110:5:110:13 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:111:5:111:10 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:134:5:134:16 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 1 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 1 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 1 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 1 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 1 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 1 | params_flow.rb:108:1:112:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:49:1:53:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:98:1:103:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 2 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 2 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 2 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 2 (shifted) | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 2 (shifted) | params_flow.rb:98:1:103:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 3 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 3 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 3 (shifted) | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 4 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 4 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 4 (shifted) | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 5 (shifted) | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:14:12:14:19 | call to taint |
@@ -199,158 +209,156 @@ track
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content attribute [] | params_flow.rb:117:1:117:1 | [post] x |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element | params_flow.rb:116:5:116:6 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element | params_flow.rb:118:12:118:13 | * ... |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:14:1:14:30 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:43:8:43:18 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:44:1:44:28 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:46:8:46:29 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:55:1:55:29 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:57:8:57:18 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:58:1:58:25 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:60:8:60:29 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:78:1:78:63 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:80:8:80:51 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:81:1:81:37 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:93:8:93:51 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:94:1:94:48 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:96:1:96:88 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:96:33:96:65 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:105:1:105:49 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:105:27:105:48 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:106:1:106:46 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:114:1:114:67 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:128:10:128:31 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:128:34:128:60 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:130:8:130:29 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:137:11:137:43 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:43:8:43:18 | call to [] |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:44:23:44:27 | * ... |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:46:8:46:29 | call to [] |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:47:12:47:16 | * ... |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:57:8:57:18 | call to [] |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:58:20:58:24 | * ... |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:60:8:60:29 | call to [] |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:61:9:61:13 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:43:8:43:18 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:43:8:43:18 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:44:23:44:27 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:46:8:46:29 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:46:8:46:29 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:47:12:47:16 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:57:8:57:18 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:57:8:57:18 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:58:20:58:24 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:60:8:60:29 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:60:8:60:29 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:61:9:61:13 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:80:8:80:51 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:80:8:80:51 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:81:21:81:25 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:93:8:93:51 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:93:8:93:51 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:94:32:94:36 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:96:32:96:65 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:96:33:96:65 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:96:33:96:65 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:105:26:105:48 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:105:27:105:48 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:105:27:105:48 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:128:10:128:31 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:128:10:128:31 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:128:34:128:60 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:128:34:128:60 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:130:8:130:29 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:130:8:130:29 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:131:10:131:14 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:137:10:137:43 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:137:11:137:43 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:137:11:137:43 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:67:12:67:16 | * ... |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:80:8:80:51 | call to [] |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:81:21:81:25 | * ... |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:93:8:93:51 | call to [] |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:94:32:94:36 | * ... |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:96:32:96:65 | * ... |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:96:33:96:65 | call to [] |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:105:26:105:48 | * ... |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:105:27:105:48 | call to [] |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:128:10:128:31 | call to [] |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:128:34:128:60 | call to [] |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:130:8:130:29 | call to [] |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:131:10:131:14 | * ... |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:137:10:137:43 | * ... |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:137:11:137:43 | call to [] |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:14:1:14:30 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:44:1:44:28 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:46:8:46:29 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:55:1:55:29 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:58:1:58:25 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:60:8:60:29 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:78:1:78:63 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:80:8:80:51 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:81:1:81:37 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:93:8:93:51 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:94:1:94:48 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:96:1:96:88 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:96:33:96:65 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:105:1:105:49 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:105:27:105:48 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:106:1:106:46 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:114:1:114:67 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:117:1:117:15 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:128:10:128:31 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:128:46:128:59 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:130:8:130:29 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:131:1:131:46 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:137:11:137:43 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:46:8:46:29 | call to [] |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:47:12:47:16 | * ... |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:60:8:60:29 | call to [] |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:61:9:61:13 | * ... |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:80:8:80:51 | call to [] |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:81:21:81:25 | * ... |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:93:8:93:51 | call to [] |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:94:32:94:36 | * ... |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:96:32:96:65 | * ... |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:96:33:96:65 | call to [] |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:105:26:105:48 | * ... |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:105:27:105:48 | call to [] |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:128:10:128:31 | call to [] |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:128:46:128:59 | call to [] |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:130:8:130:29 | call to [] |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:131:10:131:14 | * ... |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:137:10:137:43 | * ... |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:137:11:137:43 | call to [] |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:78:1:78:63 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:80:8:80:51 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:81:1:81:37 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:93:8:93:51 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:94:1:94:48 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:96:1:96:88 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:96:33:96:65 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:105:1:105:49 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:106:1:106:46 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:137:11:137:43 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 or unknown | params_flow.rb:80:8:80:51 | call to [] |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 or unknown | params_flow.rb:81:21:81:25 | * ... |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 or unknown | params_flow.rb:93:8:93:51 | call to [] |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 or unknown | params_flow.rb:94:32:94:36 | * ... |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 or unknown | params_flow.rb:96:32:96:65 | * ... |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 or unknown | params_flow.rb:96:33:96:65 | call to [] |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 or unknown | params_flow.rb:137:10:137:43 | * ... |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 or unknown | params_flow.rb:137:11:137:43 | call to [] |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 | params_flow.rb:78:1:78:63 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 | params_flow.rb:80:8:80:51 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 | params_flow.rb:81:1:81:37 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 | params_flow.rb:93:8:93:51 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 | params_flow.rb:94:1:94:48 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 | params_flow.rb:96:1:96:88 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 or unknown | params_flow.rb:80:8:80:51 | call to [] |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 or unknown | params_flow.rb:81:21:81:25 | * ... |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 or unknown | params_flow.rb:93:8:93:51 | call to [] |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 or unknown | params_flow.rb:94:32:94:36 | * ... |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 4 | params_flow.rb:78:1:78:63 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 4 | params_flow.rb:81:1:81:37 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 4 | params_flow.rb:94:1:94:48 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 4 | params_flow.rb:96:1:96:88 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 5 | params_flow.rb:94:1:94:48 | * |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :c | params_flow.rb:114:1:114:67 | ** |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:21:1:21:35 | ** |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:22:1:22:35 | ** |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:23:1:23:41 | ** |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:33:1:33:58 | ** |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:35:1:35:29 | ** |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:37:8:37:44 | ** |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:46:8:46:29 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:46:8:46:29 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:47:12:47:16 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:60:8:60:29 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:60:8:60:29 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:61:9:61:13 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:80:8:80:51 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:80:8:80:51 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:81:21:81:25 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:93:8:93:51 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:93:8:93:51 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:94:32:94:36 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:96:32:96:65 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:96:33:96:65 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:96:33:96:65 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:105:26:105:48 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:105:27:105:48 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:105:27:105:48 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:128:10:128:31 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:128:10:128:31 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:128:46:128:59 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:128:46:128:59 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:130:8:130:29 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:130:8:130:29 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:131:10:131:14 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:137:10:137:43 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:137:11:137:43 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:137:11:137:43 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:80:8:80:51 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:80:8:80:51 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:81:21:81:25 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:93:8:93:51 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:93:8:93:51 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:94:32:94:36 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:96:32:96:65 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:96:33:96:65 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:96:33:96:65 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:137:10:137:43 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:137:11:137:43 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:137:11:137:43 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 | params_flow.rb:80:8:80:51 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 | params_flow.rb:80:8:80:51 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 | params_flow.rb:81:21:81:25 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 | params_flow.rb:93:8:93:51 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 | params_flow.rb:93:8:93:51 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 | params_flow.rb:94:32:94:36 | * ... |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:37:8:37:44 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:37:8:37:44 | synthetic hash-splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:38:8:38:13 | ** ... |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:40:8:40:26 | ** |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:40:8:40:26 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:40:8:40:26 | synthetic hash-splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:41:24:41:29 | ** ... |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:21:1:21:35 | ** |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:22:1:22:35 | ** |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:23:1:23:41 | ** |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:33:1:33:58 | ** |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:37:8:37:44 | ** |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:37:8:37:44 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:37:8:37:44 | synthetic hash-splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:38:8:38:13 | ** ... |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:41:1:41:30 | ** |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p3 | params_flow.rb:33:1:33:58 | ** |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p3 | params_flow.rb:34:8:34:32 | ** |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p3 | params_flow.rb:34:8:34:32 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p3 | params_flow.rb:34:8:34:32 | synthetic hash-splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p3 | params_flow.rb:35:23:35:28 | ** ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content hash-splat position :c | params_flow.rb:114:1:114:67 | synthetic hash-splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:21:1:21:35 | synthetic hash-splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:22:1:22:35 | synthetic hash-splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:23:1:23:41 | synthetic hash-splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:35:1:35:29 | synthetic hash-splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:21:1:21:35 | synthetic hash-splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:22:1:22:35 | synthetic hash-splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:23:1:23:41 | synthetic hash-splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:41:1:41:30 | synthetic hash-splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content hash-splat position :p3 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 0 | params_flow.rb:14:1:14:30 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 0 | params_flow.rb:44:1:44:28 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 0 | params_flow.rb:55:1:55:29 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 0 | params_flow.rb:58:1:58:25 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 0 | params_flow.rb:78:1:78:63 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 0 | params_flow.rb:81:1:81:37 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 0 | params_flow.rb:94:1:94:48 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 0 | params_flow.rb:96:1:96:88 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 0 | params_flow.rb:105:1:105:49 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 0 | params_flow.rb:106:1:106:46 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 0 | params_flow.rb:114:1:114:67 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 1 | params_flow.rb:14:1:14:30 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 1 | params_flow.rb:55:1:55:29 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 1 | params_flow.rb:78:1:78:63 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 1 | params_flow.rb:94:1:94:48 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 1 | params_flow.rb:96:1:96:88 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 1 | params_flow.rb:106:1:106:46 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 1 | params_flow.rb:114:1:114:67 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 1 | params_flow.rb:117:1:117:15 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:44:1:44:28 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:58:1:58:25 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:81:1:81:37 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:105:1:105:49 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 2 | params_flow.rb:78:1:78:63 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 2 | params_flow.rb:106:1:106:46 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:81:1:81:37 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:94:1:94:48 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:96:1:96:88 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:105:1:105:49 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 3 | params_flow.rb:78:1:78:63 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 3 (shifted) | params_flow.rb:81:1:81:37 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 3 (shifted) | params_flow.rb:94:1:94:48 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 3 (shifted) | params_flow.rb:96:1:96:88 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 4 | params_flow.rb:78:1:78:63 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 4 (shifted) | params_flow.rb:81:1:81:37 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 4 (shifted) | params_flow.rb:94:1:94:48 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 4 (shifted) | params_flow.rb:96:1:96:88 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 5 (shifted) | params_flow.rb:94:1:94:48 | synthetic splat argument |
 | params_flow.rb:5:1:7:3 | &block | type tracker without call steps | params_flow.rb:5:1:7:3 | &block |
 | params_flow.rb:5:1:7:3 | self in sink | type tracker without call steps | params_flow.rb:5:1:7:3 | self in sink |
 | params_flow.rb:5:1:7:3 | sink | type tracker without call steps | params_flow.rb:5:1:7:3 | sink |
-| params_flow.rb:5:1:7:3 | synthetic *args | type tracker without call steps | params_flow.rb:5:1:7:3 | synthetic *args |
+| params_flow.rb:5:1:7:3 | synthetic splat parameter | type tracker without call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:5:10:5:10 | x | type tracker without call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:5:10:5:10 | x | type tracker without call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:5:10:5:10 | x | type tracker without call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:6:5:6:10 | * | type tracker without call steps | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:5:10:5:10 | x | type tracker without call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:6:5:6:10 | call to puts |
 | params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:10:5:10:11 | call to sink |
 | params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:11:5:11:11 | call to sink |
@@ -416,1068 +424,1079 @@ track
 | params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:131:1:131:46 | call to pos_many |
 | params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:134:5:134:16 | call to sink |
 | params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:137:1:137:44 | call to splatall |
+| params_flow.rb:6:5:6:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:9:1:12:3 | &block | type tracker without call steps | params_flow.rb:9:1:12:3 | &block |
 | params_flow.rb:9:1:12:3 | positional | type tracker without call steps | params_flow.rb:9:1:12:3 | positional |
 | params_flow.rb:9:1:12:3 | self in positional | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
 | params_flow.rb:9:1:12:3 | self in positional | type tracker without call steps | params_flow.rb:9:1:12:3 | self in positional |
-| params_flow.rb:9:1:12:3 | synthetic *args | type tracker without call steps | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:9:1:12:3 | synthetic splat parameter | type tracker without call steps | params_flow.rb:9:1:12:3 | synthetic splat parameter |
 | params_flow.rb:9:16:9:17 | p1 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:9:16:9:17 | p1 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:9:16:9:17 | p1 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:9:16:9:17 | p1 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:9:16:9:17 | p1 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:9:16:9:17 | p1 | type tracker without call steps | params_flow.rb:9:16:9:17 | p1 |
 | params_flow.rb:9:16:9:17 | p1 | type tracker without call steps | params_flow.rb:9:16:9:17 | p1 |
-| params_flow.rb:9:16:9:17 | p1 | type tracker without call steps with content element 0 | params_flow.rb:10:5:10:11 | * |
+| params_flow.rb:9:16:9:17 | p1 | type tracker without call steps with content splat position 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
 | params_flow.rb:9:20:9:21 | p2 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:9:20:9:21 | p2 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:9:20:9:21 | p2 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:9:20:9:21 | p2 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:9:20:9:21 | p2 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:9:20:9:21 | p2 | type tracker without call steps | params_flow.rb:9:20:9:21 | p2 |
 | params_flow.rb:9:20:9:21 | p2 | type tracker without call steps | params_flow.rb:9:20:9:21 | p2 |
-| params_flow.rb:9:20:9:21 | p2 | type tracker without call steps with content element 0 | params_flow.rb:11:5:11:11 | * |
-| params_flow.rb:10:5:10:11 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:10:5:10:11 | * | type tracker without call steps | params_flow.rb:10:5:10:11 | * |
+| params_flow.rb:9:20:9:21 | p2 | type tracker without call steps with content splat position 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
 | params_flow.rb:10:5:10:11 | call to sink | type tracker without call steps | params_flow.rb:10:5:10:11 | call to sink |
-| params_flow.rb:11:5:11:11 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:11:5:11:11 | * | type tracker without call steps | params_flow.rb:11:5:11:11 | * |
+| params_flow.rb:10:5:10:11 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:10:5:10:11 | synthetic splat argument | type tracker without call steps | params_flow.rb:10:5:10:11 | synthetic splat argument |
 | params_flow.rb:11:5:11:11 | call to sink | type tracker without call steps | params_flow.rb:11:5:11:11 | call to sink |
 | params_flow.rb:11:5:11:11 | call to sink | type tracker without call steps | params_flow.rb:14:1:14:30 | call to positional |
 | params_flow.rb:11:5:11:11 | call to sink | type tracker without call steps | params_flow.rb:44:1:44:28 | call to positional |
 | params_flow.rb:11:5:11:11 | call to sink | type tracker without call steps | params_flow.rb:47:1:47:17 | call to positional |
 | params_flow.rb:11:5:11:11 | call to sink | type tracker without call steps | params_flow.rb:118:1:118:14 | call to positional |
-| params_flow.rb:14:1:14:30 | * | type tracker with call steps | params_flow.rb:9:1:12:3 | synthetic *args |
-| params_flow.rb:14:1:14:30 | * | type tracker without call steps | params_flow.rb:14:1:14:30 | * |
+| params_flow.rb:11:5:11:11 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:11:5:11:11 | synthetic splat argument | type tracker without call steps | params_flow.rb:11:5:11:11 | synthetic splat argument |
 | params_flow.rb:14:1:14:30 | call to positional | type tracker without call steps | params_flow.rb:14:1:14:30 | call to positional |
-| params_flow.rb:14:12:14:19 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:14:12:14:19 | * | type tracker without call steps | params_flow.rb:14:12:14:19 | * |
+| params_flow.rb:14:1:14:30 | synthetic splat argument | type tracker with call steps | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:14:1:14:30 | synthetic splat argument | type tracker without call steps | params_flow.rb:14:1:14:30 | synthetic splat argument |
 | params_flow.rb:14:12:14:19 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:14:12:14:19 | call to taint | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
-| params_flow.rb:14:12:14:19 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:14:12:14:19 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:14:12:14:19 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:9:1:12:3 | synthetic *args |
-| params_flow.rb:14:12:14:19 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | * |
+| params_flow.rb:14:12:14:19 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:14:12:14:19 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:14:12:14:19 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:14:12:14:19 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
 | params_flow.rb:14:12:14:19 | call to taint | type tracker without call steps | params_flow.rb:14:12:14:19 | call to taint |
-| params_flow.rb:14:12:14:19 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:14:1:14:30 | * |
+| params_flow.rb:14:12:14:19 | call to taint | type tracker without call steps with content splat position 0 | params_flow.rb:14:1:14:30 | synthetic splat argument |
+| params_flow.rb:14:12:14:19 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:14:12:14:19 | synthetic splat argument | type tracker without call steps | params_flow.rb:14:12:14:19 | synthetic splat argument |
 | params_flow.rb:14:18:14:18 | 1 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:14:18:14:18 | 1 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:14:18:14:18 | 1 | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
-| params_flow.rb:14:18:14:18 | 1 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:14:18:14:18 | 1 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:14:18:14:18 | 1 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:14:18:14:18 | 1 | type tracker with call steps with content element 0 | params_flow.rb:9:1:12:3 | synthetic *args |
-| params_flow.rb:14:18:14:18 | 1 | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | * |
+| params_flow.rb:14:18:14:18 | 1 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:14:18:14:18 | 1 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:14:18:14:18 | 1 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:14:18:14:18 | 1 | type tracker with call steps with content splat position 0 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:14:18:14:18 | 1 | type tracker with call steps with content splat position 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
 | params_flow.rb:14:18:14:18 | 1 | type tracker without call steps | params_flow.rb:14:12:14:19 | call to taint |
 | params_flow.rb:14:18:14:18 | 1 | type tracker without call steps | params_flow.rb:14:18:14:18 | 1 |
-| params_flow.rb:14:18:14:18 | 1 | type tracker without call steps with content element 0 | params_flow.rb:14:1:14:30 | * |
-| params_flow.rb:14:18:14:18 | 1 | type tracker without call steps with content element 0 | params_flow.rb:14:12:14:19 | * |
-| params_flow.rb:14:22:14:29 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:14:22:14:29 | * | type tracker without call steps | params_flow.rb:14:22:14:29 | * |
+| params_flow.rb:14:18:14:18 | 1 | type tracker without call steps with content splat position 0 | params_flow.rb:14:1:14:30 | synthetic splat argument |
+| params_flow.rb:14:18:14:18 | 1 | type tracker without call steps with content splat position 0 | params_flow.rb:14:12:14:19 | synthetic splat argument |
 | params_flow.rb:14:22:14:29 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:14:22:14:29 | call to taint | type tracker with call steps | params_flow.rb:9:20:9:21 | p2 |
-| params_flow.rb:14:22:14:29 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:14:22:14:29 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:14:22:14:29 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:11:5:11:11 | * |
-| params_flow.rb:14:22:14:29 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:14:22:14:29 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:14:22:14:29 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:14:22:14:29 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
+| params_flow.rb:14:22:14:29 | call to taint | type tracker with call steps with content splat position 1 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
 | params_flow.rb:14:22:14:29 | call to taint | type tracker without call steps | params_flow.rb:14:22:14:29 | call to taint |
-| params_flow.rb:14:22:14:29 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:14:1:14:30 | * |
+| params_flow.rb:14:22:14:29 | call to taint | type tracker without call steps with content splat position 1 | params_flow.rb:14:1:14:30 | synthetic splat argument |
+| params_flow.rb:14:22:14:29 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:14:22:14:29 | synthetic splat argument | type tracker without call steps | params_flow.rb:14:22:14:29 | synthetic splat argument |
 | params_flow.rb:14:28:14:28 | 2 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:14:28:14:28 | 2 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:14:28:14:28 | 2 | type tracker with call steps | params_flow.rb:9:20:9:21 | p2 |
-| params_flow.rb:14:28:14:28 | 2 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:14:28:14:28 | 2 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:14:28:14:28 | 2 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:14:28:14:28 | 2 | type tracker with call steps with content element 0 | params_flow.rb:11:5:11:11 | * |
-| params_flow.rb:14:28:14:28 | 2 | type tracker with call steps with content element 1 | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:14:28:14:28 | 2 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:14:28:14:28 | 2 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:14:28:14:28 | 2 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:14:28:14:28 | 2 | type tracker with call steps with content splat position 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
+| params_flow.rb:14:28:14:28 | 2 | type tracker with call steps with content splat position 1 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
 | params_flow.rb:14:28:14:28 | 2 | type tracker without call steps | params_flow.rb:14:22:14:29 | call to taint |
 | params_flow.rb:14:28:14:28 | 2 | type tracker without call steps | params_flow.rb:14:28:14:28 | 2 |
-| params_flow.rb:14:28:14:28 | 2 | type tracker without call steps with content element 0 | params_flow.rb:14:22:14:29 | * |
-| params_flow.rb:14:28:14:28 | 2 | type tracker without call steps with content element 1 | params_flow.rb:14:1:14:30 | * |
+| params_flow.rb:14:28:14:28 | 2 | type tracker without call steps with content splat position 0 | params_flow.rb:14:22:14:29 | synthetic splat argument |
+| params_flow.rb:14:28:14:28 | 2 | type tracker without call steps with content splat position 1 | params_flow.rb:14:1:14:30 | synthetic splat argument |
 | params_flow.rb:16:1:19:3 | &block | type tracker without call steps | params_flow.rb:16:1:19:3 | &block |
-| params_flow.rb:16:1:19:3 | **kwargs | type tracker without call steps | params_flow.rb:16:1:19:3 | **kwargs |
 | params_flow.rb:16:1:19:3 | keyword | type tracker without call steps | params_flow.rb:16:1:19:3 | keyword |
 | params_flow.rb:16:1:19:3 | self in keyword | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
 | params_flow.rb:16:1:19:3 | self in keyword | type tracker without call steps | params_flow.rb:16:1:19:3 | self in keyword |
+| params_flow.rb:16:1:19:3 | synthetic hash-splat parameter | type tracker without call steps | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:16:13:16:14 | p1 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:16:13:16:14 | p1 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:16:13:16:14 | p1 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:16:13:16:14 | p1 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:16:13:16:14 | p1 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:16:13:16:14 | p1 | type tracker without call steps | params_flow.rb:16:13:16:14 | p1 |
 | params_flow.rb:16:13:16:14 | p1 | type tracker without call steps | params_flow.rb:16:13:16:14 | p1 |
-| params_flow.rb:16:13:16:14 | p1 | type tracker without call steps with content element 0 | params_flow.rb:17:5:17:11 | * |
+| params_flow.rb:16:13:16:14 | p1 | type tracker without call steps with content splat position 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
 | params_flow.rb:16:18:16:19 | p2 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:16:18:16:19 | p2 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:16:18:16:19 | p2 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:16:18:16:19 | p2 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:16:18:16:19 | p2 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:16:18:16:19 | p2 | type tracker without call steps | params_flow.rb:16:18:16:19 | p2 |
 | params_flow.rb:16:18:16:19 | p2 | type tracker without call steps | params_flow.rb:16:18:16:19 | p2 |
-| params_flow.rb:16:18:16:19 | p2 | type tracker without call steps with content element 0 | params_flow.rb:18:5:18:11 | * |
-| params_flow.rb:17:5:17:11 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:17:5:17:11 | * | type tracker without call steps | params_flow.rb:17:5:17:11 | * |
+| params_flow.rb:16:18:16:19 | p2 | type tracker without call steps with content splat position 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:17:5:17:11 | call to sink | type tracker without call steps | params_flow.rb:17:5:17:11 | call to sink |
-| params_flow.rb:18:5:18:11 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:18:5:18:11 | * | type tracker without call steps | params_flow.rb:18:5:18:11 | * |
+| params_flow.rb:17:5:17:11 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:17:5:17:11 | synthetic splat argument | type tracker without call steps | params_flow.rb:17:5:17:11 | synthetic splat argument |
 | params_flow.rb:18:5:18:11 | call to sink | type tracker without call steps | params_flow.rb:18:5:18:11 | call to sink |
 | params_flow.rb:18:5:18:11 | call to sink | type tracker without call steps | params_flow.rb:21:1:21:35 | call to keyword |
 | params_flow.rb:18:5:18:11 | call to sink | type tracker without call steps | params_flow.rb:22:1:22:35 | call to keyword |
 | params_flow.rb:18:5:18:11 | call to sink | type tracker without call steps | params_flow.rb:23:1:23:41 | call to keyword |
 | params_flow.rb:18:5:18:11 | call to sink | type tracker without call steps | params_flow.rb:41:1:41:30 | call to keyword |
-| params_flow.rb:21:1:21:35 | ** | type tracker with call steps | params_flow.rb:16:1:19:3 | **kwargs |
-| params_flow.rb:21:1:21:35 | ** | type tracker without call steps | params_flow.rb:21:1:21:35 | ** |
+| params_flow.rb:18:5:18:11 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:18:5:18:11 | synthetic splat argument | type tracker without call steps | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:21:1:21:35 | call to keyword | type tracker without call steps | params_flow.rb:21:1:21:35 | call to keyword |
+| params_flow.rb:21:1:21:35 | synthetic hash-splat argument | type tracker with call steps | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
+| params_flow.rb:21:1:21:35 | synthetic hash-splat argument | type tracker without call steps | params_flow.rb:21:1:21:35 | synthetic hash-splat argument |
 | params_flow.rb:21:9:21:10 | :p1 | type tracker without call steps | params_flow.rb:21:9:21:10 | :p1 |
 | params_flow.rb:21:9:21:20 | Pair | type tracker without call steps | params_flow.rb:21:9:21:20 | Pair |
-| params_flow.rb:21:13:21:20 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:21:13:21:20 | * | type tracker without call steps | params_flow.rb:21:13:21:20 | * |
 | params_flow.rb:21:13:21:20 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:21:13:21:20 | call to taint | type tracker with call steps | params_flow.rb:16:13:16:14 | p1 |
-| params_flow.rb:21:13:21:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:21:13:21:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:21:13:21:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | * |
-| params_flow.rb:21:13:21:20 | call to taint | type tracker with call steps with content element :p1 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:21:13:21:20 | call to taint | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
+| params_flow.rb:21:13:21:20 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:21:13:21:20 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:21:13:21:20 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
 | params_flow.rb:21:13:21:20 | call to taint | type tracker without call steps | params_flow.rb:21:13:21:20 | call to taint |
-| params_flow.rb:21:13:21:20 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:21:1:21:35 | ** |
+| params_flow.rb:21:13:21:20 | call to taint | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:21:1:21:35 | synthetic hash-splat argument |
+| params_flow.rb:21:13:21:20 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:21:13:21:20 | synthetic splat argument | type tracker without call steps | params_flow.rb:21:13:21:20 | synthetic splat argument |
 | params_flow.rb:21:19:21:19 | 3 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:21:19:21:19 | 3 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:21:19:21:19 | 3 | type tracker with call steps | params_flow.rb:16:13:16:14 | p1 |
-| params_flow.rb:21:19:21:19 | 3 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:21:19:21:19 | 3 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:21:19:21:19 | 3 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:21:19:21:19 | 3 | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | * |
-| params_flow.rb:21:19:21:19 | 3 | type tracker with call steps with content element :p1 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:21:19:21:19 | 3 | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
+| params_flow.rb:21:19:21:19 | 3 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:21:19:21:19 | 3 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:21:19:21:19 | 3 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:21:19:21:19 | 3 | type tracker with call steps with content splat position 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
 | params_flow.rb:21:19:21:19 | 3 | type tracker without call steps | params_flow.rb:21:13:21:20 | call to taint |
 | params_flow.rb:21:19:21:19 | 3 | type tracker without call steps | params_flow.rb:21:19:21:19 | 3 |
-| params_flow.rb:21:19:21:19 | 3 | type tracker without call steps with content element 0 | params_flow.rb:21:13:21:20 | * |
-| params_flow.rb:21:19:21:19 | 3 | type tracker without call steps with content element :p1 | params_flow.rb:21:1:21:35 | ** |
+| params_flow.rb:21:19:21:19 | 3 | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:21:1:21:35 | synthetic hash-splat argument |
+| params_flow.rb:21:19:21:19 | 3 | type tracker without call steps with content splat position 0 | params_flow.rb:21:13:21:20 | synthetic splat argument |
 | params_flow.rb:21:23:21:24 | :p2 | type tracker without call steps | params_flow.rb:21:23:21:24 | :p2 |
 | params_flow.rb:21:23:21:34 | Pair | type tracker without call steps | params_flow.rb:21:23:21:34 | Pair |
-| params_flow.rb:21:27:21:34 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:21:27:21:34 | * | type tracker without call steps | params_flow.rb:21:27:21:34 | * |
 | params_flow.rb:21:27:21:34 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:21:27:21:34 | call to taint | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
-| params_flow.rb:21:27:21:34 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:21:27:21:34 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:21:27:21:34 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | * |
-| params_flow.rb:21:27:21:34 | call to taint | type tracker with call steps with content element :p2 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:21:27:21:34 | call to taint | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
+| params_flow.rb:21:27:21:34 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:21:27:21:34 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:21:27:21:34 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:21:27:21:34 | call to taint | type tracker without call steps | params_flow.rb:21:27:21:34 | call to taint |
-| params_flow.rb:21:27:21:34 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:21:1:21:35 | ** |
+| params_flow.rb:21:27:21:34 | call to taint | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:21:1:21:35 | synthetic hash-splat argument |
+| params_flow.rb:21:27:21:34 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:21:27:21:34 | synthetic splat argument | type tracker without call steps | params_flow.rb:21:27:21:34 | synthetic splat argument |
 | params_flow.rb:21:33:21:33 | 4 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:21:33:21:33 | 4 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:21:33:21:33 | 4 | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
-| params_flow.rb:21:33:21:33 | 4 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:21:33:21:33 | 4 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:21:33:21:33 | 4 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:21:33:21:33 | 4 | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | * |
-| params_flow.rb:21:33:21:33 | 4 | type tracker with call steps with content element :p2 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:21:33:21:33 | 4 | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
+| params_flow.rb:21:33:21:33 | 4 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:21:33:21:33 | 4 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:21:33:21:33 | 4 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:21:33:21:33 | 4 | type tracker with call steps with content splat position 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:21:33:21:33 | 4 | type tracker without call steps | params_flow.rb:21:27:21:34 | call to taint |
 | params_flow.rb:21:33:21:33 | 4 | type tracker without call steps | params_flow.rb:21:33:21:33 | 4 |
-| params_flow.rb:21:33:21:33 | 4 | type tracker without call steps with content element 0 | params_flow.rb:21:27:21:34 | * |
-| params_flow.rb:21:33:21:33 | 4 | type tracker without call steps with content element :p2 | params_flow.rb:21:1:21:35 | ** |
-| params_flow.rb:22:1:22:35 | ** | type tracker with call steps | params_flow.rb:16:1:19:3 | **kwargs |
-| params_flow.rb:22:1:22:35 | ** | type tracker without call steps | params_flow.rb:22:1:22:35 | ** |
+| params_flow.rb:21:33:21:33 | 4 | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:21:1:21:35 | synthetic hash-splat argument |
+| params_flow.rb:21:33:21:33 | 4 | type tracker without call steps with content splat position 0 | params_flow.rb:21:27:21:34 | synthetic splat argument |
 | params_flow.rb:22:1:22:35 | call to keyword | type tracker without call steps | params_flow.rb:22:1:22:35 | call to keyword |
+| params_flow.rb:22:1:22:35 | synthetic hash-splat argument | type tracker with call steps | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
+| params_flow.rb:22:1:22:35 | synthetic hash-splat argument | type tracker without call steps | params_flow.rb:22:1:22:35 | synthetic hash-splat argument |
 | params_flow.rb:22:9:22:10 | :p2 | type tracker without call steps | params_flow.rb:22:9:22:10 | :p2 |
 | params_flow.rb:22:9:22:20 | Pair | type tracker without call steps | params_flow.rb:22:9:22:20 | Pair |
-| params_flow.rb:22:13:22:20 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:22:13:22:20 | * | type tracker without call steps | params_flow.rb:22:13:22:20 | * |
 | params_flow.rb:22:13:22:20 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:22:13:22:20 | call to taint | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
-| params_flow.rb:22:13:22:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:22:13:22:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:22:13:22:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | * |
-| params_flow.rb:22:13:22:20 | call to taint | type tracker with call steps with content element :p2 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:22:13:22:20 | call to taint | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
+| params_flow.rb:22:13:22:20 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:22:13:22:20 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:22:13:22:20 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:22:13:22:20 | call to taint | type tracker without call steps | params_flow.rb:22:13:22:20 | call to taint |
-| params_flow.rb:22:13:22:20 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:22:1:22:35 | ** |
+| params_flow.rb:22:13:22:20 | call to taint | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:22:1:22:35 | synthetic hash-splat argument |
+| params_flow.rb:22:13:22:20 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:22:13:22:20 | synthetic splat argument | type tracker without call steps | params_flow.rb:22:13:22:20 | synthetic splat argument |
 | params_flow.rb:22:19:22:19 | 5 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:22:19:22:19 | 5 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:22:19:22:19 | 5 | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
-| params_flow.rb:22:19:22:19 | 5 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:22:19:22:19 | 5 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:22:19:22:19 | 5 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:22:19:22:19 | 5 | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | * |
-| params_flow.rb:22:19:22:19 | 5 | type tracker with call steps with content element :p2 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:22:19:22:19 | 5 | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
+| params_flow.rb:22:19:22:19 | 5 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:22:19:22:19 | 5 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:22:19:22:19 | 5 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:22:19:22:19 | 5 | type tracker with call steps with content splat position 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:22:19:22:19 | 5 | type tracker without call steps | params_flow.rb:22:13:22:20 | call to taint |
 | params_flow.rb:22:19:22:19 | 5 | type tracker without call steps | params_flow.rb:22:19:22:19 | 5 |
-| params_flow.rb:22:19:22:19 | 5 | type tracker without call steps with content element 0 | params_flow.rb:22:13:22:20 | * |
-| params_flow.rb:22:19:22:19 | 5 | type tracker without call steps with content element :p2 | params_flow.rb:22:1:22:35 | ** |
+| params_flow.rb:22:19:22:19 | 5 | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:22:1:22:35 | synthetic hash-splat argument |
+| params_flow.rb:22:19:22:19 | 5 | type tracker without call steps with content splat position 0 | params_flow.rb:22:13:22:20 | synthetic splat argument |
 | params_flow.rb:22:23:22:24 | :p1 | type tracker without call steps | params_flow.rb:22:23:22:24 | :p1 |
 | params_flow.rb:22:23:22:34 | Pair | type tracker without call steps | params_flow.rb:22:23:22:34 | Pair |
-| params_flow.rb:22:27:22:34 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:22:27:22:34 | * | type tracker without call steps | params_flow.rb:22:27:22:34 | * |
 | params_flow.rb:22:27:22:34 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:22:27:22:34 | call to taint | type tracker with call steps | params_flow.rb:16:13:16:14 | p1 |
-| params_flow.rb:22:27:22:34 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:22:27:22:34 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:22:27:22:34 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | * |
-| params_flow.rb:22:27:22:34 | call to taint | type tracker with call steps with content element :p1 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:22:27:22:34 | call to taint | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
+| params_flow.rb:22:27:22:34 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:22:27:22:34 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:22:27:22:34 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
 | params_flow.rb:22:27:22:34 | call to taint | type tracker without call steps | params_flow.rb:22:27:22:34 | call to taint |
-| params_flow.rb:22:27:22:34 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:22:1:22:35 | ** |
+| params_flow.rb:22:27:22:34 | call to taint | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:22:1:22:35 | synthetic hash-splat argument |
+| params_flow.rb:22:27:22:34 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:22:27:22:34 | synthetic splat argument | type tracker without call steps | params_flow.rb:22:27:22:34 | synthetic splat argument |
 | params_flow.rb:22:33:22:33 | 6 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:22:33:22:33 | 6 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:22:33:22:33 | 6 | type tracker with call steps | params_flow.rb:16:13:16:14 | p1 |
-| params_flow.rb:22:33:22:33 | 6 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:22:33:22:33 | 6 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:22:33:22:33 | 6 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:22:33:22:33 | 6 | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | * |
-| params_flow.rb:22:33:22:33 | 6 | type tracker with call steps with content element :p1 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:22:33:22:33 | 6 | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
+| params_flow.rb:22:33:22:33 | 6 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:22:33:22:33 | 6 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:22:33:22:33 | 6 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:22:33:22:33 | 6 | type tracker with call steps with content splat position 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
 | params_flow.rb:22:33:22:33 | 6 | type tracker without call steps | params_flow.rb:22:27:22:34 | call to taint |
 | params_flow.rb:22:33:22:33 | 6 | type tracker without call steps | params_flow.rb:22:33:22:33 | 6 |
-| params_flow.rb:22:33:22:33 | 6 | type tracker without call steps with content element 0 | params_flow.rb:22:27:22:34 | * |
-| params_flow.rb:22:33:22:33 | 6 | type tracker without call steps with content element :p1 | params_flow.rb:22:1:22:35 | ** |
-| params_flow.rb:23:1:23:41 | ** | type tracker with call steps | params_flow.rb:16:1:19:3 | **kwargs |
-| params_flow.rb:23:1:23:41 | ** | type tracker without call steps | params_flow.rb:23:1:23:41 | ** |
+| params_flow.rb:22:33:22:33 | 6 | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:22:1:22:35 | synthetic hash-splat argument |
+| params_flow.rb:22:33:22:33 | 6 | type tracker without call steps with content splat position 0 | params_flow.rb:22:27:22:34 | synthetic splat argument |
 | params_flow.rb:23:1:23:41 | call to keyword | type tracker without call steps | params_flow.rb:23:1:23:41 | call to keyword |
+| params_flow.rb:23:1:23:41 | synthetic hash-splat argument | type tracker with call steps | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
+| params_flow.rb:23:1:23:41 | synthetic hash-splat argument | type tracker without call steps | params_flow.rb:23:1:23:41 | synthetic hash-splat argument |
 | params_flow.rb:23:9:23:11 | :p2 | type tracker without call steps | params_flow.rb:23:9:23:11 | :p2 |
 | params_flow.rb:23:9:23:23 | Pair | type tracker without call steps | params_flow.rb:23:9:23:23 | Pair |
-| params_flow.rb:23:16:23:23 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:23:16:23:23 | * | type tracker without call steps | params_flow.rb:23:16:23:23 | * |
 | params_flow.rb:23:16:23:23 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:23:16:23:23 | call to taint | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
-| params_flow.rb:23:16:23:23 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:23:16:23:23 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:23:16:23:23 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | * |
-| params_flow.rb:23:16:23:23 | call to taint | type tracker with call steps with content element :p2 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:23:16:23:23 | call to taint | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
+| params_flow.rb:23:16:23:23 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:23:16:23:23 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:23:16:23:23 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:23:16:23:23 | call to taint | type tracker without call steps | params_flow.rb:23:16:23:23 | call to taint |
-| params_flow.rb:23:16:23:23 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:23:1:23:41 | ** |
+| params_flow.rb:23:16:23:23 | call to taint | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:23:1:23:41 | synthetic hash-splat argument |
+| params_flow.rb:23:16:23:23 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:23:16:23:23 | synthetic splat argument | type tracker without call steps | params_flow.rb:23:16:23:23 | synthetic splat argument |
 | params_flow.rb:23:22:23:22 | 7 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:23:22:23:22 | 7 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:23:22:23:22 | 7 | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
-| params_flow.rb:23:22:23:22 | 7 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:23:22:23:22 | 7 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:23:22:23:22 | 7 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:23:22:23:22 | 7 | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | * |
-| params_flow.rb:23:22:23:22 | 7 | type tracker with call steps with content element :p2 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:23:22:23:22 | 7 | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
+| params_flow.rb:23:22:23:22 | 7 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:23:22:23:22 | 7 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:23:22:23:22 | 7 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:23:22:23:22 | 7 | type tracker with call steps with content splat position 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:23:22:23:22 | 7 | type tracker without call steps | params_flow.rb:23:16:23:23 | call to taint |
 | params_flow.rb:23:22:23:22 | 7 | type tracker without call steps | params_flow.rb:23:22:23:22 | 7 |
-| params_flow.rb:23:22:23:22 | 7 | type tracker without call steps with content element 0 | params_flow.rb:23:16:23:23 | * |
-| params_flow.rb:23:22:23:22 | 7 | type tracker without call steps with content element :p2 | params_flow.rb:23:1:23:41 | ** |
+| params_flow.rb:23:22:23:22 | 7 | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:23:1:23:41 | synthetic hash-splat argument |
+| params_flow.rb:23:22:23:22 | 7 | type tracker without call steps with content splat position 0 | params_flow.rb:23:16:23:23 | synthetic splat argument |
 | params_flow.rb:23:26:23:28 | :p1 | type tracker without call steps | params_flow.rb:23:26:23:28 | :p1 |
 | params_flow.rb:23:26:23:40 | Pair | type tracker without call steps | params_flow.rb:23:26:23:40 | Pair |
-| params_flow.rb:23:33:23:40 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:23:33:23:40 | * | type tracker without call steps | params_flow.rb:23:33:23:40 | * |
 | params_flow.rb:23:33:23:40 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:23:33:23:40 | call to taint | type tracker with call steps | params_flow.rb:16:13:16:14 | p1 |
-| params_flow.rb:23:33:23:40 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:23:33:23:40 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:23:33:23:40 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | * |
-| params_flow.rb:23:33:23:40 | call to taint | type tracker with call steps with content element :p1 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:23:33:23:40 | call to taint | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
+| params_flow.rb:23:33:23:40 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:23:33:23:40 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:23:33:23:40 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
 | params_flow.rb:23:33:23:40 | call to taint | type tracker without call steps | params_flow.rb:23:33:23:40 | call to taint |
-| params_flow.rb:23:33:23:40 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:23:1:23:41 | ** |
+| params_flow.rb:23:33:23:40 | call to taint | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:23:1:23:41 | synthetic hash-splat argument |
+| params_flow.rb:23:33:23:40 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:23:33:23:40 | synthetic splat argument | type tracker without call steps | params_flow.rb:23:33:23:40 | synthetic splat argument |
 | params_flow.rb:23:39:23:39 | 8 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:23:39:23:39 | 8 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:23:39:23:39 | 8 | type tracker with call steps | params_flow.rb:16:13:16:14 | p1 |
-| params_flow.rb:23:39:23:39 | 8 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:23:39:23:39 | 8 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:23:39:23:39 | 8 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:23:39:23:39 | 8 | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | * |
-| params_flow.rb:23:39:23:39 | 8 | type tracker with call steps with content element :p1 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:23:39:23:39 | 8 | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
+| params_flow.rb:23:39:23:39 | 8 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:23:39:23:39 | 8 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:23:39:23:39 | 8 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:23:39:23:39 | 8 | type tracker with call steps with content splat position 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
 | params_flow.rb:23:39:23:39 | 8 | type tracker without call steps | params_flow.rb:23:33:23:40 | call to taint |
 | params_flow.rb:23:39:23:39 | 8 | type tracker without call steps | params_flow.rb:23:39:23:39 | 8 |
-| params_flow.rb:23:39:23:39 | 8 | type tracker without call steps with content element 0 | params_flow.rb:23:33:23:40 | * |
-| params_flow.rb:23:39:23:39 | 8 | type tracker without call steps with content element :p1 | params_flow.rb:23:1:23:41 | ** |
+| params_flow.rb:23:39:23:39 | 8 | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:23:1:23:41 | synthetic hash-splat argument |
+| params_flow.rb:23:39:23:39 | 8 | type tracker without call steps with content splat position 0 | params_flow.rb:23:33:23:40 | synthetic splat argument |
 | params_flow.rb:25:1:31:3 | &block | type tracker without call steps | params_flow.rb:25:1:31:3 | &block |
-| params_flow.rb:25:1:31:3 | **kwargs | type tracker without call steps | params_flow.rb:25:1:31:3 | **kwargs |
 | params_flow.rb:25:1:31:3 | kwargs | type tracker without call steps | params_flow.rb:25:1:31:3 | kwargs |
 | params_flow.rb:25:1:31:3 | self in kwargs | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
 | params_flow.rb:25:1:31:3 | self in kwargs | type tracker without call steps | params_flow.rb:25:1:31:3 | self in kwargs |
+| params_flow.rb:25:1:31:3 | synthetic hash-splat parameter | type tracker without call steps | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:25:12:25:13 | p1 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:25:12:25:13 | p1 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:25:12:25:13 | p1 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:25:12:25:13 | p1 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:25:12:25:13 | p1 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:25:12:25:13 | p1 | type tracker without call steps | params_flow.rb:25:12:25:13 | p1 |
 | params_flow.rb:25:12:25:13 | p1 | type tracker without call steps | params_flow.rb:25:12:25:13 | p1 |
-| params_flow.rb:25:12:25:13 | p1 | type tracker without call steps with content element 0 | params_flow.rb:26:5:26:11 | * |
+| params_flow.rb:25:12:25:13 | p1 | type tracker without call steps with content splat position 0 | params_flow.rb:26:5:26:11 | synthetic splat argument |
 | params_flow.rb:25:17:25:24 | **kwargs | type tracker without call steps | params_flow.rb:25:17:25:24 | **kwargs |
 | params_flow.rb:25:19:25:24 | kwargs | type tracker without call steps | params_flow.rb:25:19:25:24 | kwargs |
-| params_flow.rb:26:5:26:11 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:26:5:26:11 | * | type tracker without call steps | params_flow.rb:26:5:26:11 | * |
 | params_flow.rb:26:5:26:11 | call to sink | type tracker without call steps | params_flow.rb:26:5:26:11 | call to sink |
-| params_flow.rb:27:5:27:22 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:27:5:27:22 | * | type tracker without call steps | params_flow.rb:27:5:27:22 | * |
+| params_flow.rb:26:5:26:11 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:26:5:26:11 | synthetic splat argument | type tracker without call steps | params_flow.rb:26:5:26:11 | synthetic splat argument |
 | params_flow.rb:27:5:27:22 | call to sink | type tracker without call steps | params_flow.rb:27:5:27:22 | call to sink |
-| params_flow.rb:27:11:27:21 | * | type tracker without call steps | params_flow.rb:27:11:27:21 | * |
+| params_flow.rb:27:5:27:22 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:27:5:27:22 | synthetic splat argument | type tracker without call steps | params_flow.rb:27:5:27:22 | synthetic splat argument |
 | params_flow.rb:27:11:27:21 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:27:11:27:21 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:27:11:27:21 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:27:11:27:21 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:27:11:27:21 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:27:11:27:21 | ...[...] | type tracker without call steps | params_flow.rb:27:11:27:21 | ...[...] |
-| params_flow.rb:27:11:27:21 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:27:5:27:22 | * |
+| params_flow.rb:27:11:27:21 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:27:5:27:22 | synthetic splat argument |
+| params_flow.rb:27:11:27:21 | synthetic splat argument | type tracker without call steps | params_flow.rb:27:11:27:21 | synthetic splat argument |
 | params_flow.rb:27:18:27:20 | :p1 | type tracker without call steps | params_flow.rb:27:18:27:20 | :p1 |
-| params_flow.rb:27:18:27:20 | :p1 | type tracker without call steps with content element 0 | params_flow.rb:27:11:27:21 | * |
-| params_flow.rb:28:5:28:22 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:28:5:28:22 | * | type tracker without call steps | params_flow.rb:28:5:28:22 | * |
+| params_flow.rb:27:18:27:20 | :p1 | type tracker without call steps with content splat position 0 | params_flow.rb:27:11:27:21 | synthetic splat argument |
 | params_flow.rb:28:5:28:22 | call to sink | type tracker without call steps | params_flow.rb:28:5:28:22 | call to sink |
-| params_flow.rb:28:11:28:21 | * | type tracker without call steps | params_flow.rb:28:11:28:21 | * |
+| params_flow.rb:28:5:28:22 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:28:5:28:22 | synthetic splat argument | type tracker without call steps | params_flow.rb:28:5:28:22 | synthetic splat argument |
 | params_flow.rb:28:11:28:21 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:28:11:28:21 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:28:11:28:21 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:28:11:28:21 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:28:11:28:21 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:28:11:28:21 | ...[...] | type tracker without call steps | params_flow.rb:28:11:28:21 | ...[...] |
-| params_flow.rb:28:11:28:21 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:28:5:28:22 | * |
+| params_flow.rb:28:11:28:21 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:28:5:28:22 | synthetic splat argument |
+| params_flow.rb:28:11:28:21 | synthetic splat argument | type tracker without call steps | params_flow.rb:28:11:28:21 | synthetic splat argument |
 | params_flow.rb:28:18:28:20 | :p2 | type tracker without call steps | params_flow.rb:28:18:28:20 | :p2 |
-| params_flow.rb:28:18:28:20 | :p2 | type tracker without call steps with content element 0 | params_flow.rb:28:11:28:21 | * |
-| params_flow.rb:29:5:29:22 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:29:5:29:22 | * | type tracker without call steps | params_flow.rb:29:5:29:22 | * |
+| params_flow.rb:28:18:28:20 | :p2 | type tracker without call steps with content splat position 0 | params_flow.rb:28:11:28:21 | synthetic splat argument |
 | params_flow.rb:29:5:29:22 | call to sink | type tracker without call steps | params_flow.rb:29:5:29:22 | call to sink |
-| params_flow.rb:29:11:29:21 | * | type tracker without call steps | params_flow.rb:29:11:29:21 | * |
+| params_flow.rb:29:5:29:22 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:29:5:29:22 | synthetic splat argument | type tracker without call steps | params_flow.rb:29:5:29:22 | synthetic splat argument |
 | params_flow.rb:29:11:29:21 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:29:11:29:21 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:29:11:29:21 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:29:11:29:21 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:29:11:29:21 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:29:11:29:21 | ...[...] | type tracker without call steps | params_flow.rb:29:11:29:21 | ...[...] |
-| params_flow.rb:29:11:29:21 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:29:5:29:22 | * |
+| params_flow.rb:29:11:29:21 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:29:5:29:22 | synthetic splat argument |
+| params_flow.rb:29:11:29:21 | synthetic splat argument | type tracker without call steps | params_flow.rb:29:11:29:21 | synthetic splat argument |
 | params_flow.rb:29:18:29:20 | :p3 | type tracker without call steps | params_flow.rb:29:18:29:20 | :p3 |
-| params_flow.rb:29:18:29:20 | :p3 | type tracker without call steps with content element 0 | params_flow.rb:29:11:29:21 | * |
-| params_flow.rb:30:5:30:22 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:30:5:30:22 | * | type tracker without call steps | params_flow.rb:30:5:30:22 | * |
+| params_flow.rb:29:18:29:20 | :p3 | type tracker without call steps with content splat position 0 | params_flow.rb:29:11:29:21 | synthetic splat argument |
 | params_flow.rb:30:5:30:22 | call to sink | type tracker without call steps | params_flow.rb:30:5:30:22 | call to sink |
 | params_flow.rb:30:5:30:22 | call to sink | type tracker without call steps | params_flow.rb:33:1:33:58 | call to kwargs |
 | params_flow.rb:30:5:30:22 | call to sink | type tracker without call steps | params_flow.rb:35:1:35:29 | call to kwargs |
 | params_flow.rb:30:5:30:22 | call to sink | type tracker without call steps | params_flow.rb:38:1:38:14 | call to kwargs |
-| params_flow.rb:30:11:30:21 | * | type tracker without call steps | params_flow.rb:30:11:30:21 | * |
+| params_flow.rb:30:5:30:22 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:30:5:30:22 | synthetic splat argument | type tracker without call steps | params_flow.rb:30:5:30:22 | synthetic splat argument |
 | params_flow.rb:30:11:30:21 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:30:11:30:21 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:30:11:30:21 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:30:11:30:21 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:30:11:30:21 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:30:11:30:21 | ...[...] | type tracker without call steps | params_flow.rb:30:11:30:21 | ...[...] |
-| params_flow.rb:30:11:30:21 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:30:5:30:22 | * |
+| params_flow.rb:30:11:30:21 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:30:5:30:22 | synthetic splat argument |
+| params_flow.rb:30:11:30:21 | synthetic splat argument | type tracker without call steps | params_flow.rb:30:11:30:21 | synthetic splat argument |
 | params_flow.rb:30:18:30:20 | :p4 | type tracker without call steps | params_flow.rb:30:18:30:20 | :p4 |
-| params_flow.rb:30:18:30:20 | :p4 | type tracker without call steps with content element 0 | params_flow.rb:30:11:30:21 | * |
-| params_flow.rb:33:1:33:58 | ** | type tracker with call steps | params_flow.rb:25:1:31:3 | **kwargs |
-| params_flow.rb:33:1:33:58 | ** | type tracker with call steps | params_flow.rb:25:17:25:24 | **kwargs |
-| params_flow.rb:33:1:33:58 | ** | type tracker without call steps | params_flow.rb:33:1:33:58 | ** |
+| params_flow.rb:30:18:30:20 | :p4 | type tracker without call steps with content splat position 0 | params_flow.rb:30:11:30:21 | synthetic splat argument |
 | params_flow.rb:33:1:33:58 | call to kwargs | type tracker without call steps | params_flow.rb:33:1:33:58 | call to kwargs |
+| params_flow.rb:33:1:33:58 | synthetic hash-splat argument | type tracker with call steps | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
+| params_flow.rb:33:1:33:58 | synthetic hash-splat argument | type tracker with call steps | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:1:33:58 | synthetic hash-splat argument | type tracker without call steps | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
 | params_flow.rb:33:8:33:9 | :p1 | type tracker without call steps | params_flow.rb:33:8:33:9 | :p1 |
 | params_flow.rb:33:8:33:19 | Pair | type tracker without call steps | params_flow.rb:33:8:33:19 | Pair |
-| params_flow.rb:33:12:33:19 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:33:12:33:19 | * | type tracker without call steps | params_flow.rb:33:12:33:19 | * |
 | params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps | params_flow.rb:25:12:25:13 | p1 |
 | params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps | params_flow.rb:27:11:27:21 | ...[...] |
-| params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:26:5:26:11 | * |
-| params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:27:5:27:22 | * |
-| params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content element :p1 | params_flow.rb:25:1:31:3 | **kwargs |
-| params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content element :p1 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
+| params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:26:5:26:11 | synthetic splat argument |
+| params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:27:5:27:22 | synthetic splat argument |
 | params_flow.rb:33:12:33:19 | call to taint | type tracker without call steps | params_flow.rb:33:12:33:19 | call to taint |
-| params_flow.rb:33:12:33:19 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:33:1:33:58 | ** |
+| params_flow.rb:33:12:33:19 | call to taint | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
+| params_flow.rb:33:12:33:19 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:33:12:33:19 | synthetic splat argument | type tracker without call steps | params_flow.rb:33:12:33:19 | synthetic splat argument |
 | params_flow.rb:33:18:33:18 | 9 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:33:18:33:18 | 9 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:33:18:33:18 | 9 | type tracker with call steps | params_flow.rb:25:12:25:13 | p1 |
 | params_flow.rb:33:18:33:18 | 9 | type tracker with call steps | params_flow.rb:27:11:27:21 | ...[...] |
-| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content element 0 | params_flow.rb:26:5:26:11 | * |
-| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content element 0 | params_flow.rb:27:5:27:22 | * |
-| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content element :p1 | params_flow.rb:25:1:31:3 | **kwargs |
-| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content element :p1 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
+| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content splat position 0 | params_flow.rb:26:5:26:11 | synthetic splat argument |
+| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content splat position 0 | params_flow.rb:27:5:27:22 | synthetic splat argument |
 | params_flow.rb:33:18:33:18 | 9 | type tracker without call steps | params_flow.rb:33:12:33:19 | call to taint |
 | params_flow.rb:33:18:33:18 | 9 | type tracker without call steps | params_flow.rb:33:18:33:18 | 9 |
-| params_flow.rb:33:18:33:18 | 9 | type tracker without call steps with content element 0 | params_flow.rb:33:12:33:19 | * |
-| params_flow.rb:33:18:33:18 | 9 | type tracker without call steps with content element :p1 | params_flow.rb:33:1:33:58 | ** |
+| params_flow.rb:33:18:33:18 | 9 | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
+| params_flow.rb:33:18:33:18 | 9 | type tracker without call steps with content splat position 0 | params_flow.rb:33:12:33:19 | synthetic splat argument |
 | params_flow.rb:33:22:33:23 | :p2 | type tracker without call steps | params_flow.rb:33:22:33:23 | :p2 |
 | params_flow.rb:33:22:33:34 | Pair | type tracker without call steps | params_flow.rb:33:22:33:34 | Pair |
-| params_flow.rb:33:26:33:34 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:33:26:33:34 | * | type tracker without call steps | params_flow.rb:33:26:33:34 | * |
 | params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps | params_flow.rb:28:11:28:21 | ...[...] |
-| params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:28:5:28:22 | * |
-| params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps with content element :p2 | params_flow.rb:25:1:31:3 | **kwargs |
-| params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps with content element :p2 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
+| params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:28:5:28:22 | synthetic splat argument |
 | params_flow.rb:33:26:33:34 | call to taint | type tracker without call steps | params_flow.rb:33:26:33:34 | call to taint |
-| params_flow.rb:33:26:33:34 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:33:1:33:58 | ** |
+| params_flow.rb:33:26:33:34 | call to taint | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
+| params_flow.rb:33:26:33:34 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:33:26:33:34 | synthetic splat argument | type tracker without call steps | params_flow.rb:33:26:33:34 | synthetic splat argument |
 | params_flow.rb:33:32:33:33 | 10 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:33:32:33:33 | 10 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:33:32:33:33 | 10 | type tracker with call steps | params_flow.rb:28:11:28:21 | ...[...] |
-| params_flow.rb:33:32:33:33 | 10 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:33:32:33:33 | 10 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:33:32:33:33 | 10 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:33:32:33:33 | 10 | type tracker with call steps with content element 0 | params_flow.rb:28:5:28:22 | * |
-| params_flow.rb:33:32:33:33 | 10 | type tracker with call steps with content element :p2 | params_flow.rb:25:1:31:3 | **kwargs |
-| params_flow.rb:33:32:33:33 | 10 | type tracker with call steps with content element :p2 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:32:33:33 | 10 | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
+| params_flow.rb:33:32:33:33 | 10 | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:32:33:33 | 10 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:33:32:33:33 | 10 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:33:32:33:33 | 10 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:33:32:33:33 | 10 | type tracker with call steps with content splat position 0 | params_flow.rb:28:5:28:22 | synthetic splat argument |
 | params_flow.rb:33:32:33:33 | 10 | type tracker without call steps | params_flow.rb:33:26:33:34 | call to taint |
 | params_flow.rb:33:32:33:33 | 10 | type tracker without call steps | params_flow.rb:33:32:33:33 | 10 |
-| params_flow.rb:33:32:33:33 | 10 | type tracker without call steps with content element 0 | params_flow.rb:33:26:33:34 | * |
-| params_flow.rb:33:32:33:33 | 10 | type tracker without call steps with content element :p2 | params_flow.rb:33:1:33:58 | ** |
+| params_flow.rb:33:32:33:33 | 10 | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
+| params_flow.rb:33:32:33:33 | 10 | type tracker without call steps with content splat position 0 | params_flow.rb:33:26:33:34 | synthetic splat argument |
 | params_flow.rb:33:37:33:38 | :p3 | type tracker without call steps | params_flow.rb:33:37:33:38 | :p3 |
 | params_flow.rb:33:37:33:49 | Pair | type tracker without call steps | params_flow.rb:33:37:33:49 | Pair |
-| params_flow.rb:33:41:33:49 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:33:41:33:49 | * | type tracker without call steps | params_flow.rb:33:41:33:49 | * |
 | params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps | params_flow.rb:29:11:29:21 | ...[...] |
-| params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:29:5:29:22 | * |
-| params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps with content element :p3 | params_flow.rb:25:1:31:3 | **kwargs |
-| params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps with content element :p3 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps with content hash-splat position :p3 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
+| params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps with content hash-splat position :p3 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:29:5:29:22 | synthetic splat argument |
 | params_flow.rb:33:41:33:49 | call to taint | type tracker without call steps | params_flow.rb:33:41:33:49 | call to taint |
-| params_flow.rb:33:41:33:49 | call to taint | type tracker without call steps with content element :p3 | params_flow.rb:33:1:33:58 | ** |
+| params_flow.rb:33:41:33:49 | call to taint | type tracker without call steps with content hash-splat position :p3 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
+| params_flow.rb:33:41:33:49 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:33:41:33:49 | synthetic splat argument | type tracker without call steps | params_flow.rb:33:41:33:49 | synthetic splat argument |
 | params_flow.rb:33:47:33:48 | 11 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:33:47:33:48 | 11 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:33:47:33:48 | 11 | type tracker with call steps | params_flow.rb:29:11:29:21 | ...[...] |
-| params_flow.rb:33:47:33:48 | 11 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:33:47:33:48 | 11 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:33:47:33:48 | 11 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:33:47:33:48 | 11 | type tracker with call steps with content element 0 | params_flow.rb:29:5:29:22 | * |
-| params_flow.rb:33:47:33:48 | 11 | type tracker with call steps with content element :p3 | params_flow.rb:25:1:31:3 | **kwargs |
-| params_flow.rb:33:47:33:48 | 11 | type tracker with call steps with content element :p3 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:47:33:48 | 11 | type tracker with call steps with content hash-splat position :p3 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
+| params_flow.rb:33:47:33:48 | 11 | type tracker with call steps with content hash-splat position :p3 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:47:33:48 | 11 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:33:47:33:48 | 11 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:33:47:33:48 | 11 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:33:47:33:48 | 11 | type tracker with call steps with content splat position 0 | params_flow.rb:29:5:29:22 | synthetic splat argument |
 | params_flow.rb:33:47:33:48 | 11 | type tracker without call steps | params_flow.rb:33:41:33:49 | call to taint |
 | params_flow.rb:33:47:33:48 | 11 | type tracker without call steps | params_flow.rb:33:47:33:48 | 11 |
-| params_flow.rb:33:47:33:48 | 11 | type tracker without call steps with content element 0 | params_flow.rb:33:41:33:49 | * |
-| params_flow.rb:33:47:33:48 | 11 | type tracker without call steps with content element :p3 | params_flow.rb:33:1:33:58 | ** |
+| params_flow.rb:33:47:33:48 | 11 | type tracker without call steps with content hash-splat position :p3 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
+| params_flow.rb:33:47:33:48 | 11 | type tracker without call steps with content splat position 0 | params_flow.rb:33:41:33:49 | synthetic splat argument |
 | params_flow.rb:33:52:33:53 | :p4 | type tracker without call steps | params_flow.rb:33:52:33:53 | :p4 |
 | params_flow.rb:33:52:33:57 | Pair | type tracker without call steps | params_flow.rb:33:52:33:57 | Pair |
 | params_flow.rb:33:56:33:57 | "" | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:33:56:33:57 | "" | type tracker with call steps | params_flow.rb:30:11:30:21 | ...[...] |
-| params_flow.rb:33:56:33:57 | "" | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:33:56:33:57 | "" | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:33:56:33:57 | "" | type tracker with call steps with content element 0 | params_flow.rb:30:5:30:22 | * |
-| params_flow.rb:33:56:33:57 | "" | type tracker with call steps with content element :p4 | params_flow.rb:25:1:31:3 | **kwargs |
-| params_flow.rb:33:56:33:57 | "" | type tracker with call steps with content element :p4 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:56:33:57 | "" | type tracker with call steps with content hash-splat position :p4 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
+| params_flow.rb:33:56:33:57 | "" | type tracker with call steps with content hash-splat position :p4 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:56:33:57 | "" | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:33:56:33:57 | "" | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:33:56:33:57 | "" | type tracker with call steps with content splat position 0 | params_flow.rb:30:5:30:22 | synthetic splat argument |
 | params_flow.rb:33:56:33:57 | "" | type tracker without call steps | params_flow.rb:33:56:33:57 | "" |
-| params_flow.rb:33:56:33:57 | "" | type tracker without call steps with content element :p4 | params_flow.rb:33:1:33:58 | ** |
+| params_flow.rb:33:56:33:57 | "" | type tracker without call steps with content hash-splat position :p4 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
 | params_flow.rb:34:1:34:4 | args | type tracker without call steps | params_flow.rb:34:1:34:4 | args |
-| params_flow.rb:34:8:34:32 | ** | type tracker without call steps | params_flow.rb:34:8:34:32 | ** |
 | params_flow.rb:34:8:34:32 | Hash | type tracker without call steps | params_flow.rb:34:8:34:32 | Hash |
 | params_flow.rb:34:8:34:32 | call to [] | type tracker without call steps | params_flow.rb:34:8:34:32 | call to [] |
+| params_flow.rb:34:8:34:32 | synthetic hash-splat argument | type tracker without call steps | params_flow.rb:34:8:34:32 | call to [] |
+| params_flow.rb:34:8:34:32 | synthetic hash-splat argument | type tracker without call steps | params_flow.rb:34:8:34:32 | synthetic hash-splat argument |
 | params_flow.rb:34:10:34:11 | :p3 | type tracker without call steps | params_flow.rb:34:10:34:11 | :p3 |
 | params_flow.rb:34:10:34:22 | Pair | type tracker without call steps | params_flow.rb:34:10:34:22 | Pair |
-| params_flow.rb:34:14:34:22 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:34:14:34:22 | * | type tracker without call steps | params_flow.rb:34:14:34:22 | * |
 | params_flow.rb:34:14:34:22 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:34:14:34:22 | call to taint | type tracker with call steps | params_flow.rb:29:11:29:21 | ...[...] |
-| params_flow.rb:34:14:34:22 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:34:14:34:22 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:34:14:34:22 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:29:5:29:22 | * |
-| params_flow.rb:34:14:34:22 | call to taint | type tracker with call steps with content element :p3 | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:34:14:34:22 | call to taint | type tracker with call steps with content element :p3 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:34:14:34:22 | call to taint | type tracker with call steps with content element :p3 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:34:14:34:22 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:34:14:34:22 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:34:14:34:22 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:29:5:29:22 | synthetic splat argument |
 | params_flow.rb:34:14:34:22 | call to taint | type tracker without call steps | params_flow.rb:34:14:34:22 | call to taint |
-| params_flow.rb:34:14:34:22 | call to taint | type tracker without call steps with content element :p3 | params_flow.rb:34:8:34:32 | ** |
 | params_flow.rb:34:14:34:22 | call to taint | type tracker without call steps with content element :p3 | params_flow.rb:34:8:34:32 | call to [] |
+| params_flow.rb:34:14:34:22 | call to taint | type tracker without call steps with content element :p3 | params_flow.rb:34:8:34:32 | synthetic hash-splat argument |
 | params_flow.rb:34:14:34:22 | call to taint | type tracker without call steps with content element :p3 | params_flow.rb:35:23:35:28 | ** ... |
+| params_flow.rb:34:14:34:22 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:34:14:34:22 | synthetic splat argument | type tracker without call steps | params_flow.rb:34:14:34:22 | synthetic splat argument |
 | params_flow.rb:34:20:34:21 | 12 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:34:20:34:21 | 12 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:34:20:34:21 | 12 | type tracker with call steps | params_flow.rb:29:11:29:21 | ...[...] |
-| params_flow.rb:34:20:34:21 | 12 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:34:20:34:21 | 12 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:34:20:34:21 | 12 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:34:20:34:21 | 12 | type tracker with call steps with content element 0 | params_flow.rb:29:5:29:22 | * |
-| params_flow.rb:34:20:34:21 | 12 | type tracker with call steps with content element :p3 | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:34:20:34:21 | 12 | type tracker with call steps with content element :p3 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:34:20:34:21 | 12 | type tracker with call steps with content element :p3 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:34:20:34:21 | 12 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:34:20:34:21 | 12 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:34:20:34:21 | 12 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:34:20:34:21 | 12 | type tracker with call steps with content splat position 0 | params_flow.rb:29:5:29:22 | synthetic splat argument |
 | params_flow.rb:34:20:34:21 | 12 | type tracker without call steps | params_flow.rb:34:14:34:22 | call to taint |
 | params_flow.rb:34:20:34:21 | 12 | type tracker without call steps | params_flow.rb:34:20:34:21 | 12 |
-| params_flow.rb:34:20:34:21 | 12 | type tracker without call steps with content element 0 | params_flow.rb:34:14:34:22 | * |
-| params_flow.rb:34:20:34:21 | 12 | type tracker without call steps with content element :p3 | params_flow.rb:34:8:34:32 | ** |
 | params_flow.rb:34:20:34:21 | 12 | type tracker without call steps with content element :p3 | params_flow.rb:34:8:34:32 | call to [] |
+| params_flow.rb:34:20:34:21 | 12 | type tracker without call steps with content element :p3 | params_flow.rb:34:8:34:32 | synthetic hash-splat argument |
 | params_flow.rb:34:20:34:21 | 12 | type tracker without call steps with content element :p3 | params_flow.rb:35:23:35:28 | ** ... |
+| params_flow.rb:34:20:34:21 | 12 | type tracker without call steps with content splat position 0 | params_flow.rb:34:14:34:22 | synthetic splat argument |
 | params_flow.rb:34:25:34:26 | :p4 | type tracker without call steps | params_flow.rb:34:25:34:26 | :p4 |
 | params_flow.rb:34:25:34:30 | Pair | type tracker without call steps | params_flow.rb:34:25:34:30 | Pair |
 | params_flow.rb:34:29:34:30 | "" | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:34:29:34:30 | "" | type tracker with call steps | params_flow.rb:30:11:30:21 | ...[...] |
-| params_flow.rb:34:29:34:30 | "" | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:34:29:34:30 | "" | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:34:29:34:30 | "" | type tracker with call steps with content element 0 | params_flow.rb:30:5:30:22 | * |
-| params_flow.rb:34:29:34:30 | "" | type tracker with call steps with content element :p4 | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:34:29:34:30 | "" | type tracker with call steps with content element :p4 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:34:29:34:30 | "" | type tracker with call steps with content element :p4 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:34:29:34:30 | "" | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:34:29:34:30 | "" | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:34:29:34:30 | "" | type tracker with call steps with content splat position 0 | params_flow.rb:30:5:30:22 | synthetic splat argument |
 | params_flow.rb:34:29:34:30 | "" | type tracker without call steps | params_flow.rb:34:29:34:30 | "" |
-| params_flow.rb:34:29:34:30 | "" | type tracker without call steps with content element :p4 | params_flow.rb:34:8:34:32 | ** |
 | params_flow.rb:34:29:34:30 | "" | type tracker without call steps with content element :p4 | params_flow.rb:34:8:34:32 | call to [] |
+| params_flow.rb:34:29:34:30 | "" | type tracker without call steps with content element :p4 | params_flow.rb:34:8:34:32 | synthetic hash-splat argument |
 | params_flow.rb:34:29:34:30 | "" | type tracker without call steps with content element :p4 | params_flow.rb:35:23:35:28 | ** ... |
-| params_flow.rb:35:1:35:29 | ** | type tracker with call steps | params_flow.rb:25:1:31:3 | **kwargs |
-| params_flow.rb:35:1:35:29 | ** | type tracker with call steps | params_flow.rb:25:17:25:24 | **kwargs |
-| params_flow.rb:35:1:35:29 | ** | type tracker without call steps | params_flow.rb:35:1:35:29 | ** |
 | params_flow.rb:35:1:35:29 | call to kwargs | type tracker without call steps | params_flow.rb:35:1:35:29 | call to kwargs |
+| params_flow.rb:35:1:35:29 | synthetic hash-splat argument | type tracker with call steps | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
+| params_flow.rb:35:1:35:29 | synthetic hash-splat argument | type tracker with call steps | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:35:1:35:29 | synthetic hash-splat argument | type tracker without call steps | params_flow.rb:35:1:35:29 | synthetic hash-splat argument |
 | params_flow.rb:35:8:35:9 | :p1 | type tracker without call steps | params_flow.rb:35:8:35:9 | :p1 |
 | params_flow.rb:35:8:35:20 | Pair | type tracker without call steps | params_flow.rb:35:8:35:20 | Pair |
-| params_flow.rb:35:12:35:20 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:35:12:35:20 | * | type tracker without call steps | params_flow.rb:35:12:35:20 | * |
 | params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps | params_flow.rb:25:12:25:13 | p1 |
 | params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps | params_flow.rb:27:11:27:21 | ...[...] |
-| params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:26:5:26:11 | * |
-| params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:27:5:27:22 | * |
-| params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content element :p1 | params_flow.rb:25:1:31:3 | **kwargs |
-| params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content element :p1 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
+| params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:26:5:26:11 | synthetic splat argument |
+| params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:27:5:27:22 | synthetic splat argument |
 | params_flow.rb:35:12:35:20 | call to taint | type tracker without call steps | params_flow.rb:35:12:35:20 | call to taint |
-| params_flow.rb:35:12:35:20 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:35:1:35:29 | ** |
+| params_flow.rb:35:12:35:20 | call to taint | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:35:1:35:29 | synthetic hash-splat argument |
+| params_flow.rb:35:12:35:20 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:35:12:35:20 | synthetic splat argument | type tracker without call steps | params_flow.rb:35:12:35:20 | synthetic splat argument |
 | params_flow.rb:35:18:35:19 | 13 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:35:18:35:19 | 13 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:35:18:35:19 | 13 | type tracker with call steps | params_flow.rb:25:12:25:13 | p1 |
 | params_flow.rb:35:18:35:19 | 13 | type tracker with call steps | params_flow.rb:27:11:27:21 | ...[...] |
-| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content element 0 | params_flow.rb:26:5:26:11 | * |
-| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content element 0 | params_flow.rb:27:5:27:22 | * |
-| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content element :p1 | params_flow.rb:25:1:31:3 | **kwargs |
-| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content element :p1 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
+| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content splat position 0 | params_flow.rb:26:5:26:11 | synthetic splat argument |
+| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content splat position 0 | params_flow.rb:27:5:27:22 | synthetic splat argument |
 | params_flow.rb:35:18:35:19 | 13 | type tracker without call steps | params_flow.rb:35:12:35:20 | call to taint |
 | params_flow.rb:35:18:35:19 | 13 | type tracker without call steps | params_flow.rb:35:18:35:19 | 13 |
-| params_flow.rb:35:18:35:19 | 13 | type tracker without call steps with content element 0 | params_flow.rb:35:12:35:20 | * |
-| params_flow.rb:35:18:35:19 | 13 | type tracker without call steps with content element :p1 | params_flow.rb:35:1:35:29 | ** |
-| params_flow.rb:35:23:35:28 | ** ... | type tracker with call steps | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:35:18:35:19 | 13 | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:35:1:35:29 | synthetic hash-splat argument |
+| params_flow.rb:35:18:35:19 | 13 | type tracker without call steps with content splat position 0 | params_flow.rb:35:12:35:20 | synthetic splat argument |
+| params_flow.rb:35:23:35:28 | ** ... | type tracker with call steps | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:35:23:35:28 | ** ... | type tracker with call steps | params_flow.rb:25:17:25:24 | **kwargs |
 | params_flow.rb:35:23:35:28 | ** ... | type tracker without call steps | params_flow.rb:35:23:35:28 | ** ... |
 | params_flow.rb:37:1:37:4 | args | type tracker without call steps | params_flow.rb:37:1:37:4 | args |
-| params_flow.rb:37:8:37:44 | ** | type tracker without call steps | params_flow.rb:37:8:37:44 | ** |
 | params_flow.rb:37:8:37:44 | Hash | type tracker without call steps | params_flow.rb:37:8:37:44 | Hash |
 | params_flow.rb:37:8:37:44 | call to [] | type tracker without call steps | params_flow.rb:37:8:37:44 | call to [] |
+| params_flow.rb:37:8:37:44 | synthetic hash-splat argument | type tracker without call steps | params_flow.rb:37:8:37:44 | call to [] |
+| params_flow.rb:37:8:37:44 | synthetic hash-splat argument | type tracker without call steps | params_flow.rb:37:8:37:44 | synthetic hash-splat argument |
 | params_flow.rb:37:9:37:11 | :p1 | type tracker without call steps | params_flow.rb:37:9:37:11 | :p1 |
 | params_flow.rb:37:9:37:24 | Pair | type tracker without call steps | params_flow.rb:37:9:37:24 | Pair |
-| params_flow.rb:37:16:37:24 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:37:16:37:24 | * | type tracker without call steps | params_flow.rb:37:16:37:24 | * |
 | params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps | params_flow.rb:25:12:25:13 | p1 |
 | params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps | params_flow.rb:27:11:27:21 | ...[...] |
-| params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:26:5:26:11 | * |
-| params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:27:5:27:22 | * |
-| params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps with content element :p1 | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps with content element :p1 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps with content element :p1 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:26:5:26:11 | synthetic splat argument |
+| params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:27:5:27:22 | synthetic splat argument |
 | params_flow.rb:37:16:37:24 | call to taint | type tracker without call steps | params_flow.rb:37:16:37:24 | call to taint |
-| params_flow.rb:37:16:37:24 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:37:8:37:44 | ** |
 | params_flow.rb:37:16:37:24 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:37:8:37:44 | call to [] |
+| params_flow.rb:37:16:37:24 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:37:8:37:44 | synthetic hash-splat argument |
 | params_flow.rb:37:16:37:24 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:38:8:38:13 | ** ... |
+| params_flow.rb:37:16:37:24 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:37:16:37:24 | synthetic splat argument | type tracker without call steps | params_flow.rb:37:16:37:24 | synthetic splat argument |
 | params_flow.rb:37:22:37:23 | 14 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:37:22:37:23 | 14 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:37:22:37:23 | 14 | type tracker with call steps | params_flow.rb:25:12:25:13 | p1 |
 | params_flow.rb:37:22:37:23 | 14 | type tracker with call steps | params_flow.rb:27:11:27:21 | ...[...] |
-| params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content element 0 | params_flow.rb:26:5:26:11 | * |
-| params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content element 0 | params_flow.rb:27:5:27:22 | * |
-| params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content element :p1 | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content element :p1 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content element :p1 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content splat position 0 | params_flow.rb:26:5:26:11 | synthetic splat argument |
+| params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content splat position 0 | params_flow.rb:27:5:27:22 | synthetic splat argument |
 | params_flow.rb:37:22:37:23 | 14 | type tracker without call steps | params_flow.rb:37:16:37:24 | call to taint |
 | params_flow.rb:37:22:37:23 | 14 | type tracker without call steps | params_flow.rb:37:22:37:23 | 14 |
-| params_flow.rb:37:22:37:23 | 14 | type tracker without call steps with content element 0 | params_flow.rb:37:16:37:24 | * |
-| params_flow.rb:37:22:37:23 | 14 | type tracker without call steps with content element :p1 | params_flow.rb:37:8:37:44 | ** |
 | params_flow.rb:37:22:37:23 | 14 | type tracker without call steps with content element :p1 | params_flow.rb:37:8:37:44 | call to [] |
+| params_flow.rb:37:22:37:23 | 14 | type tracker without call steps with content element :p1 | params_flow.rb:37:8:37:44 | synthetic hash-splat argument |
 | params_flow.rb:37:22:37:23 | 14 | type tracker without call steps with content element :p1 | params_flow.rb:38:8:38:13 | ** ... |
+| params_flow.rb:37:22:37:23 | 14 | type tracker without call steps with content splat position 0 | params_flow.rb:37:16:37:24 | synthetic splat argument |
 | params_flow.rb:37:27:37:29 | :p2 | type tracker without call steps | params_flow.rb:37:27:37:29 | :p2 |
 | params_flow.rb:37:27:37:42 | Pair | type tracker without call steps | params_flow.rb:37:27:37:42 | Pair |
-| params_flow.rb:37:34:37:42 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:37:34:37:42 | * | type tracker without call steps | params_flow.rb:37:34:37:42 | * |
 | params_flow.rb:37:34:37:42 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:37:34:37:42 | call to taint | type tracker with call steps | params_flow.rb:28:11:28:21 | ...[...] |
-| params_flow.rb:37:34:37:42 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:37:34:37:42 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:37:34:37:42 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:28:5:28:22 | * |
-| params_flow.rb:37:34:37:42 | call to taint | type tracker with call steps with content element :p2 | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:37:34:37:42 | call to taint | type tracker with call steps with content element :p2 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:37:34:37:42 | call to taint | type tracker with call steps with content element :p2 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:37:34:37:42 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:37:34:37:42 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:37:34:37:42 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:28:5:28:22 | synthetic splat argument |
 | params_flow.rb:37:34:37:42 | call to taint | type tracker without call steps | params_flow.rb:37:34:37:42 | call to taint |
-| params_flow.rb:37:34:37:42 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:37:8:37:44 | ** |
 | params_flow.rb:37:34:37:42 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:37:8:37:44 | call to [] |
+| params_flow.rb:37:34:37:42 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:37:8:37:44 | synthetic hash-splat argument |
 | params_flow.rb:37:34:37:42 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:38:8:38:13 | ** ... |
+| params_flow.rb:37:34:37:42 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:37:34:37:42 | synthetic splat argument | type tracker without call steps | params_flow.rb:37:34:37:42 | synthetic splat argument |
 | params_flow.rb:37:40:37:41 | 15 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:37:40:37:41 | 15 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:37:40:37:41 | 15 | type tracker with call steps | params_flow.rb:28:11:28:21 | ...[...] |
-| params_flow.rb:37:40:37:41 | 15 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:37:40:37:41 | 15 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:37:40:37:41 | 15 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:37:40:37:41 | 15 | type tracker with call steps with content element 0 | params_flow.rb:28:5:28:22 | * |
-| params_flow.rb:37:40:37:41 | 15 | type tracker with call steps with content element :p2 | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:37:40:37:41 | 15 | type tracker with call steps with content element :p2 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:37:40:37:41 | 15 | type tracker with call steps with content element :p2 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:37:40:37:41 | 15 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:37:40:37:41 | 15 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:37:40:37:41 | 15 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:37:40:37:41 | 15 | type tracker with call steps with content splat position 0 | params_flow.rb:28:5:28:22 | synthetic splat argument |
 | params_flow.rb:37:40:37:41 | 15 | type tracker without call steps | params_flow.rb:37:34:37:42 | call to taint |
 | params_flow.rb:37:40:37:41 | 15 | type tracker without call steps | params_flow.rb:37:40:37:41 | 15 |
-| params_flow.rb:37:40:37:41 | 15 | type tracker without call steps with content element 0 | params_flow.rb:37:34:37:42 | * |
-| params_flow.rb:37:40:37:41 | 15 | type tracker without call steps with content element :p2 | params_flow.rb:37:8:37:44 | ** |
 | params_flow.rb:37:40:37:41 | 15 | type tracker without call steps with content element :p2 | params_flow.rb:37:8:37:44 | call to [] |
+| params_flow.rb:37:40:37:41 | 15 | type tracker without call steps with content element :p2 | params_flow.rb:37:8:37:44 | synthetic hash-splat argument |
 | params_flow.rb:37:40:37:41 | 15 | type tracker without call steps with content element :p2 | params_flow.rb:38:8:38:13 | ** ... |
+| params_flow.rb:37:40:37:41 | 15 | type tracker without call steps with content splat position 0 | params_flow.rb:37:34:37:42 | synthetic splat argument |
 | params_flow.rb:38:1:38:14 | call to kwargs | type tracker without call steps | params_flow.rb:38:1:38:14 | call to kwargs |
-| params_flow.rb:38:8:38:13 | ** ... | type tracker with call steps | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:38:8:38:13 | ** ... | type tracker with call steps | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:38:8:38:13 | ** ... | type tracker with call steps | params_flow.rb:25:17:25:24 | **kwargs |
 | params_flow.rb:38:8:38:13 | ** ... | type tracker without call steps | params_flow.rb:38:8:38:13 | ** ... |
 | params_flow.rb:40:1:40:4 | args | type tracker without call steps | params_flow.rb:40:1:40:4 | args |
-| params_flow.rb:40:8:40:26 | ** | type tracker without call steps | params_flow.rb:40:8:40:26 | ** |
 | params_flow.rb:40:8:40:26 | Hash | type tracker without call steps | params_flow.rb:40:8:40:26 | Hash |
 | params_flow.rb:40:8:40:26 | call to [] | type tracker without call steps | params_flow.rb:40:8:40:26 | call to [] |
+| params_flow.rb:40:8:40:26 | synthetic hash-splat argument | type tracker without call steps | params_flow.rb:40:8:40:26 | call to [] |
+| params_flow.rb:40:8:40:26 | synthetic hash-splat argument | type tracker without call steps | params_flow.rb:40:8:40:26 | synthetic hash-splat argument |
 | params_flow.rb:40:9:40:11 | :p1 | type tracker without call steps | params_flow.rb:40:9:40:11 | :p1 |
 | params_flow.rb:40:9:40:24 | Pair | type tracker without call steps | params_flow.rb:40:9:40:24 | Pair |
-| params_flow.rb:40:16:40:24 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:40:16:40:24 | * | type tracker without call steps | params_flow.rb:40:16:40:24 | * |
 | params_flow.rb:40:16:40:24 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:40:16:40:24 | call to taint | type tracker with call steps | params_flow.rb:16:13:16:14 | p1 |
-| params_flow.rb:40:16:40:24 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:40:16:40:24 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:40:16:40:24 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | * |
-| params_flow.rb:40:16:40:24 | call to taint | type tracker with call steps with content element :p1 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:40:16:40:24 | call to taint | type tracker with call steps with content element :p1 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
+| params_flow.rb:40:16:40:24 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:40:16:40:24 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:40:16:40:24 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
 | params_flow.rb:40:16:40:24 | call to taint | type tracker without call steps | params_flow.rb:40:16:40:24 | call to taint |
-| params_flow.rb:40:16:40:24 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:40:8:40:26 | ** |
 | params_flow.rb:40:16:40:24 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:40:8:40:26 | call to [] |
+| params_flow.rb:40:16:40:24 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:40:8:40:26 | synthetic hash-splat argument |
 | params_flow.rb:40:16:40:24 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:41:24:41:29 | ** ... |
+| params_flow.rb:40:16:40:24 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:40:16:40:24 | synthetic splat argument | type tracker without call steps | params_flow.rb:40:16:40:24 | synthetic splat argument |
 | params_flow.rb:40:22:40:23 | 16 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:40:22:40:23 | 16 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:40:22:40:23 | 16 | type tracker with call steps | params_flow.rb:16:13:16:14 | p1 |
-| params_flow.rb:40:22:40:23 | 16 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:40:22:40:23 | 16 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:40:22:40:23 | 16 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:40:22:40:23 | 16 | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | * |
-| params_flow.rb:40:22:40:23 | 16 | type tracker with call steps with content element :p1 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:40:22:40:23 | 16 | type tracker with call steps with content element :p1 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
+| params_flow.rb:40:22:40:23 | 16 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:40:22:40:23 | 16 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:40:22:40:23 | 16 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:40:22:40:23 | 16 | type tracker with call steps with content splat position 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
 | params_flow.rb:40:22:40:23 | 16 | type tracker without call steps | params_flow.rb:40:16:40:24 | call to taint |
 | params_flow.rb:40:22:40:23 | 16 | type tracker without call steps | params_flow.rb:40:22:40:23 | 16 |
-| params_flow.rb:40:22:40:23 | 16 | type tracker without call steps with content element 0 | params_flow.rb:40:16:40:24 | * |
-| params_flow.rb:40:22:40:23 | 16 | type tracker without call steps with content element :p1 | params_flow.rb:40:8:40:26 | ** |
 | params_flow.rb:40:22:40:23 | 16 | type tracker without call steps with content element :p1 | params_flow.rb:40:8:40:26 | call to [] |
+| params_flow.rb:40:22:40:23 | 16 | type tracker without call steps with content element :p1 | params_flow.rb:40:8:40:26 | synthetic hash-splat argument |
 | params_flow.rb:40:22:40:23 | 16 | type tracker without call steps with content element :p1 | params_flow.rb:41:24:41:29 | ** ... |
-| params_flow.rb:41:1:41:30 | ** | type tracker with call steps | params_flow.rb:16:1:19:3 | **kwargs |
-| params_flow.rb:41:1:41:30 | ** | type tracker without call steps | params_flow.rb:41:1:41:30 | ** |
+| params_flow.rb:40:22:40:23 | 16 | type tracker without call steps with content splat position 0 | params_flow.rb:40:16:40:24 | synthetic splat argument |
 | params_flow.rb:41:1:41:30 | call to keyword | type tracker without call steps | params_flow.rb:41:1:41:30 | call to keyword |
+| params_flow.rb:41:1:41:30 | synthetic hash-splat argument | type tracker with call steps | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
+| params_flow.rb:41:1:41:30 | synthetic hash-splat argument | type tracker without call steps | params_flow.rb:41:1:41:30 | synthetic hash-splat argument |
 | params_flow.rb:41:9:41:10 | :p2 | type tracker without call steps | params_flow.rb:41:9:41:10 | :p2 |
 | params_flow.rb:41:9:41:21 | Pair | type tracker without call steps | params_flow.rb:41:9:41:21 | Pair |
-| params_flow.rb:41:13:41:21 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:41:13:41:21 | * | type tracker without call steps | params_flow.rb:41:13:41:21 | * |
 | params_flow.rb:41:13:41:21 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:41:13:41:21 | call to taint | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
-| params_flow.rb:41:13:41:21 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:41:13:41:21 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:41:13:41:21 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | * |
-| params_flow.rb:41:13:41:21 | call to taint | type tracker with call steps with content element :p2 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:41:13:41:21 | call to taint | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
+| params_flow.rb:41:13:41:21 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:41:13:41:21 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:41:13:41:21 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:41:13:41:21 | call to taint | type tracker without call steps | params_flow.rb:41:13:41:21 | call to taint |
-| params_flow.rb:41:13:41:21 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:41:1:41:30 | ** |
+| params_flow.rb:41:13:41:21 | call to taint | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:41:1:41:30 | synthetic hash-splat argument |
+| params_flow.rb:41:13:41:21 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:41:13:41:21 | synthetic splat argument | type tracker without call steps | params_flow.rb:41:13:41:21 | synthetic splat argument |
 | params_flow.rb:41:19:41:20 | 17 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:41:19:41:20 | 17 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:41:19:41:20 | 17 | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
-| params_flow.rb:41:19:41:20 | 17 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:41:19:41:20 | 17 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:41:19:41:20 | 17 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:41:19:41:20 | 17 | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | * |
-| params_flow.rb:41:19:41:20 | 17 | type tracker with call steps with content element :p2 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:41:19:41:20 | 17 | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
+| params_flow.rb:41:19:41:20 | 17 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:41:19:41:20 | 17 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:41:19:41:20 | 17 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:41:19:41:20 | 17 | type tracker with call steps with content splat position 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:41:19:41:20 | 17 | type tracker without call steps | params_flow.rb:41:13:41:21 | call to taint |
 | params_flow.rb:41:19:41:20 | 17 | type tracker without call steps | params_flow.rb:41:19:41:20 | 17 |
-| params_flow.rb:41:19:41:20 | 17 | type tracker without call steps with content element 0 | params_flow.rb:41:13:41:21 | * |
-| params_flow.rb:41:19:41:20 | 17 | type tracker without call steps with content element :p2 | params_flow.rb:41:1:41:30 | ** |
-| params_flow.rb:41:24:41:29 | ** ... | type tracker with call steps | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:41:19:41:20 | 17 | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:41:1:41:30 | synthetic hash-splat argument |
+| params_flow.rb:41:19:41:20 | 17 | type tracker without call steps with content splat position 0 | params_flow.rb:41:13:41:21 | synthetic splat argument |
+| params_flow.rb:41:24:41:29 | ** ... | type tracker with call steps | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:41:24:41:29 | ** ... | type tracker without call steps | params_flow.rb:41:24:41:29 | ** ... |
 | params_flow.rb:43:1:43:4 | args | type tracker without call steps | params_flow.rb:43:1:43:4 | args |
-| params_flow.rb:43:8:43:18 | * | type tracker without call steps | params_flow.rb:43:8:43:18 | * |
 | params_flow.rb:43:8:43:18 | Array | type tracker without call steps | params_flow.rb:43:8:43:18 | Array |
 | params_flow.rb:43:8:43:18 | call to [] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:43:8:43:18 | call to [] | type tracker with call steps | params_flow.rb:9:20:9:21 | p2 |
-| params_flow.rb:43:8:43:18 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:43:8:43:18 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:43:8:43:18 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:11:5:11:11 | * |
-| params_flow.rb:43:8:43:18 | call to [] | type tracker with call steps with content element 1 | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:43:8:43:18 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:43:8:43:18 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:43:8:43:18 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
+| params_flow.rb:43:8:43:18 | call to [] | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:9:1:12:3 | synthetic splat parameter |
 | params_flow.rb:43:8:43:18 | call to [] | type tracker without call steps | params_flow.rb:43:8:43:18 | call to [] |
 | params_flow.rb:43:8:43:18 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:44:23:44:27 | * ... |
-| params_flow.rb:43:8:43:18 | call to [] | type tracker without call steps with content element 1 | params_flow.rb:44:1:44:28 | * |
-| params_flow.rb:43:9:43:17 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:43:9:43:17 | * | type tracker without call steps | params_flow.rb:43:9:43:17 | * |
+| params_flow.rb:43:8:43:18 | call to [] | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:44:1:44:28 | synthetic splat argument |
+| params_flow.rb:43:8:43:18 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:43:8:43:18 | synthetic splat argument | type tracker with call steps | params_flow.rb:9:20:9:21 | p2 |
+| params_flow.rb:43:8:43:18 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:43:8:43:18 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:43:8:43:18 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
+| params_flow.rb:43:8:43:18 | synthetic splat argument | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:43:8:43:18 | synthetic splat argument | type tracker without call steps | params_flow.rb:43:8:43:18 | call to [] |
+| params_flow.rb:43:8:43:18 | synthetic splat argument | type tracker without call steps | params_flow.rb:43:8:43:18 | synthetic splat argument |
+| params_flow.rb:43:8:43:18 | synthetic splat argument | type tracker without call steps with content element 0 or unknown | params_flow.rb:44:23:44:27 | * ... |
+| params_flow.rb:43:8:43:18 | synthetic splat argument | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:44:1:44:28 | synthetic splat argument |
 | params_flow.rb:43:9:43:17 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:43:9:43:17 | call to taint | type tracker with call steps | params_flow.rb:9:20:9:21 | p2 |
-| params_flow.rb:43:9:43:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:43:9:43:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:43:9:43:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:11:5:11:11 | * |
-| params_flow.rb:43:9:43:17 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:43:9:43:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:43:9:43:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:43:9:43:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
+| params_flow.rb:43:9:43:17 | call to taint | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:9:1:12:3 | synthetic splat parameter |
 | params_flow.rb:43:9:43:17 | call to taint | type tracker without call steps | params_flow.rb:43:9:43:17 | call to taint |
-| params_flow.rb:43:9:43:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:43:8:43:18 | * |
-| params_flow.rb:43:9:43:17 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:43:8:43:18 | call to [] |
-| params_flow.rb:43:9:43:17 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:44:23:44:27 | * ... |
-| params_flow.rb:43:9:43:17 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:44:1:44:28 | * |
+| params_flow.rb:43:9:43:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:43:8:43:18 | call to [] |
+| params_flow.rb:43:9:43:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:43:8:43:18 | synthetic splat argument |
+| params_flow.rb:43:9:43:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:44:23:44:27 | * ... |
+| params_flow.rb:43:9:43:17 | call to taint | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:44:1:44:28 | synthetic splat argument |
+| params_flow.rb:43:9:43:17 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:43:9:43:17 | synthetic splat argument | type tracker without call steps | params_flow.rb:43:9:43:17 | synthetic splat argument |
 | params_flow.rb:43:15:43:16 | 17 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:43:15:43:16 | 17 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:43:15:43:16 | 17 | type tracker with call steps | params_flow.rb:9:20:9:21 | p2 |
-| params_flow.rb:43:15:43:16 | 17 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:43:15:43:16 | 17 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:43:15:43:16 | 17 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:43:15:43:16 | 17 | type tracker with call steps with content element 0 | params_flow.rb:11:5:11:11 | * |
-| params_flow.rb:43:15:43:16 | 17 | type tracker with call steps with content element 1 | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:43:15:43:16 | 17 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:43:15:43:16 | 17 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:43:15:43:16 | 17 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:43:15:43:16 | 17 | type tracker with call steps with content splat position 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
+| params_flow.rb:43:15:43:16 | 17 | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:9:1:12:3 | synthetic splat parameter |
 | params_flow.rb:43:15:43:16 | 17 | type tracker without call steps | params_flow.rb:43:9:43:17 | call to taint |
 | params_flow.rb:43:15:43:16 | 17 | type tracker without call steps | params_flow.rb:43:15:43:16 | 17 |
-| params_flow.rb:43:15:43:16 | 17 | type tracker without call steps with content element 0 | params_flow.rb:43:8:43:18 | * |
-| params_flow.rb:43:15:43:16 | 17 | type tracker without call steps with content element 0 | params_flow.rb:43:9:43:17 | * |
-| params_flow.rb:43:15:43:16 | 17 | type tracker without call steps with content element 0 or unknown | params_flow.rb:43:8:43:18 | call to [] |
-| params_flow.rb:43:15:43:16 | 17 | type tracker without call steps with content element 0 or unknown | params_flow.rb:44:23:44:27 | * ... |
-| params_flow.rb:43:15:43:16 | 17 | type tracker without call steps with content element 1 | params_flow.rb:44:1:44:28 | * |
-| params_flow.rb:44:1:44:28 | * | type tracker with call steps | params_flow.rb:9:1:12:3 | synthetic *args |
-| params_flow.rb:44:1:44:28 | * | type tracker without call steps | params_flow.rb:44:1:44:28 | * |
+| params_flow.rb:43:15:43:16 | 17 | type tracker without call steps with content element 0 | params_flow.rb:43:8:43:18 | call to [] |
+| params_flow.rb:43:15:43:16 | 17 | type tracker without call steps with content element 0 | params_flow.rb:43:8:43:18 | synthetic splat argument |
+| params_flow.rb:43:15:43:16 | 17 | type tracker without call steps with content element 0 | params_flow.rb:44:23:44:27 | * ... |
+| params_flow.rb:43:15:43:16 | 17 | type tracker without call steps with content splat position 0 | params_flow.rb:43:9:43:17 | synthetic splat argument |
+| params_flow.rb:43:15:43:16 | 17 | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:44:1:44:28 | synthetic splat argument |
 | params_flow.rb:44:1:44:28 | call to positional | type tracker without call steps | params_flow.rb:44:1:44:28 | call to positional |
-| params_flow.rb:44:12:44:20 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:44:12:44:20 | * | type tracker without call steps | params_flow.rb:44:12:44:20 | * |
+| params_flow.rb:44:1:44:28 | synthetic splat argument | type tracker with call steps | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:44:1:44:28 | synthetic splat argument | type tracker without call steps | params_flow.rb:44:1:44:28 | synthetic splat argument |
 | params_flow.rb:44:12:44:20 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:44:12:44:20 | call to taint | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
-| params_flow.rb:44:12:44:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:44:12:44:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:44:12:44:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:9:1:12:3 | synthetic *args |
-| params_flow.rb:44:12:44:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | * |
+| params_flow.rb:44:12:44:20 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:44:12:44:20 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:44:12:44:20 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:44:12:44:20 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
 | params_flow.rb:44:12:44:20 | call to taint | type tracker without call steps | params_flow.rb:44:12:44:20 | call to taint |
-| params_flow.rb:44:12:44:20 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:44:1:44:28 | * |
+| params_flow.rb:44:12:44:20 | call to taint | type tracker without call steps with content splat position 0 | params_flow.rb:44:1:44:28 | synthetic splat argument |
+| params_flow.rb:44:12:44:20 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:44:12:44:20 | synthetic splat argument | type tracker without call steps | params_flow.rb:44:12:44:20 | synthetic splat argument |
 | params_flow.rb:44:18:44:19 | 16 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:44:18:44:19 | 16 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:44:18:44:19 | 16 | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
-| params_flow.rb:44:18:44:19 | 16 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:44:18:44:19 | 16 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:44:18:44:19 | 16 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:44:18:44:19 | 16 | type tracker with call steps with content element 0 | params_flow.rb:9:1:12:3 | synthetic *args |
-| params_flow.rb:44:18:44:19 | 16 | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | * |
+| params_flow.rb:44:18:44:19 | 16 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:44:18:44:19 | 16 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:44:18:44:19 | 16 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:44:18:44:19 | 16 | type tracker with call steps with content splat position 0 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:44:18:44:19 | 16 | type tracker with call steps with content splat position 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
 | params_flow.rb:44:18:44:19 | 16 | type tracker without call steps | params_flow.rb:44:12:44:20 | call to taint |
 | params_flow.rb:44:18:44:19 | 16 | type tracker without call steps | params_flow.rb:44:18:44:19 | 16 |
-| params_flow.rb:44:18:44:19 | 16 | type tracker without call steps with content element 0 | params_flow.rb:44:1:44:28 | * |
-| params_flow.rb:44:18:44:19 | 16 | type tracker without call steps with content element 0 | params_flow.rb:44:12:44:20 | * |
+| params_flow.rb:44:18:44:19 | 16 | type tracker without call steps with content splat position 0 | params_flow.rb:44:1:44:28 | synthetic splat argument |
+| params_flow.rb:44:18:44:19 | 16 | type tracker without call steps with content splat position 0 | params_flow.rb:44:12:44:20 | synthetic splat argument |
 | params_flow.rb:44:23:44:27 | * ... | type tracker without call steps | params_flow.rb:44:23:44:27 | * ... |
 | params_flow.rb:46:1:46:4 | args | type tracker without call steps | params_flow.rb:46:1:46:4 | args |
-| params_flow.rb:46:8:46:29 | * | type tracker without call steps | params_flow.rb:46:8:46:29 | * |
 | params_flow.rb:46:8:46:29 | Array | type tracker without call steps | params_flow.rb:46:8:46:29 | Array |
 | params_flow.rb:46:8:46:29 | call to [] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:46:8:46:29 | call to [] | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
-| params_flow.rb:46:8:46:29 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:46:8:46:29 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:46:8:46:29 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | * |
-| params_flow.rb:46:8:46:29 | call to [] | type tracker with call steps with content element 0 or unknown | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:46:8:46:29 | call to [] | type tracker with call steps with content element 0 or unknown | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:46:8:46:29 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:46:8:46:29 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:46:8:46:29 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
 | params_flow.rb:46:8:46:29 | call to [] | type tracker without call steps | params_flow.rb:46:8:46:29 | call to [] |
 | params_flow.rb:46:8:46:29 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:47:12:47:16 | * ... |
-| params_flow.rb:46:9:46:17 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:46:9:46:17 | * | type tracker without call steps | params_flow.rb:46:9:46:17 | * |
+| params_flow.rb:46:8:46:29 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:46:8:46:29 | synthetic splat argument | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:46:8:46:29 | synthetic splat argument | type tracker with call steps with content element 0 or unknown | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:46:8:46:29 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:46:8:46:29 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:46:8:46:29 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
+| params_flow.rb:46:8:46:29 | synthetic splat argument | type tracker without call steps | params_flow.rb:46:8:46:29 | call to [] |
+| params_flow.rb:46:8:46:29 | synthetic splat argument | type tracker without call steps | params_flow.rb:46:8:46:29 | synthetic splat argument |
+| params_flow.rb:46:8:46:29 | synthetic splat argument | type tracker without call steps with content element 0 or unknown | params_flow.rb:47:12:47:16 | * ... |
 | params_flow.rb:46:9:46:17 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:46:9:46:17 | call to taint | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
-| params_flow.rb:46:9:46:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:46:9:46:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:46:9:46:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | * |
-| params_flow.rb:46:9:46:17 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:46:9:46:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:46:9:46:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:46:9:46:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:46:9:46:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
 | params_flow.rb:46:9:46:17 | call to taint | type tracker without call steps | params_flow.rb:46:9:46:17 | call to taint |
-| params_flow.rb:46:9:46:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:46:8:46:29 | * |
-| params_flow.rb:46:9:46:17 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:46:8:46:29 | call to [] |
-| params_flow.rb:46:9:46:17 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:47:12:47:16 | * ... |
+| params_flow.rb:46:9:46:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:46:8:46:29 | call to [] |
+| params_flow.rb:46:9:46:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:46:8:46:29 | synthetic splat argument |
+| params_flow.rb:46:9:46:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:47:12:47:16 | * ... |
+| params_flow.rb:46:9:46:17 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:46:9:46:17 | synthetic splat argument | type tracker without call steps | params_flow.rb:46:9:46:17 | synthetic splat argument |
 | params_flow.rb:46:15:46:16 | 18 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:46:15:46:16 | 18 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:46:15:46:16 | 18 | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
-| params_flow.rb:46:15:46:16 | 18 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:46:15:46:16 | 18 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:46:15:46:16 | 18 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:46:15:46:16 | 18 | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | * |
-| params_flow.rb:46:15:46:16 | 18 | type tracker with call steps with content element 0 or unknown | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:46:15:46:16 | 18 | type tracker with call steps with content element 0 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:46:15:46:16 | 18 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:46:15:46:16 | 18 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:46:15:46:16 | 18 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:46:15:46:16 | 18 | type tracker with call steps with content splat position 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
 | params_flow.rb:46:15:46:16 | 18 | type tracker without call steps | params_flow.rb:46:9:46:17 | call to taint |
 | params_flow.rb:46:15:46:16 | 18 | type tracker without call steps | params_flow.rb:46:15:46:16 | 18 |
-| params_flow.rb:46:15:46:16 | 18 | type tracker without call steps with content element 0 | params_flow.rb:46:8:46:29 | * |
-| params_flow.rb:46:15:46:16 | 18 | type tracker without call steps with content element 0 | params_flow.rb:46:9:46:17 | * |
-| params_flow.rb:46:15:46:16 | 18 | type tracker without call steps with content element 0 or unknown | params_flow.rb:46:8:46:29 | call to [] |
-| params_flow.rb:46:15:46:16 | 18 | type tracker without call steps with content element 0 or unknown | params_flow.rb:47:12:47:16 | * ... |
-| params_flow.rb:46:20:46:28 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:46:20:46:28 | * | type tracker without call steps | params_flow.rb:46:20:46:28 | * |
+| params_flow.rb:46:15:46:16 | 18 | type tracker without call steps with content element 0 | params_flow.rb:46:8:46:29 | call to [] |
+| params_flow.rb:46:15:46:16 | 18 | type tracker without call steps with content element 0 | params_flow.rb:46:8:46:29 | synthetic splat argument |
+| params_flow.rb:46:15:46:16 | 18 | type tracker without call steps with content element 0 | params_flow.rb:47:12:47:16 | * ... |
+| params_flow.rb:46:15:46:16 | 18 | type tracker without call steps with content splat position 0 | params_flow.rb:46:9:46:17 | synthetic splat argument |
 | params_flow.rb:46:20:46:28 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:46:20:46:28 | call to taint | type tracker with call steps | params_flow.rb:9:20:9:21 | p2 |
-| params_flow.rb:46:20:46:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:46:20:46:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:46:20:46:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:11:5:11:11 | * |
-| params_flow.rb:46:20:46:28 | call to taint | type tracker with call steps with content element 1 or unknown | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:46:20:46:28 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:46:20:46:28 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:46:20:46:28 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:46:20:46:28 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
 | params_flow.rb:46:20:46:28 | call to taint | type tracker without call steps | params_flow.rb:46:20:46:28 | call to taint |
-| params_flow.rb:46:20:46:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:46:8:46:29 | * |
-| params_flow.rb:46:20:46:28 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:46:8:46:29 | call to [] |
-| params_flow.rb:46:20:46:28 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:47:12:47:16 | * ... |
+| params_flow.rb:46:20:46:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:46:8:46:29 | call to [] |
+| params_flow.rb:46:20:46:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:46:8:46:29 | synthetic splat argument |
+| params_flow.rb:46:20:46:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:47:12:47:16 | * ... |
+| params_flow.rb:46:20:46:28 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:46:20:46:28 | synthetic splat argument | type tracker without call steps | params_flow.rb:46:20:46:28 | synthetic splat argument |
 | params_flow.rb:46:26:46:27 | 19 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:46:26:46:27 | 19 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:46:26:46:27 | 19 | type tracker with call steps | params_flow.rb:9:20:9:21 | p2 |
-| params_flow.rb:46:26:46:27 | 19 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:46:26:46:27 | 19 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:46:26:46:27 | 19 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:46:26:46:27 | 19 | type tracker with call steps with content element 0 | params_flow.rb:11:5:11:11 | * |
-| params_flow.rb:46:26:46:27 | 19 | type tracker with call steps with content element 1 or unknown | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:46:26:46:27 | 19 | type tracker with call steps with content element 1 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:46:26:46:27 | 19 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:46:26:46:27 | 19 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:46:26:46:27 | 19 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:46:26:46:27 | 19 | type tracker with call steps with content splat position 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
 | params_flow.rb:46:26:46:27 | 19 | type tracker without call steps | params_flow.rb:46:20:46:28 | call to taint |
 | params_flow.rb:46:26:46:27 | 19 | type tracker without call steps | params_flow.rb:46:26:46:27 | 19 |
-| params_flow.rb:46:26:46:27 | 19 | type tracker without call steps with content element 0 | params_flow.rb:46:20:46:28 | * |
-| params_flow.rb:46:26:46:27 | 19 | type tracker without call steps with content element 1 | params_flow.rb:46:8:46:29 | * |
-| params_flow.rb:46:26:46:27 | 19 | type tracker without call steps with content element 1 or unknown | params_flow.rb:46:8:46:29 | call to [] |
-| params_flow.rb:46:26:46:27 | 19 | type tracker without call steps with content element 1 or unknown | params_flow.rb:47:12:47:16 | * ... |
+| params_flow.rb:46:26:46:27 | 19 | type tracker without call steps with content element 1 | params_flow.rb:46:8:46:29 | call to [] |
+| params_flow.rb:46:26:46:27 | 19 | type tracker without call steps with content element 1 | params_flow.rb:46:8:46:29 | synthetic splat argument |
+| params_flow.rb:46:26:46:27 | 19 | type tracker without call steps with content element 1 | params_flow.rb:47:12:47:16 | * ... |
+| params_flow.rb:46:26:46:27 | 19 | type tracker without call steps with content splat position 0 | params_flow.rb:46:20:46:28 | synthetic splat argument |
 | params_flow.rb:47:1:47:17 | call to positional | type tracker without call steps | params_flow.rb:47:1:47:17 | call to positional |
-| params_flow.rb:47:12:47:16 | * ... | type tracker with call steps | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:47:12:47:16 | * ... | type tracker with call steps | params_flow.rb:9:1:12:3 | synthetic splat parameter |
 | params_flow.rb:47:12:47:16 | * ... | type tracker without call steps | params_flow.rb:47:12:47:16 | * ... |
 | params_flow.rb:49:1:53:3 | &block | type tracker without call steps | params_flow.rb:49:1:53:3 | &block |
 | params_flow.rb:49:1:53:3 | posargs | type tracker without call steps | params_flow.rb:49:1:53:3 | posargs |
 | params_flow.rb:49:1:53:3 | self in posargs | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
 | params_flow.rb:49:1:53:3 | self in posargs | type tracker without call steps | params_flow.rb:49:1:53:3 | self in posargs |
-| params_flow.rb:49:1:53:3 | synthetic *args | type tracker without call steps | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:49:1:53:3 | synthetic splat parameter | type tracker without call steps | params_flow.rb:49:1:53:3 | synthetic splat parameter |
 | params_flow.rb:49:13:49:14 | p1 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:49:13:49:14 | p1 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:49:13:49:14 | p1 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:49:13:49:14 | p1 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:49:13:49:14 | p1 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:49:13:49:14 | p1 | type tracker without call steps | params_flow.rb:49:13:49:14 | p1 |
 | params_flow.rb:49:13:49:14 | p1 | type tracker without call steps | params_flow.rb:49:13:49:14 | p1 |
-| params_flow.rb:49:13:49:14 | p1 | type tracker without call steps with content element 0 | params_flow.rb:50:5:50:11 | * |
+| params_flow.rb:49:13:49:14 | p1 | type tracker without call steps with content splat position 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
 | params_flow.rb:49:17:49:24 | *posargs | type tracker without call steps | params_flow.rb:49:17:49:24 | *posargs |
 | params_flow.rb:49:18:49:24 | posargs | type tracker without call steps | params_flow.rb:49:18:49:24 | posargs |
-| params_flow.rb:50:5:50:11 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:50:5:50:11 | * | type tracker without call steps | params_flow.rb:50:5:50:11 | * |
 | params_flow.rb:50:5:50:11 | call to sink | type tracker without call steps | params_flow.rb:50:5:50:11 | call to sink |
-| params_flow.rb:51:5:51:21 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:51:5:51:21 | * | type tracker without call steps | params_flow.rb:51:5:51:21 | * |
+| params_flow.rb:50:5:50:11 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:50:5:50:11 | synthetic splat argument | type tracker without call steps | params_flow.rb:50:5:50:11 | synthetic splat argument |
 | params_flow.rb:51:5:51:21 | call to sink | type tracker without call steps | params_flow.rb:51:5:51:21 | call to sink |
-| params_flow.rb:51:11:51:20 | * | type tracker without call steps | params_flow.rb:51:11:51:20 | * |
+| params_flow.rb:51:5:51:21 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:51:5:51:21 | synthetic splat argument | type tracker without call steps | params_flow.rb:51:5:51:21 | synthetic splat argument |
 | params_flow.rb:51:11:51:20 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:51:11:51:20 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:51:11:51:20 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:51:11:51:20 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:51:11:51:20 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:51:11:51:20 | ...[...] | type tracker without call steps | params_flow.rb:51:11:51:20 | ...[...] |
-| params_flow.rb:51:11:51:20 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:51:5:51:21 | * |
+| params_flow.rb:51:11:51:20 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
+| params_flow.rb:51:11:51:20 | synthetic splat argument | type tracker without call steps | params_flow.rb:51:11:51:20 | synthetic splat argument |
 | params_flow.rb:51:19:51:19 | 0 | type tracker without call steps | params_flow.rb:51:19:51:19 | 0 |
-| params_flow.rb:51:19:51:19 | 0 | type tracker without call steps with content element 0 | params_flow.rb:51:11:51:20 | * |
-| params_flow.rb:52:5:52:21 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:52:5:52:21 | * | type tracker without call steps | params_flow.rb:52:5:52:21 | * |
+| params_flow.rb:51:19:51:19 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:51:11:51:20 | synthetic splat argument |
 | params_flow.rb:52:5:52:21 | call to sink | type tracker without call steps | params_flow.rb:52:5:52:21 | call to sink |
 | params_flow.rb:52:5:52:21 | call to sink | type tracker without call steps | params_flow.rb:55:1:55:29 | call to posargs |
 | params_flow.rb:52:5:52:21 | call to sink | type tracker without call steps | params_flow.rb:58:1:58:25 | call to posargs |
 | params_flow.rb:52:5:52:21 | call to sink | type tracker without call steps | params_flow.rb:61:1:61:14 | call to posargs |
-| params_flow.rb:52:11:52:20 | * | type tracker without call steps | params_flow.rb:52:11:52:20 | * |
+| params_flow.rb:52:5:52:21 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:52:5:52:21 | synthetic splat argument | type tracker without call steps | params_flow.rb:52:5:52:21 | synthetic splat argument |
 | params_flow.rb:52:11:52:20 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:52:11:52:20 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:52:11:52:20 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:52:11:52:20 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:52:11:52:20 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:52:11:52:20 | ...[...] | type tracker without call steps | params_flow.rb:52:11:52:20 | ...[...] |
-| params_flow.rb:52:11:52:20 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:52:5:52:21 | * |
+| params_flow.rb:52:11:52:20 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:52:5:52:21 | synthetic splat argument |
+| params_flow.rb:52:11:52:20 | synthetic splat argument | type tracker without call steps | params_flow.rb:52:11:52:20 | synthetic splat argument |
 | params_flow.rb:52:19:52:19 | 1 | type tracker without call steps | params_flow.rb:52:19:52:19 | 1 |
-| params_flow.rb:52:19:52:19 | 1 | type tracker without call steps with content element 0 | params_flow.rb:52:11:52:20 | * |
-| params_flow.rb:55:1:55:29 | * | type tracker with call steps | params_flow.rb:49:1:53:3 | synthetic *args |
-| params_flow.rb:55:1:55:29 | * | type tracker without call steps | params_flow.rb:55:1:55:29 | * |
+| params_flow.rb:52:19:52:19 | 1 | type tracker without call steps with content splat position 0 | params_flow.rb:52:11:52:20 | synthetic splat argument |
 | params_flow.rb:55:1:55:29 | call to posargs | type tracker without call steps | params_flow.rb:55:1:55:29 | call to posargs |
-| params_flow.rb:55:9:55:17 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:55:9:55:17 | * | type tracker without call steps | params_flow.rb:55:9:55:17 | * |
+| params_flow.rb:55:1:55:29 | synthetic splat argument | type tracker with call steps | params_flow.rb:49:1:53:3 | synthetic splat parameter |
+| params_flow.rb:55:1:55:29 | synthetic splat argument | type tracker without call steps | params_flow.rb:55:1:55:29 | synthetic splat argument |
 | params_flow.rb:55:9:55:17 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:55:9:55:17 | call to taint | type tracker with call steps | params_flow.rb:49:13:49:14 | p1 |
-| params_flow.rb:55:9:55:17 | call to taint | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
-| params_flow.rb:55:9:55:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:55:9:55:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:55:9:55:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:49:1:53:3 | synthetic *args |
-| params_flow.rb:55:9:55:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:55:9:55:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:50:5:50:11 | * |
-| params_flow.rb:55:9:55:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:51:5:51:21 | * |
+| params_flow.rb:55:9:55:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:55:9:55:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:55:9:55:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
+| params_flow.rb:55:9:55:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
 | params_flow.rb:55:9:55:17 | call to taint | type tracker without call steps | params_flow.rb:55:9:55:17 | call to taint |
-| params_flow.rb:55:9:55:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:55:1:55:29 | * |
+| params_flow.rb:55:9:55:17 | call to taint | type tracker without call steps with content splat position 0 | params_flow.rb:55:1:55:29 | synthetic splat argument |
+| params_flow.rb:55:9:55:17 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:55:9:55:17 | synthetic splat argument | type tracker without call steps | params_flow.rb:55:9:55:17 | synthetic splat argument |
 | params_flow.rb:55:15:55:16 | 20 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:55:15:55:16 | 20 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:55:15:55:16 | 20 | type tracker with call steps | params_flow.rb:49:13:49:14 | p1 |
-| params_flow.rb:55:15:55:16 | 20 | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
-| params_flow.rb:55:15:55:16 | 20 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:55:15:55:16 | 20 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:55:15:55:16 | 20 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:55:15:55:16 | 20 | type tracker with call steps with content element 0 | params_flow.rb:49:1:53:3 | synthetic *args |
-| params_flow.rb:55:15:55:16 | 20 | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:55:15:55:16 | 20 | type tracker with call steps with content element 0 | params_flow.rb:50:5:50:11 | * |
-| params_flow.rb:55:15:55:16 | 20 | type tracker with call steps with content element 0 | params_flow.rb:51:5:51:21 | * |
+| params_flow.rb:55:15:55:16 | 20 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:55:15:55:16 | 20 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:55:15:55:16 | 20 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:55:15:55:16 | 20 | type tracker with call steps with content splat position 0 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
+| params_flow.rb:55:15:55:16 | 20 | type tracker with call steps with content splat position 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
 | params_flow.rb:55:15:55:16 | 20 | type tracker without call steps | params_flow.rb:55:9:55:17 | call to taint |
 | params_flow.rb:55:15:55:16 | 20 | type tracker without call steps | params_flow.rb:55:15:55:16 | 20 |
-| params_flow.rb:55:15:55:16 | 20 | type tracker without call steps with content element 0 | params_flow.rb:55:1:55:29 | * |
-| params_flow.rb:55:15:55:16 | 20 | type tracker without call steps with content element 0 | params_flow.rb:55:9:55:17 | * |
-| params_flow.rb:55:20:55:28 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:55:20:55:28 | * | type tracker without call steps | params_flow.rb:55:20:55:28 | * |
+| params_flow.rb:55:15:55:16 | 20 | type tracker without call steps with content splat position 0 | params_flow.rb:55:1:55:29 | synthetic splat argument |
+| params_flow.rb:55:15:55:16 | 20 | type tracker without call steps with content splat position 0 | params_flow.rb:55:9:55:17 | synthetic splat argument |
 | params_flow.rb:55:20:55:28 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:55:20:55:28 | call to taint | type tracker with call steps | params_flow.rb:52:11:52:20 | ...[...] |
-| params_flow.rb:55:20:55:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:55:20:55:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:55:20:55:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:52:5:52:21 | * |
-| params_flow.rb:55:20:55:28 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:49:1:53:3 | synthetic *args |
-| params_flow.rb:55:20:55:28 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:55:20:55:28 | call to taint | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
+| params_flow.rb:55:20:55:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:55:20:55:28 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:55:20:55:28 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:55:20:55:28 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
+| params_flow.rb:55:20:55:28 | call to taint | type tracker with call steps with content splat position 1 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
 | params_flow.rb:55:20:55:28 | call to taint | type tracker without call steps | params_flow.rb:55:20:55:28 | call to taint |
-| params_flow.rb:55:20:55:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:55:1:55:29 | * |
+| params_flow.rb:55:20:55:28 | call to taint | type tracker without call steps with content splat position 1 | params_flow.rb:55:1:55:29 | synthetic splat argument |
+| params_flow.rb:55:20:55:28 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:55:20:55:28 | synthetic splat argument | type tracker without call steps | params_flow.rb:55:20:55:28 | synthetic splat argument |
 | params_flow.rb:55:26:55:27 | 21 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:55:26:55:27 | 21 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:55:26:55:27 | 21 | type tracker with call steps | params_flow.rb:52:11:52:20 | ...[...] |
-| params_flow.rb:55:26:55:27 | 21 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:55:26:55:27 | 21 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:55:26:55:27 | 21 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:55:26:55:27 | 21 | type tracker with call steps with content element 0 | params_flow.rb:52:5:52:21 | * |
-| params_flow.rb:55:26:55:27 | 21 | type tracker with call steps with content element 1 | params_flow.rb:49:1:53:3 | synthetic *args |
-| params_flow.rb:55:26:55:27 | 21 | type tracker with call steps with content element 1 | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:55:26:55:27 | 21 | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
+| params_flow.rb:55:26:55:27 | 21 | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:55:26:55:27 | 21 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:55:26:55:27 | 21 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:55:26:55:27 | 21 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:55:26:55:27 | 21 | type tracker with call steps with content splat position 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
+| params_flow.rb:55:26:55:27 | 21 | type tracker with call steps with content splat position 1 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
 | params_flow.rb:55:26:55:27 | 21 | type tracker without call steps | params_flow.rb:55:20:55:28 | call to taint |
 | params_flow.rb:55:26:55:27 | 21 | type tracker without call steps | params_flow.rb:55:26:55:27 | 21 |
-| params_flow.rb:55:26:55:27 | 21 | type tracker without call steps with content element 0 | params_flow.rb:55:20:55:28 | * |
-| params_flow.rb:55:26:55:27 | 21 | type tracker without call steps with content element 1 | params_flow.rb:55:1:55:29 | * |
+| params_flow.rb:55:26:55:27 | 21 | type tracker without call steps with content splat position 0 | params_flow.rb:55:20:55:28 | synthetic splat argument |
+| params_flow.rb:55:26:55:27 | 21 | type tracker without call steps with content splat position 1 | params_flow.rb:55:1:55:29 | synthetic splat argument |
 | params_flow.rb:57:1:57:4 | args | type tracker without call steps | params_flow.rb:57:1:57:4 | args |
-| params_flow.rb:57:8:57:18 | * | type tracker without call steps | params_flow.rb:57:8:57:18 | * |
 | params_flow.rb:57:8:57:18 | Array | type tracker without call steps | params_flow.rb:57:8:57:18 | Array |
 | params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
-| params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps | params_flow.rb:52:11:52:20 | ...[...] |
-| params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:51:5:51:21 | * |
-| params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:52:5:52:21 | * |
+| params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
 | params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps with content element 0 or unknown | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps with content element 1 | params_flow.rb:49:1:53:3 | synthetic *args |
-| params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps with content element 1 | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
+| params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:49:1:53:3 | synthetic splat parameter |
 | params_flow.rb:57:8:57:18 | call to [] | type tracker without call steps | params_flow.rb:57:8:57:18 | call to [] |
 | params_flow.rb:57:8:57:18 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:58:20:58:24 | * ... |
-| params_flow.rb:57:8:57:18 | call to [] | type tracker without call steps with content element 1 | params_flow.rb:58:1:58:25 | * |
-| params_flow.rb:57:9:57:17 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:57:9:57:17 | * | type tracker without call steps | params_flow.rb:57:9:57:17 | * |
+| params_flow.rb:57:8:57:18 | call to [] | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:58:1:58:25 | synthetic splat argument |
+| params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
+| params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker with call steps with content element 0 or unknown | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
+| params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:49:1:53:3 | synthetic splat parameter |
+| params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker without call steps | params_flow.rb:57:8:57:18 | call to [] |
+| params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker without call steps | params_flow.rb:57:8:57:18 | synthetic splat argument |
+| params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker without call steps with content element 0 or unknown | params_flow.rb:58:20:58:24 | * ... |
+| params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:58:1:58:25 | synthetic splat argument |
 | params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
-| params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps | params_flow.rb:52:11:52:20 | ...[...] |
-| params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:51:5:51:21 | * |
-| params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:52:5:52:21 | * |
-| params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:49:1:53:3 | synthetic *args |
-| params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
+| params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:49:1:53:3 | synthetic splat parameter |
 | params_flow.rb:57:9:57:17 | call to taint | type tracker without call steps | params_flow.rb:57:9:57:17 | call to taint |
-| params_flow.rb:57:9:57:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:57:8:57:18 | * |
-| params_flow.rb:57:9:57:17 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:57:8:57:18 | call to [] |
-| params_flow.rb:57:9:57:17 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:58:20:58:24 | * ... |
-| params_flow.rb:57:9:57:17 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:58:1:58:25 | * |
+| params_flow.rb:57:9:57:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:57:8:57:18 | call to [] |
+| params_flow.rb:57:9:57:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:57:8:57:18 | synthetic splat argument |
+| params_flow.rb:57:9:57:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:58:20:58:24 | * ... |
+| params_flow.rb:57:9:57:17 | call to taint | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:58:1:58:25 | synthetic splat argument |
+| params_flow.rb:57:9:57:17 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:57:9:57:17 | synthetic splat argument | type tracker without call steps | params_flow.rb:57:9:57:17 | synthetic splat argument |
 | params_flow.rb:57:15:57:16 | 22 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:57:15:57:16 | 22 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:57:15:57:16 | 22 | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
-| params_flow.rb:57:15:57:16 | 22 | type tracker with call steps | params_flow.rb:52:11:52:20 | ...[...] |
-| params_flow.rb:57:15:57:16 | 22 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:57:15:57:16 | 22 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:57:15:57:16 | 22 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:57:15:57:16 | 22 | type tracker with call steps with content element 0 | params_flow.rb:51:5:51:21 | * |
-| params_flow.rb:57:15:57:16 | 22 | type tracker with call steps with content element 0 | params_flow.rb:52:5:52:21 | * |
-| params_flow.rb:57:15:57:16 | 22 | type tracker with call steps with content element 0 or unknown | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:57:15:57:16 | 22 | type tracker with call steps with content element 1 | params_flow.rb:49:1:53:3 | synthetic *args |
-| params_flow.rb:57:15:57:16 | 22 | type tracker with call steps with content element 1 | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:57:15:57:16 | 22 | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:57:15:57:16 | 22 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:57:15:57:16 | 22 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:57:15:57:16 | 22 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:57:15:57:16 | 22 | type tracker with call steps with content splat position 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
+| params_flow.rb:57:15:57:16 | 22 | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:49:1:53:3 | synthetic splat parameter |
 | params_flow.rb:57:15:57:16 | 22 | type tracker without call steps | params_flow.rb:57:9:57:17 | call to taint |
 | params_flow.rb:57:15:57:16 | 22 | type tracker without call steps | params_flow.rb:57:15:57:16 | 22 |
-| params_flow.rb:57:15:57:16 | 22 | type tracker without call steps with content element 0 | params_flow.rb:57:8:57:18 | * |
-| params_flow.rb:57:15:57:16 | 22 | type tracker without call steps with content element 0 | params_flow.rb:57:9:57:17 | * |
-| params_flow.rb:57:15:57:16 | 22 | type tracker without call steps with content element 0 or unknown | params_flow.rb:57:8:57:18 | call to [] |
-| params_flow.rb:57:15:57:16 | 22 | type tracker without call steps with content element 0 or unknown | params_flow.rb:58:20:58:24 | * ... |
-| params_flow.rb:57:15:57:16 | 22 | type tracker without call steps with content element 1 | params_flow.rb:58:1:58:25 | * |
-| params_flow.rb:58:1:58:25 | * | type tracker with call steps | params_flow.rb:49:1:53:3 | synthetic *args |
-| params_flow.rb:58:1:58:25 | * | type tracker without call steps | params_flow.rb:58:1:58:25 | * |
+| params_flow.rb:57:15:57:16 | 22 | type tracker without call steps with content element 0 | params_flow.rb:57:8:57:18 | call to [] |
+| params_flow.rb:57:15:57:16 | 22 | type tracker without call steps with content element 0 | params_flow.rb:57:8:57:18 | synthetic splat argument |
+| params_flow.rb:57:15:57:16 | 22 | type tracker without call steps with content element 0 | params_flow.rb:58:20:58:24 | * ... |
+| params_flow.rb:57:15:57:16 | 22 | type tracker without call steps with content splat position 0 | params_flow.rb:57:9:57:17 | synthetic splat argument |
+| params_flow.rb:57:15:57:16 | 22 | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:58:1:58:25 | synthetic splat argument |
 | params_flow.rb:58:1:58:25 | call to posargs | type tracker without call steps | params_flow.rb:58:1:58:25 | call to posargs |
-| params_flow.rb:58:9:58:17 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:58:9:58:17 | * | type tracker without call steps | params_flow.rb:58:9:58:17 | * |
+| params_flow.rb:58:1:58:25 | synthetic splat argument | type tracker with call steps | params_flow.rb:49:1:53:3 | synthetic splat parameter |
+| params_flow.rb:58:1:58:25 | synthetic splat argument | type tracker without call steps | params_flow.rb:58:1:58:25 | synthetic splat argument |
 | params_flow.rb:58:9:58:17 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:58:9:58:17 | call to taint | type tracker with call steps | params_flow.rb:49:13:49:14 | p1 |
-| params_flow.rb:58:9:58:17 | call to taint | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
-| params_flow.rb:58:9:58:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:58:9:58:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:58:9:58:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:49:1:53:3 | synthetic *args |
-| params_flow.rb:58:9:58:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:58:9:58:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:50:5:50:11 | * |
-| params_flow.rb:58:9:58:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:51:5:51:21 | * |
+| params_flow.rb:58:9:58:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:58:9:58:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:58:9:58:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
+| params_flow.rb:58:9:58:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
 | params_flow.rb:58:9:58:17 | call to taint | type tracker without call steps | params_flow.rb:58:9:58:17 | call to taint |
-| params_flow.rb:58:9:58:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:58:1:58:25 | * |
+| params_flow.rb:58:9:58:17 | call to taint | type tracker without call steps with content splat position 0 | params_flow.rb:58:1:58:25 | synthetic splat argument |
+| params_flow.rb:58:9:58:17 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:58:9:58:17 | synthetic splat argument | type tracker without call steps | params_flow.rb:58:9:58:17 | synthetic splat argument |
 | params_flow.rb:58:15:58:16 | 23 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:58:15:58:16 | 23 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:58:15:58:16 | 23 | type tracker with call steps | params_flow.rb:49:13:49:14 | p1 |
-| params_flow.rb:58:15:58:16 | 23 | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
-| params_flow.rb:58:15:58:16 | 23 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:58:15:58:16 | 23 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:58:15:58:16 | 23 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:58:15:58:16 | 23 | type tracker with call steps with content element 0 | params_flow.rb:49:1:53:3 | synthetic *args |
-| params_flow.rb:58:15:58:16 | 23 | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:58:15:58:16 | 23 | type tracker with call steps with content element 0 | params_flow.rb:50:5:50:11 | * |
-| params_flow.rb:58:15:58:16 | 23 | type tracker with call steps with content element 0 | params_flow.rb:51:5:51:21 | * |
+| params_flow.rb:58:15:58:16 | 23 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:58:15:58:16 | 23 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:58:15:58:16 | 23 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:58:15:58:16 | 23 | type tracker with call steps with content splat position 0 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
+| params_flow.rb:58:15:58:16 | 23 | type tracker with call steps with content splat position 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
 | params_flow.rb:58:15:58:16 | 23 | type tracker without call steps | params_flow.rb:58:9:58:17 | call to taint |
 | params_flow.rb:58:15:58:16 | 23 | type tracker without call steps | params_flow.rb:58:15:58:16 | 23 |
-| params_flow.rb:58:15:58:16 | 23 | type tracker without call steps with content element 0 | params_flow.rb:58:1:58:25 | * |
-| params_flow.rb:58:15:58:16 | 23 | type tracker without call steps with content element 0 | params_flow.rb:58:9:58:17 | * |
+| params_flow.rb:58:15:58:16 | 23 | type tracker without call steps with content splat position 0 | params_flow.rb:58:1:58:25 | synthetic splat argument |
+| params_flow.rb:58:15:58:16 | 23 | type tracker without call steps with content splat position 0 | params_flow.rb:58:9:58:17 | synthetic splat argument |
 | params_flow.rb:58:20:58:24 | * ... | type tracker with call steps | params_flow.rb:49:17:49:24 | *posargs |
 | params_flow.rb:58:20:58:24 | * ... | type tracker without call steps | params_flow.rb:58:20:58:24 | * ... |
 | params_flow.rb:60:1:60:4 | args | type tracker without call steps | params_flow.rb:60:1:60:4 | args |
-| params_flow.rb:60:8:60:29 | * | type tracker without call steps | params_flow.rb:60:8:60:29 | * |
 | params_flow.rb:60:8:60:29 | Array | type tracker without call steps | params_flow.rb:60:8:60:29 | Array |
 | params_flow.rb:60:8:60:29 | call to [] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:60:8:60:29 | call to [] | type tracker with call steps | params_flow.rb:49:13:49:14 | p1 |
-| params_flow.rb:60:8:60:29 | call to [] | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
-| params_flow.rb:60:8:60:29 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:60:8:60:29 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:60:8:60:29 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:60:8:60:29 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:50:5:50:11 | * |
-| params_flow.rb:60:8:60:29 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:51:5:51:21 | * |
-| params_flow.rb:60:8:60:29 | call to [] | type tracker with call steps with content element 0 or unknown | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:60:8:60:29 | call to [] | type tracker with call steps with content element 0 or unknown | params_flow.rb:49:1:53:3 | synthetic splat parameter |
+| params_flow.rb:60:8:60:29 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:60:8:60:29 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:60:8:60:29 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
 | params_flow.rb:60:8:60:29 | call to [] | type tracker without call steps | params_flow.rb:60:8:60:29 | call to [] |
 | params_flow.rb:60:8:60:29 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:61:9:61:13 | * ... |
-| params_flow.rb:60:9:60:17 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:60:9:60:17 | * | type tracker without call steps | params_flow.rb:60:9:60:17 | * |
+| params_flow.rb:60:8:60:29 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:60:8:60:29 | synthetic splat argument | type tracker with call steps | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:60:8:60:29 | synthetic splat argument | type tracker with call steps with content element 0 or unknown | params_flow.rb:49:1:53:3 | synthetic splat parameter |
+| params_flow.rb:60:8:60:29 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:60:8:60:29 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:60:8:60:29 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
+| params_flow.rb:60:8:60:29 | synthetic splat argument | type tracker without call steps | params_flow.rb:60:8:60:29 | call to [] |
+| params_flow.rb:60:8:60:29 | synthetic splat argument | type tracker without call steps | params_flow.rb:60:8:60:29 | synthetic splat argument |
+| params_flow.rb:60:8:60:29 | synthetic splat argument | type tracker without call steps with content element 0 or unknown | params_flow.rb:61:9:61:13 | * ... |
 | params_flow.rb:60:9:60:17 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:60:9:60:17 | call to taint | type tracker with call steps | params_flow.rb:49:13:49:14 | p1 |
-| params_flow.rb:60:9:60:17 | call to taint | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
-| params_flow.rb:60:9:60:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:60:9:60:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:60:9:60:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:60:9:60:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:50:5:50:11 | * |
-| params_flow.rb:60:9:60:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:51:5:51:21 | * |
-| params_flow.rb:60:9:60:17 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:60:9:60:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
+| params_flow.rb:60:9:60:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:60:9:60:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:60:9:60:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
 | params_flow.rb:60:9:60:17 | call to taint | type tracker without call steps | params_flow.rb:60:9:60:17 | call to taint |
-| params_flow.rb:60:9:60:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:60:8:60:29 | * |
-| params_flow.rb:60:9:60:17 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:60:8:60:29 | call to [] |
-| params_flow.rb:60:9:60:17 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:61:9:61:13 | * ... |
+| params_flow.rb:60:9:60:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:60:8:60:29 | call to [] |
+| params_flow.rb:60:9:60:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:60:8:60:29 | synthetic splat argument |
+| params_flow.rb:60:9:60:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:61:9:61:13 | * ... |
+| params_flow.rb:60:9:60:17 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:60:9:60:17 | synthetic splat argument | type tracker without call steps | params_flow.rb:60:9:60:17 | synthetic splat argument |
 | params_flow.rb:60:15:60:16 | 24 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:60:15:60:16 | 24 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:60:15:60:16 | 24 | type tracker with call steps | params_flow.rb:49:13:49:14 | p1 |
-| params_flow.rb:60:15:60:16 | 24 | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
-| params_flow.rb:60:15:60:16 | 24 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:60:15:60:16 | 24 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:60:15:60:16 | 24 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:60:15:60:16 | 24 | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:60:15:60:16 | 24 | type tracker with call steps with content element 0 | params_flow.rb:50:5:50:11 | * |
-| params_flow.rb:60:15:60:16 | 24 | type tracker with call steps with content element 0 | params_flow.rb:51:5:51:21 | * |
-| params_flow.rb:60:15:60:16 | 24 | type tracker with call steps with content element 0 or unknown | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:60:15:60:16 | 24 | type tracker with call steps with content element 0 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
+| params_flow.rb:60:15:60:16 | 24 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:60:15:60:16 | 24 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:60:15:60:16 | 24 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:60:15:60:16 | 24 | type tracker with call steps with content splat position 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
 | params_flow.rb:60:15:60:16 | 24 | type tracker without call steps | params_flow.rb:60:9:60:17 | call to taint |
 | params_flow.rb:60:15:60:16 | 24 | type tracker without call steps | params_flow.rb:60:15:60:16 | 24 |
-| params_flow.rb:60:15:60:16 | 24 | type tracker without call steps with content element 0 | params_flow.rb:60:8:60:29 | * |
-| params_flow.rb:60:15:60:16 | 24 | type tracker without call steps with content element 0 | params_flow.rb:60:9:60:17 | * |
-| params_flow.rb:60:15:60:16 | 24 | type tracker without call steps with content element 0 or unknown | params_flow.rb:60:8:60:29 | call to [] |
-| params_flow.rb:60:15:60:16 | 24 | type tracker without call steps with content element 0 or unknown | params_flow.rb:61:9:61:13 | * ... |
-| params_flow.rb:60:20:60:28 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:60:20:60:28 | * | type tracker without call steps | params_flow.rb:60:20:60:28 | * |
+| params_flow.rb:60:15:60:16 | 24 | type tracker without call steps with content element 0 | params_flow.rb:60:8:60:29 | call to [] |
+| params_flow.rb:60:15:60:16 | 24 | type tracker without call steps with content element 0 | params_flow.rb:60:8:60:29 | synthetic splat argument |
+| params_flow.rb:60:15:60:16 | 24 | type tracker without call steps with content element 0 | params_flow.rb:61:9:61:13 | * ... |
+| params_flow.rb:60:15:60:16 | 24 | type tracker without call steps with content splat position 0 | params_flow.rb:60:9:60:17 | synthetic splat argument |
 | params_flow.rb:60:20:60:28 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:60:20:60:28 | call to taint | type tracker with call steps | params_flow.rb:52:11:52:20 | ...[...] |
-| params_flow.rb:60:20:60:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:60:20:60:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:60:20:60:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:52:5:52:21 | * |
-| params_flow.rb:60:20:60:28 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:60:20:60:28 | call to taint | type tracker with call steps with content element 1 or unknown | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:60:20:60:28 | call to taint | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
+| params_flow.rb:60:20:60:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:60:20:60:28 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
+| params_flow.rb:60:20:60:28 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:60:20:60:28 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:60:20:60:28 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
 | params_flow.rb:60:20:60:28 | call to taint | type tracker without call steps | params_flow.rb:60:20:60:28 | call to taint |
-| params_flow.rb:60:20:60:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:60:8:60:29 | * |
-| params_flow.rb:60:20:60:28 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:60:8:60:29 | call to [] |
-| params_flow.rb:60:20:60:28 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:61:9:61:13 | * ... |
+| params_flow.rb:60:20:60:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:60:8:60:29 | call to [] |
+| params_flow.rb:60:20:60:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:60:8:60:29 | synthetic splat argument |
+| params_flow.rb:60:20:60:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:61:9:61:13 | * ... |
+| params_flow.rb:60:20:60:28 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:60:20:60:28 | synthetic splat argument | type tracker without call steps | params_flow.rb:60:20:60:28 | synthetic splat argument |
 | params_flow.rb:60:26:60:27 | 25 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:60:26:60:27 | 25 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:60:26:60:27 | 25 | type tracker with call steps | params_flow.rb:52:11:52:20 | ...[...] |
-| params_flow.rb:60:26:60:27 | 25 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:60:26:60:27 | 25 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:60:26:60:27 | 25 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:60:26:60:27 | 25 | type tracker with call steps with content element 0 | params_flow.rb:52:5:52:21 | * |
-| params_flow.rb:60:26:60:27 | 25 | type tracker with call steps with content element 1 | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:60:26:60:27 | 25 | type tracker with call steps with content element 1 or unknown | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:60:26:60:27 | 25 | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
+| params_flow.rb:60:26:60:27 | 25 | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:60:26:60:27 | 25 | type tracker with call steps with content element 1 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
+| params_flow.rb:60:26:60:27 | 25 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:60:26:60:27 | 25 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:60:26:60:27 | 25 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:60:26:60:27 | 25 | type tracker with call steps with content splat position 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
 | params_flow.rb:60:26:60:27 | 25 | type tracker without call steps | params_flow.rb:60:20:60:28 | call to taint |
 | params_flow.rb:60:26:60:27 | 25 | type tracker without call steps | params_flow.rb:60:26:60:27 | 25 |
-| params_flow.rb:60:26:60:27 | 25 | type tracker without call steps with content element 0 | params_flow.rb:60:20:60:28 | * |
-| params_flow.rb:60:26:60:27 | 25 | type tracker without call steps with content element 1 | params_flow.rb:60:8:60:29 | * |
-| params_flow.rb:60:26:60:27 | 25 | type tracker without call steps with content element 1 or unknown | params_flow.rb:60:8:60:29 | call to [] |
-| params_flow.rb:60:26:60:27 | 25 | type tracker without call steps with content element 1 or unknown | params_flow.rb:61:9:61:13 | * ... |
+| params_flow.rb:60:26:60:27 | 25 | type tracker without call steps with content element 1 | params_flow.rb:60:8:60:29 | call to [] |
+| params_flow.rb:60:26:60:27 | 25 | type tracker without call steps with content element 1 | params_flow.rb:60:8:60:29 | synthetic splat argument |
+| params_flow.rb:60:26:60:27 | 25 | type tracker without call steps with content element 1 | params_flow.rb:61:9:61:13 | * ... |
+| params_flow.rb:60:26:60:27 | 25 | type tracker without call steps with content splat position 0 | params_flow.rb:60:20:60:28 | synthetic splat argument |
 | params_flow.rb:61:1:61:14 | call to posargs | type tracker without call steps | params_flow.rb:61:1:61:14 | call to posargs |
-| params_flow.rb:61:9:61:13 | * ... | type tracker with call steps | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:61:9:61:13 | * ... | type tracker with call steps | params_flow.rb:49:1:53:3 | synthetic splat parameter |
 | params_flow.rb:61:9:61:13 | * ... | type tracker without call steps | params_flow.rb:61:9:61:13 | * ... |
 | params_flow.rb:63:1:63:4 | args | type tracker without call steps | params_flow.rb:63:1:63:4 | args |
-| params_flow.rb:63:8:63:16 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:63:8:63:16 | * | type tracker without call steps | params_flow.rb:63:8:63:16 | * |
 | params_flow.rb:63:8:63:16 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:63:8:63:16 | call to taint | type tracker with call steps | params_flow.rb:65:10:65:13 | ...[...] |
-| params_flow.rb:63:8:63:16 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:63:8:63:16 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:63:8:63:16 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:65:5:65:13 | * |
 | params_flow.rb:63:8:63:16 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:64:16:64:17 | *x |
+| params_flow.rb:63:8:63:16 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:63:8:63:16 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:63:8:63:16 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:65:5:65:13 | synthetic splat argument |
 | params_flow.rb:63:8:63:16 | call to taint | type tracker without call steps | params_flow.rb:63:8:63:16 | call to taint |
 | params_flow.rb:63:8:63:16 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:67:12:67:16 | * ... |
+| params_flow.rb:63:8:63:16 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:63:8:63:16 | synthetic splat argument | type tracker without call steps | params_flow.rb:63:8:63:16 | synthetic splat argument |
 | params_flow.rb:63:14:63:15 | 26 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:63:14:63:15 | 26 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:63:14:63:15 | 26 | type tracker with call steps | params_flow.rb:65:10:65:13 | ...[...] |
-| params_flow.rb:63:14:63:15 | 26 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:63:14:63:15 | 26 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:63:14:63:15 | 26 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:63:14:63:15 | 26 | type tracker with call steps with content element 0 | params_flow.rb:65:5:65:13 | * |
 | params_flow.rb:63:14:63:15 | 26 | type tracker with call steps with content element 0 or unknown | params_flow.rb:64:16:64:17 | *x |
+| params_flow.rb:63:14:63:15 | 26 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:63:14:63:15 | 26 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:63:14:63:15 | 26 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:63:14:63:15 | 26 | type tracker with call steps with content splat position 0 | params_flow.rb:65:5:65:13 | synthetic splat argument |
 | params_flow.rb:63:14:63:15 | 26 | type tracker without call steps | params_flow.rb:63:8:63:16 | call to taint |
 | params_flow.rb:63:14:63:15 | 26 | type tracker without call steps | params_flow.rb:63:14:63:15 | 26 |
-| params_flow.rb:63:14:63:15 | 26 | type tracker without call steps with content element 0 | params_flow.rb:63:8:63:16 | * |
 | params_flow.rb:63:14:63:15 | 26 | type tracker without call steps with content element 0 or unknown | params_flow.rb:67:12:67:16 | * ... |
+| params_flow.rb:63:14:63:15 | 26 | type tracker without call steps with content splat position 0 | params_flow.rb:63:8:63:16 | synthetic splat argument |
 | params_flow.rb:64:1:66:3 | &block | type tracker without call steps | params_flow.rb:64:1:66:3 | &block |
 | params_flow.rb:64:1:66:3 | self in splatstuff | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
 | params_flow.rb:64:1:66:3 | self in splatstuff | type tracker without call steps | params_flow.rb:64:1:66:3 | self in splatstuff |
 | params_flow.rb:64:1:66:3 | splatstuff | type tracker without call steps | params_flow.rb:64:1:66:3 | splatstuff |
 | params_flow.rb:64:16:64:17 | *x | type tracker without call steps | params_flow.rb:64:16:64:17 | *x |
 | params_flow.rb:64:17:64:17 | x | type tracker without call steps | params_flow.rb:64:17:64:17 | x |
-| params_flow.rb:65:5:65:13 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:65:5:65:13 | * | type tracker without call steps | params_flow.rb:65:5:65:13 | * |
 | params_flow.rb:65:5:65:13 | call to sink | type tracker without call steps | params_flow.rb:65:5:65:13 | call to sink |
 | params_flow.rb:65:5:65:13 | call to sink | type tracker without call steps | params_flow.rb:67:1:67:17 | call to splatstuff |
-| params_flow.rb:65:10:65:13 | * | type tracker without call steps | params_flow.rb:65:10:65:13 | * |
+| params_flow.rb:65:5:65:13 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:65:5:65:13 | synthetic splat argument | type tracker without call steps | params_flow.rb:65:5:65:13 | synthetic splat argument |
 | params_flow.rb:65:10:65:13 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:65:10:65:13 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:65:10:65:13 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:65:10:65:13 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:65:10:65:13 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:65:10:65:13 | ...[...] | type tracker without call steps | params_flow.rb:65:10:65:13 | ...[...] |
-| params_flow.rb:65:10:65:13 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:65:5:65:13 | * |
+| params_flow.rb:65:10:65:13 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:65:5:65:13 | synthetic splat argument |
+| params_flow.rb:65:10:65:13 | synthetic splat argument | type tracker without call steps | params_flow.rb:65:10:65:13 | synthetic splat argument |
 | params_flow.rb:65:12:65:12 | 0 | type tracker without call steps | params_flow.rb:65:12:65:12 | 0 |
-| params_flow.rb:65:12:65:12 | 0 | type tracker without call steps with content element 0 | params_flow.rb:65:10:65:13 | * |
+| params_flow.rb:65:12:65:12 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:65:10:65:13 | synthetic splat argument |
 | params_flow.rb:67:1:67:17 | call to splatstuff | type tracker without call steps | params_flow.rb:67:1:67:17 | call to splatstuff |
 | params_flow.rb:67:12:67:16 | * ... | type tracker with call steps | params_flow.rb:64:16:64:17 | *x |
 | params_flow.rb:67:12:67:16 | * ... | type tracker without call steps | params_flow.rb:67:12:67:16 | * ... |
@@ -1485,1113 +1504,1077 @@ track
 | params_flow.rb:69:1:76:3 | self in splatmid | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
 | params_flow.rb:69:1:76:3 | self in splatmid | type tracker without call steps | params_flow.rb:69:1:76:3 | self in splatmid |
 | params_flow.rb:69:1:76:3 | splatmid | type tracker without call steps | params_flow.rb:69:1:76:3 | splatmid |
-| params_flow.rb:69:1:76:3 | synthetic *args | type tracker without call steps | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:69:1:76:3 | synthetic splat parameter | type tracker without call steps | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:69:14:69:14 | x | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:69:14:69:14 | x | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:69:14:69:14 | x | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:69:14:69:14 | x | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:69:14:69:14 | x | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:69:14:69:14 | x | type tracker without call steps | params_flow.rb:69:14:69:14 | x |
 | params_flow.rb:69:14:69:14 | x | type tracker without call steps | params_flow.rb:69:14:69:14 | x |
-| params_flow.rb:69:14:69:14 | x | type tracker without call steps with content element 0 | params_flow.rb:70:5:70:10 | * |
+| params_flow.rb:69:14:69:14 | x | type tracker without call steps with content splat position 0 | params_flow.rb:70:5:70:10 | synthetic splat argument |
 | params_flow.rb:69:17:69:17 | y | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:69:17:69:17 | y | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:69:17:69:17 | y | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:69:17:69:17 | y | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:69:17:69:17 | y | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:69:17:69:17 | y | type tracker without call steps | params_flow.rb:69:17:69:17 | y |
 | params_flow.rb:69:17:69:17 | y | type tracker without call steps | params_flow.rb:69:17:69:17 | y |
-| params_flow.rb:69:17:69:17 | y | type tracker without call steps with content element 0 | params_flow.rb:71:5:71:10 | * |
+| params_flow.rb:69:17:69:17 | y | type tracker without call steps with content splat position 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
 | params_flow.rb:69:20:69:21 | *z | type tracker without call steps | params_flow.rb:69:20:69:21 | *z |
 | params_flow.rb:69:21:69:21 | z | type tracker without call steps | params_flow.rb:69:21:69:21 | z |
 | params_flow.rb:69:24:69:24 | w | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:69:24:69:24 | w | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:69:24:69:24 | w | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:69:24:69:24 | w | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:69:24:69:24 | w | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:69:24:69:24 | w | type tracker without call steps | params_flow.rb:69:24:69:24 | w |
 | params_flow.rb:69:24:69:24 | w | type tracker without call steps | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:69:24:69:24 | w | type tracker without call steps with content element 0 | params_flow.rb:74:5:74:10 | * |
+| params_flow.rb:69:24:69:24 | w | type tracker without call steps with content splat position 0 | params_flow.rb:74:5:74:10 | synthetic splat argument |
 | params_flow.rb:69:27:69:27 | r | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:69:27:69:27 | r | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:69:27:69:27 | r | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:69:27:69:27 | r | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:69:27:69:27 | r | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:69:27:69:27 | r | type tracker without call steps | params_flow.rb:69:27:69:27 | r |
 | params_flow.rb:69:27:69:27 | r | type tracker without call steps | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:69:27:69:27 | r | type tracker without call steps with content element 0 | params_flow.rb:75:5:75:10 | * |
-| params_flow.rb:70:5:70:10 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:70:5:70:10 | * | type tracker without call steps | params_flow.rb:70:5:70:10 | * |
+| params_flow.rb:69:27:69:27 | r | type tracker without call steps with content splat position 0 | params_flow.rb:75:5:75:10 | synthetic splat argument |
 | params_flow.rb:70:5:70:10 | call to sink | type tracker without call steps | params_flow.rb:70:5:70:10 | call to sink |
-| params_flow.rb:71:5:71:10 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:71:5:71:10 | * | type tracker without call steps | params_flow.rb:71:5:71:10 | * |
+| params_flow.rb:70:5:70:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:70:5:70:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:70:5:70:10 | synthetic splat argument |
 | params_flow.rb:71:5:71:10 | call to sink | type tracker without call steps | params_flow.rb:71:5:71:10 | call to sink |
-| params_flow.rb:72:5:72:13 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:72:5:72:13 | * | type tracker without call steps | params_flow.rb:72:5:72:13 | * |
+| params_flow.rb:71:5:71:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:71:5:71:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:71:5:71:10 | synthetic splat argument |
 | params_flow.rb:72:5:72:13 | call to sink | type tracker without call steps | params_flow.rb:72:5:72:13 | call to sink |
-| params_flow.rb:72:10:72:13 | * | type tracker without call steps | params_flow.rb:72:10:72:13 | * |
+| params_flow.rb:72:5:72:13 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:72:5:72:13 | synthetic splat argument | type tracker without call steps | params_flow.rb:72:5:72:13 | synthetic splat argument |
 | params_flow.rb:72:10:72:13 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:72:10:72:13 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:72:10:72:13 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:72:10:72:13 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:72:10:72:13 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:72:10:72:13 | ...[...] | type tracker without call steps | params_flow.rb:72:10:72:13 | ...[...] |
-| params_flow.rb:72:10:72:13 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:72:5:72:13 | * |
+| params_flow.rb:72:10:72:13 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:72:5:72:13 | synthetic splat argument |
+| params_flow.rb:72:10:72:13 | synthetic splat argument | type tracker without call steps | params_flow.rb:72:10:72:13 | synthetic splat argument |
 | params_flow.rb:72:12:72:12 | 0 | type tracker without call steps | params_flow.rb:72:12:72:12 | 0 |
-| params_flow.rb:72:12:72:12 | 0 | type tracker without call steps with content element 0 | params_flow.rb:72:10:72:13 | * |
-| params_flow.rb:73:5:73:13 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:73:5:73:13 | * | type tracker without call steps | params_flow.rb:73:5:73:13 | * |
+| params_flow.rb:72:12:72:12 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:72:10:72:13 | synthetic splat argument |
 | params_flow.rb:73:5:73:13 | call to sink | type tracker without call steps | params_flow.rb:73:5:73:13 | call to sink |
-| params_flow.rb:73:10:73:13 | * | type tracker without call steps | params_flow.rb:73:10:73:13 | * |
+| params_flow.rb:73:5:73:13 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:73:5:73:13 | synthetic splat argument | type tracker without call steps | params_flow.rb:73:5:73:13 | synthetic splat argument |
 | params_flow.rb:73:10:73:13 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:73:10:73:13 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:73:10:73:13 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:73:10:73:13 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:73:10:73:13 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:73:10:73:13 | ...[...] | type tracker without call steps | params_flow.rb:73:10:73:13 | ...[...] |
-| params_flow.rb:73:10:73:13 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:73:5:73:13 | * |
+| params_flow.rb:73:10:73:13 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:73:5:73:13 | synthetic splat argument |
+| params_flow.rb:73:10:73:13 | synthetic splat argument | type tracker without call steps | params_flow.rb:73:10:73:13 | synthetic splat argument |
 | params_flow.rb:73:12:73:12 | 1 | type tracker without call steps | params_flow.rb:73:12:73:12 | 1 |
-| params_flow.rb:73:12:73:12 | 1 | type tracker without call steps with content element 0 | params_flow.rb:73:10:73:13 | * |
-| params_flow.rb:74:5:74:10 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:74:5:74:10 | * | type tracker without call steps | params_flow.rb:74:5:74:10 | * |
+| params_flow.rb:73:12:73:12 | 1 | type tracker without call steps with content splat position 0 | params_flow.rb:73:10:73:13 | synthetic splat argument |
 | params_flow.rb:74:5:74:10 | call to sink | type tracker without call steps | params_flow.rb:74:5:74:10 | call to sink |
-| params_flow.rb:75:5:75:10 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:75:5:75:10 | * | type tracker without call steps | params_flow.rb:75:5:75:10 | * |
+| params_flow.rb:74:5:74:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:74:5:74:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:74:5:74:10 | synthetic splat argument |
 | params_flow.rb:75:5:75:10 | call to sink | type tracker without call steps | params_flow.rb:75:5:75:10 | call to sink |
 | params_flow.rb:75:5:75:10 | call to sink | type tracker without call steps | params_flow.rb:78:1:78:63 | call to splatmid |
 | params_flow.rb:75:5:75:10 | call to sink | type tracker without call steps | params_flow.rb:81:1:81:37 | call to splatmid |
 | params_flow.rb:75:5:75:10 | call to sink | type tracker without call steps | params_flow.rb:96:1:96:88 | call to splatmid |
-| params_flow.rb:78:1:78:63 | * | type tracker with call steps | params_flow.rb:69:1:76:3 | synthetic *args |
-| params_flow.rb:78:1:78:63 | * | type tracker without call steps | params_flow.rb:78:1:78:63 | * |
+| params_flow.rb:75:5:75:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:75:5:75:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:75:5:75:10 | synthetic splat argument |
 | params_flow.rb:78:1:78:63 | call to splatmid | type tracker without call steps | params_flow.rb:78:1:78:63 | call to splatmid |
-| params_flow.rb:78:10:78:18 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:78:10:78:18 | * | type tracker without call steps | params_flow.rb:78:10:78:18 | * |
+| params_flow.rb:78:1:78:63 | synthetic splat argument | type tracker with call steps | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:78:1:78:63 | synthetic splat argument | type tracker without call steps | params_flow.rb:78:1:78:63 | synthetic splat argument |
 | params_flow.rb:78:10:78:18 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:78:10:78:18 | call to taint | type tracker with call steps | params_flow.rb:69:14:69:14 | x |
-| params_flow.rb:78:10:78:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:78:10:78:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:78:10:78:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:69:1:76:3 | synthetic *args |
-| params_flow.rb:78:10:78:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:70:5:70:10 | * |
+| params_flow.rb:78:10:78:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:78:10:78:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:78:10:78:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:78:10:78:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:70:5:70:10 | synthetic splat argument |
 | params_flow.rb:78:10:78:18 | call to taint | type tracker without call steps | params_flow.rb:78:10:78:18 | call to taint |
-| params_flow.rb:78:10:78:18 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:78:1:78:63 | * |
+| params_flow.rb:78:10:78:18 | call to taint | type tracker without call steps with content splat position 0 | params_flow.rb:78:1:78:63 | synthetic splat argument |
+| params_flow.rb:78:10:78:18 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:78:10:78:18 | synthetic splat argument | type tracker without call steps | params_flow.rb:78:10:78:18 | synthetic splat argument |
 | params_flow.rb:78:16:78:17 | 27 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:78:16:78:17 | 27 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:78:16:78:17 | 27 | type tracker with call steps | params_flow.rb:69:14:69:14 | x |
-| params_flow.rb:78:16:78:17 | 27 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:78:16:78:17 | 27 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:78:16:78:17 | 27 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:78:16:78:17 | 27 | type tracker with call steps with content element 0 | params_flow.rb:69:1:76:3 | synthetic *args |
-| params_flow.rb:78:16:78:17 | 27 | type tracker with call steps with content element 0 | params_flow.rb:70:5:70:10 | * |
+| params_flow.rb:78:16:78:17 | 27 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:78:16:78:17 | 27 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:78:16:78:17 | 27 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:78:16:78:17 | 27 | type tracker with call steps with content splat position 0 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:78:16:78:17 | 27 | type tracker with call steps with content splat position 0 | params_flow.rb:70:5:70:10 | synthetic splat argument |
 | params_flow.rb:78:16:78:17 | 27 | type tracker without call steps | params_flow.rb:78:10:78:18 | call to taint |
 | params_flow.rb:78:16:78:17 | 27 | type tracker without call steps | params_flow.rb:78:16:78:17 | 27 |
-| params_flow.rb:78:16:78:17 | 27 | type tracker without call steps with content element 0 | params_flow.rb:78:1:78:63 | * |
-| params_flow.rb:78:16:78:17 | 27 | type tracker without call steps with content element 0 | params_flow.rb:78:10:78:18 | * |
-| params_flow.rb:78:21:78:29 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:78:21:78:29 | * | type tracker without call steps | params_flow.rb:78:21:78:29 | * |
+| params_flow.rb:78:16:78:17 | 27 | type tracker without call steps with content splat position 0 | params_flow.rb:78:1:78:63 | synthetic splat argument |
+| params_flow.rb:78:16:78:17 | 27 | type tracker without call steps with content splat position 0 | params_flow.rb:78:10:78:18 | synthetic splat argument |
 | params_flow.rb:78:21:78:29 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:78:21:78:29 | call to taint | type tracker with call steps | params_flow.rb:69:17:69:17 | y |
-| params_flow.rb:78:21:78:29 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:78:21:78:29 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:78:21:78:29 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:71:5:71:10 | * |
-| params_flow.rb:78:21:78:29 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:78:21:78:29 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:78:21:78:29 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:78:21:78:29 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
+| params_flow.rb:78:21:78:29 | call to taint | type tracker with call steps with content splat position 1 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:78:21:78:29 | call to taint | type tracker without call steps | params_flow.rb:78:21:78:29 | call to taint |
-| params_flow.rb:78:21:78:29 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:78:1:78:63 | * |
+| params_flow.rb:78:21:78:29 | call to taint | type tracker without call steps with content splat position 1 | params_flow.rb:78:1:78:63 | synthetic splat argument |
+| params_flow.rb:78:21:78:29 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:78:21:78:29 | synthetic splat argument | type tracker without call steps | params_flow.rb:78:21:78:29 | synthetic splat argument |
 | params_flow.rb:78:27:78:28 | 28 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:78:27:78:28 | 28 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:78:27:78:28 | 28 | type tracker with call steps | params_flow.rb:69:17:69:17 | y |
-| params_flow.rb:78:27:78:28 | 28 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:78:27:78:28 | 28 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:78:27:78:28 | 28 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:78:27:78:28 | 28 | type tracker with call steps with content element 0 | params_flow.rb:71:5:71:10 | * |
-| params_flow.rb:78:27:78:28 | 28 | type tracker with call steps with content element 1 | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:78:27:78:28 | 28 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:78:27:78:28 | 28 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:78:27:78:28 | 28 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:78:27:78:28 | 28 | type tracker with call steps with content splat position 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
+| params_flow.rb:78:27:78:28 | 28 | type tracker with call steps with content splat position 1 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:78:27:78:28 | 28 | type tracker without call steps | params_flow.rb:78:21:78:29 | call to taint |
 | params_flow.rb:78:27:78:28 | 28 | type tracker without call steps | params_flow.rb:78:27:78:28 | 28 |
-| params_flow.rb:78:27:78:28 | 28 | type tracker without call steps with content element 0 | params_flow.rb:78:21:78:29 | * |
-| params_flow.rb:78:27:78:28 | 28 | type tracker without call steps with content element 1 | params_flow.rb:78:1:78:63 | * |
-| params_flow.rb:78:32:78:40 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:78:32:78:40 | * | type tracker without call steps | params_flow.rb:78:32:78:40 | * |
-| params_flow.rb:78:32:78:40 | call to taint | type tracker with call steps with content element 2 | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:78:27:78:28 | 28 | type tracker without call steps with content splat position 0 | params_flow.rb:78:21:78:29 | synthetic splat argument |
+| params_flow.rb:78:27:78:28 | 28 | type tracker without call steps with content splat position 1 | params_flow.rb:78:1:78:63 | synthetic splat argument |
+| params_flow.rb:78:32:78:40 | call to taint | type tracker with call steps with content splat position 2 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:78:32:78:40 | call to taint | type tracker without call steps | params_flow.rb:78:32:78:40 | call to taint |
-| params_flow.rb:78:32:78:40 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:78:1:78:63 | * |
+| params_flow.rb:78:32:78:40 | call to taint | type tracker without call steps with content splat position 2 | params_flow.rb:78:1:78:63 | synthetic splat argument |
+| params_flow.rb:78:32:78:40 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:78:32:78:40 | synthetic splat argument | type tracker without call steps | params_flow.rb:78:32:78:40 | synthetic splat argument |
 | params_flow.rb:78:38:78:39 | 29 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:78:38:78:39 | 29 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:78:38:78:39 | 29 | type tracker with call steps with content element 2 | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:78:38:78:39 | 29 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:78:38:78:39 | 29 | type tracker with call steps with content splat position 2 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:78:38:78:39 | 29 | type tracker without call steps | params_flow.rb:78:32:78:40 | call to taint |
 | params_flow.rb:78:38:78:39 | 29 | type tracker without call steps | params_flow.rb:78:38:78:39 | 29 |
-| params_flow.rb:78:38:78:39 | 29 | type tracker without call steps with content element 0 | params_flow.rb:78:32:78:40 | * |
-| params_flow.rb:78:38:78:39 | 29 | type tracker without call steps with content element 2 | params_flow.rb:78:1:78:63 | * |
-| params_flow.rb:78:43:78:51 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:78:43:78:51 | * | type tracker without call steps | params_flow.rb:78:43:78:51 | * |
+| params_flow.rb:78:38:78:39 | 29 | type tracker without call steps with content splat position 0 | params_flow.rb:78:32:78:40 | synthetic splat argument |
+| params_flow.rb:78:38:78:39 | 29 | type tracker without call steps with content splat position 2 | params_flow.rb:78:1:78:63 | synthetic splat argument |
 | params_flow.rb:78:43:78:51 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:78:43:78:51 | call to taint | type tracker with call steps | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:78:43:78:51 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:78:43:78:51 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:78:43:78:51 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:74:5:74:10 | * |
-| params_flow.rb:78:43:78:51 | call to taint | type tracker with call steps with content element 3 | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:78:43:78:51 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:78:43:78:51 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:78:43:78:51 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:74:5:74:10 | synthetic splat argument |
+| params_flow.rb:78:43:78:51 | call to taint | type tracker with call steps with content splat position 3 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:78:43:78:51 | call to taint | type tracker without call steps | params_flow.rb:78:43:78:51 | call to taint |
-| params_flow.rb:78:43:78:51 | call to taint | type tracker without call steps with content element 3 | params_flow.rb:78:1:78:63 | * |
+| params_flow.rb:78:43:78:51 | call to taint | type tracker without call steps with content splat position 3 | params_flow.rb:78:1:78:63 | synthetic splat argument |
+| params_flow.rb:78:43:78:51 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:78:43:78:51 | synthetic splat argument | type tracker without call steps | params_flow.rb:78:43:78:51 | synthetic splat argument |
 | params_flow.rb:78:49:78:50 | 30 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:78:49:78:50 | 30 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:78:49:78:50 | 30 | type tracker with call steps | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:78:49:78:50 | 30 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:78:49:78:50 | 30 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:78:49:78:50 | 30 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:78:49:78:50 | 30 | type tracker with call steps with content element 0 | params_flow.rb:74:5:74:10 | * |
-| params_flow.rb:78:49:78:50 | 30 | type tracker with call steps with content element 3 | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:78:49:78:50 | 30 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:78:49:78:50 | 30 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:78:49:78:50 | 30 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:78:49:78:50 | 30 | type tracker with call steps with content splat position 0 | params_flow.rb:74:5:74:10 | synthetic splat argument |
+| params_flow.rb:78:49:78:50 | 30 | type tracker with call steps with content splat position 3 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:78:49:78:50 | 30 | type tracker without call steps | params_flow.rb:78:43:78:51 | call to taint |
 | params_flow.rb:78:49:78:50 | 30 | type tracker without call steps | params_flow.rb:78:49:78:50 | 30 |
-| params_flow.rb:78:49:78:50 | 30 | type tracker without call steps with content element 0 | params_flow.rb:78:43:78:51 | * |
-| params_flow.rb:78:49:78:50 | 30 | type tracker without call steps with content element 3 | params_flow.rb:78:1:78:63 | * |
-| params_flow.rb:78:54:78:62 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:78:54:78:62 | * | type tracker without call steps | params_flow.rb:78:54:78:62 | * |
+| params_flow.rb:78:49:78:50 | 30 | type tracker without call steps with content splat position 0 | params_flow.rb:78:43:78:51 | synthetic splat argument |
+| params_flow.rb:78:49:78:50 | 30 | type tracker without call steps with content splat position 3 | params_flow.rb:78:1:78:63 | synthetic splat argument |
 | params_flow.rb:78:54:78:62 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:78:54:78:62 | call to taint | type tracker with call steps | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:78:54:78:62 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:78:54:78:62 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:78:54:78:62 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:75:5:75:10 | * |
-| params_flow.rb:78:54:78:62 | call to taint | type tracker with call steps with content element 4 | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:78:54:78:62 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:78:54:78:62 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:78:54:78:62 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:75:5:75:10 | synthetic splat argument |
+| params_flow.rb:78:54:78:62 | call to taint | type tracker with call steps with content splat position 4 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:78:54:78:62 | call to taint | type tracker without call steps | params_flow.rb:78:54:78:62 | call to taint |
-| params_flow.rb:78:54:78:62 | call to taint | type tracker without call steps with content element 4 | params_flow.rb:78:1:78:63 | * |
+| params_flow.rb:78:54:78:62 | call to taint | type tracker without call steps with content splat position 4 | params_flow.rb:78:1:78:63 | synthetic splat argument |
+| params_flow.rb:78:54:78:62 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:78:54:78:62 | synthetic splat argument | type tracker without call steps | params_flow.rb:78:54:78:62 | synthetic splat argument |
 | params_flow.rb:78:60:78:61 | 31 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:78:60:78:61 | 31 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:78:60:78:61 | 31 | type tracker with call steps | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:78:60:78:61 | 31 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:78:60:78:61 | 31 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:78:60:78:61 | 31 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:78:60:78:61 | 31 | type tracker with call steps with content element 0 | params_flow.rb:75:5:75:10 | * |
-| params_flow.rb:78:60:78:61 | 31 | type tracker with call steps with content element 4 | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:78:60:78:61 | 31 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:78:60:78:61 | 31 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:78:60:78:61 | 31 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:78:60:78:61 | 31 | type tracker with call steps with content splat position 0 | params_flow.rb:75:5:75:10 | synthetic splat argument |
+| params_flow.rb:78:60:78:61 | 31 | type tracker with call steps with content splat position 4 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:78:60:78:61 | 31 | type tracker without call steps | params_flow.rb:78:54:78:62 | call to taint |
 | params_flow.rb:78:60:78:61 | 31 | type tracker without call steps | params_flow.rb:78:60:78:61 | 31 |
-| params_flow.rb:78:60:78:61 | 31 | type tracker without call steps with content element 0 | params_flow.rb:78:54:78:62 | * |
-| params_flow.rb:78:60:78:61 | 31 | type tracker without call steps with content element 4 | params_flow.rb:78:1:78:63 | * |
+| params_flow.rb:78:60:78:61 | 31 | type tracker without call steps with content splat position 0 | params_flow.rb:78:54:78:62 | synthetic splat argument |
+| params_flow.rb:78:60:78:61 | 31 | type tracker without call steps with content splat position 4 | params_flow.rb:78:1:78:63 | synthetic splat argument |
 | params_flow.rb:80:1:80:4 | args | type tracker without call steps | params_flow.rb:80:1:80:4 | args |
-| params_flow.rb:80:8:80:51 | * | type tracker without call steps | params_flow.rb:80:8:80:51 | * |
 | params_flow.rb:80:8:80:51 | Array | type tracker without call steps | params_flow.rb:80:8:80:51 | Array |
 | params_flow.rb:80:8:80:51 | call to [] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:80:8:80:51 | call to [] | type tracker with call steps | params_flow.rb:69:17:69:17 | y |
-| params_flow.rb:80:8:80:51 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:80:8:80:51 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:80:8:80:51 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:71:5:71:10 | * |
-| params_flow.rb:80:8:80:51 | call to [] | type tracker with call steps with content element 1 | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:80:8:80:51 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:80:8:80:51 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:80:8:80:51 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
+| params_flow.rb:80:8:80:51 | call to [] | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:80:8:80:51 | call to [] | type tracker without call steps | params_flow.rb:80:8:80:51 | call to [] |
 | params_flow.rb:80:8:80:51 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:81:21:81:25 | * ... |
-| params_flow.rb:80:8:80:51 | call to [] | type tracker without call steps with content element 1 | params_flow.rb:81:1:81:37 | * |
-| params_flow.rb:80:9:80:17 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:80:9:80:17 | * | type tracker without call steps | params_flow.rb:80:9:80:17 | * |
+| params_flow.rb:80:8:80:51 | call to [] | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:81:1:81:37 | synthetic splat argument |
+| params_flow.rb:80:8:80:51 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:80:8:80:51 | synthetic splat argument | type tracker with call steps | params_flow.rb:69:17:69:17 | y |
+| params_flow.rb:80:8:80:51 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:80:8:80:51 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:80:8:80:51 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
+| params_flow.rb:80:8:80:51 | synthetic splat argument | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:80:8:80:51 | synthetic splat argument | type tracker without call steps | params_flow.rb:80:8:80:51 | call to [] |
+| params_flow.rb:80:8:80:51 | synthetic splat argument | type tracker without call steps | params_flow.rb:80:8:80:51 | synthetic splat argument |
+| params_flow.rb:80:8:80:51 | synthetic splat argument | type tracker without call steps with content element 0 or unknown | params_flow.rb:81:21:81:25 | * ... |
+| params_flow.rb:80:8:80:51 | synthetic splat argument | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:81:1:81:37 | synthetic splat argument |
 | params_flow.rb:80:9:80:17 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:80:9:80:17 | call to taint | type tracker with call steps | params_flow.rb:69:17:69:17 | y |
-| params_flow.rb:80:9:80:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:80:9:80:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:80:9:80:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:71:5:71:10 | * |
-| params_flow.rb:80:9:80:17 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:80:9:80:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:80:9:80:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:80:9:80:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
+| params_flow.rb:80:9:80:17 | call to taint | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:80:9:80:17 | call to taint | type tracker without call steps | params_flow.rb:80:9:80:17 | call to taint |
-| params_flow.rb:80:9:80:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:80:8:80:51 | * |
-| params_flow.rb:80:9:80:17 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:80:8:80:51 | call to [] |
-| params_flow.rb:80:9:80:17 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:81:21:81:25 | * ... |
-| params_flow.rb:80:9:80:17 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:81:1:81:37 | * |
+| params_flow.rb:80:9:80:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:80:8:80:51 | call to [] |
+| params_flow.rb:80:9:80:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:80:8:80:51 | synthetic splat argument |
+| params_flow.rb:80:9:80:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:81:21:81:25 | * ... |
+| params_flow.rb:80:9:80:17 | call to taint | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:81:1:81:37 | synthetic splat argument |
+| params_flow.rb:80:9:80:17 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:80:9:80:17 | synthetic splat argument | type tracker without call steps | params_flow.rb:80:9:80:17 | synthetic splat argument |
 | params_flow.rb:80:15:80:16 | 33 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:80:15:80:16 | 33 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:80:15:80:16 | 33 | type tracker with call steps | params_flow.rb:69:17:69:17 | y |
-| params_flow.rb:80:15:80:16 | 33 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:80:15:80:16 | 33 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:80:15:80:16 | 33 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:80:15:80:16 | 33 | type tracker with call steps with content element 0 | params_flow.rb:71:5:71:10 | * |
-| params_flow.rb:80:15:80:16 | 33 | type tracker with call steps with content element 1 | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:80:15:80:16 | 33 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:80:15:80:16 | 33 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:80:15:80:16 | 33 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:80:15:80:16 | 33 | type tracker with call steps with content splat position 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
+| params_flow.rb:80:15:80:16 | 33 | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:80:15:80:16 | 33 | type tracker without call steps | params_flow.rb:80:9:80:17 | call to taint |
 | params_flow.rb:80:15:80:16 | 33 | type tracker without call steps | params_flow.rb:80:15:80:16 | 33 |
-| params_flow.rb:80:15:80:16 | 33 | type tracker without call steps with content element 0 | params_flow.rb:80:8:80:51 | * |
-| params_flow.rb:80:15:80:16 | 33 | type tracker without call steps with content element 0 | params_flow.rb:80:9:80:17 | * |
-| params_flow.rb:80:15:80:16 | 33 | type tracker without call steps with content element 0 or unknown | params_flow.rb:80:8:80:51 | call to [] |
-| params_flow.rb:80:15:80:16 | 33 | type tracker without call steps with content element 0 or unknown | params_flow.rb:81:21:81:25 | * ... |
-| params_flow.rb:80:15:80:16 | 33 | type tracker without call steps with content element 1 | params_flow.rb:81:1:81:37 | * |
-| params_flow.rb:80:20:80:28 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:80:20:80:28 | * | type tracker without call steps | params_flow.rb:80:20:80:28 | * |
-| params_flow.rb:80:20:80:28 | call to taint | type tracker with call steps with content element 2 | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:80:15:80:16 | 33 | type tracker without call steps with content element 0 | params_flow.rb:80:8:80:51 | call to [] |
+| params_flow.rb:80:15:80:16 | 33 | type tracker without call steps with content element 0 | params_flow.rb:80:8:80:51 | synthetic splat argument |
+| params_flow.rb:80:15:80:16 | 33 | type tracker without call steps with content element 0 | params_flow.rb:81:21:81:25 | * ... |
+| params_flow.rb:80:15:80:16 | 33 | type tracker without call steps with content splat position 0 | params_flow.rb:80:9:80:17 | synthetic splat argument |
+| params_flow.rb:80:15:80:16 | 33 | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:81:1:81:37 | synthetic splat argument |
+| params_flow.rb:80:20:80:28 | call to taint | type tracker with call steps with content splat position 2 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:80:20:80:28 | call to taint | type tracker without call steps | params_flow.rb:80:20:80:28 | call to taint |
-| params_flow.rb:80:20:80:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:80:8:80:51 | * |
-| params_flow.rb:80:20:80:28 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:80:8:80:51 | call to [] |
-| params_flow.rb:80:20:80:28 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:81:21:81:25 | * ... |
-| params_flow.rb:80:20:80:28 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:81:1:81:37 | * |
+| params_flow.rb:80:20:80:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:80:8:80:51 | call to [] |
+| params_flow.rb:80:20:80:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:80:8:80:51 | synthetic splat argument |
+| params_flow.rb:80:20:80:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:81:21:81:25 | * ... |
+| params_flow.rb:80:20:80:28 | call to taint | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:81:1:81:37 | synthetic splat argument |
+| params_flow.rb:80:20:80:28 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:80:20:80:28 | synthetic splat argument | type tracker without call steps | params_flow.rb:80:20:80:28 | synthetic splat argument |
 | params_flow.rb:80:26:80:27 | 34 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:80:26:80:27 | 34 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:80:26:80:27 | 34 | type tracker with call steps with content element 2 | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:80:26:80:27 | 34 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:80:26:80:27 | 34 | type tracker with call steps with content splat position 2 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:80:26:80:27 | 34 | type tracker without call steps | params_flow.rb:80:20:80:28 | call to taint |
 | params_flow.rb:80:26:80:27 | 34 | type tracker without call steps | params_flow.rb:80:26:80:27 | 34 |
-| params_flow.rb:80:26:80:27 | 34 | type tracker without call steps with content element 0 | params_flow.rb:80:20:80:28 | * |
-| params_flow.rb:80:26:80:27 | 34 | type tracker without call steps with content element 1 | params_flow.rb:80:8:80:51 | * |
-| params_flow.rb:80:26:80:27 | 34 | type tracker without call steps with content element 1 or unknown | params_flow.rb:80:8:80:51 | call to [] |
-| params_flow.rb:80:26:80:27 | 34 | type tracker without call steps with content element 1 or unknown | params_flow.rb:81:21:81:25 | * ... |
-| params_flow.rb:80:26:80:27 | 34 | type tracker without call steps with content element 2 | params_flow.rb:81:1:81:37 | * |
-| params_flow.rb:80:31:80:39 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:80:31:80:39 | * | type tracker without call steps | params_flow.rb:80:31:80:39 | * |
-| params_flow.rb:80:31:80:39 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:80:31:80:39 | call to taint | type tracker with call steps | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:80:31:80:39 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:80:31:80:39 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:80:31:80:39 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:74:5:74:10 | * |
-| params_flow.rb:80:31:80:39 | call to taint | type tracker with call steps with content element 3 | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:80:26:80:27 | 34 | type tracker without call steps with content element 1 | params_flow.rb:80:8:80:51 | call to [] |
+| params_flow.rb:80:26:80:27 | 34 | type tracker without call steps with content element 1 | params_flow.rb:80:8:80:51 | synthetic splat argument |
+| params_flow.rb:80:26:80:27 | 34 | type tracker without call steps with content element 1 | params_flow.rb:81:21:81:25 | * ... |
+| params_flow.rb:80:26:80:27 | 34 | type tracker without call steps with content splat position 0 | params_flow.rb:80:20:80:28 | synthetic splat argument |
+| params_flow.rb:80:26:80:27 | 34 | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:81:1:81:37 | synthetic splat argument |
+| params_flow.rb:80:31:80:39 | call to taint | type tracker with call steps with content splat position 3 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:80:31:80:39 | call to taint | type tracker without call steps | params_flow.rb:80:31:80:39 | call to taint |
-| params_flow.rb:80:31:80:39 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:80:8:80:51 | * |
-| params_flow.rb:80:31:80:39 | call to taint | type tracker without call steps with content element 2 or unknown | params_flow.rb:80:8:80:51 | call to [] |
-| params_flow.rb:80:31:80:39 | call to taint | type tracker without call steps with content element 2 or unknown | params_flow.rb:81:21:81:25 | * ... |
-| params_flow.rb:80:31:80:39 | call to taint | type tracker without call steps with content element 3 | params_flow.rb:81:1:81:37 | * |
+| params_flow.rb:80:31:80:39 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:80:8:80:51 | call to [] |
+| params_flow.rb:80:31:80:39 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:80:8:80:51 | synthetic splat argument |
+| params_flow.rb:80:31:80:39 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:81:21:81:25 | * ... |
+| params_flow.rb:80:31:80:39 | call to taint | type tracker without call steps with content splat position 3 (shifted) | params_flow.rb:81:1:81:37 | synthetic splat argument |
+| params_flow.rb:80:31:80:39 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:80:31:80:39 | synthetic splat argument | type tracker without call steps | params_flow.rb:80:31:80:39 | synthetic splat argument |
 | params_flow.rb:80:37:80:38 | 35 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:80:37:80:38 | 35 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:80:37:80:38 | 35 | type tracker with call steps | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:80:37:80:38 | 35 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:80:37:80:38 | 35 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:80:37:80:38 | 35 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:80:37:80:38 | 35 | type tracker with call steps with content element 0 | params_flow.rb:74:5:74:10 | * |
-| params_flow.rb:80:37:80:38 | 35 | type tracker with call steps with content element 3 | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:80:37:80:38 | 35 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:80:37:80:38 | 35 | type tracker with call steps with content splat position 3 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:80:37:80:38 | 35 | type tracker without call steps | params_flow.rb:80:31:80:39 | call to taint |
 | params_flow.rb:80:37:80:38 | 35 | type tracker without call steps | params_flow.rb:80:37:80:38 | 35 |
-| params_flow.rb:80:37:80:38 | 35 | type tracker without call steps with content element 0 | params_flow.rb:80:31:80:39 | * |
-| params_flow.rb:80:37:80:38 | 35 | type tracker without call steps with content element 2 | params_flow.rb:80:8:80:51 | * |
-| params_flow.rb:80:37:80:38 | 35 | type tracker without call steps with content element 2 or unknown | params_flow.rb:80:8:80:51 | call to [] |
-| params_flow.rb:80:37:80:38 | 35 | type tracker without call steps with content element 2 or unknown | params_flow.rb:81:21:81:25 | * ... |
-| params_flow.rb:80:37:80:38 | 35 | type tracker without call steps with content element 3 | params_flow.rb:81:1:81:37 | * |
-| params_flow.rb:80:42:80:50 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:80:42:80:50 | * | type tracker without call steps | params_flow.rb:80:42:80:50 | * |
-| params_flow.rb:80:42:80:50 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:80:42:80:50 | call to taint | type tracker with call steps | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:80:42:80:50 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:80:42:80:50 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:80:42:80:50 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:75:5:75:10 | * |
-| params_flow.rb:80:42:80:50 | call to taint | type tracker with call steps with content element 4 | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:80:37:80:38 | 35 | type tracker without call steps with content element 2 | params_flow.rb:80:8:80:51 | call to [] |
+| params_flow.rb:80:37:80:38 | 35 | type tracker without call steps with content element 2 | params_flow.rb:80:8:80:51 | synthetic splat argument |
+| params_flow.rb:80:37:80:38 | 35 | type tracker without call steps with content element 2 | params_flow.rb:81:21:81:25 | * ... |
+| params_flow.rb:80:37:80:38 | 35 | type tracker without call steps with content splat position 0 | params_flow.rb:80:31:80:39 | synthetic splat argument |
+| params_flow.rb:80:37:80:38 | 35 | type tracker without call steps with content splat position 3 (shifted) | params_flow.rb:81:1:81:37 | synthetic splat argument |
+| params_flow.rb:80:42:80:50 | call to taint | type tracker with call steps with content splat position 4 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:80:42:80:50 | call to taint | type tracker without call steps | params_flow.rb:80:42:80:50 | call to taint |
-| params_flow.rb:80:42:80:50 | call to taint | type tracker without call steps with content element 3 | params_flow.rb:80:8:80:51 | * |
-| params_flow.rb:80:42:80:50 | call to taint | type tracker without call steps with content element 3 or unknown | params_flow.rb:80:8:80:51 | call to [] |
-| params_flow.rb:80:42:80:50 | call to taint | type tracker without call steps with content element 3 or unknown | params_flow.rb:81:21:81:25 | * ... |
-| params_flow.rb:80:42:80:50 | call to taint | type tracker without call steps with content element 4 | params_flow.rb:81:1:81:37 | * |
+| params_flow.rb:80:42:80:50 | call to taint | type tracker without call steps with content element 3 | params_flow.rb:80:8:80:51 | call to [] |
+| params_flow.rb:80:42:80:50 | call to taint | type tracker without call steps with content element 3 | params_flow.rb:80:8:80:51 | synthetic splat argument |
+| params_flow.rb:80:42:80:50 | call to taint | type tracker without call steps with content element 3 | params_flow.rb:81:21:81:25 | * ... |
+| params_flow.rb:80:42:80:50 | call to taint | type tracker without call steps with content splat position 4 (shifted) | params_flow.rb:81:1:81:37 | synthetic splat argument |
+| params_flow.rb:80:42:80:50 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:80:42:80:50 | synthetic splat argument | type tracker without call steps | params_flow.rb:80:42:80:50 | synthetic splat argument |
 | params_flow.rb:80:48:80:49 | 36 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:80:48:80:49 | 36 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:80:48:80:49 | 36 | type tracker with call steps | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:80:48:80:49 | 36 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:80:48:80:49 | 36 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:80:48:80:49 | 36 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:80:48:80:49 | 36 | type tracker with call steps with content element 0 | params_flow.rb:75:5:75:10 | * |
-| params_flow.rb:80:48:80:49 | 36 | type tracker with call steps with content element 4 | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:80:48:80:49 | 36 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:80:48:80:49 | 36 | type tracker with call steps with content splat position 4 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:80:48:80:49 | 36 | type tracker without call steps | params_flow.rb:80:42:80:50 | call to taint |
 | params_flow.rb:80:48:80:49 | 36 | type tracker without call steps | params_flow.rb:80:48:80:49 | 36 |
-| params_flow.rb:80:48:80:49 | 36 | type tracker without call steps with content element 0 | params_flow.rb:80:42:80:50 | * |
-| params_flow.rb:80:48:80:49 | 36 | type tracker without call steps with content element 3 | params_flow.rb:80:8:80:51 | * |
-| params_flow.rb:80:48:80:49 | 36 | type tracker without call steps with content element 3 or unknown | params_flow.rb:80:8:80:51 | call to [] |
-| params_flow.rb:80:48:80:49 | 36 | type tracker without call steps with content element 3 or unknown | params_flow.rb:81:21:81:25 | * ... |
-| params_flow.rb:80:48:80:49 | 36 | type tracker without call steps with content element 4 | params_flow.rb:81:1:81:37 | * |
-| params_flow.rb:81:1:81:37 | * | type tracker with call steps | params_flow.rb:69:1:76:3 | synthetic *args |
-| params_flow.rb:81:1:81:37 | * | type tracker without call steps | params_flow.rb:81:1:81:37 | * |
+| params_flow.rb:80:48:80:49 | 36 | type tracker without call steps with content element 3 | params_flow.rb:80:8:80:51 | call to [] |
+| params_flow.rb:80:48:80:49 | 36 | type tracker without call steps with content element 3 | params_flow.rb:80:8:80:51 | synthetic splat argument |
+| params_flow.rb:80:48:80:49 | 36 | type tracker without call steps with content element 3 | params_flow.rb:81:21:81:25 | * ... |
+| params_flow.rb:80:48:80:49 | 36 | type tracker without call steps with content splat position 0 | params_flow.rb:80:42:80:50 | synthetic splat argument |
+| params_flow.rb:80:48:80:49 | 36 | type tracker without call steps with content splat position 4 (shifted) | params_flow.rb:81:1:81:37 | synthetic splat argument |
 | params_flow.rb:81:1:81:37 | call to splatmid | type tracker without call steps | params_flow.rb:81:1:81:37 | call to splatmid |
-| params_flow.rb:81:10:81:18 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:81:10:81:18 | * | type tracker without call steps | params_flow.rb:81:10:81:18 | * |
+| params_flow.rb:81:1:81:37 | synthetic splat argument | type tracker with call steps | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:81:1:81:37 | synthetic splat argument | type tracker without call steps | params_flow.rb:81:1:81:37 | synthetic splat argument |
 | params_flow.rb:81:10:81:18 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:81:10:81:18 | call to taint | type tracker with call steps | params_flow.rb:69:14:69:14 | x |
-| params_flow.rb:81:10:81:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:81:10:81:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:81:10:81:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:69:1:76:3 | synthetic *args |
-| params_flow.rb:81:10:81:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:70:5:70:10 | * |
+| params_flow.rb:81:10:81:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:81:10:81:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:81:10:81:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:81:10:81:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:70:5:70:10 | synthetic splat argument |
 | params_flow.rb:81:10:81:18 | call to taint | type tracker without call steps | params_flow.rb:81:10:81:18 | call to taint |
-| params_flow.rb:81:10:81:18 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:81:1:81:37 | * |
+| params_flow.rb:81:10:81:18 | call to taint | type tracker without call steps with content splat position 0 | params_flow.rb:81:1:81:37 | synthetic splat argument |
+| params_flow.rb:81:10:81:18 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:81:10:81:18 | synthetic splat argument | type tracker without call steps | params_flow.rb:81:10:81:18 | synthetic splat argument |
 | params_flow.rb:81:16:81:17 | 32 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:81:16:81:17 | 32 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:81:16:81:17 | 32 | type tracker with call steps | params_flow.rb:69:14:69:14 | x |
-| params_flow.rb:81:16:81:17 | 32 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:81:16:81:17 | 32 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:81:16:81:17 | 32 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:81:16:81:17 | 32 | type tracker with call steps with content element 0 | params_flow.rb:69:1:76:3 | synthetic *args |
-| params_flow.rb:81:16:81:17 | 32 | type tracker with call steps with content element 0 | params_flow.rb:70:5:70:10 | * |
+| params_flow.rb:81:16:81:17 | 32 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:81:16:81:17 | 32 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:81:16:81:17 | 32 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:81:16:81:17 | 32 | type tracker with call steps with content splat position 0 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:81:16:81:17 | 32 | type tracker with call steps with content splat position 0 | params_flow.rb:70:5:70:10 | synthetic splat argument |
 | params_flow.rb:81:16:81:17 | 32 | type tracker without call steps | params_flow.rb:81:10:81:18 | call to taint |
 | params_flow.rb:81:16:81:17 | 32 | type tracker without call steps | params_flow.rb:81:16:81:17 | 32 |
-| params_flow.rb:81:16:81:17 | 32 | type tracker without call steps with content element 0 | params_flow.rb:81:1:81:37 | * |
-| params_flow.rb:81:16:81:17 | 32 | type tracker without call steps with content element 0 | params_flow.rb:81:10:81:18 | * |
+| params_flow.rb:81:16:81:17 | 32 | type tracker without call steps with content splat position 0 | params_flow.rb:81:1:81:37 | synthetic splat argument |
+| params_flow.rb:81:16:81:17 | 32 | type tracker without call steps with content splat position 0 | params_flow.rb:81:10:81:18 | synthetic splat argument |
 | params_flow.rb:81:21:81:25 | * ... | type tracker without call steps | params_flow.rb:81:21:81:25 | * ... |
-| params_flow.rb:81:28:81:36 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:81:28:81:36 | * | type tracker without call steps | params_flow.rb:81:28:81:36 | * |
-| params_flow.rb:81:28:81:36 | call to taint | type tracker with call steps with content element 2 | params_flow.rb:69:1:76:3 | synthetic *args |
 | params_flow.rb:81:28:81:36 | call to taint | type tracker without call steps | params_flow.rb:81:28:81:36 | call to taint |
-| params_flow.rb:81:28:81:36 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:81:1:81:37 | * |
+| params_flow.rb:81:28:81:36 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:81:28:81:36 | synthetic splat argument | type tracker without call steps | params_flow.rb:81:28:81:36 | synthetic splat argument |
 | params_flow.rb:81:34:81:35 | 37 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:81:34:81:35 | 37 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:81:34:81:35 | 37 | type tracker with call steps with content element 2 | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:81:34:81:35 | 37 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:81:34:81:35 | 37 | type tracker without call steps | params_flow.rb:81:28:81:36 | call to taint |
 | params_flow.rb:81:34:81:35 | 37 | type tracker without call steps | params_flow.rb:81:34:81:35 | 37 |
-| params_flow.rb:81:34:81:35 | 37 | type tracker without call steps with content element 0 | params_flow.rb:81:28:81:36 | * |
-| params_flow.rb:81:34:81:35 | 37 | type tracker without call steps with content element 2 | params_flow.rb:81:1:81:37 | * |
+| params_flow.rb:81:34:81:35 | 37 | type tracker without call steps with content splat position 0 | params_flow.rb:81:28:81:36 | synthetic splat argument |
 | params_flow.rb:83:1:91:3 | &block | type tracker without call steps | params_flow.rb:83:1:91:3 | &block |
 | params_flow.rb:83:1:91:3 | pos_many | type tracker without call steps | params_flow.rb:83:1:91:3 | pos_many |
 | params_flow.rb:83:1:91:3 | self in pos_many | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
 | params_flow.rb:83:1:91:3 | self in pos_many | type tracker without call steps | params_flow.rb:83:1:91:3 | self in pos_many |
-| params_flow.rb:83:1:91:3 | synthetic *args | type tracker without call steps | params_flow.rb:83:1:91:3 | synthetic *args |
+| params_flow.rb:83:1:91:3 | synthetic splat parameter | type tracker without call steps | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:83:14:83:14 | t | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:83:14:83:14 | t | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:83:14:83:14 | t | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:83:14:83:14 | t | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:83:14:83:14 | t | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:83:14:83:14 | t | type tracker without call steps | params_flow.rb:83:14:83:14 | t |
 | params_flow.rb:83:14:83:14 | t | type tracker without call steps | params_flow.rb:83:14:83:14 | t |
-| params_flow.rb:83:14:83:14 | t | type tracker without call steps with content element 0 | params_flow.rb:84:5:84:10 | * |
+| params_flow.rb:83:14:83:14 | t | type tracker without call steps with content splat position 0 | params_flow.rb:84:5:84:10 | synthetic splat argument |
 | params_flow.rb:83:17:83:17 | u | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:83:17:83:17 | u | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:83:17:83:17 | u | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:83:17:83:17 | u | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:83:17:83:17 | u | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:83:17:83:17 | u | type tracker without call steps | params_flow.rb:83:17:83:17 | u |
 | params_flow.rb:83:17:83:17 | u | type tracker without call steps | params_flow.rb:83:17:83:17 | u |
-| params_flow.rb:83:17:83:17 | u | type tracker without call steps with content element 0 | params_flow.rb:85:5:85:10 | * |
+| params_flow.rb:83:17:83:17 | u | type tracker without call steps with content splat position 0 | params_flow.rb:85:5:85:10 | synthetic splat argument |
 | params_flow.rb:83:20:83:20 | v | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:83:20:83:20 | v | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:83:20:83:20 | v | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:83:20:83:20 | v | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:83:20:83:20 | v | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:83:20:83:20 | v | type tracker without call steps | params_flow.rb:83:20:83:20 | v |
 | params_flow.rb:83:20:83:20 | v | type tracker without call steps | params_flow.rb:83:20:83:20 | v |
-| params_flow.rb:83:20:83:20 | v | type tracker without call steps with content element 0 | params_flow.rb:86:5:86:10 | * |
+| params_flow.rb:83:20:83:20 | v | type tracker without call steps with content splat position 0 | params_flow.rb:86:5:86:10 | synthetic splat argument |
 | params_flow.rb:83:23:83:23 | w | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:83:23:83:23 | w | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:83:23:83:23 | w | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:83:23:83:23 | w | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:83:23:83:23 | w | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:83:23:83:23 | w | type tracker without call steps | params_flow.rb:83:23:83:23 | w |
 | params_flow.rb:83:23:83:23 | w | type tracker without call steps | params_flow.rb:83:23:83:23 | w |
-| params_flow.rb:83:23:83:23 | w | type tracker without call steps with content element 0 | params_flow.rb:87:5:87:10 | * |
+| params_flow.rb:83:23:83:23 | w | type tracker without call steps with content splat position 0 | params_flow.rb:87:5:87:10 | synthetic splat argument |
 | params_flow.rb:83:26:83:26 | x | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:83:26:83:26 | x | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:83:26:83:26 | x | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:83:26:83:26 | x | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:83:26:83:26 | x | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:83:26:83:26 | x | type tracker without call steps | params_flow.rb:83:26:83:26 | x |
 | params_flow.rb:83:26:83:26 | x | type tracker without call steps | params_flow.rb:83:26:83:26 | x |
-| params_flow.rb:83:26:83:26 | x | type tracker without call steps with content element 0 | params_flow.rb:88:5:88:10 | * |
+| params_flow.rb:83:26:83:26 | x | type tracker without call steps with content splat position 0 | params_flow.rb:88:5:88:10 | synthetic splat argument |
 | params_flow.rb:83:29:83:29 | y | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:83:29:83:29 | y | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:83:29:83:29 | y | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:83:29:83:29 | y | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:83:29:83:29 | y | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:83:29:83:29 | y | type tracker without call steps | params_flow.rb:83:29:83:29 | y |
 | params_flow.rb:83:29:83:29 | y | type tracker without call steps | params_flow.rb:83:29:83:29 | y |
-| params_flow.rb:83:29:83:29 | y | type tracker without call steps with content element 0 | params_flow.rb:89:5:89:10 | * |
+| params_flow.rb:83:29:83:29 | y | type tracker without call steps with content splat position 0 | params_flow.rb:89:5:89:10 | synthetic splat argument |
 | params_flow.rb:83:32:83:32 | z | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:83:32:83:32 | z | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:83:32:83:32 | z | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:83:32:83:32 | z | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:83:32:83:32 | z | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:83:32:83:32 | z | type tracker without call steps | params_flow.rb:83:32:83:32 | z |
 | params_flow.rb:83:32:83:32 | z | type tracker without call steps | params_flow.rb:83:32:83:32 | z |
-| params_flow.rb:83:32:83:32 | z | type tracker without call steps with content element 0 | params_flow.rb:90:5:90:10 | * |
-| params_flow.rb:84:5:84:10 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:84:5:84:10 | * | type tracker without call steps | params_flow.rb:84:5:84:10 | * |
+| params_flow.rb:83:32:83:32 | z | type tracker without call steps with content splat position 0 | params_flow.rb:90:5:90:10 | synthetic splat argument |
 | params_flow.rb:84:5:84:10 | call to sink | type tracker without call steps | params_flow.rb:84:5:84:10 | call to sink |
-| params_flow.rb:85:5:85:10 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:85:5:85:10 | * | type tracker without call steps | params_flow.rb:85:5:85:10 | * |
+| params_flow.rb:84:5:84:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:84:5:84:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:84:5:84:10 | synthetic splat argument |
 | params_flow.rb:85:5:85:10 | call to sink | type tracker without call steps | params_flow.rb:85:5:85:10 | call to sink |
-| params_flow.rb:86:5:86:10 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:86:5:86:10 | * | type tracker without call steps | params_flow.rb:86:5:86:10 | * |
+| params_flow.rb:85:5:85:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:85:5:85:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:85:5:85:10 | synthetic splat argument |
 | params_flow.rb:86:5:86:10 | call to sink | type tracker without call steps | params_flow.rb:86:5:86:10 | call to sink |
-| params_flow.rb:87:5:87:10 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:87:5:87:10 | * | type tracker without call steps | params_flow.rb:87:5:87:10 | * |
+| params_flow.rb:86:5:86:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:86:5:86:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:86:5:86:10 | synthetic splat argument |
 | params_flow.rb:87:5:87:10 | call to sink | type tracker without call steps | params_flow.rb:87:5:87:10 | call to sink |
-| params_flow.rb:88:5:88:10 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:88:5:88:10 | * | type tracker without call steps | params_flow.rb:88:5:88:10 | * |
+| params_flow.rb:87:5:87:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:87:5:87:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:87:5:87:10 | synthetic splat argument |
 | params_flow.rb:88:5:88:10 | call to sink | type tracker without call steps | params_flow.rb:88:5:88:10 | call to sink |
-| params_flow.rb:89:5:89:10 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:89:5:89:10 | * | type tracker without call steps | params_flow.rb:89:5:89:10 | * |
+| params_flow.rb:88:5:88:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:88:5:88:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:88:5:88:10 | synthetic splat argument |
 | params_flow.rb:89:5:89:10 | call to sink | type tracker without call steps | params_flow.rb:89:5:89:10 | call to sink |
-| params_flow.rb:90:5:90:10 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:90:5:90:10 | * | type tracker without call steps | params_flow.rb:90:5:90:10 | * |
+| params_flow.rb:89:5:89:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:89:5:89:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:89:5:89:10 | synthetic splat argument |
 | params_flow.rb:90:5:90:10 | call to sink | type tracker without call steps | params_flow.rb:90:5:90:10 | call to sink |
 | params_flow.rb:90:5:90:10 | call to sink | type tracker without call steps | params_flow.rb:94:1:94:48 | call to pos_many |
 | params_flow.rb:90:5:90:10 | call to sink | type tracker without call steps | params_flow.rb:131:1:131:46 | call to pos_many |
+| params_flow.rb:90:5:90:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:90:5:90:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:90:5:90:10 | synthetic splat argument |
 | params_flow.rb:93:1:93:4 | args | type tracker without call steps | params_flow.rb:93:1:93:4 | args |
-| params_flow.rb:93:8:93:51 | * | type tracker without call steps | params_flow.rb:93:8:93:51 | * |
 | params_flow.rb:93:8:93:51 | Array | type tracker without call steps | params_flow.rb:93:8:93:51 | Array |
 | params_flow.rb:93:8:93:51 | call to [] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:93:8:93:51 | call to [] | type tracker with call steps | params_flow.rb:83:20:83:20 | v |
-| params_flow.rb:93:8:93:51 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:93:8:93:51 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:93:8:93:51 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:86:5:86:10 | * |
-| params_flow.rb:93:8:93:51 | call to [] | type tracker with call steps with content element 2 | params_flow.rb:83:1:91:3 | synthetic *args |
+| params_flow.rb:93:8:93:51 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:93:8:93:51 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:93:8:93:51 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:86:5:86:10 | synthetic splat argument |
+| params_flow.rb:93:8:93:51 | call to [] | type tracker with call steps with content splat position 2 (shifted) | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:93:8:93:51 | call to [] | type tracker without call steps | params_flow.rb:93:8:93:51 | call to [] |
 | params_flow.rb:93:8:93:51 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:94:32:94:36 | * ... |
-| params_flow.rb:93:8:93:51 | call to [] | type tracker without call steps with content element 2 | params_flow.rb:94:1:94:48 | * |
-| params_flow.rb:93:9:93:17 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:93:9:93:17 | * | type tracker without call steps | params_flow.rb:93:9:93:17 | * |
+| params_flow.rb:93:8:93:51 | call to [] | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:94:1:94:48 | synthetic splat argument |
+| params_flow.rb:93:8:93:51 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:93:8:93:51 | synthetic splat argument | type tracker with call steps | params_flow.rb:83:20:83:20 | v |
+| params_flow.rb:93:8:93:51 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:93:8:93:51 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:93:8:93:51 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:86:5:86:10 | synthetic splat argument |
+| params_flow.rb:93:8:93:51 | synthetic splat argument | type tracker with call steps with content splat position 2 (shifted) | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:93:8:93:51 | synthetic splat argument | type tracker without call steps | params_flow.rb:93:8:93:51 | call to [] |
+| params_flow.rb:93:8:93:51 | synthetic splat argument | type tracker without call steps | params_flow.rb:93:8:93:51 | synthetic splat argument |
+| params_flow.rb:93:8:93:51 | synthetic splat argument | type tracker without call steps with content element 0 or unknown | params_flow.rb:94:32:94:36 | * ... |
+| params_flow.rb:93:8:93:51 | synthetic splat argument | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:94:1:94:48 | synthetic splat argument |
 | params_flow.rb:93:9:93:17 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:93:9:93:17 | call to taint | type tracker with call steps | params_flow.rb:83:20:83:20 | v |
-| params_flow.rb:93:9:93:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:93:9:93:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:93:9:93:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:86:5:86:10 | * |
-| params_flow.rb:93:9:93:17 | call to taint | type tracker with call steps with content element 2 | params_flow.rb:83:1:91:3 | synthetic *args |
+| params_flow.rb:93:9:93:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:93:9:93:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:93:9:93:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:86:5:86:10 | synthetic splat argument |
+| params_flow.rb:93:9:93:17 | call to taint | type tracker with call steps with content splat position 2 (shifted) | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:93:9:93:17 | call to taint | type tracker without call steps | params_flow.rb:93:9:93:17 | call to taint |
-| params_flow.rb:93:9:93:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:93:8:93:51 | * |
-| params_flow.rb:93:9:93:17 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:93:8:93:51 | call to [] |
-| params_flow.rb:93:9:93:17 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:94:32:94:36 | * ... |
-| params_flow.rb:93:9:93:17 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:94:1:94:48 | * |
+| params_flow.rb:93:9:93:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:93:8:93:51 | call to [] |
+| params_flow.rb:93:9:93:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:93:8:93:51 | synthetic splat argument |
+| params_flow.rb:93:9:93:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:94:32:94:36 | * ... |
+| params_flow.rb:93:9:93:17 | call to taint | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:94:1:94:48 | synthetic splat argument |
+| params_flow.rb:93:9:93:17 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:93:9:93:17 | synthetic splat argument | type tracker without call steps | params_flow.rb:93:9:93:17 | synthetic splat argument |
 | params_flow.rb:93:15:93:16 | 40 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:93:15:93:16 | 40 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:93:15:93:16 | 40 | type tracker with call steps | params_flow.rb:83:20:83:20 | v |
-| params_flow.rb:93:15:93:16 | 40 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:93:15:93:16 | 40 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:93:15:93:16 | 40 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:93:15:93:16 | 40 | type tracker with call steps with content element 0 | params_flow.rb:86:5:86:10 | * |
-| params_flow.rb:93:15:93:16 | 40 | type tracker with call steps with content element 2 | params_flow.rb:83:1:91:3 | synthetic *args |
+| params_flow.rb:93:15:93:16 | 40 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:93:15:93:16 | 40 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:93:15:93:16 | 40 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:93:15:93:16 | 40 | type tracker with call steps with content splat position 0 | params_flow.rb:86:5:86:10 | synthetic splat argument |
+| params_flow.rb:93:15:93:16 | 40 | type tracker with call steps with content splat position 2 (shifted) | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:93:15:93:16 | 40 | type tracker without call steps | params_flow.rb:93:9:93:17 | call to taint |
 | params_flow.rb:93:15:93:16 | 40 | type tracker without call steps | params_flow.rb:93:15:93:16 | 40 |
-| params_flow.rb:93:15:93:16 | 40 | type tracker without call steps with content element 0 | params_flow.rb:93:8:93:51 | * |
-| params_flow.rb:93:15:93:16 | 40 | type tracker without call steps with content element 0 | params_flow.rb:93:9:93:17 | * |
-| params_flow.rb:93:15:93:16 | 40 | type tracker without call steps with content element 0 or unknown | params_flow.rb:93:8:93:51 | call to [] |
-| params_flow.rb:93:15:93:16 | 40 | type tracker without call steps with content element 0 or unknown | params_flow.rb:94:32:94:36 | * ... |
-| params_flow.rb:93:15:93:16 | 40 | type tracker without call steps with content element 2 | params_flow.rb:94:1:94:48 | * |
-| params_flow.rb:93:20:93:28 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:93:20:93:28 | * | type tracker without call steps | params_flow.rb:93:20:93:28 | * |
+| params_flow.rb:93:15:93:16 | 40 | type tracker without call steps with content element 0 | params_flow.rb:93:8:93:51 | call to [] |
+| params_flow.rb:93:15:93:16 | 40 | type tracker without call steps with content element 0 | params_flow.rb:93:8:93:51 | synthetic splat argument |
+| params_flow.rb:93:15:93:16 | 40 | type tracker without call steps with content element 0 | params_flow.rb:94:32:94:36 | * ... |
+| params_flow.rb:93:15:93:16 | 40 | type tracker without call steps with content splat position 0 | params_flow.rb:93:9:93:17 | synthetic splat argument |
+| params_flow.rb:93:15:93:16 | 40 | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:94:1:94:48 | synthetic splat argument |
 | params_flow.rb:93:20:93:28 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:93:20:93:28 | call to taint | type tracker with call steps | params_flow.rb:83:23:83:23 | w |
-| params_flow.rb:93:20:93:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:93:20:93:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:93:20:93:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:87:5:87:10 | * |
-| params_flow.rb:93:20:93:28 | call to taint | type tracker with call steps with content element 3 | params_flow.rb:83:1:91:3 | synthetic *args |
+| params_flow.rb:93:20:93:28 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:93:20:93:28 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:93:20:93:28 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:87:5:87:10 | synthetic splat argument |
+| params_flow.rb:93:20:93:28 | call to taint | type tracker with call steps with content splat position 3 (shifted) | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:93:20:93:28 | call to taint | type tracker without call steps | params_flow.rb:93:20:93:28 | call to taint |
-| params_flow.rb:93:20:93:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:93:8:93:51 | * |
-| params_flow.rb:93:20:93:28 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:93:8:93:51 | call to [] |
-| params_flow.rb:93:20:93:28 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:94:32:94:36 | * ... |
-| params_flow.rb:93:20:93:28 | call to taint | type tracker without call steps with content element 3 | params_flow.rb:94:1:94:48 | * |
+| params_flow.rb:93:20:93:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:93:8:93:51 | call to [] |
+| params_flow.rb:93:20:93:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:93:8:93:51 | synthetic splat argument |
+| params_flow.rb:93:20:93:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:94:32:94:36 | * ... |
+| params_flow.rb:93:20:93:28 | call to taint | type tracker without call steps with content splat position 3 (shifted) | params_flow.rb:94:1:94:48 | synthetic splat argument |
+| params_flow.rb:93:20:93:28 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:93:20:93:28 | synthetic splat argument | type tracker without call steps | params_flow.rb:93:20:93:28 | synthetic splat argument |
 | params_flow.rb:93:26:93:27 | 41 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:93:26:93:27 | 41 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:93:26:93:27 | 41 | type tracker with call steps | params_flow.rb:83:23:83:23 | w |
-| params_flow.rb:93:26:93:27 | 41 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:93:26:93:27 | 41 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:93:26:93:27 | 41 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:93:26:93:27 | 41 | type tracker with call steps with content element 0 | params_flow.rb:87:5:87:10 | * |
-| params_flow.rb:93:26:93:27 | 41 | type tracker with call steps with content element 3 | params_flow.rb:83:1:91:3 | synthetic *args |
+| params_flow.rb:93:26:93:27 | 41 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:93:26:93:27 | 41 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:93:26:93:27 | 41 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:93:26:93:27 | 41 | type tracker with call steps with content splat position 0 | params_flow.rb:87:5:87:10 | synthetic splat argument |
+| params_flow.rb:93:26:93:27 | 41 | type tracker with call steps with content splat position 3 (shifted) | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:93:26:93:27 | 41 | type tracker without call steps | params_flow.rb:93:20:93:28 | call to taint |
 | params_flow.rb:93:26:93:27 | 41 | type tracker without call steps | params_flow.rb:93:26:93:27 | 41 |
-| params_flow.rb:93:26:93:27 | 41 | type tracker without call steps with content element 0 | params_flow.rb:93:20:93:28 | * |
-| params_flow.rb:93:26:93:27 | 41 | type tracker without call steps with content element 1 | params_flow.rb:93:8:93:51 | * |
-| params_flow.rb:93:26:93:27 | 41 | type tracker without call steps with content element 1 or unknown | params_flow.rb:93:8:93:51 | call to [] |
-| params_flow.rb:93:26:93:27 | 41 | type tracker without call steps with content element 1 or unknown | params_flow.rb:94:32:94:36 | * ... |
-| params_flow.rb:93:26:93:27 | 41 | type tracker without call steps with content element 3 | params_flow.rb:94:1:94:48 | * |
-| params_flow.rb:93:31:93:39 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:93:31:93:39 | * | type tracker without call steps | params_flow.rb:93:31:93:39 | * |
+| params_flow.rb:93:26:93:27 | 41 | type tracker without call steps with content element 1 | params_flow.rb:93:8:93:51 | call to [] |
+| params_flow.rb:93:26:93:27 | 41 | type tracker without call steps with content element 1 | params_flow.rb:93:8:93:51 | synthetic splat argument |
+| params_flow.rb:93:26:93:27 | 41 | type tracker without call steps with content element 1 | params_flow.rb:94:32:94:36 | * ... |
+| params_flow.rb:93:26:93:27 | 41 | type tracker without call steps with content splat position 0 | params_flow.rb:93:20:93:28 | synthetic splat argument |
+| params_flow.rb:93:26:93:27 | 41 | type tracker without call steps with content splat position 3 (shifted) | params_flow.rb:94:1:94:48 | synthetic splat argument |
 | params_flow.rb:93:31:93:39 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:93:31:93:39 | call to taint | type tracker with call steps | params_flow.rb:83:26:83:26 | x |
-| params_flow.rb:93:31:93:39 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:93:31:93:39 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:93:31:93:39 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:88:5:88:10 | * |
-| params_flow.rb:93:31:93:39 | call to taint | type tracker with call steps with content element 4 | params_flow.rb:83:1:91:3 | synthetic *args |
+| params_flow.rb:93:31:93:39 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:93:31:93:39 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:93:31:93:39 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:88:5:88:10 | synthetic splat argument |
+| params_flow.rb:93:31:93:39 | call to taint | type tracker with call steps with content splat position 4 (shifted) | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:93:31:93:39 | call to taint | type tracker without call steps | params_flow.rb:93:31:93:39 | call to taint |
-| params_flow.rb:93:31:93:39 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:93:8:93:51 | * |
-| params_flow.rb:93:31:93:39 | call to taint | type tracker without call steps with content element 2 or unknown | params_flow.rb:93:8:93:51 | call to [] |
-| params_flow.rb:93:31:93:39 | call to taint | type tracker without call steps with content element 2 or unknown | params_flow.rb:94:32:94:36 | * ... |
-| params_flow.rb:93:31:93:39 | call to taint | type tracker without call steps with content element 4 | params_flow.rb:94:1:94:48 | * |
+| params_flow.rb:93:31:93:39 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:93:8:93:51 | call to [] |
+| params_flow.rb:93:31:93:39 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:93:8:93:51 | synthetic splat argument |
+| params_flow.rb:93:31:93:39 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:94:32:94:36 | * ... |
+| params_flow.rb:93:31:93:39 | call to taint | type tracker without call steps with content splat position 4 (shifted) | params_flow.rb:94:1:94:48 | synthetic splat argument |
+| params_flow.rb:93:31:93:39 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:93:31:93:39 | synthetic splat argument | type tracker without call steps | params_flow.rb:93:31:93:39 | synthetic splat argument |
 | params_flow.rb:93:37:93:38 | 42 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:93:37:93:38 | 42 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:93:37:93:38 | 42 | type tracker with call steps | params_flow.rb:83:26:83:26 | x |
-| params_flow.rb:93:37:93:38 | 42 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:93:37:93:38 | 42 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:93:37:93:38 | 42 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:93:37:93:38 | 42 | type tracker with call steps with content element 0 | params_flow.rb:88:5:88:10 | * |
-| params_flow.rb:93:37:93:38 | 42 | type tracker with call steps with content element 4 | params_flow.rb:83:1:91:3 | synthetic *args |
+| params_flow.rb:93:37:93:38 | 42 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:93:37:93:38 | 42 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:93:37:93:38 | 42 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:93:37:93:38 | 42 | type tracker with call steps with content splat position 0 | params_flow.rb:88:5:88:10 | synthetic splat argument |
+| params_flow.rb:93:37:93:38 | 42 | type tracker with call steps with content splat position 4 (shifted) | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:93:37:93:38 | 42 | type tracker without call steps | params_flow.rb:93:31:93:39 | call to taint |
 | params_flow.rb:93:37:93:38 | 42 | type tracker without call steps | params_flow.rb:93:37:93:38 | 42 |
-| params_flow.rb:93:37:93:38 | 42 | type tracker without call steps with content element 0 | params_flow.rb:93:31:93:39 | * |
-| params_flow.rb:93:37:93:38 | 42 | type tracker without call steps with content element 2 | params_flow.rb:93:8:93:51 | * |
-| params_flow.rb:93:37:93:38 | 42 | type tracker without call steps with content element 2 or unknown | params_flow.rb:93:8:93:51 | call to [] |
-| params_flow.rb:93:37:93:38 | 42 | type tracker without call steps with content element 2 or unknown | params_flow.rb:94:32:94:36 | * ... |
-| params_flow.rb:93:37:93:38 | 42 | type tracker without call steps with content element 4 | params_flow.rb:94:1:94:48 | * |
-| params_flow.rb:93:42:93:50 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:93:42:93:50 | * | type tracker without call steps | params_flow.rb:93:42:93:50 | * |
+| params_flow.rb:93:37:93:38 | 42 | type tracker without call steps with content element 2 | params_flow.rb:93:8:93:51 | call to [] |
+| params_flow.rb:93:37:93:38 | 42 | type tracker without call steps with content element 2 | params_flow.rb:93:8:93:51 | synthetic splat argument |
+| params_flow.rb:93:37:93:38 | 42 | type tracker without call steps with content element 2 | params_flow.rb:94:32:94:36 | * ... |
+| params_flow.rb:93:37:93:38 | 42 | type tracker without call steps with content splat position 0 | params_flow.rb:93:31:93:39 | synthetic splat argument |
+| params_flow.rb:93:37:93:38 | 42 | type tracker without call steps with content splat position 4 (shifted) | params_flow.rb:94:1:94:48 | synthetic splat argument |
 | params_flow.rb:93:42:93:50 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:93:42:93:50 | call to taint | type tracker with call steps | params_flow.rb:83:29:83:29 | y |
-| params_flow.rb:93:42:93:50 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:93:42:93:50 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:93:42:93:50 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:89:5:89:10 | * |
-| params_flow.rb:93:42:93:50 | call to taint | type tracker with call steps with content element 5 | params_flow.rb:83:1:91:3 | synthetic *args |
+| params_flow.rb:93:42:93:50 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:93:42:93:50 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:93:42:93:50 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:89:5:89:10 | synthetic splat argument |
+| params_flow.rb:93:42:93:50 | call to taint | type tracker with call steps with content splat position 5 (shifted) | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:93:42:93:50 | call to taint | type tracker without call steps | params_flow.rb:93:42:93:50 | call to taint |
-| params_flow.rb:93:42:93:50 | call to taint | type tracker without call steps with content element 3 | params_flow.rb:93:8:93:51 | * |
-| params_flow.rb:93:42:93:50 | call to taint | type tracker without call steps with content element 3 or unknown | params_flow.rb:93:8:93:51 | call to [] |
-| params_flow.rb:93:42:93:50 | call to taint | type tracker without call steps with content element 3 or unknown | params_flow.rb:94:32:94:36 | * ... |
-| params_flow.rb:93:42:93:50 | call to taint | type tracker without call steps with content element 5 | params_flow.rb:94:1:94:48 | * |
+| params_flow.rb:93:42:93:50 | call to taint | type tracker without call steps with content element 3 | params_flow.rb:93:8:93:51 | call to [] |
+| params_flow.rb:93:42:93:50 | call to taint | type tracker without call steps with content element 3 | params_flow.rb:93:8:93:51 | synthetic splat argument |
+| params_flow.rb:93:42:93:50 | call to taint | type tracker without call steps with content element 3 | params_flow.rb:94:32:94:36 | * ... |
+| params_flow.rb:93:42:93:50 | call to taint | type tracker without call steps with content splat position 5 (shifted) | params_flow.rb:94:1:94:48 | synthetic splat argument |
+| params_flow.rb:93:42:93:50 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:93:42:93:50 | synthetic splat argument | type tracker without call steps | params_flow.rb:93:42:93:50 | synthetic splat argument |
 | params_flow.rb:93:48:93:49 | 43 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:93:48:93:49 | 43 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:93:48:93:49 | 43 | type tracker with call steps | params_flow.rb:83:29:83:29 | y |
-| params_flow.rb:93:48:93:49 | 43 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:93:48:93:49 | 43 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:93:48:93:49 | 43 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:93:48:93:49 | 43 | type tracker with call steps with content element 0 | params_flow.rb:89:5:89:10 | * |
-| params_flow.rb:93:48:93:49 | 43 | type tracker with call steps with content element 5 | params_flow.rb:83:1:91:3 | synthetic *args |
+| params_flow.rb:93:48:93:49 | 43 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:93:48:93:49 | 43 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:93:48:93:49 | 43 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:93:48:93:49 | 43 | type tracker with call steps with content splat position 0 | params_flow.rb:89:5:89:10 | synthetic splat argument |
+| params_flow.rb:93:48:93:49 | 43 | type tracker with call steps with content splat position 5 (shifted) | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:93:48:93:49 | 43 | type tracker without call steps | params_flow.rb:93:42:93:50 | call to taint |
 | params_flow.rb:93:48:93:49 | 43 | type tracker without call steps | params_flow.rb:93:48:93:49 | 43 |
-| params_flow.rb:93:48:93:49 | 43 | type tracker without call steps with content element 0 | params_flow.rb:93:42:93:50 | * |
-| params_flow.rb:93:48:93:49 | 43 | type tracker without call steps with content element 3 | params_flow.rb:93:8:93:51 | * |
-| params_flow.rb:93:48:93:49 | 43 | type tracker without call steps with content element 3 or unknown | params_flow.rb:93:8:93:51 | call to [] |
-| params_flow.rb:93:48:93:49 | 43 | type tracker without call steps with content element 3 or unknown | params_flow.rb:94:32:94:36 | * ... |
-| params_flow.rb:93:48:93:49 | 43 | type tracker without call steps with content element 5 | params_flow.rb:94:1:94:48 | * |
-| params_flow.rb:94:1:94:48 | * | type tracker with call steps | params_flow.rb:83:1:91:3 | synthetic *args |
-| params_flow.rb:94:1:94:48 | * | type tracker without call steps | params_flow.rb:94:1:94:48 | * |
+| params_flow.rb:93:48:93:49 | 43 | type tracker without call steps with content element 3 | params_flow.rb:93:8:93:51 | call to [] |
+| params_flow.rb:93:48:93:49 | 43 | type tracker without call steps with content element 3 | params_flow.rb:93:8:93:51 | synthetic splat argument |
+| params_flow.rb:93:48:93:49 | 43 | type tracker without call steps with content element 3 | params_flow.rb:94:32:94:36 | * ... |
+| params_flow.rb:93:48:93:49 | 43 | type tracker without call steps with content splat position 0 | params_flow.rb:93:42:93:50 | synthetic splat argument |
+| params_flow.rb:93:48:93:49 | 43 | type tracker without call steps with content splat position 5 (shifted) | params_flow.rb:94:1:94:48 | synthetic splat argument |
 | params_flow.rb:94:1:94:48 | call to pos_many | type tracker without call steps | params_flow.rb:94:1:94:48 | call to pos_many |
-| params_flow.rb:94:10:94:18 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:94:10:94:18 | * | type tracker without call steps | params_flow.rb:94:10:94:18 | * |
+| params_flow.rb:94:1:94:48 | synthetic splat argument | type tracker with call steps | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:94:1:94:48 | synthetic splat argument | type tracker without call steps | params_flow.rb:94:1:94:48 | synthetic splat argument |
 | params_flow.rb:94:10:94:18 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:94:10:94:18 | call to taint | type tracker with call steps | params_flow.rb:83:14:83:14 | t |
-| params_flow.rb:94:10:94:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:94:10:94:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:94:10:94:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:83:1:91:3 | synthetic *args |
-| params_flow.rb:94:10:94:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:84:5:84:10 | * |
+| params_flow.rb:94:10:94:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:94:10:94:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:94:10:94:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:94:10:94:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:84:5:84:10 | synthetic splat argument |
 | params_flow.rb:94:10:94:18 | call to taint | type tracker without call steps | params_flow.rb:94:10:94:18 | call to taint |
-| params_flow.rb:94:10:94:18 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:94:1:94:48 | * |
+| params_flow.rb:94:10:94:18 | call to taint | type tracker without call steps with content splat position 0 | params_flow.rb:94:1:94:48 | synthetic splat argument |
+| params_flow.rb:94:10:94:18 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:94:10:94:18 | synthetic splat argument | type tracker without call steps | params_flow.rb:94:10:94:18 | synthetic splat argument |
 | params_flow.rb:94:16:94:17 | 38 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:94:16:94:17 | 38 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:94:16:94:17 | 38 | type tracker with call steps | params_flow.rb:83:14:83:14 | t |
-| params_flow.rb:94:16:94:17 | 38 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:94:16:94:17 | 38 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:94:16:94:17 | 38 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:94:16:94:17 | 38 | type tracker with call steps with content element 0 | params_flow.rb:83:1:91:3 | synthetic *args |
-| params_flow.rb:94:16:94:17 | 38 | type tracker with call steps with content element 0 | params_flow.rb:84:5:84:10 | * |
+| params_flow.rb:94:16:94:17 | 38 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:94:16:94:17 | 38 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:94:16:94:17 | 38 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:94:16:94:17 | 38 | type tracker with call steps with content splat position 0 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:94:16:94:17 | 38 | type tracker with call steps with content splat position 0 | params_flow.rb:84:5:84:10 | synthetic splat argument |
 | params_flow.rb:94:16:94:17 | 38 | type tracker without call steps | params_flow.rb:94:10:94:18 | call to taint |
 | params_flow.rb:94:16:94:17 | 38 | type tracker without call steps | params_flow.rb:94:16:94:17 | 38 |
-| params_flow.rb:94:16:94:17 | 38 | type tracker without call steps with content element 0 | params_flow.rb:94:1:94:48 | * |
-| params_flow.rb:94:16:94:17 | 38 | type tracker without call steps with content element 0 | params_flow.rb:94:10:94:18 | * |
-| params_flow.rb:94:21:94:29 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:94:21:94:29 | * | type tracker without call steps | params_flow.rb:94:21:94:29 | * |
+| params_flow.rb:94:16:94:17 | 38 | type tracker without call steps with content splat position 0 | params_flow.rb:94:1:94:48 | synthetic splat argument |
+| params_flow.rb:94:16:94:17 | 38 | type tracker without call steps with content splat position 0 | params_flow.rb:94:10:94:18 | synthetic splat argument |
 | params_flow.rb:94:21:94:29 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:94:21:94:29 | call to taint | type tracker with call steps | params_flow.rb:83:17:83:17 | u |
-| params_flow.rb:94:21:94:29 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:94:21:94:29 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:94:21:94:29 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:85:5:85:10 | * |
-| params_flow.rb:94:21:94:29 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:83:1:91:3 | synthetic *args |
+| params_flow.rb:94:21:94:29 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:94:21:94:29 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:94:21:94:29 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:85:5:85:10 | synthetic splat argument |
+| params_flow.rb:94:21:94:29 | call to taint | type tracker with call steps with content splat position 1 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:94:21:94:29 | call to taint | type tracker without call steps | params_flow.rb:94:21:94:29 | call to taint |
-| params_flow.rb:94:21:94:29 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:94:1:94:48 | * |
+| params_flow.rb:94:21:94:29 | call to taint | type tracker without call steps with content splat position 1 | params_flow.rb:94:1:94:48 | synthetic splat argument |
+| params_flow.rb:94:21:94:29 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:94:21:94:29 | synthetic splat argument | type tracker without call steps | params_flow.rb:94:21:94:29 | synthetic splat argument |
 | params_flow.rb:94:27:94:28 | 39 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:94:27:94:28 | 39 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:94:27:94:28 | 39 | type tracker with call steps | params_flow.rb:83:17:83:17 | u |
-| params_flow.rb:94:27:94:28 | 39 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:94:27:94:28 | 39 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:94:27:94:28 | 39 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:94:27:94:28 | 39 | type tracker with call steps with content element 0 | params_flow.rb:85:5:85:10 | * |
-| params_flow.rb:94:27:94:28 | 39 | type tracker with call steps with content element 1 | params_flow.rb:83:1:91:3 | synthetic *args |
+| params_flow.rb:94:27:94:28 | 39 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:94:27:94:28 | 39 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:94:27:94:28 | 39 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:94:27:94:28 | 39 | type tracker with call steps with content splat position 0 | params_flow.rb:85:5:85:10 | synthetic splat argument |
+| params_flow.rb:94:27:94:28 | 39 | type tracker with call steps with content splat position 1 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:94:27:94:28 | 39 | type tracker without call steps | params_flow.rb:94:21:94:29 | call to taint |
 | params_flow.rb:94:27:94:28 | 39 | type tracker without call steps | params_flow.rb:94:27:94:28 | 39 |
-| params_flow.rb:94:27:94:28 | 39 | type tracker without call steps with content element 0 | params_flow.rb:94:21:94:29 | * |
-| params_flow.rb:94:27:94:28 | 39 | type tracker without call steps with content element 1 | params_flow.rb:94:1:94:48 | * |
+| params_flow.rb:94:27:94:28 | 39 | type tracker without call steps with content splat position 0 | params_flow.rb:94:21:94:29 | synthetic splat argument |
+| params_flow.rb:94:27:94:28 | 39 | type tracker without call steps with content splat position 1 | params_flow.rb:94:1:94:48 | synthetic splat argument |
 | params_flow.rb:94:32:94:36 | * ... | type tracker without call steps | params_flow.rb:94:32:94:36 | * ... |
-| params_flow.rb:94:39:94:47 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:94:39:94:47 | * | type tracker without call steps | params_flow.rb:94:39:94:47 | * |
 | params_flow.rb:94:39:94:47 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:94:39:94:47 | call to taint | type tracker with call steps | params_flow.rb:83:23:83:23 | w |
-| params_flow.rb:94:39:94:47 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:94:39:94:47 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:94:39:94:47 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:87:5:87:10 | * |
-| params_flow.rb:94:39:94:47 | call to taint | type tracker with call steps with content element 3 | params_flow.rb:83:1:91:3 | synthetic *args |
+| params_flow.rb:94:39:94:47 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:94:39:94:47 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:94:39:94:47 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:87:5:87:10 | synthetic splat argument |
 | params_flow.rb:94:39:94:47 | call to taint | type tracker without call steps | params_flow.rb:94:39:94:47 | call to taint |
-| params_flow.rb:94:39:94:47 | call to taint | type tracker without call steps with content element 3 | params_flow.rb:94:1:94:48 | * |
+| params_flow.rb:94:39:94:47 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:94:39:94:47 | synthetic splat argument | type tracker without call steps | params_flow.rb:94:39:94:47 | synthetic splat argument |
 | params_flow.rb:94:45:94:46 | 44 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:94:45:94:46 | 44 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:94:45:94:46 | 44 | type tracker with call steps | params_flow.rb:83:23:83:23 | w |
-| params_flow.rb:94:45:94:46 | 44 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:94:45:94:46 | 44 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:94:45:94:46 | 44 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:94:45:94:46 | 44 | type tracker with call steps with content element 0 | params_flow.rb:87:5:87:10 | * |
-| params_flow.rb:94:45:94:46 | 44 | type tracker with call steps with content element 3 | params_flow.rb:83:1:91:3 | synthetic *args |
+| params_flow.rb:94:45:94:46 | 44 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:94:45:94:46 | 44 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:94:45:94:46 | 44 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:94:45:94:46 | 44 | type tracker with call steps with content splat position 0 | params_flow.rb:87:5:87:10 | synthetic splat argument |
 | params_flow.rb:94:45:94:46 | 44 | type tracker without call steps | params_flow.rb:94:39:94:47 | call to taint |
 | params_flow.rb:94:45:94:46 | 44 | type tracker without call steps | params_flow.rb:94:45:94:46 | 44 |
-| params_flow.rb:94:45:94:46 | 44 | type tracker without call steps with content element 0 | params_flow.rb:94:39:94:47 | * |
-| params_flow.rb:94:45:94:46 | 44 | type tracker without call steps with content element 3 | params_flow.rb:94:1:94:48 | * |
-| params_flow.rb:96:1:96:88 | * | type tracker with call steps | params_flow.rb:69:1:76:3 | synthetic *args |
-| params_flow.rb:96:1:96:88 | * | type tracker without call steps | params_flow.rb:96:1:96:88 | * |
+| params_flow.rb:94:45:94:46 | 44 | type tracker without call steps with content splat position 0 | params_flow.rb:94:39:94:47 | synthetic splat argument |
 | params_flow.rb:96:1:96:88 | call to splatmid | type tracker without call steps | params_flow.rb:96:1:96:88 | call to splatmid |
-| params_flow.rb:96:10:96:18 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:96:10:96:18 | * | type tracker without call steps | params_flow.rb:96:10:96:18 | * |
+| params_flow.rb:96:1:96:88 | synthetic splat argument | type tracker with call steps | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:96:1:96:88 | synthetic splat argument | type tracker without call steps | params_flow.rb:96:1:96:88 | synthetic splat argument |
 | params_flow.rb:96:10:96:18 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:96:10:96:18 | call to taint | type tracker with call steps | params_flow.rb:69:14:69:14 | x |
-| params_flow.rb:96:10:96:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:96:10:96:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:96:10:96:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:69:1:76:3 | synthetic *args |
-| params_flow.rb:96:10:96:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:70:5:70:10 | * |
+| params_flow.rb:96:10:96:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:96:10:96:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:96:10:96:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:96:10:96:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:70:5:70:10 | synthetic splat argument |
 | params_flow.rb:96:10:96:18 | call to taint | type tracker without call steps | params_flow.rb:96:10:96:18 | call to taint |
-| params_flow.rb:96:10:96:18 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:96:1:96:88 | * |
+| params_flow.rb:96:10:96:18 | call to taint | type tracker without call steps with content splat position 0 | params_flow.rb:96:1:96:88 | synthetic splat argument |
+| params_flow.rb:96:10:96:18 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:96:10:96:18 | synthetic splat argument | type tracker without call steps | params_flow.rb:96:10:96:18 | synthetic splat argument |
 | params_flow.rb:96:16:96:17 | 45 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:16:96:17 | 45 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:96:16:96:17 | 45 | type tracker with call steps | params_flow.rb:69:14:69:14 | x |
-| params_flow.rb:96:16:96:17 | 45 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:96:16:96:17 | 45 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:96:16:96:17 | 45 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:96:16:96:17 | 45 | type tracker with call steps with content element 0 | params_flow.rb:69:1:76:3 | synthetic *args |
-| params_flow.rb:96:16:96:17 | 45 | type tracker with call steps with content element 0 | params_flow.rb:70:5:70:10 | * |
+| params_flow.rb:96:16:96:17 | 45 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:96:16:96:17 | 45 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:96:16:96:17 | 45 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:96:16:96:17 | 45 | type tracker with call steps with content splat position 0 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:96:16:96:17 | 45 | type tracker with call steps with content splat position 0 | params_flow.rb:70:5:70:10 | synthetic splat argument |
 | params_flow.rb:96:16:96:17 | 45 | type tracker without call steps | params_flow.rb:96:10:96:18 | call to taint |
 | params_flow.rb:96:16:96:17 | 45 | type tracker without call steps | params_flow.rb:96:16:96:17 | 45 |
-| params_flow.rb:96:16:96:17 | 45 | type tracker without call steps with content element 0 | params_flow.rb:96:1:96:88 | * |
-| params_flow.rb:96:16:96:17 | 45 | type tracker without call steps with content element 0 | params_flow.rb:96:10:96:18 | * |
-| params_flow.rb:96:21:96:29 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:96:21:96:29 | * | type tracker without call steps | params_flow.rb:96:21:96:29 | * |
+| params_flow.rb:96:16:96:17 | 45 | type tracker without call steps with content splat position 0 | params_flow.rb:96:1:96:88 | synthetic splat argument |
+| params_flow.rb:96:16:96:17 | 45 | type tracker without call steps with content splat position 0 | params_flow.rb:96:10:96:18 | synthetic splat argument |
 | params_flow.rb:96:21:96:29 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:96:21:96:29 | call to taint | type tracker with call steps | params_flow.rb:69:17:69:17 | y |
-| params_flow.rb:96:21:96:29 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:96:21:96:29 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:96:21:96:29 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:71:5:71:10 | * |
-| params_flow.rb:96:21:96:29 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:96:21:96:29 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:96:21:96:29 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:96:21:96:29 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
+| params_flow.rb:96:21:96:29 | call to taint | type tracker with call steps with content splat position 1 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:21:96:29 | call to taint | type tracker without call steps | params_flow.rb:96:21:96:29 | call to taint |
-| params_flow.rb:96:21:96:29 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:96:1:96:88 | * |
+| params_flow.rb:96:21:96:29 | call to taint | type tracker without call steps with content splat position 1 | params_flow.rb:96:1:96:88 | synthetic splat argument |
+| params_flow.rb:96:21:96:29 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:96:21:96:29 | synthetic splat argument | type tracker without call steps | params_flow.rb:96:21:96:29 | synthetic splat argument |
 | params_flow.rb:96:27:96:28 | 46 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:27:96:28 | 46 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:96:27:96:28 | 46 | type tracker with call steps | params_flow.rb:69:17:69:17 | y |
-| params_flow.rb:96:27:96:28 | 46 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:96:27:96:28 | 46 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:96:27:96:28 | 46 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:96:27:96:28 | 46 | type tracker with call steps with content element 0 | params_flow.rb:71:5:71:10 | * |
-| params_flow.rb:96:27:96:28 | 46 | type tracker with call steps with content element 1 | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:96:27:96:28 | 46 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:96:27:96:28 | 46 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:96:27:96:28 | 46 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:96:27:96:28 | 46 | type tracker with call steps with content splat position 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
+| params_flow.rb:96:27:96:28 | 46 | type tracker with call steps with content splat position 1 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:27:96:28 | 46 | type tracker without call steps | params_flow.rb:96:21:96:29 | call to taint |
 | params_flow.rb:96:27:96:28 | 46 | type tracker without call steps | params_flow.rb:96:27:96:28 | 46 |
-| params_flow.rb:96:27:96:28 | 46 | type tracker without call steps with content element 0 | params_flow.rb:96:21:96:29 | * |
-| params_flow.rb:96:27:96:28 | 46 | type tracker without call steps with content element 1 | params_flow.rb:96:1:96:88 | * |
+| params_flow.rb:96:27:96:28 | 46 | type tracker without call steps with content splat position 0 | params_flow.rb:96:21:96:29 | synthetic splat argument |
+| params_flow.rb:96:27:96:28 | 46 | type tracker without call steps with content splat position 1 | params_flow.rb:96:1:96:88 | synthetic splat argument |
 | params_flow.rb:96:32:96:65 | * ... | type tracker without call steps | params_flow.rb:96:32:96:65 | * ... |
-| params_flow.rb:96:33:96:65 | * | type tracker without call steps | params_flow.rb:96:33:96:65 | * |
 | params_flow.rb:96:33:96:65 | Array | type tracker without call steps | params_flow.rb:96:33:96:65 | Array |
-| params_flow.rb:96:33:96:65 | call to [] | type tracker with call steps with content element 2 | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:96:33:96:65 | call to [] | type tracker with call steps with content splat position 2 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:33:96:65 | call to [] | type tracker without call steps | params_flow.rb:96:33:96:65 | call to [] |
 | params_flow.rb:96:33:96:65 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:96:32:96:65 | * ... |
-| params_flow.rb:96:33:96:65 | call to [] | type tracker without call steps with content element 2 | params_flow.rb:96:1:96:88 | * |
-| params_flow.rb:96:34:96:42 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:96:34:96:42 | * | type tracker without call steps | params_flow.rb:96:34:96:42 | * |
-| params_flow.rb:96:34:96:42 | call to taint | type tracker with call steps with content element 2 | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:96:33:96:65 | call to [] | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:96:1:96:88 | synthetic splat argument |
+| params_flow.rb:96:33:96:65 | synthetic splat argument | type tracker with call steps with content splat position 2 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:96:33:96:65 | synthetic splat argument | type tracker without call steps | params_flow.rb:96:33:96:65 | call to [] |
+| params_flow.rb:96:33:96:65 | synthetic splat argument | type tracker without call steps | params_flow.rb:96:33:96:65 | synthetic splat argument |
+| params_flow.rb:96:33:96:65 | synthetic splat argument | type tracker without call steps with content element 0 or unknown | params_flow.rb:96:32:96:65 | * ... |
+| params_flow.rb:96:33:96:65 | synthetic splat argument | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:96:1:96:88 | synthetic splat argument |
+| params_flow.rb:96:34:96:42 | call to taint | type tracker with call steps with content splat position 2 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:34:96:42 | call to taint | type tracker without call steps | params_flow.rb:96:34:96:42 | call to taint |
-| params_flow.rb:96:34:96:42 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:96:33:96:65 | * |
-| params_flow.rb:96:34:96:42 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:96:32:96:65 | * ... |
-| params_flow.rb:96:34:96:42 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:96:33:96:65 | call to [] |
-| params_flow.rb:96:34:96:42 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:96:1:96:88 | * |
+| params_flow.rb:96:34:96:42 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:96:32:96:65 | * ... |
+| params_flow.rb:96:34:96:42 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:96:33:96:65 | call to [] |
+| params_flow.rb:96:34:96:42 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:96:33:96:65 | synthetic splat argument |
+| params_flow.rb:96:34:96:42 | call to taint | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:96:1:96:88 | synthetic splat argument |
+| params_flow.rb:96:34:96:42 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:96:34:96:42 | synthetic splat argument | type tracker without call steps | params_flow.rb:96:34:96:42 | synthetic splat argument |
 | params_flow.rb:96:40:96:41 | 47 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:96:40:96:41 | 47 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:96:40:96:41 | 47 | type tracker with call steps with content element 2 | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:96:40:96:41 | 47 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:96:40:96:41 | 47 | type tracker with call steps with content splat position 2 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:40:96:41 | 47 | type tracker without call steps | params_flow.rb:96:34:96:42 | call to taint |
 | params_flow.rb:96:40:96:41 | 47 | type tracker without call steps | params_flow.rb:96:40:96:41 | 47 |
-| params_flow.rb:96:40:96:41 | 47 | type tracker without call steps with content element 0 | params_flow.rb:96:33:96:65 | * |
-| params_flow.rb:96:40:96:41 | 47 | type tracker without call steps with content element 0 | params_flow.rb:96:34:96:42 | * |
-| params_flow.rb:96:40:96:41 | 47 | type tracker without call steps with content element 0 or unknown | params_flow.rb:96:32:96:65 | * ... |
-| params_flow.rb:96:40:96:41 | 47 | type tracker without call steps with content element 0 or unknown | params_flow.rb:96:33:96:65 | call to [] |
-| params_flow.rb:96:40:96:41 | 47 | type tracker without call steps with content element 2 | params_flow.rb:96:1:96:88 | * |
-| params_flow.rb:96:45:96:53 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:96:45:96:53 | * | type tracker without call steps | params_flow.rb:96:45:96:53 | * |
-| params_flow.rb:96:45:96:53 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:96:45:96:53 | call to taint | type tracker with call steps | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:96:45:96:53 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:96:45:96:53 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:96:45:96:53 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:74:5:74:10 | * |
-| params_flow.rb:96:45:96:53 | call to taint | type tracker with call steps with content element 3 | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:96:40:96:41 | 47 | type tracker without call steps with content element 0 | params_flow.rb:96:32:96:65 | * ... |
+| params_flow.rb:96:40:96:41 | 47 | type tracker without call steps with content element 0 | params_flow.rb:96:33:96:65 | call to [] |
+| params_flow.rb:96:40:96:41 | 47 | type tracker without call steps with content element 0 | params_flow.rb:96:33:96:65 | synthetic splat argument |
+| params_flow.rb:96:40:96:41 | 47 | type tracker without call steps with content splat position 0 | params_flow.rb:96:34:96:42 | synthetic splat argument |
+| params_flow.rb:96:40:96:41 | 47 | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:96:1:96:88 | synthetic splat argument |
+| params_flow.rb:96:45:96:53 | call to taint | type tracker with call steps with content splat position 3 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:45:96:53 | call to taint | type tracker without call steps | params_flow.rb:96:45:96:53 | call to taint |
-| params_flow.rb:96:45:96:53 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:96:33:96:65 | * |
-| params_flow.rb:96:45:96:53 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:96:32:96:65 | * ... |
-| params_flow.rb:96:45:96:53 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:96:33:96:65 | call to [] |
-| params_flow.rb:96:45:96:53 | call to taint | type tracker without call steps with content element 3 | params_flow.rb:96:1:96:88 | * |
+| params_flow.rb:96:45:96:53 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:96:32:96:65 | * ... |
+| params_flow.rb:96:45:96:53 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:96:33:96:65 | call to [] |
+| params_flow.rb:96:45:96:53 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:96:33:96:65 | synthetic splat argument |
+| params_flow.rb:96:45:96:53 | call to taint | type tracker without call steps with content splat position 3 (shifted) | params_flow.rb:96:1:96:88 | synthetic splat argument |
+| params_flow.rb:96:45:96:53 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:96:45:96:53 | synthetic splat argument | type tracker without call steps | params_flow.rb:96:45:96:53 | synthetic splat argument |
 | params_flow.rb:96:51:96:52 | 48 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:96:51:96:52 | 48 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:96:51:96:52 | 48 | type tracker with call steps | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:96:51:96:52 | 48 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:96:51:96:52 | 48 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:96:51:96:52 | 48 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:96:51:96:52 | 48 | type tracker with call steps with content element 0 | params_flow.rb:74:5:74:10 | * |
-| params_flow.rb:96:51:96:52 | 48 | type tracker with call steps with content element 3 | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:96:51:96:52 | 48 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:96:51:96:52 | 48 | type tracker with call steps with content splat position 3 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:51:96:52 | 48 | type tracker without call steps | params_flow.rb:96:45:96:53 | call to taint |
 | params_flow.rb:96:51:96:52 | 48 | type tracker without call steps | params_flow.rb:96:51:96:52 | 48 |
-| params_flow.rb:96:51:96:52 | 48 | type tracker without call steps with content element 0 | params_flow.rb:96:45:96:53 | * |
-| params_flow.rb:96:51:96:52 | 48 | type tracker without call steps with content element 1 | params_flow.rb:96:33:96:65 | * |
-| params_flow.rb:96:51:96:52 | 48 | type tracker without call steps with content element 1 or unknown | params_flow.rb:96:32:96:65 | * ... |
-| params_flow.rb:96:51:96:52 | 48 | type tracker without call steps with content element 1 or unknown | params_flow.rb:96:33:96:65 | call to [] |
-| params_flow.rb:96:51:96:52 | 48 | type tracker without call steps with content element 3 | params_flow.rb:96:1:96:88 | * |
-| params_flow.rb:96:56:96:64 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:96:56:96:64 | * | type tracker without call steps | params_flow.rb:96:56:96:64 | * |
-| params_flow.rb:96:56:96:64 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:96:56:96:64 | call to taint | type tracker with call steps | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:96:56:96:64 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:96:56:96:64 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:96:56:96:64 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:75:5:75:10 | * |
-| params_flow.rb:96:56:96:64 | call to taint | type tracker with call steps with content element 4 | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:96:51:96:52 | 48 | type tracker without call steps with content element 1 | params_flow.rb:96:32:96:65 | * ... |
+| params_flow.rb:96:51:96:52 | 48 | type tracker without call steps with content element 1 | params_flow.rb:96:33:96:65 | call to [] |
+| params_flow.rb:96:51:96:52 | 48 | type tracker without call steps with content element 1 | params_flow.rb:96:33:96:65 | synthetic splat argument |
+| params_flow.rb:96:51:96:52 | 48 | type tracker without call steps with content splat position 0 | params_flow.rb:96:45:96:53 | synthetic splat argument |
+| params_flow.rb:96:51:96:52 | 48 | type tracker without call steps with content splat position 3 (shifted) | params_flow.rb:96:1:96:88 | synthetic splat argument |
+| params_flow.rb:96:56:96:64 | call to taint | type tracker with call steps with content splat position 4 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:56:96:64 | call to taint | type tracker without call steps | params_flow.rb:96:56:96:64 | call to taint |
-| params_flow.rb:96:56:96:64 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:96:33:96:65 | * |
-| params_flow.rb:96:56:96:64 | call to taint | type tracker without call steps with content element 2 or unknown | params_flow.rb:96:32:96:65 | * ... |
-| params_flow.rb:96:56:96:64 | call to taint | type tracker without call steps with content element 2 or unknown | params_flow.rb:96:33:96:65 | call to [] |
-| params_flow.rb:96:56:96:64 | call to taint | type tracker without call steps with content element 4 | params_flow.rb:96:1:96:88 | * |
+| params_flow.rb:96:56:96:64 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:96:32:96:65 | * ... |
+| params_flow.rb:96:56:96:64 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:96:33:96:65 | call to [] |
+| params_flow.rb:96:56:96:64 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:96:33:96:65 | synthetic splat argument |
+| params_flow.rb:96:56:96:64 | call to taint | type tracker without call steps with content splat position 4 (shifted) | params_flow.rb:96:1:96:88 | synthetic splat argument |
+| params_flow.rb:96:56:96:64 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:96:56:96:64 | synthetic splat argument | type tracker without call steps | params_flow.rb:96:56:96:64 | synthetic splat argument |
 | params_flow.rb:96:62:96:63 | 49 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:96:62:96:63 | 49 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:96:62:96:63 | 49 | type tracker with call steps | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:96:62:96:63 | 49 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:96:62:96:63 | 49 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:96:62:96:63 | 49 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:96:62:96:63 | 49 | type tracker with call steps with content element 0 | params_flow.rb:75:5:75:10 | * |
-| params_flow.rb:96:62:96:63 | 49 | type tracker with call steps with content element 4 | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:96:62:96:63 | 49 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:96:62:96:63 | 49 | type tracker with call steps with content splat position 4 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:62:96:63 | 49 | type tracker without call steps | params_flow.rb:96:56:96:64 | call to taint |
 | params_flow.rb:96:62:96:63 | 49 | type tracker without call steps | params_flow.rb:96:62:96:63 | 49 |
-| params_flow.rb:96:62:96:63 | 49 | type tracker without call steps with content element 0 | params_flow.rb:96:56:96:64 | * |
-| params_flow.rb:96:62:96:63 | 49 | type tracker without call steps with content element 2 | params_flow.rb:96:33:96:65 | * |
-| params_flow.rb:96:62:96:63 | 49 | type tracker without call steps with content element 2 or unknown | params_flow.rb:96:32:96:65 | * ... |
-| params_flow.rb:96:62:96:63 | 49 | type tracker without call steps with content element 2 or unknown | params_flow.rb:96:33:96:65 | call to [] |
-| params_flow.rb:96:62:96:63 | 49 | type tracker without call steps with content element 4 | params_flow.rb:96:1:96:88 | * |
-| params_flow.rb:96:68:96:76 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:96:68:96:76 | * | type tracker without call steps | params_flow.rb:96:68:96:76 | * |
+| params_flow.rb:96:62:96:63 | 49 | type tracker without call steps with content element 2 | params_flow.rb:96:32:96:65 | * ... |
+| params_flow.rb:96:62:96:63 | 49 | type tracker without call steps with content element 2 | params_flow.rb:96:33:96:65 | call to [] |
+| params_flow.rb:96:62:96:63 | 49 | type tracker without call steps with content element 2 | params_flow.rb:96:33:96:65 | synthetic splat argument |
+| params_flow.rb:96:62:96:63 | 49 | type tracker without call steps with content splat position 0 | params_flow.rb:96:56:96:64 | synthetic splat argument |
+| params_flow.rb:96:62:96:63 | 49 | type tracker without call steps with content splat position 4 (shifted) | params_flow.rb:96:1:96:88 | synthetic splat argument |
 | params_flow.rb:96:68:96:76 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:96:68:96:76 | call to taint | type tracker with call steps | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:96:68:96:76 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:96:68:96:76 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:96:68:96:76 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:74:5:74:10 | * |
-| params_flow.rb:96:68:96:76 | call to taint | type tracker with call steps with content element 3 | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:96:68:96:76 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:96:68:96:76 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:96:68:96:76 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:74:5:74:10 | synthetic splat argument |
 | params_flow.rb:96:68:96:76 | call to taint | type tracker without call steps | params_flow.rb:96:68:96:76 | call to taint |
-| params_flow.rb:96:68:96:76 | call to taint | type tracker without call steps with content element 3 | params_flow.rb:96:1:96:88 | * |
+| params_flow.rb:96:68:96:76 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:96:68:96:76 | synthetic splat argument | type tracker without call steps | params_flow.rb:96:68:96:76 | synthetic splat argument |
 | params_flow.rb:96:74:96:75 | 50 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:74:96:75 | 50 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:96:74:96:75 | 50 | type tracker with call steps | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:96:74:96:75 | 50 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:96:74:96:75 | 50 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:96:74:96:75 | 50 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:96:74:96:75 | 50 | type tracker with call steps with content element 0 | params_flow.rb:74:5:74:10 | * |
-| params_flow.rb:96:74:96:75 | 50 | type tracker with call steps with content element 3 | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:96:74:96:75 | 50 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:96:74:96:75 | 50 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:96:74:96:75 | 50 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:96:74:96:75 | 50 | type tracker with call steps with content splat position 0 | params_flow.rb:74:5:74:10 | synthetic splat argument |
 | params_flow.rb:96:74:96:75 | 50 | type tracker without call steps | params_flow.rb:96:68:96:76 | call to taint |
 | params_flow.rb:96:74:96:75 | 50 | type tracker without call steps | params_flow.rb:96:74:96:75 | 50 |
-| params_flow.rb:96:74:96:75 | 50 | type tracker without call steps with content element 0 | params_flow.rb:96:68:96:76 | * |
-| params_flow.rb:96:74:96:75 | 50 | type tracker without call steps with content element 3 | params_flow.rb:96:1:96:88 | * |
-| params_flow.rb:96:79:96:87 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:96:79:96:87 | * | type tracker without call steps | params_flow.rb:96:79:96:87 | * |
+| params_flow.rb:96:74:96:75 | 50 | type tracker without call steps with content splat position 0 | params_flow.rb:96:68:96:76 | synthetic splat argument |
 | params_flow.rb:96:79:96:87 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:96:79:96:87 | call to taint | type tracker with call steps | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:96:79:96:87 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:96:79:96:87 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:96:79:96:87 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:75:5:75:10 | * |
-| params_flow.rb:96:79:96:87 | call to taint | type tracker with call steps with content element 4 | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:96:79:96:87 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:96:79:96:87 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:96:79:96:87 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:75:5:75:10 | synthetic splat argument |
 | params_flow.rb:96:79:96:87 | call to taint | type tracker without call steps | params_flow.rb:96:79:96:87 | call to taint |
-| params_flow.rb:96:79:96:87 | call to taint | type tracker without call steps with content element 4 | params_flow.rb:96:1:96:88 | * |
+| params_flow.rb:96:79:96:87 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:96:79:96:87 | synthetic splat argument | type tracker without call steps | params_flow.rb:96:79:96:87 | synthetic splat argument |
 | params_flow.rb:96:85:96:86 | 51 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:85:96:86 | 51 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:96:85:96:86 | 51 | type tracker with call steps | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:96:85:96:86 | 51 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:96:85:96:86 | 51 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:96:85:96:86 | 51 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:96:85:96:86 | 51 | type tracker with call steps with content element 0 | params_flow.rb:75:5:75:10 | * |
-| params_flow.rb:96:85:96:86 | 51 | type tracker with call steps with content element 4 | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:96:85:96:86 | 51 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:96:85:96:86 | 51 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:96:85:96:86 | 51 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:96:85:96:86 | 51 | type tracker with call steps with content splat position 0 | params_flow.rb:75:5:75:10 | synthetic splat argument |
 | params_flow.rb:96:85:96:86 | 51 | type tracker without call steps | params_flow.rb:96:79:96:87 | call to taint |
 | params_flow.rb:96:85:96:86 | 51 | type tracker without call steps | params_flow.rb:96:85:96:86 | 51 |
-| params_flow.rb:96:85:96:86 | 51 | type tracker without call steps with content element 0 | params_flow.rb:96:79:96:87 | * |
-| params_flow.rb:96:85:96:86 | 51 | type tracker without call steps with content element 4 | params_flow.rb:96:1:96:88 | * |
+| params_flow.rb:96:85:96:86 | 51 | type tracker without call steps with content splat position 0 | params_flow.rb:96:79:96:87 | synthetic splat argument |
 | params_flow.rb:98:1:103:3 | &block | type tracker without call steps | params_flow.rb:98:1:103:3 | &block |
 | params_flow.rb:98:1:103:3 | self in splatmidsmall | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
 | params_flow.rb:98:1:103:3 | self in splatmidsmall | type tracker without call steps | params_flow.rb:98:1:103:3 | self in splatmidsmall |
 | params_flow.rb:98:1:103:3 | splatmidsmall | type tracker without call steps | params_flow.rb:98:1:103:3 | splatmidsmall |
-| params_flow.rb:98:1:103:3 | synthetic *args | type tracker without call steps | params_flow.rb:98:1:103:3 | synthetic *args |
+| params_flow.rb:98:1:103:3 | synthetic splat parameter | type tracker without call steps | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:98:19:98:19 | a | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:98:19:98:19 | a | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:98:19:98:19 | a | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:98:19:98:19 | a | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:98:19:98:19 | a | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:98:19:98:19 | a | type tracker without call steps | params_flow.rb:98:19:98:19 | a |
 | params_flow.rb:98:19:98:19 | a | type tracker without call steps | params_flow.rb:98:19:98:19 | a |
-| params_flow.rb:98:19:98:19 | a | type tracker without call steps with content element 0 | params_flow.rb:99:5:99:10 | * |
+| params_flow.rb:98:19:98:19 | a | type tracker without call steps with content splat position 0 | params_flow.rb:99:5:99:10 | synthetic splat argument |
 | params_flow.rb:98:22:98:28 | *splats | type tracker without call steps | params_flow.rb:98:22:98:28 | *splats |
 | params_flow.rb:98:23:98:28 | splats | type tracker without call steps | params_flow.rb:98:23:98:28 | splats |
 | params_flow.rb:98:31:98:31 | b | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:98:31:98:31 | b | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:98:31:98:31 | b | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:98:31:98:31 | b | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:98:31:98:31 | b | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:98:31:98:31 | b | type tracker without call steps | params_flow.rb:98:31:98:31 | b |
 | params_flow.rb:98:31:98:31 | b | type tracker without call steps | params_flow.rb:98:31:98:31 | b |
-| params_flow.rb:98:31:98:31 | b | type tracker without call steps with content element 0 | params_flow.rb:102:5:102:10 | * |
-| params_flow.rb:99:5:99:10 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:99:5:99:10 | * | type tracker without call steps | params_flow.rb:99:5:99:10 | * |
+| params_flow.rb:98:31:98:31 | b | type tracker without call steps with content splat position 0 | params_flow.rb:102:5:102:10 | synthetic splat argument |
 | params_flow.rb:99:5:99:10 | call to sink | type tracker without call steps | params_flow.rb:99:5:99:10 | call to sink |
-| params_flow.rb:100:5:100:18 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:100:5:100:18 | * | type tracker without call steps | params_flow.rb:100:5:100:18 | * |
+| params_flow.rb:99:5:99:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:99:5:99:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:99:5:99:10 | synthetic splat argument |
 | params_flow.rb:100:5:100:18 | call to sink | type tracker without call steps | params_flow.rb:100:5:100:18 | call to sink |
-| params_flow.rb:100:10:100:18 | * | type tracker without call steps | params_flow.rb:100:10:100:18 | * |
+| params_flow.rb:100:5:100:18 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:100:5:100:18 | synthetic splat argument | type tracker without call steps | params_flow.rb:100:5:100:18 | synthetic splat argument |
 | params_flow.rb:100:10:100:18 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:100:10:100:18 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:100:10:100:18 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:100:10:100:18 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:100:10:100:18 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:100:10:100:18 | ...[...] | type tracker without call steps | params_flow.rb:100:10:100:18 | ...[...] |
-| params_flow.rb:100:10:100:18 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:100:5:100:18 | * |
+| params_flow.rb:100:10:100:18 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:100:5:100:18 | synthetic splat argument |
+| params_flow.rb:100:10:100:18 | synthetic splat argument | type tracker without call steps | params_flow.rb:100:10:100:18 | synthetic splat argument |
 | params_flow.rb:100:17:100:17 | 0 | type tracker without call steps | params_flow.rb:100:17:100:17 | 0 |
-| params_flow.rb:100:17:100:17 | 0 | type tracker without call steps with content element 0 | params_flow.rb:100:10:100:18 | * |
-| params_flow.rb:101:5:101:18 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:101:5:101:18 | * | type tracker without call steps | params_flow.rb:101:5:101:18 | * |
+| params_flow.rb:100:17:100:17 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:100:10:100:18 | synthetic splat argument |
 | params_flow.rb:101:5:101:18 | call to sink | type tracker without call steps | params_flow.rb:101:5:101:18 | call to sink |
-| params_flow.rb:101:10:101:18 | * | type tracker without call steps | params_flow.rb:101:10:101:18 | * |
+| params_flow.rb:101:5:101:18 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:101:5:101:18 | synthetic splat argument | type tracker without call steps | params_flow.rb:101:5:101:18 | synthetic splat argument |
 | params_flow.rb:101:10:101:18 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:101:10:101:18 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:101:10:101:18 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:101:10:101:18 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:101:10:101:18 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:101:10:101:18 | ...[...] | type tracker without call steps | params_flow.rb:101:10:101:18 | ...[...] |
-| params_flow.rb:101:10:101:18 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:101:5:101:18 | * |
+| params_flow.rb:101:10:101:18 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:101:5:101:18 | synthetic splat argument |
+| params_flow.rb:101:10:101:18 | synthetic splat argument | type tracker without call steps | params_flow.rb:101:10:101:18 | synthetic splat argument |
 | params_flow.rb:101:17:101:17 | 1 | type tracker without call steps | params_flow.rb:101:17:101:17 | 1 |
-| params_flow.rb:101:17:101:17 | 1 | type tracker without call steps with content element 0 | params_flow.rb:101:10:101:18 | * |
-| params_flow.rb:102:5:102:10 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:102:5:102:10 | * | type tracker without call steps | params_flow.rb:102:5:102:10 | * |
+| params_flow.rb:101:17:101:17 | 1 | type tracker without call steps with content splat position 0 | params_flow.rb:101:10:101:18 | synthetic splat argument |
 | params_flow.rb:102:5:102:10 | call to sink | type tracker without call steps | params_flow.rb:102:5:102:10 | call to sink |
 | params_flow.rb:102:5:102:10 | call to sink | type tracker without call steps | params_flow.rb:105:1:105:49 | call to splatmidsmall |
 | params_flow.rb:102:5:102:10 | call to sink | type tracker without call steps | params_flow.rb:106:1:106:46 | call to splatmidsmall |
-| params_flow.rb:105:1:105:49 | * | type tracker with call steps | params_flow.rb:98:1:103:3 | synthetic *args |
-| params_flow.rb:105:1:105:49 | * | type tracker without call steps | params_flow.rb:105:1:105:49 | * |
+| params_flow.rb:102:5:102:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:102:5:102:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:102:5:102:10 | synthetic splat argument |
 | params_flow.rb:105:1:105:49 | call to splatmidsmall | type tracker without call steps | params_flow.rb:105:1:105:49 | call to splatmidsmall |
-| params_flow.rb:105:15:105:23 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:105:15:105:23 | * | type tracker without call steps | params_flow.rb:105:15:105:23 | * |
+| params_flow.rb:105:1:105:49 | synthetic splat argument | type tracker with call steps | params_flow.rb:98:1:103:3 | synthetic splat parameter |
+| params_flow.rb:105:1:105:49 | synthetic splat argument | type tracker without call steps | params_flow.rb:105:1:105:49 | synthetic splat argument |
 | params_flow.rb:105:15:105:23 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:105:15:105:23 | call to taint | type tracker with call steps | params_flow.rb:98:19:98:19 | a |
-| params_flow.rb:105:15:105:23 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:105:15:105:23 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:105:15:105:23 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:98:1:103:3 | synthetic *args |
-| params_flow.rb:105:15:105:23 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:99:5:99:10 | * |
+| params_flow.rb:105:15:105:23 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:105:15:105:23 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:105:15:105:23 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
+| params_flow.rb:105:15:105:23 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:99:5:99:10 | synthetic splat argument |
 | params_flow.rb:105:15:105:23 | call to taint | type tracker without call steps | params_flow.rb:105:15:105:23 | call to taint |
-| params_flow.rb:105:15:105:23 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:105:1:105:49 | * |
+| params_flow.rb:105:15:105:23 | call to taint | type tracker without call steps with content splat position 0 | params_flow.rb:105:1:105:49 | synthetic splat argument |
+| params_flow.rb:105:15:105:23 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:105:15:105:23 | synthetic splat argument | type tracker without call steps | params_flow.rb:105:15:105:23 | synthetic splat argument |
 | params_flow.rb:105:21:105:22 | 52 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:105:21:105:22 | 52 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:105:21:105:22 | 52 | type tracker with call steps | params_flow.rb:98:19:98:19 | a |
-| params_flow.rb:105:21:105:22 | 52 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:105:21:105:22 | 52 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:105:21:105:22 | 52 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:105:21:105:22 | 52 | type tracker with call steps with content element 0 | params_flow.rb:98:1:103:3 | synthetic *args |
-| params_flow.rb:105:21:105:22 | 52 | type tracker with call steps with content element 0 | params_flow.rb:99:5:99:10 | * |
+| params_flow.rb:105:21:105:22 | 52 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:105:21:105:22 | 52 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:105:21:105:22 | 52 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:105:21:105:22 | 52 | type tracker with call steps with content splat position 0 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
+| params_flow.rb:105:21:105:22 | 52 | type tracker with call steps with content splat position 0 | params_flow.rb:99:5:99:10 | synthetic splat argument |
 | params_flow.rb:105:21:105:22 | 52 | type tracker without call steps | params_flow.rb:105:15:105:23 | call to taint |
 | params_flow.rb:105:21:105:22 | 52 | type tracker without call steps | params_flow.rb:105:21:105:22 | 52 |
-| params_flow.rb:105:21:105:22 | 52 | type tracker without call steps with content element 0 | params_flow.rb:105:1:105:49 | * |
-| params_flow.rb:105:21:105:22 | 52 | type tracker without call steps with content element 0 | params_flow.rb:105:15:105:23 | * |
+| params_flow.rb:105:21:105:22 | 52 | type tracker without call steps with content splat position 0 | params_flow.rb:105:1:105:49 | synthetic splat argument |
+| params_flow.rb:105:21:105:22 | 52 | type tracker without call steps with content splat position 0 | params_flow.rb:105:15:105:23 | synthetic splat argument |
 | params_flow.rb:105:26:105:48 | * ... | type tracker without call steps | params_flow.rb:105:26:105:48 | * ... |
-| params_flow.rb:105:27:105:48 | * | type tracker without call steps | params_flow.rb:105:27:105:48 | * |
 | params_flow.rb:105:27:105:48 | Array | type tracker without call steps | params_flow.rb:105:27:105:48 | Array |
-| params_flow.rb:105:27:105:48 | call to [] | type tracker with call steps with content element 1 | params_flow.rb:98:1:103:3 | synthetic *args |
+| params_flow.rb:105:27:105:48 | call to [] | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:105:27:105:48 | call to [] | type tracker without call steps | params_flow.rb:105:27:105:48 | call to [] |
 | params_flow.rb:105:27:105:48 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:105:26:105:48 | * ... |
-| params_flow.rb:105:27:105:48 | call to [] | type tracker without call steps with content element 1 | params_flow.rb:105:1:105:49 | * |
-| params_flow.rb:105:28:105:36 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:105:28:105:36 | * | type tracker without call steps | params_flow.rb:105:28:105:36 | * |
-| params_flow.rb:105:28:105:36 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:98:1:103:3 | synthetic *args |
+| params_flow.rb:105:27:105:48 | call to [] | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:105:1:105:49 | synthetic splat argument |
+| params_flow.rb:105:27:105:48 | synthetic splat argument | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:98:1:103:3 | synthetic splat parameter |
+| params_flow.rb:105:27:105:48 | synthetic splat argument | type tracker without call steps | params_flow.rb:105:27:105:48 | call to [] |
+| params_flow.rb:105:27:105:48 | synthetic splat argument | type tracker without call steps | params_flow.rb:105:27:105:48 | synthetic splat argument |
+| params_flow.rb:105:27:105:48 | synthetic splat argument | type tracker without call steps with content element 0 or unknown | params_flow.rb:105:26:105:48 | * ... |
+| params_flow.rb:105:27:105:48 | synthetic splat argument | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:105:1:105:49 | synthetic splat argument |
+| params_flow.rb:105:28:105:36 | call to taint | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:105:28:105:36 | call to taint | type tracker without call steps | params_flow.rb:105:28:105:36 | call to taint |
-| params_flow.rb:105:28:105:36 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:105:27:105:48 | * |
-| params_flow.rb:105:28:105:36 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:105:26:105:48 | * ... |
-| params_flow.rb:105:28:105:36 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:105:27:105:48 | call to [] |
-| params_flow.rb:105:28:105:36 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:105:1:105:49 | * |
+| params_flow.rb:105:28:105:36 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:105:26:105:48 | * ... |
+| params_flow.rb:105:28:105:36 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:105:27:105:48 | call to [] |
+| params_flow.rb:105:28:105:36 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:105:27:105:48 | synthetic splat argument |
+| params_flow.rb:105:28:105:36 | call to taint | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:105:1:105:49 | synthetic splat argument |
+| params_flow.rb:105:28:105:36 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:105:28:105:36 | synthetic splat argument | type tracker without call steps | params_flow.rb:105:28:105:36 | synthetic splat argument |
 | params_flow.rb:105:34:105:35 | 53 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:105:34:105:35 | 53 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:105:34:105:35 | 53 | type tracker with call steps with content element 1 | params_flow.rb:98:1:103:3 | synthetic *args |
+| params_flow.rb:105:34:105:35 | 53 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:105:34:105:35 | 53 | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:105:34:105:35 | 53 | type tracker without call steps | params_flow.rb:105:28:105:36 | call to taint |
 | params_flow.rb:105:34:105:35 | 53 | type tracker without call steps | params_flow.rb:105:34:105:35 | 53 |
-| params_flow.rb:105:34:105:35 | 53 | type tracker without call steps with content element 0 | params_flow.rb:105:27:105:48 | * |
-| params_flow.rb:105:34:105:35 | 53 | type tracker without call steps with content element 0 | params_flow.rb:105:28:105:36 | * |
-| params_flow.rb:105:34:105:35 | 53 | type tracker without call steps with content element 0 or unknown | params_flow.rb:105:26:105:48 | * ... |
-| params_flow.rb:105:34:105:35 | 53 | type tracker without call steps with content element 0 or unknown | params_flow.rb:105:27:105:48 | call to [] |
-| params_flow.rb:105:34:105:35 | 53 | type tracker without call steps with content element 1 | params_flow.rb:105:1:105:49 | * |
-| params_flow.rb:105:39:105:47 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:105:39:105:47 | * | type tracker without call steps | params_flow.rb:105:39:105:47 | * |
-| params_flow.rb:105:39:105:47 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:105:39:105:47 | call to taint | type tracker with call steps | params_flow.rb:98:31:98:31 | b |
-| params_flow.rb:105:39:105:47 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:105:39:105:47 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:105:39:105:47 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:102:5:102:10 | * |
-| params_flow.rb:105:39:105:47 | call to taint | type tracker with call steps with content element 2 | params_flow.rb:98:1:103:3 | synthetic *args |
+| params_flow.rb:105:34:105:35 | 53 | type tracker without call steps with content element 0 | params_flow.rb:105:26:105:48 | * ... |
+| params_flow.rb:105:34:105:35 | 53 | type tracker without call steps with content element 0 | params_flow.rb:105:27:105:48 | call to [] |
+| params_flow.rb:105:34:105:35 | 53 | type tracker without call steps with content element 0 | params_flow.rb:105:27:105:48 | synthetic splat argument |
+| params_flow.rb:105:34:105:35 | 53 | type tracker without call steps with content splat position 0 | params_flow.rb:105:28:105:36 | synthetic splat argument |
+| params_flow.rb:105:34:105:35 | 53 | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:105:1:105:49 | synthetic splat argument |
+| params_flow.rb:105:39:105:47 | call to taint | type tracker with call steps with content splat position 2 (shifted) | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:105:39:105:47 | call to taint | type tracker without call steps | params_flow.rb:105:39:105:47 | call to taint |
-| params_flow.rb:105:39:105:47 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:105:27:105:48 | * |
-| params_flow.rb:105:39:105:47 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:105:26:105:48 | * ... |
-| params_flow.rb:105:39:105:47 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:105:27:105:48 | call to [] |
-| params_flow.rb:105:39:105:47 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:105:1:105:49 | * |
+| params_flow.rb:105:39:105:47 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:105:26:105:48 | * ... |
+| params_flow.rb:105:39:105:47 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:105:27:105:48 | call to [] |
+| params_flow.rb:105:39:105:47 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:105:27:105:48 | synthetic splat argument |
+| params_flow.rb:105:39:105:47 | call to taint | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:105:1:105:49 | synthetic splat argument |
+| params_flow.rb:105:39:105:47 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:105:39:105:47 | synthetic splat argument | type tracker without call steps | params_flow.rb:105:39:105:47 | synthetic splat argument |
 | params_flow.rb:105:45:105:46 | 54 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:105:45:105:46 | 54 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:105:45:105:46 | 54 | type tracker with call steps | params_flow.rb:98:31:98:31 | b |
-| params_flow.rb:105:45:105:46 | 54 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:105:45:105:46 | 54 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:105:45:105:46 | 54 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:105:45:105:46 | 54 | type tracker with call steps with content element 0 | params_flow.rb:102:5:102:10 | * |
-| params_flow.rb:105:45:105:46 | 54 | type tracker with call steps with content element 2 | params_flow.rb:98:1:103:3 | synthetic *args |
+| params_flow.rb:105:45:105:46 | 54 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:105:45:105:46 | 54 | type tracker with call steps with content splat position 2 (shifted) | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:105:45:105:46 | 54 | type tracker without call steps | params_flow.rb:105:39:105:47 | call to taint |
 | params_flow.rb:105:45:105:46 | 54 | type tracker without call steps | params_flow.rb:105:45:105:46 | 54 |
-| params_flow.rb:105:45:105:46 | 54 | type tracker without call steps with content element 0 | params_flow.rb:105:39:105:47 | * |
-| params_flow.rb:105:45:105:46 | 54 | type tracker without call steps with content element 1 | params_flow.rb:105:27:105:48 | * |
-| params_flow.rb:105:45:105:46 | 54 | type tracker without call steps with content element 1 or unknown | params_flow.rb:105:26:105:48 | * ... |
-| params_flow.rb:105:45:105:46 | 54 | type tracker without call steps with content element 1 or unknown | params_flow.rb:105:27:105:48 | call to [] |
-| params_flow.rb:105:45:105:46 | 54 | type tracker without call steps with content element 2 | params_flow.rb:105:1:105:49 | * |
-| params_flow.rb:106:1:106:46 | * | type tracker with call steps | params_flow.rb:98:1:103:3 | synthetic *args |
-| params_flow.rb:106:1:106:46 | * | type tracker without call steps | params_flow.rb:106:1:106:46 | * |
+| params_flow.rb:105:45:105:46 | 54 | type tracker without call steps with content element 1 | params_flow.rb:105:26:105:48 | * ... |
+| params_flow.rb:105:45:105:46 | 54 | type tracker without call steps with content element 1 | params_flow.rb:105:27:105:48 | call to [] |
+| params_flow.rb:105:45:105:46 | 54 | type tracker without call steps with content element 1 | params_flow.rb:105:27:105:48 | synthetic splat argument |
+| params_flow.rb:105:45:105:46 | 54 | type tracker without call steps with content splat position 0 | params_flow.rb:105:39:105:47 | synthetic splat argument |
+| params_flow.rb:105:45:105:46 | 54 | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:105:1:105:49 | synthetic splat argument |
 | params_flow.rb:106:1:106:46 | call to splatmidsmall | type tracker without call steps | params_flow.rb:106:1:106:46 | call to splatmidsmall |
-| params_flow.rb:106:15:106:23 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:106:15:106:23 | * | type tracker without call steps | params_flow.rb:106:15:106:23 | * |
+| params_flow.rb:106:1:106:46 | synthetic splat argument | type tracker with call steps | params_flow.rb:98:1:103:3 | synthetic splat parameter |
+| params_flow.rb:106:1:106:46 | synthetic splat argument | type tracker without call steps | params_flow.rb:106:1:106:46 | synthetic splat argument |
 | params_flow.rb:106:15:106:23 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:106:15:106:23 | call to taint | type tracker with call steps | params_flow.rb:98:19:98:19 | a |
-| params_flow.rb:106:15:106:23 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:106:15:106:23 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:106:15:106:23 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:98:1:103:3 | synthetic *args |
-| params_flow.rb:106:15:106:23 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:99:5:99:10 | * |
+| params_flow.rb:106:15:106:23 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:106:15:106:23 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:106:15:106:23 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
+| params_flow.rb:106:15:106:23 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:99:5:99:10 | synthetic splat argument |
 | params_flow.rb:106:15:106:23 | call to taint | type tracker without call steps | params_flow.rb:106:15:106:23 | call to taint |
-| params_flow.rb:106:15:106:23 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:106:1:106:46 | * |
+| params_flow.rb:106:15:106:23 | call to taint | type tracker without call steps with content splat position 0 | params_flow.rb:106:1:106:46 | synthetic splat argument |
+| params_flow.rb:106:15:106:23 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:106:15:106:23 | synthetic splat argument | type tracker without call steps | params_flow.rb:106:15:106:23 | synthetic splat argument |
 | params_flow.rb:106:21:106:22 | 55 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:106:21:106:22 | 55 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:106:21:106:22 | 55 | type tracker with call steps | params_flow.rb:98:19:98:19 | a |
-| params_flow.rb:106:21:106:22 | 55 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:106:21:106:22 | 55 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:106:21:106:22 | 55 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:106:21:106:22 | 55 | type tracker with call steps with content element 0 | params_flow.rb:98:1:103:3 | synthetic *args |
-| params_flow.rb:106:21:106:22 | 55 | type tracker with call steps with content element 0 | params_flow.rb:99:5:99:10 | * |
+| params_flow.rb:106:21:106:22 | 55 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:106:21:106:22 | 55 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:106:21:106:22 | 55 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:106:21:106:22 | 55 | type tracker with call steps with content splat position 0 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
+| params_flow.rb:106:21:106:22 | 55 | type tracker with call steps with content splat position 0 | params_flow.rb:99:5:99:10 | synthetic splat argument |
 | params_flow.rb:106:21:106:22 | 55 | type tracker without call steps | params_flow.rb:106:15:106:23 | call to taint |
 | params_flow.rb:106:21:106:22 | 55 | type tracker without call steps | params_flow.rb:106:21:106:22 | 55 |
-| params_flow.rb:106:21:106:22 | 55 | type tracker without call steps with content element 0 | params_flow.rb:106:1:106:46 | * |
-| params_flow.rb:106:21:106:22 | 55 | type tracker without call steps with content element 0 | params_flow.rb:106:15:106:23 | * |
-| params_flow.rb:106:26:106:34 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:106:26:106:34 | * | type tracker without call steps | params_flow.rb:106:26:106:34 | * |
-| params_flow.rb:106:26:106:34 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:98:1:103:3 | synthetic *args |
+| params_flow.rb:106:21:106:22 | 55 | type tracker without call steps with content splat position 0 | params_flow.rb:106:1:106:46 | synthetic splat argument |
+| params_flow.rb:106:21:106:22 | 55 | type tracker without call steps with content splat position 0 | params_flow.rb:106:15:106:23 | synthetic splat argument |
+| params_flow.rb:106:26:106:34 | call to taint | type tracker with call steps with content splat position 1 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:106:26:106:34 | call to taint | type tracker without call steps | params_flow.rb:106:26:106:34 | call to taint |
-| params_flow.rb:106:26:106:34 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:106:1:106:46 | * |
+| params_flow.rb:106:26:106:34 | call to taint | type tracker without call steps with content splat position 1 | params_flow.rb:106:1:106:46 | synthetic splat argument |
+| params_flow.rb:106:26:106:34 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:106:26:106:34 | synthetic splat argument | type tracker without call steps | params_flow.rb:106:26:106:34 | synthetic splat argument |
 | params_flow.rb:106:32:106:33 | 56 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:106:32:106:33 | 56 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:106:32:106:33 | 56 | type tracker with call steps with content element 1 | params_flow.rb:98:1:103:3 | synthetic *args |
+| params_flow.rb:106:32:106:33 | 56 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:106:32:106:33 | 56 | type tracker with call steps with content splat position 1 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:106:32:106:33 | 56 | type tracker without call steps | params_flow.rb:106:26:106:34 | call to taint |
 | params_flow.rb:106:32:106:33 | 56 | type tracker without call steps | params_flow.rb:106:32:106:33 | 56 |
-| params_flow.rb:106:32:106:33 | 56 | type tracker without call steps with content element 0 | params_flow.rb:106:26:106:34 | * |
-| params_flow.rb:106:32:106:33 | 56 | type tracker without call steps with content element 1 | params_flow.rb:106:1:106:46 | * |
-| params_flow.rb:106:37:106:45 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:106:37:106:45 | * | type tracker without call steps | params_flow.rb:106:37:106:45 | * |
+| params_flow.rb:106:32:106:33 | 56 | type tracker without call steps with content splat position 0 | params_flow.rb:106:26:106:34 | synthetic splat argument |
+| params_flow.rb:106:32:106:33 | 56 | type tracker without call steps with content splat position 1 | params_flow.rb:106:1:106:46 | synthetic splat argument |
 | params_flow.rb:106:37:106:45 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:106:37:106:45 | call to taint | type tracker with call steps | params_flow.rb:98:31:98:31 | b |
-| params_flow.rb:106:37:106:45 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:106:37:106:45 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:106:37:106:45 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:102:5:102:10 | * |
-| params_flow.rb:106:37:106:45 | call to taint | type tracker with call steps with content element 2 | params_flow.rb:98:1:103:3 | synthetic *args |
+| params_flow.rb:106:37:106:45 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:106:37:106:45 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:106:37:106:45 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:102:5:102:10 | synthetic splat argument |
+| params_flow.rb:106:37:106:45 | call to taint | type tracker with call steps with content splat position 2 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:106:37:106:45 | call to taint | type tracker without call steps | params_flow.rb:106:37:106:45 | call to taint |
-| params_flow.rb:106:37:106:45 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:106:1:106:46 | * |
+| params_flow.rb:106:37:106:45 | call to taint | type tracker without call steps with content splat position 2 | params_flow.rb:106:1:106:46 | synthetic splat argument |
+| params_flow.rb:106:37:106:45 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:106:37:106:45 | synthetic splat argument | type tracker without call steps | params_flow.rb:106:37:106:45 | synthetic splat argument |
 | params_flow.rb:106:43:106:44 | 57 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:106:43:106:44 | 57 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:106:43:106:44 | 57 | type tracker with call steps | params_flow.rb:98:31:98:31 | b |
-| params_flow.rb:106:43:106:44 | 57 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:106:43:106:44 | 57 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:106:43:106:44 | 57 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:106:43:106:44 | 57 | type tracker with call steps with content element 0 | params_flow.rb:102:5:102:10 | * |
-| params_flow.rb:106:43:106:44 | 57 | type tracker with call steps with content element 2 | params_flow.rb:98:1:103:3 | synthetic *args |
+| params_flow.rb:106:43:106:44 | 57 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:106:43:106:44 | 57 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:106:43:106:44 | 57 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:106:43:106:44 | 57 | type tracker with call steps with content splat position 0 | params_flow.rb:102:5:102:10 | synthetic splat argument |
+| params_flow.rb:106:43:106:44 | 57 | type tracker with call steps with content splat position 2 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:106:43:106:44 | 57 | type tracker without call steps | params_flow.rb:106:37:106:45 | call to taint |
 | params_flow.rb:106:43:106:44 | 57 | type tracker without call steps | params_flow.rb:106:43:106:44 | 57 |
-| params_flow.rb:106:43:106:44 | 57 | type tracker without call steps with content element 0 | params_flow.rb:106:37:106:45 | * |
-| params_flow.rb:106:43:106:44 | 57 | type tracker without call steps with content element 2 | params_flow.rb:106:1:106:46 | * |
+| params_flow.rb:106:43:106:44 | 57 | type tracker without call steps with content splat position 0 | params_flow.rb:106:37:106:45 | synthetic splat argument |
+| params_flow.rb:106:43:106:44 | 57 | type tracker without call steps with content splat position 2 | params_flow.rb:106:1:106:46 | synthetic splat argument |
 | params_flow.rb:108:1:112:3 | &block | type tracker without call steps | params_flow.rb:108:1:112:3 | &block |
-| params_flow.rb:108:1:112:3 | **kwargs | type tracker without call steps | params_flow.rb:108:1:112:3 | **kwargs |
 | params_flow.rb:108:1:112:3 | self in splat_followed_by_keyword_param | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
 | params_flow.rb:108:1:112:3 | self in splat_followed_by_keyword_param | type tracker without call steps | params_flow.rb:108:1:112:3 | self in splat_followed_by_keyword_param |
 | params_flow.rb:108:1:112:3 | splat_followed_by_keyword_param | type tracker without call steps | params_flow.rb:108:1:112:3 | splat_followed_by_keyword_param |
-| params_flow.rb:108:1:112:3 | synthetic *args | type tracker without call steps | params_flow.rb:108:1:112:3 | synthetic *args |
+| params_flow.rb:108:1:112:3 | synthetic hash-splat parameter | type tracker without call steps | params_flow.rb:108:1:112:3 | synthetic hash-splat parameter |
+| params_flow.rb:108:1:112:3 | synthetic splat parameter | type tracker without call steps | params_flow.rb:108:1:112:3 | synthetic splat parameter |
 | params_flow.rb:108:37:108:37 | a | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:108:37:108:37 | a | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:108:37:108:37 | a | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:108:37:108:37 | a | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:108:37:108:37 | a | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:108:37:108:37 | a | type tracker without call steps | params_flow.rb:108:37:108:37 | a |
 | params_flow.rb:108:37:108:37 | a | type tracker without call steps | params_flow.rb:108:37:108:37 | a |
-| params_flow.rb:108:37:108:37 | a | type tracker without call steps with content element 0 | params_flow.rb:109:5:109:10 | * |
+| params_flow.rb:108:37:108:37 | a | type tracker without call steps with content splat position 0 | params_flow.rb:109:5:109:10 | synthetic splat argument |
 | params_flow.rb:108:40:108:41 | *b | type tracker without call steps | params_flow.rb:108:40:108:41 | *b |
 | params_flow.rb:108:41:108:41 | b | type tracker without call steps | params_flow.rb:108:41:108:41 | b |
 | params_flow.rb:108:44:108:44 | c | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:108:44:108:44 | c | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:108:44:108:44 | c | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:108:44:108:44 | c | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:108:44:108:44 | c | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:108:44:108:44 | c | type tracker without call steps | params_flow.rb:108:44:108:44 | c |
 | params_flow.rb:108:44:108:44 | c | type tracker without call steps | params_flow.rb:108:44:108:44 | c |
-| params_flow.rb:108:44:108:44 | c | type tracker without call steps with content element 0 | params_flow.rb:111:5:111:10 | * |
-| params_flow.rb:109:5:109:10 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:109:5:109:10 | * | type tracker without call steps | params_flow.rb:109:5:109:10 | * |
+| params_flow.rb:108:44:108:44 | c | type tracker without call steps with content splat position 0 | params_flow.rb:111:5:111:10 | synthetic splat argument |
 | params_flow.rb:109:5:109:10 | call to sink | type tracker without call steps | params_flow.rb:109:5:109:10 | call to sink |
-| params_flow.rb:110:5:110:13 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:110:5:110:13 | * | type tracker without call steps | params_flow.rb:110:5:110:13 | * |
+| params_flow.rb:109:5:109:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:109:5:109:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:109:5:109:10 | synthetic splat argument |
 | params_flow.rb:110:5:110:13 | call to sink | type tracker without call steps | params_flow.rb:110:5:110:13 | call to sink |
-| params_flow.rb:110:10:110:13 | * | type tracker without call steps | params_flow.rb:110:10:110:13 | * |
+| params_flow.rb:110:5:110:13 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:110:5:110:13 | synthetic splat argument | type tracker without call steps | params_flow.rb:110:5:110:13 | synthetic splat argument |
 | params_flow.rb:110:10:110:13 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:110:10:110:13 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:110:10:110:13 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:110:10:110:13 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:110:10:110:13 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:110:10:110:13 | ...[...] | type tracker without call steps | params_flow.rb:110:10:110:13 | ...[...] |
-| params_flow.rb:110:10:110:13 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:110:5:110:13 | * |
+| params_flow.rb:110:10:110:13 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:110:5:110:13 | synthetic splat argument |
+| params_flow.rb:110:10:110:13 | synthetic splat argument | type tracker without call steps | params_flow.rb:110:10:110:13 | synthetic splat argument |
 | params_flow.rb:110:12:110:12 | 0 | type tracker without call steps | params_flow.rb:110:12:110:12 | 0 |
-| params_flow.rb:110:12:110:12 | 0 | type tracker without call steps with content element 0 | params_flow.rb:110:10:110:13 | * |
-| params_flow.rb:111:5:111:10 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:111:5:111:10 | * | type tracker without call steps | params_flow.rb:111:5:111:10 | * |
+| params_flow.rb:110:12:110:12 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:110:10:110:13 | synthetic splat argument |
 | params_flow.rb:111:5:111:10 | call to sink | type tracker without call steps | params_flow.rb:111:5:111:10 | call to sink |
 | params_flow.rb:111:5:111:10 | call to sink | type tracker without call steps | params_flow.rb:114:1:114:67 | call to splat_followed_by_keyword_param |
-| params_flow.rb:114:1:114:67 | * | type tracker with call steps | params_flow.rb:108:1:112:3 | synthetic *args |
-| params_flow.rb:114:1:114:67 | * | type tracker without call steps | params_flow.rb:114:1:114:67 | * |
-| params_flow.rb:114:1:114:67 | ** | type tracker with call steps | params_flow.rb:108:1:112:3 | **kwargs |
-| params_flow.rb:114:1:114:67 | ** | type tracker without call steps | params_flow.rb:114:1:114:67 | ** |
+| params_flow.rb:111:5:111:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:111:5:111:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:111:5:111:10 | synthetic splat argument |
 | params_flow.rb:114:1:114:67 | call to splat_followed_by_keyword_param | type tracker without call steps | params_flow.rb:114:1:114:67 | call to splat_followed_by_keyword_param |
-| params_flow.rb:114:33:114:41 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:114:33:114:41 | * | type tracker without call steps | params_flow.rb:114:33:114:41 | * |
+| params_flow.rb:114:1:114:67 | synthetic hash-splat argument | type tracker with call steps | params_flow.rb:108:1:112:3 | synthetic hash-splat parameter |
+| params_flow.rb:114:1:114:67 | synthetic hash-splat argument | type tracker without call steps | params_flow.rb:114:1:114:67 | synthetic hash-splat argument |
+| params_flow.rb:114:1:114:67 | synthetic splat argument | type tracker with call steps | params_flow.rb:108:1:112:3 | synthetic splat parameter |
+| params_flow.rb:114:1:114:67 | synthetic splat argument | type tracker without call steps | params_flow.rb:114:1:114:67 | synthetic splat argument |
 | params_flow.rb:114:33:114:41 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:114:33:114:41 | call to taint | type tracker with call steps | params_flow.rb:108:37:108:37 | a |
-| params_flow.rb:114:33:114:41 | call to taint | type tracker with call steps | params_flow.rb:110:10:110:13 | ...[...] |
-| params_flow.rb:114:33:114:41 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:114:33:114:41 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:114:33:114:41 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:108:1:112:3 | synthetic *args |
-| params_flow.rb:114:33:114:41 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:108:40:108:41 | *b |
-| params_flow.rb:114:33:114:41 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:109:5:109:10 | * |
-| params_flow.rb:114:33:114:41 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:110:5:110:13 | * |
+| params_flow.rb:114:33:114:41 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:114:33:114:41 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:114:33:114:41 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:108:1:112:3 | synthetic splat parameter |
+| params_flow.rb:114:33:114:41 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:109:5:109:10 | synthetic splat argument |
 | params_flow.rb:114:33:114:41 | call to taint | type tracker without call steps | params_flow.rb:114:33:114:41 | call to taint |
-| params_flow.rb:114:33:114:41 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:114:1:114:67 | * |
+| params_flow.rb:114:33:114:41 | call to taint | type tracker without call steps with content splat position 0 | params_flow.rb:114:1:114:67 | synthetic splat argument |
+| params_flow.rb:114:33:114:41 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:114:33:114:41 | synthetic splat argument | type tracker without call steps | params_flow.rb:114:33:114:41 | synthetic splat argument |
 | params_flow.rb:114:39:114:40 | 58 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:114:39:114:40 | 58 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:114:39:114:40 | 58 | type tracker with call steps | params_flow.rb:108:37:108:37 | a |
-| params_flow.rb:114:39:114:40 | 58 | type tracker with call steps | params_flow.rb:110:10:110:13 | ...[...] |
-| params_flow.rb:114:39:114:40 | 58 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:114:39:114:40 | 58 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:114:39:114:40 | 58 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:114:39:114:40 | 58 | type tracker with call steps with content element 0 | params_flow.rb:108:1:112:3 | synthetic *args |
-| params_flow.rb:114:39:114:40 | 58 | type tracker with call steps with content element 0 | params_flow.rb:108:40:108:41 | *b |
-| params_flow.rb:114:39:114:40 | 58 | type tracker with call steps with content element 0 | params_flow.rb:109:5:109:10 | * |
-| params_flow.rb:114:39:114:40 | 58 | type tracker with call steps with content element 0 | params_flow.rb:110:5:110:13 | * |
+| params_flow.rb:114:39:114:40 | 58 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:114:39:114:40 | 58 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:114:39:114:40 | 58 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:114:39:114:40 | 58 | type tracker with call steps with content splat position 0 | params_flow.rb:108:1:112:3 | synthetic splat parameter |
+| params_flow.rb:114:39:114:40 | 58 | type tracker with call steps with content splat position 0 | params_flow.rb:109:5:109:10 | synthetic splat argument |
 | params_flow.rb:114:39:114:40 | 58 | type tracker without call steps | params_flow.rb:114:33:114:41 | call to taint |
 | params_flow.rb:114:39:114:40 | 58 | type tracker without call steps | params_flow.rb:114:39:114:40 | 58 |
-| params_flow.rb:114:39:114:40 | 58 | type tracker without call steps with content element 0 | params_flow.rb:114:1:114:67 | * |
-| params_flow.rb:114:39:114:40 | 58 | type tracker without call steps with content element 0 | params_flow.rb:114:33:114:41 | * |
-| params_flow.rb:114:44:114:52 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:114:44:114:52 | * | type tracker without call steps | params_flow.rb:114:44:114:52 | * |
-| params_flow.rb:114:44:114:52 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:108:1:112:3 | synthetic *args |
-| params_flow.rb:114:44:114:52 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:108:40:108:41 | *b |
+| params_flow.rb:114:39:114:40 | 58 | type tracker without call steps with content splat position 0 | params_flow.rb:114:1:114:67 | synthetic splat argument |
+| params_flow.rb:114:39:114:40 | 58 | type tracker without call steps with content splat position 0 | params_flow.rb:114:33:114:41 | synthetic splat argument |
+| params_flow.rb:114:44:114:52 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:114:44:114:52 | call to taint | type tracker with call steps | params_flow.rb:110:10:110:13 | ...[...] |
+| params_flow.rb:114:44:114:52 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:108:40:108:41 | *b |
+| params_flow.rb:114:44:114:52 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:114:44:114:52 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:114:44:114:52 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:110:5:110:13 | synthetic splat argument |
+| params_flow.rb:114:44:114:52 | call to taint | type tracker with call steps with content splat position 1 | params_flow.rb:108:1:112:3 | synthetic splat parameter |
 | params_flow.rb:114:44:114:52 | call to taint | type tracker without call steps | params_flow.rb:114:44:114:52 | call to taint |
-| params_flow.rb:114:44:114:52 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:114:1:114:67 | * |
+| params_flow.rb:114:44:114:52 | call to taint | type tracker without call steps with content splat position 1 | params_flow.rb:114:1:114:67 | synthetic splat argument |
+| params_flow.rb:114:44:114:52 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:114:44:114:52 | synthetic splat argument | type tracker without call steps | params_flow.rb:114:44:114:52 | synthetic splat argument |
 | params_flow.rb:114:50:114:51 | 59 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:114:50:114:51 | 59 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:114:50:114:51 | 59 | type tracker with call steps with content element 1 | params_flow.rb:108:1:112:3 | synthetic *args |
-| params_flow.rb:114:50:114:51 | 59 | type tracker with call steps with content element 1 | params_flow.rb:108:40:108:41 | *b |
+| params_flow.rb:114:50:114:51 | 59 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:114:50:114:51 | 59 | type tracker with call steps | params_flow.rb:110:10:110:13 | ...[...] |
+| params_flow.rb:114:50:114:51 | 59 | type tracker with call steps with content element 0 | params_flow.rb:108:40:108:41 | *b |
+| params_flow.rb:114:50:114:51 | 59 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:114:50:114:51 | 59 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:114:50:114:51 | 59 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:114:50:114:51 | 59 | type tracker with call steps with content splat position 0 | params_flow.rb:110:5:110:13 | synthetic splat argument |
+| params_flow.rb:114:50:114:51 | 59 | type tracker with call steps with content splat position 1 | params_flow.rb:108:1:112:3 | synthetic splat parameter |
 | params_flow.rb:114:50:114:51 | 59 | type tracker without call steps | params_flow.rb:114:44:114:52 | call to taint |
 | params_flow.rb:114:50:114:51 | 59 | type tracker without call steps | params_flow.rb:114:50:114:51 | 59 |
-| params_flow.rb:114:50:114:51 | 59 | type tracker without call steps with content element 0 | params_flow.rb:114:44:114:52 | * |
-| params_flow.rb:114:50:114:51 | 59 | type tracker without call steps with content element 1 | params_flow.rb:114:1:114:67 | * |
+| params_flow.rb:114:50:114:51 | 59 | type tracker without call steps with content splat position 0 | params_flow.rb:114:44:114:52 | synthetic splat argument |
+| params_flow.rb:114:50:114:51 | 59 | type tracker without call steps with content splat position 1 | params_flow.rb:114:1:114:67 | synthetic splat argument |
 | params_flow.rb:114:55:114:55 | :c | type tracker without call steps | params_flow.rb:114:55:114:55 | :c |
 | params_flow.rb:114:55:114:66 | Pair | type tracker without call steps | params_flow.rb:114:55:114:66 | Pair |
-| params_flow.rb:114:58:114:66 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:114:58:114:66 | * | type tracker without call steps | params_flow.rb:114:58:114:66 | * |
 | params_flow.rb:114:58:114:66 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:114:58:114:66 | call to taint | type tracker with call steps | params_flow.rb:108:44:108:44 | c |
-| params_flow.rb:114:58:114:66 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:114:58:114:66 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:114:58:114:66 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:111:5:111:10 | * |
-| params_flow.rb:114:58:114:66 | call to taint | type tracker with call steps with content element :c | params_flow.rb:108:1:112:3 | **kwargs |
+| params_flow.rb:114:58:114:66 | call to taint | type tracker with call steps with content hash-splat position :c | params_flow.rb:108:1:112:3 | synthetic hash-splat parameter |
+| params_flow.rb:114:58:114:66 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:114:58:114:66 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:114:58:114:66 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:111:5:111:10 | synthetic splat argument |
 | params_flow.rb:114:58:114:66 | call to taint | type tracker without call steps | params_flow.rb:114:58:114:66 | call to taint |
-| params_flow.rb:114:58:114:66 | call to taint | type tracker without call steps with content element :c | params_flow.rb:114:1:114:67 | ** |
+| params_flow.rb:114:58:114:66 | call to taint | type tracker without call steps with content hash-splat position :c | params_flow.rb:114:1:114:67 | synthetic hash-splat argument |
+| params_flow.rb:114:58:114:66 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:114:58:114:66 | synthetic splat argument | type tracker without call steps | params_flow.rb:114:58:114:66 | synthetic splat argument |
 | params_flow.rb:114:64:114:65 | 60 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:114:64:114:65 | 60 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:114:64:114:65 | 60 | type tracker with call steps | params_flow.rb:108:44:108:44 | c |
-| params_flow.rb:114:64:114:65 | 60 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:114:64:114:65 | 60 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:114:64:114:65 | 60 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:114:64:114:65 | 60 | type tracker with call steps with content element 0 | params_flow.rb:111:5:111:10 | * |
-| params_flow.rb:114:64:114:65 | 60 | type tracker with call steps with content element :c | params_flow.rb:108:1:112:3 | **kwargs |
+| params_flow.rb:114:64:114:65 | 60 | type tracker with call steps with content hash-splat position :c | params_flow.rb:108:1:112:3 | synthetic hash-splat parameter |
+| params_flow.rb:114:64:114:65 | 60 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:114:64:114:65 | 60 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:114:64:114:65 | 60 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:114:64:114:65 | 60 | type tracker with call steps with content splat position 0 | params_flow.rb:111:5:111:10 | synthetic splat argument |
 | params_flow.rb:114:64:114:65 | 60 | type tracker without call steps | params_flow.rb:114:58:114:66 | call to taint |
 | params_flow.rb:114:64:114:65 | 60 | type tracker without call steps | params_flow.rb:114:64:114:65 | 60 |
-| params_flow.rb:114:64:114:65 | 60 | type tracker without call steps with content element 0 | params_flow.rb:114:58:114:66 | * |
-| params_flow.rb:114:64:114:65 | 60 | type tracker without call steps with content element :c | params_flow.rb:114:1:114:67 | ** |
+| params_flow.rb:114:64:114:65 | 60 | type tracker without call steps with content hash-splat position :c | params_flow.rb:114:1:114:67 | synthetic hash-splat argument |
+| params_flow.rb:114:64:114:65 | 60 | type tracker without call steps with content splat position 0 | params_flow.rb:114:58:114:66 | synthetic splat argument |
 | params_flow.rb:116:1:116:1 | x | type tracker without call steps | params_flow.rb:116:1:116:1 | x |
 | params_flow.rb:116:5:116:6 | Array | type tracker without call steps | params_flow.rb:116:5:116:6 | Array |
 | params_flow.rb:116:5:116:6 | call to [] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:116:5:116:6 | call to [] | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
-| params_flow.rb:116:5:116:6 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:116:5:116:6 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:116:5:116:6 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | * |
-| params_flow.rb:116:5:116:6 | call to [] | type tracker with call steps with content element 0 or unknown | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:116:5:116:6 | call to [] | type tracker with call steps with content element 0 or unknown | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:116:5:116:6 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:116:5:116:6 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:116:5:116:6 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
 | params_flow.rb:116:5:116:6 | call to [] | type tracker without call steps | params_flow.rb:116:5:116:6 | call to [] |
 | params_flow.rb:116:5:116:6 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:118:12:118:13 | * ... |
 | params_flow.rb:117:1:117:1 | [post] x | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:117:1:117:1 | [post] x | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
-| params_flow.rb:117:1:117:1 | [post] x | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:117:1:117:1 | [post] x | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:117:1:117:1 | [post] x | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | * |
-| params_flow.rb:117:1:117:1 | [post] x | type tracker with call steps with content element 0 or unknown | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:117:1:117:1 | [post] x | type tracker with call steps with content element 0 or unknown | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:117:1:117:1 | [post] x | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:117:1:117:1 | [post] x | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:117:1:117:1 | [post] x | type tracker with call steps with content splat position 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
 | params_flow.rb:117:1:117:1 | [post] x | type tracker without call steps | params_flow.rb:117:1:117:1 | [post] x |
 | params_flow.rb:117:1:117:1 | [post] x | type tracker without call steps with content element 0 or unknown | params_flow.rb:118:12:118:13 | * ... |
-| params_flow.rb:117:1:117:15 | * | type tracker without call steps | params_flow.rb:117:1:117:15 | * |
 | params_flow.rb:117:1:117:15 | call to []= | type tracker without call steps | params_flow.rb:117:1:117:15 | call to []= |
+| params_flow.rb:117:1:117:15 | synthetic splat argument | type tracker without call steps | params_flow.rb:117:1:117:15 | synthetic splat argument |
 | params_flow.rb:117:3:117:14 | call to some_index | type tracker without call steps | params_flow.rb:117:3:117:14 | call to some_index |
-| params_flow.rb:117:3:117:14 | call to some_index | type tracker without call steps with content element 0 | params_flow.rb:117:1:117:15 | * |
-| params_flow.rb:117:19:117:27 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:117:19:117:27 | * | type tracker without call steps | params_flow.rb:117:19:117:27 | * |
+| params_flow.rb:117:3:117:14 | call to some_index | type tracker without call steps with content splat position 0 | params_flow.rb:117:1:117:15 | synthetic splat argument |
 | params_flow.rb:117:19:117:27 | __synth__0 | type tracker without call steps | params_flow.rb:117:19:117:27 | __synth__0 |
 | params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
 | params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps | params_flow.rb:9:20:9:21 | p2 |
-| params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps with content element | params_flow.rb:9:1:12:3 | synthetic *args |
-| params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | * |
-| params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:11:5:11:11 | * |
+| params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps with content element | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
+| params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
 | params_flow.rb:117:19:117:27 | call to taint | type tracker without call steps | params_flow.rb:117:19:117:27 | call to taint |
 | params_flow.rb:117:19:117:27 | call to taint | type tracker without call steps with content attribute [] | params_flow.rb:117:1:117:1 | [post] x |
 | params_flow.rb:117:19:117:27 | call to taint | type tracker without call steps with content element | params_flow.rb:116:5:116:6 | call to [] |
 | params_flow.rb:117:19:117:27 | call to taint | type tracker without call steps with content element | params_flow.rb:118:12:118:13 | * ... |
-| params_flow.rb:117:19:117:27 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:117:1:117:15 | * |
+| params_flow.rb:117:19:117:27 | call to taint | type tracker without call steps with content splat position 1 | params_flow.rb:117:1:117:15 | synthetic splat argument |
+| params_flow.rb:117:19:117:27 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:117:19:117:27 | synthetic splat argument | type tracker without call steps | params_flow.rb:117:19:117:27 | synthetic splat argument |
 | params_flow.rb:117:25:117:26 | 61 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:117:25:117:26 | 61 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:117:25:117:26 | 61 | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
 | params_flow.rb:117:25:117:26 | 61 | type tracker with call steps | params_flow.rb:9:20:9:21 | p2 |
-| params_flow.rb:117:25:117:26 | 61 | type tracker with call steps with content element | params_flow.rb:9:1:12:3 | synthetic *args |
-| params_flow.rb:117:25:117:26 | 61 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:117:25:117:26 | 61 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:117:25:117:26 | 61 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:117:25:117:26 | 61 | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | * |
-| params_flow.rb:117:25:117:26 | 61 | type tracker with call steps with content element 0 | params_flow.rb:11:5:11:11 | * |
+| params_flow.rb:117:25:117:26 | 61 | type tracker with call steps with content element | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:117:25:117:26 | 61 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:117:25:117:26 | 61 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:117:25:117:26 | 61 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:117:25:117:26 | 61 | type tracker with call steps with content splat position 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
+| params_flow.rb:117:25:117:26 | 61 | type tracker with call steps with content splat position 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
 | params_flow.rb:117:25:117:26 | 61 | type tracker without call steps | params_flow.rb:117:19:117:27 | call to taint |
 | params_flow.rb:117:25:117:26 | 61 | type tracker without call steps | params_flow.rb:117:25:117:26 | 61 |
 | params_flow.rb:117:25:117:26 | 61 | type tracker without call steps with content attribute [] | params_flow.rb:117:1:117:1 | [post] x |
 | params_flow.rb:117:25:117:26 | 61 | type tracker without call steps with content element | params_flow.rb:116:5:116:6 | call to [] |
 | params_flow.rb:117:25:117:26 | 61 | type tracker without call steps with content element | params_flow.rb:118:12:118:13 | * ... |
-| params_flow.rb:117:25:117:26 | 61 | type tracker without call steps with content element 0 | params_flow.rb:117:19:117:27 | * |
-| params_flow.rb:117:25:117:26 | 61 | type tracker without call steps with content element 1 | params_flow.rb:117:1:117:15 | * |
+| params_flow.rb:117:25:117:26 | 61 | type tracker without call steps with content splat position 0 | params_flow.rb:117:19:117:27 | synthetic splat argument |
+| params_flow.rb:117:25:117:26 | 61 | type tracker without call steps with content splat position 1 | params_flow.rb:117:1:117:15 | synthetic splat argument |
 | params_flow.rb:118:1:118:14 | call to positional | type tracker without call steps | params_flow.rb:118:1:118:14 | call to positional |
-| params_flow.rb:118:12:118:13 | * ... | type tracker with call steps | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:118:12:118:13 | * ... | type tracker with call steps | params_flow.rb:9:1:12:3 | synthetic splat parameter |
 | params_flow.rb:118:12:118:13 | * ... | type tracker without call steps | params_flow.rb:118:12:118:13 | * ... |
 | params_flow.rb:120:1:126:3 | &block | type tracker without call steps | params_flow.rb:120:1:126:3 | &block |
 | params_flow.rb:120:1:126:3 | destruct | type tracker without call steps | params_flow.rb:120:1:126:3 | destruct |
@@ -2602,323 +2585,327 @@ track
 | params_flow.rb:120:22:120:22 | c | type tracker without call steps | params_flow.rb:120:22:120:22 | c |
 | params_flow.rb:120:25:120:25 | d | type tracker without call steps | params_flow.rb:120:25:120:25 | d |
 | params_flow.rb:120:27:120:27 | e | type tracker without call steps | params_flow.rb:120:27:120:27 | e |
-| params_flow.rb:121:5:121:10 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:121:5:121:10 | * | type tracker without call steps | params_flow.rb:121:5:121:10 | * |
 | params_flow.rb:121:5:121:10 | call to sink | type tracker without call steps | params_flow.rb:121:5:121:10 | call to sink |
+| params_flow.rb:121:5:121:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:121:5:121:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:121:5:121:10 | synthetic splat argument |
 | params_flow.rb:121:10:121:10 | a | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:121:10:121:10 | a | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:121:10:121:10 | a | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:121:10:121:10 | a | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:121:10:121:10 | a | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:121:10:121:10 | a | type tracker without call steps | params_flow.rb:121:10:121:10 | a |
-| params_flow.rb:121:10:121:10 | a | type tracker without call steps with content element 0 | params_flow.rb:121:5:121:10 | * |
-| params_flow.rb:122:5:122:10 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:122:5:122:10 | * | type tracker without call steps | params_flow.rb:122:5:122:10 | * |
+| params_flow.rb:121:10:121:10 | a | type tracker without call steps with content splat position 0 | params_flow.rb:121:5:121:10 | synthetic splat argument |
 | params_flow.rb:122:5:122:10 | call to sink | type tracker without call steps | params_flow.rb:122:5:122:10 | call to sink |
+| params_flow.rb:122:5:122:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:122:5:122:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:122:5:122:10 | synthetic splat argument |
 | params_flow.rb:122:10:122:10 | b | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:122:10:122:10 | b | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:122:10:122:10 | b | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:122:10:122:10 | b | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:122:10:122:10 | b | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:122:10:122:10 | b | type tracker without call steps | params_flow.rb:122:10:122:10 | b |
-| params_flow.rb:122:10:122:10 | b | type tracker without call steps with content element 0 | params_flow.rb:122:5:122:10 | * |
-| params_flow.rb:123:5:123:10 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:123:5:123:10 | * | type tracker without call steps | params_flow.rb:123:5:123:10 | * |
+| params_flow.rb:122:10:122:10 | b | type tracker without call steps with content splat position 0 | params_flow.rb:122:5:122:10 | synthetic splat argument |
 | params_flow.rb:123:5:123:10 | call to sink | type tracker without call steps | params_flow.rb:123:5:123:10 | call to sink |
+| params_flow.rb:123:5:123:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:123:5:123:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:123:5:123:10 | synthetic splat argument |
 | params_flow.rb:123:10:123:10 | c | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:123:10:123:10 | c | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:123:10:123:10 | c | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:123:10:123:10 | c | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:123:10:123:10 | c | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:123:10:123:10 | c | type tracker without call steps | params_flow.rb:123:10:123:10 | c |
-| params_flow.rb:123:10:123:10 | c | type tracker without call steps with content element 0 | params_flow.rb:123:5:123:10 | * |
-| params_flow.rb:124:5:124:10 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:124:5:124:10 | * | type tracker without call steps | params_flow.rb:124:5:124:10 | * |
+| params_flow.rb:123:10:123:10 | c | type tracker without call steps with content splat position 0 | params_flow.rb:123:5:123:10 | synthetic splat argument |
 | params_flow.rb:124:5:124:10 | call to sink | type tracker without call steps | params_flow.rb:124:5:124:10 | call to sink |
+| params_flow.rb:124:5:124:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:124:5:124:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:124:5:124:10 | synthetic splat argument |
 | params_flow.rb:124:10:124:10 | d | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:124:10:124:10 | d | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:124:10:124:10 | d | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:124:10:124:10 | d | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:124:10:124:10 | d | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:124:10:124:10 | d | type tracker without call steps | params_flow.rb:124:10:124:10 | d |
-| params_flow.rb:124:10:124:10 | d | type tracker without call steps with content element 0 | params_flow.rb:124:5:124:10 | * |
-| params_flow.rb:125:5:125:10 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:125:5:125:10 | * | type tracker without call steps | params_flow.rb:125:5:125:10 | * |
+| params_flow.rb:124:10:124:10 | d | type tracker without call steps with content splat position 0 | params_flow.rb:124:5:124:10 | synthetic splat argument |
 | params_flow.rb:125:5:125:10 | call to sink | type tracker without call steps | params_flow.rb:125:5:125:10 | call to sink |
 | params_flow.rb:125:5:125:10 | call to sink | type tracker without call steps | params_flow.rb:128:1:128:61 | call to destruct |
+| params_flow.rb:125:5:125:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:125:5:125:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:125:5:125:10 | synthetic splat argument |
 | params_flow.rb:125:10:125:10 | e | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:125:10:125:10 | e | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:125:10:125:10 | e | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:125:10:125:10 | e | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:125:10:125:10 | e | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:125:10:125:10 | e | type tracker without call steps | params_flow.rb:125:10:125:10 | e |
-| params_flow.rb:125:10:125:10 | e | type tracker without call steps with content element 0 | params_flow.rb:125:5:125:10 | * |
-| params_flow.rb:128:1:128:61 | * | type tracker without call steps | params_flow.rb:128:1:128:61 | * |
+| params_flow.rb:125:10:125:10 | e | type tracker without call steps with content splat position 0 | params_flow.rb:125:5:125:10 | synthetic splat argument |
 | params_flow.rb:128:1:128:61 | call to destruct | type tracker without call steps | params_flow.rb:128:1:128:61 | call to destruct |
-| params_flow.rb:128:10:128:31 | * | type tracker without call steps | params_flow.rb:128:10:128:31 | * |
+| params_flow.rb:128:1:128:61 | synthetic splat argument | type tracker without call steps | params_flow.rb:128:1:128:61 | synthetic splat argument |
 | params_flow.rb:128:10:128:31 | Array | type tracker without call steps | params_flow.rb:128:10:128:31 | Array |
 | params_flow.rb:128:10:128:31 | call to [] | type tracker without call steps | params_flow.rb:128:10:128:31 | call to [] |
-| params_flow.rb:128:10:128:31 | call to [] | type tracker without call steps with content element 0 | params_flow.rb:128:1:128:61 | * |
-| params_flow.rb:128:11:128:19 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:128:11:128:19 | * | type tracker without call steps | params_flow.rb:128:11:128:19 | * |
+| params_flow.rb:128:10:128:31 | call to [] | type tracker without call steps with content splat position 0 | params_flow.rb:128:1:128:61 | synthetic splat argument |
+| params_flow.rb:128:10:128:31 | synthetic splat argument | type tracker without call steps | params_flow.rb:128:10:128:31 | call to [] |
+| params_flow.rb:128:10:128:31 | synthetic splat argument | type tracker without call steps | params_flow.rb:128:10:128:31 | synthetic splat argument |
+| params_flow.rb:128:10:128:31 | synthetic splat argument | type tracker without call steps with content splat position 0 | params_flow.rb:128:1:128:61 | synthetic splat argument |
 | params_flow.rb:128:11:128:19 | call to taint | type tracker without call steps | params_flow.rb:128:11:128:19 | call to taint |
-| params_flow.rb:128:11:128:19 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:128:10:128:31 | * |
-| params_flow.rb:128:11:128:19 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:128:10:128:31 | call to [] |
+| params_flow.rb:128:11:128:19 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:128:10:128:31 | call to [] |
+| params_flow.rb:128:11:128:19 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:128:10:128:31 | synthetic splat argument |
+| params_flow.rb:128:11:128:19 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:128:11:128:19 | synthetic splat argument | type tracker without call steps | params_flow.rb:128:11:128:19 | synthetic splat argument |
 | params_flow.rb:128:17:128:18 | 62 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:128:17:128:18 | 62 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
+| params_flow.rb:128:17:128:18 | 62 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:128:17:128:18 | 62 | type tracker without call steps | params_flow.rb:128:11:128:19 | call to taint |
 | params_flow.rb:128:17:128:18 | 62 | type tracker without call steps | params_flow.rb:128:17:128:18 | 62 |
-| params_flow.rb:128:17:128:18 | 62 | type tracker without call steps with content element 0 | params_flow.rb:128:10:128:31 | * |
-| params_flow.rb:128:17:128:18 | 62 | type tracker without call steps with content element 0 | params_flow.rb:128:11:128:19 | * |
-| params_flow.rb:128:17:128:18 | 62 | type tracker without call steps with content element 0 or unknown | params_flow.rb:128:10:128:31 | call to [] |
-| params_flow.rb:128:22:128:30 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:128:22:128:30 | * | type tracker without call steps | params_flow.rb:128:22:128:30 | * |
+| params_flow.rb:128:17:128:18 | 62 | type tracker without call steps with content element 0 | params_flow.rb:128:10:128:31 | call to [] |
+| params_flow.rb:128:17:128:18 | 62 | type tracker without call steps with content element 0 | params_flow.rb:128:10:128:31 | synthetic splat argument |
+| params_flow.rb:128:17:128:18 | 62 | type tracker without call steps with content splat position 0 | params_flow.rb:128:11:128:19 | synthetic splat argument |
 | params_flow.rb:128:22:128:30 | call to taint | type tracker without call steps | params_flow.rb:128:22:128:30 | call to taint |
-| params_flow.rb:128:22:128:30 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:128:10:128:31 | * |
-| params_flow.rb:128:22:128:30 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:128:10:128:31 | call to [] |
+| params_flow.rb:128:22:128:30 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:128:10:128:31 | call to [] |
+| params_flow.rb:128:22:128:30 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:128:10:128:31 | synthetic splat argument |
+| params_flow.rb:128:22:128:30 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:128:22:128:30 | synthetic splat argument | type tracker without call steps | params_flow.rb:128:22:128:30 | synthetic splat argument |
 | params_flow.rb:128:28:128:29 | 63 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:128:28:128:29 | 63 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
+| params_flow.rb:128:28:128:29 | 63 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:128:28:128:29 | 63 | type tracker without call steps | params_flow.rb:128:22:128:30 | call to taint |
 | params_flow.rb:128:28:128:29 | 63 | type tracker without call steps | params_flow.rb:128:28:128:29 | 63 |
-| params_flow.rb:128:28:128:29 | 63 | type tracker without call steps with content element 0 | params_flow.rb:128:22:128:30 | * |
-| params_flow.rb:128:28:128:29 | 63 | type tracker without call steps with content element 1 | params_flow.rb:128:10:128:31 | * |
-| params_flow.rb:128:28:128:29 | 63 | type tracker without call steps with content element 1 or unknown | params_flow.rb:128:10:128:31 | call to [] |
-| params_flow.rb:128:34:128:60 | * | type tracker without call steps | params_flow.rb:128:34:128:60 | * |
+| params_flow.rb:128:28:128:29 | 63 | type tracker without call steps with content element 1 | params_flow.rb:128:10:128:31 | call to [] |
+| params_flow.rb:128:28:128:29 | 63 | type tracker without call steps with content element 1 | params_flow.rb:128:10:128:31 | synthetic splat argument |
+| params_flow.rb:128:28:128:29 | 63 | type tracker without call steps with content splat position 0 | params_flow.rb:128:22:128:30 | synthetic splat argument |
 | params_flow.rb:128:34:128:60 | Array | type tracker without call steps | params_flow.rb:128:34:128:60 | Array |
 | params_flow.rb:128:34:128:60 | call to [] | type tracker without call steps | params_flow.rb:128:34:128:60 | call to [] |
-| params_flow.rb:128:34:128:60 | call to [] | type tracker without call steps with content element 1 | params_flow.rb:128:1:128:61 | * |
-| params_flow.rb:128:35:128:43 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:128:35:128:43 | * | type tracker without call steps | params_flow.rb:128:35:128:43 | * |
+| params_flow.rb:128:34:128:60 | call to [] | type tracker without call steps with content splat position 1 | params_flow.rb:128:1:128:61 | synthetic splat argument |
+| params_flow.rb:128:34:128:60 | synthetic splat argument | type tracker without call steps | params_flow.rb:128:34:128:60 | call to [] |
+| params_flow.rb:128:34:128:60 | synthetic splat argument | type tracker without call steps | params_flow.rb:128:34:128:60 | synthetic splat argument |
+| params_flow.rb:128:34:128:60 | synthetic splat argument | type tracker without call steps with content splat position 1 | params_flow.rb:128:1:128:61 | synthetic splat argument |
 | params_flow.rb:128:35:128:43 | call to taint | type tracker without call steps | params_flow.rb:128:35:128:43 | call to taint |
-| params_flow.rb:128:35:128:43 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:128:34:128:60 | * |
-| params_flow.rb:128:35:128:43 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:128:34:128:60 | call to [] |
+| params_flow.rb:128:35:128:43 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:128:34:128:60 | call to [] |
+| params_flow.rb:128:35:128:43 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:128:34:128:60 | synthetic splat argument |
+| params_flow.rb:128:35:128:43 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:128:35:128:43 | synthetic splat argument | type tracker without call steps | params_flow.rb:128:35:128:43 | synthetic splat argument |
 | params_flow.rb:128:41:128:42 | 64 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:128:41:128:42 | 64 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
+| params_flow.rb:128:41:128:42 | 64 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:128:41:128:42 | 64 | type tracker without call steps | params_flow.rb:128:35:128:43 | call to taint |
 | params_flow.rb:128:41:128:42 | 64 | type tracker without call steps | params_flow.rb:128:41:128:42 | 64 |
-| params_flow.rb:128:41:128:42 | 64 | type tracker without call steps with content element 0 | params_flow.rb:128:34:128:60 | * |
-| params_flow.rb:128:41:128:42 | 64 | type tracker without call steps with content element 0 | params_flow.rb:128:35:128:43 | * |
-| params_flow.rb:128:41:128:42 | 64 | type tracker without call steps with content element 0 or unknown | params_flow.rb:128:34:128:60 | call to [] |
-| params_flow.rb:128:46:128:59 | * | type tracker without call steps | params_flow.rb:128:46:128:59 | * |
+| params_flow.rb:128:41:128:42 | 64 | type tracker without call steps with content element 0 | params_flow.rb:128:34:128:60 | call to [] |
+| params_flow.rb:128:41:128:42 | 64 | type tracker without call steps with content element 0 | params_flow.rb:128:34:128:60 | synthetic splat argument |
+| params_flow.rb:128:41:128:42 | 64 | type tracker without call steps with content splat position 0 | params_flow.rb:128:35:128:43 | synthetic splat argument |
 | params_flow.rb:128:46:128:59 | Array | type tracker without call steps | params_flow.rb:128:46:128:59 | Array |
 | params_flow.rb:128:46:128:59 | call to [] | type tracker without call steps | params_flow.rb:128:46:128:59 | call to [] |
-| params_flow.rb:128:46:128:59 | call to [] | type tracker without call steps with content element 1 | params_flow.rb:128:34:128:60 | * |
-| params_flow.rb:128:46:128:59 | call to [] | type tracker without call steps with content element 1 or unknown | params_flow.rb:128:34:128:60 | call to [] |
+| params_flow.rb:128:46:128:59 | call to [] | type tracker without call steps with content element 1 | params_flow.rb:128:34:128:60 | call to [] |
+| params_flow.rb:128:46:128:59 | call to [] | type tracker without call steps with content element 1 | params_flow.rb:128:34:128:60 | synthetic splat argument |
+| params_flow.rb:128:46:128:59 | synthetic splat argument | type tracker without call steps | params_flow.rb:128:46:128:59 | call to [] |
+| params_flow.rb:128:46:128:59 | synthetic splat argument | type tracker without call steps | params_flow.rb:128:46:128:59 | synthetic splat argument |
+| params_flow.rb:128:46:128:59 | synthetic splat argument | type tracker without call steps with content element 1 | params_flow.rb:128:34:128:60 | call to [] |
+| params_flow.rb:128:46:128:59 | synthetic splat argument | type tracker without call steps with content element 1 | params_flow.rb:128:34:128:60 | synthetic splat argument |
 | params_flow.rb:128:47:128:47 | 0 | type tracker without call steps | params_flow.rb:128:47:128:47 | 0 |
-| params_flow.rb:128:47:128:47 | 0 | type tracker without call steps with content element 0 | params_flow.rb:128:46:128:59 | * |
-| params_flow.rb:128:47:128:47 | 0 | type tracker without call steps with content element 0 or unknown | params_flow.rb:128:46:128:59 | call to [] |
-| params_flow.rb:128:50:128:58 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:128:50:128:58 | * | type tracker without call steps | params_flow.rb:128:50:128:58 | * |
+| params_flow.rb:128:47:128:47 | 0 | type tracker without call steps with content element 0 | params_flow.rb:128:46:128:59 | call to [] |
+| params_flow.rb:128:47:128:47 | 0 | type tracker without call steps with content element 0 | params_flow.rb:128:46:128:59 | synthetic splat argument |
 | params_flow.rb:128:50:128:58 | call to taint | type tracker without call steps | params_flow.rb:128:50:128:58 | call to taint |
-| params_flow.rb:128:50:128:58 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:128:46:128:59 | * |
-| params_flow.rb:128:50:128:58 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:128:46:128:59 | call to [] |
+| params_flow.rb:128:50:128:58 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:128:46:128:59 | call to [] |
+| params_flow.rb:128:50:128:58 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:128:46:128:59 | synthetic splat argument |
+| params_flow.rb:128:50:128:58 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:128:50:128:58 | synthetic splat argument | type tracker without call steps | params_flow.rb:128:50:128:58 | synthetic splat argument |
 | params_flow.rb:128:56:128:57 | 65 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:128:56:128:57 | 65 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
+| params_flow.rb:128:56:128:57 | 65 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:128:56:128:57 | 65 | type tracker without call steps | params_flow.rb:128:50:128:58 | call to taint |
 | params_flow.rb:128:56:128:57 | 65 | type tracker without call steps | params_flow.rb:128:56:128:57 | 65 |
-| params_flow.rb:128:56:128:57 | 65 | type tracker without call steps with content element 0 | params_flow.rb:128:50:128:58 | * |
-| params_flow.rb:128:56:128:57 | 65 | type tracker without call steps with content element 1 | params_flow.rb:128:46:128:59 | * |
-| params_flow.rb:128:56:128:57 | 65 | type tracker without call steps with content element 1 or unknown | params_flow.rb:128:46:128:59 | call to [] |
+| params_flow.rb:128:56:128:57 | 65 | type tracker without call steps with content element 1 | params_flow.rb:128:46:128:59 | call to [] |
+| params_flow.rb:128:56:128:57 | 65 | type tracker without call steps with content element 1 | params_flow.rb:128:46:128:59 | synthetic splat argument |
+| params_flow.rb:128:56:128:57 | 65 | type tracker without call steps with content splat position 0 | params_flow.rb:128:50:128:58 | synthetic splat argument |
 | params_flow.rb:130:1:130:4 | args | type tracker without call steps | params_flow.rb:130:1:130:4 | args |
-| params_flow.rb:130:8:130:29 | * | type tracker without call steps | params_flow.rb:130:8:130:29 | * |
 | params_flow.rb:130:8:130:29 | Array | type tracker without call steps | params_flow.rb:130:8:130:29 | Array |
 | params_flow.rb:130:8:130:29 | call to [] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:130:8:130:29 | call to [] | type tracker with call steps | params_flow.rb:83:14:83:14 | t |
-| params_flow.rb:130:8:130:29 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:130:8:130:29 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:130:8:130:29 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:84:5:84:10 | * |
-| params_flow.rb:130:8:130:29 | call to [] | type tracker with call steps with content element 0 or unknown | params_flow.rb:83:1:91:3 | synthetic *args |
+| params_flow.rb:130:8:130:29 | call to [] | type tracker with call steps with content element 0 or unknown | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:130:8:130:29 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:130:8:130:29 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:130:8:130:29 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:84:5:84:10 | synthetic splat argument |
 | params_flow.rb:130:8:130:29 | call to [] | type tracker without call steps | params_flow.rb:130:8:130:29 | call to [] |
 | params_flow.rb:130:8:130:29 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:131:10:131:14 | * ... |
-| params_flow.rb:130:9:130:17 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:130:9:130:17 | * | type tracker without call steps | params_flow.rb:130:9:130:17 | * |
+| params_flow.rb:130:8:130:29 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:130:8:130:29 | synthetic splat argument | type tracker with call steps | params_flow.rb:83:14:83:14 | t |
+| params_flow.rb:130:8:130:29 | synthetic splat argument | type tracker with call steps with content element 0 or unknown | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:130:8:130:29 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:130:8:130:29 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:130:8:130:29 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:84:5:84:10 | synthetic splat argument |
+| params_flow.rb:130:8:130:29 | synthetic splat argument | type tracker without call steps | params_flow.rb:130:8:130:29 | call to [] |
+| params_flow.rb:130:8:130:29 | synthetic splat argument | type tracker without call steps | params_flow.rb:130:8:130:29 | synthetic splat argument |
+| params_flow.rb:130:8:130:29 | synthetic splat argument | type tracker without call steps with content element 0 or unknown | params_flow.rb:131:10:131:14 | * ... |
 | params_flow.rb:130:9:130:17 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:130:9:130:17 | call to taint | type tracker with call steps | params_flow.rb:83:14:83:14 | t |
-| params_flow.rb:130:9:130:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:130:9:130:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:130:9:130:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:84:5:84:10 | * |
-| params_flow.rb:130:9:130:17 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:83:1:91:3 | synthetic *args |
+| params_flow.rb:130:9:130:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:130:9:130:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:130:9:130:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:130:9:130:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:84:5:84:10 | synthetic splat argument |
 | params_flow.rb:130:9:130:17 | call to taint | type tracker without call steps | params_flow.rb:130:9:130:17 | call to taint |
-| params_flow.rb:130:9:130:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:130:8:130:29 | * |
-| params_flow.rb:130:9:130:17 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:130:8:130:29 | call to [] |
-| params_flow.rb:130:9:130:17 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:131:10:131:14 | * ... |
+| params_flow.rb:130:9:130:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:130:8:130:29 | call to [] |
+| params_flow.rb:130:9:130:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:130:8:130:29 | synthetic splat argument |
+| params_flow.rb:130:9:130:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:131:10:131:14 | * ... |
+| params_flow.rb:130:9:130:17 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:130:9:130:17 | synthetic splat argument | type tracker without call steps | params_flow.rb:130:9:130:17 | synthetic splat argument |
 | params_flow.rb:130:15:130:16 | 66 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:130:15:130:16 | 66 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:130:15:130:16 | 66 | type tracker with call steps | params_flow.rb:83:14:83:14 | t |
-| params_flow.rb:130:15:130:16 | 66 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:130:15:130:16 | 66 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:130:15:130:16 | 66 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:130:15:130:16 | 66 | type tracker with call steps with content element 0 | params_flow.rb:84:5:84:10 | * |
-| params_flow.rb:130:15:130:16 | 66 | type tracker with call steps with content element 0 or unknown | params_flow.rb:83:1:91:3 | synthetic *args |
+| params_flow.rb:130:15:130:16 | 66 | type tracker with call steps with content element 0 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:130:15:130:16 | 66 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:130:15:130:16 | 66 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:130:15:130:16 | 66 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:130:15:130:16 | 66 | type tracker with call steps with content splat position 0 | params_flow.rb:84:5:84:10 | synthetic splat argument |
 | params_flow.rb:130:15:130:16 | 66 | type tracker without call steps | params_flow.rb:130:9:130:17 | call to taint |
 | params_flow.rb:130:15:130:16 | 66 | type tracker without call steps | params_flow.rb:130:15:130:16 | 66 |
-| params_flow.rb:130:15:130:16 | 66 | type tracker without call steps with content element 0 | params_flow.rb:130:8:130:29 | * |
-| params_flow.rb:130:15:130:16 | 66 | type tracker without call steps with content element 0 | params_flow.rb:130:9:130:17 | * |
-| params_flow.rb:130:15:130:16 | 66 | type tracker without call steps with content element 0 or unknown | params_flow.rb:130:8:130:29 | call to [] |
-| params_flow.rb:130:15:130:16 | 66 | type tracker without call steps with content element 0 or unknown | params_flow.rb:131:10:131:14 | * ... |
-| params_flow.rb:130:20:130:28 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:130:20:130:28 | * | type tracker without call steps | params_flow.rb:130:20:130:28 | * |
+| params_flow.rb:130:15:130:16 | 66 | type tracker without call steps with content element 0 | params_flow.rb:130:8:130:29 | call to [] |
+| params_flow.rb:130:15:130:16 | 66 | type tracker without call steps with content element 0 | params_flow.rb:130:8:130:29 | synthetic splat argument |
+| params_flow.rb:130:15:130:16 | 66 | type tracker without call steps with content element 0 | params_flow.rb:131:10:131:14 | * ... |
+| params_flow.rb:130:15:130:16 | 66 | type tracker without call steps with content splat position 0 | params_flow.rb:130:9:130:17 | synthetic splat argument |
 | params_flow.rb:130:20:130:28 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:130:20:130:28 | call to taint | type tracker with call steps | params_flow.rb:83:17:83:17 | u |
-| params_flow.rb:130:20:130:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:130:20:130:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:130:20:130:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:85:5:85:10 | * |
-| params_flow.rb:130:20:130:28 | call to taint | type tracker with call steps with content element 1 or unknown | params_flow.rb:83:1:91:3 | synthetic *args |
+| params_flow.rb:130:20:130:28 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:130:20:130:28 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:130:20:130:28 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:130:20:130:28 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:85:5:85:10 | synthetic splat argument |
 | params_flow.rb:130:20:130:28 | call to taint | type tracker without call steps | params_flow.rb:130:20:130:28 | call to taint |
-| params_flow.rb:130:20:130:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:130:8:130:29 | * |
-| params_flow.rb:130:20:130:28 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:130:8:130:29 | call to [] |
-| params_flow.rb:130:20:130:28 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:131:10:131:14 | * ... |
+| params_flow.rb:130:20:130:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:130:8:130:29 | call to [] |
+| params_flow.rb:130:20:130:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:130:8:130:29 | synthetic splat argument |
+| params_flow.rb:130:20:130:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:131:10:131:14 | * ... |
+| params_flow.rb:130:20:130:28 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:130:20:130:28 | synthetic splat argument | type tracker without call steps | params_flow.rb:130:20:130:28 | synthetic splat argument |
 | params_flow.rb:130:26:130:27 | 67 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:130:26:130:27 | 67 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:130:26:130:27 | 67 | type tracker with call steps | params_flow.rb:83:17:83:17 | u |
-| params_flow.rb:130:26:130:27 | 67 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:130:26:130:27 | 67 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:130:26:130:27 | 67 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:130:26:130:27 | 67 | type tracker with call steps with content element 0 | params_flow.rb:85:5:85:10 | * |
-| params_flow.rb:130:26:130:27 | 67 | type tracker with call steps with content element 1 or unknown | params_flow.rb:83:1:91:3 | synthetic *args |
+| params_flow.rb:130:26:130:27 | 67 | type tracker with call steps with content element 1 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:130:26:130:27 | 67 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:130:26:130:27 | 67 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:130:26:130:27 | 67 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:130:26:130:27 | 67 | type tracker with call steps with content splat position 0 | params_flow.rb:85:5:85:10 | synthetic splat argument |
 | params_flow.rb:130:26:130:27 | 67 | type tracker without call steps | params_flow.rb:130:20:130:28 | call to taint |
 | params_flow.rb:130:26:130:27 | 67 | type tracker without call steps | params_flow.rb:130:26:130:27 | 67 |
-| params_flow.rb:130:26:130:27 | 67 | type tracker without call steps with content element 0 | params_flow.rb:130:20:130:28 | * |
-| params_flow.rb:130:26:130:27 | 67 | type tracker without call steps with content element 1 | params_flow.rb:130:8:130:29 | * |
-| params_flow.rb:130:26:130:27 | 67 | type tracker without call steps with content element 1 or unknown | params_flow.rb:130:8:130:29 | call to [] |
-| params_flow.rb:130:26:130:27 | 67 | type tracker without call steps with content element 1 or unknown | params_flow.rb:131:10:131:14 | * ... |
-| params_flow.rb:131:1:131:46 | * | type tracker with call steps | params_flow.rb:83:1:91:3 | synthetic *args |
-| params_flow.rb:131:1:131:46 | * | type tracker without call steps | params_flow.rb:131:1:131:46 | * |
+| params_flow.rb:130:26:130:27 | 67 | type tracker without call steps with content element 1 | params_flow.rb:130:8:130:29 | call to [] |
+| params_flow.rb:130:26:130:27 | 67 | type tracker without call steps with content element 1 | params_flow.rb:130:8:130:29 | synthetic splat argument |
+| params_flow.rb:130:26:130:27 | 67 | type tracker without call steps with content element 1 | params_flow.rb:131:10:131:14 | * ... |
+| params_flow.rb:130:26:130:27 | 67 | type tracker without call steps with content splat position 0 | params_flow.rb:130:20:130:28 | synthetic splat argument |
 | params_flow.rb:131:1:131:46 | call to pos_many | type tracker without call steps | params_flow.rb:131:1:131:46 | call to pos_many |
-| params_flow.rb:131:10:131:14 | * ... | type tracker with call steps | params_flow.rb:83:1:91:3 | synthetic *args |
+| params_flow.rb:131:10:131:14 | * ... | type tracker with call steps | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:131:10:131:14 | * ... | type tracker without call steps | params_flow.rb:131:10:131:14 | * ... |
-| params_flow.rb:131:17:131:25 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:131:17:131:25 | * | type tracker without call steps | params_flow.rb:131:17:131:25 | * |
 | params_flow.rb:131:17:131:25 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:131:17:131:25 | call to taint | type tracker with call steps | params_flow.rb:83:17:83:17 | u |
-| params_flow.rb:131:17:131:25 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:131:17:131:25 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:131:17:131:25 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:85:5:85:10 | * |
-| params_flow.rb:131:17:131:25 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:83:1:91:3 | synthetic *args |
+| params_flow.rb:131:17:131:25 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:131:17:131:25 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:131:17:131:25 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:85:5:85:10 | synthetic splat argument |
 | params_flow.rb:131:17:131:25 | call to taint | type tracker without call steps | params_flow.rb:131:17:131:25 | call to taint |
-| params_flow.rb:131:17:131:25 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:131:1:131:46 | * |
+| params_flow.rb:131:17:131:25 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:131:17:131:25 | synthetic splat argument | type tracker without call steps | params_flow.rb:131:17:131:25 | synthetic splat argument |
 | params_flow.rb:131:23:131:24 | 68 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:131:23:131:24 | 68 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:131:23:131:24 | 68 | type tracker with call steps | params_flow.rb:83:17:83:17 | u |
-| params_flow.rb:131:23:131:24 | 68 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:131:23:131:24 | 68 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:131:23:131:24 | 68 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:131:23:131:24 | 68 | type tracker with call steps with content element 0 | params_flow.rb:85:5:85:10 | * |
-| params_flow.rb:131:23:131:24 | 68 | type tracker with call steps with content element 1 | params_flow.rb:83:1:91:3 | synthetic *args |
+| params_flow.rb:131:23:131:24 | 68 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:131:23:131:24 | 68 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:131:23:131:24 | 68 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:131:23:131:24 | 68 | type tracker with call steps with content splat position 0 | params_flow.rb:85:5:85:10 | synthetic splat argument |
 | params_flow.rb:131:23:131:24 | 68 | type tracker without call steps | params_flow.rb:131:17:131:25 | call to taint |
 | params_flow.rb:131:23:131:24 | 68 | type tracker without call steps | params_flow.rb:131:23:131:24 | 68 |
-| params_flow.rb:131:23:131:24 | 68 | type tracker without call steps with content element 0 | params_flow.rb:131:17:131:25 | * |
-| params_flow.rb:131:23:131:24 | 68 | type tracker without call steps with content element 1 | params_flow.rb:131:1:131:46 | * |
+| params_flow.rb:131:23:131:24 | 68 | type tracker without call steps with content splat position 0 | params_flow.rb:131:17:131:25 | synthetic splat argument |
 | params_flow.rb:131:28:131:30 | nil | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:131:28:131:30 | nil | type tracker with call steps | params_flow.rb:83:20:83:20 | v |
-| params_flow.rb:131:28:131:30 | nil | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:131:28:131:30 | nil | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:131:28:131:30 | nil | type tracker with call steps with content element 0 | params_flow.rb:86:5:86:10 | * |
-| params_flow.rb:131:28:131:30 | nil | type tracker with call steps with content element 2 | params_flow.rb:83:1:91:3 | synthetic *args |
+| params_flow.rb:131:28:131:30 | nil | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:131:28:131:30 | nil | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:131:28:131:30 | nil | type tracker with call steps with content splat position 0 | params_flow.rb:86:5:86:10 | synthetic splat argument |
 | params_flow.rb:131:28:131:30 | nil | type tracker without call steps | params_flow.rb:131:28:131:30 | nil |
-| params_flow.rb:131:28:131:30 | nil | type tracker without call steps with content element 2 | params_flow.rb:131:1:131:46 | * |
 | params_flow.rb:131:33:131:35 | nil | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:131:33:131:35 | nil | type tracker with call steps | params_flow.rb:83:23:83:23 | w |
-| params_flow.rb:131:33:131:35 | nil | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:131:33:131:35 | nil | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:131:33:131:35 | nil | type tracker with call steps with content element 0 | params_flow.rb:87:5:87:10 | * |
-| params_flow.rb:131:33:131:35 | nil | type tracker with call steps with content element 3 | params_flow.rb:83:1:91:3 | synthetic *args |
+| params_flow.rb:131:33:131:35 | nil | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:131:33:131:35 | nil | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:131:33:131:35 | nil | type tracker with call steps with content splat position 0 | params_flow.rb:87:5:87:10 | synthetic splat argument |
 | params_flow.rb:131:33:131:35 | nil | type tracker without call steps | params_flow.rb:131:33:131:35 | nil |
-| params_flow.rb:131:33:131:35 | nil | type tracker without call steps with content element 3 | params_flow.rb:131:1:131:46 | * |
 | params_flow.rb:131:38:131:40 | nil | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:131:38:131:40 | nil | type tracker with call steps | params_flow.rb:83:26:83:26 | x |
-| params_flow.rb:131:38:131:40 | nil | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:131:38:131:40 | nil | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:131:38:131:40 | nil | type tracker with call steps with content element 0 | params_flow.rb:88:5:88:10 | * |
-| params_flow.rb:131:38:131:40 | nil | type tracker with call steps with content element 4 | params_flow.rb:83:1:91:3 | synthetic *args |
+| params_flow.rb:131:38:131:40 | nil | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:131:38:131:40 | nil | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:131:38:131:40 | nil | type tracker with call steps with content splat position 0 | params_flow.rb:88:5:88:10 | synthetic splat argument |
 | params_flow.rb:131:38:131:40 | nil | type tracker without call steps | params_flow.rb:131:38:131:40 | nil |
-| params_flow.rb:131:38:131:40 | nil | type tracker without call steps with content element 4 | params_flow.rb:131:1:131:46 | * |
 | params_flow.rb:131:43:131:45 | nil | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:131:43:131:45 | nil | type tracker with call steps | params_flow.rb:83:29:83:29 | y |
-| params_flow.rb:131:43:131:45 | nil | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:131:43:131:45 | nil | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:131:43:131:45 | nil | type tracker with call steps with content element 0 | params_flow.rb:89:5:89:10 | * |
-| params_flow.rb:131:43:131:45 | nil | type tracker with call steps with content element 5 | params_flow.rb:83:1:91:3 | synthetic *args |
+| params_flow.rb:131:43:131:45 | nil | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:131:43:131:45 | nil | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:131:43:131:45 | nil | type tracker with call steps with content splat position 0 | params_flow.rb:89:5:89:10 | synthetic splat argument |
 | params_flow.rb:131:43:131:45 | nil | type tracker without call steps | params_flow.rb:131:43:131:45 | nil |
-| params_flow.rb:131:43:131:45 | nil | type tracker without call steps with content element 5 | params_flow.rb:131:1:131:46 | * |
 | params_flow.rb:133:1:135:3 | &block | type tracker without call steps | params_flow.rb:133:1:135:3 | &block |
 | params_flow.rb:133:1:135:3 | self in splatall | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
 | params_flow.rb:133:1:135:3 | self in splatall | type tracker without call steps | params_flow.rb:133:1:135:3 | self in splatall |
 | params_flow.rb:133:1:135:3 | splatall | type tracker without call steps | params_flow.rb:133:1:135:3 | splatall |
 | params_flow.rb:133:14:133:18 | *args | type tracker without call steps | params_flow.rb:133:14:133:18 | *args |
 | params_flow.rb:133:15:133:18 | args | type tracker without call steps | params_flow.rb:133:15:133:18 | args |
-| params_flow.rb:134:5:134:16 | * | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:134:5:134:16 | * | type tracker without call steps | params_flow.rb:134:5:134:16 | * |
 | params_flow.rb:134:5:134:16 | call to sink | type tracker without call steps | params_flow.rb:134:5:134:16 | call to sink |
 | params_flow.rb:134:5:134:16 | call to sink | type tracker without call steps | params_flow.rb:137:1:137:44 | call to splatall |
-| params_flow.rb:134:10:134:16 | * | type tracker without call steps | params_flow.rb:134:10:134:16 | * |
+| params_flow.rb:134:5:134:16 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:134:5:134:16 | synthetic splat argument | type tracker without call steps | params_flow.rb:134:5:134:16 | synthetic splat argument |
 | params_flow.rb:134:10:134:16 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:134:10:134:16 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:134:10:134:16 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:134:10:134:16 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:134:10:134:16 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:134:10:134:16 | ...[...] | type tracker without call steps | params_flow.rb:134:10:134:16 | ...[...] |
-| params_flow.rb:134:10:134:16 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:134:5:134:16 | * |
+| params_flow.rb:134:10:134:16 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:134:5:134:16 | synthetic splat argument |
+| params_flow.rb:134:10:134:16 | synthetic splat argument | type tracker without call steps | params_flow.rb:134:10:134:16 | synthetic splat argument |
 | params_flow.rb:134:15:134:15 | 1 | type tracker without call steps | params_flow.rb:134:15:134:15 | 1 |
-| params_flow.rb:134:15:134:15 | 1 | type tracker without call steps with content element 0 | params_flow.rb:134:10:134:16 | * |
+| params_flow.rb:134:15:134:15 | 1 | type tracker without call steps with content splat position 0 | params_flow.rb:134:10:134:16 | synthetic splat argument |
 | params_flow.rb:137:1:137:44 | call to splatall | type tracker without call steps | params_flow.rb:137:1:137:44 | call to splatall |
 | params_flow.rb:137:10:137:43 | * ... | type tracker with call steps | params_flow.rb:133:14:133:18 | *args |
 | params_flow.rb:137:10:137:43 | * ... | type tracker without call steps | params_flow.rb:137:10:137:43 | * ... |
-| params_flow.rb:137:11:137:43 | * | type tracker without call steps | params_flow.rb:137:11:137:43 | * |
 | params_flow.rb:137:11:137:43 | Array | type tracker without call steps | params_flow.rb:137:11:137:43 | Array |
 | params_flow.rb:137:11:137:43 | call to [] | type tracker with call steps with content element 0 or unknown | params_flow.rb:133:14:133:18 | *args |
 | params_flow.rb:137:11:137:43 | call to [] | type tracker without call steps | params_flow.rb:137:11:137:43 | call to [] |
 | params_flow.rb:137:11:137:43 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:137:10:137:43 | * ... |
-| params_flow.rb:137:12:137:20 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:137:12:137:20 | * | type tracker without call steps | params_flow.rb:137:12:137:20 | * |
-| params_flow.rb:137:12:137:20 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:133:14:133:18 | *args |
+| params_flow.rb:137:11:137:43 | synthetic splat argument | type tracker with call steps with content element 0 or unknown | params_flow.rb:133:14:133:18 | *args |
+| params_flow.rb:137:11:137:43 | synthetic splat argument | type tracker without call steps | params_flow.rb:137:11:137:43 | call to [] |
+| params_flow.rb:137:11:137:43 | synthetic splat argument | type tracker without call steps | params_flow.rb:137:11:137:43 | synthetic splat argument |
+| params_flow.rb:137:11:137:43 | synthetic splat argument | type tracker without call steps with content element 0 or unknown | params_flow.rb:137:10:137:43 | * ... |
+| params_flow.rb:137:12:137:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:133:14:133:18 | *args |
 | params_flow.rb:137:12:137:20 | call to taint | type tracker without call steps | params_flow.rb:137:12:137:20 | call to taint |
-| params_flow.rb:137:12:137:20 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:137:11:137:43 | * |
-| params_flow.rb:137:12:137:20 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:137:10:137:43 | * ... |
-| params_flow.rb:137:12:137:20 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:137:11:137:43 | call to [] |
+| params_flow.rb:137:12:137:20 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:137:10:137:43 | * ... |
+| params_flow.rb:137:12:137:20 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:137:11:137:43 | call to [] |
+| params_flow.rb:137:12:137:20 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:137:11:137:43 | synthetic splat argument |
+| params_flow.rb:137:12:137:20 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:137:12:137:20 | synthetic splat argument | type tracker without call steps | params_flow.rb:137:12:137:20 | synthetic splat argument |
 | params_flow.rb:137:18:137:19 | 69 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:137:18:137:19 | 69 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:137:18:137:19 | 69 | type tracker with call steps with content element 0 or unknown | params_flow.rb:133:14:133:18 | *args |
+| params_flow.rb:137:18:137:19 | 69 | type tracker with call steps with content element 0 | params_flow.rb:133:14:133:18 | *args |
+| params_flow.rb:137:18:137:19 | 69 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:137:18:137:19 | 69 | type tracker without call steps | params_flow.rb:137:12:137:20 | call to taint |
 | params_flow.rb:137:18:137:19 | 69 | type tracker without call steps | params_flow.rb:137:18:137:19 | 69 |
-| params_flow.rb:137:18:137:19 | 69 | type tracker without call steps with content element 0 | params_flow.rb:137:11:137:43 | * |
-| params_flow.rb:137:18:137:19 | 69 | type tracker without call steps with content element 0 | params_flow.rb:137:12:137:20 | * |
-| params_flow.rb:137:18:137:19 | 69 | type tracker without call steps with content element 0 or unknown | params_flow.rb:137:10:137:43 | * ... |
-| params_flow.rb:137:18:137:19 | 69 | type tracker without call steps with content element 0 or unknown | params_flow.rb:137:11:137:43 | call to [] |
-| params_flow.rb:137:23:137:31 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:137:23:137:31 | * | type tracker without call steps | params_flow.rb:137:23:137:31 | * |
+| params_flow.rb:137:18:137:19 | 69 | type tracker without call steps with content element 0 | params_flow.rb:137:10:137:43 | * ... |
+| params_flow.rb:137:18:137:19 | 69 | type tracker without call steps with content element 0 | params_flow.rb:137:11:137:43 | call to [] |
+| params_flow.rb:137:18:137:19 | 69 | type tracker without call steps with content element 0 | params_flow.rb:137:11:137:43 | synthetic splat argument |
+| params_flow.rb:137:18:137:19 | 69 | type tracker without call steps with content splat position 0 | params_flow.rb:137:12:137:20 | synthetic splat argument |
 | params_flow.rb:137:23:137:31 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:137:23:137:31 | call to taint | type tracker with call steps | params_flow.rb:134:10:134:16 | ...[...] |
-| params_flow.rb:137:23:137:31 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:137:23:137:31 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:137:23:137:31 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:134:5:134:16 | * |
-| params_flow.rb:137:23:137:31 | call to taint | type tracker with call steps with content element 1 or unknown | params_flow.rb:133:14:133:18 | *args |
+| params_flow.rb:137:23:137:31 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:133:14:133:18 | *args |
+| params_flow.rb:137:23:137:31 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:137:23:137:31 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:137:23:137:31 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:134:5:134:16 | synthetic splat argument |
 | params_flow.rb:137:23:137:31 | call to taint | type tracker without call steps | params_flow.rb:137:23:137:31 | call to taint |
-| params_flow.rb:137:23:137:31 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:137:11:137:43 | * |
-| params_flow.rb:137:23:137:31 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:137:10:137:43 | * ... |
-| params_flow.rb:137:23:137:31 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:137:11:137:43 | call to [] |
+| params_flow.rb:137:23:137:31 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:137:10:137:43 | * ... |
+| params_flow.rb:137:23:137:31 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:137:11:137:43 | call to [] |
+| params_flow.rb:137:23:137:31 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:137:11:137:43 | synthetic splat argument |
+| params_flow.rb:137:23:137:31 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:137:23:137:31 | synthetic splat argument | type tracker without call steps | params_flow.rb:137:23:137:31 | synthetic splat argument |
 | params_flow.rb:137:29:137:30 | 70 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:137:29:137:30 | 70 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:137:29:137:30 | 70 | type tracker with call steps | params_flow.rb:134:10:134:16 | ...[...] |
-| params_flow.rb:137:29:137:30 | 70 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:137:29:137:30 | 70 | type tracker with call steps with content element 0 | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:137:29:137:30 | 70 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:137:29:137:30 | 70 | type tracker with call steps with content element 0 | params_flow.rb:134:5:134:16 | * |
-| params_flow.rb:137:29:137:30 | 70 | type tracker with call steps with content element 1 or unknown | params_flow.rb:133:14:133:18 | *args |
+| params_flow.rb:137:29:137:30 | 70 | type tracker with call steps with content element 1 | params_flow.rb:133:14:133:18 | *args |
+| params_flow.rb:137:29:137:30 | 70 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:137:29:137:30 | 70 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:137:29:137:30 | 70 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:137:29:137:30 | 70 | type tracker with call steps with content splat position 0 | params_flow.rb:134:5:134:16 | synthetic splat argument |
 | params_flow.rb:137:29:137:30 | 70 | type tracker without call steps | params_flow.rb:137:23:137:31 | call to taint |
 | params_flow.rb:137:29:137:30 | 70 | type tracker without call steps | params_flow.rb:137:29:137:30 | 70 |
-| params_flow.rb:137:29:137:30 | 70 | type tracker without call steps with content element 0 | params_flow.rb:137:23:137:31 | * |
-| params_flow.rb:137:29:137:30 | 70 | type tracker without call steps with content element 1 | params_flow.rb:137:11:137:43 | * |
-| params_flow.rb:137:29:137:30 | 70 | type tracker without call steps with content element 1 or unknown | params_flow.rb:137:10:137:43 | * ... |
-| params_flow.rb:137:29:137:30 | 70 | type tracker without call steps with content element 1 or unknown | params_flow.rb:137:11:137:43 | call to [] |
-| params_flow.rb:137:34:137:42 | * | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:137:34:137:42 | * | type tracker without call steps | params_flow.rb:137:34:137:42 | * |
-| params_flow.rb:137:34:137:42 | call to taint | type tracker with call steps with content element 2 or unknown | params_flow.rb:133:14:133:18 | *args |
+| params_flow.rb:137:29:137:30 | 70 | type tracker without call steps with content element 1 | params_flow.rb:137:10:137:43 | * ... |
+| params_flow.rb:137:29:137:30 | 70 | type tracker without call steps with content element 1 | params_flow.rb:137:11:137:43 | call to [] |
+| params_flow.rb:137:29:137:30 | 70 | type tracker without call steps with content element 1 | params_flow.rb:137:11:137:43 | synthetic splat argument |
+| params_flow.rb:137:29:137:30 | 70 | type tracker without call steps with content splat position 0 | params_flow.rb:137:23:137:31 | synthetic splat argument |
+| params_flow.rb:137:34:137:42 | call to taint | type tracker with call steps with content element 2 | params_flow.rb:133:14:133:18 | *args |
 | params_flow.rb:137:34:137:42 | call to taint | type tracker without call steps | params_flow.rb:137:34:137:42 | call to taint |
-| params_flow.rb:137:34:137:42 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:137:11:137:43 | * |
-| params_flow.rb:137:34:137:42 | call to taint | type tracker without call steps with content element 2 or unknown | params_flow.rb:137:10:137:43 | * ... |
-| params_flow.rb:137:34:137:42 | call to taint | type tracker without call steps with content element 2 or unknown | params_flow.rb:137:11:137:43 | call to [] |
+| params_flow.rb:137:34:137:42 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:137:10:137:43 | * ... |
+| params_flow.rb:137:34:137:42 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:137:11:137:43 | call to [] |
+| params_flow.rb:137:34:137:42 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:137:11:137:43 | synthetic splat argument |
+| params_flow.rb:137:34:137:42 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:137:34:137:42 | synthetic splat argument | type tracker without call steps | params_flow.rb:137:34:137:42 | synthetic splat argument |
 | params_flow.rb:137:40:137:41 | 71 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:137:40:137:41 | 71 | type tracker with call steps with content element 0 | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:137:40:137:41 | 71 | type tracker with call steps with content element 2 or unknown | params_flow.rb:133:14:133:18 | *args |
+| params_flow.rb:137:40:137:41 | 71 | type tracker with call steps with content element 2 | params_flow.rb:133:14:133:18 | *args |
+| params_flow.rb:137:40:137:41 | 71 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:137:40:137:41 | 71 | type tracker without call steps | params_flow.rb:137:34:137:42 | call to taint |
 | params_flow.rb:137:40:137:41 | 71 | type tracker without call steps | params_flow.rb:137:40:137:41 | 71 |
-| params_flow.rb:137:40:137:41 | 71 | type tracker without call steps with content element 0 | params_flow.rb:137:34:137:42 | * |
-| params_flow.rb:137:40:137:41 | 71 | type tracker without call steps with content element 2 | params_flow.rb:137:11:137:43 | * |
-| params_flow.rb:137:40:137:41 | 71 | type tracker without call steps with content element 2 or unknown | params_flow.rb:137:10:137:43 | * ... |
-| params_flow.rb:137:40:137:41 | 71 | type tracker without call steps with content element 2 or unknown | params_flow.rb:137:11:137:43 | call to [] |
+| params_flow.rb:137:40:137:41 | 71 | type tracker without call steps with content element 2 | params_flow.rb:137:10:137:43 | * ... |
+| params_flow.rb:137:40:137:41 | 71 | type tracker without call steps with content element 2 | params_flow.rb:137:11:137:43 | call to [] |
+| params_flow.rb:137:40:137:41 | 71 | type tracker without call steps with content element 2 | params_flow.rb:137:11:137:43 | synthetic splat argument |
+| params_flow.rb:137:40:137:41 | 71 | type tracker without call steps with content splat position 0 | params_flow.rb:137:34:137:42 | synthetic splat argument |
 trackEnd
 | params_flow.rb:1:1:3:3 | &block | params_flow.rb:1:1:3:3 | &block |
 | params_flow.rb:1:1:3:3 | self in taint | params_flow.rb:1:1:3:3 | self in taint |
-| params_flow.rb:1:1:3:3 | synthetic *args | params_flow.rb:1:1:3:3 | synthetic *args |
+| params_flow.rb:1:1:3:3 | synthetic splat parameter | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:1:1:3:3 | taint | params_flow.rb:1:1:3:3 | taint |
 | params_flow.rb:1:1:137:45 | self (params_flow.rb) | params_flow.rb:1:1:3:3 | self in taint |
 | params_flow.rb:1:1:137:45 | self (params_flow.rb) | params_flow.rb:1:1:137:45 | self (params_flow.rb) |
@@ -3139,8 +3126,6 @@ trackEnd
 | params_flow.rb:1:11:1:11 | x | params_flow.rb:50:10:50:11 | p1 |
 | params_flow.rb:1:11:1:11 | x | params_flow.rb:51:10:51:21 | ( ... ) |
 | params_flow.rb:1:11:1:11 | x | params_flow.rb:51:11:51:20 | ...[...] |
-| params_flow.rb:1:11:1:11 | x | params_flow.rb:52:10:52:21 | ( ... ) |
-| params_flow.rb:1:11:1:11 | x | params_flow.rb:52:11:52:20 | ...[...] |
 | params_flow.rb:1:11:1:11 | x | params_flow.rb:55:9:55:17 | call to taint |
 | params_flow.rb:1:11:1:11 | x | params_flow.rb:55:20:55:28 | call to taint |
 | params_flow.rb:1:11:1:11 | x | params_flow.rb:57:9:57:17 | call to taint |
@@ -3250,12 +3235,11 @@ trackEnd
 | params_flow.rb:5:1:7:3 | self in sink | params_flow.rb:5:1:7:3 | self in sink |
 | params_flow.rb:5:1:7:3 | self in sink | params_flow.rb:6:5:6:10 | self |
 | params_flow.rb:5:1:7:3 | sink | params_flow.rb:5:1:7:3 | sink |
-| params_flow.rb:5:1:7:3 | synthetic *args | params_flow.rb:5:1:7:3 | synthetic *args |
+| params_flow.rb:5:1:7:3 | synthetic splat parameter | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:5:10:5:10 | x | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:5:10:5:10 | x | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:5:10:5:10 | x | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:5:10:5:10 | x | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:6:5:6:10 | * | params_flow.rb:6:5:6:10 | * |
 | params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:6:5:6:10 | call to puts |
 | params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:10:5:10:11 | call to sink |
 | params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:11:5:11:11 | call to sink |
@@ -3321,6 +3305,7 @@ trackEnd
 | params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:131:1:131:46 | call to pos_many |
 | params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:134:5:134:16 | call to sink |
 | params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:137:1:137:44 | call to splatall |
+| params_flow.rb:6:5:6:10 | synthetic splat argument | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:9:1:12:3 | &block | params_flow.rb:9:1:12:3 | &block |
 | params_flow.rb:9:1:12:3 | positional | params_flow.rb:9:1:12:3 | positional |
 | params_flow.rb:9:1:12:3 | self in positional | params_flow.rb:5:1:7:3 | self (sink) |
@@ -3330,7 +3315,7 @@ trackEnd
 | params_flow.rb:9:1:12:3 | self in positional | params_flow.rb:9:1:12:3 | self in positional |
 | params_flow.rb:9:1:12:3 | self in positional | params_flow.rb:10:5:10:11 | self |
 | params_flow.rb:9:1:12:3 | self in positional | params_flow.rb:11:5:11:11 | self |
-| params_flow.rb:9:1:12:3 | synthetic *args | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:9:1:12:3 | synthetic splat parameter | params_flow.rb:9:1:12:3 | synthetic splat parameter |
 | params_flow.rb:9:16:9:17 | p1 | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:9:16:9:17 | p1 | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:9:16:9:17 | p1 | params_flow.rb:6:10:6:10 | x |
@@ -3345,21 +3330,19 @@ trackEnd
 | params_flow.rb:9:20:9:21 | p2 | params_flow.rb:9:20:9:21 | p2 |
 | params_flow.rb:9:20:9:21 | p2 | params_flow.rb:9:20:9:21 | p2 |
 | params_flow.rb:9:20:9:21 | p2 | params_flow.rb:11:10:11:11 | p2 |
-| params_flow.rb:10:5:10:11 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:10:5:10:11 | * | params_flow.rb:10:5:10:11 | * |
 | params_flow.rb:10:5:10:11 | call to sink | params_flow.rb:10:5:10:11 | call to sink |
-| params_flow.rb:11:5:11:11 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:11:5:11:11 | * | params_flow.rb:11:5:11:11 | * |
+| params_flow.rb:10:5:10:11 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:10:5:10:11 | synthetic splat argument | params_flow.rb:10:5:10:11 | synthetic splat argument |
 | params_flow.rb:11:5:11:11 | call to sink | params_flow.rb:11:5:11:11 | call to sink |
 | params_flow.rb:11:5:11:11 | call to sink | params_flow.rb:14:1:14:30 | call to positional |
 | params_flow.rb:11:5:11:11 | call to sink | params_flow.rb:44:1:44:28 | call to positional |
 | params_flow.rb:11:5:11:11 | call to sink | params_flow.rb:47:1:47:17 | call to positional |
 | params_flow.rb:11:5:11:11 | call to sink | params_flow.rb:118:1:118:14 | call to positional |
-| params_flow.rb:14:1:14:30 | * | params_flow.rb:9:1:12:3 | synthetic *args |
-| params_flow.rb:14:1:14:30 | * | params_flow.rb:14:1:14:30 | * |
+| params_flow.rb:11:5:11:11 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:11:5:11:11 | synthetic splat argument | params_flow.rb:11:5:11:11 | synthetic splat argument |
 | params_flow.rb:14:1:14:30 | call to positional | params_flow.rb:14:1:14:30 | call to positional |
-| params_flow.rb:14:12:14:19 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:14:12:14:19 | * | params_flow.rb:14:12:14:19 | * |
+| params_flow.rb:14:1:14:30 | synthetic splat argument | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:14:1:14:30 | synthetic splat argument | params_flow.rb:14:1:14:30 | synthetic splat argument |
 | params_flow.rb:14:12:14:19 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:14:12:14:19 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:14:12:14:19 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -3367,6 +3350,8 @@ trackEnd
 | params_flow.rb:14:12:14:19 | call to taint | params_flow.rb:9:16:9:17 | p1 |
 | params_flow.rb:14:12:14:19 | call to taint | params_flow.rb:10:10:10:11 | p1 |
 | params_flow.rb:14:12:14:19 | call to taint | params_flow.rb:14:12:14:19 | call to taint |
+| params_flow.rb:14:12:14:19 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:14:12:14:19 | synthetic splat argument | params_flow.rb:14:12:14:19 | synthetic splat argument |
 | params_flow.rb:14:18:14:18 | 1 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:14:18:14:18 | 1 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:14:18:14:18 | 1 | params_flow.rb:2:5:2:5 | x |
@@ -3378,8 +3363,6 @@ trackEnd
 | params_flow.rb:14:18:14:18 | 1 | params_flow.rb:10:10:10:11 | p1 |
 | params_flow.rb:14:18:14:18 | 1 | params_flow.rb:14:12:14:19 | call to taint |
 | params_flow.rb:14:18:14:18 | 1 | params_flow.rb:14:18:14:18 | 1 |
-| params_flow.rb:14:22:14:29 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:14:22:14:29 | * | params_flow.rb:14:22:14:29 | * |
 | params_flow.rb:14:22:14:29 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:14:22:14:29 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:14:22:14:29 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -3387,6 +3370,8 @@ trackEnd
 | params_flow.rb:14:22:14:29 | call to taint | params_flow.rb:9:20:9:21 | p2 |
 | params_flow.rb:14:22:14:29 | call to taint | params_flow.rb:11:10:11:11 | p2 |
 | params_flow.rb:14:22:14:29 | call to taint | params_flow.rb:14:22:14:29 | call to taint |
+| params_flow.rb:14:22:14:29 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:14:22:14:29 | synthetic splat argument | params_flow.rb:14:22:14:29 | synthetic splat argument |
 | params_flow.rb:14:28:14:28 | 2 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:14:28:14:28 | 2 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:14:28:14:28 | 2 | params_flow.rb:2:5:2:5 | x |
@@ -3399,7 +3384,6 @@ trackEnd
 | params_flow.rb:14:28:14:28 | 2 | params_flow.rb:14:22:14:29 | call to taint |
 | params_flow.rb:14:28:14:28 | 2 | params_flow.rb:14:28:14:28 | 2 |
 | params_flow.rb:16:1:19:3 | &block | params_flow.rb:16:1:19:3 | &block |
-| params_flow.rb:16:1:19:3 | **kwargs | params_flow.rb:16:1:19:3 | **kwargs |
 | params_flow.rb:16:1:19:3 | keyword | params_flow.rb:16:1:19:3 | keyword |
 | params_flow.rb:16:1:19:3 | self in keyword | params_flow.rb:5:1:7:3 | self (sink) |
 | params_flow.rb:16:1:19:3 | self in keyword | params_flow.rb:5:1:7:3 | self in sink |
@@ -3408,6 +3392,7 @@ trackEnd
 | params_flow.rb:16:1:19:3 | self in keyword | params_flow.rb:16:1:19:3 | self in keyword |
 | params_flow.rb:16:1:19:3 | self in keyword | params_flow.rb:17:5:17:11 | self |
 | params_flow.rb:16:1:19:3 | self in keyword | params_flow.rb:18:5:18:11 | self |
+| params_flow.rb:16:1:19:3 | synthetic hash-splat parameter | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:16:13:16:14 | p1 | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:16:13:16:14 | p1 | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:16:13:16:14 | p1 | params_flow.rb:6:10:6:10 | x |
@@ -3422,23 +3407,21 @@ trackEnd
 | params_flow.rb:16:18:16:19 | p2 | params_flow.rb:16:18:16:19 | p2 |
 | params_flow.rb:16:18:16:19 | p2 | params_flow.rb:16:18:16:19 | p2 |
 | params_flow.rb:16:18:16:19 | p2 | params_flow.rb:18:10:18:11 | p2 |
-| params_flow.rb:17:5:17:11 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:17:5:17:11 | * | params_flow.rb:17:5:17:11 | * |
 | params_flow.rb:17:5:17:11 | call to sink | params_flow.rb:17:5:17:11 | call to sink |
-| params_flow.rb:18:5:18:11 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:18:5:18:11 | * | params_flow.rb:18:5:18:11 | * |
+| params_flow.rb:17:5:17:11 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:17:5:17:11 | synthetic splat argument | params_flow.rb:17:5:17:11 | synthetic splat argument |
 | params_flow.rb:18:5:18:11 | call to sink | params_flow.rb:18:5:18:11 | call to sink |
 | params_flow.rb:18:5:18:11 | call to sink | params_flow.rb:21:1:21:35 | call to keyword |
 | params_flow.rb:18:5:18:11 | call to sink | params_flow.rb:22:1:22:35 | call to keyword |
 | params_flow.rb:18:5:18:11 | call to sink | params_flow.rb:23:1:23:41 | call to keyword |
 | params_flow.rb:18:5:18:11 | call to sink | params_flow.rb:41:1:41:30 | call to keyword |
-| params_flow.rb:21:1:21:35 | ** | params_flow.rb:16:1:19:3 | **kwargs |
-| params_flow.rb:21:1:21:35 | ** | params_flow.rb:21:1:21:35 | ** |
+| params_flow.rb:18:5:18:11 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:18:5:18:11 | synthetic splat argument | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:21:1:21:35 | call to keyword | params_flow.rb:21:1:21:35 | call to keyword |
+| params_flow.rb:21:1:21:35 | synthetic hash-splat argument | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
+| params_flow.rb:21:1:21:35 | synthetic hash-splat argument | params_flow.rb:21:1:21:35 | synthetic hash-splat argument |
 | params_flow.rb:21:9:21:10 | :p1 | params_flow.rb:21:9:21:10 | :p1 |
 | params_flow.rb:21:9:21:20 | Pair | params_flow.rb:21:9:21:20 | Pair |
-| params_flow.rb:21:13:21:20 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:21:13:21:20 | * | params_flow.rb:21:13:21:20 | * |
 | params_flow.rb:21:13:21:20 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:21:13:21:20 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:21:13:21:20 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -3446,6 +3429,8 @@ trackEnd
 | params_flow.rb:21:13:21:20 | call to taint | params_flow.rb:16:13:16:14 | p1 |
 | params_flow.rb:21:13:21:20 | call to taint | params_flow.rb:17:10:17:11 | p1 |
 | params_flow.rb:21:13:21:20 | call to taint | params_flow.rb:21:13:21:20 | call to taint |
+| params_flow.rb:21:13:21:20 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:21:13:21:20 | synthetic splat argument | params_flow.rb:21:13:21:20 | synthetic splat argument |
 | params_flow.rb:21:19:21:19 | 3 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:21:19:21:19 | 3 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:21:19:21:19 | 3 | params_flow.rb:2:5:2:5 | x |
@@ -3459,8 +3444,6 @@ trackEnd
 | params_flow.rb:21:19:21:19 | 3 | params_flow.rb:21:19:21:19 | 3 |
 | params_flow.rb:21:23:21:24 | :p2 | params_flow.rb:21:23:21:24 | :p2 |
 | params_flow.rb:21:23:21:34 | Pair | params_flow.rb:21:23:21:34 | Pair |
-| params_flow.rb:21:27:21:34 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:21:27:21:34 | * | params_flow.rb:21:27:21:34 | * |
 | params_flow.rb:21:27:21:34 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:21:27:21:34 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:21:27:21:34 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -3468,6 +3451,8 @@ trackEnd
 | params_flow.rb:21:27:21:34 | call to taint | params_flow.rb:16:18:16:19 | p2 |
 | params_flow.rb:21:27:21:34 | call to taint | params_flow.rb:18:10:18:11 | p2 |
 | params_flow.rb:21:27:21:34 | call to taint | params_flow.rb:21:27:21:34 | call to taint |
+| params_flow.rb:21:27:21:34 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:21:27:21:34 | synthetic splat argument | params_flow.rb:21:27:21:34 | synthetic splat argument |
 | params_flow.rb:21:33:21:33 | 4 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:21:33:21:33 | 4 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:21:33:21:33 | 4 | params_flow.rb:2:5:2:5 | x |
@@ -3479,13 +3464,11 @@ trackEnd
 | params_flow.rb:21:33:21:33 | 4 | params_flow.rb:18:10:18:11 | p2 |
 | params_flow.rb:21:33:21:33 | 4 | params_flow.rb:21:27:21:34 | call to taint |
 | params_flow.rb:21:33:21:33 | 4 | params_flow.rb:21:33:21:33 | 4 |
-| params_flow.rb:22:1:22:35 | ** | params_flow.rb:16:1:19:3 | **kwargs |
-| params_flow.rb:22:1:22:35 | ** | params_flow.rb:22:1:22:35 | ** |
 | params_flow.rb:22:1:22:35 | call to keyword | params_flow.rb:22:1:22:35 | call to keyword |
+| params_flow.rb:22:1:22:35 | synthetic hash-splat argument | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
+| params_flow.rb:22:1:22:35 | synthetic hash-splat argument | params_flow.rb:22:1:22:35 | synthetic hash-splat argument |
 | params_flow.rb:22:9:22:10 | :p2 | params_flow.rb:22:9:22:10 | :p2 |
 | params_flow.rb:22:9:22:20 | Pair | params_flow.rb:22:9:22:20 | Pair |
-| params_flow.rb:22:13:22:20 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:22:13:22:20 | * | params_flow.rb:22:13:22:20 | * |
 | params_flow.rb:22:13:22:20 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:22:13:22:20 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:22:13:22:20 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -3493,6 +3476,8 @@ trackEnd
 | params_flow.rb:22:13:22:20 | call to taint | params_flow.rb:16:18:16:19 | p2 |
 | params_flow.rb:22:13:22:20 | call to taint | params_flow.rb:18:10:18:11 | p2 |
 | params_flow.rb:22:13:22:20 | call to taint | params_flow.rb:22:13:22:20 | call to taint |
+| params_flow.rb:22:13:22:20 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:22:13:22:20 | synthetic splat argument | params_flow.rb:22:13:22:20 | synthetic splat argument |
 | params_flow.rb:22:19:22:19 | 5 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:22:19:22:19 | 5 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:22:19:22:19 | 5 | params_flow.rb:2:5:2:5 | x |
@@ -3506,8 +3491,6 @@ trackEnd
 | params_flow.rb:22:19:22:19 | 5 | params_flow.rb:22:19:22:19 | 5 |
 | params_flow.rb:22:23:22:24 | :p1 | params_flow.rb:22:23:22:24 | :p1 |
 | params_flow.rb:22:23:22:34 | Pair | params_flow.rb:22:23:22:34 | Pair |
-| params_flow.rb:22:27:22:34 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:22:27:22:34 | * | params_flow.rb:22:27:22:34 | * |
 | params_flow.rb:22:27:22:34 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:22:27:22:34 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:22:27:22:34 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -3515,6 +3498,8 @@ trackEnd
 | params_flow.rb:22:27:22:34 | call to taint | params_flow.rb:16:13:16:14 | p1 |
 | params_flow.rb:22:27:22:34 | call to taint | params_flow.rb:17:10:17:11 | p1 |
 | params_flow.rb:22:27:22:34 | call to taint | params_flow.rb:22:27:22:34 | call to taint |
+| params_flow.rb:22:27:22:34 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:22:27:22:34 | synthetic splat argument | params_flow.rb:22:27:22:34 | synthetic splat argument |
 | params_flow.rb:22:33:22:33 | 6 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:22:33:22:33 | 6 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:22:33:22:33 | 6 | params_flow.rb:2:5:2:5 | x |
@@ -3526,13 +3511,11 @@ trackEnd
 | params_flow.rb:22:33:22:33 | 6 | params_flow.rb:17:10:17:11 | p1 |
 | params_flow.rb:22:33:22:33 | 6 | params_flow.rb:22:27:22:34 | call to taint |
 | params_flow.rb:22:33:22:33 | 6 | params_flow.rb:22:33:22:33 | 6 |
-| params_flow.rb:23:1:23:41 | ** | params_flow.rb:16:1:19:3 | **kwargs |
-| params_flow.rb:23:1:23:41 | ** | params_flow.rb:23:1:23:41 | ** |
 | params_flow.rb:23:1:23:41 | call to keyword | params_flow.rb:23:1:23:41 | call to keyword |
+| params_flow.rb:23:1:23:41 | synthetic hash-splat argument | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
+| params_flow.rb:23:1:23:41 | synthetic hash-splat argument | params_flow.rb:23:1:23:41 | synthetic hash-splat argument |
 | params_flow.rb:23:9:23:11 | :p2 | params_flow.rb:23:9:23:11 | :p2 |
 | params_flow.rb:23:9:23:23 | Pair | params_flow.rb:23:9:23:23 | Pair |
-| params_flow.rb:23:16:23:23 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:23:16:23:23 | * | params_flow.rb:23:16:23:23 | * |
 | params_flow.rb:23:16:23:23 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:23:16:23:23 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:23:16:23:23 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -3540,6 +3523,8 @@ trackEnd
 | params_flow.rb:23:16:23:23 | call to taint | params_flow.rb:16:18:16:19 | p2 |
 | params_flow.rb:23:16:23:23 | call to taint | params_flow.rb:18:10:18:11 | p2 |
 | params_flow.rb:23:16:23:23 | call to taint | params_flow.rb:23:16:23:23 | call to taint |
+| params_flow.rb:23:16:23:23 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:23:16:23:23 | synthetic splat argument | params_flow.rb:23:16:23:23 | synthetic splat argument |
 | params_flow.rb:23:22:23:22 | 7 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:23:22:23:22 | 7 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:23:22:23:22 | 7 | params_flow.rb:2:5:2:5 | x |
@@ -3553,8 +3538,6 @@ trackEnd
 | params_flow.rb:23:22:23:22 | 7 | params_flow.rb:23:22:23:22 | 7 |
 | params_flow.rb:23:26:23:28 | :p1 | params_flow.rb:23:26:23:28 | :p1 |
 | params_flow.rb:23:26:23:40 | Pair | params_flow.rb:23:26:23:40 | Pair |
-| params_flow.rb:23:33:23:40 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:23:33:23:40 | * | params_flow.rb:23:33:23:40 | * |
 | params_flow.rb:23:33:23:40 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:23:33:23:40 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:23:33:23:40 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -3562,6 +3545,8 @@ trackEnd
 | params_flow.rb:23:33:23:40 | call to taint | params_flow.rb:16:13:16:14 | p1 |
 | params_flow.rb:23:33:23:40 | call to taint | params_flow.rb:17:10:17:11 | p1 |
 | params_flow.rb:23:33:23:40 | call to taint | params_flow.rb:23:33:23:40 | call to taint |
+| params_flow.rb:23:33:23:40 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:23:33:23:40 | synthetic splat argument | params_flow.rb:23:33:23:40 | synthetic splat argument |
 | params_flow.rb:23:39:23:39 | 8 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:23:39:23:39 | 8 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:23:39:23:39 | 8 | params_flow.rb:2:5:2:5 | x |
@@ -3574,7 +3559,6 @@ trackEnd
 | params_flow.rb:23:39:23:39 | 8 | params_flow.rb:23:33:23:40 | call to taint |
 | params_flow.rb:23:39:23:39 | 8 | params_flow.rb:23:39:23:39 | 8 |
 | params_flow.rb:25:1:31:3 | &block | params_flow.rb:25:1:31:3 | &block |
-| params_flow.rb:25:1:31:3 | **kwargs | params_flow.rb:25:1:31:3 | **kwargs |
 | params_flow.rb:25:1:31:3 | kwargs | params_flow.rb:25:1:31:3 | kwargs |
 | params_flow.rb:25:1:31:3 | self in kwargs | params_flow.rb:5:1:7:3 | self (sink) |
 | params_flow.rb:25:1:31:3 | self in kwargs | params_flow.rb:5:1:7:3 | self in sink |
@@ -3586,6 +3570,7 @@ trackEnd
 | params_flow.rb:25:1:31:3 | self in kwargs | params_flow.rb:28:5:28:22 | self |
 | params_flow.rb:25:1:31:3 | self in kwargs | params_flow.rb:29:5:29:22 | self |
 | params_flow.rb:25:1:31:3 | self in kwargs | params_flow.rb:30:5:30:22 | self |
+| params_flow.rb:25:1:31:3 | synthetic hash-splat parameter | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:25:12:25:13 | p1 | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:25:12:25:13 | p1 | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:25:12:25:13 | p1 | params_flow.rb:6:10:6:10 | x |
@@ -3600,65 +3585,63 @@ trackEnd
 | params_flow.rb:25:17:25:24 | **kwargs | params_flow.rb:29:11:29:16 | kwargs |
 | params_flow.rb:25:17:25:24 | **kwargs | params_flow.rb:30:11:30:16 | kwargs |
 | params_flow.rb:25:19:25:24 | kwargs | params_flow.rb:25:19:25:24 | kwargs |
-| params_flow.rb:26:5:26:11 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:26:5:26:11 | * | params_flow.rb:26:5:26:11 | * |
 | params_flow.rb:26:5:26:11 | call to sink | params_flow.rb:26:5:26:11 | call to sink |
-| params_flow.rb:27:5:27:22 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:27:5:27:22 | * | params_flow.rb:27:5:27:22 | * |
+| params_flow.rb:26:5:26:11 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:26:5:26:11 | synthetic splat argument | params_flow.rb:26:5:26:11 | synthetic splat argument |
 | params_flow.rb:27:5:27:22 | call to sink | params_flow.rb:27:5:27:22 | call to sink |
-| params_flow.rb:27:11:27:21 | * | params_flow.rb:27:11:27:21 | * |
+| params_flow.rb:27:5:27:22 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:27:5:27:22 | synthetic splat argument | params_flow.rb:27:5:27:22 | synthetic splat argument |
 | params_flow.rb:27:11:27:21 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:27:11:27:21 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:27:11:27:21 | ...[...] | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:27:11:27:21 | ...[...] | params_flow.rb:27:10:27:22 | ( ... ) |
 | params_flow.rb:27:11:27:21 | ...[...] | params_flow.rb:27:11:27:21 | ...[...] |
+| params_flow.rb:27:11:27:21 | synthetic splat argument | params_flow.rb:27:11:27:21 | synthetic splat argument |
 | params_flow.rb:27:18:27:20 | :p1 | params_flow.rb:27:18:27:20 | :p1 |
-| params_flow.rb:28:5:28:22 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:28:5:28:22 | * | params_flow.rb:28:5:28:22 | * |
 | params_flow.rb:28:5:28:22 | call to sink | params_flow.rb:28:5:28:22 | call to sink |
-| params_flow.rb:28:11:28:21 | * | params_flow.rb:28:11:28:21 | * |
+| params_flow.rb:28:5:28:22 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:28:5:28:22 | synthetic splat argument | params_flow.rb:28:5:28:22 | synthetic splat argument |
 | params_flow.rb:28:11:28:21 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:28:11:28:21 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:28:11:28:21 | ...[...] | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:28:11:28:21 | ...[...] | params_flow.rb:28:10:28:22 | ( ... ) |
 | params_flow.rb:28:11:28:21 | ...[...] | params_flow.rb:28:11:28:21 | ...[...] |
+| params_flow.rb:28:11:28:21 | synthetic splat argument | params_flow.rb:28:11:28:21 | synthetic splat argument |
 | params_flow.rb:28:18:28:20 | :p2 | params_flow.rb:28:18:28:20 | :p2 |
-| params_flow.rb:29:5:29:22 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:29:5:29:22 | * | params_flow.rb:29:5:29:22 | * |
 | params_flow.rb:29:5:29:22 | call to sink | params_flow.rb:29:5:29:22 | call to sink |
-| params_flow.rb:29:11:29:21 | * | params_flow.rb:29:11:29:21 | * |
+| params_flow.rb:29:5:29:22 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:29:5:29:22 | synthetic splat argument | params_flow.rb:29:5:29:22 | synthetic splat argument |
 | params_flow.rb:29:11:29:21 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:29:11:29:21 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:29:11:29:21 | ...[...] | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:29:11:29:21 | ...[...] | params_flow.rb:29:10:29:22 | ( ... ) |
 | params_flow.rb:29:11:29:21 | ...[...] | params_flow.rb:29:11:29:21 | ...[...] |
+| params_flow.rb:29:11:29:21 | synthetic splat argument | params_flow.rb:29:11:29:21 | synthetic splat argument |
 | params_flow.rb:29:18:29:20 | :p3 | params_flow.rb:29:18:29:20 | :p3 |
-| params_flow.rb:30:5:30:22 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:30:5:30:22 | * | params_flow.rb:30:5:30:22 | * |
 | params_flow.rb:30:5:30:22 | call to sink | params_flow.rb:30:5:30:22 | call to sink |
 | params_flow.rb:30:5:30:22 | call to sink | params_flow.rb:33:1:33:58 | call to kwargs |
 | params_flow.rb:30:5:30:22 | call to sink | params_flow.rb:35:1:35:29 | call to kwargs |
 | params_flow.rb:30:5:30:22 | call to sink | params_flow.rb:38:1:38:14 | call to kwargs |
-| params_flow.rb:30:11:30:21 | * | params_flow.rb:30:11:30:21 | * |
+| params_flow.rb:30:5:30:22 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:30:5:30:22 | synthetic splat argument | params_flow.rb:30:5:30:22 | synthetic splat argument |
 | params_flow.rb:30:11:30:21 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:30:11:30:21 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:30:11:30:21 | ...[...] | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:30:11:30:21 | ...[...] | params_flow.rb:30:10:30:22 | ( ... ) |
 | params_flow.rb:30:11:30:21 | ...[...] | params_flow.rb:30:11:30:21 | ...[...] |
+| params_flow.rb:30:11:30:21 | synthetic splat argument | params_flow.rb:30:11:30:21 | synthetic splat argument |
 | params_flow.rb:30:18:30:20 | :p4 | params_flow.rb:30:18:30:20 | :p4 |
-| params_flow.rb:33:1:33:58 | ** | params_flow.rb:25:1:31:3 | **kwargs |
-| params_flow.rb:33:1:33:58 | ** | params_flow.rb:25:17:25:24 | **kwargs |
-| params_flow.rb:33:1:33:58 | ** | params_flow.rb:25:19:25:24 | kwargs |
-| params_flow.rb:33:1:33:58 | ** | params_flow.rb:27:11:27:16 | kwargs |
-| params_flow.rb:33:1:33:58 | ** | params_flow.rb:28:11:28:16 | kwargs |
-| params_flow.rb:33:1:33:58 | ** | params_flow.rb:29:11:29:16 | kwargs |
-| params_flow.rb:33:1:33:58 | ** | params_flow.rb:30:11:30:16 | kwargs |
-| params_flow.rb:33:1:33:58 | ** | params_flow.rb:33:1:33:58 | ** |
 | params_flow.rb:33:1:33:58 | call to kwargs | params_flow.rb:33:1:33:58 | call to kwargs |
+| params_flow.rb:33:1:33:58 | synthetic hash-splat argument | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
+| params_flow.rb:33:1:33:58 | synthetic hash-splat argument | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:1:33:58 | synthetic hash-splat argument | params_flow.rb:25:19:25:24 | kwargs |
+| params_flow.rb:33:1:33:58 | synthetic hash-splat argument | params_flow.rb:27:11:27:16 | kwargs |
+| params_flow.rb:33:1:33:58 | synthetic hash-splat argument | params_flow.rb:28:11:28:16 | kwargs |
+| params_flow.rb:33:1:33:58 | synthetic hash-splat argument | params_flow.rb:29:11:29:16 | kwargs |
+| params_flow.rb:33:1:33:58 | synthetic hash-splat argument | params_flow.rb:30:11:30:16 | kwargs |
+| params_flow.rb:33:1:33:58 | synthetic hash-splat argument | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
 | params_flow.rb:33:8:33:9 | :p1 | params_flow.rb:33:8:33:9 | :p1 |
 | params_flow.rb:33:8:33:19 | Pair | params_flow.rb:33:8:33:19 | Pair |
-| params_flow.rb:33:12:33:19 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:33:12:33:19 | * | params_flow.rb:33:12:33:19 | * |
 | params_flow.rb:33:12:33:19 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:33:12:33:19 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:33:12:33:19 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -3668,6 +3651,8 @@ trackEnd
 | params_flow.rb:33:12:33:19 | call to taint | params_flow.rb:27:10:27:22 | ( ... ) |
 | params_flow.rb:33:12:33:19 | call to taint | params_flow.rb:27:11:27:21 | ...[...] |
 | params_flow.rb:33:12:33:19 | call to taint | params_flow.rb:33:12:33:19 | call to taint |
+| params_flow.rb:33:12:33:19 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:33:12:33:19 | synthetic splat argument | params_flow.rb:33:12:33:19 | synthetic splat argument |
 | params_flow.rb:33:18:33:18 | 9 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:33:18:33:18 | 9 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:33:18:33:18 | 9 | params_flow.rb:2:5:2:5 | x |
@@ -3683,14 +3668,14 @@ trackEnd
 | params_flow.rb:33:18:33:18 | 9 | params_flow.rb:33:18:33:18 | 9 |
 | params_flow.rb:33:22:33:23 | :p2 | params_flow.rb:33:22:33:23 | :p2 |
 | params_flow.rb:33:22:33:34 | Pair | params_flow.rb:33:22:33:34 | Pair |
-| params_flow.rb:33:26:33:34 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:33:26:33:34 | * | params_flow.rb:33:26:33:34 | * |
 | params_flow.rb:33:26:33:34 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:33:26:33:34 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:33:26:33:34 | call to taint | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:33:26:33:34 | call to taint | params_flow.rb:28:10:28:22 | ( ... ) |
 | params_flow.rb:33:26:33:34 | call to taint | params_flow.rb:28:11:28:21 | ...[...] |
 | params_flow.rb:33:26:33:34 | call to taint | params_flow.rb:33:26:33:34 | call to taint |
+| params_flow.rb:33:26:33:34 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:33:26:33:34 | synthetic splat argument | params_flow.rb:33:26:33:34 | synthetic splat argument |
 | params_flow.rb:33:32:33:33 | 10 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:33:32:33:33 | 10 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:33:32:33:33 | 10 | params_flow.rb:2:5:2:5 | x |
@@ -3703,14 +3688,14 @@ trackEnd
 | params_flow.rb:33:32:33:33 | 10 | params_flow.rb:33:32:33:33 | 10 |
 | params_flow.rb:33:37:33:38 | :p3 | params_flow.rb:33:37:33:38 | :p3 |
 | params_flow.rb:33:37:33:49 | Pair | params_flow.rb:33:37:33:49 | Pair |
-| params_flow.rb:33:41:33:49 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:33:41:33:49 | * | params_flow.rb:33:41:33:49 | * |
 | params_flow.rb:33:41:33:49 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:33:41:33:49 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:33:41:33:49 | call to taint | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:33:41:33:49 | call to taint | params_flow.rb:29:10:29:22 | ( ... ) |
 | params_flow.rb:33:41:33:49 | call to taint | params_flow.rb:29:11:29:21 | ...[...] |
 | params_flow.rb:33:41:33:49 | call to taint | params_flow.rb:33:41:33:49 | call to taint |
+| params_flow.rb:33:41:33:49 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:33:41:33:49 | synthetic splat argument | params_flow.rb:33:41:33:49 | synthetic splat argument |
 | params_flow.rb:33:47:33:48 | 11 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:33:47:33:48 | 11 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:33:47:33:48 | 11 | params_flow.rb:2:5:2:5 | x |
@@ -3730,22 +3715,26 @@ trackEnd
 | params_flow.rb:33:56:33:57 | "" | params_flow.rb:30:11:30:21 | ...[...] |
 | params_flow.rb:33:56:33:57 | "" | params_flow.rb:33:56:33:57 | "" |
 | params_flow.rb:34:1:34:4 | args | params_flow.rb:34:1:34:4 | args |
-| params_flow.rb:34:8:34:32 | ** | params_flow.rb:34:8:34:32 | ** |
 | params_flow.rb:34:8:34:32 | Hash | params_flow.rb:34:8:34:32 | Hash |
 | params_flow.rb:34:8:34:32 | call to [] | params_flow.rb:34:1:34:4 | args |
 | params_flow.rb:34:8:34:32 | call to [] | params_flow.rb:34:1:34:32 | ... = ... |
 | params_flow.rb:34:8:34:32 | call to [] | params_flow.rb:34:8:34:32 | call to [] |
 | params_flow.rb:34:8:34:32 | call to [] | params_flow.rb:35:25:35:28 | args |
+| params_flow.rb:34:8:34:32 | synthetic hash-splat argument | params_flow.rb:34:1:34:4 | args |
+| params_flow.rb:34:8:34:32 | synthetic hash-splat argument | params_flow.rb:34:1:34:32 | ... = ... |
+| params_flow.rb:34:8:34:32 | synthetic hash-splat argument | params_flow.rb:34:8:34:32 | call to [] |
+| params_flow.rb:34:8:34:32 | synthetic hash-splat argument | params_flow.rb:34:8:34:32 | synthetic hash-splat argument |
+| params_flow.rb:34:8:34:32 | synthetic hash-splat argument | params_flow.rb:35:25:35:28 | args |
 | params_flow.rb:34:10:34:11 | :p3 | params_flow.rb:34:10:34:11 | :p3 |
 | params_flow.rb:34:10:34:22 | Pair | params_flow.rb:34:10:34:22 | Pair |
-| params_flow.rb:34:14:34:22 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:34:14:34:22 | * | params_flow.rb:34:14:34:22 | * |
 | params_flow.rb:34:14:34:22 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:34:14:34:22 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:34:14:34:22 | call to taint | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:34:14:34:22 | call to taint | params_flow.rb:29:10:29:22 | ( ... ) |
 | params_flow.rb:34:14:34:22 | call to taint | params_flow.rb:29:11:29:21 | ...[...] |
 | params_flow.rb:34:14:34:22 | call to taint | params_flow.rb:34:14:34:22 | call to taint |
+| params_flow.rb:34:14:34:22 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:34:14:34:22 | synthetic splat argument | params_flow.rb:34:14:34:22 | synthetic splat argument |
 | params_flow.rb:34:20:34:21 | 12 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:34:20:34:21 | 12 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:34:20:34:21 | 12 | params_flow.rb:2:5:2:5 | x |
@@ -3764,19 +3753,17 @@ trackEnd
 | params_flow.rb:34:29:34:30 | "" | params_flow.rb:30:10:30:22 | ( ... ) |
 | params_flow.rb:34:29:34:30 | "" | params_flow.rb:30:11:30:21 | ...[...] |
 | params_flow.rb:34:29:34:30 | "" | params_flow.rb:34:29:34:30 | "" |
-| params_flow.rb:35:1:35:29 | ** | params_flow.rb:25:1:31:3 | **kwargs |
-| params_flow.rb:35:1:35:29 | ** | params_flow.rb:25:17:25:24 | **kwargs |
-| params_flow.rb:35:1:35:29 | ** | params_flow.rb:25:19:25:24 | kwargs |
-| params_flow.rb:35:1:35:29 | ** | params_flow.rb:27:11:27:16 | kwargs |
-| params_flow.rb:35:1:35:29 | ** | params_flow.rb:28:11:28:16 | kwargs |
-| params_flow.rb:35:1:35:29 | ** | params_flow.rb:29:11:29:16 | kwargs |
-| params_flow.rb:35:1:35:29 | ** | params_flow.rb:30:11:30:16 | kwargs |
-| params_flow.rb:35:1:35:29 | ** | params_flow.rb:35:1:35:29 | ** |
 | params_flow.rb:35:1:35:29 | call to kwargs | params_flow.rb:35:1:35:29 | call to kwargs |
+| params_flow.rb:35:1:35:29 | synthetic hash-splat argument | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
+| params_flow.rb:35:1:35:29 | synthetic hash-splat argument | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:35:1:35:29 | synthetic hash-splat argument | params_flow.rb:25:19:25:24 | kwargs |
+| params_flow.rb:35:1:35:29 | synthetic hash-splat argument | params_flow.rb:27:11:27:16 | kwargs |
+| params_flow.rb:35:1:35:29 | synthetic hash-splat argument | params_flow.rb:28:11:28:16 | kwargs |
+| params_flow.rb:35:1:35:29 | synthetic hash-splat argument | params_flow.rb:29:11:29:16 | kwargs |
+| params_flow.rb:35:1:35:29 | synthetic hash-splat argument | params_flow.rb:30:11:30:16 | kwargs |
+| params_flow.rb:35:1:35:29 | synthetic hash-splat argument | params_flow.rb:35:1:35:29 | synthetic hash-splat argument |
 | params_flow.rb:35:8:35:9 | :p1 | params_flow.rb:35:8:35:9 | :p1 |
 | params_flow.rb:35:8:35:20 | Pair | params_flow.rb:35:8:35:20 | Pair |
-| params_flow.rb:35:12:35:20 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:35:12:35:20 | * | params_flow.rb:35:12:35:20 | * |
 | params_flow.rb:35:12:35:20 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:35:12:35:20 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:35:12:35:20 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -3786,6 +3773,8 @@ trackEnd
 | params_flow.rb:35:12:35:20 | call to taint | params_flow.rb:27:10:27:22 | ( ... ) |
 | params_flow.rb:35:12:35:20 | call to taint | params_flow.rb:27:11:27:21 | ...[...] |
 | params_flow.rb:35:12:35:20 | call to taint | params_flow.rb:35:12:35:20 | call to taint |
+| params_flow.rb:35:12:35:20 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:35:12:35:20 | synthetic splat argument | params_flow.rb:35:12:35:20 | synthetic splat argument |
 | params_flow.rb:35:18:35:19 | 13 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:35:18:35:19 | 13 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:35:18:35:19 | 13 | params_flow.rb:2:5:2:5 | x |
@@ -3799,7 +3788,7 @@ trackEnd
 | params_flow.rb:35:18:35:19 | 13 | params_flow.rb:27:11:27:21 | ...[...] |
 | params_flow.rb:35:18:35:19 | 13 | params_flow.rb:35:12:35:20 | call to taint |
 | params_flow.rb:35:18:35:19 | 13 | params_flow.rb:35:18:35:19 | 13 |
-| params_flow.rb:35:23:35:28 | ** ... | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:35:23:35:28 | ** ... | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:35:23:35:28 | ** ... | params_flow.rb:25:17:25:24 | **kwargs |
 | params_flow.rb:35:23:35:28 | ** ... | params_flow.rb:25:19:25:24 | kwargs |
 | params_flow.rb:35:23:35:28 | ** ... | params_flow.rb:27:11:27:16 | kwargs |
@@ -3808,16 +3797,18 @@ trackEnd
 | params_flow.rb:35:23:35:28 | ** ... | params_flow.rb:30:11:30:16 | kwargs |
 | params_flow.rb:35:23:35:28 | ** ... | params_flow.rb:35:23:35:28 | ** ... |
 | params_flow.rb:37:1:37:4 | args | params_flow.rb:37:1:37:4 | args |
-| params_flow.rb:37:8:37:44 | ** | params_flow.rb:37:8:37:44 | ** |
 | params_flow.rb:37:8:37:44 | Hash | params_flow.rb:37:8:37:44 | Hash |
 | params_flow.rb:37:8:37:44 | call to [] | params_flow.rb:37:1:37:4 | args |
 | params_flow.rb:37:8:37:44 | call to [] | params_flow.rb:37:1:37:44 | ... = ... |
 | params_flow.rb:37:8:37:44 | call to [] | params_flow.rb:37:8:37:44 | call to [] |
 | params_flow.rb:37:8:37:44 | call to [] | params_flow.rb:38:10:38:13 | args |
+| params_flow.rb:37:8:37:44 | synthetic hash-splat argument | params_flow.rb:37:1:37:4 | args |
+| params_flow.rb:37:8:37:44 | synthetic hash-splat argument | params_flow.rb:37:1:37:44 | ... = ... |
+| params_flow.rb:37:8:37:44 | synthetic hash-splat argument | params_flow.rb:37:8:37:44 | call to [] |
+| params_flow.rb:37:8:37:44 | synthetic hash-splat argument | params_flow.rb:37:8:37:44 | synthetic hash-splat argument |
+| params_flow.rb:37:8:37:44 | synthetic hash-splat argument | params_flow.rb:38:10:38:13 | args |
 | params_flow.rb:37:9:37:11 | :p1 | params_flow.rb:37:9:37:11 | :p1 |
 | params_flow.rb:37:9:37:24 | Pair | params_flow.rb:37:9:37:24 | Pair |
-| params_flow.rb:37:16:37:24 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:37:16:37:24 | * | params_flow.rb:37:16:37:24 | * |
 | params_flow.rb:37:16:37:24 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:37:16:37:24 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:37:16:37:24 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -3827,6 +3818,8 @@ trackEnd
 | params_flow.rb:37:16:37:24 | call to taint | params_flow.rb:27:10:27:22 | ( ... ) |
 | params_flow.rb:37:16:37:24 | call to taint | params_flow.rb:27:11:27:21 | ...[...] |
 | params_flow.rb:37:16:37:24 | call to taint | params_flow.rb:37:16:37:24 | call to taint |
+| params_flow.rb:37:16:37:24 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:37:16:37:24 | synthetic splat argument | params_flow.rb:37:16:37:24 | synthetic splat argument |
 | params_flow.rb:37:22:37:23 | 14 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:37:22:37:23 | 14 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:37:22:37:23 | 14 | params_flow.rb:2:5:2:5 | x |
@@ -3842,14 +3835,14 @@ trackEnd
 | params_flow.rb:37:22:37:23 | 14 | params_flow.rb:37:22:37:23 | 14 |
 | params_flow.rb:37:27:37:29 | :p2 | params_flow.rb:37:27:37:29 | :p2 |
 | params_flow.rb:37:27:37:42 | Pair | params_flow.rb:37:27:37:42 | Pair |
-| params_flow.rb:37:34:37:42 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:37:34:37:42 | * | params_flow.rb:37:34:37:42 | * |
 | params_flow.rb:37:34:37:42 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:37:34:37:42 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:37:34:37:42 | call to taint | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:37:34:37:42 | call to taint | params_flow.rb:28:10:28:22 | ( ... ) |
 | params_flow.rb:37:34:37:42 | call to taint | params_flow.rb:28:11:28:21 | ...[...] |
 | params_flow.rb:37:34:37:42 | call to taint | params_flow.rb:37:34:37:42 | call to taint |
+| params_flow.rb:37:34:37:42 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:37:34:37:42 | synthetic splat argument | params_flow.rb:37:34:37:42 | synthetic splat argument |
 | params_flow.rb:37:40:37:41 | 15 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:37:40:37:41 | 15 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:37:40:37:41 | 15 | params_flow.rb:2:5:2:5 | x |
@@ -3861,7 +3854,7 @@ trackEnd
 | params_flow.rb:37:40:37:41 | 15 | params_flow.rb:37:34:37:42 | call to taint |
 | params_flow.rb:37:40:37:41 | 15 | params_flow.rb:37:40:37:41 | 15 |
 | params_flow.rb:38:1:38:14 | call to kwargs | params_flow.rb:38:1:38:14 | call to kwargs |
-| params_flow.rb:38:8:38:13 | ** ... | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:38:8:38:13 | ** ... | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:38:8:38:13 | ** ... | params_flow.rb:25:17:25:24 | **kwargs |
 | params_flow.rb:38:8:38:13 | ** ... | params_flow.rb:25:19:25:24 | kwargs |
 | params_flow.rb:38:8:38:13 | ** ... | params_flow.rb:27:11:27:16 | kwargs |
@@ -3870,16 +3863,18 @@ trackEnd
 | params_flow.rb:38:8:38:13 | ** ... | params_flow.rb:30:11:30:16 | kwargs |
 | params_flow.rb:38:8:38:13 | ** ... | params_flow.rb:38:8:38:13 | ** ... |
 | params_flow.rb:40:1:40:4 | args | params_flow.rb:40:1:40:4 | args |
-| params_flow.rb:40:8:40:26 | ** | params_flow.rb:40:8:40:26 | ** |
 | params_flow.rb:40:8:40:26 | Hash | params_flow.rb:40:8:40:26 | Hash |
 | params_flow.rb:40:8:40:26 | call to [] | params_flow.rb:40:1:40:4 | args |
 | params_flow.rb:40:8:40:26 | call to [] | params_flow.rb:40:1:40:26 | ... = ... |
 | params_flow.rb:40:8:40:26 | call to [] | params_flow.rb:40:8:40:26 | call to [] |
 | params_flow.rb:40:8:40:26 | call to [] | params_flow.rb:41:26:41:29 | args |
+| params_flow.rb:40:8:40:26 | synthetic hash-splat argument | params_flow.rb:40:1:40:4 | args |
+| params_flow.rb:40:8:40:26 | synthetic hash-splat argument | params_flow.rb:40:1:40:26 | ... = ... |
+| params_flow.rb:40:8:40:26 | synthetic hash-splat argument | params_flow.rb:40:8:40:26 | call to [] |
+| params_flow.rb:40:8:40:26 | synthetic hash-splat argument | params_flow.rb:40:8:40:26 | synthetic hash-splat argument |
+| params_flow.rb:40:8:40:26 | synthetic hash-splat argument | params_flow.rb:41:26:41:29 | args |
 | params_flow.rb:40:9:40:11 | :p1 | params_flow.rb:40:9:40:11 | :p1 |
 | params_flow.rb:40:9:40:24 | Pair | params_flow.rb:40:9:40:24 | Pair |
-| params_flow.rb:40:16:40:24 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:40:16:40:24 | * | params_flow.rb:40:16:40:24 | * |
 | params_flow.rb:40:16:40:24 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:40:16:40:24 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:40:16:40:24 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -3887,6 +3882,8 @@ trackEnd
 | params_flow.rb:40:16:40:24 | call to taint | params_flow.rb:16:13:16:14 | p1 |
 | params_flow.rb:40:16:40:24 | call to taint | params_flow.rb:17:10:17:11 | p1 |
 | params_flow.rb:40:16:40:24 | call to taint | params_flow.rb:40:16:40:24 | call to taint |
+| params_flow.rb:40:16:40:24 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:40:16:40:24 | synthetic splat argument | params_flow.rb:40:16:40:24 | synthetic splat argument |
 | params_flow.rb:40:22:40:23 | 16 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:40:22:40:23 | 16 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:40:22:40:23 | 16 | params_flow.rb:2:5:2:5 | x |
@@ -3898,13 +3895,11 @@ trackEnd
 | params_flow.rb:40:22:40:23 | 16 | params_flow.rb:17:10:17:11 | p1 |
 | params_flow.rb:40:22:40:23 | 16 | params_flow.rb:40:16:40:24 | call to taint |
 | params_flow.rb:40:22:40:23 | 16 | params_flow.rb:40:22:40:23 | 16 |
-| params_flow.rb:41:1:41:30 | ** | params_flow.rb:16:1:19:3 | **kwargs |
-| params_flow.rb:41:1:41:30 | ** | params_flow.rb:41:1:41:30 | ** |
 | params_flow.rb:41:1:41:30 | call to keyword | params_flow.rb:41:1:41:30 | call to keyword |
+| params_flow.rb:41:1:41:30 | synthetic hash-splat argument | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
+| params_flow.rb:41:1:41:30 | synthetic hash-splat argument | params_flow.rb:41:1:41:30 | synthetic hash-splat argument |
 | params_flow.rb:41:9:41:10 | :p2 | params_flow.rb:41:9:41:10 | :p2 |
 | params_flow.rb:41:9:41:21 | Pair | params_flow.rb:41:9:41:21 | Pair |
-| params_flow.rb:41:13:41:21 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:41:13:41:21 | * | params_flow.rb:41:13:41:21 | * |
 | params_flow.rb:41:13:41:21 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:41:13:41:21 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:41:13:41:21 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -3912,6 +3907,8 @@ trackEnd
 | params_flow.rb:41:13:41:21 | call to taint | params_flow.rb:16:18:16:19 | p2 |
 | params_flow.rb:41:13:41:21 | call to taint | params_flow.rb:18:10:18:11 | p2 |
 | params_flow.rb:41:13:41:21 | call to taint | params_flow.rb:41:13:41:21 | call to taint |
+| params_flow.rb:41:13:41:21 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:41:13:41:21 | synthetic splat argument | params_flow.rb:41:13:41:21 | synthetic splat argument |
 | params_flow.rb:41:19:41:20 | 17 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:41:19:41:20 | 17 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:41:19:41:20 | 17 | params_flow.rb:2:5:2:5 | x |
@@ -3923,10 +3920,9 @@ trackEnd
 | params_flow.rb:41:19:41:20 | 17 | params_flow.rb:18:10:18:11 | p2 |
 | params_flow.rb:41:19:41:20 | 17 | params_flow.rb:41:13:41:21 | call to taint |
 | params_flow.rb:41:19:41:20 | 17 | params_flow.rb:41:19:41:20 | 17 |
-| params_flow.rb:41:24:41:29 | ** ... | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:41:24:41:29 | ** ... | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:41:24:41:29 | ** ... | params_flow.rb:41:24:41:29 | ** ... |
 | params_flow.rb:43:1:43:4 | args | params_flow.rb:43:1:43:4 | args |
-| params_flow.rb:43:8:43:18 | * | params_flow.rb:43:8:43:18 | * |
 | params_flow.rb:43:8:43:18 | Array | params_flow.rb:43:8:43:18 | Array |
 | params_flow.rb:43:8:43:18 | call to [] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:43:8:43:18 | call to [] | params_flow.rb:5:10:5:10 | x |
@@ -3938,8 +3934,17 @@ trackEnd
 | params_flow.rb:43:8:43:18 | call to [] | params_flow.rb:43:1:43:18 | ... = ... |
 | params_flow.rb:43:8:43:18 | call to [] | params_flow.rb:43:8:43:18 | call to [] |
 | params_flow.rb:43:8:43:18 | call to [] | params_flow.rb:44:24:44:27 | args |
-| params_flow.rb:43:9:43:17 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:43:9:43:17 | * | params_flow.rb:43:9:43:17 | * |
+| params_flow.rb:43:8:43:18 | synthetic splat argument | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:43:8:43:18 | synthetic splat argument | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:43:8:43:18 | synthetic splat argument | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:43:8:43:18 | synthetic splat argument | params_flow.rb:9:20:9:21 | p2 |
+| params_flow.rb:43:8:43:18 | synthetic splat argument | params_flow.rb:9:20:9:21 | p2 |
+| params_flow.rb:43:8:43:18 | synthetic splat argument | params_flow.rb:11:10:11:11 | p2 |
+| params_flow.rb:43:8:43:18 | synthetic splat argument | params_flow.rb:43:1:43:4 | args |
+| params_flow.rb:43:8:43:18 | synthetic splat argument | params_flow.rb:43:1:43:18 | ... = ... |
+| params_flow.rb:43:8:43:18 | synthetic splat argument | params_flow.rb:43:8:43:18 | call to [] |
+| params_flow.rb:43:8:43:18 | synthetic splat argument | params_flow.rb:43:8:43:18 | synthetic splat argument |
+| params_flow.rb:43:8:43:18 | synthetic splat argument | params_flow.rb:44:24:44:27 | args |
 | params_flow.rb:43:9:43:17 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:43:9:43:17 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:43:9:43:17 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -3947,6 +3952,8 @@ trackEnd
 | params_flow.rb:43:9:43:17 | call to taint | params_flow.rb:9:20:9:21 | p2 |
 | params_flow.rb:43:9:43:17 | call to taint | params_flow.rb:11:10:11:11 | p2 |
 | params_flow.rb:43:9:43:17 | call to taint | params_flow.rb:43:9:43:17 | call to taint |
+| params_flow.rb:43:9:43:17 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:43:9:43:17 | synthetic splat argument | params_flow.rb:43:9:43:17 | synthetic splat argument |
 | params_flow.rb:43:15:43:16 | 17 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:43:15:43:16 | 17 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:43:15:43:16 | 17 | params_flow.rb:2:5:2:5 | x |
@@ -3958,11 +3965,9 @@ trackEnd
 | params_flow.rb:43:15:43:16 | 17 | params_flow.rb:11:10:11:11 | p2 |
 | params_flow.rb:43:15:43:16 | 17 | params_flow.rb:43:9:43:17 | call to taint |
 | params_flow.rb:43:15:43:16 | 17 | params_flow.rb:43:15:43:16 | 17 |
-| params_flow.rb:44:1:44:28 | * | params_flow.rb:9:1:12:3 | synthetic *args |
-| params_flow.rb:44:1:44:28 | * | params_flow.rb:44:1:44:28 | * |
 | params_flow.rb:44:1:44:28 | call to positional | params_flow.rb:44:1:44:28 | call to positional |
-| params_flow.rb:44:12:44:20 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:44:12:44:20 | * | params_flow.rb:44:12:44:20 | * |
+| params_flow.rb:44:1:44:28 | synthetic splat argument | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:44:1:44:28 | synthetic splat argument | params_flow.rb:44:1:44:28 | synthetic splat argument |
 | params_flow.rb:44:12:44:20 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:44:12:44:20 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:44:12:44:20 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -3970,6 +3975,8 @@ trackEnd
 | params_flow.rb:44:12:44:20 | call to taint | params_flow.rb:9:16:9:17 | p1 |
 | params_flow.rb:44:12:44:20 | call to taint | params_flow.rb:10:10:10:11 | p1 |
 | params_flow.rb:44:12:44:20 | call to taint | params_flow.rb:44:12:44:20 | call to taint |
+| params_flow.rb:44:12:44:20 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:44:12:44:20 | synthetic splat argument | params_flow.rb:44:12:44:20 | synthetic splat argument |
 | params_flow.rb:44:18:44:19 | 16 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:44:18:44:19 | 16 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:44:18:44:19 | 16 | params_flow.rb:2:5:2:5 | x |
@@ -3983,7 +3990,6 @@ trackEnd
 | params_flow.rb:44:18:44:19 | 16 | params_flow.rb:44:18:44:19 | 16 |
 | params_flow.rb:44:23:44:27 | * ... | params_flow.rb:44:23:44:27 | * ... |
 | params_flow.rb:46:1:46:4 | args | params_flow.rb:46:1:46:4 | args |
-| params_flow.rb:46:8:46:29 | * | params_flow.rb:46:8:46:29 | * |
 | params_flow.rb:46:8:46:29 | Array | params_flow.rb:46:8:46:29 | Array |
 | params_flow.rb:46:8:46:29 | call to [] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:46:8:46:29 | call to [] | params_flow.rb:5:10:5:10 | x |
@@ -3995,8 +4001,17 @@ trackEnd
 | params_flow.rb:46:8:46:29 | call to [] | params_flow.rb:46:1:46:29 | ... = ... |
 | params_flow.rb:46:8:46:29 | call to [] | params_flow.rb:46:8:46:29 | call to [] |
 | params_flow.rb:46:8:46:29 | call to [] | params_flow.rb:47:13:47:16 | args |
-| params_flow.rb:46:9:46:17 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:46:9:46:17 | * | params_flow.rb:46:9:46:17 | * |
+| params_flow.rb:46:8:46:29 | synthetic splat argument | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:46:8:46:29 | synthetic splat argument | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:46:8:46:29 | synthetic splat argument | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:46:8:46:29 | synthetic splat argument | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:46:8:46:29 | synthetic splat argument | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:46:8:46:29 | synthetic splat argument | params_flow.rb:10:10:10:11 | p1 |
+| params_flow.rb:46:8:46:29 | synthetic splat argument | params_flow.rb:46:1:46:4 | args |
+| params_flow.rb:46:8:46:29 | synthetic splat argument | params_flow.rb:46:1:46:29 | ... = ... |
+| params_flow.rb:46:8:46:29 | synthetic splat argument | params_flow.rb:46:8:46:29 | call to [] |
+| params_flow.rb:46:8:46:29 | synthetic splat argument | params_flow.rb:46:8:46:29 | synthetic splat argument |
+| params_flow.rb:46:8:46:29 | synthetic splat argument | params_flow.rb:47:13:47:16 | args |
 | params_flow.rb:46:9:46:17 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:46:9:46:17 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:46:9:46:17 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -4004,6 +4019,8 @@ trackEnd
 | params_flow.rb:46:9:46:17 | call to taint | params_flow.rb:9:16:9:17 | p1 |
 | params_flow.rb:46:9:46:17 | call to taint | params_flow.rb:10:10:10:11 | p1 |
 | params_flow.rb:46:9:46:17 | call to taint | params_flow.rb:46:9:46:17 | call to taint |
+| params_flow.rb:46:9:46:17 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:46:9:46:17 | synthetic splat argument | params_flow.rb:46:9:46:17 | synthetic splat argument |
 | params_flow.rb:46:15:46:16 | 18 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:46:15:46:16 | 18 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:46:15:46:16 | 18 | params_flow.rb:2:5:2:5 | x |
@@ -4015,8 +4032,6 @@ trackEnd
 | params_flow.rb:46:15:46:16 | 18 | params_flow.rb:10:10:10:11 | p1 |
 | params_flow.rb:46:15:46:16 | 18 | params_flow.rb:46:9:46:17 | call to taint |
 | params_flow.rb:46:15:46:16 | 18 | params_flow.rb:46:15:46:16 | 18 |
-| params_flow.rb:46:20:46:28 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:46:20:46:28 | * | params_flow.rb:46:20:46:28 | * |
 | params_flow.rb:46:20:46:28 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:46:20:46:28 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:46:20:46:28 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -4024,6 +4039,8 @@ trackEnd
 | params_flow.rb:46:20:46:28 | call to taint | params_flow.rb:9:20:9:21 | p2 |
 | params_flow.rb:46:20:46:28 | call to taint | params_flow.rb:11:10:11:11 | p2 |
 | params_flow.rb:46:20:46:28 | call to taint | params_flow.rb:46:20:46:28 | call to taint |
+| params_flow.rb:46:20:46:28 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:46:20:46:28 | synthetic splat argument | params_flow.rb:46:20:46:28 | synthetic splat argument |
 | params_flow.rb:46:26:46:27 | 19 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:46:26:46:27 | 19 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:46:26:46:27 | 19 | params_flow.rb:2:5:2:5 | x |
@@ -4036,7 +4053,7 @@ trackEnd
 | params_flow.rb:46:26:46:27 | 19 | params_flow.rb:46:20:46:28 | call to taint |
 | params_flow.rb:46:26:46:27 | 19 | params_flow.rb:46:26:46:27 | 19 |
 | params_flow.rb:47:1:47:17 | call to positional | params_flow.rb:47:1:47:17 | call to positional |
-| params_flow.rb:47:12:47:16 | * ... | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:47:12:47:16 | * ... | params_flow.rb:9:1:12:3 | synthetic splat parameter |
 | params_flow.rb:47:12:47:16 | * ... | params_flow.rb:47:12:47:16 | * ... |
 | params_flow.rb:49:1:53:3 | &block | params_flow.rb:49:1:53:3 | &block |
 | params_flow.rb:49:1:53:3 | posargs | params_flow.rb:49:1:53:3 | posargs |
@@ -4048,7 +4065,7 @@ trackEnd
 | params_flow.rb:49:1:53:3 | self in posargs | params_flow.rb:50:5:50:11 | self |
 | params_flow.rb:49:1:53:3 | self in posargs | params_flow.rb:51:5:51:21 | self |
 | params_flow.rb:49:1:53:3 | self in posargs | params_flow.rb:52:5:52:21 | self |
-| params_flow.rb:49:1:53:3 | synthetic *args | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:49:1:53:3 | synthetic splat parameter | params_flow.rb:49:1:53:3 | synthetic splat parameter |
 | params_flow.rb:49:13:49:14 | p1 | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:49:13:49:14 | p1 | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:49:13:49:14 | p1 | params_flow.rb:6:10:6:10 | x |
@@ -4061,46 +4078,44 @@ trackEnd
 | params_flow.rb:49:17:49:24 | *posargs | params_flow.rb:51:11:51:17 | posargs |
 | params_flow.rb:49:17:49:24 | *posargs | params_flow.rb:52:11:52:17 | posargs |
 | params_flow.rb:49:18:49:24 | posargs | params_flow.rb:49:18:49:24 | posargs |
-| params_flow.rb:50:5:50:11 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:50:5:50:11 | * | params_flow.rb:50:5:50:11 | * |
 | params_flow.rb:50:5:50:11 | call to sink | params_flow.rb:50:5:50:11 | call to sink |
-| params_flow.rb:51:5:51:21 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:51:5:51:21 | * | params_flow.rb:51:5:51:21 | * |
+| params_flow.rb:50:5:50:11 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:50:5:50:11 | synthetic splat argument | params_flow.rb:50:5:50:11 | synthetic splat argument |
 | params_flow.rb:51:5:51:21 | call to sink | params_flow.rb:51:5:51:21 | call to sink |
-| params_flow.rb:51:11:51:20 | * | params_flow.rb:51:11:51:20 | * |
+| params_flow.rb:51:5:51:21 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:51:5:51:21 | synthetic splat argument | params_flow.rb:51:5:51:21 | synthetic splat argument |
 | params_flow.rb:51:11:51:20 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:51:11:51:20 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:51:11:51:20 | ...[...] | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:51:11:51:20 | ...[...] | params_flow.rb:51:10:51:21 | ( ... ) |
 | params_flow.rb:51:11:51:20 | ...[...] | params_flow.rb:51:11:51:20 | ...[...] |
+| params_flow.rb:51:11:51:20 | synthetic splat argument | params_flow.rb:51:11:51:20 | synthetic splat argument |
 | params_flow.rb:51:19:51:19 | 0 | params_flow.rb:51:19:51:19 | 0 |
-| params_flow.rb:52:5:52:21 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:52:5:52:21 | * | params_flow.rb:52:5:52:21 | * |
 | params_flow.rb:52:5:52:21 | call to sink | params_flow.rb:52:5:52:21 | call to sink |
 | params_flow.rb:52:5:52:21 | call to sink | params_flow.rb:55:1:55:29 | call to posargs |
 | params_flow.rb:52:5:52:21 | call to sink | params_flow.rb:58:1:58:25 | call to posargs |
 | params_flow.rb:52:5:52:21 | call to sink | params_flow.rb:61:1:61:14 | call to posargs |
-| params_flow.rb:52:11:52:20 | * | params_flow.rb:52:11:52:20 | * |
+| params_flow.rb:52:5:52:21 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:52:5:52:21 | synthetic splat argument | params_flow.rb:52:5:52:21 | synthetic splat argument |
 | params_flow.rb:52:11:52:20 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:52:11:52:20 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:52:11:52:20 | ...[...] | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:52:11:52:20 | ...[...] | params_flow.rb:52:10:52:21 | ( ... ) |
 | params_flow.rb:52:11:52:20 | ...[...] | params_flow.rb:52:11:52:20 | ...[...] |
+| params_flow.rb:52:11:52:20 | synthetic splat argument | params_flow.rb:52:11:52:20 | synthetic splat argument |
 | params_flow.rb:52:19:52:19 | 1 | params_flow.rb:52:19:52:19 | 1 |
-| params_flow.rb:55:1:55:29 | * | params_flow.rb:49:1:53:3 | synthetic *args |
-| params_flow.rb:55:1:55:29 | * | params_flow.rb:55:1:55:29 | * |
 | params_flow.rb:55:1:55:29 | call to posargs | params_flow.rb:55:1:55:29 | call to posargs |
-| params_flow.rb:55:9:55:17 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:55:9:55:17 | * | params_flow.rb:55:9:55:17 | * |
+| params_flow.rb:55:1:55:29 | synthetic splat argument | params_flow.rb:49:1:53:3 | synthetic splat parameter |
+| params_flow.rb:55:1:55:29 | synthetic splat argument | params_flow.rb:55:1:55:29 | synthetic splat argument |
 | params_flow.rb:55:9:55:17 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:55:9:55:17 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:55:9:55:17 | call to taint | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:55:9:55:17 | call to taint | params_flow.rb:49:13:49:14 | p1 |
 | params_flow.rb:55:9:55:17 | call to taint | params_flow.rb:49:13:49:14 | p1 |
 | params_flow.rb:55:9:55:17 | call to taint | params_flow.rb:50:10:50:11 | p1 |
-| params_flow.rb:55:9:55:17 | call to taint | params_flow.rb:51:10:51:21 | ( ... ) |
-| params_flow.rb:55:9:55:17 | call to taint | params_flow.rb:51:11:51:20 | ...[...] |
 | params_flow.rb:55:9:55:17 | call to taint | params_flow.rb:55:9:55:17 | call to taint |
+| params_flow.rb:55:9:55:17 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:55:9:55:17 | synthetic splat argument | params_flow.rb:55:9:55:17 | synthetic splat argument |
 | params_flow.rb:55:15:55:16 | 20 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:55:15:55:16 | 20 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:55:15:55:16 | 20 | params_flow.rb:2:5:2:5 | x |
@@ -4110,52 +4125,55 @@ trackEnd
 | params_flow.rb:55:15:55:16 | 20 | params_flow.rb:49:13:49:14 | p1 |
 | params_flow.rb:55:15:55:16 | 20 | params_flow.rb:49:13:49:14 | p1 |
 | params_flow.rb:55:15:55:16 | 20 | params_flow.rb:50:10:50:11 | p1 |
-| params_flow.rb:55:15:55:16 | 20 | params_flow.rb:51:10:51:21 | ( ... ) |
-| params_flow.rb:55:15:55:16 | 20 | params_flow.rb:51:11:51:20 | ...[...] |
 | params_flow.rb:55:15:55:16 | 20 | params_flow.rb:55:9:55:17 | call to taint |
 | params_flow.rb:55:15:55:16 | 20 | params_flow.rb:55:15:55:16 | 20 |
-| params_flow.rb:55:20:55:28 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:55:20:55:28 | * | params_flow.rb:55:20:55:28 | * |
 | params_flow.rb:55:20:55:28 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:55:20:55:28 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:55:20:55:28 | call to taint | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:55:20:55:28 | call to taint | params_flow.rb:52:10:52:21 | ( ... ) |
-| params_flow.rb:55:20:55:28 | call to taint | params_flow.rb:52:11:52:20 | ...[...] |
+| params_flow.rb:55:20:55:28 | call to taint | params_flow.rb:51:10:51:21 | ( ... ) |
+| params_flow.rb:55:20:55:28 | call to taint | params_flow.rb:51:11:51:20 | ...[...] |
 | params_flow.rb:55:20:55:28 | call to taint | params_flow.rb:55:20:55:28 | call to taint |
+| params_flow.rb:55:20:55:28 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:55:20:55:28 | synthetic splat argument | params_flow.rb:55:20:55:28 | synthetic splat argument |
 | params_flow.rb:55:26:55:27 | 21 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:55:26:55:27 | 21 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:55:26:55:27 | 21 | params_flow.rb:2:5:2:5 | x |
 | params_flow.rb:55:26:55:27 | 21 | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:55:26:55:27 | 21 | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:55:26:55:27 | 21 | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:55:26:55:27 | 21 | params_flow.rb:52:10:52:21 | ( ... ) |
-| params_flow.rb:55:26:55:27 | 21 | params_flow.rb:52:11:52:20 | ...[...] |
+| params_flow.rb:55:26:55:27 | 21 | params_flow.rb:51:10:51:21 | ( ... ) |
+| params_flow.rb:55:26:55:27 | 21 | params_flow.rb:51:11:51:20 | ...[...] |
 | params_flow.rb:55:26:55:27 | 21 | params_flow.rb:55:20:55:28 | call to taint |
 | params_flow.rb:55:26:55:27 | 21 | params_flow.rb:55:26:55:27 | 21 |
 | params_flow.rb:57:1:57:4 | args | params_flow.rb:57:1:57:4 | args |
-| params_flow.rb:57:8:57:18 | * | params_flow.rb:57:8:57:18 | * |
 | params_flow.rb:57:8:57:18 | Array | params_flow.rb:57:8:57:18 | Array |
 | params_flow.rb:57:8:57:18 | call to [] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:57:8:57:18 | call to [] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:57:8:57:18 | call to [] | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:57:8:57:18 | call to [] | params_flow.rb:51:10:51:21 | ( ... ) |
 | params_flow.rb:57:8:57:18 | call to [] | params_flow.rb:51:11:51:20 | ...[...] |
-| params_flow.rb:57:8:57:18 | call to [] | params_flow.rb:52:10:52:21 | ( ... ) |
-| params_flow.rb:57:8:57:18 | call to [] | params_flow.rb:52:11:52:20 | ...[...] |
 | params_flow.rb:57:8:57:18 | call to [] | params_flow.rb:57:1:57:4 | args |
 | params_flow.rb:57:8:57:18 | call to [] | params_flow.rb:57:1:57:18 | ... = ... |
 | params_flow.rb:57:8:57:18 | call to [] | params_flow.rb:57:8:57:18 | call to [] |
 | params_flow.rb:57:8:57:18 | call to [] | params_flow.rb:58:21:58:24 | args |
-| params_flow.rb:57:9:57:17 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:57:9:57:17 | * | params_flow.rb:57:9:57:17 | * |
+| params_flow.rb:57:8:57:18 | synthetic splat argument | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:57:8:57:18 | synthetic splat argument | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:57:8:57:18 | synthetic splat argument | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:57:8:57:18 | synthetic splat argument | params_flow.rb:51:10:51:21 | ( ... ) |
+| params_flow.rb:57:8:57:18 | synthetic splat argument | params_flow.rb:51:11:51:20 | ...[...] |
+| params_flow.rb:57:8:57:18 | synthetic splat argument | params_flow.rb:57:1:57:4 | args |
+| params_flow.rb:57:8:57:18 | synthetic splat argument | params_flow.rb:57:1:57:18 | ... = ... |
+| params_flow.rb:57:8:57:18 | synthetic splat argument | params_flow.rb:57:8:57:18 | call to [] |
+| params_flow.rb:57:8:57:18 | synthetic splat argument | params_flow.rb:57:8:57:18 | synthetic splat argument |
+| params_flow.rb:57:8:57:18 | synthetic splat argument | params_flow.rb:58:21:58:24 | args |
 | params_flow.rb:57:9:57:17 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:57:9:57:17 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:57:9:57:17 | call to taint | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:57:9:57:17 | call to taint | params_flow.rb:51:10:51:21 | ( ... ) |
 | params_flow.rb:57:9:57:17 | call to taint | params_flow.rb:51:11:51:20 | ...[...] |
-| params_flow.rb:57:9:57:17 | call to taint | params_flow.rb:52:10:52:21 | ( ... ) |
-| params_flow.rb:57:9:57:17 | call to taint | params_flow.rb:52:11:52:20 | ...[...] |
 | params_flow.rb:57:9:57:17 | call to taint | params_flow.rb:57:9:57:17 | call to taint |
+| params_flow.rb:57:9:57:17 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:57:9:57:17 | synthetic splat argument | params_flow.rb:57:9:57:17 | synthetic splat argument |
 | params_flow.rb:57:15:57:16 | 22 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:57:15:57:16 | 22 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:57:15:57:16 | 22 | params_flow.rb:2:5:2:5 | x |
@@ -4164,24 +4182,20 @@ trackEnd
 | params_flow.rb:57:15:57:16 | 22 | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:57:15:57:16 | 22 | params_flow.rb:51:10:51:21 | ( ... ) |
 | params_flow.rb:57:15:57:16 | 22 | params_flow.rb:51:11:51:20 | ...[...] |
-| params_flow.rb:57:15:57:16 | 22 | params_flow.rb:52:10:52:21 | ( ... ) |
-| params_flow.rb:57:15:57:16 | 22 | params_flow.rb:52:11:52:20 | ...[...] |
 | params_flow.rb:57:15:57:16 | 22 | params_flow.rb:57:9:57:17 | call to taint |
 | params_flow.rb:57:15:57:16 | 22 | params_flow.rb:57:15:57:16 | 22 |
-| params_flow.rb:58:1:58:25 | * | params_flow.rb:49:1:53:3 | synthetic *args |
-| params_flow.rb:58:1:58:25 | * | params_flow.rb:58:1:58:25 | * |
 | params_flow.rb:58:1:58:25 | call to posargs | params_flow.rb:58:1:58:25 | call to posargs |
-| params_flow.rb:58:9:58:17 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:58:9:58:17 | * | params_flow.rb:58:9:58:17 | * |
+| params_flow.rb:58:1:58:25 | synthetic splat argument | params_flow.rb:49:1:53:3 | synthetic splat parameter |
+| params_flow.rb:58:1:58:25 | synthetic splat argument | params_flow.rb:58:1:58:25 | synthetic splat argument |
 | params_flow.rb:58:9:58:17 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:58:9:58:17 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:58:9:58:17 | call to taint | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:58:9:58:17 | call to taint | params_flow.rb:49:13:49:14 | p1 |
 | params_flow.rb:58:9:58:17 | call to taint | params_flow.rb:49:13:49:14 | p1 |
 | params_flow.rb:58:9:58:17 | call to taint | params_flow.rb:50:10:50:11 | p1 |
-| params_flow.rb:58:9:58:17 | call to taint | params_flow.rb:51:10:51:21 | ( ... ) |
-| params_flow.rb:58:9:58:17 | call to taint | params_flow.rb:51:11:51:20 | ...[...] |
 | params_flow.rb:58:9:58:17 | call to taint | params_flow.rb:58:9:58:17 | call to taint |
+| params_flow.rb:58:9:58:17 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:58:9:58:17 | synthetic splat argument | params_flow.rb:58:9:58:17 | synthetic splat argument |
 | params_flow.rb:58:15:58:16 | 23 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:58:15:58:16 | 23 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:58:15:58:16 | 23 | params_flow.rb:2:5:2:5 | x |
@@ -4191,8 +4205,6 @@ trackEnd
 | params_flow.rb:58:15:58:16 | 23 | params_flow.rb:49:13:49:14 | p1 |
 | params_flow.rb:58:15:58:16 | 23 | params_flow.rb:49:13:49:14 | p1 |
 | params_flow.rb:58:15:58:16 | 23 | params_flow.rb:50:10:50:11 | p1 |
-| params_flow.rb:58:15:58:16 | 23 | params_flow.rb:51:10:51:21 | ( ... ) |
-| params_flow.rb:58:15:58:16 | 23 | params_flow.rb:51:11:51:20 | ...[...] |
 | params_flow.rb:58:15:58:16 | 23 | params_flow.rb:58:9:58:17 | call to taint |
 | params_flow.rb:58:15:58:16 | 23 | params_flow.rb:58:15:58:16 | 23 |
 | params_flow.rb:58:20:58:24 | * ... | params_flow.rb:49:17:49:24 | *posargs |
@@ -4201,7 +4213,6 @@ trackEnd
 | params_flow.rb:58:20:58:24 | * ... | params_flow.rb:52:11:52:17 | posargs |
 | params_flow.rb:58:20:58:24 | * ... | params_flow.rb:58:20:58:24 | * ... |
 | params_flow.rb:60:1:60:4 | args | params_flow.rb:60:1:60:4 | args |
-| params_flow.rb:60:8:60:29 | * | params_flow.rb:60:8:60:29 | * |
 | params_flow.rb:60:8:60:29 | Array | params_flow.rb:60:8:60:29 | Array |
 | params_flow.rb:60:8:60:29 | call to [] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:60:8:60:29 | call to [] | params_flow.rb:5:10:5:10 | x |
@@ -4209,23 +4220,30 @@ trackEnd
 | params_flow.rb:60:8:60:29 | call to [] | params_flow.rb:49:13:49:14 | p1 |
 | params_flow.rb:60:8:60:29 | call to [] | params_flow.rb:49:13:49:14 | p1 |
 | params_flow.rb:60:8:60:29 | call to [] | params_flow.rb:50:10:50:11 | p1 |
-| params_flow.rb:60:8:60:29 | call to [] | params_flow.rb:51:10:51:21 | ( ... ) |
-| params_flow.rb:60:8:60:29 | call to [] | params_flow.rb:51:11:51:20 | ...[...] |
 | params_flow.rb:60:8:60:29 | call to [] | params_flow.rb:60:1:60:4 | args |
 | params_flow.rb:60:8:60:29 | call to [] | params_flow.rb:60:1:60:29 | ... = ... |
 | params_flow.rb:60:8:60:29 | call to [] | params_flow.rb:60:8:60:29 | call to [] |
 | params_flow.rb:60:8:60:29 | call to [] | params_flow.rb:61:10:61:13 | args |
-| params_flow.rb:60:9:60:17 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:60:9:60:17 | * | params_flow.rb:60:9:60:17 | * |
+| params_flow.rb:60:8:60:29 | synthetic splat argument | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:60:8:60:29 | synthetic splat argument | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:60:8:60:29 | synthetic splat argument | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:60:8:60:29 | synthetic splat argument | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:60:8:60:29 | synthetic splat argument | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:60:8:60:29 | synthetic splat argument | params_flow.rb:50:10:50:11 | p1 |
+| params_flow.rb:60:8:60:29 | synthetic splat argument | params_flow.rb:60:1:60:4 | args |
+| params_flow.rb:60:8:60:29 | synthetic splat argument | params_flow.rb:60:1:60:29 | ... = ... |
+| params_flow.rb:60:8:60:29 | synthetic splat argument | params_flow.rb:60:8:60:29 | call to [] |
+| params_flow.rb:60:8:60:29 | synthetic splat argument | params_flow.rb:60:8:60:29 | synthetic splat argument |
+| params_flow.rb:60:8:60:29 | synthetic splat argument | params_flow.rb:61:10:61:13 | args |
 | params_flow.rb:60:9:60:17 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:60:9:60:17 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:60:9:60:17 | call to taint | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:60:9:60:17 | call to taint | params_flow.rb:49:13:49:14 | p1 |
 | params_flow.rb:60:9:60:17 | call to taint | params_flow.rb:49:13:49:14 | p1 |
 | params_flow.rb:60:9:60:17 | call to taint | params_flow.rb:50:10:50:11 | p1 |
-| params_flow.rb:60:9:60:17 | call to taint | params_flow.rb:51:10:51:21 | ( ... ) |
-| params_flow.rb:60:9:60:17 | call to taint | params_flow.rb:51:11:51:20 | ...[...] |
 | params_flow.rb:60:9:60:17 | call to taint | params_flow.rb:60:9:60:17 | call to taint |
+| params_flow.rb:60:9:60:17 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:60:9:60:17 | synthetic splat argument | params_flow.rb:60:9:60:17 | synthetic splat argument |
 | params_flow.rb:60:15:60:16 | 24 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:60:15:60:16 | 24 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:60:15:60:16 | 24 | params_flow.rb:2:5:2:5 | x |
@@ -4235,34 +4253,30 @@ trackEnd
 | params_flow.rb:60:15:60:16 | 24 | params_flow.rb:49:13:49:14 | p1 |
 | params_flow.rb:60:15:60:16 | 24 | params_flow.rb:49:13:49:14 | p1 |
 | params_flow.rb:60:15:60:16 | 24 | params_flow.rb:50:10:50:11 | p1 |
-| params_flow.rb:60:15:60:16 | 24 | params_flow.rb:51:10:51:21 | ( ... ) |
-| params_flow.rb:60:15:60:16 | 24 | params_flow.rb:51:11:51:20 | ...[...] |
 | params_flow.rb:60:15:60:16 | 24 | params_flow.rb:60:9:60:17 | call to taint |
 | params_flow.rb:60:15:60:16 | 24 | params_flow.rb:60:15:60:16 | 24 |
-| params_flow.rb:60:20:60:28 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:60:20:60:28 | * | params_flow.rb:60:20:60:28 | * |
 | params_flow.rb:60:20:60:28 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:60:20:60:28 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:60:20:60:28 | call to taint | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:60:20:60:28 | call to taint | params_flow.rb:52:10:52:21 | ( ... ) |
-| params_flow.rb:60:20:60:28 | call to taint | params_flow.rb:52:11:52:20 | ...[...] |
+| params_flow.rb:60:20:60:28 | call to taint | params_flow.rb:51:10:51:21 | ( ... ) |
+| params_flow.rb:60:20:60:28 | call to taint | params_flow.rb:51:11:51:20 | ...[...] |
 | params_flow.rb:60:20:60:28 | call to taint | params_flow.rb:60:20:60:28 | call to taint |
+| params_flow.rb:60:20:60:28 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:60:20:60:28 | synthetic splat argument | params_flow.rb:60:20:60:28 | synthetic splat argument |
 | params_flow.rb:60:26:60:27 | 25 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:60:26:60:27 | 25 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:60:26:60:27 | 25 | params_flow.rb:2:5:2:5 | x |
 | params_flow.rb:60:26:60:27 | 25 | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:60:26:60:27 | 25 | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:60:26:60:27 | 25 | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:60:26:60:27 | 25 | params_flow.rb:52:10:52:21 | ( ... ) |
-| params_flow.rb:60:26:60:27 | 25 | params_flow.rb:52:11:52:20 | ...[...] |
+| params_flow.rb:60:26:60:27 | 25 | params_flow.rb:51:10:51:21 | ( ... ) |
+| params_flow.rb:60:26:60:27 | 25 | params_flow.rb:51:11:51:20 | ...[...] |
 | params_flow.rb:60:26:60:27 | 25 | params_flow.rb:60:20:60:28 | call to taint |
 | params_flow.rb:60:26:60:27 | 25 | params_flow.rb:60:26:60:27 | 25 |
 | params_flow.rb:61:1:61:14 | call to posargs | params_flow.rb:61:1:61:14 | call to posargs |
-| params_flow.rb:61:9:61:13 | * ... | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:61:9:61:13 | * ... | params_flow.rb:49:1:53:3 | synthetic splat parameter |
 | params_flow.rb:61:9:61:13 | * ... | params_flow.rb:61:9:61:13 | * ... |
 | params_flow.rb:63:1:63:4 | args | params_flow.rb:63:1:63:4 | args |
-| params_flow.rb:63:8:63:16 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:63:8:63:16 | * | params_flow.rb:63:8:63:16 | * |
 | params_flow.rb:63:8:63:16 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:63:8:63:16 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:63:8:63:16 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -4271,6 +4285,8 @@ trackEnd
 | params_flow.rb:63:8:63:16 | call to taint | params_flow.rb:63:8:63:16 | call to taint |
 | params_flow.rb:63:8:63:16 | call to taint | params_flow.rb:65:10:65:13 | ...[...] |
 | params_flow.rb:63:8:63:16 | call to taint | params_flow.rb:67:13:67:16 | args |
+| params_flow.rb:63:8:63:16 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:63:8:63:16 | synthetic splat argument | params_flow.rb:63:8:63:16 | synthetic splat argument |
 | params_flow.rb:63:14:63:15 | 26 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:63:14:63:15 | 26 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:63:14:63:15 | 26 | params_flow.rb:2:5:2:5 | x |
@@ -4295,15 +4311,15 @@ trackEnd
 | params_flow.rb:64:16:64:17 | *x | params_flow.rb:64:17:64:17 | x |
 | params_flow.rb:64:16:64:17 | *x | params_flow.rb:65:10:65:10 | x |
 | params_flow.rb:64:17:64:17 | x | params_flow.rb:64:17:64:17 | x |
-| params_flow.rb:65:5:65:13 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:65:5:65:13 | * | params_flow.rb:65:5:65:13 | * |
 | params_flow.rb:65:5:65:13 | call to sink | params_flow.rb:65:5:65:13 | call to sink |
 | params_flow.rb:65:5:65:13 | call to sink | params_flow.rb:67:1:67:17 | call to splatstuff |
-| params_flow.rb:65:10:65:13 | * | params_flow.rb:65:10:65:13 | * |
+| params_flow.rb:65:5:65:13 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:65:5:65:13 | synthetic splat argument | params_flow.rb:65:5:65:13 | synthetic splat argument |
 | params_flow.rb:65:10:65:13 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:65:10:65:13 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:65:10:65:13 | ...[...] | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:65:10:65:13 | ...[...] | params_flow.rb:65:10:65:13 | ...[...] |
+| params_flow.rb:65:10:65:13 | synthetic splat argument | params_flow.rb:65:10:65:13 | synthetic splat argument |
 | params_flow.rb:65:12:65:12 | 0 | params_flow.rb:65:12:65:12 | 0 |
 | params_flow.rb:67:1:67:17 | call to splatstuff | params_flow.rb:67:1:67:17 | call to splatstuff |
 | params_flow.rb:67:12:67:16 | * ... | params_flow.rb:64:16:64:17 | *x |
@@ -4323,7 +4339,7 @@ trackEnd
 | params_flow.rb:69:1:76:3 | self in splatmid | params_flow.rb:74:5:74:10 | self |
 | params_flow.rb:69:1:76:3 | self in splatmid | params_flow.rb:75:5:75:10 | self |
 | params_flow.rb:69:1:76:3 | splatmid | params_flow.rb:69:1:76:3 | splatmid |
-| params_flow.rb:69:1:76:3 | synthetic *args | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:69:1:76:3 | synthetic splat parameter | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:69:14:69:14 | x | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:69:14:69:14 | x | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:69:14:69:14 | x | params_flow.rb:6:10:6:10 | x |
@@ -4357,44 +4373,42 @@ trackEnd
 | params_flow.rb:69:27:69:27 | r | params_flow.rb:69:27:69:27 | r |
 | params_flow.rb:69:27:69:27 | r | params_flow.rb:69:27:69:27 | r |
 | params_flow.rb:69:27:69:27 | r | params_flow.rb:75:10:75:10 | r |
-| params_flow.rb:70:5:70:10 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:70:5:70:10 | * | params_flow.rb:70:5:70:10 | * |
 | params_flow.rb:70:5:70:10 | call to sink | params_flow.rb:70:5:70:10 | call to sink |
-| params_flow.rb:71:5:71:10 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:71:5:71:10 | * | params_flow.rb:71:5:71:10 | * |
+| params_flow.rb:70:5:70:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:70:5:70:10 | synthetic splat argument | params_flow.rb:70:5:70:10 | synthetic splat argument |
 | params_flow.rb:71:5:71:10 | call to sink | params_flow.rb:71:5:71:10 | call to sink |
-| params_flow.rb:72:5:72:13 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:72:5:72:13 | * | params_flow.rb:72:5:72:13 | * |
+| params_flow.rb:71:5:71:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:71:5:71:10 | synthetic splat argument | params_flow.rb:71:5:71:10 | synthetic splat argument |
 | params_flow.rb:72:5:72:13 | call to sink | params_flow.rb:72:5:72:13 | call to sink |
-| params_flow.rb:72:10:72:13 | * | params_flow.rb:72:10:72:13 | * |
+| params_flow.rb:72:5:72:13 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:72:5:72:13 | synthetic splat argument | params_flow.rb:72:5:72:13 | synthetic splat argument |
 | params_flow.rb:72:10:72:13 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:72:10:72:13 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:72:10:72:13 | ...[...] | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:72:10:72:13 | ...[...] | params_flow.rb:72:10:72:13 | ...[...] |
+| params_flow.rb:72:10:72:13 | synthetic splat argument | params_flow.rb:72:10:72:13 | synthetic splat argument |
 | params_flow.rb:72:12:72:12 | 0 | params_flow.rb:72:12:72:12 | 0 |
-| params_flow.rb:73:5:73:13 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:73:5:73:13 | * | params_flow.rb:73:5:73:13 | * |
 | params_flow.rb:73:5:73:13 | call to sink | params_flow.rb:73:5:73:13 | call to sink |
-| params_flow.rb:73:10:73:13 | * | params_flow.rb:73:10:73:13 | * |
+| params_flow.rb:73:5:73:13 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:73:5:73:13 | synthetic splat argument | params_flow.rb:73:5:73:13 | synthetic splat argument |
 | params_flow.rb:73:10:73:13 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:73:10:73:13 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:73:10:73:13 | ...[...] | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:73:10:73:13 | ...[...] | params_flow.rb:73:10:73:13 | ...[...] |
+| params_flow.rb:73:10:73:13 | synthetic splat argument | params_flow.rb:73:10:73:13 | synthetic splat argument |
 | params_flow.rb:73:12:73:12 | 1 | params_flow.rb:73:12:73:12 | 1 |
-| params_flow.rb:74:5:74:10 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:74:5:74:10 | * | params_flow.rb:74:5:74:10 | * |
 | params_flow.rb:74:5:74:10 | call to sink | params_flow.rb:74:5:74:10 | call to sink |
-| params_flow.rb:75:5:75:10 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:75:5:75:10 | * | params_flow.rb:75:5:75:10 | * |
+| params_flow.rb:74:5:74:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:74:5:74:10 | synthetic splat argument | params_flow.rb:74:5:74:10 | synthetic splat argument |
 | params_flow.rb:75:5:75:10 | call to sink | params_flow.rb:75:5:75:10 | call to sink |
 | params_flow.rb:75:5:75:10 | call to sink | params_flow.rb:78:1:78:63 | call to splatmid |
 | params_flow.rb:75:5:75:10 | call to sink | params_flow.rb:81:1:81:37 | call to splatmid |
 | params_flow.rb:75:5:75:10 | call to sink | params_flow.rb:96:1:96:88 | call to splatmid |
-| params_flow.rb:78:1:78:63 | * | params_flow.rb:69:1:76:3 | synthetic *args |
-| params_flow.rb:78:1:78:63 | * | params_flow.rb:78:1:78:63 | * |
+| params_flow.rb:75:5:75:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:75:5:75:10 | synthetic splat argument | params_flow.rb:75:5:75:10 | synthetic splat argument |
 | params_flow.rb:78:1:78:63 | call to splatmid | params_flow.rb:78:1:78:63 | call to splatmid |
-| params_flow.rb:78:10:78:18 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:78:10:78:18 | * | params_flow.rb:78:10:78:18 | * |
+| params_flow.rb:78:1:78:63 | synthetic splat argument | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:78:1:78:63 | synthetic splat argument | params_flow.rb:78:1:78:63 | synthetic splat argument |
 | params_flow.rb:78:10:78:18 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:78:10:78:18 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:78:10:78:18 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -4402,6 +4416,8 @@ trackEnd
 | params_flow.rb:78:10:78:18 | call to taint | params_flow.rb:69:14:69:14 | x |
 | params_flow.rb:78:10:78:18 | call to taint | params_flow.rb:70:10:70:10 | x |
 | params_flow.rb:78:10:78:18 | call to taint | params_flow.rb:78:10:78:18 | call to taint |
+| params_flow.rb:78:10:78:18 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:78:10:78:18 | synthetic splat argument | params_flow.rb:78:10:78:18 | synthetic splat argument |
 | params_flow.rb:78:16:78:17 | 27 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:78:16:78:17 | 27 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:78:16:78:17 | 27 | params_flow.rb:2:5:2:5 | x |
@@ -4413,8 +4429,6 @@ trackEnd
 | params_flow.rb:78:16:78:17 | 27 | params_flow.rb:70:10:70:10 | x |
 | params_flow.rb:78:16:78:17 | 27 | params_flow.rb:78:10:78:18 | call to taint |
 | params_flow.rb:78:16:78:17 | 27 | params_flow.rb:78:16:78:17 | 27 |
-| params_flow.rb:78:21:78:29 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:78:21:78:29 | * | params_flow.rb:78:21:78:29 | * |
 | params_flow.rb:78:21:78:29 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:78:21:78:29 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:78:21:78:29 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -4422,6 +4436,8 @@ trackEnd
 | params_flow.rb:78:21:78:29 | call to taint | params_flow.rb:69:17:69:17 | y |
 | params_flow.rb:78:21:78:29 | call to taint | params_flow.rb:71:10:71:10 | y |
 | params_flow.rb:78:21:78:29 | call to taint | params_flow.rb:78:21:78:29 | call to taint |
+| params_flow.rb:78:21:78:29 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:78:21:78:29 | synthetic splat argument | params_flow.rb:78:21:78:29 | synthetic splat argument |
 | params_flow.rb:78:27:78:28 | 28 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:78:27:78:28 | 28 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:78:27:78:28 | 28 | params_flow.rb:2:5:2:5 | x |
@@ -4433,16 +4449,14 @@ trackEnd
 | params_flow.rb:78:27:78:28 | 28 | params_flow.rb:71:10:71:10 | y |
 | params_flow.rb:78:27:78:28 | 28 | params_flow.rb:78:21:78:29 | call to taint |
 | params_flow.rb:78:27:78:28 | 28 | params_flow.rb:78:27:78:28 | 28 |
-| params_flow.rb:78:32:78:40 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:78:32:78:40 | * | params_flow.rb:78:32:78:40 | * |
 | params_flow.rb:78:32:78:40 | call to taint | params_flow.rb:78:32:78:40 | call to taint |
+| params_flow.rb:78:32:78:40 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:78:32:78:40 | synthetic splat argument | params_flow.rb:78:32:78:40 | synthetic splat argument |
 | params_flow.rb:78:38:78:39 | 29 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:78:38:78:39 | 29 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:78:38:78:39 | 29 | params_flow.rb:2:5:2:5 | x |
 | params_flow.rb:78:38:78:39 | 29 | params_flow.rb:78:32:78:40 | call to taint |
 | params_flow.rb:78:38:78:39 | 29 | params_flow.rb:78:38:78:39 | 29 |
-| params_flow.rb:78:43:78:51 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:78:43:78:51 | * | params_flow.rb:78:43:78:51 | * |
 | params_flow.rb:78:43:78:51 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:78:43:78:51 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:78:43:78:51 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -4450,6 +4464,8 @@ trackEnd
 | params_flow.rb:78:43:78:51 | call to taint | params_flow.rb:69:24:69:24 | w |
 | params_flow.rb:78:43:78:51 | call to taint | params_flow.rb:74:10:74:10 | w |
 | params_flow.rb:78:43:78:51 | call to taint | params_flow.rb:78:43:78:51 | call to taint |
+| params_flow.rb:78:43:78:51 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:78:43:78:51 | synthetic splat argument | params_flow.rb:78:43:78:51 | synthetic splat argument |
 | params_flow.rb:78:49:78:50 | 30 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:78:49:78:50 | 30 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:78:49:78:50 | 30 | params_flow.rb:2:5:2:5 | x |
@@ -4461,8 +4477,6 @@ trackEnd
 | params_flow.rb:78:49:78:50 | 30 | params_flow.rb:74:10:74:10 | w |
 | params_flow.rb:78:49:78:50 | 30 | params_flow.rb:78:43:78:51 | call to taint |
 | params_flow.rb:78:49:78:50 | 30 | params_flow.rb:78:49:78:50 | 30 |
-| params_flow.rb:78:54:78:62 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:78:54:78:62 | * | params_flow.rb:78:54:78:62 | * |
 | params_flow.rb:78:54:78:62 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:78:54:78:62 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:78:54:78:62 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -4470,6 +4484,8 @@ trackEnd
 | params_flow.rb:78:54:78:62 | call to taint | params_flow.rb:69:27:69:27 | r |
 | params_flow.rb:78:54:78:62 | call to taint | params_flow.rb:75:10:75:10 | r |
 | params_flow.rb:78:54:78:62 | call to taint | params_flow.rb:78:54:78:62 | call to taint |
+| params_flow.rb:78:54:78:62 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:78:54:78:62 | synthetic splat argument | params_flow.rb:78:54:78:62 | synthetic splat argument |
 | params_flow.rb:78:60:78:61 | 31 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:78:60:78:61 | 31 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:78:60:78:61 | 31 | params_flow.rb:2:5:2:5 | x |
@@ -4482,7 +4498,6 @@ trackEnd
 | params_flow.rb:78:60:78:61 | 31 | params_flow.rb:78:54:78:62 | call to taint |
 | params_flow.rb:78:60:78:61 | 31 | params_flow.rb:78:60:78:61 | 31 |
 | params_flow.rb:80:1:80:4 | args | params_flow.rb:80:1:80:4 | args |
-| params_flow.rb:80:8:80:51 | * | params_flow.rb:80:8:80:51 | * |
 | params_flow.rb:80:8:80:51 | Array | params_flow.rb:80:8:80:51 | Array |
 | params_flow.rb:80:8:80:51 | call to [] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:80:8:80:51 | call to [] | params_flow.rb:5:10:5:10 | x |
@@ -4494,8 +4509,17 @@ trackEnd
 | params_flow.rb:80:8:80:51 | call to [] | params_flow.rb:80:1:80:51 | ... = ... |
 | params_flow.rb:80:8:80:51 | call to [] | params_flow.rb:80:8:80:51 | call to [] |
 | params_flow.rb:80:8:80:51 | call to [] | params_flow.rb:81:22:81:25 | args |
-| params_flow.rb:80:9:80:17 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:80:9:80:17 | * | params_flow.rb:80:9:80:17 | * |
+| params_flow.rb:80:8:80:51 | synthetic splat argument | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:80:8:80:51 | synthetic splat argument | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:80:8:80:51 | synthetic splat argument | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:80:8:80:51 | synthetic splat argument | params_flow.rb:69:17:69:17 | y |
+| params_flow.rb:80:8:80:51 | synthetic splat argument | params_flow.rb:69:17:69:17 | y |
+| params_flow.rb:80:8:80:51 | synthetic splat argument | params_flow.rb:71:10:71:10 | y |
+| params_flow.rb:80:8:80:51 | synthetic splat argument | params_flow.rb:80:1:80:4 | args |
+| params_flow.rb:80:8:80:51 | synthetic splat argument | params_flow.rb:80:1:80:51 | ... = ... |
+| params_flow.rb:80:8:80:51 | synthetic splat argument | params_flow.rb:80:8:80:51 | call to [] |
+| params_flow.rb:80:8:80:51 | synthetic splat argument | params_flow.rb:80:8:80:51 | synthetic splat argument |
+| params_flow.rb:80:8:80:51 | synthetic splat argument | params_flow.rb:81:22:81:25 | args |
 | params_flow.rb:80:9:80:17 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:80:9:80:17 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:80:9:80:17 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -4503,6 +4527,8 @@ trackEnd
 | params_flow.rb:80:9:80:17 | call to taint | params_flow.rb:69:17:69:17 | y |
 | params_flow.rb:80:9:80:17 | call to taint | params_flow.rb:71:10:71:10 | y |
 | params_flow.rb:80:9:80:17 | call to taint | params_flow.rb:80:9:80:17 | call to taint |
+| params_flow.rb:80:9:80:17 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:80:9:80:17 | synthetic splat argument | params_flow.rb:80:9:80:17 | synthetic splat argument |
 | params_flow.rb:80:15:80:16 | 33 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:80:15:80:16 | 33 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:80:15:80:16 | 33 | params_flow.rb:2:5:2:5 | x |
@@ -4514,59 +4540,33 @@ trackEnd
 | params_flow.rb:80:15:80:16 | 33 | params_flow.rb:71:10:71:10 | y |
 | params_flow.rb:80:15:80:16 | 33 | params_flow.rb:80:9:80:17 | call to taint |
 | params_flow.rb:80:15:80:16 | 33 | params_flow.rb:80:15:80:16 | 33 |
-| params_flow.rb:80:20:80:28 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:80:20:80:28 | * | params_flow.rb:80:20:80:28 | * |
 | params_flow.rb:80:20:80:28 | call to taint | params_flow.rb:80:20:80:28 | call to taint |
+| params_flow.rb:80:20:80:28 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:80:20:80:28 | synthetic splat argument | params_flow.rb:80:20:80:28 | synthetic splat argument |
 | params_flow.rb:80:26:80:27 | 34 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:80:26:80:27 | 34 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:80:26:80:27 | 34 | params_flow.rb:2:5:2:5 | x |
 | params_flow.rb:80:26:80:27 | 34 | params_flow.rb:80:20:80:28 | call to taint |
 | params_flow.rb:80:26:80:27 | 34 | params_flow.rb:80:26:80:27 | 34 |
-| params_flow.rb:80:31:80:39 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:80:31:80:39 | * | params_flow.rb:80:31:80:39 | * |
-| params_flow.rb:80:31:80:39 | call to taint | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:80:31:80:39 | call to taint | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:80:31:80:39 | call to taint | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:80:31:80:39 | call to taint | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:80:31:80:39 | call to taint | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:80:31:80:39 | call to taint | params_flow.rb:74:10:74:10 | w |
 | params_flow.rb:80:31:80:39 | call to taint | params_flow.rb:80:31:80:39 | call to taint |
+| params_flow.rb:80:31:80:39 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:80:31:80:39 | synthetic splat argument | params_flow.rb:80:31:80:39 | synthetic splat argument |
 | params_flow.rb:80:37:80:38 | 35 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:80:37:80:38 | 35 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:80:37:80:38 | 35 | params_flow.rb:2:5:2:5 | x |
-| params_flow.rb:80:37:80:38 | 35 | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:80:37:80:38 | 35 | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:80:37:80:38 | 35 | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:80:37:80:38 | 35 | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:80:37:80:38 | 35 | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:80:37:80:38 | 35 | params_flow.rb:74:10:74:10 | w |
 | params_flow.rb:80:37:80:38 | 35 | params_flow.rb:80:31:80:39 | call to taint |
 | params_flow.rb:80:37:80:38 | 35 | params_flow.rb:80:37:80:38 | 35 |
-| params_flow.rb:80:42:80:50 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:80:42:80:50 | * | params_flow.rb:80:42:80:50 | * |
-| params_flow.rb:80:42:80:50 | call to taint | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:80:42:80:50 | call to taint | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:80:42:80:50 | call to taint | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:80:42:80:50 | call to taint | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:80:42:80:50 | call to taint | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:80:42:80:50 | call to taint | params_flow.rb:75:10:75:10 | r |
 | params_flow.rb:80:42:80:50 | call to taint | params_flow.rb:80:42:80:50 | call to taint |
+| params_flow.rb:80:42:80:50 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:80:42:80:50 | synthetic splat argument | params_flow.rb:80:42:80:50 | synthetic splat argument |
 | params_flow.rb:80:48:80:49 | 36 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:80:48:80:49 | 36 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:80:48:80:49 | 36 | params_flow.rb:2:5:2:5 | x |
-| params_flow.rb:80:48:80:49 | 36 | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:80:48:80:49 | 36 | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:80:48:80:49 | 36 | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:80:48:80:49 | 36 | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:80:48:80:49 | 36 | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:80:48:80:49 | 36 | params_flow.rb:75:10:75:10 | r |
 | params_flow.rb:80:48:80:49 | 36 | params_flow.rb:80:42:80:50 | call to taint |
 | params_flow.rb:80:48:80:49 | 36 | params_flow.rb:80:48:80:49 | 36 |
-| params_flow.rb:81:1:81:37 | * | params_flow.rb:69:1:76:3 | synthetic *args |
-| params_flow.rb:81:1:81:37 | * | params_flow.rb:81:1:81:37 | * |
 | params_flow.rb:81:1:81:37 | call to splatmid | params_flow.rb:81:1:81:37 | call to splatmid |
-| params_flow.rb:81:10:81:18 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:81:10:81:18 | * | params_flow.rb:81:10:81:18 | * |
+| params_flow.rb:81:1:81:37 | synthetic splat argument | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:81:1:81:37 | synthetic splat argument | params_flow.rb:81:1:81:37 | synthetic splat argument |
 | params_flow.rb:81:10:81:18 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:81:10:81:18 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:81:10:81:18 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -4574,6 +4574,8 @@ trackEnd
 | params_flow.rb:81:10:81:18 | call to taint | params_flow.rb:69:14:69:14 | x |
 | params_flow.rb:81:10:81:18 | call to taint | params_flow.rb:70:10:70:10 | x |
 | params_flow.rb:81:10:81:18 | call to taint | params_flow.rb:81:10:81:18 | call to taint |
+| params_flow.rb:81:10:81:18 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:81:10:81:18 | synthetic splat argument | params_flow.rb:81:10:81:18 | synthetic splat argument |
 | params_flow.rb:81:16:81:17 | 32 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:81:16:81:17 | 32 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:81:16:81:17 | 32 | params_flow.rb:2:5:2:5 | x |
@@ -4586,9 +4588,9 @@ trackEnd
 | params_flow.rb:81:16:81:17 | 32 | params_flow.rb:81:10:81:18 | call to taint |
 | params_flow.rb:81:16:81:17 | 32 | params_flow.rb:81:16:81:17 | 32 |
 | params_flow.rb:81:21:81:25 | * ... | params_flow.rb:81:21:81:25 | * ... |
-| params_flow.rb:81:28:81:36 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:81:28:81:36 | * | params_flow.rb:81:28:81:36 | * |
 | params_flow.rb:81:28:81:36 | call to taint | params_flow.rb:81:28:81:36 | call to taint |
+| params_flow.rb:81:28:81:36 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:81:28:81:36 | synthetic splat argument | params_flow.rb:81:28:81:36 | synthetic splat argument |
 | params_flow.rb:81:34:81:35 | 37 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:81:34:81:35 | 37 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:81:34:81:35 | 37 | params_flow.rb:2:5:2:5 | x |
@@ -4608,7 +4610,7 @@ trackEnd
 | params_flow.rb:83:1:91:3 | self in pos_many | params_flow.rb:88:5:88:10 | self |
 | params_flow.rb:83:1:91:3 | self in pos_many | params_flow.rb:89:5:89:10 | self |
 | params_flow.rb:83:1:91:3 | self in pos_many | params_flow.rb:90:5:90:10 | self |
-| params_flow.rb:83:1:91:3 | synthetic *args | params_flow.rb:83:1:91:3 | synthetic *args |
+| params_flow.rb:83:1:91:3 | synthetic splat parameter | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:83:14:83:14 | t | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:83:14:83:14 | t | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:83:14:83:14 | t | params_flow.rb:6:10:6:10 | x |
@@ -4658,31 +4660,30 @@ trackEnd
 | params_flow.rb:83:32:83:32 | z | params_flow.rb:83:32:83:32 | z |
 | params_flow.rb:83:32:83:32 | z | params_flow.rb:83:32:83:32 | z |
 | params_flow.rb:83:32:83:32 | z | params_flow.rb:90:10:90:10 | z |
-| params_flow.rb:84:5:84:10 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:84:5:84:10 | * | params_flow.rb:84:5:84:10 | * |
 | params_flow.rb:84:5:84:10 | call to sink | params_flow.rb:84:5:84:10 | call to sink |
-| params_flow.rb:85:5:85:10 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:85:5:85:10 | * | params_flow.rb:85:5:85:10 | * |
+| params_flow.rb:84:5:84:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:84:5:84:10 | synthetic splat argument | params_flow.rb:84:5:84:10 | synthetic splat argument |
 | params_flow.rb:85:5:85:10 | call to sink | params_flow.rb:85:5:85:10 | call to sink |
-| params_flow.rb:86:5:86:10 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:86:5:86:10 | * | params_flow.rb:86:5:86:10 | * |
+| params_flow.rb:85:5:85:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:85:5:85:10 | synthetic splat argument | params_flow.rb:85:5:85:10 | synthetic splat argument |
 | params_flow.rb:86:5:86:10 | call to sink | params_flow.rb:86:5:86:10 | call to sink |
-| params_flow.rb:87:5:87:10 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:87:5:87:10 | * | params_flow.rb:87:5:87:10 | * |
+| params_flow.rb:86:5:86:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:86:5:86:10 | synthetic splat argument | params_flow.rb:86:5:86:10 | synthetic splat argument |
 | params_flow.rb:87:5:87:10 | call to sink | params_flow.rb:87:5:87:10 | call to sink |
-| params_flow.rb:88:5:88:10 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:88:5:88:10 | * | params_flow.rb:88:5:88:10 | * |
+| params_flow.rb:87:5:87:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:87:5:87:10 | synthetic splat argument | params_flow.rb:87:5:87:10 | synthetic splat argument |
 | params_flow.rb:88:5:88:10 | call to sink | params_flow.rb:88:5:88:10 | call to sink |
-| params_flow.rb:89:5:89:10 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:89:5:89:10 | * | params_flow.rb:89:5:89:10 | * |
+| params_flow.rb:88:5:88:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:88:5:88:10 | synthetic splat argument | params_flow.rb:88:5:88:10 | synthetic splat argument |
 | params_flow.rb:89:5:89:10 | call to sink | params_flow.rb:89:5:89:10 | call to sink |
-| params_flow.rb:90:5:90:10 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:90:5:90:10 | * | params_flow.rb:90:5:90:10 | * |
+| params_flow.rb:89:5:89:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:89:5:89:10 | synthetic splat argument | params_flow.rb:89:5:89:10 | synthetic splat argument |
 | params_flow.rb:90:5:90:10 | call to sink | params_flow.rb:90:5:90:10 | call to sink |
 | params_flow.rb:90:5:90:10 | call to sink | params_flow.rb:94:1:94:48 | call to pos_many |
 | params_flow.rb:90:5:90:10 | call to sink | params_flow.rb:131:1:131:46 | call to pos_many |
+| params_flow.rb:90:5:90:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:90:5:90:10 | synthetic splat argument | params_flow.rb:90:5:90:10 | synthetic splat argument |
 | params_flow.rb:93:1:93:4 | args | params_flow.rb:93:1:93:4 | args |
-| params_flow.rb:93:8:93:51 | * | params_flow.rb:93:8:93:51 | * |
 | params_flow.rb:93:8:93:51 | Array | params_flow.rb:93:8:93:51 | Array |
 | params_flow.rb:93:8:93:51 | call to [] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:93:8:93:51 | call to [] | params_flow.rb:5:10:5:10 | x |
@@ -4694,8 +4695,17 @@ trackEnd
 | params_flow.rb:93:8:93:51 | call to [] | params_flow.rb:93:1:93:51 | ... = ... |
 | params_flow.rb:93:8:93:51 | call to [] | params_flow.rb:93:8:93:51 | call to [] |
 | params_flow.rb:93:8:93:51 | call to [] | params_flow.rb:94:33:94:36 | args |
-| params_flow.rb:93:9:93:17 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:93:9:93:17 | * | params_flow.rb:93:9:93:17 | * |
+| params_flow.rb:93:8:93:51 | synthetic splat argument | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:93:8:93:51 | synthetic splat argument | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:93:8:93:51 | synthetic splat argument | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:93:8:93:51 | synthetic splat argument | params_flow.rb:83:20:83:20 | v |
+| params_flow.rb:93:8:93:51 | synthetic splat argument | params_flow.rb:83:20:83:20 | v |
+| params_flow.rb:93:8:93:51 | synthetic splat argument | params_flow.rb:86:10:86:10 | v |
+| params_flow.rb:93:8:93:51 | synthetic splat argument | params_flow.rb:93:1:93:4 | args |
+| params_flow.rb:93:8:93:51 | synthetic splat argument | params_flow.rb:93:1:93:51 | ... = ... |
+| params_flow.rb:93:8:93:51 | synthetic splat argument | params_flow.rb:93:8:93:51 | call to [] |
+| params_flow.rb:93:8:93:51 | synthetic splat argument | params_flow.rb:93:8:93:51 | synthetic splat argument |
+| params_flow.rb:93:8:93:51 | synthetic splat argument | params_flow.rb:94:33:94:36 | args |
 | params_flow.rb:93:9:93:17 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:93:9:93:17 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:93:9:93:17 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -4703,6 +4713,8 @@ trackEnd
 | params_flow.rb:93:9:93:17 | call to taint | params_flow.rb:83:20:83:20 | v |
 | params_flow.rb:93:9:93:17 | call to taint | params_flow.rb:86:10:86:10 | v |
 | params_flow.rb:93:9:93:17 | call to taint | params_flow.rb:93:9:93:17 | call to taint |
+| params_flow.rb:93:9:93:17 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:93:9:93:17 | synthetic splat argument | params_flow.rb:93:9:93:17 | synthetic splat argument |
 | params_flow.rb:93:15:93:16 | 40 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:93:15:93:16 | 40 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:93:15:93:16 | 40 | params_flow.rb:2:5:2:5 | x |
@@ -4714,8 +4726,6 @@ trackEnd
 | params_flow.rb:93:15:93:16 | 40 | params_flow.rb:86:10:86:10 | v |
 | params_flow.rb:93:15:93:16 | 40 | params_flow.rb:93:9:93:17 | call to taint |
 | params_flow.rb:93:15:93:16 | 40 | params_flow.rb:93:15:93:16 | 40 |
-| params_flow.rb:93:20:93:28 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:93:20:93:28 | * | params_flow.rb:93:20:93:28 | * |
 | params_flow.rb:93:20:93:28 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:93:20:93:28 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:93:20:93:28 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -4723,6 +4733,8 @@ trackEnd
 | params_flow.rb:93:20:93:28 | call to taint | params_flow.rb:83:23:83:23 | w |
 | params_flow.rb:93:20:93:28 | call to taint | params_flow.rb:87:10:87:10 | w |
 | params_flow.rb:93:20:93:28 | call to taint | params_flow.rb:93:20:93:28 | call to taint |
+| params_flow.rb:93:20:93:28 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:93:20:93:28 | synthetic splat argument | params_flow.rb:93:20:93:28 | synthetic splat argument |
 | params_flow.rb:93:26:93:27 | 41 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:93:26:93:27 | 41 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:93:26:93:27 | 41 | params_flow.rb:2:5:2:5 | x |
@@ -4734,8 +4746,6 @@ trackEnd
 | params_flow.rb:93:26:93:27 | 41 | params_flow.rb:87:10:87:10 | w |
 | params_flow.rb:93:26:93:27 | 41 | params_flow.rb:93:20:93:28 | call to taint |
 | params_flow.rb:93:26:93:27 | 41 | params_flow.rb:93:26:93:27 | 41 |
-| params_flow.rb:93:31:93:39 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:93:31:93:39 | * | params_flow.rb:93:31:93:39 | * |
 | params_flow.rb:93:31:93:39 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:93:31:93:39 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:93:31:93:39 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -4743,6 +4753,8 @@ trackEnd
 | params_flow.rb:93:31:93:39 | call to taint | params_flow.rb:83:26:83:26 | x |
 | params_flow.rb:93:31:93:39 | call to taint | params_flow.rb:88:10:88:10 | x |
 | params_flow.rb:93:31:93:39 | call to taint | params_flow.rb:93:31:93:39 | call to taint |
+| params_flow.rb:93:31:93:39 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:93:31:93:39 | synthetic splat argument | params_flow.rb:93:31:93:39 | synthetic splat argument |
 | params_flow.rb:93:37:93:38 | 42 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:93:37:93:38 | 42 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:93:37:93:38 | 42 | params_flow.rb:2:5:2:5 | x |
@@ -4754,8 +4766,6 @@ trackEnd
 | params_flow.rb:93:37:93:38 | 42 | params_flow.rb:88:10:88:10 | x |
 | params_flow.rb:93:37:93:38 | 42 | params_flow.rb:93:31:93:39 | call to taint |
 | params_flow.rb:93:37:93:38 | 42 | params_flow.rb:93:37:93:38 | 42 |
-| params_flow.rb:93:42:93:50 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:93:42:93:50 | * | params_flow.rb:93:42:93:50 | * |
 | params_flow.rb:93:42:93:50 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:93:42:93:50 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:93:42:93:50 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -4763,6 +4773,8 @@ trackEnd
 | params_flow.rb:93:42:93:50 | call to taint | params_flow.rb:83:29:83:29 | y |
 | params_flow.rb:93:42:93:50 | call to taint | params_flow.rb:89:10:89:10 | y |
 | params_flow.rb:93:42:93:50 | call to taint | params_flow.rb:93:42:93:50 | call to taint |
+| params_flow.rb:93:42:93:50 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:93:42:93:50 | synthetic splat argument | params_flow.rb:93:42:93:50 | synthetic splat argument |
 | params_flow.rb:93:48:93:49 | 43 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:93:48:93:49 | 43 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:93:48:93:49 | 43 | params_flow.rb:2:5:2:5 | x |
@@ -4774,11 +4786,9 @@ trackEnd
 | params_flow.rb:93:48:93:49 | 43 | params_flow.rb:89:10:89:10 | y |
 | params_flow.rb:93:48:93:49 | 43 | params_flow.rb:93:42:93:50 | call to taint |
 | params_flow.rb:93:48:93:49 | 43 | params_flow.rb:93:48:93:49 | 43 |
-| params_flow.rb:94:1:94:48 | * | params_flow.rb:83:1:91:3 | synthetic *args |
-| params_flow.rb:94:1:94:48 | * | params_flow.rb:94:1:94:48 | * |
 | params_flow.rb:94:1:94:48 | call to pos_many | params_flow.rb:94:1:94:48 | call to pos_many |
-| params_flow.rb:94:10:94:18 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:94:10:94:18 | * | params_flow.rb:94:10:94:18 | * |
+| params_flow.rb:94:1:94:48 | synthetic splat argument | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:94:1:94:48 | synthetic splat argument | params_flow.rb:94:1:94:48 | synthetic splat argument |
 | params_flow.rb:94:10:94:18 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:94:10:94:18 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:94:10:94:18 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -4786,6 +4796,8 @@ trackEnd
 | params_flow.rb:94:10:94:18 | call to taint | params_flow.rb:83:14:83:14 | t |
 | params_flow.rb:94:10:94:18 | call to taint | params_flow.rb:84:10:84:10 | t |
 | params_flow.rb:94:10:94:18 | call to taint | params_flow.rb:94:10:94:18 | call to taint |
+| params_flow.rb:94:10:94:18 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:94:10:94:18 | synthetic splat argument | params_flow.rb:94:10:94:18 | synthetic splat argument |
 | params_flow.rb:94:16:94:17 | 38 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:94:16:94:17 | 38 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:94:16:94:17 | 38 | params_flow.rb:2:5:2:5 | x |
@@ -4797,8 +4809,6 @@ trackEnd
 | params_flow.rb:94:16:94:17 | 38 | params_flow.rb:84:10:84:10 | t |
 | params_flow.rb:94:16:94:17 | 38 | params_flow.rb:94:10:94:18 | call to taint |
 | params_flow.rb:94:16:94:17 | 38 | params_flow.rb:94:16:94:17 | 38 |
-| params_flow.rb:94:21:94:29 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:94:21:94:29 | * | params_flow.rb:94:21:94:29 | * |
 | params_flow.rb:94:21:94:29 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:94:21:94:29 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:94:21:94:29 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -4806,6 +4816,8 @@ trackEnd
 | params_flow.rb:94:21:94:29 | call to taint | params_flow.rb:83:17:83:17 | u |
 | params_flow.rb:94:21:94:29 | call to taint | params_flow.rb:85:10:85:10 | u |
 | params_flow.rb:94:21:94:29 | call to taint | params_flow.rb:94:21:94:29 | call to taint |
+| params_flow.rb:94:21:94:29 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:94:21:94:29 | synthetic splat argument | params_flow.rb:94:21:94:29 | synthetic splat argument |
 | params_flow.rb:94:27:94:28 | 39 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:94:27:94:28 | 39 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:94:27:94:28 | 39 | params_flow.rb:2:5:2:5 | x |
@@ -4818,8 +4830,6 @@ trackEnd
 | params_flow.rb:94:27:94:28 | 39 | params_flow.rb:94:21:94:29 | call to taint |
 | params_flow.rb:94:27:94:28 | 39 | params_flow.rb:94:27:94:28 | 39 |
 | params_flow.rb:94:32:94:36 | * ... | params_flow.rb:94:32:94:36 | * ... |
-| params_flow.rb:94:39:94:47 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:94:39:94:47 | * | params_flow.rb:94:39:94:47 | * |
 | params_flow.rb:94:39:94:47 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:94:39:94:47 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:94:39:94:47 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -4827,6 +4837,8 @@ trackEnd
 | params_flow.rb:94:39:94:47 | call to taint | params_flow.rb:83:23:83:23 | w |
 | params_flow.rb:94:39:94:47 | call to taint | params_flow.rb:87:10:87:10 | w |
 | params_flow.rb:94:39:94:47 | call to taint | params_flow.rb:94:39:94:47 | call to taint |
+| params_flow.rb:94:39:94:47 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:94:39:94:47 | synthetic splat argument | params_flow.rb:94:39:94:47 | synthetic splat argument |
 | params_flow.rb:94:45:94:46 | 44 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:94:45:94:46 | 44 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:94:45:94:46 | 44 | params_flow.rb:2:5:2:5 | x |
@@ -4838,11 +4850,9 @@ trackEnd
 | params_flow.rb:94:45:94:46 | 44 | params_flow.rb:87:10:87:10 | w |
 | params_flow.rb:94:45:94:46 | 44 | params_flow.rb:94:39:94:47 | call to taint |
 | params_flow.rb:94:45:94:46 | 44 | params_flow.rb:94:45:94:46 | 44 |
-| params_flow.rb:96:1:96:88 | * | params_flow.rb:69:1:76:3 | synthetic *args |
-| params_flow.rb:96:1:96:88 | * | params_flow.rb:96:1:96:88 | * |
 | params_flow.rb:96:1:96:88 | call to splatmid | params_flow.rb:96:1:96:88 | call to splatmid |
-| params_flow.rb:96:10:96:18 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:96:10:96:18 | * | params_flow.rb:96:10:96:18 | * |
+| params_flow.rb:96:1:96:88 | synthetic splat argument | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:96:1:96:88 | synthetic splat argument | params_flow.rb:96:1:96:88 | synthetic splat argument |
 | params_flow.rb:96:10:96:18 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:96:10:96:18 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:96:10:96:18 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -4850,6 +4860,8 @@ trackEnd
 | params_flow.rb:96:10:96:18 | call to taint | params_flow.rb:69:14:69:14 | x |
 | params_flow.rb:96:10:96:18 | call to taint | params_flow.rb:70:10:70:10 | x |
 | params_flow.rb:96:10:96:18 | call to taint | params_flow.rb:96:10:96:18 | call to taint |
+| params_flow.rb:96:10:96:18 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:96:10:96:18 | synthetic splat argument | params_flow.rb:96:10:96:18 | synthetic splat argument |
 | params_flow.rb:96:16:96:17 | 45 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:16:96:17 | 45 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:16:96:17 | 45 | params_flow.rb:2:5:2:5 | x |
@@ -4861,8 +4873,6 @@ trackEnd
 | params_flow.rb:96:16:96:17 | 45 | params_flow.rb:70:10:70:10 | x |
 | params_flow.rb:96:16:96:17 | 45 | params_flow.rb:96:10:96:18 | call to taint |
 | params_flow.rb:96:16:96:17 | 45 | params_flow.rb:96:16:96:17 | 45 |
-| params_flow.rb:96:21:96:29 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:96:21:96:29 | * | params_flow.rb:96:21:96:29 | * |
 | params_flow.rb:96:21:96:29 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:96:21:96:29 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:96:21:96:29 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -4870,6 +4880,8 @@ trackEnd
 | params_flow.rb:96:21:96:29 | call to taint | params_flow.rb:69:17:69:17 | y |
 | params_flow.rb:96:21:96:29 | call to taint | params_flow.rb:71:10:71:10 | y |
 | params_flow.rb:96:21:96:29 | call to taint | params_flow.rb:96:21:96:29 | call to taint |
+| params_flow.rb:96:21:96:29 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:96:21:96:29 | synthetic splat argument | params_flow.rb:96:21:96:29 | synthetic splat argument |
 | params_flow.rb:96:27:96:28 | 46 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:27:96:28 | 46 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:27:96:28 | 46 | params_flow.rb:2:5:2:5 | x |
@@ -4882,59 +4894,34 @@ trackEnd
 | params_flow.rb:96:27:96:28 | 46 | params_flow.rb:96:21:96:29 | call to taint |
 | params_flow.rb:96:27:96:28 | 46 | params_flow.rb:96:27:96:28 | 46 |
 | params_flow.rb:96:32:96:65 | * ... | params_flow.rb:96:32:96:65 | * ... |
-| params_flow.rb:96:33:96:65 | * | params_flow.rb:96:33:96:65 | * |
 | params_flow.rb:96:33:96:65 | Array | params_flow.rb:96:33:96:65 | Array |
 | params_flow.rb:96:33:96:65 | call to [] | params_flow.rb:96:33:96:65 | call to [] |
-| params_flow.rb:96:34:96:42 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:96:34:96:42 | * | params_flow.rb:96:34:96:42 | * |
+| params_flow.rb:96:33:96:65 | synthetic splat argument | params_flow.rb:96:33:96:65 | call to [] |
+| params_flow.rb:96:33:96:65 | synthetic splat argument | params_flow.rb:96:33:96:65 | synthetic splat argument |
 | params_flow.rb:96:34:96:42 | call to taint | params_flow.rb:96:34:96:42 | call to taint |
+| params_flow.rb:96:34:96:42 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:96:34:96:42 | synthetic splat argument | params_flow.rb:96:34:96:42 | synthetic splat argument |
 | params_flow.rb:96:40:96:41 | 47 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:40:96:41 | 47 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:40:96:41 | 47 | params_flow.rb:2:5:2:5 | x |
 | params_flow.rb:96:40:96:41 | 47 | params_flow.rb:96:34:96:42 | call to taint |
 | params_flow.rb:96:40:96:41 | 47 | params_flow.rb:96:40:96:41 | 47 |
-| params_flow.rb:96:45:96:53 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:96:45:96:53 | * | params_flow.rb:96:45:96:53 | * |
-| params_flow.rb:96:45:96:53 | call to taint | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:96:45:96:53 | call to taint | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:96:45:96:53 | call to taint | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:96:45:96:53 | call to taint | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:96:45:96:53 | call to taint | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:96:45:96:53 | call to taint | params_flow.rb:74:10:74:10 | w |
 | params_flow.rb:96:45:96:53 | call to taint | params_flow.rb:96:45:96:53 | call to taint |
+| params_flow.rb:96:45:96:53 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:96:45:96:53 | synthetic splat argument | params_flow.rb:96:45:96:53 | synthetic splat argument |
 | params_flow.rb:96:51:96:52 | 48 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:51:96:52 | 48 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:51:96:52 | 48 | params_flow.rb:2:5:2:5 | x |
-| params_flow.rb:96:51:96:52 | 48 | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:96:51:96:52 | 48 | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:96:51:96:52 | 48 | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:96:51:96:52 | 48 | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:96:51:96:52 | 48 | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:96:51:96:52 | 48 | params_flow.rb:74:10:74:10 | w |
 | params_flow.rb:96:51:96:52 | 48 | params_flow.rb:96:45:96:53 | call to taint |
 | params_flow.rb:96:51:96:52 | 48 | params_flow.rb:96:51:96:52 | 48 |
-| params_flow.rb:96:56:96:64 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:96:56:96:64 | * | params_flow.rb:96:56:96:64 | * |
-| params_flow.rb:96:56:96:64 | call to taint | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:96:56:96:64 | call to taint | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:96:56:96:64 | call to taint | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:96:56:96:64 | call to taint | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:96:56:96:64 | call to taint | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:96:56:96:64 | call to taint | params_flow.rb:75:10:75:10 | r |
 | params_flow.rb:96:56:96:64 | call to taint | params_flow.rb:96:56:96:64 | call to taint |
+| params_flow.rb:96:56:96:64 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:96:56:96:64 | synthetic splat argument | params_flow.rb:96:56:96:64 | synthetic splat argument |
 | params_flow.rb:96:62:96:63 | 49 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:62:96:63 | 49 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:62:96:63 | 49 | params_flow.rb:2:5:2:5 | x |
-| params_flow.rb:96:62:96:63 | 49 | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:96:62:96:63 | 49 | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:96:62:96:63 | 49 | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:96:62:96:63 | 49 | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:96:62:96:63 | 49 | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:96:62:96:63 | 49 | params_flow.rb:75:10:75:10 | r |
 | params_flow.rb:96:62:96:63 | 49 | params_flow.rb:96:56:96:64 | call to taint |
 | params_flow.rb:96:62:96:63 | 49 | params_flow.rb:96:62:96:63 | 49 |
-| params_flow.rb:96:68:96:76 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:96:68:96:76 | * | params_flow.rb:96:68:96:76 | * |
 | params_flow.rb:96:68:96:76 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:96:68:96:76 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:96:68:96:76 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -4942,6 +4929,8 @@ trackEnd
 | params_flow.rb:96:68:96:76 | call to taint | params_flow.rb:69:24:69:24 | w |
 | params_flow.rb:96:68:96:76 | call to taint | params_flow.rb:74:10:74:10 | w |
 | params_flow.rb:96:68:96:76 | call to taint | params_flow.rb:96:68:96:76 | call to taint |
+| params_flow.rb:96:68:96:76 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:96:68:96:76 | synthetic splat argument | params_flow.rb:96:68:96:76 | synthetic splat argument |
 | params_flow.rb:96:74:96:75 | 50 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:74:96:75 | 50 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:74:96:75 | 50 | params_flow.rb:2:5:2:5 | x |
@@ -4953,8 +4942,6 @@ trackEnd
 | params_flow.rb:96:74:96:75 | 50 | params_flow.rb:74:10:74:10 | w |
 | params_flow.rb:96:74:96:75 | 50 | params_flow.rb:96:68:96:76 | call to taint |
 | params_flow.rb:96:74:96:75 | 50 | params_flow.rb:96:74:96:75 | 50 |
-| params_flow.rb:96:79:96:87 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:96:79:96:87 | * | params_flow.rb:96:79:96:87 | * |
 | params_flow.rb:96:79:96:87 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:96:79:96:87 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:96:79:96:87 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -4962,6 +4949,8 @@ trackEnd
 | params_flow.rb:96:79:96:87 | call to taint | params_flow.rb:69:27:69:27 | r |
 | params_flow.rb:96:79:96:87 | call to taint | params_flow.rb:75:10:75:10 | r |
 | params_flow.rb:96:79:96:87 | call to taint | params_flow.rb:96:79:96:87 | call to taint |
+| params_flow.rb:96:79:96:87 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:96:79:96:87 | synthetic splat argument | params_flow.rb:96:79:96:87 | synthetic splat argument |
 | params_flow.rb:96:85:96:86 | 51 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:85:96:86 | 51 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:85:96:86 | 51 | params_flow.rb:2:5:2:5 | x |
@@ -4984,7 +4973,7 @@ trackEnd
 | params_flow.rb:98:1:103:3 | self in splatmidsmall | params_flow.rb:101:5:101:18 | self |
 | params_flow.rb:98:1:103:3 | self in splatmidsmall | params_flow.rb:102:5:102:10 | self |
 | params_flow.rb:98:1:103:3 | splatmidsmall | params_flow.rb:98:1:103:3 | splatmidsmall |
-| params_flow.rb:98:1:103:3 | synthetic *args | params_flow.rb:98:1:103:3 | synthetic *args |
+| params_flow.rb:98:1:103:3 | synthetic splat parameter | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:98:19:98:19 | a | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:98:19:98:19 | a | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:98:19:98:19 | a | params_flow.rb:6:10:6:10 | x |
@@ -5004,37 +4993,35 @@ trackEnd
 | params_flow.rb:98:31:98:31 | b | params_flow.rb:98:31:98:31 | b |
 | params_flow.rb:98:31:98:31 | b | params_flow.rb:98:31:98:31 | b |
 | params_flow.rb:98:31:98:31 | b | params_flow.rb:102:10:102:10 | b |
-| params_flow.rb:99:5:99:10 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:99:5:99:10 | * | params_flow.rb:99:5:99:10 | * |
 | params_flow.rb:99:5:99:10 | call to sink | params_flow.rb:99:5:99:10 | call to sink |
-| params_flow.rb:100:5:100:18 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:100:5:100:18 | * | params_flow.rb:100:5:100:18 | * |
+| params_flow.rb:99:5:99:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:99:5:99:10 | synthetic splat argument | params_flow.rb:99:5:99:10 | synthetic splat argument |
 | params_flow.rb:100:5:100:18 | call to sink | params_flow.rb:100:5:100:18 | call to sink |
-| params_flow.rb:100:10:100:18 | * | params_flow.rb:100:10:100:18 | * |
+| params_flow.rb:100:5:100:18 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:100:5:100:18 | synthetic splat argument | params_flow.rb:100:5:100:18 | synthetic splat argument |
 | params_flow.rb:100:10:100:18 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:100:10:100:18 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:100:10:100:18 | ...[...] | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:100:10:100:18 | ...[...] | params_flow.rb:100:10:100:18 | ...[...] |
+| params_flow.rb:100:10:100:18 | synthetic splat argument | params_flow.rb:100:10:100:18 | synthetic splat argument |
 | params_flow.rb:100:17:100:17 | 0 | params_flow.rb:100:17:100:17 | 0 |
-| params_flow.rb:101:5:101:18 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:101:5:101:18 | * | params_flow.rb:101:5:101:18 | * |
 | params_flow.rb:101:5:101:18 | call to sink | params_flow.rb:101:5:101:18 | call to sink |
-| params_flow.rb:101:10:101:18 | * | params_flow.rb:101:10:101:18 | * |
+| params_flow.rb:101:5:101:18 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:101:5:101:18 | synthetic splat argument | params_flow.rb:101:5:101:18 | synthetic splat argument |
 | params_flow.rb:101:10:101:18 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:101:10:101:18 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:101:10:101:18 | ...[...] | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:101:10:101:18 | ...[...] | params_flow.rb:101:10:101:18 | ...[...] |
+| params_flow.rb:101:10:101:18 | synthetic splat argument | params_flow.rb:101:10:101:18 | synthetic splat argument |
 | params_flow.rb:101:17:101:17 | 1 | params_flow.rb:101:17:101:17 | 1 |
-| params_flow.rb:102:5:102:10 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:102:5:102:10 | * | params_flow.rb:102:5:102:10 | * |
 | params_flow.rb:102:5:102:10 | call to sink | params_flow.rb:102:5:102:10 | call to sink |
 | params_flow.rb:102:5:102:10 | call to sink | params_flow.rb:105:1:105:49 | call to splatmidsmall |
 | params_flow.rb:102:5:102:10 | call to sink | params_flow.rb:106:1:106:46 | call to splatmidsmall |
-| params_flow.rb:105:1:105:49 | * | params_flow.rb:98:1:103:3 | synthetic *args |
-| params_flow.rb:105:1:105:49 | * | params_flow.rb:105:1:105:49 | * |
+| params_flow.rb:102:5:102:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:102:5:102:10 | synthetic splat argument | params_flow.rb:102:5:102:10 | synthetic splat argument |
 | params_flow.rb:105:1:105:49 | call to splatmidsmall | params_flow.rb:105:1:105:49 | call to splatmidsmall |
-| params_flow.rb:105:15:105:23 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:105:15:105:23 | * | params_flow.rb:105:15:105:23 | * |
+| params_flow.rb:105:1:105:49 | synthetic splat argument | params_flow.rb:98:1:103:3 | synthetic splat parameter |
+| params_flow.rb:105:1:105:49 | synthetic splat argument | params_flow.rb:105:1:105:49 | synthetic splat argument |
 | params_flow.rb:105:15:105:23 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:105:15:105:23 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:105:15:105:23 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -5042,6 +5029,8 @@ trackEnd
 | params_flow.rb:105:15:105:23 | call to taint | params_flow.rb:98:19:98:19 | a |
 | params_flow.rb:105:15:105:23 | call to taint | params_flow.rb:99:10:99:10 | a |
 | params_flow.rb:105:15:105:23 | call to taint | params_flow.rb:105:15:105:23 | call to taint |
+| params_flow.rb:105:15:105:23 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:105:15:105:23 | synthetic splat argument | params_flow.rb:105:15:105:23 | synthetic splat argument |
 | params_flow.rb:105:21:105:22 | 52 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:105:21:105:22 | 52 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:105:21:105:22 | 52 | params_flow.rb:2:5:2:5 | x |
@@ -5054,42 +5043,29 @@ trackEnd
 | params_flow.rb:105:21:105:22 | 52 | params_flow.rb:105:15:105:23 | call to taint |
 | params_flow.rb:105:21:105:22 | 52 | params_flow.rb:105:21:105:22 | 52 |
 | params_flow.rb:105:26:105:48 | * ... | params_flow.rb:105:26:105:48 | * ... |
-| params_flow.rb:105:27:105:48 | * | params_flow.rb:105:27:105:48 | * |
 | params_flow.rb:105:27:105:48 | Array | params_flow.rb:105:27:105:48 | Array |
 | params_flow.rb:105:27:105:48 | call to [] | params_flow.rb:105:27:105:48 | call to [] |
-| params_flow.rb:105:28:105:36 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:105:28:105:36 | * | params_flow.rb:105:28:105:36 | * |
+| params_flow.rb:105:27:105:48 | synthetic splat argument | params_flow.rb:105:27:105:48 | call to [] |
+| params_flow.rb:105:27:105:48 | synthetic splat argument | params_flow.rb:105:27:105:48 | synthetic splat argument |
 | params_flow.rb:105:28:105:36 | call to taint | params_flow.rb:105:28:105:36 | call to taint |
+| params_flow.rb:105:28:105:36 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:105:28:105:36 | synthetic splat argument | params_flow.rb:105:28:105:36 | synthetic splat argument |
 | params_flow.rb:105:34:105:35 | 53 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:105:34:105:35 | 53 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:105:34:105:35 | 53 | params_flow.rb:2:5:2:5 | x |
 | params_flow.rb:105:34:105:35 | 53 | params_flow.rb:105:28:105:36 | call to taint |
 | params_flow.rb:105:34:105:35 | 53 | params_flow.rb:105:34:105:35 | 53 |
-| params_flow.rb:105:39:105:47 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:105:39:105:47 | * | params_flow.rb:105:39:105:47 | * |
-| params_flow.rb:105:39:105:47 | call to taint | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:105:39:105:47 | call to taint | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:105:39:105:47 | call to taint | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:105:39:105:47 | call to taint | params_flow.rb:98:31:98:31 | b |
-| params_flow.rb:105:39:105:47 | call to taint | params_flow.rb:98:31:98:31 | b |
-| params_flow.rb:105:39:105:47 | call to taint | params_flow.rb:102:10:102:10 | b |
 | params_flow.rb:105:39:105:47 | call to taint | params_flow.rb:105:39:105:47 | call to taint |
+| params_flow.rb:105:39:105:47 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:105:39:105:47 | synthetic splat argument | params_flow.rb:105:39:105:47 | synthetic splat argument |
 | params_flow.rb:105:45:105:46 | 54 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:105:45:105:46 | 54 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:105:45:105:46 | 54 | params_flow.rb:2:5:2:5 | x |
-| params_flow.rb:105:45:105:46 | 54 | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:105:45:105:46 | 54 | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:105:45:105:46 | 54 | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:105:45:105:46 | 54 | params_flow.rb:98:31:98:31 | b |
-| params_flow.rb:105:45:105:46 | 54 | params_flow.rb:98:31:98:31 | b |
-| params_flow.rb:105:45:105:46 | 54 | params_flow.rb:102:10:102:10 | b |
 | params_flow.rb:105:45:105:46 | 54 | params_flow.rb:105:39:105:47 | call to taint |
 | params_flow.rb:105:45:105:46 | 54 | params_flow.rb:105:45:105:46 | 54 |
-| params_flow.rb:106:1:106:46 | * | params_flow.rb:98:1:103:3 | synthetic *args |
-| params_flow.rb:106:1:106:46 | * | params_flow.rb:106:1:106:46 | * |
 | params_flow.rb:106:1:106:46 | call to splatmidsmall | params_flow.rb:106:1:106:46 | call to splatmidsmall |
-| params_flow.rb:106:15:106:23 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:106:15:106:23 | * | params_flow.rb:106:15:106:23 | * |
+| params_flow.rb:106:1:106:46 | synthetic splat argument | params_flow.rb:98:1:103:3 | synthetic splat parameter |
+| params_flow.rb:106:1:106:46 | synthetic splat argument | params_flow.rb:106:1:106:46 | synthetic splat argument |
 | params_flow.rb:106:15:106:23 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:106:15:106:23 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:106:15:106:23 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -5097,6 +5073,8 @@ trackEnd
 | params_flow.rb:106:15:106:23 | call to taint | params_flow.rb:98:19:98:19 | a |
 | params_flow.rb:106:15:106:23 | call to taint | params_flow.rb:99:10:99:10 | a |
 | params_flow.rb:106:15:106:23 | call to taint | params_flow.rb:106:15:106:23 | call to taint |
+| params_flow.rb:106:15:106:23 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:106:15:106:23 | synthetic splat argument | params_flow.rb:106:15:106:23 | synthetic splat argument |
 | params_flow.rb:106:21:106:22 | 55 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:106:21:106:22 | 55 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:106:21:106:22 | 55 | params_flow.rb:2:5:2:5 | x |
@@ -5108,16 +5086,14 @@ trackEnd
 | params_flow.rb:106:21:106:22 | 55 | params_flow.rb:99:10:99:10 | a |
 | params_flow.rb:106:21:106:22 | 55 | params_flow.rb:106:15:106:23 | call to taint |
 | params_flow.rb:106:21:106:22 | 55 | params_flow.rb:106:21:106:22 | 55 |
-| params_flow.rb:106:26:106:34 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:106:26:106:34 | * | params_flow.rb:106:26:106:34 | * |
 | params_flow.rb:106:26:106:34 | call to taint | params_flow.rb:106:26:106:34 | call to taint |
+| params_flow.rb:106:26:106:34 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:106:26:106:34 | synthetic splat argument | params_flow.rb:106:26:106:34 | synthetic splat argument |
 | params_flow.rb:106:32:106:33 | 56 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:106:32:106:33 | 56 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:106:32:106:33 | 56 | params_flow.rb:2:5:2:5 | x |
 | params_flow.rb:106:32:106:33 | 56 | params_flow.rb:106:26:106:34 | call to taint |
 | params_flow.rb:106:32:106:33 | 56 | params_flow.rb:106:32:106:33 | 56 |
-| params_flow.rb:106:37:106:45 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:106:37:106:45 | * | params_flow.rb:106:37:106:45 | * |
 | params_flow.rb:106:37:106:45 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:106:37:106:45 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:106:37:106:45 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -5125,6 +5101,8 @@ trackEnd
 | params_flow.rb:106:37:106:45 | call to taint | params_flow.rb:98:31:98:31 | b |
 | params_flow.rb:106:37:106:45 | call to taint | params_flow.rb:102:10:102:10 | b |
 | params_flow.rb:106:37:106:45 | call to taint | params_flow.rb:106:37:106:45 | call to taint |
+| params_flow.rb:106:37:106:45 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:106:37:106:45 | synthetic splat argument | params_flow.rb:106:37:106:45 | synthetic splat argument |
 | params_flow.rb:106:43:106:44 | 57 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:106:43:106:44 | 57 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:106:43:106:44 | 57 | params_flow.rb:2:5:2:5 | x |
@@ -5137,7 +5115,6 @@ trackEnd
 | params_flow.rb:106:43:106:44 | 57 | params_flow.rb:106:37:106:45 | call to taint |
 | params_flow.rb:106:43:106:44 | 57 | params_flow.rb:106:43:106:44 | 57 |
 | params_flow.rb:108:1:112:3 | &block | params_flow.rb:108:1:112:3 | &block |
-| params_flow.rb:108:1:112:3 | **kwargs | params_flow.rb:108:1:112:3 | **kwargs |
 | params_flow.rb:108:1:112:3 | self in splat_followed_by_keyword_param | params_flow.rb:5:1:7:3 | self (sink) |
 | params_flow.rb:108:1:112:3 | self in splat_followed_by_keyword_param | params_flow.rb:5:1:7:3 | self in sink |
 | params_flow.rb:108:1:112:3 | self in splat_followed_by_keyword_param | params_flow.rb:6:5:6:10 | self |
@@ -5147,7 +5124,8 @@ trackEnd
 | params_flow.rb:108:1:112:3 | self in splat_followed_by_keyword_param | params_flow.rb:110:5:110:13 | self |
 | params_flow.rb:108:1:112:3 | self in splat_followed_by_keyword_param | params_flow.rb:111:5:111:10 | self |
 | params_flow.rb:108:1:112:3 | splat_followed_by_keyword_param | params_flow.rb:108:1:112:3 | splat_followed_by_keyword_param |
-| params_flow.rb:108:1:112:3 | synthetic *args | params_flow.rb:108:1:112:3 | synthetic *args |
+| params_flow.rb:108:1:112:3 | synthetic hash-splat parameter | params_flow.rb:108:1:112:3 | synthetic hash-splat parameter |
+| params_flow.rb:108:1:112:3 | synthetic splat parameter | params_flow.rb:108:1:112:3 | synthetic splat parameter |
 | params_flow.rb:108:37:108:37 | a | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:108:37:108:37 | a | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:108:37:108:37 | a | params_flow.rb:6:10:6:10 | x |
@@ -5166,37 +5144,36 @@ trackEnd
 | params_flow.rb:108:44:108:44 | c | params_flow.rb:108:44:108:44 | c |
 | params_flow.rb:108:44:108:44 | c | params_flow.rb:108:44:108:44 | c |
 | params_flow.rb:108:44:108:44 | c | params_flow.rb:111:10:111:10 | c |
-| params_flow.rb:109:5:109:10 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:109:5:109:10 | * | params_flow.rb:109:5:109:10 | * |
 | params_flow.rb:109:5:109:10 | call to sink | params_flow.rb:109:5:109:10 | call to sink |
-| params_flow.rb:110:5:110:13 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:110:5:110:13 | * | params_flow.rb:110:5:110:13 | * |
+| params_flow.rb:109:5:109:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:109:5:109:10 | synthetic splat argument | params_flow.rb:109:5:109:10 | synthetic splat argument |
 | params_flow.rb:110:5:110:13 | call to sink | params_flow.rb:110:5:110:13 | call to sink |
-| params_flow.rb:110:10:110:13 | * | params_flow.rb:110:10:110:13 | * |
+| params_flow.rb:110:5:110:13 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:110:5:110:13 | synthetic splat argument | params_flow.rb:110:5:110:13 | synthetic splat argument |
 | params_flow.rb:110:10:110:13 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:110:10:110:13 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:110:10:110:13 | ...[...] | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:110:10:110:13 | ...[...] | params_flow.rb:110:10:110:13 | ...[...] |
+| params_flow.rb:110:10:110:13 | synthetic splat argument | params_flow.rb:110:10:110:13 | synthetic splat argument |
 | params_flow.rb:110:12:110:12 | 0 | params_flow.rb:110:12:110:12 | 0 |
-| params_flow.rb:111:5:111:10 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:111:5:111:10 | * | params_flow.rb:111:5:111:10 | * |
 | params_flow.rb:111:5:111:10 | call to sink | params_flow.rb:111:5:111:10 | call to sink |
 | params_flow.rb:111:5:111:10 | call to sink | params_flow.rb:114:1:114:67 | call to splat_followed_by_keyword_param |
-| params_flow.rb:114:1:114:67 | * | params_flow.rb:108:1:112:3 | synthetic *args |
-| params_flow.rb:114:1:114:67 | * | params_flow.rb:114:1:114:67 | * |
-| params_flow.rb:114:1:114:67 | ** | params_flow.rb:108:1:112:3 | **kwargs |
-| params_flow.rb:114:1:114:67 | ** | params_flow.rb:114:1:114:67 | ** |
+| params_flow.rb:111:5:111:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:111:5:111:10 | synthetic splat argument | params_flow.rb:111:5:111:10 | synthetic splat argument |
 | params_flow.rb:114:1:114:67 | call to splat_followed_by_keyword_param | params_flow.rb:114:1:114:67 | call to splat_followed_by_keyword_param |
-| params_flow.rb:114:33:114:41 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:114:33:114:41 | * | params_flow.rb:114:33:114:41 | * |
+| params_flow.rb:114:1:114:67 | synthetic hash-splat argument | params_flow.rb:108:1:112:3 | synthetic hash-splat parameter |
+| params_flow.rb:114:1:114:67 | synthetic hash-splat argument | params_flow.rb:114:1:114:67 | synthetic hash-splat argument |
+| params_flow.rb:114:1:114:67 | synthetic splat argument | params_flow.rb:108:1:112:3 | synthetic splat parameter |
+| params_flow.rb:114:1:114:67 | synthetic splat argument | params_flow.rb:114:1:114:67 | synthetic splat argument |
 | params_flow.rb:114:33:114:41 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:114:33:114:41 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:114:33:114:41 | call to taint | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:114:33:114:41 | call to taint | params_flow.rb:108:37:108:37 | a |
 | params_flow.rb:114:33:114:41 | call to taint | params_flow.rb:108:37:108:37 | a |
 | params_flow.rb:114:33:114:41 | call to taint | params_flow.rb:109:10:109:10 | a |
-| params_flow.rb:114:33:114:41 | call to taint | params_flow.rb:110:10:110:13 | ...[...] |
 | params_flow.rb:114:33:114:41 | call to taint | params_flow.rb:114:33:114:41 | call to taint |
+| params_flow.rb:114:33:114:41 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:114:33:114:41 | synthetic splat argument | params_flow.rb:114:33:114:41 | synthetic splat argument |
 | params_flow.rb:114:39:114:40 | 58 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:114:39:114:40 | 58 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:114:39:114:40 | 58 | params_flow.rb:2:5:2:5 | x |
@@ -5206,21 +5183,26 @@ trackEnd
 | params_flow.rb:114:39:114:40 | 58 | params_flow.rb:108:37:108:37 | a |
 | params_flow.rb:114:39:114:40 | 58 | params_flow.rb:108:37:108:37 | a |
 | params_flow.rb:114:39:114:40 | 58 | params_flow.rb:109:10:109:10 | a |
-| params_flow.rb:114:39:114:40 | 58 | params_flow.rb:110:10:110:13 | ...[...] |
 | params_flow.rb:114:39:114:40 | 58 | params_flow.rb:114:33:114:41 | call to taint |
 | params_flow.rb:114:39:114:40 | 58 | params_flow.rb:114:39:114:40 | 58 |
-| params_flow.rb:114:44:114:52 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:114:44:114:52 | * | params_flow.rb:114:44:114:52 | * |
+| params_flow.rb:114:44:114:52 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:114:44:114:52 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:114:44:114:52 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:114:44:114:52 | call to taint | params_flow.rb:110:10:110:13 | ...[...] |
 | params_flow.rb:114:44:114:52 | call to taint | params_flow.rb:114:44:114:52 | call to taint |
+| params_flow.rb:114:44:114:52 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:114:44:114:52 | synthetic splat argument | params_flow.rb:114:44:114:52 | synthetic splat argument |
 | params_flow.rb:114:50:114:51 | 59 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:114:50:114:51 | 59 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:114:50:114:51 | 59 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:114:50:114:51 | 59 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:114:50:114:51 | 59 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:114:50:114:51 | 59 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:114:50:114:51 | 59 | params_flow.rb:110:10:110:13 | ...[...] |
 | params_flow.rb:114:50:114:51 | 59 | params_flow.rb:114:44:114:52 | call to taint |
 | params_flow.rb:114:50:114:51 | 59 | params_flow.rb:114:50:114:51 | 59 |
 | params_flow.rb:114:55:114:55 | :c | params_flow.rb:114:55:114:55 | :c |
 | params_flow.rb:114:55:114:66 | Pair | params_flow.rb:114:55:114:66 | Pair |
-| params_flow.rb:114:58:114:66 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:114:58:114:66 | * | params_flow.rb:114:58:114:66 | * |
 | params_flow.rb:114:58:114:66 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:114:58:114:66 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:114:58:114:66 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -5228,6 +5210,8 @@ trackEnd
 | params_flow.rb:114:58:114:66 | call to taint | params_flow.rb:108:44:108:44 | c |
 | params_flow.rb:114:58:114:66 | call to taint | params_flow.rb:111:10:111:10 | c |
 | params_flow.rb:114:58:114:66 | call to taint | params_flow.rb:114:58:114:66 | call to taint |
+| params_flow.rb:114:58:114:66 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:114:58:114:66 | synthetic splat argument | params_flow.rb:114:58:114:66 | synthetic splat argument |
 | params_flow.rb:114:64:114:65 | 60 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:114:64:114:65 | 60 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:114:64:114:65 | 60 | params_flow.rb:2:5:2:5 | x |
@@ -5260,11 +5244,9 @@ trackEnd
 | params_flow.rb:117:1:117:1 | [post] x | params_flow.rb:10:10:10:11 | p1 |
 | params_flow.rb:117:1:117:1 | [post] x | params_flow.rb:117:1:117:1 | [post] x |
 | params_flow.rb:117:1:117:1 | [post] x | params_flow.rb:118:13:118:13 | x |
-| params_flow.rb:117:1:117:15 | * | params_flow.rb:117:1:117:15 | * |
 | params_flow.rb:117:1:117:15 | call to []= | params_flow.rb:117:1:117:15 | call to []= |
+| params_flow.rb:117:1:117:15 | synthetic splat argument | params_flow.rb:117:1:117:15 | synthetic splat argument |
 | params_flow.rb:117:3:117:14 | call to some_index | params_flow.rb:117:3:117:14 | call to some_index |
-| params_flow.rb:117:19:117:27 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:117:19:117:27 | * | params_flow.rb:117:19:117:27 | * |
 | params_flow.rb:117:19:117:27 | __synth__0 | params_flow.rb:117:19:117:27 | __synth__0 |
 | params_flow.rb:117:19:117:27 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:117:19:117:27 | call to taint | params_flow.rb:5:10:5:10 | x |
@@ -5280,6 +5262,8 @@ trackEnd
 | params_flow.rb:117:19:117:27 | call to taint | params_flow.rb:117:19:117:27 | ... = ... |
 | params_flow.rb:117:19:117:27 | call to taint | params_flow.rb:117:19:117:27 | __synth__0 |
 | params_flow.rb:117:19:117:27 | call to taint | params_flow.rb:117:19:117:27 | call to taint |
+| params_flow.rb:117:19:117:27 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:117:19:117:27 | synthetic splat argument | params_flow.rb:117:19:117:27 | synthetic splat argument |
 | params_flow.rb:117:25:117:26 | 61 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:117:25:117:26 | 61 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:117:25:117:26 | 61 | params_flow.rb:2:5:2:5 | x |
@@ -5299,7 +5283,7 @@ trackEnd
 | params_flow.rb:117:25:117:26 | 61 | params_flow.rb:117:19:117:27 | call to taint |
 | params_flow.rb:117:25:117:26 | 61 | params_flow.rb:117:25:117:26 | 61 |
 | params_flow.rb:118:1:118:14 | call to positional | params_flow.rb:118:1:118:14 | call to positional |
-| params_flow.rb:118:12:118:13 | * ... | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:118:12:118:13 | * ... | params_flow.rb:9:1:12:3 | synthetic splat parameter |
 | params_flow.rb:118:12:118:13 | * ... | params_flow.rb:118:12:118:13 | * ... |
 | params_flow.rb:120:1:126:3 | &block | params_flow.rb:120:1:126:3 | &block |
 | params_flow.rb:120:1:126:3 | destruct | params_flow.rb:120:1:126:3 | destruct |
@@ -5318,88 +5302,90 @@ trackEnd
 | params_flow.rb:120:22:120:22 | c | params_flow.rb:120:22:120:22 | c |
 | params_flow.rb:120:25:120:25 | d | params_flow.rb:120:25:120:25 | d |
 | params_flow.rb:120:27:120:27 | e | params_flow.rb:120:27:120:27 | e |
-| params_flow.rb:121:5:121:10 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:121:5:121:10 | * | params_flow.rb:121:5:121:10 | * |
 | params_flow.rb:121:5:121:10 | call to sink | params_flow.rb:121:5:121:10 | call to sink |
+| params_flow.rb:121:5:121:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:121:5:121:10 | synthetic splat argument | params_flow.rb:121:5:121:10 | synthetic splat argument |
 | params_flow.rb:121:10:121:10 | a | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:121:10:121:10 | a | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:121:10:121:10 | a | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:121:10:121:10 | a | params_flow.rb:121:10:121:10 | a |
-| params_flow.rb:122:5:122:10 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:122:5:122:10 | * | params_flow.rb:122:5:122:10 | * |
 | params_flow.rb:122:5:122:10 | call to sink | params_flow.rb:122:5:122:10 | call to sink |
+| params_flow.rb:122:5:122:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:122:5:122:10 | synthetic splat argument | params_flow.rb:122:5:122:10 | synthetic splat argument |
 | params_flow.rb:122:10:122:10 | b | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:122:10:122:10 | b | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:122:10:122:10 | b | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:122:10:122:10 | b | params_flow.rb:122:10:122:10 | b |
-| params_flow.rb:123:5:123:10 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:123:5:123:10 | * | params_flow.rb:123:5:123:10 | * |
 | params_flow.rb:123:5:123:10 | call to sink | params_flow.rb:123:5:123:10 | call to sink |
+| params_flow.rb:123:5:123:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:123:5:123:10 | synthetic splat argument | params_flow.rb:123:5:123:10 | synthetic splat argument |
 | params_flow.rb:123:10:123:10 | c | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:123:10:123:10 | c | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:123:10:123:10 | c | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:123:10:123:10 | c | params_flow.rb:123:10:123:10 | c |
-| params_flow.rb:124:5:124:10 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:124:5:124:10 | * | params_flow.rb:124:5:124:10 | * |
 | params_flow.rb:124:5:124:10 | call to sink | params_flow.rb:124:5:124:10 | call to sink |
+| params_flow.rb:124:5:124:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:124:5:124:10 | synthetic splat argument | params_flow.rb:124:5:124:10 | synthetic splat argument |
 | params_flow.rb:124:10:124:10 | d | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:124:10:124:10 | d | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:124:10:124:10 | d | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:124:10:124:10 | d | params_flow.rb:124:10:124:10 | d |
-| params_flow.rb:125:5:125:10 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:125:5:125:10 | * | params_flow.rb:125:5:125:10 | * |
 | params_flow.rb:125:5:125:10 | call to sink | params_flow.rb:125:5:125:10 | call to sink |
 | params_flow.rb:125:5:125:10 | call to sink | params_flow.rb:128:1:128:61 | call to destruct |
+| params_flow.rb:125:5:125:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:125:5:125:10 | synthetic splat argument | params_flow.rb:125:5:125:10 | synthetic splat argument |
 | params_flow.rb:125:10:125:10 | e | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:125:10:125:10 | e | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:125:10:125:10 | e | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:125:10:125:10 | e | params_flow.rb:125:10:125:10 | e |
-| params_flow.rb:128:1:128:61 | * | params_flow.rb:128:1:128:61 | * |
 | params_flow.rb:128:1:128:61 | call to destruct | params_flow.rb:128:1:128:61 | call to destruct |
-| params_flow.rb:128:10:128:31 | * | params_flow.rb:128:10:128:31 | * |
+| params_flow.rb:128:1:128:61 | synthetic splat argument | params_flow.rb:128:1:128:61 | synthetic splat argument |
 | params_flow.rb:128:10:128:31 | Array | params_flow.rb:128:10:128:31 | Array |
 | params_flow.rb:128:10:128:31 | call to [] | params_flow.rb:128:10:128:31 | call to [] |
-| params_flow.rb:128:11:128:19 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:128:11:128:19 | * | params_flow.rb:128:11:128:19 | * |
+| params_flow.rb:128:10:128:31 | synthetic splat argument | params_flow.rb:128:10:128:31 | call to [] |
+| params_flow.rb:128:10:128:31 | synthetic splat argument | params_flow.rb:128:10:128:31 | synthetic splat argument |
 | params_flow.rb:128:11:128:19 | call to taint | params_flow.rb:128:11:128:19 | call to taint |
+| params_flow.rb:128:11:128:19 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:128:11:128:19 | synthetic splat argument | params_flow.rb:128:11:128:19 | synthetic splat argument |
 | params_flow.rb:128:17:128:18 | 62 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:128:17:128:18 | 62 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:128:17:128:18 | 62 | params_flow.rb:2:5:2:5 | x |
 | params_flow.rb:128:17:128:18 | 62 | params_flow.rb:128:11:128:19 | call to taint |
 | params_flow.rb:128:17:128:18 | 62 | params_flow.rb:128:17:128:18 | 62 |
-| params_flow.rb:128:22:128:30 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:128:22:128:30 | * | params_flow.rb:128:22:128:30 | * |
 | params_flow.rb:128:22:128:30 | call to taint | params_flow.rb:128:22:128:30 | call to taint |
+| params_flow.rb:128:22:128:30 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:128:22:128:30 | synthetic splat argument | params_flow.rb:128:22:128:30 | synthetic splat argument |
 | params_flow.rb:128:28:128:29 | 63 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:128:28:128:29 | 63 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:128:28:128:29 | 63 | params_flow.rb:2:5:2:5 | x |
 | params_flow.rb:128:28:128:29 | 63 | params_flow.rb:128:22:128:30 | call to taint |
 | params_flow.rb:128:28:128:29 | 63 | params_flow.rb:128:28:128:29 | 63 |
-| params_flow.rb:128:34:128:60 | * | params_flow.rb:128:34:128:60 | * |
 | params_flow.rb:128:34:128:60 | Array | params_flow.rb:128:34:128:60 | Array |
 | params_flow.rb:128:34:128:60 | call to [] | params_flow.rb:128:34:128:60 | call to [] |
-| params_flow.rb:128:35:128:43 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:128:35:128:43 | * | params_flow.rb:128:35:128:43 | * |
+| params_flow.rb:128:34:128:60 | synthetic splat argument | params_flow.rb:128:34:128:60 | call to [] |
+| params_flow.rb:128:34:128:60 | synthetic splat argument | params_flow.rb:128:34:128:60 | synthetic splat argument |
 | params_flow.rb:128:35:128:43 | call to taint | params_flow.rb:128:35:128:43 | call to taint |
+| params_flow.rb:128:35:128:43 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:128:35:128:43 | synthetic splat argument | params_flow.rb:128:35:128:43 | synthetic splat argument |
 | params_flow.rb:128:41:128:42 | 64 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:128:41:128:42 | 64 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:128:41:128:42 | 64 | params_flow.rb:2:5:2:5 | x |
 | params_flow.rb:128:41:128:42 | 64 | params_flow.rb:128:35:128:43 | call to taint |
 | params_flow.rb:128:41:128:42 | 64 | params_flow.rb:128:41:128:42 | 64 |
-| params_flow.rb:128:46:128:59 | * | params_flow.rb:128:46:128:59 | * |
 | params_flow.rb:128:46:128:59 | Array | params_flow.rb:128:46:128:59 | Array |
 | params_flow.rb:128:46:128:59 | call to [] | params_flow.rb:128:46:128:59 | call to [] |
+| params_flow.rb:128:46:128:59 | synthetic splat argument | params_flow.rb:128:46:128:59 | call to [] |
+| params_flow.rb:128:46:128:59 | synthetic splat argument | params_flow.rb:128:46:128:59 | synthetic splat argument |
 | params_flow.rb:128:47:128:47 | 0 | params_flow.rb:128:47:128:47 | 0 |
-| params_flow.rb:128:50:128:58 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:128:50:128:58 | * | params_flow.rb:128:50:128:58 | * |
 | params_flow.rb:128:50:128:58 | call to taint | params_flow.rb:128:50:128:58 | call to taint |
+| params_flow.rb:128:50:128:58 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:128:50:128:58 | synthetic splat argument | params_flow.rb:128:50:128:58 | synthetic splat argument |
 | params_flow.rb:128:56:128:57 | 65 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:128:56:128:57 | 65 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:128:56:128:57 | 65 | params_flow.rb:2:5:2:5 | x |
 | params_flow.rb:128:56:128:57 | 65 | params_flow.rb:128:50:128:58 | call to taint |
 | params_flow.rb:128:56:128:57 | 65 | params_flow.rb:128:56:128:57 | 65 |
 | params_flow.rb:130:1:130:4 | args | params_flow.rb:130:1:130:4 | args |
-| params_flow.rb:130:8:130:29 | * | params_flow.rb:130:8:130:29 | * |
 | params_flow.rb:130:8:130:29 | Array | params_flow.rb:130:8:130:29 | Array |
 | params_flow.rb:130:8:130:29 | call to [] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:130:8:130:29 | call to [] | params_flow.rb:5:10:5:10 | x |
@@ -5411,8 +5397,17 @@ trackEnd
 | params_flow.rb:130:8:130:29 | call to [] | params_flow.rb:130:1:130:29 | ... = ... |
 | params_flow.rb:130:8:130:29 | call to [] | params_flow.rb:130:8:130:29 | call to [] |
 | params_flow.rb:130:8:130:29 | call to [] | params_flow.rb:131:11:131:14 | args |
-| params_flow.rb:130:9:130:17 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:130:9:130:17 | * | params_flow.rb:130:9:130:17 | * |
+| params_flow.rb:130:8:130:29 | synthetic splat argument | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:130:8:130:29 | synthetic splat argument | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:130:8:130:29 | synthetic splat argument | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:130:8:130:29 | synthetic splat argument | params_flow.rb:83:14:83:14 | t |
+| params_flow.rb:130:8:130:29 | synthetic splat argument | params_flow.rb:83:14:83:14 | t |
+| params_flow.rb:130:8:130:29 | synthetic splat argument | params_flow.rb:84:10:84:10 | t |
+| params_flow.rb:130:8:130:29 | synthetic splat argument | params_flow.rb:130:1:130:4 | args |
+| params_flow.rb:130:8:130:29 | synthetic splat argument | params_flow.rb:130:1:130:29 | ... = ... |
+| params_flow.rb:130:8:130:29 | synthetic splat argument | params_flow.rb:130:8:130:29 | call to [] |
+| params_flow.rb:130:8:130:29 | synthetic splat argument | params_flow.rb:130:8:130:29 | synthetic splat argument |
+| params_flow.rb:130:8:130:29 | synthetic splat argument | params_flow.rb:131:11:131:14 | args |
 | params_flow.rb:130:9:130:17 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:130:9:130:17 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:130:9:130:17 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -5420,6 +5415,8 @@ trackEnd
 | params_flow.rb:130:9:130:17 | call to taint | params_flow.rb:83:14:83:14 | t |
 | params_flow.rb:130:9:130:17 | call to taint | params_flow.rb:84:10:84:10 | t |
 | params_flow.rb:130:9:130:17 | call to taint | params_flow.rb:130:9:130:17 | call to taint |
+| params_flow.rb:130:9:130:17 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:130:9:130:17 | synthetic splat argument | params_flow.rb:130:9:130:17 | synthetic splat argument |
 | params_flow.rb:130:15:130:16 | 66 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:130:15:130:16 | 66 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:130:15:130:16 | 66 | params_flow.rb:2:5:2:5 | x |
@@ -5431,8 +5428,6 @@ trackEnd
 | params_flow.rb:130:15:130:16 | 66 | params_flow.rb:84:10:84:10 | t |
 | params_flow.rb:130:15:130:16 | 66 | params_flow.rb:130:9:130:17 | call to taint |
 | params_flow.rb:130:15:130:16 | 66 | params_flow.rb:130:15:130:16 | 66 |
-| params_flow.rb:130:20:130:28 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:130:20:130:28 | * | params_flow.rb:130:20:130:28 | * |
 | params_flow.rb:130:20:130:28 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:130:20:130:28 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:130:20:130:28 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -5440,6 +5435,8 @@ trackEnd
 | params_flow.rb:130:20:130:28 | call to taint | params_flow.rb:83:17:83:17 | u |
 | params_flow.rb:130:20:130:28 | call to taint | params_flow.rb:85:10:85:10 | u |
 | params_flow.rb:130:20:130:28 | call to taint | params_flow.rb:130:20:130:28 | call to taint |
+| params_flow.rb:130:20:130:28 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:130:20:130:28 | synthetic splat argument | params_flow.rb:130:20:130:28 | synthetic splat argument |
 | params_flow.rb:130:26:130:27 | 67 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:130:26:130:27 | 67 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:130:26:130:27 | 67 | params_flow.rb:2:5:2:5 | x |
@@ -5451,13 +5448,9 @@ trackEnd
 | params_flow.rb:130:26:130:27 | 67 | params_flow.rb:85:10:85:10 | u |
 | params_flow.rb:130:26:130:27 | 67 | params_flow.rb:130:20:130:28 | call to taint |
 | params_flow.rb:130:26:130:27 | 67 | params_flow.rb:130:26:130:27 | 67 |
-| params_flow.rb:131:1:131:46 | * | params_flow.rb:83:1:91:3 | synthetic *args |
-| params_flow.rb:131:1:131:46 | * | params_flow.rb:131:1:131:46 | * |
 | params_flow.rb:131:1:131:46 | call to pos_many | params_flow.rb:131:1:131:46 | call to pos_many |
-| params_flow.rb:131:10:131:14 | * ... | params_flow.rb:83:1:91:3 | synthetic *args |
+| params_flow.rb:131:10:131:14 | * ... | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:131:10:131:14 | * ... | params_flow.rb:131:10:131:14 | * ... |
-| params_flow.rb:131:17:131:25 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:131:17:131:25 | * | params_flow.rb:131:17:131:25 | * |
 | params_flow.rb:131:17:131:25 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:131:17:131:25 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:131:17:131:25 | call to taint | params_flow.rb:6:10:6:10 | x |
@@ -5465,6 +5458,8 @@ trackEnd
 | params_flow.rb:131:17:131:25 | call to taint | params_flow.rb:83:17:83:17 | u |
 | params_flow.rb:131:17:131:25 | call to taint | params_flow.rb:85:10:85:10 | u |
 | params_flow.rb:131:17:131:25 | call to taint | params_flow.rb:131:17:131:25 | call to taint |
+| params_flow.rb:131:17:131:25 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:131:17:131:25 | synthetic splat argument | params_flow.rb:131:17:131:25 | synthetic splat argument |
 | params_flow.rb:131:23:131:24 | 68 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:131:23:131:24 | 68 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:131:23:131:24 | 68 | params_flow.rb:2:5:2:5 | x |
@@ -5516,39 +5511,40 @@ trackEnd
 | params_flow.rb:133:14:133:18 | *args | params_flow.rb:133:15:133:18 | args |
 | params_flow.rb:133:14:133:18 | *args | params_flow.rb:134:10:134:13 | args |
 | params_flow.rb:133:15:133:18 | args | params_flow.rb:133:15:133:18 | args |
-| params_flow.rb:134:5:134:16 | * | params_flow.rb:5:1:7:3 | synthetic *args |
-| params_flow.rb:134:5:134:16 | * | params_flow.rb:134:5:134:16 | * |
 | params_flow.rb:134:5:134:16 | call to sink | params_flow.rb:134:5:134:16 | call to sink |
 | params_flow.rb:134:5:134:16 | call to sink | params_flow.rb:137:1:137:44 | call to splatall |
-| params_flow.rb:134:10:134:16 | * | params_flow.rb:134:10:134:16 | * |
+| params_flow.rb:134:5:134:16 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
+| params_flow.rb:134:5:134:16 | synthetic splat argument | params_flow.rb:134:5:134:16 | synthetic splat argument |
 | params_flow.rb:134:10:134:16 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:134:10:134:16 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:134:10:134:16 | ...[...] | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:134:10:134:16 | ...[...] | params_flow.rb:134:10:134:16 | ...[...] |
+| params_flow.rb:134:10:134:16 | synthetic splat argument | params_flow.rb:134:10:134:16 | synthetic splat argument |
 | params_flow.rb:134:15:134:15 | 1 | params_flow.rb:134:15:134:15 | 1 |
 | params_flow.rb:137:1:137:44 | call to splatall | params_flow.rb:137:1:137:44 | call to splatall |
 | params_flow.rb:137:10:137:43 | * ... | params_flow.rb:133:14:133:18 | *args |
 | params_flow.rb:137:10:137:43 | * ... | params_flow.rb:133:15:133:18 | args |
 | params_flow.rb:137:10:137:43 | * ... | params_flow.rb:134:10:134:13 | args |
 | params_flow.rb:137:10:137:43 | * ... | params_flow.rb:137:10:137:43 | * ... |
-| params_flow.rb:137:11:137:43 | * | params_flow.rb:137:11:137:43 | * |
 | params_flow.rb:137:11:137:43 | Array | params_flow.rb:137:11:137:43 | Array |
 | params_flow.rb:137:11:137:43 | call to [] | params_flow.rb:137:11:137:43 | call to [] |
-| params_flow.rb:137:12:137:20 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:137:12:137:20 | * | params_flow.rb:137:12:137:20 | * |
+| params_flow.rb:137:11:137:43 | synthetic splat argument | params_flow.rb:137:11:137:43 | call to [] |
+| params_flow.rb:137:11:137:43 | synthetic splat argument | params_flow.rb:137:11:137:43 | synthetic splat argument |
 | params_flow.rb:137:12:137:20 | call to taint | params_flow.rb:137:12:137:20 | call to taint |
+| params_flow.rb:137:12:137:20 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:137:12:137:20 | synthetic splat argument | params_flow.rb:137:12:137:20 | synthetic splat argument |
 | params_flow.rb:137:18:137:19 | 69 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:137:18:137:19 | 69 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:137:18:137:19 | 69 | params_flow.rb:2:5:2:5 | x |
 | params_flow.rb:137:18:137:19 | 69 | params_flow.rb:137:12:137:20 | call to taint |
 | params_flow.rb:137:18:137:19 | 69 | params_flow.rb:137:18:137:19 | 69 |
-| params_flow.rb:137:23:137:31 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:137:23:137:31 | * | params_flow.rb:137:23:137:31 | * |
 | params_flow.rb:137:23:137:31 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:137:23:137:31 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:137:23:137:31 | call to taint | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:137:23:137:31 | call to taint | params_flow.rb:134:10:134:16 | ...[...] |
 | params_flow.rb:137:23:137:31 | call to taint | params_flow.rb:137:23:137:31 | call to taint |
+| params_flow.rb:137:23:137:31 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:137:23:137:31 | synthetic splat argument | params_flow.rb:137:23:137:31 | synthetic splat argument |
 | params_flow.rb:137:29:137:30 | 70 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:137:29:137:30 | 70 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:137:29:137:30 | 70 | params_flow.rb:2:5:2:5 | x |
@@ -5558,9 +5554,9 @@ trackEnd
 | params_flow.rb:137:29:137:30 | 70 | params_flow.rb:134:10:134:16 | ...[...] |
 | params_flow.rb:137:29:137:30 | 70 | params_flow.rb:137:23:137:31 | call to taint |
 | params_flow.rb:137:29:137:30 | 70 | params_flow.rb:137:29:137:30 | 70 |
-| params_flow.rb:137:34:137:42 | * | params_flow.rb:1:1:3:3 | synthetic *args |
-| params_flow.rb:137:34:137:42 | * | params_flow.rb:137:34:137:42 | * |
 | params_flow.rb:137:34:137:42 | call to taint | params_flow.rb:137:34:137:42 | call to taint |
+| params_flow.rb:137:34:137:42 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:137:34:137:42 | synthetic splat argument | params_flow.rb:137:34:137:42 | synthetic splat argument |
 | params_flow.rb:137:40:137:41 | 71 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:137:40:137:41 | 71 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:137:40:137:41 | 71 | params_flow.rb:2:5:2:5 | x |

--- a/ruby/ql/test/library-tests/dataflow/params/params-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/params/params-flow.expected
@@ -15,13 +15,17 @@ edges
 | params_flow.rb:25:12:25:13 | p1 | params_flow.rb:26:10:26:11 | p1 |
 | params_flow.rb:25:17:25:24 | **kwargs [element :p2] | params_flow.rb:28:11:28:16 | kwargs [element :p2] |
 | params_flow.rb:25:17:25:24 | **kwargs [element :p3] | params_flow.rb:29:11:29:16 | kwargs [element :p3] |
+| params_flow.rb:25:17:25:24 | **kwargs [hash-splat position :p2] | params_flow.rb:28:11:28:16 | kwargs [hash-splat position :p2] |
+| params_flow.rb:25:17:25:24 | **kwargs [hash-splat position :p3] | params_flow.rb:29:11:29:16 | kwargs [hash-splat position :p3] |
 | params_flow.rb:28:11:28:16 | kwargs [element :p2] | params_flow.rb:28:11:28:21 | ...[...] |
+| params_flow.rb:28:11:28:16 | kwargs [hash-splat position :p2] | params_flow.rb:28:11:28:21 | ...[...] |
 | params_flow.rb:28:11:28:21 | ...[...] | params_flow.rb:28:10:28:22 | ( ... ) |
 | params_flow.rb:29:11:29:16 | kwargs [element :p3] | params_flow.rb:29:11:29:21 | ...[...] |
+| params_flow.rb:29:11:29:16 | kwargs [hash-splat position :p3] | params_flow.rb:29:11:29:21 | ...[...] |
 | params_flow.rb:29:11:29:21 | ...[...] | params_flow.rb:29:10:29:22 | ( ... ) |
 | params_flow.rb:33:12:33:19 | call to taint | params_flow.rb:25:12:25:13 | p1 |
-| params_flow.rb:33:26:33:34 | call to taint | params_flow.rb:25:17:25:24 | **kwargs [element :p2] |
-| params_flow.rb:33:41:33:49 | call to taint | params_flow.rb:25:17:25:24 | **kwargs [element :p3] |
+| params_flow.rb:33:26:33:34 | call to taint | params_flow.rb:25:17:25:24 | **kwargs [hash-splat position :p2] |
+| params_flow.rb:33:41:33:49 | call to taint | params_flow.rb:25:17:25:24 | **kwargs [hash-splat position :p3] |
 | params_flow.rb:34:1:34:4 | args [element :p3] | params_flow.rb:35:25:35:28 | args [element :p3] |
 | params_flow.rb:34:14:34:22 | call to taint | params_flow.rb:34:1:34:4 | args [element :p3] |
 | params_flow.rb:35:12:35:20 | call to taint | params_flow.rb:25:12:25:13 | p1 |
@@ -42,9 +46,8 @@ edges
 | params_flow.rb:41:26:41:29 | args [element :p1] | params_flow.rb:41:24:41:29 | ** ... [element :p1] |
 | params_flow.rb:43:1:43:4 | args [element 0] | params_flow.rb:44:24:44:27 | args [element 0] |
 | params_flow.rb:43:9:43:17 | call to taint | params_flow.rb:43:1:43:4 | args [element 0] |
-| params_flow.rb:44:1:44:28 | *[1] | params_flow.rb:9:20:9:21 | p2 |
 | params_flow.rb:44:12:44:20 | call to taint | params_flow.rb:9:16:9:17 | p1 |
-| params_flow.rb:44:23:44:27 | * ... [element 0] | params_flow.rb:44:1:44:28 | *[1] |
+| params_flow.rb:44:23:44:27 | * ... [element 0] | params_flow.rb:9:20:9:21 | p2 |
 | params_flow.rb:44:24:44:27 | args [element 0] | params_flow.rb:44:23:44:27 | * ... [element 0] |
 | params_flow.rb:46:1:46:4 | args [element 0] | params_flow.rb:47:13:47:16 | args [element 0] |
 | params_flow.rb:46:1:46:4 | args [element 1] | params_flow.rb:47:13:47:16 | args [element 1] |
@@ -56,16 +59,17 @@ edges
 | params_flow.rb:47:13:47:16 | args [element 1] | params_flow.rb:47:12:47:16 | * ... [element 1] |
 | params_flow.rb:49:13:49:14 | p1 | params_flow.rb:50:10:50:11 | p1 |
 | params_flow.rb:49:17:49:24 | *posargs [element 0] | params_flow.rb:51:11:51:17 | posargs [element 0] |
+| params_flow.rb:49:17:49:24 | *posargs [element 0] | params_flow.rb:51:11:51:17 | posargs [element 0] |
+| params_flow.rb:51:11:51:17 | posargs [element 0] | params_flow.rb:51:11:51:20 | ...[...] |
 | params_flow.rb:51:11:51:17 | posargs [element 0] | params_flow.rb:51:11:51:20 | ...[...] |
 | params_flow.rb:51:11:51:20 | ...[...] | params_flow.rb:51:10:51:21 | ( ... ) |
 | params_flow.rb:55:9:55:17 | call to taint | params_flow.rb:49:13:49:14 | p1 |
 | params_flow.rb:55:20:55:28 | call to taint | params_flow.rb:49:17:49:24 | *posargs [element 0] |
 | params_flow.rb:57:1:57:4 | args [element 0] | params_flow.rb:58:21:58:24 | args [element 0] |
 | params_flow.rb:57:9:57:17 | call to taint | params_flow.rb:57:1:57:4 | args [element 0] |
-| params_flow.rb:58:1:58:25 | *[1] | params_flow.rb:49:17:49:24 | *posargs [element 0] |
 | params_flow.rb:58:9:58:17 | call to taint | params_flow.rb:49:13:49:14 | p1 |
 | params_flow.rb:58:20:58:24 | * ... [element 0] | params_flow.rb:49:17:49:24 | *posargs [element 0] |
-| params_flow.rb:58:20:58:24 | * ... [element 0] | params_flow.rb:58:1:58:25 | *[1] |
+| params_flow.rb:58:20:58:24 | * ... [element 0] | params_flow.rb:49:17:49:24 | *posargs [element 0] |
 | params_flow.rb:58:21:58:24 | args [element 0] | params_flow.rb:58:20:58:24 | * ... [element 0] |
 | params_flow.rb:60:1:60:4 | args [element 0] | params_flow.rb:61:10:61:13 | args [element 0] |
 | params_flow.rb:60:1:60:4 | args [element 1] | params_flow.rb:61:10:61:13 | args [element 1] |
@@ -90,21 +94,10 @@ edges
 | params_flow.rb:78:43:78:51 | call to taint | params_flow.rb:69:24:69:24 | w |
 | params_flow.rb:78:54:78:62 | call to taint | params_flow.rb:69:27:69:27 | r |
 | params_flow.rb:80:1:80:4 | args [element 0] | params_flow.rb:81:22:81:25 | args [element 0] |
-| params_flow.rb:80:1:80:4 | args [element 2] | params_flow.rb:81:22:81:25 | args [element 2] |
-| params_flow.rb:80:1:80:4 | args [element 3] | params_flow.rb:81:22:81:25 | args [element 3] |
 | params_flow.rb:80:9:80:17 | call to taint | params_flow.rb:80:1:80:4 | args [element 0] |
-| params_flow.rb:80:31:80:39 | call to taint | params_flow.rb:80:1:80:4 | args [element 2] |
-| params_flow.rb:80:42:80:50 | call to taint | params_flow.rb:80:1:80:4 | args [element 3] |
-| params_flow.rb:81:1:81:37 | *[1] | params_flow.rb:69:17:69:17 | y |
-| params_flow.rb:81:1:81:37 | *[3] | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:81:1:81:37 | *[4] | params_flow.rb:69:27:69:27 | r |
 | params_flow.rb:81:10:81:18 | call to taint | params_flow.rb:69:14:69:14 | x |
-| params_flow.rb:81:21:81:25 | * ... [element 0] | params_flow.rb:81:1:81:37 | *[1] |
-| params_flow.rb:81:21:81:25 | * ... [element 2] | params_flow.rb:81:1:81:37 | *[3] |
-| params_flow.rb:81:21:81:25 | * ... [element 3] | params_flow.rb:81:1:81:37 | *[4] |
+| params_flow.rb:81:21:81:25 | * ... [element 0] | params_flow.rb:69:17:69:17 | y |
 | params_flow.rb:81:22:81:25 | args [element 0] | params_flow.rb:81:21:81:25 | * ... [element 0] |
-| params_flow.rb:81:22:81:25 | args [element 2] | params_flow.rb:81:21:81:25 | * ... [element 2] |
-| params_flow.rb:81:22:81:25 | args [element 3] | params_flow.rb:81:21:81:25 | * ... [element 3] |
 | params_flow.rb:83:14:83:14 | t | params_flow.rb:84:10:84:10 | t |
 | params_flow.rb:83:17:83:17 | u | params_flow.rb:85:10:85:10 | u |
 | params_flow.rb:83:20:83:20 | v | params_flow.rb:86:10:86:10 | v |
@@ -119,37 +112,24 @@ edges
 | params_flow.rb:93:20:93:28 | call to taint | params_flow.rb:93:1:93:4 | args [element 1] |
 | params_flow.rb:93:31:93:39 | call to taint | params_flow.rb:93:1:93:4 | args [element 2] |
 | params_flow.rb:93:42:93:50 | call to taint | params_flow.rb:93:1:93:4 | args [element 3] |
-| params_flow.rb:94:1:94:48 | *[2] | params_flow.rb:83:20:83:20 | v |
-| params_flow.rb:94:1:94:48 | *[3] | params_flow.rb:83:23:83:23 | w |
-| params_flow.rb:94:1:94:48 | *[4] | params_flow.rb:83:26:83:26 | x |
-| params_flow.rb:94:1:94:48 | *[5] | params_flow.rb:83:29:83:29 | y |
 | params_flow.rb:94:10:94:18 | call to taint | params_flow.rb:83:14:83:14 | t |
 | params_flow.rb:94:21:94:29 | call to taint | params_flow.rb:83:17:83:17 | u |
-| params_flow.rb:94:32:94:36 | * ... [element 0] | params_flow.rb:94:1:94:48 | *[2] |
-| params_flow.rb:94:32:94:36 | * ... [element 1] | params_flow.rb:94:1:94:48 | *[3] |
-| params_flow.rb:94:32:94:36 | * ... [element 2] | params_flow.rb:94:1:94:48 | *[4] |
-| params_flow.rb:94:32:94:36 | * ... [element 3] | params_flow.rb:94:1:94:48 | *[5] |
+| params_flow.rb:94:32:94:36 | * ... [element 0] | params_flow.rb:83:20:83:20 | v |
+| params_flow.rb:94:32:94:36 | * ... [element 1] | params_flow.rb:83:23:83:23 | w |
+| params_flow.rb:94:32:94:36 | * ... [element 2] | params_flow.rb:83:26:83:26 | x |
+| params_flow.rb:94:32:94:36 | * ... [element 3] | params_flow.rb:83:29:83:29 | y |
 | params_flow.rb:94:33:94:36 | args [element 0] | params_flow.rb:94:32:94:36 | * ... [element 0] |
 | params_flow.rb:94:33:94:36 | args [element 1] | params_flow.rb:94:32:94:36 | * ... [element 1] |
 | params_flow.rb:94:33:94:36 | args [element 2] | params_flow.rb:94:32:94:36 | * ... [element 2] |
 | params_flow.rb:94:33:94:36 | args [element 3] | params_flow.rb:94:32:94:36 | * ... [element 3] |
 | params_flow.rb:94:39:94:47 | call to taint | params_flow.rb:83:23:83:23 | w |
-| params_flow.rb:96:1:96:88 | *[3] | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:96:1:96:88 | *[4] | params_flow.rb:69:27:69:27 | r |
 | params_flow.rb:96:10:96:18 | call to taint | params_flow.rb:69:14:69:14 | x |
 | params_flow.rb:96:21:96:29 | call to taint | params_flow.rb:69:17:69:17 | y |
-| params_flow.rb:96:32:96:65 | * ... [element 1] | params_flow.rb:96:1:96:88 | *[3] |
-| params_flow.rb:96:32:96:65 | * ... [element 2] | params_flow.rb:96:1:96:88 | *[4] |
-| params_flow.rb:96:45:96:53 | call to taint | params_flow.rb:96:32:96:65 | * ... [element 1] |
-| params_flow.rb:96:56:96:64 | call to taint | params_flow.rb:96:32:96:65 | * ... [element 2] |
 | params_flow.rb:96:68:96:76 | call to taint | params_flow.rb:69:24:69:24 | w |
 | params_flow.rb:96:79:96:87 | call to taint | params_flow.rb:69:27:69:27 | r |
 | params_flow.rb:98:19:98:19 | a | params_flow.rb:99:10:99:10 | a |
 | params_flow.rb:98:31:98:31 | b | params_flow.rb:102:10:102:10 | b |
-| params_flow.rb:105:1:105:49 | *[2] | params_flow.rb:98:31:98:31 | b |
 | params_flow.rb:105:15:105:23 | call to taint | params_flow.rb:98:19:98:19 | a |
-| params_flow.rb:105:26:105:48 | * ... [element 1] | params_flow.rb:105:1:105:49 | *[2] |
-| params_flow.rb:105:39:105:47 | call to taint | params_flow.rb:105:26:105:48 | * ... [element 1] |
 | params_flow.rb:106:15:106:23 | call to taint | params_flow.rb:98:19:98:19 | a |
 | params_flow.rb:106:37:106:45 | call to taint | params_flow.rb:98:31:98:31 | b |
 | params_flow.rb:108:37:108:37 | a | params_flow.rb:109:10:109:10 | a |
@@ -197,12 +177,16 @@ nodes
 | params_flow.rb:25:12:25:13 | p1 | semmle.label | p1 |
 | params_flow.rb:25:17:25:24 | **kwargs [element :p2] | semmle.label | **kwargs [element :p2] |
 | params_flow.rb:25:17:25:24 | **kwargs [element :p3] | semmle.label | **kwargs [element :p3] |
+| params_flow.rb:25:17:25:24 | **kwargs [hash-splat position :p2] | semmle.label | **kwargs [hash-splat position :p2] |
+| params_flow.rb:25:17:25:24 | **kwargs [hash-splat position :p3] | semmle.label | **kwargs [hash-splat position :p3] |
 | params_flow.rb:26:10:26:11 | p1 | semmle.label | p1 |
 | params_flow.rb:28:10:28:22 | ( ... ) | semmle.label | ( ... ) |
 | params_flow.rb:28:11:28:16 | kwargs [element :p2] | semmle.label | kwargs [element :p2] |
+| params_flow.rb:28:11:28:16 | kwargs [hash-splat position :p2] | semmle.label | kwargs [hash-splat position :p2] |
 | params_flow.rb:28:11:28:21 | ...[...] | semmle.label | ...[...] |
 | params_flow.rb:29:10:29:22 | ( ... ) | semmle.label | ( ... ) |
 | params_flow.rb:29:11:29:16 | kwargs [element :p3] | semmle.label | kwargs [element :p3] |
+| params_flow.rb:29:11:29:16 | kwargs [hash-splat position :p3] | semmle.label | kwargs [hash-splat position :p3] |
 | params_flow.rb:29:11:29:21 | ...[...] | semmle.label | ...[...] |
 | params_flow.rb:33:12:33:19 | call to taint | semmle.label | call to taint |
 | params_flow.rb:33:26:33:34 | call to taint | semmle.label | call to taint |
@@ -227,7 +211,6 @@ nodes
 | params_flow.rb:41:26:41:29 | args [element :p1] | semmle.label | args [element :p1] |
 | params_flow.rb:43:1:43:4 | args [element 0] | semmle.label | args [element 0] |
 | params_flow.rb:43:9:43:17 | call to taint | semmle.label | call to taint |
-| params_flow.rb:44:1:44:28 | *[1] | semmle.label | *[1] |
 | params_flow.rb:44:12:44:20 | call to taint | semmle.label | call to taint |
 | params_flow.rb:44:23:44:27 | * ... [element 0] | semmle.label | * ... [element 0] |
 | params_flow.rb:44:24:44:27 | args [element 0] | semmle.label | args [element 0] |
@@ -241,15 +224,16 @@ nodes
 | params_flow.rb:47:13:47:16 | args [element 1] | semmle.label | args [element 1] |
 | params_flow.rb:49:13:49:14 | p1 | semmle.label | p1 |
 | params_flow.rb:49:17:49:24 | *posargs [element 0] | semmle.label | *posargs [element 0] |
+| params_flow.rb:49:17:49:24 | *posargs [element 0] | semmle.label | *posargs [element 0] |
 | params_flow.rb:50:10:50:11 | p1 | semmle.label | p1 |
 | params_flow.rb:51:10:51:21 | ( ... ) | semmle.label | ( ... ) |
+| params_flow.rb:51:11:51:17 | posargs [element 0] | semmle.label | posargs [element 0] |
 | params_flow.rb:51:11:51:17 | posargs [element 0] | semmle.label | posargs [element 0] |
 | params_flow.rb:51:11:51:20 | ...[...] | semmle.label | ...[...] |
 | params_flow.rb:55:9:55:17 | call to taint | semmle.label | call to taint |
 | params_flow.rb:55:20:55:28 | call to taint | semmle.label | call to taint |
 | params_flow.rb:57:1:57:4 | args [element 0] | semmle.label | args [element 0] |
 | params_flow.rb:57:9:57:17 | call to taint | semmle.label | call to taint |
-| params_flow.rb:58:1:58:25 | *[1] | semmle.label | *[1] |
 | params_flow.rb:58:9:58:17 | call to taint | semmle.label | call to taint |
 | params_flow.rb:58:20:58:24 | * ... [element 0] | semmle.label | * ... [element 0] |
 | params_flow.rb:58:21:58:24 | args [element 0] | semmle.label | args [element 0] |
@@ -281,21 +265,10 @@ nodes
 | params_flow.rb:78:43:78:51 | call to taint | semmle.label | call to taint |
 | params_flow.rb:78:54:78:62 | call to taint | semmle.label | call to taint |
 | params_flow.rb:80:1:80:4 | args [element 0] | semmle.label | args [element 0] |
-| params_flow.rb:80:1:80:4 | args [element 2] | semmle.label | args [element 2] |
-| params_flow.rb:80:1:80:4 | args [element 3] | semmle.label | args [element 3] |
 | params_flow.rb:80:9:80:17 | call to taint | semmle.label | call to taint |
-| params_flow.rb:80:31:80:39 | call to taint | semmle.label | call to taint |
-| params_flow.rb:80:42:80:50 | call to taint | semmle.label | call to taint |
-| params_flow.rb:81:1:81:37 | *[1] | semmle.label | *[1] |
-| params_flow.rb:81:1:81:37 | *[3] | semmle.label | *[3] |
-| params_flow.rb:81:1:81:37 | *[4] | semmle.label | *[4] |
 | params_flow.rb:81:10:81:18 | call to taint | semmle.label | call to taint |
 | params_flow.rb:81:21:81:25 | * ... [element 0] | semmle.label | * ... [element 0] |
-| params_flow.rb:81:21:81:25 | * ... [element 2] | semmle.label | * ... [element 2] |
-| params_flow.rb:81:21:81:25 | * ... [element 3] | semmle.label | * ... [element 3] |
 | params_flow.rb:81:22:81:25 | args [element 0] | semmle.label | args [element 0] |
-| params_flow.rb:81:22:81:25 | args [element 2] | semmle.label | args [element 2] |
-| params_flow.rb:81:22:81:25 | args [element 3] | semmle.label | args [element 3] |
 | params_flow.rb:83:14:83:14 | t | semmle.label | t |
 | params_flow.rb:83:17:83:17 | u | semmle.label | u |
 | params_flow.rb:83:20:83:20 | v | semmle.label | v |
@@ -316,10 +289,6 @@ nodes
 | params_flow.rb:93:20:93:28 | call to taint | semmle.label | call to taint |
 | params_flow.rb:93:31:93:39 | call to taint | semmle.label | call to taint |
 | params_flow.rb:93:42:93:50 | call to taint | semmle.label | call to taint |
-| params_flow.rb:94:1:94:48 | *[2] | semmle.label | *[2] |
-| params_flow.rb:94:1:94:48 | *[3] | semmle.label | *[3] |
-| params_flow.rb:94:1:94:48 | *[4] | semmle.label | *[4] |
-| params_flow.rb:94:1:94:48 | *[5] | semmle.label | *[5] |
 | params_flow.rb:94:10:94:18 | call to taint | semmle.label | call to taint |
 | params_flow.rb:94:21:94:29 | call to taint | semmle.label | call to taint |
 | params_flow.rb:94:32:94:36 | * ... [element 0] | semmle.label | * ... [element 0] |
@@ -331,24 +300,15 @@ nodes
 | params_flow.rb:94:33:94:36 | args [element 2] | semmle.label | args [element 2] |
 | params_flow.rb:94:33:94:36 | args [element 3] | semmle.label | args [element 3] |
 | params_flow.rb:94:39:94:47 | call to taint | semmle.label | call to taint |
-| params_flow.rb:96:1:96:88 | *[3] | semmle.label | *[3] |
-| params_flow.rb:96:1:96:88 | *[4] | semmle.label | *[4] |
 | params_flow.rb:96:10:96:18 | call to taint | semmle.label | call to taint |
 | params_flow.rb:96:21:96:29 | call to taint | semmle.label | call to taint |
-| params_flow.rb:96:32:96:65 | * ... [element 1] | semmle.label | * ... [element 1] |
-| params_flow.rb:96:32:96:65 | * ... [element 2] | semmle.label | * ... [element 2] |
-| params_flow.rb:96:45:96:53 | call to taint | semmle.label | call to taint |
-| params_flow.rb:96:56:96:64 | call to taint | semmle.label | call to taint |
 | params_flow.rb:96:68:96:76 | call to taint | semmle.label | call to taint |
 | params_flow.rb:96:79:96:87 | call to taint | semmle.label | call to taint |
 | params_flow.rb:98:19:98:19 | a | semmle.label | a |
 | params_flow.rb:98:31:98:31 | b | semmle.label | b |
 | params_flow.rb:99:10:99:10 | a | semmle.label | a |
 | params_flow.rb:102:10:102:10 | b | semmle.label | b |
-| params_flow.rb:105:1:105:49 | *[2] | semmle.label | *[2] |
 | params_flow.rb:105:15:105:23 | call to taint | semmle.label | call to taint |
-| params_flow.rb:105:26:105:48 | * ... [element 1] | semmle.label | * ... [element 1] |
-| params_flow.rb:105:39:105:47 | call to taint | semmle.label | call to taint |
 | params_flow.rb:106:15:106:23 | call to taint | semmle.label | call to taint |
 | params_flow.rb:106:37:106:45 | call to taint | semmle.label | call to taint |
 | params_flow.rb:108:37:108:37 | a | semmle.label | a |
@@ -418,12 +378,8 @@ subpaths
 | params_flow.rb:71:10:71:10 | y | params_flow.rb:80:9:80:17 | call to taint | params_flow.rb:71:10:71:10 | y | $@ | params_flow.rb:80:9:80:17 | call to taint | call to taint |
 | params_flow.rb:71:10:71:10 | y | params_flow.rb:96:21:96:29 | call to taint | params_flow.rb:71:10:71:10 | y | $@ | params_flow.rb:96:21:96:29 | call to taint | call to taint |
 | params_flow.rb:74:10:74:10 | w | params_flow.rb:78:43:78:51 | call to taint | params_flow.rb:74:10:74:10 | w | $@ | params_flow.rb:78:43:78:51 | call to taint | call to taint |
-| params_flow.rb:74:10:74:10 | w | params_flow.rb:80:31:80:39 | call to taint | params_flow.rb:74:10:74:10 | w | $@ | params_flow.rb:80:31:80:39 | call to taint | call to taint |
-| params_flow.rb:74:10:74:10 | w | params_flow.rb:96:45:96:53 | call to taint | params_flow.rb:74:10:74:10 | w | $@ | params_flow.rb:96:45:96:53 | call to taint | call to taint |
 | params_flow.rb:74:10:74:10 | w | params_flow.rb:96:68:96:76 | call to taint | params_flow.rb:74:10:74:10 | w | $@ | params_flow.rb:96:68:96:76 | call to taint | call to taint |
 | params_flow.rb:75:10:75:10 | r | params_flow.rb:78:54:78:62 | call to taint | params_flow.rb:75:10:75:10 | r | $@ | params_flow.rb:78:54:78:62 | call to taint | call to taint |
-| params_flow.rb:75:10:75:10 | r | params_flow.rb:80:42:80:50 | call to taint | params_flow.rb:75:10:75:10 | r | $@ | params_flow.rb:80:42:80:50 | call to taint | call to taint |
-| params_flow.rb:75:10:75:10 | r | params_flow.rb:96:56:96:64 | call to taint | params_flow.rb:75:10:75:10 | r | $@ | params_flow.rb:96:56:96:64 | call to taint | call to taint |
 | params_flow.rb:75:10:75:10 | r | params_flow.rb:96:79:96:87 | call to taint | params_flow.rb:75:10:75:10 | r | $@ | params_flow.rb:96:79:96:87 | call to taint | call to taint |
 | params_flow.rb:84:10:84:10 | t | params_flow.rb:94:10:94:18 | call to taint | params_flow.rb:84:10:84:10 | t | $@ | params_flow.rb:94:10:94:18 | call to taint | call to taint |
 | params_flow.rb:84:10:84:10 | t | params_flow.rb:130:9:130:17 | call to taint | params_flow.rb:84:10:84:10 | t | $@ | params_flow.rb:130:9:130:17 | call to taint | call to taint |
@@ -437,7 +393,6 @@ subpaths
 | params_flow.rb:89:10:89:10 | y | params_flow.rb:93:42:93:50 | call to taint | params_flow.rb:89:10:89:10 | y | $@ | params_flow.rb:93:42:93:50 | call to taint | call to taint |
 | params_flow.rb:99:10:99:10 | a | params_flow.rb:105:15:105:23 | call to taint | params_flow.rb:99:10:99:10 | a | $@ | params_flow.rb:105:15:105:23 | call to taint | call to taint |
 | params_flow.rb:99:10:99:10 | a | params_flow.rb:106:15:106:23 | call to taint | params_flow.rb:99:10:99:10 | a | $@ | params_flow.rb:106:15:106:23 | call to taint | call to taint |
-| params_flow.rb:102:10:102:10 | b | params_flow.rb:105:39:105:47 | call to taint | params_flow.rb:102:10:102:10 | b | $@ | params_flow.rb:105:39:105:47 | call to taint | call to taint |
 | params_flow.rb:102:10:102:10 | b | params_flow.rb:106:37:106:45 | call to taint | params_flow.rb:102:10:102:10 | b | $@ | params_flow.rb:106:37:106:45 | call to taint | call to taint |
 | params_flow.rb:109:10:109:10 | a | params_flow.rb:114:33:114:41 | call to taint | params_flow.rb:109:10:109:10 | a | $@ | params_flow.rb:114:33:114:41 | call to taint | call to taint |
 | params_flow.rb:110:10:110:13 | ...[...] | params_flow.rb:114:44:114:52 | call to taint | params_flow.rb:110:10:110:13 | ...[...] | $@ | params_flow.rb:114:44:114:52 | call to taint | call to taint |

--- a/ruby/ql/test/library-tests/dataflow/params/params_flow.rb
+++ b/ruby/ql/test/library-tests/dataflow/params/params_flow.rb
@@ -71,8 +71,8 @@ def splatmid(x, y, *z, w, r)
     sink y # $ hasValueFlow=28 $ hasValueFlow=46 $ hasValueFlow=33
     sink z[0] # MISSING: $ hasValueFlow=47 $ hasValueFlow=29 $ hasValueFlow=34
     sink z[1] # $ MISSING: hasValueFlow=48 $ hasValueFlow=35
-    sink w # $ hasValueFlow=30 $ hasValueFlow=50 $ MISSING: hasValueFlow=36 $ SPURIOUS: hasValueFlow=35 $ hasValueFlow=48
-    sink r # $ hasValueFlow=31 $ hasValueFlow=51 $ MISSING: hasValueFlow=37 $ SPURIOUS: hasValueFlow=36 $ hasValueFlow=49
+    sink w # $ hasValueFlow=30 $ hasValueFlow=50 $ MISSING: hasValueFlow=36
+    sink r # $ hasValueFlow=31 $ hasValueFlow=51 $ MISSING: hasValueFlow=37
 end
 
 splatmid(taint(27), taint(28), taint(29), taint(30), taint(31))
@@ -99,7 +99,7 @@ def splatmidsmall(a, *splats, b)
     sink a # $ hasValueFlow=52 $ hasValueFlow=55
     sink splats[0] # $ MISSING: hasValueFlow=53
     sink splats[1]
-    sink b # $ hasValueFlow=57 $ hasValueFlow=54
+    sink b # $ hasValueFlow=57 $ MISSING: hasValueFlow=54
 end
 
 splatmidsmall(taint(52), *[taint(53), taint(54)])

--- a/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
+++ b/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
@@ -250,7 +250,7 @@ edges
 | summaries.rb:122:33:122:33 | [post] z | summaries.rb:125:6:125:6 | z |
 | summaries.rb:128:1:128:1 | [post] x | summaries.rb:129:6:129:6 | x |
 | summaries.rb:128:14:128:20 | tainted | summaries.rb:128:1:128:1 | [post] x |
-| summaries.rb:131:16:131:22 | tainted | summaries.rb:131:1:131:23 | * |
+| summaries.rb:131:16:131:22 | tainted | summaries.rb:131:1:131:23 | synthetic splat argument |
 | summaries.rb:157:14:160:3 | do ... end [captured tainted] | summaries.rb:158:15:158:21 | tainted |
 | summaries.rb:157:14:160:3 | do ... end [captured tainted] | summaries.rb:158:15:158:21 | tainted |
 nodes
@@ -469,7 +469,7 @@ nodes
 | summaries.rb:128:1:128:1 | [post] x | semmle.label | [post] x |
 | summaries.rb:128:14:128:20 | tainted | semmle.label | tainted |
 | summaries.rb:129:6:129:6 | x | semmle.label | x |
-| summaries.rb:131:1:131:23 | * | semmle.label | * |
+| summaries.rb:131:1:131:23 | synthetic splat argument | semmle.label | synthetic splat argument |
 | summaries.rb:131:16:131:22 | tainted | semmle.label | tainted |
 | summaries.rb:131:16:131:22 | tainted | semmle.label | tainted |
 | summaries.rb:131:16:131:22 | tainted | semmle.label | tainted |
@@ -584,7 +584,7 @@ invalidSpecComponent
 | summaries.rb:124:6:124:6 | y | summaries.rb:1:20:1:36 | call to source | summaries.rb:124:6:124:6 | y | $@ | summaries.rb:1:20:1:36 | call to source | call to source |
 | summaries.rb:125:6:125:6 | z | summaries.rb:1:20:1:36 | call to source | summaries.rb:125:6:125:6 | z | $@ | summaries.rb:1:20:1:36 | call to source | call to source |
 | summaries.rb:129:6:129:6 | x | summaries.rb:1:20:1:36 | call to source | summaries.rb:129:6:129:6 | x | $@ | summaries.rb:1:20:1:36 | call to source | call to source |
-| summaries.rb:131:1:131:23 | * | summaries.rb:1:20:1:36 | call to source | summaries.rb:131:1:131:23 | * | $@ | summaries.rb:1:20:1:36 | call to source | call to source |
+| summaries.rb:131:1:131:23 | synthetic splat argument | summaries.rb:1:20:1:36 | call to source | summaries.rb:131:1:131:23 | synthetic splat argument | $@ | summaries.rb:1:20:1:36 | call to source | call to source |
 | summaries.rb:131:16:131:22 | tainted | summaries.rb:1:20:1:36 | call to source | summaries.rb:131:16:131:22 | tainted | $@ | summaries.rb:1:20:1:36 | call to source | call to source |
 | summaries.rb:131:16:131:22 | tainted | summaries.rb:1:20:1:36 | call to source | summaries.rb:131:16:131:22 | tainted | $@ | summaries.rb:1:20:1:36 | call to source | call to source |
 | summaries.rb:132:21:132:27 | tainted | summaries.rb:1:20:1:36 | call to source | summaries.rb:132:21:132:27 | tainted | $@ | summaries.rb:1:20:1:36 | call to source | call to source |

--- a/ruby/ql/test/library-tests/dataflow/type-tracker/TypeTracker.expected
+++ b/ruby/ql/test/library-tests/dataflow/type-tracker/TypeTracker.expected
@@ -7,19 +7,19 @@ track
 | type_tracker.rb:2:5:5:7 | field= | type tracker without call steps | type_tracker.rb:2:5:5:7 | field= |
 | type_tracker.rb:2:5:5:7 | self in field= | type tracker with call steps | type_tracker.rb:7:5:9:7 | self in field |
 | type_tracker.rb:2:5:5:7 | self in field= | type tracker without call steps | type_tracker.rb:2:5:5:7 | self in field= |
-| type_tracker.rb:2:5:5:7 | synthetic *args | type tracker without call steps | type_tracker.rb:2:5:5:7 | synthetic *args |
+| type_tracker.rb:2:5:5:7 | synthetic splat parameter | type tracker without call steps | type_tracker.rb:2:5:5:7 | synthetic splat parameter |
 | type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:2:16:2:18 | val |
 | type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:2:16:2:18 | val |
 | type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:3:14:3:23 | call to field |
 | type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:8:9:8:14 | @field |
 | type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:14:5:14:13 | call to field= |
 | type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:15:10:15:18 | call to field |
-| type_tracker.rb:2:16:2:18 | val | type tracker without call steps with content element 0 | type_tracker.rb:3:9:3:23 | * |
-| type_tracker.rb:2:16:2:18 | val | type tracker without call steps with content element 0 | type_tracker.rb:15:5:15:18 | * |
-| type_tracker.rb:3:9:3:23 | * | type tracker without call steps | type_tracker.rb:3:9:3:23 | * |
+| type_tracker.rb:2:16:2:18 | val | type tracker without call steps with content splat position 0 | type_tracker.rb:3:9:3:23 | synthetic splat argument |
+| type_tracker.rb:2:16:2:18 | val | type tracker without call steps with content splat position 0 | type_tracker.rb:15:5:15:18 | synthetic splat argument |
 | type_tracker.rb:3:9:3:23 | call to puts | type tracker without call steps | type_tracker.rb:3:9:3:23 | call to puts |
+| type_tracker.rb:3:9:3:23 | synthetic splat argument | type tracker without call steps | type_tracker.rb:3:9:3:23 | synthetic splat argument |
 | type_tracker.rb:3:14:3:23 | call to field | type tracker without call steps | type_tracker.rb:3:14:3:23 | call to field |
-| type_tracker.rb:3:14:3:23 | call to field | type tracker without call steps with content element 0 | type_tracker.rb:3:9:3:23 | * |
+| type_tracker.rb:3:14:3:23 | call to field | type tracker without call steps with content splat position 0 | type_tracker.rb:3:9:3:23 | synthetic splat argument |
 | type_tracker.rb:4:9:4:14 | @field | type tracker without call steps | type_tracker.rb:4:9:4:14 | @field |
 | type_tracker.rb:7:5:9:7 | &block | type tracker without call steps | type_tracker.rb:7:5:9:7 | &block |
 | type_tracker.rb:7:5:9:7 | field | type tracker without call steps | type_tracker.rb:7:5:9:7 | field |
@@ -27,8 +27,8 @@ track
 | type_tracker.rb:8:9:8:14 | @field | type tracker without call steps | type_tracker.rb:3:14:3:23 | call to field |
 | type_tracker.rb:8:9:8:14 | @field | type tracker without call steps | type_tracker.rb:8:9:8:14 | @field |
 | type_tracker.rb:8:9:8:14 | @field | type tracker without call steps | type_tracker.rb:15:10:15:18 | call to field |
-| type_tracker.rb:8:9:8:14 | @field | type tracker without call steps with content element 0 | type_tracker.rb:3:9:3:23 | * |
-| type_tracker.rb:8:9:8:14 | @field | type tracker without call steps with content element 0 | type_tracker.rb:15:5:15:18 | * |
+| type_tracker.rb:8:9:8:14 | @field | type tracker without call steps with content splat position 0 | type_tracker.rb:3:9:3:23 | synthetic splat argument |
+| type_tracker.rb:8:9:8:14 | @field | type tracker without call steps with content splat position 0 | type_tracker.rb:15:5:15:18 | synthetic splat argument |
 | type_tracker.rb:12:1:16:3 | &block | type tracker without call steps | type_tracker.rb:12:1:16:3 | &block |
 | type_tracker.rb:12:1:16:3 | m | type tracker without call steps | type_tracker.rb:12:1:16:3 | m |
 | type_tracker.rb:12:1:16:3 | self in m | type tracker without call steps | type_tracker.rb:12:1:16:3 | self in m |
@@ -39,123 +39,123 @@ track
 | type_tracker.rb:13:11:13:23 | call to new | type tracker without call steps | type_tracker.rb:13:11:13:23 | call to new |
 | type_tracker.rb:14:5:14:7 | [post] var | type tracker with call steps | type_tracker.rb:7:5:9:7 | self in field |
 | type_tracker.rb:14:5:14:7 | [post] var | type tracker without call steps | type_tracker.rb:14:5:14:7 | [post] var |
-| type_tracker.rb:14:5:14:13 | * | type tracker with call steps | type_tracker.rb:2:5:5:7 | synthetic *args |
-| type_tracker.rb:14:5:14:13 | * | type tracker without call steps | type_tracker.rb:14:5:14:13 | * |
 | type_tracker.rb:14:5:14:13 | call to field= | type tracker without call steps | type_tracker.rb:14:5:14:13 | call to field= |
+| type_tracker.rb:14:5:14:13 | synthetic splat argument | type tracker with call steps | type_tracker.rb:2:5:5:7 | synthetic splat parameter |
+| type_tracker.rb:14:5:14:13 | synthetic splat argument | type tracker without call steps | type_tracker.rb:14:5:14:13 | synthetic splat argument |
 | type_tracker.rb:14:17:14:23 | "hello" | type tracker with call steps | type_tracker.rb:2:16:2:18 | val |
 | type_tracker.rb:14:17:14:23 | "hello" | type tracker with call steps | type_tracker.rb:8:9:8:14 | @field |
 | type_tracker.rb:14:17:14:23 | "hello" | type tracker with call steps with content attribute field | type_tracker.rb:7:5:9:7 | self in field |
-| type_tracker.rb:14:17:14:23 | "hello" | type tracker with call steps with content element 0 | type_tracker.rb:2:5:5:7 | synthetic *args |
+| type_tracker.rb:14:17:14:23 | "hello" | type tracker with call steps with content splat position 0 | type_tracker.rb:2:5:5:7 | synthetic splat parameter |
 | type_tracker.rb:14:17:14:23 | "hello" | type tracker without call steps | type_tracker.rb:14:5:14:13 | call to field= |
 | type_tracker.rb:14:17:14:23 | "hello" | type tracker without call steps | type_tracker.rb:14:17:14:23 | "hello" |
 | type_tracker.rb:14:17:14:23 | "hello" | type tracker without call steps | type_tracker.rb:15:10:15:18 | call to field |
 | type_tracker.rb:14:17:14:23 | "hello" | type tracker without call steps with content attribute field | type_tracker.rb:14:5:14:7 | [post] var |
-| type_tracker.rb:14:17:14:23 | "hello" | type tracker without call steps with content element 0 | type_tracker.rb:14:5:14:13 | * |
-| type_tracker.rb:14:17:14:23 | "hello" | type tracker without call steps with content element 0 | type_tracker.rb:15:5:15:18 | * |
+| type_tracker.rb:14:17:14:23 | "hello" | type tracker without call steps with content splat position 0 | type_tracker.rb:14:5:14:13 | synthetic splat argument |
+| type_tracker.rb:14:17:14:23 | "hello" | type tracker without call steps with content splat position 0 | type_tracker.rb:15:5:15:18 | synthetic splat argument |
 | type_tracker.rb:14:17:14:23 | __synth__0 | type tracker without call steps | type_tracker.rb:14:17:14:23 | __synth__0 |
-| type_tracker.rb:15:5:15:18 | * | type tracker without call steps | type_tracker.rb:15:5:15:18 | * |
 | type_tracker.rb:15:5:15:18 | call to puts | type tracker without call steps | type_tracker.rb:15:5:15:18 | call to puts |
+| type_tracker.rb:15:5:15:18 | synthetic splat argument | type tracker without call steps | type_tracker.rb:15:5:15:18 | synthetic splat argument |
 | type_tracker.rb:15:10:15:18 | call to field | type tracker without call steps | type_tracker.rb:15:10:15:18 | call to field |
-| type_tracker.rb:15:10:15:18 | call to field | type tracker without call steps with content element 0 | type_tracker.rb:15:5:15:18 | * |
+| type_tracker.rb:15:10:15:18 | call to field | type tracker without call steps with content splat position 0 | type_tracker.rb:15:5:15:18 | synthetic splat argument |
 | type_tracker.rb:18:1:21:3 | &block | type tracker without call steps | type_tracker.rb:18:1:21:3 | &block |
 | type_tracker.rb:18:1:21:3 | positional | type tracker without call steps | type_tracker.rb:18:1:21:3 | positional |
 | type_tracker.rb:18:1:21:3 | self in positional | type tracker without call steps | type_tracker.rb:18:1:21:3 | self in positional |
-| type_tracker.rb:18:1:21:3 | synthetic *args | type tracker without call steps | type_tracker.rb:18:1:21:3 | synthetic *args |
+| type_tracker.rb:18:1:21:3 | synthetic splat parameter | type tracker without call steps | type_tracker.rb:18:1:21:3 | synthetic splat parameter |
 | type_tracker.rb:18:16:18:17 | p1 | type tracker without call steps | type_tracker.rb:18:16:18:17 | p1 |
 | type_tracker.rb:18:16:18:17 | p1 | type tracker without call steps | type_tracker.rb:18:16:18:17 | p1 |
-| type_tracker.rb:18:16:18:17 | p1 | type tracker without call steps with content element 0 | type_tracker.rb:19:5:19:11 | * |
+| type_tracker.rb:18:16:18:17 | p1 | type tracker without call steps with content splat position 0 | type_tracker.rb:19:5:19:11 | synthetic splat argument |
 | type_tracker.rb:18:20:18:21 | p2 | type tracker without call steps | type_tracker.rb:18:20:18:21 | p2 |
 | type_tracker.rb:18:20:18:21 | p2 | type tracker without call steps | type_tracker.rb:18:20:18:21 | p2 |
-| type_tracker.rb:18:20:18:21 | p2 | type tracker without call steps with content element 0 | type_tracker.rb:20:5:20:11 | * |
-| type_tracker.rb:19:5:19:11 | * | type tracker without call steps | type_tracker.rb:19:5:19:11 | * |
+| type_tracker.rb:18:20:18:21 | p2 | type tracker without call steps with content splat position 0 | type_tracker.rb:20:5:20:11 | synthetic splat argument |
 | type_tracker.rb:19:5:19:11 | call to puts | type tracker without call steps | type_tracker.rb:19:5:19:11 | call to puts |
-| type_tracker.rb:20:5:20:11 | * | type tracker without call steps | type_tracker.rb:20:5:20:11 | * |
+| type_tracker.rb:19:5:19:11 | synthetic splat argument | type tracker without call steps | type_tracker.rb:19:5:19:11 | synthetic splat argument |
 | type_tracker.rb:20:5:20:11 | call to puts | type tracker without call steps | type_tracker.rb:20:5:20:11 | call to puts |
 | type_tracker.rb:20:5:20:11 | call to puts | type tracker without call steps | type_tracker.rb:23:1:23:16 | call to positional |
-| type_tracker.rb:23:1:23:16 | * | type tracker with call steps | type_tracker.rb:18:1:21:3 | synthetic *args |
-| type_tracker.rb:23:1:23:16 | * | type tracker without call steps | type_tracker.rb:23:1:23:16 | * |
+| type_tracker.rb:20:5:20:11 | synthetic splat argument | type tracker without call steps | type_tracker.rb:20:5:20:11 | synthetic splat argument |
 | type_tracker.rb:23:1:23:16 | call to positional | type tracker without call steps | type_tracker.rb:23:1:23:16 | call to positional |
+| type_tracker.rb:23:1:23:16 | synthetic splat argument | type tracker with call steps | type_tracker.rb:18:1:21:3 | synthetic splat parameter |
+| type_tracker.rb:23:1:23:16 | synthetic splat argument | type tracker without call steps | type_tracker.rb:23:1:23:16 | synthetic splat argument |
 | type_tracker.rb:23:12:23:12 | 1 | type tracker with call steps | type_tracker.rb:18:16:18:17 | p1 |
-| type_tracker.rb:23:12:23:12 | 1 | type tracker with call steps with content element 0 | type_tracker.rb:18:1:21:3 | synthetic *args |
-| type_tracker.rb:23:12:23:12 | 1 | type tracker with call steps with content element 0 | type_tracker.rb:19:5:19:11 | * |
+| type_tracker.rb:23:12:23:12 | 1 | type tracker with call steps with content splat position 0 | type_tracker.rb:18:1:21:3 | synthetic splat parameter |
+| type_tracker.rb:23:12:23:12 | 1 | type tracker with call steps with content splat position 0 | type_tracker.rb:19:5:19:11 | synthetic splat argument |
 | type_tracker.rb:23:12:23:12 | 1 | type tracker without call steps | type_tracker.rb:23:12:23:12 | 1 |
-| type_tracker.rb:23:12:23:12 | 1 | type tracker without call steps with content element 0 | type_tracker.rb:23:1:23:16 | * |
+| type_tracker.rb:23:12:23:12 | 1 | type tracker without call steps with content splat position 0 | type_tracker.rb:23:1:23:16 | synthetic splat argument |
 | type_tracker.rb:23:15:23:15 | 2 | type tracker with call steps | type_tracker.rb:18:20:18:21 | p2 |
-| type_tracker.rb:23:15:23:15 | 2 | type tracker with call steps with content element 0 | type_tracker.rb:20:5:20:11 | * |
-| type_tracker.rb:23:15:23:15 | 2 | type tracker with call steps with content element 1 | type_tracker.rb:18:1:21:3 | synthetic *args |
+| type_tracker.rb:23:15:23:15 | 2 | type tracker with call steps with content splat position 0 | type_tracker.rb:20:5:20:11 | synthetic splat argument |
+| type_tracker.rb:23:15:23:15 | 2 | type tracker with call steps with content splat position 1 | type_tracker.rb:18:1:21:3 | synthetic splat parameter |
 | type_tracker.rb:23:15:23:15 | 2 | type tracker without call steps | type_tracker.rb:23:15:23:15 | 2 |
-| type_tracker.rb:23:15:23:15 | 2 | type tracker without call steps with content element 1 | type_tracker.rb:23:1:23:16 | * |
+| type_tracker.rb:23:15:23:15 | 2 | type tracker without call steps with content splat position 1 | type_tracker.rb:23:1:23:16 | synthetic splat argument |
 | type_tracker.rb:25:1:28:3 | &block | type tracker without call steps | type_tracker.rb:25:1:28:3 | &block |
-| type_tracker.rb:25:1:28:3 | **kwargs | type tracker without call steps | type_tracker.rb:25:1:28:3 | **kwargs |
 | type_tracker.rb:25:1:28:3 | keyword | type tracker without call steps | type_tracker.rb:25:1:28:3 | keyword |
 | type_tracker.rb:25:1:28:3 | self in keyword | type tracker without call steps | type_tracker.rb:25:1:28:3 | self in keyword |
+| type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter | type tracker without call steps | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
 | type_tracker.rb:25:13:25:14 | p1 | type tracker without call steps | type_tracker.rb:25:13:25:14 | p1 |
 | type_tracker.rb:25:13:25:14 | p1 | type tracker without call steps | type_tracker.rb:25:13:25:14 | p1 |
-| type_tracker.rb:25:13:25:14 | p1 | type tracker without call steps with content element 0 | type_tracker.rb:26:5:26:11 | * |
+| type_tracker.rb:25:13:25:14 | p1 | type tracker without call steps with content splat position 0 | type_tracker.rb:26:5:26:11 | synthetic splat argument |
 | type_tracker.rb:25:18:25:19 | p2 | type tracker without call steps | type_tracker.rb:25:18:25:19 | p2 |
 | type_tracker.rb:25:18:25:19 | p2 | type tracker without call steps | type_tracker.rb:25:18:25:19 | p2 |
-| type_tracker.rb:25:18:25:19 | p2 | type tracker without call steps with content element 0 | type_tracker.rb:27:5:27:11 | * |
-| type_tracker.rb:26:5:26:11 | * | type tracker without call steps | type_tracker.rb:26:5:26:11 | * |
+| type_tracker.rb:25:18:25:19 | p2 | type tracker without call steps with content splat position 0 | type_tracker.rb:27:5:27:11 | synthetic splat argument |
 | type_tracker.rb:26:5:26:11 | call to puts | type tracker without call steps | type_tracker.rb:26:5:26:11 | call to puts |
-| type_tracker.rb:27:5:27:11 | * | type tracker without call steps | type_tracker.rb:27:5:27:11 | * |
+| type_tracker.rb:26:5:26:11 | synthetic splat argument | type tracker without call steps | type_tracker.rb:26:5:26:11 | synthetic splat argument |
 | type_tracker.rb:27:5:27:11 | call to puts | type tracker without call steps | type_tracker.rb:27:5:27:11 | call to puts |
 | type_tracker.rb:27:5:27:11 | call to puts | type tracker without call steps | type_tracker.rb:30:1:30:21 | call to keyword |
 | type_tracker.rb:27:5:27:11 | call to puts | type tracker without call steps | type_tracker.rb:31:1:31:21 | call to keyword |
 | type_tracker.rb:27:5:27:11 | call to puts | type tracker without call steps | type_tracker.rb:32:1:32:27 | call to keyword |
-| type_tracker.rb:30:1:30:21 | ** | type tracker with call steps | type_tracker.rb:25:1:28:3 | **kwargs |
-| type_tracker.rb:30:1:30:21 | ** | type tracker without call steps | type_tracker.rb:30:1:30:21 | ** |
+| type_tracker.rb:27:5:27:11 | synthetic splat argument | type tracker without call steps | type_tracker.rb:27:5:27:11 | synthetic splat argument |
 | type_tracker.rb:30:1:30:21 | call to keyword | type tracker without call steps | type_tracker.rb:30:1:30:21 | call to keyword |
+| type_tracker.rb:30:1:30:21 | synthetic hash-splat argument | type tracker with call steps | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
+| type_tracker.rb:30:1:30:21 | synthetic hash-splat argument | type tracker without call steps | type_tracker.rb:30:1:30:21 | synthetic hash-splat argument |
 | type_tracker.rb:30:9:30:10 | :p1 | type tracker without call steps | type_tracker.rb:30:9:30:10 | :p1 |
 | type_tracker.rb:30:9:30:13 | Pair | type tracker without call steps | type_tracker.rb:30:9:30:13 | Pair |
 | type_tracker.rb:30:13:30:13 | 3 | type tracker with call steps | type_tracker.rb:25:13:25:14 | p1 |
-| type_tracker.rb:30:13:30:13 | 3 | type tracker with call steps with content element 0 | type_tracker.rb:26:5:26:11 | * |
-| type_tracker.rb:30:13:30:13 | 3 | type tracker with call steps with content element :p1 | type_tracker.rb:25:1:28:3 | **kwargs |
+| type_tracker.rb:30:13:30:13 | 3 | type tracker with call steps with content hash-splat position :p1 | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
+| type_tracker.rb:30:13:30:13 | 3 | type tracker with call steps with content splat position 0 | type_tracker.rb:26:5:26:11 | synthetic splat argument |
 | type_tracker.rb:30:13:30:13 | 3 | type tracker without call steps | type_tracker.rb:30:13:30:13 | 3 |
-| type_tracker.rb:30:13:30:13 | 3 | type tracker without call steps with content element :p1 | type_tracker.rb:30:1:30:21 | ** |
+| type_tracker.rb:30:13:30:13 | 3 | type tracker without call steps with content hash-splat position :p1 | type_tracker.rb:30:1:30:21 | synthetic hash-splat argument |
 | type_tracker.rb:30:16:30:17 | :p2 | type tracker without call steps | type_tracker.rb:30:16:30:17 | :p2 |
 | type_tracker.rb:30:16:30:20 | Pair | type tracker without call steps | type_tracker.rb:30:16:30:20 | Pair |
 | type_tracker.rb:30:20:30:20 | 4 | type tracker with call steps | type_tracker.rb:25:18:25:19 | p2 |
-| type_tracker.rb:30:20:30:20 | 4 | type tracker with call steps with content element 0 | type_tracker.rb:27:5:27:11 | * |
-| type_tracker.rb:30:20:30:20 | 4 | type tracker with call steps with content element :p2 | type_tracker.rb:25:1:28:3 | **kwargs |
+| type_tracker.rb:30:20:30:20 | 4 | type tracker with call steps with content hash-splat position :p2 | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
+| type_tracker.rb:30:20:30:20 | 4 | type tracker with call steps with content splat position 0 | type_tracker.rb:27:5:27:11 | synthetic splat argument |
 | type_tracker.rb:30:20:30:20 | 4 | type tracker without call steps | type_tracker.rb:30:20:30:20 | 4 |
-| type_tracker.rb:30:20:30:20 | 4 | type tracker without call steps with content element :p2 | type_tracker.rb:30:1:30:21 | ** |
-| type_tracker.rb:31:1:31:21 | ** | type tracker with call steps | type_tracker.rb:25:1:28:3 | **kwargs |
-| type_tracker.rb:31:1:31:21 | ** | type tracker without call steps | type_tracker.rb:31:1:31:21 | ** |
+| type_tracker.rb:30:20:30:20 | 4 | type tracker without call steps with content hash-splat position :p2 | type_tracker.rb:30:1:30:21 | synthetic hash-splat argument |
 | type_tracker.rb:31:1:31:21 | call to keyword | type tracker without call steps | type_tracker.rb:31:1:31:21 | call to keyword |
+| type_tracker.rb:31:1:31:21 | synthetic hash-splat argument | type tracker with call steps | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
+| type_tracker.rb:31:1:31:21 | synthetic hash-splat argument | type tracker without call steps | type_tracker.rb:31:1:31:21 | synthetic hash-splat argument |
 | type_tracker.rb:31:9:31:10 | :p2 | type tracker without call steps | type_tracker.rb:31:9:31:10 | :p2 |
 | type_tracker.rb:31:9:31:13 | Pair | type tracker without call steps | type_tracker.rb:31:9:31:13 | Pair |
 | type_tracker.rb:31:13:31:13 | 5 | type tracker with call steps | type_tracker.rb:25:18:25:19 | p2 |
-| type_tracker.rb:31:13:31:13 | 5 | type tracker with call steps with content element 0 | type_tracker.rb:27:5:27:11 | * |
-| type_tracker.rb:31:13:31:13 | 5 | type tracker with call steps with content element :p2 | type_tracker.rb:25:1:28:3 | **kwargs |
+| type_tracker.rb:31:13:31:13 | 5 | type tracker with call steps with content hash-splat position :p2 | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
+| type_tracker.rb:31:13:31:13 | 5 | type tracker with call steps with content splat position 0 | type_tracker.rb:27:5:27:11 | synthetic splat argument |
 | type_tracker.rb:31:13:31:13 | 5 | type tracker without call steps | type_tracker.rb:31:13:31:13 | 5 |
-| type_tracker.rb:31:13:31:13 | 5 | type tracker without call steps with content element :p2 | type_tracker.rb:31:1:31:21 | ** |
+| type_tracker.rb:31:13:31:13 | 5 | type tracker without call steps with content hash-splat position :p2 | type_tracker.rb:31:1:31:21 | synthetic hash-splat argument |
 | type_tracker.rb:31:16:31:17 | :p1 | type tracker without call steps | type_tracker.rb:31:16:31:17 | :p1 |
 | type_tracker.rb:31:16:31:20 | Pair | type tracker without call steps | type_tracker.rb:31:16:31:20 | Pair |
 | type_tracker.rb:31:20:31:20 | 6 | type tracker with call steps | type_tracker.rb:25:13:25:14 | p1 |
-| type_tracker.rb:31:20:31:20 | 6 | type tracker with call steps with content element 0 | type_tracker.rb:26:5:26:11 | * |
-| type_tracker.rb:31:20:31:20 | 6 | type tracker with call steps with content element :p1 | type_tracker.rb:25:1:28:3 | **kwargs |
+| type_tracker.rb:31:20:31:20 | 6 | type tracker with call steps with content hash-splat position :p1 | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
+| type_tracker.rb:31:20:31:20 | 6 | type tracker with call steps with content splat position 0 | type_tracker.rb:26:5:26:11 | synthetic splat argument |
 | type_tracker.rb:31:20:31:20 | 6 | type tracker without call steps | type_tracker.rb:31:20:31:20 | 6 |
-| type_tracker.rb:31:20:31:20 | 6 | type tracker without call steps with content element :p1 | type_tracker.rb:31:1:31:21 | ** |
-| type_tracker.rb:32:1:32:27 | ** | type tracker with call steps | type_tracker.rb:25:1:28:3 | **kwargs |
-| type_tracker.rb:32:1:32:27 | ** | type tracker without call steps | type_tracker.rb:32:1:32:27 | ** |
+| type_tracker.rb:31:20:31:20 | 6 | type tracker without call steps with content hash-splat position :p1 | type_tracker.rb:31:1:31:21 | synthetic hash-splat argument |
 | type_tracker.rb:32:1:32:27 | call to keyword | type tracker without call steps | type_tracker.rb:32:1:32:27 | call to keyword |
+| type_tracker.rb:32:1:32:27 | synthetic hash-splat argument | type tracker with call steps | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
+| type_tracker.rb:32:1:32:27 | synthetic hash-splat argument | type tracker without call steps | type_tracker.rb:32:1:32:27 | synthetic hash-splat argument |
 | type_tracker.rb:32:9:32:11 | :p2 | type tracker without call steps | type_tracker.rb:32:9:32:11 | :p2 |
 | type_tracker.rb:32:9:32:16 | Pair | type tracker without call steps | type_tracker.rb:32:9:32:16 | Pair |
 | type_tracker.rb:32:16:32:16 | 7 | type tracker with call steps | type_tracker.rb:25:18:25:19 | p2 |
-| type_tracker.rb:32:16:32:16 | 7 | type tracker with call steps with content element 0 | type_tracker.rb:27:5:27:11 | * |
-| type_tracker.rb:32:16:32:16 | 7 | type tracker with call steps with content element :p2 | type_tracker.rb:25:1:28:3 | **kwargs |
+| type_tracker.rb:32:16:32:16 | 7 | type tracker with call steps with content hash-splat position :p2 | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
+| type_tracker.rb:32:16:32:16 | 7 | type tracker with call steps with content splat position 0 | type_tracker.rb:27:5:27:11 | synthetic splat argument |
 | type_tracker.rb:32:16:32:16 | 7 | type tracker without call steps | type_tracker.rb:32:16:32:16 | 7 |
-| type_tracker.rb:32:16:32:16 | 7 | type tracker without call steps with content element :p2 | type_tracker.rb:32:1:32:27 | ** |
+| type_tracker.rb:32:16:32:16 | 7 | type tracker without call steps with content hash-splat position :p2 | type_tracker.rb:32:1:32:27 | synthetic hash-splat argument |
 | type_tracker.rb:32:19:32:21 | :p1 | type tracker without call steps | type_tracker.rb:32:19:32:21 | :p1 |
 | type_tracker.rb:32:19:32:26 | Pair | type tracker without call steps | type_tracker.rb:32:19:32:26 | Pair |
 | type_tracker.rb:32:26:32:26 | 8 | type tracker with call steps | type_tracker.rb:25:13:25:14 | p1 |
-| type_tracker.rb:32:26:32:26 | 8 | type tracker with call steps with content element 0 | type_tracker.rb:26:5:26:11 | * |
-| type_tracker.rb:32:26:32:26 | 8 | type tracker with call steps with content element :p1 | type_tracker.rb:25:1:28:3 | **kwargs |
+| type_tracker.rb:32:26:32:26 | 8 | type tracker with call steps with content hash-splat position :p1 | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
+| type_tracker.rb:32:26:32:26 | 8 | type tracker with call steps with content splat position 0 | type_tracker.rb:26:5:26:11 | synthetic splat argument |
 | type_tracker.rb:32:26:32:26 | 8 | type tracker without call steps | type_tracker.rb:32:26:32:26 | 8 |
-| type_tracker.rb:32:26:32:26 | 8 | type tracker without call steps with content element :p1 | type_tracker.rb:32:1:32:27 | ** |
+| type_tracker.rb:32:26:32:26 | 8 | type tracker without call steps with content hash-splat position :p1 | type_tracker.rb:32:1:32:27 | synthetic hash-splat argument |
 | type_tracker.rb:34:1:53:3 | &block | type tracker without call steps | type_tracker.rb:34:1:53:3 | &block |
 | type_tracker.rb:34:1:53:3 | self in throughArray | type tracker without call steps | type_tracker.rb:34:1:53:3 | self in throughArray |
-| type_tracker.rb:34:1:53:3 | synthetic *args | type tracker without call steps | type_tracker.rb:34:1:53:3 | synthetic *args |
+| type_tracker.rb:34:1:53:3 | synthetic splat parameter | type tracker without call steps | type_tracker.rb:34:1:53:3 | synthetic splat parameter |
 | type_tracker.rb:34:1:53:3 | throughArray | type tracker without call steps | type_tracker.rb:34:1:53:3 | throughArray |
 | type_tracker.rb:34:18:34:20 | obj | type tracker without call steps | type_tracker.rb:34:18:34:20 | obj |
 | type_tracker.rb:34:18:34:20 | obj | type tracker without call steps | type_tracker.rb:34:18:34:20 | obj |
@@ -165,164 +165,169 @@ track
 | type_tracker.rb:34:18:34:20 | obj | type tracker without call steps | type_tracker.rb:52:5:52:13 | ...[...] |
 | type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element | type_tracker.rb:38:13:38:25 | call to [] |
 | type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element | type_tracker.rb:50:14:50:26 | call to [] |
-| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element 0 | type_tracker.rb:35:11:35:15 | * |
-| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element 0 or unknown | type_tracker.rb:35:11:35:15 | call to [] |
+| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element 0 | type_tracker.rb:35:11:35:15 | call to [] |
+| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element 0 | type_tracker.rb:35:11:35:15 | synthetic splat argument |
 | type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element 0 or unknown | type_tracker.rb:42:14:42:26 | call to [] |
 | type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element 0 or unknown | type_tracker.rb:46:14:46:26 | call to [] |
-| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element 1 | type_tracker.rb:39:5:39:12 | * |
-| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element 1 | type_tracker.rb:43:5:43:13 | * |
-| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element 1 | type_tracker.rb:47:5:47:13 | * |
-| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element 1 | type_tracker.rb:51:5:51:13 | * |
+| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content splat position 1 | type_tracker.rb:39:5:39:12 | synthetic splat argument |
+| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content splat position 1 | type_tracker.rb:43:5:43:13 | synthetic splat argument |
+| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content splat position 1 | type_tracker.rb:47:5:47:13 | synthetic splat argument |
+| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content splat position 1 | type_tracker.rb:51:5:51:13 | synthetic splat argument |
 | type_tracker.rb:34:23:34:23 | y | type tracker without call steps | type_tracker.rb:34:23:34:23 | y |
 | type_tracker.rb:34:23:34:23 | y | type tracker without call steps | type_tracker.rb:34:23:34:23 | y |
-| type_tracker.rb:34:23:34:23 | y | type tracker without call steps with content element 0 | type_tracker.rb:39:5:39:12 | * |
-| type_tracker.rb:34:23:34:23 | y | type tracker without call steps with content element 0 | type_tracker.rb:44:5:44:13 | * |
-| type_tracker.rb:34:23:34:23 | y | type tracker without call steps with content element 0 | type_tracker.rb:51:5:51:13 | * |
+| type_tracker.rb:34:23:34:23 | y | type tracker without call steps with content splat position 0 | type_tracker.rb:39:5:39:12 | synthetic splat argument |
+| type_tracker.rb:34:23:34:23 | y | type tracker without call steps with content splat position 0 | type_tracker.rb:44:5:44:13 | synthetic splat argument |
+| type_tracker.rb:34:23:34:23 | y | type tracker without call steps with content splat position 0 | type_tracker.rb:51:5:51:13 | synthetic splat argument |
 | type_tracker.rb:34:26:34:26 | z | type tracker without call steps | type_tracker.rb:34:26:34:26 | z |
 | type_tracker.rb:34:26:34:26 | z | type tracker without call steps | type_tracker.rb:34:26:34:26 | z |
-| type_tracker.rb:34:26:34:26 | z | type tracker without call steps with content element 0 | type_tracker.rb:52:5:52:13 | * |
+| type_tracker.rb:34:26:34:26 | z | type tracker without call steps with content splat position 0 | type_tracker.rb:52:5:52:13 | synthetic splat argument |
 | type_tracker.rb:35:5:35:7 | tmp | type tracker without call steps | type_tracker.rb:35:5:35:7 | tmp |
-| type_tracker.rb:35:11:35:15 | * | type tracker without call steps | type_tracker.rb:35:11:35:15 | * |
 | type_tracker.rb:35:11:35:15 | Array | type tracker without call steps | type_tracker.rb:35:11:35:15 | Array |
 | type_tracker.rb:35:11:35:15 | call to [] | type tracker without call steps | type_tracker.rb:35:11:35:15 | call to [] |
-| type_tracker.rb:36:5:36:10 | * | type tracker without call steps | type_tracker.rb:36:5:36:10 | * |
+| type_tracker.rb:35:11:35:15 | synthetic splat argument | type tracker without call steps | type_tracker.rb:35:11:35:15 | call to [] |
+| type_tracker.rb:35:11:35:15 | synthetic splat argument | type tracker without call steps | type_tracker.rb:35:11:35:15 | synthetic splat argument |
 | type_tracker.rb:36:5:36:10 | ...[...] | type tracker without call steps | type_tracker.rb:36:5:36:10 | ...[...] |
+| type_tracker.rb:36:5:36:10 | synthetic splat argument | type tracker without call steps | type_tracker.rb:36:5:36:10 | synthetic splat argument |
 | type_tracker.rb:36:9:36:9 | 0 | type tracker without call steps | type_tracker.rb:36:9:36:9 | 0 |
-| type_tracker.rb:36:9:36:9 | 0 | type tracker without call steps with content element 0 | type_tracker.rb:36:5:36:10 | * |
+| type_tracker.rb:36:9:36:9 | 0 | type tracker without call steps with content splat position 0 | type_tracker.rb:36:5:36:10 | synthetic splat argument |
 | type_tracker.rb:38:5:38:9 | array | type tracker without call steps | type_tracker.rb:38:5:38:9 | array |
-| type_tracker.rb:38:13:38:25 | * | type tracker without call steps | type_tracker.rb:38:13:38:25 | * |
 | type_tracker.rb:38:13:38:25 | Array | type tracker without call steps | type_tracker.rb:38:13:38:25 | Array |
 | type_tracker.rb:38:13:38:25 | call to [] | type tracker without call steps | type_tracker.rb:38:13:38:25 | call to [] |
+| type_tracker.rb:38:13:38:25 | synthetic splat argument | type tracker without call steps | type_tracker.rb:38:13:38:25 | call to [] |
+| type_tracker.rb:38:13:38:25 | synthetic splat argument | type tracker without call steps | type_tracker.rb:38:13:38:25 | synthetic splat argument |
 | type_tracker.rb:38:14:38:14 | 1 | type tracker without call steps | type_tracker.rb:38:14:38:14 | 1 |
 | type_tracker.rb:38:14:38:14 | 1 | type tracker without call steps | type_tracker.rb:40:5:40:12 | ...[...] |
-| type_tracker.rb:38:14:38:14 | 1 | type tracker without call steps with content element 0 | type_tracker.rb:38:13:38:25 | * |
-| type_tracker.rb:38:14:38:14 | 1 | type tracker without call steps with content element 0 or unknown | type_tracker.rb:38:13:38:25 | call to [] |
+| type_tracker.rb:38:14:38:14 | 1 | type tracker without call steps with content element 0 | type_tracker.rb:38:13:38:25 | call to [] |
+| type_tracker.rb:38:14:38:14 | 1 | type tracker without call steps with content element 0 | type_tracker.rb:38:13:38:25 | synthetic splat argument |
 | type_tracker.rb:38:16:38:16 | 2 | type tracker without call steps | type_tracker.rb:38:16:38:16 | 2 |
-| type_tracker.rb:38:16:38:16 | 2 | type tracker without call steps with content element 1 | type_tracker.rb:38:13:38:25 | * |
-| type_tracker.rb:38:16:38:16 | 2 | type tracker without call steps with content element 1 or unknown | type_tracker.rb:38:13:38:25 | call to [] |
+| type_tracker.rb:38:16:38:16 | 2 | type tracker without call steps with content element 1 | type_tracker.rb:38:13:38:25 | call to [] |
+| type_tracker.rb:38:16:38:16 | 2 | type tracker without call steps with content element 1 | type_tracker.rb:38:13:38:25 | synthetic splat argument |
 | type_tracker.rb:38:18:38:18 | 3 | type tracker without call steps | type_tracker.rb:38:18:38:18 | 3 |
-| type_tracker.rb:38:18:38:18 | 3 | type tracker without call steps with content element 2 | type_tracker.rb:38:13:38:25 | * |
-| type_tracker.rb:38:18:38:18 | 3 | type tracker without call steps with content element 2 or unknown | type_tracker.rb:38:13:38:25 | call to [] |
+| type_tracker.rb:38:18:38:18 | 3 | type tracker without call steps with content element 2 | type_tracker.rb:38:13:38:25 | call to [] |
+| type_tracker.rb:38:18:38:18 | 3 | type tracker without call steps with content element 2 | type_tracker.rb:38:13:38:25 | synthetic splat argument |
 | type_tracker.rb:38:20:38:20 | 4 | type tracker without call steps | type_tracker.rb:38:20:38:20 | 4 |
-| type_tracker.rb:38:20:38:20 | 4 | type tracker without call steps with content element 3 | type_tracker.rb:38:13:38:25 | * |
-| type_tracker.rb:38:20:38:20 | 4 | type tracker without call steps with content element 3 or unknown | type_tracker.rb:38:13:38:25 | call to [] |
+| type_tracker.rb:38:20:38:20 | 4 | type tracker without call steps with content element 3 | type_tracker.rb:38:13:38:25 | call to [] |
+| type_tracker.rb:38:20:38:20 | 4 | type tracker without call steps with content element 3 | type_tracker.rb:38:13:38:25 | synthetic splat argument |
 | type_tracker.rb:38:22:38:22 | 5 | type tracker without call steps | type_tracker.rb:38:22:38:22 | 5 |
-| type_tracker.rb:38:22:38:22 | 5 | type tracker without call steps with content element 4 | type_tracker.rb:38:13:38:25 | * |
-| type_tracker.rb:38:22:38:22 | 5 | type tracker without call steps with content element 4 or unknown | type_tracker.rb:38:13:38:25 | call to [] |
+| type_tracker.rb:38:22:38:22 | 5 | type tracker without call steps with content element 4 | type_tracker.rb:38:13:38:25 | call to [] |
+| type_tracker.rb:38:22:38:22 | 5 | type tracker without call steps with content element 4 | type_tracker.rb:38:13:38:25 | synthetic splat argument |
 | type_tracker.rb:38:24:38:24 | 6 | type tracker without call steps | type_tracker.rb:38:24:38:24 | 6 |
-| type_tracker.rb:38:24:38:24 | 6 | type tracker without call steps with content element 5 | type_tracker.rb:38:13:38:25 | * |
-| type_tracker.rb:38:24:38:24 | 6 | type tracker without call steps with content element 5 or unknown | type_tracker.rb:38:13:38:25 | call to [] |
+| type_tracker.rb:38:24:38:24 | 6 | type tracker without call steps with content element 5 | type_tracker.rb:38:13:38:25 | call to [] |
+| type_tracker.rb:38:24:38:24 | 6 | type tracker without call steps with content element 5 | type_tracker.rb:38:13:38:25 | synthetic splat argument |
 | type_tracker.rb:39:5:39:9 | [post] array | type tracker without call steps | type_tracker.rb:39:5:39:9 | [post] array |
-| type_tracker.rb:39:5:39:12 | * | type tracker without call steps | type_tracker.rb:39:5:39:12 | * |
 | type_tracker.rb:39:5:39:12 | call to []= | type tracker without call steps | type_tracker.rb:39:5:39:12 | call to []= |
+| type_tracker.rb:39:5:39:12 | synthetic splat argument | type tracker without call steps | type_tracker.rb:39:5:39:12 | synthetic splat argument |
 | type_tracker.rb:39:16:39:18 | __synth__0 | type tracker without call steps | type_tracker.rb:39:16:39:18 | __synth__0 |
-| type_tracker.rb:40:5:40:12 | * | type tracker without call steps | type_tracker.rb:40:5:40:12 | * |
 | type_tracker.rb:40:5:40:12 | ...[...] | type tracker without call steps | type_tracker.rb:40:5:40:12 | ...[...] |
+| type_tracker.rb:40:5:40:12 | synthetic splat argument | type tracker without call steps | type_tracker.rb:40:5:40:12 | synthetic splat argument |
 | type_tracker.rb:40:11:40:11 | 0 | type tracker without call steps | type_tracker.rb:40:11:40:11 | 0 |
-| type_tracker.rb:40:11:40:11 | 0 | type tracker without call steps with content element 0 | type_tracker.rb:40:5:40:12 | * |
+| type_tracker.rb:40:11:40:11 | 0 | type tracker without call steps with content splat position 0 | type_tracker.rb:40:5:40:12 | synthetic splat argument |
 | type_tracker.rb:42:5:42:10 | array2 | type tracker without call steps | type_tracker.rb:42:5:42:10 | array2 |
-| type_tracker.rb:42:14:42:26 | * | type tracker without call steps | type_tracker.rb:42:14:42:26 | * |
 | type_tracker.rb:42:14:42:26 | Array | type tracker without call steps | type_tracker.rb:42:14:42:26 | Array |
 | type_tracker.rb:42:14:42:26 | call to [] | type tracker without call steps | type_tracker.rb:42:14:42:26 | call to [] |
+| type_tracker.rb:42:14:42:26 | synthetic splat argument | type tracker without call steps | type_tracker.rb:42:14:42:26 | call to [] |
+| type_tracker.rb:42:14:42:26 | synthetic splat argument | type tracker without call steps | type_tracker.rb:42:14:42:26 | synthetic splat argument |
 | type_tracker.rb:42:15:42:15 | 1 | type tracker without call steps | type_tracker.rb:42:15:42:15 | 1 |
 | type_tracker.rb:42:15:42:15 | 1 | type tracker without call steps | type_tracker.rb:44:5:44:13 | ...[...] |
-| type_tracker.rb:42:15:42:15 | 1 | type tracker without call steps with content element 0 | type_tracker.rb:42:14:42:26 | * |
-| type_tracker.rb:42:15:42:15 | 1 | type tracker without call steps with content element 0 or unknown | type_tracker.rb:42:14:42:26 | call to [] |
+| type_tracker.rb:42:15:42:15 | 1 | type tracker without call steps with content element 0 | type_tracker.rb:42:14:42:26 | call to [] |
+| type_tracker.rb:42:15:42:15 | 1 | type tracker without call steps with content element 0 | type_tracker.rb:42:14:42:26 | synthetic splat argument |
 | type_tracker.rb:42:17:42:17 | 2 | type tracker without call steps | type_tracker.rb:42:17:42:17 | 2 |
 | type_tracker.rb:42:17:42:17 | 2 | type tracker without call steps | type_tracker.rb:44:5:44:13 | ...[...] |
-| type_tracker.rb:42:17:42:17 | 2 | type tracker without call steps with content element 1 | type_tracker.rb:42:14:42:26 | * |
-| type_tracker.rb:42:17:42:17 | 2 | type tracker without call steps with content element 1 or unknown | type_tracker.rb:42:14:42:26 | call to [] |
+| type_tracker.rb:42:17:42:17 | 2 | type tracker without call steps with content element 1 | type_tracker.rb:42:14:42:26 | call to [] |
+| type_tracker.rb:42:17:42:17 | 2 | type tracker without call steps with content element 1 | type_tracker.rb:42:14:42:26 | synthetic splat argument |
 | type_tracker.rb:42:19:42:19 | 3 | type tracker without call steps | type_tracker.rb:42:19:42:19 | 3 |
 | type_tracker.rb:42:19:42:19 | 3 | type tracker without call steps | type_tracker.rb:44:5:44:13 | ...[...] |
-| type_tracker.rb:42:19:42:19 | 3 | type tracker without call steps with content element 2 | type_tracker.rb:42:14:42:26 | * |
-| type_tracker.rb:42:19:42:19 | 3 | type tracker without call steps with content element 2 or unknown | type_tracker.rb:42:14:42:26 | call to [] |
+| type_tracker.rb:42:19:42:19 | 3 | type tracker without call steps with content element 2 | type_tracker.rb:42:14:42:26 | call to [] |
+| type_tracker.rb:42:19:42:19 | 3 | type tracker without call steps with content element 2 | type_tracker.rb:42:14:42:26 | synthetic splat argument |
 | type_tracker.rb:42:21:42:21 | 4 | type tracker without call steps | type_tracker.rb:42:21:42:21 | 4 |
 | type_tracker.rb:42:21:42:21 | 4 | type tracker without call steps | type_tracker.rb:44:5:44:13 | ...[...] |
-| type_tracker.rb:42:21:42:21 | 4 | type tracker without call steps with content element 3 | type_tracker.rb:42:14:42:26 | * |
-| type_tracker.rb:42:21:42:21 | 4 | type tracker without call steps with content element 3 or unknown | type_tracker.rb:42:14:42:26 | call to [] |
+| type_tracker.rb:42:21:42:21 | 4 | type tracker without call steps with content element 3 | type_tracker.rb:42:14:42:26 | call to [] |
+| type_tracker.rb:42:21:42:21 | 4 | type tracker without call steps with content element 3 | type_tracker.rb:42:14:42:26 | synthetic splat argument |
 | type_tracker.rb:42:23:42:23 | 5 | type tracker without call steps | type_tracker.rb:42:23:42:23 | 5 |
 | type_tracker.rb:42:23:42:23 | 5 | type tracker without call steps | type_tracker.rb:44:5:44:13 | ...[...] |
-| type_tracker.rb:42:23:42:23 | 5 | type tracker without call steps with content element 4 | type_tracker.rb:42:14:42:26 | * |
-| type_tracker.rb:42:23:42:23 | 5 | type tracker without call steps with content element 4 or unknown | type_tracker.rb:42:14:42:26 | call to [] |
+| type_tracker.rb:42:23:42:23 | 5 | type tracker without call steps with content element 4 | type_tracker.rb:42:14:42:26 | call to [] |
+| type_tracker.rb:42:23:42:23 | 5 | type tracker without call steps with content element 4 | type_tracker.rb:42:14:42:26 | synthetic splat argument |
 | type_tracker.rb:42:25:42:25 | 6 | type tracker without call steps | type_tracker.rb:42:25:42:25 | 6 |
 | type_tracker.rb:42:25:42:25 | 6 | type tracker without call steps | type_tracker.rb:44:5:44:13 | ...[...] |
-| type_tracker.rb:42:25:42:25 | 6 | type tracker without call steps with content element 5 | type_tracker.rb:42:14:42:26 | * |
-| type_tracker.rb:42:25:42:25 | 6 | type tracker without call steps with content element 5 or unknown | type_tracker.rb:42:14:42:26 | call to [] |
+| type_tracker.rb:42:25:42:25 | 6 | type tracker without call steps with content element 5 | type_tracker.rb:42:14:42:26 | call to [] |
+| type_tracker.rb:42:25:42:25 | 6 | type tracker without call steps with content element 5 | type_tracker.rb:42:14:42:26 | synthetic splat argument |
 | type_tracker.rb:43:5:43:10 | [post] array2 | type tracker without call steps | type_tracker.rb:43:5:43:10 | [post] array2 |
-| type_tracker.rb:43:5:43:13 | * | type tracker without call steps | type_tracker.rb:43:5:43:13 | * |
 | type_tracker.rb:43:5:43:13 | call to []= | type tracker without call steps | type_tracker.rb:43:5:43:13 | call to []= |
+| type_tracker.rb:43:5:43:13 | synthetic splat argument | type tracker without call steps | type_tracker.rb:43:5:43:13 | synthetic splat argument |
 | type_tracker.rb:43:12:43:12 | 0 | type tracker without call steps | type_tracker.rb:43:12:43:12 | 0 |
-| type_tracker.rb:43:12:43:12 | 0 | type tracker without call steps with content element 0 | type_tracker.rb:43:5:43:13 | * |
+| type_tracker.rb:43:12:43:12 | 0 | type tracker without call steps with content splat position 0 | type_tracker.rb:43:5:43:13 | synthetic splat argument |
 | type_tracker.rb:43:17:43:19 | __synth__0 | type tracker without call steps | type_tracker.rb:43:17:43:19 | __synth__0 |
-| type_tracker.rb:44:5:44:13 | * | type tracker without call steps | type_tracker.rb:44:5:44:13 | * |
 | type_tracker.rb:44:5:44:13 | ...[...] | type tracker without call steps | type_tracker.rb:44:5:44:13 | ...[...] |
+| type_tracker.rb:44:5:44:13 | synthetic splat argument | type tracker without call steps | type_tracker.rb:44:5:44:13 | synthetic splat argument |
 | type_tracker.rb:46:5:46:10 | array3 | type tracker without call steps | type_tracker.rb:46:5:46:10 | array3 |
-| type_tracker.rb:46:14:46:26 | * | type tracker without call steps | type_tracker.rb:46:14:46:26 | * |
 | type_tracker.rb:46:14:46:26 | Array | type tracker without call steps | type_tracker.rb:46:14:46:26 | Array |
 | type_tracker.rb:46:14:46:26 | call to [] | type tracker without call steps | type_tracker.rb:46:14:46:26 | call to [] |
+| type_tracker.rb:46:14:46:26 | synthetic splat argument | type tracker without call steps | type_tracker.rb:46:14:46:26 | call to [] |
+| type_tracker.rb:46:14:46:26 | synthetic splat argument | type tracker without call steps | type_tracker.rb:46:14:46:26 | synthetic splat argument |
 | type_tracker.rb:46:15:46:15 | 1 | type tracker without call steps | type_tracker.rb:46:15:46:15 | 1 |
-| type_tracker.rb:46:15:46:15 | 1 | type tracker without call steps with content element 0 | type_tracker.rb:46:14:46:26 | * |
-| type_tracker.rb:46:15:46:15 | 1 | type tracker without call steps with content element 0 or unknown | type_tracker.rb:46:14:46:26 | call to [] |
+| type_tracker.rb:46:15:46:15 | 1 | type tracker without call steps with content element 0 | type_tracker.rb:46:14:46:26 | call to [] |
+| type_tracker.rb:46:15:46:15 | 1 | type tracker without call steps with content element 0 | type_tracker.rb:46:14:46:26 | synthetic splat argument |
 | type_tracker.rb:46:17:46:17 | 2 | type tracker without call steps | type_tracker.rb:46:17:46:17 | 2 |
 | type_tracker.rb:46:17:46:17 | 2 | type tracker without call steps | type_tracker.rb:48:5:48:13 | ...[...] |
-| type_tracker.rb:46:17:46:17 | 2 | type tracker without call steps with content element 1 | type_tracker.rb:46:14:46:26 | * |
-| type_tracker.rb:46:17:46:17 | 2 | type tracker without call steps with content element 1 or unknown | type_tracker.rb:46:14:46:26 | call to [] |
+| type_tracker.rb:46:17:46:17 | 2 | type tracker without call steps with content element 1 | type_tracker.rb:46:14:46:26 | call to [] |
+| type_tracker.rb:46:17:46:17 | 2 | type tracker without call steps with content element 1 | type_tracker.rb:46:14:46:26 | synthetic splat argument |
 | type_tracker.rb:46:19:46:19 | 3 | type tracker without call steps | type_tracker.rb:46:19:46:19 | 3 |
-| type_tracker.rb:46:19:46:19 | 3 | type tracker without call steps with content element 2 | type_tracker.rb:46:14:46:26 | * |
-| type_tracker.rb:46:19:46:19 | 3 | type tracker without call steps with content element 2 or unknown | type_tracker.rb:46:14:46:26 | call to [] |
+| type_tracker.rb:46:19:46:19 | 3 | type tracker without call steps with content element 2 | type_tracker.rb:46:14:46:26 | call to [] |
+| type_tracker.rb:46:19:46:19 | 3 | type tracker without call steps with content element 2 | type_tracker.rb:46:14:46:26 | synthetic splat argument |
 | type_tracker.rb:46:21:46:21 | 4 | type tracker without call steps | type_tracker.rb:46:21:46:21 | 4 |
-| type_tracker.rb:46:21:46:21 | 4 | type tracker without call steps with content element 3 | type_tracker.rb:46:14:46:26 | * |
-| type_tracker.rb:46:21:46:21 | 4 | type tracker without call steps with content element 3 or unknown | type_tracker.rb:46:14:46:26 | call to [] |
+| type_tracker.rb:46:21:46:21 | 4 | type tracker without call steps with content element 3 | type_tracker.rb:46:14:46:26 | call to [] |
+| type_tracker.rb:46:21:46:21 | 4 | type tracker without call steps with content element 3 | type_tracker.rb:46:14:46:26 | synthetic splat argument |
 | type_tracker.rb:46:23:46:23 | 5 | type tracker without call steps | type_tracker.rb:46:23:46:23 | 5 |
-| type_tracker.rb:46:23:46:23 | 5 | type tracker without call steps with content element 4 | type_tracker.rb:46:14:46:26 | * |
-| type_tracker.rb:46:23:46:23 | 5 | type tracker without call steps with content element 4 or unknown | type_tracker.rb:46:14:46:26 | call to [] |
+| type_tracker.rb:46:23:46:23 | 5 | type tracker without call steps with content element 4 | type_tracker.rb:46:14:46:26 | call to [] |
+| type_tracker.rb:46:23:46:23 | 5 | type tracker without call steps with content element 4 | type_tracker.rb:46:14:46:26 | synthetic splat argument |
 | type_tracker.rb:46:25:46:25 | 6 | type tracker without call steps | type_tracker.rb:46:25:46:25 | 6 |
-| type_tracker.rb:46:25:46:25 | 6 | type tracker without call steps with content element 5 | type_tracker.rb:46:14:46:26 | * |
-| type_tracker.rb:46:25:46:25 | 6 | type tracker without call steps with content element 5 or unknown | type_tracker.rb:46:14:46:26 | call to [] |
+| type_tracker.rb:46:25:46:25 | 6 | type tracker without call steps with content element 5 | type_tracker.rb:46:14:46:26 | call to [] |
+| type_tracker.rb:46:25:46:25 | 6 | type tracker without call steps with content element 5 | type_tracker.rb:46:14:46:26 | synthetic splat argument |
 | type_tracker.rb:47:5:47:10 | [post] array3 | type tracker without call steps | type_tracker.rb:47:5:47:10 | [post] array3 |
-| type_tracker.rb:47:5:47:13 | * | type tracker without call steps | type_tracker.rb:47:5:47:13 | * |
 | type_tracker.rb:47:5:47:13 | call to []= | type tracker without call steps | type_tracker.rb:47:5:47:13 | call to []= |
+| type_tracker.rb:47:5:47:13 | synthetic splat argument | type tracker without call steps | type_tracker.rb:47:5:47:13 | synthetic splat argument |
 | type_tracker.rb:47:12:47:12 | 0 | type tracker without call steps | type_tracker.rb:47:12:47:12 | 0 |
-| type_tracker.rb:47:12:47:12 | 0 | type tracker without call steps with content element 0 | type_tracker.rb:47:5:47:13 | * |
+| type_tracker.rb:47:12:47:12 | 0 | type tracker without call steps with content splat position 0 | type_tracker.rb:47:5:47:13 | synthetic splat argument |
 | type_tracker.rb:47:17:47:19 | __synth__0 | type tracker without call steps | type_tracker.rb:47:17:47:19 | __synth__0 |
-| type_tracker.rb:48:5:48:13 | * | type tracker without call steps | type_tracker.rb:48:5:48:13 | * |
 | type_tracker.rb:48:5:48:13 | ...[...] | type tracker without call steps | type_tracker.rb:48:5:48:13 | ...[...] |
+| type_tracker.rb:48:5:48:13 | synthetic splat argument | type tracker without call steps | type_tracker.rb:48:5:48:13 | synthetic splat argument |
 | type_tracker.rb:48:12:48:12 | 1 | type tracker without call steps | type_tracker.rb:48:12:48:12 | 1 |
-| type_tracker.rb:48:12:48:12 | 1 | type tracker without call steps with content element 0 | type_tracker.rb:48:5:48:13 | * |
+| type_tracker.rb:48:12:48:12 | 1 | type tracker without call steps with content splat position 0 | type_tracker.rb:48:5:48:13 | synthetic splat argument |
 | type_tracker.rb:50:5:50:10 | array4 | type tracker without call steps | type_tracker.rb:50:5:50:10 | array4 |
-| type_tracker.rb:50:14:50:26 | * | type tracker without call steps | type_tracker.rb:50:14:50:26 | * |
 | type_tracker.rb:50:14:50:26 | Array | type tracker without call steps | type_tracker.rb:50:14:50:26 | Array |
 | type_tracker.rb:50:14:50:26 | call to [] | type tracker without call steps | type_tracker.rb:50:14:50:26 | call to [] |
+| type_tracker.rb:50:14:50:26 | synthetic splat argument | type tracker without call steps | type_tracker.rb:50:14:50:26 | call to [] |
+| type_tracker.rb:50:14:50:26 | synthetic splat argument | type tracker without call steps | type_tracker.rb:50:14:50:26 | synthetic splat argument |
 | type_tracker.rb:50:15:50:15 | 1 | type tracker without call steps | type_tracker.rb:50:15:50:15 | 1 |
 | type_tracker.rb:50:15:50:15 | 1 | type tracker without call steps | type_tracker.rb:52:5:52:13 | ...[...] |
-| type_tracker.rb:50:15:50:15 | 1 | type tracker without call steps with content element 0 | type_tracker.rb:50:14:50:26 | * |
-| type_tracker.rb:50:15:50:15 | 1 | type tracker without call steps with content element 0 or unknown | type_tracker.rb:50:14:50:26 | call to [] |
+| type_tracker.rb:50:15:50:15 | 1 | type tracker without call steps with content element 0 | type_tracker.rb:50:14:50:26 | call to [] |
+| type_tracker.rb:50:15:50:15 | 1 | type tracker without call steps with content element 0 | type_tracker.rb:50:14:50:26 | synthetic splat argument |
 | type_tracker.rb:50:17:50:17 | 2 | type tracker without call steps | type_tracker.rb:50:17:50:17 | 2 |
 | type_tracker.rb:50:17:50:17 | 2 | type tracker without call steps | type_tracker.rb:52:5:52:13 | ...[...] |
-| type_tracker.rb:50:17:50:17 | 2 | type tracker without call steps with content element 1 | type_tracker.rb:50:14:50:26 | * |
-| type_tracker.rb:50:17:50:17 | 2 | type tracker without call steps with content element 1 or unknown | type_tracker.rb:50:14:50:26 | call to [] |
+| type_tracker.rb:50:17:50:17 | 2 | type tracker without call steps with content element 1 | type_tracker.rb:50:14:50:26 | call to [] |
+| type_tracker.rb:50:17:50:17 | 2 | type tracker without call steps with content element 1 | type_tracker.rb:50:14:50:26 | synthetic splat argument |
 | type_tracker.rb:50:19:50:19 | 3 | type tracker without call steps | type_tracker.rb:50:19:50:19 | 3 |
 | type_tracker.rb:50:19:50:19 | 3 | type tracker without call steps | type_tracker.rb:52:5:52:13 | ...[...] |
-| type_tracker.rb:50:19:50:19 | 3 | type tracker without call steps with content element 2 | type_tracker.rb:50:14:50:26 | * |
-| type_tracker.rb:50:19:50:19 | 3 | type tracker without call steps with content element 2 or unknown | type_tracker.rb:50:14:50:26 | call to [] |
+| type_tracker.rb:50:19:50:19 | 3 | type tracker without call steps with content element 2 | type_tracker.rb:50:14:50:26 | call to [] |
+| type_tracker.rb:50:19:50:19 | 3 | type tracker without call steps with content element 2 | type_tracker.rb:50:14:50:26 | synthetic splat argument |
 | type_tracker.rb:50:21:50:21 | 4 | type tracker without call steps | type_tracker.rb:50:21:50:21 | 4 |
 | type_tracker.rb:50:21:50:21 | 4 | type tracker without call steps | type_tracker.rb:52:5:52:13 | ...[...] |
-| type_tracker.rb:50:21:50:21 | 4 | type tracker without call steps with content element 3 | type_tracker.rb:50:14:50:26 | * |
-| type_tracker.rb:50:21:50:21 | 4 | type tracker without call steps with content element 3 or unknown | type_tracker.rb:50:14:50:26 | call to [] |
+| type_tracker.rb:50:21:50:21 | 4 | type tracker without call steps with content element 3 | type_tracker.rb:50:14:50:26 | call to [] |
+| type_tracker.rb:50:21:50:21 | 4 | type tracker without call steps with content element 3 | type_tracker.rb:50:14:50:26 | synthetic splat argument |
 | type_tracker.rb:50:23:50:23 | 5 | type tracker without call steps | type_tracker.rb:50:23:50:23 | 5 |
 | type_tracker.rb:50:23:50:23 | 5 | type tracker without call steps | type_tracker.rb:52:5:52:13 | ...[...] |
-| type_tracker.rb:50:23:50:23 | 5 | type tracker without call steps with content element 4 | type_tracker.rb:50:14:50:26 | * |
-| type_tracker.rb:50:23:50:23 | 5 | type tracker without call steps with content element 4 or unknown | type_tracker.rb:50:14:50:26 | call to [] |
+| type_tracker.rb:50:23:50:23 | 5 | type tracker without call steps with content element 4 | type_tracker.rb:50:14:50:26 | call to [] |
+| type_tracker.rb:50:23:50:23 | 5 | type tracker without call steps with content element 4 | type_tracker.rb:50:14:50:26 | synthetic splat argument |
 | type_tracker.rb:50:25:50:25 | 6 | type tracker without call steps | type_tracker.rb:50:25:50:25 | 6 |
 | type_tracker.rb:50:25:50:25 | 6 | type tracker without call steps | type_tracker.rb:52:5:52:13 | ...[...] |
-| type_tracker.rb:50:25:50:25 | 6 | type tracker without call steps with content element 5 | type_tracker.rb:50:14:50:26 | * |
-| type_tracker.rb:50:25:50:25 | 6 | type tracker without call steps with content element 5 or unknown | type_tracker.rb:50:14:50:26 | call to [] |
+| type_tracker.rb:50:25:50:25 | 6 | type tracker without call steps with content element 5 | type_tracker.rb:50:14:50:26 | call to [] |
+| type_tracker.rb:50:25:50:25 | 6 | type tracker without call steps with content element 5 | type_tracker.rb:50:14:50:26 | synthetic splat argument |
 | type_tracker.rb:51:5:51:10 | [post] array4 | type tracker without call steps | type_tracker.rb:51:5:51:10 | [post] array4 |
-| type_tracker.rb:51:5:51:13 | * | type tracker without call steps | type_tracker.rb:51:5:51:13 | * |
 | type_tracker.rb:51:5:51:13 | call to []= | type tracker without call steps | type_tracker.rb:51:5:51:13 | call to []= |
+| type_tracker.rb:51:5:51:13 | synthetic splat argument | type tracker without call steps | type_tracker.rb:51:5:51:13 | synthetic splat argument |
 | type_tracker.rb:51:17:51:19 | __synth__0 | type tracker without call steps | type_tracker.rb:51:17:51:19 | __synth__0 |
-| type_tracker.rb:52:5:52:13 | * | type tracker without call steps | type_tracker.rb:52:5:52:13 | * |
 | type_tracker.rb:52:5:52:13 | ...[...] | type tracker without call steps | type_tracker.rb:52:5:52:13 | ...[...] |
+| type_tracker.rb:52:5:52:13 | synthetic splat argument | type tracker without call steps | type_tracker.rb:52:5:52:13 | synthetic splat argument |
 trackEnd
 | type_tracker.rb:1:1:10:3 | self (Container) | type_tracker.rb:1:1:10:3 | self (Container) |
 | type_tracker.rb:1:1:53:4 | self (type_tracker.rb) | type_tracker.rb:1:1:53:4 | self (type_tracker.rb) |
@@ -348,7 +353,7 @@ trackEnd
 | type_tracker.rb:2:5:5:7 | self in field= | type_tracker.rb:7:5:9:7 | self (field) |
 | type_tracker.rb:2:5:5:7 | self in field= | type_tracker.rb:7:5:9:7 | self in field |
 | type_tracker.rb:2:5:5:7 | self in field= | type_tracker.rb:8:9:8:14 | self |
-| type_tracker.rb:2:5:5:7 | synthetic *args | type_tracker.rb:2:5:5:7 | synthetic *args |
+| type_tracker.rb:2:5:5:7 | synthetic splat parameter | type_tracker.rb:2:5:5:7 | synthetic splat parameter |
 | type_tracker.rb:2:16:2:18 | val | type_tracker.rb:2:16:2:18 | val |
 | type_tracker.rb:2:16:2:18 | val | type_tracker.rb:2:16:2:18 | val |
 | type_tracker.rb:2:16:2:18 | val | type_tracker.rb:2:16:2:18 | val |
@@ -358,8 +363,8 @@ trackEnd
 | type_tracker.rb:2:16:2:18 | val | type_tracker.rb:8:9:8:14 | @field |
 | type_tracker.rb:2:16:2:18 | val | type_tracker.rb:14:5:14:13 | call to field= |
 | type_tracker.rb:2:16:2:18 | val | type_tracker.rb:15:10:15:18 | call to field |
-| type_tracker.rb:3:9:3:23 | * | type_tracker.rb:3:9:3:23 | * |
 | type_tracker.rb:3:9:3:23 | call to puts | type_tracker.rb:3:9:3:23 | call to puts |
+| type_tracker.rb:3:9:3:23 | synthetic splat argument | type_tracker.rb:3:9:3:23 | synthetic splat argument |
 | type_tracker.rb:3:14:3:23 | call to field | type_tracker.rb:3:14:3:23 | call to field |
 | type_tracker.rb:4:9:4:14 | @field | type_tracker.rb:4:9:4:14 | @field |
 | type_tracker.rb:7:5:9:7 | &block | type_tracker.rb:7:5:9:7 | &block |
@@ -396,9 +401,9 @@ trackEnd
 | type_tracker.rb:14:5:14:7 | [post] var | type_tracker.rb:8:9:8:14 | self |
 | type_tracker.rb:14:5:14:7 | [post] var | type_tracker.rb:14:5:14:7 | [post] var |
 | type_tracker.rb:14:5:14:7 | [post] var | type_tracker.rb:15:10:15:12 | var |
-| type_tracker.rb:14:5:14:13 | * | type_tracker.rb:2:5:5:7 | synthetic *args |
-| type_tracker.rb:14:5:14:13 | * | type_tracker.rb:14:5:14:13 | * |
 | type_tracker.rb:14:5:14:13 | call to field= | type_tracker.rb:14:5:14:13 | call to field= |
+| type_tracker.rb:14:5:14:13 | synthetic splat argument | type_tracker.rb:2:5:5:7 | synthetic splat parameter |
+| type_tracker.rb:14:5:14:13 | synthetic splat argument | type_tracker.rb:14:5:14:13 | synthetic splat argument |
 | type_tracker.rb:14:17:14:23 | "hello" | type_tracker.rb:2:16:2:18 | val |
 | type_tracker.rb:14:17:14:23 | "hello" | type_tracker.rb:2:16:2:18 | val |
 | type_tracker.rb:14:17:14:23 | "hello" | type_tracker.rb:4:9:4:20 | ... = ... |
@@ -412,8 +417,8 @@ trackEnd
 | type_tracker.rb:14:17:14:23 | "hello" | type_tracker.rb:14:17:14:23 | __synth__0 |
 | type_tracker.rb:14:17:14:23 | "hello" | type_tracker.rb:15:10:15:18 | call to field |
 | type_tracker.rb:14:17:14:23 | __synth__0 | type_tracker.rb:14:17:14:23 | __synth__0 |
-| type_tracker.rb:15:5:15:18 | * | type_tracker.rb:15:5:15:18 | * |
 | type_tracker.rb:15:5:15:18 | call to puts | type_tracker.rb:15:5:15:18 | call to puts |
+| type_tracker.rb:15:5:15:18 | synthetic splat argument | type_tracker.rb:15:5:15:18 | synthetic splat argument |
 | type_tracker.rb:15:10:15:18 | call to field | type_tracker.rb:15:10:15:18 | call to field |
 | type_tracker.rb:18:1:21:3 | &block | type_tracker.rb:18:1:21:3 | &block |
 | type_tracker.rb:18:1:21:3 | positional | type_tracker.rb:18:1:21:3 | positional |
@@ -421,7 +426,7 @@ trackEnd
 | type_tracker.rb:18:1:21:3 | self in positional | type_tracker.rb:18:1:21:3 | self in positional |
 | type_tracker.rb:18:1:21:3 | self in positional | type_tracker.rb:19:5:19:11 | self |
 | type_tracker.rb:18:1:21:3 | self in positional | type_tracker.rb:20:5:20:11 | self |
-| type_tracker.rb:18:1:21:3 | synthetic *args | type_tracker.rb:18:1:21:3 | synthetic *args |
+| type_tracker.rb:18:1:21:3 | synthetic splat parameter | type_tracker.rb:18:1:21:3 | synthetic splat parameter |
 | type_tracker.rb:18:16:18:17 | p1 | type_tracker.rb:18:16:18:17 | p1 |
 | type_tracker.rb:18:16:18:17 | p1 | type_tracker.rb:18:16:18:17 | p1 |
 | type_tracker.rb:18:16:18:17 | p1 | type_tracker.rb:18:16:18:17 | p1 |
@@ -430,14 +435,14 @@ trackEnd
 | type_tracker.rb:18:20:18:21 | p2 | type_tracker.rb:18:20:18:21 | p2 |
 | type_tracker.rb:18:20:18:21 | p2 | type_tracker.rb:18:20:18:21 | p2 |
 | type_tracker.rb:18:20:18:21 | p2 | type_tracker.rb:20:10:20:11 | p2 |
-| type_tracker.rb:19:5:19:11 | * | type_tracker.rb:19:5:19:11 | * |
 | type_tracker.rb:19:5:19:11 | call to puts | type_tracker.rb:19:5:19:11 | call to puts |
-| type_tracker.rb:20:5:20:11 | * | type_tracker.rb:20:5:20:11 | * |
+| type_tracker.rb:19:5:19:11 | synthetic splat argument | type_tracker.rb:19:5:19:11 | synthetic splat argument |
 | type_tracker.rb:20:5:20:11 | call to puts | type_tracker.rb:20:5:20:11 | call to puts |
 | type_tracker.rb:20:5:20:11 | call to puts | type_tracker.rb:23:1:23:16 | call to positional |
-| type_tracker.rb:23:1:23:16 | * | type_tracker.rb:18:1:21:3 | synthetic *args |
-| type_tracker.rb:23:1:23:16 | * | type_tracker.rb:23:1:23:16 | * |
+| type_tracker.rb:20:5:20:11 | synthetic splat argument | type_tracker.rb:20:5:20:11 | synthetic splat argument |
 | type_tracker.rb:23:1:23:16 | call to positional | type_tracker.rb:23:1:23:16 | call to positional |
+| type_tracker.rb:23:1:23:16 | synthetic splat argument | type_tracker.rb:18:1:21:3 | synthetic splat parameter |
+| type_tracker.rb:23:1:23:16 | synthetic splat argument | type_tracker.rb:23:1:23:16 | synthetic splat argument |
 | type_tracker.rb:23:12:23:12 | 1 | type_tracker.rb:18:16:18:17 | p1 |
 | type_tracker.rb:23:12:23:12 | 1 | type_tracker.rb:18:16:18:17 | p1 |
 | type_tracker.rb:23:12:23:12 | 1 | type_tracker.rb:19:10:19:11 | p1 |
@@ -447,12 +452,12 @@ trackEnd
 | type_tracker.rb:23:15:23:15 | 2 | type_tracker.rb:20:10:20:11 | p2 |
 | type_tracker.rb:23:15:23:15 | 2 | type_tracker.rb:23:15:23:15 | 2 |
 | type_tracker.rb:25:1:28:3 | &block | type_tracker.rb:25:1:28:3 | &block |
-| type_tracker.rb:25:1:28:3 | **kwargs | type_tracker.rb:25:1:28:3 | **kwargs |
 | type_tracker.rb:25:1:28:3 | keyword | type_tracker.rb:25:1:28:3 | keyword |
 | type_tracker.rb:25:1:28:3 | self in keyword | type_tracker.rb:25:1:28:3 | self (keyword) |
 | type_tracker.rb:25:1:28:3 | self in keyword | type_tracker.rb:25:1:28:3 | self in keyword |
 | type_tracker.rb:25:1:28:3 | self in keyword | type_tracker.rb:26:5:26:11 | self |
 | type_tracker.rb:25:1:28:3 | self in keyword | type_tracker.rb:27:5:27:11 | self |
+| type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
 | type_tracker.rb:25:13:25:14 | p1 | type_tracker.rb:25:13:25:14 | p1 |
 | type_tracker.rb:25:13:25:14 | p1 | type_tracker.rb:25:13:25:14 | p1 |
 | type_tracker.rb:25:13:25:14 | p1 | type_tracker.rb:25:13:25:14 | p1 |
@@ -461,16 +466,16 @@ trackEnd
 | type_tracker.rb:25:18:25:19 | p2 | type_tracker.rb:25:18:25:19 | p2 |
 | type_tracker.rb:25:18:25:19 | p2 | type_tracker.rb:25:18:25:19 | p2 |
 | type_tracker.rb:25:18:25:19 | p2 | type_tracker.rb:27:10:27:11 | p2 |
-| type_tracker.rb:26:5:26:11 | * | type_tracker.rb:26:5:26:11 | * |
 | type_tracker.rb:26:5:26:11 | call to puts | type_tracker.rb:26:5:26:11 | call to puts |
-| type_tracker.rb:27:5:27:11 | * | type_tracker.rb:27:5:27:11 | * |
+| type_tracker.rb:26:5:26:11 | synthetic splat argument | type_tracker.rb:26:5:26:11 | synthetic splat argument |
 | type_tracker.rb:27:5:27:11 | call to puts | type_tracker.rb:27:5:27:11 | call to puts |
 | type_tracker.rb:27:5:27:11 | call to puts | type_tracker.rb:30:1:30:21 | call to keyword |
 | type_tracker.rb:27:5:27:11 | call to puts | type_tracker.rb:31:1:31:21 | call to keyword |
 | type_tracker.rb:27:5:27:11 | call to puts | type_tracker.rb:32:1:32:27 | call to keyword |
-| type_tracker.rb:30:1:30:21 | ** | type_tracker.rb:25:1:28:3 | **kwargs |
-| type_tracker.rb:30:1:30:21 | ** | type_tracker.rb:30:1:30:21 | ** |
+| type_tracker.rb:27:5:27:11 | synthetic splat argument | type_tracker.rb:27:5:27:11 | synthetic splat argument |
 | type_tracker.rb:30:1:30:21 | call to keyword | type_tracker.rb:30:1:30:21 | call to keyword |
+| type_tracker.rb:30:1:30:21 | synthetic hash-splat argument | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
+| type_tracker.rb:30:1:30:21 | synthetic hash-splat argument | type_tracker.rb:30:1:30:21 | synthetic hash-splat argument |
 | type_tracker.rb:30:9:30:10 | :p1 | type_tracker.rb:30:9:30:10 | :p1 |
 | type_tracker.rb:30:9:30:13 | Pair | type_tracker.rb:30:9:30:13 | Pair |
 | type_tracker.rb:30:13:30:13 | 3 | type_tracker.rb:25:13:25:14 | p1 |
@@ -483,9 +488,9 @@ trackEnd
 | type_tracker.rb:30:20:30:20 | 4 | type_tracker.rb:25:18:25:19 | p2 |
 | type_tracker.rb:30:20:30:20 | 4 | type_tracker.rb:27:10:27:11 | p2 |
 | type_tracker.rb:30:20:30:20 | 4 | type_tracker.rb:30:20:30:20 | 4 |
-| type_tracker.rb:31:1:31:21 | ** | type_tracker.rb:25:1:28:3 | **kwargs |
-| type_tracker.rb:31:1:31:21 | ** | type_tracker.rb:31:1:31:21 | ** |
 | type_tracker.rb:31:1:31:21 | call to keyword | type_tracker.rb:31:1:31:21 | call to keyword |
+| type_tracker.rb:31:1:31:21 | synthetic hash-splat argument | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
+| type_tracker.rb:31:1:31:21 | synthetic hash-splat argument | type_tracker.rb:31:1:31:21 | synthetic hash-splat argument |
 | type_tracker.rb:31:9:31:10 | :p2 | type_tracker.rb:31:9:31:10 | :p2 |
 | type_tracker.rb:31:9:31:13 | Pair | type_tracker.rb:31:9:31:13 | Pair |
 | type_tracker.rb:31:13:31:13 | 5 | type_tracker.rb:25:18:25:19 | p2 |
@@ -498,9 +503,9 @@ trackEnd
 | type_tracker.rb:31:20:31:20 | 6 | type_tracker.rb:25:13:25:14 | p1 |
 | type_tracker.rb:31:20:31:20 | 6 | type_tracker.rb:26:10:26:11 | p1 |
 | type_tracker.rb:31:20:31:20 | 6 | type_tracker.rb:31:20:31:20 | 6 |
-| type_tracker.rb:32:1:32:27 | ** | type_tracker.rb:25:1:28:3 | **kwargs |
-| type_tracker.rb:32:1:32:27 | ** | type_tracker.rb:32:1:32:27 | ** |
 | type_tracker.rb:32:1:32:27 | call to keyword | type_tracker.rb:32:1:32:27 | call to keyword |
+| type_tracker.rb:32:1:32:27 | synthetic hash-splat argument | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
+| type_tracker.rb:32:1:32:27 | synthetic hash-splat argument | type_tracker.rb:32:1:32:27 | synthetic hash-splat argument |
 | type_tracker.rb:32:9:32:11 | :p2 | type_tracker.rb:32:9:32:11 | :p2 |
 | type_tracker.rb:32:9:32:16 | Pair | type_tracker.rb:32:9:32:16 | Pair |
 | type_tracker.rb:32:16:32:16 | 7 | type_tracker.rb:25:18:25:19 | p2 |
@@ -515,7 +520,7 @@ trackEnd
 | type_tracker.rb:32:26:32:26 | 8 | type_tracker.rb:32:26:32:26 | 8 |
 | type_tracker.rb:34:1:53:3 | &block | type_tracker.rb:34:1:53:3 | &block |
 | type_tracker.rb:34:1:53:3 | self in throughArray | type_tracker.rb:34:1:53:3 | self in throughArray |
-| type_tracker.rb:34:1:53:3 | synthetic *args | type_tracker.rb:34:1:53:3 | synthetic *args |
+| type_tracker.rb:34:1:53:3 | synthetic splat parameter | type_tracker.rb:34:1:53:3 | synthetic splat parameter |
 | type_tracker.rb:34:1:53:3 | throughArray | type_tracker.rb:34:1:53:3 | throughArray |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:34:18:34:20 | obj |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:34:18:34:20 | obj |
@@ -556,23 +561,32 @@ trackEnd
 | type_tracker.rb:34:26:34:26 | z | type_tracker.rb:34:26:34:26 | z |
 | type_tracker.rb:34:26:34:26 | z | type_tracker.rb:52:12:52:12 | z |
 | type_tracker.rb:35:5:35:7 | tmp | type_tracker.rb:35:5:35:7 | tmp |
-| type_tracker.rb:35:11:35:15 | * | type_tracker.rb:35:11:35:15 | * |
 | type_tracker.rb:35:11:35:15 | Array | type_tracker.rb:35:11:35:15 | Array |
 | type_tracker.rb:35:11:35:15 | call to [] | type_tracker.rb:35:5:35:7 | tmp |
 | type_tracker.rb:35:11:35:15 | call to [] | type_tracker.rb:35:5:35:15 | ... = ... |
 | type_tracker.rb:35:11:35:15 | call to [] | type_tracker.rb:35:11:35:15 | call to [] |
 | type_tracker.rb:35:11:35:15 | call to [] | type_tracker.rb:36:5:36:7 | tmp |
-| type_tracker.rb:36:5:36:10 | * | type_tracker.rb:36:5:36:10 | * |
+| type_tracker.rb:35:11:35:15 | synthetic splat argument | type_tracker.rb:35:5:35:7 | tmp |
+| type_tracker.rb:35:11:35:15 | synthetic splat argument | type_tracker.rb:35:5:35:15 | ... = ... |
+| type_tracker.rb:35:11:35:15 | synthetic splat argument | type_tracker.rb:35:11:35:15 | call to [] |
+| type_tracker.rb:35:11:35:15 | synthetic splat argument | type_tracker.rb:35:11:35:15 | synthetic splat argument |
+| type_tracker.rb:35:11:35:15 | synthetic splat argument | type_tracker.rb:36:5:36:7 | tmp |
 | type_tracker.rb:36:5:36:10 | ...[...] | type_tracker.rb:36:5:36:10 | ...[...] |
+| type_tracker.rb:36:5:36:10 | synthetic splat argument | type_tracker.rb:36:5:36:10 | synthetic splat argument |
 | type_tracker.rb:36:9:36:9 | 0 | type_tracker.rb:36:9:36:9 | 0 |
 | type_tracker.rb:38:5:38:9 | array | type_tracker.rb:38:5:38:9 | array |
-| type_tracker.rb:38:13:38:25 | * | type_tracker.rb:38:13:38:25 | * |
 | type_tracker.rb:38:13:38:25 | Array | type_tracker.rb:38:13:38:25 | Array |
 | type_tracker.rb:38:13:38:25 | call to [] | type_tracker.rb:38:5:38:9 | array |
 | type_tracker.rb:38:13:38:25 | call to [] | type_tracker.rb:38:5:38:25 | ... = ... |
 | type_tracker.rb:38:13:38:25 | call to [] | type_tracker.rb:38:13:38:25 | call to [] |
 | type_tracker.rb:38:13:38:25 | call to [] | type_tracker.rb:39:5:39:9 | array |
 | type_tracker.rb:38:13:38:25 | call to [] | type_tracker.rb:40:5:40:9 | array |
+| type_tracker.rb:38:13:38:25 | synthetic splat argument | type_tracker.rb:38:5:38:9 | array |
+| type_tracker.rb:38:13:38:25 | synthetic splat argument | type_tracker.rb:38:5:38:25 | ... = ... |
+| type_tracker.rb:38:13:38:25 | synthetic splat argument | type_tracker.rb:38:13:38:25 | call to [] |
+| type_tracker.rb:38:13:38:25 | synthetic splat argument | type_tracker.rb:38:13:38:25 | synthetic splat argument |
+| type_tracker.rb:38:13:38:25 | synthetic splat argument | type_tracker.rb:39:5:39:9 | array |
+| type_tracker.rb:38:13:38:25 | synthetic splat argument | type_tracker.rb:40:5:40:9 | array |
 | type_tracker.rb:38:14:38:14 | 1 | type_tracker.rb:38:14:38:14 | 1 |
 | type_tracker.rb:38:14:38:14 | 1 | type_tracker.rb:40:5:40:12 | ...[...] |
 | type_tracker.rb:38:16:38:16 | 2 | type_tracker.rb:38:16:38:16 | 2 |
@@ -582,20 +596,25 @@ trackEnd
 | type_tracker.rb:38:24:38:24 | 6 | type_tracker.rb:38:24:38:24 | 6 |
 | type_tracker.rb:39:5:39:9 | [post] array | type_tracker.rb:39:5:39:9 | [post] array |
 | type_tracker.rb:39:5:39:9 | [post] array | type_tracker.rb:40:5:40:9 | array |
-| type_tracker.rb:39:5:39:12 | * | type_tracker.rb:39:5:39:12 | * |
 | type_tracker.rb:39:5:39:12 | call to []= | type_tracker.rb:39:5:39:12 | call to []= |
+| type_tracker.rb:39:5:39:12 | synthetic splat argument | type_tracker.rb:39:5:39:12 | synthetic splat argument |
 | type_tracker.rb:39:16:39:18 | __synth__0 | type_tracker.rb:39:16:39:18 | __synth__0 |
-| type_tracker.rb:40:5:40:12 | * | type_tracker.rb:40:5:40:12 | * |
 | type_tracker.rb:40:5:40:12 | ...[...] | type_tracker.rb:40:5:40:12 | ...[...] |
+| type_tracker.rb:40:5:40:12 | synthetic splat argument | type_tracker.rb:40:5:40:12 | synthetic splat argument |
 | type_tracker.rb:40:11:40:11 | 0 | type_tracker.rb:40:11:40:11 | 0 |
 | type_tracker.rb:42:5:42:10 | array2 | type_tracker.rb:42:5:42:10 | array2 |
-| type_tracker.rb:42:14:42:26 | * | type_tracker.rb:42:14:42:26 | * |
 | type_tracker.rb:42:14:42:26 | Array | type_tracker.rb:42:14:42:26 | Array |
 | type_tracker.rb:42:14:42:26 | call to [] | type_tracker.rb:42:5:42:10 | array2 |
 | type_tracker.rb:42:14:42:26 | call to [] | type_tracker.rb:42:5:42:26 | ... = ... |
 | type_tracker.rb:42:14:42:26 | call to [] | type_tracker.rb:42:14:42:26 | call to [] |
 | type_tracker.rb:42:14:42:26 | call to [] | type_tracker.rb:43:5:43:10 | array2 |
 | type_tracker.rb:42:14:42:26 | call to [] | type_tracker.rb:44:5:44:10 | array2 |
+| type_tracker.rb:42:14:42:26 | synthetic splat argument | type_tracker.rb:42:5:42:10 | array2 |
+| type_tracker.rb:42:14:42:26 | synthetic splat argument | type_tracker.rb:42:5:42:26 | ... = ... |
+| type_tracker.rb:42:14:42:26 | synthetic splat argument | type_tracker.rb:42:14:42:26 | call to [] |
+| type_tracker.rb:42:14:42:26 | synthetic splat argument | type_tracker.rb:42:14:42:26 | synthetic splat argument |
+| type_tracker.rb:42:14:42:26 | synthetic splat argument | type_tracker.rb:43:5:43:10 | array2 |
+| type_tracker.rb:42:14:42:26 | synthetic splat argument | type_tracker.rb:44:5:44:10 | array2 |
 | type_tracker.rb:42:15:42:15 | 1 | type_tracker.rb:42:15:42:15 | 1 |
 | type_tracker.rb:42:15:42:15 | 1 | type_tracker.rb:44:5:44:13 | ...[...] |
 | type_tracker.rb:42:17:42:17 | 2 | type_tracker.rb:42:17:42:17 | 2 |
@@ -610,20 +629,25 @@ trackEnd
 | type_tracker.rb:42:25:42:25 | 6 | type_tracker.rb:44:5:44:13 | ...[...] |
 | type_tracker.rb:43:5:43:10 | [post] array2 | type_tracker.rb:43:5:43:10 | [post] array2 |
 | type_tracker.rb:43:5:43:10 | [post] array2 | type_tracker.rb:44:5:44:10 | array2 |
-| type_tracker.rb:43:5:43:13 | * | type_tracker.rb:43:5:43:13 | * |
 | type_tracker.rb:43:5:43:13 | call to []= | type_tracker.rb:43:5:43:13 | call to []= |
+| type_tracker.rb:43:5:43:13 | synthetic splat argument | type_tracker.rb:43:5:43:13 | synthetic splat argument |
 | type_tracker.rb:43:12:43:12 | 0 | type_tracker.rb:43:12:43:12 | 0 |
 | type_tracker.rb:43:17:43:19 | __synth__0 | type_tracker.rb:43:17:43:19 | __synth__0 |
-| type_tracker.rb:44:5:44:13 | * | type_tracker.rb:44:5:44:13 | * |
 | type_tracker.rb:44:5:44:13 | ...[...] | type_tracker.rb:44:5:44:13 | ...[...] |
+| type_tracker.rb:44:5:44:13 | synthetic splat argument | type_tracker.rb:44:5:44:13 | synthetic splat argument |
 | type_tracker.rb:46:5:46:10 | array3 | type_tracker.rb:46:5:46:10 | array3 |
-| type_tracker.rb:46:14:46:26 | * | type_tracker.rb:46:14:46:26 | * |
 | type_tracker.rb:46:14:46:26 | Array | type_tracker.rb:46:14:46:26 | Array |
 | type_tracker.rb:46:14:46:26 | call to [] | type_tracker.rb:46:5:46:10 | array3 |
 | type_tracker.rb:46:14:46:26 | call to [] | type_tracker.rb:46:5:46:26 | ... = ... |
 | type_tracker.rb:46:14:46:26 | call to [] | type_tracker.rb:46:14:46:26 | call to [] |
 | type_tracker.rb:46:14:46:26 | call to [] | type_tracker.rb:47:5:47:10 | array3 |
 | type_tracker.rb:46:14:46:26 | call to [] | type_tracker.rb:48:5:48:10 | array3 |
+| type_tracker.rb:46:14:46:26 | synthetic splat argument | type_tracker.rb:46:5:46:10 | array3 |
+| type_tracker.rb:46:14:46:26 | synthetic splat argument | type_tracker.rb:46:5:46:26 | ... = ... |
+| type_tracker.rb:46:14:46:26 | synthetic splat argument | type_tracker.rb:46:14:46:26 | call to [] |
+| type_tracker.rb:46:14:46:26 | synthetic splat argument | type_tracker.rb:46:14:46:26 | synthetic splat argument |
+| type_tracker.rb:46:14:46:26 | synthetic splat argument | type_tracker.rb:47:5:47:10 | array3 |
+| type_tracker.rb:46:14:46:26 | synthetic splat argument | type_tracker.rb:48:5:48:10 | array3 |
 | type_tracker.rb:46:15:46:15 | 1 | type_tracker.rb:46:15:46:15 | 1 |
 | type_tracker.rb:46:17:46:17 | 2 | type_tracker.rb:46:17:46:17 | 2 |
 | type_tracker.rb:46:17:46:17 | 2 | type_tracker.rb:48:5:48:13 | ...[...] |
@@ -633,21 +657,26 @@ trackEnd
 | type_tracker.rb:46:25:46:25 | 6 | type_tracker.rb:46:25:46:25 | 6 |
 | type_tracker.rb:47:5:47:10 | [post] array3 | type_tracker.rb:47:5:47:10 | [post] array3 |
 | type_tracker.rb:47:5:47:10 | [post] array3 | type_tracker.rb:48:5:48:10 | array3 |
-| type_tracker.rb:47:5:47:13 | * | type_tracker.rb:47:5:47:13 | * |
 | type_tracker.rb:47:5:47:13 | call to []= | type_tracker.rb:47:5:47:13 | call to []= |
+| type_tracker.rb:47:5:47:13 | synthetic splat argument | type_tracker.rb:47:5:47:13 | synthetic splat argument |
 | type_tracker.rb:47:12:47:12 | 0 | type_tracker.rb:47:12:47:12 | 0 |
 | type_tracker.rb:47:17:47:19 | __synth__0 | type_tracker.rb:47:17:47:19 | __synth__0 |
-| type_tracker.rb:48:5:48:13 | * | type_tracker.rb:48:5:48:13 | * |
 | type_tracker.rb:48:5:48:13 | ...[...] | type_tracker.rb:48:5:48:13 | ...[...] |
+| type_tracker.rb:48:5:48:13 | synthetic splat argument | type_tracker.rb:48:5:48:13 | synthetic splat argument |
 | type_tracker.rb:48:12:48:12 | 1 | type_tracker.rb:48:12:48:12 | 1 |
 | type_tracker.rb:50:5:50:10 | array4 | type_tracker.rb:50:5:50:10 | array4 |
-| type_tracker.rb:50:14:50:26 | * | type_tracker.rb:50:14:50:26 | * |
 | type_tracker.rb:50:14:50:26 | Array | type_tracker.rb:50:14:50:26 | Array |
 | type_tracker.rb:50:14:50:26 | call to [] | type_tracker.rb:50:5:50:10 | array4 |
 | type_tracker.rb:50:14:50:26 | call to [] | type_tracker.rb:50:5:50:26 | ... = ... |
 | type_tracker.rb:50:14:50:26 | call to [] | type_tracker.rb:50:14:50:26 | call to [] |
 | type_tracker.rb:50:14:50:26 | call to [] | type_tracker.rb:51:5:51:10 | array4 |
 | type_tracker.rb:50:14:50:26 | call to [] | type_tracker.rb:52:5:52:10 | array4 |
+| type_tracker.rb:50:14:50:26 | synthetic splat argument | type_tracker.rb:50:5:50:10 | array4 |
+| type_tracker.rb:50:14:50:26 | synthetic splat argument | type_tracker.rb:50:5:50:26 | ... = ... |
+| type_tracker.rb:50:14:50:26 | synthetic splat argument | type_tracker.rb:50:14:50:26 | call to [] |
+| type_tracker.rb:50:14:50:26 | synthetic splat argument | type_tracker.rb:50:14:50:26 | synthetic splat argument |
+| type_tracker.rb:50:14:50:26 | synthetic splat argument | type_tracker.rb:51:5:51:10 | array4 |
+| type_tracker.rb:50:14:50:26 | synthetic splat argument | type_tracker.rb:52:5:52:10 | array4 |
 | type_tracker.rb:50:15:50:15 | 1 | type_tracker.rb:50:15:50:15 | 1 |
 | type_tracker.rb:50:15:50:15 | 1 | type_tracker.rb:52:5:52:13 | ...[...] |
 | type_tracker.rb:50:17:50:17 | 2 | type_tracker.rb:50:17:50:17 | 2 |
@@ -662,10 +691,10 @@ trackEnd
 | type_tracker.rb:50:25:50:25 | 6 | type_tracker.rb:52:5:52:13 | ...[...] |
 | type_tracker.rb:51:5:51:10 | [post] array4 | type_tracker.rb:51:5:51:10 | [post] array4 |
 | type_tracker.rb:51:5:51:10 | [post] array4 | type_tracker.rb:52:5:52:10 | array4 |
-| type_tracker.rb:51:5:51:13 | * | type_tracker.rb:51:5:51:13 | * |
 | type_tracker.rb:51:5:51:13 | call to []= | type_tracker.rb:51:5:51:13 | call to []= |
+| type_tracker.rb:51:5:51:13 | synthetic splat argument | type_tracker.rb:51:5:51:13 | synthetic splat argument |
 | type_tracker.rb:51:17:51:19 | __synth__0 | type_tracker.rb:51:17:51:19 | __synth__0 |
-| type_tracker.rb:52:5:52:13 | * | type_tracker.rb:52:5:52:13 | * |
 | type_tracker.rb:52:5:52:13 | ...[...] | type_tracker.rb:52:5:52:13 | ...[...] |
+| type_tracker.rb:52:5:52:13 | synthetic splat argument | type_tracker.rb:52:5:52:13 | synthetic splat argument |
 forwardButNoBackwardFlow
 backwardButNoForwardFlow

--- a/ruby/ql/test/library-tests/frameworks/action_controller/params-flow.expected
+++ b/ruby/ql/test/library-tests/frameworks/action_controller/params-flow.expected
@@ -71,21 +71,21 @@ edges
 | params_flow.rb:107:10:107:33 | call to values_at [element 0] | params_flow.rb:107:10:107:33 | call to values_at |
 | params_flow.rb:107:10:107:33 | call to values_at [element 1] | params_flow.rb:107:10:107:33 | call to values_at |
 | params_flow.rb:111:10:111:15 | call to params | params_flow.rb:111:10:111:29 | call to merge |
-| params_flow.rb:112:10:112:29 | call to merge [element 0] | params_flow.rb:112:10:112:29 | call to merge |
+| params_flow.rb:112:10:112:29 | call to merge [splat position 0] | params_flow.rb:112:10:112:29 | call to merge |
 | params_flow.rb:112:23:112:28 | call to params | params_flow.rb:112:10:112:29 | call to merge |
-| params_flow.rb:112:23:112:28 | call to params | params_flow.rb:112:10:112:29 | call to merge [element 0] |
+| params_flow.rb:112:23:112:28 | call to params | params_flow.rb:112:10:112:29 | call to merge [splat position 0] |
 | params_flow.rb:116:10:116:15 | call to params | params_flow.rb:116:10:116:37 | call to reverse_merge |
 | params_flow.rb:117:31:117:36 | call to params | params_flow.rb:117:10:117:37 | call to reverse_merge |
 | params_flow.rb:121:10:121:15 | call to params | params_flow.rb:121:10:121:43 | call to with_defaults |
 | params_flow.rb:122:31:122:36 | call to params | params_flow.rb:122:10:122:37 | call to with_defaults |
 | params_flow.rb:126:10:126:15 | call to params | params_flow.rb:126:10:126:30 | call to merge! |
-| params_flow.rb:127:10:127:30 | call to merge! [element 0] | params_flow.rb:127:10:127:30 | call to merge! |
+| params_flow.rb:127:10:127:30 | call to merge! [splat position 0] | params_flow.rb:127:10:127:30 | call to merge! |
 | params_flow.rb:127:24:127:29 | call to params | params_flow.rb:127:10:127:30 | call to merge! |
-| params_flow.rb:127:24:127:29 | call to params | params_flow.rb:127:10:127:30 | call to merge! [element 0] |
+| params_flow.rb:127:24:127:29 | call to params | params_flow.rb:127:10:127:30 | call to merge! [splat position 0] |
 | params_flow.rb:130:5:130:5 | [post] p | params_flow.rb:131:10:131:10 | p |
-| params_flow.rb:130:5:130:5 | [post] p [element 0] | params_flow.rb:131:10:131:10 | p |
+| params_flow.rb:130:5:130:5 | [post] p [splat position 0] | params_flow.rb:131:10:131:10 | p |
 | params_flow.rb:130:14:130:19 | call to params | params_flow.rb:130:5:130:5 | [post] p |
-| params_flow.rb:130:14:130:19 | call to params | params_flow.rb:130:5:130:5 | [post] p [element 0] |
+| params_flow.rb:130:14:130:19 | call to params | params_flow.rb:130:5:130:5 | [post] p [splat position 0] |
 | params_flow.rb:135:10:135:15 | call to params | params_flow.rb:135:10:135:38 | call to reverse_merge! |
 | params_flow.rb:136:32:136:37 | call to params | params_flow.rb:136:10:136:38 | call to reverse_merge! |
 | params_flow.rb:139:5:139:5 | [post] p | params_flow.rb:140:10:140:10 | p |
@@ -198,7 +198,7 @@ nodes
 | params_flow.rb:111:10:111:15 | call to params | semmle.label | call to params |
 | params_flow.rb:111:10:111:29 | call to merge | semmle.label | call to merge |
 | params_flow.rb:112:10:112:29 | call to merge | semmle.label | call to merge |
-| params_flow.rb:112:10:112:29 | call to merge [element 0] | semmle.label | call to merge [element 0] |
+| params_flow.rb:112:10:112:29 | call to merge [splat position 0] | semmle.label | call to merge [splat position 0] |
 | params_flow.rb:112:23:112:28 | call to params | semmle.label | call to params |
 | params_flow.rb:116:10:116:15 | call to params | semmle.label | call to params |
 | params_flow.rb:116:10:116:37 | call to reverse_merge | semmle.label | call to reverse_merge |
@@ -211,10 +211,10 @@ nodes
 | params_flow.rb:126:10:126:15 | call to params | semmle.label | call to params |
 | params_flow.rb:126:10:126:30 | call to merge! | semmle.label | call to merge! |
 | params_flow.rb:127:10:127:30 | call to merge! | semmle.label | call to merge! |
-| params_flow.rb:127:10:127:30 | call to merge! [element 0] | semmle.label | call to merge! [element 0] |
+| params_flow.rb:127:10:127:30 | call to merge! [splat position 0] | semmle.label | call to merge! [splat position 0] |
 | params_flow.rb:127:24:127:29 | call to params | semmle.label | call to params |
 | params_flow.rb:130:5:130:5 | [post] p | semmle.label | [post] p |
-| params_flow.rb:130:5:130:5 | [post] p [element 0] | semmle.label | [post] p [element 0] |
+| params_flow.rb:130:5:130:5 | [post] p [splat position 0] | semmle.label | [post] p [splat position 0] |
 | params_flow.rb:130:14:130:19 | call to params | semmle.label | call to params |
 | params_flow.rb:131:10:131:10 | p | semmle.label | p |
 | params_flow.rb:135:10:135:15 | call to params | semmle.label | call to params |


### PR DESCRIPTION
This PR builds on top of https://github.com/github/codeql/pull/14090. [This DCA run](https://github.com/github/codeql-dca-main/issues/16381) shows the combined effect of those two PRs, while [this DCA run](https://github.com/github/codeql-dca-main/issues/16446) is for this PR alone.

### Hash splats

We support flow through hash-splats in all possible combinations:
```rb
def m1(key1:, key2:); end
args = { key1: a, key2: b }
m1(**args)

def m2(**kwargs); end
m2(key1: a, key2: b)

def m3(key1:, **kwargs); end
args = { key1: a }
m3(key2: b, **args)
```

The first case (`m1`) is handled by synthesizing an implicit hash-splat parameter `implicit-hash-param` inside `m1`, and then adding read steps out of `implicit-hash-param` into `key1` (resp. `key2`), reading out a `KnownElementContent` corresponding to the symbol `:key1` (resp. `:key2`):
```rb
def m1(**implicit-hash-param)
  key1 = implicit-hash-param[:key1]
  key2 = implicit-hash-param[:key2]
end
```

The second case is handled dually: we synthesize an implicit hash-splat argument `implicit-hash-arg` at the call site, and add store steps from the keyword arguments into `implicit-hash-arg`:
```rb
implicit-hash-arg = { key1: a, key2: b }
m2(**implicit-hash-arg)
```

The third case is handled using a combination, but care must be taken to ensure that the `:key1` argument does not end up in `**kwargs` (we do this using `clearsContent`).

Reusing `KnownElementContent` for the implicit stores/reads makes semantically sense. However, performance-wise it is not great, as we are generating redundant stores/reads for the simple cases
```
def m4(key1:, key2:); end
m4(key1: a, key2: b)
```
where we will be able to match the keyword arguments directly against the keyword parameters. Not only are the stores/reads redundant, they also put extra pressure on the data flow computation, as we are generating many more [cons-candidates](https://github.com/github/codeql/blob/7b779ca9d0f5b6e11b1e1d2b48e1c5c65448edbc/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll#L1384).

In order to avoid this redundancy, we introduce a new type of content, `HashSplatContent`, which is used for the implicit argument stores (`implicit-hash-arg`), but which are _not_ allowed in reads out of `implicit-hash-param` (`KnownElementContent` reads should still be allowed in order to handle the `m1` example). This will effectively remove the redundancy in the `m4` example, but in order for reads such as `kwargs[:key1]` inside `m2` to work, such reads should be able to match both `KnownElementContent`s and `HashSplatContent`s, which we achieve using 
`ContentSet::getAReadContent`.

### Splats

Unlike hash-splats, where we can simply merge all keywords arguments/parameters with all hash-splat arguments/parameters, flow through splats is limited to methods containing zero or more positional parameters followed by at most one splat parameter, and calls containing zero or more positional arguments followed by at most one splat argument (since we are not tracking the length of arrays):

```rb
def m1(p1, p2); end
args = [a, b]
m1(*args)

def m2(*posargs); end
m2(a, b)

def m3(p1, **rest); end
args = [b]
m3(a, *args)
```

As for hash-splats, the first case (`m1`) is handled by synthesizing an implicit splat parameter `implicit-splat-param` inside `m1`, and then adding read steps out of `implicit-splat-param` into `p1` (resp. `p2`), reading out a `KnownElementContent` corresponding to the integer `0` (resp. `1`):
```rb
def m1(*implicit-splat-param)
  p1 = implicit-splat-param[0]
  p2 = implicit-splat-param[1]
end
```

The second case is handled dually: we synthesize an implicit splat argument `implicit-splat-arg` at the call site, and add store steps from the positional arguments into `implicit-splat-arg`:
```rb
implicit-splat-arg = [a, b]
m2(*implicit-splat-arg)
```

The third case is handled using a combination, but care must be taken to shift indices both at the call site (where `a` must have index `0` and `b` must have index `1` inside `implicit-splat-arg`), and similarly only `b` must end up in `rest` with re-shifted index `0`.

As for hash-splats, reusing `KnownElementContent` for the implicit stores/reads makes semantically sense, but introduces the same kind of redundancy and performance issues:
```
def m4(p1, p2); end
m4(a, b)
```

The solution is similar: we introduce a new type of content, `SplatContent`, which is used for the implicit argument stores (`implicit-splat-arg`), but we record not only the index, but also whether the index was shifted or not (in the `m3` example, only `b` will have a shifted index). Then only `SplatContent`s with shifted indices (as well as `KnownElementContent`s in the `m1` example) need to read out of `implicit-splat-param`, as all other arguments will be able to match directly. Like for `HashSplatContent`, we also need to ensure that reads such as `rest[0]` inside `m2` work, and we make use of `ContentSet::getAReadContent` for this as well.