### PR TITLE
Type tracking: Parameterize consistency checks

### DIFF
--- a/shared/typetracking/codeql/typetracking/TypeTracking.qll
+++ b/shared/typetracking/codeql/typetracking/TypeTracking.qll
@@ -124,7 +124,9 @@ private import internal.TypeTrackingImpl as Impl
 module TypeTracking<TypeTrackingInput I> {
   private module MkImpl = Impl::TypeTracking<I>;
 
-  deprecated module ConsistencyChecks = MkImpl::ConsistencyChecks;
+  private module ConsistencyChecksInput implements MkImpl::ConsistencyChecksInputSig { }
+
+  deprecated module ConsistencyChecks = MkImpl::ConsistencyChecks<ConsistencyChecksInput>;
 
   class TypeTracker = MkImpl::TypeTracker;
 


### PR DESCRIPTION
Needed for Ruby, where we will allow for (irrelevant) post-update use-use steps where the origin node is not a local source node.