### PR TITLE
C++: Don't use GVN as SSAVariable in new range analysis

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/SemanticExprSpecific.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/SemanticExprSpecific.qll
@@ -132,17 +132,7 @@ module SemanticExprConfig {
 
   newtype TSsaVariable =
     TSsaInstruction(IR::Instruction instr) { instr.hasMemoryResult() } or
-    TSsaOperand(IR::Operand op) { op.isDefinitionInexact() } or
-    TSsaPointerArithmeticGuard(ValueNumber instr) {
-      exists(Guard g, IR::Operand use |
-        use = instr.getAUse() and use.getIRType() instanceof IR::IRAddressType
-      |
-        g.comparesLt(use, _, _, _, _) or
-        g.comparesLt(_, use, _, _, _) or
-        g.comparesEq(use, _, _, _, _) or
-        g.comparesEq(_, use, _, _, _)
-      )
-    }
+    TSsaOperand(IR::Operand op) { op.isDefinitionInexact() }
 
   class SsaVariable extends TSsaVariable {
     string toString() { none() }
@@ -150,8 +140,6 @@ module SemanticExprConfig {
     Location getLocation() { none() }
 
     IR::Instruction asInstruction() { none() }
-
-    ValueNumber asPointerArithGuard() { none() }
 
     IR::Operand asOperand() { none() }
   }
@@ -166,18 +154,6 @@ module SemanticExprConfig {
     final override Location getLocation() { result = instr.getLocation() }
 
     final override IR::Instruction asInstruction() { result = instr }
-  }
-
-  class SsaPointerArithmeticGuard extends SsaVariable, TSsaPointerArithmeticGuard {
-    ValueNumber vn;
-
-    SsaPointerArithmeticGuard() { this = TSsaPointerArithmeticGuard(vn) }
-
-    final override string toString() { result = vn.toString() }
-
-    final override Location getLocation() { result = vn.getLocation() }
-
-    final override ValueNumber asPointerArithGuard() { result = vn }
   }
 
   class SsaOperand extends SsaVariable, TSsaOperand {
@@ -212,11 +188,7 @@ module SemanticExprConfig {
     )
   }
 
-  Expr getAUse(SsaVariable v) {
-    result.(IR::LoadInstruction).getSourceValue() = v.asInstruction()
-    or
-    result = v.asPointerArithGuard().getAnInstruction()
-  }
+  Expr getAUse(SsaVariable v) { result.(IR::LoadInstruction).getSourceValue() = v.asInstruction() }
 
   SemType getSsaVariableType(SsaVariable v) {
     result = getSemanticType(v.asInstruction().getResultIRType())
@@ -255,10 +227,7 @@ module SemanticExprConfig {
     final override Location getLocation() { result = block.getLocation() }
 
     final override predicate hasRead(SsaVariable v) {
-      exists(IR::Operand operand |
-        operand.getDef() = v.asInstruction() or
-        operand.getDef() = v.asPointerArithGuard().getAnInstruction()
-      |
+      exists(IR::Operand operand | operand.getDef() = v.asInstruction() |
         not operand instanceof IR::PhiInputOperand and
         operand.getUse().getBlock() = block
       )
@@ -276,10 +245,7 @@ module SemanticExprConfig {
     final override Location getLocation() { result = succ.getLocation() }
 
     final override predicate hasRead(SsaVariable v) {
-      exists(IR::PhiInputOperand operand |
-        operand.getDef() = v.asInstruction() or
-        operand.getDef() = v.asPointerArithGuard().getAnInstruction()
-      |
+      exists(IR::PhiInputOperand operand | operand.getDef() = v.asInstruction() |
         operand.getPredecessorBlock() = pred and
         operand.getUse().getBlock() = succ
       )

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-193/InvalidPointerDeref.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-193/InvalidPointerDeref.expected
@@ -22,10 +22,6 @@ edges
 | test.cpp:52:19:52:37 | call to malloc | test.cpp:53:12:53:23 | ... + ... |
 | test.cpp:53:12:53:23 | ... + ... | test.cpp:51:33:51:35 | end |
 | test.cpp:60:34:60:37 | mk_array output argument | test.cpp:67:9:67:14 | ... = ... |
-| test.cpp:194:15:194:33 | call to malloc | test.cpp:195:17:195:23 | ... + ... |
-| test.cpp:195:17:195:23 | ... + ... | test.cpp:195:17:195:23 | ... + ... |
-| test.cpp:195:17:195:23 | ... + ... | test.cpp:201:5:201:19 | ... = ... |
-| test.cpp:195:17:195:23 | ... + ... | test.cpp:201:5:201:19 | ... = ... |
 | test.cpp:205:15:205:33 | call to malloc | test.cpp:206:17:206:23 | ... + ... |
 | test.cpp:206:17:206:23 | ... + ... | test.cpp:206:17:206:23 | ... + ... |
 | test.cpp:206:17:206:23 | ... + ... | test.cpp:213:5:213:13 | ... = ... |
@@ -125,10 +121,6 @@ nodes
 | test.cpp:53:12:53:23 | ... + ... | semmle.label | ... + ... |
 | test.cpp:60:34:60:37 | mk_array output argument | semmle.label | mk_array output argument |
 | test.cpp:67:9:67:14 | ... = ... | semmle.label | ... = ... |
-| test.cpp:194:15:194:33 | call to malloc | semmle.label | call to malloc |
-| test.cpp:195:17:195:23 | ... + ... | semmle.label | ... + ... |
-| test.cpp:195:17:195:23 | ... + ... | semmle.label | ... + ... |
-| test.cpp:201:5:201:19 | ... = ... | semmle.label | ... = ... |
 | test.cpp:205:15:205:33 | call to malloc | semmle.label | call to malloc |
 | test.cpp:206:17:206:23 | ... + ... | semmle.label | ... + ... |
 | test.cpp:206:17:206:23 | ... + ... | semmle.label | ... + ... |
@@ -214,7 +206,6 @@ subpaths
 | test.cpp:30:14:30:15 | * ... | test.cpp:28:15:28:37 | call to malloc | test.cpp:30:14:30:15 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:28:15:28:37 | call to malloc | call to malloc | test.cpp:29:20:29:27 | ... + ... | ... + ... |
 | test.cpp:32:14:32:21 | * ... | test.cpp:28:15:28:37 | call to malloc | test.cpp:32:14:32:21 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@ + 1. | test.cpp:28:15:28:37 | call to malloc | call to malloc | test.cpp:29:20:29:27 | ... + ... | ... + ... |
 | test.cpp:67:9:67:14 | ... = ... | test.cpp:52:19:52:37 | call to malloc | test.cpp:67:9:67:14 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:52:19:52:37 | call to malloc | call to malloc | test.cpp:53:20:53:23 | size | size |
-| test.cpp:201:5:201:19 | ... = ... | test.cpp:194:15:194:33 | call to malloc | test.cpp:201:5:201:19 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:194:15:194:33 | call to malloc | call to malloc | test.cpp:195:21:195:23 | len | len |
 | test.cpp:213:5:213:13 | ... = ... | test.cpp:205:15:205:33 | call to malloc | test.cpp:213:5:213:13 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:205:15:205:33 | call to malloc | call to malloc | test.cpp:206:21:206:23 | len | len |
 | test.cpp:264:13:264:14 | * ... | test.cpp:260:13:260:24 | new[] | test.cpp:264:13:264:14 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:260:13:260:24 | new[] | new[] | test.cpp:261:19:261:21 | len | len |
 | test.cpp:274:5:274:10 | ... = ... | test.cpp:270:13:270:24 | new[] | test.cpp:274:5:274:10 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:270:13:270:24 | new[] | new[] | test.cpp:271:19:271:21 | len | len |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-193/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-193/test.cpp
@@ -198,7 +198,7 @@ void test12(unsigned len, unsigned index) {
         return;
     }
     
-    p[index] = '\0'; // $ deref=L195->L201 // BAD
+    p[index] = '\0'; // $ MISSING: deref=L195->L201 // BAD [NOT DETECTED]
 }
 
 void test13(unsigned len, unsigned index) {


### PR DESCRIPTION
In https://github.com/github/codeql/pull/10555 I added very specialized code to the range analysis library to catch a very specific pattern motivated by https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-10160. This worked really well to convince ourselves that this query can catch real-world issues. Unfortunately, using a value number as an SSA variable gives some weird results because GVN doesn't behave as SSA would.

This PR basically reverts the above PR. We can then figure out how to properly do this once @aschackmull is done with his ongoing work on sharing the range analysis code between C/C++ and Java.