### PR TITLE
CPP: Simplify some code in IRGuards.

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/controlflow/IRGuards.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/IRGuards.qll
@@ -240,7 +240,7 @@ private class GuardConditionFromIR extends GuardCondition {
    */
   private predicate controlsBlock(BasicBlock controlled, boolean testIsTrue) {
     exists(IRBlock irb |
-      forex(IRGuardCondition inst | inst = ir | inst.controls(irb, testIsTrue)) and
+      ir.controls(irb, testIsTrue) and
       irb.getAnInstruction().getAst().(ControlFlowNode).getBasicBlock() = controlled and
       not isUnreachedBlock(irb)
     )


### PR DESCRIPTION
This is equivalent as `inst = ir` is functional the forex does nothing.