### PR TITLE
C++: Add a `PropertyProvider` for only showing dataflow-relevant IR

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/PrintDataFlowRelevantIR.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/PrintDataFlowRelevantIR.qll
@@ -1,0 +1,12 @@
+private import cpp
+private import semmle.code.cpp.ir.IR
+private import SsaInternals as Ssa
+
+/**
+ * Property provider that hides all instructions and operands that are not relevant for IR dataflow.
+ */
+class DataFlowRelevantIRPropertyProvider extends IRPropertyProvider {
+  override predicate shouldPrintOperand(Operand operand) { not Ssa::ignoreOperand(operand) }
+
+  override predicate shouldPrintInstruction(Instruction instr) { not Ssa::ignoreInstruction(instr) }
+}

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/PrintDataFlowRelevantIR.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/PrintDataFlowRelevantIR.qll
@@ -3,7 +3,7 @@ private import semmle.code.cpp.ir.IR
 private import SsaInternals as Ssa
 
 /**
- * Property provider that hides all instructions and operands that are not relevant for IR dataflow.
+ * A property provider that hides all instructions and operands that are not relevant for IR dataflow.
  */
 class DataFlowRelevantIRPropertyProvider extends IRPropertyProvider {
   override predicate shouldPrintOperand(Operand operand) { not Ssa::ignoreOperand(operand) }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/PrintIRLocalFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/PrintIRLocalFlow.qll
@@ -59,8 +59,4 @@ class LocalFlowPropertyProvider extends IRPropertyProvider {
       result = getNodeProperty(node, key)
     )
   }
-
-  override predicate shouldPrintOperand(Operand operand) { not Ssa::ignoreOperand(operand) }
-
-  override predicate shouldPrintInstruction(Instruction instr) { not Ssa::ignoreInstruction(instr) }
 }


### PR DESCRIPTION
Previously, when I was debugging IR dataflow issues I'd import `PrintIRLocalFlow.qll` to reduce the amount of IR printed, and then comment out the `getOperandProperty` and `getInstructionProperty` overrides (because they're simply too noisy and not very helpful).

This PR separates the property provider that hides IR from the property provider that prints local flow. That means you can hide the irrelevant IR without needing to comment out anything.

This is strictly for debugging purposes, and thus I don't believe this needs to be run on DCA.