### PR TITLE
Swift: Clean up the swift/unsafe-js-eval test

### DIFF
--- a/swift/ql/test/query-tests/Security/CWE-094/UnsafeJsEval.expected
+++ b/swift/ql/test/query-tests/Security/CWE-094/UnsafeJsEval.expected
@@ -1,9 +1,4 @@
 edges
-| UnsafeJsEval.swift:165:10:165:37 | try ... | UnsafeJsEval.swift:201:21:201:35 | call to getRemoteData() |
-| UnsafeJsEval.swift:165:14:165:37 | call to String.init(contentsOf:) | UnsafeJsEval.swift:165:10:165:37 | try ... |
-| UnsafeJsEval.swift:201:21:201:35 | call to getRemoteData() | UnsafeJsEval.swift:205:7:205:7 | remoteString |
-| UnsafeJsEval.swift:201:21:201:35 | call to getRemoteData() | UnsafeJsEval.swift:208:7:208:39 | ... .+(_:_:) ... |
-| UnsafeJsEval.swift:201:21:201:35 | call to getRemoteData() | UnsafeJsEval.swift:211:24:211:37 | .utf8 |
 | UnsafeJsEval.swift:204:7:204:66 | try! ... | UnsafeJsEval.swift:265:13:265:13 | string |
 | UnsafeJsEval.swift:204:7:204:66 | try! ... | UnsafeJsEval.swift:268:13:268:13 | string |
 | UnsafeJsEval.swift:204:7:204:66 | try! ... | UnsafeJsEval.swift:276:13:276:13 | string |
@@ -11,20 +6,23 @@ edges
 | UnsafeJsEval.swift:204:7:204:66 | try! ... | UnsafeJsEval.swift:285:13:285:13 | string |
 | UnsafeJsEval.swift:204:7:204:66 | try! ... | UnsafeJsEval.swift:299:13:299:13 | string |
 | UnsafeJsEval.swift:204:12:204:66 | call to String.init(contentsOf:) | UnsafeJsEval.swift:204:7:204:66 | try! ... |
