### PR TITLE
C#: Remove legacy runtime packages from extraction references

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
@@ -164,6 +164,11 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 Path.Combine(packageFolder, "microsoft.netcore.app.runtime"),
                 Path.Combine(packageFolder, "microsoft.aspnetcore.app.runtime"),
                 Path.Combine(packageFolder, "microsoft.windowsdesktop.app.runtime"),
+
+                // legacy runtime packages:
+                Path.Combine(packageFolder, "runtime.linux-x64.microsoft.netcore.app"),
+                Path.Combine(packageFolder, "runtime.osx-x64.microsoft.netcore.app"),
+                Path.Combine(packageFolder, "runtime.win-x64.microsoft.netcore.app"),
             };
 
             foreach (var filename in usedReferences.Keys)


### PR DESCRIPTION
This change improves the accuracy on `powershell/powershell`:

```diff
Results for PowerShell/PowerShell
 Query CallTargets.ql:
-  Result count - both/traced/standalone: 92650/74812/29209
-  Result count in the matching 838 files - both/traced/standalone: 92650/60281/9401
-   Matching 57.07%
+  Result count - both/traced/standalone: 140974/26488/42628
+  Result count in the matching 838 files - both/traced/standalone: 140974/11957/7620
+   Matching 87.81%
```