### PR TITLE
C++: Fix the declaration of `malloc` in test

### DIFF
--- a/cpp/ql/test/query-tests/Security/CWE/CWE-193/InvalidPointerDeref.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-193/InvalidPointerDeref.expected
@@ -180,6 +180,8 @@ edges
 | test.cpp:815:52:815:54 | end | test.cpp:821:7:821:12 | ... = ... |
 | test.cpp:832:40:832:43 | mk_array_no_field_flow output argument | test.cpp:833:37:833:39 | end |
 | test.cpp:833:37:833:39 | end | test.cpp:815:52:815:54 | end |
+| test.cpp:841:18:841:35 | call to malloc | test.cpp:842:3:842:20 | ... = ... |
+| test.cpp:848:20:848:37 | call to malloc | test.cpp:849:5:849:22 | ... = ... |
 nodes
 | test.cpp:4:15:4:33 | call to malloc | semmle.label | call to malloc |
 | test.cpp:5:15:5:22 | ... + ... | semmle.label | ... + ... |
@@ -304,6 +306,10 @@ nodes
 | test.cpp:821:7:821:12 | ... = ... | semmle.label | ... = ... |
 | test.cpp:832:40:832:43 | mk_array_no_field_flow output argument | semmle.label | mk_array_no_field_flow output argument |
 | test.cpp:833:37:833:39 | end | semmle.label | end |
+| test.cpp:841:18:841:35 | call to malloc | semmle.label | call to malloc |
+| test.cpp:842:3:842:20 | ... = ... | semmle.label | ... = ... |
+| test.cpp:848:20:848:37 | call to malloc | semmle.label | call to malloc |
+| test.cpp:849:5:849:22 | ... = ... | semmle.label | ... = ... |
 subpaths
 #select
 | test.cpp:6:14:6:15 | * ... | test.cpp:4:15:4:33 | call to malloc | test.cpp:6:14:6:15 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:4:15:4:33 | call to malloc | call to malloc | test.cpp:5:19:5:22 | size | size |
@@ -340,3 +346,5 @@ subpaths
 | test.cpp:786:18:786:27 | access to array | test.cpp:781:14:781:27 | new[] | test.cpp:786:18:786:27 | access to array | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:781:14:781:27 | new[] | new[] | test.cpp:786:20:786:26 | ... + ... | ... + ... |
 | test.cpp:807:7:807:12 | ... = ... | test.cpp:793:14:793:32 | call to malloc | test.cpp:807:7:807:12 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:793:14:793:32 | call to malloc | call to malloc | test.cpp:794:21:794:24 | size | size |
 | test.cpp:821:7:821:12 | ... = ... | test.cpp:793:14:793:32 | call to malloc | test.cpp:821:7:821:12 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:793:14:793:32 | call to malloc | call to malloc | test.cpp:794:21:794:24 | size | size |
+| test.cpp:842:3:842:20 | ... = ... | test.cpp:841:18:841:35 | call to malloc | test.cpp:842:3:842:20 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:841:18:841:35 | call to malloc | call to malloc | test.cpp:842:11:842:15 | index | index |
+| test.cpp:849:5:849:22 | ... = ... | test.cpp:848:20:848:37 | call to malloc | test.cpp:849:5:849:22 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:848:20:848:37 | call to malloc | call to malloc | test.cpp:849:13:849:17 | index | index |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-193/InvalidPointerDeref.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-193/InvalidPointerDeref.expected
@@ -1,9 +1,9 @@
 edges
-| test.cpp:4:15:4:20 | call to malloc | test.cpp:5:15:5:22 | ... + ... |
-| test.cpp:4:15:4:20 | call to malloc | test.cpp:5:15:5:22 | ... + ... |
-| test.cpp:4:15:4:20 | call to malloc | test.cpp:6:14:6:15 | * ... |
-| test.cpp:4:15:4:20 | call to malloc | test.cpp:6:14:6:15 | * ... |
-| test.cpp:4:15:4:20 | call to malloc | test.cpp:8:14:8:21 | * ... |
+| test.cpp:4:15:4:33 | call to malloc | test.cpp:5:15:5:22 | ... + ... |
+| test.cpp:4:15:4:33 | call to malloc | test.cpp:5:15:5:22 | ... + ... |
+| test.cpp:4:15:4:33 | call to malloc | test.cpp:6:14:6:15 | * ... |
+| test.cpp:4:15:4:33 | call to malloc | test.cpp:6:14:6:15 | * ... |
+| test.cpp:4:15:4:33 | call to malloc | test.cpp:8:14:8:21 | * ... |
 | test.cpp:5:15:5:22 | ... + ... | test.cpp:5:15:5:22 | ... + ... |
 | test.cpp:5:15:5:22 | ... + ... | test.cpp:6:14:6:15 | * ... |
 | test.cpp:5:15:5:22 | ... + ... | test.cpp:6:14:6:15 | * ... |