-| UnsafeJsEval.swift:205:7:205:7 | remoteString | UnsafeJsEval.swift:265:13:265:13 | string |
-| UnsafeJsEval.swift:205:7:205:7 | remoteString | UnsafeJsEval.swift:268:13:268:13 | string |
-| UnsafeJsEval.swift:205:7:205:7 | remoteString | UnsafeJsEval.swift:276:13:276:13 | string |
-| UnsafeJsEval.swift:205:7:205:7 | remoteString | UnsafeJsEval.swift:279:13:279:13 | string |
-| UnsafeJsEval.swift:205:7:205:7 | remoteString | UnsafeJsEval.swift:285:13:285:13 | string |
-| UnsafeJsEval.swift:205:7:205:7 | remoteString | UnsafeJsEval.swift:299:13:299:13 | string |
-| UnsafeJsEval.swift:208:7:208:39 | ... .+(_:_:) ... | UnsafeJsEval.swift:265:13:265:13 | string |
-| UnsafeJsEval.swift:208:7:208:39 | ... .+(_:_:) ... | UnsafeJsEval.swift:268:13:268:13 | string |
-| UnsafeJsEval.swift:208:7:208:39 | ... .+(_:_:) ... | UnsafeJsEval.swift:276:13:276:13 | string |
-| UnsafeJsEval.swift:208:7:208:39 | ... .+(_:_:) ... | UnsafeJsEval.swift:279:13:279:13 | string |
-| UnsafeJsEval.swift:208:7:208:39 | ... .+(_:_:) ... | UnsafeJsEval.swift:285:13:285:13 | string |
-| UnsafeJsEval.swift:208:7:208:39 | ... .+(_:_:) ... | UnsafeJsEval.swift:299:13:299:13 | string |
-| UnsafeJsEval.swift:211:19:211:41 | call to Data.init(_:) | UnsafeJsEval.swift:214:24:214:24 | remoteData |
-| UnsafeJsEval.swift:211:24:211:37 | .utf8 | UnsafeJsEval.swift:211:19:211:41 | call to Data.init(_:) |
+| UnsafeJsEval.swift:205:7:205:35 | try! ... | UnsafeJsEval.swift:265:13:265:13 | string |
+| UnsafeJsEval.swift:205:7:205:35 | try! ... | UnsafeJsEval.swift:268:13:268:13 | string |
+| UnsafeJsEval.swift:205:7:205:35 | try! ... | UnsafeJsEval.swift:276:13:276:13 | string |
+| UnsafeJsEval.swift:205:7:205:35 | try! ... | UnsafeJsEval.swift:279:13:279:13 | string |
+| UnsafeJsEval.swift:205:7:205:35 | try! ... | UnsafeJsEval.swift:285:13:285:13 | string |
+| UnsafeJsEval.swift:205:7:205:35 | try! ... | UnsafeJsEval.swift:299:13:299:13 | string |
+| UnsafeJsEval.swift:205:12:205:35 | call to String.init(contentsOf:) | UnsafeJsEval.swift:205:7:205:35 | try! ... |
+| UnsafeJsEval.swift:208:7:208:58 | ... .+(_:_:) ... | UnsafeJsEval.swift:265:13:265:13 | string |
+| UnsafeJsEval.swift:208:7:208:58 | ... .+(_:_:) ... | UnsafeJsEval.swift:268:13:268:13 | string |
+| UnsafeJsEval.swift:208:7:208:58 | ... .+(_:_:) ... | UnsafeJsEval.swift:276:13:276:13 | string |
+| UnsafeJsEval.swift:208:7:208:58 | ... .+(_:_:) ... | UnsafeJsEval.swift:279:13:279:13 | string |
+| UnsafeJsEval.swift:208:7:208:58 | ... .+(_:_:) ... | UnsafeJsEval.swift:285:13:285:13 | string |
+| UnsafeJsEval.swift:208:7:208:58 | ... .+(_:_:) ... | UnsafeJsEval.swift:299:13:299:13 | string |
+| UnsafeJsEval.swift:208:30:208:53 | call to String.init(contentsOf:) | UnsafeJsEval.swift:208:7:208:58 | ... .+(_:_:) ... |
+| UnsafeJsEval.swift:211:19:211:60 | call to Data.init(_:) | UnsafeJsEval.swift:214:24:214:24 | remoteData |
+| UnsafeJsEval.swift:211:24:211:56 | .utf8 | UnsafeJsEval.swift:211:19:211:60 | call to Data.init(_:) |
+| UnsafeJsEval.swift:211:30:211:53 | call to String.init(contentsOf:) | UnsafeJsEval.swift:211:24:211:56 | .utf8 |
 | UnsafeJsEval.swift:214:7:214:49 | call to String.init(decoding:as:) | UnsafeJsEval.swift:265:13:265:13 | string |
 | UnsafeJsEval.swift:214:7:214:49 | call to String.init(decoding:as:) | UnsafeJsEval.swift:268:13:268:13 | string |
 | UnsafeJsEval.swift:214:7:214:49 | call to String.init(decoding:as:) | UnsafeJsEval.swift:276:13:276:13 | string |
@@ -56,15 +54,15 @@ edges
 | UnsafeJsEval.swift:301:61:301:73 | .baseAddress | UnsafeJsEval.swift:301:31:301:84 | call to JSStringCreateWithUTF8CString(_:) |
 | UnsafeJsEval.swift:318:24:318:87 | call to String.init(contentsOf:) | UnsafeJsEval.swift:320:44:320:74 | ... .+(_:_:) ... |
 nodes
-| UnsafeJsEval.swift:165:10:165:37 | try ... | semmle.label | try ... |
-| UnsafeJsEval.swift:165:14:165:37 | call to String.init(contentsOf:) | semmle.label | call to String.init(contentsOf:) |
-| UnsafeJsEval.swift:201:21:201:35 | call to getRemoteData() | semmle.label | call to getRemoteData() |
 | UnsafeJsEval.swift:204:7:204:66 | try! ... | semmle.label | try! ... |
 | UnsafeJsEval.swift:204:12:204:66 | call to String.init(contentsOf:) | semmle.label | call to String.init(contentsOf:) |
