### PR TITLE
Java: Enable threat models for most Java queries.

### DIFF
--- a/java/ql/lib/ext/threatmodels/supported-threat-models.model.yml
+++ b/java/ql/lib/ext/threatmodels/supported-threat-models.model.yml
@@ -5,4 +5,3 @@ extensions:
       extensible: supportedThreatModels
     data:
       - ["default"] # The "default" threat model is always included.
-      - ["local"] # REMOVE AGAIN: Add the local threat models for testing purposes.

--- a/java/ql/lib/ext/threatmodels/supported-threat-models.model.yml
+++ b/java/ql/lib/ext/threatmodels/supported-threat-models.model.yml
@@ -5,3 +5,4 @@ extensions:
       extensible: supportedThreatModels
     data:
       - ["default"] # The "default" threat model is always included.
+      - ["local"] # REMOVE AGAIN: Add the local threat models for testing purposes.

--- a/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
@@ -618,7 +618,7 @@ private MethodAccess callReturningSameType(Expr ref) {
 }
 
 private SrcRefType entrypointType() {
-  exists(RemoteFlowSource s, RefType t |
+  exists(ThreatModelFlowSource s, RefType t |
     s instanceof DataFlow::ExplicitParameterNode and
     t = pragma[only_bind_out](s).getType() and
     not t instanceof TypeObject and
@@ -629,6 +629,10 @@ private SrcRefType entrypointType() {
 }
 
 private predicate entrypointFieldStep(DataFlow::Node src, DataFlow::Node sink) {
-  src = DataFlow::getFieldQualifier(sink.asExpr().(FieldRead)) and
+  exists(FieldRead fa |
+    fa = sink.asExpr() and
+    src = DataFlow::getFieldQualifier(fa) and
+    not fa.getField().isStatic()
+  ) and
   src.getType().(RefType).getSourceDeclaration() = entrypointType()
 }

--- a/java/ql/lib/semmle/code/java/security/AndroidIntentRedirectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/AndroidIntentRedirectionQuery.qll
@@ -30,7 +30,7 @@ deprecated class IntentRedirectionConfiguration extends TaintTracking::Configura
 
 /** A taint tracking configuration for tainted Intents being used to start Android components. */
 module IntentRedirectionConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof IntentRedirectionSink }
 
@@ -57,7 +57,7 @@ private class OriginalIntentSanitizer extends IntentRedirectionSanitizer {
  * flowing directly to sinks that start Android components.
  */
 private module SameIntentBeingRelaunchedConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof IntentRedirectionSink }
 
@@ -93,7 +93,7 @@ private class IntentWithTaintedComponent extends DataFlow::Node {
  * A taint tracking configuration for tainted data flowing to an `Intent`'s component.
  */
 private module TaintedIntentComponentConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) {
     any(IntentSetComponent setComponent).getSink() = sink.asExpr()

--- a/java/ql/lib/semmle/code/java/security/ArbitraryApkInstallation.qll
+++ b/java/ql/lib/semmle/code/java/security/ArbitraryApkInstallation.qll
@@ -74,7 +74,7 @@ class ExternalApkSource extends DataFlow::Node {
     sourceNode(this, "android-external-storage-dir") or
     this.asExpr().(MethodAccess).getMethod() instanceof UriConstructorMethod or
     this.asExpr().(StringLiteral).getValue().matches("file://%") or
-    this instanceof RemoteFlowSource
+    this instanceof ThreatModelFlowSource
   }
 }
 

--- a/java/ql/lib/semmle/code/java/security/ArithmeticTaintedQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/ArithmeticTaintedQuery.qll
@@ -6,7 +6,7 @@ private import semmle.code.java.security.ArithmeticCommon
 
 /** A taint-tracking configuration to reason about overflow from unvalidated user input. */
 module RemoteUserInputOverflowConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { overflowSink(_, sink.asExpr()) }
 
@@ -17,7 +17,7 @@ module RemoteUserInputOverflowConfig implements DataFlow::ConfigSig {
 
 /** A taint-tracking configuration to reason about underflow from unvalidated user input. */
 module RemoteUserInputUnderflowConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { underflowSink(_, sink.asExpr()) }
 

--- a/java/ql/lib/semmle/code/java/security/CommandLineQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/CommandLineQuery.qll
@@ -52,7 +52,7 @@ private class DefaultCommandInjectionSanitizer extends CommandInjectionSanitizer
  * A taint-tracking configuration for unvalidated user input that is used to run an external process.
  */
 module RemoteUserInputToArgumentToExecFlowConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node src) { src instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof CommandInjectionSink }
 

--- a/java/ql/lib/semmle/code/java/security/ConditionalBypassQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/ConditionalBypassQuery.qll
@@ -57,7 +57,7 @@ deprecated class ConditionalBypassFlowConfig extends TaintTracking::Configuratio
  * A taint tracking configuration for untrusted data flowing to sensitive conditions.
  */
 module ConditionalBypassFlowConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { conditionControlsMethod(_, sink.asExpr()) }
 

--- a/java/ql/lib/semmle/code/java/security/ExternalAPIs.qll
+++ b/java/ql/lib/semmle/code/java/security/ExternalAPIs.qll
@@ -106,10 +106,10 @@ deprecated class UntrustedDataToExternalApiConfig extends TaintTracking::Configu
 }
 
 /**
- * Taint tracking configuration for flow from `RemoteFlowSource`s to `ExternalApiDataNode`s.
+ * Taint tracking configuration for flow from `ThreatModelFlowSource`s to `ExternalApiDataNode`s.
  */
 module UntrustedDataToExternalApiConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof ExternalApiDataNode }
 }

