### PR TITLE
C++: Add range analysis testcase

### DIFF
--- a/cpp/ql/test/library-tests/ir/range-analysis/test.cpp
+++ b/cpp/ql/test/library-tests/ir/range-analysis/test.cpp
@@ -130,3 +130,13 @@ void test_div(int x) {
     range(x >> 2); // $ range=>=0 range=<=2
   }
 }
+
+struct X { int n; };
+void read_argument(const X *);
+
+void nonterminating_without_operands_as_ssa(X *x) {
+  read_argument(x);
+  while (x->n) {
+    x->n--;
+  }
+}


### PR DESCRIPTION
This snippet causes non-terminating modulus analysis when we remove IR phi input operands as SSA variables. I think it has something to do with the non-exact phi operand, but I've yet to verify this. For now it's good to simply have this testcase included