@@ -12,12 +12,12 @@ edges
 | test.cpp:5:15:5:22 | ... + ... | test.cpp:8:14:8:21 | * ... |
 | test.cpp:5:15:5:22 | ... + ... | test.cpp:8:14:8:21 | * ... |
 | test.cpp:6:14:6:15 | * ... | test.cpp:8:14:8:21 | * ... |
-| test.cpp:16:15:16:20 | call to malloc | test.cpp:20:14:20:21 | * ... |
-| test.cpp:28:15:28:20 | call to malloc | test.cpp:29:15:29:28 | ... + ... |
-| test.cpp:28:15:28:20 | call to malloc | test.cpp:29:15:29:28 | ... + ... |
-| test.cpp:28:15:28:20 | call to malloc | test.cpp:30:14:30:15 | * ... |
-| test.cpp:28:15:28:20 | call to malloc | test.cpp:30:14:30:15 | * ... |
-| test.cpp:28:15:28:20 | call to malloc | test.cpp:32:14:32:21 | * ... |
+| test.cpp:16:15:16:33 | call to malloc | test.cpp:20:14:20:21 | * ... |
+| test.cpp:28:15:28:37 | call to malloc | test.cpp:29:15:29:28 | ... + ... |
+| test.cpp:28:15:28:37 | call to malloc | test.cpp:29:15:29:28 | ... + ... |
+| test.cpp:28:15:28:37 | call to malloc | test.cpp:30:14:30:15 | * ... |
+| test.cpp:28:15:28:37 | call to malloc | test.cpp:30:14:30:15 | * ... |
+| test.cpp:28:15:28:37 | call to malloc | test.cpp:32:14:32:21 | * ... |
 | test.cpp:29:15:29:28 | ... + ... | test.cpp:29:15:29:28 | ... + ... |
 | test.cpp:29:15:29:28 | ... + ... | test.cpp:30:14:30:15 | * ... |
 | test.cpp:29:15:29:28 | ... + ... | test.cpp:30:14:30:15 | * ... |
@@ -26,22 +26,9 @@ edges
 | test.cpp:29:15:29:28 | ... + ... | test.cpp:32:14:32:21 | * ... |
 | test.cpp:29:15:29:28 | ... + ... | test.cpp:32:14:32:21 | * ... |
 | test.cpp:30:14:30:15 | * ... | test.cpp:32:14:32:21 | * ... |
-| test.cpp:40:15:40:20 | call to malloc | test.cpp:41:15:41:28 | ... + ... |
-| test.cpp:40:15:40:20 | call to malloc | test.cpp:41:15:41:28 | ... + ... |
-| test.cpp:40:15:40:20 | call to malloc | test.cpp:42:14:42:15 | * ... |
-| test.cpp:40:15:40:20 | call to malloc | test.cpp:42:14:42:15 | * ... |
-| test.cpp:40:15:40:20 | call to malloc | test.cpp:44:14:44:21 | * ... |
-| test.cpp:41:15:41:28 | ... + ... | test.cpp:41:15:41:28 | ... + ... |
-| test.cpp:41:15:41:28 | ... + ... | test.cpp:42:14:42:15 | * ... |
-| test.cpp:41:15:41:28 | ... + ... | test.cpp:42:14:42:15 | * ... |
-| test.cpp:41:15:41:28 | ... + ... | test.cpp:42:14:42:15 | * ... |
-| test.cpp:41:15:41:28 | ... + ... | test.cpp:42:14:42:15 | * ... |
-| test.cpp:41:15:41:28 | ... + ... | test.cpp:44:14:44:21 | * ... |
-| test.cpp:41:15:41:28 | ... + ... | test.cpp:44:14:44:21 | * ... |
-| test.cpp:42:14:42:15 | * ... | test.cpp:44:14:44:21 | * ... |
 | test.cpp:51:33:51:35 | end | test.cpp:60:34:60:37 | mk_array output argument |
