### PR TITLE
C++: Don't short circuit logical negation in conditions

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/constant/ConstantAnalysis.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/constant/ConstantAnalysis.qll
@@ -12,6 +12,9 @@ int getConstantValue(Instruction instr) {
   or
   result = getConstantValue(instr.(CopyInstruction).getSourceValue())
   or
+  getConstantValue(instr.(LogicalNotInstruction).getUnary()) != 0 and
+  result = 0
+  or
   exists(PhiInstruction phi |
     phi = instr and
     result = unique(Operand op | op = phi.getAnInputOperand() | getConstantValue(op.getDef()))
@@ -26,28 +29,25 @@ private predicate binaryInstructionOperands(BinaryInstruction instr, int left, i
 
 pragma[noinline]
 private int getBinaryInstructionValue(BinaryInstruction instr) {
-  exists(int left, int right |
-    binaryInstructionOperands(instr, left, right) and
-    (
-      instr instanceof AddInstruction and result = add(left, right)
-      or
-      instr instanceof SubInstruction and result = sub(left, right)
-      or
-      instr instanceof MulInstruction and result = mul(left, right)
-      or
-      instr instanceof DivInstruction and result = div(left, right)
-      or
-      instr instanceof CompareEQInstruction and result = compareEQ(left, right)
-      or
-      instr instanceof CompareNEInstruction and result = compareNE(left, right)
-      or
-      instr instanceof CompareLTInstruction and result = compareLT(left, right)
-      or
-      instr instanceof CompareGTInstruction and result = compareGT(left, right)
-      or
-      instr instanceof CompareLEInstruction and result = compareLE(left, right)
-      or
-      instr instanceof CompareGEInstruction and result = compareGE(left, right)
-    )
+  exists(int left, int right | binaryInstructionOperands(instr, left, right) |
+    instr instanceof AddInstruction and result = add(left, right)
+    or
+    instr instanceof SubInstruction and result = sub(left, right)
+    or
+    instr instanceof MulInstruction and result = mul(left, right)
+    or
+    instr instanceof DivInstruction and result = div(left, right)
+    or
+    instr instanceof CompareEQInstruction and result = compareEQ(left, right)
+    or
+    instr instanceof CompareNEInstruction and result = compareNE(left, right)
+    or
+    instr instanceof CompareLTInstruction and result = compareLT(left, right)
+    or
+    instr instanceof CompareGTInstruction and result = compareGT(left, right)
+    or
+    instr instanceof CompareLEInstruction and result = compareLE(left, right)
+    or
+    instr instanceof CompareGEInstruction and result = compareGE(left, right)
   )
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/constant/ConstantAnalysis.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/constant/ConstantAnalysis.qll
@@ -12,6 +12,9 @@ int getConstantValue(Instruction instr) {
   or
   result = getConstantValue(instr.(CopyInstruction).getSourceValue())
   or
+  getConstantValue(instr.(LogicalNotInstruction).getUnary()) != 0 and
+  result = 0
+  or
   exists(PhiInstruction phi |
     phi = instr and
     result = unique(Operand op | op = phi.getAnInputOperand() | getConstantValue(op.getDef()))
@@ -26,28 +29,25 @@ private predicate binaryInstructionOperands(BinaryInstruction instr, int left, i
 
 pragma[noinline]
 private int getBinaryInstructionValue(BinaryInstruction instr) {
-  exists(int left, int right |
-    binaryInstructionOperands(instr, left, right) and
-    (
-      instr instanceof AddInstruction and result = add(left, right)
-      or
-      instr instanceof SubInstruction and result = sub(left, right)
-      or
-      instr instanceof MulInstruction and result = mul(left, right)
-      or
-      instr instanceof DivInstruction and result = div(left, right)
-      or
-      instr instanceof CompareEQInstruction and result = compareEQ(left, right)
-      or
-      instr instanceof CompareNEInstruction and result = compareNE(left, right)
-      or
-      instr instanceof CompareLTInstruction and result = compareLT(left, right)
-      or
-      instr instanceof CompareGTInstruction and result = compareGT(left, right)
-      or
-      instr instanceof CompareLEInstruction and result = compareLE(left, right)
-      or
-      instr instanceof CompareGEInstruction and result = compareGE(left, right)
-    )
+  exists(int left, int right | binaryInstructionOperands(instr, left, right) |
+    instr instanceof AddInstruction and result = add(left, right)
+    or
+    instr instanceof SubInstruction and result = sub(left, right)
+    or
+    instr instanceof MulInstruction and result = mul(left, right)
+    or
+    instr instanceof DivInstruction and result = div(left, right)
+    or
+    instr instanceof CompareEQInstruction and result = compareEQ(left, right)
+    or
+    instr instanceof CompareNEInstruction and result = compareNE(left, right)
+    or
+    instr instanceof CompareLTInstruction and result = compareLT(left, right)
+    or
+    instr instanceof CompareGTInstruction and result = compareGT(left, right)
+    or
+    instr instanceof CompareLEInstruction and result = compareLE(left, right)
+    or
+    instr instanceof CompareGEInstruction and result = compareGE(left, right)
   )
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedCondition.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedCondition.qll
@@ -77,24 +77,6 @@ class TranslatedParenthesisCondition extends TranslatedFlexibleCondition {
   }
 }
 
-class TranslatedNotCondition extends TranslatedFlexibleCondition {
-  override NotExpr expr;
-
-  override Instruction getChildTrueSuccessor(TranslatedCondition child) {
-    child = this.getOperand() and
-    result = this.getConditionContext().getChildFalseSuccessor(this)
-  }
-
-  override Instruction getChildFalseSuccessor(TranslatedCondition child) {
-    child = this.getOperand() and
-    result = this.getConditionContext().getChildTrueSuccessor(this)
-  }
-
-  override TranslatedCondition getOperand() {
-    result = getTranslatedCondition(expr.getOperand().getFullyConverted())
-  }
-}
-
 abstract class TranslatedNativeCondition extends TranslatedCondition, TTranslatedNativeCondition {
   TranslatedNativeCondition() { this = TTranslatedNativeCondition(expr) }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedElement.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedElement.qll
@@ -190,10 +190,7 @@ private predicate isNativeCondition(Expr expr) {
  * depending on context.
  */
 private predicate isFlexibleCondition(Expr expr) {
-  (
-    expr instanceof ParenthesisExpr or
-    expr instanceof NotExpr
-  ) and
+  expr instanceof ParenthesisExpr and
   usedAsCondition(expr) and
   not isIRConstant(expr)
 }
@@ -216,11 +213,6 @@ private predicate usedAsCondition(Expr expr) {
     // The two-operand form of `ConditionalExpr` treats its condition as a value, since it needs to
     // be reused as a value if the condition is true.
     condExpr.getCondition().getFullyConverted() = expr and not condExpr.isTwoOperand()
-  )
-  or
-  exists(NotExpr notExpr |
-    notExpr.getOperand().getFullyConverted() = expr and
-    usedAsCondition(notExpr)
   )
   or
   exists(ParenthesisExpr paren |

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/constant/ConstantAnalysis.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/constant/ConstantAnalysis.qll
@@ -12,6 +12,9 @@ int getConstantValue(Instruction instr) {
   or
   result = getConstantValue(instr.(CopyInstruction).getSourceValue())
   or
+  getConstantValue(instr.(LogicalNotInstruction).getUnary()) != 0 and
+  result = 0
+  or
   exists(PhiInstruction phi |
     phi = instr and
     result = unique(Operand op | op = phi.getAnInputOperand() | getConstantValue(op.getDef()))
@@ -26,28 +29,25 @@ private predicate binaryInstructionOperands(BinaryInstruction instr, int left, i
 
 pragma[noinline]
 private int getBinaryInstructionValue(BinaryInstruction instr) {
-  exists(int left, int right |
-    binaryInstructionOperands(instr, left, right) and
-    (
-      instr instanceof AddInstruction and result = add(left, right)
-      or
-      instr instanceof SubInstruction and result = sub(left, right)
-      or
-      instr instanceof MulInstruction and result = mul(left, right)
-      or
-      instr instanceof DivInstruction and result = div(left, right)
-      or
-      instr instanceof CompareEQInstruction and result = compareEQ(left, right)
-      or
-      instr instanceof CompareNEInstruction and result = compareNE(left, right)
-      or
-      instr instanceof CompareLTInstruction and result = compareLT(left, right)
-      or
-      instr instanceof CompareGTInstruction and result = compareGT(left, right)
-      or
-      instr instanceof CompareLEInstruction and result = compareLE(left, right)
-      or
-      instr instanceof CompareGEInstruction and result = compareGE(left, right)
-    )
+  exists(int left, int right | binaryInstructionOperands(instr, left, right) |
+    instr instanceof AddInstruction and result = add(left, right)
+    or
+    instr instanceof SubInstruction and result = sub(left, right)
+    or
+    instr instanceof MulInstruction and result = mul(left, right)
+    or
+    instr instanceof DivInstruction and result = div(left, right)
+    or
+    instr instanceof CompareEQInstruction and result = compareEQ(left, right)
+    or
+    instr instanceof CompareNEInstruction and result = compareNE(left, right)
+    or
+    instr instanceof CompareLTInstruction and result = compareLT(left, right)
+    or
+    instr instanceof CompareGTInstruction and result = compareGT(left, right)
+    or
+    instr instanceof CompareLEInstruction and result = compareLE(left, right)
+    or
+    instr instanceof CompareGEInstruction and result = compareGE(left, right)
   )
 }

--- a/cpp/ql/test/library-tests/controlflow/guards-ir/tests.expected
+++ b/cpp/ql/test/library-tests/controlflow/guards-ir/tests.expected
@@ -450,6 +450,7 @@ irGuards
 | test.c:126:12:126:26 | Call: call to test3_condition |
 | test.c:131:7:131:7 | Load: b |
 | test.c:137:7:137:7 | Constant: 0 |
+| test.c:146:7:146:8 | LogicalNot: ! ... |
 | test.c:146:8:146:8 | Load: x |
 | test.c:152:10:152:10 | Load: x |
 | test.c:152:15:152:15 | Load: y |
@@ -640,6 +641,7 @@ irGuardsControl
 | test.c:126:12:126:26 | Call: call to test3_condition | true | 127 | 127 |
 | test.c:131:7:131:7 | Load: b | true | 132 | 132 |
 | test.c:137:7:137:7 | Constant: 0 | false | 142 | 142 |
+| test.c:146:7:146:8 | LogicalNot: ! ... | true | 147 | 147 |
 | test.c:146:8:146:8 | Load: x | false | 147 | 147 |
 | test.c:152:10:152:10 | Load: x | true | 152 | 152 |
 | test.c:152:15:152:15 | Load: y | true | 152 | 152 |

--- a/cpp/ql/test/library-tests/ir/ir/aliased_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ir/aliased_ir.expected
@@ -2770,43 +2770,65 @@ ir.cpp:
 #  462|     m462_2(int)         = Uninitialized[x]       : &:r462_1
 #  463|     r463_1(glval<bool>) = VariableAddress[a]     : 
 #  463|     r463_2(bool)        = Load[a]                : &:r463_1, m461_6
-#  463|     v463_3(void)        = ConditionalBranch      : r463_2
-#-----|   False -> Block 1
-#-----|   True -> Block 2
+#  463|     r463_3(bool)        = LogicalNot             : r463_2
+#  463|     v463_4(void)        = ConditionalBranch      : r463_3
+#-----|   False -> Block 5
+#-----|   True -> Block 1
 
 #  464|   Block 1
 #  464|     r464_1(int)        = Constant[1]        : 
 #  464|     r464_2(glval<int>) = VariableAddress[x] : 
 #  464|     m464_3(int)        = Store[x]           : &:r464_2, r464_1
-#-----|   Goto -> Block 2
+#-----|   Goto -> Block 5
 
 #  467|   Block 2
-#  467|     r467_1(glval<bool>) = VariableAddress[a] : 
-#  467|     r467_2(bool)        = Load[a]            : &:r467_1, m461_6
-#  467|     v467_3(void)        = ConditionalBranch  : r467_2
-#-----|   False -> Block 4
-#-----|   True -> Block 3
+#  467|     r467_1(glval<bool>) = VariableAddress[#temp467:11] : 
+#  467|     r467_2(bool)        = Constant[0]                  : 
+#  467|     m467_3(bool)        = Store[#temp467:11]           : &:r467_1, r467_2
+#-----|   Goto -> Block 3
 
 #  467|   Block 3
-#  467|     r467_4(glval<bool>) = VariableAddress[b] : 
-#  467|     r467_5(bool)        = Load[b]            : &:r467_4, m461_8
-#  467|     v467_6(void)        = ConditionalBranch  : r467_5
-#-----|   False -> Block 4
-#-----|   True -> Block 5
+#  467|     m467_4(bool)        = Phi                          : from 2:m467_3, from 4:m467_11
+#  467|     r467_5(glval<bool>) = VariableAddress[#temp467:11] : 
+#  467|     r467_6(bool)        = Load[#temp467:11]            : &:r467_5, m467_4
+#  467|     r467_7(bool)        = LogicalNot                   : r467_6
+#  467|     v467_8(void)        = ConditionalBranch            : r467_7
+#-----|   False -> Block 8
+#-----|   True -> Block 7
 
-#  468|   Block 4
+#  467|   Block 4
+#  467|     r467_9(glval<bool>) = VariableAddress[#temp467:11] : 
+#  467|     r467_10(bool)       = Constant[1]                  : 
+#  467|     m467_11(bool)       = Store[#temp467:11]           : &:r467_9, r467_10
+#-----|   Goto -> Block 3
+
+#  467|   Block 5
+#  467|     r467_12(glval<bool>) = VariableAddress[a] : 
+#  467|     r467_13(bool)        = Load[a]            : &:r467_12, m461_6
+#  467|     v467_14(void)        = ConditionalBranch  : r467_13
+#-----|   False -> Block 2
+#-----|   True -> Block 6
+
+#  467|   Block 6
+#  467|     r467_15(glval<bool>) = VariableAddress[b] : 
+#  467|     r467_16(bool)        = Load[b]            : &:r467_15, m461_8
+#  467|     v467_17(void)        = ConditionalBranch  : r467_16
+#-----|   False -> Block 2
+#-----|   True -> Block 4
+
+#  468|   Block 7
 #  468|     r468_1(int)        = Constant[2]        : 
 #  468|     r468_2(glval<int>) = VariableAddress[x] : 
 #  468|     m468_3(int)        = Store[x]           : &:r468_2, r468_1
-#-----|   Goto -> Block 6
+#-----|   Goto -> Block 9
 
-#  471|   Block 5
+#  471|   Block 8
 #  471|     r471_1(int)        = Constant[3]        : 
 #  471|     r471_2(glval<int>) = VariableAddress[x] : 
 #  471|     m471_3(int)        = Store[x]           : &:r471_2, r471_1
-#-----|   Goto -> Block 6
+#-----|   Goto -> Block 9
 
-#  473|   Block 6
+#  473|   Block 9
 #  473|     v473_1(void)  = NoOp         : 
 #  461|     v461_9(void)  = ReturnVoid   : 
 #  461|     v461_10(void) = AliasedUse   : m461_3

--- a/cpp/ql/test/library-tests/ir/ir/operand_locations.expected
+++ b/cpp/ql/test/library-tests/ir/ir/operand_locations.expected
@@ -2398,16 +2398,27 @@
 | ir.cpp:461:22:461:22 | Address | &:r461_5 |
 | ir.cpp:461:30:461:30 | Address | &:r461_7 |
 | ir.cpp:462:9:462:9 | Address | &:r462_1 |
+| ir.cpp:463:9:463:10 | Condition | r463_3 |
 | ir.cpp:463:10:463:10 | Address | &:r463_1 |
-| ir.cpp:463:10:463:10 | Condition | r463_2 |
 | ir.cpp:463:10:463:10 | Load | m461_6 |
+| ir.cpp:463:10:463:10 | Unary | r463_2 |
 | ir.cpp:464:9:464:9 | Address | &:r464_2 |
 | ir.cpp:464:13:464:13 | StoreValue | r464_1 |
-| ir.cpp:467:11:467:11 | Address | &:r467_1 |
-| ir.cpp:467:11:467:11 | Condition | r467_2 |
+| ir.cpp:467:9:467:17 | Condition | r467_7 |
+| ir.cpp:467:11:467:11 | Address | &:r467_12 |
+| ir.cpp:467:11:467:11 | Condition | r467_13 |
 | ir.cpp:467:11:467:11 | Load | m461_6 |
-| ir.cpp:467:16:467:16 | Address | &:r467_4 |
-| ir.cpp:467:16:467:16 | Condition | r467_5 |
+| ir.cpp:467:11:467:16 | Address | &:r467_1 |
+| ir.cpp:467:11:467:16 | Address | &:r467_5 |
+| ir.cpp:467:11:467:16 | Address | &:r467_9 |
+| ir.cpp:467:11:467:16 | Load | m467_4 |
+| ir.cpp:467:11:467:16 | Phi | from 2:m467_3 |
+| ir.cpp:467:11:467:16 | Phi | from 4:m467_11 |
+| ir.cpp:467:11:467:16 | StoreValue | r467_2 |
+| ir.cpp:467:11:467:16 | StoreValue | r467_10 |
+| ir.cpp:467:11:467:16 | Unary | r467_6 |
+| ir.cpp:467:16:467:16 | Address | &:r467_15 |
+| ir.cpp:467:16:467:16 | Condition | r467_16 |
 | ir.cpp:467:16:467:16 | Load | m461_8 |
 | ir.cpp:468:9:468:9 | Address | &:r468_2 |
 | ir.cpp:468:13:468:13 | StoreValue | r468_1 |

--- a/cpp/ql/test/library-tests/ir/ir/raw_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ir/raw_ir.expected
@@ -2725,43 +2725,64 @@ ir.cpp:
 #  462|     mu462_2(int)        = Uninitialized[x]       : &:r462_1
 #  463|     r463_1(glval<bool>) = VariableAddress[a]     : 
 #  463|     r463_2(bool)        = Load[a]                : &:r463_1, ~m?
-#  463|     v463_3(void)        = ConditionalBranch      : r463_2
-#-----|   False -> Block 1
-#-----|   True -> Block 2
+#  463|     r463_3(bool)        = LogicalNot             : r463_2
+#  463|     v463_4(void)        = ConditionalBranch      : r463_3
+#-----|   False -> Block 5
+#-----|   True -> Block 1
 
 #  464|   Block 1
 #  464|     r464_1(int)        = Constant[1]        : 
 #  464|     r464_2(glval<int>) = VariableAddress[x] : 
 #  464|     mu464_3(int)       = Store[x]           : &:r464_2, r464_1
-#-----|   Goto -> Block 2
+#-----|   Goto -> Block 5
 
 #  467|   Block 2
-#  467|     r467_1(glval<bool>) = VariableAddress[a] : 
-#  467|     r467_2(bool)        = Load[a]            : &:r467_1, ~m?
-#  467|     v467_3(void)        = ConditionalBranch  : r467_2
-#-----|   False -> Block 4
-#-----|   True -> Block 3
+#  467|     r467_1(glval<bool>) = VariableAddress[#temp467:11] : 
+#  467|     r467_2(bool)        = Constant[0]                  : 
+#  467|     mu467_3(bool)       = Store[#temp467:11]           : &:r467_1, r467_2
+#-----|   Goto -> Block 3
 
 #  467|   Block 3
-#  467|     r467_4(glval<bool>) = VariableAddress[b] : 
-#  467|     r467_5(bool)        = Load[b]            : &:r467_4, ~m?
-#  467|     v467_6(void)        = ConditionalBranch  : r467_5
-#-----|   False -> Block 4
-#-----|   True -> Block 5
+#  467|     r467_4(glval<bool>) = VariableAddress[#temp467:11] : 
+#  467|     r467_5(bool)        = Load[#temp467:11]            : &:r467_4, ~m?
+#  467|     r467_6(bool)        = LogicalNot                   : r467_5
+#  467|     v467_7(void)        = ConditionalBranch            : r467_6
+#-----|   False -> Block 8
+#-----|   True -> Block 7
 
-#  468|   Block 4
+#  467|   Block 4
+#  467|     r467_8(glval<bool>) = VariableAddress[#temp467:11] : 
+#  467|     r467_9(bool)        = Constant[1]                  : 
+#  467|     mu467_10(bool)      = Store[#temp467:11]           : &:r467_8, r467_9
+#-----|   Goto -> Block 3
+
+#  467|   Block 5
+#  467|     r467_11(glval<bool>) = VariableAddress[a] : 
+#  467|     r467_12(bool)        = Load[a]            : &:r467_11, ~m?
+#  467|     v467_13(void)        = ConditionalBranch  : r467_12
+#-----|   False -> Block 2
+#-----|   True -> Block 6
+
+#  467|   Block 6
+#  467|     r467_14(glval<bool>) = VariableAddress[b] : 
+#  467|     r467_15(bool)        = Load[b]            : &:r467_14, ~m?
+#  467|     v467_16(void)        = ConditionalBranch  : r467_15
+#-----|   False -> Block 2
+#-----|   True -> Block 4
+
+#  468|   Block 7
 #  468|     r468_1(int)        = Constant[2]        : 
 #  468|     r468_2(glval<int>) = VariableAddress[x] : 
 #  468|     mu468_3(int)       = Store[x]           : &:r468_2, r468_1
-#-----|   Goto -> Block 6
+#-----|   Goto -> Block 9
 
-#  471|   Block 5
+#  471|   Block 8
 #  471|     r471_1(int)        = Constant[3]        : 
 #  471|     r471_2(glval<int>) = VariableAddress[x] : 
 #  471|     mu471_3(int)       = Store[x]           : &:r471_2, r471_1
-#-----|   Goto -> Block 6
+#-----|   Goto -> Block 9
 
-#  473|   Block 6
+#  473|   Block 9
 #  473|     v473_1(void)  = NoOp         : 
 #  461|     v461_8(void)  = ReturnVoid   : 
 #  461|     v461_9(void)  = AliasedUse   : ~m?

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/ifs/ifs.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/ifs/ifs.expected
@@ -1,5 +1,4 @@
 edges
-| ifs.c:16:27:16:30 | argv indirection | ifs.c:50:9:50:10 | c5 indirection |
 | ifs.c:16:27:16:30 | argv indirection | ifs.c:62:9:62:10 | c7 indirection |
 | ifs.c:16:27:16:30 | argv indirection | ifs.c:69:9:69:10 | c8 indirection |
 | ifs.c:16:27:16:30 | argv indirection | ifs.c:75:9:75:10 | i1 indirection |
@@ -13,7 +12,6 @@ edges
 | ifs.c:16:27:16:30 | argv indirection | ifs.c:124:9:124:10 | i9 indirection |
 nodes
 | ifs.c:16:27:16:30 | argv indirection | semmle.label | argv indirection |
-| ifs.c:50:9:50:10 | c5 indirection | semmle.label | c5 indirection |
 | ifs.c:62:9:62:10 | c7 indirection | semmle.label | c7 indirection |
 | ifs.c:69:9:69:10 | c8 indirection | semmle.label | c8 indirection |
 | ifs.c:75:9:75:10 | i1 indirection | semmle.label | i1 indirection |
@@ -27,7 +25,6 @@ nodes
 | ifs.c:124:9:124:10 | i9 indirection | semmle.label | i9 indirection |
 subpaths
 #select
-| ifs.c:50:9:50:10 | c5 indirection | ifs.c:16:27:16:30 | argv indirection | ifs.c:50:9:50:10 | c5 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | argv indirection | a command-line argument |
 | ifs.c:62:9:62:10 | c7 indirection | ifs.c:16:27:16:30 | argv indirection | ifs.c:62:9:62:10 | c7 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | argv indirection | a command-line argument |
 | ifs.c:69:9:69:10 | c8 indirection | ifs.c:16:27:16:30 | argv indirection | ifs.c:69:9:69:10 | c8 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | argv indirection | a command-line argument |
 | ifs.c:75:9:75:10 | i1 indirection | ifs.c:16:27:16:30 | argv indirection | ifs.c:75:9:75:10 | i1 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | argv indirection | a command-line argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/ifs/ifs.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/ifs/ifs.expected
@@ -1,4 +1,5 @@
 edges
+| ifs.c:16:27:16:30 | argv indirection | ifs.c:50:9:50:10 | c5 indirection |
 | ifs.c:16:27:16:30 | argv indirection | ifs.c:62:9:62:10 | c7 indirection |
 | ifs.c:16:27:16:30 | argv indirection | ifs.c:69:9:69:10 | c8 indirection |
 | ifs.c:16:27:16:30 | argv indirection | ifs.c:75:9:75:10 | i1 indirection |
@@ -12,6 +13,7 @@ edges
 | ifs.c:16:27:16:30 | argv indirection | ifs.c:124:9:124:10 | i9 indirection |
 nodes
 | ifs.c:16:27:16:30 | argv indirection | semmle.label | argv indirection |
+| ifs.c:50:9:50:10 | c5 indirection | semmle.label | c5 indirection |
 | ifs.c:62:9:62:10 | c7 indirection | semmle.label | c7 indirection |
 | ifs.c:69:9:69:10 | c8 indirection | semmle.label | c8 indirection |
 | ifs.c:75:9:75:10 | i1 indirection | semmle.label | i1 indirection |
@@ -25,6 +27,7 @@ nodes
 | ifs.c:124:9:124:10 | i9 indirection | semmle.label | i9 indirection |
 subpaths
 #select
+| ifs.c:50:9:50:10 | c5 indirection | ifs.c:16:27:16:30 | argv indirection | ifs.c:50:9:50:10 | c5 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | argv indirection | a command-line argument |
 | ifs.c:62:9:62:10 | c7 indirection | ifs.c:16:27:16:30 | argv indirection | ifs.c:62:9:62:10 | c7 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | argv indirection | a command-line argument |
 | ifs.c:69:9:69:10 | c8 indirection | ifs.c:16:27:16:30 | argv indirection | ifs.c:69:9:69:10 | c8 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | argv indirection | a command-line argument |
 | ifs.c:75:9:75:10 | i1 indirection | ifs.c:16:27:16:30 | argv indirection | ifs.c:75:9:75:10 | i1 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | argv indirection | a command-line argument |


### PR DESCRIPTION
This PR changes IR generation negations in conditional branches to generate a `LogicalNot` instruction instead of swapping the branches. While swapping the branches is technically correct, it means that we don't always have an instruction (and hence: a dataflow node) that computes result of the conditional expression.

For example, on the following snippet:

```cpp
if(!b) {
  foo();
} else {
  bar();
}
```
we would generate:
```cpp
Block 0
  r4_5(glval<bool>) = VariableAddress[b]     :
  m4_6(bool)        = InitializeParameter[b] : &:r4_5
  r5_1(glval<bool>) = VariableAddress[b]     :
  r5_2(bool)        = Load[b]                : &:r5_1
  v5_3(void)        = ConditionalBranch      : r5_2
False -> Block 1
True -> Block 2

Block 1
  r6_1(glval<unknown>) = FunctionAddress[foo] :
  v6_2(void)           = Call[foo]            : func:r6_1
Goto -> Block 3

Block 2
  r8_1(glval<unknown>) = FunctionAddress[bar] :
  v8_2(void)           = Call[bar]            : func:r8_1
Goto -> Block 3

Block 3
  v10_2(void)    = NoOp         :
  v4_7(void)     = ReturnVoid   :
```

where the True, and False edges after Block 0 have been swapped to implement the negation. This meant that a dataflow query looking for flow to `!b` would not have a result.

After this PR we now generate:
```cpp
Block 0
  r4_5(glval<bool>) = VariableAddress[b]     :
  m4_6(bool)        = InitializeParameter[b] : &:r4_5
  r5_1(glval<bool>) = VariableAddress[b]     :
  r5_2(bool)        = Load[b]                : &:r5_1
  r5_3(bool)        = LogicalNot             : r5_2
  v5_4(void)        = ConditionalBranch      : r5_3
False -> Block 2
True -> Block 1

Block 1
  r6_1(glval<unknown>) = FunctionAddress[foo] :
  v6_2(void)           = Call[foo]            : func:r6_1
Goto -> Block 3

Block 2
  r8_1(glval<unknown>) = FunctionAddress[bar] :
  v8_2(void)           = Call[bar]            : func:r8_1
Goto -> Block 3

Block 3
  v10_2(void)    = NoOp         :
  v4_7(void)     = ReturnVoid   :
```
where we've now inserted a `LogicalNot` instruction whose `getUnconvertedResultExpression` is `!b`.

Commit-by-commit review recommended:

- The first commit changes IR generation
- The next commit simplifies `IRGuards` since we now have an instruction representing the negation
- The next commit accepts test changes. There is one regression in `cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/ifs/ifs.expected` caused by us no longer realizing that the true branch [here](https://github.com/github/codeql/blob/main/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/ifs/ifs.c#L48) is dead code. We deduced this before because there was no negation in the conditional before, and https://github.com/github/codeql/blob/main/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/reachability/ReachableBlock.qll#L5 was able to deduce that the code was dead.
- The next commit fixes the above regression by teaching the constant analysis about `LogicalNot` instructions