### PR TITLE
Update inconsistent CWE tags

### DIFF
--- a/csharp/ql/src/Security Features/CWE-639/InsecureDirectObjectReference.ql
+++ b/csharp/ql/src/Security Features/CWE-639/InsecureDirectObjectReference.ql
@@ -8,7 +8,7 @@
  * @precision medium
  * @id cs/web/insecure-direct-object-reference
  * @tags security
- *       external/cwe-639
+ *       external/cwe/cwe-639
  */
 
 import csharp

--- a/csharp/ql/src/experimental/Security Features/CWE-759/HashWithoutSalt.ql
+++ b/csharp/ql/src/experimental/Security Features/CWE-759/HashWithoutSalt.ql
@@ -6,7 +6,7 @@
  * @id cs/hash-without-salt
  * @tags security
  *       experimental
- *       external/cwe-759
+ *       external/cwe/cwe-759
  */
 
 import csharp

--- a/java/ql/src/experimental/Security/CWE/CWE-073/FilePathInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-073/FilePathInjection.ql
@@ -9,7 +9,7 @@
  * @id java/file-path-injection
  * @tags security
  *       experimental
- *       external/cwe-073
+ *       external/cwe/cwe-073
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-552/UnsafeUrlForward.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-552/UnsafeUrlForward.ql
@@ -8,7 +8,7 @@
  * @id java/unsafe-url-forward-dispatch-load
  * @tags security
  *       experimental
- *       external/cwe-552
+ *       external/cwe/cwe-552
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-625/PermissiveDotRegex.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-625/PermissiveDotRegex.ql
@@ -8,8 +8,8 @@
  * @id java/permissive-dot-regex
  * @tags security
  *       experimental
- *       external/cwe-625
- *       external/cwe-863
+ *       external/cwe/cwe-625
+ *       external/cwe/cwe-863
  */
 
 import java


### PR DESCRIPTION
Most tags use the "external/cwe/cwe-xxx" format, except for these few queries. Updating them for consistency (even though most of them are experimental).

Noticed in passing while we were adding a process for GitHub docs to automatically pull in query lists with their associated CWEs.