### PR TITLE
Swift: Fix defaultImplicitTaintRead on fields

### DIFF
--- a/swift/ql/lib/change-notes/2023-11-01-field-sinks.md
+++ b/swift/ql/lib/change-notes/2023-11-01-field-sinks.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+
+* Fixed a bug where some flow sinks at field accesses were not being correctly identified.

--- a/swift/ql/lib/codeql/swift/dataflow/internal/TaintTrackingPublic.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/TaintTrackingPublic.qll
@@ -32,8 +32,12 @@ predicate defaultImplicitTaintRead(DataFlow::Node node, DataFlow::ContentSet cs)
   // So when the node is a `PostUpdateNode` we allow any sequence of implicit read steps of an appropriate
   // type to make sure we arrive at the sink with an empty access path.
   exists(NominalTypeDecl d, Decl cx |
-    node.(DataFlow::PostUpdateNode).getPreUpdateNode().asExpr().getType().getUnderlyingType() =
-      d.getType().getABaseType*() and
+    node.(DataFlow::PostUpdateNode)
+        .getPreUpdateNode()
+        .asExpr()
+        .getType()
+        .getUnderlyingType()
+        .getABaseType*() = d.getType() and
     cx.asNominalTypeDecl() = d and
     cs.getAReadContent().(DataFlow::Content::FieldContent).getField() = cx.getAMember()
   )

--- a/swift/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
+++ b/swift/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
@@ -33,6 +33,7 @@ edges
 | CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:114:36:114:36 | userControlledString |
 | CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:115:28:115:28 | userControlledString |
 | CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:119:45:119:45 | userControlledString |
+| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:120:36:120:36 | userControlledString |
 | CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:121:28:121:36 | ... .+(_:_:) ... |
 | CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:125:46:125:46 | userControlledString |
 | CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:126:22:126:22 | userControlledString |
@@ -49,6 +50,7 @@ edges
 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:114:36:114:36 | userControlledString |
 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:115:28:115:28 | userControlledString |
 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:119:45:119:45 | userControlledString |
+| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:120:36:120:36 | userControlledString |
 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:121:28:121:36 | ... .+(_:_:) ... |
 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:125:46:125:46 | userControlledString |
 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:126:22:126:22 | userControlledString |
@@ -72,6 +74,10 @@ edges
 | CommandInjection.swift:119:2:119:2 | [post] task4 [executableURL] | CommandInjection.swift:119:2:119:2 | [post] task4 |
 | CommandInjection.swift:119:24:119:65 | call to URL.init(fileURLWithPath:) | CommandInjection.swift:119:2:119:2 | [post] task4 [executableURL] |
 | CommandInjection.swift:119:45:119:45 | userControlledString | CommandInjection.swift:119:24:119:65 | call to URL.init(fileURLWithPath:) |
+| CommandInjection.swift:120:2:120:2 | [post] task4 [executableURL] | CommandInjection.swift:120:2:120:2 | [post] task4 |
+| CommandInjection.swift:120:24:120:56 | call to URL.init(string:) [some:0] | CommandInjection.swift:120:24:120:57 | ...! |
+| CommandInjection.swift:120:24:120:57 | ...! | CommandInjection.swift:120:2:120:2 | [post] task4 [executableURL] |
+| CommandInjection.swift:120:36:120:36 | userControlledString | CommandInjection.swift:120:24:120:56 | call to URL.init(string:) [some:0] |
 | CommandInjection.swift:121:2:121:2 | [post] task4 [arguments, Collection element] | CommandInjection.swift:121:2:121:2 | [post] task4 |
 | CommandInjection.swift:121:20:121:56 | [...] [Collection element] | CommandInjection.swift:121:2:121:2 | [post] task4 [arguments, Collection element] |
 | CommandInjection.swift:121:28:121:36 | ... .+(_:_:) ... | CommandInjection.swift:121:20:121:56 | [...] [Collection element] |
@@ -194,6 +200,11 @@ nodes
 | CommandInjection.swift:119:2:119:2 | [post] task4 [executableURL] | semmle.label | [post] task4 [executableURL] |
 | CommandInjection.swift:119:24:119:65 | call to URL.init(fileURLWithPath:) | semmle.label | call to URL.init(fileURLWithPath:) |
 | CommandInjection.swift:119:45:119:45 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:120:2:120:2 | [post] task4 | semmle.label | [post] task4 |
+| CommandInjection.swift:120:2:120:2 | [post] task4 [executableURL] | semmle.label | [post] task4 [executableURL] |
+| CommandInjection.swift:120:24:120:56 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
+| CommandInjection.swift:120:24:120:57 | ...! | semmle.label | ...! |
+| CommandInjection.swift:120:36:120:36 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:121:2:121:2 | [post] task4 | semmle.label | [post] task4 |
 | CommandInjection.swift:121:2:121:2 | [post] task4 [arguments, Collection element] | semmle.label | [post] task4 [arguments, Collection element] |
 | CommandInjection.swift:121:20:121:56 | [...] [Collection element] | semmle.label | [...] [Collection element] |
@@ -282,6 +293,7 @@ subpaths
 | CommandInjection.swift:114:2:114:2 | [post] task3 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:114:2:114:2 | [post] task3 | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
 | CommandInjection.swift:115:2:115:2 | [post] task3 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:115:2:115:2 | [post] task3 | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
 | CommandInjection.swift:119:2:119:2 | [post] task4 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:119:2:119:2 | [post] task4 | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:120:2:120:2 | [post] task4 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:120:2:120:2 | [post] task4 | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
 | CommandInjection.swift:121:2:121:2 | [post] task4 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:121:2:121:2 | [post] task4 | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
 | CommandInjection.swift:125:2:125:7 | [post] ...? | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:125:2:125:7 | [post] ...? | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
 | CommandInjection.swift:126:2:126:7 | [post] ...? | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:126:2:126:7 | [post] ...? | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |

--- a/swift/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
+++ b/swift/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
@@ -33,34 +33,34 @@ edges
 | CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:114:36:114:36 | userControlledString |
 | CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:115:28:115:28 | userControlledString |
 | CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:119:45:119:45 | userControlledString |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:120:28:120:36 | ... .+(_:_:) ... |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:124:46:124:46 | userControlledString |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:125:22:125:22 | userControlledString |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:132:24:132:24 | userControlledString |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:142:42:142:42 | userControlledString |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:143:75:143:75 | userControlledString |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:146:35:146:35 | userControlledString |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:147:70:147:70 | userControlledString |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:152:53:152:53 | userControlledString |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:155:52:155:52 | userControlledString |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:156:33:156:33 | userControlledString |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:158:57:158:57 | userControlledString |
+| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:121:28:121:36 | ... .+(_:_:) ... |
+| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:125:46:125:46 | userControlledString |
+| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:126:22:126:22 | userControlledString |
+| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:134:24:134:24 | userControlledString |
+| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:144:42:144:42 | userControlledString |
+| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:145:75:145:75 | userControlledString |
+| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:148:35:148:35 | userControlledString |
+| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:149:70:149:70 | userControlledString |
+| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:154:53:154:53 | userControlledString |
+| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:157:52:157:52 | userControlledString |
+| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:158:33:158:33 | userControlledString |
+| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:160:57:160:57 | userControlledString |
 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) [some:0] |
 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:114:36:114:36 | userControlledString |
 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:115:28:115:28 | userControlledString |
 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:119:45:119:45 | userControlledString |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:120:28:120:36 | ... .+(_:_:) ... |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:124:46:124:46 | userControlledString |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:125:22:125:22 | userControlledString |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:132:24:132:24 | userControlledString |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:142:42:142:42 | userControlledString |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:143:75:143:75 | userControlledString |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:146:35:146:35 | userControlledString |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:147:70:147:70 | userControlledString |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:152:53:152:53 | userControlledString |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:155:52:155:52 | userControlledString |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:156:33:156:33 | userControlledString |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:158:57:158:57 | userControlledString |
+| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:121:28:121:36 | ... .+(_:_:) ... |
+| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:125:46:125:46 | userControlledString |
+| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:126:22:126:22 | userControlledString |
+| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:134:24:134:24 | userControlledString |
+| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:144:42:144:42 | userControlledString |
+| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:145:75:145:75 | userControlledString |
+| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:148:35:148:35 | userControlledString |
+| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:149:70:149:70 | userControlledString |
+| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:154:53:154:53 | userControlledString |
+| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:157:52:157:52 | userControlledString |
+| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:158:33:158:33 | userControlledString |
+| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:160:57:160:57 | userControlledString |
 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) [some:0] | CommandInjection.swift:99:8:99:12 | let ...? [some:0] |
 | CommandInjection.swift:114:2:114:2 | [post] task3 [executableURL] | CommandInjection.swift:114:2:114:2 | [post] task3 |
 | CommandInjection.swift:114:24:114:56 | call to URL.init(string:) [some:0] | CommandInjection.swift:114:24:114:57 | ...! |
@@ -72,82 +72,82 @@ edges
 | CommandInjection.swift:119:2:119:2 | [post] task4 [executableURL] | CommandInjection.swift:119:2:119:2 | [post] task4 |
 | CommandInjection.swift:119:24:119:65 | call to URL.init(fileURLWithPath:) | CommandInjection.swift:119:2:119:2 | [post] task4 [executableURL] |
 | CommandInjection.swift:119:45:119:45 | userControlledString | CommandInjection.swift:119:24:119:65 | call to URL.init(fileURLWithPath:) |
