### PR TITLE
Go: Improve Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,5 +25,9 @@ updates:
     allow:
       - dependency-name: "golang.org/x/mod"
       - dependency-name: "golang.org/x/tools"
+    group:
+      extractor-dependencies:
+        patterns:
+          - "golang.org/x/*"
     reviewers:
       - "github/codeql-go"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,5 +22,8 @@ updates:
     directory: "go/extractor"
     schedule:
       interval: "daily"
+    allow:
+      - dependency-name: "golang.org/x/mod"
+      - dependency-name: "golang.org/x/tools"
     reviewers:
       - "github/codeql-go"


### PR DESCRIPTION
We re-add the allow list to (hopefully) suppress the security updates for the test dependencies and group the `golang.org` dependencies together to avoid generating redundant PRs in cases such as https://github.com/github/codeql/pull/14440