### PR TITLE
Python: Remove control flow nodes for module entry definitions from the dataflow graph.

### DIFF
--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPublic.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPublic.qll
@@ -15,13 +15,11 @@ private import semmle.python.frameworks.data.ModelsAsData
 /**
  * IPA type for data flow nodes.
  *
- * Flow between SSA variables are computed in `Essa.qll`
+ * Nodes broadly fall into three categories.
  *
- * Flow from SSA variables to control flow nodes are generally via uses.
- *
- * Flow from control flow nodes to SSA variables are generally via assignments.
- *
- * The current implementation of these cross flows can be seen in `EssaTaintTracking`.
+ * - Control flow nodes: Flow between these is based on use-use flow computed via an SSA analysis.
+ * - Module variable nodes: These represent global variables and act as canonical targets for reads and writes of these.
+ * - Synthetic nodes: These handle flow in various special cases.
  */
 newtype TNode =
   /** A node corresponding to a control flow node. */

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPublic.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPublic.qll
@@ -30,7 +30,7 @@ newtype TNode =
     or
     node.getNode() instanceof Pattern
     or
-    node = any(ScopeEntryDefinition def).getDefiningNode()
+    node = any(ScopeEntryDefinition def | not def.getScope() instanceof Module).getDefiningNode()
   } or
   /**
    * A synthetic node representing the value of an object before a state change.

--- a/python/ql/test/experimental/dataflow/basic/local.expected
+++ b/python/ql/test/experimental/dataflow/basic/local.expected
@@ -1,4 +1,3 @@
-| test.py:0:0:0:0 | Entry node for Module test | test.py:0:0:0:0 | Entry node for Module test |
 | test.py:1:1:1:21 | ControlFlowNode for FunctionExpr | test.py:1:1:1:21 | ControlFlowNode for FunctionExpr |
 | test.py:1:1:1:21 | ControlFlowNode for FunctionExpr | test.py:1:5:1:17 | ControlFlowNode for obfuscated_id |
 | test.py:1:1:1:21 | ControlFlowNode for FunctionExpr | test.py:7:5:7:17 | ControlFlowNode for obfuscated_id |

--- a/python/ql/test/experimental/dataflow/basic/sinks.expected
+++ b/python/ql/test/experimental/dataflow/basic/sinks.expected
@@ -1,4 +1,3 @@
-| test.py:0:0:0:0 | Entry node for Module test |
 | test.py:1:1:1:21 | ControlFlowNode for FunctionExpr |
 | test.py:1:1:1:21 | SynthDictSplatParameterNode |
 | test.py:1:5:1:17 | ControlFlowNode for obfuscated_id |

--- a/python/ql/test/experimental/dataflow/basic/sources.expected
+++ b/python/ql/test/experimental/dataflow/basic/sources.expected
@@ -1,4 +1,3 @@
-| test.py:0:0:0:0 | Entry node for Module test |
 | test.py:1:1:1:21 | ControlFlowNode for FunctionExpr |
 | test.py:1:1:1:21 | SynthDictSplatParameterNode |
 | test.py:1:5:1:17 | ControlFlowNode for obfuscated_id |

--- a/python/ql/test/experimental/dataflow/enclosing-callable/EnclosingCallable.expected
+++ b/python/ql/test/experimental/dataflow/enclosing-callable/EnclosingCallable.expected
@@ -1,4 +1,3 @@
-| class_example.py:0:0:0:0 | Module class_example | class_example.py:0:0:0:0 | Entry node for Module class_example |
 | class_example.py:0:0:0:0 | Module class_example | class_example.py:1:1:1:3 | ControlFlowNode for wat |
 | class_example.py:0:0:0:0 | Module class_example | class_example.py:1:7:1:7 | ControlFlowNode for IntegerLiteral |
 | class_example.py:0:0:0:0 | Module class_example | class_example.py:3:1:3:10 | ControlFlowNode for ClassExpr |
@@ -13,7 +12,6 @@
 | class_example.py:0:0:0:0 | Module class_example | class_example.py:7:1:7:23 | ControlFlowNode for print() |
 | class_example.py:0:0:0:0 | Module class_example | class_example.py:7:7:7:17 | ControlFlowNode for Str |
 | class_example.py:0:0:0:0 | Module class_example | class_example.py:7:20:7:22 | ControlFlowNode for wat |
-| generator.py:0:0:0:0 | Module generator | generator.py:0:0:0:0 | Entry node for Module generator |
 | generator.py:0:0:0:0 | Module generator | generator.py:1:1:1:23 | ControlFlowNode for FunctionExpr |
 | generator.py:0:0:0:0 | Module generator | generator.py:1:5:1:18 | ControlFlowNode for generator_func |
 | generator.py:1:1:1:23 | Function generator_func | generator.py:1:20:1:21 | ControlFlowNode for xs |

--- a/python/ql/test/experimental/dataflow/import-star/global.expected
+++ b/python/ql/test/experimental/dataflow/import-star/global.expected
@@ -1,9 +1,3 @@
-| deux.py:0:0:0:0 | Entry node for Module deux | deux.py:2:1:2:5 | ControlFlowNode for print |
-| deux.py:0:0:0:0 | Entry node for Module deux | deux.py:2:7:2:9 | ControlFlowNode for foo |
-| test1.py:0:0:0:0 | Entry node for Module test1 | test1.py:2:1:2:5 | ControlFlowNode for print |
-| test1.py:0:0:0:0 | Entry node for Module test1 | test1.py:2:7:2:9 | ControlFlowNode for foo |
-| test2.py:0:0:0:0 | Entry node for Module test2 | test2.py:2:1:2:5 | ControlFlowNode for print |
-| test2.py:0:0:0:0 | Entry node for Module test2 | test2.py:2:7:2:9 | ControlFlowNode for foo |
 | test3.py:1:17:1:19 | ControlFlowNode for ImportMember | test3.py:1:17:1:19 | ControlFlowNode for foo |
 | test3.py:1:17:1:19 | ControlFlowNode for ImportMember | test3.py:2:7:2:9 | ControlFlowNode for foo |
 | test3.py:1:17:1:19 | ControlFlowNode for foo | test3.py:2:7:2:9 | ControlFlowNode for foo |
@@ -23,11 +17,6 @@
 | trois.py:1:7:1:7 | ControlFlowNode for IntegerLiteral | deux.py:2:7:2:9 | ControlFlowNode for foo |
 | trois.py:1:7:1:7 | ControlFlowNode for IntegerLiteral | test2.py:2:7:2:9 | ControlFlowNode for foo |
 | trois.py:1:7:1:7 | ControlFlowNode for IntegerLiteral | trois.py:1:1:1:3 | ControlFlowNode for foo |
-| two.py:0:0:0:0 | Entry node for Module two | test3.py:1:17:1:19 | ControlFlowNode for ImportMember |
-| two.py:0:0:0:0 | Entry node for Module two | test3.py:1:17:1:19 | ControlFlowNode for foo |
-| two.py:0:0:0:0 | Entry node for Module two | test3.py:2:7:2:9 | ControlFlowNode for foo |
-| two.py:0:0:0:0 | Entry node for Module two | two.py:2:1:2:5 | ControlFlowNode for print |
-| two.py:0:0:0:0 | Entry node for Module two | two.py:2:7:2:9 | ControlFlowNode for foo |
 | two.py:2:7:2:9 | ControlFlowNode for foo | test3.py:1:17:1:19 | ControlFlowNode for ImportMember |
 | two.py:2:7:2:9 | ControlFlowNode for foo | test3.py:1:17:1:19 | ControlFlowNode for foo |
 | two.py:2:7:2:9 | ControlFlowNode for foo | test3.py:2:7:2:9 | ControlFlowNode for foo |

--- a/python/ql/test/experimental/import-resolution/ModuleExport.expected
+++ b/python/ql/test/experimental/import-resolution/ModuleExport.expected
@@ -1,44 +1,29 @@
 | attr_clash.__init__ | __file__ | attr_clash/__init__.py:6:6:6:13 | ControlFlowNode for __file__ |
-| attr_clash.__init__ | __name__ | attr_clash/__init__.py:0:0:0:0 | Entry node for Module attr_clash.__init__ |
-| attr_clash.__init__ | __package__ | attr_clash/__init__.py:0:0:0:0 | Entry node for Module attr_clash.__init__ |
 | attr_clash.__init__ | clashing_attr | attr_clash/__init__.py:4:1:4:13 | ControlFlowNode for clashing_attr |
 | attr_clash.__init__ | enter | attr_clash/__init__.py:2:1:2:5 | ControlFlowNode for enter |
 | attr_clash.__init__ | exit | attr_clash/__init__.py:6:1:6:4 | ControlFlowNode for exit |
 | attr_clash.clashing_attr | __file__ | attr_clash/clashing_attr.py:4:6:4:13 | ControlFlowNode for __file__ |
-| attr_clash.clashing_attr | __name__ | attr_clash/clashing_attr.py:0:0:0:0 | Entry node for Module attr_clash.clashing_attr |
-| attr_clash.clashing_attr | __package__ | attr_clash/clashing_attr.py:0:0:0:0 | Entry node for Module attr_clash.clashing_attr |
 | attr_clash.clashing_attr | enter | attr_clash/clashing_attr.py:2:1:2:5 | ControlFlowNode for enter |
 | attr_clash.clashing_attr | exit | attr_clash/clashing_attr.py:4:1:4:4 | ControlFlowNode for exit |
 | attr_clash.non_clashing_submodule | __file__ | attr_clash/non_clashing_submodule.py:4:6:4:13 | ControlFlowNode for __file__ |
-| attr_clash.non_clashing_submodule | __name__ | attr_clash/non_clashing_submodule.py:0:0:0:0 | Entry node for Module attr_clash.non_clashing_submodule |
-| attr_clash.non_clashing_submodule | __package__ | attr_clash/non_clashing_submodule.py:0:0:0:0 | Entry node for Module attr_clash.non_clashing_submodule |
 | attr_clash.non_clashing_submodule | enter | attr_clash/non_clashing_submodule.py:2:1:2:5 | ControlFlowNode for enter |
 | attr_clash.non_clashing_submodule | exit | attr_clash/non_clashing_submodule.py:4:1:4:4 | ControlFlowNode for exit |
 | bar | __file__ | bar.py:6:6:6:13 | ControlFlowNode for __file__ |
-| bar | __name__ | bar.py:0:0:0:0 | Entry node for Module bar |
-| bar | __package__ | bar.py:0:0:0:0 | Entry node for Module bar |
 | bar | bar_attr | bar.py:4:1:4:8 | ControlFlowNode for bar_attr |
 | bar | enter | bar.py:2:1:2:5 | ControlFlowNode for enter |
 | bar | exit | bar.py:6:1:6:4 | ControlFlowNode for exit |
 | baz | __file__ | baz.py:6:6:6:13 | ControlFlowNode for __file__ |
-| baz | __name__ | baz.py:0:0:0:0 | Entry node for Module baz |
-| baz | __package__ | baz.py:0:0:0:0 | Entry node for Module baz |
 | baz | baz_attr | baz.py:4:1:4:8 | ControlFlowNode for baz_attr |
 | baz | enter | baz.py:2:1:2:5 | ControlFlowNode for enter |
 | baz | exit | baz.py:6:1:6:4 | ControlFlowNode for exit |
 | block_flow_check | SOURCE | block_flow_check.py:12:25:12:30 | ControlFlowNode for SOURCE |
 | block_flow_check | __file__ | block_flow_check.py:14:6:14:13 | ControlFlowNode for __file__ |
-| block_flow_check | __name__ | block_flow_check.py:0:0:0:0 | Entry node for Module block_flow_check |
-| block_flow_check | __package__ | block_flow_check.py:0:0:0:0 | Entry node for Module block_flow_check |
 | block_flow_check | check | block_flow_check.py:12:1:12:5 | ControlFlowNode for check |
 | block_flow_check | enter | block_flow_check.py:2:1:2:5 | ControlFlowNode for enter |
 | block_flow_check | exit | block_flow_check.py:14:1:14:4 | ControlFlowNode for exit |
 | block_flow_check | globals | block_flow_check.py:12:33:12:39 | ControlFlowNode for globals |
 | block_flow_check | object | block_flow_check.py:4:14:4:19 | ControlFlowNode for object |
-| block_flow_check | staticmethod | block_flow_check.py:0:0:0:0 | Entry node for Module block_flow_check |
 | foo | __file__ | foo.py:14:6:14:13 | ControlFlowNode for __file__ |
-| foo | __name__ | foo.py:0:0:0:0 | Entry node for Module foo |
-| foo | __package__ | foo.py:0:0:0:0 | Entry node for Module foo |
 | foo | __private_foo_attr | foo.py:8:1:8:18 | ControlFlowNode for __private_foo_attr |
 | foo | bar_reexported | foo.py:11:8:11:10 | ControlFlowNode for ImportExpr |
 | foo | bar_reexported | foo.py:12:34:12:47 | ControlFlowNode for bar_reexported |
@@ -51,8 +36,6 @@
 | generous_export | SOURCE | generous_export.py:15:11:15:16 | ControlFlowNode for SOURCE |
 | generous_export | SOURCE | generous_export.py:20:25:20:30 | ControlFlowNode for SOURCE |
 | generous_export | __file__ | generous_export.py:22:6:22:13 | ControlFlowNode for __file__ |
-| generous_export | __name__ | generous_export.py:0:0:0:0 | Entry node for Module generous_export |
-| generous_export | __package__ | generous_export.py:0:0:0:0 | Entry node for Module generous_export |
 | generous_export | check | generous_export.py:20:1:20:5 | ControlFlowNode for check |
 | generous_export | enter | generous_export.py:2:1:2:5 | ControlFlowNode for enter |
 | generous_export | eval | generous_export.py:10:4:10:7 | ControlFlowNode for eval |
@@ -60,32 +43,23 @@
 | generous_export | globals | generous_export.py:20:33:20:39 | ControlFlowNode for globals |
 | generous_export | object | generous_export.py:4:14:4:19 | ControlFlowNode for object |
 | generous_export | print | generous_export.py:15:5:15:9 | ControlFlowNode for print |
-| generous_export | staticmethod | generous_export.py:0:0:0:0 | Entry node for Module generous_export |
 | has_defined_all | __all__ | has_defined_all.py:7:1:7:7 | ControlFlowNode for __all__ |
 | has_defined_all | __file__ | has_defined_all.py:9:6:9:13 | ControlFlowNode for __file__ |
-| has_defined_all | __name__ | has_defined_all.py:0:0:0:0 | Entry node for Module has_defined_all |
-| has_defined_all | __package__ | has_defined_all.py:0:0:0:0 | Entry node for Module has_defined_all |
 | has_defined_all | all_defined_bar | has_defined_all.py:5:1:5:15 | ControlFlowNode for all_defined_bar |
 | has_defined_all | all_defined_foo | has_defined_all.py:4:1:4:15 | ControlFlowNode for all_defined_foo |
 | has_defined_all | enter | has_defined_all.py:2:1:2:5 | ControlFlowNode for enter |
 | has_defined_all | exit | has_defined_all.py:9:1:9:4 | ControlFlowNode for exit |
 | has_defined_all_copy | __all__ | has_defined_all_copy.py:9:1:9:7 | ControlFlowNode for __all__ |
 | has_defined_all_copy | __file__ | has_defined_all_copy.py:11:6:11:13 | ControlFlowNode for __file__ |
-| has_defined_all_copy | __name__ | has_defined_all_copy.py:0:0:0:0 | Entry node for Module has_defined_all_copy |
-| has_defined_all_copy | __package__ | has_defined_all_copy.py:0:0:0:0 | Entry node for Module has_defined_all_copy |
 | has_defined_all_copy | all_defined_bar_copy | has_defined_all_copy.py:7:1:7:20 | ControlFlowNode for all_defined_bar_copy |
 | has_defined_all_copy | all_defined_foo_copy | has_defined_all_copy.py:6:1:6:20 | ControlFlowNode for all_defined_foo_copy |
 | has_defined_all_copy | enter | has_defined_all_copy.py:4:1:4:5 | ControlFlowNode for enter |
 | has_defined_all_copy | exit | has_defined_all_copy.py:11:1:11:4 | ControlFlowNode for exit |
 | has_defined_all_indirection | __file__ | has_defined_all_indirection.py:6:6:6:13 | ControlFlowNode for __file__ |
-| has_defined_all_indirection | __name__ | has_defined_all_indirection.py:0:0:0:0 | Entry node for Module has_defined_all_indirection |
-| has_defined_all_indirection | __package__ | has_defined_all_indirection.py:0:0:0:0 | Entry node for Module has_defined_all_indirection |
 | has_defined_all_indirection | all_defined_foo_copy | has_defined_all_copy.py:6:1:6:20 | ControlFlowNode for all_defined_foo_copy |
 | has_defined_all_indirection | enter | has_defined_all_indirection.py:2:1:2:5 | ControlFlowNode for enter |
 | has_defined_all_indirection | exit | has_defined_all_indirection.py:6:1:6:4 | ControlFlowNode for exit |
 | if_then_else | __file__ | if_then_else.py:16:6:16:13 | ControlFlowNode for __file__ |
-| if_then_else | __name__ | if_then_else.py:0:0:0:0 | Entry node for Module if_then_else |
-| if_then_else | __package__ | if_then_else.py:0:0:0:0 | Entry node for Module if_then_else |
 | if_then_else | enter | if_then_else.py:2:1:2:5 | ControlFlowNode for enter |
 | if_then_else | eval | if_then_else.py:11:8:11:11 | ControlFlowNode for eval |
 | if_then_else | exit | if_then_else.py:16:1:16:4 | ControlFlowNode for exit |
@@ -95,8 +69,6 @@
 | if_then_else_refined | SOURCE | if_then_else_refined.py:11:11:11:16 | ControlFlowNode for SOURCE |
 | if_then_else_refined | SOURCE | if_then_else_refined.py:13:11:13:16 | ControlFlowNode for SOURCE |
 | if_then_else_refined | __file__ | if_then_else_refined.py:19:6:19:13 | ControlFlowNode for __file__ |
-| if_then_else_refined | __name__ | if_then_else_refined.py:0:0:0:0 | Entry node for Module if_then_else_refined |
-| if_then_else_refined | __package__ | if_then_else_refined.py:0:0:0:0 | Entry node for Module if_then_else_refined |
 | if_then_else_refined | check | if_then_else_refined.py:17:1:17:5 | ControlFlowNode for check |
 | if_then_else_refined | enter | if_then_else_refined.py:4:1:4:5 | ControlFlowNode for enter |
 | if_then_else_refined | eval | if_then_else_refined.py:10:4:10:7 | ControlFlowNode for eval |
@@ -104,21 +76,15 @@
 | if_then_else_refined | globals | if_then_else_refined.py:17:24:17:30 | ControlFlowNode for globals |
 | if_then_else_refined | src | if_then_else_refined.py:17:19:17:21 | ControlFlowNode for src |
 | package.__init__ | __file__ | package/__init__.py:7:6:7:13 | ControlFlowNode for __file__ |
-| package.__init__ | __name__ | package/__init__.py:0:0:0:0 | Entry node for Module package.__init__ |
-| package.__init__ | __package__ | package/__init__.py:0:0:0:0 | Entry node for Module package.__init__ |
 | package.__init__ | attr_used_in_subpackage | package/__init__.py:4:1:4:23 | ControlFlowNode for attr_used_in_subpackage |
 | package.__init__ | enter | package/__init__.py:2:1:2:5 | ControlFlowNode for enter |
 | package.__init__ | exit | package/__init__.py:7:1:7:4 | ControlFlowNode for exit |
 | package.__init__ | package_attr | package/__init__.py:5:1:5:12 | ControlFlowNode for package_attr |
 | package.subpackage2.__init__ | __file__ | package/subpackage2/__init__.py:6:6:6:13 | ControlFlowNode for __file__ |
-| package.subpackage2.__init__ | __name__ | package/subpackage2/__init__.py:0:0:0:0 | Entry node for Module package.subpackage2.__init__ |
-| package.subpackage2.__init__ | __package__ | package/subpackage2/__init__.py:0:0:0:0 | Entry node for Module package.subpackage2.__init__ |
 | package.subpackage2.__init__ | enter | package/subpackage2/__init__.py:2:1:2:5 | ControlFlowNode for enter |
 | package.subpackage2.__init__ | exit | package/subpackage2/__init__.py:6:1:6:4 | ControlFlowNode for exit |
 | package.subpackage2.__init__ | subpackage2_attr | package/subpackage2/__init__.py:4:1:4:16 | ControlFlowNode for subpackage2_attr |
 | package.subpackage.__init__ | __file__ | package/subpackage/__init__.py:14:6:14:13 | ControlFlowNode for __file__ |
-| package.subpackage.__init__ | __name__ | package/subpackage/__init__.py:0:0:0:0 | Entry node for Module package.subpackage.__init__ |
-| package.subpackage.__init__ | __package__ | package/subpackage/__init__.py:0:0:0:0 | Entry node for Module package.subpackage.__init__ |
 | package.subpackage.__init__ | check | package/subpackage/__init__.py:12:1:12:5 | ControlFlowNode for check |
 | package.subpackage.__init__ | enter | package/subpackage/__init__.py:2:1:2:5 | ControlFlowNode for enter |
 | package.subpackage.__init__ | exit | package/subpackage/__init__.py:14:1:14:4 | ControlFlowNode for exit |
@@ -130,24 +96,18 @@
 | package.subpackage.__init__ | submodule | package/subpackage/__init__.py:12:35:12:43 | ControlFlowNode for submodule |
 | package.subpackage.__init__ | subpackage_attr | package/subpackage/__init__.py:4:1:4:15 | ControlFlowNode for subpackage_attr |
 | package.subpackage.submodule | __file__ | package/subpackage/submodule.py:7:6:7:13 | ControlFlowNode for __file__ |
-| package.subpackage.submodule | __name__ | package/subpackage/submodule.py:0:0:0:0 | Entry node for Module package.subpackage.submodule |
-| package.subpackage.submodule | __package__ | package/subpackage/submodule.py:0:0:0:0 | Entry node for Module package.subpackage.submodule |
 | package.subpackage.submodule | enter | package/subpackage/submodule.py:2:1:2:5 | ControlFlowNode for enter |
 | package.subpackage.submodule | exit | package/subpackage/submodule.py:7:1:7:4 | ControlFlowNode for exit |
 | package.subpackage.submodule | irrelevant_attr | package/subpackage/submodule.py:5:1:5:15 | ControlFlowNode for irrelevant_attr |
 | package.subpackage.submodule | submodule_attr | package/subpackage/submodule.py:4:1:4:14 | ControlFlowNode for submodule_attr |
 | refined | SOURCE | refined.py:12:25:12:30 | ControlFlowNode for SOURCE |
 | refined | __file__ | refined.py:14:6:14:13 | ControlFlowNode for __file__ |
-| refined | __name__ | refined.py:0:0:0:0 | Entry node for Module refined |
-| refined | __package__ | refined.py:0:0:0:0 | Entry node for Module refined |
 | refined | check | refined.py:12:1:12:5 | ControlFlowNode for check |
 | refined | enter | refined.py:2:1:2:5 | ControlFlowNode for enter |
 | refined | exit | refined.py:14:1:14:4 | ControlFlowNode for exit |
 | refined | globals | refined.py:12:33:12:39 | ControlFlowNode for globals |
 | refined | object | refined.py:4:14:4:19 | ControlFlowNode for object |
 | simplistic_reexport | __file__ | simplistic_reexport.py:19:6:19:13 | ControlFlowNode for __file__ |
-| simplistic_reexport | __name__ | simplistic_reexport.py:0:0:0:0 | Entry node for Module simplistic_reexport |
-| simplistic_reexport | __package__ | simplistic_reexport.py:0:0:0:0 | Entry node for Module simplistic_reexport |
 | simplistic_reexport | bar_attr | simplistic_reexport.py:6:17:6:24 | ControlFlowNode for ImportMember |
 | simplistic_reexport | bar_attr | simplistic_reexport.py:10:19:10:26 | ControlFlowNode for bar_attr |
 | simplistic_reexport | baz_attr | baz.py:4:1:4:8 | ControlFlowNode for baz_attr |

--- a/python/ql/test/experimental/import-resolution/package/subpackage/__init__.py
+++ b/python/ql/test/experimental/import-resolution/package/subpackage/__init__.py
@@ -9,6 +9,6 @@ check("imported_attr", imported_attr,  "attr_used_in_subpackage", globals()) #$ 
 
 # Importing an irrelevant attribute from a sibling module binds the name to the module.
 from .submodule import irrelevant_attr
-check("submodule.submodule_attr", submodule.submodule_attr, "submodule_attr", globals()) #$ prints=submodule_attr
+check("submodule.submodule_attr", submodule.submodule_attr, "submodule_attr", globals()) #$ MISSING:prints=submodule_attr
 
 exit(__file__)

--- a/python/ql/test/library-tests/PointsTo/new/ImpliesDataflow.expected
+++ b/python/ql/test/library-tests/PointsTo/new/ImpliesDataflow.expected
@@ -3,22 +3,5 @@
 | code/l_calls.py:12:1:12:20 | ControlFlowNode for ClassExpr | code/l_calls.py:16:16:16:18 | ControlFlowNode for cls |
 | code/l_calls.py:12:1:12:20 | ControlFlowNode for ClassExpr | code/l_calls.py:24:13:24:22 | ControlFlowNode for Attribute() |
 | code/l_calls.py:12:1:12:20 | ControlFlowNode for ClassExpr | code/l_calls.py:25:16:25:16 | ControlFlowNode for a |
-| code/n_nesting.py:0:0:0:0 | Entry node for Module code.n_nesting | code/i_imports.py:38:1:38:14 | ControlFlowNode for Attribute |
-| code/package/module2.py:0:0:0:0 | Entry node for Module code.package.module2 | code/package/__init__.py:4:15:4:32 | ControlFlowNode for ImportMember |
-| code/package/module2.py:0:0:0:0 | Entry node for Module code.package.module2 | code/package/__init__.py:7:15:7:32 | ControlFlowNode for ImportMember |
-| code/package/module.py:0:0:0:0 | Entry node for Module code.package.module | code/package/__init__.py:1:6:1:12 | ControlFlowNode for ImportExpr |
-| code/package/moduleX.py:0:0:0:0 | Entry node for Module code.package.moduleX | code/j_convoluted_imports.py:16:26:16:32 | ControlFlowNode for ImportMember |
-| code/package/moduleX.py:0:0:0:0 | Entry node for Module code.package.moduleX | code/j_convoluted_imports.py:17:1:17:7 | ControlFlowNode for moduleX |
-| code/package/moduleX.py:0:0:0:0 | Entry node for Module code.package.moduleX | code/package/__init__.py:8:26:8:32 | ControlFlowNode for ImportMember |
-| code/package/x.py:0:0:0:0 | Entry node for Module code.package.x | code/i_imports.py:24:1:24:14 | ControlFlowNode for Attribute |
-| code/package/x.py:0:0:0:0 | Entry node for Module code.package.x | code/j_convoluted_imports.py:6:8:6:8 | ControlFlowNode for ImportMember |
-| code/package/x.py:0:0:0:0 | Entry node for Module code.package.x | code/j_convoluted_imports.py:14:34:14:34 | ControlFlowNode for ImportMember |
 | code/t_type.py:3:1:3:16 | ControlFlowNode for ClassExpr | code/t_type.py:6:1:6:9 | ControlFlowNode for type() |
 | code/t_type.py:3:1:3:16 | ControlFlowNode for ClassExpr | code/t_type.py:13:5:13:13 | ControlFlowNode for type() |
-| code/test_package/module1.py:0:0:0:0 | Entry node for Module code.test_package.module1 | code/j_convoluted_imports.py:20:10:20:34 | ControlFlowNode for ImportExpr |
-| code/test_package/module1.py:0:0:0:0 | Entry node for Module code.test_package.module1 | code/test_package/__init__.py:1:6:1:13 | ControlFlowNode for ImportExpr |
-| code/test_package/module2.py:0:0:0:0 | Entry node for Module code.test_package.module2 | code/j_convoluted_imports.py:22:10:22:34 | ControlFlowNode for ImportExpr |
-| code/test_package/module2.py:0:0:0:0 | Entry node for Module code.test_package.module2 | code/test_package/__init__.py:2:6:2:13 | ControlFlowNode for ImportExpr |
-| code/xyz.py:0:0:0:0 | Entry node for Module code.xyz | code/i_imports.py:7:6:7:9 | ControlFlowNode for ImportExpr |
-| code/xyz.py:0:0:0:0 | Entry node for Module code.xyz | code/i_imports.py:8:15:8:17 | ControlFlowNode for ImportMember |
-| code/xyz.py:0:0:0:0 | Entry node for Module code.xyz | code/i_imports.py:9:1:9:3 | ControlFlowNode for xyz |


### PR DESCRIPTION
This should have been part of https://github.com/github/codeql/pull/14777.
These nodes are extra copared to which SSA nodes existed before.

We do lose one result that we gained by having these nodes:
```
testFailures
+| package/subpackage/__init__.py:12:90:12:113 | Comment #$ prints=submodule_attr | Missing result:prints=submodule_attr |
```
which is the one we might expect to lose. We do get to keep the other one (about lambdas in flow summaries),