### PR TITLE
CI: Update framework coverage difference commenter

### DIFF
--- a/.github/workflows/csv-coverage-pr-artifacts.yml
+++ b/.github/workflows/csv-coverage-pr-artifacts.yml
@@ -89,9 +89,25 @@ jobs:
       - name: Save PR number
         run: |
           mkdir -p pr
-          echo ${{ github.event.pull_request.number }} > pr/NR
+          echo ${PR_NUMBER} > pr/NR
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
       - name: Upload PR number
         uses: actions/upload-artifact@v3
         with:
           name: pr
           path: pr/
+      - name: Save comment ID (if it exists)
+        run: |
+          mkdir -p comment
+          # Find the latest comment starting with COMMENT_PREFIX
+          COMMENT_PREFIX=":warning: The head of this PR and the base branch were compared for differences in the framework coverage reports."
+          gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate | jq --arg prefix "${COMMENT_PREFIX}" '[.[] | select(.body|startswith($prefix)) | .id] | max' > comment/ID
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+      - name: Upload comment ID (if it exists)
+        uses: actions/upload-artifact@v3
+        with:
+          name: comment
+          path: comment/

--- a/.github/workflows/csv-coverage-pr-artifacts.yml
+++ b/.github/workflows/csv-coverage-pr-artifacts.yml
@@ -99,10 +99,16 @@ jobs:
           path: pr/
       - name: Save comment ID (if it exists)
         run: |
-          mkdir -p comment
           # Find the latest comment starting with COMMENT_PREFIX
           COMMENT_PREFIX=":warning: The head of this PR and the base branch were compared for differences in the framework coverage reports."
-          gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate | jq --arg prefix "${COMMENT_PREFIX}" '[.[] | select(.body|startswith($prefix)) | .id] | max' > comment/ID
+          COMMENT_ID=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate | jq --arg prefix "${COMMENT_PREFIX}" 'map(select(.body|startswith($prefix)) | .id) | max // empty')
+          if [[ -z ${COMMENT_ID} ]]
+          then
+            echo "Comment not found. Not uploading 'comment/ID' artifact."
+          else
+            mkdir -p comment
+            echo ${COMMENT_ID} > comment/ID
+          fi
         env:
           GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -111,3 +117,4 @@ jobs:
         with:
           name: comment
           path: comment/
+          if-no-files-found: ignore

--- a/misc/scripts/library-coverage/comment-pr.py
+++ b/misc/scripts/library-coverage/comment-pr.py
@@ -56,14 +56,13 @@ def comment_pr(repo, run_id):
         if os.path.isdir("pr"):
             shutil.rmtree("pr")
 
-    utils.download_artifact(repo, "comment", "comment", run_id)
-
     try:
+        utils.download_artifact(repo, "comment", "comment", run_id)
         with open("comment/ID") as file:
             raw_comment_id = int(file.read())
     except Exception as e:
-        # If there is no existing comment, comment/ID will contain just a
-        # newline (due to jq & gh behaviour). This will cause `int(file.read())`
+        # If there is no existing comment, the `comment/ID` artifact
+        # will not exist. This will cause `utils.download_artifact`
         # to fail, so we catch that and set `raw_comment_id` to `None`.
         print("Could not retrieve an existing comment ID. \n", e)
         raw_comment_id = None

--- a/misc/scripts/library-coverage/comment-pr.py
+++ b/misc/scripts/library-coverage/comment-pr.py
@@ -59,7 +59,7 @@ def comment_pr(repo, run_id):
     try:
         utils.download_artifact(repo, "comment", "comment", run_id)
         with open("comment/ID") as file:
-            raw_comment_id = int(file.read())
+            raw_comment_id = int(file.read().strip())
     except Exception as e:
         # If there is no existing comment, the `comment/ID` artifact
         # will not exist. This will cause `utils.download_artifact`

--- a/misc/scripts/library-coverage/comment-pr.py
+++ b/misc/scripts/library-coverage/comment-pr.py
@@ -56,6 +56,21 @@ def comment_pr(repo, run_id):
         if os.path.isdir("pr"):
             shutil.rmtree("pr")
 
+    utils.download_artifact(repo, "comment", "comment", run_id)
+
+    try:
+        with open("comment/ID") as file:
+            raw_comment_id = int(file.read())
+    except Exception as e:
+        # If there is no existing comment, comment/ID will contain just a
+        # newline (due to jq & gh behaviour). This will cause `int(file.read())`
+        # to fail, so we catch that and set `raw_comment_id` to `None`.
+        print("Could not retrieve an existing comment ID. \n", e)
+        raw_comment_id = None
+    finally:
+        if os.path.isdir("comment"):
+            shutil.rmtree("comment")
+
     # Try storing diff for previous run:
     prev_run_id = 0
     prev_diff_exists = False
@@ -95,14 +110,37 @@ def comment_pr(repo, run_id):
 
         comment = comment_first_line + \
             "A recent commit removed the previously reported differences."
-    post_comment(comment, repo, pr_number)
+
+    if raw_comment_id is None:
+        post_initial_comment(comment, repo, pr_number)
+    else:
+        update_existing_comment(comment, repo, pr_number, raw_comment_id)
 
 
-def post_comment(comment, repo, pr_number):
+def post_initial_comment(comment, repo, pr_number):
     print(f"Posting comment to PR #{pr_number}")
     utils.subprocess_run(["gh", "pr", "comment", str(pr_number),
                          "--repo", repo, "--body", comment])
 
