### PR TITLE
JS: lower the severity of js/identity-replacement to medium

### DIFF
--- a/javascript/ql/src/RegExp/IdentityReplacement.ql
+++ b/javascript/ql/src/RegExp/IdentityReplacement.ql
@@ -3,7 +3,7 @@
  * @description Replacing a substring with itself has no effect and may indicate a mistake.
  * @kind problem
  * @problem.severity warning
- * @security-severity 7.8
+ * @security-severity 5.0
  * @id js/identity-replacement
  * @precision very-high
  * @tags correctness


### PR DESCRIPTION
A customer pointed out that it didn't make much sense to have this query marked as "high severity", and I agree.  
(CodeQL devs: See backref for more context). 

I'm lowering it to a medium of 5.0 for now.  