### PR TITLE
C#: Fix integration test failures after dotnet upgrade on runners.

### DIFF
--- a/csharp/ql/integration-tests/all-platforms/dotnet_pack/test.py
+++ b/csharp/ql/integration-tests/all-platforms/dotnet_pack/test.py
@@ -2,10 +2,10 @@ import os
 from create_database_utils import *
 from diagnostics_test_utils import *
 
-run_codeql_database_create(['dotnet pack'], db=None, lang="csharp")
+run_codeql_database_create(['dotnet pack -o nugetpackage'], db=None, lang="csharp")
 
 ## Check that the NuGet package is created.
-if not os.path.isfile("bin/Debug/dotnet_pack.1.0.0.nupkg"):
+if not os.path.isfile("nugetpackage/dotnet_pack.1.0.0.nupkg"):
     raise Exception("The NuGet package was not created.")
 
 check_diagnostics()

--- a/csharp/ql/integration-tests/posix-only/dotnet_test_mstest/dotnet_test_mstest.csproj
+++ b/csharp/ql/integration-tests/posix-only/dotnet_test_mstest/dotnet_test_mstest.csproj
@@ -7,6 +7,7 @@
 
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
+    <SelfContained>false</SelfContained>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
After the runners have been updated to a newer version of dotnet, some of the integration tests have started to fail. These are fixed in this PR.