### PR TITLE
C#: Fix names of generic types/methods in model editor queries

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/ExternalFlow.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/ExternalFlow.qll
@@ -269,7 +269,7 @@ private predicate elementSpec(
   UnboundValueOrRefType t
 ) {
   elementSpec(namespace, type, subtypes, name, signature, ext) and
-  QN::hasQualifiedName(t, namespace, type)
+  hasQualifiedTypeName(t, namespace, type)
 }
 
 private class UnboundValueOrRefType extends ValueOrRefType {
@@ -337,7 +337,7 @@ Declaration interpretBaseDeclaration(string namespace, string type, string name,
   exists(UnboundValueOrRefType t | elementSpec(namespace, type, _, name, signature, _, t) |
     result =
       any(Declaration d |
-        QN::hasQualifiedName(d, namespace, type, name) and
+        hasQualifiedMethodName(d, namespace, type, name) and
         (
           signature = ""
           or
@@ -438,6 +438,19 @@ private module QualifiedNameInput implements QualifiedNameInputSig {
 }
 
 private module QN = QualifiedName<QualifiedNameInput>;
+
+/** Holds if declaration `d` has the qualified name `qualifier`.`name`. */
+predicate hasQualifiedTypeName(Type t, string namespace, string type) {
+  QN::hasQualifiedName(t, namespace, type)
+}
+
+/**
+ * Holds if declaration `d` has name `name` and is defined in type `type`
+ * with namespace `namespace`.
+ */
+predicate hasQualifiedMethodName(Declaration d, string namespace, string type, string name) {
+  QN::hasQualifiedName(d, namespace, type, name)
+}
 
 pragma[nomagic]
 private string parameterQualifiedType(Parameter p) {

--- a/csharp/ql/src/utils/modeleditor/ApplicationModeEndpoints.ql
+++ b/csharp/ql/src/utils/modeleditor/ApplicationModeEndpoints.ql
@@ -18,6 +18,6 @@ where
   usage = aUsage(endpoint) and
   type = supportedType(endpoint) and
   classification = methodClassification(usage)
-select usage, endpoint.getNamespace(), endpoint.getTypeName(), endpoint.getName(),
+select usage, endpoint.getNamespace(), endpoint.getTypeName(), endpoint.getMethodName(),
   endpoint.getParameterTypes(), supported, endpoint.dllName(), endpoint.dllVersion(), type,
   classification

--- a/csharp/ql/src/utils/modeleditor/ApplicationModeEndpoints.ql
+++ b/csharp/ql/src/utils/modeleditor/ApplicationModeEndpoints.ql
@@ -18,6 +18,6 @@ where
   usage = aUsage(endpoint) and
   type = supportedType(endpoint) and
   classification = methodClassification(usage)
-select usage, endpoint.getNamespace(), endpoint.getTypeName(), endpoint.getMethodName(),
+select usage, endpoint.getNamespace(), endpoint.getTypeName(), endpoint.getEndpointName(),
   endpoint.getParameterTypes(), supported, endpoint.dllName(), endpoint.dllVersion(), type,
   classification

--- a/csharp/ql/src/utils/modeleditor/FrameworkModeEndpoints.ql
+++ b/csharp/ql/src/utils/modeleditor/FrameworkModeEndpoints.ql
@@ -14,5 +14,5 @@ from PublicEndpointFromSource endpoint, boolean supported, string type
 where
   supported = isSupported(endpoint) and
   type = supportedType(endpoint)
-select endpoint, endpoint.getNamespace(), endpoint.getTypeName(), endpoint.getMethodName(),
+select endpoint, endpoint.getNamespace(), endpoint.getTypeName(), endpoint.getEndpointName(),
   endpoint.getParameterTypes(), supported, endpoint.getFile().getBaseName(), type

--- a/csharp/ql/src/utils/modeleditor/FrameworkModeEndpoints.ql
+++ b/csharp/ql/src/utils/modeleditor/FrameworkModeEndpoints.ql
@@ -14,5 +14,5 @@ from PublicEndpointFromSource endpoint, boolean supported, string type
 where
   supported = isSupported(endpoint) and
   type = supportedType(endpoint)
-select endpoint, endpoint.getNamespace(), endpoint.getTypeName(), endpoint.getName(),
+select endpoint, endpoint.getNamespace(), endpoint.getTypeName(), endpoint.getMethodName(),
   endpoint.getParameterTypes(), supported, endpoint.getFile().getBaseName(), type

--- a/csharp/ql/src/utils/modeleditor/ModelEditor.qll
+++ b/csharp/ql/src/utils/modeleditor/ModelEditor.qll
@@ -39,10 +39,10 @@ class Endpoint extends Callable {
   }
 
   /**
-   * Gets the qualified method name of this endpoint.
+   * Gets the qualified name of this endpoint.
    */
   bindingset[this]
-  string getMethodName() {
+  string getEndpointName() {
     result = qualifiedCallableName(this.getNamespace(), this.getTypeName(), this)
   }
 

--- a/csharp/ql/src/utils/modeleditor/ModelEditor.qll
+++ b/csharp/ql/src/utils/modeleditor/ModelEditor.qll
@@ -1,7 +1,6 @@
 /** Provides classes and predicates related to handling APIs for the VS Code extension. */
 
 private import csharp
-private import semmle.code.csharp.commons.QualifiedName
 private import semmle.code.csharp.dataflow.FlowSummary
 private import semmle.code.csharp.dataflow.internal.FlowSummaryImpl as FlowSummaryImpl
 private import semmle.code.csharp.dataflow.internal.ExternalFlow
@@ -121,22 +120,12 @@ string methodClassification(Call method) {
  * Gets the fully qualified name of the type `t`.
  */
 private string qualifiedTypeName(string namespace, Type t) {
-  exists(string type | QN::hasQualifiedName(t, namespace, type) | result = type)
+  exists(string type | hasQualifiedTypeName(t, namespace, type) | result = type)
 }
 
 /**
  * Gets the fully qualified name of the callable `c`.
  */
 private string qualifiedCallableName(string namespace, string type, Callable c) {
-  exists(string name | QN::hasQualifiedName(c, namespace, type, name) | result = name)
+  exists(string name | hasQualifiedMethodName(c, namespace, type, name) | result = name)
 }
-
-private module QualifiedNameInput implements QualifiedNameInputSig {
-  string getUnboundGenericSuffix(UnboundGeneric ug) {
-    result =
-      "<" + strictconcat(int i, string s | s = ug.getTypeParameter(i).getName() | s, "," order by i)
-        + ">"
-  }
-}
-
-private module QN = QualifiedName<QualifiedNameInput>;

--- a/csharp/ql/test/utils/modeleditor/FrameworkModeEndpoints.expected
+++ b/csharp/ql/test/utils/modeleditor/FrameworkModeEndpoints.expected
@@ -9,6 +9,7 @@
 | PublicClass.cs:50:17:50:28 | neutralStuff | GitHub.CodeQL | PublicClass | neutralStuff | (System.String) | true | PublicClass.cs | neutral |
 | PublicGenericClass.cs:7:17:7:21 | stuff | GitHub.CodeQL | PublicGenericClass`2 | stuff | (T) | false | PublicGenericClass.cs |  |
 | PublicGenericClass.cs:12:17:12:26 | stuff2`1 | GitHub.CodeQL | PublicGenericClass`2 | stuff2`1 | (T2) | false | PublicGenericClass.cs |  |
+| PublicGenericClass.cs:17:18:17:36 | summaryStuff`1 | GitHub.CodeQL | PublicGenericClass`2 | summaryStuff`1 | (TNode) | true | PublicGenericClass.cs | summary |
 | PublicGenericInterface.cs:7:10:7:14 | stuff | GitHub.CodeQL | PublicGenericInterface`1 | stuff | (T) | false | PublicGenericInterface.cs |  |
 | PublicGenericInterface.cs:9:10:9:19 | stuff2`1 | GitHub.CodeQL | PublicGenericInterface`1 | stuff2`1 | (T2) | false | PublicGenericInterface.cs |  |
 | PublicGenericInterface.cs:11:17:11:27 | staticStuff | GitHub.CodeQL | PublicGenericInterface`1 | staticStuff | (System.String) | false | PublicGenericInterface.cs |  |

--- a/csharp/ql/test/utils/modeleditor/FrameworkModeEndpoints.expected
+++ b/csharp/ql/test/utils/modeleditor/FrameworkModeEndpoints.expected
@@ -7,12 +7,12 @@
 | PublicClass.cs:40:19:40:29 | sourceStuff | GitHub.CodeQL | PublicClass | sourceStuff | () | true | PublicClass.cs | source |
 | PublicClass.cs:45:17:45:25 | sinkStuff | GitHub.CodeQL | PublicClass | sinkStuff | (System.String) | true | PublicClass.cs | sink |
 | PublicClass.cs:50:17:50:28 | neutralStuff | GitHub.CodeQL | PublicClass | neutralStuff | (System.String) | true | PublicClass.cs | neutral |
-| PublicGenericClass.cs:7:17:7:21 | stuff | GitHub.CodeQL | PublicGenericClass`2 | stuff | (T) | false | PublicGenericClass.cs |  |
-| PublicGenericClass.cs:12:17:12:26 | stuff2`1 | GitHub.CodeQL | PublicGenericClass`2 | stuff2`1 | (T2) | false | PublicGenericClass.cs |  |
-| PublicGenericClass.cs:17:18:17:36 | summaryStuff`1 | GitHub.CodeQL | PublicGenericClass`2 | summaryStuff`1 | (TNode) | true | PublicGenericClass.cs | summary |
-| PublicGenericInterface.cs:7:10:7:14 | stuff | GitHub.CodeQL | PublicGenericInterface`1 | stuff | (T) | false | PublicGenericInterface.cs |  |
-| PublicGenericInterface.cs:9:10:9:19 | stuff2`1 | GitHub.CodeQL | PublicGenericInterface`1 | stuff2`1 | (T2) | false | PublicGenericInterface.cs |  |
-| PublicGenericInterface.cs:11:17:11:27 | staticStuff | GitHub.CodeQL | PublicGenericInterface`1 | staticStuff | (System.String) | false | PublicGenericInterface.cs |  |
+| PublicGenericClass.cs:7:17:7:21 | stuff | GitHub.CodeQL | PublicGenericClass<T,T2> | stuff | (T) | false | PublicGenericClass.cs |  |
+| PublicGenericClass.cs:12:17:12:26 | stuff2`1 | GitHub.CodeQL | PublicGenericClass<T,T2> | stuff2<T2> | (T2) | false | PublicGenericClass.cs |  |
+| PublicGenericClass.cs:17:18:17:36 | summaryStuff`1 | GitHub.CodeQL | PublicGenericClass<T,T2> | summaryStuff<TNode> | (TNode) | true | PublicGenericClass.cs | summary |
+| PublicGenericInterface.cs:7:10:7:14 | stuff | GitHub.CodeQL | PublicGenericInterface<T> | stuff | (T) | false | PublicGenericInterface.cs |  |
+| PublicGenericInterface.cs:9:10:9:19 | stuff2`1 | GitHub.CodeQL | PublicGenericInterface<T> | stuff2<T2> | (T2) | false | PublicGenericInterface.cs |  |
+| PublicGenericInterface.cs:11:17:11:27 | staticStuff | GitHub.CodeQL | PublicGenericInterface<T> | staticStuff | (System.String) | false | PublicGenericInterface.cs |  |
 | PublicInterface.cs:7:10:7:14 | stuff | GitHub.CodeQL | PublicInterface | stuff | (System.String) | false | PublicInterface.cs |  |
 | PublicInterface.cs:9:29:9:31 | get_PublicProperty | GitHub.CodeQL | PublicInterface | get_PublicProperty | () | false | PublicInterface.cs |  |
 | PublicInterface.cs:9:34:9:36 | set_PublicProperty | GitHub.CodeQL | PublicInterface | set_PublicProperty | (System.String) | false | PublicInterface.cs |  |

--- a/csharp/ql/test/utils/modeleditor/FrameworkModeEndpoints.ext.yml
+++ b/csharp/ql/test/utils/modeleditor/FrameworkModeEndpoints.ext.yml
@@ -16,6 +16,7 @@ extensions:
       extensible: summaryModel
     data:
       - ["GitHub.CodeQL","PublicClass",true,"summaryStuff","(System.String)","","Argument[0]","ReturnValue","taint","manual"]
+      - ["GitHub.CodeQL","PublicGenericClass<T,T2>",true,"summaryStuff<TNode>","(TNode)","","Argument[0]","ReturnValue","value","manual"]
 
   - addsTo:
       pack: codeql/csharp-all

--- a/csharp/ql/test/utils/modeleditor/PublicGenericClass.cs
+++ b/csharp/ql/test/utils/modeleditor/PublicGenericClass.cs
@@ -13,4 +13,9 @@ public class PublicGenericClass<T, T2> : PublicGenericInterface<T>
     {
         Console.WriteLine(arg);
     }
+
+    public TNode summaryStuff<TNode>(TNode arg)
+    {
+        return arg;
+    }
 }


### PR DESCRIPTION
The names returned in the C# model editor queries did not match the names that were expected in the MaD files. For example, it would return `PublicGenericClass`2`, whereas the MaD format expects `PublicGenericClass<T,T2>`. This fixes it by reusing the same `QualifiedName` module that `ExternalFlow.qll` uses.