### PR TITLE
Java: Just make the implementation slightly clearer for threat models.

### DIFF
--- a/shared/threat-models/codeql/threatmodels/ThreatModels.qll
+++ b/shared/threat-models/codeql/threatmodels/ThreatModels.qll
@@ -59,7 +59,7 @@ private predicate threatModelEnabled(string kind) {
       threatModelConfiguration(configuredKind, enabled, priority)
     )
   |
-    enabled order by priority
+    enabled order by priority, enabled
   ) = true
 }
 


### PR DESCRIPTION
There was a question on whether a threat model is enabled, when there exist two tuples with the same priority but different `enabled` columns.
Even though it is stated clearly in the comment, we also order the result based on the enabled column. This is a semantics preserving change.