-| CommandInjection.swift:120:2:120:2 | [post] task4 [arguments, Collection element] | CommandInjection.swift:120:2:120:2 | [post] task4 |
-| CommandInjection.swift:120:20:120:56 | [...] [Collection element] | CommandInjection.swift:120:2:120:2 | [post] task4 [arguments, Collection element] |
-| CommandInjection.swift:120:28:120:36 | ... .+(_:_:) ... | CommandInjection.swift:120:20:120:56 | [...] [Collection element] |
-| CommandInjection.swift:124:2:124:7 | [post] ...? [executableURL] | CommandInjection.swift:124:2:124:7 | [post] ...? |
-| CommandInjection.swift:124:25:124:66 | call to URL.init(fileURLWithPath:) | CommandInjection.swift:124:2:124:7 | [post] ...? [executableURL] |
-| CommandInjection.swift:124:46:124:46 | userControlledString | CommandInjection.swift:124:25:124:66 | call to URL.init(fileURLWithPath:) |
-| CommandInjection.swift:125:2:125:7 | [post] ...? [arguments, Collection element] | CommandInjection.swift:125:2:125:7 | [post] ...? |
-| CommandInjection.swift:125:21:125:42 | [...] [Collection element] | CommandInjection.swift:125:2:125:7 | [post] ...? [arguments, Collection element] |
-| CommandInjection.swift:125:22:125:22 | userControlledString | CommandInjection.swift:125:21:125:42 | [...] [Collection element] |
-| CommandInjection.swift:132:24:132:24 | userControlledString | CommandInjection.swift:142:42:142:42 | userControlledString |
-| CommandInjection.swift:132:24:132:24 | userControlledString | CommandInjection.swift:143:75:143:75 | userControlledString |
-| CommandInjection.swift:132:24:132:24 | userControlledString | CommandInjection.swift:146:35:146:35 | userControlledString |
-| CommandInjection.swift:132:24:132:24 | userControlledString | CommandInjection.swift:147:70:147:70 | userControlledString |
-| CommandInjection.swift:132:24:132:24 | userControlledString | CommandInjection.swift:152:53:152:53 | userControlledString |
-| CommandInjection.swift:132:24:132:24 | userControlledString | CommandInjection.swift:155:52:155:52 | userControlledString |
-| CommandInjection.swift:132:24:132:24 | userControlledString | CommandInjection.swift:156:33:156:33 | userControlledString |
-| CommandInjection.swift:132:24:132:24 | userControlledString | CommandInjection.swift:158:57:158:57 | userControlledString |
-| CommandInjection.swift:143:67:143:95 | [...] [Collection element] | CommandInjection.swift:143:67:143:95 | [...] |
-| CommandInjection.swift:143:75:143:75 | userControlledString | CommandInjection.swift:143:67:143:95 | [...] [Collection element] |
-| CommandInjection.swift:146:23:146:55 | call to URL.init(string:) [some:0] | CommandInjection.swift:146:23:146:56 | ...! |
-| CommandInjection.swift:146:35:146:35 | userControlledString | CommandInjection.swift:146:23:146:55 | call to URL.init(string:) [some:0] |
-| CommandInjection.swift:147:62:147:90 | [...] [Collection element] | CommandInjection.swift:147:62:147:90 | [...] |
-| CommandInjection.swift:147:70:147:70 | userControlledString | CommandInjection.swift:147:62:147:90 | [...] [Collection element] |
-| CommandInjection.swift:152:41:152:73 | call to URL.init(string:) [some:0] | CommandInjection.swift:152:41:152:74 | ...! |
-| CommandInjection.swift:152:53:152:53 | userControlledString | CommandInjection.swift:152:41:152:73 | call to URL.init(string:) [some:0] |
-| CommandInjection.swift:155:40:155:72 | call to URL.init(string:) [some:0] | CommandInjection.swift:155:40:155:73 | ...! |
-| CommandInjection.swift:155:40:155:72 | call to URL.init(string:) [some:0] | CommandInjection.swift:155:40:155:73 | ...! |
-| CommandInjection.swift:155:40:155:73 | ...! | file://:0:0:0:0 | url |
-| CommandInjection.swift:155:52:155:52 | userControlledString | CommandInjection.swift:155:40:155:72 | call to URL.init(string:) [some:0] |
-| CommandInjection.swift:156:32:156:53 | [...] [Collection element] | CommandInjection.swift:156:32:156:53 | [...] |
-| CommandInjection.swift:156:33:156:33 | userControlledString | CommandInjection.swift:156:32:156:53 | [...] [Collection element] |
-| CommandInjection.swift:158:45:158:77 | call to URL.init(string:) [some:0] | CommandInjection.swift:158:45:158:78 | ...! |
-| CommandInjection.swift:158:45:158:77 | call to URL.init(string:) [some:0] | CommandInjection.swift:158:45:158:78 | ...! |
-| CommandInjection.swift:158:45:158:78 | ...! | file://:0:0:0:0 | url |
-| CommandInjection.swift:158:57:158:57 | userControlledString | CommandInjection.swift:158:45:158:77 | call to URL.init(string:) [some:0] |
-| CommandInjection.swift:172:3:172:3 | newValue [Collection element] | CommandInjection.swift:173:19:173:19 | newValue [Collection element] |
-| CommandInjection.swift:172:3:172:3 | newValue [Collection element] | CommandInjection.swift:174:20:174:20 | newValue [Collection element] |
-| CommandInjection.swift:172:3:172:3 | newValue [Collection element] | CommandInjection.swift:175:19:175:19 | newValue [Collection element] |
-| CommandInjection.swift:173:4:173:4 | [post] getter for .p1 [arguments, Collection element] | CommandInjection.swift:173:4:173:4 | [post] getter for .p1 |
-| CommandInjection.swift:173:19:173:19 | newValue [Collection element] | CommandInjection.swift:173:4:173:4 | [post] getter for .p1 [arguments, Collection element] |
-| CommandInjection.swift:174:4:174:6 | [post] ...! [arguments, Collection element] | CommandInjection.swift:174:4:174:6 | [post] ...! |
-| CommandInjection.swift:174:20:174:20 | newValue [Collection element] | CommandInjection.swift:174:4:174:6 | [post] ...! [arguments, Collection element] |
-| CommandInjection.swift:175:4:175:4 | [post] ...! [arguments, Collection element] | CommandInjection.swift:175:4:175:4 | [post] ...! |
-| CommandInjection.swift:175:19:175:19 | newValue [Collection element] | CommandInjection.swift:175:4:175:4 | [post] ...! [arguments, Collection element] |
-| CommandInjection.swift:180:9:180:13 | let ...? [some:0] | CommandInjection.swift:180:13:180:13 | userControlledString |
-| CommandInjection.swift:180:13:180:13 | userControlledString | CommandInjection.swift:184:19:184:19 | userControlledString |
-| CommandInjection.swift:180:13:180:13 | userControlledString | CommandInjection.swift:190:31:190:31 | userControlledString |
-| CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) | CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) [some:0] |
-| CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) | CommandInjection.swift:184:19:184:19 | userControlledString |
-| CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) | CommandInjection.swift:190:31:190:31 | userControlledString |
-| CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) [some:0] | CommandInjection.swift:180:9:180:13 | let ...? [some:0] |
-| CommandInjection.swift:184:18:184:39 | [...] [Collection element] | CommandInjection.swift:186:18:186:18 | tainted1 [Collection element] |
-| CommandInjection.swift:184:18:184:39 | [...] [Collection element] | CommandInjection.swift:187:19:187:19 | tainted1 [Collection element] |
-| CommandInjection.swift:184:18:184:39 | [...] [Collection element] | CommandInjection.swift:188:18:188:18 | tainted1 [Collection element] |
-| CommandInjection.swift:184:19:184:19 | userControlledString | CommandInjection.swift:184:18:184:39 | [...] [Collection element] |
-| CommandInjection.swift:186:3:186:3 | [post] getter for .p1 [arguments, Collection element] | CommandInjection.swift:186:3:186:3 | [post] getter for .p1 |
-| CommandInjection.swift:186:18:186:18 | tainted1 [Collection element] | CommandInjection.swift:186:3:186:3 | [post] getter for .p1 [arguments, Collection element] |
-| CommandInjection.swift:186:18:186:18 | tainted1 [Collection element] | CommandInjection.swift:187:19:187:19 | tainted1 [Collection element] |
-| CommandInjection.swift:186:18:186:18 | tainted1 [Collection element] | CommandInjection.swift:188:18:188:18 | tainted1 [Collection element] |
-| CommandInjection.swift:187:3:187:5 | [post] ...! [arguments, Collection element] | CommandInjection.swift:187:3:187:5 | [post] ...! |
-| CommandInjection.swift:187:19:187:19 | tainted1 [Collection element] | CommandInjection.swift:187:3:187:5 | [post] ...! [arguments, Collection element] |
-| CommandInjection.swift:187:19:187:19 | tainted1 [Collection element] | CommandInjection.swift:188:18:188:18 | tainted1 [Collection element] |
-| CommandInjection.swift:188:3:188:3 | [post] ...! [arguments, Collection element] | CommandInjection.swift:188:3:188:3 | [post] ...! |
-| CommandInjection.swift:188:18:188:18 | tainted1 [Collection element] | CommandInjection.swift:188:3:188:3 | [post] ...! [arguments, Collection element] |
-| CommandInjection.swift:190:30:190:51 | [...] [Collection element] | CommandInjection.swift:192:18:192:18 | tainted2 [Collection element] |
-| CommandInjection.swift:190:30:190:51 | [...] [Collection element] | CommandInjection.swift:193:19:193:19 | tainted2 [Collection element] |
-| CommandInjection.swift:190:30:190:51 | [...] [Collection element] | CommandInjection.swift:194:18:194:18 | tainted2 [Collection element] |
-| CommandInjection.swift:190:30:190:51 | [...] [Collection element] | CommandInjection.swift:196:13:196:13 | tainted2 [Collection element] |
-| CommandInjection.swift:190:31:190:31 | userControlledString | CommandInjection.swift:190:30:190:51 | [...] [Collection element] |
-| CommandInjection.swift:192:3:192:3 | [post] getter for .p1 [arguments, Collection element] | CommandInjection.swift:192:3:192:3 | [post] getter for .p1 |
-| CommandInjection.swift:192:18:192:18 | tainted2 [Collection element] | CommandInjection.swift:192:3:192:3 | [post] getter for .p1 [arguments, Collection element] |
-| CommandInjection.swift:193:3:193:5 | [post] ...! [arguments, Collection element] | CommandInjection.swift:193:3:193:5 | [post] ...! |
-| CommandInjection.swift:193:19:193:19 | tainted2 [Collection element] | CommandInjection.swift:193:3:193:5 | [post] ...! [arguments, Collection element] |
-| CommandInjection.swift:194:3:194:3 | [post] ...! [arguments, Collection element] | CommandInjection.swift:194:3:194:3 | [post] ...! |
-| CommandInjection.swift:194:18:194:18 | tainted2 [Collection element] | CommandInjection.swift:194:3:194:3 | [post] ...! [arguments, Collection element] |
-| CommandInjection.swift:196:13:196:13 | tainted2 [Collection element] | CommandInjection.swift:172:3:172:3 | newValue [Collection element] |
+| CommandInjection.swift:121:2:121:2 | [post] task4 [arguments, Collection element] | CommandInjection.swift:121:2:121:2 | [post] task4 |
+| CommandInjection.swift:121:20:121:56 | [...] [Collection element] | CommandInjection.swift:121:2:121:2 | [post] task4 [arguments, Collection element] |
+| CommandInjection.swift:121:28:121:36 | ... .+(_:_:) ... | CommandInjection.swift:121:20:121:56 | [...] [Collection element] |
+| CommandInjection.swift:125:2:125:7 | [post] ...? [executableURL] | CommandInjection.swift:125:2:125:7 | [post] ...? |
+| CommandInjection.swift:125:25:125:66 | call to URL.init(fileURLWithPath:) | CommandInjection.swift:125:2:125:7 | [post] ...? [executableURL] |
+| CommandInjection.swift:125:46:125:46 | userControlledString | CommandInjection.swift:125:25:125:66 | call to URL.init(fileURLWithPath:) |
+| CommandInjection.swift:126:2:126:7 | [post] ...? [arguments, Collection element] | CommandInjection.swift:126:2:126:7 | [post] ...? |
+| CommandInjection.swift:126:21:126:42 | [...] [Collection element] | CommandInjection.swift:126:2:126:7 | [post] ...? [arguments, Collection element] |
+| CommandInjection.swift:126:22:126:22 | userControlledString | CommandInjection.swift:126:21:126:42 | [...] [Collection element] |
+| CommandInjection.swift:134:24:134:24 | userControlledString | CommandInjection.swift:144:42:144:42 | userControlledString |
+| CommandInjection.swift:134:24:134:24 | userControlledString | CommandInjection.swift:145:75:145:75 | userControlledString |
+| CommandInjection.swift:134:24:134:24 | userControlledString | CommandInjection.swift:148:35:148:35 | userControlledString |
+| CommandInjection.swift:134:24:134:24 | userControlledString | CommandInjection.swift:149:70:149:70 | userControlledString |
+| CommandInjection.swift:134:24:134:24 | userControlledString | CommandInjection.swift:154:53:154:53 | userControlledString |
+| CommandInjection.swift:134:24:134:24 | userControlledString | CommandInjection.swift:157:52:157:52 | userControlledString |
+| CommandInjection.swift:134:24:134:24 | userControlledString | CommandInjection.swift:158:33:158:33 | userControlledString |
+| CommandInjection.swift:134:24:134:24 | userControlledString | CommandInjection.swift:160:57:160:57 | userControlledString |
+| CommandInjection.swift:145:67:145:95 | [...] [Collection element] | CommandInjection.swift:145:67:145:95 | [...] |
+| CommandInjection.swift:145:75:145:75 | userControlledString | CommandInjection.swift:145:67:145:95 | [...] [Collection element] |
+| CommandInjection.swift:148:23:148:55 | call to URL.init(string:) [some:0] | CommandInjection.swift:148:23:148:56 | ...! |
+| CommandInjection.swift:148:35:148:35 | userControlledString | CommandInjection.swift:148:23:148:55 | call to URL.init(string:) [some:0] |
+| CommandInjection.swift:149:62:149:90 | [...] [Collection element] | CommandInjection.swift:149:62:149:90 | [...] |
+| CommandInjection.swift:149:70:149:70 | userControlledString | CommandInjection.swift:149:62:149:90 | [...] [Collection element] |
+| CommandInjection.swift:154:41:154:73 | call to URL.init(string:) [some:0] | CommandInjection.swift:154:41:154:74 | ...! |
+| CommandInjection.swift:154:53:154:53 | userControlledString | CommandInjection.swift:154:41:154:73 | call to URL.init(string:) [some:0] |
+| CommandInjection.swift:157:40:157:72 | call to URL.init(string:) [some:0] | CommandInjection.swift:157:40:157:73 | ...! |
+| CommandInjection.swift:157:40:157:72 | call to URL.init(string:) [some:0] | CommandInjection.swift:157:40:157:73 | ...! |
+| CommandInjection.swift:157:40:157:73 | ...! | file://:0:0:0:0 | url |
+| CommandInjection.swift:157:52:157:52 | userControlledString | CommandInjection.swift:157:40:157:72 | call to URL.init(string:) [some:0] |
+| CommandInjection.swift:158:32:158:53 | [...] [Collection element] | CommandInjection.swift:158:32:158:53 | [...] |
+| CommandInjection.swift:158:33:158:33 | userControlledString | CommandInjection.swift:158:32:158:53 | [...] [Collection element] |
+| CommandInjection.swift:160:45:160:77 | call to URL.init(string:) [some:0] | CommandInjection.swift:160:45:160:78 | ...! |
+| CommandInjection.swift:160:45:160:77 | call to URL.init(string:) [some:0] | CommandInjection.swift:160:45:160:78 | ...! |
+| CommandInjection.swift:160:45:160:78 | ...! | file://:0:0:0:0 | url |
+| CommandInjection.swift:160:57:160:57 | userControlledString | CommandInjection.swift:160:45:160:77 | call to URL.init(string:) [some:0] |
+| CommandInjection.swift:174:3:174:3 | newValue [Collection element] | CommandInjection.swift:175:19:175:19 | newValue [Collection element] |
+| CommandInjection.swift:174:3:174:3 | newValue [Collection element] | CommandInjection.swift:176:20:176:20 | newValue [Collection element] |
+| CommandInjection.swift:174:3:174:3 | newValue [Collection element] | CommandInjection.swift:177:19:177:19 | newValue [Collection element] |
+| CommandInjection.swift:175:4:175:4 | [post] getter for .p1 [arguments, Collection element] | CommandInjection.swift:175:4:175:4 | [post] getter for .p1 |
+| CommandInjection.swift:175:19:175:19 | newValue [Collection element] | CommandInjection.swift:175:4:175:4 | [post] getter for .p1 [arguments, Collection element] |
+| CommandInjection.swift:176:4:176:6 | [post] ...! [arguments, Collection element] | CommandInjection.swift:176:4:176:6 | [post] ...! |
+| CommandInjection.swift:176:20:176:20 | newValue [Collection element] | CommandInjection.swift:176:4:176:6 | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:177:4:177:4 | [post] ...! [arguments, Collection element] | CommandInjection.swift:177:4:177:4 | [post] ...! |
+| CommandInjection.swift:177:19:177:19 | newValue [Collection element] | CommandInjection.swift:177:4:177:4 | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:182:9:182:13 | let ...? [some:0] | CommandInjection.swift:182:13:182:13 | userControlledString |
+| CommandInjection.swift:182:13:182:13 | userControlledString | CommandInjection.swift:186:19:186:19 | userControlledString |
+| CommandInjection.swift:182:13:182:13 | userControlledString | CommandInjection.swift:192:31:192:31 | userControlledString |
+| CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) [some:0] |
+| CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | CommandInjection.swift:186:19:186:19 | userControlledString |
+| CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | CommandInjection.swift:192:31:192:31 | userControlledString |
+| CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) [some:0] | CommandInjection.swift:182:9:182:13 | let ...? [some:0] |
+| CommandInjection.swift:186:18:186:39 | [...] [Collection element] | CommandInjection.swift:188:18:188:18 | tainted1 [Collection element] |
+| CommandInjection.swift:186:18:186:39 | [...] [Collection element] | CommandInjection.swift:189:19:189:19 | tainted1 [Collection element] |
+| CommandInjection.swift:186:18:186:39 | [...] [Collection element] | CommandInjection.swift:190:18:190:18 | tainted1 [Collection element] |
+| CommandInjection.swift:186:19:186:19 | userControlledString | CommandInjection.swift:186:18:186:39 | [...] [Collection element] |
+| CommandInjection.swift:188:3:188:3 | [post] getter for .p1 [arguments, Collection element] | CommandInjection.swift:188:3:188:3 | [post] getter for .p1 |
+| CommandInjection.swift:188:18:188:18 | tainted1 [Collection element] | CommandInjection.swift:188:3:188:3 | [post] getter for .p1 [arguments, Collection element] |
+| CommandInjection.swift:188:18:188:18 | tainted1 [Collection element] | CommandInjection.swift:189:19:189:19 | tainted1 [Collection element] |
+| CommandInjection.swift:188:18:188:18 | tainted1 [Collection element] | CommandInjection.swift:190:18:190:18 | tainted1 [Collection element] |
+| CommandInjection.swift:189:3:189:5 | [post] ...! [arguments, Collection element] | CommandInjection.swift:189:3:189:5 | [post] ...! |
+| CommandInjection.swift:189:19:189:19 | tainted1 [Collection element] | CommandInjection.swift:189:3:189:5 | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:189:19:189:19 | tainted1 [Collection element] | CommandInjection.swift:190:18:190:18 | tainted1 [Collection element] |
+| CommandInjection.swift:190:3:190:3 | [post] ...! [arguments, Collection element] | CommandInjection.swift:190:3:190:3 | [post] ...! |
+| CommandInjection.swift:190:18:190:18 | tainted1 [Collection element] | CommandInjection.swift:190:3:190:3 | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:192:30:192:51 | [...] [Collection element] | CommandInjection.swift:194:18:194:18 | tainted2 [Collection element] |
+| CommandInjection.swift:192:30:192:51 | [...] [Collection element] | CommandInjection.swift:195:19:195:19 | tainted2 [Collection element] |
+| CommandInjection.swift:192:30:192:51 | [...] [Collection element] | CommandInjection.swift:196:18:196:18 | tainted2 [Collection element] |
+| CommandInjection.swift:192:30:192:51 | [...] [Collection element] | CommandInjection.swift:198:13:198:13 | tainted2 [Collection element] |
+| CommandInjection.swift:192:31:192:31 | userControlledString | CommandInjection.swift:192:30:192:51 | [...] [Collection element] |
+| CommandInjection.swift:194:3:194:3 | [post] getter for .p1 [arguments, Collection element] | CommandInjection.swift:194:3:194:3 | [post] getter for .p1 |
+| CommandInjection.swift:194:18:194:18 | tainted2 [Collection element] | CommandInjection.swift:194:3:194:3 | [post] getter for .p1 [arguments, Collection element] |
+| CommandInjection.swift:195:3:195:5 | [post] ...! [arguments, Collection element] | CommandInjection.swift:195:3:195:5 | [post] ...! |
+| CommandInjection.swift:195:19:195:19 | tainted2 [Collection element] | CommandInjection.swift:195:3:195:5 | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:196:3:196:3 | [post] ...! [arguments, Collection element] | CommandInjection.swift:196:3:196:3 | [post] ...! |
+| CommandInjection.swift:196:18:196:18 | tainted2 [Collection element] | CommandInjection.swift:196:3:196:3 | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:198:13:198:13 | tainted2 [Collection element] | CommandInjection.swift:174:3:174:3 | newValue [Collection element] |
 | file://:0:0:0:0 | url | file://:0:0:0:0 | url |
 | file://:0:0:0:0 | url | file://:0:0:0:0 | url |
 nodes
