### PR TITLE
InlineFlowTest: Allow for custom `getArgString`

### DIFF
--- a/ruby/ql/test/TestUtilities/InlineFlowTest.qll
+++ b/ruby/ql/test/TestUtilities/InlineFlowTest.qll
@@ -12,6 +12,7 @@ private import internal.InlineExpectationsTestImpl
 private module FlowTestImpl implements InputSig<RubyDataFlow> {
   import TestUtilities.InlineFlowTestUtil
 
+  bindingset[src, sink]
   string getArgString(DataFlow::Node src, DataFlow::Node sink) {
     (if exists(getSourceArgString(src)) then result = getSourceArgString(src) else result = "") and
     exists(sink)

--- a/shared/dataflow/codeql/dataflow/test/InlineFlowTest.qll
+++ b/shared/dataflow/codeql/dataflow/test/InlineFlowTest.qll
@@ -35,6 +35,7 @@ signature module InputSig<DF::InputSig DataFlowLang> {
 
   predicate defaultSink(DataFlowLang::Node source);
 
+  bindingset[src, sink]
   string getArgString(DataFlowLang::Node src, DataFlowLang::Node sink);
 }
 
@@ -62,7 +63,13 @@ module InlineFlowTestMake<
     predicate isSink(DataFlowLang::Node sink) { none() }
   }
 
-  module FlowTest<DataFlow::ConfigSig ValueFlowConfig, DataFlow::ConfigSig TaintFlowConfig> {
+  bindingset[src, sink]
+  signature string getArgStringSig(DataFlowLang::Node src, DataFlowLang::Node sink);
+
+  module FlowTestArgString<
+    DataFlow::ConfigSig ValueFlowConfig, DataFlow::ConfigSig TaintFlowConfig,
+    getArgStringSig/2 getArgString>
+  {
     module ValueFlow = DataFlow::Global<ValueFlowConfig>;
 
     module TaintFlow = TaintTracking::Global<TaintFlowConfig>;
@@ -82,7 +89,7 @@ module InlineFlowTestMake<
         exists(DataFlowLang::Node src, DataFlowLang::Node sink | ValueFlow::flow(src, sink) |
           hasLocationInfo(sink, location) and
           element = sink.toString() and
-          value = Impl::getArgString(src, sink)
+          value = getArgString(src, sink)
         )
         or
         tag = "hasTaintFlow" and
@@ -91,7 +98,7 @@ module InlineFlowTestMake<
         |
           hasLocationInfo(sink, location) and
           element = sink.toString() and
-          value = Impl::getArgString(src, sink)
+          value = getArgString(src, sink)
         )
       }
     }
@@ -105,10 +112,24 @@ module InlineFlowTestMake<
     }
   }
 
+  module FlowTest<DataFlow::ConfigSig ValueFlowConfig, DataFlow::ConfigSig TaintFlowConfig> {
+    import FlowTestArgString<ValueFlowConfig, TaintFlowConfig, Impl::getArgString/2>
+  }
+
   module DefaultFlowTest = FlowTest<DefaultFlowConfig, DefaultFlowConfig>;
+
+  module ValueFlowTestArgString<DataFlow::ConfigSig ValueFlowConfig, getArgStringSig/2 getArgString>
+  {
+    import FlowTestArgString<ValueFlowConfig, NoFlowConfig, getArgString/2>
+  }
 
   module ValueFlowTest<DataFlow::ConfigSig ValueFlowConfig> {
     import FlowTest<ValueFlowConfig, NoFlowConfig>
+  }
+
+  module TaintFlowTestArgString<DataFlow::ConfigSig TaintFlowConfig, getArgStringSig/2 getArgString>
+  {
+    import FlowTestArgString<NoFlowConfig, TaintFlowConfig, getArgString/2>
   }
 
   module TaintFlowTest<DataFlow::ConfigSig TaintFlowConfig> {

--- a/shared/dataflow/codeql/dataflow/test/InlineFlowTest.qll
+++ b/shared/dataflow/codeql/dataflow/test/InlineFlowTest.qll
@@ -124,7 +124,7 @@ module InlineFlowTestMake<
   }
 
   module ValueFlowTest<DataFlow::ConfigSig ValueFlowConfig> {
-    import FlowTest<ValueFlowConfig, NoFlowConfig>
+    import ValueFlowTestArgString<ValueFlowConfig, Impl::getArgString/2>
   }
 
   module TaintFlowTestArgString<DataFlow::ConfigSig TaintFlowConfig, getArgStringSig/2 getArgString>
@@ -133,6 +133,6 @@ module InlineFlowTestMake<
   }
 
   module TaintFlowTest<DataFlow::ConfigSig TaintFlowConfig> {
-    import FlowTest<NoFlowConfig, TaintFlowConfig>
+    import TaintFlowTestArgString<TaintFlowConfig, Impl::getArgString/2>
   }
 }


### PR DESCRIPTION
When not using `DefaultFlowTest`, it is useful to be able to implement a custom `getArtString` predicate.