### PR TITLE
C++: Add more documentation about dataflow through indirections

### DIFF
--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -58,7 +58,7 @@ A regular dataflow query such as the following query:
   where Flow::flowPath(source, sink)
   select sink.getNode(), source, sink, "Flow from user input to sink!"
 
-will catch most things such as
+will catch most things such as:
 
 .. code-block:: cpp
 

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -325,7 +325,7 @@ Consider an alternative scenario where ``U`` contains a single ``int`` data, and
 Since the ``data`` field is now an ``int`` instead of an ``int*`` the field no longer has any indirections, and so the use of ``asIndirectExpr`` in ``isAdditionalFlowStep`` no longer makes sense (and so the additional step will have no results). So there is no choice about whether to taint the value of the field or its indirection: it has to be the value.
 
 However, since we pass the address of ``data`` to ``use_pointer`` on line 12 the tainted value is what is pointed to by the argument of ``use_pointer`` (since the value pointed to by ``&data`` is exactly ``data``). So to handle this case we need a mix of the two situations above:
-  1. We need to taint the value of the field as described the :ref:`Using asExpr <using-asExpr>` section.
+  1. We need to taint the value of the field as described in the :ref:`Using asExpr <using-asExpr>` section.
   2. We need to select the indirection of the argument as described in the :ref:`Using asIndirectExpr <using-asIndirectExpr>` section.
 
 With these changes the query looks like:

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -102,7 +102,9 @@ This data flow is simple to match because the CodeQL database contains the infor
 Flow from a qualifier to a field access
 ---------------------------------------
 
-However, sometimes the writes or reads are not visible to CodeQL (for example, because the implementation of the function isn't included in the database), and so dataflow won't be able to match up all stores with reads, and thus you don't get the result you want. For example, consider an alternative setup where our source of data starts as the outgoing argument of a function `write_user_input_to`. We can model this setup in the dataflow library using the following ``isSource``:
+Sometimes field accesses are not visible to CodeQL (for example, because the implementation of the function isn't included in the database), and so dataflow cannot match up all stores with reads. This leads to missing (false negative) results. 
+
+For example, consider an alternative setup where our source of data starts as the outgoing argument of a function ``write_user_input_to``. We can model this setup in the dataflow library using the following ``isSource``:
 
 .. code-block:: ql
 

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -191,7 +191,7 @@ We have an important choice here: Should the relationship between ``n2`` and ``f
 Using asIndirectExpr
 ~~~~~~~~~~~~~~~~~~~~
 
-If we use ``n2.asIndirectExpr() = fa`` we specify that flow moves to what ``fa`` points to. This allows dataflow to flow through a later dereference, which is exactly what we need to to flow from ``p`` to ``*p`` in ``process_user_data``.
+If we use ``n2.asIndirectExpr() = fa`` we specify that flow moves to what ``fa`` points to. This allows data to flow through a later dereference, which is exactly what we need to track data flow from ``p`` to ``*p`` in ``process_user_data``.
 
 Thus we get the required flow path.
 

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -93,7 +93,7 @@ will catch most things such as
     free(b);
   }
 
-This is simple to match because we see:
+This data flow is simple to match because the CodeQL database contains the information to see:
   1. User input starts at ``user_input()`` and flows into ``fill_structure``.
   2. The data is written to the object ``b`` with access path ``[a, p]``.
   3. The object ``b`` flows out of ``fill_structure`` and into ``process_structure``.

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -392,7 +392,12 @@ To set the stage, consider the following scenario:
     free(b.a);
   }
 
-We write a user-controlled value into the object ``b`` at the access path ``[a, x]``. Afterwards, ``b`` is passed to ``read_data`` which we don't have the definition of in the database. We now want to track this user-input flowing into ``read_data``.
+What happens here is the following:
+
+  1. We write a user-controlled value into the object ``b`` at the access path ``[a, x]``.
+  2. Afterwards, ``b`` is passed to ``read_data`` which we don't have the definition of in the database.
+
+We now want to track this user-input flowing into ``read_data``.
 
 The dataflow library has a specific predicate to handle this scenario, and thus we don't need to add any additional flow steps using ``isAdditionalFlowStep``. Instead, we tell the dataflow library that ``read_data`` is a sink and may implicitly read the data from fields in the object it is passed. To do that, we implement ``allowImplicitRead`` in our dataflow module:
 

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -16,7 +16,7 @@ For almost all situations we only need to instantiate a dataflow configuration a
 
 However, when a write to a field is not visible to CodeQL (for example, because it happens in a function whose definition is not in the database) we need to track the qualifier, and tell the dataflow library that it should transfer flow from the qualifier to the field access. This is done by adding an ``isAdditionalFlowStep`` predicate to the dataflow module.
 
-When adding additional flow steps involving pointers one needs to be careful about whether the dataflow step should flow from the pointer or its indirection. Similarly, care must be taken to decide whether the additional step should target a pointer or its indirection.
+When you write additional flow steps to track pointers, you must decide whether the dataflow step should flow from the pointer or its indirection. Similarly, you must decide whether the additional step should target a pointer or its indirection.
 
 In the dual situation where a read of a field is not visible to CodeQL, the dataflow library's "implicit read" mechanism can be used to achieve the right flow.
 

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -138,7 +138,12 @@ This would match the call to ``write_user_input_to`` in the following example:
     free(u);
   }
 
-Flow now starts at the outgoing argument of ``write_user_input_to(...)`` and proceeds to ``u->p``. However, because CodeQL has not observed a write to ``p`` prior to the read ``u->p``, dataflow will stop at ``u``. In order to convince CodeQL to proceed we need to add an additional flow step through field reads like so:
+With this definition of ``isSource`` the data flow tracks flow along the following path:
+
+  1. The flow now starts at the outgoing argument of ``write_user_input_to(...)``.
+  2. The flow proceeds to ``u->p`` on the next line.
+
+However, because CodeQL has not observed a write to ``p`` before the read ``u->p``, dataflow will stop at ``u``. We can correct this gap in the information available to dataflow by adding an additional flow step through field reads:
 
 .. code-block:: ql
 

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -7,7 +7,7 @@
 Advanced dataflow scenarios for C/C++
 ======================================
 
-Data flow for C and C++ distinguish between the value of a pointer and the value of what the pointer points to. We call this the "indirection" of the pointer. Tracking the pointer and its indirection as separate entities is important for precise dataflow, but it may mean that you do not get the right flow if you select the wrong data flow node. This article demonstrates various scenarios where it is important to consider whether data flow should be computed on the value of the pointer or its indirection.
+Data flow for C and C++ distinguishes between the value of a pointer and the value of what the pointer points to. We call this the "indirection" of the pointer. Tracking the pointer and its indirection as separate entities is important for precise dataflow. However, it also means that you need to specify which data flow node to model. If you select the wrong data flow node, then analysis will be flawed. This article discusses several scenarios where it is important to consider whether data flow should be computed on the value of the pointer or its indirection.
 
 For almost all situations we only need to instantiate a dataflow configuration and specify our sources and sinks, and dataflow will handle everything for us.
 

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -187,7 +187,7 @@ Notice how the ``isSource`` and ``isSink`` are as expected: we're looking for fl
 
 In a real query the ``isAdditionalFlowStep`` step would be restricted in various ways to make sure that it doesn't add too much flow (since flow from a field qualifier to the field access in general will generate a lot of spurious flow). For example, one could restrict ``fa`` to be a field access that targets a particular field, or a field access of a field that's defined in a certain ``struct`` type.
 
