### PR TITLE
Go CI: test multiple Go versions

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -15,17 +15,21 @@ on:
       - .github/workflows/go-tests.yml
       - .github/actions/**
       - codeql-workspace.yml
-env:
-  GO_VERSION: '~1.21.0'
 jobs:
   test-linux:
     name: Test Linux (Ubuntu)
     runs-on: ubuntu-latest-xl
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version:
+          - '~1.21.0'
+          - '~1.20'
     steps:
-      - name: Set up Go ${{ env.GO_VERSION }}
+      - name: Set up Go ${{ matrix.go-version }}
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: ${{ matrix.go-version }}
         id: go
 
       - name: Check out code


### PR DESCRIPTION
This PR modifies the CI workflow for Go on Linux to run a matrix build with multiple different versions of Go (1.20 and 1.21). 