### PR TITLE
C#: Stub generator support for `ref readonly` parameters.

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.StubGenerator/StubVisitor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.StubGenerator/StubVisitor.cs
@@ -534,6 +534,9 @@ internal sealed class StubVisitor : SymbolVisitor
                 case RefKind.In:
                     stubWriter.Write("in ");
                     break;
+                case RefKind.RefReadOnlyParameter:
+                    stubWriter.Write("ref readonly ");
+                    break;
                 default:
                     stubWriter.Write($"/* TODO: {parameter.RefKind} */");
                     break;

--- a/csharp/extractor/Semmle.Extraction.Tests/StubGenerator.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/StubGenerator.cs
@@ -42,7 +42,7 @@ public const string MyField2 = default;
         // Setup
         const string source = @"
 public class MyTest {
-    public int M1(string arg1) { return 0;}
+    public int M1(string arg1) { return 0; }
 }";
 
         // Execute
@@ -51,6 +51,26 @@ public class MyTest {
         // Verify
         const string expected = @"public class MyTest {
 public int M1(string arg1) => throw null;
+}
+";
+        Assert.Equal(expected, stub);
+    }
+
+    [Fact]
+    public void StubGeneratorRefReadonlyParameterTest()
+    {
+        // Setup
+        const string source = @"
+public class MyTest {
+    public int M1(ref readonly Guid guid) { return 0; }
+}";
+
+        // Execute
+        var stub = GenerateStub(source);
+
+        // Verify
+        const string expected = @"public class MyTest {
+public int M1(ref readonly Guid guid) => throw null;
 }
 ";
         Assert.Equal(expected, stub);


### PR DESCRIPTION
This is a pre-requisite for updating the stubs as the `ref readonly` parameter feature from C# 12 is already used in the .NET 8 Core framework.