### PR TITLE
C++: Rewrite `cpp/tainted-format-string` away from `DefaultTaintTracking`

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-134/UncontrolledFormatString.ql
+++ b/cpp/ql/src/Security/CWE/CWE-134/UncontrolledFormatString.ql
@@ -16,22 +16,50 @@
 import cpp
 import semmle.code.cpp.security.Security
 import semmle.code.cpp.security.FunctionWithWrappers
-import semmle.code.cpp.ir.dataflow.internal.DefaultTaintTrackingImpl
-import TaintedWithPath
+import semmle.code.cpp.security.FlowSources
+import semmle.code.cpp.ir.dataflow.TaintTracking
+import semmle.code.cpp.ir.IR
+import Flow::PathGraph
 
-class Configuration extends TaintTrackingConfiguration {
-  override predicate isSink(Element tainted) {
-    exists(PrintfLikeFunction printf | printf.outermostWrapperFunctionCall(tainted, _))
+predicate isSource(FlowSource source, string sourceType) {
+  not source instanceof DataFlow::ExprNode and
+  sourceType = source.getSourceType()
+}
+
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node node) { isSource(node, _) }
+
+  predicate isSink(DataFlow::Node node) {
+    exists(PrintfLikeFunction printf |
+      printf.outermostWrapperFunctionCall([node.asExpr(), node.asIndirectExpr()], _)
+    )
+  }
+
+  private predicate isArithmeticNonCharType(ArithmeticType type) {
+    not type instanceof CharType and
+    not type instanceof Char8Type and
+    not type instanceof Char16Type and
+    not type instanceof Char32Type
+  }
+
+  predicate isBarrier(DataFlow::Node node) {
+    isSink(node) and isArithmeticNonCharType(node.asExpr().getUnspecifiedType())
+    or
+    isArithmeticNonCharType(node.asInstruction().(StoreInstruction).getResultType())
   }
 }
 
+module Flow = TaintTracking::Global<Config>;
+
 from
-  PrintfLikeFunction printf, Expr arg, PathNode sourceNode, PathNode sinkNode,
-  string printfFunction, Expr userValue, string cause
+  PrintfLikeFunction printf, string printfFunction, string sourceType, DataFlow::Node source,
+  DataFlow::Node sink, Flow::PathNode sourceNode, Flow::PathNode sinkNode
 where
-  printf.outermostWrapperFunctionCall(arg, printfFunction) and
-  taintedWithPath(userValue, arg, sourceNode, sinkNode) and
-  isUserInput(userValue, cause)
-select arg, sourceNode, sinkNode,
+  source = sourceNode.getNode() and
+  sink = sinkNode.getNode() and
+  isSource(source, sourceType) and
+  printf.outermostWrapperFunctionCall([sink.asExpr(), sink.asIndirectExpr()], printfFunction) and
+  Flow::flowPath(sourceNode, sinkNode)
+select sink, sourceNode, sinkNode,
   "The value of this argument may come from $@ and is being used as a formatting argument to " +
-    printfFunction + ".", userValue, cause
+    printfFunction + ".", source, sourceType

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-134/SAMATE/UncontrolledFormatString.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-134/SAMATE/UncontrolledFormatString.expected
@@ -1,31 +1,16 @@
 edges
-| char_connect_socket_w32_vsnprintf_01_bad.c:94:46:94:69 | recv output argument | char_connect_socket_w32_vsnprintf_01_bad.c:125:15:125:18 | data |
-| char_connect_socket_w32_vsnprintf_01_bad.c:94:46:94:69 | recv output argument | char_connect_socket_w32_vsnprintf_01_bad.c:125:15:125:18 | data |
-| char_connect_socket_w32_vsnprintf_01_bad.c:94:55:94:68 | ... + ... | char_connect_socket_w32_vsnprintf_01_bad.c:125:15:125:18 | data |
-| char_connect_socket_w32_vsnprintf_01_bad.c:94:55:94:68 | ... + ... | char_connect_socket_w32_vsnprintf_01_bad.c:125:15:125:18 | data |
-| char_console_fprintf_01_bad.c:30:23:30:35 | ... + ... | char_console_fprintf_01_bad.c:49:21:49:24 | data |
-| char_console_fprintf_01_bad.c:30:23:30:35 | ... + ... | char_console_fprintf_01_bad.c:49:21:49:24 | data |
-| char_console_fprintf_01_bad.c:30:23:30:35 | fgets output argument | char_console_fprintf_01_bad.c:49:21:49:24 | data |
-| char_console_fprintf_01_bad.c:30:23:30:35 | fgets output argument | char_console_fprintf_01_bad.c:49:21:49:24 | data |
-| char_environment_fprintf_01_bad.c:27:30:27:35 | call to getenv | char_environment_fprintf_01_bad.c:36:21:36:24 | data |
-| char_environment_fprintf_01_bad.c:27:30:27:35 | call to getenv | char_environment_fprintf_01_bad.c:36:21:36:24 | data |
-| char_environment_fprintf_01_bad.c:27:30:27:35 | call to getenv | char_environment_fprintf_01_bad.c:36:21:36:24 | data |
-| char_environment_fprintf_01_bad.c:27:30:27:35 | call to getenv | char_environment_fprintf_01_bad.c:36:21:36:24 | data |
-subpaths
+| char_connect_socket_w32_vsnprintf_01_bad.c:94:46:94:69 | recv output argument | char_connect_socket_w32_vsnprintf_01_bad.c:125:15:125:18 | data indirection |
+| char_console_fprintf_01_bad.c:30:23:30:35 | fgets output argument | char_console_fprintf_01_bad.c:49:21:49:24 | data indirection |
+| char_environment_fprintf_01_bad.c:27:30:27:35 | call to getenv indirection | char_environment_fprintf_01_bad.c:36:21:36:24 | data indirection |
 nodes
 | char_connect_socket_w32_vsnprintf_01_bad.c:94:46:94:69 | recv output argument | semmle.label | recv output argument |
-| char_connect_socket_w32_vsnprintf_01_bad.c:94:55:94:68 | ... + ... | semmle.label | ... + ... |
-| char_connect_socket_w32_vsnprintf_01_bad.c:125:15:125:18 | data | semmle.label | data |
-| char_connect_socket_w32_vsnprintf_01_bad.c:125:15:125:18 | data | semmle.label | data |
-| char_console_fprintf_01_bad.c:30:23:30:35 | ... + ... | semmle.label | ... + ... |
+| char_connect_socket_w32_vsnprintf_01_bad.c:125:15:125:18 | data indirection | semmle.label | data indirection |
 | char_console_fprintf_01_bad.c:30:23:30:35 | fgets output argument | semmle.label | fgets output argument |
-| char_console_fprintf_01_bad.c:49:21:49:24 | data | semmle.label | data |
-| char_console_fprintf_01_bad.c:49:21:49:24 | data | semmle.label | data |
-| char_environment_fprintf_01_bad.c:27:30:27:35 | call to getenv | semmle.label | call to getenv |
-| char_environment_fprintf_01_bad.c:27:30:27:35 | call to getenv | semmle.label | call to getenv |
-| char_environment_fprintf_01_bad.c:36:21:36:24 | data | semmle.label | data |
-| char_environment_fprintf_01_bad.c:36:21:36:24 | data | semmle.label | data |
+| char_console_fprintf_01_bad.c:49:21:49:24 | data indirection | semmle.label | data indirection |
+| char_environment_fprintf_01_bad.c:27:30:27:35 | call to getenv indirection | semmle.label | call to getenv indirection |
+| char_environment_fprintf_01_bad.c:36:21:36:24 | data indirection | semmle.label | data indirection |
+subpaths
 #select