--- a/java/ql/lib/semmle/code/java/security/ExternallyControlledFormatStringQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/ExternallyControlledFormatStringQuery.qll
@@ -8,7 +8,7 @@ private import semmle.code.java.StringFormat
  * A taint-tracking configuration for externally controlled format string vulnerabilities.
  */
 module ExternallyControlledFormatStringConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) {
     sink.asExpr() = any(StringFormat formatCall).getFormatArgument()

--- a/java/ql/lib/semmle/code/java/security/FragmentInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/FragmentInjectionQuery.qll
@@ -28,7 +28,7 @@ deprecated class FragmentInjectionTaintConf extends TaintTracking::Configuration
  * that is used to create Android fragments dynamically.
  */
 module FragmentInjectionTaintConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof FragmentInjectionSink }
 

--- a/java/ql/lib/semmle/code/java/security/GroovyInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/GroovyInjectionQuery.qll
@@ -28,7 +28,7 @@ deprecated class GroovyInjectionConfig extends TaintTracking::Configuration {
  * that is used to evaluate a Groovy expression.
  */
 module GroovyInjectionConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof GroovyInjectionSink }
 

--- a/java/ql/lib/semmle/code/java/security/ImproperValidationOfArrayConstructionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/ImproperValidationOfArrayConstructionQuery.qll
@@ -5,10 +5,11 @@ private import semmle.code.java.security.internal.ArraySizing
 private import semmle.code.java.dataflow.FlowSources
 
 /**
- * A taint-tracking configuration to reason about improper validation of user-provided size used for array construction.
+ * A taint-tracking configuration to reason about improper validation of
+ * user-provided size used for array construction.
  */
 module ImproperValidationOfArrayConstructionConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) {
     any(CheckableArrayAccess caa).canThrowOutOfBoundsDueToEmptyArray(sink.asExpr(), _)
@@ -16,7 +17,8 @@ module ImproperValidationOfArrayConstructionConfig implements DataFlow::ConfigSi
 }
 
 /**
- * Taint-tracking flow for improper validation of user-provided size used for array construction.
+ * Taint-tracking flow for improper validation of user-provided size used
+ * for array construction.
  */
 module ImproperValidationOfArrayConstructionFlow =
   TaintTracking::Global<ImproperValidationOfArrayConstructionConfig>;

--- a/java/ql/lib/semmle/code/java/security/ImproperValidationOfArrayIndexQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/ImproperValidationOfArrayIndexQuery.qll
@@ -5,10 +5,11 @@ private import semmle.code.java.security.internal.ArraySizing
 private import semmle.code.java.dataflow.FlowSources
 
 /**
- * A taint-tracking configuration to reason about improper validation of user-provided array index.
+ * A taint-tracking configuration to reason about improper validation
+ * of user-provided array index.
  */
 module ImproperValidationOfArrayIndexConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) {
     any(CheckableArrayAccess caa).canThrowOutOfBounds(sink.asExpr())

--- a/java/ql/lib/semmle/code/java/security/InsecureBeanValidationQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/InsecureBeanValidationQuery.qll
@@ -46,7 +46,7 @@ class SetMessageInterpolatorCall extends MethodAccess {
  * to the argument of a method that builds constraint error messages.
  */
 module BeanValidationConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof BeanValidationSink }
 }

--- a/java/ql/lib/semmle/code/java/security/IntentUriPermissionManipulationQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/IntentUriPermissionManipulationQuery.qll
@@ -39,7 +39,7 @@ deprecated class IntentUriPermissionManipulationConf extends TaintTracking::Conf
  * A taint tracking configuration for user-provided Intents being returned to third party apps.
  */
 module IntentUriPermissionManipulationConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof IntentUriPermissionManipulationSink }
 

--- a/java/ql/lib/semmle/code/java/security/JexlInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/JexlInjectionQuery.qll
@@ -63,7 +63,7 @@ deprecated class JexlInjectionConfig extends TaintTracking::Configuration {
  * It supports both JEXL 2 and 3.
  */
 module JexlInjectionConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof JexlEvaluationSink }
 

--- a/java/ql/lib/semmle/code/java/security/JndiInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/JndiInjectionQuery.qll
@@ -33,7 +33,7 @@ deprecated class JndiInjectionFlowConfig extends TaintTracking::Configuration {
  * A taint-tracking configuration for unvalidated user input that is used in JNDI lookup.
  */
 module JndiInjectionFlowConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof JndiInjectionSink }
 

--- a/java/ql/lib/semmle/code/java/security/LdapInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/LdapInjectionQuery.qll
@@ -8,7 +8,7 @@ import semmle.code.java.security.LdapInjection
  * A taint-tracking configuration for unvalidated user input that is used to construct LDAP queries.
  */
 module LdapInjectionFlowConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof LdapInjectionSink }
 

