### PR TITLE
Java/C++/RangeAnalysis: Move SsaReadPosition to shared qlpack.

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/SemanticSSA.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/SemanticSSA.qll
@@ -31,35 +31,8 @@ class SemSsaPhiNode extends SemSsaVariable {
   SemSsaPhiNode() { Specific::phi(this) }
 
   final SemSsaVariable getAPhiInput() { result = Specific::getAPhiInput(this) }
-}
 
-class SemSsaReadPosition instanceof Specific::SsaReadPosition {
-  final string toString() { result = super.toString() }
-
-  final Specific::Location getLocation() { result = super.getLocation() }
-
-  final predicate hasReadOfVar(SemSsaVariable var) { Specific::hasReadOfSsaVariable(this, var) }
-}
-
-class SemSsaReadPositionPhiInputEdge extends SemSsaReadPosition {
-  SemBasicBlock origBlock;
-  SemBasicBlock phiBlock;
-
-  SemSsaReadPositionPhiInputEdge() { Specific::phiInputEdge(this, origBlock, phiBlock) }
-
-  predicate phiInput(SemSsaPhiNode phi, SemSsaVariable inp) { Specific::phiInput(this, phi, inp) }
-
-  SemBasicBlock getOrigBlock() { result = origBlock }
-
-  SemBasicBlock getPhiBlock() { result = phiBlock }
-}
-
-class SemSsaReadPositionBlock extends SemSsaReadPosition {
-  SemBasicBlock block;
-
-  SemSsaReadPositionBlock() { Specific::readBlock(this, block) }
-
-  SemBasicBlock getBlock() { result = block }
-
-  SemExpr getAnExpr() { result = this.getBlock().getAnExpr() }
+  final predicate hasInputFromBlock(SemSsaVariable inp, SemBasicBlock bb) {
+    Specific::phiInputFromBlock(this, inp, bb)
+  }
 }

