### PR TITLE
C#: Use `project.assets.json` for package dependencies.

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/AssemblyCache.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/AssemblyCache.cs
@@ -27,11 +27,17 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 if (File.Exists(path))
                 {
                     pendingDllsToIndex.Enqueue(path);
+                    continue;
                 }
-                else
+
+                if (Directory.Exists(path))
                 {
                     progressMonitor.FindingFiles(path);
                     AddReferenceDirectory(path);
+                }
+                else
+                {
+                    progressMonitor.LogInfo("AssemblyCache: Path not found: " + path);
                 }
             }
             IndexReferences();

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/Assets.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/Assets.cs
@@ -159,6 +159,16 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 return false;
             }
         }
+
+        public static IEnumerable<string> GetCompilationDependencies(ProgressMonitor progressMonitor, IEnumerable<string> assets)
+        {
+            var parser = new Assets(progressMonitor);
+            return assets.SelectMany(asset =>
+            {
+                var json = File.ReadAllText(asset);
+                return parser.TryParse(json, out var dependencies) ? dependencies : Array.Empty<string>();
+            });
+        }
     }
 
     internal static class JsonExtensions

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/Assets.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/Assets.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace Semmle.Extraction.CSharp.DependencyFetching
+{
+    /// <summary>
+    /// Class for parsing project.assets.json files.
+    /// </summary>
+    internal class Assets
+    {
+        private readonly ProgressMonitor progressMonitor;
+
+        private static readonly string[] netFrameworks = new[] {
+            "microsoft.aspnetcore.app.ref",
+            "microsoft.netcore.app.ref",
+            "microsoft.netframework.referenceassemblies",
+            "microsoft.windowsdesktop.app.ref",
+            "netstandard.library.ref"
+        };
+
+
+        internal Assets(ProgressMonitor progressMonitor)
+        {
+            this.progressMonitor = progressMonitor;
+        }
+
+        /// <summary>
+        /// In most cases paths in asset files point to dll's or the empty _._ file, which
+        /// is sometimes there to avoid the directory being empty.
+        /// That is, if the path specifically adds a .dll we use that, otherwise we as a fallback
+        /// add the entire directory (which should be fine in case of _._ as well).
+        /// </summary>
+        private static string ParseFilePath(string path)
+        {
+            if (path.EndsWith(".dll"))
+            {
+                return path;
+            }
+            return Path.GetDirectoryName(path) ?? path;
+        }
+
+        /// <summary>
+        /// Class needed for deserializing parts of an assets file.
+        /// It holds information about a reference.
+        /// </summary>
+        private class ReferenceInfo
+        {
+            /// <summary>
+            /// This carries the type of the reference.
+            /// We are only interested in package references.
+            /// </summary>
+            public string Type { get; set; } = "";
+
+            /// <summary>
+            /// If not a .NET framework reference we assume that only the files mentioned
+            /// in the compile section are needed for compilation.
+            /// </summary>
+            public Dictionary<string, object> Compile { get; set; } = new();
+        }
+
+        /// <summary>
+        /// Gets the package dependencies from the assets file.
+        /// 
+        /// Parse a part of the JSon assets file and returns the paths
+        /// to the dependencies required for compilation.
+        ///
+        /// Example:
+        /// {
+        ///   "Castle.Core/4.4.1": {
+        ///     "type": "package",
+        ///     "compile": {
+        ///       "lib/netstandard1.5/Castle.Core.dll": {
+        ///         "related": ".xml"
+        ///        }
+        ///     }
+        ///   },
+        ///   "Json.Net/1.0.33": {
+        ///     "type": "package",
+        ///     "compile": {
+        ///       "lib/netstandard2.0/Json.Net.dll": {}
+        ///     },
+        ///     "runtime": {
+        ///       "lib/netstandard2.0/Json.Net.dll": {}
+        ///     }
+        ///   }
+        /// }
+        /// 
+        /// Returns {
+        ///   "castle.core/4.4.1/lib/netstandard1.5/Castle.Core.dll",
+        ///   "json.net/1.0.33/lib/netstandard2.0/Json.Net.dll"
+        /// }
+        /// </summary>
+        private IEnumerable<string> GetPackageDependencies(JObject json)
+        {
+            // If there are more than one framework we need to pick just one.
+            // To ensure stability we pick one based on the lexicographic order of
+            // the framework names.
+            var references = json
+                .GetProperty("targets")?
+                .Properties()?
+                .MaxBy(p => p.Name)?
+                .Value
+                .ToObject<Dictionary<string, ReferenceInfo>>();
+
+            if (references is null)
+            {
+                progressMonitor.LogDebug("No references found in the targets section in the assets file.");
+                return Array.Empty<string>();
+            }
+
+            // Find all the compile dependencies for each reference and
+            // create the relative path to the dependency.
+            var dependencies = references
+                .SelectMany(r =>
+                {
+                    var info = r.Value;
+                    var name = r.Key.ToLowerInvariant();
+                    if (info.Type != "package")
+                    {
+                        return Array.Empty<string>();
+                    }
+
+                    // If this is a .NET framework reference then include everything.
+                    return netFrameworks.Any(framework => name.StartsWith(framework))
+                        ? new[] { name }
+                        : info
+                            .Compile
+                            .Select(p => Path.Combine(name, ParseFilePath(p.Key)));
+                })
+                .ToList();
+
+            return dependencies;
+        }
+
+        /// <summary>
+        /// Parse `json` as project.assets.json content and populate `dependencies` with the
+        /// relative paths to the dependencies required for compilation.
+        /// </summary>
+        /// <returns>True if parsing succeeds, otherwise false.</returns>
+        public bool TryParse(string json, out IEnumerable<string> dependencies)
+        {
+            dependencies = Array.Empty<string>();
+
+            try
+            {
+                var obj = JObject.Parse(json);
+                var packages = GetPackageDependencies(obj);
+
+                dependencies = packages.ToList();
+
+                return true;
+            }
+            catch (Exception e)
+            {
+                progressMonitor.LogDebug($"Failed to parse assets file (unexpected error): {e.Message}");
+                return false;
+            }
+        }
+    }
+
+    internal static class JsonExtensions
+    {
+        internal static JObject? GetProperty(this JObject json, string property) =>
+            json[property] as JObject;
+    }
+}

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/Dependencies.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/Dependencies.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Semmle.Extraction.CSharp.DependencyFetching
+{
+    /// <summary>
+    /// Container class for dependencies found in the assets file.
+    /// </summary>
+    internal class Dependencies
+    {
+        private readonly List<string> required = new();
+        private readonly HashSet<string> usedPackages = new();
+
+        /// <summary>
+        /// In most cases paths in asset files point to dll's or the empty _._ file, which
+        /// is sometimes there to avoid the directory being empty.
+        /// That is, if the path specifically adds a .dll we use that, otherwise we as a fallback
+        /// add the entire directory (which should be fine in case of _._ as well).
+        /// </summary>
+        private static string ParseFilePath(string path)
+        {
+            if (path.EndsWith(".dll"))
+            {
+                return path;
+            }
+            return Path.GetDirectoryName(path) ?? path;
+        }
+
+        private static string GetPackageName(string package) =>
+            package
+                .Split("/")
+                .First();
+
+        /// <summary>
+        /// Dependencies required for Compilation.
+        /// </summary>
+        public IEnumerable<string> Required => required;
+
+        /// <summary>
+        /// Packages that are used as a part of the required dependencies.
+        /// </summary>
+        public IEnumerable<string> UsedPackages => usedPackages;
+
+        /// <summary>
+        /// Add a dependency inside a package.
+        /// </summary>
+        public Dependencies Add(string package, string dependency)
+        {
+            var path = Path.Combine(package, ParseFilePath(dependency));
+            required.Add(path);
+            usedPackages.Add(GetPackageName(package));
+            return this;
+        }
+
+        /// <summary>
+        /// Add a dependency to an entire package
+        /// </summary>
+        public Dependencies Add(string package)
+        {
+            required.Add(package);
+            usedPackages.Add(GetPackageName(package));
+            return this;
+        }
+    }
+}

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/Dependencies.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/Dependencies.cs
@@ -40,7 +40,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         /// <summary>
         /// Packages that are used as a part of the required dependencies.
         /// </summary>
