### PR TITLE
Python: module for import time flow

### DIFF
--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -445,13 +445,11 @@ module StepRelationTransformations {
    */
   module IncludePostUpdateFlow<stepSig/2 rawStep> {
     predicate step(Node nodeFrom, Node nodeTo) {
-      // If a raw step can be taken out of a node `node`, a step can be taken
-      // both out of `node` and any post-update node of `node`.
-      exists(Node node | rawStep(node, nodeTo) |
-        nodeFrom = node
-        or
-        nodeFrom.(PostUpdateNode).getPreUpdateNode() = node
-      )
+      // We either have a raw step from `nodeFrom`...
+      rawStep(nodeFrom, nodeTo)
+      or
+      // ...or we have a raw step from a pre-update node of `nodeFrom`
+      rawStep(nodeFrom.(PostUpdateNode).getPreUpdateNode(), nodeTo)
     }
   }
 }

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -383,7 +383,12 @@ module EssaFlow {
 //--------
 /** A module for transforming step relations. */
 module StepRelationTransformations {
-  /** A step relation */
+  /**
+   * Holds if there is a step from `nodeFrom` to `nodeTo` in
+   * the step relation to be transformed.
+   *
+   * This is the input relation to the transformations.
+   */
   signature predicate stepSig(Node nodeFrom, Node nodeTo);
 
   /**

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -389,7 +389,7 @@ module StepRelationTransformations {
   /**
    * A module to separate import-time from run-time.
    *
-   * We really have two local flow relations, on for module initialisation time (or _import time_) and one for runtime.
+   * We really have two local flow relations, one for module initialisation time (or _import time_) and one for runtime.
    * Consider a read from a global variable `x = foo`. At import time there should be a local flow step from `foo` to `x`,
    * while at runtime there should be a jump step from the module variable corresponding to `foo` to `x`.
    *
@@ -404,7 +404,7 @@ module StepRelationTransformations {
    * with the heuristic that global variables act according to import time rules at top-level program points and according
    * to runtime rules everywhere else. This will forego some import time local flow but otherwise be consistent.
    */
-  module Separate<stepSig/2 rawStep> {
+  module PhaseDependentFlow<stepSig/2 rawStep> {
     /**
      * Holds if `node` is found at the top level of a module.
      */
@@ -476,7 +476,7 @@ predicate simpleLocalFlowStep(Node nodeFrom, Node nodeTo) {
  * or at runtime when callables in the module are called.
  */
 predicate simpleLocalFlowStepForTypetracking(Node nodeFrom, Node nodeTo) {
-  IncludePostUpdateFlow<Separate<EssaFlow::essaFlowStep/2>::step/2>::step(nodeFrom, nodeTo)
+  IncludePostUpdateFlow<PhaseDependentFlow<EssaFlow::essaFlowStep/2>::step/2>::step(nodeFrom, nodeTo)
 }
 
 private predicate summaryLocalStep(Node nodeFrom, Node nodeTo) {
@@ -485,7 +485,7 @@ private predicate summaryLocalStep(Node nodeFrom, Node nodeTo) {
 }
 
 predicate summaryFlowSteps(Node nodeFrom, Node nodeTo) {
-  IncludePostUpdateFlow<Separate<summaryLocalStep/2>::step/2>::step(nodeFrom, nodeTo)
+  IncludePostUpdateFlow<PhaseDependentFlow<summaryLocalStep/2>::step/2>::step(nodeFrom, nodeTo)
 }
 
 /** `ModuleVariable`s are accessed via jump steps at runtime. */

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -393,12 +393,12 @@ module StepRelationTransformations {
    * Consider a read from a global variable `x = foo`. At import time there should be a local flow step from `foo` to `x`,
    * while at runtime there should be a jump step from the module variable corresponding to `foo` to `x`.
    *
-   * Similarly for, a write `foo = y`, at import time, there is a local flow step from `y` to `foo` while at runtime there
+   * Similarly, for a write `foo = y`, at import time, there is a local flow step from `y` to `foo` while at runtime there
    * is a jump step from `y` to the module variable corresponding to `foo`.
    *
    * We need a way of distinguishing if we are looking at import time or runtime. We have the following helpful facts:
    * - All top-level executable statements are import time (and import time only)
-   * - All -non-top-level code may be executed at runtime (but could also be executed at import time)
+   * - All non-top-level code may be executed at runtime (but could also be executed at import time)
    *
    * We could write an analysis to determine which functions are called at import time, but until we have that, we will go
    * with the heuristic that global variables act according to import time rules at top-level program points and according
@@ -409,7 +409,7 @@ module StepRelationTransformations {
      * Holds if `node` is found at the top level of a module.
      */
     pragma[inline]
-    predicate isTopLevel(Node node) { node.getScope() instanceof Module }
+    private predicate isTopLevel(Node node) { node.getScope() instanceof Module }
 
     /** Holds if a step can be taken from `nodeFrom` to `nodeTo` at import time. */
     predicate importTimeStep(Node nodeFrom, Node nodeTo) {

--- a/python/ql/test/experimental/dataflow/module-initialization/localFlow.ql
+++ b/python/ql/test/experimental/dataflow/module-initialization/localFlow.ql
@@ -12,7 +12,7 @@ module ImportTimeLocalFlowTest implements FlowTestSig {
     // results are displayed next to `nodeTo`, so we need a line to write on
     nodeTo.getLocation().getStartLine() > 0 and
     nodeTo.asVar() instanceof GlobalSsaVariable and
-    DP::Separate<DP::EssaFlow::essaFlowStep/2>::importTimeStep(nodeFrom, nodeTo)
+    DP::PhaseDependentFlow<DP::EssaFlow::essaFlowStep/2>::importTimeStep(nodeFrom, nodeTo)
   }
 }
 

--- a/python/ql/test/experimental/dataflow/module-initialization/localFlow.ql
+++ b/python/ql/test/experimental/dataflow/module-initialization/localFlow.ql
@@ -12,7 +12,7 @@ module ImportTimeLocalFlowTest implements FlowTestSig {
     // results are displayed next to `nodeTo`, so we need a line to write on
     nodeTo.getLocation().getStartLine() > 0 and
     nodeTo.asVar() instanceof GlobalSsaVariable and
-    DP::importTimeLocalFlowStep(nodeFrom, nodeTo)
+    DP::Separate<DP::EssaFlow::essaFlowStep/2>::importTimeStep(nodeFrom, nodeTo)
   }
 }
 


### PR DESCRIPTION
The logic for separating local flow into _import time_ and _runtime_ was duplicated a few times.
Create a module for it instead, and add a good qldoc.

The logic for adding flow out of post-update-nodes
was also duplicated, so I added a module for that also.

The two modules are now only used together (except in one test file).
I did not fuse them, though, as I think they may not be used
together in the case of use-use-flow.