### PR TITLE
Shared: add in/out barriers with flow state

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl1.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl1.qll
@@ -297,6 +297,10 @@ private module Config implements FullStateConfigSig {
 
   predicate isBarrierOut(Node node) { any(Configuration config).isBarrierOut(node) }
 
+  predicate isBarrierIn(Node node, FlowState state) { none() }
+
+  predicate isBarrierOut(Node node, FlowState state) { none() }
+
   predicate isAdditionalFlowStep(Node node1, Node node2) {
     singleConfiguration() and
     any(Configuration config).isAdditionalFlowStep(node1, node2)

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -297,6 +297,10 @@ private module Config implements FullStateConfigSig {
 
   predicate isBarrierOut(Node node) { any(Configuration config).isBarrierOut(node) }
 
+  predicate isBarrierIn(Node node, FlowState state) { none() }
+
+  predicate isBarrierOut(Node node, FlowState state) { none() }
+
   predicate isAdditionalFlowStep(Node node1, Node node2) {
     singleConfiguration() and
     any(Configuration config).isAdditionalFlowStep(node1, node2)

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -297,6 +297,10 @@ private module Config implements FullStateConfigSig {
 
   predicate isBarrierOut(Node node) { any(Configuration config).isBarrierOut(node) }
 
+  predicate isBarrierIn(Node node, FlowState state) { none() }
+
+  predicate isBarrierOut(Node node, FlowState state) { none() }
+
   predicate isAdditionalFlowStep(Node node1, Node node2) {
     singleConfiguration() and
     any(Configuration config).isAdditionalFlowStep(node1, node2)

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -297,6 +297,10 @@ private module Config implements FullStateConfigSig {
 
   predicate isBarrierOut(Node node) { any(Configuration config).isBarrierOut(node) }
 
+  predicate isBarrierIn(Node node, FlowState state) { none() }
+
+  predicate isBarrierOut(Node node, FlowState state) { none() }
+
   predicate isAdditionalFlowStep(Node node1, Node node2) {
     singleConfiguration() and
     any(Configuration config).isAdditionalFlowStep(node1, node2)

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -297,6 +297,10 @@ private module Config implements FullStateConfigSig {
 
   predicate isBarrierOut(Node node) { any(Configuration config).isBarrierOut(node) }
 
+  predicate isBarrierIn(Node node, FlowState state) { none() }
+
+  predicate isBarrierOut(Node node, FlowState state) { none() }
+
   predicate isAdditionalFlowStep(Node node1, Node node2) {
     singleConfiguration() and
     any(Configuration config).isAdditionalFlowStep(node1, node2)

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl1.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl1.qll
@@ -297,6 +297,10 @@ private module Config implements FullStateConfigSig {
 
   predicate isBarrierOut(Node node) { any(Configuration config).isBarrierOut(node) }
 
+  predicate isBarrierIn(Node node, FlowState state) { none() }
+
+  predicate isBarrierOut(Node node, FlowState state) { none() }
+
   predicate isAdditionalFlowStep(Node node1, Node node2) {
     singleConfiguration() and
     any(Configuration config).isAdditionalFlowStep(node1, node2)

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -297,6 +297,10 @@ private module Config implements FullStateConfigSig {
 
   predicate isBarrierOut(Node node) { any(Configuration config).isBarrierOut(node) }
 
+  predicate isBarrierIn(Node node, FlowState state) { none() }
+
+  predicate isBarrierOut(Node node, FlowState state) { none() }
+
   predicate isAdditionalFlowStep(Node node1, Node node2) {
     singleConfiguration() and
     any(Configuration config).isAdditionalFlowStep(node1, node2)

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -297,6 +297,10 @@ private module Config implements FullStateConfigSig {
 
   predicate isBarrierOut(Node node) { any(Configuration config).isBarrierOut(node) }
 
+  predicate isBarrierIn(Node node, FlowState state) { none() }
+
+  predicate isBarrierOut(Node node, FlowState state) { none() }
+
   predicate isAdditionalFlowStep(Node node1, Node node2) {
     singleConfiguration() and
     any(Configuration config).isAdditionalFlowStep(node1, node2)

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -297,6 +297,10 @@ private module Config implements FullStateConfigSig {
 
   predicate isBarrierOut(Node node) { any(Configuration config).isBarrierOut(node) }
 
+  predicate isBarrierIn(Node node, FlowState state) { none() }
+
+  predicate isBarrierOut(Node node, FlowState state) { none() }
+
   predicate isAdditionalFlowStep(Node node1, Node node2) {
     singleConfiguration() and
     any(Configuration config).isAdditionalFlowStep(node1, node2)

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl1.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl1.qll
@@ -297,6 +297,10 @@ private module Config implements FullStateConfigSig {
 
   predicate isBarrierOut(Node node) { any(Configuration config).isBarrierOut(node) }
 
+  predicate isBarrierIn(Node node, FlowState state) { none() }
+
+  predicate isBarrierOut(Node node, FlowState state) { none() }
+
   predicate isAdditionalFlowStep(Node node1, Node node2) {
     singleConfiguration() and
     any(Configuration config).isAdditionalFlowStep(node1, node2)

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -297,6 +297,10 @@ private module Config implements FullStateConfigSig {
 
   predicate isBarrierOut(Node node) { any(Configuration config).isBarrierOut(node) }
 
+  predicate isBarrierIn(Node node, FlowState state) { none() }
+
+  predicate isBarrierOut(Node node, FlowState state) { none() }
+
   predicate isAdditionalFlowStep(Node node1, Node node2) {
     singleConfiguration() and
     any(Configuration config).isAdditionalFlowStep(node1, node2)

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -297,6 +297,10 @@ private module Config implements FullStateConfigSig {
 
   predicate isBarrierOut(Node node) { any(Configuration config).isBarrierOut(node) }
 
+  predicate isBarrierIn(Node node, FlowState state) { none() }
+
+  predicate isBarrierOut(Node node, FlowState state) { none() }
+
   predicate isAdditionalFlowStep(Node node1, Node node2) {
     singleConfiguration() and
     any(Configuration config).isAdditionalFlowStep(node1, node2)

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -297,6 +297,10 @@ private module Config implements FullStateConfigSig {
 
   predicate isBarrierOut(Node node) { any(Configuration config).isBarrierOut(node) }
 
+  predicate isBarrierIn(Node node, FlowState state) { none() }
+
+  predicate isBarrierOut(Node node, FlowState state) { none() }
+
   predicate isAdditionalFlowStep(Node node1, Node node2) {
     singleConfiguration() and
     any(Configuration config).isAdditionalFlowStep(node1, node2)

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -297,6 +297,10 @@ private module Config implements FullStateConfigSig {
 
   predicate isBarrierOut(Node node) { any(Configuration config).isBarrierOut(node) }
 
+  predicate isBarrierIn(Node node, FlowState state) { none() }
+
+  predicate isBarrierOut(Node node, FlowState state) { none() }
+
   predicate isAdditionalFlowStep(Node node1, Node node2) {
     singleConfiguration() and
     any(Configuration config).isAdditionalFlowStep(node1, node2)

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl1.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl1.qll
@@ -297,6 +297,10 @@ private module Config implements FullStateConfigSig {
 
   predicate isBarrierOut(Node node) { any(Configuration config).isBarrierOut(node) }
 
+  predicate isBarrierIn(Node node, FlowState state) { none() }
+
+  predicate isBarrierOut(Node node, FlowState state) { none() }
+
   predicate isAdditionalFlowStep(Node node1, Node node2) {
     singleConfiguration() and
     any(Configuration config).isAdditionalFlowStep(node1, node2)

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl2.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl2.qll
@@ -297,6 +297,10 @@ private module Config implements FullStateConfigSig {
 
   predicate isBarrierOut(Node node) { any(Configuration config).isBarrierOut(node) }
 
+  predicate isBarrierIn(Node node, FlowState state) { none() }
+
+  predicate isBarrierOut(Node node, FlowState state) { none() }
+
   predicate isAdditionalFlowStep(Node node1, Node node2) {
     singleConfiguration() and
     any(Configuration config).isAdditionalFlowStep(node1, node2)

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl1.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl1.qll
@@ -297,6 +297,10 @@ private module Config implements FullStateConfigSig {
 
   predicate isBarrierOut(Node node) { any(Configuration config).isBarrierOut(node) }
 
+  predicate isBarrierIn(Node node, FlowState state) { none() }
+
+  predicate isBarrierOut(Node node, FlowState state) { none() }
+
   predicate isAdditionalFlowStep(Node node1, Node node2) {
     singleConfiguration() and
     any(Configuration config).isAdditionalFlowStep(node1, node2)

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -297,6 +297,10 @@ private module Config implements FullStateConfigSig {
 
   predicate isBarrierOut(Node node) { any(Configuration config).isBarrierOut(node) }
 
+  predicate isBarrierIn(Node node, FlowState state) { none() }
+
+  predicate isBarrierOut(Node node, FlowState state) { none() }
+
   predicate isAdditionalFlowStep(Node node1, Node node2) {
     singleConfiguration() and
     any(Configuration config).isAdditionalFlowStep(node1, node2)

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -297,6 +297,10 @@ private module Config implements FullStateConfigSig {
 
   predicate isBarrierOut(Node node) { any(Configuration config).isBarrierOut(node) }
 
+  predicate isBarrierIn(Node node, FlowState state) { none() }
+
+  predicate isBarrierOut(Node node, FlowState state) { none() }
+
   predicate isAdditionalFlowStep(Node node1, Node node2) {
     singleConfiguration() and
     any(Configuration config).isAdditionalFlowStep(node1, node2)

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -297,6 +297,10 @@ private module Config implements FullStateConfigSig {
 
   predicate isBarrierOut(Node node) { any(Configuration config).isBarrierOut(node) }
 
+  predicate isBarrierIn(Node node, FlowState state) { none() }
+
+  predicate isBarrierOut(Node node, FlowState state) { none() }
+
   predicate isAdditionalFlowStep(Node node1, Node node2) {
     singleConfiguration() and
     any(Configuration config).isAdditionalFlowStep(node1, node2)

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -297,6 +297,10 @@ private module Config implements FullStateConfigSig {
 
   predicate isBarrierOut(Node node) { any(Configuration config).isBarrierOut(node) }
 
+  predicate isBarrierIn(Node node, FlowState state) { none() }
+
+  predicate isBarrierOut(Node node, FlowState state) { none() }
+
   predicate isAdditionalFlowStep(Node node1, Node node2) {
     singleConfiguration() and
     any(Configuration config).isAdditionalFlowStep(node1, node2)

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
@@ -297,6 +297,10 @@ private module Config implements FullStateConfigSig {
 
   predicate isBarrierOut(Node node) { any(Configuration config).isBarrierOut(node) }
 
+  predicate isBarrierIn(Node node, FlowState state) { none() }
+
+  predicate isBarrierOut(Node node, FlowState state) { none() }
+
   predicate isAdditionalFlowStep(Node node1, Node node2) {
     singleConfiguration() and
     any(Configuration config).isAdditionalFlowStep(node1, node2)

--- a/java/ql/test/library-tests/dataflow/inoutbarriers/test.expected
+++ b/java/ql/test/library-tests/dataflow/inoutbarriers/test.expected
@@ -1,3 +1,8 @@
+inconsistentFlow
+| A.java:9:16:9:19 | fsrc | A.java:15:10:15:10 | s | spurious state-flow in configuration sinkbarrier |
+| A.java:12:9:12:14 | src(...) | A.java:15:10:15:10 | s | spurious state-flow in configuration both |
+| A.java:12:9:12:14 | src(...) | A.java:15:10:15:10 | s | spurious state-flow in configuration sinkbarrier |
+#select
 | A.java:9:16:9:19 | fsrc | A.java:13:10:13:10 | s | nobarrier, sinkbarrier |
 | A.java:9:16:9:19 | fsrc | A.java:15:10:15:10 | s | nobarrier |
 | A.java:10:10:10:13 | fsrc | A.java:10:10:10:13 | fsrc | both, nobarrier, sinkbarrier, srcbarrier |

--- a/java/ql/test/library-tests/dataflow/inoutbarriers/test.expected
+++ b/java/ql/test/library-tests/dataflow/inoutbarriers/test.expected
@@ -1,7 +1,4 @@
 inconsistentFlow
-| A.java:9:16:9:19 | fsrc | A.java:15:10:15:10 | s | spurious state-flow in configuration sinkbarrier |
-| A.java:12:9:12:14 | src(...) | A.java:15:10:15:10 | s | spurious state-flow in configuration both |
-| A.java:12:9:12:14 | src(...) | A.java:15:10:15:10 | s | spurious state-flow in configuration sinkbarrier |
 #select
 | A.java:9:16:9:19 | fsrc | A.java:13:10:13:10 | s | nobarrier, sinkbarrier |
 | A.java:9:16:9:19 | fsrc | A.java:15:10:15:10 | s | nobarrier |

--- a/java/ql/test/library-tests/dataflow/inoutbarriers/test.ql
+++ b/java/ql/test/library-tests/dataflow/inoutbarriers/test.ql
@@ -46,6 +46,46 @@ module Conf4 implements ConfigSig {
   predicate isBarrierOut(Node n) { sink0(n) }
 }
 
+module StateConf1 implements StateConfigSig {
+  class FlowState = Unit;
+
+  predicate isSource(Node n, FlowState state) { src0(n) and exists(state) }
+
+  predicate isSink(Node n, FlowState state) { sink0(n) and exists(state) }
+}
+
+module StateConf2 implements StateConfigSig {
+  class FlowState = Unit;
+
+  predicate isSource(Node n, FlowState state) { src0(n) and exists(state) }
+
+  predicate isSink(Node n, FlowState state) { sink0(n) and exists(state) }
+
+  predicate isBarrierIn(Node n, FlowState state) { isSource(n, state) }
+}
+
+module StateConf3 implements StateConfigSig {
+  class FlowState = Unit;
+
+  predicate isSource(Node n, FlowState state) { src0(n) and exists(state) }
+
+  predicate isSink(Node n, FlowState state) { sink0(n) and exists(state) }
+
+  predicate isBarrierOut(Node n, FlowState state) { isSink(n, state) }
+}
+
+module StateConf4 implements StateConfigSig {
+  class FlowState = Unit;
+
+  predicate isSource(Node n, FlowState state) { src0(n) and exists(state) }
+
+  predicate isSink(Node n, FlowState state) { sink0(n) and exists(state) }
+
+  predicate isBarrierIn(Node n, FlowState state) { isSource(n, state) }
+
+  predicate isBarrierOut(Node n, FlowState state) { isSink(n, state) }
+}
+
 predicate flow(Node src, Node sink, string s) {
   Global<Conf1>::flow(src, sink) and s = "nobarrier"
   or
@@ -54,6 +94,26 @@ predicate flow(Node src, Node sink, string s) {
   Global<Conf3>::flow(src, sink) and s = "sinkbarrier"
   or
   Global<Conf4>::flow(src, sink) and s = "both"
+}
+
+predicate stateFlow(Node src, Node sink, string s) {
+  GlobalWithState<StateConf1>::flow(src, sink) and s = "nobarrier"
+  or
+  GlobalWithState<StateConf2>::flow(src, sink) and s = "srcbarrier"
+  or
+  GlobalWithState<StateConf3>::flow(src, sink) and s = "sinkbarrier"
+  or
+  GlobalWithState<StateConf4>::flow(src, sink) and s = "both"
+}
+
+query predicate inconsistentFlow(Node src, Node sink, string message) {
+  exists(string kind |
+    (flow(src, sink, kind) and not stateFlow(src, sink, kind)) and
+    message = "missing state-flow in configuration " + kind
+    or
+    (not flow(src, sink, kind) and stateFlow(src, sink, kind)) and
+    message = "spurious state-flow in configuration " + kind
+  )
 }
 
 from Node src, Node sink, string s

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl1.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl1.qll
@@ -297,6 +297,10 @@ private module Config implements FullStateConfigSig {
 
   predicate isBarrierOut(Node node) { any(Configuration config).isBarrierOut(node) }
 
+  predicate isBarrierIn(Node node, FlowState state) { none() }
+
+  predicate isBarrierOut(Node node, FlowState state) { none() }
+
   predicate isAdditionalFlowStep(Node node1, Node node2) {
     singleConfiguration() and
     any(Configuration config).isAdditionalFlowStep(node1, node2)

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
@@ -297,6 +297,10 @@ private module Config implements FullStateConfigSig {
 
   predicate isBarrierOut(Node node) { any(Configuration config).isBarrierOut(node) }
 
+  predicate isBarrierIn(Node node, FlowState state) { none() }
+
+  predicate isBarrierOut(Node node, FlowState state) { none() }
+
   predicate isAdditionalFlowStep(Node node1, Node node2) {
     singleConfiguration() and
     any(Configuration config).isAdditionalFlowStep(node1, node2)

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
@@ -297,6 +297,10 @@ private module Config implements FullStateConfigSig {
 
   predicate isBarrierOut(Node node) { any(Configuration config).isBarrierOut(node) }
 
+  predicate isBarrierIn(Node node, FlowState state) { none() }
+
+  predicate isBarrierOut(Node node, FlowState state) { none() }
+
   predicate isAdditionalFlowStep(Node node1, Node node2) {
     singleConfiguration() and
     any(Configuration config).isAdditionalFlowStep(node1, node2)

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
@@ -297,6 +297,10 @@ private module Config implements FullStateConfigSig {
 
   predicate isBarrierOut(Node node) { any(Configuration config).isBarrierOut(node) }
 
+  predicate isBarrierIn(Node node, FlowState state) { none() }
+
+  predicate isBarrierOut(Node node, FlowState state) { none() }
+
   predicate isAdditionalFlowStep(Node node1, Node node2) {
     singleConfiguration() and
     any(Configuration config).isAdditionalFlowStep(node1, node2)

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl1.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl1.qll
@@ -297,6 +297,10 @@ private module Config implements FullStateConfigSig {
 
   predicate isBarrierOut(Node node) { any(Configuration config).isBarrierOut(node) }
 
+  predicate isBarrierIn(Node node, FlowState state) { none() }
+
+  predicate isBarrierOut(Node node, FlowState state) { none() }
+
   predicate isAdditionalFlowStep(Node node1, Node node2) {
     singleConfiguration() and
     any(Configuration config).isAdditionalFlowStep(node1, node2)

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
@@ -297,6 +297,10 @@ private module Config implements FullStateConfigSig {
 
   predicate isBarrierOut(Node node) { any(Configuration config).isBarrierOut(node) }
 
+  predicate isBarrierIn(Node node, FlowState state) { none() }
+
+  predicate isBarrierOut(Node node, FlowState state) { none() }
+
   predicate isAdditionalFlowStep(Node node1, Node node2) {
     singleConfiguration() and
     any(Configuration config).isAdditionalFlowStep(node1, node2)

--- a/shared/dataflow/change-notes/2023-09-26-inout-barrier-flow-state.md
+++ b/shared/dataflow/change-notes/2023-09-26-inout-barrier-flow-state.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `isBarrierIn` and `isBarrierOut` predicates in `DataFlow::StateConfigSig` now have overloaded variants that block a specific `FlowState`.

--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -357,8 +357,14 @@ module Configs<InputSig Lang> {
     /** Holds if data flow into `node` is prohibited. */
     default predicate isBarrierIn(Node node) { none() }
 
+    /** Holds if data flow into `node` is prohibited when the target flow state is `state`. */
+    default predicate isBarrierIn(Node node, FlowState state) { none() }
+
     /** Holds if data flow out of `node` is prohibited. */
     default predicate isBarrierOut(Node node) { none() }
+
+    /** Holds if data flow out of `node` is prohibited when the originating flow state is `state`. */
+    default predicate isBarrierOut(Node node, FlowState state) { none() }
 
     /**
      * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -304,7 +304,6 @@ module MakeImpl<InputSig Lang> {
 
     /** Provides the relevant barriers for a step from `node1` to `node2`. */
     bindingset[node1, node2]
-    pragma[inline]
     private predicate stepFilter(NodeEx node1, NodeEx node2) {
       not outBarrier(node1) and
       not inBarrier(node2) and
@@ -314,7 +313,6 @@ module MakeImpl<InputSig Lang> {
 
     /** Provides the relevant barriers for a step from `node1,state1` to `node2,state2`, including stateless barriers for `node1` to `node2`. */
     bindingset[node1, state1, node2, state2]
-    pragma[inline]
     private predicate stateStepFilter(NodeEx node1, FlowState state1, NodeEx node2, FlowState state2) {
       stepFilter(node1, node2) and
       not outBarrier(node1, state1) and

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -4436,6 +4436,7 @@ module MakeImpl<InputSig Lang> {
           ) and
           not fullBarrier(node) and
           not stateBarrier(node, state) and
+          not outBarrier(node, state) and
           distSink(node.getEnclosingCallable()) <= explorationLimit()
         }
 
@@ -4456,6 +4457,7 @@ module MakeImpl<InputSig Lang> {
         partialPathStep0(mid, node, state, cc, sc1, sc2, sc3, sc4, t0, ap) and
         not fullBarrier(node) and
         not stateBarrier(node, state) and
+        not inBarrier(node, state) and
         not clearsContentEx(node, ap.getHead()) and
         (
           notExpectsContent(node) or
@@ -4595,6 +4597,7 @@ module MakeImpl<InputSig Lang> {
         PartialAccessPath getAp() { result = ap }
 
         override PartialPathNodeFwd getASuccessor() {
+          not outBarrier(node, state) and
           partialPathStep(this, result.getNodeEx(), result.getState(), result.getCallContext(),
             result.getSummaryCtx1(), result.getSummaryCtx2(), result.getSummaryCtx3(),
             result.getSummaryCtx4(), result.getType(), result.getAp())
@@ -4634,6 +4637,7 @@ module MakeImpl<InputSig Lang> {
         PartialAccessPath getAp() { result = ap }
 
         override PartialPathNodeRev getASuccessor() {
+          not inBarrier(node, state) and
           revPartialPathStep(result, this.getNodeEx(), this.getState(), this.getSummaryCtx1(),
             this.getSummaryCtx2(), this.getSummaryCtx3(), this.getAp())
         }

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl1.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl1.qll
@@ -297,6 +297,10 @@ private module Config implements FullStateConfigSig {
 
   predicate isBarrierOut(Node node) { any(Configuration config).isBarrierOut(node) }
 
+  predicate isBarrierIn(Node node, FlowState state) { none() }
+
+  predicate isBarrierOut(Node node, FlowState state) { none() }
+
   predicate isAdditionalFlowStep(Node node1, Node node2) {
     singleConfiguration() and
     any(Configuration config).isAdditionalFlowStep(node1, node2)


### PR DESCRIPTION
Adds overloads of `isBarrierIn` and `isBarrierOut` that take a FlowState.
```codeql
predicate isBarrierIn(Node node, FlowState state)
predicate isBarrierOut(Node node, FlowState state)
```

The most immediate use-case for these is to be able to implement these as calls to `isSource` or `isSink`, without losing the flow state:
```codeql
predicate isBarrierIn(Node node, FlowState state) { isSource(node, state) }
predicate isBarrierOut(Node node, FlowState state) { isSink(node, state) }
```

This is needed for the JS data flow migration. Since this isn't merged yet, I haven't added the use sites in this PR, though I have verified that it works in the JS queries where I have used it.

To get a bit more validation, I also ran a C++ experiment with [this commit](https://github.com/github/codeql/commit/313ac43314d8434a9a3d99d462cd39dc3e157902) resulting in [this evaluation](https://github.com/github/codeql-dca-main/tree/data/asgerf/use-inout-barriers-with-flow-state/reports) which seems to look fine.