### PR TITLE
Swift: Replace two additional taint steps with implicit reads

### DIFF
--- a/swift/ql/lib/codeql/swift/security/CleartextStorageDatabaseExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextStorageDatabaseExtensions.qll
@@ -128,15 +128,9 @@ private class CleartextStorageDatabaseDefaultBarrier extends CleartextStorageDat
 /**
  * An additional taint step for cleartext database storage vulnerabilities.
  */
-private class CleartextStorageDatabaseArrayAdditionalFlowStep extends CleartextStorageDatabaseAdditionalFlowStep
+private class CleartextStorageDatabaseFieldsAdditionalFlowStep extends CleartextStorageDatabaseAdditionalFlowStep
 {
   override predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
-    // needed until we have proper content flow through arrays.
-    exists(ArrayExpr arr |
-      nodeFrom.asExpr() = arr.getAnElement() and
-      nodeTo.asExpr() = arr
-    )
-    or
     // if an object is sensitive, its fields are always sensitive
     // (this is needed because the sensitive data sources are in a sense
     //  approximate; for example we might identify `passwordBox` as a source,

--- a/swift/ql/lib/codeql/swift/security/CleartextStorageDatabaseQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextStorageDatabaseQuery.qll
@@ -39,6 +39,11 @@ module CleartextStorageDatabaseConfig implements DataFlow::ConfigSig {
       cx.asNominalTypeDecl() = d and
       c.getAReadContent().(DataFlow::Content::FieldContent).getField() = cx.getAMember()
     )
+    or
+    // flow out from array elements of at the sink,
+    // for example in `database.allStatements(sql: "", arguments: [sensitive])`.
+    isSink(node) and
+    c.getAReadContent() instanceof DataFlow::Content::ArrayContent
   }
 }
 

--- a/swift/ql/lib/codeql/swift/security/CleartextStorageDatabaseQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextStorageDatabaseQuery.qll
@@ -43,7 +43,7 @@ module CleartextStorageDatabaseConfig implements DataFlow::ConfigSig {
     // flow out from array elements of at the sink,
     // for example in `database.allStatements(sql: "", arguments: [sensitive])`.
     isSink(node) and
-    c.getAReadContent() instanceof DataFlow::Content::ArrayContent
+    c.getAReadContent() instanceof DataFlow::Content::CollectionContent
   }
 }
 

