### PR TITLE
Java: Deprecate or remove imports of dataflow library copies

### DIFF
--- a/java/ql/lib/change-notes/2023-12-08-deprecate-reexport-of-old-dataflow-libraries.md
+++ b/java/ql/lib/change-notes/2023-12-08-deprecate-reexport-of-old-dataflow-libraries.md
@@ -1,0 +1,4 @@
+---
+category: deprecated
+---
+* Imports of the old dataflow libraries (e.g. `semmle.code.java.dataflow.DataFlow2`) have been deprecated in the libraries under the `semmle.code.java.security` namespace.

--- a/java/ql/lib/semmle/code/java/frameworks/JsonIo.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/JsonIo.qll
@@ -6,6 +6,7 @@ import java
 import semmle.code.java.Maps
 import semmle.code.java.dataflow.DataFlow
 deprecated import semmle.code.java.dataflow.DataFlow2
+private import semmle.code.java.dataflow.DataFlow2
 
 /**
  * The class `com.cedarsoftware.util.io.JsonReader`.

--- a/java/ql/lib/semmle/code/java/frameworks/JsonIo.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/JsonIo.qll
@@ -5,7 +5,7 @@
 import java
 import semmle.code.java.Maps
 import semmle.code.java.dataflow.DataFlow
-import semmle.code.java.dataflow.DataFlow2
+deprecated import semmle.code.java.dataflow.DataFlow2
 
 /**
  * The class `com.cedarsoftware.util.io.JsonReader`.

--- a/java/ql/lib/semmle/code/java/regex/RegexFlowConfigs.qll
+++ b/java/ql/lib/semmle/code/java/regex/RegexFlowConfigs.qll
@@ -5,7 +5,6 @@
 import java
 import semmle.code.java.dataflow.ExternalFlow
 private import semmle.code.java.dataflow.DataFlow
-private import semmle.code.java.dataflow.DataFlow2
 private import semmle.code.java.security.SecurityTests
 
 private class ExploitableStringLiteral extends StringLiteral {

--- a/java/ql/lib/semmle/code/java/security/AndroidIntentRedirectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/AndroidIntentRedirectionQuery.qll
@@ -2,9 +2,9 @@
 
 import java
 import semmle.code.java.dataflow.FlowSources
-import semmle.code.java.dataflow.DataFlow2
+deprecated import semmle.code.java.dataflow.DataFlow2
 import semmle.code.java.dataflow.TaintTracking
-import semmle.code.java.dataflow.TaintTracking3
+deprecated import semmle.code.java.dataflow.TaintTracking3
 import semmle.code.java.security.AndroidIntentRedirection
 
 /**

--- a/java/ql/lib/semmle/code/java/security/CleartextStorageCookieQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/CleartextStorageCookieQuery.qll
@@ -2,7 +2,7 @@
 
 import java
 import semmle.code.java.dataflow.DataFlow
-import semmle.code.java.dataflow.DataFlow3
+deprecated import semmle.code.java.dataflow.DataFlow3
 import semmle.code.java.security.CleartextStorageQuery
 
 private class CookieCleartextStorageSink extends CleartextStorageSink {

--- a/java/ql/lib/semmle/code/java/security/CleartextStorageQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/CleartextStorageQuery.qll
@@ -1,9 +1,7 @@
 /** Provides classes and predicates to reason about cleartext storage vulnerabilities. */
 
 import java
-private import semmle.code.java.dataflow.DataFlow4
 private import semmle.code.java.dataflow.TaintTracking
-private import semmle.code.java.dataflow.TaintTracking2
 private import semmle.code.java.security.SensitiveActions
 
 /** A sink representing persistent storage that saves data in clear text. */

--- a/java/ql/lib/semmle/code/java/security/HardcodedCredentialsSourceCallQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/HardcodedCredentialsSourceCallQuery.qll
@@ -4,7 +4,7 @@
 
 import java
 import semmle.code.java.dataflow.DataFlow
-import semmle.code.java.dataflow.DataFlow2
+deprecated import semmle.code.java.dataflow.DataFlow2
 import HardcodedCredentials
 
 /**

--- a/java/ql/lib/semmle/code/java/security/HardcodedCredentialsSourceCallQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/HardcodedCredentialsSourceCallQuery.qll
@@ -5,6 +5,7 @@
 import java
 import semmle.code.java.dataflow.DataFlow
 deprecated import semmle.code.java.dataflow.DataFlow2
+private import semmle.code.java.dataflow.DataFlow2
 import HardcodedCredentials
 
 /**

--- a/java/ql/lib/semmle/code/java/security/XmlParsers.qll
+++ b/java/ql/lib/semmle/code/java/security/XmlParsers.qll
@@ -3,6 +3,7 @@
 import java
 import semmle.code.java.dataflow.DataFlow
 deprecated import semmle.code.java.dataflow.DataFlow3
+private import semmle.code.java.dataflow.DataFlow3
 private import semmle.code.java.dataflow.RangeUtils
 
 private module Frameworks {

--- a/java/ql/lib/semmle/code/java/security/XmlParsers.qll
+++ b/java/ql/lib/semmle/code/java/security/XmlParsers.qll
@@ -2,7 +2,7 @@
 
 import java
 import semmle.code.java.dataflow.DataFlow
-import semmle.code.java.dataflow.DataFlow3
+deprecated import semmle.code.java.dataflow.DataFlow3
 private import semmle.code.java.dataflow.RangeUtils
 
 private module Frameworks {

--- a/java/ql/src/experimental/Security/CWE/CWE-1004/SensitiveCookieNotHttpOnly.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-1004/SensitiveCookieNotHttpOnly.ql
@@ -24,7 +24,6 @@ import java
 import semmle.code.java.dataflow.FlowSteps
 import semmle.code.java.frameworks.Servlets
 import semmle.code.java.dataflow.TaintTracking
-import semmle.code.java.dataflow.TaintTracking2
 import MissingHttpOnlyFlow::PathGraph
 
 /** Gets a regular expression for matching common names of sensitive cookies. */


### PR DESCRIPTION
This deprecates the public re-exporting of the copies of the old dataflow library (e.g. `semmle.code.java.dataflow.DataFlow2` or `semmle.code.java.dataflow.TaintTracking3`).

Currently CodeQL issues a warning when using an item from a `deprecated import`, even if the usage is in a deprecated context. So for now, modules which still use the deprecated items (e.g. a deprecated class extending `TaintTracking2::Configuration`) mark the import as deprecated, and then re-import it privately.