### PR TITLE
Go: Add Go frameworks for automated coverage reports

### DIFF
--- a/go/documentation/library-coverage/coverage.rst
+++ b/go/documentation/library-coverage/coverage.rst
@@ -7,6 +7,23 @@ Go framework & library support
    :widths: auto
 
    Framework / library,Package,Flow sources,Taint & value steps,Sinks (total)
-   Others,"````, ``archive/tar``, ``archive/zip``, ``bufio``, ``bytes``, ``compress/bzip2``, ``compress/flate``, ``compress/gzip``, ``compress/lzw``, ``compress/zlib``, ``container/heap``, ``container/list``, ``container/ring``, ``context``, ``crypto``, ``crypto/cipher``, ``crypto/rsa``, ``crypto/tls``, ``crypto/x509``, ``database/sql``, ``database/sql/driver``, ``encoding``, ``encoding/ascii85``, ``encoding/asn1``, ``encoding/base32``, ``encoding/base64``, ``encoding/binary``, ``encoding/csv``, ``encoding/gob``, ``encoding/hex``, ``encoding/json``, ``encoding/pem``, ``encoding/xml``, ``errors``, ``expvar``, ``fmt``, ``github.com/astaxie/beego``, ``github.com/astaxie/beego/context``, ``github.com/astaxie/beego/utils``, ``github.com/beego/beego/core/utils``, ``github.com/beego/beego/server/web``, ``github.com/beego/beego/server/web/context``, ``github.com/couchbase/gocb``, ``github.com/couchbaselabs/gocb``, ``github.com/elazarl/goproxy``, ``github.com/evanphx/json-patch``, ``github.com/gin-gonic/gin``, ``github.com/go-pg/pg/$ANYVERSION/orm``, ``github.com/golang/protobuf/$ANYVERSION/proto``, ``github.com/json-iterator/go``, ``github.com/labstack/echo``, ``github.com/revel/revel``, ``github.com/robfig/revel``, ``github.com/sendgrid/sendgrid-go/$ANYVERSION/helpers/mail``, ``go.uber.org/zap``, ``golang.org/x/net/$ANYVERSION/html``, ``golang.org/x/net/context``, ``google.golang.org/protobuf/$ANYVERSION/internal/encoding/text``, ``google.golang.org/protobuf/$ANYVERSION/internal/impl``, ``google.golang.org/protobuf/$ANYVERSION/proto``, ``google.golang.org/protobuf/$ANYVERSION/reflect/protoreflect``, ``gopkg.in/couchbase/gocb``, ``gopkg.in/macaron``, ``gopkg.in/yaml``, ``html``, ``html/template``, ``io``, ``io/fs``, ``io/ioutil``, ``k8s.io/api/core``, ``k8s.io/apimachinery/$ANYVERSION/pkg/runtime``, ``log``, ``mime``, ``mime/multipart``, ``mime/quotedprintable``, ``net``, ``net/http``, ``net/http/httputil``, ``net/mail``, ``net/textproto``, ``net/url``, ``os``, ``path``, ``path/filepath``, ``reflect``, ``regexp``, ``sort``, ``strconv``, ``strings``, ``sync``, ``sync/atomic``, ``syscall``, ``text/scanner``, ``text/tabwriter``, ``text/template``",8,826,
+   `Couchbase official client(gocb) <https://github.com/couchbase/gocb>`_,"``github.com/couchbase/gocb*``, ``gopkg.in/couchbase/gocb*``",,36,
+   `Couchbase unofficial client <http://www.github.com/couchbase/go-couchbase>`_,``github.com/couchbaselabs/gocb*``,,18,
+   `Echo <https://echo.labstack.com/>`_,``github.com/labstack/echo*``,,2,
+   `Gin <https://github.com/gin-gonic/gin>`_,``github.com/gin-gonic/gin*``,,2,
+   `Kubernetes <https://kubernetes.io/>`_,"``k8s.io/api*``, ``k8s.io/apimachinery*``",,57,
+   `Macaron <https://gopkg.in/macaron.v1>`_,``gopkg.in/macaron*``,,1,
+   `Revel <http://revel.github.io/>`_,"``github.com/revel/revel*``, ``github.com/robfig/revel*``",,20,
+   `SendGrid <https://github.com/sendgrid/sendgrid-go>`_,``github.com/sendgrid/sendgrid-go*``,,1,
+   `Standard library <https://pkg.go.dev/std>`_,"````, ``archive/*``, ``bufio``, ``bytes``, ``cmp``, ``compress/*``, ``container/*``, ``context``, ``crypto``, ``crypto/*``, ``database/*``, ``debug/*``, ``embed``, ``encoding``, ``encoding/*``, ``errors``, ``expvar``, ``flag``, ``fmt``, ``go/*``, ``hash``, ``hash/*``, ``html``, ``html/*``, ``image``, ``image/*``, ``index/*``, ``io``, ``io/*``, ``log``, ``log/*``, ``maps``, ``math``, ``math/*``, ``mime``, ``mime/*``, ``net``, ``net/*``, ``os``, ``os/*``, ``path``, ``path/*``, ``plugin``, ``reflect``, ``reflect/*``, ``regexp``, ``regexp/*``, ``slices``, ``sort``, ``strconv``, ``strings``, ``sync``, ``sync/*``, ``syscall``, ``syscall/*``, ``testing``, ``testing/*``, ``text/*``, ``time``, ``time/*``, ``unicode``, ``unicode/*``, ``unsafe``",8,566,
+   `beego <https://beego.me/>`_,"``github.com/astaxie/beego*``, ``github.com/beego/beego*``",,42,
+   `go-pg <https://pg.uptrace.dev/>`_,``github.com/go-pg/pg*``,,6,
+   `golang.org/x/net <https://pkg.go.dev/golang.org/x/net>`_,``golang.org/x/net*``,,21,
+   `goproxy <https://github.com/elazarl/goproxy>`_,``github.com/elazarl/goproxy*``,,2,
+   `json-iterator <https://github.com/json-iterator/go>`_,``github.com/json-iterator/go*``,,4,
+   `jsonpatch <https://github.com/evanphx/json-patch>`_,``github.com/evanphx/json-patch*``,,12,
+   `protobuf <https://pkg.go.dev/google.golang.org/protobuf>`_,"``github.com/golang/protobuf*``, ``google.golang.org/protobuf*``",,16,
+   `yaml <https://gopkg.in/yaml.v3>`_,``gopkg.in/yaml*``,,9,
+   `zap <https://go.uber.org/zap>`_,``go.uber.org/zap*``,,11,
    Totals,,8,826,
 