--- a/java/ql/lib/semmle/code/java/security/LogInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/LogInjectionQuery.qll
@@ -27,7 +27,7 @@ deprecated class LogInjectionConfiguration extends TaintTracking::Configuration 
  * A taint-tracking configuration for tracking untrusted user input used in log entries.
  */
 module LogInjectionConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof LogInjectionSink }
 

--- a/java/ql/lib/semmle/code/java/security/MvelInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/MvelInjectionQuery.qll
@@ -32,7 +32,7 @@ deprecated class MvelInjectionFlowConfig extends TaintTracking::Configuration {
  * that is used to construct and evaluate a MVEL expression.
  */
 module MvelInjectionFlowConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof MvelEvaluationSink }
 

--- a/java/ql/lib/semmle/code/java/security/NumericCastTaintedQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/NumericCastTaintedQuery.qll
@@ -85,7 +85,7 @@ private predicate smallExpr(Expr e) {
  * numeric cast.
  */
 module NumericCastFlowConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node src) { src instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) {
     sink.asExpr() = any(NumericNarrowingCastExpr cast).getExpr() and

--- a/java/ql/lib/semmle/code/java/security/OgnlInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/OgnlInjectionQuery.qll
@@ -29,7 +29,7 @@ deprecated class OgnlInjectionFlowConfig extends TaintTracking::Configuration {
  * A taint-tracking configuration for unvalidated user input that is used in OGNL EL evaluation.
  */
 module OgnlInjectionFlowConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof OgnlInjectionSink }
 

--- a/java/ql/lib/semmle/code/java/security/PartialPathTraversalQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/PartialPathTraversalQuery.qll
@@ -29,7 +29,7 @@ deprecated class PartialPathTraversalFromRemoteConfig extends TaintTracking::Con
  * and remains vulnerable to Partial Path Traversal.
  */
 module PartialPathTraversalFromRemoteConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node node) { node instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node node) { node instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node node) {
     any(PartialPathTraversalMethodAccess ma).getQualifier() = node.asExpr()

--- a/java/ql/lib/semmle/code/java/security/RequestForgeryConfig.qll
+++ b/java/ql/lib/semmle/code/java/security/RequestForgeryConfig.qll
@@ -37,7 +37,7 @@ deprecated class RequestForgeryConfiguration extends TaintTracking::Configuratio
  */
 module RequestForgeryConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) {
-    source instanceof RemoteFlowSource and
+    source instanceof ThreatModelFlowSource and
     // Exclude results of remote HTTP requests: fetching something else based on that result
     // is no worse than following a redirect returned by the remote server, and typically
     // we're requesting a resource via https which we trust to only send us to safe URLs.

--- a/java/ql/lib/semmle/code/java/security/ResponseSplittingQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/ResponseSplittingQuery.qll
@@ -9,7 +9,7 @@ import semmle.code.java.security.ResponseSplitting
  */
 module ResponseSplittingConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) {
-    source instanceof RemoteFlowSource and
+    source instanceof ThreatModelFlowSource and
     not source instanceof SafeHeaderSplittingSource
   }
 

--- a/java/ql/lib/semmle/code/java/security/SensitiveResultReceiverQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/SensitiveResultReceiverQuery.qll
@@ -18,7 +18,7 @@ private class ResultReceiverSendCall extends MethodAccess {
 }
 
 private module UntrustedResultReceiverConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node node) { node instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node node) { node instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node node) {
     node.asExpr() = any(ResultReceiverSendCall c).getReceiver()

--- a/java/ql/lib/semmle/code/java/security/SpelInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/SpelInjectionQuery.qll
@@ -29,7 +29,7 @@ deprecated class SpelInjectionConfig extends TaintTracking::Configuration {
  * that is used to construct and evaluate a SpEL expression.
  */
 module SpelInjectionConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof SpelExpressionEvaluationSink }
 

--- a/java/ql/lib/semmle/code/java/security/SqlInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/SqlInjectionQuery.qll
@@ -37,7 +37,7 @@ deprecated class QueryInjectionFlowConfig extends TaintTracking::Configuration {
  * A taint-tracking configuration for unvalidated user input that is used in SQL queries.
  */
 module QueryInjectionFlowConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node src) { src instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof QueryInjectionSink }
 

--- a/java/ql/lib/semmle/code/java/security/TaintedPathQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/TaintedPathQuery.qll
@@ -52,7 +52,7 @@ private class TaintPreservingUriCtorParam extends Parameter {
  * A taint-tracking configuration for tracking flow from remote sources to the creation of a path.
  */
 module TaintedPathConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sinkNode(sink, "path-injection") }
 

--- a/java/ql/lib/semmle/code/java/security/TemplateInjection.qll
+++ b/java/ql/lib/semmle/code/java/security/TemplateInjection.qll
@@ -62,7 +62,7 @@ abstract class TemplateInjectionSanitizerWithState extends DataFlow::Node {
   abstract predicate hasState(DataFlow::FlowState state);
 }
 
-private class DefaultTemplateInjectionSource extends TemplateInjectionSource instanceof RemoteFlowSource
+private class DefaultTemplateInjectionSource extends TemplateInjectionSource instanceof ThreatModelFlowSource
 { }
 
 private class DefaultTemplateInjectionSink extends TemplateInjectionSink {

--- a/java/ql/lib/semmle/code/java/security/TrustBoundaryViolationQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/TrustBoundaryViolationQuery.qll
@@ -12,7 +12,8 @@ private import semmle.code.java.frameworks.owasp.Esapi
  */
 abstract class TrustBoundaryViolationSource extends DataFlow::Node { }
 
-private class RemoteSource extends TrustBoundaryViolationSource instanceof RemoteFlowSource { }
+private class ThreatModelSource extends TrustBoundaryViolationSource instanceof ThreatModelFlowSource
+{ }
 
 /**
  * A sink for data that crosses a trust boundary.

--- a/java/ql/lib/semmle/code/java/security/UnsafeAndroidAccessQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/UnsafeAndroidAccessQuery.qll
@@ -27,7 +27,7 @@ deprecated class FetchUntrustedResourceConfiguration extends TaintTracking::Conf
  * A taint configuration tracking flow from untrusted inputs to a resource fetching call.
  */
 module FetchUntrustedResourceConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof UrlResourceSink }
 

--- a/java/ql/lib/semmle/code/java/security/UnsafeContentUriResolutionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/UnsafeContentUriResolutionQuery.qll
@@ -30,7 +30,7 @@ deprecated class UnsafeContentResolutionConf extends TaintTracking::Configuratio
  * A taint-tracking configuration to find paths from remote sources to content URI resolutions.
  */
 module UnsafeContentResolutionConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node src) { src instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof ContentUriResolutionSink }
 

