### PR TITLE
C#: Update DependencyManager logic to exclude commented out references.

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FileContent.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FileContent.cs
@@ -197,19 +197,19 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             }
         }
 
-        [GeneratedRegex("<PackageReference.*\\sInclude=\"(.*?)\".*/?>", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.Singleline)]
+        [GeneratedRegex("(?<!<!--.*)<PackageReference.*\\sInclude=\"(.*?)\".*/?>", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.Singleline)]
         private static partial Regex PackageReference();
 
-        [GeneratedRegex("<FrameworkReference.*\\sInclude=\"(.*?)\".*/?>", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.Singleline)]
+        [GeneratedRegex("(?<!<!--.*)<FrameworkReference.*\\sInclude=\"(.*?)\".*/?>", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.Singleline)]
         private static partial Regex FrameworkReference();
 
-        [GeneratedRegex("<(.*\\s)?Project.*\\sSdk=\"(.*?)\".*/?>", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.Singleline)]
+        [GeneratedRegex("(?<!<!--.*)<(.*\\s)?Project.*\\sSdk=\"(.*?)\".*/?>", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.Singleline)]
         private static partial Regex ProjectSdk();
 
-        [GeneratedRegex("<Using.*\\sInclude=\"(.*?)\".*/?>", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.Singleline)]
+        [GeneratedRegex("(?<!<!--.*)<Using.*\\sInclude=\"(.*?)\".*/?>", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.Singleline)]
         private static partial Regex CustomImplicitUsingDeclarations();
 
-        [GeneratedRegex("<Import.*\\sProject=\".*Microsoft\\.CSharp\\.targets\".*/?>", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.Singleline)]
+        [GeneratedRegex("(?<!<!--.*)<Import.*\\sProject=\".*Microsoft\\.CSharp\\.targets\".*/?>", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.Singleline)]
         private static partial Regex MicrosoftCSharpTargets();
     }
 

--- a/csharp/extractor/Semmle.Extraction.Tests/FileContent.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/FileContent.cs
@@ -43,6 +43,7 @@ namespace Semmle.Extraction.Tests
                 "<PackageReference Include=\"DotNetAnalyzers.DocumentationAnalyzers\" Version=\"1.0.0-beta.59\" PrivateAssets=\"all\" />",
                 "<PackageReference Version=\"7.0.0\" Include=\"Microsoft.CodeAnalysis.NetAnalyzers\"PrivateAssets=\"all\" />",
                 "<PackageReference Include=\"StyleCop.Analyzers\" Version=\"1.2.0-beta.406\">",
+                "<!-- <PackageReference Include=\"NUnit\" Version=\"3.10.1\" /> -->",
                 "<FrameworkReference Include=\"My.Framework\"/>"
             };
             var fileContent = new TestFileContent(lines);

--- a/csharp/ql/integration-tests/posix-only/standalone_dependencies/Assemblies.expected
+++ b/csharp/ql/integration-tests/posix-only/standalone_dependencies/Assemblies.expected
@@ -169,4 +169,3 @@
 | /microsoft.netcore.app.ref/7.0.2/ref/net7.0/mscorlib.dll |
 | /microsoft.netcore.app.ref/7.0.2/ref/net7.0/netstandard.dll |
 | /newtonsoft.json/12.0.1/lib/portable-net45+win8+wp8+wpa81/Newtonsoft.Json.dll |
-| /nunit/3.13.3/lib/netstandard2.0/nunit.framework.dll |

--- a/csharp/ql/integration-tests/windows-only/standalone_dependencies/Assemblies.expected
+++ b/csharp/ql/integration-tests/windows-only/standalone_dependencies/Assemblies.expected
@@ -213,4 +213,3 @@
 | /microsoft.windowsdesktop.app.ref/7.0.2/ref/net7.0/WindowsBase.dll |
 | /microsoft.windowsdesktop.app.ref/7.0.2/ref/net7.0/WindowsFormsIntegration.dll |
 | /newtonsoft.json/12.0.1/lib/portable-net45+win8+wp8+wpa81/Newtonsoft.Json.dll |
-| /nunit/3.13.3/lib/netstandard2.0/nunit.framework.dll |


### PR DESCRIPTION
In the DependencyManager we do some processing of eg. `PackageReference` and other content.
However, in some cases this might be commented out.
That is, the dependency manager shouldn't detect that we have a package dependency when it comes across something like
```csharp
<!-- <PackageReference Include=\"NUnit\" Version=\"3.10.1\" /> -->
```
as this is commented out.