### PR TITLE
Swift: Model RawRepresentable

### DIFF
--- a/swift/ql/lib/change-notes/2023-10-13-rawrepresentable.md
+++ b/swift/ql/lib/change-notes/2023-10-13-rawrepresentable.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+
+* Added taint flow models for `RawRepresentable`.

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/RawRepresentable.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/RawRepresentable.qll
@@ -17,19 +17,12 @@ private class RawRepresentableSummaries extends SummaryModelCsv {
 }
 
 /**
- * A content implying that, if an `RawRepresentable` is tainted, then
- * the `rawValue` field is tainted as well.
+ * A content implying that, if a `RawRepresentable` is tainted, then the
+ * `rawValue` field is tainted as well. This model has been extended to assume
+ * that any object's `rawValue` field also inherits taint.
  */
 private class RawRepresentableFieldsInheritTaint extends TaintInheritingContent,
   DataFlow::Content::FieldContent
 {
-  RawRepresentableFieldsInheritTaint() {
-    exists(FieldDecl fieldDecl, Decl declaringDecl, TypeDecl namedTypeDecl |
-      namedTypeDecl.getFullName() = "RawRepresentable" and
-      fieldDecl.getName() = "rawValue" and
-      declaringDecl.getAMember() = fieldDecl and
-      declaringDecl.asNominalTypeDecl() = namedTypeDecl.getADerivedTypeDecl*() and
-      this.getField() = fieldDecl
-    )
-  }
+  RawRepresentableFieldsInheritTaint() { this.getField().getName() = "rawValue" }
 }

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/RawRepresentable.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/RawRepresentable.qll
@@ -1,0 +1,35 @@
+/**
+ * Provides models the `RawRepresentable` Swift class.
+ */
+
+import swift
+private import codeql.swift.dataflow.DataFlow
+private import codeql.swift.dataflow.ExternalFlow
+private import codeql.swift.dataflow.FlowSteps
+
+/**
+ * A model for `RawRepresentable` class members that permit taint flow.
+ */
+private class RawRepresentableSummaries extends SummaryModelCsv {
+  override predicate row(string row) {
+    row = ";RawRepresentable;true;init(rawValue:);;;Argument[0];ReturnValue;taint"
+  }
+}
+
+/**
+ * A content implying that, if an `RawRepresentable` is tainted, then
+ * the `rawValue` field is tainted as well.
+ */
+private class RawRepresentableFieldsInheritTaint extends TaintInheritingContent,
+  DataFlow::Content::FieldContent
+{
+  RawRepresentableFieldsInheritTaint() {
+    exists(FieldDecl fieldDecl, Decl declaringDecl, TypeDecl namedTypeDecl |
+      namedTypeDecl.getFullName() = "RawRepresentable" and
+      fieldDecl.getName() = "rawValue" and
+      declaringDecl.getAMember() = fieldDecl and
+      declaringDecl.asNominalTypeDecl() = namedTypeDecl.getADerivedTypeDecl*() and
+      this.getField() = fieldDecl
+    )
+  }
+}

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/StandardLibrary.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/StandardLibrary.qll
@@ -17,6 +17,7 @@ private import NsObject
 private import NsString
 private import NsUrl
 private import Numeric
+private import RawRepresentable
 private import PointerTypes
 private import Sequence
 private import Set

