### PR TITLE
Add skeleton bazel files for accessing the dbschemes.

### DIFF
--- a/cpp/BUILD.bazel
+++ b/cpp/BUILD.bazel
@@ -1,10 +1,15 @@
-package(default_visibility = ["//visibility:public"])
-
 load("@rules_pkg//:mappings.bzl", "pkg_filegroup")
+
+package(default_visibility = ["//visibility:public"])
 
 alias(
     name = "dbscheme",
     actual = "//cpp/ql/lib:dbscheme",
+)
+
+alias(
+    name = "dbscheme-stats",
+    actual = "//cpp/ql/lib:dbscheme-stats",
 )
 
 pkg_filegroup(

--- a/cpp/ql/lib/BUILD.bazel
+++ b/cpp/ql/lib/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//cpp:__pkg__"])
-
 load("@rules_pkg//:mappings.bzl", "pkg_files")
+
+package(default_visibility = ["//cpp:__pkg__"])
 
 pkg_files(
     name = "dbscheme",

--- a/csharp/BUILD.bazel
+++ b/csharp/BUILD.bazel
@@ -1,0 +1,11 @@
+package(default_visibility = ["//visibility:public"])
+
+alias(
+    name = "dbscheme",
+    actual = "//csharp/ql/lib:dbscheme",
+)
+
+alias(
+    name = "dbscheme-stats",
+    actual = "//csharp/ql/lib:dbscheme-stats",
+)

--- a/csharp/ql/lib/BUILD.bazel
+++ b/csharp/ql/lib/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_pkg//:mappings.bzl", "pkg_files")
+
+package(default_visibility = ["//csharp:__pkg__"])
+
+pkg_files(
+    name = "dbscheme",
+    srcs = ["semmlecode.csharp.dbscheme"],
+    prefix = "csharp",
+)
+
+pkg_files(
+    name = "dbscheme-stats",
+    srcs = ["semmlecode.csharp.dbscheme.stats"],
+    prefix = "csharp",
+)

--- a/java/BUILD.bazel
+++ b/java/BUILD.bazel
@@ -1,0 +1,11 @@
+package(default_visibility = ["//visibility:public"])
+
+alias(
+    name = "dbscheme",
+    actual = "//java/ql/lib/config:dbscheme",
+)
+
+alias(
+    name = "dbscheme-stats",
+    actual = "//java/ql/lib/config:dbscheme-stats",
+)

--- a/java/ql/lib/config/BUILD.bazel
+++ b/java/ql/lib/config/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_pkg//:mappings.bzl", "pkg_files")
+
+package(default_visibility = ["//java:__pkg__"])
+
+pkg_files(
+    name = "dbscheme",
+    srcs = ["semmlecode.dbscheme"],
+    prefix = "java",
+)
+
+pkg_files(
+    name = "dbscheme-stats",
+    srcs = ["semmlecode.dbscheme.stats"],
+    prefix = "java",
+)

--- a/javascript/BUILD.bazel
+++ b/javascript/BUILD.bazel
@@ -1,0 +1,11 @@
+package(default_visibility = ["//visibility:public"])
+
+alias(
+    name = "dbscheme",
+    actual = "//javascript/ql/lib:dbscheme",
+)
+
+alias(
+    name = "dbscheme-stats",
+    actual = "//javascript/ql/lib:dbscheme-stats",
+)

--- a/javascript/ql/lib/BUILD.bazel
+++ b/javascript/ql/lib/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_pkg//:mappings.bzl", "pkg_files")
+
+package(default_visibility = ["//javascript:__pkg__"])
+
+pkg_files(
+    name = "dbscheme",
+    srcs = ["semmlecode.javascript.dbscheme"],
+    prefix = "javascript",
+)
+
+pkg_files(
+    name = "dbscheme-stats",
+    srcs = ["semmlecode.javascript.dbscheme.stats"],
+    prefix = "javascript",
+)

--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -1,0 +1,11 @@
+package(default_visibility = ["//visibility:public"])
+
+alias(
+    name = "dbscheme",
+    actual = "//python/ql/lib:dbscheme",
+)
+
+alias(
+    name = "dbscheme-stats",
+    actual = "//python/ql/lib:dbscheme-stats",
+)

--- a/python/ql/lib/BUILD.bazel
+++ b/python/ql/lib/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_pkg//:mappings.bzl", "pkg_files")
+
+package(default_visibility = ["//python:__pkg__"])
+
+pkg_files(
+    name = "dbscheme",
+    srcs = ["semmlecode.python.dbscheme"],
+    prefix = "python",
+)
+
+pkg_files(
+    name = "dbscheme-stats",
+    srcs = ["semmlecode.python.dbscheme.stats"],
+    prefix = "python",
+)


### PR DESCRIPTION
This adds skeleton bazel files that export the dbschemes and stats files.

This is needed so our internal unit tests can read those files.