### PR TITLE
C#: Tolerate missing call targets in LogMessageSink

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/flowsinks/ExternalLocationSink.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/flowsinks/ExternalLocationSink.qll
@@ -27,8 +27,9 @@ private class ExternalModelSink extends ExternalLocationSink {
  */
 class LogMessageSink extends ExternalLocationSink {
   LogMessageSink() {
-    this.getExpr() = any(LoggerType i).getAMethod().getACall().getAnArgument()
-    or
+    this.getExpr() = any(LoggerType i).getAMethod().getACall().getAnArgument() or
+    this.getExpr() =
+      any(MethodCall call | call.getQualifier().getType() instanceof LoggerType).getAnArgument() or
     this.getExpr() =
       any(ExtensionMethodCall call |
         call.getTarget().(ExtensionMethod).getExtendedType() instanceof LoggerType

--- a/csharp/ql/test/library-tests/standalone/externalLocationSink/externalLocationSink.expected
+++ b/csharp/ql/test/library-tests/standalone/externalLocationSink/externalLocationSink.expected
@@ -1,4 +1,6 @@
 #select
+| standalone.cs:20:20:20:20 | access to parameter s | standalone.cs:20:20:20:20 | access to parameter s |
+| standalone.cs:25:28:25:32 | "abc" | standalone.cs:25:28:25:32 | "abc" |
 compilationErrors
 | standalone.cs:16:12:16:18 | CS0104: 'ILogger' is an ambiguous reference between 'A.ILogger' and 'B.ILogger' |
 methodCalls

--- a/csharp/ql/test/library-tests/standalone/externalLocationSink/externalLocationSink.expected
+++ b/csharp/ql/test/library-tests/standalone/externalLocationSink/externalLocationSink.expected
@@ -1,0 +1,6 @@
+#select
+compilationErrors
+| standalone.cs:16:12:16:18 | CS0104: 'ILogger' is an ambiguous reference between 'A.ILogger' and 'B.ILogger' |
+methodCalls
+| standalone.cs:20:9:20:21 | call to method  |
+| standalone.cs:25:9:25:33 | call to method  |

--- a/csharp/ql/test/library-tests/standalone/externalLocationSink/externalLocationSink.ql
+++ b/csharp/ql/test/library-tests/standalone/externalLocationSink/externalLocationSink.ql
@@ -1,0 +1,10 @@
+import semmle.code.csharp.security.dataflow.flowsinks.ExternalLocationSink
+import semmle.code.csharp.commons.Diagnostics
+
+from ExternalLocationSink sink
+where sink.getLocation().getFile().fromSource()
+select sink, sink.getExpr()
+
+query predicate compilationErrors(CompilerError e) { any() }
+
+query predicate methodCalls(MethodCall m) { any() }

--- a/csharp/ql/test/library-tests/standalone/externalLocationSink/options
+++ b/csharp/ql/test/library-tests/standalone/externalLocationSink/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --standalone

--- a/csharp/ql/test/library-tests/standalone/externalLocationSink/standalone.cs
+++ b/csharp/ql/test/library-tests/standalone/externalLocationSink/standalone.cs
@@ -1,0 +1,27 @@
+using A;
+using B;
+
+namespace A
+{
+    public interface ILogger { }
+}
+
+namespace B
+{
+    public interface ILogger { }
+}
+
+public class C
+{
+    public ILogger logger;
+
+    private void M(string s)
+    {
+        logger.Log(s);
+    }
+
+    private static void Main()
+    {
+        new C().logger.Log("abc");
+    }
+}


### PR DESCRIPTION
In the standalone mode, we're automatically adding implicit usings to the compilation. If we detect any web application in the repo, we're adding the asp.net core specific implicit usings, which include `Microsoft.Extensions.Logging`. This namespace contains `ILogger`, which is quite a common name, and oftentimes conflict with `ILogger` interfaces defined in the repo. As a result, we're facing ambiguities in the standalone extracted compilation, and we end up with an incomplete DB. This PR adjusts the `LogMessageSink` class to work in cases when "logger-like" method calls have no extracted target.