### PR TITLE
C# integration tests: Prepare for moving to GH-hosted ARM runner

### DIFF
--- a/cpp/autobuilder/Semmle.Autobuild.Cpp.Tests/BuildScripts.cs
+++ b/cpp/autobuilder/Semmle.Autobuild.Cpp.Tests/BuildScripts.cs
@@ -145,9 +145,9 @@ namespace Semmle.Autobuild.Cpp.Tests
 
         bool IBuildActions.IsMacOs() => IsMacOs;
 
-        public bool IsArm { get; set; }
+        public bool IsRunningOnAppleSilicon { get; set; }
 
-        bool IBuildActions.IsArm() => IsArm;
+        bool IBuildActions.IsRunningOnAppleSilicon() => IsRunningOnAppleSilicon;
 
         string IBuildActions.PathCombine(params string[] parts)
         {

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
@@ -159,9 +159,9 @@ namespace Semmle.Autobuild.CSharp.Tests
 
         bool IBuildActions.IsMacOs() => IsMacOs;
 
-        public bool IsArm { get; set; }
+        public bool IsRunningOnAppleSilicon { get; set; }
 
-        bool IBuildActions.IsArm() => IsArm;
+        bool IBuildActions.IsRunningOnAppleSilicon() => IsRunningOnAppleSilicon;
 
         public string PathCombine(params string[] parts)
         {

--- a/csharp/autobuilder/Semmle.Autobuild.Shared/BuildActions.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.Shared/BuildActions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Xml;
 using Semmle.Util;
@@ -119,10 +120,10 @@ namespace Semmle.Autobuild.Shared
         bool IsMacOs();
 
         /// <summary>
-        /// Gets a value indicating whether we are running on arm.
+        /// Gets a value indicating whether we are running on Apple Silicon.
         /// </summary>
-        /// <returns>True if we are running on arm.</returns>
-        bool IsArm();
+        /// <returns>True if we are running on Apple Silicon.</returns>
+        bool IsRunningOnAppleSilicon();
 
         /// <summary>
         /// Combine path segments, Path.Combine().
@@ -240,9 +241,25 @@ namespace Semmle.Autobuild.Shared
 
         bool IBuildActions.IsMacOs() => RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 
-        bool IBuildActions.IsArm() =>
-            RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ||
-            RuntimeInformation.ProcessArchitecture == Architecture.Arm;
+        bool IBuildActions.IsRunningOnAppleSilicon()
+        {
+            var thisBuildActions = (IBuildActions)this;
+
+            if (!thisBuildActions.IsMacOs())
+            {
+                return false;
+            }
+
+            try
+            {
+                var res = thisBuildActions.RunProcess("sysctl", "machdep.cpu.brand_string", workingDirectory: null, env: null, out var stdOut);
+                return stdOut?.Any(s => s?.ToLowerInvariant().Contains("apple") == true) ?? false;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
 
         string IBuildActions.PathCombine(params string[] parts) => Path.Combine(parts);
 

--- a/csharp/autobuilder/Semmle.Autobuild.Shared/MsBuildRule.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.Shared/MsBuildRule.cs
@@ -15,12 +15,12 @@ namespace Semmle.Autobuild.Shared
         /// <returns></returns>
         public static CommandBuilder MsBuildCommand(this CommandBuilder cmdBuilder, IAutobuilder<AutobuildOptionsShared> builder)
         {
-            var isArmMac = builder.Actions.IsMacOs() && builder.Actions.IsArm();
+            var IsRunningOnAppleSiliconMac = builder.Actions.IsMacOs() && builder.Actions.IsRunningOnAppleSilicon();
 
             // mono doesn't ship with `msbuild` on Arm-based Macs, but we can fall back to
             // msbuild that ships with `dotnet` which can be invoked with `dotnet msbuild`
             // perhaps we should do this on all platforms?
-            return isArmMac ?
+            return IsRunningOnAppleSiliconMac ?
                 cmdBuilder.RunCommand("dotnet").Argument("msbuild") :
                 cmdBuilder.RunCommand("msbuild");
         }

--- a/csharp/ql/integration-tests/all-platforms/msbuild/test.py
+++ b/csharp/ql/integration-tests/all-platforms/msbuild/test.py
@@ -1,5 +1,23 @@
+import os
+
 from create_database_utils import *
 from diagnostics_test_utils import *
+
+def is_running_on_apple_silicon():
+   arch = subprocess.Popen(['sysctl', 'machdep.cpu.brand_string'], stdout=subprocess.PIPE)
+   output, errors = arch.communicate()
+   if b'apple' in output.lower():
+       return True
+   return False
+
+# if on ARM runners, remove Mono from the path, so we're using
+# dotnet restore instead of nuget.exe restore - on ARM machines
+# we run dotner msbuild (instead of the mono-provided msbuild.exe)
+# so we need to match the restore command, too.
+
+platform_name = sys.platform.lower()
+if platform_name.startswith("darwin") and is_running_on_apple_silicon():
+    os.environ["PATH"] = os.environ["PATH"].replace("/Library/Frameworks/Mono.framework/Versions/Current/Commands:", "")
 
 # force CodeQL to use MSBuild by setting `LGTM_INDEX_MSBUILD_TARGET`
 run_codeql_database_create([], db=None, lang="csharp", extra_env={ 'LGTM_INDEX_MSBUILD_TARGET': 'Build' })


### PR DESCRIPTION
This PR allows us to move the C# MacOS ARM integration tests to a GH-hosted runner.