### PR TITLE
Java/Kotlin: Reshuffle our LoC queries

### DIFF
--- a/java/ql/src/Metrics/Summaries/LinesOfCode.ql
+++ b/java/ql/src/Metrics/Summaries/LinesOfCode.ql
@@ -1,8 +1,8 @@
 /**
  * @id java/summary/lines-of-code
- * @name Total lines of Java code in the database
- * @description The total number of lines of code across all Java files. This is a useful metric of the size of a database.
- *              For all Java files that were seen during the build, this query counts the lines of code, excluding whitespace
+ * @name Total lines of Java+Kotlin code in the database
+ * @description The total number of lines of code across all Java and Kotlin files. This is a useful metric of the size of a database.
+ *              For all source files that were seen during the build, this query counts the lines of code, excluding whitespace
  *              or comments.
  * @kind metric
  * @tags summary
@@ -11,4 +11,4 @@
 
 import java
 
-select sum(CompilationUnit f | f.fromSource() and f.isJavaSourceFile() | f.getNumberOfLinesOfCode())
+select sum(CompilationUnit f | f.fromSource() | f.getNumberOfLinesOfCode())

--- a/java/ql/src/Metrics/Summaries/LinesOfCode.ql
+++ b/java/ql/src/Metrics/Summaries/LinesOfCode.ql
@@ -1,6 +1,6 @@
 /**
  * @id java/summary/lines-of-code
- * @name Total lines of Java+Kotlin code in the database
+ * @name Total lines of Java/Kotlin code in the database
  * @description The total number of lines of code across all Java and Kotlin files. This is a useful metric of the size of a database.
  *              For all source files that were seen during the build, this query counts the lines of code, excluding whitespace
  *              or comments.

--- a/java/ql/src/Metrics/Summaries/LinesOfCodeJava.ql
+++ b/java/ql/src/Metrics/Summaries/LinesOfCodeJava.ql
@@ -1,0 +1,13 @@
+/**
+ * @id java/summary/lines-of-code-java
+ * @name Total lines of Java code in the database
+ * @description The total number of lines of code across all Java files. This is a useful metric of the size of a database.
+ *              For all Java files that were seen during the build, this query counts the lines of code, excluding whitespace
+ *              or comments.
+ * @kind metric
+ * @tags summary
+ */
+
+import java
+
+select sum(CompilationUnit f | f.fromSource() and f.isJavaSourceFile() | f.getNumberOfLinesOfCode())

--- a/java/ql/src/Metrics/Summaries/LinesOfCodeKotlin.ql
+++ b/java/ql/src/Metrics/Summaries/LinesOfCodeKotlin.ql
@@ -6,7 +6,6 @@
  *              or comments.
  * @kind metric
  * @tags summary
- *       lines-of-code
  */
 
 import java

--- a/java/ql/src/change-notes/2023-10-20-lines-of-code.md
+++ b/java/ql/src/change-notes/2023-10-20-lines-of-code.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* java/summary/lines-of-code now gives the total number of lines of Java and Kotlin code, and is the only query tagged `lines-of-code`. java/summary/lines-of-code-java and java/summary/lines-of-code-kotlin give the per-language counts.


### PR DESCRIPTION
There's now a single lines-of-code query that gives the total number of lines of code over both languages.

Per-language LoC queries are now just summaries.

@henrymercer 