--- a/java/ql/lib/semmle/code/java/security/UnsafeDeserializationQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/UnsafeDeserializationQuery.qll
@@ -324,7 +324,7 @@ deprecated class UnsafeDeserializationConfig extends TaintTracking::Configuratio
 
 /** Tracks flows from remote user input to a deserialization sink. */
 private module UnsafeDeserializationConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof UnsafeDeserializationSink }
 
@@ -448,7 +448,7 @@ deprecated class UnsafeTypeConfig extends TaintTracking2::Configuration {
  * If this is user-controlled, arbitrary code could be executed while instantiating the user-specified type.
  */
 module UnsafeTypeConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node src) { src instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof UnsafeTypeSink }
 

--- a/java/ql/lib/semmle/code/java/security/UrlRedirectQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/UrlRedirectQuery.qll
@@ -8,7 +8,7 @@ private import semmle.code.java.security.UrlRedirect
  * A taint-tracking configuration for reasoning about URL redirections.
  */
 module UrlRedirectConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof UrlRedirectSink }
 }

--- a/java/ql/lib/semmle/code/java/security/XPathInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/XPathInjectionQuery.qll
@@ -9,7 +9,7 @@ private import semmle.code.java.security.XPath
  * A taint-tracking configuration for reasoning about XPath injection vulnerabilities.
  */
 module XPathInjectionConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof XPathInjectionSink }
 }

--- a/java/ql/lib/semmle/code/java/security/XsltInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/XsltInjectionQuery.qll
@@ -31,7 +31,7 @@ deprecated class XsltInjectionFlowConfig extends TaintTracking::Configuration {
  * A taint-tracking configuration for unvalidated user input that is used in XSLT transformation.
  */
 module XsltInjectionFlowConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof XsltInjectionSink }
 

--- a/java/ql/lib/semmle/code/java/security/XssQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/XssQuery.qll
@@ -9,7 +9,7 @@ import semmle.code.java.security.XSS
  * A taint-tracking configuration for cross site scripting vulnerabilities.
  */
 module XssConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof XssSink }
 

--- a/java/ql/lib/semmle/code/java/security/XxeRemoteQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/XxeRemoteQuery.qll
@@ -28,7 +28,7 @@ deprecated class XxeConfig extends TaintTracking::Configuration {
  * A taint-tracking configuration for unvalidated remote user input that is used in XML external entity expansion.
  */
 module XxeConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node src) { src instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof XxeSink }
 

