### PR TITLE
C#: Detect `TargetFramework`s and install them if there is no `global.json`

### DIFF
--- a/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
@@ -559,6 +559,7 @@ namespace Semmle.Autobuild.CSharp.Tests
         {
             actions.RunProcess[@"C:\codeql\csharp/tools/linux64/Semmle.Extraction.CSharp.Standalone"] = 0;
             actions.FileExists["csharp.log"] = true;
+            actions.FileExists["test.sln"] = false;
             actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
             actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_SOURCE_ARCHIVE_DIR"] = "";
             actions.EnumerateFiles[@"C:\Project"] = "foo.cs\ntest.sln";
@@ -573,6 +574,7 @@ namespace Semmle.Autobuild.CSharp.Tests
         {
             actions.RunProcess[@"C:\codeql\csharp/tools/linux64/Semmle.Extraction.CSharp.Standalone"] = 10;
             actions.FileExists["csharp.log"] = true;
+            actions.FileExists["test.sln"] = false;
             actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
             actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_SOURCE_ARCHIVE_DIR"] = "";
             actions.EnumerateFiles[@"C:\Project"] = "foo.cs\ntest.sln";
@@ -587,6 +589,7 @@ namespace Semmle.Autobuild.CSharp.Tests
         {
             actions.RunProcess[@"C:\codeql\csharp/tools/linux64/Semmle.Extraction.CSharp.Standalone foo.sln"] = 0;
             actions.FileExists["csharp.log"] = true;
+            actions.FileExists["foo.sln"] = false;
             actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
             actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_SOURCE_ARCHIVE_DIR"] = "";
             actions.EnumerateFiles[@"C:\Project"] = "foo.cs\ntest.sln";
@@ -629,6 +632,7 @@ namespace Semmle.Autobuild.CSharp.Tests
         {
             actions.RunProcess["./build.sh --skip-tests"] = 0;
             actions.FileExists["csharp.log"] = true;
+            actions.FileExists["test.sln"] = false;
             actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
             actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_SOURCE_ARCHIVE_DIR"] = "";
             actions.EnumerateFiles[@"C:\Project"] = "foo.cs\ntest.sln";
@@ -729,6 +733,7 @@ namespace Semmle.Autobuild.CSharp.Tests
             actions.RunProcess[@"cmd.exe /C C:\codeql\tools\java\bin\java -jar C:\codeql\csharp\tools\extractor-asp.jar ."] = 0;
             actions.RunProcess[@"cmd.exe /C C:\codeql\tools\codeql index --xml --extensions config"] = 0;
             actions.FileExists["csharp.log"] = true;
+            actions.FileExists[@"C:\Project\test.sln"] = false;
             SkipVsWhere();
 
             actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
@@ -875,6 +880,7 @@ namespace Semmle.Autobuild.CSharp.Tests
         {
             actions.RunProcess[@"C:\codeql\csharp/tools/linux64/Semmle.Extraction.CSharp.Standalone foo.sln --skip-nuget"] = 0;
             actions.FileExists["csharp.log"] = true;
+            actions.FileExists["foo.sln"] = false;
             actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
             actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_SOURCE_ARCHIVE_DIR"] = "";
             actions.EnumerateFiles[@"C:\Project"] = "foo.cs\ntest.sln";

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
@@ -1,4 +1,4 @@
-﻿using Xunit;
+using Xunit;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -1016,7 +1016,7 @@ namespace Semmle.Autobuild.CSharp.Tests
         {
             TestDotnetVersionWindows(() =>
             {
-                actions.RunProcess[@"cmd.exe /C pwsh -NoProfile -ExecutionPolicy unrestricted -Command ""[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -Version 2.1.3 -InstallDir C:\Project\.dotnet"""] = 0;
+                actions.RunProcess[@"cmd.exe /C pwsh -NoProfile -ExecutionPolicy unrestricted -Command ""[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -Channel release -Version 2.1.3 -InstallDir C:\Project\.dotnet"""] = 0;
             },
             6);
         }
@@ -1026,8 +1026,8 @@ namespace Semmle.Autobuild.CSharp.Tests
         {
             TestDotnetVersionWindows(() =>
             {
-                actions.RunProcess[@"cmd.exe /C pwsh -NoProfile -ExecutionPolicy unrestricted -Command ""[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -Version 2.1.3 -InstallDir C:\Project\.dotnet"""] = 1;
-                actions.RunProcess[@"cmd.exe /C powershell -NoProfile -ExecutionPolicy unrestricted -Command ""[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -Version 2.1.3 -InstallDir C:\Project\.dotnet"""] = 0;
+                actions.RunProcess[@"cmd.exe /C pwsh -NoProfile -ExecutionPolicy unrestricted -Command ""[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -Channel release -Version 2.1.3 -InstallDir C:\Project\.dotnet"""] = 1;
+                actions.RunProcess[@"cmd.exe /C powershell -NoProfile -ExecutionPolicy unrestricted -Command ""[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -Channel release -Version 2.1.3 -InstallDir C:\Project\.dotnet"""] = 0;
             },
             7);
         }

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp/DotNetRule.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp/DotNetRule.cs
@@ -160,16 +160,39 @@ namespace Semmle.Autobuild.CSharp
             // Download versions mentioned in `global.json` files
             // See https://docs.microsoft.com/en-us/dotnet/core/tools/global-json
             var installScript = BuildScript.Success;
-            var validGlobalJson = false;
+            var foundFrameworkVersion = false;
             var globalJsonSdkVersion = SdkVersionFromGlobalJson(builder);
 
             if (!string.IsNullOrEmpty(globalJsonSdkVersion))
             {
                 installScript &= DownloadDotNetVersion(builder, installDir, globalJsonSdkVersion);
-                validGlobalJson = true;
+                foundFrameworkVersion = true;
+            }
+            else
+            {
+                // If there is no `global.json` to retrieve the .NET version from, we find all the
+                // TargetFramework values in the project files and install the latest versions
+                // from the corresponding channels
+                var targetFrameworkVersions = builder.ProjectsOrSolutionsToBuild
+                    .SelectMany(p => Enumerators.Singleton(p).Concat(p.IncludedProjects))
+                    .OfType<Project<CSharpAutobuildOptions>>()
+                    .Select(p => p.TargetFramework)
+                    .OfType<string>()
+                    .Where(v => v.StartsWith("net"));
+
+                foreach (var targetFrameworkVersion in targetFrameworkVersions)
+                {
+                    // For simplicity, we only accept target frameworks of the form "netX.Y"
+                    Version? version = null;
+                    if (Version.TryParse(targetFrameworkVersion[3..], out version))
+                    {
+                        installScript &= DownloadDotNetVersion(builder, installDir, "latest", channel: version.ToString());
+                        foundFrameworkVersion = true;
+                    }
+                }
             }
 
-            return validGlobalJson ? installScript : BuildScript.Failure;
+            return foundFrameworkVersion ? installScript : BuildScript.Failure;
         }
 
         /// <summary>

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp/DotNetRule.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp/DotNetRule.cs
@@ -160,7 +160,7 @@ namespace Semmle.Autobuild.CSharp
         ///
         /// See https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script.
         /// </summary>
-        private static BuildScript DownloadDotNetVersion(IAutobuilder<AutobuildOptionsShared> builder, string path, string version)
+        private static BuildScript DownloadDotNetVersion(IAutobuilder<AutobuildOptionsShared> builder, string path, string version, string? channel = "release")
         {
             return BuildScript.Bind(GetInstalledSdksScript(builder.Actions), (sdks, sdksRet) =>
                 {
@@ -174,7 +174,7 @@ namespace Semmle.Autobuild.CSharp
                     if (builder.Actions.IsWindows())
                     {
 
-                        var psCommand = $"[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -Version {version} -InstallDir {path}";
+                        var psCommand = $"[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -Channel {channel} -Version {version} -InstallDir {path}";
 
                         BuildScript GetInstall(string pwsh) =>
                             new CommandBuilder(builder.Actions).
@@ -203,7 +203,7 @@ namespace Semmle.Autobuild.CSharp
                         var install = new CommandBuilder(builder.Actions).
                             RunCommand("./dotnet-install.sh").
                             Argument("--channel").
-                            Argument("release").
+                            Argument(channel).
                             Argument("--version").
                             Argument(version).
                             Argument("--install-dir").

--- a/csharp/autobuilder/Semmle.Autobuild.Shared/Solution.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.Shared/Solution.cs
@@ -61,6 +61,12 @@ namespace Semmle.Autobuild.Shared
         {
             try
             {
+                // SolutionFile.Parse won't throw a FileNotFoundException if it is given a Windows path on a non-Windows platform
+                if (!builder.Actions.FileExists(FullPath))
+                {
+                    throw new FileNotFoundException(FullPath);
+                }
+
                 solution = SolutionFile.Parse(FullPath);
             }
             catch (Exception ex) when (ex is InvalidProjectFileException || ex is FileNotFoundException)


### PR DESCRIPTION
**Summary**

For .NET projects, our builds may fail if a .NET version that is specified as a `TargetFramework` is not available on the host. We have seen this recently in cases where e.g. a `.csproj` specifies .NET 8 but .NET 8 was not available on a GHA runner yet by default.

This PR:

- Retrieves `TargetFramework` values from the project files, where available.
- If there's no `global.json`, we look at the `TargetFramework` values and install those SDKs. (Should we do this even if there is a `global.json`?)