### PR TITLE
C#: Add another data flow test

### DIFF
--- a/csharp/ql/test/TestUtilities/InlineFlowTest.qll
+++ b/csharp/ql/test/TestUtilities/InlineFlowTest.qll
@@ -26,7 +26,11 @@ private module FlowTestImpl implements InputSig<CsharpDataFlow> {
   }
 
   string getArgString(DataFlow::Node src, DataFlow::Node sink) {
-    (if exists(getSourceArgString(src)) then result = getSourceArgString(src) else result = "") and
+    (
+      result = getSourceArgString(src)
+      or
+      not exists(getSourceArgString(src)) and result = "line:" + src.getLocation().getStartLine()
+    ) and
     exists(sink)
   }
 }

--- a/csharp/ql/test/library-tests/dataflow/types/Types.cs
+++ b/csharp/ql/test/library-tests/dataflow/types/Types.cs
@@ -13,7 +13,7 @@ class Types
 
     class D : B<string>
     {
-        public override void M() => Sink(this);
+        public override void M() => Sink(this); // $ hasValueFlow=line:32 $ hasValueFlow=line:33 $ hasValueFlow=line:40
     }
 
     static void M1()
@@ -41,13 +41,13 @@ class Types
         M9(new D()); // no flow
 
         object o = null; // flow
-        Sink(o);
+        Sink(o); // $ hasValueFlow=line:43
     }
 
     static void M2(A a)
     {
         if (a is C c)
-            Sink(c);
+            Sink(c); // $ hasValueFlow=line:23
     }
 
     static void M3(A a)
@@ -55,18 +55,18 @@ class Types
         switch (a)
         {
             case D d:
-                Sink(d);
+                Sink(d); // $ hasValueFlow=line:35
                 break;
         }
     }
 
-    static void M4(A a) => Sink((C)a);
+    static void M4(A a) => Sink((C)a); // $ hasValueFlow=line:25
 
-    static void M5<T>(T x) => Sink(x);
+    static void M5<T>(T x) => Sink(x); // $ hasValueFlow=line:26 $ hasValueFlow=line:37
 
-    static void M6<T>(T x) where T : A => Sink(x);
+    static void M6<T>(T x) where T : A => Sink(x); // $ hasValueFlow=line:27 $ hasValueFlow=line:38
 
-    static void M7<T>(T x) where T : class => Sink(x);
+    static void M7<T>(T x) where T : class => Sink(x); // $ hasValueFlow=line:28 $ hasValueFlow=line:39
 
     static void M8<T>(T x)
     {
@@ -77,7 +77,7 @@ class Types
     static void M9(A a)
     {
         if (a is B<int> b)
-            Sink(b);
+            Sink(b); // $ hasValueFlow=line:30
     }
 
     static void Sink<T>(T x) { }
@@ -112,15 +112,15 @@ class Types
 
             public override void M()
             {
-                Sink(this.Field);
+                Sink(this.Field); // $ hasValueFlow=line:110
             }
 
             void M10()
             {
                 var a = new A();
                 var e2 = new E2();
-                Sink(Through(a)); // flow
-                Sink(Through(e2)); // flow
+                Sink(Through(a)); // $ hasValueFlow=line:120
+                Sink(Through(e2)); // $ hasValueFlow=line:121
                 Sink((E2)Through(a)); // no flow
                 Sink((A)Through(e2)); // no flow
             }
@@ -150,6 +150,6 @@ class Types
 
     class FieldC : FieldA
     {
-        public override void M() => Sink(this.Field);
+        public override void M() => Sink(this.Field); // $ hasValueFlow=line:144
     }
 }

--- a/csharp/ql/test/library-tests/dataflow/types/Types.cs
+++ b/csharp/ql/test/library-tests/dataflow/types/Types.cs
@@ -152,4 +152,26 @@ class Types
     {
         public override void M() => Sink(this.Field); // $ hasValueFlow=line:144
     }
+
+    class F
+    {
+        public virtual void M() { }
+
+        class F1<T> : F
+        {
+            public override void M() => Sink(this); // $ hasValueFlow=line:167
+        }
+
+        class F2 : F { }
+
+        F GetF1() => new F1<int>();
+
+        F GetF2() => new F2();
+
+        private void M2()
+        {
+            GetF1().M();
+            GetF2().M();
+        }
+    }
 }

--- a/csharp/ql/test/library-tests/dataflow/types/Types.expected
+++ b/csharp/ql/test/library-tests/dataflow/types/Types.expected
@@ -55,6 +55,9 @@ edges
 | Types.cs:145:13:145:13 | access to parameter c : FieldC [field Field] : Object | Types.cs:138:21:138:25 | this : FieldC [field Field] : Object |
 | Types.cs:153:30:153:30 | this : FieldC [field Field] : Object | Types.cs:153:42:153:45 | this access : FieldC [field Field] : Object |
 | Types.cs:153:42:153:45 | this access : FieldC [field Field] : Object | Types.cs:153:42:153:51 | access to field Field |
