### PR TITLE
Java: Synchronize `*Local` versions of queries with their remote counterpart

### DIFF
--- a/java/ql/lib/change-notes/2023-10-12-sync-local-and-remote-dataflow-configurations.md
+++ b/java/ql/lib/change-notes/2023-10-12-sync-local-and-remote-dataflow-configurations.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `isBarrier`, `isBarrierIn`, `isBarrierOut`, and `isAdditionalFlowStep` methods of the taint-tracking configurations for local queries in the `ArithmeticTaintedLocalQuery`, `ExternallyControlledFormatStringLocalQuery`, `ImproperValidationOfArrayIndexQuery`, `NumericCastTaintedQuery`, `ResponseSplittingLocalQuery`, `SqlTaintedLocalQuery`, and `XssLocalQuery` libraries have been changed to match their remote counterpart configurations.

--- a/java/ql/lib/semmle/code/java/security/ArithmeticTaintedLocalQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/ArithmeticTaintedLocalQuery.qll
@@ -13,6 +13,8 @@ module ArithmeticTaintedLocalOverflowConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { overflowSink(_, sink.asExpr()) }
 
   predicate isBarrier(DataFlow::Node n) { overflowBarrier(n) }
+
+  predicate isBarrierIn(DataFlow::Node node) { isSource(node) }
 }
 
 /**
@@ -30,6 +32,8 @@ module ArithmeticTaintedLocalUnderflowConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { underflowSink(_, sink.asExpr()) }
 
   predicate isBarrier(DataFlow::Node n) { underflowBarrier(n) }
+
+  predicate isBarrierIn(DataFlow::Node node) { isSource(node) }
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/security/ExternallyControlledFormatStringLocalQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/ExternallyControlledFormatStringLocalQuery.qll
@@ -11,6 +11,10 @@ module ExternallyControlledFormatStringLocalConfig implements DataFlow::ConfigSi
   predicate isSink(DataFlow::Node sink) {
     sink.asExpr() = any(StringFormat formatCall).getFormatArgument()
   }
+
+  predicate isBarrier(DataFlow::Node node) {
+    node.getType() instanceof NumericType or node.getType() instanceof BooleanType
+  }
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/security/ImproperValidationOfArrayIndexLocalQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/ImproperValidationOfArrayIndexLocalQuery.qll
@@ -13,6 +13,10 @@ module ImproperValidationOfArrayIndexLocalConfig implements DataFlow::ConfigSig 
   predicate isSink(DataFlow::Node sink) {
     any(CheckableArrayAccess caa).canThrowOutOfBounds(sink.asExpr())
   }
+
+  predicate isBarrier(DataFlow::Node node) { node.getType() instanceof BooleanType }
+
+  predicate isBarrierIn(DataFlow::Node node) { isSource(node) }
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/security/NumericCastTaintedQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/NumericCastTaintedQuery.qll
@@ -117,7 +117,8 @@ module NumericCastLocalFlowConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node src) { src instanceof LocalUserInput }
 
   predicate isSink(DataFlow::Node sink) {
-    sink.asExpr() = any(NumericNarrowingCastExpr cast).getExpr()
+    sink.asExpr() = any(NumericNarrowingCastExpr cast).getExpr() and
+    sink.asExpr() instanceof VarAccess
   }
 
   predicate isBarrier(DataFlow::Node node) {
@@ -125,8 +126,11 @@ module NumericCastLocalFlowConfig implements DataFlow::ConfigSig {
     castCheck(node.asExpr()) or
     node.getType() instanceof SmallType or
     smallExpr(node.asExpr()) or
-    node.getEnclosingCallable() instanceof HashCodeMethod
+    node.getEnclosingCallable() instanceof HashCodeMethod or
+    exists(RightShiftOp e | e.getShiftedVariable().getAnAccess() = node.asExpr())
   }
+
+  predicate isBarrierIn(DataFlow::Node node) { isSource(node) }
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/security/SqlTaintedLocalQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/SqlTaintedLocalQuery.qll
@@ -17,7 +17,9 @@ module LocalUserInputToQueryInjectionFlowConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { sink instanceof QueryInjectionSink }
 
   predicate isBarrier(DataFlow::Node node) {
-    node.getType() instanceof PrimitiveType or node.getType() instanceof BoxedType
+    node.getType() instanceof PrimitiveType or
+    node.getType() instanceof BoxedType or
+    node.getType() instanceof NumberType
   }
 
   predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {

--- a/java/ql/lib/semmle/code/java/security/XssLocalQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/XssLocalQuery.qll
@@ -12,6 +12,14 @@ module XssLocalConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source instanceof LocalUserInput }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof XssSink }
+
+  predicate isBarrier(DataFlow::Node node) { node instanceof XssSanitizer }
+
+  predicate isBarrierOut(DataFlow::Node node) { node instanceof XssSinkBarrier }
+
+  predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
+    any(XssAdditionalTaintStep s).step(node1, node2)
+  }
 }
 
 /**


### PR DESCRIPTION
Some of the `*Local` versions of queries diverge from their remote counterpart. This PR synchronizes them.