### PR TITLE
Java: Add `.properties` file references in integration tests

### DIFF
--- a/java/ql/integration-tests/all-platforms/java/buildless-maven/test.expected
+++ b/java/ql/integration-tests/all-platforms/java/buildless-maven/test.expected
@@ -1,8 +1,10 @@
+#select
+| src/main/java/com/example/App.java:0:0:0:0 | App |
+| src/test/java/com/example/AppTest.java:0:0:0:0 | AppTest |
 xmlFiles
 | pom.xml:0:0:0:0 | pom.xml |
 | src/main/resources/page.xml:0:0:0:0 | src/main/resources/page.xml |
 | src/main/resources/struts.xml:0:0:0:0 | src/main/resources/struts.xml |
 propertiesFiles
-#select
-| src/main/java/com/example/App.java:0:0:0:0 | App |
-| src/test/java/com/example/AppTest.java:0:0:0:0 | AppTest |
+| src/main/resources/my-app.properties:0:0:0:0 | src/main/resources/my-app.properties |
+| test-db/log/ext/javac.properties:0:0:0:0 | test-db/log/ext/javac.properties |

--- a/java/ql/integration-tests/all-platforms/java/buildless/test.expected
+++ b/java/ql/integration-tests/all-platforms/java/buildless/test.expected
@@ -1,7 +1,9 @@
+#select
+| src/main/java/com/example/App.java:0:0:0:0 | App |
+| src/test/java/com/example/AppTest.java:0:0:0:0 | AppTest |
 xmlFiles
 | src/main/resources/page.xml:0:0:0:0 | src/main/resources/page.xml |
 | src/main/resources/struts.xml:0:0:0:0 | src/main/resources/struts.xml |
 propertiesFiles
-#select
-| src/main/java/com/example/App.java:0:0:0:0 | App |
-| src/test/java/com/example/AppTest.java:0:0:0:0 | AppTest |
+| src/main/resources/my-app.properties:0:0:0:0 | src/main/resources/my-app.properties |
+| test-db/log/ext/javac.properties:0:0:0:0 | test-db/log/ext/javac.properties |

--- a/java/ql/integration-tests/all-platforms/java/maven-sample/test.expected
+++ b/java/ql/integration-tests/all-platforms/java/maven-sample/test.expected
@@ -1,3 +1,6 @@
+#select
+| src/main/java/com/example/App.java:0:0:0:0 | App |
+| src/test/java/com/example/AppTest.java:0:0:0:0 | AppTest |
 xmlFiles
 | pom.xml:0:0:0:0 | pom.xml |
 | src/main/resources/page.xml:0:0:0:0 | src/main/resources/page.xml |
@@ -5,6 +8,8 @@ xmlFiles
 | target/classes/page.xml:0:0:0:0 | target/classes/page.xml |
 | target/classes/struts.xml:0:0:0:0 | target/classes/struts.xml |
 propertiesFiles
-#select
-| src/main/java/com/example/App.java:0:0:0:0 | App |
-| src/test/java/com/example/AppTest.java:0:0:0:0 | AppTest |
+| src/main/resources/my-app.properties:0:0:0:0 | src/main/resources/my-app.properties |
+| target/classes/my-app.properties:0:0:0:0 | target/classes/my-app.properties |
+| target/maven-archiver/pom.properties:0:0:0:0 | target/maven-archiver/pom.properties |
+| test-db/log/ext/javac-1.properties:0:0:0:0 | test-db/log/ext/javac-1.properties |
+| test-db/log/ext/javac.properties:0:0:0:0 | test-db/log/ext/javac.properties |


### PR DESCRIPTION
This updates some of the integration tests to handle the `.properties` extractor being enabled.