### PR TITLE
C++: Don't exclude `ExprNode`s as sources

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-114/UncontrolledProcessOperation.ql
+++ b/cpp/ql/src/Security/CWE/CWE-114/UncontrolledProcessOperation.ql
@@ -27,10 +27,7 @@ predicate isProcessOperationExplanation(DataFlow::Node arg, string processOperat
   )
 }
 
-predicate isSource(FlowSource source, string sourceType) {
-  not source instanceof DataFlow::ExprNode and
-  sourceType = source.getSourceType()
-}
+predicate isSource(FlowSource source, string sourceType) { sourceType = source.getSourceType() }
 
 module Config implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node node) { isSource(node, _) }

--- a/cpp/ql/src/Security/CWE/CWE-134/UncontrolledFormatString.ql
+++ b/cpp/ql/src/Security/CWE/CWE-134/UncontrolledFormatString.ql
@@ -21,10 +21,7 @@ import semmle.code.cpp.ir.dataflow.TaintTracking
 import semmle.code.cpp.ir.IR
 import Flow::PathGraph
 
-predicate isSource(FlowSource source, string sourceType) {
-  not source instanceof DataFlow::ExprNode and
-  sourceType = source.getSourceType()
-}
+predicate isSource(FlowSource source, string sourceType) { sourceType = source.getSourceType() }
 
 module Config implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node node) { isSource(node, _) }

--- a/cpp/ql/src/Security/CWE/CWE-290/AuthenticationBypass.ql
+++ b/cpp/ql/src/Security/CWE/CWE-290/AuthenticationBypass.ql
@@ -62,9 +62,7 @@ predicate hardCodedAddressInCondition(Expr subexpression, Expr condition) {
   condition = any(IfStmt ifStmt).getCondition()
 }
 
-predicate isSource(FS::FlowSource source, string sourceType) {
-  source.getSourceType() = sourceType and not source instanceof DataFlow::ExprNode
-}
+predicate isSource(FS::FlowSource source, string sourceType) { source.getSourceType() = sourceType }
 
 predicate isSink(DataFlow::Node sink, Expr condition) {
   hardCodedAddressInCondition([sink.asExpr(), sink.asIndirectExpr()], condition)


### PR DESCRIPTION
This should not be needed anymore now that #14903 is merged 🤞