### PR TITLE
Java: Automodel Framework Mode Extraction Bug

### DIFF
--- a/java/ql/automodel/src/AutomodelFrameworkModeExtractPositiveExamples.ql
+++ b/java/ql/automodel/src/AutomodelFrameworkModeExtractPositiveExamples.ql
@@ -7,15 +7,16 @@
  * @id java/ml/extract-automodel-framework-positive-examples
  * @tags internal extract automodel framework-mode positive examples
  */
+
 private import AutomodelFrameworkModeCharacteristics
 private import AutomodelEndpointTypes
 private import AutomodelJavaUtil
 
 from
-  Endpoint endpoint, EndpointType endpointType, FrameworkModeMetadataExtractor meta, DollarAtString package,
-  DollarAtString type, DollarAtString subtypes, DollarAtString name, DollarAtString signature,
-  DollarAtString input, DollarAtString output, DollarAtString parameterName,
-  DollarAtString extensibleType
+  Endpoint endpoint, EndpointType endpointType, FrameworkModeMetadataExtractor meta,
+  DollarAtString package, DollarAtString type, DollarAtString subtypes, DollarAtString name,
+  DollarAtString signature, DollarAtString input, DollarAtString output,
+  DollarAtString parameterName, DollarAtString extensibleType
 where
   endpoint.getExtensibleType() = extensibleType and
   meta.hasMetadata(endpoint, package, type, subtypes, name, signature, input, output, parameterName) and

--- a/java/ql/automodel/src/AutomodelFrameworkModeExtractPositiveExamples.ql
+++ b/java/ql/automodel/src/AutomodelFrameworkModeExtractPositiveExamples.ql
@@ -7,13 +7,12 @@
  * @id java/ml/extract-automodel-framework-positive-examples
  * @tags internal extract automodel framework-mode positive examples
  */
-
 private import AutomodelFrameworkModeCharacteristics
 private import AutomodelEndpointTypes
 private import AutomodelJavaUtil
 
 from
-  Endpoint endpoint, SinkType sinkType, FrameworkModeMetadataExtractor meta, DollarAtString package,
+  Endpoint endpoint, EndpointType endpointType, FrameworkModeMetadataExtractor meta, DollarAtString package,
   DollarAtString type, DollarAtString subtypes, DollarAtString name, DollarAtString signature,
   DollarAtString input, DollarAtString output, DollarAtString parameterName,
   DollarAtString extensibleType
@@ -21,9 +20,9 @@ where
   endpoint.getExtensibleType() = extensibleType and
   meta.hasMetadata(endpoint, package, type, subtypes, name, signature, input, output, parameterName) and
   // Extract positive examples of sinks belonging to the existing ATM query configurations.
-  CharacteristicsImpl::isKnownAs(endpoint, sinkType, _)
+  CharacteristicsImpl::isKnownAs(endpoint, endpointType, _)
 select endpoint,
-  sinkType + "\nrelated locations: $@, $@." + "\nmetadata: $@, $@, $@, $@, $@, $@, $@, $@, $@.", //
+  endpointType + "\nrelated locations: $@, $@." + "\nmetadata: $@, $@, $@, $@, $@, $@, $@, $@, $@.", //
   CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, MethodDoc()), "MethodDoc", //
   CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, ClassDoc()), "ClassDoc", //
   package, "package", //


### PR DESCRIPTION
The framework mode +example extraction query had a subtle bug that limited its output to sink examples.

The first commit is the actual fix, the second commit is just autoformatting.