-| UnsafeJsEval.swift:205:7:205:7 | remoteString | semmle.label | remoteString |
-| UnsafeJsEval.swift:208:7:208:39 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
-| UnsafeJsEval.swift:211:19:211:41 | call to Data.init(_:) | semmle.label | call to Data.init(_:) |
-| UnsafeJsEval.swift:211:24:211:37 | .utf8 | semmle.label | .utf8 |
+| UnsafeJsEval.swift:205:7:205:35 | try! ... | semmle.label | try! ... |
+| UnsafeJsEval.swift:205:12:205:35 | call to String.init(contentsOf:) | semmle.label | call to String.init(contentsOf:) |
+| UnsafeJsEval.swift:208:7:208:58 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
+| UnsafeJsEval.swift:208:30:208:53 | call to String.init(contentsOf:) | semmle.label | call to String.init(contentsOf:) |
+| UnsafeJsEval.swift:211:19:211:60 | call to Data.init(_:) | semmle.label | call to Data.init(_:) |
+| UnsafeJsEval.swift:211:24:211:56 | .utf8 | semmle.label | .utf8 |
+| UnsafeJsEval.swift:211:30:211:53 | call to String.init(contentsOf:) | semmle.label | call to String.init(contentsOf:) |
 | UnsafeJsEval.swift:214:7:214:49 | call to String.init(decoding:as:) | semmle.label | call to String.init(decoding:as:) |
 | UnsafeJsEval.swift:214:24:214:24 | remoteData | semmle.label | remoteData |
 | UnsafeJsEval.swift:265:13:265:13 | string | semmle.label | string |
@@ -99,16 +97,28 @@ nodes
 | UnsafeJsEval.swift:320:44:320:74 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
 subpaths
 #select
-| UnsafeJsEval.swift:266:22:266:107 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:) | UnsafeJsEval.swift:165:14:165:37 | call to String.init(contentsOf:) | UnsafeJsEval.swift:266:22:266:107 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:) | Evaluation of uncontrolled JavaScript from a remote source. |
 | UnsafeJsEval.swift:266:22:266:107 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:) | UnsafeJsEval.swift:204:12:204:66 | call to String.init(contentsOf:) | UnsafeJsEval.swift:266:22:266:107 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:) | Evaluation of uncontrolled JavaScript from a remote source. |
-| UnsafeJsEval.swift:269:22:269:124 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) | UnsafeJsEval.swift:165:14:165:37 | call to String.init(contentsOf:) | UnsafeJsEval.swift:269:22:269:124 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) | Evaluation of uncontrolled JavaScript from a remote source. |
+| UnsafeJsEval.swift:266:22:266:107 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:) | UnsafeJsEval.swift:205:12:205:35 | call to String.init(contentsOf:) | UnsafeJsEval.swift:266:22:266:107 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:) | Evaluation of uncontrolled JavaScript from a remote source. |
+| UnsafeJsEval.swift:266:22:266:107 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:) | UnsafeJsEval.swift:208:30:208:53 | call to String.init(contentsOf:) | UnsafeJsEval.swift:266:22:266:107 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:) | Evaluation of uncontrolled JavaScript from a remote source. |
+| UnsafeJsEval.swift:266:22:266:107 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:) | UnsafeJsEval.swift:211:30:211:53 | call to String.init(contentsOf:) | UnsafeJsEval.swift:266:22:266:107 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:) | Evaluation of uncontrolled JavaScript from a remote source. |
 | UnsafeJsEval.swift:269:22:269:124 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) | UnsafeJsEval.swift:204:12:204:66 | call to String.init(contentsOf:) | UnsafeJsEval.swift:269:22:269:124 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) | Evaluation of uncontrolled JavaScript from a remote source. |
