### PR TITLE
Java: Improve java/spring-disabled-csrf-protection

### DIFF
--- a/java/ql/lib/semmle/code/java/security/SpringCsrfProtection.qll
+++ b/java/ql/lib/semmle/code/java/security/SpringCsrfProtection.qll
@@ -1,0 +1,20 @@
+/** Provides predicates to reason about disabling CSRF protection in Spring. */
+
+import java
+
+/** Holds if `call` disables CSRF protection in Spring. */
+predicate disablesSpringCsrfProtection(MethodAccess call) {
+  call.getMethod().hasName("disable") and
+  call.getReceiverType()
+      .hasQualifiedName("org.springframework.security.config.annotation.web.configurers",
+        "CsrfConfigurer<HttpSecurity>")
+  or
+  call.getMethod()
+      .hasQualifiedName("org.springframework.security.config.annotation.web.builders",
+        "HttpSecurity", "csrf") and
+  call.getArgument(0)
+      .(MemberRefExpr)
+      .getReferencedCallable()
+      .hasQualifiedName("org.springframework.security.config.annotation.web.configurers",
+        "AbstractHttpConfigurer", "disable")
+}

--- a/java/ql/src/Security/CWE/CWE-352/SpringCSRFProtection.ql
+++ b/java/ql/src/Security/CWE/CWE-352/SpringCSRFProtection.ql
@@ -12,11 +12,8 @@
  */
 
 import java
+import semmle.code.java.security.SpringCsrfProtection
 
 from MethodAccess call
-where
-  call.getMethod().hasName("disable") and
-  call.getReceiverType()
-      .hasQualifiedName("org.springframework.security.config.annotation.web.configurers",
-        "CsrfConfigurer<HttpSecurity>")
+where disablesSpringCsrfProtection(call)
 select call, "CSRF vulnerability due to protection being disabled."

--- a/java/ql/src/change-notes/2023-10-16-spring-disabled-csrf-protection-improved.md
+++ b/java/ql/src/change-notes/2023-10-16-spring-disabled-csrf-protection-improved.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The query `java/spring-disabled-csrf-protection` has been improved to detect more ways of disabling CSRF in Spring.

--- a/java/ql/test/query-tests/security/CWE-352/CONSISTENCY/typeParametersInScope.expected
+++ b/java/ql/test/query-tests/security/CWE-352/CONSISTENCY/typeParametersInScope.expected
@@ -1,0 +1,1 @@
+| Type new Customizer<CsrfConfigurer<HttpSecurity>>(...) { ... } uses out-of-scope type variable B. Note the Java extractor is known to sometimes do this; the Kotlin extractor should not. |

--- a/java/ql/test/query-tests/security/CWE-352/SpringCsrfProtectionTest.expected
+++ b/java/ql/test/query-tests/security/CWE-352/SpringCsrfProtectionTest.expected
@@ -1,0 +1,2 @@
+testFailures
+failures

--- a/java/ql/test/query-tests/security/CWE-352/SpringCsrfProtectionTest.java
+++ b/java/ql/test/query-tests/security/CWE-352/SpringCsrfProtectionTest.java
@@ -1,0 +1,10 @@
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+
+public class SpringCsrfProtectionTest {
+    protected void test(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable()); // $ hasSpringCsrfProtectionDisabled
+        http.csrf().disable(); // $ hasSpringCsrfProtectionDisabled
+        http.csrf(AbstractHttpConfigurer::disable); // $ hasSpringCsrfProtectionDisabled
+    }
+}

--- a/java/ql/test/query-tests/security/CWE-352/SpringCsrfProtectionTest.ql
+++ b/java/ql/test/query-tests/security/CWE-352/SpringCsrfProtectionTest.ql
@@ -1,0 +1,18 @@
+import java
+import semmle.code.java.security.SpringCsrfProtection
+import TestUtilities.InlineExpectationsTest
+
+module SpringCsrfProtectionTest implements TestSig {
+  string getARelevantTag() { result = "hasSpringCsrfProtectionDisabled" }
+
+  predicate hasActualResult(Location location, string element, string tag, string value) {
+    tag = "hasSpringCsrfProtectionDisabled" and
+    exists(MethodAccess call | disablesSpringCsrfProtection(call) |
+      call.getLocation() = location and
+      element = call.toString() and
+      value = ""
+    )
+  }
+}
+
+import MakeTest<SpringCsrfProtectionTest>

--- a/java/ql/test/query-tests/security/CWE-352/options
+++ b/java/ql/test/query-tests/security/CWE-352/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --javac-args -cp ${testdir}/../../../stubs/springframework-5.3.8

--- a/java/ql/test/stubs/springframework-5.3.8/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
+++ b/java/ql/test/stubs/springframework-5.3.8/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
@@ -3,9 +3,11 @@ package org.springframework.security.config.annotation.web.builders;
 import org.springframework.security.config.annotation.AbstractConfiguredSecurityBuilder;
 import org.springframework.security.config.annotation.SecurityBuilder;
 import org.springframework.security.config.annotation.web.HttpSecurityBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity.RequestMatcherConfigurer;
 import org.springframework.security.web.DefaultSecurityFilterChain;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.config.annotation.web.configurers.ExpressionUrlAuthorizationConfigurer;
 import org.springframework.security.config.annotation.web.AbstractRequestMatcherRegistry;
 
@@ -32,6 +34,14 @@ public final class HttpSecurity extends AbstractConfiguredSecurityBuilder<Defaul
 	}
 
 	public RequestMatcherConfigurer requestMatchers() {
+		return null;
+	}
+
+	public CsrfConfigurer<HttpSecurity> csrf() {
+		return null;
+	}
+
+	public HttpSecurity csrf(Customizer<CsrfConfigurer<HttpSecurity>> csrfCustomizer) {
 		return null;
 	}
 

--- a/java/ql/test/stubs/springframework-5.3.8/org/springframework/security/config/annotation/web/configurers/AbstractHttpConfigurer.java
+++ b/java/ql/test/stubs/springframework-5.3.8/org/springframework/security/config/annotation/web/configurers/AbstractHttpConfigurer.java
@@ -5,4 +5,6 @@ import org.springframework.security.config.annotation.web.HttpSecurityBuilder;
 import org.springframework.security.web.DefaultSecurityFilterChain;
 
 public abstract class AbstractHttpConfigurer<T extends AbstractHttpConfigurer<T, B>, B extends HttpSecurityBuilder<B>>
-		extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, B> {}
+		extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, B> {
+	public B disable() { return null; }
+}

--- a/java/ql/test/stubs/springframework-5.3.8/org/springframework/security/config/annotation/web/configurers/CsrfConfigurer.java
+++ b/java/ql/test/stubs/springframework-5.3.8/org/springframework/security/config/annotation/web/configurers/CsrfConfigurer.java
@@ -1,0 +1,8 @@
+package org.springframework.security.config.annotation.web.configurers;
+
+import org.springframework.security.config.annotation.web.HttpSecurityBuilder;
+
+public class CsrfConfigurer<H extends HttpSecurityBuilder<H>>
+        extends AbstractHttpConfigurer<CsrfConfigurer<H>, H> {
+
+}


### PR DESCRIPTION
Improves the query `java/spring-disabled-csrf-protection` to detect the pattern:

```java
http.csrf(AbstractHttpConfigurer::disable);
```