### PR TITLE
Fix changelog docs based on latest generator version

### DIFF
--- a/docs/codeql/codeql-overview/codeql-changelog/codeql-cli-2.11.0.rst
+++ b/docs/codeql/codeql-overview/codeql-changelog/codeql-cli-2.11.0.rst
@@ -71,8 +71,8 @@ Java
 JavaScript/TypeScript
 """""""""""""""""""""
 
-*   Improved how the JavaScript parser handles ambiguities between plain JavaScript and dialects such as Flow and E4X that use the same file extension. The parser now prefers plain JavaScript if possible, falling back to dialects only if the source code can not be parsed as plain JavaScript. Previously, there were rare cases where parsing would fail because the parser would erroneously attempt to parse dialect-specific syntax in a regular JavaScript file.- The :code:`js/regexp/always-matches` query will no longer report an empty regular expression as always matching, as this is often the intended behavior.
-    
+*   Improved how the JavaScript parser handles ambiguities between plain JavaScript and dialects such as Flow and E4X that use the same file extension. The parser now prefers plain JavaScript if possible, falling back to dialects only if the source code can not be parsed as plain JavaScript. Previously, there were rare cases where parsing would fail because the parser would erroneously attempt to parse dialect-specific syntax in a regular JavaScript file.
+*   The :code:`js/regexp/always-matches` query will no longer report an empty regular expression as always matching, as this is often the intended behavior.
 *   The alert message of many queries have been changed to make the message consistent with other languages.
 
 Python

--- a/docs/codeql/codeql-overview/codeql-changelog/codeql-cli-2.15.0.rst
+++ b/docs/codeql/codeql-overview/codeql-changelog/codeql-cli-2.15.0.rst
@@ -147,15 +147,11 @@ Ruby
 Swift
 """""
 
-*   The predicates :code:`getABaseType`, :code:`getABaseTypeDecl`, :code:`getADerivedType` and :code:`getADerivedTypeDecl` on :code:`Type` and :code:`TypeDecl` now behave more usefully and consistently. They now explore through type aliases used in base class declarations, and include protocols added in extensions.To examine base class declarations at a low level without these enhancements, use :code:`TypeDecl.getInheritedType`.
-*   Modelled varargs function in :code:`NSString` more accurately.
-*   Modelled :code:`CustomStringConvertible.description` and :code:`CustomDebugStringConvertible.debugDescription`, replacing ad-hoc models of these properties on derived classes.
-*   The regular expressions library now accepts a wider range of mode flags in a regular expression mode flag group (such as :code:`(?u)`). The :code:`(?w`) flag has been renamed from "UNICODE" to "UNICODEBOUNDARY", and the :code:`(?u)` flag is called "UNICODE" in the libraries.
-*   Renamed :code:`TypeDecl.getBaseType/1` to :code:`getInheritedType`.
-*   Flow through writes via keypaths is now supported by the data flow library.
-*   Added flow through variadic arguments, and the :code:`getVaList` function.
-*   Added flow steps through :code:`Dictionary` keys and values.
-*   Added taint models for :code:`Numeric` conversions.
+*   The predicates :code:`getABaseType`, :code:`getABaseTypeDecl`, :code:`getADerivedType` and :code:`getADerivedTypeDecl` on :code:`Type` and :code:`TypeDecl` now behave more usefully and consistently. They now explore through type aliases used in base class declarations, and include protocols added in extensions.
+    
+    To examine base class declarations at a low level without these enhancements, use :code:`TypeDecl.getInheritedType`.
+    
+    :code:`Type.getABaseType` (only) previously resolved a type alias it was called directly on. This behaviour no longer exists. To find any base type of a type that could be an alias, the construct :code:`Type.getUnderlyingType().getABaseType*()` is recommended.
 
 Minor Analysis Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -187,6 +183,18 @@ Python
 
 *   Django Rest Framework better handles custom :code:`ModelViewSet` classes functions
 *   Regular expression fragments residing inside implicitly concatenated strings now have better location information.