-| test.cpp:52:19:52:24 | call to malloc | test.cpp:53:5:53:23 | ... = ... |
-| test.cpp:52:19:52:24 | call to malloc | test.cpp:53:12:53:23 | ... + ... |
+| test.cpp:52:19:52:37 | call to malloc | test.cpp:53:5:53:23 | ... = ... |
+| test.cpp:52:19:52:37 | call to malloc | test.cpp:53:12:53:23 | ... + ... |
 | test.cpp:53:5:53:23 | ... = ... | test.cpp:51:33:51:35 | end |
 | test.cpp:53:12:53:23 | ... + ... | test.cpp:53:5:53:23 | ... = ... |
 | test.cpp:60:34:60:37 | mk_array output argument | test.cpp:67:9:67:14 | ... = ... |
@@ -183,8 +170,8 @@ edges
 | test.cpp:781:14:781:27 | new[] | test.cpp:786:18:786:27 | access to array |
 | test.cpp:792:60:792:62 | end | test.cpp:800:40:800:43 | mk_array_no_field_flow output argument |
 | test.cpp:792:60:792:62 | end | test.cpp:832:40:832:43 | mk_array_no_field_flow output argument |
-| test.cpp:793:14:793:19 | call to malloc | test.cpp:794:5:794:24 | ... = ... |
-| test.cpp:793:14:793:19 | call to malloc | test.cpp:794:12:794:24 | ... + ... |
+| test.cpp:793:14:793:32 | call to malloc | test.cpp:794:5:794:24 | ... = ... |
+| test.cpp:793:14:793:32 | call to malloc | test.cpp:794:12:794:24 | ... + ... |
 | test.cpp:794:5:794:24 | ... = ... | test.cpp:792:60:792:62 | end |
 | test.cpp:794:12:794:24 | ... + ... | test.cpp:794:5:794:24 | ... = ... |
 | test.cpp:800:40:800:43 | mk_array_no_field_flow output argument | test.cpp:807:7:807:12 | ... = ... |
@@ -194,28 +181,22 @@ edges
 | test.cpp:832:40:832:43 | mk_array_no_field_flow output argument | test.cpp:833:37:833:39 | end |
 | test.cpp:833:37:833:39 | end | test.cpp:815:52:815:54 | end |
 nodes
-| test.cpp:4:15:4:20 | call to malloc | semmle.label | call to malloc |
+| test.cpp:4:15:4:33 | call to malloc | semmle.label | call to malloc |
 | test.cpp:5:15:5:22 | ... + ... | semmle.label | ... + ... |
 | test.cpp:5:15:5:22 | ... + ... | semmle.label | ... + ... |
 | test.cpp:6:14:6:15 | * ... | semmle.label | * ... |
 | test.cpp:6:14:6:15 | * ... | semmle.label | * ... |
 | test.cpp:8:14:8:21 | * ... | semmle.label | * ... |
-| test.cpp:16:15:16:20 | call to malloc | semmle.label | call to malloc |
+| test.cpp:16:15:16:33 | call to malloc | semmle.label | call to malloc |
 | test.cpp:20:14:20:21 | * ... | semmle.label | * ... |
-| test.cpp:28:15:28:20 | call to malloc | semmle.label | call to malloc |
+| test.cpp:28:15:28:37 | call to malloc | semmle.label | call to malloc |
 | test.cpp:29:15:29:28 | ... + ... | semmle.label | ... + ... |
 | test.cpp:29:15:29:28 | ... + ... | semmle.label | ... + ... |
 | test.cpp:30:14:30:15 | * ... | semmle.label | * ... |
 | test.cpp:30:14:30:15 | * ... | semmle.label | * ... |
 | test.cpp:32:14:32:21 | * ... | semmle.label | * ... |
-| test.cpp:40:15:40:20 | call to malloc | semmle.label | call to malloc |
-| test.cpp:41:15:41:28 | ... + ... | semmle.label | ... + ... |
-| test.cpp:41:15:41:28 | ... + ... | semmle.label | ... + ... |
-| test.cpp:42:14:42:15 | * ... | semmle.label | * ... |
-| test.cpp:42:14:42:15 | * ... | semmle.label | * ... |
-| test.cpp:44:14:44:21 | * ... | semmle.label | * ... |
 | test.cpp:51:33:51:35 | end | semmle.label | end |
