### PR TITLE
C++: Do not use `isReturnValue` in `getenv`, `gets`, and `fgets` models

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Getenv.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Getenv.qll
@@ -16,10 +16,7 @@ class Getenv extends LocalFlowSourceFunction {
   }
 
   override predicate hasLocalFlowSource(FunctionOutput output, string description) {
-    (
-      output.isReturnValueDeref() or
-      output.isReturnValue()
-    ) and
+    output.isReturnValueDeref() and
     description = "an environment variable"
   }
 }

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Gets.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Gets.qll
@@ -51,7 +51,6 @@ private class FgetsFunction extends DataFlowFunction, TaintFunction, ArrayFuncti
   override predicate hasRemoteFlowSource(FunctionOutput output, string description) {
     (
       output.isParameterDeref(0) or
-      output.isReturnValue() or
       output.isReturnValueDeref()
     ) and
     description = "string read by " + this.getName()
@@ -102,7 +101,6 @@ private class GetsFunction extends DataFlowFunction, ArrayFunction, AliasFunctio
   override predicate hasLocalFlowSource(FunctionOutput output, string description) {
     (
       output.isParameterDeref(0) or
-      output.isReturnValue() or
       output.isReturnValueDeref()
     ) and
     description = "string read by " + this.getName()

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-078/semmle/ExecTainted/ExecTainted.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-078/semmle/ExecTainted/ExecTainted.expected
@@ -14,18 +14,15 @@ edges
 | test.cpp:91:9:91:16 | fread output argument | test.cpp:93:17:93:24 | filename indirection |
 | test.cpp:93:11:93:14 | strncat output argument | test.cpp:94:45:94:48 | path indirection |
 | test.cpp:93:17:93:24 | filename indirection | test.cpp:93:11:93:14 | strncat output argument |
-| test.cpp:106:20:106:38 | call to getenv | test.cpp:107:33:107:36 | path indirection |
 | test.cpp:106:20:106:38 | call to getenv indirection | test.cpp:107:33:107:36 | path indirection |
 | test.cpp:107:31:107:31 | call to operator+ | test.cpp:108:18:108:22 | call to c_str indirection |
 | test.cpp:107:33:107:36 | path indirection | test.cpp:107:31:107:31 | call to operator+ |
-| test.cpp:113:20:113:38 | call to getenv | test.cpp:114:19:114:22 | path indirection |
 | test.cpp:113:20:113:38 | call to getenv indirection | test.cpp:114:19:114:22 | path indirection |
 | test.cpp:114:10:114:23 | call to operator+ | test.cpp:114:25:114:29 | call to c_str indirection |
 | test.cpp:114:10:114:23 | call to operator+ | test.cpp:114:25:114:29 | call to c_str indirection |
 | test.cpp:114:17:114:17 | call to operator+ | test.cpp:114:10:114:23 | call to operator+ |
 | test.cpp:114:19:114:22 | path indirection | test.cpp:114:10:114:23 | call to operator+ |
 | test.cpp:114:19:114:22 | path indirection | test.cpp:114:17:114:17 | call to operator+ |
-| test.cpp:119:20:119:38 | call to getenv | test.cpp:120:19:120:22 | path indirection |
 | test.cpp:119:20:119:38 | call to getenv indirection | test.cpp:120:19:120:22 | path indirection |
 | test.cpp:120:17:120:17 | call to operator+ | test.cpp:120:10:120:30 | call to data indirection |
 | test.cpp:120:19:120:22 | path indirection | test.cpp:120:17:120:17 | call to operator+ |
@@ -89,12 +86,10 @@ nodes
 | test.cpp:93:11:93:14 | strncat output argument | semmle.label | strncat output argument |
 | test.cpp:93:17:93:24 | filename indirection | semmle.label | filename indirection |
 | test.cpp:94:45:94:48 | path indirection | semmle.label | path indirection |
-| test.cpp:106:20:106:38 | call to getenv | semmle.label | call to getenv |
 | test.cpp:106:20:106:38 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:107:31:107:31 | call to operator+ | semmle.label | call to operator+ |
 | test.cpp:107:33:107:36 | path indirection | semmle.label | path indirection |
 | test.cpp:108:18:108:22 | call to c_str indirection | semmle.label | call to c_str indirection |
-| test.cpp:113:20:113:38 | call to getenv | semmle.label | call to getenv |
 | test.cpp:113:20:113:38 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:114:10:114:23 | call to operator+ | semmle.label | call to operator+ |
 | test.cpp:114:10:114:23 | call to operator+ | semmle.label | call to operator+ |
@@ -102,7 +97,6 @@ nodes
 | test.cpp:114:19:114:22 | path indirection | semmle.label | path indirection |
 | test.cpp:114:25:114:29 | call to c_str indirection | semmle.label | call to c_str indirection |
 | test.cpp:114:25:114:29 | call to c_str indirection | semmle.label | call to c_str indirection |
-| test.cpp:119:20:119:38 | call to getenv | semmle.label | call to getenv |
 | test.cpp:119:20:119:38 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:120:10:120:30 | call to data indirection | semmle.label | call to data indirection |
 | test.cpp:120:17:120:17 | call to operator+ | semmle.label | call to operator+ |
@@ -156,13 +150,9 @@ subpaths
 | test.cpp:65:10:65:16 | command | test.cpp:62:9:62:16 | fread output argument | test.cpp:65:10:65:16 | command indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:62:9:62:16 | fread output argument | user input (string read by fread) | test.cpp:64:11:64:17 | strncat output argument | strncat output argument |
 | test.cpp:85:32:85:38 | command | test.cpp:82:9:82:16 | fread output argument | test.cpp:85:32:85:38 | command indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl. | test.cpp:82:9:82:16 | fread output argument | user input (string read by fread) | test.cpp:84:11:84:17 | strncat output argument | strncat output argument |
 | test.cpp:94:45:94:48 | path | test.cpp:91:9:91:16 | fread output argument | test.cpp:94:45:94:48 | path indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl. | test.cpp:91:9:91:16 | fread output argument | user input (string read by fread) | test.cpp:93:11:93:14 | strncat output argument | strncat output argument |
-| test.cpp:108:18:108:22 | call to c_str | test.cpp:106:20:106:38 | call to getenv | test.cpp:108:18:108:22 | call to c_str indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:106:20:106:38 | call to getenv | user input (an environment variable) | test.cpp:107:31:107:31 | call to operator+ | call to operator+ |
 | test.cpp:108:18:108:22 | call to c_str | test.cpp:106:20:106:38 | call to getenv indirection | test.cpp:108:18:108:22 | call to c_str indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:106:20:106:38 | call to getenv indirection | user input (an environment variable) | test.cpp:107:31:107:31 | call to operator+ | call to operator+ |
-| test.cpp:114:25:114:29 | call to c_str | test.cpp:113:20:113:38 | call to getenv | test.cpp:114:25:114:29 | call to c_str indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:113:20:113:38 | call to getenv | user input (an environment variable) | test.cpp:114:10:114:23 | call to operator+ | call to operator+ |
-| test.cpp:114:25:114:29 | call to c_str | test.cpp:113:20:113:38 | call to getenv | test.cpp:114:25:114:29 | call to c_str indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:113:20:113:38 | call to getenv | user input (an environment variable) | test.cpp:114:17:114:17 | call to operator+ | call to operator+ |
 | test.cpp:114:25:114:29 | call to c_str | test.cpp:113:20:113:38 | call to getenv indirection | test.cpp:114:25:114:29 | call to c_str indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:113:20:113:38 | call to getenv indirection | user input (an environment variable) | test.cpp:114:10:114:23 | call to operator+ | call to operator+ |
 | test.cpp:114:25:114:29 | call to c_str | test.cpp:113:20:113:38 | call to getenv indirection | test.cpp:114:25:114:29 | call to c_str indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:113:20:113:38 | call to getenv indirection | user input (an environment variable) | test.cpp:114:17:114:17 | call to operator+ | call to operator+ |
-| test.cpp:120:25:120:28 | call to data | test.cpp:119:20:119:38 | call to getenv | test.cpp:120:10:120:30 | call to data indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:119:20:119:38 | call to getenv | user input (an environment variable) | test.cpp:120:17:120:17 | call to operator+ | call to operator+ |
 | test.cpp:120:25:120:28 | call to data | test.cpp:119:20:119:38 | call to getenv indirection | test.cpp:120:10:120:30 | call to data indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:119:20:119:38 | call to getenv indirection | user input (an environment variable) | test.cpp:120:17:120:17 | call to operator+ | call to operator+ |
 | test.cpp:143:10:143:16 | command | test.cpp:140:9:140:11 | fread output argument | test.cpp:143:10:143:16 | command indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:140:9:140:11 | fread output argument | user input (string read by fread) | test.cpp:142:11:142:17 | sprintf output argument | sprintf output argument |
 | test.cpp:183:32:183:38 | command | test.cpp:174:9:174:16 | fread output argument | test.cpp:183:32:183:38 | command indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl. | test.cpp:174:9:174:16 | fread output argument | user input (string read by fread) | test.cpp:177:13:177:17 | strncat output argument | strncat output argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
@@ -5,33 +5,22 @@ edges
 | test.cpp:39:27:39:30 | argv indirection | test.cpp:49:32:49:35 | size |
 | test.cpp:39:27:39:30 | argv indirection | test.cpp:50:17:50:30 | size |
 | test.cpp:39:27:39:30 | argv indirection | test.cpp:53:35:53:60 | ... * ... |
-| test.cpp:124:18:124:31 | call to getenv | test.cpp:128:24:128:41 | ... * ... |
 | test.cpp:124:18:124:31 | call to getenv indirection | test.cpp:128:24:128:41 | ... * ... |
-| test.cpp:133:19:133:32 | call to getenv | test.cpp:135:10:135:27 | ... * ... |
 | test.cpp:133:19:133:32 | call to getenv indirection | test.cpp:135:10:135:27 | ... * ... |
-| test.cpp:148:20:148:33 | call to getenv | test.cpp:152:11:152:28 | ... * ... |
 | test.cpp:148:20:148:33 | call to getenv indirection | test.cpp:152:11:152:28 | ... * ... |
 | test.cpp:209:8:209:23 | get_tainted_size indirection | test.cpp:241:9:241:24 | call to get_tainted_size |
-| test.cpp:211:14:211:27 | call to getenv | test.cpp:209:8:209:23 | get_tainted_size indirection |
 | test.cpp:211:14:211:27 | call to getenv indirection | test.cpp:209:8:209:23 | get_tainted_size indirection |
 | test.cpp:230:21:230:21 | s | test.cpp:231:21:231:21 | s |
-| test.cpp:237:24:237:37 | call to getenv | test.cpp:239:9:239:18 | local_size |
-| test.cpp:237:24:237:37 | call to getenv | test.cpp:245:11:245:20 | local_size |
-| test.cpp:237:24:237:37 | call to getenv | test.cpp:247:10:247:19 | local_size |
 | test.cpp:237:24:237:37 | call to getenv indirection | test.cpp:239:9:239:18 | local_size |
 | test.cpp:237:24:237:37 | call to getenv indirection | test.cpp:245:11:245:20 | local_size |
 | test.cpp:237:24:237:37 | call to getenv indirection | test.cpp:247:10:247:19 | local_size |
 | test.cpp:247:10:247:19 | local_size | test.cpp:230:21:230:21 | s |
 | test.cpp:250:20:250:27 | out_size | test.cpp:289:17:289:20 | get_size output argument |
 | test.cpp:250:20:250:27 | out_size | test.cpp:305:18:305:21 | get_size output argument |
-| test.cpp:251:18:251:31 | call to getenv | test.cpp:250:20:250:27 | out_size |
 | test.cpp:251:18:251:31 | call to getenv indirection | test.cpp:250:20:250:27 | out_size |
-| test.cpp:259:20:259:33 | call to getenv | test.cpp:263:11:263:29 | ... * ... |
 | test.cpp:259:20:259:33 | call to getenv indirection | test.cpp:263:11:263:29 | ... * ... |
 | test.cpp:289:17:289:20 | get_size output argument | test.cpp:291:11:291:28 | ... * ... |
 | test.cpp:305:18:305:21 | get_size output argument | test.cpp:308:10:308:27 | ... * ... |
-| test.cpp:353:18:353:31 | call to getenv | test.cpp:355:35:355:38 | size |
-| test.cpp:353:18:353:31 | call to getenv | test.cpp:356:35:356:38 | size |
 | test.cpp:353:18:353:31 | call to getenv indirection | test.cpp:355:35:355:38 | size |
 | test.cpp:353:18:353:31 | call to getenv indirection | test.cpp:356:35:356:38 | size |
 nodes
@@ -42,37 +31,29 @@ nodes
 | test.cpp:49:32:49:35 | size | semmle.label | size |
 | test.cpp:50:17:50:30 | size | semmle.label | size |
 | test.cpp:53:35:53:60 | ... * ... | semmle.label | ... * ... |
-| test.cpp:124:18:124:31 | call to getenv | semmle.label | call to getenv |
 | test.cpp:124:18:124:31 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:128:24:128:41 | ... * ... | semmle.label | ... * ... |
-| test.cpp:133:19:133:32 | call to getenv | semmle.label | call to getenv |
 | test.cpp:133:19:133:32 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:135:10:135:27 | ... * ... | semmle.label | ... * ... |
-| test.cpp:148:20:148:33 | call to getenv | semmle.label | call to getenv |
 | test.cpp:148:20:148:33 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:152:11:152:28 | ... * ... | semmle.label | ... * ... |
 | test.cpp:209:8:209:23 | get_tainted_size indirection | semmle.label | get_tainted_size indirection |
-| test.cpp:211:14:211:27 | call to getenv | semmle.label | call to getenv |
 | test.cpp:211:14:211:27 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:230:21:230:21 | s | semmle.label | s |
 | test.cpp:231:21:231:21 | s | semmle.label | s |
-| test.cpp:237:24:237:37 | call to getenv | semmle.label | call to getenv |
 | test.cpp:237:24:237:37 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:239:9:239:18 | local_size | semmle.label | local_size |
 | test.cpp:241:9:241:24 | call to get_tainted_size | semmle.label | call to get_tainted_size |
 | test.cpp:245:11:245:20 | local_size | semmle.label | local_size |
 | test.cpp:247:10:247:19 | local_size | semmle.label | local_size |
 | test.cpp:250:20:250:27 | out_size | semmle.label | out_size |
-| test.cpp:251:18:251:31 | call to getenv | semmle.label | call to getenv |
 | test.cpp:251:18:251:31 | call to getenv indirection | semmle.label | call to getenv indirection |
-| test.cpp:259:20:259:33 | call to getenv | semmle.label | call to getenv |
 | test.cpp:259:20:259:33 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:263:11:263:29 | ... * ... | semmle.label | ... * ... |
 | test.cpp:289:17:289:20 | get_size output argument | semmle.label | get_size output argument |
 | test.cpp:291:11:291:28 | ... * ... | semmle.label | ... * ... |
 | test.cpp:305:18:305:21 | get_size output argument | semmle.label | get_size output argument |
 | test.cpp:308:10:308:27 | ... * ... | semmle.label | ... * ... |
-| test.cpp:353:18:353:31 | call to getenv | semmle.label | call to getenv |
 | test.cpp:353:18:353:31 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:355:35:355:38 | size | semmle.label | size |
 | test.cpp:356:35:356:38 | size | semmle.label | size |
@@ -84,27 +65,15 @@ subpaths
 | test.cpp:49:25:49:30 | call to malloc | test.cpp:39:27:39:30 | argv indirection | test.cpp:49:32:49:35 | size | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | argv indirection | user input (a command-line argument) |
 | test.cpp:50:17:50:30 | new[] | test.cpp:39:27:39:30 | argv indirection | test.cpp:50:17:50:30 | size | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | argv indirection | user input (a command-line argument) |
 | test.cpp:53:21:53:27 | call to realloc | test.cpp:39:27:39:30 | argv indirection | test.cpp:53:35:53:60 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | argv indirection | user input (a command-line argument) |
-| test.cpp:128:17:128:22 | call to malloc | test.cpp:124:18:124:31 | call to getenv | test.cpp:128:24:128:41 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:124:18:124:31 | call to getenv | user input (an environment variable) |
 | test.cpp:128:17:128:22 | call to malloc | test.cpp:124:18:124:31 | call to getenv indirection | test.cpp:128:24:128:41 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:124:18:124:31 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:135:3:135:8 | call to malloc | test.cpp:133:19:133:32 | call to getenv | test.cpp:135:10:135:27 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:133:19:133:32 | call to getenv | user input (an environment variable) |
 | test.cpp:135:3:135:8 | call to malloc | test.cpp:133:19:133:32 | call to getenv indirection | test.cpp:135:10:135:27 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:133:19:133:32 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:152:4:152:9 | call to malloc | test.cpp:148:20:148:33 | call to getenv | test.cpp:152:11:152:28 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:148:20:148:33 | call to getenv | user input (an environment variable) |
 | test.cpp:152:4:152:9 | call to malloc | test.cpp:148:20:148:33 | call to getenv indirection | test.cpp:152:11:152:28 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:148:20:148:33 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:231:14:231:19 | call to malloc | test.cpp:237:24:237:37 | call to getenv | test.cpp:231:21:231:21 | s | This allocation size is derived from $@ and might overflow. | test.cpp:237:24:237:37 | call to getenv | user input (an environment variable) |
 | test.cpp:231:14:231:19 | call to malloc | test.cpp:237:24:237:37 | call to getenv indirection | test.cpp:231:21:231:21 | s | This allocation size is derived from $@ and might overflow. | test.cpp:237:24:237:37 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:239:2:239:7 | call to malloc | test.cpp:237:24:237:37 | call to getenv | test.cpp:239:9:239:18 | local_size | This allocation size is derived from $@ and might overflow. | test.cpp:237:24:237:37 | call to getenv | user input (an environment variable) |
 | test.cpp:239:2:239:7 | call to malloc | test.cpp:237:24:237:37 | call to getenv indirection | test.cpp:239:9:239:18 | local_size | This allocation size is derived from $@ and might overflow. | test.cpp:237:24:237:37 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:241:2:241:7 | call to malloc | test.cpp:211:14:211:27 | call to getenv | test.cpp:241:9:241:24 | call to get_tainted_size | This allocation size is derived from $@ and might overflow. | test.cpp:211:14:211:27 | call to getenv | user input (an environment variable) |
 | test.cpp:241:2:241:7 | call to malloc | test.cpp:211:14:211:27 | call to getenv indirection | test.cpp:241:9:241:24 | call to get_tainted_size | This allocation size is derived from $@ and might overflow. | test.cpp:211:14:211:27 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:245:2:245:9 | call to my_alloc | test.cpp:237:24:237:37 | call to getenv | test.cpp:245:11:245:20 | local_size | This allocation size is derived from $@ and might overflow. | test.cpp:237:24:237:37 | call to getenv | user input (an environment variable) |
 | test.cpp:245:2:245:9 | call to my_alloc | test.cpp:237:24:237:37 | call to getenv indirection | test.cpp:245:11:245:20 | local_size | This allocation size is derived from $@ and might overflow. | test.cpp:237:24:237:37 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:263:4:263:9 | call to malloc | test.cpp:259:20:259:33 | call to getenv | test.cpp:263:11:263:29 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:259:20:259:33 | call to getenv | user input (an environment variable) |
 | test.cpp:263:4:263:9 | call to malloc | test.cpp:259:20:259:33 | call to getenv indirection | test.cpp:263:11:263:29 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:259:20:259:33 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:291:4:291:9 | call to malloc | test.cpp:251:18:251:31 | call to getenv | test.cpp:291:11:291:28 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:251:18:251:31 | call to getenv | user input (an environment variable) |
 | test.cpp:291:4:291:9 | call to malloc | test.cpp:251:18:251:31 | call to getenv indirection | test.cpp:291:11:291:28 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:251:18:251:31 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:308:3:308:8 | call to malloc | test.cpp:251:18:251:31 | call to getenv | test.cpp:308:10:308:27 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:251:18:251:31 | call to getenv | user input (an environment variable) |
 | test.cpp:308:3:308:8 | call to malloc | test.cpp:251:18:251:31 | call to getenv indirection | test.cpp:308:10:308:27 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:251:18:251:31 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:355:25:355:33 | call to MyMalloc1 | test.cpp:353:18:353:31 | call to getenv | test.cpp:355:35:355:38 | size | This allocation size is derived from $@ and might overflow. | test.cpp:353:18:353:31 | call to getenv | user input (an environment variable) |
 | test.cpp:355:25:355:33 | call to MyMalloc1 | test.cpp:353:18:353:31 | call to getenv indirection | test.cpp:355:35:355:38 | size | This allocation size is derived from $@ and might overflow. | test.cpp:353:18:353:31 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:356:25:356:33 | call to MyMalloc2 | test.cpp:353:18:353:31 | call to getenv | test.cpp:356:35:356:38 | size | This allocation size is derived from $@ and might overflow. | test.cpp:353:18:353:31 | call to getenv | user input (an environment variable) |
 | test.cpp:356:25:356:33 | call to MyMalloc2 | test.cpp:353:18:353:31 | call to getenv indirection | test.cpp:356:35:356:38 | size | This allocation size is derived from $@ and might overflow. | test.cpp:353:18:353:31 | call to getenv indirection | user input (an environment variable) |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-807/semmle/TaintedCondition/TaintedCondition.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-807/semmle/TaintedCondition/TaintedCondition.expected
@@ -1,11 +1,8 @@
 edges
-| test.cpp:20:29:20:47 | call to getenv | test.cpp:24:10:24:35 | ! ... |
 | test.cpp:20:29:20:47 | call to getenv indirection | test.cpp:24:10:24:35 | ! ... |
 nodes
-| test.cpp:20:29:20:47 | call to getenv | semmle.label | call to getenv |
 | test.cpp:20:29:20:47 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:24:10:24:35 | ! ... | semmle.label | ! ... |
 subpaths
 #select
-| test.cpp:24:10:24:35 | ! ... | test.cpp:20:29:20:47 | call to getenv | test.cpp:24:10:24:35 | ! ... | Reliance on $@ to raise privilege at $@. | test.cpp:20:29:20:47 | call to getenv | an environment variable | test.cpp:25:9:25:27 | ... = ... | ... = ... |
 | test.cpp:24:10:24:35 | ! ... | test.cpp:20:29:20:47 | call to getenv indirection | test.cpp:24:10:24:35 | ! ... | Reliance on $@ to raise privilege at $@. | test.cpp:20:29:20:47 | call to getenv indirection | an environment variable | test.cpp:25:9:25:27 | ... = ... | ... = ... |


### PR DESCRIPTION
All disappearing DCA results look ok (I spot checked the systemd ones), and follow the pattern:
```cpp
x = getenv(...);
strcpy(y, x);
strcpy(z, y);
```
Before we got flow to the second strcpy, because we were looking at x directly, and not its indirection.