### PR TITLE
C#: Parallelize restore logic of missing packages

### DIFF
--- a/csharp/autobuilder/Semmle.Autobuild.Shared/Autobuilder.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.Shared/Autobuilder.cs
@@ -267,7 +267,7 @@ namespace Semmle.Autobuild.Shared
 
         protected DiagnosticClassifier DiagnosticClassifier { get; }
 
-        private readonly ILogger logger = new ConsoleLogger(Verbosity.Info);
+        private readonly ILogger logger = new ConsoleLogger(Verbosity.Info, logThreadId: false);
 
         private readonly IDiagnosticsWriter diagnostics;
 

--- a/csharp/autobuilder/Semmle.Autobuild.Shared/BuildActions.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.Shared/BuildActions.cs
@@ -187,12 +187,12 @@ namespace Semmle.Autobuild.Shared
 
         bool IBuildActions.FileExists(string file) => File.Exists(file);
 
-        private static ProcessStartInfo GetProcessStartInfo(string exe, string arguments, string? workingDirectory, IDictionary<string, string>? environment, bool redirectStandardOutput)
+        private static ProcessStartInfo GetProcessStartInfo(string exe, string arguments, string? workingDirectory, IDictionary<string, string>? environment)
         {
             var pi = new ProcessStartInfo(exe, arguments)
             {
                 UseShellExecute = false,
-                RedirectStandardOutput = redirectStandardOutput
+                RedirectStandardOutput = true
             };
             if (workingDirectory is not null)
                 pi.WorkingDirectory = workingDirectory;
@@ -204,40 +204,22 @@ namespace Semmle.Autobuild.Shared
 
         int IBuildActions.RunProcess(string exe, string args, string? workingDirectory, System.Collections.Generic.IDictionary<string, string>? env, BuildOutputHandler onOutput, BuildOutputHandler onError)
         {
-            var pi = GetProcessStartInfo(exe, args, workingDirectory, env, true);
-            using var p = new Process
-            {
-                StartInfo = pi
-            };
-            p.StartInfo.RedirectStandardError = true;
-            p.OutputDataReceived += new DataReceivedEventHandler((sender, e) => onOutput(e.Data));
-            p.ErrorDataReceived += new DataReceivedEventHandler((sender, e) => onError(e.Data));
+            var pi = GetProcessStartInfo(exe, args, workingDirectory, env);
+            pi.RedirectStandardError = true;
 
-            p.Start();
-
-            p.BeginErrorReadLine();
-            p.BeginOutputReadLine();
-
-            p.WaitForExit();
-            return p.ExitCode;
+            return pi.ReadOutput(out _, onOut: s => onOutput(s), onError: s => onError(s));
         }
 
         int IBuildActions.RunProcess(string cmd, string args, string? workingDirectory, IDictionary<string, string>? environment)
         {
-            var pi = GetProcessStartInfo(cmd, args, workingDirectory, environment, false);
-            using var p = Process.Start(pi);
-            if (p is null)
-            {
-                return -1;
-            }
-            p.WaitForExit();
-            return p.ExitCode;
+            var pi = GetProcessStartInfo(cmd, args, workingDirectory, environment);
+            return pi.ReadOutput(out _, onOut: Console.WriteLine, onError: null);
         }
 
         int IBuildActions.RunProcess(string cmd, string args, string? workingDirectory, IDictionary<string, string>? environment, out IList<string> stdOut)
         {
-            var pi = GetProcessStartInfo(cmd, args, workingDirectory, environment, true);
-            return pi.ReadOutput(out stdOut, printToConsole: false);
+            var pi = GetProcessStartInfo(cmd, args, workingDirectory, environment);
+            return pi.ReadOutput(out stdOut, onOut: null, onError: null);
         }
 
         void IBuildActions.DirectoryDelete(string dir, bool recursive) => Directory.Delete(dir, recursive);

--- a/csharp/autobuilder/Semmle.Autobuild.Shared/BuildActions.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.Shared/BuildActions.cs
@@ -237,7 +237,7 @@ namespace Semmle.Autobuild.Shared
         int IBuildActions.RunProcess(string cmd, string args, string? workingDirectory, IDictionary<string, string>? environment, out IList<string> stdOut)
         {
             var pi = GetProcessStartInfo(cmd, args, workingDirectory, environment, true);
-            return pi.ReadOutput(out stdOut);
+            return pi.ReadOutput(out stdOut, printToConsole: false);
         }
 
         void IBuildActions.DirectoryDelete(string dir, bool recursive) => Directory.Delete(dir, recursive);

--- a/csharp/extractor/Semmle.Extraction.CIL.Driver/Program.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL.Driver/Program.cs
@@ -38,7 +38,7 @@ namespace Semmle.Extraction.CIL.Driver
             }
 
             var options = new ExtractorOptions(args);
