### PR TITLE
Kotlin: Mention `Literal::getLiteral()` difference from source code

### DIFF
--- a/java/ql/lib/semmle/code/java/Expr.qll
+++ b/java/ql/lib/semmle/code/java/Expr.qll
@@ -530,6 +530,9 @@ class Literal extends Expr, @literal {
    * Gets a string representation of this literal as it appeared
    * in the source code.
    *
+   * For Kotlin the result might not match the exact representation
+   * used in the source code.
+   *
    * **Important:** Unless a query explicitly wants to check how
    * a literal was written in the source code, the predicate
    * `getValue()` (or value predicates of subclasses) should be


### PR DESCRIPTION
It appears the Kotlin extractor does not have access to the actual string representation in the source code, and for most literal types uses simply the represented value also as `getLiteral` result, see https://github.com/github/codeql/blob/codeql-cli/v2.15.1/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt#L4443

And also #11296

Feedback, especially regarding the wording, is appreciated.