### PR TITLE
JS: catch when the main: path is invalid on Windows

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -892,10 +892,15 @@ protected DependencyInstallationResult preparePackagesAndDependencies(Set<Path> 
           // For named packages, find the main file.
           String name = packageJson.getName();
           if (name != null) {
-            Path entryPoint = guessPackageMainFile(path, packageJson, FileType.TYPESCRIPT.getExtensions());
-            if (entryPoint == null) {
-              // Try a TypeScript-recognized JS extension instead
-              entryPoint = guessPackageMainFile(path, packageJson, Arrays.asList(".js", ".jsx"));
+            Path entryPoint = null; 
+            try {
+              entryPoint = guessPackageMainFile(path, packageJson, FileType.TYPESCRIPT.getExtensions());
+              if (entryPoint == null) {
+                // Try a TypeScript-recognized JS extension instead
+                entryPoint = guessPackageMainFile(path, packageJson, Arrays.asList(".js", ".jsx"));
+              }
+            } catch (InvalidPathException ignore) {
+              // can happen if the `main:` field is invalid. E.g. on Windows a path like `dist/*.js` will crash.
             }
             if (entryPoint != null) {
               System.out.println(relativePath + ": Main file set to " + sourceRoot.relativize(entryPoint));


### PR DESCRIPTION
No test case, because this only causes crashes on Windows (where e.g. `*.js` is not a valid file name).  
That also means I haven't tested it.  
But it should fix the reported error... 

Fixes an internally reported crash on Windows. 
See the backref for a stacktrace and some more details. 