-We have an important choice here: Should the relationship between ``n2`` and ``fa`` be implemented using ``asExpr`` or ``asIndirectExpr``? 
+We have an important choice here: Should ``n2`` be the node corresponding to the pointer value of ``fa`` or the indirection of ``fa`` (i.e., what ``fa`` points to)?
 
 .. _using-asIndirectExpr:
 

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -18,7 +18,7 @@ However, when a write to a field is not visible to CodeQL (for example, because 
 
 When you write additional flow steps to track pointers, you must decide whether the dataflow step should flow from the pointer or its indirection. Similarly, you must decide whether the additional step should target a pointer or its indirection.
 
-In the dual situation where a read of a field is not visible to CodeQL, the dataflow library's "implicit read" mechanism can be used to achieve the right flow.
+In contrast, if the read of a field is not visible to CodeQL, you can add an ``allowImplicitRead`` predicate to model the data flow.
 
 The setup
 ---------

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -240,7 +240,7 @@ Alternatively, this flow could also be tracked by:
   1. Changing ``isAdditionalFlowStep`` so that it targets the dataflow node that represents the value of the ``FieldAccess`` instead of the value it points to, and
   2. Changing ``isSink`` to specify that we're interested in tracking the value the argument passed to ``use_pointer`` (instead of the value of what the argument points to).
 
-With those changes our QL query becomes:
+With those changes our query becomes:
 
 .. code-block:: ql
 

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -138,7 +138,7 @@ This would match the call to ``write_user_input_to`` in the following example:
     free(u);
   }
 
-With this definition of ``isSource`` the data flow tracks flow along the following path:
+With this definition of ``isSource`` the dataflow library tracks flow along the following path:
 
   1. The flow now starts at the outgoing argument of ``write_user_input_to(...)``.
   2. The flow proceeds to ``u->p`` on the next line.

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -9,7 +9,7 @@ Advanced dataflow scenarios for C/C++
 
 Data flow for C and C++ distinguishes between the value of a pointer and the value of what the pointer points to. We call this the "indirection" of the pointer. Tracking the pointer and its indirection as separate entities is important for precise dataflow. However, it also means that you need to specify which data flow node to model. If you select the wrong data flow node, then analysis will be flawed. This article discusses several scenarios where it is important to consider whether data flow should be computed on the value of the pointer or its indirection.
 
-For almost all situations we only need to instantiate a dataflow configuration and specify our sources and sinks, and dataflow will handle everything for us.
+For almost all situations we only need to instantiate a dataflow configuration and specify our sources and sinks, and the dataflow library will handle everything for us.
 
 However, when a write to a field is not visible to CodeQL (for example because it happens in a function whose definition is not in the database) we need to track the qualifier, and tell the dataflow library that it is okay to transfer flow from the qualifier to the field access. This is done by adding an ``isAdditionalFlowStep`` predicate to the dataflow module.
 

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -389,7 +389,7 @@ To set the stage, consider the following scenario:
 
 We write a user-controlled value into the object ``b`` at the access path ``[a, x]``. Afterwards, ``b`` is passed to ``read_data`` which we don't have the definition of in the database. We now want to track this user-input flowing into ``read_data``.
 
-The dataflow library actually has a specific tool to handle this scenario, and thus we don't need to add any additional flow steps using ``isAdditionalFlowStep`` to handle this. Instead, we have to tell the dataflow library that ``read_data`` is a sink and may implicitly read the data from fields in the object it has been passed. To do that, we implement ``allowImplicitRead`` in our dataflow module:
+The dataflow library has a specific predicate to handle this scenario, and thus we don't need to add any additional flow steps using ``isAdditionalFlowStep``. Instead, we tell the dataflow library that ``read_data`` is a sink and may implicitly read the data from fields in the object it is passed. To do that, we implement ``allowImplicitRead`` in our dataflow module:
 
 .. code-block:: ql
 

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -238,7 +238,7 @@ Using asExpr
 
 Alternatively, this flow could also be tracked by:
   1. Changing ``isAdditionalFlowStep`` so that it targets the dataflow node that represents the value of the ``FieldAccess`` instead of the value it points to, and
-  2. Changing ``isSink`` so specify that we're interested in tracking the value the argument passed to ``use_pointer`` (instead of the value of what the argument points to).
+  2. Changing ``isSink`` to specify that we're interested in tracking the value the argument passed to ``use_pointer`` (instead of the value of what the argument points to).
 
 With those changes our QL query becomes:
 

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -20,8 +20,8 @@ When you write additional flow steps to track pointers, you must decide whether 
 
 In contrast, if the read of a field is not visible to CodeQL, you can add an ``allowImplicitRead`` predicate to model the data flow.
 
-The setup
----------
+Regular dataflow analysis
+-------------------------
 
 Consider the following scenario: We have data coming out of ``user_input()`` and we want to figure out if that data can ever reach an argument of `sink`.
 

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -310,8 +310,8 @@ Consider an alternative scenario where ``U`` contains a single ``int`` data, and
   }
 
 Since data is no longer a pointer our ``isAdditionalFlowStep`` doesn't make any sense because it specifies flow to the indirection of the field (and an integer does not have any indirections). So there is no choice about whether to taint the value of the field or its indirection: it has to be the value. However, since we pass the address of ``data`` to ``use_pointer`` the tainted data is what is pointed to by the argument of ``use_pointer`` (since the data pointed to by ``&data`` is exactly ``data``). So to handle this case we need a mix of the two situations above:
-  1. We need to taint the value of the field just like in the :ref:`Using asExpr <using-asExpr>` section.
-  2. We need to select the indirection of the argument just like in the :ref:`Using asIndirectExpr <using-asIndirectExpr>` section.
+  1. We need to taint the value of the field as described the :ref:`Using asExpr <using-asExpr>` section.
+  2. We need to select the indirection of the argument as described in the :ref:`Using asIndirectExpr <using-asIndirectExpr>` section.
 
 With these changes the query looks like:
 

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -61,6 +61,7 @@ A regular dataflow query such as the following query:
 will catch most things such as:
 
 .. code-block:: cpp
