### PR TITLE
Java: Split the different layers of virtual dispatch into separate cached stages.

### DIFF
--- a/java/ql/lib/semmle/code/java/dispatch/VirtualDispatch.qll
+++ b/java/ql/lib/semmle/code/java/dispatch/VirtualDispatch.qll
@@ -48,7 +48,6 @@ class VirtCalledSrcMethod extends SrcMethod {
   }
 }
 
-cached
 private module Dispatch {
   /** Gets a viable implementation of the method called in the given method access. */
   cached


### PR DESCRIPTION
As the title says this splits the different layers of virtual dispatch into separate stages. Having them in a single stage has been a source of annoyance when editing anything in between as everything kept being recomputed.