### PR TITLE
C#: Prefer assembly version over netcore version in conflict resolution

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/AssemblyCacheExtensions.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/AssemblyCacheExtensions.cs
@@ -9,7 +9,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         private static readonly Version emptyVersion = new Version(0, 0, 0, 0);
 
         /// <summary>
-        /// This method orders AssemblyInfos by version numbers (.net core version first, then assembly version). Finally, it orders by filename to make the order deterministic.
+        /// This method orders AssemblyInfos. The method is used to define the assembly preference order in case of conflicts.
         /// </summary>
         public static IOrderedEnumerable<AssemblyInfo> OrderAssemblyInfosByPreference(this IEnumerable<AssemblyInfo> assemblies, IEnumerable<string> frameworkPaths)
         {

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/AssemblyCacheExtensions.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/AssemblyCacheExtensions.cs
@@ -21,8 +21,8 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 : assemblies.OrderBy(initialOrdering);
 
             return ordered
-                .ThenBy(info => info.NetCoreVersion ?? emptyVersion)
                 .ThenBy(info => info.Version ?? emptyVersion)
+                .ThenBy(info => info.NetCoreVersion ?? emptyVersion)
                 .ThenBy(info => info.Filename);
         }
     }

--- a/csharp/ql/integration-tests/posix-only/standalone_dependencies/Assemblies.expected
+++ b/csharp/ql/integration-tests/posix-only/standalone_dependencies/Assemblies.expected
@@ -1,5 +1,6 @@
 | /avalara.avatax/21.10.0/lib/netstandard20/Avalara.AvaTax.netstandard20.dll |
 | /microsoft.bcl.asyncinterfaces/6.0.0/lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll |
+| /microsoft.netcore.app.ref/3.1.0/ref/netcoreapp3.1/System.Data.DataSetExtensions.dll |
 | /microsoft.netcore.app.ref/3.1.0/ref/netcoreapp3.1/System.Runtime.InteropServices.WindowsRuntime.dll |
 | /microsoft.netcore.app.ref/6.0.13/ref/net6.0/System.Data.dll |
 | /microsoft.netcore.app.ref/6.0.13/ref/net6.0/System.Xml.dll |
@@ -26,7 +27,6 @@
 | /microsoft.netcore.app.ref/7.0.2/ref/net7.0/System.Console.dll |
 | /microsoft.netcore.app.ref/7.0.2/ref/net7.0/System.Core.dll |
 | /microsoft.netcore.app.ref/7.0.2/ref/net7.0/System.Data.Common.dll |
-| /microsoft.netcore.app.ref/7.0.2/ref/net7.0/System.Data.DataSetExtensions.dll |
 | /microsoft.netcore.app.ref/7.0.2/ref/net7.0/System.Diagnostics.Contracts.dll |
 | /microsoft.netcore.app.ref/7.0.2/ref/net7.0/System.Diagnostics.Debug.dll |
 | /microsoft.netcore.app.ref/7.0.2/ref/net7.0/System.Diagnostics.DiagnosticSource.dll |

--- a/csharp/ql/integration-tests/windows-only/standalone_dependencies/Assemblies.expected
+++ b/csharp/ql/integration-tests/windows-only/standalone_dependencies/Assemblies.expected
@@ -1,5 +1,6 @@
 | /avalara.avatax/21.10.0/lib/netstandard20/Avalara.AvaTax.netstandard20.dll |
 | /microsoft.bcl.asyncinterfaces/6.0.0/lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll |
+| /microsoft.netcore.app.ref/3.1.0/ref/netcoreapp3.1/System.Data.DataSetExtensions.dll |
 | /microsoft.netcore.app.ref/3.1.0/ref/netcoreapp3.1/System.Runtime.InteropServices.WindowsRuntime.dll |
 | /microsoft.netcore.app.ref/6.0.13/ref/net6.0/System.Data.dll |
 | /microsoft.netcore.app.ref/6.0.13/ref/net6.0/System.Xml.dll |
@@ -25,7 +26,6 @@
 | /microsoft.netcore.app.ref/7.0.2/ref/net7.0/System.Console.dll |
 | /microsoft.netcore.app.ref/7.0.2/ref/net7.0/System.Core.dll |
 | /microsoft.netcore.app.ref/7.0.2/ref/net7.0/System.Data.Common.dll |
-| /microsoft.netcore.app.ref/7.0.2/ref/net7.0/System.Data.DataSetExtensions.dll |
 | /microsoft.netcore.app.ref/7.0.2/ref/net7.0/System.Diagnostics.Contracts.dll |
 | /microsoft.netcore.app.ref/7.0.2/ref/net7.0/System.Diagnostics.Debug.dll |
 | /microsoft.netcore.app.ref/7.0.2/ref/net7.0/System.Diagnostics.DiagnosticSource.dll |


### PR DESCRIPTION
This PR is changing the sorting of conflicting assemblies. Assembly version now takes precedence over .net core version.