### PR TITLE
C++: Fix ImplicitThisFieldAccess

### DIFF
--- a/cpp/ql/lib/change-notes/2023-10-20-implicit-this.md
+++ b/cpp/ql/lib/change-notes/2023-10-20-implicit-this.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* More field accesses are identified as `ImplicitThisFieldAccess`.

--- a/cpp/ql/lib/semmle/code/cpp/exprs/Access.qll
+++ b/cpp/ql/lib/semmle/code/cpp/exprs/Access.qll
@@ -311,7 +311,7 @@ class ImplicitThisFieldAccess extends FieldAccess {
   override string getAPrimaryQlClass() { result = "ImplicitThisFieldAccess" }
 
   ImplicitThisFieldAccess() {
-    this.getQualifier().isCompilerGenerated() or not exists(this.getQualifier())
+    this.getQualifier().(ThisExpr).isCompilerGenerated() or not exists(this.getQualifier())
   }
 }
 
@@ -330,7 +330,7 @@ class PointerToFieldLiteral extends ImplicitThisFieldAccess {
     // access without a qualifier. The only other unqualified field accesses it
     // emits are for compiler-generated constructors and destructors. When we
     // filter those out, there are only pointer-to-field literals left.
-    not this.isCompilerGenerated()
+    not this.isCompilerGenerated() and not exists(this.getQualifier())
   }
 
   override predicate isConstant() { any() }

