### PR TITLE
Prepare for the bazel 7 upgrade.

### DIFF
--- a/swift/extractor/trap/BUILD.bazel
+++ b/swift/extractor/trap/BUILD.bazel
@@ -23,7 +23,7 @@ genrule(
         "--schema=$(location //swift:schema)",
         "--script-name=codegen/codegen.py",
     ]),
-    exec_tools = [
+    tools = [
         "//misc/codegen",
         "//swift:schema",
     ],


### PR DESCRIPTION
The exec_tools property is no more, see https://github.com/bazelbuild/bazel/issues/19132.