-        public IEnumerable<string> UsedPackages => usedPackages;
+        public HashSet<string> UsedPackages => usedPackages;
 
         /// <summary>
         /// Add a dependency inside a package.

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/Dependencies.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/Dependencies.cs
@@ -29,7 +29,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
         private static string GetPackageName(string package) =>
             package
-                .Split("/")
+                .Split(Path.DirectorySeparatorChar)
                 .First();
 
         /// <summary>
@@ -47,9 +47,13 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         /// </summary>
         public Dependencies Add(string package, string dependency)
         {
-            var path = Path.Combine(package, ParseFilePath(dependency));
+            var p = package.Replace('/', Path.DirectorySeparatorChar);
+            var d = dependency.Replace('/', Path.DirectorySeparatorChar);
+
+            var path = Path.Combine(p, ParseFilePath(d));
             required.Add(path);
-            usedPackages.Add(GetPackageName(package));
+            usedPackages.Add(GetPackageName(p));
+
             return this;
         }
 
@@ -58,8 +62,11 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         /// </summary>
         public Dependencies Add(string package)
         {
-            required.Add(package);
-            usedPackages.Add(GetPackageName(package));
+            var p = package.Replace('/', Path.DirectorySeparatorChar);
+
+            required.Add(p);
+            usedPackages.Add(GetPackageName(p));
+
             return this;
         }
     }

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyContainer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyContainer.cs
@@ -7,9 +7,9 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
     /// <summary>
     /// Container class for dependencies found in the assets file.
     /// </summary>
-    internal class Dependencies
+    internal class DependencyContainer
     {
-        private readonly List<string> required = new();
+        private readonly List<string> requiredPaths = new();
         private readonly HashSet<string> usedPackages = new();
 
         /// <summary>
@@ -33,9 +33,9 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 .First();
 
         /// <summary>
-        /// Dependencies required for Compilation.
+        /// Paths to dependencies required for compilation.
         /// </summary>
-        public IEnumerable<string> Required => required;
+        public IEnumerable<string> RequiredPaths => requiredPaths;
 
         /// <summary>
         /// Packages that are used as a part of the required dependencies.
@@ -45,29 +45,25 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         /// <summary>
         /// Add a dependency inside a package.
         /// </summary>
-        public Dependencies Add(string package, string dependency)
+        public void Add(string package, string dependency)
         {
             var p = package.Replace('/', Path.DirectorySeparatorChar);
             var d = dependency.Replace('/', Path.DirectorySeparatorChar);
 
             var path = Path.Combine(p, ParseFilePath(d));
-            required.Add(path);
+            requiredPaths.Add(path);
             usedPackages.Add(GetPackageName(p));
-
-            return this;
         }
 
         /// <summary>
         /// Add a dependency to an entire package
         /// </summary>
-        public Dependencies Add(string package)
+        public void Add(string package)
         {
             var p = package.Replace('/', Path.DirectorySeparatorChar);
 
-            required.Add(p);
+            requiredPaths.Add(p);
             usedPackages.Add(GetPackageName(p));
-
-            return this;
         }
     }
 }

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
@@ -104,8 +104,11 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 var dependencies = Assets.GetCompilationDependencies(progressMonitor, assets1.Union(assets2));
 
                 var paths = dependencies
