### PR TITLE
Ruby: Fix bad join

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
@@ -740,6 +740,12 @@ class ContentSet extends TContentSet {
  */
 signature predicate guardChecksSig(CfgNodes::AstCfgNode g, CfgNode e, boolean branch);
 
+bindingset[def1, def2]
+pragma[inline_late]
+private predicate sameSourceVariable(Ssa::Definition def1, Ssa::Definition def2) {
+  def1.getSourceVariable() = def2.getSourceVariable()
+}
+
 /**
  * Provides a set of barrier nodes for a guard that validates an expression.
  *
@@ -784,9 +790,9 @@ module BarrierGuard<guardChecksSig/3 guardChecks> {
     |
       def.getARead() = testedNode and
       guardChecks(g, testedNode, branch) and
-      def.getSourceVariable() = result.getSourceVariable() and
       guardControlsBlock(g, call.getBasicBlock(), branch) and
-      result.getBasicBlock().getScope() = call.getExpr().(MethodCall).getBlock()
+      result.getBasicBlock().getScope() = call.getExpr().(MethodCall).getBlock() and
+      sameSourceVariable(def, result)
     )
   }
 }
@@ -849,9 +855,9 @@ abstract deprecated class BarrierGuard extends CfgNodes::ExprCfgNode {
     |
       def.getARead() = testedNode and
       this.checks(testedNode, branch) and
-      def.getSourceVariable() = result.getSourceVariable() and
       this.controlsBlock(call.getBasicBlock(), branch) and
-      result.getBasicBlock().getScope() = call.getExpr().(MethodCall).getBlock()
+      result.getBasicBlock().getScope() = call.getExpr().(MethodCall).getBlock() and
+      sameSourceVariable(def, result)
     )
   }
 


### PR DESCRIPTION
Before
```
Evaluated relational algebra for predicate DataFlowPublic#e1781e31::BarrierGuard#PolynomialReDoSCustomizations#32063fa3::PolynomialReDoS::lengthGuard#::getAMaybeGuardedCapturedDef#0#f@3c903abq with tuple counts:
          280924  ~0%    {2} r1 = SCAN Ssa#da392372::Make#SsaImpl#ff97b16a::SsaInput#::Definition::definesAt#3#dispred#ffff OUTPUT In.2, In.0
          280924  ~0%    {2} r2 = JOIN r1 WITH BasicBlocks#d5fe3e99::BasicBlock::getScope#0#dispred#ff ON FIRST 1 OUTPUT Lhs.1, Rhs.1
          103843  ~1%    {2} r3 = JOIN r2 WITH SSA#304893e3::Ssa::CapturedEntryDefinition#f ON FIRST 1 OUTPUT Lhs.0, Lhs.1
          103843  ~5%    {3} r4 = JOIN r3 WITH Ssa#da392372::Make#SsaImpl#ff97b16a::SsaInput#::Definition::getSourceVariable#0#dispred#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.0
        19665045  ~0%    {3} r5 = JOIN r4 WITH Ssa#da392372::Make#SsaImpl#ff97b16a::SsaInput#::Definition::getSourceVariable#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Rhs.1
        19497860  ~0%    {3} r6 = JOIN r5 WITH Call#841c84e8::MethodCall::getBlock#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
        19496808  ~0%    {3} r7 = JOIN r6 WITH CfgNodes#ace8e412::ExprCfgNode::getExpr#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
        19496808  ~0%    {3} r8 = JOIN r7 WITH CfgNodes#ace8e412::ExprNodes::CallCfgNode#ff ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2
        19496808  ~0%    {3} r9 = JOIN r8 WITH ControlFlowGraph#46cebcbd::CfgNode::getBasicBlock#0#dispred#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
        19496808  ~3%    {4} r10 = SCAN r9 OUTPUT In.0, true, In.1, In.2
           49434  ~7%    {3} r11 = JOIN r10 WITH DataFlowPublic#e1781e31::guardControlsBlock#3#fff_120#join_rhs ON FIRST 2 OUTPUT Rhs.2, Lhs.2, Lhs.3
             117  ~4%    {3} r12 = JOIN r11 WITH PolynomialReDoSCustomizations#32063fa3::PolynomialReDoS::lengthGuard#3#cpe#12#ff ON FIRST 1 OUTPUT Lhs.2, Rhs.1, Lhs.1
               0  ~0%    {1} r13 = JOIN r12 WITH SsaImpl#ff97b16a::Cached::getARead#1#ff ON FIRST 2 OUTPUT Lhs.2
                         return r13
```

After
```
Evaluated relational algebra for predicate DataFlowPublic#e1781e31::BarrierGuard#PolynomialReDoSCustomizations#32063fa3::PolynomialReDoS::lengthGuard#::getAMaybeGuardedCapturedDef#0#f@137a23jm with tuple counts:
        280924  ~0%    {2} r1 = SCAN Ssa#da392372::Make#SsaImpl#ff97b16a::SsaInput#::Definition::definesAt#3#dispred#ffff OUTPUT In.2, In.0
        280924  ~0%    {2} r2 = JOIN r1 WITH BasicBlocks#d5fe3e99::BasicBlock::getScope#0#dispred#ff ON FIRST 1 OUTPUT Lhs.1, Rhs.1
        103843  ~1%    {2} r3 = JOIN r2 WITH SSA#304893e3::Ssa::CapturedEntryDefinition#f ON FIRST 1 OUTPUT Lhs.1, Lhs.0
        102517  ~1%    {2} r4 = JOIN r3 WITH Call#841c84e8::MethodCall::getBlock#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
        102378  ~2%    {2} r5 = JOIN r4 WITH CfgNodes#ace8e412::ExprCfgNode::getExpr#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
        102378  ~2%    {2} r6 = JOIN r5 WITH CfgNodes#ace8e412::ExprNodes::CallCfgNode#ff ON FIRST 1 OUTPUT Lhs.0, Lhs.1
        102378  ~0%    {2} r7 = JOIN r6 WITH ControlFlowGraph#46cebcbd::CfgNode::getBasicBlock#0#dispred#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1
        102378  ~0%    {3} r8 = SCAN r7 OUTPUT In.0, true, In.1
          7417  ~5%    {2} r9 = JOIN r8 WITH DataFlowPublic#e1781e31::guardControlsBlock#3#fff_120#join_rhs ON FIRST 2 OUTPUT Rhs.2, Lhs.2
            22  ~0%    {2} r10 = JOIN r9 WITH PolynomialReDoSCustomizations#32063fa3::PolynomialReDoS::lengthGuard#3#cpe#12#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1
            12  ~0%    {2} r11 = JOIN r10 WITH SsaImpl#ff97b16a::Cached::getARead#1#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
            12  ~0%    {2} r12 = JOIN r11 WITH Ssa#da392372::Make#SsaImpl#ff97b16a::SsaInput#::Definition::getSourceVariable#0#dispred#ff ON FIRST 1 OUTPUT Lhs.1, Rhs.1
             0  ~0%    {1} r13 = JOIN r12 WITH Ssa#da392372::Make#SsaImpl#ff97b16a::SsaInput#::Definition::getSourceVariable#0#dispred#ff ON FIRST 2 OUTPUT Lhs.0
                       return r13
```