+| Types.cs:162:34:162:34 | this : Types+F+F1<Int32> | Types.cs:162:46:162:49 | this access |
+| Types.cs:167:22:167:34 | object creation of type F1<Int32> : Types+F+F1<Int32> | Types.cs:173:13:173:19 | call to method GetF1 : Types+F+F1<Int32> |
+| Types.cs:173:13:173:19 | call to method GetF1 : Types+F+F1<Int32> | Types.cs:162:34:162:34 | this : Types+F+F1<Int32> |
 nodes
 | Types.cs:7:21:7:25 | this : D | semmle.label | this : D |
 | Types.cs:7:32:7:35 | this access : D | semmle.label | this access : D |
@@ -124,6 +127,10 @@ nodes
 | Types.cs:153:30:153:30 | this : FieldC [field Field] : Object | semmle.label | this : FieldC [field Field] : Object |
 | Types.cs:153:42:153:45 | this access : FieldC [field Field] : Object | semmle.label | this access : FieldC [field Field] : Object |
 | Types.cs:153:42:153:51 | access to field Field | semmle.label | access to field Field |
+| Types.cs:162:34:162:34 | this : Types+F+F1<Int32> | semmle.label | this : Types+F+F1<Int32> |
+| Types.cs:162:46:162:49 | this access | semmle.label | this access |
+| Types.cs:167:22:167:34 | object creation of type F1<Int32> : Types+F+F1<Int32> | semmle.label | object creation of type F1<Int32> : Types+F+F1<Int32> |
+| Types.cs:173:13:173:19 | call to method GetF1 : Types+F+F1<Int32> | semmle.label | call to method GetF1 : Types+F+F1<Int32> |
 subpaths
 | Types.cs:122:30:122:30 | access to local variable a : A | Types.cs:130:34:130:34 | x : A | Types.cs:130:40:130:40 | access to parameter x : A | Types.cs:122:22:122:31 | call to method Through |
 | Types.cs:123:30:123:31 | access to local variable e2 : Types+E<D>.E2 | Types.cs:130:34:130:34 | x : Types+E<D>.E2 | Types.cs:130:40:130:40 | access to parameter x : Types+E<D>.E2 | Types.cs:123:22:123:32 | call to method Through |
@@ -146,3 +153,4 @@ subpaths
 | Types.cs:120:25:120:31 | object creation of type A : A | Types.cs:120:25:120:31 | object creation of type A : A | Types.cs:122:22:122:31 | call to method Through | $@ | Types.cs:122:22:122:31 | call to method Through | call to method Through |
 | Types.cs:121:26:121:33 | object creation of type E2 : Types+E<D>.E2 | Types.cs:121:26:121:33 | object creation of type E2 : Types+E<D>.E2 | Types.cs:123:22:123:32 | call to method Through | $@ | Types.cs:123:22:123:32 | call to method Through | call to method Through |
 | Types.cs:144:23:144:34 | object creation of type Object : Object | Types.cs:144:23:144:34 | object creation of type Object : Object | Types.cs:153:42:153:51 | access to field Field | $@ | Types.cs:153:42:153:51 | access to field Field | access to field Field |
+| Types.cs:167:22:167:34 | object creation of type F1<Int32> : Types+F+F1<Int32> | Types.cs:167:22:167:34 | object creation of type F1<Int32> : Types+F+F1<Int32> | Types.cs:162:46:162:49 | this access | $@ | Types.cs:162:46:162:49 | this access | this access |

--- a/csharp/ql/test/library-tests/dataflow/types/Types.expected
+++ b/csharp/ql/test/library-tests/dataflow/types/Types.expected
@@ -1,3 +1,4 @@
+testFailures
 edges
 | Types.cs:7:21:7:25 | this : D | Types.cs:7:32:7:35 | this access : D |
 | Types.cs:7:32:7:35 | this access : D | Types.cs:16:30:16:30 | this : D |

--- a/csharp/ql/test/library-tests/dataflow/types/Types.ql
+++ b/csharp/ql/test/library-tests/dataflow/types/Types.ql
@@ -3,7 +3,8 @@
  */
 
 import csharp
-import Types::PathGraph
+import TestUtilities.InlineFlowTest
+import PathGraph
 
 module TypesConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node src) {
@@ -17,10 +18,12 @@ module TypesConfig implements DataFlow::ConfigSig {
       mc.getAnArgument() = sink.asExpr()
     )
   }
+
+  int fieldFlowBranchLimit() { result = 1000 }
 }
 
-module Types = DataFlow::Global<TypesConfig>;
+import ValueFlowTest<TypesConfig>
 
-from Types::PathNode source, Types::PathNode sink
-where Types::flowPath(source, sink)
+from PathNode source, PathNode sink
+where flowPath(source, sink)
 select source, source, sink, "$@", sink, sink.toString()


### PR DESCRIPTION
I initially thought we didn't handle unbound generic types correctly in our GVN translation, and hence data flow, but [it turns out](https://github.com/github/codeql/blob/c6bc1a3f3ac043cd6714f51f70f2aafa880a48a0/csharp/ql/lib/semmle/code/csharp/Unification.qll#L29) that we actually do properly treat type parameters as type arguments for unbound generic types. So this PR merely confirms that, by adding a test that would otherwise fail.