### PR TITLE
Swift: "contentsOf" sources

### DIFF
--- a/swift/ql/lib/change-notes/2023-11-22-contentsof.md
+++ b/swift/ql/lib/change-notes/2023-11-22-contentsof.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added imprecise flow sources matching initializers such as `init(contentsOfFile:)`.

--- a/swift/ql/lib/codeql/swift/frameworks/Frameworks.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/Frameworks.qll
@@ -8,3 +8,4 @@ private import SQL.SQL
 private import StandardLibrary.StandardLibrary
 private import UIKit.UIKit
 private import Xml.Xml
+private import Heuristic

--- a/swift/ql/lib/codeql/swift/frameworks/Heuristic.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/Heuristic.qll
@@ -1,0 +1,48 @@
+/**
+ * Provides heuristic models that match taint sources and flow through unknown
+ * classes and libraries.
+ */
+
+import swift
+private import codeql.swift.dataflow.DataFlow
+private import codeql.swift.dataflow.FlowSources
+
+/**
+ * An imprecise flow source for an initializer call with a "contentsOf"
+ * argument that appears to be remote. For example:
+ * ```
+ * let myObject = MyClass(contentsOf: url)
+ * ```
+ */
+private class InitializerContentsOfRemoteSource extends RemoteFlowSource {
+  InitializerContentsOfRemoteSource() {
+    exists(InitializerCallExpr ce, Argument arg |
+      ce.getAnArgument() = arg and
+      arg.getLabel() = ["contentsOf", "contentsOfFile", "contentsOfPath", "contentsOfDirectory"] and
+      arg.getExpr().getType().getUnderlyingType().getName() = ["URL", "NSURL"] and
+      this.asExpr() = ce
+    )
+  }
+
+  override string getSourceType() { result = "contentsOf initializer" }
+}
+
+/**
+ * An imprecise flow source for an initializer call with a "contentsOf"
+ * argument that appears to be local. For example:
+ * ```
+ * let myObject = MyClass(contentsOfFile: "foo.txt")
+ * ```
+ */
+private class InitializerContentsOfLocalSource extends LocalFlowSource {
+  InitializerContentsOfLocalSource() {
+    exists(InitializerCallExpr ce, Argument arg |
+      ce.getAnArgument() = arg and
+      arg.getLabel() = ["contentsOf", "contentsOfFile", "contentsOfPath", "contentsOfDirectory"] and
+      not arg.getExpr().getType().getUnderlyingType().getName() = ["URL", "NSURL"] and
+      this.asExpr() = ce
+    )
+  }
+
+  override string getSourceType() { result = "contentsOf initializer" }
+}

--- a/swift/ql/test/library-tests/dataflow/flowsources/custom.swift
+++ b/swift/ql/test/library-tests/dataflow/flowsources/custom.swift
@@ -1,0 +1,34 @@
+
+// --- stubs ---
+
+struct URL {
+	init?(string: String) {}
+}
+
+class MyClass {
+	init(contentsOfFile: String) { }
+	init(contentsOfFile: String?, options: [Int]) { }
+	init(contentsOf: URL, fileTypeHint: Int) { }
+
+	init(contentsOfPath: String) { }
+	init(contentsOfDirectory: String) { }
+
+	func append(contentsOf: String) { }
+	func appending(contentsOf: String) -> MyClass { return self }
+}
+
+// --- tests ---
+
+func testCustom() {
+	let url = URL(string: "http://example.com/")!
+
+	let x = MyClass(contentsOfFile: "foo.txt") // $ MISSING: source=remote
+	_ = MyClass(contentsOfFile: "foo.txt", options: []) // $ MISSING: source=remote
+	_ = MyClass(contentsOf: url, fileTypeHint: 1) // $ MISSING: source=remote
+
+	_ = MyClass(contentsOfPath: "/foo/bar") // $ MISSING: source=remote
+	_ = MyClass(contentsOfDirectory: "/foo/bar") // $ MISSING: source=remote
+
+	x.append(contentsOf: "abcdef") // (not a flow source)
+	_ = x.appending(contentsOf: "abcdef") // (not a flow source)
+}

--- a/swift/ql/test/library-tests/dataflow/flowsources/custom.swift
+++ b/swift/ql/test/library-tests/dataflow/flowsources/custom.swift
@@ -22,12 +22,12 @@ class MyClass {
 func testCustom() {
 	let url = URL(string: "http://example.com/")!
 
-	let x = MyClass(contentsOfFile: "foo.txt") // $ MISSING: source=remote
-	_ = MyClass(contentsOfFile: "foo.txt", options: []) // $ MISSING: source=remote
-	_ = MyClass(contentsOf: url, fileTypeHint: 1) // $ MISSING: source=remote
+	let x = MyClass(contentsOfFile: "foo.txt") // $ source=local
+	_ = MyClass(contentsOfFile: "foo.txt", options: []) // $ source=local
+	_ = MyClass(contentsOf: url, fileTypeHint: 1) // $ source=remote
 
-	_ = MyClass(contentsOfPath: "/foo/bar") // $ MISSING: source=remote
-	_ = MyClass(contentsOfDirectory: "/foo/bar") // $ MISSING: source=remote
+	_ = MyClass(contentsOfPath: "/foo/bar") // $ source=local
+	_ = MyClass(contentsOfDirectory: "/foo/bar") // $ source=local
 
 	x.append(contentsOf: "abcdef") // (not a flow source)
 	_ = x.appending(contentsOf: "abcdef") // (not a flow source)


### PR DESCRIPTION
Adds a simple heuristic matching of "contentsOf" functions as flow sources in Swift code.  In practice many of the sources found by this heuristic are already modelled - `Data(contentsOfFile:)` is especially common.  But we now catch some more obscure stuff as well, e.g. [`NSDictionary(contentsOf:)`](https://developer.apple.com/documentation/foundation/nsdictionary/1416069-init), [`NSImage(contentsOf:)`](https://developer.apple.com/documentation/appkit/nsimage/1519907-init), [`NSArray(contentsOfFile:)`](https://developer.apple.com/documentation/foundation/nsarray/1413844-init) and [`AVAudioPlayer(contentsOf:)`](https://developer.apple.com/documentation/avfaudio/avaudioplayer/1387281-init)...