### PR TITLE
Python: Remove `@tags meta` from internal debug queries

### DIFF
--- a/python/ql/src/meta/analysis-quality/TTCallGraph.ql
+++ b/python/ql/src/meta/analysis-quality/TTCallGraph.ql
@@ -3,7 +3,6 @@
  * @kind problem
  * @problem.severity recommendation
  * @id py/meta/type-tracking-call-graph
- * @tags meta
  * @precision very-low
  */
 

--- a/python/ql/src/meta/analysis-quality/TTCallGraphMissing.ql
+++ b/python/ql/src/meta/analysis-quality/TTCallGraphMissing.ql
@@ -3,7 +3,6 @@
  * @kind problem
  * @problem.severity recommendation
  * @id py/meta/call-graph-missing
- * @tags meta
  * @precision very-low
  */
 

--- a/python/ql/src/meta/analysis-quality/TTCallGraphNew.ql
+++ b/python/ql/src/meta/analysis-quality/TTCallGraphNew.ql
@@ -3,7 +3,6 @@
  * @kind problem
  * @problem.severity recommendation
  * @id py/meta/call-graph-new
- * @tags meta
  * @precision very-low
  */
 

--- a/python/ql/src/meta/analysis-quality/TTCallGraphNewAmbiguous.ql
+++ b/python/ql/src/meta/analysis-quality/TTCallGraphNewAmbiguous.ql
@@ -3,7 +3,6 @@
  * @kind problem
  * @problem.severity recommendation
  * @id py/meta/call-graph-new-ambiguous
- * @tags meta
  * @precision very-low
  */
 

--- a/python/ql/src/meta/analysis-quality/TTCallGraphShared.ql
+++ b/python/ql/src/meta/analysis-quality/TTCallGraphShared.ql
@@ -3,7 +3,6 @@
  * @kind problem
  * @problem.severity recommendation
  * @id py/meta/call-graph-shared
- * @tags meta
  * @precision very-low
  */
 


### PR DESCRIPTION
These queries were great when evaluating coverage of the new call-graph compared with the old.

However, they are not useful to run as part of our DCA experiments.