### PR TITLE
Remove unwanted period from query name

### DIFF
--- a/javascript/ql/src/Security/CWE-327/BadRandomness.ql
+++ b/javascript/ql/src/Security/CWE-327/BadRandomness.ql
@@ -1,5 +1,5 @@
 /**
- * @name Creating biased random numbers from a cryptographically secure source.
+ * @name Creating biased random numbers from a cryptographically secure source
  * @description Some mathematical operations on random numbers can cause bias in
  *              the results and compromise security.
  * @kind problem


### PR DESCRIPTION
Our style guide states that names should not end in a period. I'm updating this now to allow us to automate a process for GitHub docs, see: https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md#query-name-name