### PR TITLE
Python: exclude loops from `varBlockStep`

### DIFF
--- a/python/ql/lib/semmle/python/essa/SsaCompute.qll
+++ b/python/ql/lib/semmle/python/essa/SsaCompute.qll
@@ -399,6 +399,7 @@ private module SsaComputeImpl {
       b2 = b1.getASuccessor() and
       blockPrecedesVar(v, b2)
       or
+      not b1 = b2 and
       exists(BasicBlock mid |
         varBlockReaches(v, b1, mid) and
         b2 = mid.getASuccessor() and

--- a/python/ql/test/experimental/dataflow/coverage/dataflow-consistency.expected
+++ b/python/ql/test/experimental/dataflow/coverage/dataflow-consistency.expected
@@ -25,18 +25,5 @@ uniqueParameterNodeAtPosition
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep
-| datamodel.py:84:15:84:15 | ControlFlowNode for x | Node steps to itself |
-| datamodel.py:166:11:166:11 | ControlFlowNode for x | Node steps to itself |
-| test.py:103:10:103:15 | ControlFlowNode for SOURCE | Node steps to itself |
-| test.py:130:10:130:15 | ControlFlowNode for SOURCE | Node steps to itself |
-| test.py:162:13:162:18 | ControlFlowNode for SOURCE | Node steps to itself |
-| test.py:167:13:167:18 | ControlFlowNode for SOURCE | Node steps to itself |
-| test.py:216:10:216:15 | ControlFlowNode for SOURCE | Node steps to itself |
-| test.py:242:9:242:12 | ControlFlowNode for SINK | Node steps to itself |
-| test.py:673:9:673:12 | ControlFlowNode for SINK | Node steps to itself |
-| test.py:674:9:674:14 | ControlFlowNode for SINK_F | Node steps to itself |
-| test.py:682:9:682:12 | ControlFlowNode for SINK | Node steps to itself |
-| test.py:690:9:690:12 | ControlFlowNode for SINK | Node steps to itself |
-| test.py:696:5:696:8 | ControlFlowNode for SINK | Node steps to itself |
 missingArgumentCall
 multipleArgumentCall

--- a/python/ql/test/experimental/dataflow/tainttracking/defaultAdditionalTaintStep-py3/dataflow-consistency.expected
+++ b/python/ql/test/experimental/dataflow/tainttracking/defaultAdditionalTaintStep-py3/dataflow-consistency.expected
@@ -23,7 +23,5 @@ uniqueParameterNodeAtPosition
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep
-| test_collections.py:20:9:20:22 | ControlFlowNode for ensure_tainted | Node steps to itself |
-| test_unpacking.py:31:9:31:22 | ControlFlowNode for ensure_tainted | Node steps to itself |
 missingArgumentCall
 multipleArgumentCall

--- a/python/ql/test/experimental/dataflow/tainttracking/defaultAdditionalTaintStep/dataflow-consistency.expected
+++ b/python/ql/test/experimental/dataflow/tainttracking/defaultAdditionalTaintStep/dataflow-consistency.expected
@@ -23,20 +23,5 @@ uniqueParameterNodeAtPosition
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep
-| test_async.py:48:9:48:22 | ControlFlowNode for ensure_tainted | Node steps to itself |
-| test_collections.py:64:10:64:21 | ControlFlowNode for tainted_list | Node steps to itself |
-| test_collections.py:71:9:71:22 | ControlFlowNode for ensure_tainted | Node steps to itself |
-| test_collections.py:73:9:73:22 | ControlFlowNode for ensure_tainted | Node steps to itself |
-| test_collections.py:88:10:88:21 | ControlFlowNode for tainted_list | Node steps to itself |
-| test_collections.py:89:10:89:23 | ControlFlowNode for TAINTED_STRING | Node steps to itself |
-| test_collections.py:97:9:97:22 | ControlFlowNode for ensure_tainted | Node steps to itself |
-| test_collections.py:99:9:99:22 | ControlFlowNode for ensure_tainted | Node steps to itself |
-| test_collections.py:112:9:112:22 | ControlFlowNode for ensure_tainted | Node steps to itself |
-| test_collections.py:114:9:114:22 | ControlFlowNode for ensure_tainted | Node steps to itself |
-| test_collections.py:147:9:147:22 | ControlFlowNode for ensure_tainted | Node steps to itself |
-| test_collections.py:149:9:149:22 | ControlFlowNode for ensure_tainted | Node steps to itself |
-| test_collections.py:246:9:246:15 | ControlFlowNode for my_dict | Node steps to itself |
-| test_collections.py:246:22:246:33 | ControlFlowNode for tainted_dict | Node steps to itself |
-| test_for.py:24:9:24:22 | ControlFlowNode for ensure_tainted | Node steps to itself |
 missingArgumentCall
 multipleArgumentCall

--- a/python/ql/test/experimental/dataflow/variable-capture/dataflow-consistency.expected
+++ b/python/ql/test/experimental/dataflow/variable-capture/dataflow-consistency.expected
@@ -29,8 +29,5 @@ uniqueParameterNodeAtPosition
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep
-| test_collections.py:36:10:36:15 | ControlFlowNode for SOURCE | Node steps to itself |
-| test_collections.py:45:19:45:21 | ControlFlowNode for mod | Node steps to itself |
-| test_collections.py:52:13:52:21 | ControlFlowNode for mod_local | Node steps to itself |
 missingArgumentCall
 multipleArgumentCall

--- a/python/ql/test/library-tests/ApiGraphs/py3/dataflow-consistency.expected
+++ b/python/ql/test/library-tests/ApiGraphs/py3/dataflow-consistency.expected
@@ -27,7 +27,5 @@ uniqueParameterNodeAtPosition
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep
-| test_captured.py:7:22:7:22 | ControlFlowNode for p | Node steps to itself |
-| test_captured.py:14:26:14:27 | ControlFlowNode for pp | Node steps to itself |
 missingArgumentCall
 multipleArgumentCall

--- a/python/ql/test/library-tests/frameworks/django-orm/ReflectedXss.expected
+++ b/python/ql/test/library-tests/frameworks/django-orm/ReflectedXss.expected
@@ -16,7 +16,6 @@ edges
 | testapp/orm_security_tests.py:42:13:42:18 | SSA variable person [Attribute name] | testapp/orm_security_tests.py:43:49:43:54 | ControlFlowNode for person [Attribute name] |
 | testapp/orm_security_tests.py:42:23:42:42 | ControlFlowNode for Attribute() [List element, Attribute age] | testapp/orm_security_tests.py:42:13:42:18 | SSA variable person [Attribute age] |
 | testapp/orm_security_tests.py:42:23:42:42 | ControlFlowNode for Attribute() [List element, Attribute name] | testapp/orm_security_tests.py:42:13:42:18 | SSA variable person [Attribute name] |
-| testapp/orm_security_tests.py:43:13:43:21 | SSA variable resp_text | testapp/orm_security_tests.py:43:13:43:21 | SSA variable resp_text |
 | testapp/orm_security_tests.py:43:13:43:21 | SSA variable resp_text | testapp/orm_security_tests.py:44:29:44:37 | ControlFlowNode for resp_text |
 | testapp/orm_security_tests.py:43:49:43:54 | ControlFlowNode for person [Attribute name] | testapp/orm_security_tests.py:43:49:43:59 | ControlFlowNode for Attribute |
 | testapp/orm_security_tests.py:43:49:43:59 | ControlFlowNode for Attribute | testapp/orm_security_tests.py:43:13:43:21 | SSA variable resp_text |

--- a/python/ql/test/library-tests/frameworks/django-orm/dataflow-consistency.expected
+++ b/python/ql/test/library-tests/frameworks/django-orm/dataflow-consistency.expected
@@ -106,23 +106,5 @@ uniqueParameterNodeAtPosition
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep
-| testapp/orm_tests.py:217:24:217:29 | ControlFlowNode for SOURCE | Node steps to itself |
-| testapp/orm_tests.py:244:24:244:29 | ControlFlowNode for SOURCE | Node steps to itself |
-| testapp/orm_tests.py:283:20:283:25 | ControlFlowNode for SOURCE | Node steps to itself |
-| testapp/orm_tests.py:299:15:299:22 | ControlFlowNode for TestLoad | Node steps to itself |
-| testapp/orm_tests.py:300:20:300:25 | ControlFlowNode for SOURCE | Node steps to itself |
-| testapp/orm_tests.py:310:9:310:12 | ControlFlowNode for SINK | Node steps to itself |
-| testapp/orm_tests.py:316:9:316:12 | ControlFlowNode for SINK | Node steps to itself |
-| testapp/orm_tests.py:326:9:326:12 | ControlFlowNode for SINK | Node steps to itself |
-| testapp/orm_tests.py:333:9:333:12 | ControlFlowNode for SINK | Node steps to itself |
-| testapp/orm_tests.py:339:9:339:12 | ControlFlowNode for SINK | Node steps to itself |
-| testapp/orm_tests.py:346:9:346:12 | ControlFlowNode for SINK | Node steps to itself |
-| testapp/orm_tests.py:352:9:352:12 | ControlFlowNode for SINK | Node steps to itself |
-| testapp/orm_tests.py:358:9:358:12 | ControlFlowNode for SINK | Node steps to itself |
-| testapp/orm_tests.py:365:9:365:12 | ControlFlowNode for SINK | Node steps to itself |
-| testapp/tests.py:12:13:12:14 | ControlFlowNode for re | Node steps to itself |
-| testapp/tests.py:16:9:16:18 | ControlFlowNode for test_names | Node steps to itself |
-| testapp/tests.py:25:13:25:14 | ControlFlowNode for re | Node steps to itself |
-| testapp/tests.py:31:9:31:18 | ControlFlowNode for test_names | Node steps to itself |
 missingArgumentCall
 multipleArgumentCall


### PR DESCRIPTION
I tracked the "flow to self" to be in "use to next use", specifically `adjacentUseUseSameVar` can hold when `use1` = `use2`.
This because second conjunct (the non-base case with non-consecutive basic blocks) of `adjacentVarRefs` can become true when `varBlockStep` holds for a loop.

Changes on tests all look good. I would like to understand why this break is not necessary for other languages, though. Do they have other assumptions that we violate?

Edit: I did find [this similar restriction in C#](https://github.com/github/codeql/blob/main/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll#L920), but they do it on the dataflow level. So the question is perhaps more, where the restriction should best be put.

Edit2: Reached out to other language teams, and likely the restriction should be on the dataflow level. The reason is that we actually want to preserve self-loops on the SSA level, since a self loop from `x` to `x` should lead to a dataflow step from `[post] x` to `x` (but not to a dataflow step from `x` to `x`). I will pursue this solution in a different PR.