### PR TITLE
Swift: Add sinks for the GRDB database library to swift/hardcoded-key

### DIFF
--- a/swift/ql/lib/codeql/swift/security/HardcodedEncryptionKeyExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/HardcodedEncryptionKeyExtensions.qll
@@ -71,6 +71,9 @@ private class EncryptionKeySinks extends SinkModelCsv {
         ";Realm.Configuration;true;init(fileURL:inMemoryIdentifier:syncConfiguration:encryptionKey:readOnly:schemaVersion:migrationBlock:deleteRealmIfMigrationNeeded:shouldCompactOnLaunch:objectTypes:);;;Argument[3];encryption-key",
         ";Realm.Configuration;true;init(fileURL:inMemoryIdentifier:syncConfiguration:encryptionKey:readOnly:schemaVersion:migrationBlock:deleteRealmIfMigrationNeeded:shouldCompactOnLaunch:objectTypes:seedFilePath:);;;Argument[3];encryption-key",
         ";Realm.Configuration;true;encryptionKey;;;PostUpdate;encryption-key",
+        // GRDB
+        ";Database;true;usePassphrase(_:);;;Argument[0];encryption-key",
+        ";Database;true;changePassphrase(_:);;;Argument[0];encryption-key",
       ]
   }
 }

--- a/swift/ql/src/change-notes/2023-10-06-const-key-sinks.md
+++ b/swift/ql/src/change-notes/2023-10-06-const-key-sinks.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added sinks for the GRDB database library to the `swift/hardcoded-key` query.

--- a/swift/ql/test/query-tests/Security/CWE-321/HardcodedEncryptionKey.expected
+++ b/swift/ql/test/query-tests/Security/CWE-321/HardcodedEncryptionKey.expected
@@ -22,6 +22,12 @@ edges
 | file://:0:0:0:0 | [post] self [encryptionKey] | file://:0:0:0:0 | [post] self |
 | file://:0:0:0:0 | [post] self [encryptionKey] | file://:0:0:0:0 | [post] self |
 | file://:0:0:0:0 | value | file://:0:0:0:0 | [post] self [encryptionKey] |
+| grdb.swift:21:20:21:20 | abc123 | grdb.swift:27:23:27:23 | constString |
+| grdb.swift:21:20:21:20 | abc123 | grdb.swift:31:26:31:26 | constString |
+| grdb.swift:22:33:22:50 | [...] | grdb.swift:23:23:23:23 | constArray |
+| grdb.swift:23:18:23:33 | call to Data.init(_:) | grdb.swift:29:23:29:23 | constData |
+| grdb.swift:23:18:23:33 | call to Data.init(_:) | grdb.swift:33:26:33:26 | constData |
+| grdb.swift:23:23:23:23 | constArray | grdb.swift:23:18:23:33 | call to Data.init(_:) |
 | misc.swift:30:7:30:7 | value | file://:0:0:0:0 | value |
 | misc.swift:46:19:46:38 | call to Data.init(_:) | misc.swift:49:41:49:41 | myConstKey |
 | misc.swift:46:19:46:38 | call to Data.init(_:) | misc.swift:53:25:53:25 | myConstKey |
@@ -78,6 +84,14 @@ nodes
 | file://:0:0:0:0 | [post] self | semmle.label | [post] self |
 | file://:0:0:0:0 | [post] self [encryptionKey] | semmle.label | [post] self [encryptionKey] |
 | file://:0:0:0:0 | value | semmle.label | value |
+| grdb.swift:21:20:21:20 | abc123 | semmle.label | abc123 |
+| grdb.swift:22:33:22:50 | [...] | semmle.label | [...] |
+| grdb.swift:23:18:23:33 | call to Data.init(_:) | semmle.label | call to Data.init(_:) |
+| grdb.swift:23:23:23:23 | constArray | semmle.label | constArray |
+| grdb.swift:27:23:27:23 | constString | semmle.label | constString |
+| grdb.swift:29:23:29:23 | constData | semmle.label | constData |
+| grdb.swift:31:26:31:26 | constString | semmle.label | constString |
+| grdb.swift:33:26:33:26 | constData | semmle.label | constData |
 | misc.swift:30:7:30:7 | value | semmle.label | value |
 | misc.swift:46:19:46:38 | call to Data.init(_:) | semmle.label | call to Data.init(_:) |
 | misc.swift:46:24:46:24 | abcdef123456 | semmle.label | abcdef123456 |
@@ -131,6 +145,10 @@ subpaths
 | cryptoswift.swift:163:24:163:24 | key | cryptoswift.swift:90:26:90:121 | [...] | cryptoswift.swift:163:24:163:24 | key | The key 'key' has been initialized with hard-coded values from $@. | cryptoswift.swift:90:26:90:121 | [...] | [...] |
 | cryptoswift.swift:164:24:164:24 | keyString | cryptoswift.swift:76:3:76:3 | this string is constant | cryptoswift.swift:164:24:164:24 | keyString | The key 'keyString' has been initialized with hard-coded values from $@. | cryptoswift.swift:76:3:76:3 | this string is constant | this string is constant |
 | file://:0:0:0:0 | [post] self | misc.swift:46:24:46:24 | abcdef123456 | file://:0:0:0:0 | [post] self | The key '[post] self' has been initialized with hard-coded values from $@. | misc.swift:46:24:46:24 | abcdef123456 | abcdef123456 |