+                    .Required
                     .Select(d => Path.Combine(packageDirectory.DirInfo.FullName, d))
                     .ToList();
+
+                // TODO: Log all packages that are not used as a dependency.
 
                 dllPaths.AddRange(paths);
                 DownloadMissingPackages(allNonBinaryFiles, dllPaths);

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
@@ -116,7 +116,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             if (options.ScanNetFrameworkDlls)
             {
                 AddNetFrameworkDlls(dllPaths);
-                AddAspNetFrameworkDlls(dllPaths);
+                AddAspNetCoreFrameworkDlls(dllPaths);
                 AddMicrosoftWindowsDesktopDlls(dllPaths);
             }
 
@@ -247,14 +247,14 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             dllPaths.Add(runtimeLocation);
         }
 
-        private void AddAspNetFrameworkDlls(List<string> dllPaths)
+        private void AddAspNetCoreFrameworkDlls(List<string> dllPaths)
         {
             if (!fileContent.IsNewProjectStructureUsed || !fileContent.UseAspNetCoreDlls)
             {
                 return;
             }
 
-            // First try to find ASP.NET assemblies in the NuGet packages
+            // First try to find ASP.NET Core assemblies in the NuGet packages
             if (GetPackageDirectory("microsoft.aspnetcore.app.ref") is string aspNetCorePackage)
             {
                 progressMonitor.LogInfo($"Found ASP.NET Core in NuGet packages. Not adding installation directory.");
@@ -678,27 +678,25 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             });
         }
 
-        public void Dispose()
+        public void Dispose(TemporaryDirectory? dir, string name)
         {
             try
             {
-                packageDirectory?.Dispose();
-                missingPackageDirectory?.Dispose();
+                dir?.Dispose();
             }
             catch (Exception exc)
             {
-                progressMonitor.LogInfo("Couldn't delete package directory: " + exc.Message);
+                progressMonitor.LogInfo($"Couldn't delete {name} directory {exc.Message}");
             }
+        }
+
+        public void Dispose()
+        {
+            Dispose(packageDirectory, "package");
+            Dispose(missingPackageDirectory, "missing package");
             if (cleanupTempWorkingDirectory)
             {
-                try
-                {
-                    tempWorkingDirectory?.Dispose();
-                }
-                catch (Exception exc)
-                {
-                    progressMonitor.LogInfo("Couldn't delete temporary working directory: " + exc.Message);
-                }
+                Dispose(tempWorkingDirectory, "temporary working");
             }
         }
     }

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
@@ -117,6 +117,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             {
                 AddNetFrameworkDlls(dllPaths);
                 AddAspNetFrameworkDlls(dllPaths);
+                AddMicrosoftWindowsDesktopDlls(dllPaths);
             }
 
             assemblyCache = new AssemblyCache(dllPaths, progressMonitor);
@@ -263,6 +264,15 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             {
                 progressMonitor.LogInfo($"ASP.NET runtime location selected: {aspNetCoreRuntime}");
                 dllPaths.Add(aspNetCoreRuntime);
+            }
+        }
+
+        private void AddMicrosoftWindowsDesktopDlls(List<string> dllPaths)
+        {
+            if (GetPackageDirectory("microsoft.windowsdesktop.app.ref") is string windowsDesktopApp)
+            {
+                progressMonitor.LogInfo($"Found Windows Desktop App in NuGet packages.");
+                dllPaths.Add(windowsDesktopApp);
             }
         }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
@@ -104,7 +104,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 var dependencies = Assets.GetCompilationDependencies(progressMonitor, assets1.Union(assets2));
 
                 var paths = dependencies
-                    .Required
+                    .RequiredPaths
                     .Select(d => Path.Combine(packageDirectory.DirInfo.FullName, d))
                     .ToList();
                 dllPaths.AddRange(paths);
@@ -303,7 +303,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 .Select(d => d.FullName);
         }
 
