### PR TITLE
Go: Improve tests for Incorrect Integer Conversion

### DIFF
--- a/go/ql/test/query-tests/Security/CWE-681/IncorrectIntegerConversion.go
+++ b/go/ql/test/query-tests/Security/CWE-681/IncorrectIntegerConversion.go
@@ -33,7 +33,7 @@ func lab(s string) (*something, error) {
 		}
 		num = int(number)
 	}
-	target, err := lookupTarget(&config{}, int32(num)) // $ hasValueFlow="type conversion"
+	target, err := lookupTarget(&config{}, int32(num)) // $ hasValueFlow="num"
 	if err != nil {
 		return nil, err
 	}
@@ -67,8 +67,8 @@ func testParseInt() {
 		if err != nil {
 			panic(err)
 		}
-		_ = int8(parsed)  // $ hasValueFlow="type conversion"
-		_ = uint8(parsed) // $ hasValueFlow="type conversion"
+		_ = int8(parsed)  // $ hasValueFlow="parsed"
+		_ = uint8(parsed) // $ hasValueFlow="parsed"
 		_ = int16(parsed)
 		_ = uint16(parsed)
 		_ = int32(parsed)
@@ -83,10 +83,10 @@ func testParseInt() {
 		if err != nil {
 			panic(err)
 		}
-		_ = int8(parsed)   // $ hasValueFlow="type conversion"
-		_ = uint8(parsed)  // $ hasValueFlow="type conversion"
-		_ = int16(parsed)  // $ hasValueFlow="type conversion"
-		_ = uint16(parsed) // $ hasValueFlow="type conversion"
+		_ = int8(parsed)   // $ hasValueFlow="parsed"
+		_ = uint8(parsed)  // $ hasValueFlow="parsed"
+		_ = int16(parsed)  // $ hasValueFlow="parsed"
+		_ = uint16(parsed) // $ hasValueFlow="parsed"
 		_ = int32(parsed)
 		_ = uint32(parsed)
 		_ = int64(parsed)
@@ -99,28 +99,28 @@ func testParseInt() {
 		if err != nil {
 			panic(err)
 		}
-		_ = int8(parsed)   // $ hasValueFlow="type conversion"
-		_ = uint8(parsed)  // $ hasValueFlow="type conversion"
-		_ = int16(parsed)  // $ hasValueFlow="type conversion"
-		_ = uint16(parsed) // $ hasValueFlow="type conversion"
-		_ = int32(parsed)  // $ hasValueFlow="type conversion"
-		_ = uint32(parsed) // $ hasValueFlow="type conversion"
+		_ = int8(parsed)   // $ hasValueFlow="parsed"
+		_ = uint8(parsed)  // $ hasValueFlow="parsed"
+		_ = int16(parsed)  // $ hasValueFlow="parsed"
+		_ = uint16(parsed) // $ hasValueFlow="parsed"
+		_ = int32(parsed)  // $ hasValueFlow="parsed"
+		_ = uint32(parsed) // $ hasValueFlow="parsed"
 		_ = int64(parsed)
 		_ = uint64(parsed)
-		_ = int(parsed)  // $ hasValueFlow="type conversion"
-		_ = uint(parsed) // $ hasValueFlow="type conversion"
+		_ = int(parsed)  // $ hasValueFlow="parsed"
+		_ = uint(parsed) // $ hasValueFlow="parsed"
 	}
 	{
 		parsed, err := strconv.ParseInt("3456", 10, 0)
 		if err != nil {
 			panic(err)
 		}
-		_ = int8(parsed)   // $ hasValueFlow="type conversion"
-		_ = uint8(parsed)  // $ hasValueFlow="type conversion"
-		_ = int16(parsed)  // $ hasValueFlow="type conversion"
-		_ = uint16(parsed) // $ hasValueFlow="type conversion"
-		_ = int32(parsed)  // $ hasValueFlow="type conversion"
-		_ = uint32(parsed) // $ hasValueFlow="type conversion"
+		_ = int8(parsed)   // $ hasValueFlow="parsed"
+		_ = uint8(parsed)  // $ hasValueFlow="parsed"
+		_ = int16(parsed)  // $ hasValueFlow="parsed"
+		_ = uint16(parsed) // $ hasValueFlow="parsed"
+		_ = int32(parsed)  // $ hasValueFlow="parsed"
+		_ = uint32(parsed) // $ hasValueFlow="parsed"
 		_ = int64(parsed)
 		_ = uint64(parsed)
 		_ = int(parsed)
@@ -134,7 +134,7 @@ func testParseUint() {
 		if err != nil {
 			panic(err)
 		}
-		_ = int8(parsed) // $ hasValueFlow="type conversion"
+		_ = int8(parsed) // $ hasValueFlow="parsed"
 		_ = uint8(parsed)
 		_ = int16(parsed)
 		_ = uint16(parsed)
@@ -150,9 +150,9 @@ func testParseUint() {
 		if err != nil {
 			panic(err)
 		}
-		_ = int8(parsed)  // $ hasValueFlow="type conversion"
-		_ = uint8(parsed) // $ hasValueFlow="type conversion"
-		_ = int16(parsed) // $ hasValueFlow="type conversion"
+		_ = int8(parsed)  // $ hasValueFlow="parsed"
+		_ = uint8(parsed) // $ hasValueFlow="parsed"
+		_ = int16(parsed) // $ hasValueFlow="parsed"
 		_ = uint16(parsed)
 		_ = int32(parsed)
 		_ = uint32(parsed)
@@ -166,15 +166,15 @@ func testParseUint() {
 		if err != nil {
 			panic(err)
 		}
-		_ = int8(parsed)   // $ hasValueFlow="type conversion"
-		_ = uint8(parsed)  // $ hasValueFlow="type conversion"
-		_ = int16(parsed)  // $ hasValueFlow="type conversion"
-		_ = uint16(parsed) // $ hasValueFlow="type conversion"
-		_ = int32(parsed)  // $ hasValueFlow="type conversion"
+		_ = int8(parsed)   // $ hasValueFlow="parsed"
+		_ = uint8(parsed)  // $ hasValueFlow="parsed"
+		_ = int16(parsed)  // $ hasValueFlow="parsed"
+		_ = uint16(parsed) // $ hasValueFlow="parsed"
+		_ = int32(parsed)  // $ hasValueFlow="parsed"
 		_ = uint32(parsed)
 		_ = int64(parsed)
 		_ = uint64(parsed)
-		_ = int(parsed) // $ hasValueFlow="type conversion"
+		_ = int(parsed) // $ hasValueFlow="parsed"
 		_ = uint(parsed)
 	}
 	{
@@ -182,31 +182,31 @@ func testParseUint() {
 		if err != nil {
 			panic(err)
 		}
-		_ = int8(parsed)   // $ hasValueFlow="type conversion"
-		_ = uint8(parsed)  // $ hasValueFlow="type conversion"
-		_ = int16(parsed)  // $ hasValueFlow="type conversion"
-		_ = uint16(parsed) // $ hasValueFlow="type conversion"
-		_ = int32(parsed)  // $ hasValueFlow="type conversion"
-		_ = uint32(parsed) // $ hasValueFlow="type conversion"
-		_ = int64(parsed)  // $ hasValueFlow="type conversion"
+		_ = int8(parsed)   // $ hasValueFlow="parsed"
+		_ = uint8(parsed)  // $ hasValueFlow="parsed"
+		_ = int16(parsed)  // $ hasValueFlow="parsed"
+		_ = uint16(parsed) // $ hasValueFlow="parsed"
+		_ = int32(parsed)  // $ hasValueFlow="parsed"
+		_ = uint32(parsed) // $ hasValueFlow="parsed"
+		_ = int64(parsed)  // $ hasValueFlow="parsed"
 		_ = uint64(parsed)
-		_ = int(parsed)  // $ hasValueFlow="type conversion"
-		_ = uint(parsed) // $ hasValueFlow="type conversion"
+		_ = int(parsed)  // $ hasValueFlow="parsed"
+		_ = uint(parsed) // $ hasValueFlow="parsed"
 	}
 	{
 		parsed, err := strconv.ParseUint("3456", 10, 0)
 		if err != nil {
 			panic(err)
 		}
-		_ = int8(parsed)   // $ hasValueFlow="type conversion"
-		_ = uint8(parsed)  // $ hasValueFlow="type conversion"
-		_ = int16(parsed)  // $ hasValueFlow="type conversion"
-		_ = uint16(parsed) // $ hasValueFlow="type conversion"
-		_ = int32(parsed)  // $ hasValueFlow="type conversion"
-		_ = uint32(parsed) // $ hasValueFlow="type conversion"
-		_ = int64(parsed)  // $ hasValueFlow="type conversion"
+		_ = int8(parsed)   // $ hasValueFlow="parsed"
+		_ = uint8(parsed)  // $ hasValueFlow="parsed"
+		_ = int16(parsed)  // $ hasValueFlow="parsed"
+		_ = uint16(parsed) // $ hasValueFlow="parsed"
+		_ = int32(parsed)  // $ hasValueFlow="parsed"
+		_ = uint32(parsed) // $ hasValueFlow="parsed"
+		_ = int64(parsed)  // $ hasValueFlow="parsed"
 		_ = uint64(parsed)
-		_ = int(parsed) // $ hasValueFlow="type conversion"
+		_ = int(parsed) // $ hasValueFlow="parsed"
 		_ = uint(parsed)
 	}
 }
@@ -216,12 +216,12 @@ func testAtoi() {
 	if err != nil {
 		panic(err)
 	}
-	_ = int8(parsed)   // $ hasValueFlow="type conversion"
-	_ = uint8(parsed)  // $ hasValueFlow="type conversion"
-	_ = int16(parsed)  // $ hasValueFlow="type conversion"
-	_ = uint16(parsed) // $ hasValueFlow="type conversion"
-	_ = int32(parsed)  // $ hasValueFlow="type conversion"
-	_ = uint32(parsed) // $ hasValueFlow="type conversion"
+	_ = int8(parsed)   // $ hasValueFlow="parsed"
+	_ = uint8(parsed)  // $ hasValueFlow="parsed"
+	_ = int16(parsed)  // $ hasValueFlow="parsed"
+	_ = uint16(parsed) // $ hasValueFlow="parsed"
+	_ = int32(parsed)  // $ hasValueFlow="parsed"
+	_ = uint32(parsed) // $ hasValueFlow="parsed"
 	_ = int64(parsed)
 	_ = uint64(parsed)
 	_ = int(parsed)
@@ -238,8 +238,8 @@ func typeAliases(input string) {
 			panic(err)
 		}
 		// NOTE: byte is uint8
-		_ = byte(parsed)      // $ hasValueFlow="type conversion"
-		_ = customInt(parsed) // $ hasValueFlow="type conversion"
+		_ = byte(parsed)      // $ hasValueFlow="parsed"
+		_ = customInt(parsed) // $ hasValueFlow="parsed"
 	}
 }
 
@@ -253,13 +253,13 @@ func testBoundsChecking(input string) {
 			_ = int8(parsed)
 		}
 		if parsed < math.MaxInt8 {
-			_ = int8(parsed) // $ MISSING: hasValueFlow="type conversion"  // Not found because we only check for upper bounds
+			_ = int8(parsed) // $ MISSING: hasValueFlow="parsed"  // Not found because we only check for upper bounds
 			if parsed >= 0 {
 				_ = int16(parsed)
 			}
 		}
 		if parsed >= math.MinInt8 {
-			_ = int8(parsed) // $ hasValueFlow="type conversion"
+			_ = int8(parsed) // $ hasValueFlow="parsed"
 			if parsed <= 0 {
 				_ = int16(parsed)
 			}
@@ -276,46 +276,46 @@ func testBoundsChecking(input string) {
 			panic(err)
 		}
 		if parsed <= math.MaxUint64 {
-			_ = int8(parsed)   // $ hasValueFlow="type conversion"
-			_ = uint8(parsed)  // $ hasValueFlow="type conversion"
-			_ = int16(parsed)  // $ hasValueFlow="type conversion"
-			_ = uint16(parsed) // $ hasValueFlow="type conversion"
-			_ = int32(parsed)  // $ hasValueFlow="type conversion"
-			_ = uint32(parsed) // $ hasValueFlow="type conversion"
-			_ = int64(parsed)  // $ hasValueFlow="type conversion"
+			_ = int8(parsed)   // $ hasValueFlow="parsed"
+			_ = uint8(parsed)  // $ hasValueFlow="parsed"
+			_ = int16(parsed)  // $ hasValueFlow="parsed"
+			_ = uint16(parsed) // $ hasValueFlow="parsed"
+			_ = int32(parsed)  // $ hasValueFlow="parsed"
+			_ = uint32(parsed) // $ hasValueFlow="parsed"
+			_ = int64(parsed)  // $ hasValueFlow="parsed"
 			_ = uint64(parsed)
-			_ = int(parsed) // $ hasValueFlow="type conversion"
+			_ = int(parsed) // $ hasValueFlow="parsed"
 			_ = uint(parsed)
 		}
 		if parsed <= math.MaxInt64 {
-			_ = int8(parsed)   // $ hasValueFlow="type conversion"
-			_ = uint8(parsed)  // $ hasValueFlow="type conversion"
-			_ = int16(parsed)  // $ hasValueFlow="type conversion"
-			_ = uint16(parsed) // $ hasValueFlow="type conversion"
-			_ = int32(parsed)  // $ hasValueFlow="type conversion"
-			_ = uint32(parsed) // $ hasValueFlow="type conversion"
+			_ = int8(parsed)   // $ hasValueFlow="parsed"
+			_ = uint8(parsed)  // $ hasValueFlow="parsed"
+			_ = int16(parsed)  // $ hasValueFlow="parsed"
+			_ = uint16(parsed) // $ hasValueFlow="parsed"
+			_ = int32(parsed)  // $ hasValueFlow="parsed"
+			_ = uint32(parsed) // $ hasValueFlow="parsed"
 			_ = int64(parsed)
 			_ = uint64(parsed)
-			_ = int(parsed) // $ hasValueFlow="type conversion"
+			_ = int(parsed) // $ hasValueFlow="parsed"
 			_ = uint(parsed)
 		}
 		if parsed <= math.MaxUint32 {
-			_ = int8(parsed)   // $ hasValueFlow="type conversion"
-			_ = uint8(parsed)  // $ hasValueFlow="type conversion"
-			_ = int16(parsed)  // $ hasValueFlow="type conversion"
-			_ = uint16(parsed) // $ hasValueFlow="type conversion"
-			_ = int32(parsed)  // $ hasValueFlow="type conversion"
+			_ = int8(parsed)   // $ hasValueFlow="parsed"
+			_ = uint8(parsed)  // $ hasValueFlow="parsed"
+			_ = int16(parsed)  // $ hasValueFlow="parsed"
+			_ = uint16(parsed) // $ hasValueFlow="parsed"
+			_ = int32(parsed)  // $ hasValueFlow="parsed"
 			_ = uint32(parsed)
 			_ = int64(parsed)
 			_ = uint64(parsed)
-			_ = int(parsed) // $ hasValueFlow="type conversion"
+			_ = int(parsed) // $ hasValueFlow="parsed"
 			_ = uint(parsed)
 		}
 		if parsed <= math.MaxInt32 {
-			_ = int8(parsed)   // $ hasValueFlow="type conversion"
-			_ = uint8(parsed)  // $ hasValueFlow="type conversion"
-			_ = int16(parsed)  // $ hasValueFlow="type conversion"
-			_ = uint16(parsed) // $ hasValueFlow="type conversion"
+			_ = int8(parsed)   // $ hasValueFlow="parsed"
+			_ = uint8(parsed)  // $ hasValueFlow="parsed"
+			_ = int16(parsed)  // $ hasValueFlow="parsed"
+			_ = uint16(parsed) // $ hasValueFlow="parsed"
 			_ = int32(parsed)
 			_ = uint32(parsed)
 			_ = int64(parsed)
@@ -331,19 +331,19 @@ func testBoundsChecking(input string) {
 		}
 		if parsed <= math.MaxUint16 {
 			_ = uint16(parsed)
-			_ = int16(parsed) // $ hasValueFlow="type conversion"
+			_ = int16(parsed) // $ hasValueFlow="parsed"
 		}
 		if parsed <= 255 {
 			_ = uint8(parsed)
 		}
 		if parsed <= 256 {
-			_ = uint8(parsed) // $ hasValueFlow="type conversion"
+			_ = uint8(parsed) // $ hasValueFlow="parsed"
 		}
 		if err == nil && 1 == 1 && parsed < math.MaxInt8 {
 			_ = int8(parsed)
 		}
 		if parsed > 42 {
-			_ = uint16(parsed) // $ hasValueFlow="type conversion"
+			_ = uint16(parsed) // $ hasValueFlow="parsed"
 		}
 		if parsed >= math.MaxUint8+1 {
 			return
@@ -393,7 +393,7 @@ func testRightShifted(input string) {
 		if err != nil {
 			panic(err)
 		}
-		_ = byte(parsed) // $ hasValueFlow="type conversion"
+		_ = byte(parsed) // $ hasValueFlow="parsed"
 		_ = byte(parsed << 8)
 	}
 }
@@ -404,7 +404,7 @@ func testPathWithMoreThanOneSink(input string) {
 		if err != nil {
 			panic(err)
 		}
-		v1 := int16(parsed) // $ hasValueFlow="type conversion"
+		v1 := int16(parsed) // $ hasValueFlow="parsed"
 		_ = int16(v1)
 	}
 	{
@@ -412,7 +412,7 @@ func testPathWithMoreThanOneSink(input string) {
 		if err != nil {
 			panic(err)
 		}
-		v := int16(parsed) // $ hasValueFlow="type conversion"
+		v := int16(parsed) // $ hasValueFlow="parsed"
 		_ = int8(v)
 	}
 	{
@@ -421,7 +421,7 @@ func testPathWithMoreThanOneSink(input string) {
 			panic(err)
 		}
 		v1 := int32(parsed)
-		v2 := int16(v1) // $ hasValueFlow="type conversion"
+		v2 := int16(v1) // $ hasValueFlow="v1"
 		_ = int8(v2)
 	}
 	{
@@ -432,7 +432,7 @@ func testPathWithMoreThanOneSink(input string) {
 		v1 := int64(parsed)
 		v2 := int32(v1)
 		v3 := int16(v2)
-		_ = int8(v3) // $ hasValueFlow="type conversion"
+		_ = int8(v3) // $ hasValueFlow="v3"
 	}
 }
 
@@ -441,12 +441,12 @@ func testUsingStrConvIntSize(input string) {
 	if err != nil {
 		panic(err)
 	}
-	_ = int8(parsed)   // $ hasValueFlow="type conversion"
-	_ = uint8(parsed)  // $ hasValueFlow="type conversion"
-	_ = int16(parsed)  // $ hasValueFlow="type conversion"
-	_ = uint16(parsed) // $ hasValueFlow="type conversion"
-	_ = int32(parsed)  // $ hasValueFlow="type conversion"
-	_ = uint32(parsed) // $ hasValueFlow="type conversion"
+	_ = int8(parsed)   // $ hasValueFlow="parsed"
+	_ = uint8(parsed)  // $ hasValueFlow="parsed"
+	_ = int16(parsed)  // $ hasValueFlow="parsed"
+	_ = uint16(parsed) // $ hasValueFlow="parsed"
+	_ = int32(parsed)  // $ hasValueFlow="parsed"
+	_ = uint32(parsed) // $ hasValueFlow="parsed"
 	_ = int64(parsed)
 	_ = uint64(parsed)
 	_ = int(parsed)

--- a/go/ql/test/query-tests/Security/CWE-681/IncorrectIntegerConversion.ql
+++ b/go/ql/test/query-tests/Security/CWE-681/IncorrectIntegerConversion.ql
@@ -7,15 +7,11 @@ module TestIncorrectIntegerConversion implements TestSig {
 
   predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "hasValueFlow" and
-    exists(DataFlow::Node sink, DataFlow::Node sinkConverted |
-      Flow::flowTo(sink) and
-      sinkConverted = sink.getASuccessor()
-    |
-      sinkConverted
-          .hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
-            location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
-      element = sinkConverted.toString() and
-      value = "\"" + sinkConverted.toString() + "\""
+    exists(DataFlow::Node sink | Flow::flowTo(sink) |
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      element = sink.toString() and
+      value = "\"" + sink.toString() + "\""
     )
   }
 }

--- a/go/ql/test/query-tests/Security/CWE-681/Test32BitArchitectureBuildConstraintInFileName_386.go
+++ b/go/ql/test/query-tests/Security/CWE-681/Test32BitArchitectureBuildConstraintInFileName_386.go
@@ -20,7 +20,7 @@ func testIntSource386() {
 		if err != nil {
 			panic(err)
 		}
-		_ = int32(parsed) // $ hasValueFlow="type conversion"
+		_ = int32(parsed) // $ hasValueFlow="parsed"
 		_ = uint32(parsed)
 	}
 	{

--- a/go/ql/test/query-tests/Security/CWE-681/Test32BitArchitectureBuildConstraints.go
+++ b/go/ql/test/query-tests/Security/CWE-681/Test32BitArchitectureBuildConstraints.go
@@ -23,7 +23,7 @@ func testIntSource32() {
 		if err != nil {
 			panic(err)
 		}
-		_ = int32(parsed) // $ hasValueFlow="type conversion"
+		_ = int32(parsed) // $ hasValueFlow="parsed"
 		_ = uint32(parsed)
 	}
 	{

--- a/go/ql/test/query-tests/Security/CWE-681/Test64BitArchitectureBuildConstraintInFileName_amd64.go
+++ b/go/ql/test/query-tests/Security/CWE-681/Test64BitArchitectureBuildConstraintInFileName_amd64.go
@@ -20,7 +20,7 @@ func testIntSinkAmd64() {
 		if err != nil {
 			panic(err)
 		}
-		_ = int(parsed) // $ hasValueFlow="type conversion"
+		_ = int(parsed) // $ hasValueFlow="parsed"
 		_ = uint(parsed)
 	}
 }

--- a/go/ql/test/query-tests/Security/CWE-681/Test64BitArchitectureBuildConstraints.go
+++ b/go/ql/test/query-tests/Security/CWE-681/Test64BitArchitectureBuildConstraints.go
@@ -23,7 +23,7 @@ func testIntSink64() {
 		if err != nil {
 			panic(err)
 		}
-		_ = int(parsed) // $ hasValueFlow="type conversion"
+		_ = int(parsed) // $ hasValueFlow="parsed"
 		_ = uint(parsed)
 	}
 }

--- a/go/ql/test/query-tests/Security/CWE-681/TestNoArchitectureBuildConstraints.go
+++ b/go/ql/test/query-tests/Security/CWE-681/TestNoArchitectureBuildConstraints.go
@@ -13,15 +13,15 @@ func testIntSizeIsArchicturallyDependent1() {
 		if err != nil {
 			panic(err)
 		}
-		_ = int32(parsed)  // $ hasValueFlow="type conversion"
-		_ = uint32(parsed) // $ hasValueFlow="type conversion"
+		_ = int32(parsed)  // $ hasValueFlow="parsed"
+		_ = uint32(parsed) // $ hasValueFlow="parsed"
 	}
 	{
 		parsed, err := strconv.ParseInt("3456", 10, 64)
 		if err != nil {
 			panic(err)
 		}
-		_ = int(parsed)  // $ hasValueFlow="type conversion"
-		_ = uint(parsed) // $ hasValueFlow="type conversion"
+		_ = int(parsed)  // $ hasValueFlow="parsed"
+		_ = uint(parsed) // $ hasValueFlow="parsed"
 	}
 }

--- a/go/ql/test/query-tests/Security/CWE-681/TestOldBuildConstraints.go
+++ b/go/ql/test/query-tests/Security/CWE-681/TestOldBuildConstraints.go
@@ -24,7 +24,7 @@ func oldTestIntSink64() {
 		if err != nil {
 			panic(err)
 		}
-		_ = int(parsed) // $ hasValueFlow="type conversion"
+		_ = int(parsed) // $ hasValueFlow="parsed"
 		_ = uint(parsed)
 	}
 }


### PR DESCRIPTION
We changed the test query when the query was changed so that the comments in the test file would stay the same.
I've reverted the test query and updated the comments in the test file. This avoids problems in the branch switching to use-use flow.