### PR TITLE
Swift: Add some tests and model SecKeyCopyExternalRepresentation

### DIFF
--- a/swift/ql/lib/change-notes/2023-12-05-seckey.md
+++ b/swift/ql/lib/change-notes/2023-12-05-seckey.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added a sensitive data model for `SecKeyCopyExternalRepresentation`.

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Security.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Security.qll
@@ -1,0 +1,13 @@
+/**
+ * Provides models for standard library Swift classses related to security
+ * (certificate, key and trust services).
+ */
+
+import swift
+private import codeql.swift.dataflow.ExternalFlow
+
+private class SensitiveSources extends SourceModelCsv {
+  override predicate row(string row) {
+    row = ";;false;SecKeyCopyExternalRepresentation(_:_:);;;ReturnValue;sensitive-credential"
+  }
+}

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/StandardLibrary.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/StandardLibrary.qll
@@ -19,6 +19,7 @@ private import NsUrl
 private import Numeric
 private import RawRepresentable
 private import PointerTypes
+private import Security
 private import Sequence
 private import Set
 private import Stream

--- a/swift/ql/lib/codeql/swift/security/SensitiveExprs.qll
+++ b/swift/ql/lib/codeql/swift/security/SensitiveExprs.qll
@@ -6,6 +6,8 @@
 
 import swift
 import internal.SensitiveDataHeuristics
+private import codeql.swift.dataflow.DataFlow
+private import codeql.swift.dataflow.ExternalFlow
 
 private newtype TSensitiveDataType =
   TCredential() or
@@ -172,6 +174,18 @@ class SensitiveExpr extends Expr {
     ) and
     // do not mark as sensitive it if it is probably safe
     not label.regexpMatch(regexpProbablySafe())