--- a/java/ql/lib/semmle/code/java/security/regexp/PolynomialReDoSQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/regexp/PolynomialReDoSQuery.qll
@@ -66,7 +66,7 @@ deprecated predicate hasPolynomialReDoSResult(
 
 /** A configuration for Polynomial ReDoS queries. */
 module PolynomialRedosConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node src) { src instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) {
     exists(SuperlinearBackTracking::PolynomialBackTrackingTerm regexp |

--- a/java/ql/lib/semmle/code/java/security/regexp/RegexInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/regexp/RegexInjectionQuery.qll
@@ -24,7 +24,7 @@ deprecated class RegexInjectionConfiguration extends TaintTracking::Configuratio
  * A taint-tracking configuration for untrusted user input used to construct regular expressions.
  */
 module RegexInjectionConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof RegexInjectionSink }
 

--- a/java/ql/src/change-notes/2023-10-06-threat-models.md
+++ b/java/ql/src/change-notes/2023-10-06-threat-models.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Most data flow queries that track flow from *remote* flow sources now use the current *threat model* configuration instead. This doesn't lead to any changes in the produced alerts (as the default configuration is *remote* flow sources) unless the threat model configuration is changed.

--- a/java/ql/src/experimental/Security/CWE/CWE-020/Log4jJndiInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-020/Log4jJndiInjection.ql
@@ -43,7 +43,7 @@ class Log4jInjectionSanitizer extends DataFlow::Node {
  * A taint-tracking configuration for tracking untrusted user input used in log entries.
  */
 module Log4jInjectionConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof Log4jInjectionSink }
 

--- a/java/ql/src/experimental/Security/CWE/CWE-036/OpenStream.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-036/OpenStream.ql
@@ -33,7 +33,7 @@ class UrlConstructor extends ClassInstanceExpr {
 }
 
 module RemoteUrlToOpenStreamFlowConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) {
     exists(MethodAccess m |

--- a/java/ql/src/experimental/Security/CWE/CWE-073/FilePathInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-073/FilePathInjection.ql
@@ -48,7 +48,7 @@ class NormalizedPathNode extends DataFlow::Node {
 }
 
 module InjectFilePathConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) {
     sinkNode(sink, "path-injection") and

--- a/java/ql/src/experimental/Security/CWE/CWE-078/CommandInjectionRuntimeExec.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-078/CommandInjectionRuntimeExec.ql
@@ -14,7 +14,7 @@
 import CommandInjectionRuntimeExec
 import ExecUserFlow::PathGraph
 
-class RemoteSource extends Source instanceof RemoteFlowSource { }
+class ThreatModelSource extends Source instanceof ThreatModelFlowSource { }
 
 from
   ExecUserFlow::PathNode source, ExecUserFlow::PathNode sink, DataFlow::Node sourceCmd,

--- a/java/ql/src/experimental/Security/CWE/CWE-089/MyBatisAnnotationSqlInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-089/MyBatisAnnotationSqlInjection.ql
@@ -20,7 +20,7 @@ import semmle.code.java.dataflow.TaintTracking
 import MyBatisAnnotationSqlInjectionFlow::PathGraph
 
 private module MyBatisAnnotationSqlInjectionConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof MyBatisAnnotatedMethodCallArgument }
 

--- a/java/ql/src/experimental/Security/CWE/CWE-089/MyBatisMapperXmlSqlInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-089/MyBatisMapperXmlSqlInjection.ql
@@ -20,7 +20,7 @@ import semmle.code.java.dataflow.FlowSources
 import MyBatisMapperXmlSqlInjectionFlow::PathGraph
 
 private module MyBatisMapperXmlSqlInjectionConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof MyBatisMapperMethodCallAnArgument }
 

--- a/java/ql/src/experimental/Security/CWE/CWE-094/BeanShellInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/BeanShellInjection.ql
@@ -18,7 +18,7 @@ import semmle.code.java.dataflow.TaintTracking
 import BeanShellInjectionFlow::PathGraph
 
 module BeanShellInjectionConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof BeanShellInjectionSink }
 

--- a/java/ql/src/experimental/Security/CWE/CWE-094/JShellInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/JShellInjection.ql
@@ -18,7 +18,7 @@ import semmle.code.java.dataflow.TaintTracking
 import JShellInjectionFlow::PathGraph
 
 module JShellInjectionConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof JShellInjectionSink }
 

--- a/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjectionLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjectionLib.qll
@@ -8,7 +8,7 @@ import semmle.code.java.dataflow.TaintTracking
  * that is used to construct and evaluate an expression.
  */
 module JakartaExpressionInjectionConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof ExpressionEvaluationSink }
 

--- a/java/ql/src/experimental/Security/CWE/CWE-094/JythonInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/JythonInjection.ql
@@ -99,17 +99,17 @@ class CodeInjectionSink extends DataFlow::ExprNode {
 }
 
 /**
- * A taint configuration for tracking flow from `RemoteFlowSource` to a Jython method call
+ * A taint configuration for tracking flow from `ThreatModelFlowSource` to a Jython method call
  * `CodeInjectionSink` that executes injected code.
  */
 module CodeInjectionConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof CodeInjectionSink }
 }
 
 /**
- * Taint tracking flow from `RemoteFlowSource` to a Jython method call
+ * Taint tracking flow from `ThreatModelFlowSource` to a Jython method call
  * `CodeInjectionSink` that executes injected code.
  */
 module CodeInjectionFlow = TaintTracking::Global<CodeInjectionConfig>;

--- a/java/ql/src/experimental/Security/CWE/CWE-094/ScriptInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/ScriptInjection.ql
@@ -131,11 +131,11 @@ class ScriptInjectionSink extends DataFlow::ExprNode {
 }
 
 /**
- * A taint tracking configuration that tracks flow from `RemoteFlowSource` to an argument
+ * A taint tracking configuration that tracks flow from `ThreatModelFlowSource` to an argument
  * of a method call that executes injected script.
  */
 module ScriptInjectionConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof ScriptInjectionSink }
 }

--- a/java/ql/src/experimental/Security/CWE/CWE-094/SpringViewManipulationLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/SpringViewManipulationLib.qll
@@ -42,7 +42,7 @@ class PortletRenderRequestMethod extends Method {
  */
 module SpringViewManipulationConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) {
-    source instanceof RemoteFlowSource or
+    source instanceof ThreatModelFlowSource or
     source instanceof WebRequestSource or
     source.asExpr().(MethodAccess).getMethod() instanceof PortletRenderRequestMethod
   }

