### PR TITLE
Python - Add RestFramework handler kwargs

### DIFF
--- a/python/ql/lib/semmle/python/frameworks/RestFramework.qll
+++ b/python/ql/lib/semmle/python/frameworks/RestFramework.qll
@@ -194,6 +194,9 @@ private module RestFramework {
       exists(RestFrameworkApiViewClass vc |
         this.getParameter() =
           vc.getARequestHandler().(PrivateDjango::DjangoRouteHandler).getRequestParam()
+        or
+        // retrieve(self, request, **kwargs)
+        this.getParameter() = vc.getARequestHandler().(PrivateDjango::DjangoRouteHandler).getKwarg()
       )
       or
       // annotated with @api_view decorator

--- a/python/ql/test/library-tests/frameworks/rest_framework/taint_test.py
+++ b/python/ql/test/library-tests/frameworks/rest_framework/taint_test.py
@@ -107,12 +107,30 @@ class MyClass(APIView):
 
         return Response("ok") # $ HttpResponse
 
+# Viewsets
+# see https://www.django-rest-framework.org/api-guide/viewsets/
+
+class MyModelViewSet(viewsets.ModelViewSet):
+    def retrieve(self, request, *args, **kwargs): # $ requestHandler
+        ensure_tainted(
+            request, # $ tainted
+            request.GET, # $ tainted
+            request.GET.get("pk"), # $ tainted
+        )
+
+        ensure_tainted(
+            kwargs, # $ tainted
+            kwargs["pk"], # $ tainted
+            kwargs.get("pk"), # $ tainted
+        )
+        return Response("retrieve") # $ HttpResponse
 
 
 # fake setup, you can't actually run this
 urlpatterns = [
     path("test-taint/<routed_param>", test_taint),  # $ routeSetup="test-taint/<routed_param>"
-    path("ClassView/<routed_param>", MyClass.as_view()), # $ routeSetup="ClassView/<routed_param>"
+    path("ClassView/<routed_param>", MyClass.as_view()), # $ routeSetup="ClassView/<routed_param>",
+    path("MyModelViewSet/<routed_param>", MyModelViewSet.as_view()) # $ routeSetup="MyModelViewSet/<routed_param>",
 ]
 
 # tests with no route-setup, but we can still tell that these are using Django REST


### PR DESCRIPTION
Add support for `**kwargs` in RestFramework handler + tests