### PR TITLE
Ruby: Model editor improvements

### DIFF
--- a/ruby/ql/lib/codeql/ruby/ast/Module.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/Module.qll
@@ -173,6 +173,11 @@ class Module extends TModule {
     result.getParentModule() = this and
     result.getOwnModuleName() = name
   }
+
+  /**
+   * Holds if this is a built-in module, e.g. `Object`.
+   */
+  predicate isBuiltin() { isBuiltinModule(this) }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/ast/internal/Module.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/internal/Module.qll
@@ -43,6 +43,9 @@ private module Cached {
   }
 
   cached
+  predicate isBuiltinModule(Module m) { m = TResolved(builtin()) }
+
+  cached
   Module getSuperClass(Module cls) {
     cls = TResolved("Object") and result = TResolved("BasicObject")
     or

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
@@ -1144,6 +1144,11 @@ class ModuleNode instanceof Module {
   bindingset[this]
   pragma[inline]
   API::Node trackInstance() { result = API::Internal::getModuleInstance(this) }
+
+  /**
+   * Holds if this is a built-in module, e.g. `Object`.
+   */
+  predicate isBuiltin() { super.isBuiltin() }
 }
 
 /**

--- a/ruby/ql/src/queries/modeling/internal/Types.qll
+++ b/ruby/ql/src/queries/modeling/internal/Types.qll
@@ -47,7 +47,6 @@ module Types {
     or
     // class Type2 < Type1
     // class Type2; include Type1
-    // class Type2; extend Type1
     exists(Module m1, Module m2 |
       m2.getAnImmediateAncestor() = m1 and not m2.isBuiltin() and not m1.isBuiltin()
     |

--- a/ruby/ql/src/queries/modeling/internal/Types.qll
+++ b/ruby/ql/src/queries/modeling/internal/Types.qll
@@ -6,6 +6,8 @@
 private import ruby
 private import codeql.ruby.ApiGraphs
 private import Util as Util
+private import codeql.ruby.ast.Module
+private import codeql.ruby.ast.internal.Module
 
 /**
  * Contains predicates for generating `typeModel`s that contain typing
@@ -41,6 +43,15 @@ module Types {
     exists(API::Node node |
       valueHasTypeName(node.getAValueReachingSink(), type1) and
       Util::pathToNode(node, type2, path, true)
+    )
+    or
+    // class Type2 < Type1
+    // class Type2; include Type1
+    // class Type2; extend Type1
+    exists(Module m1, Module m2 |
+      m2.getAnImmediateAncestor() = m1 and not m2.isBuiltin() and not m1.isBuiltin()
+    |
+      m1.getQualifiedName() = type1 and m2.getQualifiedName() = type2 and path = ""
     )
   }
 }

--- a/ruby/ql/src/utils/modeleditor/FrameworkModeEndpoints.ql
+++ b/ruby/ql/src/utils/modeleditor/FrameworkModeEndpoints.ql
@@ -7,9 +7,10 @@
  */
 
 import ruby
+import codeql.ruby.AST
 import ModelEditor
 
-from PublicEndpointFromSource endpoint
-select endpoint, endpoint.getNamespace(), endpoint.getTypeName(), endpoint.getName(),
-  endpoint.getParameterTypes(), endpoint.getSupportedStatus(), endpoint.getFile().getBaseName(),
+from Endpoint endpoint
+select endpoint, endpoint.getNamespace(), endpoint.getType(), endpoint.getName(),
+  endpoint.getParameters(), endpoint.getSupportedStatus(), endpoint.getFileName(),
   endpoint.getSupportedType()

--- a/ruby/ql/src/utils/modeleditor/ModelEditor.qll
+++ b/ruby/ql/src/utils/modeleditor/ModelEditor.qll
@@ -61,15 +61,15 @@ abstract class Endpoint instanceof DataFlow::Node {
 /**
  * A callable method or accessor from source code.
  */
-class MethodEndpoint extends Endpoint {
+class MethodEndpoint extends Endpoint instanceof DataFlow::MethodNode {
   MethodEndpoint() {
-    this.(DataFlow::MethodNode).isPublic() and
+    this.isPublic() and
     not isUninteresting(this)
   }
 
   DataFlow::MethodNode getNode() { result = this }
 
-  override string getName() { result = this.(DataFlow::MethodNode).getMethodName() }
+  override string getName() { result = super.getMethodName() }
 
   /**
    * Gets the unbound type name of this endpoint.
@@ -91,15 +91,10 @@ class MethodEndpoint extends Endpoint {
     result =
       "(" +
         concat(string key, string value |
-          value =
-            any(int i |
-              i.toString() = key
-            |
-              this.(DataFlow::MethodNode).asCallable().getParameter(i)
-            ).getName()
+          value = any(int i | i.toString() = key | super.asCallable().getParameter(i)).getName()
           or
           exists(DataFlow::ParameterNode param |
-            param = this.(DataFlow::MethodNode).asCallable().getKeywordParameter(key)
+            param = super.asCallable().getKeywordParameter(key)
           |
             value = key + ":"
           )

--- a/ruby/ql/src/utils/modeleditor/ModelEditor.qll
+++ b/ruby/ql/src/utils/modeleditor/ModelEditor.qll
@@ -48,6 +48,8 @@ abstract class Endpoint instanceof AstNode {
 
   string toString() { result = this.(AstNode).toString() }
 
+  Location getLocation() { result = this.(AstNode).getLocation() }
+
   abstract string getType();
 
   abstract string getName();

--- a/ruby/ql/src/utils/modeleditor/ModelEditor.qll
+++ b/ruby/ql/src/utils/modeleditor/ModelEditor.qll
@@ -9,6 +9,9 @@ private import codeql.ruby.frameworks.core.Gem
 private import codeql.ruby.frameworks.data.ModelsAsData
 private import codeql.ruby.frameworks.data.internal.ApiGraphModelsExtensions
 private import queries.modeling.internal.Util as Util
+private import codeql.util.Unit
+private import codeql.ruby.AST
+private import codeql.ruby.ast.Module
 
 /** Holds if the given callable is not worth supporting. */
 private predicate isUninteresting(DataFlow::MethodNode c) {
@@ -26,56 +29,78 @@ private predicate gemFileStep(Gem::GemSpec gem, Folder folder, int n) {
 }
 
 /**
- * A callable method or accessor from either the Ruby Standard Library, a 3rd party library, or from the source.
+ * Gets the namespace of an endpoint in `file`.
  */
-class Endpoint extends DataFlow::MethodNode {
-  Endpoint() { this.isPublic() and not isUninteresting(this) }
+string getNamespace(File file) {
+  exists(Folder folder | folder = file.getParentContainer() |
+    // The nearest gemspec to this endpoint, if one exists
+    result = min(Gem::GemSpec g, int n | gemFileStep(g, folder, n) | g order by n).getName()
+    or
+    not gemFileStep(_, folder, _) and
+    result = ""
+  )
+}
 
-  File getFile() { result = this.getLocation().getFile() }
+abstract class Endpoint instanceof AstNode {
+  string getNamespace() { result = getNamespace(this.(AstNode).getLocation().getFile()) }
 
-  string getName() { result = this.getMethodName() }
+  string getFileName() { result = this.(AstNode).getLocation().getFile().getBaseName() }
 
-  /**
-   * Gets the namespace of this endpoint.
-   */
-  bindingset[this]
-  string getNamespace() {
-    exists(Folder folder | folder = this.getFile().getParentContainer() |
-      // The nearest gemspec to this endpoint, if one exists
-      result = min(Gem::GemSpec g, int n | gemFileStep(g, folder, n) | g order by n).getName()
-      or
-      not gemFileStep(_, folder, _) and
-      result = ""
-    )
+  string toString() { result = this.(AstNode).toString() }
+
+  abstract string getType();
+
+  abstract string getName();
+
+  abstract string getParameters();
+
+  abstract boolean getSupportedStatus();
+
+  abstract string getSupportedType();
+}
+
+/**
+ * A callable method or accessor from source code.
+ */
+class MethodEndpoint extends Endpoint {
+  private DataFlow::MethodNode methodNode;
+
+  MethodEndpoint() {
+    this = methodNode.asExpr().getExpr() and
+    methodNode.isPublic() and
+    not isUninteresting(methodNode)
   }
+
+  DataFlow::MethodNode getNode() { result = methodNode }
+
+  override string getName() { result = methodNode.getMethodName() }
 
   /**
    * Gets the unbound type name of this endpoint.
    */
-  bindingset[this]
-  string getTypeName() {
+  override string getType() {
     result =
-      any(DataFlow::ModuleNode m | m.getOwnInstanceMethod(this.getMethodName()) = this)
+      any(DataFlow::ModuleNode m | m.getOwnInstanceMethod(this.getName()) = methodNode)
           .getQualifiedName() or
     result =
-      any(DataFlow::ModuleNode m | m.getOwnSingletonMethod(this.getMethodName()) = this)
+      any(DataFlow::ModuleNode m | m.getOwnSingletonMethod(this.getName()) = methodNode)
             .getQualifiedName() + "!"
   }
 
   /**
    * Gets the parameter types of this endpoint.
    */
-  bindingset[this]
-  string getParameterTypes() {
+  override string getParameters() {
     // For now, return the names of postional and keyword parameters. We don't always have type information, so we can't return type names.
     // We don't yet handle splat params or block params.
     result =
       "(" +
         concat(string key, string value |
-          value = any(int i | i.toString() = key | this.asCallable().getParameter(i)).getName()
+          value =
+            any(int i | i.toString() = key | methodNode.asCallable().getParameter(i)).getName()
           or
           exists(DataFlow::ParameterNode param |
-            param = this.asCallable().getKeywordParameter(key)
+            param = methodNode.asCallable().getKeywordParameter(key)
           |
             value = key + ":"
           )
@@ -90,11 +115,11 @@ class Endpoint extends DataFlow::MethodNode {
 
   /** Holds if this API is a known source. */
   pragma[nomagic]
-  abstract predicate isSource();
+  predicate isSource() { this.getNode() instanceof SourceCallable }
 
   /** Holds if this API is a known sink. */
   pragma[nomagic]
-  abstract predicate isSink();
+  predicate isSink() { this.getNode() instanceof SinkCallable }
 
   /** Holds if this API is a known neutral. */
   pragma[nomagic]
@@ -108,9 +133,11 @@ class Endpoint extends DataFlow::MethodNode {
     this.hasSummary() or this.isSource() or this.isSink() or this.isNeutral()
   }
 
-  boolean getSupportedStatus() { if this.isSupported() then result = true else result = false }
+  override boolean getSupportedStatus() {
+    if this.isSupported() then result = true else result = false
+  }
 
-  string getSupportedType() {
+  override string getSupportedType() {
     this.isSink() and result = "sink"
     or
     this.isSource() and result = "source"
@@ -132,7 +159,7 @@ string methodClassification(Call method) {
 
 class TestFile extends File {
   TestFile() {
-    this.getRelativePath().regexpMatch(".*(test|spec).+") and
+    this.getRelativePath().regexpMatch(".*(test|spec|examples).+") and
     not this.getAbsolutePath().matches("%/ql/test/%") // allows our test cases to work
   }
 }
@@ -164,10 +191,32 @@ class SourceCallable extends DataFlow::CallableNode {
 }
 
 /**
- * A class of effectively public callables from source code.
+ * A module defined in source code
  */
-class PublicEndpointFromSource extends Endpoint {
-  override predicate isSource() { this instanceof SourceCallable }
+class ModuleEndpoint extends Endpoint {
+  private DataFlow::ModuleNode moduleNode;
 
-  override predicate isSink() { this instanceof SinkCallable }
+  ModuleEndpoint() {
+    this =
+      min(AstNode n, Location loc |
+        n = moduleNode.getADeclaration() and
+        loc = n.getLocation()
+      |
+        n order by loc.getFile().getAbsolutePath(), loc.getStartLine(), loc.getStartColumn()
+      ) and
+    not moduleNode.(Module).isBuiltin() and
+    not moduleNode.getLocation().getFile() instanceof TestFile
+  }
+
+  DataFlow::ModuleNode getNode() { result = moduleNode }
+
+  override string getType() { result = this.getNode().getQualifiedName() }
+
+  override string getName() { result = "" }
+
+  override string getParameters() { result = "" }
+
+  override boolean getSupportedStatus() { result = false }
+
+  override string getSupportedType() { result = "" }
 }

--- a/ruby/ql/src/utils/modeleditor/ModelEditor.qll
+++ b/ruby/ql/src/utils/modeleditor/ModelEditor.qll
@@ -62,27 +62,23 @@ abstract class Endpoint instanceof DataFlow::Node {
  * A callable method or accessor from source code.
  */
 class MethodEndpoint extends Endpoint {
-  private DataFlow::MethodNode methodNode;
-
   MethodEndpoint() {
-    this = methodNode and
-    methodNode.isPublic() and
-    not isUninteresting(methodNode)
+    this.(DataFlow::MethodNode).isPublic() and
+    not isUninteresting(this)
   }
 
-  DataFlow::MethodNode getNode() { result = methodNode }
+  DataFlow::MethodNode getNode() { result = this }
 
-  override string getName() { result = methodNode.getMethodName() }
+  override string getName() { result = this.(DataFlow::MethodNode).getMethodName() }
 
   /**
    * Gets the unbound type name of this endpoint.
    */
   override string getType() {
     result =
-      any(DataFlow::ModuleNode m | m.getOwnInstanceMethod(this.getName()) = methodNode)
-          .getQualifiedName() or
+      any(DataFlow::ModuleNode m | m.getOwnInstanceMethod(this.getName()) = this).getQualifiedName() or
     result =
-      any(DataFlow::ModuleNode m | m.getOwnSingletonMethod(this.getName()) = methodNode)
+      any(DataFlow::ModuleNode m | m.getOwnSingletonMethod(this.getName()) = this)
             .getQualifiedName() + "!"
   }
 
@@ -90,16 +86,20 @@ class MethodEndpoint extends Endpoint {
    * Gets the parameter types of this endpoint.
    */
   override string getParameters() {
-    // For now, return the names of postional and keyword parameters. We don't always have type information, so we can't return type names.
+    // For now, return the names of positional and keyword parameters. We don't always have type information, so we can't return type names.
     // We don't yet handle splat params or block params.
     result =
       "(" +
         concat(string key, string value |
           value =
-            any(int i | i.toString() = key | methodNode.asCallable().getParameter(i)).getName()
+            any(int i |
+              i.toString() = key
+            |
+              this.(DataFlow::MethodNode).asCallable().getParameter(i)
+            ).getName()
           or
           exists(DataFlow::ParameterNode param |
-            param = methodNode.asCallable().getKeywordParameter(key)
+            param = this.(DataFlow::MethodNode).asCallable().getKeywordParameter(key)
           |
             value = key + ":"
           )

--- a/ruby/ql/src/utils/modeleditor/ModelEditor.qll
+++ b/ruby/ql/src/utils/modeleditor/ModelEditor.qll
@@ -9,9 +9,6 @@ private import codeql.ruby.frameworks.core.Gem
 private import codeql.ruby.frameworks.data.ModelsAsData
 private import codeql.ruby.frameworks.data.internal.ApiGraphModelsExtensions
 private import queries.modeling.internal.Util as Util
-private import codeql.util.Unit
-private import codeql.ruby.AST
-private import codeql.ruby.ast.Module
 
 /** Holds if the given callable is not worth supporting. */
 private predicate isUninteresting(DataFlow::MethodNode c) {

--- a/ruby/ql/src/utils/modeleditor/ModelEditor.qll
+++ b/ruby/ql/src/utils/modeleditor/ModelEditor.qll
@@ -38,14 +38,14 @@ string getNamespace(File file) {
   )
 }
 
-abstract class Endpoint instanceof AstNode {
-  string getNamespace() { result = getNamespace(this.(AstNode).getLocation().getFile()) }
+abstract class Endpoint instanceof DataFlow::Node {
+  string getNamespace() { result = getNamespace(super.getLocation().getFile()) }
 
-  string getFileName() { result = this.(AstNode).getLocation().getFile().getBaseName() }
+  string getFileName() { result = super.getLocation().getFile().getBaseName() }
 
-  string toString() { result = this.(AstNode).toString() }
+  string toString() { result = super.toString() }
 
-  Location getLocation() { result = this.(AstNode).getLocation() }
+  Location getLocation() { result = super.getLocation() }
 
   abstract string getType();
 
@@ -65,7 +65,7 @@ class MethodEndpoint extends Endpoint {
   private DataFlow::MethodNode methodNode;
 
   MethodEndpoint() {
-    this = methodNode.asExpr().getExpr() and
+    this = methodNode and
     methodNode.isPublic() and
     not isUninteresting(methodNode)
   }
@@ -197,8 +197,8 @@ class ModuleEndpoint extends Endpoint {
 
   ModuleEndpoint() {
     this =
-      min(AstNode n, Location loc |
-        n = moduleNode.getADeclaration() and
+      min(DataFlow::Node n, Location loc |
+        n.asExpr().getExpr() = moduleNode.getADeclaration() and
         loc = n.getLocation()
       |
         n order by loc.getFile().getAbsolutePath(), loc.getStartLine(), loc.getStartColumn()

--- a/ruby/ql/test/query-tests/utils/modeleditor/FrameworkModeEndpoints.expected
+++ b/ruby/ql/test/query-tests/utils/modeleditor/FrameworkModeEndpoints.expected
@@ -1,8 +1,15 @@
+| lib/module.rb:1:1:7:3 | M1 | mylib | M1 |  |  | false | module.rb |  |
 | lib/module.rb:2:3:3:5 | foo | mylib | M1 | foo | (x,y) | false | module.rb |  |
 | lib/module.rb:5:3:6:5 | self_foo | mylib | M1! | self_foo | (x,y) | false | module.rb |  |
+| lib/mylib.rb:3:1:27:3 | A | mylib | A |  |  | false | mylib.rb |  |
 | lib/mylib.rb:4:3:5:5 | foo | mylib | A | foo | (x,y,key1:) | false | mylib.rb |  |
 | lib/mylib.rb:7:3:8:5 | bar | mylib | A | bar | (x) | false | mylib.rb |  |
 | lib/mylib.rb:10:3:11:5 | self_foo | mylib | A! | self_foo | (x,y) | false | mylib.rb |  |
+| lib/mylib.rb:18:3:26:5 | ANested | mylib | A::ANested |  |  | false | mylib.rb |  |
 | lib/mylib.rb:19:5:20:7 | foo | mylib | A::ANested | foo | (x,y) | false | mylib.rb |  |
+| lib/other.rb:3:1:8:3 | B | mylib | B |  |  | false | other.rb |  |
 | lib/other.rb:6:3:7:5 | foo | mylib | B | foo | (x,y) | false | other.rb |  |
+| lib/other.rb:10:1:12:3 | C | mylib | C |  |  | false | other.rb |  |
+| other_lib/lib/other_gem.rb:1:1:6:3 | OtherLib | other-lib | OtherLib |  |  | false | other_gem.rb |  |
+| other_lib/lib/other_gem.rb:2:5:5:7 | A | other-lib | OtherLib::A |  |  | false | other_gem.rb |  |
 | other_lib/lib/other_gem.rb:3:9:4:11 | foo | other-lib | OtherLib::A | foo | (x,y) | false | other_gem.rb |  |

--- a/ruby/ql/test/query-tests/utils/modeleditor/GenerateModel.expected
+++ b/ruby/ql/test/query-tests/utils/modeleditor/GenerateModel.expected
@@ -1,0 +1,6 @@
+sourceModel
+sinkModel
+typeVariableModel
+typeModel
+| M1 | B |  |
+summaryModel

--- a/ruby/ql/test/query-tests/utils/modeleditor/GenerateModel.qlref
+++ b/ruby/ql/test/query-tests/utils/modeleditor/GenerateModel.qlref
@@ -1,0 +1,1 @@
+queries/modeling/GenerateModel.ql


### PR DESCRIPTION
This PR does a few things:

- Excludes endpoints whose path has `examples` in it. This removes a lot of example code that otherwise gets picked up when modeling libraries.
- Changes the `FrameworkModeEndpoints` query to produce not only methods, but also classes. These are not technically endpoints, but it allows the model editor to learn about them and thus handle the new results from `GenerateModel` (see below). This involves some refactoring of the `Endpoint` class, because we want to include both `DataFlow::MethodNode`s and `DataFlow::ModuleNode`s, which don't have a common ancestor.
- Updates the `GenerateModel` query to produce `typeModel` rows for subclass relationships. For example:

```rb
class A
  def foo(x)
    # ...
  end
end

class B < A
end
```

If we mark `A#foo` as a sink, we also want to recognise calls to `B#foo` as a sink as well. Instead of duplicating the models for every subclass, we instead emit a type row:
```
A,B,
```
which states that `B` can be considered to have type `A`. This means any models that target `A` will target `B` as well.

The same applies for `include`:
```rb
module C
  def bar(x)
    # ...
  end
end

class D
  include C
end
```

but not for `extend`, because its behaviour is a bit odd (instance methods on the included module become _class_ methods on the including class). I haven't worked out how to deal with them yet.