### PR TITLE
Go: Fix version detection and test for `newer-go-version-needed`

### DIFF
--- a/go/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/go/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -788,7 +788,9 @@ func installDependenciesAndBuild() {
 
 	goVersionInfo := tryReadGoDirective(buildInfo)
 
-	if goVersionInfo.Found && semver.Compare("v"+goVersionInfo.Version, getEnvGoSemVer()) > 0 {
+	// This diagnostic is not required if the system Go version is 1.21 or greater, since the
+	// Go tooling should install required Go versions as needed.
+	if semver.Compare(getEnvGoSemVer(), "v1.21.0") < 0 && goVersionInfo.Found && semver.Compare("v"+goVersionInfo.Version, getEnvGoSemVer()) > 0 {
 		diagnostics.EmitNewerGoVersionNeeded()
 	}
 

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/newer-go-version-needed/diagnostics.expected
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/newer-go-version-needed/diagnostics.expected
@@ -12,17 +12,3 @@
     "telemetry": true
   }
 }
-{
-  "markdownMessage": "The detected version of Go is lower than the version specified in `go.mod`. [Install a newer version](https://github.com/actions/setup-go#basic).",
-  "severity": "error",
-  "source": {
-    "extractorName": "go",
-    "id": "go/autobuilder/newer-go-version-needed",
-    "name": "Newer Go version needed"
-  },
-  "visibility": {
-    "cliSummaryTable": true,
-    "statusPage": true,
-    "telemetry": true
-  }
-}

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/newer-go-version-needed/test.py
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/newer-go-version-needed/test.py
@@ -4,6 +4,6 @@ from create_database_utils import *
 from diagnostics_test_utils import *
 
 os.environ['LGTM_INDEX_IMPORT_PATH'] = "test"
-run_codeql_database_create([], lang="go", source="work", db=None)
+run_codeql_database_create([], lang="go", source="work", db=None, runFunction=runUnsuccessfully)
 
 check_diagnostics()

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/newer-go-version-needed/work/go.mod
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/newer-go-version-needed/work/go.mod
@@ -1,3 +1,3 @@
-go 999.0
+go 1.999.0
 
 module test


### PR DESCRIPTION
**Sumarry**

This PR cherry-picks the commits from #14194 that are needed to support an internal PR. 

We change the following:
- We invoke `go version` with `GOTOOLCHAIN=local` to force it to return the version of the local toolchain, rather than attempt to download whatever toolchain the project needs and then run its `version` command.
- The `newer-go-version-needed` diagnostic is no longer needed for Go 1.21+
- The test for the `newer-go-version-needed` diagnostic needs to be updated to account for that, since we are running the tests with Go 1.21+ only.

**How to review**

The tests here are expected to fail, but should pass for the internal PR. 

#14194 was previously approved.