@@ -194,80 +194,80 @@ nodes
 | CommandInjection.swift:119:2:119:2 | [post] task4 [executableURL] | semmle.label | [post] task4 [executableURL] |
 | CommandInjection.swift:119:24:119:65 | call to URL.init(fileURLWithPath:) | semmle.label | call to URL.init(fileURLWithPath:) |
 | CommandInjection.swift:119:45:119:45 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:120:2:120:2 | [post] task4 | semmle.label | [post] task4 |
-| CommandInjection.swift:120:2:120:2 | [post] task4 [arguments, Collection element] | semmle.label | [post] task4 [arguments, Collection element] |
-| CommandInjection.swift:120:20:120:56 | [...] [Collection element] | semmle.label | [...] [Collection element] |
-| CommandInjection.swift:120:28:120:36 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
-| CommandInjection.swift:124:2:124:7 | [post] ...? | semmle.label | [post] ...? |
-| CommandInjection.swift:124:2:124:7 | [post] ...? [executableURL] | semmle.label | [post] ...? [executableURL] |
-| CommandInjection.swift:124:25:124:66 | call to URL.init(fileURLWithPath:) | semmle.label | call to URL.init(fileURLWithPath:) |
-| CommandInjection.swift:124:46:124:46 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:121:2:121:2 | [post] task4 | semmle.label | [post] task4 |
+| CommandInjection.swift:121:2:121:2 | [post] task4 [arguments, Collection element] | semmle.label | [post] task4 [arguments, Collection element] |
+| CommandInjection.swift:121:20:121:56 | [...] [Collection element] | semmle.label | [...] [Collection element] |
+| CommandInjection.swift:121:28:121:36 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
 | CommandInjection.swift:125:2:125:7 | [post] ...? | semmle.label | [post] ...? |
