### PR TITLE
Fix a dead ReDoS link in docs

### DIFF
--- a/java/ql/lib/semmle/code/java/security/regexp/ExponentialBackTracking.qll
+++ b/java/ql/lib/semmle/code/java/security/regexp/ExponentialBackTracking.qll
@@ -3,7 +3,7 @@
  *
  *   James Kirrage, Asiri Rathnayake, Hayo Thielecke: Static Analysis for
  *     Regular Expression Denial-of-Service Attacks. NSS 2013.
- *     (http://www.cs.bham.ac.uk/~hxt/research/reg-exp-sec.pdf)
+ *     (https://arxiv.org/abs/1301.0849)
  *   Asiri Rathnayake, Hayo Thielecke: Static Analysis for Regular Expression
  *     Exponential Runtime via Substructural Logics. 2014.
  *     (https://www.cs.bham.ac.uk/~hxt/research/redos_full.pdf)

--- a/java/ql/src/Security/CWE/CWE-730/ReDoSReferences.inc.qhelp
+++ b/java/ql/src/Security/CWE/CWE-730/ReDoSReferences.inc.qhelp
@@ -10,7 +10,7 @@
 		<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/ReDoS">ReDoS</a>.</li>
 		<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Time_complexity">Time complexity</a>.</li>
 		<li>James Kirrage, Asiri Rathnayake, Hayo Thielecke:
-		<a href="http://www.cs.bham.ac.uk/~hxt/research/reg-exp-sec.pdf">Static Analysis for Regular Expression Denial-of-Service Attack</a>.
+		<a href="https://arxiv.org/abs/1301.0849">Static Analysis for Regular Expression Denial-of-Service Attack</a>.
 		</li>
 	</references>
 </qhelp>

--- a/javascript/ql/lib/semmle/javascript/security/regexp/ExponentialBackTracking.qll
+++ b/javascript/ql/lib/semmle/javascript/security/regexp/ExponentialBackTracking.qll
@@ -3,7 +3,7 @@
  *
  *   James Kirrage, Asiri Rathnayake, Hayo Thielecke: Static Analysis for
  *     Regular Expression Denial-of-Service Attacks. NSS 2013.
- *     (http://www.cs.bham.ac.uk/~hxt/research/reg-exp-sec.pdf)
+ *     (https://arxiv.org/abs/1301.0849)
  *   Asiri Rathnayake, Hayo Thielecke: Static Analysis for Regular Expression
  *     Exponential Runtime via Substructural Logics. 2014.
  *     (https://www.cs.bham.ac.uk/~hxt/research/redos_full.pdf)

--- a/javascript/ql/src/Performance/ReDoSReferences.inc.qhelp
+++ b/javascript/ql/src/Performance/ReDoSReferences.inc.qhelp
@@ -10,7 +10,7 @@
 		<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/ReDoS">ReDoS</a>.</li>
 		<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Time_complexity">Time complexity</a>.</li>
 		<li>James Kirrage, Asiri Rathnayake, Hayo Thielecke:
-		<a href="http://www.cs.bham.ac.uk/~hxt/research/reg-exp-sec.pdf">Static Analysis for Regular Expression Denial-of-Service Attack</a>.
+		<a href="https://arxiv.org/abs/1301.0849">Static Analysis for Regular Expression Denial-of-Service Attack</a>.
 		</li>
 	</references>
 </qhelp>

--- a/python/ql/lib/semmle/python/security/regexp/ExponentialBackTracking.qll
+++ b/python/ql/lib/semmle/python/security/regexp/ExponentialBackTracking.qll
@@ -3,7 +3,7 @@
  *
  *   James Kirrage, Asiri Rathnayake, Hayo Thielecke: Static Analysis for
  *     Regular Expression Denial-of-Service Attacks. NSS 2013.
- *     (http://www.cs.bham.ac.uk/~hxt/research/reg-exp-sec.pdf)
+ *     (https://arxiv.org/abs/1301.0849)
  *   Asiri Rathnayake, Hayo Thielecke: Static Analysis for Regular Expression
  *     Exponential Runtime via Substructural Logics. 2014.
  *     (https://www.cs.bham.ac.uk/~hxt/research/redos_full.pdf)

--- a/python/ql/src/Security/CWE-730/ReDoSReferences.inc.qhelp
+++ b/python/ql/src/Security/CWE-730/ReDoSReferences.inc.qhelp
@@ -10,7 +10,7 @@
 		<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/ReDoS">ReDoS</a>.</li>
 		<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Time_complexity">Time complexity</a>.</li>
 		<li>James Kirrage, Asiri Rathnayake, Hayo Thielecke:
-		<a href="http://www.cs.bham.ac.uk/~hxt/research/reg-exp-sec.pdf">Static Analysis for Regular Expression Denial-of-Service Attack</a>.
+		<a href="https://arxiv.org/abs/1301.0849">Static Analysis for Regular Expression Denial-of-Service Attack</a>.
 		</li>
 	</references>
 </qhelp>

--- a/ruby/ql/lib/codeql/ruby/security/regexp/ExponentialBackTracking.qll
+++ b/ruby/ql/lib/codeql/ruby/security/regexp/ExponentialBackTracking.qll
@@ -3,7 +3,7 @@
  *
  *   James Kirrage, Asiri Rathnayake, Hayo Thielecke: Static Analysis for
  *     Regular Expression Denial-of-Service Attacks. NSS 2013.
- *     (http://www.cs.bham.ac.uk/~hxt/research/reg-exp-sec.pdf)
+ *     (https://arxiv.org/abs/1301.0849)
  *   Asiri Rathnayake, Hayo Thielecke: Static Analysis for Regular Expression
  *     Exponential Runtime via Substructural Logics. 2014.
  *     (https://www.cs.bham.ac.uk/~hxt/research/redos_full.pdf)

--- a/ruby/ql/src/queries/security/cwe-1333/ReDoSReferences.inc.qhelp
+++ b/ruby/ql/src/queries/security/cwe-1333/ReDoSReferences.inc.qhelp
@@ -7,7 +7,7 @@
     <li>Wikipedia: <a href="https://en.wikipedia.org/wiki/ReDoS">ReDoS</a>.</li>
     <li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Time_complexity">Time complexity</a>.</li>
     <li>James Kirrage, Asiri Rathnayake, Hayo Thielecke:
-      <a href="http://www.cs.bham.ac.uk/~hxt/research/reg-exp-sec.pdf">Static Analysis for Regular Expression Denial-of-Service Attack</a>.
+      <a href="https://arxiv.org/abs/1301.0849">Static Analysis for Regular Expression Denial-of-Service Attack</a>.
     </li>
   </references>
 </qhelp>

--- a/shared/regex/codeql/regex/nfa/ExponentialBackTracking.qll
+++ b/shared/regex/codeql/regex/nfa/ExponentialBackTracking.qll
@@ -3,7 +3,7 @@
  *
  *   James Kirrage, Asiri Rathnayake, Hayo Thielecke: Static Analysis for
  *     Regular Expression Denial-of-Service Attacks. NSS 2013.
- *     (http://www.cs.bham.ac.uk/~hxt/research/reg-exp-sec.pdf)
+ *     (https://arxiv.org/abs/1301.0849)
  *   Asiri Rathnayake, Hayo Thielecke: Static Analysis for Regular Expression
  *     Exponential Runtime via Substructural Logics. 2014.
  *     (https://www.cs.bham.ac.uk/~hxt/research/redos_full.pdf)


### PR DESCRIPTION
Fix a dead link related to the ReDoS query in all places where it occurs.
- old link: http://www.cs.bham.ac.uk/~hxt/research/reg-exp-sec.pdf (claimed to be "James Kirrage, Asiri Rathnayake, Hayo Thielecke: Static Analysis for Regular Expression Denial-of-Service Attacks. NSS 2013.", now "404: Not Found")
- new link: https://arxiv.org/abs/1301.0849 ("Static Analysis for Regular Expression Denial-of-Service Attacks James Kirrage, Asiri Rathnayake, Hayo Thielecke")
- I noticed this was a dead link while working on the [Swift ReDoS query `.qhelp`](https://github.com/github/codeql/blob/main/swift/ql/src/queries/Security/CWE-1333/ReDoSReferences.inc.qhelp#L10), and already did the substitution there.  This PR extends that substitution to every other occurrence.