### PR TITLE
C++: Mark `cpp/redundant-null-check-simple` as a security query

### DIFF
--- a/cpp/ql/src/Likely Bugs/RedundantNullCheckSimple.ql
+++ b/cpp/ql/src/Likely Bugs/RedundantNullCheckSimple.ql
@@ -5,10 +5,12 @@
  *              it should be moved before the dereference.
  * @kind path-problem
  * @problem.severity error
+ * @security-severity 7.5
  * @precision high
  * @id cpp/redundant-null-check-simple
  * @tags reliability
  *       correctness
+ *       security
  *       external/cwe/cwe-476
  */
 

--- a/cpp/ql/src/change-notes/2023-10-16-redundant-null-check-simple.md
+++ b/cpp/ql/src/change-notes/2023-10-16-redundant-null-check-simple.md
@@ -1,0 +1,6 @@
+---
+category: newQuery
+---
+* The query `cpp/redundant-null-check-simple` has been promoted to Code Scanning. The query finds cases where a pointer is compared to null after it has already been dereferenced. Such comparisons likely indicate a bug at the place where the pointer is dereferenced, or where the pointer is compared to null.
+
+Note: This query was incorrectly noted as being promoted to Code Scanning in CodeQL version 2.14.6.

--- a/cpp/ql/src/change-notes/2023-10-16-redundant-null-check-simple.md
+++ b/cpp/ql/src/change-notes/2023-10-16-redundant-null-check-simple.md
@@ -3,4 +3,4 @@ category: newQuery
 ---
 * The query `cpp/redundant-null-check-simple` has been promoted to Code Scanning. The query finds cases where a pointer is compared to null after it has already been dereferenced. Such comparisons likely indicate a bug at the place where the pointer is dereferenced, or where the pointer is compared to null.
 
-Note: This query was incorrectly noted as being promoted to Code Scanning in CodeQL version 2.14.6.
+  Note: This query was incorrectly noted as being promoted to Code Scanning in CodeQL version 2.14.6.


### PR DESCRIPTION
This query was supposed to be promoted in https://github.com/github/codeql/pull/12822, but I forgot to add the `security` tag. So it was actually never promoted 😱!