### PR TITLE
C#: Deprecate `UnboundGenericType::getInstanceType/0`

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/Generics.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Generics.qll
@@ -123,11 +123,13 @@ class UnboundGenericType extends ValueOrRefType, UnboundGeneric {
   }
 
   /**
+   * DEPRECATED: predicate does not contain any tuples.
+   *
    * Gets the instance type of this type. For an unbound generic type, the instance type
    * is a constructed type created from the unbound type, with each of the supplied type
    * arguments being the corresponding type parameter.
    */
-  ConstructedType getInstanceType() {
+  deprecated ConstructedType getInstanceType() {
     result = this.getAConstructedGeneric() and
     forall(TypeParameter tp, int i | tp = this.getTypeParameter(i) | tp = result.getTypeArgument(i))
   }
@@ -277,7 +279,7 @@ class TypeParameterConstraints extends Element, @type_parameter_constraints {
  * ```
  */
 class UnboundGenericStruct extends Struct, UnboundGenericType {
-  override ConstructedStruct getInstanceType() {
+  deprecated override ConstructedStruct getInstanceType() {
     result = UnboundGenericType.super.getInstanceType()
   }
 
@@ -300,7 +302,7 @@ class UnboundGenericStruct extends Struct, UnboundGenericType {
  * ```
  */
 class UnboundGenericClass extends Class, UnboundGenericType {
-  override ConstructedClass getInstanceType() {
+  deprecated override ConstructedClass getInstanceType() {
     result = UnboundGenericType.super.getInstanceType()
   }
 
@@ -323,7 +325,7 @@ class UnboundGenericClass extends Class, UnboundGenericType {
  * ```
  */
 class UnboundGenericInterface extends Interface, UnboundGenericType {
-  override ConstructedInterface getInstanceType() {
+  deprecated override ConstructedInterface getInstanceType() {
     result = UnboundGenericType.super.getInstanceType()
   }
 
@@ -347,7 +349,7 @@ class UnboundGenericInterface extends Interface, UnboundGenericType {
  * ```
  */
 class UnboundGenericDelegateType extends DelegateType, UnboundGenericType {
-  override ConstructedDelegateType getInstanceType() {
+  deprecated override ConstructedDelegateType getInstanceType() {
     result = UnboundGenericType.super.getInstanceType()
   }
 


### PR DESCRIPTION
This predicate would never contain any tuples, given that the extractor considers a constructed type `C<T1, ..., Tn>`, where `Ti` is the `i`th type parameter of `C`, identical with the unbound generic type ``C`n``.