### PR TITLE
Swift: Fix bug in taint flow through string interpolation

### DIFF
--- a/swift/ql/lib/codeql/swift/dataflow/internal/TaintTrackingPrivate.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/TaintTrackingPrivate.qll
@@ -33,7 +33,7 @@ private module Cached {
     exists(ApplyExpr apply, ExprCfgNode e |
       nodeFrom.asExpr() = [apply.getAnArgument().getExpr(), apply.getQualifier()] and
       apply.getStaticTarget().getName() = ["appendLiteral(_:)", "appendInterpolation(_:)"] and
-      e.getExpr() = [apply.getAnArgument().getExpr(), apply.getQualifier()] and
+      e.getExpr() = apply.getQualifier() and
       nodeTo.(PostUpdateNodeImpl).getPreUpdateNode().getCfgNode() = e
     )
     or

--- a/swift/ql/test/library-tests/dataflow/taint/core/LocalTaint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/core/LocalTaint.expected
@@ -147,14 +147,10 @@
 | stringinterpolation.swift:13:3:13:3 | [post] self | stringinterpolation.swift:13:3:13:3 | &... |
 | stringinterpolation.swift:13:3:13:3 | self | stringinterpolation.swift:13:3:13:3 | &... |
 | stringinterpolation.swift:13:3:13:3 | self | stringinterpolation.swift:13:3:13:3 | [post] self |
-| stringinterpolation.swift:13:3:13:3 | self | stringinterpolation.swift:13:23:13:23 | [post] "..." |
 | stringinterpolation.swift:13:23:13:23 | "..." | stringinterpolation.swift:13:3:13:3 | [post] self |
-| stringinterpolation.swift:13:23:13:23 | "..." | stringinterpolation.swift:13:23:13:23 | [post] "..." |
 | stringinterpolation.swift:13:23:13:23 | SSA def($interpolation) | stringinterpolation.swift:13:24:13:24 | $interpolation |
 | stringinterpolation.swift:13:23:13:23 | TapExpr | stringinterpolation.swift:13:23:13:23 | "..." |
-| stringinterpolation.swift:13:23:13:23 | first is:  | stringinterpolation.swift:13:23:13:23 | [post] first is:  |
 | stringinterpolation.swift:13:23:13:23 | first is:  | stringinterpolation.swift:13:24:13:24 | [post] $interpolation |
-| stringinterpolation.swift:13:24:13:24 | $interpolation | stringinterpolation.swift:13:23:13:23 | [post] first is:  |
 | stringinterpolation.swift:13:24:13:24 | $interpolation | stringinterpolation.swift:13:24:13:24 | &... |
 | stringinterpolation.swift:13:24:13:24 | $interpolation | stringinterpolation.swift:13:24:13:24 | [post] $interpolation |
 | stringinterpolation.swift:13:24:13:24 | &... | stringinterpolation.swift:13:35:13:35 | $interpolation |
@@ -164,10 +160,8 @@
 | stringinterpolation.swift:13:35:13:35 | &... | stringinterpolation.swift:13:47:13:47 | $interpolation |
 | stringinterpolation.swift:13:35:13:35 | [post] $interpolation | stringinterpolation.swift:13:35:13:35 | &... |
 | stringinterpolation.swift:13:36:13:41 | .first | stringinterpolation.swift:13:35:13:35 | [post] $interpolation |
-| stringinterpolation.swift:13:47:13:47 |  | stringinterpolation.swift:13:47:13:47 | [post]  |
 | stringinterpolation.swift:13:47:13:47 |  | stringinterpolation.swift:13:47:13:47 | [post] $interpolation |
 | stringinterpolation.swift:13:47:13:47 | $interpolation | stringinterpolation.swift:13:47:13:47 | &... |
-| stringinterpolation.swift:13:47:13:47 | $interpolation | stringinterpolation.swift:13:47:13:47 | [post]  |
 | stringinterpolation.swift:13:47:13:47 | $interpolation | stringinterpolation.swift:13:47:13:47 | [post] $interpolation |
 | stringinterpolation.swift:13:47:13:47 | &... | stringinterpolation.swift:13:23:13:23 | TapExpr |
 | stringinterpolation.swift:13:47:13:47 | [post] $interpolation | stringinterpolation.swift:13:47:13:47 | &... |
@@ -180,9 +174,7 @@
 | stringinterpolation.swift:20:2:20:2 | p1 | stringinterpolation.swift:22:21:22:21 | p1 |
 | stringinterpolation.swift:22:12:22:12 | SSA def($interpolation) | stringinterpolation.swift:22:13:22:13 | $interpolation |
 | stringinterpolation.swift:22:12:22:12 | TapExpr | stringinterpolation.swift:22:12:22:12 | "..." |
-| stringinterpolation.swift:22:12:22:12 | pair:  | stringinterpolation.swift:22:12:22:12 | [post] pair:  |
 | stringinterpolation.swift:22:12:22:12 | pair:  | stringinterpolation.swift:22:13:22:13 | [post] $interpolation |
-| stringinterpolation.swift:22:13:22:13 | $interpolation | stringinterpolation.swift:22:12:22:12 | [post] pair:  |
 | stringinterpolation.swift:22:13:22:13 | $interpolation | stringinterpolation.swift:22:13:22:13 | &... |
 | stringinterpolation.swift:22:13:22:13 | $interpolation | stringinterpolation.swift:22:13:22:13 | [post] $interpolation |
 | stringinterpolation.swift:22:13:22:13 | &... | stringinterpolation.swift:22:20:22:20 | $interpolation |
@@ -194,18 +186,14 @@
 | stringinterpolation.swift:22:21:22:21 | [post] p1 | stringinterpolation.swift:23:21:23:21 | p1 |
 | stringinterpolation.swift:22:21:22:21 | p1 | stringinterpolation.swift:23:21:23:21 | p1 |
 | stringinterpolation.swift:22:21:22:24 | .first | stringinterpolation.swift:22:20:22:20 | [post] $interpolation |
-| stringinterpolation.swift:22:30:22:30 |  | stringinterpolation.swift:22:30:22:30 | [post]  |
 | stringinterpolation.swift:22:30:22:30 |  | stringinterpolation.swift:22:30:22:30 | [post] $interpolation |
 | stringinterpolation.swift:22:30:22:30 | $interpolation | stringinterpolation.swift:22:30:22:30 | &... |
-| stringinterpolation.swift:22:30:22:30 | $interpolation | stringinterpolation.swift:22:30:22:30 | [post]  |
 | stringinterpolation.swift:22:30:22:30 | $interpolation | stringinterpolation.swift:22:30:22:30 | [post] $interpolation |
 | stringinterpolation.swift:22:30:22:30 | &... | stringinterpolation.swift:22:12:22:12 | TapExpr |
 | stringinterpolation.swift:22:30:22:30 | [post] $interpolation | stringinterpolation.swift:22:30:22:30 | &... |
 | stringinterpolation.swift:23:12:23:12 | SSA def($interpolation) | stringinterpolation.swift:23:13:23:13 | $interpolation |
 | stringinterpolation.swift:23:12:23:12 | TapExpr | stringinterpolation.swift:23:12:23:12 | "..." |
-| stringinterpolation.swift:23:12:23:12 | pair:  | stringinterpolation.swift:23:12:23:12 | [post] pair:  |
 | stringinterpolation.swift:23:12:23:12 | pair:  | stringinterpolation.swift:23:13:23:13 | [post] $interpolation |
-| stringinterpolation.swift:23:13:23:13 | $interpolation | stringinterpolation.swift:23:12:23:12 | [post] pair:  |
 | stringinterpolation.swift:23:13:23:13 | $interpolation | stringinterpolation.swift:23:13:23:13 | &... |
 | stringinterpolation.swift:23:13:23:13 | $interpolation | stringinterpolation.swift:23:13:23:13 | [post] $interpolation |
 | stringinterpolation.swift:23:13:23:13 | &... | stringinterpolation.swift:23:20:23:20 | $interpolation |
@@ -217,33 +205,25 @@
 | stringinterpolation.swift:23:21:23:21 | [post] p1 | stringinterpolation.swift:24:21:24:21 | p1 |
 | stringinterpolation.swift:23:21:23:21 | p1 | stringinterpolation.swift:24:21:24:21 | p1 |
 | stringinterpolation.swift:23:21:23:24 | .second | stringinterpolation.swift:23:20:23:20 | [post] $interpolation |
-| stringinterpolation.swift:23:31:23:31 |  | stringinterpolation.swift:23:31:23:31 | [post]  |
 | stringinterpolation.swift:23:31:23:31 |  | stringinterpolation.swift:23:31:23:31 | [post] $interpolation |
 | stringinterpolation.swift:23:31:23:31 | $interpolation | stringinterpolation.swift:23:31:23:31 | &... |
-| stringinterpolation.swift:23:31:23:31 | $interpolation | stringinterpolation.swift:23:31:23:31 | [post]  |
 | stringinterpolation.swift:23:31:23:31 | $interpolation | stringinterpolation.swift:23:31:23:31 | [post] $interpolation |
 | stringinterpolation.swift:23:31:23:31 | &... | stringinterpolation.swift:23:12:23:12 | TapExpr |
 | stringinterpolation.swift:23:31:23:31 | [post] $interpolation | stringinterpolation.swift:23:31:23:31 | &... |
 | stringinterpolation.swift:24:12:24:12 | SSA def($interpolation) | stringinterpolation.swift:24:13:24:13 | $interpolation |
 | stringinterpolation.swift:24:12:24:12 | TapExpr | stringinterpolation.swift:24:12:24:12 | "..." |
-| stringinterpolation.swift:24:12:24:12 | pair:  | stringinterpolation.swift:24:12:24:12 | [post] pair:  |
 | stringinterpolation.swift:24:12:24:12 | pair:  | stringinterpolation.swift:24:13:24:13 | [post] $interpolation |
-| stringinterpolation.swift:24:13:24:13 | $interpolation | stringinterpolation.swift:24:12:24:12 | [post] pair:  |
 | stringinterpolation.swift:24:13:24:13 | $interpolation | stringinterpolation.swift:24:13:24:13 | &... |
 | stringinterpolation.swift:24:13:24:13 | $interpolation | stringinterpolation.swift:24:13:24:13 | [post] $interpolation |
 | stringinterpolation.swift:24:13:24:13 | &... | stringinterpolation.swift:24:20:24:20 | $interpolation |
 | stringinterpolation.swift:24:13:24:13 | [post] $interpolation | stringinterpolation.swift:24:13:24:13 | &... |
 | stringinterpolation.swift:24:20:24:20 | $interpolation | stringinterpolation.swift:24:20:24:20 | &... |
 | stringinterpolation.swift:24:20:24:20 | $interpolation | stringinterpolation.swift:24:20:24:20 | [post] $interpolation |
-| stringinterpolation.swift:24:20:24:20 | $interpolation | stringinterpolation.swift:24:21:24:21 | [post] p1 |
 | stringinterpolation.swift:24:20:24:20 | &... | stringinterpolation.swift:24:24:24:24 | $interpolation |
 | stringinterpolation.swift:24:20:24:20 | [post] $interpolation | stringinterpolation.swift:24:20:24:20 | &... |
 | stringinterpolation.swift:24:21:24:21 | p1 | stringinterpolation.swift:24:20:24:20 | [post] $interpolation |
-| stringinterpolation.swift:24:21:24:21 | p1 | stringinterpolation.swift:24:21:24:21 | [post] p1 |
-| stringinterpolation.swift:24:24:24:24 |  | stringinterpolation.swift:24:24:24:24 | [post]  |
 | stringinterpolation.swift:24:24:24:24 |  | stringinterpolation.swift:24:24:24:24 | [post] $interpolation |
 | stringinterpolation.swift:24:24:24:24 | $interpolation | stringinterpolation.swift:24:24:24:24 | &... |
-| stringinterpolation.swift:24:24:24:24 | $interpolation | stringinterpolation.swift:24:24:24:24 | [post]  |
 | stringinterpolation.swift:24:24:24:24 | $interpolation | stringinterpolation.swift:24:24:24:24 | [post] $interpolation |
 | stringinterpolation.swift:24:24:24:24 | &... | stringinterpolation.swift:24:12:24:12 | TapExpr |
 | stringinterpolation.swift:24:24:24:24 | [post] $interpolation | stringinterpolation.swift:24:24:24:24 | &... |
@@ -256,9 +236,7 @@
 | stringinterpolation.swift:28:2:28:2 | p2 | stringinterpolation.swift:30:21:30:21 | p2 |
 | stringinterpolation.swift:30:12:30:12 | SSA def($interpolation) | stringinterpolation.swift:30:13:30:13 | $interpolation |
 | stringinterpolation.swift:30:12:30:12 | TapExpr | stringinterpolation.swift:30:12:30:12 | "..." |
-| stringinterpolation.swift:30:12:30:12 | pair:  | stringinterpolation.swift:30:12:30:12 | [post] pair:  |
 | stringinterpolation.swift:30:12:30:12 | pair:  | stringinterpolation.swift:30:13:30:13 | [post] $interpolation |
-| stringinterpolation.swift:30:13:30:13 | $interpolation | stringinterpolation.swift:30:12:30:12 | [post] pair:  |
 | stringinterpolation.swift:30:13:30:13 | $interpolation | stringinterpolation.swift:30:13:30:13 | &... |
 | stringinterpolation.swift:30:13:30:13 | $interpolation | stringinterpolation.swift:30:13:30:13 | [post] $interpolation |
 | stringinterpolation.swift:30:13:30:13 | &... | stringinterpolation.swift:30:20:30:20 | $interpolation |
@@ -270,18 +248,14 @@
 | stringinterpolation.swift:30:21:30:21 | [post] p2 | stringinterpolation.swift:31:21:31:21 | p2 |
 | stringinterpolation.swift:30:21:30:21 | p2 | stringinterpolation.swift:31:21:31:21 | p2 |
 | stringinterpolation.swift:30:21:30:24 | .first | stringinterpolation.swift:30:20:30:20 | [post] $interpolation |
-| stringinterpolation.swift:30:30:30:30 |  | stringinterpolation.swift:30:30:30:30 | [post]  |
 | stringinterpolation.swift:30:30:30:30 |  | stringinterpolation.swift:30:30:30:30 | [post] $interpolation |
 | stringinterpolation.swift:30:30:30:30 | $interpolation | stringinterpolation.swift:30:30:30:30 | &... |
-| stringinterpolation.swift:30:30:30:30 | $interpolation | stringinterpolation.swift:30:30:30:30 | [post]  |
 | stringinterpolation.swift:30:30:30:30 | $interpolation | stringinterpolation.swift:30:30:30:30 | [post] $interpolation |
 | stringinterpolation.swift:30:30:30:30 | &... | stringinterpolation.swift:30:12:30:12 | TapExpr |
 | stringinterpolation.swift:30:30:30:30 | [post] $interpolation | stringinterpolation.swift:30:30:30:30 | &... |
 | stringinterpolation.swift:31:12:31:12 | SSA def($interpolation) | stringinterpolation.swift:31:13:31:13 | $interpolation |
 | stringinterpolation.swift:31:12:31:12 | TapExpr | stringinterpolation.swift:31:12:31:12 | "..." |
-| stringinterpolation.swift:31:12:31:12 | pair:  | stringinterpolation.swift:31:12:31:12 | [post] pair:  |
 | stringinterpolation.swift:31:12:31:12 | pair:  | stringinterpolation.swift:31:13:31:13 | [post] $interpolation |
-| stringinterpolation.swift:31:13:31:13 | $interpolation | stringinterpolation.swift:31:12:31:12 | [post] pair:  |
 | stringinterpolation.swift:31:13:31:13 | $interpolation | stringinterpolation.swift:31:13:31:13 | &... |
 | stringinterpolation.swift:31:13:31:13 | $interpolation | stringinterpolation.swift:31:13:31:13 | [post] $interpolation |
 | stringinterpolation.swift:31:13:31:13 | &... | stringinterpolation.swift:31:20:31:20 | $interpolation |
@@ -293,33 +267,25 @@
 | stringinterpolation.swift:31:21:31:21 | [post] p2 | stringinterpolation.swift:32:21:32:21 | p2 |
 | stringinterpolation.swift:31:21:31:21 | p2 | stringinterpolation.swift:32:21:32:21 | p2 |
 | stringinterpolation.swift:31:21:31:24 | .second | stringinterpolation.swift:31:20:31:20 | [post] $interpolation |
-| stringinterpolation.swift:31:31:31:31 |  | stringinterpolation.swift:31:31:31:31 | [post]  |
 | stringinterpolation.swift:31:31:31:31 |  | stringinterpolation.swift:31:31:31:31 | [post] $interpolation |
 | stringinterpolation.swift:31:31:31:31 | $interpolation | stringinterpolation.swift:31:31:31:31 | &... |
-| stringinterpolation.swift:31:31:31:31 | $interpolation | stringinterpolation.swift:31:31:31:31 | [post]  |
 | stringinterpolation.swift:31:31:31:31 | $interpolation | stringinterpolation.swift:31:31:31:31 | [post] $interpolation |
 | stringinterpolation.swift:31:31:31:31 | &... | stringinterpolation.swift:31:12:31:12 | TapExpr |
 | stringinterpolation.swift:31:31:31:31 | [post] $interpolation | stringinterpolation.swift:31:31:31:31 | &... |
 | stringinterpolation.swift:32:12:32:12 | SSA def($interpolation) | stringinterpolation.swift:32:13:32:13 | $interpolation |
 | stringinterpolation.swift:32:12:32:12 | TapExpr | stringinterpolation.swift:32:12:32:12 | "..." |
-| stringinterpolation.swift:32:12:32:12 | pair:  | stringinterpolation.swift:32:12:32:12 | [post] pair:  |
 | stringinterpolation.swift:32:12:32:12 | pair:  | stringinterpolation.swift:32:13:32:13 | [post] $interpolation |
-| stringinterpolation.swift:32:13:32:13 | $interpolation | stringinterpolation.swift:32:12:32:12 | [post] pair:  |
 | stringinterpolation.swift:32:13:32:13 | $interpolation | stringinterpolation.swift:32:13:32:13 | &... |
 | stringinterpolation.swift:32:13:32:13 | $interpolation | stringinterpolation.swift:32:13:32:13 | [post] $interpolation |
 | stringinterpolation.swift:32:13:32:13 | &... | stringinterpolation.swift:32:20:32:20 | $interpolation |
 | stringinterpolation.swift:32:13:32:13 | [post] $interpolation | stringinterpolation.swift:32:13:32:13 | &... |
 | stringinterpolation.swift:32:20:32:20 | $interpolation | stringinterpolation.swift:32:20:32:20 | &... |
 | stringinterpolation.swift:32:20:32:20 | $interpolation | stringinterpolation.swift:32:20:32:20 | [post] $interpolation |
-| stringinterpolation.swift:32:20:32:20 | $interpolation | stringinterpolation.swift:32:21:32:21 | [post] p2 |
 | stringinterpolation.swift:32:20:32:20 | &... | stringinterpolation.swift:32:24:32:24 | $interpolation |
 | stringinterpolation.swift:32:20:32:20 | [post] $interpolation | stringinterpolation.swift:32:20:32:20 | &... |
 | stringinterpolation.swift:32:21:32:21 | p2 | stringinterpolation.swift:32:20:32:20 | [post] $interpolation |
-| stringinterpolation.swift:32:21:32:21 | p2 | stringinterpolation.swift:32:21:32:21 | [post] p2 |
-| stringinterpolation.swift:32:24:32:24 |  | stringinterpolation.swift:32:24:32:24 | [post]  |
 | stringinterpolation.swift:32:24:32:24 |  | stringinterpolation.swift:32:24:32:24 | [post] $interpolation |
 | stringinterpolation.swift:32:24:32:24 | $interpolation | stringinterpolation.swift:32:24:32:24 | &... |
-| stringinterpolation.swift:32:24:32:24 | $interpolation | stringinterpolation.swift:32:24:32:24 | [post]  |
 | stringinterpolation.swift:32:24:32:24 | $interpolation | stringinterpolation.swift:32:24:32:24 | [post] $interpolation |
 | stringinterpolation.swift:32:24:32:24 | &... | stringinterpolation.swift:32:12:32:12 | TapExpr |
 | stringinterpolation.swift:32:24:32:24 | [post] $interpolation | stringinterpolation.swift:32:24:32:24 | &... |
@@ -332,202 +298,152 @@
 | stringinterpolation.swift:38:6:38:6 | SSA def(c) | stringinterpolation.swift:44:15:44:15 | c |
 | stringinterpolation.swift:38:6:38:6 | c | stringinterpolation.swift:38:6:38:6 | SSA def(c) |
 | stringinterpolation.swift:38:10:38:16 | call to clean() | stringinterpolation.swift:38:6:38:6 | c |
-| stringinterpolation.swift:40:12:40:12 |  | stringinterpolation.swift:40:12:40:12 | [post]  |
 | stringinterpolation.swift:40:12:40:12 |  | stringinterpolation.swift:40:13:40:13 | [post] $interpolation |
 | stringinterpolation.swift:40:12:40:12 | SSA def($interpolation) | stringinterpolation.swift:40:13:40:13 | $interpolation |
 | stringinterpolation.swift:40:12:40:12 | TapExpr | stringinterpolation.swift:40:12:40:12 | "..." |
-| stringinterpolation.swift:40:13:40:13 | $interpolation | stringinterpolation.swift:40:12:40:12 | [post]  |
 | stringinterpolation.swift:40:13:40:13 | $interpolation | stringinterpolation.swift:40:13:40:13 | &... |
 | stringinterpolation.swift:40:13:40:13 | $interpolation | stringinterpolation.swift:40:13:40:13 | [post] $interpolation |
 | stringinterpolation.swift:40:13:40:13 | &... | stringinterpolation.swift:40:14:40:14 | $interpolation |
 | stringinterpolation.swift:40:13:40:13 | [post] $interpolation | stringinterpolation.swift:40:13:40:13 | &... |
 | stringinterpolation.swift:40:14:40:14 | $interpolation | stringinterpolation.swift:40:14:40:14 | &... |
 | stringinterpolation.swift:40:14:40:14 | $interpolation | stringinterpolation.swift:40:14:40:14 | [post] $interpolation |
-| stringinterpolation.swift:40:14:40:14 | $interpolation | stringinterpolation.swift:40:15:40:15 | [post] a |
 | stringinterpolation.swift:40:14:40:14 | &... | stringinterpolation.swift:40:17:40:17 | $interpolation |
 | stringinterpolation.swift:40:14:40:14 | [post] $interpolation | stringinterpolation.swift:40:14:40:14 | &... |
 | stringinterpolation.swift:40:15:40:15 | [post] a | stringinterpolation.swift:40:24:40:24 | a |
 | stringinterpolation.swift:40:15:40:15 | a | stringinterpolation.swift:40:14:40:14 | [post] $interpolation |
-| stringinterpolation.swift:40:15:40:15 | a | stringinterpolation.swift:40:15:40:15 | [post] a |
 | stringinterpolation.swift:40:15:40:15 | a | stringinterpolation.swift:40:24:40:24 | a |
-| stringinterpolation.swift:40:17:40:17 |  and  | stringinterpolation.swift:40:17:40:17 | [post]  and  |
 | stringinterpolation.swift:40:17:40:17 |  and  | stringinterpolation.swift:40:17:40:17 | [post] $interpolation |
 | stringinterpolation.swift:40:17:40:17 | $interpolation | stringinterpolation.swift:40:17:40:17 | &... |
-| stringinterpolation.swift:40:17:40:17 | $interpolation | stringinterpolation.swift:40:17:40:17 | [post]  and  |
 | stringinterpolation.swift:40:17:40:17 | $interpolation | stringinterpolation.swift:40:17:40:17 | [post] $interpolation |
 | stringinterpolation.swift:40:17:40:17 | &... | stringinterpolation.swift:40:23:40:23 | $interpolation |
 | stringinterpolation.swift:40:17:40:17 | [post] $interpolation | stringinterpolation.swift:40:17:40:17 | &... |
 | stringinterpolation.swift:40:23:40:23 | $interpolation | stringinterpolation.swift:40:23:40:23 | &... |
 | stringinterpolation.swift:40:23:40:23 | $interpolation | stringinterpolation.swift:40:23:40:23 | [post] $interpolation |
-| stringinterpolation.swift:40:23:40:23 | $interpolation | stringinterpolation.swift:40:24:40:24 | [post] a |
 | stringinterpolation.swift:40:23:40:23 | &... | stringinterpolation.swift:40:26:40:26 | $interpolation |
 | stringinterpolation.swift:40:23:40:23 | [post] $interpolation | stringinterpolation.swift:40:23:40:23 | &... |
 | stringinterpolation.swift:40:24:40:24 | [post] a | stringinterpolation.swift:41:15:41:15 | a |
 | stringinterpolation.swift:40:24:40:24 | a | stringinterpolation.swift:40:23:40:23 | [post] $interpolation |
-| stringinterpolation.swift:40:24:40:24 | a | stringinterpolation.swift:40:24:40:24 | [post] a |
 | stringinterpolation.swift:40:24:40:24 | a | stringinterpolation.swift:41:15:41:15 | a |
-| stringinterpolation.swift:40:26:40:26 |  | stringinterpolation.swift:40:26:40:26 | [post]  |
 | stringinterpolation.swift:40:26:40:26 |  | stringinterpolation.swift:40:26:40:26 | [post] $interpolation |
 | stringinterpolation.swift:40:26:40:26 | $interpolation | stringinterpolation.swift:40:26:40:26 | &... |
-| stringinterpolation.swift:40:26:40:26 | $interpolation | stringinterpolation.swift:40:26:40:26 | [post]  |
 | stringinterpolation.swift:40:26:40:26 | $interpolation | stringinterpolation.swift:40:26:40:26 | [post] $interpolation |
 | stringinterpolation.swift:40:26:40:26 | &... | stringinterpolation.swift:40:12:40:12 | TapExpr |
 | stringinterpolation.swift:40:26:40:26 | [post] $interpolation | stringinterpolation.swift:40:26:40:26 | &... |
-| stringinterpolation.swift:41:12:41:12 |  | stringinterpolation.swift:41:12:41:12 | [post]  |
 | stringinterpolation.swift:41:12:41:12 |  | stringinterpolation.swift:41:13:41:13 | [post] $interpolation |
 | stringinterpolation.swift:41:12:41:12 | SSA def($interpolation) | stringinterpolation.swift:41:13:41:13 | $interpolation |
 | stringinterpolation.swift:41:12:41:12 | TapExpr | stringinterpolation.swift:41:12:41:12 | "..." |
-| stringinterpolation.swift:41:13:41:13 | $interpolation | stringinterpolation.swift:41:12:41:12 | [post]  |
 | stringinterpolation.swift:41:13:41:13 | $interpolation | stringinterpolation.swift:41:13:41:13 | &... |
 | stringinterpolation.swift:41:13:41:13 | $interpolation | stringinterpolation.swift:41:13:41:13 | [post] $interpolation |
 | stringinterpolation.swift:41:13:41:13 | &... | stringinterpolation.swift:41:14:41:14 | $interpolation |
 | stringinterpolation.swift:41:13:41:13 | [post] $interpolation | stringinterpolation.swift:41:13:41:13 | &... |
 | stringinterpolation.swift:41:14:41:14 | $interpolation | stringinterpolation.swift:41:14:41:14 | &... |
 | stringinterpolation.swift:41:14:41:14 | $interpolation | stringinterpolation.swift:41:14:41:14 | [post] $interpolation |
-| stringinterpolation.swift:41:14:41:14 | $interpolation | stringinterpolation.swift:41:15:41:15 | [post] a |
 | stringinterpolation.swift:41:14:41:14 | &... | stringinterpolation.swift:41:17:41:17 | $interpolation |
 | stringinterpolation.swift:41:14:41:14 | [post] $interpolation | stringinterpolation.swift:41:14:41:14 | &... |
 | stringinterpolation.swift:41:15:41:15 | [post] a | stringinterpolation.swift:42:24:42:24 | a |
 | stringinterpolation.swift:41:15:41:15 | a | stringinterpolation.swift:41:14:41:14 | [post] $interpolation |
-| stringinterpolation.swift:41:15:41:15 | a | stringinterpolation.swift:41:15:41:15 | [post] a |
 | stringinterpolation.swift:41:15:41:15 | a | stringinterpolation.swift:42:24:42:24 | a |
-| stringinterpolation.swift:41:17:41:17 |  and  | stringinterpolation.swift:41:17:41:17 | [post]  and  |
 | stringinterpolation.swift:41:17:41:17 |  and  | stringinterpolation.swift:41:17:41:17 | [post] $interpolation |
 | stringinterpolation.swift:41:17:41:17 | $interpolation | stringinterpolation.swift:41:17:41:17 | &... |
-| stringinterpolation.swift:41:17:41:17 | $interpolation | stringinterpolation.swift:41:17:41:17 | [post]  and  |
 | stringinterpolation.swift:41:17:41:17 | $interpolation | stringinterpolation.swift:41:17:41:17 | [post] $interpolation |
 | stringinterpolation.swift:41:17:41:17 | &... | stringinterpolation.swift:41:23:41:23 | $interpolation |
 | stringinterpolation.swift:41:17:41:17 | [post] $interpolation | stringinterpolation.swift:41:17:41:17 | &... |
 | stringinterpolation.swift:41:23:41:23 | $interpolation | stringinterpolation.swift:41:23:41:23 | &... |
 | stringinterpolation.swift:41:23:41:23 | $interpolation | stringinterpolation.swift:41:23:41:23 | [post] $interpolation |
-| stringinterpolation.swift:41:23:41:23 | $interpolation | stringinterpolation.swift:41:24:41:24 | [post] b |
 | stringinterpolation.swift:41:23:41:23 | &... | stringinterpolation.swift:41:26:41:26 | $interpolation |
 | stringinterpolation.swift:41:23:41:23 | [post] $interpolation | stringinterpolation.swift:41:23:41:23 | &... |
 | stringinterpolation.swift:41:24:41:24 | [post] b | stringinterpolation.swift:42:15:42:15 | b |
 | stringinterpolation.swift:41:24:41:24 | b | stringinterpolation.swift:41:23:41:23 | [post] $interpolation |
-| stringinterpolation.swift:41:24:41:24 | b | stringinterpolation.swift:41:24:41:24 | [post] b |
 | stringinterpolation.swift:41:24:41:24 | b | stringinterpolation.swift:42:15:42:15 | b |
-| stringinterpolation.swift:41:26:41:26 |  | stringinterpolation.swift:41:26:41:26 | [post]  |
 | stringinterpolation.swift:41:26:41:26 |  | stringinterpolation.swift:41:26:41:26 | [post] $interpolation |
 | stringinterpolation.swift:41:26:41:26 | $interpolation | stringinterpolation.swift:41:26:41:26 | &... |
-| stringinterpolation.swift:41:26:41:26 | $interpolation | stringinterpolation.swift:41:26:41:26 | [post]  |
 | stringinterpolation.swift:41:26:41:26 | $interpolation | stringinterpolation.swift:41:26:41:26 | [post] $interpolation |
 | stringinterpolation.swift:41:26:41:26 | &... | stringinterpolation.swift:41:12:41:12 | TapExpr |
 | stringinterpolation.swift:41:26:41:26 | [post] $interpolation | stringinterpolation.swift:41:26:41:26 | &... |
-| stringinterpolation.swift:42:12:42:12 |  | stringinterpolation.swift:42:12:42:12 | [post]  |
 | stringinterpolation.swift:42:12:42:12 |  | stringinterpolation.swift:42:13:42:13 | [post] $interpolation |
 | stringinterpolation.swift:42:12:42:12 | SSA def($interpolation) | stringinterpolation.swift:42:13:42:13 | $interpolation |
 | stringinterpolation.swift:42:12:42:12 | TapExpr | stringinterpolation.swift:42:12:42:12 | "..." |
-| stringinterpolation.swift:42:13:42:13 | $interpolation | stringinterpolation.swift:42:12:42:12 | [post]  |
 | stringinterpolation.swift:42:13:42:13 | $interpolation | stringinterpolation.swift:42:13:42:13 | &... |
 | stringinterpolation.swift:42:13:42:13 | $interpolation | stringinterpolation.swift:42:13:42:13 | [post] $interpolation |
 | stringinterpolation.swift:42:13:42:13 | &... | stringinterpolation.swift:42:14:42:14 | $interpolation |
 | stringinterpolation.swift:42:13:42:13 | [post] $interpolation | stringinterpolation.swift:42:13:42:13 | &... |
 | stringinterpolation.swift:42:14:42:14 | $interpolation | stringinterpolation.swift:42:14:42:14 | &... |
 | stringinterpolation.swift:42:14:42:14 | $interpolation | stringinterpolation.swift:42:14:42:14 | [post] $interpolation |
-| stringinterpolation.swift:42:14:42:14 | $interpolation | stringinterpolation.swift:42:15:42:15 | [post] b |
 | stringinterpolation.swift:42:14:42:14 | &... | stringinterpolation.swift:42:17:42:17 | $interpolation |
 | stringinterpolation.swift:42:14:42:14 | [post] $interpolation | stringinterpolation.swift:42:14:42:14 | &... |
 | stringinterpolation.swift:42:15:42:15 | [post] b | stringinterpolation.swift:43:15:43:15 | b |
 | stringinterpolation.swift:42:15:42:15 | b | stringinterpolation.swift:42:14:42:14 | [post] $interpolation |
-| stringinterpolation.swift:42:15:42:15 | b | stringinterpolation.swift:42:15:42:15 | [post] b |
 | stringinterpolation.swift:42:15:42:15 | b | stringinterpolation.swift:43:15:43:15 | b |
-| stringinterpolation.swift:42:17:42:17 |  and  | stringinterpolation.swift:42:17:42:17 | [post]  and  |
 | stringinterpolation.swift:42:17:42:17 |  and  | stringinterpolation.swift:42:17:42:17 | [post] $interpolation |
 | stringinterpolation.swift:42:17:42:17 | $interpolation | stringinterpolation.swift:42:17:42:17 | &... |
-| stringinterpolation.swift:42:17:42:17 | $interpolation | stringinterpolation.swift:42:17:42:17 | [post]  and  |
 | stringinterpolation.swift:42:17:42:17 | $interpolation | stringinterpolation.swift:42:17:42:17 | [post] $interpolation |
 | stringinterpolation.swift:42:17:42:17 | &... | stringinterpolation.swift:42:23:42:23 | $interpolation |
 | stringinterpolation.swift:42:17:42:17 | [post] $interpolation | stringinterpolation.swift:42:17:42:17 | &... |
 | stringinterpolation.swift:42:23:42:23 | $interpolation | stringinterpolation.swift:42:23:42:23 | &... |
 | stringinterpolation.swift:42:23:42:23 | $interpolation | stringinterpolation.swift:42:23:42:23 | [post] $interpolation |
-| stringinterpolation.swift:42:23:42:23 | $interpolation | stringinterpolation.swift:42:24:42:24 | [post] a |
 | stringinterpolation.swift:42:23:42:23 | &... | stringinterpolation.swift:42:26:42:26 | $interpolation |
 | stringinterpolation.swift:42:23:42:23 | [post] $interpolation | stringinterpolation.swift:42:23:42:23 | &... |
 | stringinterpolation.swift:42:24:42:24 | a | stringinterpolation.swift:42:23:42:23 | [post] $interpolation |
-| stringinterpolation.swift:42:24:42:24 | a | stringinterpolation.swift:42:24:42:24 | [post] a |
-| stringinterpolation.swift:42:26:42:26 |  | stringinterpolation.swift:42:26:42:26 | [post]  |
 | stringinterpolation.swift:42:26:42:26 |  | stringinterpolation.swift:42:26:42:26 | [post] $interpolation |
 | stringinterpolation.swift:42:26:42:26 | $interpolation | stringinterpolation.swift:42:26:42:26 | &... |
-| stringinterpolation.swift:42:26:42:26 | $interpolation | stringinterpolation.swift:42:26:42:26 | [post]  |
 | stringinterpolation.swift:42:26:42:26 | $interpolation | stringinterpolation.swift:42:26:42:26 | [post] $interpolation |
 | stringinterpolation.swift:42:26:42:26 | &... | stringinterpolation.swift:42:12:42:12 | TapExpr |
 | stringinterpolation.swift:42:26:42:26 | [post] $interpolation | stringinterpolation.swift:42:26:42:26 | &... |
-| stringinterpolation.swift:43:12:43:12 |  | stringinterpolation.swift:43:12:43:12 | [post]  |
 | stringinterpolation.swift:43:12:43:12 |  | stringinterpolation.swift:43:13:43:13 | [post] $interpolation |
 | stringinterpolation.swift:43:12:43:12 | SSA def($interpolation) | stringinterpolation.swift:43:13:43:13 | $interpolation |
 | stringinterpolation.swift:43:12:43:12 | TapExpr | stringinterpolation.swift:43:12:43:12 | "..." |
-| stringinterpolation.swift:43:13:43:13 | $interpolation | stringinterpolation.swift:43:12:43:12 | [post]  |
 | stringinterpolation.swift:43:13:43:13 | $interpolation | stringinterpolation.swift:43:13:43:13 | &... |
 | stringinterpolation.swift:43:13:43:13 | $interpolation | stringinterpolation.swift:43:13:43:13 | [post] $interpolation |
 | stringinterpolation.swift:43:13:43:13 | &... | stringinterpolation.swift:43:14:43:14 | $interpolation |
 | stringinterpolation.swift:43:13:43:13 | [post] $interpolation | stringinterpolation.swift:43:13:43:13 | &... |
 | stringinterpolation.swift:43:14:43:14 | $interpolation | stringinterpolation.swift:43:14:43:14 | &... |
 | stringinterpolation.swift:43:14:43:14 | $interpolation | stringinterpolation.swift:43:14:43:14 | [post] $interpolation |
-| stringinterpolation.swift:43:14:43:14 | $interpolation | stringinterpolation.swift:43:15:43:15 | [post] b |
 | stringinterpolation.swift:43:14:43:14 | &... | stringinterpolation.swift:43:17:43:17 | $interpolation |
 | stringinterpolation.swift:43:14:43:14 | [post] $interpolation | stringinterpolation.swift:43:14:43:14 | &... |
 | stringinterpolation.swift:43:15:43:15 | [post] b | stringinterpolation.swift:43:24:43:24 | b |
 | stringinterpolation.swift:43:15:43:15 | b | stringinterpolation.swift:43:14:43:14 | [post] $interpolation |
-| stringinterpolation.swift:43:15:43:15 | b | stringinterpolation.swift:43:15:43:15 | [post] b |
 | stringinterpolation.swift:43:15:43:15 | b | stringinterpolation.swift:43:24:43:24 | b |
-| stringinterpolation.swift:43:17:43:17 |  and  | stringinterpolation.swift:43:17:43:17 | [post]  and  |
 | stringinterpolation.swift:43:17:43:17 |  and  | stringinterpolation.swift:43:17:43:17 | [post] $interpolation |
 | stringinterpolation.swift:43:17:43:17 | $interpolation | stringinterpolation.swift:43:17:43:17 | &... |
-| stringinterpolation.swift:43:17:43:17 | $interpolation | stringinterpolation.swift:43:17:43:17 | [post]  and  |
 | stringinterpolation.swift:43:17:43:17 | $interpolation | stringinterpolation.swift:43:17:43:17 | [post] $interpolation |
 | stringinterpolation.swift:43:17:43:17 | &... | stringinterpolation.swift:43:23:43:23 | $interpolation |
 | stringinterpolation.swift:43:17:43:17 | [post] $interpolation | stringinterpolation.swift:43:17:43:17 | &... |
 | stringinterpolation.swift:43:23:43:23 | $interpolation | stringinterpolation.swift:43:23:43:23 | &... |
 | stringinterpolation.swift:43:23:43:23 | $interpolation | stringinterpolation.swift:43:23:43:23 | [post] $interpolation |
-| stringinterpolation.swift:43:23:43:23 | $interpolation | stringinterpolation.swift:43:24:43:24 | [post] b |
 | stringinterpolation.swift:43:23:43:23 | &... | stringinterpolation.swift:43:26:43:26 | $interpolation |
 | stringinterpolation.swift:43:23:43:23 | [post] $interpolation | stringinterpolation.swift:43:23:43:23 | &... |
 | stringinterpolation.swift:43:24:43:24 | b | stringinterpolation.swift:43:23:43:23 | [post] $interpolation |
-| stringinterpolation.swift:43:24:43:24 | b | stringinterpolation.swift:43:24:43:24 | [post] b |
-| stringinterpolation.swift:43:26:43:26 |  | stringinterpolation.swift:43:26:43:26 | [post]  |
 | stringinterpolation.swift:43:26:43:26 |  | stringinterpolation.swift:43:26:43:26 | [post] $interpolation |
 | stringinterpolation.swift:43:26:43:26 | $interpolation | stringinterpolation.swift:43:26:43:26 | &... |
-| stringinterpolation.swift:43:26:43:26 | $interpolation | stringinterpolation.swift:43:26:43:26 | [post]  |
 | stringinterpolation.swift:43:26:43:26 | $interpolation | stringinterpolation.swift:43:26:43:26 | [post] $interpolation |
 | stringinterpolation.swift:43:26:43:26 | &... | stringinterpolation.swift:43:12:43:12 | TapExpr |
 | stringinterpolation.swift:43:26:43:26 | [post] $interpolation | stringinterpolation.swift:43:26:43:26 | &... |
-| stringinterpolation.swift:44:12:44:12 |  | stringinterpolation.swift:44:12:44:12 | [post]  |
 | stringinterpolation.swift:44:12:44:12 |  | stringinterpolation.swift:44:13:44:13 | [post] $interpolation |
 | stringinterpolation.swift:44:12:44:12 | SSA def($interpolation) | stringinterpolation.swift:44:13:44:13 | $interpolation |
 | stringinterpolation.swift:44:12:44:12 | TapExpr | stringinterpolation.swift:44:12:44:12 | "..." |
-| stringinterpolation.swift:44:13:44:13 | $interpolation | stringinterpolation.swift:44:12:44:12 | [post]  |
 | stringinterpolation.swift:44:13:44:13 | $interpolation | stringinterpolation.swift:44:13:44:13 | &... |
 | stringinterpolation.swift:44:13:44:13 | $interpolation | stringinterpolation.swift:44:13:44:13 | [post] $interpolation |
 | stringinterpolation.swift:44:13:44:13 | &... | stringinterpolation.swift:44:14:44:14 | $interpolation |
 | stringinterpolation.swift:44:13:44:13 | [post] $interpolation | stringinterpolation.swift:44:13:44:13 | &... |
 | stringinterpolation.swift:44:14:44:14 | $interpolation | stringinterpolation.swift:44:14:44:14 | &... |
 | stringinterpolation.swift:44:14:44:14 | $interpolation | stringinterpolation.swift:44:14:44:14 | [post] $interpolation |
-| stringinterpolation.swift:44:14:44:14 | $interpolation | stringinterpolation.swift:44:15:44:15 | [post] c |
 | stringinterpolation.swift:44:14:44:14 | &... | stringinterpolation.swift:44:17:44:17 | $interpolation |
 | stringinterpolation.swift:44:14:44:14 | [post] $interpolation | stringinterpolation.swift:44:14:44:14 | &... |
 | stringinterpolation.swift:44:15:44:15 | [post] c | stringinterpolation.swift:44:24:44:24 | c |
 | stringinterpolation.swift:44:15:44:15 | c | stringinterpolation.swift:44:14:44:14 | [post] $interpolation |
-| stringinterpolation.swift:44:15:44:15 | c | stringinterpolation.swift:44:15:44:15 | [post] c |
 | stringinterpolation.swift:44:15:44:15 | c | stringinterpolation.swift:44:24:44:24 | c |
-| stringinterpolation.swift:44:17:44:17 |  and  | stringinterpolation.swift:44:17:44:17 | [post]  and  |
 | stringinterpolation.swift:44:17:44:17 |  and  | stringinterpolation.swift:44:17:44:17 | [post] $interpolation |
 | stringinterpolation.swift:44:17:44:17 | $interpolation | stringinterpolation.swift:44:17:44:17 | &... |
-| stringinterpolation.swift:44:17:44:17 | $interpolation | stringinterpolation.swift:44:17:44:17 | [post]  and  |
 | stringinterpolation.swift:44:17:44:17 | $interpolation | stringinterpolation.swift:44:17:44:17 | [post] $interpolation |
 | stringinterpolation.swift:44:17:44:17 | &... | stringinterpolation.swift:44:23:44:23 | $interpolation |
 | stringinterpolation.swift:44:17:44:17 | [post] $interpolation | stringinterpolation.swift:44:17:44:17 | &... |
 | stringinterpolation.swift:44:23:44:23 | $interpolation | stringinterpolation.swift:44:23:44:23 | &... |
 | stringinterpolation.swift:44:23:44:23 | $interpolation | stringinterpolation.swift:44:23:44:23 | [post] $interpolation |
-| stringinterpolation.swift:44:23:44:23 | $interpolation | stringinterpolation.swift:44:24:44:24 | [post] c |
 | stringinterpolation.swift:44:23:44:23 | &... | stringinterpolation.swift:44:26:44:26 | $interpolation |
 | stringinterpolation.swift:44:23:44:23 | [post] $interpolation | stringinterpolation.swift:44:23:44:23 | &... |
 | stringinterpolation.swift:44:24:44:24 | c | stringinterpolation.swift:44:23:44:23 | [post] $interpolation |
-| stringinterpolation.swift:44:24:44:24 | c | stringinterpolation.swift:44:24:44:24 | [post] c |
-| stringinterpolation.swift:44:26:44:26 |  | stringinterpolation.swift:44:26:44:26 | [post]  |
 | stringinterpolation.swift:44:26:44:26 |  | stringinterpolation.swift:44:26:44:26 | [post] $interpolation |
 | stringinterpolation.swift:44:26:44:26 | $interpolation | stringinterpolation.swift:44:26:44:26 | &... |
-| stringinterpolation.swift:44:26:44:26 | $interpolation | stringinterpolation.swift:44:26:44:26 | [post]  |
 | stringinterpolation.swift:44:26:44:26 | $interpolation | stringinterpolation.swift:44:26:44:26 | [post] $interpolation |
 | stringinterpolation.swift:44:26:44:26 | &... | stringinterpolation.swift:44:12:44:12 | TapExpr |
 | stringinterpolation.swift:44:26:44:26 | [post] $interpolation | stringinterpolation.swift:44:26:44:26 | &... |

--- a/swift/ql/test/library-tests/dataflow/taint/core/LocalTaint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/core/LocalTaint.expected
@@ -323,6 +323,214 @@
 | stringinterpolation.swift:32:24:32:24 | $interpolation | stringinterpolation.swift:32:24:32:24 | [post] $interpolation |
 | stringinterpolation.swift:32:24:32:24 | &... | stringinterpolation.swift:32:12:32:12 | TapExpr |
 | stringinterpolation.swift:32:24:32:24 | [post] $interpolation | stringinterpolation.swift:32:24:32:24 | &... |
+| stringinterpolation.swift:36:6:36:6 | SSA def(a) | stringinterpolation.swift:40:15:40:15 | a |
+| stringinterpolation.swift:36:6:36:6 | a | stringinterpolation.swift:36:6:36:6 | SSA def(a) |
+| stringinterpolation.swift:36:10:36:17 | call to source() | stringinterpolation.swift:36:6:36:6 | a |
+| stringinterpolation.swift:37:6:37:6 | SSA def(b) | stringinterpolation.swift:41:24:41:24 | b |
+| stringinterpolation.swift:37:6:37:6 | b | stringinterpolation.swift:37:6:37:6 | SSA def(b) |
+| stringinterpolation.swift:37:10:37:16 | call to clean() | stringinterpolation.swift:37:6:37:6 | b |
+| stringinterpolation.swift:38:6:38:6 | SSA def(c) | stringinterpolation.swift:44:15:44:15 | c |
+| stringinterpolation.swift:38:6:38:6 | c | stringinterpolation.swift:38:6:38:6 | SSA def(c) |
+| stringinterpolation.swift:38:10:38:16 | call to clean() | stringinterpolation.swift:38:6:38:6 | c |
+| stringinterpolation.swift:40:12:40:12 |  | stringinterpolation.swift:40:12:40:12 | [post]  |
+| stringinterpolation.swift:40:12:40:12 |  | stringinterpolation.swift:40:13:40:13 | [post] $interpolation |
+| stringinterpolation.swift:40:12:40:12 | SSA def($interpolation) | stringinterpolation.swift:40:13:40:13 | $interpolation |
+| stringinterpolation.swift:40:12:40:12 | TapExpr | stringinterpolation.swift:40:12:40:12 | "..." |
+| stringinterpolation.swift:40:13:40:13 | $interpolation | stringinterpolation.swift:40:12:40:12 | [post]  |
+| stringinterpolation.swift:40:13:40:13 | $interpolation | stringinterpolation.swift:40:13:40:13 | &... |
+| stringinterpolation.swift:40:13:40:13 | $interpolation | stringinterpolation.swift:40:13:40:13 | [post] $interpolation |
+| stringinterpolation.swift:40:13:40:13 | &... | stringinterpolation.swift:40:14:40:14 | $interpolation |
+| stringinterpolation.swift:40:13:40:13 | [post] $interpolation | stringinterpolation.swift:40:13:40:13 | &... |
+| stringinterpolation.swift:40:14:40:14 | $interpolation | stringinterpolation.swift:40:14:40:14 | &... |
+| stringinterpolation.swift:40:14:40:14 | $interpolation | stringinterpolation.swift:40:14:40:14 | [post] $interpolation |
+| stringinterpolation.swift:40:14:40:14 | $interpolation | stringinterpolation.swift:40:15:40:15 | [post] a |
+| stringinterpolation.swift:40:14:40:14 | &... | stringinterpolation.swift:40:17:40:17 | $interpolation |
+| stringinterpolation.swift:40:14:40:14 | [post] $interpolation | stringinterpolation.swift:40:14:40:14 | &... |
+| stringinterpolation.swift:40:15:40:15 | [post] a | stringinterpolation.swift:40:24:40:24 | a |
+| stringinterpolation.swift:40:15:40:15 | a | stringinterpolation.swift:40:14:40:14 | [post] $interpolation |
+| stringinterpolation.swift:40:15:40:15 | a | stringinterpolation.swift:40:15:40:15 | [post] a |
+| stringinterpolation.swift:40:15:40:15 | a | stringinterpolation.swift:40:24:40:24 | a |
+| stringinterpolation.swift:40:17:40:17 |  and  | stringinterpolation.swift:40:17:40:17 | [post]  and  |
+| stringinterpolation.swift:40:17:40:17 |  and  | stringinterpolation.swift:40:17:40:17 | [post] $interpolation |
+| stringinterpolation.swift:40:17:40:17 | $interpolation | stringinterpolation.swift:40:17:40:17 | &... |
+| stringinterpolation.swift:40:17:40:17 | $interpolation | stringinterpolation.swift:40:17:40:17 | [post]  and  |
+| stringinterpolation.swift:40:17:40:17 | $interpolation | stringinterpolation.swift:40:17:40:17 | [post] $interpolation |
+| stringinterpolation.swift:40:17:40:17 | &... | stringinterpolation.swift:40:23:40:23 | $interpolation |
+| stringinterpolation.swift:40:17:40:17 | [post] $interpolation | stringinterpolation.swift:40:17:40:17 | &... |
+| stringinterpolation.swift:40:23:40:23 | $interpolation | stringinterpolation.swift:40:23:40:23 | &... |
+| stringinterpolation.swift:40:23:40:23 | $interpolation | stringinterpolation.swift:40:23:40:23 | [post] $interpolation |
+| stringinterpolation.swift:40:23:40:23 | $interpolation | stringinterpolation.swift:40:24:40:24 | [post] a |
+| stringinterpolation.swift:40:23:40:23 | &... | stringinterpolation.swift:40:26:40:26 | $interpolation |
+| stringinterpolation.swift:40:23:40:23 | [post] $interpolation | stringinterpolation.swift:40:23:40:23 | &... |
+| stringinterpolation.swift:40:24:40:24 | [post] a | stringinterpolation.swift:41:15:41:15 | a |
+| stringinterpolation.swift:40:24:40:24 | a | stringinterpolation.swift:40:23:40:23 | [post] $interpolation |
+| stringinterpolation.swift:40:24:40:24 | a | stringinterpolation.swift:40:24:40:24 | [post] a |
+| stringinterpolation.swift:40:24:40:24 | a | stringinterpolation.swift:41:15:41:15 | a |
+| stringinterpolation.swift:40:26:40:26 |  | stringinterpolation.swift:40:26:40:26 | [post]  |
+| stringinterpolation.swift:40:26:40:26 |  | stringinterpolation.swift:40:26:40:26 | [post] $interpolation |
+| stringinterpolation.swift:40:26:40:26 | $interpolation | stringinterpolation.swift:40:26:40:26 | &... |
+| stringinterpolation.swift:40:26:40:26 | $interpolation | stringinterpolation.swift:40:26:40:26 | [post]  |
+| stringinterpolation.swift:40:26:40:26 | $interpolation | stringinterpolation.swift:40:26:40:26 | [post] $interpolation |
+| stringinterpolation.swift:40:26:40:26 | &... | stringinterpolation.swift:40:12:40:12 | TapExpr |
+| stringinterpolation.swift:40:26:40:26 | [post] $interpolation | stringinterpolation.swift:40:26:40:26 | &... |
+| stringinterpolation.swift:41:12:41:12 |  | stringinterpolation.swift:41:12:41:12 | [post]  |
+| stringinterpolation.swift:41:12:41:12 |  | stringinterpolation.swift:41:13:41:13 | [post] $interpolation |
+| stringinterpolation.swift:41:12:41:12 | SSA def($interpolation) | stringinterpolation.swift:41:13:41:13 | $interpolation |
+| stringinterpolation.swift:41:12:41:12 | TapExpr | stringinterpolation.swift:41:12:41:12 | "..." |
+| stringinterpolation.swift:41:13:41:13 | $interpolation | stringinterpolation.swift:41:12:41:12 | [post]  |
+| stringinterpolation.swift:41:13:41:13 | $interpolation | stringinterpolation.swift:41:13:41:13 | &... |
+| stringinterpolation.swift:41:13:41:13 | $interpolation | stringinterpolation.swift:41:13:41:13 | [post] $interpolation |
+| stringinterpolation.swift:41:13:41:13 | &... | stringinterpolation.swift:41:14:41:14 | $interpolation |
+| stringinterpolation.swift:41:13:41:13 | [post] $interpolation | stringinterpolation.swift:41:13:41:13 | &... |
+| stringinterpolation.swift:41:14:41:14 | $interpolation | stringinterpolation.swift:41:14:41:14 | &... |
+| stringinterpolation.swift:41:14:41:14 | $interpolation | stringinterpolation.swift:41:14:41:14 | [post] $interpolation |
+| stringinterpolation.swift:41:14:41:14 | $interpolation | stringinterpolation.swift:41:15:41:15 | [post] a |
+| stringinterpolation.swift:41:14:41:14 | &... | stringinterpolation.swift:41:17:41:17 | $interpolation |
+| stringinterpolation.swift:41:14:41:14 | [post] $interpolation | stringinterpolation.swift:41:14:41:14 | &... |
+| stringinterpolation.swift:41:15:41:15 | [post] a | stringinterpolation.swift:42:24:42:24 | a |
+| stringinterpolation.swift:41:15:41:15 | a | stringinterpolation.swift:41:14:41:14 | [post] $interpolation |
+| stringinterpolation.swift:41:15:41:15 | a | stringinterpolation.swift:41:15:41:15 | [post] a |
+| stringinterpolation.swift:41:15:41:15 | a | stringinterpolation.swift:42:24:42:24 | a |
+| stringinterpolation.swift:41:17:41:17 |  and  | stringinterpolation.swift:41:17:41:17 | [post]  and  |
+| stringinterpolation.swift:41:17:41:17 |  and  | stringinterpolation.swift:41:17:41:17 | [post] $interpolation |
+| stringinterpolation.swift:41:17:41:17 | $interpolation | stringinterpolation.swift:41:17:41:17 | &... |
+| stringinterpolation.swift:41:17:41:17 | $interpolation | stringinterpolation.swift:41:17:41:17 | [post]  and  |
+| stringinterpolation.swift:41:17:41:17 | $interpolation | stringinterpolation.swift:41:17:41:17 | [post] $interpolation |
+| stringinterpolation.swift:41:17:41:17 | &... | stringinterpolation.swift:41:23:41:23 | $interpolation |
+| stringinterpolation.swift:41:17:41:17 | [post] $interpolation | stringinterpolation.swift:41:17:41:17 | &... |
+| stringinterpolation.swift:41:23:41:23 | $interpolation | stringinterpolation.swift:41:23:41:23 | &... |
+| stringinterpolation.swift:41:23:41:23 | $interpolation | stringinterpolation.swift:41:23:41:23 | [post] $interpolation |
+| stringinterpolation.swift:41:23:41:23 | $interpolation | stringinterpolation.swift:41:24:41:24 | [post] b |
+| stringinterpolation.swift:41:23:41:23 | &... | stringinterpolation.swift:41:26:41:26 | $interpolation |
+| stringinterpolation.swift:41:23:41:23 | [post] $interpolation | stringinterpolation.swift:41:23:41:23 | &... |
+| stringinterpolation.swift:41:24:41:24 | [post] b | stringinterpolation.swift:42:15:42:15 | b |
+| stringinterpolation.swift:41:24:41:24 | b | stringinterpolation.swift:41:23:41:23 | [post] $interpolation |
+| stringinterpolation.swift:41:24:41:24 | b | stringinterpolation.swift:41:24:41:24 | [post] b |
+| stringinterpolation.swift:41:24:41:24 | b | stringinterpolation.swift:42:15:42:15 | b |
+| stringinterpolation.swift:41:26:41:26 |  | stringinterpolation.swift:41:26:41:26 | [post]  |
+| stringinterpolation.swift:41:26:41:26 |  | stringinterpolation.swift:41:26:41:26 | [post] $interpolation |
+| stringinterpolation.swift:41:26:41:26 | $interpolation | stringinterpolation.swift:41:26:41:26 | &... |
+| stringinterpolation.swift:41:26:41:26 | $interpolation | stringinterpolation.swift:41:26:41:26 | [post]  |
+| stringinterpolation.swift:41:26:41:26 | $interpolation | stringinterpolation.swift:41:26:41:26 | [post] $interpolation |
+| stringinterpolation.swift:41:26:41:26 | &... | stringinterpolation.swift:41:12:41:12 | TapExpr |
+| stringinterpolation.swift:41:26:41:26 | [post] $interpolation | stringinterpolation.swift:41:26:41:26 | &... |
+| stringinterpolation.swift:42:12:42:12 |  | stringinterpolation.swift:42:12:42:12 | [post]  |
+| stringinterpolation.swift:42:12:42:12 |  | stringinterpolation.swift:42:13:42:13 | [post] $interpolation |
+| stringinterpolation.swift:42:12:42:12 | SSA def($interpolation) | stringinterpolation.swift:42:13:42:13 | $interpolation |
+| stringinterpolation.swift:42:12:42:12 | TapExpr | stringinterpolation.swift:42:12:42:12 | "..." |
+| stringinterpolation.swift:42:13:42:13 | $interpolation | stringinterpolation.swift:42:12:42:12 | [post]  |
+| stringinterpolation.swift:42:13:42:13 | $interpolation | stringinterpolation.swift:42:13:42:13 | &... |
+| stringinterpolation.swift:42:13:42:13 | $interpolation | stringinterpolation.swift:42:13:42:13 | [post] $interpolation |
+| stringinterpolation.swift:42:13:42:13 | &... | stringinterpolation.swift:42:14:42:14 | $interpolation |
+| stringinterpolation.swift:42:13:42:13 | [post] $interpolation | stringinterpolation.swift:42:13:42:13 | &... |
+| stringinterpolation.swift:42:14:42:14 | $interpolation | stringinterpolation.swift:42:14:42:14 | &... |
+| stringinterpolation.swift:42:14:42:14 | $interpolation | stringinterpolation.swift:42:14:42:14 | [post] $interpolation |
+| stringinterpolation.swift:42:14:42:14 | $interpolation | stringinterpolation.swift:42:15:42:15 | [post] b |
+| stringinterpolation.swift:42:14:42:14 | &... | stringinterpolation.swift:42:17:42:17 | $interpolation |
+| stringinterpolation.swift:42:14:42:14 | [post] $interpolation | stringinterpolation.swift:42:14:42:14 | &... |
+| stringinterpolation.swift:42:15:42:15 | [post] b | stringinterpolation.swift:43:15:43:15 | b |
+| stringinterpolation.swift:42:15:42:15 | b | stringinterpolation.swift:42:14:42:14 | [post] $interpolation |
+| stringinterpolation.swift:42:15:42:15 | b | stringinterpolation.swift:42:15:42:15 | [post] b |
+| stringinterpolation.swift:42:15:42:15 | b | stringinterpolation.swift:43:15:43:15 | b |
+| stringinterpolation.swift:42:17:42:17 |  and  | stringinterpolation.swift:42:17:42:17 | [post]  and  |
+| stringinterpolation.swift:42:17:42:17 |  and  | stringinterpolation.swift:42:17:42:17 | [post] $interpolation |
+| stringinterpolation.swift:42:17:42:17 | $interpolation | stringinterpolation.swift:42:17:42:17 | &... |
+| stringinterpolation.swift:42:17:42:17 | $interpolation | stringinterpolation.swift:42:17:42:17 | [post]  and  |
+| stringinterpolation.swift:42:17:42:17 | $interpolation | stringinterpolation.swift:42:17:42:17 | [post] $interpolation |
+| stringinterpolation.swift:42:17:42:17 | &... | stringinterpolation.swift:42:23:42:23 | $interpolation |
+| stringinterpolation.swift:42:17:42:17 | [post] $interpolation | stringinterpolation.swift:42:17:42:17 | &... |
+| stringinterpolation.swift:42:23:42:23 | $interpolation | stringinterpolation.swift:42:23:42:23 | &... |
+| stringinterpolation.swift:42:23:42:23 | $interpolation | stringinterpolation.swift:42:23:42:23 | [post] $interpolation |
+| stringinterpolation.swift:42:23:42:23 | $interpolation | stringinterpolation.swift:42:24:42:24 | [post] a |
+| stringinterpolation.swift:42:23:42:23 | &... | stringinterpolation.swift:42:26:42:26 | $interpolation |
+| stringinterpolation.swift:42:23:42:23 | [post] $interpolation | stringinterpolation.swift:42:23:42:23 | &... |
+| stringinterpolation.swift:42:24:42:24 | a | stringinterpolation.swift:42:23:42:23 | [post] $interpolation |
+| stringinterpolation.swift:42:24:42:24 | a | stringinterpolation.swift:42:24:42:24 | [post] a |
+| stringinterpolation.swift:42:26:42:26 |  | stringinterpolation.swift:42:26:42:26 | [post]  |
+| stringinterpolation.swift:42:26:42:26 |  | stringinterpolation.swift:42:26:42:26 | [post] $interpolation |
+| stringinterpolation.swift:42:26:42:26 | $interpolation | stringinterpolation.swift:42:26:42:26 | &... |
+| stringinterpolation.swift:42:26:42:26 | $interpolation | stringinterpolation.swift:42:26:42:26 | [post]  |
+| stringinterpolation.swift:42:26:42:26 | $interpolation | stringinterpolation.swift:42:26:42:26 | [post] $interpolation |
+| stringinterpolation.swift:42:26:42:26 | &... | stringinterpolation.swift:42:12:42:12 | TapExpr |
+| stringinterpolation.swift:42:26:42:26 | [post] $interpolation | stringinterpolation.swift:42:26:42:26 | &... |
+| stringinterpolation.swift:43:12:43:12 |  | stringinterpolation.swift:43:12:43:12 | [post]  |
+| stringinterpolation.swift:43:12:43:12 |  | stringinterpolation.swift:43:13:43:13 | [post] $interpolation |
+| stringinterpolation.swift:43:12:43:12 | SSA def($interpolation) | stringinterpolation.swift:43:13:43:13 | $interpolation |
+| stringinterpolation.swift:43:12:43:12 | TapExpr | stringinterpolation.swift:43:12:43:12 | "..." |
+| stringinterpolation.swift:43:13:43:13 | $interpolation | stringinterpolation.swift:43:12:43:12 | [post]  |
+| stringinterpolation.swift:43:13:43:13 | $interpolation | stringinterpolation.swift:43:13:43:13 | &... |
+| stringinterpolation.swift:43:13:43:13 | $interpolation | stringinterpolation.swift:43:13:43:13 | [post] $interpolation |
+| stringinterpolation.swift:43:13:43:13 | &... | stringinterpolation.swift:43:14:43:14 | $interpolation |
+| stringinterpolation.swift:43:13:43:13 | [post] $interpolation | stringinterpolation.swift:43:13:43:13 | &... |
+| stringinterpolation.swift:43:14:43:14 | $interpolation | stringinterpolation.swift:43:14:43:14 | &... |
+| stringinterpolation.swift:43:14:43:14 | $interpolation | stringinterpolation.swift:43:14:43:14 | [post] $interpolation |
+| stringinterpolation.swift:43:14:43:14 | $interpolation | stringinterpolation.swift:43:15:43:15 | [post] b |
+| stringinterpolation.swift:43:14:43:14 | &... | stringinterpolation.swift:43:17:43:17 | $interpolation |
+| stringinterpolation.swift:43:14:43:14 | [post] $interpolation | stringinterpolation.swift:43:14:43:14 | &... |
+| stringinterpolation.swift:43:15:43:15 | [post] b | stringinterpolation.swift:43:24:43:24 | b |
+| stringinterpolation.swift:43:15:43:15 | b | stringinterpolation.swift:43:14:43:14 | [post] $interpolation |
+| stringinterpolation.swift:43:15:43:15 | b | stringinterpolation.swift:43:15:43:15 | [post] b |
+| stringinterpolation.swift:43:15:43:15 | b | stringinterpolation.swift:43:24:43:24 | b |
+| stringinterpolation.swift:43:17:43:17 |  and  | stringinterpolation.swift:43:17:43:17 | [post]  and  |
+| stringinterpolation.swift:43:17:43:17 |  and  | stringinterpolation.swift:43:17:43:17 | [post] $interpolation |
+| stringinterpolation.swift:43:17:43:17 | $interpolation | stringinterpolation.swift:43:17:43:17 | &... |
+| stringinterpolation.swift:43:17:43:17 | $interpolation | stringinterpolation.swift:43:17:43:17 | [post]  and  |
+| stringinterpolation.swift:43:17:43:17 | $interpolation | stringinterpolation.swift:43:17:43:17 | [post] $interpolation |
+| stringinterpolation.swift:43:17:43:17 | &... | stringinterpolation.swift:43:23:43:23 | $interpolation |
+| stringinterpolation.swift:43:17:43:17 | [post] $interpolation | stringinterpolation.swift:43:17:43:17 | &... |
+| stringinterpolation.swift:43:23:43:23 | $interpolation | stringinterpolation.swift:43:23:43:23 | &... |
+| stringinterpolation.swift:43:23:43:23 | $interpolation | stringinterpolation.swift:43:23:43:23 | [post] $interpolation |
+| stringinterpolation.swift:43:23:43:23 | $interpolation | stringinterpolation.swift:43:24:43:24 | [post] b |
+| stringinterpolation.swift:43:23:43:23 | &... | stringinterpolation.swift:43:26:43:26 | $interpolation |
+| stringinterpolation.swift:43:23:43:23 | [post] $interpolation | stringinterpolation.swift:43:23:43:23 | &... |
+| stringinterpolation.swift:43:24:43:24 | b | stringinterpolation.swift:43:23:43:23 | [post] $interpolation |
+| stringinterpolation.swift:43:24:43:24 | b | stringinterpolation.swift:43:24:43:24 | [post] b |
+| stringinterpolation.swift:43:26:43:26 |  | stringinterpolation.swift:43:26:43:26 | [post]  |
+| stringinterpolation.swift:43:26:43:26 |  | stringinterpolation.swift:43:26:43:26 | [post] $interpolation |
+| stringinterpolation.swift:43:26:43:26 | $interpolation | stringinterpolation.swift:43:26:43:26 | &... |
+| stringinterpolation.swift:43:26:43:26 | $interpolation | stringinterpolation.swift:43:26:43:26 | [post]  |
+| stringinterpolation.swift:43:26:43:26 | $interpolation | stringinterpolation.swift:43:26:43:26 | [post] $interpolation |
+| stringinterpolation.swift:43:26:43:26 | &... | stringinterpolation.swift:43:12:43:12 | TapExpr |
+| stringinterpolation.swift:43:26:43:26 | [post] $interpolation | stringinterpolation.swift:43:26:43:26 | &... |
+| stringinterpolation.swift:44:12:44:12 |  | stringinterpolation.swift:44:12:44:12 | [post]  |
+| stringinterpolation.swift:44:12:44:12 |  | stringinterpolation.swift:44:13:44:13 | [post] $interpolation |
+| stringinterpolation.swift:44:12:44:12 | SSA def($interpolation) | stringinterpolation.swift:44:13:44:13 | $interpolation |
+| stringinterpolation.swift:44:12:44:12 | TapExpr | stringinterpolation.swift:44:12:44:12 | "..." |
+| stringinterpolation.swift:44:13:44:13 | $interpolation | stringinterpolation.swift:44:12:44:12 | [post]  |
+| stringinterpolation.swift:44:13:44:13 | $interpolation | stringinterpolation.swift:44:13:44:13 | &... |
+| stringinterpolation.swift:44:13:44:13 | $interpolation | stringinterpolation.swift:44:13:44:13 | [post] $interpolation |
+| stringinterpolation.swift:44:13:44:13 | &... | stringinterpolation.swift:44:14:44:14 | $interpolation |
+| stringinterpolation.swift:44:13:44:13 | [post] $interpolation | stringinterpolation.swift:44:13:44:13 | &... |
+| stringinterpolation.swift:44:14:44:14 | $interpolation | stringinterpolation.swift:44:14:44:14 | &... |
+| stringinterpolation.swift:44:14:44:14 | $interpolation | stringinterpolation.swift:44:14:44:14 | [post] $interpolation |
+| stringinterpolation.swift:44:14:44:14 | $interpolation | stringinterpolation.swift:44:15:44:15 | [post] c |
+| stringinterpolation.swift:44:14:44:14 | &... | stringinterpolation.swift:44:17:44:17 | $interpolation |
+| stringinterpolation.swift:44:14:44:14 | [post] $interpolation | stringinterpolation.swift:44:14:44:14 | &... |
+| stringinterpolation.swift:44:15:44:15 | [post] c | stringinterpolation.swift:44:24:44:24 | c |
+| stringinterpolation.swift:44:15:44:15 | c | stringinterpolation.swift:44:14:44:14 | [post] $interpolation |
+| stringinterpolation.swift:44:15:44:15 | c | stringinterpolation.swift:44:15:44:15 | [post] c |
+| stringinterpolation.swift:44:15:44:15 | c | stringinterpolation.swift:44:24:44:24 | c |
+| stringinterpolation.swift:44:17:44:17 |  and  | stringinterpolation.swift:44:17:44:17 | [post]  and  |
+| stringinterpolation.swift:44:17:44:17 |  and  | stringinterpolation.swift:44:17:44:17 | [post] $interpolation |
+| stringinterpolation.swift:44:17:44:17 | $interpolation | stringinterpolation.swift:44:17:44:17 | &... |
+| stringinterpolation.swift:44:17:44:17 | $interpolation | stringinterpolation.swift:44:17:44:17 | [post]  and  |
+| stringinterpolation.swift:44:17:44:17 | $interpolation | stringinterpolation.swift:44:17:44:17 | [post] $interpolation |
+| stringinterpolation.swift:44:17:44:17 | &... | stringinterpolation.swift:44:23:44:23 | $interpolation |
+| stringinterpolation.swift:44:17:44:17 | [post] $interpolation | stringinterpolation.swift:44:17:44:17 | &... |
+| stringinterpolation.swift:44:23:44:23 | $interpolation | stringinterpolation.swift:44:23:44:23 | &... |
+| stringinterpolation.swift:44:23:44:23 | $interpolation | stringinterpolation.swift:44:23:44:23 | [post] $interpolation |
+| stringinterpolation.swift:44:23:44:23 | $interpolation | stringinterpolation.swift:44:24:44:24 | [post] c |
+| stringinterpolation.swift:44:23:44:23 | &... | stringinterpolation.swift:44:26:44:26 | $interpolation |
+| stringinterpolation.swift:44:23:44:23 | [post] $interpolation | stringinterpolation.swift:44:23:44:23 | &... |
+| stringinterpolation.swift:44:24:44:24 | c | stringinterpolation.swift:44:23:44:23 | [post] $interpolation |
+| stringinterpolation.swift:44:24:44:24 | c | stringinterpolation.swift:44:24:44:24 | [post] c |
+| stringinterpolation.swift:44:26:44:26 |  | stringinterpolation.swift:44:26:44:26 | [post]  |
+| stringinterpolation.swift:44:26:44:26 |  | stringinterpolation.swift:44:26:44:26 | [post] $interpolation |
+| stringinterpolation.swift:44:26:44:26 | $interpolation | stringinterpolation.swift:44:26:44:26 | &... |
+| stringinterpolation.swift:44:26:44:26 | $interpolation | stringinterpolation.swift:44:26:44:26 | [post]  |
+| stringinterpolation.swift:44:26:44:26 | $interpolation | stringinterpolation.swift:44:26:44:26 | [post] $interpolation |
+| stringinterpolation.swift:44:26:44:26 | &... | stringinterpolation.swift:44:12:44:12 | TapExpr |
+| stringinterpolation.swift:44:26:44:26 | [post] $interpolation | stringinterpolation.swift:44:26:44:26 | &... |
 | subscript.swift:1:7:1:7 | SSA def(self) | subscript.swift:1:7:1:7 | self[return] |
 | subscript.swift:1:7:1:7 | SSA def(self) | subscript.swift:1:7:1:7 | self[return] |
 | subscript.swift:1:7:1:7 | self | subscript.swift:1:7:1:7 | SSA def(self) |

--- a/swift/ql/test/library-tests/dataflow/taint/core/Taint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/core/Taint.expected
@@ -71,7 +71,6 @@ edges
 | stringinterpolation.swift:36:10:36:17 | call to source() | stringinterpolation.swift:40:12:40:12 | "..." |
 | stringinterpolation.swift:36:10:36:17 | call to source() | stringinterpolation.swift:41:12:41:12 | "..." |
 | stringinterpolation.swift:36:10:36:17 | call to source() | stringinterpolation.swift:42:12:42:12 | "..." |
-| stringinterpolation.swift:36:10:36:17 | call to source() | stringinterpolation.swift:43:12:43:12 | "..." |
 | subscript.swift:13:15:13:22 | call to source() | subscript.swift:13:15:13:25 | ...[...] |
 | subscript.swift:14:15:14:23 | call to source2() | subscript.swift:14:15:14:26 | ...[...] |
 | try.swift:9:17:9:24 | call to source() | try.swift:9:13:9:24 | try ... |
@@ -187,7 +186,6 @@ nodes
 | stringinterpolation.swift:40:12:40:12 | "..." | semmle.label | "..." |
 | stringinterpolation.swift:41:12:41:12 | "..." | semmle.label | "..." |
 | stringinterpolation.swift:42:12:42:12 | "..." | semmle.label | "..." |
-| stringinterpolation.swift:43:12:43:12 | "..." | semmle.label | "..." |
 | subscript.swift:13:15:13:22 | call to source() | semmle.label | call to source() |
 | subscript.swift:13:15:13:25 | ...[...] | semmle.label | ...[...] |
 | subscript.swift:14:15:14:23 | call to source2() | semmle.label | call to source2() |
@@ -253,7 +251,6 @@ subpaths
 | stringinterpolation.swift:40:12:40:12 | "..." | stringinterpolation.swift:36:10:36:17 | call to source() | stringinterpolation.swift:40:12:40:12 | "..." | result |
 | stringinterpolation.swift:41:12:41:12 | "..." | stringinterpolation.swift:36:10:36:17 | call to source() | stringinterpolation.swift:41:12:41:12 | "..." | result |
 | stringinterpolation.swift:42:12:42:12 | "..." | stringinterpolation.swift:36:10:36:17 | call to source() | stringinterpolation.swift:42:12:42:12 | "..." | result |
-| stringinterpolation.swift:43:12:43:12 | "..." | stringinterpolation.swift:36:10:36:17 | call to source() | stringinterpolation.swift:43:12:43:12 | "..." | result |
 | subscript.swift:13:15:13:25 | ...[...] | subscript.swift:13:15:13:22 | call to source() | subscript.swift:13:15:13:25 | ...[...] | result |
 | subscript.swift:14:15:14:26 | ...[...] | subscript.swift:14:15:14:23 | call to source2() | subscript.swift:14:15:14:26 | ...[...] | result |
 | try.swift:9:13:9:24 | try ... | try.swift:9:17:9:24 | call to source() | try.swift:9:13:9:24 | try ... | result |

--- a/swift/ql/test/library-tests/dataflow/taint/core/Taint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/core/Taint.expected
@@ -68,6 +68,10 @@ edges
 | stringinterpolation.swift:31:21:31:21 | p2 [second] | stringinterpolation.swift:7:6:7:6 | self [second] |
 | stringinterpolation.swift:31:21:31:21 | p2 [second] | stringinterpolation.swift:31:21:31:24 | .second |
 | stringinterpolation.swift:31:21:31:24 | .second | stringinterpolation.swift:31:12:31:12 | "..." |
+| stringinterpolation.swift:36:10:36:17 | call to source() | stringinterpolation.swift:40:12:40:12 | "..." |
+| stringinterpolation.swift:36:10:36:17 | call to source() | stringinterpolation.swift:41:12:41:12 | "..." |
+| stringinterpolation.swift:36:10:36:17 | call to source() | stringinterpolation.swift:42:12:42:12 | "..." |
+| stringinterpolation.swift:36:10:36:17 | call to source() | stringinterpolation.swift:43:12:43:12 | "..." |
 | subscript.swift:13:15:13:22 | call to source() | subscript.swift:13:15:13:25 | ...[...] |
 | subscript.swift:14:15:14:23 | call to source2() | subscript.swift:14:15:14:26 | ...[...] |
 | try.swift:9:17:9:24 | call to source() | try.swift:9:13:9:24 | try ... |
@@ -179,6 +183,11 @@ nodes
 | stringinterpolation.swift:31:12:31:12 | "..." | semmle.label | "..." |
 | stringinterpolation.swift:31:21:31:21 | p2 [second] | semmle.label | p2 [second] |
 | stringinterpolation.swift:31:21:31:24 | .second | semmle.label | .second |
+| stringinterpolation.swift:36:10:36:17 | call to source() | semmle.label | call to source() |
+| stringinterpolation.swift:40:12:40:12 | "..." | semmle.label | "..." |
+| stringinterpolation.swift:41:12:41:12 | "..." | semmle.label | "..." |
+| stringinterpolation.swift:42:12:42:12 | "..." | semmle.label | "..." |
+| stringinterpolation.swift:43:12:43:12 | "..." | semmle.label | "..." |
 | subscript.swift:13:15:13:22 | call to source() | semmle.label | call to source() |
 | subscript.swift:13:15:13:25 | ...[...] | semmle.label | ...[...] |
 | subscript.swift:14:15:14:23 | call to source2() | semmle.label | call to source2() |
@@ -241,6 +250,10 @@ subpaths
 | stringinterpolation.swift:22:12:22:12 | "..." | stringinterpolation.swift:19:13:19:20 | call to source() | stringinterpolation.swift:22:12:22:12 | "..." | result |
 | stringinterpolation.swift:24:12:24:12 | "..." | stringinterpolation.swift:19:13:19:20 | call to source() | stringinterpolation.swift:24:12:24:12 | "..." | result |
 | stringinterpolation.swift:31:12:31:12 | "..." | stringinterpolation.swift:28:14:28:21 | call to source() | stringinterpolation.swift:31:12:31:12 | "..." | result |
+| stringinterpolation.swift:40:12:40:12 | "..." | stringinterpolation.swift:36:10:36:17 | call to source() | stringinterpolation.swift:40:12:40:12 | "..." | result |
+| stringinterpolation.swift:41:12:41:12 | "..." | stringinterpolation.swift:36:10:36:17 | call to source() | stringinterpolation.swift:41:12:41:12 | "..." | result |
+| stringinterpolation.swift:42:12:42:12 | "..." | stringinterpolation.swift:36:10:36:17 | call to source() | stringinterpolation.swift:42:12:42:12 | "..." | result |
+| stringinterpolation.swift:43:12:43:12 | "..." | stringinterpolation.swift:36:10:36:17 | call to source() | stringinterpolation.swift:43:12:43:12 | "..." | result |
 | subscript.swift:13:15:13:25 | ...[...] | subscript.swift:13:15:13:22 | call to source() | subscript.swift:13:15:13:25 | ...[...] | result |
 | subscript.swift:14:15:14:26 | ...[...] | subscript.swift:14:15:14:23 | call to source2() | subscript.swift:14:15:14:26 | ...[...] | result |
 | try.swift:9:13:9:24 | try ... | try.swift:9:17:9:24 | call to source() | try.swift:9:13:9:24 | try ... | result |

--- a/swift/ql/test/library-tests/dataflow/taint/core/TaintInline.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/core/TaintInline.expected
@@ -1,2 +1,2 @@
-failures
 testFailures
+failures

--- a/swift/ql/test/library-tests/dataflow/taint/core/stringinterpolation.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/core/stringinterpolation.swift
@@ -40,6 +40,6 @@ func moreTestsStringInterpolation() {
 	sink(arg: "\(a) and \(a)") // $ tainted=36
 	sink(arg: "\(a) and \(b)") // $ tainted=36
 	sink(arg: "\(b) and \(a)") // $ tainted=36
-	sink(arg: "\(b) and \(b)") // $ SPURIOUS: tainted=36
+	sink(arg: "\(b) and \(b)")
 	sink(arg: "\(c) and \(c)")
 }

--- a/swift/ql/test/library-tests/dataflow/taint/core/stringinterpolation.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/core/stringinterpolation.swift
@@ -31,3 +31,15 @@ func taintThroughCustomStringInterpolation() {
 	sink(arg: "pair: \(p2.second)") // $ tainted=28
 	sink(arg: "pair: \(p2)")
 }
+
+func moreTestsStringInterpolation() {
+	let a = source()
+	let b = clean()
+	let c = clean()
+
+	sink(arg: "\(a) and \(a)") // $ tainted=36
+	sink(arg: "\(a) and \(b)") // $ tainted=36
+	sink(arg: "\(b) and \(a)") // $ tainted=36
+	sink(arg: "\(b) and \(b)") // $ SPURIOUS: tainted=36
+	sink(arg: "\(c) and \(c)")
+}


### PR DESCRIPTION
Fix a bug in taint flow through string interpolation, where taint was flowing from input to other inputs (see the first commit for the demonstrative test).

@MathiasVP assuming the tests even pass, would you mind checking I'm not missing something here.  It looks like it might've been done the way it was done for a reason (at least one that applied at the time).