### PR TITLE
yeast: Add a bare-bones binary

### DIFF
--- a/shared/yeast/Cargo.toml
+++ b/shared/yeast/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+clap = { version = "4.4.10", features = ["derive"] }
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
 tree-sitter = "0.20.10"
 
-[dev-dependencies]
 tree-sitter-ruby = "0.20.0"
 tree-sitter-python = "0.20.4"

--- a/shared/yeast/src/bin/main.rs
+++ b/shared/yeast/src/bin/main.rs
@@ -1,0 +1,26 @@
+use clap::Parser;
+
+#[derive(Parser)]
+#[clap(name = "yeast", about = "yeast elaborates abstract syntax trees")]
+struct Cli {
+    file: String,
+    #[clap(default_value = "ruby")]
+    language: String,
+}
+
+fn get_language(language: &str) -> tree_sitter::Language {
+    match language {
+        "ruby" => tree_sitter_ruby::language(),
+        "python" => tree_sitter_python::language(),
+        _ => panic!("Unsupported language: {}", language),
+    }
+}
+
+fn main() {
+    let args = Cli::parse();
+    let language = get_language(&args.language);
+    let source = std::fs::read_to_string(&args.file).unwrap();
+    let runner = yeast::Runner::new(language, vec![]);
+    let (ast, root_id) = runner.run(&source);
+    println!("{}", ast.print(&source, root_id).to_string());
+}


### PR DESCRIPTION
Run using `cargo run <filename> [language]`, where if language is not specified we use `ruby`. Outputs the desugared AST as JSON.