### PR TITLE
JS/Ruby/Python: Add neutralModel extensible predicate

### DIFF
--- a/codeql-workspace.yml
+++ b/codeql-workspace.yml
@@ -29,6 +29,7 @@ provide:
   - "swift/extractor-pack/codeql-extractor.yml"
   - "swift/integration-tests/qlpack.yml"
   - "ql/extractor-pack/codeql-extractor.yml"
+  - ".github/codeql/extensions/**/codeql-pack.yml"
 
 versionPolicies:
   default:

--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsExtensions.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsExtensions.qll
@@ -17,13 +17,20 @@ extensible predicate sourceModel(string type, string path, string kind);
 extensible predicate sinkModel(string type, string path, string kind);
 
 /**
- * Holds if calls to `(type, path)`, the value referred to by `input`
+ * Holds if in calls to `(type, path)`, the value referred to by `input`
  * can flow to the value referred to by `output`.
  *
  * `kind` should be either `value` or `taint`, for value-preserving or taint-preserving steps,
  * respectively.
  */
 extensible predicate summaryModel(string type, string path, string input, string output, string kind);
+
+/**
+ * Holds if calls to `(type, path)` should be considered neutral. The meaning of this depends on the `kind`.
+ * If `kind` is `summary`, the call does not propagate data flow. If `kind` is `source`, the call is not a source.
+ * If `kind` is `sink`, the call is not a sink.
+ */
+extensible predicate neutralModel(string type, string path, string kind);
 
 /**
  * Holds if `(type2, path)` should be seen as an instance of `type1`.

--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/model.yml
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/model.yml
@@ -17,6 +17,11 @@ extensions:
 
   - addsTo:
       pack: codeql/javascript-all
+      extensible: neutralModel
+    data: []
+
+  - addsTo:
+      pack: codeql/javascript-all
       extensible: typeModel
     data: []
 

--- a/python/ql/lib/semmle/python/frameworks/data/internal/ApiGraphModelsExtensions.qll
+++ b/python/ql/lib/semmle/python/frameworks/data/internal/ApiGraphModelsExtensions.qll
@@ -17,13 +17,20 @@ extensible predicate sourceModel(string type, string path, string kind);
 extensible predicate sinkModel(string type, string path, string kind);
 
 /**
- * Holds if calls to `(type, path)`, the value referred to by `input`
+ * Holds if in calls to `(type, path)`, the value referred to by `input`
  * can flow to the value referred to by `output`.
  *
  * `kind` should be either `value` or `taint`, for value-preserving or taint-preserving steps,
  * respectively.
  */
 extensible predicate summaryModel(string type, string path, string input, string output, string kind);
+
+/**
+ * Holds if calls to `(type, path)` should be considered neutral. The meaning of this depends on the `kind`.
+ * If `kind` is `summary`, the call does not propagate data flow. If `kind` is `source`, the call is not a source.
+ * If `kind` is `sink`, the call is not a sink.
+ */
+extensible predicate neutralModel(string type, string path, string kind);
 
 /**
  * Holds if `(type2, path)` should be seen as an instance of `type1`.

--- a/python/ql/lib/semmle/python/frameworks/data/internal/empty.model.yml
+++ b/python/ql/lib/semmle/python/frameworks/data/internal/empty.model.yml
@@ -17,6 +17,11 @@ extensions:
 
   - addsTo:
       pack: codeql/python-all
+      extensible: neutralModel
+    data: []
+
+  - addsTo:
+      pack: codeql/python-all
       extensible: typeModel
     data: []
 

--- a/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModelsExtensions.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModelsExtensions.qll
@@ -17,13 +17,20 @@ extensible predicate sourceModel(string type, string path, string kind);
 extensible predicate sinkModel(string type, string path, string kind);
 
 /**
- * Holds if calls to `(type, path)`, the value referred to by `input`
+ * Holds if in calls to `(type, path)`, the value referred to by `input`
  * can flow to the value referred to by `output`.
  *
  * `kind` should be either `value` or `taint`, for value-preserving or taint-preserving steps,
  * respectively.
  */
 extensible predicate summaryModel(string type, string path, string input, string output, string kind);
+
+/**
+ * Holds if calls to `(type, path)` should be considered neutral. The meaning of this depends on the `kind`.
+ * If `kind` is `summary`, the call does not propagate data flow. If `kind` is `source`, the call is not a source.
+ * If `kind` is `sink`, the call is not a sink.
+ */
+extensible predicate neutralModel(string type, string path, string kind);
 
 /**
  * Holds if `(type2, path)` should be seen as an instance of `type1`.

--- a/ruby/ql/lib/codeql/ruby/frameworks/data/internal/model.yml
+++ b/ruby/ql/lib/codeql/ruby/frameworks/data/internal/model.yml
@@ -17,6 +17,11 @@ extensions:
 
   - addsTo:
       pack: codeql/ruby-all
+      extensible: neutralModel
+    data: []
+
+  - addsTo:
+      pack: codeql/ruby-all
       extensible: typeModel
     data: []
 


### PR DESCRIPTION
The neutralModel extensible predicate already exists in Java and C#, so
this change brings the dynamic languages more in line with static
languages. The Model Editor uses this predicate to mark endpoints as
"not interesting" from a data flow perspective.

We don't actually make use of this predicate inside the dynamic libraries (indeed, at the moment I think only Java and C# do so), but the model editor should be able to take advantage of it nonetheless.

The first commit allows codeql to see data extensions stored in the .github
directory inside the codeql repo. This is useful when using the CodeQL
Model Editor whilst working inside the codeql repo.