### PR TITLE
Java: basic version of automodel extraction query docs

### DIFF
--- a/java/ql/automodel/src/README.md
+++ b/java/ql/automodel/src/README.md
@@ -1,6 +1,6 @@
 # Automodel Java Extraction Queries
 
-This pack contains the automodel extraction queries for Java.
+This pack contains the automodel extraction queries for Java. Automodel uses extraction queries to extract the information it needs in order to create a prompt for a large language model. There's extraction queries for positive examples (things that are known to be, e.g., a sink), for negative examples (things that are known not to be, e.g., a sink), and for candidates (things where we should ask the large language model to classify).
 
 ## Extraction Queries in `java/ql/automodel/src`
 


### PR DESCRIPTION
This adds documentation for the Java extraction queries.

Much of this content is writing down "lore" that accumulated over building and maintaining these queries.

I've tried to stick to information that I would find difficult to get across as comments in the ql/qll files.

## Dear Reviewer

 - I recommend _not_ reviewing commit-by-commit, the documentation should make sense as a whole.
 - I'm a bit reluctant to make the markdown file too big, because it's difficult to keep them in sync with the implementation: Let me know if there's any content missing :smile:
 - I'm trying not to depend on implementation details (that may change) unnecessarily - this would make the documentation prone to going stale quickly. If you spot locations where this obscures the message, please let me know.