### PR TITLE
Swift: Use TaintInheritingContent in WebView.qll`

### DIFF
--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/WebView.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/WebView.qll
@@ -74,19 +74,15 @@ private class WKNavigationDelegateSource extends RemoteFlowSource {
 }
 
 /**
- * A taint step implying that, if a `WKNavigationAction` is tainted, its `request` field is also tainted.
+ * A content implying that, if a `WKNavigationAction` is tainted, its
+ * `request` field is also tainted.
  */
-private class WKNavigationActionTaintStep extends AdditionalTaintStep {
-  override predicate step(DataFlow::Node n1, DataFlow::Node n2) {
-    exists(MemberRefExpr e, Expr self, VarDecl member |
-      self.getType().getName() = "WKNavigationAction" and
-      member.getName() = "request"
-    |
-      e.getBase() = self and
-      e.getMember() = member and
-      n1.asExpr() = self and
-      n2.asExpr() = e
-    )
+private class UrlRequestFieldsInheritTaint extends TaintInheritingContent,
+  DataFlow::Content::FieldContent
+{
+  UrlRequestFieldsInheritTaint() {
+    this.getField().getEnclosingDecl().asNominalTypeDecl().getName() = "WKNavigationAction" and
+    this.getField().getName() = "request"
   }
 }
 

--- a/swift/ql/test/library-tests/dataflow/taint/libraries/webview.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/libraries/webview.swift
@@ -150,5 +150,5 @@ func testWKNavigationAction() {
     sink(src.request) // $ tainted=WKNavigationAction
 
     let keypath = \WKNavigationAction.request
-    sink(src[keyPath: keypath]) // $ MISSING: tainted=WKNavigationAction
+    sink(src[keyPath: keypath]) // $ tainted=WKNavigationAction
 }

--- a/swift/ql/test/library-tests/dataflow/taint/libraries/webview.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/libraries/webview.swift
@@ -76,7 +76,7 @@ struct URLRequest {}
 
 // --- tests ---
 
-func source() -> Any { return "" }
+func source(_ label: String? = "") -> Any { return "" }
 func sink(_: Any) {}
 
 func testInheritBodyTaint() {
@@ -146,6 +146,9 @@ func testWKUserScript() {
 }
 
 func testWKNavigationAction() {
-    let src = source() as! WKNavigationAction
-    sink(src.request) // $ tainted=149
+    let src = source("WKNavigationAction") as! WKNavigationAction
+    sink(src.request) // $ tainted=WKNavigationAction
+
+    let keypath = \WKNavigationAction.request
+    sink(src[keyPath: keypath]) // $ MISSING: tainted=WKNavigationAction
 }


### PR DESCRIPTION
Modernize tainted content in `WebView.qll` by using `TaintInheritingContent` instead of an `AdditionalTaintStep`.