### PR TITLE
Ruby: Model simple pattern matching as value steps instead of taint steps

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
@@ -663,7 +663,8 @@ private module TrackInstanceInput implements CallGraphConstruction::InputSig {
     // We exclude steps into type checked variables. For those, we instead rely on the
     // type being checked against
     localFlowStep(nodeFrom, nodeTo, summary) and
-    not hasAdjacentTypeCheckedReads(nodeTo)
+    not hasAdjacentTypeCheckedReads(nodeTo) and
+    not asModulePattern(nodeTo, _)
   }
 
   predicate stepCall(DataFlow::Node nodeFrom, DataFlow::Node nodeTo, StepSummary summary) {

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/TaintTrackingPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/TaintTrackingPrivate.qll
@@ -79,11 +79,16 @@ private module Cached {
   cached
   predicate defaultAdditionalTaintStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     // value of `case` expression into variables in patterns
-    exists(CfgNodes::ExprNodes::CaseExprCfgNode case, CfgNodes::ExprNodes::InClauseCfgNode clause |
-      nodeFrom.asExpr() = case.getValue() and
+    exists(
+      CfgNodes::ExprNodes::CaseExprCfgNode case, CfgNodes::ExprCfgNode value,
+      CfgNodes::ExprNodes::InClauseCfgNode clause, Ssa::Definition def
+    |
+      nodeFrom.asExpr() = value and
+      value = case.getValue() and
       clause = case.getBranch(_) and
-      nodeTo.(SsaDefinitionExtNode).getDefinitionExt().(Ssa::Definition).getControlFlowNode() =
-        variablesInPattern(clause.getPattern())
+      def = nodeTo.(SsaDefinitionExtNode).getDefinitionExt() and
+      def.getControlFlowNode() = variablesInPattern(clause.getPattern()) and
+      not LocalFlow::ssaDefAssigns(def, value)
     )
     or
     // operation involving `nodeFrom`

--- a/ruby/ql/test/library-tests/dataflow/local/DataflowStep.expected
+++ b/ruby/ql/test/library-tests/dataflow/local/DataflowStep.expected
@@ -2528,6 +2528,8 @@
 | local_dataflow.rb:78:12:78:20 | [post] self | local_dataflow.rb:85:22:85:28 | self |
 | local_dataflow.rb:78:12:78:20 | [post] self | local_dataflow.rb:86:28:86:34 | self |
 | local_dataflow.rb:78:12:78:20 | [post] self | local_dataflow.rb:87:20:87:26 | self |
+| local_dataflow.rb:78:12:78:20 | call to source | local_dataflow.rb:79:13:79:13 | b |
+| local_dataflow.rb:78:12:78:20 | call to source | local_dataflow.rb:80:8:80:8 | a |
 | local_dataflow.rb:78:12:78:20 | self | local_dataflow.rb:79:20:79:26 | self |
 | local_dataflow.rb:78:12:78:20 | self | local_dataflow.rb:80:24:80:30 | self |
 | local_dataflow.rb:78:12:78:20 | self | local_dataflow.rb:82:7:82:13 | self |

--- a/ruby/ql/test/library-tests/dataflow/local/local_dataflow.rb
+++ b/ruby/ql/test/library-tests/dataflow/local/local_dataflow.rb
@@ -76,8 +76,8 @@ def test_case x
   end
 
   z = case source(1)
-    in 5 => b then sink(b) # $ hasTaintFlow=1
-    in a if a > 0 then sink(a) # $ hasTaintFlow=1
+    in 5 => b then sink(b) # $ hasValueFlow=1
+    in a if a > 0 then sink(a) # $ hasValueFlow=1
     in [c, *d, e ] then [
       sink(c), # $ hasTaintFlow=1
       sink(d), # $ hasTaintFlow=1


### PR DESCRIPTION
Until we have proper data flow for pattern matching (possibly using desugaring and flow summaries), this PR changes simple pattern matches such as
```rb
case value
  in Foo => x then ...
  in y => then ...
end
```
from being taint steps to value steps.