### PR TITLE
Swift: Simplify AdoptsWkNavigationDelegate in WebView.qll.

### DIFF
--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/WebView.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/WebView.qll
@@ -43,12 +43,7 @@ private class WKScriptMessageBodyInheritsTaint extends TaintInheritingContent,
  */
 private class AdoptsWkNavigationDelegate extends Decl {
   AdoptsWkNavigationDelegate() {
-    exists(ProtocolDecl delegate |
-      this.(ExtensionDecl).getAProtocol().getABaseTypeDecl*() = delegate or
-      this.(NominalTypeDecl).getABaseTypeDecl*() = delegate
-    |
-      delegate.getName() = "WKNavigationDelegate"
-    )
+    this.asNominalTypeDecl().getABaseTypeDecl*().(ProtocolDecl).getName() = "WKNavigationDelegate"
   }
 }
 


### PR DESCRIPTION
Simplify `AdoptsWkNavigationDelegate` in `WebView.qll`.  As promised (quite a while ago) in https://github.com/github/codeql/pull/12044/files#r1091832015 .