+    or
+    (
+      // modelled sensitive credential
+      sourceNode(DataFlow::exprNode(this), "sensitive-credential") and
+      sensitiveType = TCredential() and
+      label = "credential"
+      or
+      // modelled sensitive private information
+      sourceNode(DataFlow::exprNode(this), "sensitive-private-info") and
+      sensitiveType = TPrivateInfo() and
+      label = "private information"
+    )
   }
 
   /**

--- a/swift/ql/test/query-tests/Security/CWE-311/CleartextStorageDatabase.expected
+++ b/swift/ql/test/query-tests/Security/CWE-311/CleartextStorageDatabase.expected
@@ -555,6 +555,8 @@ nodes
 | testCoreData.swift:95:15:95:15 | x | semmle.label | x |
 | testCoreData.swift:96:15:96:15 | y | semmle.label | y |
 | testCoreData.swift:97:15:97:15 | z | semmle.label | z |
+| testCoreData.swift:128:15:128:33 | call to generateSecretKey() | semmle.label | call to generateSecretKey() |
+| testCoreData.swift:129:15:129:30 | call to getCertificate() | semmle.label | call to getCertificate() |
 | testGRDB.swift:73:56:73:65 | [...] | semmle.label | [...] |
 | testGRDB.swift:73:56:73:65 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:73:57:73:57 | password | semmle.label | password |
@@ -825,6 +827,8 @@ subpaths
 | testCoreData.swift:95:15:95:15 | x | testCoreData.swift:91:10:91:10 | passwd | testCoreData.swift:95:15:95:15 | x | This operation stores 'x' in a database. It may contain unencrypted sensitive data from $@. | testCoreData.swift:91:10:91:10 | passwd | passwd |
 | testCoreData.swift:96:15:96:15 | y | testCoreData.swift:92:10:92:10 | passwd | testCoreData.swift:96:15:96:15 | y | This operation stores 'y' in a database. It may contain unencrypted sensitive data from $@. | testCoreData.swift:92:10:92:10 | passwd | passwd |
 | testCoreData.swift:97:15:97:15 | z | testCoreData.swift:93:10:93:10 | passwd | testCoreData.swift:97:15:97:15 | z | This operation stores 'z' in a database. It may contain unencrypted sensitive data from $@. | testCoreData.swift:93:10:93:10 | passwd | passwd |
+| testCoreData.swift:128:15:128:33 | call to generateSecretKey() | testCoreData.swift:128:15:128:33 | call to generateSecretKey() | testCoreData.swift:128:15:128:33 | call to generateSecretKey() | This operation stores 'call to generateSecretKey()' in a database. It may contain unencrypted sensitive data from $@. | testCoreData.swift:128:15:128:33 | call to generateSecretKey() | call to generateSecretKey() |
+| testCoreData.swift:129:15:129:30 | call to getCertificate() | testCoreData.swift:129:15:129:30 | call to getCertificate() | testCoreData.swift:129:15:129:30 | call to getCertificate() | This operation stores 'call to getCertificate()' in a database. It may contain unencrypted sensitive data from $@. | testCoreData.swift:129:15:129:30 | call to getCertificate() | call to getCertificate() |
 | testGRDB.swift:73:56:73:65 | [...] | testGRDB.swift:73:57:73:57 | password | testGRDB.swift:73:56:73:65 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:73:57:73:57 | password | password |
 | testGRDB.swift:76:42:76:51 | [...] | testGRDB.swift:76:43:76:43 | password | testGRDB.swift:76:42:76:51 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:76:43:76:43 | password | password |
 | testGRDB.swift:81:44:81:53 | [...] | testGRDB.swift:81:45:81:45 | password | testGRDB.swift:81:44:81:53 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:81:45:81:45 | password | password |

--- a/swift/ql/test/query-tests/Security/CWE-311/CleartextTransmission.expected
+++ b/swift/ql/test/query-tests/Security/CWE-311/CleartextTransmission.expected
@@ -14,12 +14,15 @@ edges
 | testSend.swift:86:7:86:7 | self | file://:0:0:0:0 | self |
 | testSend.swift:94:27:94:30 | .password | testSend.swift:86:7:86:7 | self |
 | testSend.swift:94:27:94:30 | .password | testSend.swift:94:27:94:39 | .value |
-| testURL.swift:17:54:17:54 | passwd | testURL.swift:17:22:17:54 | ... .+(_:_:) ... |
-| testURL.swift:19:55:19:55 | account_no | testURL.swift:19:22:19:55 | ... .+(_:_:) ... |
-| testURL.swift:20:55:20:55 | credit_card_no | testURL.swift:20:22:20:55 | ... .+(_:_:) ... |
-| testURL.swift:28:55:28:55 | e_mail | testURL.swift:28:22:28:55 | ... .+(_:_:) ... |
-| testURL.swift:30:57:30:57 | a_homeaddr_z | testURL.swift:30:22:30:57 | ... .+(_:_:) ... |
-| testURL.swift:32:55:32:55 | resident_ID | testURL.swift:32:22:32:55 | ... .+(_:_:) ... |
+| testURL.swift:17:50:17:50 | passwd | testURL.swift:17:18:17:50 | ... .+(_:_:) ... |
+| testURL.swift:19:51:19:51 | account_no | testURL.swift:19:18:19:51 | ... .+(_:_:) ... |
+| testURL.swift:20:51:20:51 | credit_card_no | testURL.swift:20:18:20:51 | ... .+(_:_:) ... |
+| testURL.swift:28:51:28:51 | e_mail | testURL.swift:28:18:28:51 | ... .+(_:_:) ... |
+| testURL.swift:30:53:30:53 | a_homeaddr_z | testURL.swift:30:18:30:53 | ... .+(_:_:) ... |
+| testURL.swift:32:51:32:51 | resident_ID | testURL.swift:32:18:32:51 | ... .+(_:_:) ... |
+| testURL.swift:51:52:51:67 | call to get_secret_key() | testURL.swift:51:18:51:67 | ... .+(_:_:) ... |
+| testURL.swift:53:53:53:69 | call to get_cert_string() | testURL.swift:53:18:53:69 | ... .+(_:_:) ... |
+| testURL.swift:74:51:74:51 | certificate | testURL.swift:74:18:74:18 | "..." |
 nodes
 | file://:0:0:0:0 | .value | semmle.label | .value |
 | file://:0:0:0:0 | self | semmle.label | self |
@@ -52,19 +55,25 @@ nodes
 | testSend.swift:86:7:86:7 | self | semmle.label | self |
 | testSend.swift:94:27:94:30 | .password | semmle.label | .password |
 | testSend.swift:94:27:94:39 | .value | semmle.label | .value |
-| testURL.swift:17:22:17:54 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
-| testURL.swift:17:54:17:54 | passwd | semmle.label | passwd |
-| testURL.swift:19:22:19:55 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
-| testURL.swift:19:55:19:55 | account_no | semmle.label | account_no |
-| testURL.swift:20:22:20:55 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
-| testURL.swift:20:55:20:55 | credit_card_no | semmle.label | credit_card_no |
+| testURL.swift:17:18:17:50 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
+| testURL.swift:17:50:17:50 | passwd | semmle.label | passwd |
+| testURL.swift:19:18:19:51 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
+| testURL.swift:19:51:19:51 | account_no | semmle.label | account_no |
+| testURL.swift:20:18:20:51 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
+| testURL.swift:20:51:20:51 | credit_card_no | semmle.label | credit_card_no |
 | testURL.swift:24:22:24:22 | passwd | semmle.label | passwd |
-| testURL.swift:28:22:28:55 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
-| testURL.swift:28:55:28:55 | e_mail | semmle.label | e_mail |
-| testURL.swift:30:22:30:57 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
-| testURL.swift:30:57:30:57 | a_homeaddr_z | semmle.label | a_homeaddr_z |
-| testURL.swift:32:22:32:55 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
-| testURL.swift:32:55:32:55 | resident_ID | semmle.label | resident_ID |
+| testURL.swift:28:18:28:51 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
+| testURL.swift:28:51:28:51 | e_mail | semmle.label | e_mail |
+| testURL.swift:30:18:30:53 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
+| testURL.swift:30:53:30:53 | a_homeaddr_z | semmle.label | a_homeaddr_z |
+| testURL.swift:32:18:32:51 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
+| testURL.swift:32:51:32:51 | resident_ID | semmle.label | resident_ID |
+| testURL.swift:51:18:51:67 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
+| testURL.swift:51:52:51:67 | call to get_secret_key() | semmle.label | call to get_secret_key() |
+| testURL.swift:53:18:53:69 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
+| testURL.swift:53:53:53:69 | call to get_cert_string() | semmle.label | call to get_cert_string() |
+| testURL.swift:74:18:74:18 | "..." | semmle.label | "..." |
+| testURL.swift:74:51:74:51 | certificate | semmle.label | certificate |
 subpaths
 | testSend.swift:60:17:60:17 | password | testSend.swift:41:10:41:18 | data | testSend.swift:41:45:41:45 | data | testSend.swift:60:13:60:25 | call to pad(_:) |
 | testSend.swift:94:27:94:30 | .password | testSend.swift:86:7:86:7 | self | file://:0:0:0:0 | .value | testSend.swift:94:27:94:39 | .value |
@@ -85,10 +94,13 @@ subpaths
 | testSend.swift:79:27:79:30 | .BankCardNo | testSend.swift:79:27:79:30 | .BankCardNo | testSend.swift:79:27:79:30 | .BankCardNo | This operation transmits '.BankCardNo', which may contain unencrypted sensitive data from $@. | testSend.swift:79:27:79:30 | .BankCardNo | .BankCardNo |
 | testSend.swift:80:27:80:30 | .MyCreditRating | testSend.swift:80:27:80:30 | .MyCreditRating | testSend.swift:80:27:80:30 | .MyCreditRating | This operation transmits '.MyCreditRating', which may contain unencrypted sensitive data from $@. | testSend.swift:80:27:80:30 | .MyCreditRating | .MyCreditRating |
 | testSend.swift:94:27:94:39 | .value | testSend.swift:94:27:94:30 | .password | testSend.swift:94:27:94:39 | .value | This operation transmits '.value', which may contain unencrypted sensitive data from $@. | testSend.swift:94:27:94:30 | .password | .password |
-| testURL.swift:17:22:17:54 | ... .+(_:_:) ... | testURL.swift:17:54:17:54 | passwd | testURL.swift:17:22:17:54 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:17:54:17:54 | passwd | passwd |
-| testURL.swift:19:22:19:55 | ... .+(_:_:) ... | testURL.swift:19:55:19:55 | account_no | testURL.swift:19:22:19:55 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:19:55:19:55 | account_no | account_no |
-| testURL.swift:20:22:20:55 | ... .+(_:_:) ... | testURL.swift:20:55:20:55 | credit_card_no | testURL.swift:20:22:20:55 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:20:55:20:55 | credit_card_no | credit_card_no |
+| testURL.swift:17:18:17:50 | ... .+(_:_:) ... | testURL.swift:17:50:17:50 | passwd | testURL.swift:17:18:17:50 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:17:50:17:50 | passwd | passwd |
+| testURL.swift:19:18:19:51 | ... .+(_:_:) ... | testURL.swift:19:51:19:51 | account_no | testURL.swift:19:18:19:51 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:19:51:19:51 | account_no | account_no |
+| testURL.swift:20:18:20:51 | ... .+(_:_:) ... | testURL.swift:20:51:20:51 | credit_card_no | testURL.swift:20:18:20:51 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:20:51:20:51 | credit_card_no | credit_card_no |
 | testURL.swift:24:22:24:22 | passwd | testURL.swift:24:22:24:22 | passwd | testURL.swift:24:22:24:22 | passwd | This operation transmits 'passwd', which may contain unencrypted sensitive data from $@. | testURL.swift:24:22:24:22 | passwd | passwd |
-| testURL.swift:28:22:28:55 | ... .+(_:_:) ... | testURL.swift:28:55:28:55 | e_mail | testURL.swift:28:22:28:55 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:28:55:28:55 | e_mail | e_mail |
-| testURL.swift:30:22:30:57 | ... .+(_:_:) ... | testURL.swift:30:57:30:57 | a_homeaddr_z | testURL.swift:30:22:30:57 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:30:57:30:57 | a_homeaddr_z | a_homeaddr_z |
-| testURL.swift:32:22:32:55 | ... .+(_:_:) ... | testURL.swift:32:55:32:55 | resident_ID | testURL.swift:32:22:32:55 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:32:55:32:55 | resident_ID | resident_ID |
+| testURL.swift:28:18:28:51 | ... .+(_:_:) ... | testURL.swift:28:51:28:51 | e_mail | testURL.swift:28:18:28:51 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:28:51:28:51 | e_mail | e_mail |
+| testURL.swift:30:18:30:53 | ... .+(_:_:) ... | testURL.swift:30:53:30:53 | a_homeaddr_z | testURL.swift:30:18:30:53 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:30:53:30:53 | a_homeaddr_z | a_homeaddr_z |
+| testURL.swift:32:18:32:51 | ... .+(_:_:) ... | testURL.swift:32:51:32:51 | resident_ID | testURL.swift:32:18:32:51 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:32:51:32:51 | resident_ID | resident_ID |
+| testURL.swift:51:18:51:67 | ... .+(_:_:) ... | testURL.swift:51:52:51:67 | call to get_secret_key() | testURL.swift:51:18:51:67 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:51:52:51:67 | call to get_secret_key() | call to get_secret_key() |
+| testURL.swift:53:18:53:69 | ... .+(_:_:) ... | testURL.swift:53:53:53:69 | call to get_cert_string() | testURL.swift:53:18:53:69 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:53:53:53:69 | call to get_cert_string() | call to get_cert_string() |
+| testURL.swift:74:18:74:18 | "..." | testURL.swift:74:51:74:51 | certificate | testURL.swift:74:18:74:18 | "..." | This operation transmits '"..."', which may contain unencrypted sensitive data from $@. | testURL.swift:74:51:74:51 | certificate | certificate |

--- a/swift/ql/test/query-tests/Security/CWE-311/CleartextTransmission.expected
+++ b/swift/ql/test/query-tests/Security/CWE-311/CleartextTransmission.expected
@@ -14,15 +14,15 @@ edges
 | testSend.swift:86:7:86:7 | self | file://:0:0:0:0 | self |
 | testSend.swift:94:27:94:30 | .password | testSend.swift:86:7:86:7 | self |
 | testSend.swift:94:27:94:30 | .password | testSend.swift:94:27:94:39 | .value |
-| testURL.swift:17:50:17:50 | passwd | testURL.swift:17:18:17:50 | ... .+(_:_:) ... |
-| testURL.swift:19:51:19:51 | account_no | testURL.swift:19:18:19:51 | ... .+(_:_:) ... |
-| testURL.swift:20:51:20:51 | credit_card_no | testURL.swift:20:18:20:51 | ... .+(_:_:) ... |
-| testURL.swift:28:51:28:51 | e_mail | testURL.swift:28:18:28:51 | ... .+(_:_:) ... |
-| testURL.swift:30:53:30:53 | a_homeaddr_z | testURL.swift:30:18:30:53 | ... .+(_:_:) ... |
-| testURL.swift:32:51:32:51 | resident_ID | testURL.swift:32:18:32:51 | ... .+(_:_:) ... |
-| testURL.swift:51:52:51:67 | call to get_secret_key() | testURL.swift:51:18:51:67 | ... .+(_:_:) ... |
-| testURL.swift:53:53:53:69 | call to get_cert_string() | testURL.swift:53:18:53:69 | ... .+(_:_:) ... |
-| testURL.swift:74:51:74:51 | certificate | testURL.swift:74:18:74:18 | "..." |
+| testURL.swift:39:50:39:50 | passwd | testURL.swift:39:18:39:50 | ... .+(_:_:) ... |
+| testURL.swift:41:51:41:51 | account_no | testURL.swift:41:18:41:51 | ... .+(_:_:) ... |
+| testURL.swift:42:51:42:51 | credit_card_no | testURL.swift:42:18:42:51 | ... .+(_:_:) ... |
+| testURL.swift:50:51:50:51 | e_mail | testURL.swift:50:18:50:51 | ... .+(_:_:) ... |
+| testURL.swift:52:53:52:53 | a_homeaddr_z | testURL.swift:52:18:52:53 | ... .+(_:_:) ... |
+| testURL.swift:54:51:54:51 | resident_ID | testURL.swift:54:18:54:51 | ... .+(_:_:) ... |
+| testURL.swift:73:52:73:67 | call to get_secret_key() | testURL.swift:73:18:73:67 | ... .+(_:_:) ... |
+| testURL.swift:75:53:75:69 | call to get_cert_string() | testURL.swift:75:18:75:69 | ... .+(_:_:) ... |
+| testURL.swift:96:51:96:51 | certificate | testURL.swift:96:18:96:18 | "..." |
 nodes
 | file://:0:0:0:0 | .value | semmle.label | .value |
 | file://:0:0:0:0 | self | semmle.label | self |
@@ -55,25 +55,25 @@ nodes
 | testSend.swift:86:7:86:7 | self | semmle.label | self |
 | testSend.swift:94:27:94:30 | .password | semmle.label | .password |
 | testSend.swift:94:27:94:39 | .value | semmle.label | .value |
-| testURL.swift:17:18:17:50 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
-| testURL.swift:17:50:17:50 | passwd | semmle.label | passwd |
-| testURL.swift:19:18:19:51 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
-| testURL.swift:19:51:19:51 | account_no | semmle.label | account_no |
-| testURL.swift:20:18:20:51 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
-| testURL.swift:20:51:20:51 | credit_card_no | semmle.label | credit_card_no |
-| testURL.swift:24:22:24:22 | passwd | semmle.label | passwd |
-| testURL.swift:28:18:28:51 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
-| testURL.swift:28:51:28:51 | e_mail | semmle.label | e_mail |
-| testURL.swift:30:18:30:53 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
-| testURL.swift:30:53:30:53 | a_homeaddr_z | semmle.label | a_homeaddr_z |
-| testURL.swift:32:18:32:51 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
-| testURL.swift:32:51:32:51 | resident_ID | semmle.label | resident_ID |
-| testURL.swift:51:18:51:67 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
-| testURL.swift:51:52:51:67 | call to get_secret_key() | semmle.label | call to get_secret_key() |
-| testURL.swift:53:18:53:69 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
-| testURL.swift:53:53:53:69 | call to get_cert_string() | semmle.label | call to get_cert_string() |
-| testURL.swift:74:18:74:18 | "..." | semmle.label | "..." |
-| testURL.swift:74:51:74:51 | certificate | semmle.label | certificate |
+| testURL.swift:39:18:39:50 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
+| testURL.swift:39:50:39:50 | passwd | semmle.label | passwd |
+| testURL.swift:41:18:41:51 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
+| testURL.swift:41:51:41:51 | account_no | semmle.label | account_no |
+| testURL.swift:42:18:42:51 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
+| testURL.swift:42:51:42:51 | credit_card_no | semmle.label | credit_card_no |
+| testURL.swift:46:22:46:22 | passwd | semmle.label | passwd |
+| testURL.swift:50:18:50:51 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
+| testURL.swift:50:51:50:51 | e_mail | semmle.label | e_mail |
+| testURL.swift:52:18:52:53 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
+| testURL.swift:52:53:52:53 | a_homeaddr_z | semmle.label | a_homeaddr_z |
+| testURL.swift:54:18:54:51 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
+| testURL.swift:54:51:54:51 | resident_ID | semmle.label | resident_ID |
+| testURL.swift:73:18:73:67 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
+| testURL.swift:73:52:73:67 | call to get_secret_key() | semmle.label | call to get_secret_key() |
+| testURL.swift:75:18:75:69 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
+| testURL.swift:75:53:75:69 | call to get_cert_string() | semmle.label | call to get_cert_string() |
+| testURL.swift:96:18:96:18 | "..." | semmle.label | "..." |
+| testURL.swift:96:51:96:51 | certificate | semmle.label | certificate |
 subpaths
 | testSend.swift:60:17:60:17 | password | testSend.swift:41:10:41:18 | data | testSend.swift:41:45:41:45 | data | testSend.swift:60:13:60:25 | call to pad(_:) |
 | testSend.swift:94:27:94:30 | .password | testSend.swift:86:7:86:7 | self | file://:0:0:0:0 | .value | testSend.swift:94:27:94:39 | .value |
@@ -94,13 +94,13 @@ subpaths
 | testSend.swift:79:27:79:30 | .BankCardNo | testSend.swift:79:27:79:30 | .BankCardNo | testSend.swift:79:27:79:30 | .BankCardNo | This operation transmits '.BankCardNo', which may contain unencrypted sensitive data from $@. | testSend.swift:79:27:79:30 | .BankCardNo | .BankCardNo |
 | testSend.swift:80:27:80:30 | .MyCreditRating | testSend.swift:80:27:80:30 | .MyCreditRating | testSend.swift:80:27:80:30 | .MyCreditRating | This operation transmits '.MyCreditRating', which may contain unencrypted sensitive data from $@. | testSend.swift:80:27:80:30 | .MyCreditRating | .MyCreditRating |
 | testSend.swift:94:27:94:39 | .value | testSend.swift:94:27:94:30 | .password | testSend.swift:94:27:94:39 | .value | This operation transmits '.value', which may contain unencrypted sensitive data from $@. | testSend.swift:94:27:94:30 | .password | .password |
-| testURL.swift:17:18:17:50 | ... .+(_:_:) ... | testURL.swift:17:50:17:50 | passwd | testURL.swift:17:18:17:50 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:17:50:17:50 | passwd | passwd |
-| testURL.swift:19:18:19:51 | ... .+(_:_:) ... | testURL.swift:19:51:19:51 | account_no | testURL.swift:19:18:19:51 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:19:51:19:51 | account_no | account_no |
-| testURL.swift:20:18:20:51 | ... .+(_:_:) ... | testURL.swift:20:51:20:51 | credit_card_no | testURL.swift:20:18:20:51 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:20:51:20:51 | credit_card_no | credit_card_no |
-| testURL.swift:24:22:24:22 | passwd | testURL.swift:24:22:24:22 | passwd | testURL.swift:24:22:24:22 | passwd | This operation transmits 'passwd', which may contain unencrypted sensitive data from $@. | testURL.swift:24:22:24:22 | passwd | passwd |
-| testURL.swift:28:18:28:51 | ... .+(_:_:) ... | testURL.swift:28:51:28:51 | e_mail | testURL.swift:28:18:28:51 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:28:51:28:51 | e_mail | e_mail |
-| testURL.swift:30:18:30:53 | ... .+(_:_:) ... | testURL.swift:30:53:30:53 | a_homeaddr_z | testURL.swift:30:18:30:53 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:30:53:30:53 | a_homeaddr_z | a_homeaddr_z |
-| testURL.swift:32:18:32:51 | ... .+(_:_:) ... | testURL.swift:32:51:32:51 | resident_ID | testURL.swift:32:18:32:51 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:32:51:32:51 | resident_ID | resident_ID |
-| testURL.swift:51:18:51:67 | ... .+(_:_:) ... | testURL.swift:51:52:51:67 | call to get_secret_key() | testURL.swift:51:18:51:67 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:51:52:51:67 | call to get_secret_key() | call to get_secret_key() |
-| testURL.swift:53:18:53:69 | ... .+(_:_:) ... | testURL.swift:53:53:53:69 | call to get_cert_string() | testURL.swift:53:18:53:69 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:53:53:53:69 | call to get_cert_string() | call to get_cert_string() |
-| testURL.swift:74:18:74:18 | "..." | testURL.swift:74:51:74:51 | certificate | testURL.swift:74:18:74:18 | "..." | This operation transmits '"..."', which may contain unencrypted sensitive data from $@. | testURL.swift:74:51:74:51 | certificate | certificate |
+| testURL.swift:39:18:39:50 | ... .+(_:_:) ... | testURL.swift:39:50:39:50 | passwd | testURL.swift:39:18:39:50 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:39:50:39:50 | passwd | passwd |
+| testURL.swift:41:18:41:51 | ... .+(_:_:) ... | testURL.swift:41:51:41:51 | account_no | testURL.swift:41:18:41:51 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:41:51:41:51 | account_no | account_no |
+| testURL.swift:42:18:42:51 | ... .+(_:_:) ... | testURL.swift:42:51:42:51 | credit_card_no | testURL.swift:42:18:42:51 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:42:51:42:51 | credit_card_no | credit_card_no |
+| testURL.swift:46:22:46:22 | passwd | testURL.swift:46:22:46:22 | passwd | testURL.swift:46:22:46:22 | passwd | This operation transmits 'passwd', which may contain unencrypted sensitive data from $@. | testURL.swift:46:22:46:22 | passwd | passwd |
+| testURL.swift:50:18:50:51 | ... .+(_:_:) ... | testURL.swift:50:51:50:51 | e_mail | testURL.swift:50:18:50:51 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:50:51:50:51 | e_mail | e_mail |
+| testURL.swift:52:18:52:53 | ... .+(_:_:) ... | testURL.swift:52:53:52:53 | a_homeaddr_z | testURL.swift:52:18:52:53 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:52:53:52:53 | a_homeaddr_z | a_homeaddr_z |
+| testURL.swift:54:18:54:51 | ... .+(_:_:) ... | testURL.swift:54:51:54:51 | resident_ID | testURL.swift:54:18:54:51 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:54:51:54:51 | resident_ID | resident_ID |
+| testURL.swift:73:18:73:67 | ... .+(_:_:) ... | testURL.swift:73:52:73:67 | call to get_secret_key() | testURL.swift:73:18:73:67 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:73:52:73:67 | call to get_secret_key() | call to get_secret_key() |
+| testURL.swift:75:18:75:69 | ... .+(_:_:) ... | testURL.swift:75:53:75:69 | call to get_cert_string() | testURL.swift:75:18:75:69 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:75:53:75:69 | call to get_cert_string() | call to get_cert_string() |
+| testURL.swift:96:18:96:18 | "..." | testURL.swift:96:51:96:51 | certificate | testURL.swift:96:18:96:18 | "..." | This operation transmits '"..."', which may contain unencrypted sensitive data from $@. | testURL.swift:96:51:96:51 | certificate | certificate |

--- a/swift/ql/test/query-tests/Security/CWE-311/CleartextTransmission.expected
+++ b/swift/ql/test/query-tests/Security/CWE-311/CleartextTransmission.expected
@@ -23,6 +23,11 @@ edges
 | testURL.swift:73:52:73:67 | call to get_secret_key() | testURL.swift:73:18:73:67 | ... .+(_:_:) ... |
 | testURL.swift:75:53:75:69 | call to get_cert_string() | testURL.swift:75:18:75:69 | ... .+(_:_:) ... |
 | testURL.swift:96:51:96:51 | certificate | testURL.swift:96:18:96:18 | "..." |
+| testURL.swift:104:16:104:57 | call to SecKeyCopyExternalRepresentation(_:_:) | testURL.swift:105:32:105:32 | data |
+| testURL.swift:105:6:105:10 | let ...? [some:0] | testURL.swift:105:10:105:10 | string |
+| testURL.swift:105:10:105:10 | string | testURL.swift:106:20:106:20 | "..." |
+| testURL.swift:105:19:105:53 | call to String.init(data:encoding:) [some:0] | testURL.swift:105:6:105:10 | let ...? [some:0] |
+| testURL.swift:105:32:105:32 | data | testURL.swift:105:19:105:53 | call to String.init(data:encoding:) [some:0] |
 nodes
 | file://:0:0:0:0 | .value | semmle.label | .value |
 | file://:0:0:0:0 | self | semmle.label | self |
@@ -74,6 +79,12 @@ nodes
 | testURL.swift:75:53:75:69 | call to get_cert_string() | semmle.label | call to get_cert_string() |
 | testURL.swift:96:18:96:18 | "..." | semmle.label | "..." |
 | testURL.swift:96:51:96:51 | certificate | semmle.label | certificate |
+| testURL.swift:104:16:104:57 | call to SecKeyCopyExternalRepresentation(_:_:) | semmle.label | call to SecKeyCopyExternalRepresentation(_:_:) |
+| testURL.swift:105:6:105:10 | let ...? [some:0] | semmle.label | let ...? [some:0] |
+| testURL.swift:105:10:105:10 | string | semmle.label | string |
+| testURL.swift:105:19:105:53 | call to String.init(data:encoding:) [some:0] | semmle.label | call to String.init(data:encoding:) [some:0] |
+| testURL.swift:105:32:105:32 | data | semmle.label | data |
+| testURL.swift:106:20:106:20 | "..." | semmle.label | "..." |
 subpaths
 | testSend.swift:60:17:60:17 | password | testSend.swift:41:10:41:18 | data | testSend.swift:41:45:41:45 | data | testSend.swift:60:13:60:25 | call to pad(_:) |
 | testSend.swift:94:27:94:30 | .password | testSend.swift:86:7:86:7 | self | file://:0:0:0:0 | .value | testSend.swift:94:27:94:39 | .value |
@@ -104,3 +115,4 @@ subpaths
 | testURL.swift:73:18:73:67 | ... .+(_:_:) ... | testURL.swift:73:52:73:67 | call to get_secret_key() | testURL.swift:73:18:73:67 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:73:52:73:67 | call to get_secret_key() | call to get_secret_key() |
 | testURL.swift:75:18:75:69 | ... .+(_:_:) ... | testURL.swift:75:53:75:69 | call to get_cert_string() | testURL.swift:75:18:75:69 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:75:53:75:69 | call to get_cert_string() | call to get_cert_string() |
 | testURL.swift:96:18:96:18 | "..." | testURL.swift:96:51:96:51 | certificate | testURL.swift:96:18:96:18 | "..." | This operation transmits '"..."', which may contain unencrypted sensitive data from $@. | testURL.swift:96:51:96:51 | certificate | certificate |
+| testURL.swift:106:20:106:20 | "..." | testURL.swift:104:16:104:57 | call to SecKeyCopyExternalRepresentation(_:_:) | testURL.swift:106:20:106:20 | "..." | This operation transmits '"..."', which may contain unencrypted sensitive data from $@. | testURL.swift:104:16:104:57 | call to SecKeyCopyExternalRepresentation(_:_:) | call to SecKeyCopyExternalRepresentation(_:_:) |

--- a/swift/ql/test/query-tests/Security/CWE-311/SensitiveExprs.expected
+++ b/swift/ql/test/query-tests/Security/CWE-311/SensitiveExprs.expected
@@ -87,6 +87,8 @@
 | testCoreData.swift:91:10:91:10 | passwd | label:passwd, type:credential |
 | testCoreData.swift:92:10:92:10 | passwd | label:passwd, type:credential |
 | testCoreData.swift:93:10:93:10 | passwd | label:passwd, type:credential |
+| testCoreData.swift:128:15:128:33 | call to generateSecretKey() | label:generateSecretKey, type:credential |
+| testCoreData.swift:129:15:129:30 | call to getCertificate() | label:getCertificate, type:credential |
 | testGRDB.swift:73:57:73:57 | password | label:password, type:credential |
 | testGRDB.swift:76:43:76:43 | password | label:password, type:credential |
 | testGRDB.swift:81:45:81:45 | password | label:password, type:credential |
@@ -163,10 +165,13 @@
 | testSend.swift:79:27:79:30 | .BankCardNo | label:BankCardNo, type:private information |
 | testSend.swift:80:27:80:30 | .MyCreditRating | label:MyCreditRating, type:private information |
 | testSend.swift:94:27:94:30 | .password | label:password, type:credential |
-| testURL.swift:17:54:17:54 | passwd | label:passwd, type:credential |
-| testURL.swift:19:55:19:55 | account_no | label:account_no, type:private information |
-| testURL.swift:20:55:20:55 | credit_card_no | label:credit_card_no, type:private information |
+| testURL.swift:17:50:17:50 | passwd | label:passwd, type:credential |
+| testURL.swift:19:51:19:51 | account_no | label:account_no, type:private information |
+| testURL.swift:20:51:20:51 | credit_card_no | label:credit_card_no, type:private information |
 | testURL.swift:24:22:24:22 | passwd | label:passwd, type:credential |
-| testURL.swift:28:55:28:55 | e_mail | label:e_mail, type:private information |
-| testURL.swift:30:57:30:57 | a_homeaddr_z | label:a_homeaddr_z, type:private information |
-| testURL.swift:32:55:32:55 | resident_ID | label:resident_ID, type:private information |
+| testURL.swift:28:51:28:51 | e_mail | label:e_mail, type:private information |
+| testURL.swift:30:53:30:53 | a_homeaddr_z | label:a_homeaddr_z, type:private information |
+| testURL.swift:32:51:32:51 | resident_ID | label:resident_ID, type:private information |
+| testURL.swift:51:52:51:67 | call to get_secret_key() | label:get_secret_key, type:credential |
+| testURL.swift:53:53:53:69 | call to get_cert_string() | label:get_cert_string, type:credential |
+| testURL.swift:74:51:74:51 | certificate | label:certificate, type:credential |

--- a/swift/ql/test/query-tests/Security/CWE-311/SensitiveExprs.expected
+++ b/swift/ql/test/query-tests/Security/CWE-311/SensitiveExprs.expected
@@ -165,13 +165,13 @@
 | testSend.swift:79:27:79:30 | .BankCardNo | label:BankCardNo, type:private information |
 | testSend.swift:80:27:80:30 | .MyCreditRating | label:MyCreditRating, type:private information |
 | testSend.swift:94:27:94:30 | .password | label:password, type:credential |
-| testURL.swift:17:50:17:50 | passwd | label:passwd, type:credential |
-| testURL.swift:19:51:19:51 | account_no | label:account_no, type:private information |
-| testURL.swift:20:51:20:51 | credit_card_no | label:credit_card_no, type:private information |
-| testURL.swift:24:22:24:22 | passwd | label:passwd, type:credential |
-| testURL.swift:28:51:28:51 | e_mail | label:e_mail, type:private information |
-| testURL.swift:30:53:30:53 | a_homeaddr_z | label:a_homeaddr_z, type:private information |
-| testURL.swift:32:51:32:51 | resident_ID | label:resident_ID, type:private information |
-| testURL.swift:51:52:51:67 | call to get_secret_key() | label:get_secret_key, type:credential |
-| testURL.swift:53:53:53:69 | call to get_cert_string() | label:get_cert_string, type:credential |
-| testURL.swift:74:51:74:51 | certificate | label:certificate, type:credential |
+| testURL.swift:39:50:39:50 | passwd | label:passwd, type:credential |
+| testURL.swift:41:51:41:51 | account_no | label:account_no, type:private information |
+| testURL.swift:42:51:42:51 | credit_card_no | label:credit_card_no, type:private information |
+| testURL.swift:46:22:46:22 | passwd | label:passwd, type:credential |
+| testURL.swift:50:51:50:51 | e_mail | label:e_mail, type:private information |
+| testURL.swift:52:53:52:53 | a_homeaddr_z | label:a_homeaddr_z, type:private information |
+| testURL.swift:54:51:54:51 | resident_ID | label:resident_ID, type:private information |
+| testURL.swift:73:52:73:67 | call to get_secret_key() | label:get_secret_key, type:credential |
+| testURL.swift:75:53:75:69 | call to get_cert_string() | label:get_cert_string, type:credential |
+| testURL.swift:96:51:96:51 | certificate | label:certificate, type:credential |

--- a/swift/ql/test/query-tests/Security/CWE-311/SensitiveExprs.expected
+++ b/swift/ql/test/query-tests/Security/CWE-311/SensitiveExprs.expected
@@ -175,3 +175,4 @@
 | testURL.swift:73:52:73:67 | call to get_secret_key() | label:get_secret_key, type:credential |
 | testURL.swift:75:53:75:69 | call to get_cert_string() | label:get_cert_string, type:credential |
 | testURL.swift:96:51:96:51 | certificate | label:certificate, type:credential |
+| testURL.swift:104:16:104:57 | call to SecKeyCopyExternalRepresentation(_:_:) | label:credential, type:credential |

--- a/swift/ql/test/query-tests/Security/CWE-311/testCoreData.swift
+++ b/swift/ql/test/query-tests/Security/CWE-311/testCoreData.swift
@@ -77,10 +77,10 @@ func test3(obj : NSManagedObject, x : String) {
 	doSomething(password: x);
 	obj.setValue(x, forKey: "myKey") // BAD
 
-	var y = getPassword();
+	let y = getPassword();
 	obj.setValue(y, forKey: "myKey") // BAD
 
-	var z = MyClass()
+	let z = MyClass()
 	obj.setValue(z.harmless, forKey: "myKey") // GOOD (not sensitive)
 	obj.setValue(z.password, forKey: "myKey") // BAD
 }
@@ -103,4 +103,37 @@ func test4(obj : NSManagedObject, passwd : String) {
 	obj.setValue(x, forKey: "myKey") // GOOD (not sensitive)
 	obj.setValue(y, forKey: "myKey") // GOOD (not sensitive)
 	obj.setValue(z, forKey: "myKey") // GOOD (not sensitive)
+}
+
+func createSecureKey() -> String { return "" }
+func generateSecretKey() -> String { return "" }
+func getCertificate() -> String { return "" }
+
+class KeyGen {
+	func generate() -> String { return "" }
+}
+
+class KeyManager {
+	func generateKey() -> String { return "" }
+}
+
+class SecureKeyStore {
+	func getEncryptionKey() -> String { return "" }
+}
+
+func test5(obj : NSManagedObject) {
+	// more variants...
+
+	obj.setValue(createSecureKey(), forKey: "myKey") // BAD [NOT DETECTED]
+	obj.setValue(generateSecretKey(), forKey: "myKey") // BAD
+	obj.setValue(getCertificate(), forKey: "myKey") // BAD
+
+	let gen = KeyGen()
+	let v = gen.generate()
+
+	obj.setValue(KeyGen().generate(), forKey: "myKey") // BAD [NOT DETECTED]
+	obj.setValue(gen.generate(), forKey: "myKey") // BAD [NOT DETECTED]
+	obj.setValue(v, forKey: "myKey") // BAD [NOT DETECTED]
+	obj.setValue(KeyManager().generateKey(), forKey: "myKey") // BAD [NOT DETECTED]
+	obj.setValue(SecureKeyStore().getEncryptionKey(), forKey: "myKey") // BAD [NOT DETECTED]
 }

--- a/swift/ql/test/query-tests/Security/CWE-311/testURL.swift
+++ b/swift/ql/test/query-tests/Security/CWE-311/testURL.swift
@@ -14,20 +14,66 @@ func setMyString(str: String) { myString = str }
 func getMyString() -> String { return myString }
 
 func test1(passwd : String, encrypted_passwd : String, account_no : String, credit_card_no : String) {
-	let a = URL(string: "http://example.com/login?p=" + passwd); // BAD
-	let b = URL(string: "http://example.com/login?p=" + encrypted_passwd); // GOOD (not sensitive)
-	let c = URL(string: "http://example.com/login?ac=" + account_no); // BAD
-	let d = URL(string: "http://example.com/login?cc=" + credit_card_no); // BAD
+	_ = URL(string: "http://example.com/login?p=" + passwd); // BAD
+	_ = URL(string: "http://example.com/login?p=" + encrypted_passwd); // GOOD (not sensitive)
+	_ = URL(string: "http://example.com/login?ac=" + account_no); // BAD
+	_ = URL(string: "http://example.com/login?cc=" + credit_card_no); // BAD
 
 	let base = URL(string: "http://example.com/"); // GOOD (not sensitive)
-	let e = URL(string: "abc", relativeTo: base); // GOOD (not sensitive)
+	_ = URL(string: "abc", relativeTo: base); // GOOD (not sensitive)
 	let f = URL(string: passwd, relativeTo: base); // BAD
-	let g = URL(string: "abc", relativeTo: f); // BAD (reported on line above)
+	_ = URL(string: "abc", relativeTo: f); // BAD (reported on line above)
 
 	let e_mail = myString
-	let h = URL(string: "http://example.com/login?em=" + e_mail); // BAD
-	var a_homeaddr_z = getMyString()
-	let i = URL(string: "http://example.com/login?home=" + a_homeaddr_z); // BAD
-	var resident_ID = getMyString()
-	let j = URL(string: "http://example.com/login?id=" + resident_ID); // BAD
+	_ = URL(string: "http://example.com/login?em=" + e_mail); // BAD
+	let a_homeaddr_z = getMyString()
+	_ = URL(string: "http://example.com/login?home=" + a_homeaddr_z); // BAD
+	let resident_ID = getMyString()
+	_ = URL(string: "http://example.com/login?id=" + resident_ID); // BAD
+}
+
+func get_private_key() -> String { return "" }
+func get_aes_key() -> String { return "" }
+func get_aws_key() -> String { return "" }
+func get_access_key() -> String { return "" }
+func get_secret_key() -> String { return "" }
+func get_key_press() -> String { return "" }
+func get_cert_string() -> String { return "" }
+func get_certain() -> String { return "" }
+
+func test2() {
+	// more variants...
+
+	_ = URL(string: "http://example.com/login?key=" + get_private_key()); // BAD [NOT DETECTED]
+	_ = URL(string: "http://example.com/login?key=" + get_aes_key()); // BAD [NOT DETECTED]
+	_ = URL(string: "http://example.com/login?key=" + get_aws_key()); // BAD [NOT DETECTED]
+	_ = URL(string: "http://example.com/login?key=" + get_access_key()); // BAD [NOT DETECTED]
+	_ = URL(string: "http://example.com/login?key=" + get_secret_key()); // BAD
+	_ = URL(string: "http://example.com/login?key=" + get_key_press()); // GOOD (not sensitive)
+	_ = URL(string: "http://example.com/login?cert=" + get_cert_string()); // BAD
+	_ = URL(string: "http://example.com/login?cert=" + get_certain()); // GOOD (not sensitive)
+}
+
+func get_string() -> String { return "" }
+
+func test3() {
+	// more variants...
+
+	let priv_key = get_string()
+	let private_key = get_string()
+	let pub_key = get_string()
+	let certificate = get_string()
+	let secure_token = get_string()
+	let access_token = get_string()
+	let auth_token = get_string()
+	let next_token = get_string()
+
+	_ = URL(string: "http://example.com/login?key=\(priv_key)"); // BAD [NOT DETECTED]
+	_ = URL(string: "http://example.com/login?key=\(private_key)"); // BAD [NOT DETECTED]
+	_ = URL(string: "http://example.com/login?key=\(pub_key)"); // GOOD (not sensitive)
+	_ = URL(string: "http://example.com/login?cert=\(certificate)"); // BAD
+	_ = URL(string: "http://example.com/login?tok=\(secure_token)"); // BAD [NOT DETECTED]
+	_ = URL(string: "http://example.com/login?tok=\(access_token)"); // BAD [NOT DETECTED]
+	_ = URL(string: "http://example.com/login?tok=\(auth_token)"); // BAD [NOT DETECTED]
+	_ = URL(string: "http://example.com/login?tok=\(next_token)"); // GOOD (not sensitive)
 }

--- a/swift/ql/test/query-tests/Security/CWE-311/testURL.swift
+++ b/swift/ql/test/query-tests/Security/CWE-311/testURL.swift
@@ -7,6 +7,28 @@ struct URL
 	init?(string: String, relativeTo: URL?) {}
 }
 
+class Data {
+}
+
+extension String {
+	struct Encoding {
+		static let utf8 = Encoding()
+	}
+
+	init?(data: Data, encoding: Encoding) { self.init() }
+}
+
+class SecKey {
+}
+
+class CFData {
+}
+
+class CFError {
+}
+
+func SecKeyCopyExternalRepresentation(_ key: SecKey, _ error: UnsafeMutablePointer<Unmanaged<CFError>?>?) -> CFData? { return nil }
+
 // --- tests ---
 
 var myString = ""
@@ -51,7 +73,7 @@ func test2() {
 	_ = URL(string: "http://example.com/login?key=" + get_secret_key()); // BAD
 	_ = URL(string: "http://example.com/login?key=" + get_key_press()); // GOOD (not sensitive)
 	_ = URL(string: "http://example.com/login?cert=" + get_cert_string()); // BAD
-	_ = URL(string: "http://example.com/login?cert=" + get_certain()); // GOOD (not sensitive)
+	_ = URL(string: "http://example.com/login?certain=" + get_certain()); // GOOD (not sensitive)
 }
 
 func get_string() -> String { return "" }
@@ -76,4 +98,12 @@ func test3() {
 	_ = URL(string: "http://example.com/login?tok=\(access_token)"); // BAD [NOT DETECTED]
 	_ = URL(string: "http://example.com/login?tok=\(auth_token)"); // BAD [NOT DETECTED]
 	_ = URL(string: "http://example.com/login?tok=\(next_token)"); // GOOD (not sensitive)
+}
+
+func test4(key: SecKey) {
+	if let data = SecKeyCopyExternalRepresentation(key, nil) as? Data {
+		if let string = String(data: data, encoding: .utf8) {
+			_ = URL(string: "http://example.com/login?tok=\(string)"); // BAD [NOT DETECTED]
+		}
+	}
 }

--- a/swift/ql/test/query-tests/Security/CWE-311/testURL.swift
+++ b/swift/ql/test/query-tests/Security/CWE-311/testURL.swift
@@ -103,7 +103,7 @@ func test3() {
 func test4(key: SecKey) {
 	if let data = SecKeyCopyExternalRepresentation(key, nil) as? Data {
 		if let string = String(data: data, encoding: .utf8) {
-			_ = URL(string: "http://example.com/login?tok=\(string)"); // BAD [NOT DETECTED]
+			_ = URL(string: "http://example.com/login?tok=\(string)"); // BAD
 		}
 	}
 }


### PR DESCRIPTION
This PR does two things:
- adds some tests of things that look like encryption keys (and certificates) as sensitive data that I had lying around in a local commit.  These aren't currently flagged because heuristics based on the word "key" tend to produce a lot of false positives - but they're important cases we should figure out at some point (there is already an issue tracking this).
- solve a small slice of the problem by creating an explicit model for [SecKeyCopyExternalRepresentation(_:_:)](https://developer.apple.com/documentation/security/1643698-seckeycopyexternalrepresentation), that turns a `SecKey` object into data (which could potentially be stored or transmitted).  This is the first sensitive data source defined explicitly using models-as-data - so a bit of plumbing is involved as well.