--- a/java/ql/src/experimental/Security/CWE/CWE-200/InsecureWebResourceResponse.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-200/InsecureWebResourceResponse.ql
@@ -19,7 +19,7 @@ import AndroidWebResourceResponse
 import InsecureWebResourceResponseFlow::PathGraph
 
 module InsecureWebResourceResponseConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node src) { src instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof WebResourceResponseSink }
 

--- a/java/ql/src/experimental/Security/CWE/CWE-208/NonConstantTimeCheckOnSignatureQuery.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-208/NonConstantTimeCheckOnSignatureQuery.qll
@@ -148,7 +148,7 @@ private predicate updateMessageDigestStep(DataFlow2::Node fromNode, DataFlow2::N
  * such as cipher, MAC or signature.
  */
 private module UserInputInCryptoOperationConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) {
     exists(ProduceCryptoCall call | call.getQualifier() = sink.asExpr())
@@ -214,7 +214,7 @@ private class NonConstantTimeComparisonCall extends StaticMethodAccess {
  * that compare inputs using a non-constant-time algorithm.
  */
 private module UserInputInComparisonConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) {
     exists(NonConstantTimeEqualsCall call |

--- a/java/ql/src/experimental/Security/CWE/CWE-346/UnvalidatedCors.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-346/UnvalidatedCors.ql
@@ -63,7 +63,7 @@ module CorsSourceReachesCheckConfig implements DataFlow::ConfigSig {
 module CorsSourceReachesCheckFlow = TaintTracking::Global<CorsSourceReachesCheckConfig>;
 
 private module CorsOriginConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) {
     exists(MethodAccess corsHeader, MethodAccess allowCredentialsHeader |

--- a/java/ql/src/experimental/Security/CWE/CWE-352/JsonpInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-352/JsonpInjection.ql
@@ -22,7 +22,7 @@ import RequestResponseFlow::PathGraph
 /** Taint-tracking configuration tracing flow from get method request sources to output jsonp data. */
 module RequestResponseFlowConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) {
-    source instanceof RemoteFlowSource and
+    source instanceof ThreatModelFlowSource and
     any(RequestGetMethod m).polyCalls*(source.getEnclosingCallable())
   }
 

--- a/java/ql/src/experimental/Security/CWE/CWE-352/JsonpInjectionLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-352/JsonpInjectionLib.qll
@@ -77,16 +77,26 @@ class JsonpBuilderExpr extends AddExpr {
   Expr getJsonExpr() { result = this.getLeftOperand().(AddExpr).getRightOperand() }
 }
 
-/** A data flow configuration tracing flow from remote sources to jsonp function name. */
-module RemoteFlowConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
+/** A data flow configuration tracing flow from threat model sources to jsonp function name. */
+module ThreatModelFlowConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node src) { src instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) {
     exists(JsonpBuilderExpr jhe | jhe.getFunctionName() = sink.asExpr())
   }
 }
 
-module RemoteFlow = DataFlow::Global<RemoteFlowConfig>;
+/**
+ * DEPRECATED: Use `ThreatModelFlowConfig` instead.
+ */
+deprecated module RemoteFlowConfig = ThreatModelFlowConfig;
+
+module ThreatModelFlow = DataFlow::Global<ThreatModelFlowConfig>;
+
+/**
+ * DEPRECATED: Use `ThreatModelFlow` instead.
+ */
+deprecated module RemoteFlow = ThreatModelFlow;
 
 /** A data flow configuration tracing flow from json data into the argument `json` of JSONP-like string `someFunctionName + "(" + json + ")"`. */
 module JsonDataFlowConfig implements DataFlow::ConfigSig {
@@ -105,7 +115,7 @@ module JsonpInjectionFlowConfig implements DataFlow::ConfigSig {
     exists(JsonpBuilderExpr jhe |
       jhe = src.asExpr() and
       JsonDataFlow::flowTo(DataFlow::exprNode(jhe.getJsonExpr())) and
-      RemoteFlow::flowTo(DataFlow::exprNode(jhe.getFunctionName()))
+      ThreatModelFlow::flowTo(DataFlow::exprNode(jhe.getFunctionName()))
     )
   }
 

--- a/java/ql/src/experimental/Security/CWE/CWE-352/JsonpInjectionLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-352/JsonpInjectionLib.qll
@@ -86,17 +86,7 @@ module ThreatModelFlowConfig implements DataFlow::ConfigSig {
   }
 }
 
-/**
- * DEPRECATED: Use `ThreatModelFlowConfig` instead.
- */
-deprecated module RemoteFlowConfig = ThreatModelFlowConfig;
-
 module ThreatModelFlow = DataFlow::Global<ThreatModelFlowConfig>;
-
-/**
- * DEPRECATED: Use `ThreatModelFlow` instead.
- */
-deprecated module RemoteFlow = ThreatModelFlow;
 
 /** A data flow configuration tracing flow from json data into the argument `json` of JSONP-like string `someFunctionName + "(" + json + ")"`. */
 module JsonDataFlowConfig implements DataFlow::ConfigSig {

--- a/java/ql/src/experimental/Security/CWE/CWE-400/ThreadResourceAbuse.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-400/ThreadResourceAbuse.ql
@@ -17,7 +17,7 @@ import ThreadResourceAbuseFlow::PathGraph
 
 /** Taint configuration of uncontrolled thread resource consumption. */
 module ThreadResourceAbuseConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof PauseThreadSink }
 

--- a/java/ql/src/experimental/Security/CWE/CWE-470/UnsafeReflection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-470/UnsafeReflection.ql
@@ -32,7 +32,7 @@ private predicate equalsSanitizer(Guard g, Expr e, boolean branch) {
 }
 
 module UnsafeReflectionConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof UnsafeReflectionSink }
 

--- a/java/ql/src/experimental/Security/CWE/CWE-552/UnsafeUrlForward.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-552/UnsafeUrlForward.ql
@@ -21,7 +21,7 @@ import UnsafeUrlForwardFlow::PathGraph
 
 module UnsafeUrlForwardFlowConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) {
-    source instanceof RemoteFlowSource and
+    source instanceof ThreatModelFlowSource and
     not exists(MethodAccess ma, Method m | ma.getMethod() = m |
       (
         m instanceof HttpServletRequestGetRequestUriMethod or

--- a/java/ql/src/experimental/Security/CWE/CWE-600/UncaughtServletException.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-600/UncaughtServletException.ql
@@ -65,9 +65,9 @@ class UncaughtServletExceptionSink extends DataFlow::ExprNode {
   }
 }
 
-/** Taint configuration of uncaught exceptions caused by user provided data from `RemoteFlowSource` */
+/** Taint configuration of uncaught exceptions caused by user provided data from `ThreatModelFlowSource` */
 module UncaughtServletExceptionConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof UncaughtServletExceptionSink }
 }

