### PR TITLE
Java: add a new query cover some instance of CWE-209

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-209/ExceptionOrControlConsoleExposure.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-209/ExceptionOrControlConsoleExposure.java
@@ -1,0 +1,31 @@
+import javax.servlet.*;
+import javax.servlet.http.*;
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SimpleServlet extends HttpServlet {
+    private static List<String> queryList = new ArrayList<>();
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        response.setContentType("text/html");
+
+        PrintWriter out = response.getWriter();
+        String queryString = "";
+        try{
+            queryString = request.getQueryString();
+            saveQuery(queryString);
+        } catch (Exception e) {
+            System.out.println(queryString);
+        }
+
+        // 输出HTML页面
+        out.println("<html>");
+        out.println("<head><title>Simple Servlet</title></head>");
+        out.println("<body>");
+        out.println("Hello, World!");
+        out.println("</body></html>");
+    }
+    public void saveQuery(String queryString) {
+        queryList.add(queryString);
+    }
+}

--- a/java/ql/src/experimental/Security/CWE/CWE-209/ExceptionOrControlConsoleExposure.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-209/ExceptionOrControlConsoleExposure.java
@@ -11,18 +11,21 @@ public class SimpleServlet extends HttpServlet {
 
         PrintWriter out = response.getWriter();
         String queryString = "";
-        try{
-            queryString = request.getQueryString();
-            saveQuery(queryString);
-        } catch (Exception e) {
+        queryString = request.getQueryString();
+        if (queryString.matches("save_query_0")) {
+            throw new RuntimeException(queryString);
+        } else if(queryString.matches("save_query_1")) {
             System.out.println(queryString);
+        } else if(queryString.matches("save_query_2")) {
+            System.out.print(queryString);
         }
+        saveQuery(queryString);
 
-        // 输出HTML页面
         out.println("<html>");
         out.println("<head><title>Simple Servlet</title></head>");
         out.println("<body>");
         out.println("Hello, World!");
+        out.println(queryString);
         out.println("</body></html>");
     }
     public void saveQuery(String queryString) {

--- a/java/ql/src/experimental/Security/CWE/CWE-209/ExceptionOrControlConsoleExposure.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-209/ExceptionOrControlConsoleExposure.ql
@@ -1,0 +1,43 @@
+/**
+ * @name Information exposure through a exception throwing or control console
+ * @description Remote information output through exception throwing or control console.
+ * @kind problem
+ * @problem.severity warning
+ * @precision medium
+ * @id java/exception-or-control-console-exposure
+ * @tags security
+ *       experimental
+ *       external/cwe/cwe-209
+ */
+
+import java
+import semmle.code.java.dataflow.FlowSources
+import DataFlow::PathGraph
+
+class ThrowRemoteMessageConfig extends TaintTracking::Configuration {
+    ThrowRemoteMessageConfig() { this = "ThrowRemoteMessageConfig" }
+    
+    override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+
+    override predicate isSink(DataFlow::Node sink) {
+        exists ( ClassInstanceExpr newExpr |
+          newExpr.getConstructedType().getAnAncestor() instanceof TypeThrowable and
+          newExpr.getAnArgument() = sink.asExpr()
+        )
+        or
+        exists ( MethodAccess methodAccess, Class c |
+            ( 
+              methodAccess.getMethod().hasName("print") 
+              or 
+              methodAccess.getMethod().hasName("println") 
+            ) and
+            methodAccess.getCallee().getAParamType() = c and
+            c.getASupertype*().hasQualifiedName("java.lang", "String") and
+            methodAccess.getMethod().getAParameter().getAnArgument() = sink.asExpr()
+        )
+    }
+}
+
+from ThrowRemoteMessageConfig config, DataFlow::PathNode source, DataFlow::PathNode sink
+where config.hasFlowPath(source, sink)
+select source, sink, "Remote information exposure through a exception throwing or control console"


### PR DESCRIPTION
The query can track remote information output through exception throwing or control console print.