### PR TITLE
JS: Various TypeScript extraction fixes.

### DIFF
--- a/javascript/extractor/lib/typescript/src/ast_extractor.ts
+++ b/javascript/extractor/lib/typescript/src/ast_extractor.ts
@@ -192,7 +192,7 @@ export function augmentAst(ast: AugmentedSourceFile, code: string, project: Proj
         }
 
         if (typeChecker != null) {
-            if (isTypedNode(node)) {
+            if (isTypedNode(node) && !typeTable.skipExtractingTypes) {
                 let contextualType = isContextuallyTypedNode(node)
                     ? typeChecker.getContextualType(node)
                     : null;

--- a/javascript/extractor/lib/typescript/src/main.ts
+++ b/javascript/extractor/lib/typescript/src/main.ts
@@ -886,6 +886,7 @@ if (process.argv.length > 2) {
     if (argument === "--version") {
         console.log("parser-wrapper with TypeScript " + ts.version);
     } else if (pathlib.basename(argument) === "tsconfig.json") {
+        reset();
         handleOpenProjectCommand({
             command: "open-project",
             tsConfig: argument,

--- a/javascript/extractor/lib/typescript/src/main.ts
+++ b/javascript/extractor/lib/typescript/src/main.ts
@@ -808,7 +808,7 @@ function handleGetMetadataCommand(command: GetMetadataCommand) {
 function reset() {
     state = new State();
     state.typeTable.restrictedExpansion = getEnvironmentVariable("SEMMLE_TYPESCRIPT_NO_EXPANSION", Boolean, true);
-    state.typeTable.skipExtractingTypes = getEnvironmentVariable("SEMMLE_TYPESCRIPT_SKIP_EXTRACTING_TYPES", Boolean, false);
+    state.typeTable.skipExtractingTypes = getEnvironmentVariable("CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_SKIP_TYPES", Boolean, false);
 }
 
 function getEnvironmentVariable<T>(name: string, parse: (x: string) => T, defaultValue: T) {

--- a/javascript/extractor/lib/typescript/src/main.ts
+++ b/javascript/extractor/lib/typescript/src/main.ts
@@ -808,6 +808,7 @@ function handleGetMetadataCommand(command: GetMetadataCommand) {
 function reset() {
     state = new State();
     state.typeTable.restrictedExpansion = getEnvironmentVariable("SEMMLE_TYPESCRIPT_NO_EXPANSION", Boolean, true);
+    state.typeTable.skipExtractingTypes = getEnvironmentVariable("SEMMLE_TYPESCRIPT_SKIP_EXTRACTING_TYPES", Boolean, false);
 }
 
 function getEnvironmentVariable<T>(name: string, parse: (x: string) => T, defaultValue: T) {

--- a/javascript/extractor/lib/typescript/src/main.ts
+++ b/javascript/extractor/lib/typescript/src/main.ts
@@ -895,7 +895,7 @@ if (process.argv.length > 2) {
             virtualSourceRoot: null,
         });
         for (let sf of state.project.program.getSourceFiles()) {
-            if (pathlib.basename(sf.fileName) === "lib.d.ts") continue;
+            if (/lib\..*\.d\.ts/.test(pathlib.basename(sf.fileName)) || pathlib.basename(sf.fileName) === "lib.d.ts") continue;
             handleParseCommand({
                 command: "parse",
                 filename: sf.fileName,

--- a/javascript/extractor/lib/typescript/src/type_table.ts
+++ b/javascript/extractor/lib/typescript/src/type_table.ts
@@ -383,6 +383,11 @@ export class TypeTable {
    */
   public restrictedExpansion = false;
 
+  /**
+   * If set to true, skip extracting types.
+   */
+  public skipExtractingTypes = false;
+
   private virtualSourceRoot: VirtualSourceRoot;
 
   /**

--- a/javascript/extractor/lib/typescript/src/type_table.ts
+++ b/javascript/extractor/lib/typescript/src/type_table.ts
@@ -1241,7 +1241,7 @@ export class TypeTable {
       stack.push(id);
 
       for (let symbol of type.getProperties()) {
-        let propertyType = this.tryGetTypeOfSymbol(symbol);
+        let propertyType = typeTable.tryGetTypeOfSymbol(symbol);
         if (propertyType == null) continue;
         traverseType(propertyType);
       }

--- a/javascript/extractor/lib/typescript/src/type_table.ts
+++ b/javascript/extractor/lib/typescript/src/type_table.ts
@@ -1240,6 +1240,13 @@ export class TypeTable {
       let indexOnStack = stack.length;
       stack.push(id);
 
+      /** Indicates if a type contains no type variables, is a type variable, or strictly contains type variables. */
+      const enum TypeVarDepth {
+        noTypeVar = 0,
+        isTypeVar = 1,
+        containsTypeVar = 2,
+      }
+
       for (let symbol of type.getProperties()) {
         let propertyType = typeTable.tryGetTypeOfSymbol(symbol);
         if (propertyType == null) continue;
@@ -1266,13 +1273,6 @@ export class TypeTable {
       }
 
       return lowlinkTable.get(id);
-
-      /** Indicates if a type contains no type variables, is a type variable, or strictly contains type variables. */
-      const enum TypeVarDepth {
-        noTypeVar = 0,
-        isTypeVar = 1,
-        containsTypeVar = 2,
-      }
 
       function traverseType(type: ts.Type): TypeVarDepth {
         if (isTypeVariable(type)) return TypeVarDepth.isTypeVar;


### PR DESCRIPTION
And add a new `SEMMLE_TYPESCRIPT_SKIP_EXTRACTING_TYPES` environment variable to skip extraction of all types.  
This is a workaround for an internal report about long extraction times.  

I'm not sure why those fixes weren't needed previously, and I couldn't replicate them when running tests. 
They're clearly basic TypeScript errors, so I'm not sure what's going on.  
I think it's something for @asgerf to look at when he's back?

I tried the new flag locally on `microsoft/vscode`. 
The extraction got faster, and we only lost a single alert on that project.
And extraction is way faster with the flag on a minimal example from the internal report.

Evaluation were very uneventful ([nightly-old.yml](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/pr-15072-896432__nightly-old__code-scanning__1/reports), [typescript-full.yml](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/pr-15072-896432__typescript-full__code-scanning/reports))