-| char_connect_socket_w32_vsnprintf_01_bad.c:125:15:125:18 | data | char_connect_socket_w32_vsnprintf_01_bad.c:94:55:94:68 | ... + ... | char_connect_socket_w32_vsnprintf_01_bad.c:125:15:125:18 | data | The value of this argument may come from $@ and is being used as a formatting argument to badVaSink(data), which calls vsnprintf(format). | char_connect_socket_w32_vsnprintf_01_bad.c:94:55:94:68 | ... + ... | recv |
-| char_console_fprintf_01_bad.c:49:21:49:24 | data | char_console_fprintf_01_bad.c:30:23:30:35 | ... + ... | char_console_fprintf_01_bad.c:49:21:49:24 | data | The value of this argument may come from $@ and is being used as a formatting argument to fprintf(format). | char_console_fprintf_01_bad.c:30:23:30:35 | ... + ... | fgets |
-| char_environment_fprintf_01_bad.c:36:21:36:24 | data | char_environment_fprintf_01_bad.c:27:30:27:35 | call to getenv | char_environment_fprintf_01_bad.c:36:21:36:24 | data | The value of this argument may come from $@ and is being used as a formatting argument to fprintf(format). | char_environment_fprintf_01_bad.c:27:30:27:35 | call to getenv | getenv |
+| char_connect_socket_w32_vsnprintf_01_bad.c:125:15:125:18 | data indirection | char_connect_socket_w32_vsnprintf_01_bad.c:94:46:94:69 | recv output argument | char_connect_socket_w32_vsnprintf_01_bad.c:125:15:125:18 | data indirection | The value of this argument may come from $@ and is being used as a formatting argument to badVaSink(data), which calls vsnprintf(format). | char_connect_socket_w32_vsnprintf_01_bad.c:94:46:94:69 | recv output argument | buffer read by recv |
+| char_console_fprintf_01_bad.c:49:21:49:24 | data indirection | char_console_fprintf_01_bad.c:30:23:30:35 | fgets output argument | char_console_fprintf_01_bad.c:49:21:49:24 | data indirection | The value of this argument may come from $@ and is being used as a formatting argument to fprintf(format). | char_console_fprintf_01_bad.c:30:23:30:35 | fgets output argument | string read by fgets |
+| char_environment_fprintf_01_bad.c:36:21:36:24 | data indirection | char_environment_fprintf_01_bad.c:27:30:27:35 | call to getenv indirection | char_environment_fprintf_01_bad.c:36:21:36:24 | data indirection | The value of this argument may come from $@ and is being used as a formatting argument to fprintf(format). | char_environment_fprintf_01_bad.c:27:30:27:35 | call to getenv indirection | an environment variable |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/argv/argvLocal.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/argv/argvLocal.c
@@ -164,7 +164,7 @@ int main(int argc, char **argv) {
 	printf(i91);
 	printWrapper(i91);
 
-	// BAD: i10 value comes from argv
+	// BAD: i10 value comes from argv [NOT DETECTED]
 	int i10 = (int) argv[1];
 	printf((char *) i10);
 	printWrapper((char *) i10);

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/argv/argvLocal.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/argv/argvLocal.expected
@@ -1,211 +1,80 @@
 edges
-| argvLocal.c:95:9:95:12 | argv | argvLocal.c:95:9:95:15 | access to array |
-| argvLocal.c:95:9:95:12 | argv | argvLocal.c:95:9:95:15 | access to array |
-| argvLocal.c:95:9:95:12 | argv | argvLocal.c:95:9:95:15 | access to array |
-| argvLocal.c:95:9:95:12 | argv | argvLocal.c:95:9:95:15 | access to array |
-| argvLocal.c:96:15:96:18 | argv | argvLocal.c:96:15:96:21 | access to array |
-| argvLocal.c:96:15:96:18 | argv | argvLocal.c:96:15:96:21 | access to array |
-| argvLocal.c:96:15:96:18 | argv | argvLocal.c:96:15:96:21 | access to array |
-| argvLocal.c:96:15:96:18 | argv | argvLocal.c:96:15:96:21 | access to array |
-| argvLocal.c:100:7:100:10 | argv | argvLocal.c:101:9:101:10 | i1 |
-| argvLocal.c:100:7:100:10 | argv | argvLocal.c:101:9:101:10 | i1 |
-| argvLocal.c:100:7:100:10 | argv | argvLocal.c:101:9:101:10 | i1 |
-| argvLocal.c:100:7:100:10 | argv | argvLocal.c:101:9:101:10 | i1 |
-| argvLocal.c:100:7:100:10 | argv | argvLocal.c:102:15:102:16 | i1 |
-| argvLocal.c:100:7:100:10 | argv | argvLocal.c:102:15:102:16 | i1 |
-| argvLocal.c:100:7:100:10 | argv | argvLocal.c:102:15:102:16 | i1 |
-| argvLocal.c:100:7:100:10 | argv | argvLocal.c:102:15:102:16 | i1 |
-| argvLocal.c:100:7:100:10 | argv | argvLocal.c:144:9:144:10 | i7 |
-| argvLocal.c:100:7:100:10 | argv | argvLocal.c:144:9:144:10 | i7 |
-| argvLocal.c:100:7:100:10 | argv | argvLocal.c:144:9:144:10 | i7 |
-| argvLocal.c:100:7:100:10 | argv | argvLocal.c:144:9:144:10 | i7 |
-| argvLocal.c:100:7:100:10 | argv | argvLocal.c:145:15:145:16 | i7 |
-| argvLocal.c:100:7:100:10 | argv | argvLocal.c:145:15:145:16 | i7 |
-| argvLocal.c:100:7:100:10 | argv | argvLocal.c:145:15:145:16 | i7 |
-| argvLocal.c:100:7:100:10 | argv | argvLocal.c:145:15:145:16 | i7 |
-| argvLocal.c:105:14:105:17 | argv | argvLocal.c:106:9:106:13 | access to array |
-| argvLocal.c:105:14:105:17 | argv | argvLocal.c:106:9:106:13 | access to array |
-| argvLocal.c:105:14:105:17 | argv | argvLocal.c:106:9:106:13 | access to array |
-| argvLocal.c:105:14:105:17 | argv | argvLocal.c:106:9:106:13 | access to array |
-| argvLocal.c:105:14:105:17 | argv | argvLocal.c:107:15:107:19 | access to array |
-| argvLocal.c:105:14:105:17 | argv | argvLocal.c:107:15:107:19 | access to array |
-| argvLocal.c:105:14:105:17 | argv | argvLocal.c:107:15:107:19 | access to array |
-| argvLocal.c:105:14:105:17 | argv | argvLocal.c:107:15:107:19 | access to array |
-| argvLocal.c:105:14:105:17 | argv | argvLocal.c:110:9:110:11 | * ... |
-| argvLocal.c:105:14:105:17 | argv | argvLocal.c:110:9:110:11 | * ... |
-| argvLocal.c:105:14:105:17 | argv | argvLocal.c:110:9:110:11 | * ... |
-| argvLocal.c:105:14:105:17 | argv | argvLocal.c:110:9:110:11 | * ... |
-| argvLocal.c:105:14:105:17 | argv | argvLocal.c:111:15:111:17 | * ... |
-| argvLocal.c:105:14:105:17 | argv | argvLocal.c:111:15:111:17 | * ... |
-| argvLocal.c:105:14:105:17 | argv | argvLocal.c:111:15:111:17 | * ... |
-| argvLocal.c:105:14:105:17 | argv | argvLocal.c:111:15:111:17 | * ... |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:116:9:116:10 | i3 |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:116:9:116:10 | i3 |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:116:9:116:10 | i3 |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:116:9:116:10 | i3 |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:117:15:117:16 | i3 |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:117:15:117:16 | i3 |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:117:15:117:16 | i3 |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:117:15:117:16 | i3 |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:121:9:121:10 | i4 |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:121:9:121:10 | i4 |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:121:9:121:10 | i4 |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:121:9:121:10 | i4 |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:122:15:122:16 | i4 |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:122:15:122:16 | i4 |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:122:15:122:16 | i4 |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:122:15:122:16 | i4 |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:135:9:135:10 | i4 |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:135:9:135:10 | i4 |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:135:9:135:12 | ... ++ |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:135:9:135:12 | ... ++ |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:135:9:135:12 | ... ++ |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:135:9:135:12 | ... ++ |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:135:9:135:12 | ... ++ |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:135:9:135:12 | ... ++ |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:136:15:136:18 | -- ... |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:136:15:136:18 | -- ... |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:136:15:136:18 | -- ... |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:136:15:136:18 | -- ... |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:136:17:136:18 | i4 |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:136:17:136:18 | i4 |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:127:9:127:10 | i5 |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:127:9:127:10 | i5 |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:127:9:127:10 | i5 |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:127:9:127:10 | i5 |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:128:15:128:16 | i5 |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:128:15:128:16 | i5 |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:128:15:128:16 | i5 |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:128:15:128:16 | i5 |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:131:9:131:14 | ... + ... |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:131:9:131:14 | ... + ... |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:131:9:131:14 | ... + ... |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:131:9:131:14 | ... + ... |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:132:15:132:20 | ... + ... |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:132:15:132:20 | ... + ... |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:132:15:132:20 | ... + ... |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:132:15:132:20 | ... + ... |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:139:9:139:26 | ... ? ... : ... |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:139:9:139:26 | ... ? ... : ... |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:139:9:139:26 | ... ? ... : ... |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:139:9:139:26 | ... ? ... : ... |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:140:15:140:32 | ... ? ... : ... |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:140:15:140:32 | ... ? ... : ... |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:140:15:140:32 | ... ? ... : ... |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:140:15:140:32 | ... ? ... : ... |
-| argvLocal.c:149:11:149:14 | argv | argvLocal.c:150:9:150:10 | i8 |
-| argvLocal.c:149:11:149:14 | argv | argvLocal.c:150:9:150:10 | i8 |
-| argvLocal.c:149:11:149:14 | argv | argvLocal.c:150:9:150:10 | i8 |
-| argvLocal.c:149:11:149:14 | argv | argvLocal.c:150:9:150:10 | i8 |
-| argvLocal.c:149:11:149:14 | argv | argvLocal.c:151:15:151:16 | i8 |
-| argvLocal.c:149:11:149:14 | argv | argvLocal.c:151:15:151:16 | i8 |
-| argvLocal.c:149:11:149:14 | argv | argvLocal.c:151:15:151:16 | i8 |
-| argvLocal.c:149:11:149:14 | argv | argvLocal.c:151:15:151:16 | i8 |
-| argvLocal.c:168:18:168:21 | argv | argvLocal.c:169:9:169:20 | i10 |
-| argvLocal.c:168:18:168:21 | argv | argvLocal.c:169:9:169:20 | i10 |
-| argvLocal.c:168:18:168:21 | argv | argvLocal.c:169:18:169:20 | i10 |
-| argvLocal.c:168:18:168:21 | argv | argvLocal.c:169:18:169:20 | i10 |
-| argvLocal.c:168:18:168:21 | argv | argvLocal.c:170:15:170:26 | i10 |
-| argvLocal.c:168:18:168:21 | argv | argvLocal.c:170:15:170:26 | i10 |
-| argvLocal.c:168:18:168:21 | argv | argvLocal.c:170:24:170:26 | i10 |
-| argvLocal.c:168:18:168:21 | argv | argvLocal.c:170:24:170:26 | i10 |
-subpaths
+| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:95:9:95:15 | access to array indirection |
+| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:96:15:96:21 | access to array indirection |
+| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:101:9:101:10 | i1 indirection |
+| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:102:15:102:16 | i1 indirection |
+| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:106:9:106:13 | access to array indirection |
+| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:107:15:107:19 | access to array indirection |
+| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:110:9:110:11 | * ... indirection |
+| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:111:15:111:17 | * ... indirection |
+| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:116:9:116:10 | i3 indirection |
+| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:117:15:117:16 | i3 indirection |
+| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:121:9:121:10 | i4 indirection |
+| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:122:15:122:16 | i4 indirection |
+| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:127:9:127:10 | i5 indirection |
+| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:128:15:128:16 | i5 indirection |
+| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:131:9:131:14 | ... + ... indirection |
+| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:132:15:132:20 | ... + ... indirection |
+| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:135:9:135:12 | ... ++ indirection |
+| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:135:9:135:12 | ... ++ indirection |
+| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:136:15:136:18 | -- ... indirection |
+| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:139:9:139:26 | ... ? ... : ... indirection |
+| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:140:15:140:32 | ... ? ... : ... indirection |
+| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:144:9:144:10 | i7 indirection |
+| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:145:15:145:16 | i7 indirection |
+| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:150:9:150:10 | i8 indirection |
+| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:151:15:151:16 | i8 indirection |
 nodes
-| argvLocal.c:95:9:95:12 | argv | semmle.label | argv |
-| argvLocal.c:95:9:95:12 | argv | semmle.label | argv |
-| argvLocal.c:95:9:95:15 | access to array | semmle.label | access to array |
-| argvLocal.c:95:9:95:15 | access to array | semmle.label | access to array |
-| argvLocal.c:96:15:96:18 | argv | semmle.label | argv |
-| argvLocal.c:96:15:96:18 | argv | semmle.label | argv |
-| argvLocal.c:96:15:96:21 | access to array | semmle.label | access to array |
-| argvLocal.c:96:15:96:21 | access to array | semmle.label | access to array |
-| argvLocal.c:100:7:100:10 | argv | semmle.label | argv |
-| argvLocal.c:100:7:100:10 | argv | semmle.label | argv |
-| argvLocal.c:101:9:101:10 | i1 | semmle.label | i1 |
-| argvLocal.c:101:9:101:10 | i1 | semmle.label | i1 |
-| argvLocal.c:102:15:102:16 | i1 | semmle.label | i1 |
-| argvLocal.c:102:15:102:16 | i1 | semmle.label | i1 |
-| argvLocal.c:105:14:105:17 | argv | semmle.label | argv |
-| argvLocal.c:105:14:105:17 | argv | semmle.label | argv |
-| argvLocal.c:106:9:106:13 | access to array | semmle.label | access to array |
-| argvLocal.c:106:9:106:13 | access to array | semmle.label | access to array |
-| argvLocal.c:107:15:107:19 | access to array | semmle.label | access to array |
-| argvLocal.c:107:15:107:19 | access to array | semmle.label | access to array |
-| argvLocal.c:110:9:110:11 | * ... | semmle.label | * ... |
-| argvLocal.c:110:9:110:11 | * ... | semmle.label | * ... |
-| argvLocal.c:111:15:111:17 | * ... | semmle.label | * ... |
-| argvLocal.c:111:15:111:17 | * ... | semmle.label | * ... |
-| argvLocal.c:115:13:115:16 | argv | semmle.label | argv |
-| argvLocal.c:115:13:115:16 | argv | semmle.label | argv |
-| argvLocal.c:116:9:116:10 | i3 | semmle.label | i3 |
-| argvLocal.c:116:9:116:10 | i3 | semmle.label | i3 |
-| argvLocal.c:117:15:117:16 | i3 | semmle.label | i3 |
-| argvLocal.c:117:15:117:16 | i3 | semmle.label | i3 |
-| argvLocal.c:121:9:121:10 | i4 | semmle.label | i4 |
-| argvLocal.c:121:9:121:10 | i4 | semmle.label | i4 |
-| argvLocal.c:122:15:122:16 | i4 | semmle.label | i4 |
-| argvLocal.c:122:15:122:16 | i4 | semmle.label | i4 |
-| argvLocal.c:126:10:126:13 | argv | semmle.label | argv |
-| argvLocal.c:126:10:126:13 | argv | semmle.label | argv |
-| argvLocal.c:127:9:127:10 | i5 | semmle.label | i5 |
-| argvLocal.c:127:9:127:10 | i5 | semmle.label | i5 |
-| argvLocal.c:128:15:128:16 | i5 | semmle.label | i5 |
-| argvLocal.c:128:15:128:16 | i5 | semmle.label | i5 |
-| argvLocal.c:131:9:131:14 | ... + ... | semmle.label | ... + ... |
-| argvLocal.c:131:9:131:14 | ... + ... | semmle.label | ... + ... |
-| argvLocal.c:132:15:132:20 | ... + ... | semmle.label | ... + ... |
-| argvLocal.c:132:15:132:20 | ... + ... | semmle.label | ... + ... |
-| argvLocal.c:135:9:135:10 | i4 | semmle.label | i4 |
-| argvLocal.c:135:9:135:12 | ... ++ | semmle.label | ... ++ |
-| argvLocal.c:135:9:135:12 | ... ++ | semmle.label | ... ++ |
-| argvLocal.c:135:9:135:12 | ... ++ | semmle.label | ... ++ |
-| argvLocal.c:136:15:136:18 | -- ... | semmle.label | -- ... |
-| argvLocal.c:136:15:136:18 | -- ... | semmle.label | -- ... |
-| argvLocal.c:136:17:136:18 | i4 | semmle.label | i4 |
-| argvLocal.c:139:9:139:26 | ... ? ... : ... | semmle.label | ... ? ... : ... |
-| argvLocal.c:139:9:139:26 | ... ? ... : ... | semmle.label | ... ? ... : ... |
-| argvLocal.c:140:15:140:32 | ... ? ... : ... | semmle.label | ... ? ... : ... |
-| argvLocal.c:140:15:140:32 | ... ? ... : ... | semmle.label | ... ? ... : ... |
-| argvLocal.c:144:9:144:10 | i7 | semmle.label | i7 |
-| argvLocal.c:144:9:144:10 | i7 | semmle.label | i7 |
-| argvLocal.c:145:15:145:16 | i7 | semmle.label | i7 |
-| argvLocal.c:145:15:145:16 | i7 | semmle.label | i7 |
-| argvLocal.c:149:11:149:14 | argv | semmle.label | argv |
-| argvLocal.c:149:11:149:14 | argv | semmle.label | argv |
-| argvLocal.c:150:9:150:10 | i8 | semmle.label | i8 |
-| argvLocal.c:150:9:150:10 | i8 | semmle.label | i8 |
-| argvLocal.c:151:15:151:16 | i8 | semmle.label | i8 |
-| argvLocal.c:151:15:151:16 | i8 | semmle.label | i8 |
-| argvLocal.c:168:18:168:21 | argv | semmle.label | argv |
-| argvLocal.c:168:18:168:21 | argv | semmle.label | argv |
-| argvLocal.c:169:9:169:20 | i10 | semmle.label | i10 |
-| argvLocal.c:169:18:169:20 | i10 | semmle.label | i10 |
-| argvLocal.c:170:15:170:26 | i10 | semmle.label | i10 |
-| argvLocal.c:170:24:170:26 | i10 | semmle.label | i10 |
+| argvLocal.c:13:27:13:30 | argv indirection | semmle.label | argv indirection |
+| argvLocal.c:95:9:95:15 | access to array indirection | semmle.label | access to array indirection |
+| argvLocal.c:96:15:96:21 | access to array indirection | semmle.label | access to array indirection |
+| argvLocal.c:101:9:101:10 | i1 indirection | semmle.label | i1 indirection |
+| argvLocal.c:102:15:102:16 | i1 indirection | semmle.label | i1 indirection |
+| argvLocal.c:106:9:106:13 | access to array indirection | semmle.label | access to array indirection |
+| argvLocal.c:107:15:107:19 | access to array indirection | semmle.label | access to array indirection |
+| argvLocal.c:110:9:110:11 | * ... indirection | semmle.label | * ... indirection |
+| argvLocal.c:111:15:111:17 | * ... indirection | semmle.label | * ... indirection |
+| argvLocal.c:116:9:116:10 | i3 indirection | semmle.label | i3 indirection |
+| argvLocal.c:117:15:117:16 | i3 indirection | semmle.label | i3 indirection |
+| argvLocal.c:121:9:121:10 | i4 indirection | semmle.label | i4 indirection |
+| argvLocal.c:122:15:122:16 | i4 indirection | semmle.label | i4 indirection |
+| argvLocal.c:127:9:127:10 | i5 indirection | semmle.label | i5 indirection |
+| argvLocal.c:128:15:128:16 | i5 indirection | semmle.label | i5 indirection |
+| argvLocal.c:131:9:131:14 | ... + ... indirection | semmle.label | ... + ... indirection |
+| argvLocal.c:132:15:132:20 | ... + ... indirection | semmle.label | ... + ... indirection |
+| argvLocal.c:135:9:135:12 | ... ++ indirection | semmle.label | ... ++ indirection |
+| argvLocal.c:135:9:135:12 | ... ++ indirection | semmle.label | ... ++ indirection |
+| argvLocal.c:136:15:136:18 | -- ... indirection | semmle.label | -- ... indirection |
+| argvLocal.c:139:9:139:26 | ... ? ... : ... indirection | semmle.label | ... ? ... : ... indirection |
+| argvLocal.c:140:15:140:32 | ... ? ... : ... indirection | semmle.label | ... ? ... : ... indirection |
+| argvLocal.c:144:9:144:10 | i7 indirection | semmle.label | i7 indirection |
+| argvLocal.c:145:15:145:16 | i7 indirection | semmle.label | i7 indirection |
+| argvLocal.c:150:9:150:10 | i8 indirection | semmle.label | i8 indirection |
+| argvLocal.c:151:15:151:16 | i8 indirection | semmle.label | i8 indirection |
+subpaths
 #select
-| argvLocal.c:95:9:95:15 | access to array | argvLocal.c:95:9:95:12 | argv | argvLocal.c:95:9:95:15 | access to array | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:95:9:95:12 | argv | argv |
-| argvLocal.c:96:15:96:21 | access to array | argvLocal.c:96:15:96:18 | argv | argvLocal.c:96:15:96:21 | access to array | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:96:15:96:18 | argv | argv |
-| argvLocal.c:101:9:101:10 | i1 | argvLocal.c:100:7:100:10 | argv | argvLocal.c:101:9:101:10 | i1 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:100:7:100:10 | argv | argv |
-| argvLocal.c:102:15:102:16 | i1 | argvLocal.c:100:7:100:10 | argv | argvLocal.c:102:15:102:16 | i1 | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:100:7:100:10 | argv | argv |
-| argvLocal.c:106:9:106:13 | access to array | argvLocal.c:105:14:105:17 | argv | argvLocal.c:106:9:106:13 | access to array | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:105:14:105:17 | argv | argv |
-| argvLocal.c:107:15:107:19 | access to array | argvLocal.c:105:14:105:17 | argv | argvLocal.c:107:15:107:19 | access to array | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:105:14:105:17 | argv | argv |
-| argvLocal.c:110:9:110:11 | * ... | argvLocal.c:105:14:105:17 | argv | argvLocal.c:110:9:110:11 | * ... | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:105:14:105:17 | argv | argv |
-| argvLocal.c:111:15:111:17 | * ... | argvLocal.c:105:14:105:17 | argv | argvLocal.c:111:15:111:17 | * ... | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:105:14:105:17 | argv | argv |
-| argvLocal.c:116:9:116:10 | i3 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:116:9:116:10 | i3 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:115:13:115:16 | argv | argv |
-| argvLocal.c:117:15:117:16 | i3 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:117:15:117:16 | i3 | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:115:13:115:16 | argv | argv |
-| argvLocal.c:121:9:121:10 | i4 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:121:9:121:10 | i4 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:115:13:115:16 | argv | argv |
-| argvLocal.c:122:15:122:16 | i4 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:122:15:122:16 | i4 | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:115:13:115:16 | argv | argv |
-| argvLocal.c:127:9:127:10 | i5 | argvLocal.c:126:10:126:13 | argv | argvLocal.c:127:9:127:10 | i5 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:126:10:126:13 | argv | argv |
-| argvLocal.c:128:15:128:16 | i5 | argvLocal.c:126:10:126:13 | argv | argvLocal.c:128:15:128:16 | i5 | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:126:10:126:13 | argv | argv |
-| argvLocal.c:131:9:131:14 | ... + ... | argvLocal.c:126:10:126:13 | argv | argvLocal.c:131:9:131:14 | ... + ... | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:126:10:126:13 | argv | argv |
-| argvLocal.c:132:15:132:20 | ... + ... | argvLocal.c:126:10:126:13 | argv | argvLocal.c:132:15:132:20 | ... + ... | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:126:10:126:13 | argv | argv |
-| argvLocal.c:135:9:135:12 | ... ++ | argvLocal.c:115:13:115:16 | argv | argvLocal.c:135:9:135:12 | ... ++ | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:115:13:115:16 | argv | argv |
-| argvLocal.c:136:15:136:18 | -- ... | argvLocal.c:115:13:115:16 | argv | argvLocal.c:136:15:136:18 | -- ... | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:115:13:115:16 | argv | argv |
-| argvLocal.c:139:9:139:26 | ... ? ... : ... | argvLocal.c:126:10:126:13 | argv | argvLocal.c:139:9:139:26 | ... ? ... : ... | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:126:10:126:13 | argv | argv |
-| argvLocal.c:140:15:140:32 | ... ? ... : ... | argvLocal.c:126:10:126:13 | argv | argvLocal.c:140:15:140:32 | ... ? ... : ... | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:126:10:126:13 | argv | argv |
-| argvLocal.c:144:9:144:10 | i7 | argvLocal.c:100:7:100:10 | argv | argvLocal.c:144:9:144:10 | i7 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:100:7:100:10 | argv | argv |
-| argvLocal.c:145:15:145:16 | i7 | argvLocal.c:100:7:100:10 | argv | argvLocal.c:145:15:145:16 | i7 | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:100:7:100:10 | argv | argv |
-| argvLocal.c:150:9:150:10 | i8 | argvLocal.c:149:11:149:14 | argv | argvLocal.c:150:9:150:10 | i8 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:149:11:149:14 | argv | argv |
-| argvLocal.c:151:15:151:16 | i8 | argvLocal.c:149:11:149:14 | argv | argvLocal.c:151:15:151:16 | i8 | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:149:11:149:14 | argv | argv |
-| argvLocal.c:169:18:169:20 | i10 | argvLocal.c:168:18:168:21 | argv | argvLocal.c:169:18:169:20 | i10 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:168:18:168:21 | argv | argv |
-| argvLocal.c:170:24:170:26 | i10 | argvLocal.c:168:18:168:21 | argv | argvLocal.c:170:24:170:26 | i10 | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:168:18:168:21 | argv | argv |
+| argvLocal.c:95:9:95:15 | access to array indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:95:9:95:15 | access to array indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
+| argvLocal.c:96:15:96:21 | access to array indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:96:15:96:21 | access to array indirection | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
+| argvLocal.c:101:9:101:10 | i1 indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:101:9:101:10 | i1 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
+| argvLocal.c:102:15:102:16 | i1 indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:102:15:102:16 | i1 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
+| argvLocal.c:106:9:106:13 | access to array indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:106:9:106:13 | access to array indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
+| argvLocal.c:107:15:107:19 | access to array indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:107:15:107:19 | access to array indirection | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
+| argvLocal.c:110:9:110:11 | * ... indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:110:9:110:11 | * ... indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
+| argvLocal.c:111:15:111:17 | * ... indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:111:15:111:17 | * ... indirection | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
+| argvLocal.c:116:9:116:10 | i3 indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:116:9:116:10 | i3 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
+| argvLocal.c:117:15:117:16 | i3 indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:117:15:117:16 | i3 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
+| argvLocal.c:121:9:121:10 | i4 indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:121:9:121:10 | i4 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
+| argvLocal.c:122:15:122:16 | i4 indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:122:15:122:16 | i4 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
+| argvLocal.c:127:9:127:10 | i5 indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:127:9:127:10 | i5 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
+| argvLocal.c:128:15:128:16 | i5 indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:128:15:128:16 | i5 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
+| argvLocal.c:131:9:131:14 | ... + ... indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:131:9:131:14 | ... + ... indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
+| argvLocal.c:132:15:132:20 | ... + ... indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:132:15:132:20 | ... + ... indirection | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
+| argvLocal.c:135:9:135:12 | ... ++ indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:135:9:135:12 | ... ++ indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
+| argvLocal.c:135:9:135:12 | ... ++ indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:135:9:135:12 | ... ++ indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
+| argvLocal.c:136:15:136:18 | -- ... indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:136:15:136:18 | -- ... indirection | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
+| argvLocal.c:139:9:139:26 | ... ? ... : ... indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:139:9:139:26 | ... ? ... : ... indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
+| argvLocal.c:140:15:140:32 | ... ? ... : ... indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:140:15:140:32 | ... ? ... : ... indirection | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
+| argvLocal.c:144:9:144:10 | i7 indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:144:9:144:10 | i7 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
+| argvLocal.c:145:15:145:16 | i7 indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:145:15:145:16 | i7 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
+| argvLocal.c:150:9:150:10 | i8 indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:150:9:150:10 | i8 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
+| argvLocal.c:151:15:151:16 | i8 indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:151:15:151:16 | i8 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/funcs/funcsLocal.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/funcs/funcsLocal.expected
@@ -1,88 +1,35 @@
 edges
-| funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:17:9:17:10 | i1 |
-| funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:17:9:17:10 | i1 |
-| funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:58:9:58:10 | e1 |
-| funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:58:9:58:10 | e1 |
-| funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:17:9:17:10 | i1 |
-| funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:17:9:17:10 | i1 |
-| funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:17:9:17:10 | i1 |
-| funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:17:9:17:10 | i1 |
-| funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:58:9:58:10 | e1 |
-| funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:58:9:58:10 | e1 |
-| funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:58:9:58:10 | e1 |
-| funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:58:9:58:10 | e1 |
-| funcsLocal.c:26:8:26:9 | fgets output argument | funcsLocal.c:27:9:27:10 | i3 |
-| funcsLocal.c:26:8:26:9 | fgets output argument | funcsLocal.c:27:9:27:10 | i3 |
-| funcsLocal.c:26:8:26:9 | i3 | funcsLocal.c:27:9:27:10 | i3 |
-| funcsLocal.c:26:8:26:9 | i3 | funcsLocal.c:27:9:27:10 | i3 |
-| funcsLocal.c:26:8:26:9 | i3 | funcsLocal.c:27:9:27:10 | i3 |
-| funcsLocal.c:26:8:26:9 | i3 | funcsLocal.c:27:9:27:10 | i3 |
-| funcsLocal.c:31:13:31:17 | call to fgets | funcsLocal.c:32:9:32:10 | i4 |
-| funcsLocal.c:31:13:31:17 | call to fgets | funcsLocal.c:32:9:32:10 | i4 |
-| funcsLocal.c:31:13:31:17 | call to fgets | funcsLocal.c:32:9:32:10 | i4 |
-| funcsLocal.c:31:13:31:17 | call to fgets | funcsLocal.c:32:9:32:10 | i4 |
-| funcsLocal.c:36:7:36:8 | gets output argument | funcsLocal.c:37:9:37:10 | i5 |
-| funcsLocal.c:36:7:36:8 | gets output argument | funcsLocal.c:37:9:37:10 | i5 |
-| funcsLocal.c:36:7:36:8 | i5 | funcsLocal.c:37:9:37:10 | i5 |
-| funcsLocal.c:36:7:36:8 | i5 | funcsLocal.c:37:9:37:10 | i5 |
-| funcsLocal.c:36:7:36:8 | i5 | funcsLocal.c:37:9:37:10 | i5 |
-| funcsLocal.c:36:7:36:8 | i5 | funcsLocal.c:37:9:37:10 | i5 |
-| funcsLocal.c:41:13:41:16 | call to gets | funcsLocal.c:42:9:42:10 | i6 |
-| funcsLocal.c:41:13:41:16 | call to gets | funcsLocal.c:42:9:42:10 | i6 |
-| funcsLocal.c:41:13:41:16 | call to gets | funcsLocal.c:42:9:42:10 | i6 |
-| funcsLocal.c:41:13:41:16 | call to gets | funcsLocal.c:42:9:42:10 | i6 |
-| funcsLocal.c:46:7:46:9 | * ... | funcsLocal.c:47:9:47:11 | * ... |
-| funcsLocal.c:46:7:46:9 | * ... | funcsLocal.c:47:9:47:11 | * ... |
-| funcsLocal.c:46:7:46:9 | * ... | funcsLocal.c:47:9:47:11 | * ... |
-| funcsLocal.c:46:7:46:9 | * ... | funcsLocal.c:47:9:47:11 | * ... |
-| funcsLocal.c:46:7:46:9 | gets output argument | funcsLocal.c:47:9:47:11 | * ... |
-| funcsLocal.c:46:7:46:9 | gets output argument | funcsLocal.c:47:9:47:11 | * ... |
-| funcsLocal.c:52:8:52:11 | call to gets | funcsLocal.c:53:9:53:11 | * ... |
-| funcsLocal.c:52:8:52:11 | call to gets | funcsLocal.c:53:9:53:11 | * ... |
-| funcsLocal.c:52:8:52:11 | call to gets | funcsLocal.c:53:9:53:11 | * ... |
-| funcsLocal.c:52:8:52:11 | call to gets | funcsLocal.c:53:9:53:11 | * ... |
-subpaths
+| funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:17:9:17:10 | i1 indirection |
+| funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:58:9:58:10 | e1 indirection |
+| funcsLocal.c:26:8:26:9 | fgets output argument | funcsLocal.c:27:9:27:10 | i3 indirection |
+| funcsLocal.c:31:13:31:17 | call to fgets indirection | funcsLocal.c:32:9:32:10 | i4 indirection |
+| funcsLocal.c:36:7:36:8 | gets output argument | funcsLocal.c:37:9:37:10 | i5 indirection |
+| funcsLocal.c:41:13:41:16 | call to gets indirection | funcsLocal.c:42:9:42:10 | i6 indirection |
+| funcsLocal.c:46:7:46:9 | gets output argument | funcsLocal.c:47:9:47:11 | * ... indirection |
+| funcsLocal.c:52:8:52:11 | call to gets indirection | funcsLocal.c:53:9:53:11 | * ... indirection |
 nodes
 | funcsLocal.c:16:8:16:9 | fread output argument | semmle.label | fread output argument |
-| funcsLocal.c:16:8:16:9 | i1 | semmle.label | i1 |
-| funcsLocal.c:16:8:16:9 | i1 | semmle.label | i1 |
-| funcsLocal.c:17:9:17:10 | i1 | semmle.label | i1 |
-| funcsLocal.c:17:9:17:10 | i1 | semmle.label | i1 |
+| funcsLocal.c:17:9:17:10 | i1 indirection | semmle.label | i1 indirection |
 | funcsLocal.c:26:8:26:9 | fgets output argument | semmle.label | fgets output argument |
-| funcsLocal.c:26:8:26:9 | i3 | semmle.label | i3 |
-| funcsLocal.c:26:8:26:9 | i3 | semmle.label | i3 |
-| funcsLocal.c:27:9:27:10 | i3 | semmle.label | i3 |
-| funcsLocal.c:27:9:27:10 | i3 | semmle.label | i3 |
-| funcsLocal.c:31:13:31:17 | call to fgets | semmle.label | call to fgets |
-| funcsLocal.c:31:13:31:17 | call to fgets | semmle.label | call to fgets |
-| funcsLocal.c:32:9:32:10 | i4 | semmle.label | i4 |
-| funcsLocal.c:32:9:32:10 | i4 | semmle.label | i4 |
+| funcsLocal.c:27:9:27:10 | i3 indirection | semmle.label | i3 indirection |
+| funcsLocal.c:31:13:31:17 | call to fgets indirection | semmle.label | call to fgets indirection |
+| funcsLocal.c:32:9:32:10 | i4 indirection | semmle.label | i4 indirection |
 | funcsLocal.c:36:7:36:8 | gets output argument | semmle.label | gets output argument |
-| funcsLocal.c:36:7:36:8 | i5 | semmle.label | i5 |
-| funcsLocal.c:36:7:36:8 | i5 | semmle.label | i5 |
-| funcsLocal.c:37:9:37:10 | i5 | semmle.label | i5 |
-| funcsLocal.c:37:9:37:10 | i5 | semmle.label | i5 |
-| funcsLocal.c:41:13:41:16 | call to gets | semmle.label | call to gets |
-| funcsLocal.c:41:13:41:16 | call to gets | semmle.label | call to gets |
-| funcsLocal.c:42:9:42:10 | i6 | semmle.label | i6 |
-| funcsLocal.c:42:9:42:10 | i6 | semmle.label | i6 |
-| funcsLocal.c:46:7:46:9 | * ... | semmle.label | * ... |
-| funcsLocal.c:46:7:46:9 | * ... | semmle.label | * ... |
+| funcsLocal.c:37:9:37:10 | i5 indirection | semmle.label | i5 indirection |
+| funcsLocal.c:41:13:41:16 | call to gets indirection | semmle.label | call to gets indirection |
+| funcsLocal.c:42:9:42:10 | i6 indirection | semmle.label | i6 indirection |
 | funcsLocal.c:46:7:46:9 | gets output argument | semmle.label | gets output argument |
-| funcsLocal.c:47:9:47:11 | * ... | semmle.label | * ... |
-| funcsLocal.c:47:9:47:11 | * ... | semmle.label | * ... |
-| funcsLocal.c:52:8:52:11 | call to gets | semmle.label | call to gets |
-| funcsLocal.c:52:8:52:11 | call to gets | semmle.label | call to gets |
-| funcsLocal.c:53:9:53:11 | * ... | semmle.label | * ... |
-| funcsLocal.c:53:9:53:11 | * ... | semmle.label | * ... |
-| funcsLocal.c:58:9:58:10 | e1 | semmle.label | e1 |
-| funcsLocal.c:58:9:58:10 | e1 | semmle.label | e1 |
+| funcsLocal.c:47:9:47:11 | * ... indirection | semmle.label | * ... indirection |
+| funcsLocal.c:52:8:52:11 | call to gets indirection | semmle.label | call to gets indirection |
+| funcsLocal.c:53:9:53:11 | * ... indirection | semmle.label | * ... indirection |
+| funcsLocal.c:58:9:58:10 | e1 indirection | semmle.label | e1 indirection |
+subpaths
 #select
-| funcsLocal.c:17:9:17:10 | i1 | funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:17:9:17:10 | i1 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:16:8:16:9 | i1 | fread |
-| funcsLocal.c:27:9:27:10 | i3 | funcsLocal.c:26:8:26:9 | i3 | funcsLocal.c:27:9:27:10 | i3 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:26:8:26:9 | i3 | fgets |
-| funcsLocal.c:32:9:32:10 | i4 | funcsLocal.c:31:13:31:17 | call to fgets | funcsLocal.c:32:9:32:10 | i4 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:31:13:31:17 | call to fgets | fgets |
-| funcsLocal.c:37:9:37:10 | i5 | funcsLocal.c:36:7:36:8 | i5 | funcsLocal.c:37:9:37:10 | i5 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:36:7:36:8 | i5 | gets |
-| funcsLocal.c:42:9:42:10 | i6 | funcsLocal.c:41:13:41:16 | call to gets | funcsLocal.c:42:9:42:10 | i6 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:41:13:41:16 | call to gets | gets |
-| funcsLocal.c:47:9:47:11 | * ... | funcsLocal.c:46:7:46:9 | * ... | funcsLocal.c:47:9:47:11 | * ... | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:46:7:46:9 | * ... | gets |
-| funcsLocal.c:53:9:53:11 | * ... | funcsLocal.c:52:8:52:11 | call to gets | funcsLocal.c:53:9:53:11 | * ... | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:52:8:52:11 | call to gets | gets |
-| funcsLocal.c:58:9:58:10 | e1 | funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:58:9:58:10 | e1 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:16:8:16:9 | i1 | fread |
+| funcsLocal.c:17:9:17:10 | i1 indirection | funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:17:9:17:10 | i1 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:16:8:16:9 | fread output argument | string read by fread |
+| funcsLocal.c:27:9:27:10 | i3 indirection | funcsLocal.c:26:8:26:9 | fgets output argument | funcsLocal.c:27:9:27:10 | i3 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:26:8:26:9 | fgets output argument | string read by fgets |
+| funcsLocal.c:32:9:32:10 | i4 indirection | funcsLocal.c:31:13:31:17 | call to fgets indirection | funcsLocal.c:32:9:32:10 | i4 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:31:13:31:17 | call to fgets indirection | string read by fgets |
+| funcsLocal.c:37:9:37:10 | i5 indirection | funcsLocal.c:36:7:36:8 | gets output argument | funcsLocal.c:37:9:37:10 | i5 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:36:7:36:8 | gets output argument | string read by gets |
+| funcsLocal.c:42:9:42:10 | i6 indirection | funcsLocal.c:41:13:41:16 | call to gets indirection | funcsLocal.c:42:9:42:10 | i6 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:41:13:41:16 | call to gets indirection | string read by gets |
+| funcsLocal.c:47:9:47:11 | * ... indirection | funcsLocal.c:46:7:46:9 | gets output argument | funcsLocal.c:47:9:47:11 | * ... indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:46:7:46:9 | gets output argument | string read by gets |
+| funcsLocal.c:53:9:53:11 | * ... indirection | funcsLocal.c:52:8:52:11 | call to gets indirection | funcsLocal.c:53:9:53:11 | * ... indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:52:8:52:11 | call to gets indirection | string read by gets |
+| funcsLocal.c:58:9:58:10 | e1 indirection | funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:58:9:58:10 | e1 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:16:8:16:9 | fread output argument | string read by fread |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/globalVars/UncontrolledFormatString.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/globalVars/UncontrolledFormatString.expected
@@ -1,42 +1,32 @@
 edges
-| globalVars.c:8:7:8:10 | copy | globalVars.c:27:9:27:12 | copy |
-| globalVars.c:8:7:8:10 | copy | globalVars.c:27:9:27:12 | copy |
-| globalVars.c:8:7:8:10 | copy | globalVars.c:30:15:30:18 | copy |
-| globalVars.c:8:7:8:10 | copy | globalVars.c:30:15:30:18 | copy |
-| globalVars.c:8:7:8:10 | copy | globalVars.c:35:11:35:14 | copy |
-| globalVars.c:9:7:9:11 | copy2 | globalVars.c:38:9:38:13 | copy2 |
-| globalVars.c:9:7:9:11 | copy2 | globalVars.c:38:9:38:13 | copy2 |
-| globalVars.c:9:7:9:11 | copy2 | globalVars.c:41:15:41:19 | copy2 |
-| globalVars.c:9:7:9:11 | copy2 | globalVars.c:41:15:41:19 | copy2 |
-| globalVars.c:9:7:9:11 | copy2 | globalVars.c:50:9:50:13 | copy2 |
-| globalVars.c:9:7:9:11 | copy2 | globalVars.c:50:9:50:13 | copy2 |
-| globalVars.c:11:22:11:25 | argv | globalVars.c:8:7:8:10 | copy |
-| globalVars.c:15:21:15:23 | val | globalVars.c:9:7:9:11 | copy2 |
-| globalVars.c:24:11:24:14 | argv | globalVars.c:11:22:11:25 | argv |
-| globalVars.c:24:11:24:14 | argv | globalVars.c:11:22:11:25 | argv |
-| globalVars.c:35:11:35:14 | copy | globalVars.c:15:21:15:23 | val |
-subpaths
+| globalVars.c:8:7:8:10 | copy indirection | globalVars.c:27:9:27:12 | copy indirection |
+| globalVars.c:8:7:8:10 | copy indirection | globalVars.c:30:15:30:18 | copy indirection |
+| globalVars.c:8:7:8:10 | copy indirection | globalVars.c:35:11:35:14 | copy indirection |
+| globalVars.c:9:7:9:11 | copy2 indirection | globalVars.c:38:9:38:13 | copy2 indirection |
+| globalVars.c:9:7:9:11 | copy2 indirection | globalVars.c:41:15:41:19 | copy2 indirection |
+| globalVars.c:9:7:9:11 | copy2 indirection | globalVars.c:50:9:50:13 | copy2 indirection |
+| globalVars.c:11:22:11:25 | argv indirection | globalVars.c:8:7:8:10 | copy indirection |
+| globalVars.c:15:21:15:23 | val indirection | globalVars.c:9:7:9:11 | copy2 indirection |
+| globalVars.c:23:27:23:30 | argv indirection | globalVars.c:24:11:24:14 | argv indirection |
+| globalVars.c:24:11:24:14 | argv indirection | globalVars.c:11:22:11:25 | argv indirection |
+| globalVars.c:35:11:35:14 | copy indirection | globalVars.c:15:21:15:23 | val indirection |
 nodes
-| globalVars.c:8:7:8:10 | copy | semmle.label | copy |
-| globalVars.c:9:7:9:11 | copy2 | semmle.label | copy2 |
-| globalVars.c:11:22:11:25 | argv | semmle.label | argv |
-| globalVars.c:15:21:15:23 | val | semmle.label | val |
-| globalVars.c:24:11:24:14 | argv | semmle.label | argv |
-| globalVars.c:24:11:24:14 | argv | semmle.label | argv |
-| globalVars.c:27:9:27:12 | copy | semmle.label | copy |
-| globalVars.c:27:9:27:12 | copy | semmle.label | copy |
-| globalVars.c:30:15:30:18 | copy | semmle.label | copy |
-| globalVars.c:30:15:30:18 | copy | semmle.label | copy |
-| globalVars.c:35:11:35:14 | copy | semmle.label | copy |
-| globalVars.c:38:9:38:13 | copy2 | semmle.label | copy2 |
-| globalVars.c:38:9:38:13 | copy2 | semmle.label | copy2 |
-| globalVars.c:41:15:41:19 | copy2 | semmle.label | copy2 |
-| globalVars.c:41:15:41:19 | copy2 | semmle.label | copy2 |
-| globalVars.c:50:9:50:13 | copy2 | semmle.label | copy2 |
-| globalVars.c:50:9:50:13 | copy2 | semmle.label | copy2 |
+| globalVars.c:8:7:8:10 | copy indirection | semmle.label | copy indirection |
+| globalVars.c:9:7:9:11 | copy2 indirection | semmle.label | copy2 indirection |
+| globalVars.c:11:22:11:25 | argv indirection | semmle.label | argv indirection |
+| globalVars.c:15:21:15:23 | val indirection | semmle.label | val indirection |
+| globalVars.c:23:27:23:30 | argv indirection | semmle.label | argv indirection |
+| globalVars.c:24:11:24:14 | argv indirection | semmle.label | argv indirection |
+| globalVars.c:27:9:27:12 | copy indirection | semmle.label | copy indirection |
+| globalVars.c:30:15:30:18 | copy indirection | semmle.label | copy indirection |
+| globalVars.c:35:11:35:14 | copy indirection | semmle.label | copy indirection |
+| globalVars.c:38:9:38:13 | copy2 indirection | semmle.label | copy2 indirection |
+| globalVars.c:41:15:41:19 | copy2 indirection | semmle.label | copy2 indirection |
+| globalVars.c:50:9:50:13 | copy2 indirection | semmle.label | copy2 indirection |
+subpaths
 #select
-| globalVars.c:27:9:27:12 | copy | globalVars.c:24:11:24:14 | argv | globalVars.c:27:9:27:12 | copy | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | globalVars.c:24:11:24:14 | argv | argv |
-| globalVars.c:30:15:30:18 | copy | globalVars.c:24:11:24:14 | argv | globalVars.c:30:15:30:18 | copy | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(str), which calls printf(format). | globalVars.c:24:11:24:14 | argv | argv |
-| globalVars.c:38:9:38:13 | copy2 | globalVars.c:24:11:24:14 | argv | globalVars.c:38:9:38:13 | copy2 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | globalVars.c:24:11:24:14 | argv | argv |
-| globalVars.c:41:15:41:19 | copy2 | globalVars.c:24:11:24:14 | argv | globalVars.c:41:15:41:19 | copy2 | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(str), which calls printf(format). | globalVars.c:24:11:24:14 | argv | argv |
-| globalVars.c:50:9:50:13 | copy2 | globalVars.c:24:11:24:14 | argv | globalVars.c:50:9:50:13 | copy2 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | globalVars.c:24:11:24:14 | argv | argv |
+| globalVars.c:27:9:27:12 | copy indirection | globalVars.c:23:27:23:30 | argv indirection | globalVars.c:27:9:27:12 | copy indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | globalVars.c:23:27:23:30 | argv indirection | a command-line argument |
+| globalVars.c:30:15:30:18 | copy indirection | globalVars.c:23:27:23:30 | argv indirection | globalVars.c:30:15:30:18 | copy indirection | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(str), which calls printf(format). | globalVars.c:23:27:23:30 | argv indirection | a command-line argument |
+| globalVars.c:38:9:38:13 | copy2 indirection | globalVars.c:23:27:23:30 | argv indirection | globalVars.c:38:9:38:13 | copy2 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | globalVars.c:23:27:23:30 | argv indirection | a command-line argument |
+| globalVars.c:41:15:41:19 | copy2 indirection | globalVars.c:23:27:23:30 | argv indirection | globalVars.c:41:15:41:19 | copy2 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(str), which calls printf(format). | globalVars.c:23:27:23:30 | argv indirection | a command-line argument |
+| globalVars.c:50:9:50:13 | copy2 indirection | globalVars.c:23:27:23:30 | argv indirection | globalVars.c:50:9:50:13 | copy2 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | globalVars.c:23:27:23:30 | argv indirection | a command-line argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/ifs/ifs.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/ifs/ifs.expected
@@ -1,103 +1,38 @@
 edges
-| ifs.c:61:8:61:11 | argv | ifs.c:62:9:62:10 | c7 |
-| ifs.c:61:8:61:11 | argv | ifs.c:62:9:62:10 | c7 |
-| ifs.c:61:8:61:11 | argv | ifs.c:62:9:62:10 | c7 |
-| ifs.c:61:8:61:11 | argv | ifs.c:62:9:62:10 | c7 |
-| ifs.c:68:8:68:11 | argv | ifs.c:69:9:69:10 | c8 |
-| ifs.c:68:8:68:11 | argv | ifs.c:69:9:69:10 | c8 |
-| ifs.c:68:8:68:11 | argv | ifs.c:69:9:69:10 | c8 |
-| ifs.c:68:8:68:11 | argv | ifs.c:69:9:69:10 | c8 |
-| ifs.c:74:8:74:11 | argv | ifs.c:75:9:75:10 | i1 |
-| ifs.c:74:8:74:11 | argv | ifs.c:75:9:75:10 | i1 |
-| ifs.c:74:8:74:11 | argv | ifs.c:75:9:75:10 | i1 |
-| ifs.c:74:8:74:11 | argv | ifs.c:75:9:75:10 | i1 |
-| ifs.c:80:8:80:11 | argv | ifs.c:81:9:81:10 | i2 |
-| ifs.c:80:8:80:11 | argv | ifs.c:81:9:81:10 | i2 |
-| ifs.c:80:8:80:11 | argv | ifs.c:81:9:81:10 | i2 |
-| ifs.c:80:8:80:11 | argv | ifs.c:81:9:81:10 | i2 |
-| ifs.c:86:8:86:11 | argv | ifs.c:87:9:87:10 | i3 |
-| ifs.c:86:8:86:11 | argv | ifs.c:87:9:87:10 | i3 |
-| ifs.c:86:8:86:11 | argv | ifs.c:87:9:87:10 | i3 |
-| ifs.c:86:8:86:11 | argv | ifs.c:87:9:87:10 | i3 |
-| ifs.c:92:8:92:11 | argv | ifs.c:93:9:93:10 | i4 |
-| ifs.c:92:8:92:11 | argv | ifs.c:93:9:93:10 | i4 |
-| ifs.c:92:8:92:11 | argv | ifs.c:93:9:93:10 | i4 |
-| ifs.c:92:8:92:11 | argv | ifs.c:93:9:93:10 | i4 |
-| ifs.c:98:8:98:11 | argv | ifs.c:99:9:99:10 | i5 |
-| ifs.c:98:8:98:11 | argv | ifs.c:99:9:99:10 | i5 |
-| ifs.c:98:8:98:11 | argv | ifs.c:99:9:99:10 | i5 |
-| ifs.c:98:8:98:11 | argv | ifs.c:99:9:99:10 | i5 |
-| ifs.c:105:8:105:11 | argv | ifs.c:106:9:106:10 | i6 |
-| ifs.c:105:8:105:11 | argv | ifs.c:106:9:106:10 | i6 |
-| ifs.c:105:8:105:11 | argv | ifs.c:106:9:106:10 | i6 |
-| ifs.c:105:8:105:11 | argv | ifs.c:106:9:106:10 | i6 |
-| ifs.c:111:8:111:11 | argv | ifs.c:112:9:112:10 | i7 |
-| ifs.c:111:8:111:11 | argv | ifs.c:112:9:112:10 | i7 |
-| ifs.c:111:8:111:11 | argv | ifs.c:112:9:112:10 | i7 |
-| ifs.c:111:8:111:11 | argv | ifs.c:112:9:112:10 | i7 |
-| ifs.c:117:8:117:11 | argv | ifs.c:118:9:118:10 | i8 |
-| ifs.c:117:8:117:11 | argv | ifs.c:118:9:118:10 | i8 |
-| ifs.c:117:8:117:11 | argv | ifs.c:118:9:118:10 | i8 |
-| ifs.c:117:8:117:11 | argv | ifs.c:118:9:118:10 | i8 |
-| ifs.c:123:8:123:11 | argv | ifs.c:124:9:124:10 | i9 |
-| ifs.c:123:8:123:11 | argv | ifs.c:124:9:124:10 | i9 |
-| ifs.c:123:8:123:11 | argv | ifs.c:124:9:124:10 | i9 |
-| ifs.c:123:8:123:11 | argv | ifs.c:124:9:124:10 | i9 |
-subpaths
+| ifs.c:16:27:16:30 | argv indirection | ifs.c:62:9:62:10 | c7 indirection |
+| ifs.c:16:27:16:30 | argv indirection | ifs.c:69:9:69:10 | c8 indirection |
+| ifs.c:16:27:16:30 | argv indirection | ifs.c:75:9:75:10 | i1 indirection |
+| ifs.c:16:27:16:30 | argv indirection | ifs.c:81:9:81:10 | i2 indirection |
+| ifs.c:16:27:16:30 | argv indirection | ifs.c:87:9:87:10 | i3 indirection |
+| ifs.c:16:27:16:30 | argv indirection | ifs.c:93:9:93:10 | i4 indirection |
+| ifs.c:16:27:16:30 | argv indirection | ifs.c:99:9:99:10 | i5 indirection |
+| ifs.c:16:27:16:30 | argv indirection | ifs.c:106:9:106:10 | i6 indirection |
+| ifs.c:16:27:16:30 | argv indirection | ifs.c:112:9:112:10 | i7 indirection |
+| ifs.c:16:27:16:30 | argv indirection | ifs.c:118:9:118:10 | i8 indirection |
+| ifs.c:16:27:16:30 | argv indirection | ifs.c:124:9:124:10 | i9 indirection |
 nodes
-| ifs.c:61:8:61:11 | argv | semmle.label | argv |
-| ifs.c:61:8:61:11 | argv | semmle.label | argv |
-| ifs.c:62:9:62:10 | c7 | semmle.label | c7 |
-| ifs.c:62:9:62:10 | c7 | semmle.label | c7 |
-| ifs.c:68:8:68:11 | argv | semmle.label | argv |
-| ifs.c:68:8:68:11 | argv | semmle.label | argv |
-| ifs.c:69:9:69:10 | c8 | semmle.label | c8 |
-| ifs.c:69:9:69:10 | c8 | semmle.label | c8 |
-| ifs.c:74:8:74:11 | argv | semmle.label | argv |
-| ifs.c:74:8:74:11 | argv | semmle.label | argv |
-| ifs.c:75:9:75:10 | i1 | semmle.label | i1 |
-| ifs.c:75:9:75:10 | i1 | semmle.label | i1 |
-| ifs.c:80:8:80:11 | argv | semmle.label | argv |
-| ifs.c:80:8:80:11 | argv | semmle.label | argv |
-| ifs.c:81:9:81:10 | i2 | semmle.label | i2 |
-| ifs.c:81:9:81:10 | i2 | semmle.label | i2 |
-| ifs.c:86:8:86:11 | argv | semmle.label | argv |
-| ifs.c:86:8:86:11 | argv | semmle.label | argv |
-| ifs.c:87:9:87:10 | i3 | semmle.label | i3 |
-| ifs.c:87:9:87:10 | i3 | semmle.label | i3 |
-| ifs.c:92:8:92:11 | argv | semmle.label | argv |
-| ifs.c:92:8:92:11 | argv | semmle.label | argv |
-| ifs.c:93:9:93:10 | i4 | semmle.label | i4 |
-| ifs.c:93:9:93:10 | i4 | semmle.label | i4 |
-| ifs.c:98:8:98:11 | argv | semmle.label | argv |
-| ifs.c:98:8:98:11 | argv | semmle.label | argv |
-| ifs.c:99:9:99:10 | i5 | semmle.label | i5 |
-| ifs.c:99:9:99:10 | i5 | semmle.label | i5 |
-| ifs.c:105:8:105:11 | argv | semmle.label | argv |
-| ifs.c:105:8:105:11 | argv | semmle.label | argv |
-| ifs.c:106:9:106:10 | i6 | semmle.label | i6 |
-| ifs.c:106:9:106:10 | i6 | semmle.label | i6 |
-| ifs.c:111:8:111:11 | argv | semmle.label | argv |
-| ifs.c:111:8:111:11 | argv | semmle.label | argv |
-| ifs.c:112:9:112:10 | i7 | semmle.label | i7 |
-| ifs.c:112:9:112:10 | i7 | semmle.label | i7 |
-| ifs.c:117:8:117:11 | argv | semmle.label | argv |
-| ifs.c:117:8:117:11 | argv | semmle.label | argv |
-| ifs.c:118:9:118:10 | i8 | semmle.label | i8 |
-| ifs.c:118:9:118:10 | i8 | semmle.label | i8 |
-| ifs.c:123:8:123:11 | argv | semmle.label | argv |
-| ifs.c:123:8:123:11 | argv | semmle.label | argv |
-| ifs.c:124:9:124:10 | i9 | semmle.label | i9 |
-| ifs.c:124:9:124:10 | i9 | semmle.label | i9 |
+| ifs.c:16:27:16:30 | argv indirection | semmle.label | argv indirection |
+| ifs.c:62:9:62:10 | c7 indirection | semmle.label | c7 indirection |
+| ifs.c:69:9:69:10 | c8 indirection | semmle.label | c8 indirection |
+| ifs.c:75:9:75:10 | i1 indirection | semmle.label | i1 indirection |
+| ifs.c:81:9:81:10 | i2 indirection | semmle.label | i2 indirection |
+| ifs.c:87:9:87:10 | i3 indirection | semmle.label | i3 indirection |
+| ifs.c:93:9:93:10 | i4 indirection | semmle.label | i4 indirection |
+| ifs.c:99:9:99:10 | i5 indirection | semmle.label | i5 indirection |
+| ifs.c:106:9:106:10 | i6 indirection | semmle.label | i6 indirection |
+| ifs.c:112:9:112:10 | i7 indirection | semmle.label | i7 indirection |
+| ifs.c:118:9:118:10 | i8 indirection | semmle.label | i8 indirection |
+| ifs.c:124:9:124:10 | i9 indirection | semmle.label | i9 indirection |
+subpaths
 #select
-| ifs.c:62:9:62:10 | c7 | ifs.c:61:8:61:11 | argv | ifs.c:62:9:62:10 | c7 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:61:8:61:11 | argv | argv |
-| ifs.c:69:9:69:10 | c8 | ifs.c:68:8:68:11 | argv | ifs.c:69:9:69:10 | c8 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:68:8:68:11 | argv | argv |
-| ifs.c:75:9:75:10 | i1 | ifs.c:74:8:74:11 | argv | ifs.c:75:9:75:10 | i1 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:74:8:74:11 | argv | argv |
-| ifs.c:81:9:81:10 | i2 | ifs.c:80:8:80:11 | argv | ifs.c:81:9:81:10 | i2 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:80:8:80:11 | argv | argv |
-| ifs.c:87:9:87:10 | i3 | ifs.c:86:8:86:11 | argv | ifs.c:87:9:87:10 | i3 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:86:8:86:11 | argv | argv |
-| ifs.c:93:9:93:10 | i4 | ifs.c:92:8:92:11 | argv | ifs.c:93:9:93:10 | i4 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:92:8:92:11 | argv | argv |
-| ifs.c:99:9:99:10 | i5 | ifs.c:98:8:98:11 | argv | ifs.c:99:9:99:10 | i5 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:98:8:98:11 | argv | argv |
-| ifs.c:106:9:106:10 | i6 | ifs.c:105:8:105:11 | argv | ifs.c:106:9:106:10 | i6 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:105:8:105:11 | argv | argv |
-| ifs.c:112:9:112:10 | i7 | ifs.c:111:8:111:11 | argv | ifs.c:112:9:112:10 | i7 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:111:8:111:11 | argv | argv |
-| ifs.c:118:9:118:10 | i8 | ifs.c:117:8:117:11 | argv | ifs.c:118:9:118:10 | i8 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:117:8:117:11 | argv | argv |
-| ifs.c:124:9:124:10 | i9 | ifs.c:123:8:123:11 | argv | ifs.c:124:9:124:10 | i9 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:123:8:123:11 | argv | argv |
+| ifs.c:62:9:62:10 | c7 indirection | ifs.c:16:27:16:30 | argv indirection | ifs.c:62:9:62:10 | c7 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | argv indirection | a command-line argument |
+| ifs.c:69:9:69:10 | c8 indirection | ifs.c:16:27:16:30 | argv indirection | ifs.c:69:9:69:10 | c8 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | argv indirection | a command-line argument |
+| ifs.c:75:9:75:10 | i1 indirection | ifs.c:16:27:16:30 | argv indirection | ifs.c:75:9:75:10 | i1 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | argv indirection | a command-line argument |
+| ifs.c:81:9:81:10 | i2 indirection | ifs.c:16:27:16:30 | argv indirection | ifs.c:81:9:81:10 | i2 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | argv indirection | a command-line argument |
+| ifs.c:87:9:87:10 | i3 indirection | ifs.c:16:27:16:30 | argv indirection | ifs.c:87:9:87:10 | i3 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | argv indirection | a command-line argument |
+| ifs.c:93:9:93:10 | i4 indirection | ifs.c:16:27:16:30 | argv indirection | ifs.c:93:9:93:10 | i4 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | argv indirection | a command-line argument |
+| ifs.c:99:9:99:10 | i5 indirection | ifs.c:16:27:16:30 | argv indirection | ifs.c:99:9:99:10 | i5 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | argv indirection | a command-line argument |
+| ifs.c:106:9:106:10 | i6 indirection | ifs.c:16:27:16:30 | argv indirection | ifs.c:106:9:106:10 | i6 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | argv indirection | a command-line argument |
+| ifs.c:112:9:112:10 | i7 indirection | ifs.c:16:27:16:30 | argv indirection | ifs.c:112:9:112:10 | i7 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | argv indirection | a command-line argument |
+| ifs.c:118:9:118:10 | i8 indirection | ifs.c:16:27:16:30 | argv indirection | ifs.c:118:9:118:10 | i8 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | argv indirection | a command-line argument |
+| ifs.c:124:9:124:10 | i9 indirection | ifs.c:16:27:16:30 | argv indirection | ifs.c:124:9:124:10 | i9 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | argv indirection | a command-line argument |


### PR DESCRIPTION
For discussion of MRVA results see internal issue. The alerts lost on vim in DCA seem related to pointer/pointee conflation.

I'll fix up the internal tests once we're ok with this PR.