### PR TITLE
Remove mono from path for the msbuild test.

### DIFF
--- a/csharp/ql/integration-tests/all-platforms/msbuild/test.py
+++ b/csharp/ql/integration-tests/all-platforms/msbuild/test.py
@@ -1,5 +1,23 @@
+import os
+
 from create_database_utils import *
 from diagnostics_test_utils import *
+
+def is_running_on_apple_silicon():
+   arch = subprocess.Popen(['sysctl', 'machdep.cpu.brand_string'], stdout=subprocess.PIPE)
+   output, errors = arch.communicate()
+   if b'apple' in output.lower():
+       return True
+   return False
+
+# if on ARM runners, remove Mono from the path, so we're using
+# dotnet restore instead of nuget.exe restore - on ARM machines
+# we run dotner msbuild (instead of the mono-provided msbuild.exe)
+# so we need to match the restore command, too.
+
+platform_name = sys.platform.lower()
+if platform_name.startswith("darwin") and is_running_on_apple_silicon():
+    os.environ["PATH"] = os.environ["PATH"].replace("/Library/Frameworks/Mono.framework/Versions/Current/Commands:", "")
 
 # force CodeQL to use MSBuild by setting `LGTM_INDEX_MSBUILD_TARGET`
 run_codeql_database_create([], db=None, lang="csharp", extra_env={ 'LGTM_INDEX_MSBUILD_TARGET': 'Build' })


### PR DESCRIPTION
This test fails on M1 ARM machines hosted by GH
because the presence of mono confuses the restore mechanism. We call dotnet msbuild on the M1 machines, but also need a corresponding dotnet restore to be called.
However, with mono on the path, the test will call nuget restore instead, and then dotnet msbuild
will not find the restored artifacts. Instead, it fails with Error: [2023-11-14 12:11:05] [build-stdout] /Users/runner/.dotnet/sdk/7.0.403/Microsoft.Common.CurrentVersion.targets(1241,5): error MSB3644: The reference assemblies for .NETFramework,Version=v4.0 were not found. To resolve this, install the Developer Pack (SDK/Targeting Pack) for this framework version or retarget your application. You can download .NET Framework Developer Packs at https://aka.ms/msbuild/developerpacks [/Users/runner/work/semmle-code/semmle-code/target/codeql-csharp-integration-tests/ql/csharp/ql/integration-tests/all-platforms/msbuild/test.csproj]