### PR TITLE
C++: Also support the `__noreturn__` attribute in `exits`

### DIFF
--- a/cpp/ql/lib/DefaultOptions.qll
+++ b/cpp/ql/lib/DefaultOptions.qll
@@ -52,12 +52,13 @@ class Options extends string {
   /**
    * Holds if a call to this function will never return.
    *
-   * By default, this holds for `exit`, `_exit`, `abort`, `__assert_fail`,
-   * `longjmp`, `__builtin_unreachable` and any function with a
-   * `noreturn` attribute or specifier.
+   * By default, this holds for `exit`, `_exit`, `_Exit`, `abort`,
+   * `__assert_fail`, `longjmp`, `__builtin_unreachable` and any
+   * function with a `noreturn` or `__noreturn__` attribute or
+   * `noreturn` specifier.
    */
   predicate exits(Function f) {
-    f.getAnAttribute().hasName("noreturn")
+    f.getAnAttribute().hasName(["noreturn", "__noreturn__"])
     or
     f.getASpecifier().hasName("noreturn")
     or


### PR DESCRIPTION
Observed this attribute while working on coding standards test regression when replacing Guards by IRGuards.