### PR TITLE
Swift: Model .description, .debugDescription more generally

### DIFF
--- a/swift/ql/lib/change-notes/2023-09-27-debugdesc.md
+++ b/swift/ql/lib/change-notes/2023-09-27-debugdesc.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+
+* Modelled `CustomStringConvertible.description` and `CustomDebugStringConvertible.debugDescription`, replacing ad-hoc models of these properties on derived classes.

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/FilePath.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/FilePath.qll
@@ -61,11 +61,7 @@ private class FilePathFieldsInheritTaint extends TaintInheritingContent,
   FilePathFieldsInheritTaint() {
     exists(FieldDecl f | this.getField() = f |
       f.getEnclosingDecl().asNominalTypeDecl() instanceof FilePath and
-      f.getName() =
-        [
-          "description", "debugDescription", "components", "extension", "lastComponent", "root",
-          "stem", "string"
-        ]
+      f.getName() = ["components", "extension", "lastComponent", "root", "stem", "string"]
     )
   }
 }

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/String.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/String.qll
@@ -131,8 +131,8 @@ private class StringSummaries extends SummaryModelCsv {
 }
 
 /**
- * A content implying that, if a `String` is tainted, then many of its fields are
- * tainted. This also includes fields declared in `StringProtocol`.
+ * A content implying that, if a `String`, `StringProtocol` or related class is tainted, then many
+ * of its fields are tainted.
  */
 private class StringFieldsInheritTaint extends TaintInheritingContent,
   DataFlow::Content::FieldContent
@@ -141,12 +141,11 @@ private class StringFieldsInheritTaint extends TaintInheritingContent,
     this.getField()
         .hasQualifiedName(["String", "StringProtocol"],
           [
-            "unicodeScalars", "utf8", "utf16", "lazy", "utf8CString", "description",
-            "debugDescription", "dataValue", "identifierValue", "capitalized",
-            "localizedCapitalized", "localizedLowercase", "localizedUppercase",
-            "decomposedStringWithCanonicalMapping", "decomposedStringWithCompatibilityMapping",
-            "precomposedStringWithCanonicalMapping", "precomposedStringWithCompatibilityMapping",
-            "removingPercentEncoding"
+            "unicodeScalars", "utf8", "utf16", "lazy", "utf8CString", "dataValue",
+            "identifierValue", "capitalized", "localizedCapitalized", "localizedLowercase",
+            "localizedUppercase", "decomposedStringWithCanonicalMapping",
+            "decomposedStringWithCompatibilityMapping", "precomposedStringWithCanonicalMapping",
+            "precomposedStringWithCompatibilityMapping", "removingPercentEncoding"
           ])
   }
 }

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/String.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/String.qll
@@ -150,13 +150,11 @@ private class StringFieldsInheritTaint extends TaintInheritingContent,
     or
     exists(FieldDecl fieldDecl, Decl declaringDecl, TypeDecl namedTypeDecl |
       (
-        (
-          namedTypeDecl.getFullName() = "CustomStringConvertible" and
-          fieldDecl.getName() = "description"
-        ) or (
-          namedTypeDecl.getFullName() = "CustomDebugStringConvertible" and
-          fieldDecl.getName() = "debugDescription"
-        )
+        namedTypeDecl.getFullName() = "CustomStringConvertible" and
+        fieldDecl.getName() = "description"
+        or
+        namedTypeDecl.getFullName() = "CustomDebugStringConvertible" and
+        fieldDecl.getName() = "debugDescription"
       ) and
       declaringDecl.getAMember() = fieldDecl and
       declaringDecl.asNominalTypeDecl() = namedTypeDecl.getADerivedTypeDecl*() and

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/String.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/String.qll
@@ -147,5 +147,20 @@ private class StringFieldsInheritTaint extends TaintInheritingContent,
             "decomposedStringWithCompatibilityMapping", "precomposedStringWithCanonicalMapping",
             "precomposedStringWithCompatibilityMapping", "removingPercentEncoding"
           ])
