### PR TITLE
Kotlin: Fix findTopLevelFunctionOrWarn for Kotlin 2

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -2457,8 +2457,12 @@ open class KotlinFileExtractor(
 
         val fn = getFunctionsByFqName(pluginContext, functionPkg, functionName)
             .firstOrNull { fnSymbol ->
-                fnSymbol.owner.parentClassOrNull?.fqNameWhenAvailable?.asString() == type &&
-                fnSymbol.owner.valueParameters.map { it.type.classFqName?.asString() }.toTypedArray() contentEquals parameterTypes
+                val owner = fnSymbol.owner
+                (owner.parentClassOrNull?.fqNameWhenAvailable?.asString() == type
+                 ||
+                 (owner.parent is IrExternalPackageFragment && getFileClassFqName(owner)?.asString() == type))
+                &&
+                owner.valueParameters.map { it.type.classFqName?.asString() }.toTypedArray() contentEquals parameterTypes
             }?.owner
 
         if (fn != null) {


### PR DESCRIPTION
The AST when the parent class is a file class is different in Kotlin 2 mode.