--- a/java/ql/src/experimental/Security/CWE/CWE-601/SpringUrlRedirect.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-601/SpringUrlRedirect.ql
@@ -26,7 +26,7 @@ private predicate startsWithSanitizer(Guard g, Expr e, boolean branch) {
 }
 
 module SpringUrlRedirectFlowConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof SpringUrlRedirectSink }
 

--- a/java/ql/src/experimental/Security/CWE/CWE-652/XQueryInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-652/XQueryInjection.ql
@@ -20,7 +20,7 @@ import XQueryInjectionFlow::PathGraph
  * A taint-tracking configuration tracing flow from remote sources, through an XQuery parser, to its eventual execution.
  */
 module XQueryInjectionConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) {
     sink.asExpr() = any(XQueryPreparedExecuteCall xpec).getPreparedExpression() or

--- a/java/ql/src/experimental/Security/CWE/CWE-755/NFEAndroidDoS.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-755/NFEAndroidDoS.ql
@@ -24,7 +24,7 @@ import NfeLocalDoSFlow::PathGraph
  */
 module NfeLocalDoSConfig implements DataFlow::ConfigSig {
   /** Holds if source is a remote flow source */
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   /** Holds if NFE is thrown but not caught */
   predicate isSink(DataFlow::Node sink) {

--- a/java/ql/test/library-tests/dataflow/entrypoint-types/EntryPointTypesTest.ql
+++ b/java/ql/test/library-tests/dataflow/entrypoint-types/EntryPointTypesTest.ql
@@ -9,7 +9,7 @@ class TestRemoteFlowSource extends RemoteFlowSource {
 }
 
 module TaintFlowConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node n) { n instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node n) { n instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node n) {
     exists(MethodAccess ma | ma.getMethod().hasName("sink") | n.asExpr() = ma.getAnArgument())

--- a/java/ql/test/library-tests/frameworks/JaxWs/JaxRsFlow.ql
+++ b/java/ql/test/library-tests/frameworks/JaxWs/JaxRsFlow.ql
@@ -7,7 +7,7 @@ module Config implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node node) {
     DefaultFlowConfig::isSource(node)
     or
-    node instanceof RemoteFlowSource
+    node instanceof ThreatModelFlowSource
   }
 
   predicate isSink = DefaultFlowConfig::isSink/1;

--- a/java/ql/test/library-tests/frameworks/android/content-provider/test.ql
+++ b/java/ql/test/library-tests/frameworks/android/content-provider/test.ql
@@ -3,7 +3,7 @@ import semmle.code.java.dataflow.FlowSources
 import TestUtilities.InlineFlowTest
 
 module ProviderTaintFlowConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node n) { n instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node n) { n instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node n) { DefaultFlowConfig::isSink(n) }
 

--- a/java/ql/test/library-tests/frameworks/android/external-storage/test.ql
+++ b/java/ql/test/library-tests/frameworks/android/external-storage/test.ql
@@ -4,7 +4,7 @@ import semmle.code.java.dataflow.FlowSources
 import TestUtilities.InlineFlowTest
 
 module Config implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node src) { src instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) {
     sink.asExpr().(Argument).getCall().getCallee().hasName("sink")

--- a/java/ql/test/library-tests/frameworks/android/slice/test.ql
+++ b/java/ql/test/library-tests/frameworks/android/slice/test.ql
@@ -5,7 +5,7 @@ import semmle.code.java.dataflow.FlowSources
 
 module SliceValueFlowConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) {
-    DefaultFlowConfig::isSource(source) or source instanceof RemoteFlowSource
+    DefaultFlowConfig::isSource(source) or source instanceof ThreatModelFlowSource
   }
 
   predicate isSink = DefaultFlowConfig::isSink/1;

