### PR TITLE
C#: Change IsARM to Apple silicon check

### DIFF
--- a/cpp/autobuilder/Semmle.Autobuild.Cpp.Tests/BuildScripts.cs
+++ b/cpp/autobuilder/Semmle.Autobuild.Cpp.Tests/BuildScripts.cs
@@ -145,9 +145,9 @@ namespace Semmle.Autobuild.Cpp.Tests
 
         bool IBuildActions.IsMacOs() => IsMacOs;
 
-        public bool IsArm { get; set; }
+        public bool IsRunningOnAppleSilicon { get; set; }
 
-        bool IBuildActions.IsArm() => IsArm;
+        bool IBuildActions.IsRunningOnAppleSilicon() => IsRunningOnAppleSilicon;
 
         string IBuildActions.PathCombine(params string[] parts)
         {

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
@@ -159,9 +159,9 @@ namespace Semmle.Autobuild.CSharp.Tests
 
         bool IBuildActions.IsMacOs() => IsMacOs;
 
-        public bool IsArm { get; set; }
+        public bool IsRunningOnAppleSilicon { get; set; }
 
-        bool IBuildActions.IsArm() => IsArm;
+        bool IBuildActions.IsRunningOnAppleSilicon() => IsRunningOnAppleSilicon;
 
         public string PathCombine(params string[] parts)
         {

--- a/csharp/autobuilder/Semmle.Autobuild.Shared/BuildActions.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.Shared/BuildActions.cs
@@ -252,7 +252,7 @@ namespace Semmle.Autobuild.Shared
 
             try
             {
-                var res = thisBuildActions.RunProcess("sysctl", "machdep.cpu.brand_string", workingDirectory: null, env: null, out var stdOut);
+                thisBuildActions.RunProcess("sysctl", "machdep.cpu.brand_string", workingDirectory: null, env: null, out var stdOut);
                 return stdOut?.Any(s => s?.ToLowerInvariant().Contains("apple") == true) ?? false;
             }
             catch (Exception)

--- a/csharp/autobuilder/Semmle.Autobuild.Shared/BuildActions.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.Shared/BuildActions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Xml;
 using Semmle.Util;
@@ -119,10 +120,10 @@ namespace Semmle.Autobuild.Shared
         bool IsMacOs();
 
         /// <summary>
-        /// Gets a value indicating whether we are running on arm.
+        /// Gets a value indicating whether we are running on Apple Silicon.
         /// </summary>
-        /// <returns>True if we are running on arm.</returns>
-        bool IsArm();
+        /// <returns>True if we are running on Apple Silicon.</returns>
+        bool IsRunningOnAppleSilicon();
 
         /// <summary>
         /// Combine path segments, Path.Combine().
@@ -240,9 +241,25 @@ namespace Semmle.Autobuild.Shared
 
         bool IBuildActions.IsMacOs() => RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 
-        bool IBuildActions.IsArm() =>
-            RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ||
-            RuntimeInformation.ProcessArchitecture == Architecture.Arm;
+        bool IBuildActions.IsRunningOnAppleSilicon()
+        {
+            var thisBuildActions = (IBuildActions)this;
+
+            if (!thisBuildActions.IsMacOs())
+            {
+                return false;
+            }
+
+            try
+            {
+                var res = thisBuildActions.RunProcess("sysctl", "machdep.cpu.brand_string", workingDirectory: null, env: null, out var stdOut);
+                return stdOut?.Any(s => s?.ToLowerInvariant().Contains("apple") == true) ?? false;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
 
         string IBuildActions.PathCombine(params string[] parts) => Path.Combine(parts);
 

--- a/csharp/autobuilder/Semmle.Autobuild.Shared/MsBuildRule.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.Shared/MsBuildRule.cs
@@ -15,12 +15,12 @@ namespace Semmle.Autobuild.Shared
         /// <returns></returns>
         public static CommandBuilder MsBuildCommand(this CommandBuilder cmdBuilder, IAutobuilder<AutobuildOptionsShared> builder)
         {
-            var isArmMac = builder.Actions.IsMacOs() && builder.Actions.IsArm();
+            var IsRunningOnAppleSiliconMac = builder.Actions.IsMacOs() && builder.Actions.IsRunningOnAppleSilicon();
 
             // mono doesn't ship with `msbuild` on Arm-based Macs, but we can fall back to
             // msbuild that ships with `dotnet` which can be invoked with `dotnet msbuild`
             // perhaps we should do this on all platforms?
-            return isArmMac ?
+            return IsRunningOnAppleSiliconMac ?
                 cmdBuilder.RunCommand("dotnet").Argument("msbuild") :
                 cmdBuilder.RunCommand("msbuild");
         }

--- a/csharp/autobuilder/Semmle.Autobuild.Shared/MsBuildRule.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.Shared/MsBuildRule.cs
@@ -15,14 +15,12 @@ namespace Semmle.Autobuild.Shared
         /// <returns></returns>
         public static CommandBuilder MsBuildCommand(this CommandBuilder cmdBuilder, IAutobuilder<AutobuildOptionsShared> builder)
         {
-            var IsRunningOnAppleSiliconMac = builder.Actions.IsMacOs() && builder.Actions.IsRunningOnAppleSilicon();
-
             // mono doesn't ship with `msbuild` on Arm-based Macs, but we can fall back to
             // msbuild that ships with `dotnet` which can be invoked with `dotnet msbuild`
             // perhaps we should do this on all platforms?
-            return IsRunningOnAppleSiliconMac ?
-                cmdBuilder.RunCommand("dotnet").Argument("msbuild") :
-                cmdBuilder.RunCommand("msbuild");
+            return builder.Actions.IsRunningOnAppleSilicon()
+                ? cmdBuilder.RunCommand("dotnet").Argument("msbuild")
+                : cmdBuilder.RunCommand("msbuild");
         }
     }
 


### PR DESCRIPTION
The autobuilder was checking if the process was on ARM macos, and executed `dotnet msbuild` instead of `msbuild` if so. However, we execute an x64 dotnet binary on an ARM machine, so the execution platform reported is x64, which in turn leads to running `msbuild`, and not `dotnet msbuild`. Instead of checking the execution platform, we're now checking the host operating system, as that's relevant to whether the mono installation has msbuild or not.