### PR TITLE
Fix rst code format.

### DIFF
--- a/docs/codeql/codeql-language-guides/using-api-graphs-in-python.rst
+++ b/docs/codeql/codeql-language-guides/using-api-graphs-in-python.rst
@@ -97,8 +97,8 @@ local flow. To get just the *calls* to ``re.compile``, you can use ``asSource`` 
 ``getReturn`` followed by ``asSource``, simply use ``getACall``. This will result in an
 ``API::CallNode``, which deserves a small description of its own.
 
-``API::CallNode``s are not ``API::Node``s. Instead they are ``DataFlow::Node``s with some convenience
-predicates that allows you to recover ``API::Node``s for the return value as well as for arguments
+``API::CallNode``\ s are not ``API::Node``\ s. Instead they are ``DataFlow::Node``\ s with some convenience
+predicates that allows you to recover ``API::Node``\ s for the return value as well as for arguments
 to the call. This enables you to constrain the call in various ways using the API graph. The following
 snippet finds all calls to ``re.compile`` where the ``pattern`` argument comes from parsing a command
 line argument using the ``argparse`` library.


### PR DESCRIPTION
This fixes the code format.

Before:
<img width="580" alt="图片" src="https://github.com/github/codeql/assets/948336/64234b3e-3241-4c3c-9f34-78f35e7d6447">

After:
<img width="591" alt="图片" src="https://github.com/github/codeql/assets/948336/dbf11718-7752-4561-83c6-5296b69a5b37">