--- a/swift/ql/lib/codeql/swift/security/CommandInjectionExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/CommandInjectionExtensions.qll
@@ -30,19 +30,6 @@ class CommandInjectionAdditionalFlowStep extends Unit {
 }
 
 /**
- * An additional taint step for command injection vulnerabilities.
- */
-private class CommandInjectionArrayAdditionalFlowStep extends CommandInjectionAdditionalFlowStep {
-  override predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
-    // needed until we have proper content flow through arrays.
-    exists(ArrayExpr arr |
-      nodeFrom.asExpr() = arr.getAnElement() and
-      nodeTo.asExpr() = arr
-    )
-  }
-}
-
-/**
  * A sink defined in a CSV model.
  */
 private class DefaultCommandInjectionSink extends CommandInjectionSink {

--- a/swift/ql/lib/codeql/swift/security/CommandInjectionQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/CommandInjectionQuery.qll
@@ -27,7 +27,7 @@ module CommandInjectionConfig implements DataFlow::ConfigSig {
   predicate allowImplicitRead(DataFlow::Node node, DataFlow::ContentSet c) {
     // flow out from array elements of at the sink, for example in `task.arguments = [tainted]`.
     isSink(node) and
-    c.getAReadContent() instanceof DataFlow::Content::ArrayContent
+    c.getAReadContent() instanceof DataFlow::Content::CollectionContent
   }
 }
 

--- a/swift/ql/lib/codeql/swift/security/CommandInjectionQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/CommandInjectionQuery.qll
@@ -23,6 +23,12 @@ module CommandInjectionConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(CommandInjectionAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
+
+  predicate allowImplicitRead(DataFlow::Node node, DataFlow::ContentSet c) {
+    // flow out from array elements of at the sink, for example in `task.arguments = [tainted]`.
+    isSink(node) and
+    c.getAReadContent() instanceof DataFlow::Content::ArrayContent
+  }
 }
 
 /**

--- a/swift/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
+++ b/swift/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
@@ -5,18 +5,18 @@ edges
 | CommandInjection.swift:69:8:69:12 | let ...? [some:0, some:0] | CommandInjection.swift:69:12:69:12 | userControlledString [some:0] |
 | CommandInjection.swift:69:8:69:12 | let ...? [some:0] | CommandInjection.swift:69:12:69:12 | userControlledString |
 | CommandInjection.swift:69:12:69:12 | userControlledString | CommandInjection.swift:75:27:75:27 | userControlledString |
-| CommandInjection.swift:69:12:69:12 | userControlledString [some:0] | CommandInjection.swift:75:27:75:27 | userControlledString [some:0] |
+| CommandInjection.swift:69:12:69:12 | userControlledString | CommandInjection.swift:78:43:78:43 | userControlledString |
+| CommandInjection.swift:69:12:69:12 | userControlledString [some:0] | CommandInjection.swift:78:43:78:43 | userControlledString [some:0] |
 | CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) | CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) [some:0] |
 | CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) | CommandInjection.swift:75:27:75:27 | userControlledString |
+| CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) | CommandInjection.swift:78:43:78:43 | userControlledString |
 | CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) [some:0, some:0] | CommandInjection.swift:69:8:69:12 | let ...? [some:0, some:0] |
 | CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) [some:0] | CommandInjection.swift:69:8:69:12 | let ...? [some:0] |
 | CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) [some:0] | CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) [some:0, some:0] |
-| CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) [some:0] | CommandInjection.swift:75:27:75:27 | userControlledString [some:0] |
-| CommandInjection.swift:75:2:75:2 | [post] task1 [arguments] | CommandInjection.swift:75:2:75:2 | [post] task1 |
-| CommandInjection.swift:75:20:75:47 | [...] | CommandInjection.swift:75:2:75:2 | [post] task1 [arguments] |
-| CommandInjection.swift:75:27:75:27 | userControlledString | CommandInjection.swift:75:20:75:47 | [...] |
-| CommandInjection.swift:75:27:75:27 | userControlledString | CommandInjection.swift:78:43:78:43 | userControlledString |
-| CommandInjection.swift:75:27:75:27 | userControlledString [some:0] | CommandInjection.swift:78:43:78:43 | userControlledString [some:0] |
+| CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) [some:0] | CommandInjection.swift:78:43:78:43 | userControlledString [some:0] |
+| CommandInjection.swift:75:2:75:2 | [post] task1 [arguments, Collection element] | CommandInjection.swift:75:2:75:2 | [post] task1 |
+| CommandInjection.swift:75:20:75:47 | [...] [Collection element] | CommandInjection.swift:75:2:75:2 | [post] task1 [arguments, Collection element] |
+| CommandInjection.swift:75:27:75:27 | userControlledString | CommandInjection.swift:75:20:75:47 | [...] [Collection element] |
 | CommandInjection.swift:78:5:78:9 | let ...? [some:0] | CommandInjection.swift:78:9:78:9 | validatedString |
 | CommandInjection.swift:78:9:78:9 | validatedString | CommandInjection.swift:81:31:81:31 | validatedString |
 | CommandInjection.swift:78:27:78:63 | call to validateCommand(_:) | CommandInjection.swift:81:31:81:31 | validatedString |
@@ -26,104 +26,128 @@ edges
 | CommandInjection.swift:78:43:78:43 | userControlledString | CommandInjection.swift:78:27:78:63 | call to validateCommand(_:) [some:0] |
 | CommandInjection.swift:78:43:78:43 | userControlledString [some:0] | CommandInjection.swift:58:22:58:33 | command [some:0] |
 | CommandInjection.swift:78:43:78:43 | userControlledString [some:0] | CommandInjection.swift:78:27:78:63 | call to validateCommand(_:) [some:0] |
-| CommandInjection.swift:81:6:81:6 | [post] task2 [arguments] | CommandInjection.swift:81:6:81:6 | [post] task2 |
-| CommandInjection.swift:81:24:81:46 | [...] | CommandInjection.swift:81:6:81:6 | [post] task2 [arguments] |
-| CommandInjection.swift:81:31:81:31 | validatedString | CommandInjection.swift:81:24:81:46 | [...] |
+| CommandInjection.swift:81:6:81:6 | [post] task2 [arguments, Collection element] | CommandInjection.swift:81:6:81:6 | [post] task2 |
+| CommandInjection.swift:81:24:81:46 | [...] [Collection element] | CommandInjection.swift:81:6:81:6 | [post] task2 [arguments, Collection element] |
+| CommandInjection.swift:81:31:81:31 | validatedString | CommandInjection.swift:81:24:81:46 | [...] [Collection element] |
 | CommandInjection.swift:99:8:99:12 | let ...? [some:0] | CommandInjection.swift:99:12:99:12 | userControlledString |
 | CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:114:36:114:36 | userControlledString |
 | CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:115:28:115:28 | userControlledString |
+| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:119:45:119:45 | userControlledString |
+| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:120:28:120:36 | ... .+(_:_:) ... |
+| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:124:46:124:46 | userControlledString |
+| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:125:22:125:22 | userControlledString |
+| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:132:24:132:24 | userControlledString |
+| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:142:42:142:42 | userControlledString |
+| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:143:75:143:75 | userControlledString |
+| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:146:35:146:35 | userControlledString |
+| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:147:70:147:70 | userControlledString |
+| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:152:53:152:53 | userControlledString |
+| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:155:52:155:52 | userControlledString |
+| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:156:33:156:33 | userControlledString |
+| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:158:57:158:57 | userControlledString |
 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) [some:0] |
 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:114:36:114:36 | userControlledString |
 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:115:28:115:28 | userControlledString |
+| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:119:45:119:45 | userControlledString |
+| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:120:28:120:36 | ... .+(_:_:) ... |
+| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:124:46:124:46 | userControlledString |
+| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:125:22:125:22 | userControlledString |
+| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:132:24:132:24 | userControlledString |
+| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:142:42:142:42 | userControlledString |
+| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:143:75:143:75 | userControlledString |
+| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:146:35:146:35 | userControlledString |
+| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:147:70:147:70 | userControlledString |
+| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:152:53:152:53 | userControlledString |
+| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:155:52:155:52 | userControlledString |
+| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:156:33:156:33 | userControlledString |
+| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:158:57:158:57 | userControlledString |
 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) [some:0] | CommandInjection.swift:99:8:99:12 | let ...? [some:0] |
 | CommandInjection.swift:114:2:114:2 | [post] task3 [executableURL] | CommandInjection.swift:114:2:114:2 | [post] task3 |
 | CommandInjection.swift:114:24:114:56 | call to URL.init(string:) [some:0] | CommandInjection.swift:114:24:114:57 | ...! |
 | CommandInjection.swift:114:24:114:57 | ...! | CommandInjection.swift:114:2:114:2 | [post] task3 [executableURL] |
 | CommandInjection.swift:114:36:114:36 | userControlledString | CommandInjection.swift:114:24:114:56 | call to URL.init(string:) [some:0] |
-| CommandInjection.swift:115:2:115:2 | [post] task3 [arguments] | CommandInjection.swift:115:2:115:2 | [post] task3 |
-| CommandInjection.swift:115:20:115:48 | [...] | CommandInjection.swift:115:2:115:2 | [post] task3 [arguments] |
-| CommandInjection.swift:115:28:115:28 | userControlledString | CommandInjection.swift:115:20:115:48 | [...] |
-| CommandInjection.swift:115:28:115:28 | userControlledString | CommandInjection.swift:119:45:119:45 | userControlledString |
-| CommandInjection.swift:115:28:115:28 | userControlledString | CommandInjection.swift:120:28:120:36 | ... .+(_:_:) ... |
-| CommandInjection.swift:115:28:115:28 | userControlledString | CommandInjection.swift:124:46:124:46 | userControlledString |
-| CommandInjection.swift:115:28:115:28 | userControlledString | CommandInjection.swift:125:22:125:22 | userControlledString |
+| CommandInjection.swift:115:2:115:2 | [post] task3 [arguments, Collection element] | CommandInjection.swift:115:2:115:2 | [post] task3 |
+| CommandInjection.swift:115:20:115:48 | [...] [Collection element] | CommandInjection.swift:115:2:115:2 | [post] task3 [arguments, Collection element] |
+| CommandInjection.swift:115:28:115:28 | userControlledString | CommandInjection.swift:115:20:115:48 | [...] [Collection element] |
 | CommandInjection.swift:119:2:119:2 | [post] task4 [executableURL] | CommandInjection.swift:119:2:119:2 | [post] task4 |
 | CommandInjection.swift:119:24:119:65 | call to URL.init(fileURLWithPath:) | CommandInjection.swift:119:2:119:2 | [post] task4 [executableURL] |
 | CommandInjection.swift:119:45:119:45 | userControlledString | CommandInjection.swift:119:24:119:65 | call to URL.init(fileURLWithPath:) |
-| CommandInjection.swift:120:2:120:2 | [post] task4 [arguments] | CommandInjection.swift:120:2:120:2 | [post] task4 |
-| CommandInjection.swift:120:20:120:56 | [...] | CommandInjection.swift:120:2:120:2 | [post] task4 [arguments] |
-| CommandInjection.swift:120:28:120:36 | ... .+(_:_:) ... | CommandInjection.swift:120:20:120:56 | [...] |
+| CommandInjection.swift:120:2:120:2 | [post] task4 [arguments, Collection element] | CommandInjection.swift:120:2:120:2 | [post] task4 |
+| CommandInjection.swift:120:20:120:56 | [...] [Collection element] | CommandInjection.swift:120:2:120:2 | [post] task4 [arguments, Collection element] |
+| CommandInjection.swift:120:28:120:36 | ... .+(_:_:) ... | CommandInjection.swift:120:20:120:56 | [...] [Collection element] |
 | CommandInjection.swift:124:2:124:7 | [post] ...? [executableURL] | CommandInjection.swift:124:2:124:7 | [post] ...? |
 | CommandInjection.swift:124:25:124:66 | call to URL.init(fileURLWithPath:) | CommandInjection.swift:124:2:124:7 | [post] ...? [executableURL] |
 | CommandInjection.swift:124:46:124:46 | userControlledString | CommandInjection.swift:124:25:124:66 | call to URL.init(fileURLWithPath:) |
-| CommandInjection.swift:125:2:125:7 | [post] ...? [arguments] | CommandInjection.swift:125:2:125:7 | [post] ...? |
-| CommandInjection.swift:125:21:125:42 | [...] | CommandInjection.swift:125:2:125:7 | [post] ...? [arguments] |
-| CommandInjection.swift:125:22:125:22 | userControlledString | CommandInjection.swift:125:21:125:42 | [...] |
-| CommandInjection.swift:125:22:125:22 | userControlledString | CommandInjection.swift:130:21:130:21 | userControlledString |
-| CommandInjection.swift:130:21:130:21 | userControlledString | CommandInjection.swift:131:22:131:22 | userControlledString |
-| CommandInjection.swift:131:22:131:22 | userControlledString | CommandInjection.swift:142:42:142:42 | userControlledString |
-| CommandInjection.swift:131:22:131:22 | userControlledString | CommandInjection.swift:143:75:143:75 | userControlledString |
-| CommandInjection.swift:143:75:143:75 | userControlledString | CommandInjection.swift:143:67:143:95 | [...] |
-| CommandInjection.swift:143:75:143:75 | userControlledString | CommandInjection.swift:146:35:146:35 | userControlledString |
-| CommandInjection.swift:143:75:143:75 | userControlledString | CommandInjection.swift:147:70:147:70 | userControlledString |
+| CommandInjection.swift:125:2:125:7 | [post] ...? [arguments, Collection element] | CommandInjection.swift:125:2:125:7 | [post] ...? |
+| CommandInjection.swift:125:21:125:42 | [...] [Collection element] | CommandInjection.swift:125:2:125:7 | [post] ...? [arguments, Collection element] |
+| CommandInjection.swift:125:22:125:22 | userControlledString | CommandInjection.swift:125:21:125:42 | [...] [Collection element] |
+| CommandInjection.swift:132:24:132:24 | userControlledString | CommandInjection.swift:142:42:142:42 | userControlledString |
+| CommandInjection.swift:132:24:132:24 | userControlledString | CommandInjection.swift:143:75:143:75 | userControlledString |
+| CommandInjection.swift:132:24:132:24 | userControlledString | CommandInjection.swift:146:35:146:35 | userControlledString |
+| CommandInjection.swift:132:24:132:24 | userControlledString | CommandInjection.swift:147:70:147:70 | userControlledString |
+| CommandInjection.swift:132:24:132:24 | userControlledString | CommandInjection.swift:152:53:152:53 | userControlledString |
+| CommandInjection.swift:132:24:132:24 | userControlledString | CommandInjection.swift:155:52:155:52 | userControlledString |
+| CommandInjection.swift:132:24:132:24 | userControlledString | CommandInjection.swift:156:33:156:33 | userControlledString |
+| CommandInjection.swift:132:24:132:24 | userControlledString | CommandInjection.swift:158:57:158:57 | userControlledString |
+| CommandInjection.swift:143:67:143:95 | [...] [Collection element] | CommandInjection.swift:143:67:143:95 | [...] |
+| CommandInjection.swift:143:75:143:75 | userControlledString | CommandInjection.swift:143:67:143:95 | [...] [Collection element] |
 | CommandInjection.swift:146:23:146:55 | call to URL.init(string:) [some:0] | CommandInjection.swift:146:23:146:56 | ...! |
 | CommandInjection.swift:146:35:146:35 | userControlledString | CommandInjection.swift:146:23:146:55 | call to URL.init(string:) [some:0] |
-| CommandInjection.swift:147:70:147:70 | userControlledString | CommandInjection.swift:147:62:147:90 | [...] |
-| CommandInjection.swift:147:70:147:70 | userControlledString | CommandInjection.swift:152:53:152:53 | userControlledString |
-| CommandInjection.swift:147:70:147:70 | userControlledString | CommandInjection.swift:155:52:155:52 | userControlledString |
-| CommandInjection.swift:147:70:147:70 | userControlledString | CommandInjection.swift:156:33:156:33 | userControlledString |
+| CommandInjection.swift:147:62:147:90 | [...] [Collection element] | CommandInjection.swift:147:62:147:90 | [...] |
+| CommandInjection.swift:147:70:147:70 | userControlledString | CommandInjection.swift:147:62:147:90 | [...] [Collection element] |
 | CommandInjection.swift:152:41:152:73 | call to URL.init(string:) [some:0] | CommandInjection.swift:152:41:152:74 | ...! |
 | CommandInjection.swift:152:53:152:53 | userControlledString | CommandInjection.swift:152:41:152:73 | call to URL.init(string:) [some:0] |
 | CommandInjection.swift:155:40:155:72 | call to URL.init(string:) [some:0] | CommandInjection.swift:155:40:155:73 | ...! |
 | CommandInjection.swift:155:40:155:72 | call to URL.init(string:) [some:0] | CommandInjection.swift:155:40:155:73 | ...! |
 | CommandInjection.swift:155:40:155:73 | ...! | file://:0:0:0:0 | url |
 | CommandInjection.swift:155:52:155:52 | userControlledString | CommandInjection.swift:155:40:155:72 | call to URL.init(string:) [some:0] |
-| CommandInjection.swift:156:33:156:33 | userControlledString | CommandInjection.swift:156:32:156:53 | [...] |
-| CommandInjection.swift:156:33:156:33 | userControlledString | CommandInjection.swift:158:57:158:57 | userControlledString |
+| CommandInjection.swift:156:32:156:53 | [...] [Collection element] | CommandInjection.swift:156:32:156:53 | [...] |
+| CommandInjection.swift:156:33:156:33 | userControlledString | CommandInjection.swift:156:32:156:53 | [...] [Collection element] |
 | CommandInjection.swift:158:45:158:77 | call to URL.init(string:) [some:0] | CommandInjection.swift:158:45:158:78 | ...! |
 | CommandInjection.swift:158:45:158:77 | call to URL.init(string:) [some:0] | CommandInjection.swift:158:45:158:78 | ...! |
 | CommandInjection.swift:158:45:158:78 | ...! | file://:0:0:0:0 | url |
 | CommandInjection.swift:158:57:158:57 | userControlledString | CommandInjection.swift:158:45:158:77 | call to URL.init(string:) [some:0] |
-| CommandInjection.swift:172:3:172:3 | newValue | CommandInjection.swift:173:19:173:19 | newValue |
-| CommandInjection.swift:172:3:172:3 | newValue | CommandInjection.swift:174:20:174:20 | newValue |
-| CommandInjection.swift:172:3:172:3 | newValue | CommandInjection.swift:175:19:175:19 | newValue |
-| CommandInjection.swift:173:4:173:4 | [post] getter for .p1 [arguments] | CommandInjection.swift:173:4:173:4 | [post] getter for .p1 |
-| CommandInjection.swift:173:19:173:19 | newValue | CommandInjection.swift:173:4:173:4 | [post] getter for .p1 [arguments] |
-| CommandInjection.swift:174:4:174:6 | [post] ...! [arguments] | CommandInjection.swift:174:4:174:6 | [post] ...! |
-| CommandInjection.swift:174:20:174:20 | newValue | CommandInjection.swift:174:4:174:6 | [post] ...! [arguments] |
-| CommandInjection.swift:175:4:175:4 | [post] ...! [arguments] | CommandInjection.swift:175:4:175:4 | [post] ...! |
-| CommandInjection.swift:175:19:175:19 | newValue | CommandInjection.swift:175:4:175:4 | [post] ...! [arguments] |
+| CommandInjection.swift:172:3:172:3 | newValue [Collection element] | CommandInjection.swift:173:19:173:19 | newValue [Collection element] |
+| CommandInjection.swift:172:3:172:3 | newValue [Collection element] | CommandInjection.swift:174:20:174:20 | newValue [Collection element] |
+| CommandInjection.swift:172:3:172:3 | newValue [Collection element] | CommandInjection.swift:175:19:175:19 | newValue [Collection element] |
+| CommandInjection.swift:173:4:173:4 | [post] getter for .p1 [arguments, Collection element] | CommandInjection.swift:173:4:173:4 | [post] getter for .p1 |
+| CommandInjection.swift:173:19:173:19 | newValue [Collection element] | CommandInjection.swift:173:4:173:4 | [post] getter for .p1 [arguments, Collection element] |
+| CommandInjection.swift:174:4:174:6 | [post] ...! [arguments, Collection element] | CommandInjection.swift:174:4:174:6 | [post] ...! |
+| CommandInjection.swift:174:20:174:20 | newValue [Collection element] | CommandInjection.swift:174:4:174:6 | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:175:4:175:4 | [post] ...! [arguments, Collection element] | CommandInjection.swift:175:4:175:4 | [post] ...! |
+| CommandInjection.swift:175:19:175:19 | newValue [Collection element] | CommandInjection.swift:175:4:175:4 | [post] ...! [arguments, Collection element] |
 | CommandInjection.swift:180:9:180:13 | let ...? [some:0] | CommandInjection.swift:180:13:180:13 | userControlledString |
 | CommandInjection.swift:180:13:180:13 | userControlledString | CommandInjection.swift:184:19:184:19 | userControlledString |
+| CommandInjection.swift:180:13:180:13 | userControlledString | CommandInjection.swift:190:31:190:31 | userControlledString |
 | CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) | CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) [some:0] |
 | CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) | CommandInjection.swift:184:19:184:19 | userControlledString |
+| CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) | CommandInjection.swift:190:31:190:31 | userControlledString |
 | CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) [some:0] | CommandInjection.swift:180:9:180:13 | let ...? [some:0] |
-| CommandInjection.swift:184:18:184:39 | [...] | CommandInjection.swift:186:18:186:18 | tainted1 |
-| CommandInjection.swift:184:18:184:39 | [...] | CommandInjection.swift:187:19:187:19 | tainted1 |
-| CommandInjection.swift:184:18:184:39 | [...] | CommandInjection.swift:188:18:188:18 | tainted1 |
-| CommandInjection.swift:184:19:184:19 | userControlledString | CommandInjection.swift:184:18:184:39 | [...] |
-| CommandInjection.swift:184:19:184:19 | userControlledString | CommandInjection.swift:190:31:190:31 | userControlledString |
-| CommandInjection.swift:186:3:186:3 | [post] getter for .p1 [arguments] | CommandInjection.swift:186:3:186:3 | [post] getter for .p1 |
-| CommandInjection.swift:186:18:186:18 | tainted1 | CommandInjection.swift:186:3:186:3 | [post] getter for .p1 [arguments] |
-| CommandInjection.swift:186:18:186:18 | tainted1 | CommandInjection.swift:187:19:187:19 | tainted1 |
-| CommandInjection.swift:186:18:186:18 | tainted1 | CommandInjection.swift:188:18:188:18 | tainted1 |
-| CommandInjection.swift:187:3:187:5 | [post] ...! [arguments] | CommandInjection.swift:187:3:187:5 | [post] ...! |
-| CommandInjection.swift:187:19:187:19 | tainted1 | CommandInjection.swift:187:3:187:5 | [post] ...! [arguments] |
-| CommandInjection.swift:187:19:187:19 | tainted1 | CommandInjection.swift:188:18:188:18 | tainted1 |
-| CommandInjection.swift:188:3:188:3 | [post] ...! [arguments] | CommandInjection.swift:188:3:188:3 | [post] ...! |
-| CommandInjection.swift:188:18:188:18 | tainted1 | CommandInjection.swift:188:3:188:3 | [post] ...! [arguments] |
-| CommandInjection.swift:190:30:190:51 | [...] | CommandInjection.swift:192:18:192:18 | tainted2 |
-| CommandInjection.swift:190:30:190:51 | [...] | CommandInjection.swift:193:19:193:19 | tainted2 |
-| CommandInjection.swift:190:30:190:51 | [...] | CommandInjection.swift:194:18:194:18 | tainted2 |
-| CommandInjection.swift:190:30:190:51 | [...] | CommandInjection.swift:196:13:196:13 | tainted2 |
-| CommandInjection.swift:190:31:190:31 | userControlledString | CommandInjection.swift:190:30:190:51 | [...] |
-| CommandInjection.swift:192:3:192:3 | [post] getter for .p1 [arguments] | CommandInjection.swift:192:3:192:3 | [post] getter for .p1 |
-| CommandInjection.swift:192:18:192:18 | tainted2 | CommandInjection.swift:192:3:192:3 | [post] getter for .p1 [arguments] |
-| CommandInjection.swift:193:3:193:5 | [post] ...! [arguments] | CommandInjection.swift:193:3:193:5 | [post] ...! |
-| CommandInjection.swift:193:19:193:19 | tainted2 | CommandInjection.swift:193:3:193:5 | [post] ...! [arguments] |
-| CommandInjection.swift:194:3:194:3 | [post] ...! [arguments] | CommandInjection.swift:194:3:194:3 | [post] ...! |
-| CommandInjection.swift:194:18:194:18 | tainted2 | CommandInjection.swift:194:3:194:3 | [post] ...! [arguments] |
-| CommandInjection.swift:196:13:196:13 | tainted2 | CommandInjection.swift:172:3:172:3 | newValue |
+| CommandInjection.swift:184:18:184:39 | [...] [Collection element] | CommandInjection.swift:186:18:186:18 | tainted1 [Collection element] |
+| CommandInjection.swift:184:18:184:39 | [...] [Collection element] | CommandInjection.swift:187:19:187:19 | tainted1 [Collection element] |
+| CommandInjection.swift:184:18:184:39 | [...] [Collection element] | CommandInjection.swift:188:18:188:18 | tainted1 [Collection element] |
+| CommandInjection.swift:184:19:184:19 | userControlledString | CommandInjection.swift:184:18:184:39 | [...] [Collection element] |
+| CommandInjection.swift:186:3:186:3 | [post] getter for .p1 [arguments, Collection element] | CommandInjection.swift:186:3:186:3 | [post] getter for .p1 |
+| CommandInjection.swift:186:18:186:18 | tainted1 [Collection element] | CommandInjection.swift:186:3:186:3 | [post] getter for .p1 [arguments, Collection element] |
+| CommandInjection.swift:186:18:186:18 | tainted1 [Collection element] | CommandInjection.swift:187:19:187:19 | tainted1 [Collection element] |
+| CommandInjection.swift:186:18:186:18 | tainted1 [Collection element] | CommandInjection.swift:188:18:188:18 | tainted1 [Collection element] |
+| CommandInjection.swift:187:3:187:5 | [post] ...! [arguments, Collection element] | CommandInjection.swift:187:3:187:5 | [post] ...! |
+| CommandInjection.swift:187:19:187:19 | tainted1 [Collection element] | CommandInjection.swift:187:3:187:5 | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:187:19:187:19 | tainted1 [Collection element] | CommandInjection.swift:188:18:188:18 | tainted1 [Collection element] |
+| CommandInjection.swift:188:3:188:3 | [post] ...! [arguments, Collection element] | CommandInjection.swift:188:3:188:3 | [post] ...! |
+| CommandInjection.swift:188:18:188:18 | tainted1 [Collection element] | CommandInjection.swift:188:3:188:3 | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:190:30:190:51 | [...] [Collection element] | CommandInjection.swift:192:18:192:18 | tainted2 [Collection element] |
+| CommandInjection.swift:190:30:190:51 | [...] [Collection element] | CommandInjection.swift:193:19:193:19 | tainted2 [Collection element] |
+| CommandInjection.swift:190:30:190:51 | [...] [Collection element] | CommandInjection.swift:194:18:194:18 | tainted2 [Collection element] |
+| CommandInjection.swift:190:30:190:51 | [...] [Collection element] | CommandInjection.swift:196:13:196:13 | tainted2 [Collection element] |
+| CommandInjection.swift:190:31:190:31 | userControlledString | CommandInjection.swift:190:30:190:51 | [...] [Collection element] |
+| CommandInjection.swift:192:3:192:3 | [post] getter for .p1 [arguments, Collection element] | CommandInjection.swift:192:3:192:3 | [post] getter for .p1 |
+| CommandInjection.swift:192:18:192:18 | tainted2 [Collection element] | CommandInjection.swift:192:3:192:3 | [post] getter for .p1 [arguments, Collection element] |
+| CommandInjection.swift:193:3:193:5 | [post] ...! [arguments, Collection element] | CommandInjection.swift:193:3:193:5 | [post] ...! |
+| CommandInjection.swift:193:19:193:19 | tainted2 [Collection element] | CommandInjection.swift:193:3:193:5 | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:194:3:194:3 | [post] ...! [arguments, Collection element] | CommandInjection.swift:194:3:194:3 | [post] ...! |
+| CommandInjection.swift:194:18:194:18 | tainted2 [Collection element] | CommandInjection.swift:194:3:194:3 | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:196:13:196:13 | tainted2 [Collection element] | CommandInjection.swift:172:3:172:3 | newValue [Collection element] |
 | file://:0:0:0:0 | url | file://:0:0:0:0 | url |
 | file://:0:0:0:0 | url | file://:0:0:0:0 | url |
 nodes
@@ -140,10 +164,9 @@ nodes
 | CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) [some:0, some:0] | semmle.label | call to String.init(contentsOf:) [some:0, some:0] |
 | CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) [some:0] | semmle.label | call to String.init(contentsOf:) [some:0] |
 | CommandInjection.swift:75:2:75:2 | [post] task1 | semmle.label | [post] task1 |
-| CommandInjection.swift:75:2:75:2 | [post] task1 [arguments] | semmle.label | [post] task1 [arguments] |
-| CommandInjection.swift:75:20:75:47 | [...] | semmle.label | [...] |
+| CommandInjection.swift:75:2:75:2 | [post] task1 [arguments, Collection element] | semmle.label | [post] task1 [arguments, Collection element] |
+| CommandInjection.swift:75:20:75:47 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | CommandInjection.swift:75:27:75:27 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:75:27:75:27 | userControlledString [some:0] | semmle.label | userControlledString [some:0] |
 | CommandInjection.swift:78:5:78:9 | let ...? [some:0] | semmle.label | let ...? [some:0] |
 | CommandInjection.swift:78:9:78:9 | validatedString | semmle.label | validatedString |
 | CommandInjection.swift:78:27:78:63 | call to validateCommand(_:) | semmle.label | call to validateCommand(_:) |
@@ -151,8 +174,8 @@ nodes
 | CommandInjection.swift:78:43:78:43 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:78:43:78:43 | userControlledString [some:0] | semmle.label | userControlledString [some:0] |
 | CommandInjection.swift:81:6:81:6 | [post] task2 | semmle.label | [post] task2 |
-| CommandInjection.swift:81:6:81:6 | [post] task2 [arguments] | semmle.label | [post] task2 [arguments] |
-| CommandInjection.swift:81:24:81:46 | [...] | semmle.label | [...] |
+| CommandInjection.swift:81:6:81:6 | [post] task2 [arguments, Collection element] | semmle.label | [post] task2 [arguments, Collection element] |
+| CommandInjection.swift:81:24:81:46 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | CommandInjection.swift:81:31:81:31 | validatedString | semmle.label | validatedString |
 | CommandInjection.swift:99:8:99:12 | let ...? [some:0] | semmle.label | let ...? [some:0] |
 | CommandInjection.swift:99:12:99:12 | userControlledString | semmle.label | userControlledString |
@@ -164,34 +187,35 @@ nodes
 | CommandInjection.swift:114:24:114:57 | ...! | semmle.label | ...! |
 | CommandInjection.swift:114:36:114:36 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:115:2:115:2 | [post] task3 | semmle.label | [post] task3 |
-| CommandInjection.swift:115:2:115:2 | [post] task3 [arguments] | semmle.label | [post] task3 [arguments] |
-| CommandInjection.swift:115:20:115:48 | [...] | semmle.label | [...] |
+| CommandInjection.swift:115:2:115:2 | [post] task3 [arguments, Collection element] | semmle.label | [post] task3 [arguments, Collection element] |
+| CommandInjection.swift:115:20:115:48 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | CommandInjection.swift:115:28:115:28 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:119:2:119:2 | [post] task4 | semmle.label | [post] task4 |
 | CommandInjection.swift:119:2:119:2 | [post] task4 [executableURL] | semmle.label | [post] task4 [executableURL] |
 | CommandInjection.swift:119:24:119:65 | call to URL.init(fileURLWithPath:) | semmle.label | call to URL.init(fileURLWithPath:) |
 | CommandInjection.swift:119:45:119:45 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:120:2:120:2 | [post] task4 | semmle.label | [post] task4 |
-| CommandInjection.swift:120:2:120:2 | [post] task4 [arguments] | semmle.label | [post] task4 [arguments] |
-| CommandInjection.swift:120:20:120:56 | [...] | semmle.label | [...] |
+| CommandInjection.swift:120:2:120:2 | [post] task4 [arguments, Collection element] | semmle.label | [post] task4 [arguments, Collection element] |
+| CommandInjection.swift:120:20:120:56 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | CommandInjection.swift:120:28:120:36 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
 | CommandInjection.swift:124:2:124:7 | [post] ...? | semmle.label | [post] ...? |
 | CommandInjection.swift:124:2:124:7 | [post] ...? [executableURL] | semmle.label | [post] ...? [executableURL] |
 | CommandInjection.swift:124:25:124:66 | call to URL.init(fileURLWithPath:) | semmle.label | call to URL.init(fileURLWithPath:) |
 | CommandInjection.swift:124:46:124:46 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:125:2:125:7 | [post] ...? | semmle.label | [post] ...? |
-| CommandInjection.swift:125:2:125:7 | [post] ...? [arguments] | semmle.label | [post] ...? [arguments] |
-| CommandInjection.swift:125:21:125:42 | [...] | semmle.label | [...] |
+| CommandInjection.swift:125:2:125:7 | [post] ...? [arguments, Collection element] | semmle.label | [post] ...? [arguments, Collection element] |
+| CommandInjection.swift:125:21:125:42 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | CommandInjection.swift:125:22:125:22 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:130:21:130:21 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:131:22:131:22 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:132:24:132:24 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:142:42:142:42 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:143:67:143:95 | [...] | semmle.label | [...] |
+| CommandInjection.swift:143:67:143:95 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | CommandInjection.swift:143:75:143:75 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:146:23:146:55 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
 | CommandInjection.swift:146:23:146:56 | ...! | semmle.label | ...! |
 | CommandInjection.swift:146:35:146:35 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:147:62:147:90 | [...] | semmle.label | [...] |
+| CommandInjection.swift:147:62:147:90 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | CommandInjection.swift:147:70:147:70 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:152:41:152:73 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
 | CommandInjection.swift:152:41:152:74 | ...! | semmle.label | ...! |
@@ -201,48 +225,49 @@ nodes
 | CommandInjection.swift:155:40:155:73 | ...! | semmle.label | ...! |
 | CommandInjection.swift:155:52:155:52 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:156:32:156:53 | [...] | semmle.label | [...] |
+| CommandInjection.swift:156:32:156:53 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | CommandInjection.swift:156:33:156:33 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:158:45:158:77 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
 | CommandInjection.swift:158:45:158:78 | ...! | semmle.label | ...! |
 | CommandInjection.swift:158:45:158:78 | ...! | semmle.label | ...! |
 | CommandInjection.swift:158:57:158:57 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:172:3:172:3 | newValue | semmle.label | newValue |
+| CommandInjection.swift:172:3:172:3 | newValue [Collection element] | semmle.label | newValue [Collection element] |
 | CommandInjection.swift:173:4:173:4 | [post] getter for .p1 | semmle.label | [post] getter for .p1 |
-| CommandInjection.swift:173:4:173:4 | [post] getter for .p1 [arguments] | semmle.label | [post] getter for .p1 [arguments] |
-| CommandInjection.swift:173:19:173:19 | newValue | semmle.label | newValue |
+| CommandInjection.swift:173:4:173:4 | [post] getter for .p1 [arguments, Collection element] | semmle.label | [post] getter for .p1 [arguments, Collection element] |
+| CommandInjection.swift:173:19:173:19 | newValue [Collection element] | semmle.label | newValue [Collection element] |
 | CommandInjection.swift:174:4:174:6 | [post] ...! | semmle.label | [post] ...! |
-| CommandInjection.swift:174:4:174:6 | [post] ...! [arguments] | semmle.label | [post] ...! [arguments] |
-| CommandInjection.swift:174:20:174:20 | newValue | semmle.label | newValue |
+| CommandInjection.swift:174:4:174:6 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:174:20:174:20 | newValue [Collection element] | semmle.label | newValue [Collection element] |
 | CommandInjection.swift:175:4:175:4 | [post] ...! | semmle.label | [post] ...! |
-| CommandInjection.swift:175:4:175:4 | [post] ...! [arguments] | semmle.label | [post] ...! [arguments] |
-| CommandInjection.swift:175:19:175:19 | newValue | semmle.label | newValue |
+| CommandInjection.swift:175:4:175:4 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:175:19:175:19 | newValue [Collection element] | semmle.label | newValue [Collection element] |
 | CommandInjection.swift:180:9:180:13 | let ...? [some:0] | semmle.label | let ...? [some:0] |
 | CommandInjection.swift:180:13:180:13 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) | semmle.label | call to String.init(contentsOf:) |
 | CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) [some:0] | semmle.label | call to String.init(contentsOf:) [some:0] |
-| CommandInjection.swift:184:18:184:39 | [...] | semmle.label | [...] |
+| CommandInjection.swift:184:18:184:39 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | CommandInjection.swift:184:19:184:19 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:186:3:186:3 | [post] getter for .p1 | semmle.label | [post] getter for .p1 |
-| CommandInjection.swift:186:3:186:3 | [post] getter for .p1 [arguments] | semmle.label | [post] getter for .p1 [arguments] |
-| CommandInjection.swift:186:18:186:18 | tainted1 | semmle.label | tainted1 |
+| CommandInjection.swift:186:3:186:3 | [post] getter for .p1 [arguments, Collection element] | semmle.label | [post] getter for .p1 [arguments, Collection element] |
+| CommandInjection.swift:186:18:186:18 | tainted1 [Collection element] | semmle.label | tainted1 [Collection element] |
 | CommandInjection.swift:187:3:187:5 | [post] ...! | semmle.label | [post] ...! |
-| CommandInjection.swift:187:3:187:5 | [post] ...! [arguments] | semmle.label | [post] ...! [arguments] |
-| CommandInjection.swift:187:19:187:19 | tainted1 | semmle.label | tainted1 |
+| CommandInjection.swift:187:3:187:5 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:187:19:187:19 | tainted1 [Collection element] | semmle.label | tainted1 [Collection element] |
 | CommandInjection.swift:188:3:188:3 | [post] ...! | semmle.label | [post] ...! |
-| CommandInjection.swift:188:3:188:3 | [post] ...! [arguments] | semmle.label | [post] ...! [arguments] |
-| CommandInjection.swift:188:18:188:18 | tainted1 | semmle.label | tainted1 |
-| CommandInjection.swift:190:30:190:51 | [...] | semmle.label | [...] |
+| CommandInjection.swift:188:3:188:3 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:188:18:188:18 | tainted1 [Collection element] | semmle.label | tainted1 [Collection element] |
+| CommandInjection.swift:190:30:190:51 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | CommandInjection.swift:190:31:190:31 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:192:3:192:3 | [post] getter for .p1 | semmle.label | [post] getter for .p1 |
-| CommandInjection.swift:192:3:192:3 | [post] getter for .p1 [arguments] | semmle.label | [post] getter for .p1 [arguments] |
-| CommandInjection.swift:192:18:192:18 | tainted2 | semmle.label | tainted2 |
+| CommandInjection.swift:192:3:192:3 | [post] getter for .p1 [arguments, Collection element] | semmle.label | [post] getter for .p1 [arguments, Collection element] |
+| CommandInjection.swift:192:18:192:18 | tainted2 [Collection element] | semmle.label | tainted2 [Collection element] |
 | CommandInjection.swift:193:3:193:5 | [post] ...! | semmle.label | [post] ...! |
-| CommandInjection.swift:193:3:193:5 | [post] ...! [arguments] | semmle.label | [post] ...! [arguments] |
-| CommandInjection.swift:193:19:193:19 | tainted2 | semmle.label | tainted2 |
+| CommandInjection.swift:193:3:193:5 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:193:19:193:19 | tainted2 [Collection element] | semmle.label | tainted2 [Collection element] |
 | CommandInjection.swift:194:3:194:3 | [post] ...! | semmle.label | [post] ...! |
-| CommandInjection.swift:194:3:194:3 | [post] ...! [arguments] | semmle.label | [post] ...! [arguments] |
-| CommandInjection.swift:194:18:194:18 | tainted2 | semmle.label | tainted2 |
-| CommandInjection.swift:196:13:196:13 | tainted2 | semmle.label | tainted2 |
+| CommandInjection.swift:194:3:194:3 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:194:18:194:18 | tainted2 [Collection element] | semmle.label | tainted2 [Collection element] |
+| CommandInjection.swift:196:13:196:13 | tainted2 [Collection element] | semmle.label | tainted2 [Collection element] |
 | file://:0:0:0:0 | url | semmle.label | url |
 | file://:0:0:0:0 | url | semmle.label | url |
 | file://:0:0:0:0 | url | semmle.label | url |

--- a/swift/ql/test/query-tests/Security/CWE-311/CleartextStorageDatabase.expected
+++ b/swift/ql/test/query-tests/Security/CWE-311/CleartextStorageDatabase.expected
@@ -114,108 +114,108 @@ edges
 | testCoreData.swift:91:10:91:10 | passwd | testCoreData.swift:95:15:95:15 | x |
 | testCoreData.swift:92:10:92:10 | passwd | testCoreData.swift:96:15:96:15 | y |
 | testCoreData.swift:93:10:93:10 | passwd | testCoreData.swift:97:15:97:15 | z |
-| testGRDB.swift:73:56:73:65 | [...] [Array element] | testGRDB.swift:73:56:73:65 | [...] |
-| testGRDB.swift:73:57:73:57 | password | testGRDB.swift:73:56:73:65 | [...] [Array element] |
-| testGRDB.swift:76:42:76:51 | [...] [Array element] | testGRDB.swift:76:42:76:51 | [...] |
-| testGRDB.swift:76:43:76:43 | password | testGRDB.swift:76:42:76:51 | [...] [Array element] |
-| testGRDB.swift:81:44:81:53 | [...] [Array element] | testGRDB.swift:81:44:81:53 | [...] |
-| testGRDB.swift:81:45:81:45 | password | testGRDB.swift:81:44:81:53 | [...] [Array element] |
-| testGRDB.swift:83:44:83:53 | [...] [Array element] | testGRDB.swift:83:44:83:53 | [...] |
-| testGRDB.swift:83:45:83:45 | password | testGRDB.swift:83:44:83:53 | [...] [Array element] |
-| testGRDB.swift:85:44:85:53 | [...] [Array element] | testGRDB.swift:85:44:85:53 | [...] |
-| testGRDB.swift:85:45:85:45 | password | testGRDB.swift:85:44:85:53 | [...] [Array element] |
-| testGRDB.swift:87:44:87:53 | [...] [Array element] | testGRDB.swift:87:44:87:53 | [...] |
-| testGRDB.swift:87:45:87:45 | password | testGRDB.swift:87:44:87:53 | [...] [Array element] |
-| testGRDB.swift:92:37:92:46 | [...] [Array element] | testGRDB.swift:92:37:92:46 | [...] |
-| testGRDB.swift:92:38:92:38 | password | testGRDB.swift:92:37:92:46 | [...] [Array element] |
-| testGRDB.swift:95:36:95:45 | [...] [Array element] | testGRDB.swift:95:36:95:45 | [...] |
-| testGRDB.swift:95:37:95:37 | password | testGRDB.swift:95:36:95:45 | [...] [Array element] |
-| testGRDB.swift:100:72:100:81 | [...] [Array element] | testGRDB.swift:100:72:100:81 | [...] |
-| testGRDB.swift:100:73:100:73 | password | testGRDB.swift:100:72:100:81 | [...] [Array element] |
-| testGRDB.swift:101:72:101:81 | [...] [Array element] | testGRDB.swift:101:72:101:81 | [...] |
-| testGRDB.swift:101:73:101:73 | password | testGRDB.swift:101:72:101:81 | [...] [Array element] |
-| testGRDB.swift:107:52:107:61 | [...] [Array element] | testGRDB.swift:107:52:107:61 | [...] |
-| testGRDB.swift:107:53:107:53 | password | testGRDB.swift:107:52:107:61 | [...] [Array element] |
-| testGRDB.swift:109:52:109:61 | [...] [Array element] | testGRDB.swift:109:52:109:61 | [...] |
-| testGRDB.swift:109:53:109:53 | password | testGRDB.swift:109:52:109:61 | [...] [Array element] |
-| testGRDB.swift:111:51:111:60 | [...] [Array element] | testGRDB.swift:111:51:111:60 | [...] |
-| testGRDB.swift:111:52:111:52 | password | testGRDB.swift:111:51:111:60 | [...] [Array element] |
-| testGRDB.swift:116:47:116:56 | [...] [Array element] | testGRDB.swift:116:47:116:56 | [...] |
-| testGRDB.swift:116:48:116:48 | password | testGRDB.swift:116:47:116:56 | [...] [Array element] |
-| testGRDB.swift:118:47:118:56 | [...] [Array element] | testGRDB.swift:118:47:118:56 | [...] |
-| testGRDB.swift:118:48:118:48 | password | testGRDB.swift:118:47:118:56 | [...] [Array element] |
-| testGRDB.swift:121:44:121:53 | [...] [Array element] | testGRDB.swift:121:44:121:53 | [...] |
-| testGRDB.swift:121:45:121:45 | password | testGRDB.swift:121:44:121:53 | [...] [Array element] |
-| testGRDB.swift:123:44:123:53 | [...] [Array element] | testGRDB.swift:123:44:123:53 | [...] |
-| testGRDB.swift:123:45:123:45 | password | testGRDB.swift:123:44:123:53 | [...] [Array element] |
-| testGRDB.swift:126:44:126:53 | [...] [Array element] | testGRDB.swift:126:44:126:53 | [...] |
-| testGRDB.swift:126:45:126:45 | password | testGRDB.swift:126:44:126:53 | [...] [Array element] |
-| testGRDB.swift:128:44:128:53 | [...] [Array element] | testGRDB.swift:128:44:128:53 | [...] |
-| testGRDB.swift:128:45:128:45 | password | testGRDB.swift:128:44:128:53 | [...] [Array element] |
-| testGRDB.swift:131:44:131:53 | [...] [Array element] | testGRDB.swift:131:44:131:53 | [...] |
-| testGRDB.swift:131:45:131:45 | password | testGRDB.swift:131:44:131:53 | [...] [Array element] |
-| testGRDB.swift:133:44:133:53 | [...] [Array element] | testGRDB.swift:133:44:133:53 | [...] |
-| testGRDB.swift:133:45:133:45 | password | testGRDB.swift:133:44:133:53 | [...] [Array element] |
-| testGRDB.swift:138:68:138:77 | [...] [Array element] | testGRDB.swift:138:68:138:77 | [...] |
-| testGRDB.swift:138:69:138:69 | password | testGRDB.swift:138:68:138:77 | [...] [Array element] |
-| testGRDB.swift:140:68:140:77 | [...] [Array element] | testGRDB.swift:140:68:140:77 | [...] |
-| testGRDB.swift:140:69:140:69 | password | testGRDB.swift:140:68:140:77 | [...] [Array element] |
-| testGRDB.swift:143:65:143:74 | [...] [Array element] | testGRDB.swift:143:65:143:74 | [...] |
-| testGRDB.swift:143:66:143:66 | password | testGRDB.swift:143:65:143:74 | [...] [Array element] |
-| testGRDB.swift:145:65:145:74 | [...] [Array element] | testGRDB.swift:145:65:145:74 | [...] |
-| testGRDB.swift:145:66:145:66 | password | testGRDB.swift:145:65:145:74 | [...] [Array element] |
-| testGRDB.swift:148:65:148:74 | [...] [Array element] | testGRDB.swift:148:65:148:74 | [...] |
-| testGRDB.swift:148:66:148:66 | password | testGRDB.swift:148:65:148:74 | [...] [Array element] |
-| testGRDB.swift:150:65:150:74 | [...] [Array element] | testGRDB.swift:150:65:150:74 | [...] |
-| testGRDB.swift:150:66:150:66 | password | testGRDB.swift:150:65:150:74 | [...] [Array element] |
-| testGRDB.swift:153:65:153:74 | [...] [Array element] | testGRDB.swift:153:65:153:74 | [...] |
-| testGRDB.swift:153:66:153:66 | password | testGRDB.swift:153:65:153:74 | [...] [Array element] |
-| testGRDB.swift:155:65:155:74 | [...] [Array element] | testGRDB.swift:155:65:155:74 | [...] |
-| testGRDB.swift:155:66:155:66 | password | testGRDB.swift:155:65:155:74 | [...] [Array element] |
-| testGRDB.swift:160:59:160:68 | [...] [Array element] | testGRDB.swift:160:59:160:68 | [...] |
-| testGRDB.swift:160:60:160:60 | password | testGRDB.swift:160:59:160:68 | [...] [Array element] |
-| testGRDB.swift:161:50:161:59 | [...] [Array element] | testGRDB.swift:161:50:161:59 | [...] |
-| testGRDB.swift:161:51:161:51 | password | testGRDB.swift:161:50:161:59 | [...] [Array element] |
-| testGRDB.swift:164:59:164:68 | [...] [Array element] | testGRDB.swift:164:59:164:68 | [...] |
-| testGRDB.swift:164:60:164:60 | password | testGRDB.swift:164:59:164:68 | [...] [Array element] |
-| testGRDB.swift:165:50:165:59 | [...] [Array element] | testGRDB.swift:165:50:165:59 | [...] |
-| testGRDB.swift:165:51:165:51 | password | testGRDB.swift:165:50:165:59 | [...] [Array element] |
-| testGRDB.swift:169:56:169:65 | [...] [Array element] | testGRDB.swift:169:56:169:65 | [...] |
-| testGRDB.swift:169:57:169:57 | password | testGRDB.swift:169:56:169:65 | [...] [Array element] |
-| testGRDB.swift:170:47:170:56 | [...] [Array element] | testGRDB.swift:170:47:170:56 | [...] |
-| testGRDB.swift:170:48:170:48 | password | testGRDB.swift:170:47:170:56 | [...] [Array element] |
-| testGRDB.swift:173:56:173:65 | [...] [Array element] | testGRDB.swift:173:56:173:65 | [...] |
-| testGRDB.swift:173:57:173:57 | password | testGRDB.swift:173:56:173:65 | [...] [Array element] |
-| testGRDB.swift:174:47:174:56 | [...] [Array element] | testGRDB.swift:174:47:174:56 | [...] |
-| testGRDB.swift:174:48:174:48 | password | testGRDB.swift:174:47:174:56 | [...] [Array element] |
-| testGRDB.swift:178:56:178:65 | [...] [Array element] | testGRDB.swift:178:56:178:65 | [...] |
-| testGRDB.swift:178:57:178:57 | password | testGRDB.swift:178:56:178:65 | [...] [Array element] |
-| testGRDB.swift:179:47:179:56 | [...] [Array element] | testGRDB.swift:179:47:179:56 | [...] |
-| testGRDB.swift:179:48:179:48 | password | testGRDB.swift:179:47:179:56 | [...] [Array element] |
-| testGRDB.swift:182:56:182:65 | [...] [Array element] | testGRDB.swift:182:56:182:65 | [...] |
-| testGRDB.swift:182:57:182:57 | password | testGRDB.swift:182:56:182:65 | [...] [Array element] |
-| testGRDB.swift:183:47:183:56 | [...] [Array element] | testGRDB.swift:183:47:183:56 | [...] |
-| testGRDB.swift:183:48:183:48 | password | testGRDB.swift:183:47:183:56 | [...] [Array element] |
-| testGRDB.swift:187:56:187:65 | [...] [Array element] | testGRDB.swift:187:56:187:65 | [...] |
-| testGRDB.swift:187:57:187:57 | password | testGRDB.swift:187:56:187:65 | [...] [Array element] |
-| testGRDB.swift:188:47:188:56 | [...] [Array element] | testGRDB.swift:188:47:188:56 | [...] |
-| testGRDB.swift:188:48:188:48 | password | testGRDB.swift:188:47:188:56 | [...] [Array element] |
-| testGRDB.swift:191:56:191:65 | [...] [Array element] | testGRDB.swift:191:56:191:65 | [...] |
-| testGRDB.swift:191:57:191:57 | password | testGRDB.swift:191:56:191:65 | [...] [Array element] |
-| testGRDB.swift:192:47:192:56 | [...] [Array element] | testGRDB.swift:192:47:192:56 | [...] |
-| testGRDB.swift:192:48:192:48 | password | testGRDB.swift:192:47:192:56 | [...] [Array element] |
-| testGRDB.swift:198:29:198:38 | [...] [Array element] | testGRDB.swift:198:29:198:38 | [...] |
-| testGRDB.swift:198:30:198:30 | password | testGRDB.swift:198:29:198:38 | [...] [Array element] |
-| testGRDB.swift:201:23:201:32 | [...] [Array element] | testGRDB.swift:201:23:201:32 | [...] |
-| testGRDB.swift:201:24:201:24 | password | testGRDB.swift:201:23:201:32 | [...] [Array element] |
-| testGRDB.swift:206:66:206:75 | [...] [Array element] | testGRDB.swift:206:66:206:75 | [...] |
-| testGRDB.swift:206:67:206:67 | password | testGRDB.swift:206:66:206:75 | [...] [Array element] |
-| testGRDB.swift:208:80:208:89 | [...] [Array element] | testGRDB.swift:208:80:208:89 | [...] |
-| testGRDB.swift:208:81:208:81 | password | testGRDB.swift:208:80:208:89 | [...] [Array element] |
-| testGRDB.swift:210:84:210:93 | [...] [Array element] | testGRDB.swift:210:84:210:93 | [...] |
-| testGRDB.swift:210:85:210:85 | password | testGRDB.swift:210:84:210:93 | [...] [Array element] |
-| testGRDB.swift:212:98:212:107 | [...] [Array element] | testGRDB.swift:212:98:212:107 | [...] |
-| testGRDB.swift:212:99:212:99 | password | testGRDB.swift:212:98:212:107 | [...] [Array element] |
+| testGRDB.swift:73:56:73:65 | [...] [Collection element] | testGRDB.swift:73:56:73:65 | [...] |
+| testGRDB.swift:73:57:73:57 | password | testGRDB.swift:73:56:73:65 | [...] [Collection element] |
+| testGRDB.swift:76:42:76:51 | [...] [Collection element] | testGRDB.swift:76:42:76:51 | [...] |
+| testGRDB.swift:76:43:76:43 | password | testGRDB.swift:76:42:76:51 | [...] [Collection element] |
+| testGRDB.swift:81:44:81:53 | [...] [Collection element] | testGRDB.swift:81:44:81:53 | [...] |
+| testGRDB.swift:81:45:81:45 | password | testGRDB.swift:81:44:81:53 | [...] [Collection element] |
+| testGRDB.swift:83:44:83:53 | [...] [Collection element] | testGRDB.swift:83:44:83:53 | [...] |
+| testGRDB.swift:83:45:83:45 | password | testGRDB.swift:83:44:83:53 | [...] [Collection element] |
+| testGRDB.swift:85:44:85:53 | [...] [Collection element] | testGRDB.swift:85:44:85:53 | [...] |
+| testGRDB.swift:85:45:85:45 | password | testGRDB.swift:85:44:85:53 | [...] [Collection element] |
+| testGRDB.swift:87:44:87:53 | [...] [Collection element] | testGRDB.swift:87:44:87:53 | [...] |
+| testGRDB.swift:87:45:87:45 | password | testGRDB.swift:87:44:87:53 | [...] [Collection element] |
+| testGRDB.swift:92:37:92:46 | [...] [Collection element] | testGRDB.swift:92:37:92:46 | [...] |
+| testGRDB.swift:92:38:92:38 | password | testGRDB.swift:92:37:92:46 | [...] [Collection element] |
+| testGRDB.swift:95:36:95:45 | [...] [Collection element] | testGRDB.swift:95:36:95:45 | [...] |
+| testGRDB.swift:95:37:95:37 | password | testGRDB.swift:95:36:95:45 | [...] [Collection element] |
+| testGRDB.swift:100:72:100:81 | [...] [Collection element] | testGRDB.swift:100:72:100:81 | [...] |
+| testGRDB.swift:100:73:100:73 | password | testGRDB.swift:100:72:100:81 | [...] [Collection element] |
+| testGRDB.swift:101:72:101:81 | [...] [Collection element] | testGRDB.swift:101:72:101:81 | [...] |
+| testGRDB.swift:101:73:101:73 | password | testGRDB.swift:101:72:101:81 | [...] [Collection element] |
+| testGRDB.swift:107:52:107:61 | [...] [Collection element] | testGRDB.swift:107:52:107:61 | [...] |
+| testGRDB.swift:107:53:107:53 | password | testGRDB.swift:107:52:107:61 | [...] [Collection element] |
+| testGRDB.swift:109:52:109:61 | [...] [Collection element] | testGRDB.swift:109:52:109:61 | [...] |
+| testGRDB.swift:109:53:109:53 | password | testGRDB.swift:109:52:109:61 | [...] [Collection element] |
+| testGRDB.swift:111:51:111:60 | [...] [Collection element] | testGRDB.swift:111:51:111:60 | [...] |
+| testGRDB.swift:111:52:111:52 | password | testGRDB.swift:111:51:111:60 | [...] [Collection element] |
+| testGRDB.swift:116:47:116:56 | [...] [Collection element] | testGRDB.swift:116:47:116:56 | [...] |
+| testGRDB.swift:116:48:116:48 | password | testGRDB.swift:116:47:116:56 | [...] [Collection element] |
+| testGRDB.swift:118:47:118:56 | [...] [Collection element] | testGRDB.swift:118:47:118:56 | [...] |
+| testGRDB.swift:118:48:118:48 | password | testGRDB.swift:118:47:118:56 | [...] [Collection element] |
+| testGRDB.swift:121:44:121:53 | [...] [Collection element] | testGRDB.swift:121:44:121:53 | [...] |
+| testGRDB.swift:121:45:121:45 | password | testGRDB.swift:121:44:121:53 | [...] [Collection element] |
+| testGRDB.swift:123:44:123:53 | [...] [Collection element] | testGRDB.swift:123:44:123:53 | [...] |
+| testGRDB.swift:123:45:123:45 | password | testGRDB.swift:123:44:123:53 | [...] [Collection element] |
+| testGRDB.swift:126:44:126:53 | [...] [Collection element] | testGRDB.swift:126:44:126:53 | [...] |
+| testGRDB.swift:126:45:126:45 | password | testGRDB.swift:126:44:126:53 | [...] [Collection element] |
+| testGRDB.swift:128:44:128:53 | [...] [Collection element] | testGRDB.swift:128:44:128:53 | [...] |
+| testGRDB.swift:128:45:128:45 | password | testGRDB.swift:128:44:128:53 | [...] [Collection element] |
+| testGRDB.swift:131:44:131:53 | [...] [Collection element] | testGRDB.swift:131:44:131:53 | [...] |
+| testGRDB.swift:131:45:131:45 | password | testGRDB.swift:131:44:131:53 | [...] [Collection element] |
+| testGRDB.swift:133:44:133:53 | [...] [Collection element] | testGRDB.swift:133:44:133:53 | [...] |
+| testGRDB.swift:133:45:133:45 | password | testGRDB.swift:133:44:133:53 | [...] [Collection element] |
+| testGRDB.swift:138:68:138:77 | [...] [Collection element] | testGRDB.swift:138:68:138:77 | [...] |
+| testGRDB.swift:138:69:138:69 | password | testGRDB.swift:138:68:138:77 | [...] [Collection element] |
+| testGRDB.swift:140:68:140:77 | [...] [Collection element] | testGRDB.swift:140:68:140:77 | [...] |
+| testGRDB.swift:140:69:140:69 | password | testGRDB.swift:140:68:140:77 | [...] [Collection element] |
+| testGRDB.swift:143:65:143:74 | [...] [Collection element] | testGRDB.swift:143:65:143:74 | [...] |
+| testGRDB.swift:143:66:143:66 | password | testGRDB.swift:143:65:143:74 | [...] [Collection element] |
+| testGRDB.swift:145:65:145:74 | [...] [Collection element] | testGRDB.swift:145:65:145:74 | [...] |
+| testGRDB.swift:145:66:145:66 | password | testGRDB.swift:145:65:145:74 | [...] [Collection element] |
+| testGRDB.swift:148:65:148:74 | [...] [Collection element] | testGRDB.swift:148:65:148:74 | [...] |
+| testGRDB.swift:148:66:148:66 | password | testGRDB.swift:148:65:148:74 | [...] [Collection element] |
+| testGRDB.swift:150:65:150:74 | [...] [Collection element] | testGRDB.swift:150:65:150:74 | [...] |
+| testGRDB.swift:150:66:150:66 | password | testGRDB.swift:150:65:150:74 | [...] [Collection element] |
+| testGRDB.swift:153:65:153:74 | [...] [Collection element] | testGRDB.swift:153:65:153:74 | [...] |
+| testGRDB.swift:153:66:153:66 | password | testGRDB.swift:153:65:153:74 | [...] [Collection element] |
+| testGRDB.swift:155:65:155:74 | [...] [Collection element] | testGRDB.swift:155:65:155:74 | [...] |
+| testGRDB.swift:155:66:155:66 | password | testGRDB.swift:155:65:155:74 | [...] [Collection element] |
+| testGRDB.swift:160:59:160:68 | [...] [Collection element] | testGRDB.swift:160:59:160:68 | [...] |
+| testGRDB.swift:160:60:160:60 | password | testGRDB.swift:160:59:160:68 | [...] [Collection element] |
+| testGRDB.swift:161:50:161:59 | [...] [Collection element] | testGRDB.swift:161:50:161:59 | [...] |
+| testGRDB.swift:161:51:161:51 | password | testGRDB.swift:161:50:161:59 | [...] [Collection element] |
+| testGRDB.swift:164:59:164:68 | [...] [Collection element] | testGRDB.swift:164:59:164:68 | [...] |
+| testGRDB.swift:164:60:164:60 | password | testGRDB.swift:164:59:164:68 | [...] [Collection element] |
+| testGRDB.swift:165:50:165:59 | [...] [Collection element] | testGRDB.swift:165:50:165:59 | [...] |
+| testGRDB.swift:165:51:165:51 | password | testGRDB.swift:165:50:165:59 | [...] [Collection element] |
+| testGRDB.swift:169:56:169:65 | [...] [Collection element] | testGRDB.swift:169:56:169:65 | [...] |
+| testGRDB.swift:169:57:169:57 | password | testGRDB.swift:169:56:169:65 | [...] [Collection element] |
+| testGRDB.swift:170:47:170:56 | [...] [Collection element] | testGRDB.swift:170:47:170:56 | [...] |
+| testGRDB.swift:170:48:170:48 | password | testGRDB.swift:170:47:170:56 | [...] [Collection element] |
+| testGRDB.swift:173:56:173:65 | [...] [Collection element] | testGRDB.swift:173:56:173:65 | [...] |
+| testGRDB.swift:173:57:173:57 | password | testGRDB.swift:173:56:173:65 | [...] [Collection element] |
+| testGRDB.swift:174:47:174:56 | [...] [Collection element] | testGRDB.swift:174:47:174:56 | [...] |
+| testGRDB.swift:174:48:174:48 | password | testGRDB.swift:174:47:174:56 | [...] [Collection element] |
+| testGRDB.swift:178:56:178:65 | [...] [Collection element] | testGRDB.swift:178:56:178:65 | [...] |
+| testGRDB.swift:178:57:178:57 | password | testGRDB.swift:178:56:178:65 | [...] [Collection element] |
+| testGRDB.swift:179:47:179:56 | [...] [Collection element] | testGRDB.swift:179:47:179:56 | [...] |
+| testGRDB.swift:179:48:179:48 | password | testGRDB.swift:179:47:179:56 | [...] [Collection element] |
+| testGRDB.swift:182:56:182:65 | [...] [Collection element] | testGRDB.swift:182:56:182:65 | [...] |
+| testGRDB.swift:182:57:182:57 | password | testGRDB.swift:182:56:182:65 | [...] [Collection element] |
+| testGRDB.swift:183:47:183:56 | [...] [Collection element] | testGRDB.swift:183:47:183:56 | [...] |
+| testGRDB.swift:183:48:183:48 | password | testGRDB.swift:183:47:183:56 | [...] [Collection element] |
+| testGRDB.swift:187:56:187:65 | [...] [Collection element] | testGRDB.swift:187:56:187:65 | [...] |
+| testGRDB.swift:187:57:187:57 | password | testGRDB.swift:187:56:187:65 | [...] [Collection element] |
+| testGRDB.swift:188:47:188:56 | [...] [Collection element] | testGRDB.swift:188:47:188:56 | [...] |
+| testGRDB.swift:188:48:188:48 | password | testGRDB.swift:188:47:188:56 | [...] [Collection element] |
+| testGRDB.swift:191:56:191:65 | [...] [Collection element] | testGRDB.swift:191:56:191:65 | [...] |
+| testGRDB.swift:191:57:191:57 | password | testGRDB.swift:191:56:191:65 | [...] [Collection element] |
+| testGRDB.swift:192:47:192:56 | [...] [Collection element] | testGRDB.swift:192:47:192:56 | [...] |
+| testGRDB.swift:192:48:192:48 | password | testGRDB.swift:192:47:192:56 | [...] [Collection element] |
+| testGRDB.swift:198:29:198:38 | [...] [Collection element] | testGRDB.swift:198:29:198:38 | [...] |
+| testGRDB.swift:198:30:198:30 | password | testGRDB.swift:198:29:198:38 | [...] [Collection element] |
+| testGRDB.swift:201:23:201:32 | [...] [Collection element] | testGRDB.swift:201:23:201:32 | [...] |
+| testGRDB.swift:201:24:201:24 | password | testGRDB.swift:201:23:201:32 | [...] [Collection element] |
+| testGRDB.swift:206:66:206:75 | [...] [Collection element] | testGRDB.swift:206:66:206:75 | [...] |
+| testGRDB.swift:206:67:206:67 | password | testGRDB.swift:206:66:206:75 | [...] [Collection element] |
+| testGRDB.swift:208:80:208:89 | [...] [Collection element] | testGRDB.swift:208:80:208:89 | [...] |
+| testGRDB.swift:208:81:208:81 | password | testGRDB.swift:208:80:208:89 | [...] [Collection element] |
+| testGRDB.swift:210:84:210:93 | [...] [Collection element] | testGRDB.swift:210:84:210:93 | [...] |
+| testGRDB.swift:210:85:210:85 | password | testGRDB.swift:210:84:210:93 | [...] [Collection element] |
+| testGRDB.swift:212:98:212:107 | [...] [Collection element] | testGRDB.swift:212:98:212:107 | [...] |
+| testGRDB.swift:212:99:212:99 | password | testGRDB.swift:212:98:212:107 | [...] [Collection element] |
 | testRealm.swift:27:6:27:6 | value | file://:0:0:0:0 | value |
 | testRealm.swift:34:6:34:6 | value | file://:0:0:0:0 | value |
 | testRealm.swift:41:2:41:2 | [post] a [data] | testRealm.swift:41:2:41:2 | [post] a |
@@ -377,157 +377,157 @@ nodes
 | testCoreData.swift:96:15:96:15 | y | semmle.label | y |
 | testCoreData.swift:97:15:97:15 | z | semmle.label | z |
 | testGRDB.swift:73:56:73:65 | [...] | semmle.label | [...] |
-| testGRDB.swift:73:56:73:65 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:73:56:73:65 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:73:57:73:57 | password | semmle.label | password |
 | testGRDB.swift:76:42:76:51 | [...] | semmle.label | [...] |
-| testGRDB.swift:76:42:76:51 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:76:42:76:51 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:76:43:76:43 | password | semmle.label | password |
 | testGRDB.swift:81:44:81:53 | [...] | semmle.label | [...] |
-| testGRDB.swift:81:44:81:53 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:81:44:81:53 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:81:45:81:45 | password | semmle.label | password |
 | testGRDB.swift:83:44:83:53 | [...] | semmle.label | [...] |
-| testGRDB.swift:83:44:83:53 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:83:44:83:53 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:83:45:83:45 | password | semmle.label | password |
 | testGRDB.swift:85:44:85:53 | [...] | semmle.label | [...] |
-| testGRDB.swift:85:44:85:53 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:85:44:85:53 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:85:45:85:45 | password | semmle.label | password |
 | testGRDB.swift:87:44:87:53 | [...] | semmle.label | [...] |
-| testGRDB.swift:87:44:87:53 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:87:44:87:53 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:87:45:87:45 | password | semmle.label | password |
 | testGRDB.swift:92:37:92:46 | [...] | semmle.label | [...] |
-| testGRDB.swift:92:37:92:46 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:92:37:92:46 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:92:38:92:38 | password | semmle.label | password |
 | testGRDB.swift:95:36:95:45 | [...] | semmle.label | [...] |
-| testGRDB.swift:95:36:95:45 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:95:36:95:45 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:95:37:95:37 | password | semmle.label | password |
 | testGRDB.swift:100:72:100:81 | [...] | semmle.label | [...] |
-| testGRDB.swift:100:72:100:81 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:100:72:100:81 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:100:73:100:73 | password | semmle.label | password |
 | testGRDB.swift:101:72:101:81 | [...] | semmle.label | [...] |
-| testGRDB.swift:101:72:101:81 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:101:72:101:81 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:101:73:101:73 | password | semmle.label | password |
 | testGRDB.swift:107:52:107:61 | [...] | semmle.label | [...] |
-| testGRDB.swift:107:52:107:61 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:107:52:107:61 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:107:53:107:53 | password | semmle.label | password |
 | testGRDB.swift:109:52:109:61 | [...] | semmle.label | [...] |
-| testGRDB.swift:109:52:109:61 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:109:52:109:61 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:109:53:109:53 | password | semmle.label | password |
 | testGRDB.swift:111:51:111:60 | [...] | semmle.label | [...] |
-| testGRDB.swift:111:51:111:60 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:111:51:111:60 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:111:52:111:52 | password | semmle.label | password |
 | testGRDB.swift:116:47:116:56 | [...] | semmle.label | [...] |
-| testGRDB.swift:116:47:116:56 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:116:47:116:56 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:116:48:116:48 | password | semmle.label | password |
 | testGRDB.swift:118:47:118:56 | [...] | semmle.label | [...] |
-| testGRDB.swift:118:47:118:56 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:118:47:118:56 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:118:48:118:48 | password | semmle.label | password |
 | testGRDB.swift:121:44:121:53 | [...] | semmle.label | [...] |
-| testGRDB.swift:121:44:121:53 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:121:44:121:53 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:121:45:121:45 | password | semmle.label | password |
 | testGRDB.swift:123:44:123:53 | [...] | semmle.label | [...] |
-| testGRDB.swift:123:44:123:53 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:123:44:123:53 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:123:45:123:45 | password | semmle.label | password |
 | testGRDB.swift:126:44:126:53 | [...] | semmle.label | [...] |
-| testGRDB.swift:126:44:126:53 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:126:44:126:53 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:126:45:126:45 | password | semmle.label | password |
 | testGRDB.swift:128:44:128:53 | [...] | semmle.label | [...] |
-| testGRDB.swift:128:44:128:53 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:128:44:128:53 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:128:45:128:45 | password | semmle.label | password |
 | testGRDB.swift:131:44:131:53 | [...] | semmle.label | [...] |
-| testGRDB.swift:131:44:131:53 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:131:44:131:53 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:131:45:131:45 | password | semmle.label | password |
 | testGRDB.swift:133:44:133:53 | [...] | semmle.label | [...] |
-| testGRDB.swift:133:44:133:53 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:133:44:133:53 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:133:45:133:45 | password | semmle.label | password |
 | testGRDB.swift:138:68:138:77 | [...] | semmle.label | [...] |
-| testGRDB.swift:138:68:138:77 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:138:68:138:77 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:138:69:138:69 | password | semmle.label | password |
 | testGRDB.swift:140:68:140:77 | [...] | semmle.label | [...] |
-| testGRDB.swift:140:68:140:77 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:140:68:140:77 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:140:69:140:69 | password | semmle.label | password |
 | testGRDB.swift:143:65:143:74 | [...] | semmle.label | [...] |
-| testGRDB.swift:143:65:143:74 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:143:65:143:74 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:143:66:143:66 | password | semmle.label | password |
 | testGRDB.swift:145:65:145:74 | [...] | semmle.label | [...] |
-| testGRDB.swift:145:65:145:74 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:145:65:145:74 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:145:66:145:66 | password | semmle.label | password |
 | testGRDB.swift:148:65:148:74 | [...] | semmle.label | [...] |
-| testGRDB.swift:148:65:148:74 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:148:65:148:74 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:148:66:148:66 | password | semmle.label | password |
 | testGRDB.swift:150:65:150:74 | [...] | semmle.label | [...] |
-| testGRDB.swift:150:65:150:74 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:150:65:150:74 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:150:66:150:66 | password | semmle.label | password |
 | testGRDB.swift:153:65:153:74 | [...] | semmle.label | [...] |
-| testGRDB.swift:153:65:153:74 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:153:65:153:74 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:153:66:153:66 | password | semmle.label | password |
 | testGRDB.swift:155:65:155:74 | [...] | semmle.label | [...] |
-| testGRDB.swift:155:65:155:74 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:155:65:155:74 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:155:66:155:66 | password | semmle.label | password |
 | testGRDB.swift:160:59:160:68 | [...] | semmle.label | [...] |
-| testGRDB.swift:160:59:160:68 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:160:59:160:68 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:160:60:160:60 | password | semmle.label | password |
 | testGRDB.swift:161:50:161:59 | [...] | semmle.label | [...] |
-| testGRDB.swift:161:50:161:59 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:161:50:161:59 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:161:51:161:51 | password | semmle.label | password |
 | testGRDB.swift:164:59:164:68 | [...] | semmle.label | [...] |
-| testGRDB.swift:164:59:164:68 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:164:59:164:68 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:164:60:164:60 | password | semmle.label | password |
 | testGRDB.swift:165:50:165:59 | [...] | semmle.label | [...] |
-| testGRDB.swift:165:50:165:59 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:165:50:165:59 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:165:51:165:51 | password | semmle.label | password |
 | testGRDB.swift:169:56:169:65 | [...] | semmle.label | [...] |
-| testGRDB.swift:169:56:169:65 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:169:56:169:65 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:169:57:169:57 | password | semmle.label | password |
 | testGRDB.swift:170:47:170:56 | [...] | semmle.label | [...] |
-| testGRDB.swift:170:47:170:56 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:170:47:170:56 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:170:48:170:48 | password | semmle.label | password |
 | testGRDB.swift:173:56:173:65 | [...] | semmle.label | [...] |
-| testGRDB.swift:173:56:173:65 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:173:56:173:65 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:173:57:173:57 | password | semmle.label | password |
 | testGRDB.swift:174:47:174:56 | [...] | semmle.label | [...] |
-| testGRDB.swift:174:47:174:56 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:174:47:174:56 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:174:48:174:48 | password | semmle.label | password |
 | testGRDB.swift:178:56:178:65 | [...] | semmle.label | [...] |
-| testGRDB.swift:178:56:178:65 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:178:56:178:65 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:178:57:178:57 | password | semmle.label | password |
 | testGRDB.swift:179:47:179:56 | [...] | semmle.label | [...] |
-| testGRDB.swift:179:47:179:56 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:179:47:179:56 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:179:48:179:48 | password | semmle.label | password |
 | testGRDB.swift:182:56:182:65 | [...] | semmle.label | [...] |
-| testGRDB.swift:182:56:182:65 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:182:56:182:65 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:182:57:182:57 | password | semmle.label | password |
 | testGRDB.swift:183:47:183:56 | [...] | semmle.label | [...] |
-| testGRDB.swift:183:47:183:56 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:183:47:183:56 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:183:48:183:48 | password | semmle.label | password |
 | testGRDB.swift:187:56:187:65 | [...] | semmle.label | [...] |
-| testGRDB.swift:187:56:187:65 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:187:56:187:65 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:187:57:187:57 | password | semmle.label | password |
 | testGRDB.swift:188:47:188:56 | [...] | semmle.label | [...] |
-| testGRDB.swift:188:47:188:56 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:188:47:188:56 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:188:48:188:48 | password | semmle.label | password |
 | testGRDB.swift:191:56:191:65 | [...] | semmle.label | [...] |
-| testGRDB.swift:191:56:191:65 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:191:56:191:65 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:191:57:191:57 | password | semmle.label | password |
 | testGRDB.swift:192:47:192:56 | [...] | semmle.label | [...] |
-| testGRDB.swift:192:47:192:56 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:192:47:192:56 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:192:48:192:48 | password | semmle.label | password |
 | testGRDB.swift:198:29:198:38 | [...] | semmle.label | [...] |
-| testGRDB.swift:198:29:198:38 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:198:29:198:38 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:198:30:198:30 | password | semmle.label | password |
 | testGRDB.swift:201:23:201:32 | [...] | semmle.label | [...] |
-| testGRDB.swift:201:23:201:32 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:201:23:201:32 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:201:24:201:24 | password | semmle.label | password |
 | testGRDB.swift:206:66:206:75 | [...] | semmle.label | [...] |
-| testGRDB.swift:206:66:206:75 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:206:66:206:75 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:206:67:206:67 | password | semmle.label | password |
 | testGRDB.swift:208:80:208:89 | [...] | semmle.label | [...] |
-| testGRDB.swift:208:80:208:89 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:208:80:208:89 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:208:81:208:81 | password | semmle.label | password |
 | testGRDB.swift:210:84:210:93 | [...] | semmle.label | [...] |
-| testGRDB.swift:210:84:210:93 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:210:84:210:93 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:210:85:210:85 | password | semmle.label | password |
 | testGRDB.swift:212:98:212:107 | [...] | semmle.label | [...] |
-| testGRDB.swift:212:98:212:107 | [...] [Array element] | semmle.label | [...] [Array element] |
+| testGRDB.swift:212:98:212:107 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:212:99:212:99 | password | semmle.label | password |
 | testRealm.swift:27:6:27:6 | value | semmle.label | value |
 | testRealm.swift:34:6:34:6 | value | semmle.label | value |

--- a/swift/ql/test/query-tests/Security/CWE-311/CleartextStorageDatabase.expected
+++ b/swift/ql/test/query-tests/Security/CWE-311/CleartextStorageDatabase.expected
@@ -114,57 +114,108 @@ edges
 | testCoreData.swift:91:10:91:10 | passwd | testCoreData.swift:95:15:95:15 | x |
 | testCoreData.swift:92:10:92:10 | passwd | testCoreData.swift:96:15:96:15 | y |
 | testCoreData.swift:93:10:93:10 | passwd | testCoreData.swift:97:15:97:15 | z |
-| testGRDB.swift:73:57:73:57 | password | testGRDB.swift:73:56:73:65 | [...] |
-| testGRDB.swift:76:43:76:43 | password | testGRDB.swift:76:42:76:51 | [...] |
-| testGRDB.swift:81:45:81:45 | password | testGRDB.swift:81:44:81:53 | [...] |
-| testGRDB.swift:83:45:83:45 | password | testGRDB.swift:83:44:83:53 | [...] |
-| testGRDB.swift:85:45:85:45 | password | testGRDB.swift:85:44:85:53 | [...] |
-| testGRDB.swift:87:45:87:45 | password | testGRDB.swift:87:44:87:53 | [...] |
-| testGRDB.swift:92:38:92:38 | password | testGRDB.swift:92:37:92:46 | [...] |
-| testGRDB.swift:95:37:95:37 | password | testGRDB.swift:95:36:95:45 | [...] |
-| testGRDB.swift:100:73:100:73 | password | testGRDB.swift:100:72:100:81 | [...] |
-| testGRDB.swift:101:73:101:73 | password | testGRDB.swift:101:72:101:81 | [...] |
-| testGRDB.swift:107:53:107:53 | password | testGRDB.swift:107:52:107:61 | [...] |
-| testGRDB.swift:109:53:109:53 | password | testGRDB.swift:109:52:109:61 | [...] |
-| testGRDB.swift:111:52:111:52 | password | testGRDB.swift:111:51:111:60 | [...] |
-| testGRDB.swift:116:48:116:48 | password | testGRDB.swift:116:47:116:56 | [...] |
-| testGRDB.swift:118:48:118:48 | password | testGRDB.swift:118:47:118:56 | [...] |
-| testGRDB.swift:121:45:121:45 | password | testGRDB.swift:121:44:121:53 | [...] |
-| testGRDB.swift:123:45:123:45 | password | testGRDB.swift:123:44:123:53 | [...] |
-| testGRDB.swift:126:45:126:45 | password | testGRDB.swift:126:44:126:53 | [...] |
-| testGRDB.swift:128:45:128:45 | password | testGRDB.swift:128:44:128:53 | [...] |
-| testGRDB.swift:131:45:131:45 | password | testGRDB.swift:131:44:131:53 | [...] |
-| testGRDB.swift:133:45:133:45 | password | testGRDB.swift:133:44:133:53 | [...] |
-| testGRDB.swift:138:69:138:69 | password | testGRDB.swift:138:68:138:77 | [...] |
-| testGRDB.swift:140:69:140:69 | password | testGRDB.swift:140:68:140:77 | [...] |
-| testGRDB.swift:143:66:143:66 | password | testGRDB.swift:143:65:143:74 | [...] |
-| testGRDB.swift:145:66:145:66 | password | testGRDB.swift:145:65:145:74 | [...] |
-| testGRDB.swift:148:66:148:66 | password | testGRDB.swift:148:65:148:74 | [...] |
-| testGRDB.swift:150:66:150:66 | password | testGRDB.swift:150:65:150:74 | [...] |
-| testGRDB.swift:153:66:153:66 | password | testGRDB.swift:153:65:153:74 | [...] |
-| testGRDB.swift:155:66:155:66 | password | testGRDB.swift:155:65:155:74 | [...] |
-| testGRDB.swift:160:60:160:60 | password | testGRDB.swift:160:59:160:68 | [...] |
-| testGRDB.swift:161:51:161:51 | password | testGRDB.swift:161:50:161:59 | [...] |
-| testGRDB.swift:164:60:164:60 | password | testGRDB.swift:164:59:164:68 | [...] |
-| testGRDB.swift:165:51:165:51 | password | testGRDB.swift:165:50:165:59 | [...] |
-| testGRDB.swift:169:57:169:57 | password | testGRDB.swift:169:56:169:65 | [...] |
-| testGRDB.swift:170:48:170:48 | password | testGRDB.swift:170:47:170:56 | [...] |
-| testGRDB.swift:173:57:173:57 | password | testGRDB.swift:173:56:173:65 | [...] |
-| testGRDB.swift:174:48:174:48 | password | testGRDB.swift:174:47:174:56 | [...] |
-| testGRDB.swift:178:57:178:57 | password | testGRDB.swift:178:56:178:65 | [...] |
-| testGRDB.swift:179:48:179:48 | password | testGRDB.swift:179:47:179:56 | [...] |
-| testGRDB.swift:182:57:182:57 | password | testGRDB.swift:182:56:182:65 | [...] |
-| testGRDB.swift:183:48:183:48 | password | testGRDB.swift:183:47:183:56 | [...] |
-| testGRDB.swift:187:57:187:57 | password | testGRDB.swift:187:56:187:65 | [...] |
-| testGRDB.swift:188:48:188:48 | password | testGRDB.swift:188:47:188:56 | [...] |
-| testGRDB.swift:191:57:191:57 | password | testGRDB.swift:191:56:191:65 | [...] |
-| testGRDB.swift:192:48:192:48 | password | testGRDB.swift:192:47:192:56 | [...] |
-| testGRDB.swift:198:30:198:30 | password | testGRDB.swift:198:29:198:38 | [...] |
-| testGRDB.swift:201:24:201:24 | password | testGRDB.swift:201:23:201:32 | [...] |
-| testGRDB.swift:206:67:206:67 | password | testGRDB.swift:206:66:206:75 | [...] |
-| testGRDB.swift:208:81:208:81 | password | testGRDB.swift:208:80:208:89 | [...] |
-| testGRDB.swift:210:85:210:85 | password | testGRDB.swift:210:84:210:93 | [...] |
-| testGRDB.swift:212:99:212:99 | password | testGRDB.swift:212:98:212:107 | [...] |
+| testGRDB.swift:73:56:73:65 | [...] [Array element] | testGRDB.swift:73:56:73:65 | [...] |
+| testGRDB.swift:73:57:73:57 | password | testGRDB.swift:73:56:73:65 | [...] [Array element] |
+| testGRDB.swift:76:42:76:51 | [...] [Array element] | testGRDB.swift:76:42:76:51 | [...] |
+| testGRDB.swift:76:43:76:43 | password | testGRDB.swift:76:42:76:51 | [...] [Array element] |
+| testGRDB.swift:81:44:81:53 | [...] [Array element] | testGRDB.swift:81:44:81:53 | [...] |
+| testGRDB.swift:81:45:81:45 | password | testGRDB.swift:81:44:81:53 | [...] [Array element] |
+| testGRDB.swift:83:44:83:53 | [...] [Array element] | testGRDB.swift:83:44:83:53 | [...] |
+| testGRDB.swift:83:45:83:45 | password | testGRDB.swift:83:44:83:53 | [...] [Array element] |
+| testGRDB.swift:85:44:85:53 | [...] [Array element] | testGRDB.swift:85:44:85:53 | [...] |
+| testGRDB.swift:85:45:85:45 | password | testGRDB.swift:85:44:85:53 | [...] [Array element] |
+| testGRDB.swift:87:44:87:53 | [...] [Array element] | testGRDB.swift:87:44:87:53 | [...] |
+| testGRDB.swift:87:45:87:45 | password | testGRDB.swift:87:44:87:53 | [...] [Array element] |
+| testGRDB.swift:92:37:92:46 | [...] [Array element] | testGRDB.swift:92:37:92:46 | [...] |
+| testGRDB.swift:92:38:92:38 | password | testGRDB.swift:92:37:92:46 | [...] [Array element] |
+| testGRDB.swift:95:36:95:45 | [...] [Array element] | testGRDB.swift:95:36:95:45 | [...] |
+| testGRDB.swift:95:37:95:37 | password | testGRDB.swift:95:36:95:45 | [...] [Array element] |
+| testGRDB.swift:100:72:100:81 | [...] [Array element] | testGRDB.swift:100:72:100:81 | [...] |
+| testGRDB.swift:100:73:100:73 | password | testGRDB.swift:100:72:100:81 | [...] [Array element] |
+| testGRDB.swift:101:72:101:81 | [...] [Array element] | testGRDB.swift:101:72:101:81 | [...] |
+| testGRDB.swift:101:73:101:73 | password | testGRDB.swift:101:72:101:81 | [...] [Array element] |
+| testGRDB.swift:107:52:107:61 | [...] [Array element] | testGRDB.swift:107:52:107:61 | [...] |
+| testGRDB.swift:107:53:107:53 | password | testGRDB.swift:107:52:107:61 | [...] [Array element] |
+| testGRDB.swift:109:52:109:61 | [...] [Array element] | testGRDB.swift:109:52:109:61 | [...] |
+| testGRDB.swift:109:53:109:53 | password | testGRDB.swift:109:52:109:61 | [...] [Array element] |
+| testGRDB.swift:111:51:111:60 | [...] [Array element] | testGRDB.swift:111:51:111:60 | [...] |
+| testGRDB.swift:111:52:111:52 | password | testGRDB.swift:111:51:111:60 | [...] [Array element] |
+| testGRDB.swift:116:47:116:56 | [...] [Array element] | testGRDB.swift:116:47:116:56 | [...] |
+| testGRDB.swift:116:48:116:48 | password | testGRDB.swift:116:47:116:56 | [...] [Array element] |
+| testGRDB.swift:118:47:118:56 | [...] [Array element] | testGRDB.swift:118:47:118:56 | [...] |
+| testGRDB.swift:118:48:118:48 | password | testGRDB.swift:118:47:118:56 | [...] [Array element] |
+| testGRDB.swift:121:44:121:53 | [...] [Array element] | testGRDB.swift:121:44:121:53 | [...] |
+| testGRDB.swift:121:45:121:45 | password | testGRDB.swift:121:44:121:53 | [...] [Array element] |
+| testGRDB.swift:123:44:123:53 | [...] [Array element] | testGRDB.swift:123:44:123:53 | [...] |
+| testGRDB.swift:123:45:123:45 | password | testGRDB.swift:123:44:123:53 | [...] [Array element] |
+| testGRDB.swift:126:44:126:53 | [...] [Array element] | testGRDB.swift:126:44:126:53 | [...] |
+| testGRDB.swift:126:45:126:45 | password | testGRDB.swift:126:44:126:53 | [...] [Array element] |
+| testGRDB.swift:128:44:128:53 | [...] [Array element] | testGRDB.swift:128:44:128:53 | [...] |
+| testGRDB.swift:128:45:128:45 | password | testGRDB.swift:128:44:128:53 | [...] [Array element] |
+| testGRDB.swift:131:44:131:53 | [...] [Array element] | testGRDB.swift:131:44:131:53 | [...] |
+| testGRDB.swift:131:45:131:45 | password | testGRDB.swift:131:44:131:53 | [...] [Array element] |
+| testGRDB.swift:133:44:133:53 | [...] [Array element] | testGRDB.swift:133:44:133:53 | [...] |
+| testGRDB.swift:133:45:133:45 | password | testGRDB.swift:133:44:133:53 | [...] [Array element] |
+| testGRDB.swift:138:68:138:77 | [...] [Array element] | testGRDB.swift:138:68:138:77 | [...] |
+| testGRDB.swift:138:69:138:69 | password | testGRDB.swift:138:68:138:77 | [...] [Array element] |
+| testGRDB.swift:140:68:140:77 | [...] [Array element] | testGRDB.swift:140:68:140:77 | [...] |
+| testGRDB.swift:140:69:140:69 | password | testGRDB.swift:140:68:140:77 | [...] [Array element] |
+| testGRDB.swift:143:65:143:74 | [...] [Array element] | testGRDB.swift:143:65:143:74 | [...] |
+| testGRDB.swift:143:66:143:66 | password | testGRDB.swift:143:65:143:74 | [...] [Array element] |
+| testGRDB.swift:145:65:145:74 | [...] [Array element] | testGRDB.swift:145:65:145:74 | [...] |
+| testGRDB.swift:145:66:145:66 | password | testGRDB.swift:145:65:145:74 | [...] [Array element] |
+| testGRDB.swift:148:65:148:74 | [...] [Array element] | testGRDB.swift:148:65:148:74 | [...] |
+| testGRDB.swift:148:66:148:66 | password | testGRDB.swift:148:65:148:74 | [...] [Array element] |
+| testGRDB.swift:150:65:150:74 | [...] [Array element] | testGRDB.swift:150:65:150:74 | [...] |
+| testGRDB.swift:150:66:150:66 | password | testGRDB.swift:150:65:150:74 | [...] [Array element] |
+| testGRDB.swift:153:65:153:74 | [...] [Array element] | testGRDB.swift:153:65:153:74 | [...] |
+| testGRDB.swift:153:66:153:66 | password | testGRDB.swift:153:65:153:74 | [...] [Array element] |
+| testGRDB.swift:155:65:155:74 | [...] [Array element] | testGRDB.swift:155:65:155:74 | [...] |
+| testGRDB.swift:155:66:155:66 | password | testGRDB.swift:155:65:155:74 | [...] [Array element] |
+| testGRDB.swift:160:59:160:68 | [...] [Array element] | testGRDB.swift:160:59:160:68 | [...] |
+| testGRDB.swift:160:60:160:60 | password | testGRDB.swift:160:59:160:68 | [...] [Array element] |
+| testGRDB.swift:161:50:161:59 | [...] [Array element] | testGRDB.swift:161:50:161:59 | [...] |
+| testGRDB.swift:161:51:161:51 | password | testGRDB.swift:161:50:161:59 | [...] [Array element] |
+| testGRDB.swift:164:59:164:68 | [...] [Array element] | testGRDB.swift:164:59:164:68 | [...] |
+| testGRDB.swift:164:60:164:60 | password | testGRDB.swift:164:59:164:68 | [...] [Array element] |
+| testGRDB.swift:165:50:165:59 | [...] [Array element] | testGRDB.swift:165:50:165:59 | [...] |
+| testGRDB.swift:165:51:165:51 | password | testGRDB.swift:165:50:165:59 | [...] [Array element] |
+| testGRDB.swift:169:56:169:65 | [...] [Array element] | testGRDB.swift:169:56:169:65 | [...] |
+| testGRDB.swift:169:57:169:57 | password | testGRDB.swift:169:56:169:65 | [...] [Array element] |
+| testGRDB.swift:170:47:170:56 | [...] [Array element] | testGRDB.swift:170:47:170:56 | [...] |
+| testGRDB.swift:170:48:170:48 | password | testGRDB.swift:170:47:170:56 | [...] [Array element] |
+| testGRDB.swift:173:56:173:65 | [...] [Array element] | testGRDB.swift:173:56:173:65 | [...] |
+| testGRDB.swift:173:57:173:57 | password | testGRDB.swift:173:56:173:65 | [...] [Array element] |
+| testGRDB.swift:174:47:174:56 | [...] [Array element] | testGRDB.swift:174:47:174:56 | [...] |
+| testGRDB.swift:174:48:174:48 | password | testGRDB.swift:174:47:174:56 | [...] [Array element] |
+| testGRDB.swift:178:56:178:65 | [...] [Array element] | testGRDB.swift:178:56:178:65 | [...] |
+| testGRDB.swift:178:57:178:57 | password | testGRDB.swift:178:56:178:65 | [...] [Array element] |
+| testGRDB.swift:179:47:179:56 | [...] [Array element] | testGRDB.swift:179:47:179:56 | [...] |
+| testGRDB.swift:179:48:179:48 | password | testGRDB.swift:179:47:179:56 | [...] [Array element] |
+| testGRDB.swift:182:56:182:65 | [...] [Array element] | testGRDB.swift:182:56:182:65 | [...] |
+| testGRDB.swift:182:57:182:57 | password | testGRDB.swift:182:56:182:65 | [...] [Array element] |
+| testGRDB.swift:183:47:183:56 | [...] [Array element] | testGRDB.swift:183:47:183:56 | [...] |
+| testGRDB.swift:183:48:183:48 | password | testGRDB.swift:183:47:183:56 | [...] [Array element] |
+| testGRDB.swift:187:56:187:65 | [...] [Array element] | testGRDB.swift:187:56:187:65 | [...] |
+| testGRDB.swift:187:57:187:57 | password | testGRDB.swift:187:56:187:65 | [...] [Array element] |
+| testGRDB.swift:188:47:188:56 | [...] [Array element] | testGRDB.swift:188:47:188:56 | [...] |
+| testGRDB.swift:188:48:188:48 | password | testGRDB.swift:188:47:188:56 | [...] [Array element] |
+| testGRDB.swift:191:56:191:65 | [...] [Array element] | testGRDB.swift:191:56:191:65 | [...] |
+| testGRDB.swift:191:57:191:57 | password | testGRDB.swift:191:56:191:65 | [...] [Array element] |
+| testGRDB.swift:192:47:192:56 | [...] [Array element] | testGRDB.swift:192:47:192:56 | [...] |
+| testGRDB.swift:192:48:192:48 | password | testGRDB.swift:192:47:192:56 | [...] [Array element] |
+| testGRDB.swift:198:29:198:38 | [...] [Array element] | testGRDB.swift:198:29:198:38 | [...] |
+| testGRDB.swift:198:30:198:30 | password | testGRDB.swift:198:29:198:38 | [...] [Array element] |
+| testGRDB.swift:201:23:201:32 | [...] [Array element] | testGRDB.swift:201:23:201:32 | [...] |
+| testGRDB.swift:201:24:201:24 | password | testGRDB.swift:201:23:201:32 | [...] [Array element] |
+| testGRDB.swift:206:66:206:75 | [...] [Array element] | testGRDB.swift:206:66:206:75 | [...] |
+| testGRDB.swift:206:67:206:67 | password | testGRDB.swift:206:66:206:75 | [...] [Array element] |
+| testGRDB.swift:208:80:208:89 | [...] [Array element] | testGRDB.swift:208:80:208:89 | [...] |
+| testGRDB.swift:208:81:208:81 | password | testGRDB.swift:208:80:208:89 | [...] [Array element] |
+| testGRDB.swift:210:84:210:93 | [...] [Array element] | testGRDB.swift:210:84:210:93 | [...] |
+| testGRDB.swift:210:85:210:85 | password | testGRDB.swift:210:84:210:93 | [...] [Array element] |
+| testGRDB.swift:212:98:212:107 | [...] [Array element] | testGRDB.swift:212:98:212:107 | [...] |
+| testGRDB.swift:212:99:212:99 | password | testGRDB.swift:212:98:212:107 | [...] [Array element] |
 | testRealm.swift:27:6:27:6 | value | file://:0:0:0:0 | value |
 | testRealm.swift:34:6:34:6 | value | file://:0:0:0:0 | value |
 | testRealm.swift:41:2:41:2 | [post] a [data] | testRealm.swift:41:2:41:2 | [post] a |
@@ -326,106 +377,157 @@ nodes
 | testCoreData.swift:96:15:96:15 | y | semmle.label | y |
 | testCoreData.swift:97:15:97:15 | z | semmle.label | z |
 | testGRDB.swift:73:56:73:65 | [...] | semmle.label | [...] |
+| testGRDB.swift:73:56:73:65 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:73:57:73:57 | password | semmle.label | password |
 | testGRDB.swift:76:42:76:51 | [...] | semmle.label | [...] |
+| testGRDB.swift:76:42:76:51 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:76:43:76:43 | password | semmle.label | password |
 | testGRDB.swift:81:44:81:53 | [...] | semmle.label | [...] |
+| testGRDB.swift:81:44:81:53 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:81:45:81:45 | password | semmle.label | password |
 | testGRDB.swift:83:44:83:53 | [...] | semmle.label | [...] |
+| testGRDB.swift:83:44:83:53 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:83:45:83:45 | password | semmle.label | password |
 | testGRDB.swift:85:44:85:53 | [...] | semmle.label | [...] |
+| testGRDB.swift:85:44:85:53 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:85:45:85:45 | password | semmle.label | password |
 | testGRDB.swift:87:44:87:53 | [...] | semmle.label | [...] |
+| testGRDB.swift:87:44:87:53 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:87:45:87:45 | password | semmle.label | password |
 | testGRDB.swift:92:37:92:46 | [...] | semmle.label | [...] |
+| testGRDB.swift:92:37:92:46 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:92:38:92:38 | password | semmle.label | password |
 | testGRDB.swift:95:36:95:45 | [...] | semmle.label | [...] |
+| testGRDB.swift:95:36:95:45 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:95:37:95:37 | password | semmle.label | password |
 | testGRDB.swift:100:72:100:81 | [...] | semmle.label | [...] |
+| testGRDB.swift:100:72:100:81 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:100:73:100:73 | password | semmle.label | password |
 | testGRDB.swift:101:72:101:81 | [...] | semmle.label | [...] |
+| testGRDB.swift:101:72:101:81 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:101:73:101:73 | password | semmle.label | password |
 | testGRDB.swift:107:52:107:61 | [...] | semmle.label | [...] |
+| testGRDB.swift:107:52:107:61 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:107:53:107:53 | password | semmle.label | password |
 | testGRDB.swift:109:52:109:61 | [...] | semmle.label | [...] |
+| testGRDB.swift:109:52:109:61 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:109:53:109:53 | password | semmle.label | password |
 | testGRDB.swift:111:51:111:60 | [...] | semmle.label | [...] |
+| testGRDB.swift:111:51:111:60 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:111:52:111:52 | password | semmle.label | password |
 | testGRDB.swift:116:47:116:56 | [...] | semmle.label | [...] |
+| testGRDB.swift:116:47:116:56 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:116:48:116:48 | password | semmle.label | password |
 | testGRDB.swift:118:47:118:56 | [...] | semmle.label | [...] |
+| testGRDB.swift:118:47:118:56 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:118:48:118:48 | password | semmle.label | password |
 | testGRDB.swift:121:44:121:53 | [...] | semmle.label | [...] |
+| testGRDB.swift:121:44:121:53 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:121:45:121:45 | password | semmle.label | password |
 | testGRDB.swift:123:44:123:53 | [...] | semmle.label | [...] |
+| testGRDB.swift:123:44:123:53 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:123:45:123:45 | password | semmle.label | password |
 | testGRDB.swift:126:44:126:53 | [...] | semmle.label | [...] |
+| testGRDB.swift:126:44:126:53 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:126:45:126:45 | password | semmle.label | password |
 | testGRDB.swift:128:44:128:53 | [...] | semmle.label | [...] |
+| testGRDB.swift:128:44:128:53 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:128:45:128:45 | password | semmle.label | password |
 | testGRDB.swift:131:44:131:53 | [...] | semmle.label | [...] |
+| testGRDB.swift:131:44:131:53 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:131:45:131:45 | password | semmle.label | password |
 | testGRDB.swift:133:44:133:53 | [...] | semmle.label | [...] |
+| testGRDB.swift:133:44:133:53 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:133:45:133:45 | password | semmle.label | password |
 | testGRDB.swift:138:68:138:77 | [...] | semmle.label | [...] |
+| testGRDB.swift:138:68:138:77 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:138:69:138:69 | password | semmle.label | password |
 | testGRDB.swift:140:68:140:77 | [...] | semmle.label | [...] |
+| testGRDB.swift:140:68:140:77 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:140:69:140:69 | password | semmle.label | password |
 | testGRDB.swift:143:65:143:74 | [...] | semmle.label | [...] |
+| testGRDB.swift:143:65:143:74 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:143:66:143:66 | password | semmle.label | password |
 | testGRDB.swift:145:65:145:74 | [...] | semmle.label | [...] |
+| testGRDB.swift:145:65:145:74 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:145:66:145:66 | password | semmle.label | password |
 | testGRDB.swift:148:65:148:74 | [...] | semmle.label | [...] |
+| testGRDB.swift:148:65:148:74 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:148:66:148:66 | password | semmle.label | password |
 | testGRDB.swift:150:65:150:74 | [...] | semmle.label | [...] |
+| testGRDB.swift:150:65:150:74 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:150:66:150:66 | password | semmle.label | password |
 | testGRDB.swift:153:65:153:74 | [...] | semmle.label | [...] |
+| testGRDB.swift:153:65:153:74 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:153:66:153:66 | password | semmle.label | password |
 | testGRDB.swift:155:65:155:74 | [...] | semmle.label | [...] |
+| testGRDB.swift:155:65:155:74 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:155:66:155:66 | password | semmle.label | password |
 | testGRDB.swift:160:59:160:68 | [...] | semmle.label | [...] |
+| testGRDB.swift:160:59:160:68 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:160:60:160:60 | password | semmle.label | password |
 | testGRDB.swift:161:50:161:59 | [...] | semmle.label | [...] |
+| testGRDB.swift:161:50:161:59 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:161:51:161:51 | password | semmle.label | password |
 | testGRDB.swift:164:59:164:68 | [...] | semmle.label | [...] |
+| testGRDB.swift:164:59:164:68 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:164:60:164:60 | password | semmle.label | password |
 | testGRDB.swift:165:50:165:59 | [...] | semmle.label | [...] |
+| testGRDB.swift:165:50:165:59 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:165:51:165:51 | password | semmle.label | password |
 | testGRDB.swift:169:56:169:65 | [...] | semmle.label | [...] |
+| testGRDB.swift:169:56:169:65 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:169:57:169:57 | password | semmle.label | password |
 | testGRDB.swift:170:47:170:56 | [...] | semmle.label | [...] |
+| testGRDB.swift:170:47:170:56 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:170:48:170:48 | password | semmle.label | password |
 | testGRDB.swift:173:56:173:65 | [...] | semmle.label | [...] |
+| testGRDB.swift:173:56:173:65 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:173:57:173:57 | password | semmle.label | password |
 | testGRDB.swift:174:47:174:56 | [...] | semmle.label | [...] |
+| testGRDB.swift:174:47:174:56 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:174:48:174:48 | password | semmle.label | password |
 | testGRDB.swift:178:56:178:65 | [...] | semmle.label | [...] |
+| testGRDB.swift:178:56:178:65 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:178:57:178:57 | password | semmle.label | password |
 | testGRDB.swift:179:47:179:56 | [...] | semmle.label | [...] |
+| testGRDB.swift:179:47:179:56 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:179:48:179:48 | password | semmle.label | password |
 | testGRDB.swift:182:56:182:65 | [...] | semmle.label | [...] |
+| testGRDB.swift:182:56:182:65 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:182:57:182:57 | password | semmle.label | password |
 | testGRDB.swift:183:47:183:56 | [...] | semmle.label | [...] |
+| testGRDB.swift:183:47:183:56 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:183:48:183:48 | password | semmle.label | password |
 | testGRDB.swift:187:56:187:65 | [...] | semmle.label | [...] |
+| testGRDB.swift:187:56:187:65 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:187:57:187:57 | password | semmle.label | password |
 | testGRDB.swift:188:47:188:56 | [...] | semmle.label | [...] |
+| testGRDB.swift:188:47:188:56 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:188:48:188:48 | password | semmle.label | password |
 | testGRDB.swift:191:56:191:65 | [...] | semmle.label | [...] |
+| testGRDB.swift:191:56:191:65 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:191:57:191:57 | password | semmle.label | password |
 | testGRDB.swift:192:47:192:56 | [...] | semmle.label | [...] |
+| testGRDB.swift:192:47:192:56 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:192:48:192:48 | password | semmle.label | password |
 | testGRDB.swift:198:29:198:38 | [...] | semmle.label | [...] |
+| testGRDB.swift:198:29:198:38 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:198:30:198:30 | password | semmle.label | password |
 | testGRDB.swift:201:23:201:32 | [...] | semmle.label | [...] |
+| testGRDB.swift:201:23:201:32 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:201:24:201:24 | password | semmle.label | password |
 | testGRDB.swift:206:66:206:75 | [...] | semmle.label | [...] |
+| testGRDB.swift:206:66:206:75 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:206:67:206:67 | password | semmle.label | password |
 | testGRDB.swift:208:80:208:89 | [...] | semmle.label | [...] |
+| testGRDB.swift:208:80:208:89 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:208:81:208:81 | password | semmle.label | password |
 | testGRDB.swift:210:84:210:93 | [...] | semmle.label | [...] |
+| testGRDB.swift:210:84:210:93 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:210:85:210:85 | password | semmle.label | password |
 | testGRDB.swift:212:98:212:107 | [...] | semmle.label | [...] |
+| testGRDB.swift:212:98:212:107 | [...] [Array element] | semmle.label | [...] [Array element] |
 | testGRDB.swift:212:99:212:99 | password | semmle.label | password |
 | testRealm.swift:27:6:27:6 | value | semmle.label | value |
 | testRealm.swift:34:6:34:6 | value | semmle.label | value |


### PR DESCRIPTION
Replace additional taint steps in `swift/command-line-injection` and `swift/cleartext-storage-database` with implicit reads instead.  Implicit reads are a more principled / accurate way of doing data flow out from array elements at the sink (now that we model array content and it can work).

Note that in the test changes, the `#select` parts are unaffected.