### PR TITLE
C#: Fix FP in Missing Function Level Access Control and Insecure Direct Object Reference

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/security/auth/InsecureDirectObjectReferenceQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/auth/InsecureDirectObjectReferenceQuery.qll
@@ -51,29 +51,31 @@ private predicate callsPlus(Callable c1, Callable c2) = fastTC(calls/2)(c1, c2)
 /** Holds if `m`, its containing class, or a parent class has an attribute that extends `AuthorizeAttribute` */
 private predicate hasAuthorizeAttribute(ActionMethod m) {
   exists(Attribute attr |
-    attr.getType()
-        .getABaseType*()
+    getAnUnboundBaseType*(attr.getType())
         .hasQualifiedName([
             "Microsoft.AspNetCore.Authorization", "System.Web.Mvc", "System.Web.Http"
           ], "AuthorizeAttribute")
   |
     attr = m.getOverridee*().getAnAttribute() or
-    attr = m.getDeclaringType().getABaseType*().getAnAttribute()
+    attr = getAnUnboundBaseType*(m.getDeclaringType()).getAnAttribute()
   )
 }
 
 /** Holds if `m`, its containing class, or a parent class has an attribute that extends `AllowAnonymousAttribute` */
 private predicate hasAllowAnonymousAttribute(ActionMethod m) {
   exists(Attribute attr |
-    attr.getType()
-        .getABaseType*()
+    getAnUnboundBaseType*(attr.getType())
         .hasQualifiedName([
             "Microsoft.AspNetCore.Authorization", "System.Web.Mvc", "System.Web.Http"
           ], "AllowAnonymousAttribute")
   |
     attr = m.getOverridee*().getAnAttribute() or
-    attr = m.getDeclaringType().getABaseType*().getAnAttribute()
+    attr = getAnUnboundBaseType*(m.getDeclaringType()).getAnAttribute()
   )
+}
+
+private ValueOrRefType getAnUnboundBaseType(ValueOrRefType t) {
+  result = t.getABaseType().getUnboundDeclaration()
 }
 
 /** Holds if `m` is authorized via an `Authorize` attribute */

--- a/csharp/ql/lib/semmle/code/csharp/security/auth/MissingFunctionLevelAccessControlQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/auth/MissingFunctionLevelAccessControlQuery.qll
@@ -82,9 +82,13 @@ predicate hasAuthViaXml(ActionMethod m) {
 /** Holds if the given action has an attribute that indications authorization. */
 predicate hasAuthViaAttribute(ActionMethod m) {
   exists(Attribute attr | attr.getType().getName().toLowerCase().matches("%auth%") |
-    attr = m.getAnAttribute() or
-    attr = m.getDeclaringType().getABaseType*().getAnAttribute()
+    attr = m.getOverridee*().getAnAttribute() or
+    attr = getAnUnboundBaseType*(m.getDeclaringType()).getAnAttribute()
   )
+}
+
+private ValueOrRefType getAnUnboundBaseType(ValueOrRefType t) {
+  result = t.getABaseType().getUnboundDeclaration()
 }
 
 /** Holds if `m` is a method that should have an auth check, but is missing it. */

--- a/csharp/ql/src/change-notes/2023-10-13-accesscontrol-idor-updates.md
+++ b/csharp/ql/src/change-notes/2023-10-13-accesscontrol-idor-updates.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `cs/web/insecure-direct-object-reference` and `cs/web/missing-function-level-access-control` have been improved to better recognize attributes on generic classes.

--- a/csharp/ql/test/query-tests/Security Features/CWE-285/MissingAccessControl/MVCTests/ProfileController.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-285/MissingAccessControl/MVCTests/ProfileController.cs
@@ -28,3 +28,29 @@ public class ProfileController : Controller {
     }
 
 }
+
+[Authorize]
+public class AuthBaseController : Controller {
+    protected void doThings() { }
+}
+
+public class SubController : AuthBaseController {
+    // GOOD: The Authorize attribute is used on the base class.
+    public ActionResult Delete4(int id) {
+        doThings();
+        return View();
+    }
+}
+
+[Authorize]
+public class AuthBaseGenericController<T> : Controller {
+    protected void doThings() { }
+}
+
+public class SubGenericController : AuthBaseGenericController<string> {
+    // GOOD: The Authorize attribute is used on the base class.
+    public ActionResult Delete5(int id) {
+        doThings();
+        return View();
+    }
+}

--- a/csharp/ql/test/query-tests/Security Features/CWE-639/MVCTests/MiscTestControllers.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-639/MVCTests/MiscTestControllers.cs
@@ -44,3 +44,13 @@ public class CController : BaseAnonController {
     [Authorize]
     public ActionResult Edit4(int id) { return View(); }
 }
+
+[Authorize]
+public class BaseGenController<T> : Controller {
+
+}
+
+public class SubGenController : BaseGenController<string> {
+    // GOOD - Authorize is inherited from parent class
+    public ActionResult Edit5(int id) { return View(); }
+}


### PR DESCRIPTION
Improves detection of authorize attributes to include generic classes, which should fix [this](https://github.com/github/codeql/issues/14478) FP.