### PR TITLE
JS: Add django template urls as "save urls"

### DIFF
--- a/javascript/ql/src/DOM/TargetBlank.ql
+++ b/javascript/ql/src/DOM/TargetBlank.ql
@@ -44,7 +44,9 @@ predicate hasDynamicHrefHostAttributeValue(DOM::ElementDefinition elem) {
       // ... that does not start with a fixed host or a relative path (common formats)
       not url.regexpMatch("(?i)((https?:)?//)?[-a-z0-9.]*/.*") and
       // .. that is not a call to `url_for` in a Flask / nunjucks application
-      not url.regexpMatch("\\{\\{\\s*url(_for)?\\(.+\\).*")
+      not url.regexpMatch("\\{\\{\\s*url(_for)?\\(.+\\).*") and
+      // .. that is not a call to `url` in a Django application
+      not url.regexpMatch("\\{%\\s*url.*")
     )
   )
 }

--- a/javascript/ql/src/change-notes/2023-11-28-django-urls.md
+++ b/javascript/ql/src/change-notes/2023-11-28-django-urls.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added django URLs to detected "safe" URL patterns beside flask and nunjucks

--- a/javascript/ql/src/change-notes/2023-11-28-django-urls.md
+++ b/javascript/ql/src/change-notes/2023-11-28-django-urls.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* Added django URLs to detected "safe" URL patterns beside flask and nunjucks
+* Added django URLs to detected "safe" URL patterns in `js/unsafe-external-link`. 

--- a/javascript/ql/test/query-tests/DOM/TargetBlank/tst.js
+++ b/javascript/ql/test/query-tests/DOM/TargetBlank/tst.js
@@ -65,4 +65,7 @@ function f() {
 <a href="{{ 	url_for('foo.html', 'foo')}}" target="_blank">Example</a>;
 
 // OK, nunjucks template
-<a href="{{ url('foo', query={bla}) }}" target="_blank">Example</a>
+<a href="{{ url('foo', query={bla}) }}" target="_blank">Example</a>;
+
+// OK, Django application with internal links
+<a href="{% url 'admin:auth_user_changelist' %}" target="_blank">Example</a>


### PR DESCRIPTION

Django URLs are currently not detected, but flask and nunjucks URL are.

This fixes https://github.com/github/codeql/issues/12267. See the issue for more information.