### PR TITLE
C++: Fix indirect global-variable flow

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -632,20 +632,20 @@ predicate jumpStep(Node n1, Node n2) {
       v = globalUse.getVariable() and
       n1.(FinalGlobalValue).getGlobalUse() = globalUse
     |
-      globalUse.getIndirectionIndex() = 1 and
+      globalUse.getIndirection() = 1 and
       v = n2.asVariable()
       or
-      v = n2.asIndirectVariable(globalUse.getIndirectionIndex())
+      v = n2.asIndirectVariable(globalUse.getIndirection())
     )
     or
     exists(Ssa::GlobalDef globalDef |
       v = globalDef.getVariable() and
       n2.(InitialGlobalValue).getGlobalDef() = globalDef
     |
-      globalDef.getIndirectionIndex() = 1 and
+      globalDef.getIndirection() = 1 and
       v = n1.asVariable()
       or
-      v = n1.asIndirectVariable(globalDef.getIndirectionIndex())
+      v = n1.asIndirectVariable(globalDef.getIndirection())
     )
   )
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -1007,6 +1007,9 @@ class GlobalDef extends TGlobalDef, SsaDefOrUse {
   }
 
   /** Gets the indirection index of this definition. */
+  int getIndirection() { result = global.getIndirection() }
+
+  /** Gets the indirection index of this definition. */
   int getIndirectionIndex() { result = global.getIndirectionIndex() }
 
   /**

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -143,11 +143,10 @@ private newtype TDefOrUseImpl =
 private predicate isGlobalUse(
   GlobalLikeVariable v, IRFunction f, int indirection, int indirectionIndex
 ) {
-  exists(VariableAddressInstruction vai, int defIndex |
+  exists(VariableAddressInstruction vai |
     vai.getEnclosingIRFunction() = f and
     vai.getAstVariable() = v and
-    isDef(_, _, _, vai, indirection, defIndex) and
-    indirectionIndex = [0 .. defIndex] + 1
+    isDef(_, _, _, vai, indirection, indirectionIndex)
   )
 }
 
@@ -158,7 +157,7 @@ private predicate isGlobalDefImpl(
     vai.getEnclosingIRFunction() = f and
     vai.getAstVariable() = v and
     isUse(_, _, vai, indirection, indirectionIndex) and
-    not isDef(_, _, vai.getAUse(), _, _, _)
+    not isDef(_, _, _, vai, _, indirectionIndex)
   )
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -525,7 +525,7 @@ class GlobalDefImpl extends DefOrUseImpl, TGlobalDefImpl {
    */
   Type getUnspecifiedType() { result = global.getUnspecifiedType() }
 
-  override string toString() { result = "GlobalDef" }
+  override string toString() { result = "Def of " + this.getSourceVariable() }
 
   override Location getLocation() { result = f.getLocation() }
 