+    or
+    exists(FieldDecl fieldDecl, Decl declaringDecl, TypeDecl namedTypeDecl |
+      (
+        (
+          namedTypeDecl.getFullName() = "CustomStringConvertible" and
+          fieldDecl.getName() = "description"
+        ) or (
+          namedTypeDecl.getFullName() = "CustomDebugStringConvertible" and
+          fieldDecl.getName() = "debugDescription"
+        )
+      ) and
+      declaringDecl.getAMember() = fieldDecl and
+      declaringDecl.asNominalTypeDecl() = namedTypeDecl.getADerivedTypeDecl*() and
+      this.getField() = fieldDecl
+    )
   }
 }

--- a/swift/ql/test/library-tests/dataflow/taint/core/LocalTaint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/core/LocalTaint.expected
@@ -89,8 +89,10 @@
 | conversions.swift:90:12:90:12 | [post] ms1 | conversions.swift:91:12:91:12 | ms1 |
 | conversions.swift:90:12:90:12 | ms1 | conversions.swift:91:12:91:12 | ms1 |
 | conversions.swift:91:12:91:12 | [post] ms1 | conversions.swift:92:12:92:12 | ms1 |
+| conversions.swift:91:12:91:12 | ms1 | conversions.swift:91:12:91:16 | .description |
 | conversions.swift:91:12:91:12 | ms1 | conversions.swift:92:12:92:12 | ms1 |
 | conversions.swift:92:12:92:12 | [post] ms1 | conversions.swift:93:12:93:12 | ms1 |
+| conversions.swift:92:12:92:12 | ms1 | conversions.swift:92:12:92:16 | .debugDescription |
 | conversions.swift:92:12:92:12 | ms1 | conversions.swift:93:12:93:12 | ms1 |
 | conversions.swift:95:6:95:6 | SSA def(ms2) | conversions.swift:96:12:96:12 | ms2 |
 | conversions.swift:95:6:95:6 | ms2 | conversions.swift:95:6:95:6 | SSA def(ms2) |
@@ -100,8 +102,10 @@
 | conversions.swift:96:12:96:12 | [post] ms2 | conversions.swift:97:12:97:12 | ms2 |
 | conversions.swift:96:12:96:12 | ms2 | conversions.swift:97:12:97:12 | ms2 |
 | conversions.swift:97:12:97:12 | [post] ms2 | conversions.swift:98:12:98:12 | ms2 |
+| conversions.swift:97:12:97:12 | ms2 | conversions.swift:97:12:97:16 | .description |
 | conversions.swift:97:12:97:12 | ms2 | conversions.swift:98:12:98:12 | ms2 |
 | conversions.swift:98:12:98:12 | [post] ms2 | conversions.swift:99:12:99:12 | ms2 |
+| conversions.swift:98:12:98:12 | ms2 | conversions.swift:98:12:98:16 | .debugDescription |
 | conversions.swift:98:12:98:12 | ms2 | conversions.swift:99:12:99:12 | ms2 |
 | conversions.swift:103:6:103:6 | SSA def(parent) | conversions.swift:104:12:104:12 | parent |
 | conversions.swift:103:6:103:6 | parent | conversions.swift:103:6:103:6 | SSA def(parent) |

--- a/swift/ql/test/library-tests/dataflow/taint/core/Taint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/core/Taint.expected
@@ -47,8 +47,12 @@ edges
 | conversions.swift:87:19:87:32 | call to sourceString() | conversions.swift:87:12:87:33 | call to String.init(_:) |
 | conversions.swift:95:12:95:35 | call to MyString.init(_:) | conversions.swift:95:12:95:35 | call to MyString.init(_:) [some:0] |
 | conversions.swift:95:12:95:35 | call to MyString.init(_:) | conversions.swift:96:12:96:12 | ms2 |
+| conversions.swift:95:12:95:35 | call to MyString.init(_:) | conversions.swift:97:12:97:16 | .description |
+| conversions.swift:95:12:95:35 | call to MyString.init(_:) | conversions.swift:98:12:98:16 | .debugDescription |
 | conversions.swift:95:12:95:35 | call to MyString.init(_:) [some:0] | conversions.swift:95:12:95:36 | ...! |
 | conversions.swift:95:12:95:36 | ...! | conversions.swift:96:12:96:12 | ms2 |
