### PR TITLE
Take our node, not the one that comes first on the PATH.

### DIFF
--- a/javascript/extractor/lib/typescript/BUILD.bazel
+++ b/javascript/extractor/lib/typescript/BUILD.bazel
@@ -17,7 +17,7 @@ genrule(
         # we need a temp dir, and unfortunately, $TMPDIR is not set on Windows
         "export TEMP=$$(mktemp -d)",
         # Add node to the path so that npm run can find it - it's calling env node
-        "export PATH=$$PATH:$$BAZEL_ROOT/$$(dirname $(execpath @nodejs//:node_bin))",
+        "export PATH=$$BAZEL_ROOT/$$(dirname $(execpath @nodejs//:node_bin)):$$PATH",
         "export NPM=$$BAZEL_ROOT/$(execpath @nodejs//:npm_bin)",
         # npm has a global cache which doesn't work on macos, where absolute paths aren't filtered out by the sandbox.
         # Therefore, set a temporary cache directory.


### PR DESCRIPTION
This pull request includes a single change to the `javascript/extractor/lib/typescript/BUILD.bazel` file to reorder the `PATH` environment variable in the `genrule(` function. This ensures that the `node` executable is found in the correct location when running `npm run` commands.