### PR TITLE
C++: Fix missing results in `cpp/unbounded-write`

### DIFF
--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/UnboundedWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/UnboundedWrite.expected
@@ -2,15 +2,31 @@ edges
 | main.cpp:6:27:6:30 | argv indirection | main.cpp:10:20:10:23 | argv indirection |
 | main.cpp:10:20:10:23 | argv indirection | tests.cpp:631:32:631:35 | argv indirection |
 | tests.cpp:613:19:613:24 | source indirection | tests.cpp:615:17:615:22 | source indirection |
+| tests.cpp:622:19:622:24 | source indirection | tests.cpp:625:2:625:16 | ... = ... indirection |
+| tests.cpp:625:2:625:16 | ... = ... indirection | tests.cpp:625:4:625:7 | s indirection [post update] [home indirection] |
+| tests.cpp:625:4:625:7 | s indirection [post update] [home indirection] | tests.cpp:628:14:628:14 | s indirection [home indirection] |
+| tests.cpp:628:14:628:14 | s indirection [home indirection] | tests.cpp:628:14:628:19 | home indirection |
+| tests.cpp:628:14:628:14 | s indirection [home indirection] | tests.cpp:628:16:628:19 | home indirection |
+| tests.cpp:628:16:628:19 | home indirection | tests.cpp:628:14:628:19 | home indirection |
 | tests.cpp:631:32:631:35 | argv indirection | tests.cpp:656:9:656:15 | access to array indirection |
+| tests.cpp:631:32:631:35 | argv indirection | tests.cpp:657:9:657:15 | access to array indirection |
 | tests.cpp:656:9:656:15 | access to array indirection | tests.cpp:613:19:613:24 | source indirection |
+| tests.cpp:657:9:657:15 | access to array indirection | tests.cpp:622:19:622:24 | source indirection |
 nodes
 | main.cpp:6:27:6:30 | argv indirection | semmle.label | argv indirection |
 | main.cpp:10:20:10:23 | argv indirection | semmle.label | argv indirection |
 | tests.cpp:613:19:613:24 | source indirection | semmle.label | source indirection |
 | tests.cpp:615:17:615:22 | source indirection | semmle.label | source indirection |
+| tests.cpp:622:19:622:24 | source indirection | semmle.label | source indirection |
+| tests.cpp:625:2:625:16 | ... = ... indirection | semmle.label | ... = ... indirection |
+| tests.cpp:625:4:625:7 | s indirection [post update] [home indirection] | semmle.label | s indirection [post update] [home indirection] |
+| tests.cpp:628:14:628:14 | s indirection [home indirection] | semmle.label | s indirection [home indirection] |
+| tests.cpp:628:14:628:19 | home indirection | semmle.label | home indirection |
+| tests.cpp:628:16:628:19 | home indirection | semmle.label | home indirection |
 | tests.cpp:631:32:631:35 | argv indirection | semmle.label | argv indirection |
 | tests.cpp:656:9:656:15 | access to array indirection | semmle.label | access to array indirection |
+| tests.cpp:657:9:657:15 | access to array indirection | semmle.label | access to array indirection |
 subpaths
 #select
 | tests.cpp:615:2:615:7 | call to strcpy | main.cpp:6:27:6:30 | argv indirection | tests.cpp:615:17:615:22 | source indirection | This 'call to strcpy' with input from $@ may overflow the destination. | main.cpp:6:27:6:30 | argv indirection | a command-line argument |
+| tests.cpp:628:2:628:7 | call to strcpy | main.cpp:6:27:6:30 | argv indirection | tests.cpp:628:14:628:19 | home indirection | This 'call to strcpy' with input from $@ may overflow the destination. | main.cpp:6:27:6:30 | argv indirection | a command-line argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/UnboundedWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/UnboundedWrite.expected
@@ -1,16 +1,16 @@
 edges
 | main.cpp:6:27:6:30 | argv indirection | main.cpp:10:20:10:23 | argv indirection |
-| main.cpp:10:20:10:23 | argv indirection | tests.cpp:618:32:618:35 | argv indirection |
+| main.cpp:10:20:10:23 | argv indirection | tests.cpp:631:32:631:35 | argv indirection |
 | tests.cpp:613:19:613:24 | source indirection | tests.cpp:615:17:615:22 | source indirection |
-| tests.cpp:618:32:618:35 | argv indirection | tests.cpp:643:9:643:15 | access to array indirection |
-| tests.cpp:643:9:643:15 | access to array indirection | tests.cpp:613:19:613:24 | source indirection |
+| tests.cpp:631:32:631:35 | argv indirection | tests.cpp:656:9:656:15 | access to array indirection |
+| tests.cpp:656:9:656:15 | access to array indirection | tests.cpp:613:19:613:24 | source indirection |
 nodes
 | main.cpp:6:27:6:30 | argv indirection | semmle.label | argv indirection |
 | main.cpp:10:20:10:23 | argv indirection | semmle.label | argv indirection |
 | tests.cpp:613:19:613:24 | source indirection | semmle.label | source indirection |
 | tests.cpp:615:17:615:22 | source indirection | semmle.label | source indirection |
