### PR TITLE
Swift: rework resource dir

### DIFF
--- a/swift/extractor/main.cpp
+++ b/swift/extractor/main.cpp
@@ -177,9 +177,7 @@ codeql::TrapDomain invocationTrapDomain(codeql::SwiftExtractorState& state) {
   return std::move(maybeDomain.value());
 }
 
-codeql::SwiftExtractorConfiguration configure(int argc,
-                                              char** argv,
-                                              const std::string& resourceDir) {
+codeql::SwiftExtractorConfiguration configure(int argc, char** argv) {
   codeql::SwiftExtractorConfiguration configuration{};
   configuration.trapDir = getenv_or("CODEQL_EXTRACTOR_SWIFT_TRAP_DIR", "extractor-out/trap/swift");
   configuration.sourceArchiveDir =
@@ -187,13 +185,6 @@ codeql::SwiftExtractorConfiguration configure(int argc,
   configuration.scratchDir =
       getenv_or("CODEQL_EXTRACTOR_SWIFT_SCRATCH_DIR", "extractor-out/working");
   configuration.frontendOptions.assign(argv + 1, argv + argc);
-  // TODO: Should be moved to the tracer config
-  for (int i = 0; i < argc - 1; i++) {
-    if (std::string("-resource-dir") == configuration.frontendOptions[i]) {
-      configuration.frontendOptions[i + 1] = resourceDir.c_str();
-      break;
-    }
-  }
   return configuration;
 }
 
@@ -226,9 +217,7 @@ int main(int argc, char** argv, char** envp) {
   INITIALIZE_LLVM();
   initializeSwiftModules();
 
-  std::string resourceDir = getenv_or("CODEQL_EXTRACTOR_SWIFT_ROOT", ".") + "/resource-dir/" +
-                            getenv_or("CODEQL_PLATFORM", ".");
-  const auto configuration = configure(argc, argv, resourceDir);
+  const auto configuration = configure(argc, argv);
   LOG_INFO("calling extractor with arguments \"{}\"", argDump(argc, argv));
   LOG_DEBUG("environment:\n{}\n", envDump(envp));
 

--- a/swift/third_party/BUILD.swift-llvm-support.bazel
+++ b/swift/third_party/BUILD.swift-llvm-support.bazel
@@ -41,12 +41,3 @@ pkg_files(
     strip_prefix = strip_prefix.from_pkg(),
     visibility = ["//visibility:public"],
 )
-
-pkg_files(
-    name = "swift-resource-dir",
-    srcs = glob([
-        "toolchain/lib/swift/**/*",
-    ]),
-    strip_prefix = "toolchain/lib/swift",
-    visibility = ["//visibility:public"],
-)

--- a/swift/third_party/BUILD.swift-toolchain-linux.bazel
+++ b/swift/third_party/BUILD.swift-toolchain-linux.bazel
@@ -1,0 +1,49 @@
+load("@rules_pkg//:mappings.bzl", "pkg_filegroup", "pkg_files")
+
+_strip_prefix = "usr/lib/swift"
+
+_pm_interfaces_glob = "usr/lib/swift/pm/**/*.swiftinterface"
+
+pkg_files(
+    name = "resource-dir-original",
+    srcs = glob(
+        ["usr/lib/swift/**/*"],
+        exclude = [_pm_interfaces_glob],
+    ),
+    strip_prefix = _strip_prefix,
+)
+
+# pre-compile package manager interface files as compiling them hits a mysterious crash during SIL
+_pm_interface_files = [
+    (
+        f[len(_strip_prefix) + 1:f.rindex("/")],
+        f[f.rindex("/") + 1:],
+        f[f.rindex("/") + 1:f.rindex(".")] + ".swiftmodule",
+    )
+    for f in glob([_pm_interfaces_glob])
+]
+
+[
+    [
+        genrule(
+            name = "compile-%s" % interface,
+            srcs = ["%s/%s/%s" % (_strip_prefix, dir, interface)],
+            outs = [module],
+            cmd = "$(location usr/bin/swift-frontend) -compile-module-from-interface $< -o $@ -I $$(dirname $<)",
+            local = True,
+            tools = ["usr/bin/swift-frontend"],
+        ),
+        pkg_files(
+            name = "pkg-%s" % module,
+            srcs = [":compile-%s" % interface],
+            prefix = dir,
+        ),
+    ]
+    for dir, interface, module in _pm_interface_files
+]
+
+pkg_filegroup(
+    name = "resource-dir",
+    srcs = [":resource-dir-original"] + [":pkg-%s" % module for _, _, module in _pm_interface_files],
+    visibility = ["//visibility:public"],
+)

--- a/swift/third_party/BUILD.swift-toolchain-macos.bazel
+++ b/swift/third_party/BUILD.swift-toolchain-macos.bazel
@@ -1,0 +1,12 @@
+load("@rules_pkg//:mappings.bzl", "pkg_files")
+
+_strip_prefix = "usr/lib/swift"
+
+pkg_files(
+    name = "resource-dir",
+    srcs = glob(
+        ["usr/lib/swift/**/*"],
+    ),
+    strip_prefix = _strip_prefix,
+    visibility = ["//visibility:public"],
+)

--- a/swift/third_party/load.bzl
+++ b/swift/third_party/load.bzl
@@ -16,6 +16,92 @@ _swift_arch_map = {
     "macOS-X64": "darwin_x86_64",
 }
 
+_swift_version = _swift_prebuilt_version.rpartition(".")[0]
+
+_toolchain_info = {
+    "linux": struct(
+        platform = "ubuntu2204",
+        suffix = "ubuntu22.04",
+        extension = "tar.gz",
+        sha = "bca015e9d727ca39385d7e5b5399f46302d54a02218d40d1c3063662ffc6b42f",
+    ),
+    "macos": struct(
+        platform = "xcode",
+        suffix = "osx",
+        extension = "pkg",
+        sha = "3cf7a4b2f3efcfcb4fef42b6588a7b1c54f7b0f2d0a479f41c3e1620b045f48e",
+    ),
+}
+
+def _get_toolchain_url(info):
+    return "https://download.swift.org/%s/%s/%s/%s-%s.%s" % (
+        _swift_version.lower(),
+        info.platform,
+        _swift_version,
+        _swift_version,
+        info.suffix,
+        info.extension,
+    )
+
+def _toolchains(workspace_name):
+    rules = {
+        "tar.gz": http_archive,
+        "pkg": _pkg_archive,
+    }
+    for arch, info in _toolchain_info.items():
+        rule = rules[info.extension]
+        rule(
+            name = "swift_toolchain_%s" % arch,
+            url = _get_toolchain_url(info),
+            sha256 = info.sha,
+            build_file = _build(workspace_name, "swift-toolchain-%s" % arch),
+            strip_prefix = "%s-%s" % (_swift_version, info.suffix),
+        )
+
+def _run(repository_ctx, message, cmd, working_directory = "."):
+    repository_ctx.report_progress(message)
+    res = repository_ctx.execute(
+        ["bash", "-c", cmd],
+        working_directory = working_directory,
+    )
+    if res.return_code != 0:
+        fail(message)
+
+def _pkg_archive_impl(repository_ctx):
+    archive = "file.pkg"
+    url = repository_ctx.attr.url
+    dir = "%s-package.pkg" % repository_ctx.attr.strip_prefix
+    repository_ctx.report_progress("downloading %s" % url)
+    res = repository_ctx.download(
+        url,
+        output = archive,
+        sha256 = repository_ctx.attr.sha256,
+    )
+    if not repository_ctx.attr.sha256:
+        print("please set sha256 = %s" % repr(res.sha256))
+    _run(repository_ctx, "extracting %s" % dir, "xar -xf %s" % archive)
+    repository_ctx.delete(archive)
+    _run(
+        repository_ctx,
+        "extracting Payload from %s" % dir,
+        "cat %s/Payload | gunzip -dc | cpio -i" % dir,
+    )
+    repository_ctx.delete(dir)
+    repository_ctx.symlink(repository_ctx.attr.build_file, "BUILD")
+    repository_ctx.file("WORKSPACE")
+
+_pkg_archive = repository_rule(
+    implementation = _pkg_archive_impl,
+    attrs = {
+        "url": attr.string(mandatory = True),
+        "sha256": attr.string(),
+        "strip_prefix": attr.string(),
+        "build_file": attr.label(mandatory = True),
+    },
+)
+
+# TODO apply the same mechanism to the macOS toolchain (needs some work as the toolchain is a pkg archive
+
 def _github_archive(*, name, repository, commit, build_file = None, sha256 = None):
     github_name = repository[repository.index("/") + 1:]
     maybe(
@@ -52,6 +138,8 @@ def load_dependencies(workspace_name):
                 )
             ],
         )
+
+    _toolchains(workspace_name)
 
     _github_archive(
         name = "picosha2",

--- a/swift/third_party/load.bzl
+++ b/swift/third_party/load.bzl
@@ -20,10 +20,10 @@ _swift_version = _swift_prebuilt_version.rpartition(".")[0]
 
 _toolchain_info = {
     "linux": struct(
-        platform = "ubuntu2204",
-        suffix = "ubuntu22.04",
+        platform = "ubuntu2004",
+        suffix = "ubuntu20.04",
         extension = "tar.gz",
-        sha = "bca015e9d727ca39385d7e5b5399f46302d54a02218d40d1c3063662ffc6b42f",
+        sha = "5fca0c384a1cdf9b3d4f71bcab5ff27aaee25f4bc09a134b16fa7fcf34e34c45",
     ),
     "macos": struct(
         platform = "xcode",
@@ -78,7 +78,8 @@ def _pkg_archive_impl(repository_ctx):
         sha256 = repository_ctx.attr.sha256,
     )
     if not repository_ctx.attr.sha256:
-        print("please set sha256 = %s" % repr(res.sha256))
+        print("Rule '%s' indicated that a canonical reproducible form " % repository_ctx.name +
+              "can be obtained by modifying arguments sha256 = \"%s\"" % res.sha256)
     _run(repository_ctx, "extracting %s" % dir, "xar -xf %s" % archive)
     repository_ctx.delete(archive)
     _run(
@@ -99,8 +100,6 @@ _pkg_archive = repository_rule(
         "build_file": attr.label(mandatory = True),
     },
 )
-
-# TODO apply the same mechanism to the macOS toolchain (needs some work as the toolchain is a pkg archive
 
 def _github_archive(*, name, repository, commit, build_file = None, sha256 = None):
     github_name = repository[repository.index("/") + 1:]

--- a/swift/third_party/load.bzl
+++ b/swift/third_party/load.bzl
@@ -23,13 +23,13 @@ _toolchain_info = {
         platform = "ubuntu2004",
         suffix = "ubuntu20.04",
         extension = "tar.gz",
-        sha = "5fca0c384a1cdf9b3d4f71bcab5ff27aaee25f4bc09a134b16fa7fcf34e34c45",
+        sha = "dd4b04c7f95c4ada4a2aacb66864b1ed20358313aaa4c880dc3974bf1eefa275",
     ),
     "macos": struct(
         platform = "xcode",
         suffix = "osx",
         extension = "pkg",
-        sha = "3cf7a4b2f3efcfcb4fef42b6588a7b1c54f7b0f2d0a479f41c3e1620b045f48e",
+        sha = "417d46f73b2e6b5da82ebbc8a5f4979f7187691fd42119157ba56d5a8bc89eda",
     ),
 }
 

--- a/swift/third_party/swift-llvm-support/BUILD.bazel
+++ b/swift/third_party/swift-llvm-support/BUILD.bazel
@@ -1,21 +1,25 @@
 package(default_visibility = ["//swift:__subpackages__"])
 
-#TODO we will be introducing universal binaries at a later stage, when we have both architectures prebuilt for macOS
-# for the moment, we make arm build an x86_64 binary
-_arch_override = {
-    "darwin_arm64": "darwin_x86_64",
-}
+alias(
+    name = "swift-llvm-support",
+    actual = select({
+        "@bazel_tools//src/conditions:linux": "@swift_prebuilt_linux//:swift-llvm-support",
+        "@bazel_tools//src/conditions:darwin": "@swift_prebuilt_darwin_x86_64//:swift-llvm-support",
+    }),
+)
 
-[
-    alias(
-        name = name,
-        actual = select({
-            "@bazel_tools//src/conditions:%s" % arch: "@swift_prebuilt_%s//:%s" % (
-                _arch_override.get(arch, arch),
-                name,
-            )
-            for arch in ("linux", "darwin_x86_64", "darwin_arm64")
-        }),
-    )
-    for name in ("swift-llvm-support", "swift-test-sdk", "swift-resource-dir")
-]
+alias(
+    name = "swift-test-sdk",
+    actual = select({
+        "@bazel_tools//src/conditions:linux": "@swift_prebuilt_linux//:swift-test-sdk",
+        "@bazel_tools//src/conditions:darwin": "@swift_prebuilt_darwin_x86_64//:swift-test-sdk",
+    }),
+)
+
+alias(
+    name = "swift-resource-dir",
+    actual = select({
+        "@bazel_tools//src/conditions:linux": "@swift_toolchain_linux//:resource-dir",
+        "@bazel_tools//src/conditions:darwin": "@swift_toolchain_macos//:resource-dir",
+    }),
+)

--- a/swift/tools/tracing-config.lua
+++ b/swift/tools/tracing-config.lua
@@ -2,27 +2,32 @@ function RegisterExtractorPack(id)
     local extractorDirectory = GetPlatformToolsDirectory()
     local relativeSwiftExtractor = extractorDirectory .. 'extractor'
     local swiftExtractor = AbsolutifyExtractorPath(id, relativeSwiftExtractor)
+    local resourceDirectory = AbsolutifyExtractorPath(id, 'resource-dir' .. PathSep .. PlatformDirectory)
 
     function indexOf(array, value)
-      for i, v in ipairs(array) do
-        if v == value then
-          return i
+        for i, v in ipairs(array) do
+            if v == value then
+                return i
+            end
         end
-      end
-      return nil
+        return nil
+    end
+
+    function startswith(text, prefix)
+        return string.find(text, prefix, 1, true) == 1
     end
 
     -- removes unsupported CLI arg including the following how_many args
     function strip_unsupported_arg(args, arg, how_many)
-      local index = indexOf(args, arg)
-      if index then
-        table.remove(args, index)
-        while (how_many > 0)
-        do
-          table.remove(args, index)
-          how_many = how_many - 1
+        local index = indexOf(args, arg)
+        if index then
+            table.remove(args, index)
+            while (how_many > 0)
+            do
+                table.remove(args, index)
+                how_many = how_many - 1
+            end
         end
-      end
     end
 
     -- removes unsupported -Xcc flag, e.g, calling strip_unsupported_xcc_arg('-foo', 2) against
@@ -43,68 +48,84 @@ function RegisterExtractorPack(id)
     end
 
     function strip_unsupported_args(args)
-      strip_unsupported_arg(args, '-emit-localized-strings', 0)
-      strip_unsupported_arg(args, '-emit-localized-strings-path', 1)
-      strip_unsupported_arg(args, '-stack-check', 0)
-      strip_unsupported_arg(args, '-experimental-skip-non-inlinable-function-bodies-without-types', 0)
-      strip_unsupported_clang_arg(args, '-ivfsstatcache', 1)
+        strip_unsupported_arg(args, '-emit-localized-strings', 0)
+        strip_unsupported_arg(args, '-emit-localized-strings-path', 1)
+        strip_unsupported_arg(args, '-stack-check', 0)
+        strip_unsupported_arg(args, '-experimental-skip-non-inlinable-function-bodies-without-types', 0)
+        strip_unsupported_clang_arg(args, '-ivfsstatcache', 1)
     end
 
     -- xcodebuild does not always specify the -resource-dir in which case the compiler falls back
-    -- to a resource-dir based on its path
-    -- here we mimic this behavior externally
-    -- without a proper -resource-dir compiler-specific headers cannot be found which leads to
-    -- broken extraction
-    function insert_resource_dir_if_needed(compilerPath, args)
+    -- to a resource-dir based on its path. We want to know what is the original resource-dir in
+    -- all cases so that we can patch it with out own
+    function find_original_resource_dir(compilerPath, args)
       local resource_dir_index = indexOf(args, '-resource-dir')
-      if resource_dir_index then
-        return
+      if resource_dir_index and args[resource_dir_index + 1] then
+        return args[resource_dir_index + 1]
       end
       -- derive -resource-dir based on the compilerPath
       -- e.g.: /usr/bin/swift-frontend -> /usr/bin/../lib/swift
-      local last_slash_index = string.find(compilerPath, "/[^/]*$")
-      local compiler_dir = string.sub(compilerPath, 1, last_slash_index)
-      local resource_dir = compiler_dir .. '../lib/swift'
-      table.insert(args, '-resource-dir')
-      table.insert(args, resource_dir)
+      local second_last_slash_index = string.find(compilerPath, "/[^/]*/[^/]*$")
+      local usr_dir = string.sub(compilerPath, 1, second_last_slash_index)
+      return usr_dir .. '/lib/swift'
+    end
+
+    -- replace or add our own resource directory
+    function replace_resource_dir(compilerPath, args)
+        local originalResourceDir = find_original_resource_dir(compilerPath, args)
+        for index, value in ipairs(args) do
+            if startswith(value, originalResourceDir) then
+                args[index] = resourceDirectory .. string.sub(value, #originalResourceDir + 1, -1)
+            end
+        end
+        if not indexOf(args, '-resource-dir') then
+            table.insert(args, '-resource-dir')
+            table.insert(args, resourceDirectory)
+        end
     end
 
     function SwiftMatcher(compilerName, compilerPath, compilerArguments, lang)
         -- Only match binaries names `swift-frontend`
-        if compilerName ~= 'swift-frontend' then return nil end
+        if compilerName ~= 'swift-frontend' then
+            return nil
+        end
         -- Skip the invocation in case it's not called in `-frontend` mode
-        if compilerArguments.argv[1] ~= '-frontend' then return nil end
+        if compilerArguments.argv[1] ~= '-frontend' then
+            return nil
+        end
 
         -- Drop the `-frontend` argument
         table.remove(compilerArguments.argv, 1)
 
         -- Skip "info" queries in case there is nothing to extract
         if compilerArguments.argv[1] == '-print-target-info' then
-          return nil
+            return nil
         end
         if compilerArguments.argv[1] == '-emit-supported-features' then
-          return nil
+            return nil
         end
 
         strip_unsupported_args(compilerArguments.argv)
-        insert_resource_dir_if_needed(compilerPath, compilerArguments.argv)
+        replace_resource_dir(compilerPath, compilerArguments.argv)
 
         return {
             trace = true,
             replace = false,
             order = ORDER_AFTER,
-            invocation = {path = swiftExtractor, arguments = compilerArguments}
+            invocation = { path = swiftExtractor, arguments = compilerArguments }
         }
     end
     return {
-      SwiftMatcher,
-      CreatePatternMatcher({'^lsregister$'}, MatchCompilerName, nil,
-                           {trace = false}),
-      CreatePatternMatcher({'^sandbox%-exec$'}, MatchCompilerName, nil,
-                           {trace = false}),
+        SwiftMatcher,
+        CreatePatternMatcher({ '^lsregister$' }, MatchCompilerName, nil,
+                { trace = false }),
+        CreatePatternMatcher({ '^sandbox%-exec$' }, MatchCompilerName, nil,
+                { trace = false }),
     }
 end
 
 -- Return a list of minimum supported versions of the configuration file format
 -- return one entry per supported major version.
-function GetCompatibleVersions() return {'1.0.0'} end
+function GetCompatibleVersions()
+    return { '1.0.0' }
+end


### PR DESCRIPTION
This fetches the resource directory directly from the released
toolchains, allowing us to stop prebuilding and assembling them.
Moreover insertion of our resource directory is moved to the lua
tracing configuration (solving a `TODO`) and enhanced. Now all options
that start with the original resource directory (either explicit or
implied) are redirected to our resource directory.

This solves a problem where `-I <original resource dir>/some/path` was
passed to the extractor and did not work.

This works around the 5.9 linux compatibility problem by including the
`PackageDescription` swift modules in the in-dist toolchain. Copying the
toolchain and fixing the `-I` flag was not enough as for some reason
compilation of `PackageDescription.swiftinterface`  was causing a crash
in the SIL pass. We work around that by pre-compiling those modules
during the build and  including `.swiftmodule` files in the resource
directory.

TODO (apart from testing):
* the libraries included in the macOS toolchain are now fat (they were
  intel only before), occupying more space. We should see if we need to
  trim them down.
* there might be other swiftinterface files causing problems on linux
  lurking around...
* if we go with this, we can simplify and trim down the prebuilding we
  do leaving out the resource directory.