+def update_existing_comment(comment, repo, pr_number, raw_comment_id):
+    # Fetch existing comment, and validate:
+    # - comment belongs to the PR with number `pr_number`
+    # - comment starts with the expected prefix `comment_first_line`
+    # - comment author is github-actions[bot]
+    comment_author = "github-actions[bot]"
+    filter = f"select(.issue_url | endswith(\"{repo}/issues/{pr_number}\")) " + \
+        f"| select(.body | startswith(\"{comment_first_line}\")) " + \
+        f"| select(.user.login == \"{comment_author}\") " + \
+        "| .id"
+    comment_id = utils.subprocess_check_output(["gh", "api", f"repos/{repo}/issues/comments/{raw_comment_id}",
+                                                "--jq", filter]).strip()
+
+    if comment_id:
+        print(f"Updating comment {comment_id} on PR #{pr_number}")
+        utils.subprocess_run(["gh", "api", f"repos/{repo}/issues/comments/{comment_id}",
+                          "-X", "PATCH", "-f", f"body={comment}"])
+    else:
+        print(f"Comment {raw_comment_id} did not pass validations: not editing.")
 
 def get_previous_run_id(repo, run_id, pr_number):
     """

--- a/misc/scripts/library-coverage/comment-pr.py
+++ b/misc/scripts/library-coverage/comment-pr.py
@@ -156,7 +156,7 @@ def get_previous_run_id(repo, run_id, pr_number):
     pr_repo = this_run["head_repository"]
 
     # Get all previous runs that match branch, repo and workflow name:
-    output = utils.subprocess_check_output(["gh", "api", "-X", "GET", f"repos/{repo}/actions/runs", "-f", "event=pull_request", "-f", "status=success", "-f", f"branch='{pr_branch}'", "--paginate",
+    output = utils.subprocess_check_output(["gh", "api", "-X", "GET", f"repos/{repo}/actions/runs", "-f", "event=pull_request", "-f", "status=success", "-f", f"branch={pr_branch}", "--paginate",
                                             "--jq", f'[.workflow_runs.[] | select(.head_repository.full_name=="{pr_repo}" and .name=="{artifacts_workflow_name}")] | sort_by(.id) | reverse | [.[].id]'])
 
     ids = []


### PR DESCRIPTION
### Description

The framework coverage difference commenter currently posts a new comment after new commits. When there are a lot of these comments on a PR, it can be hard to find comments from reviewers. This PR changes the workflow so that it updates one comment box instead of creating multiple comments. 

**Note:** this code is based on the QHelp preview comment workflow which updates one comment box.  The first commit https://github.com/github/codeql/pull/14517/commits/9263cfdf5616644578dce04f11633dee0b9af255 is based on [this code in qhelp-pr-preview.yml](https://github.com/github/codeql/blob/1297acf5b129fdffa0d4dbcde74ac082b1df7487/.github/workflows/qhelp-pr-preview.yml#L88-L92).  The second commit https://github.com/github/codeql/pull/14517/commits/6e29b701007ff881e56ad74a63375b76117fed7d is based on [this code in post-pr-comment.yml](https://github.com/github/codeql/blob/d56a9f0781306aa4eca59d34401f3bae562ce0c1/.github/workflows/post-pr-comment.yml#L39-L66).

This PR also fixes a bug https://github.com/github/codeql/pull/14517/commits/ee4a9c3f8d7f4962884727a3dc7e7083b49caa19 that was causing a 'list index out of range' error in the pre-existing `get_previous_run_id` function. `f"branch='{pr_branch}'"` resulted in incorrect branch names such as `'branch='"'"'test-commenting'"'"''` due to apparent escaping of the single quotes, and the [`subprocess_check_output` call](https://github.com/github/codeql/blob/6c10ba2fb17dbccd40af8cbde678d4184c245b15/misc/scripts/library-coverage/comment-pr.py#L121-L122) always returned an empty list as a result since the branch name was incorrect. Changing this code to `f"branch={pr_branch}"` seems to resolve the issue.

### Testing
I've tested these changes on https://github.com/dsp-testing/codeql-framework-coverage-pr-commenter/pull/27 (let me know if you don't have access to this PR). 

- The first commit removes a MaD model, so the workflow posts an initial [comment](https://github.com/dsp-testing/codeql-framework-coverage-pr-commenter/pull/27#issuecomment-1772889254) ([workflow run](https://github.com/dsp-testing/codeql-framework-coverage-pr-commenter/actions/runs/6589306000/job/17903477204#step:5:22)). 
- The second commit removes another MaD model, so the workflow updates the existing comment ([workflow run](https://github.com/dsp-testing/codeql-framework-coverage-pr-commenter/actions/runs/6589375859/job/17903719936#step:5:24)).
- The third commit tests the bug fix in the `get_previous_run_id` function. It does not change any MaD models, so the diff is the same as the prior run, and the comment is not updated ([workflow run](https://github.com/dsp-testing/codeql-framework-coverage-pr-commenter/actions/runs/6589475894/job/17904030759#step:5:22)).