### PR TITLE
C#: Make conflicting assembly selection deterministic in standalone

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/AssemblyCache.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/AssemblyCache.cs
@@ -70,7 +70,8 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             foreach (var info in assemblyInfoByFileName.Values
                 .OrderBy(info => info.Name)
                 .ThenBy(info => info.NetCoreVersion ?? emptyVersion)
-                .ThenBy(info => info.Version ?? emptyVersion))
+                .ThenBy(info => info.Version ?? emptyVersion)
+                .ThenBy(info => info.Filename))
             {
                 foreach (var index in info.IndexStrings)
                 {

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
@@ -322,7 +322,11 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             }
 
             var emptyVersion = new Version(0, 0);
-            sortedReferences = sortedReferences.OrderBy(r => r.NetCoreVersion ?? emptyVersion).ThenBy(r => r.Version ?? emptyVersion).ToList();
+            sortedReferences = sortedReferences
+                .OrderBy(r => r.NetCoreVersion ?? emptyVersion)
+                .ThenBy(r => r.Version ?? emptyVersion)
+                .ThenBy(r => r.Filename)
+                .ToList();
 
             var finalAssemblyList = new Dictionary<string, AssemblyInfo>();
 


### PR DESCRIPTION
This PR helps with setting up standalone integration tests that list assemblies. (https://github.com/github/codeql/pull/14368)