### PR TITLE
Shared: Add DataFlow::DeduplicatePathGraph

### DIFF
--- a/java/ql/test/library-tests/dataflow/deduplicate-path-graph/A.java
+++ b/java/ql/test/library-tests/dataflow/deduplicate-path-graph/A.java
@@ -1,0 +1,34 @@
+import java.util.function.Function;
+
+class A {
+  String source() { return ""; }
+
+  void sink(String s) { }
+
+  String propagateState(String s, String state) {
+    return "";
+  }
+
+  void foo() {
+    Function<String, String> lambda = Math.random() > 0.5
+      ? x -> propagateState(x, "A")
+      : x -> propagateState(x, "B");
+
+    String step0 = source();
+    String step1 = lambda.apply(step0);
+    String step2 = lambda.apply(step1);
+
+    sink(step2);
+  }
+
+  void bar() {
+    Function<String, String> lambda =
+      (x -> Math.random() > 0.5 ? propagateState(x, "A") : propagateState(x, "B"));
+
+    String step0 = source();
+    String step1 = lambda.apply(step0);
+    String step2 = lambda.apply(step1);
+
+    sink(step2);
+  }
+}

--- a/java/ql/test/library-tests/dataflow/deduplicate-path-graph/test.expected
+++ b/java/ql/test/library-tests/dataflow/deduplicate-path-graph/test.expected
@@ -7,11 +7,15 @@ nodes
 | A.java:15:29:15:29 | x : String | semmle.label | x : String |
 | A.java:17:20:17:27 | source(...) : String | semmle.label | source(...) : String |
 | A.java:18:20:18:38 | apply(...) : String | semmle.label | apply(...) : String |
+| A.java:18:20:18:38 | apply(...) : String | semmle.label | apply(...) : String |
 | A.java:18:33:18:37 | step0 : String | semmle.label | step0 : String |
 | A.java:19:20:19:38 | apply(...) : String | semmle.label | apply(...) : String |
 | A.java:19:33:19:37 | step1 : String | semmle.label | step1 : String |
+| A.java:19:33:19:37 | step1 : String | semmle.label | step1 : String |
 | A.java:21:10:21:14 | step2 | semmle.label | step2 |
 | A.java:26:8:26:8 | x : String | semmle.label | x : String |
+| A.java:26:8:26:8 | x : String | semmle.label | x : String |
+| A.java:26:13:26:81 | ...?...:... : String | semmle.label | ...?...:... : String |
 | A.java:26:13:26:81 | ...?...:... : String | semmle.label | ...?...:... : String |
 | A.java:26:35:26:56 | propagateState(...) : String | semmle.label | propagateState(...) : String |
 | A.java:26:50:26:50 | x : String | semmle.label | x : String |
@@ -19,8 +23,10 @@ nodes
 | A.java:26:75:26:75 | x : String | semmle.label | x : String |
 | A.java:28:20:28:27 | source(...) : String | semmle.label | source(...) : String |
 | A.java:29:20:29:38 | apply(...) : String | semmle.label | apply(...) : String |
+| A.java:29:20:29:38 | apply(...) : String | semmle.label | apply(...) : String |
 | A.java:29:33:29:37 | step0 : String | semmle.label | step0 : String |
 | A.java:30:20:30:38 | apply(...) : String | semmle.label | apply(...) : String |
+| A.java:30:33:30:37 | step1 : String | semmle.label | step1 : String |
 | A.java:30:33:30:37 | step1 : String | semmle.label | step1 : String |
 | A.java:32:10:32:14 | step2 | semmle.label | step2 |
 edges
@@ -30,12 +36,15 @@ edges
 | A.java:15:29:15:29 | x : String | A.java:15:14:15:35 | propagateState(...) : String |
 | A.java:17:20:17:27 | source(...) : String | A.java:18:33:18:37 | step0 : String |
 | A.java:18:20:18:38 | apply(...) : String | A.java:19:33:19:37 | step1 : String |
+| A.java:18:20:18:38 | apply(...) : String | A.java:19:33:19:37 | step1 : String |
 | A.java:18:33:18:37 | step0 : String | A.java:14:9:14:9 | x : String |
 | A.java:18:33:18:37 | step0 : String | A.java:15:9:15:9 | x : String |
+| A.java:18:33:18:37 | step0 : String | A.java:18:20:18:38 | apply(...) : String |
 | A.java:18:33:18:37 | step0 : String | A.java:18:20:18:38 | apply(...) : String |
 | A.java:19:20:19:38 | apply(...) : String | A.java:21:10:21:14 | step2 |
 | A.java:19:33:19:37 | step1 : String | A.java:14:9:14:9 | x : String |
 | A.java:19:33:19:37 | step1 : String | A.java:15:9:15:9 | x : String |
+| A.java:19:33:19:37 | step1 : String | A.java:19:20:19:38 | apply(...) : String |
 | A.java:19:33:19:37 | step1 : String | A.java:19:20:19:38 | apply(...) : String |
 | A.java:26:8:26:8 | x : String | A.java:26:50:26:50 | x : String |
 | A.java:26:8:26:8 | x : String | A.java:26:75:26:75 | x : String |
@@ -45,10 +54,15 @@ edges
 | A.java:26:75:26:75 | x : String | A.java:26:60:26:81 | propagateState(...) : String |
 | A.java:28:20:28:27 | source(...) : String | A.java:29:33:29:37 | step0 : String |
 | A.java:29:20:29:38 | apply(...) : String | A.java:30:33:30:37 | step1 : String |
+| A.java:29:20:29:38 | apply(...) : String | A.java:30:33:30:37 | step1 : String |
 | A.java:29:33:29:37 | step0 : String | A.java:26:8:26:8 | x : String |
+| A.java:29:33:29:37 | step0 : String | A.java:26:8:26:8 | x : String |
+| A.java:29:33:29:37 | step0 : String | A.java:29:20:29:38 | apply(...) : String |
 | A.java:29:33:29:37 | step0 : String | A.java:29:20:29:38 | apply(...) : String |
 | A.java:30:20:30:38 | apply(...) : String | A.java:32:10:32:14 | step2 |
 | A.java:30:33:30:37 | step1 : String | A.java:26:8:26:8 | x : String |
+| A.java:30:33:30:37 | step1 : String | A.java:26:8:26:8 | x : String |
+| A.java:30:33:30:37 | step1 : String | A.java:30:20:30:38 | apply(...) : String |
 | A.java:30:33:30:37 | step1 : String | A.java:30:20:30:38 | apply(...) : String |
 subpaths
 | A.java:18:33:18:37 | step0 : String | A.java:14:9:14:9 | x : String | A.java:14:14:14:35 | propagateState(...) : String | A.java:18:20:18:38 | apply(...) : String |
@@ -56,12 +70,10 @@ subpaths
 | A.java:19:33:19:37 | step1 : String | A.java:14:9:14:9 | x : String | A.java:14:14:14:35 | propagateState(...) : String | A.java:19:20:19:38 | apply(...) : String |
 | A.java:19:33:19:37 | step1 : String | A.java:15:9:15:9 | x : String | A.java:15:14:15:35 | propagateState(...) : String | A.java:19:20:19:38 | apply(...) : String |
 | A.java:29:33:29:37 | step0 : String | A.java:26:8:26:8 | x : String | A.java:26:13:26:81 | ...?...:... : String | A.java:29:20:29:38 | apply(...) : String |
