### PR TITLE
Swift: Model StringProtocol.appendingformat and String.decodecstring

### DIFF
--- a/swift/ql/lib/change-notes/2023-10-16-string.md
+++ b/swift/ql/lib/change-notes/2023-10-16-string.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+
+* Added taint models for `StringProtocol.appendingFormat` and `String.decodeCString`.

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/String.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/String.qll
@@ -40,7 +40,8 @@ private class StringSummaries extends SummaryModelCsv {
         ";StringProtocol;true;addingPercentEncoding(withAllowedCharacter:);;;Argument[-1];ReturnValue;taint",
         ";StringProtocol;true;addingPercentEscapes(using:);;;Argument[-1];ReturnValue;taint",
         ";StringProtocol;true;appending(_:);;;Argument[-1..0];ReturnValue;taint",
-        ";StringProtocol;true;appendingFormat(_:_:);;;Argument[-1..0];ReturnValue;taint", //-1..
+        ";StringProtocol;true;appendingFormat(_:_:);;;Argument[-1..0];ReturnValue;taint",
+        ";StringProtocol;true;appendingFormat(_:_:);;;Argument[1].CollectionElement;ReturnValue;taint",
         ";StringProtocol;true;applyingTransform(_:reverse:);;;Argument[-1];ReturnValue;taint",
         ";StringProtocol;true;cString(using:);;;Argument[-1];ReturnValue;taint",
         ";StringProtocol;true;capitalized(with:);;;Argument[-1];ReturnValue;taint",
@@ -123,6 +124,8 @@ private class StringSummaries extends SummaryModelCsv {
         ";String;true;randomElement(using:);;;Argument[-1];ReturnValue;taint",
         ";String;true;enumerated();;;Argument[-1];ReturnValue;taint",
         ";String;true;encode(to:);;;Argument[-1];Argument[0];taint",
+        ";String;true;decodeCString(_:as:repairingInvalidCodeUnits:);;;Argument[0];ReturnValue.TupleElement[0];taint",
+        ";String;true;decodeCString(_:as:repairingInvalidCodeUnits:);;;Argument[0].CollectionElement;ReturnValue.TupleElement[0];taint",
         ";LosslessStringConvertible;true;init(_:);;;Argument[0];ReturnValue;taint",
       ]
   }

--- a/swift/ql/test/library-tests/dataflow/taint/libraries/string.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/libraries/string.swift
@@ -662,3 +662,28 @@ func testAppendingFormat() {
   var s4 = ""
   sink(arg: s4.appendingFormat("%s %i", "", source())) // $ MISSING: tainted=663
 }
+
+func sourceUInt8() -> UInt8 { return 0 }
+
+func testDecodeCString() {
+  var input : [UInt8] = [1, 2, 3, sourceUInt8()]
+
+  let (str1, repaired1) = String.decodeCString(input, as: UTF8.self)!
+  sink(arg: str1) // $ MISSING: tainted=669
+  sink(arg: repaired1)
+
+  input.withUnsafeBufferPointer({
+    ptr in
+    let (str2, repaired2) = String.decodeCString(ptr.baseAddress, as: UTF8.self)!
+    sink(arg: str2) // $ MISSING: tainted=669
+    sink(arg: repaired2)
+  })
+
+  let (str3, repaired3) = String.decodeCString(source2(), as: UTF8.self)!
+  sink(arg: str3) // $ MISSING: tainted=682
+  sink(arg: repaired3)
+
+  let (str4, repaired4) = String.decodeCString(&input, as: UTF8.self)!
+  sink(arg: str4) // $ MISSING: tainted=669
+  sink(arg: repaired4)
+}