+| conversions.swift:95:12:95:36 | ...! | conversions.swift:97:12:97:16 | .description |
+| conversions.swift:95:12:95:36 | ...! | conversions.swift:98:12:98:16 | .debugDescription |
 | conversions.swift:95:21:95:34 | call to sourceString() | conversions.swift:95:12:95:35 | call to MyString.init(_:) |
 | conversions.swift:103:31:103:44 | call to sourceString() | conversions.swift:104:12:104:12 | parent |
 | conversions.swift:103:31:103:44 | call to sourceString() | conversions.swift:105:12:105:12 | parent |
@@ -223,6 +227,8 @@ nodes
 | conversions.swift:95:12:95:36 | ...! | semmle.label | ...! |
 | conversions.swift:95:21:95:34 | call to sourceString() | semmle.label | call to sourceString() |
 | conversions.swift:96:12:96:12 | ms2 | semmle.label | ms2 |
+| conversions.swift:97:12:97:16 | .description | semmle.label | .description |
+| conversions.swift:98:12:98:16 | .debugDescription | semmle.label | .debugDescription |
 | conversions.swift:103:31:103:44 | call to sourceString() | semmle.label | call to sourceString() |
 | conversions.swift:104:12:104:12 | parent | semmle.label | parent |
 | conversions.swift:105:12:105:12 | parent | semmle.label | parent |
@@ -395,6 +401,8 @@ subpaths
 | conversions.swift:86:12:86:25 | call to sourceString() | conversions.swift:86:12:86:25 | call to sourceString() | conversions.swift:86:12:86:25 | call to sourceString() | result |
 | conversions.swift:87:12:87:33 | call to String.init(_:) | conversions.swift:87:19:87:32 | call to sourceString() | conversions.swift:87:12:87:33 | call to String.init(_:) | result |
 | conversions.swift:96:12:96:12 | ms2 | conversions.swift:95:21:95:34 | call to sourceString() | conversions.swift:96:12:96:12 | ms2 | result |
+| conversions.swift:97:12:97:16 | .description | conversions.swift:95:21:95:34 | call to sourceString() | conversions.swift:97:12:97:16 | .description | result |
+| conversions.swift:98:12:98:16 | .debugDescription | conversions.swift:95:21:95:34 | call to sourceString() | conversions.swift:98:12:98:16 | .debugDescription | result |
 | conversions.swift:104:12:104:12 | parent | conversions.swift:103:31:103:44 | call to sourceString() | conversions.swift:104:12:104:12 | parent | result |
 | conversions.swift:105:12:105:12 | parent | conversions.swift:103:31:103:44 | call to sourceString() | conversions.swift:105:12:105:12 | parent | result |
 | conversions.swift:108:12:108:12 | v3 | conversions.swift:103:31:103:44 | call to sourceString() | conversions.swift:108:12:108:12 | v3 | result |