+| A.java:29:33:29:37 | step0 : String | A.java:26:8:26:8 | x : String | A.java:26:13:26:81 | ...?...:... : String | A.java:29:20:29:38 | apply(...) : String |
+| A.java:30:33:30:37 | step1 : String | A.java:26:8:26:8 | x : String | A.java:26:13:26:81 | ...?...:... : String | A.java:30:20:30:38 | apply(...) : String |
 | A.java:30:33:30:37 | step1 : String | A.java:26:8:26:8 | x : String | A.java:26:13:26:81 | ...?...:... : String | A.java:30:20:30:38 | apply(...) : String |
 spuriousFlow
-| A.java:14:14:14:35 | propagateState(...) : String | B | A |
-| A.java:15:14:15:35 | propagateState(...) : String | A | B |
-| A.java:26:35:26:56 | propagateState(...) : String | B | A |
-| A.java:26:60:26:81 | propagateState(...) : String | A | B |
 #select
 | A.java:17:20:17:27 | source(...) : String | A.java:17:20:17:27 | source(...) : String | A.java:21:10:21:14 | step2 | Flow |
 | A.java:28:20:28:27 | source(...) : String | A.java:28:20:28:27 | source(...) : String | A.java:32:10:32:14 | step2 | Flow |

--- a/java/ql/test/library-tests/dataflow/deduplicate-path-graph/test.expected
+++ b/java/ql/test/library-tests/dataflow/deduplicate-path-graph/test.expected
@@ -14,8 +14,6 @@ nodes
 | A.java:19:33:19:37 | step1 : String | semmle.label | step1 : String |
 | A.java:21:10:21:14 | step2 | semmle.label | step2 |
 | A.java:26:8:26:8 | x : String | semmle.label | x : String |
-| A.java:26:8:26:8 | x : String | semmle.label | x : String |
-| A.java:26:13:26:81 | ...?...:... : String | semmle.label | ...?...:... : String |
 | A.java:26:13:26:81 | ...?...:... : String | semmle.label | ...?...:... : String |
 | A.java:26:35:26:56 | propagateState(...) : String | semmle.label | propagateState(...) : String |
 | A.java:26:50:26:50 | x : String | semmle.label | x : String |
@@ -23,10 +21,8 @@ nodes
 | A.java:26:75:26:75 | x : String | semmle.label | x : String |
 | A.java:28:20:28:27 | source(...) : String | semmle.label | source(...) : String |
 | A.java:29:20:29:38 | apply(...) : String | semmle.label | apply(...) : String |
-| A.java:29:20:29:38 | apply(...) : String | semmle.label | apply(...) : String |
 | A.java:29:33:29:37 | step0 : String | semmle.label | step0 : String |
 | A.java:30:20:30:38 | apply(...) : String | semmle.label | apply(...) : String |
-| A.java:30:33:30:37 | step1 : String | semmle.label | step1 : String |
 | A.java:30:33:30:37 | step1 : String | semmle.label | step1 : String |
 | A.java:32:10:32:14 | step2 | semmle.label | step2 |
 edges
@@ -54,15 +50,10 @@ edges
 | A.java:26:75:26:75 | x : String | A.java:26:60:26:81 | propagateState(...) : String | provenance | Config |
 | A.java:28:20:28:27 | source(...) : String | A.java:29:33:29:37 | step0 : String | provenance |  |
 | A.java:29:20:29:38 | apply(...) : String | A.java:30:33:30:37 | step1 : String | provenance |  |
-| A.java:29:20:29:38 | apply(...) : String | A.java:30:33:30:37 | step1 : String | provenance |  |
 | A.java:29:33:29:37 | step0 : String | A.java:26:8:26:8 | x : String | provenance |  |
-| A.java:29:33:29:37 | step0 : String | A.java:26:8:26:8 | x : String | provenance |  |
-| A.java:29:33:29:37 | step0 : String | A.java:29:20:29:38 | apply(...) : String | provenance | Config |
 | A.java:29:33:29:37 | step0 : String | A.java:29:20:29:38 | apply(...) : String | provenance | Config |
 | A.java:30:20:30:38 | apply(...) : String | A.java:32:10:32:14 | step2 | provenance |  |
 | A.java:30:33:30:37 | step1 : String | A.java:26:8:26:8 | x : String | provenance |  |
-| A.java:30:33:30:37 | step1 : String | A.java:26:8:26:8 | x : String | provenance |  |
-| A.java:30:33:30:37 | step1 : String | A.java:30:20:30:38 | apply(...) : String | provenance | Config |
 | A.java:30:33:30:37 | step1 : String | A.java:30:20:30:38 | apply(...) : String | provenance | Config |
 subpaths
 | A.java:18:33:18:37 | step0 : String | A.java:14:9:14:9 | x : String | A.java:14:14:14:35 | propagateState(...) : String | A.java:18:20:18:38 | apply(...) : String |
@@ -70,10 +61,10 @@ subpaths
 | A.java:19:33:19:37 | step1 : String | A.java:14:9:14:9 | x : String | A.java:14:14:14:35 | propagateState(...) : String | A.java:19:20:19:38 | apply(...) : String |
 | A.java:19:33:19:37 | step1 : String | A.java:15:9:15:9 | x : String | A.java:15:14:15:35 | propagateState(...) : String | A.java:19:20:19:38 | apply(...) : String |
 | A.java:29:33:29:37 | step0 : String | A.java:26:8:26:8 | x : String | A.java:26:13:26:81 | ...?...:... : String | A.java:29:20:29:38 | apply(...) : String |
-| A.java:29:33:29:37 | step0 : String | A.java:26:8:26:8 | x : String | A.java:26:13:26:81 | ...?...:... : String | A.java:29:20:29:38 | apply(...) : String |
-| A.java:30:33:30:37 | step1 : String | A.java:26:8:26:8 | x : String | A.java:26:13:26:81 | ...?...:... : String | A.java:30:20:30:38 | apply(...) : String |
 | A.java:30:33:30:37 | step1 : String | A.java:26:8:26:8 | x : String | A.java:26:13:26:81 | ...?...:... : String | A.java:30:20:30:38 | apply(...) : String |
 spuriousFlow
+| A.java:26:35:26:56 | propagateState(...) : String | B | A |
+| A.java:26:60:26:81 | propagateState(...) : String | A | B |
 #select
 | A.java:17:20:17:27 | source(...) : String | A.java:17:20:17:27 | source(...) : String | A.java:21:10:21:14 | step2 | Flow |
 | A.java:28:20:28:27 | source(...) : String | A.java:28:20:28:27 | source(...) : String | A.java:32:10:32:14 | step2 | Flow |

--- a/java/ql/test/library-tests/dataflow/deduplicate-path-graph/test.expected
+++ b/java/ql/test/library-tests/dataflow/deduplicate-path-graph/test.expected
@@ -30,40 +30,40 @@ nodes
 | A.java:30:33:30:37 | step1 : String | semmle.label | step1 : String |
 | A.java:32:10:32:14 | step2 | semmle.label | step2 |
 edges
