### PR TITLE
All languages: Use shared FileSystem library and minor regex performance improvement.

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/File.qll
+++ b/cpp/ql/lib/semmle/code/cpp/File.qll
@@ -5,155 +5,35 @@
 import semmle.code.cpp.Element
 import semmle.code.cpp.Declaration
 import semmle.code.cpp.metrics.MetricFile
+private import codeql.util.FileSystem
+
+private module Input implements InputSig {
+  abstract class ContainerBase extends @container {
+    abstract string getAbsolutePath();
+
+    ContainerBase getParentContainer() {
+      containerparent(unresolveElement(result), underlyingElement(this))
+    }
+
+    string toString() { result = this.getAbsolutePath() }
+  }
+
+  class FolderBase extends ContainerBase, @folder {
+    override string getAbsolutePath() { folders(underlyingElement(this), result) }
+  }
+
+  class FileBase extends ContainerBase, @file {
+    override string getAbsolutePath() { files(underlyingElement(this), result) }
+  }
+
+  predicate hasSourceLocationPrefix = sourceLocationPrefix/1;
+}
+
+private module Impl = Make<Input>;
 
 /** A file or folder. */
-class Container extends Locatable, @container {
-  /**
-   * Gets the absolute, canonical path of this container, using forward slashes
-   * as path separator.
-   *
-   * The path starts with a _root prefix_ followed by zero or more _path
-   * segments_ separated by forward slashes.
-   *
-   * The root prefix is of one of the following forms:
-   *
-   *   1. A single forward slash `/` (Unix-style)
-   *   2. An upper-case drive letter followed by a colon and a forward slash,
-   *      such as `C:/` (Windows-style)
-   *   3. Two forward slashes, a computer name, and then another forward slash,
-   *      such as `//FileServer/` (UNC-style)
-   *
-   * Path segments are never empty (that is, absolute paths never contain two
-   * contiguous slashes, except as part of a UNC-style root prefix). Also, path
-   * segments never contain forward slashes, and no path segment is of the
-   * form `.` (one dot) or `..` (two dots).
-   *
-   * Note that an absolute path never ends with a forward slash, except if it is
-   * a bare root prefix, that is, the path has no path segments. A container
-   * whose absolute path has no segments is always a `Folder`, not a `File`.
-   */
-  string getAbsolutePath() { none() } // overridden by subclasses
-
-  /**
-   * Gets the relative path of this file or folder from the root folder of the
-   * analyzed source location. The relative path of the root folder itself is
-   * the empty string.
-   *
-   * This has no result if the container is outside the source root, that is,
-   * if the root folder is not a reflexive, transitive parent of this container.
-   */
-  string getRelativePath() {
-    exists(string absPath, string pref |
-      absPath = this.getAbsolutePath() and sourceLocationPrefix(pref)
-    |
-      absPath = pref and result = ""
-      or
-      absPath = pref.regexpReplaceAll("/$", "") + "/" + result and
-      not result.matches("/%")
-    )
-  }
-
-  /**
-   * Gets the base name of this container including extension, that is, the last
-   * segment of its absolute path, or the empty string if it has no segments.
-   *
-   * Here are some examples of absolute paths and the corresponding base names
-   * (surrounded with quotes to avoid ambiguity):
-   *
-   * <table border="1">
-   * <tr><th>Absolute path</th><th>Base name</th></tr>
-   * <tr><td>"/tmp/tst.js"</td><td>"tst.js"</td></tr>
-   * <tr><td>"C:/Program Files (x86)"</td><td>"Program Files (x86)"</td></tr>
-   * <tr><td>"/"</td><td>""</td></tr>
-   * <tr><td>"C:/"</td><td>""</td></tr>
-   * <tr><td>"D:/"</td><td>""</td></tr>
-   * <tr><td>"//FileServer/"</td><td>""</td></tr>
-   * </table>
-   */
-  string getBaseName() {
-    result = this.getAbsolutePath().regexpCapture(".*/(([^/]*?)(?:\\.([^.]*))?)", 1)
-  }
-
-  /**
-   * Gets the extension of this container, that is, the suffix of its base name
-   * after the last dot character, if any.
-   *
-   * In particular,
-   *
-   *  - if the name does not include a dot, there is no extension, so this
-   *    predicate has no result;
-   *  - if the name ends in a dot, the extension is the empty string;
-   *  - if the name contains multiple dots, the extension follows the last dot.
-   *
-   * Here are some examples of absolute paths and the corresponding extensions
-   * (surrounded with quotes to avoid ambiguity):
-   *
-   * <table border="1">
-   * <tr><th>Absolute path</th><th>Extension</th></tr>
-   * <tr><td>"/tmp/tst.js"</td><td>"js"</td></tr>
-   * <tr><td>"/tmp/.classpath"</td><td>"classpath"</td></tr>
-   * <tr><td>"/bin/bash"</td><td>not defined</td></tr>
-   * <tr><td>"/tmp/tst2."</td><td>""</td></tr>
-   * <tr><td>"/tmp/x.tar.gz"</td><td>"gz"</td></tr>
-   * </table>
-   */
-  string getExtension() {
-    result = this.getAbsolutePath().regexpCapture(".*/([^/]*?)(\\.([^.]*))?", 3)
-  }
-
-  /**
-   * Gets the stem of this container, that is, the prefix of its base name up to
-   * (but not including) the last dot character if there is one, or the entire
-   * base name if there is not.
-   *
-   * Here are some examples of absolute paths and the corresponding stems
-   * (surrounded with quotes to avoid ambiguity):
-   *
-   * <table border="1">
-   * <tr><th>Absolute path</th><th>Stem</th></tr>
-   * <tr><td>"/tmp/tst.js"</td><td>"tst"</td></tr>
-   * <tr><td>"/tmp/.classpath"</td><td>""</td></tr>
-   * <tr><td>"/bin/bash"</td><td>"bash"</td></tr>
-   * <tr><td>"/tmp/tst2."</td><td>"tst2"</td></tr>
-   * <tr><td>"/tmp/x.tar.gz"</td><td>"x.tar"</td></tr>
-   * </table>
-   */
-  string getStem() {
-    result = this.getAbsolutePath().regexpCapture(".*/([^/]*?)(?:\\.([^.]*))?", 1)
-  }
-
-  /** Gets the parent container of this file or folder, if any. */
-  Container getParentContainer() {
-    containerparent(unresolveElement(result), underlyingElement(this))
-  }
-
-  /** Gets a file or sub-folder in this container. */
-  Container getAChildContainer() { this = result.getParentContainer() }
-
-  /** Gets a file in this container. */
-  File getAFile() { result = this.getAChildContainer() }
-
-  /** Gets the file in this container that has the given `baseName`, if any. */
-  File getFile(string baseName) {
-    result = this.getAFile() and
-    result.getBaseName() = baseName
-  }
-
-  /** Gets a sub-folder in this container. */
-  Folder getAFolder() { result = this.getAChildContainer() }
-
-  /** Gets the sub-folder in this container that has the given `baseName`, if any. */
-  Folder getFolder(string baseName) {
-    result = this.getAFolder() and
-    result.getBaseName() = baseName
-  }
-
-  /**
-   * Gets a textual representation of the path of this container.
-   *
-   * This is the absolute path of the container.
-   */
-  override string toString() { result = this.getAbsolutePath() }
+class Container extends Locatable, Impl::Container {
+  override string toString() { result = Impl::Container.super.toString() }
 }
 
 /**
@@ -166,9 +46,7 @@ class Container extends Locatable, @container {
  *
  * To get the full path, use `getAbsolutePath`.
  */
-class Folder extends Container, @folder {
-  override string getAbsolutePath() { folders(underlyingElement(this), result) }
-
+class Folder extends Container, Impl::Folder {
   override Location getLocation() {
     result.getContainer() = this and
     result.hasLocationInfo(_, 0, 0, 0, 0)
@@ -189,9 +67,7 @@ class Folder extends Container, @folder {
  * The base name further decomposes into the _stem_ and _extension_ -- see
  * `getStem` and `getExtension`. To get the full path, use `getAbsolutePath`.
  */
-class File extends Container, @file {
-  override string getAbsolutePath() { files(underlyingElement(this), result) }
-
+class File extends Container, Impl::File {
   override string getAPrimaryQlClass() { result = "File" }
 
   override Location getLocation() {

--- a/csharp/ql/lib/semmle/code/csharp/File.qll
+++ b/csharp/ql/lib/semmle/code/csharp/File.qll
@@ -29,8 +29,7 @@ private module Impl = Make<Input>;
 
 class Container = Impl::Container;
 
-/** A folder. */
-class Folder extends Container, Impl::Folder { }
+class Folder = Impl::Folder;
 
 bindingset[flag]
 private predicate fileHasExtractionFlag(File f, int flag) {

--- a/go/ql/lib/semmle/go/Files.qll
+++ b/go/ql/lib/semmle/go/Files.qll
@@ -1,166 +1,34 @@
 /** Provides classes for working with files and folders. */
 
 import go
+private import codeql.util.FileSystem
 
-/** A file or folder. */
-abstract class Container extends @container {
-  /**
-   * Gets the absolute, canonical path of this container, using forward slashes
-   * as path separator.
-   *
-   * The path starts with a _root prefix_ followed by zero or more _path
-   * segments_ separated by forward slashes.
-   *
-   * The root prefix is of one of the following forms:
-   *
-   *   1. A single forward slash `/` (Unix-style)
-   *   2. An upper-case drive letter followed by a colon and a forward slash,
-   *      such as `C:/` (Windows-style)
-   *   3. Two forward slashes, a computer name, and then another forward slash,
-   *      such as `//FileServer/` (UNC-style)
-   *
-   * Path segments are never empty (that is, absolute paths never contain two
-   * contiguous slashes, except as part of a UNC-style root prefix). Also, path
-   * segments never contain forward slashes, and no path segment is of the
-   * form `.` (one dot) or `..` (two dots).
-   *
-   * Note that an absolute path never ends with a forward slash, except if it is
-   * a bare root prefix, that is, the path has no path segments. A container
-   * whose absolute path has no segments is always a `Folder`, not a `File`.
-   */
-  abstract string getAbsolutePath();
+private module Input implements InputSig {
+  abstract class ContainerBase extends @container {
+    abstract string getAbsolutePath();
 
-  /**
-   * Gets a URL representing the location of this container.
-   *
-   * For more information see https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/#providing-urls.
-   */
-  abstract string getURL();
+    ContainerBase getParentContainer() { containerparent(result, this) }
 
-  /**
-   * Gets the relative path of this file or folder from the root folder of the
-   * analyzed source location. The relative path of the root folder itself is
-   * the empty string.
-   *
-   * This has no result if the container is outside the source root, that is,
-   * if the root folder is not a reflexive, transitive parent of this container.
-   */
-  string getRelativePath() {
-    exists(string absPath, string pref |
-      absPath = this.getAbsolutePath() and sourceLocationPrefix(pref)
-    |
-      absPath = pref and result = ""
-      or
-      absPath = pref.regexpReplaceAll("/$", "") + "/" + result and
-      not result.matches("/%")
-    )
+    string toString() { result = this.getAbsolutePath() }
   }
 
-  /**
-   * Gets the base name of this container including extension, that is, the last
-   * segment of its absolute path, or the empty string if it has no segments.
-   *
-   * Here are some examples of absolute paths and the corresponding base names
-   * (surrounded with quotes to avoid ambiguity):
-   *
-   * <table border="1">
-   * <tr><th>Absolute path</th><th>Base name</th></tr>
-   * <tr><td>"/tmp/tst.go"</td><td>"tst.go"</td></tr>
-   * <tr><td>"C:/Program Files (x86)"</td><td>"Program Files (x86)"</td></tr>
-   * <tr><td>"/"</td><td>""</td></tr>
-   * <tr><td>"C:/"</td><td>""</td></tr>
-   * <tr><td>"D:/"</td><td>""</td></tr>
-   * <tr><td>"//FileServer/"</td><td>""</td></tr>
-   * </table>
-   */
-  string getBaseName() {
-    result = this.getAbsolutePath().regexpCapture(".*/(([^/]*?)(?:\\.([^.]*))?)", 1)
+  class FolderBase extends ContainerBase, @folder {
+    override string getAbsolutePath() { folders(this, result) }
   }
 
-  /**
-   * Gets the extension of this container, that is, the suffix of its base name
-   * after the last dot character, if any.
-   *
-   * In particular,
-   *
-   *  - if the name does not include a dot, there is no extension, so this
-   *    predicate has no result;
-   *  - if the name ends in a dot, the extension is the empty string;
-   *  - if the name contains multiple dots, the extension follows the last dot.
-   *
-   * Here are some examples of absolute paths and the corresponding extensions
-   * (surrounded with quotes to avoid ambiguity):
-   *
-   * <table border="1">
-   * <tr><th>Absolute path</th><th>Extension</th></tr>
-   * <tr><td>"/tmp/tst.go"</td><td>"go"</td></tr>
-   * <tr><td>"/tmp/.classpath"</td><td>"classpath"</td></tr>
-   * <tr><td>"/bin/bash"</td><td>not defined</td></tr>
-   * <tr><td>"/tmp/tst2."</td><td>""</td></tr>
-   * <tr><td>"/tmp/x.tar.gz"</td><td>"gz"</td></tr>
-   * </table>
-   */
-  string getExtension() {
-    result = this.getAbsolutePath().regexpCapture(".*/([^/]*?)(\\.([^.]*))?", 3)
+  class FileBase extends ContainerBase, @file {
+    override string getAbsolutePath() { files(this, result) }
   }
 
-  /**
-   * Gets the stem of this container, that is, the prefix of its base name up to
-   * (but not including) the last dot character if there is one, or the entire
-   * base name if there is not.
-   *
-   * Here are some examples of absolute paths and the corresponding stems
-   * (surrounded with quotes to avoid ambiguity):
-   *
-   * <table border="1">
-   * <tr><th>Absolute path</th><th>Stem</th></tr>
-   * <tr><td>"/tmp/tst.go"</td><td>"tst"</td></tr>
-   * <tr><td>"/tmp/.classpath"</td><td>""</td></tr>
-   * <tr><td>"/bin/bash"</td><td>"bash"</td></tr>
-   * <tr><td>"/tmp/tst2."</td><td>"tst2"</td></tr>
-   * <tr><td>"/tmp/x.tar.gz"</td><td>"x.tar"</td></tr>
-   * </table>
-   */
-  string getStem() {
-    result = this.getAbsolutePath().regexpCapture(".*/([^/]*?)(?:\\.([^.]*))?", 1)
-  }
-
-  /** Gets the parent container of this file or folder, if any. */
-  Container getParentContainer() { containerparent(result, this) }
-
-  /** Gets a file or sub-folder in this container. */
-  Container getAChildContainer() { this = result.getParentContainer() }
-
-  /** Gets a file in this container. */
-  File getAFile() { result = this.getAChildContainer() }
-
-  /** Gets the file in this container that has the given `baseName`, if any. */
-  File getFile(string baseName) {
-    result = this.getAFile() and
-    result.getBaseName() = baseName
-  }
-
-  /** Gets a sub-folder in this container. */
-  Folder getAFolder() { result = this.getAChildContainer() }
-
-  /** Gets the sub-folder in this container that has the given `baseName`, if any. */
-  Folder getFolder(string baseName) {
-    result = this.getAFolder() and
-    result.getBaseName() = baseName
-  }
-
-  /**
-   * Gets a textual representation of the path of this container.
-   *
-   * This is the absolute path of the container.
-   */
-  string toString() { result = this.getAbsolutePath() }
+  predicate hasSourceLocationPrefix = sourceLocationPrefix/1;
 }
 
-/** A folder. */
-class Folder extends Container, @folder {
-  override string getAbsolutePath() { folders(this, result) }
+private module Impl = Make<Input>;
 
+class Container = Impl::Container;
+
+/** A folder. */
+class Folder extends Container, Impl::Folder {
   /** Gets the file or subfolder in this folder that has the given `name`, if any. */
   Container getChildContainer(string name) {
     result = this.getAChildContainer() and
@@ -176,18 +44,13 @@ class Folder extends Container, @folder {
 
   /** Gets a subfolder contained in this folder. */
   Folder getASubFolder() { result = this.getAChildContainer() }
-
-  /** Gets the URL of this folder. */
-  override string getURL() { result = "folder://" + this.getAbsolutePath() }
 }
 
 /** A file, including files that have not been extracted but are referred to as locations for errors. */
-class ExtractedOrExternalFile extends Container, @file, Documentable, ExprParent, GoModExprParent,
-  DeclParent, ScopeNode
+class ExtractedOrExternalFile extends Container, Impl::File, Documentable, ExprParent,
+  GoModExprParent, DeclParent, ScopeNode
 {
   override Location getLocation() { has_location(this, result) }
-
-  override string getAbsolutePath() { files(this, result) }
 
   /** Gets the number of lines in this file. */
   int getNumberOfLines() { numlines(this, result, _, _) }
@@ -245,9 +108,6 @@ class ExtractedOrExternalFile extends Container, @file, Documentable, ExprParent
   }
 
   override string toString() { result = Container.super.toString() }
-
-  /** Gets the URL of this file. */
-  override string getURL() { result = "file://" + this.getAbsolutePath() + ":0:0:0:0" }
 
   /** Gets the `i`th child comment group. */
   CommentGroup getCommentGroup(int i) { comment_groups(result, this, i) }

--- a/java/ql/lib/semmle/code/FileSystem.qll
+++ b/java/ql/lib/semmle/code/FileSystem.qll
@@ -1,171 +1,37 @@
 /** Provides classes for working with files and folders. */
 
 import Location
+private import codeql.util.FileSystem
+
+private module Input implements InputSig {
+  abstract class ContainerBase extends @container {
+    abstract string getAbsolutePath();
+
+    ContainerBase getParentContainer() { containerparent(result, this) }
+
+    string toString() { result = this.getAbsolutePath() }
+  }
+
+  class FolderBase extends ContainerBase, @folder {
+    override string getAbsolutePath() { folders(this, result) }
+  }
+
+  class FileBase extends ContainerBase, @file {
+    override string getAbsolutePath() { files(this, result) }
+  }
+
+  predicate hasSourceLocationPrefix = sourceLocationPrefix/1;
+}
+
+private module Impl = Make<Input>;
 
 /** A file or folder. */
-class Container extends @container, Top {
-  /**
-   * Gets the absolute, canonical path of this container, using forward slashes
-   * as path separator.
-   *
-   * The path starts with a _root prefix_ followed by zero or more _path
-   * segments_ separated by forward slashes.
-   *
-   * The root prefix is of one of the following forms:
-   *
-   *   1. A single forward slash `/` (Unix-style)
-   *   2. An upper-case drive letter followed by a colon and a forward slash,
-   *      such as `C:/` (Windows-style)
-   *   3. Two forward slashes, a computer name, and then another forward slash,
-   *      such as `//FileServer/` (UNC-style)
-   *
-   * Path segments are never empty (that is, absolute paths never contain two
-   * contiguous slashes, except as part of a UNC-style root prefix). Also, path
-   * segments never contain forward slashes, and no path segment is of the
-   * form `.` (one dot) or `..` (two dots).
-   *
-   * Note that an absolute path never ends with a forward slash, except if it is
-   * a bare root prefix, that is, the path has no path segments. A container
-   * whose absolute path has no segments is always a `Folder`, not a `File`.
-   */
-  abstract string getAbsolutePath();
-
-  /**
-   * Gets a URL representing the location of this container.
-   *
-   * For more information see [Providing URLs](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/#providing-urls).
-   */
-  abstract string getURL();
-
-  /**
-   * Gets the relative path of this file or folder from the root folder of the
-   * analyzed source location. The relative path of the root folder itself is
-   * the empty string.
-   *
-   * This has no result if the container is outside the source root, that is,
-   * if the root folder is not a reflexive, transitive parent of this container.
-   */
-  string getRelativePath() {
-    exists(string absPath, string pref |
-      absPath = this.getAbsolutePath() and sourceLocationPrefix(pref)
-    |
-      absPath = pref and result = ""
-      or
-      absPath = pref.regexpReplaceAll("/$", "") + "/" + result and
-      not result.matches("/%")
-    )
-  }
-
-  /**
-   * Gets the base name of this container including extension, that is, the last
-   * segment of its absolute path, or the empty string if it has no segments.
-   *
-   * Here are some examples of absolute paths and the corresponding base names
-   * (surrounded with quotes to avoid ambiguity):
-   *
-   * <table border="1">
-   * <tr><th>Absolute path</th><th>Base name</th></tr>
-   * <tr><td>"/tmp/tst.java"</td><td>"tst.java"</td></tr>
-   * <tr><td>"C:/Program Files (x86)"</td><td>"Program Files (x86)"</td></tr>
-   * <tr><td>"/"</td><td>""</td></tr>
-   * <tr><td>"C:/"</td><td>""</td></tr>
-   * <tr><td>"D:/"</td><td>""</td></tr>
-   * <tr><td>"//FileServer/"</td><td>""</td></tr>
-   * </table>
-   */
-  string getBaseName() {
-    result = this.getAbsolutePath().regexpCapture(".*/(([^/]*?)(?:\\.([^.]*))?)", 1)
-  }
-
-  /**
-   * Gets the extension of this container, that is, the suffix of its base name
-   * after the last dot character, if any.
-   *
-   * In particular,
-   *
-   *  - if the name does not include a dot, there is no extension, so this
-   *    predicate has no result;
-   *  - if the name ends in a dot, the extension is the empty string;
-   *  - if the name contains multiple dots, the extension follows the last dot.
-   *
-   * Here are some examples of absolute paths and the corresponding extensions
-   * (surrounded with quotes to avoid ambiguity):
-   *
-   * <table border="1">
-   * <tr><th>Absolute path</th><th>Extension</th></tr>
-   * <tr><td>"/tmp/tst.java"</td><td>"java"</td></tr>
-   * <tr><td>"/tmp/.classpath"</td><td>"classpath"</td></tr>
-   * <tr><td>"/bin/bash"</td><td>not defined</td></tr>
-   * <tr><td>"/tmp/tst2."</td><td>""</td></tr>
-   * <tr><td>"/tmp/x.tar.gz"</td><td>"gz"</td></tr>
-   * </table>
-   */
-  string getExtension() {
-    result = this.getAbsolutePath().regexpCapture(".*/([^/]*?)(\\.([^.]*))?", 3)
-  }
-
-  /**
-   * Gets the stem of this container, that is, the prefix of its base name up to
-   * (but not including) the last dot character if there is one, or the entire
-   * base name if there is not.
-   *
-   * Here are some examples of absolute paths and the corresponding stems
-   * (surrounded with quotes to avoid ambiguity):
-   *
-   * <table border="1">
-   * <tr><th>Absolute path</th><th>Stem</th></tr>
-   * <tr><td>"/tmp/tst.java"</td><td>"tst"</td></tr>
-   * <tr><td>"/tmp/.classpath"</td><td>""</td></tr>
-   * <tr><td>"/bin/bash"</td><td>"bash"</td></tr>
-   * <tr><td>"/tmp/tst2."</td><td>"tst2"</td></tr>
-   * <tr><td>"/tmp/x.tar.gz"</td><td>"x.tar"</td></tr>
-   * </table>
-   */
-  string getStem() {
-    result = this.getAbsolutePath().regexpCapture(".*/([^/]*?)(?:\\.([^.]*))?", 1)
-  }
-
-  /** Gets the parent container of this file or folder, if any. */
-  Container getParentContainer() { containerparent(result, this) }
-
-  /** Gets a file or sub-folder in this container. */
-  Container getAChildContainer() { this = result.getParentContainer() }
-
-  /** Gets a file in this container. */
-  File getAFile() { result = this.getAChildContainer() }
-
-  /** Gets the file in this container that has the given `baseName`, if any. */
-  File getFile(string baseName) {
-    result = this.getAFile() and
-    result.getBaseName() = baseName
-  }
-
-  /** Gets a sub-folder in this container. */
-  Folder getAFolder() { result = this.getAChildContainer() }
-
-  /** Gets the sub-folder in this container that has the given `baseName`, if any. */
-  Folder getFolder(string baseName) {
-    result = this.getAFolder() and
-    result.getBaseName() = baseName
-  }
-
-  /**
-   * Gets a textual representation of this container.
-   *
-   * The default implementation gets the absolute path to the container, but subclasses may override
-   * to provide a different result. To get the absolute path of any `Container`, call
-   * `Container.getAbsolutePath()` directly.
-   */
-  override string toString() { result = this.getAbsolutePath() }
+class Container extends Impl::Container, Top {
+  override string toString() { result = Impl::Container.super.toString() }
 }
 
 /** A folder. */
-class Folder extends Container, @folder {
-  override string getAbsolutePath() { folders(this, result) }
-
-  /** Gets the URL of this folder. */
-  override string getURL() { result = "folder://" + this.getAbsolutePath() }
-
+class Folder extends Container, Impl::Folder {
   override string getAPrimaryQlClass() { result = "Folder" }
 }
 
@@ -174,12 +40,7 @@ class Folder extends Container, @folder {
  *
  * Note that `File` extends `Container` as it may be a `jar` file.
  */
-class File extends Container, @file {
-  override string getAbsolutePath() { files(this, result) }
-
-  /** Gets the URL of this file. */
-  override string getURL() { result = "file://" + this.getAbsolutePath() + ":0:0:0:0" }
-
+class File extends Container, Impl::File {
   override string getAPrimaryQlClass() { result = "File" }
 
   /** Holds if this is a (Java or Kotlin) source file. */

--- a/javascript/ql/lib/semmle/javascript/Files.qll
+++ b/javascript/ql/lib/semmle/javascript/Files.qll
@@ -2,166 +2,34 @@
 
 import javascript
 private import NodeModuleResolutionImpl
+private import codeql.util.FileSystem
 
-/** A file or folder. */
-abstract class Container extends @container {
-  /**
-   * Gets the absolute, canonical path of this container, using forward slashes
-   * as path separator.
-   *
-   * The path starts with a _root prefix_ followed by zero or more _path
-   * segments_ separated by forward slashes.
-   *
-   * The root prefix is of one of the following forms:
-   *
-   *   1. A single forward slash `/` (Unix-style)
-   *   2. An upper-case drive letter followed by a colon and a forward slash,
-   *      such as `C:/` (Windows-style)
-   *   3. Two forward slashes, a computer name, and then another forward slash,
-   *      such as `//FileServer/` (UNC-style)
-   *
-   * Path segments are never empty (that is, absolute paths never contain two
-   * contiguous slashes, except as part of a UNC-style root prefix). Also, path
-   * segments never contain forward slashes, and no path segment is of the
-   * form `.` (one dot) or `..` (two dots).
-   *
-   * Note that an absolute path never ends with a forward slash, except if it is
-   * a bare root prefix, that is, the path has no path segments. A container
-   * whose absolute path has no segments is always a `Folder`, not a `File`.
-   */
-  abstract string getAbsolutePath();
+private module FsInput implements InputSig {
+  abstract class ContainerBase extends @container {
+    abstract string getAbsolutePath();
 
-  /**
-   * Gets a URL representing the location of this container.
-   *
-   * For more information see [Providing URLs](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/#providing-urls).
-   */
-  abstract string getURL();
+    ContainerBase getParentContainer() { containerparent(result, this) }
 
-  /**
-   * Gets the relative path of this file or folder from the root folder of the
-   * analyzed source location. The relative path of the root folder itself is
-   * the empty string.
-   *
-   * This has no result if the container is outside the source root, that is,
-   * if the root folder is not a reflexive, transitive parent of this container.
-   */
-  string getRelativePath() {
-    exists(string absPath, string pref |
-      absPath = this.getAbsolutePath() and sourceLocationPrefix(pref)
-    |
-      absPath = pref and result = ""
-      or
-      absPath = pref.regexpReplaceAll("/$", "") + "/" + result and
-      not result.matches("/%")
-    )
+    string toString() { result = this.getAbsolutePath() }
   }
 
-  /**
-   * Gets the base name of this container including extension, that is, the last
-   * segment of its absolute path, or the empty string if it has no segments.
-   *
-   * Here are some examples of absolute paths and the corresponding base names
-   * (surrounded with quotes to avoid ambiguity):
-   *
-   * <table border="1">
-   * <tr><th>Absolute path</th><th>Base name</th></tr>
-   * <tr><td>"/tmp/tst.js"</td><td>"tst.js"</td></tr>
-   * <tr><td>"C:/Program Files (x86)"</td><td>"Program Files (x86)"</td></tr>
-   * <tr><td>"/"</td><td>""</td></tr>
-   * <tr><td>"C:/"</td><td>""</td></tr>
-   * <tr><td>"D:/"</td><td>""</td></tr>
-   * <tr><td>"//FileServer/"</td><td>""</td></tr>
-   * </table>
-   */
-  string getBaseName() {
-    result = this.getAbsolutePath().regexpCapture(".*/(([^/]*?)(\\.([^.]*))?)", 1)
+  class FolderBase extends ContainerBase, @folder {
+    override string getAbsolutePath() { folders(this, result) }
   }
 
-  /**
-   * Gets the extension of this container, that is, the suffix of its base name
-   * after the last dot character, if any.
-   *
-   * In particular,
-   *
-   *  - if the name does not include a dot, there is no extension, so this
-   *    predicate has no result;
-   *  - if the name ends in a dot, the extension is the empty string;
-   *  - if the name contains multiple dots, the extension follows the last dot.
-   *
-   * Here are some examples of absolute paths and the corresponding extensions
-   * (surrounded with quotes to avoid ambiguity):
-   *
-   * <table border="1">
-   * <tr><th>Absolute path</th><th>Extension</th></tr>
-   * <tr><td>"/tmp/tst.js"</td><td>"js"</td></tr>
-   * <tr><td>"/tmp/.classpath"</td><td>"classpath"</td></tr>
-   * <tr><td>"/bin/bash"</td><td>not defined</td></tr>
-   * <tr><td>"/tmp/tst2."</td><td>""</td></tr>
-   * <tr><td>"/tmp/x.tar.gz"</td><td>"gz"</td></tr>
-   * </table>
-   */
-  string getExtension() {
-    result = this.getAbsolutePath().regexpCapture(".*/(([^/]*?)(\\.([^.]*))?)", 4)
+  class FileBase extends ContainerBase, @file {
+    override string getAbsolutePath() { files(this, result) }
   }
 
-  /**
-   * Gets the stem of this container, that is, the prefix of its base name up to
-   * (but not including) the last dot character if there is one, or the entire
-   * base name if there is not.
-   *
-   * Here are some examples of absolute paths and the corresponding stems
-   * (surrounded with quotes to avoid ambiguity):
-   *
-   * <table border="1">
-   * <tr><th>Absolute path</th><th>Stem</th></tr>
-   * <tr><td>"/tmp/tst.js"</td><td>"tst"</td></tr>
-   * <tr><td>"/tmp/.classpath"</td><td>""</td></tr>
-   * <tr><td>"/bin/bash"</td><td>"bash"</td></tr>
-   * <tr><td>"/tmp/tst2."</td><td>"tst2"</td></tr>
-   * <tr><td>"/tmp/x.tar.gz"</td><td>"x.tar"</td></tr>
-   * </table>
-   */
-  string getStem() {
-    result = this.getAbsolutePath().regexpCapture(".*/(([^/]*?)(\\.([^.]*))?)", 2)
-  }
-
-  /** Gets the parent container of this file or folder, if any. */
-  Container getParentContainer() { containerparent(result, this) }
-
-  /** Gets a file or sub-folder in this container. */
-  Container getAChildContainer() { this = result.getParentContainer() }
-
-  /** Gets a file in this container. */
-  File getAFile() { result = this.getAChildContainer() }
-
-  /** Gets the file in this container that has the given `baseName`, if any. */
-  File getFile(string baseName) {
-    result = this.getAFile() and
-    result.getBaseName() = baseName
-  }
-
-  /** Gets a sub-folder in this container. */
-  Folder getAFolder() { result = this.getAChildContainer() }
-
-  /** Gets the sub-folder in this container that has the given `baseName`, if any. */
-  Folder getFolder(string baseName) {
-    result = this.getAFolder() and
-    result.getBaseName() = baseName
-  }
-
-  /**
-   * Gets a textual representation of the path of this container.
-   *
-   * This is the absolute path of the container.
-   */
-  string toString() { result = this.getAbsolutePath() }
+  predicate hasSourceLocationPrefix = sourceLocationPrefix/1;
 }
 
-/** A folder. */
-class Folder extends Container, @folder {
-  override string getAbsolutePath() { folders(this, result) }
+private module Impl = Make<FsInput>;
 
+class Container = Impl::Container;
+
+/** A folder. */
+class Folder extends Container, Impl::Folder {
   /** Gets the file or subfolder in this folder that has the given `name`, if any. */
   Container getChildContainer(string name) {
     result = this.getAChildContainer() and
@@ -206,21 +74,16 @@ class Folder extends Container, @folder {
 
   /** Gets a subfolder contained in this folder. */
   Folder getASubFolder() { result = this.getAChildContainer() }
-
-  /** Gets the URL of this folder. */
-  override string getURL() { result = "folder://" + this.getAbsolutePath() }
 }
 
 /** A file. */
-class File extends Container, @file {
+class File extends Container, Impl::File {
   /**
    * Gets the location of this file.
    *
    * Note that files have special locations starting and ending at line zero, column zero.
    */
   Location getLocation() { hasLocation(this, result) }
-
-  override string getAbsolutePath() { files(this, result) }
 
   /** Gets the number of lines in this file. */
   int getNumberOfLines() { result = sum(int loc | numlines(this, loc, _, _) | loc) }
@@ -233,9 +96,6 @@ class File extends Container, @file {
 
   /** Gets a toplevel piece of JavaScript code in this file. */
   TopLevel getATopLevel() { result.getFile() = this }
-
-  /** Gets the URL of this file. */
-  override string getURL() { result = "file://" + this.getAbsolutePath() + ":0:0:0:0" }
 
   /**
    * Holds if line number `lineno` of this file is indented to depth `d`

--- a/python/ql/lib/semmle/python/Files.qll
+++ b/python/ql/lib/semmle/python/Files.qll
@@ -1,7 +1,32 @@
+/** Provides classes for working with files and folders. */
+
 import python
+private import codeql.util.FileSystem
+
+private module Input implements InputSig {
+  abstract class ContainerBase extends @container {
+    abstract string getAbsolutePath();
+
+    ContainerBase getParentContainer() { containerparent(result, this) }
+
+    string toString() { result = this.getAbsolutePath() }
+  }
+
+  class FolderBase extends ContainerBase, @folder {
+    override string getAbsolutePath() { folders(this, result) }
+  }
+
+  class FileBase extends ContainerBase, @file {
+    override string getAbsolutePath() { files(this, result) }
+  }
+
+  predicate hasSourceLocationPrefix = sourceLocationPrefix/1;
+}
+
+private module Impl = Make<Input>;
 
 /** A file */
-class File extends Container, @file {
+class File extends Container, Impl::File {
   /**
    * Holds if this element is at the specified location.
    * The location spans column `startcolumn` of line `startline` to
@@ -44,11 +69,6 @@ class File extends Container, @file {
       result = c.getText().regexpCapture(".*coding[:=]\\s*([-\\w.]+).*", 1)
     )
   }
-
-  override string getAbsolutePath() { files(this, result) }
-
-  /** Gets the URL of this file. */
-  override string getURL() { result = "file://" + this.getAbsolutePath() + ":0:0:0:0" }
 
   override Container getImportRoot(int n) {
     /* File stem must be a legal Python identifier */
@@ -108,7 +128,7 @@ private predicate occupied_line(File f, int n) {
 }
 
 /** A folder (directory) */
-class Folder extends Container, @folder {
+class Folder extends Container, Impl::Folder {
   /**
    * Holds if this element is at the specified location.
    * The location spans column `startcolumn` of line `startline` to
@@ -126,11 +146,6 @@ class Folder extends Container, @folder {
     endcolumn = 0
   }
 
-  override string getAbsolutePath() { folders(this, result) }
-
-  /** Gets the URL of this folder. */
-  override string getURL() { result = "folder://" + this.getAbsolutePath() }
-
   override Container getImportRoot(int n) {
     this.isImportRoot(n) and result = this
     or
@@ -144,34 +159,8 @@ class Folder extends Container, @folder {
  * A container is an abstract representation of a file system object that can
  * hold elements of interest.
  */
-abstract class Container extends @container {
-  Container getParent() { containerparent(result, this) }
-
-  /**
-   * Gets a textual representation of the path of this container.
-   *
-   * This is the absolute path of the container.
-   */
-  string toString() { result = this.getAbsolutePath() }
-
-  /**
-   * Gets the relative path of this file or folder from the root folder of the
-   * analyzed source location. The relative path of the root folder itself is
-   * the empty string.
-   *
-   * This has no result if the container is outside the source root, that is,
-   * if the root folder is not a reflexive, transitive parent of this container.
-   */
-  string getRelativePath() {
-    exists(string absPath, string pref |
-      absPath = this.getAbsolutePath() and sourceLocationPrefix(pref)
-    |
-      absPath = pref and result = ""
-      or
-      absPath = pref.regexpReplaceAll("/$", "") + "/" + result and
-      not result.matches("/%")
-    )
-  }
+class Container extends Impl::Container {
+  Container getParent() { result = this.getParentContainer() }
 
   /** Whether this file or folder is part of the standard library */
   predicate inStdlib() { this.inStdlib(_, _) }
@@ -187,134 +176,12 @@ abstract class Container extends @container {
     )
   }
 
-  /* Standard cross-language API */
-  /** Gets a file or sub-folder in this container. */
-  Container getAChildContainer() { containerparent(this, result) }
-
-  /** Gets a file in this container. */
-  File getAFile() { result = this.getAChildContainer() }
-
-  /** Gets a sub-folder in this container. */
-  Folder getAFolder() { result = this.getAChildContainer() }
-
-  /**
-   * Gets the absolute, canonical path of this container, using forward slashes
-   * as path separator.
-   *
-   * The path starts with a _root prefix_ followed by zero or more _path
-   * segments_ separated by forward slashes.
-   *
-   * The root prefix is of one of the following forms:
-   *
-   *   1. A single forward slash `/` (Unix-style)
-   *   2. An upper-case drive letter followed by a colon and a forward slash,
-   *      such as `C:/` (Windows-style)
-   *   3. Two forward slashes, a computer name, and then another forward slash,
-   *      such as `//FileServer/` (UNC-style)
-   *
-   * Path segments are never empty (that is, absolute paths never contain two
-   * contiguous slashes, except as part of a UNC-style root prefix). Also, path
-   * segments never contain forward slashes, and no path segment is of the
-   * form `.` (one dot) or `..` (two dots).
-   *
-   * Note that an absolute path never ends with a forward slash, except if it is
-   * a bare root prefix, that is, the path has no path segments. A container
-   * whose absolute path has no segments is always a `Folder`, not a `File`.
-   */
-  abstract string getAbsolutePath();
-
-  /**
-   * Gets the base name of this container including extension, that is, the last
-   * segment of its absolute path, or the empty string if it has no segments.
-   *
-   * Here are some examples of absolute paths and the corresponding base names
-   * (surrounded with quotes to avoid ambiguity):
-   *
-   * <table border="1">
-   * <tr><th>Absolute path</th><th>Base name</th></tr>
-   * <tr><td>"/tmp/tst.py"</td><td>"tst.py"</td></tr>
-   * <tr><td>"C:/Program Files (x86)"</td><td>"Program Files (x86)"</td></tr>
-   * <tr><td>"/"</td><td>""</td></tr>
-   * <tr><td>"C:/"</td><td>""</td></tr>
-   * <tr><td>"D:/"</td><td>""</td></tr>
-   * <tr><td>"//FileServer/"</td><td>""</td></tr>
-   * </table>
-   */
-  string getBaseName() {
-    result = this.getAbsolutePath().regexpCapture(".*/(([^/]*?)(?:\\.([^.]*))?)", 1)
-  }
-
-  /**
-   * Gets the extension of this container, that is, the suffix of its base name
-   * after the last dot character, if any.
-   *
-   * In particular,
-   *
-   *  - if the name does not include a dot, there is no extension, so this
-   *    predicate has no result;
-   *  - if the name ends in a dot, the extension is the empty string;
-   *  - if the name contains multiple dots, the extension follows the last dot.
-   *
-   * Here are some examples of absolute paths and the corresponding extensions
-   * (surrounded with quotes to avoid ambiguity):
-   *
-   * <table border="1">
-   * <tr><th>Absolute path</th><th>Extension</th></tr>
-   * <tr><td>"/tmp/tst.py"</td><td>"py"</td></tr>
-   * <tr><td>"/tmp/.gitignore"</td><td>"gitignore"</td></tr>
-   * <tr><td>"/bin/bash"</td><td>not defined</td></tr>
-   * <tr><td>"/tmp/tst2."</td><td>""</td></tr>
-   * <tr><td>"/tmp/x.tar.gz"</td><td>"gz"</td></tr>
-   * </table>
-   */
-  string getExtension() {
-    result = this.getAbsolutePath().regexpCapture(".*/([^/]*?)(\\.([^.]*))?", 3)
-  }
-
-  /**
-   * Gets the stem of this container, that is, the prefix of its base name up to
-   * (but not including) the last dot character if there is one, or the entire
-   * base name if there is not.
-   *
-   * Here are some examples of absolute paths and the corresponding stems
-   * (surrounded with quotes to avoid ambiguity):
-   *
-   * <table border="1">
-   * <tr><th>Absolute path</th><th>Stem</th></tr>
-   * <tr><td>"/tmp/tst.py"</td><td>"tst"</td></tr>
-   * <tr><td>"/tmp/.gitignore"</td><td>""</td></tr>
-   * <tr><td>"/bin/bash"</td><td>"bash"</td></tr>
-   * <tr><td>"/tmp/tst2."</td><td>"tst2"</td></tr>
-   * <tr><td>"/tmp/x.tar.gz"</td><td>"x.tar"</td></tr>
-   * </table>
-   */
-  string getStem() {
-    result = this.getAbsolutePath().regexpCapture(".*/([^/]*?)(?:\\.([^.]*))?", 1)
-  }
-
-  File getFile(string baseName) {
-    result = this.getAFile() and
-    result.getBaseName() = baseName
-  }
-
-  Folder getFolder(string baseName) {
-    result = this.getAFolder() and
-    result.getBaseName() = baseName
-  }
-
-  Container getParentContainer() { this = result.getAChildContainer() }
+  override Container getParentContainer() { result = super.getParentContainer() }
 
   Container getChildContainer(string baseName) {
     result = this.getAChildContainer() and
     result.getBaseName() = baseName
   }
-
-  /**
-   * Gets a URL representing the location of this container.
-   *
-   * For more information see [Providing URLs](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/#providing-urls).
-   */
-  abstract string getURL();
 
   /** Holds if this folder is on the import path. */
   predicate isImportRoot() { this.isImportRoot(_) }

--- a/ql/ql/src/codeql/files/FileSystem.qll
+++ b/ql/ql/src/codeql/files/FileSystem.qll
@@ -2,177 +2,36 @@
 
 private import codeql_ql.ast.internal.TreeSitter
 private import codeql.Locations
+private import codeql.util.FileSystem
 
-/** A file or folder. */
-abstract class Container extends @container {
-  /** Gets a file or sub-folder in this container. */
-  Container getAChildContainer() { this = result.getParentContainer() }
+private module Input implements InputSig {
+  abstract class ContainerBase extends @container {
+    abstract string getAbsolutePath();
 
-  /** Gets a file in this container. */
-  File getAFile() { result = this.getAChildContainer() }
+    ContainerBase getParentContainer() { containerparent(result, this) }
 
-  /** Gets a sub-folder in this container. */
-  Folder getAFolder() { result = this.getAChildContainer() }
-
-  /**
-   * Gets the absolute, canonical path of this container, using forward slashes
-   * as path separator.
-   *
-   * The path starts with a _root prefix_ followed by zero or more _path
-   * segments_ separated by forward slashes.
-   *
-   * The root prefix is of one of the following forms:
-   *
-   *   1. A single forward slash `/` (Unix-style)
-   *   2. An upper-case drive letter followed by a colon and a forward slash,
-   *      such as `C:/` (Windows-style)
-   *   3. Two forward slashes, a computer name, and then another forward slash,
-   *      such as `//FileServer/` (UNC-style)
-   *
-   * Path segments are never empty (that is, absolute paths never contain two
-   * contiguous slashes, except as part of a UNC-style root prefix). Also, path
-   * segments never contain forward slashes, and no path segment is of the
-   * form `.` (one dot) or `..` (two dots).
-   *
-   * Note that an absolute path never ends with a forward slash, except if it is
-   * a bare root prefix, that is, the path has no path segments. A container
-   * whose absolute path has no segments is always a `Folder`, not a `File`.
-   */
-  abstract string getAbsolutePath();
-
-  /**
-   * Gets the base name of this container including extension, that is, the last
-   * segment of its absolute path, or the empty string if it has no segments.
-   *
-   * Here are some examples of absolute paths and the corresponding base names
-   * (surrounded with quotes to avoid ambiguity):
-   *
-   * <table border="1">
-   * <tr><th>Absolute path</th><th>Base name</th></tr>
-   * <tr><td>"/tmp/tst.go"</td><td>"tst.go"</td></tr>
-   * <tr><td>"C:/Program Files (x86)"</td><td>"Program Files (x86)"</td></tr>
-   * <tr><td>"/"</td><td>""</td></tr>
-   * <tr><td>"C:/"</td><td>""</td></tr>
-   * <tr><td>"D:/"</td><td>""</td></tr>
-   * <tr><td>"//FileServer/"</td><td>""</td></tr>
-   * </table>
-   */
-  string getBaseName() {
-    result = this.getAbsolutePath().regexpCapture(".*/(([^/]*?)(?:\\.([^.]*))?)", 1)
+    string toString() { result = this.getAbsolutePath() }
   }
 
-  /**
-   * Gets the extension of this container, that is, the suffix of its base name
-   * after the last dot character, if any.
-   *
-   * In particular,
-   *
-   *  - if the name does not include a dot, there is no extension, so this
-   *    predicate has no result;
-   *  - if the name ends in a dot, the extension is the empty string;
-   *  - if the name contains multiple dots, the extension follows the last dot.
-   *
-   * Here are some examples of absolute paths and the corresponding extensions
-   * (surrounded with quotes to avoid ambiguity):
-   *
-   * <table border="1">
-   * <tr><th>Absolute path</th><th>Extension</th></tr>
-   * <tr><td>"/tmp/tst.go"</td><td>"go"</td></tr>
-   * <tr><td>"/tmp/.classpath"</td><td>"classpath"</td></tr>
-   * <tr><td>"/bin/bash"</td><td>not defined</td></tr>
-   * <tr><td>"/tmp/tst2."</td><td>""</td></tr>
-   * <tr><td>"/tmp/x.tar.gz"</td><td>"gz"</td></tr>
-   * </table>
-   */
-  string getExtension() {
-    result = this.getAbsolutePath().regexpCapture(".*/([^/]*?)(\\.([^.]*))?", 3)
+  class FolderBase extends ContainerBase, @folder {
+    override string getAbsolutePath() { folders(this, result) }
   }
 
-  /** Gets the file in this container that has the given `baseName`, if any. */
-  File getFile(string baseName) {
-    result = this.getAFile() and
-    result.getBaseName() = baseName
+  class FileBase extends ContainerBase, @file {
+    override string getAbsolutePath() { files(this, result) }
   }
 
-  /** Gets the sub-folder in this container that has the given `baseName`, if any. */
-  Folder getFolder(string baseName) {
-    result = this.getAFolder() and
-    result.getBaseName() = baseName
-  }
-
-  /** Gets the parent container of this file or folder, if any. */
-  Container getParentContainer() { containerparent(result, this) }
-
-  /**
-   * Gets the relative path of this file or folder from the root folder of the
-   * analyzed source location. The relative path of the root folder itself is
-   * the empty string.
-   *
-   * This has no result if the container is outside the source root, that is,
-   * if the root folder is not a reflexive, transitive parent of this container.
-   */
-  string getRelativePath() {
-    exists(string absPath, string pref |
-      absPath = this.getAbsolutePath() and sourceLocationPrefix(pref)
-    |
-      absPath = pref and result = ""
-      or
-      absPath = pref.regexpReplaceAll("/$", "") + "/" + result and
-      not result.matches("/%")
-    )
-  }
-
-  /**
-   * Gets the stem of this container, that is, the prefix of its base name up to
-   * (but not including) the last dot character if there is one, or the entire
-   * base name if there is not.
-   *
-   * Here are some examples of absolute paths and the corresponding stems
-   * (surrounded with quotes to avoid ambiguity):
-   *
-   * <table border="1">
-   * <tr><th>Absolute path</th><th>Stem</th></tr>
-   * <tr><td>"/tmp/tst.go"</td><td>"tst"</td></tr>
-   * <tr><td>"/tmp/.classpath"</td><td>""</td></tr>
-   * <tr><td>"/bin/bash"</td><td>"bash"</td></tr>
-   * <tr><td>"/tmp/tst2."</td><td>"tst2"</td></tr>
-   * <tr><td>"/tmp/x.tar.gz"</td><td>"x.tar"</td></tr>
-   * </table>
-   */
-  string getStem() {
-    result = this.getAbsolutePath().regexpCapture(".*/([^/]*?)(?:\\.([^.]*))?", 1)
-  }
-
-  /**
-   * Gets a URL representing the location of this container.
-   *
-   * For more information see https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/#providing-urls.
-   */
-  abstract string getURL();
-
-  /**
-   * Gets a textual representation of the path of this container.
-   *
-   * This is the absolute path of the container.
-   */
-  string toString() { result = this.getAbsolutePath() }
+  predicate hasSourceLocationPrefix = sourceLocationPrefix/1;
 }
 
-/** A folder. */
-class Folder extends Container, @folder {
-  override string getAbsolutePath() { folders(this, result) }
+private module Impl = Make<Input>;
 
-  /** Gets the URL of this folder. */
-  override string getURL() { result = "folder://" + this.getAbsolutePath() }
-}
+class Container = Impl::Container;
+
+class Folder = Impl::Folder;
 
 /** A file. */
-class File extends Container, @file {
-  override string getAbsolutePath() { files(this, result) }
-
-  /** Gets the URL of this file. */
-  override string getURL() { result = "file://" + this.getAbsolutePath() + ":0:0:0:0" }
-
+class File extends Container, Impl::File {
   /** Gets a token in this file. */
   private QL::Token getAToken() { result.getLocation().getFile() = this }
 

--- a/ruby/ql/lib/codeql/files/FileSystem.qll
+++ b/ruby/ql/lib/codeql/files/FileSystem.qll
@@ -27,8 +27,7 @@ private module Impl = Make<Input>;
 
 class Container = Impl::Container;
 
-/** A folder. */
-class Folder extends Container, Impl::Folder { }
+class Folder = Impl::Folder;
 
 /** A file. */
 class File extends Container, Impl::File {

--- a/shared/util/codeql/util/FileSystem.qll
+++ b/shared/util/codeql/util/FileSystem.qll
@@ -85,6 +85,17 @@ module Make<InputSig Input> {
     string getAbsolutePath() { result = super.getAbsolutePath() }
 
     /**
+     * Holds if either,
+     * - `part` is the base name of this container and `i = 1`, or
+     * - `part` is the stem of this container and `i = 2`, or
+     * - `part` is the extension of this container and `i = 3`.
+     */
+    cached
+    private predicate splitAbsolutePath(string part, int i) {
+      part = this.getAbsolutePath().regexpCapture(".*/(([^/]*?)(?:\\.([^.]*))?)", i)
+    }
+
+    /**
      * Gets the base name of this container including extension, that is, the last
      * segment of its absolute path, or the empty string if it has no segments.
      *
@@ -101,9 +112,7 @@ module Make<InputSig Input> {
      * <tr><td>"//FileServer/"</td><td>""</td></tr>
      * </table>
      */
-    string getBaseName() {
-      result = this.getAbsolutePath().regexpCapture(".*/(([^/]*?)(?:\\.([^.]*))?)", 1)
-    }
+    string getBaseName() { this.splitAbsolutePath(result, 1) }
 
     /**
      * Gets the extension of this container, that is, the suffix of its base name
@@ -128,9 +137,7 @@ module Make<InputSig Input> {
      * <tr><td>"/tmp/x.tar.gz"</td><td>"gz"</td></tr>
      * </table>
      */
-    string getExtension() {
-      result = this.getAbsolutePath().regexpCapture(".*/([^/]*?)(\\.([^.]*))?", 3)
-    }
+    string getExtension() { this.splitAbsolutePath(result, 3) }
 
     /** Gets the file in this container that has the given `baseName`, if any. */
     File getFile(string baseName) {
@@ -183,9 +190,7 @@ module Make<InputSig Input> {
      * <tr><td>"/tmp/x.tar.gz"</td><td>"x.tar"</td></tr>
      * </table>
      */
-    string getStem() {
-      result = this.getAbsolutePath().regexpCapture(".*/([^/]*?)(?:\\.([^.]*))?", 1)
-    }
+    string getStem() { this.splitAbsolutePath(result, 2) }
 
     /**
      * Gets a URL representing the location of this container.

--- a/shared/util/codeql/util/FileSystem.qll
+++ b/shared/util/codeql/util/FileSystem.qll
@@ -11,11 +11,15 @@ signature module InputSig {
     /**
      * Gets the absolute path of this container.
      *
-     * Typically `containerparent(result, this)`.
+     * Typically `folders(this, result) or files(this, result)`.
      */
     string getAbsolutePath();
 
-    /** Gets the parent container of this container, if any. */
+    /**
+     * Gets the parent container of this container, if any.
+     *
+     * Typically `containerparent(result, this)`.
+     */
     ContainerBase getParentContainer();
   }
 


### PR DESCRIPTION
This switches C++, Go, Java, JavaScript, Python, and QL to the shared FileSystem library as a followup to https://github.com/github/codeql/pull/12289.

I've also made a small performance tweak to the regex matching that extracts base name, stem, and extension from absolute file paths by reusing the same regex instead of calculating the same match 3 times.

Fixes https://github.com/github/codeql-c-team/issues/1598 and https://github.com/github/codeql-go-team/issues/325