### PR TITLE
Java/C/C#: Remove library annotations

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/NameQualifiers.qll
+++ b/cpp/ql/lib/semmle/code/cpp/NameQualifiers.qll
@@ -158,9 +158,7 @@ class NameQualifyingElement extends Element, @namequalifyingelement {
 /**
  * A special name-qualifying element. For example: `__super`.
  */
-library class SpecialNameQualifyingElement extends NameQualifyingElement,
-  @specialnamequalifyingelement
-{
+class SpecialNameQualifyingElement extends NameQualifyingElement, @specialnamequalifyingelement {
   /** Gets the name of this special qualifying element. */
   override string getName() { specialnamequalifyingelements(underlyingElement(this), result) }
 

--- a/cpp/ql/lib/semmle/code/cpp/controlflow/DefinitionsAndUses.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/DefinitionsAndUses.qll
@@ -78,7 +78,7 @@ predicate parameterUsePair(Parameter p, VariableAccess va) {
 /**
  * Utility class: A definition or use of a stack variable.
  */
-library class DefOrUse extends ControlFlowNodeBase {
+class DefOrUse extends ControlFlowNodeBase {
   DefOrUse() {
     // Uninstantiated templates are purely syntax, and only on instantiation
     // will they be complete with information about types, conversions, call
@@ -140,7 +140,7 @@ library class DefOrUse extends ControlFlowNodeBase {
 }
 
 /** A definition of a stack variable. */
-library class Def extends DefOrUse {
+class Def extends DefOrUse {
   Def() { definition(_, this) }
 
   override SemanticStackVariable getVariable(boolean isDef) {
@@ -155,7 +155,7 @@ private predicate parameterIsOverwritten(Function f, Parameter p) {
 }
 
 /** A definition of a parameter. */
-library class ParameterDef extends DefOrUse {
+class ParameterDef extends DefOrUse {
   ParameterDef() {
     // Optimization: parameters that are not overwritten do not require
     // reachability analysis
@@ -169,7 +169,7 @@ library class ParameterDef extends DefOrUse {
 }
 
 /** A use of a stack variable. */
-library class Use extends DefOrUse {
+class Use extends DefOrUse {
   Use() { useOfVar(_, this) }
 
   override SemanticStackVariable getVariable(boolean isDef) {

--- a/cpp/ql/lib/semmle/code/cpp/controlflow/SSA.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/SSA.qll
@@ -10,7 +10,7 @@ import SSAUtils
  * The SSA logic comes in two versions: the standard SSA and range-analysis RangeSSA.
  * This class provides the standard SSA logic.
  */
-library class StandardSsa extends SsaHelper {
+class StandardSsa extends SsaHelper {
   StandardSsa() { this = 0 }
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/controlflow/SSAUtils.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/SSAUtils.qll
@@ -114,7 +114,7 @@ private predicate live_at_exit_of_bb(StackVariable v, BasicBlock b) {
 
 /** Common SSA logic for standard SSA and range-analysis SSA. */
 cached
-library class SsaHelper extends int {
+class SsaHelper extends int {
   /* 0 = StandardSSA, 1 = RangeSSA */
   cached
   SsaHelper() { this in [0 .. 1] }

--- a/cpp/ql/lib/semmle/code/cpp/controlflow/internal/ConstantExprs.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/internal/ConstantExprs.qll
@@ -366,12 +366,12 @@ class CompileTimeConstantInt extends Expr {
   int getIntValue() { result = val }
 }
 
-library class CompileTimeVariableExpr extends Expr {
+class CompileTimeVariableExpr extends Expr {
   CompileTimeVariableExpr() { not this instanceof CompileTimeConstantInt }
 }
 
 /** A helper class for evaluation of expressions. */
-library class ExprEvaluator extends int {
+class ExprEvaluator extends int {
   /*
    * 0 = ConditionEvaluator,
    * 1 = SwitchEvaluator,
@@ -956,7 +956,7 @@ private predicate returnStmt(Function f, Expr value) {
 }
 
 /** A helper class for evaluation of conditions. */
-library class ConditionEvaluator extends ExprEvaluator {
+class ConditionEvaluator extends ExprEvaluator {
   ConditionEvaluator() { this = 0 }
 
   override predicate interesting(Expr e) {
@@ -967,7 +967,7 @@ library class ConditionEvaluator extends ExprEvaluator {
 }
 
 /** A helper class for evaluation of switch expressions. */
-library class SwitchEvaluator extends ExprEvaluator {
+class SwitchEvaluator extends ExprEvaluator {
   SwitchEvaluator() { this = 1 }
 
   override predicate interesting(Expr e) { e = getASwitchExpr(_, _) }
@@ -976,7 +976,7 @@ library class SwitchEvaluator extends ExprEvaluator {
 private int getSwitchValue(Expr e) { exists(SwitchEvaluator x | result = x.getValue(e)) }
 
 /** A helper class for evaluation of loop entry conditions. */
-library class LoopEntryConditionEvaluator extends ExprEvaluator {
+class LoopEntryConditionEvaluator extends ExprEvaluator {
   LoopEntryConditionEvaluator() { this in [2 .. 3] }
 
   abstract override predicate interesting(Expr e);
@@ -1149,7 +1149,7 @@ library class LoopEntryConditionEvaluator extends ExprEvaluator {
 }
 
 /** A helper class for evaluation of while-loop entry conditions. */
-library class WhileLoopEntryConditionEvaluator extends LoopEntryConditionEvaluator {
+class WhileLoopEntryConditionEvaluator extends LoopEntryConditionEvaluator {
   WhileLoopEntryConditionEvaluator() { this = 2 }
 
   override predicate interesting(Expr e) { exists(WhileStmt while | e = while.getCondition()) }
@@ -1162,7 +1162,7 @@ library class WhileLoopEntryConditionEvaluator extends LoopEntryConditionEvaluat
 }
 
 /** A helper class for evaluation of for-loop entry conditions. */
-library class ForLoopEntryConditionEvaluator extends LoopEntryConditionEvaluator {
+class ForLoopEntryConditionEvaluator extends LoopEntryConditionEvaluator {
   ForLoopEntryConditionEvaluator() { this = 3 }
 
   override predicate interesting(Expr e) { exists(ForStmt for | e = for.getCondition()) }

--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/RangeSSA.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/RangeSSA.qll
@@ -29,7 +29,7 @@ private import RangeAnalysisUtils
  * The SSA logic comes in two versions: the standard SSA and range-analysis RangeSSA.
  * This class provides the range-analysis SSA logic.
  */
-library class RangeSsa extends SsaHelper {
+class RangeSsa extends SsaHelper {
   RangeSsa() { this = 1 }
 
   /**

--- a/cpp/ql/src/Microsoft/SAL.qll
+++ b/cpp/ql/src/Microsoft/SAL.qll
@@ -161,7 +161,7 @@ private predicate annotatesAtPosition(SalPosition pos, DeclarationEntry d, File 
  * A SAL element, that is, a SAL annotation or a declaration entry
  * that may have SAL annotations.
  */
-library class SalElement extends Element {
+class SalElement extends Element {
   SalElement() {
     containsSalAnnotation(this.(DeclarationEntry).getFile()) or
     this instanceof SalAnnotation

--- a/csharp/ql/lib/semmle/code/csharp/exprs/Access.qll
+++ b/csharp/ql/lib/semmle/code/csharp/exprs/Access.qll
@@ -398,7 +398,7 @@ class MemberConstantAccess extends FieldAccess {
  * An internal helper class to share logic between `PropertyAccess` and
  * `PropertyCall`.
  */
-library class PropertyAccessExpr extends Expr, @property_access_expr {
+class PropertyAccessExpr extends Expr, @property_access_expr {
   /** Gets the target of this property access. */
   Property getProperty() { expr_access(this, result) }
 
@@ -540,7 +540,7 @@ class ElementWrite extends ElementAccess, AssignableWrite { }
  * An internal helper class to share logic between `IndexerAccess` and
  * `IndexerCall`.
  */
-library class IndexerAccessExpr extends Expr, @indexer_access_expr {
+class IndexerAccessExpr extends Expr, @indexer_access_expr {
   /** Gets the target of this indexer access. */
   Indexer getIndexer() { expr_access(this, result) }
 
@@ -628,7 +628,7 @@ class VirtualIndexerAccess extends IndexerAccess {
  * An internal helper class to share logic between `EventAccess` and
  * `EventCall`.
  */
-library class EventAccessExpr extends Expr, @event_access_expr {
+class EventAccessExpr extends Expr, @event_access_expr {
   /** Gets the target of this event access. */
   Event getEvent() { expr_access(this, result) }
 

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/System.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/System.qll
@@ -654,7 +654,7 @@ class DisposeMethod extends Method {
 }
 
 /** A method with the signature `void Dispose(bool)`. */
-library class DisposeBoolMethod extends Method {
+class DisposeBoolMethod extends Method {
   DisposeBoolMethod() {
     this.hasName("Dispose") and
     this.getReturnType() instanceof VoidType and

--- a/java/ql/lib/semmle/code/java/GeneratedFiles.qll
+++ b/java/ql/lib/semmle/code/java/GeneratedFiles.qll
@@ -44,7 +44,7 @@ abstract class GeneratedFile extends File { }
 /**
  * A file detected as generated based on commonly-used marker comments.
  */
-library class MarkerCommentGeneratedFile extends GeneratedFile {
+class MarkerCommentGeneratedFile extends GeneratedFile {
   MarkerCommentGeneratedFile() { any(GeneratedFileMarker t).getFile() = this }
 }
 

--- a/java/ql/lib/semmle/code/java/JDKAnnotations.qll
+++ b/java/ql/lib/semmle/code/java/JDKAnnotations.qll
@@ -86,7 +86,7 @@ class ReflectiveAccessAnnotation extends Annotation {
  */
 abstract class NonReflectiveAnnotation extends Annotation { }
 
-library class StandardNonReflectiveAnnotation extends NonReflectiveAnnotation {
+class StandardNonReflectiveAnnotation extends NonReflectiveAnnotation {
   StandardNonReflectiveAnnotation() {
     this.getType()
         .hasQualifiedName("java.lang", ["Override", "Deprecated", "SuppressWarnings", "SafeVarargs"])

--- a/java/ql/lib/semmle/code/java/Serializability.qll
+++ b/java/ql/lib/semmle/code/java/Serializability.qll
@@ -24,7 +24,7 @@ abstract class DeserializableField extends Field { }
  * A non-`transient` field in a type that (directly or indirectly) implements the `Serializable` interface
  * and may be read or written via serialization.
  */
-library class StandardSerializableField extends SerializableField, DeserializableField {
+class StandardSerializableField extends SerializableField, DeserializableField {
   StandardSerializableField() {
     this.getDeclaringType().getAnAncestor() instanceof TypeSerializable and
     not this.isTransient()

--- a/java/ql/lib/semmle/code/java/deadcode/DeadCode.qll
+++ b/java/ql/lib/semmle/code/java/deadcode/DeadCode.qll
@@ -140,7 +140,7 @@ class NamespaceClass extends RefType {
  * This represents the set of classes and interfaces for which we will determine liveness. Each
  * `SourceClassOrInterfacce` will either be a `LiveClass` or `DeadClass`.
  */
-library class SourceClassOrInterface extends ClassOrInterface {
+class SourceClassOrInterface extends ClassOrInterface {
   SourceClassOrInterface() { this.fromSource() }
 }
 

--- a/java/ql/lib/semmle/code/java/deadcode/DeadField.qll
+++ b/java/ql/lib/semmle/code/java/deadcode/DeadField.qll
@@ -9,7 +9,7 @@ import semmle.code.java.frameworks.jackson.JacksonSerializability
  *
  * This defines the set of fields for which we will determine liveness.
  */
-library class SourceField extends Field {
+class SourceField extends Field {
   SourceField() { this.fromSource() }
 }
 

--- a/java/ql/lib/semmle/code/java/deadcode/EntryPoints.qll
+++ b/java/ql/lib/semmle/code/java/deadcode/EntryPoints.qll
@@ -94,7 +94,7 @@ abstract class ReflectivelyConstructedClass extends EntryPoint, Class {
 /**
  * Classes that are deserialized by Jackson are reflectively constructed.
  */
-library class JacksonReflectivelyConstructedClass extends ReflectivelyConstructedClass instanceof JacksonDeserializableType
+class JacksonReflectivelyConstructedClass extends ReflectivelyConstructedClass instanceof JacksonDeserializableType
 {
   override Callable getALiveCallable() {
     // Constructors may be called by Jackson, if they are a no-arg, they have a suitable annotation,

--- a/java/ql/lib/semmle/code/java/frameworks/JAXB.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/JAXB.qll
@@ -2,7 +2,7 @@
 
 import semmle.code.java.Type
 
-library class JaxbElement extends Class {
+class JaxbElement extends Class {
   JaxbElement() {
     this.getAnAncestor().getQualifiedName() = "javax.xml.bind.JAXBElement" or
     this.getAnAnnotation().getType().getName() = "XmlRootElement"
@@ -12,7 +12,7 @@ library class JaxbElement extends Class {
 /** DEPRECATED: Alias for JaxbElement */
 deprecated class JAXBElement = JaxbElement;
 
-library class JaxbMarshalMethod extends Method {
+class JaxbMarshalMethod extends Method {
   JaxbMarshalMethod() {
     this.getDeclaringType().getQualifiedName() = "javax.xml.bind.Marshaller" and
     this.getName() = "marshal"
@@ -151,7 +151,7 @@ class JaxbBoundField extends Field {
 /**
  * A getter or setter method, as defined by whether the method name starts with "set" or "get".
  */
-library class GetterOrSetterMethod extends Method {
+class GetterOrSetterMethod extends Method {
   GetterOrSetterMethod() { this.getName().matches("get%") or this.getName().matches("set%") }
 
   Field getField() {

--- a/java/ql/lib/semmle/code/java/frameworks/Mockito.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/Mockito.qll
@@ -301,7 +301,7 @@ private int mockableParameterCount(Constructor constructor) {
 /**
  * A class which is referenced by an `@InjectMocks` field.
  */
-library class MockitoMockInjectedClass extends Class {
+class MockitoMockInjectedClass extends Class {
   MockitoMockInjectedClass() {
     // There must be an `@InjectMock` field that has `this` as the type.
     exists(MockitoInjectedField injectedField | this = injectedField.getType())

--- a/java/ql/lib/semmle/code/java/frameworks/camel/CamelJavaAnnotations.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/camel/CamelJavaAnnotations.qll
@@ -19,7 +19,7 @@ import java
 import semmle.code.java.Reflection
 import semmle.code.java.frameworks.spring.Spring
 
-library class CamelAnnotation extends Annotation {
+class CamelAnnotation extends Annotation {
   CamelAnnotation() { this.getType().getPackage().hasName("org.apache.camel") }
 }
 

--- a/java/ql/lib/semmle/code/java/frameworks/camel/CamelJavaDSL.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/camel/CamelJavaDSL.qll
@@ -21,7 +21,7 @@ import semmle.code.java.frameworks.spring.Spring
 /**
  * A method call to a ProcessorDefinition element.
  */
-library class ProcessorDefinitionElement extends MethodAccess {
+class ProcessorDefinitionElement extends MethodAccess {
   ProcessorDefinitionElement() {
     this.getMethod()
         .getDeclaringType()

--- a/java/ql/lib/semmle/code/java/frameworks/javaee/JavaServerFaces.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/javaee/JavaServerFaces.qll
@@ -7,7 +7,7 @@ import semmle.code.java.frameworks.javaee.jsf.JSFFacesContextXML
 /**
  * A method that is visible to faces, if the instance type is visible to faces.
  */
-library class FacesVisibleMethod extends Method {
+class FacesVisibleMethod extends Method {
   FacesVisibleMethod() { this.isPublic() and not this.isStatic() }
 }
 

--- a/java/ql/lib/semmle/code/java/frameworks/struts/StrutsConventions.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/struts/StrutsConventions.qll
@@ -6,7 +6,7 @@ import semmle.code.xml.MavenPom
 /**
  * A Maven dependency on the Struts 2 convention plugin.
  */
-library class Struts2ConventionDependency extends Dependency {
+class Struts2ConventionDependency extends Dependency {
   Struts2ConventionDependency() {
     this.getGroup().getValue() = "org.apache.struts" and
     this.getArtifact().getValue() = "struts2-convention-plugin"

--- a/java/ql/src/Likely Bugs/Comparison/UselessComparisonTest.qll
+++ b/java/ql/src/Likely Bugs/Comparison/UselessComparisonTest.qll
@@ -6,7 +6,7 @@ import semmle.code.java.dataflow.SSA
 /**
  * The kind of bound that is known to hold for some variable.
  */
-library class BoundKind extends string {
+class BoundKind extends string {
   BoundKind() { this = ["=", "!=", ">=", "<="] }
 
   predicate isEqual() { this = "=" }


### PR DESCRIPTION
Removes all remaining deprecated `library` annotations.