-| A.java:14:9:14:9 | x : String | A.java:14:29:14:29 | x : String |
-| A.java:14:29:14:29 | x : String | A.java:14:14:14:35 | propagateState(...) : String |
-| A.java:15:9:15:9 | x : String | A.java:15:29:15:29 | x : String |
-| A.java:15:29:15:29 | x : String | A.java:15:14:15:35 | propagateState(...) : String |
-| A.java:17:20:17:27 | source(...) : String | A.java:18:33:18:37 | step0 : String |
-| A.java:18:20:18:38 | apply(...) : String | A.java:19:33:19:37 | step1 : String |
-| A.java:18:20:18:38 | apply(...) : String | A.java:19:33:19:37 | step1 : String |
-| A.java:18:33:18:37 | step0 : String | A.java:14:9:14:9 | x : String |
-| A.java:18:33:18:37 | step0 : String | A.java:15:9:15:9 | x : String |
-| A.java:18:33:18:37 | step0 : String | A.java:18:20:18:38 | apply(...) : String |
-| A.java:18:33:18:37 | step0 : String | A.java:18:20:18:38 | apply(...) : String |
-| A.java:19:20:19:38 | apply(...) : String | A.java:21:10:21:14 | step2 |
-| A.java:19:33:19:37 | step1 : String | A.java:14:9:14:9 | x : String |
-| A.java:19:33:19:37 | step1 : String | A.java:15:9:15:9 | x : String |
-| A.java:19:33:19:37 | step1 : String | A.java:19:20:19:38 | apply(...) : String |
-| A.java:19:33:19:37 | step1 : String | A.java:19:20:19:38 | apply(...) : String |
-| A.java:26:8:26:8 | x : String | A.java:26:50:26:50 | x : String |
-| A.java:26:8:26:8 | x : String | A.java:26:75:26:75 | x : String |
-| A.java:26:35:26:56 | propagateState(...) : String | A.java:26:13:26:81 | ...?...:... : String |
-| A.java:26:50:26:50 | x : String | A.java:26:35:26:56 | propagateState(...) : String |
-| A.java:26:60:26:81 | propagateState(...) : String | A.java:26:13:26:81 | ...?...:... : String |
-| A.java:26:75:26:75 | x : String | A.java:26:60:26:81 | propagateState(...) : String |
-| A.java:28:20:28:27 | source(...) : String | A.java:29:33:29:37 | step0 : String |
-| A.java:29:20:29:38 | apply(...) : String | A.java:30:33:30:37 | step1 : String |
-| A.java:29:20:29:38 | apply(...) : String | A.java:30:33:30:37 | step1 : String |
-| A.java:29:33:29:37 | step0 : String | A.java:26:8:26:8 | x : String |
-| A.java:29:33:29:37 | step0 : String | A.java:26:8:26:8 | x : String |
-| A.java:29:33:29:37 | step0 : String | A.java:29:20:29:38 | apply(...) : String |
-| A.java:29:33:29:37 | step0 : String | A.java:29:20:29:38 | apply(...) : String |
-| A.java:30:20:30:38 | apply(...) : String | A.java:32:10:32:14 | step2 |
-| A.java:30:33:30:37 | step1 : String | A.java:26:8:26:8 | x : String |
-| A.java:30:33:30:37 | step1 : String | A.java:26:8:26:8 | x : String |
-| A.java:30:33:30:37 | step1 : String | A.java:30:20:30:38 | apply(...) : String |
-| A.java:30:33:30:37 | step1 : String | A.java:30:20:30:38 | apply(...) : String |
+| A.java:14:9:14:9 | x : String | A.java:14:29:14:29 | x : String | provenance |  |
+| A.java:14:29:14:29 | x : String | A.java:14:14:14:35 | propagateState(...) : String | provenance | Config |
+| A.java:15:9:15:9 | x : String | A.java:15:29:15:29 | x : String | provenance |  |
+| A.java:15:29:15:29 | x : String | A.java:15:14:15:35 | propagateState(...) : String | provenance | Config |
+| A.java:17:20:17:27 | source(...) : String | A.java:18:33:18:37 | step0 : String | provenance |  |
+| A.java:18:20:18:38 | apply(...) : String | A.java:19:33:19:37 | step1 : String | provenance |  |
+| A.java:18:20:18:38 | apply(...) : String | A.java:19:33:19:37 | step1 : String | provenance |  |
+| A.java:18:33:18:37 | step0 : String | A.java:14:9:14:9 | x : String | provenance |  |
+| A.java:18:33:18:37 | step0 : String | A.java:15:9:15:9 | x : String | provenance |  |
+| A.java:18:33:18:37 | step0 : String | A.java:18:20:18:38 | apply(...) : String | provenance | Config |
+| A.java:18:33:18:37 | step0 : String | A.java:18:20:18:38 | apply(...) : String | provenance | Config |
+| A.java:19:20:19:38 | apply(...) : String | A.java:21:10:21:14 | step2 | provenance |  |
+| A.java:19:33:19:37 | step1 : String | A.java:14:9:14:9 | x : String | provenance |  |
+| A.java:19:33:19:37 | step1 : String | A.java:15:9:15:9 | x : String | provenance |  |
+| A.java:19:33:19:37 | step1 : String | A.java:19:20:19:38 | apply(...) : String | provenance | Config |
+| A.java:19:33:19:37 | step1 : String | A.java:19:20:19:38 | apply(...) : String | provenance | Config |
+| A.java:26:8:26:8 | x : String | A.java:26:50:26:50 | x : String | provenance |  |
+| A.java:26:8:26:8 | x : String | A.java:26:75:26:75 | x : String | provenance |  |
+| A.java:26:35:26:56 | propagateState(...) : String | A.java:26:13:26:81 | ...?...:... : String | provenance |  |
+| A.java:26:50:26:50 | x : String | A.java:26:35:26:56 | propagateState(...) : String | provenance | Config |
+| A.java:26:60:26:81 | propagateState(...) : String | A.java:26:13:26:81 | ...?...:... : String | provenance |  |
+| A.java:26:75:26:75 | x : String | A.java:26:60:26:81 | propagateState(...) : String | provenance | Config |
+| A.java:28:20:28:27 | source(...) : String | A.java:29:33:29:37 | step0 : String | provenance |  |
+| A.java:29:20:29:38 | apply(...) : String | A.java:30:33:30:37 | step1 : String | provenance |  |
+| A.java:29:20:29:38 | apply(...) : String | A.java:30:33:30:37 | step1 : String | provenance |  |
+| A.java:29:33:29:37 | step0 : String | A.java:26:8:26:8 | x : String | provenance |  |
+| A.java:29:33:29:37 | step0 : String | A.java:26:8:26:8 | x : String | provenance |  |
+| A.java:29:33:29:37 | step0 : String | A.java:29:20:29:38 | apply(...) : String | provenance | Config |
+| A.java:29:33:29:37 | step0 : String | A.java:29:20:29:38 | apply(...) : String | provenance | Config |
+| A.java:30:20:30:38 | apply(...) : String | A.java:32:10:32:14 | step2 | provenance |  |
+| A.java:30:33:30:37 | step1 : String | A.java:26:8:26:8 | x : String | provenance |  |
+| A.java:30:33:30:37 | step1 : String | A.java:26:8:26:8 | x : String | provenance |  |
+| A.java:30:33:30:37 | step1 : String | A.java:30:20:30:38 | apply(...) : String | provenance | Config |
+| A.java:30:33:30:37 | step1 : String | A.java:30:20:30:38 | apply(...) : String | provenance | Config |
 subpaths
 | A.java:18:33:18:37 | step0 : String | A.java:14:9:14:9 | x : String | A.java:14:14:14:35 | propagateState(...) : String | A.java:18:20:18:38 | apply(...) : String |
 | A.java:18:33:18:37 | step0 : String | A.java:15:9:15:9 | x : String | A.java:15:14:15:35 | propagateState(...) : String | A.java:18:20:18:38 | apply(...) : String |

--- a/java/ql/test/library-tests/dataflow/deduplicate-path-graph/test.expected
+++ b/java/ql/test/library-tests/dataflow/deduplicate-path-graph/test.expected
@@ -14,6 +14,8 @@ nodes
 | A.java:19:33:19:37 | step1 : String | semmle.label | step1 : String |
 | A.java:21:10:21:14 | step2 | semmle.label | step2 |
 | A.java:26:8:26:8 | x : String | semmle.label | x : String |
