### PR TITLE
Swift: Model Manual Memory Management closure functions and withMemoryRebound variants

### DIFF
--- a/swift/ql/lib/change-notes/2023-12-07-closure-models.md
+++ b/swift/ql/lib/change-notes/2023-12-07-closure-models.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+* Added flow models for non-member `withUnsafePointer` and similar functions.
+* Added flow models for `withMemoryRebound`, `assumingMemoryBound` and `bindMemory` member functions of library pointer classes.

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Array.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Array.qll
@@ -34,7 +34,7 @@ private class ArraySummaries extends SummaryModelCsv {
         ";Array;true;withUnsafeBytes(_:);;;Argument[0].ReturnValue;ReturnValue;value",
         ";Array;true;withUnsafeMutableBytes(_:);;;Argument[-1];Argument[0].Parameter[0].CollectionElement;taint",
         ";Array;true;withUnsafeMutableBytes(_:);;;Argument[-1].CollectionElement;Argument[0].Parameter[0].CollectionElement;taint",
-        ";Array;true;withUnsafeMutableBytes(_:);;;Argument[0].Parameter[0].CollectionElement;Argument[-1].CollectionElement;value",
+        ";Array;true;withUnsafeMutableBytes(_:);;;Argument[0].Parameter[0].CollectionElement;Argument[-1].CollectionElement;taint",
         ";Array;true;withUnsafeMutableBytes(_:);;;Argument[0].ReturnValue;ReturnValue;value",
         ";ContiguousArray;true;withUnsafeBufferPointer(_:);;;Argument[-1];Argument[0].Parameter[0].CollectionElement;taint",
         ";ContiguousArray;true;withUnsafeBufferPointer(_:);;;Argument[-1].CollectionElement;Argument[0].Parameter[0].CollectionElement;value",

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Data.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Data.qll
@@ -47,7 +47,7 @@ private class DataSummaries extends SummaryModelCsv {
         ";Data;true;trimmingPrefix(while:);;;Argument[-1];ReturnValue;taint",
         ";Data;true;withUnsafeMutableBytes(_:);;;Argument[-1];Argument[0].Parameter[0].CollectionElement;taint",
         ";Data;true;withUnsafeMutableBytes(_:);;;Argument[-1].CollectionElement;Argument[0].Parameter[0].CollectionElement;taint",
-        ";Data;true;withUnsafeMutableBytes(_:);;;Argument[0].Parameter[0].CollectionElement;Argument[-1].CollectionElement;value",
+        ";Data;true;withUnsafeMutableBytes(_:);;;Argument[0].Parameter[0].CollectionElement;Argument[-1].CollectionElement;taint",
         ";Data;true;withUnsafeMutableBytes(_:);;;Argument[0].ReturnValue;ReturnValue;value",
       ]
   }

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/PointerTypes.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/PointerTypes.qll
@@ -68,6 +68,19 @@ private class PointerSummaries extends SummaryModelCsv {
       [
         ";UnsafeMutablePointer;true;init(mutating:);;;Argument[0];ReturnValue;taint",
         ";UnsafeMutableBufferPointer;true;update(repeating:);;;Argument[0];Argument[-1].CollectionElement;value",
+        ";;false;withUnsafePointer(to:_:);;;Argument[0];Argument[1].Parameter[0].CollectionElement;taint",
+        ";;false;withUnsafePointer(to:_:);;;Argument[1].ReturnValue;ReturnValue;value",
+        ";;false;withUnsafeMutablePointer(to:_:);;;Argument[0];Argument[1].Parameter[0].CollectionElement;taint",
+        ";;false;withUnsafeMutablePointer(to:_:);;;Argument[1].Parameter[0].CollectionElement;Argument[0];value",
+        ";;false;withUnsafeMutablePointer(to:_:);;;Argument[1].ReturnValue;ReturnValue;value",
+        ";;false;withUnsafeBytes(of:_:);;;Argument[0];Argument[1].Parameter[0].CollectionElement;taint",
+        ";;false;withUnsafeBytes(of:_:);;;Argument[1].ReturnValue;ReturnValue;value",
+        ";;false;withUnsafeMutableBytes(of:_:);;;Argument[0];Argument[1].Parameter[0].CollectionElement;taint",
+        ";;false;withUnsafeMutableBytes(of:_:);;;Argument[1].Parameter[0].CollectionElement;Argument[0];taint",
+        ";;false;withUnsafeMutableBytes(of:_:);;;Argument[1].ReturnValue;ReturnValue;value",
+        ";;false;withUnsafeTemporaryAllocation(of:capacity:_:);;;Argument[2].ReturnValue;ReturnValue;value",
+        ";;false;withUnsafeTemporaryAllocation(byteCount:alignment:_:);;;Argument[2].ReturnValue;ReturnValue;value",
+        ";;false;withExtendedLifetime(_:_:);;;Argument[1].ReturnValue;ReturnValue;value",
       ]
   }
 }

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/PointerTypes.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/PointerTypes.qll
@@ -66,8 +66,50 @@ private class PointerSummaries extends SummaryModelCsv {
   override predicate row(string row) {
     row =
       [
+        ";UnsafePointer;true;withMemoryRebound(to:capacity:_:);;;Argument[-1].CollectionElement;Argument[2].Parameter[0].CollectionElement;taint",
+        ";UnsafePointer;true;withMemoryRebound(to:capacity:_:);;;Argument[2].ReturnValue;ReturnValue;value",
+        // ---
         ";UnsafeMutablePointer;true;init(mutating:);;;Argument[0];ReturnValue;taint",
+        ";UnsafeMutablePointer;true;withMemoryRebound(to:capacity:_:);;;Argument[-1].CollectionElement;Argument[2].Parameter[0].CollectionElement;taint",
+        ";UnsafeMutablePointer;true;withMemoryRebound(to:capacity:_:);;;Argument[2].Parameter[0].CollectionElement;Argument[-1].CollectionElement;taint",
+        ";UnsafeMutablePointer;true;withMemoryRebound(to:capacity:_:);;;Argument[2].ReturnValue;ReturnValue;value",
+        // ---
+        ";UnsafeBufferPointer;true;withMemoryRebound(to:_:);;;Argument[-1].CollectionElement;Argument[1].Parameter[0].CollectionElement;taint",
+        ";UnsafeBufferPointer;true;withMemoryRebound(to:_:);;;Argument[1].ReturnValue;ReturnValue;value",
+        // ---
         ";UnsafeMutableBufferPointer;true;update(repeating:);;;Argument[0];Argument[-1].CollectionElement;value",
+        ";UnsafeMutableBufferPointer;true;withMemoryRebound(to:_:);;;Argument[-1].CollectionElement;Argument[1].Parameter[0].CollectionElement;taint",
+        ";UnsafeMutableBufferPointer;true;withMemoryRebound(to:_:);;;Argument[1].Parameter[0].CollectionElement;Argument[-1].CollectionElement;taint",
+        ";UnsafeMutableBufferPointer;true;withMemoryRebound(to:_:);;;Argument[1].ReturnValue;ReturnValue;value",
+        // ---
+        ";UnsafeRawPointer;true;withMemoryRebound(to:capacity:_:);;;Argument[-1].CollectionElement;Argument[2].Parameter[0].CollectionElement;taint",
+        ";UnsafeRawPointer;true;withMemoryRebound(to:capacity:_:);;;Argument[2].ReturnValue;ReturnValue;value",
+        ";UnsafeRawPointer;true;assumingMemoryBound(to:);;;Argument[-1].CollectionElement;ReturnValue.CollectionElement;taint",
+        ";UnsafeRawPointer;true;bindMemory(to:capacity:);;;Argument[-1].CollectionElement;ReturnValue.CollectionElement;taint",
+        // ---
+        ";UnsafeMutableRawPointer;true;withMemoryRebound(to:capacity:_:);;;Argument[-1].CollectionElement;Argument[2].Parameter[0].CollectionElement;taint",
+        ";UnsafeMutableRawPointer;true;withMemoryRebound(to:capacity:_:);;;Argument[2].Parameter[0].CollectionElement;Argument[-1].CollectionElement;taint",
+        ";UnsafeMutableRawPointer;true;withMemoryRebound(to:capacity:_:);;;Argument[2].ReturnValue;ReturnValue;value",
+        ";UnsafeMutableRawPointer;true;assumingMemoryBound(to:);;;Argument[-1].CollectionElement;ReturnValue.CollectionElement;taint",
+        ";UnsafeMutableRawPointer;true;bindMemory(to:capacity:);;;Argument[-1].CollectionElement;ReturnValue.CollectionElement;taint",
+        // ---
+        ";UnsafeRawBufferPointer;true;withMemoryRebound(to:_:);;;Argument[-1].CollectionElement;Argument[1].Parameter[0].CollectionElement;taint",
+        ";UnsafeRawBufferPointer;true;withMemoryRebound(to:_:);;;Argument[1].ReturnValue;ReturnValue;value",
+        ";UnsafeRawBufferPointer;true;assumingMemoryBound(to:);;;Argument[-1].CollectionElement;ReturnValue.CollectionElement;taint",
+        ";UnsafeRawBufferPointer;true;bindMemory(to:);;;Argument[-1].CollectionElement;ReturnValue.CollectionElement;taint",
+        // ---
+        ";UnsafeMutableRawBufferPointer;true;withMemoryRebound(to:_:);;;Argument[-1].CollectionElement;Argument[1].Parameter[0].CollectionElement;taint",
+        ";UnsafeMutableRawBufferPointer;true;withMemoryRebound(to:_:);;;Argument[1].Parameter[0].CollectionElement;Argument[-1].CollectionElement;taint",
+        ";UnsafeMutableRawBufferPointer;true;withMemoryRebound(to:_:);;;Argument[1].ReturnValue;ReturnValue;value",
+        ";UnsafeMutableRawBufferPointer;true;assumingMemoryBound(to:);;;Argument[-1].CollectionElement;ReturnValue.CollectionElement;taint",
+        ";UnsafeMutableRawBufferPointer;true;bindMemory(to:);;;Argument[-1].CollectionElement;ReturnValue.CollectionElement;taint",
+        // ---
+        ";Slice;true;withMemoryRebound(to:_:);;;Argument[-1].CollectionElement;Argument[1].Parameter[0].CollectionElement;taint",
+        ";Slice;true;withMemoryRebound(to:_:);;;Argument[1].Parameter[0].CollectionElement;Argument[-1].CollectionElement;taint",
+        ";Slice;true;withMemoryRebound(to:_:);;;Argument[1].ReturnValue;ReturnValue;value",
+        ";Slice;true;assumingMemoryBound(to:);;;Argument[-1].CollectionElement;ReturnValue.CollectionElement;taint",
+        ";Slice;true;bindMemory(to:);;;Argument[-1].CollectionElement;ReturnValue.CollectionElement;taint",
+        // ---
         ";;false;withUnsafePointer(to:_:);;;Argument[0];Argument[1].Parameter[0].CollectionElement;taint",
         ";;false;withUnsafePointer(to:_:);;;Argument[1].ReturnValue;ReturnValue;value",
         ";;false;withUnsafeMutablePointer(to:_:);;;Argument[0];Argument[1].Parameter[0].CollectionElement;taint",

--- a/swift/ql/test/library-tests/dataflow/taint/libraries/unsafepointer.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/libraries/unsafepointer.swift
@@ -164,12 +164,12 @@ func testManualMemoryManagement() {
     sink(arg: ptr[0]) // $ tainted=i3
     ptr.withMemoryRebound(to: Int.self, {
       buffer in
-      sink(arg: buffer)
-      sink(arg: buffer[0]) // $ MISSING: tainted=i3
+      sink(arg: buffer) // $ tainted=i3
+      sink(arg: buffer[0]) // $ tainted=i3
     })
     let buffer2 = ptr.bindMemory(to: Int.self)
-    sink(arg: buffer2)
-    sink(arg: buffer2[0]) // $ MISSING: tainted=i3
+    sink(arg: buffer2) // $ tainted=i3
+    sink(arg: buffer2[0]) // $ tainted=i3
     return sourceInt("r3")
   })
   sink(arg: r3) // $ tainted=r3

--- a/swift/ql/test/library-tests/dataflow/taint/libraries/unsafepointer.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/libraries/unsafepointer.swift
@@ -135,33 +135,33 @@ func testManualMemoryManagement() {
   let i1 = sourceInt("i1")
   let r1 = withUnsafePointer(to: i1, {
     ptr in
-    sink(arg: ptr)
-    sink(arg: ptr[0]) // $ MISSING: tainted=i1
+    sink(arg: ptr) // $ tainted=i1
+    sink(arg: ptr[0]) // $ tainted=i1
     sink(arg: ptr.pointee) // $ MISSING: tainted=i1
     return sourceInt("r1")
   })
-  sink(arg: r1) // $ MISSING: tainted=r1
+  sink(arg: r1) // $ tainted=r1
 
   var i2 = sourceInt("i2")
   let r2 = withUnsafeMutablePointer(to: &i2, {
     ptr in
-    sink(arg: ptr)
-    sink(arg: ptr[0]) // $ MISSING: tainted=i2
+    sink(arg: ptr) // $ tainted=i2
+    sink(arg: ptr[0]) // $ tainted=i2
     sink(arg: ptr.pointee) // $ MISSING: tainted=i2
     ptr.pointee = sourceInt("i2_overwrite")
-    sink(arg: ptr)
-    sink(arg: ptr[0]) // $ MISSING: tainted=i2_overwrite
+    sink(arg: ptr) // $ SPURIOUS: tainted=i2
+    sink(arg: ptr[0]) // $ MISSING: tainted=i2_overwrite SPURIOUS: tainted=i2
     sink(arg: ptr.pointee) // $ tainted=i2_overwrite
     return sourceInt("r2")
   })
-  sink(arg: r2) // $ MISSING: tainted=r2
+  sink(arg: r2) // $ tainted=r2
   sink(arg: i2) // $ MISSING: tainted=i2_overwrite SPURIOUS: tainted=i2
 
   let i3 = sourceInt("i3")
   let r3 = withUnsafeBytes(of: i3, {
     ptr in
-    sink(arg: ptr)
-    sink(arg: ptr[0]) // $ MISSING: tainted=i3
+    sink(arg: ptr) // $ tainted=i3
+    sink(arg: ptr[0]) // $ tainted=i3
     ptr.withMemoryRebound(to: Int.self, {
       buffer in
       sink(arg: buffer)
@@ -172,20 +172,20 @@ func testManualMemoryManagement() {
     sink(arg: buffer2[0]) // $ MISSING: tainted=i3
     return sourceInt("r3")
   })
-  sink(arg: r3) // $ MISSING: tainted=r3
+  sink(arg: r3) // $ tainted=r3
 
   var i4 = sourceInt("i4")
   let r4 = withUnsafeMutableBytes(of: &i4, {
     ptr in
-    sink(arg: ptr)
-    sink(arg: ptr[0]) // $ MISSING: tainted=i4
+    sink(arg: ptr) // $ tainted=i4
+    sink(arg: ptr[0]) // $ tainted=i4
     ptr[0] = sourceUInt8("i4_partialwrite")
-    sink(arg: ptr) // $ tainted=i4_partialwrite MISSING: tainted=i4
-    sink(arg: ptr[0]) // $ tainted=i4_partialwrite
+    sink(arg: ptr) // $ tainted=i4_partialwrite tainted=i4
+    sink(arg: ptr[0]) // $ tainted=i4_partialwrite SPURIOUS: tainted=i4
     return sourceInt("r4")
   })
-  sink(arg: r4) // $ MISSING: tainted=r4
-  sink(arg: i4) // $ tainted=i4 MISSING: tainted=i4_partialwrite
+  sink(arg: r4) // $ tainted=r4
+  sink(arg: i4) // $ tainted=i4 tainted=i4_partialwrite
 
   let r5 = withUnsafeTemporaryAllocation(of: Int.self, capacity: 10, {
     buffer in
@@ -196,10 +196,10 @@ func testManualMemoryManagement() {
     sink(arg: buffer[0]) // $ tainted=buffer5
     return sourceInt("r5")
   })
-  sink(arg: r5) // $ MISSING: tainted=r5
+  sink(arg: r5) // $ tainted=r5
 
   let r6 = withExtendedLifetime(sourceInt("i6"), {
     return sourceInt("r6")
   })
-  sink(arg: r6) // $ MISSING: tainted=r6
+  sink(arg: r6) // $ tainted=r6
 }

--- a/swift/ql/test/library-tests/dataflow/taint/libraries/unsafepointer.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/libraries/unsafepointer.swift
@@ -1,8 +1,8 @@
 
 // --- stubs ---
 
-func sourceString() -> String { return "" }
-func sourceUInt8() -> UInt8 { return 0 }
+func sourceString(_ label: String) -> String { return "" }
+func sourceUInt8(_ label: String) -> UInt8 { return 0 }
 func sink(arg: Any) {}
 
 // --- tests ---
@@ -18,14 +18,14 @@ func taintPointer(ptr: UnsafeMutablePointer<String>) {
   sink(arg: ptr.pointee)
   sink(arg: ptr)
 
-  ptr.pointee = sourceString()
+  ptr.pointee = sourceString("taintPointer")
 
-  sink(arg: ptr.pointee) // $ tainted=21
+  sink(arg: ptr.pointee) // $ tainted=taintPointer
   sink(arg: ptr)
 }
 
 func clearPointer2(ptr: UnsafeMutablePointer<String>) {
-  sink(arg: ptr.pointee) // $ tainted=21
+  sink(arg: ptr.pointee) // $ tainted=taintPointer
   sink(arg: ptr)
 
   ptr.pointee = "abc"
@@ -42,12 +42,12 @@ func testMutatingPointerInCall(ptr: UnsafeMutablePointer<String>) {
 
   taintPointer(ptr: ptr) // mutates `ptr` pointee with a tainted value
 
-  sink(arg: ptr.pointee) // $ tainted=21
+  sink(arg: ptr.pointee) // $ tainted=taintPointer
   sink(arg: ptr)
 
   clearPointer2(ptr: ptr)
 
-  sink(arg: ptr.pointee) // $ SPURIOUS: tainted=21
+  sink(arg: ptr.pointee) // $ SPURIOUS: tainted=taintPointer
   sink(arg: ptr)
 }
 
@@ -57,10 +57,10 @@ func taintBuffer(buffer: UnsafeMutableBufferPointer<UInt8>) {
   sink(arg: buffer[0])
   sink(arg: buffer)
 
-  buffer[0] = sourceUInt8()
+  buffer[0] = sourceUInt8("taintBuffer")
 
-  sink(arg: buffer[0]) // $ tainted=60
-  sink(arg: buffer) // $ tainted=60
+  sink(arg: buffer[0]) // $ tainted=taintBuffer
+  sink(arg: buffer) // $ tainted=taintBuffer
 }
 
 func testMutatingBufferInCall(ptr: UnsafeMutablePointer<UInt8>) {
@@ -71,8 +71,8 @@ func testMutatingBufferInCall(ptr: UnsafeMutablePointer<UInt8>) {
 
   taintBuffer(buffer: buffer) // mutates `buffer` contents with a tainted value
 
-  sink(arg: buffer[0]) // $ tainted=60
-  sink(arg: buffer) // $ tainted=60
+  sink(arg: buffer[0]) // $ tainted=taintBuffer
+  sink(arg: buffer) // $ tainted=taintBuffer
 
 }
 
@@ -84,9 +84,9 @@ func taintMyPointer(ptr: MyPointer) {
   sink(arg: ptr.pointee)
   sink(arg: ptr)
 
-  ptr.pointee = sourceString()
+  ptr.pointee = sourceString("taintMyPointer")
 
-  sink(arg: ptr.pointee) // $ tainted=87
+  sink(arg: ptr.pointee) // $ tainted=taintMyPointer
   sink(arg: ptr)
 }
 
@@ -96,7 +96,7 @@ func testMutatingMyPointerInCall(ptr: MyPointer) {
 
   taintMyPointer(ptr: ptr) // mutates `ptr` pointee with a tainted value
 
-  sink(arg: ptr.pointee) // $ MISSING: tainted=87
+  sink(arg: ptr.pointee) // $ MISSING: tainted=taintMyPointer
   sink(arg: ptr)
 }
 
@@ -111,19 +111,19 @@ struct MyGenericPointerContainer<T> {
 }
 
 func writePointerContainer(mpc: MyPointerContainer) {
-  mpc.ptr.pointee = sourceString()
-  sink(arg: mpc.ptr.pointee) // $ tainted=114
+  mpc.ptr.pointee = sourceString("writePointerContainer")
+  sink(arg: mpc.ptr.pointee) // $ tainted=writePointerContainer
 }
 
 func writeGenericPointerContainer<T>(mgpc: MyGenericPointerContainer<T>) {
-  mgpc.ptr.pointee = sourceString() as! T
-  sink(arg: mgpc.ptr.pointee) // $ tainted=119
+  mgpc.ptr.pointee = sourceString("writeGenericPointerContainer") as! T
+  sink(arg: mgpc.ptr.pointee) // $ tainted=writeGenericPointerContainer
 }
 
 func testWritingPointerContainersInCalls(mpc: MyPointerContainer, mgpc: MyGenericPointerContainer<Int>) {
   writePointerContainer(mpc: mpc)
-  sink(arg: mpc.ptr.pointee) // $ tainted=114
+  sink(arg: mpc.ptr.pointee) // $ tainted=writePointerContainer
 
   writeGenericPointerContainer(mgpc: mgpc)
-  sink(arg: mgpc.ptr.pointee) // $ tainted=119
+  sink(arg: mgpc.ptr.pointee) // $ tainted=writeGenericPointerContainer
 }

--- a/swift/ql/test/library-tests/dataflow/taint/libraries/unsafepointer.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/libraries/unsafepointer.swift
@@ -1,6 +1,7 @@
 
 // --- stubs ---
 
+func sourceInt(_ label: String) -> Int { return 0 }
 func sourceString(_ label: String) -> String { return "" }
 func sourceUInt8(_ label: String) -> UInt8 { return 0 }
 func sink(arg: Any) {}
@@ -126,4 +127,79 @@ func testWritingPointerContainersInCalls(mpc: MyPointerContainer, mgpc: MyGeneri
 
   writeGenericPointerContainer(mgpc: mgpc)
   sink(arg: mgpc.ptr.pointee) // $ tainted=writeGenericPointerContainer
+}
+
+// ---
+
+func testManualMemoryManagement() {
+  let i1 = sourceInt("i1")
+  let r1 = withUnsafePointer(to: i1, {
+    ptr in
+    sink(arg: ptr)
+    sink(arg: ptr[0]) // $ MISSING: tainted=i1
+    sink(arg: ptr.pointee) // $ MISSING: tainted=i1
+    return sourceInt("r1")
+  })
+  sink(arg: r1) // $ MISSING: tainted=r1
+
+  var i2 = sourceInt("i2")
+  let r2 = withUnsafeMutablePointer(to: &i2, {
+    ptr in
+    sink(arg: ptr)
+    sink(arg: ptr[0]) // $ MISSING: tainted=i2
+    sink(arg: ptr.pointee) // $ MISSING: tainted=i2
+    ptr.pointee = sourceInt("i2_overwrite")
+    sink(arg: ptr)
+    sink(arg: ptr[0]) // $ MISSING: tainted=i2_overwrite
+    sink(arg: ptr.pointee) // $ tainted=i2_overwrite
+    return sourceInt("r2")
+  })
+  sink(arg: r2) // $ MISSING: tainted=r2
+  sink(arg: i2) // $ MISSING: tainted=i2_overwrite SPURIOUS: tainted=i2
+
+  let i3 = sourceInt("i3")
+  let r3 = withUnsafeBytes(of: i3, {
+    ptr in
+    sink(arg: ptr)
+    sink(arg: ptr[0]) // $ MISSING: tainted=i3
+    ptr.withMemoryRebound(to: Int.self, {
+      buffer in
+      sink(arg: buffer)
+      sink(arg: buffer[0]) // $ MISSING: tainted=i3
+    })
+    let buffer2 = ptr.bindMemory(to: Int.self)
+    sink(arg: buffer2)
+    sink(arg: buffer2[0]) // $ MISSING: tainted=i3
+    return sourceInt("r3")
+  })
+  sink(arg: r3) // $ MISSING: tainted=r3
+
+  var i4 = sourceInt("i4")
+  let r4 = withUnsafeMutableBytes(of: &i4, {
+    ptr in
+    sink(arg: ptr)
+    sink(arg: ptr[0]) // $ MISSING: tainted=i4
+    ptr[0] = sourceUInt8("i4_partialwrite")
+    sink(arg: ptr) // $ tainted=i4_partialwrite MISSING: tainted=i4
+    sink(arg: ptr[0]) // $ tainted=i4_partialwrite
+    return sourceInt("r4")
+  })
+  sink(arg: r4) // $ MISSING: tainted=r4
+  sink(arg: i4) // $ tainted=i4 MISSING: tainted=i4_partialwrite
+
+  let r5 = withUnsafeTemporaryAllocation(of: Int.self, capacity: 10, {
+    buffer in
+    sink(arg: buffer)
+    sink(arg: buffer[0])
+    buffer[0] = sourceInt("buffer5")
+    sink(arg: buffer) // $ tainted=buffer5
+    sink(arg: buffer[0]) // $ tainted=buffer5
+    return sourceInt("r5")
+  })
+  sink(arg: r5) // $ MISSING: tainted=r5
+
+  let r6 = withExtendedLifetime(sourceInt("i6"), {
+    return sourceInt("r6")
+  })
+  sink(arg: r6) // $ MISSING: tainted=r6
 }


### PR DESCRIPTION
Model "Manual Memory Management" closure functions such as (classless) `withUnsafePointer`.  Model `withMemoryRebound` and similar methods on the various pointer classes.

Note that results aren't great on the tests involve `.pointee`.  Some non-trivial work is needed to fix them and I've created an issue to track that.