-| test.cpp:52:19:52:24 | call to malloc | semmle.label | call to malloc |
+| test.cpp:52:19:52:37 | call to malloc | semmle.label | call to malloc |
 | test.cpp:53:5:53:23 | ... = ... | semmle.label | ... = ... |
 | test.cpp:53:12:53:23 | ... + ... | semmle.label | ... + ... |
 | test.cpp:60:34:60:37 | mk_array output argument | semmle.label | mk_array output argument |
@@ -313,7 +294,7 @@ nodes
 | test.cpp:781:14:781:27 | new[] | semmle.label | new[] |
 | test.cpp:786:18:786:27 | access to array | semmle.label | access to array |
 | test.cpp:792:60:792:62 | end | semmle.label | end |
-| test.cpp:793:14:793:19 | call to malloc | semmle.label | call to malloc |
+| test.cpp:793:14:793:32 | call to malloc | semmle.label | call to malloc |
 | test.cpp:794:5:794:24 | ... = ... | semmle.label | ... = ... |
 | test.cpp:794:12:794:24 | ... + ... | semmle.label | ... + ... |
 | test.cpp:800:40:800:43 | mk_array_no_field_flow output argument | semmle.label | mk_array_no_field_flow output argument |
@@ -325,14 +306,12 @@ nodes
 | test.cpp:833:37:833:39 | end | semmle.label | end |
 subpaths
 #select
-| test.cpp:6:14:6:15 | * ... | test.cpp:4:15:4:20 | call to malloc | test.cpp:6:14:6:15 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:4:15:4:20 | call to malloc | call to malloc | test.cpp:5:19:5:22 | size | size |
-| test.cpp:8:14:8:21 | * ... | test.cpp:4:15:4:20 | call to malloc | test.cpp:8:14:8:21 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@ + 1. | test.cpp:4:15:4:20 | call to malloc | call to malloc | test.cpp:5:19:5:22 | size | size |
-| test.cpp:20:14:20:21 | * ... | test.cpp:16:15:16:20 | call to malloc | test.cpp:20:14:20:21 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:16:15:16:20 | call to malloc | call to malloc | test.cpp:17:19:17:22 | size | size |
-| test.cpp:30:14:30:15 | * ... | test.cpp:28:15:28:20 | call to malloc | test.cpp:30:14:30:15 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:28:15:28:20 | call to malloc | call to malloc | test.cpp:29:20:29:27 | ... + ... | ... + ... |
-| test.cpp:32:14:32:21 | * ... | test.cpp:28:15:28:20 | call to malloc | test.cpp:32:14:32:21 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@ + 1. | test.cpp:28:15:28:20 | call to malloc | call to malloc | test.cpp:29:20:29:27 | ... + ... | ... + ... |
-| test.cpp:42:14:42:15 | * ... | test.cpp:40:15:40:20 | call to malloc | test.cpp:42:14:42:15 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:40:15:40:20 | call to malloc | call to malloc | test.cpp:41:20:41:27 | ... - ... | ... - ... |
-| test.cpp:44:14:44:21 | * ... | test.cpp:40:15:40:20 | call to malloc | test.cpp:44:14:44:21 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@ + 1. | test.cpp:40:15:40:20 | call to malloc | call to malloc | test.cpp:41:20:41:27 | ... - ... | ... - ... |
-| test.cpp:67:9:67:14 | ... = ... | test.cpp:52:19:52:24 | call to malloc | test.cpp:67:9:67:14 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:52:19:52:24 | call to malloc | call to malloc | test.cpp:53:20:53:23 | size | size |
+| test.cpp:6:14:6:15 | * ... | test.cpp:4:15:4:33 | call to malloc | test.cpp:6:14:6:15 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:4:15:4:33 | call to malloc | call to malloc | test.cpp:5:19:5:22 | size | size |
+| test.cpp:8:14:8:21 | * ... | test.cpp:4:15:4:33 | call to malloc | test.cpp:8:14:8:21 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@ + 1. | test.cpp:4:15:4:33 | call to malloc | call to malloc | test.cpp:5:19:5:22 | size | size |
+| test.cpp:20:14:20:21 | * ... | test.cpp:16:15:16:33 | call to malloc | test.cpp:20:14:20:21 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:16:15:16:33 | call to malloc | call to malloc | test.cpp:17:19:17:22 | size | size |
+| test.cpp:30:14:30:15 | * ... | test.cpp:28:15:28:37 | call to malloc | test.cpp:30:14:30:15 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:28:15:28:37 | call to malloc | call to malloc | test.cpp:29:20:29:27 | ... + ... | ... + ... |
+| test.cpp:32:14:32:21 | * ... | test.cpp:28:15:28:37 | call to malloc | test.cpp:32:14:32:21 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@ + 1. | test.cpp:28:15:28:37 | call to malloc | call to malloc | test.cpp:29:20:29:27 | ... + ... | ... + ... |
+| test.cpp:67:9:67:14 | ... = ... | test.cpp:52:19:52:37 | call to malloc | test.cpp:67:9:67:14 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:52:19:52:37 | call to malloc | call to malloc | test.cpp:53:20:53:23 | size | size |
 | test.cpp:201:5:201:19 | ... = ... | test.cpp:194:15:194:33 | call to malloc | test.cpp:201:5:201:19 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:194:15:194:33 | call to malloc | call to malloc | test.cpp:195:21:195:23 | len | len |
 | test.cpp:213:5:213:13 | ... = ... | test.cpp:205:15:205:33 | call to malloc | test.cpp:213:5:213:13 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:205:15:205:33 | call to malloc | call to malloc | test.cpp:206:21:206:23 | len | len |
 | test.cpp:232:3:232:20 | ... = ... | test.cpp:231:18:231:30 | new[] | test.cpp:232:3:232:20 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:231:18:231:30 | new[] | new[] | test.cpp:232:11:232:15 | index | index |
