### PR TITLE
Swift: More sinks for swift/uncontrolled-format-string

### DIFF
--- a/swift/ql/lib/codeql/swift/StringFormat.qll
+++ b/swift/ql/lib/codeql/swift/StringFormat.qll
@@ -56,6 +56,19 @@ class LocalizedStringWithFormat extends FormattingFunction, Method {
 }
 
 /**
+ * A method that appends a formatted string.
+ */
+class StringMethodWithFormat extends FormattingFunction, Method {
+  StringMethodWithFormat() {
+    this.hasQualifiedName("NSMutableString", "appendFormat(_:_:)")
+    or
+    this.hasQualifiedName("StringProtocol", "appendingFormat(_:_:)")
+  }
+
+  override int getFormatParameterIndex() { result = 0 }
+}
+
+/**
  * The functions `NSLog` and `NSLogv`.
  */
 class NsLog extends FormattingFunction, FreeFunction {

--- a/swift/ql/lib/codeql/swift/StringFormat.qll
+++ b/swift/ql/lib/codeql/swift/StringFormat.qll
@@ -85,3 +85,16 @@ class NsExceptionRaise extends FormattingFunction, Method {
 
   override int getFormatParameterIndex() { result = 1 }
 }
+
+/**
+ * A function that appears to be an imported C `printf` variant.
+ */
+class PrintfFormat extends FormattingFunction, FreeFunction {
+  int formatParamIndex;
+
+  PrintfFormat() {
+    this.getShortName().matches("%printf%") and this.getParam(formatParamIndex).getName() = "format"
+  }
+
+  override int getFormatParameterIndex() { result = formatParamIndex }
+}

--- a/swift/ql/lib/codeql/swift/security/UncontrolledFormatStringExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/UncontrolledFormatStringExtensions.qll
@@ -8,6 +8,7 @@ private import codeql.swift.StringFormat
 private import codeql.swift.dataflow.DataFlow
 private import codeql.swift.dataflow.TaintTracking
 private import codeql.swift.dataflow.ExternalFlow
+private import codeql.swift.frameworks.StandardLibrary.PointerTypes
 
 /**
  * A dataflow sink for uncontrolled format string vulnerabilities.
@@ -40,6 +41,47 @@ private class DefaultUncontrolledFormatStringSink extends UncontrolledFormatStri
     or
     // a sink defined in a CSV model.
     sinkNode(this, "format-string")
+  }
+}
+
+/**
+ * Holds if `f`, `ix` describe `pd` and `pd` is a parameter that might be a format
+ * string.
+ */
+pragma[noinline]
+predicate formatLikeHeuristic(Callable f, int ix, ParamDecl pd) {
+  pd.getName() = ["format", "formatString", "fmt"] and
+  pd = f.getParam(ix)
+}
+
+/**
+ * An uncontrolled format string sink that is determined by imprecise methods.
+ */
+class HeuristicUncontrolledFormatStringSink extends UncontrolledFormatStringSink {
+  HeuristicUncontrolledFormatStringSink() {
+    exists(Callable f, Type argsType |
+      (
+        // by parameter name
+        exists(CallExpr ce, int ix |
+          formatLikeHeuristic(f, ix, _) and
+          f = ce.getStaticTarget() and
+          this.asExpr() = ce.getArgument(ix).getExpr()
+        )
+        or
+        // by argument name
+        exists(Argument a |
+          a.getLabel() = ["format", "formatString", "fmt"] and
+          a.getApplyExpr().getStaticTarget() = f and
+          this.asExpr() = a.getExpr()
+        )
+      ) and
+      // last parameter is vararg
+      argsType = f.getParam(f.getNumberOfParams() - 1).getType().getUnderlyingType() and
+      (
+        argsType instanceof CVaListPointerType or
+        argsType instanceof VariadicSequenceType
+      )
+    )
   }
 }
 

--- a/swift/ql/lib/codeql/swift/security/UncontrolledFormatStringExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/UncontrolledFormatStringExtensions.qll
@@ -9,6 +9,7 @@ private import codeql.swift.dataflow.DataFlow
 private import codeql.swift.dataflow.TaintTracking
 private import codeql.swift.dataflow.ExternalFlow
 private import codeql.swift.frameworks.StandardLibrary.PointerTypes
+private import codeql.swift.security.PredicateInjectionExtensions
 
 /**
  * A dataflow sink for uncontrolled format string vulnerabilities.
@@ -81,7 +82,9 @@ class HeuristicUncontrolledFormatStringSink extends UncontrolledFormatStringSink
         argsType instanceof CVaListPointerType or
         argsType instanceof VariadicSequenceType
       )
-    )
+    ) and
+    // prevent overlap with `swift/predicate-injection`
+    not this instanceof PredicateInjectionSink
   }
 }
 

--- a/swift/ql/src/change-notes/2023-11-16-format-string.md
+++ b/swift/ql/src/change-notes/2023-11-16-format-string.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+
+* Added additional sinks for the "Uncontrolled format string" (`swift/uncontrolled-format-string`) query. Some of these sinks are heuristic (imprecise) in nature.

--- a/swift/ql/test/query-tests/Security/CWE-134/UncontrolledFormatString.expected
+++ b/swift/ql/test/query-tests/Security/CWE-134/UncontrolledFormatString.expected
@@ -20,7 +20,6 @@ edges
 | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:118:61:118:61 | tainted |
 | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:130:39:130:39 | tainted |
 | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:135:37:135:37 | tainted |
-| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:137:29:137:29 | tainted |
 | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:139:5:139:5 | tainted |
 | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:154:26:154:26 | tainted |
 | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:156:32:156:32 | tainted |
@@ -64,7 +63,6 @@ nodes
 | UncontrolledFormatString.swift:130:39:130:39 | tainted | semmle.label | tainted |
 | UncontrolledFormatString.swift:135:20:135:44 | call to NSString.init(string:) | semmle.label | call to NSString.init(string:) |
 | UncontrolledFormatString.swift:135:37:135:37 | tainted | semmle.label | tainted |
-| UncontrolledFormatString.swift:137:29:137:29 | tainted | semmle.label | tainted |
 | UncontrolledFormatString.swift:139:5:139:5 | tainted | semmle.label | tainted |
 | UncontrolledFormatString.swift:140:9:140:9 | cstr [Collection element] | semmle.label | cstr [Collection element] |
 | UncontrolledFormatString.swift:141:24:141:24 | cstr | semmle.label | cstr |
@@ -92,7 +90,6 @@ subpaths
 | UncontrolledFormatString.swift:118:61:118:61 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:118:61:118:61 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
 | UncontrolledFormatString.swift:130:39:130:39 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:130:39:130:39 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
 | UncontrolledFormatString.swift:135:20:135:44 | call to NSString.init(string:) | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:135:20:135:44 | call to NSString.init(string:) | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
-| UncontrolledFormatString.swift:137:29:137:29 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:137:29:137:29 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
 | UncontrolledFormatString.swift:141:24:141:24 | cstr | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:141:24:141:24 | cstr | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
 | UncontrolledFormatString.swift:143:21:143:21 | cstr | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:143:21:143:21 | cstr | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
 | UncontrolledFormatString.swift:145:27:145:27 | cstr | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:145:27:145:27 | cstr | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |

--- a/swift/ql/test/query-tests/Security/CWE-134/UncontrolledFormatString.expected
+++ b/swift/ql/test/query-tests/Security/CWE-134/UncontrolledFormatString.expected
@@ -16,10 +16,14 @@ edges
 | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:112:64:112:64 | tainted |
 | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:115:11:115:11 | tainted |
 | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:116:11:116:11 | tainted |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:116:11:116:11 | tainted |
 | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:118:61:118:61 | tainted |
 | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:130:39:130:39 | tainted |
 | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:135:37:135:37 | tainted |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:137:29:137:29 | tainted |
 | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:139:5:139:5 | tainted |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:154:26:154:26 | tainted |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:156:32:156:32 | tainted |
 | UncontrolledFormatString.swift:108:43:108:43 | tainted | UncontrolledFormatString.swift:108:26:108:50 | call to NSString.init(string:) |
 | UncontrolledFormatString.swift:109:57:109:57 | tainted | UncontrolledFormatString.swift:109:40:109:64 | call to NSString.init(string:) |
 | UncontrolledFormatString.swift:111:50:111:50 | tainted | UncontrolledFormatString.swift:111:33:111:57 | call to NSString.init(string:) |
@@ -55,16 +59,20 @@ nodes
 | UncontrolledFormatString.swift:112:64:112:64 | tainted | semmle.label | tainted |
 | UncontrolledFormatString.swift:115:11:115:11 | tainted | semmle.label | tainted |
 | UncontrolledFormatString.swift:116:11:116:11 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:116:11:116:11 | tainted | semmle.label | tainted |
 | UncontrolledFormatString.swift:118:61:118:61 | tainted | semmle.label | tainted |
 | UncontrolledFormatString.swift:130:39:130:39 | tainted | semmle.label | tainted |
 | UncontrolledFormatString.swift:135:20:135:44 | call to NSString.init(string:) | semmle.label | call to NSString.init(string:) |
 | UncontrolledFormatString.swift:135:37:135:37 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:137:29:137:29 | tainted | semmle.label | tainted |
 | UncontrolledFormatString.swift:139:5:139:5 | tainted | semmle.label | tainted |
 | UncontrolledFormatString.swift:140:9:140:9 | cstr [Collection element] | semmle.label | cstr [Collection element] |
 | UncontrolledFormatString.swift:141:24:141:24 | cstr | semmle.label | cstr |
 | UncontrolledFormatString.swift:143:21:143:21 | cstr | semmle.label | cstr |
 | UncontrolledFormatString.swift:145:27:145:27 | cstr | semmle.label | cstr |
 | UncontrolledFormatString.swift:147:35:147:35 | cstr | semmle.label | cstr |
+| UncontrolledFormatString.swift:154:26:154:26 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:156:32:156:32 | tainted | semmle.label | tainted |
 subpaths
 #select
 | UncontrolledFormatString.swift:79:16:79:16 | format | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:79:16:79:16 | format | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
@@ -80,10 +88,14 @@ subpaths
 | UncontrolledFormatString.swift:111:33:111:57 | call to NSString.init(string:) | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:111:33:111:57 | call to NSString.init(string:) | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
 | UncontrolledFormatString.swift:112:47:112:71 | call to NSString.init(string:) | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:112:47:112:71 | call to NSString.init(string:) | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
 | UncontrolledFormatString.swift:115:11:115:11 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:115:11:115:11 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:116:11:116:11 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:116:11:116:11 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
 | UncontrolledFormatString.swift:118:61:118:61 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:118:61:118:61 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
 | UncontrolledFormatString.swift:130:39:130:39 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:130:39:130:39 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
 | UncontrolledFormatString.swift:135:20:135:44 | call to NSString.init(string:) | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:135:20:135:44 | call to NSString.init(string:) | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:137:29:137:29 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:137:29:137:29 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
 | UncontrolledFormatString.swift:141:24:141:24 | cstr | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:141:24:141:24 | cstr | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
 | UncontrolledFormatString.swift:143:21:143:21 | cstr | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:143:21:143:21 | cstr | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
 | UncontrolledFormatString.swift:145:27:145:27 | cstr | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:145:27:145:27 | cstr | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
 | UncontrolledFormatString.swift:147:35:147:35 | cstr | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:147:35:147:35 | cstr | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:154:26:154:26 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:154:26:154:26 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:156:32:156:32 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:156:32:156:32 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |

--- a/swift/ql/test/query-tests/Security/CWE-134/UncontrolledFormatString.expected
+++ b/swift/ql/test/query-tests/Security/CWE-134/UncontrolledFormatString.expected
@@ -19,12 +19,18 @@ edges
 | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:118:61:118:61 | tainted |
 | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:130:39:130:39 | tainted |
 | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:135:37:135:37 | tainted |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:139:5:139:5 | tainted |
 | UncontrolledFormatString.swift:108:43:108:43 | tainted | UncontrolledFormatString.swift:108:26:108:50 | call to NSString.init(string:) |
 | UncontrolledFormatString.swift:109:57:109:57 | tainted | UncontrolledFormatString.swift:109:40:109:64 | call to NSString.init(string:) |
 | UncontrolledFormatString.swift:111:50:111:50 | tainted | UncontrolledFormatString.swift:111:33:111:57 | call to NSString.init(string:) |
 | UncontrolledFormatString.swift:112:64:112:64 | tainted | UncontrolledFormatString.swift:112:47:112:71 | call to NSString.init(string:) |
 | UncontrolledFormatString.swift:116:11:116:11 | tainted | UncontrolledFormatString.swift:77:12:77:22 | format |
 | UncontrolledFormatString.swift:135:37:135:37 | tainted | UncontrolledFormatString.swift:135:20:135:44 | call to NSString.init(string:) |
+| UncontrolledFormatString.swift:139:5:139:5 | tainted | UncontrolledFormatString.swift:140:9:140:9 | cstr [Collection element] |
+| UncontrolledFormatString.swift:140:9:140:9 | cstr [Collection element] | UncontrolledFormatString.swift:141:24:141:24 | cstr |
+| UncontrolledFormatString.swift:140:9:140:9 | cstr [Collection element] | UncontrolledFormatString.swift:143:21:143:21 | cstr |
+| UncontrolledFormatString.swift:140:9:140:9 | cstr [Collection element] | UncontrolledFormatString.swift:145:27:145:27 | cstr |
+| UncontrolledFormatString.swift:140:9:140:9 | cstr [Collection element] | UncontrolledFormatString.swift:147:35:147:35 | cstr |
 nodes
 | UncontrolledFormatString.swift:77:12:77:22 | format | semmle.label | format |
 | UncontrolledFormatString.swift:78:22:80:5 | format | semmle.label | format |
@@ -53,6 +59,12 @@ nodes
 | UncontrolledFormatString.swift:130:39:130:39 | tainted | semmle.label | tainted |
 | UncontrolledFormatString.swift:135:20:135:44 | call to NSString.init(string:) | semmle.label | call to NSString.init(string:) |
 | UncontrolledFormatString.swift:135:37:135:37 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:139:5:139:5 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:140:9:140:9 | cstr [Collection element] | semmle.label | cstr [Collection element] |
+| UncontrolledFormatString.swift:141:24:141:24 | cstr | semmle.label | cstr |
+| UncontrolledFormatString.swift:143:21:143:21 | cstr | semmle.label | cstr |
+| UncontrolledFormatString.swift:145:27:145:27 | cstr | semmle.label | cstr |
+| UncontrolledFormatString.swift:147:35:147:35 | cstr | semmle.label | cstr |
 subpaths
 #select
 | UncontrolledFormatString.swift:79:16:79:16 | format | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:79:16:79:16 | format | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
@@ -71,3 +83,7 @@ subpaths
 | UncontrolledFormatString.swift:118:61:118:61 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:118:61:118:61 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
 | UncontrolledFormatString.swift:130:39:130:39 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:130:39:130:39 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
 | UncontrolledFormatString.swift:135:20:135:44 | call to NSString.init(string:) | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:135:20:135:44 | call to NSString.init(string:) | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:141:24:141:24 | cstr | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:141:24:141:24 | cstr | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:143:21:143:21 | cstr | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:143:21:143:21 | cstr | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:145:27:145:27 | cstr | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:145:27:145:27 | cstr | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:147:35:147:35 | cstr | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:147:35:147:35 | cstr | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |

--- a/swift/ql/test/query-tests/Security/CWE-134/UncontrolledFormatString.expected
+++ b/swift/ql/test/query-tests/Security/CWE-134/UncontrolledFormatString.expected
@@ -3,24 +3,24 @@ edges
 | UncontrolledFormatString.swift:78:22:80:5 | format | UncontrolledFormatString.swift:78:22:80:5 | { ... } [format] |
 | UncontrolledFormatString.swift:78:22:80:5 | { ... } [format] | UncontrolledFormatString.swift:79:16:79:16 | this [format] |
 | UncontrolledFormatString.swift:79:16:79:16 | this [format] | UncontrolledFormatString.swift:79:16:79:16 | format |
-| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:97:28:97:28 | tainted |
-| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:100:28:100:28 | tainted |
-| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:101:28:101:28 | tainted |
-| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:103:28:103:28 | tainted |
-| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:104:28:104:28 | tainted |
-| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:105:28:105:28 | tainted |
-| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:106:46:106:46 | tainted |
-| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:108:47:108:47 | tainted |
-| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:109:65:109:65 | tainted |
-| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:111:54:111:54 | tainted |
-| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:112:72:112:72 | tainted |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:97:24:97:24 | tainted |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:100:24:100:24 | tainted |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:101:24:101:24 | tainted |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:103:24:103:24 | tainted |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:104:24:104:24 | tainted |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:105:24:105:24 | tainted |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:106:42:106:42 | tainted |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:108:43:108:43 | tainted |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:109:57:109:57 | tainted |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:111:50:111:50 | tainted |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:112:64:112:64 | tainted |
 | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:115:11:115:11 | tainted |
 | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:116:11:116:11 | tainted |
 | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:118:61:118:61 | tainted |
-| UncontrolledFormatString.swift:108:47:108:47 | tainted | UncontrolledFormatString.swift:108:30:108:54 | call to NSString.init(string:) |
-| UncontrolledFormatString.swift:109:65:109:65 | tainted | UncontrolledFormatString.swift:109:48:109:72 | call to NSString.init(string:) |
-| UncontrolledFormatString.swift:111:54:111:54 | tainted | UncontrolledFormatString.swift:111:37:111:61 | call to NSString.init(string:) |
-| UncontrolledFormatString.swift:112:72:112:72 | tainted | UncontrolledFormatString.swift:112:55:112:79 | call to NSString.init(string:) |
+| UncontrolledFormatString.swift:108:43:108:43 | tainted | UncontrolledFormatString.swift:108:26:108:50 | call to NSString.init(string:) |
+| UncontrolledFormatString.swift:109:57:109:57 | tainted | UncontrolledFormatString.swift:109:40:109:64 | call to NSString.init(string:) |
+| UncontrolledFormatString.swift:111:50:111:50 | tainted | UncontrolledFormatString.swift:111:33:111:57 | call to NSString.init(string:) |
+| UncontrolledFormatString.swift:112:64:112:64 | tainted | UncontrolledFormatString.swift:112:47:112:71 | call to NSString.init(string:) |
 | UncontrolledFormatString.swift:116:11:116:11 | tainted | UncontrolledFormatString.swift:77:12:77:22 | format |
 nodes
 | UncontrolledFormatString.swift:77:12:77:22 | format | semmle.label | format |
@@ -29,37 +29,37 @@ nodes
 | UncontrolledFormatString.swift:79:16:79:16 | format | semmle.label | format |
 | UncontrolledFormatString.swift:79:16:79:16 | this [format] | semmle.label | this [format] |
 | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | semmle.label | call to String.init(contentsOf:) |
-| UncontrolledFormatString.swift:97:28:97:28 | tainted | semmle.label | tainted |
-| UncontrolledFormatString.swift:100:28:100:28 | tainted | semmle.label | tainted |
-| UncontrolledFormatString.swift:101:28:101:28 | tainted | semmle.label | tainted |
-| UncontrolledFormatString.swift:103:28:103:28 | tainted | semmle.label | tainted |
-| UncontrolledFormatString.swift:104:28:104:28 | tainted | semmle.label | tainted |
-| UncontrolledFormatString.swift:105:28:105:28 | tainted | semmle.label | tainted |
-| UncontrolledFormatString.swift:106:46:106:46 | tainted | semmle.label | tainted |
-| UncontrolledFormatString.swift:108:30:108:54 | call to NSString.init(string:) | semmle.label | call to NSString.init(string:) |
-| UncontrolledFormatString.swift:108:47:108:47 | tainted | semmle.label | tainted |
-| UncontrolledFormatString.swift:109:48:109:72 | call to NSString.init(string:) | semmle.label | call to NSString.init(string:) |
-| UncontrolledFormatString.swift:109:65:109:65 | tainted | semmle.label | tainted |
-| UncontrolledFormatString.swift:111:37:111:61 | call to NSString.init(string:) | semmle.label | call to NSString.init(string:) |
-| UncontrolledFormatString.swift:111:54:111:54 | tainted | semmle.label | tainted |
-| UncontrolledFormatString.swift:112:55:112:79 | call to NSString.init(string:) | semmle.label | call to NSString.init(string:) |
-| UncontrolledFormatString.swift:112:72:112:72 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:97:24:97:24 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:100:24:100:24 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:101:24:101:24 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:103:24:103:24 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:104:24:104:24 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:105:24:105:24 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:106:42:106:42 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:108:26:108:50 | call to NSString.init(string:) | semmle.label | call to NSString.init(string:) |
+| UncontrolledFormatString.swift:108:43:108:43 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:109:40:109:64 | call to NSString.init(string:) | semmle.label | call to NSString.init(string:) |
+| UncontrolledFormatString.swift:109:57:109:57 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:111:33:111:57 | call to NSString.init(string:) | semmle.label | call to NSString.init(string:) |
+| UncontrolledFormatString.swift:111:50:111:50 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:112:47:112:71 | call to NSString.init(string:) | semmle.label | call to NSString.init(string:) |
+| UncontrolledFormatString.swift:112:64:112:64 | tainted | semmle.label | tainted |
 | UncontrolledFormatString.swift:115:11:115:11 | tainted | semmle.label | tainted |
 | UncontrolledFormatString.swift:116:11:116:11 | tainted | semmle.label | tainted |
 | UncontrolledFormatString.swift:118:61:118:61 | tainted | semmle.label | tainted |
 subpaths
 #select
 | UncontrolledFormatString.swift:79:16:79:16 | format | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:79:16:79:16 | format | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
-| UncontrolledFormatString.swift:97:28:97:28 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:97:28:97:28 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
-| UncontrolledFormatString.swift:100:28:100:28 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:100:28:100:28 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
-| UncontrolledFormatString.swift:101:28:101:28 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:101:28:101:28 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
-| UncontrolledFormatString.swift:103:28:103:28 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:103:28:103:28 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
-| UncontrolledFormatString.swift:104:28:104:28 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:104:28:104:28 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
-| UncontrolledFormatString.swift:105:28:105:28 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:105:28:105:28 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
-| UncontrolledFormatString.swift:106:46:106:46 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:106:46:106:46 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
-| UncontrolledFormatString.swift:108:30:108:54 | call to NSString.init(string:) | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:108:30:108:54 | call to NSString.init(string:) | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
-| UncontrolledFormatString.swift:109:48:109:72 | call to NSString.init(string:) | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:109:48:109:72 | call to NSString.init(string:) | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
-| UncontrolledFormatString.swift:111:37:111:61 | call to NSString.init(string:) | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:111:37:111:61 | call to NSString.init(string:) | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
-| UncontrolledFormatString.swift:112:55:112:79 | call to NSString.init(string:) | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:112:55:112:79 | call to NSString.init(string:) | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:97:24:97:24 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:97:24:97:24 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:100:24:100:24 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:100:24:100:24 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:101:24:101:24 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:101:24:101:24 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:103:24:103:24 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:103:24:103:24 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:104:24:104:24 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:104:24:104:24 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:105:24:105:24 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:105:24:105:24 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:106:42:106:42 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:106:42:106:42 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:108:26:108:50 | call to NSString.init(string:) | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:108:26:108:50 | call to NSString.init(string:) | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:109:40:109:64 | call to NSString.init(string:) | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:109:40:109:64 | call to NSString.init(string:) | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:111:33:111:57 | call to NSString.init(string:) | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:111:33:111:57 | call to NSString.init(string:) | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:112:47:112:71 | call to NSString.init(string:) | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:112:47:112:71 | call to NSString.init(string:) | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
 | UncontrolledFormatString.swift:115:11:115:11 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:115:11:115:11 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
 | UncontrolledFormatString.swift:118:61:118:61 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:118:61:118:61 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |

--- a/swift/ql/test/query-tests/Security/CWE-134/UncontrolledFormatString.expected
+++ b/swift/ql/test/query-tests/Security/CWE-134/UncontrolledFormatString.expected
@@ -1,65 +1,65 @@
 edges
-| UncontrolledFormatString.swift:57:12:57:22 | format | UncontrolledFormatString.swift:58:22:60:5 | format |
-| UncontrolledFormatString.swift:58:22:60:5 | format | UncontrolledFormatString.swift:58:22:60:5 | { ... } [format] |
-| UncontrolledFormatString.swift:58:22:60:5 | { ... } [format] | UncontrolledFormatString.swift:59:16:59:16 | this [format] |
-| UncontrolledFormatString.swift:59:16:59:16 | this [format] | UncontrolledFormatString.swift:59:16:59:16 | format |
-| UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:70:28:70:28 | tainted |
-| UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:73:28:73:28 | tainted |
-| UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:74:28:74:28 | tainted |
-| UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:76:28:76:28 | tainted |
-| UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:77:28:77:28 | tainted |
-| UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:78:28:78:28 | tainted |
-| UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:79:46:79:46 | tainted |
-| UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:81:47:81:47 | tainted |
-| UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:82:65:82:65 | tainted |
-| UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:84:54:84:54 | tainted |
-| UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:85:72:85:72 | tainted |
-| UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:88:11:88:11 | tainted |
-| UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:89:11:89:11 | tainted |
-| UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:91:61:91:61 | tainted |
-| UncontrolledFormatString.swift:81:47:81:47 | tainted | UncontrolledFormatString.swift:81:30:81:54 | call to NSString.init(string:) |
-| UncontrolledFormatString.swift:82:65:82:65 | tainted | UncontrolledFormatString.swift:82:48:82:72 | call to NSString.init(string:) |
-| UncontrolledFormatString.swift:84:54:84:54 | tainted | UncontrolledFormatString.swift:84:37:84:61 | call to NSString.init(string:) |
-| UncontrolledFormatString.swift:85:72:85:72 | tainted | UncontrolledFormatString.swift:85:55:85:79 | call to NSString.init(string:) |
-| UncontrolledFormatString.swift:89:11:89:11 | tainted | UncontrolledFormatString.swift:57:12:57:22 | format |
+| UncontrolledFormatString.swift:77:12:77:22 | format | UncontrolledFormatString.swift:78:22:80:5 | format |
+| UncontrolledFormatString.swift:78:22:80:5 | format | UncontrolledFormatString.swift:78:22:80:5 | { ... } [format] |
+| UncontrolledFormatString.swift:78:22:80:5 | { ... } [format] | UncontrolledFormatString.swift:79:16:79:16 | this [format] |
+| UncontrolledFormatString.swift:79:16:79:16 | this [format] | UncontrolledFormatString.swift:79:16:79:16 | format |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:97:28:97:28 | tainted |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:100:28:100:28 | tainted |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:101:28:101:28 | tainted |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:103:28:103:28 | tainted |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:104:28:104:28 | tainted |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:105:28:105:28 | tainted |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:106:46:106:46 | tainted |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:108:47:108:47 | tainted |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:109:65:109:65 | tainted |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:111:54:111:54 | tainted |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:112:72:112:72 | tainted |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:115:11:115:11 | tainted |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:116:11:116:11 | tainted |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:118:61:118:61 | tainted |
+| UncontrolledFormatString.swift:108:47:108:47 | tainted | UncontrolledFormatString.swift:108:30:108:54 | call to NSString.init(string:) |
+| UncontrolledFormatString.swift:109:65:109:65 | tainted | UncontrolledFormatString.swift:109:48:109:72 | call to NSString.init(string:) |
+| UncontrolledFormatString.swift:111:54:111:54 | tainted | UncontrolledFormatString.swift:111:37:111:61 | call to NSString.init(string:) |
+| UncontrolledFormatString.swift:112:72:112:72 | tainted | UncontrolledFormatString.swift:112:55:112:79 | call to NSString.init(string:) |
+| UncontrolledFormatString.swift:116:11:116:11 | tainted | UncontrolledFormatString.swift:77:12:77:22 | format |
 nodes
-| UncontrolledFormatString.swift:57:12:57:22 | format | semmle.label | format |
-| UncontrolledFormatString.swift:58:22:60:5 | format | semmle.label | format |
-| UncontrolledFormatString.swift:58:22:60:5 | { ... } [format] | semmle.label | { ... } [format] |
-| UncontrolledFormatString.swift:59:16:59:16 | format | semmle.label | format |
-| UncontrolledFormatString.swift:59:16:59:16 | this [format] | semmle.label | this [format] |
-| UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | semmle.label | call to String.init(contentsOf:) |
-| UncontrolledFormatString.swift:70:28:70:28 | tainted | semmle.label | tainted |
-| UncontrolledFormatString.swift:73:28:73:28 | tainted | semmle.label | tainted |
-| UncontrolledFormatString.swift:74:28:74:28 | tainted | semmle.label | tainted |
-| UncontrolledFormatString.swift:76:28:76:28 | tainted | semmle.label | tainted |
-| UncontrolledFormatString.swift:77:28:77:28 | tainted | semmle.label | tainted |
-| UncontrolledFormatString.swift:78:28:78:28 | tainted | semmle.label | tainted |
-| UncontrolledFormatString.swift:79:46:79:46 | tainted | semmle.label | tainted |
-| UncontrolledFormatString.swift:81:30:81:54 | call to NSString.init(string:) | semmle.label | call to NSString.init(string:) |
-| UncontrolledFormatString.swift:81:47:81:47 | tainted | semmle.label | tainted |
-| UncontrolledFormatString.swift:82:48:82:72 | call to NSString.init(string:) | semmle.label | call to NSString.init(string:) |
-| UncontrolledFormatString.swift:82:65:82:65 | tainted | semmle.label | tainted |
-| UncontrolledFormatString.swift:84:37:84:61 | call to NSString.init(string:) | semmle.label | call to NSString.init(string:) |
-| UncontrolledFormatString.swift:84:54:84:54 | tainted | semmle.label | tainted |
-| UncontrolledFormatString.swift:85:55:85:79 | call to NSString.init(string:) | semmle.label | call to NSString.init(string:) |
-| UncontrolledFormatString.swift:85:72:85:72 | tainted | semmle.label | tainted |
-| UncontrolledFormatString.swift:88:11:88:11 | tainted | semmle.label | tainted |
-| UncontrolledFormatString.swift:89:11:89:11 | tainted | semmle.label | tainted |
-| UncontrolledFormatString.swift:91:61:91:61 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:77:12:77:22 | format | semmle.label | format |
+| UncontrolledFormatString.swift:78:22:80:5 | format | semmle.label | format |
+| UncontrolledFormatString.swift:78:22:80:5 | { ... } [format] | semmle.label | { ... } [format] |
+| UncontrolledFormatString.swift:79:16:79:16 | format | semmle.label | format |
+| UncontrolledFormatString.swift:79:16:79:16 | this [format] | semmle.label | this [format] |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | semmle.label | call to String.init(contentsOf:) |
+| UncontrolledFormatString.swift:97:28:97:28 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:100:28:100:28 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:101:28:101:28 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:103:28:103:28 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:104:28:104:28 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:105:28:105:28 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:106:46:106:46 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:108:30:108:54 | call to NSString.init(string:) | semmle.label | call to NSString.init(string:) |
+| UncontrolledFormatString.swift:108:47:108:47 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:109:48:109:72 | call to NSString.init(string:) | semmle.label | call to NSString.init(string:) |
+| UncontrolledFormatString.swift:109:65:109:65 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:111:37:111:61 | call to NSString.init(string:) | semmle.label | call to NSString.init(string:) |
+| UncontrolledFormatString.swift:111:54:111:54 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:112:55:112:79 | call to NSString.init(string:) | semmle.label | call to NSString.init(string:) |
+| UncontrolledFormatString.swift:112:72:112:72 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:115:11:115:11 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:116:11:116:11 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:118:61:118:61 | tainted | semmle.label | tainted |
 subpaths
 #select
-| UncontrolledFormatString.swift:59:16:59:16 | format | UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:59:16:59:16 | format | This format string depends on $@. | UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | this user-provided value |
-| UncontrolledFormatString.swift:70:28:70:28 | tainted | UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:70:28:70:28 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | this user-provided value |
-| UncontrolledFormatString.swift:73:28:73:28 | tainted | UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:73:28:73:28 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | this user-provided value |
-| UncontrolledFormatString.swift:74:28:74:28 | tainted | UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:74:28:74:28 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | this user-provided value |
-| UncontrolledFormatString.swift:76:28:76:28 | tainted | UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:76:28:76:28 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | this user-provided value |
-| UncontrolledFormatString.swift:77:28:77:28 | tainted | UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:77:28:77:28 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | this user-provided value |
-| UncontrolledFormatString.swift:78:28:78:28 | tainted | UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:78:28:78:28 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | this user-provided value |
-| UncontrolledFormatString.swift:79:46:79:46 | tainted | UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:79:46:79:46 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | this user-provided value |
-| UncontrolledFormatString.swift:81:30:81:54 | call to NSString.init(string:) | UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:81:30:81:54 | call to NSString.init(string:) | This format string depends on $@. | UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | this user-provided value |
-| UncontrolledFormatString.swift:82:48:82:72 | call to NSString.init(string:) | UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:82:48:82:72 | call to NSString.init(string:) | This format string depends on $@. | UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | this user-provided value |
-| UncontrolledFormatString.swift:84:37:84:61 | call to NSString.init(string:) | UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:84:37:84:61 | call to NSString.init(string:) | This format string depends on $@. | UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | this user-provided value |
-| UncontrolledFormatString.swift:85:55:85:79 | call to NSString.init(string:) | UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:85:55:85:79 | call to NSString.init(string:) | This format string depends on $@. | UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | this user-provided value |
-| UncontrolledFormatString.swift:88:11:88:11 | tainted | UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:88:11:88:11 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | this user-provided value |
-| UncontrolledFormatString.swift:91:61:91:61 | tainted | UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:91:61:91:61 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:64:24:64:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:79:16:79:16 | format | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:79:16:79:16 | format | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:97:28:97:28 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:97:28:97:28 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:100:28:100:28 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:100:28:100:28 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:101:28:101:28 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:101:28:101:28 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:103:28:103:28 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:103:28:103:28 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:104:28:104:28 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:104:28:104:28 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:105:28:105:28 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:105:28:105:28 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:106:46:106:46 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:106:46:106:46 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:108:30:108:54 | call to NSString.init(string:) | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:108:30:108:54 | call to NSString.init(string:) | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:109:48:109:72 | call to NSString.init(string:) | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:109:48:109:72 | call to NSString.init(string:) | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:111:37:111:61 | call to NSString.init(string:) | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:111:37:111:61 | call to NSString.init(string:) | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:112:55:112:79 | call to NSString.init(string:) | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:112:55:112:79 | call to NSString.init(string:) | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:115:11:115:11 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:115:11:115:11 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:118:61:118:61 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:118:61:118:61 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |

--- a/swift/ql/test/query-tests/Security/CWE-134/UncontrolledFormatString.expected
+++ b/swift/ql/test/query-tests/Security/CWE-134/UncontrolledFormatString.expected
@@ -17,11 +17,14 @@ edges
 | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:115:11:115:11 | tainted |
 | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:116:11:116:11 | tainted |
 | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:118:61:118:61 | tainted |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:130:39:130:39 | tainted |
+| UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:135:37:135:37 | tainted |
 | UncontrolledFormatString.swift:108:43:108:43 | tainted | UncontrolledFormatString.swift:108:26:108:50 | call to NSString.init(string:) |
 | UncontrolledFormatString.swift:109:57:109:57 | tainted | UncontrolledFormatString.swift:109:40:109:64 | call to NSString.init(string:) |
 | UncontrolledFormatString.swift:111:50:111:50 | tainted | UncontrolledFormatString.swift:111:33:111:57 | call to NSString.init(string:) |
 | UncontrolledFormatString.swift:112:64:112:64 | tainted | UncontrolledFormatString.swift:112:47:112:71 | call to NSString.init(string:) |
 | UncontrolledFormatString.swift:116:11:116:11 | tainted | UncontrolledFormatString.swift:77:12:77:22 | format |
+| UncontrolledFormatString.swift:135:37:135:37 | tainted | UncontrolledFormatString.swift:135:20:135:44 | call to NSString.init(string:) |
 nodes
 | UncontrolledFormatString.swift:77:12:77:22 | format | semmle.label | format |
 | UncontrolledFormatString.swift:78:22:80:5 | format | semmle.label | format |
@@ -47,6 +50,9 @@ nodes
 | UncontrolledFormatString.swift:115:11:115:11 | tainted | semmle.label | tainted |
 | UncontrolledFormatString.swift:116:11:116:11 | tainted | semmle.label | tainted |
 | UncontrolledFormatString.swift:118:61:118:61 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:130:39:130:39 | tainted | semmle.label | tainted |
+| UncontrolledFormatString.swift:135:20:135:44 | call to NSString.init(string:) | semmle.label | call to NSString.init(string:) |
+| UncontrolledFormatString.swift:135:37:135:37 | tainted | semmle.label | tainted |
 subpaths
 #select
 | UncontrolledFormatString.swift:79:16:79:16 | format | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:79:16:79:16 | format | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
@@ -63,3 +69,5 @@ subpaths
 | UncontrolledFormatString.swift:112:47:112:71 | call to NSString.init(string:) | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:112:47:112:71 | call to NSString.init(string:) | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
 | UncontrolledFormatString.swift:115:11:115:11 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:115:11:115:11 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
 | UncontrolledFormatString.swift:118:61:118:61 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:118:61:118:61 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:130:39:130:39 | tainted | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:130:39:130:39 | tainted | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |
+| UncontrolledFormatString.swift:135:20:135:44 | call to NSString.init(string:) | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | UncontrolledFormatString.swift:135:20:135:44 | call to NSString.init(string:) | This format string depends on $@. | UncontrolledFormatString.swift:91:24:91:77 | call to String.init(contentsOf:) | this user-provided value |

--- a/swift/ql/test/query-tests/Security/CWE-134/UncontrolledFormatString.swift
+++ b/swift/ql/test/query-tests/Security/CWE-134/UncontrolledFormatString.swift
@@ -90,26 +90,26 @@ class MyString {
 func tests() throws {
     let tainted = try! String(contentsOf: URL(string: "http://example.com")!)
 
-    let a = String("abc") // GOOD: not a format string
-    let b = String(tainted) // GOOD: not a format string
+    _ = String("abc") // GOOD: not a format string
+    _ = String(tainted) // GOOD: not a format string
 
-    let c = String(format: "abc") // GOOD: not tainted
-    let d = String(format: tainted) // BAD
-    let e = String(format: "%s", "abc") // GOOD: not tainted
-    let f = String(format: "%s", tainted) // GOOD: format string itself is not tainted
-    let g = String(format: tainted, "abc") // BAD
-    let h = String(format: tainted, tainted) // BAD
+    _ = String(format: "abc") // GOOD: not tainted
+    _ = String(format: tainted) // BAD
+    _ = String(format: "%s", "abc") // GOOD: not tainted
+    _ = String(format: "%s", tainted) // GOOD: format string itself is not tainted
+    _ = String(format: tainted, "abc") // BAD
+    _ = String(format: tainted, tainted) // BAD
 
-    let i = String(format: tainted, arguments: []) // BAD
-    let j = String(format: tainted, locale: nil) // BAD
-    let k = String(format: tainted, locale: nil, arguments: []) // BAD
-    let l = String.localizedStringWithFormat(tainted) // BAD
+    _ = String(format: tainted, arguments: []) // BAD
+    _ = String(format: tainted, locale: nil) // BAD
+    _ = String(format: tainted, locale: nil, arguments: []) // BAD
+    _ = String.localizedStringWithFormat(tainted) // BAD
 
-    let m = NSString(format: NSString(string: tainted), "abc") // BAD
-    let n = NSString.localizedStringWithFormat(NSString(string: tainted)) // BAD
+    _ = NSString(format: NSString(string: tainted), "abc") // BAD
+    NSString.localizedStringWithFormat(NSString(string: tainted)) // BAD
 
-    var o = NSMutableString(format: NSString(string: tainted), "abc") // BAD
-    var p = NSMutableString.localizedStringWithFormat(NSString(string: tainted)) // BAD
+    _ = NSMutableString(format: NSString(string: tainted), "abc") // BAD
+    NSMutableString.localizedStringWithFormat(NSString(string: tainted)) // BAD
 
     NSLog("abc") // GOOD: not tainted
     NSLog(tainted) // BAD
@@ -119,11 +119,11 @@ func tests() throws {
 
     let taintedVal = Int(tainted)!
     let taintedSan = "\(taintedVal)"
-    let q = String(format: taintedSan) // GOOD: sufficiently sanitized
+    _ = String(format: taintedSan) // GOOD: sufficiently sanitized
 
     let taintedVal2 = Int(tainted) ?? 0
     let taintedSan2 = String(taintedVal2)
-    let r = String(format: taintedSan2) // GOOD: sufficiently sanitized
+    _ = String(format: taintedSan2) // GOOD: sufficiently sanitized
 
     _ = String("abc").appendingFormat("%s", "abc") // GOOD: not tainted
     _ = String("abc").appendingFormat("%s", tainted) // GOOD: format not tainted

--- a/swift/ql/test/query-tests/Security/CWE-134/UncontrolledFormatString.swift
+++ b/swift/ql/test/query-tests/Security/CWE-134/UncontrolledFormatString.swift
@@ -138,13 +138,13 @@ func tests() throws {
 
     tainted.withCString({
         cstr in
-        _ = dprintf(0, cstr, "abc") // BAD [NOT DETECTED]
+        _ = dprintf(0, cstr, "abc") // BAD
         _ = dprintf(0, "%s", cstr) // GOOD: format not tainted
-        _ = vprintf(cstr, getVaList(["abc"])) // BAD [NOT DETECTED]
+        _ = vprintf(cstr, getVaList(["abc"])) // BAD
         _ = vprintf("%s", getVaList([cstr])) // GOOD: format not tainted
-        _ = vfprintf(nil, cstr, getVaList(["abc"])) // BAD [NOT DETECTED]
+        _ = vfprintf(nil, cstr, getVaList(["abc"])) // BAD
         _ = vfprintf(nil, "%s", getVaList([cstr])) // GOOD: format not tainted
-        _ = vasprintf_l(nil, nil, cstr, getVaList(["abc"])) // BAD [NOT DETECTED]
+        _ = vasprintf_l(nil, nil, cstr, getVaList(["abc"])) // BAD
         _ = vasprintf_l(nil, nil, "%s", getVaList([cstr])) // GOOD: format not tainted
     })
 

--- a/swift/ql/test/query-tests/Security/CWE-134/UncontrolledFormatString.swift
+++ b/swift/ql/test/query-tests/Security/CWE-134/UncontrolledFormatString.swift
@@ -113,7 +113,7 @@ func tests() throws {
 
     NSLog("abc") // GOOD: not tainted
     NSLog(tainted) // BAD
-    MyLog(tainted) // BAD [NOT DETECTED]
+    MyLog(tainted) // BAD
 
     NSException.raise(NSExceptionName("exception"), format: tainted, arguments: getVaList([])) // BAD
 
@@ -134,7 +134,7 @@ func tests() throws {
     s.appendFormat(NSString(string: "%s"), "abc") // GOOD: not tainted
     s.appendFormat(NSString(string: tainted), "abc") // BAD
 
-    _ = NSPredicate(format: tainted) // GOOD: this should be flagged by `swift/predicate-injection`, not `swift/uncontrolled-format-string`
+    _ = NSPredicate(format: tainted) // GOOD: this should be flagged by `swift/predicate-injection`, not `swift/uncontrolled-format-string` [FALSE POSITIVE]
 
     tainted.withCString({
         cstr in
@@ -151,8 +151,8 @@ func tests() throws {
     myFormatMessage(string: tainted, "abc") // BAD [NOT DETECTED]
     myFormatMessage(string: "%s", tainted) // GOOD: format not tainted
 
-    _ = MyString(format: tainted, "abc") // BAD [NOT DETECTED]
+    _ = MyString(format: tainted, "abc") // BAD
     _ = MyString(format: "%s", tainted) // GOOD: format not tainted
-    _ = MyString(formatString: tainted, "abc") // BAD [NOT DETECTED]
+    _ = MyString(formatString: tainted, "abc") // BAD
     _ = MyString(formatString: "%s", tainted) // GOOD: format not tainted
 }

--- a/swift/ql/test/query-tests/Security/CWE-134/UncontrolledFormatString.swift
+++ b/swift/ql/test/query-tests/Security/CWE-134/UncontrolledFormatString.swift
@@ -21,6 +21,10 @@ extension String : CVarArg {
     static func localizedStringWithFormat(_ format: String, _ arguments: CVarArg...) -> String { return "" }
 }
 
+extension StringProtocol {
+    func appendingFormat<T>(_ format: T, _ arguments: CVarArg...) -> String where T : StringProtocol { return "" }
+}
+
 class NSObject
 {
 }
@@ -35,6 +39,7 @@ class NSString : NSObject
 
 class NSMutableString : NSString
 {
+    func appendFormat(_ format: NSString, _ args: CVarArg...) {}
 }
 
 struct NSExceptionName {
@@ -52,6 +57,21 @@ func NSLogv(_ format: String, _ args: CVaListPointer) {}
 
 func getVaList(_ args: [CVarArg]) -> CVaListPointer { return (nil as CVaListPointer?)! }
 
+// not a (normal) formatting function
+class NSPredicate {
+    init(format: String, _: CVarArg...) {}
+}
+
+// imported from C
+typealias FILE = Int32 // this is a simplification
+typealias wchar_t = Int32
+typealias locale_t = OpaquePointer
+func dprintf(_ fd: Int, _ format: UnsafePointer<Int8>, _ args: CVarArg...) -> Int32 { return 0 }
+func vprintf(_ format: UnsafePointer<CChar>, _ arg: CVaListPointer) -> Int32 { return 0 }
+func vfprintf(_ file: UnsafeMutablePointer<FILE>?, _ format: UnsafePointer<CChar>?, _ arg: CVaListPointer) -> Int32 { return 0 }
+func vasprintf_l(_ ret: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?, _ loc: locale_t?, _ format: UnsafePointer<CChar>?, _ ap: CVaListPointer) -> Int32 { return 0 }
+
+
 // --- tests ---
 
 func MyLog(_ format: String, _ args: CVarArg...) {
@@ -60,7 +80,14 @@ func MyLog(_ format: String, _ args: CVarArg...) {
     }
 }
 
-func tests() {
+func myFormatMessage(string: String, _ args: CVarArg...) { }
+
+class MyString {
+    init(format: String, _ args: CVarArg...) { }
+    init(formatString: String, _ args: CVarArg...) { }
+}
+
+func tests() throws {
     let tainted = try! String(contentsOf: URL(string: "http://example.com")!)
 
     let a = String("abc") // GOOD: not a format string

--- a/swift/ql/test/query-tests/Security/CWE-134/UncontrolledFormatString.swift
+++ b/swift/ql/test/query-tests/Security/CWE-134/UncontrolledFormatString.swift
@@ -127,12 +127,12 @@ func tests() throws {
 
     _ = String("abc").appendingFormat("%s", "abc") // GOOD: not tainted
     _ = String("abc").appendingFormat("%s", tainted) // GOOD: format not tainted
-    _ = String("abc").appendingFormat(tainted, "abc") // BAD [NOT DETECTED]
+    _ = String("abc").appendingFormat(tainted, "abc") // BAD
     _ = String(tainted).appendingFormat("%s", "abc") // GOOD: format not tainted
 
     let s = NSMutableString(string: "foo")
     s.appendFormat(NSString(string: "%s"), "abc") // GOOD: not tainted
-    s.appendFormat(NSString(string: tainted), "abc") // BAD [NOT DETECTED]
+    s.appendFormat(NSString(string: tainted), "abc") // BAD
 
     _ = NSPredicate(format: tainted) // GOOD: this should be flagged by `swift/predicate-injection`, not `swift/uncontrolled-format-string`
 

--- a/swift/ql/test/query-tests/Security/CWE-134/UncontrolledFormatString.swift
+++ b/swift/ql/test/query-tests/Security/CWE-134/UncontrolledFormatString.swift
@@ -134,7 +134,7 @@ func tests() throws {
     s.appendFormat(NSString(string: "%s"), "abc") // GOOD: not tainted
     s.appendFormat(NSString(string: tainted), "abc") // BAD
 
-    _ = NSPredicate(format: tainted) // GOOD: this should be flagged by `swift/predicate-injection`, not `swift/uncontrolled-format-string` [FALSE POSITIVE]
+    _ = NSPredicate(format: tainted) // GOOD: this should be flagged by `swift/predicate-injection`, not `swift/uncontrolled-format-string`
 
     tainted.withCString({
         cstr in


### PR DESCRIPTION
More sinks for `swift/uncontrolled-format-string`:
- sinks for [`NSMutableString.appendFormat(_:_:)`](https://developer.apple.com/documentation/foundation/nsmutablestring/1415629-appendformat) and [`StringProtocol.appendingFormat(_:_:)`](https://developer.apple.com/documentation/swift/stringprotocol/appendingformat(_:_:)).
- sink for imported C `printf` functions.
- heuristic sink for things that look like formatting functions.