### PR TITLE
C++: Add Taint through int -> bool casts

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/TaintTrackingUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/TaintTrackingUtil.qll
@@ -72,6 +72,16 @@ private predicate operandToInstructionTaintStep(Operand opFrom, Instruction inst
     or
     instrTo.(FieldAddressInstruction).getField().getDeclaringType() instanceof Union
   )
+  or
+  // Taint from int to boolean casts. This ensures that we have flow to `!x` in:
+  // ```cpp
+  // x = integer_source();
+  // if(!x) { ... }
+  // ```
+  exists(Operand zero |
+    zero.getDef().(ConstantValueInstruction).getValue() = "0" and
+    instrTo.(CompareNEInstruction).hasOperands(opFrom, zero)
+  )
 }
 
 /**

--- a/cpp/ql/src/Security/CWE/CWE-807/TaintedCondition.ql
+++ b/cpp/ql/src/Security/CWE/CWE-807/TaintedCondition.ql
@@ -19,16 +19,10 @@ import semmle.code.cpp.ir.dataflow.TaintTracking
 import semmle.code.cpp.ir.IR
 import Flow::PathGraph
 
-Expr getExprWithoutNot(Expr expr) {
-  result = expr and not expr instanceof NotExpr
-  or
-  result = getExprWithoutNot(expr.(NotExpr).getOperand()) and expr instanceof NotExpr
-}
-
 predicate sensitiveCondition(Expr condition, Expr raise) {
   raisesPrivilege(raise) and
   exists(IfStmt ifstmt |
-    getExprWithoutNot(ifstmt.getCondition()) = condition and
+    ifstmt.getCondition() = condition and
     raise.getEnclosingStmt().getParentStmt*() = ifstmt
   )
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-807/semmle/TaintedCondition/TaintedCondition.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-807/semmle/TaintedCondition/TaintedCondition.expected
@@ -1,11 +1,11 @@
 edges
-| test.cpp:20:29:20:47 | call to getenv | test.cpp:24:11:24:16 | call to strcmp |
-| test.cpp:20:29:20:47 | call to getenv indirection | test.cpp:24:11:24:16 | call to strcmp |
+| test.cpp:20:29:20:47 | call to getenv | test.cpp:24:10:24:35 | ! ... |
+| test.cpp:20:29:20:47 | call to getenv indirection | test.cpp:24:10:24:35 | ! ... |
 nodes
 | test.cpp:20:29:20:47 | call to getenv | semmle.label | call to getenv |
 | test.cpp:20:29:20:47 | call to getenv indirection | semmle.label | call to getenv indirection |
-| test.cpp:24:11:24:16 | call to strcmp | semmle.label | call to strcmp |
+| test.cpp:24:10:24:35 | ! ... | semmle.label | ! ... |
 subpaths
 #select
-| test.cpp:24:11:24:16 | call to strcmp | test.cpp:20:29:20:47 | call to getenv | test.cpp:24:11:24:16 | call to strcmp | Reliance on $@ to raise privilege at $@. | test.cpp:20:29:20:47 | call to getenv | an environment variable | test.cpp:25:9:25:27 | ... = ... | ... = ... |
-| test.cpp:24:11:24:16 | call to strcmp | test.cpp:20:29:20:47 | call to getenv indirection | test.cpp:24:11:24:16 | call to strcmp | Reliance on $@ to raise privilege at $@. | test.cpp:20:29:20:47 | call to getenv indirection | an environment variable | test.cpp:25:9:25:27 | ... = ... | ... = ... |
+| test.cpp:24:10:24:35 | ! ... | test.cpp:20:29:20:47 | call to getenv | test.cpp:24:10:24:35 | ! ... | Reliance on $@ to raise privilege at $@. | test.cpp:20:29:20:47 | call to getenv | an environment variable | test.cpp:25:9:25:27 | ... = ... | ... = ... |
+| test.cpp:24:10:24:35 | ! ... | test.cpp:20:29:20:47 | call to getenv indirection | test.cpp:24:10:24:35 | ! ... | Reliance on $@ to raise privilege at $@. | test.cpp:20:29:20:47 | call to getenv indirection | an environment variable | test.cpp:25:9:25:27 | ... = ... | ... = ... |


### PR DESCRIPTION
The final step in undoing the workaround in https://github.com/github/codeql/pull/14886/files#diff-40e2016a464c1cf96ccb2a7469f1d6d2da1768ab2f355c8beb3bd0050ecd6a18R31 we add taint-flow through the implicit integer to boolean cast generated in a snippet such as:
```cpp
int x = some_int();
if(!x) { ... }
```
This is necessary because we generate IR that's equivalent to:
```cpp
int x = some_int();
if(!(x != 0)) { ... }
```

and since we already have taint-flow from `x` to `!x`, the additional taint from `x` to `x != 0` ensures that we get flow to the result of the condition.