+  :caption: Example 1
 
   struct A {
     const int *p;
@@ -116,6 +117,7 @@ For example, consider an alternative setup where our source of data starts as th
 This would match the call to ``write_user_input_to`` in the following example:
 
 .. code-block:: cpp
+   :caption: Example 2
 
   void write_user_input_to(void*);
   void use_value(int);
@@ -194,13 +196,14 @@ We have an important choice here: Should ``n2`` be the node corresponding to the
 Using asIndirectExpr
 ~~~~~~~~~~~~~~~~~~~~
 
-If we use ``n2.asIndirectExpr() = fa`` we specify that flow moves to what ``fa`` points to. This allows data to flow through a later dereference, which is exactly what we need to track data flow from ``p`` to ``*p`` in ``process_user_data``.
+If we use ``n2.asIndirectExpr() = fa`` we specify that flow in example 2 moves to what ``fa`` points to. This allows data to flow through a later dereference, which is exactly what we need to track data flow from ``p`` to ``*p`` in ``process_user_data``.
 
 Thus we get the required flow path.
 
 Consider a slightly different sink:
 
 .. code-block:: cpp
+  :caption: Example 3
 
   void write_user_input_to(void*);
   void use_pointer(int*);
@@ -239,7 +242,7 @@ The only difference between the previous example and this one is that our data e
 Using asExpr
 ~~~~~~~~~~~~
 
-Alternatively, this flow could also be tracked by:
+Alternatively, the flow in example 2 could also be tracked by:
   1. Changing ``isAdditionalFlowStep`` so that it targets the dataflow node that represents the value of the ``FieldAccess`` instead of the value it points to, and
   2. Changing ``isSink`` to specify that we're interested in tracking the value the argument passed to ``use_pointer`` (instead of the value of what the argument points to).
 
@@ -291,6 +294,7 @@ Passing the address of a variable to ``use_pointer``
 Consider an alternative scenario where ``U`` contains a single ``int`` data, and we pass the address of data to ``use_pointer`` as seen below.
 
 .. code-block:: cpp
+  :caption: Example 4
 
   void write_user_input_to(void*);
   void use_pointer(int*);
@@ -368,6 +372,7 @@ The previous section demonstrated how to add flow from qualifiers to field acces
 To set the stage, consider the following scenario:
 
 .. code-block:: cpp
+  :caption: Example 5
 
   struct A {
     const int *p;

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -404,7 +404,7 @@ To set the stage, consider the following scenario:
     free(b.a);
   }
 
-What happens here is the following:
+In this example, the data flows as follows:
 
   1. We write a user-controlled value into the object ``b`` at the access path ``[a, x]``.
   2. Afterwards, ``b`` is passed to ``read_data`` which we don't have the definition of in the database.

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -118,8 +118,8 @@ For example, consider an alternative setup where our source of data starts as th
 This would match the call to ``write_user_input_to`` in the following example:
 
 .. code-block:: cpp
-   :caption: Example 2
-   :linenos:
+  :caption: Example 2
+  :linenos:
 
   void write_user_input_to(void*);
   void use_value(int);

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -191,7 +191,7 @@ Notice how the ``isSource`` and ``isSink`` are as expected: we're looking for fl
 
 In a real query the ``isAdditionalFlowStep`` step would be restricted in various ways to make sure that it doesn't add too much flow (since flow from a field qualifier to the field access in general will generate a lot of spurious flow). For example, one could restrict ``fa`` to be a field access that targets a particular field, or a field access of a field that's defined in a certain ``struct`` type.
 
-We have an important choice here: Should ``n2`` be the node corresponding to the pointer value of ``fa`` or the indirection of ``fa`` (i.e., what ``fa`` points to)?
+We have an important choice here: Should ``n2`` be the node corresponding to the pointer value of ``fa`` or the indirection of ``fa`` (that is, what ``fa`` points to)?
 
 .. _using-asIndirectExpr:
 

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -1,8 +1,6 @@
 .. _advanced-dataflow-scenarios-cpp:
 
-.. pull-quote:: Note
-
-   The data flow library described here is available from CodeQL 2.12.5 onwards. With the release of CodeQL 2.13.0 the library uses the new modular API for data flow. For information on the previous version of the library, see :ref:`Analyzing data flow in C and C++ <analyzing-data-flow-in-cpp>` and for information about the new modular API and how to migrate any existing queries to the updated data flow library, see `New dataflow API for CodeQL query writing <https://gh.io/codeql-new-dataflow-api>`__.
+.. include:: ../reusables/cpp-new-dataflow-api-note.rst
 
 Advanced dataflow scenarios for C/C++
 ======================================

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -11,7 +11,7 @@ Data flow for C and C++ distinguishes between the value of a pointer and the val
 
 For almost all situations we only need to instantiate a dataflow configuration and specify our sources and sinks, and the dataflow library will handle everything for us.
 
-However, when a write to a field is not visible to CodeQL (for example because it happens in a function whose definition is not in the database) we need to track the qualifier, and tell the dataflow library that it is okay to transfer flow from the qualifier to the field access. This is done by adding an ``isAdditionalFlowStep`` predicate to the dataflow module.
+However, when a write to a field is not visible to CodeQL (for example, because it happens in a function whose definition is not in the database) we need to track the qualifier, and tell the dataflow library that it should transfer flow from the qualifier to the field access. This is done by adding an ``isAdditionalFlowStep`` predicate to the dataflow module.
 
 When adding additional flow steps involving pointers one needs to be careful about whether the dataflow step should flow from the pointer or its indirection. Similarly, care must be taken to decide whether the additional step should target a pointer or its indirection.
 

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -23,7 +23,7 @@ In contrast, if the read of a field is not visible to CodeQL, you can add an ``a
 Regular dataflow analysis
 -------------------------
 
-Consider the following scenario: We have data coming out of ``user_input()`` and we want to figure out if that data can ever reach an argument of `sink`.
+Consider the following scenario: We have data coming out of ``user_input()`` and we want to figure out if that data can ever reach an argument of ``sink``.
 
 .. code-block:: cpp
 

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -9,6 +9,9 @@ Advanced dataflow scenarios for C/C++
 
 Data flow for C and C++ distinguishes between the value of a pointer and the value of what the pointer points to. We call this the "indirection" of the pointer. Tracking the pointer and its indirection as separate entities is important for precise dataflow. However, it also means that you need to specify which data flow node to model. If you select the wrong data flow node, then analysis will be flawed. This article discusses several scenarios where it is important to consider whether data flow should be computed on the value of the pointer or its indirection.
 
+Overview
+---------
+
 For almost all situations we only need to instantiate a dataflow configuration and specify our sources and sinks, and the dataflow library will handle everything for us.
 
 However, when a write to a field is not visible to CodeQL (for example, because it happens in a function whose definition is not in the database) we need to track the qualifier, and tell the dataflow library that it should transfer flow from the qualifier to the field access. This is done by adding an ``isAdditionalFlowStep`` predicate to the dataflow module.

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -62,6 +62,7 @@ will catch most things such as:
 
 .. code-block:: cpp
   :caption: Example 1
+  :linenos:
 
   struct A {
     const int *p;
@@ -118,6 +119,7 @@ This would match the call to ``write_user_input_to`` in the following example:
 
 .. code-block:: cpp
    :caption: Example 2
+   :linenos:
 
   void write_user_input_to(void*);
   void use_value(int);
@@ -204,6 +206,7 @@ Consider a slightly different sink:
 
 .. code-block:: cpp
   :caption: Example 3
+  :linenos:
 
   void write_user_input_to(void*);
   void use_pointer(int*);
@@ -295,6 +298,7 @@ Consider an alternative scenario where ``U`` contains a single ``int`` data, and
 
 .. code-block:: cpp
   :caption: Example 4
+  :linenos:
 
   void write_user_input_to(void*);
   void use_pointer(int*);
@@ -318,7 +322,9 @@ Consider an alternative scenario where ``U`` contains a single ``int`` data, and
     free(u);
   }
 
-Since data is no longer a pointer our ``isAdditionalFlowStep`` doesn't make any sense because it specifies flow to the indirection of the field (and an integer does not have any indirections). So there is no choice about whether to taint the value of the field or its indirection: it has to be the value. However, since we pass the address of ``data`` to ``use_pointer`` the tainted data is what is pointed to by the argument of ``use_pointer`` (since the data pointed to by ``&data`` is exactly ``data``). So to handle this case we need a mix of the two situations above:
+Since the ``data`` field is now an ``int`` instead of an ``int*`` the field no longer has any indirections, and so the use of ``asIndirectExpr`` in ``isAdditionalFlowStep`` no longer makes sense (and so the additional step will have no results). So there is no choice about whether to taint the value of the field or its indirection: it has to be the value.
+
+However, since we pass the address of ``data`` to ``use_pointer`` on line 12 the tainted value is what is pointed to by the argument of ``use_pointer`` (since the value pointed to by ``&data`` is exactly ``data``). So to handle this case we need a mix of the two situations above:
   1. We need to taint the value of the field as described the :ref:`Using asExpr <using-asExpr>` section.
   2. We need to select the indirection of the argument as described in the :ref:`Using asIndirectExpr <using-asIndirectExpr>` section.
 
@@ -373,6 +379,7 @@ To set the stage, consider the following scenario:
 
 .. code-block:: cpp
   :caption: Example 5
+  :linenos:
 
   struct A {
     const int *p;

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -30,7 +30,7 @@ Consider the following scenario: We have data coming out of ``user_input()`` and
   void sink(int);
   int user_input();
 
-A regular dataflow query such as the following query
+A regular dataflow query such as the following query:
 
 .. code-block:: ql
 

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -434,4 +434,4 @@ The ``allowImplicitRead`` predicate specifies that if we're at a node that satis
   3. The data flowing to the indirection of ``&b`` (i.e., the object ``b``).
   4. An implicit read of the field ``x`` followed by an implicit read of the field ``a`` at the sink.
 
-Thus, we end up at a node that satisfies ``isSink`` with an empty access path, and hence a dataflow path is successfully found.
+Thus, we end up at a node that satisfies ``isSink`` with an empty access path, and successfully track the full dataflow path.

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -423,7 +423,7 @@ The dataflow library actually has a specific tool to handle this scenario, and t
   where Flow::flowPath(source, sink)
   select sink.getNode(), source, sink, "Flow from user input to sink!"
 
-The ``allowImplicitRead`` predicate specifies that if we're at a node that satisfies ``isSink`` then we're allowed to assume that there is an implicit read of a field named ``a`` or a field named ``x``. This gets us the flow we are interested in because the dataflow library now will see:
+The ``allowImplicitRead`` predicate specifies that if we're at a node that satisfies ``isSink`` then we're allowed to assume that there is an implicit read of a field named ``a`` or a field named ``x`` (in this case both). This gets us the flow we are interested in because the dataflow library now will see:
 
   1. User input starts at ``user_input()``.
   2. The data flowing into ``b`` with access path ``[a, x]``.

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -20,24 +20,11 @@ In the dual situation where a read of a field is not visible to CodeQL, the data
 The setup
 ---------
 
-Consider the following scenario: We have a two structs, each containing two fields, and we have two types of ways of getting user input, and two places that data can end up in:
+Consider the following scenario: We have data coming out of ``user_input()`` and we want to figure out if that data can ever reach an argument of `sink`.
 
 .. code-block:: cpp
-
-  struct A {
-    const int *p;
-    int x;
-  };
-
-  struct B {
-    A *a;
-    int y;
-  };
-
   void sink(int);
   int user_input();
-  void write_user_input_to(void *);
-  void read_data(const void *);
 
 A regular dataflow query such as the following query
 
@@ -69,9 +56,19 @@ A regular dataflow query such as the following query
   where Flow::flowPath(source, sink)
   select sink.getNode(), source, sink, "Flow from user input to sink!"
 
-will catch most things á la
+will catch most things such as
 
 .. code-block:: cpp
+
+  struct A {
+    const int *p;
+    int x;
+  };
+
+  struct B {
+    A *a;
+    int y;
+  };
 
   void fill_structure(B* b, const int* pu) {
     // ...

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -166,7 +166,7 @@ Here, flow starts at the outgoing argument of ``write_user_input_to(...)`` and p
   where Flow::flowPath(source, sink)
   select sink.getNode(), source, sink, "Flow from user input to sink!"
 
-Notice how the ``isSource`` and ``isSink`` are as expected: we're looking for flow that starts at the outgoing parameter of ``write_user_input_to(...)``, and ends up as an argument to ``isSink``. The interesting part is the addition of ``isAdditionalFlow`` which specifies an additional flow step from the qualifier of a ``FieldAccess`` to the result of the access. Note that we have an important choice here: Should the relationship between ``n2`` and ``fa`` be implemented using ``asExpr`` or ``asIndirectExpr``? 
+Notice how the ``isSource`` and ``isSink`` are as expected: we're looking for flow that starts at the outgoing parameter of ``write_user_input_to(...)``, and ends up as an argument to ``isSink``. The interesting part is the addition of ``isAdditionalFlow`` which specifies an additional flow step from the qualifier of a ``FieldAccess`` to the result of the access. We have an important choice here: Should the relationship between ``n2`` and ``fa`` be implemented using ``asExpr`` or ``asIndirectExpr``? 
 
 .. _using-asIndirectExpr:
 

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -11,7 +11,7 @@ Data flow for C and C++ distinguish between the value of a pointer and the value
 
 For almost all situations we only need to instantiate a dataflow configuration and specify our sources and sinks, and dataflow will handle everything for us.
 
-However, when a write to a field is not visible to CodeQL (for example because it happens in a function whose definition is not in the database) we need to track the qualifier, and tell the dataflow library that it is okay to transfer from flow from the qualifier to the field access. This is done by adding an ``isAdditionalFlowStep`` predicate to the dataflow module.
+However, when a write to a field is not visible to CodeQL (for example because it happens in a function whose definition is not in the database) we need to track the qualifier, and tell the dataflow library that it is okay to transfer flow from the qualifier to the field access. This is done by adding an ``isAdditionalFlowStep`` predicate to the dataflow module.
 
 When adding additional flow steps involving pointers one needs to be careful about whether the dataflow step should flow from the pointer or its indirection. Similarly, care must be taken to decide whether the additional step should target a pointer or its indirection.
 

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -383,7 +383,7 @@ To set the stage, consider the following scenario:
     free(b.a);
   }
 
-We write a user-controlled value into the object ``b`` at the access path ``[a, x]``. Afterwards, ``b`` is passed to ``read_data`` which we assume we don't have the definition of in the database. We now want to track this user-input flowing into ``read_data``.
+We write a user-controlled value into the object ``b`` at the access path ``[a, x]``. Afterwards, ``b`` is passed to ``read_data`` which we don't have the definition of in the database. We now want to track this user-input flowing into ``read_data``.
 
 The dataflow library actually has a specific tool to handle this scenario, and thus we don't need to add any additional flow steps using ``isAdditionalFlowStep`` to handle this. Instead, we have to tell the dataflow library that ``read_data`` may implicitly read the data from the object that it has been passed. To do that, we implement ``allowImplicitRead`` in our dataflow module:
 

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -428,6 +428,6 @@ The ``allowImplicitRead`` predicate specifies that if we're at a node that satis
   1. User input starts at ``user_input()``.
   2. The data flowing into ``b`` with access path ``[a, x]``.
   3. The data flowing to the indirection of ``&b`` (i.e., the object ``b``).
-  4. An implicit read of the field ``x`` followed by an implicit read of the field ``a``.
+  4. An implicit read of the field ``x`` followed by an implicit read of the field ``a`` at the sink.
 
 Thus, we end up at a node that satisfies ``isSink`` with an empty access path, and hence a dataflow path is successfully found.

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -174,7 +174,11 @@ Flow now starts at the outgoing argument of ``write_user_input_to(...)`` and pro
   where Flow::flowPath(source, sink)
   select sink.getNode(), source, sink, "Flow from user input to sink!"
 
-Notice how the ``isSource`` and ``isSink`` are as expected: we're looking for flow that starts at the outgoing parameter of ``write_user_input_to(...)``, and ends up as an argument to ``isSink``. The interesting part is the addition of ``isAdditionalFlow`` which specifies an additional flow step from the qualifier of a ``FieldAccess`` to the result of the access. We have an important choice here: Should the relationship between ``n2`` and ``fa`` be implemented using ``asExpr`` or ``asIndirectExpr``? 
+Notice how the ``isSource`` and ``isSink`` are as expected: we're looking for flow that starts at the outgoing parameter of ``write_user_input_to(...)``, and ends up as an argument to ``isSink``. The interesting part is the addition of ``isAdditionalFlow`` which specifies an additional flow step from the qualifier of a ``FieldAccess`` to the result of the access.
+
+In a real query the ``isAdditionalFlowStep`` step would be restricted in various ways to make sure that it doesn't add too much flow (since flow from a field qualifier to the field access in general will generate a lot of spurious flow). For example, one could restrict ``fa`` to be a field access that targets a particular field, or a field access of a field that's defined in a certain ``struct`` type.
+
+We have an important choice here: Should the relationship between ``n2`` and ``fa`` be implemented using ``asExpr`` or ``asIndirectExpr``? 
 
 .. _using-asIndirectExpr:
 

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -102,6 +102,7 @@ Flow from a qualifier to a field access
 However, sometimes the writes or reads are not visible to CodeQL (for example, because the implementation of the function isn't included in the database), and so dataflow won't be able to match up all stores with reads, and thus you don't get the result you want. For example, consider an alternative setup where our source of data starts as the outgoing argument of a function `write_user_input_to`. We can model this setup in the dataflow library using the following ``isSource``:
 
 .. code-block:: ql
+
   predicate isSource(DataFlow::Node source) {
     exists(Call call |
       call.getTarget().hasName("write_user_input_to") and

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -369,18 +369,18 @@ To set the stage, consider the following scenario:
   void read_data(const void *);
   void *malloc(size_t);
 
-  void get_input_and_use_data() {
+  void get_input_and_read_data() {
     B b;
     b.a = (A *)malloc(sizeof(A));
     b.a->x = user_input();
     // ...
-    use_data(&b);
+    read_data(&b);
     free(b.a);
   }
 
-We write a user-controlled value into the object ``b`` at the access path ``[a, x]``. Afterwards, ``b`` is passed to ``use_data`` which we assume we don't have the definition of in the database. We now want to track this user-input flowing into ``use_data``.
+We write a user-controlled value into the object ``b`` at the access path ``[a, x]``. Afterwards, ``b`` is passed to ``read_data`` which we assume we don't have the definition of in the database. We now want to track this user-input flowing into ``read_data``.
 
-The dataflow library actually has a specific tool to handle this scenario, and thus we don't need to add any additional flow steps using ``isAdditionalFlowStep`` to handle this. Instead, we have to tell the dataflow library that ``use_data`` may implicitly read the data from the object that it has been passed. To do that, we implement ``allowImplicitRead`` in our dataflow module:
+The dataflow library actually has a specific tool to handle this scenario, and thus we don't need to add any additional flow steps using ``isAdditionalFlowStep`` to handle this. Instead, we have to tell the dataflow library that ``read_data`` may implicitly read the data from the object that it has been passed. To do that, we implement ``allowImplicitRead`` in our dataflow module:
 
 .. code-block:: ql
 

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -385,7 +385,7 @@ To set the stage, consider the following scenario:
 
 We write a user-controlled value into the object ``b`` at the access path ``[a, x]``. Afterwards, ``b`` is passed to ``read_data`` which we don't have the definition of in the database. We now want to track this user-input flowing into ``read_data``.
 
-The dataflow library actually has a specific tool to handle this scenario, and thus we don't need to add any additional flow steps using ``isAdditionalFlowStep`` to handle this. Instead, we have to tell the dataflow library that ``read_data`` may implicitly read the data from the object that it has been passed. To do that, we implement ``allowImplicitRead`` in our dataflow module:
+The dataflow library actually has a specific tool to handle this scenario, and thus we don't need to add any additional flow steps using ``isAdditionalFlowStep`` to handle this. Instead, we have to tell the dataflow library that ``read_data`` is a sink and may implicitly read the data from fields in the object it has been passed. To do that, we implement ``allowImplicitRead`` in our dataflow module:
 
 .. code-block:: ql
 

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -1,0 +1,421 @@
+.. _advanced-dataflow-scenarios-cpp:
+
+.. pull-quote:: Note
+
+   The data flow library described here is available from CodeQL 2.12.5 onwards. With the release of CodeQL 2.13.0 the library uses the new modular API for data flow. For information on the previous version of the library, see :ref:`Analyzing data flow in C and C++ <analyzing-data-flow-in-cpp>` and for information about the new modular API and how to migrate any existing queries to the updated data flow library, see `New dataflow API for CodeQL query writing <https://gh.io/codeql-new-dataflow-api>`__.
+
+Advanced dataflow scenarios for C/C++
+======================================
+
+Data flow for C and C++ distinguish between the value of a pointer and the value of what the pointer points to. We call this the "indirection" of the pointer. Tracking the pointer and its indirection as separate entities is important for precise dataflow, but it may mean that you do not get the right flow if you select the wrong data flow node. This article demonstrates various scenarios where it is important to consider whether data flow should be computed on the value of the pointer or its indirection.
+
+For almost all situations we only need to instantiate a dataflow configuration and specify our sources and sinks, and dataflow will handle everything for us.
+
+However, when a write to a field is not visible to CodeQL (for example because it happens in a function whose definition is not in the database) we need to track the qualifier, and tell the dataflow library that it is okay to transfer from flow from the qualifier to the field access. This is done by adding an ``isAdditionalFlowStep`` predicate to the dataflow module.
+
+When adding additional flow steps involving pointers one needs to be careful about whether the dataflow step should flow from the pointer or its indirection. Similarly, care must be taken to decide whether the additional step should target a pointer or its indirection.
+
+In the dual situation where a read of a field is not visible to CodeQL, the dataflow library's "implicit read" mechanism can be used to achieve the right flow.
+
+The setup
+---------
+
+Consider the following scenario: We have a two structs, each containing two fields, and we have two types of ways of getting user input, and two places that data can end up in:
+
+.. code-block:: cpp
+
+  struct A {
+    const int *p;
+    int x;
+  };
+
+  struct B {
+    A *a;
+    int y;
+  };
+
+  void sink(int);
+  int user_input();
+  void write_user_input_to(void *);
+  void read_data(const void *);
+
+A regular dataflow query such as the following query
+
+.. code-block:: ql
+
+  /**
+  * @kind path-problem
+  */
+
+  import semmle.code.cpp.dataflow.new.DataFlow
+  import Flow::PathGraph
+
+  module Config implements DataFlow::ConfigSig {
+    predicate isSource(DataFlow::Node source) {
+      source.asExpr().(Call).getTarget().hasName("user_input")
+    }
+
+    predicate isSink(DataFlow::Node sink) {
+      exists(Call call |
+        call.getTarget().hasName("sink") and
+        sink.asExpr() = call.getAnArgument()
+      )
+    }
+  }
+
+  module Flow = DataFlow::Global<Config>;
+
+  from Flow::PathNode source, Flow::PathNode sink
+  where Flow::flowPath(source, sink)
+  select sink.getNode(), source, sink, "Flow from user input to sink!"
+
+will catch most things á la
+
+.. code-block:: cpp
+
+  void fill_structure(B* b, const int* pu) {
+    // ...
+    b->a->p = pu;
+  }
+
+  void process_structure(const B* b) {
+    sink(*b->a->p);
+  }
+
+  void get_and_process() {
+    int u = user_input();
+    B* b = (B*)malloc(sizeof(B));
+    // ...
+    fill_structure(b, &u);
+    // ...
+    process_structure(b);
+    free(b);
+  }
+
+This is simple to match because we see:
+  1. User input starts at ``user_input()`` and flows into ``fill_structure``.
+  2. The data is written to the object ``b`` with access path ``[a, p]``.
+  3. The object ``b`` flows out of ``fill_structure`` and into ``process_structure``.
+  4. The access path ``[a, p]`` is read in ``process_structure`` and the value ends up in the sink.
+
+Flow from a qualifier to a field access
+---------------------------------------
+
+However, sometimes the writes or reads are not visible to CodeQL (for example, because the implementation of the function isn’t included in the database), and so dataflow won't be able to match up all stores with reads, and thus you don't get the result you want. For example, consider the following example:
+
+.. code-block:: cpp
+
+  void write_user_input_to(void*);
+  void use_value(int);
+  void* malloc(unsigned long);
+
+  struct U {
+    const int* p;
+    int x;
+  };
+
+  void process_user_data(const int* p) {
+    // ...
+    use_value(*p);
+  }
+
+  void get_and_process_user_input_v2() {
+    U* u = (U*)malloc(sizeof(U));
+    write_user_input_to(u);
+    process_user_data(u->p);
+    free(u);
+  }
+
+Here, flow starts at the outgoing argument of ``write_user_input_to(...)`` and proceeds to ``u->p``. However, because CodeQL has not observed a write to p prior to the read ``u->p``, dataflow will stop at ``u``. In order to convince CodeQL to proceed we need to add an additional flow step through field reads like so:
+
+.. code-block:: ql
+
+  /**
+  * @kind path-problem
+  */
+
+  import semmle.code.cpp.dataflow.new.DataFlow
+  import Flow::PathGraph
+
+  module Config implements DataFlow::ConfigSig {
+    predicate isSource(DataFlow::Node source) {
+      exists(Call call |
+        call.getTarget().hasName("write_user_input_to") and
+        source.asDefiningArgument() = call.getArgument(0)
+      )
+    }
+
+    predicate isSink(DataFlow::Node sink) {
+      exists(Call call |
+        call.getTarget().hasName("use_value") and
+        sink.asExpr() = call.getAnArgument()
+      )
+    }
+
+    predicate isAdditionalFlowStep(DataFlow::Node n1, DataFlow::Node n2) {
+      exists(FieldAccess fa |
+        n1.asIndirectExpr() = fa.getQualifier() and
+        n2.asIndirectExpr() = fa
+      )
+    }
+  }
+
+  module Flow = DataFlow::Global<Config>;
+
+  from Flow::PathNode source, Flow::PathNode sink
+  where Flow::flowPath(source, sink)
+  select sink.getNode(), source, sink, "Flow from user input to sink!"
+
+Notice how the ``isSource`` and ``isSink`` are as expected: we're looking for flow that starts at the outgoing parameter of ``write_user_input_to(...)``, and ends up as an argument to ``isSink``. The interesting part is the addition of ``isAdditionalFlow`` which specifies an additional flow step from the qualifier of a ``FieldAccess`` to the result of the access. Note that we have an important choice here: Should the relationship between ``n2`` and ``fa`` be implemented using ``asExpr`` or ``asIndirectExpr``? 
+
+.. _using-asIndirectExpr:
+
+Using asIndirectExpr
+~~~~~~~~~~~~~~~~~~~~
+
+If we use ``n2.asIndirectExpr() = fa`` we specify that flow moves to what ``fa`` points to. This allows dataflow to flow through a later dereference, which is exactly what we need to to flow from ``p`` to ``*p`` in ``process_user_data``.
+
+Thus we get the required flow path.
+
+Consider a slightly different sink:
+
+.. code-block:: cpp
+
+  void write_user_input_to(void*);
+  void use_pointer(int*);
+  void* malloc(unsigned long);
+
+  struct U {
+    const int* p;
+    int x;
+  };
+
+  void process_user_data(const int* p) {
+    // ...
+    use_pointer(p);
+  }
+
+  void get_and_process_user_input_v2() {
+    U* u = (U*)malloc(sizeof(U));
+    write_user_input_to(u);
+    process_user_data(u->p);
+    free(u);
+  }
+
+The only difference between the previous example and this one is that our data ends up in a call to ``use_pointer`` which takes an ``int*`` instead of an ``int`` as an argument. Since our ``isAdditionalFlowStep`` implementation already steps to the indirection of the ``FieldAccess`` we're already tracking what the field points to. So we can find this flow by using ``sink.asIndirectExpr()`` to specify that the data we're interested in tracking is the value that ends up being pointed to by an argument that is passed to ``use_pointer``:
+
+.. code-block:: ql
+
+  predicate isSink(DataFlow::Node sink) {
+    exists(Call call |
+      call.getTarget().hasName("use_pointer") and
+      sink.asIndirectExpr() = call.getAnArgument()
+    )
+  }
+
+.. _using-asExpr:
+
+Using asExpr
+~~~~~~~~~~~~
+
+Alternatively, this flow could also be tracked by:
+  1. Changing ``isAdditionalFlowStep`` so that it targets the dataflow node that represents the value of the ``FieldAccess`` instead of the value it points to, and
+  2. Changing ``isSink`` so specify that we're interested in tracking the value the argument passed to ``use_pointer`` (instead of the value of what the argument points to).
+
+With those changes our QL query becomes:
+
+.. code-block:: ql
+
+  /**
+  * @kind path-problem
+  */
+
+  import semmle.code.cpp.dataflow.new.DataFlow
+  import Flow::PathGraph
+
+  module Config implements DataFlow::ConfigSig {
+    predicate isSource(DataFlow::Node source) {
+      exists(Call call |
+        call.getTarget().hasName("write_user_input_to") and
+        source.asDefiningArgument() = call.getArgument(0)
+      )
+    }
+
+    predicate isSink(DataFlow::Node sink) {
+      exists(Call call |
+        call.getTarget().hasName("use_pointer") and
+        sink.asExpr() = call.getAnArgument()
+      )
+    }
+
+    predicate isAdditionalFlowStep(DataFlow::Node n1, DataFlow::Node n2) {
+      exists(FieldAccess fa |
+        n1.asIndirectExpr() = fa.getQualifier() and
+        n2.asExpr() = fa
+      )
+    }
+  }
+
+  module Flow = DataFlow::Global<Config>;
+
+  from Flow::PathNode source, Flow::PathNode sink
+  where Flow::flowPath(source, sink)
+  select sink.getNode(), source, sink, "Flow from user input to sink!"
+
+When we get to ``u->p`` the additional step transfers flow from what the qualifier points to, to the result of the ``FieldAccess``. After this, dataflow proceeds to ``p`` in ``use_pointer(p)`` and since we specified in our ``isSink`` that we're interested in the value of the argument, our dataflow analysis finds a result.
+
+Passing the address of a variable to ``use_pointer``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Consider an alternative scenario where ``U`` contains a single ``int`` data, and we pass the address of data to ``use_pointer`` as seen below.
+
+.. code-block:: cpp
+
+  void write_user_input_to(void*);
+  void use_pointer(int*);
+  void* malloc(unsigned long);
+
+  struct U {
+    int data;
+    int x;
+  };
+
+  void process_user_data(int data) {
+    // ...
+    use_pointer(&data);
+  }
+
+
+  void get_and_process_user_input_v2() {
+    U* u = (U*)malloc(sizeof(U));
+    write_user_input_to(u);
+    process_user_data(u->data);
+    free(u);
+  }
+
+Since data is no longer a pointer our ``isAdditionalFlowStep`` doesn't make any sense because it specifies flow to the indirection of the field (and an integer does not have any indirections). So there is no choice about whether to taint the value of the field or its indirection: it has to be the value. However, since we pass the address of ``data`` to ``use_pointer`` the tainted data is what is pointed to by the argument of ``use_pointer`` (since the data pointed to by ``&data`` is exactly ``data``). So to handle this case we need a mix of the two situations above:
+  1. We need to taint the value of the field just like in the :ref:`Using asExpr <using-asExpr>` section.
+  2. We need to select the indirection of the argument just like in the :ref:`Using asIndirectExpr <using-asIndirectExpr>` section.
+
+With these changes the query looks like:
+
+.. code-block:: ql
+
+  /**
+  * @kind path-problem
+  */
+
+  import semmle.code.cpp.dataflow.new.DataFlow
+  import Flow::PathGraph
+
+  module Config implements DataFlow::ConfigSig {
+    predicate isSource(DataFlow::Node source) {
+      exists(Call call |
+        call.getTarget().hasName("write_user_input_to") and
+        source.asDefiningArgument() = call.getArgument(0)
+      )
+    }
+
+    predicate isSink(DataFlow::Node sink) {
+      exists(Call call |
+        call.getTarget().hasName("use_pointer") and
+        sink.asIndirectExpr() = call.getAnArgument()
+      )
+    }
+
+    predicate isAdditionalFlowStep(DataFlow::Node n1, DataFlow::Node n2) {
+      exists(FieldAccess fa |
+        n1.asIndirectExpr() = fa.getQualifier() and
+        n2.asExpr() = fa
+      )
+    }
+  }
+
+  module Flow = DataFlow::Global<Config>;
+
+  from Flow::PathNode source, Flow::PathNode sink
+  where Flow::flowPath(source, sink)
+  select sink.getNode(), source, sink, "Flow from user input to sink!"
+
+And with that query the flow is identified.
+
+Specifying implicit reads
+-------------------------
+
+The previous section demonstrated how to add flow from qualifiers to field accesses because a source implicitly tainted all the fields of a struct. This section considers the opposite scenario: A specific field is being tainted, and we want to find any place that may read from this object, including any place that reads an unknown set of fields.
+
+To set the stage, consider the following scenario:
+
+.. code-block:: cpp
+
+  struct A {
+    const int *p;
+    int x;
+  };
+
+  struct B {
+    A *a;
+    int z;
+  };
+
+  int user_input();
+  void read_data(const void *);
+  void *malloc(size_t);
+
+  void get_input_and_use_data() {
+    B b;
+    b.a = (A *)malloc(sizeof(A));
+    b.a->x = user_input();
+    // ...
+    use_data(&b);
+    free(b.a);
+  }
+
+We write a user-controlled value into the object ``b`` at the access path ``[a, x]``. Afterwards, ``b`` is passed to ``use_data`` which we assume we don't have the definition of in the database. We now want to track this user-input flowing into ``use_data``.
+
+The dataflow library actually has a specific tool to handle this scenario, and thus we don't need to add any additional flow steps using ``isAdditionalFlowStep`` to handle this. Instead, we have to tell the dataflow library that ``use_data`` may implicitly read the data from the object that it has been passed. To do that, we implement ``allowImplicitRead`` in our dataflow module:
+
+.. code-block:: ql
+
+  /**
+  * @kind path-problem
+  */
+
+  import semmle.code.cpp.dataflow.new.DataFlow
+  import Flow::PathGraph
+
+  module Config implements DataFlow::ConfigSig {
+    predicate isSource(DataFlow::Node source) {
+      exists(Call call |
+        call.getTarget().hasName("user_input") and
+        source.asExpr() = call
+      )
+    }
+
+    predicate isSink(DataFlow::Node sink) {
+      exists(Call call |
+        call.getTarget().hasName("read_data") and
+        sink.asIndirectExpr() = call.getAnArgument()
+      )
+    }
+
+    predicate allowImplicitRead(DataFlow::Node n, DataFlow::ContentSet cs) {
+      isSink(n) and
+      cs.getAReadContent().(DataFlow::FieldContent).getField().hasName(["a", "x"])
+    }
+  }
+
+  module Flow = DataFlow::Global<Config>;
+
+  from Flow::PathNode source, Flow::PathNode sink
+  where Flow::flowPath(source, sink)
+  select sink.getNode(), source, sink, "Flow from user input to sink!"
+
+The ``allowImplicitRead`` predicate specifies that if we're at a node that satisfies ``isSink`` then we're allowed to assume that there is an implicit read of a field named ``a`` or a field named ``x``. This gets us the flow we are interested in because the dataflow library now will see:
+
+  1. User input starts at ``user_input()``.
+  2. The data flowing into ``b`` with access path ``[a, x]``.
+  3. The data flowing to the indirection of ``&b`` (i.e., the object ``b``).
+  4. An implicit read of the field ``x`` followed by an implicit read of the field ``a``.
+
+Thus, we end up at a node that satisfies ``isSink`` with an empty access path, and hence a dataflow path is successfully found.

--- a/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
+++ b/docs/codeql/codeql-language-guides/advanced-dataflow-scenarios-cpp.rst
@@ -23,6 +23,7 @@ The setup
 Consider the following scenario: We have data coming out of ``user_input()`` and we want to figure out if that data can ever reach an argument of `sink`.
 
 .. code-block:: cpp
+
   void sink(int);
   int user_input();
 

--- a/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp-new.rst
+++ b/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp-new.rst
@@ -1,8 +1,6 @@
 .. _analyzing-data-flow-in-cpp-new:
 
-.. pull-quote:: Note
-
-   The data flow library described here is available from CodeQL 2.12.5 onwards. With the release of CodeQL 2.13.0 the library uses the new modular API for data flow. For information on the previous version of the library, see :ref:`Analyzing data flow in C and C++ <analyzing-data-flow-in-cpp>` and for information about the new modular API and how to migrate any existing queries to the updated data flow library, see `New dataflow API for CodeQL query writing <https://gh.io/codeql-new-dataflow-api>`__.
+.. include:: ../reusables/cpp-new-dataflow-api-note.rst
 
 Analyzing data flow in C and C++ (new)
 ======================================

--- a/docs/codeql/codeql-language-guides/codeql-for-cpp.rst
+++ b/docs/codeql/codeql-language-guides/codeql-for-cpp.rst
@@ -45,4 +45,4 @@ Experiment and learn how to write effective and efficient queries for CodeQL dat
 
 -  :doc:`Hash consing and value numbering <hash-consing-and-value-numbering>`: You can use specialized CodeQL libraries to recognize expressions that are syntactically identical or compute the same value at runtime in C and C++ codebases.
 
--  :doc:`Advanced C/C++ dataflow scenarios <advanced-dataflow-scenarios-cpp>`: You can do precise data flow analysis of C and C++ codebases by distinguishing between a pointer and its indirection(s).
+-  :doc:`Advanced C/C++ dataflow scenarios <advanced-dataflow-scenarios-cpp>`: You can track precise data flow in C and C++ codebases by distinguishing between a pointer and its indirection(s).

--- a/docs/codeql/codeql-language-guides/codeql-for-cpp.rst
+++ b/docs/codeql/codeql-language-guides/codeql-for-cpp.rst
@@ -20,6 +20,7 @@ Experiment and learn how to write effective and efficient queries for CodeQL dat
    using-the-guards-library-in-cpp
    using-range-analsis-in-cpp
    hash-consing-and-value-numbering
+   advanced-dataflow-scenarios-cpp
 
 
 -  :doc:`Basic query for C and C++ code <basic-query-for-cpp-code>`: Learn to write and run a simple CodeQL query.
@@ -43,3 +44,5 @@ Experiment and learn how to write effective and efficient queries for CodeQL dat
 -  :doc:`Using range analysis for C and C++ <using-range-analsis-in-cpp>`: You can use range analysis to determine the upper or lower bounds on an expression, or whether an expression could potentially over or underflow.
 
 -  :doc:`Hash consing and value numbering <hash-consing-and-value-numbering>`: You can use specialized CodeQL libraries to recognize expressions that are syntactically identical or compute the same value at runtime in C and C++ codebases.
+
+-  :doc:`Advanced C/C++ dataflow scenarios <advanced-dataflow-scenarios-cpp>`: You can do precise data flow analysis of C and C++ codebases by distinguishing between a pointer and its indirection(s).

--- a/docs/codeql/reusables/cpp-new-dataflow-api-note.rst
+++ b/docs/codeql/reusables/cpp-new-dataflow-api-note.rst
@@ -1,0 +1,3 @@
+.. pull-quote:: Note
+
+   The data flow library described here is available from CodeQL 2.12.5 onwards. With the release of CodeQL 2.13.0 the library uses the new modular API for data flow. For information on the previous version of the library, see :ref:`Analyzing data flow in C and C++ <analyzing-data-flow-in-cpp>` and for information about the new modular API and how to migrate any existing queries to the updated data flow library, see `New dataflow API for CodeQL query writing <https://gh.io/codeql-new-dataflow-api>`__.


### PR DESCRIPTION
This PR adds a new article (linked from https://codeql.github.com/docs/codeql-language-guides/codeql-for-cpp/) explaining how we would tackle a few situations that involve tainting a pointer or tainting its indirection.

We know from past experience that this has been something Microsoft has needed some explanation of, and this document should hopefully answer some of the common questions we've gotten (with the expectation that other people will have similar questions).

cc @felicitymay