### PR TITLE
Adds call to reusable ready-for-doc-review workflow 

### DIFF
--- a/.github/workflows/ready-for-doc-review.yml
+++ b/.github/workflows/ready-for-doc-review.yml
@@ -1,0 +1,11 @@
+name: Ready for docs-content review
+
+on:
+  pull_request_target:
+    types: [labeled, review_requested]
+
+jobs:
+  call-workflow-ready-for-doc-review:
+    if: github.event.label.name == 'ready-for-doc-review' || github.event.requested_team.name == 'docs-content'
+    uses: github/docs-internal/.github/workflows/ready-for-doc-review.yml@main
+    secrets: inherit


### PR DESCRIPTION
We have a workflow that automatically adds relevant fields from given PRs for our review board.

That workflow is now [reusable](https://docs.github.com/en/actions/using-workflows/reusing-workflows). We've tested it, and it works successfully. This PR simply adds the same workflow to this repo. Since the label already exists, no further steps should be required. It's possible a secret will be needed in this repo for the `actions` step, but I'm confident it should just inherit it successfully for the whole workflow.

I could test this using this branch, but given that the exact same implementation works successfully elsewhere, I didn't think this was necessary. The only potential pitfall is the need for the aforementioned secret, but that will be obvious in any workflow failures and can be easily rectified without the need for another PR.

The risk of adding this should be nil, because the existing procedure that users add to PRs in this repo when they want a doc review is to add the `ready-for-doc-review` label already. This then triggers an automation to our docs first responder, who then triage it and make sure the relevant team sees it. This PR does not affect that automation. Instead, this should just make it easier for us to review PRs.