### PR TITLE
C#: Telemetry should only count calls in source.

### DIFF
--- a/csharp/ql/src/Telemetry/ExternalApi.qll
+++ b/csharp/ql/src/Telemetry/ExternalApi.qll
@@ -134,7 +134,8 @@ module Results<relevantApi/1 getRelevantUsages> {
       strictcount(Call c, ExternalApi api |
         c.getTarget().getUnboundDeclaration() = api and
         apiName = api.getApiName() and
-        getRelevantUsages(api)
+        getRelevantUsages(api) and
+        c.fromSource()
       )
   }
 

--- a/csharp/ql/src/Telemetry/ExternalLibraryUsage.ql
+++ b/csharp/ql/src/Telemetry/ExternalLibraryUsage.ql
@@ -14,7 +14,8 @@ private predicate getRelevantUsages(string namespace, int usages) {
   usages =
     strictcount(Call c, ExternalApi api |
       c.getTarget().getUnboundDeclaration() = api and
-      api.getNamespace() = namespace
+      api.getNamespace() = namespace and
+      c.fromSource()
     )
 }
 

--- a/csharp/ql/test/query-tests/Telemetry/LibraryUsage/options
+++ b/csharp/ql/test/query-tests/Telemetry/LibraryUsage/options
@@ -1,3 +1,2 @@
 semmle-extractor-options: /nostdlib /noconfig
 semmle-extractor-options: --load-sources-from-project:${testdir}/../../../resources/stubs/_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj
-semmle-extractor-options: ${testdir}/../../../resources/stubs/System.Web.cs

--- a/csharp/ql/test/query-tests/Telemetry/SupportedExternalSinks/options
+++ b/csharp/ql/test/query-tests/Telemetry/SupportedExternalSinks/options
@@ -1,2 +1,3 @@
-semmle-extractor-options: /r:System.Collections.Specialized.dll
+semmle-extractor-options: /nostdlib /noconfig
+semmle-extractor-options: --load-sources-from-project:${testdir}/../../../resources/stubs/_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj
 semmle-extractor-options: ${testdir}/../../../resources/stubs/System.Web.cs

--- a/csharp/ql/test/query-tests/Telemetry/SupportedExternalSources/options
+++ b/csharp/ql/test/query-tests/Telemetry/SupportedExternalSources/options
@@ -1,3 +1,2 @@
 semmle-extractor-options: /nostdlib /noconfig
 semmle-extractor-options: --load-sources-from-project:${testdir}/../../../resources/stubs/_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj
-semmle-extractor-options: ${testdir}/../../../resources/stubs/System.Web.cs


### PR DESCRIPTION
In this PR we change the telemetry queries slightly (which should have no impact in production) and make it explicit that we are only interested in calls performed in source code. This is important for testing purposes as we would like to use our stubs (which contains base constructor calls) to avoid cluttering the output.

This PR is a preparation for the .NET 8 stub update.