@@ -359,5 +338,5 @@ subpaths
 | test.cpp:772:16:772:29 | access to array | test.cpp:754:18:754:31 | new[] | test.cpp:772:16:772:29 | access to array | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:754:18:754:31 | new[] | new[] | test.cpp:767:22:767:28 | ... + ... | ... + ... |
 | test.cpp:772:16:772:29 | access to array | test.cpp:754:18:754:31 | new[] | test.cpp:772:16:772:29 | access to array | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:754:18:754:31 | new[] | new[] | test.cpp:772:22:772:28 | ... + ... | ... + ... |
 | test.cpp:786:18:786:27 | access to array | test.cpp:781:14:781:27 | new[] | test.cpp:786:18:786:27 | access to array | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:781:14:781:27 | new[] | new[] | test.cpp:786:20:786:26 | ... + ... | ... + ... |
-| test.cpp:807:7:807:12 | ... = ... | test.cpp:793:14:793:19 | call to malloc | test.cpp:807:7:807:12 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:793:14:793:19 | call to malloc | call to malloc | test.cpp:794:21:794:24 | size | size |
-| test.cpp:821:7:821:12 | ... = ... | test.cpp:793:14:793:19 | call to malloc | test.cpp:821:7:821:12 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:793:14:793:19 | call to malloc | call to malloc | test.cpp:794:21:794:24 | size | size |
+| test.cpp:807:7:807:12 | ... = ... | test.cpp:793:14:793:32 | call to malloc | test.cpp:807:7:807:12 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:793:14:793:32 | call to malloc | call to malloc | test.cpp:794:21:794:24 | size | size |
+| test.cpp:821:7:821:12 | ... = ... | test.cpp:793:14:793:32 | call to malloc | test.cpp:821:7:821:12 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:793:14:793:32 | call to malloc | call to malloc | test.cpp:794:21:794:24 | size | size |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-193/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-193/test.cpp
@@ -832,3 +832,20 @@ void test7_no_field_flow(int size) {
   mk_array_no_field_flow(size, &begin, &end);
   test7_callee_no_field_flow(begin, end);
 }
