### PR TITLE
C++: Fix nonterminating test

### DIFF
--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/UnboundedWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/UnboundedWrite.expected
@@ -1,4 +1,4 @@
 edges
-subpaths
 nodes
+subpaths
 #select

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/UnboundedWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/UnboundedWrite.expected
@@ -1,4 +1,16 @@
 edges
+| main.cpp:6:27:6:30 | argv indirection | main.cpp:10:20:10:23 | argv indirection |
+| main.cpp:10:20:10:23 | argv indirection | tests.cpp:618:32:618:35 | argv indirection |
+| tests.cpp:613:19:613:24 | source indirection | tests.cpp:615:17:615:22 | source indirection |
+| tests.cpp:618:32:618:35 | argv indirection | tests.cpp:643:9:643:15 | access to array indirection |
+| tests.cpp:643:9:643:15 | access to array indirection | tests.cpp:613:19:613:24 | source indirection |
 nodes
+| main.cpp:6:27:6:30 | argv indirection | semmle.label | argv indirection |
+| main.cpp:10:20:10:23 | argv indirection | semmle.label | argv indirection |
+| tests.cpp:613:19:613:24 | source indirection | semmle.label | source indirection |
+| tests.cpp:615:17:615:22 | source indirection | semmle.label | source indirection |
+| tests.cpp:618:32:618:35 | argv indirection | semmle.label | argv indirection |
+| tests.cpp:643:9:643:15 | access to array indirection | semmle.label | access to array indirection |
 subpaths
 #select
+| tests.cpp:615:2:615:7 | call to strcpy | main.cpp:6:27:6:30 | argv indirection | tests.cpp:615:17:615:22 | source indirection | This 'call to strcpy' with input from $@ may overflow the destination. | main.cpp:6:27:6:30 | argv indirection | a command-line argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/tests.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/tests.cpp
@@ -407,7 +407,7 @@ void test15()
 		{
 			if (ptr[5] == ' ') // GOOD
 			{
-				// ...
+				break;
 			}
 		}
 	}

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/tests.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/tests.cpp
@@ -608,6 +608,13 @@ int test23() {
 	return sizeof(buffer) / sizeof(buffer[101]); // GOOD
 }
 
+char* strcpy(char *, const char *);
+
+void test24(char* source) {
+	char buffer[100];
+	strcpy(buffer, source); // BAD
+}
+
 int tests_main(int argc, char *argv[])
 {
 	long long arr17[19];
@@ -633,6 +640,7 @@ int tests_main(int argc, char *argv[])
 	test21(argc == 0);
 	test22(argc == 0, argv[0]);
 	test23();
+	test24(argv[0]);
 
 	return 0;
 }


### PR DESCRIPTION
I spent so long wondering why the test I added wasn't detected. In the end, it turned out this was because a function call that dominates the test I added was non-terminating, and thus the CFG containing any of the later tests was pruned away 😂.