### PR TITLE
C#: Also run extractor unit tests on a windows runner.

### DIFF
--- a/.github/workflows/csharp-qltest.yml
+++ b/.github/workflows/csharp-qltest.yml
@@ -65,7 +65,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
   unit-tests:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-2019]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup dotnet

--- a/.github/workflows/csharp-qltest.yml
+++ b/.github/workflows/csharp-qltest.yml
@@ -81,6 +81,7 @@ jobs:
           dotnet test -p:RuntimeFrameworkVersion=7.0.2 extractor/Semmle.Extraction.Tests
           dotnet test -p:RuntimeFrameworkVersion=7.0.2 autobuilder/Semmle.Autobuild.CSharp.Tests
           dotnet test -p:RuntimeFrameworkVersion=7.0.2 "${{ github.workspace }}/cpp/autobuilder/Semmle.Autobuild.Cpp.Tests"
+        shell: bash
   stubgentest:
     runs-on: ubuntu-latest
     steps:

--- a/csharp/extractor/Semmle.Extraction.CSharp.StubGenerator/StubGenerator.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.StubGenerator/StubGenerator.cs
@@ -68,7 +68,7 @@ public static class StubGenerator
         var stubPath = FileUtils.NestPaths(logger, outputPath, path.Replace(".dll", ".cs"));
         stubPaths.Add(stubPath);
         using var fileStream = new FileStream(stubPath, FileMode.Create, FileAccess.Write);
-        using var writer = new StreamWriter(fileStream, new UTF8Encoding(false));
+        using var writer = new StreamWriter(fileStream, new UTF8Encoding(false)) { NewLine = "\n" };
 
         var visitor = new StubVisitor(writer, relevantSymbol);
 

--- a/csharp/extractor/Semmle.Extraction.Tests/StubGenerator.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/StubGenerator.cs
@@ -61,7 +61,7 @@ public int M1(string arg1) => throw null;
         var st = CSharpSyntaxTree.ParseText(source);
         var compilation = CSharpCompilation.Create(null, new[] { st });
         var sb = new StringBuilder();
-        var visitor = new StubVisitor(new StringWriter(sb), new RelevantSymbolStub());
+        var visitor = new StubVisitor(new StringWriter(sb) { NewLine = "\n" }, new RelevantSymbolStub());
         compilation.GlobalNamespace.Accept(visitor);
         return sb.ToString();
     }

--- a/csharp/extractor/Semmle.Extraction.Tests/StubGenerator.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/StubGenerator.cs
@@ -13,7 +13,7 @@ namespace Semmle.Extraction.Tests;
 /// </summary>
 public class StubGeneratorTests
 {
-    // [Fact]
+    [Fact]
     public void StubGeneratorFieldTest()
     {
         // Setup
@@ -36,7 +36,7 @@ public const string MyField2 = default;
         Assert.Equal(expected, stub);
     }
 
-    // [Fact]
+    [Fact]
     public void StubGeneratorMethodTest()
     {
         // Setup


### PR DESCRIPTION
In this PR we
- Add a workflow for running the extractor unit tests on windows. Please note that this requires that we use *bash* as shell when executing the workflow, otherwise the workflow doesn't stop on failure.
- Re-write and re-enable the stub generator unit tests.