### PR TITLE
C#: Fix assembly attribute extraction in standalone mode

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Populators/TypeContainerVisitor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Populators/TypeContainerVisitor.cs
@@ -89,8 +89,10 @@ namespace Semmle.Extraction.CSharp.Populators
                 SyntaxKind.ModuleKeyword => Entities.AttributeKind.Module,
                 _ => throw new InternalError(node, "Unhandled global target")
             };
-            foreach (var attribute in node.Attributes)
+            var attributes = node.Attributes;
+            for (var i = 0; i < attributes.Count; i++)
             {
+                var attribute = attributes[i];
                 if (attributeLookup.Value(attribute) is AttributeData attributeData)
                 {
                     var ae = Entities.Attribute.Create(Cx, attributeData, outputAssembly, kind);

--- a/csharp/ql/test/library-tests/standalone/assemblyattribute/attr.expected
+++ b/csharp/ql/test/library-tests/standalone/assemblyattribute/attr.expected
@@ -1,0 +1,2 @@
+| standalone.cs:3:12:3:29 | [assembly: Attribute1(...)] |
+| standalone.cs:9:2:9:11 | [Attribute1(...)] |

--- a/csharp/ql/test/library-tests/standalone/assemblyattribute/attr.ql
+++ b/csharp/ql/test/library-tests/standalone/assemblyattribute/attr.ql
@@ -1,0 +1,5 @@
+import csharp
+
+from Attribute a
+where a.getType().getName() = "Attribute1Attribute"
+select a

--- a/csharp/ql/test/library-tests/standalone/assemblyattribute/options
+++ b/csharp/ql/test/library-tests/standalone/assemblyattribute/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --standalone

--- a/csharp/ql/test/library-tests/standalone/assemblyattribute/standalone.cs
+++ b/csharp/ql/test/library-tests/standalone/assemblyattribute/standalone.cs
@@ -1,0 +1,12 @@
+using System;
+
+[assembly: global::Attribute1]
+
+class Attribute1Attribute : Attribute
+{
+}
+
+[Attribute1]
+class A
+{
+}


### PR DESCRIPTION
This PR tries to fix assembly attribute extraction in standalone mode. I can't reliably repro the issue, but occasionally we're seeing the below exception:
```
Exception has occurred: CLR/System.ArgumentOutOfRangeException
Exception thrown: 'System.ArgumentOutOfRangeException' in Microsoft.CodeAnalysis.dll: 'Specified argument was out of the range of valid values.'
   at Microsoft.CodeAnalysis.SeparatedSyntaxList`1.get_Item(Int32 index)
   at Microsoft.CodeAnalysis.SeparatedSyntaxList`1.Enumerator.get_Current()
   at Semmle.Extraction.CSharp.Populators.TypeContainerVisitor.VisitAttributeList(AttributeListSyntax node) in .../ql/csharp/extractor/Semmle.Extraction.CSharp/Populators/TypeContainerVisitor.cs:line 92
```

I don't know if this fix is really fixing the problem, but it avoids using `Microsoft.CodeAnalysis.SeparatedSyntaxList`1.Enumerator.get_Current()`, which might be causing the issue.