-| CommandInjection.swift:125:2:125:7 | [post] ...? [arguments, Collection element] | semmle.label | [post] ...? [arguments, Collection element] |
-| CommandInjection.swift:125:21:125:42 | [...] [Collection element] | semmle.label | [...] [Collection element] |
-| CommandInjection.swift:125:22:125:22 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:132:24:132:24 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:142:42:142:42 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:143:67:143:95 | [...] | semmle.label | [...] |
-| CommandInjection.swift:143:67:143:95 | [...] [Collection element] | semmle.label | [...] [Collection element] |
-| CommandInjection.swift:143:75:143:75 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:146:23:146:55 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
-| CommandInjection.swift:146:23:146:56 | ...! | semmle.label | ...! |
-| CommandInjection.swift:146:35:146:35 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:147:62:147:90 | [...] | semmle.label | [...] |
-| CommandInjection.swift:147:62:147:90 | [...] [Collection element] | semmle.label | [...] [Collection element] |
-| CommandInjection.swift:147:70:147:70 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:152:41:152:73 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
-| CommandInjection.swift:152:41:152:74 | ...! | semmle.label | ...! |
-| CommandInjection.swift:152:53:152:53 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:155:40:155:72 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
-| CommandInjection.swift:155:40:155:73 | ...! | semmle.label | ...! |
-| CommandInjection.swift:155:40:155:73 | ...! | semmle.label | ...! |
-| CommandInjection.swift:155:52:155:52 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:156:32:156:53 | [...] | semmle.label | [...] |
-| CommandInjection.swift:156:32:156:53 | [...] [Collection element] | semmle.label | [...] [Collection element] |
-| CommandInjection.swift:156:33:156:33 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:158:45:158:77 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
-| CommandInjection.swift:158:45:158:78 | ...! | semmle.label | ...! |
-| CommandInjection.swift:158:45:158:78 | ...! | semmle.label | ...! |
-| CommandInjection.swift:158:57:158:57 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:172:3:172:3 | newValue [Collection element] | semmle.label | newValue [Collection element] |
-| CommandInjection.swift:173:4:173:4 | [post] getter for .p1 | semmle.label | [post] getter for .p1 |
-| CommandInjection.swift:173:4:173:4 | [post] getter for .p1 [arguments, Collection element] | semmle.label | [post] getter for .p1 [arguments, Collection element] |
-| CommandInjection.swift:173:19:173:19 | newValue [Collection element] | semmle.label | newValue [Collection element] |
-| CommandInjection.swift:174:4:174:6 | [post] ...! | semmle.label | [post] ...! |
-| CommandInjection.swift:174:4:174:6 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
-| CommandInjection.swift:174:20:174:20 | newValue [Collection element] | semmle.label | newValue [Collection element] |
-| CommandInjection.swift:175:4:175:4 | [post] ...! | semmle.label | [post] ...! |
-| CommandInjection.swift:175:4:175:4 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:125:2:125:7 | [post] ...? [executableURL] | semmle.label | [post] ...? [executableURL] |
+| CommandInjection.swift:125:25:125:66 | call to URL.init(fileURLWithPath:) | semmle.label | call to URL.init(fileURLWithPath:) |
+| CommandInjection.swift:125:46:125:46 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:126:2:126:7 | [post] ...? | semmle.label | [post] ...? |
+| CommandInjection.swift:126:2:126:7 | [post] ...? [arguments, Collection element] | semmle.label | [post] ...? [arguments, Collection element] |
+| CommandInjection.swift:126:21:126:42 | [...] [Collection element] | semmle.label | [...] [Collection element] |
+| CommandInjection.swift:126:22:126:22 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:134:24:134:24 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:144:42:144:42 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:145:67:145:95 | [...] | semmle.label | [...] |
+| CommandInjection.swift:145:67:145:95 | [...] [Collection element] | semmle.label | [...] [Collection element] |
+| CommandInjection.swift:145:75:145:75 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:148:23:148:55 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
+| CommandInjection.swift:148:23:148:56 | ...! | semmle.label | ...! |
+| CommandInjection.swift:148:35:148:35 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:149:62:149:90 | [...] | semmle.label | [...] |
+| CommandInjection.swift:149:62:149:90 | [...] [Collection element] | semmle.label | [...] [Collection element] |
+| CommandInjection.swift:149:70:149:70 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:154:41:154:73 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
+| CommandInjection.swift:154:41:154:74 | ...! | semmle.label | ...! |
+| CommandInjection.swift:154:53:154:53 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:157:40:157:72 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
+| CommandInjection.swift:157:40:157:73 | ...! | semmle.label | ...! |
+| CommandInjection.swift:157:40:157:73 | ...! | semmle.label | ...! |
+| CommandInjection.swift:157:52:157:52 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:158:32:158:53 | [...] | semmle.label | [...] |
+| CommandInjection.swift:158:32:158:53 | [...] [Collection element] | semmle.label | [...] [Collection element] |
+| CommandInjection.swift:158:33:158:33 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:160:45:160:77 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
+| CommandInjection.swift:160:45:160:78 | ...! | semmle.label | ...! |
+| CommandInjection.swift:160:45:160:78 | ...! | semmle.label | ...! |
+| CommandInjection.swift:160:57:160:57 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:174:3:174:3 | newValue [Collection element] | semmle.label | newValue [Collection element] |
+| CommandInjection.swift:175:4:175:4 | [post] getter for .p1 | semmle.label | [post] getter for .p1 |
+| CommandInjection.swift:175:4:175:4 | [post] getter for .p1 [arguments, Collection element] | semmle.label | [post] getter for .p1 [arguments, Collection element] |
 | CommandInjection.swift:175:19:175:19 | newValue [Collection element] | semmle.label | newValue [Collection element] |