--- a/cpp/ql/lib/semmle/code/cpp/exprs/Access.qll
+++ b/cpp/ql/lib/semmle/code/cpp/exprs/Access.qll
@@ -314,7 +314,7 @@ private predicate exprHasReferenceConversion(Expr e) { referenceConversion(e.get
 class ImplicitThisFieldAccess extends FieldAccess {
   override string getAPrimaryQlClass() { result = "ImplicitThisFieldAccess" }
 
-  ImplicitThisFieldAccess() { not exists(this.getQualifier()) }
+  ImplicitThisFieldAccess() { this.getQualifier().isCompilerGenerated() or not exists(this.getQualifier()) }
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/exprs/Access.qll
+++ b/cpp/ql/lib/semmle/code/cpp/exprs/Access.qll
@@ -306,15 +306,13 @@ private predicate exprHasReferenceConversion(Expr e) { referenceConversion(e.get
  *   }
  * };
  * ```
- * Note: the C++ front-end often automatically desugars `field` to
- * `this->field`, so most accesses of `this->field` are instances
- * of `PointerFieldAccess` (with `ThisExpr` as the qualifier), not
- * `ImplicitThisFieldAccess`.
  */
 class ImplicitThisFieldAccess extends FieldAccess {
   override string getAPrimaryQlClass() { result = "ImplicitThisFieldAccess" }
 
-  ImplicitThisFieldAccess() { this.getQualifier().isCompilerGenerated() or not exists(this.getQualifier()) }
+  ImplicitThisFieldAccess() {
+    this.getQualifier().isCompilerGenerated() or not exists(this.getQualifier())
+  }
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/valuenumbering/HashCons.qll
+++ b/cpp/ql/lib/semmle/code/cpp/valuenumbering/HashCons.qll
@@ -372,7 +372,8 @@ private predicate analyzablePointerFieldAccess(PointerFieldAccess access) {
 private predicate mk_PointerFieldAccess(HashCons qualifier, Field target, PointerFieldAccess access) {
   analyzablePointerFieldAccess(access) and
   target = access.getTarget() and
-  qualifier = hashCons(access.getQualifier().getFullyConverted())
+  qualifier = hashCons(access.getQualifier().getFullyConverted()) and
+  not access instanceof ImplicitThisFieldAccess
 }
 
 private predicate analyzableImplicitThisFieldAccess(ImplicitThisFieldAccess access) {

--- a/cpp/ql/test/examples/expressions/PrintAST.expected
+++ b/cpp/ql/test/examples/expressions/PrintAST.expected
@@ -1298,7 +1298,7 @@ union_etc.cpp:
 #    6|       getExpr(): [AssignExpr] ... = ...
 #    6|           Type = [IntType] int
 #    6|           ValueCategory = lvalue
-#    6|         getLValue(): [PointerFieldAccess] x
+#    6|         getLValue(): [ImplicitThisFieldAccess,PointerFieldAccess] x
 #    6|             Type = [IntType] int
 #    6|             ValueCategory = lvalue
 #    6|           getQualifier(): [ThisExpr] this
@@ -1488,7 +1488,7 @@ union_etc.cpp:
 #   33|       getExpr(): [AssignExpr] ... = ...
 #   33|           Type = [IntType] int
 #   33|           ValueCategory = lvalue
-#   33|         getLValue(): [PointerFieldAccess] q
+#   33|         getLValue(): [ImplicitThisFieldAccess,PointerFieldAccess] q
 #   33|             Type = [IntType] int
 #   33|             ValueCategory = lvalue
 #   33|           getQualifier(): [ThisExpr] this

--- a/cpp/ql/test/library-tests/access/FieldAccess/FieldAccess.expected
+++ b/cpp/ql/test/library-tests/access/FieldAccess/FieldAccess.expected
@@ -1,6 +1,6 @@
-| FieldAccess.cpp:11:12:11:13 | p1 | ptr |
-| FieldAccess.cpp:12:12:12:13 | p2 | ptr |
-| FieldAccess.cpp:25:12:25:13 | x1 | ptr |
+| FieldAccess.cpp:11:12:11:13 | p1 | ptr, this |
+| FieldAccess.cpp:12:12:12:13 | p2 | ptr, this |
+| FieldAccess.cpp:25:12:25:13 | x1 | ptr, this |
 | FieldAccess.cpp:29:18:29:19 | x2 | ptr |
 | FieldAccess.cpp:34:3:34:3 | d | this |
 | FieldAccess.cpp:45:13:45:14 | x1 | ptr |
@@ -19,10 +19,10 @@
 | FieldAccess.cpp:91:7:91:7 | x | val |
 | FieldAccess.cpp:91:13:91:13 | y | ref |
 | FieldAccess.cpp:92:8:92:8 | x | ptr |
-| FieldAccess.cpp:92:12:92:12 | y | ptr |
+| FieldAccess.cpp:92:12:92:12 | y | ptr, this |
 | FieldAccess.cpp:93:8:93:8 | x | ptr |
 | FieldAccess.cpp:93:18:93:18 | y | ptr |
 | FieldAccess.cpp:94:11:94:11 | y | ptr |
 | FieldAccess.cpp:94:20:94:20 | y | val |
-| FieldAccess.cpp:113:5:113:5 | x | ptr |
+| FieldAccess.cpp:113:5:113:5 | x | ptr, this |
 | FieldAccess.cpp:116:3:116:3 | v | this |

--- a/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
+++ b/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
@@ -83,7 +83,7 @@ bad_asts.cpp:
 #   10|               Type = [IntType] int
 #   10|               Value = [Literal] 6
 #   10|               ValueCategory = prvalue
-#   10|           getRightOperand(): [PointerFieldAccess] x
+#   10|           getRightOperand(): [ImplicitThisFieldAccess,PointerFieldAccess] x
 #   10|               Type = [IntType] int
 #   10|               ValueCategory = prvalue(load)
 #   10|             getQualifier(): [ThisExpr] this
@@ -108,7 +108,7 @@ bad_asts.cpp:
 #   10|               Type = [IntType] int
 #   10|               Value = [Literal] t
 #   10|               ValueCategory = prvalue
-#   10|           getRightOperand(): [PointerFieldAccess] x
+#   10|           getRightOperand(): [ImplicitThisFieldAccess,PointerFieldAccess] x
 #   10|               Type = [IntType] int
 #   10|               ValueCategory = prvalue(load)
 #   10|             getQualifier(): [ThisExpr] this
@@ -5718,7 +5718,7 @@ ir.cpp:
 #  645|       getExpr(): [AssignExpr] ... = ...
 #  645|           Type = [IntType] int
 #  645|           ValueCategory = lvalue
-#  645|         getLValue(): [PointerFieldAccess] m_a
+#  645|         getLValue(): [ImplicitThisFieldAccess,PointerFieldAccess] m_a
 #  645|             Type = [IntType] int
 #  645|             ValueCategory = lvalue
 #  645|           getQualifier(): [ThisExpr] this
@@ -5770,7 +5770,7 @@ ir.cpp:
 #  649|         getLValue(): [VariableAccess] x
 #  649|             Type = [IntType] int
 #  649|             ValueCategory = lvalue
-#  649|         getRValue(): [PointerFieldAccess] m_a
+#  649|         getRValue(): [ImplicitThisFieldAccess,PointerFieldAccess] m_a
 #  649|             Type = [IntType] int
 #  649|             ValueCategory = prvalue(load)
 #  649|           getQualifier(): [ThisExpr] this
@@ -9012,7 +9012,7 @@ ir.cpp:
 # 1043|         getArrayBase(): [FunctionCall] call to c_str
 # 1043|             Type = [PointerType] const char *
 # 1043|             ValueCategory = prvalue
-# 1043|           getQualifier(): [PointerFieldAccess] s
+# 1043|           getQualifier(): [ImplicitThisFieldAccess,PointerFieldAccess] s
 # 1043|               Type = [LValueReferenceType] const String &
 # 1043|               ValueCategory = prvalue(load)
 # 1043|             getQualifier(): [ThisExpr] this
@@ -9021,7 +9021,7 @@ ir.cpp:
 # 1043|           getQualifier().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 # 1043|               Type = [SpecifiedType] const String
 # 1043|               ValueCategory = lvalue
-# 1043|         getArrayOffset(): [PointerFieldAccess] x
+# 1043|         getArrayOffset(): [ImplicitThisFieldAccess,PointerFieldAccess] x
 # 1043|             Type = [LValueReferenceType] int &
 # 1043|             ValueCategory = prvalue(load)
 # 1043|           getQualifier(): [ThisExpr] this
@@ -9070,13 +9070,13 @@ ir.cpp:
 # 1045|         getArrayBase(): [FunctionCall] call to c_str
 # 1045|             Type = [PointerType] const char *
 # 1045|             ValueCategory = prvalue
-# 1045|           getQualifier(): [PointerFieldAccess] s
+# 1045|           getQualifier(): [ImplicitThisFieldAccess,PointerFieldAccess] s
 # 1045|               Type = [SpecifiedType] const String
 # 1045|               ValueCategory = lvalue
 # 1045|             getQualifier(): [ThisExpr] this
 # 1045|                 Type = [PointerType] const lambda [] type at line 1045, col. 21 *
 # 1045|                 ValueCategory = prvalue(load)
-# 1045|         getArrayOffset(): [PointerFieldAccess] x
+# 1045|         getArrayOffset(): [ImplicitThisFieldAccess,PointerFieldAccess] x
 # 1045|             Type = [IntType] int
 # 1045|             ValueCategory = prvalue(load)
 # 1045|           getQualifier(): [ThisExpr] this
@@ -9108,7 +9108,7 @@ ir.cpp:
 # 1047|         getArrayBase(): [FunctionCall] call to c_str
 # 1047|             Type = [PointerType] const char *
 # 1047|             ValueCategory = prvalue
-# 1047|           getQualifier(): [PointerFieldAccess] s
+# 1047|           getQualifier(): [ImplicitThisFieldAccess,PointerFieldAccess] s
 # 1047|               Type = [LValueReferenceType] const String &
 # 1047|               ValueCategory = prvalue(load)
 # 1047|             getQualifier(): [ThisExpr] this
@@ -9161,7 +9161,7 @@ ir.cpp:
 # 1049|         getArrayBase(): [FunctionCall] call to c_str
 # 1049|             Type = [PointerType] const char *
 # 1049|             ValueCategory = prvalue
-# 1049|           getQualifier(): [PointerFieldAccess] s
+# 1049|           getQualifier(): [ImplicitThisFieldAccess,PointerFieldAccess] s
 # 1049|               Type = [SpecifiedType] const String
 # 1049|               ValueCategory = lvalue
 # 1049|             getQualifier(): [ThisExpr] this
@@ -9197,7 +9197,7 @@ ir.cpp:
 # 1051|         getArrayBase(): [FunctionCall] call to c_str
 # 1051|             Type = [PointerType] const char *
 # 1051|             ValueCategory = prvalue
-# 1051|           getQualifier(): [PointerFieldAccess] s
+# 1051|           getQualifier(): [ImplicitThisFieldAccess,PointerFieldAccess] s
 # 1051|               Type = [LValueReferenceType] const String &
 # 1051|               ValueCategory = prvalue(load)
 # 1051|             getQualifier(): [ThisExpr] this
@@ -9206,7 +9206,7 @@ ir.cpp:
 # 1051|           getQualifier().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 # 1051|               Type = [SpecifiedType] const String
 # 1051|               ValueCategory = lvalue
-# 1051|         getArrayOffset(): [PointerFieldAccess] x
+# 1051|         getArrayOffset(): [ImplicitThisFieldAccess,PointerFieldAccess] x
 # 1051|             Type = [IntType] int
 # 1051|             ValueCategory = prvalue(load)
 # 1051|           getQualifier(): [ThisExpr] this
@@ -9238,7 +9238,7 @@ ir.cpp:
 # 1054|         getArrayBase(): [FunctionCall] call to c_str
 # 1054|             Type = [PointerType] const char *
 # 1054|             ValueCategory = prvalue
-# 1054|           getQualifier(): [PointerFieldAccess] s
+# 1054|           getQualifier(): [ImplicitThisFieldAccess,PointerFieldAccess] s
 # 1054|               Type = [LValueReferenceType] const String &
 # 1054|               ValueCategory = prvalue(load)
 # 1054|             getQualifier(): [ThisExpr] this
@@ -9253,7 +9253,7 @@ ir.cpp:
 # 1054|           getLeftOperand(): [AddExpr] ... + ...
 # 1054|               Type = [IntType] int
 # 1054|               ValueCategory = prvalue
-# 1054|             getLeftOperand(): [PointerFieldAccess] x
+# 1054|             getLeftOperand(): [ImplicitThisFieldAccess,PointerFieldAccess] x
 # 1054|                 Type = [IntType] int
 # 1054|                 ValueCategory = prvalue(load)
 # 1054|               getQualifier(): [ThisExpr] this
@@ -11484,7 +11484,7 @@ ir.cpp:
 # 1458|       getExpr(): [AssignExpr] ... = ...
 # 1458|           Type = [IntType] int
 # 1458|           ValueCategory = lvalue
-# 1458|         getLValue(): [PointerFieldAccess] y
+# 1458|         getLValue(): [ImplicitThisFieldAccess,PointerFieldAccess] y
 # 1458|             Type = [IntType] int
 # 1458|             ValueCategory = lvalue
 # 1458|           getQualifier(): [ThisExpr] this
@@ -12296,7 +12296,7 @@ ir.cpp:
 # 1567|   <params>: 
 # 1567|   getEntryPoint(): [BlockStmt] { ... }
 # 1568|     getStmt(0): [ReturnStmt] return ...
-# 1568|       getExpr(): [PointerFieldAccess] i
+# 1568|       getExpr(): [ImplicitThisFieldAccess,PointerFieldAccess] i
 # 1568|           Type = [IntType] int
 # 1568|           ValueCategory = lvalue
 # 1568|         getQualifier(): [ThisExpr] this
@@ -12309,7 +12309,7 @@ ir.cpp:
 # 1571|   <params>: 
 # 1571|   getEntryPoint(): [BlockStmt] { ... }
 # 1572|     getStmt(0): [ReturnStmt] return ...
-# 1572|       getExpr(): [PointerFieldAccess] d
+# 1572|       getExpr(): [ImplicitThisFieldAccess,PointerFieldAccess] d
 # 1572|           Type = [DoubleType] double
 # 1572|           ValueCategory = lvalue
 # 1572|         getQualifier(): [ThisExpr] this
@@ -12322,7 +12322,7 @@ ir.cpp:
 # 1575|   <params>: 
 # 1575|   getEntryPoint(): [BlockStmt] { ... }
 # 1576|     getStmt(0): [ReturnStmt] return ...
-# 1576|       getExpr(): [PointerFieldAccess] r
+# 1576|       getExpr(): [ImplicitThisFieldAccess,PointerFieldAccess] r
 # 1576|           Type = [LValueReferenceType] int &
 # 1576|           ValueCategory = prvalue(load)
 # 1576|         getQualifier(): [ThisExpr] this
@@ -12663,7 +12663,7 @@ ir.cpp:
 # 1633|   <params>: 
 # 1633|   getEntryPoint(): [BlockStmt] { ... }
 # 1634|     getStmt(0): [ReturnStmt] return ...
-# 1634|       getExpr(): [PointerFieldAccess] i
+# 1634|       getExpr(): [ImplicitThisFieldAccess,PointerFieldAccess] i
 # 1634|           Type = [IntType] int
 # 1634|           ValueCategory = prvalue(load)
 # 1634|         getQualifier(): [ThisExpr] this
@@ -12673,7 +12673,7 @@ ir.cpp:
 # 1637|   <params>: 
 # 1637|   getEntryPoint(): [BlockStmt] { ... }
 # 1638|     getStmt(0): [ReturnStmt] return ...
-# 1638|       getExpr(): [PointerFieldAccess] r
+# 1638|       getExpr(): [ImplicitThisFieldAccess,PointerFieldAccess] r
 # 1638|           Type = [LValueReferenceType] int &
 # 1638|           ValueCategory = prvalue(load)
 # 1638|         getQualifier(): [ThisExpr] this
@@ -13284,7 +13284,7 @@ ir.cpp:
 # 1703|         getQualifier(): [AddressOfExpr] & ...
 # 1703|             Type = [PointerType] const TrivialLambdaClass *
 # 1703|             ValueCategory = prvalue
-# 1703|           getOperand(): [PointerFieldAccess] (captured this)
+# 1703|           getOperand(): [ImplicitThisFieldAccess,PointerFieldAccess] (captured this)
 # 1703|               Type = [SpecifiedType] const TrivialLambdaClass
 # 1703|               ValueCategory = lvalue
 # 1703|             getQualifier(): [ThisExpr] this
@@ -13331,7 +13331,7 @@ ir.cpp:
 # 1706|         getQualifier(): [AddressOfExpr] & ...
 # 1706|             Type = [PointerType] const TrivialLambdaClass *
 # 1706|             ValueCategory = prvalue
-# 1706|           getOperand(): [PointerFieldAccess] (captured this)
+# 1706|           getOperand(): [ImplicitThisFieldAccess,PointerFieldAccess] (captured this)
 # 1706|               Type = [SpecifiedType] const TrivialLambdaClass
 # 1706|               ValueCategory = lvalue
 # 1706|             getQualifier(): [ThisExpr] this
@@ -13477,7 +13477,7 @@ ir.cpp:
 # 1726|       getExpr(): [AssignExpr] ... = ...
 # 1726|           Type = [IntType] int
 # 1726|           ValueCategory = lvalue
-# 1726|         getLValue(): [PointerFieldAccess] x
+# 1726|         getLValue(): [ImplicitThisFieldAccess,PointerFieldAccess] x
 # 1726|             Type = [IntType] int
 # 1726|             ValueCategory = lvalue
 # 1726|           getQualifier(): [ThisExpr] this


### PR DESCRIPTION
Closes https://github.com/github/codeql-c-team/issues/1239

`ImplicitThisFieldAccess` now works as expected by using the recently-fixed `compgenerated()` predicate.

As a consequence, the `FieldAccess` test now correctly identifies the field accesses as `ImplicitThisFieldAccess` as well as `PointerFieldAccess`.

I needed to fix up GVN because `ImplicitThisFieldAccess` overlaps with other classes.

Change-note required?