### PR TITLE
Go: mark all integration tests non-parallelisable

### DIFF
--- a/go/ql/integration-tests/all-platforms/go/bazel-sample-1/force_sequential_test_execution
+++ b/go/ql/integration-tests/all-platforms/go/bazel-sample-1/force_sequential_test_execution
@@ -1,0 +1,1 @@
+# go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.

--- a/go/ql/integration-tests/all-platforms/go/bazel-sample-1/force_sequential_test_execution
+++ b/go/ql/integration-tests/all-platforms/go/bazel-sample-1/force_sequential_test_execution
@@ -1,1 +1,2 @@
 # go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.
+goget

--- a/go/ql/integration-tests/all-platforms/go/bazel-sample-2/force_sequential_test_execution
+++ b/go/ql/integration-tests/all-platforms/go/bazel-sample-2/force_sequential_test_execution
@@ -1,0 +1,1 @@
+# go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.

--- a/go/ql/integration-tests/all-platforms/go/bazel-sample-2/force_sequential_test_execution
+++ b/go/ql/integration-tests/all-platforms/go/bazel-sample-2/force_sequential_test_execution
@@ -1,1 +1,2 @@
 # go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.
+goget

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/force_sequential_test_execution
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/force_sequential_test_execution
@@ -1,0 +1,1 @@
+# go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/force_sequential_test_execution
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/force_sequential_test_execution
@@ -1,1 +1,2 @@
 # go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.
+goget

--- a/go/ql/integration-tests/all-platforms/go/go-get-without-modules-sample/force_sequential_test_execution
+++ b/go/ql/integration-tests/all-platforms/go/go-get-without-modules-sample/force_sequential_test_execution
@@ -1,0 +1,1 @@
+# go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.

--- a/go/ql/integration-tests/all-platforms/go/go-get-without-modules-sample/force_sequential_test_execution
+++ b/go/ql/integration-tests/all-platforms/go/go-get-without-modules-sample/force_sequential_test_execution
@@ -1,1 +1,2 @@
 # go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.
+goget

--- a/go/ql/integration-tests/all-platforms/go/go-mod-sample/force_sequential_test_execution
+++ b/go/ql/integration-tests/all-platforms/go/go-mod-sample/force_sequential_test_execution
@@ -1,0 +1,1 @@
+# go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.

--- a/go/ql/integration-tests/all-platforms/go/go-mod-sample/force_sequential_test_execution
+++ b/go/ql/integration-tests/all-platforms/go/go-mod-sample/force_sequential_test_execution
@@ -1,1 +1,2 @@
 # go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.
+goget

--- a/go/ql/integration-tests/all-platforms/go/make-sample/force_sequential_test_execution
+++ b/go/ql/integration-tests/all-platforms/go/make-sample/force_sequential_test_execution
@@ -1,0 +1,1 @@
+# go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.

--- a/go/ql/integration-tests/all-platforms/go/make-sample/force_sequential_test_execution
+++ b/go/ql/integration-tests/all-platforms/go/make-sample/force_sequential_test_execution
@@ -1,1 +1,2 @@
 # go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.
+goget

--- a/go/ql/integration-tests/all-platforms/go/ninja-sample/force_sequential_test_execution
+++ b/go/ql/integration-tests/all-platforms/go/ninja-sample/force_sequential_test_execution
@@ -1,0 +1,1 @@
+# go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.

--- a/go/ql/integration-tests/all-platforms/go/ninja-sample/force_sequential_test_execution
+++ b/go/ql/integration-tests/all-platforms/go/ninja-sample/force_sequential_test_execution
@@ -1,1 +1,2 @@
 # go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.
+goget

--- a/go/ql/integration-tests/all-platforms/go/single-go-mod-and-go-files-not-under-it/force_sequential_test_execution
+++ b/go/ql/integration-tests/all-platforms/go/single-go-mod-and-go-files-not-under-it/force_sequential_test_execution
@@ -1,0 +1,1 @@
+# go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.

--- a/go/ql/integration-tests/all-platforms/go/single-go-mod-and-go-files-not-under-it/force_sequential_test_execution
+++ b/go/ql/integration-tests/all-platforms/go/single-go-mod-and-go-files-not-under-it/force_sequential_test_execution
@@ -1,1 +1,2 @@
 # go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.
+goget

--- a/go/ql/integration-tests/all-platforms/go/single-go-mod-in-root/force_sequential_test_execution
+++ b/go/ql/integration-tests/all-platforms/go/single-go-mod-in-root/force_sequential_test_execution
@@ -1,0 +1,1 @@
+# go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.

