### PR TITLE
Revert "Bump actions/labeler from 4 to 5"

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,6 +9,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This PR breaks the pull request labeler workflow and prevents https://github.com/github/codeql/pull/15014 from being merged.

For https://github.com/github/codeql-team/issues/2610