### PR TITLE
C++: Remove getLocation from Container.

### DIFF
--- a/cpp/ql/lib/change-notes/2023-10-24-remove-getlocation-from-folder.md
+++ b/cpp/ql/lib/change-notes/2023-10-24-remove-getlocation-from-folder.md
@@ -1,0 +1,4 @@
+---
+category: breaking
+---
+* The `Container` and `Folder` classes now derive from `ElementBase` instead of `Locatable`, and no longer expose the `getLocation` predicate. Use `getURL` instead.

--- a/cpp/ql/lib/semmle/code/cpp/File.qll
+++ b/cpp/ql/lib/semmle/code/cpp/File.qll
@@ -65,6 +65,12 @@ class Folder extends Container, Impl::Folder {
 class File extends Container, Impl::File {
   override string getAPrimaryQlClass() { result = "File" }
 
+  /** Gets the primary location of this file. */
+  Location getLocation() {
+    result.getContainer() = this and
+    result.hasLocationInfo(_, 0, 0, 0, 0)
+  }
+
   /** Holds if this file was compiled as C (at any point). */
   predicate compiledAsC() { fileannotations(underlyingElement(this), 1, "compiled as c", "1") }
 

--- a/cpp/ql/lib/semmle/code/cpp/File.qll
+++ b/cpp/ql/lib/semmle/code/cpp/File.qll
@@ -62,11 +62,10 @@ class Folder extends Container, Impl::Folder {
  * The base name further decomposes into the _stem_ and _extension_ -- see
  * `getStem` and `getExtension`. To get the full path, use `getAbsolutePath`.
  */
-class File extends Container, Impl::File {
+class File extends Container, Locatable, Impl::File {
   override string getAPrimaryQlClass() { result = "File" }
 
-  /** Gets the primary location of this file. */
-  Location getLocation() {
+  override Location getLocation() {
     result.getContainer() = this and
     result.hasLocationInfo(_, 0, 0, 0, 0)
   }
@@ -124,7 +123,7 @@ class File extends Container, Impl::File {
    * except the dummy file, whose name is the empty string, which contains
    * declarations that are built into the compiler.
    */
-  predicate fromSource() { numlines(underlyingElement(this), _, _, _) }
+  override predicate fromSource() { numlines(underlyingElement(this), _, _, _) }
 
   /** Gets the metric file. */
   MetricFile getMetrics() { result = this }

--- a/cpp/ql/lib/semmle/code/cpp/File.qll
+++ b/cpp/ql/lib/semmle/code/cpp/File.qll
@@ -32,7 +32,7 @@ private module Input implements InputSig {
 private module Impl = Make<Input>;
 
 /** A file or folder. */
-class Container extends Locatable, Impl::Container {
+class Container extends ElementBase, Impl::Container {
   override string toString() { result = Impl::Container.super.toString() }
 }
 
@@ -47,11 +47,6 @@ class Container extends Locatable, Impl::Container {
  * To get the full path, use `getAbsolutePath`.
  */
 class Folder extends Container, Impl::Folder {
-  override Location getLocation() {
-    result.getContainer() = this and
-    result.hasLocationInfo(_, 0, 0, 0, 0)
-  }
-
   override string getAPrimaryQlClass() { result = "Folder" }
 }
 
@@ -69,11 +64,6 @@ class Folder extends Container, Impl::Folder {
  */
 class File extends Container, Impl::File {
   override string getAPrimaryQlClass() { result = "File" }
-
-  override Location getLocation() {
-    result.getContainer() = this and
-    result.hasLocationInfo(_, 0, 0, 0, 0)
-  }
 
   /** Holds if this file was compiled as C (at any point). */
   predicate compiledAsC() { fileannotations(underlyingElement(this), 1, "compiled as c", "1") }
@@ -128,7 +118,7 @@ class File extends Container, Impl::File {
    * except the dummy file, whose name is the empty string, which contains
    * declarations that are built into the compiler.
    */
-  override predicate fromSource() { numlines(underlyingElement(this), _, _, _) }
+  predicate fromSource() { numlines(underlyingElement(this), _, _, _) }
 
   /** Gets the metric file. */
   MetricFile getMetrics() { result = this }


### PR DESCRIPTION
Follow up to https://github.com/github/codeql/pull/14321

With the above-mentioned PR, `Container` now has conflicting urls provided by `getURL` and `getLocation`, respectively. This PR removes `getLocation`, since `getURL` ought to be sufficient. I was a bit in doubt about whether to switch the `extends` to `Element` or `ElementBase`, but it seemed that the additional predicates inherited from `Element` made little sense for `Container`s, so I chose `ElementBase`.

cc @jketema 