### PR TITLE
Python: Minor cleanup for string pool interaction

### DIFF
--- a/python/ql/lib/semmle/python/dataflow/new/internal/ImportResolution.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/ImportResolution.qll
@@ -227,7 +227,7 @@ module ImportResolution {
    */
   pragma[inline]
   private Module getModuleFromName(string name) {
-    isPreferredModuleForName(result.getFile(), name + ["", ".__init__"])
+    isPreferredModuleForName(result.getFile(), [name, name + ".__init__"])
   }
 
   /** Gets the module from which attributes are imported by `i`. */


### PR DESCRIPTION
This doesn't really seem to impact performance, is just a bit cleaner way to write the QL code.

In the worst case, since we do string concat with empty string, we would need to load string + attempt to store new string in string pool, which is useless since we can surely just reuse the integer ID.

## Previously

```
Evaluated non-recursive predicate ImportResolution#f829f0f0::ImportResolution::getImmediateModuleReference#1#ff#reorder_1_0#join_rhs#CSE@5fdc6eia in 1ms (size: 2).
Evaluated relational algebra for predicate ImportResolution#f829f0f0::ImportResolution::getImmediateModuleReference#1#ff#reorder_1_0#join_rhs#CSE@5fdc6eia with tuple counts:
         1   ~0%    {1} r1 = CONSTANT(unique string)[""]

         1   ~0%    {1} r2 = CONSTANT(unique string)[".__init__"]

         2   ~0%    {1} r3 = r1 UNION r2
                    return r3

Evaluated recursive predicate ImportResolution#f829f0f0::ImportResolution::getImmediateModuleReference#1#ff#reorder_1_0@b4f54xlv in 72ms on iteration 1 (delta size: 26339).
Evaluated relational algebra for predicate ImportResolution#f829f0f0::ImportResolution::getImmediateModuleReference#1#ff#reorder_1_0@b4f54xlv on iteration 1 running pipeline base with tuple counts:
         6382   ~0%    {3} r1 = JOIN ImportResolution#f829f0f0::ImportResolution::getImmediateModuleReference#1#ff#reorder_1_0#join_rhs#CSE WITH Module#68efc075::Module::getFile#0#dispred#ff CARTESIAN PRODUCT OUTPUT Rhs.1, Lhs.0, Rhs.0
         6066   ~2%    {4} r2 = JOIN r1 WITH Module#68efc075::isPreferredModuleForName#2#ff ON FIRST 1 OUTPUT Lhs.2, _, Lhs.1, Rhs.1
                       {2} r3 = REWRITE r2 WITH Tmp.1 := "", Out.1 := InverseAppend(Tmp.1,In.2,In.3) KEEPING 2
         3721   ~0%    {2} r4 = SCAN r3 OUTPUT In.1, In.0
        25945   ~2%    {2} r5 = JOIN r4 WITH ImportResolution#f829f0f0::ImportResolution::getReferenceToModuleName#1#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1

           38   ~4%    {3} r6 = SCAN SsaDefinitions#9197156e::SsaSource::init_module_submodule_defn#2#ff OUTPUT In.1, _, In.0
           38   ~1%    {3} r7 = REWRITE r6 WITH Out.1 := -1
           38   ~1%    {2} r8 = JOIN r7 WITH py_scope_flow_021#join_rhs ON FIRST 2 OUTPUT Rhs.2, Lhs.2
           38   ~0%    {2} r9 = JOIN r8 WITH Module#68efc075::Module::getPackageName#0#dispred#ff ON FIRST 1 OUTPUT Lhs.1, Rhs.1
          394   ~2%    {2} r10 = JOIN r9 WITH Essa#24e22a14::EssaVariable::getSourceVariable#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
          394   ~0%    {3} r11 = JOIN r10 WITH DataFlowPublic#c4b6ce7e::EssaNode#ff_10#join_rhs ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Rhs.1

          394   ~0%    {5} r12 = JOIN r11 WITH Essa#24e22a14::EssaVariable::getName#0#dispred#ff ON FIRST 1 OUTPUT _, Lhs.2, Lhs.1, Rhs.1, _
          394   ~0%    {2} r13 = REWRITE r12 WITH Tmp.0 := ".", Tmp.4 := "", Out.0 := (In.2 ++ Tmp.0 ++ In.3 ++ Tmp.4) KEEPING 2

          394   ~0%    {5} r14 = JOIN r11 WITH Essa#24e22a14::EssaVariable::getName#0#dispred#ff ON FIRST 1 OUTPUT _, Lhs.2, Lhs.1, Rhs.1, _
          394   ~1%    {2} r15 = REWRITE r14 WITH Tmp.0 := ".", Tmp.4 := ".__init__", Out.0 := (In.2 ++ Tmp.0 ++ In.3 ++ Tmp.4) KEEPING 2

          788   ~3%    {2} r16 = r13 UNION r15
          401   ~2%    {2} r17 = JOIN r16 WITH Module#68efc075::isPreferredModuleForName#2#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
          394   ~1%    {2} r18 = JOIN r17 WITH Module#68efc075::Module::getFile#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Lhs.1, Rhs.1

        26339   ~1%    {2} r19 = r5 UNION r18
                       return r19
```

## Now

```
Evaluated recursive predicate ImportResolution#f829f0f0::ImportResolution::getImmediateModuleReference#1#ff#reorder_1_0@409a0xhe in 8ms on iteration 1 (delta size: 26339).
Evaluated relational algebra for predicate ImportResolution#f829f0f0::ImportResolution::getImmediateModuleReference#1#ff#reorder_1_0@409a0xhe on iteration 1 running pipeline base with tuple counts:
         3033   ~0%    {2} r1 = JOIN Module#68efc075::Module::getFile#0#dispred#ff_10#join_rhs WITH Module#68efc075::isPreferredModuleForName#2#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1

         3033   ~0%    {4} r2 = JOIN Module#68efc075::Module::getFile#0#dispred#ff_10#join_rhs WITH Module#68efc075::isPreferredModuleForName#2#ff ON FIRST 1 OUTPUT Lhs.1, _, Rhs.1, _
                       {2} r3 = REWRITE r2 WITH Tmp.1 := "", Tmp.3 := ".__init__", Out.1 := InverseAppend(Tmp.1,Tmp.3,In.2) KEEPING 2
          688   ~0%    {2} r4 = SCAN r3 OUTPUT In.1, In.0

         3721   ~0%    {2} r5 = r1 UNION r4
        25945   ~2%    {2} r6 = JOIN r5 WITH ImportResolution#f829f0f0::ImportResolution::getReferenceToModuleName#1#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1

           38   ~4%    {3} r7 = SCAN SsaDefinitions#9197156e::SsaSource::init_module_submodule_defn#2#ff OUTPUT In.1, _, In.0
           38   ~1%    {3} r8 = REWRITE r7 WITH Out.1 := -1
           38   ~1%    {2} r9 = JOIN r8 WITH py_scope_flow_021#join_rhs ON FIRST 2 OUTPUT Rhs.2, Lhs.2
           38   ~0%    {2} r10 = JOIN r9 WITH Module#68efc075::Module::getPackageName#0#dispred#ff ON FIRST 1 OUTPUT Lhs.1, Rhs.1
          394   ~2%    {2} r11 = JOIN r10 WITH Essa#24e22a14::EssaVariable::getSourceVariable#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
          394   ~0%    {3} r12 = JOIN r11 WITH DataFlowPublic#c4b6ce7e::EssaNode#ff_10#join_rhs ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Rhs.1

          394   ~2%    {4} r13 = JOIN r12 WITH Essa#24e22a14::EssaVariable::getName#0#dispred#ff ON FIRST 1 OUTPUT _, Lhs.2, Lhs.1, Rhs.1
          394   ~0%    {2} r14 = REWRITE r13 WITH Tmp.0 := ".", Out.0 := (In.2 ++ Tmp.0 ++ In.3) KEEPING 2

          394   ~0%    {5} r15 = JOIN r12 WITH Essa#24e22a14::EssaVariable::getName#0#dispred#ff ON FIRST 1 OUTPUT _, Lhs.2, Lhs.1, Rhs.1, _
          394   ~5%    {2} r16 = REWRITE r15 WITH Tmp.0 := ".", Tmp.0 := (In.2 ++ Tmp.0 ++ In.3), Tmp.4 := ".__init__", Out.0 := (Tmp.0 ++ Tmp.4) KEEPING 2

          788   ~0%    {2} r17 = r14 UNION r16
          401   ~1%    {2} r18 = JOIN r17 WITH Module#68efc075::isPreferredModuleForName#2#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
          394   ~1%    {2} r19 = JOIN r18 WITH Module#68efc075::Module::getFile#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Lhs.1, Rhs.1

        26339   ~0%    {2} r20 = r6 UNION r19
                       return r20
```