### PR TITLE
Java: Add more sinks to the Insecure Randomness query

### DIFF
--- a/java/ql/lib/ext/org.pac4j.jwt.config.encryption.model.yml
+++ b/java/ql/lib/ext/org.pac4j.jwt.config.encryption.model.yml
@@ -1,0 +1,9 @@
+extensions:
+  - addsTo:
+      pack: codeql/java-all
+      extensible: sinkModel
+    data:
+      - ["org.pac4j.jwt.config.encryption", "SecretEncryptionConfiguration", True, "SecretEncryptionConfiguration", "", "", "Argument[0]", "credentials-key", "manual"]
+      - ["org.pac4j.jwt.config.encryption", "SecretEncryptionConfiguration", True, "setSecret", "", "", "Argument[0]", "credentials-key", "manual"]
+      - ["org.pac4j.jwt.config.encryption", "SecretEncryptionConfiguration", True, "setSecretBase64", "", "", "Argument[0]", "credentials-key", "manual"]
+      - ["org.pac4j.jwt.config.encryption", "SecretEncryptionConfiguration", True, "setSecretBytes", "", "", "Argument[0]", "credentials-key", "manual"]

--- a/java/ql/lib/ext/org.pac4j.jwt.config.signature.model.yml
+++ b/java/ql/lib/ext/org.pac4j.jwt.config.signature.model.yml
@@ -1,0 +1,9 @@
+extensions:
+  - addsTo:
+      pack: codeql/java-all
+      extensible: sinkModel
+    data:
+      - ["org.pac4j.jwt.config.signature", "SecretSignatureConfiguration", True, "SecretEncryptionConfiguration", "", "", "Argument[0]", "credentials-key", "manual"]
+      - ["org.pac4j.jwt.config.signature", "SecretSignatureConfiguration", True, "setSecret", "", "", "Argument[0]", "credentials-key", "manual"]
+      - ["org.pac4j.jwt.config.signature", "SecretSignatureConfiguration", True, "setSecretBase64", "", "", "Argument[0]", "credentials-key", "manual"]
+      - ["org.pac4j.jwt.config.signature", "SecretSignatureConfiguration", True, "setSecretBytes", "", "", "Argument[0]", "credentials-key", "manual"]

--- a/java/ql/lib/semmle/code/java/frameworks/Netty.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/Netty.qll
@@ -1,0 +1,23 @@
+/** Provides definitions related to the Netty framework. */
+
+import java
+
+/** The interface `Cookie` in the packages `io.netty.handler.codec.http` and `io.netty.handler.codec.http.cookie`. */
+class NettyCookie extends Interface {
+  NettyCookie() { this.hasQualifiedName("io.netty.handler.codec.http" + [".cookie", ""], "Cookie") }
+}
+
+/** The class `DefaultCookie` in the packages `io.netty.handler.codec.http` and `io.netty.handler.codec.http.cookie`. */
+class NettyDefaultCookie extends Class {
+  NettyDefaultCookie() {
+    this.hasQualifiedName("io.netty.handler.codec.http" + [".cookie", ""], "DefaultCookie")
+  }
+}
+
+/** The method `setValue` of the interface `Cookie` or a class implementing it. */
+class NettySetCookieValueMethod extends Method {
+  NettySetCookieValueMethod() {
+    this.getDeclaringType*() instanceof NettyCookie and
+    this.hasName("setValue")
+  }
+}

--- a/java/ql/lib/semmle/code/java/frameworks/OpenSaml.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/OpenSaml.qll
@@ -1,0 +1,29 @@
+/**
+ * Provides classes and predicates for working with the OpenSAML libraries.
+ */
+
+import java
+private import semmle.code.java.security.InsecureRandomnessQuery
+
+/** The interface  `org.opensaml.saml.saml2.core.RequestAbstractType`. */
+class SamlRequestAbstractType extends Interface {
+  SamlRequestAbstractType() {
+    this.hasQualifiedName("org.opensaml.saml.saml2.core", "RequestAbstractType")
+  }
+}
+
+/** The method `setID` of  the interface `RequestAbstractType`. */
+class SamlRequestSetIdMethod extends Method {
+  SamlRequestSetIdMethod() {
+    this.getDeclaringType() instanceof SamlRequestAbstractType and
+    this.hasName("setID")
+  }
+}
+
+private class SamlRequestSetIdSink extends InsecureRandomnessSink {
+  SamlRequestSetIdSink() {
+    exists(MethodCall c | c.getMethod() instanceof SamlRequestSetIdMethod |
+      c.getArgument(0) = this.asExpr()
+    )
+  }
+}

--- a/java/ql/lib/semmle/code/java/frameworks/Servlets.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/Servlets.qll
@@ -244,13 +244,23 @@ class TypeCookie extends Class {
 }
 
 /**
- * The method `getValue(String)` declared in `javax.servlet.http.Cookie`.
+ * The method `getValue()` declared in `javax.servlet.http.Cookie`.
  */
 class CookieGetValueMethod extends Method {
   CookieGetValueMethod() {
     this.getDeclaringType() instanceof TypeCookie and
     this.hasName("getValue") and
     this.getReturnType() instanceof TypeString
+  }
+}
+
+/**
+ * The method `setValue(String)` declared in `javax.servlet.http.Cookie`.
+ */
+class CookieSetValueMethod extends Method {
+  CookieSetValueMethod() {
+    this.getDeclaringType() instanceof TypeCookie and
+    this.hasName("setValue")
   }
 }
 