--- a/go/ql/integration-tests/all-platforms/go/single-go-mod-in-root/force_sequential_test_execution
+++ b/go/ql/integration-tests/all-platforms/go/single-go-mod-in-root/force_sequential_test_execution
@@ -1,1 +1,2 @@
 # go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.
+goget

--- a/go/ql/integration-tests/all-platforms/go/single-go-mod-not-in-root/force_sequential_test_execution
+++ b/go/ql/integration-tests/all-platforms/go/single-go-mod-not-in-root/force_sequential_test_execution
@@ -1,0 +1,1 @@
+# go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.

--- a/go/ql/integration-tests/all-platforms/go/single-go-mod-not-in-root/force_sequential_test_execution
+++ b/go/ql/integration-tests/all-platforms/go/single-go-mod-not-in-root/force_sequential_test_execution
@@ -1,1 +1,2 @@
 # go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.
+goget

--- a/go/ql/integration-tests/all-platforms/go/single-go-work-not-in-root/force_sequential_test_execution
+++ b/go/ql/integration-tests/all-platforms/go/single-go-work-not-in-root/force_sequential_test_execution
@@ -1,0 +1,1 @@
+# go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.

--- a/go/ql/integration-tests/all-platforms/go/single-go-work-not-in-root/force_sequential_test_execution
+++ b/go/ql/integration-tests/all-platforms/go/single-go-work-not-in-root/force_sequential_test_execution
@@ -1,1 +1,2 @@
 # go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.
+goget

--- a/go/ql/integration-tests/all-platforms/go/two-go-mods-nested-none-in-root/force_sequential_test_execution
+++ b/go/ql/integration-tests/all-platforms/go/two-go-mods-nested-none-in-root/force_sequential_test_execution
@@ -1,0 +1,1 @@
+# go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.

--- a/go/ql/integration-tests/all-platforms/go/two-go-mods-nested-none-in-root/force_sequential_test_execution
+++ b/go/ql/integration-tests/all-platforms/go/two-go-mods-nested-none-in-root/force_sequential_test_execution
@@ -1,1 +1,2 @@
 # go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.
+goget

--- a/go/ql/integration-tests/all-platforms/go/two-go-mods-nested-one-in-root/force_sequential_test_execution
+++ b/go/ql/integration-tests/all-platforms/go/two-go-mods-nested-one-in-root/force_sequential_test_execution
@@ -1,0 +1,1 @@
+# go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.

--- a/go/ql/integration-tests/all-platforms/go/two-go-mods-nested-one-in-root/force_sequential_test_execution
+++ b/go/ql/integration-tests/all-platforms/go/two-go-mods-nested-one-in-root/force_sequential_test_execution
@@ -1,1 +1,2 @@
 # go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.
+goget

--- a/go/ql/integration-tests/all-platforms/go/two-go-mods-not-nested/force_sequential_test_execution
+++ b/go/ql/integration-tests/all-platforms/go/two-go-mods-not-nested/force_sequential_test_execution
@@ -1,0 +1,1 @@
+# go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.

--- a/go/ql/integration-tests/all-platforms/go/two-go-mods-not-nested/force_sequential_test_execution
+++ b/go/ql/integration-tests/all-platforms/go/two-go-mods-not-nested/force_sequential_test_execution
@@ -1,1 +1,2 @@
 # go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.
+goget

--- a/go/ql/integration-tests/linux-only/go/dep-sample/force_sequential_test_execution
+++ b/go/ql/integration-tests/linux-only/go/dep-sample/force_sequential_test_execution
@@ -1,0 +1,1 @@
+# go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.

--- a/go/ql/integration-tests/linux-only/go/dep-sample/force_sequential_test_execution
+++ b/go/ql/integration-tests/linux-only/go/dep-sample/force_sequential_test_execution
@@ -1,1 +1,2 @@
 # go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.
+goget

--- a/go/ql/integration-tests/linux-only/go/glide-sample/force_sequential_test_execution
+++ b/go/ql/integration-tests/linux-only/go/glide-sample/force_sequential_test_execution
@@ -1,0 +1,1 @@
+# go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.

--- a/go/ql/integration-tests/linux-only/go/glide-sample/force_sequential_test_execution
+++ b/go/ql/integration-tests/linux-only/go/glide-sample/force_sequential_test_execution
@@ -1,1 +1,2 @@
 # go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.
+goget


### PR DESCRIPTION
`go get` has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.