### PR TITLE
C++: Rewrite `cpp/user-controlled-null-termination-tainted` away from `DefaultTaintTracking`

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-170/ImproperNullTerminationTainted.ql
+++ b/cpp/ql/src/Security/CWE/CWE-170/ImproperNullTerminationTainted.ql
@@ -52,4 +52,4 @@ where
   Flow::flow(source, sink) and
   isSource(source, sourceType) and
   isSink(sink, va)
-select va, "String operation depends on a $@ that may not be null terminated.", source, sourceType
+select va, "String operation depends on $@ that may not be null terminated.", source, sourceType

--- a/cpp/ql/src/Security/CWE/CWE-170/ImproperNullTerminationTainted.ql
+++ b/cpp/ql/src/Security/CWE/CWE-170/ImproperNullTerminationTainted.ql
@@ -12,79 +12,44 @@
 
 import cpp
 import semmle.code.cpp.commons.NullTermination
-import semmle.code.cpp.ir.dataflow.internal.DefaultTaintTrackingImpl
+import semmle.code.cpp.security.FlowSources as FS
+import semmle.code.cpp.dataflow.new.TaintTracking
+import semmle.code.cpp.ir.IR
 
-/** A user-controlled expression that may not be null terminated. */
-class TaintSource extends VariableAccess {
-  TaintSource() {
-    exists(SecurityOptions x, string cause |
-      this.getTarget() instanceof SemanticStackVariable and
-      x.isUserInput(this, cause)
-    |
-      cause = ["read", "fread", "recv", "recvfrom", "recvmsg"]
-    )
-  }
-
-  /**
-   * Holds if `sink` is a tainted variable access that must be null
-   * terminated.
-   */
-  private predicate isSink(VariableAccess sink) {
-    tainted(this, sink) and
-    variableMustBeNullTerminated(sink)
-  }
-
-  /**
-   * Holds if this source can reach `va`, possibly using intermediate
-   * reassignments.
-   */
-  private predicate sourceReaches(VariableAccess va) {
-    definitionUsePair(_, this, va)
-    or
-    exists(VariableAccess mid, Expr def |
-      this.sourceReaches(mid) and
-      exprDefinition(_, def, mid) and
-      definitionUsePair(_, def, va)
-    )
-  }
-
-  /**
-   * Holds if the sink `sink` is reachable both from this source and
-   * from `va`, possibly using intermediate reassignments.
-   */
-  private predicate reachesSink(VariableAccess va, VariableAccess sink) {
-    this.isSink(sink) and
-    va = sink
-    or
-    exists(VariableAccess mid, Expr def |
-      this.reachesSink(mid, sink) and
-      exprDefinition(_, def, va) and
-      definitionUsePair(_, def, mid)
-    )
-  }
-
-  /**
-   * Holds if `sink` is a tainted variable access that must be null
-   * terminated, and no access which null terminates its contents can
-   * either reach the sink or be reached from the source. (Ideally,
-   * we should instead look for such accesses only on the path from
-   * this source to `sink` found via `tainted(source, sink)`.)
-   */
-  predicate reaches(VariableAccess sink) {
-    this.isSink(sink) and
-    not exists(VariableAccess va |
-      va != this and
-      va != sink and
-      mayAddNullTerminator(_, va)
-    |
-      this.sourceReaches(va)
-      or
-      this.reachesSink(va, sink)
-    )
-  }
+predicate isSource(FS::FlowSource source, string sourceType) {
+  sourceType = source.getSourceType() and
+  exists(VariableAccess va, Call call |
+    va = source.asDefiningArgument() and
+    call.getAnArgument() = va and
+    va.getTarget() instanceof SemanticStackVariable and
+    call.getTarget().hasGlobalName(["read", "fread", "recv", "recvfrom", "recvmsg"])
+  )
 }
 
-from TaintSource source, VariableAccess sink
-where source.reaches(sink)
-select sink, "String operation depends on a $@ that may not be null terminated.", source,
-  "user-provided value"
+predicate isSink(DataFlow::Node sink, VariableAccess va) {
+  va = [sink.asExpr(), sink.asIndirectExpr()] and
+  variableMustBeNullTerminated(va)
+}
+
+private module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { isSource(source, _) }
+
+  predicate isBarrier(DataFlow::Node node) {
+    isSink(node) and node.asExpr().getUnspecifiedType() instanceof ArithmeticType
+    or
+    node.asInstruction().(StoreInstruction).getResultType() instanceof ArithmeticType
+    or
+    mayAddNullTerminator(_, node.asIndirectExpr())
+  }
+
+  predicate isSink(DataFlow::Node sink) { isSink(sink, _) }
+}
+
+module Flow = TaintTracking::Global<Config>;
+
+from DataFlow::Node source, DataFlow::Node sink, VariableAccess va, string sourceType
+where
+  Flow::flow(source, sink) and
+  isSource(source, sourceType) and
+  isSink(sink, va)
+select va, "String operation depends on a $@ that may not be null terminated.", source, sourceType

