### PR TITLE
C#: Tracer improvement for `dotnet test`

### DIFF
--- a/csharp/ql/integration-tests/posix-only/dotnet_test/dotnet_test.csproj
+++ b/csharp/ql/integration-tests/posix-only/dotnet_test/dotnet_test.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -14,4 +13,9 @@
     <PackageReference Include="coverlet.collector" Version="3.2.0" />
   </ItemGroup>
 
+  <Target Name="DeleteBinObjFolders" BeforeTargets="Clean">
+    <RemoveDir Directories=".\bin" />
+    <RemoveDir Directories=".\obj" />
+    <RemoveDir Directories=".\myout" />
+  </Target>
 </Project>

--- a/csharp/ql/integration-tests/posix-only/dotnet_test/test.py
+++ b/csharp/ql/integration-tests/posix-only/dotnet_test/test.py
@@ -8,3 +8,8 @@ check_diagnostics()
 # Explicitly build and then run tests.
 run_codeql_database_create(['dotnet clean', 'rm -rf test-db', 'dotnet build -o myout', 'dotnet test myout/dotnet_test.dll'], test_db="test2-db", lang="csharp")
 check_diagnostics(test_db="test2-db")
+
+thisDir = os.path.abspath(os.getcwd())
+# Explicit build and then run tests using the absolute path.
+run_codeql_database_create(['dotnet clean', 'rm -rf test2-db', 'dotnet build -o myout', f'dotnet test {thisDir}/myout/dotnet_test.dll'], test_db="test3-db", lang="csharp")
+check_diagnostics(test_db="test3-db")

--- a/csharp/tools/tracing-config.lua
+++ b/csharp/tools/tracing-config.lua
@@ -80,15 +80,14 @@ function RegisterExtractorPack(id)
                     end
                 end
 
-                -- for `dotnet test`, we should not append `-p:UseSharedCompilation=false` to the command line
-                -- if an `exe` or `dll` is passed as an argument as the call is forwarded to vstest.
-                if testMatch and (arg:match('%.exe$') or arg:match('%.dll')) then
-                    match = false
-                    break
-                end
-
                 -- we have found a sub-command, ignore all strings that look like sub-command names from now on
                 inSubCommandPosition = false
+            end
+            -- for `dotnet test`, we should not append `-p:UseSharedCompilation=false` to the command line
+            -- if an `exe` or `dll` is passed as an argument as the call is forwarded to vstest.
+            if testMatch and (arg:match('%.exe$') or arg:match('%.dll')) then
+                match = false
+                break
             end
             -- if we see a separator to `dotnet run`, inject just prior to the existing separator
             if arg == '--' then


### PR DESCRIPTION
If an absolute path is provided for a `.dll` or `.exe` file on an OS where slashes `/` are used as directory path separators then the tracer fails to identify that `dotnet test` shouldn't inject the `-p:UseSharedCompilation=false` (as the call is directly delegated to `vstest` and doesn't include any compilation).

This is fixed in this PR.