-        private void LogAllUnusedPackages(Dependencies dependencies) =>
+        private void LogAllUnusedPackages(DependencyContainer dependencies) =>
             GetAllPackageDirectories()
                 .Where(package => !dependencies.UsedPackages.Contains(package))
                 .ForEach(package => progressMonitor.LogInfo($"Unused package: {package}"));

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNet.cs
@@ -42,7 +42,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
         private string GetRestoreArgs(string projectOrSolutionFile, string packageDirectory, bool forceDotnetRefAssemblyFetching)
         {
-            var args = $"restore --no-dependencies \"{projectOrSolutionFile}\" --packages \"{packageDirectory}\" /p:DisableImplicitNuGetFallbackFolder=true";
+            var args = $"restore --no-dependencies \"{projectOrSolutionFile}\" --packages \"{packageDirectory}\" /p:DisableImplicitNuGetFallbackFolder=true --verbosity normal";
 
             if (forceDotnetRefAssemblyFetching)
             {
@@ -74,7 +74,6 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         public bool RestoreSolutionToDirectory(string solutionFile, string packageDirectory, bool forceDotnetRefAssemblyFetching, out IEnumerable<string> projects)
         {
             var args = GetRestoreArgs(solutionFile, packageDirectory, forceDotnetRefAssemblyFetching);
-            args += " --verbosity normal";
             if (dotnetCliInvoker.RunCommand(args, out var output))
             {
                 var regex = RestoreProjectRegex();

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNet.cs
@@ -60,7 +60,19 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             return args;
         }
 
-        public bool RestoreProjectToDirectory(string projectFile, string packageDirectory, bool forceDotnetRefAssemblyFetching, string? pathToNugetConfig = null)
+        private static IEnumerable<string> GetFirstGroupOnMatch(Regex regex, IEnumerable<string> lines) =>
+            lines
+                .Select(line => regex.Match(line))
+                .Where(match => match.Success)
+                .Select(match => match.Groups[1].Value);
+
+        private static IEnumerable<string> GetAssetsFilePaths(IEnumerable<string> lines) =>
+            GetFirstGroupOnMatch(AssetsFileRegex(), lines);
+
+        private static IEnumerable<string> GetRestoredProjects(IEnumerable<string> lines) =>
+            GetFirstGroupOnMatch(RestoredProjectRegex(), lines);
+
+        public bool RestoreProjectToDirectory(string projectFile, string packageDirectory, bool forceDotnetRefAssemblyFetching, out IEnumerable<string> assets, string? pathToNugetConfig = null)
         {
             var args = GetRestoreArgs(projectFile, packageDirectory, forceDotnetRefAssemblyFetching);
             if (pathToNugetConfig != null)
@@ -68,24 +80,18 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 args += $" --configfile \"{pathToNugetConfig}\"";
             }
 
-            return dotnetCliInvoker.RunCommand(args);
+            var success = dotnetCliInvoker.RunCommand(args, out var output);
+            assets = success ? GetAssetsFilePaths(output) : Array.Empty<string>();
+            return success;
         }
 
-        public bool RestoreSolutionToDirectory(string solutionFile, string packageDirectory, bool forceDotnetRefAssemblyFetching, out IEnumerable<string> projects)
+        public bool RestoreSolutionToDirectory(string solutionFile, string packageDirectory, bool forceDotnetRefAssemblyFetching, out IEnumerable<string> projects, out IEnumerable<string> assets)
         {
             var args = GetRestoreArgs(solutionFile, packageDirectory, forceDotnetRefAssemblyFetching);
-            if (dotnetCliInvoker.RunCommand(args, out var output))
-            {
-                var regex = RestoreProjectRegex();
-                projects = output
-                    .Select(line => regex.Match(line))
-                    .Where(match => match.Success)
-                    .Select(match => match.Groups[1].Value);
-                return true;
-            }
-
-            projects = Array.Empty<string>();
-            return false;
+            var success = dotnetCliInvoker.RunCommand(args, out var output);
+            projects = success ? GetRestoredProjects(output) : Array.Empty<string>();
+            assets = success ? GetAssetsFilePaths(output) : Array.Empty<string>();
+            return success;
         }
 
         public bool New(string folder)
@@ -120,6 +126,9 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         }
 
         [GeneratedRegex("Restored\\s+(.+\\.csproj)", RegexOptions.Compiled)]
-        private static partial Regex RestoreProjectRegex();
+        private static partial Regex RestoredProjectRegex();
+
+        [GeneratedRegex("[Assets\\sfile\\shas\\snot\\schanged.\\sSkipping\\sassets\\sfile\\swriting.|Writing\\sassets\\sfile\\sto\\sdisk.]\\sPath:\\s(.*)", RegexOptions.Compiled)]
+        private static partial Regex AssetsFileRegex();
     }
 }

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/IDotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/IDotNet.cs
@@ -4,8 +4,8 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 {
     internal interface IDotNet
     {
-        bool RestoreProjectToDirectory(string project, string directory, bool forceDotnetRefAssemblyFetching, string? pathToNugetConfig = null);
-        bool RestoreSolutionToDirectory(string solutionFile, string packageDirectory, bool forceDotnetRefAssemblyFetching, out IEnumerable<string> projects);
+        bool RestoreProjectToDirectory(string project, string directory, bool forceDotnetRefAssemblyFetching, out IEnumerable<string> assets, string? pathToNugetConfig = null);
+        bool RestoreSolutionToDirectory(string solutionFile, string packageDirectory, bool forceDotnetRefAssemblyFetching, out IEnumerable<string> projects, out IEnumerable<string> assets);
         bool New(string folder);
         bool AddPackage(string folder, string package);
         IList<string> GetListedRuntimes();

--- a/csharp/extractor/Semmle.Extraction.Tests/Assets.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/Assets.cs
@@ -52,9 +52,11 @@ namespace Semmle.Extraction.Tests
             // Verify
             Assert.True(success);
             Assert.Equal(2, dependencies.Required.Count());
+
+            var normalizedPaths = dependencies.Required.Select(FixExpectedPathOnWindows);
             // Required references
-            Assert.Contains("microsoft.netframework.referenceassemblies/1.0.3", dependencies.Required);
-            Assert.Contains("microsoft.netframework.referenceassemblies.net48/1.0.3", dependencies.Required);
+            Assert.Contains("microsoft.netframework.referenceassemblies/1.0.3", normalizedPaths);
+            Assert.Contains("microsoft.netframework.referenceassemblies.net48/1.0.3", normalizedPaths);
             // Used packages
             Assert.Contains("microsoft.netframework.referenceassemblies", dependencies.UsedPackages);
             Assert.Contains("microsoft.netframework.referenceassemblies.net48", dependencies.UsedPackages);

--- a/csharp/extractor/Semmle.Extraction.Tests/Assets.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/Assets.cs
@@ -14,17 +14,17 @@ namespace Semmle.Extraction.Tests
             // Setup
             var assets = new Assets(new ProgressMonitor(new LoggerStub()));
             var json = assetsJson1;
-            var dependencies = new Dependencies();
+            var dependencies = new DependencyContainer();
 
             // Execute
             var success = assets.TryParse(json, dependencies);
 
             // Verify
             Assert.True(success);
-            Assert.Equal(5, dependencies.Required.Count());
+            Assert.Equal(5, dependencies.RequiredPaths.Count());
             Assert.Equal(4, dependencies.UsedPackages.Count());
 
-            var normalizedPaths = dependencies.Required.Select(FixExpectedPathOnWindows);
+            var normalizedPaths = dependencies.RequiredPaths.Select(FixExpectedPathOnWindows);
             // Required references
             Assert.Contains("castle.core/4.4.1/lib/netstandard1.5/Castle.Core.dll", normalizedPaths);
             Assert.Contains("castle.core/4.4.1/lib/netstandard1.5/Castle.Core2.dll", normalizedPaths);
@@ -44,16 +44,16 @@ namespace Semmle.Extraction.Tests
             // Setup
             var assets = new Assets(new ProgressMonitor(new LoggerStub()));
             var json = assetsJson2;
-            var dependencies = new Dependencies();
+            var dependencies = new DependencyContainer();
 
             // Execute
             var success = assets.TryParse(json, dependencies);
 
             // Verify
             Assert.True(success);
-            Assert.Equal(2, dependencies.Required.Count());
+            Assert.Equal(2, dependencies.RequiredPaths.Count());
 
-            var normalizedPaths = dependencies.Required.Select(FixExpectedPathOnWindows);
+            var normalizedPaths = dependencies.RequiredPaths.Select(FixExpectedPathOnWindows);
             // Required references
             Assert.Contains("microsoft.netframework.referenceassemblies/1.0.3", normalizedPaths);
             Assert.Contains("microsoft.netframework.referenceassemblies.net48/1.0.3", normalizedPaths);
@@ -68,14 +68,14 @@ namespace Semmle.Extraction.Tests
             // Setup
             var assets = new Assets(new ProgressMonitor(new LoggerStub()));
             var json = "garbage data";
-            var dependencies = new Dependencies();
+            var dependencies = new DependencyContainer();
 
             // Execute
             var success = assets.TryParse(json, dependencies);
 
             // Verify
             Assert.False(success);
-            Assert.Empty(dependencies.Required);
+            Assert.Empty(dependencies.RequiredPaths);
         }
 
         private readonly string assetsJson1 = """

--- a/csharp/extractor/Semmle.Extraction.Tests/Assets.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/Assets.cs
@@ -1,0 +1,187 @@
+using Xunit;
+using System.Linq;
+using Semmle.Extraction.CSharp.DependencyFetching;
+
+namespace Semmle.Extraction.Tests
+{
+    public class AssetsTests
+    {
+        private static string FixExpectedPathOnWindows(string path) => path.Replace('\\', '/');
+
+        [Fact]
+        public void TestAssets1()
+        {
+            // Setup
+            var assets = new Assets(new ProgressMonitor(new LoggerStub()));
+            var json = assetsJson1;
+
+            // Execute
+            var success = assets.TryParse(json, out var dependencies);
+
+            // Verify
+            Assert.True(success);
+            Assert.Equal(4, dependencies.Count());
+
+            var normalizedPaths = dependencies.Select(FixExpectedPathOnWindows);
+            // Packages references
+            Assert.Contains("castle.core/4.4.1/lib/netstandard1.5/Castle.Core.dll", normalizedPaths);
+            Assert.Contains("json.net/1.0.33/lib/netstandard2.0/Json.Net.dll", normalizedPaths);
+            Assert.Contains("microsoft.aspnetcore.cryptography.internal/6.0.8/lib/net6.0/Microsoft.AspNetCore.Cryptography.Internal.dll", normalizedPaths);
+            Assert.Contains("humanizer.core/2.8.26/lib/netstandard2.0", normalizedPaths);
+        }
+
+        [Fact]
+        public void TestAssets2()
+        {
+            // Setup
+            var assets = new Assets(new ProgressMonitor(new LoggerStub()));
+            var json = assetsJson2;
+
+            // Execute
+            var success = assets.TryParse(json, out var dependencies);
+
+            // Verify
+            Assert.True(success);
+            Assert.Equal(2, dependencies.Count());
+            Assert.Contains("microsoft.netframework.referenceassemblies/1.0.3", dependencies);
+            Assert.Contains("microsoft.netframework.referenceassemblies.net48/1.0.3", dependencies);
+        }
+
+        [Fact]
+        public void TestAssets3()
+        {
+            // Setup
+            var assets = new Assets(new ProgressMonitor(new LoggerStub()));
+            var json = "garbage data";
+
+            // Execute
+            var success = assets.TryParse(json, out var dependencies);
+
+            // Verify
+            Assert.False(success);
+            Assert.Empty(dependencies);
+        }
+
+        private readonly string assetsJson1 = """
+{
+    "version": 3,
+    "targets": {
+        "net7.0": {
+            "Castle.Core/4.4.1": {
+                "type": "package",
+                "dependencies": {
+                    "NETStandard.Library": "1.6.1",
+                    "System.Collections.Specialized": "4.3.0",
+                },
+                "compile": {
+                    "lib/netstandard1.5/Castle.Core.dll": {
+                        "related": ".xml"
+                    }
+                },
+                "runtime": {
+                    "lib/netstandard1.5/Castle.Core.dll": {
+                        "related": ".xml"
+                    }
+                }
+            },
+            "Json.Net/1.0.33": {
+                "type": "package",
+                "compile": {
+                     "lib/netstandard2.0/Json.Net.dll": {}
+                },
+                "runtime": {
+                    "lib/netstandard2.0/Json.Net.dll": {}
+                }
+            },
+            "MessagePackAnalyzer/2.1.152": {
+                "type": "package"
+            },
+            "Microsoft.AspNetCore.Cryptography.Internal/6.0.8": {
+                "type": "package",
+                "compile": {
+                    "lib/net6.0/Microsoft.AspNetCore.Cryptography.Internal.dll": {
+                        "related": ".xml"
+                    }
+                },
+                "runtime": {
+                    "lib/net6.0/Microsoft.AspNetCore.Cryptography.Internal.dll": {
+                        "related": ".xml"
+                    }
+                }
+            },
+            "Humanizer.Core/2.8.26": {
+                "type": "package",
+                "compile": {
+                    "lib/netstandard2.0/_._": {
+                        "related": ".xml"
+                    }
+                },
+                "runtime": {
+                    "lib/netstandard2.0/Humanizer.dll": {
+                        "related": ".xml"
+                    }
+                }
+            },
+            "Nop.Core/4.5.0": {
+                "type": "project",
+                "compile": {
+                    "bin/placeholder/Nop.Core.dll": {}
+                },
+                "runtime": {
+                    "bin/placeholder/Nop.Core.dll": {}
+                }
+            },
+        }
+    },
+    "project": {
+        "version": "1.0.0",
+        "frameworks": {
+            "net7.0": {
+                "targetAlias": "net7.0",
+                "downloadDependencies": [
+                    {
+                        "name": "Microsoft.AspNetCore.App.Ref",
+                        "version": "[7.0.2, 7.0.2]"
+                    },
+                    {
+                        "name": "Microsoft.NETCore.App.Ref",
+                        "version": "[7.0.2, 7.0.2]"
+                    }
+                ],
+                "frameworkReferences": {
+                    "Microsoft.AspNetCore.App": {
+                        "privateAssets": "none"
+                    },
+                    "Microsoft.NETCore.App": {
+                        "privateAssets": "all"
+                    }
+                }
+            }
+        }
+    }
+}
+""";
+
+        private readonly string assetsJson2 = """
+{
+    "version": 3,
+    "targets": {
+        ".NETFramework,Version=v4.8": {
+            "Microsoft.NETFramework.ReferenceAssemblies/1.0.3": {
+                "type": "package",
+                "dependencies": {
+                    "Microsoft.NETFramework.ReferenceAssemblies.net48": "1.0.3"
+                }
+            },
+            "Microsoft.NETFramework.ReferenceAssemblies.net48/1.0.3": {
+                "type": "package",
+                "build": {
+                    "build/Microsoft.NETFramework.ReferenceAssemblies.net48.targets": {}
+                }
+            }
+        }
+    }
+}
+""";
+    }
+}

--- a/csharp/extractor/Semmle.Extraction.Tests/DotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/DotNet.cs
@@ -43,9 +43,11 @@ namespace Semmle.Extraction.Tests
         private static IList<string> MakeDotnetRestoreOutput() =>
             new List<string> {
                 "  Determining projects to restore...",
+                "  Writing assets file to disk. Path: /path/to/project.assets.json",
                 "  Restored /path/to/project.csproj (in 1.23 sec).",
                 "  Other output...",
                 "  More output...",
+                "  Assets file has not changed. Skipping assets file writing. Path: /path/to/project2.assets.json",
                 "  Restored /path/to/project2.csproj (in 4.56 sec).",
                 "  Other output...",
                 };
@@ -99,7 +101,7 @@ namespace Semmle.Extraction.Tests
             var dotnet = MakeDotnet(dotnetCliInvoker);
 
             // Execute
-            dotnet.RestoreProjectToDirectory("myproject.csproj", "mypackages", false);
+            dotnet.RestoreProjectToDirectory("myproject.csproj", "mypackages", false, out var assets);
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();
@@ -110,15 +112,18 @@ namespace Semmle.Extraction.Tests
         public void TestDotnetRestoreProjectToDirectory2()
         {
             // Setup
-            var dotnetCliInvoker = new DotNetCliInvokerStub(new List<string>());
+            var dotnetCliInvoker = new DotNetCliInvokerStub(MakeDotnetRestoreOutput());
             var dotnet = MakeDotnet(dotnetCliInvoker);
 
             // Execute
-            dotnet.RestoreProjectToDirectory("myproject.csproj", "mypackages", false, "myconfig.config");
+            dotnet.RestoreProjectToDirectory("myproject.csproj", "mypackages", false, out var assets, "myconfig.config");
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();
             Assert.Equal("restore --no-dependencies \"myproject.csproj\" --packages \"mypackages\" /p:DisableImplicitNuGetFallbackFolder=true --verbosity normal --configfile \"myconfig.config\"", lastArgs);
+            Assert.Equal(2, assets.Count());
+            Assert.Contains("/path/to/project.assets.json", assets);
+            Assert.Contains("/path/to/project2.assets.json", assets);
         }
 
         [Fact]
@@ -129,7 +134,7 @@ namespace Semmle.Extraction.Tests
             var dotnet = MakeDotnet(dotnetCliInvoker);
 
             // Execute
-            dotnet.RestoreSolutionToDirectory("mysolution.sln", "mypackages", false, out var projects);
+            dotnet.RestoreSolutionToDirectory("mysolution.sln", "mypackages", false, out var projects, out var assets);
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();
@@ -137,6 +142,9 @@ namespace Semmle.Extraction.Tests
             Assert.Equal(2, projects.Count());
             Assert.Contains("/path/to/project.csproj", projects);
             Assert.Contains("/path/to/project2.csproj", projects);
+            Assert.Equal(2, assets.Count());
+            Assert.Contains("/path/to/project.assets.json", assets);
+            Assert.Contains("/path/to/project2.assets.json", assets);
         }
 
         [Fact]
@@ -148,12 +156,13 @@ namespace Semmle.Extraction.Tests
             dotnetCliInvoker.Success = false;
 
             // Execute
-            dotnet.RestoreSolutionToDirectory("mysolution.sln", "mypackages", false, out var projects);
+            dotnet.RestoreSolutionToDirectory("mysolution.sln", "mypackages", false, out var projects, out var assets);
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();
             Assert.Equal("restore --no-dependencies \"mysolution.sln\" --packages \"mypackages\" /p:DisableImplicitNuGetFallbackFolder=true --verbosity normal", lastArgs);
             Assert.Empty(projects);
+            Assert.Empty(assets);
         }
 
         [Fact]

--- a/csharp/extractor/Semmle.Extraction.Tests/DotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/DotNet.cs
@@ -103,7 +103,7 @@ namespace Semmle.Extraction.Tests
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();
-            Assert.Equal("restore --no-dependencies \"myproject.csproj\" --packages \"mypackages\" /p:DisableImplicitNuGetFallbackFolder=true", lastArgs);
+            Assert.Equal("restore --no-dependencies \"myproject.csproj\" --packages \"mypackages\" /p:DisableImplicitNuGetFallbackFolder=true --verbosity normal", lastArgs);
         }
 
         [Fact]
@@ -118,7 +118,7 @@ namespace Semmle.Extraction.Tests
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();
-            Assert.Equal("restore --no-dependencies \"myproject.csproj\" --packages \"mypackages\" /p:DisableImplicitNuGetFallbackFolder=true --configfile \"myconfig.config\"", lastArgs);
+            Assert.Equal("restore --no-dependencies \"myproject.csproj\" --packages \"mypackages\" /p:DisableImplicitNuGetFallbackFolder=true --verbosity normal --configfile \"myconfig.config\"", lastArgs);
         }
 
         [Fact]

--- a/csharp/extractor/Semmle.Extraction.Tests/Runtime.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/Runtime.cs
@@ -19,11 +19,16 @@ namespace Semmle.Extraction.Tests
 
         public bool New(string folder) => true;
 
-        public bool RestoreProjectToDirectory(string project, string directory, bool forceDotnetRefAssemblyFetching, string? pathToNugetConfig = null) => true;
+        public bool RestoreProjectToDirectory(string project, string directory, bool forceDotnetRefAssemblyFetching, out IEnumerable<string> assets, string? pathToNugetConfig = null)
+        {
+            assets = Array.Empty<string>();
+            return true;
+        }
 
-        public bool RestoreSolutionToDirectory(string solution, string directory, bool forceDotnetRefAssemblyFetching, out IEnumerable<string> projects)
+        public bool RestoreSolutionToDirectory(string solution, string directory, bool forceDotnetRefAssemblyFetching, out IEnumerable<string> projects, out IEnumerable<string> assets)
         {
             projects = Array.Empty<string>();
+            assets = Array.Empty<string>();
             return true;
         }
 

--- a/csharp/extractor/Semmle.Util/IEnumerableExtensions.cs
+++ b/csharp/extractor/Semmle.Util/IEnumerableExtensions.cs
@@ -113,5 +113,11 @@ namespace Semmle.Util
                 h = h * 7 + i.GetHashCode();
             return h;
         }
+
+        /// <summary>
+        /// Returns the sequence with nulls removed.
+        /// </summary>
+        public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> items) where T : class =>
+            items.Where(i => i is not null)!;
     }
 }

--- a/csharp/ql/integration-tests/posix-only/standalone_dependencies/Assemblies.expected
+++ b/csharp/ql/integration-tests/posix-only/standalone_dependencies/Assemblies.expected
@@ -1,7 +1,3 @@
-| /avalara.avatax/21.10.0/lib/net20/Avalara.AvaTax.RestClient.net20.dll |
-| /avalara.avatax/21.10.0/lib/net45/Avalara.AvaTax.RestClient.net45.dll |
-| /avalara.avatax/21.10.0/lib/net461/Avalara.AvaTax.RestClient.net461.dll |
-| /avalara.avatax/21.10.0/lib/netstandard16/Avalara.AvaTax.netstandard11.dll |
 | /avalara.avatax/21.10.0/lib/netstandard20/Avalara.AvaTax.netstandard20.dll |
 | /microsoft.bcl.asyncinterfaces/6.0.0/lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll |
 | /microsoft.netcore.app.ref/3.1.0/ref/netcoreapp3.1/System.Runtime.InteropServices.WindowsRuntime.dll |
@@ -168,4 +164,4 @@
 | /microsoft.netcore.app.ref/7.0.2/ref/net7.0/WindowsBase.dll |
 | /microsoft.netcore.app.ref/7.0.2/ref/net7.0/mscorlib.dll |
 | /microsoft.netcore.app.ref/7.0.2/ref/net7.0/netstandard.dll |
-| /newtonsoft.json/12.0.1/lib/portable-net45+win8+wp8+wpa81/Newtonsoft.Json.dll |
+| /newtonsoft.json/12.0.1/lib/netstandard2.0/Newtonsoft.Json.dll |

--- a/csharp/ql/integration-tests/windows-only/standalone_dependencies/Assemblies.expected
+++ b/csharp/ql/integration-tests/windows-only/standalone_dependencies/Assemblies.expected
@@ -1,7 +1,3 @@
-| /avalara.avatax/21.10.0/lib/net20/Avalara.AvaTax.RestClient.net20.dll |
-| /avalara.avatax/21.10.0/lib/net45/Avalara.AvaTax.RestClient.net45.dll |
-| /avalara.avatax/21.10.0/lib/net461/Avalara.AvaTax.RestClient.net461.dll |
-| /avalara.avatax/21.10.0/lib/netstandard16/Avalara.AvaTax.netstandard11.dll |
 | /avalara.avatax/21.10.0/lib/netstandard20/Avalara.AvaTax.netstandard20.dll |
 | /microsoft.bcl.asyncinterfaces/6.0.0/lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll |
 | /microsoft.netcore.app.ref/3.1.0/ref/netcoreapp3.1/System.Runtime.InteropServices.WindowsRuntime.dll |
@@ -212,4 +208,4 @@
 | /microsoft.windowsdesktop.app.ref/7.0.2/ref/net7.0/UIAutomationTypes.dll |
 | /microsoft.windowsdesktop.app.ref/7.0.2/ref/net7.0/WindowsBase.dll |
 | /microsoft.windowsdesktop.app.ref/7.0.2/ref/net7.0/WindowsFormsIntegration.dll |
-| /newtonsoft.json/12.0.1/lib/portable-net45+win8+wp8+wpa81/Newtonsoft.Json.dll |
+| /newtonsoft.json/12.0.1/lib/netstandard2.0/Newtonsoft.Json.dll |


### PR DESCRIPTION
In this PR we try to narrow which dependencies to include in standalone compilation.
Prior to this PR we took all dll's in all the packages that were downloaded as a part of the `dotnet restore` process and included them in the standalone compilation.

As a result
- It often led to conflicts as Packages might contain the assemblies for multiple versions of .NET (which then conflict with each other). The deduplication of dll's can only fix this if the dll's have identical names.
- Way to many assemblies not required for compilation got included.

We try to solve this issue by inspecting the content of all `project.assets.json` files after `dotnet restore`s have been executed:
- In the `targets` section we try to find all *package* references and _only_ include the dll's that are required for compilation (under the `compile` tag). If a package reference is to a set of .NET framework reference assemblies we still include the entire package folder (for that package).

The added testcases contain examples of `project.assets.json` content (some context to the above).
Please note, that this work is based on reverse engineering (guessing) what the content of a `project.assets.json` file means.

Furthermore, this means that we have changed the logic in the DependencyManager to be *addition* based instead of *subtraction* based (that is we add packages, if we find information in the assets file about them otherwise we don't add them).

Implementation notes
- .NET Frameworks are handled a bit differently. If we discover that framework dll's are downloaded as a part of the `dotnet restore` process we included the relevant NuGet package (based on a hardcoded list of priorities). If none of these packages have been downloaded, we add the assemblies from the .NET installation directory instead.
- If the ASP.NET core NuGet package is downloaded and if the project files gives us an indication that this is needed for compilation we include this package (otherwise we include the ASP.NET from the .NET installation directory).
- In the `project.assets.json` file there are sometimes a reference to a file named `_._`. This is an empty fail that may or may not exist and is sometimes there due to issues with empty directories (according to https://stackoverflow.com/questions/36338052/what-do-files-mean-in-nuget-packages). In this case we just add the entire directory as a dependency.
- The AssemblyCache has been made more robust in case the information from the assets files turn out to be different than expected.
- We might not need to the DownloadMissingPackages anymore. If we assume that we process all project files then if a package is not downloaded, it might be because it is not included in any of the assets files. At least for the integration tests, it appears that this part adds unwanted dlls <-- This happens because the logic in FileContent doesn't exclude package references that are commented out (I will fix this in another PR).

With these changes we reduce the number of *extra* dll's that is taken into the compilation for the standalone extractor compared to the tracing extractor. 

Before
```
Results for nopSolutions/nopCommerce
 Query Dependencies.ql:
  Result count - both/traced/standalone: 446/0/35

Results for tobyash86/WebGoat.NET
 Query Dependencies.ql:
  Result count - both/traced/standalone: 367/0/17

Results for AAEmu/AAEmu
 Query Dependencies.ql:
  Result count - both/traced/standalone: 234/3/48
```

After
```
Results for nopSolutions/nopCommerce
  Query Dependencies.ql:
  Result count - both/traced/standalone: 446/0/1

Results for tobyash86/WebGoat.NET
 Query Dependencies.ql:
  Result count - both/traced/standalone: 367/0/2

Results for AAEmu/AAEmu
 Query Dependencies.ql:
  Result count - both/traced/standalone: 237/0/4
```