-| CommandInjection.swift:180:9:180:13 | let ...? [some:0] | semmle.label | let ...? [some:0] |
-| CommandInjection.swift:180:13:180:13 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) | semmle.label | call to String.init(contentsOf:) |
-| CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) [some:0] | semmle.label | call to String.init(contentsOf:) [some:0] |
-| CommandInjection.swift:184:18:184:39 | [...] [Collection element] | semmle.label | [...] [Collection element] |
-| CommandInjection.swift:184:19:184:19 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:186:3:186:3 | [post] getter for .p1 | semmle.label | [post] getter for .p1 |
-| CommandInjection.swift:186:3:186:3 | [post] getter for .p1 [arguments, Collection element] | semmle.label | [post] getter for .p1 [arguments, Collection element] |
-| CommandInjection.swift:186:18:186:18 | tainted1 [Collection element] | semmle.label | tainted1 [Collection element] |
-| CommandInjection.swift:187:3:187:5 | [post] ...! | semmle.label | [post] ...! |
-| CommandInjection.swift:187:3:187:5 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
-| CommandInjection.swift:187:19:187:19 | tainted1 [Collection element] | semmle.label | tainted1 [Collection element] |
-| CommandInjection.swift:188:3:188:3 | [post] ...! | semmle.label | [post] ...! |
-| CommandInjection.swift:188:3:188:3 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:176:4:176:6 | [post] ...! | semmle.label | [post] ...! |
+| CommandInjection.swift:176:4:176:6 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:176:20:176:20 | newValue [Collection element] | semmle.label | newValue [Collection element] |
+| CommandInjection.swift:177:4:177:4 | [post] ...! | semmle.label | [post] ...! |
+| CommandInjection.swift:177:4:177:4 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:177:19:177:19 | newValue [Collection element] | semmle.label | newValue [Collection element] |
+| CommandInjection.swift:182:9:182:13 | let ...? [some:0] | semmle.label | let ...? [some:0] |
+| CommandInjection.swift:182:13:182:13 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | semmle.label | call to String.init(contentsOf:) |
+| CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) [some:0] | semmle.label | call to String.init(contentsOf:) [some:0] |
+| CommandInjection.swift:186:18:186:39 | [...] [Collection element] | semmle.label | [...] [Collection element] |
+| CommandInjection.swift:186:19:186:19 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:188:3:188:3 | [post] getter for .p1 | semmle.label | [post] getter for .p1 |
+| CommandInjection.swift:188:3:188:3 | [post] getter for .p1 [arguments, Collection element] | semmle.label | [post] getter for .p1 [arguments, Collection element] |
 | CommandInjection.swift:188:18:188:18 | tainted1 [Collection element] | semmle.label | tainted1 [Collection element] |
-| CommandInjection.swift:190:30:190:51 | [...] [Collection element] | semmle.label | [...] [Collection element] |
-| CommandInjection.swift:190:31:190:31 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:192:3:192:3 | [post] getter for .p1 | semmle.label | [post] getter for .p1 |
-| CommandInjection.swift:192:3:192:3 | [post] getter for .p1 [arguments, Collection element] | semmle.label | [post] getter for .p1 [arguments, Collection element] |
-| CommandInjection.swift:192:18:192:18 | tainted2 [Collection element] | semmle.label | tainted2 [Collection element] |
-| CommandInjection.swift:193:3:193:5 | [post] ...! | semmle.label | [post] ...! |
-| CommandInjection.swift:193:3:193:5 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
-| CommandInjection.swift:193:19:193:19 | tainted2 [Collection element] | semmle.label | tainted2 [Collection element] |
-| CommandInjection.swift:194:3:194:3 | [post] ...! | semmle.label | [post] ...! |
-| CommandInjection.swift:194:3:194:3 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:189:3:189:5 | [post] ...! | semmle.label | [post] ...! |
+| CommandInjection.swift:189:3:189:5 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:189:19:189:19 | tainted1 [Collection element] | semmle.label | tainted1 [Collection element] |
+| CommandInjection.swift:190:3:190:3 | [post] ...! | semmle.label | [post] ...! |
+| CommandInjection.swift:190:3:190:3 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:190:18:190:18 | tainted1 [Collection element] | semmle.label | tainted1 [Collection element] |
+| CommandInjection.swift:192:30:192:51 | [...] [Collection element] | semmle.label | [...] [Collection element] |
+| CommandInjection.swift:192:31:192:31 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:194:3:194:3 | [post] getter for .p1 | semmle.label | [post] getter for .p1 |
+| CommandInjection.swift:194:3:194:3 | [post] getter for .p1 [arguments, Collection element] | semmle.label | [post] getter for .p1 [arguments, Collection element] |
 | CommandInjection.swift:194:18:194:18 | tainted2 [Collection element] | semmle.label | tainted2 [Collection element] |
-| CommandInjection.swift:196:13:196:13 | tainted2 [Collection element] | semmle.label | tainted2 [Collection element] |
+| CommandInjection.swift:195:3:195:5 | [post] ...! | semmle.label | [post] ...! |
+| CommandInjection.swift:195:3:195:5 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:195:19:195:19 | tainted2 [Collection element] | semmle.label | tainted2 [Collection element] |
+| CommandInjection.swift:196:3:196:3 | [post] ...! | semmle.label | [post] ...! |
+| CommandInjection.swift:196:3:196:3 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:196:18:196:18 | tainted2 [Collection element] | semmle.label | tainted2 [Collection element] |
+| CommandInjection.swift:198:13:198:13 | tainted2 [Collection element] | semmle.label | tainted2 [Collection element] |
 | file://:0:0:0:0 | url | semmle.label | url |
 | file://:0:0:0:0 | url | semmle.label | url |
 | file://:0:0:0:0 | url | semmle.label | url |
@@ -282,25 +282,25 @@ subpaths
 | CommandInjection.swift:114:2:114:2 | [post] task3 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:114:2:114:2 | [post] task3 | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
 | CommandInjection.swift:115:2:115:2 | [post] task3 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:115:2:115:2 | [post] task3 | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
 | CommandInjection.swift:119:2:119:2 | [post] task4 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:119:2:119:2 | [post] task4 | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:120:2:120:2 | [post] task4 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:120:2:120:2 | [post] task4 | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:124:2:124:7 | [post] ...? | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:124:2:124:7 | [post] ...? | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:121:2:121:2 | [post] task4 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:121:2:121:2 | [post] task4 | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
 | CommandInjection.swift:125:2:125:7 | [post] ...? | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:125:2:125:7 | [post] ...? | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:142:42:142:42 | userControlledString | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:142:42:142:42 | userControlledString | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:143:67:143:95 | [...] | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:143:67:143:95 | [...] | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:146:23:146:56 | ...! | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:146:23:146:56 | ...! | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:147:62:147:90 | [...] | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:147:62:147:90 | [...] | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:152:41:152:74 | ...! | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:152:41:152:74 | ...! | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:155:40:155:73 | ...! | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:155:40:155:73 | ...! | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:156:32:156:53 | [...] | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:156:32:156:53 | [...] | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:158:45:158:78 | ...! | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:158:45:158:78 | ...! | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:173:4:173:4 | [post] getter for .p1 | CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) | CommandInjection.swift:173:4:173:4 | [post] getter for .p1 | This command depends on a $@. | CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:174:4:174:6 | [post] ...! | CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) | CommandInjection.swift:174:4:174:6 | [post] ...! | This command depends on a $@. | CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:175:4:175:4 | [post] ...! | CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) | CommandInjection.swift:175:4:175:4 | [post] ...! | This command depends on a $@. | CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:186:3:186:3 | [post] getter for .p1 | CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) | CommandInjection.swift:186:3:186:3 | [post] getter for .p1 | This command depends on a $@. | CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:187:3:187:5 | [post] ...! | CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) | CommandInjection.swift:187:3:187:5 | [post] ...! | This command depends on a $@. | CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:188:3:188:3 | [post] ...! | CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) | CommandInjection.swift:188:3:188:3 | [post] ...! | This command depends on a $@. | CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:192:3:192:3 | [post] getter for .p1 | CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) | CommandInjection.swift:192:3:192:3 | [post] getter for .p1 | This command depends on a $@. | CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:193:3:193:5 | [post] ...! | CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) | CommandInjection.swift:193:3:193:5 | [post] ...! | This command depends on a $@. | CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:194:3:194:3 | [post] ...! | CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) | CommandInjection.swift:194:3:194:3 | [post] ...! | This command depends on a $@. | CommandInjection.swift:180:41:180:95 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:126:2:126:7 | [post] ...? | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:126:2:126:7 | [post] ...? | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:144:42:144:42 | userControlledString | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:144:42:144:42 | userControlledString | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:145:67:145:95 | [...] | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:145:67:145:95 | [...] | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:148:23:148:56 | ...! | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:148:23:148:56 | ...! | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:149:62:149:90 | [...] | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:149:62:149:90 | [...] | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:154:41:154:74 | ...! | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:154:41:154:74 | ...! | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:157:40:157:73 | ...! | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:157:40:157:73 | ...! | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:158:32:158:53 | [...] | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:158:32:158:53 | [...] | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:160:45:160:78 | ...! | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:160:45:160:78 | ...! | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:175:4:175:4 | [post] getter for .p1 | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | CommandInjection.swift:175:4:175:4 | [post] getter for .p1 | This command depends on a $@. | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:176:4:176:6 | [post] ...! | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | CommandInjection.swift:176:4:176:6 | [post] ...! | This command depends on a $@. | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:177:4:177:4 | [post] ...! | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | CommandInjection.swift:177:4:177:4 | [post] ...! | This command depends on a $@. | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:188:3:188:3 | [post] getter for .p1 | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | CommandInjection.swift:188:3:188:3 | [post] getter for .p1 | This command depends on a $@. | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:189:3:189:5 | [post] ...! | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | CommandInjection.swift:189:3:189:5 | [post] ...! | This command depends on a $@. | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:190:3:190:3 | [post] ...! | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | CommandInjection.swift:190:3:190:3 | [post] ...! | This command depends on a $@. | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:194:3:194:3 | [post] getter for .p1 | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | CommandInjection.swift:194:3:194:3 | [post] getter for .p1 | This command depends on a $@. | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:195:3:195:5 | [post] ...! | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | CommandInjection.swift:195:3:195:5 | [post] ...! | This command depends on a $@. | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:196:3:196:3 | [post] ...! | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | CommandInjection.swift:196:3:196:3 | [post] ...! | This command depends on a $@. | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | user-provided value |
 | file://:0:0:0:0 | url | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | file://:0:0:0:0 | url | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
 | file://:0:0:0:0 | url | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | file://:0:0:0:0 | url | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |

