### PR TITLE
Rangeanalysis: Prune range calculation.

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/analysis/RangeAnalysisConstantSpecific.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/analysis/RangeAnalysisConstantSpecific.qll
@@ -25,4 +25,8 @@ module CppLangImplConstant implements LangSig<Sem, FloatDelta> {
    * Holds if `e2 >= e1 + delta` (if `upper = false`) or `e2 <= e1 + delta` (if `upper = true`).
    */
   predicate additionalBoundFlowStep(SemExpr e2, SemExpr e1, float delta, boolean upper) { none() }
+
+  predicate includeConstantBounds() { any() }
+
+  predicate includeRelativeBounds() { none() }
 }

--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/analysis/RangeAnalysisImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/analysis/RangeAnalysisImpl.qll
@@ -173,11 +173,11 @@ private module ModulusAnalysisInstantiated implements ModulusAnalysisSig<Sem> {
 }
 
 module ConstantStage =
-  RangeStage<SemLocation, Sem, FloatDelta, ConstantBounds, FloatOverflow, CppLangImplConstant,
+  RangeStage<SemLocation, Sem, FloatDelta, AllBounds, FloatOverflow, CppLangImplConstant,
     SignAnalysis, ModulusAnalysisInstantiated>;
 
 module RelativeStage =
-  RangeStage<SemLocation, Sem, FloatDelta, RelativeBounds, FloatOverflow, CppLangImplRelative,
+  RangeStage<SemLocation, Sem, FloatDelta, AllBounds, FloatOverflow, CppLangImplRelative,
     SignAnalysis, ModulusAnalysisInstantiated>;
 
 private newtype TSemReason =

--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/analysis/RangeAnalysisRelativeSpecific.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/analysis/RangeAnalysisRelativeSpecific.qll
@@ -57,4 +57,8 @@ module CppLangImplRelative implements LangSig<Sem, FloatDelta> {
    * Holds if `e2 >= e1 + delta` (if `upper = false`) or `e2 <= e1 + delta` (if `upper = true`).
    */
   predicate additionalBoundFlowStep(SemExpr e2, SemExpr e1, float delta, boolean upper) { none() }
+
+  predicate includeConstantBounds() { none() }
+
+  predicate includeRelativeBounds() { any() }
 }


### PR DESCRIPTION
This adds a pre-bound calculation to range analysis, which does an initial simple pass using forward-flowing steps only. Nodes with multiple incoming bound-flow edges such as bitwise-and and ssa references under a guard, might have simple tight bounds coming from one edge, and multiple looser bounds from the other. By inferring the simpler bounds in an initial pass, we're able to prune away the other looser bounds including those that might proliferate through a back-edge. An example is `x &= 7` for which this initial pass will ensure that no upper bound for `x` greater than 7 can pass the assignment.

Commit-by-commit review encouraged, as the first couple of commits are just refactorings.