### PR TITLE
Docs: List Python 3.12 as supported

### DIFF
--- a/docs/codeql/reusables/supported-versions-compilers.rst
+++ b/docs/codeql/reusables/supported-versions-compilers.rst
@@ -22,7 +22,7 @@
    Eclipse compiler for Java (ECJ) [5]_",``.java``
    Kotlin [6]_,"Kotlin 1.5.0 to 1.9.20","kotlinc",``.kt``
    JavaScript,ECMAScript 2022 or lower,Not applicable,"``.js``, ``.jsx``, ``.mjs``, ``.es``, ``.es6``, ``.htm``, ``.html``, ``.xhtm``, ``.xhtml``, ``.vue``, ``.hbs``, ``.ejs``, ``.njk``, ``.json``, ``.yaml``, ``.yml``, ``.raml``, ``.xml`` [7]_"
-   Python [8]_,"2.7, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11",Not applicable,``.py``
+   Python [8]_,"2.7, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12",Not applicable,``.py``
    Ruby [9]_,"up to 3.2",Not applicable,"``.rb``, ``.erb``, ``.gemspec``, ``Gemfile``"
    Swift [10]_,"Swift 5.4-5.8.1","Swift compiler","``.swift``"
    TypeScript [11]_,"2.6-5.3",Standard TypeScript compiler,"``.ts``, ``.tsx``, ``.mts``, ``.cts``"


### PR DESCRIPTION
Support was added in https://github.com/github/codeql/pull/14636