+
+void test15_with_malloc(unsigned long index) {
+  unsigned long size = index + 13;
+  if(size < index) {
+    return;
+  }
+  int* newname = (int*)malloc(size);
+  newname[index] = 0; // $ SPURIOUS: alloc=L841 deref=L842 // GOOD [FALSE POSITIVE]
+}
+
+void test16_with_malloc(unsigned long index) {
+  unsigned long size = index + 13;
+  if(size >= index) {
+    int* newname = (int*)malloc(size);
+    newname[index] = 0; // $ SPURIOUS: alloc=L848 deref=L849 // GOOD [FALSE POSITIVE]
+  }
+}

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-193/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-193/test.cpp
@@ -1,7 +1,7 @@
-char *malloc(int size);
+void* malloc(unsigned long size);
 
 void test1(int size) {
-    char* p = malloc(size);
+    char* p = (char*)malloc(size);
     char* q = p + size; // $ alloc=L4
     char a = *q; // $ deref=L6 // BAD
     char b = *(q - 1); // GOOD
@@ -13,7 +13,7 @@ void test1(int size) {
 }
 
 void test2(int size) {
-    char* p = malloc(size);
+    char* p = (char*)malloc(size);
     char* q = p + size - 1; // $ alloc=L16
     char a = *q; // GOOD
     char b = *(q - 1); // GOOD
@@ -25,7 +25,7 @@ void test2(int size) {
 }
 
 void test3(int size) {
-    char* p = malloc(size + 1);
+    char* p = (char*)malloc(size + 1);
     char* q = p + (size + 1); // $ alloc=L28+1
     char a = *q; // $ deref=L30 // BAD
     char b = *(q - 1); // GOOD
@@ -37,11 +37,11 @@ void test3(int size) {
 }
 
 void test4(int size) {
-    char* p = malloc(size - 1);
-    char* q = p + (size - 1); // $ alloc=L40-1
-    char a = *q; // $ deref=L42 // BAD
+    char* p = (char*)malloc(size - 1);
+    char* q = p + (size - 1); // $ MISSING: alloc=L40-1
+    char a = *q; // $ MISSING: deref=L42 // BAD [NOT DETECTED]
     char b = *(q - 1); // GOOD
-    char c = *(q + 1); // $ deref=L44+1 // BAD
+    char c = *(q + 1); // $ MISSING: deref=L44+1 // BAD [NOT DETECTED]
     char d = *(q + size); // BAD [NOT DETECTED]
     char e = *(q - size); // GOOD
     char f = *(q + size + 1); // BAD [NOT DETECTED]
@@ -49,7 +49,7 @@ void test4(int size) {
 }
 
 char* mk_array(int size, char** end) {
-    char* begin = malloc(size);
+    char* begin = (char*)malloc(size);
     *end = begin + size; // $ alloc=L52
 
     return begin;
@@ -79,7 +79,7 @@ struct array_t {
 
 array_t mk_array(int size) {
     array_t arr;
-    arr.begin = malloc(size);
+    arr.begin = (char*)malloc(size);
     arr.end = arr.begin + size; // $ MISSING: alloc=L82
 
     return arr;
@@ -121,7 +121,7 @@ void test7(int size) {
 
 void test8(int size) {
     array_t arr;
-    char* p = malloc(size);
+    char* p = (char*)malloc(size);
     arr.begin = p;
     arr.end = p + size; // $ alloc=L124
 
@@ -140,7 +140,7 @@ void test8(int size) {
 
 array_t *mk_array_p(int size) {
     array_t *arr = (array_t*) malloc(sizeof(array_t));
-    arr->begin = malloc(size);
+    arr->begin = (char*)malloc(size);
     arr->end = arr->begin + size; // $ MISSING: alloc=L143
 
     return arr;
@@ -185,7 +185,7 @@ void deref_plus_one(char* q) {
 }
 
 void test11(unsigned size) {
-    char *p = malloc(size);
+    char *p = (char*)malloc(size);
     char *q = p + size - 1; // $ alloc=L188
     deref_plus_one(q);
 }
@@ -790,7 +790,7 @@ void test38_simple(unsigned size, unsigned pos, unsigned numParams) {
 }
 
 void mk_array_no_field_flow(int size, char** begin, char** end) {
-    *begin = malloc(size);
+    *begin = (char*)malloc(size);
     *end = *begin + size; // $ alloc=L793
 }
 


### PR DESCRIPTION
Note that this breaks a couple of tests. This is good, however: prior to this PR these things wouldn't work on a real project anyway, but now we at least know about it in our tests 😄.

The last commit adds a couple of additional tests.