--- a/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ImproperNullTermination/ImproperNullTerminationTainted.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ImproperNullTermination/ImproperNullTerminationTainted.expected
@@ -1,2 +1,2 @@
-| test.cpp:466:10:466:15 | buffer | String operation depends on a $@ that may not be null terminated. | test.cpp:465:18:465:23 | buffer | user-provided value |
-| test.cpp:481:10:481:15 | buffer | String operation depends on a $@ that may not be null terminated. | test.cpp:480:9:480:14 | buffer | user-provided value |
+| test.cpp:466:10:466:15 | buffer | String operation depends on a $@ that may not be null terminated. | test.cpp:465:18:465:23 | read output argument | buffer read by read |
+| test.cpp:481:10:481:15 | buffer | String operation depends on a $@ that may not be null terminated. | test.cpp:480:9:480:14 | fread output argument | string read by fread |

--- a/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ImproperNullTermination/ImproperNullTerminationTainted.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ImproperNullTermination/ImproperNullTerminationTainted.expected
@@ -1,2 +1,2 @@
-| test.cpp:466:10:466:15 | buffer | String operation depends on a $@ that may not be null terminated. | test.cpp:465:18:465:23 | read output argument | buffer read by read |
-| test.cpp:481:10:481:15 | buffer | String operation depends on a $@ that may not be null terminated. | test.cpp:480:9:480:14 | fread output argument | string read by fread |
+| test.cpp:466:10:466:15 | buffer | String operation depends on $@ that may not be null terminated. | test.cpp:465:18:465:23 | read output argument | buffer read by read |
+| test.cpp:481:10:481:15 | buffer | String operation depends on $@ that may not be null terminated. | test.cpp:480:9:480:14 | fread output argument | string read by fread |


### PR DESCRIPTION
This query logic in this query was kinda odd. The query starts by tracking flow from a subset of flow sources (the ones that can leave the variable with a non-zero terminated string) to a specific kind of `VariableAccess` (places where we know a zero-terminated string is expceted). That's all well and good. The problem is that, to weed out false positives, the query adds barrier logic to the query by reinventing a query-specific dataflow library. This dataflow library is implemented as a less-than-ideal transitive closure over the old `exprDefinition` predicate from [DefinitionsAndUses library](https://github.com/github/codeql/blob/main/cpp/ql/lib/semmle/code/cpp/controlflow/DefinitionsAndUses.qll#L279).

This PR rewrites the query to be a standard taint-tracking query. This is not totally what the old query was doing (since it used taint-tracking to track the flow, but used _dataflow_ to implement a barrier), but I think this is within the spirit of the query.

There are a lot of lost results on MRVA. Most of the ones I've seen are due to fixed pointer conflation. There are a few new results (about 200 out of 23000 the result changes), and the ones I've looked at look like TP which was blocked by the queries incorrect handling of barriers.

I don't think we should spend too much time on this query as it's not part of any suite (it has no precision).