--- a/java/ql/lib/semmle/code/java/security/Cookies.qll
+++ b/java/ql/lib/semmle/code/java/security/Cookies.qll
@@ -1,0 +1,32 @@
+/** Provides definitions to reason about HTTP cookies. */
+
+import java
+private import semmle.code.java.frameworks.Netty
+private import semmle.code.java.frameworks.Servlets
+
+/** An expression setting the value of a cookie. */
+abstract class SetCookieValue extends Expr { }
+
+private class ServletSetCookieValue extends SetCookieValue {
+  ServletSetCookieValue() {
+    exists(Call c |
+      c.(ClassInstanceExpr).getConstructedType() instanceof TypeCookie and
+      this = c.getArgument(1)
+      or
+      c.(MethodCall).getMethod() instanceof CookieSetValueMethod and
+      this = c.getArgument(0)
+    )
+  }
+}
+
+private class NettySetCookieValue extends SetCookieValue {
+  NettySetCookieValue() {
+    exists(Call c |
+      c.(ClassInstanceExpr).getConstructedType() instanceof NettyDefaultCookie and
+      this = c.getArgument(1)
+      or
+      c.(MethodCall).getMethod() instanceof NettySetCookieValueMethod and
+      this = c.getArgument(0)
+    )
+  }
+}

--- a/java/ql/lib/semmle/code/java/security/InsecureRandomnessQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/InsecureRandomnessQuery.qll
@@ -3,11 +3,12 @@
 import java
 private import semmle.code.java.frameworks.OpenSaml
 private import semmle.code.java.frameworks.Servlets
+private import semmle.code.java.dataflow.ExternalFlow
+private import semmle.code.java.dataflow.TaintTracking
+private import semmle.code.java.security.Cookies
+private import semmle.code.java.security.RandomQuery
 private import semmle.code.java.security.SensitiveActions
 private import semmle.code.java.security.SensitiveApi
-private import semmle.code.java.dataflow.TaintTracking
-private import semmle.code.java.dataflow.ExternalFlow
-private import semmle.code.java.security.RandomQuery
 
 /**
  * A node representing a source of insecure randomness.
@@ -49,16 +50,7 @@ abstract class InsecureRandomnessSink extends DataFlow::Node { }
  * A node which sets the value of a cookie.
  */
 private class CookieSink extends InsecureRandomnessSink {
-  CookieSink() {
-    exists(Call c |
-      c.(ClassInstanceExpr).getConstructedType() instanceof TypeCookie and
-      this.asExpr() = c.getArgument(1)
-      or
-      c.(MethodCall).getMethod().getDeclaringType() instanceof TypeCookie and
-      c.(MethodCall).getMethod().hasName("setValue") and
-      this.asExpr() = c.getArgument(0)
-    )
-  }
+  CookieSink() { this.asExpr() instanceof SetCookieValue }
 }
 
 private class SensitiveActionSink extends InsecureRandomnessSink {
@@ -88,6 +80,17 @@ module InsecureRandomnessConfig implements DataFlow::ConfigSig {
     |
       n1.asExpr() = mc.getArgument(0) and
       n2.asExpr() = mc
+    )
+    or
+    // TODO: Once we have a default sanitizer for UUIDs, we can convert these to global summaries.
+    exists(Call c |
+      c.(ClassInstanceExpr).getConstructedType().hasQualifiedName("java.util", "UUID") and
+      n1.asExpr() = c.getAnArgument() and
+      n2.asExpr() = c
+      or
+      c.(MethodCall).getMethod().hasQualifiedName("java.util", "UUID", "toString") and
+      n1.asExpr() = c.getQualifier() and
+      n2.asExpr() = c
     )
   }
 }

--- a/java/ql/lib/semmle/code/java/security/InsecureRandomnessQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/InsecureRandomnessQuery.qll
@@ -20,7 +20,7 @@ abstract class InsecureRandomnessSource extends DataFlow::Node { }
 private class RandomMethodSource extends InsecureRandomnessSource {
   RandomMethodSource() {
     exists(RandomDataSource s | this.asExpr() = s.getOutput() |
-      not s.getQualifier().getType() instanceof SafeRandomImplementation
+      not s.getSourceOfRandomness() instanceof SafeRandomImplementation
     )
   }
 }
@@ -68,6 +68,8 @@ module InsecureRandomnessConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { sink instanceof InsecureRandomnessSink }
 
   predicate isBarrierIn(DataFlow::Node n) { isSource(n) }
