### PR TITLE
C++: Use `size_t` explicitly in CWE-193 tests

### DIFF
--- a/cpp/ql/test/query-tests/Security/CWE/CWE-193/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-193/test.cpp
@@ -1,4 +1,4 @@
-void* malloc(unsigned long size);
+using size_t = decltype(sizeof 0); void* malloc(size_t size);
 
 void test1(int size) {
     char* p = (char*)malloc(size);
@@ -215,7 +215,7 @@ void test13(unsigned len, unsigned index) {
 
 bool unknown();
 
-void test14(unsigned long n, char *p) {
+void test14(size_t n, char *p) {
   while (unknown()) {
     n++;
     p = (char *)malloc(n);
@@ -706,7 +706,7 @@ void deref(char* q) {
   char x = *q; // $ deref=L714->L705->L706 // BAD
 }
 
-void test35(unsigned long size, char* q)
+void test35(size_t size, char* q)
 {
   char* p = new char[size];
   char* end = p + size; // $ alloc=L711
@@ -734,10 +734,10 @@ void test36(unsigned size, unsigned n) {
   }
 }
 
-void test37(unsigned long n)
+void test37(size_t n)
 {
   int *p = new int[n];
-  for (unsigned long i = n; i != 0u; i--)
+  for (size_t i = n; i != 0u; i--)
   {
     p[n - i] = 0; // GOOD
   }
@@ -833,8 +833,8 @@ void test7_no_field_flow(int size) {
   test7_callee_no_field_flow(begin, end);
 }
 
-void test15_with_malloc(unsigned long index) {
-  unsigned long size = index + 13;
+void test15_with_malloc(size_t index) {
+  size_t size = index + 13;
   if(size < index) {
     return;
   }
@@ -842,8 +842,8 @@ void test15_with_malloc(unsigned long index) {
   newname[index] = 0; // $ SPURIOUS: alloc=L841 deref=L842 // GOOD [FALSE POSITIVE]
 }
 
-void test16_with_malloc(unsigned long index) {
-  unsigned long size = index + 13;
+void test16_with_malloc(size_t index) {
+  size_t size = index + 13;
   if(size >= index) {
     int* newname = (int*)malloc(size);
     newname[index] = 0; // $ SPURIOUS: alloc=L848 deref=L849 // GOOD [FALSE POSITIVE]


### PR DESCRIPTION
cc @sashabu 