--- a/java/ql/test/library-tests/frameworks/android/sources/OnActivityResultSourceTest.ql
+++ b/java/ql/test/library-tests/frameworks/android/sources/OnActivityResultSourceTest.ql
@@ -3,7 +3,7 @@ import semmle.code.java.dataflow.FlowSources
 import TestUtilities.InlineFlowTest
 
 module SourceValueFlowConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node src) { src instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { DefaultFlowConfig::isSink(sink) }
 

--- a/java/ql/test/library-tests/frameworks/apache-http/flow.ql
+++ b/java/ql/test/library-tests/frameworks/apache-http/flow.ql
@@ -9,7 +9,7 @@ module Config implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node n) {
     n.asExpr().(MethodAccess).getMethod().hasName("taint")
     or
-    n instanceof RemoteFlowSource
+    n instanceof ThreatModelFlowSource
   }
 
   predicate isSink(DataFlow::Node n) {

--- a/java/ql/test/library-tests/frameworks/guice/flow.ql
+++ b/java/ql/test/library-tests/frameworks/guice/flow.ql
@@ -3,7 +3,7 @@ import semmle.code.java.dataflow.FlowSources
 import semmle.code.java.dataflow.TaintTracking
 
 module Config implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node src) { src instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) {
     exists(MethodAccess ma |

--- a/java/ql/test/library-tests/frameworks/jms/FlowTest.ql
+++ b/java/ql/test/library-tests/frameworks/jms/FlowTest.ql
@@ -3,7 +3,7 @@ import semmle.code.java.dataflow.FlowSources
 import TestUtilities.InlineExpectationsTest
 
 module TestConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) {
     exists(MethodAccess call |

--- a/java/ql/test/library-tests/frameworks/netty/manual/test.ql
+++ b/java/ql/test/library-tests/frameworks/netty/manual/test.ql
@@ -7,7 +7,7 @@ module Config implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node node) {
     DefaultFlowConfig::isSource(node)
     or
-    node instanceof RemoteFlowSource
+    node instanceof ThreatModelFlowSource
   }
 
   predicate isSink = DefaultFlowConfig::isSink/1;

--- a/java/ql/test/library-tests/frameworks/rabbitmq/FlowTest.ql
+++ b/java/ql/test/library-tests/frameworks/rabbitmq/FlowTest.ql
@@ -4,7 +4,7 @@ import semmle.code.java.dataflow.FlowSources
 import TestUtilities.InlineFlowTest
 
 module Config implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node node) { node instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node node) { node instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node node) {
     exists(MethodAccess ma | ma.getMethod().hasName("sink") | node.asExpr() = ma.getAnArgument())

--- a/java/ql/test/library-tests/frameworks/ratpack/flow.ql
+++ b/java/ql/test/library-tests/frameworks/ratpack/flow.ql
@@ -7,7 +7,7 @@ module Config implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node n) {
     n.asExpr().(MethodAccess).getMethod().hasName("taint")
     or
-    n instanceof RemoteFlowSource
+    n instanceof ThreatModelFlowSource
   }
 
   predicate isSink(DataFlow::Node n) {

--- a/java/ql/test/library-tests/frameworks/spring/controller/test.ql
+++ b/java/ql/test/library-tests/frameworks/spring/controller/test.ql
@@ -3,7 +3,7 @@ import semmle.code.java.dataflow.FlowSources
 import TestUtilities.InlineFlowTest
 
 module ValueFlowConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) {
     sink.asExpr().(Argument).getCall().getCallee().hasName("sink")


### PR DESCRIPTION
In this PR we basically opt-in all existing java queries (that are tracking dataflow from remote flow sources) to threat models.
This PR is semantics preserving in terms of results (under the *default* threat model). However, query results can change drastically if the threat model is changed (as the DCA executions below show)

There is one open question: Should we use the `ThreatModelFlowSource` class of nodes in `entrypointType` instead of `RemoteFlowSource` - this will affect all taint tracking configurations as it changes the semantics of `defaultAdditionalTaintStep`. To me it looks like we should make the change.

DCA executions show the following:
1. There are no changes in results or any indication of performance regressions on the nightly test/query suite, if the *default* threat model is applied.
2. If we extend the current threat model to also include *local* sources, thousands of new results are produced across queries for nightly/nightly. Also there doesn't appear to be any performance regressions. Some comments and explanations:
   - The query `java/concatenated-command-line` in some cases produces less results and this is because it excludes the results of `java/command-line-injection` (which might produce more results as more sources are taken into account). 
   - The query `java/tainted-arithmetic` in some cases produces lots of extra results. For the project `geogebra__geogebra` there are only two extra results. I spot checked that one of these extra results actually originated from a *local* source.
   - The query `java/path-injection` and `java/path-injection-local` produces 28 and 90 results on main and on this feature branch they produce 118 and 90 (for the project `geogebra__geogebra`), which is as expected: On main `java/path-injection-local` uses local sources and `java/path-injection` uses remote flow sources. In this feature branch, the threat model configuration, includes both the remote- and local sources and the result of `java/path-injection` is the union of the results of the `path-injection` queries on main (results have been spot checked - and the numbers add up).

