### PR TITLE
C++: Don't use operands as range analysis SSA variables

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/SemanticExprSpecific.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/SemanticExprSpecific.qll
@@ -128,26 +128,10 @@ module SemanticExprConfig {
 
   int getBasicBlockUniqueId(BasicBlock block) { idOf(block.getFirstInstruction().getAst(), result) }
 
-  newtype TSsaVariable = TSsaInstruction(IR::Instruction instr) { instr.hasMemoryResult() }
+  class SsaVariable extends IR::Instruction {
+    SsaVariable() { this.hasMemoryResult() }
 
-  class SsaVariable extends TSsaVariable {
-    string toString() { none() }
-
-    Location getLocation() { none() }
-
-    IR::Instruction asInstruction() { none() }
-  }
-
-  class SsaInstructionVariable extends SsaVariable, TSsaInstruction {
-    IR::Instruction instr;
-
-    SsaInstructionVariable() { this = TSsaInstruction(instr) }
-
-    final override string toString() { result = instr.toString() }
-
-    final override Location getLocation() { result = instr.getLocation() }
-
-    final override IR::Instruction asInstruction() { result = instr }
+    IR::Instruction asInstruction() { result = this }
   }
 
   predicate explicitUpdate(SsaVariable v, Expr sourceExpr) {

--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/SemanticExprSpecific.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/SemanticExprSpecific.qll
@@ -128,9 +128,7 @@ module SemanticExprConfig {
 
   int getBasicBlockUniqueId(BasicBlock block) { idOf(block.getFirstInstruction().getAst(), result) }
 
-  newtype TSsaVariable =
-    TSsaInstruction(IR::Instruction instr) { instr.hasMemoryResult() } or
-    TSsaOperand(IR::Operand op) { op.isDefinitionInexact() }
+  newtype TSsaVariable = TSsaInstruction(IR::Instruction instr) { instr.hasMemoryResult() }
 
   class SsaVariable extends TSsaVariable {
     string toString() { none() }
@@ -138,8 +136,6 @@ module SemanticExprConfig {
     Location getLocation() { none() }
 
     IR::Instruction asInstruction() { none() }
-
-    IR::Operand asOperand() { none() }
   }
 
   class SsaInstructionVariable extends SsaVariable, TSsaInstruction {
@@ -152,18 +148,6 @@ module SemanticExprConfig {
     final override Location getLocation() { result = instr.getLocation() }
 
     final override IR::Instruction asInstruction() { result = instr }
-  }
-
-  class SsaOperand extends SsaVariable, TSsaOperand {
-    IR::Operand op;
-
-    SsaOperand() { this = TSsaOperand(op) }
-
-    final override string toString() { result = op.toString() }
-
-    final override Location getLocation() { result = op.getLocation() }
-
-    final override IR::Operand asOperand() { result = op }
   }
 
   predicate explicitUpdate(SsaVariable v, Expr sourceExpr) {
@@ -181,8 +165,6 @@ module SemanticExprConfig {
   SsaVariable getAPhiInput(SsaVariable v) {
     exists(IR::PhiInstruction instr | v.asInstruction() = instr |
       result.asInstruction() = instr.getAnInput()
-      or
-      result.asOperand() = instr.getAnInputOperand()
     )
   }
 
@@ -192,11 +174,7 @@ module SemanticExprConfig {
     result = getSemanticType(v.asInstruction().getResultIRType())
   }
 
-  BasicBlock getSsaVariableBasicBlock(SsaVariable v) {
-    result = v.asInstruction().getBlock()
-    or
-    result = v.asOperand().getUse().getBlock()
-  }
+  BasicBlock getSsaVariableBasicBlock(SsaVariable v) { result = v.asInstruction().getBlock() }
 
   private newtype TReadPosition =
     TReadPositionBlock(IR::IRBlock block) or
@@ -263,11 +241,7 @@ module SemanticExprConfig {
       pos = TReadPositionPhiInputEdge(operand.getPredecessorBlock(), operand.getUse().getBlock())
     |
       phi.asInstruction() = operand.getUse() and
-      (
-        input.asInstruction() = operand.getDef()
-        or
-        input.asOperand() = operand
-      )
+      input.asInstruction() = operand.getDef()
     )
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/SemanticExprSpecific.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/SemanticExprSpecific.qll
@@ -164,7 +164,7 @@ module SemanticExprConfig {
 
   SsaVariable getAPhiInput(SsaVariable v) {
     exists(IR::PhiInstruction instr | v.asInstruction() = instr |
-      result.asInstruction() = instr.getAnInput()
+      result.asInstruction() = instr.getAnInputOperand().getAnyDef()
     )
   }
 
@@ -241,7 +241,7 @@ module SemanticExprConfig {
       pos = TReadPositionPhiInputEdge(operand.getPredecessorBlock(), operand.getUse().getBlock())
     |
       phi.asInstruction() = operand.getUse() and
-      input.asInstruction() = operand.getDef()
+      input.asInstruction() = operand.getAnyDef()
     )
   }
 


### PR DESCRIPTION
This PR gets rid of operands as SSA variables for range analysis. Merely removing those SSA variables causes nontermination on Wireshark, and in a previous [PR](https://github.com/github/codeql/pull/14708) I reduced the issue to the snippet:
```cpp
struct X { int n; };
void read_argument(const X *);

void nonterminating_without_operands_as_ssa(X *x) {
  read_argument(x);
  while (x->n) {
    x->n--;
  }
}
```
the problem is the `PhiInstruction` before the entry to the `while` loop that merges the incoming edge from (1) `x->n--` and from (2) the initial value of `x` at the entry point of the function. The second operand of that `PhiInstruction` is an _inexact_ operand which means that the IR has deduced that it's not guaranteed that the entire operand will be consumed by the `PhiInstruction`. This can be seen by the `~` prefix on the operand in the IR for the above:
```
4| void nonterminating_without_operands_as_ssa(X*)
4|   Block 0
4|     v4_1(void)           = EnterFunction                  :
4|     m4_2(unknown)        = AliasedDefinition              :
4|     m4_3(unknown)        = InitializeNonLocal             :
4|     m4_4(unknown)        = Chi                            : total:m4_2, partial:m4_3
4|     r4_5(glval<X *>)     = VariableAddress[x]             :
4|     m4_6(X *)            = InitializeParameter[x]         : &:r4_5
4|     r4_7(X *)            = Load[x]                        : &:r4_5, m4_6
4|     m4_8(unknown)        = InitializeIndirection[x]       : &:r4_7
5|     r5_1(glval<unknown>) = FunctionAddress[read_argument] :
5|     r5_2(glval<X *>)     = VariableAddress[x]             :
5|     r5_3(X *)            = Load[x]                        : &:r5_2, m4_6
5|     r5_4(X *)            = Convert                        : r5_3
5|     v5_5(void)           = Call[read_argument]            : func:r5_1, 0:r5_4
5|     m5_6(unknown)        = ^CallSideEffect                : ~m4_4
5|     m5_7(unknown)        = Chi                            : total:m4_4, partial:m5_6
5|     v5_8(void)           = ^BufferReadSideEffect[0]       : &:r5_4, ~m4_8
-|   Goto -> Block 1

6|   Block 1
6|     m6_1(int)        = Phi                : from 0:~m4_8, from 2:m7_7 <--- Here!
6|     m6_2(unknown)    = Phi                : from 0:m4_8, from 2:m7_8
6|     r6_3(glval<X *>) = VariableAddress[x] :
6|     r6_4(X *)        = Load[x]            : &:r6_3, m4_6
6|     r6_5(glval<int>) = FieldAddress[n]    : r6_4
6|     r6_6(int)        = Load[?]            : &:r6_5, m6_1
6|     r6_7(int)        = Constant[0]        :
6|     r6_8(bool)       = CompareNE          : r6_6, r6_7
6|     v6_9(void)       = ConditionalBranch  : r6_8
-|   False -> Block 3
-|   True -> Block 2

7|   Block 2
7|     r7_1(glval<X *>) = VariableAddress[x] :
7|     r7_2(X *)        = Load[x]            : &:r7_1, m4_6
7|     r7_3(glval<int>) = FieldAddress[n]    : r7_2
7|     r7_4(int)        = Load[?]            : &:r7_3, m6_1
7|     r7_5(int)        = Constant[1]        :
7|     r7_6(int)        = Sub                : r7_4, r7_5
7|     m7_7(int)        = Store[?]           : &:r7_3, r7_6
7|     m7_8(unknown)    = Chi                : total:m6_2, partial:m7_7
-|   Goto (back edge) -> Block 1

9|   Block 3
9|     v9_1(void)  = NoOp                 :
4|     v4_9(void)  = ReturnIndirection[x] : &:r4_7, m6_2
4|     v4_10(void) = ReturnVoid           :
4|     v4_11(void) = AliasedUse           : ~m5_7
4|     v4_12(void) = ExitFunction         :
```
And when one uses the `getAnInput()` predicate on `PhiInstruction`s, only the _exact_ operands are returned. So we were missing the phi input at this edge, and this made the modulus analysis nonterminating.

This PR fixes this by replacing `getAnInput()` with `getAnOperand().getAnyDef()`. This means we'll include those inexact operands as well.

Commit-by-commit review recommended:
- The first commit deletes operands from range analysis SSA
- The second commit implements the above small fix
- The final commit does a bit of cleanup