### PR TITLE
C++: Easier debugging of dataflow node `toString` output

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -6,7 +6,7 @@ private import semmle.code.cpp.ir.internal.IRCppLanguage
 private import SsaInternals as Ssa
 private import DataFlowImplCommon as DataFlowImplCommon
 private import codeql.util.Unit
-import Node0ToString
+private import Node0ToString
 
 cached
 private module Cached {

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -6,6 +6,7 @@ private import semmle.code.cpp.ir.internal.IRCppLanguage
 private import SsaInternals as Ssa
 private import DataFlowImplCommon as DataFlowImplCommon
 private import codeql.util.Unit
+import Node0ToString
 
 cached
 private module Cached {
@@ -138,11 +139,7 @@ abstract class InstructionNode0 extends Node0Impl {
 
   override DataFlowType getType() { result = getInstructionType(instr, _) }
 
-  override string toStringImpl() {
-    if instr.(InitializeParameterInstruction).getIRVariable() instanceof IRThisVariable
-    then result = "this"
-    else result = instr.getAst().toString()
-  }
+  override string toStringImpl() { result = instructionToString(instr) }
 
   override Location getLocationImpl() {
     if exists(instr.getAst().getLocation())
@@ -187,11 +184,7 @@ abstract class OperandNode0 extends Node0Impl {
 
   override DataFlowType getType() { result = getOperandType(op, _) }
 
-  override string toStringImpl() {
-    if op.getDef().(InitializeParameterInstruction).getIRVariable() instanceof IRThisVariable
-    then result = "this"
-    else result = op.getDef().getAst().toString()
-  }
+  override string toStringImpl() { result = operandToString(op) }
 
   override Location getLocationImpl() {
     if exists(op.getDef().getAst().getLocation())

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -15,6 +15,7 @@ private import ModelUtil
 private import SsaInternals as Ssa
 private import DataFlowImplCommon as DataFlowImplCommon
 private import codeql.util.Unit
+private import Node0ToString
 
 /**
  * The IR dataflow graph consists of the following nodes:

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -487,7 +487,7 @@ class Node extends TIRDataFlowNode {
 }
 
 private string toExprString(Node n) {
-  isDebugMode() and
+  not isDebugMode() and
   (
     result = n.asExpr(0).toString()
     or

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -486,10 +486,13 @@ class Node extends TIRDataFlowNode {
 }
 
 private string toExprString(Node n) {
-  result = n.asExpr(0).toString()
-  or
-  not exists(n.asExpr()) and
-  result = n.asIndirectExpr(0, 1).toString() + " indirection"
+  isDebugMode() and
+  (
+    result = n.asExpr(0).toString()
+    or
+    not exists(n.asExpr()) and
+    result = n.asIndirectExpr(0, 1).toString() + " indirection"
+  )
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DebugPrinting.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DebugPrinting.qll
@@ -1,0 +1,9 @@
+/**
+ * This file activates debugging mode for dataflow node printing.
+ */
+
+private import Node0ToString
+
+private class DebugNode0ToString extends Node0ToString {
+  final override predicate isDebugMode() { any() }
+}

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/Node0ToString.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/Node0ToString.qll
@@ -1,0 +1,75 @@
+/**
+ * This file contains the abstract class that serves as the base class for
+ * dataflow node printing.
+ *
+ * By default, a non-debug string is produced. However, a debug-friendly
+ * string can be produced by importing `DebugPrinting.qll`.
+ */
+
+private import semmle.code.cpp.ir.IR
+private import codeql.util.Unit
+
+/**
+ * A class to control whether a debugging version of instructions and operands
+ * should be printed as part of the `toString` output of dataflow nodes.
+ *
+ * To enable debug printing import the `DebugPrinting.ql` file. By default,
+ * non-debug output will be used.
+ */
+class Node0ToString extends Unit {
+  abstract predicate isDebugMode();
+
+  private string normalInstructionToString(Instruction i) {
+    not this.isDebugMode() and
+    if i.(InitializeParameterInstruction).getIRVariable() instanceof IRThisVariable
+    then result = "this"
+    else result = i.getAst().toString()
+  }
+
+  private string normalOperandToString(Operand op) {
+    not this.isDebugMode() and
+    if op.getDef().(InitializeParameterInstruction).getIRVariable() instanceof IRThisVariable
+    then result = "this"
+    else result = op.getDef().getAst().toString()
+  }
+
+  /**
+   * Gets the string that should be used by `InstructionNode.toString`
+   */
+  string instructionToString(Instruction i) {
+    if this.isDebugMode()
+    then result = i.getDumpString()
+    else result = this.normalInstructionToString(i)
+  }
+
+  /**
+   * Gets the string that should be used by `OperandNode.toString`.
+   */
+  string operandToString(Operand op) {
+    if this.isDebugMode()
+    then result = op.getDumpString() + " @ " + op.getUse().getResultId()
+    else result = this.normalOperandToString(op)
+  }
+}
+
+private class NoDebugNode0ToString extends Node0ToString {
+  final override predicate isDebugMode() { none() }
+}
+
+/**
+ * Gets the string that should be used by `OperandNode.toString`.
+ */
+string operandToString(Operand op) { result = any(Node0ToString nts).operandToString(op) }
+
+/**
+ * Gets the string that should be used by `InstructionNode.toString`
+ */
+string instructionToString(Instruction i) { result = any(Node0ToString nts).instructionToString(i) }
+
+/**
+ * Holds if debugging mode is enabled.
+ *
+ * In debug mode the `toString` on dataflow nodes is more expensive to compute,
+ * but gives more precise information about the different dataflow nodes.
+ */
+predicate isDebugMode() { not any(Node0ToString nts).isDebugMode() }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/Node0ToString.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/Node0ToString.qll
@@ -72,4 +72,4 @@ string instructionToString(Instruction i) { result = any(Node0ToString nts).inst
  * In debug mode the `toString` on dataflow nodes is more expensive to compute,
  * but gives more precise information about the different dataflow nodes.
  */
-predicate isDebugMode() { not any(Node0ToString nts).isDebugMode() }
+predicate isDebugMode() { any(Node0ToString nts).isDebugMode() }


### PR DESCRIPTION
One of the first things I do when I debug dataflow node-related things is to modify the `toString` of `InstructionNode`s and `OperandNode`s. This PR simplifies that process by creating an abstract class to control whether the debug version (or the efficient) version should be used.

Then, to enable debug printing, one can simply import `DebugPrinting.qll` to modify the output.

By default `toString` already present on `main` will be used. So nothing should change from the user point-of-view. I've checked that the `toString` still compiles to the efficient RA when debugging isn't enabled:
```ql
Evaluated relational algebra for predicate DataFlowPrivate::Node0Impl.toStringImpl/0#dispred#9d03b963@295a56td with tuple counts:
    5160283   ~0%    {2} r1 = JOIN DataFlowPrivate::OperandNode0#class#93408876_10#join_rhs WITH `Node0ToString::Node0ToString.normalOperandToString/1#dispred#e901e619#cpe#23` ON FIRST 1 OUTPUT Lhs.1, Rhs.1
                
    5699527   ~0%    {2} r2 = JOIN DataFlowPrivate::InstructionNode0#class#f561e555_10#join_rhs WITH `Node0ToString::Node0ToString.normalInstructionToString/1#dispred#2fbb829d#cpe#23` ON FIRST 1 OUTPUT Lhs.1, Rhs.1
                
  10859810  ~71%    {2} r3 = r1 UNION r2
                    return r3
```