--- a/swift/ql/test/library-tests/dataflow/taint/core/conversions.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/core/conversions.swift
@@ -94,8 +94,8 @@ func testConversions() {
 
 	let ms2 = MyString(sourceString())!
 	sink(arg: ms2) // $ tainted=95
-	sink(arg: ms2.description) // $ MISSING: tainted=
-	sink(arg: ms2.debugDescription) // $ MISSING: tainted=
+	sink(arg: ms2.description) // $ tainted=95
+	sink(arg: ms2.debugDescription) // $ tainted=95
 	sink(arg: ms2.clean)
 
 	// ---

--- a/swift/ql/test/library-tests/dataflow/taint/libraries/files.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/libraries/files.swift
@@ -184,8 +184,8 @@ func test_files(e1: Encoder) {
 
 	// --- FilePath member variables ---
 
-	sink(string: tainted.description) // $ tainted=133
-	sink(string: tainted.debugDescription) // $ tainted=133
+	sink(string: tainted.description) // $ MISSING: tainted=133
+	sink(string: tainted.debugDescription) // $ MISSING: tainted=133
 	sink(string: tainted.extension!) // $ tainted=133
 	sink(string: tainted.stem!) // $ tainted=133
 	sink(string: tainted.string) // $ tainted=133

--- a/swift/ql/test/library-tests/dataflow/taint/libraries/files.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/libraries/files.swift
@@ -9,7 +9,7 @@ enum CInterop {
   typealias PlatformChar = CInterop.Char
 }
 
-struct FilePath {
+struct FilePath : CustomStringConvertible, CustomDebugStringConvertible {
 	struct Component {
 		init?(_ string: String) { }
 
@@ -184,8 +184,8 @@ func test_files(e1: Encoder) {
 
 	// --- FilePath member variables ---
 
-	sink(string: tainted.description) // $ MISSING: tainted=133
-	sink(string: tainted.debugDescription) // $ MISSING: tainted=133
+	sink(string: tainted.description) // $ tainted=133
+	sink(string: tainted.debugDescription) // $ tainted=133
 	sink(string: tainted.extension!) // $ tainted=133
 	sink(string: tainted.stem!) // $ tainted=133
 	sink(string: tainted.string) // $ tainted=133

--- a/swift/ql/test/library-tests/dataflow/taint/libraries/string.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/libraries/string.swift
@@ -272,9 +272,9 @@ func taintThroughSimpleStringOperations() {
   sink(arg: [tainted, tainted].joined()) // $ MISSING: tainted=217
 
   sink(arg: clean.description)
-  sink(arg: tainted.description) // $ MISSING: tainted=217
+  sink(arg: tainted.description) // $ tainted=217
   sink(arg: clean.debugDescription)
-  sink(arg: tainted.debugDescription) // $ MISSING: tainted=217
+  sink(arg: tainted.debugDescription) // $ tainted=217
   sink(arg: clean.utf8)
   sink(arg: tainted.utf8) // $ tainted=217
   sink(arg: clean.utf16)
@@ -584,7 +584,7 @@ func taintedThroughConversion() {
   sink(arg: String(0))
   sink(arg: String(source())) // $ tainted=585
   sink(arg: Int(0).description)
-  sink(arg: source().description) // $ MISSING: tainted=587
+  sink(arg: source().description) // $ tainted=587
   sink(arg: String(describing: 0))
   sink(arg: String(describing: source())) // $ tainted=589
 

--- a/swift/ql/test/library-tests/dataflow/taint/libraries/string.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/libraries/string.swift
@@ -272,9 +272,9 @@ func taintThroughSimpleStringOperations() {
   sink(arg: [tainted, tainted].joined()) // $ MISSING: tainted=217
 
   sink(arg: clean.description)
-  sink(arg: tainted.description) // $ tainted=217
+  sink(arg: tainted.description) // $ MISSING: tainted=217
   sink(arg: clean.debugDescription)
-  sink(arg: tainted.debugDescription) // $ tainted=217
+  sink(arg: tainted.debugDescription) // $ MISSING: tainted=217
   sink(arg: clean.utf8)
   sink(arg: tainted.utf8) // $ tainted=217
   sink(arg: clean.utf16)

--- a/swift/ql/test/library-tests/dataflow/taint/libraries/url.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/libraries/url.swift
@@ -154,7 +154,7 @@ struct URLResource {
 	let subdirectory: String?
 }
 
-struct URLRequest {
+struct URLRequest : CustomStringConvertible, CustomDebugStringConvertible {
 	enum CachePolicy { case none }
 	enum NetworkServiceType { case none }
 	enum Attribution { case none }
@@ -463,9 +463,9 @@ func taintThroughUrlRequest() {
 	sink(any: clean.attribution)
 	sink(any: tainted.attribution)
 	sink(any: clean.description)
-	sink(any: tainted.description)
+	sink(any: tainted.description) // $ tainted=431
 	sink(any: clean.debugDescription)
-	sink(any: tainted.debugDescription)
+	sink(any: tainted.debugDescription) // $ tainted=431
 	sink(any: clean.customMirror)
 	sink(any: tainted.customMirror)
 	sink(any: clean.hashValue)


### PR DESCRIPTION
Model `CustomStringConvertible.description` and `CustomDebugStringConvertible.debugDescription`.  Delete ad-hoc models of these methods on specific classes.