### PR TITLE
Kotlin: Add more CODEOWNERS entries

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,6 +8,8 @@
 /swift/ @github/codeql-swift
 /misc/codegen/ @github/codeql-swift
 /java/kotlin-extractor/ @github/codeql-kotlin
+/java/ql/test/kotlin/ @github/codeql-kotlin
+/java/ql/test-kotlin2/ @github/codeql-kotlin
 
 # ML-powered queries
 /javascript/ql/experimental/adaptivethreatmodeling/ @github/codeql-ml-powered-queries-reviewers


### PR DESCRIPTION
The second one is added by https://github.com/github/codeql/pull/14833.