### PR TITLE
Fix invalid `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,7 +25,7 @@ updates:
     allow:
       - dependency-name: "golang.org/x/mod"
       - dependency-name: "golang.org/x/tools"
-    group:
+    groups:
       extractor-dependencies:
         patterns:
           - "golang.org/x/*"


### PR DESCRIPTION
Typo didn't get caught before merging #14483.