+| A.java:26:8:26:8 | x : String | semmle.label | x : String |
+| A.java:26:13:26:81 | ...?...:... : String | semmle.label | ...?...:... : String |
 | A.java:26:13:26:81 | ...?...:... : String | semmle.label | ...?...:... : String |
 | A.java:26:35:26:56 | propagateState(...) : String | semmle.label | propagateState(...) : String |
 | A.java:26:50:26:50 | x : String | semmle.label | x : String |
@@ -21,8 +23,10 @@ nodes
 | A.java:26:75:26:75 | x : String | semmle.label | x : String |
 | A.java:28:20:28:27 | source(...) : String | semmle.label | source(...) : String |
 | A.java:29:20:29:38 | apply(...) : String | semmle.label | apply(...) : String |
+| A.java:29:20:29:38 | apply(...) : String | semmle.label | apply(...) : String |
 | A.java:29:33:29:37 | step0 : String | semmle.label | step0 : String |
 | A.java:30:20:30:38 | apply(...) : String | semmle.label | apply(...) : String |
+| A.java:30:33:30:37 | step1 : String | semmle.label | step1 : String |
 | A.java:30:33:30:37 | step1 : String | semmle.label | step1 : String |
 | A.java:32:10:32:14 | step2 | semmle.label | step2 |
 edges
@@ -50,10 +54,15 @@ edges
 | A.java:26:75:26:75 | x : String | A.java:26:60:26:81 | propagateState(...) : String | provenance | Config |
 | A.java:28:20:28:27 | source(...) : String | A.java:29:33:29:37 | step0 : String | provenance |  |
 | A.java:29:20:29:38 | apply(...) : String | A.java:30:33:30:37 | step1 : String | provenance |  |
+| A.java:29:20:29:38 | apply(...) : String | A.java:30:33:30:37 | step1 : String | provenance |  |
 | A.java:29:33:29:37 | step0 : String | A.java:26:8:26:8 | x : String | provenance |  |
+| A.java:29:33:29:37 | step0 : String | A.java:26:8:26:8 | x : String | provenance |  |
+| A.java:29:33:29:37 | step0 : String | A.java:29:20:29:38 | apply(...) : String | provenance | Config |
 | A.java:29:33:29:37 | step0 : String | A.java:29:20:29:38 | apply(...) : String | provenance | Config |
 | A.java:30:20:30:38 | apply(...) : String | A.java:32:10:32:14 | step2 | provenance |  |
 | A.java:30:33:30:37 | step1 : String | A.java:26:8:26:8 | x : String | provenance |  |
+| A.java:30:33:30:37 | step1 : String | A.java:26:8:26:8 | x : String | provenance |  |
+| A.java:30:33:30:37 | step1 : String | A.java:30:20:30:38 | apply(...) : String | provenance | Config |
 | A.java:30:33:30:37 | step1 : String | A.java:30:20:30:38 | apply(...) : String | provenance | Config |
 subpaths
 | A.java:18:33:18:37 | step0 : String | A.java:14:9:14:9 | x : String | A.java:14:14:14:35 | propagateState(...) : String | A.java:18:20:18:38 | apply(...) : String |
@@ -61,10 +70,10 @@ subpaths
 | A.java:19:33:19:37 | step1 : String | A.java:14:9:14:9 | x : String | A.java:14:14:14:35 | propagateState(...) : String | A.java:19:20:19:38 | apply(...) : String |
 | A.java:19:33:19:37 | step1 : String | A.java:15:9:15:9 | x : String | A.java:15:14:15:35 | propagateState(...) : String | A.java:19:20:19:38 | apply(...) : String |
 | A.java:29:33:29:37 | step0 : String | A.java:26:8:26:8 | x : String | A.java:26:13:26:81 | ...?...:... : String | A.java:29:20:29:38 | apply(...) : String |
+| A.java:29:33:29:37 | step0 : String | A.java:26:8:26:8 | x : String | A.java:26:13:26:81 | ...?...:... : String | A.java:29:20:29:38 | apply(...) : String |
+| A.java:30:33:30:37 | step1 : String | A.java:26:8:26:8 | x : String | A.java:26:13:26:81 | ...?...:... : String | A.java:30:20:30:38 | apply(...) : String |
 | A.java:30:33:30:37 | step1 : String | A.java:26:8:26:8 | x : String | A.java:26:13:26:81 | ...?...:... : String | A.java:30:20:30:38 | apply(...) : String |
 spuriousFlow
-| A.java:26:35:26:56 | propagateState(...) : String | B | A |
-| A.java:26:60:26:81 | propagateState(...) : String | A | B |
 #select
 | A.java:17:20:17:27 | source(...) : String | A.java:17:20:17:27 | source(...) : String | A.java:21:10:21:14 | step2 | Flow |
 | A.java:28:20:28:27 | source(...) : String | A.java:28:20:28:27 | source(...) : String | A.java:32:10:32:14 | step2 | Flow |

