### PR TITLE
fix typo ('Configration' to ‘Configuration’)

### DIFF
--- a/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeHtmlConstructionQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeHtmlConstructionQuery.qll
@@ -9,6 +9,9 @@ private import semmle.javascript.security.dataflow.UnsafeJQueryPluginCustomizati
 import UnsafeHtmlConstructionCustomizations::UnsafeHtmlConstruction
 import semmle.javascript.security.TaintedObject
 
+/** DEPRECATED: Mis-spelled class name, alias for Configuration. */
+deprecated class Configration = Configuration;
+
 /**
  * A taint-tracking configuration for reasoning about unsafe HTML constructed from library input vulnerabilities.
  */

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeHtmlConstructionQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeHtmlConstructionQuery.qll
@@ -12,8 +12,8 @@ import semmle.javascript.security.TaintedObject
 /**
  * A taint-tracking configuration for reasoning about unsafe HTML constructed from library input vulnerabilities.
  */
-class Configration extends TaintTracking::Configuration {
-  Configration() { this = "UnsafeHtmlConstruction" }
+class Configuration extends TaintTracking::Configuration {
+  Configuration() { this = "UnsafeHtmlConstruction" }
 
   override predicate isSource(DataFlow::Node source, DataFlow::FlowLabel label) {
     source instanceof Source and


### PR DESCRIPTION
fix typo ('Configration' to ‘Configuration’)