### PR TITLE
Python: Add AWS Lambda as a supported framework

### DIFF
--- a/docs/codeql/reusables/supported-frameworks.rst
+++ b/docs/codeql/reusables/supported-frameworks.rst
@@ -191,6 +191,7 @@ and the CodeQL library pack ``codeql/python-all`` (`changelog <https://github.co
    :widths: auto
 
    Name, Category
+   AWS Lambda, Web framework
    aiohttp.web, Web framework
    Django, Web framework
    djangorestframework, Web framework


### PR DESCRIPTION
After https://github.com/github/codeql/pull/13729 was merged, we can probably claim support for AWS Lambda. Let me know if you think otherwise.