### PR TITLE
JS: update the JS change notes to mention security severity instead of just severity

### DIFF
--- a/javascript/ql/src/CHANGELOG.md
+++ b/javascript/ql/src/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ### Query Metadata Changes
 
-* Lower the severity of log-injection to medium.
-* Increase the severity of XSS to high.
+* Lower the security severity of log-injection to medium.
+* Increase the security severity of XSS to high.
 
 ## 0.8.2
 

--- a/javascript/ql/src/change-notes/released/0.8.3.md
+++ b/javascript/ql/src/change-notes/released/0.8.3.md
@@ -2,5 +2,5 @@
 
 ### Query Metadata Changes
 
-* Lower the severity of log-injection to medium.
-* Increase the severity of XSS to high.
+* Lower the security severity of log-injection to medium.
+* Increase the security severity of XSS to high.


### PR DESCRIPTION
A late implementation of this comment from docs: https://github.com/github/codeql/pull/14876#discussion_r1402144127 