--- a/java/ql/test/library-tests/dataflow/deduplicate-path-graph/test.expected
+++ b/java/ql/test/library-tests/dataflow/deduplicate-path-graph/test.expected
@@ -1,0 +1,67 @@
+nodes
+| A.java:14:9:14:9 | x : String | semmle.label | x : String |
+| A.java:14:14:14:35 | propagateState(...) : String | semmle.label | propagateState(...) : String |
+| A.java:14:29:14:29 | x : String | semmle.label | x : String |
+| A.java:15:9:15:9 | x : String | semmle.label | x : String |
+| A.java:15:14:15:35 | propagateState(...) : String | semmle.label | propagateState(...) : String |
+| A.java:15:29:15:29 | x : String | semmle.label | x : String |
+| A.java:17:20:17:27 | source(...) : String | semmle.label | source(...) : String |
+| A.java:18:20:18:38 | apply(...) : String | semmle.label | apply(...) : String |
+| A.java:18:33:18:37 | step0 : String | semmle.label | step0 : String |
+| A.java:19:20:19:38 | apply(...) : String | semmle.label | apply(...) : String |
+| A.java:19:33:19:37 | step1 : String | semmle.label | step1 : String |
+| A.java:21:10:21:14 | step2 | semmle.label | step2 |
+| A.java:26:8:26:8 | x : String | semmle.label | x : String |
+| A.java:26:13:26:81 | ...?...:... : String | semmle.label | ...?...:... : String |
+| A.java:26:35:26:56 | propagateState(...) : String | semmle.label | propagateState(...) : String |
+| A.java:26:50:26:50 | x : String | semmle.label | x : String |
+| A.java:26:60:26:81 | propagateState(...) : String | semmle.label | propagateState(...) : String |
+| A.java:26:75:26:75 | x : String | semmle.label | x : String |
+| A.java:28:20:28:27 | source(...) : String | semmle.label | source(...) : String |
+| A.java:29:20:29:38 | apply(...) : String | semmle.label | apply(...) : String |
+| A.java:29:33:29:37 | step0 : String | semmle.label | step0 : String |
+| A.java:30:20:30:38 | apply(...) : String | semmle.label | apply(...) : String |
+| A.java:30:33:30:37 | step1 : String | semmle.label | step1 : String |
+| A.java:32:10:32:14 | step2 | semmle.label | step2 |
+edges
+| A.java:14:9:14:9 | x : String | A.java:14:29:14:29 | x : String |
+| A.java:14:29:14:29 | x : String | A.java:14:14:14:35 | propagateState(...) : String |
+| A.java:15:9:15:9 | x : String | A.java:15:29:15:29 | x : String |
+| A.java:15:29:15:29 | x : String | A.java:15:14:15:35 | propagateState(...) : String |
+| A.java:17:20:17:27 | source(...) : String | A.java:18:33:18:37 | step0 : String |
+| A.java:18:20:18:38 | apply(...) : String | A.java:19:33:19:37 | step1 : String |
+| A.java:18:33:18:37 | step0 : String | A.java:14:9:14:9 | x : String |
+| A.java:18:33:18:37 | step0 : String | A.java:15:9:15:9 | x : String |
+| A.java:18:33:18:37 | step0 : String | A.java:18:20:18:38 | apply(...) : String |
+| A.java:19:20:19:38 | apply(...) : String | A.java:21:10:21:14 | step2 |
+| A.java:19:33:19:37 | step1 : String | A.java:14:9:14:9 | x : String |
+| A.java:19:33:19:37 | step1 : String | A.java:15:9:15:9 | x : String |
+| A.java:19:33:19:37 | step1 : String | A.java:19:20:19:38 | apply(...) : String |
+| A.java:26:8:26:8 | x : String | A.java:26:50:26:50 | x : String |
+| A.java:26:8:26:8 | x : String | A.java:26:75:26:75 | x : String |
+| A.java:26:35:26:56 | propagateState(...) : String | A.java:26:13:26:81 | ...?...:... : String |
+| A.java:26:50:26:50 | x : String | A.java:26:35:26:56 | propagateState(...) : String |
+| A.java:26:60:26:81 | propagateState(...) : String | A.java:26:13:26:81 | ...?...:... : String |
+| A.java:26:75:26:75 | x : String | A.java:26:60:26:81 | propagateState(...) : String |
+| A.java:28:20:28:27 | source(...) : String | A.java:29:33:29:37 | step0 : String |
+| A.java:29:20:29:38 | apply(...) : String | A.java:30:33:30:37 | step1 : String |
+| A.java:29:33:29:37 | step0 : String | A.java:26:8:26:8 | x : String |
+| A.java:29:33:29:37 | step0 : String | A.java:29:20:29:38 | apply(...) : String |
+| A.java:30:20:30:38 | apply(...) : String | A.java:32:10:32:14 | step2 |
+| A.java:30:33:30:37 | step1 : String | A.java:26:8:26:8 | x : String |
+| A.java:30:33:30:37 | step1 : String | A.java:30:20:30:38 | apply(...) : String |
+subpaths
+| A.java:18:33:18:37 | step0 : String | A.java:14:9:14:9 | x : String | A.java:14:14:14:35 | propagateState(...) : String | A.java:18:20:18:38 | apply(...) : String |
+| A.java:18:33:18:37 | step0 : String | A.java:15:9:15:9 | x : String | A.java:15:14:15:35 | propagateState(...) : String | A.java:18:20:18:38 | apply(...) : String |
+| A.java:19:33:19:37 | step1 : String | A.java:14:9:14:9 | x : String | A.java:14:14:14:35 | propagateState(...) : String | A.java:19:20:19:38 | apply(...) : String |
+| A.java:19:33:19:37 | step1 : String | A.java:15:9:15:9 | x : String | A.java:15:14:15:35 | propagateState(...) : String | A.java:19:20:19:38 | apply(...) : String |
+| A.java:29:33:29:37 | step0 : String | A.java:26:8:26:8 | x : String | A.java:26:13:26:81 | ...?...:... : String | A.java:29:20:29:38 | apply(...) : String |
+| A.java:30:33:30:37 | step1 : String | A.java:26:8:26:8 | x : String | A.java:26:13:26:81 | ...?...:... : String | A.java:30:20:30:38 | apply(...) : String |
+spuriousFlow
+| A.java:14:14:14:35 | propagateState(...) : String | B | A |
+| A.java:15:14:15:35 | propagateState(...) : String | A | B |
+| A.java:26:35:26:56 | propagateState(...) : String | B | A |
+| A.java:26:60:26:81 | propagateState(...) : String | A | B |
+#select
+| A.java:17:20:17:27 | source(...) : String | A.java:17:20:17:27 | source(...) : String | A.java:21:10:21:14 | step2 | Flow |
+| A.java:28:20:28:27 | source(...) : String | A.java:28:20:28:27 | source(...) : String | A.java:32:10:32:14 | step2 | Flow |