--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/analysis/RangeAnalysisImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/analysis/RangeAnalysisImpl.qll
@@ -74,6 +74,8 @@ module Sem implements Semantic {
 
   BasicBlock getABasicBlockSuccessor(BasicBlock bb) { result = bb.getASuccessor() }
 
+  int getBlockId1(BasicBlock bb) { result = bb.getUniqueId() }
+
   class Guard = SemGuard;
 
   predicate implies_v2 = semImplies_v2/4;
@@ -91,12 +93,6 @@ module Sem implements Semantic {
   class SsaPhiNode = SemSsaPhiNode;
 
   class SsaExplicitUpdate = SemSsaExplicitUpdate;
-
-  class SsaReadPosition = SemSsaReadPosition;
-
-  class SsaReadPositionPhiInputEdge = SemSsaReadPositionPhiInputEdge;
-
-  class SsaReadPositionBlock = SemSsaReadPositionBlock;
 
   predicate conversionCannotOverflow(Type fromType, Type toType) {
     SemanticType::conversionCannotOverflow(fromType, toType)

--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/analysis/RangeUtils.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/analysis/RangeUtils.qll
@@ -133,33 +133,4 @@ module RangeUtil<DeltaSig D, LangSig<Sem, D> Lang> implements UtilSig<Sem, D> {
     or
     not exists(Lang::getAlternateTypeForSsaVariable(var)) and result = var.getType()
   }
-
-  import Ranking
-}
-
-import Ranking
-
-module Ranking {
-  /**
-   * Holds if `rix` is the number of input edges to `phi`.
-   */
-  predicate maxPhiInputRank(SemSsaPhiNode phi, int rix) {
-    rix = max(int r | rankedPhiInput(phi, _, _, r))
-  }
-
-  /**
-   * Holds if `inp` is an input to `phi` along `edge` and this input has index `r`
-   * in an arbitrary 1-based numbering of the input edges to `phi`.
-   */
-  predicate rankedPhiInput(
-    SemSsaPhiNode phi, SemSsaVariable inp, SemSsaReadPositionPhiInputEdge edge, int r
-  ) {
-    edge.phiInput(phi, inp) and
-    edge =
-      rank[r](SemSsaReadPositionPhiInputEdge e |
-        e.phiInput(phi, _)
-      |
-        e order by e.getOrigBlock().getUniqueId()
-      )
-  }
 }

--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/analysis/SignAnalysisCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/analysis/SignAnalysisCommon.qll
@@ -45,7 +45,7 @@ module SignAnalysis<DeltaSig D, UtilSig<Sem, D> Utils> {
   /** An SSA Phi definition, whose sign is the union of the signs of its inputs. */
   private class PhiSignDef extends FlowSignDef instanceof SemSsaPhiNode {
     final override Sign getSign() {
-      exists(SemSsaVariable inp, SemSsaReadPositionPhiInputEdge edge |
+      exists(SemSsaVariable inp, SsaReadPositionPhiInputEdge edge |
         edge.phiInput(this, inp) and
         result = semSsaSign(inp, edge)
       )
@@ -170,11 +170,11 @@ module SignAnalysis<DeltaSig D, UtilSig<Sem, D> Utils> {
     override Sign getSignRestriction() {
       // Propagate via SSA
       // Propagate the sign from the def of `v`, incorporating any inference from guards.
-      result = semSsaSign(v, any(SemSsaReadPositionBlock bb | bb.getAnExpr() = this))
+      result = semSsaSign(v, any(SsaReadPositionBlock bb | bb.getBlock().getAnExpr() = this))
       or
       // No block for this read. Just use the sign of the def.
       // REVIEW: How can this happen?
-      not exists(SemSsaReadPositionBlock bb | bb.getAnExpr() = this) and
+      not exists(SsaReadPositionBlock bb | bb.getBlock().getAnExpr() = this) and
       result = semSsaDefSign(v)
     }
   }
@@ -290,7 +290,7 @@ module SignAnalysis<DeltaSig D, UtilSig<Sem, D> Utils> {
    * to only include bounds for which we might determine a sign.
    */
   private predicate lowerBound(
-    SemExpr lowerbound, SemSsaVariable v, SemSsaReadPosition pos, boolean isStrict
+    SemExpr lowerbound, SemSsaVariable v, SsaReadPosition pos, boolean isStrict
   ) {
     exists(boolean testIsTrue, SemRelationalExpr comp |
       pos.hasReadOfVar(v) and
@@ -314,7 +314,7 @@ module SignAnalysis<DeltaSig D, UtilSig<Sem, D> Utils> {
    * to only include bounds for which we might determine a sign.
    */
   private predicate upperBound(
-    SemExpr upperbound, SemSsaVariable v, SemSsaReadPosition pos, boolean isStrict
+    SemExpr upperbound, SemSsaVariable v, SsaReadPosition pos, boolean isStrict
   ) {
     exists(boolean testIsTrue, SemRelationalExpr comp |
       pos.hasReadOfVar(v) and
@@ -340,7 +340,7 @@ module SignAnalysis<DeltaSig D, UtilSig<Sem, D> Utils> {
    *  - `isEq = true` : `v = eqbound`
    *  - `isEq = false` : `v != eqbound`
    */
-  private predicate eqBound(SemExpr eqbound, SemSsaVariable v, SemSsaReadPosition pos, boolean isEq) {
+  private predicate eqBound(SemExpr eqbound, SemSsaVariable v, SsaReadPosition pos, boolean isEq) {
     exists(SemGuard guard, boolean testIsTrue, boolean polarity, SemExpr e |
       pos.hasReadOfVar(pragma[only_bind_into](v)) and
       guardControlsSsaRead(guard, pragma[only_bind_into](pos), testIsTrue) and
@@ -355,7 +355,7 @@ module SignAnalysis<DeltaSig D, UtilSig<Sem, D> Utils> {
    * Holds if `bound` is a bound for `v` at `pos` that needs to be positive in
    * order for `v` to be positive.
    */
-  private predicate posBound(SemExpr bound, SemSsaVariable v, SemSsaReadPosition pos) {
+  private predicate posBound(SemExpr bound, SemSsaVariable v, SsaReadPosition pos) {
     upperBound(bound, v, pos, _) or
     eqBound(bound, v, pos, true)
   }
@@ -364,7 +364,7 @@ module SignAnalysis<DeltaSig D, UtilSig<Sem, D> Utils> {
    * Holds if `bound` is a bound for `v` at `pos` that needs to be negative in
    * order for `v` to be negative.
    */
-  private predicate negBound(SemExpr bound, SemSsaVariable v, SemSsaReadPosition pos) {
+  private predicate negBound(SemExpr bound, SemSsaVariable v, SsaReadPosition pos) {
     lowerBound(bound, v, pos, _) or
     eqBound(bound, v, pos, true)
   }
@@ -373,24 +373,24 @@ module SignAnalysis<DeltaSig D, UtilSig<Sem, D> Utils> {
    * Holds if `bound` is a bound for `v` at `pos` that can restrict whether `v`
    * can be zero.
    */
-  private predicate zeroBound(SemExpr bound, SemSsaVariable v, SemSsaReadPosition pos) {
+  private predicate zeroBound(SemExpr bound, SemSsaVariable v, SsaReadPosition pos) {
     lowerBound(bound, v, pos, _) or
     upperBound(bound, v, pos, _) or
     eqBound(bound, v, pos, _)
   }
 
   /** Holds if `bound` allows `v` to be positive at `pos`. */
-  private predicate posBoundOk(SemExpr bound, SemSsaVariable v, SemSsaReadPosition pos) {
+  private predicate posBoundOk(SemExpr bound, SemSsaVariable v, SsaReadPosition pos) {
     posBound(bound, v, pos) and TPos() = semExprSign(bound)
   }
 
   /** Holds if `bound` allows `v` to be negative at `pos`. */
-  private predicate negBoundOk(SemExpr bound, SemSsaVariable v, SemSsaReadPosition pos) {
+  private predicate negBoundOk(SemExpr bound, SemSsaVariable v, SsaReadPosition pos) {
     negBound(bound, v, pos) and TNeg() = semExprSign(bound)
   }
 
   /** Holds if `bound` allows `v` to be zero at `pos`. */
-  private predicate zeroBoundOk(SemExpr bound, SemSsaVariable v, SemSsaReadPosition pos) {
+  private predicate zeroBoundOk(SemExpr bound, SemSsaVariable v, SsaReadPosition pos) {
     lowerBound(bound, v, pos, _) and TNeg() = semExprSign(bound)
     or
     lowerBound(bound, v, pos, false) and TZero() = semExprSign(bound)
@@ -408,7 +408,7 @@ module SignAnalysis<DeltaSig D, UtilSig<Sem, D> Utils> {
    * Holds if there is a bound that might restrict whether `v` has the sign `s`
    * at `pos`.
    */
-  private predicate hasGuard(SemSsaVariable v, SemSsaReadPosition pos, Sign s) {
+  private predicate hasGuard(SemSsaVariable v, SsaReadPosition pos, Sign s) {
     s = TPos() and posBound(_, v, pos)
     or
     s = TNeg() and negBound(_, v, pos)
@@ -421,7 +421,7 @@ module SignAnalysis<DeltaSig D, UtilSig<Sem, D> Utils> {
    * might be ruled out by a guard.
    */
   pragma[noinline]
-  private Sign guardedSsaSign(SemSsaVariable v, SemSsaReadPosition pos) {
+  private Sign guardedSsaSign(SemSsaVariable v, SsaReadPosition pos) {
     result = semSsaDefSign(v) and
     pos.hasReadOfVar(v) and
     hasGuard(v, pos, result)
@@ -432,7 +432,7 @@ module SignAnalysis<DeltaSig D, UtilSig<Sem, D> Utils> {
    * can rule it out.
    */
   pragma[noinline]
-  private Sign unguardedSsaSign(SemSsaVariable v, SemSsaReadPosition pos) {
+  private Sign unguardedSsaSign(SemSsaVariable v, SsaReadPosition pos) {
     result = semSsaDefSign(v) and
     pos.hasReadOfVar(v) and
     not hasGuard(v, pos, result)
@@ -443,7 +443,7 @@ module SignAnalysis<DeltaSig D, UtilSig<Sem, D> Utils> {
    * ruled out the sign but does not.
    * This does not check that the definition of `v` also allows the sign.
    */
-  private Sign guardedSsaSignOk(SemSsaVariable v, SemSsaReadPosition pos) {
+  private Sign guardedSsaSignOk(SemSsaVariable v, SsaReadPosition pos) {
     result = TPos() and
     forex(SemExpr bound | posBound(bound, v, pos) | posBoundOk(bound, v, pos))
     or
@@ -455,7 +455,7 @@ module SignAnalysis<DeltaSig D, UtilSig<Sem, D> Utils> {
   }
 
   /** Gets a possible sign for `v` at `pos`. */
-  private Sign semSsaSign(SemSsaVariable v, SemSsaReadPosition pos) {
+  private Sign semSsaSign(SemSsaVariable v, SsaReadPosition pos) {
     result = unguardedSsaSign(v, pos)
     or
     result = guardedSsaSign(v, pos) and

--- a/java/ql/lib/semmle/code/java/dataflow/RangeUtils.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/RangeUtils.qll
@@ -5,7 +5,6 @@
 import java
 private import SSA
 private import semmle.code.java.controlflow.internal.GuardsLogic
-private import semmle.code.java.dataflow.internal.rangeanalysis.SsaReadPositionCommon
 private import semmle.code.java.Constants
 private import semmle.code.java.dataflow.RangeAnalysis
 private import codeql.rangeanalysis.internal.RangeUtils

--- a/java/ql/lib/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisSpecific.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisSpecific.qll
@@ -6,6 +6,8 @@ module Private {
   import semmle.code.java.dataflow.RangeUtils as RU
   private import semmle.code.java.dataflow.SSA as Ssa
   private import semmle.code.java.controlflow.Guards as G
+  private import SsaReadPositionCommon
+  private import semmle.code.java.controlflow.internal.GuardsLogic as GL
   private import Sign
   import Impl
 
@@ -168,7 +170,33 @@ module Private {
 
   predicate ssaRead = RU::ssaRead/2;
 
-  predicate guardControlsSsaRead = RU::guardControlsSsaRead/3;
+  /**
+   * Holds if `guard` directly controls the position `controlled` with the
+   * value `testIsTrue`.
+   */
+  pragma[nomagic]
+  private predicate guardDirectlyControlsSsaRead(
+    Guard guard, SsaReadPosition controlled, boolean testIsTrue
+  ) {
+    guard.directlyControls(controlled.(SsaReadPositionBlock).getBlock(), testIsTrue)
+    or
+    exists(SsaReadPositionPhiInputEdge controlledEdge | controlledEdge = controlled |
+      guard.directlyControls(controlledEdge.getOrigBlock(), testIsTrue) or
+      guard.hasBranchEdge(controlledEdge.getOrigBlock(), controlledEdge.getPhiBlock(), testIsTrue)
+    )
+  }
+
+  /**
+   * Holds if `guard` controls the position `controlled` with the value `testIsTrue`.
+   */
+  predicate guardControlsSsaRead(Guard guard, SsaReadPosition controlled, boolean testIsTrue) {
+    guardDirectlyControlsSsaRead(guard, controlled, testIsTrue)
+    or
+    exists(Guard guard0, boolean testIsTrue0 |
+      GL::implies_v2(guard0, testIsTrue0, guard, testIsTrue) and
+      guardControlsSsaRead(guard0, controlled, testIsTrue0)
+    )
+  }
 }
 
 private module Impl {

--- a/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
+++ b/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
@@ -150,6 +150,16 @@ signature module Semantic {
   /** Gets an immediate successor of basic block `bb`, if any. */
   BasicBlock getABasicBlockSuccessor(BasicBlock bb);
 
+  /**
+   * Gets an ideally unique integer for `bb`. If it is undesirable to make this
+   * unique, then `getBlock2` must provide a tiebreaker, such that the pair
+   * `(getBlockId1(bb),getBlockId2(bb))` becomes unique.
+   */
+  int getBlockId1(BasicBlock bb);
+
+  /** Gets a tiebreaker id in case `getBlockId1` is not unique. */
+  default string getBlockId2(BasicBlock bb) { result = "" }
+
   class Guard {
     string toString();
 
@@ -184,26 +194,13 @@ signature module Semantic {
     BasicBlock getBasicBlock();
   }
 
-  class SsaPhiNode extends SsaVariable;
+  class SsaPhiNode extends SsaVariable {
+    /** Holds if `inp` is an input to the phi node along the edge originating in `bb`. */
+    predicate hasInputFromBlock(SsaVariable inp, BasicBlock bb);
+  }
 
   class SsaExplicitUpdate extends SsaVariable {
     Expr getDefiningExpr();
-  }
-
-  class SsaReadPosition {
-    predicate hasReadOfVar(SsaVariable v);
-  }
-
-  class SsaReadPositionPhiInputEdge extends SsaReadPosition {
-    BasicBlock getOrigBlock();
-
-    BasicBlock getPhiBlock();
-
-    predicate phiInput(SsaPhiNode phi, SsaVariable inp);
-  }
-
-  class SsaReadPositionBlock extends SsaReadPosition {
-    BasicBlock getBlock();
   }
 
   predicate conversionCannotOverflow(Type fromType, Type toType);
@@ -330,19 +327,6 @@ signature module UtilSig<Semantic Sem, DeltaSig DeltaParam> {
    * primitive types as the underlying primitive type.
    */
   Sem::Type getTrackedType(Sem::Expr e);
-
-  /**
-   * Holds if `inp` is an input to `phi` along `edge` and this input has index `r`
-   * in an arbitrary 1-based numbering of the input edges to `phi`.
-   */
-  predicate rankedPhiInput(
-    Sem::SsaPhiNode phi, Sem::SsaVariable inp, Sem::SsaReadPositionPhiInputEdge edge, int r
-  );
-
-  /**
-   * Holds if `rix` is the number of input edges to `phi`.
-   */
-  predicate maxPhiInputRank(Sem::SsaPhiNode phi, int rix);
 }
 
 signature module BoundSig<LocationSig Location, Semantic Sem, DeltaSig D> {
@@ -688,7 +672,7 @@ module RangeStage<
    * - `upper = false` : `v >= e + delta`
    */
   private predicate boundFlowStepSsa(
-    Sem::SsaVariable v, Sem::SsaReadPosition pos, Sem::Expr e, D::Delta delta, boolean upper,
+    Sem::SsaVariable v, SsaReadPosition pos, Sem::Expr e, D::Delta delta, boolean upper,
     SemReason reason
   ) {
     semSsaUpdateStep(v, e, delta) and
@@ -706,7 +690,7 @@ module RangeStage<
 
   /** Holds if `v != e + delta` at `pos` and `v` is of integral type. */
   private predicate unequalFlowStepIntegralSsa(
-    Sem::SsaVariable v, Sem::SsaReadPosition pos, Sem::Expr e, D::Delta delta, SemReason reason
+    Sem::SsaVariable v, SsaReadPosition pos, Sem::Expr e, D::Delta delta, SemReason reason
   ) {
     getTrackedTypeForSsaVariable(v) instanceof Sem::IntegerType and
     exists(Sem::Guard guard, boolean testIsTrue |
@@ -836,7 +820,7 @@ module RangeStage<
    * - `upper = false` : `v >= b + delta`
    */
   private predicate boundedSsa(
-    Sem::SsaVariable v, SemBound b, D::Delta delta, Sem::SsaReadPosition pos, boolean upper,
+    Sem::SsaVariable v, SemBound b, D::Delta delta, SsaReadPosition pos, boolean upper,
     boolean fromBackEdge, D::Delta origdelta, SemReason reason
   ) {
     exists(Sem::Expr mid, D::Delta d1, D::Delta d2, SemReason r1, SemReason r2 |
@@ -873,7 +857,7 @@ module RangeStage<
    * Holds if `v != b + delta` at `pos` and `v` is of integral type.
    */
   private predicate unequalIntegralSsa(
-    Sem::SsaVariable v, SemBound b, D::Delta delta, Sem::SsaReadPosition pos, SemReason reason
+    Sem::SsaVariable v, SemBound b, D::Delta delta, SsaReadPosition pos, SemReason reason
   ) {
     exists(Sem::Expr e, D::Delta d1, D::Delta d2 |
       unequalFlowStepIntegralSsa(v, pos, e, d1, reason) and
@@ -920,7 +904,7 @@ module RangeStage<
    * - `upper = false` : `inp >= b + delta`
    */
   private predicate boundedPhiInp(
-    Sem::SsaPhiNode phi, Sem::SsaVariable inp, Sem::SsaReadPositionPhiInputEdge edge, SemBound b,
+    Sem::SsaPhiNode phi, Sem::SsaVariable inp, SsaReadPositionPhiInputEdge edge, SemBound b,
     D::Delta delta, boolean upper, boolean fromBackEdge, D::Delta origdelta, SemReason reason
   ) {
     edge.phiInput(phi, inp) and
@@ -964,7 +948,7 @@ module RangeStage<
   pragma[noinline]
   private predicate boundedPhiInp1(
     Sem::SsaPhiNode phi, SemBound b, boolean upper, Sem::SsaVariable inp,
-    Sem::SsaReadPositionPhiInputEdge edge, D::Delta delta
+    SsaReadPositionPhiInputEdge edge, D::Delta delta
   ) {
     boundedPhiInp(phi, inp, edge, b, delta, upper, _, _, _)
   }
@@ -976,7 +960,7 @@ module RangeStage<
    * - `upper = false` : `inp >= phi`
    */
   private predicate selfBoundedPhiInp(
-    Sem::SsaPhiNode phi, Sem::SsaVariable inp, Sem::SsaReadPositionPhiInputEdge edge, boolean upper
+    Sem::SsaPhiNode phi, Sem::SsaVariable inp, SsaReadPositionPhiInputEdge edge, boolean upper
   ) {
     exists(D::Delta d, SemSsaBound phibound |
       phibound.getVariable() = phi and
@@ -1009,8 +993,7 @@ module RangeStage<
    */
   private predicate boundedPhiCandValidForEdge(
     Sem::SsaPhiNode phi, SemBound b, D::Delta delta, boolean upper, boolean fromBackEdge,
-    D::Delta origdelta, SemReason reason, Sem::SsaVariable inp,
-    Sem::SsaReadPositionPhiInputEdge edge
+    D::Delta origdelta, SemReason reason, Sem::SsaVariable inp, SsaReadPositionPhiInputEdge edge
   ) {
     boundedPhiCand(phi, upper, b, delta, fromBackEdge, origdelta, reason) and
     (
@@ -1036,7 +1019,7 @@ module RangeStage<
     Sem::SsaPhiNode phi, SemBound b, D::Delta delta, boolean upper, boolean fromBackEdge,
     D::Delta origdelta, SemReason reason, int rix
   ) {
-    exists(Sem::SsaVariable inp, Sem::SsaReadPositionPhiInputEdge edge |
+    exists(Sem::SsaVariable inp, SsaReadPositionPhiInputEdge edge |
       rankedPhiInput(phi, inp, edge, rix) and
       boundedPhiCandValidForEdge(phi, b, delta, upper, fromBackEdge, origdelta, reason, inp, edge)
     |
@@ -1208,7 +1191,7 @@ module RangeStage<
       origdelta = delta and
       reason = TSemNoReason()
       or
-      exists(Sem::SsaVariable v, Sem::SsaReadPositionBlock bb |
+      exists(Sem::SsaVariable v, SsaReadPositionBlock bb |
         boundedSsa(v, b, delta, bb, upper, fromBackEdge, origdelta, reason) and
         e = v.getAUse() and
         bb.getBlock() = e.getBasicBlock()


### PR DESCRIPTION
This should ideally be completely semantics-preserving as a straight refactor, but there was some weirdness around C++ SSA variables, which makes that claim non-trivial, so let's see what DCA says.
Also, I've duplicated a predicate in `SignAnalysisSpecific.qll` in order to avoid C# changes in this PR - that cleanup will follow in a later PR.