### PR TITLE
C++: Experimental query for implementation of a cryptographic primitive

### DIFF
--- a/cpp/ql/src/experimental/Security/CWE/CWE-1240/CustomCryptographicPrimitive.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-1240/CustomCryptographicPrimitive.ql
@@ -82,4 +82,6 @@ where
   amount = strictcount(Expr e | computeHeuristic(e) and e.getEnclosingFunction() = f) and
   amount >= 8 and
   exists(f.getFile().getRelativePath()) // exclude library files
-select f, "This may be a custom implementation of a cryptographic primitive."
+select f,
+  "This function, \"" + f.getName() +
+    "\", may be a custom implementation of a cryptographic primitive."

--- a/cpp/ql/src/experimental/Security/CWE/CWE-1240/CustomCryptographicPrimitive.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-1240/CustomCryptographicPrimitive.ql
@@ -29,7 +29,7 @@ string encryptionWord() {
         "Camellia",
         //"(?<!Bit|Type)Cast",
         "Chacha", "ChaCha", "Poly[0-9]", "Ripemd", "Whirlpool", "Sbox", "SBox", "Cblock", "CBlock",
-        "Sub.?Byte", "Mix.?Column", "ECDH", "ECDSA", "EdDSA", "ECMQV", "ECQV", "Curve[0-9][0-9]"
+        "Sub.?Bytes?", "Mix.?Columns?", "ECDH", "ECDSA", "EdDSA", "ECMQV", "ECQV", "Curve[0-9][0-9]"
       ] and
     (
       result = word or

--- a/cpp/ql/src/experimental/Security/CWE/CWE-1240/CustomCryptographicPrimitive.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-1240/CustomCryptographicPrimitive.ql
@@ -13,11 +13,11 @@
 import cpp
 
 /**
- * A word that might be in the name of an encryption function.
+ * Gets a word that might be in the name of an encryption function.
  */
 string encryptionWord() {
   exists(string word |
-    // `(?<!P)` is negative lookbehind, i.e. the match is not preceeded by `P`.
+    // `(?<!P)` is negative lookbehind, i.e. the match is not preceded by `P`.
     // `(?!P)` is negative lookahead, i.e. the match is not followed by `P`.
     word =
       [
@@ -27,9 +27,8 @@ string encryptionWord() {
         //"Asn[0-9]",
         "Camellia",
         //"(?<!Bit|Type)Cast",
-        "Chacha", "ChaCha", "Idea", "Poly[0-9]", "Ripemd", "Whirlpool", "Sbox", "SBox", "Cblock",
-        "CBlock", "Sub.?Byte", "Mix.?Column", "ECDH", "ECDSA", "EdDSA", "ECMQV", "ECQV",
-        "Curve[0-9][0-9]"
+        "Chacha", "ChaCha", "Poly[0-9]", "Ripemd", "Whirlpool", "Sbox", "SBox", "Cblock", "CBlock",
+        "Sub.?Byte", "Mix.?Column", "ECDH", "ECDSA", "EdDSA", "ECMQV", "ECQV", "Curve[0-9][0-9]"
       ] and
     (
       result = word or
@@ -40,8 +39,8 @@ string encryptionWord() {
 }
 
 /**
- * A function whose name suggests it may be doing encryption (but may or may
- * not actually implement an encryption primitive itself).
+ * Holds if `f` is a function whose name suggests it may be doing encryption
+ * (but may or may not actually implement an encryption primitive itself).
  */
 predicate likelyEncryptionFunction(Function f) {
   exists(string fName | fName = f.getName() |
@@ -50,8 +49,8 @@ predicate likelyEncryptionFunction(Function f) {
 }
 
 /**
- * A type that is common in encryption-like computations. That is, an integral
- * type or array of integral type elements.
+ * Holds if `t` is a type that is common in encryption-like computations. That
+ * is, an integral type or array of integral type elements.
  */
 predicate computeHeuristicType(Type t) {
   t instanceof IntegralType or
@@ -59,9 +58,10 @@ predicate computeHeuristicType(Type t) {
 }
 
 /**
- * An operation that is common in encryption-like computations. Looking for
- * clusters of these tends to find things like encrpytion, compression, random
- * number generation, graphics processing and other compute heavy algoritms.
+ * Holds if `e` is an operation that is common in encryption-like computations.
+ * Looking for clusters of these tends to find things like encrpytion,
+ * compression, random number generation, graphics processing and other compute
+ * heavy algorithms.
  */
 predicate computeHeuristic(Expr e) {
   (

--- a/cpp/ql/src/experimental/Security/CWE/CWE-1240/CustomCryptographicPrimitive.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-1240/CustomCryptographicPrimitive.ql
@@ -7,6 +7,7 @@
  * @precision medium
  * @id cpp/crypto-primitive
  * @tags security
+ *       experimental
  *       external/cwe/cwe-1240
  */
 

--- a/cpp/ql/src/experimental/Security/CWE/CWE-1240/CustomCryptographicPrimitive.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-1240/CustomCryptographicPrimitive.ql
@@ -1,0 +1,85 @@
+/**
+ * @name Implementation of a cryptographic primitive
+ * @description Writing your own cryptographic primitives is prone to errors and omissions that weaken cryptographic protection.
+ * @kind problem
+ * @problem.severity warning
+ * @security-severity 7.5
+ * @precision medium
+ * @id cpp/crypto-primitive
+ * @tags security
+ *       external/cwe/cwe-1240
+ */
+
+import cpp
+
+/**
+ * A word that might be in the name of an encryption function.
+ */
+string encryptionWord() {
+  exists(string word |
+    // `(?<!P)` is negative lookbehind, i.e. the match is not preceeded by `P`.
+    // `(?!P)` is negative lookahead, i.e. the match is not followed by `P`.
+    word =
+      [
+        "Crypt", "Cipher", "Aes", "Rijndael",
+        //"(?<!Wi|Co|No)Des(?!truct)",
+        "(?<!C)Rc[0-9]", "(?<!Cha|Unive)Rsa", "Blowfish", "Twofish", "Idea", "Kyber", "(?<!V)Aria",
+        //"Asn[0-9]",
+        "Camellia",
+        //"(?<!Bit|Type)Cast",
+        "Chacha", "ChaCha", "Idea", "Poly[0-9]", "Ripemd", "Whirlpool", "Sbox", "SBox", "Cblock",
+        "CBlock", "Sub.?Byte", "Mix.?Column", "ECDH", "ECDSA", "EdDSA", "ECMQV", "ECQV",
+        "Curve[0-9][0-9]"
+      ] and
+    (
+      result = word or
+      result = word.toLowerCase() + "(?![a-z])" or // avoid matching middles of words
+      result = word.toUpperCase() + "(?![A-Z])" // avoid matching middles of words
+    )
+  )
+}
+
+/**
+ * A function whose name suggests it may be doing encryption (but may or may
+ * not actually implement an encryption primitive itself).
+ */
+predicate likelyEncryptionFunction(Function f) {
+  exists(string fName | fName = f.getName() |
+    fName.regexpMatch(".*(" + concat(encryptionWord(), "|") + ").*")
+  )
+}
+
+/**
+ * A type that is common in encryption-like computations. That is, an integral
+ * type or array of integral type elements.
+ */
+predicate computeHeuristicType(Type t) {
+  t instanceof IntegralType or
+  computeHeuristicType(t.(ArrayType).getBaseType().getUnspecifiedType())
+}
+
+/**
+ * An operation that is common in encryption-like computations. Looking for
+ * clusters of these tends to find things like encrpytion, compression, random
+ * number generation, graphics processing and other compute heavy algoritms.
+ */
+predicate computeHeuristic(Expr e) {
+  (
+    e instanceof BitwiseXorExpr or
+    e instanceof AssignXorExpr or
+    e instanceof LShiftExpr or
+    e instanceof AssignLShiftExpr or
+    e instanceof RShiftExpr or
+    e instanceof AssignRShiftExpr or
+    e instanceof ArrayExpr
+  ) and
+  computeHeuristicType(e.getUnspecifiedType())
+}
+
+from Function f, int amount
+where
+  likelyEncryptionFunction(f) and
+  amount = strictcount(Expr e | computeHeuristic(e) and e.getEnclosingFunction() = f) and
+  amount >= 8 and
+  exists(f.getFile().getRelativePath()) // exclude library files
+select f, "This may be a custom implementation of a cryptographic primitive."

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-1240/CustomCryptographicPrimitive.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-1240/CustomCryptographicPrimitive.expected
@@ -1,3 +1,3 @@
-| tests_crypto.cpp:11:6:11:18 | encryptString | This may be a custom implementation of a cryptographic primitive. |
-| tests_crypto.cpp:30:6:30:14 | MyEncrypt | This may be a custom implementation of a cryptographic primitive. |
-| tests_crypto.cpp:83:6:83:18 | init_aes_sbox | This may be a custom implementation of a cryptographic primitive. |
+| tests_crypto.cpp:11:6:11:18 | encryptString | This function, "encryptString", may be a custom implementation of a cryptographic primitive. |
+| tests_crypto.cpp:30:6:30:14 | MyEncrypt | This function, "MyEncrypt", may be a custom implementation of a cryptographic primitive. |
+| tests_crypto.cpp:83:6:83:18 | init_aes_sbox | This function, "init_aes_sbox", may be a custom implementation of a cryptographic primitive. |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-1240/CustomCryptographicPrimitive.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-1240/CustomCryptographicPrimitive.expected
@@ -1,3 +1,4 @@
+| library/tests_library.h:4:6:4:19 | do_aes_encrypt | This function, "do_aes_encrypt", may be a custom implementation of a cryptographic primitive. |
 | tests_crypto.cpp:11:6:11:18 | encryptString | This function, "encryptString", may be a custom implementation of a cryptographic primitive. |
 | tests_crypto.cpp:30:6:30:14 | MyEncrypt | This function, "MyEncrypt", may be a custom implementation of a cryptographic primitive. |
 | tests_crypto.cpp:83:6:83:18 | init_aes_sbox | This function, "init_aes_sbox", may be a custom implementation of a cryptographic primitive. |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-1240/CustomCryptographicPrimitive.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-1240/CustomCryptographicPrimitive.expected
@@ -1,4 +1,3 @@
-| library/tests_library.h:4:6:4:19 | do_aes_encrypt | This function, "do_aes_encrypt", may be a custom implementation of a cryptographic primitive. |
 | tests_crypto.cpp:11:6:11:18 | encryptString | This function, "encryptString", may be a custom implementation of a cryptographic primitive. |
 | tests_crypto.cpp:30:6:30:14 | MyEncrypt | This function, "MyEncrypt", may be a custom implementation of a cryptographic primitive. |
 | tests_crypto.cpp:83:6:83:18 | init_aes_sbox | This function, "init_aes_sbox", may be a custom implementation of a cryptographic primitive. |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-1240/CustomCryptographicPrimitive.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-1240/CustomCryptographicPrimitive.expected
@@ -1,3 +1,4 @@
 | tests_crypto.cpp:11:6:11:18 | encryptString | This function, "encryptString", may be a custom implementation of a cryptographic primitive. |
 | tests_crypto.cpp:30:6:30:14 | MyEncrypt | This function, "MyEncrypt", may be a custom implementation of a cryptographic primitive. |
+| tests_crypto.cpp:51:6:51:16 | mix_columns | This function, "mix_columns", may be a custom implementation of a cryptographic primitive. |
 | tests_crypto.cpp:83:6:83:18 | init_aes_sbox | This function, "init_aes_sbox", may be a custom implementation of a cryptographic primitive. |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-1240/CustomCryptographicPrimitive.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-1240/CustomCryptographicPrimitive.expected
@@ -1,0 +1,3 @@
+| tests_crypto.cpp:11:6:11:18 | encryptString | This may be a custom implementation of a cryptographic primitive. |
+| tests_crypto.cpp:30:6:30:14 | MyEncrypt | This may be a custom implementation of a cryptographic primitive. |
+| tests_crypto.cpp:83:6:83:18 | init_aes_sbox | This may be a custom implementation of a cryptographic primitive. |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-1240/CustomCryptographicPrimitive.qlref
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-1240/CustomCryptographicPrimitive.qlref
@@ -1,0 +1,1 @@
+experimental/Security/CWE/CWE-1240/CustomCryptographicPrimitive.ql

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-1240/library/tests_library.h
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-1240/library/tests_library.h
@@ -1,0 +1,6 @@
+// Cryptography 'library' snippets.  Nothing in this file should be flagged by the query, because
+// it's in a library.
+
+void do_aes_encrypt(unsigned int *v) {
+	COMPUTE(v)
+}

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-1240/tests_crypto.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-1240/tests_crypto.cpp
@@ -1,0 +1,97 @@
+// Cryptography snippets.  All (non-stub) functions in this file should be flagged by the query.
+
+typedef unsigned char uint8_t;
+
+int strlen(const char *string);
+
+// ---
+
+// the following function is homebrew crypto written for this test.  This is a bad algorithm
+// on multiple levels and should never be used in cryptography.
+void encryptString(char *string, unsigned int key) {
+	char *ptr = string;
+	int len = strlen(string);
+
+	while (len >= 4) {
+		// encrypt block by XOR-ing with the key
+		ptr[0] = ptr[0] ^ (key >> 0);
+		ptr[1] = ptr[1] ^ (key >> 8);
+		ptr[2] = ptr[2] ^ (key >> 16);
+		ptr[3] = ptr[3] ^ (key >> 24);
+
+		// move on
+		ptr += 4;
+		len -= 4;
+	}
+}
+
+// the following function is homebrew crypto written for this test.  This is a bad algorithm
+// on multiple levels and should never be used in cryptography.
+void MyEncrypt(const unsigned int *dataIn, unsigned int *dataOut, unsigned int dataSize, unsigned int key[2]) {
+	unsigned int state[2];
+	unsigned int t;
+
+	state[0] = key[0];
+	state[1] = key[1];
+	
+	for (unsigned int i = 0; i < dataSize; i++) {
+		// mix state
+		t = state[0];
+		state[0] = (state[0] << 1) | (state[1] >> 31);
+		state[1] = (state[1] << 1) | (t >> 31);
+
+		// encrypt data
+		dataOut[i] = dataIn[i] ^ state[0];
+	}
+}
+
+// the following function resembles an implementation of the AES "mix columns"
+// step. It is not accurate, efficient or safe and should never be used in
+// cryptography.
+void mix_columns(const uint8_t inputs[4], uint8_t outputs[4]) {
+	// The "mix columns" step takes four bytes as inputs. Each byte represents a
+	// polynomial with 8 one-bit coefficients, e.g. input bits 00001101
+	// represent the polynomial x^3 + x^2 + 1.  Arithmetic is reduced modulo
+	// x^8 + x^4 + x^3 + x + 1 (= 0x11b).
+	//
+	// The "mix columns" step multiplies each input by 2 (in the field described
+	// above) to produce four more values. The output is then four values
+	// produced by XOR-ing specific combinations of five of these eight values.
+	// The exact values selected here do not match the actual AES algorithm.
+	//
+	// We avoid control flow decisions that depend on the inputs.
+	uint8_t vs[4];
+
+	vs[0] = inputs[0] << 1; // multiply by two
+	vs[0] ^= (inputs[0] >> 7) * 0x1b; // reduce modulo 0x11b; the top bit was removed in the shift.
+	vs[1] = inputs[1] << 1;
+	vs[1] ^= (inputs[1] >> 7) * 0x1b;
+	vs[2] = inputs[2] << 1;
+	vs[2] ^= (inputs[2] >> 7) * 0x1b;
+	vs[3] = inputs[3] << 1;
+	vs[3] ^= (inputs[3] >> 7) * 0x1b;
+
+	outputs[0] = inputs[0] ^ inputs[1] ^ inputs[2] ^ vs[0] ^ vs[1];
+	outputs[1] = inputs[1] ^ inputs[2] ^ inputs[3] ^ vs[1] ^ vs[2];
+	outputs[2] = inputs[2] ^ inputs[3] ^ inputs[0] ^ vs[2] ^ vs[3];
+	outputs[3] = inputs[3] ^ inputs[0] ^ inputs[1] ^ vs[3] ^ vs[0];
+}
+
+// the following function resembles initialization of an S-box as may be done
+// in an implementation of DES, AES and other encryption algorithms. It is not
+// accurate, efficient or safe and should never be used in cryptography.
+void init_aes_sbox(unsigned char data[256]) {
+	// initialize `data` in a loop using lots of ^, ^= and << operations and
+	// a few fixed constants.
+	unsigned int state = 0x12345678;
+
+	for (int i = 0; i < 256; i++)
+	{
+		state ^= (i ^ 0x86) << 24;
+		state ^= (i ^ 0xb9) << 16;
+		state ^= (i ^ 0x11) << 8;
+		state ^= (i ^ 0x23) << 0;
+		state = (state << 1) ^ (state >> 31);
+		data[i] = state & 0xff;
+	}
+}

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-1240/tests_not_crypto.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-1240/tests_not_crypto.cpp
@@ -21,7 +21,22 @@ namespace std
 	extern ostream cout;
 }
 
+// this macro expands to some compute operations that look a bit like cryptography
+#define COMPUTE(v) \
+	v[0] ^= v[1] ^ v[2] ^ v[3] ^ v[4]; \
+	v[1] ^= v[2] ^ v[3] ^ v[4] ^ v[5]; \
+	v[2] ^= v[3] ^ v[4] ^ v[5] ^ v[6]; \
+	v[3] ^= v[4] ^ v[5] ^ v[6] ^ v[7];
+
 // ---
+
+#include "library/tests_library.h"
+
+bool isEnabledAes() {
+	// This function has "Aes" in it's name, but does not contain enough compute to
+	// be an encryption implementation.
+	return false;
+}
 
 uint32_t lookup[256];
 
@@ -78,13 +93,6 @@ void output_encrypt_decrypt_algorithms() {
 	std::cout << indent << "Twofish (" << yes_no_setting() << ")\n";
 	std::cout << indent << "Chacha (" << yes_no_setting() << ")\n";
 }
-
-// this macro expands to some compute operations that look a bit like cryptography
-#define COMPUTE(v) \
-	v[0] ^= v[1] ^ v[2] ^ v[3] ^ v[4]; \
-	v[1] ^= v[2] ^ v[3] ^ v[4] ^ v[5]; \
-	v[2] ^= v[3] ^ v[4] ^ v[5] ^ v[6]; \
-	v[3] ^= v[4] ^ v[5] ^ v[6] ^ v[7];
 
 void wideStringCharsAt(int *v) {
 	// This function has "des" and "rsa" in the name.

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-1240/tests_not_crypto.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-1240/tests_not_crypto.cpp
@@ -1,0 +1,107 @@
+// Non-cryptography snippets.  Nothing in this file should be flagged by the query.
+
+typedef unsigned char uint8_t;
+typedef unsigned int uint32_t;
+typedef unsigned long size_t;
+
+// a very cut down stub for `std::cout`
+namespace std
+{
+	template<class charT> struct char_traits;
+
+	template <class charT, class traits = char_traits<charT> >
+	class basic_ostream {
+	public:
+		typedef charT char_type;
+	};
+	template<class charT, class traits> basic_ostream<charT,traits>& operator<<(basic_ostream<charT,traits>&, const charT*);
+
+	typedef basic_ostream<char> ostream;
+
+	extern ostream cout;
+}
+
+// ---
+
+uint32_t lookup[256];
+
+uint8_t computeCRC32(const uint8_t *data, size_t dataLen) {
+	// This function has "RC3" in its name, but is not an implementation of the (broken) RC3 encryption algorithm.
+	uint32_t result = 0xFFFFFFFF;
+
+	for (size_t i = 0; i < dataLen; i++) {
+		result = (result >> 8) + lookup[(result ^ data[i]) & 0xFF];
+		result = (result >> 8) + lookup[(result ^ data[i]) & 0xFF]; // artificial extra compute
+		result = (result >> 8) + lookup[(result ^ data[i]) & 0xFF]; // artificial extra compute
+		result = (result >> 8) + lookup[(result ^ data[i]) & 0xFF]; // artificial extra compute
+	}
+
+	return result ^ 0xFFFFFFFF;
+}
+
+void convert_image_universal(uint32_t *img, int width, int height) {
+	// This function has "rsa" in its name, but is nothing to do with the RSA encryption algorithm.
+	uint32_t *pixel_ptr = img;
+	uint32_t num_pixels = width * height;
+
+	// convert pixels RGBA -> ARGB (with probably unhelpful loop unrolling)
+	while (num_pixels >= 4) {
+		pixel_ptr[0] = (pixel_ptr[0] >> 8) ^ (pixel_ptr[0] << 24);
+		pixel_ptr[1] = (pixel_ptr[1] >> 8) ^ (pixel_ptr[1] << 24);
+		pixel_ptr[2] = (pixel_ptr[2] >> 8) ^ (pixel_ptr[2] << 24);
+		pixel_ptr[3] = (pixel_ptr[3] >> 8) ^ (pixel_ptr[3] << 24);
+		num_pixels -= 4;
+	}
+	if (num_pixels >= 2) {
+		pixel_ptr[0] = (pixel_ptr[0] >> 8) ^ (pixel_ptr[0] << 24);
+		pixel_ptr[1] = (pixel_ptr[1] >> 8) ^ (pixel_ptr[1] << 24);
+		num_pixels -= 2;
+	}
+	if (num_pixels >= 1) {
+		pixel_ptr[2] = (pixel_ptr[2] >> 8) ^ (pixel_ptr[2] << 24);
+	}
+}
+
+const char* yes_no_setting() { return "no"; }
+
+void output_encrypt_decrypt_algorithms() {
+	// This function has "encrypt" and "decrypt" in its name, but no encryption is done.
+	// This function uses `<<` heavily, but not as an integer shift left.
+	const char *indent = "  ";
+
+	std::cout << "Supported algorithms:\n";
+	std::cout << indent << "DES (" << yes_no_setting() << ")\n";
+	std::cout << indent << "3DES (" << yes_no_setting() << ")\n";
+	std::cout << indent << "AES (" << yes_no_setting() << ")\n";
+	std::cout << indent << "RSA (" << yes_no_setting() << ")\n";
+	std::cout << indent << "Blowfish (" << yes_no_setting() << ")\n";
+	std::cout << indent << "Twofish (" << yes_no_setting() << ")\n";
+	std::cout << indent << "Chacha (" << yes_no_setting() << ")\n";
+}
+
+// this macro expands to some compute operations that look a bit like cryptography
+#define COMPUTE(v) \
+	v[0] ^= v[1] ^ v[2] ^ v[3] ^ v[4]; \
+	v[1] ^= v[2] ^ v[3] ^ v[4] ^ v[5]; \
+	v[2] ^= v[3] ^ v[4] ^ v[5] ^ v[6]; \
+	v[3] ^= v[4] ^ v[5] ^ v[6] ^ v[7];
+
+void wideStringCharsAt(int *v) {
+	// This function has "des" and "rsa" in the name.
+	COMPUTE(v)
+}
+
+void bitcastVariable(int *v) {
+	// This function has "aria" and "cast" in the name.
+	COMPUTE(v)
+}
+
+void dividesVariance(int *v) {
+	// This function has "des" and "aria" in the name.
+	COMPUTE(v)
+}
+
+void broadcastNodes(int *v) {
+	// This function has "cast" and "des" in the name.
+	COMPUTE(v)
+}

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-1240/tests_not_crypto.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-1240/tests_not_crypto.cpp
@@ -113,3 +113,26 @@ void broadcastNodes(int *v) {
 	// This function has "cast" and "des" in the name.
 	COMPUTE(v)
 }
+
+#define ROTATE(val, amount) ( (val << amount) | (val >> (32 - amount)) )
+
+static inline void hashMix(const int *data, int &state) {
+	// This function looks like part of a hashing function.  It's not necessarily intended to
+	// be a cryptographic hash, so should not be flagged.
+	state ^= data[0];
+	ROTATE(state, 1);
+	state ^= data[1];
+	ROTATE(state, 7);
+	state ^= data[2];
+	ROTATE(state, 11);
+	state ^= data[3];
+	ROTATE(state, 3);
+	state ^= data[4];
+	ROTATE(state, 13);
+	state ^= data[5];
+	ROTATE(state, 5);
+	state ^= data[6];
+	ROTATE(state, 2);
+	state ^= data[7];
+	ROTATE(state, 17);
+}


### PR DESCRIPTION
Adds an experimental query for detecting custom implementations of a cryptographic primitive (i.e. covering https://mas.owasp.org/MASTG/General/0x04g-Testing-Cryptography/#custom-implementations-of-cryptography
 and parts of https://cwe.mitre.org/data/definitions/1240.html).

Currently `@precision medium`, because it flags established library encryption implementations just as happily as custom implementations and entirely custom algorithms.  Though probably none of these should be in a database unless it's a database for a cryptography library.

Developed during a hackathon.  Needs more work to be production quality - in particular it currently lacks:
- [ ] qhelp / examples --- not strictly necessary for experimental.
- [x] more non-crypto unit tests --- I have added a few more test cases that should not be flagged.
- [x] more crypto unit tests --- I have added a couple of 'homebrew' algorithms in the test that should be flagged.
- [x] and perhaps some more testing in the wild and refinement. --- further refinement: we now reject results that appear to be in encryption libraries.