### PR TITLE
Java: exclude internal packages globally from MaD models

### DIFF
--- a/java/ql/lib/semmle/code/java/dataflow/internal/ModelExclusions.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/ModelExclusions.qll
@@ -53,10 +53,16 @@ private predicate isJdkInternal(CompilationUnit cu) {
   cu.getPackage().getName() = ""
 }
 
+/** Holds if the given compilation unit's package is internal. */
+private predicate isInternal(CompilationUnit cu) {
+  isJdkInternal(cu) or
+  cu.getPackage().getName().matches("%internal%")
+}
+
 /** Holds if the given callable is not worth modeling. */
 predicate isUninterestingForModels(Callable c) {
   isInTestFile(c.getCompilationUnit().getFile()) or
-  isJdkInternal(c.getCompilationUnit()) or
+  isInternal(c.getCompilationUnit()) or
   c instanceof MainMethod or
   c instanceof StaticInitializer or
   exists(FunctionalExpr funcExpr | c = funcExpr.asMethod()) or


### PR DESCRIPTION
We currently exclude only JDK internals from MaD models. This PR excludes any models with `%internal%` in their  package name since such models have come up during ML and heuristic triage. 

Let me know if there is any reason not to apply this exclusion.