### PR TITLE
C++: Fix `strtok` model for indirections

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Strtok.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Strtok.qll
@@ -32,6 +32,8 @@ private class Strtok extends ArrayFunction, AliasFunction, TaintFunction, SideEf
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     input.isParameter(0) and output.isReturnValue()
+    or
+    input.isParameterDeref(0) and output.isReturnValueDeref()
   }
 
   override predicate hasOnlySpecificReadSideEffects() { none() }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -6622,6 +6622,13 @@ WARNING: Module TaintTracking has been deprecated and may be removed in future (
 | taint.cpp:711:13:711:13 | s | taint.cpp:711:2:711:8 | call to strncpy | TAINT |
 | taint.cpp:711:13:711:13 | s | taint.cpp:711:10:711:10 | ref arg d | TAINT |
 | taint.cpp:712:7:712:7 | ref arg d | taint.cpp:709:25:709:25 | d |  |
+| taint.cpp:718:17:718:31 | call to indirect_source | taint.cpp:720:27:720:32 | source |  |
+| taint.cpp:719:22:719:29 | ,.-;:_ | taint.cpp:720:35:720:39 | delim |  |
+| taint.cpp:719:22:719:29 | ,.-;:_ | taint.cpp:722:8:722:12 | delim |  |
+| taint.cpp:720:20:720:25 | call to strtok | taint.cpp:721:8:721:16 | tokenized |  |
+| taint.cpp:720:27:720:32 | source | taint.cpp:720:20:720:25 | call to strtok | TAINT |
+| taint.cpp:721:8:721:16 | tokenized | taint.cpp:721:7:721:16 | * ... | TAINT |
+| taint.cpp:722:8:722:12 | delim | taint.cpp:722:7:722:12 | * ... | TAINT |
 | vector.cpp:16:43:16:49 | source1 | vector.cpp:17:26:17:32 | source1 |  |
 | vector.cpp:16:43:16:49 | source1 | vector.cpp:31:38:31:44 | source1 |  |
 | vector.cpp:17:21:17:33 | call to vector | vector.cpp:19:14:19:14 | v |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
@@ -718,6 +718,6 @@ void test_strtok_indirect() {
 	char *source = indirect_source();
 	const char* delim = ",.-;:_";
 	char* tokenized = strtok(source, delim);
-	sink(*tokenized); // $ MISSING: ast,ir
+	sink(*tokenized); // $ ir MISSING: ast
 	sink(*delim);
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
@@ -711,3 +711,13 @@ void test_strncpy(char* d, char* s) {
 	strncpy(d, s, 16);
 	sink(d); // $ ast ir
 }
+
+char* indirect_source();
+
+void test_strtok_indirect() {
+	char *source = indirect_source();
+	const char* delim = ",.-;:_";
+	char* tokenized = strtok(source, delim);
+	sink(*tokenized); // $ MISSING: ast,ir
+	sink(*delim);
+}


### PR DESCRIPTION
This fixes a missing case for the `strtok` model. The problem was revealed by the fixes in https://github.com/github/codeql/pull/14571, but the DCA run for the project that had this regression failed the DCA run. So we didn't spot the regression in the PR 😭.