### PR TITLE
Python - Add Django Request attributes for RestFramework

### DIFF
--- a/python/ql/lib/semmle/python/frameworks/RestFramework.qll
+++ b/python/ql/lib/semmle/python/frameworks/RestFramework.qll
@@ -253,7 +253,11 @@ private module RestFramework {
       override DataFlow::Node getInstance() { result = instance() }
 
       override string getAttributeName() {
-        result in ["data", "query_params", "user", "auth", "content_type", "stream"]
+        result in [
+            "data", "query_params", "user", "auth", "content_type", "stream",
+            // Django HttpRequest attributes
+            "COOKIES", "FILES", "GET", "PATCH", "POST", "PUT", "DELETE"
+          ]
       }
 
       override string getMethodName() { none() }


### PR DESCRIPTION
The RestRequest framework `request` uses some of the same attributes that Django `HttpRequest` uses.

- [Django HttpRequest Attributes](https://github.com/github/codeql/blob/e7384da1622486bc0bbeedbc81b75524b9915e59/python/ql/lib/semmle/python/frameworks/Django.qll#L1193)