### PR TITLE
Update about-telemetry-in-codeql-for-visual-studio-code.rst to mention telemtry.telemetryLevel

### DIFF
--- a/docs/codeql/codeql-for-visual-studio-code/about-telemetry-in-codeql-for-visual-studio-code.rst
+++ b/docs/codeql/codeql-for-visual-studio-code/about-telemetry-in-codeql-for-visual-studio-code.rst
@@ -62,7 +62,7 @@ When telemetry collection is disabled, no data will be sent to GitHub servers.
 
 You can disable telemetry collection by setting ``codeQL.telemetry.enableTelemetry`` to ``false`` in your settings. For more information about CodeQL settings, see ":doc:`Customizing settings <customizing-settings>`." 
 
-Additionally, telemetry collection will be disabled if the global ``telemetry.enableTelemetry`` setting is set to ``false``. For more information about global telemetry collection, see "`Microsoft's documentation <https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting>`__."
+Additionally, telemetry collection will be disabled if the global ``telemetry.telemetryLevel`` setting is set to ``off``. For more information about global telemetry collection, see "`Microsoft's documentation <https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting>`__."
 
 Further reading
 ----------------


### PR DESCRIPTION
The recommended setting to use is now `telemetry.telemetryLevel`.

See https://github.com/github/vscode-codeql/pull/2824 which implemented this change in the extension (currently not released as of writing).

I considered still mentioning the old setting because the extension currently respects both. But the [microsoft documentation](https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting) we link to only mentions the new setting, so I decided to follow that example.