### PR TITLE
s/Replace/ReplaceAll/ in LogInjectionGood.go

### DIFF
--- a/go/ql/src/Security/CWE-117/LogInjectionGood.go
+++ b/go/ql/src/Security/CWE-117/LogInjectionGood.go
@@ -9,7 +9,7 @@ import (
 // GOOD: The user-provided value is escaped before being written to the log.
 func handlerGood(req *http.Request) {
 	username := req.URL.Query()["username"][0]
-	escapedUsername := strings.ReplaceAll(username, "\n", "", -1)
-	escapedUsername = strings.ReplaceAll(escapedUsername, "\r", "", -1)
+	escapedUsername := strings.ReplaceAll(username, "\n", "")
+	escapedUsername = strings.ReplaceAll(escapedUsername, "\r", "")
 	log.Printf("user %s logged in.\n", escapedUsername)
 }

--- a/go/ql/src/Security/CWE-117/LogInjectionGood.go
+++ b/go/ql/src/Security/CWE-117/LogInjectionGood.go
@@ -9,7 +9,7 @@ import (
 // GOOD: The user-provided value is escaped before being written to the log.
 func handlerGood(req *http.Request) {
 	username := req.URL.Query()["username"][0]
-	escapedUsername := strings.Replace(username, "\n", "", -1)
-	escapedUsername = strings.Replace(escapedUsername, "\r", "", -1)
+	escapedUsername := strings.ReplaceAll(username, "\n", "", -1)
+	escapedUsername = strings.ReplaceAll(escapedUsername, "\r", "", -1)
 	log.Printf("user %s logged in.\n", escapedUsername)
 }


### PR DESCRIPTION
Hello friends,

We recently came across a Code-QL alert for LogInjection, and the suggestion was really useful!

However, after we applied the suggested fix our linter came back and said "actually, don't you mean `ReplaceAll`?" And on second thought, I think the linter is correct! A malicious payload could just have two `\n`s and evade this escaping.

I am hereby proposing that the suggestion instead use `ReplaceAll`.