### PR TITLE
Remove LoC metrics from the analysis summary

### DIFF
--- a/cpp/ql/src/Summary/LinesOfCode.ql
+++ b/cpp/ql/src/Summary/LinesOfCode.ql
@@ -4,6 +4,7 @@
  * @description The total number of lines of C/C++ code across all files, including system headers, libraries, and auto-generated files. This is a useful metric of the size of a database. For all files that were seen during the build, this query counts the lines of code, excluding whitespace or comments.
  * @kind metric
  * @tags summary
+ *       telemetry
  */
 
 import cpp

--- a/javascript/ql/src/Summary/LinesOfCode.ql
+++ b/javascript/ql/src/Summary/LinesOfCode.ql
@@ -4,6 +4,7 @@
  * @description The total number of lines of JavaScript or TypeScript code across all files checked into the repository, except in `node_modules`. This is a useful metric of the size of a database. For all files that were seen during extraction, this query counts the lines of code, excluding whitespace or comments.
  * @kind metric
  * @tags summary
+ *       telemetry
  */
 
 import javascript

--- a/python/ql/src/Summary/LinesOfCode.ql
+++ b/python/ql/src/Summary/LinesOfCode.ql
@@ -5,6 +5,7 @@
  *   database. This query counts the lines of code, excluding whitespace or comments.
  * @kind metric
  * @tags summary
+ *       telemetry
  * @id py/summary/lines-of-code
  */
 


### PR DESCRIPTION
Currently for C/C++, JavaScript/TypeScript, and Python, we print a table like the following after analyzing the database:

```
Analysis produced the following metric data:

|                  Metric                   | Value  |
+-------------------------------------------+--------+
| Total lines of C/C++ code in the database | 490947 |
```

We want to stop printing this lines of code information now that we have replaced it by file coverage information.  We have already removed queries tagged `lines-of-code` from the analysis summary, but C/C++, JavaScript/TypeScript, and Python define both lines of code and lines of user code queries, and only the lines of user code queries are tagged `lines-of-code`.  Therefore, this PR tags the lines of code queries with `telemetry` to remove them from the analysis summary, while preserving the metric data in the SARIF file for advanced users.