--- a/java/ql/test/library-tests/dataflow/deduplicate-path-graph/test.ql
+++ b/java/ql/test/library-tests/dataflow/deduplicate-path-graph/test.ql
@@ -47,7 +47,7 @@ predicate reachableFromPropagate(Graph::PathNode node, string state, boolean cal
   node.getNode().asExpr() = propagateCall(state) and call = false
   or
   exists(Graph::PathNode prev | reachableFromPropagate(prev, state, call) |
-    Graph::edges(prev, node)
+    Graph::edges(prev, node, _, _)
     or
     Graph::subpaths(prev, _, _, node) // arg -> out
   )

--- a/java/ql/test/library-tests/dataflow/deduplicate-path-graph/test.ql
+++ b/java/ql/test/library-tests/dataflow/deduplicate-path-graph/test.ql
@@ -47,9 +47,10 @@ predicate reachableFromPropagate(Graph::PathNode node, string state, boolean cal
   node.getNode().asExpr() = propagateCall(state) and call = false
   or
   exists(Graph::PathNode prev | reachableFromPropagate(prev, state, call) |
-    Graph::edges(prev, node, _, _)
+    Graph::edges(prev, node, _, _) and
+    not Graph::subpaths(prev, node, _, _) // argument-passing edges are handled separately
     or
-    Graph::subpaths(prev, _, _, node) // arg -> out
+    Graph::subpaths(prev, _, _, node) // arg -> out (should be included in 'edges' but handle the case here for clarity)
   )
   or
   exists(Graph::PathNode prev |

--- a/java/ql/test/library-tests/dataflow/deduplicate-path-graph/test.ql
+++ b/java/ql/test/library-tests/dataflow/deduplicate-path-graph/test.ql
@@ -6,7 +6,7 @@ import java
 import semmle.code.java.dataflow.DataFlow
 import DataFlow
 
-MethodAccess propagateCall(string state) {
+MethodCall propagateCall(string state) {
   result.getMethod().getName() = "propagateState" and
   state = result.getArgument(1).(StringLiteral).getValue()
 }
@@ -15,16 +15,16 @@ module TestConfig implements StateConfigSig {
   class FlowState = string;
 
   predicate isSource(Node n, FlowState state) {
-    n.asExpr().(MethodAccess).getMethod().getName() = "source" and state = ["A", "B"]
+    n.asExpr().(MethodCall).getMethod().getName() = "source" and state = ["A", "B"]
   }
 
   predicate isSink(Node n, FlowState state) {
-    n.asExpr() = any(MethodAccess acc | acc.getMethod().getName() = "sink").getAnArgument() and
+    n.asExpr() = any(MethodCall acc | acc.getMethod().getName() = "sink").getAnArgument() and
     state = ["A", "B"]
   }
 
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
-    exists(MethodAccess call |
+    exists(MethodCall call |
       call = propagateCall(state1) and
       state2 = state1 and
       node1.asExpr() = call.getArgument(0) and

--- a/java/ql/test/library-tests/dataflow/deduplicate-path-graph/test.ql
+++ b/java/ql/test/library-tests/dataflow/deduplicate-path-graph/test.ql
@@ -1,0 +1,83 @@
+/**
+ * @kind path-problem
+ */
+
+import java
+import semmle.code.java.dataflow.DataFlow
+import DataFlow
+
+MethodAccess propagateCall(string state) {
+  result.getMethod().getName() = "propagateState" and
+  state = result.getArgument(1).(StringLiteral).getValue()
+}
+
+module TestConfig implements StateConfigSig {
+  class FlowState = string;
+
+  predicate isSource(Node n, FlowState state) {
+    n.asExpr().(MethodAccess).getMethod().getName() = "source" and state = ["A", "B"]
+  }
+
+  predicate isSink(Node n, FlowState state) {
+    n.asExpr() = any(MethodAccess acc | acc.getMethod().getName() = "sink").getAnArgument() and
+    state = ["A", "B"]
+  }
+
+  predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
+    exists(MethodAccess call |
+      call = propagateCall(state1) and
+      state2 = state1 and
+      node1.asExpr() = call.getArgument(0) and
+      node2.asExpr() = call
+    )
+  }
+}
+
+module TestFlow = DataFlow::GlobalWithState<TestConfig>;
+
+module Graph = DataFlow::DeduplicatePathGraph<TestFlow::PathNode, TestFlow::PathGraph>;
+
+/**
+ * Holds if `node` is reachable from a call to `propagateState` with the given `state` argument.
+ * `call` indicates if a call step was taken (i.e. into a subpath).
+ *
+ * We use this to check if one `propagateState` can flow out of another, which is not allowed.
+ */
+predicate reachableFromPropagate(Graph::PathNode node, string state, boolean call) {
+  node.getNode().asExpr() = propagateCall(state) and call = false
+  or
+  exists(Graph::PathNode prev | reachableFromPropagate(prev, state, call) |
+    Graph::edges(prev, node)
+    or
+    Graph::subpaths(prev, _, _, node) // arg -> out
+  )
+  or
+  exists(Graph::PathNode prev |
+    reachableFromPropagate(prev, state, _) and
+    Graph::subpaths(prev, node, _, _) and // arg -> parameter
+    call = true
+  )
+  or
+  exists(Graph::PathNode prev |
+    reachableFromPropagate(prev, state, call) and
+    Graph::subpaths(_, _, prev, node) and // return -> out
+    call = false
+  )
+}
+
+/**
+ * Holds if `node` is the return value of a `propagateState` call that appears to be reachable
+ * with a different state than the one propagated by the call, indicating spurious flow resulting from
+ * merging path nodes.
+ */
+query predicate spuriousFlow(Graph::PathNode node, string state1, string state2) {
+  reachableFromPropagate(node, state1, _) and
+  node.getNode().asExpr() = propagateCall(state2) and
+  state1 != state2
+}
+
+import Graph::PathGraph
+
+from Graph::PathNode source, Graph::PathNode sink
+where TestFlow::flowPath(source.getAnOriginalPathNode(), sink.getAnOriginalPathNode())
+select source, source, sink, "Flow"

--- a/ruby/ql/test/query-tests/security/cwe-094/CodeInjection/CodeInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-094/CodeInjection/CodeInjection.expected
@@ -1,74 +1,18 @@
-edges
-| CodeInjection.rb:5:5:5:8 | code | CodeInjection.rb:8:10:8:13 | code | provenance |  |
-| CodeInjection.rb:5:5:5:8 | code | CodeInjection.rb:8:10:8:13 | code | provenance |  |
-| CodeInjection.rb:5:5:5:8 | code | CodeInjection.rb:20:20:20:23 | code | provenance |  |
-| CodeInjection.rb:5:5:5:8 | code | CodeInjection.rb:20:20:20:23 | code | provenance |  |
-| CodeInjection.rb:5:5:5:8 | code | CodeInjection.rb:23:21:23:24 | code | provenance |  |
-| CodeInjection.rb:5:5:5:8 | code | CodeInjection.rb:23:21:23:24 | code | provenance |  |
-| CodeInjection.rb:5:5:5:8 | code | CodeInjection.rb:29:15:29:18 | code | provenance |  |
-| CodeInjection.rb:5:5:5:8 | code | CodeInjection.rb:32:19:32:22 | code | provenance |  |
-| CodeInjection.rb:5:5:5:8 | code | CodeInjection.rb:38:24:38:27 | code | provenance |  |
-| CodeInjection.rb:5:5:5:8 | code | CodeInjection.rb:38:24:38:27 | code | provenance |  |
-| CodeInjection.rb:5:5:5:8 | code | CodeInjection.rb:41:40:41:43 | code | provenance |  |
-| CodeInjection.rb:5:12:5:17 | call to params | CodeInjection.rb:5:12:5:24 | ...[...] | provenance |  |
-| CodeInjection.rb:5:12:5:17 | call to params | CodeInjection.rb:5:12:5:24 | ...[...] | provenance |  |
-| CodeInjection.rb:5:12:5:24 | ...[...] | CodeInjection.rb:5:5:5:8 | code | provenance |  |
-| CodeInjection.rb:5:12:5:24 | ...[...] | CodeInjection.rb:5:5:5:8 | code | provenance |  |
-| CodeInjection.rb:38:24:38:27 | code | CodeInjection.rb:38:10:38:28 | call to escape | provenance | MaD:21 |
-| CodeInjection.rb:38:24:38:27 | code | CodeInjection.rb:38:10:38:28 | call to escape | provenance | MaD:21 |
-| CodeInjection.rb:78:5:78:8 | code | CodeInjection.rb:80:16:80:19 | code | provenance |  |
-| CodeInjection.rb:78:5:78:8 | code | CodeInjection.rb:86:10:86:37 | ... + ... | provenance |  |
-| CodeInjection.rb:78:5:78:8 | code | CodeInjection.rb:86:22:86:25 | code | provenance |  |
-| CodeInjection.rb:78:5:78:8 | code | CodeInjection.rb:88:10:88:32 | "prefix_#{...}_suffix" | provenance | AdditionalTaintStep |
-| CodeInjection.rb:78:5:78:8 | code | CodeInjection.rb:90:10:90:13 | code | provenance |  |
-| CodeInjection.rb:78:5:78:8 | code | CodeInjection.rb:90:10:90:13 | code | provenance |  |
-| CodeInjection.rb:78:12:78:17 | call to params | CodeInjection.rb:78:12:78:24 | ...[...] | provenance |  |
-| CodeInjection.rb:78:12:78:17 | call to params | CodeInjection.rb:78:12:78:24 | ...[...] | provenance |  |
-| CodeInjection.rb:78:12:78:24 | ...[...] | CodeInjection.rb:78:5:78:8 | code | provenance |  |
-| CodeInjection.rb:78:12:78:24 | ...[...] | CodeInjection.rb:78:5:78:8 | code | provenance |  |
-| CodeInjection.rb:86:10:86:25 | ... + ... [element] | CodeInjection.rb:86:10:86:37 | ... + ... | provenance |  |
-| CodeInjection.rb:86:22:86:25 | code | CodeInjection.rb:86:10:86:25 | ... + ... [element] | provenance |  |
-| CodeInjection.rb:101:3:102:5 | self in index [@foo] | CodeInjection.rb:111:3:113:5 | self in baz [@foo] | provenance |  |
-| CodeInjection.rb:101:3:102:5 | self in index [@foo] | CodeInjection.rb:111:3:113:5 | self in baz [@foo] | provenance |  |
-| CodeInjection.rb:105:5:105:8 | [post] self [@foo] | CodeInjection.rb:108:3:109:5 | self in bar [@foo] | provenance |  |
-| CodeInjection.rb:105:5:105:8 | [post] self [@foo] | CodeInjection.rb:108:3:109:5 | self in bar [@foo] | provenance |  |
-| CodeInjection.rb:105:12:105:17 | call to params | CodeInjection.rb:105:12:105:23 | ...[...] | provenance |  |
-| CodeInjection.rb:105:12:105:17 | call to params | CodeInjection.rb:105:12:105:23 | ...[...] | provenance |  |
-| CodeInjection.rb:105:12:105:23 | ...[...] | CodeInjection.rb:105:5:105:8 | [post] self [@foo] | provenance |  |
-| CodeInjection.rb:105:12:105:23 | ...[...] | CodeInjection.rb:105:5:105:8 | [post] self [@foo] | provenance |  |
-| CodeInjection.rb:108:3:109:5 | self in bar [@foo] | CodeInjection.rb:101:3:102:5 | self in index [@foo] | provenance |  |
-| CodeInjection.rb:108:3:109:5 | self in bar [@foo] | CodeInjection.rb:101:3:102:5 | self in index [@foo] | provenance |  |
-| CodeInjection.rb:111:3:113:5 | self in baz [@foo] | CodeInjection.rb:112:10:112:13 | self [@foo] | provenance |  |
-| CodeInjection.rb:111:3:113:5 | self in baz [@foo] | CodeInjection.rb:112:10:112:13 | self [@foo] | provenance |  |
-| CodeInjection.rb:112:10:112:13 | self [@foo] | CodeInjection.rb:112:10:112:13 | @foo | provenance |  |
-| CodeInjection.rb:112:10:112:13 | self [@foo] | CodeInjection.rb:112:10:112:13 | @foo | provenance |  |
 nodes
 | CodeInjection.rb:5:5:5:8 | code | semmle.label | code |
-| CodeInjection.rb:5:5:5:8 | code | semmle.label | code |
-| CodeInjection.rb:5:12:5:17 | call to params | semmle.label | call to params |
 | CodeInjection.rb:5:12:5:17 | call to params | semmle.label | call to params |
 | CodeInjection.rb:5:12:5:24 | ...[...] | semmle.label | ...[...] |
-| CodeInjection.rb:5:12:5:24 | ...[...] | semmle.label | ...[...] |
-| CodeInjection.rb:8:10:8:13 | code | semmle.label | code |
 | CodeInjection.rb:8:10:8:13 | code | semmle.label | code |
 | CodeInjection.rb:11:10:11:15 | call to params | semmle.label | call to params |
-| CodeInjection.rb:11:10:11:15 | call to params | semmle.label | call to params |
 | CodeInjection.rb:20:20:20:23 | code | semmle.label | code |
-| CodeInjection.rb:20:20:20:23 | code | semmle.label | code |
-| CodeInjection.rb:23:21:23:24 | code | semmle.label | code |
 | CodeInjection.rb:23:21:23:24 | code | semmle.label | code |
 | CodeInjection.rb:29:15:29:18 | code | semmle.label | code |
 | CodeInjection.rb:32:19:32:22 | code | semmle.label | code |
 | CodeInjection.rb:38:10:38:28 | call to escape | semmle.label | call to escape |
-| CodeInjection.rb:38:10:38:28 | call to escape | semmle.label | call to escape |
-| CodeInjection.rb:38:24:38:27 | code | semmle.label | code |
 | CodeInjection.rb:38:24:38:27 | code | semmle.label | code |
 | CodeInjection.rb:41:40:41:43 | code | semmle.label | code |
 | CodeInjection.rb:78:5:78:8 | code | semmle.label | code |
-| CodeInjection.rb:78:5:78:8 | code | semmle.label | code |
 | CodeInjection.rb:78:12:78:17 | call to params | semmle.label | call to params |
-| CodeInjection.rb:78:12:78:17 | call to params | semmle.label | call to params |
-| CodeInjection.rb:78:12:78:24 | ...[...] | semmle.label | ...[...] |
 | CodeInjection.rb:78:12:78:24 | ...[...] | semmle.label | ...[...] |
 | CodeInjection.rb:80:16:80:19 | code | semmle.label | code |
 | CodeInjection.rb:86:10:86:25 | ... + ... [element] | semmle.label | ... + ... [element] |
@@ -76,23 +20,41 @@ nodes
 | CodeInjection.rb:86:22:86:25 | code | semmle.label | code |
 | CodeInjection.rb:88:10:88:32 | "prefix_#{...}_suffix" | semmle.label | "prefix_#{...}_suffix" |
 | CodeInjection.rb:90:10:90:13 | code | semmle.label | code |
-| CodeInjection.rb:90:10:90:13 | code | semmle.label | code |
-| CodeInjection.rb:101:3:102:5 | self in index [@foo] | semmle.label | self in index [@foo] |
 | CodeInjection.rb:101:3:102:5 | self in index [@foo] | semmle.label | self in index [@foo] |
 | CodeInjection.rb:105:5:105:8 | [post] self [@foo] | semmle.label | [post] self [@foo] |
-| CodeInjection.rb:105:5:105:8 | [post] self [@foo] | semmle.label | [post] self [@foo] |
-| CodeInjection.rb:105:12:105:17 | call to params | semmle.label | call to params |
 | CodeInjection.rb:105:12:105:17 | call to params | semmle.label | call to params |
 | CodeInjection.rb:105:12:105:23 | ...[...] | semmle.label | ...[...] |
-| CodeInjection.rb:105:12:105:23 | ...[...] | semmle.label | ...[...] |
-| CodeInjection.rb:108:3:109:5 | self in bar [@foo] | semmle.label | self in bar [@foo] |
 | CodeInjection.rb:108:3:109:5 | self in bar [@foo] | semmle.label | self in bar [@foo] |
 | CodeInjection.rb:111:3:113:5 | self in baz [@foo] | semmle.label | self in baz [@foo] |
-| CodeInjection.rb:111:3:113:5 | self in baz [@foo] | semmle.label | self in baz [@foo] |
-| CodeInjection.rb:112:10:112:13 | @foo | semmle.label | @foo |
 | CodeInjection.rb:112:10:112:13 | @foo | semmle.label | @foo |
 | CodeInjection.rb:112:10:112:13 | self [@foo] | semmle.label | self [@foo] |
-| CodeInjection.rb:112:10:112:13 | self [@foo] | semmle.label | self [@foo] |
+edges
+| CodeInjection.rb:5:5:5:8 | code | CodeInjection.rb:8:10:8:13 | code | provenance |  |
+| CodeInjection.rb:5:5:5:8 | code | CodeInjection.rb:20:20:20:23 | code | provenance |  |
+| CodeInjection.rb:5:5:5:8 | code | CodeInjection.rb:23:21:23:24 | code | provenance |  |
+| CodeInjection.rb:5:5:5:8 | code | CodeInjection.rb:29:15:29:18 | code | provenance |  |
+| CodeInjection.rb:5:5:5:8 | code | CodeInjection.rb:32:19:32:22 | code | provenance |  |
+| CodeInjection.rb:5:5:5:8 | code | CodeInjection.rb:38:24:38:27 | code | provenance |  |
+| CodeInjection.rb:5:5:5:8 | code | CodeInjection.rb:41:40:41:43 | code | provenance |  |
+| CodeInjection.rb:5:12:5:17 | call to params | CodeInjection.rb:5:12:5:24 | ...[...] | provenance |  |
+| CodeInjection.rb:5:12:5:24 | ...[...] | CodeInjection.rb:5:5:5:8 | code | provenance |  |
+| CodeInjection.rb:38:24:38:27 | code | CodeInjection.rb:38:10:38:28 | call to escape | provenance | MaD:21 |
+| CodeInjection.rb:78:5:78:8 | code | CodeInjection.rb:80:16:80:19 | code | provenance |  |
+| CodeInjection.rb:78:5:78:8 | code | CodeInjection.rb:86:10:86:37 | ... + ... | provenance |  |
+| CodeInjection.rb:78:5:78:8 | code | CodeInjection.rb:86:22:86:25 | code | provenance |  |
+| CodeInjection.rb:78:5:78:8 | code | CodeInjection.rb:88:10:88:32 | "prefix_#{...}_suffix" | provenance | AdditionalTaintStep |
+| CodeInjection.rb:78:5:78:8 | code | CodeInjection.rb:90:10:90:13 | code | provenance |  |
+| CodeInjection.rb:78:12:78:17 | call to params | CodeInjection.rb:78:12:78:24 | ...[...] | provenance |  |
+| CodeInjection.rb:78:12:78:24 | ...[...] | CodeInjection.rb:78:5:78:8 | code | provenance |  |
+| CodeInjection.rb:86:10:86:25 | ... + ... [element] | CodeInjection.rb:86:10:86:37 | ... + ... | provenance |  |
+| CodeInjection.rb:86:22:86:25 | code | CodeInjection.rb:86:10:86:25 | ... + ... [element] | provenance |  |
+| CodeInjection.rb:101:3:102:5 | self in index [@foo] | CodeInjection.rb:111:3:113:5 | self in baz [@foo] | provenance |  |
+| CodeInjection.rb:105:5:105:8 | [post] self [@foo] | CodeInjection.rb:108:3:109:5 | self in bar [@foo] | provenance |  |
+| CodeInjection.rb:105:12:105:17 | call to params | CodeInjection.rb:105:12:105:23 | ...[...] | provenance |  |
+| CodeInjection.rb:105:12:105:23 | ...[...] | CodeInjection.rb:105:5:105:8 | [post] self [@foo] | provenance |  |
+| CodeInjection.rb:108:3:109:5 | self in bar [@foo] | CodeInjection.rb:101:3:102:5 | self in index [@foo] | provenance |  |
+| CodeInjection.rb:111:3:113:5 | self in baz [@foo] | CodeInjection.rb:112:10:112:13 | self [@foo] | provenance |  |
+| CodeInjection.rb:112:10:112:13 | self [@foo] | CodeInjection.rb:112:10:112:13 | @foo | provenance |  |
 subpaths
 #select
 | CodeInjection.rb:8:10:8:13 | code | CodeInjection.rb:5:12:5:17 | call to params | CodeInjection.rb:8:10:8:13 | code | This code execution depends on a $@. | CodeInjection.rb:5:12:5:17 | call to params | user-provided value |

--- a/shared/dataflow/change-notes/2023-10-02-deduplicate-path-graph.md
+++ b/shared/dataflow/change-notes/2023-10-02-deduplicate-path-graph.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added a module `DataFlow::DeduplicatePathGraph` that can be used to avoid generating duplicate path explanations in queries that use flow state.

--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -973,13 +973,13 @@ module DataFlowMake<LocationSig Location, InputSig<Location> Lang> {
           // Retain flow state if one of the successors requires it to be retained
           discriminatedPathNode(stepEx(getAPathNode(node, toString)), hasEnter)
           or
-          // Enter a subpath
-          discriminatedPathNode(enterSubpathStep(getAPathNode(node, toString)), _) and
-          hasEnter = true
-          or
-          // Exit a subpath
-          discriminatedPathNode(exitSubpathStep(getAPathNode(node, toString)), false) and
+          // Propagate backwards from parameter to argument
+          discriminatedPathNode(enterSubpathStep(getAPathNode(node, toString)), false) and
           hasEnter = false
+          or
+          // Propagate backwards from out to return
+          discriminatedPathNode(exitSubpathStep(getAPathNode(node, toString)), _) and
+          hasEnter = true
         )
       }
 

--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -996,8 +996,12 @@ module DataFlowMake<LocationSig Location, InputSig<Location> Lang> {
       predicate discriminatedPathNode(InputPathNode pathNode) { discriminatedPathNode(pathNode, _) }
     }
 
+    private InputPathNode getUniqPathNode(Node node, string toString) {
+      result = unique(InputPathNode pathNode | pathNode = getAPathNode(node, toString))
+    }
+
     private predicate initialCandidate(Node node, string toString) {
-      exists(getAPathNode(node, toString))
+      exists(getAPathNode(node, toString)) and not exists(getUniqPathNode(node, toString))
     }
 
     private module Pass1 =
@@ -1017,7 +1021,7 @@ module DataFlowMake<LocationSig Location, InputSig<Location> Lang> {
       MakeDiscriminatorPass<Pass1::discriminatedPair/2, edgesRev/4, subpathsRev/4>;
 
     private newtype TPathNode =
-      TPreservedPathNode(InputPathNode node) { Pass2::discriminatedPathNode(node) } or
+      TPreservedPathNode(InputPathNode node) { Pass2::discriminatedPathNode(node) or node = getUniqPathNode(_, _) } or
       TCollapsedPathNode(Node node, string toString) {
         initialCandidate(node, toString) and
         not Pass2::discriminatedPair(node, toString)

--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -1025,7 +1025,9 @@ module DataFlowMake<LocationSig Location, InputSig<Location> Lang> {
       MakeDiscriminatorPass<Pass1::discriminatedPair/2, edgesRev/4, subpathsRev/4>;
 
     private newtype TPathNode =
-      TPreservedPathNode(InputPathNode node) { Pass2::discriminatedPathNode(node) or node = getUniqPathNode(_, _) } or
+      TPreservedPathNode(InputPathNode node) {
+        Pass2::discriminatedPathNode(node) or node = getUniqPathNode(_, _)
+      } or
       TCollapsedPathNode(Node node, string toString) {
         initialCandidate(node, toString) and
         not Pass2::discriminatedPair(node, toString)

--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -935,11 +935,15 @@ module DataFlowMake<LocationSig Location, InputSig<Location> Lang> {
           )
       }
 
-      /** Gets a successor of `node` including subpath flow-through. */
+      /** Gets a successor of `node`, including subpath flow-through, but not enter or exit subpath steps. */
       InputPathNode stepEx(InputPathNode node) {
-        step(node, result, _, _)
+        step(node, result, _, _) and
+        not result = enterSubpathStep(node) and
+        not result = exitSubpathStep(node)
         or
-        subpathStep(node, _, _, result) // assuming the input is pruned properly, all subpaths have flow-through
+        // Assuming the input is pruned properly, all subpaths have flow-through.
+        // This step should be in 'step' as well, but include it here for clarity as we rely on it.
+        subpathStep(node, _, _, result)
       }
 
       InputPathNode enterSubpathStep(InputPathNode node) { subpathStep(node, result, _, _) }


### PR DESCRIPTION
Adds a shared parameterised module, `DataFlow::DeduplicatePathGraph`, for post-processing a `PathGraph` so that it doesn't result in duplicate alerts or alerts with multiple identical paths.

This issue usually arises from using `FlowState`, which is embedded in the `PathNode` but not rendered as part of its string value. This can thus result in paths that have different intermediate flow states but appear to be identical to the end-user.

The issue with multiple alerts, i.e. seemingly-identical rows in the `#select` clause, is particularly bad for tools that attempt to diff results (such as DCA) but does not perform its own deduplication in advance.

The module works by projecting `PathNode` down to their `(node, toString)` values, which is closer to what the end-user actually sees in the end. By seeing the path graph as an NFA that accepts input symbols of type `(node, toString)` we try to minimise this NFA by merging states.

This is needed by the JavaScript data-flow migration, but I've put this in its own PR so it can be reviewed separately. I've used the library in a Ruby query that had some very ad-hoc alert deduplication logic. Note that the expected output diff is mainly due to reordering of result sets in the output.