--- a/swift/ql/test/library-tests/dataflow/taint/libraries/string.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/libraries/string.swift
@@ -25,7 +25,6 @@ struct Locale {
 
 
 
-
 enum CInterop {
   typealias Char = CChar
   typealias PlatformChar = CInterop.Char
@@ -104,6 +103,7 @@ extension StringProtocol {
   func substring(from index: Self.Index) -> String { return "" }
   func trimmingCharacters(in set: CharacterSet) -> String { return "" }
   func appending<T>(_ aString: T) -> String where T : StringProtocol { return "" }
+  func appendingFormat<T>(_ format: T, _ arguments: CVarArg...) -> String where T : StringProtocol { return "" }
   func padding<T>(toLength newLength: Int, withPad padString: T, startingAt padIndex: Int) -> String where T: StringProtocol { return "" }
   func components(separatedBy separator: CharacterSet) -> [String] { return [] }
   func folding(options: String.CompareOptions = [], locale: Locale?) -> String { return "" }
@@ -647,4 +647,18 @@ func furtherTaintThroughCallbacks() {
   sink(arg: result5!)
   let result6 = try? tainted.withContiguousStorageIfAvailable(callbackWithTaintedPointer)
   sink(arg: result6!) // $ tainted=612
+}
+
+func testAppendingFormat() {
+  var s1 = source2()
+  sink(arg: s1.appendingFormat("%s %i", "", 0)) // $ tainted=653
+
+  var s2 = ""
+  sink(arg: s2.appendingFormat(source2(), "", 0)) // $ tainted=657
+
+  var s3 = ""
+  sink(arg: s3.appendingFormat("%s %i", source2(), 0)) // $ MISSING: tainted=660
+
+  var s4 = ""
+  sink(arg: s4.appendingFormat("%s %i", "", source())) // $ MISSING: tainted=663
 }

--- a/swift/ql/test/library-tests/dataflow/taint/libraries/string.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/libraries/string.swift
@@ -657,10 +657,10 @@ func testAppendingFormat() {
   sink(arg: s2.appendingFormat(source2(), "", 0)) // $ tainted=657
 
   var s3 = ""
-  sink(arg: s3.appendingFormat("%s %i", source2(), 0)) // $ MISSING: tainted=660
+  sink(arg: s3.appendingFormat("%s %i", source2(), 0)) // $ tainted=660
 
   var s4 = ""
-  sink(arg: s4.appendingFormat("%s %i", "", source())) // $ MISSING: tainted=663
+  sink(arg: s4.appendingFormat("%s %i", "", source())) // $ tainted=663
 }
 
 func sourceUInt8() -> UInt8 { return 0 }
@@ -669,7 +669,7 @@ func testDecodeCString() {
   var input : [UInt8] = [1, 2, 3, sourceUInt8()]
 
   let (str1, repaired1) = String.decodeCString(input, as: UTF8.self)!
-  sink(arg: str1) // $ MISSING: tainted=669
+  sink(arg: str1) // $ tainted=669
   sink(arg: repaired1)
 
   input.withUnsafeBufferPointer({
@@ -680,10 +680,10 @@ func testDecodeCString() {
   })
 
   let (str3, repaired3) = String.decodeCString(source2(), as: UTF8.self)!
-  sink(arg: str3) // $ MISSING: tainted=682
+  sink(arg: str3) // $ tainted=682
   sink(arg: repaired3)
 
   let (str4, repaired4) = String.decodeCString(&input, as: UTF8.self)!
-  sink(arg: str4) // $ MISSING: tainted=669
+  sink(arg: str4) // $ tainted=669
   sink(arg: repaired4)
 }


### PR DESCRIPTION
Swift: Add models for some missing string methods:
- [`StringProtocol.appendingformat(_:_:)`](https://developer.apple.com/documentation/swift/stringprotocol/appendingformat(_:_:))
- [`String.decodecstring(_:as:repairinginvalidcodeunits:)`](https://developer.apple.com/documentation/swift/string/decodecstring(_:as:repairinginvalidcodeunits:)-3mvvy)
- there are actually four variations of the latter, covered by two models