+
+Swift
+"""""
+
+*   Modelled varargs function in :code:`NSString` more accurately.
+*   Modelled :code:`CustomStringConvertible.description` and :code:`CustomDebugStringConvertible.debugDescription`, replacing ad-hoc models of these properties on derived classes.
+*   The regular expressions library now accepts a wider range of mode flags in a regular expression mode flag group (such as :code:`(?u)`). The :code:`(?w`) flag has been renamed from "UNICODE" to "UNICODEBOUNDARY", and the :code:`(?u)` flag is called "UNICODE" in the libraries.
+*   Renamed :code:`TypeDecl.getBaseType/1` to :code:`getInheritedType`.
+*   Flow through writes via keypaths is now supported by the data flow library.
+*   Added flow through variadic arguments, and the :code:`getVaList` function.
+*   Added flow steps through :code:`Dictionary` keys and values.
+*   Added taint models for :code:`Numeric` conversions.
 
 Deprecated APIs
 ~~~~~~~~~~~~~~~

--- a/docs/codeql/codeql-overview/codeql-changelog/codeql-cli-2.15.3.rst
+++ b/docs/codeql/codeql-overview/codeql-changelog/codeql-cli-2.15.3.rst
@@ -138,9 +138,11 @@ C/C++
 C#
 ""
 
-*   The predicate :code:`UnboundGeneric::getName` now prints the number of type parameters as a :code:` `N` suffix, instead of a :code:`<,...,>` suffix. For example, the unbound generic type
-    :code:`System.Collections.Generic.IList<T>` is printed as :code:`IList`1` instead of :code:`IList<>`.
+*   The predicate :code:`UnboundGeneric::getName` now prints the number of type parameters as a ```N`` suffix, instead of a :code:`<,...,>` suffix. For example, the unbound generic type
+    :code:`System.Collections.Generic.IList<T>` is printed as ``IList`1`` instead of :code:`IList<>`.
+    
 *   The predicates :code:`hasQualifiedName`, :code:`getQualifiedName`, and :code:`getQualifiedNameWithTypes` have been deprecated, and are instead replaced by :code:`hasFullyQualifiedName`, :code:`getFullyQualifiedName`, and :code:`getFullyQualifiedNameWithTypes`, respectively. The new predicates use the same format for unbound generic types as mentioned above.
+    
 *   These changes also affect models-as-data rows that refer to a field or a property belonging to a generic type. For example, instead of writing
 
     ..  code-block:: yaml
@@ -151,6 +153,17 @@ C#
               extensible: summaryModel
               data:
                 - ["System.Collections.Generic", "Dictionary<TKey,TValue>", False, "Add", "(System.Collections.Generic.KeyValuePair<TKey,TValue>)", "", "Argument[0].Property[System.Collections.Generic.KeyValuePair<,>.Key]", "Argument[this].Element.Property[System.Collections.Generic.KeyValuePair<,>.Key]", "value", "manual"]
+
+    one now writes
+
+    ..  code-block:: yaml
+    
+        extensions:
+          - addsTo:
+              pack: codeql/csharp-all
+              extensible: summaryModel
+              data:
+                - ["System.Collections.Generic", "Dictionary<TKey,TValue>", False, "Add", "(System.Collections.Generic.KeyValuePair<TKey,TValue>)", "", "Argument[0].Property[System.Collections.Generic.KeyValuePair`2.Key]", "Argument[this].Element.Property[System.Collections.Generic.KeyValuePair`2.Key]", "value", "manual"]
 
 *   The models-as-data format for types and methods with type parameters has been changed to include the names of the type parameters. For example, instead of writing
 
@@ -163,6 +176,18 @@ C#
               data:
                 - ["System.Collections.Generic", "IList<>", True, "Insert", "(System.Int32,T)", "", "Argument[1]", "Argument[this].Element", "value", "manual"]
                 - ["System.Linq", "Enumerable", False, "Select<,>", "(System.Collections.Generic.IEnumerable<TSource>,System.Func<TSource,System.Int32,TResult>)", "", "Argument[0].Element", "Argument[1].Parameter[0]", "value", "manual"]
+
+    one now writes
+
+    ..  code-block:: yaml
+    
+        extensions:
+          - addsTo:
+              pack: codeql/csharp-all
+              extensible: summaryModel
+              data:
+                - ["System.Collections.Generic", "IList<T>", True, "Insert", "(System.Int32,T)", "", "Argument[1]", "Argument[this].Element", "value", "manual"]
+                - ["System.Linq", "Enumerable", False, "Select<TSource,TResult>", "(System.Collections.Generic.IEnumerable<TSource>,System.Func<TSource,System.Int32,TResult>)", "", "Argument[0].Element", "Argument[1].Parameter[0]", "value", "manual"]
 
 Golang
 """"""

--- a/docs/codeql/codeql-overview/codeql-changelog/codeql-cli-2.7.5.rst
+++ b/docs/codeql/codeql-overview/codeql-changelog/codeql-cli-2.7.5.rst
@@ -68,7 +68,7 @@ Java
 JavaScript/TypeScript
 """""""""""""""""""""
 
