### PR TITLE
Shared: Allow implicit read step at the start of a default taint step

### DIFF
--- a/shared/dataflow/codeql/dataflow/TaintTracking.qll
+++ b/shared/dataflow/codeql/dataflow/TaintTracking.qll
@@ -59,7 +59,8 @@ module TaintFlowMake<DF::InputSig DataFlowLang, InputSig<DataFlowLang> TaintTrac
         Config::isSink(node) or
         Config::isSink(node, _) or
         Config::isAdditionalFlowStep(node, _) or
-        Config::isAdditionalFlowStep(node, _, _, _)
+        Config::isAdditionalFlowStep(node, _, _, _) or
+        defaultAdditionalTaintStep(node, _)
       ) and
       defaultImplicitTaintRead(node, c)
     }


### PR DESCRIPTION
`defaultImplicitTaintRead` currently only works at a sink and or when taking a _configuration-specific_ flow step. This PR extends it to work for default taint steps as well.

It does remove the potential for a future compiler optimization, which is to reduce `TNodeEx` to a single-branch newtype and subsequently optimise it away, for configurations that don't contribute any implicit reads. AFAIK the compiler is not currently able to perform this optimization. If we wanted to enable it in the future, we could possibly move the configuration-agnostic nodes into the layer materialised by `DataFlowImplCommon.qll`.