@@ -995,7 +995,7 @@ class GlobalDef extends TGlobalDef, SsaDefOrUse {
   final override Location getLocation() { result = global.getLocation() }
 
   /** Gets a textual representation of this definition. */
-  override string toString() { result = "GlobalDef" }
+  override string toString() { result = global.toString() }
 
   /**
    * Holds if this definition has index `index` in block `block`, and

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -472,7 +472,9 @@ class GlobalUse extends UseImpl, TGlobalUse {
     )
   }
 
-  override SourceVariable getSourceVariable() { sourceVariableIsGlobal(result, global, f, ind) }
+  override SourceVariable getSourceVariable() {
+    sourceVariableIsGlobal(result, global, f, this.getIndirection())
+  }
 
   final override Cpp::Location getLocation() { result = f.getLocation() }
 
@@ -513,8 +515,10 @@ class GlobalDefImpl extends DefOrUseImpl, TGlobalDefImpl {
 
   /** Gets the global variable associated with this definition. */
   override SourceVariable getSourceVariable() {
-    sourceVariableIsGlobal(result, global, f, indirectionIndex)
+    sourceVariableIsGlobal(result, global, f, this.getIndirection())
   }
+
+  int getIndirection() { result = indirectionIndex }
 
   /**
    * Gets the type of this use after specifiers have been deeply stripped

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
@@ -23,6 +23,7 @@ argHasPostUpdate
 | lambdas.cpp:38:2:38:2 | d | ArgumentNode is missing PostUpdateNode. |
 | lambdas.cpp:45:2:45:2 | e | ArgumentNode is missing PostUpdateNode. |
 | test.cpp:67:29:67:35 | source1 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:813:19:813:35 | * ... | ArgumentNode is missing PostUpdateNode. |
 postWithInFlow
 | BarrierGuard.cpp:49:6:49:6 | x [post update] | PostUpdateNode should not be the target of local flow. |
 | BarrierGuard.cpp:60:7:60:7 | x [post update] | PostUpdateNode should not be the target of local flow. |
@@ -136,6 +137,9 @@ postWithInFlow
 | test.cpp:728:3:728:4 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:728:4:728:4 | p [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:734:41:734:41 | x [inner post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:808:5:808:21 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:808:6:808:21 | global_indirect1 [inner post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:832:5:832:17 | global_direct [post update] | PostUpdateNode should not be the target of local flow. |
 viableImplInCallContextTooLarge
 uniqueParameterNodeAtPosition
 uniqueParameterNodePosition

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
@@ -797,3 +797,43 @@ void test() {
   intPointerSource(a.content, a.content);
   indirect_sink(a.content); // $ ast ir
 }
+
+namespace MoreGlobalTests {
+  int **global_indirect1;
+  int **global_indirect2;
+  int **global_direct;
+
+  void set_indirect1()
+  {
+    *global_indirect1 = indirect_source();
+  }
+
+  void read_indirect1() {
+    sink(global_indirect1); // clean
+    indirect_sink(*global_indirect1); // $ MISSING: ir,ast
+  }
+
+  void set_indirect2()
+  {
+    **global_indirect2 = source();
+  }
+
+  void read_indirect2() {
+    sink(global_indirect2); // clean
+    sink(**global_indirect2); // $ MISSING: ir,ast
+  }
+
+  // overload source with a boolean parameter so
+  // that we can define a variant that return an int**.
+  int** source(bool);
+
+  void set_direct()
+  {
+    global_direct = source(true);
+  }
+
+  void read_direct() {
+    sink(global_direct); // $ ir MISSING: ast
+    indirect_sink(global_direct); // clean
+  }
+}

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
@@ -810,7 +810,7 @@ namespace MoreGlobalTests {
 
   void read_indirect1() {
     sink(global_indirect1); // clean
-    indirect_sink(*global_indirect1); // $ MISSING: ir,ast
+    indirect_sink(*global_indirect1); // $ ir MISSING: ast
   }
 
   void set_indirect2()
@@ -820,7 +820,7 @@ namespace MoreGlobalTests {
 
   void read_indirect2() {
     sink(global_indirect2); // clean
-    sink(**global_indirect2); // $ MISSING: ir,ast
+    sink(**global_indirect2); // $ ir MISSING: ast
   }
 
   // overload source with a boolean parameter so

--- a/cpp/ql/test/library-tests/syntax-zoo/dataflow-ir-consistency.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/dataflow-ir-consistency.expected
@@ -4,7 +4,12 @@ uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
-| cpp11.cpp:50:15:50:16 | (no string representation) | Node should have one toString but has 0. |
+| builtin.c:5:5:5:11 | (no string representation) | Node should have one toString but has 0. |
+| misc.c:227:7:227:28 | (no string representation) | Node should have one toString but has 0. |
+| static_init_templates.cpp:80:18:80:23 | (no string representation) | Node should have one toString but has 0. |
+| static_init_templates.cpp:80:18:80:23 | (no string representation) | Node should have one toString but has 0. |
+| static_init_templates.cpp:89:18:89:23 | (no string representation) | Node should have one toString but has 0. |
+| static_init_templates.cpp:89:18:89:23 | (no string representation) | Node should have one toString but has 0. |
 parameterCallable
 localFlowIsLocal
 readStepIsLocal


### PR DESCRIPTION
The logic for handling indirections of global variables was all wrong 😭. This PR hopefully fixes this logic 🤞.

The first commit adds a bunch of tests. I've then split the fix into a sequence of small commits. Finally, the last commit accepts the test changes.

There are a couple of new inconsistencies regarding missing `toString` on some esoteric syntax. I haven't investigated those yet, but I don't think they should block this PR.

@jketema I'm requesting a review from you because you initially identified these missing steps. Let me know what I can do to help the review process here!