### PR TITLE
Java: add Spring models

### DIFF
--- a/java/ql/lib/change-notes/2023-11-29-new-spring-models.md
+++ b/java/ql/lib/change-notes/2023-11-29-new-spring-models.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+* Added a sink model for the `createRelative` method of the `org.springframework.core.io.Resource` interface.
+* Added source models for methods of the `org.springframework.web.util.UrlPathHelper` class and removed their taint flow models.

--- a/java/ql/lib/ext/org.springframework.cloud.config.server.environment.model.yml
+++ b/java/ql/lib/ext/org.springframework.cloud.config.server.environment.model.yml
@@ -1,7 +1,0 @@
-extensions:
-  - addsTo:
-      pack: codeql/java-all
-      extensible: summaryModel
-    data:
-      - ["org.springframework.cloud.config.server.environment", "SearchPathLocator", True, "getLocations", "(String,String,String)", "", "Argument[0..2]", "ReturnValue", "taint", "manual"]
-      - ["org.springframework.cloud.config.server.environment", "SearchPathLocator$Locations", True, "getLocations", "()", "", "Argument[this]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/org.springframework.cloud.config.server.environment.model.yml
+++ b/java/ql/lib/ext/org.springframework.cloud.config.server.environment.model.yml
@@ -1,0 +1,7 @@
+extensions:
+  - addsTo:
+      pack: codeql/java-all
+      extensible: summaryModel
+    data:
+      - ["org.springframework.cloud.config.server.environment", "SearchPathLocator", True, "getLocations", "(String,String,String)", "", "Argument[0..2]", "ReturnValue", "taint", "manual"]
+      - ["org.springframework.cloud.config.server.environment", "SearchPathLocator$Locations", True, "getLocations", "()", "", "Argument[this]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/org.springframework.core.io.model.yml
+++ b/java/ql/lib/ext/org.springframework.core.io.model.yml
@@ -3,5 +3,6 @@ extensions:
       pack: codeql/java-all
       extensible: sinkModel
     data:
+      - ["org.springframework.core.io", "Resource", True, "createRelative", "(String)", "", "Argument[0]", "path-injection", "manual"]
       - ["org.springframework.core.io", "ResourceLoader", True, "getResource", "(String)", "", "Argument[0]", "path-injection", "ai-manual"]
       - ["org.springframework.core.io", "ResourceLoader", True, "getResource", "(String)", "", "Argument[0]", "request-forgery", "manual"]

--- a/java/ql/lib/ext/org.springframework.web.util.model.yml
+++ b/java/ql/lib/ext/org.springframework.web.util.model.yml
@@ -1,6 +1,20 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
+      extensible: sourceModel
+    data:
+      - ["org.springframework.web.util", "UrlPathHelper", False, "getLookupPathForRequest", "", "", "ReturnValue", "remote", "manual"]
+      - ["org.springframework.web.util", "UrlPathHelper", False, "getOriginatingQueryString", "", "", "ReturnValue", "remote", "manual"]
+      - ["org.springframework.web.util", "UrlPathHelper", False, "getOriginatingRequestUri", "", "", "ReturnValue", "remote", "manual"]
+      - ["org.springframework.web.util", "UrlPathHelper", False, "getPathWithinApplication", "", "", "ReturnValue", "remote", "manual"]
+      - ["org.springframework.web.util", "UrlPathHelper", False, "getPathWithinServletMapping", "", "", "ReturnValue", "remote", "manual"]
+      - ["org.springframework.web.util", "UrlPathHelper", False, "getRequestUri", "", "", "ReturnValue", "remote", "manual"]
+      - ["org.springframework.web.util", "UrlPathHelper", False, "getResolvedLookupPath", "", "", "ReturnValue", "remote", "manual"]
+      - ["org.springframework.web.util", "UrlPathHelper", False, "getServletPath", "", "", "ReturnValue", "remote", "manual"]
+      - ["org.springframework.web.util", "UrlPathHelper", False, "resolveAndCacheLookupPath", "", "", "ReturnValue", "remote", "manual"]
+
+  - addsTo:
+      pack: codeql/java-all
       extensible: summaryModel
     data:
       - ["org.springframework.web.util", "AbstractUriTemplateHandler", True, "getBaseUrl", "", "", "Argument[this]", "ReturnValue", "taint", "manual"]
@@ -147,15 +161,7 @@ extensions:
       - ["org.springframework.web.util", "UrlPathHelper", False, "decodeRequestString", "", "", "Argument[1]", "ReturnValue", "taint", "manual"]
       - ["org.springframework.web.util", "UrlPathHelper", False, "getContextPath", "", "", "Argument[0]", "ReturnValue", "taint", "manual"]
       - ["org.springframework.web.util", "UrlPathHelper", False, "getOriginatingContextPath", "", "", "Argument[0]", "ReturnValue", "taint", "manual"]
-      - ["org.springframework.web.util", "UrlPathHelper", False, "getOriginatingQueryString", "", "", "Argument[0]", "ReturnValue", "taint", "manual"]
-      - ["org.springframework.web.util", "UrlPathHelper", False, "getOriginatingRequestUri", "", "", "Argument[0]", "ReturnValue", "taint", "manual"]
-      - ["org.springframework.web.util", "UrlPathHelper", False, "getPathWithinApplication", "", "", "Argument[0]", "ReturnValue", "taint", "manual"]
-      - ["org.springframework.web.util", "UrlPathHelper", False, "getPathWithinServletMapping", "", "", "Argument[0]", "ReturnValue", "taint", "manual"]
-      - ["org.springframework.web.util", "UrlPathHelper", False, "getRequestUri", "", "", "Argument[0]", "ReturnValue", "taint", "manual"]
-      - ["org.springframework.web.util", "UrlPathHelper", False, "getResolvedLookupPath", "", "", "Argument[0]", "ReturnValue", "taint", "manual"]
-      - ["org.springframework.web.util", "UrlPathHelper", False, "getServletPath", "", "", "Argument[0]", "ReturnValue", "taint", "manual"]
       - ["org.springframework.web.util", "UrlPathHelper", False, "removeSemicolonContent", "", "", "Argument[0]", "ReturnValue", "taint", "manual"]
-      - ["org.springframework.web.util", "UrlPathHelper", False, "resolveAndCacheLookupPath", "", "", "Argument[0]", "ReturnValue", "taint", "manual"]
       - ["org.springframework.web.util", "WebUtils", False, "findParameterValue", "(Map,String)", "", "Argument[0].MapValue", "ReturnValue", "value", "manual"]
       - ["org.springframework.web.util", "WebUtils", False, "findParameterValue", "(ServletRequest,String)", "", "Argument[0]", "ReturnValue", "taint", "manual"]
       - ["org.springframework.web.util", "WebUtils", False, "getCookie", "", "", "Argument[0]", "ReturnValue", "taint", "manual"]

--- a/java/ql/test/library-tests/frameworks/spring/webutil/Test.java
+++ b/java/ql/test/library-tests/frameworks/spring/webutil/Test.java
@@ -2397,58 +2397,11 @@ public class Test {
 			sink(out); // $hasTaintFlow
 		}
 		{
-			// "org.springframework.web.util;UrlPathHelper;false;getOriginatingQueryString;;;Argument[0];ReturnValue;taint;manual"
-			String out = null;
-			HttpServletRequest in = (HttpServletRequest)source();
-			UrlPathHelper instance = null;
-			out = instance.getOriginatingQueryString(in);
-			sink(out); // $hasTaintFlow
-		}
-		{
-			// "org.springframework.web.util;UrlPathHelper;false;getOriginatingRequestUri;;;Argument[0];ReturnValue;taint;manual"
-			String out = null;
-			HttpServletRequest in = (HttpServletRequest)source();
-			UrlPathHelper instance = null;
-			out = instance.getOriginatingRequestUri(in);
-			sink(out); // $hasTaintFlow
-		}
-		{
-			// "org.springframework.web.util;UrlPathHelper;false;getRequestUri;;;Argument[0];ReturnValue;taint;manual"
-			String out = null;
-			HttpServletRequest in = (HttpServletRequest)source();
-			UrlPathHelper instance = null;
-			out = instance.getRequestUri(in);
-			sink(out); // $hasTaintFlow
-		}
-		{
-			// "org.springframework.web.util;UrlPathHelper;false;getResolvedLookupPath;;;Argument[0];ReturnValue;taint;manual"
-			String out = null;
-			ServletRequest in = (ServletRequest)source();
-			out = UrlPathHelper.getResolvedLookupPath(in);
-			sink(out); // $hasTaintFlow
-		}
-		{
-			// "org.springframework.web.util;UrlPathHelper;false;getServletPath;;;Argument[0];ReturnValue;taint;manual"
-			String out = null;
-			HttpServletRequest in = (HttpServletRequest)source();
-			UrlPathHelper instance = null;
-			out = instance.getServletPath(in);
-			sink(out); // $hasTaintFlow
-		}
-		{
 			// "org.springframework.web.util;UrlPathHelper;false;removeSemicolonContent;;;Argument[0];ReturnValue;taint;manual"
 			String out = null;
 			String in = (String)source();
 			UrlPathHelper instance = null;
 			out = instance.removeSemicolonContent(in);
-			sink(out); // $hasTaintFlow
-		}
-		{
-			// "org.springframework.web.util;UrlPathHelper;false;resolveAndCacheLookupPath;;;Argument[0];ReturnValue;taint;manual"
-			String out = null;
-			HttpServletRequest in = (HttpServletRequest)source();
-			UrlPathHelper instance = null;
-			out = instance.resolveAndCacheLookupPath(in);
 			sink(out); // $hasTaintFlow
 		}
 		{
@@ -2603,22 +2556,6 @@ public class Test {
 			String out = null;
 			UriTemplate in = (UriTemplate)source();
 			out = in.toString();
-			sink(out); // $ hasTaintFlow
-		}
-		{
-			// "org.springframework.web.util;UrlPathHelper;false;getPathWithinApplication;;;Argument[0];ReturnValue;taint;manual"
-			String out = null;
-			HttpServletRequest in = (HttpServletRequest)source();
-			UrlPathHelper instance = null;
-			out = instance.getPathWithinApplication(in);
-			sink(out); // $ hasTaintFlow
-		}
-		{
-			// "org.springframework.web.util;UrlPathHelper;false;getPathWithinServletMapping;;;Argument[0];ReturnValue;taint;manual"
-			String out = null;
-			HttpServletRequest in = (HttpServletRequest)source();
-			UrlPathHelper instance = null;
-			out = instance.getPathWithinServletMapping(in);
 			sink(out); // $ hasTaintFlow
 		}
 		{


### PR DESCRIPTION
This PR adds a `path-injection` sink for `org.springframework.core.io.Resource#createRelative(String)` and a source for `org.springframework.web.util.UrlPathHelper#getPathWithinApplication` in order to cover CVE-2019-3799.

Additional `UrlPathHelper` sources are also added and their existing taint steps are removed. Let me know if anything looks wrong with these changes.