+
+  predicate isBarrierOut(DataFlow::Node n) { isSink(n) }
 
   predicate isAdditionalFlowStep(DataFlow::Node n1, DataFlow::Node n2) {
     n1.asExpr() = n2.asExpr().(BinaryExpr).getAnOperand()

--- a/java/ql/lib/semmle/code/java/security/InsecureRandomnessQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/InsecureRandomnessQuery.qll
@@ -1,6 +1,7 @@
 /** Provides classes and predicates for reasoning about insecure randomness. */
 
 import java
+private import semmle.code.java.frameworks.OpenSaml
 private import semmle.code.java.frameworks.Servlets
 private import semmle.code.java.security.SensitiveActions
 private import semmle.code.java.security.SensitiveApi
@@ -40,7 +41,7 @@ private class TypeHadoopOsSecureRandom extends SafeRandomImplementation {
 }
 
 /**
- * A node representing an operation which should not use a Insecurely random value.
+ * A node representing an operation which should not use an insecurely random value.
  */
 abstract class InsecureRandomnessSink extends DataFlow::Node { }
 

--- a/java/ql/test/query-tests/security/CWE-330/InsecureRandomCookies.java
+++ b/java/ql/test/query-tests/security/CWE-330/InsecureRandomCookies.java
@@ -10,7 +10,7 @@ import javax.servlet.http.Cookie;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.owasp.esapi.Encoder;
 
-public class WeakRandomCookies extends HttpServlet {
+public class InsecureRandomCookies extends HttpServlet {
     HttpServletResponse response;
 
     public void doGet() {
@@ -44,8 +44,8 @@ public class WeakRandomCookies extends HttpServlet {
         byte[] bytes2 = new byte[16];
         sr.nextBytes(bytes2);
         // GOOD: The cookie value is unpredictable.
-        Cookie cookie4 = new Cookie("name", new String(bytes2)); 
-        
+        Cookie cookie4 = new Cookie("name", new String(bytes2));
+
         ThreadLocalRandom tlr = ThreadLocalRandom.current();
 
         Cookie cookie5 = new Cookie("name", Integer.toString(tlr.nextInt())); // $hasWeakRandomFlow

--- a/java/ql/test/query-tests/security/CWE-330/WeakRandomCookies.java
+++ b/java/ql/test/query-tests/security/CWE-330/WeakRandomCookies.java
@@ -19,6 +19,14 @@ public class WeakRandomCookies extends HttpServlet {
         int c = r.nextInt();
         // BAD: The cookie value may be predictable.
         Cookie cookie = new Cookie("name", Integer.toString(c)); // $hasWeakRandomFlow
+        cookie.setValue(Integer.toString(c)); // $hasWeakRandomFlow
+
+        io.netty.handler.codec.http.Cookie nettyCookie =
+                new io.netty.handler.codec.http.DefaultCookie("name", Integer.toString(c)); // $hasWeakRandomFlow
+        nettyCookie.setValue(Integer.toString(c)); // $hasWeakRandomFlow
+        io.netty.handler.codec.http.cookie.Cookie nettyCookie2 =
+                new io.netty.handler.codec.http.cookie.DefaultCookie("name", Integer.toString(c)); // $hasWeakRandomFlow
+        nettyCookie2.setValue(Integer.toString(c)); // $hasWeakRandomFlow
 
         Encoder enc = null;
         int c2 = r.nextInt();

--- a/java/ql/test/query-tests/security/CWE-330/options
+++ b/java/ql/test/query-tests/security/CWE-330/options
@@ -1,1 +1,1 @@
-//semmle-extractor-options: --javac-args -cp ${testdir}/../../../stubs/servlet-api-2.4:${testdir}/../../../stubs/apache-commons-lang3-3.7:${testdir}/../../../stubs/esapi-2.0.1
+//semmle-extractor-options: --javac-args -cp ${testdir}/../../../stubs/servlet-api-2.4:${testdir}/../../../stubs/apache-commons-lang3-3.7:${testdir}/../../../stubs/esapi-2.0.1:${testdir}/../../../stubs/netty-4.1.x

--- a/java/ql/test/stubs/netty-4.1.x/io/netty/handler/codec/http/Cookie.java
+++ b/java/ql/test/stubs/netty-4.1.x/io/netty/handler/codec/http/Cookie.java
@@ -1,0 +1,6 @@
+// Generated automatically from io.netty.handler.codec.http.cookie.Cookie for testing purposes
+
+package io.netty.handler.codec.http;
+
+public interface Cookie extends io.netty.handler.codec.http.cookie.Cookie {
+}

--- a/java/ql/test/stubs/netty-4.1.x/io/netty/handler/codec/http/DefaultCookie.java
+++ b/java/ql/test/stubs/netty-4.1.x/io/netty/handler/codec/http/DefaultCookie.java
@@ -1,0 +1,9 @@
+// Generated automatically from io.netty.handler.codec.http.cookie.DefaultCookie for testing
+// purposes
+
+package io.netty.handler.codec.http;
+
+public class DefaultCookie extends io.netty.handler.codec.http.cookie.DefaultCookie
+        implements Cookie {
+    public DefaultCookie(String p0, String p1) {}
+}


### PR DESCRIPTION
Adds more sinks for increased CVE coverage.

No change note since this is part of https://github.com/github/codeql/pull/13608 and ought to be released at the same time, so they can share change note.