+| grdb.swift:27:23:27:23 | constString | grdb.swift:21:20:21:20 | abc123 | grdb.swift:27:23:27:23 | constString | The key 'constString' has been initialized with hard-coded values from $@. | grdb.swift:21:20:21:20 | abc123 | abc123 |
+| grdb.swift:29:23:29:23 | constData | grdb.swift:22:33:22:50 | [...] | grdb.swift:29:23:29:23 | constData | The key 'constData' has been initialized with hard-coded values from $@. | grdb.swift:22:33:22:50 | [...] | [...] |
+| grdb.swift:31:26:31:26 | constString | grdb.swift:21:20:21:20 | abc123 | grdb.swift:31:26:31:26 | constString | The key 'constString' has been initialized with hard-coded values from $@. | grdb.swift:21:20:21:20 | abc123 | abc123 |
+| grdb.swift:33:26:33:26 | constData | grdb.swift:22:33:22:50 | [...] | grdb.swift:33:26:33:26 | constData | The key 'constData' has been initialized with hard-coded values from $@. | grdb.swift:22:33:22:50 | [...] | [...] |
 | misc.swift:49:41:49:41 | myConstKey | misc.swift:46:24:46:24 | abcdef123456 | misc.swift:49:41:49:41 | myConstKey | The key 'myConstKey' has been initialized with hard-coded values from $@. | misc.swift:46:24:46:24 | abcdef123456 | abcdef123456 |
 | misc.swift:53:2:53:2 | [post] config | misc.swift:46:24:46:24 | abcdef123456 | misc.swift:53:2:53:2 | [post] config | The key '[post] config' has been initialized with hard-coded values from $@. | misc.swift:46:24:46:24 | abcdef123456 | abcdef123456 |
 | misc.swift:57:2:57:18 | [post] getter for .config | misc.swift:46:24:46:24 | abcdef123456 | misc.swift:57:2:57:18 | [post] getter for .config | The key '[post] getter for .config' has been initialized with hard-coded values from $@. | misc.swift:46:24:46:24 | abcdef123456 | abcdef123456 |

--- a/swift/ql/test/query-tests/Security/CWE-321/grdb.swift
+++ b/swift/ql/test/query-tests/Security/CWE-321/grdb.swift
@@ -24,11 +24,11 @@ func test(db: Database, varString: String, varArray: Array<UInt8>, varData: Data
 
 	// GRDB
 	try db.usePassphrase(varString)
-	try db.usePassphrase(constString) // BAD: constant key [NOT DETECTED]
+	try db.usePassphrase(constString) // BAD: constant key
 	try db.usePassphrase(varData)
-	try db.usePassphrase(constData) // BAD: constant key [NOT DETECTED]
+	try db.usePassphrase(constData) // BAD: constant key
 	try db.changePassphrase(varString)
-	try db.changePassphrase(constString) // BAD: constant key [NOT DETECTED]
+	try db.changePassphrase(constString) // BAD: constant key
 	try db.changePassphrase(Data(varArray))
-	try db.changePassphrase(constData) // BAD: constant key [NOT DETECTED]
+	try db.changePassphrase(constData) // BAD: constant key
 }

--- a/swift/ql/test/query-tests/Security/CWE-321/grdb.swift
+++ b/swift/ql/test/query-tests/Security/CWE-321/grdb.swift
@@ -1,0 +1,34 @@
+
+// --- stubs ---
+
+class Data {
+    init<S>(_ elements: S) {}
+}
+
+class Database {
+}
+
+extension Database {
+	func usePassphrase(_ passphrase: String) throws { }
+	func usePassphrase(_ passphrase: Data) throws { }
+	func changePassphrase(_ passphrase: String) throws { }
+	func changePassphrase(_ passphrase: Data) throws { }
+}
+
+// --- tests ---
+
+func test(db: Database, varString: String, varArray: Array<UInt8>, varData: Data) throws {
+	let constString = "abc123"
+	let constArray: Array<UInt8> = [1, 2, 3, 4, 5, 6]
+	let constData = Data(constArray)
+
+	// GRDB
+	try db.usePassphrase(varString)
+	try db.usePassphrase(constString) // BAD: constant key [NOT DETECTED]
+	try db.usePassphrase(varData)
+	try db.usePassphrase(constData) // BAD: constant key [NOT DETECTED]
+	try db.changePassphrase(varString)
+	try db.changePassphrase(constString) // BAD: constant key [NOT DETECTED]
+	try db.changePassphrase(Data(varArray))
+	try db.changePassphrase(constData) // BAD: constant key [NOT DETECTED]
+}


### PR DESCRIPTION
Add sinks for the GRDB database library to `swift/hardcoded-key`.  That is, model the functions in that library that deal with encryption keys.