### PR TITLE
C#: Fix parentheses in model editor queries

### DIFF
--- a/csharp/ql/src/utils/modeleditor/ModelEditor.qll
+++ b/csharp/ql/src/utils/modeleditor/ModelEditor.qll
@@ -40,7 +40,7 @@ class Endpoint extends Callable {
    * Gets the parameter types of this endpoint.
    */
   bindingset[this]
-  string getParameterTypes() { result = parameterQualifiedTypeNamesToString(this) }
+  string getParameterTypes() { result = "(" + parameterQualifiedTypeNamesToString(this) + ")" }
 
   private string getDllName() { result = this.getLocation().(Assembly).getName() }
 

--- a/csharp/ql/test/utils/modeleditor/ApplicationModeEndpoints.expected
+++ b/csharp/ql/test/utils/modeleditor/ApplicationModeEndpoints.expected
@@ -1,14 +1,14 @@
-| NonPublicClass.cs:9:9:9:31 | call to method WriteLine | System | Console | WriteLine | System.String | true | System.Console | 7.0.0.0 | neutral | source |
-| PublicClass.cs:9:9:9:30 | call to method WriteLine | System | Console | WriteLine | System.String | true | System.Console | 7.0.0.0 | neutral | source |
-| PublicClass.cs:14:9:14:30 | call to method WriteLine | System | Console | WriteLine | System.String | true | System.Console | 7.0.0.0 | neutral | source |
-| PublicClass.cs:19:9:19:51 | call to method WriteLine | System | Console | WriteLine | System.String | true | System.Console | 7.0.0.0 | neutral | source |
-| PublicClass.cs:19:33:19:50 | call to method ReadLine | System | Console | ReadLine |  | true | System.Console | 7.0.0.0 | neutral | source |
-| PublicClass.cs:19:33:19:50 | call to method ReadLine | System | Console | ReadLine |  | true | System.Console | 7.0.0.0 | source | source |
-| PublicClass.cs:24:9:24:46 | call to method Write | System | Console | Write | System.Object | true | System.Console | 7.0.0.0 | neutral | source |
-| PublicClass.cs:24:23:24:45 | access to property BackgroundColor | System | Console | get_BackgroundColor |  | true | System.Console | 7.0.0.0 | neutral | source |
-| PublicClass.cs:25:9:25:31 | access to property ForegroundColor | System | Console | set_ForegroundColor | System.ConsoleColor | true | System.Console | 7.0.0.0 | neutral | source |
-| PublicClass.cs:30:9:30:30 | call to method WriteLine | System | Console | WriteLine | System.String | true | System.Console | 7.0.0.0 | neutral | source |
-| PublicGenericClass.cs:9:9:9:30 | call to method WriteLine | System | Console | WriteLine | System.Object | true | System.Console | 7.0.0.0 | neutral | source |
-| PublicGenericClass.cs:14:9:14:30 | call to method WriteLine | System | Console | WriteLine | System.Object | true | System.Console | 7.0.0.0 | neutral | source |
-| PublicGenericInterface.cs:13:9:13:30 | call to method WriteLine | System | Console | WriteLine | System.String | true | System.Console | 7.0.0.0 | neutral | source |
-| PublicInterface.cs:13:9:13:30 | call to method WriteLine | System | Console | WriteLine | System.String | true | System.Console | 7.0.0.0 | neutral | source |
+| NonPublicClass.cs:9:9:9:31 | call to method WriteLine | System | Console | WriteLine | (System.String) | true | System.Console | 7.0.0.0 | neutral | source |
+| PublicClass.cs:9:9:9:30 | call to method WriteLine | System | Console | WriteLine | (System.String) | true | System.Console | 7.0.0.0 | neutral | source |
+| PublicClass.cs:14:9:14:30 | call to method WriteLine | System | Console | WriteLine | (System.String) | true | System.Console | 7.0.0.0 | neutral | source |
+| PublicClass.cs:19:9:19:51 | call to method WriteLine | System | Console | WriteLine | (System.String) | true | System.Console | 7.0.0.0 | neutral | source |
+| PublicClass.cs:19:33:19:50 | call to method ReadLine | System | Console | ReadLine | () | true | System.Console | 7.0.0.0 | neutral | source |
+| PublicClass.cs:19:33:19:50 | call to method ReadLine | System | Console | ReadLine | () | true | System.Console | 7.0.0.0 | source | source |
+| PublicClass.cs:24:9:24:46 | call to method Write | System | Console | Write | (System.Object) | true | System.Console | 7.0.0.0 | neutral | source |
+| PublicClass.cs:24:23:24:45 | access to property BackgroundColor | System | Console | get_BackgroundColor | () | true | System.Console | 7.0.0.0 | neutral | source |
+| PublicClass.cs:25:9:25:31 | access to property ForegroundColor | System | Console | set_ForegroundColor | (System.ConsoleColor) | true | System.Console | 7.0.0.0 | neutral | source |
+| PublicClass.cs:30:9:30:30 | call to method WriteLine | System | Console | WriteLine | (System.String) | true | System.Console | 7.0.0.0 | neutral | source |
+| PublicGenericClass.cs:9:9:9:30 | call to method WriteLine | System | Console | WriteLine | (System.Object) | true | System.Console | 7.0.0.0 | neutral | source |
+| PublicGenericClass.cs:14:9:14:30 | call to method WriteLine | System | Console | WriteLine | (System.Object) | true | System.Console | 7.0.0.0 | neutral | source |
+| PublicGenericInterface.cs:13:9:13:30 | call to method WriteLine | System | Console | WriteLine | (System.String) | true | System.Console | 7.0.0.0 | neutral | source |
+| PublicInterface.cs:13:9:13:30 | call to method WriteLine | System | Console | WriteLine | (System.String) | true | System.Console | 7.0.0.0 | neutral | source |

--- a/csharp/ql/test/utils/modeleditor/FrameworkModeEndpoints.expected
+++ b/csharp/ql/test/utils/modeleditor/FrameworkModeEndpoints.expected
@@ -1,18 +1,18 @@
-| PublicClass.cs:7:17:7:21 | stuff | GitHub.CodeQL | PublicClass | stuff | System.String | false | PublicClass.cs |  |
-| PublicClass.cs:12:24:12:34 | staticStuff | GitHub.CodeQL | PublicClass | staticStuff | System.String | false | PublicClass.cs |  |
-| PublicClass.cs:17:20:17:33 | protectedStuff | GitHub.CodeQL | PublicClass | protectedStuff | System.String | false | PublicClass.cs |  |
-| PublicClass.cs:33:45:33:47 | get_PublicProperty | GitHub.CodeQL | PublicClass | get_PublicProperty |  | false | PublicClass.cs |  |
-| PublicClass.cs:33:50:33:52 | set_PublicProperty | GitHub.CodeQL | PublicClass | set_PublicProperty | System.String | false | PublicClass.cs |  |
-| PublicClass.cs:35:19:35:30 | summaryStuff | GitHub.CodeQL | PublicClass | summaryStuff | System.String | true | PublicClass.cs | summary |
-| PublicClass.cs:40:19:40:29 | sourceStuff | GitHub.CodeQL | PublicClass | sourceStuff |  | true | PublicClass.cs | source |
-| PublicClass.cs:45:17:45:25 | sinkStuff | GitHub.CodeQL | PublicClass | sinkStuff | System.String | true | PublicClass.cs | sink |
-| PublicClass.cs:50:17:50:28 | neutralStuff | GitHub.CodeQL | PublicClass | neutralStuff | System.String | true | PublicClass.cs | neutral |
-| PublicGenericClass.cs:7:17:7:21 | stuff | GitHub.CodeQL | PublicGenericClass<,> | stuff | T | false | PublicGenericClass.cs |  |
-| PublicGenericClass.cs:12:17:12:26 | stuff2<> | GitHub.CodeQL | PublicGenericClass<,> | stuff2<> | T2 | false | PublicGenericClass.cs |  |
-| PublicGenericInterface.cs:7:10:7:14 | stuff | GitHub.CodeQL | PublicGenericInterface<> | stuff | T | false | PublicGenericInterface.cs |  |
-| PublicGenericInterface.cs:9:10:9:19 | stuff2<> | GitHub.CodeQL | PublicGenericInterface<> | stuff2<> | T2 | false | PublicGenericInterface.cs |  |
-| PublicGenericInterface.cs:11:17:11:27 | staticStuff | GitHub.CodeQL | PublicGenericInterface<> | staticStuff | System.String | false | PublicGenericInterface.cs |  |
-| PublicInterface.cs:7:10:7:14 | stuff | GitHub.CodeQL | PublicInterface | stuff | System.String | false | PublicInterface.cs |  |
-| PublicInterface.cs:9:29:9:31 | get_PublicProperty | GitHub.CodeQL | PublicInterface | get_PublicProperty |  | false | PublicInterface.cs |  |
-| PublicInterface.cs:9:34:9:36 | set_PublicProperty | GitHub.CodeQL | PublicInterface | set_PublicProperty | System.String | false | PublicInterface.cs |  |
-| PublicInterface.cs:11:17:11:27 | staticStuff | GitHub.CodeQL | PublicInterface | staticStuff | System.String | false | PublicInterface.cs |  |
+| PublicClass.cs:7:17:7:21 | stuff | GitHub.CodeQL | PublicClass | stuff | (System.String) | false | PublicClass.cs |  |
+| PublicClass.cs:12:24:12:34 | staticStuff | GitHub.CodeQL | PublicClass | staticStuff | (System.String) | false | PublicClass.cs |  |
+| PublicClass.cs:17:20:17:33 | protectedStuff | GitHub.CodeQL | PublicClass | protectedStuff | (System.String) | false | PublicClass.cs |  |
+| PublicClass.cs:33:45:33:47 | get_PublicProperty | GitHub.CodeQL | PublicClass | get_PublicProperty | () | false | PublicClass.cs |  |
+| PublicClass.cs:33:50:33:52 | set_PublicProperty | GitHub.CodeQL | PublicClass | set_PublicProperty | (System.String) | false | PublicClass.cs |  |
+| PublicClass.cs:35:19:35:30 | summaryStuff | GitHub.CodeQL | PublicClass | summaryStuff | (System.String) | true | PublicClass.cs | summary |
+| PublicClass.cs:40:19:40:29 | sourceStuff | GitHub.CodeQL | PublicClass | sourceStuff | () | true | PublicClass.cs | source |
+| PublicClass.cs:45:17:45:25 | sinkStuff | GitHub.CodeQL | PublicClass | sinkStuff | (System.String) | true | PublicClass.cs | sink |
+| PublicClass.cs:50:17:50:28 | neutralStuff | GitHub.CodeQL | PublicClass | neutralStuff | (System.String) | true | PublicClass.cs | neutral |
+| PublicGenericClass.cs:7:17:7:21 | stuff | GitHub.CodeQL | PublicGenericClass<,> | stuff | (T) | false | PublicGenericClass.cs |  |
+| PublicGenericClass.cs:12:17:12:26 | stuff2<> | GitHub.CodeQL | PublicGenericClass<,> | stuff2<> | (T2) | false | PublicGenericClass.cs |  |
+| PublicGenericInterface.cs:7:10:7:14 | stuff | GitHub.CodeQL | PublicGenericInterface<> | stuff | (T) | false | PublicGenericInterface.cs |  |
+| PublicGenericInterface.cs:9:10:9:19 | stuff2<> | GitHub.CodeQL | PublicGenericInterface<> | stuff2<> | (T2) | false | PublicGenericInterface.cs |  |
+| PublicGenericInterface.cs:11:17:11:27 | staticStuff | GitHub.CodeQL | PublicGenericInterface<> | staticStuff | (System.String) | false | PublicGenericInterface.cs |  |
+| PublicInterface.cs:7:10:7:14 | stuff | GitHub.CodeQL | PublicInterface | stuff | (System.String) | false | PublicInterface.cs |  |
+| PublicInterface.cs:9:29:9:31 | get_PublicProperty | GitHub.CodeQL | PublicInterface | get_PublicProperty | () | false | PublicInterface.cs |  |
+| PublicInterface.cs:9:34:9:36 | set_PublicProperty | GitHub.CodeQL | PublicInterface | set_PublicProperty | (System.String) | false | PublicInterface.cs |  |
+| PublicInterface.cs:11:17:11:27 | staticStuff | GitHub.CodeQL | PublicInterface | staticStuff | (System.String) | false | PublicInterface.cs |  |


### PR DESCRIPTION
The MaD format and the Java model editor queries use parentheses around the method parameter types, but `parameterQualifiedTypeNamesToString` returns the parameter types without parentheses. This adds the parentheses to the result of `getParameterTypes` to ensure consistency between the Java and C# queries.