### PR TITLE
C++: Use 'unique' in `hasIRRepresentationOfIndirectInstruction`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
@@ -815,7 +815,7 @@ private module Cached {
   ) {
     indirectionIndex = [1 .. countIndirectionsForCppType(getResultLanguageType(instr))] and
     exists(Instruction load, Operand address |
-      address.getDef() = instr and
+      address = unique( | | getAUse(instr)) and
       isDereference(load, address, false) and
       instrRepr = load and
       indirectionIndexRepr = indirectionIndex - 1


### PR DESCRIPTION
The predicate `hasIRRepresentationOfIndirectInstruction` introduced in https://github.com/github/codeql/pull/14008 didn't require the address had a single use. This gave some new FPs when upgrading the frontend. This PR fixes these regressions.