### PR TITLE
Swift: Fix an issue with Realm sinks for swift/cleartext-storage-database

### DIFF
--- a/swift/ql/lib/codeql/swift/security/CleartextStorageDatabaseExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextStorageDatabaseExtensions.qll
@@ -58,6 +58,26 @@ private class CoreDataStore extends CleartextStorageDatabaseSink {
 }
 
 /**
+ * The Realm database `RealmSwiftObject` type. Also matches the Realm `Object`
+ * type, which may or may not be a type alias for `RealmSwiftObject`.
+ */
+class RealmSwiftObject extends Type {
+  RealmSwiftObject() {
+    this.getName() = "RealmSwiftObject"
+    or
+    this.getName() = "Object" and
+    this.(NominalType).getDeclaration().getModule().getName() = "RealmSwift"
+  }
+}
+
+/**
+ * A class that inherits from `RealmSwiftObject`.
+ */
+class RealmSwiftObjectType extends Type {
+  RealmSwiftObjectType() { this.getUnderlyingType().getABaseType*() instanceof RealmSwiftObject }
+}
+
+/**
  * A `DataFlow::Node` that is an expression stored with the Realm database
  * library.
  */
@@ -66,10 +86,9 @@ private class RealmStore extends CleartextStorageDatabaseSink instanceof DataFlo
     // any write into a class derived from `RealmSwiftObject` is a sink. For
     // example in `realmObj.data = sensitive` the post-update node corresponding
     // with `realmObj.data` is a sink.
-    exists(NominalType t, Type base, Expr e |
-      base.getName() = "RealmSwiftObject" and
+    exists(Expr e |
       this.getPreUpdateNode().asExpr() = e and
-      e.getFullyConverted().getType().getUnderlyingType().getABaseType*() = base and
+      e.getFullyConverted().getType() instanceof RealmSwiftObjectType and
       not e.(DeclRefExpr).getDecl() instanceof SelfParamDecl
     )
   }

--- a/swift/ql/lib/codeql/swift/security/CleartextStorageDatabaseExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextStorageDatabaseExtensions.qll
@@ -66,10 +66,10 @@ private class RealmStore extends CleartextStorageDatabaseSink instanceof DataFlo
     // any write into a class derived from `RealmSwiftObject` is a sink. For
     // example in `realmObj.data = sensitive` the post-update node corresponding
     // with `realmObj.data` is a sink.
-    exists(NominalType t, Expr e |
-      t.getUnderlyingType().getABaseType*().getName() = "RealmSwiftObject" and
+    exists(NominalType t, Type base, Expr e |
+      base.getName() = "RealmSwiftObject" and
       this.getPreUpdateNode().asExpr() = e and
-      e.getFullyConverted().getType() = t and
+      e.getFullyConverted().getType().getUnderlyingType().getABaseType*() = base and
       not e.(DeclRefExpr).getDecl() instanceof SelfParamDecl
     )
   }