-| tests.cpp:618:32:618:35 | argv indirection | semmle.label | argv indirection |
-| tests.cpp:643:9:643:15 | access to array indirection | semmle.label | access to array indirection |
+| tests.cpp:631:32:631:35 | argv indirection | semmle.label | argv indirection |
+| tests.cpp:656:9:656:15 | access to array indirection | semmle.label | access to array indirection |
 subpaths
 #select
 | tests.cpp:615:2:615:7 | call to strcpy | main.cpp:6:27:6:30 | argv indirection | tests.cpp:615:17:615:22 | source indirection | This 'call to strcpy' with input from $@ may overflow the destination. | main.cpp:6:27:6:30 | argv indirection | a command-line argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/tests.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/tests.cpp
@@ -615,6 +615,19 @@ void test24(char* source) {
 	strcpy(buffer, source); // BAD
 }
 
+struct my_struct {
+	char* home;
+};
+
+void test25(char* source) {
+	my_struct s;
+
+	s.home = source;
+
+	char buf[100];
+	strcpy(buf, s.home); // BAD [NOT DETECTED]
+}
+
 int tests_main(int argc, char *argv[])
 {
 	long long arr17[19];
@@ -641,6 +654,7 @@ int tests_main(int argc, char *argv[])
 	test22(argc == 0, argv[0]);
 	test23();
 	test24(argv[0]);
+	test25(argv[0]);
 
 	return 0;
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/tests.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/tests.cpp
@@ -625,7 +625,7 @@ void test25(char* source) {
 	s.home = source;
 
 	char buf[100];
-	strcpy(buf, s.home); // BAD [NOT DETECTED]
+	strcpy(buf, s.home); // BAD
 }
 
 int tests_main(int argc, char *argv[])

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-120/semmle/tests/UnboundedWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-120/semmle/tests/UnboundedWrite.expected
@@ -1,18 +1,24 @@
 edges
 | tests.c:16:26:16:29 | argv indirection | tests.c:28:22:28:28 | access to array indirection |
 | tests.c:16:26:16:29 | argv indirection | tests.c:29:28:29:34 | access to array indirection |
+| tests.c:16:26:16:29 | argv indirection | tests.c:31:15:31:23 | buffer100 indirection |
+| tests.c:16:26:16:29 | argv indirection | tests.c:33:21:33:29 | buffer100 indirection |
 | tests.c:16:26:16:29 | argv indirection | tests.c:34:10:34:16 | access to array indirection |
 nodes
 | tests.c:16:26:16:29 | argv indirection | semmle.label | argv indirection |
 | tests.c:28:22:28:28 | access to array indirection | semmle.label | access to array indirection |
 | tests.c:29:28:29:34 | access to array indirection | semmle.label | access to array indirection |
+| tests.c:31:15:31:23 | buffer100 indirection | semmle.label | buffer100 indirection |
 | tests.c:31:15:31:23 | scanf output argument | semmle.label | scanf output argument |
+| tests.c:33:21:33:29 | buffer100 indirection | semmle.label | buffer100 indirection |
 | tests.c:33:21:33:29 | scanf output argument | semmle.label | scanf output argument |
 | tests.c:34:10:34:16 | access to array indirection | semmle.label | access to array indirection |
 subpaths
 #select
 | tests.c:28:3:28:9 | call to sprintf | tests.c:16:26:16:29 | argv indirection | tests.c:28:22:28:28 | access to array indirection | This 'call to sprintf' with input from $@ may overflow the destination. | tests.c:16:26:16:29 | argv indirection | a command-line argument |
 | tests.c:29:3:29:9 | call to sprintf | tests.c:16:26:16:29 | argv indirection | tests.c:29:28:29:34 | access to array indirection | This 'call to sprintf' with input from $@ may overflow the destination. | tests.c:16:26:16:29 | argv indirection | a command-line argument |
+| tests.c:31:15:31:23 | buffer100 | tests.c:16:26:16:29 | argv indirection | tests.c:31:15:31:23 | buffer100 indirection | This 'scanf string argument' with input from $@ may overflow the destination. | tests.c:16:26:16:29 | argv indirection | a command-line argument |
 | tests.c:31:15:31:23 | buffer100 | tests.c:31:15:31:23 | scanf output argument | tests.c:31:15:31:23 | scanf output argument | This 'scanf string argument' with input from $@ may overflow the destination. | tests.c:31:15:31:23 | scanf output argument | value read by scanf |
+| tests.c:33:21:33:29 | buffer100 | tests.c:16:26:16:29 | argv indirection | tests.c:33:21:33:29 | buffer100 indirection | This 'scanf string argument' with input from $@ may overflow the destination. | tests.c:16:26:16:29 | argv indirection | a command-line argument |
 | tests.c:33:21:33:29 | buffer100 | tests.c:33:21:33:29 | scanf output argument | tests.c:33:21:33:29 | scanf output argument | This 'scanf string argument' with input from $@ may overflow the destination. | tests.c:33:21:33:29 | scanf output argument | value read by scanf |
 | tests.c:34:25:34:33 | buffer100 | tests.c:16:26:16:29 | argv indirection | tests.c:34:10:34:16 | access to array indirection | This 'sscanf string argument' with input from $@ may overflow the destination. | tests.c:16:26:16:29 | argv indirection | a command-line argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-120/semmle/tests/UnboundedWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-120/semmle/tests/UnboundedWrite.expected
@@ -1,24 +1,18 @@
 edges
 | tests.c:16:26:16:29 | argv indirection | tests.c:28:22:28:28 | access to array indirection |
 | tests.c:16:26:16:29 | argv indirection | tests.c:29:28:29:34 | access to array indirection |
-| tests.c:16:26:16:29 | argv indirection | tests.c:31:15:31:23 | buffer100 indirection |
-| tests.c:16:26:16:29 | argv indirection | tests.c:33:21:33:29 | buffer100 indirection |
 | tests.c:16:26:16:29 | argv indirection | tests.c:34:10:34:16 | access to array indirection |
 nodes
 | tests.c:16:26:16:29 | argv indirection | semmle.label | argv indirection |
 | tests.c:28:22:28:28 | access to array indirection | semmle.label | access to array indirection |
 | tests.c:29:28:29:34 | access to array indirection | semmle.label | access to array indirection |
-| tests.c:31:15:31:23 | buffer100 indirection | semmle.label | buffer100 indirection |
 | tests.c:31:15:31:23 | scanf output argument | semmle.label | scanf output argument |
-| tests.c:33:21:33:29 | buffer100 indirection | semmle.label | buffer100 indirection |
 | tests.c:33:21:33:29 | scanf output argument | semmle.label | scanf output argument |
 | tests.c:34:10:34:16 | access to array indirection | semmle.label | access to array indirection |
 subpaths
 #select
 | tests.c:28:3:28:9 | call to sprintf | tests.c:16:26:16:29 | argv indirection | tests.c:28:22:28:28 | access to array indirection | This 'call to sprintf' with input from $@ may overflow the destination. | tests.c:16:26:16:29 | argv indirection | a command-line argument |
 | tests.c:29:3:29:9 | call to sprintf | tests.c:16:26:16:29 | argv indirection | tests.c:29:28:29:34 | access to array indirection | This 'call to sprintf' with input from $@ may overflow the destination. | tests.c:16:26:16:29 | argv indirection | a command-line argument |
-| tests.c:31:15:31:23 | buffer100 | tests.c:16:26:16:29 | argv indirection | tests.c:31:15:31:23 | buffer100 indirection | This 'scanf string argument' with input from $@ may overflow the destination. | tests.c:16:26:16:29 | argv indirection | a command-line argument |
 | tests.c:31:15:31:23 | buffer100 | tests.c:31:15:31:23 | scanf output argument | tests.c:31:15:31:23 | scanf output argument | This 'scanf string argument' with input from $@ may overflow the destination. | tests.c:31:15:31:23 | scanf output argument | value read by scanf |
-| tests.c:33:21:33:29 | buffer100 | tests.c:16:26:16:29 | argv indirection | tests.c:33:21:33:29 | buffer100 indirection | This 'scanf string argument' with input from $@ may overflow the destination. | tests.c:16:26:16:29 | argv indirection | a command-line argument |
 | tests.c:33:21:33:29 | buffer100 | tests.c:33:21:33:29 | scanf output argument | tests.c:33:21:33:29 | scanf output argument | This 'scanf string argument' with input from $@ may overflow the destination. | tests.c:33:21:33:29 | scanf output argument | value read by scanf |
 | tests.c:34:25:34:33 | buffer100 | tests.c:16:26:16:29 | argv indirection | tests.c:34:10:34:16 | access to array indirection | This 'sscanf string argument' with input from $@ may overflow the destination. | tests.c:16:26:16:29 | argv indirection | a command-line argument |


### PR DESCRIPTION
I had missed this issue in https://github.com/github/codeql/pull/14669.

The problem was that every sink was marked as an out barrier. I did this to avoid path duplication when the outgoing argument was marked as a sink to continue to flag up cases such as:
```cpp
char buffer[1024];
gets(buffer);
```
However, marking all sinks are out barriers was slightly too aggressive (as seen in the first commit). This is because the query also flags up writes fields when the _qualifier_ of the field is tainted. That is, this is also flagged up:
```cpp
S* s = tainted_struct();
strcpy(buffer, s->field);
```
so both `struct` _and_ `s->field` are marked as sinks. But since we mark every sink as an out barrier we'd mark `s` as a barrier, and thus we'd never get a to the read step required to catch something like:
```cpp
S* s;
s->field = tainted();
strcpy(buffer, s->field);
```
This PR fixes the problem by only marking `gets` (and friends) functions as out barriers.