-            using var logger = new ConsoleLogger(options.Verbosity);
+            using var logger = new ConsoleLogger(options.Verbosity, logThreadId: false);
 
             var actions = options.AssembliesToExtract
                 .Select(asm => asm.Filename)

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNetCliInvoker.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNetCliInvoker.cs
@@ -19,23 +19,23 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             this.Exec = exec;
         }
 
-        private ProcessStartInfo MakeDotnetStartInfo(string args, bool redirectStandardOutput)
+        private ProcessStartInfo MakeDotnetStartInfo(string args)
         {
             var startInfo = new ProcessStartInfo(Exec, args)
             {
                 UseShellExecute = false,
-                RedirectStandardOutput = redirectStandardOutput
+                RedirectStandardOutput = true
             };
             // Set the .NET CLI language to English to avoid localized output.
             startInfo.EnvironmentVariables["DOTNET_CLI_UI_LANGUAGE"] = "en";
             return startInfo;
         }
 
-        private bool RunCommandAux(string args, bool redirectStandardOutput, out IList<string> output)
+        private bool RunCommandAux(string args, out IList<string> output)
         {
             progressMonitor.RunningProcess($"{Exec} {args}");
-            var pi = MakeDotnetStartInfo(args, redirectStandardOutput);
-            var exitCode = pi.ReadOutput(out output);
+            var pi = MakeDotnetStartInfo(args);
+            var exitCode = pi.ReadOutput(out output, true);
             if (exitCode != 0)
             {
                 progressMonitor.CommandFailed(Exec, args, exitCode);
@@ -45,9 +45,9 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         }
 
         public bool RunCommand(string args) =>
-            RunCommandAux(args, redirectStandardOutput: false, out _);
+            RunCommandAux(args, out _);
 
         public bool RunCommand(string args, out IList<string> output) =>
-            RunCommandAux(args, redirectStandardOutput: true, out output);
+            RunCommandAux(args, out output);
     }
 }

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/IDotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/IDotNet.cs
@@ -6,8 +6,8 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
     {
         bool RestoreProjectToDirectory(string project, string directory, out string stdout, string? pathToNugetConfig = null);
         bool RestoreSolutionToDirectory(string solutionFile, string packageDirectory, out IEnumerable<string> projects);
-        bool New(string folder);
-        bool AddPackage(string folder, string package);
+        bool New(string folder, out string stdout);
+        bool AddPackage(string folder, string package, out string stdout);
         IList<string> GetListedRuntimes();
         IList<string> GetListedSdks();
         bool Exec(string execArgs);

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/IDotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/IDotNet.cs
@@ -4,10 +4,10 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 {
     internal interface IDotNet
     {
-        bool RestoreProjectToDirectory(string project, string directory, out string stdout, string? pathToNugetConfig = null);
+        bool RestoreProjectToDirectory(string project, string directory, string? pathToNugetConfig = null);
         bool RestoreSolutionToDirectory(string solutionFile, string packageDirectory, out IEnumerable<string> projects);
-        bool New(string folder, out string stdout);
-        bool AddPackage(string folder, string package, out string stdout);
+        bool New(string folder);
+        bool AddPackage(string folder, string package);
         IList<string> GetListedRuntimes();
         IList<string> GetListedSdks();
         bool Exec(string execArgs);

--- a/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Extractor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Extractor.cs
@@ -119,7 +119,7 @@ namespace Semmle.Extraction.CSharp.Standalone
             var stopwatch = new Stopwatch();
             stopwatch.Start();
 
-            using var logger = new ConsoleLogger(options.Verbosity);
+            using var logger = new ConsoleLogger(options.Verbosity, logThreadId: true);
             logger.Log(Severity.Info, "Running C# standalone extractor");
             using var a = new Analysis(logger, options);
             var sourceFileCount = a.Extraction.Sources.Count;

--- a/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Options.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Options.cs
@@ -2,6 +2,7 @@ using System.IO;
 using Semmle.Util;
 using Semmle.Util.Logging;
 using Semmle.Extraction.CSharp.DependencyFetching;
+using System;
 
 namespace Semmle.Extraction.CSharp.Standalone
 {
@@ -64,7 +65,7 @@ namespace Semmle.Extraction.CSharp.Standalone
             var fi = new FileInfo(dependencies.SolutionFile);
             if (!fi.Exists)
             {
-                System.Console.WriteLine("Error: The solution {0} does not exist", fi.FullName);
+                System.Console.WriteLine($"[{Environment.CurrentManagedThreadId:D3}] Error: The solution {fi.FullName} does not exist");
                 Errors = true;
             }
             return true;
@@ -72,7 +73,7 @@ namespace Semmle.Extraction.CSharp.Standalone
 
         public override void InvalidArgument(string argument)
         {
-            System.Console.WriteLine($"Error: Invalid argument {argument}");
+            System.Console.WriteLine($"[{Environment.CurrentManagedThreadId:D3}] Error: Invalid argument {argument}");
             Errors = true;
         }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Extractor/Extractor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Extractor/Extractor.cs
@@ -71,9 +71,9 @@ namespace Semmle.Extraction.CSharp
 
         public static ILogger MakeLogger(Verbosity verbosity, bool includeConsole)
         {
-            var fileLogger = new FileLogger(verbosity, GetCSharpLogPath());
+            var fileLogger = new FileLogger(verbosity, GetCSharpLogPath(), logThreadId: true);
             return includeConsole
-                ? new CombinedLogger(new ConsoleLogger(verbosity), fileLogger)
+                ? new CombinedLogger(new ConsoleLogger(verbosity, logThreadId: true), fileLogger)
                 : (ILogger)fileLogger;
         }
 

--- a/csharp/extractor/Semmle.Extraction.Tests/DotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/DotNet.cs
@@ -164,7 +164,7 @@ namespace Semmle.Extraction.Tests
             var dotnet = MakeDotnet(dotnetCliInvoker);
 
             // Execute
-            dotnet.New("myfolder");
+            dotnet.New("myfolder", out var _);
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();
@@ -179,7 +179,7 @@ namespace Semmle.Extraction.Tests
             var dotnet = MakeDotnet(dotnetCliInvoker);
 
             // Execute
-            dotnet.AddPackage("myfolder", "mypackage");
+            dotnet.AddPackage("myfolder", "mypackage", out var _);
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();

--- a/csharp/extractor/Semmle.Extraction.Tests/DotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/DotNet.cs
@@ -99,7 +99,7 @@ namespace Semmle.Extraction.Tests
             var dotnet = MakeDotnet(dotnetCliInvoker);
 
             // Execute
-            dotnet.RestoreProjectToDirectory("myproject.csproj", "mypackages", out var _);
+            dotnet.RestoreProjectToDirectory("myproject.csproj", "mypackages");
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();
@@ -114,7 +114,7 @@ namespace Semmle.Extraction.Tests
             var dotnet = MakeDotnet(dotnetCliInvoker);
 
             // Execute
-            dotnet.RestoreProjectToDirectory("myproject.csproj", "mypackages", out var _, "myconfig.config");
+            dotnet.RestoreProjectToDirectory("myproject.csproj", "mypackages", "myconfig.config");
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();
@@ -164,7 +164,7 @@ namespace Semmle.Extraction.Tests
             var dotnet = MakeDotnet(dotnetCliInvoker);
 
             // Execute
-            dotnet.New("myfolder", out var _);
+            dotnet.New("myfolder");
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();
@@ -179,7 +179,7 @@ namespace Semmle.Extraction.Tests
             var dotnet = MakeDotnet(dotnetCliInvoker);
 
             // Execute
-            dotnet.AddPackage("myfolder", "mypackage", out var _);
+            dotnet.AddPackage("myfolder", "mypackage");
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();

--- a/csharp/extractor/Semmle.Extraction.Tests/Runtime.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/Runtime.cs
@@ -15,23 +15,11 @@ namespace Semmle.Extraction.Tests
             this.runtimes = runtimes;
             this.sdks = sdks;
         }
-        public bool AddPackage(string folder, string package, out string stdout)
-        {
-            stdout = "";
-            return true;
-        }
+        public bool AddPackage(string folder, string package) => true;
 
-        public bool New(string folder, out string stdout)
-        {
-            stdout = "";
-            return true;
-        }
+        public bool New(string folder) => true;
 
-        public bool RestoreProjectToDirectory(string project, string directory, out string stdout, string? pathToNugetConfig = null)
-        {
-            stdout = "";
-            return true;
-        }
+        public bool RestoreProjectToDirectory(string project, string directory, string? pathToNugetConfig = null) => true;
 
         public bool RestoreSolutionToDirectory(string solution, string directory, out IEnumerable<string> projects)
         {

--- a/csharp/extractor/Semmle.Extraction.Tests/Runtime.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/Runtime.cs
@@ -15,9 +15,17 @@ namespace Semmle.Extraction.Tests
             this.runtimes = runtimes;
             this.sdks = sdks;
         }
-        public bool AddPackage(string folder, string package) => true;
+        public bool AddPackage(string folder, string package, out string stdout)
+        {
+            stdout = "";
+            return true;
+        }
 
-        public bool New(string folder) => true;
+        public bool New(string folder, out string stdout)
+        {
+            stdout = "";
+            return true;
+        }
 
         public bool RestoreProjectToDirectory(string project, string directory, out string stdout, string? pathToNugetConfig = null)
         {

--- a/csharp/extractor/Semmle.Util/Logger.cs
+++ b/csharp/extractor/Semmle.Util/Logger.cs
@@ -59,10 +59,12 @@ namespace Semmle.Util.Logging
     {
         private readonly StreamWriter writer;
         private readonly Verbosity verbosity;
+        private readonly bool logThreadId;
 
-        public FileLogger(Verbosity verbosity, string outputFile)
+        public FileLogger(Verbosity verbosity, string outputFile, bool logThreadId)
         {
             this.verbosity = verbosity;
+            this.logThreadId = logThreadId;
 
             try
             {
@@ -93,7 +95,10 @@ namespace Semmle.Util.Logging
         public void Log(Severity s, string text)
         {
             if (verbosity.Includes(s))
-                writer.WriteLine(GetSeverityPrefix(s) + text);
+            {
+                var threadId = this.logThreadId ? $"[{Environment.CurrentManagedThreadId:D3}] " : "";
+                writer.WriteLine(threadId + GetSeverityPrefix(s) + text);
+            }
         }
     }
 
@@ -103,10 +108,12 @@ namespace Semmle.Util.Logging
     public sealed class ConsoleLogger : ILogger
     {
         private readonly Verbosity verbosity;
+        private readonly bool logThreadId;
 
-        public ConsoleLogger(Verbosity verbosity)
+        public ConsoleLogger(Verbosity verbosity, bool logThreadId)
         {
             this.verbosity = verbosity;
+            this.logThreadId = logThreadId;
         }
 
         public void Dispose() { }
@@ -136,7 +143,10 @@ namespace Semmle.Util.Logging
         public void Log(Severity s, string text)
         {
             if (verbosity.Includes(s))
-                GetConsole(s).WriteLine(GetSeverityPrefix(s) + text);
+            {
+                var threadId = this.logThreadId ? $"[{Environment.CurrentManagedThreadId:D3}] " : "";
+                GetConsole(s).WriteLine(threadId + GetSeverityPrefix(s) + text);
+            }
         }
     }
 

--- a/csharp/extractor/Semmle.Util/ProcessStartInfoExtensions.cs
+++ b/csharp/extractor/Semmle.Util/ProcessStartInfoExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace Semmle.Util
@@ -7,9 +8,11 @@ namespace Semmle.Util
     {
         /// <summary>
         /// Runs this process, and returns the exit code, as well as the contents
-        /// of stdout in <paramref name="stdout"/>.
+        /// of stdout in <paramref name="stdout"/>. If <paramref name="printToConsole"/>
+        /// is true, then stdout is printed to the console and each line is prefixed
+        /// with the thread id.
         /// </summary>
-        public static int ReadOutput(this ProcessStartInfo pi, out IList<string> stdout)
+        public static int ReadOutput(this ProcessStartInfo pi, out IList<string> stdout, bool printToConsole)
         {
             stdout = new List<string>();
             using var process = Process.Start(pi);
@@ -27,6 +30,10 @@ namespace Semmle.Util
                     s = process.StandardOutput.ReadLine();
                     if (s is not null)
                     {
+                        if (printToConsole)
+                        {
+                            Console.WriteLine($"[{Environment.CurrentManagedThreadId:D3}] {s}");
+                        }
                         stdout.Add(s);
                     }
                 }


### PR DESCRIPTION
This PR 
- parallelizes the implementation of `DependencyManager.DownloadMissingPackages`,
- adds the managed thread ID to all the extractor log messages, and
- merges two implementations of the `Process` starting logic.

Commit-by-commit review is suggested.