### PR TITLE
Java: Fix FPs in Missing certificate pinning

### DIFF
--- a/java/ql/src/change-notes/2023-12-12-android-certificate-pinning-precision.md
+++ b/java/ql/src/change-notes/2023-12-12-android-certificate-pinning-precision.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The query `java/android/missing-certificate-pinning` should no longer alert about requests pointing to the local filesystem.

--- a/java/ql/test/query-tests/security/CWE-295/AndroidMissingCertificatePinning/Test1/Test.java
+++ b/java/ql/test/query-tests/security/CWE-295/AndroidMissingCertificatePinning/Test1/Test.java
@@ -1,12 +1,24 @@
 import java.net.URL;
 import java.net.URLConnection;
 
-class Test{
+class Test {
     URLConnection test1() throws Exception {
         return new URL("https://good.example.com").openConnection();
     }
 
     URLConnection test2() throws Exception {
         return new URL("https://bad.example.com").openConnection(); // $hasUntrustedResult
+    }
+
+    URLConnection test3() throws Exception {
+        return new URL("classpath:example/directory/test.class").openConnection();
+    }
+
+    URLConnection test4() throws Exception {
+        return new URL("file:///example/file").openConnection();
+    }
+
+    URLConnection test5() throws Exception {
+        return new URL("jar:file:///C:/example/test.jar!/test.xml").openConnection();
     }
 }

--- a/java/ql/test/query-tests/security/CWE-295/AndroidMissingCertificatePinning/Test2/Test.java
+++ b/java/ql/test/query-tests/security/CWE-295/AndroidMissingCertificatePinning/Test2/Test.java
@@ -1,8 +1,20 @@
 import java.net.URL;
 import java.net.URLConnection;
 
-class Test{
+class Test {
     URLConnection test2() throws Exception {
         return new URL("https://example.com").openConnection(); // $hasNoTrustedResult
+    }
+
+    URLConnection test3() throws Exception {
+        return new URL("classpath:example/directory/test.class").openConnection();
+    }
+
+    URLConnection test4() throws Exception {
+        return new URL("file:///example/file").openConnection();
+    }
+
+    URLConnection test5() throws Exception {
+        return new URL("jar:file:///C:/example/test.jar!/test.xml").openConnection();
     }
 }

--- a/java/ql/test/query-tests/security/CWE-295/AndroidMissingCertificatePinning/Test3/Test.java
+++ b/java/ql/test/query-tests/security/CWE-295/AndroidMissingCertificatePinning/Test3/Test.java
@@ -2,16 +2,21 @@ import okhttp3.OkHttpClient;
 import okhttp3.CertificatePinner;
 import okhttp3.Request;
 
-class Test{
+class Test {
     void test1() throws Exception {
-    CertificatePinner certificatePinner = new CertificatePinner.Builder()
-         .add("good.example.com", "sha256/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
-         .build();
-     OkHttpClient client = new OkHttpClient.Builder()
-         .certificatePinner(certificatePinner)
-         .build();
+        CertificatePinner certificatePinner = new CertificatePinner.Builder()
+                .add("good.example.com", "sha256/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+                .build();
+        OkHttpClient client =
+                new OkHttpClient.Builder().certificatePinner(certificatePinner).build();
 
-     client.newCall(new Request.Builder().url("https://good.example.com").build()).execute();
-     client.newCall(new Request.Builder().url("https://bad.example.com").build()).execute(); // $hasUntrustedResult
+        client.newCall(new Request.Builder().url("https://good.example.com").build()).execute();
+        client.newCall(new Request.Builder().url("https://bad.example.com").build()).execute(); // $hasUntrustedResult
+        client.newCall(new Request.Builder().url("classpath:example/directory/test.class").build())
+                .execute();
+        client.newCall(new Request.Builder().url("file:///example/file").build()).execute();
+        client.newCall(
+                new Request.Builder().url("jar:file:///C:/example/test.jar!/test.xml").build())
+                .execute();
     }
 }

--- a/java/ql/test/query-tests/security/CWE-295/AndroidMissingCertificatePinning/Test4/Test.java
+++ b/java/ql/test/query-tests/security/CWE-295/AndroidMissingCertificatePinning/Test4/Test.java
@@ -8,19 +8,20 @@ import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import android.content.res.Resources;
 
-class Test{
+class Test {
     void test1(Resources resources) throws Exception {
         KeyStore keyStore = KeyStore.getInstance("BKS");
         keyStore.load(resources.openRawResource(R.raw.cert), null);
 
-        TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        TrustManagerFactory tmf =
+                TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
         tmf.init(keyStore);
 
         SSLContext sslContext = SSLContext.getInstance("TLS");
         sslContext.init(null, tmf.getTrustManagers(), null);
 
         URL url = new URL("http://www.example.com/");
-        HttpsURLConnection urlConnection = (HttpsURLConnection) url.openConnection(); 
+        HttpsURLConnection urlConnection = (HttpsURLConnection) url.openConnection();
 
         urlConnection.setSSLSocketFactory(sslContext.getSocketFactory());
     }

--- a/java/ql/test/query-tests/security/CWE-295/AndroidMissingCertificatePinning/Test5/Test.java
+++ b/java/ql/test/query-tests/security/CWE-295/AndroidMissingCertificatePinning/Test5/Test.java
@@ -9,12 +9,13 @@ import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import android.content.res.Resources;
 
-class Test{
+class Test {
     void init(Resources resources) throws Exception {
         KeyStore keyStore = KeyStore.getInstance("BKS");
         keyStore.load(resources.openRawResource(R.raw.cert), null);
 
-        TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        TrustManagerFactory tmf =
+                TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
         tmf.init(keyStore);
 
         SSLContext sslContext = SSLContext.getInstance("TLS");
@@ -25,11 +26,26 @@ class Test{
 
     URLConnection test1() throws Exception {
         URL url = new URL("http://www.example.com/");
-        return url.openConnection(); 
+        return url.openConnection();
     }
 
     InputStream test2() throws Exception {
         URL url = new URL("http://www.example.com/");
-        return url.openStream(); 
+        return url.openStream();
+    }
+
+    InputStream test3() throws Exception {
+        URL url = new URL("classpath:example/directory/test.class");
+        return url.openStream();
+    }
+
+    InputStream test4() throws Exception {
+        URL url = new URL("file:///example/file");
+        return url.openStream();
+    }
+
+    InputStream test5() throws Exception {
+        URL url = new URL("jar:file:///C:/example/test.jar!/test.xml");
+        return url.openStream();
     }
 }


### PR DESCRIPTION
Local URIs should never require pinning.

In this PR we are making the conscious decision of _requiring_ a URL string to flow to the sink in order to consider it a valid "missing certificate pinning" candidate, and then we check any sort of certificate pinning validation on the domain of the URL string.

In the old version, if we couldn't find a flow from a string to the sink and there was no certificate pinning check in place, we'd just alert on the sink, but that was prone to FPs for things like `getResource`, `getResourceAsStream`, `newFileSystem`, and similar calls that _can_ operate on the network but normally access the local filesystem.