### PR TITLE
C#: Handle `netstandard` references in standalone extraction

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
@@ -268,7 +268,8 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 "runtime.win-x64.microsoft.netcore.app",
 
                 // Internal implementation packages not meant for direct consumption:
-                "runtime."
+                "runtime.",
+                "netstandard.library.ref"
             };
             RemoveNugetPackageReference(runtimePackagePrefixes);
         }

--- a/csharp/ql/integration-tests/posix-only/standalone_dependencies/Assemblies.expected
+++ b/csharp/ql/integration-tests/posix-only/standalone_dependencies/Assemblies.expected
@@ -168,6 +168,5 @@
 | /microsoft.netcore.app.ref/7.0.2/ref/net7.0/WindowsBase.dll |
 | /microsoft.netcore.app.ref/7.0.2/ref/net7.0/mscorlib.dll |
 | /microsoft.netcore.app.ref/7.0.2/ref/net7.0/netstandard.dll |
-| /netstandard.library/2.0.3/build/netstandard2.0/ref/System.ComponentModel.Composition.dll |
 | /newtonsoft.json/12.0.1/lib/portable-net45+win8+wp8+wpa81/Newtonsoft.Json.dll |
 | /nunit/3.13.3/lib/netstandard2.0/nunit.framework.dll |

--- a/csharp/ql/integration-tests/windows-only/standalone_dependencies/Assemblies.expected
+++ b/csharp/ql/integration-tests/windows-only/standalone_dependencies/Assemblies.expected
@@ -212,6 +212,5 @@
 | /microsoft.windowsdesktop.app.ref/7.0.2/ref/net7.0/UIAutomationTypes.dll |
 | /microsoft.windowsdesktop.app.ref/7.0.2/ref/net7.0/WindowsBase.dll |
 | /microsoft.windowsdesktop.app.ref/7.0.2/ref/net7.0/WindowsFormsIntegration.dll |
-| /netstandard.library/2.0.3/build/netstandard2.0/ref/System.ComponentModel.Composition.dll |
 | /newtonsoft.json/12.0.1/lib/portable-net45+win8+wp8+wpa81/Newtonsoft.Json.dll |
 | /nunit/3.13.3/lib/netstandard2.0/nunit.framework.dll |


### PR DESCRIPTION
This PR handles `netstandard` target frameworks. When multiple frameworks are targeted then the assemblies get deduplicated by name. Netstandard packages contain a `netstandard.dll` assembly, which conflicts with other variants.

The DCA experiments shows significant improvement on `DewGaming/PokemonDatabase`, where it removes 266810 compilation errors.