### PR TITLE
JS: Add JSON Stringify Sanitizer

### DIFF
--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ReflectedXssCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ReflectedXssCustomizations.qll
@@ -4,7 +4,6 @@
  */
 
 import javascript
-
 module ReflectedXss {
   private import Xss::Shared as Shared
 
@@ -147,6 +146,13 @@ module ReflectedXss {
   { }
 
   private class IsEscapedInSwitchSanitizer extends Sanitizer, Shared::IsEscapedInSwitchSanitizer { }
+
+  private class JSONParseSanitzier extends Sanitizer {
+    JSONParseSanitzier() {
+      this instanceof JsonStringifyCall and
+      this instanceof HttpResponseSink
+    }
+  }
 
   /** A third-party controllable request input, considered as a flow source for reflected XSS. */
   class ThirdPartyRequestInputAccessAsSource extends Source {

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ReflectedXssCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ReflectedXssCustomizations.qll
@@ -4,6 +4,7 @@
  */
 
 import javascript
+
 module ReflectedXss {
   private import Xss::Shared as Shared
 
@@ -147,11 +148,7 @@ module ReflectedXss {
 
   private class IsEscapedInSwitchSanitizer extends Sanitizer, Shared::IsEscapedInSwitchSanitizer { }
 
-  private class JSONParseSanitzier extends Sanitizer {
-    JSONParseSanitzier() {
-      this instanceof JsonStringifyCall and
-      this instanceof HttpResponseSink
-    }
+  private class JsonParseSanitzier extends Sanitizer instanceof JsonStringifyCall, HttpResponseSink {
   }
 
   /** A third-party controllable request input, considered as a flow source for reflected XSS. */

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ReflectedXssCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ReflectedXssCustomizations.qll
@@ -148,7 +148,7 @@ module ReflectedXss {
 
   private class IsEscapedInSwitchSanitizer extends Sanitizer, Shared::IsEscapedInSwitchSanitizer { }
 
-  private class JsonParseSanitzier extends Sanitizer instanceof JsonStringifyCall, HttpResponseSink {
+  private class JsonStringifySanitzier extends Sanitizer instanceof JsonStringifyCall, HttpResponseSink {
   }
 
   /** A third-party controllable request input, considered as a flow source for reflected XSS. */

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ReflectedXssCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ReflectedXssCustomizations.qll
@@ -148,8 +148,9 @@ module ReflectedXss {
 
   private class IsEscapedInSwitchSanitizer extends Sanitizer, Shared::IsEscapedInSwitchSanitizer { }
 
-  private class JsonStringifySanitzier extends Sanitizer instanceof JsonStringifyCall, HttpResponseSink {
-  }
+  private class JsonStringifySanitzier extends Sanitizer instanceof JsonStringifyCall,
+    HttpResponseSink
+  { }
 
   /** A third-party controllable request input, considered as a flow source for reflected XSS. */
   class ThirdPartyRequestInputAccessAsSource extends Source {

--- a/javascript/ql/src/change-notes/2023-10-11-Jsonstringify-sanitizer
+++ b/javascript/ql/src/change-notes/2023-10-11-Jsonstringify-sanitizer
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added Json.Stringify sanitizer to js/reflected-xss query.

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXssGood.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXssGood.js
@@ -57,6 +57,12 @@ app.get('/user/:id', function(req, res) {
   }
 });
 
+app.get('/user/:id', function(req, res) {
+  const url = req.params.id;
+  // Good: response is stringified and interpreted as json
+  res.send(JSON.stringify(url)); // OK
+});
+
 function escapeHtml1 (str) {
   if (!/["'&<>]/.exec(str)) {
       return str;


### PR DESCRIPTION
JSON Stringify accounts for roughly half of all false positives in the reflected xss query and is found in the form res.send(JSON.stringify(malicious_input)). This sanitizer will remove these FPs.