--- a/swift/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
+++ b/swift/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
@@ -29,6 +29,9 @@ edges
 | CommandInjection.swift:81:6:81:6 | [post] task2 [arguments, Collection element] | CommandInjection.swift:81:6:81:6 | [post] task2 |
 | CommandInjection.swift:81:24:81:46 | [...] [Collection element] | CommandInjection.swift:81:6:81:6 | [post] task2 [arguments, Collection element] |
 | CommandInjection.swift:81:31:81:31 | validatedString | CommandInjection.swift:81:24:81:46 | [...] [Collection element] |
+| CommandInjection.swift:93:20:93:40 | arguments [Collection element] | CommandInjection.swift:94:20:94:20 | arguments [Collection element] |
+| CommandInjection.swift:94:3:94:3 | [post] self [arguments, Collection element] | CommandInjection.swift:94:3:94:3 | [post] self |
+| CommandInjection.swift:94:20:94:20 | arguments [Collection element] | CommandInjection.swift:94:3:94:3 | [post] self [arguments, Collection element] |
 | CommandInjection.swift:99:8:99:12 | let ...? [some:0] | CommandInjection.swift:99:12:99:12 | userControlledString |
 | CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:114:36:114:36 | userControlledString |
 | CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:115:28:115:28 | userControlledString |
@@ -37,6 +40,10 @@ edges
 | CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:121:28:121:36 | ... .+(_:_:) ... |
 | CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:125:46:125:46 | userControlledString |
 | CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:126:22:126:22 | userControlledString |
+| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:130:45:130:45 | userControlledString |
+| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:131:36:131:36 | userControlledString |
+| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:132:21:132:21 | userControlledString |
+| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:133:22:133:22 | userControlledString |
 | CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:134:24:134:24 | userControlledString |
 | CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:144:42:144:42 | userControlledString |
 | CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:145:75:145:75 | userControlledString |
@@ -54,6 +61,10 @@ edges
 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:121:28:121:36 | ... .+(_:_:) ... |
 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:125:46:125:46 | userControlledString |
 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:126:22:126:22 | userControlledString |
+| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:130:45:130:45 | userControlledString |
+| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:131:36:131:36 | userControlledString |
+| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:132:21:132:21 | userControlledString |
+| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:133:22:133:22 | userControlledString |
 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:134:24:134:24 | userControlledString |
 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:144:42:144:42 | userControlledString |
 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:145:75:145:75 | userControlledString |
@@ -87,6 +98,18 @@ edges
 | CommandInjection.swift:126:2:126:7 | [post] ...? [arguments, Collection element] | CommandInjection.swift:126:2:126:7 | [post] ...? |
 | CommandInjection.swift:126:21:126:42 | [...] [Collection element] | CommandInjection.swift:126:2:126:7 | [post] ...? [arguments, Collection element] |
 | CommandInjection.swift:126:22:126:22 | userControlledString | CommandInjection.swift:126:21:126:42 | [...] [Collection element] |
+| CommandInjection.swift:130:2:130:2 | [post] task6 [executableURL] | CommandInjection.swift:130:2:130:2 | [post] task6 |
+| CommandInjection.swift:130:24:130:65 | call to URL.init(fileURLWithPath:) | CommandInjection.swift:130:2:130:2 | [post] task6 [executableURL] |
+| CommandInjection.swift:130:45:130:45 | userControlledString | CommandInjection.swift:130:24:130:65 | call to URL.init(fileURLWithPath:) |
+| CommandInjection.swift:131:2:131:2 | [post] task6 [executableURL] | CommandInjection.swift:131:2:131:2 | [post] task6 |
+| CommandInjection.swift:131:24:131:56 | call to URL.init(string:) [some:0] | CommandInjection.swift:131:24:131:57 | ...! |
+| CommandInjection.swift:131:24:131:57 | ...! | CommandInjection.swift:131:2:131:2 | [post] task6 [executableURL] |
+| CommandInjection.swift:131:36:131:36 | userControlledString | CommandInjection.swift:131:24:131:56 | call to URL.init(string:) [some:0] |
+| CommandInjection.swift:132:2:132:2 | [post] task6 [arguments, Collection element] | CommandInjection.swift:132:2:132:2 | [post] task6 |
+| CommandInjection.swift:132:20:132:41 | [...] [Collection element] | CommandInjection.swift:132:2:132:2 | [post] task6 [arguments, Collection element] |
+| CommandInjection.swift:132:21:132:21 | userControlledString | CommandInjection.swift:132:20:132:41 | [...] [Collection element] |
+| CommandInjection.swift:133:21:133:42 | [...] [Collection element] | CommandInjection.swift:93:20:93:40 | arguments [Collection element] |
+| CommandInjection.swift:133:22:133:22 | userControlledString | CommandInjection.swift:133:21:133:42 | [...] [Collection element] |
 | CommandInjection.swift:134:24:134:24 | userControlledString | CommandInjection.swift:144:42:144:42 | userControlledString |
 | CommandInjection.swift:134:24:134:24 | userControlledString | CommandInjection.swift:145:75:145:75 | userControlledString |
 | CommandInjection.swift:134:24:134:24 | userControlledString | CommandInjection.swift:148:35:148:35 | userControlledString |
@@ -183,6 +206,10 @@ nodes
 | CommandInjection.swift:81:6:81:6 | [post] task2 [arguments, Collection element] | semmle.label | [post] task2 [arguments, Collection element] |
 | CommandInjection.swift:81:24:81:46 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | CommandInjection.swift:81:31:81:31 | validatedString | semmle.label | validatedString |
+| CommandInjection.swift:93:20:93:40 | arguments [Collection element] | semmle.label | arguments [Collection element] |
+| CommandInjection.swift:94:3:94:3 | [post] self | semmle.label | [post] self |
+| CommandInjection.swift:94:3:94:3 | [post] self [arguments, Collection element] | semmle.label | [post] self [arguments, Collection element] |
+| CommandInjection.swift:94:20:94:20 | arguments [Collection element] | semmle.label | arguments [Collection element] |
 | CommandInjection.swift:99:8:99:12 | let ...? [some:0] | semmle.label | let ...? [some:0] |
 | CommandInjection.swift:99:12:99:12 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | semmle.label | call to String.init(contentsOf:) |
