### PR TITLE
Swift: defaultImplicitTaintRead performance improvement

### DIFF
--- a/swift/ql/lib/codeql/swift/dataflow/internal/TaintTrackingPublic.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/TaintTrackingPublic.qll
@@ -31,7 +31,7 @@ predicate defaultImplicitTaintRead(DataFlow::Node node, DataFlow::ContentSet cs)
   // So when the node is a `PostUpdateNode` we allow any sequence of implicit read steps of an appropriate
   // type to make sure we arrive at the sink with an empty access path.
   exists(NominalTypeDecl d, Decl cx |
-    node.(DataFlow::PostUpdateNode).getPreUpdateNode().asExpr().getType().getUnderlyingType() =
+    pragma[only_bind_out](node).(DataFlow::PostUpdateNode).getPreUpdateNode().asExpr().getType().getUnderlyingType() =
       d.getType().getABaseType*() and
     cx.asNominalTypeDecl() = d and
     cs.getAReadContent().(DataFlow::Content::FieldContent).getField() = cx.getAMember()

--- a/swift/ql/lib/codeql/swift/dataflow/internal/TaintTrackingPublic.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/TaintTrackingPublic.qll
@@ -31,8 +31,12 @@ predicate defaultImplicitTaintRead(DataFlow::Node node, DataFlow::ContentSet cs)
   // So when the node is a `PostUpdateNode` we allow any sequence of implicit read steps of an appropriate
   // type to make sure we arrive at the sink with an empty access path.
   exists(NominalTypeDecl d, Decl cx |
-    pragma[only_bind_out](node).(DataFlow::PostUpdateNode).getPreUpdateNode().asExpr().getType().getUnderlyingType() =
-      d.getType().getABaseType*() and
+    pragma[only_bind_out](node)
+        .(DataFlow::PostUpdateNode)
+        .getPreUpdateNode()
+        .asExpr()
+        .getType()
+        .getUnderlyingType() = d.getType().getABaseType*() and
     cx.asNominalTypeDecl() = d and
     cs.getAReadContent().(DataFlow::Content::FieldContent).getField() = cx.getAMember()
   )

--- a/swift/ql/lib/codeql/swift/dataflow/internal/TaintTrackingPublic.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/TaintTrackingPublic.qll
@@ -26,17 +26,14 @@ predicate localTaintStep = localTaintStepCached/2;
  * of `c` at sinks and inputs to additional taint steps.
  */
 bindingset[node]
+pragma[inline_late]
 predicate defaultImplicitTaintRead(DataFlow::Node node, DataFlow::ContentSet cs) {
   // If a `PostUpdateNode` is specified as a sink, there's (almost) always a store step preceding it.
   // So when the node is a `PostUpdateNode` we allow any sequence of implicit read steps of an appropriate
   // type to make sure we arrive at the sink with an empty access path.
   exists(NominalTypeDecl d, Decl cx |
-    pragma[only_bind_out](node)
-        .(DataFlow::PostUpdateNode)
-        .getPreUpdateNode()
-        .asExpr()
-        .getType()
-        .getUnderlyingType() = d.getType().getABaseType*() and
+    node.(DataFlow::PostUpdateNode).getPreUpdateNode().asExpr().getType().getUnderlyingType() =
+      d.getType().getABaseType*() and
     cx.asNominalTypeDecl() = d and
     cs.getAReadContent().(DataFlow::Content::FieldContent).getField() = cx.getAMember()
   )


### PR DESCRIPTION
Performance Improvement motivated by a discovery on a nightly run.

Despite the `bindingset[node]` annotation, the evaluator was attempting to bind `node` using the internal logic of the predicate before applying the externally derived binding (which comes from `TaintTrackingImpl.qll`'s `allowImplicitRead`), causing an explosion of computation.  Forcing the issue with `pragma[only_bind_out]` appears to entirely solve the issue.

Locally I'm seeing something like a 30s improvement on multiple queries.  A DCA run should confirm...