### PR TITLE
JS/PY/RB/Java: escape unicode chars in overly-large-range

### DIFF
--- a/python/ql/test/query-tests/Security/CWE-020-SuspiciousRegexpRange/OverlyLargeRangeQuery.expected
+++ b/python/ql/test/query-tests/Security/CWE-020-SuspiciousRegexpRange/OverlyLargeRangeQuery.expected
@@ -8,3 +8,4 @@
 | test.py:25:32:25:34 | 7-F | Suspicious character range that is equivalent to [7-9:;<=>?@A-F]. |
 | test.py:27:36:27:38 | 0-9 | Suspicious character range that overlaps with \\d in the same character class. |
 | test.py:29:39:29:41 | .-? | Suspicious character range that overlaps with \\w in the same character class, and is equivalent to [.\\/0-9:;<=>?]. |
+| test.py:31:30:31:32 | \ufffd-\ufffd | Suspicious character range that overlaps with \\ufffd-\\ufffd in the same character class. |

--- a/python/ql/test/query-tests/Security/CWE-020-SuspiciousRegexpRange/test.py
+++ b/python/ql/test/query-tests/Security/CWE-020-SuspiciousRegexpRange/test.py
@@ -27,3 +27,5 @@ numberToLetter = re.compile(r'[7-F]') # NOT OK
 overlapsWithClass1 = re.compile(r'[0-9\d]') # NOT OK
 
 overlapsWithClass2 = re.compile(r'[\w,.-?:*+]') # NOT OK
+
+unicodeStuff =  re.compile('[\U0001D173-\U0001D17A\U000E0020-\U000E007F\U000e0001]') # NOT OK

--- a/shared/regex/codeql/regex/nfa/NfaUtils.qll
+++ b/shared/regex/codeql/regex/nfa/NfaUtils.qll
@@ -4,6 +4,7 @@
 
 private import codeql.regex.RegexTreeView
 private import codeql.util.Numbers
