### PR TITLE
Kotlin: Don't convert back and forth between ClassId and FqName

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
@@ -139,7 +139,7 @@ open class KotlinUsesExtractor(
     }
 
     fun getJavaEquivalentClass(c: IrClass) =
-        getJavaEquivalentClassId(c)?.let { getClassByFqName(pluginContext, it.asSingleFqName()) }?.owner
+        getJavaEquivalentClassId(c)?.let { getClassByClassId(pluginContext, it) }?.owner
 
     /**
      * Gets a KotlinFileExtractor based on this one, except it attributes locations to the file that declares the given class.

--- a/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_5_0/ReferenceEntity.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_5_0/ReferenceEntity.kt
@@ -2,11 +2,16 @@ package com.github.codeql.utils
 
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.ir.symbols.*
+import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 
 fun getClassByFqName(pluginContext: IrPluginContext, fqName: FqName): IrClassSymbol? {
     return pluginContext.referenceClass(fqName)
+}
+
+fun getClassByClassId(pluginContext: IrPluginContext, id: ClassId): IrClassSymbol? {
+    return getClassByFqName(pluginContext, id.asSingleFqName())
 }
 
 fun getFunctionsByFqName(pluginContext: IrPluginContext, pkgName: FqName, name: Name): Collection<IrSimpleFunctionSymbol> {

--- a/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_8_0/ReferenceEntity.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_8_0/ReferenceEntity.kt
@@ -10,6 +10,10 @@ import org.jetbrains.kotlin.name.Name
 
 fun getClassByFqName(pluginContext: IrPluginContext, fqName: FqName): IrClassSymbol? {
     val id = ClassId.topLevel(fqName)
+    return getClassByClassId(pluginContext, id)
+}
+
+fun getClassByClassId(pluginContext: IrPluginContext, id: ClassId): IrClassSymbol? {
     return pluginContext.referenceClass(id)
 }
 


### PR DESCRIPTION
This showed up as a bug in Kotlin 2 mode:

We were starting with the Class Id "java/util/Map.Entry", which we then converted to the FqName "java.util.Map.Entry", and then back to a Class Id with ClassId.topLevel. This gave us a Class Id that referenceClass wasn't able to resolve.

Now we just stick with the Class Id that we started with, and the class can be resolved by Kotlin 2.