### PR TITLE
Java: Make integration test more robust wrt recent Java versions.

### DIFF
--- a/java/ql/integration-tests/all-platforms/java/diagnostics/java-version-too-old/test.py
+++ b/java/ql/integration-tests/all-platforms/java/diagnostics/java-version-too-old/test.py
@@ -3,9 +3,9 @@ from create_database_utils import *
 from diagnostics_test_utils import *
 
 # Ensure we're using an old Java version that won't work with Gradle
-for java_home in ["JAVA_HOME_8_X64", "JAVA_HOME_8_arm64", "JAVA_HOME_8_ARM64"]:
-  if java_home in os.environ:
-    os.environ["JAVA_HOME"] = os.environ[java_home]
+for k in os.environ:
+  if k.upper() in ["JAVA_HOME_8_X64", "JAVA_HOME_8_ARM64"]:
+    os.environ["JAVA_HOME"] = os.environ[k]
     sep = ";" if platform.system() == "Windows" else ":"
     os.environ["PATH"] = "".join([os.path.join(os.environ["JAVA_HOME"], "bin"), sep, os.environ["PATH"]])
     break

--- a/java/ql/integration-tests/all-platforms/java/diagnostics/java-version-too-old/test.py
+++ b/java/ql/integration-tests/all-platforms/java/diagnostics/java-version-too-old/test.py
@@ -3,14 +3,16 @@ from create_database_utils import *
 from diagnostics_test_utils import *
 
 # Ensure we're using an old Java version that won't work with Gradle
-if "JAVA_HOME_8_X64" in os.environ:
-  os.environ["JAVA_HOME"] = os.environ["JAVA_HOME_8_X64"]
-  sep = ";" if platform.system() == "Windows" else ":"
-  os.environ["PATH"] = "".join([os.path.join(os.environ["JAVA_HOME"], "bin"), sep, os.environ["PATH"]])
+for java_home in ["JAVA_HOME_8_X64", "JAVA_HOME_8_arm64", "JAVA_HOME_8_ARM64"]:
+  if java_home in os.environ:
+    os.environ["JAVA_HOME"] = os.environ[java_home]
+    sep = ";" if platform.system() == "Windows" else ":"
+    os.environ["PATH"] = "".join([os.path.join(os.environ["JAVA_HOME"], "bin"), sep, os.environ["PATH"]])
+    break
 
-# Ensure the autobuilder *doesn't* see Java 11 or 17, which it could switch to in order to build the project:
-for k in ["JAVA_HOME_11_X64", "JAVA_HOME_17_X64"]:
-  if k in os.environ:
+# Ensure the autobuilder *doesn't* see newer Java versions, which it could switch to in order to build the project:
+for k in os.environ:
+  if re.match(r"^JAVA_HOME_\d\d_", k):
     del os.environ[k]
 
 # Use a custom, empty toolchains.xml file so the autobuilder doesn't see any Java versions that may be


### PR DESCRIPTION
I've been investigating moving the Java integration tests to a
GH-hosted macos runner, instead of a self-hosted one.
This test is not compatible with a GH-hosted runners Java setup.
It is also not compatible to being exposed to JAVA_21_HOME_X64 variable yet.
    
This PR fixes both issues.