--- a/go/documentation/library-coverage/frameworks.csv
+++ b/go/documentation/library-coverage/frameworks.csv
@@ -1,1 +1,19 @@
 Framework name,URL,Package prefixes
+Standard library,https://pkg.go.dev/std, archive/* bufio bytes cmp compress/* container/* context crypto crypto/* database/* debug/* embed encoding encoding/* errors expvar flag fmt go/* hash hash/* html html/* image image/* index/* io io/* log log/* maps math math/* mime mime/* net net/* os os/* path path/* plugin reflect reflect/* regexp regexp/* slices sort strconv strings sync sync/* syscall syscall/* testing testing/* text/* time time/* unicode unicode/* unsafe
+beego,https://beego.me/,github.com/astaxie/beego* github.com/beego/beego*
+Couchbase official client(gocb),https://github.com/couchbase/gocb,github.com/couchbase/gocb* gopkg.in/couchbase/gocb*
+Couchbase unofficial client,http://www.github.com/couchbase/go-couchbase,github.com/couchbaselabs/gocb*
+Echo,https://echo.labstack.com/,github.com/labstack/echo*
+Gin,https://github.com/gin-gonic/gin,github.com/gin-gonic/gin*
+go-pg,https://pg.uptrace.dev/,github.com/go-pg/pg*
+golang.org/x/net,https://pkg.go.dev/golang.org/x/net,golang.org/x/net*
+goproxy,https://github.com/elazarl/goproxy,github.com/elazarl/goproxy*
+json-iterator,https://github.com/json-iterator/go,github.com/json-iterator/go*
+jsonpatch,https://github.com/evanphx/json-patch,github.com/evanphx/json-patch*
+Kubernetes,https://kubernetes.io/,k8s.io/api* k8s.io/apimachinery*
+Macaron,https://gopkg.in/macaron.v1,gopkg.in/macaron*
+protobuf,https://pkg.go.dev/google.golang.org/protobuf,github.com/golang/protobuf* google.golang.org/protobuf*
+Revel,http://revel.github.io/,github.com/revel/revel* github.com/robfig/revel*
+SendGrid,https://github.com/sendgrid/sendgrid-go,github.com/sendgrid/sendgrid-go*
+yaml,https://gopkg.in/yaml.v3,gopkg.in/yaml*
+zap,https://go.uber.org/zap,go.uber.org/zap*


### PR DESCRIPTION
Note that the space at the beginning of the package patterns for the standard library is deliberate, because builtin functions use the empty string as their package and we want to attribute them to the standard library.