### PR TITLE
Kotlin: Make the enum test more precise

### DIFF
--- a/java/ql/test/kotlin/library-tests/enum/test.expected
+++ b/java/ql/test/kotlin/library-tests/enum/test.expected
@@ -1,36 +1,16 @@
 #select
-| addAll |
-| addRange |
-| allOf |
-| asIterator |
-| clone |
-| compareTo |
-| complement |
-| complementOf |
-| copyOf |
-| describeConstable |
-| equals |
-| finalize |
-| forEach |
-| getDeclaringClass |
-| hasMoreElements |
-| hashCode |
-| name |
-| nextElement |
-| noneOf |
-| of |
-| ordinal |
-| parallelStream |
-| range |
-| resolveConstantDesc |
-| spliterator |
-| stream |
-| toArray |
-| toString |
-| typeCheck |
-| usesEnum |
-| valueOf |
-| writeReplace |
+| Enum<E> | clone |
+| Enum<E> | compareTo |
+| Enum<E> | describeConstable |
+| Enum<E> | equals |
+| Enum<E> | finalize |
+| Enum<E> | getDeclaringClass |
+| Enum<E> | hashCode |
+| Enum<E> | name |
+| Enum<E> | ordinal |
+| Enum<E> | toString |
+| Enum<E> | valueOf |
+| EnumUserKt | usesEnum |
 enumConstants
 | enumUser.kt:3:16:3:17 | A |
 | enumUser.kt:3:19:3:20 | B |

--- a/java/ql/test/kotlin/library-tests/enum/test.expected
+++ b/java/ql/test/kotlin/library-tests/enum/test.expected
@@ -1,16 +1,48 @@
 #select
-| Enum<E> | clone |
-| Enum<E> | compareTo |
-| Enum<E> | describeConstable |
-| Enum<E> | equals |
-| Enum<E> | finalize |
-| Enum<E> | getDeclaringClass |
-| Enum<E> | hashCode |
-| Enum<E> | name |
-| Enum<E> | ordinal |
-| Enum<E> | toString |
-| Enum<E> | valueOf |
-| EnumUserKt | usesEnum |
+| EnumUserKt | EnumUserKt | usesEnum |
+| java.lang.Enum | Enum | clone |
+| java.lang.Enum | Enum | compareTo |
+| java.lang.Enum | Enum | describeConstable |
+| java.lang.Enum | Enum | equals |
+| java.lang.Enum | Enum | finalize |
+| java.lang.Enum | Enum | getDeclaringClass |
+| java.lang.Enum | Enum | hashCode |
+| java.lang.Enum | Enum | name |
+| java.lang.Enum | Enum | ordinal |
+| java.lang.Enum | Enum | toString |
+| java.lang.Enum | Enum | valueOf |
+| java.lang.Enum<?> | Enum<?> | clone |
+| java.lang.Enum<?> | Enum<?> | compareTo |
+| java.lang.Enum<?> | Enum<?> | describeConstable |
+| java.lang.Enum<?> | Enum<?> | equals |
+| java.lang.Enum<?> | Enum<?> | finalize |
+| java.lang.Enum<?> | Enum<?> | getDeclaringClass |
+| java.lang.Enum<?> | Enum<?> | hashCode |
+| java.lang.Enum<?> | Enum<?> | name |
+| java.lang.Enum<?> | Enum<?> | ordinal |
+| java.lang.Enum<?> | Enum<?> | toString |
+| java.lang.Enum<?> | Enum<?> | valueOf |
+| java.lang.Enum<E> | Enum<E> | clone |
+| java.lang.Enum<E> | Enum<E> | compareTo |
+| java.lang.Enum<E> | Enum<E> | describeConstable |
+| java.lang.Enum<E> | Enum<E> | equals |
+| java.lang.Enum<E> | Enum<E> | finalize |
+| java.lang.Enum<E> | Enum<E> | getDeclaringClass |
+| java.lang.Enum<E> | Enum<E> | hashCode |
+| java.lang.Enum<E> | Enum<E> | name |
+| java.lang.Enum<E> | Enum<E> | ordinal |
+| java.lang.Enum<E> | Enum<E> | toString |
+| java.lang.Enum<E> | Enum<E> | valueOf |
+| kotlin.Enum | Enum | clone |
+| kotlin.Enum | Enum | compareTo |
+| kotlin.Enum | Enum | describeConstable |
+| kotlin.Enum | Enum | equals |
+| kotlin.Enum | Enum | finalize |
+| kotlin.Enum | Enum | getDeclaringClass |
+| kotlin.Enum | Enum | hashCode |
+| kotlin.Enum | Enum | name |
+| kotlin.Enum | Enum | ordinal |
+| kotlin.Enum | Enum | toString |
 enumConstants
 | enumUser.kt:3:16:3:17 | A |
 | enumUser.kt:3:19:3:20 | B |

--- a/java/ql/test/kotlin/library-tests/enum/test.ql
+++ b/java/ql/test/kotlin/library-tests/enum/test.ql
@@ -1,7 +1,9 @@
 import java
 
-from Method m
-where m.getDeclaringType().getName().matches("Enum%")
-select m.getName()
+from Method m, Type t
+where
+  t = m.getDeclaringType() and
+  t.getName() = ["Enum<E>", "EnumUserKt"]
+select t.getName(), m.getName()
 
 query predicate enumConstants(EnumConstant ec) { ec.fromSource() }

--- a/java/ql/test/kotlin/library-tests/enum/test.ql
+++ b/java/ql/test/kotlin/library-tests/enum/test.ql
@@ -1,9 +1,9 @@
 import java
 
-from Method m, Type t
+from Method m, RefType t
 where
   t = m.getDeclaringType() and
-  t.getName() = ["Enum<E>", "EnumUserKt"]
-select t.getName(), m.getName()
+  t.getName() = ["Enum", "Enum<?>", "Enum<E>", "EnumUserKt"]
+select t.getQualifiedName(), t.getName(), m.getName()
 
 query predicate enumConstants(EnumConstant ec) { ec.fromSource() }


### PR DESCRIPTION
In Kotlin 2 mode, there are more library classes matching `Enum%`, so the output was spuriously different.