### PR TITLE
Swift: skip declarations marked as unavailable

### DIFF
--- a/swift/extractor/SwiftExtractor.cpp
+++ b/swift/extractor/SwiftExtractor.cpp
@@ -170,6 +170,9 @@ static std::unordered_set<swift::ModuleDecl*> extractDeclarations(
                        bodyEmissionStrategy);
   auto topLevelDecls = getTopLevelDecls(module, primaryFile, lazyDeclaration);
   for (auto decl : topLevelDecls) {
+    if (swift::AvailableAttr::isUnavailable(decl)) {
+      continue;
+    }
     visitor.extract(decl);
   }
   for (auto& comment : comments) {

--- a/swift/extractor/translators/DeclTranslator.cpp
+++ b/swift/extractor/translators/DeclTranslator.cpp
@@ -279,7 +279,12 @@ void DeclTranslator::fillTypeDecl(const swift::TypeDecl& decl, codeql::TypeDecl&
 
 void DeclTranslator::fillIterableDeclContext(const swift::IterableDeclContext& decl,
                                              codeql::Decl& entry) {
-  entry.members = dispatcher.fetchRepeatedLabels(decl.getAllMembers());
+  for (auto member : decl.getMembers()) {
+    if (swift::AvailableAttr::isUnavailable(member)) {
+      continue;
+    }
+    entry.members.emplace_back(dispatcher.fetchLabel(member));
+  }
 }
 
 void DeclTranslator::fillVarDecl(const swift::VarDecl& decl, codeql::VarDecl& entry) {

--- a/swift/ql/test/extractor-tests/generated/decl/ClassDecl/ClassDecl_getMember.expected
+++ b/swift/ql/test/extractor-tests/generated/decl/ClassDecl/ClassDecl_getMember.expected
@@ -8,5 +8,5 @@
 | class.swift:11:1:14:1 | Generic | 3 | class.swift:13:9:13:9 | y |
 | class.swift:11:1:14:1 | Generic | 4 | class.swift:11:7:11:7 | Generic<X, Y>.deinit() |
 | class.swift:11:1:14:1 | Generic | 5 | class.swift:11:7:11:7 | Generic<X, Y>.init() |
-| class.swift:16:1:17:1 | Baz | 0 | class.swift:16:21:16:21 | Baz.init() |
-| class.swift:16:1:17:1 | Baz | 1 | class.swift:16:7:16:7 | Baz.deinit() |
+| class.swift:16:1:17:1 | Baz | 0 | class.swift:16:7:16:7 | Baz.deinit() |
+| class.swift:16:1:17:1 | Baz | 1 | class.swift:16:21:16:21 | Baz.init() |

--- a/swift/ql/test/extractor-tests/generated/decl/EnumDecl/EnumDecl_getMember.expected
+++ b/swift/ql/test/extractor-tests/generated/decl/EnumDecl/EnumDecl_getMember.expected
@@ -6,9 +6,9 @@
 | enums.swift:1:1:4:1 | EnumValues | 5 | enums.swift:3:18:3:18 | value4 |
 | enums.swift:1:1:4:1 | EnumValues | 6 | enums.swift:3:26:3:26 | value5 |
 | enums.swift:1:1:4:1 | EnumValues | 7 | file://:0:0:0:0 | __derived_enum_equals(_:_:) |
-| enums.swift:1:1:4:1 | EnumValues | 8 | file://:0:0:0:0 | var ... = ... |
-| enums.swift:1:1:4:1 | EnumValues | 9 | file://:0:0:0:0 | hash(into:) |
-| enums.swift:1:1:4:1 | EnumValues | 10 | file://:0:0:0:0 | hashValue |
+| enums.swift:1:1:4:1 | EnumValues | 8 | file://:0:0:0:0 | hashValue |
+| enums.swift:1:1:4:1 | EnumValues | 9 | file://:0:0:0:0 | var ... = ... |
+| enums.swift:1:1:4:1 | EnumValues | 10 | file://:0:0:0:0 | hash(into:) |
 | enums.swift:7:1:10:1 | EnumValuesWithBase | 0 | enums.swift:8:5:8:18 | case ... |
 | enums.swift:7:1:10:1 | EnumValuesWithBase | 1 | enums.swift:8:10:8:10 | value1 |
 | enums.swift:7:1:10:1 | EnumValuesWithBase | 2 | enums.swift:8:18:8:18 | value2 |
@@ -16,10 +16,10 @@
 | enums.swift:7:1:10:1 | EnumValuesWithBase | 4 | enums.swift:9:10:9:10 | value3 |
 | enums.swift:7:1:10:1 | EnumValuesWithBase | 5 | enums.swift:9:18:9:18 | value4 |
 | enums.swift:7:1:10:1 | EnumValuesWithBase | 6 | enums.swift:9:26:9:26 | value5 |
-| enums.swift:7:1:10:1 | EnumValuesWithBase | 7 | file://:0:0:0:0 | EnumValuesWithBase.init(rawValue:) |
-| enums.swift:7:1:10:1 | EnumValuesWithBase | 8 | file://:0:0:0:0 | var ... = ... |
-| enums.swift:7:1:10:1 | EnumValuesWithBase | 9 | file://:0:0:0:0 | RawValue |
-| enums.swift:7:1:10:1 | EnumValuesWithBase | 10 | file://:0:0:0:0 | rawValue |
+| enums.swift:7:1:10:1 | EnumValuesWithBase | 7 | file://:0:0:0:0 | RawValue |
+| enums.swift:7:1:10:1 | EnumValuesWithBase | 8 | file://:0:0:0:0 | EnumValuesWithBase.init(rawValue:) |
+| enums.swift:7:1:10:1 | EnumValuesWithBase | 9 | file://:0:0:0:0 | rawValue |
+| enums.swift:7:1:10:1 | EnumValuesWithBase | 10 | file://:0:0:0:0 | var ... = ... |
 | enums.swift:12:1:16:1 | EnumWithParams | 0 | enums.swift:13:5:13:22 | case ... |
 | enums.swift:12:1:16:1 | EnumWithParams | 1 | enums.swift:13:10:13:22 | nodata1 |
 | enums.swift:12:1:16:1 | EnumWithParams | 2 | enums.swift:14:5:14:21 | case ... |

--- a/swift/ql/test/extractor-tests/updates/PrintAst.expected
+++ b/swift/ql/test/extractor-tests/updates/PrintAst.expected
@@ -148,18 +148,18 @@ v5.8.swift:
 #-----|           getResult(0): [MemberRefExpr] .tapHandler
 #-----|             getBase(): [DeclRefExpr] self
 #-----|           getResult(0).getFullyConverted(): [InOutExpr] &...
-#   29|   getMember(2): [Initializer] Button.init()
-#   29|       InterfaceType = (Button.Type) -> () -> Button
-#   29|     getSelfParam(): [ParamDecl] self
-#   29|         Type = Button
-#   29|     getBody(): [BraceStmt] { ... }
-#   29|       getElement(0): [ReturnStmt] return
-#   29|   getMember(3): [Initializer] Button.init(tapHandler:)
+#   29|   getMember(2): [Initializer] Button.init(tapHandler:)
 #   29|       InterfaceType = (Button.Type) -> ((() -> ())?) -> Button
 #   29|     getSelfParam(): [ParamDecl] self
 #   29|         Type = Button
 #   29|     getParam(0): [ParamDecl] tapHandler
 #   29|         Type = (() -> ())?
+#   29|   getMember(3): [Initializer] Button.init()
+#   29|       InterfaceType = (Button.Type) -> () -> Button
+#   29|     getSelfParam(): [ParamDecl] self
+#   29|         Type = Button
+#   29|     getBody(): [BraceStmt] { ... }
+#   29|       getElement(0): [ReturnStmt] return
 #   33| [ClassDecl] ViewController
 #   34|   getMember(0): [PatternBindingDecl] var ... = ...
 #   34|     getInit(0): [CallExpr] call to Button.init()

--- a/swift/ql/test/library-tests/ast/PrintAst.expected
+++ b/swift/ql/test/library-tests/ast/PrintAst.expected
@@ -2503,7 +2503,12 @@ cfg.swift:
 #  379|           getArgument(0): [Argument] n: 0
 #  379|             getExpr(): [IntegerLiteralExpr] 0
 #  380|       getElement(1): [ReturnStmt] return
-#  377|   getMember(1): [Initializer] Derived.init(n:)
+#  377|   getMember(1): [Deinitializer] Derived.deinit()
+#  377|       InterfaceType = (Derived) -> () -> ()
+#  377|     getSelfParam(): [ParamDecl] self
+#  377|         Type = Derived
+#  377|     getBody(): [BraceStmt] { ... }
+#  377|   getMember(2): [Initializer] Derived.init(n:)
 #  377|       InterfaceType = (Derived.Type) -> (Int) -> Derived
 #  377|     getSelfParam(): [ParamDecl] self
 #  377|         Type = Derived
@@ -2523,11 +2528,6 @@ cfg.swift:
 #  377|         getArgument(4): [Argument] : #...
 #  377|           getExpr(): [MagicIdentifierLiteralExpr] #...
 #-----|       getElement(1): [ReturnStmt] return
-#  377|   getMember(2): [Deinitializer] Derived.deinit()
-#  377|       InterfaceType = (Derived) -> () -> ()
-#  377|     getSelfParam(): [ParamDecl] self
-#  377|         Type = Derived
-#  377|     getBody(): [BraceStmt] { ... }
 #  383| [NamedFunction] doWithoutCatch(x:)
 #  383|     InterfaceType = (Int) throws -> Int
 #  383|   getParam(0): [ParamDecl] x
@@ -2799,10 +2799,22 @@ cfg.swift:
 #-----|                 getExpr(): [DeclRefExpr] index_a
 #-----|               getArgument(1): [Argument] : index_b
 #-----|                 getExpr(): [DeclRefExpr] index_b
-#-----|       getMember(5): [PatternBindingDecl] var ... = ...
+#-----|       getMember(5): [ConcreteVarDecl] hashValue
+#-----|           Type = Int
+#-----|         getAccessor(0): [Accessor] get
+#-----|             InterfaceType = (MyLocalEnum) -> () -> Int
+#-----|           getSelfParam(): [ParamDecl] self
+#-----|               Type = MyLocalEnum
+#-----|           getBody(): [BraceStmt] { ... }
+#-----|             getElement(0): [ReturnStmt] return ...
+#-----|               getResult(): [CallExpr] call to _hashValue(for:)
+#-----|                 getFunction(): [DeclRefExpr] _hashValue(for:)
+#-----|                 getArgument(0): [Argument] for: self
+#-----|                   getExpr(): [DeclRefExpr] self
+#-----|       getMember(6): [PatternBindingDecl] var ... = ...
 #-----|         getPattern(0): [TypedPattern] ... as ...
 #-----|           getSubPattern(): [NamedPattern] hashValue
-#-----|       getMember(6): [NamedFunction] hash(into:)
+#-----|       getMember(7): [NamedFunction] hash(into:)
 #-----|           InterfaceType = (MyLocalEnum) -> (inout Hasher) -> ()
 #-----|         getSelfParam(): [ParamDecl] self
 #-----|             Type = MyLocalEnum
@@ -2836,18 +2848,6 @@ cfg.swift:
 #-----|             getArgument(0): [Argument] : discriminator
 #-----|               getExpr(): [DeclRefExpr] discriminator
 #-----|               getExpr().getFullyConverted(): [LoadExpr] (Int) ...
-#-----|       getMember(7): [ConcreteVarDecl] hashValue
-#-----|           Type = Int
-#-----|         getAccessor(0): [Accessor] get
-#-----|             InterfaceType = (MyLocalEnum) -> () -> Int
-#-----|           getSelfParam(): [ParamDecl] self
-#-----|               Type = MyLocalEnum
-#-----|           getBody(): [BraceStmt] { ... }
-#-----|             getElement(0): [ReturnStmt] return ...
-#-----|               getResult(): [CallExpr] call to _hashValue(for:)
-#-----|                 getFunction(): [DeclRefExpr] _hashValue(for:)
-#-----|                 getArgument(0): [Argument] for: self
-#-----|                   getExpr(): [DeclRefExpr] self
 #  428|     getElement(3): [PatternBindingDecl] var ... = ...
 #  428|       getPattern(0): [TypedPattern] ... as ...
 #  428|         getSubPattern(): [NamedPattern] myLocalVar
@@ -3451,18 +3451,18 @@ declarations.swift:
 #-----|           getResult(0): [MemberRefExpr] .next
 #-----|             getBase(): [DeclRefExpr] self
 #-----|           getResult(0).getFullyConverted(): [InOutExpr] &...
-#    1|   getMember(4): [Initializer] Foo.init()
-#    1|       InterfaceType = (Foo.Type) -> () -> Foo
-#    1|     getSelfParam(): [ParamDecl] self
-#    1|         Type = Foo
-#    1|     getBody(): [BraceStmt] { ... }
-#    1|       getElement(0): [ReturnStmt] return
-#    1|   getMember(5): [Initializer] Foo.init(x:)
+#    1|   getMember(4): [Initializer] Foo.init(x:)
 #    1|       InterfaceType = (Foo.Type) -> (Int) -> Foo
 #    1|     getSelfParam(): [ParamDecl] self
 #    1|         Type = Foo
 #    1|     getParam(0): [ParamDecl] x
 #    1|         Type = Int
+#    1|   getMember(5): [Initializer] Foo.init()
+#    1|       InterfaceType = (Foo.Type) -> () -> Foo
+#    1|     getSelfParam(): [ParamDecl] self
+#    1|         Type = Foo
+#    1|     getBody(): [BraceStmt] { ... }
+#    1|       getElement(0): [ReturnStmt] return
 #    9| [ClassDecl] Bar
 #    9|   getMember(0): [PatternBindingDecl] var ... = ...
 #    9|     getInit(0): [FloatLiteralExpr] 1.3
@@ -3616,10 +3616,22 @@ declarations.swift:
 #-----|             getExpr(): [DeclRefExpr] index_a
 #-----|           getArgument(1): [Argument] : index_b
 #-----|             getExpr(): [DeclRefExpr] index_b
-#-----|   getMember(8): [PatternBindingDecl] var ... = ...
+#-----|   getMember(8): [ConcreteVarDecl] hashValue
+#-----|       Type = Int
+#-----|     getAccessor(0): [Accessor] get
+#-----|         InterfaceType = (EnumValues) -> () -> Int
+#-----|       getSelfParam(): [ParamDecl] self
+#-----|           Type = EnumValues
+#-----|       getBody(): [BraceStmt] { ... }
+#-----|         getElement(0): [ReturnStmt] return ...
+#-----|           getResult(): [CallExpr] call to _hashValue(for:)
+#-----|             getFunction(): [DeclRefExpr] _hashValue(for:)
+#-----|             getArgument(0): [Argument] for: self
+#-----|               getExpr(): [DeclRefExpr] self
+#-----|   getMember(9): [PatternBindingDecl] var ... = ...
 #-----|     getPattern(0): [TypedPattern] ... as ...
 #-----|       getSubPattern(): [NamedPattern] hashValue
-#-----|   getMember(9): [NamedFunction] hash(into:)
+#-----|   getMember(10): [NamedFunction] hash(into:)
 #-----|       InterfaceType = (EnumValues) -> (inout Hasher) -> ()
 #-----|     getSelfParam(): [ParamDecl] self
 #-----|         Type = EnumValues
@@ -3674,18 +3686,6 @@ declarations.swift:
 #-----|         getArgument(0): [Argument] : discriminator
 #-----|           getExpr(): [DeclRefExpr] discriminator
 #-----|           getExpr().getFullyConverted(): [LoadExpr] (Int) ...
-#-----|   getMember(10): [ConcreteVarDecl] hashValue
-#-----|       Type = Int
-#-----|     getAccessor(0): [Accessor] get
-#-----|         InterfaceType = (EnumValues) -> () -> Int
-#-----|       getSelfParam(): [ParamDecl] self
-#-----|           Type = EnumValues
-#-----|       getBody(): [BraceStmt] { ... }
-#-----|         getElement(0): [ReturnStmt] return ...
-#-----|           getResult(): [CallExpr] call to _hashValue(for:)
-#-----|             getFunction(): [DeclRefExpr] _hashValue(for:)
-#-----|             getArgument(0): [Argument] for: self
-#-----|               getExpr(): [DeclRefExpr] self
 #   16| [EnumDecl] EnumWithParams
 #   17|   getMember(0): [EnumCaseDecl] case ...
 #   17|   getMember(1): [EnumElementDecl] nodata1
@@ -4370,7 +4370,12 @@ declarations.swift:
 #  150|       Type = C
 #  150|   getBody(): [BraceStmt] { ... }
 #  152| [ClassDecl] Derived
-#  152|   getMember(0): [Initializer] Derived.init()
+#  152|   getMember(0): [Deinitializer] Derived.deinit()
+#  152|       InterfaceType = (Derived) -> () -> ()
+#  152|     getSelfParam(): [ParamDecl] self
+#  152|         Type = Derived
+#  152|     getBody(): [BraceStmt] { ... }
+#  152|   getMember(1): [Initializer] Derived.init()
 #  152|       InterfaceType = (Derived.Type) -> () -> Derived
 #  152|     getSelfParam(): [ParamDecl] self
 #  152|         Type = Derived
@@ -4381,11 +4386,6 @@ declarations.swift:
 #-----|             getBase(): [SuperRefExpr] super
 #-----|             getMethodRef(): [OtherInitializerRefExpr] Baz.init()
 #-----|       getElement(1): [ReturnStmt] return
-#  152|   getMember(1): [Deinitializer] Derived.deinit()
-#  152|       InterfaceType = (Derived) -> () -> ()
-#  152|     getSelfParam(): [ParamDecl] self
-#  152|         Type = Derived
-#  152|     getBody(): [BraceStmt] { ... }
 #  154| [Comment] // multiple conversions
 #  154| 
 #  155| [TopLevelCodeDecl] { ... }
@@ -4559,10 +4559,22 @@ expressions.swift:
 #-----|             getExpr(): [DeclRefExpr] index_a
 #-----|           getArgument(1): [Argument] : index_b
 #-----|             getExpr(): [DeclRefExpr] index_b
-#-----|   getMember(3): [PatternBindingDecl] var ... = ...
+#-----|   getMember(3): [ConcreteVarDecl] hashValue
+#-----|       Type = Int
+#-----|     getAccessor(0): [Accessor] get
+#-----|         InterfaceType = (AnError) -> () -> Int
+#-----|       getSelfParam(): [ParamDecl] self
+#-----|           Type = AnError
+#-----|       getBody(): [BraceStmt] { ... }
+#-----|         getElement(0): [ReturnStmt] return ...
+#-----|           getResult(): [CallExpr] call to _hashValue(for:)
+#-----|             getFunction(): [DeclRefExpr] _hashValue(for:)
+#-----|             getArgument(0): [Argument] for: self
+#-----|               getExpr(): [DeclRefExpr] self
+#-----|   getMember(4): [PatternBindingDecl] var ... = ...
 #-----|     getPattern(0): [TypedPattern] ... as ...
 #-----|       getSubPattern(): [NamedPattern] hashValue
-#-----|   getMember(4): [NamedFunction] hash(into:)
+#-----|   getMember(5): [NamedFunction] hash(into:)
 #-----|       InterfaceType = (AnError) -> (inout Hasher) -> ()
 #-----|     getSelfParam(): [ParamDecl] self
 #-----|         Type = AnError
@@ -4589,18 +4601,6 @@ expressions.swift:
 #-----|         getArgument(0): [Argument] : discriminator
 #-----|           getExpr(): [DeclRefExpr] discriminator
 #-----|           getExpr().getFullyConverted(): [LoadExpr] (Int) ...
-#-----|   getMember(5): [ConcreteVarDecl] hashValue
-#-----|       Type = Int
-#-----|     getAccessor(0): [Accessor] get
-#-----|         InterfaceType = (AnError) -> () -> Int
-#-----|       getSelfParam(): [ParamDecl] self
-#-----|           Type = AnError
-#-----|       getBody(): [BraceStmt] { ... }
-#-----|         getElement(0): [ReturnStmt] return ...
-#-----|           getResult(): [CallExpr] call to _hashValue(for:)
-#-----|             getFunction(): [DeclRefExpr] _hashValue(for:)
-#-----|             getArgument(0): [Argument] for: self
-#-----|               getExpr(): [DeclRefExpr] self
 #   14| [NamedFunction] failure(_:)
 #   14|     InterfaceType = (Int) throws -> ()
 #   14|   getParam(0): [ParamDecl] x
@@ -4953,7 +4953,12 @@ expressions.swift:
 #   79|           getArgument(0): [Argument] x: 22
 #   79|             getExpr(): [IntegerLiteralExpr] 22
 #   80|       getElement(1): [ReturnStmt] return
-#   77|   getMember(1): [Initializer] Derived.init(x:)
+#   77|   getMember(1): [Deinitializer] Derived.deinit()
+#   77|       InterfaceType = (Derived) -> () -> ()
+#   77|     getSelfParam(): [ParamDecl] self
+#   77|         Type = Derived
+#   77|     getBody(): [BraceStmt] { ... }
+#   77|   getMember(2): [Initializer] Derived.init(x:)
 #   77|       InterfaceType = (Derived.Type) -> (Int) -> Derived
 #   77|     getSelfParam(): [ParamDecl] self
 #   77|         Type = Derived
@@ -4973,11 +4978,6 @@ expressions.swift:
 #   77|         getArgument(4): [Argument] : #...
 #   77|           getExpr(): [MagicIdentifierLiteralExpr] #...
 #-----|       getElement(1): [ReturnStmt] return
-#   77|   getMember(2): [Deinitializer] Derived.deinit()
-#   77|       InterfaceType = (Derived) -> () -> ()
-#   77|     getSelfParam(): [ParamDecl] self
-#   77|         Type = Derived
-#   77|     getBody(): [BraceStmt] { ... }
 #   83| [TopLevelCodeDecl] { ... }
 #   83|   getBody(): [BraceStmt] { ... }
 #   83|     getElement(0): [PatternBindingDecl] var ... = ...
@@ -6862,10 +6862,22 @@ statements.swift:
 #-----|             getExpr(): [DeclRefExpr] index_a
 #-----|           getArgument(1): [Argument] : index_b
 #-----|             getExpr(): [DeclRefExpr] index_b
-#-----|   getMember(3): [PatternBindingDecl] var ... = ...
+#-----|   getMember(3): [ConcreteVarDecl] hashValue
+#-----|       Type = Int
+#-----|     getAccessor(0): [Accessor] get
+#-----|         InterfaceType = (AnError) -> () -> Int
+#-----|       getSelfParam(): [ParamDecl] self
+#-----|           Type = AnError
+#-----|       getBody(): [BraceStmt] { ... }
+#-----|         getElement(0): [ReturnStmt] return ...
+#-----|           getResult(): [CallExpr] call to _hashValue(for:)
+#-----|             getFunction(): [DeclRefExpr] _hashValue(for:)
+#-----|             getArgument(0): [Argument] for: self
+#-----|               getExpr(): [DeclRefExpr] self
+#-----|   getMember(4): [PatternBindingDecl] var ... = ...
 #-----|     getPattern(0): [TypedPattern] ... as ...
 #-----|       getSubPattern(): [NamedPattern] hashValue
-#-----|   getMember(4): [NamedFunction] hash(into:)
+#-----|   getMember(5): [NamedFunction] hash(into:)
 #-----|       InterfaceType = (AnError) -> (inout Hasher) -> ()
 #-----|     getSelfParam(): [ParamDecl] self
 #-----|         Type = AnError
@@ -6892,18 +6904,6 @@ statements.swift:
 #-----|         getArgument(0): [Argument] : discriminator
 #-----|           getExpr(): [DeclRefExpr] discriminator
 #-----|           getExpr().getFullyConverted(): [LoadExpr] (Int) ...
-#-----|   getMember(5): [ConcreteVarDecl] hashValue
-#-----|       Type = Int
-#-----|     getAccessor(0): [Accessor] get
-#-----|         InterfaceType = (AnError) -> () -> Int
-#-----|       getSelfParam(): [ParamDecl] self
-#-----|           Type = AnError
-#-----|       getBody(): [BraceStmt] { ... }
-#-----|         getElement(0): [ReturnStmt] return ...
-#-----|           getResult(): [CallExpr] call to _hashValue(for:)
-#-----|             getFunction(): [DeclRefExpr] _hashValue(for:)
-#-----|             getArgument(0): [Argument] for: self
-#-----|               getExpr(): [DeclRefExpr] self
 #   38| [NamedFunction] failure(_:)
 #   38|     InterfaceType = (Int) throws -> ()
 #   38|   getParam(0): [ParamDecl] x

--- a/swift/ql/test/library-tests/dataflow/taint/core/TaintInline.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/core/TaintInline.expected
@@ -1,2 +1,2 @@
-testFailures
 failures
+testFailures

--- a/swift/ql/test/library-tests/dataflow/taint/libraries/TaintInline.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/libraries/TaintInline.expected
@@ -1,2 +1,2 @@
-testFailures
 failures
+testFailures

--- a/swift/ql/test/library-tests/elements/expr/methodlookup/PrintAst.expected
+++ b/swift/ql/test/library-tests/elements/expr/methodlookup/PrintAst.expected
@@ -43,15 +43,7 @@ methodlookup.swift:
 #   11|     getSelfParam(): [ParamDecl] self
 #   11|         Type = Bar.Type
 #   11|     getBody(): [BraceStmt] { ... }
-#-----|   getMember(3): [PatternBindingDecl] var ... = ...
-#-----|     getPattern(0): [TypedPattern] ... as ...
-#-----|       getSubPattern(): [NamedPattern] unownedExecutor
-#    8|   getMember(4): [Deinitializer] Bar.deinit()
-#    8|       InterfaceType = (Bar) -> () -> ()
-#    8|     getSelfParam(): [ParamDecl] self
-#    8|         Type = Bar
-#    8|     getBody(): [BraceStmt] { ... }
-#-----|   getMember(5): [ConcreteVarDecl] unownedExecutor
+#-----|   getMember(3): [ConcreteVarDecl] unownedExecutor
 #-----|       Type = UnownedSerialExecutor
 #-----|     getAccessor(0): [Accessor] get
 #-----|         InterfaceType = (Bar) -> () -> UnownedSerialExecutor
@@ -68,6 +60,14 @@ methodlookup.swift:
 #-----|                 getFunction(): [DeclRefExpr] buildDefaultActorExecutorRef(_:)
 #-----|                 getArgument(0): [Argument] : self
 #-----|                   getExpr(): [DeclRefExpr] self
+#-----|   getMember(4): [PatternBindingDecl] var ... = ...
+#-----|     getPattern(0): [TypedPattern] ... as ...
+#-----|       getSubPattern(): [NamedPattern] unownedExecutor
+#    8|   getMember(5): [Deinitializer] Bar.deinit()
+#    8|       InterfaceType = (Bar) -> () -> ()
+#    8|     getSelfParam(): [ParamDecl] self
+#    8|         Type = Bar
+#    8|     getBody(): [BraceStmt] { ... }
 #   15| [ClassDecl] Baz
 #   16|   getMember(0): [Initializer] Baz.init()
 #   16|       InterfaceType = (Baz.Type) -> () -> Baz


### PR DESCRIPTION
Technically, this is a no-op for our test suite, though I'm not sure why the order has changed.
This is required for https://github.com/github/codeql/pull/14261 as it fixes a crash when we try to extract certain unavailable declarations.