### PR TITLE
C++: Reduce dataflow duplication for allocations

### DIFF
--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/SAMATE/OverrunWriteProductFlow.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/SAMATE/OverrunWriteProductFlow.expected
@@ -47,25 +47,19 @@ edges
 | test.cpp:207:17:207:19 | str indirection [string] | test.cpp:207:22:207:27 | string |
 | test.cpp:214:24:214:24 | p | test.cpp:216:10:216:10 | p |
 | test.cpp:220:27:220:54 | call to malloc | test.cpp:222:15:222:20 | buffer |
-| test.cpp:220:43:220:48 | call to malloc | test.cpp:222:15:222:20 | buffer |
 | test.cpp:222:15:222:20 | buffer | test.cpp:214:24:214:24 | p |
 | test.cpp:228:27:228:54 | call to malloc | test.cpp:232:10:232:15 | buffer |
-| test.cpp:228:43:228:48 | call to malloc | test.cpp:232:10:232:15 | buffer |
 | test.cpp:235:40:235:45 | buffer | test.cpp:236:5:236:26 | ... = ... |
 | test.cpp:236:5:236:26 | ... = ... | test.cpp:236:12:236:17 | p_str indirection [post update] [string] |
 | test.cpp:241:20:241:38 | call to malloc | test.cpp:242:22:242:27 | buffer |
-| test.cpp:241:27:241:32 | call to malloc | test.cpp:242:22:242:27 | buffer |
 | test.cpp:242:16:242:19 | set_string output argument [string] | test.cpp:243:12:243:14 | str indirection [string] |
 | test.cpp:242:22:242:27 | buffer | test.cpp:235:40:235:45 | buffer |
 | test.cpp:242:22:242:27 | buffer | test.cpp:242:16:242:19 | set_string output argument [string] |
 | test.cpp:243:12:243:14 | str indirection [string] | test.cpp:243:12:243:21 | string |
 | test.cpp:249:14:249:33 | call to my_alloc | test.cpp:250:12:250:12 | p |
 | test.cpp:256:9:256:25 | call to malloc | test.cpp:257:12:257:12 | p |
-| test.cpp:256:17:256:22 | call to malloc | test.cpp:257:12:257:12 | p |
 | test.cpp:262:15:262:30 | call to malloc | test.cpp:266:12:266:12 | p |
-| test.cpp:262:22:262:27 | call to malloc | test.cpp:266:12:266:12 | p |
 | test.cpp:264:13:264:30 | call to malloc | test.cpp:266:12:266:12 | p |
-| test.cpp:264:20:264:25 | call to malloc | test.cpp:266:12:266:12 | p |
 nodes
 | test.cpp:16:11:16:21 | mk_string_t indirection [string] | semmle.label | mk_string_t indirection [string] |
 | test.cpp:18:5:18:30 | ... = ... | semmle.label | ... = ... |
@@ -116,16 +110,13 @@ nodes
 | test.cpp:214:24:214:24 | p | semmle.label | p |
 | test.cpp:216:10:216:10 | p | semmle.label | p |
 | test.cpp:220:27:220:54 | call to malloc | semmle.label | call to malloc |
-| test.cpp:220:43:220:48 | call to malloc | semmle.label | call to malloc |
 | test.cpp:222:15:222:20 | buffer | semmle.label | buffer |
 | test.cpp:228:27:228:54 | call to malloc | semmle.label | call to malloc |
-| test.cpp:228:43:228:48 | call to malloc | semmle.label | call to malloc |
 | test.cpp:232:10:232:15 | buffer | semmle.label | buffer |
 | test.cpp:235:40:235:45 | buffer | semmle.label | buffer |
 | test.cpp:236:5:236:26 | ... = ... | semmle.label | ... = ... |
 | test.cpp:236:12:236:17 | p_str indirection [post update] [string] | semmle.label | p_str indirection [post update] [string] |
 | test.cpp:241:20:241:38 | call to malloc | semmle.label | call to malloc |
-| test.cpp:241:27:241:32 | call to malloc | semmle.label | call to malloc |
 | test.cpp:242:16:242:19 | set_string output argument [string] | semmle.label | set_string output argument [string] |
 | test.cpp:242:22:242:27 | buffer | semmle.label | buffer |
 | test.cpp:243:12:243:14 | str indirection [string] | semmle.label | str indirection [string] |
@@ -133,12 +124,9 @@ nodes
 | test.cpp:249:14:249:33 | call to my_alloc | semmle.label | call to my_alloc |
 | test.cpp:250:12:250:12 | p | semmle.label | p |
 | test.cpp:256:9:256:25 | call to malloc | semmle.label | call to malloc |
-| test.cpp:256:17:256:22 | call to malloc | semmle.label | call to malloc |
 | test.cpp:257:12:257:12 | p | semmle.label | p |
 | test.cpp:262:15:262:30 | call to malloc | semmle.label | call to malloc |
-| test.cpp:262:22:262:27 | call to malloc | semmle.label | call to malloc |
 | test.cpp:264:13:264:30 | call to malloc | semmle.label | call to malloc |
-| test.cpp:264:20:264:25 | call to malloc | semmle.label | call to malloc |
 | test.cpp:266:12:266:12 | p | semmle.label | p |
 subpaths
 | test.cpp:242:22:242:27 | buffer | test.cpp:235:40:235:45 | buffer | test.cpp:236:12:236:17 | p_str indirection [post update] [string] | test.cpp:242:16:242:19 | set_string output argument [string] |
@@ -159,7 +147,5 @@ subpaths
 | test.cpp:203:9:203:15 | call to strncpy | test.cpp:147:19:147:24 | call to malloc | test.cpp:203:22:203:27 | string | This write may overflow $@ by 2 elements. | test.cpp:203:22:203:27 | string | string |
 | test.cpp:207:9:207:15 | call to strncpy | test.cpp:147:19:147:24 | call to malloc | test.cpp:207:22:207:27 | string | This write may overflow $@ by 3 elements. | test.cpp:207:22:207:27 | string | string |
 | test.cpp:243:5:243:10 | call to memset | test.cpp:241:20:241:38 | call to malloc | test.cpp:243:12:243:21 | string | This write may overflow $@ by 1 element. | test.cpp:243:16:243:21 | string | string |
-| test.cpp:243:5:243:10 | call to memset | test.cpp:241:27:241:32 | call to malloc | test.cpp:243:12:243:21 | string | This write may overflow $@ by 1 element. | test.cpp:243:16:243:21 | string | string |
 | test.cpp:250:5:250:10 | call to memset | test.cpp:249:14:249:33 | call to my_alloc | test.cpp:250:12:250:12 | p | This write may overflow $@ by 1 element. | test.cpp:250:12:250:12 | p | p |
 | test.cpp:266:5:266:10 | call to memset | test.cpp:262:15:262:30 | call to malloc | test.cpp:266:12:266:12 | p | This write may overflow $@ by 1 element. | test.cpp:266:12:266:12 | p | p |
-| test.cpp:266:5:266:10 | call to memset | test.cpp:262:22:262:27 | call to malloc | test.cpp:266:12:266:12 | p | This write may overflow $@ by 1 element. | test.cpp:266:12:266:12 | p | p |


### PR DESCRIPTION
Quite an awkward change, but at least the diff is small and the change is very local `:half-tada:`