-| UnsafeJsEval.swift:277:26:277:26 | string | UnsafeJsEval.swift:165:14:165:37 | call to String.init(contentsOf:) | UnsafeJsEval.swift:277:26:277:26 | string | Evaluation of uncontrolled JavaScript from a remote source. |
+| UnsafeJsEval.swift:269:22:269:124 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) | UnsafeJsEval.swift:205:12:205:35 | call to String.init(contentsOf:) | UnsafeJsEval.swift:269:22:269:124 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) | Evaluation of uncontrolled JavaScript from a remote source. |
+| UnsafeJsEval.swift:269:22:269:124 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) | UnsafeJsEval.swift:208:30:208:53 | call to String.init(contentsOf:) | UnsafeJsEval.swift:269:22:269:124 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) | Evaluation of uncontrolled JavaScript from a remote source. |
+| UnsafeJsEval.swift:269:22:269:124 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) | UnsafeJsEval.swift:211:30:211:53 | call to String.init(contentsOf:) | UnsafeJsEval.swift:269:22:269:124 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) | Evaluation of uncontrolled JavaScript from a remote source. |
 | UnsafeJsEval.swift:277:26:277:26 | string | UnsafeJsEval.swift:204:12:204:66 | call to String.init(contentsOf:) | UnsafeJsEval.swift:277:26:277:26 | string | Evaluation of uncontrolled JavaScript from a remote source. |
-| UnsafeJsEval.swift:280:26:280:26 | string | UnsafeJsEval.swift:165:14:165:37 | call to String.init(contentsOf:) | UnsafeJsEval.swift:280:26:280:26 | string | Evaluation of uncontrolled JavaScript from a remote source. |
+| UnsafeJsEval.swift:277:26:277:26 | string | UnsafeJsEval.swift:205:12:205:35 | call to String.init(contentsOf:) | UnsafeJsEval.swift:277:26:277:26 | string | Evaluation of uncontrolled JavaScript from a remote source. |
+| UnsafeJsEval.swift:277:26:277:26 | string | UnsafeJsEval.swift:208:30:208:53 | call to String.init(contentsOf:) | UnsafeJsEval.swift:277:26:277:26 | string | Evaluation of uncontrolled JavaScript from a remote source. |
+| UnsafeJsEval.swift:277:26:277:26 | string | UnsafeJsEval.swift:211:30:211:53 | call to String.init(contentsOf:) | UnsafeJsEval.swift:277:26:277:26 | string | Evaluation of uncontrolled JavaScript from a remote source. |
 | UnsafeJsEval.swift:280:26:280:26 | string | UnsafeJsEval.swift:204:12:204:66 | call to String.init(contentsOf:) | UnsafeJsEval.swift:280:26:280:26 | string | Evaluation of uncontrolled JavaScript from a remote source. |
-| UnsafeJsEval.swift:291:17:291:17 | jsstr | UnsafeJsEval.swift:165:14:165:37 | call to String.init(contentsOf:) | UnsafeJsEval.swift:291:17:291:17 | jsstr | Evaluation of uncontrolled JavaScript from a remote source. |
+| UnsafeJsEval.swift:280:26:280:26 | string | UnsafeJsEval.swift:205:12:205:35 | call to String.init(contentsOf:) | UnsafeJsEval.swift:280:26:280:26 | string | Evaluation of uncontrolled JavaScript from a remote source. |
+| UnsafeJsEval.swift:280:26:280:26 | string | UnsafeJsEval.swift:208:30:208:53 | call to String.init(contentsOf:) | UnsafeJsEval.swift:280:26:280:26 | string | Evaluation of uncontrolled JavaScript from a remote source. |
+| UnsafeJsEval.swift:280:26:280:26 | string | UnsafeJsEval.swift:211:30:211:53 | call to String.init(contentsOf:) | UnsafeJsEval.swift:280:26:280:26 | string | Evaluation of uncontrolled JavaScript from a remote source. |
 | UnsafeJsEval.swift:291:17:291:17 | jsstr | UnsafeJsEval.swift:204:12:204:66 | call to String.init(contentsOf:) | UnsafeJsEval.swift:291:17:291:17 | jsstr | Evaluation of uncontrolled JavaScript from a remote source. |
