### PR TITLE
C#: Remove platform-specific runtime nuget packages from the reference list in Standalone

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/ProgressMonitor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/ProgressMonitor.cs
@@ -57,6 +57,9 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         public void ResolvedReference(string filename) =>
             LogInfo($"Resolved {filename}");
 
+        public void RemovedReference(string filename) =>
+            LogInfo($"Reference {filename} has been removed");
+
         public void Summary(int existingSources, int usedSources, int missingSources,
             int references, int unresolvedReferences,
             int resolvedConflicts, int totalProjects, int failedProjects,


### PR DESCRIPTION
When the installed sdk doesn't match the target framework versions, reference assemblies are downloaded as nuget packages. Similarly platform specific runtime packages such as `Microsoft.NETCore.App.Runtime.linux-x64` are also downloaded and extracted in Standalone mode. This PR removes the runtime packages from the reference list.

I tested this change on the `ThreeMammals/Ocelot` repo with dotnet 8 installed on the machine. Before the change we had conflicts:
```
error CS0433: The type 'List<T>' exists in both 'System.Collections, Version=8.0.0.0, ...' and 'System.Private.CoreLib, Version=7.0.0.0, ...'
```

After the change the call target query shows improved precision:
```diff
 Query CallTargets.ql:
-  Result count - both/traced/standalone: 22026/9434/893
-  Result count in the matching 627 files - both/traced/standalone: 22026/9434/873
-   Matching 68.12%
+  Result count - both/traced/standalone: 30312/1148/703
+  Result count in the matching 627 files - both/traced/standalone: 30312/1148/683
+   Matching 94.3%
```