-*   Support for handlebars templates has improved. Raw interpolation tags of the form :code:`{{&amp; ... }}` are now recognized,
+*   Support for handlebars templates has improved. Raw interpolation tags of the form :code:`{{& ... }}` are now recognized,
     as well as whitespace-trimming tags like :code:`{{~ ... }}`.
 *   Data flow is now tracked across middleware functions in more cases, leading to more security results in general. Affected packages are :code:`express` and :code:`fastify`.
 *   :code:`js/missing-token-validation` has been made more precise, yielding both fewer false positives and more true positives.

--- a/docs/codeql/codeql-overview/codeql-changelog/codeql-cli-2.8.0.rst
+++ b/docs/codeql/codeql-overview/codeql-changelog/codeql-cli-2.8.0.rst
@@ -122,18 +122,16 @@ Major Analysis Improvements
 C#
 ""
 
-*   Added support for the following C# 10 features.* \ `Record structs <https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-10#record-structs>`__.
+*   Added support for the following C# 10 features.
+*   \ `Record structs <https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-10#record-structs>`__.
+*   \ `Improvements of structure types <https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-10#improvements-of-structure-types>`__.
 
-    *   \ `Improvements of structure types <https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-10#improvements-of-structure-types>`__.
+    *   Instance parameterless constructor in a structure type.
+    *   Enhance :code:`WithExpr` in QL to support :code:`structs` and anonymous classes.
     
-        *   Instance parameterless constructor in a structure type.
-        *   Enhance :code:`WithExpr` in QL to support :code:`structs` and anonymous classes.
-        
-    *   \ `Global using directives <https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-10#global-using-directives>`__.
-    *   \ `File-scoped namespace declaration <https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-10#file-scoped-namespace-declaration>`__.
-    *   \ `Enhanced #line pragma <https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-10#enhanced-line-pragma>`__.
-    
-*   The query :code:`cs/local-shadows-member` no longer highlights parameters of :code:`record` types.
+*   \ `Global using directives <https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-10#global-using-directives>`__.
+*   \ `File-scoped namespace declaration <https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-10#file-scoped-namespace-declaration>`__.
+*   \ `Enhanced #line pragma <https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-10#enhanced-line-pragma>`__.
 
 Minor Analysis Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -142,6 +140,11 @@ C/C++
 """""
 
 *   :code:`FormatLiteral::getMaxConvertedLength` now uses range analysis to provide a more accurate length for integers formatted with :code:`%x`
+
+C#
+""
+
+*   The query :code:`cs/local-shadows-member` no longer highlights parameters of :code:`record` types.
 
 Deprecated APIs
 ~~~~~~~~~~~~~~~

--- a/docs/codeql/codeql-overview/codeql-changelog/codeql-cli-2.9.3.rst
+++ b/docs/codeql/codeql-overview/codeql-changelog/codeql-cli-2.9.3.rst
@@ -160,7 +160,7 @@ Ruby
 """"
 
 *   Support for data flow through instance variables has been added.
-*   Support of the safe navigation operator (:code:`&amp;.`) has been added; there is a new predicate :code:`MethodCall.isSafeNavigation()`.
+*   Support of the safe navigation operator (:code:`&.`) has been added; there is a new predicate :code:`MethodCall.isSafeNavigation()`.
 
 Deprecated APIs
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
Fixes several generator bugs:

* The same unordered list with multiple different markers is no longer mangled into a single line (see 2.11.0, 2.8.0)
* A major aggregator bug led to category header confusion and bullets ended up in the wrong category, this is now fixed (see 2.15.0)
* List continuation parser logic led to skipped tokens, now fixed (see 2.15.3)
* Difficult nested backticks are now rendered as literals, and dangling whitespace is handled correctly (see 2.15.3)
* Inline code no longer produces HTML entities (see 2.7.5)