### PR TITLE
Go: Two fixes to upper bound checks in "incorrect integer conversion" query

### DIFF
--- a/go/ql/lib/semmle/go/security/IncorrectIntegerConversionLib.qll
+++ b/go/ql/lib/semmle/go/security/IncorrectIntegerConversionLib.qll
@@ -3,10 +3,11 @@ import go
 /** The constant `math.MaxInt` or the constant `math.MaxUint`. */
 abstract private class MaxIntOrMaxUint extends DeclaredConstant {
   /**
-   * Gets the integer `x` such that `2.pow(x) - 1` is the value of this
-   * constant when the architecture has bit size `architectureBitSize`.
+   * Gets the (binary) order of magnitude when the architecture has bit size
+   * `architectureBitSize`, which is defined to be the integer `x` such that
+   * `2.pow(x) - 1` is the value of this constant.
    */
-  abstract int getX(int architectureBitSize);
+  abstract int getOrder(int architectureBitSize);
 
   /**
    * Holds if the value of this constant given `architectureBitSize` minus
@@ -15,7 +16,7 @@ abstract private class MaxIntOrMaxUint extends DeclaredConstant {
   predicate isBoundFor(int b, int architectureBitSize, float strictnessOffset) {
     // 2.pow(x) - 1 - strictnessOffset <= 2.pow(b) - 1
     exists(int x |
-      x = this.getX(architectureBitSize) and
+      x = this.getOrder(architectureBitSize) and
       b = validBitSize() and
       (
         strictnessOffset = 0 and x <= b
@@ -30,7 +31,7 @@ abstract private class MaxIntOrMaxUint extends DeclaredConstant {
 private class MaxInt extends MaxIntOrMaxUint {
   MaxInt() { this.hasQualifiedName("math", "MaxInt") }
 
-  override int getX(int architectureBitSize) {
+  override int getOrder(int architectureBitSize) {
     architectureBitSize = [32, 64] and result = architectureBitSize - 1
   }
 }
@@ -39,7 +40,7 @@ private class MaxInt extends MaxIntOrMaxUint {
 private class MaxUint extends MaxIntOrMaxUint {
   MaxUint() { this.hasQualifiedName("math", "MaxUint") }
 
-  override int getX(int architectureBitSize) {
+  override int getOrder(int architectureBitSize) {
     architectureBitSize = [32, 64] and result = architectureBitSize
   }
 }

--- a/go/ql/lib/semmle/go/security/IncorrectIntegerConversionLib.qll
+++ b/go/ql/lib/semmle/go/security/IncorrectIntegerConversionLib.qll
@@ -235,7 +235,7 @@ private class MaxValueState extends TMaxValueState {
   predicate architectureBitSizeUnknown() { this.architectureBitSize().isUnknown() }
 
   /**
-   * Gets the bitsize we should use for a sink.
+   * Gets the bitsize we should use for a sink of type `uint`.
    *
    * If the architecture bit size is known, then we should use that. Otherwise,
    * we should use 32 bits, because that will find results that only exist on
@@ -344,7 +344,7 @@ class UpperBoundCheckGuard extends DataFlow::RelationalComparisonNode {
  *   _ = uint16(parsed)
  * }
  * ```
- * `parsed < math.MaxInt16` is an `UpperBoundCheckGuard` and `uint16(parsed)`
+ * `parsed <= math.MaxInt16` is an `UpperBoundCheckGuard` and `uint16(parsed)`
  * is an `UpperBoundCheck` that would be a barrier for flow states with bit
  * size greater than 15 and would transform them to a flow state with bit size
  * 15 and the same architecture bit size.

--- a/go/ql/lib/semmle/go/security/IncorrectIntegerConversionLib.qll
+++ b/go/ql/lib/semmle/go/security/IncorrectIntegerConversionLib.qll
@@ -5,7 +5,7 @@ import go
  * is true, unsigned otherwise) with `bitSize` bits.
  */
 float getMaxIntValue(int bitSize, boolean isSigned) {
-  bitSize in [8, 16, 32] and
+  bitSize in [8, 16, 32, 64] and
   (
     isSigned = true and result = 2.pow(bitSize - 1) - 1
     or

--- a/go/ql/src/change-notes/2023-10-27-incorrect-integer-conversion-guards.md
+++ b/go/ql/src/change-notes/2023-10-27-incorrect-integer-conversion-guards.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The query `go/incorrect-integer-conversion` now correctly recognizes more guards of the form `if val <= x` to protect a conversion `uintX(val)`.

--- a/go/ql/test/query-tests/Security/CWE-681/IncorrectIntegerConversion.go
+++ b/go/ql/test/query-tests/Security/CWE-681/IncorrectIntegerConversion.go
@@ -349,6 +349,15 @@ func testBoundsChecking(input string) {
 	}
 }
 
+func testBoundsChecking2(input string) error {
+	version, err := strconv.ParseUint(input, 10, 0)
+	if err != nil || version > math.MaxInt {
+		return fmt.Errorf("checksum has invalid version: %w", err)
+	}
+	_ = int(version)
+	return nil
+}
+
 func testRightShifted(input string) {
 	{
 		parsed, err := strconv.ParseInt(input, 10, 32)

--- a/go/ql/test/query-tests/Security/CWE-681/IncorrectIntegerConversion.go
+++ b/go/ql/test/query-tests/Security/CWE-681/IncorrectIntegerConversion.go
@@ -333,8 +333,11 @@ func testBoundsChecking(input string) {
 			_ = uint16(parsed)
 			_ = int16(parsed) // $ hasValueFlow="type conversion"
 		}
-		if parsed < 5 {
-			_ = uint16(parsed)
+		if parsed <= 255 {
+			_ = uint8(parsed)
+		}
+		if parsed <= 256 {
+			_ = uint8(parsed) // $ hasValueFlow="type conversion"
 		}
 		if err == nil && 1 == 1 && parsed < math.MaxInt8 {
 			_ = int8(parsed)


### PR DESCRIPTION
Two bugs fixed, with corresponding test cases, plus some miscellaneous refactoring to make some of the code a bit nicer to read and to try to avoid doing integer arithmetic with floats (because CodeQL integers are signed 32-bit integers) above the level where that is precise.