### PR TITLE
C++: Remove one use of range analysis in `cpp/invalid-pointer-deref`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/security/InvalidPointerDereference/InvalidPointerToDereference.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/InvalidPointerDereference/InvalidPointerToDereference.qll
@@ -198,11 +198,7 @@ private import DataFlow::GlobalWithState<InvalidPointerToDerefConfig>
 
 /**
  * Holds if `allocSource` is dataflow node that represents an allocation that flows to the
- * left-hand side of the pointer-arithmetic `pai`, and `derefSource <= pai + derefSourcePaiDelta`.
- *
- * For example, if `pai` is a pointer-arithmetic operation `p + size` in an expression such
- * as `(p + size) + 1` and `derefSource` is the node representing `(p + size) + 1`. In this
- * case `derefSourcePaiDelta` is 1.
+ * left-hand side of the pointer-arithmetic instruction represented by `derefSource`.
  */
 private predicate invalidPointerToDerefSource(
   DataFlow::Node allocSource, PointerArithmeticInstruction pai, DataFlow::Node derefSource,
@@ -213,9 +209,8 @@ private predicate invalidPointerToDerefSource(
   // `deltaDerefSourceAndPai` is the constant difference between the pointer-arithmetic instruction
   // and the instruction computing the address for which we will search for a dereference.
   AllocToInvalidPointer::pointerAddInstructionHasBounds(allocSource, pai, _, _) and
-  // derefSource <= pai + deltaDerefSourceAndPai
-  bounded2(derefSource.asInstruction(), pai, deltaDerefSourceAndPai) and
-  deltaDerefSourceAndPai >= 0
+  derefSource.asInstruction() = pai and
+  deltaDerefSourceAndPai = 0
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/security/InvalidPointerDereference/InvalidPointerToDereference.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/InvalidPointerDereference/InvalidPointerToDereference.qll
@@ -23,9 +23,7 @@
  * configuration (see `InvalidPointerToDerefConfig`).
  *
  * The dataflow traversal defines the set of sources as any dataflow node `n` such that there exists a pointer-arithmetic
- * instruction `pai` found by `AllocationToInvalidPointer.qll` and a `n.asInstruction() >= pai + deltaDerefSourceAndPai`.
- * Here, `deltaDerefSourceAndPai` is the constant difference between the source we track for finding a dereference and the
- * pointer-arithmetic instruction.
+ * instruction `pai` found by `AllocationToInvalidPointer.qll` and a `n.asInstruction() = pai`.
  *
  * The set of sinks is defined as any dataflow node `n` such that `addr <= n.asInstruction() + deltaDerefSinkAndDerefAddress`
  * for some address operand `addr` and constant difference `deltaDerefSinkAndDerefAddress`. Since an address operand is
@@ -37,9 +35,8 @@
  * `deltaDerefSinkAndDerefAddress >= 0`. The load attached to `*p` is the "operation". To ensure that the path makes
  * intuitive sense, we only pick operations that are control-flow reachable from the dereference sink.
  *
- * To compute how many elements the dereference is beyond the end position of the allocation, we sum the two deltas
- * `deltaDerefSourceAndPai` and `deltaDerefSinkAndDerefAddress`. This is done in the `operationIsOffBy` predicate
- * (which is the only predicate exposed by this file).
+ * We use the `deltaDerefSinkAndDerefAddress` to compute how many elements the dereference is beyond the end position of
+ * the allocation. This is done in the `operationIsOffBy` predicate (which is the only predicate exposed by this file).
  *
  * Handling false positives:
  *

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-193/InvalidPointerDeref.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-193/InvalidPointerDeref.expected
@@ -1,9 +1,5 @@
 edges
 | test.cpp:4:15:4:33 | call to malloc | test.cpp:5:15:5:22 | ... + ... |
-| test.cpp:4:15:4:33 | call to malloc | test.cpp:5:15:5:22 | ... + ... |
-| test.cpp:4:15:4:33 | call to malloc | test.cpp:6:14:6:15 | * ... |
-| test.cpp:4:15:4:33 | call to malloc | test.cpp:6:14:6:15 | * ... |
-| test.cpp:4:15:4:33 | call to malloc | test.cpp:8:14:8:21 | * ... |
 | test.cpp:5:15:5:22 | ... + ... | test.cpp:5:15:5:22 | ... + ... |
 | test.cpp:5:15:5:22 | ... + ... | test.cpp:6:14:6:15 | * ... |
 | test.cpp:5:15:5:22 | ... + ... | test.cpp:6:14:6:15 | * ... |
@@ -14,10 +10,6 @@ edges
 | test.cpp:6:14:6:15 | * ... | test.cpp:8:14:8:21 | * ... |
 | test.cpp:16:15:16:33 | call to malloc | test.cpp:20:14:20:21 | * ... |
 | test.cpp:28:15:28:37 | call to malloc | test.cpp:29:15:29:28 | ... + ... |
-| test.cpp:28:15:28:37 | call to malloc | test.cpp:29:15:29:28 | ... + ... |
-| test.cpp:28:15:28:37 | call to malloc | test.cpp:30:14:30:15 | * ... |
-| test.cpp:28:15:28:37 | call to malloc | test.cpp:30:14:30:15 | * ... |
-| test.cpp:28:15:28:37 | call to malloc | test.cpp:32:14:32:21 | * ... |
 | test.cpp:29:15:29:28 | ... + ... | test.cpp:29:15:29:28 | ... + ... |
 | test.cpp:29:15:29:28 | ... + ... | test.cpp:30:14:30:15 | * ... |
 | test.cpp:29:15:29:28 | ... + ... | test.cpp:30:14:30:15 | * ... |
@@ -27,29 +19,20 @@ edges
 | test.cpp:29:15:29:28 | ... + ... | test.cpp:32:14:32:21 | * ... |
 | test.cpp:30:14:30:15 | * ... | test.cpp:32:14:32:21 | * ... |
 | test.cpp:51:33:51:35 | end | test.cpp:60:34:60:37 | mk_array output argument |
-| test.cpp:52:19:52:37 | call to malloc | test.cpp:53:5:53:23 | ... = ... |
 | test.cpp:52:19:52:37 | call to malloc | test.cpp:53:12:53:23 | ... + ... |
-| test.cpp:53:5:53:23 | ... = ... | test.cpp:51:33:51:35 | end |
-| test.cpp:53:12:53:23 | ... + ... | test.cpp:53:5:53:23 | ... = ... |
+| test.cpp:53:12:53:23 | ... + ... | test.cpp:51:33:51:35 | end |
 | test.cpp:60:34:60:37 | mk_array output argument | test.cpp:67:9:67:14 | ... = ... |
 | test.cpp:194:15:194:33 | call to malloc | test.cpp:195:17:195:23 | ... + ... |
-| test.cpp:194:15:194:33 | call to malloc | test.cpp:195:17:195:23 | ... + ... |
-| test.cpp:194:15:194:33 | call to malloc | test.cpp:201:5:201:19 | ... = ... |
 | test.cpp:195:17:195:23 | ... + ... | test.cpp:195:17:195:23 | ... + ... |
 | test.cpp:195:17:195:23 | ... + ... | test.cpp:201:5:201:19 | ... = ... |
 | test.cpp:195:17:195:23 | ... + ... | test.cpp:201:5:201:19 | ... = ... |
 | test.cpp:205:15:205:33 | call to malloc | test.cpp:206:17:206:23 | ... + ... |
-| test.cpp:205:15:205:33 | call to malloc | test.cpp:206:17:206:23 | ... + ... |
-| test.cpp:205:15:205:33 | call to malloc | test.cpp:213:5:213:13 | ... = ... |
 | test.cpp:206:17:206:23 | ... + ... | test.cpp:206:17:206:23 | ... + ... |
 | test.cpp:206:17:206:23 | ... + ... | test.cpp:213:5:213:13 | ... = ... |
 | test.cpp:206:17:206:23 | ... + ... | test.cpp:213:5:213:13 | ... = ... |
 | test.cpp:231:18:231:30 | new[] | test.cpp:232:3:232:20 | ... = ... |
 | test.cpp:238:20:238:32 | new[] | test.cpp:239:5:239:22 | ... = ... |
 | test.cpp:260:13:260:24 | new[] | test.cpp:261:14:261:21 | ... + ... |
-| test.cpp:260:13:260:24 | new[] | test.cpp:261:14:261:21 | ... + ... |
-| test.cpp:260:13:260:24 | new[] | test.cpp:264:13:264:14 | * ... |
-| test.cpp:260:13:260:24 | new[] | test.cpp:264:13:264:14 | * ... |
 | test.cpp:261:14:261:21 | ... + ... | test.cpp:261:14:261:21 | ... + ... |
 | test.cpp:261:14:261:21 | ... + ... | test.cpp:264:13:264:14 | * ... |
 | test.cpp:261:14:261:21 | ... + ... | test.cpp:264:13:264:14 | * ... |
@@ -58,107 +41,48 @@ edges
 | test.cpp:264:13:264:14 | * ... | test.cpp:264:13:264:14 | * ... |
 | test.cpp:264:13:264:14 | * ... | test.cpp:264:13:264:14 | * ... |
 | test.cpp:270:13:270:24 | new[] | test.cpp:271:14:271:21 | ... + ... |
-| test.cpp:270:13:270:24 | new[] | test.cpp:271:14:271:21 | ... + ... |
-| test.cpp:270:13:270:24 | new[] | test.cpp:274:5:274:10 | ... = ... |
 | test.cpp:271:14:271:21 | ... + ... | test.cpp:271:14:271:21 | ... + ... |
 | test.cpp:271:14:271:21 | ... + ... | test.cpp:274:5:274:10 | ... = ... |
 | test.cpp:271:14:271:21 | ... + ... | test.cpp:274:5:274:10 | ... = ... |
 | test.cpp:355:14:355:27 | new[] | test.cpp:356:15:356:23 | ... + ... |
-| test.cpp:355:14:355:27 | new[] | test.cpp:356:15:356:23 | ... + ... |
-| test.cpp:355:14:355:27 | new[] | test.cpp:357:24:357:30 | ... + ... |
-| test.cpp:355:14:355:27 | new[] | test.cpp:357:24:357:30 | ... + ... |
-| test.cpp:355:14:355:27 | new[] | test.cpp:358:14:358:26 | end_plus_one indirection |
-| test.cpp:355:14:355:27 | new[] | test.cpp:359:14:359:32 | ... + ... indirection |
 | test.cpp:356:15:356:23 | ... + ... | test.cpp:356:15:356:23 | ... + ... |
 | test.cpp:356:15:356:23 | ... + ... | test.cpp:358:14:358:26 | end_plus_one indirection |
 | test.cpp:356:15:356:23 | ... + ... | test.cpp:358:14:358:26 | end_plus_one indirection |
 | test.cpp:356:15:356:23 | ... + ... | test.cpp:359:14:359:32 | ... + ... indirection |
 | test.cpp:356:15:356:23 | ... + ... | test.cpp:359:14:359:32 | ... + ... indirection |
-| test.cpp:357:24:357:30 | ... + ... | test.cpp:357:24:357:30 | ... + ... |
-| test.cpp:357:24:357:30 | ... + ... | test.cpp:358:14:358:26 | end_plus_one indirection |
-| test.cpp:357:24:357:30 | ... + ... | test.cpp:358:14:358:26 | end_plus_one indirection |
-| test.cpp:357:24:357:30 | ... + ... | test.cpp:359:14:359:32 | ... + ... indirection |
-| test.cpp:357:24:357:30 | ... + ... | test.cpp:359:14:359:32 | ... + ... indirection |
 | test.cpp:377:14:377:27 | new[] | test.cpp:378:15:378:23 | ... + ... |
-| test.cpp:377:14:377:27 | new[] | test.cpp:378:15:378:23 | ... + ... |
-| test.cpp:377:14:377:27 | new[] | test.cpp:381:5:381:9 | ... ++ |
-| test.cpp:377:14:377:27 | new[] | test.cpp:381:5:381:9 | ... ++ |
-| test.cpp:377:14:377:27 | new[] | test.cpp:384:13:384:16 | end indirection |
 | test.cpp:378:15:378:23 | ... + ... | test.cpp:378:15:378:23 | ... + ... |
 | test.cpp:378:15:378:23 | ... + ... | test.cpp:384:13:384:16 | end indirection |
 | test.cpp:378:15:378:23 | ... + ... | test.cpp:384:13:384:16 | end indirection |
-| test.cpp:381:5:381:9 | ... ++ | test.cpp:381:5:381:9 | ... ++ |
-| test.cpp:381:5:381:9 | ... ++ | test.cpp:384:13:384:16 | end indirection |
 | test.cpp:410:14:410:27 | new[] | test.cpp:411:15:411:23 | & ... |
-| test.cpp:410:14:410:27 | new[] | test.cpp:411:15:411:23 | & ... |
-| test.cpp:410:14:410:27 | new[] | test.cpp:413:5:413:8 | ... ++ |
-| test.cpp:410:14:410:27 | new[] | test.cpp:413:5:413:8 | ... ++ |
 | test.cpp:410:14:410:27 | new[] | test.cpp:415:7:415:15 | ... = ... |
 | test.cpp:411:15:411:23 | & ... | test.cpp:411:15:411:23 | & ... |
 | test.cpp:411:15:411:23 | & ... | test.cpp:415:7:415:15 | ... = ... |
 | test.cpp:411:15:411:23 | & ... | test.cpp:415:7:415:15 | ... = ... |
-| test.cpp:413:5:413:8 | ... ++ | test.cpp:413:5:413:8 | ... ++ |
-| test.cpp:413:5:413:8 | ... ++ | test.cpp:415:7:415:15 | ... = ... |
-| test.cpp:413:5:413:8 | ... ++ | test.cpp:415:7:415:15 | ... = ... |
 | test.cpp:421:14:421:27 | new[] | test.cpp:422:15:422:23 | & ... |
-| test.cpp:421:14:421:27 | new[] | test.cpp:422:15:422:23 | & ... |
-| test.cpp:421:14:421:27 | new[] | test.cpp:424:5:424:8 | ... ++ |
-| test.cpp:421:14:421:27 | new[] | test.cpp:424:5:424:8 | ... ++ |
 | test.cpp:421:14:421:27 | new[] | test.cpp:426:7:426:15 | ... = ... |
 | test.cpp:422:15:422:23 | & ... | test.cpp:422:15:422:23 | & ... |
 | test.cpp:422:15:422:23 | & ... | test.cpp:426:7:426:15 | ... = ... |
 | test.cpp:422:15:422:23 | & ... | test.cpp:426:7:426:15 | ... = ... |
-| test.cpp:424:5:424:8 | ... ++ | test.cpp:424:5:424:8 | ... ++ |
-| test.cpp:424:5:424:8 | ... ++ | test.cpp:426:7:426:15 | ... = ... |
-| test.cpp:424:5:424:8 | ... ++ | test.cpp:426:7:426:15 | ... = ... |
 | test.cpp:432:14:432:27 | new[] | test.cpp:433:15:433:23 | & ... |
-| test.cpp:432:14:432:27 | new[] | test.cpp:433:15:433:23 | & ... |
-| test.cpp:432:14:432:27 | new[] | test.cpp:436:5:436:8 | ... ++ |
-| test.cpp:432:14:432:27 | new[] | test.cpp:436:5:436:8 | ... ++ |
 | test.cpp:432:14:432:27 | new[] | test.cpp:438:7:438:15 | ... = ... |
 | test.cpp:433:15:433:23 | & ... | test.cpp:433:15:433:23 | & ... |
 | test.cpp:433:15:433:23 | & ... | test.cpp:438:7:438:15 | ... = ... |
 | test.cpp:433:15:433:23 | & ... | test.cpp:438:7:438:15 | ... = ... |
-| test.cpp:436:5:436:8 | ... ++ | test.cpp:436:5:436:8 | ... ++ |
-| test.cpp:436:5:436:8 | ... ++ | test.cpp:438:7:438:15 | ... = ... |
-| test.cpp:436:5:436:8 | ... ++ | test.cpp:438:7:438:15 | ... = ... |
 | test.cpp:444:14:444:27 | new[] | test.cpp:445:15:445:23 | & ... |
-| test.cpp:444:14:444:27 | new[] | test.cpp:445:15:445:23 | & ... |
-| test.cpp:444:14:444:27 | new[] | test.cpp:448:5:448:8 | ... ++ |
-| test.cpp:444:14:444:27 | new[] | test.cpp:448:5:448:8 | ... ++ |
 | test.cpp:444:14:444:27 | new[] | test.cpp:450:7:450:15 | ... = ... |
 | test.cpp:445:15:445:23 | & ... | test.cpp:445:15:445:23 | & ... |
 | test.cpp:445:15:445:23 | & ... | test.cpp:450:7:450:15 | ... = ... |
 | test.cpp:445:15:445:23 | & ... | test.cpp:450:7:450:15 | ... = ... |
-| test.cpp:448:5:448:8 | ... ++ | test.cpp:448:5:448:8 | ... ++ |
-| test.cpp:448:5:448:8 | ... ++ | test.cpp:450:7:450:15 | ... = ... |
-| test.cpp:448:5:448:8 | ... ++ | test.cpp:450:7:450:15 | ... = ... |
 | test.cpp:480:14:480:27 | new[] | test.cpp:481:15:481:23 | & ... |
-| test.cpp:480:14:480:27 | new[] | test.cpp:481:15:481:23 | & ... |
-| test.cpp:480:14:480:27 | new[] | test.cpp:484:5:484:8 | ... ++ |
-| test.cpp:480:14:480:27 | new[] | test.cpp:484:5:484:8 | ... ++ |
 | test.cpp:480:14:480:27 | new[] | test.cpp:486:7:486:15 | ... = ... |
 | test.cpp:481:15:481:23 | & ... | test.cpp:481:15:481:23 | & ... |
 | test.cpp:481:15:481:23 | & ... | test.cpp:486:7:486:15 | ... = ... |
 | test.cpp:481:15:481:23 | & ... | test.cpp:486:7:486:15 | ... = ... |
-| test.cpp:484:5:484:8 | ... ++ | test.cpp:484:5:484:8 | ... ++ |
-| test.cpp:484:5:484:8 | ... ++ | test.cpp:486:7:486:15 | ... = ... |
-| test.cpp:484:5:484:8 | ... ++ | test.cpp:486:7:486:15 | ... = ... |
 | test.cpp:543:14:543:27 | new[] | test.cpp:548:5:548:19 | ... = ... |
 | test.cpp:554:14:554:27 | new[] | test.cpp:559:5:559:19 | ... = ... |
 | test.cpp:642:14:642:31 | new[] | test.cpp:647:5:647:19 | ... = ... |
-| test.cpp:695:13:695:26 | new[] | test.cpp:698:5:698:10 | ... += ... |
-| test.cpp:695:13:695:26 | new[] | test.cpp:698:5:698:10 | ... += ... |
-| test.cpp:698:5:698:10 | ... += ... | test.cpp:698:5:698:10 | ... += ... |
-| test.cpp:698:5:698:10 | ... += ... | test.cpp:701:15:701:16 | p indirection |
-| test.cpp:705:18:705:18 | q | test.cpp:705:18:705:18 | q |
-| test.cpp:705:18:705:18 | q | test.cpp:706:12:706:13 | * ... |
-| test.cpp:705:18:705:18 | q | test.cpp:706:12:706:13 | * ... |
-| test.cpp:711:13:711:26 | new[] | test.cpp:714:11:714:11 | q |
-| test.cpp:714:11:714:11 | q | test.cpp:705:18:705:18 | q |
 | test.cpp:730:12:730:28 | new[] | test.cpp:732:16:732:26 | ... + ... |
-| test.cpp:730:12:730:28 | new[] | test.cpp:732:16:732:26 | ... + ... |
-| test.cpp:730:12:730:28 | new[] | test.cpp:733:5:733:12 | ... = ... |
 | test.cpp:732:16:732:26 | ... + ... | test.cpp:732:16:732:26 | ... + ... |
 | test.cpp:732:16:732:26 | ... + ... | test.cpp:733:5:733:12 | ... = ... |
 | test.cpp:732:16:732:26 | ... + ... | test.cpp:733:5:733:12 | ... = ... |
@@ -169,10 +93,8 @@ edges
 | test.cpp:781:14:781:27 | new[] | test.cpp:786:18:786:27 | access to array |
 | test.cpp:792:60:792:62 | end | test.cpp:800:40:800:43 | mk_array_no_field_flow output argument |
 | test.cpp:792:60:792:62 | end | test.cpp:832:40:832:43 | mk_array_no_field_flow output argument |
-| test.cpp:793:14:793:32 | call to malloc | test.cpp:794:5:794:24 | ... = ... |
 | test.cpp:793:14:793:32 | call to malloc | test.cpp:794:12:794:24 | ... + ... |
-| test.cpp:794:5:794:24 | ... = ... | test.cpp:792:60:792:62 | end |
-| test.cpp:794:12:794:24 | ... + ... | test.cpp:794:5:794:24 | ... = ... |
+| test.cpp:794:12:794:24 | ... + ... | test.cpp:792:60:792:62 | end |
 | test.cpp:800:40:800:43 | mk_array_no_field_flow output argument | test.cpp:807:7:807:12 | ... = ... |
 | test.cpp:815:52:815:54 | end | test.cpp:815:52:815:54 | end |
 | test.cpp:815:52:815:54 | end | test.cpp:821:7:821:12 | ... = ... |
@@ -182,8 +104,6 @@ edges
 | test.cpp:841:18:841:35 | call to malloc | test.cpp:842:3:842:20 | ... = ... |
 | test.cpp:848:20:848:37 | call to malloc | test.cpp:849:5:849:22 | ... = ... |
 | test.cpp:856:12:856:35 | call to malloc | test.cpp:857:16:857:29 | ... + ... |
-| test.cpp:856:12:856:35 | call to malloc | test.cpp:857:16:857:29 | ... + ... |
-| test.cpp:856:12:856:35 | call to malloc | test.cpp:860:5:860:11 | ... = ... |
 | test.cpp:857:16:857:29 | ... + ... | test.cpp:857:16:857:29 | ... + ... |
 | test.cpp:857:16:857:29 | ... + ... | test.cpp:860:5:860:11 | ... = ... |
 | test.cpp:857:16:857:29 | ... + ... | test.cpp:860:5:860:11 | ... = ... |
@@ -204,7 +124,6 @@ nodes
 | test.cpp:32:14:32:21 | * ... | semmle.label | * ... |
 | test.cpp:51:33:51:35 | end | semmle.label | end |
 | test.cpp:52:19:52:37 | call to malloc | semmle.label | call to malloc |
-| test.cpp:53:5:53:23 | ... = ... | semmle.label | ... = ... |
 | test.cpp:53:12:53:23 | ... + ... | semmle.label | ... + ... |
 | test.cpp:60:34:60:37 | mk_array output argument | semmle.label | mk_array output argument |
 | test.cpp:67:9:67:14 | ... = ... | semmle.label | ... = ... |
@@ -232,45 +151,31 @@ nodes
 | test.cpp:355:14:355:27 | new[] | semmle.label | new[] |
 | test.cpp:356:15:356:23 | ... + ... | semmle.label | ... + ... |
 | test.cpp:356:15:356:23 | ... + ... | semmle.label | ... + ... |
-| test.cpp:357:24:357:30 | ... + ... | semmle.label | ... + ... |
-| test.cpp:357:24:357:30 | ... + ... | semmle.label | ... + ... |
 | test.cpp:358:14:358:26 | end_plus_one indirection | semmle.label | end_plus_one indirection |
 | test.cpp:359:14:359:32 | ... + ... indirection | semmle.label | ... + ... indirection |
 | test.cpp:377:14:377:27 | new[] | semmle.label | new[] |
 | test.cpp:378:15:378:23 | ... + ... | semmle.label | ... + ... |
 | test.cpp:378:15:378:23 | ... + ... | semmle.label | ... + ... |
-| test.cpp:381:5:381:9 | ... ++ | semmle.label | ... ++ |
-| test.cpp:381:5:381:9 | ... ++ | semmle.label | ... ++ |
 | test.cpp:384:13:384:16 | end indirection | semmle.label | end indirection |
 | test.cpp:410:14:410:27 | new[] | semmle.label | new[] |
 | test.cpp:411:15:411:23 | & ... | semmle.label | & ... |
 | test.cpp:411:15:411:23 | & ... | semmle.label | & ... |
-| test.cpp:413:5:413:8 | ... ++ | semmle.label | ... ++ |
-| test.cpp:413:5:413:8 | ... ++ | semmle.label | ... ++ |
 | test.cpp:415:7:415:15 | ... = ... | semmle.label | ... = ... |
 | test.cpp:421:14:421:27 | new[] | semmle.label | new[] |
 | test.cpp:422:15:422:23 | & ... | semmle.label | & ... |
 | test.cpp:422:15:422:23 | & ... | semmle.label | & ... |
-| test.cpp:424:5:424:8 | ... ++ | semmle.label | ... ++ |
-| test.cpp:424:5:424:8 | ... ++ | semmle.label | ... ++ |
 | test.cpp:426:7:426:15 | ... = ... | semmle.label | ... = ... |
 | test.cpp:432:14:432:27 | new[] | semmle.label | new[] |
 | test.cpp:433:15:433:23 | & ... | semmle.label | & ... |
 | test.cpp:433:15:433:23 | & ... | semmle.label | & ... |
-| test.cpp:436:5:436:8 | ... ++ | semmle.label | ... ++ |
-| test.cpp:436:5:436:8 | ... ++ | semmle.label | ... ++ |
 | test.cpp:438:7:438:15 | ... = ... | semmle.label | ... = ... |
 | test.cpp:444:14:444:27 | new[] | semmle.label | new[] |
 | test.cpp:445:15:445:23 | & ... | semmle.label | & ... |
 | test.cpp:445:15:445:23 | & ... | semmle.label | & ... |
-| test.cpp:448:5:448:8 | ... ++ | semmle.label | ... ++ |
-| test.cpp:448:5:448:8 | ... ++ | semmle.label | ... ++ |
 | test.cpp:450:7:450:15 | ... = ... | semmle.label | ... = ... |
 | test.cpp:480:14:480:27 | new[] | semmle.label | new[] |
 | test.cpp:481:15:481:23 | & ... | semmle.label | & ... |
 | test.cpp:481:15:481:23 | & ... | semmle.label | & ... |
-| test.cpp:484:5:484:8 | ... ++ | semmle.label | ... ++ |
-| test.cpp:484:5:484:8 | ... ++ | semmle.label | ... ++ |
 | test.cpp:486:7:486:15 | ... = ... | semmle.label | ... = ... |
 | test.cpp:543:14:543:27 | new[] | semmle.label | new[] |
 | test.cpp:548:5:548:19 | ... = ... | semmle.label | ... = ... |
@@ -278,15 +183,6 @@ nodes
 | test.cpp:559:5:559:19 | ... = ... | semmle.label | ... = ... |
 | test.cpp:642:14:642:31 | new[] | semmle.label | new[] |
 | test.cpp:647:5:647:19 | ... = ... | semmle.label | ... = ... |
-| test.cpp:695:13:695:26 | new[] | semmle.label | new[] |
-| test.cpp:698:5:698:10 | ... += ... | semmle.label | ... += ... |
-| test.cpp:698:5:698:10 | ... += ... | semmle.label | ... += ... |
-| test.cpp:701:15:701:16 | p indirection | semmle.label | p indirection |
-| test.cpp:705:18:705:18 | q | semmle.label | q |
-| test.cpp:705:18:705:18 | q | semmle.label | q |
-| test.cpp:706:12:706:13 | * ... | semmle.label | * ... |
-| test.cpp:711:13:711:26 | new[] | semmle.label | new[] |
-| test.cpp:714:11:714:11 | q | semmle.label | q |
 | test.cpp:730:12:730:28 | new[] | semmle.label | new[] |
 | test.cpp:732:16:732:26 | ... + ... | semmle.label | ... + ... |
 | test.cpp:732:16:732:26 | ... + ... | semmle.label | ... + ... |
@@ -300,7 +196,6 @@ nodes
 | test.cpp:786:18:786:27 | access to array | semmle.label | access to array |
 | test.cpp:792:60:792:62 | end | semmle.label | end |
 | test.cpp:793:14:793:32 | call to malloc | semmle.label | call to malloc |
-| test.cpp:794:5:794:24 | ... = ... | semmle.label | ... = ... |
 | test.cpp:794:12:794:24 | ... + ... | semmle.label | ... + ... |
 | test.cpp:800:40:800:43 | mk_array_no_field_flow output argument | semmle.label | mk_array_no_field_flow output argument |
 | test.cpp:807:7:807:12 | ... = ... | semmle.label | ... = ... |
@@ -342,8 +237,6 @@ subpaths
 | test.cpp:548:5:548:19 | ... = ... | test.cpp:543:14:543:27 | new[] | test.cpp:548:5:548:19 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:543:14:543:27 | new[] | new[] | test.cpp:548:8:548:14 | src_pos | src_pos |
 | test.cpp:559:5:559:19 | ... = ... | test.cpp:554:14:554:27 | new[] | test.cpp:559:5:559:19 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:554:14:554:27 | new[] | new[] | test.cpp:559:8:559:14 | src_pos | src_pos |
 | test.cpp:647:5:647:19 | ... = ... | test.cpp:642:14:642:31 | new[] | test.cpp:647:5:647:19 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:642:14:642:31 | new[] | new[] | test.cpp:647:8:647:14 | src_pos | src_pos |
-| test.cpp:701:15:701:16 | p indirection | test.cpp:695:13:695:26 | new[] | test.cpp:701:15:701:16 | p indirection | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:695:13:695:26 | new[] | new[] | test.cpp:696:19:696:22 | size | size |
-| test.cpp:706:12:706:13 | * ... | test.cpp:711:13:711:26 | new[] | test.cpp:706:12:706:13 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:711:13:711:26 | new[] | new[] | test.cpp:712:19:712:22 | size | size |
 | test.cpp:733:5:733:12 | ... = ... | test.cpp:730:12:730:28 | new[] | test.cpp:733:5:733:12 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:730:12:730:28 | new[] | new[] | test.cpp:732:21:732:25 | ... + ... | ... + ... |
 | test.cpp:767:16:767:29 | access to array | test.cpp:754:18:754:31 | new[] | test.cpp:767:16:767:29 | access to array | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:754:18:754:31 | new[] | new[] | test.cpp:767:22:767:28 | ... + ... | ... + ... |
 | test.cpp:767:16:767:29 | access to array | test.cpp:754:18:754:31 | new[] | test.cpp:767:16:767:29 | access to array | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:754:18:754:31 | new[] | new[] | test.cpp:772:22:772:28 | ... + ... | ... + ... |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-193/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-193/test.cpp
@@ -3,9 +3,9 @@ using size_t = decltype(sizeof 0); void* malloc(size_t size);
 void test1(int size) {
     char* p = (char*)malloc(size);
     char* q = p + size; // $ alloc=L4
-    char a = *q; // $ deref=L6 // BAD
+    char a = *q; // $ deref=L5->L6 // BAD
     char b = *(q - 1); // GOOD
-    char c = *(q + 1); // $ deref=L8+1 // BAD
+    char c = *(q + 1); // $ deref=L5->L8+1 // BAD
     char d = *(q + size); // BAD [NOT DETECTED]
     char e = *(q - size); // GOOD
     char f = *(q + size + 1); // BAD [NOT DETECTED]
@@ -17,7 +17,7 @@ void test2(int size) {
     char* q = p + size - 1; // $ alloc=L16
     char a = *q; // GOOD
     char b = *(q - 1); // GOOD
-    char c = *(q + 1); // $ deref=L20 // BAD
+    char c = *(q + 1); // $ deref=L17->L20 // BAD
     char d = *(q + size); // BAD [NOT DETECTED]
     char e = *(q - size); // GOOD
     char f = *(q + size + 1); // BAD [NOT DETECTED]
@@ -27,9 +27,9 @@ void test2(int size) {
 void test3(int size) {
     char* p = (char*)malloc(size + 1);
     char* q = p + (size + 1); // $ alloc=L28+1
-    char a = *q; // $ deref=L30 // BAD
+    char a = *q; // $ deref=L29->L30 // BAD
     char b = *(q - 1); // GOOD
-    char c = *(q + 1); // $ deref=L32+1 // BAD
+    char c = *(q + 1); // $ deref=L29->L32+1 // BAD
     char d = *(q + size); // BAD [NOT DETECTED]
     char e = *(q - size); // GOOD
     char f = *(q + size + 1); // BAD [NOT DETECTED]
@@ -198,7 +198,7 @@ void test12(unsigned len, unsigned index) {
         return;
     }
     
-    p[index] = '\0'; // $ deref=L201 // BAD
+    p[index] = '\0'; // $ deref=L195->L201 // BAD
 }
 
 void test13(unsigned len, unsigned index) {
@@ -210,7 +210,7 @@ void test13(unsigned len, unsigned index) {
         return;
     }
     
-    *q = '\0'; // $ deref=L213 // BAD
+    *q = '\0'; // $ deref=L206->L213 // BAD
 }
 
 bool unknown();
@@ -261,7 +261,7 @@ void test17(unsigned len)
   int *end = xs + len; // $ alloc=L260
   for (int *x = xs; x <= end; x++)
   {
-    int i = *x; // $ deref=L264 // BAD
+    int i = *x; // $ deref=L261->L264 // BAD
   }
 }
 
@@ -271,7 +271,7 @@ void test18(unsigned len)
   int *end = xs + len; // $ alloc=L270
   for (int *x = xs; x <= end; x++)
   {
-    *x = 0; // $ deref=L274 // BAD
+    *x = 0; // $ deref=L271->L274 // BAD
   }
 }
 
@@ -355,8 +355,8 @@ void test25(unsigned size) {
   char *xs = new char[size];
   char *end = xs + size; // $ alloc=L355
   char *end_plus_one = end + 1;
-  int val1 = *end_plus_one; // $ deref=L358+1 // BAD
-  int val2 = *(end_plus_one + 1); // $ deref=L359+2 // BAD
+  int val1 = *end_plus_one; // $ deref=L356->L358+1 // BAD
+  int val2 = *(end_plus_one + 1); // $ deref=L356->L359+2 // BAD
 }
 
 void test26(unsigned size) {
@@ -381,7 +381,7 @@ void test27(unsigned size, bool b) {
     end++;
   }
 
-  int val = *end; // $ deref=L384+1 // BAD
+  int val = *end; // $ deref=L378->L384+1 // BAD
 }
 
 void test28(unsigned size) {
@@ -412,7 +412,7 @@ void test28_simple2(unsigned size) {
   if (xs < end) {
     xs++;
     if (xs < end + 1) {
-      xs[0] = 0; // $ deref=L415 // BAD
+      xs[0] = 0; // $ deref=L411->L415 // BAD
     }
   }
 }
@@ -423,7 +423,7 @@ void test28_simple3(unsigned size) {
   if (xs < end) {
     xs++;
     if (xs - 1 < end) {
-      xs[0] = 0; // $ deref=L426 // BAD
+      xs[0] = 0; // $ deref=L422->L426 // BAD
     }
   }
 }
@@ -435,7 +435,7 @@ void test28_simple4(unsigned size) {
     end++;
     xs++;
     if (xs < end) {
-      xs[0] = 0; // $ deref=L438 // BAD
+      xs[0] = 0; // $ deref=L433->L438 // BAD
     }
   }
 }
@@ -447,7 +447,7 @@ void test28_simple5(unsigned size) {
   if (xs < end) {
     xs++;
     if (xs < end) {
-      xs[0] = 0; // $ deref=L450 // BAD
+      xs[0] = 0; // $ deref=L445->L450 // BAD
     }
   }
 }
@@ -483,7 +483,7 @@ void test28_simple8(unsigned size) {
   if (xs < end) {
     xs++;
     if (xs < end - 1) {
-      xs[0] = 0; // $ deref=L486+498 // BAD
+      xs[0] = 0; // $ deref=L481->L486+498 // BAD
     }
   }
 }
@@ -698,12 +698,12 @@ void test34(unsigned size) {
     p += 1;
   }
   if (p + 1 < end) {
-    int val = *p; // $ deref=L698->L700->L701 // GOOD [FALSE POSITIVE]
+    int val = *p; // GOOD
   }
 }
 
 void deref(char* q) {
-  char x = *q; // $ deref=L714->L705->L706 // BAD
+  char x = *q; // $ MISSING: deref=L714->L705->L706 // BAD [NOT DETECTED]
 }
 
 void test35(size_t size, char* q)
@@ -730,7 +730,7 @@ void test36(unsigned size, unsigned n) {
   int* p = new int[size + 2];
   if(n < size + 1) {
     int* end = p + (n + 2); // $ alloc=L730+2
-    *end = 0; // $ deref=L733 // BAD
+    *end = 0; // $ deref=L732->L733 // BAD
   }
 }
 
@@ -857,6 +857,6 @@ void test_regression(size_t size) {
   int* chend = p + (size + 1); // $ alloc=L856+1
 
   if(p <= chend) {
-    *p = 42; // $ deref=L860 // BAD
+    *p = 42; // $ deref=L857->L860 // BAD
   }
 }


### PR DESCRIPTION
This is quite a nice simplification of `cpp/invalid-pointer-deref`. The only actual change is in https://github.com/github/codeql/commit/c8edf3151b90515d36a82fb1453425990c002ade#diff-fae29bfae3f7ffbf1c40e3b1e68cec1869e8757d7461d85382914f9c74b69699, and the remaining code just:
- Accepts the test changes
- Simplify the surrounding code now that `deltaDerefSourceAndPai` is always 0
- Updates the documentation

This removes a nasty FP (which is awesome) at the cost of removing a synthetic TP we added in https://github.com/github/codeql/pull/13815. I think this is a worthwhile change (and I'll run a difference query on MRVA to see the impact of this).