### PR TITLE
Go: Also follow jump steps when looking for a callee source

### DIFF
--- a/go/ql/lib/change-notes/2023-12-08-find-more-callees-for-captured-functions.md
+++ b/go/ql/lib/change-notes/2023-12-08-find-more-callees-for-captured-functions.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* When a function literal refers to a variable which has function type, there was a bug that meant that we were not able to find any possible callees for calls to that variable. This has now been fixed.

--- a/go/ql/lib/change-notes/2023-12-08-find-more-callees-for-captured-functions.md
+++ b/go/ql/lib/change-notes/2023-12-08-find-more-callees-for-captured-functions.md
@@ -1,4 +1,4 @@
 ---
-category: fix
+category: minorAnalysis
 ---
-* When a function literal refers to a variable which has function type, there was a bug that meant that we were not able to find any possible callees for calls to that variable. This has now been fixed.
+* `CallNode::getACallee` and related predicates now recognise more callees accessed via a function variable, in particular when the callee is stored into a global variable or is captured by an anonymous function. This may lead to new alerts where data-flow into such a callee is relevant.

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowNodes.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowNodes.qll
@@ -473,6 +473,7 @@ module Public {
   private DataFlow::Node getACalleeSource(DataFlow::CallNode cn) {
     result = cn.getCalleeNode() or
     basicLocalFlowStep(result, getACalleeSource(cn)) or
+    jumpStep(result, getACalleeSource(cn)) or
     result.asExpr() = getACalleeSource(cn).asExpr().(GenericFunctionInstantiationExpr).getBase()
   }
 

--- a/go/ql/test/library-tests/semmle/go/frameworks/Twirp/RequestForgery.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Twirp/RequestForgery.expected
@@ -3,11 +3,21 @@ edges
 | client/main.go:16:35:16:78 | &... | server/main.go:19:56:19:61 | definition of params |
 | rpc/notes/service.twirp.go:473:6:473:13 | definition of typedReq | rpc/notes/service.twirp.go:477:44:477:51 | typedReq |
 | rpc/notes/service.twirp.go:477:44:477:51 | typedReq | server/main.go:19:56:19:61 | definition of params |
+| rpc/notes/service.twirp.go:493:2:493:2 | capture variable reqContent | rpc/notes/service.twirp.go:495:35:495:44 | reqContent |
+| rpc/notes/service.twirp.go:495:35:495:44 | reqContent | server/main.go:19:56:19:61 | definition of params |
+| rpc/notes/service.twirp.go:538:2:538:33 | ... := ...[0] | rpc/notes/service.twirp.go:544:27:544:29 | buf |
+| rpc/notes/service.twirp.go:538:25:538:32 | selection of Body | rpc/notes/service.twirp.go:538:2:538:33 | ... := ...[0] |
+| rpc/notes/service.twirp.go:543:2:543:11 | definition of reqContent | rpc/notes/service.twirp.go:574:2:574:2 | capture variable reqContent |
+| rpc/notes/service.twirp.go:544:27:544:29 | buf | rpc/notes/service.twirp.go:543:2:543:11 | definition of reqContent |
 | rpc/notes/service.twirp.go:554:6:554:13 | definition of typedReq | rpc/notes/service.twirp.go:558:44:558:51 | typedReq |
 | rpc/notes/service.twirp.go:558:44:558:51 | typedReq | server/main.go:19:56:19:61 | definition of params |
+| rpc/notes/service.twirp.go:574:2:574:2 | capture variable reqContent | rpc/notes/service.twirp.go:576:35:576:44 | reqContent |
+| rpc/notes/service.twirp.go:576:35:576:44 | reqContent | server/main.go:19:56:19:61 | definition of params |
 | server/main.go:19:56:19:61 | definition of params | client/main.go:16:35:16:78 | &... |
 | server/main.go:19:56:19:61 | definition of params | rpc/notes/service.twirp.go:473:6:473:13 | definition of typedReq |
+| server/main.go:19:56:19:61 | definition of params | rpc/notes/service.twirp.go:493:2:493:2 | capture variable reqContent |
 | server/main.go:19:56:19:61 | definition of params | rpc/notes/service.twirp.go:554:6:554:13 | definition of typedReq |
+| server/main.go:19:56:19:61 | definition of params | rpc/notes/service.twirp.go:574:2:574:2 | capture variable reqContent |
 | server/main.go:19:56:19:61 | definition of params | server/main.go:19:56:19:61 | definition of params |
 | server/main.go:19:56:19:61 | definition of params | server/main.go:19:56:19:61 | definition of params |
 | server/main.go:19:56:19:61 | definition of params | server/main.go:30:38:30:48 | selection of Text |
@@ -16,11 +26,20 @@ nodes
 | client/main.go:16:35:16:78 | &... | semmle.label | &... |
 | rpc/notes/service.twirp.go:473:6:473:13 | definition of typedReq | semmle.label | definition of typedReq |
 | rpc/notes/service.twirp.go:477:44:477:51 | typedReq | semmle.label | typedReq |
+| rpc/notes/service.twirp.go:493:2:493:2 | capture variable reqContent | semmle.label | capture variable reqContent |
+| rpc/notes/service.twirp.go:495:35:495:44 | reqContent | semmle.label | reqContent |
+| rpc/notes/service.twirp.go:538:2:538:33 | ... := ...[0] | semmle.label | ... := ...[0] |
+| rpc/notes/service.twirp.go:538:25:538:32 | selection of Body | semmle.label | selection of Body |
+| rpc/notes/service.twirp.go:543:2:543:11 | definition of reqContent | semmle.label | definition of reqContent |
+| rpc/notes/service.twirp.go:544:27:544:29 | buf | semmle.label | buf |
 | rpc/notes/service.twirp.go:554:6:554:13 | definition of typedReq | semmle.label | definition of typedReq |
 | rpc/notes/service.twirp.go:558:44:558:51 | typedReq | semmle.label | typedReq |
+| rpc/notes/service.twirp.go:574:2:574:2 | capture variable reqContent | semmle.label | capture variable reqContent |
+| rpc/notes/service.twirp.go:576:35:576:44 | reqContent | semmle.label | reqContent |
 | server/main.go:19:56:19:61 | definition of params | semmle.label | definition of params |
 | server/main.go:19:56:19:61 | definition of params | semmle.label | definition of params |
 | server/main.go:30:38:30:48 | selection of Text | semmle.label | selection of Text |
 subpaths
 #select
+| server/main.go:30:38:30:48 | selection of Text | rpc/notes/service.twirp.go:538:25:538:32 | selection of Body | server/main.go:30:38:30:48 | selection of Text | The $@ of this request depends on a $@. | server/main.go:30:38:30:48 | selection of Text | URL | rpc/notes/service.twirp.go:538:25:538:32 | selection of Body | user-provided value |
 | server/main.go:30:38:30:48 | selection of Text | server/main.go:19:56:19:61 | definition of params | server/main.go:30:38:30:48 | selection of Text | The $@ of this request depends on a $@. | server/main.go:30:38:30:48 | selection of Text | URL | server/main.go:19:56:19:61 | definition of params | user-provided value |


### PR DESCRIPTION
This is needed because capturing a variable is a jump step and we want to find a callee source for captured functions.