--- a/swift/ql/lib/codeql/swift/security/CleartextStorageDatabaseQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextStorageDatabaseQuery.qll
@@ -34,8 +34,10 @@ module CleartextStorageDatabaseConfig implements DataFlow::ConfigSig {
     // for example in `realmObj.data = sensitive`.
     isSink(node) and
     exists(NominalTypeDecl d, Decl cx |
-      d.getType().getUnderlyingType().getABaseType*().getName() =
-        ["NSManagedObject", "RealmSwiftObject"] and
+      (
+        d.getType().getUnderlyingType().getABaseType*().getName() = "NSManagedObject" or
+        d.getType() instanceof RealmSwiftObjectType
+      ) and
       cx.asNominalTypeDecl() = d and
       c.getAReadContent().(DataFlow::Content::FieldContent).getField() = cx.getAMember()
     )

--- a/swift/ql/src/change-notes/2023-11-06-realm.md
+++ b/swift/ql/src/change-notes/2023-11-06-realm.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+
+* Fixed an issue where some Realm database sinks were not being recognized for the `swift/cleartext-storage-database` query.

--- a/swift/ql/test/query-tests/Security/CWE-311/CleartextStorageDatabase.expected
+++ b/swift/ql/test/query-tests/Security/CWE-311/CleartextStorageDatabase.expected
@@ -73,6 +73,7 @@ edges
 | file://:0:0:0:0 | self | file://:0:0:0:0 | .value2 |
 | file://:0:0:0:0 | self [value] | file://:0:0:0:0 | .value |
 | file://:0:0:0:0 | value | file://:0:0:0:0 | [post] self [data] |
+| file://:0:0:0:0 | value | file://:0:0:0:0 | [post] self [data] |
 | file://:0:0:0:0 | value | file://:0:0:0:0 | [post] self [notStoredBankAccountNumber] |
 | file://:0:0:0:0 | value | file://:0:0:0:0 | [post] self [password] |
 | file://:0:0:0:0 | value | file://:0:0:0:0 | [post] self [value] |
@@ -288,6 +289,10 @@ edges
 | testGRDB.swift:210:85:210:85 | password | testGRDB.swift:210:84:210:93 | [...] [Collection element] |
 | testGRDB.swift:212:98:212:107 | [...] [Collection element] | testGRDB.swift:212:98:212:107 | [...] |
 | testGRDB.swift:212:99:212:99 | password | testGRDB.swift:212:98:212:107 | [...] [Collection element] |
+| testRealm2.swift:13:6:13:6 | value | file://:0:0:0:0 | value |
+| testRealm2.swift:18:2:18:2 | [post] o [data] | testRealm2.swift:18:2:18:2 | [post] o |
+| testRealm2.swift:18:11:18:11 | myPassword | testRealm2.swift:13:6:13:6 | value |
+| testRealm2.swift:18:11:18:11 | myPassword | testRealm2.swift:18:2:18:2 | [post] o [data] |
 | testRealm.swift:27:6:27:6 | value | file://:0:0:0:0 | value |
 | testRealm.swift:34:6:34:6 | value | file://:0:0:0:0 | value |
 | testRealm.swift:41:2:41:2 | [post] a [data] | testRealm.swift:41:2:41:2 | [post] a |
@@ -405,12 +410,14 @@ nodes
 | file://:0:0:0:0 | .value | semmle.label | .value |
 | file://:0:0:0:0 | .value2 | semmle.label | .value2 |
 | file://:0:0:0:0 | [post] self [data] | semmle.label | [post] self [data] |
+| file://:0:0:0:0 | [post] self [data] | semmle.label | [post] self [data] |
 | file://:0:0:0:0 | [post] self [notStoredBankAccountNumber] | semmle.label | [post] self [notStoredBankAccountNumber] |
 | file://:0:0:0:0 | [post] self [password] | semmle.label | [post] self [password] |
 | file://:0:0:0:0 | [post] self [value] | semmle.label | [post] self [value] |
 | file://:0:0:0:0 | self | semmle.label | self |
 | file://:0:0:0:0 | self | semmle.label | self |
 | file://:0:0:0:0 | self [value] | semmle.label | self [value] |
+| file://:0:0:0:0 | value | semmle.label | value |
 | file://:0:0:0:0 | value | semmle.label | value |
 | file://:0:0:0:0 | value | semmle.label | value |
 | file://:0:0:0:0 | value | semmle.label | value |
@@ -701,6 +708,10 @@ nodes
 | testGRDB.swift:212:98:212:107 | [...] | semmle.label | [...] |
 | testGRDB.swift:212:98:212:107 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:212:99:212:99 | password | semmle.label | password |
+| testRealm2.swift:13:6:13:6 | value | semmle.label | value |
+| testRealm2.swift:18:2:18:2 | [post] o | semmle.label | [post] o |
+| testRealm2.swift:18:2:18:2 | [post] o [data] | semmle.label | [post] o [data] |
+| testRealm2.swift:18:11:18:11 | myPassword | semmle.label | myPassword |
 | testRealm.swift:27:6:27:6 | value | semmle.label | value |
 | testRealm.swift:34:6:34:6 | value | semmle.label | value |
 | testRealm.swift:41:2:41:2 | [post] a | semmle.label | [post] a |
@@ -733,6 +744,7 @@ subpaths
 | testCoreData2.swift:98:18:98:18 | d [value] | testCoreData2.swift:70:9:70:9 | self [value] | file://:0:0:0:0 | .value | testCoreData2.swift:98:18:98:20 | .value |
 | testCoreData2.swift:104:18:104:18 | e | testCoreData2.swift:70:9:70:9 | self | file://:0:0:0:0 | .value | testCoreData2.swift:104:18:104:20 | .value |
 | testCoreData2.swift:105:18:105:18 | e | testCoreData2.swift:71:9:71:9 | self | file://:0:0:0:0 | .value2 | testCoreData2.swift:105:18:105:20 | .value2 |
+| testRealm2.swift:18:11:18:11 | myPassword | testRealm2.swift:13:6:13:6 | value | file://:0:0:0:0 | [post] self [data] | testRealm2.swift:18:2:18:2 | [post] o [data] |
 | testRealm.swift:41:11:41:11 | myPassword | testRealm.swift:27:6:27:6 | value | file://:0:0:0:0 | [post] self [data] | testRealm.swift:41:2:41:2 | [post] a [data] |
 | testRealm.swift:49:11:49:11 | myPassword | testRealm.swift:27:6:27:6 | value | file://:0:0:0:0 | [post] self [data] | testRealm.swift:49:2:49:2 | [post] c [data] |
 | testRealm.swift:59:12:59:12 | myPassword | testRealm.swift:27:6:27:6 | value | file://:0:0:0:0 | [post] self [data] | testRealm.swift:59:2:59:3 | [post] ...! [data] |
@@ -864,6 +876,7 @@ subpaths
 | testGRDB.swift:208:80:208:89 | [...] | testGRDB.swift:208:81:208:81 | password | testGRDB.swift:208:80:208:89 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:208:81:208:81 | password | password |
 | testGRDB.swift:210:84:210:93 | [...] | testGRDB.swift:210:85:210:85 | password | testGRDB.swift:210:84:210:93 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:210:85:210:85 | password | password |
 | testGRDB.swift:212:98:212:107 | [...] | testGRDB.swift:212:99:212:99 | password | testGRDB.swift:212:98:212:107 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:212:99:212:99 | password | password |
+| testRealm2.swift:18:2:18:2 | o | testRealm2.swift:18:11:18:11 | myPassword | testRealm2.swift:18:2:18:2 | [post] o | This operation stores 'o' in a database. It may contain unencrypted sensitive data from $@. | testRealm2.swift:18:11:18:11 | myPassword | myPassword |
 | testRealm.swift:41:2:41:2 | a | testRealm.swift:41:11:41:11 | myPassword | testRealm.swift:41:2:41:2 | [post] a | This operation stores 'a' in a database. It may contain unencrypted sensitive data from $@. | testRealm.swift:41:11:41:11 | myPassword | myPassword |
 | testRealm.swift:49:2:49:2 | c | testRealm.swift:49:11:49:11 | myPassword | testRealm.swift:49:2:49:2 | [post] c | This operation stores 'c' in a database. It may contain unencrypted sensitive data from $@. | testRealm.swift:49:11:49:11 | myPassword | myPassword |
 | testRealm.swift:59:2:59:3 | ...! | testRealm.swift:59:12:59:12 | myPassword | testRealm.swift:59:2:59:3 | [post] ...! | This operation stores '...!' in a database. It may contain unencrypted sensitive data from $@. | testRealm.swift:59:12:59:12 | myPassword | myPassword |

--- a/swift/ql/test/query-tests/Security/CWE-311/SensitiveExprs.expected
+++ b/swift/ql/test/query-tests/Security/CWE-311/SensitiveExprs.expected
@@ -138,6 +138,7 @@
 | testGRDB.swift:208:81:208:81 | password | label:password, type:credential |
 | testGRDB.swift:210:85:210:85 | password | label:password, type:credential |
 | testGRDB.swift:212:99:212:99 | password | label:password, type:credential |
+| testRealm2.swift:18:11:18:11 | myPassword | label:myPassword, type:credential |
 | testRealm.swift:31:20:31:20 | .password | label:password, type:credential |
 | testRealm.swift:41:11:41:11 | myPassword | label:myPassword, type:credential |
 | testRealm.swift:49:11:49:11 | myPassword | label:myPassword, type:credential |

--- a/swift/ql/test/query-tests/Security/CWE-311/testRealm2.swift
+++ b/swift/ql/test/query-tests/Security/CWE-311/testRealm2.swift
@@ -15,7 +15,7 @@ class MyRealmSwiftObject3 : Object {
 
 func test1(o: MyRealmSwiftObject3, myHarmless: String, myPassword : String) {
 	// ...
-	o.data = myPassword // BAD [NOT DETECTED]
+	o.data = myPassword // BAD
 	o.data = myHarmless
 	// ...
 }

--- a/swift/ql/test/query-tests/Security/CWE-311/testRealm2.swift
+++ b/swift/ql/test/query-tests/Security/CWE-311/testRealm2.swift
@@ -1,0 +1,21 @@
+//codeql-extractor-options: -module-name RealmSwift
+
+// --- stubs ---
+
+class Object {
+}
+
+// --- tests ---
+
+class MyRealmSwiftObject3 : Object {
+	override init() { data = "" }
+
+	var data: String
+}
+
+func test1(o: MyRealmSwiftObject3, myHarmless: String, myPassword : String) {
+	// ...
+	o.data = myPassword // BAD [NOT DETECTED]
+	o.data = myHarmless
+	// ...
+}


### PR DESCRIPTION
Fix an issue where some Realm database sinks were not being recognized for the `swift/cleartext-storage-database` query.  The assumption is that an object is stored in the Realm database if it has `RealmSwiftObject` as a base type.  In many cases the given base type is in fact `Object`, a [type alias for `RealmSwiftObject`](https://github.com/realm/realm-swift/blob/6b992e508b1fab07d47775f2fd7485fd5f110893/RealmSwift/Object.swift#L83), which is fine and tested.  However it turns out in some snapshots `Object` is in fact a distinct class type (I'm not sure why - maybe a slightly different version or build options for Realm).  This change extends the query to recognize sinks correctly in these cases.

This change gets us several new results results in [DVIA-v2](https://github.com/prateek147/DVIA-v2/blob/master/DVIA-v2/DVIA-v2/Vulnerabilities/Insecure%20Data%20Storage/Controller/RealmViewController.swift#L38C48-L39C52), that we had previously been narrowly failing to catch.