--- a/swift/ql/lib/codeql/swift/security/XXEExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/XXEExtensions.qll
@@ -188,13 +188,6 @@ private predicate lib2xmlOptionLocalTaintStep(DataFlow::Node source, DataFlow::N
   exists(MemberRefExpr rawValue | rawValue.getMember().(VarDecl).getName() = "rawValue" |
     source.asExpr() = rawValue.getBase() and sink.asExpr() = rawValue
   )
-  or
-  exists(ApplyExpr int32Init |
-    int32Init.getStaticTarget().(Initializer).getEnclosingDecl().asNominalTypeDecl().getName() =
-      "SignedInteger"
-  |
-    source.asExpr() = int32Init.getAnArgument().getExpr() and sink.asExpr() = int32Init
-  )
 }
 
 /**

--- a/swift/ql/lib/codeql/swift/security/XXEExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/XXEExtensions.qll
@@ -184,10 +184,6 @@ private class Libxml2XxeSink extends XxeSink {
  */
 private predicate lib2xmlOptionLocalTaintStep(DataFlow::Node source, DataFlow::Node sink) {
   TaintTracking::localTaintStep(source, sink)
-  or
-  exists(MemberRefExpr rawValue | rawValue.getMember().(VarDecl).getName() = "rawValue" |
-    source.asExpr() = rawValue.getBase() and sink.asExpr() = rawValue
-  )
 }
 
 /**

--- a/swift/ql/lib/codeql/swift/security/XXEExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/XXEExtensions.qll
@@ -172,18 +172,10 @@ private class Libxml2XxeSink extends XxeSink {
   Libxml2XxeSink() {
     exists(Libxml2ParseCall c, Libxml2BadOption opt |
       this.asExpr() = c.getXml() and
-      lib2xmlOptionLocalTaintStep*(DataFlow::exprNode(opt.getAnAccess()),
+      TaintTracking::localTaintStep*(DataFlow::exprNode(opt.getAnAccess()),
         DataFlow::exprNode(c.getOptions()))
     )
   }
-}
-
-/**
- * Holds if taint can flow from `source` to `sink` in one local step,
- * including bitwise operations, accesses to `.rawValue`, and casts to `Int32`.
- */
-private predicate lib2xmlOptionLocalTaintStep(DataFlow::Node source, DataFlow::Node sink) {
-  TaintTracking::localTaintStep(source, sink)
 }
 
 /**

--- a/swift/ql/test/library-tests/dataflow/taint/libraries/optionset.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/libraries/optionset.swift
@@ -1,0 +1,66 @@
+
+// --- stubs ---
+
+// --- tests ---
+
+func sourceInt() -> Int { return 0 }
+func sourceUInt() -> UInt { return 0 }
+func sink(arg: Any) {}
+
+// ---
+
+enum MyRawRepresentable : RawRepresentable {
+  case valueOne
+  case valueTwo
+
+	init?(rawValue: Int) {
+    switch rawValue {
+      case 1: self = .valueOne
+      case 2: self = .valueTwo
+      default: return nil
+    }
+  }
+
+  var rawValue: Int {
+    switch self {
+      case .valueOne: return 1
+      case .valueTwo: return 2
+    }
+  }
+}
+
+func testRawRepresentable() {
+  let rr1 = MyRawRepresentable.valueOne
+  let rr2 = MyRawRepresentable(rawValue: 1)!
+  let rr3 = MyRawRepresentable(rawValue: sourceInt())!
+
+  sink(arg: rr1)
+  sink(arg: rr2)
+  sink(arg: rr3) // $ MISSING: tainted=
+
+  sink(arg: rr1.rawValue)
+  sink(arg: rr2.rawValue)
+  sink(arg: rr3.rawValue) // $ MISSING: tainted=
+}
+
+// ---
+
+struct MyOptionSet : OptionSet {
+	let rawValue: UInt
+
+	static let red = MyOptionSet(rawValue: 1 << 0)
+	static let green = MyOptionSet(rawValue: 1 << 1)
+	static let blue = MyOptionSet(rawValue: 1 << 2)
+}
+
+func testOptionSet() {
+	sink(arg: MyOptionSet.red)
+	sink(arg: MyOptionSet([.red, .green]))
+	sink(arg: MyOptionSet(rawValue: 0))
+	sink(arg: MyOptionSet(rawValue: sourceUInt())) // $ MISSING: tainted=
+
+	sink(arg: MyOptionSet.red.rawValue)
+	sink(arg: MyOptionSet([.red, .green]).rawValue)
+	sink(arg: MyOptionSet(rawValue: 0).rawValue)
+	sink(arg: MyOptionSet(rawValue: sourceUInt()).rawValue) // $ MISSING: tainted=
+}

--- a/swift/ql/test/library-tests/dataflow/taint/libraries/optionset.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/libraries/optionset.swift
@@ -36,11 +36,11 @@ func testRawRepresentable() {
 
   sink(arg: rr1)
   sink(arg: rr2)
-  sink(arg: rr3) // $ MISSING: tainted=
+  sink(arg: rr3) // $ tainted=35
 
   sink(arg: rr1.rawValue)
   sink(arg: rr2.rawValue)
-  sink(arg: rr3.rawValue) // $ MISSING: tainted=
+  sink(arg: rr3.rawValue) // $ tainted=35
 }
 
 // ---
@@ -57,10 +57,10 @@ func testOptionSet() {
 	sink(arg: MyOptionSet.red)
 	sink(arg: MyOptionSet([.red, .green]))
 	sink(arg: MyOptionSet(rawValue: 0))
-	sink(arg: MyOptionSet(rawValue: sourceUInt())) // $ MISSING: tainted=
+	sink(arg: MyOptionSet(rawValue: sourceUInt())) // $ tainted=60
 
 	sink(arg: MyOptionSet.red.rawValue)
 	sink(arg: MyOptionSet([.red, .green]).rawValue)
 	sink(arg: MyOptionSet(rawValue: 0).rawValue)
-	sink(arg: MyOptionSet(rawValue: sourceUInt()).rawValue) // $ MISSING: tainted=
+	sink(arg: MyOptionSet(rawValue: sourceUInt()).rawValue) // $ tainted=65
 }

--- a/swift/ql/test/query-tests/Security/CWE-611/XXETest.expected
+++ b/swift/ql/test/query-tests/Security/CWE-611/XXETest.expected
@@ -1,2 +1,18 @@
-failures
 testFailures
+| testLibxmlXXE.swift:101:78:102:1 | // $ hasXXE=96\n | Missing result:hasXXE=96 |
+| testLibxmlXXE.swift:102:80:103:1 | // $ hasXXE=96\n | Missing result:hasXXE=96 |
+| testLibxmlXXE.swift:103:107:104:1 | // $ hasXXE=96\n | Missing result:hasXXE=96 |
+| testLibxmlXXE.swift:104:82:105:1 | // $ hasXXE=96\n | Missing result:hasXXE=96 |
+| testLibxmlXXE.swift:106:78:107:1 | // $ hasXXE=95\n | Missing result:hasXXE=95 |
+| testLibxmlXXE.swift:107:80:108:1 | // $ hasXXE=95\n | Missing result:hasXXE=95 |
+| testLibxmlXXE.swift:109:87:110:1 | // $ hasXXE=96\n | Missing result:hasXXE=96 |
+| testLibxmlXXE.swift:110:89:111:1 | // $ hasXXE=96\n | Missing result:hasXXE=96 |
+| testLibxmlXXE.swift:112:99:113:1 | // $ hasXXE=96\n | Missing result:hasXXE=96 |
+| testLibxmlXXE.swift:113:97:114:1 | // $ hasXXE=96\n | Missing result:hasXXE=96 |
+| testLibxmlXXE.swift:115:87:116:1 | // $ hasXXE=95\n | Missing result:hasXXE=95 |
+| testLibxmlXXE.swift:116:89:117:1 | // $ hasXXE=95\n | Missing result:hasXXE=95 |
+| testLibxmlXXE.swift:118:89:119:1 | // $ hasXXE=96\n | Missing result:hasXXE=96 |
+| testLibxmlXXE.swift:119:91:120:1 | // $ hasXXE=96\n | Missing result:hasXXE=96 |
+| testLibxmlXXE.swift:121:98:122:1 | // $ hasXXE=96\n | Missing result:hasXXE=96 |
+| testLibxmlXXE.swift:122:100:123:1 | // $ hasXXE=96\n | Missing result:hasXXE=96 |
+failures

--- a/swift/ql/test/query-tests/Security/CWE-611/XXETest.expected
+++ b/swift/ql/test/query-tests/Security/CWE-611/XXETest.expected
@@ -1,18 +1,2 @@
 testFailures
-| testLibxmlXXE.swift:101:78:102:1 | // $ hasXXE=96\n | Missing result:hasXXE=96 |
-| testLibxmlXXE.swift:102:80:103:1 | // $ hasXXE=96\n | Missing result:hasXXE=96 |
-| testLibxmlXXE.swift:103:107:104:1 | // $ hasXXE=96\n | Missing result:hasXXE=96 |
-| testLibxmlXXE.swift:104:82:105:1 | // $ hasXXE=96\n | Missing result:hasXXE=96 |
-| testLibxmlXXE.swift:106:78:107:1 | // $ hasXXE=95\n | Missing result:hasXXE=95 |
-| testLibxmlXXE.swift:107:80:108:1 | // $ hasXXE=95\n | Missing result:hasXXE=95 |
-| testLibxmlXXE.swift:109:87:110:1 | // $ hasXXE=96\n | Missing result:hasXXE=96 |
-| testLibxmlXXE.swift:110:89:111:1 | // $ hasXXE=96\n | Missing result:hasXXE=96 |
-| testLibxmlXXE.swift:112:99:113:1 | // $ hasXXE=96\n | Missing result:hasXXE=96 |
-| testLibxmlXXE.swift:113:97:114:1 | // $ hasXXE=96\n | Missing result:hasXXE=96 |
-| testLibxmlXXE.swift:115:87:116:1 | // $ hasXXE=95\n | Missing result:hasXXE=95 |
-| testLibxmlXXE.swift:116:89:117:1 | // $ hasXXE=95\n | Missing result:hasXXE=95 |
-| testLibxmlXXE.swift:118:89:119:1 | // $ hasXXE=96\n | Missing result:hasXXE=96 |
-| testLibxmlXXE.swift:119:91:120:1 | // $ hasXXE=96\n | Missing result:hasXXE=96 |
-| testLibxmlXXE.swift:121:98:122:1 | // $ hasXXE=96\n | Missing result:hasXXE=96 |
-| testLibxmlXXE.swift:122:100:123:1 | // $ hasXXE=96\n | Missing result:hasXXE=96 |
 failures


### PR DESCRIPTION
Model [`RawRepresentable`](https://developer.apple.com/documentation/swift/rawrepresentable), and by extension some uses of [`OptionSet`](https://developer.apple.com/documentation/swift/optionset).  Simplify the XXE query logic a little now that it no longer needs to make special cases for `.rawValue` (or `SignedInteger` initializers).

Query sinks for `swift/xxe` are not affected.  DCA run to follow...