-| UnsafeJsEval.swift:305:17:305:17 | jsstr | UnsafeJsEval.swift:165:14:165:37 | call to String.init(contentsOf:) | UnsafeJsEval.swift:305:17:305:17 | jsstr | Evaluation of uncontrolled JavaScript from a remote source. |
+| UnsafeJsEval.swift:291:17:291:17 | jsstr | UnsafeJsEval.swift:205:12:205:35 | call to String.init(contentsOf:) | UnsafeJsEval.swift:291:17:291:17 | jsstr | Evaluation of uncontrolled JavaScript from a remote source. |
+| UnsafeJsEval.swift:291:17:291:17 | jsstr | UnsafeJsEval.swift:208:30:208:53 | call to String.init(contentsOf:) | UnsafeJsEval.swift:291:17:291:17 | jsstr | Evaluation of uncontrolled JavaScript from a remote source. |
+| UnsafeJsEval.swift:291:17:291:17 | jsstr | UnsafeJsEval.swift:211:30:211:53 | call to String.init(contentsOf:) | UnsafeJsEval.swift:291:17:291:17 | jsstr | Evaluation of uncontrolled JavaScript from a remote source. |
 | UnsafeJsEval.swift:305:17:305:17 | jsstr | UnsafeJsEval.swift:204:12:204:66 | call to String.init(contentsOf:) | UnsafeJsEval.swift:305:17:305:17 | jsstr | Evaluation of uncontrolled JavaScript from a remote source. |
+| UnsafeJsEval.swift:305:17:305:17 | jsstr | UnsafeJsEval.swift:205:12:205:35 | call to String.init(contentsOf:) | UnsafeJsEval.swift:305:17:305:17 | jsstr | Evaluation of uncontrolled JavaScript from a remote source. |
+| UnsafeJsEval.swift:305:17:305:17 | jsstr | UnsafeJsEval.swift:208:30:208:53 | call to String.init(contentsOf:) | UnsafeJsEval.swift:305:17:305:17 | jsstr | Evaluation of uncontrolled JavaScript from a remote source. |
+| UnsafeJsEval.swift:305:17:305:17 | jsstr | UnsafeJsEval.swift:211:30:211:53 | call to String.init(contentsOf:) | UnsafeJsEval.swift:305:17:305:17 | jsstr | Evaluation of uncontrolled JavaScript from a remote source. |
 | UnsafeJsEval.swift:320:44:320:74 | ... .+(_:_:) ... | UnsafeJsEval.swift:318:24:318:87 | call to String.init(contentsOf:) | UnsafeJsEval.swift:320:44:320:74 | ... .+(_:_:) ... | Evaluation of uncontrolled JavaScript from a remote source. |

--- a/swift/ql/test/query-tests/Security/CWE-094/UnsafeJsEval.swift
+++ b/swift/ql/test/query-tests/Security/CWE-094/UnsafeJsEval.swift
@@ -224,7 +224,7 @@ func testUIWebView() {
 	let webview = UIWebView()
 
 	testAsync { string in
-		_ = await webview.stringByEvaluatingJavaScript(from: string)
+		_ = await webview.stringByEvaluatingJavaScript(from: string) // BAD [NOT DETECTED]
 	}
 }
 
@@ -232,7 +232,7 @@ func testWebView() {
 	let webview = WebView()
 
 	testAsync { string in
-		_ = await webview.stringByEvaluatingJavaScript(from: string)
+		_ = await webview.stringByEvaluatingJavaScript(from: string) // BAD [NOT DETECTED]
 	}
 }
 
