### PR TITLE
Java: Consider AssignOps in ArithExpr

### DIFF
--- a/java/ql/lib/change-notes/2023-09-19-arithexpr-assignop.md
+++ b/java/ql/lib/change-notes/2023-09-19-arithexpr-assignop.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Improved the class `ArithExpr` of the `Overflow.qll` module to also include compound operators. Because of this, new alerts may be raised in queries related to overflows/underflows.

--- a/java/ql/lib/semmle/code/java/arithmetic/Overflow.qll
+++ b/java/ql/lib/semmle/code/java/arithmetic/Overflow.qll
@@ -80,11 +80,19 @@ class ArithExpr extends Expr {
     (
       this instanceof UnaryAssignExpr or
       this instanceof AddExpr or
+      this instanceof AssignAddExpr or
       this instanceof MulExpr or
+      this instanceof AssignMulExpr or
       this instanceof SubExpr or
-      this instanceof DivExpr
+      this instanceof AssignSubExpr or
+      this instanceof DivExpr or
+      this instanceof AssignDivExpr
     ) and
-    forall(Expr e | e = this.(BinaryExpr).getAnOperand() or e = this.(UnaryAssignExpr).getExpr() |
+    forall(Expr e |
+      e = this.(BinaryExpr).getAnOperand() or
+      e = this.(UnaryAssignExpr).getExpr() or
+      e = this.(AssignOp).getSource()
+    |
       e.getType() instanceof NumType
     )
   }
@@ -103,17 +111,21 @@ class ArithExpr extends Expr {
    */
   Expr getLeftOperand() {
     result = this.(BinaryExpr).getLeftOperand() or
-    result = this.(UnaryAssignExpr).getExpr()
+    result = this.(UnaryAssignExpr).getExpr() or
+    result = this.(AssignOp).getDest()
   }
 
   /**
    * Gets the right-hand operand if this is a binary expression.
    */
-  Expr getRightOperand() { result = this.(BinaryExpr).getRightOperand() }
+  Expr getRightOperand() {
+    result = this.(BinaryExpr).getRightOperand() or result = this.(AssignOp).getRhs()
+  }
 
   /** Gets an operand of this arithmetic expression. */
   Expr getAnOperand() {
     result = this.(BinaryExpr).getAnOperand() or
-    result = this.(UnaryAssignExpr).getExpr()
+    result = this.(UnaryAssignExpr).getExpr() or
+    result = this.(AssignOp).getSource()
   }
 }


### PR DESCRIPTION
`ArithExpr` was considering unary and binary operators, but not compound operators, which are equally relevant for arithmetic-related questions. This PR adds `AssignOp`s to the definition of `ArithExpr` to address that.