### PR TITLE
JS/Ruby: desync two queries and port the Ruby version to ConfigSig-style

### DIFF
--- a/config/identical-files.json
+++ b/config/identical-files.json
@@ -498,22 +498,6 @@
     "ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModelsExtensions.qll",
     "python/ql/lib/semmle/python/frameworks/data/internal/ApiGraphModelsExtensions.qll"
   ],
-  "TaintedFormatStringQuery Ruby/JS": [
-    "javascript/ql/lib/semmle/javascript/security/dataflow/TaintedFormatStringQuery.qll",
-    "ruby/ql/lib/codeql/ruby/security/TaintedFormatStringQuery.qll"
-  ],
-  "TaintedFormatStringCustomizations Ruby/JS": [
-    "javascript/ql/lib/semmle/javascript/security/dataflow/TaintedFormatStringCustomizations.qll",
-    "ruby/ql/lib/codeql/ruby/security/TaintedFormatStringCustomizations.qll"
-  ],
-  "HttpToFileAccessQuery JS/Ruby": [
-    "javascript/ql/lib/semmle/javascript/security/dataflow/HttpToFileAccessQuery.qll",
-    "ruby/ql/lib/codeql/ruby/security/HttpToFileAccessQuery.qll"
-  ],
-  "HttpToFileAccessCustomizations JS/Ruby": [
-    "javascript/ql/lib/semmle/javascript/security/dataflow/HttpToFileAccessCustomizations.qll",
-    "ruby/ql/lib/codeql/ruby/security/HttpToFileAccessCustomizations.qll"
-  ],
   "Typo database": [
     "javascript/ql/src/Expressions/TypoDatabase.qll",
     "ql/ql/src/codeql_ql/style/TypoDatabase.qll"

--- a/ruby/ql/lib/codeql/ruby/security/HttpToFileAccessQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/HttpToFileAccessQuery.qll
@@ -11,7 +11,23 @@ private import HttpToFileAccessCustomizations::HttpToFileAccess
 /**
  * A taint tracking configuration for writing user-controlled data to files.
  */
-class Configuration extends TaintTracking::Configuration {
+module HttpToFileAccessConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof Source }
+
+  predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
+
+  predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+}
+
+/**
+ * Taint tracking for writing user-controlled data to files.
+ */
+module HttpToFileAccessFlow = TaintTracking::Global<HttpToFileAccessConfig>;
+
+/**
+ * DEPRECATED. Use the `HttpToFileAccessFlow` module instead.
+ */
+deprecated class Configuration extends TaintTracking::Configuration {
   Configuration() { this = "HttpToFileAccess" }
 
   override predicate isSource(DataFlow::Node source) { source instanceof Source }

--- a/ruby/ql/lib/codeql/ruby/security/TaintedFormatStringQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/TaintedFormatStringQuery.qll
@@ -13,7 +13,23 @@ private import TaintedFormatStringCustomizations::TaintedFormatString
 /**
  * A taint-tracking configuration for format injections.
  */
-class Configuration extends TaintTracking::Configuration {
+module TaintedFormatStringConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof Source }
+
+  predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
+
+  predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+}
+
+/**
+ * Taint-tracking for format injections.
+ */
+module TaintedFormatStringFlow = TaintTracking::Global<TaintedFormatStringConfig>;
+
+/**
+ * DEPRECATED. Use the `TaintedFormatStringFlow` module instead.
+ */
+deprecated class Configuration extends TaintTracking::Configuration {
   Configuration() { this = "TaintedFormatString" }
 
   override predicate isSource(DataFlow::Node source) { source instanceof Source }

--- a/ruby/ql/src/queries/security/cwe-134/TaintedFormatString.ql
+++ b/ruby/ql/src/queries/security/cwe-134/TaintedFormatString.ql
@@ -13,9 +13,9 @@
 import codeql.ruby.AST
 import codeql.ruby.DataFlow
 import codeql.ruby.security.TaintedFormatStringQuery
-import DataFlow::PathGraph
+import TaintedFormatStringFlow::PathGraph
 
-from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasFlowPath(source, sink)
+from TaintedFormatStringFlow::PathNode source, TaintedFormatStringFlow::PathNode sink
+where TaintedFormatStringFlow::flowPath(source, sink)
 select sink.getNode(), source, sink, "Format string depends on a $@.", source.getNode(),
   "user-provided value"

--- a/ruby/ql/src/queries/security/cwe-912/HttpToFileAccess.ql
+++ b/ruby/ql/src/queries/security/cwe-912/HttpToFileAccess.ql
@@ -13,10 +13,10 @@
 
 import codeql.ruby.AST
 import codeql.ruby.DataFlow
-import codeql.ruby.DataFlow::DataFlow::PathGraph
 import codeql.ruby.security.HttpToFileAccessQuery
+import HttpToFileAccessFlow::PathGraph
 
-from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasFlowPath(source, sink)
+from HttpToFileAccessFlow::PathNode source, HttpToFileAccessFlow::PathNode sink
+where HttpToFileAccessFlow::flowPath(source, sink)
 select sink.getNode(), source, sink, "Write to file system depends on $@.", source.getNode(),
   "untrusted data"


### PR DESCRIPTION
The `HttpToFileAccess` and `TaintedFormatString` queries had some files synced by `identical-files.json`, which previously made it impossible to migrate them for one language at a time.

This is problematic for Ruby because a rather trivial change becomes blocked by the JS data flow migration. It's also problematic for the JS migration because the already-large change needs to include Ruby changes on the same branch.

This PR removes the synchronization so each language can migrate independently, and then migrates the queries for Ruby.