@@ -240,22 +240,22 @@ func testWKWebView() {
 	let webview = WKWebView()
 
 	testAsync { string in
-		_ = try await webview.evaluateJavaScript(string)
+		_ = try await webview.evaluateJavaScript(string) // BAD [NOT DETECTED]
 	}
 	testAsync { string in
-		await webview.evaluateJavaScript(string) { _, _ in }
+		await webview.evaluateJavaScript(string) { _, _ in } // BAD [NOT DETECTED]
 	}
 	testAsync { string in
-		await webview.evaluateJavaScript(string, in: nil, in: WKContentWorld.defaultClient) { _ in }
+		await webview.evaluateJavaScript(string, in: nil, in: WKContentWorld.defaultClient) { _ in } // BAD [NOT DETECTED]
 	}
 	testAsync { string in
-		_ = try await webview.evaluateJavaScript(string, contentWorld: .defaultClient)
+		_ = try await webview.evaluateJavaScript(string, contentWorld: .defaultClient) // BAD [NOT DETECTED]
 	}
 	testAsync { string in
-		await webview.callAsyncJavaScript(string, in: nil, in: .defaultClient) { _ in () }
+		await webview.callAsyncJavaScript(string, in: nil, in: .defaultClient) { _ in () } // BAD [NOT DETECTED]
 	}
 	testAsync { string in
-		_ = try await webview.callAsyncJavaScript(string, contentWorld: WKContentWorld.defaultClient)
+		_ = try await webview.callAsyncJavaScript(string, contentWorld: WKContentWorld.defaultClient) // BAD [NOT DETECTED]
 	}
 }
 
@@ -263,10 +263,10 @@ func testWKUserContentController() {
 	let ctrl = WKUserContentController()
 
 	testSync { string in
-		ctrl.addUserScript(WKUserScript(source: string, injectionTime: .atDocumentStart, forMainFrameOnly: false))
+		ctrl.addUserScript(WKUserScript(source: string, injectionTime: .atDocumentStart, forMainFrameOnly: false)) // BAD (multiple sources)
 	}
 	testSync { string in
-		ctrl.addUserScript(WKUserScript(source: string, injectionTime: .atDocumentEnd, forMainFrameOnly: true, in: .defaultClient))
+		ctrl.addUserScript(WKUserScript(source: string, injectionTime: .atDocumentEnd, forMainFrameOnly: true, in: .defaultClient)) // BAD (multiple sources)
 	}
 }
 
@@ -274,10 +274,10 @@ func testJSContext() {
 	let ctx = JSContext()
 
 	testSync { string in
-		_ = ctx.evaluateScript(string)
+		_ = ctx.evaluateScript(string) // BAD (multiple sources)
 	}
 	testSync { string in
-		_ = ctx.evaluateScript(string, withSourceURL: URL(string: "https://example.com"))
+		_ = ctx.evaluateScript(string, withSourceURL: URL(string: "https://example.com")) // BAD (multiple sources)
 	}
 }
 
@@ -288,7 +288,7 @@ func testJSEvaluateScript() {
 			defer { JSStringRelease(jsstr) }
 			_ = JSEvaluateScript(
 				/*ctx:*/ OpaquePointer(bitPattern: 0),
-				/*script:*/ jsstr,
+				/*script:*/ jsstr, // BAD (multiple sources)
 				/*thisObject:*/ OpaquePointer(bitPattern: 0),
 				/*sourceURL:*/ OpaquePointer(bitPattern: 0),
 				/*startingLineNumber:*/ 0,
@@ -302,7 +302,7 @@ func testJSEvaluateScript() {
 			defer { JSStringRelease(jsstr) }
 			_ = JSEvaluateScript(
 				/*ctx:*/ OpaquePointer(bitPattern: 0),
-				/*script:*/ jsstr,
+				/*script:*/ jsstr, // BAD (multiple sources)
 				/*thisObject:*/ OpaquePointer(bitPattern: 0),
 				/*sourceURL:*/ OpaquePointer(bitPattern: 0),
 				/*startingLineNumber:*/ 0,


### PR DESCRIPTION
Clean up the `swift/unsafe-js-eval` test, with the intent of making the results easier to understand.  It's an unusual test because the `testAsync` and `testSync` methods are matrix tests - each pairs a number of sources to a number of sinks via calling a closure called `sink` representing each of the sinks.  I've labelled both source and sink lines as `BAD` to make it clearer which lines should appear in the results.