### PR TITLE
Disable the nuget standalone dependencies test on ARM-osx.

### DIFF
--- a/csharp/ql/integration-tests/posix-only/standalone_dependencies_nuget/skip-on-platform-osx-arm
+++ b/csharp/ql/integration-tests/posix-only/standalone_dependencies_nuget/skip-on-platform-osx-arm
@@ -1,0 +1,1 @@
+Skipping the test on the ARM runners, as we're running into trouble with Mono and nuget.


### PR DESCRIPTION
The test is failing currently, and that needs further investigation. This is a temporary workaround to allow us to continue to work on some necessary infrastructure investments around these tests.