### PR TITLE
CPP: Add dataflow FP with output arguments

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
@@ -41,6 +41,9 @@ postWithInFlow
 | example.c:26:9:26:9 | x [post update] | PostUpdateNode should not be the target of local flow. |
 | example.c:26:19:26:24 | coords [inner post update] | PostUpdateNode should not be the target of local flow. |
 | example.c:28:23:28:25 | pos [inner post update] | PostUpdateNode should not be the target of local flow. |
+| flowOut.cpp:5:5:5:12 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
+| flowOut.cpp:5:6:5:12 | toTaint [inner post update] | PostUpdateNode should not be the target of local flow. |
+| flowOut.cpp:18:17:18:17 | x [inner post update] | PostUpdateNode should not be the target of local flow. |
 | globals.cpp:13:5:13:19 | flowTestGlobal1 [post update] | PostUpdateNode should not be the target of local flow. |
 | globals.cpp:23:5:23:19 | flowTestGlobal2 [post update] | PostUpdateNode should not be the target of local flow. |
 | lambdas.cpp:23:3:23:14 | v [post update] | PostUpdateNode should not be the target of local flow. |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/flowOut.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/flowOut.cpp
@@ -1,0 +1,20 @@
+int source();
+void sink(int);
+
+void source_ref(int *toTaint) { // $ ir-def=*toTaint ast-def=toTaint
+    *toTaint = source();
+}
+
+
+
+void modify_copy(int* ptr) { // $ ast-def=ptr
+  int deref = *ptr;
+  int* other = &deref;
+  source_ref(other);
+}
+
+void test_output() {
+   int x = 0;
+   modify_copy(&x);
+   sink(x); // $ ir
+}

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/flowOut.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/flowOut.cpp
@@ -16,5 +16,5 @@ void modify_copy(int* ptr) { // $ ast-def=ptr
 void test_output() {
    int x = 0;
    modify_copy(&x);
-   sink(x); // $ ir
+   sink(x); // $ SPURIOUS: ir
 }


### PR DESCRIPTION
This demonstrates a false dataflow edge that shouldn't exist.