### PR TITLE
Kotlin: Add a 2.0.255 snapshot

### DIFF
--- a/java/kotlin-extractor/kotlin_plugin_versions.py
+++ b/java/kotlin-extractor/kotlin_plugin_versions.py
@@ -46,7 +46,7 @@ def version_string_to_version(version):
 # Version number used by CI.
 ci_version = '1.9.0'
 
-many_versions = [ '1.5.0', '1.5.10', '1.5.20', '1.5.30', '1.6.0', '1.6.20', '1.7.0', '1.7.20', '1.8.0', '1.9.0-Beta', '1.9.20-Beta', '2.0.0-Beta1' ]
+many_versions = [ '1.5.0', '1.5.10', '1.5.20', '1.5.30', '1.6.0', '1.6.20', '1.7.0', '1.7.20', '1.8.0', '1.9.0-Beta', '1.9.20-Beta', '2.0.0-Beta1', '2.0.255-SNAPSHOT' ]
 
 many_versions_versions = [version_string_to_version(v) for v in many_versions]
 many_versions_versions_asc  = sorted(many_versions_versions, key = lambda v: v.toTupleWithTag())

--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -6,7 +6,6 @@ import com.github.codeql.utils.*
 import com.github.codeql.utils.versions.*
 import com.semmle.extractor.java.OdasaOutput
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
-import org.jetbrains.kotlin.backend.common.lower.parents
 import org.jetbrains.kotlin.backend.common.pop
 import org.jetbrains.kotlin.builtins.functions.BuiltInFunctionArity
 import org.jetbrains.kotlin.config.JvmAnalysisFlags
@@ -43,6 +42,7 @@ import org.jetbrains.kotlin.ir.util.isSuspendFunctionOrKFunction
 import org.jetbrains.kotlin.ir.util.isVararg
 import org.jetbrains.kotlin.ir.util.kotlinFqName
 import org.jetbrains.kotlin.ir.util.packageFqName
+import org.jetbrains.kotlin.ir.util.parents
 import org.jetbrains.kotlin.ir.util.parentAsClass
 import org.jetbrains.kotlin.ir.util.parentClassOrNull
 import org.jetbrains.kotlin.ir.util.primaryConstructor

--- a/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
@@ -5,8 +5,6 @@ import com.github.codeql.utils.versions.*
 import com.semmle.extractor.java.OdasaOutput
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.ir.*
-import org.jetbrains.kotlin.backend.common.lower.parents
-import org.jetbrains.kotlin.backend.common.lower.parentsWithSelf
 import org.jetbrains.kotlin.backend.jvm.ir.propertyIfAccessor
 import org.jetbrains.kotlin.codegen.JvmCodegenUtil
 import org.jetbrains.kotlin.descriptors.*

--- a/java/kotlin-extractor/src/main/kotlin/utils/TypeSubstitution.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/TypeSubstitution.kt
@@ -6,7 +6,6 @@ import com.github.codeql.getJavaEquivalentClassId
 import com.github.codeql.utils.versions.codeQlWithHasQuestionMark
 import com.github.codeql.utils.versions.createImplicitParameterDeclarationWithWrappedDescriptor
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
-import org.jetbrains.kotlin.backend.common.lower.parents
 import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.ir.builders.declarations.addConstructor
 import org.jetbrains.kotlin.ir.builders.declarations.buildClass
@@ -27,6 +26,7 @@ import org.jetbrains.kotlin.ir.util.classId
 import org.jetbrains.kotlin.ir.util.constructedClassType
 import org.jetbrains.kotlin.ir.util.constructors
 import org.jetbrains.kotlin.ir.util.kotlinFqName
+import org.jetbrains.kotlin.ir.util.parents
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.types.Variance

--- a/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_5_0/parents.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_5_0/parents.kt
@@ -1,0 +1,13 @@
+
+package org.jetbrains.kotlin.ir.util
+
+import org.jetbrains.kotlin.backend.common.lower.parents as kParents
+import org.jetbrains.kotlin.backend.common.lower.parentsWithSelf as kParentsWithSelf
+import org.jetbrains.kotlin.ir.declarations.*
+
+val IrDeclaration.parents: Sequence<IrDeclarationParent>
+    get() = this.kParents
+
+val IrDeclaration.parentsWithSelf: Sequence<IrDeclarationParent>
+    get() = this.kParentsWithSelf
+

--- a/java/kotlin-extractor/src/main/kotlin/utils/versions/v_2_0_255-SNAPSHOT/parents.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/versions/v_2_0_255-SNAPSHOT/parents.kt
@@ -1,0 +1,1 @@
+// Nothing to do


### PR DESCRIPTION
The current master isn't compatible with the 2.0.0-Beta1