@@ -217,6 +244,21 @@ nodes
 | CommandInjection.swift:126:2:126:7 | [post] ...? [arguments, Collection element] | semmle.label | [post] ...? [arguments, Collection element] |
 | CommandInjection.swift:126:21:126:42 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | CommandInjection.swift:126:22:126:22 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:130:2:130:2 | [post] task6 | semmle.label | [post] task6 |
+| CommandInjection.swift:130:2:130:2 | [post] task6 [executableURL] | semmle.label | [post] task6 [executableURL] |
+| CommandInjection.swift:130:24:130:65 | call to URL.init(fileURLWithPath:) | semmle.label | call to URL.init(fileURLWithPath:) |
+| CommandInjection.swift:130:45:130:45 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:131:2:131:2 | [post] task6 | semmle.label | [post] task6 |
+| CommandInjection.swift:131:2:131:2 | [post] task6 [executableURL] | semmle.label | [post] task6 [executableURL] |
+| CommandInjection.swift:131:24:131:56 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
+| CommandInjection.swift:131:24:131:57 | ...! | semmle.label | ...! |
+| CommandInjection.swift:131:36:131:36 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:132:2:132:2 | [post] task6 | semmle.label | [post] task6 |
+| CommandInjection.swift:132:2:132:2 | [post] task6 [arguments, Collection element] | semmle.label | [post] task6 [arguments, Collection element] |
+| CommandInjection.swift:132:20:132:41 | [...] [Collection element] | semmle.label | [...] [Collection element] |
+| CommandInjection.swift:132:21:132:21 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:133:21:133:42 | [...] [Collection element] | semmle.label | [...] [Collection element] |
+| CommandInjection.swift:133:22:133:22 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:134:24:134:24 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:144:42:144:42 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:145:67:145:95 | [...] | semmle.label | [...] |
@@ -290,6 +332,7 @@ subpaths
 #select
 | CommandInjection.swift:75:2:75:2 | [post] task1 | CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) | CommandInjection.swift:75:2:75:2 | [post] task1 | This command depends on a $@. | CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) | user-provided value |
 | CommandInjection.swift:81:6:81:6 | [post] task2 | CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) | CommandInjection.swift:81:6:81:6 | [post] task2 | This command depends on a $@. | CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:94:3:94:3 | [post] self | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:94:3:94:3 | [post] self | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
 | CommandInjection.swift:114:2:114:2 | [post] task3 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:114:2:114:2 | [post] task3 | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
 | CommandInjection.swift:115:2:115:2 | [post] task3 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:115:2:115:2 | [post] task3 | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
 | CommandInjection.swift:119:2:119:2 | [post] task4 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:119:2:119:2 | [post] task4 | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
@@ -297,6 +340,9 @@ subpaths
 | CommandInjection.swift:121:2:121:2 | [post] task4 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:121:2:121:2 | [post] task4 | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
 | CommandInjection.swift:125:2:125:7 | [post] ...? | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:125:2:125:7 | [post] ...? | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
 | CommandInjection.swift:126:2:126:7 | [post] ...? | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:126:2:126:7 | [post] ...? | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:130:2:130:2 | [post] task6 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:130:2:130:2 | [post] task6 | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:131:2:131:2 | [post] task6 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:131:2:131:2 | [post] task6 | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:132:2:132:2 | [post] task6 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:132:2:132:2 | [post] task6 | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
 | CommandInjection.swift:144:42:144:42 | userControlledString | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:144:42:144:42 | userControlledString | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
 | CommandInjection.swift:145:67:145:95 | [...] | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:145:67:145:95 | [...] | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
 | CommandInjection.swift:148:23:148:56 | ...! | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:148:23:148:56 | ...! | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |

--- a/swift/ql/test/query-tests/Security/CWE-078/CommandInjection.swift
+++ b/swift/ql/test/query-tests/Security/CWE-078/CommandInjection.swift
@@ -117,7 +117,7 @@ func testCommandInjectionMore(mySafeString: String) {
 
 	let task4 = Process()
 	task4.executableURL = URL(fileURLWithPath: userControlledString) // BAD
-
+	task4.executableURL = URL(string: userControlledString)! // BAD
 	task4.arguments = ["abc", "def" + userControlledString] // BAD
 	try! task4.run()
 
@@ -127,7 +127,7 @@ func testCommandInjectionMore(mySafeString: String) {
 	try! task5?.run()
 
 	let task6 = MyProcess()
-
+	task6.executableURL = URL(fileURLWithPath: userControlledString) // BAD [NOT DETECTED]
 	task6.executableURL = URL(string: userControlledString)! // BAD [NOT DETECTED]
 	task6.arguments = [userControlledString] // BAD [NOT DETECTED]
 	task6.setArguments([userControlledString]) // BAD [NOT DETECTED]

--- a/swift/ql/test/query-tests/Security/CWE-078/CommandInjection.swift
+++ b/swift/ql/test/query-tests/Security/CWE-078/CommandInjection.swift
@@ -91,7 +91,7 @@ class MyProcess : Process {
 	var harmlessField: String?
 
 	func setArguments(_ arguments: [String]) {
-		self.arguments = arguments
+		self.arguments = arguments // BAD
 	}
 }
 
@@ -127,10 +127,10 @@ func testCommandInjectionMore(mySafeString: String) {
 	try! task5?.run()
 
 	let task6 = MyProcess()
-	task6.executableURL = URL(fileURLWithPath: userControlledString) // BAD [NOT DETECTED]
-	task6.executableURL = URL(string: userControlledString)! // BAD [NOT DETECTED]
-	task6.arguments = [userControlledString] // BAD [NOT DETECTED]
-	task6.setArguments([userControlledString]) // BAD [NOT DETECTED]
+	task6.executableURL = URL(fileURLWithPath: userControlledString) // BAD
+	task6.executableURL = URL(string: userControlledString)! // BAD
+	task6.arguments = [userControlledString] // BAD
+	task6.setArguments([userControlledString]) // BAD (flagged inside `setArguments`)
 	task6.harmlessField = userControlledString // GOOD
 	try! task6.run()
 

--- a/swift/ql/test/query-tests/Security/CWE-078/CommandInjection.swift
+++ b/swift/ql/test/query-tests/Security/CWE-078/CommandInjection.swift
@@ -117,6 +117,7 @@ func testCommandInjectionMore(mySafeString: String) {
 
 	let task4 = Process()
 	task4.executableURL = URL(fileURLWithPath: userControlledString) // BAD
+
 	task4.arguments = ["abc", "def" + userControlledString] // BAD
 	try! task4.run()
 
@@ -126,6 +127,7 @@ func testCommandInjectionMore(mySafeString: String) {
 	try! task5?.run()
 
 	let task6 = MyProcess()
+
 	task6.executableURL = URL(string: userControlledString)! // BAD [NOT DETECTED]
 	task6.arguments = [userControlledString] // BAD [NOT DETECTED]
 	task6.setArguments([userControlledString]) // BAD [NOT DETECTED]


### PR DESCRIPTION
Fix a bug in the `defaultImplicitTaintRead` mechanism for reading from field access paths at sinks.  Assuming `source()` is a taint source and `Mid.field` is a sink (say, defined through models-as-data), consider:
```
class Base { }

class Mid : Base {
  var field : String
}

class Derived : Mid {
}

...

base.field = source() // case 1
mid.field = source() // case 2
derived.field = source() // case 3
```
- case 1 is impossible, as `Base` does not have a `field`.
- case 2 is the normal case.  Taint flows from `source()` to the access of `mid` with an access path for `.field`.  `defaultImplicitTaintRead` recognizes that the sink is an access to `Mid` and permits any field of `Mid` to be stripped off the access path, and we get a result.
- in case 3, once again taint flows from `source()` to the access of `derived` with an access path for `.field`.  But this time `defaultImplicitTaintRead` sees that the sink is an access to `Derived` and permits any field of `Derived` to be stripped off the access path.  That's not good enough, it needs to consider fields of base classes of `Derived` as well in order to find `Mid.field`.

In fact we had logic for this, but it was implemented the wrong way around.

TL;DR: `getABaseType*()` was in the wrong place.  Moving it fixes some sinks.

I definitely want to do a DCA run on this one.