+private import codeql.util.Strings
 
 /**
  * Classes and predicates that create an NFA and various algorithms for working with it.
@@ -15,34 +16,7 @@ module Make<RegexTreeViewSig TreeImpl> {
    * Gets the char after `c` (from a simplified ASCII table).
    */
   private string nextChar(string c) {
-    exists(int code | code = ascii(c) | code + 1 = ascii(result))
-  }
-
-  /**
-   * Gets the `i`th codepoint in `s`.
-   */
-  bindingset[s]
-  private string getCodepointAt(string s, int i) { result = s.regexpFind("(.|\\s)", i, _) }
-
-  /**
-   * Gets the length of `s` in codepoints.
-   */
-  bindingset[str]
-  private int getCodepointLength(string str) {
-    result = str.regexpReplaceAll("(.|\\s)", "x").length()
-  }
-
-  /**
-   * Gets an approximation for the ASCII code for `char`.
-   * Only the easily printable chars are included (so no newline, tab, null, etc).
-   */
-  private int ascii(string char) {
-    char =
-      rank[result](string c |
-        c =
-          "! \"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
-              .charAt(_)
-      )
+    exists(int code | code = asciiPrintable(c) | code + 1 = asciiPrintable(result))
   }
 
   /**
@@ -394,7 +368,7 @@ module Make<RegexTreeViewSig TreeImpl> {
      * Includes all printable ascii chars, all constants mentioned in a regexp, and all chars matches by the regexp `/\s|\d|\w/`.
      */
     string getARelevantChar() {
-      exists(ascii(result))
+      exists(asciiPrintable(result))
       or
       exists(RegexpCharacterConstant c | result = getCodepointAt(c.getValue(), _))
       or
@@ -1191,7 +1165,7 @@ module Make<RegexTreeViewSig TreeImpl> {
       private string relevant(RegExpRoot root) {
         root = relevantRoot() and
         (
-          exists(ascii(result)) and exists(root)
+          exists(asciiPrintable(result)) and exists(root)
           or
           exists(InputSymbol s | belongsTo(s, root) | result = intersect(s, _))
           or
@@ -1320,49 +1294,6 @@ module Make<RegexTreeViewSig TreeImpl> {
         or
         not exists(Prefix::prefix(s)) and prefixMsg = ""
       )
-    }
-
-    /**
-     * Gets the result of backslash-escaping newlines, carriage-returns and
-     * backslashes in `s`.
-     */
-    bindingset[s]
-    private string escape(string s) {
-      result =
-        escapeUnicodeString(s.replaceAll("\\", "\\\\")
-              .replaceAll("\n", "\\n")
-              .replaceAll("\r", "\\r")
-              .replaceAll("\t", "\\t"))
-    }
-
-    /**
-     * Gets a string where the unicode characters in `s` have been escaped.
-     */
-    bindingset[s]
-    private string escapeUnicodeString(string s) {
-      result =
-        concat(int i, string char | char = escapeUnicodeChar(getCodepointAt(s, i)) | char order by i)
-    }
-
-    /**
-     * Gets a unicode escaped string for `char`.
-     * If `char` is a printable char, then `char` is returned.
-     */
-    bindingset[char]
-    private string escapeUnicodeChar(string char) {
-      if isPrintable(char)
-      then result = char
-      else
-        if exists(to4digitHex(any(int i | i.toUnicode() = char)))
-        then result = "\\u" + to4digitHex(any(int i | i.toUnicode() = char))
-        else result = "\\u{" + toHex(any(int i | i.toUnicode() = char)) + "}"
-    }
-
-    /** Holds if `char` is easily printable char, or whitespace. */
-    private predicate isPrintable(string char) {
-      exists(ascii(char))
-      or
-      char = "\n\r\t".charAt(_)
     }
 
     /**

--- a/shared/util/codeql/util/Strings.qll
+++ b/shared/util/codeql/util/Strings.qll
@@ -1,0 +1,68 @@
+private import Numbers
+
+/**
+ * Gets the result of backslash-escaping newlines, carriage-returns, backslashes, and unicode characters in `s`.
+ */
+bindingset[s]
+string escape(string s) {
+  result =
+    escapeUnicodeString(s.replaceAll("\\", "\\\\")
+          .replaceAll("\n", "\\n")
+          .replaceAll("\r", "\\r")
+          .replaceAll("\t", "\\t"))
+}
+
+/**
+ * Gets a string where the unicode characters in `s` have been escaped.
+ */
+bindingset[s]
+private string escapeUnicodeString(string s) {
+  result =
+    concat(int i, string char | char = escapeUnicodeChar(getCodepointAt(s, i)) | char order by i)
+}
+
+/**
+ * Gets a unicode escaped string for `char`.
+ * If `char` is a printable char, then `char` is returned.
+ */
+bindingset[char]
+private string escapeUnicodeChar(string char) {
+  if isPrintable(char)
+  then result = char
+  else
+    if exists(to4digitHex(any(int i | i.toUnicode() = char)))
+    then result = "\\u" + to4digitHex(any(int i | i.toUnicode() = char))
+    else result = "\\u{" + toHex(any(int i | i.toUnicode() = char)) + "}"
+}
+
+/** Holds if `char` is easily printable char, or whitespace. */
+private predicate isPrintable(string char) {
+  exists(asciiPrintable(char))
+  or
+  char = "\n\r\t".charAt(_)
+}
+
+/**
+ * Gets the `i`th codepoint in `s`.
+ */
+bindingset[s]
+string getCodepointAt(string s, int i) { result = s.regexpFind("(.|\\s)", i, _) }
+
+/**
+ * Gets the length of `s` in codepoints.
+ */
+bindingset[str]
+int getCodepointLength(string str) { result = str.regexpReplaceAll("(.|\\s)", "x").length() }
+
+/**
+ * Gets the ASCII code for `char`.
+ * Only the easily printable chars are included (so no newline, tab, null, etc).
+ */
+int asciiPrintable(string char) {
+  char =
+    rank[result](string c |
+      c =
+        "! \"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+            .charAt(_)
+    )
+}


### PR DESCRIPTION
A friend of mine found it confusing to see an alert message like this:  
![Screenshot 2023-09-28 at 20 21 19](https://github.com/github/codeql/assets/54990334/65506a80-dd4d-4bcf-8c30-7d092056210b)

So I used the same escaping that I recently made for the ReDoS queries.  

I could have put that escaping in `NfaUtils.qll`, but that seemed wrong, as it has nothing to do with regular expressions or NFAs. 
So I made a new `Strings` library inside the `utils` pack.    

---- 

The root problem seems to be that the string-constants in the Python extractor (and other languages, but I've only tested Python) are unescaped before being put in the database, which makes sense for the vast majority of use-cases.    
And until recently you couldn't really work with unicode chars in CodeQL in a nice way.

For regular expressions it would make sense to work on the "raw" string instead of the unescaped string that Python has.  
But that is a lager piece of work that I think if more fitting for the Python team to do.   

---- 

Evaluations were uneventful: [Java](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/pr-14339-5d4b54__nightly__code-scanning/reports), [Ruby](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/PR-14339-3-ruby/reports), [Python](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/PR-14339-2-python/reports), [JavaScript](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/PR-14339-1-javascript/reports). 