### PR TITLE
C++: Produce a better `toString` for dataflow nodes with indirections

### DIFF
--- a/cpp/ql/lib/change-notes/2023-12-14-dataflow-tostring.md
+++ b/cpp/ql/lib/change-notes/2023-12-14-dataflow-tostring.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Changed the output of `Node.toString` to better reflect how many indirections a given dataflow node has.

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -2288,6 +2288,10 @@ private module ContentStars {
     result = "*" + repeatStars(n - 1)
   }
 
+  /**
+   * Gets the number of stars (i.e., `*`s) needed to produce the `toString`
+   * output for `c`.
+   */
   string contentStars(Content c) { result = repeatStars(c.getIndirectionIndex() - 1) }
 }
 

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-078/WordexpTainted.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-078/WordexpTainted.expected
@@ -1,8 +1,8 @@
 edges
-| test.cpp:22:27:22:30 | argv indirection | test.cpp:29:13:29:20 | filePath indirection |
+| test.cpp:22:27:22:30 | **argv | test.cpp:29:13:29:20 | *filePath |
 nodes
-| test.cpp:22:27:22:30 | argv indirection | semmle.label | argv indirection |
-| test.cpp:29:13:29:20 | filePath indirection | semmle.label | filePath indirection |
+| test.cpp:22:27:22:30 | **argv | semmle.label | **argv |
+| test.cpp:29:13:29:20 | *filePath | semmle.label | *filePath |
 subpaths
 #select
-| test.cpp:29:13:29:20 | filePath indirection | test.cpp:22:27:22:30 | argv indirection | test.cpp:29:13:29:20 | filePath indirection | Using user-supplied data in a `wordexp` command, without disabling command substitution, can make code vulnerable to command injection. |
+| test.cpp:29:13:29:20 | *filePath | test.cpp:22:27:22:30 | **argv | test.cpp:29:13:29:20 | *filePath | Using user-supplied data in a `wordexp` command, without disabling command substitution, can make code vulnerable to command injection. |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/array-access/ArrayAccessProductFlow.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/array-access/ArrayAccessProductFlow.expected
@@ -1,87 +1,87 @@
 edges
 | test.cpp:4:17:4:22 | call to malloc | test.cpp:6:9:6:11 | arr |
 | test.cpp:4:17:4:22 | call to malloc | test.cpp:10:9:10:11 | arr |
-| test.cpp:19:9:19:16 | mk_array indirection [p] | test.cpp:28:19:28:26 | call to mk_array [p] |
-| test.cpp:19:9:19:16 | mk_array indirection [p] | test.cpp:50:18:50:25 | call to mk_array [p] |
-| test.cpp:21:5:21:7 | arr indirection [post update] [p] | test.cpp:22:5:22:7 | arr indirection [p] |
-| test.cpp:21:5:21:24 | ... = ... | test.cpp:21:5:21:7 | arr indirection [post update] [p] |
+| test.cpp:19:9:19:16 | *mk_array [p] | test.cpp:28:19:28:26 | call to mk_array [p] |
+| test.cpp:19:9:19:16 | *mk_array [p] | test.cpp:50:18:50:25 | call to mk_array [p] |
+| test.cpp:21:5:21:7 | *arr [post update] [p] | test.cpp:22:5:22:7 | *arr [p] |
+| test.cpp:21:5:21:24 | ... = ... | test.cpp:21:5:21:7 | *arr [post update] [p] |
 | test.cpp:21:13:21:18 | call to malloc | test.cpp:21:5:21:24 | ... = ... |
-| test.cpp:22:5:22:7 | arr indirection [p] | test.cpp:19:9:19:16 | mk_array indirection [p] |
-| test.cpp:28:19:28:26 | call to mk_array [p] | test.cpp:31:9:31:11 | arr indirection [p] |
-| test.cpp:28:19:28:26 | call to mk_array [p] | test.cpp:35:9:35:11 | arr indirection [p] |
-| test.cpp:31:9:31:11 | arr indirection [p] | test.cpp:31:13:31:13 | p |
-| test.cpp:35:9:35:11 | arr indirection [p] | test.cpp:35:13:35:13 | p |
-| test.cpp:39:27:39:29 | arr [p] | test.cpp:41:9:41:11 | arr indirection [p] |
-| test.cpp:39:27:39:29 | arr [p] | test.cpp:45:9:45:11 | arr indirection [p] |
-| test.cpp:41:9:41:11 | arr indirection [p] | test.cpp:41:13:41:13 | p |
-| test.cpp:45:9:45:11 | arr indirection [p] | test.cpp:45:13:45:13 | p |
+| test.cpp:22:5:22:7 | *arr [p] | test.cpp:19:9:19:16 | *mk_array [p] |
+| test.cpp:28:19:28:26 | call to mk_array [p] | test.cpp:31:9:31:11 | *arr [p] |
+| test.cpp:28:19:28:26 | call to mk_array [p] | test.cpp:35:9:35:11 | *arr [p] |
+| test.cpp:31:9:31:11 | *arr [p] | test.cpp:31:13:31:13 | p |
+| test.cpp:35:9:35:11 | *arr [p] | test.cpp:35:13:35:13 | p |
+| test.cpp:39:27:39:29 | arr [p] | test.cpp:41:9:41:11 | *arr [p] |
+| test.cpp:39:27:39:29 | arr [p] | test.cpp:45:9:45:11 | *arr [p] |
+| test.cpp:41:9:41:11 | *arr [p] | test.cpp:41:13:41:13 | p |
+| test.cpp:45:9:45:11 | *arr [p] | test.cpp:45:13:45:13 | p |
 | test.cpp:50:18:50:25 | call to mk_array [p] | test.cpp:39:27:39:29 | arr [p] |
-| test.cpp:55:5:55:7 | arr indirection [post update] [p] | test.cpp:56:5:56:7 | arr indirection [p] |
-| test.cpp:55:5:55:24 | ... = ... | test.cpp:55:5:55:7 | arr indirection [post update] [p] |
+| test.cpp:55:5:55:7 | *arr [post update] [p] | test.cpp:56:5:56:7 | *arr [p] |
+| test.cpp:55:5:55:24 | ... = ... | test.cpp:55:5:55:7 | *arr [post update] [p] |
 | test.cpp:55:13:55:18 | call to malloc | test.cpp:55:5:55:24 | ... = ... |
-| test.cpp:56:5:56:7 | arr indirection [p] | test.cpp:59:9:59:11 | arr indirection [p] |
-| test.cpp:56:5:56:7 | arr indirection [p] | test.cpp:63:9:63:11 | arr indirection [p] |
-| test.cpp:59:9:59:11 | arr indirection [p] | test.cpp:59:13:59:13 | p |
-| test.cpp:63:9:63:11 | arr indirection [p] | test.cpp:63:13:63:13 | p |
-| test.cpp:67:10:67:19 | mk_array_p indirection [p] | test.cpp:76:20:76:29 | call to mk_array_p indirection [p] |
-| test.cpp:67:10:67:19 | mk_array_p indirection [p] | test.cpp:98:18:98:27 | call to mk_array_p indirection [p] |
-| test.cpp:69:5:69:7 | arr indirection [post update] [p] | test.cpp:70:5:70:7 | arr indirection [p] |
-| test.cpp:69:5:69:25 | ... = ... | test.cpp:69:5:69:7 | arr indirection [post update] [p] |
+| test.cpp:56:5:56:7 | *arr [p] | test.cpp:59:9:59:11 | *arr [p] |
+| test.cpp:56:5:56:7 | *arr [p] | test.cpp:63:9:63:11 | *arr [p] |
+| test.cpp:59:9:59:11 | *arr [p] | test.cpp:59:13:59:13 | p |
+| test.cpp:63:9:63:11 | *arr [p] | test.cpp:63:13:63:13 | p |
+| test.cpp:67:10:67:19 | **mk_array_p [p] | test.cpp:76:20:76:29 | *call to mk_array_p [p] |
+| test.cpp:67:10:67:19 | **mk_array_p [p] | test.cpp:98:18:98:27 | *call to mk_array_p [p] |
+| test.cpp:69:5:69:7 | *arr [post update] [p] | test.cpp:70:5:70:7 | *arr [p] |
+| test.cpp:69:5:69:25 | ... = ... | test.cpp:69:5:69:7 | *arr [post update] [p] |
 | test.cpp:69:14:69:19 | call to malloc | test.cpp:69:5:69:25 | ... = ... |
-| test.cpp:70:5:70:7 | arr indirection [p] | test.cpp:67:10:67:19 | mk_array_p indirection [p] |
-| test.cpp:76:20:76:29 | call to mk_array_p indirection [p] | test.cpp:79:9:79:11 | arr indirection [p] |
-| test.cpp:76:20:76:29 | call to mk_array_p indirection [p] | test.cpp:83:9:83:11 | arr indirection [p] |
-| test.cpp:79:9:79:11 | arr indirection [p] | test.cpp:79:14:79:14 | p |
-| test.cpp:83:9:83:11 | arr indirection [p] | test.cpp:83:14:83:14 | p |
-| test.cpp:87:28:87:30 | arr indirection [p] | test.cpp:89:9:89:11 | arr indirection [p] |
-| test.cpp:87:28:87:30 | arr indirection [p] | test.cpp:93:9:93:11 | arr indirection [p] |
-| test.cpp:89:9:89:11 | arr indirection [p] | test.cpp:89:14:89:14 | p |
-| test.cpp:93:9:93:11 | arr indirection [p] | test.cpp:93:14:93:14 | p |
-| test.cpp:98:18:98:27 | call to mk_array_p indirection [p] | test.cpp:87:28:87:30 | arr indirection [p] |
+| test.cpp:70:5:70:7 | *arr [p] | test.cpp:67:10:67:19 | **mk_array_p [p] |
+| test.cpp:76:20:76:29 | *call to mk_array_p [p] | test.cpp:79:9:79:11 | *arr [p] |
+| test.cpp:76:20:76:29 | *call to mk_array_p [p] | test.cpp:83:9:83:11 | *arr [p] |
+| test.cpp:79:9:79:11 | *arr [p] | test.cpp:79:14:79:14 | p |
+| test.cpp:83:9:83:11 | *arr [p] | test.cpp:83:14:83:14 | p |
+| test.cpp:87:28:87:30 | *arr [p] | test.cpp:89:9:89:11 | *arr [p] |
+| test.cpp:87:28:87:30 | *arr [p] | test.cpp:93:9:93:11 | *arr [p] |
+| test.cpp:89:9:89:11 | *arr [p] | test.cpp:89:14:89:14 | p |
+| test.cpp:93:9:93:11 | *arr [p] | test.cpp:93:14:93:14 | p |
+| test.cpp:98:18:98:27 | *call to mk_array_p [p] | test.cpp:87:28:87:30 | *arr [p] |
 nodes
 | test.cpp:4:17:4:22 | call to malloc | semmle.label | call to malloc |
 | test.cpp:6:9:6:11 | arr | semmle.label | arr |
 | test.cpp:10:9:10:11 | arr | semmle.label | arr |
-| test.cpp:19:9:19:16 | mk_array indirection [p] | semmle.label | mk_array indirection [p] |
-| test.cpp:21:5:21:7 | arr indirection [post update] [p] | semmle.label | arr indirection [post update] [p] |
+| test.cpp:19:9:19:16 | *mk_array [p] | semmle.label | *mk_array [p] |
+| test.cpp:21:5:21:7 | *arr [post update] [p] | semmle.label | *arr [post update] [p] |
 | test.cpp:21:5:21:24 | ... = ... | semmle.label | ... = ... |
 | test.cpp:21:13:21:18 | call to malloc | semmle.label | call to malloc |
-| test.cpp:22:5:22:7 | arr indirection [p] | semmle.label | arr indirection [p] |
+| test.cpp:22:5:22:7 | *arr [p] | semmle.label | *arr [p] |
 | test.cpp:28:19:28:26 | call to mk_array [p] | semmle.label | call to mk_array [p] |
-| test.cpp:31:9:31:11 | arr indirection [p] | semmle.label | arr indirection [p] |
+| test.cpp:31:9:31:11 | *arr [p] | semmle.label | *arr [p] |
 | test.cpp:31:13:31:13 | p | semmle.label | p |
-| test.cpp:35:9:35:11 | arr indirection [p] | semmle.label | arr indirection [p] |
+| test.cpp:35:9:35:11 | *arr [p] | semmle.label | *arr [p] |
 | test.cpp:35:13:35:13 | p | semmle.label | p |
 | test.cpp:39:27:39:29 | arr [p] | semmle.label | arr [p] |
-| test.cpp:41:9:41:11 | arr indirection [p] | semmle.label | arr indirection [p] |
+| test.cpp:41:9:41:11 | *arr [p] | semmle.label | *arr [p] |
 | test.cpp:41:13:41:13 | p | semmle.label | p |
-| test.cpp:45:9:45:11 | arr indirection [p] | semmle.label | arr indirection [p] |
+| test.cpp:45:9:45:11 | *arr [p] | semmle.label | *arr [p] |
 | test.cpp:45:13:45:13 | p | semmle.label | p |
 | test.cpp:50:18:50:25 | call to mk_array [p] | semmle.label | call to mk_array [p] |
-| test.cpp:55:5:55:7 | arr indirection [post update] [p] | semmle.label | arr indirection [post update] [p] |
+| test.cpp:55:5:55:7 | *arr [post update] [p] | semmle.label | *arr [post update] [p] |
 | test.cpp:55:5:55:24 | ... = ... | semmle.label | ... = ... |
 | test.cpp:55:13:55:18 | call to malloc | semmle.label | call to malloc |
-| test.cpp:56:5:56:7 | arr indirection [p] | semmle.label | arr indirection [p] |
-| test.cpp:59:9:59:11 | arr indirection [p] | semmle.label | arr indirection [p] |
+| test.cpp:56:5:56:7 | *arr [p] | semmle.label | *arr [p] |
+| test.cpp:59:9:59:11 | *arr [p] | semmle.label | *arr [p] |
 | test.cpp:59:13:59:13 | p | semmle.label | p |
-| test.cpp:63:9:63:11 | arr indirection [p] | semmle.label | arr indirection [p] |
+| test.cpp:63:9:63:11 | *arr [p] | semmle.label | *arr [p] |
 | test.cpp:63:13:63:13 | p | semmle.label | p |
-| test.cpp:67:10:67:19 | mk_array_p indirection [p] | semmle.label | mk_array_p indirection [p] |
-| test.cpp:69:5:69:7 | arr indirection [post update] [p] | semmle.label | arr indirection [post update] [p] |
+| test.cpp:67:10:67:19 | **mk_array_p [p] | semmle.label | **mk_array_p [p] |
+| test.cpp:69:5:69:7 | *arr [post update] [p] | semmle.label | *arr [post update] [p] |
 | test.cpp:69:5:69:25 | ... = ... | semmle.label | ... = ... |
 | test.cpp:69:14:69:19 | call to malloc | semmle.label | call to malloc |
-| test.cpp:70:5:70:7 | arr indirection [p] | semmle.label | arr indirection [p] |
-| test.cpp:76:20:76:29 | call to mk_array_p indirection [p] | semmle.label | call to mk_array_p indirection [p] |
-| test.cpp:79:9:79:11 | arr indirection [p] | semmle.label | arr indirection [p] |
+| test.cpp:70:5:70:7 | *arr [p] | semmle.label | *arr [p] |
+| test.cpp:76:20:76:29 | *call to mk_array_p [p] | semmle.label | *call to mk_array_p [p] |
+| test.cpp:79:9:79:11 | *arr [p] | semmle.label | *arr [p] |
 | test.cpp:79:14:79:14 | p | semmle.label | p |
-| test.cpp:83:9:83:11 | arr indirection [p] | semmle.label | arr indirection [p] |
+| test.cpp:83:9:83:11 | *arr [p] | semmle.label | *arr [p] |
 | test.cpp:83:14:83:14 | p | semmle.label | p |
-| test.cpp:87:28:87:30 | arr indirection [p] | semmle.label | arr indirection [p] |
-| test.cpp:89:9:89:11 | arr indirection [p] | semmle.label | arr indirection [p] |
+| test.cpp:87:28:87:30 | *arr [p] | semmle.label | *arr [p] |
+| test.cpp:89:9:89:11 | *arr [p] | semmle.label | *arr [p] |
 | test.cpp:89:14:89:14 | p | semmle.label | p |
-| test.cpp:93:9:93:11 | arr indirection [p] | semmle.label | arr indirection [p] |
+| test.cpp:93:9:93:11 | *arr [p] | semmle.label | *arr [p] |
 | test.cpp:93:14:93:14 | p | semmle.label | p |
-| test.cpp:98:18:98:27 | call to mk_array_p indirection [p] | semmle.label | call to mk_array_p indirection [p] |
+| test.cpp:98:18:98:27 | *call to mk_array_p [p] | semmle.label | *call to mk_array_p [p] |
 subpaths
 #select
 | test.cpp:10:9:10:11 | arr | test.cpp:4:17:4:22 | call to malloc | test.cpp:10:9:10:11 | arr | Off-by one error allocated at $@ bounded by $@. | test.cpp:4:17:4:22 | call to malloc | call to malloc | test.cpp:4:24:4:27 | size | size |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/constant-size/ConstantSizeArrayOffByOne.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/constant-size/ConstantSizeArrayOffByOne.expected
@@ -35,10 +35,10 @@ edges
 | test.cpp:136:9:136:16 | ... += ... | test.cpp:138:13:138:15 | arr |
 | test.cpp:143:18:143:21 | asdf | test.cpp:134:25:134:27 | arr |
 | test.cpp:143:18:143:21 | asdf | test.cpp:143:18:143:21 | asdf |
-| test.cpp:146:26:146:26 | p indirection | test.cpp:147:4:147:9 | -- ... |
+| test.cpp:146:26:146:26 | *p | test.cpp:147:4:147:9 | -- ... |
 | test.cpp:156:12:156:14 | buf | test.cpp:156:12:156:18 | ... + ... |
-| test.cpp:156:12:156:18 | ... + ... | test.cpp:158:17:158:18 | & ... indirection |
-| test.cpp:158:17:158:18 | & ... indirection | test.cpp:146:26:146:26 | p indirection |
+| test.cpp:156:12:156:18 | ... + ... | test.cpp:158:17:158:18 | *& ... |
+| test.cpp:158:17:158:18 | *& ... | test.cpp:146:26:146:26 | *p |
 | test.cpp:218:23:218:28 | buffer | test.cpp:220:5:220:11 | access to array |
 | test.cpp:218:23:218:28 | buffer | test.cpp:221:5:221:11 | access to array |
 | test.cpp:229:25:229:29 | array | test.cpp:231:5:231:10 | access to array |
@@ -121,11 +121,11 @@ nodes
 | test.cpp:138:13:138:15 | arr | semmle.label | arr |
 | test.cpp:143:18:143:21 | asdf | semmle.label | asdf |
 | test.cpp:143:18:143:21 | asdf | semmle.label | asdf |
-| test.cpp:146:26:146:26 | p indirection | semmle.label | p indirection |
+| test.cpp:146:26:146:26 | *p | semmle.label | *p |
 | test.cpp:147:4:147:9 | -- ... | semmle.label | -- ... |
 | test.cpp:156:12:156:14 | buf | semmle.label | buf |
 | test.cpp:156:12:156:18 | ... + ... | semmle.label | ... + ... |
-| test.cpp:158:17:158:18 | & ... indirection | semmle.label | & ... indirection |
+| test.cpp:158:17:158:18 | *& ... | semmle.label | *& ... |
 | test.cpp:218:23:218:28 | buffer | semmle.label | buffer |
 | test.cpp:220:5:220:11 | access to array | semmle.label | access to array |
 | test.cpp:221:5:221:11 | access to array | semmle.label | access to array |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-359/semmle/tests/PrivateCleartextWrite.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-359/semmle/tests/PrivateCleartextWrite.expected
@@ -1,5 +1,5 @@
 edges
-| test.cpp:45:18:45:23 | buffer | test.cpp:45:7:45:10 | func indirection |
+| test.cpp:45:18:45:23 | buffer | test.cpp:45:7:45:10 | *func |
 | test.cpp:74:24:74:30 | medical | test.cpp:78:24:78:27 | temp |
 | test.cpp:74:24:74:30 | medical | test.cpp:81:22:81:28 | medical |
 | test.cpp:77:16:77:22 | medical | test.cpp:78:24:78:27 | temp |
@@ -10,7 +10,7 @@ edges
 | test.cpp:96:37:96:46 | theZipcode | test.cpp:99:42:99:51 | theZipcode |
 | test.cpp:99:61:99:70 | theZipcode | test.cpp:99:42:99:51 | theZipcode |
 nodes
-| test.cpp:45:7:45:10 | func indirection | semmle.label | func indirection |
+| test.cpp:45:7:45:10 | *func | semmle.label | *func |
 | test.cpp:45:18:45:23 | buffer | semmle.label | buffer |
 | test.cpp:57:9:57:18 | theZipcode | semmle.label | theZipcode |
 | test.cpp:74:24:74:30 | medical | semmle.label | medical |
@@ -25,7 +25,7 @@ nodes
 | test.cpp:99:42:99:51 | theZipcode | semmle.label | theZipcode |
 | test.cpp:99:61:99:70 | theZipcode | semmle.label | theZipcode |
 subpaths
-| test.cpp:81:22:81:28 | medical | test.cpp:45:18:45:23 | buffer | test.cpp:45:7:45:10 | func indirection | test.cpp:81:17:81:20 | call to func |
+| test.cpp:81:22:81:28 | medical | test.cpp:45:18:45:23 | buffer | test.cpp:45:7:45:10 | *func | test.cpp:81:17:81:20 | call to func |
 #select
 | test.cpp:57:9:57:18 | theZipcode | test.cpp:57:9:57:18 | theZipcode | test.cpp:57:9:57:18 | theZipcode | This write into the external location 'theZipcode' may contain unencrypted data from $@. | test.cpp:57:9:57:18 | theZipcode | this source of private data. |
 | test.cpp:74:24:74:30 | medical | test.cpp:74:24:74:30 | medical | test.cpp:74:24:74:30 | medical | This write into the external location 'medical' may contain unencrypted data from $@. | test.cpp:74:24:74:30 | medical | this source of private data. |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-ir-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-ir-consistency.expected
@@ -12,14 +12,14 @@ compatibleTypesReflexive
 unreachableNodeCCtx
 localCallNodes
 postIsNotPre
-| flowOut.cpp:84:3:84:14 | access to array indirection | PostUpdateNode should not equal its pre-update node. |
+| flowOut.cpp:84:3:84:14 | *access to array | PostUpdateNode should not equal its pre-update node. |
 postHasUniquePre
 uniquePostUpdate
 postIsInSameCallable
 reverseRead
 argHasPostUpdate
 postWithInFlow
-| flowOut.cpp:84:3:84:14 | access to array indirection | PostUpdateNode should not be the target of local flow. |
+| flowOut.cpp:84:3:84:14 | *access to array | PostUpdateNode should not be the target of local flow. |
 | test.cpp:384:10:384:13 | memcpy output argument | PostUpdateNode should not be the target of local flow. |
 | test.cpp:391:10:391:13 | memcpy output argument | PostUpdateNode should not be the target of local flow. |
 | test.cpp:400:10:400:13 | memcpy output argument | PostUpdateNode should not be the target of local flow. |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test-source-sink.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test-source-sink.expected
@@ -142,16 +142,16 @@ irFlow
 | BarrierGuard.cpp:60:11:60:16 | call to source | BarrierGuard.cpp:66:14:66:14 | x |
 | acrossLinkTargets.cpp:19:27:19:32 | call to source | acrossLinkTargets.cpp:12:8:12:8 | x |
 | clang.cpp:12:9:12:20 | sourceArray1 | clang.cpp:18:8:18:19 | sourceArray1 |
-| clang.cpp:12:9:12:20 | sourceArray1 | clang.cpp:23:17:23:29 | & ... indirection |
+| clang.cpp:12:9:12:20 | sourceArray1 | clang.cpp:23:17:23:29 | *& ... |
 | clang.cpp:29:27:29:32 | call to source | clang.cpp:30:27:30:28 | m1 |
 | clang.cpp:29:27:29:32 | call to source | clang.cpp:31:27:31:34 | call to getFirst |
 | clang.cpp:35:32:35:37 | call to source | clang.cpp:38:10:38:11 | m2 |
 | clang.cpp:40:42:40:47 | call to source | clang.cpp:42:18:42:19 | m2 |
 | clang.cpp:44:35:44:40 | call to source | clang.cpp:46:17:46:18 | m2 |
 | clang.cpp:50:7:50:16 | definition of stackArray | clang.cpp:52:8:52:17 | stackArray |
-| clang.cpp:50:25:50:30 | call to source | clang.cpp:53:17:53:26 | stackArray indirection |
-| clang.cpp:50:35:50:40 | call to source | clang.cpp:53:17:53:26 | stackArray indirection |
-| clang.cpp:51:19:51:24 | call to source | clang.cpp:53:17:53:26 | stackArray indirection |
+| clang.cpp:50:25:50:30 | call to source | clang.cpp:53:17:53:26 | *stackArray |
+| clang.cpp:50:35:50:40 | call to source | clang.cpp:53:17:53:26 | *stackArray |
+| clang.cpp:51:19:51:24 | call to source | clang.cpp:53:17:53:26 | *stackArray |
 | dispatch.cpp:9:37:9:42 | call to source | dispatch.cpp:35:16:35:25 | call to notSource1 |
 | dispatch.cpp:9:37:9:42 | call to source | dispatch.cpp:43:15:43:24 | call to notSource1 |
 | dispatch.cpp:10:37:10:42 | call to source | dispatch.cpp:36:16:36:25 | call to notSource2 |
@@ -210,7 +210,7 @@ irFlow
 | test.cpp:75:7:75:8 | definition of u1 | test.cpp:76:8:76:9 | u1 |
 | test.cpp:83:7:83:8 | definition of u2 | test.cpp:84:8:84:18 | ... ? ... : ... |
 | test.cpp:83:7:83:8 | definition of u2 | test.cpp:86:8:86:9 | i1 |
-| test.cpp:89:28:89:34 | source1 indirection | test.cpp:90:8:90:14 | source1 |
+| test.cpp:89:28:89:34 | *source1 | test.cpp:90:8:90:14 | source1 |
 | test.cpp:100:13:100:18 | call to source | test.cpp:103:10:103:12 | ref |
 | test.cpp:138:27:138:32 | call to source | test.cpp:140:8:140:8 | y |
 | test.cpp:151:33:151:38 | call to source | test.cpp:144:8:144:8 | s |
@@ -256,19 +256,19 @@ irFlow
 | test.cpp:531:29:531:34 | call to source | test.cpp:532:8:532:9 | * ... |
 | test.cpp:547:9:547:9 | definition of x | test.cpp:536:10:536:11 | * ... |
 | test.cpp:551:9:551:9 | definition of y | test.cpp:541:10:541:10 | y |
-| test.cpp:562:17:562:31 | call to indirect_source indirection | test.cpp:566:10:566:19 | * ... |
-| test.cpp:562:17:562:31 | call to indirect_source indirection | test.cpp:568:10:568:19 | * ... |
-| test.cpp:562:17:562:31 | call to indirect_source indirection | test.cpp:572:10:572:19 | * ... |
-| test.cpp:562:17:562:31 | call to indirect_source indirection | test.cpp:578:10:578:19 | * ... |
-| test.cpp:576:17:576:31 | call to indirect_source indirection | test.cpp:566:10:566:19 | * ... |
-| test.cpp:576:17:576:31 | call to indirect_source indirection | test.cpp:568:10:568:19 | * ... |
-| test.cpp:576:17:576:31 | call to indirect_source indirection | test.cpp:572:10:572:19 | * ... |
-| test.cpp:576:17:576:31 | call to indirect_source indirection | test.cpp:578:10:578:19 | * ... |
-| test.cpp:594:12:594:26 | call to indirect_source indirection | test.cpp:597:8:597:13 | * ... |
+| test.cpp:562:17:562:31 | *call to indirect_source | test.cpp:566:10:566:19 | * ... |
+| test.cpp:562:17:562:31 | *call to indirect_source | test.cpp:568:10:568:19 | * ... |
+| test.cpp:562:17:562:31 | *call to indirect_source | test.cpp:572:10:572:19 | * ... |
+| test.cpp:562:17:562:31 | *call to indirect_source | test.cpp:578:10:578:19 | * ... |
+| test.cpp:576:17:576:31 | *call to indirect_source | test.cpp:566:10:566:19 | * ... |
+| test.cpp:576:17:576:31 | *call to indirect_source | test.cpp:568:10:568:19 | * ... |
+| test.cpp:576:17:576:31 | *call to indirect_source | test.cpp:572:10:572:19 | * ... |
+| test.cpp:576:17:576:31 | *call to indirect_source | test.cpp:578:10:578:19 | * ... |
+| test.cpp:594:12:594:26 | *call to indirect_source | test.cpp:597:8:597:13 | * ... |
 | test.cpp:601:20:601:20 | intPointerSource output argument | test.cpp:603:8:603:9 | * ... |
 | test.cpp:607:20:607:20 | intPointerSource output argument | test.cpp:609:8:609:9 | * ... |
 | test.cpp:614:20:614:20 | intPointerSource output argument | test.cpp:616:8:616:17 | * ... |
-| test.cpp:628:20:628:25 | intPointerSource output argument | test.cpp:629:17:629:22 | buffer indirection |
+| test.cpp:628:20:628:25 | intPointerSource output argument | test.cpp:629:17:629:22 | *buffer |
 | test.cpp:633:18:633:23 | call to source | test.cpp:634:8:634:8 | x |
 | test.cpp:646:7:646:12 | call to source | test.cpp:645:8:645:8 | x |
 | test.cpp:660:7:660:12 | call to source | test.cpp:658:8:658:8 | x |
@@ -283,23 +283,23 @@ irFlow
 | test.cpp:775:32:775:37 | call to source | test.cpp:760:10:760:10 | x |
 | test.cpp:788:31:788:36 | call to source | test.cpp:782:12:782:12 | x |
 | test.cpp:790:31:790:36 | call to source | test.cpp:782:12:782:12 | x |
-| test.cpp:797:22:797:28 | intPointerSource output argument | test.cpp:798:19:798:25 | content indirection |
-| test.cpp:808:25:808:39 | call to indirect_source indirection | test.cpp:813:19:813:35 | * ... indirection |
+| test.cpp:797:22:797:28 | intPointerSource output argument | test.cpp:798:19:798:25 | *content |
+| test.cpp:808:25:808:39 | *call to indirect_source | test.cpp:813:19:813:35 | ** ... |
 | test.cpp:818:26:818:31 | call to source | test.cpp:823:10:823:27 | * ... |
 | test.cpp:832:21:832:26 | call to source | test.cpp:836:10:836:22 | global_direct |
 | test.cpp:842:11:842:16 | call to source | test.cpp:844:8:844:8 | y |
-| test.cpp:846:13:846:27 | call to indirect_source indirection | test.cpp:848:17:848:25 | rpx indirection |
+| test.cpp:846:13:846:27 | *call to indirect_source | test.cpp:848:17:848:25 | *rpx |
 | test.cpp:853:55:853:62 | call to source | test.cpp:854:10:854:36 | * ... |
 | test.cpp:860:54:860:59 | call to source | test.cpp:861:10:861:37 | static_local_pointer_dynamic |
 | test.cpp:872:46:872:51 | call to source | test.cpp:875:10:875:31 | global_pointer_dynamic |
-| test.cpp:880:64:880:83 | indirect_source(1) indirection | test.cpp:883:10:883:45 | static_local_array_static_indirect_1 |
-| test.cpp:881:64:881:83 | indirect_source(2) indirection | test.cpp:886:19:886:54 | static_local_array_static_indirect_2 indirection |
+| test.cpp:880:64:880:83 | indirect_source(1) | test.cpp:883:10:883:45 | static_local_array_static_indirect_1 |
+| test.cpp:881:64:881:83 | *indirect_source(2) | test.cpp:886:19:886:54 | *static_local_array_static_indirect_2 |
 | test.cpp:890:54:890:61 | source | test.cpp:893:10:893:36 | static_local_pointer_static |
-| test.cpp:891:65:891:84 | indirect_source(1) indirection | test.cpp:895:19:895:56 | static_local_pointer_static_indirect_1 indirection |
-| test.cpp:901:56:901:75 | indirect_source(1) indirection | test.cpp:907:10:907:39 | global_array_static_indirect_1 |
-| test.cpp:902:56:902:75 | indirect_source(2) indirection | test.cpp:911:19:911:48 | global_array_static_indirect_2 indirection |
+| test.cpp:891:65:891:84 | *indirect_source(1) | test.cpp:895:19:895:56 | *static_local_pointer_static_indirect_1 |
+| test.cpp:901:56:901:75 | indirect_source(1) | test.cpp:907:10:907:39 | global_array_static_indirect_1 |
+| test.cpp:902:56:902:75 | *indirect_source(2) | test.cpp:911:19:911:48 | *global_array_static_indirect_2 |
 | test.cpp:914:46:914:53 | source | test.cpp:919:10:919:30 | global_pointer_static |
-| test.cpp:915:57:915:76 | indirect_source(1) indirection | test.cpp:921:19:921:50 | global_pointer_static_indirect_1 indirection |
+| test.cpp:915:57:915:76 | *indirect_source(1) | test.cpp:921:19:921:50 | *global_pointer_static_indirect_1 |
 | true_upon_entry.cpp:9:11:9:16 | call to source | true_upon_entry.cpp:13:8:13:8 | x |
 | true_upon_entry.cpp:17:11:17:16 | call to source | true_upon_entry.cpp:21:8:21:8 | x |
 | true_upon_entry.cpp:27:9:27:14 | call to source | true_upon_entry.cpp:29:8:29:8 | x |

--- a/cpp/ql/test/library-tests/dataflow/fields/ir-path-flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/ir-path-flow.expected
@@ -1,1009 +1,1009 @@
 edges
 | A.cpp:23:10:23:10 | c | A.cpp:25:7:25:17 | ... = ... |
-| A.cpp:25:7:25:17 | ... = ... | A.cpp:25:7:25:10 | this indirection [post update] [c] |
+| A.cpp:25:7:25:17 | ... = ... | A.cpp:25:7:25:10 | *this [post update] [c] |
 | A.cpp:27:17:27:17 | c | A.cpp:27:22:27:32 | ... = ... |
-| A.cpp:27:22:27:32 | ... = ... | A.cpp:27:22:27:25 | this indirection [post update] [c] |
-| A.cpp:28:8:28:10 | this indirection [c] | A.cpp:28:23:28:26 | this indirection [c] |
-| A.cpp:28:23:28:26 | this indirection [c] | A.cpp:28:29:28:29 | c |
-| A.cpp:28:29:28:29 | c | A.cpp:28:8:28:10 | get indirection |
+| A.cpp:27:22:27:32 | ... = ... | A.cpp:27:22:27:25 | *this [post update] [c] |
+| A.cpp:28:8:28:10 | *this [c] | A.cpp:28:23:28:26 | *this [c] |
+| A.cpp:28:23:28:26 | *this [c] | A.cpp:28:29:28:29 | c |
+| A.cpp:28:29:28:29 | c | A.cpp:28:8:28:10 | *get |
 | A.cpp:29:23:29:23 | c | A.cpp:31:20:31:20 | c |
-| A.cpp:31:14:31:21 | call to B [c] | A.cpp:29:15:29:18 | make indirection [c] |
+| A.cpp:31:14:31:21 | call to B [c] | A.cpp:29:15:29:18 | **make [c] |
 | A.cpp:31:20:31:20 | c | A.cpp:23:10:23:10 | c |
 | A.cpp:31:20:31:20 | c | A.cpp:31:14:31:21 | call to B [c] |
-| A.cpp:41:5:41:6 | insert output argument | A.cpp:43:10:43:12 | & ... indirection |
+| A.cpp:41:5:41:6 | insert output argument | A.cpp:43:10:43:12 | *& ... |
 | A.cpp:41:15:41:21 | new | A.cpp:41:5:41:6 | insert output argument |
 | A.cpp:41:15:41:21 | new | A.cpp:41:5:41:6 | insert output argument |
 | A.cpp:41:15:41:21 | new | A.cpp:41:15:41:21 | new |
 | A.cpp:47:12:47:18 | new | A.cpp:48:20:48:20 | c |
-| A.cpp:48:12:48:18 | call to make indirection [c] | A.cpp:49:10:49:10 | b indirection [c] |
+| A.cpp:48:12:48:18 | *call to make [c] | A.cpp:49:10:49:10 | *b [c] |
 | A.cpp:48:20:48:20 | c | A.cpp:29:23:29:23 | c |
-| A.cpp:48:20:48:20 | c | A.cpp:48:12:48:18 | call to make indirection [c] |
-| A.cpp:49:10:49:10 | b indirection [c] | A.cpp:49:10:49:13 | c |
-| A.cpp:55:5:55:5 | set output argument [c] | A.cpp:56:10:56:10 | b indirection [c] |
+| A.cpp:48:20:48:20 | c | A.cpp:48:12:48:18 | *call to make [c] |
+| A.cpp:49:10:49:10 | *b [c] | A.cpp:49:10:49:13 | c |
+| A.cpp:55:5:55:5 | set output argument [c] | A.cpp:56:10:56:10 | *b [c] |
 | A.cpp:55:12:55:19 | new | A.cpp:27:17:27:17 | c |
 | A.cpp:55:12:55:19 | new | A.cpp:55:5:55:5 | set output argument [c] |
 | A.cpp:55:12:55:19 | new | A.cpp:55:12:55:19 | new |
-| A.cpp:56:10:56:10 | b indirection [c] | A.cpp:28:8:28:10 | this indirection [c] |
-| A.cpp:56:10:56:10 | b indirection [c] | A.cpp:56:10:56:17 | call to get |
-| A.cpp:57:11:57:24 | call to B [c] | A.cpp:57:11:57:24 | new indirection [c] |
-| A.cpp:57:11:57:24 | new indirection [c] | A.cpp:28:8:28:10 | this indirection [c] |
-| A.cpp:57:11:57:24 | new indirection [c] | A.cpp:57:10:57:32 | call to get |
+| A.cpp:56:10:56:10 | *b [c] | A.cpp:28:8:28:10 | *this [c] |
+| A.cpp:56:10:56:10 | *b [c] | A.cpp:56:10:56:17 | call to get |
+| A.cpp:57:11:57:24 | *new [c] | A.cpp:28:8:28:10 | *this [c] |
+| A.cpp:57:11:57:24 | *new [c] | A.cpp:57:10:57:32 | call to get |
+| A.cpp:57:11:57:24 | call to B [c] | A.cpp:57:11:57:24 | *new [c] |
 | A.cpp:57:17:57:23 | new | A.cpp:23:10:23:10 | c |
 | A.cpp:57:17:57:23 | new | A.cpp:57:11:57:24 | call to B [c] |
 | A.cpp:57:17:57:23 | new | A.cpp:57:17:57:23 | new |
-| A.cpp:64:10:64:15 | call to setOnB indirection [c] | A.cpp:66:10:66:11 | b2 indirection [c] |
-| A.cpp:64:21:64:28 | new | A.cpp:64:10:64:15 | call to setOnB indirection [c] |
+| A.cpp:64:10:64:15 | *call to setOnB [c] | A.cpp:66:10:66:11 | *b2 [c] |
+| A.cpp:64:21:64:28 | new | A.cpp:64:10:64:15 | *call to setOnB [c] |
 | A.cpp:64:21:64:28 | new | A.cpp:64:21:64:28 | new |
 | A.cpp:64:21:64:28 | new | A.cpp:85:26:85:26 | c |
-| A.cpp:66:10:66:11 | b2 indirection [c] | A.cpp:66:10:66:14 | c |
-| A.cpp:73:10:73:19 | call to setOnBWrap indirection [c] | A.cpp:75:10:75:11 | b2 indirection [c] |
-| A.cpp:73:25:73:32 | new | A.cpp:73:10:73:19 | call to setOnBWrap indirection [c] |
+| A.cpp:66:10:66:11 | *b2 [c] | A.cpp:66:10:66:14 | c |
+| A.cpp:73:10:73:19 | *call to setOnBWrap [c] | A.cpp:75:10:75:11 | *b2 [c] |
+| A.cpp:73:25:73:32 | new | A.cpp:73:10:73:19 | *call to setOnBWrap [c] |
 | A.cpp:73:25:73:32 | new | A.cpp:73:25:73:32 | new |
 | A.cpp:73:25:73:32 | new | A.cpp:78:27:78:27 | c |
-| A.cpp:75:10:75:11 | b2 indirection [c] | A.cpp:75:10:75:14 | c |
+| A.cpp:75:10:75:11 | *b2 [c] | A.cpp:75:10:75:14 | c |
 | A.cpp:78:27:78:27 | c | A.cpp:81:21:81:21 | c |
-| A.cpp:81:10:81:15 | call to setOnB indirection [c] | A.cpp:78:6:78:15 | setOnBWrap indirection [c] |
-| A.cpp:81:21:81:21 | c | A.cpp:81:10:81:15 | call to setOnB indirection [c] |
+| A.cpp:81:10:81:15 | *call to setOnB [c] | A.cpp:78:6:78:15 | **setOnBWrap [c] |
+| A.cpp:81:21:81:21 | c | A.cpp:81:10:81:15 | *call to setOnB [c] |
 | A.cpp:81:21:81:21 | c | A.cpp:85:26:85:26 | c |
 | A.cpp:85:26:85:26 | c | A.cpp:90:15:90:15 | c |
-| A.cpp:90:7:90:8 | set output argument [c] | A.cpp:85:9:85:14 | setOnB indirection [c] |
+| A.cpp:90:7:90:8 | set output argument [c] | A.cpp:85:9:85:14 | **setOnB [c] |
 | A.cpp:90:15:90:15 | c | A.cpp:27:17:27:17 | c |
 | A.cpp:90:15:90:15 | c | A.cpp:90:7:90:8 | set output argument [c] |
 | A.cpp:98:12:98:18 | new | A.cpp:100:5:100:13 | ... = ... |
-| A.cpp:100:5:100:6 | c1 indirection [post update] [a] | A.cpp:101:8:101:9 | c1 indirection [a] |
-| A.cpp:100:5:100:13 | ... = ... | A.cpp:100:5:100:6 | c1 indirection [post update] [a] |
-| A.cpp:101:8:101:9 | c1 indirection [a] | A.cpp:103:14:103:14 | c indirection [a] |
-| A.cpp:103:14:103:14 | c indirection [a] | A.cpp:107:12:107:13 | c1 indirection [a] |
-| A.cpp:103:14:103:14 | c indirection [a] | A.cpp:120:12:120:13 | c1 indirection [a] |
-| A.cpp:107:12:107:13 | c1 indirection [a] | A.cpp:107:12:107:16 | a |
-| A.cpp:120:12:120:13 | c1 indirection [a] | A.cpp:120:12:120:16 | a |
+| A.cpp:100:5:100:6 | *c1 [post update] [a] | A.cpp:101:8:101:9 | *c1 [a] |
+| A.cpp:100:5:100:13 | ... = ... | A.cpp:100:5:100:6 | *c1 [post update] [a] |
+| A.cpp:101:8:101:9 | *c1 [a] | A.cpp:103:14:103:14 | *c [a] |
+| A.cpp:103:14:103:14 | *c [a] | A.cpp:107:12:107:13 | *c1 [a] |
+| A.cpp:103:14:103:14 | *c [a] | A.cpp:120:12:120:13 | *c1 [a] |
+| A.cpp:107:12:107:13 | *c1 [a] | A.cpp:107:12:107:16 | a |
+| A.cpp:120:12:120:13 | *c1 [a] | A.cpp:120:12:120:16 | a |
 | A.cpp:126:5:126:5 | set output argument [c] | A.cpp:131:8:131:8 | f7 output argument [c] |
 | A.cpp:126:12:126:18 | new | A.cpp:27:17:27:17 | c |
 | A.cpp:126:12:126:18 | new | A.cpp:126:5:126:5 | set output argument [c] |
 | A.cpp:126:12:126:18 | new | A.cpp:126:12:126:18 | new |
-| A.cpp:131:8:131:8 | f7 output argument [c] | A.cpp:132:10:132:10 | b indirection [c] |
-| A.cpp:132:10:132:10 | b indirection [c] | A.cpp:132:10:132:13 | c |
+| A.cpp:131:8:131:8 | f7 output argument [c] | A.cpp:132:10:132:10 | *b [c] |
+| A.cpp:132:10:132:10 | *b [c] | A.cpp:132:10:132:13 | c |
 | A.cpp:140:13:140:13 | b | A.cpp:143:7:143:31 | ... = ... |
-| A.cpp:142:7:142:7 | b indirection [post update] [c] | A.cpp:143:7:143:31 | ... = ... indirection [c] |
-| A.cpp:142:7:142:7 | b indirection [post update] [c] | A.cpp:151:18:151:18 | D output argument [c] |
-| A.cpp:142:7:142:20 | ... = ... | A.cpp:142:7:142:7 | b indirection [post update] [c] |
+| A.cpp:142:7:142:7 | *b [post update] [c] | A.cpp:143:7:143:31 | *... = ... [c] |
+| A.cpp:142:7:142:7 | *b [post update] [c] | A.cpp:151:18:151:18 | D output argument [c] |
+| A.cpp:142:7:142:20 | ... = ... | A.cpp:142:7:142:7 | *b [post update] [c] |
 | A.cpp:142:14:142:20 | new | A.cpp:142:7:142:20 | ... = ... |
-| A.cpp:143:7:143:10 | this indirection [post update] [b indirection, c] | A.cpp:151:12:151:24 | call to D [b indirection, c] |
-| A.cpp:143:7:143:10 | this indirection [post update] [b] | A.cpp:151:12:151:24 | call to D [b] |
-| A.cpp:143:7:143:31 | ... = ... | A.cpp:143:7:143:10 | this indirection [post update] [b] |
-| A.cpp:143:7:143:31 | ... = ... | A.cpp:143:7:143:10 | this indirection [post update] [b] |
-| A.cpp:143:7:143:31 | ... = ... indirection [c] | A.cpp:143:7:143:10 | this indirection [post update] [b indirection, c] |
+| A.cpp:143:7:143:10 | *this [post update] [*b, c] | A.cpp:151:12:151:24 | call to D [*b, c] |
+| A.cpp:143:7:143:10 | *this [post update] [b] | A.cpp:151:12:151:24 | call to D [b] |
+| A.cpp:143:7:143:31 | *... = ... [c] | A.cpp:143:7:143:10 | *this [post update] [*b, c] |
+| A.cpp:143:7:143:31 | ... = ... | A.cpp:143:7:143:10 | *this [post update] [b] |
+| A.cpp:143:7:143:31 | ... = ... | A.cpp:143:7:143:10 | *this [post update] [b] |
 | A.cpp:143:25:143:31 | new | A.cpp:143:7:143:31 | ... = ... |
 | A.cpp:150:12:150:18 | new | A.cpp:151:18:151:18 | b |
-| A.cpp:151:12:151:24 | call to D [b indirection, c] | A.cpp:153:10:153:10 | d indirection [b indirection, c] |
-| A.cpp:151:12:151:24 | call to D [b] | A.cpp:152:10:152:10 | d indirection [b] |
-| A.cpp:151:18:151:18 | D output argument [c] | A.cpp:154:10:154:10 | b indirection [c] |
+| A.cpp:151:12:151:24 | call to D [*b, c] | A.cpp:153:10:153:10 | *d [*b, c] |
+| A.cpp:151:12:151:24 | call to D [b] | A.cpp:152:10:152:10 | *d [b] |
+| A.cpp:151:18:151:18 | D output argument [c] | A.cpp:154:10:154:10 | *b [c] |
 | A.cpp:151:18:151:18 | b | A.cpp:140:13:140:13 | b |
 | A.cpp:151:18:151:18 | b | A.cpp:151:12:151:24 | call to D [b] |
-| A.cpp:152:10:152:10 | d indirection [b] | A.cpp:152:10:152:13 | b |
-| A.cpp:153:10:153:10 | d indirection [b indirection, c] | A.cpp:153:13:153:13 | b indirection [c] |
-| A.cpp:153:13:153:13 | b indirection [c] | A.cpp:153:10:153:16 | c |
-| A.cpp:154:10:154:10 | b indirection [c] | A.cpp:154:10:154:13 | c |
+| A.cpp:152:10:152:10 | *d [b] | A.cpp:152:10:152:13 | b |
+| A.cpp:153:10:153:10 | *d [*b, c] | A.cpp:153:13:153:13 | *b [c] |
+| A.cpp:153:13:153:13 | *b [c] | A.cpp:153:10:153:16 | c |
+| A.cpp:154:10:154:10 | *b [c] | A.cpp:154:10:154:13 | c |
 | A.cpp:159:12:159:18 | new | A.cpp:160:29:160:29 | b |
-| A.cpp:160:18:160:60 | call to MyList [head] | A.cpp:161:38:161:39 | l1 indirection [head] |
+| A.cpp:160:18:160:60 | call to MyList [head] | A.cpp:161:38:161:39 | *l1 [head] |
 | A.cpp:160:29:160:29 | b | A.cpp:160:18:160:60 | call to MyList [head] |
 | A.cpp:160:29:160:29 | b | A.cpp:181:15:181:21 | newHead |
-| A.cpp:161:18:161:40 | call to MyList [next indirection, head] | A.cpp:162:38:162:39 | l2 indirection [next indirection, head] |
-| A.cpp:161:38:161:39 | l1 indirection [head] | A.cpp:161:18:161:40 | call to MyList [next indirection, head] |
-| A.cpp:161:38:161:39 | l1 indirection [head] | A.cpp:181:32:181:35 | next indirection [head] |
-| A.cpp:162:18:162:40 | call to MyList [next indirection, next indirection, head] | A.cpp:165:10:165:11 | l3 indirection [next indirection, next indirection, head] |
-| A.cpp:162:18:162:40 | call to MyList [next indirection, next indirection, head] | A.cpp:167:44:167:44 | l indirection [next indirection, next indirection, head] |
-| A.cpp:162:38:162:39 | l2 indirection [next indirection, head] | A.cpp:162:18:162:40 | call to MyList [next indirection, next indirection, head] |
-| A.cpp:162:38:162:39 | l2 indirection [next indirection, head] | A.cpp:181:32:181:35 | next indirection [next indirection, head] |
-| A.cpp:165:10:165:11 | l3 indirection [next indirection, next indirection, head] | A.cpp:165:14:165:17 | next indirection [next indirection, head] |
-| A.cpp:165:14:165:17 | next indirection [next indirection, head] | A.cpp:165:20:165:23 | next indirection [head] |
-| A.cpp:165:20:165:23 | next indirection [head] | A.cpp:165:10:165:29 | head |
-| A.cpp:167:44:167:44 | l indirection [next indirection, head] | A.cpp:167:47:167:50 | next indirection [head] |
-| A.cpp:167:44:167:44 | l indirection [next indirection, next indirection, head] | A.cpp:167:47:167:50 | next indirection [next indirection, head] |
-| A.cpp:167:47:167:50 | next indirection [head] | A.cpp:169:12:169:12 | l indirection [head] |
-| A.cpp:167:47:167:50 | next indirection [next indirection, head] | A.cpp:167:44:167:44 | l indirection [next indirection, head] |
-| A.cpp:169:12:169:12 | l indirection [head] | A.cpp:169:12:169:18 | head |
+| A.cpp:161:18:161:40 | call to MyList [*next, head] | A.cpp:162:38:162:39 | *l2 [*next, head] |
+| A.cpp:161:38:161:39 | *l1 [head] | A.cpp:161:18:161:40 | call to MyList [*next, head] |
+| A.cpp:161:38:161:39 | *l1 [head] | A.cpp:181:32:181:35 | *next [head] |
+| A.cpp:162:18:162:40 | call to MyList [*next, *next, head] | A.cpp:165:10:165:11 | *l3 [*next, *next, head] |
+| A.cpp:162:18:162:40 | call to MyList [*next, *next, head] | A.cpp:167:44:167:44 | *l [*next, *next, head] |
+| A.cpp:162:38:162:39 | *l2 [*next, head] | A.cpp:162:18:162:40 | call to MyList [*next, *next, head] |
+| A.cpp:162:38:162:39 | *l2 [*next, head] | A.cpp:181:32:181:35 | *next [*next, head] |
+| A.cpp:165:10:165:11 | *l3 [*next, *next, head] | A.cpp:165:14:165:17 | *next [*next, head] |
+| A.cpp:165:14:165:17 | *next [*next, head] | A.cpp:165:20:165:23 | *next [head] |
+| A.cpp:165:20:165:23 | *next [head] | A.cpp:165:10:165:29 | head |
+| A.cpp:167:44:167:44 | *l [*next, *next, head] | A.cpp:167:47:167:50 | *next [*next, head] |
+| A.cpp:167:44:167:44 | *l [*next, head] | A.cpp:167:47:167:50 | *next [head] |
+| A.cpp:167:47:167:50 | *next [*next, head] | A.cpp:167:44:167:44 | *l [*next, head] |
+| A.cpp:167:47:167:50 | *next [head] | A.cpp:169:12:169:12 | *l [head] |
+| A.cpp:169:12:169:12 | *l [head] | A.cpp:169:12:169:18 | head |
 | A.cpp:181:15:181:21 | newHead | A.cpp:183:7:183:20 | ... = ... |
-| A.cpp:181:32:181:35 | next indirection [head] | A.cpp:184:7:184:23 | ... = ... indirection [head] |
-| A.cpp:181:32:181:35 | next indirection [next indirection, head] | A.cpp:184:7:184:23 | ... = ... indirection [next indirection, head] |
-| A.cpp:183:7:183:20 | ... = ... | A.cpp:183:7:183:10 | this indirection [post update] [head] |
-| A.cpp:184:7:184:23 | ... = ... indirection [head] | A.cpp:184:7:184:10 | this indirection [post update] [next indirection, head] |
-| A.cpp:184:7:184:23 | ... = ... indirection [next indirection, head] | A.cpp:184:7:184:10 | this indirection [post update] [next indirection, next indirection, head] |
+| A.cpp:181:32:181:35 | *next [*next, head] | A.cpp:184:7:184:23 | *... = ... [*next, head] |
+| A.cpp:181:32:181:35 | *next [head] | A.cpp:184:7:184:23 | *... = ... [head] |
+| A.cpp:183:7:183:20 | ... = ... | A.cpp:183:7:183:10 | *this [post update] [head] |
+| A.cpp:184:7:184:23 | *... = ... [*next, head] | A.cpp:184:7:184:10 | *this [post update] [*next, *next, head] |
+| A.cpp:184:7:184:23 | *... = ... [head] | A.cpp:184:7:184:10 | *this [post update] [*next, head] |
 | B.cpp:6:15:6:24 | new | B.cpp:7:25:7:25 | e |
-| B.cpp:7:16:7:35 | call to Box1 [elem1] | B.cpp:8:25:8:26 | b1 indirection [elem1] |
+| B.cpp:7:16:7:35 | call to Box1 [elem1] | B.cpp:8:25:8:26 | *b1 [elem1] |
 | B.cpp:7:25:7:25 | e | B.cpp:7:16:7:35 | call to Box1 [elem1] |
 | B.cpp:7:25:7:25 | e | B.cpp:33:16:33:17 | e1 |
-| B.cpp:8:16:8:27 | call to Box2 [box1 indirection, elem1] | B.cpp:9:10:9:11 | b2 indirection [box1 indirection, elem1] |
-| B.cpp:8:25:8:26 | b1 indirection [elem1] | B.cpp:8:16:8:27 | call to Box2 [box1 indirection, elem1] |
-| B.cpp:8:25:8:26 | b1 indirection [elem1] | B.cpp:44:16:44:17 | b1 indirection [elem1] |
-| B.cpp:9:10:9:11 | b2 indirection [box1 indirection, elem1] | B.cpp:9:14:9:17 | box1 indirection [elem1] |
-| B.cpp:9:14:9:17 | box1 indirection [elem1] | B.cpp:9:10:9:24 | elem1 |
+| B.cpp:8:16:8:27 | call to Box2 [*box1, elem1] | B.cpp:9:10:9:11 | *b2 [*box1, elem1] |
+| B.cpp:8:25:8:26 | *b1 [elem1] | B.cpp:8:16:8:27 | call to Box2 [*box1, elem1] |
+| B.cpp:8:25:8:26 | *b1 [elem1] | B.cpp:44:16:44:17 | *b1 [elem1] |
+| B.cpp:9:10:9:11 | *b2 [*box1, elem1] | B.cpp:9:14:9:17 | *box1 [elem1] |
+| B.cpp:9:14:9:17 | *box1 [elem1] | B.cpp:9:10:9:24 | elem1 |
 | B.cpp:15:15:15:27 | new | B.cpp:16:37:16:37 | e |
-| B.cpp:16:16:16:38 | call to Box1 [elem2] | B.cpp:17:25:17:26 | b1 indirection [elem2] |
+| B.cpp:16:16:16:38 | call to Box1 [elem2] | B.cpp:17:25:17:26 | *b1 [elem2] |
 | B.cpp:16:37:16:37 | e | B.cpp:16:16:16:38 | call to Box1 [elem2] |
 | B.cpp:16:37:16:37 | e | B.cpp:33:26:33:27 | e2 |
-| B.cpp:17:16:17:27 | call to Box2 [box1 indirection, elem2] | B.cpp:19:10:19:11 | b2 indirection [box1 indirection, elem2] |
-| B.cpp:17:25:17:26 | b1 indirection [elem2] | B.cpp:17:16:17:27 | call to Box2 [box1 indirection, elem2] |
-| B.cpp:17:25:17:26 | b1 indirection [elem2] | B.cpp:44:16:44:17 | b1 indirection [elem2] |
-| B.cpp:19:10:19:11 | b2 indirection [box1 indirection, elem2] | B.cpp:19:14:19:17 | box1 indirection [elem2] |
-| B.cpp:19:14:19:17 | box1 indirection [elem2] | B.cpp:19:10:19:24 | elem2 |
+| B.cpp:17:16:17:27 | call to Box2 [*box1, elem2] | B.cpp:19:10:19:11 | *b2 [*box1, elem2] |
+| B.cpp:17:25:17:26 | *b1 [elem2] | B.cpp:17:16:17:27 | call to Box2 [*box1, elem2] |
+| B.cpp:17:25:17:26 | *b1 [elem2] | B.cpp:44:16:44:17 | *b1 [elem2] |
+| B.cpp:19:10:19:11 | *b2 [*box1, elem2] | B.cpp:19:14:19:17 | *box1 [elem2] |
+| B.cpp:19:14:19:17 | *box1 [elem2] | B.cpp:19:10:19:24 | elem2 |
 | B.cpp:33:16:33:17 | e1 | B.cpp:35:7:35:22 | ... = ... |
 | B.cpp:33:26:33:27 | e2 | B.cpp:36:7:36:22 | ... = ... |
-| B.cpp:35:7:35:22 | ... = ... | B.cpp:35:7:35:10 | this indirection [post update] [elem1] |
-| B.cpp:36:7:36:22 | ... = ... | B.cpp:36:7:36:10 | this indirection [post update] [elem2] |
-| B.cpp:44:16:44:17 | b1 indirection [elem1] | B.cpp:46:7:46:21 | ... = ... indirection [elem1] |
-| B.cpp:44:16:44:17 | b1 indirection [elem2] | B.cpp:46:7:46:21 | ... = ... indirection [elem2] |
-| B.cpp:46:7:46:21 | ... = ... indirection [elem1] | B.cpp:46:7:46:10 | this indirection [post update] [box1 indirection, elem1] |
-| B.cpp:46:7:46:21 | ... = ... indirection [elem2] | B.cpp:46:7:46:10 | this indirection [post update] [box1 indirection, elem2] |
-| C.cpp:18:12:18:18 | call to C [s1] | C.cpp:19:5:19:5 | c indirection [s1] |
-| C.cpp:18:12:18:18 | call to C [s3] | C.cpp:19:5:19:5 | c indirection [s3] |
-| C.cpp:19:5:19:5 | c indirection [s1] | C.cpp:27:8:27:11 | this indirection [s1] |
-| C.cpp:19:5:19:5 | c indirection [s3] | C.cpp:27:8:27:11 | this indirection [s3] |
-| C.cpp:22:3:22:3 | this indirection [post update] [s1] | C.cpp:18:12:18:18 | call to C [s1] |
-| C.cpp:22:12:22:21 | new | C.cpp:22:3:22:3 | this indirection [post update] [s1] |
+| B.cpp:35:7:35:22 | ... = ... | B.cpp:35:7:35:10 | *this [post update] [elem1] |
+| B.cpp:36:7:36:22 | ... = ... | B.cpp:36:7:36:10 | *this [post update] [elem2] |
+| B.cpp:44:16:44:17 | *b1 [elem1] | B.cpp:46:7:46:21 | *... = ... [elem1] |
+| B.cpp:44:16:44:17 | *b1 [elem2] | B.cpp:46:7:46:21 | *... = ... [elem2] |
+| B.cpp:46:7:46:21 | *... = ... [elem1] | B.cpp:46:7:46:10 | *this [post update] [*box1, elem1] |
+| B.cpp:46:7:46:21 | *... = ... [elem2] | B.cpp:46:7:46:10 | *this [post update] [*box1, elem2] |
+| C.cpp:18:12:18:18 | call to C [s1] | C.cpp:19:5:19:5 | *c [s1] |
+| C.cpp:18:12:18:18 | call to C [s3] | C.cpp:19:5:19:5 | *c [s3] |
+| C.cpp:19:5:19:5 | *c [s1] | C.cpp:27:8:27:11 | *this [s1] |
+| C.cpp:19:5:19:5 | *c [s3] | C.cpp:27:8:27:11 | *this [s3] |
+| C.cpp:22:3:22:3 | *this [post update] [s1] | C.cpp:18:12:18:18 | call to C [s1] |
+| C.cpp:22:12:22:21 | new | C.cpp:22:3:22:3 | *this [post update] [s1] |
 | C.cpp:22:12:22:21 | new | C.cpp:22:12:22:21 | new |
-| C.cpp:24:5:24:8 | this indirection [post update] [s3] | C.cpp:18:12:18:18 | call to C [s3] |
-| C.cpp:24:5:24:25 | ... = ... | C.cpp:24:5:24:8 | this indirection [post update] [s3] |
+| C.cpp:24:5:24:8 | *this [post update] [s3] | C.cpp:18:12:18:18 | call to C [s3] |
+| C.cpp:24:5:24:25 | ... = ... | C.cpp:24:5:24:8 | *this [post update] [s3] |
 | C.cpp:24:16:24:25 | new | C.cpp:24:5:24:25 | ... = ... |
-| C.cpp:27:8:27:11 | this indirection [s1] | C.cpp:29:10:29:11 | this indirection [s1] |
-| C.cpp:27:8:27:11 | this indirection [s3] | C.cpp:31:10:31:11 | this indirection [s3] |
-| C.cpp:29:10:29:11 | this indirection [s1] | C.cpp:29:10:29:11 | s1 |
-| C.cpp:31:10:31:11 | this indirection [s3] | C.cpp:31:10:31:11 | s3 |
-| D.cpp:10:11:10:17 | this indirection [elem] | D.cpp:10:30:10:33 | this indirection [elem] |
-| D.cpp:10:30:10:33 | elem | D.cpp:10:11:10:17 | getElem indirection |
-| D.cpp:10:30:10:33 | this indirection [elem] | D.cpp:10:30:10:33 | elem |
+| C.cpp:27:8:27:11 | *this [s1] | C.cpp:29:10:29:11 | *this [s1] |
+| C.cpp:27:8:27:11 | *this [s3] | C.cpp:31:10:31:11 | *this [s3] |
+| C.cpp:29:10:29:11 | *this [s1] | C.cpp:29:10:29:11 | s1 |
+| C.cpp:31:10:31:11 | *this [s3] | C.cpp:31:10:31:11 | s3 |
+| D.cpp:10:11:10:17 | *this [elem] | D.cpp:10:30:10:33 | *this [elem] |
+| D.cpp:10:30:10:33 | *this [elem] | D.cpp:10:30:10:33 | elem |
+| D.cpp:10:30:10:33 | elem | D.cpp:10:11:10:17 | *getElem |
 | D.cpp:11:24:11:24 | e | D.cpp:11:29:11:36 | ... = ... |
-| D.cpp:11:29:11:36 | ... = ... | D.cpp:11:29:11:32 | this indirection [post update] [elem] |
-| D.cpp:17:11:17:17 | this indirection [box indirection, elem] | D.cpp:17:30:17:32 | this indirection [box indirection, elem] |
-| D.cpp:17:30:17:32 | box indirection [elem] | D.cpp:17:11:17:17 | getBox1 indirection [elem] |
-| D.cpp:17:30:17:32 | this indirection [box indirection, elem] | D.cpp:17:30:17:32 | box indirection [elem] |
-| D.cpp:21:30:21:31 | b2 indirection [box indirection, elem] | D.cpp:22:10:22:11 | b2 indirection [box indirection, elem] |
-| D.cpp:22:10:22:11 | b2 indirection [box indirection, elem] | D.cpp:17:11:17:17 | this indirection [box indirection, elem] |
-| D.cpp:22:10:22:11 | b2 indirection [box indirection, elem] | D.cpp:22:14:22:20 | call to getBox1 indirection [elem] |
-| D.cpp:22:14:22:20 | call to getBox1 indirection [elem] | D.cpp:10:11:10:17 | this indirection [elem] |
-| D.cpp:22:14:22:20 | call to getBox1 indirection [elem] | D.cpp:22:10:22:33 | call to getElem |
+| D.cpp:11:29:11:36 | ... = ... | D.cpp:11:29:11:32 | *this [post update] [elem] |
+| D.cpp:17:11:17:17 | *this [*box, elem] | D.cpp:17:30:17:32 | *this [*box, elem] |
+| D.cpp:17:30:17:32 | *box [elem] | D.cpp:17:11:17:17 | **getBox1 [elem] |
+| D.cpp:17:30:17:32 | *this [*box, elem] | D.cpp:17:30:17:32 | *box [elem] |
+| D.cpp:21:30:21:31 | *b2 [*box, elem] | D.cpp:22:10:22:11 | *b2 [*box, elem] |
+| D.cpp:22:10:22:11 | *b2 [*box, elem] | D.cpp:17:11:17:17 | *this [*box, elem] |
+| D.cpp:22:10:22:11 | *b2 [*box, elem] | D.cpp:22:14:22:20 | *call to getBox1 [elem] |
+| D.cpp:22:14:22:20 | *call to getBox1 [elem] | D.cpp:10:11:10:17 | *this [elem] |
+| D.cpp:22:14:22:20 | *call to getBox1 [elem] | D.cpp:22:10:22:33 | call to getElem |
 | D.cpp:28:15:28:24 | new | D.cpp:30:5:30:20 | ... = ... |
-| D.cpp:30:5:30:5 | b indirection [post update] [box indirection, elem] | D.cpp:31:14:31:14 | b indirection [box indirection, elem] |
-| D.cpp:30:5:30:20 | ... = ... | D.cpp:30:8:30:10 | box indirection [post update] [elem] |
-| D.cpp:30:8:30:10 | box indirection [post update] [elem] | D.cpp:30:5:30:5 | b indirection [post update] [box indirection, elem] |
-| D.cpp:31:14:31:14 | b indirection [box indirection, elem] | D.cpp:21:30:21:31 | b2 indirection [box indirection, elem] |
+| D.cpp:30:5:30:5 | *b [post update] [*box, elem] | D.cpp:31:14:31:14 | *b [*box, elem] |
+| D.cpp:30:5:30:20 | ... = ... | D.cpp:30:8:30:10 | *box [post update] [elem] |
+| D.cpp:30:8:30:10 | *box [post update] [elem] | D.cpp:30:5:30:5 | *b [post update] [*box, elem] |
+| D.cpp:31:14:31:14 | *b [*box, elem] | D.cpp:21:30:21:31 | *b2 [*box, elem] |
 | D.cpp:35:15:35:24 | new | D.cpp:37:21:37:21 | e |
-| D.cpp:37:5:37:5 | b indirection [post update] [box indirection, elem] | D.cpp:38:14:38:14 | b indirection [box indirection, elem] |
-| D.cpp:37:8:37:10 | setElem output argument [elem] | D.cpp:37:5:37:5 | b indirection [post update] [box indirection, elem] |
+| D.cpp:37:5:37:5 | *b [post update] [*box, elem] | D.cpp:38:14:38:14 | *b [*box, elem] |
+| D.cpp:37:8:37:10 | setElem output argument [elem] | D.cpp:37:5:37:5 | *b [post update] [*box, elem] |
 | D.cpp:37:21:37:21 | e | D.cpp:11:24:11:24 | e |
 | D.cpp:37:21:37:21 | e | D.cpp:37:8:37:10 | setElem output argument [elem] |
-| D.cpp:38:14:38:14 | b indirection [box indirection, elem] | D.cpp:21:30:21:31 | b2 indirection [box indirection, elem] |
+| D.cpp:38:14:38:14 | *b [*box, elem] | D.cpp:21:30:21:31 | *b2 [*box, elem] |
 | D.cpp:42:15:42:24 | new | D.cpp:44:5:44:26 | ... = ... |
-| D.cpp:44:5:44:5 | getBox1 output argument [box indirection, elem] | D.cpp:45:14:45:14 | b indirection [box indirection, elem] |
-| D.cpp:44:5:44:26 | ... = ... | D.cpp:44:8:44:14 | call to getBox1 indirection [post update] [elem] |
-| D.cpp:44:8:44:14 | call to getBox1 indirection [post update] [elem] | D.cpp:44:5:44:5 | getBox1 output argument [box indirection, elem] |
-| D.cpp:45:14:45:14 | b indirection [box indirection, elem] | D.cpp:21:30:21:31 | b2 indirection [box indirection, elem] |
+| D.cpp:44:5:44:5 | getBox1 output argument [*box, elem] | D.cpp:45:14:45:14 | *b [*box, elem] |
+| D.cpp:44:5:44:26 | ... = ... | D.cpp:44:8:44:14 | *call to getBox1 [post update] [elem] |
+| D.cpp:44:8:44:14 | *call to getBox1 [post update] [elem] | D.cpp:44:5:44:5 | getBox1 output argument [*box, elem] |
+| D.cpp:45:14:45:14 | *b [*box, elem] | D.cpp:21:30:21:31 | *b2 [*box, elem] |
 | D.cpp:49:15:49:24 | new | D.cpp:51:27:51:27 | e |
-| D.cpp:51:5:51:5 | getBox1 output argument [box indirection, elem] | D.cpp:52:14:52:14 | b indirection [box indirection, elem] |
-| D.cpp:51:8:51:14 | setElem output argument [elem] | D.cpp:51:5:51:5 | getBox1 output argument [box indirection, elem] |
+| D.cpp:51:5:51:5 | getBox1 output argument [*box, elem] | D.cpp:52:14:52:14 | *b [*box, elem] |
+| D.cpp:51:8:51:14 | setElem output argument [elem] | D.cpp:51:5:51:5 | getBox1 output argument [*box, elem] |
 | D.cpp:51:27:51:27 | e | D.cpp:11:24:11:24 | e |
 | D.cpp:51:27:51:27 | e | D.cpp:51:8:51:14 | setElem output argument [elem] |
-| D.cpp:52:14:52:14 | b indirection [box indirection, elem] | D.cpp:21:30:21:31 | b2 indirection [box indirection, elem] |
+| D.cpp:52:14:52:14 | *b [*box, elem] | D.cpp:21:30:21:31 | *b2 [*box, elem] |
 | D.cpp:56:15:56:24 | new | D.cpp:58:5:58:27 | ... = ... |
-| D.cpp:58:5:58:12 | boxfield indirection [post update] [box indirection, elem] | D.cpp:58:5:58:12 | this indirection [post update] [boxfield indirection, box indirection, elem] |
-| D.cpp:58:5:58:12 | this indirection [post update] [boxfield indirection, box indirection, elem] | D.cpp:59:5:59:7 | this indirection [boxfield indirection, box indirection, elem] |
-| D.cpp:58:5:58:27 | ... = ... | D.cpp:58:15:58:17 | box indirection [post update] [elem] |
-| D.cpp:58:15:58:17 | box indirection [post update] [elem] | D.cpp:58:5:58:12 | boxfield indirection [post update] [box indirection, elem] |
-| D.cpp:59:5:59:7 | this indirection [boxfield indirection, box indirection, elem] | D.cpp:63:8:63:10 | this indirection [boxfield indirection, box indirection, elem] |
-| D.cpp:63:8:63:10 | this indirection [boxfield indirection, box indirection, elem] | D.cpp:64:10:64:17 | this indirection [boxfield indirection, box indirection, elem] |
-| D.cpp:64:10:64:17 | boxfield indirection [box indirection, elem] | D.cpp:64:20:64:22 | box indirection [elem] |
-| D.cpp:64:10:64:17 | this indirection [boxfield indirection, box indirection, elem] | D.cpp:64:10:64:17 | boxfield indirection [box indirection, elem] |
-| D.cpp:64:20:64:22 | box indirection [elem] | D.cpp:64:10:64:28 | elem |
-| E.cpp:19:27:19:27 | p indirection [data, buffer indirection] | E.cpp:21:10:21:10 | p indirection [data, buffer indirection] |
-| E.cpp:21:10:21:10 | p indirection [data, buffer indirection] | E.cpp:21:13:21:16 | data indirection [buffer indirection] |
-| E.cpp:21:13:21:16 | data indirection [buffer indirection] | E.cpp:21:18:21:23 | buffer indirection |
-| E.cpp:28:21:28:23 | argument_source output argument | E.cpp:31:10:31:12 | raw indirection |
-| E.cpp:29:21:29:21 | b indirection [post update] [buffer indirection] | E.cpp:32:10:32:10 | b indirection [buffer indirection] |
-| E.cpp:29:21:29:29 | argument_source output argument | E.cpp:29:21:29:21 | b indirection [post update] [buffer indirection] |
-| E.cpp:30:21:30:21 | p indirection [post update] [data, buffer indirection] | E.cpp:33:18:33:19 | & ... indirection [data, buffer indirection] |
-| E.cpp:30:21:30:33 | argument_source output argument | E.cpp:30:23:30:26 | data indirection [post update] [buffer indirection] |
-| E.cpp:30:23:30:26 | data indirection [post update] [buffer indirection] | E.cpp:30:21:30:21 | p indirection [post update] [data, buffer indirection] |
-| E.cpp:32:10:32:10 | b indirection [buffer indirection] | E.cpp:32:13:32:18 | buffer indirection |
-| E.cpp:33:18:33:19 | & ... indirection [data, buffer indirection] | E.cpp:19:27:19:27 | p indirection [data, buffer indirection] |
-| aliasing.cpp:9:3:9:3 | s indirection [post update] [m1] | aliasing.cpp:25:17:25:19 | pointerSetter output argument [m1] |
-| aliasing.cpp:9:3:9:22 | ... = ... | aliasing.cpp:9:3:9:3 | s indirection [post update] [m1] |
+| D.cpp:58:5:58:12 | *boxfield [post update] [*box, elem] | D.cpp:58:5:58:12 | *this [post update] [*boxfield, *box, elem] |
+| D.cpp:58:5:58:12 | *this [post update] [*boxfield, *box, elem] | D.cpp:59:5:59:7 | *this [*boxfield, *box, elem] |
+| D.cpp:58:5:58:27 | ... = ... | D.cpp:58:15:58:17 | *box [post update] [elem] |
+| D.cpp:58:15:58:17 | *box [post update] [elem] | D.cpp:58:5:58:12 | *boxfield [post update] [*box, elem] |
+| D.cpp:59:5:59:7 | *this [*boxfield, *box, elem] | D.cpp:63:8:63:10 | *this [*boxfield, *box, elem] |
+| D.cpp:63:8:63:10 | *this [*boxfield, *box, elem] | D.cpp:64:10:64:17 | *this [*boxfield, *box, elem] |
+| D.cpp:64:10:64:17 | *boxfield [*box, elem] | D.cpp:64:20:64:22 | *box [elem] |
+| D.cpp:64:10:64:17 | *this [*boxfield, *box, elem] | D.cpp:64:10:64:17 | *boxfield [*box, elem] |
+| D.cpp:64:20:64:22 | *box [elem] | D.cpp:64:10:64:28 | elem |
+| E.cpp:19:27:19:27 | *p [data, *buffer] | E.cpp:21:10:21:10 | *p [data, *buffer] |
+| E.cpp:21:10:21:10 | *p [data, *buffer] | E.cpp:21:13:21:16 | *data [*buffer] |
+| E.cpp:21:13:21:16 | *data [*buffer] | E.cpp:21:18:21:23 | *buffer |
+| E.cpp:28:21:28:23 | argument_source output argument | E.cpp:31:10:31:12 | *raw |
+| E.cpp:29:21:29:21 | *b [post update] [*buffer] | E.cpp:32:10:32:10 | *b [*buffer] |
+| E.cpp:29:21:29:29 | argument_source output argument | E.cpp:29:21:29:21 | *b [post update] [*buffer] |
+| E.cpp:30:21:30:21 | *p [post update] [data, *buffer] | E.cpp:33:18:33:19 | *& ... [data, *buffer] |
+| E.cpp:30:21:30:33 | argument_source output argument | E.cpp:30:23:30:26 | *data [post update] [*buffer] |
+| E.cpp:30:23:30:26 | *data [post update] [*buffer] | E.cpp:30:21:30:21 | *p [post update] [data, *buffer] |
+| E.cpp:32:10:32:10 | *b [*buffer] | E.cpp:32:13:32:18 | *buffer |
+| E.cpp:33:18:33:19 | *& ... [data, *buffer] | E.cpp:19:27:19:27 | *p [data, *buffer] |
+| aliasing.cpp:9:3:9:3 | *s [post update] [m1] | aliasing.cpp:25:17:25:19 | pointerSetter output argument [m1] |
+| aliasing.cpp:9:3:9:22 | ... = ... | aliasing.cpp:9:3:9:3 | *s [post update] [m1] |
 | aliasing.cpp:9:11:9:20 | call to user_input | aliasing.cpp:9:3:9:22 | ... = ... |
-| aliasing.cpp:13:3:13:3 | s indirection [post update] [m1] | aliasing.cpp:26:19:26:20 | referenceSetter output argument [m1] |
-| aliasing.cpp:13:3:13:21 | ... = ... | aliasing.cpp:13:3:13:3 | s indirection [post update] [m1] |
+| aliasing.cpp:13:3:13:3 | *s [post update] [m1] | aliasing.cpp:26:19:26:20 | referenceSetter output argument [m1] |
+| aliasing.cpp:13:3:13:21 | ... = ... | aliasing.cpp:13:3:13:3 | *s [post update] [m1] |
 | aliasing.cpp:13:10:13:19 | call to user_input | aliasing.cpp:13:3:13:21 | ... = ... |
-| aliasing.cpp:25:17:25:19 | pointerSetter output argument [m1] | aliasing.cpp:29:8:29:9 | s1 indirection [m1] |
-| aliasing.cpp:26:19:26:20 | referenceSetter output argument [m1] | aliasing.cpp:30:8:30:9 | s2 indirection [m1] |
-| aliasing.cpp:29:8:29:9 | s1 indirection [m1] | aliasing.cpp:29:11:29:12 | m1 |
-| aliasing.cpp:30:8:30:9 | s2 indirection [m1] | aliasing.cpp:30:11:30:12 | m1 |
-| aliasing.cpp:60:3:60:4 | s2 indirection [post update] [m1] | aliasing.cpp:62:8:62:12 | copy2 indirection [m1] |
-| aliasing.cpp:60:3:60:22 | ... = ... | aliasing.cpp:60:3:60:4 | s2 indirection [post update] [m1] |
+| aliasing.cpp:25:17:25:19 | pointerSetter output argument [m1] | aliasing.cpp:29:8:29:9 | *s1 [m1] |
+| aliasing.cpp:26:19:26:20 | referenceSetter output argument [m1] | aliasing.cpp:30:8:30:9 | *s2 [m1] |
+| aliasing.cpp:29:8:29:9 | *s1 [m1] | aliasing.cpp:29:11:29:12 | m1 |
+| aliasing.cpp:30:8:30:9 | *s2 [m1] | aliasing.cpp:30:11:30:12 | m1 |
+| aliasing.cpp:60:3:60:4 | *s2 [post update] [m1] | aliasing.cpp:62:8:62:12 | *copy2 [m1] |
+| aliasing.cpp:60:3:60:22 | ... = ... | aliasing.cpp:60:3:60:4 | *s2 [post update] [m1] |
 | aliasing.cpp:60:11:60:20 | call to user_input | aliasing.cpp:60:3:60:22 | ... = ... |
-| aliasing.cpp:62:8:62:12 | copy2 indirection [m1] | aliasing.cpp:62:14:62:15 | m1 |
-| aliasing.cpp:92:3:92:3 | w indirection [post update] [s, m1] | aliasing.cpp:93:8:93:8 | w indirection [s, m1] |
-| aliasing.cpp:92:3:92:23 | ... = ... | aliasing.cpp:92:5:92:5 | s indirection [post update] [m1] |
-| aliasing.cpp:92:5:92:5 | s indirection [post update] [m1] | aliasing.cpp:92:3:92:3 | w indirection [post update] [s, m1] |
+| aliasing.cpp:62:8:62:12 | *copy2 [m1] | aliasing.cpp:62:14:62:15 | m1 |
+| aliasing.cpp:92:3:92:3 | *w [post update] [s, m1] | aliasing.cpp:93:8:93:8 | *w [s, m1] |
+| aliasing.cpp:92:3:92:23 | ... = ... | aliasing.cpp:92:5:92:5 | *s [post update] [m1] |
+| aliasing.cpp:92:5:92:5 | *s [post update] [m1] | aliasing.cpp:92:3:92:3 | *w [post update] [s, m1] |
 | aliasing.cpp:92:12:92:21 | call to user_input | aliasing.cpp:92:3:92:23 | ... = ... |
-| aliasing.cpp:93:8:93:8 | w indirection [s, m1] | aliasing.cpp:93:10:93:10 | s indirection [m1] |
-| aliasing.cpp:93:10:93:10 | s indirection [m1] | aliasing.cpp:93:12:93:13 | m1 |
-| aliasing.cpp:98:3:98:3 | s indirection [post update] [m1] | aliasing.cpp:101:14:101:19 | s_copy indirection [m1] |
-| aliasing.cpp:98:3:98:21 | ... = ... | aliasing.cpp:98:3:98:3 | s indirection [post update] [m1] |
+| aliasing.cpp:93:8:93:8 | *w [s, m1] | aliasing.cpp:93:10:93:10 | *s [m1] |
+| aliasing.cpp:93:10:93:10 | *s [m1] | aliasing.cpp:93:12:93:13 | m1 |
+| aliasing.cpp:98:3:98:3 | *s [post update] [m1] | aliasing.cpp:101:14:101:19 | *s_copy [m1] |
+| aliasing.cpp:98:3:98:21 | ... = ... | aliasing.cpp:98:3:98:3 | *s [post update] [m1] |
 | aliasing.cpp:98:10:98:19 | call to user_input | aliasing.cpp:98:3:98:21 | ... = ... |
-| aliasing.cpp:101:13:101:22 | & ... indirection | aliasing.cpp:102:8:102:10 | * ... |
-| aliasing.cpp:101:14:101:19 | s_copy indirection [m1] | aliasing.cpp:101:13:101:22 | & ... indirection |
-| aliasing.cpp:105:23:105:24 | pa | aliasing.cpp:121:15:121:16 | taint_a_ptr output argument |
-| aliasing.cpp:105:23:105:24 | pa | aliasing.cpp:126:15:126:20 | taint_a_ptr output argument |
-| aliasing.cpp:105:23:105:24 | pa | aliasing.cpp:131:15:131:16 | taint_a_ptr output argument |
-| aliasing.cpp:105:23:105:24 | pa | aliasing.cpp:136:15:136:17 | taint_a_ptr output argument |
-| aliasing.cpp:105:23:105:24 | pa | aliasing.cpp:141:17:141:20 | taint_a_ptr output argument |
-| aliasing.cpp:105:23:105:24 | pa | aliasing.cpp:158:15:158:20 | taint_a_ptr output argument |
-| aliasing.cpp:105:23:105:24 | pa | aliasing.cpp:164:15:164:20 | taint_a_ptr output argument |
-| aliasing.cpp:105:23:105:24 | pa | aliasing.cpp:175:15:175:22 | taint_a_ptr output argument |
-| aliasing.cpp:105:23:105:24 | pa | aliasing.cpp:187:15:187:22 | taint_a_ptr output argument |
-| aliasing.cpp:105:23:105:24 | pa | aliasing.cpp:200:15:200:24 | taint_a_ptr output argument |
-| aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:105:23:105:24 | pa |
+| aliasing.cpp:101:13:101:22 | *& ... | aliasing.cpp:102:8:102:10 | * ... |
+| aliasing.cpp:101:14:101:19 | *s_copy [m1] | aliasing.cpp:101:13:101:22 | *& ... |
+| aliasing.cpp:105:23:105:24 | *pa | aliasing.cpp:121:15:121:16 | taint_a_ptr output argument |
+| aliasing.cpp:105:23:105:24 | *pa | aliasing.cpp:126:15:126:20 | taint_a_ptr output argument |
+| aliasing.cpp:105:23:105:24 | *pa | aliasing.cpp:131:15:131:16 | taint_a_ptr output argument |
+| aliasing.cpp:105:23:105:24 | *pa | aliasing.cpp:136:15:136:17 | taint_a_ptr output argument |
+| aliasing.cpp:105:23:105:24 | *pa | aliasing.cpp:141:17:141:20 | taint_a_ptr output argument |
+| aliasing.cpp:105:23:105:24 | *pa | aliasing.cpp:158:15:158:20 | taint_a_ptr output argument |
+| aliasing.cpp:105:23:105:24 | *pa | aliasing.cpp:164:15:164:20 | taint_a_ptr output argument |
+| aliasing.cpp:105:23:105:24 | *pa | aliasing.cpp:175:15:175:22 | taint_a_ptr output argument |
+| aliasing.cpp:105:23:105:24 | *pa | aliasing.cpp:187:15:187:22 | taint_a_ptr output argument |
+| aliasing.cpp:105:23:105:24 | *pa | aliasing.cpp:200:15:200:24 | taint_a_ptr output argument |
+| aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:105:23:105:24 | *pa |
 | aliasing.cpp:121:15:121:16 | taint_a_ptr output argument | aliasing.cpp:122:8:122:12 | access to array |
 | aliasing.cpp:126:15:126:20 | taint_a_ptr output argument | aliasing.cpp:127:8:127:16 | * ... |
 | aliasing.cpp:131:15:131:16 | taint_a_ptr output argument | aliasing.cpp:132:8:132:14 | * ... |
 | aliasing.cpp:136:15:136:17 | taint_a_ptr output argument | aliasing.cpp:137:8:137:11 | * ... |
-| aliasing.cpp:141:15:141:15 | s indirection [post update] [data indirection] | aliasing.cpp:143:8:143:8 | s indirection [data indirection] |
-| aliasing.cpp:141:17:141:20 | taint_a_ptr output argument | aliasing.cpp:141:15:141:15 | s indirection [post update] [data indirection] |
-| aliasing.cpp:143:8:143:8 | s indirection [data indirection] | aliasing.cpp:143:8:143:16 | access to array |
-| aliasing.cpp:143:8:143:8 | s indirection [data indirection] | aliasing.cpp:143:10:143:13 | data indirection |
-| aliasing.cpp:143:10:143:13 | data indirection | aliasing.cpp:143:8:143:16 | access to array |
-| aliasing.cpp:158:15:158:15 | s indirection [post update] [data] | aliasing.cpp:159:9:159:9 | s indirection [data] |
-| aliasing.cpp:158:15:158:20 | taint_a_ptr output argument | aliasing.cpp:158:15:158:15 | s indirection [post update] [data] |
-| aliasing.cpp:159:9:159:9 | s indirection [data] | aliasing.cpp:159:8:159:14 | * ... |
-| aliasing.cpp:164:15:164:15 | s indirection [post update] [data] | aliasing.cpp:165:8:165:8 | s indirection [data] |
-| aliasing.cpp:164:15:164:20 | taint_a_ptr output argument | aliasing.cpp:164:15:164:15 | s indirection [post update] [data] |
-| aliasing.cpp:165:8:165:8 | s indirection [data] | aliasing.cpp:165:8:165:16 | access to array |
-| aliasing.cpp:175:15:175:22 | taint_a_ptr output argument | aliasing.cpp:175:19:175:19 | s indirection [post update] [m1] |
-| aliasing.cpp:175:16:175:17 | s2 indirection [post update] [s, m1] | aliasing.cpp:176:8:176:9 | s2 indirection [s, m1] |
-| aliasing.cpp:175:19:175:19 | s indirection [post update] [m1] | aliasing.cpp:175:16:175:17 | s2 indirection [post update] [s, m1] |
-| aliasing.cpp:176:8:176:9 | s2 indirection [s, m1] | aliasing.cpp:176:11:176:11 | s indirection [m1] |
-| aliasing.cpp:176:11:176:11 | s indirection [m1] | aliasing.cpp:176:13:176:14 | m1 |
-| aliasing.cpp:187:15:187:22 | taint_a_ptr output argument | aliasing.cpp:187:19:187:19 | s indirection [post update] [m1] |
-| aliasing.cpp:187:16:187:17 | s2 indirection [post update] [s, m1] | aliasing.cpp:189:8:189:11 | s2_2 indirection [s, m1] |
-| aliasing.cpp:187:19:187:19 | s indirection [post update] [m1] | aliasing.cpp:187:16:187:17 | s2 indirection [post update] [s, m1] |
-| aliasing.cpp:189:8:189:11 | s2_2 indirection [s, m1] | aliasing.cpp:189:13:189:13 | s indirection [m1] |
-| aliasing.cpp:189:13:189:13 | s indirection [m1] | aliasing.cpp:189:15:189:16 | m1 |
-| aliasing.cpp:200:15:200:24 | taint_a_ptr output argument | aliasing.cpp:200:21:200:21 | s indirection [post update] [m1] |
-| aliasing.cpp:200:16:200:18 | ps2 indirection [post update] [s, m1] | aliasing.cpp:201:8:201:10 | ps2 indirection [s, m1] |
-| aliasing.cpp:200:21:200:21 | s indirection [post update] [m1] | aliasing.cpp:200:16:200:18 | ps2 indirection [post update] [s, m1] |
-| aliasing.cpp:201:8:201:10 | ps2 indirection [s, m1] | aliasing.cpp:201:13:201:13 | s indirection [m1] |
-| aliasing.cpp:201:13:201:13 | s indirection [m1] | aliasing.cpp:201:15:201:16 | m1 |
+| aliasing.cpp:141:15:141:15 | *s [post update] [*data] | aliasing.cpp:143:8:143:8 | *s [*data] |
+| aliasing.cpp:141:17:141:20 | taint_a_ptr output argument | aliasing.cpp:141:15:141:15 | *s [post update] [*data] |
+| aliasing.cpp:143:8:143:8 | *s [*data] | aliasing.cpp:143:8:143:16 | access to array |
+| aliasing.cpp:143:8:143:8 | *s [*data] | aliasing.cpp:143:10:143:13 | *data |
+| aliasing.cpp:143:10:143:13 | *data | aliasing.cpp:143:8:143:16 | access to array |
+| aliasing.cpp:158:15:158:15 | *s [post update] [data] | aliasing.cpp:159:9:159:9 | *s [data] |
+| aliasing.cpp:158:15:158:20 | taint_a_ptr output argument | aliasing.cpp:158:15:158:15 | *s [post update] [data] |
+| aliasing.cpp:159:9:159:9 | *s [data] | aliasing.cpp:159:8:159:14 | * ... |
+| aliasing.cpp:164:15:164:15 | *s [post update] [data] | aliasing.cpp:165:8:165:8 | *s [data] |
+| aliasing.cpp:164:15:164:20 | taint_a_ptr output argument | aliasing.cpp:164:15:164:15 | *s [post update] [data] |
+| aliasing.cpp:165:8:165:8 | *s [data] | aliasing.cpp:165:8:165:16 | access to array |
+| aliasing.cpp:175:15:175:22 | taint_a_ptr output argument | aliasing.cpp:175:19:175:19 | *s [post update] [m1] |
+| aliasing.cpp:175:16:175:17 | *s2 [post update] [s, m1] | aliasing.cpp:176:8:176:9 | *s2 [s, m1] |
+| aliasing.cpp:175:19:175:19 | *s [post update] [m1] | aliasing.cpp:175:16:175:17 | *s2 [post update] [s, m1] |
+| aliasing.cpp:176:8:176:9 | *s2 [s, m1] | aliasing.cpp:176:11:176:11 | *s [m1] |
+| aliasing.cpp:176:11:176:11 | *s [m1] | aliasing.cpp:176:13:176:14 | m1 |
+| aliasing.cpp:187:15:187:22 | taint_a_ptr output argument | aliasing.cpp:187:19:187:19 | *s [post update] [m1] |
+| aliasing.cpp:187:16:187:17 | *s2 [post update] [s, m1] | aliasing.cpp:189:8:189:11 | *s2_2 [s, m1] |
+| aliasing.cpp:187:19:187:19 | *s [post update] [m1] | aliasing.cpp:187:16:187:17 | *s2 [post update] [s, m1] |
+| aliasing.cpp:189:8:189:11 | *s2_2 [s, m1] | aliasing.cpp:189:13:189:13 | *s [m1] |
+| aliasing.cpp:189:13:189:13 | *s [m1] | aliasing.cpp:189:15:189:16 | m1 |
+| aliasing.cpp:200:15:200:24 | taint_a_ptr output argument | aliasing.cpp:200:21:200:21 | *s [post update] [m1] |
+| aliasing.cpp:200:16:200:18 | *ps2 [post update] [s, m1] | aliasing.cpp:201:8:201:10 | *ps2 [s, m1] |
+| aliasing.cpp:200:21:200:21 | *s [post update] [m1] | aliasing.cpp:200:16:200:18 | *ps2 [post update] [s, m1] |
+| aliasing.cpp:201:8:201:10 | *ps2 [s, m1] | aliasing.cpp:201:13:201:13 | *s [m1] |
+| aliasing.cpp:201:13:201:13 | *s [m1] | aliasing.cpp:201:15:201:16 | m1 |
 | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:7:8:7:13 | access to array |
 | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:8:8:8:13 | access to array |
 | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:9:8:9:11 | * ... |
 | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:10:8:10:15 | * ... |
 | arrays.cpp:15:14:15:23 | call to user_input | arrays.cpp:16:8:16:13 | access to array |
 | arrays.cpp:15:14:15:23 | call to user_input | arrays.cpp:17:8:17:13 | access to array |
-| arrays.cpp:36:3:36:3 | o indirection [post update] [nested, arr, data] | arrays.cpp:37:8:37:8 | o indirection [nested, arr, data] |
-| arrays.cpp:36:3:36:3 | o indirection [post update] [nested, arr, data] | arrays.cpp:38:8:38:8 | o indirection [nested, arr, data] |
-| arrays.cpp:36:3:36:17 | access to array indirection [post update] [data] | arrays.cpp:36:5:36:10 | nested indirection [post update] [arr, data] |
-| arrays.cpp:36:3:36:37 | ... = ... | arrays.cpp:36:3:36:17 | access to array indirection [post update] [data] |
-| arrays.cpp:36:5:36:10 | nested indirection [post update] [arr, data] | arrays.cpp:36:3:36:3 | o indirection [post update] [nested, arr, data] |
+| arrays.cpp:36:3:36:3 | *o [post update] [nested, arr, data] | arrays.cpp:37:8:37:8 | *o [nested, arr, data] |
+| arrays.cpp:36:3:36:3 | *o [post update] [nested, arr, data] | arrays.cpp:38:8:38:8 | *o [nested, arr, data] |
+| arrays.cpp:36:3:36:17 | *access to array [post update] [data] | arrays.cpp:36:5:36:10 | *nested [post update] [arr, data] |
+| arrays.cpp:36:3:36:37 | ... = ... | arrays.cpp:36:3:36:17 | *access to array [post update] [data] |
+| arrays.cpp:36:5:36:10 | *nested [post update] [arr, data] | arrays.cpp:36:3:36:3 | *o [post update] [nested, arr, data] |
 | arrays.cpp:36:26:36:35 | call to user_input | arrays.cpp:36:3:36:37 | ... = ... |
-| arrays.cpp:37:8:37:8 | o indirection [nested, arr, data] | arrays.cpp:37:10:37:15 | nested indirection [arr, data] |
-| arrays.cpp:37:8:37:22 | access to array indirection [data] | arrays.cpp:37:24:37:27 | data |
-| arrays.cpp:37:10:37:15 | nested indirection [arr, data] | arrays.cpp:37:8:37:22 | access to array indirection [data] |
-| arrays.cpp:38:8:38:8 | o indirection [nested, arr, data] | arrays.cpp:38:10:38:15 | nested indirection [arr, data] |
-| arrays.cpp:38:8:38:22 | access to array indirection [data] | arrays.cpp:38:24:38:27 | data |
-| arrays.cpp:38:10:38:15 | nested indirection [arr, data] | arrays.cpp:38:8:38:22 | access to array indirection [data] |
-| arrays.cpp:42:3:42:3 | o indirection [post update] [indirect indirection, arr, data] | arrays.cpp:43:8:43:8 | o indirection [indirect indirection, arr, data] |
-| arrays.cpp:42:3:42:3 | o indirection [post update] [indirect indirection, arr, data] | arrays.cpp:44:8:44:8 | o indirection [indirect indirection, arr, data] |
-| arrays.cpp:42:3:42:20 | access to array indirection [post update] [data] | arrays.cpp:42:5:42:12 | indirect indirection [post update] [arr, data] |
-| arrays.cpp:42:3:42:40 | ... = ... | arrays.cpp:42:3:42:20 | access to array indirection [post update] [data] |
-| arrays.cpp:42:5:42:12 | indirect indirection [post update] [arr, data] | arrays.cpp:42:3:42:3 | o indirection [post update] [indirect indirection, arr, data] |
+| arrays.cpp:37:8:37:8 | *o [nested, arr, data] | arrays.cpp:37:10:37:15 | *nested [arr, data] |
+| arrays.cpp:37:8:37:22 | *access to array [data] | arrays.cpp:37:24:37:27 | data |
+| arrays.cpp:37:10:37:15 | *nested [arr, data] | arrays.cpp:37:8:37:22 | *access to array [data] |
+| arrays.cpp:38:8:38:8 | *o [nested, arr, data] | arrays.cpp:38:10:38:15 | *nested [arr, data] |
+| arrays.cpp:38:8:38:22 | *access to array [data] | arrays.cpp:38:24:38:27 | data |
+| arrays.cpp:38:10:38:15 | *nested [arr, data] | arrays.cpp:38:8:38:22 | *access to array [data] |
+| arrays.cpp:42:3:42:3 | *o [post update] [*indirect, arr, data] | arrays.cpp:43:8:43:8 | *o [*indirect, arr, data] |
+| arrays.cpp:42:3:42:3 | *o [post update] [*indirect, arr, data] | arrays.cpp:44:8:44:8 | *o [*indirect, arr, data] |
+| arrays.cpp:42:3:42:20 | *access to array [post update] [data] | arrays.cpp:42:5:42:12 | *indirect [post update] [arr, data] |
+| arrays.cpp:42:3:42:40 | ... = ... | arrays.cpp:42:3:42:20 | *access to array [post update] [data] |
+| arrays.cpp:42:5:42:12 | *indirect [post update] [arr, data] | arrays.cpp:42:3:42:3 | *o [post update] [*indirect, arr, data] |
 | arrays.cpp:42:29:42:38 | call to user_input | arrays.cpp:42:3:42:40 | ... = ... |
-| arrays.cpp:43:8:43:8 | o indirection [indirect indirection, arr, data] | arrays.cpp:43:10:43:17 | indirect indirection [arr, data] |
-| arrays.cpp:43:8:43:25 | access to array indirection [data] | arrays.cpp:43:27:43:30 | data |
-| arrays.cpp:43:10:43:17 | indirect indirection [arr, data] | arrays.cpp:43:8:43:25 | access to array indirection [data] |
-| arrays.cpp:44:8:44:8 | o indirection [indirect indirection, arr, data] | arrays.cpp:44:10:44:17 | indirect indirection [arr, data] |
-| arrays.cpp:44:8:44:25 | access to array indirection [data] | arrays.cpp:44:27:44:30 | data |
-| arrays.cpp:44:10:44:17 | indirect indirection [arr, data] | arrays.cpp:44:8:44:25 | access to array indirection [data] |
-| arrays.cpp:48:3:48:3 | o indirection [post update] [indirect indirection, ptr indirection, data] | arrays.cpp:49:8:49:8 | o indirection [indirect indirection, ptr indirection, data] |
-| arrays.cpp:48:3:48:3 | o indirection [post update] [indirect indirection, ptr indirection, data] | arrays.cpp:50:8:50:8 | o indirection [indirect indirection, ptr indirection, data] |
-| arrays.cpp:48:3:48:20 | access to array indirection [post update] [data] | arrays.cpp:48:5:48:12 | indirect indirection [post update] [ptr indirection, data] |
-| arrays.cpp:48:3:48:40 | ... = ... | arrays.cpp:48:3:48:20 | access to array indirection [post update] [data] |
-| arrays.cpp:48:5:48:12 | indirect indirection [post update] [ptr indirection, data] | arrays.cpp:48:3:48:3 | o indirection [post update] [indirect indirection, ptr indirection, data] |
+| arrays.cpp:43:8:43:8 | *o [*indirect, arr, data] | arrays.cpp:43:10:43:17 | *indirect [arr, data] |
+| arrays.cpp:43:8:43:25 | *access to array [data] | arrays.cpp:43:27:43:30 | data |
+| arrays.cpp:43:10:43:17 | *indirect [arr, data] | arrays.cpp:43:8:43:25 | *access to array [data] |
+| arrays.cpp:44:8:44:8 | *o [*indirect, arr, data] | arrays.cpp:44:10:44:17 | *indirect [arr, data] |
+| arrays.cpp:44:8:44:25 | *access to array [data] | arrays.cpp:44:27:44:30 | data |
+| arrays.cpp:44:10:44:17 | *indirect [arr, data] | arrays.cpp:44:8:44:25 | *access to array [data] |
+| arrays.cpp:48:3:48:3 | *o [post update] [*indirect, *ptr, data] | arrays.cpp:49:8:49:8 | *o [*indirect, *ptr, data] |
+| arrays.cpp:48:3:48:3 | *o [post update] [*indirect, *ptr, data] | arrays.cpp:50:8:50:8 | *o [*indirect, *ptr, data] |
+| arrays.cpp:48:3:48:20 | *access to array [post update] [data] | arrays.cpp:48:5:48:12 | *indirect [post update] [*ptr, data] |
+| arrays.cpp:48:3:48:40 | ... = ... | arrays.cpp:48:3:48:20 | *access to array [post update] [data] |
+| arrays.cpp:48:5:48:12 | *indirect [post update] [*ptr, data] | arrays.cpp:48:3:48:3 | *o [post update] [*indirect, *ptr, data] |
 | arrays.cpp:48:29:48:38 | call to user_input | arrays.cpp:48:3:48:40 | ... = ... |
-| arrays.cpp:49:8:49:8 | o indirection [indirect indirection, ptr indirection, data] | arrays.cpp:49:10:49:17 | indirect indirection [ptr indirection, data] |
-| arrays.cpp:49:8:49:25 | access to array indirection [data] | arrays.cpp:49:27:49:30 | data |
-| arrays.cpp:49:10:49:17 | indirect indirection [ptr indirection, data] | arrays.cpp:49:8:49:25 | access to array indirection [data] |
-| arrays.cpp:49:10:49:17 | indirect indirection [ptr indirection, data] | arrays.cpp:49:20:49:22 | ptr indirection [data] |
-| arrays.cpp:49:20:49:22 | ptr indirection [data] | arrays.cpp:49:8:49:25 | access to array indirection [data] |
-| arrays.cpp:50:8:50:8 | o indirection [indirect indirection, ptr indirection, data] | arrays.cpp:50:10:50:17 | indirect indirection [ptr indirection, data] |
-| arrays.cpp:50:8:50:25 | access to array indirection [data] | arrays.cpp:50:27:50:30 | data |
-| arrays.cpp:50:10:50:17 | indirect indirection [ptr indirection, data] | arrays.cpp:50:8:50:25 | access to array indirection [data] |
-| arrays.cpp:50:10:50:17 | indirect indirection [ptr indirection, data] | arrays.cpp:50:20:50:22 | ptr indirection [data] |
-| arrays.cpp:50:20:50:22 | ptr indirection [data] | arrays.cpp:50:8:50:25 | access to array indirection [data] |
+| arrays.cpp:49:8:49:8 | *o [*indirect, *ptr, data] | arrays.cpp:49:10:49:17 | *indirect [*ptr, data] |
+| arrays.cpp:49:8:49:25 | *access to array [data] | arrays.cpp:49:27:49:30 | data |
+| arrays.cpp:49:10:49:17 | *indirect [*ptr, data] | arrays.cpp:49:8:49:25 | *access to array [data] |
+| arrays.cpp:49:10:49:17 | *indirect [*ptr, data] | arrays.cpp:49:20:49:22 | *ptr [data] |
+| arrays.cpp:49:20:49:22 | *ptr [data] | arrays.cpp:49:8:49:25 | *access to array [data] |
+| arrays.cpp:50:8:50:8 | *o [*indirect, *ptr, data] | arrays.cpp:50:10:50:17 | *indirect [*ptr, data] |
+| arrays.cpp:50:8:50:25 | *access to array [data] | arrays.cpp:50:27:50:30 | data |
+| arrays.cpp:50:10:50:17 | *indirect [*ptr, data] | arrays.cpp:50:8:50:25 | *access to array [data] |
+| arrays.cpp:50:10:50:17 | *indirect [*ptr, data] | arrays.cpp:50:20:50:22 | *ptr [data] |
+| arrays.cpp:50:20:50:22 | *ptr [data] | arrays.cpp:50:8:50:25 | *access to array [data] |
 | by_reference.cpp:11:48:11:52 | value | by_reference.cpp:12:5:12:16 | ... = ... |
-| by_reference.cpp:12:5:12:16 | ... = ... | by_reference.cpp:12:5:12:5 | s indirection [post update] [a] |
+| by_reference.cpp:12:5:12:16 | ... = ... | by_reference.cpp:12:5:12:5 | *s [post update] [a] |
 | by_reference.cpp:15:26:15:30 | value | by_reference.cpp:16:5:16:19 | ... = ... |
-| by_reference.cpp:16:5:16:19 | ... = ... | by_reference.cpp:16:5:16:8 | this indirection [post update] [a] |
+| by_reference.cpp:16:5:16:19 | ... = ... | by_reference.cpp:16:5:16:8 | *this [post update] [a] |
 | by_reference.cpp:19:28:19:32 | value | by_reference.cpp:20:23:20:27 | value |
 | by_reference.cpp:20:23:20:27 | value | by_reference.cpp:15:26:15:30 | value |
 | by_reference.cpp:20:23:20:27 | value | by_reference.cpp:20:5:20:8 | setDirectly output argument [a] |
 | by_reference.cpp:23:34:23:38 | value | by_reference.cpp:24:25:24:29 | value |
 | by_reference.cpp:24:25:24:29 | value | by_reference.cpp:11:48:11:52 | value |
 | by_reference.cpp:24:25:24:29 | value | by_reference.cpp:24:19:24:22 | nonMemberSetA output argument [a] |
-| by_reference.cpp:31:46:31:46 | s indirection [a] | by_reference.cpp:32:12:32:12 | s indirection [a] |
-| by_reference.cpp:32:12:32:12 | s indirection [a] | by_reference.cpp:32:15:32:15 | a |
-| by_reference.cpp:32:15:32:15 | a | by_reference.cpp:31:16:31:28 | nonMemberGetA indirection |
-| by_reference.cpp:35:9:35:19 | this indirection [a] | by_reference.cpp:36:12:36:15 | this indirection [a] |
-| by_reference.cpp:36:12:36:15 | this indirection [a] | by_reference.cpp:36:18:36:18 | a |
-| by_reference.cpp:36:18:36:18 | a | by_reference.cpp:35:9:35:19 | getDirectly indirection |
-| by_reference.cpp:39:9:39:21 | this indirection [a] | by_reference.cpp:40:12:40:15 | this indirection [a] |
-| by_reference.cpp:40:12:40:15 | this indirection [a] | by_reference.cpp:35:9:35:19 | this indirection [a] |
-| by_reference.cpp:40:12:40:15 | this indirection [a] | by_reference.cpp:40:18:40:28 | call to getDirectly |
-| by_reference.cpp:40:18:40:28 | call to getDirectly | by_reference.cpp:39:9:39:21 | getIndirectly indirection |
-| by_reference.cpp:43:9:43:27 | this indirection [a] | by_reference.cpp:44:26:44:29 | this indirection [a] |
-| by_reference.cpp:44:12:44:24 | call to nonMemberGetA | by_reference.cpp:43:9:43:27 | getThroughNonMember indirection |
-| by_reference.cpp:44:26:44:29 | this indirection [a] | by_reference.cpp:31:46:31:46 | s indirection [a] |
-| by_reference.cpp:44:26:44:29 | this indirection [a] | by_reference.cpp:44:12:44:24 | call to nonMemberGetA |
-| by_reference.cpp:50:3:50:3 | setDirectly output argument [a] | by_reference.cpp:51:8:51:8 | s indirection [a] |
+| by_reference.cpp:31:46:31:46 | *s [a] | by_reference.cpp:32:12:32:12 | *s [a] |
+| by_reference.cpp:32:12:32:12 | *s [a] | by_reference.cpp:32:15:32:15 | a |
+| by_reference.cpp:32:15:32:15 | a | by_reference.cpp:31:16:31:28 | *nonMemberGetA |
+| by_reference.cpp:35:9:35:19 | *this [a] | by_reference.cpp:36:12:36:15 | *this [a] |
+| by_reference.cpp:36:12:36:15 | *this [a] | by_reference.cpp:36:18:36:18 | a |
+| by_reference.cpp:36:18:36:18 | a | by_reference.cpp:35:9:35:19 | *getDirectly |
+| by_reference.cpp:39:9:39:21 | *this [a] | by_reference.cpp:40:12:40:15 | *this [a] |
+| by_reference.cpp:40:12:40:15 | *this [a] | by_reference.cpp:35:9:35:19 | *this [a] |
+| by_reference.cpp:40:12:40:15 | *this [a] | by_reference.cpp:40:18:40:28 | call to getDirectly |
+| by_reference.cpp:40:18:40:28 | call to getDirectly | by_reference.cpp:39:9:39:21 | *getIndirectly |
+| by_reference.cpp:43:9:43:27 | *this [a] | by_reference.cpp:44:26:44:29 | *this [a] |
+| by_reference.cpp:44:12:44:24 | call to nonMemberGetA | by_reference.cpp:43:9:43:27 | *getThroughNonMember |
+| by_reference.cpp:44:26:44:29 | *this [a] | by_reference.cpp:31:46:31:46 | *s [a] |
+| by_reference.cpp:44:26:44:29 | *this [a] | by_reference.cpp:44:12:44:24 | call to nonMemberGetA |
+| by_reference.cpp:50:3:50:3 | setDirectly output argument [a] | by_reference.cpp:51:8:51:8 | *s [a] |
 | by_reference.cpp:50:17:50:26 | call to user_input | by_reference.cpp:15:26:15:30 | value |
 | by_reference.cpp:50:17:50:26 | call to user_input | by_reference.cpp:50:3:50:3 | setDirectly output argument [a] |
-| by_reference.cpp:51:8:51:8 | s indirection [a] | by_reference.cpp:35:9:35:19 | this indirection [a] |
-| by_reference.cpp:51:8:51:8 | s indirection [a] | by_reference.cpp:51:10:51:20 | call to getDirectly |
-| by_reference.cpp:56:3:56:3 | setIndirectly output argument [a] | by_reference.cpp:57:8:57:8 | s indirection [a] |
+| by_reference.cpp:51:8:51:8 | *s [a] | by_reference.cpp:35:9:35:19 | *this [a] |
+| by_reference.cpp:51:8:51:8 | *s [a] | by_reference.cpp:51:10:51:20 | call to getDirectly |
+| by_reference.cpp:56:3:56:3 | setIndirectly output argument [a] | by_reference.cpp:57:8:57:8 | *s [a] |
 | by_reference.cpp:56:19:56:28 | call to user_input | by_reference.cpp:19:28:19:32 | value |
 | by_reference.cpp:56:19:56:28 | call to user_input | by_reference.cpp:56:3:56:3 | setIndirectly output argument [a] |
-| by_reference.cpp:57:8:57:8 | s indirection [a] | by_reference.cpp:39:9:39:21 | this indirection [a] |
-| by_reference.cpp:57:8:57:8 | s indirection [a] | by_reference.cpp:57:10:57:22 | call to getIndirectly |
-| by_reference.cpp:62:3:62:3 | setThroughNonMember output argument [a] | by_reference.cpp:63:8:63:8 | s indirection [a] |
+| by_reference.cpp:57:8:57:8 | *s [a] | by_reference.cpp:39:9:39:21 | *this [a] |
+| by_reference.cpp:57:8:57:8 | *s [a] | by_reference.cpp:57:10:57:22 | call to getIndirectly |
+| by_reference.cpp:62:3:62:3 | setThroughNonMember output argument [a] | by_reference.cpp:63:8:63:8 | *s [a] |
 | by_reference.cpp:62:25:62:34 | call to user_input | by_reference.cpp:23:34:23:38 | value |
 | by_reference.cpp:62:25:62:34 | call to user_input | by_reference.cpp:62:3:62:3 | setThroughNonMember output argument [a] |
-| by_reference.cpp:63:8:63:8 | s indirection [a] | by_reference.cpp:43:9:43:27 | this indirection [a] |
-| by_reference.cpp:63:8:63:8 | s indirection [a] | by_reference.cpp:63:10:63:28 | call to getThroughNonMember |
-| by_reference.cpp:68:17:68:18 | nonMemberSetA output argument [a] | by_reference.cpp:69:22:69:23 | & ... indirection [a] |
+| by_reference.cpp:63:8:63:8 | *s [a] | by_reference.cpp:43:9:43:27 | *this [a] |
+| by_reference.cpp:63:8:63:8 | *s [a] | by_reference.cpp:63:10:63:28 | call to getThroughNonMember |
+| by_reference.cpp:68:17:68:18 | nonMemberSetA output argument [a] | by_reference.cpp:69:22:69:23 | *& ... [a] |
 | by_reference.cpp:68:21:68:30 | call to user_input | by_reference.cpp:11:48:11:52 | value |
 | by_reference.cpp:68:21:68:30 | call to user_input | by_reference.cpp:68:17:68:18 | nonMemberSetA output argument [a] |
-| by_reference.cpp:69:22:69:23 | & ... indirection [a] | by_reference.cpp:31:46:31:46 | s indirection [a] |
-| by_reference.cpp:69:22:69:23 | & ... indirection [a] | by_reference.cpp:69:8:69:20 | call to nonMemberGetA |
-| by_reference.cpp:84:3:84:7 | inner indirection [post update] [a] | by_reference.cpp:102:21:102:39 | taint_inner_a_ptr output argument [a] |
-| by_reference.cpp:84:3:84:7 | inner indirection [post update] [a] | by_reference.cpp:103:27:103:35 | taint_inner_a_ptr output argument [a] |
-| by_reference.cpp:84:3:84:7 | inner indirection [post update] [a] | by_reference.cpp:106:21:106:41 | taint_inner_a_ptr output argument [a] |
-| by_reference.cpp:84:3:84:7 | inner indirection [post update] [a] | by_reference.cpp:107:29:107:37 | taint_inner_a_ptr output argument [a] |
-| by_reference.cpp:84:3:84:25 | ... = ... | by_reference.cpp:84:3:84:7 | inner indirection [post update] [a] |
+| by_reference.cpp:69:22:69:23 | *& ... [a] | by_reference.cpp:31:46:31:46 | *s [a] |
+| by_reference.cpp:69:22:69:23 | *& ... [a] | by_reference.cpp:69:8:69:20 | call to nonMemberGetA |
+| by_reference.cpp:84:3:84:7 | *inner [post update] [a] | by_reference.cpp:102:21:102:39 | taint_inner_a_ptr output argument [a] |
+| by_reference.cpp:84:3:84:7 | *inner [post update] [a] | by_reference.cpp:103:27:103:35 | taint_inner_a_ptr output argument [a] |
+| by_reference.cpp:84:3:84:7 | *inner [post update] [a] | by_reference.cpp:106:21:106:41 | taint_inner_a_ptr output argument [a] |
+| by_reference.cpp:84:3:84:7 | *inner [post update] [a] | by_reference.cpp:107:29:107:37 | taint_inner_a_ptr output argument [a] |
+| by_reference.cpp:84:3:84:25 | ... = ... | by_reference.cpp:84:3:84:7 | *inner [post update] [a] |
 | by_reference.cpp:84:14:84:23 | call to user_input | by_reference.cpp:84:3:84:25 | ... = ... |
-| by_reference.cpp:88:3:88:7 | inner indirection [post update] [a] | by_reference.cpp:122:21:122:38 | taint_inner_a_ref output argument [a] |
-| by_reference.cpp:88:3:88:7 | inner indirection [post update] [a] | by_reference.cpp:123:21:123:36 | taint_inner_a_ref output argument [a] |
-| by_reference.cpp:88:3:88:7 | inner indirection [post update] [a] | by_reference.cpp:126:21:126:40 | taint_inner_a_ref output argument [a] |
-| by_reference.cpp:88:3:88:7 | inner indirection [post update] [a] | by_reference.cpp:127:21:127:38 | taint_inner_a_ref output argument [a] |
-| by_reference.cpp:88:3:88:24 | ... = ... | by_reference.cpp:88:3:88:7 | inner indirection [post update] [a] |
+| by_reference.cpp:88:3:88:7 | *inner [post update] [a] | by_reference.cpp:122:21:122:38 | taint_inner_a_ref output argument [a] |
+| by_reference.cpp:88:3:88:7 | *inner [post update] [a] | by_reference.cpp:123:21:123:36 | taint_inner_a_ref output argument [a] |
+| by_reference.cpp:88:3:88:7 | *inner [post update] [a] | by_reference.cpp:126:21:126:40 | taint_inner_a_ref output argument [a] |
+| by_reference.cpp:88:3:88:7 | *inner [post update] [a] | by_reference.cpp:127:21:127:38 | taint_inner_a_ref output argument [a] |
+| by_reference.cpp:88:3:88:24 | ... = ... | by_reference.cpp:88:3:88:7 | *inner [post update] [a] |
 | by_reference.cpp:88:13:88:22 | call to user_input | by_reference.cpp:88:3:88:24 | ... = ... |
-| by_reference.cpp:91:25:91:26 | pa | by_reference.cpp:104:15:104:22 | taint_a_ptr output argument |
-| by_reference.cpp:91:25:91:26 | pa | by_reference.cpp:108:15:108:24 | taint_a_ptr output argument |
-| by_reference.cpp:92:9:92:18 | call to user_input | by_reference.cpp:91:25:91:26 | pa |
-| by_reference.cpp:95:25:95:26 | pa | by_reference.cpp:124:15:124:21 | taint_a_ref output argument |
-| by_reference.cpp:95:25:95:26 | pa | by_reference.cpp:128:15:128:23 | taint_a_ref output argument |
-| by_reference.cpp:96:8:96:17 | call to user_input | by_reference.cpp:95:25:95:26 | pa |
-| by_reference.cpp:102:21:102:39 | taint_inner_a_ptr output argument [a] | by_reference.cpp:102:22:102:26 | outer indirection [post update] [inner_nested, a] |
-| by_reference.cpp:102:22:102:26 | outer indirection [post update] [inner_nested, a] | by_reference.cpp:110:8:110:12 | outer indirection [inner_nested, a] |
-| by_reference.cpp:103:21:103:25 | outer indirection [post update] [inner_ptr indirection, a] | by_reference.cpp:111:8:111:12 | outer indirection [inner_ptr indirection, a] |
-| by_reference.cpp:103:27:103:35 | taint_inner_a_ptr output argument [a] | by_reference.cpp:103:21:103:25 | outer indirection [post update] [inner_ptr indirection, a] |
-| by_reference.cpp:104:15:104:22 | taint_a_ptr output argument | by_reference.cpp:104:16:104:20 | outer indirection [post update] [a] |
-| by_reference.cpp:104:16:104:20 | outer indirection [post update] [a] | by_reference.cpp:112:8:112:12 | outer indirection [a] |
-| by_reference.cpp:106:21:106:41 | taint_inner_a_ptr output argument [a] | by_reference.cpp:106:22:106:27 | pouter indirection [post update] [inner_nested, a] |
-| by_reference.cpp:106:22:106:27 | pouter indirection [post update] [inner_nested, a] | by_reference.cpp:114:8:114:13 | pouter indirection [inner_nested, a] |
-| by_reference.cpp:107:21:107:26 | pouter indirection [post update] [inner_ptr indirection, a] | by_reference.cpp:115:8:115:13 | pouter indirection [inner_ptr indirection, a] |
-| by_reference.cpp:107:29:107:37 | taint_inner_a_ptr output argument [a] | by_reference.cpp:107:21:107:26 | pouter indirection [post update] [inner_ptr indirection, a] |
-| by_reference.cpp:108:15:108:24 | taint_a_ptr output argument | by_reference.cpp:108:16:108:21 | pouter indirection [post update] [a] |
-| by_reference.cpp:108:16:108:21 | pouter indirection [post update] [a] | by_reference.cpp:116:8:116:13 | pouter indirection [a] |
-| by_reference.cpp:110:8:110:12 | outer indirection [inner_nested, a] | by_reference.cpp:110:14:110:25 | inner_nested indirection [a] |
-| by_reference.cpp:110:14:110:25 | inner_nested indirection [a] | by_reference.cpp:110:27:110:27 | a |
-| by_reference.cpp:111:8:111:12 | outer indirection [inner_ptr indirection, a] | by_reference.cpp:111:14:111:22 | inner_ptr indirection [a] |
-| by_reference.cpp:111:14:111:22 | inner_ptr indirection [a] | by_reference.cpp:111:25:111:25 | a |
-| by_reference.cpp:112:8:112:12 | outer indirection [a] | by_reference.cpp:112:14:112:14 | a |
-| by_reference.cpp:114:8:114:13 | pouter indirection [inner_nested, a] | by_reference.cpp:114:16:114:27 | inner_nested indirection [a] |
-| by_reference.cpp:114:16:114:27 | inner_nested indirection [a] | by_reference.cpp:114:29:114:29 | a |
-| by_reference.cpp:115:8:115:13 | pouter indirection [inner_ptr indirection, a] | by_reference.cpp:115:16:115:24 | inner_ptr indirection [a] |
-| by_reference.cpp:115:16:115:24 | inner_ptr indirection [a] | by_reference.cpp:115:27:115:27 | a |
-| by_reference.cpp:116:8:116:13 | pouter indirection [a] | by_reference.cpp:116:16:116:16 | a |
-| by_reference.cpp:122:21:122:25 | outer indirection [post update] [inner_nested, a] | by_reference.cpp:130:8:130:12 | outer indirection [inner_nested, a] |
-| by_reference.cpp:122:21:122:38 | taint_inner_a_ref output argument [a] | by_reference.cpp:122:21:122:25 | outer indirection [post update] [inner_nested, a] |
-| by_reference.cpp:123:21:123:36 | taint_inner_a_ref output argument [a] | by_reference.cpp:123:22:123:26 | outer indirection [post update] [inner_ptr indirection, a] |
-| by_reference.cpp:123:22:123:26 | outer indirection [post update] [inner_ptr indirection, a] | by_reference.cpp:131:8:131:12 | outer indirection [inner_ptr indirection, a] |
-| by_reference.cpp:124:15:124:19 | outer indirection [post update] [a] | by_reference.cpp:132:8:132:12 | outer indirection [a] |
-| by_reference.cpp:124:15:124:21 | taint_a_ref output argument | by_reference.cpp:124:15:124:19 | outer indirection [post update] [a] |
-| by_reference.cpp:126:21:126:26 | pouter indirection [post update] [inner_nested, a] | by_reference.cpp:134:8:134:13 | pouter indirection [inner_nested, a] |
-| by_reference.cpp:126:21:126:40 | taint_inner_a_ref output argument [a] | by_reference.cpp:126:21:126:26 | pouter indirection [post update] [inner_nested, a] |
-| by_reference.cpp:127:21:127:38 | taint_inner_a_ref output argument [a] | by_reference.cpp:127:22:127:27 | pouter indirection [post update] [inner_ptr indirection, a] |
-| by_reference.cpp:127:22:127:27 | pouter indirection [post update] [inner_ptr indirection, a] | by_reference.cpp:135:8:135:13 | pouter indirection [inner_ptr indirection, a] |
-| by_reference.cpp:128:15:128:20 | pouter indirection [post update] [a] | by_reference.cpp:136:8:136:13 | pouter indirection [a] |
-| by_reference.cpp:128:15:128:23 | taint_a_ref output argument | by_reference.cpp:128:15:128:20 | pouter indirection [post update] [a] |
-| by_reference.cpp:130:8:130:12 | outer indirection [inner_nested, a] | by_reference.cpp:130:14:130:25 | inner_nested indirection [a] |
-| by_reference.cpp:130:14:130:25 | inner_nested indirection [a] | by_reference.cpp:130:27:130:27 | a |
-| by_reference.cpp:131:8:131:12 | outer indirection [inner_ptr indirection, a] | by_reference.cpp:131:14:131:22 | inner_ptr indirection [a] |
-| by_reference.cpp:131:14:131:22 | inner_ptr indirection [a] | by_reference.cpp:131:25:131:25 | a |
-| by_reference.cpp:132:8:132:12 | outer indirection [a] | by_reference.cpp:132:14:132:14 | a |
-| by_reference.cpp:134:8:134:13 | pouter indirection [inner_nested, a] | by_reference.cpp:134:16:134:27 | inner_nested indirection [a] |
-| by_reference.cpp:134:16:134:27 | inner_nested indirection [a] | by_reference.cpp:134:29:134:29 | a |
-| by_reference.cpp:135:8:135:13 | pouter indirection [inner_ptr indirection, a] | by_reference.cpp:135:16:135:24 | inner_ptr indirection [a] |
-| by_reference.cpp:135:16:135:24 | inner_ptr indirection [a] | by_reference.cpp:135:27:135:27 | a |
-| by_reference.cpp:136:8:136:13 | pouter indirection [a] | by_reference.cpp:136:16:136:16 | a |
-| clearning.cpp:32:3:32:25 | ... = ... | clearning.cpp:32:4:32:4 | s indirection [post update] [x indirection] |
-| clearning.cpp:32:4:32:4 | s indirection [post update] [x indirection] | clearning.cpp:33:5:33:5 | s indirection [x indirection] |
+| by_reference.cpp:91:25:91:26 | *pa | by_reference.cpp:104:15:104:22 | taint_a_ptr output argument |
+| by_reference.cpp:91:25:91:26 | *pa | by_reference.cpp:108:15:108:24 | taint_a_ptr output argument |
+| by_reference.cpp:92:9:92:18 | call to user_input | by_reference.cpp:91:25:91:26 | *pa |
+| by_reference.cpp:95:25:95:26 | *pa | by_reference.cpp:124:15:124:21 | taint_a_ref output argument |
+| by_reference.cpp:95:25:95:26 | *pa | by_reference.cpp:128:15:128:23 | taint_a_ref output argument |
+| by_reference.cpp:96:8:96:17 | call to user_input | by_reference.cpp:95:25:95:26 | *pa |
+| by_reference.cpp:102:21:102:39 | taint_inner_a_ptr output argument [a] | by_reference.cpp:102:22:102:26 | *outer [post update] [inner_nested, a] |
+| by_reference.cpp:102:22:102:26 | *outer [post update] [inner_nested, a] | by_reference.cpp:110:8:110:12 | *outer [inner_nested, a] |
+| by_reference.cpp:103:21:103:25 | *outer [post update] [*inner_ptr, a] | by_reference.cpp:111:8:111:12 | *outer [*inner_ptr, a] |
+| by_reference.cpp:103:27:103:35 | taint_inner_a_ptr output argument [a] | by_reference.cpp:103:21:103:25 | *outer [post update] [*inner_ptr, a] |
+| by_reference.cpp:104:15:104:22 | taint_a_ptr output argument | by_reference.cpp:104:16:104:20 | *outer [post update] [a] |
+| by_reference.cpp:104:16:104:20 | *outer [post update] [a] | by_reference.cpp:112:8:112:12 | *outer [a] |
+| by_reference.cpp:106:21:106:41 | taint_inner_a_ptr output argument [a] | by_reference.cpp:106:22:106:27 | *pouter [post update] [inner_nested, a] |
+| by_reference.cpp:106:22:106:27 | *pouter [post update] [inner_nested, a] | by_reference.cpp:114:8:114:13 | *pouter [inner_nested, a] |
+| by_reference.cpp:107:21:107:26 | *pouter [post update] [*inner_ptr, a] | by_reference.cpp:115:8:115:13 | *pouter [*inner_ptr, a] |
+| by_reference.cpp:107:29:107:37 | taint_inner_a_ptr output argument [a] | by_reference.cpp:107:21:107:26 | *pouter [post update] [*inner_ptr, a] |
+| by_reference.cpp:108:15:108:24 | taint_a_ptr output argument | by_reference.cpp:108:16:108:21 | *pouter [post update] [a] |
+| by_reference.cpp:108:16:108:21 | *pouter [post update] [a] | by_reference.cpp:116:8:116:13 | *pouter [a] |
+| by_reference.cpp:110:8:110:12 | *outer [inner_nested, a] | by_reference.cpp:110:14:110:25 | *inner_nested [a] |
+| by_reference.cpp:110:14:110:25 | *inner_nested [a] | by_reference.cpp:110:27:110:27 | a |
+| by_reference.cpp:111:8:111:12 | *outer [*inner_ptr, a] | by_reference.cpp:111:14:111:22 | *inner_ptr [a] |
+| by_reference.cpp:111:14:111:22 | *inner_ptr [a] | by_reference.cpp:111:25:111:25 | a |
+| by_reference.cpp:112:8:112:12 | *outer [a] | by_reference.cpp:112:14:112:14 | a |
+| by_reference.cpp:114:8:114:13 | *pouter [inner_nested, a] | by_reference.cpp:114:16:114:27 | *inner_nested [a] |
+| by_reference.cpp:114:16:114:27 | *inner_nested [a] | by_reference.cpp:114:29:114:29 | a |
+| by_reference.cpp:115:8:115:13 | *pouter [*inner_ptr, a] | by_reference.cpp:115:16:115:24 | *inner_ptr [a] |
+| by_reference.cpp:115:16:115:24 | *inner_ptr [a] | by_reference.cpp:115:27:115:27 | a |
+| by_reference.cpp:116:8:116:13 | *pouter [a] | by_reference.cpp:116:16:116:16 | a |
+| by_reference.cpp:122:21:122:25 | *outer [post update] [inner_nested, a] | by_reference.cpp:130:8:130:12 | *outer [inner_nested, a] |
+| by_reference.cpp:122:21:122:38 | taint_inner_a_ref output argument [a] | by_reference.cpp:122:21:122:25 | *outer [post update] [inner_nested, a] |
+| by_reference.cpp:123:21:123:36 | taint_inner_a_ref output argument [a] | by_reference.cpp:123:22:123:26 | *outer [post update] [*inner_ptr, a] |
+| by_reference.cpp:123:22:123:26 | *outer [post update] [*inner_ptr, a] | by_reference.cpp:131:8:131:12 | *outer [*inner_ptr, a] |
+| by_reference.cpp:124:15:124:19 | *outer [post update] [a] | by_reference.cpp:132:8:132:12 | *outer [a] |
+| by_reference.cpp:124:15:124:21 | taint_a_ref output argument | by_reference.cpp:124:15:124:19 | *outer [post update] [a] |
+| by_reference.cpp:126:21:126:26 | *pouter [post update] [inner_nested, a] | by_reference.cpp:134:8:134:13 | *pouter [inner_nested, a] |
+| by_reference.cpp:126:21:126:40 | taint_inner_a_ref output argument [a] | by_reference.cpp:126:21:126:26 | *pouter [post update] [inner_nested, a] |
+| by_reference.cpp:127:21:127:38 | taint_inner_a_ref output argument [a] | by_reference.cpp:127:22:127:27 | *pouter [post update] [*inner_ptr, a] |
+| by_reference.cpp:127:22:127:27 | *pouter [post update] [*inner_ptr, a] | by_reference.cpp:135:8:135:13 | *pouter [*inner_ptr, a] |
+| by_reference.cpp:128:15:128:20 | *pouter [post update] [a] | by_reference.cpp:136:8:136:13 | *pouter [a] |
+| by_reference.cpp:128:15:128:23 | taint_a_ref output argument | by_reference.cpp:128:15:128:20 | *pouter [post update] [a] |
+| by_reference.cpp:130:8:130:12 | *outer [inner_nested, a] | by_reference.cpp:130:14:130:25 | *inner_nested [a] |
+| by_reference.cpp:130:14:130:25 | *inner_nested [a] | by_reference.cpp:130:27:130:27 | a |
+| by_reference.cpp:131:8:131:12 | *outer [*inner_ptr, a] | by_reference.cpp:131:14:131:22 | *inner_ptr [a] |
+| by_reference.cpp:131:14:131:22 | *inner_ptr [a] | by_reference.cpp:131:25:131:25 | a |
+| by_reference.cpp:132:8:132:12 | *outer [a] | by_reference.cpp:132:14:132:14 | a |
+| by_reference.cpp:134:8:134:13 | *pouter [inner_nested, a] | by_reference.cpp:134:16:134:27 | *inner_nested [a] |
+| by_reference.cpp:134:16:134:27 | *inner_nested [a] | by_reference.cpp:134:29:134:29 | a |
+| by_reference.cpp:135:8:135:13 | *pouter [*inner_ptr, a] | by_reference.cpp:135:16:135:24 | *inner_ptr [a] |
+| by_reference.cpp:135:16:135:24 | *inner_ptr [a] | by_reference.cpp:135:27:135:27 | a |
+| by_reference.cpp:136:8:136:13 | *pouter [a] | by_reference.cpp:136:16:136:16 | a |
+| clearning.cpp:32:3:32:25 | ... = ... | clearning.cpp:32:4:32:4 | *s [post update] [*x] |
+| clearning.cpp:32:4:32:4 | *s [post update] [*x] | clearning.cpp:33:5:33:5 | *s [*x] |
 | clearning.cpp:32:10:32:19 | call to user_input | clearning.cpp:32:3:32:25 | ... = ... |
-| clearning.cpp:33:5:33:5 | s indirection [x indirection] | clearning.cpp:34:9:34:9 | s indirection [x indirection] |
-| clearning.cpp:34:9:34:9 | s indirection [x indirection] | clearning.cpp:34:8:34:11 | * ... |
-| clearning.cpp:53:3:53:25 | ... = ... | clearning.cpp:53:4:53:4 | s indirection [post update] [x indirection] |
-| clearning.cpp:53:4:53:4 | s indirection [post update] [x indirection] | clearning.cpp:54:3:54:3 | s indirection [x indirection] |
+| clearning.cpp:33:5:33:5 | *s [*x] | clearning.cpp:34:9:34:9 | *s [*x] |
+| clearning.cpp:34:9:34:9 | *s [*x] | clearning.cpp:34:8:34:11 | * ... |
+| clearning.cpp:53:3:53:25 | ... = ... | clearning.cpp:53:4:53:4 | *s [post update] [*x] |
+| clearning.cpp:53:4:53:4 | *s [post update] [*x] | clearning.cpp:54:3:54:3 | *s [*x] |
 | clearning.cpp:53:10:53:19 | call to user_input | clearning.cpp:53:3:53:25 | ... = ... |
-| clearning.cpp:54:3:54:3 | s indirection [post update] [x indirection] | clearning.cpp:55:8:55:8 | s indirection [x indirection] |
-| clearning.cpp:54:3:54:3 | s indirection [x indirection] | clearning.cpp:54:3:54:7 | ... ++ indirection |
-| clearning.cpp:54:3:54:3 | s indirection [x indirection] | clearning.cpp:54:5:54:5 | x indirection |
-| clearning.cpp:54:3:54:3 | s indirection [x indirection] | clearning.cpp:55:8:55:8 | s indirection [x indirection] |
-| clearning.cpp:54:3:54:7 | ... ++ indirection | clearning.cpp:54:3:54:3 | s indirection [post update] [x indirection] |
-| clearning.cpp:54:3:54:7 | ... ++ indirection | clearning.cpp:54:3:54:7 | ... ++ indirection |
-| clearning.cpp:54:5:54:5 | x indirection | clearning.cpp:54:3:54:7 | ... ++ indirection |
-| clearning.cpp:55:8:55:8 | s indirection [x indirection] | clearning.cpp:55:10:55:10 | x indirection |
-| clearning.cpp:60:3:60:22 | ... = ... | clearning.cpp:60:5:60:5 | s indirection [post update] [x indirection] |
-| clearning.cpp:60:5:60:5 | s indirection [post update] [x indirection] | clearning.cpp:61:3:61:3 | s indirection [x indirection] |
+| clearning.cpp:54:3:54:3 | *s [*x] | clearning.cpp:54:3:54:7 | *... ++ |
+| clearning.cpp:54:3:54:3 | *s [*x] | clearning.cpp:54:5:54:5 | *x |
+| clearning.cpp:54:3:54:3 | *s [*x] | clearning.cpp:55:8:55:8 | *s [*x] |
+| clearning.cpp:54:3:54:3 | *s [post update] [*x] | clearning.cpp:55:8:55:8 | *s [*x] |
+| clearning.cpp:54:3:54:7 | *... ++ | clearning.cpp:54:3:54:3 | *s [post update] [*x] |
+| clearning.cpp:54:3:54:7 | *... ++ | clearning.cpp:54:3:54:7 | *... ++ |
+| clearning.cpp:54:5:54:5 | *x | clearning.cpp:54:3:54:7 | *... ++ |
+| clearning.cpp:55:8:55:8 | *s [*x] | clearning.cpp:55:10:55:10 | *x |
+| clearning.cpp:60:3:60:22 | ... = ... | clearning.cpp:60:5:60:5 | *s [post update] [**x] |
+| clearning.cpp:60:5:60:5 | *s [post update] [**x] | clearning.cpp:61:3:61:3 | *s [**x] |
 | clearning.cpp:60:11:60:20 | call to user_input | clearning.cpp:60:3:60:22 | ... = ... |
-| clearning.cpp:61:3:61:3 | s indirection [post update] [x indirection] | clearning.cpp:62:8:62:8 | s indirection [x indirection] |
-| clearning.cpp:61:3:61:3 | s indirection [x indirection] | clearning.cpp:61:3:61:7 | ... ++ indirection |
-| clearning.cpp:61:3:61:3 | s indirection [x indirection] | clearning.cpp:61:5:61:5 | x indirection |
-| clearning.cpp:61:3:61:3 | s indirection [x indirection] | clearning.cpp:62:8:62:8 | s indirection [x indirection] |
-| clearning.cpp:61:3:61:7 | ... ++ indirection | clearning.cpp:61:3:61:3 | s indirection [post update] [x indirection] |
-| clearning.cpp:61:3:61:7 | ... ++ indirection | clearning.cpp:61:3:61:7 | ... ++ indirection |
-| clearning.cpp:61:5:61:5 | x indirection | clearning.cpp:61:3:61:7 | ... ++ indirection |
-| clearning.cpp:62:8:62:8 | s indirection [x indirection] | clearning.cpp:62:10:62:10 | x indirection |
-| clearning.cpp:74:18:74:18 | s indirection [post update] [val indirection] | clearning.cpp:76:8:76:8 | s indirection [val indirection] |
-| clearning.cpp:74:20:74:22 | argument_source output argument | clearning.cpp:74:18:74:18 | s indirection [post update] [val indirection] |
-| clearning.cpp:76:8:76:8 | s indirection [val indirection] | clearning.cpp:76:7:76:12 | * ... |
-| clearning.cpp:81:18:81:18 | s indirection [post update] [val indirection] | clearning.cpp:83:13:83:13 | s indirection [val indirection] |
-| clearning.cpp:81:20:81:22 | argument_source output argument | clearning.cpp:81:18:81:18 | s indirection [post update] [val indirection] |
-| clearning.cpp:83:5:83:5 | s indirection [post update] [val indirection] | clearning.cpp:84:8:84:8 | s indirection [val indirection] |
-| clearning.cpp:83:5:83:21 | ... = ... indirection | clearning.cpp:83:5:83:5 | s indirection [post update] [val indirection] |
-| clearning.cpp:83:13:83:13 | s indirection [val indirection] | clearning.cpp:83:13:83:21 | ... + ... indirection |
-| clearning.cpp:83:13:83:13 | s indirection [val indirection] | clearning.cpp:83:15:83:17 | val indirection |
-| clearning.cpp:83:13:83:21 | ... + ... indirection | clearning.cpp:83:5:83:21 | ... = ... indirection |
-| clearning.cpp:83:15:83:17 | val indirection | clearning.cpp:83:5:83:21 | ... = ... indirection |
-| clearning.cpp:84:8:84:8 | s indirection [val indirection] | clearning.cpp:84:7:84:12 | * ... |
-| clearning.cpp:89:18:89:18 | s indirection [post update] [val indirection] | clearning.cpp:90:3:90:3 | s indirection [val indirection] |
-| clearning.cpp:89:20:89:22 | argument_source output argument | clearning.cpp:89:18:89:18 | s indirection [post update] [val indirection] |
-| clearning.cpp:90:3:90:3 | s indirection [post update] [val indirection] | clearning.cpp:91:8:91:8 | s indirection [val indirection] |
-| clearning.cpp:90:3:90:3 | s indirection [val indirection] | clearning.cpp:90:3:90:9 | ... ++ indirection |
-| clearning.cpp:90:3:90:3 | s indirection [val indirection] | clearning.cpp:90:5:90:7 | val indirection |
-| clearning.cpp:90:3:90:3 | s indirection [val indirection] | clearning.cpp:91:8:91:8 | s indirection [val indirection] |
-| clearning.cpp:90:3:90:9 | ... ++ indirection | clearning.cpp:90:3:90:3 | s indirection [post update] [val indirection] |
-| clearning.cpp:90:3:90:9 | ... ++ indirection | clearning.cpp:90:3:90:9 | ... ++ indirection |
-| clearning.cpp:90:5:90:7 | val indirection | clearning.cpp:90:3:90:9 | ... ++ indirection |
-| clearning.cpp:91:8:91:8 | s indirection [val indirection] | clearning.cpp:91:7:91:12 | * ... |
-| clearning.cpp:96:18:96:18 | s indirection [post update] [val indirection] | clearning.cpp:97:10:97:10 | s indirection [val indirection] |
-| clearning.cpp:96:20:96:22 | argument_source output argument | clearning.cpp:96:18:96:18 | s indirection [post update] [val indirection] |
-| clearning.cpp:97:2:97:2 | s indirection [post update] [val indirection] | clearning.cpp:98:8:98:8 | s indirection [val indirection] |
-| clearning.cpp:97:2:97:18 | ... = ... indirection | clearning.cpp:97:2:97:2 | s indirection [post update] [val indirection] |
-| clearning.cpp:97:10:97:10 | s indirection [val indirection] | clearning.cpp:97:10:97:18 | ... + ... indirection |
-| clearning.cpp:97:10:97:10 | s indirection [val indirection] | clearning.cpp:97:12:97:14 | val indirection |
-| clearning.cpp:97:10:97:18 | ... + ... indirection | clearning.cpp:97:2:97:18 | ... = ... indirection |
-| clearning.cpp:97:12:97:14 | val indirection | clearning.cpp:97:2:97:18 | ... = ... indirection |
-| clearning.cpp:98:8:98:8 | s indirection [val indirection] | clearning.cpp:98:7:98:12 | * ... |
-| clearning.cpp:103:18:103:18 | s indirection [post update] [val indirection] | clearning.cpp:104:2:104:2 | s indirection [val indirection] |
-| clearning.cpp:103:20:103:22 | argument_source output argument | clearning.cpp:103:18:103:18 | s indirection [post update] [val indirection] |
-| clearning.cpp:104:2:104:2 | s indirection [post update] [val indirection] | clearning.cpp:105:8:105:8 | s indirection [val indirection] |
-| clearning.cpp:104:2:104:2 | s indirection [val indirection] | clearning.cpp:104:2:104:8 | ... ++ indirection |
-| clearning.cpp:104:2:104:2 | s indirection [val indirection] | clearning.cpp:104:4:104:6 | val indirection |
-| clearning.cpp:104:2:104:2 | s indirection [val indirection] | clearning.cpp:105:8:105:8 | s indirection [val indirection] |
-| clearning.cpp:104:2:104:8 | ... ++ indirection | clearning.cpp:104:2:104:2 | s indirection [post update] [val indirection] |
-| clearning.cpp:104:2:104:8 | ... ++ indirection | clearning.cpp:104:2:104:8 | ... ++ indirection |
-| clearning.cpp:104:4:104:6 | val indirection | clearning.cpp:104:2:104:8 | ... ++ indirection |
-| clearning.cpp:105:8:105:8 | s indirection [val indirection] | clearning.cpp:105:7:105:12 | * ... |
-| clearning.cpp:110:18:110:18 | s indirection [post update] [val indirection] | clearning.cpp:111:4:111:4 | s indirection [val indirection] |
-| clearning.cpp:110:20:110:22 | argument_source output argument | clearning.cpp:110:18:110:18 | s indirection [post update] [val indirection] |
-| clearning.cpp:111:2:111:8 | ++ ... indirection | clearning.cpp:111:2:111:8 | ++ ... indirection |
-| clearning.cpp:111:2:111:8 | ++ ... indirection | clearning.cpp:111:4:111:4 | s indirection [post update] [val indirection] |
-| clearning.cpp:111:4:111:4 | s indirection [post update] [val indirection] | clearning.cpp:112:8:112:8 | s indirection [val indirection] |
-| clearning.cpp:111:4:111:4 | s indirection [val indirection] | clearning.cpp:111:2:111:8 | ++ ... indirection |
-| clearning.cpp:111:4:111:4 | s indirection [val indirection] | clearning.cpp:111:6:111:8 | val indirection |
-| clearning.cpp:111:4:111:4 | s indirection [val indirection] | clearning.cpp:112:8:112:8 | s indirection [val indirection] |
-| clearning.cpp:111:6:111:8 | val indirection | clearning.cpp:111:2:111:8 | ++ ... indirection |
-| clearning.cpp:112:8:112:8 | s indirection [val indirection] | clearning.cpp:112:7:112:12 | * ... |
-| clearning.cpp:117:18:117:18 | s indirection [post update] [val indirection] | clearning.cpp:118:2:118:2 | s indirection [val indirection] |
-| clearning.cpp:117:20:117:22 | argument_source output argument | clearning.cpp:117:18:117:18 | s indirection [post update] [val indirection] |
-| clearning.cpp:118:2:118:2 | s indirection [post update] [val indirection] | clearning.cpp:119:8:119:8 | s indirection [val indirection] |
-| clearning.cpp:118:2:118:2 | s indirection [val indirection] | clearning.cpp:118:2:118:11 | ... += ... indirection |
-| clearning.cpp:118:2:118:2 | s indirection [val indirection] | clearning.cpp:118:4:118:6 | val indirection |
-| clearning.cpp:118:2:118:2 | s indirection [val indirection] | clearning.cpp:119:8:119:8 | s indirection [val indirection] |
-| clearning.cpp:118:2:118:11 | ... += ... indirection | clearning.cpp:118:2:118:2 | s indirection [post update] [val indirection] |
-| clearning.cpp:118:2:118:11 | ... += ... indirection | clearning.cpp:118:2:118:11 | ... += ... indirection |
-| clearning.cpp:118:4:118:6 | val indirection | clearning.cpp:118:2:118:11 | ... += ... indirection |
-| clearning.cpp:119:8:119:8 | s indirection [val indirection] | clearning.cpp:119:7:119:12 | * ... |
-| clearning.cpp:151:3:151:3 | s indirection [post update] [val] | clearning.cpp:152:8:152:8 | s indirection [val] |
-| clearning.cpp:151:3:151:22 | ... = ... | clearning.cpp:151:3:151:3 | s indirection [post update] [val] |
+| clearning.cpp:61:3:61:3 | *s [**x] | clearning.cpp:61:3:61:7 | **... ++ |
+| clearning.cpp:61:3:61:3 | *s [**x] | clearning.cpp:61:5:61:5 | **x |
+| clearning.cpp:61:3:61:3 | *s [**x] | clearning.cpp:62:8:62:8 | *s [**x] |
+| clearning.cpp:61:3:61:3 | *s [post update] [**x] | clearning.cpp:62:8:62:8 | *s [**x] |
+| clearning.cpp:61:3:61:7 | **... ++ | clearning.cpp:61:3:61:3 | *s [post update] [**x] |
+| clearning.cpp:61:3:61:7 | **... ++ | clearning.cpp:61:3:61:7 | **... ++ |
+| clearning.cpp:61:5:61:5 | **x | clearning.cpp:61:3:61:7 | **... ++ |
+| clearning.cpp:62:8:62:8 | *s [**x] | clearning.cpp:62:10:62:10 | **x |
+| clearning.cpp:74:18:74:18 | *s [post update] [*val] | clearning.cpp:76:8:76:8 | *s [*val] |
+| clearning.cpp:74:20:74:22 | argument_source output argument | clearning.cpp:74:18:74:18 | *s [post update] [*val] |
+| clearning.cpp:76:8:76:8 | *s [*val] | clearning.cpp:76:7:76:12 | * ... |
+| clearning.cpp:81:18:81:18 | *s [post update] [*val] | clearning.cpp:83:13:83:13 | *s [*val] |
+| clearning.cpp:81:20:81:22 | argument_source output argument | clearning.cpp:81:18:81:18 | *s [post update] [*val] |
+| clearning.cpp:83:5:83:5 | *s [post update] [*val] | clearning.cpp:84:8:84:8 | *s [*val] |
+| clearning.cpp:83:5:83:21 | *... = ... | clearning.cpp:83:5:83:5 | *s [post update] [*val] |
+| clearning.cpp:83:13:83:13 | *s [*val] | clearning.cpp:83:13:83:21 | *... + ... |
+| clearning.cpp:83:13:83:13 | *s [*val] | clearning.cpp:83:15:83:17 | *val |
+| clearning.cpp:83:13:83:21 | *... + ... | clearning.cpp:83:5:83:21 | *... = ... |
+| clearning.cpp:83:15:83:17 | *val | clearning.cpp:83:5:83:21 | *... = ... |
+| clearning.cpp:84:8:84:8 | *s [*val] | clearning.cpp:84:7:84:12 | * ... |
+| clearning.cpp:89:18:89:18 | *s [post update] [*val] | clearning.cpp:90:3:90:3 | *s [*val] |
+| clearning.cpp:89:20:89:22 | argument_source output argument | clearning.cpp:89:18:89:18 | *s [post update] [*val] |
+| clearning.cpp:90:3:90:3 | *s [*val] | clearning.cpp:90:3:90:9 | *... ++ |
+| clearning.cpp:90:3:90:3 | *s [*val] | clearning.cpp:90:5:90:7 | **val |
+| clearning.cpp:90:3:90:3 | *s [*val] | clearning.cpp:91:8:91:8 | *s [*val] |
+| clearning.cpp:90:3:90:3 | *s [post update] [*val] | clearning.cpp:91:8:91:8 | *s [*val] |
+| clearning.cpp:90:3:90:9 | *... ++ | clearning.cpp:90:3:90:3 | *s [post update] [*val] |
+| clearning.cpp:90:3:90:9 | *... ++ | clearning.cpp:90:3:90:9 | *... ++ |
+| clearning.cpp:90:5:90:7 | **val | clearning.cpp:90:3:90:9 | *... ++ |
+| clearning.cpp:91:8:91:8 | *s [*val] | clearning.cpp:91:7:91:12 | * ... |
+| clearning.cpp:96:18:96:18 | *s [post update] [*val] | clearning.cpp:97:10:97:10 | *s [*val] |
+| clearning.cpp:96:20:96:22 | argument_source output argument | clearning.cpp:96:18:96:18 | *s [post update] [*val] |
+| clearning.cpp:97:2:97:2 | *s [post update] [*val] | clearning.cpp:98:8:98:8 | *s [*val] |
+| clearning.cpp:97:2:97:18 | *... = ... | clearning.cpp:97:2:97:2 | *s [post update] [*val] |
+| clearning.cpp:97:10:97:10 | *s [*val] | clearning.cpp:97:10:97:18 | *... + ... |
+| clearning.cpp:97:10:97:10 | *s [*val] | clearning.cpp:97:12:97:14 | *val |
+| clearning.cpp:97:10:97:18 | *... + ... | clearning.cpp:97:2:97:18 | *... = ... |
+| clearning.cpp:97:12:97:14 | *val | clearning.cpp:97:2:97:18 | *... = ... |
+| clearning.cpp:98:8:98:8 | *s [*val] | clearning.cpp:98:7:98:12 | * ... |
+| clearning.cpp:103:18:103:18 | *s [post update] [*val] | clearning.cpp:104:2:104:2 | *s [*val] |
+| clearning.cpp:103:20:103:22 | argument_source output argument | clearning.cpp:103:18:103:18 | *s [post update] [*val] |
+| clearning.cpp:104:2:104:2 | *s [*val] | clearning.cpp:104:2:104:8 | *... ++ |
+| clearning.cpp:104:2:104:2 | *s [*val] | clearning.cpp:104:4:104:6 | *val |
+| clearning.cpp:104:2:104:2 | *s [*val] | clearning.cpp:105:8:105:8 | *s [*val] |
+| clearning.cpp:104:2:104:2 | *s [post update] [*val] | clearning.cpp:105:8:105:8 | *s [*val] |
+| clearning.cpp:104:2:104:8 | *... ++ | clearning.cpp:104:2:104:2 | *s [post update] [*val] |
+| clearning.cpp:104:2:104:8 | *... ++ | clearning.cpp:104:2:104:8 | *... ++ |
+| clearning.cpp:104:4:104:6 | *val | clearning.cpp:104:2:104:8 | *... ++ |
+| clearning.cpp:105:8:105:8 | *s [*val] | clearning.cpp:105:7:105:12 | * ... |
+| clearning.cpp:110:18:110:18 | *s [post update] [*val] | clearning.cpp:111:4:111:4 | *s [*val] |
+| clearning.cpp:110:20:110:22 | argument_source output argument | clearning.cpp:110:18:110:18 | *s [post update] [*val] |
+| clearning.cpp:111:2:111:8 | *++ ... | clearning.cpp:111:2:111:8 | *++ ... |
+| clearning.cpp:111:2:111:8 | *++ ... | clearning.cpp:111:4:111:4 | *s [post update] [*val] |
+| clearning.cpp:111:4:111:4 | *s [*val] | clearning.cpp:111:2:111:8 | *++ ... |
+| clearning.cpp:111:4:111:4 | *s [*val] | clearning.cpp:111:6:111:8 | *val |
+| clearning.cpp:111:4:111:4 | *s [*val] | clearning.cpp:112:8:112:8 | *s [*val] |
+| clearning.cpp:111:4:111:4 | *s [post update] [*val] | clearning.cpp:112:8:112:8 | *s [*val] |
+| clearning.cpp:111:6:111:8 | *val | clearning.cpp:111:2:111:8 | *++ ... |
+| clearning.cpp:112:8:112:8 | *s [*val] | clearning.cpp:112:7:112:12 | * ... |
+| clearning.cpp:117:18:117:18 | *s [post update] [*val] | clearning.cpp:118:2:118:2 | *s [*val] |
+| clearning.cpp:117:20:117:22 | argument_source output argument | clearning.cpp:117:18:117:18 | *s [post update] [*val] |
+| clearning.cpp:118:2:118:2 | *s [*val] | clearning.cpp:118:2:118:11 | *... += ... |
+| clearning.cpp:118:2:118:2 | *s [*val] | clearning.cpp:118:4:118:6 | *val |
+| clearning.cpp:118:2:118:2 | *s [*val] | clearning.cpp:119:8:119:8 | *s [*val] |
+| clearning.cpp:118:2:118:2 | *s [post update] [*val] | clearning.cpp:119:8:119:8 | *s [*val] |
+| clearning.cpp:118:2:118:11 | *... += ... | clearning.cpp:118:2:118:2 | *s [post update] [*val] |
+| clearning.cpp:118:2:118:11 | *... += ... | clearning.cpp:118:2:118:11 | *... += ... |
+| clearning.cpp:118:4:118:6 | *val | clearning.cpp:118:2:118:11 | *... += ... |
+| clearning.cpp:119:8:119:8 | *s [*val] | clearning.cpp:119:7:119:12 | * ... |
+| clearning.cpp:151:3:151:3 | *s [post update] [val] | clearning.cpp:152:8:152:8 | *s [val] |
+| clearning.cpp:151:3:151:22 | ... = ... | clearning.cpp:151:3:151:3 | *s [post update] [val] |
 | clearning.cpp:151:11:151:20 | call to user_input | clearning.cpp:151:3:151:22 | ... = ... |
-| clearning.cpp:152:8:152:8 | s indirection [val] | clearning.cpp:152:10:152:12 | val |
-| complex.cpp:9:7:9:7 | this indirection [a_] | complex.cpp:9:20:9:21 | this indirection [a_] |
-| complex.cpp:9:20:9:21 | a_ | complex.cpp:9:7:9:7 | a indirection |
-| complex.cpp:9:20:9:21 | this indirection [a_] | complex.cpp:9:20:9:21 | a_ |
-| complex.cpp:10:7:10:7 | this indirection [b_] | complex.cpp:10:20:10:21 | this indirection [b_] |
-| complex.cpp:10:20:10:21 | b_ | complex.cpp:10:7:10:7 | b indirection |
-| complex.cpp:10:20:10:21 | this indirection [b_] | complex.cpp:10:20:10:21 | b_ |
+| clearning.cpp:152:8:152:8 | *s [val] | clearning.cpp:152:10:152:12 | val |
+| complex.cpp:9:7:9:7 | *this [a_] | complex.cpp:9:20:9:21 | *this [a_] |
+| complex.cpp:9:20:9:21 | *this [a_] | complex.cpp:9:20:9:21 | a_ |
+| complex.cpp:9:20:9:21 | a_ | complex.cpp:9:7:9:7 | *a |
+| complex.cpp:10:7:10:7 | *this [b_] | complex.cpp:10:20:10:21 | *this [b_] |
+| complex.cpp:10:20:10:21 | *this [b_] | complex.cpp:10:20:10:21 | b_ |
+| complex.cpp:10:20:10:21 | b_ | complex.cpp:10:7:10:7 | *b |
 | complex.cpp:11:17:11:17 | a | complex.cpp:11:22:11:27 | ... = ... |
-| complex.cpp:11:22:11:27 | ... = ... | complex.cpp:11:22:11:23 | this indirection [post update] [a_] |
+| complex.cpp:11:22:11:27 | ... = ... | complex.cpp:11:22:11:23 | *this [post update] [a_] |
 | complex.cpp:12:17:12:17 | b | complex.cpp:12:22:12:27 | ... = ... |
-| complex.cpp:12:22:12:27 | ... = ... | complex.cpp:12:22:12:23 | this indirection [post update] [b_] |
-| complex.cpp:40:17:40:17 | b indirection [inner, f, a_] | complex.cpp:42:8:42:8 | b indirection [inner, f, a_] |
-| complex.cpp:40:17:40:17 | b indirection [inner, f, b_] | complex.cpp:43:8:43:8 | b indirection [inner, f, b_] |
-| complex.cpp:42:8:42:8 | b indirection [inner, f, a_] | complex.cpp:42:10:42:14 | inner indirection [f, a_] |
-| complex.cpp:42:10:42:14 | inner indirection [f, a_] | complex.cpp:42:16:42:16 | f indirection [a_] |
-| complex.cpp:42:16:42:16 | f indirection [a_] | complex.cpp:9:7:9:7 | this indirection [a_] |
-| complex.cpp:42:16:42:16 | f indirection [a_] | complex.cpp:42:18:42:18 | call to a |
-| complex.cpp:43:8:43:8 | b indirection [inner, f, b_] | complex.cpp:43:10:43:14 | inner indirection [f, b_] |
-| complex.cpp:43:10:43:14 | inner indirection [f, b_] | complex.cpp:43:16:43:16 | f indirection [b_] |
-| complex.cpp:43:16:43:16 | f indirection [b_] | complex.cpp:10:7:10:7 | this indirection [b_] |
-| complex.cpp:43:16:43:16 | f indirection [b_] | complex.cpp:43:18:43:18 | call to b |
-| complex.cpp:53:3:53:4 | b1 indirection [post update] [inner, f, a_] | complex.cpp:59:7:59:8 | b1 indirection [inner, f, a_] |
-| complex.cpp:53:6:53:10 | inner indirection [post update] [f, a_] | complex.cpp:53:3:53:4 | b1 indirection [post update] [inner, f, a_] |
-| complex.cpp:53:12:53:12 | setA output argument [a_] | complex.cpp:53:6:53:10 | inner indirection [post update] [f, a_] |
+| complex.cpp:12:22:12:27 | ... = ... | complex.cpp:12:22:12:23 | *this [post update] [b_] |
+| complex.cpp:40:17:40:17 | *b [inner, f, a_] | complex.cpp:42:8:42:8 | *b [inner, f, a_] |
+| complex.cpp:40:17:40:17 | *b [inner, f, b_] | complex.cpp:43:8:43:8 | *b [inner, f, b_] |
+| complex.cpp:42:8:42:8 | *b [inner, f, a_] | complex.cpp:42:10:42:14 | *inner [f, a_] |
+| complex.cpp:42:10:42:14 | *inner [f, a_] | complex.cpp:42:16:42:16 | *f [a_] |
+| complex.cpp:42:16:42:16 | *f [a_] | complex.cpp:9:7:9:7 | *this [a_] |
+| complex.cpp:42:16:42:16 | *f [a_] | complex.cpp:42:18:42:18 | call to a |
+| complex.cpp:43:8:43:8 | *b [inner, f, b_] | complex.cpp:43:10:43:14 | *inner [f, b_] |
+| complex.cpp:43:10:43:14 | *inner [f, b_] | complex.cpp:43:16:43:16 | *f [b_] |
+| complex.cpp:43:16:43:16 | *f [b_] | complex.cpp:10:7:10:7 | *this [b_] |
+| complex.cpp:43:16:43:16 | *f [b_] | complex.cpp:43:18:43:18 | call to b |
+| complex.cpp:53:3:53:4 | *b1 [post update] [inner, f, a_] | complex.cpp:59:7:59:8 | *b1 [inner, f, a_] |
+| complex.cpp:53:6:53:10 | *inner [post update] [f, a_] | complex.cpp:53:3:53:4 | *b1 [post update] [inner, f, a_] |
+| complex.cpp:53:12:53:12 | setA output argument [a_] | complex.cpp:53:6:53:10 | *inner [post update] [f, a_] |
 | complex.cpp:53:19:53:28 | call to user_input | complex.cpp:11:17:11:17 | a |
 | complex.cpp:53:19:53:28 | call to user_input | complex.cpp:53:12:53:12 | setA output argument [a_] |
-| complex.cpp:54:3:54:4 | b2 indirection [post update] [inner, f, b_] | complex.cpp:62:7:62:8 | b2 indirection [inner, f, b_] |
-| complex.cpp:54:6:54:10 | inner indirection [post update] [f, b_] | complex.cpp:54:3:54:4 | b2 indirection [post update] [inner, f, b_] |
-| complex.cpp:54:12:54:12 | setB output argument [b_] | complex.cpp:54:6:54:10 | inner indirection [post update] [f, b_] |
+| complex.cpp:54:3:54:4 | *b2 [post update] [inner, f, b_] | complex.cpp:62:7:62:8 | *b2 [inner, f, b_] |
+| complex.cpp:54:6:54:10 | *inner [post update] [f, b_] | complex.cpp:54:3:54:4 | *b2 [post update] [inner, f, b_] |
+| complex.cpp:54:12:54:12 | setB output argument [b_] | complex.cpp:54:6:54:10 | *inner [post update] [f, b_] |
 | complex.cpp:54:19:54:28 | call to user_input | complex.cpp:12:17:12:17 | b |
 | complex.cpp:54:19:54:28 | call to user_input | complex.cpp:54:12:54:12 | setB output argument [b_] |
-| complex.cpp:55:3:55:4 | b3 indirection [post update] [inner, f, a_] | complex.cpp:65:7:65:8 | b3 indirection [inner, f, a_] |
-| complex.cpp:55:6:55:10 | inner indirection [post update] [f, a_] | complex.cpp:55:3:55:4 | b3 indirection [post update] [inner, f, a_] |
-| complex.cpp:55:12:55:12 | setA output argument [a_] | complex.cpp:55:6:55:10 | inner indirection [post update] [f, a_] |
+| complex.cpp:55:3:55:4 | *b3 [post update] [inner, f, a_] | complex.cpp:65:7:65:8 | *b3 [inner, f, a_] |
+| complex.cpp:55:6:55:10 | *inner [post update] [f, a_] | complex.cpp:55:3:55:4 | *b3 [post update] [inner, f, a_] |
+| complex.cpp:55:12:55:12 | setA output argument [a_] | complex.cpp:55:6:55:10 | *inner [post update] [f, a_] |
 | complex.cpp:55:19:55:28 | call to user_input | complex.cpp:11:17:11:17 | a |
 | complex.cpp:55:19:55:28 | call to user_input | complex.cpp:55:12:55:12 | setA output argument [a_] |
-| complex.cpp:56:3:56:4 | b3 indirection [post update] [inner, f, b_] | complex.cpp:65:7:65:8 | b3 indirection [inner, f, b_] |
-| complex.cpp:56:6:56:10 | inner indirection [post update] [f, b_] | complex.cpp:56:3:56:4 | b3 indirection [post update] [inner, f, b_] |
-| complex.cpp:56:12:56:12 | setB output argument [b_] | complex.cpp:56:6:56:10 | inner indirection [post update] [f, b_] |
+| complex.cpp:56:3:56:4 | *b3 [post update] [inner, f, b_] | complex.cpp:65:7:65:8 | *b3 [inner, f, b_] |
+| complex.cpp:56:6:56:10 | *inner [post update] [f, b_] | complex.cpp:56:3:56:4 | *b3 [post update] [inner, f, b_] |
+| complex.cpp:56:12:56:12 | setB output argument [b_] | complex.cpp:56:6:56:10 | *inner [post update] [f, b_] |
 | complex.cpp:56:19:56:28 | call to user_input | complex.cpp:12:17:12:17 | b |
 | complex.cpp:56:19:56:28 | call to user_input | complex.cpp:56:12:56:12 | setB output argument [b_] |
-| complex.cpp:59:7:59:8 | b1 indirection [inner, f, a_] | complex.cpp:40:17:40:17 | b indirection [inner, f, a_] |
-| complex.cpp:62:7:62:8 | b2 indirection [inner, f, b_] | complex.cpp:40:17:40:17 | b indirection [inner, f, b_] |
-| complex.cpp:65:7:65:8 | b3 indirection [inner, f, a_] | complex.cpp:40:17:40:17 | b indirection [inner, f, a_] |
-| complex.cpp:65:7:65:8 | b3 indirection [inner, f, b_] | complex.cpp:40:17:40:17 | b indirection [inner, f, b_] |
-| conflated.cpp:10:3:10:22 | ... = ... | conflated.cpp:10:4:10:5 | ra indirection [post update] [p indirection] |
-| conflated.cpp:10:4:10:5 | ra indirection [post update] [p indirection] | conflated.cpp:11:9:11:10 | ra indirection [p indirection] |
+| complex.cpp:59:7:59:8 | *b1 [inner, f, a_] | complex.cpp:40:17:40:17 | *b [inner, f, a_] |
+| complex.cpp:62:7:62:8 | *b2 [inner, f, b_] | complex.cpp:40:17:40:17 | *b [inner, f, b_] |
+| complex.cpp:65:7:65:8 | *b3 [inner, f, a_] | complex.cpp:40:17:40:17 | *b [inner, f, a_] |
+| complex.cpp:65:7:65:8 | *b3 [inner, f, b_] | complex.cpp:40:17:40:17 | *b [inner, f, b_] |
+| conflated.cpp:10:3:10:22 | ... = ... | conflated.cpp:10:4:10:5 | *ra [post update] [*p] |
+| conflated.cpp:10:4:10:5 | *ra [post update] [*p] | conflated.cpp:11:9:11:10 | *ra [*p] |
 | conflated.cpp:10:11:10:20 | call to user_input | conflated.cpp:10:3:10:22 | ... = ... |
-| conflated.cpp:11:9:11:10 | ra indirection [p indirection] | conflated.cpp:11:8:11:12 | * ... |
-| conflated.cpp:19:19:19:21 | argument_source output argument | conflated.cpp:20:8:20:10 | raw indirection |
-| conflated.cpp:29:3:29:4 | pa indirection [post update] [x] | conflated.cpp:30:8:30:9 | pa indirection [x] |
-| conflated.cpp:29:3:29:22 | ... = ... | conflated.cpp:29:3:29:4 | pa indirection [post update] [x] |
+| conflated.cpp:11:9:11:10 | *ra [*p] | conflated.cpp:11:8:11:12 | * ... |
+| conflated.cpp:19:19:19:21 | argument_source output argument | conflated.cpp:20:8:20:10 | *raw |
+| conflated.cpp:29:3:29:4 | *pa [post update] [x] | conflated.cpp:30:8:30:9 | *pa [x] |
+| conflated.cpp:29:3:29:22 | ... = ... | conflated.cpp:29:3:29:4 | *pa [post update] [x] |
 | conflated.cpp:29:11:29:20 | call to user_input | conflated.cpp:29:3:29:22 | ... = ... |
-| conflated.cpp:30:8:30:9 | pa indirection [x] | conflated.cpp:30:12:30:12 | x |
-| conflated.cpp:36:3:36:4 | pa indirection [post update] [x] | conflated.cpp:37:8:37:9 | pa indirection [x] |
-| conflated.cpp:36:3:36:22 | ... = ... | conflated.cpp:36:3:36:4 | pa indirection [post update] [x] |
+| conflated.cpp:30:8:30:9 | *pa [x] | conflated.cpp:30:12:30:12 | x |
+| conflated.cpp:36:3:36:4 | *pa [post update] [x] | conflated.cpp:37:8:37:9 | *pa [x] |
+| conflated.cpp:36:3:36:22 | ... = ... | conflated.cpp:36:3:36:4 | *pa [post update] [x] |
 | conflated.cpp:36:11:36:20 | call to user_input | conflated.cpp:36:3:36:22 | ... = ... |
-| conflated.cpp:37:8:37:9 | pa indirection [x] | conflated.cpp:37:12:37:12 | x |
-| conflated.cpp:54:3:54:4 | ll indirection [post update] [next indirection, y] | conflated.cpp:55:8:55:9 | ll indirection [next indirection, y] |
-| conflated.cpp:54:3:54:28 | ... = ... | conflated.cpp:54:7:54:10 | next indirection [post update] [y] |
-| conflated.cpp:54:7:54:10 | next indirection [post update] [y] | conflated.cpp:54:3:54:4 | ll indirection [post update] [next indirection, y] |
+| conflated.cpp:37:8:37:9 | *pa [x] | conflated.cpp:37:12:37:12 | x |
+| conflated.cpp:54:3:54:4 | *ll [post update] [*next, y] | conflated.cpp:55:8:55:9 | *ll [*next, y] |
+| conflated.cpp:54:3:54:28 | ... = ... | conflated.cpp:54:7:54:10 | *next [post update] [y] |
+| conflated.cpp:54:7:54:10 | *next [post update] [y] | conflated.cpp:54:3:54:4 | *ll [post update] [*next, y] |
 | conflated.cpp:54:17:54:26 | call to user_input | conflated.cpp:54:3:54:28 | ... = ... |
-| conflated.cpp:55:8:55:9 | ll indirection [next indirection, y] | conflated.cpp:55:12:55:15 | next indirection [y] |
-| conflated.cpp:55:12:55:15 | next indirection [y] | conflated.cpp:55:18:55:18 | y |
-| conflated.cpp:60:3:60:4 | ll indirection [post update] [next indirection, y] | conflated.cpp:61:8:61:9 | ll indirection [next indirection, y] |
-| conflated.cpp:60:3:60:28 | ... = ... | conflated.cpp:60:7:60:10 | next indirection [post update] [y] |
-| conflated.cpp:60:7:60:10 | next indirection [post update] [y] | conflated.cpp:60:3:60:4 | ll indirection [post update] [next indirection, y] |
+| conflated.cpp:55:8:55:9 | *ll [*next, y] | conflated.cpp:55:12:55:15 | *next [y] |
+| conflated.cpp:55:12:55:15 | *next [y] | conflated.cpp:55:18:55:18 | y |
+| conflated.cpp:60:3:60:4 | *ll [post update] [*next, y] | conflated.cpp:61:8:61:9 | *ll [*next, y] |
+| conflated.cpp:60:3:60:28 | ... = ... | conflated.cpp:60:7:60:10 | *next [post update] [y] |
+| conflated.cpp:60:7:60:10 | *next [post update] [y] | conflated.cpp:60:3:60:4 | *ll [post update] [*next, y] |
 | conflated.cpp:60:17:60:26 | call to user_input | conflated.cpp:60:3:60:28 | ... = ... |
-| conflated.cpp:61:8:61:9 | ll indirection [next indirection, y] | conflated.cpp:61:12:61:15 | next indirection [y] |
-| conflated.cpp:61:12:61:15 | next indirection [y] | conflated.cpp:61:18:61:18 | y |
-| constructors.cpp:18:9:18:9 | this indirection [a_] | constructors.cpp:18:22:18:23 | this indirection [a_] |
-| constructors.cpp:18:22:18:23 | a_ | constructors.cpp:18:9:18:9 | a indirection |
-| constructors.cpp:18:22:18:23 | this indirection [a_] | constructors.cpp:18:22:18:23 | a_ |
-| constructors.cpp:19:9:19:9 | this indirection [b_] | constructors.cpp:19:22:19:23 | this indirection [b_] |
-| constructors.cpp:19:22:19:23 | b_ | constructors.cpp:19:9:19:9 | b indirection |
-| constructors.cpp:19:22:19:23 | this indirection [b_] | constructors.cpp:19:22:19:23 | b_ |
+| conflated.cpp:61:8:61:9 | *ll [*next, y] | conflated.cpp:61:12:61:15 | *next [y] |
+| conflated.cpp:61:12:61:15 | *next [y] | conflated.cpp:61:18:61:18 | y |
+| constructors.cpp:18:9:18:9 | *this [a_] | constructors.cpp:18:22:18:23 | *this [a_] |
+| constructors.cpp:18:22:18:23 | *this [a_] | constructors.cpp:18:22:18:23 | a_ |
+| constructors.cpp:18:22:18:23 | a_ | constructors.cpp:18:9:18:9 | *a |
+| constructors.cpp:19:9:19:9 | *this [b_] | constructors.cpp:19:22:19:23 | *this [b_] |
+| constructors.cpp:19:22:19:23 | *this [b_] | constructors.cpp:19:22:19:23 | b_ |
+| constructors.cpp:19:22:19:23 | b_ | constructors.cpp:19:9:19:9 | *b |
 | constructors.cpp:23:13:23:13 | a | constructors.cpp:23:28:23:28 | a |
 | constructors.cpp:23:20:23:20 | b | constructors.cpp:23:35:23:35 | b |
-| constructors.cpp:23:28:23:28 | a | constructors.cpp:23:5:23:7 | this indirection [post update] [a_] |
-| constructors.cpp:23:35:23:35 | b | constructors.cpp:23:5:23:7 | this indirection [post update] [b_] |
-| constructors.cpp:26:15:26:15 | f indirection [a_] | constructors.cpp:28:10:28:10 | f indirection [a_] |
-| constructors.cpp:26:15:26:15 | f indirection [b_] | constructors.cpp:29:10:29:10 | f indirection [b_] |
-| constructors.cpp:28:10:28:10 | f indirection [a_] | constructors.cpp:18:9:18:9 | this indirection [a_] |
-| constructors.cpp:28:10:28:10 | f indirection [a_] | constructors.cpp:28:12:28:12 | call to a |
-| constructors.cpp:29:10:29:10 | f indirection [b_] | constructors.cpp:19:9:19:9 | this indirection [b_] |
-| constructors.cpp:29:10:29:10 | f indirection [b_] | constructors.cpp:29:12:29:12 | call to b |
-| constructors.cpp:34:9:34:9 | call to Foo [a_] | constructors.cpp:40:9:40:9 | f indirection [a_] |
+| constructors.cpp:23:28:23:28 | a | constructors.cpp:23:5:23:7 | *this [post update] [a_] |
+| constructors.cpp:23:35:23:35 | b | constructors.cpp:23:5:23:7 | *this [post update] [b_] |
+| constructors.cpp:26:15:26:15 | *f [a_] | constructors.cpp:28:10:28:10 | *f [a_] |
+| constructors.cpp:26:15:26:15 | *f [b_] | constructors.cpp:29:10:29:10 | *f [b_] |
+| constructors.cpp:28:10:28:10 | *f [a_] | constructors.cpp:18:9:18:9 | *this [a_] |
+| constructors.cpp:28:10:28:10 | *f [a_] | constructors.cpp:28:12:28:12 | call to a |
+| constructors.cpp:29:10:29:10 | *f [b_] | constructors.cpp:19:9:19:9 | *this [b_] |
+| constructors.cpp:29:10:29:10 | *f [b_] | constructors.cpp:29:12:29:12 | call to b |
+| constructors.cpp:34:9:34:9 | call to Foo [a_] | constructors.cpp:40:9:40:9 | *f [a_] |
 | constructors.cpp:34:11:34:20 | call to user_input | constructors.cpp:23:13:23:13 | a |
 | constructors.cpp:34:11:34:20 | call to user_input | constructors.cpp:34:9:34:9 | call to Foo [a_] |
-| constructors.cpp:35:9:35:9 | call to Foo [b_] | constructors.cpp:43:9:43:9 | g indirection [b_] |
+| constructors.cpp:35:9:35:9 | call to Foo [b_] | constructors.cpp:43:9:43:9 | *g [b_] |
 | constructors.cpp:35:14:35:23 | call to user_input | constructors.cpp:23:20:23:20 | b |
 | constructors.cpp:35:14:35:23 | call to user_input | constructors.cpp:35:9:35:9 | call to Foo [b_] |
-| constructors.cpp:36:9:36:9 | call to Foo [a_] | constructors.cpp:46:9:46:9 | h indirection [a_] |
-| constructors.cpp:36:9:36:9 | call to Foo [b_] | constructors.cpp:46:9:46:9 | h indirection [b_] |
+| constructors.cpp:36:9:36:9 | call to Foo [a_] | constructors.cpp:46:9:46:9 | *h [a_] |
+| constructors.cpp:36:9:36:9 | call to Foo [b_] | constructors.cpp:46:9:46:9 | *h [b_] |
 | constructors.cpp:36:11:36:20 | call to user_input | constructors.cpp:23:13:23:13 | a |
 | constructors.cpp:36:11:36:20 | call to user_input | constructors.cpp:36:9:36:9 | call to Foo [a_] |
 | constructors.cpp:36:25:36:34 | call to user_input | constructors.cpp:23:20:23:20 | b |
 | constructors.cpp:36:25:36:34 | call to user_input | constructors.cpp:36:9:36:9 | call to Foo [b_] |
-| constructors.cpp:40:9:40:9 | f indirection [a_] | constructors.cpp:26:15:26:15 | f indirection [a_] |
-| constructors.cpp:43:9:43:9 | g indirection [b_] | constructors.cpp:26:15:26:15 | f indirection [b_] |
-| constructors.cpp:46:9:46:9 | h indirection [a_] | constructors.cpp:26:15:26:15 | f indirection [a_] |
-| constructors.cpp:46:9:46:9 | h indirection [b_] | constructors.cpp:26:15:26:15 | f indirection [b_] |
+| constructors.cpp:40:9:40:9 | *f [a_] | constructors.cpp:26:15:26:15 | *f [a_] |
+| constructors.cpp:43:9:43:9 | *g [b_] | constructors.cpp:26:15:26:15 | *f [b_] |
+| constructors.cpp:46:9:46:9 | *h [a_] | constructors.cpp:26:15:26:15 | *f [a_] |
+| constructors.cpp:46:9:46:9 | *h [b_] | constructors.cpp:26:15:26:15 | *f [b_] |
 | qualifiers.cpp:9:21:9:25 | value | qualifiers.cpp:9:30:9:44 | ... = ... |
-| qualifiers.cpp:9:30:9:44 | ... = ... | qualifiers.cpp:9:30:9:33 | this indirection [post update] [a] |
+| qualifiers.cpp:9:30:9:44 | ... = ... | qualifiers.cpp:9:30:9:33 | *this [post update] [a] |
 | qualifiers.cpp:12:40:12:44 | value | qualifiers.cpp:12:49:12:64 | ... = ... |
-| qualifiers.cpp:12:49:12:64 | ... = ... | qualifiers.cpp:12:49:12:53 | inner indirection [post update] [a] |
+| qualifiers.cpp:12:49:12:64 | ... = ... | qualifiers.cpp:12:49:12:53 | *inner [post update] [a] |
 | qualifiers.cpp:13:42:13:46 | value | qualifiers.cpp:13:51:13:65 | ... = ... |
-| qualifiers.cpp:13:51:13:65 | ... = ... | qualifiers.cpp:13:51:13:55 | inner indirection [post update] [a] |
-| qualifiers.cpp:22:5:22:9 | getInner output argument [inner indirection, a] | qualifiers.cpp:23:10:23:14 | outer indirection [inner indirection, a] |
-| qualifiers.cpp:22:5:22:38 | ... = ... | qualifiers.cpp:22:11:22:18 | call to getInner indirection [post update] [a] |
-| qualifiers.cpp:22:11:22:18 | call to getInner indirection [post update] [a] | qualifiers.cpp:22:5:22:9 | getInner output argument [inner indirection, a] |
+| qualifiers.cpp:13:51:13:65 | ... = ... | qualifiers.cpp:13:51:13:55 | *inner [post update] [a] |
+| qualifiers.cpp:22:5:22:9 | getInner output argument [*inner, a] | qualifiers.cpp:23:10:23:14 | *outer [*inner, a] |
+| qualifiers.cpp:22:5:22:38 | ... = ... | qualifiers.cpp:22:11:22:18 | *call to getInner [post update] [a] |
+| qualifiers.cpp:22:11:22:18 | *call to getInner [post update] [a] | qualifiers.cpp:22:5:22:9 | getInner output argument [*inner, a] |
 | qualifiers.cpp:22:27:22:36 | call to user_input | qualifiers.cpp:22:5:22:38 | ... = ... |
-| qualifiers.cpp:23:10:23:14 | outer indirection [inner indirection, a] | qualifiers.cpp:23:16:23:20 | inner indirection [a] |
-| qualifiers.cpp:23:16:23:20 | inner indirection [a] | qualifiers.cpp:23:23:23:23 | a |
-| qualifiers.cpp:27:5:27:9 | getInner output argument [inner indirection, a] | qualifiers.cpp:28:10:28:14 | outer indirection [inner indirection, a] |
-| qualifiers.cpp:27:11:27:18 | setA output argument [a] | qualifiers.cpp:27:5:27:9 | getInner output argument [inner indirection, a] |
+| qualifiers.cpp:23:10:23:14 | *outer [*inner, a] | qualifiers.cpp:23:16:23:20 | *inner [a] |
+| qualifiers.cpp:23:16:23:20 | *inner [a] | qualifiers.cpp:23:23:23:23 | a |
+| qualifiers.cpp:27:5:27:9 | getInner output argument [*inner, a] | qualifiers.cpp:28:10:28:14 | *outer [*inner, a] |
+| qualifiers.cpp:27:11:27:18 | setA output argument [a] | qualifiers.cpp:27:5:27:9 | getInner output argument [*inner, a] |
 | qualifiers.cpp:27:28:27:37 | call to user_input | qualifiers.cpp:9:21:9:25 | value |
 | qualifiers.cpp:27:28:27:37 | call to user_input | qualifiers.cpp:27:11:27:18 | setA output argument [a] |
-| qualifiers.cpp:28:10:28:14 | outer indirection [inner indirection, a] | qualifiers.cpp:28:16:28:20 | inner indirection [a] |
-| qualifiers.cpp:28:16:28:20 | inner indirection [a] | qualifiers.cpp:28:23:28:23 | a |
-| qualifiers.cpp:32:17:32:21 | getInner output argument [inner indirection, a] | qualifiers.cpp:33:10:33:14 | outer indirection [inner indirection, a] |
-| qualifiers.cpp:32:23:32:30 | pointerSetA output argument [a] | qualifiers.cpp:32:17:32:21 | getInner output argument [inner indirection, a] |
+| qualifiers.cpp:28:10:28:14 | *outer [*inner, a] | qualifiers.cpp:28:16:28:20 | *inner [a] |
+| qualifiers.cpp:28:16:28:20 | *inner [a] | qualifiers.cpp:28:23:28:23 | a |
+| qualifiers.cpp:32:17:32:21 | getInner output argument [*inner, a] | qualifiers.cpp:33:10:33:14 | *outer [*inner, a] |
+| qualifiers.cpp:32:23:32:30 | pointerSetA output argument [a] | qualifiers.cpp:32:17:32:21 | getInner output argument [*inner, a] |
 | qualifiers.cpp:32:35:32:44 | call to user_input | qualifiers.cpp:12:40:12:44 | value |
 | qualifiers.cpp:32:35:32:44 | call to user_input | qualifiers.cpp:32:23:32:30 | pointerSetA output argument [a] |
-| qualifiers.cpp:33:10:33:14 | outer indirection [inner indirection, a] | qualifiers.cpp:33:16:33:20 | inner indirection [a] |
-| qualifiers.cpp:33:16:33:20 | inner indirection [a] | qualifiers.cpp:33:23:33:23 | a |
-| qualifiers.cpp:37:19:37:35 | referenceSetA output argument [a] | qualifiers.cpp:37:20:37:24 | getInner output argument [inner indirection, a] |
-| qualifiers.cpp:37:20:37:24 | getInner output argument [inner indirection, a] | qualifiers.cpp:38:10:38:14 | outer indirection [inner indirection, a] |
+| qualifiers.cpp:33:10:33:14 | *outer [*inner, a] | qualifiers.cpp:33:16:33:20 | *inner [a] |
+| qualifiers.cpp:33:16:33:20 | *inner [a] | qualifiers.cpp:33:23:33:23 | a |
+| qualifiers.cpp:37:19:37:35 | referenceSetA output argument [a] | qualifiers.cpp:37:20:37:24 | getInner output argument [*inner, a] |
+| qualifiers.cpp:37:20:37:24 | getInner output argument [*inner, a] | qualifiers.cpp:38:10:38:14 | *outer [*inner, a] |
 | qualifiers.cpp:37:38:37:47 | call to user_input | qualifiers.cpp:13:42:13:46 | value |
 | qualifiers.cpp:37:38:37:47 | call to user_input | qualifiers.cpp:37:19:37:35 | referenceSetA output argument [a] |
-| qualifiers.cpp:38:10:38:14 | outer indirection [inner indirection, a] | qualifiers.cpp:38:16:38:20 | inner indirection [a] |
-| qualifiers.cpp:38:16:38:20 | inner indirection [a] | qualifiers.cpp:38:23:38:23 | a |
-| qualifiers.cpp:42:5:42:40 | ... = ... | qualifiers.cpp:42:6:42:22 | * ... indirection [post update] [a] |
-| qualifiers.cpp:42:6:42:22 | * ... indirection [post update] [a] | qualifiers.cpp:42:7:42:11 | getInner output argument [inner indirection, a] |
-| qualifiers.cpp:42:7:42:11 | getInner output argument [inner indirection, a] | qualifiers.cpp:43:10:43:14 | outer indirection [inner indirection, a] |
+| qualifiers.cpp:38:10:38:14 | *outer [*inner, a] | qualifiers.cpp:38:16:38:20 | *inner [a] |
+| qualifiers.cpp:38:16:38:20 | *inner [a] | qualifiers.cpp:38:23:38:23 | a |
+| qualifiers.cpp:42:5:42:40 | ... = ... | qualifiers.cpp:42:6:42:22 | ** ... [post update] [a] |
+| qualifiers.cpp:42:6:42:22 | ** ... [post update] [a] | qualifiers.cpp:42:7:42:11 | getInner output argument [*inner, a] |
+| qualifiers.cpp:42:7:42:11 | getInner output argument [*inner, a] | qualifiers.cpp:43:10:43:14 | *outer [*inner, a] |
 | qualifiers.cpp:42:29:42:38 | call to user_input | qualifiers.cpp:42:5:42:40 | ... = ... |
-| qualifiers.cpp:43:10:43:14 | outer indirection [inner indirection, a] | qualifiers.cpp:43:16:43:20 | inner indirection [a] |
-| qualifiers.cpp:43:16:43:20 | inner indirection [a] | qualifiers.cpp:43:23:43:23 | a |
-| qualifiers.cpp:47:5:47:42 | ... = ... | qualifiers.cpp:47:15:47:22 | call to getInner indirection [post update] [a] |
-| qualifiers.cpp:47:6:47:11 | getInner output argument [inner indirection, a] | qualifiers.cpp:48:10:48:14 | outer indirection [inner indirection, a] |
-| qualifiers.cpp:47:15:47:22 | call to getInner indirection [post update] [a] | qualifiers.cpp:47:6:47:11 | getInner output argument [inner indirection, a] |
+| qualifiers.cpp:43:10:43:14 | *outer [*inner, a] | qualifiers.cpp:43:16:43:20 | *inner [a] |
+| qualifiers.cpp:43:16:43:20 | *inner [a] | qualifiers.cpp:43:23:43:23 | a |
+| qualifiers.cpp:47:5:47:42 | ... = ... | qualifiers.cpp:47:15:47:22 | *call to getInner [post update] [a] |
+| qualifiers.cpp:47:6:47:11 | getInner output argument [*inner, a] | qualifiers.cpp:48:10:48:14 | *outer [*inner, a] |
+| qualifiers.cpp:47:15:47:22 | *call to getInner [post update] [a] | qualifiers.cpp:47:6:47:11 | getInner output argument [*inner, a] |
 | qualifiers.cpp:47:31:47:40 | call to user_input | qualifiers.cpp:47:5:47:42 | ... = ... |
-| qualifiers.cpp:48:10:48:14 | outer indirection [inner indirection, a] | qualifiers.cpp:48:16:48:20 | inner indirection [a] |
-| qualifiers.cpp:48:16:48:20 | inner indirection [a] | qualifiers.cpp:48:23:48:23 | a |
-| realistic.cpp:53:9:53:11 | foo indirection [post update] [bar, baz indirection, userInput, bufferLen] | realistic.cpp:61:21:61:23 | foo indirection [bar, baz indirection, userInput, bufferLen] |
-| realistic.cpp:53:9:53:18 | access to array indirection [post update] [baz indirection, userInput, bufferLen] | realistic.cpp:53:9:53:11 | foo indirection [post update] [bar, baz indirection, userInput, bufferLen] |
-| realistic.cpp:53:9:53:66 | ... = ... | realistic.cpp:53:25:53:33 | userInput indirection [post update] [bufferLen] |
-| realistic.cpp:53:20:53:22 | baz indirection [post update] [userInput, bufferLen] | realistic.cpp:53:9:53:18 | access to array indirection [post update] [baz indirection, userInput, bufferLen] |
-| realistic.cpp:53:25:53:33 | userInput indirection [post update] [bufferLen] | realistic.cpp:53:20:53:22 | baz indirection [post update] [userInput, bufferLen] |
+| qualifiers.cpp:48:10:48:14 | *outer [*inner, a] | qualifiers.cpp:48:16:48:20 | *inner [a] |
+| qualifiers.cpp:48:16:48:20 | *inner [a] | qualifiers.cpp:48:23:48:23 | a |
+| realistic.cpp:53:9:53:11 | *foo [post update] [bar, *baz, userInput, bufferLen] | realistic.cpp:61:21:61:23 | *foo [bar, *baz, userInput, bufferLen] |
+| realistic.cpp:53:9:53:18 | *access to array [post update] [*baz, userInput, bufferLen] | realistic.cpp:53:9:53:11 | *foo [post update] [bar, *baz, userInput, bufferLen] |
+| realistic.cpp:53:9:53:66 | ... = ... | realistic.cpp:53:25:53:33 | *userInput [post update] [bufferLen] |
+| realistic.cpp:53:20:53:22 | *baz [post update] [userInput, bufferLen] | realistic.cpp:53:9:53:18 | *access to array [post update] [*baz, userInput, bufferLen] |
+| realistic.cpp:53:25:53:33 | *userInput [post update] [bufferLen] | realistic.cpp:53:20:53:22 | *baz [post update] [userInput, bufferLen] |
 | realistic.cpp:53:47:53:66 | call to user_input | realistic.cpp:53:9:53:66 | ... = ... |
-| realistic.cpp:61:21:61:23 | foo indirection [bar, baz indirection, userInput, bufferLen] | realistic.cpp:61:21:61:30 | access to array indirection [baz indirection, userInput, bufferLen] |
-| realistic.cpp:61:21:61:30 | access to array indirection [baz indirection, userInput, bufferLen] | realistic.cpp:61:32:61:34 | baz indirection [userInput, bufferLen] |
-| realistic.cpp:61:32:61:34 | baz indirection [userInput, bufferLen] | realistic.cpp:61:37:61:45 | userInput indirection [bufferLen] |
-| realistic.cpp:61:37:61:45 | userInput indirection [bufferLen] | realistic.cpp:61:14:61:55 | bufferLen |
-| simple.cpp:18:9:18:9 | this indirection [a_] | simple.cpp:18:22:18:23 | this indirection [a_] |
-| simple.cpp:18:22:18:23 | a_ | simple.cpp:18:9:18:9 | a indirection |
-| simple.cpp:18:22:18:23 | this indirection [a_] | simple.cpp:18:22:18:23 | a_ |
-| simple.cpp:19:9:19:9 | this indirection [b_] | simple.cpp:19:22:19:23 | this indirection [b_] |
-| simple.cpp:19:22:19:23 | b_ | simple.cpp:19:9:19:9 | b indirection |
-| simple.cpp:19:22:19:23 | this indirection [b_] | simple.cpp:19:22:19:23 | b_ |
+| realistic.cpp:61:21:61:23 | *foo [bar, *baz, userInput, bufferLen] | realistic.cpp:61:21:61:30 | *access to array [*baz, userInput, bufferLen] |
+| realistic.cpp:61:21:61:30 | *access to array [*baz, userInput, bufferLen] | realistic.cpp:61:32:61:34 | *baz [userInput, bufferLen] |
+| realistic.cpp:61:32:61:34 | *baz [userInput, bufferLen] | realistic.cpp:61:37:61:45 | *userInput [bufferLen] |
+| realistic.cpp:61:37:61:45 | *userInput [bufferLen] | realistic.cpp:61:14:61:55 | bufferLen |
+| simple.cpp:18:9:18:9 | *this [a_] | simple.cpp:18:22:18:23 | *this [a_] |
+| simple.cpp:18:22:18:23 | *this [a_] | simple.cpp:18:22:18:23 | a_ |
+| simple.cpp:18:22:18:23 | a_ | simple.cpp:18:9:18:9 | *a |
+| simple.cpp:19:9:19:9 | *this [b_] | simple.cpp:19:22:19:23 | *this [b_] |
+| simple.cpp:19:22:19:23 | *this [b_] | simple.cpp:19:22:19:23 | b_ |
+| simple.cpp:19:22:19:23 | b_ | simple.cpp:19:9:19:9 | *b |
 | simple.cpp:20:19:20:19 | a | simple.cpp:20:24:20:29 | ... = ... |
-| simple.cpp:20:24:20:29 | ... = ... | simple.cpp:20:24:20:25 | this indirection [post update] [a_] |
+| simple.cpp:20:24:20:29 | ... = ... | simple.cpp:20:24:20:25 | *this [post update] [a_] |
 | simple.cpp:21:19:21:19 | b | simple.cpp:21:24:21:29 | ... = ... |
-| simple.cpp:21:24:21:29 | ... = ... | simple.cpp:21:24:21:25 | this indirection [post update] [b_] |
-| simple.cpp:26:15:26:15 | f indirection [a_] | simple.cpp:28:10:28:10 | f indirection [a_] |
-| simple.cpp:26:15:26:15 | f indirection [b_] | simple.cpp:29:10:29:10 | f indirection [b_] |
-| simple.cpp:28:10:28:10 | f indirection [a_] | simple.cpp:18:9:18:9 | this indirection [a_] |
-| simple.cpp:28:10:28:10 | f indirection [a_] | simple.cpp:28:12:28:12 | call to a |
-| simple.cpp:29:10:29:10 | f indirection [b_] | simple.cpp:19:9:19:9 | this indirection [b_] |
-| simple.cpp:29:10:29:10 | f indirection [b_] | simple.cpp:29:12:29:12 | call to b |
-| simple.cpp:39:5:39:5 | setA output argument [a_] | simple.cpp:45:9:45:9 | f indirection [a_] |
+| simple.cpp:21:24:21:29 | ... = ... | simple.cpp:21:24:21:25 | *this [post update] [b_] |
+| simple.cpp:26:15:26:15 | *f [a_] | simple.cpp:28:10:28:10 | *f [a_] |
+| simple.cpp:26:15:26:15 | *f [b_] | simple.cpp:29:10:29:10 | *f [b_] |
+| simple.cpp:28:10:28:10 | *f [a_] | simple.cpp:18:9:18:9 | *this [a_] |
+| simple.cpp:28:10:28:10 | *f [a_] | simple.cpp:28:12:28:12 | call to a |
+| simple.cpp:29:10:29:10 | *f [b_] | simple.cpp:19:9:19:9 | *this [b_] |
+| simple.cpp:29:10:29:10 | *f [b_] | simple.cpp:29:12:29:12 | call to b |
+| simple.cpp:39:5:39:5 | setA output argument [a_] | simple.cpp:45:9:45:9 | *f [a_] |
 | simple.cpp:39:12:39:21 | call to user_input | simple.cpp:20:19:20:19 | a |
 | simple.cpp:39:12:39:21 | call to user_input | simple.cpp:39:5:39:5 | setA output argument [a_] |
-| simple.cpp:40:5:40:5 | setB output argument [b_] | simple.cpp:48:9:48:9 | g indirection [b_] |
+| simple.cpp:40:5:40:5 | setB output argument [b_] | simple.cpp:48:9:48:9 | *g [b_] |
 | simple.cpp:40:12:40:21 | call to user_input | simple.cpp:21:19:21:19 | b |
 | simple.cpp:40:12:40:21 | call to user_input | simple.cpp:40:5:40:5 | setB output argument [b_] |
-| simple.cpp:41:5:41:5 | setA output argument [a_] | simple.cpp:51:9:51:9 | h indirection [a_] |
+| simple.cpp:41:5:41:5 | setA output argument [a_] | simple.cpp:51:9:51:9 | *h [a_] |
 | simple.cpp:41:12:41:21 | call to user_input | simple.cpp:20:19:20:19 | a |
 | simple.cpp:41:12:41:21 | call to user_input | simple.cpp:41:5:41:5 | setA output argument [a_] |
-| simple.cpp:42:5:42:5 | setB output argument [b_] | simple.cpp:51:9:51:9 | h indirection [b_] |
+| simple.cpp:42:5:42:5 | setB output argument [b_] | simple.cpp:51:9:51:9 | *h [b_] |
 | simple.cpp:42:12:42:21 | call to user_input | simple.cpp:21:19:21:19 | b |
 | simple.cpp:42:12:42:21 | call to user_input | simple.cpp:42:5:42:5 | setB output argument [b_] |
-| simple.cpp:45:9:45:9 | f indirection [a_] | simple.cpp:26:15:26:15 | f indirection [a_] |
-| simple.cpp:48:9:48:9 | g indirection [b_] | simple.cpp:26:15:26:15 | f indirection [b_] |
-| simple.cpp:51:9:51:9 | h indirection [a_] | simple.cpp:26:15:26:15 | f indirection [a_] |
-| simple.cpp:51:9:51:9 | h indirection [b_] | simple.cpp:26:15:26:15 | f indirection [b_] |
-| simple.cpp:65:5:65:5 | a indirection [post update] [i] | simple.cpp:67:10:67:11 | a2 indirection [i] |
-| simple.cpp:65:5:65:22 | ... = ... | simple.cpp:65:5:65:5 | a indirection [post update] [i] |
+| simple.cpp:45:9:45:9 | *f [a_] | simple.cpp:26:15:26:15 | *f [a_] |
+| simple.cpp:48:9:48:9 | *g [b_] | simple.cpp:26:15:26:15 | *f [b_] |
+| simple.cpp:51:9:51:9 | *h [a_] | simple.cpp:26:15:26:15 | *f [a_] |
+| simple.cpp:51:9:51:9 | *h [b_] | simple.cpp:26:15:26:15 | *f [b_] |
+| simple.cpp:65:5:65:5 | *a [post update] [i] | simple.cpp:67:10:67:11 | *a2 [i] |
+| simple.cpp:65:5:65:22 | ... = ... | simple.cpp:65:5:65:5 | *a [post update] [i] |
 | simple.cpp:65:11:65:20 | call to user_input | simple.cpp:65:5:65:22 | ... = ... |
-| simple.cpp:67:10:67:11 | a2 indirection [i] | simple.cpp:67:13:67:13 | i |
-| simple.cpp:78:9:78:15 | this indirection [f2, f1] | simple.cpp:79:16:79:17 | this indirection [f2, f1] |
-| simple.cpp:79:16:79:17 | f2 indirection [f1] | simple.cpp:79:19:79:20 | f1 |
-| simple.cpp:79:16:79:17 | this indirection [f2, f1] | simple.cpp:79:16:79:17 | f2 indirection [f1] |
-| simple.cpp:79:19:79:20 | f1 | simple.cpp:78:9:78:15 | getf2f1 indirection |
-| simple.cpp:83:9:83:10 | f2 indirection [post update] [f1] | simple.cpp:83:9:83:10 | this indirection [post update] [f2, f1] |
-| simple.cpp:83:9:83:10 | this indirection [post update] [f2, f1] | simple.cpp:84:14:84:20 | this indirection [f2, f1] |
-| simple.cpp:83:9:83:28 | ... = ... | simple.cpp:83:9:83:10 | f2 indirection [post update] [f1] |
+| simple.cpp:67:10:67:11 | *a2 [i] | simple.cpp:67:13:67:13 | i |
+| simple.cpp:78:9:78:15 | *this [f2, f1] | simple.cpp:79:16:79:17 | *this [f2, f1] |
+| simple.cpp:79:16:79:17 | *f2 [f1] | simple.cpp:79:19:79:20 | f1 |
+| simple.cpp:79:16:79:17 | *this [f2, f1] | simple.cpp:79:16:79:17 | *f2 [f1] |
+| simple.cpp:79:19:79:20 | f1 | simple.cpp:78:9:78:15 | *getf2f1 |
+| simple.cpp:83:9:83:10 | *f2 [post update] [f1] | simple.cpp:83:9:83:10 | *this [post update] [f2, f1] |
+| simple.cpp:83:9:83:10 | *this [post update] [f2, f1] | simple.cpp:84:14:84:20 | *this [f2, f1] |
+| simple.cpp:83:9:83:28 | ... = ... | simple.cpp:83:9:83:10 | *f2 [post update] [f1] |
 | simple.cpp:83:17:83:26 | call to user_input | simple.cpp:83:9:83:28 | ... = ... |
-| simple.cpp:84:14:84:20 | this indirection [f2, f1] | simple.cpp:78:9:78:15 | this indirection [f2, f1] |
-| simple.cpp:84:14:84:20 | this indirection [f2, f1] | simple.cpp:84:14:84:20 | call to getf2f1 |
-| simple.cpp:92:5:92:5 | a indirection [post update] [i] | simple.cpp:94:10:94:11 | a2 indirection [i] |
-| simple.cpp:92:5:92:22 | ... = ... | simple.cpp:92:5:92:5 | a indirection [post update] [i] |
+| simple.cpp:84:14:84:20 | *this [f2, f1] | simple.cpp:78:9:78:15 | *this [f2, f1] |
+| simple.cpp:84:14:84:20 | *this [f2, f1] | simple.cpp:84:14:84:20 | call to getf2f1 |
+| simple.cpp:92:5:92:5 | *a [post update] [i] | simple.cpp:94:10:94:11 | *a2 [i] |
+| simple.cpp:92:5:92:22 | ... = ... | simple.cpp:92:5:92:5 | *a [post update] [i] |
 | simple.cpp:92:11:92:20 | call to user_input | simple.cpp:92:5:92:22 | ... = ... |
-| simple.cpp:94:10:94:11 | a2 indirection [i] | simple.cpp:94:13:94:13 | i |
+| simple.cpp:94:10:94:11 | *a2 [i] | simple.cpp:94:13:94:13 | i |
 | simple.cpp:103:24:103:24 | x | simple.cpp:104:14:104:14 | x |
 | simple.cpp:108:17:108:26 | call to user_input | simple.cpp:109:43:109:43 | x |
 | simple.cpp:109:43:109:43 | x | simple.cpp:103:24:103:24 | x |
-| struct_init.c:14:24:14:25 | ab indirection [a] | struct_init.c:15:8:15:9 | ab indirection [a] |
-| struct_init.c:15:8:15:9 | ab indirection [a] | struct_init.c:15:12:15:12 | a |
-| struct_init.c:20:13:20:14 | definition of ab indirection [a] | struct_init.c:22:8:22:9 | ab indirection [a] |
-| struct_init.c:20:13:20:14 | definition of ab indirection [a] | struct_init.c:24:10:24:12 | & ... indirection [a] |
-| struct_init.c:20:13:20:14 | definition of ab indirection [a] | struct_init.c:28:5:28:7 | & ... indirection [a] |
-| struct_init.c:20:13:20:14 | definition of ab indirection [post update] [a] | struct_init.c:20:13:20:14 | definition of ab indirection [a] |
-| struct_init.c:20:20:20:29 | call to user_input | struct_init.c:20:13:20:14 | definition of ab indirection [post update] [a] |
+| struct_init.c:14:24:14:25 | *ab [a] | struct_init.c:15:8:15:9 | *ab [a] |
+| struct_init.c:15:8:15:9 | *ab [a] | struct_init.c:15:12:15:12 | a |
+| struct_init.c:20:13:20:14 | *definition of ab [a] | struct_init.c:22:8:22:9 | *ab [a] |
+| struct_init.c:20:13:20:14 | *definition of ab [a] | struct_init.c:24:10:24:12 | *& ... [a] |
+| struct_init.c:20:13:20:14 | *definition of ab [a] | struct_init.c:28:5:28:7 | *& ... [a] |
+| struct_init.c:20:13:20:14 | *definition of ab [post update] [a] | struct_init.c:20:13:20:14 | *definition of ab [a] |
+| struct_init.c:20:20:20:29 | call to user_input | struct_init.c:20:13:20:14 | *definition of ab [post update] [a] |
 | struct_init.c:20:20:20:29 | call to user_input | struct_init.c:20:20:20:29 | call to user_input |
-| struct_init.c:22:8:22:9 | ab indirection [a] | struct_init.c:22:11:22:11 | a |
-| struct_init.c:24:10:24:12 | & ... indirection [a] | struct_init.c:14:24:14:25 | ab indirection [a] |
-| struct_init.c:26:16:26:20 | definition of outer indirection [nestedAB, a] | struct_init.c:31:8:31:12 | outer indirection [nestedAB, a] |
-| struct_init.c:26:16:26:20 | definition of outer indirection [nestedAB, a] | struct_init.c:36:11:36:15 | outer indirection [nestedAB, a] |
-| struct_init.c:26:16:26:20 | definition of outer indirection [post update] [nestedAB, a] | struct_init.c:26:16:26:20 | definition of outer indirection [nestedAB, a] |
-| struct_init.c:26:16:26:20 | definition of outer indirection [post update] [pointerAB indirection, a] | struct_init.c:33:8:33:12 | outer indirection [pointerAB indirection, a] |
-| struct_init.c:26:23:29:3 | {...} indirection [post update] [a] | struct_init.c:26:16:26:20 | definition of outer indirection [post update] [nestedAB, a] |
-| struct_init.c:27:7:27:16 | call to user_input | struct_init.c:26:23:29:3 | {...} indirection [post update] [a] |
+| struct_init.c:22:8:22:9 | *ab [a] | struct_init.c:22:11:22:11 | a |
+| struct_init.c:24:10:24:12 | *& ... [a] | struct_init.c:14:24:14:25 | *ab [a] |
+| struct_init.c:26:16:26:20 | *definition of outer [nestedAB, a] | struct_init.c:31:8:31:12 | *outer [nestedAB, a] |
+| struct_init.c:26:16:26:20 | *definition of outer [nestedAB, a] | struct_init.c:36:11:36:15 | *outer [nestedAB, a] |
+| struct_init.c:26:16:26:20 | *definition of outer [post update] [*pointerAB, a] | struct_init.c:33:8:33:12 | *outer [*pointerAB, a] |
+| struct_init.c:26:16:26:20 | *definition of outer [post update] [nestedAB, a] | struct_init.c:26:16:26:20 | *definition of outer [nestedAB, a] |
+| struct_init.c:26:23:29:3 | *{...} [post update] [a] | struct_init.c:26:16:26:20 | *definition of outer [post update] [nestedAB, a] |
+| struct_init.c:27:7:27:16 | call to user_input | struct_init.c:26:23:29:3 | *{...} [post update] [a] |
 | struct_init.c:27:7:27:16 | call to user_input | struct_init.c:27:7:27:16 | call to user_input |
-| struct_init.c:28:5:28:7 | & ... indirection [a] | struct_init.c:26:16:26:20 | definition of outer indirection [post update] [pointerAB indirection, a] |
-| struct_init.c:31:8:31:12 | outer indirection [nestedAB, a] | struct_init.c:31:14:31:21 | nestedAB indirection [a] |
-| struct_init.c:31:14:31:21 | nestedAB indirection [a] | struct_init.c:31:23:31:23 | a |
-| struct_init.c:33:8:33:12 | outer indirection [pointerAB indirection, a] | struct_init.c:33:14:33:22 | pointerAB indirection [a] |
-| struct_init.c:33:14:33:22 | pointerAB indirection [a] | struct_init.c:33:25:33:25 | a |
-| struct_init.c:36:10:36:24 | & ... indirection [a] | struct_init.c:14:24:14:25 | ab indirection [a] |
-| struct_init.c:36:11:36:15 | outer indirection [nestedAB, a] | struct_init.c:36:10:36:24 | & ... indirection [a] |
-| struct_init.c:40:13:40:14 | definition of ab indirection [a] | struct_init.c:43:5:43:7 | & ... indirection [a] |
-| struct_init.c:40:13:40:14 | definition of ab indirection [post update] [a] | struct_init.c:40:13:40:14 | definition of ab indirection [a] |
-| struct_init.c:40:20:40:29 | call to user_input | struct_init.c:40:13:40:14 | definition of ab indirection [post update] [a] |
+| struct_init.c:28:5:28:7 | *& ... [a] | struct_init.c:26:16:26:20 | *definition of outer [post update] [*pointerAB, a] |
+| struct_init.c:31:8:31:12 | *outer [nestedAB, a] | struct_init.c:31:14:31:21 | *nestedAB [a] |
+| struct_init.c:31:14:31:21 | *nestedAB [a] | struct_init.c:31:23:31:23 | a |
+| struct_init.c:33:8:33:12 | *outer [*pointerAB, a] | struct_init.c:33:14:33:22 | *pointerAB [a] |
+| struct_init.c:33:14:33:22 | *pointerAB [a] | struct_init.c:33:25:33:25 | a |
+| struct_init.c:36:10:36:24 | *& ... [a] | struct_init.c:14:24:14:25 | *ab [a] |
+| struct_init.c:36:11:36:15 | *outer [nestedAB, a] | struct_init.c:36:10:36:24 | *& ... [a] |
+| struct_init.c:40:13:40:14 | *definition of ab [a] | struct_init.c:43:5:43:7 | *& ... [a] |
+| struct_init.c:40:13:40:14 | *definition of ab [post update] [a] | struct_init.c:40:13:40:14 | *definition of ab [a] |
+| struct_init.c:40:20:40:29 | call to user_input | struct_init.c:40:13:40:14 | *definition of ab [post update] [a] |
 | struct_init.c:40:20:40:29 | call to user_input | struct_init.c:40:20:40:29 | call to user_input |
-| struct_init.c:41:16:41:20 | definition of outer indirection [post update] [pointerAB indirection, a] | struct_init.c:46:10:46:14 | outer indirection [pointerAB indirection, a] |
-| struct_init.c:43:5:43:7 | & ... indirection [a] | struct_init.c:41:16:41:20 | definition of outer indirection [post update] [pointerAB indirection, a] |
-| struct_init.c:46:10:46:14 | outer indirection [pointerAB indirection, a] | struct_init.c:46:16:46:24 | pointerAB indirection [a] |
-| struct_init.c:46:16:46:24 | pointerAB indirection [a] | struct_init.c:14:24:14:25 | ab indirection [a] |
+| struct_init.c:41:16:41:20 | *definition of outer [post update] [*pointerAB, a] | struct_init.c:46:10:46:14 | *outer [*pointerAB, a] |
+| struct_init.c:43:5:43:7 | *& ... [a] | struct_init.c:41:16:41:20 | *definition of outer [post update] [*pointerAB, a] |
+| struct_init.c:46:10:46:14 | *outer [*pointerAB, a] | struct_init.c:46:16:46:24 | *pointerAB [a] |
+| struct_init.c:46:16:46:24 | *pointerAB [a] | struct_init.c:14:24:14:25 | *ab [a] |
 nodes
 | A.cpp:23:10:23:10 | c | semmle.label | c |
-| A.cpp:25:7:25:10 | this indirection [post update] [c] | semmle.label | this indirection [post update] [c] |
+| A.cpp:25:7:25:10 | *this [post update] [c] | semmle.label | *this [post update] [c] |
 | A.cpp:25:7:25:17 | ... = ... | semmle.label | ... = ... |
 | A.cpp:27:17:27:17 | c | semmle.label | c |
-| A.cpp:27:22:27:25 | this indirection [post update] [c] | semmle.label | this indirection [post update] [c] |
+| A.cpp:27:22:27:25 | *this [post update] [c] | semmle.label | *this [post update] [c] |
 | A.cpp:27:22:27:32 | ... = ... | semmle.label | ... = ... |
-| A.cpp:28:8:28:10 | get indirection | semmle.label | get indirection |
-| A.cpp:28:8:28:10 | this indirection [c] | semmle.label | this indirection [c] |
-| A.cpp:28:23:28:26 | this indirection [c] | semmle.label | this indirection [c] |
+| A.cpp:28:8:28:10 | *get | semmle.label | *get |
+| A.cpp:28:8:28:10 | *this [c] | semmle.label | *this [c] |
+| A.cpp:28:23:28:26 | *this [c] | semmle.label | *this [c] |
 | A.cpp:28:29:28:29 | c | semmle.label | c |
-| A.cpp:29:15:29:18 | make indirection [c] | semmle.label | make indirection [c] |
+| A.cpp:29:15:29:18 | **make [c] | semmle.label | **make [c] |
 | A.cpp:29:23:29:23 | c | semmle.label | c |
 | A.cpp:31:14:31:21 | call to B [c] | semmle.label | call to B [c] |
 | A.cpp:31:20:31:20 | c | semmle.label | c |
 | A.cpp:41:5:41:6 | insert output argument | semmle.label | insert output argument |
 | A.cpp:41:15:41:21 | new | semmle.label | new |
 | A.cpp:41:15:41:21 | new | semmle.label | new |
-| A.cpp:43:10:43:12 | & ... indirection | semmle.label | & ... indirection |
+| A.cpp:43:10:43:12 | *& ... | semmle.label | *& ... |
 | A.cpp:47:12:47:18 | new | semmle.label | new |
-| A.cpp:48:12:48:18 | call to make indirection [c] | semmle.label | call to make indirection [c] |
+| A.cpp:48:12:48:18 | *call to make [c] | semmle.label | *call to make [c] |
 | A.cpp:48:20:48:20 | c | semmle.label | c |
-| A.cpp:49:10:49:10 | b indirection [c] | semmle.label | b indirection [c] |
+| A.cpp:49:10:49:10 | *b [c] | semmle.label | *b [c] |
 | A.cpp:49:10:49:13 | c | semmle.label | c |
 | A.cpp:55:5:55:5 | set output argument [c] | semmle.label | set output argument [c] |
 | A.cpp:55:12:55:19 | new | semmle.label | new |
 | A.cpp:55:12:55:19 | new | semmle.label | new |
-| A.cpp:56:10:56:10 | b indirection [c] | semmle.label | b indirection [c] |
+| A.cpp:56:10:56:10 | *b [c] | semmle.label | *b [c] |
 | A.cpp:56:10:56:17 | call to get | semmle.label | call to get |
 | A.cpp:57:10:57:32 | call to get | semmle.label | call to get |
+| A.cpp:57:11:57:24 | *new [c] | semmle.label | *new [c] |
 | A.cpp:57:11:57:24 | call to B [c] | semmle.label | call to B [c] |
-| A.cpp:57:11:57:24 | new indirection [c] | semmle.label | new indirection [c] |
 | A.cpp:57:17:57:23 | new | semmle.label | new |
 | A.cpp:57:17:57:23 | new | semmle.label | new |
-| A.cpp:64:10:64:15 | call to setOnB indirection [c] | semmle.label | call to setOnB indirection [c] |
+| A.cpp:64:10:64:15 | *call to setOnB [c] | semmle.label | *call to setOnB [c] |
 | A.cpp:64:21:64:28 | new | semmle.label | new |
 | A.cpp:64:21:64:28 | new | semmle.label | new |
-| A.cpp:66:10:66:11 | b2 indirection [c] | semmle.label | b2 indirection [c] |
+| A.cpp:66:10:66:11 | *b2 [c] | semmle.label | *b2 [c] |
 | A.cpp:66:10:66:14 | c | semmle.label | c |
-| A.cpp:73:10:73:19 | call to setOnBWrap indirection [c] | semmle.label | call to setOnBWrap indirection [c] |
+| A.cpp:73:10:73:19 | *call to setOnBWrap [c] | semmle.label | *call to setOnBWrap [c] |
 | A.cpp:73:25:73:32 | new | semmle.label | new |
 | A.cpp:73:25:73:32 | new | semmle.label | new |
-| A.cpp:75:10:75:11 | b2 indirection [c] | semmle.label | b2 indirection [c] |
+| A.cpp:75:10:75:11 | *b2 [c] | semmle.label | *b2 [c] |
 | A.cpp:75:10:75:14 | c | semmle.label | c |
-| A.cpp:78:6:78:15 | setOnBWrap indirection [c] | semmle.label | setOnBWrap indirection [c] |
+| A.cpp:78:6:78:15 | **setOnBWrap [c] | semmle.label | **setOnBWrap [c] |
 | A.cpp:78:27:78:27 | c | semmle.label | c |
-| A.cpp:81:10:81:15 | call to setOnB indirection [c] | semmle.label | call to setOnB indirection [c] |
+| A.cpp:81:10:81:15 | *call to setOnB [c] | semmle.label | *call to setOnB [c] |
 | A.cpp:81:21:81:21 | c | semmle.label | c |
-| A.cpp:85:9:85:14 | setOnB indirection [c] | semmle.label | setOnB indirection [c] |
+| A.cpp:85:9:85:14 | **setOnB [c] | semmle.label | **setOnB [c] |
 | A.cpp:85:26:85:26 | c | semmle.label | c |
 | A.cpp:90:7:90:8 | set output argument [c] | semmle.label | set output argument [c] |
 | A.cpp:90:15:90:15 | c | semmle.label | c |
 | A.cpp:98:12:98:18 | new | semmle.label | new |
-| A.cpp:100:5:100:6 | c1 indirection [post update] [a] | semmle.label | c1 indirection [post update] [a] |
+| A.cpp:100:5:100:6 | *c1 [post update] [a] | semmle.label | *c1 [post update] [a] |
 | A.cpp:100:5:100:13 | ... = ... | semmle.label | ... = ... |
-| A.cpp:101:8:101:9 | c1 indirection [a] | semmle.label | c1 indirection [a] |
-| A.cpp:103:14:103:14 | c indirection [a] | semmle.label | c indirection [a] |
-| A.cpp:107:12:107:13 | c1 indirection [a] | semmle.label | c1 indirection [a] |
+| A.cpp:101:8:101:9 | *c1 [a] | semmle.label | *c1 [a] |
+| A.cpp:103:14:103:14 | *c [a] | semmle.label | *c [a] |
+| A.cpp:107:12:107:13 | *c1 [a] | semmle.label | *c1 [a] |
 | A.cpp:107:12:107:16 | a | semmle.label | a |
-| A.cpp:120:12:120:13 | c1 indirection [a] | semmle.label | c1 indirection [a] |
+| A.cpp:120:12:120:13 | *c1 [a] | semmle.label | *c1 [a] |
 | A.cpp:120:12:120:16 | a | semmle.label | a |
 | A.cpp:126:5:126:5 | set output argument [c] | semmle.label | set output argument [c] |
 | A.cpp:126:12:126:18 | new | semmle.label | new |
 | A.cpp:126:12:126:18 | new | semmle.label | new |
 | A.cpp:131:8:131:8 | f7 output argument [c] | semmle.label | f7 output argument [c] |
-| A.cpp:132:10:132:10 | b indirection [c] | semmle.label | b indirection [c] |
+| A.cpp:132:10:132:10 | *b [c] | semmle.label | *b [c] |
 | A.cpp:132:10:132:13 | c | semmle.label | c |
 | A.cpp:140:13:140:13 | b | semmle.label | b |
-| A.cpp:142:7:142:7 | b indirection [post update] [c] | semmle.label | b indirection [post update] [c] |
+| A.cpp:142:7:142:7 | *b [post update] [c] | semmle.label | *b [post update] [c] |
 | A.cpp:142:7:142:20 | ... = ... | semmle.label | ... = ... |
 | A.cpp:142:14:142:20 | new | semmle.label | new |
-| A.cpp:143:7:143:10 | this indirection [post update] [b indirection, c] | semmle.label | this indirection [post update] [b indirection, c] |
-| A.cpp:143:7:143:10 | this indirection [post update] [b] | semmle.label | this indirection [post update] [b] |
-| A.cpp:143:7:143:10 | this indirection [post update] [b] | semmle.label | this indirection [post update] [b] |
+| A.cpp:143:7:143:10 | *this [post update] [*b, c] | semmle.label | *this [post update] [*b, c] |
+| A.cpp:143:7:143:10 | *this [post update] [b] | semmle.label | *this [post update] [b] |
+| A.cpp:143:7:143:10 | *this [post update] [b] | semmle.label | *this [post update] [b] |
+| A.cpp:143:7:143:31 | *... = ... [c] | semmle.label | *... = ... [c] |
 | A.cpp:143:7:143:31 | ... = ... | semmle.label | ... = ... |
 | A.cpp:143:7:143:31 | ... = ... | semmle.label | ... = ... |
-| A.cpp:143:7:143:31 | ... = ... indirection [c] | semmle.label | ... = ... indirection [c] |
 | A.cpp:143:25:143:31 | new | semmle.label | new |
 | A.cpp:150:12:150:18 | new | semmle.label | new |
-| A.cpp:151:12:151:24 | call to D [b indirection, c] | semmle.label | call to D [b indirection, c] |
+| A.cpp:151:12:151:24 | call to D [*b, c] | semmle.label | call to D [*b, c] |
 | A.cpp:151:12:151:24 | call to D [b] | semmle.label | call to D [b] |
 | A.cpp:151:18:151:18 | D output argument [c] | semmle.label | D output argument [c] |
 | A.cpp:151:18:151:18 | b | semmle.label | b |
-| A.cpp:152:10:152:10 | d indirection [b] | semmle.label | d indirection [b] |
+| A.cpp:152:10:152:10 | *d [b] | semmle.label | *d [b] |
 | A.cpp:152:10:152:13 | b | semmle.label | b |
-| A.cpp:153:10:153:10 | d indirection [b indirection, c] | semmle.label | d indirection [b indirection, c] |
+| A.cpp:153:10:153:10 | *d [*b, c] | semmle.label | *d [*b, c] |
 | A.cpp:153:10:153:16 | c | semmle.label | c |
-| A.cpp:153:13:153:13 | b indirection [c] | semmle.label | b indirection [c] |
-| A.cpp:154:10:154:10 | b indirection [c] | semmle.label | b indirection [c] |
+| A.cpp:153:13:153:13 | *b [c] | semmle.label | *b [c] |
+| A.cpp:154:10:154:10 | *b [c] | semmle.label | *b [c] |
 | A.cpp:154:10:154:13 | c | semmle.label | c |
 | A.cpp:159:12:159:18 | new | semmle.label | new |
 | A.cpp:160:18:160:60 | call to MyList [head] | semmle.label | call to MyList [head] |
 | A.cpp:160:29:160:29 | b | semmle.label | b |
-| A.cpp:161:18:161:40 | call to MyList [next indirection, head] | semmle.label | call to MyList [next indirection, head] |
-| A.cpp:161:38:161:39 | l1 indirection [head] | semmle.label | l1 indirection [head] |
-| A.cpp:162:18:162:40 | call to MyList [next indirection, next indirection, head] | semmle.label | call to MyList [next indirection, next indirection, head] |
-| A.cpp:162:38:162:39 | l2 indirection [next indirection, head] | semmle.label | l2 indirection [next indirection, head] |
-| A.cpp:165:10:165:11 | l3 indirection [next indirection, next indirection, head] | semmle.label | l3 indirection [next indirection, next indirection, head] |
+| A.cpp:161:18:161:40 | call to MyList [*next, head] | semmle.label | call to MyList [*next, head] |
+| A.cpp:161:38:161:39 | *l1 [head] | semmle.label | *l1 [head] |
+| A.cpp:162:18:162:40 | call to MyList [*next, *next, head] | semmle.label | call to MyList [*next, *next, head] |
+| A.cpp:162:38:162:39 | *l2 [*next, head] | semmle.label | *l2 [*next, head] |
+| A.cpp:165:10:165:11 | *l3 [*next, *next, head] | semmle.label | *l3 [*next, *next, head] |
 | A.cpp:165:10:165:29 | head | semmle.label | head |
-| A.cpp:165:14:165:17 | next indirection [next indirection, head] | semmle.label | next indirection [next indirection, head] |
-| A.cpp:165:20:165:23 | next indirection [head] | semmle.label | next indirection [head] |
-| A.cpp:167:44:167:44 | l indirection [next indirection, head] | semmle.label | l indirection [next indirection, head] |
-| A.cpp:167:44:167:44 | l indirection [next indirection, next indirection, head] | semmle.label | l indirection [next indirection, next indirection, head] |
-| A.cpp:167:47:167:50 | next indirection [head] | semmle.label | next indirection [head] |
-| A.cpp:167:47:167:50 | next indirection [next indirection, head] | semmle.label | next indirection [next indirection, head] |
-| A.cpp:169:12:169:12 | l indirection [head] | semmle.label | l indirection [head] |
+| A.cpp:165:14:165:17 | *next [*next, head] | semmle.label | *next [*next, head] |
+| A.cpp:165:20:165:23 | *next [head] | semmle.label | *next [head] |
+| A.cpp:167:44:167:44 | *l [*next, *next, head] | semmle.label | *l [*next, *next, head] |
+| A.cpp:167:44:167:44 | *l [*next, head] | semmle.label | *l [*next, head] |
+| A.cpp:167:47:167:50 | *next [*next, head] | semmle.label | *next [*next, head] |
+| A.cpp:167:47:167:50 | *next [head] | semmle.label | *next [head] |
+| A.cpp:169:12:169:12 | *l [head] | semmle.label | *l [head] |
 | A.cpp:169:12:169:18 | head | semmle.label | head |
 | A.cpp:181:15:181:21 | newHead | semmle.label | newHead |
-| A.cpp:181:32:181:35 | next indirection [head] | semmle.label | next indirection [head] |
-| A.cpp:181:32:181:35 | next indirection [next indirection, head] | semmle.label | next indirection [next indirection, head] |
-| A.cpp:183:7:183:10 | this indirection [post update] [head] | semmle.label | this indirection [post update] [head] |
+| A.cpp:181:32:181:35 | *next [*next, head] | semmle.label | *next [*next, head] |
+| A.cpp:181:32:181:35 | *next [head] | semmle.label | *next [head] |
+| A.cpp:183:7:183:10 | *this [post update] [head] | semmle.label | *this [post update] [head] |
 | A.cpp:183:7:183:20 | ... = ... | semmle.label | ... = ... |
-| A.cpp:184:7:184:10 | this indirection [post update] [next indirection, head] | semmle.label | this indirection [post update] [next indirection, head] |
-| A.cpp:184:7:184:10 | this indirection [post update] [next indirection, next indirection, head] | semmle.label | this indirection [post update] [next indirection, next indirection, head] |
-| A.cpp:184:7:184:23 | ... = ... indirection [head] | semmle.label | ... = ... indirection [head] |
-| A.cpp:184:7:184:23 | ... = ... indirection [next indirection, head] | semmle.label | ... = ... indirection [next indirection, head] |
+| A.cpp:184:7:184:10 | *this [post update] [*next, *next, head] | semmle.label | *this [post update] [*next, *next, head] |
+| A.cpp:184:7:184:10 | *this [post update] [*next, head] | semmle.label | *this [post update] [*next, head] |
+| A.cpp:184:7:184:23 | *... = ... [*next, head] | semmle.label | *... = ... [*next, head] |
+| A.cpp:184:7:184:23 | *... = ... [head] | semmle.label | *... = ... [head] |
 | B.cpp:6:15:6:24 | new | semmle.label | new |
 | B.cpp:7:16:7:35 | call to Box1 [elem1] | semmle.label | call to Box1 [elem1] |
 | B.cpp:7:25:7:25 | e | semmle.label | e |
-| B.cpp:8:16:8:27 | call to Box2 [box1 indirection, elem1] | semmle.label | call to Box2 [box1 indirection, elem1] |
-| B.cpp:8:25:8:26 | b1 indirection [elem1] | semmle.label | b1 indirection [elem1] |
-| B.cpp:9:10:9:11 | b2 indirection [box1 indirection, elem1] | semmle.label | b2 indirection [box1 indirection, elem1] |
+| B.cpp:8:16:8:27 | call to Box2 [*box1, elem1] | semmle.label | call to Box2 [*box1, elem1] |
+| B.cpp:8:25:8:26 | *b1 [elem1] | semmle.label | *b1 [elem1] |
+| B.cpp:9:10:9:11 | *b2 [*box1, elem1] | semmle.label | *b2 [*box1, elem1] |
 | B.cpp:9:10:9:24 | elem1 | semmle.label | elem1 |
-| B.cpp:9:14:9:17 | box1 indirection [elem1] | semmle.label | box1 indirection [elem1] |
+| B.cpp:9:14:9:17 | *box1 [elem1] | semmle.label | *box1 [elem1] |
 | B.cpp:15:15:15:27 | new | semmle.label | new |
 | B.cpp:16:16:16:38 | call to Box1 [elem2] | semmle.label | call to Box1 [elem2] |
 | B.cpp:16:37:16:37 | e | semmle.label | e |
-| B.cpp:17:16:17:27 | call to Box2 [box1 indirection, elem2] | semmle.label | call to Box2 [box1 indirection, elem2] |
-| B.cpp:17:25:17:26 | b1 indirection [elem2] | semmle.label | b1 indirection [elem2] |
-| B.cpp:19:10:19:11 | b2 indirection [box1 indirection, elem2] | semmle.label | b2 indirection [box1 indirection, elem2] |
+| B.cpp:17:16:17:27 | call to Box2 [*box1, elem2] | semmle.label | call to Box2 [*box1, elem2] |
+| B.cpp:17:25:17:26 | *b1 [elem2] | semmle.label | *b1 [elem2] |
+| B.cpp:19:10:19:11 | *b2 [*box1, elem2] | semmle.label | *b2 [*box1, elem2] |
 | B.cpp:19:10:19:24 | elem2 | semmle.label | elem2 |
-| B.cpp:19:14:19:17 | box1 indirection [elem2] | semmle.label | box1 indirection [elem2] |
+| B.cpp:19:14:19:17 | *box1 [elem2] | semmle.label | *box1 [elem2] |
 | B.cpp:33:16:33:17 | e1 | semmle.label | e1 |
 | B.cpp:33:26:33:27 | e2 | semmle.label | e2 |
-| B.cpp:35:7:35:10 | this indirection [post update] [elem1] | semmle.label | this indirection [post update] [elem1] |
+| B.cpp:35:7:35:10 | *this [post update] [elem1] | semmle.label | *this [post update] [elem1] |
 | B.cpp:35:7:35:22 | ... = ... | semmle.label | ... = ... |
-| B.cpp:36:7:36:10 | this indirection [post update] [elem2] | semmle.label | this indirection [post update] [elem2] |
+| B.cpp:36:7:36:10 | *this [post update] [elem2] | semmle.label | *this [post update] [elem2] |
 | B.cpp:36:7:36:22 | ... = ... | semmle.label | ... = ... |
-| B.cpp:44:16:44:17 | b1 indirection [elem1] | semmle.label | b1 indirection [elem1] |
-| B.cpp:44:16:44:17 | b1 indirection [elem2] | semmle.label | b1 indirection [elem2] |
-| B.cpp:46:7:46:10 | this indirection [post update] [box1 indirection, elem1] | semmle.label | this indirection [post update] [box1 indirection, elem1] |
-| B.cpp:46:7:46:10 | this indirection [post update] [box1 indirection, elem2] | semmle.label | this indirection [post update] [box1 indirection, elem2] |
-| B.cpp:46:7:46:21 | ... = ... indirection [elem1] | semmle.label | ... = ... indirection [elem1] |
-| B.cpp:46:7:46:21 | ... = ... indirection [elem2] | semmle.label | ... = ... indirection [elem2] |
+| B.cpp:44:16:44:17 | *b1 [elem1] | semmle.label | *b1 [elem1] |
+| B.cpp:44:16:44:17 | *b1 [elem2] | semmle.label | *b1 [elem2] |
+| B.cpp:46:7:46:10 | *this [post update] [*box1, elem1] | semmle.label | *this [post update] [*box1, elem1] |
+| B.cpp:46:7:46:10 | *this [post update] [*box1, elem2] | semmle.label | *this [post update] [*box1, elem2] |
+| B.cpp:46:7:46:21 | *... = ... [elem1] | semmle.label | *... = ... [elem1] |
+| B.cpp:46:7:46:21 | *... = ... [elem2] | semmle.label | *... = ... [elem2] |
 | C.cpp:18:12:18:18 | call to C [s1] | semmle.label | call to C [s1] |
 | C.cpp:18:12:18:18 | call to C [s3] | semmle.label | call to C [s3] |
-| C.cpp:19:5:19:5 | c indirection [s1] | semmle.label | c indirection [s1] |
-| C.cpp:19:5:19:5 | c indirection [s3] | semmle.label | c indirection [s3] |
-| C.cpp:22:3:22:3 | this indirection [post update] [s1] | semmle.label | this indirection [post update] [s1] |
+| C.cpp:19:5:19:5 | *c [s1] | semmle.label | *c [s1] |
+| C.cpp:19:5:19:5 | *c [s3] | semmle.label | *c [s3] |
+| C.cpp:22:3:22:3 | *this [post update] [s1] | semmle.label | *this [post update] [s1] |
 | C.cpp:22:12:22:21 | new | semmle.label | new |
 | C.cpp:22:12:22:21 | new | semmle.label | new |
-| C.cpp:24:5:24:8 | this indirection [post update] [s3] | semmle.label | this indirection [post update] [s3] |
+| C.cpp:24:5:24:8 | *this [post update] [s3] | semmle.label | *this [post update] [s3] |
 | C.cpp:24:5:24:25 | ... = ... | semmle.label | ... = ... |
 | C.cpp:24:16:24:25 | new | semmle.label | new |
-| C.cpp:27:8:27:11 | this indirection [s1] | semmle.label | this indirection [s1] |
-| C.cpp:27:8:27:11 | this indirection [s3] | semmle.label | this indirection [s3] |
+| C.cpp:27:8:27:11 | *this [s1] | semmle.label | *this [s1] |
+| C.cpp:27:8:27:11 | *this [s3] | semmle.label | *this [s3] |
+| C.cpp:29:10:29:11 | *this [s1] | semmle.label | *this [s1] |
 | C.cpp:29:10:29:11 | s1 | semmle.label | s1 |
-| C.cpp:29:10:29:11 | this indirection [s1] | semmle.label | this indirection [s1] |
+| C.cpp:31:10:31:11 | *this [s3] | semmle.label | *this [s3] |
 | C.cpp:31:10:31:11 | s3 | semmle.label | s3 |
-| C.cpp:31:10:31:11 | this indirection [s3] | semmle.label | this indirection [s3] |
-| D.cpp:10:11:10:17 | getElem indirection | semmle.label | getElem indirection |
-| D.cpp:10:11:10:17 | this indirection [elem] | semmle.label | this indirection [elem] |
+| D.cpp:10:11:10:17 | *getElem | semmle.label | *getElem |
+| D.cpp:10:11:10:17 | *this [elem] | semmle.label | *this [elem] |
+| D.cpp:10:30:10:33 | *this [elem] | semmle.label | *this [elem] |
 | D.cpp:10:30:10:33 | elem | semmle.label | elem |
-| D.cpp:10:30:10:33 | this indirection [elem] | semmle.label | this indirection [elem] |
 | D.cpp:11:24:11:24 | e | semmle.label | e |
-| D.cpp:11:29:11:32 | this indirection [post update] [elem] | semmle.label | this indirection [post update] [elem] |
+| D.cpp:11:29:11:32 | *this [post update] [elem] | semmle.label | *this [post update] [elem] |
 | D.cpp:11:29:11:36 | ... = ... | semmle.label | ... = ... |
-| D.cpp:17:11:17:17 | getBox1 indirection [elem] | semmle.label | getBox1 indirection [elem] |
-| D.cpp:17:11:17:17 | this indirection [box indirection, elem] | semmle.label | this indirection [box indirection, elem] |
-| D.cpp:17:30:17:32 | box indirection [elem] | semmle.label | box indirection [elem] |
-| D.cpp:17:30:17:32 | this indirection [box indirection, elem] | semmle.label | this indirection [box indirection, elem] |
-| D.cpp:21:30:21:31 | b2 indirection [box indirection, elem] | semmle.label | b2 indirection [box indirection, elem] |
-| D.cpp:22:10:22:11 | b2 indirection [box indirection, elem] | semmle.label | b2 indirection [box indirection, elem] |
+| D.cpp:17:11:17:17 | **getBox1 [elem] | semmle.label | **getBox1 [elem] |
+| D.cpp:17:11:17:17 | *this [*box, elem] | semmle.label | *this [*box, elem] |
+| D.cpp:17:30:17:32 | *box [elem] | semmle.label | *box [elem] |
+| D.cpp:17:30:17:32 | *this [*box, elem] | semmle.label | *this [*box, elem] |
+| D.cpp:21:30:21:31 | *b2 [*box, elem] | semmle.label | *b2 [*box, elem] |
+| D.cpp:22:10:22:11 | *b2 [*box, elem] | semmle.label | *b2 [*box, elem] |
 | D.cpp:22:10:22:33 | call to getElem | semmle.label | call to getElem |
-| D.cpp:22:14:22:20 | call to getBox1 indirection [elem] | semmle.label | call to getBox1 indirection [elem] |
+| D.cpp:22:14:22:20 | *call to getBox1 [elem] | semmle.label | *call to getBox1 [elem] |
 | D.cpp:28:15:28:24 | new | semmle.label | new |
-| D.cpp:30:5:30:5 | b indirection [post update] [box indirection, elem] | semmle.label | b indirection [post update] [box indirection, elem] |
+| D.cpp:30:5:30:5 | *b [post update] [*box, elem] | semmle.label | *b [post update] [*box, elem] |
 | D.cpp:30:5:30:20 | ... = ... | semmle.label | ... = ... |
-| D.cpp:30:8:30:10 | box indirection [post update] [elem] | semmle.label | box indirection [post update] [elem] |
-| D.cpp:31:14:31:14 | b indirection [box indirection, elem] | semmle.label | b indirection [box indirection, elem] |
+| D.cpp:30:8:30:10 | *box [post update] [elem] | semmle.label | *box [post update] [elem] |
+| D.cpp:31:14:31:14 | *b [*box, elem] | semmle.label | *b [*box, elem] |
 | D.cpp:35:15:35:24 | new | semmle.label | new |
-| D.cpp:37:5:37:5 | b indirection [post update] [box indirection, elem] | semmle.label | b indirection [post update] [box indirection, elem] |
+| D.cpp:37:5:37:5 | *b [post update] [*box, elem] | semmle.label | *b [post update] [*box, elem] |
 | D.cpp:37:8:37:10 | setElem output argument [elem] | semmle.label | setElem output argument [elem] |
 | D.cpp:37:21:37:21 | e | semmle.label | e |
-| D.cpp:38:14:38:14 | b indirection [box indirection, elem] | semmle.label | b indirection [box indirection, elem] |
+| D.cpp:38:14:38:14 | *b [*box, elem] | semmle.label | *b [*box, elem] |
 | D.cpp:42:15:42:24 | new | semmle.label | new |
-| D.cpp:44:5:44:5 | getBox1 output argument [box indirection, elem] | semmle.label | getBox1 output argument [box indirection, elem] |
+| D.cpp:44:5:44:5 | getBox1 output argument [*box, elem] | semmle.label | getBox1 output argument [*box, elem] |
 | D.cpp:44:5:44:26 | ... = ... | semmle.label | ... = ... |
-| D.cpp:44:8:44:14 | call to getBox1 indirection [post update] [elem] | semmle.label | call to getBox1 indirection [post update] [elem] |
-| D.cpp:45:14:45:14 | b indirection [box indirection, elem] | semmle.label | b indirection [box indirection, elem] |
+| D.cpp:44:8:44:14 | *call to getBox1 [post update] [elem] | semmle.label | *call to getBox1 [post update] [elem] |
+| D.cpp:45:14:45:14 | *b [*box, elem] | semmle.label | *b [*box, elem] |
 | D.cpp:49:15:49:24 | new | semmle.label | new |
-| D.cpp:51:5:51:5 | getBox1 output argument [box indirection, elem] | semmle.label | getBox1 output argument [box indirection, elem] |
+| D.cpp:51:5:51:5 | getBox1 output argument [*box, elem] | semmle.label | getBox1 output argument [*box, elem] |
 | D.cpp:51:8:51:14 | setElem output argument [elem] | semmle.label | setElem output argument [elem] |
 | D.cpp:51:27:51:27 | e | semmle.label | e |
-| D.cpp:52:14:52:14 | b indirection [box indirection, elem] | semmle.label | b indirection [box indirection, elem] |
+| D.cpp:52:14:52:14 | *b [*box, elem] | semmle.label | *b [*box, elem] |
 | D.cpp:56:15:56:24 | new | semmle.label | new |
-| D.cpp:58:5:58:12 | boxfield indirection [post update] [box indirection, elem] | semmle.label | boxfield indirection [post update] [box indirection, elem] |
-| D.cpp:58:5:58:12 | this indirection [post update] [boxfield indirection, box indirection, elem] | semmle.label | this indirection [post update] [boxfield indirection, box indirection, elem] |
+| D.cpp:58:5:58:12 | *boxfield [post update] [*box, elem] | semmle.label | *boxfield [post update] [*box, elem] |
+| D.cpp:58:5:58:12 | *this [post update] [*boxfield, *box, elem] | semmle.label | *this [post update] [*boxfield, *box, elem] |
 | D.cpp:58:5:58:27 | ... = ... | semmle.label | ... = ... |
-| D.cpp:58:15:58:17 | box indirection [post update] [elem] | semmle.label | box indirection [post update] [elem] |
-| D.cpp:59:5:59:7 | this indirection [boxfield indirection, box indirection, elem] | semmle.label | this indirection [boxfield indirection, box indirection, elem] |
-| D.cpp:63:8:63:10 | this indirection [boxfield indirection, box indirection, elem] | semmle.label | this indirection [boxfield indirection, box indirection, elem] |
-| D.cpp:64:10:64:17 | boxfield indirection [box indirection, elem] | semmle.label | boxfield indirection [box indirection, elem] |
-| D.cpp:64:10:64:17 | this indirection [boxfield indirection, box indirection, elem] | semmle.label | this indirection [boxfield indirection, box indirection, elem] |
+| D.cpp:58:15:58:17 | *box [post update] [elem] | semmle.label | *box [post update] [elem] |
+| D.cpp:59:5:59:7 | *this [*boxfield, *box, elem] | semmle.label | *this [*boxfield, *box, elem] |
+| D.cpp:63:8:63:10 | *this [*boxfield, *box, elem] | semmle.label | *this [*boxfield, *box, elem] |
+| D.cpp:64:10:64:17 | *boxfield [*box, elem] | semmle.label | *boxfield [*box, elem] |
+| D.cpp:64:10:64:17 | *this [*boxfield, *box, elem] | semmle.label | *this [*boxfield, *box, elem] |
 | D.cpp:64:10:64:28 | elem | semmle.label | elem |
-| D.cpp:64:20:64:22 | box indirection [elem] | semmle.label | box indirection [elem] |
-| E.cpp:19:27:19:27 | p indirection [data, buffer indirection] | semmle.label | p indirection [data, buffer indirection] |
-| E.cpp:21:10:21:10 | p indirection [data, buffer indirection] | semmle.label | p indirection [data, buffer indirection] |
-| E.cpp:21:13:21:16 | data indirection [buffer indirection] | semmle.label | data indirection [buffer indirection] |
-| E.cpp:21:18:21:23 | buffer indirection | semmle.label | buffer indirection |
+| D.cpp:64:20:64:22 | *box [elem] | semmle.label | *box [elem] |
+| E.cpp:19:27:19:27 | *p [data, *buffer] | semmle.label | *p [data, *buffer] |
+| E.cpp:21:10:21:10 | *p [data, *buffer] | semmle.label | *p [data, *buffer] |
+| E.cpp:21:13:21:16 | *data [*buffer] | semmle.label | *data [*buffer] |
+| E.cpp:21:18:21:23 | *buffer | semmle.label | *buffer |
 | E.cpp:28:21:28:23 | argument_source output argument | semmle.label | argument_source output argument |
-| E.cpp:29:21:29:21 | b indirection [post update] [buffer indirection] | semmle.label | b indirection [post update] [buffer indirection] |
+| E.cpp:29:21:29:21 | *b [post update] [*buffer] | semmle.label | *b [post update] [*buffer] |
 | E.cpp:29:21:29:29 | argument_source output argument | semmle.label | argument_source output argument |
-| E.cpp:30:21:30:21 | p indirection [post update] [data, buffer indirection] | semmle.label | p indirection [post update] [data, buffer indirection] |
+| E.cpp:30:21:30:21 | *p [post update] [data, *buffer] | semmle.label | *p [post update] [data, *buffer] |
 | E.cpp:30:21:30:33 | argument_source output argument | semmle.label | argument_source output argument |
-| E.cpp:30:23:30:26 | data indirection [post update] [buffer indirection] | semmle.label | data indirection [post update] [buffer indirection] |
-| E.cpp:31:10:31:12 | raw indirection | semmle.label | raw indirection |
-| E.cpp:32:10:32:10 | b indirection [buffer indirection] | semmle.label | b indirection [buffer indirection] |
-| E.cpp:32:13:32:18 | buffer indirection | semmle.label | buffer indirection |
-| E.cpp:33:18:33:19 | & ... indirection [data, buffer indirection] | semmle.label | & ... indirection [data, buffer indirection] |
-| aliasing.cpp:9:3:9:3 | s indirection [post update] [m1] | semmle.label | s indirection [post update] [m1] |
+| E.cpp:30:23:30:26 | *data [post update] [*buffer] | semmle.label | *data [post update] [*buffer] |
+| E.cpp:31:10:31:12 | *raw | semmle.label | *raw |
+| E.cpp:32:10:32:10 | *b [*buffer] | semmle.label | *b [*buffer] |
+| E.cpp:32:13:32:18 | *buffer | semmle.label | *buffer |
+| E.cpp:33:18:33:19 | *& ... [data, *buffer] | semmle.label | *& ... [data, *buffer] |
+| aliasing.cpp:9:3:9:3 | *s [post update] [m1] | semmle.label | *s [post update] [m1] |
 | aliasing.cpp:9:3:9:22 | ... = ... | semmle.label | ... = ... |
 | aliasing.cpp:9:11:9:20 | call to user_input | semmle.label | call to user_input |
-| aliasing.cpp:13:3:13:3 | s indirection [post update] [m1] | semmle.label | s indirection [post update] [m1] |
+| aliasing.cpp:13:3:13:3 | *s [post update] [m1] | semmle.label | *s [post update] [m1] |
 | aliasing.cpp:13:3:13:21 | ... = ... | semmle.label | ... = ... |
 | aliasing.cpp:13:10:13:19 | call to user_input | semmle.label | call to user_input |
 | aliasing.cpp:25:17:25:19 | pointerSetter output argument [m1] | semmle.label | pointerSetter output argument [m1] |
 | aliasing.cpp:26:19:26:20 | referenceSetter output argument [m1] | semmle.label | referenceSetter output argument [m1] |
-| aliasing.cpp:29:8:29:9 | s1 indirection [m1] | semmle.label | s1 indirection [m1] |
+| aliasing.cpp:29:8:29:9 | *s1 [m1] | semmle.label | *s1 [m1] |
 | aliasing.cpp:29:11:29:12 | m1 | semmle.label | m1 |
-| aliasing.cpp:30:8:30:9 | s2 indirection [m1] | semmle.label | s2 indirection [m1] |
+| aliasing.cpp:30:8:30:9 | *s2 [m1] | semmle.label | *s2 [m1] |
 | aliasing.cpp:30:11:30:12 | m1 | semmle.label | m1 |
-| aliasing.cpp:60:3:60:4 | s2 indirection [post update] [m1] | semmle.label | s2 indirection [post update] [m1] |
+| aliasing.cpp:60:3:60:4 | *s2 [post update] [m1] | semmle.label | *s2 [post update] [m1] |
 | aliasing.cpp:60:3:60:22 | ... = ... | semmle.label | ... = ... |
 | aliasing.cpp:60:11:60:20 | call to user_input | semmle.label | call to user_input |
-| aliasing.cpp:62:8:62:12 | copy2 indirection [m1] | semmle.label | copy2 indirection [m1] |
+| aliasing.cpp:62:8:62:12 | *copy2 [m1] | semmle.label | *copy2 [m1] |
 | aliasing.cpp:62:14:62:15 | m1 | semmle.label | m1 |
-| aliasing.cpp:92:3:92:3 | w indirection [post update] [s, m1] | semmle.label | w indirection [post update] [s, m1] |
+| aliasing.cpp:92:3:92:3 | *w [post update] [s, m1] | semmle.label | *w [post update] [s, m1] |
 | aliasing.cpp:92:3:92:23 | ... = ... | semmle.label | ... = ... |
-| aliasing.cpp:92:5:92:5 | s indirection [post update] [m1] | semmle.label | s indirection [post update] [m1] |
+| aliasing.cpp:92:5:92:5 | *s [post update] [m1] | semmle.label | *s [post update] [m1] |
 | aliasing.cpp:92:12:92:21 | call to user_input | semmle.label | call to user_input |
-| aliasing.cpp:93:8:93:8 | w indirection [s, m1] | semmle.label | w indirection [s, m1] |
-| aliasing.cpp:93:10:93:10 | s indirection [m1] | semmle.label | s indirection [m1] |
+| aliasing.cpp:93:8:93:8 | *w [s, m1] | semmle.label | *w [s, m1] |
+| aliasing.cpp:93:10:93:10 | *s [m1] | semmle.label | *s [m1] |
 | aliasing.cpp:93:12:93:13 | m1 | semmle.label | m1 |
-| aliasing.cpp:98:3:98:3 | s indirection [post update] [m1] | semmle.label | s indirection [post update] [m1] |
+| aliasing.cpp:98:3:98:3 | *s [post update] [m1] | semmle.label | *s [post update] [m1] |
 | aliasing.cpp:98:3:98:21 | ... = ... | semmle.label | ... = ... |
 | aliasing.cpp:98:10:98:19 | call to user_input | semmle.label | call to user_input |
-| aliasing.cpp:101:13:101:22 | & ... indirection | semmle.label | & ... indirection |
-| aliasing.cpp:101:14:101:19 | s_copy indirection [m1] | semmle.label | s_copy indirection [m1] |
+| aliasing.cpp:101:13:101:22 | *& ... | semmle.label | *& ... |
+| aliasing.cpp:101:14:101:19 | *s_copy [m1] | semmle.label | *s_copy [m1] |
 | aliasing.cpp:102:8:102:10 | * ... | semmle.label | * ... |
-| aliasing.cpp:105:23:105:24 | pa | semmle.label | pa |
+| aliasing.cpp:105:23:105:24 | *pa | semmle.label | *pa |
 | aliasing.cpp:106:9:106:18 | call to user_input | semmle.label | call to user_input |
 | aliasing.cpp:121:15:121:16 | taint_a_ptr output argument | semmle.label | taint_a_ptr output argument |
 | aliasing.cpp:122:8:122:12 | access to array | semmle.label | access to array |
@@ -1013,36 +1013,36 @@ nodes
 | aliasing.cpp:132:8:132:14 | * ... | semmle.label | * ... |
 | aliasing.cpp:136:15:136:17 | taint_a_ptr output argument | semmle.label | taint_a_ptr output argument |
 | aliasing.cpp:137:8:137:11 | * ... | semmle.label | * ... |
-| aliasing.cpp:141:15:141:15 | s indirection [post update] [data indirection] | semmle.label | s indirection [post update] [data indirection] |
+| aliasing.cpp:141:15:141:15 | *s [post update] [*data] | semmle.label | *s [post update] [*data] |
 | aliasing.cpp:141:17:141:20 | taint_a_ptr output argument | semmle.label | taint_a_ptr output argument |
-| aliasing.cpp:143:8:143:8 | s indirection [data indirection] | semmle.label | s indirection [data indirection] |
+| aliasing.cpp:143:8:143:8 | *s [*data] | semmle.label | *s [*data] |
 | aliasing.cpp:143:8:143:16 | access to array | semmle.label | access to array |
-| aliasing.cpp:143:10:143:13 | data indirection | semmle.label | data indirection |
-| aliasing.cpp:158:15:158:15 | s indirection [post update] [data] | semmle.label | s indirection [post update] [data] |
+| aliasing.cpp:143:10:143:13 | *data | semmle.label | *data |
+| aliasing.cpp:158:15:158:15 | *s [post update] [data] | semmle.label | *s [post update] [data] |
 | aliasing.cpp:158:15:158:20 | taint_a_ptr output argument | semmle.label | taint_a_ptr output argument |
 | aliasing.cpp:159:8:159:14 | * ... | semmle.label | * ... |
-| aliasing.cpp:159:9:159:9 | s indirection [data] | semmle.label | s indirection [data] |
-| aliasing.cpp:164:15:164:15 | s indirection [post update] [data] | semmle.label | s indirection [post update] [data] |
+| aliasing.cpp:159:9:159:9 | *s [data] | semmle.label | *s [data] |
+| aliasing.cpp:164:15:164:15 | *s [post update] [data] | semmle.label | *s [post update] [data] |
 | aliasing.cpp:164:15:164:20 | taint_a_ptr output argument | semmle.label | taint_a_ptr output argument |
-| aliasing.cpp:165:8:165:8 | s indirection [data] | semmle.label | s indirection [data] |
+| aliasing.cpp:165:8:165:8 | *s [data] | semmle.label | *s [data] |
 | aliasing.cpp:165:8:165:16 | access to array | semmle.label | access to array |
 | aliasing.cpp:175:15:175:22 | taint_a_ptr output argument | semmle.label | taint_a_ptr output argument |
-| aliasing.cpp:175:16:175:17 | s2 indirection [post update] [s, m1] | semmle.label | s2 indirection [post update] [s, m1] |
-| aliasing.cpp:175:19:175:19 | s indirection [post update] [m1] | semmle.label | s indirection [post update] [m1] |
-| aliasing.cpp:176:8:176:9 | s2 indirection [s, m1] | semmle.label | s2 indirection [s, m1] |
-| aliasing.cpp:176:11:176:11 | s indirection [m1] | semmle.label | s indirection [m1] |
+| aliasing.cpp:175:16:175:17 | *s2 [post update] [s, m1] | semmle.label | *s2 [post update] [s, m1] |
+| aliasing.cpp:175:19:175:19 | *s [post update] [m1] | semmle.label | *s [post update] [m1] |
+| aliasing.cpp:176:8:176:9 | *s2 [s, m1] | semmle.label | *s2 [s, m1] |
+| aliasing.cpp:176:11:176:11 | *s [m1] | semmle.label | *s [m1] |
 | aliasing.cpp:176:13:176:14 | m1 | semmle.label | m1 |
 | aliasing.cpp:187:15:187:22 | taint_a_ptr output argument | semmle.label | taint_a_ptr output argument |
-| aliasing.cpp:187:16:187:17 | s2 indirection [post update] [s, m1] | semmle.label | s2 indirection [post update] [s, m1] |
-| aliasing.cpp:187:19:187:19 | s indirection [post update] [m1] | semmle.label | s indirection [post update] [m1] |
-| aliasing.cpp:189:8:189:11 | s2_2 indirection [s, m1] | semmle.label | s2_2 indirection [s, m1] |
-| aliasing.cpp:189:13:189:13 | s indirection [m1] | semmle.label | s indirection [m1] |
+| aliasing.cpp:187:16:187:17 | *s2 [post update] [s, m1] | semmle.label | *s2 [post update] [s, m1] |
+| aliasing.cpp:187:19:187:19 | *s [post update] [m1] | semmle.label | *s [post update] [m1] |
+| aliasing.cpp:189:8:189:11 | *s2_2 [s, m1] | semmle.label | *s2_2 [s, m1] |
+| aliasing.cpp:189:13:189:13 | *s [m1] | semmle.label | *s [m1] |
 | aliasing.cpp:189:15:189:16 | m1 | semmle.label | m1 |
 | aliasing.cpp:200:15:200:24 | taint_a_ptr output argument | semmle.label | taint_a_ptr output argument |
-| aliasing.cpp:200:16:200:18 | ps2 indirection [post update] [s, m1] | semmle.label | ps2 indirection [post update] [s, m1] |
-| aliasing.cpp:200:21:200:21 | s indirection [post update] [m1] | semmle.label | s indirection [post update] [m1] |
-| aliasing.cpp:201:8:201:10 | ps2 indirection [s, m1] | semmle.label | ps2 indirection [s, m1] |
-| aliasing.cpp:201:13:201:13 | s indirection [m1] | semmle.label | s indirection [m1] |
+| aliasing.cpp:200:16:200:18 | *ps2 [post update] [s, m1] | semmle.label | *ps2 [post update] [s, m1] |
+| aliasing.cpp:200:21:200:21 | *s [post update] [m1] | semmle.label | *s [post update] [m1] |
+| aliasing.cpp:201:8:201:10 | *ps2 [s, m1] | semmle.label | *ps2 [s, m1] |
+| aliasing.cpp:201:13:201:13 | *s [m1] | semmle.label | *s [m1] |
 | aliasing.cpp:201:15:201:16 | m1 | semmle.label | m1 |
 | arrays.cpp:6:12:6:21 | call to user_input | semmle.label | call to user_input |
 | arrays.cpp:7:8:7:13 | access to array | semmle.label | access to array |
@@ -1052,52 +1052,52 @@ nodes
 | arrays.cpp:15:14:15:23 | call to user_input | semmle.label | call to user_input |
 | arrays.cpp:16:8:16:13 | access to array | semmle.label | access to array |
 | arrays.cpp:17:8:17:13 | access to array | semmle.label | access to array |
-| arrays.cpp:36:3:36:3 | o indirection [post update] [nested, arr, data] | semmle.label | o indirection [post update] [nested, arr, data] |
-| arrays.cpp:36:3:36:17 | access to array indirection [post update] [data] | semmle.label | access to array indirection [post update] [data] |
+| arrays.cpp:36:3:36:3 | *o [post update] [nested, arr, data] | semmle.label | *o [post update] [nested, arr, data] |
+| arrays.cpp:36:3:36:17 | *access to array [post update] [data] | semmle.label | *access to array [post update] [data] |
 | arrays.cpp:36:3:36:37 | ... = ... | semmle.label | ... = ... |
-| arrays.cpp:36:5:36:10 | nested indirection [post update] [arr, data] | semmle.label | nested indirection [post update] [arr, data] |
+| arrays.cpp:36:5:36:10 | *nested [post update] [arr, data] | semmle.label | *nested [post update] [arr, data] |
 | arrays.cpp:36:26:36:35 | call to user_input | semmle.label | call to user_input |
-| arrays.cpp:37:8:37:8 | o indirection [nested, arr, data] | semmle.label | o indirection [nested, arr, data] |
-| arrays.cpp:37:8:37:22 | access to array indirection [data] | semmle.label | access to array indirection [data] |
-| arrays.cpp:37:10:37:15 | nested indirection [arr, data] | semmle.label | nested indirection [arr, data] |
+| arrays.cpp:37:8:37:8 | *o [nested, arr, data] | semmle.label | *o [nested, arr, data] |
+| arrays.cpp:37:8:37:22 | *access to array [data] | semmle.label | *access to array [data] |
+| arrays.cpp:37:10:37:15 | *nested [arr, data] | semmle.label | *nested [arr, data] |
 | arrays.cpp:37:24:37:27 | data | semmle.label | data |
-| arrays.cpp:38:8:38:8 | o indirection [nested, arr, data] | semmle.label | o indirection [nested, arr, data] |
-| arrays.cpp:38:8:38:22 | access to array indirection [data] | semmle.label | access to array indirection [data] |
-| arrays.cpp:38:10:38:15 | nested indirection [arr, data] | semmle.label | nested indirection [arr, data] |
+| arrays.cpp:38:8:38:8 | *o [nested, arr, data] | semmle.label | *o [nested, arr, data] |
+| arrays.cpp:38:8:38:22 | *access to array [data] | semmle.label | *access to array [data] |
+| arrays.cpp:38:10:38:15 | *nested [arr, data] | semmle.label | *nested [arr, data] |
 | arrays.cpp:38:24:38:27 | data | semmle.label | data |
-| arrays.cpp:42:3:42:3 | o indirection [post update] [indirect indirection, arr, data] | semmle.label | o indirection [post update] [indirect indirection, arr, data] |
-| arrays.cpp:42:3:42:20 | access to array indirection [post update] [data] | semmle.label | access to array indirection [post update] [data] |
+| arrays.cpp:42:3:42:3 | *o [post update] [*indirect, arr, data] | semmle.label | *o [post update] [*indirect, arr, data] |
+| arrays.cpp:42:3:42:20 | *access to array [post update] [data] | semmle.label | *access to array [post update] [data] |
 | arrays.cpp:42:3:42:40 | ... = ... | semmle.label | ... = ... |
-| arrays.cpp:42:5:42:12 | indirect indirection [post update] [arr, data] | semmle.label | indirect indirection [post update] [arr, data] |
+| arrays.cpp:42:5:42:12 | *indirect [post update] [arr, data] | semmle.label | *indirect [post update] [arr, data] |
 | arrays.cpp:42:29:42:38 | call to user_input | semmle.label | call to user_input |
-| arrays.cpp:43:8:43:8 | o indirection [indirect indirection, arr, data] | semmle.label | o indirection [indirect indirection, arr, data] |
-| arrays.cpp:43:8:43:25 | access to array indirection [data] | semmle.label | access to array indirection [data] |
-| arrays.cpp:43:10:43:17 | indirect indirection [arr, data] | semmle.label | indirect indirection [arr, data] |
+| arrays.cpp:43:8:43:8 | *o [*indirect, arr, data] | semmle.label | *o [*indirect, arr, data] |
+| arrays.cpp:43:8:43:25 | *access to array [data] | semmle.label | *access to array [data] |
+| arrays.cpp:43:10:43:17 | *indirect [arr, data] | semmle.label | *indirect [arr, data] |
 | arrays.cpp:43:27:43:30 | data | semmle.label | data |
-| arrays.cpp:44:8:44:8 | o indirection [indirect indirection, arr, data] | semmle.label | o indirection [indirect indirection, arr, data] |
-| arrays.cpp:44:8:44:25 | access to array indirection [data] | semmle.label | access to array indirection [data] |
-| arrays.cpp:44:10:44:17 | indirect indirection [arr, data] | semmle.label | indirect indirection [arr, data] |
+| arrays.cpp:44:8:44:8 | *o [*indirect, arr, data] | semmle.label | *o [*indirect, arr, data] |
+| arrays.cpp:44:8:44:25 | *access to array [data] | semmle.label | *access to array [data] |
+| arrays.cpp:44:10:44:17 | *indirect [arr, data] | semmle.label | *indirect [arr, data] |
 | arrays.cpp:44:27:44:30 | data | semmle.label | data |
-| arrays.cpp:48:3:48:3 | o indirection [post update] [indirect indirection, ptr indirection, data] | semmle.label | o indirection [post update] [indirect indirection, ptr indirection, data] |
-| arrays.cpp:48:3:48:20 | access to array indirection [post update] [data] | semmle.label | access to array indirection [post update] [data] |
+| arrays.cpp:48:3:48:3 | *o [post update] [*indirect, *ptr, data] | semmle.label | *o [post update] [*indirect, *ptr, data] |
+| arrays.cpp:48:3:48:20 | *access to array [post update] [data] | semmle.label | *access to array [post update] [data] |
 | arrays.cpp:48:3:48:40 | ... = ... | semmle.label | ... = ... |
-| arrays.cpp:48:5:48:12 | indirect indirection [post update] [ptr indirection, data] | semmle.label | indirect indirection [post update] [ptr indirection, data] |
+| arrays.cpp:48:5:48:12 | *indirect [post update] [*ptr, data] | semmle.label | *indirect [post update] [*ptr, data] |
 | arrays.cpp:48:29:48:38 | call to user_input | semmle.label | call to user_input |
-| arrays.cpp:49:8:49:8 | o indirection [indirect indirection, ptr indirection, data] | semmle.label | o indirection [indirect indirection, ptr indirection, data] |
-| arrays.cpp:49:8:49:25 | access to array indirection [data] | semmle.label | access to array indirection [data] |
-| arrays.cpp:49:10:49:17 | indirect indirection [ptr indirection, data] | semmle.label | indirect indirection [ptr indirection, data] |
-| arrays.cpp:49:20:49:22 | ptr indirection [data] | semmle.label | ptr indirection [data] |
+| arrays.cpp:49:8:49:8 | *o [*indirect, *ptr, data] | semmle.label | *o [*indirect, *ptr, data] |
+| arrays.cpp:49:8:49:25 | *access to array [data] | semmle.label | *access to array [data] |
+| arrays.cpp:49:10:49:17 | *indirect [*ptr, data] | semmle.label | *indirect [*ptr, data] |
+| arrays.cpp:49:20:49:22 | *ptr [data] | semmle.label | *ptr [data] |
 | arrays.cpp:49:27:49:30 | data | semmle.label | data |
-| arrays.cpp:50:8:50:8 | o indirection [indirect indirection, ptr indirection, data] | semmle.label | o indirection [indirect indirection, ptr indirection, data] |
-| arrays.cpp:50:8:50:25 | access to array indirection [data] | semmle.label | access to array indirection [data] |
-| arrays.cpp:50:10:50:17 | indirect indirection [ptr indirection, data] | semmle.label | indirect indirection [ptr indirection, data] |
-| arrays.cpp:50:20:50:22 | ptr indirection [data] | semmle.label | ptr indirection [data] |
+| arrays.cpp:50:8:50:8 | *o [*indirect, *ptr, data] | semmle.label | *o [*indirect, *ptr, data] |
+| arrays.cpp:50:8:50:25 | *access to array [data] | semmle.label | *access to array [data] |
+| arrays.cpp:50:10:50:17 | *indirect [*ptr, data] | semmle.label | *indirect [*ptr, data] |
+| arrays.cpp:50:20:50:22 | *ptr [data] | semmle.label | *ptr [data] |
 | arrays.cpp:50:27:50:30 | data | semmle.label | data |
 | by_reference.cpp:11:48:11:52 | value | semmle.label | value |
-| by_reference.cpp:12:5:12:5 | s indirection [post update] [a] | semmle.label | s indirection [post update] [a] |
+| by_reference.cpp:12:5:12:5 | *s [post update] [a] | semmle.label | *s [post update] [a] |
 | by_reference.cpp:12:5:12:16 | ... = ... | semmle.label | ... = ... |
 | by_reference.cpp:15:26:15:30 | value | semmle.label | value |
-| by_reference.cpp:16:5:16:8 | this indirection [post update] [a] | semmle.label | this indirection [post update] [a] |
+| by_reference.cpp:16:5:16:8 | *this [post update] [a] | semmle.label | *this [post update] [a] |
 | by_reference.cpp:16:5:16:19 | ... = ... | semmle.label | ... = ... |
 | by_reference.cpp:19:28:19:32 | value | semmle.label | value |
 | by_reference.cpp:20:5:20:8 | setDirectly output argument [a] | semmle.label | setDirectly output argument [a] |
@@ -1105,287 +1105,287 @@ nodes
 | by_reference.cpp:23:34:23:38 | value | semmle.label | value |
 | by_reference.cpp:24:19:24:22 | nonMemberSetA output argument [a] | semmle.label | nonMemberSetA output argument [a] |
 | by_reference.cpp:24:25:24:29 | value | semmle.label | value |
-| by_reference.cpp:31:16:31:28 | nonMemberGetA indirection | semmle.label | nonMemberGetA indirection |
-| by_reference.cpp:31:46:31:46 | s indirection [a] | semmle.label | s indirection [a] |
-| by_reference.cpp:32:12:32:12 | s indirection [a] | semmle.label | s indirection [a] |
+| by_reference.cpp:31:16:31:28 | *nonMemberGetA | semmle.label | *nonMemberGetA |
+| by_reference.cpp:31:46:31:46 | *s [a] | semmle.label | *s [a] |
+| by_reference.cpp:32:12:32:12 | *s [a] | semmle.label | *s [a] |
 | by_reference.cpp:32:15:32:15 | a | semmle.label | a |
-| by_reference.cpp:35:9:35:19 | getDirectly indirection | semmle.label | getDirectly indirection |
-| by_reference.cpp:35:9:35:19 | this indirection [a] | semmle.label | this indirection [a] |
-| by_reference.cpp:36:12:36:15 | this indirection [a] | semmle.label | this indirection [a] |
+| by_reference.cpp:35:9:35:19 | *getDirectly | semmle.label | *getDirectly |
+| by_reference.cpp:35:9:35:19 | *this [a] | semmle.label | *this [a] |
+| by_reference.cpp:36:12:36:15 | *this [a] | semmle.label | *this [a] |
 | by_reference.cpp:36:18:36:18 | a | semmle.label | a |
-| by_reference.cpp:39:9:39:21 | getIndirectly indirection | semmle.label | getIndirectly indirection |
-| by_reference.cpp:39:9:39:21 | this indirection [a] | semmle.label | this indirection [a] |
-| by_reference.cpp:40:12:40:15 | this indirection [a] | semmle.label | this indirection [a] |
+| by_reference.cpp:39:9:39:21 | *getIndirectly | semmle.label | *getIndirectly |
+| by_reference.cpp:39:9:39:21 | *this [a] | semmle.label | *this [a] |
+| by_reference.cpp:40:12:40:15 | *this [a] | semmle.label | *this [a] |
 | by_reference.cpp:40:18:40:28 | call to getDirectly | semmle.label | call to getDirectly |
-| by_reference.cpp:43:9:43:27 | getThroughNonMember indirection | semmle.label | getThroughNonMember indirection |
-| by_reference.cpp:43:9:43:27 | this indirection [a] | semmle.label | this indirection [a] |
+| by_reference.cpp:43:9:43:27 | *getThroughNonMember | semmle.label | *getThroughNonMember |
+| by_reference.cpp:43:9:43:27 | *this [a] | semmle.label | *this [a] |
 | by_reference.cpp:44:12:44:24 | call to nonMemberGetA | semmle.label | call to nonMemberGetA |
-| by_reference.cpp:44:26:44:29 | this indirection [a] | semmle.label | this indirection [a] |
+| by_reference.cpp:44:26:44:29 | *this [a] | semmle.label | *this [a] |
 | by_reference.cpp:50:3:50:3 | setDirectly output argument [a] | semmle.label | setDirectly output argument [a] |
 | by_reference.cpp:50:17:50:26 | call to user_input | semmle.label | call to user_input |
-| by_reference.cpp:51:8:51:8 | s indirection [a] | semmle.label | s indirection [a] |
+| by_reference.cpp:51:8:51:8 | *s [a] | semmle.label | *s [a] |
 | by_reference.cpp:51:10:51:20 | call to getDirectly | semmle.label | call to getDirectly |
 | by_reference.cpp:56:3:56:3 | setIndirectly output argument [a] | semmle.label | setIndirectly output argument [a] |
 | by_reference.cpp:56:19:56:28 | call to user_input | semmle.label | call to user_input |
-| by_reference.cpp:57:8:57:8 | s indirection [a] | semmle.label | s indirection [a] |
+| by_reference.cpp:57:8:57:8 | *s [a] | semmle.label | *s [a] |
 | by_reference.cpp:57:10:57:22 | call to getIndirectly | semmle.label | call to getIndirectly |
 | by_reference.cpp:62:3:62:3 | setThroughNonMember output argument [a] | semmle.label | setThroughNonMember output argument [a] |
 | by_reference.cpp:62:25:62:34 | call to user_input | semmle.label | call to user_input |
-| by_reference.cpp:63:8:63:8 | s indirection [a] | semmle.label | s indirection [a] |
+| by_reference.cpp:63:8:63:8 | *s [a] | semmle.label | *s [a] |
 | by_reference.cpp:63:10:63:28 | call to getThroughNonMember | semmle.label | call to getThroughNonMember |
 | by_reference.cpp:68:17:68:18 | nonMemberSetA output argument [a] | semmle.label | nonMemberSetA output argument [a] |
 | by_reference.cpp:68:21:68:30 | call to user_input | semmle.label | call to user_input |
 | by_reference.cpp:69:8:69:20 | call to nonMemberGetA | semmle.label | call to nonMemberGetA |
-| by_reference.cpp:69:22:69:23 | & ... indirection [a] | semmle.label | & ... indirection [a] |
-| by_reference.cpp:84:3:84:7 | inner indirection [post update] [a] | semmle.label | inner indirection [post update] [a] |
+| by_reference.cpp:69:22:69:23 | *& ... [a] | semmle.label | *& ... [a] |
+| by_reference.cpp:84:3:84:7 | *inner [post update] [a] | semmle.label | *inner [post update] [a] |
 | by_reference.cpp:84:3:84:25 | ... = ... | semmle.label | ... = ... |
 | by_reference.cpp:84:14:84:23 | call to user_input | semmle.label | call to user_input |
-| by_reference.cpp:88:3:88:7 | inner indirection [post update] [a] | semmle.label | inner indirection [post update] [a] |
+| by_reference.cpp:88:3:88:7 | *inner [post update] [a] | semmle.label | *inner [post update] [a] |
 | by_reference.cpp:88:3:88:24 | ... = ... | semmle.label | ... = ... |
 | by_reference.cpp:88:13:88:22 | call to user_input | semmle.label | call to user_input |
-| by_reference.cpp:91:25:91:26 | pa | semmle.label | pa |
+| by_reference.cpp:91:25:91:26 | *pa | semmle.label | *pa |
 | by_reference.cpp:92:9:92:18 | call to user_input | semmle.label | call to user_input |
-| by_reference.cpp:95:25:95:26 | pa | semmle.label | pa |
+| by_reference.cpp:95:25:95:26 | *pa | semmle.label | *pa |
 | by_reference.cpp:96:8:96:17 | call to user_input | semmle.label | call to user_input |
 | by_reference.cpp:102:21:102:39 | taint_inner_a_ptr output argument [a] | semmle.label | taint_inner_a_ptr output argument [a] |
-| by_reference.cpp:102:22:102:26 | outer indirection [post update] [inner_nested, a] | semmle.label | outer indirection [post update] [inner_nested, a] |
-| by_reference.cpp:103:21:103:25 | outer indirection [post update] [inner_ptr indirection, a] | semmle.label | outer indirection [post update] [inner_ptr indirection, a] |
+| by_reference.cpp:102:22:102:26 | *outer [post update] [inner_nested, a] | semmle.label | *outer [post update] [inner_nested, a] |
+| by_reference.cpp:103:21:103:25 | *outer [post update] [*inner_ptr, a] | semmle.label | *outer [post update] [*inner_ptr, a] |
 | by_reference.cpp:103:27:103:35 | taint_inner_a_ptr output argument [a] | semmle.label | taint_inner_a_ptr output argument [a] |
 | by_reference.cpp:104:15:104:22 | taint_a_ptr output argument | semmle.label | taint_a_ptr output argument |
-| by_reference.cpp:104:16:104:20 | outer indirection [post update] [a] | semmle.label | outer indirection [post update] [a] |
+| by_reference.cpp:104:16:104:20 | *outer [post update] [a] | semmle.label | *outer [post update] [a] |
 | by_reference.cpp:106:21:106:41 | taint_inner_a_ptr output argument [a] | semmle.label | taint_inner_a_ptr output argument [a] |
-| by_reference.cpp:106:22:106:27 | pouter indirection [post update] [inner_nested, a] | semmle.label | pouter indirection [post update] [inner_nested, a] |
-| by_reference.cpp:107:21:107:26 | pouter indirection [post update] [inner_ptr indirection, a] | semmle.label | pouter indirection [post update] [inner_ptr indirection, a] |
+| by_reference.cpp:106:22:106:27 | *pouter [post update] [inner_nested, a] | semmle.label | *pouter [post update] [inner_nested, a] |
+| by_reference.cpp:107:21:107:26 | *pouter [post update] [*inner_ptr, a] | semmle.label | *pouter [post update] [*inner_ptr, a] |
 | by_reference.cpp:107:29:107:37 | taint_inner_a_ptr output argument [a] | semmle.label | taint_inner_a_ptr output argument [a] |
 | by_reference.cpp:108:15:108:24 | taint_a_ptr output argument | semmle.label | taint_a_ptr output argument |
-| by_reference.cpp:108:16:108:21 | pouter indirection [post update] [a] | semmle.label | pouter indirection [post update] [a] |
-| by_reference.cpp:110:8:110:12 | outer indirection [inner_nested, a] | semmle.label | outer indirection [inner_nested, a] |
-| by_reference.cpp:110:14:110:25 | inner_nested indirection [a] | semmle.label | inner_nested indirection [a] |
+| by_reference.cpp:108:16:108:21 | *pouter [post update] [a] | semmle.label | *pouter [post update] [a] |
+| by_reference.cpp:110:8:110:12 | *outer [inner_nested, a] | semmle.label | *outer [inner_nested, a] |
+| by_reference.cpp:110:14:110:25 | *inner_nested [a] | semmle.label | *inner_nested [a] |
 | by_reference.cpp:110:27:110:27 | a | semmle.label | a |
-| by_reference.cpp:111:8:111:12 | outer indirection [inner_ptr indirection, a] | semmle.label | outer indirection [inner_ptr indirection, a] |
-| by_reference.cpp:111:14:111:22 | inner_ptr indirection [a] | semmle.label | inner_ptr indirection [a] |
+| by_reference.cpp:111:8:111:12 | *outer [*inner_ptr, a] | semmle.label | *outer [*inner_ptr, a] |
+| by_reference.cpp:111:14:111:22 | *inner_ptr [a] | semmle.label | *inner_ptr [a] |
 | by_reference.cpp:111:25:111:25 | a | semmle.label | a |
-| by_reference.cpp:112:8:112:12 | outer indirection [a] | semmle.label | outer indirection [a] |
+| by_reference.cpp:112:8:112:12 | *outer [a] | semmle.label | *outer [a] |
 | by_reference.cpp:112:14:112:14 | a | semmle.label | a |
-| by_reference.cpp:114:8:114:13 | pouter indirection [inner_nested, a] | semmle.label | pouter indirection [inner_nested, a] |
-| by_reference.cpp:114:16:114:27 | inner_nested indirection [a] | semmle.label | inner_nested indirection [a] |
+| by_reference.cpp:114:8:114:13 | *pouter [inner_nested, a] | semmle.label | *pouter [inner_nested, a] |
+| by_reference.cpp:114:16:114:27 | *inner_nested [a] | semmle.label | *inner_nested [a] |
 | by_reference.cpp:114:29:114:29 | a | semmle.label | a |
-| by_reference.cpp:115:8:115:13 | pouter indirection [inner_ptr indirection, a] | semmle.label | pouter indirection [inner_ptr indirection, a] |
-| by_reference.cpp:115:16:115:24 | inner_ptr indirection [a] | semmle.label | inner_ptr indirection [a] |
+| by_reference.cpp:115:8:115:13 | *pouter [*inner_ptr, a] | semmle.label | *pouter [*inner_ptr, a] |
+| by_reference.cpp:115:16:115:24 | *inner_ptr [a] | semmle.label | *inner_ptr [a] |
 | by_reference.cpp:115:27:115:27 | a | semmle.label | a |
-| by_reference.cpp:116:8:116:13 | pouter indirection [a] | semmle.label | pouter indirection [a] |
+| by_reference.cpp:116:8:116:13 | *pouter [a] | semmle.label | *pouter [a] |
 | by_reference.cpp:116:16:116:16 | a | semmle.label | a |
-| by_reference.cpp:122:21:122:25 | outer indirection [post update] [inner_nested, a] | semmle.label | outer indirection [post update] [inner_nested, a] |
+| by_reference.cpp:122:21:122:25 | *outer [post update] [inner_nested, a] | semmle.label | *outer [post update] [inner_nested, a] |
 | by_reference.cpp:122:21:122:38 | taint_inner_a_ref output argument [a] | semmle.label | taint_inner_a_ref output argument [a] |
 | by_reference.cpp:123:21:123:36 | taint_inner_a_ref output argument [a] | semmle.label | taint_inner_a_ref output argument [a] |
-| by_reference.cpp:123:22:123:26 | outer indirection [post update] [inner_ptr indirection, a] | semmle.label | outer indirection [post update] [inner_ptr indirection, a] |
-| by_reference.cpp:124:15:124:19 | outer indirection [post update] [a] | semmle.label | outer indirection [post update] [a] |
+| by_reference.cpp:123:22:123:26 | *outer [post update] [*inner_ptr, a] | semmle.label | *outer [post update] [*inner_ptr, a] |
+| by_reference.cpp:124:15:124:19 | *outer [post update] [a] | semmle.label | *outer [post update] [a] |
 | by_reference.cpp:124:15:124:21 | taint_a_ref output argument | semmle.label | taint_a_ref output argument |
-| by_reference.cpp:126:21:126:26 | pouter indirection [post update] [inner_nested, a] | semmle.label | pouter indirection [post update] [inner_nested, a] |
+| by_reference.cpp:126:21:126:26 | *pouter [post update] [inner_nested, a] | semmle.label | *pouter [post update] [inner_nested, a] |
 | by_reference.cpp:126:21:126:40 | taint_inner_a_ref output argument [a] | semmle.label | taint_inner_a_ref output argument [a] |
 | by_reference.cpp:127:21:127:38 | taint_inner_a_ref output argument [a] | semmle.label | taint_inner_a_ref output argument [a] |
-| by_reference.cpp:127:22:127:27 | pouter indirection [post update] [inner_ptr indirection, a] | semmle.label | pouter indirection [post update] [inner_ptr indirection, a] |
-| by_reference.cpp:128:15:128:20 | pouter indirection [post update] [a] | semmle.label | pouter indirection [post update] [a] |
+| by_reference.cpp:127:22:127:27 | *pouter [post update] [*inner_ptr, a] | semmle.label | *pouter [post update] [*inner_ptr, a] |
+| by_reference.cpp:128:15:128:20 | *pouter [post update] [a] | semmle.label | *pouter [post update] [a] |
 | by_reference.cpp:128:15:128:23 | taint_a_ref output argument | semmle.label | taint_a_ref output argument |
-| by_reference.cpp:130:8:130:12 | outer indirection [inner_nested, a] | semmle.label | outer indirection [inner_nested, a] |
-| by_reference.cpp:130:14:130:25 | inner_nested indirection [a] | semmle.label | inner_nested indirection [a] |
+| by_reference.cpp:130:8:130:12 | *outer [inner_nested, a] | semmle.label | *outer [inner_nested, a] |
+| by_reference.cpp:130:14:130:25 | *inner_nested [a] | semmle.label | *inner_nested [a] |
 | by_reference.cpp:130:27:130:27 | a | semmle.label | a |
-| by_reference.cpp:131:8:131:12 | outer indirection [inner_ptr indirection, a] | semmle.label | outer indirection [inner_ptr indirection, a] |
-| by_reference.cpp:131:14:131:22 | inner_ptr indirection [a] | semmle.label | inner_ptr indirection [a] |
+| by_reference.cpp:131:8:131:12 | *outer [*inner_ptr, a] | semmle.label | *outer [*inner_ptr, a] |
+| by_reference.cpp:131:14:131:22 | *inner_ptr [a] | semmle.label | *inner_ptr [a] |
 | by_reference.cpp:131:25:131:25 | a | semmle.label | a |
-| by_reference.cpp:132:8:132:12 | outer indirection [a] | semmle.label | outer indirection [a] |
+| by_reference.cpp:132:8:132:12 | *outer [a] | semmle.label | *outer [a] |
 | by_reference.cpp:132:14:132:14 | a | semmle.label | a |
-| by_reference.cpp:134:8:134:13 | pouter indirection [inner_nested, a] | semmle.label | pouter indirection [inner_nested, a] |
-| by_reference.cpp:134:16:134:27 | inner_nested indirection [a] | semmle.label | inner_nested indirection [a] |
+| by_reference.cpp:134:8:134:13 | *pouter [inner_nested, a] | semmle.label | *pouter [inner_nested, a] |
+| by_reference.cpp:134:16:134:27 | *inner_nested [a] | semmle.label | *inner_nested [a] |
 | by_reference.cpp:134:29:134:29 | a | semmle.label | a |
-| by_reference.cpp:135:8:135:13 | pouter indirection [inner_ptr indirection, a] | semmle.label | pouter indirection [inner_ptr indirection, a] |
-| by_reference.cpp:135:16:135:24 | inner_ptr indirection [a] | semmle.label | inner_ptr indirection [a] |
+| by_reference.cpp:135:8:135:13 | *pouter [*inner_ptr, a] | semmle.label | *pouter [*inner_ptr, a] |
+| by_reference.cpp:135:16:135:24 | *inner_ptr [a] | semmle.label | *inner_ptr [a] |
 | by_reference.cpp:135:27:135:27 | a | semmle.label | a |
-| by_reference.cpp:136:8:136:13 | pouter indirection [a] | semmle.label | pouter indirection [a] |
+| by_reference.cpp:136:8:136:13 | *pouter [a] | semmle.label | *pouter [a] |
 | by_reference.cpp:136:16:136:16 | a | semmle.label | a |
 | clearning.cpp:32:3:32:25 | ... = ... | semmle.label | ... = ... |
-| clearning.cpp:32:4:32:4 | s indirection [post update] [x indirection] | semmle.label | s indirection [post update] [x indirection] |
+| clearning.cpp:32:4:32:4 | *s [post update] [*x] | semmle.label | *s [post update] [*x] |
 | clearning.cpp:32:10:32:19 | call to user_input | semmle.label | call to user_input |
-| clearning.cpp:33:5:33:5 | s indirection [x indirection] | semmle.label | s indirection [x indirection] |
+| clearning.cpp:33:5:33:5 | *s [*x] | semmle.label | *s [*x] |
 | clearning.cpp:34:8:34:11 | * ... | semmle.label | * ... |
-| clearning.cpp:34:9:34:9 | s indirection [x indirection] | semmle.label | s indirection [x indirection] |
+| clearning.cpp:34:9:34:9 | *s [*x] | semmle.label | *s [*x] |
 | clearning.cpp:53:3:53:25 | ... = ... | semmle.label | ... = ... |
-| clearning.cpp:53:4:53:4 | s indirection [post update] [x indirection] | semmle.label | s indirection [post update] [x indirection] |
+| clearning.cpp:53:4:53:4 | *s [post update] [*x] | semmle.label | *s [post update] [*x] |
 | clearning.cpp:53:10:53:19 | call to user_input | semmle.label | call to user_input |
-| clearning.cpp:54:3:54:3 | s indirection [post update] [x indirection] | semmle.label | s indirection [post update] [x indirection] |
-| clearning.cpp:54:3:54:3 | s indirection [x indirection] | semmle.label | s indirection [x indirection] |
-| clearning.cpp:54:3:54:7 | ... ++ indirection | semmle.label | ... ++ indirection |
-| clearning.cpp:54:3:54:7 | ... ++ indirection | semmle.label | ... ++ indirection |
-| clearning.cpp:54:5:54:5 | x indirection | semmle.label | x indirection |
-| clearning.cpp:55:8:55:8 | s indirection [x indirection] | semmle.label | s indirection [x indirection] |
-| clearning.cpp:55:10:55:10 | x indirection | semmle.label | x indirection |
+| clearning.cpp:54:3:54:3 | *s [*x] | semmle.label | *s [*x] |
+| clearning.cpp:54:3:54:3 | *s [post update] [*x] | semmle.label | *s [post update] [*x] |
+| clearning.cpp:54:3:54:7 | *... ++ | semmle.label | *... ++ |
+| clearning.cpp:54:3:54:7 | *... ++ | semmle.label | *... ++ |
+| clearning.cpp:54:5:54:5 | *x | semmle.label | *x |
+| clearning.cpp:55:8:55:8 | *s [*x] | semmle.label | *s [*x] |
+| clearning.cpp:55:10:55:10 | *x | semmle.label | *x |
 | clearning.cpp:60:3:60:22 | ... = ... | semmle.label | ... = ... |
-| clearning.cpp:60:5:60:5 | s indirection [post update] [x indirection] | semmle.label | s indirection [post update] [x indirection] |
+| clearning.cpp:60:5:60:5 | *s [post update] [**x] | semmle.label | *s [post update] [**x] |
 | clearning.cpp:60:11:60:20 | call to user_input | semmle.label | call to user_input |
-| clearning.cpp:61:3:61:3 | s indirection [post update] [x indirection] | semmle.label | s indirection [post update] [x indirection] |
-| clearning.cpp:61:3:61:3 | s indirection [x indirection] | semmle.label | s indirection [x indirection] |
-| clearning.cpp:61:3:61:7 | ... ++ indirection | semmle.label | ... ++ indirection |
-| clearning.cpp:61:3:61:7 | ... ++ indirection | semmle.label | ... ++ indirection |
-| clearning.cpp:61:5:61:5 | x indirection | semmle.label | x indirection |
-| clearning.cpp:62:8:62:8 | s indirection [x indirection] | semmle.label | s indirection [x indirection] |
-| clearning.cpp:62:10:62:10 | x indirection | semmle.label | x indirection |
-| clearning.cpp:74:18:74:18 | s indirection [post update] [val indirection] | semmle.label | s indirection [post update] [val indirection] |
+| clearning.cpp:61:3:61:3 | *s [**x] | semmle.label | *s [**x] |
+| clearning.cpp:61:3:61:3 | *s [post update] [**x] | semmle.label | *s [post update] [**x] |
+| clearning.cpp:61:3:61:7 | **... ++ | semmle.label | **... ++ |
+| clearning.cpp:61:3:61:7 | **... ++ | semmle.label | **... ++ |
+| clearning.cpp:61:5:61:5 | **x | semmle.label | **x |
+| clearning.cpp:62:8:62:8 | *s [**x] | semmle.label | *s [**x] |
+| clearning.cpp:62:10:62:10 | **x | semmle.label | **x |
+| clearning.cpp:74:18:74:18 | *s [post update] [*val] | semmle.label | *s [post update] [*val] |
 | clearning.cpp:74:20:74:22 | argument_source output argument | semmle.label | argument_source output argument |
 | clearning.cpp:76:7:76:12 | * ... | semmle.label | * ... |
-| clearning.cpp:76:8:76:8 | s indirection [val indirection] | semmle.label | s indirection [val indirection] |
-| clearning.cpp:81:18:81:18 | s indirection [post update] [val indirection] | semmle.label | s indirection [post update] [val indirection] |
+| clearning.cpp:76:8:76:8 | *s [*val] | semmle.label | *s [*val] |
+| clearning.cpp:81:18:81:18 | *s [post update] [*val] | semmle.label | *s [post update] [*val] |
 | clearning.cpp:81:20:81:22 | argument_source output argument | semmle.label | argument_source output argument |
-| clearning.cpp:83:5:83:5 | s indirection [post update] [val indirection] | semmle.label | s indirection [post update] [val indirection] |
-| clearning.cpp:83:5:83:21 | ... = ... indirection | semmle.label | ... = ... indirection |
-| clearning.cpp:83:13:83:13 | s indirection [val indirection] | semmle.label | s indirection [val indirection] |
-| clearning.cpp:83:13:83:21 | ... + ... indirection | semmle.label | ... + ... indirection |
-| clearning.cpp:83:15:83:17 | val indirection | semmle.label | val indirection |
+| clearning.cpp:83:5:83:5 | *s [post update] [*val] | semmle.label | *s [post update] [*val] |
+| clearning.cpp:83:5:83:21 | *... = ... | semmle.label | *... = ... |
+| clearning.cpp:83:13:83:13 | *s [*val] | semmle.label | *s [*val] |
+| clearning.cpp:83:13:83:21 | *... + ... | semmle.label | *... + ... |
+| clearning.cpp:83:15:83:17 | *val | semmle.label | *val |
 | clearning.cpp:84:7:84:12 | * ... | semmle.label | * ... |
-| clearning.cpp:84:8:84:8 | s indirection [val indirection] | semmle.label | s indirection [val indirection] |
-| clearning.cpp:89:18:89:18 | s indirection [post update] [val indirection] | semmle.label | s indirection [post update] [val indirection] |
+| clearning.cpp:84:8:84:8 | *s [*val] | semmle.label | *s [*val] |
+| clearning.cpp:89:18:89:18 | *s [post update] [*val] | semmle.label | *s [post update] [*val] |
 | clearning.cpp:89:20:89:22 | argument_source output argument | semmle.label | argument_source output argument |
-| clearning.cpp:90:3:90:3 | s indirection [post update] [val indirection] | semmle.label | s indirection [post update] [val indirection] |
-| clearning.cpp:90:3:90:3 | s indirection [val indirection] | semmle.label | s indirection [val indirection] |
-| clearning.cpp:90:3:90:9 | ... ++ indirection | semmle.label | ... ++ indirection |
-| clearning.cpp:90:3:90:9 | ... ++ indirection | semmle.label | ... ++ indirection |
-| clearning.cpp:90:5:90:7 | val indirection | semmle.label | val indirection |
+| clearning.cpp:90:3:90:3 | *s [*val] | semmle.label | *s [*val] |
+| clearning.cpp:90:3:90:3 | *s [post update] [*val] | semmle.label | *s [post update] [*val] |
+| clearning.cpp:90:3:90:9 | *... ++ | semmle.label | *... ++ |
+| clearning.cpp:90:3:90:9 | *... ++ | semmle.label | *... ++ |
+| clearning.cpp:90:5:90:7 | **val | semmle.label | **val |
 | clearning.cpp:91:7:91:12 | * ... | semmle.label | * ... |
-| clearning.cpp:91:8:91:8 | s indirection [val indirection] | semmle.label | s indirection [val indirection] |
-| clearning.cpp:96:18:96:18 | s indirection [post update] [val indirection] | semmle.label | s indirection [post update] [val indirection] |
+| clearning.cpp:91:8:91:8 | *s [*val] | semmle.label | *s [*val] |
+| clearning.cpp:96:18:96:18 | *s [post update] [*val] | semmle.label | *s [post update] [*val] |
 | clearning.cpp:96:20:96:22 | argument_source output argument | semmle.label | argument_source output argument |
-| clearning.cpp:97:2:97:2 | s indirection [post update] [val indirection] | semmle.label | s indirection [post update] [val indirection] |
-| clearning.cpp:97:2:97:18 | ... = ... indirection | semmle.label | ... = ... indirection |
-| clearning.cpp:97:10:97:10 | s indirection [val indirection] | semmle.label | s indirection [val indirection] |
-| clearning.cpp:97:10:97:18 | ... + ... indirection | semmle.label | ... + ... indirection |
-| clearning.cpp:97:12:97:14 | val indirection | semmle.label | val indirection |
+| clearning.cpp:97:2:97:2 | *s [post update] [*val] | semmle.label | *s [post update] [*val] |
+| clearning.cpp:97:2:97:18 | *... = ... | semmle.label | *... = ... |
+| clearning.cpp:97:10:97:10 | *s [*val] | semmle.label | *s [*val] |
+| clearning.cpp:97:10:97:18 | *... + ... | semmle.label | *... + ... |
+| clearning.cpp:97:12:97:14 | *val | semmle.label | *val |
 | clearning.cpp:98:7:98:12 | * ... | semmle.label | * ... |
-| clearning.cpp:98:8:98:8 | s indirection [val indirection] | semmle.label | s indirection [val indirection] |
-| clearning.cpp:103:18:103:18 | s indirection [post update] [val indirection] | semmle.label | s indirection [post update] [val indirection] |
+| clearning.cpp:98:8:98:8 | *s [*val] | semmle.label | *s [*val] |
+| clearning.cpp:103:18:103:18 | *s [post update] [*val] | semmle.label | *s [post update] [*val] |
 | clearning.cpp:103:20:103:22 | argument_source output argument | semmle.label | argument_source output argument |
-| clearning.cpp:104:2:104:2 | s indirection [post update] [val indirection] | semmle.label | s indirection [post update] [val indirection] |
-| clearning.cpp:104:2:104:2 | s indirection [val indirection] | semmle.label | s indirection [val indirection] |
-| clearning.cpp:104:2:104:8 | ... ++ indirection | semmle.label | ... ++ indirection |
-| clearning.cpp:104:2:104:8 | ... ++ indirection | semmle.label | ... ++ indirection |
-| clearning.cpp:104:4:104:6 | val indirection | semmle.label | val indirection |
+| clearning.cpp:104:2:104:2 | *s [*val] | semmle.label | *s [*val] |
+| clearning.cpp:104:2:104:2 | *s [post update] [*val] | semmle.label | *s [post update] [*val] |
+| clearning.cpp:104:2:104:8 | *... ++ | semmle.label | *... ++ |
+| clearning.cpp:104:2:104:8 | *... ++ | semmle.label | *... ++ |
+| clearning.cpp:104:4:104:6 | *val | semmle.label | *val |
 | clearning.cpp:105:7:105:12 | * ... | semmle.label | * ... |
-| clearning.cpp:105:8:105:8 | s indirection [val indirection] | semmle.label | s indirection [val indirection] |
-| clearning.cpp:110:18:110:18 | s indirection [post update] [val indirection] | semmle.label | s indirection [post update] [val indirection] |
+| clearning.cpp:105:8:105:8 | *s [*val] | semmle.label | *s [*val] |
+| clearning.cpp:110:18:110:18 | *s [post update] [*val] | semmle.label | *s [post update] [*val] |
 | clearning.cpp:110:20:110:22 | argument_source output argument | semmle.label | argument_source output argument |
-| clearning.cpp:111:2:111:8 | ++ ... indirection | semmle.label | ++ ... indirection |
-| clearning.cpp:111:2:111:8 | ++ ... indirection | semmle.label | ++ ... indirection |
-| clearning.cpp:111:4:111:4 | s indirection [post update] [val indirection] | semmle.label | s indirection [post update] [val indirection] |
-| clearning.cpp:111:4:111:4 | s indirection [val indirection] | semmle.label | s indirection [val indirection] |
-| clearning.cpp:111:6:111:8 | val indirection | semmle.label | val indirection |
+| clearning.cpp:111:2:111:8 | *++ ... | semmle.label | *++ ... |
+| clearning.cpp:111:2:111:8 | *++ ... | semmle.label | *++ ... |
+| clearning.cpp:111:4:111:4 | *s [*val] | semmle.label | *s [*val] |
+| clearning.cpp:111:4:111:4 | *s [post update] [*val] | semmle.label | *s [post update] [*val] |
+| clearning.cpp:111:6:111:8 | *val | semmle.label | *val |
 | clearning.cpp:112:7:112:12 | * ... | semmle.label | * ... |
-| clearning.cpp:112:8:112:8 | s indirection [val indirection] | semmle.label | s indirection [val indirection] |
-| clearning.cpp:117:18:117:18 | s indirection [post update] [val indirection] | semmle.label | s indirection [post update] [val indirection] |
+| clearning.cpp:112:8:112:8 | *s [*val] | semmle.label | *s [*val] |
+| clearning.cpp:117:18:117:18 | *s [post update] [*val] | semmle.label | *s [post update] [*val] |
 | clearning.cpp:117:20:117:22 | argument_source output argument | semmle.label | argument_source output argument |
-| clearning.cpp:118:2:118:2 | s indirection [post update] [val indirection] | semmle.label | s indirection [post update] [val indirection] |
-| clearning.cpp:118:2:118:2 | s indirection [val indirection] | semmle.label | s indirection [val indirection] |
-| clearning.cpp:118:2:118:11 | ... += ... indirection | semmle.label | ... += ... indirection |
-| clearning.cpp:118:2:118:11 | ... += ... indirection | semmle.label | ... += ... indirection |
-| clearning.cpp:118:4:118:6 | val indirection | semmle.label | val indirection |
+| clearning.cpp:118:2:118:2 | *s [*val] | semmle.label | *s [*val] |
+| clearning.cpp:118:2:118:2 | *s [post update] [*val] | semmle.label | *s [post update] [*val] |
+| clearning.cpp:118:2:118:11 | *... += ... | semmle.label | *... += ... |
+| clearning.cpp:118:2:118:11 | *... += ... | semmle.label | *... += ... |
+| clearning.cpp:118:4:118:6 | *val | semmle.label | *val |
 | clearning.cpp:119:7:119:12 | * ... | semmle.label | * ... |
-| clearning.cpp:119:8:119:8 | s indirection [val indirection] | semmle.label | s indirection [val indirection] |
-| clearning.cpp:151:3:151:3 | s indirection [post update] [val] | semmle.label | s indirection [post update] [val] |
+| clearning.cpp:119:8:119:8 | *s [*val] | semmle.label | *s [*val] |
+| clearning.cpp:151:3:151:3 | *s [post update] [val] | semmle.label | *s [post update] [val] |
 | clearning.cpp:151:3:151:22 | ... = ... | semmle.label | ... = ... |
 | clearning.cpp:151:11:151:20 | call to user_input | semmle.label | call to user_input |
-| clearning.cpp:152:8:152:8 | s indirection [val] | semmle.label | s indirection [val] |
+| clearning.cpp:152:8:152:8 | *s [val] | semmle.label | *s [val] |
 | clearning.cpp:152:10:152:12 | val | semmle.label | val |
-| complex.cpp:9:7:9:7 | a indirection | semmle.label | a indirection |
-| complex.cpp:9:7:9:7 | this indirection [a_] | semmle.label | this indirection [a_] |
+| complex.cpp:9:7:9:7 | *a | semmle.label | *a |
+| complex.cpp:9:7:9:7 | *this [a_] | semmle.label | *this [a_] |
+| complex.cpp:9:20:9:21 | *this [a_] | semmle.label | *this [a_] |
 | complex.cpp:9:20:9:21 | a_ | semmle.label | a_ |
-| complex.cpp:9:20:9:21 | this indirection [a_] | semmle.label | this indirection [a_] |
-| complex.cpp:10:7:10:7 | b indirection | semmle.label | b indirection |
-| complex.cpp:10:7:10:7 | this indirection [b_] | semmle.label | this indirection [b_] |
+| complex.cpp:10:7:10:7 | *b | semmle.label | *b |
+| complex.cpp:10:7:10:7 | *this [b_] | semmle.label | *this [b_] |
+| complex.cpp:10:20:10:21 | *this [b_] | semmle.label | *this [b_] |
 | complex.cpp:10:20:10:21 | b_ | semmle.label | b_ |
-| complex.cpp:10:20:10:21 | this indirection [b_] | semmle.label | this indirection [b_] |
 | complex.cpp:11:17:11:17 | a | semmle.label | a |
-| complex.cpp:11:22:11:23 | this indirection [post update] [a_] | semmle.label | this indirection [post update] [a_] |
+| complex.cpp:11:22:11:23 | *this [post update] [a_] | semmle.label | *this [post update] [a_] |
 | complex.cpp:11:22:11:27 | ... = ... | semmle.label | ... = ... |
 | complex.cpp:12:17:12:17 | b | semmle.label | b |
-| complex.cpp:12:22:12:23 | this indirection [post update] [b_] | semmle.label | this indirection [post update] [b_] |
+| complex.cpp:12:22:12:23 | *this [post update] [b_] | semmle.label | *this [post update] [b_] |
 | complex.cpp:12:22:12:27 | ... = ... | semmle.label | ... = ... |
-| complex.cpp:40:17:40:17 | b indirection [inner, f, a_] | semmle.label | b indirection [inner, f, a_] |
-| complex.cpp:40:17:40:17 | b indirection [inner, f, b_] | semmle.label | b indirection [inner, f, b_] |
-| complex.cpp:42:8:42:8 | b indirection [inner, f, a_] | semmle.label | b indirection [inner, f, a_] |
-| complex.cpp:42:10:42:14 | inner indirection [f, a_] | semmle.label | inner indirection [f, a_] |
-| complex.cpp:42:16:42:16 | f indirection [a_] | semmle.label | f indirection [a_] |
+| complex.cpp:40:17:40:17 | *b [inner, f, a_] | semmle.label | *b [inner, f, a_] |
+| complex.cpp:40:17:40:17 | *b [inner, f, b_] | semmle.label | *b [inner, f, b_] |
+| complex.cpp:42:8:42:8 | *b [inner, f, a_] | semmle.label | *b [inner, f, a_] |
+| complex.cpp:42:10:42:14 | *inner [f, a_] | semmle.label | *inner [f, a_] |
+| complex.cpp:42:16:42:16 | *f [a_] | semmle.label | *f [a_] |
 | complex.cpp:42:18:42:18 | call to a | semmle.label | call to a |
-| complex.cpp:43:8:43:8 | b indirection [inner, f, b_] | semmle.label | b indirection [inner, f, b_] |
-| complex.cpp:43:10:43:14 | inner indirection [f, b_] | semmle.label | inner indirection [f, b_] |
-| complex.cpp:43:16:43:16 | f indirection [b_] | semmle.label | f indirection [b_] |
+| complex.cpp:43:8:43:8 | *b [inner, f, b_] | semmle.label | *b [inner, f, b_] |
+| complex.cpp:43:10:43:14 | *inner [f, b_] | semmle.label | *inner [f, b_] |
+| complex.cpp:43:16:43:16 | *f [b_] | semmle.label | *f [b_] |
 | complex.cpp:43:18:43:18 | call to b | semmle.label | call to b |
-| complex.cpp:53:3:53:4 | b1 indirection [post update] [inner, f, a_] | semmle.label | b1 indirection [post update] [inner, f, a_] |
-| complex.cpp:53:6:53:10 | inner indirection [post update] [f, a_] | semmle.label | inner indirection [post update] [f, a_] |
+| complex.cpp:53:3:53:4 | *b1 [post update] [inner, f, a_] | semmle.label | *b1 [post update] [inner, f, a_] |
+| complex.cpp:53:6:53:10 | *inner [post update] [f, a_] | semmle.label | *inner [post update] [f, a_] |
 | complex.cpp:53:12:53:12 | setA output argument [a_] | semmle.label | setA output argument [a_] |
 | complex.cpp:53:19:53:28 | call to user_input | semmle.label | call to user_input |
-| complex.cpp:54:3:54:4 | b2 indirection [post update] [inner, f, b_] | semmle.label | b2 indirection [post update] [inner, f, b_] |
-| complex.cpp:54:6:54:10 | inner indirection [post update] [f, b_] | semmle.label | inner indirection [post update] [f, b_] |
+| complex.cpp:54:3:54:4 | *b2 [post update] [inner, f, b_] | semmle.label | *b2 [post update] [inner, f, b_] |
+| complex.cpp:54:6:54:10 | *inner [post update] [f, b_] | semmle.label | *inner [post update] [f, b_] |
 | complex.cpp:54:12:54:12 | setB output argument [b_] | semmle.label | setB output argument [b_] |
 | complex.cpp:54:19:54:28 | call to user_input | semmle.label | call to user_input |
-| complex.cpp:55:3:55:4 | b3 indirection [post update] [inner, f, a_] | semmle.label | b3 indirection [post update] [inner, f, a_] |
-| complex.cpp:55:6:55:10 | inner indirection [post update] [f, a_] | semmle.label | inner indirection [post update] [f, a_] |
+| complex.cpp:55:3:55:4 | *b3 [post update] [inner, f, a_] | semmle.label | *b3 [post update] [inner, f, a_] |
+| complex.cpp:55:6:55:10 | *inner [post update] [f, a_] | semmle.label | *inner [post update] [f, a_] |
 | complex.cpp:55:12:55:12 | setA output argument [a_] | semmle.label | setA output argument [a_] |
 | complex.cpp:55:19:55:28 | call to user_input | semmle.label | call to user_input |
-| complex.cpp:56:3:56:4 | b3 indirection [post update] [inner, f, b_] | semmle.label | b3 indirection [post update] [inner, f, b_] |
-| complex.cpp:56:6:56:10 | inner indirection [post update] [f, b_] | semmle.label | inner indirection [post update] [f, b_] |
+| complex.cpp:56:3:56:4 | *b3 [post update] [inner, f, b_] | semmle.label | *b3 [post update] [inner, f, b_] |
+| complex.cpp:56:6:56:10 | *inner [post update] [f, b_] | semmle.label | *inner [post update] [f, b_] |
 | complex.cpp:56:12:56:12 | setB output argument [b_] | semmle.label | setB output argument [b_] |
 | complex.cpp:56:19:56:28 | call to user_input | semmle.label | call to user_input |
-| complex.cpp:59:7:59:8 | b1 indirection [inner, f, a_] | semmle.label | b1 indirection [inner, f, a_] |
-| complex.cpp:62:7:62:8 | b2 indirection [inner, f, b_] | semmle.label | b2 indirection [inner, f, b_] |
-| complex.cpp:65:7:65:8 | b3 indirection [inner, f, a_] | semmle.label | b3 indirection [inner, f, a_] |
-| complex.cpp:65:7:65:8 | b3 indirection [inner, f, b_] | semmle.label | b3 indirection [inner, f, b_] |
+| complex.cpp:59:7:59:8 | *b1 [inner, f, a_] | semmle.label | *b1 [inner, f, a_] |
+| complex.cpp:62:7:62:8 | *b2 [inner, f, b_] | semmle.label | *b2 [inner, f, b_] |
+| complex.cpp:65:7:65:8 | *b3 [inner, f, a_] | semmle.label | *b3 [inner, f, a_] |
+| complex.cpp:65:7:65:8 | *b3 [inner, f, b_] | semmle.label | *b3 [inner, f, b_] |
 | conflated.cpp:10:3:10:22 | ... = ... | semmle.label | ... = ... |
-| conflated.cpp:10:4:10:5 | ra indirection [post update] [p indirection] | semmle.label | ra indirection [post update] [p indirection] |
+| conflated.cpp:10:4:10:5 | *ra [post update] [*p] | semmle.label | *ra [post update] [*p] |
 | conflated.cpp:10:11:10:20 | call to user_input | semmle.label | call to user_input |
 | conflated.cpp:11:8:11:12 | * ... | semmle.label | * ... |
-| conflated.cpp:11:9:11:10 | ra indirection [p indirection] | semmle.label | ra indirection [p indirection] |
+| conflated.cpp:11:9:11:10 | *ra [*p] | semmle.label | *ra [*p] |
 | conflated.cpp:19:19:19:21 | argument_source output argument | semmle.label | argument_source output argument |
-| conflated.cpp:20:8:20:10 | raw indirection | semmle.label | raw indirection |
-| conflated.cpp:29:3:29:4 | pa indirection [post update] [x] | semmle.label | pa indirection [post update] [x] |
+| conflated.cpp:20:8:20:10 | *raw | semmle.label | *raw |
+| conflated.cpp:29:3:29:4 | *pa [post update] [x] | semmle.label | *pa [post update] [x] |
 | conflated.cpp:29:3:29:22 | ... = ... | semmle.label | ... = ... |
 | conflated.cpp:29:11:29:20 | call to user_input | semmle.label | call to user_input |
-| conflated.cpp:30:8:30:9 | pa indirection [x] | semmle.label | pa indirection [x] |
+| conflated.cpp:30:8:30:9 | *pa [x] | semmle.label | *pa [x] |
 | conflated.cpp:30:12:30:12 | x | semmle.label | x |
-| conflated.cpp:36:3:36:4 | pa indirection [post update] [x] | semmle.label | pa indirection [post update] [x] |
+| conflated.cpp:36:3:36:4 | *pa [post update] [x] | semmle.label | *pa [post update] [x] |
 | conflated.cpp:36:3:36:22 | ... = ... | semmle.label | ... = ... |
 | conflated.cpp:36:11:36:20 | call to user_input | semmle.label | call to user_input |
-| conflated.cpp:37:8:37:9 | pa indirection [x] | semmle.label | pa indirection [x] |
+| conflated.cpp:37:8:37:9 | *pa [x] | semmle.label | *pa [x] |
 | conflated.cpp:37:12:37:12 | x | semmle.label | x |
-| conflated.cpp:54:3:54:4 | ll indirection [post update] [next indirection, y] | semmle.label | ll indirection [post update] [next indirection, y] |
+| conflated.cpp:54:3:54:4 | *ll [post update] [*next, y] | semmle.label | *ll [post update] [*next, y] |
 | conflated.cpp:54:3:54:28 | ... = ... | semmle.label | ... = ... |
-| conflated.cpp:54:7:54:10 | next indirection [post update] [y] | semmle.label | next indirection [post update] [y] |
+| conflated.cpp:54:7:54:10 | *next [post update] [y] | semmle.label | *next [post update] [y] |
 | conflated.cpp:54:17:54:26 | call to user_input | semmle.label | call to user_input |
-| conflated.cpp:55:8:55:9 | ll indirection [next indirection, y] | semmle.label | ll indirection [next indirection, y] |
-| conflated.cpp:55:12:55:15 | next indirection [y] | semmle.label | next indirection [y] |
+| conflated.cpp:55:8:55:9 | *ll [*next, y] | semmle.label | *ll [*next, y] |
+| conflated.cpp:55:12:55:15 | *next [y] | semmle.label | *next [y] |
 | conflated.cpp:55:18:55:18 | y | semmle.label | y |
-| conflated.cpp:60:3:60:4 | ll indirection [post update] [next indirection, y] | semmle.label | ll indirection [post update] [next indirection, y] |
+| conflated.cpp:60:3:60:4 | *ll [post update] [*next, y] | semmle.label | *ll [post update] [*next, y] |
 | conflated.cpp:60:3:60:28 | ... = ... | semmle.label | ... = ... |
-| conflated.cpp:60:7:60:10 | next indirection [post update] [y] | semmle.label | next indirection [post update] [y] |
+| conflated.cpp:60:7:60:10 | *next [post update] [y] | semmle.label | *next [post update] [y] |
 | conflated.cpp:60:17:60:26 | call to user_input | semmle.label | call to user_input |
-| conflated.cpp:61:8:61:9 | ll indirection [next indirection, y] | semmle.label | ll indirection [next indirection, y] |
-| conflated.cpp:61:12:61:15 | next indirection [y] | semmle.label | next indirection [y] |
+| conflated.cpp:61:8:61:9 | *ll [*next, y] | semmle.label | *ll [*next, y] |
+| conflated.cpp:61:12:61:15 | *next [y] | semmle.label | *next [y] |
 | conflated.cpp:61:18:61:18 | y | semmle.label | y |
-| constructors.cpp:18:9:18:9 | a indirection | semmle.label | a indirection |
-| constructors.cpp:18:9:18:9 | this indirection [a_] | semmle.label | this indirection [a_] |
+| constructors.cpp:18:9:18:9 | *a | semmle.label | *a |
+| constructors.cpp:18:9:18:9 | *this [a_] | semmle.label | *this [a_] |
+| constructors.cpp:18:22:18:23 | *this [a_] | semmle.label | *this [a_] |
 | constructors.cpp:18:22:18:23 | a_ | semmle.label | a_ |
-| constructors.cpp:18:22:18:23 | this indirection [a_] | semmle.label | this indirection [a_] |
-| constructors.cpp:19:9:19:9 | b indirection | semmle.label | b indirection |
-| constructors.cpp:19:9:19:9 | this indirection [b_] | semmle.label | this indirection [b_] |
+| constructors.cpp:19:9:19:9 | *b | semmle.label | *b |
+| constructors.cpp:19:9:19:9 | *this [b_] | semmle.label | *this [b_] |
+| constructors.cpp:19:22:19:23 | *this [b_] | semmle.label | *this [b_] |
 | constructors.cpp:19:22:19:23 | b_ | semmle.label | b_ |
-| constructors.cpp:19:22:19:23 | this indirection [b_] | semmle.label | this indirection [b_] |
-| constructors.cpp:23:5:23:7 | this indirection [post update] [a_] | semmle.label | this indirection [post update] [a_] |
-| constructors.cpp:23:5:23:7 | this indirection [post update] [b_] | semmle.label | this indirection [post update] [b_] |
+| constructors.cpp:23:5:23:7 | *this [post update] [a_] | semmle.label | *this [post update] [a_] |
+| constructors.cpp:23:5:23:7 | *this [post update] [b_] | semmle.label | *this [post update] [b_] |
 | constructors.cpp:23:13:23:13 | a | semmle.label | a |
 | constructors.cpp:23:20:23:20 | b | semmle.label | b |
 | constructors.cpp:23:28:23:28 | a | semmle.label | a |
 | constructors.cpp:23:35:23:35 | b | semmle.label | b |
-| constructors.cpp:26:15:26:15 | f indirection [a_] | semmle.label | f indirection [a_] |
-| constructors.cpp:26:15:26:15 | f indirection [b_] | semmle.label | f indirection [b_] |
-| constructors.cpp:28:10:28:10 | f indirection [a_] | semmle.label | f indirection [a_] |
+| constructors.cpp:26:15:26:15 | *f [a_] | semmle.label | *f [a_] |
+| constructors.cpp:26:15:26:15 | *f [b_] | semmle.label | *f [b_] |
+| constructors.cpp:28:10:28:10 | *f [a_] | semmle.label | *f [a_] |
 | constructors.cpp:28:12:28:12 | call to a | semmle.label | call to a |
-| constructors.cpp:29:10:29:10 | f indirection [b_] | semmle.label | f indirection [b_] |
+| constructors.cpp:29:10:29:10 | *f [b_] | semmle.label | *f [b_] |
 | constructors.cpp:29:12:29:12 | call to b | semmle.label | call to b |
 | constructors.cpp:34:9:34:9 | call to Foo [a_] | semmle.label | call to Foo [a_] |
 | constructors.cpp:34:11:34:20 | call to user_input | semmle.label | call to user_input |
@@ -1395,88 +1395,88 @@ nodes
 | constructors.cpp:36:9:36:9 | call to Foo [b_] | semmle.label | call to Foo [b_] |
 | constructors.cpp:36:11:36:20 | call to user_input | semmle.label | call to user_input |
 | constructors.cpp:36:25:36:34 | call to user_input | semmle.label | call to user_input |
-| constructors.cpp:40:9:40:9 | f indirection [a_] | semmle.label | f indirection [a_] |
-| constructors.cpp:43:9:43:9 | g indirection [b_] | semmle.label | g indirection [b_] |
-| constructors.cpp:46:9:46:9 | h indirection [a_] | semmle.label | h indirection [a_] |
-| constructors.cpp:46:9:46:9 | h indirection [b_] | semmle.label | h indirection [b_] |
+| constructors.cpp:40:9:40:9 | *f [a_] | semmle.label | *f [a_] |
+| constructors.cpp:43:9:43:9 | *g [b_] | semmle.label | *g [b_] |
+| constructors.cpp:46:9:46:9 | *h [a_] | semmle.label | *h [a_] |
+| constructors.cpp:46:9:46:9 | *h [b_] | semmle.label | *h [b_] |
 | qualifiers.cpp:9:21:9:25 | value | semmle.label | value |
-| qualifiers.cpp:9:30:9:33 | this indirection [post update] [a] | semmle.label | this indirection [post update] [a] |
+| qualifiers.cpp:9:30:9:33 | *this [post update] [a] | semmle.label | *this [post update] [a] |
 | qualifiers.cpp:9:30:9:44 | ... = ... | semmle.label | ... = ... |
 | qualifiers.cpp:12:40:12:44 | value | semmle.label | value |
-| qualifiers.cpp:12:49:12:53 | inner indirection [post update] [a] | semmle.label | inner indirection [post update] [a] |
+| qualifiers.cpp:12:49:12:53 | *inner [post update] [a] | semmle.label | *inner [post update] [a] |
 | qualifiers.cpp:12:49:12:64 | ... = ... | semmle.label | ... = ... |
 | qualifiers.cpp:13:42:13:46 | value | semmle.label | value |
-| qualifiers.cpp:13:51:13:55 | inner indirection [post update] [a] | semmle.label | inner indirection [post update] [a] |
+| qualifiers.cpp:13:51:13:55 | *inner [post update] [a] | semmle.label | *inner [post update] [a] |
 | qualifiers.cpp:13:51:13:65 | ... = ... | semmle.label | ... = ... |
-| qualifiers.cpp:22:5:22:9 | getInner output argument [inner indirection, a] | semmle.label | getInner output argument [inner indirection, a] |
+| qualifiers.cpp:22:5:22:9 | getInner output argument [*inner, a] | semmle.label | getInner output argument [*inner, a] |
 | qualifiers.cpp:22:5:22:38 | ... = ... | semmle.label | ... = ... |
-| qualifiers.cpp:22:11:22:18 | call to getInner indirection [post update] [a] | semmle.label | call to getInner indirection [post update] [a] |
+| qualifiers.cpp:22:11:22:18 | *call to getInner [post update] [a] | semmle.label | *call to getInner [post update] [a] |
 | qualifiers.cpp:22:27:22:36 | call to user_input | semmle.label | call to user_input |
-| qualifiers.cpp:23:10:23:14 | outer indirection [inner indirection, a] | semmle.label | outer indirection [inner indirection, a] |
-| qualifiers.cpp:23:16:23:20 | inner indirection [a] | semmle.label | inner indirection [a] |
+| qualifiers.cpp:23:10:23:14 | *outer [*inner, a] | semmle.label | *outer [*inner, a] |
+| qualifiers.cpp:23:16:23:20 | *inner [a] | semmle.label | *inner [a] |
 | qualifiers.cpp:23:23:23:23 | a | semmle.label | a |
-| qualifiers.cpp:27:5:27:9 | getInner output argument [inner indirection, a] | semmle.label | getInner output argument [inner indirection, a] |
+| qualifiers.cpp:27:5:27:9 | getInner output argument [*inner, a] | semmle.label | getInner output argument [*inner, a] |
 | qualifiers.cpp:27:11:27:18 | setA output argument [a] | semmle.label | setA output argument [a] |
 | qualifiers.cpp:27:28:27:37 | call to user_input | semmle.label | call to user_input |
-| qualifiers.cpp:28:10:28:14 | outer indirection [inner indirection, a] | semmle.label | outer indirection [inner indirection, a] |
-| qualifiers.cpp:28:16:28:20 | inner indirection [a] | semmle.label | inner indirection [a] |
+| qualifiers.cpp:28:10:28:14 | *outer [*inner, a] | semmle.label | *outer [*inner, a] |
+| qualifiers.cpp:28:16:28:20 | *inner [a] | semmle.label | *inner [a] |
 | qualifiers.cpp:28:23:28:23 | a | semmle.label | a |
-| qualifiers.cpp:32:17:32:21 | getInner output argument [inner indirection, a] | semmle.label | getInner output argument [inner indirection, a] |
+| qualifiers.cpp:32:17:32:21 | getInner output argument [*inner, a] | semmle.label | getInner output argument [*inner, a] |
 | qualifiers.cpp:32:23:32:30 | pointerSetA output argument [a] | semmle.label | pointerSetA output argument [a] |
 | qualifiers.cpp:32:35:32:44 | call to user_input | semmle.label | call to user_input |
-| qualifiers.cpp:33:10:33:14 | outer indirection [inner indirection, a] | semmle.label | outer indirection [inner indirection, a] |
-| qualifiers.cpp:33:16:33:20 | inner indirection [a] | semmle.label | inner indirection [a] |
+| qualifiers.cpp:33:10:33:14 | *outer [*inner, a] | semmle.label | *outer [*inner, a] |
+| qualifiers.cpp:33:16:33:20 | *inner [a] | semmle.label | *inner [a] |
 | qualifiers.cpp:33:23:33:23 | a | semmle.label | a |
 | qualifiers.cpp:37:19:37:35 | referenceSetA output argument [a] | semmle.label | referenceSetA output argument [a] |
-| qualifiers.cpp:37:20:37:24 | getInner output argument [inner indirection, a] | semmle.label | getInner output argument [inner indirection, a] |
+| qualifiers.cpp:37:20:37:24 | getInner output argument [*inner, a] | semmle.label | getInner output argument [*inner, a] |
 | qualifiers.cpp:37:38:37:47 | call to user_input | semmle.label | call to user_input |
-| qualifiers.cpp:38:10:38:14 | outer indirection [inner indirection, a] | semmle.label | outer indirection [inner indirection, a] |
-| qualifiers.cpp:38:16:38:20 | inner indirection [a] | semmle.label | inner indirection [a] |
+| qualifiers.cpp:38:10:38:14 | *outer [*inner, a] | semmle.label | *outer [*inner, a] |
+| qualifiers.cpp:38:16:38:20 | *inner [a] | semmle.label | *inner [a] |
 | qualifiers.cpp:38:23:38:23 | a | semmle.label | a |
 | qualifiers.cpp:42:5:42:40 | ... = ... | semmle.label | ... = ... |
-| qualifiers.cpp:42:6:42:22 | * ... indirection [post update] [a] | semmle.label | * ... indirection [post update] [a] |
-| qualifiers.cpp:42:7:42:11 | getInner output argument [inner indirection, a] | semmle.label | getInner output argument [inner indirection, a] |
+| qualifiers.cpp:42:6:42:22 | ** ... [post update] [a] | semmle.label | ** ... [post update] [a] |
+| qualifiers.cpp:42:7:42:11 | getInner output argument [*inner, a] | semmle.label | getInner output argument [*inner, a] |
 | qualifiers.cpp:42:29:42:38 | call to user_input | semmle.label | call to user_input |
-| qualifiers.cpp:43:10:43:14 | outer indirection [inner indirection, a] | semmle.label | outer indirection [inner indirection, a] |
-| qualifiers.cpp:43:16:43:20 | inner indirection [a] | semmle.label | inner indirection [a] |
+| qualifiers.cpp:43:10:43:14 | *outer [*inner, a] | semmle.label | *outer [*inner, a] |
+| qualifiers.cpp:43:16:43:20 | *inner [a] | semmle.label | *inner [a] |
 | qualifiers.cpp:43:23:43:23 | a | semmle.label | a |
 | qualifiers.cpp:47:5:47:42 | ... = ... | semmle.label | ... = ... |
-| qualifiers.cpp:47:6:47:11 | getInner output argument [inner indirection, a] | semmle.label | getInner output argument [inner indirection, a] |
-| qualifiers.cpp:47:15:47:22 | call to getInner indirection [post update] [a] | semmle.label | call to getInner indirection [post update] [a] |
+| qualifiers.cpp:47:6:47:11 | getInner output argument [*inner, a] | semmle.label | getInner output argument [*inner, a] |
+| qualifiers.cpp:47:15:47:22 | *call to getInner [post update] [a] | semmle.label | *call to getInner [post update] [a] |
 | qualifiers.cpp:47:31:47:40 | call to user_input | semmle.label | call to user_input |
-| qualifiers.cpp:48:10:48:14 | outer indirection [inner indirection, a] | semmle.label | outer indirection [inner indirection, a] |
-| qualifiers.cpp:48:16:48:20 | inner indirection [a] | semmle.label | inner indirection [a] |
+| qualifiers.cpp:48:10:48:14 | *outer [*inner, a] | semmle.label | *outer [*inner, a] |
+| qualifiers.cpp:48:16:48:20 | *inner [a] | semmle.label | *inner [a] |
 | qualifiers.cpp:48:23:48:23 | a | semmle.label | a |
-| realistic.cpp:53:9:53:11 | foo indirection [post update] [bar, baz indirection, userInput, bufferLen] | semmle.label | foo indirection [post update] [bar, baz indirection, userInput, bufferLen] |
-| realistic.cpp:53:9:53:18 | access to array indirection [post update] [baz indirection, userInput, bufferLen] | semmle.label | access to array indirection [post update] [baz indirection, userInput, bufferLen] |
+| realistic.cpp:53:9:53:11 | *foo [post update] [bar, *baz, userInput, bufferLen] | semmle.label | *foo [post update] [bar, *baz, userInput, bufferLen] |
+| realistic.cpp:53:9:53:18 | *access to array [post update] [*baz, userInput, bufferLen] | semmle.label | *access to array [post update] [*baz, userInput, bufferLen] |
 | realistic.cpp:53:9:53:66 | ... = ... | semmle.label | ... = ... |
-| realistic.cpp:53:20:53:22 | baz indirection [post update] [userInput, bufferLen] | semmle.label | baz indirection [post update] [userInput, bufferLen] |
-| realistic.cpp:53:25:53:33 | userInput indirection [post update] [bufferLen] | semmle.label | userInput indirection [post update] [bufferLen] |
+| realistic.cpp:53:20:53:22 | *baz [post update] [userInput, bufferLen] | semmle.label | *baz [post update] [userInput, bufferLen] |
+| realistic.cpp:53:25:53:33 | *userInput [post update] [bufferLen] | semmle.label | *userInput [post update] [bufferLen] |
 | realistic.cpp:53:47:53:66 | call to user_input | semmle.label | call to user_input |
 | realistic.cpp:61:14:61:55 | bufferLen | semmle.label | bufferLen |
-| realistic.cpp:61:21:61:23 | foo indirection [bar, baz indirection, userInput, bufferLen] | semmle.label | foo indirection [bar, baz indirection, userInput, bufferLen] |
-| realistic.cpp:61:21:61:30 | access to array indirection [baz indirection, userInput, bufferLen] | semmle.label | access to array indirection [baz indirection, userInput, bufferLen] |
-| realistic.cpp:61:32:61:34 | baz indirection [userInput, bufferLen] | semmle.label | baz indirection [userInput, bufferLen] |
-| realistic.cpp:61:37:61:45 | userInput indirection [bufferLen] | semmle.label | userInput indirection [bufferLen] |
-| simple.cpp:18:9:18:9 | a indirection | semmle.label | a indirection |
-| simple.cpp:18:9:18:9 | this indirection [a_] | semmle.label | this indirection [a_] |
+| realistic.cpp:61:21:61:23 | *foo [bar, *baz, userInput, bufferLen] | semmle.label | *foo [bar, *baz, userInput, bufferLen] |
+| realistic.cpp:61:21:61:30 | *access to array [*baz, userInput, bufferLen] | semmle.label | *access to array [*baz, userInput, bufferLen] |
+| realistic.cpp:61:32:61:34 | *baz [userInput, bufferLen] | semmle.label | *baz [userInput, bufferLen] |
+| realistic.cpp:61:37:61:45 | *userInput [bufferLen] | semmle.label | *userInput [bufferLen] |
+| simple.cpp:18:9:18:9 | *a | semmle.label | *a |
+| simple.cpp:18:9:18:9 | *this [a_] | semmle.label | *this [a_] |
+| simple.cpp:18:22:18:23 | *this [a_] | semmle.label | *this [a_] |
 | simple.cpp:18:22:18:23 | a_ | semmle.label | a_ |
-| simple.cpp:18:22:18:23 | this indirection [a_] | semmle.label | this indirection [a_] |
-| simple.cpp:19:9:19:9 | b indirection | semmle.label | b indirection |
-| simple.cpp:19:9:19:9 | this indirection [b_] | semmle.label | this indirection [b_] |
+| simple.cpp:19:9:19:9 | *b | semmle.label | *b |
+| simple.cpp:19:9:19:9 | *this [b_] | semmle.label | *this [b_] |
+| simple.cpp:19:22:19:23 | *this [b_] | semmle.label | *this [b_] |
 | simple.cpp:19:22:19:23 | b_ | semmle.label | b_ |
-| simple.cpp:19:22:19:23 | this indirection [b_] | semmle.label | this indirection [b_] |
 | simple.cpp:20:19:20:19 | a | semmle.label | a |
-| simple.cpp:20:24:20:25 | this indirection [post update] [a_] | semmle.label | this indirection [post update] [a_] |
+| simple.cpp:20:24:20:25 | *this [post update] [a_] | semmle.label | *this [post update] [a_] |
 | simple.cpp:20:24:20:29 | ... = ... | semmle.label | ... = ... |
 | simple.cpp:21:19:21:19 | b | semmle.label | b |
-| simple.cpp:21:24:21:25 | this indirection [post update] [b_] | semmle.label | this indirection [post update] [b_] |
+| simple.cpp:21:24:21:25 | *this [post update] [b_] | semmle.label | *this [post update] [b_] |
 | simple.cpp:21:24:21:29 | ... = ... | semmle.label | ... = ... |
-| simple.cpp:26:15:26:15 | f indirection [a_] | semmle.label | f indirection [a_] |
-| simple.cpp:26:15:26:15 | f indirection [b_] | semmle.label | f indirection [b_] |
-| simple.cpp:28:10:28:10 | f indirection [a_] | semmle.label | f indirection [a_] |
+| simple.cpp:26:15:26:15 | *f [a_] | semmle.label | *f [a_] |
+| simple.cpp:26:15:26:15 | *f [b_] | semmle.label | *f [b_] |
+| simple.cpp:28:10:28:10 | *f [a_] | semmle.label | *f [a_] |
 | simple.cpp:28:12:28:12 | call to a | semmle.label | call to a |
-| simple.cpp:29:10:29:10 | f indirection [b_] | semmle.label | f indirection [b_] |
+| simple.cpp:29:10:29:10 | *f [b_] | semmle.label | *f [b_] |
 | simple.cpp:29:12:29:12 | call to b | semmle.label | call to b |
 | simple.cpp:39:5:39:5 | setA output argument [a_] | semmle.label | setA output argument [a_] |
 | simple.cpp:39:12:39:21 | call to user_input | semmle.label | call to user_input |
@@ -1486,129 +1486,129 @@ nodes
 | simple.cpp:41:12:41:21 | call to user_input | semmle.label | call to user_input |
 | simple.cpp:42:5:42:5 | setB output argument [b_] | semmle.label | setB output argument [b_] |
 | simple.cpp:42:12:42:21 | call to user_input | semmle.label | call to user_input |
-| simple.cpp:45:9:45:9 | f indirection [a_] | semmle.label | f indirection [a_] |
-| simple.cpp:48:9:48:9 | g indirection [b_] | semmle.label | g indirection [b_] |
-| simple.cpp:51:9:51:9 | h indirection [a_] | semmle.label | h indirection [a_] |
-| simple.cpp:51:9:51:9 | h indirection [b_] | semmle.label | h indirection [b_] |
-| simple.cpp:65:5:65:5 | a indirection [post update] [i] | semmle.label | a indirection [post update] [i] |
+| simple.cpp:45:9:45:9 | *f [a_] | semmle.label | *f [a_] |
+| simple.cpp:48:9:48:9 | *g [b_] | semmle.label | *g [b_] |
+| simple.cpp:51:9:51:9 | *h [a_] | semmle.label | *h [a_] |
+| simple.cpp:51:9:51:9 | *h [b_] | semmle.label | *h [b_] |
+| simple.cpp:65:5:65:5 | *a [post update] [i] | semmle.label | *a [post update] [i] |
 | simple.cpp:65:5:65:22 | ... = ... | semmle.label | ... = ... |
 | simple.cpp:65:11:65:20 | call to user_input | semmle.label | call to user_input |
-| simple.cpp:67:10:67:11 | a2 indirection [i] | semmle.label | a2 indirection [i] |
+| simple.cpp:67:10:67:11 | *a2 [i] | semmle.label | *a2 [i] |
 | simple.cpp:67:13:67:13 | i | semmle.label | i |
-| simple.cpp:78:9:78:15 | getf2f1 indirection | semmle.label | getf2f1 indirection |
-| simple.cpp:78:9:78:15 | this indirection [f2, f1] | semmle.label | this indirection [f2, f1] |
-| simple.cpp:79:16:79:17 | f2 indirection [f1] | semmle.label | f2 indirection [f1] |
-| simple.cpp:79:16:79:17 | this indirection [f2, f1] | semmle.label | this indirection [f2, f1] |
+| simple.cpp:78:9:78:15 | *getf2f1 | semmle.label | *getf2f1 |
+| simple.cpp:78:9:78:15 | *this [f2, f1] | semmle.label | *this [f2, f1] |
+| simple.cpp:79:16:79:17 | *f2 [f1] | semmle.label | *f2 [f1] |
+| simple.cpp:79:16:79:17 | *this [f2, f1] | semmle.label | *this [f2, f1] |
 | simple.cpp:79:19:79:20 | f1 | semmle.label | f1 |
-| simple.cpp:83:9:83:10 | f2 indirection [post update] [f1] | semmle.label | f2 indirection [post update] [f1] |
-| simple.cpp:83:9:83:10 | this indirection [post update] [f2, f1] | semmle.label | this indirection [post update] [f2, f1] |
+| simple.cpp:83:9:83:10 | *f2 [post update] [f1] | semmle.label | *f2 [post update] [f1] |
+| simple.cpp:83:9:83:10 | *this [post update] [f2, f1] | semmle.label | *this [post update] [f2, f1] |
 | simple.cpp:83:9:83:28 | ... = ... | semmle.label | ... = ... |
 | simple.cpp:83:17:83:26 | call to user_input | semmle.label | call to user_input |
+| simple.cpp:84:14:84:20 | *this [f2, f1] | semmle.label | *this [f2, f1] |
 | simple.cpp:84:14:84:20 | call to getf2f1 | semmle.label | call to getf2f1 |
-| simple.cpp:84:14:84:20 | this indirection [f2, f1] | semmle.label | this indirection [f2, f1] |
-| simple.cpp:92:5:92:5 | a indirection [post update] [i] | semmle.label | a indirection [post update] [i] |
+| simple.cpp:92:5:92:5 | *a [post update] [i] | semmle.label | *a [post update] [i] |
 | simple.cpp:92:5:92:22 | ... = ... | semmle.label | ... = ... |
 | simple.cpp:92:11:92:20 | call to user_input | semmle.label | call to user_input |
-| simple.cpp:94:10:94:11 | a2 indirection [i] | semmle.label | a2 indirection [i] |
+| simple.cpp:94:10:94:11 | *a2 [i] | semmle.label | *a2 [i] |
 | simple.cpp:94:13:94:13 | i | semmle.label | i |
 | simple.cpp:103:24:103:24 | x | semmle.label | x |
 | simple.cpp:104:14:104:14 | x | semmle.label | x |
 | simple.cpp:108:17:108:26 | call to user_input | semmle.label | call to user_input |
 | simple.cpp:109:43:109:43 | x | semmle.label | x |
-| struct_init.c:14:24:14:25 | ab indirection [a] | semmle.label | ab indirection [a] |
-| struct_init.c:15:8:15:9 | ab indirection [a] | semmle.label | ab indirection [a] |
+| struct_init.c:14:24:14:25 | *ab [a] | semmle.label | *ab [a] |
+| struct_init.c:15:8:15:9 | *ab [a] | semmle.label | *ab [a] |
 | struct_init.c:15:12:15:12 | a | semmle.label | a |
-| struct_init.c:20:13:20:14 | definition of ab indirection [a] | semmle.label | definition of ab indirection [a] |
-| struct_init.c:20:13:20:14 | definition of ab indirection [post update] [a] | semmle.label | definition of ab indirection [post update] [a] |
+| struct_init.c:20:13:20:14 | *definition of ab [a] | semmle.label | *definition of ab [a] |
+| struct_init.c:20:13:20:14 | *definition of ab [post update] [a] | semmle.label | *definition of ab [post update] [a] |
 | struct_init.c:20:20:20:29 | call to user_input | semmle.label | call to user_input |
 | struct_init.c:20:20:20:29 | call to user_input | semmle.label | call to user_input |
-| struct_init.c:22:8:22:9 | ab indirection [a] | semmle.label | ab indirection [a] |
+| struct_init.c:22:8:22:9 | *ab [a] | semmle.label | *ab [a] |
 | struct_init.c:22:11:22:11 | a | semmle.label | a |
-| struct_init.c:24:10:24:12 | & ... indirection [a] | semmle.label | & ... indirection [a] |
-| struct_init.c:26:16:26:20 | definition of outer indirection [nestedAB, a] | semmle.label | definition of outer indirection [nestedAB, a] |
-| struct_init.c:26:16:26:20 | definition of outer indirection [post update] [nestedAB, a] | semmle.label | definition of outer indirection [post update] [nestedAB, a] |
-| struct_init.c:26:16:26:20 | definition of outer indirection [post update] [pointerAB indirection, a] | semmle.label | definition of outer indirection [post update] [pointerAB indirection, a] |
-| struct_init.c:26:23:29:3 | {...} indirection [post update] [a] | semmle.label | {...} indirection [post update] [a] |
+| struct_init.c:24:10:24:12 | *& ... [a] | semmle.label | *& ... [a] |
+| struct_init.c:26:16:26:20 | *definition of outer [nestedAB, a] | semmle.label | *definition of outer [nestedAB, a] |
+| struct_init.c:26:16:26:20 | *definition of outer [post update] [*pointerAB, a] | semmle.label | *definition of outer [post update] [*pointerAB, a] |
+| struct_init.c:26:16:26:20 | *definition of outer [post update] [nestedAB, a] | semmle.label | *definition of outer [post update] [nestedAB, a] |
+| struct_init.c:26:23:29:3 | *{...} [post update] [a] | semmle.label | *{...} [post update] [a] |
 | struct_init.c:27:7:27:16 | call to user_input | semmle.label | call to user_input |
 | struct_init.c:27:7:27:16 | call to user_input | semmle.label | call to user_input |
-| struct_init.c:28:5:28:7 | & ... indirection [a] | semmle.label | & ... indirection [a] |
-| struct_init.c:31:8:31:12 | outer indirection [nestedAB, a] | semmle.label | outer indirection [nestedAB, a] |
-| struct_init.c:31:14:31:21 | nestedAB indirection [a] | semmle.label | nestedAB indirection [a] |
+| struct_init.c:28:5:28:7 | *& ... [a] | semmle.label | *& ... [a] |
+| struct_init.c:31:8:31:12 | *outer [nestedAB, a] | semmle.label | *outer [nestedAB, a] |
+| struct_init.c:31:14:31:21 | *nestedAB [a] | semmle.label | *nestedAB [a] |
 | struct_init.c:31:23:31:23 | a | semmle.label | a |
-| struct_init.c:33:8:33:12 | outer indirection [pointerAB indirection, a] | semmle.label | outer indirection [pointerAB indirection, a] |
-| struct_init.c:33:14:33:22 | pointerAB indirection [a] | semmle.label | pointerAB indirection [a] |
+| struct_init.c:33:8:33:12 | *outer [*pointerAB, a] | semmle.label | *outer [*pointerAB, a] |
+| struct_init.c:33:14:33:22 | *pointerAB [a] | semmle.label | *pointerAB [a] |
 | struct_init.c:33:25:33:25 | a | semmle.label | a |
-| struct_init.c:36:10:36:24 | & ... indirection [a] | semmle.label | & ... indirection [a] |
-| struct_init.c:36:11:36:15 | outer indirection [nestedAB, a] | semmle.label | outer indirection [nestedAB, a] |
-| struct_init.c:40:13:40:14 | definition of ab indirection [a] | semmle.label | definition of ab indirection [a] |
-| struct_init.c:40:13:40:14 | definition of ab indirection [post update] [a] | semmle.label | definition of ab indirection [post update] [a] |
+| struct_init.c:36:10:36:24 | *& ... [a] | semmle.label | *& ... [a] |
+| struct_init.c:36:11:36:15 | *outer [nestedAB, a] | semmle.label | *outer [nestedAB, a] |
+| struct_init.c:40:13:40:14 | *definition of ab [a] | semmle.label | *definition of ab [a] |
+| struct_init.c:40:13:40:14 | *definition of ab [post update] [a] | semmle.label | *definition of ab [post update] [a] |
 | struct_init.c:40:20:40:29 | call to user_input | semmle.label | call to user_input |
 | struct_init.c:40:20:40:29 | call to user_input | semmle.label | call to user_input |
-| struct_init.c:41:16:41:20 | definition of outer indirection [post update] [pointerAB indirection, a] | semmle.label | definition of outer indirection [post update] [pointerAB indirection, a] |
-| struct_init.c:43:5:43:7 | & ... indirection [a] | semmle.label | & ... indirection [a] |
-| struct_init.c:46:10:46:14 | outer indirection [pointerAB indirection, a] | semmle.label | outer indirection [pointerAB indirection, a] |
-| struct_init.c:46:16:46:24 | pointerAB indirection [a] | semmle.label | pointerAB indirection [a] |
+| struct_init.c:41:16:41:20 | *definition of outer [post update] [*pointerAB, a] | semmle.label | *definition of outer [post update] [*pointerAB, a] |
+| struct_init.c:43:5:43:7 | *& ... [a] | semmle.label | *& ... [a] |
+| struct_init.c:46:10:46:14 | *outer [*pointerAB, a] | semmle.label | *outer [*pointerAB, a] |
+| struct_init.c:46:16:46:24 | *pointerAB [a] | semmle.label | *pointerAB [a] |
 subpaths
-| A.cpp:31:20:31:20 | c | A.cpp:23:10:23:10 | c | A.cpp:25:7:25:10 | this indirection [post update] [c] | A.cpp:31:14:31:21 | call to B [c] |
-| A.cpp:48:20:48:20 | c | A.cpp:29:23:29:23 | c | A.cpp:29:15:29:18 | make indirection [c] | A.cpp:48:12:48:18 | call to make indirection [c] |
-| A.cpp:55:12:55:19 | new | A.cpp:27:17:27:17 | c | A.cpp:27:22:27:25 | this indirection [post update] [c] | A.cpp:55:5:55:5 | set output argument [c] |
-| A.cpp:56:10:56:10 | b indirection [c] | A.cpp:28:8:28:10 | this indirection [c] | A.cpp:28:8:28:10 | get indirection | A.cpp:56:10:56:17 | call to get |
-| A.cpp:57:11:57:24 | new indirection [c] | A.cpp:28:8:28:10 | this indirection [c] | A.cpp:28:8:28:10 | get indirection | A.cpp:57:10:57:32 | call to get |
-| A.cpp:57:17:57:23 | new | A.cpp:23:10:23:10 | c | A.cpp:25:7:25:10 | this indirection [post update] [c] | A.cpp:57:11:57:24 | call to B [c] |
-| A.cpp:64:21:64:28 | new | A.cpp:85:26:85:26 | c | A.cpp:85:9:85:14 | setOnB indirection [c] | A.cpp:64:10:64:15 | call to setOnB indirection [c] |
-| A.cpp:73:25:73:32 | new | A.cpp:78:27:78:27 | c | A.cpp:78:6:78:15 | setOnBWrap indirection [c] | A.cpp:73:10:73:19 | call to setOnBWrap indirection [c] |
-| A.cpp:81:21:81:21 | c | A.cpp:85:26:85:26 | c | A.cpp:85:9:85:14 | setOnB indirection [c] | A.cpp:81:10:81:15 | call to setOnB indirection [c] |
-| A.cpp:90:15:90:15 | c | A.cpp:27:17:27:17 | c | A.cpp:27:22:27:25 | this indirection [post update] [c] | A.cpp:90:7:90:8 | set output argument [c] |
-| A.cpp:126:12:126:18 | new | A.cpp:27:17:27:17 | c | A.cpp:27:22:27:25 | this indirection [post update] [c] | A.cpp:126:5:126:5 | set output argument [c] |
-| A.cpp:151:18:151:18 | b | A.cpp:140:13:140:13 | b | A.cpp:143:7:143:10 | this indirection [post update] [b] | A.cpp:151:12:151:24 | call to D [b] |
-| A.cpp:160:29:160:29 | b | A.cpp:181:15:181:21 | newHead | A.cpp:183:7:183:10 | this indirection [post update] [head] | A.cpp:160:18:160:60 | call to MyList [head] |
-| A.cpp:161:38:161:39 | l1 indirection [head] | A.cpp:181:32:181:35 | next indirection [head] | A.cpp:184:7:184:10 | this indirection [post update] [next indirection, head] | A.cpp:161:18:161:40 | call to MyList [next indirection, head] |
-| A.cpp:162:38:162:39 | l2 indirection [next indirection, head] | A.cpp:181:32:181:35 | next indirection [next indirection, head] | A.cpp:184:7:184:10 | this indirection [post update] [next indirection, next indirection, head] | A.cpp:162:18:162:40 | call to MyList [next indirection, next indirection, head] |
-| B.cpp:7:25:7:25 | e | B.cpp:33:16:33:17 | e1 | B.cpp:35:7:35:10 | this indirection [post update] [elem1] | B.cpp:7:16:7:35 | call to Box1 [elem1] |
-| B.cpp:8:25:8:26 | b1 indirection [elem1] | B.cpp:44:16:44:17 | b1 indirection [elem1] | B.cpp:46:7:46:10 | this indirection [post update] [box1 indirection, elem1] | B.cpp:8:16:8:27 | call to Box2 [box1 indirection, elem1] |
-| B.cpp:16:37:16:37 | e | B.cpp:33:26:33:27 | e2 | B.cpp:36:7:36:10 | this indirection [post update] [elem2] | B.cpp:16:16:16:38 | call to Box1 [elem2] |
-| B.cpp:17:25:17:26 | b1 indirection [elem2] | B.cpp:44:16:44:17 | b1 indirection [elem2] | B.cpp:46:7:46:10 | this indirection [post update] [box1 indirection, elem2] | B.cpp:17:16:17:27 | call to Box2 [box1 indirection, elem2] |
-| D.cpp:22:10:22:11 | b2 indirection [box indirection, elem] | D.cpp:17:11:17:17 | this indirection [box indirection, elem] | D.cpp:17:11:17:17 | getBox1 indirection [elem] | D.cpp:22:14:22:20 | call to getBox1 indirection [elem] |
-| D.cpp:22:14:22:20 | call to getBox1 indirection [elem] | D.cpp:10:11:10:17 | this indirection [elem] | D.cpp:10:11:10:17 | getElem indirection | D.cpp:22:10:22:33 | call to getElem |
-| D.cpp:37:21:37:21 | e | D.cpp:11:24:11:24 | e | D.cpp:11:29:11:32 | this indirection [post update] [elem] | D.cpp:37:8:37:10 | setElem output argument [elem] |
-| D.cpp:51:27:51:27 | e | D.cpp:11:24:11:24 | e | D.cpp:11:29:11:32 | this indirection [post update] [elem] | D.cpp:51:8:51:14 | setElem output argument [elem] |
-| by_reference.cpp:20:23:20:27 | value | by_reference.cpp:15:26:15:30 | value | by_reference.cpp:16:5:16:8 | this indirection [post update] [a] | by_reference.cpp:20:5:20:8 | setDirectly output argument [a] |
-| by_reference.cpp:24:25:24:29 | value | by_reference.cpp:11:48:11:52 | value | by_reference.cpp:12:5:12:5 | s indirection [post update] [a] | by_reference.cpp:24:19:24:22 | nonMemberSetA output argument [a] |
-| by_reference.cpp:40:12:40:15 | this indirection [a] | by_reference.cpp:35:9:35:19 | this indirection [a] | by_reference.cpp:35:9:35:19 | getDirectly indirection | by_reference.cpp:40:18:40:28 | call to getDirectly |
-| by_reference.cpp:44:26:44:29 | this indirection [a] | by_reference.cpp:31:46:31:46 | s indirection [a] | by_reference.cpp:31:16:31:28 | nonMemberGetA indirection | by_reference.cpp:44:12:44:24 | call to nonMemberGetA |
-| by_reference.cpp:50:17:50:26 | call to user_input | by_reference.cpp:15:26:15:30 | value | by_reference.cpp:16:5:16:8 | this indirection [post update] [a] | by_reference.cpp:50:3:50:3 | setDirectly output argument [a] |
-| by_reference.cpp:51:8:51:8 | s indirection [a] | by_reference.cpp:35:9:35:19 | this indirection [a] | by_reference.cpp:35:9:35:19 | getDirectly indirection | by_reference.cpp:51:10:51:20 | call to getDirectly |
+| A.cpp:31:20:31:20 | c | A.cpp:23:10:23:10 | c | A.cpp:25:7:25:10 | *this [post update] [c] | A.cpp:31:14:31:21 | call to B [c] |
+| A.cpp:48:20:48:20 | c | A.cpp:29:23:29:23 | c | A.cpp:29:15:29:18 | **make [c] | A.cpp:48:12:48:18 | *call to make [c] |
+| A.cpp:55:12:55:19 | new | A.cpp:27:17:27:17 | c | A.cpp:27:22:27:25 | *this [post update] [c] | A.cpp:55:5:55:5 | set output argument [c] |
+| A.cpp:56:10:56:10 | *b [c] | A.cpp:28:8:28:10 | *this [c] | A.cpp:28:8:28:10 | *get | A.cpp:56:10:56:17 | call to get |
+| A.cpp:57:11:57:24 | *new [c] | A.cpp:28:8:28:10 | *this [c] | A.cpp:28:8:28:10 | *get | A.cpp:57:10:57:32 | call to get |
+| A.cpp:57:17:57:23 | new | A.cpp:23:10:23:10 | c | A.cpp:25:7:25:10 | *this [post update] [c] | A.cpp:57:11:57:24 | call to B [c] |
+| A.cpp:64:21:64:28 | new | A.cpp:85:26:85:26 | c | A.cpp:85:9:85:14 | **setOnB [c] | A.cpp:64:10:64:15 | *call to setOnB [c] |
+| A.cpp:73:25:73:32 | new | A.cpp:78:27:78:27 | c | A.cpp:78:6:78:15 | **setOnBWrap [c] | A.cpp:73:10:73:19 | *call to setOnBWrap [c] |
+| A.cpp:81:21:81:21 | c | A.cpp:85:26:85:26 | c | A.cpp:85:9:85:14 | **setOnB [c] | A.cpp:81:10:81:15 | *call to setOnB [c] |
+| A.cpp:90:15:90:15 | c | A.cpp:27:17:27:17 | c | A.cpp:27:22:27:25 | *this [post update] [c] | A.cpp:90:7:90:8 | set output argument [c] |
+| A.cpp:126:12:126:18 | new | A.cpp:27:17:27:17 | c | A.cpp:27:22:27:25 | *this [post update] [c] | A.cpp:126:5:126:5 | set output argument [c] |
+| A.cpp:151:18:151:18 | b | A.cpp:140:13:140:13 | b | A.cpp:143:7:143:10 | *this [post update] [b] | A.cpp:151:12:151:24 | call to D [b] |
+| A.cpp:160:29:160:29 | b | A.cpp:181:15:181:21 | newHead | A.cpp:183:7:183:10 | *this [post update] [head] | A.cpp:160:18:160:60 | call to MyList [head] |
+| A.cpp:161:38:161:39 | *l1 [head] | A.cpp:181:32:181:35 | *next [head] | A.cpp:184:7:184:10 | *this [post update] [*next, head] | A.cpp:161:18:161:40 | call to MyList [*next, head] |
+| A.cpp:162:38:162:39 | *l2 [*next, head] | A.cpp:181:32:181:35 | *next [*next, head] | A.cpp:184:7:184:10 | *this [post update] [*next, *next, head] | A.cpp:162:18:162:40 | call to MyList [*next, *next, head] |
+| B.cpp:7:25:7:25 | e | B.cpp:33:16:33:17 | e1 | B.cpp:35:7:35:10 | *this [post update] [elem1] | B.cpp:7:16:7:35 | call to Box1 [elem1] |
+| B.cpp:8:25:8:26 | *b1 [elem1] | B.cpp:44:16:44:17 | *b1 [elem1] | B.cpp:46:7:46:10 | *this [post update] [*box1, elem1] | B.cpp:8:16:8:27 | call to Box2 [*box1, elem1] |
+| B.cpp:16:37:16:37 | e | B.cpp:33:26:33:27 | e2 | B.cpp:36:7:36:10 | *this [post update] [elem2] | B.cpp:16:16:16:38 | call to Box1 [elem2] |
+| B.cpp:17:25:17:26 | *b1 [elem2] | B.cpp:44:16:44:17 | *b1 [elem2] | B.cpp:46:7:46:10 | *this [post update] [*box1, elem2] | B.cpp:17:16:17:27 | call to Box2 [*box1, elem2] |
+| D.cpp:22:10:22:11 | *b2 [*box, elem] | D.cpp:17:11:17:17 | *this [*box, elem] | D.cpp:17:11:17:17 | **getBox1 [elem] | D.cpp:22:14:22:20 | *call to getBox1 [elem] |
+| D.cpp:22:14:22:20 | *call to getBox1 [elem] | D.cpp:10:11:10:17 | *this [elem] | D.cpp:10:11:10:17 | *getElem | D.cpp:22:10:22:33 | call to getElem |
+| D.cpp:37:21:37:21 | e | D.cpp:11:24:11:24 | e | D.cpp:11:29:11:32 | *this [post update] [elem] | D.cpp:37:8:37:10 | setElem output argument [elem] |
+| D.cpp:51:27:51:27 | e | D.cpp:11:24:11:24 | e | D.cpp:11:29:11:32 | *this [post update] [elem] | D.cpp:51:8:51:14 | setElem output argument [elem] |
+| by_reference.cpp:20:23:20:27 | value | by_reference.cpp:15:26:15:30 | value | by_reference.cpp:16:5:16:8 | *this [post update] [a] | by_reference.cpp:20:5:20:8 | setDirectly output argument [a] |
+| by_reference.cpp:24:25:24:29 | value | by_reference.cpp:11:48:11:52 | value | by_reference.cpp:12:5:12:5 | *s [post update] [a] | by_reference.cpp:24:19:24:22 | nonMemberSetA output argument [a] |
+| by_reference.cpp:40:12:40:15 | *this [a] | by_reference.cpp:35:9:35:19 | *this [a] | by_reference.cpp:35:9:35:19 | *getDirectly | by_reference.cpp:40:18:40:28 | call to getDirectly |
+| by_reference.cpp:44:26:44:29 | *this [a] | by_reference.cpp:31:46:31:46 | *s [a] | by_reference.cpp:31:16:31:28 | *nonMemberGetA | by_reference.cpp:44:12:44:24 | call to nonMemberGetA |
+| by_reference.cpp:50:17:50:26 | call to user_input | by_reference.cpp:15:26:15:30 | value | by_reference.cpp:16:5:16:8 | *this [post update] [a] | by_reference.cpp:50:3:50:3 | setDirectly output argument [a] |
+| by_reference.cpp:51:8:51:8 | *s [a] | by_reference.cpp:35:9:35:19 | *this [a] | by_reference.cpp:35:9:35:19 | *getDirectly | by_reference.cpp:51:10:51:20 | call to getDirectly |
 | by_reference.cpp:56:19:56:28 | call to user_input | by_reference.cpp:19:28:19:32 | value | by_reference.cpp:20:5:20:8 | setDirectly output argument [a] | by_reference.cpp:56:3:56:3 | setIndirectly output argument [a] |
-| by_reference.cpp:57:8:57:8 | s indirection [a] | by_reference.cpp:39:9:39:21 | this indirection [a] | by_reference.cpp:39:9:39:21 | getIndirectly indirection | by_reference.cpp:57:10:57:22 | call to getIndirectly |
+| by_reference.cpp:57:8:57:8 | *s [a] | by_reference.cpp:39:9:39:21 | *this [a] | by_reference.cpp:39:9:39:21 | *getIndirectly | by_reference.cpp:57:10:57:22 | call to getIndirectly |
 | by_reference.cpp:62:25:62:34 | call to user_input | by_reference.cpp:23:34:23:38 | value | by_reference.cpp:24:19:24:22 | nonMemberSetA output argument [a] | by_reference.cpp:62:3:62:3 | setThroughNonMember output argument [a] |
-| by_reference.cpp:63:8:63:8 | s indirection [a] | by_reference.cpp:43:9:43:27 | this indirection [a] | by_reference.cpp:43:9:43:27 | getThroughNonMember indirection | by_reference.cpp:63:10:63:28 | call to getThroughNonMember |
-| by_reference.cpp:68:21:68:30 | call to user_input | by_reference.cpp:11:48:11:52 | value | by_reference.cpp:12:5:12:5 | s indirection [post update] [a] | by_reference.cpp:68:17:68:18 | nonMemberSetA output argument [a] |
-| by_reference.cpp:69:22:69:23 | & ... indirection [a] | by_reference.cpp:31:46:31:46 | s indirection [a] | by_reference.cpp:31:16:31:28 | nonMemberGetA indirection | by_reference.cpp:69:8:69:20 | call to nonMemberGetA |
-| complex.cpp:42:16:42:16 | f indirection [a_] | complex.cpp:9:7:9:7 | this indirection [a_] | complex.cpp:9:7:9:7 | a indirection | complex.cpp:42:18:42:18 | call to a |
-| complex.cpp:43:16:43:16 | f indirection [b_] | complex.cpp:10:7:10:7 | this indirection [b_] | complex.cpp:10:7:10:7 | b indirection | complex.cpp:43:18:43:18 | call to b |
-| complex.cpp:53:19:53:28 | call to user_input | complex.cpp:11:17:11:17 | a | complex.cpp:11:22:11:23 | this indirection [post update] [a_] | complex.cpp:53:12:53:12 | setA output argument [a_] |
-| complex.cpp:54:19:54:28 | call to user_input | complex.cpp:12:17:12:17 | b | complex.cpp:12:22:12:23 | this indirection [post update] [b_] | complex.cpp:54:12:54:12 | setB output argument [b_] |
-| complex.cpp:55:19:55:28 | call to user_input | complex.cpp:11:17:11:17 | a | complex.cpp:11:22:11:23 | this indirection [post update] [a_] | complex.cpp:55:12:55:12 | setA output argument [a_] |
-| complex.cpp:56:19:56:28 | call to user_input | complex.cpp:12:17:12:17 | b | complex.cpp:12:22:12:23 | this indirection [post update] [b_] | complex.cpp:56:12:56:12 | setB output argument [b_] |
-| constructors.cpp:28:10:28:10 | f indirection [a_] | constructors.cpp:18:9:18:9 | this indirection [a_] | constructors.cpp:18:9:18:9 | a indirection | constructors.cpp:28:12:28:12 | call to a |
-| constructors.cpp:29:10:29:10 | f indirection [b_] | constructors.cpp:19:9:19:9 | this indirection [b_] | constructors.cpp:19:9:19:9 | b indirection | constructors.cpp:29:12:29:12 | call to b |
-| constructors.cpp:34:11:34:20 | call to user_input | constructors.cpp:23:13:23:13 | a | constructors.cpp:23:5:23:7 | this indirection [post update] [a_] | constructors.cpp:34:9:34:9 | call to Foo [a_] |
-| constructors.cpp:35:14:35:23 | call to user_input | constructors.cpp:23:20:23:20 | b | constructors.cpp:23:5:23:7 | this indirection [post update] [b_] | constructors.cpp:35:9:35:9 | call to Foo [b_] |
-| constructors.cpp:36:11:36:20 | call to user_input | constructors.cpp:23:13:23:13 | a | constructors.cpp:23:5:23:7 | this indirection [post update] [a_] | constructors.cpp:36:9:36:9 | call to Foo [a_] |
-| constructors.cpp:36:25:36:34 | call to user_input | constructors.cpp:23:20:23:20 | b | constructors.cpp:23:5:23:7 | this indirection [post update] [b_] | constructors.cpp:36:9:36:9 | call to Foo [b_] |
-| qualifiers.cpp:27:28:27:37 | call to user_input | qualifiers.cpp:9:21:9:25 | value | qualifiers.cpp:9:30:9:33 | this indirection [post update] [a] | qualifiers.cpp:27:11:27:18 | setA output argument [a] |
-| qualifiers.cpp:32:35:32:44 | call to user_input | qualifiers.cpp:12:40:12:44 | value | qualifiers.cpp:12:49:12:53 | inner indirection [post update] [a] | qualifiers.cpp:32:23:32:30 | pointerSetA output argument [a] |
-| qualifiers.cpp:37:38:37:47 | call to user_input | qualifiers.cpp:13:42:13:46 | value | qualifiers.cpp:13:51:13:55 | inner indirection [post update] [a] | qualifiers.cpp:37:19:37:35 | referenceSetA output argument [a] |
-| simple.cpp:28:10:28:10 | f indirection [a_] | simple.cpp:18:9:18:9 | this indirection [a_] | simple.cpp:18:9:18:9 | a indirection | simple.cpp:28:12:28:12 | call to a |
-| simple.cpp:29:10:29:10 | f indirection [b_] | simple.cpp:19:9:19:9 | this indirection [b_] | simple.cpp:19:9:19:9 | b indirection | simple.cpp:29:12:29:12 | call to b |
-| simple.cpp:39:12:39:21 | call to user_input | simple.cpp:20:19:20:19 | a | simple.cpp:20:24:20:25 | this indirection [post update] [a_] | simple.cpp:39:5:39:5 | setA output argument [a_] |
-| simple.cpp:40:12:40:21 | call to user_input | simple.cpp:21:19:21:19 | b | simple.cpp:21:24:21:25 | this indirection [post update] [b_] | simple.cpp:40:5:40:5 | setB output argument [b_] |
-| simple.cpp:41:12:41:21 | call to user_input | simple.cpp:20:19:20:19 | a | simple.cpp:20:24:20:25 | this indirection [post update] [a_] | simple.cpp:41:5:41:5 | setA output argument [a_] |
-| simple.cpp:42:12:42:21 | call to user_input | simple.cpp:21:19:21:19 | b | simple.cpp:21:24:21:25 | this indirection [post update] [b_] | simple.cpp:42:5:42:5 | setB output argument [b_] |
-| simple.cpp:84:14:84:20 | this indirection [f2, f1] | simple.cpp:78:9:78:15 | this indirection [f2, f1] | simple.cpp:78:9:78:15 | getf2f1 indirection | simple.cpp:84:14:84:20 | call to getf2f1 |
+| by_reference.cpp:63:8:63:8 | *s [a] | by_reference.cpp:43:9:43:27 | *this [a] | by_reference.cpp:43:9:43:27 | *getThroughNonMember | by_reference.cpp:63:10:63:28 | call to getThroughNonMember |
+| by_reference.cpp:68:21:68:30 | call to user_input | by_reference.cpp:11:48:11:52 | value | by_reference.cpp:12:5:12:5 | *s [post update] [a] | by_reference.cpp:68:17:68:18 | nonMemberSetA output argument [a] |
+| by_reference.cpp:69:22:69:23 | *& ... [a] | by_reference.cpp:31:46:31:46 | *s [a] | by_reference.cpp:31:16:31:28 | *nonMemberGetA | by_reference.cpp:69:8:69:20 | call to nonMemberGetA |
+| complex.cpp:42:16:42:16 | *f [a_] | complex.cpp:9:7:9:7 | *this [a_] | complex.cpp:9:7:9:7 | *a | complex.cpp:42:18:42:18 | call to a |
+| complex.cpp:43:16:43:16 | *f [b_] | complex.cpp:10:7:10:7 | *this [b_] | complex.cpp:10:7:10:7 | *b | complex.cpp:43:18:43:18 | call to b |
+| complex.cpp:53:19:53:28 | call to user_input | complex.cpp:11:17:11:17 | a | complex.cpp:11:22:11:23 | *this [post update] [a_] | complex.cpp:53:12:53:12 | setA output argument [a_] |
+| complex.cpp:54:19:54:28 | call to user_input | complex.cpp:12:17:12:17 | b | complex.cpp:12:22:12:23 | *this [post update] [b_] | complex.cpp:54:12:54:12 | setB output argument [b_] |
+| complex.cpp:55:19:55:28 | call to user_input | complex.cpp:11:17:11:17 | a | complex.cpp:11:22:11:23 | *this [post update] [a_] | complex.cpp:55:12:55:12 | setA output argument [a_] |
+| complex.cpp:56:19:56:28 | call to user_input | complex.cpp:12:17:12:17 | b | complex.cpp:12:22:12:23 | *this [post update] [b_] | complex.cpp:56:12:56:12 | setB output argument [b_] |
+| constructors.cpp:28:10:28:10 | *f [a_] | constructors.cpp:18:9:18:9 | *this [a_] | constructors.cpp:18:9:18:9 | *a | constructors.cpp:28:12:28:12 | call to a |
+| constructors.cpp:29:10:29:10 | *f [b_] | constructors.cpp:19:9:19:9 | *this [b_] | constructors.cpp:19:9:19:9 | *b | constructors.cpp:29:12:29:12 | call to b |
+| constructors.cpp:34:11:34:20 | call to user_input | constructors.cpp:23:13:23:13 | a | constructors.cpp:23:5:23:7 | *this [post update] [a_] | constructors.cpp:34:9:34:9 | call to Foo [a_] |
+| constructors.cpp:35:14:35:23 | call to user_input | constructors.cpp:23:20:23:20 | b | constructors.cpp:23:5:23:7 | *this [post update] [b_] | constructors.cpp:35:9:35:9 | call to Foo [b_] |
+| constructors.cpp:36:11:36:20 | call to user_input | constructors.cpp:23:13:23:13 | a | constructors.cpp:23:5:23:7 | *this [post update] [a_] | constructors.cpp:36:9:36:9 | call to Foo [a_] |
+| constructors.cpp:36:25:36:34 | call to user_input | constructors.cpp:23:20:23:20 | b | constructors.cpp:23:5:23:7 | *this [post update] [b_] | constructors.cpp:36:9:36:9 | call to Foo [b_] |
+| qualifiers.cpp:27:28:27:37 | call to user_input | qualifiers.cpp:9:21:9:25 | value | qualifiers.cpp:9:30:9:33 | *this [post update] [a] | qualifiers.cpp:27:11:27:18 | setA output argument [a] |
+| qualifiers.cpp:32:35:32:44 | call to user_input | qualifiers.cpp:12:40:12:44 | value | qualifiers.cpp:12:49:12:53 | *inner [post update] [a] | qualifiers.cpp:32:23:32:30 | pointerSetA output argument [a] |
+| qualifiers.cpp:37:38:37:47 | call to user_input | qualifiers.cpp:13:42:13:46 | value | qualifiers.cpp:13:51:13:55 | *inner [post update] [a] | qualifiers.cpp:37:19:37:35 | referenceSetA output argument [a] |
+| simple.cpp:28:10:28:10 | *f [a_] | simple.cpp:18:9:18:9 | *this [a_] | simple.cpp:18:9:18:9 | *a | simple.cpp:28:12:28:12 | call to a |
+| simple.cpp:29:10:29:10 | *f [b_] | simple.cpp:19:9:19:9 | *this [b_] | simple.cpp:19:9:19:9 | *b | simple.cpp:29:12:29:12 | call to b |
+| simple.cpp:39:12:39:21 | call to user_input | simple.cpp:20:19:20:19 | a | simple.cpp:20:24:20:25 | *this [post update] [a_] | simple.cpp:39:5:39:5 | setA output argument [a_] |
+| simple.cpp:40:12:40:21 | call to user_input | simple.cpp:21:19:21:19 | b | simple.cpp:21:24:21:25 | *this [post update] [b_] | simple.cpp:40:5:40:5 | setB output argument [b_] |
+| simple.cpp:41:12:41:21 | call to user_input | simple.cpp:20:19:20:19 | a | simple.cpp:20:24:20:25 | *this [post update] [a_] | simple.cpp:41:5:41:5 | setA output argument [a_] |
+| simple.cpp:42:12:42:21 | call to user_input | simple.cpp:21:19:21:19 | b | simple.cpp:21:24:21:25 | *this [post update] [b_] | simple.cpp:42:5:42:5 | setB output argument [b_] |
+| simple.cpp:84:14:84:20 | *this [f2, f1] | simple.cpp:78:9:78:15 | *this [f2, f1] | simple.cpp:78:9:78:15 | *getf2f1 | simple.cpp:84:14:84:20 | call to getf2f1 |
 #select
-| A.cpp:43:10:43:12 | & ... indirection | A.cpp:41:15:41:21 | new | A.cpp:43:10:43:12 | & ... indirection | & ... indirection flows from $@ | A.cpp:41:15:41:21 | new | new |
-| A.cpp:43:10:43:12 | & ... indirection | A.cpp:41:15:41:21 | new | A.cpp:43:10:43:12 | & ... indirection | & ... indirection flows from $@ | A.cpp:41:15:41:21 | new | new |
+| A.cpp:43:10:43:12 | *& ... | A.cpp:41:15:41:21 | new | A.cpp:43:10:43:12 | *& ... | *& ... flows from $@ | A.cpp:41:15:41:21 | new | new |
+| A.cpp:43:10:43:12 | *& ... | A.cpp:41:15:41:21 | new | A.cpp:43:10:43:12 | *& ... | *& ... flows from $@ | A.cpp:41:15:41:21 | new | new |
 | A.cpp:49:10:49:13 | c | A.cpp:47:12:47:18 | new | A.cpp:49:10:49:13 | c | c flows from $@ | A.cpp:47:12:47:18 | new | new |
 | A.cpp:56:10:56:17 | call to get | A.cpp:55:12:55:19 | new | A.cpp:56:10:56:17 | call to get | call to get flows from $@ | A.cpp:55:12:55:19 | new | new |
 | A.cpp:56:10:56:17 | call to get | A.cpp:55:12:55:19 | new | A.cpp:56:10:56:17 | call to get | call to get flows from $@ | A.cpp:55:12:55:19 | new | new |
@@ -1635,9 +1635,9 @@ subpaths
 | D.cpp:22:10:22:33 | call to getElem | D.cpp:42:15:42:24 | new | D.cpp:22:10:22:33 | call to getElem | call to getElem flows from $@ | D.cpp:42:15:42:24 | new | new |
 | D.cpp:22:10:22:33 | call to getElem | D.cpp:49:15:49:24 | new | D.cpp:22:10:22:33 | call to getElem | call to getElem flows from $@ | D.cpp:49:15:49:24 | new | new |
 | D.cpp:64:10:64:28 | elem | D.cpp:56:15:56:24 | new | D.cpp:64:10:64:28 | elem | elem flows from $@ | D.cpp:56:15:56:24 | new | new |
-| E.cpp:21:18:21:23 | buffer indirection | E.cpp:30:21:30:33 | argument_source output argument | E.cpp:21:18:21:23 | buffer indirection | buffer indirection flows from $@ | E.cpp:30:21:30:33 | argument_source output argument | argument_source output argument |
-| E.cpp:31:10:31:12 | raw indirection | E.cpp:28:21:28:23 | argument_source output argument | E.cpp:31:10:31:12 | raw indirection | raw indirection flows from $@ | E.cpp:28:21:28:23 | argument_source output argument | argument_source output argument |
-| E.cpp:32:13:32:18 | buffer indirection | E.cpp:29:21:29:29 | argument_source output argument | E.cpp:32:13:32:18 | buffer indirection | buffer indirection flows from $@ | E.cpp:29:21:29:29 | argument_source output argument | argument_source output argument |
+| E.cpp:21:18:21:23 | *buffer | E.cpp:30:21:30:33 | argument_source output argument | E.cpp:21:18:21:23 | *buffer | *buffer flows from $@ | E.cpp:30:21:30:33 | argument_source output argument | argument_source output argument |
+| E.cpp:31:10:31:12 | *raw | E.cpp:28:21:28:23 | argument_source output argument | E.cpp:31:10:31:12 | *raw | *raw flows from $@ | E.cpp:28:21:28:23 | argument_source output argument | argument_source output argument |
+| E.cpp:32:13:32:18 | *buffer | E.cpp:29:21:29:29 | argument_source output argument | E.cpp:32:13:32:18 | *buffer | *buffer flows from $@ | E.cpp:29:21:29:29 | argument_source output argument | argument_source output argument |
 | aliasing.cpp:29:11:29:12 | m1 | aliasing.cpp:9:11:9:20 | call to user_input | aliasing.cpp:29:11:29:12 | m1 | m1 flows from $@ | aliasing.cpp:9:11:9:20 | call to user_input | call to user_input |
 | aliasing.cpp:30:11:30:12 | m1 | aliasing.cpp:13:10:13:19 | call to user_input | aliasing.cpp:30:11:30:12 | m1 | m1 flows from $@ | aliasing.cpp:13:10:13:19 | call to user_input | call to user_input |
 | aliasing.cpp:62:14:62:15 | m1 | aliasing.cpp:60:11:60:20 | call to user_input | aliasing.cpp:62:14:62:15 | m1 | m1 flows from $@ | aliasing.cpp:60:11:60:20 | call to user_input | call to user_input |
@@ -1682,8 +1682,8 @@ subpaths
 | by_reference.cpp:135:27:135:27 | a | by_reference.cpp:88:13:88:22 | call to user_input | by_reference.cpp:135:27:135:27 | a | a flows from $@ | by_reference.cpp:88:13:88:22 | call to user_input | call to user_input |
 | by_reference.cpp:136:16:136:16 | a | by_reference.cpp:96:8:96:17 | call to user_input | by_reference.cpp:136:16:136:16 | a | a flows from $@ | by_reference.cpp:96:8:96:17 | call to user_input | call to user_input |
 | clearning.cpp:34:8:34:11 | * ... | clearning.cpp:32:10:32:19 | call to user_input | clearning.cpp:34:8:34:11 | * ... | * ... flows from $@ | clearning.cpp:32:10:32:19 | call to user_input | call to user_input |
-| clearning.cpp:55:10:55:10 | x indirection | clearning.cpp:53:10:53:19 | call to user_input | clearning.cpp:55:10:55:10 | x indirection | x indirection flows from $@ | clearning.cpp:53:10:53:19 | call to user_input | call to user_input |
-| clearning.cpp:62:10:62:10 | x indirection | clearning.cpp:60:11:60:20 | call to user_input | clearning.cpp:62:10:62:10 | x indirection | x indirection flows from $@ | clearning.cpp:60:11:60:20 | call to user_input | call to user_input |
+| clearning.cpp:55:10:55:10 | *x | clearning.cpp:53:10:53:19 | call to user_input | clearning.cpp:55:10:55:10 | *x | *x flows from $@ | clearning.cpp:53:10:53:19 | call to user_input | call to user_input |
+| clearning.cpp:62:10:62:10 | **x | clearning.cpp:60:11:60:20 | call to user_input | clearning.cpp:62:10:62:10 | **x | **x flows from $@ | clearning.cpp:60:11:60:20 | call to user_input | call to user_input |
 | clearning.cpp:76:7:76:12 | * ... | clearning.cpp:74:20:74:22 | argument_source output argument | clearning.cpp:76:7:76:12 | * ... | * ... flows from $@ | clearning.cpp:74:20:74:22 | argument_source output argument | argument_source output argument |
 | clearning.cpp:84:7:84:12 | * ... | clearning.cpp:81:20:81:22 | argument_source output argument | clearning.cpp:84:7:84:12 | * ... | * ... flows from $@ | clearning.cpp:81:20:81:22 | argument_source output argument | argument_source output argument |
 | clearning.cpp:91:7:91:12 | * ... | clearning.cpp:89:20:89:22 | argument_source output argument | clearning.cpp:91:7:91:12 | * ... | * ... flows from $@ | clearning.cpp:89:20:89:22 | argument_source output argument | argument_source output argument |
@@ -1697,7 +1697,7 @@ subpaths
 | complex.cpp:43:18:43:18 | call to b | complex.cpp:54:19:54:28 | call to user_input | complex.cpp:43:18:43:18 | call to b | call to b flows from $@ | complex.cpp:54:19:54:28 | call to user_input | call to user_input |
 | complex.cpp:43:18:43:18 | call to b | complex.cpp:56:19:56:28 | call to user_input | complex.cpp:43:18:43:18 | call to b | call to b flows from $@ | complex.cpp:56:19:56:28 | call to user_input | call to user_input |
 | conflated.cpp:11:8:11:12 | * ... | conflated.cpp:10:11:10:20 | call to user_input | conflated.cpp:11:8:11:12 | * ... | * ... flows from $@ | conflated.cpp:10:11:10:20 | call to user_input | call to user_input |
-| conflated.cpp:20:8:20:10 | raw indirection | conflated.cpp:19:19:19:21 | argument_source output argument | conflated.cpp:20:8:20:10 | raw indirection | raw indirection flows from $@ | conflated.cpp:19:19:19:21 | argument_source output argument | argument_source output argument |
+| conflated.cpp:20:8:20:10 | *raw | conflated.cpp:19:19:19:21 | argument_source output argument | conflated.cpp:20:8:20:10 | *raw | *raw flows from $@ | conflated.cpp:19:19:19:21 | argument_source output argument | argument_source output argument |
 | conflated.cpp:30:12:30:12 | x | conflated.cpp:29:11:29:20 | call to user_input | conflated.cpp:30:12:30:12 | x | x flows from $@ | conflated.cpp:29:11:29:20 | call to user_input | call to user_input |
 | conflated.cpp:37:12:37:12 | x | conflated.cpp:36:11:36:20 | call to user_input | conflated.cpp:37:12:37:12 | x | x flows from $@ | conflated.cpp:36:11:36:20 | call to user_input | call to user_input |
 | conflated.cpp:55:18:55:18 | y | conflated.cpp:54:17:54:26 | call to user_input | conflated.cpp:55:18:55:18 | y | y flows from $@ | conflated.cpp:54:17:54:26 | call to user_input | call to user_input |

--- a/cpp/ql/test/library-tests/syntax-zoo/dataflow-ir-consistency.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/dataflow-ir-consistency.expected
@@ -35,8 +35,8 @@ postWithInFlow
 | try_catch.cpp:7:8:7:8 | call to exception | PostUpdateNode should not be the target of local flow. |
 viableImplInCallContextTooLarge
 uniqueParameterNodeAtPosition
-| ir.cpp:726:6:726:13 | TryCatch | 0 indirection | ir.cpp:737:22:737:22 | s indirection | Parameters with overlapping positions. |
-| ir.cpp:726:6:726:13 | TryCatch | 0 indirection | ir.cpp:740:24:740:24 | e indirection | Parameters with overlapping positions. |
+| ir.cpp:726:6:726:13 | TryCatch | 0 indirection | ir.cpp:737:22:737:22 | *s | Parameters with overlapping positions. |
+| ir.cpp:726:6:726:13 | TryCatch | 0 indirection | ir.cpp:740:24:740:24 | *e | Parameters with overlapping positions. |
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep

--- a/cpp/ql/test/query-tests/Critical/MemoryFreed/UseAfterFree.expected
+++ b/cpp/ql/test/query-tests/Critical/MemoryFreed/UseAfterFree.expected
@@ -12,16 +12,16 @@ edges
 | test_free.cpp:233:14:233:15 | pointer to free output argument | test_free.cpp:236:9:236:10 | * ... |
 | test_free.cpp:239:14:239:15 | pointer to free output argument | test_free.cpp:241:9:241:10 | * ... |
 | test_free.cpp:245:10:245:11 | pointer to free output argument | test_free.cpp:246:9:246:10 | * ... |
-| test_free.cpp:277:8:277:8 | s indirection [post update] [buf] | test_free.cpp:278:12:278:12 | s indirection [buf] |
-| test_free.cpp:277:8:277:13 | pointer to free output argument | test_free.cpp:277:8:277:8 | s indirection [post update] [buf] |
-| test_free.cpp:278:12:278:12 | s indirection [buf] | test_free.cpp:278:15:278:17 | buf |
-| test_free.cpp:282:8:282:8 | s indirection [post update] [buf] | test_free.cpp:283:12:283:12 | s indirection [buf] |
-| test_free.cpp:282:8:282:12 | pointer to free output argument | test_free.cpp:282:8:282:8 | s indirection [post update] [buf] |
-| test_free.cpp:283:12:283:12 | s indirection [buf] | test_free.cpp:283:14:283:16 | buf |
+| test_free.cpp:277:8:277:8 | *s [post update] [buf] | test_free.cpp:278:12:278:12 | *s [buf] |
+| test_free.cpp:277:8:277:13 | pointer to free output argument | test_free.cpp:277:8:277:8 | *s [post update] [buf] |
+| test_free.cpp:278:12:278:12 | *s [buf] | test_free.cpp:278:15:278:17 | buf |
+| test_free.cpp:282:8:282:8 | *s [post update] [buf] | test_free.cpp:283:12:283:12 | *s [buf] |
+| test_free.cpp:282:8:282:12 | pointer to free output argument | test_free.cpp:282:8:282:8 | *s [post update] [buf] |
+| test_free.cpp:283:12:283:12 | *s [buf] | test_free.cpp:283:14:283:16 | buf |
 | test_free.cpp:293:8:293:10 | pointer to free output argument | test_free.cpp:294:3:294:13 | ... = ... |
-| test_free.cpp:294:3:294:3 | s indirection [post update] [buf] | test_free.cpp:295:12:295:12 | s indirection [buf] |
-| test_free.cpp:294:3:294:13 | ... = ... | test_free.cpp:294:3:294:3 | s indirection [post update] [buf] |
-| test_free.cpp:295:12:295:12 | s indirection [buf] | test_free.cpp:295:14:295:16 | buf |
+| test_free.cpp:294:3:294:3 | *s [post update] [buf] | test_free.cpp:295:12:295:12 | *s [buf] |
+| test_free.cpp:294:3:294:13 | ... = ... | test_free.cpp:294:3:294:3 | *s [post update] [buf] |
+| test_free.cpp:295:12:295:12 | *s [buf] | test_free.cpp:295:14:295:16 | buf |
 nodes
 | test_free.cpp:11:10:11:10 | pointer to free output argument | semmle.label | pointer to free output argument |
 | test_free.cpp:12:5:12:5 | a | semmle.label | a |
@@ -48,18 +48,18 @@ nodes
 | test_free.cpp:241:9:241:10 | * ... | semmle.label | * ... |
 | test_free.cpp:245:10:245:11 | pointer to free output argument | semmle.label | pointer to free output argument |
 | test_free.cpp:246:9:246:10 | * ... | semmle.label | * ... |
-| test_free.cpp:277:8:277:8 | s indirection [post update] [buf] | semmle.label | s indirection [post update] [buf] |
+| test_free.cpp:277:8:277:8 | *s [post update] [buf] | semmle.label | *s [post update] [buf] |
 | test_free.cpp:277:8:277:13 | pointer to free output argument | semmle.label | pointer to free output argument |
-| test_free.cpp:278:12:278:12 | s indirection [buf] | semmle.label | s indirection [buf] |
+| test_free.cpp:278:12:278:12 | *s [buf] | semmle.label | *s [buf] |
 | test_free.cpp:278:15:278:17 | buf | semmle.label | buf |
-| test_free.cpp:282:8:282:8 | s indirection [post update] [buf] | semmle.label | s indirection [post update] [buf] |
+| test_free.cpp:282:8:282:8 | *s [post update] [buf] | semmle.label | *s [post update] [buf] |
 | test_free.cpp:282:8:282:12 | pointer to free output argument | semmle.label | pointer to free output argument |
-| test_free.cpp:283:12:283:12 | s indirection [buf] | semmle.label | s indirection [buf] |
+| test_free.cpp:283:12:283:12 | *s [buf] | semmle.label | *s [buf] |
 | test_free.cpp:283:14:283:16 | buf | semmle.label | buf |
 | test_free.cpp:293:8:293:10 | pointer to free output argument | semmle.label | pointer to free output argument |
-| test_free.cpp:294:3:294:3 | s indirection [post update] [buf] | semmle.label | s indirection [post update] [buf] |
+| test_free.cpp:294:3:294:3 | *s [post update] [buf] | semmle.label | *s [post update] [buf] |
 | test_free.cpp:294:3:294:13 | ... = ... | semmle.label | ... = ... |
-| test_free.cpp:295:12:295:12 | s indirection [buf] | semmle.label | s indirection [buf] |
+| test_free.cpp:295:12:295:12 | *s [buf] | semmle.label | *s [buf] |
 | test_free.cpp:295:14:295:16 | buf | semmle.label | buf |
 subpaths
 #select

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-022/SAMATE/TaintedPath/TaintedPath.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-022/SAMATE/TaintedPath/TaintedPath.expected
@@ -1,8 +1,8 @@
 edges
-| CWE23_Relative_Path_Traversal__char_console_fopen_11.cpp:55:27:55:38 | fgets output argument | CWE23_Relative_Path_Traversal__char_console_fopen_11.cpp:77:23:77:26 | data indirection |
+| CWE23_Relative_Path_Traversal__char_console_fopen_11.cpp:55:27:55:38 | fgets output argument | CWE23_Relative_Path_Traversal__char_console_fopen_11.cpp:77:23:77:26 | *data |
 nodes
 | CWE23_Relative_Path_Traversal__char_console_fopen_11.cpp:55:27:55:38 | fgets output argument | semmle.label | fgets output argument |
-| CWE23_Relative_Path_Traversal__char_console_fopen_11.cpp:77:23:77:26 | data indirection | semmle.label | data indirection |
+| CWE23_Relative_Path_Traversal__char_console_fopen_11.cpp:77:23:77:26 | *data | semmle.label | *data |
 subpaths
 #select
-| CWE23_Relative_Path_Traversal__char_console_fopen_11.cpp:77:23:77:26 | data | CWE23_Relative_Path_Traversal__char_console_fopen_11.cpp:55:27:55:38 | fgets output argument | CWE23_Relative_Path_Traversal__char_console_fopen_11.cpp:77:23:77:26 | data indirection | This argument to a file access function is derived from $@ and then passed to fopen(filename). | CWE23_Relative_Path_Traversal__char_console_fopen_11.cpp:55:27:55:38 | fgets output argument | user input (string read by fgets) |
+| CWE23_Relative_Path_Traversal__char_console_fopen_11.cpp:77:23:77:26 | data | CWE23_Relative_Path_Traversal__char_console_fopen_11.cpp:55:27:55:38 | fgets output argument | CWE23_Relative_Path_Traversal__char_console_fopen_11.cpp:77:23:77:26 | *data | This argument to a file access function is derived from $@ and then passed to fopen(filename). | CWE23_Relative_Path_Traversal__char_console_fopen_11.cpp:55:27:55:38 | fgets output argument | user input (string read by fgets) |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-022/semmle/tests/TaintedPath.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-022/semmle/tests/TaintedPath.expected
@@ -1,22 +1,22 @@
 edges
-| test.c:8:27:8:30 | argv indirection | test.c:17:11:17:18 | fileName indirection |
-| test.c:8:27:8:30 | argv indirection | test.c:32:11:32:18 | fileName indirection |
-| test.c:8:27:8:30 | argv indirection | test.c:57:10:57:16 | access to array indirection |
-| test.c:37:17:37:24 | scanf output argument | test.c:38:11:38:18 | fileName indirection |
-| test.c:43:17:43:24 | scanf output argument | test.c:44:11:44:18 | fileName indirection |
+| test.c:8:27:8:30 | **argv | test.c:17:11:17:18 | *fileName |
+| test.c:8:27:8:30 | **argv | test.c:32:11:32:18 | *fileName |
+| test.c:8:27:8:30 | **argv | test.c:57:10:57:16 | *access to array |
+| test.c:37:17:37:24 | scanf output argument | test.c:38:11:38:18 | *fileName |
+| test.c:43:17:43:24 | scanf output argument | test.c:44:11:44:18 | *fileName |
 nodes
-| test.c:8:27:8:30 | argv indirection | semmle.label | argv indirection |
-| test.c:17:11:17:18 | fileName indirection | semmle.label | fileName indirection |
-| test.c:32:11:32:18 | fileName indirection | semmle.label | fileName indirection |
+| test.c:8:27:8:30 | **argv | semmle.label | **argv |
+| test.c:17:11:17:18 | *fileName | semmle.label | *fileName |
+| test.c:32:11:32:18 | *fileName | semmle.label | *fileName |
 | test.c:37:17:37:24 | scanf output argument | semmle.label | scanf output argument |
-| test.c:38:11:38:18 | fileName indirection | semmle.label | fileName indirection |
+| test.c:38:11:38:18 | *fileName | semmle.label | *fileName |
 | test.c:43:17:43:24 | scanf output argument | semmle.label | scanf output argument |
-| test.c:44:11:44:18 | fileName indirection | semmle.label | fileName indirection |
-| test.c:57:10:57:16 | access to array indirection | semmle.label | access to array indirection |
+| test.c:44:11:44:18 | *fileName | semmle.label | *fileName |
+| test.c:57:10:57:16 | *access to array | semmle.label | *access to array |
 subpaths
 #select
-| test.c:17:11:17:18 | fileName | test.c:8:27:8:30 | argv indirection | test.c:17:11:17:18 | fileName indirection | This argument to a file access function is derived from $@ and then passed to fopen(filename). | test.c:8:27:8:30 | argv indirection | user input (a command-line argument) |
-| test.c:32:11:32:18 | fileName | test.c:8:27:8:30 | argv indirection | test.c:32:11:32:18 | fileName indirection | This argument to a file access function is derived from $@ and then passed to fopen(filename). | test.c:8:27:8:30 | argv indirection | user input (a command-line argument) |
-| test.c:38:11:38:18 | fileName | test.c:37:17:37:24 | scanf output argument | test.c:38:11:38:18 | fileName indirection | This argument to a file access function is derived from $@ and then passed to fopen(filename). | test.c:37:17:37:24 | scanf output argument | user input (value read by scanf) |
-| test.c:44:11:44:18 | fileName | test.c:43:17:43:24 | scanf output argument | test.c:44:11:44:18 | fileName indirection | This argument to a file access function is derived from $@ and then passed to fopen(filename). | test.c:43:17:43:24 | scanf output argument | user input (value read by scanf) |
-| test.c:57:10:57:16 | access to array | test.c:8:27:8:30 | argv indirection | test.c:57:10:57:16 | access to array indirection | This argument to a file access function is derived from $@ and then passed to read(fileName), which calls fopen(filename). | test.c:8:27:8:30 | argv indirection | user input (a command-line argument) |
+| test.c:17:11:17:18 | fileName | test.c:8:27:8:30 | **argv | test.c:17:11:17:18 | *fileName | This argument to a file access function is derived from $@ and then passed to fopen(filename). | test.c:8:27:8:30 | **argv | user input (a command-line argument) |
+| test.c:32:11:32:18 | fileName | test.c:8:27:8:30 | **argv | test.c:32:11:32:18 | *fileName | This argument to a file access function is derived from $@ and then passed to fopen(filename). | test.c:8:27:8:30 | **argv | user input (a command-line argument) |
+| test.c:38:11:38:18 | fileName | test.c:37:17:37:24 | scanf output argument | test.c:38:11:38:18 | *fileName | This argument to a file access function is derived from $@ and then passed to fopen(filename). | test.c:37:17:37:24 | scanf output argument | user input (value read by scanf) |
+| test.c:44:11:44:18 | fileName | test.c:43:17:43:24 | scanf output argument | test.c:44:11:44:18 | *fileName | This argument to a file access function is derived from $@ and then passed to fopen(filename). | test.c:43:17:43:24 | scanf output argument | user input (value read by scanf) |
+| test.c:57:10:57:16 | access to array | test.c:8:27:8:30 | **argv | test.c:57:10:57:16 | *access to array | This argument to a file access function is derived from $@ and then passed to read(fileName), which calls fopen(filename). | test.c:8:27:8:30 | **argv | user input (a command-line argument) |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-078/SAMATE/ExecTainted/ExecTainted.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-078/SAMATE/ExecTainted/ExecTainted.expected
@@ -1,16 +1,16 @@
 edges
-| tests.cpp:26:15:26:23 | badSource indirection | tests.cpp:51:12:51:20 | call to badSource indirection |
-| tests.cpp:33:34:33:39 | call to getenv indirection | tests.cpp:38:39:38:49 | environment indirection |
-| tests.cpp:38:25:38:36 | strncat output argument | tests.cpp:26:15:26:23 | badSource indirection |
-| tests.cpp:38:39:38:49 | environment indirection | tests.cpp:38:25:38:36 | strncat output argument |
-| tests.cpp:51:12:51:20 | call to badSource indirection | tests.cpp:53:16:53:19 | data indirection |
+| tests.cpp:26:15:26:23 | **badSource | tests.cpp:51:12:51:20 | *call to badSource |
+| tests.cpp:33:34:33:39 | *call to getenv | tests.cpp:38:39:38:49 | *environment |
+| tests.cpp:38:25:38:36 | strncat output argument | tests.cpp:26:15:26:23 | **badSource |
+| tests.cpp:38:39:38:49 | *environment | tests.cpp:38:25:38:36 | strncat output argument |
+| tests.cpp:51:12:51:20 | *call to badSource | tests.cpp:53:16:53:19 | *data |
 nodes
-| tests.cpp:26:15:26:23 | badSource indirection | semmle.label | badSource indirection |
-| tests.cpp:33:34:33:39 | call to getenv indirection | semmle.label | call to getenv indirection |
+| tests.cpp:26:15:26:23 | **badSource | semmle.label | **badSource |
+| tests.cpp:33:34:33:39 | *call to getenv | semmle.label | *call to getenv |
 | tests.cpp:38:25:38:36 | strncat output argument | semmle.label | strncat output argument |
-| tests.cpp:38:39:38:49 | environment indirection | semmle.label | environment indirection |
-| tests.cpp:51:12:51:20 | call to badSource indirection | semmle.label | call to badSource indirection |
-| tests.cpp:53:16:53:19 | data indirection | semmle.label | data indirection |
+| tests.cpp:38:39:38:49 | *environment | semmle.label | *environment |
+| tests.cpp:51:12:51:20 | *call to badSource | semmle.label | *call to badSource |
+| tests.cpp:53:16:53:19 | *data | semmle.label | *data |
 subpaths
 #select
-| tests.cpp:53:16:53:19 | data | tests.cpp:33:34:33:39 | call to getenv indirection | tests.cpp:53:16:53:19 | data indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | tests.cpp:33:34:33:39 | call to getenv indirection | user input (an environment variable) | tests.cpp:38:25:38:36 | strncat output argument | strncat output argument |
+| tests.cpp:53:16:53:19 | data | tests.cpp:33:34:33:39 | *call to getenv | tests.cpp:53:16:53:19 | *data | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | tests.cpp:33:34:33:39 | *call to getenv | user input (an environment variable) | tests.cpp:38:25:38:36 | strncat output argument | strncat output argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-078/semmle/ExecTainted/ExecTainted.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-078/semmle/ExecTainted/ExecTainted.expected
@@ -1,164 +1,164 @@
 edges
-| test.cpp:15:27:15:30 | argv indirection | test.cpp:22:45:22:52 | userName indirection |
-| test.cpp:22:13:22:20 | sprintf output argument | test.cpp:23:12:23:19 | command1 indirection |
-| test.cpp:22:45:22:52 | userName indirection | test.cpp:22:13:22:20 | sprintf output argument |
-| test.cpp:47:21:47:26 | call to getenv indirection | test.cpp:50:35:50:43 | envCflags indirection |
-| test.cpp:50:11:50:17 | sprintf output argument | test.cpp:51:10:51:16 | command indirection |
-| test.cpp:50:35:50:43 | envCflags indirection | test.cpp:50:11:50:17 | sprintf output argument |
-| test.cpp:62:9:62:16 | fread output argument | test.cpp:64:20:64:27 | filename indirection |
-| test.cpp:64:11:64:17 | strncat output argument | test.cpp:65:10:65:16 | command indirection |
-| test.cpp:64:20:64:27 | filename indirection | test.cpp:64:11:64:17 | strncat output argument |
-| test.cpp:82:9:82:16 | fread output argument | test.cpp:84:20:84:27 | filename indirection |
-| test.cpp:84:11:84:17 | strncat output argument | test.cpp:85:32:85:38 | command indirection |
-| test.cpp:84:20:84:27 | filename indirection | test.cpp:84:11:84:17 | strncat output argument |
-| test.cpp:91:9:91:16 | fread output argument | test.cpp:93:17:93:24 | filename indirection |
-| test.cpp:93:11:93:14 | strncat output argument | test.cpp:94:45:94:48 | path indirection |
-| test.cpp:93:17:93:24 | filename indirection | test.cpp:93:11:93:14 | strncat output argument |
-| test.cpp:106:20:106:38 | call to getenv indirection | test.cpp:107:33:107:36 | path indirection |
-| test.cpp:107:31:107:31 | call to operator+ | test.cpp:108:18:108:22 | call to c_str indirection |
-| test.cpp:107:33:107:36 | path indirection | test.cpp:107:31:107:31 | call to operator+ |
-| test.cpp:113:20:113:38 | call to getenv indirection | test.cpp:114:19:114:22 | path indirection |
-| test.cpp:114:10:114:23 | call to operator+ | test.cpp:114:25:114:29 | call to c_str indirection |
-| test.cpp:114:10:114:23 | call to operator+ | test.cpp:114:25:114:29 | call to c_str indirection |
+| test.cpp:15:27:15:30 | **argv | test.cpp:22:45:22:52 | *userName |
+| test.cpp:22:13:22:20 | sprintf output argument | test.cpp:23:12:23:19 | *command1 |
+| test.cpp:22:45:22:52 | *userName | test.cpp:22:13:22:20 | sprintf output argument |
+| test.cpp:47:21:47:26 | *call to getenv | test.cpp:50:35:50:43 | *envCflags |
+| test.cpp:50:11:50:17 | sprintf output argument | test.cpp:51:10:51:16 | *command |
+| test.cpp:50:35:50:43 | *envCflags | test.cpp:50:11:50:17 | sprintf output argument |
+| test.cpp:62:9:62:16 | fread output argument | test.cpp:64:20:64:27 | *filename |
+| test.cpp:64:11:64:17 | strncat output argument | test.cpp:65:10:65:16 | *command |
+| test.cpp:64:20:64:27 | *filename | test.cpp:64:11:64:17 | strncat output argument |
+| test.cpp:82:9:82:16 | fread output argument | test.cpp:84:20:84:27 | *filename |
+| test.cpp:84:11:84:17 | strncat output argument | test.cpp:85:32:85:38 | *command |
+| test.cpp:84:20:84:27 | *filename | test.cpp:84:11:84:17 | strncat output argument |
+| test.cpp:91:9:91:16 | fread output argument | test.cpp:93:17:93:24 | *filename |
+| test.cpp:93:11:93:14 | strncat output argument | test.cpp:94:45:94:48 | *path |
+| test.cpp:93:17:93:24 | *filename | test.cpp:93:11:93:14 | strncat output argument |
+| test.cpp:106:20:106:38 | *call to getenv | test.cpp:107:33:107:36 | *path |
+| test.cpp:107:31:107:31 | call to operator+ | test.cpp:108:18:108:22 | *call to c_str |
+| test.cpp:107:33:107:36 | *path | test.cpp:107:31:107:31 | call to operator+ |
+| test.cpp:113:20:113:38 | *call to getenv | test.cpp:114:19:114:22 | *path |
+| test.cpp:114:10:114:23 | call to operator+ | test.cpp:114:25:114:29 | *call to c_str |
+| test.cpp:114:10:114:23 | call to operator+ | test.cpp:114:25:114:29 | *call to c_str |
 | test.cpp:114:17:114:17 | call to operator+ | test.cpp:114:10:114:23 | call to operator+ |
-| test.cpp:114:19:114:22 | path indirection | test.cpp:114:10:114:23 | call to operator+ |
-| test.cpp:114:19:114:22 | path indirection | test.cpp:114:17:114:17 | call to operator+ |
-| test.cpp:119:20:119:38 | call to getenv indirection | test.cpp:120:19:120:22 | path indirection |
-| test.cpp:120:17:120:17 | call to operator+ | test.cpp:120:10:120:30 | call to data indirection |
-| test.cpp:120:19:120:22 | path indirection | test.cpp:120:17:120:17 | call to operator+ |
-| test.cpp:140:9:140:11 | fread output argument | test.cpp:142:31:142:33 | str indirection |
-| test.cpp:142:11:142:17 | sprintf output argument | test.cpp:143:10:143:16 | command indirection |
-| test.cpp:142:31:142:33 | str indirection | test.cpp:142:11:142:17 | sprintf output argument |
-| test.cpp:174:9:174:16 | fread output argument | test.cpp:177:20:177:27 | filename indirection |
-| test.cpp:174:9:174:16 | fread output argument | test.cpp:180:22:180:29 | filename indirection |
-| test.cpp:177:13:177:17 | strncat output argument | test.cpp:178:22:178:26 | flags indirection |
-| test.cpp:177:13:177:17 | strncat output argument | test.cpp:178:22:178:26 | flags indirection |
-| test.cpp:177:20:177:27 | filename indirection | test.cpp:177:13:177:17 | strncat output argument |
-| test.cpp:177:20:177:27 | filename indirection | test.cpp:177:13:177:17 | strncat output argument |
-| test.cpp:178:13:178:19 | strncat output argument | test.cpp:183:32:183:38 | command indirection |
-| test.cpp:178:13:178:19 | strncat output argument | test.cpp:183:32:183:38 | command indirection |
-| test.cpp:178:22:178:26 | flags indirection | test.cpp:178:13:178:19 | strncat output argument |
-| test.cpp:178:22:178:26 | flags indirection | test.cpp:178:13:178:19 | strncat output argument |
-| test.cpp:180:13:180:19 | strncat output argument | test.cpp:183:32:183:38 | command indirection |
-| test.cpp:180:22:180:29 | filename indirection | test.cpp:180:13:180:19 | strncat output argument |
-| test.cpp:186:47:186:54 | filename indirection | test.cpp:187:18:187:25 | filename indirection |
-| test.cpp:187:11:187:15 | strncat output argument | test.cpp:188:20:188:24 | flags indirection |
-| test.cpp:187:11:187:15 | strncat output argument | test.cpp:188:20:188:24 | flags indirection |
-| test.cpp:187:18:187:25 | filename indirection | test.cpp:187:11:187:15 | strncat output argument |
-| test.cpp:187:18:187:25 | filename indirection | test.cpp:187:11:187:15 | strncat output argument |
-| test.cpp:188:20:188:24 | flags indirection | test.cpp:188:11:188:17 | strncat output argument |
-| test.cpp:188:20:188:24 | flags indirection | test.cpp:188:11:188:17 | strncat output argument |
-| test.cpp:194:9:194:16 | fread output argument | test.cpp:196:26:196:33 | filename indirection |
-| test.cpp:196:10:196:16 | concat output argument | test.cpp:198:32:198:38 | command indirection |
-| test.cpp:196:10:196:16 | concat output argument | test.cpp:198:32:198:38 | command indirection |
-| test.cpp:196:26:196:33 | filename indirection | test.cpp:186:47:186:54 | filename indirection |
-| test.cpp:196:26:196:33 | filename indirection | test.cpp:196:10:196:16 | concat output argument |
-| test.cpp:196:26:196:33 | filename indirection | test.cpp:196:10:196:16 | concat output argument |
-| test.cpp:218:9:218:16 | fread output argument | test.cpp:220:19:220:26 | filename indirection |
+| test.cpp:114:19:114:22 | *path | test.cpp:114:10:114:23 | call to operator+ |
+| test.cpp:114:19:114:22 | *path | test.cpp:114:17:114:17 | call to operator+ |
+| test.cpp:119:20:119:38 | *call to getenv | test.cpp:120:19:120:22 | *path |
+| test.cpp:120:17:120:17 | call to operator+ | test.cpp:120:10:120:30 | *call to data |
+| test.cpp:120:19:120:22 | *path | test.cpp:120:17:120:17 | call to operator+ |
+| test.cpp:140:9:140:11 | fread output argument | test.cpp:142:31:142:33 | *str |
+| test.cpp:142:11:142:17 | sprintf output argument | test.cpp:143:10:143:16 | *command |
+| test.cpp:142:31:142:33 | *str | test.cpp:142:11:142:17 | sprintf output argument |
+| test.cpp:174:9:174:16 | fread output argument | test.cpp:177:20:177:27 | *filename |
+| test.cpp:174:9:174:16 | fread output argument | test.cpp:180:22:180:29 | *filename |
+| test.cpp:177:13:177:17 | strncat output argument | test.cpp:178:22:178:26 | *flags |
+| test.cpp:177:13:177:17 | strncat output argument | test.cpp:178:22:178:26 | *flags |
+| test.cpp:177:20:177:27 | *filename | test.cpp:177:13:177:17 | strncat output argument |
+| test.cpp:177:20:177:27 | *filename | test.cpp:177:13:177:17 | strncat output argument |
+| test.cpp:178:13:178:19 | strncat output argument | test.cpp:183:32:183:38 | *command |
+| test.cpp:178:13:178:19 | strncat output argument | test.cpp:183:32:183:38 | *command |
+| test.cpp:178:22:178:26 | *flags | test.cpp:178:13:178:19 | strncat output argument |
+| test.cpp:178:22:178:26 | *flags | test.cpp:178:13:178:19 | strncat output argument |
+| test.cpp:180:13:180:19 | strncat output argument | test.cpp:183:32:183:38 | *command |
+| test.cpp:180:22:180:29 | *filename | test.cpp:180:13:180:19 | strncat output argument |
+| test.cpp:186:47:186:54 | *filename | test.cpp:187:18:187:25 | *filename |
+| test.cpp:187:11:187:15 | strncat output argument | test.cpp:188:20:188:24 | *flags |
+| test.cpp:187:11:187:15 | strncat output argument | test.cpp:188:20:188:24 | *flags |
+| test.cpp:187:18:187:25 | *filename | test.cpp:187:11:187:15 | strncat output argument |
+| test.cpp:187:18:187:25 | *filename | test.cpp:187:11:187:15 | strncat output argument |
+| test.cpp:188:20:188:24 | *flags | test.cpp:188:11:188:17 | strncat output argument |
+| test.cpp:188:20:188:24 | *flags | test.cpp:188:11:188:17 | strncat output argument |
+| test.cpp:194:9:194:16 | fread output argument | test.cpp:196:26:196:33 | *filename |
+| test.cpp:196:10:196:16 | concat output argument | test.cpp:198:32:198:38 | *command |
+| test.cpp:196:10:196:16 | concat output argument | test.cpp:198:32:198:38 | *command |
+| test.cpp:196:26:196:33 | *filename | test.cpp:186:47:186:54 | *filename |
+| test.cpp:196:26:196:33 | *filename | test.cpp:196:10:196:16 | concat output argument |
+| test.cpp:196:26:196:33 | *filename | test.cpp:196:10:196:16 | concat output argument |
+| test.cpp:218:9:218:16 | fread output argument | test.cpp:220:19:220:26 | *filename |
 | test.cpp:220:10:220:16 | strncat output argument | test.cpp:220:10:220:16 | strncat output argument |
 | test.cpp:220:10:220:16 | strncat output argument | test.cpp:220:10:220:16 | strncat output argument |
 | test.cpp:220:10:220:16 | strncat output argument | test.cpp:220:10:220:16 | strncat output argument |
-| test.cpp:220:10:220:16 | strncat output argument | test.cpp:222:32:222:38 | command indirection |
-| test.cpp:220:10:220:16 | strncat output argument | test.cpp:222:32:222:38 | command indirection |
-| test.cpp:220:10:220:16 | strncat output argument | test.cpp:222:32:222:38 | command indirection |
-| test.cpp:220:10:220:16 | strncat output argument | test.cpp:222:32:222:38 | command indirection |
-| test.cpp:220:19:220:26 | filename indirection | test.cpp:220:10:220:16 | strncat output argument |
-| test.cpp:220:19:220:26 | filename indirection | test.cpp:220:10:220:16 | strncat output argument |
-| test.cpp:220:19:220:26 | filename indirection | test.cpp:220:19:220:26 | filename indirection |
+| test.cpp:220:10:220:16 | strncat output argument | test.cpp:222:32:222:38 | *command |
+| test.cpp:220:10:220:16 | strncat output argument | test.cpp:222:32:222:38 | *command |
+| test.cpp:220:10:220:16 | strncat output argument | test.cpp:222:32:222:38 | *command |
+| test.cpp:220:10:220:16 | strncat output argument | test.cpp:222:32:222:38 | *command |
+| test.cpp:220:19:220:26 | *filename | test.cpp:220:10:220:16 | strncat output argument |
+| test.cpp:220:19:220:26 | *filename | test.cpp:220:10:220:16 | strncat output argument |
+| test.cpp:220:19:220:26 | *filename | test.cpp:220:19:220:26 | *filename |
 nodes
-| test.cpp:15:27:15:30 | argv indirection | semmle.label | argv indirection |
+| test.cpp:15:27:15:30 | **argv | semmle.label | **argv |
 | test.cpp:22:13:22:20 | sprintf output argument | semmle.label | sprintf output argument |
-| test.cpp:22:45:22:52 | userName indirection | semmle.label | userName indirection |
-| test.cpp:23:12:23:19 | command1 indirection | semmle.label | command1 indirection |
-| test.cpp:47:21:47:26 | call to getenv indirection | semmle.label | call to getenv indirection |
+| test.cpp:22:45:22:52 | *userName | semmle.label | *userName |
+| test.cpp:23:12:23:19 | *command1 | semmle.label | *command1 |
+| test.cpp:47:21:47:26 | *call to getenv | semmle.label | *call to getenv |
 | test.cpp:50:11:50:17 | sprintf output argument | semmle.label | sprintf output argument |
-| test.cpp:50:35:50:43 | envCflags indirection | semmle.label | envCflags indirection |
-| test.cpp:51:10:51:16 | command indirection | semmle.label | command indirection |
+| test.cpp:50:35:50:43 | *envCflags | semmle.label | *envCflags |
+| test.cpp:51:10:51:16 | *command | semmle.label | *command |
 | test.cpp:62:9:62:16 | fread output argument | semmle.label | fread output argument |
 | test.cpp:64:11:64:17 | strncat output argument | semmle.label | strncat output argument |
-| test.cpp:64:20:64:27 | filename indirection | semmle.label | filename indirection |
-| test.cpp:65:10:65:16 | command indirection | semmle.label | command indirection |
+| test.cpp:64:20:64:27 | *filename | semmle.label | *filename |
+| test.cpp:65:10:65:16 | *command | semmle.label | *command |
 | test.cpp:82:9:82:16 | fread output argument | semmle.label | fread output argument |
 | test.cpp:84:11:84:17 | strncat output argument | semmle.label | strncat output argument |
-| test.cpp:84:20:84:27 | filename indirection | semmle.label | filename indirection |
-| test.cpp:85:32:85:38 | command indirection | semmle.label | command indirection |
+| test.cpp:84:20:84:27 | *filename | semmle.label | *filename |
+| test.cpp:85:32:85:38 | *command | semmle.label | *command |
 | test.cpp:91:9:91:16 | fread output argument | semmle.label | fread output argument |
 | test.cpp:93:11:93:14 | strncat output argument | semmle.label | strncat output argument |
-| test.cpp:93:17:93:24 | filename indirection | semmle.label | filename indirection |
-| test.cpp:94:45:94:48 | path indirection | semmle.label | path indirection |
-| test.cpp:106:20:106:38 | call to getenv indirection | semmle.label | call to getenv indirection |
+| test.cpp:93:17:93:24 | *filename | semmle.label | *filename |
+| test.cpp:94:45:94:48 | *path | semmle.label | *path |
+| test.cpp:106:20:106:38 | *call to getenv | semmle.label | *call to getenv |
 | test.cpp:107:31:107:31 | call to operator+ | semmle.label | call to operator+ |
-| test.cpp:107:33:107:36 | path indirection | semmle.label | path indirection |
-| test.cpp:108:18:108:22 | call to c_str indirection | semmle.label | call to c_str indirection |
-| test.cpp:113:20:113:38 | call to getenv indirection | semmle.label | call to getenv indirection |
+| test.cpp:107:33:107:36 | *path | semmle.label | *path |
+| test.cpp:108:18:108:22 | *call to c_str | semmle.label | *call to c_str |
+| test.cpp:113:20:113:38 | *call to getenv | semmle.label | *call to getenv |
 | test.cpp:114:10:114:23 | call to operator+ | semmle.label | call to operator+ |
 | test.cpp:114:10:114:23 | call to operator+ | semmle.label | call to operator+ |
 | test.cpp:114:17:114:17 | call to operator+ | semmle.label | call to operator+ |
-| test.cpp:114:19:114:22 | path indirection | semmle.label | path indirection |
-| test.cpp:114:25:114:29 | call to c_str indirection | semmle.label | call to c_str indirection |
-| test.cpp:114:25:114:29 | call to c_str indirection | semmle.label | call to c_str indirection |
-| test.cpp:119:20:119:38 | call to getenv indirection | semmle.label | call to getenv indirection |
-| test.cpp:120:10:120:30 | call to data indirection | semmle.label | call to data indirection |
+| test.cpp:114:19:114:22 | *path | semmle.label | *path |
+| test.cpp:114:25:114:29 | *call to c_str | semmle.label | *call to c_str |
+| test.cpp:114:25:114:29 | *call to c_str | semmle.label | *call to c_str |
+| test.cpp:119:20:119:38 | *call to getenv | semmle.label | *call to getenv |
+| test.cpp:120:10:120:30 | *call to data | semmle.label | *call to data |
 | test.cpp:120:17:120:17 | call to operator+ | semmle.label | call to operator+ |
-| test.cpp:120:19:120:22 | path indirection | semmle.label | path indirection |
+| test.cpp:120:19:120:22 | *path | semmle.label | *path |
 | test.cpp:140:9:140:11 | fread output argument | semmle.label | fread output argument |
 | test.cpp:142:11:142:17 | sprintf output argument | semmle.label | sprintf output argument |
-| test.cpp:142:31:142:33 | str indirection | semmle.label | str indirection |
-| test.cpp:143:10:143:16 | command indirection | semmle.label | command indirection |
+| test.cpp:142:31:142:33 | *str | semmle.label | *str |
+| test.cpp:143:10:143:16 | *command | semmle.label | *command |
 | test.cpp:174:9:174:16 | fread output argument | semmle.label | fread output argument |
 | test.cpp:177:13:177:17 | strncat output argument | semmle.label | strncat output argument |
 | test.cpp:177:13:177:17 | strncat output argument | semmle.label | strncat output argument |
-| test.cpp:177:20:177:27 | filename indirection | semmle.label | filename indirection |
+| test.cpp:177:20:177:27 | *filename | semmle.label | *filename |
 | test.cpp:178:13:178:19 | strncat output argument | semmle.label | strncat output argument |
 | test.cpp:178:13:178:19 | strncat output argument | semmle.label | strncat output argument |
-| test.cpp:178:22:178:26 | flags indirection | semmle.label | flags indirection |
-| test.cpp:178:22:178:26 | flags indirection | semmle.label | flags indirection |
+| test.cpp:178:22:178:26 | *flags | semmle.label | *flags |
+| test.cpp:178:22:178:26 | *flags | semmle.label | *flags |
 | test.cpp:180:13:180:19 | strncat output argument | semmle.label | strncat output argument |
-| test.cpp:180:22:180:29 | filename indirection | semmle.label | filename indirection |
-| test.cpp:183:32:183:38 | command indirection | semmle.label | command indirection |
-| test.cpp:183:32:183:38 | command indirection | semmle.label | command indirection |
-| test.cpp:183:32:183:38 | command indirection | semmle.label | command indirection |
-| test.cpp:186:47:186:54 | filename indirection | semmle.label | filename indirection |
+| test.cpp:180:22:180:29 | *filename | semmle.label | *filename |
+| test.cpp:183:32:183:38 | *command | semmle.label | *command |
+| test.cpp:183:32:183:38 | *command | semmle.label | *command |
+| test.cpp:183:32:183:38 | *command | semmle.label | *command |
+| test.cpp:186:47:186:54 | *filename | semmle.label | *filename |
 | test.cpp:187:11:187:15 | strncat output argument | semmle.label | strncat output argument |
 | test.cpp:187:11:187:15 | strncat output argument | semmle.label | strncat output argument |
-| test.cpp:187:18:187:25 | filename indirection | semmle.label | filename indirection |
+| test.cpp:187:18:187:25 | *filename | semmle.label | *filename |
 | test.cpp:188:11:188:17 | strncat output argument | semmle.label | strncat output argument |
 | test.cpp:188:11:188:17 | strncat output argument | semmle.label | strncat output argument |
-| test.cpp:188:20:188:24 | flags indirection | semmle.label | flags indirection |
-| test.cpp:188:20:188:24 | flags indirection | semmle.label | flags indirection |
+| test.cpp:188:20:188:24 | *flags | semmle.label | *flags |
+| test.cpp:188:20:188:24 | *flags | semmle.label | *flags |
 | test.cpp:194:9:194:16 | fread output argument | semmle.label | fread output argument |
 | test.cpp:196:10:196:16 | concat output argument | semmle.label | concat output argument |
 | test.cpp:196:10:196:16 | concat output argument | semmle.label | concat output argument |
-| test.cpp:196:26:196:33 | filename indirection | semmle.label | filename indirection |
-| test.cpp:198:32:198:38 | command indirection | semmle.label | command indirection |
-| test.cpp:198:32:198:38 | command indirection | semmle.label | command indirection |
+| test.cpp:196:26:196:33 | *filename | semmle.label | *filename |
+| test.cpp:198:32:198:38 | *command | semmle.label | *command |
+| test.cpp:198:32:198:38 | *command | semmle.label | *command |
 | test.cpp:218:9:218:16 | fread output argument | semmle.label | fread output argument |
 | test.cpp:220:10:220:16 | strncat output argument | semmle.label | strncat output argument |
 | test.cpp:220:10:220:16 | strncat output argument | semmle.label | strncat output argument |
 | test.cpp:220:10:220:16 | strncat output argument | semmle.label | strncat output argument |
 | test.cpp:220:10:220:16 | strncat output argument | semmle.label | strncat output argument |
-| test.cpp:220:19:220:26 | filename indirection | semmle.label | filename indirection |
-| test.cpp:220:19:220:26 | filename indirection | semmle.label | filename indirection |
-| test.cpp:222:32:222:38 | command indirection | semmle.label | command indirection |
-| test.cpp:222:32:222:38 | command indirection | semmle.label | command indirection |
+| test.cpp:220:19:220:26 | *filename | semmle.label | *filename |
+| test.cpp:220:19:220:26 | *filename | semmle.label | *filename |
+| test.cpp:222:32:222:38 | *command | semmle.label | *command |
+| test.cpp:222:32:222:38 | *command | semmle.label | *command |
 subpaths
-| test.cpp:196:26:196:33 | filename indirection | test.cpp:186:47:186:54 | filename indirection | test.cpp:188:11:188:17 | strncat output argument | test.cpp:196:10:196:16 | concat output argument |
-| test.cpp:196:26:196:33 | filename indirection | test.cpp:186:47:186:54 | filename indirection | test.cpp:188:11:188:17 | strncat output argument | test.cpp:196:10:196:16 | concat output argument |
+| test.cpp:196:26:196:33 | *filename | test.cpp:186:47:186:54 | *filename | test.cpp:188:11:188:17 | strncat output argument | test.cpp:196:10:196:16 | concat output argument |
+| test.cpp:196:26:196:33 | *filename | test.cpp:186:47:186:54 | *filename | test.cpp:188:11:188:17 | strncat output argument | test.cpp:196:10:196:16 | concat output argument |
 #select
-| test.cpp:23:12:23:19 | command1 | test.cpp:15:27:15:30 | argv indirection | test.cpp:23:12:23:19 | command1 indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:15:27:15:30 | argv indirection | user input (a command-line argument) | test.cpp:22:13:22:20 | sprintf output argument | sprintf output argument |
-| test.cpp:51:10:51:16 | command | test.cpp:47:21:47:26 | call to getenv indirection | test.cpp:51:10:51:16 | command indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:47:21:47:26 | call to getenv indirection | user input (an environment variable) | test.cpp:50:11:50:17 | sprintf output argument | sprintf output argument |
-| test.cpp:65:10:65:16 | command | test.cpp:62:9:62:16 | fread output argument | test.cpp:65:10:65:16 | command indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:62:9:62:16 | fread output argument | user input (string read by fread) | test.cpp:64:11:64:17 | strncat output argument | strncat output argument |
-| test.cpp:85:32:85:38 | command | test.cpp:82:9:82:16 | fread output argument | test.cpp:85:32:85:38 | command indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl. | test.cpp:82:9:82:16 | fread output argument | user input (string read by fread) | test.cpp:84:11:84:17 | strncat output argument | strncat output argument |
-| test.cpp:94:45:94:48 | path | test.cpp:91:9:91:16 | fread output argument | test.cpp:94:45:94:48 | path indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl. | test.cpp:91:9:91:16 | fread output argument | user input (string read by fread) | test.cpp:93:11:93:14 | strncat output argument | strncat output argument |
-| test.cpp:108:18:108:22 | call to c_str | test.cpp:106:20:106:38 | call to getenv indirection | test.cpp:108:18:108:22 | call to c_str indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:106:20:106:38 | call to getenv indirection | user input (an environment variable) | test.cpp:107:31:107:31 | call to operator+ | call to operator+ |
-| test.cpp:114:25:114:29 | call to c_str | test.cpp:113:20:113:38 | call to getenv indirection | test.cpp:114:25:114:29 | call to c_str indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:113:20:113:38 | call to getenv indirection | user input (an environment variable) | test.cpp:114:10:114:23 | call to operator+ | call to operator+ |
-| test.cpp:114:25:114:29 | call to c_str | test.cpp:113:20:113:38 | call to getenv indirection | test.cpp:114:25:114:29 | call to c_str indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:113:20:113:38 | call to getenv indirection | user input (an environment variable) | test.cpp:114:17:114:17 | call to operator+ | call to operator+ |
-| test.cpp:120:25:120:28 | call to data | test.cpp:119:20:119:38 | call to getenv indirection | test.cpp:120:10:120:30 | call to data indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:119:20:119:38 | call to getenv indirection | user input (an environment variable) | test.cpp:120:17:120:17 | call to operator+ | call to operator+ |
-| test.cpp:143:10:143:16 | command | test.cpp:140:9:140:11 | fread output argument | test.cpp:143:10:143:16 | command indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:140:9:140:11 | fread output argument | user input (string read by fread) | test.cpp:142:11:142:17 | sprintf output argument | sprintf output argument |
-| test.cpp:183:32:183:38 | command | test.cpp:174:9:174:16 | fread output argument | test.cpp:183:32:183:38 | command indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl. | test.cpp:174:9:174:16 | fread output argument | user input (string read by fread) | test.cpp:177:13:177:17 | strncat output argument | strncat output argument |
-| test.cpp:183:32:183:38 | command | test.cpp:174:9:174:16 | fread output argument | test.cpp:183:32:183:38 | command indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl. | test.cpp:174:9:174:16 | fread output argument | user input (string read by fread) | test.cpp:178:13:178:19 | strncat output argument | strncat output argument |
-| test.cpp:183:32:183:38 | command | test.cpp:174:9:174:16 | fread output argument | test.cpp:183:32:183:38 | command indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl. | test.cpp:174:9:174:16 | fread output argument | user input (string read by fread) | test.cpp:180:13:180:19 | strncat output argument | strncat output argument |
-| test.cpp:198:32:198:38 | command | test.cpp:194:9:194:16 | fread output argument | test.cpp:198:32:198:38 | command indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl. | test.cpp:194:9:194:16 | fread output argument | user input (string read by fread) | test.cpp:187:11:187:15 | strncat output argument | strncat output argument |
-| test.cpp:198:32:198:38 | command | test.cpp:194:9:194:16 | fread output argument | test.cpp:198:32:198:38 | command indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl. | test.cpp:194:9:194:16 | fread output argument | user input (string read by fread) | test.cpp:188:11:188:17 | strncat output argument | strncat output argument |
-| test.cpp:222:32:222:38 | command | test.cpp:218:9:218:16 | fread output argument | test.cpp:222:32:222:38 | command indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl. | test.cpp:218:9:218:16 | fread output argument | user input (string read by fread) | test.cpp:220:10:220:16 | strncat output argument | strncat output argument |
-| test.cpp:222:32:222:38 | command | test.cpp:218:9:218:16 | fread output argument | test.cpp:222:32:222:38 | command indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl. | test.cpp:218:9:218:16 | fread output argument | user input (string read by fread) | test.cpp:220:10:220:16 | strncat output argument | strncat output argument |
+| test.cpp:23:12:23:19 | command1 | test.cpp:15:27:15:30 | **argv | test.cpp:23:12:23:19 | *command1 | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:15:27:15:30 | **argv | user input (a command-line argument) | test.cpp:22:13:22:20 | sprintf output argument | sprintf output argument |
+| test.cpp:51:10:51:16 | command | test.cpp:47:21:47:26 | *call to getenv | test.cpp:51:10:51:16 | *command | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:47:21:47:26 | *call to getenv | user input (an environment variable) | test.cpp:50:11:50:17 | sprintf output argument | sprintf output argument |
+| test.cpp:65:10:65:16 | command | test.cpp:62:9:62:16 | fread output argument | test.cpp:65:10:65:16 | *command | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:62:9:62:16 | fread output argument | user input (string read by fread) | test.cpp:64:11:64:17 | strncat output argument | strncat output argument |
+| test.cpp:85:32:85:38 | command | test.cpp:82:9:82:16 | fread output argument | test.cpp:85:32:85:38 | *command | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl. | test.cpp:82:9:82:16 | fread output argument | user input (string read by fread) | test.cpp:84:11:84:17 | strncat output argument | strncat output argument |
+| test.cpp:94:45:94:48 | path | test.cpp:91:9:91:16 | fread output argument | test.cpp:94:45:94:48 | *path | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl. | test.cpp:91:9:91:16 | fread output argument | user input (string read by fread) | test.cpp:93:11:93:14 | strncat output argument | strncat output argument |
+| test.cpp:108:18:108:22 | call to c_str | test.cpp:106:20:106:38 | *call to getenv | test.cpp:108:18:108:22 | *call to c_str | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:106:20:106:38 | *call to getenv | user input (an environment variable) | test.cpp:107:31:107:31 | call to operator+ | call to operator+ |
+| test.cpp:114:25:114:29 | call to c_str | test.cpp:113:20:113:38 | *call to getenv | test.cpp:114:25:114:29 | *call to c_str | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:113:20:113:38 | *call to getenv | user input (an environment variable) | test.cpp:114:10:114:23 | call to operator+ | call to operator+ |
+| test.cpp:114:25:114:29 | call to c_str | test.cpp:113:20:113:38 | *call to getenv | test.cpp:114:25:114:29 | *call to c_str | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:113:20:113:38 | *call to getenv | user input (an environment variable) | test.cpp:114:17:114:17 | call to operator+ | call to operator+ |
+| test.cpp:120:25:120:28 | call to data | test.cpp:119:20:119:38 | *call to getenv | test.cpp:120:10:120:30 | *call to data | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:119:20:119:38 | *call to getenv | user input (an environment variable) | test.cpp:120:17:120:17 | call to operator+ | call to operator+ |
+| test.cpp:143:10:143:16 | command | test.cpp:140:9:140:11 | fread output argument | test.cpp:143:10:143:16 | *command | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:140:9:140:11 | fread output argument | user input (string read by fread) | test.cpp:142:11:142:17 | sprintf output argument | sprintf output argument |
+| test.cpp:183:32:183:38 | command | test.cpp:174:9:174:16 | fread output argument | test.cpp:183:32:183:38 | *command | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl. | test.cpp:174:9:174:16 | fread output argument | user input (string read by fread) | test.cpp:177:13:177:17 | strncat output argument | strncat output argument |
+| test.cpp:183:32:183:38 | command | test.cpp:174:9:174:16 | fread output argument | test.cpp:183:32:183:38 | *command | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl. | test.cpp:174:9:174:16 | fread output argument | user input (string read by fread) | test.cpp:178:13:178:19 | strncat output argument | strncat output argument |
+| test.cpp:183:32:183:38 | command | test.cpp:174:9:174:16 | fread output argument | test.cpp:183:32:183:38 | *command | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl. | test.cpp:174:9:174:16 | fread output argument | user input (string read by fread) | test.cpp:180:13:180:19 | strncat output argument | strncat output argument |
+| test.cpp:198:32:198:38 | command | test.cpp:194:9:194:16 | fread output argument | test.cpp:198:32:198:38 | *command | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl. | test.cpp:194:9:194:16 | fread output argument | user input (string read by fread) | test.cpp:187:11:187:15 | strncat output argument | strncat output argument |
+| test.cpp:198:32:198:38 | command | test.cpp:194:9:194:16 | fread output argument | test.cpp:198:32:198:38 | *command | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl. | test.cpp:194:9:194:16 | fread output argument | user input (string read by fread) | test.cpp:188:11:188:17 | strncat output argument | strncat output argument |
+| test.cpp:222:32:222:38 | command | test.cpp:218:9:218:16 | fread output argument | test.cpp:222:32:222:38 | *command | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl. | test.cpp:218:9:218:16 | fread output argument | user input (string read by fread) | test.cpp:220:10:220:16 | strncat output argument | strncat output argument |
+| test.cpp:222:32:222:38 | command | test.cpp:218:9:218:16 | fread output argument | test.cpp:222:32:222:38 | *command | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl. | test.cpp:218:9:218:16 | fread output argument | user input (string read by fread) | test.cpp:220:10:220:16 | strncat output argument | strncat output argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-079/semmle/CgiXss/CgiXss.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-079/semmle/CgiXss/CgiXss.expected
@@ -1,26 +1,26 @@
 edges
-| search.c:14:24:14:28 | query indirection | search.c:17:8:17:12 | query indirection |
-| search.c:22:24:22:28 | query indirection | search.c:23:39:23:43 | query indirection |
-| search.c:55:24:55:28 | query indirection | search.c:62:8:62:17 | query_text indirection |
-| search.c:67:21:67:26 | call to getenv indirection | search.c:71:17:71:25 | raw_query indirection |
-| search.c:67:21:67:26 | call to getenv indirection | search.c:73:17:73:25 | raw_query indirection |
-| search.c:67:21:67:26 | call to getenv indirection | search.c:77:17:77:25 | raw_query indirection |
-| search.c:71:17:71:25 | raw_query indirection | search.c:14:24:14:28 | query indirection |
-| search.c:73:17:73:25 | raw_query indirection | search.c:22:24:22:28 | query indirection |
-| search.c:77:17:77:25 | raw_query indirection | search.c:55:24:55:28 | query indirection |
+| search.c:14:24:14:28 | *query | search.c:17:8:17:12 | *query |
+| search.c:22:24:22:28 | *query | search.c:23:39:23:43 | *query |
+| search.c:55:24:55:28 | *query | search.c:62:8:62:17 | *query_text |
+| search.c:67:21:67:26 | *call to getenv | search.c:71:17:71:25 | *raw_query |
+| search.c:67:21:67:26 | *call to getenv | search.c:73:17:73:25 | *raw_query |
+| search.c:67:21:67:26 | *call to getenv | search.c:77:17:77:25 | *raw_query |
+| search.c:71:17:71:25 | *raw_query | search.c:14:24:14:28 | *query |
+| search.c:73:17:73:25 | *raw_query | search.c:22:24:22:28 | *query |
+| search.c:77:17:77:25 | *raw_query | search.c:55:24:55:28 | *query |
 nodes
-| search.c:14:24:14:28 | query indirection | semmle.label | query indirection |
-| search.c:17:8:17:12 | query indirection | semmle.label | query indirection |
-| search.c:22:24:22:28 | query indirection | semmle.label | query indirection |
-| search.c:23:39:23:43 | query indirection | semmle.label | query indirection |
-| search.c:55:24:55:28 | query indirection | semmle.label | query indirection |
-| search.c:62:8:62:17 | query_text indirection | semmle.label | query_text indirection |
-| search.c:67:21:67:26 | call to getenv indirection | semmle.label | call to getenv indirection |
-| search.c:71:17:71:25 | raw_query indirection | semmle.label | raw_query indirection |
-| search.c:73:17:73:25 | raw_query indirection | semmle.label | raw_query indirection |
-| search.c:77:17:77:25 | raw_query indirection | semmle.label | raw_query indirection |
+| search.c:14:24:14:28 | *query | semmle.label | *query |
+| search.c:17:8:17:12 | *query | semmle.label | *query |
+| search.c:22:24:22:28 | *query | semmle.label | *query |
+| search.c:23:39:23:43 | *query | semmle.label | *query |
+| search.c:55:24:55:28 | *query | semmle.label | *query |
+| search.c:62:8:62:17 | *query_text | semmle.label | *query_text |
+| search.c:67:21:67:26 | *call to getenv | semmle.label | *call to getenv |
+| search.c:71:17:71:25 | *raw_query | semmle.label | *raw_query |
+| search.c:73:17:73:25 | *raw_query | semmle.label | *raw_query |
+| search.c:77:17:77:25 | *raw_query | semmle.label | *raw_query |
 subpaths
 #select
-| search.c:17:8:17:12 | query indirection | search.c:67:21:67:26 | call to getenv indirection | search.c:17:8:17:12 | query indirection | Cross-site scripting vulnerability due to $@. | search.c:67:21:67:26 | call to getenv | this query data |
-| search.c:23:39:23:43 | query indirection | search.c:67:21:67:26 | call to getenv indirection | search.c:23:39:23:43 | query indirection | Cross-site scripting vulnerability due to $@. | search.c:67:21:67:26 | call to getenv | this query data |
-| search.c:62:8:62:17 | query_text indirection | search.c:67:21:67:26 | call to getenv indirection | search.c:62:8:62:17 | query_text indirection | Cross-site scripting vulnerability due to $@. | search.c:67:21:67:26 | call to getenv | this query data |
+| search.c:17:8:17:12 | *query | search.c:67:21:67:26 | *call to getenv | search.c:17:8:17:12 | *query | Cross-site scripting vulnerability due to $@. | search.c:67:21:67:26 | call to getenv | this query data |
+| search.c:23:39:23:43 | *query | search.c:67:21:67:26 | *call to getenv | search.c:23:39:23:43 | *query | Cross-site scripting vulnerability due to $@. | search.c:67:21:67:26 | call to getenv | this query data |
+| search.c:62:8:62:17 | *query_text | search.c:67:21:67:26 | *call to getenv | search.c:62:8:62:17 | *query_text | Cross-site scripting vulnerability due to $@. | search.c:67:21:67:26 | call to getenv | this query data |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-089/SqlTainted/SqlTainted.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-089/SqlTainted/SqlTainted.expected
@@ -1,28 +1,28 @@
 edges
-| test.c:14:27:14:30 | argv indirection | test.c:21:18:21:23 | query1 indirection |
-| test.c:14:27:14:30 | argv indirection | test.c:35:16:35:23 | userName indirection |
-| test.c:35:16:35:23 | userName indirection | test.c:40:25:40:32 | username indirection |
-| test.c:38:7:38:20 | globalUsername indirection | test.c:51:18:51:23 | query1 indirection |
-| test.c:40:25:40:32 | username indirection | test.c:38:7:38:20 | globalUsername indirection |
-| test.c:75:8:75:16 | gets output argument | test.c:76:17:76:25 | userInput indirection |
-| test.c:75:8:75:16 | gets output argument | test.c:77:20:77:28 | userInput indirection |
-| test.cpp:39:27:39:30 | argv indirection | test.cpp:43:27:43:33 | access to array indirection |
+| test.c:14:27:14:30 | **argv | test.c:21:18:21:23 | *query1 |
+| test.c:14:27:14:30 | **argv | test.c:35:16:35:23 | *userName |
+| test.c:35:16:35:23 | *userName | test.c:40:25:40:32 | *username |
+| test.c:38:7:38:20 | **globalUsername | test.c:51:18:51:23 | *query1 |
+| test.c:40:25:40:32 | *username | test.c:38:7:38:20 | **globalUsername |
+| test.c:75:8:75:16 | gets output argument | test.c:76:17:76:25 | *userInput |
+| test.c:75:8:75:16 | gets output argument | test.c:77:20:77:28 | *userInput |
+| test.cpp:39:27:39:30 | **argv | test.cpp:43:27:43:33 | *access to array |
 nodes
-| test.c:14:27:14:30 | argv indirection | semmle.label | argv indirection |
-| test.c:21:18:21:23 | query1 indirection | semmle.label | query1 indirection |
-| test.c:35:16:35:23 | userName indirection | semmle.label | userName indirection |
-| test.c:38:7:38:20 | globalUsername indirection | semmle.label | globalUsername indirection |
-| test.c:40:25:40:32 | username indirection | semmle.label | username indirection |
-| test.c:51:18:51:23 | query1 indirection | semmle.label | query1 indirection |
+| test.c:14:27:14:30 | **argv | semmle.label | **argv |
+| test.c:21:18:21:23 | *query1 | semmle.label | *query1 |
+| test.c:35:16:35:23 | *userName | semmle.label | *userName |
+| test.c:38:7:38:20 | **globalUsername | semmle.label | **globalUsername |
+| test.c:40:25:40:32 | *username | semmle.label | *username |
+| test.c:51:18:51:23 | *query1 | semmle.label | *query1 |
 | test.c:75:8:75:16 | gets output argument | semmle.label | gets output argument |
-| test.c:76:17:76:25 | userInput indirection | semmle.label | userInput indirection |
-| test.c:77:20:77:28 | userInput indirection | semmle.label | userInput indirection |
-| test.cpp:39:27:39:30 | argv indirection | semmle.label | argv indirection |
-| test.cpp:43:27:43:33 | access to array indirection | semmle.label | access to array indirection |
+| test.c:76:17:76:25 | *userInput | semmle.label | *userInput |
+| test.c:77:20:77:28 | *userInput | semmle.label | *userInput |
+| test.cpp:39:27:39:30 | **argv | semmle.label | **argv |
+| test.cpp:43:27:43:33 | *access to array | semmle.label | *access to array |
 subpaths
 #select
-| test.c:21:18:21:23 | query1 | test.c:14:27:14:30 | argv indirection | test.c:21:18:21:23 | query1 indirection | This argument to a SQL query function is derived from $@ and then passed to mysql_query(sqlArg). | test.c:14:27:14:30 | argv indirection | user input (a command-line argument) |
-| test.c:51:18:51:23 | query1 | test.c:14:27:14:30 | argv indirection | test.c:51:18:51:23 | query1 indirection | This argument to a SQL query function is derived from $@ and then passed to mysql_query(sqlArg). | test.c:14:27:14:30 | argv indirection | user input (a command-line argument) |
-| test.c:76:17:76:25 | userInput | test.c:75:8:75:16 | gets output argument | test.c:76:17:76:25 | userInput indirection | This argument to a SQL query function is derived from $@ and then passed to SQLPrepare(StatementText). | test.c:75:8:75:16 | gets output argument | user input (string read by gets) |
-| test.c:77:20:77:28 | userInput | test.c:75:8:75:16 | gets output argument | test.c:77:20:77:28 | userInput indirection | This argument to a SQL query function is derived from $@ and then passed to SQLExecDirect(StatementText). | test.c:75:8:75:16 | gets output argument | user input (string read by gets) |
-| test.cpp:43:27:43:33 | access to array | test.cpp:39:27:39:30 | argv indirection | test.cpp:43:27:43:33 | access to array indirection | This argument to a SQL query function is derived from $@ and then passed to pqxx::work::exec1((unnamed parameter 0)). | test.cpp:39:27:39:30 | argv indirection | user input (a command-line argument) |
+| test.c:21:18:21:23 | query1 | test.c:14:27:14:30 | **argv | test.c:21:18:21:23 | *query1 | This argument to a SQL query function is derived from $@ and then passed to mysql_query(sqlArg). | test.c:14:27:14:30 | **argv | user input (a command-line argument) |
+| test.c:51:18:51:23 | query1 | test.c:14:27:14:30 | **argv | test.c:51:18:51:23 | *query1 | This argument to a SQL query function is derived from $@ and then passed to mysql_query(sqlArg). | test.c:14:27:14:30 | **argv | user input (a command-line argument) |
+| test.c:76:17:76:25 | userInput | test.c:75:8:75:16 | gets output argument | test.c:76:17:76:25 | *userInput | This argument to a SQL query function is derived from $@ and then passed to SQLPrepare(StatementText). | test.c:75:8:75:16 | gets output argument | user input (string read by gets) |
+| test.c:77:20:77:28 | userInput | test.c:75:8:75:16 | gets output argument | test.c:77:20:77:28 | *userInput | This argument to a SQL query function is derived from $@ and then passed to SQLExecDirect(StatementText). | test.c:75:8:75:16 | gets output argument | user input (string read by gets) |
+| test.cpp:43:27:43:33 | access to array | test.cpp:39:27:39:30 | **argv | test.cpp:43:27:43:33 | *access to array | This argument to a SQL query function is derived from $@ and then passed to pqxx::work::exec1((unnamed parameter 0)). | test.cpp:39:27:39:30 | **argv | user input (a command-line argument) |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-114/SAMATE/UncontrolledProcessOperation/UncontrolledProcessOperation.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-114/SAMATE/UncontrolledProcessOperation/UncontrolledProcessOperation.expected
@@ -1,12 +1,12 @@
 edges
-| test.cpp:37:73:37:76 | data indirection | test.cpp:43:32:43:35 | data indirection |
-| test.cpp:64:30:64:35 | call to getenv indirection | test.cpp:73:24:73:27 | data indirection |
-| test.cpp:73:24:73:27 | data indirection | test.cpp:37:73:37:76 | data indirection |
+| test.cpp:37:73:37:76 | *data | test.cpp:43:32:43:35 | *data |
+| test.cpp:64:30:64:35 | *call to getenv | test.cpp:73:24:73:27 | *data |
+| test.cpp:73:24:73:27 | *data | test.cpp:37:73:37:76 | *data |
 nodes
-| test.cpp:37:73:37:76 | data indirection | semmle.label | data indirection |
-| test.cpp:43:32:43:35 | data indirection | semmle.label | data indirection |
-| test.cpp:64:30:64:35 | call to getenv indirection | semmle.label | call to getenv indirection |
-| test.cpp:73:24:73:27 | data indirection | semmle.label | data indirection |
+| test.cpp:37:73:37:76 | *data | semmle.label | *data |
+| test.cpp:43:32:43:35 | *data | semmle.label | *data |
+| test.cpp:64:30:64:35 | *call to getenv | semmle.label | *call to getenv |
+| test.cpp:73:24:73:27 | *data | semmle.label | *data |
 subpaths
 #select
-| test.cpp:43:32:43:35 | data indirection | test.cpp:64:30:64:35 | call to getenv indirection | test.cpp:43:32:43:35 | data indirection | The value of this argument may come from $@ and is being passed to LoadLibraryA. | test.cpp:64:30:64:35 | call to getenv indirection | an environment variable |
+| test.cpp:43:32:43:35 | *data | test.cpp:64:30:64:35 | *call to getenv | test.cpp:43:32:43:35 | *data | The value of this argument may come from $@ and is being passed to LoadLibraryA. | test.cpp:64:30:64:35 | *call to getenv | an environment variable |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-114/semmle/UncontrolledProcessOperation/UncontrolledProcessOperation.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-114/semmle/UncontrolledProcessOperation/UncontrolledProcessOperation.expected
@@ -1,45 +1,45 @@
 edges
-| test.cpp:24:30:24:36 | command indirection | test.cpp:26:10:26:16 | command indirection |
-| test.cpp:29:30:29:36 | command indirection | test.cpp:31:10:31:16 | command indirection |
-| test.cpp:42:18:42:34 | call to getenv indirection | test.cpp:24:30:24:36 | command indirection |
-| test.cpp:43:18:43:34 | call to getenv indirection | test.cpp:29:30:29:36 | command indirection |
-| test.cpp:56:12:56:17 | fgets output argument | test.cpp:62:10:62:15 | buffer indirection |
-| test.cpp:56:12:56:17 | fgets output argument | test.cpp:63:10:63:13 | data indirection |
-| test.cpp:56:12:56:17 | fgets output argument | test.cpp:64:10:64:16 | dataref indirection |
-| test.cpp:56:12:56:17 | fgets output argument | test.cpp:65:10:65:14 | data2 indirection |
-| test.cpp:76:12:76:17 | fgets output argument | test.cpp:78:10:78:15 | buffer indirection |
-| test.cpp:98:17:98:22 | recv output argument | test.cpp:99:15:99:20 | buffer indirection |
-| test.cpp:106:17:106:22 | recv output argument | test.cpp:107:15:107:20 | buffer indirection |
-| test.cpp:113:8:113:12 | call to fgets indirection | test.cpp:114:9:114:11 | ptr indirection |
+| test.cpp:24:30:24:36 | *command | test.cpp:26:10:26:16 | *command |
+| test.cpp:29:30:29:36 | *command | test.cpp:31:10:31:16 | *command |
+| test.cpp:42:18:42:34 | *call to getenv | test.cpp:24:30:24:36 | *command |
+| test.cpp:43:18:43:34 | *call to getenv | test.cpp:29:30:29:36 | *command |
+| test.cpp:56:12:56:17 | fgets output argument | test.cpp:62:10:62:15 | *buffer |
+| test.cpp:56:12:56:17 | fgets output argument | test.cpp:63:10:63:13 | *data |
+| test.cpp:56:12:56:17 | fgets output argument | test.cpp:64:10:64:16 | *dataref |
+| test.cpp:56:12:56:17 | fgets output argument | test.cpp:65:10:65:14 | *data2 |
+| test.cpp:76:12:76:17 | fgets output argument | test.cpp:78:10:78:15 | *buffer |
+| test.cpp:98:17:98:22 | recv output argument | test.cpp:99:15:99:20 | *buffer |
+| test.cpp:106:17:106:22 | recv output argument | test.cpp:107:15:107:20 | *buffer |
+| test.cpp:113:8:113:12 | *call to fgets | test.cpp:114:9:114:11 | *ptr |
 nodes
-| test.cpp:24:30:24:36 | command indirection | semmle.label | command indirection |
-| test.cpp:26:10:26:16 | command indirection | semmle.label | command indirection |
-| test.cpp:29:30:29:36 | command indirection | semmle.label | command indirection |
-| test.cpp:31:10:31:16 | command indirection | semmle.label | command indirection |
-| test.cpp:42:18:42:34 | call to getenv indirection | semmle.label | call to getenv indirection |
-| test.cpp:43:18:43:34 | call to getenv indirection | semmle.label | call to getenv indirection |
+| test.cpp:24:30:24:36 | *command | semmle.label | *command |
+| test.cpp:26:10:26:16 | *command | semmle.label | *command |
+| test.cpp:29:30:29:36 | *command | semmle.label | *command |
+| test.cpp:31:10:31:16 | *command | semmle.label | *command |
+| test.cpp:42:18:42:34 | *call to getenv | semmle.label | *call to getenv |
+| test.cpp:43:18:43:34 | *call to getenv | semmle.label | *call to getenv |
 | test.cpp:56:12:56:17 | fgets output argument | semmle.label | fgets output argument |
-| test.cpp:62:10:62:15 | buffer indirection | semmle.label | buffer indirection |
-| test.cpp:63:10:63:13 | data indirection | semmle.label | data indirection |
-| test.cpp:64:10:64:16 | dataref indirection | semmle.label | dataref indirection |
-| test.cpp:65:10:65:14 | data2 indirection | semmle.label | data2 indirection |
+| test.cpp:62:10:62:15 | *buffer | semmle.label | *buffer |
+| test.cpp:63:10:63:13 | *data | semmle.label | *data |
+| test.cpp:64:10:64:16 | *dataref | semmle.label | *dataref |
+| test.cpp:65:10:65:14 | *data2 | semmle.label | *data2 |
 | test.cpp:76:12:76:17 | fgets output argument | semmle.label | fgets output argument |
-| test.cpp:78:10:78:15 | buffer indirection | semmle.label | buffer indirection |
+| test.cpp:78:10:78:15 | *buffer | semmle.label | *buffer |
 | test.cpp:98:17:98:22 | recv output argument | semmle.label | recv output argument |
-| test.cpp:99:15:99:20 | buffer indirection | semmle.label | buffer indirection |
+| test.cpp:99:15:99:20 | *buffer | semmle.label | *buffer |
 | test.cpp:106:17:106:22 | recv output argument | semmle.label | recv output argument |
-| test.cpp:107:15:107:20 | buffer indirection | semmle.label | buffer indirection |
-| test.cpp:113:8:113:12 | call to fgets indirection | semmle.label | call to fgets indirection |
-| test.cpp:114:9:114:11 | ptr indirection | semmle.label | ptr indirection |
+| test.cpp:107:15:107:20 | *buffer | semmle.label | *buffer |
+| test.cpp:113:8:113:12 | *call to fgets | semmle.label | *call to fgets |
+| test.cpp:114:9:114:11 | *ptr | semmle.label | *ptr |
 subpaths
 #select
-| test.cpp:26:10:26:16 | command indirection | test.cpp:42:18:42:34 | call to getenv indirection | test.cpp:26:10:26:16 | command indirection | The value of this argument may come from $@ and is being passed to system. | test.cpp:42:18:42:34 | call to getenv indirection | an environment variable |
-| test.cpp:31:10:31:16 | command indirection | test.cpp:43:18:43:34 | call to getenv indirection | test.cpp:31:10:31:16 | command indirection | The value of this argument may come from $@ and is being passed to system. | test.cpp:43:18:43:34 | call to getenv indirection | an environment variable |
-| test.cpp:62:10:62:15 | buffer indirection | test.cpp:56:12:56:17 | fgets output argument | test.cpp:62:10:62:15 | buffer indirection | The value of this argument may come from $@ and is being passed to system. | test.cpp:56:12:56:17 | fgets output argument | string read by fgets |
-| test.cpp:63:10:63:13 | data indirection | test.cpp:56:12:56:17 | fgets output argument | test.cpp:63:10:63:13 | data indirection | The value of this argument may come from $@ and is being passed to system. | test.cpp:56:12:56:17 | fgets output argument | string read by fgets |
-| test.cpp:64:10:64:16 | dataref indirection | test.cpp:56:12:56:17 | fgets output argument | test.cpp:64:10:64:16 | dataref indirection | The value of this argument may come from $@ and is being passed to system. | test.cpp:56:12:56:17 | fgets output argument | string read by fgets |
-| test.cpp:65:10:65:14 | data2 indirection | test.cpp:56:12:56:17 | fgets output argument | test.cpp:65:10:65:14 | data2 indirection | The value of this argument may come from $@ and is being passed to system. | test.cpp:56:12:56:17 | fgets output argument | string read by fgets |
-| test.cpp:78:10:78:15 | buffer indirection | test.cpp:76:12:76:17 | fgets output argument | test.cpp:78:10:78:15 | buffer indirection | The value of this argument may come from $@ and is being passed to system. | test.cpp:76:12:76:17 | fgets output argument | string read by fgets |
-| test.cpp:99:15:99:20 | buffer indirection | test.cpp:98:17:98:22 | recv output argument | test.cpp:99:15:99:20 | buffer indirection | The value of this argument may come from $@ and is being passed to LoadLibrary. | test.cpp:98:17:98:22 | recv output argument | buffer read by recv |
-| test.cpp:107:15:107:20 | buffer indirection | test.cpp:106:17:106:22 | recv output argument | test.cpp:107:15:107:20 | buffer indirection | The value of this argument may come from $@ and is being passed to LoadLibrary. | test.cpp:106:17:106:22 | recv output argument | buffer read by recv |
-| test.cpp:114:9:114:11 | ptr indirection | test.cpp:113:8:113:12 | call to fgets indirection | test.cpp:114:9:114:11 | ptr indirection | The value of this argument may come from $@ and is being passed to system. | test.cpp:113:8:113:12 | call to fgets indirection | string read by fgets |
+| test.cpp:26:10:26:16 | *command | test.cpp:42:18:42:34 | *call to getenv | test.cpp:26:10:26:16 | *command | The value of this argument may come from $@ and is being passed to system. | test.cpp:42:18:42:34 | *call to getenv | an environment variable |
+| test.cpp:31:10:31:16 | *command | test.cpp:43:18:43:34 | *call to getenv | test.cpp:31:10:31:16 | *command | The value of this argument may come from $@ and is being passed to system. | test.cpp:43:18:43:34 | *call to getenv | an environment variable |
+| test.cpp:62:10:62:15 | *buffer | test.cpp:56:12:56:17 | fgets output argument | test.cpp:62:10:62:15 | *buffer | The value of this argument may come from $@ and is being passed to system. | test.cpp:56:12:56:17 | fgets output argument | string read by fgets |
+| test.cpp:63:10:63:13 | *data | test.cpp:56:12:56:17 | fgets output argument | test.cpp:63:10:63:13 | *data | The value of this argument may come from $@ and is being passed to system. | test.cpp:56:12:56:17 | fgets output argument | string read by fgets |
+| test.cpp:64:10:64:16 | *dataref | test.cpp:56:12:56:17 | fgets output argument | test.cpp:64:10:64:16 | *dataref | The value of this argument may come from $@ and is being passed to system. | test.cpp:56:12:56:17 | fgets output argument | string read by fgets |
+| test.cpp:65:10:65:14 | *data2 | test.cpp:56:12:56:17 | fgets output argument | test.cpp:65:10:65:14 | *data2 | The value of this argument may come from $@ and is being passed to system. | test.cpp:56:12:56:17 | fgets output argument | string read by fgets |
+| test.cpp:78:10:78:15 | *buffer | test.cpp:76:12:76:17 | fgets output argument | test.cpp:78:10:78:15 | *buffer | The value of this argument may come from $@ and is being passed to system. | test.cpp:76:12:76:17 | fgets output argument | string read by fgets |
+| test.cpp:99:15:99:20 | *buffer | test.cpp:98:17:98:22 | recv output argument | test.cpp:99:15:99:20 | *buffer | The value of this argument may come from $@ and is being passed to LoadLibrary. | test.cpp:98:17:98:22 | recv output argument | buffer read by recv |
+| test.cpp:107:15:107:20 | *buffer | test.cpp:106:17:106:22 | recv output argument | test.cpp:107:15:107:20 | *buffer | The value of this argument may come from $@ and is being passed to LoadLibrary. | test.cpp:106:17:106:22 | recv output argument | buffer read by recv |
+| test.cpp:114:9:114:11 | *ptr | test.cpp:113:8:113:12 | *call to fgets | test.cpp:114:9:114:11 | *ptr | The value of this argument may come from $@ and is being passed to system. | test.cpp:113:8:113:12 | *call to fgets | string read by fgets |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/SAMATE/OverrunWriteProductFlow.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/SAMATE/OverrunWriteProductFlow.expected
@@ -1,108 +1,108 @@
 edges
-| test.cpp:16:11:16:21 | mk_string_t indirection [string] | test.cpp:39:21:39:31 | call to mk_string_t indirection [string] |
-| test.cpp:18:5:18:7 | str indirection [post update] [string] | test.cpp:19:5:19:7 | str indirection [string] |
-| test.cpp:18:5:18:30 | ... = ... | test.cpp:18:5:18:7 | str indirection [post update] [string] |
+| test.cpp:16:11:16:21 | **mk_string_t [string] | test.cpp:39:21:39:31 | *call to mk_string_t [string] |
+| test.cpp:18:5:18:7 | *str [post update] [string] | test.cpp:19:5:19:7 | *str [string] |
+| test.cpp:18:5:18:30 | ... = ... | test.cpp:18:5:18:7 | *str [post update] [string] |
 | test.cpp:18:19:18:24 | call to malloc | test.cpp:18:5:18:30 | ... = ... |
-| test.cpp:19:5:19:7 | str indirection [string] | test.cpp:16:11:16:21 | mk_string_t indirection [string] |
-| test.cpp:39:21:39:31 | call to mk_string_t indirection [string] | test.cpp:42:13:42:15 | str indirection [string] |
-| test.cpp:39:21:39:31 | call to mk_string_t indirection [string] | test.cpp:72:17:72:19 | str indirection [string] |
-| test.cpp:39:21:39:31 | call to mk_string_t indirection [string] | test.cpp:80:17:80:19 | str indirection [string] |
-| test.cpp:42:13:42:15 | str indirection [string] | test.cpp:42:18:42:23 | string |
-| test.cpp:72:17:72:19 | str indirection [string] | test.cpp:72:22:72:27 | string |
-| test.cpp:80:17:80:19 | str indirection [string] | test.cpp:80:22:80:27 | string |
-| test.cpp:88:11:88:30 | mk_string_t_plus_one indirection [string] | test.cpp:96:21:96:40 | call to mk_string_t_plus_one indirection [string] |
-| test.cpp:90:5:90:7 | str indirection [post update] [string] | test.cpp:91:5:91:7 | str indirection [string] |
-| test.cpp:90:5:90:34 | ... = ... | test.cpp:90:5:90:7 | str indirection [post update] [string] |
+| test.cpp:19:5:19:7 | *str [string] | test.cpp:16:11:16:21 | **mk_string_t [string] |
+| test.cpp:39:21:39:31 | *call to mk_string_t [string] | test.cpp:42:13:42:15 | *str [string] |
+| test.cpp:39:21:39:31 | *call to mk_string_t [string] | test.cpp:72:17:72:19 | *str [string] |
+| test.cpp:39:21:39:31 | *call to mk_string_t [string] | test.cpp:80:17:80:19 | *str [string] |
+| test.cpp:42:13:42:15 | *str [string] | test.cpp:42:18:42:23 | string |
+| test.cpp:72:17:72:19 | *str [string] | test.cpp:72:22:72:27 | string |
+| test.cpp:80:17:80:19 | *str [string] | test.cpp:80:22:80:27 | string |
+| test.cpp:88:11:88:30 | **mk_string_t_plus_one [string] | test.cpp:96:21:96:40 | *call to mk_string_t_plus_one [string] |
+| test.cpp:90:5:90:7 | *str [post update] [string] | test.cpp:91:5:91:7 | *str [string] |
+| test.cpp:90:5:90:34 | ... = ... | test.cpp:90:5:90:7 | *str [post update] [string] |
 | test.cpp:90:19:90:24 | call to malloc | test.cpp:90:5:90:34 | ... = ... |
-| test.cpp:91:5:91:7 | str indirection [string] | test.cpp:88:11:88:30 | mk_string_t_plus_one indirection [string] |
-| test.cpp:96:21:96:40 | call to mk_string_t_plus_one indirection [string] | test.cpp:99:13:99:15 | str indirection [string] |
-| test.cpp:96:21:96:40 | call to mk_string_t_plus_one indirection [string] | test.cpp:129:17:129:19 | str indirection [string] |
-| test.cpp:96:21:96:40 | call to mk_string_t_plus_one indirection [string] | test.cpp:137:17:137:19 | str indirection [string] |
-| test.cpp:99:13:99:15 | str indirection [string] | test.cpp:99:18:99:23 | string |
-| test.cpp:129:17:129:19 | str indirection [string] | test.cpp:129:22:129:27 | string |
-| test.cpp:137:17:137:19 | str indirection [string] | test.cpp:137:22:137:27 | string |
-| test.cpp:147:5:147:7 | str indirection [post update] [string] | test.cpp:148:5:148:7 | str indirection [string] |
-| test.cpp:147:5:147:34 | ... = ... | test.cpp:147:5:147:7 | str indirection [post update] [string] |
+| test.cpp:91:5:91:7 | *str [string] | test.cpp:88:11:88:30 | **mk_string_t_plus_one [string] |
+| test.cpp:96:21:96:40 | *call to mk_string_t_plus_one [string] | test.cpp:99:13:99:15 | *str [string] |
+| test.cpp:96:21:96:40 | *call to mk_string_t_plus_one [string] | test.cpp:129:17:129:19 | *str [string] |
+| test.cpp:96:21:96:40 | *call to mk_string_t_plus_one [string] | test.cpp:137:17:137:19 | *str [string] |
+| test.cpp:99:13:99:15 | *str [string] | test.cpp:99:18:99:23 | string |
+| test.cpp:129:17:129:19 | *str [string] | test.cpp:129:22:129:27 | string |
+| test.cpp:137:17:137:19 | *str [string] | test.cpp:137:22:137:27 | string |
+| test.cpp:147:5:147:7 | *str [post update] [string] | test.cpp:148:5:148:7 | *str [string] |
+| test.cpp:147:5:147:34 | ... = ... | test.cpp:147:5:147:7 | *str [post update] [string] |
 | test.cpp:147:19:147:24 | call to malloc | test.cpp:147:5:147:34 | ... = ... |
-| test.cpp:148:5:148:7 | str indirection [string] | test.cpp:152:13:152:15 | str indirection [string] |
-| test.cpp:148:5:148:7 | str indirection [string] | test.cpp:154:13:154:15 | str indirection [string] |
-| test.cpp:148:5:148:7 | str indirection [string] | test.cpp:156:13:156:15 | str indirection [string] |
-| test.cpp:148:5:148:7 | str indirection [string] | test.cpp:175:17:175:19 | str indirection [string] |
-| test.cpp:148:5:148:7 | str indirection [string] | test.cpp:187:17:187:19 | str indirection [string] |
-| test.cpp:148:5:148:7 | str indirection [string] | test.cpp:195:17:195:19 | str indirection [string] |
-| test.cpp:148:5:148:7 | str indirection [string] | test.cpp:199:17:199:19 | str indirection [string] |
-| test.cpp:148:5:148:7 | str indirection [string] | test.cpp:203:17:203:19 | str indirection [string] |
-| test.cpp:148:5:148:7 | str indirection [string] | test.cpp:207:17:207:19 | str indirection [string] |
-| test.cpp:152:13:152:15 | str indirection [string] | test.cpp:152:18:152:23 | string |
-| test.cpp:154:13:154:15 | str indirection [string] | test.cpp:154:18:154:23 | string |
-| test.cpp:156:13:156:15 | str indirection [string] | test.cpp:156:18:156:23 | string |
-| test.cpp:175:17:175:19 | str indirection [string] | test.cpp:175:22:175:27 | string |
-| test.cpp:187:17:187:19 | str indirection [string] | test.cpp:187:22:187:27 | string |
-| test.cpp:195:17:195:19 | str indirection [string] | test.cpp:195:22:195:27 | string |
-| test.cpp:199:17:199:19 | str indirection [string] | test.cpp:199:22:199:27 | string |
-| test.cpp:203:17:203:19 | str indirection [string] | test.cpp:203:22:203:27 | string |
-| test.cpp:207:17:207:19 | str indirection [string] | test.cpp:207:22:207:27 | string |
+| test.cpp:148:5:148:7 | *str [string] | test.cpp:152:13:152:15 | *str [string] |
+| test.cpp:148:5:148:7 | *str [string] | test.cpp:154:13:154:15 | *str [string] |
+| test.cpp:148:5:148:7 | *str [string] | test.cpp:156:13:156:15 | *str [string] |
+| test.cpp:148:5:148:7 | *str [string] | test.cpp:175:17:175:19 | *str [string] |
+| test.cpp:148:5:148:7 | *str [string] | test.cpp:187:17:187:19 | *str [string] |
+| test.cpp:148:5:148:7 | *str [string] | test.cpp:195:17:195:19 | *str [string] |
+| test.cpp:148:5:148:7 | *str [string] | test.cpp:199:17:199:19 | *str [string] |
+| test.cpp:148:5:148:7 | *str [string] | test.cpp:203:17:203:19 | *str [string] |
+| test.cpp:148:5:148:7 | *str [string] | test.cpp:207:17:207:19 | *str [string] |
+| test.cpp:152:13:152:15 | *str [string] | test.cpp:152:18:152:23 | string |
+| test.cpp:154:13:154:15 | *str [string] | test.cpp:154:18:154:23 | string |
+| test.cpp:156:13:156:15 | *str [string] | test.cpp:156:18:156:23 | string |
+| test.cpp:175:17:175:19 | *str [string] | test.cpp:175:22:175:27 | string |
+| test.cpp:187:17:187:19 | *str [string] | test.cpp:187:22:187:27 | string |
+| test.cpp:195:17:195:19 | *str [string] | test.cpp:195:22:195:27 | string |
+| test.cpp:199:17:199:19 | *str [string] | test.cpp:199:22:199:27 | string |
+| test.cpp:203:17:203:19 | *str [string] | test.cpp:203:22:203:27 | string |
+| test.cpp:207:17:207:19 | *str [string] | test.cpp:207:22:207:27 | string |
 | test.cpp:214:24:214:24 | p | test.cpp:216:10:216:10 | p |
 | test.cpp:220:27:220:54 | call to malloc | test.cpp:222:15:222:20 | buffer |
 | test.cpp:222:15:222:20 | buffer | test.cpp:214:24:214:24 | p |
 | test.cpp:228:27:228:54 | call to malloc | test.cpp:232:10:232:15 | buffer |
 | test.cpp:235:40:235:45 | buffer | test.cpp:236:5:236:26 | ... = ... |
-| test.cpp:236:5:236:26 | ... = ... | test.cpp:236:5:236:9 | p_str indirection [post update] [string] |
+| test.cpp:236:5:236:26 | ... = ... | test.cpp:236:5:236:9 | *p_str [post update] [string] |
 | test.cpp:241:20:241:38 | call to malloc | test.cpp:242:22:242:27 | buffer |
-| test.cpp:242:16:242:19 | set_string output argument [string] | test.cpp:243:12:243:14 | str indirection [string] |
+| test.cpp:242:16:242:19 | set_string output argument [string] | test.cpp:243:12:243:14 | *str [string] |
 | test.cpp:242:22:242:27 | buffer | test.cpp:235:40:235:45 | buffer |
 | test.cpp:242:22:242:27 | buffer | test.cpp:242:16:242:19 | set_string output argument [string] |
-| test.cpp:243:12:243:14 | str indirection [string] | test.cpp:243:12:243:21 | string |
+| test.cpp:243:12:243:14 | *str [string] | test.cpp:243:12:243:21 | string |
 | test.cpp:249:14:249:33 | call to my_alloc | test.cpp:250:12:250:12 | p |
 | test.cpp:256:9:256:25 | call to malloc | test.cpp:257:12:257:12 | p |
 | test.cpp:262:15:262:30 | call to malloc | test.cpp:266:12:266:12 | p |
 | test.cpp:264:13:264:30 | call to malloc | test.cpp:266:12:266:12 | p |
 nodes
-| test.cpp:16:11:16:21 | mk_string_t indirection [string] | semmle.label | mk_string_t indirection [string] |
-| test.cpp:18:5:18:7 | str indirection [post update] [string] | semmle.label | str indirection [post update] [string] |
+| test.cpp:16:11:16:21 | **mk_string_t [string] | semmle.label | **mk_string_t [string] |
+| test.cpp:18:5:18:7 | *str [post update] [string] | semmle.label | *str [post update] [string] |
 | test.cpp:18:5:18:30 | ... = ... | semmle.label | ... = ... |
 | test.cpp:18:19:18:24 | call to malloc | semmle.label | call to malloc |
-| test.cpp:19:5:19:7 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:39:21:39:31 | call to mk_string_t indirection [string] | semmle.label | call to mk_string_t indirection [string] |
-| test.cpp:42:13:42:15 | str indirection [string] | semmle.label | str indirection [string] |
+| test.cpp:19:5:19:7 | *str [string] | semmle.label | *str [string] |
+| test.cpp:39:21:39:31 | *call to mk_string_t [string] | semmle.label | *call to mk_string_t [string] |
+| test.cpp:42:13:42:15 | *str [string] | semmle.label | *str [string] |
 | test.cpp:42:18:42:23 | string | semmle.label | string |
-| test.cpp:72:17:72:19 | str indirection [string] | semmle.label | str indirection [string] |
+| test.cpp:72:17:72:19 | *str [string] | semmle.label | *str [string] |
 | test.cpp:72:22:72:27 | string | semmle.label | string |
-| test.cpp:80:17:80:19 | str indirection [string] | semmle.label | str indirection [string] |
+| test.cpp:80:17:80:19 | *str [string] | semmle.label | *str [string] |
 | test.cpp:80:22:80:27 | string | semmle.label | string |
-| test.cpp:88:11:88:30 | mk_string_t_plus_one indirection [string] | semmle.label | mk_string_t_plus_one indirection [string] |
-| test.cpp:90:5:90:7 | str indirection [post update] [string] | semmle.label | str indirection [post update] [string] |
+| test.cpp:88:11:88:30 | **mk_string_t_plus_one [string] | semmle.label | **mk_string_t_plus_one [string] |
+| test.cpp:90:5:90:7 | *str [post update] [string] | semmle.label | *str [post update] [string] |
 | test.cpp:90:5:90:34 | ... = ... | semmle.label | ... = ... |
 | test.cpp:90:19:90:24 | call to malloc | semmle.label | call to malloc |
-| test.cpp:91:5:91:7 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:96:21:96:40 | call to mk_string_t_plus_one indirection [string] | semmle.label | call to mk_string_t_plus_one indirection [string] |
-| test.cpp:99:13:99:15 | str indirection [string] | semmle.label | str indirection [string] |
+| test.cpp:91:5:91:7 | *str [string] | semmle.label | *str [string] |
+| test.cpp:96:21:96:40 | *call to mk_string_t_plus_one [string] | semmle.label | *call to mk_string_t_plus_one [string] |
+| test.cpp:99:13:99:15 | *str [string] | semmle.label | *str [string] |
 | test.cpp:99:18:99:23 | string | semmle.label | string |
-| test.cpp:129:17:129:19 | str indirection [string] | semmle.label | str indirection [string] |
+| test.cpp:129:17:129:19 | *str [string] | semmle.label | *str [string] |
 | test.cpp:129:22:129:27 | string | semmle.label | string |
-| test.cpp:137:17:137:19 | str indirection [string] | semmle.label | str indirection [string] |
+| test.cpp:137:17:137:19 | *str [string] | semmle.label | *str [string] |
 | test.cpp:137:22:137:27 | string | semmle.label | string |
-| test.cpp:147:5:147:7 | str indirection [post update] [string] | semmle.label | str indirection [post update] [string] |
+| test.cpp:147:5:147:7 | *str [post update] [string] | semmle.label | *str [post update] [string] |
 | test.cpp:147:5:147:34 | ... = ... | semmle.label | ... = ... |
 | test.cpp:147:19:147:24 | call to malloc | semmle.label | call to malloc |
-| test.cpp:148:5:148:7 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:152:13:152:15 | str indirection [string] | semmle.label | str indirection [string] |
+| test.cpp:148:5:148:7 | *str [string] | semmle.label | *str [string] |
+| test.cpp:152:13:152:15 | *str [string] | semmle.label | *str [string] |
 | test.cpp:152:18:152:23 | string | semmle.label | string |
-| test.cpp:154:13:154:15 | str indirection [string] | semmle.label | str indirection [string] |
+| test.cpp:154:13:154:15 | *str [string] | semmle.label | *str [string] |
 | test.cpp:154:18:154:23 | string | semmle.label | string |
-| test.cpp:156:13:156:15 | str indirection [string] | semmle.label | str indirection [string] |
+| test.cpp:156:13:156:15 | *str [string] | semmle.label | *str [string] |
 | test.cpp:156:18:156:23 | string | semmle.label | string |
-| test.cpp:175:17:175:19 | str indirection [string] | semmle.label | str indirection [string] |
+| test.cpp:175:17:175:19 | *str [string] | semmle.label | *str [string] |
 | test.cpp:175:22:175:27 | string | semmle.label | string |
-| test.cpp:187:17:187:19 | str indirection [string] | semmle.label | str indirection [string] |
+| test.cpp:187:17:187:19 | *str [string] | semmle.label | *str [string] |
 | test.cpp:187:22:187:27 | string | semmle.label | string |
-| test.cpp:195:17:195:19 | str indirection [string] | semmle.label | str indirection [string] |
+| test.cpp:195:17:195:19 | *str [string] | semmle.label | *str [string] |
 | test.cpp:195:22:195:27 | string | semmle.label | string |
-| test.cpp:199:17:199:19 | str indirection [string] | semmle.label | str indirection [string] |
+| test.cpp:199:17:199:19 | *str [string] | semmle.label | *str [string] |
 | test.cpp:199:22:199:27 | string | semmle.label | string |
-| test.cpp:203:17:203:19 | str indirection [string] | semmle.label | str indirection [string] |
+| test.cpp:203:17:203:19 | *str [string] | semmle.label | *str [string] |
 | test.cpp:203:22:203:27 | string | semmle.label | string |
-| test.cpp:207:17:207:19 | str indirection [string] | semmle.label | str indirection [string] |
+| test.cpp:207:17:207:19 | *str [string] | semmle.label | *str [string] |
 | test.cpp:207:22:207:27 | string | semmle.label | string |
 | test.cpp:214:24:214:24 | p | semmle.label | p |
 | test.cpp:216:10:216:10 | p | semmle.label | p |
@@ -111,12 +111,12 @@ nodes
 | test.cpp:228:27:228:54 | call to malloc | semmle.label | call to malloc |
 | test.cpp:232:10:232:15 | buffer | semmle.label | buffer |
 | test.cpp:235:40:235:45 | buffer | semmle.label | buffer |
-| test.cpp:236:5:236:9 | p_str indirection [post update] [string] | semmle.label | p_str indirection [post update] [string] |
+| test.cpp:236:5:236:9 | *p_str [post update] [string] | semmle.label | *p_str [post update] [string] |
 | test.cpp:236:5:236:26 | ... = ... | semmle.label | ... = ... |
 | test.cpp:241:20:241:38 | call to malloc | semmle.label | call to malloc |
 | test.cpp:242:16:242:19 | set_string output argument [string] | semmle.label | set_string output argument [string] |
 | test.cpp:242:22:242:27 | buffer | semmle.label | buffer |
-| test.cpp:243:12:243:14 | str indirection [string] | semmle.label | str indirection [string] |
+| test.cpp:243:12:243:14 | *str [string] | semmle.label | *str [string] |
 | test.cpp:243:12:243:21 | string | semmle.label | string |
 | test.cpp:249:14:249:33 | call to my_alloc | semmle.label | call to my_alloc |
 | test.cpp:250:12:250:12 | p | semmle.label | p |
@@ -126,7 +126,7 @@ nodes
 | test.cpp:264:13:264:30 | call to malloc | semmle.label | call to malloc |
 | test.cpp:266:12:266:12 | p | semmle.label | p |
 subpaths
-| test.cpp:242:22:242:27 | buffer | test.cpp:235:40:235:45 | buffer | test.cpp:236:5:236:9 | p_str indirection [post update] [string] | test.cpp:242:16:242:19 | set_string output argument [string] |
+| test.cpp:242:22:242:27 | buffer | test.cpp:235:40:235:45 | buffer | test.cpp:236:5:236:9 | *p_str [post update] [string] | test.cpp:242:16:242:19 | set_string output argument [string] |
 #select
 | test.cpp:42:5:42:11 | call to strncpy | test.cpp:18:19:18:24 | call to malloc | test.cpp:42:18:42:23 | string | This write may overflow $@ by 1 element. | test.cpp:42:18:42:23 | string | string |
 | test.cpp:72:9:72:15 | call to strncpy | test.cpp:18:19:18:24 | call to malloc | test.cpp:72:22:72:27 | string | This write may overflow $@ by 1 element. | test.cpp:72:22:72:27 | string | string |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/OverflowDestination.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/OverflowDestination.expected
@@ -1,42 +1,42 @@
 edges
-| main.cpp:6:27:6:30 | argv indirection | main.cpp:7:33:7:36 | argv indirection |
-| main.cpp:7:33:7:36 | argv indirection | overflowdestination.cpp:23:45:23:48 | argv indirection |
-| overflowdestination.cpp:23:45:23:48 | argv indirection | overflowdestination.cpp:30:17:30:20 | arg1 indirection |
-| overflowdestination.cpp:43:8:43:10 | fgets output argument | overflowdestination.cpp:46:15:46:17 | src indirection |
-| overflowdestination.cpp:50:52:50:54 | src indirection | overflowdestination.cpp:53:9:53:12 | memcpy output argument |
-| overflowdestination.cpp:50:52:50:54 | src indirection | overflowdestination.cpp:53:15:53:17 | src indirection |
-| overflowdestination.cpp:50:52:50:54 | src indirection | overflowdestination.cpp:54:9:54:12 | memcpy output argument |
+| main.cpp:6:27:6:30 | **argv | main.cpp:7:33:7:36 | **argv |
+| main.cpp:7:33:7:36 | **argv | overflowdestination.cpp:23:45:23:48 | **argv |
+| overflowdestination.cpp:23:45:23:48 | **argv | overflowdestination.cpp:30:17:30:20 | *arg1 |
+| overflowdestination.cpp:43:8:43:10 | fgets output argument | overflowdestination.cpp:46:15:46:17 | *src |
+| overflowdestination.cpp:50:52:50:54 | *src | overflowdestination.cpp:53:9:53:12 | memcpy output argument |
+| overflowdestination.cpp:50:52:50:54 | *src | overflowdestination.cpp:53:15:53:17 | *src |
+| overflowdestination.cpp:50:52:50:54 | *src | overflowdestination.cpp:54:9:54:12 | memcpy output argument |
 | overflowdestination.cpp:53:9:53:12 | memcpy output argument | overflowdestination.cpp:54:9:54:12 | memcpy output argument |
 | overflowdestination.cpp:54:9:54:12 | memcpy output argument | overflowdestination.cpp:54:9:54:12 | memcpy output argument |
-| overflowdestination.cpp:57:52:57:54 | src indirection | overflowdestination.cpp:64:16:64:19 | src2 indirection |
-| overflowdestination.cpp:73:8:73:10 | fgets output argument | overflowdestination.cpp:75:30:75:32 | src indirection |
-| overflowdestination.cpp:73:8:73:10 | fgets output argument | overflowdestination.cpp:76:30:76:32 | src indirection |
-| overflowdestination.cpp:75:30:75:32 | overflowdest_test2 output argument | overflowdestination.cpp:76:30:76:32 | src indirection |
-| overflowdestination.cpp:75:30:75:32 | src indirection | overflowdestination.cpp:50:52:50:54 | src indirection |
-| overflowdestination.cpp:75:30:75:32 | src indirection | overflowdestination.cpp:75:30:75:32 | overflowdest_test2 output argument |
-| overflowdestination.cpp:76:30:76:32 | src indirection | overflowdestination.cpp:57:52:57:54 | src indirection |
+| overflowdestination.cpp:57:52:57:54 | *src | overflowdestination.cpp:64:16:64:19 | *src2 |
+| overflowdestination.cpp:73:8:73:10 | fgets output argument | overflowdestination.cpp:75:30:75:32 | *src |
+| overflowdestination.cpp:73:8:73:10 | fgets output argument | overflowdestination.cpp:76:30:76:32 | *src |
+| overflowdestination.cpp:75:30:75:32 | *src | overflowdestination.cpp:50:52:50:54 | *src |
+| overflowdestination.cpp:75:30:75:32 | *src | overflowdestination.cpp:75:30:75:32 | overflowdest_test2 output argument |
+| overflowdestination.cpp:75:30:75:32 | overflowdest_test2 output argument | overflowdestination.cpp:76:30:76:32 | *src |
+| overflowdestination.cpp:76:30:76:32 | *src | overflowdestination.cpp:57:52:57:54 | *src |
 nodes
-| main.cpp:6:27:6:30 | argv indirection | semmle.label | argv indirection |
-| main.cpp:7:33:7:36 | argv indirection | semmle.label | argv indirection |
-| overflowdestination.cpp:23:45:23:48 | argv indirection | semmle.label | argv indirection |
-| overflowdestination.cpp:30:17:30:20 | arg1 indirection | semmle.label | arg1 indirection |
+| main.cpp:6:27:6:30 | **argv | semmle.label | **argv |
+| main.cpp:7:33:7:36 | **argv | semmle.label | **argv |
+| overflowdestination.cpp:23:45:23:48 | **argv | semmle.label | **argv |
+| overflowdestination.cpp:30:17:30:20 | *arg1 | semmle.label | *arg1 |
 | overflowdestination.cpp:43:8:43:10 | fgets output argument | semmle.label | fgets output argument |
-| overflowdestination.cpp:46:15:46:17 | src indirection | semmle.label | src indirection |
-| overflowdestination.cpp:50:52:50:54 | src indirection | semmle.label | src indirection |
+| overflowdestination.cpp:46:15:46:17 | *src | semmle.label | *src |
+| overflowdestination.cpp:50:52:50:54 | *src | semmle.label | *src |
 | overflowdestination.cpp:53:9:53:12 | memcpy output argument | semmle.label | memcpy output argument |
-| overflowdestination.cpp:53:15:53:17 | src indirection | semmle.label | src indirection |
+| overflowdestination.cpp:53:15:53:17 | *src | semmle.label | *src |
 | overflowdestination.cpp:54:9:54:12 | memcpy output argument | semmle.label | memcpy output argument |
-| overflowdestination.cpp:57:52:57:54 | src indirection | semmle.label | src indirection |
-| overflowdestination.cpp:64:16:64:19 | src2 indirection | semmle.label | src2 indirection |
+| overflowdestination.cpp:57:52:57:54 | *src | semmle.label | *src |
+| overflowdestination.cpp:64:16:64:19 | *src2 | semmle.label | *src2 |
 | overflowdestination.cpp:73:8:73:10 | fgets output argument | semmle.label | fgets output argument |
+| overflowdestination.cpp:75:30:75:32 | *src | semmle.label | *src |
 | overflowdestination.cpp:75:30:75:32 | overflowdest_test2 output argument | semmle.label | overflowdest_test2 output argument |
-| overflowdestination.cpp:75:30:75:32 | src indirection | semmle.label | src indirection |
-| overflowdestination.cpp:76:30:76:32 | src indirection | semmle.label | src indirection |
+| overflowdestination.cpp:76:30:76:32 | *src | semmle.label | *src |
 subpaths
-| overflowdestination.cpp:75:30:75:32 | src indirection | overflowdestination.cpp:50:52:50:54 | src indirection | overflowdestination.cpp:53:9:53:12 | memcpy output argument | overflowdestination.cpp:75:30:75:32 | overflowdest_test2 output argument |
-| overflowdestination.cpp:75:30:75:32 | src indirection | overflowdestination.cpp:50:52:50:54 | src indirection | overflowdestination.cpp:54:9:54:12 | memcpy output argument | overflowdestination.cpp:75:30:75:32 | overflowdest_test2 output argument |
+| overflowdestination.cpp:75:30:75:32 | *src | overflowdestination.cpp:50:52:50:54 | *src | overflowdestination.cpp:53:9:53:12 | memcpy output argument | overflowdestination.cpp:75:30:75:32 | overflowdest_test2 output argument |
+| overflowdestination.cpp:75:30:75:32 | *src | overflowdestination.cpp:50:52:50:54 | *src | overflowdestination.cpp:54:9:54:12 | memcpy output argument | overflowdestination.cpp:75:30:75:32 | overflowdest_test2 output argument |
 #select
-| overflowdestination.cpp:30:2:30:8 | call to strncpy | main.cpp:6:27:6:30 | argv indirection | overflowdestination.cpp:30:17:30:20 | arg1 indirection | To avoid overflow, this operation should be bounded by destination-buffer size, not source-buffer size. |
-| overflowdestination.cpp:46:2:46:7 | call to memcpy | overflowdestination.cpp:43:8:43:10 | fgets output argument | overflowdestination.cpp:46:15:46:17 | src indirection | To avoid overflow, this operation should be bounded by destination-buffer size, not source-buffer size. |
-| overflowdestination.cpp:53:2:53:7 | call to memcpy | overflowdestination.cpp:73:8:73:10 | fgets output argument | overflowdestination.cpp:53:15:53:17 | src indirection | To avoid overflow, this operation should be bounded by destination-buffer size, not source-buffer size. |
-| overflowdestination.cpp:64:2:64:7 | call to memcpy | overflowdestination.cpp:73:8:73:10 | fgets output argument | overflowdestination.cpp:64:16:64:19 | src2 indirection | To avoid overflow, this operation should be bounded by destination-buffer size, not source-buffer size. |
+| overflowdestination.cpp:30:2:30:8 | call to strncpy | main.cpp:6:27:6:30 | **argv | overflowdestination.cpp:30:17:30:20 | *arg1 | To avoid overflow, this operation should be bounded by destination-buffer size, not source-buffer size. |
+| overflowdestination.cpp:46:2:46:7 | call to memcpy | overflowdestination.cpp:43:8:43:10 | fgets output argument | overflowdestination.cpp:46:15:46:17 | *src | To avoid overflow, this operation should be bounded by destination-buffer size, not source-buffer size. |
+| overflowdestination.cpp:53:2:53:7 | call to memcpy | overflowdestination.cpp:73:8:73:10 | fgets output argument | overflowdestination.cpp:53:15:53:17 | *src | To avoid overflow, this operation should be bounded by destination-buffer size, not source-buffer size. |
+| overflowdestination.cpp:64:2:64:7 | call to memcpy | overflowdestination.cpp:73:8:73:10 | fgets output argument | overflowdestination.cpp:64:16:64:19 | *src2 | To avoid overflow, this operation should be bounded by destination-buffer size, not source-buffer size. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/UnboundedWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/UnboundedWrite.expected
@@ -1,32 +1,32 @@
 edges
-| main.cpp:6:27:6:30 | argv indirection | main.cpp:10:20:10:23 | argv indirection |
-| main.cpp:10:20:10:23 | argv indirection | tests.cpp:657:32:657:35 | argv indirection |
-| tests.cpp:613:19:613:24 | source indirection | tests.cpp:615:17:615:22 | source indirection |
-| tests.cpp:622:19:622:24 | source indirection | tests.cpp:625:2:625:16 | ... = ... indirection |
-| tests.cpp:625:2:625:2 | s indirection [post update] [home indirection] | tests.cpp:628:14:628:14 | s indirection [home indirection] |
-| tests.cpp:625:2:625:16 | ... = ... indirection | tests.cpp:625:2:625:2 | s indirection [post update] [home indirection] |
-| tests.cpp:628:14:628:14 | s indirection [home indirection] | tests.cpp:628:14:628:19 | home indirection |
-| tests.cpp:628:14:628:14 | s indirection [home indirection] | tests.cpp:628:16:628:19 | home indirection |
-| tests.cpp:628:16:628:19 | home indirection | tests.cpp:628:14:628:19 | home indirection |
-| tests.cpp:657:32:657:35 | argv indirection | tests.cpp:682:9:682:15 | access to array indirection |
-| tests.cpp:657:32:657:35 | argv indirection | tests.cpp:683:9:683:15 | access to array indirection |
-| tests.cpp:682:9:682:15 | access to array indirection | tests.cpp:613:19:613:24 | source indirection |
-| tests.cpp:683:9:683:15 | access to array indirection | tests.cpp:622:19:622:24 | source indirection |
+| main.cpp:6:27:6:30 | **argv | main.cpp:10:20:10:23 | **argv |
+| main.cpp:10:20:10:23 | **argv | tests.cpp:657:32:657:35 | **argv |
+| tests.cpp:613:19:613:24 | *source | tests.cpp:615:17:615:22 | *source |
+| tests.cpp:622:19:622:24 | *source | tests.cpp:625:2:625:16 | *... = ... |
+| tests.cpp:625:2:625:2 | *s [post update] [*home] | tests.cpp:628:14:628:14 | *s [*home] |
+| tests.cpp:625:2:625:16 | *... = ... | tests.cpp:625:2:625:2 | *s [post update] [*home] |
+| tests.cpp:628:14:628:14 | *s [*home] | tests.cpp:628:14:628:19 | *home |
+| tests.cpp:628:14:628:14 | *s [*home] | tests.cpp:628:16:628:19 | *home |
+| tests.cpp:628:16:628:19 | *home | tests.cpp:628:14:628:19 | *home |
+| tests.cpp:657:32:657:35 | **argv | tests.cpp:682:9:682:15 | *access to array |
+| tests.cpp:657:32:657:35 | **argv | tests.cpp:683:9:683:15 | *access to array |
+| tests.cpp:682:9:682:15 | *access to array | tests.cpp:613:19:613:24 | *source |
+| tests.cpp:683:9:683:15 | *access to array | tests.cpp:622:19:622:24 | *source |
 nodes
-| main.cpp:6:27:6:30 | argv indirection | semmle.label | argv indirection |
-| main.cpp:10:20:10:23 | argv indirection | semmle.label | argv indirection |
-| tests.cpp:613:19:613:24 | source indirection | semmle.label | source indirection |
-| tests.cpp:615:17:615:22 | source indirection | semmle.label | source indirection |
-| tests.cpp:622:19:622:24 | source indirection | semmle.label | source indirection |
-| tests.cpp:625:2:625:2 | s indirection [post update] [home indirection] | semmle.label | s indirection [post update] [home indirection] |
-| tests.cpp:625:2:625:16 | ... = ... indirection | semmle.label | ... = ... indirection |
-| tests.cpp:628:14:628:14 | s indirection [home indirection] | semmle.label | s indirection [home indirection] |
-| tests.cpp:628:14:628:19 | home indirection | semmle.label | home indirection |
-| tests.cpp:628:16:628:19 | home indirection | semmle.label | home indirection |
-| tests.cpp:657:32:657:35 | argv indirection | semmle.label | argv indirection |
-| tests.cpp:682:9:682:15 | access to array indirection | semmle.label | access to array indirection |
-| tests.cpp:683:9:683:15 | access to array indirection | semmle.label | access to array indirection |
+| main.cpp:6:27:6:30 | **argv | semmle.label | **argv |
+| main.cpp:10:20:10:23 | **argv | semmle.label | **argv |
+| tests.cpp:613:19:613:24 | *source | semmle.label | *source |
+| tests.cpp:615:17:615:22 | *source | semmle.label | *source |
+| tests.cpp:622:19:622:24 | *source | semmle.label | *source |
+| tests.cpp:625:2:625:2 | *s [post update] [*home] | semmle.label | *s [post update] [*home] |
+| tests.cpp:625:2:625:16 | *... = ... | semmle.label | *... = ... |
+| tests.cpp:628:14:628:14 | *s [*home] | semmle.label | *s [*home] |
+| tests.cpp:628:14:628:19 | *home | semmle.label | *home |
+| tests.cpp:628:16:628:19 | *home | semmle.label | *home |
+| tests.cpp:657:32:657:35 | **argv | semmle.label | **argv |
+| tests.cpp:682:9:682:15 | *access to array | semmle.label | *access to array |
+| tests.cpp:683:9:683:15 | *access to array | semmle.label | *access to array |
 subpaths
 #select
-| tests.cpp:615:2:615:7 | call to strcpy | main.cpp:6:27:6:30 | argv indirection | tests.cpp:615:17:615:22 | source indirection | This 'call to strcpy' with input from $@ may overflow the destination. | main.cpp:6:27:6:30 | argv indirection | a command-line argument |
-| tests.cpp:628:2:628:7 | call to strcpy | main.cpp:6:27:6:30 | argv indirection | tests.cpp:628:14:628:19 | home indirection | This 'call to strcpy' with input from $@ may overflow the destination. | main.cpp:6:27:6:30 | argv indirection | a command-line argument |
+| tests.cpp:615:2:615:7 | call to strcpy | main.cpp:6:27:6:30 | **argv | tests.cpp:615:17:615:22 | *source | This 'call to strcpy' with input from $@ may overflow the destination. | main.cpp:6:27:6:30 | **argv | a command-line argument |
+| tests.cpp:628:2:628:7 | call to strcpy | main.cpp:6:27:6:30 | **argv | tests.cpp:628:14:628:19 | *home | This 'call to strcpy' with input from $@ may overflow the destination. | main.cpp:6:27:6:30 | **argv | a command-line argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-120/semmle/tests/UnboundedWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-120/semmle/tests/UnboundedWrite.expected
@@ -1,18 +1,18 @@
 edges
-| tests.c:16:26:16:29 | argv indirection | tests.c:28:22:28:28 | access to array indirection |
-| tests.c:16:26:16:29 | argv indirection | tests.c:29:28:29:34 | access to array indirection |
-| tests.c:16:26:16:29 | argv indirection | tests.c:34:10:34:16 | access to array indirection |
+| tests.c:16:26:16:29 | **argv | tests.c:28:22:28:28 | *access to array |
+| tests.c:16:26:16:29 | **argv | tests.c:29:28:29:34 | *access to array |
+| tests.c:16:26:16:29 | **argv | tests.c:34:10:34:16 | *access to array |
 nodes
-| tests.c:16:26:16:29 | argv indirection | semmle.label | argv indirection |
-| tests.c:28:22:28:28 | access to array indirection | semmle.label | access to array indirection |
-| tests.c:29:28:29:34 | access to array indirection | semmle.label | access to array indirection |
+| tests.c:16:26:16:29 | **argv | semmle.label | **argv |
+| tests.c:28:22:28:28 | *access to array | semmle.label | *access to array |
+| tests.c:29:28:29:34 | *access to array | semmle.label | *access to array |
 | tests.c:31:15:31:23 | scanf output argument | semmle.label | scanf output argument |
 | tests.c:33:21:33:29 | scanf output argument | semmle.label | scanf output argument |
-| tests.c:34:10:34:16 | access to array indirection | semmle.label | access to array indirection |
+| tests.c:34:10:34:16 | *access to array | semmle.label | *access to array |
 subpaths
 #select
-| tests.c:28:3:28:9 | call to sprintf | tests.c:16:26:16:29 | argv indirection | tests.c:28:22:28:28 | access to array indirection | This 'call to sprintf' with input from $@ may overflow the destination. | tests.c:16:26:16:29 | argv indirection | a command-line argument |
-| tests.c:29:3:29:9 | call to sprintf | tests.c:16:26:16:29 | argv indirection | tests.c:29:28:29:34 | access to array indirection | This 'call to sprintf' with input from $@ may overflow the destination. | tests.c:16:26:16:29 | argv indirection | a command-line argument |
+| tests.c:28:3:28:9 | call to sprintf | tests.c:16:26:16:29 | **argv | tests.c:28:22:28:28 | *access to array | This 'call to sprintf' with input from $@ may overflow the destination. | tests.c:16:26:16:29 | **argv | a command-line argument |
+| tests.c:29:3:29:9 | call to sprintf | tests.c:16:26:16:29 | **argv | tests.c:29:28:29:34 | *access to array | This 'call to sprintf' with input from $@ may overflow the destination. | tests.c:16:26:16:29 | **argv | a command-line argument |
 | tests.c:31:15:31:23 | buffer100 | tests.c:31:15:31:23 | scanf output argument | tests.c:31:15:31:23 | scanf output argument | This 'scanf string argument' with input from $@ may overflow the destination. | tests.c:31:15:31:23 | scanf output argument | value read by scanf |
 | tests.c:33:21:33:29 | buffer100 | tests.c:33:21:33:29 | scanf output argument | tests.c:33:21:33:29 | scanf output argument | This 'scanf string argument' with input from $@ may overflow the destination. | tests.c:33:21:33:29 | scanf output argument | value read by scanf |
-| tests.c:34:25:34:33 | buffer100 | tests.c:16:26:16:29 | argv indirection | tests.c:34:10:34:16 | access to array indirection | This 'sscanf string argument' with input from $@ may overflow the destination. | tests.c:16:26:16:29 | argv indirection | a command-line argument |
+| tests.c:34:25:34:33 | buffer100 | tests.c:16:26:16:29 | **argv | tests.c:34:10:34:16 | *access to array | This 'sscanf string argument' with input from $@ may overflow the destination. | tests.c:16:26:16:29 | **argv | a command-line argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/ImproperArrayIndexValidation.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/ImproperArrayIndexValidation.expected
@@ -1,7 +1,7 @@
 edges
-| test1.c:7:26:7:29 | argv indirection | test1.c:9:9:9:9 | i |
-| test1.c:7:26:7:29 | argv indirection | test1.c:11:9:11:9 | i |
-| test1.c:7:26:7:29 | argv indirection | test1.c:13:9:13:9 | i |
+| test1.c:7:26:7:29 | **argv | test1.c:9:9:9:9 | i |
+| test1.c:7:26:7:29 | **argv | test1.c:11:9:11:9 | i |
+| test1.c:7:26:7:29 | **argv | test1.c:13:9:13:9 | i |
 | test1.c:9:9:9:9 | i | test1.c:16:16:16:16 | i |
 | test1.c:11:9:11:9 | i | test1.c:32:16:32:16 | i |
 | test1.c:13:9:13:9 | i | test1.c:48:16:48:16 | i |
@@ -9,7 +9,7 @@ edges
 | test1.c:32:16:32:16 | i | test1.c:33:11:33:11 | i |
 | test1.c:48:16:48:16 | i | test1.c:53:15:53:15 | j |
 nodes
-| test1.c:7:26:7:29 | argv indirection | semmle.label | argv indirection |
+| test1.c:7:26:7:29 | **argv | semmle.label | **argv |
 | test1.c:9:9:9:9 | i | semmle.label | i |
 | test1.c:11:9:11:9 | i | semmle.label | i |
 | test1.c:13:9:13:9 | i | semmle.label | i |
@@ -21,6 +21,6 @@ nodes
 | test1.c:53:15:53:15 | j | semmle.label | j |
 subpaths
 #select
-| test1.c:18:16:18:16 | i | test1.c:7:26:7:29 | argv indirection | test1.c:18:16:18:16 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | argv indirection | a command-line argument |
-| test1.c:33:11:33:11 | i | test1.c:7:26:7:29 | argv indirection | test1.c:33:11:33:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | argv indirection | a command-line argument |
-| test1.c:53:15:53:15 | j | test1.c:7:26:7:29 | argv indirection | test1.c:53:15:53:15 | j | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | argv indirection | a command-line argument |
+| test1.c:18:16:18:16 | i | test1.c:7:26:7:29 | **argv | test1.c:18:16:18:16 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
+| test1.c:33:11:33:11 | i | test1.c:7:26:7:29 | **argv | test1.c:33:11:33:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
+| test1.c:53:15:53:15 | j | test1.c:7:26:7:29 | **argv | test1.c:53:15:53:15 | j | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-134/SAMATE/UncontrolledFormatString.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-134/SAMATE/UncontrolledFormatString.expected
@@ -1,16 +1,16 @@
 edges
-| char_connect_socket_w32_vsnprintf_01_bad.c:94:46:94:69 | recv output argument | char_connect_socket_w32_vsnprintf_01_bad.c:125:15:125:18 | data indirection |
-| char_console_fprintf_01_bad.c:30:23:30:35 | fgets output argument | char_console_fprintf_01_bad.c:49:21:49:24 | data indirection |
-| char_environment_fprintf_01_bad.c:27:30:27:35 | call to getenv indirection | char_environment_fprintf_01_bad.c:36:21:36:24 | data indirection |
+| char_connect_socket_w32_vsnprintf_01_bad.c:94:46:94:69 | recv output argument | char_connect_socket_w32_vsnprintf_01_bad.c:125:15:125:18 | *data |
+| char_console_fprintf_01_bad.c:30:23:30:35 | fgets output argument | char_console_fprintf_01_bad.c:49:21:49:24 | *data |
+| char_environment_fprintf_01_bad.c:27:30:27:35 | *call to getenv | char_environment_fprintf_01_bad.c:36:21:36:24 | *data |
 nodes
 | char_connect_socket_w32_vsnprintf_01_bad.c:94:46:94:69 | recv output argument | semmle.label | recv output argument |
-| char_connect_socket_w32_vsnprintf_01_bad.c:125:15:125:18 | data indirection | semmle.label | data indirection |
+| char_connect_socket_w32_vsnprintf_01_bad.c:125:15:125:18 | *data | semmle.label | *data |
 | char_console_fprintf_01_bad.c:30:23:30:35 | fgets output argument | semmle.label | fgets output argument |
-| char_console_fprintf_01_bad.c:49:21:49:24 | data indirection | semmle.label | data indirection |
-| char_environment_fprintf_01_bad.c:27:30:27:35 | call to getenv indirection | semmle.label | call to getenv indirection |
-| char_environment_fprintf_01_bad.c:36:21:36:24 | data indirection | semmle.label | data indirection |
+| char_console_fprintf_01_bad.c:49:21:49:24 | *data | semmle.label | *data |
+| char_environment_fprintf_01_bad.c:27:30:27:35 | *call to getenv | semmle.label | *call to getenv |
+| char_environment_fprintf_01_bad.c:36:21:36:24 | *data | semmle.label | *data |
 subpaths
 #select
-| char_connect_socket_w32_vsnprintf_01_bad.c:125:15:125:18 | data indirection | char_connect_socket_w32_vsnprintf_01_bad.c:94:46:94:69 | recv output argument | char_connect_socket_w32_vsnprintf_01_bad.c:125:15:125:18 | data indirection | The value of this argument may come from $@ and is being used as a formatting argument to badVaSink(data), which calls vsnprintf(format). | char_connect_socket_w32_vsnprintf_01_bad.c:94:46:94:69 | recv output argument | buffer read by recv |
-| char_console_fprintf_01_bad.c:49:21:49:24 | data indirection | char_console_fprintf_01_bad.c:30:23:30:35 | fgets output argument | char_console_fprintf_01_bad.c:49:21:49:24 | data indirection | The value of this argument may come from $@ and is being used as a formatting argument to fprintf(format). | char_console_fprintf_01_bad.c:30:23:30:35 | fgets output argument | string read by fgets |
-| char_environment_fprintf_01_bad.c:36:21:36:24 | data indirection | char_environment_fprintf_01_bad.c:27:30:27:35 | call to getenv indirection | char_environment_fprintf_01_bad.c:36:21:36:24 | data indirection | The value of this argument may come from $@ and is being used as a formatting argument to fprintf(format). | char_environment_fprintf_01_bad.c:27:30:27:35 | call to getenv indirection | an environment variable |
+| char_connect_socket_w32_vsnprintf_01_bad.c:125:15:125:18 | *data | char_connect_socket_w32_vsnprintf_01_bad.c:94:46:94:69 | recv output argument | char_connect_socket_w32_vsnprintf_01_bad.c:125:15:125:18 | *data | The value of this argument may come from $@ and is being used as a formatting argument to badVaSink(data), which calls vsnprintf(format). | char_connect_socket_w32_vsnprintf_01_bad.c:94:46:94:69 | recv output argument | buffer read by recv |
+| char_console_fprintf_01_bad.c:49:21:49:24 | *data | char_console_fprintf_01_bad.c:30:23:30:35 | fgets output argument | char_console_fprintf_01_bad.c:49:21:49:24 | *data | The value of this argument may come from $@ and is being used as a formatting argument to fprintf(format). | char_console_fprintf_01_bad.c:30:23:30:35 | fgets output argument | string read by fgets |
+| char_environment_fprintf_01_bad.c:36:21:36:24 | *data | char_environment_fprintf_01_bad.c:27:30:27:35 | *call to getenv | char_environment_fprintf_01_bad.c:36:21:36:24 | *data | The value of this argument may come from $@ and is being used as a formatting argument to fprintf(format). | char_environment_fprintf_01_bad.c:27:30:27:35 | *call to getenv | an environment variable |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/argv/argvLocal.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/argv/argvLocal.expected
@@ -1,77 +1,77 @@
 edges
-| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:95:9:95:15 | access to array indirection |
-| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:96:15:96:21 | access to array indirection |
-| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:101:9:101:10 | i1 indirection |
-| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:102:15:102:16 | i1 indirection |
-| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:106:9:106:13 | access to array indirection |
-| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:107:15:107:19 | access to array indirection |
-| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:110:9:110:11 | * ... indirection |
-| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:111:15:111:17 | * ... indirection |
-| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:116:9:116:10 | i3 indirection |
-| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:117:15:117:16 | i3 indirection |
-| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:121:9:121:10 | i4 indirection |
-| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:122:15:122:16 | i4 indirection |
-| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:127:9:127:10 | i5 indirection |
-| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:128:15:128:16 | i5 indirection |
-| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:131:9:131:14 | ... + ... indirection |
-| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:132:15:132:20 | ... + ... indirection |
-| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:135:9:135:12 | ... ++ indirection |
-| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:136:15:136:18 | -- ... indirection |
-| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:139:9:139:26 | ... ? ... : ... indirection |
-| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:140:15:140:32 | ... ? ... : ... indirection |
-| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:144:9:144:10 | i7 indirection |
-| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:145:15:145:16 | i7 indirection |
-| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:150:9:150:10 | i8 indirection |
-| argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:151:15:151:16 | i8 indirection |
+| argvLocal.c:13:27:13:30 | **argv | argvLocal.c:95:9:95:15 | *access to array |
+| argvLocal.c:13:27:13:30 | **argv | argvLocal.c:96:15:96:21 | *access to array |
+| argvLocal.c:13:27:13:30 | **argv | argvLocal.c:101:9:101:10 | *i1 |
+| argvLocal.c:13:27:13:30 | **argv | argvLocal.c:102:15:102:16 | *i1 |
+| argvLocal.c:13:27:13:30 | **argv | argvLocal.c:106:9:106:13 | *access to array |
+| argvLocal.c:13:27:13:30 | **argv | argvLocal.c:107:15:107:19 | *access to array |
+| argvLocal.c:13:27:13:30 | **argv | argvLocal.c:110:9:110:11 | ** ... |
+| argvLocal.c:13:27:13:30 | **argv | argvLocal.c:111:15:111:17 | ** ... |
+| argvLocal.c:13:27:13:30 | **argv | argvLocal.c:116:9:116:10 | *i3 |
+| argvLocal.c:13:27:13:30 | **argv | argvLocal.c:117:15:117:16 | *i3 |
+| argvLocal.c:13:27:13:30 | **argv | argvLocal.c:121:9:121:10 | *i4 |
+| argvLocal.c:13:27:13:30 | **argv | argvLocal.c:122:15:122:16 | *i4 |
+| argvLocal.c:13:27:13:30 | **argv | argvLocal.c:127:9:127:10 | *i5 |
+| argvLocal.c:13:27:13:30 | **argv | argvLocal.c:128:15:128:16 | *i5 |
+| argvLocal.c:13:27:13:30 | **argv | argvLocal.c:131:9:131:14 | *... + ... |
+| argvLocal.c:13:27:13:30 | **argv | argvLocal.c:132:15:132:20 | *... + ... |
+| argvLocal.c:13:27:13:30 | **argv | argvLocal.c:135:9:135:12 | *... ++ |
+| argvLocal.c:13:27:13:30 | **argv | argvLocal.c:136:15:136:18 | *-- ... |
+| argvLocal.c:13:27:13:30 | **argv | argvLocal.c:139:9:139:26 | *... ? ... : ... |
+| argvLocal.c:13:27:13:30 | **argv | argvLocal.c:140:15:140:32 | *... ? ... : ... |
+| argvLocal.c:13:27:13:30 | **argv | argvLocal.c:144:9:144:10 | *i7 |
+| argvLocal.c:13:27:13:30 | **argv | argvLocal.c:145:15:145:16 | *i7 |
+| argvLocal.c:13:27:13:30 | **argv | argvLocal.c:150:9:150:10 | *i8 |
+| argvLocal.c:13:27:13:30 | **argv | argvLocal.c:151:15:151:16 | *i8 |
 nodes
-| argvLocal.c:13:27:13:30 | argv indirection | semmle.label | argv indirection |
-| argvLocal.c:95:9:95:15 | access to array indirection | semmle.label | access to array indirection |
-| argvLocal.c:96:15:96:21 | access to array indirection | semmle.label | access to array indirection |
-| argvLocal.c:101:9:101:10 | i1 indirection | semmle.label | i1 indirection |
-| argvLocal.c:102:15:102:16 | i1 indirection | semmle.label | i1 indirection |
-| argvLocal.c:106:9:106:13 | access to array indirection | semmle.label | access to array indirection |
-| argvLocal.c:107:15:107:19 | access to array indirection | semmle.label | access to array indirection |
-| argvLocal.c:110:9:110:11 | * ... indirection | semmle.label | * ... indirection |
-| argvLocal.c:111:15:111:17 | * ... indirection | semmle.label | * ... indirection |
-| argvLocal.c:116:9:116:10 | i3 indirection | semmle.label | i3 indirection |
-| argvLocal.c:117:15:117:16 | i3 indirection | semmle.label | i3 indirection |
-| argvLocal.c:121:9:121:10 | i4 indirection | semmle.label | i4 indirection |
-| argvLocal.c:122:15:122:16 | i4 indirection | semmle.label | i4 indirection |
-| argvLocal.c:127:9:127:10 | i5 indirection | semmle.label | i5 indirection |
-| argvLocal.c:128:15:128:16 | i5 indirection | semmle.label | i5 indirection |
-| argvLocal.c:131:9:131:14 | ... + ... indirection | semmle.label | ... + ... indirection |
-| argvLocal.c:132:15:132:20 | ... + ... indirection | semmle.label | ... + ... indirection |
-| argvLocal.c:135:9:135:12 | ... ++ indirection | semmle.label | ... ++ indirection |
-| argvLocal.c:136:15:136:18 | -- ... indirection | semmle.label | -- ... indirection |
-| argvLocal.c:139:9:139:26 | ... ? ... : ... indirection | semmle.label | ... ? ... : ... indirection |
-| argvLocal.c:140:15:140:32 | ... ? ... : ... indirection | semmle.label | ... ? ... : ... indirection |
-| argvLocal.c:144:9:144:10 | i7 indirection | semmle.label | i7 indirection |
-| argvLocal.c:145:15:145:16 | i7 indirection | semmle.label | i7 indirection |
-| argvLocal.c:150:9:150:10 | i8 indirection | semmle.label | i8 indirection |
-| argvLocal.c:151:15:151:16 | i8 indirection | semmle.label | i8 indirection |
+| argvLocal.c:13:27:13:30 | **argv | semmle.label | **argv |
+| argvLocal.c:95:9:95:15 | *access to array | semmle.label | *access to array |
+| argvLocal.c:96:15:96:21 | *access to array | semmle.label | *access to array |
+| argvLocal.c:101:9:101:10 | *i1 | semmle.label | *i1 |
+| argvLocal.c:102:15:102:16 | *i1 | semmle.label | *i1 |
+| argvLocal.c:106:9:106:13 | *access to array | semmle.label | *access to array |
+| argvLocal.c:107:15:107:19 | *access to array | semmle.label | *access to array |
+| argvLocal.c:110:9:110:11 | ** ... | semmle.label | ** ... |
+| argvLocal.c:111:15:111:17 | ** ... | semmle.label | ** ... |
+| argvLocal.c:116:9:116:10 | *i3 | semmle.label | *i3 |
+| argvLocal.c:117:15:117:16 | *i3 | semmle.label | *i3 |
+| argvLocal.c:121:9:121:10 | *i4 | semmle.label | *i4 |
+| argvLocal.c:122:15:122:16 | *i4 | semmle.label | *i4 |
+| argvLocal.c:127:9:127:10 | *i5 | semmle.label | *i5 |
+| argvLocal.c:128:15:128:16 | *i5 | semmle.label | *i5 |
+| argvLocal.c:131:9:131:14 | *... + ... | semmle.label | *... + ... |
+| argvLocal.c:132:15:132:20 | *... + ... | semmle.label | *... + ... |
+| argvLocal.c:135:9:135:12 | *... ++ | semmle.label | *... ++ |
+| argvLocal.c:136:15:136:18 | *-- ... | semmle.label | *-- ... |
+| argvLocal.c:139:9:139:26 | *... ? ... : ... | semmle.label | *... ? ... : ... |
+| argvLocal.c:140:15:140:32 | *... ? ... : ... | semmle.label | *... ? ... : ... |
+| argvLocal.c:144:9:144:10 | *i7 | semmle.label | *i7 |
+| argvLocal.c:145:15:145:16 | *i7 | semmle.label | *i7 |
+| argvLocal.c:150:9:150:10 | *i8 | semmle.label | *i8 |
+| argvLocal.c:151:15:151:16 | *i8 | semmle.label | *i8 |
 subpaths
 #select
-| argvLocal.c:95:9:95:15 | access to array indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:95:9:95:15 | access to array indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
-| argvLocal.c:96:15:96:21 | access to array indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:96:15:96:21 | access to array indirection | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
-| argvLocal.c:101:9:101:10 | i1 indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:101:9:101:10 | i1 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
-| argvLocal.c:102:15:102:16 | i1 indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:102:15:102:16 | i1 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
-| argvLocal.c:106:9:106:13 | access to array indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:106:9:106:13 | access to array indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
-| argvLocal.c:107:15:107:19 | access to array indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:107:15:107:19 | access to array indirection | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
-| argvLocal.c:110:9:110:11 | * ... indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:110:9:110:11 | * ... indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
-| argvLocal.c:111:15:111:17 | * ... indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:111:15:111:17 | * ... indirection | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
-| argvLocal.c:116:9:116:10 | i3 indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:116:9:116:10 | i3 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
-| argvLocal.c:117:15:117:16 | i3 indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:117:15:117:16 | i3 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
-| argvLocal.c:121:9:121:10 | i4 indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:121:9:121:10 | i4 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
-| argvLocal.c:122:15:122:16 | i4 indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:122:15:122:16 | i4 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
-| argvLocal.c:127:9:127:10 | i5 indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:127:9:127:10 | i5 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
-| argvLocal.c:128:15:128:16 | i5 indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:128:15:128:16 | i5 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
-| argvLocal.c:131:9:131:14 | ... + ... indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:131:9:131:14 | ... + ... indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
-| argvLocal.c:132:15:132:20 | ... + ... indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:132:15:132:20 | ... + ... indirection | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
-| argvLocal.c:135:9:135:12 | ... ++ indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:135:9:135:12 | ... ++ indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
-| argvLocal.c:136:15:136:18 | -- ... indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:136:15:136:18 | -- ... indirection | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
-| argvLocal.c:139:9:139:26 | ... ? ... : ... indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:139:9:139:26 | ... ? ... : ... indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
-| argvLocal.c:140:15:140:32 | ... ? ... : ... indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:140:15:140:32 | ... ? ... : ... indirection | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
-| argvLocal.c:144:9:144:10 | i7 indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:144:9:144:10 | i7 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
-| argvLocal.c:145:15:145:16 | i7 indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:145:15:145:16 | i7 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
-| argvLocal.c:150:9:150:10 | i8 indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:150:9:150:10 | i8 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
-| argvLocal.c:151:15:151:16 | i8 indirection | argvLocal.c:13:27:13:30 | argv indirection | argvLocal.c:151:15:151:16 | i8 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | argv indirection | a command-line argument |
+| argvLocal.c:95:9:95:15 | *access to array | argvLocal.c:13:27:13:30 | **argv | argvLocal.c:95:9:95:15 | *access to array | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | **argv | a command-line argument |
+| argvLocal.c:96:15:96:21 | *access to array | argvLocal.c:13:27:13:30 | **argv | argvLocal.c:96:15:96:21 | *access to array | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | **argv | a command-line argument |
+| argvLocal.c:101:9:101:10 | *i1 | argvLocal.c:13:27:13:30 | **argv | argvLocal.c:101:9:101:10 | *i1 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | **argv | a command-line argument |
+| argvLocal.c:102:15:102:16 | *i1 | argvLocal.c:13:27:13:30 | **argv | argvLocal.c:102:15:102:16 | *i1 | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | **argv | a command-line argument |
+| argvLocal.c:106:9:106:13 | *access to array | argvLocal.c:13:27:13:30 | **argv | argvLocal.c:106:9:106:13 | *access to array | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | **argv | a command-line argument |
+| argvLocal.c:107:15:107:19 | *access to array | argvLocal.c:13:27:13:30 | **argv | argvLocal.c:107:15:107:19 | *access to array | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | **argv | a command-line argument |
+| argvLocal.c:110:9:110:11 | ** ... | argvLocal.c:13:27:13:30 | **argv | argvLocal.c:110:9:110:11 | ** ... | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | **argv | a command-line argument |
+| argvLocal.c:111:15:111:17 | ** ... | argvLocal.c:13:27:13:30 | **argv | argvLocal.c:111:15:111:17 | ** ... | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | **argv | a command-line argument |
+| argvLocal.c:116:9:116:10 | *i3 | argvLocal.c:13:27:13:30 | **argv | argvLocal.c:116:9:116:10 | *i3 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | **argv | a command-line argument |
+| argvLocal.c:117:15:117:16 | *i3 | argvLocal.c:13:27:13:30 | **argv | argvLocal.c:117:15:117:16 | *i3 | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | **argv | a command-line argument |
+| argvLocal.c:121:9:121:10 | *i4 | argvLocal.c:13:27:13:30 | **argv | argvLocal.c:121:9:121:10 | *i4 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | **argv | a command-line argument |
+| argvLocal.c:122:15:122:16 | *i4 | argvLocal.c:13:27:13:30 | **argv | argvLocal.c:122:15:122:16 | *i4 | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | **argv | a command-line argument |
+| argvLocal.c:127:9:127:10 | *i5 | argvLocal.c:13:27:13:30 | **argv | argvLocal.c:127:9:127:10 | *i5 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | **argv | a command-line argument |
+| argvLocal.c:128:15:128:16 | *i5 | argvLocal.c:13:27:13:30 | **argv | argvLocal.c:128:15:128:16 | *i5 | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | **argv | a command-line argument |
+| argvLocal.c:131:9:131:14 | *... + ... | argvLocal.c:13:27:13:30 | **argv | argvLocal.c:131:9:131:14 | *... + ... | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | **argv | a command-line argument |
+| argvLocal.c:132:15:132:20 | *... + ... | argvLocal.c:13:27:13:30 | **argv | argvLocal.c:132:15:132:20 | *... + ... | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | **argv | a command-line argument |
+| argvLocal.c:135:9:135:12 | *... ++ | argvLocal.c:13:27:13:30 | **argv | argvLocal.c:135:9:135:12 | *... ++ | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | **argv | a command-line argument |
+| argvLocal.c:136:15:136:18 | *-- ... | argvLocal.c:13:27:13:30 | **argv | argvLocal.c:136:15:136:18 | *-- ... | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | **argv | a command-line argument |
+| argvLocal.c:139:9:139:26 | *... ? ... : ... | argvLocal.c:13:27:13:30 | **argv | argvLocal.c:139:9:139:26 | *... ? ... : ... | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | **argv | a command-line argument |
+| argvLocal.c:140:15:140:32 | *... ? ... : ... | argvLocal.c:13:27:13:30 | **argv | argvLocal.c:140:15:140:32 | *... ? ... : ... | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | **argv | a command-line argument |
+| argvLocal.c:144:9:144:10 | *i7 | argvLocal.c:13:27:13:30 | **argv | argvLocal.c:144:9:144:10 | *i7 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | **argv | a command-line argument |
+| argvLocal.c:145:15:145:16 | *i7 | argvLocal.c:13:27:13:30 | **argv | argvLocal.c:145:15:145:16 | *i7 | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | **argv | a command-line argument |
+| argvLocal.c:150:9:150:10 | *i8 | argvLocal.c:13:27:13:30 | **argv | argvLocal.c:150:9:150:10 | *i8 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:13:27:13:30 | **argv | a command-line argument |
+| argvLocal.c:151:15:151:16 | *i8 | argvLocal.c:13:27:13:30 | **argv | argvLocal.c:151:15:151:16 | *i8 | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:13:27:13:30 | **argv | a command-line argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/funcs/funcsLocal.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/funcs/funcsLocal.expected
@@ -1,35 +1,35 @@
 edges
-| funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:17:9:17:10 | i1 indirection |
-| funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:58:9:58:10 | e1 indirection |
-| funcsLocal.c:26:8:26:9 | fgets output argument | funcsLocal.c:27:9:27:10 | i3 indirection |
-| funcsLocal.c:31:13:31:17 | call to fgets indirection | funcsLocal.c:32:9:32:10 | i4 indirection |
-| funcsLocal.c:36:7:36:8 | gets output argument | funcsLocal.c:37:9:37:10 | i5 indirection |
-| funcsLocal.c:41:13:41:16 | call to gets indirection | funcsLocal.c:42:9:42:10 | i6 indirection |
-| funcsLocal.c:46:7:46:9 | gets output argument | funcsLocal.c:47:9:47:11 | * ... indirection |
-| funcsLocal.c:52:8:52:11 | call to gets indirection | funcsLocal.c:53:9:53:11 | * ... indirection |
+| funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:17:9:17:10 | *i1 |
+| funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:58:9:58:10 | *e1 |
+| funcsLocal.c:26:8:26:9 | fgets output argument | funcsLocal.c:27:9:27:10 | *i3 |
+| funcsLocal.c:31:13:31:17 | *call to fgets | funcsLocal.c:32:9:32:10 | *i4 |
+| funcsLocal.c:36:7:36:8 | gets output argument | funcsLocal.c:37:9:37:10 | *i5 |
+| funcsLocal.c:41:13:41:16 | *call to gets | funcsLocal.c:42:9:42:10 | *i6 |
+| funcsLocal.c:46:7:46:9 | gets output argument | funcsLocal.c:47:9:47:11 | ** ... |
+| funcsLocal.c:52:8:52:11 | *call to gets | funcsLocal.c:53:9:53:11 | ** ... |
 nodes
 | funcsLocal.c:16:8:16:9 | fread output argument | semmle.label | fread output argument |
-| funcsLocal.c:17:9:17:10 | i1 indirection | semmle.label | i1 indirection |
+| funcsLocal.c:17:9:17:10 | *i1 | semmle.label | *i1 |
 | funcsLocal.c:26:8:26:9 | fgets output argument | semmle.label | fgets output argument |
-| funcsLocal.c:27:9:27:10 | i3 indirection | semmle.label | i3 indirection |
-| funcsLocal.c:31:13:31:17 | call to fgets indirection | semmle.label | call to fgets indirection |
-| funcsLocal.c:32:9:32:10 | i4 indirection | semmle.label | i4 indirection |
+| funcsLocal.c:27:9:27:10 | *i3 | semmle.label | *i3 |
+| funcsLocal.c:31:13:31:17 | *call to fgets | semmle.label | *call to fgets |
+| funcsLocal.c:32:9:32:10 | *i4 | semmle.label | *i4 |
 | funcsLocal.c:36:7:36:8 | gets output argument | semmle.label | gets output argument |
-| funcsLocal.c:37:9:37:10 | i5 indirection | semmle.label | i5 indirection |
-| funcsLocal.c:41:13:41:16 | call to gets indirection | semmle.label | call to gets indirection |
-| funcsLocal.c:42:9:42:10 | i6 indirection | semmle.label | i6 indirection |
+| funcsLocal.c:37:9:37:10 | *i5 | semmle.label | *i5 |
+| funcsLocal.c:41:13:41:16 | *call to gets | semmle.label | *call to gets |
+| funcsLocal.c:42:9:42:10 | *i6 | semmle.label | *i6 |
 | funcsLocal.c:46:7:46:9 | gets output argument | semmle.label | gets output argument |
-| funcsLocal.c:47:9:47:11 | * ... indirection | semmle.label | * ... indirection |
-| funcsLocal.c:52:8:52:11 | call to gets indirection | semmle.label | call to gets indirection |
-| funcsLocal.c:53:9:53:11 | * ... indirection | semmle.label | * ... indirection |
-| funcsLocal.c:58:9:58:10 | e1 indirection | semmle.label | e1 indirection |
+| funcsLocal.c:47:9:47:11 | ** ... | semmle.label | ** ... |
+| funcsLocal.c:52:8:52:11 | *call to gets | semmle.label | *call to gets |
+| funcsLocal.c:53:9:53:11 | ** ... | semmle.label | ** ... |
+| funcsLocal.c:58:9:58:10 | *e1 | semmle.label | *e1 |
 subpaths
 #select
-| funcsLocal.c:17:9:17:10 | i1 indirection | funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:17:9:17:10 | i1 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:16:8:16:9 | fread output argument | string read by fread |
-| funcsLocal.c:27:9:27:10 | i3 indirection | funcsLocal.c:26:8:26:9 | fgets output argument | funcsLocal.c:27:9:27:10 | i3 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:26:8:26:9 | fgets output argument | string read by fgets |
-| funcsLocal.c:32:9:32:10 | i4 indirection | funcsLocal.c:31:13:31:17 | call to fgets indirection | funcsLocal.c:32:9:32:10 | i4 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:31:13:31:17 | call to fgets indirection | string read by fgets |
-| funcsLocal.c:37:9:37:10 | i5 indirection | funcsLocal.c:36:7:36:8 | gets output argument | funcsLocal.c:37:9:37:10 | i5 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:36:7:36:8 | gets output argument | string read by gets |
-| funcsLocal.c:42:9:42:10 | i6 indirection | funcsLocal.c:41:13:41:16 | call to gets indirection | funcsLocal.c:42:9:42:10 | i6 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:41:13:41:16 | call to gets indirection | string read by gets |
-| funcsLocal.c:47:9:47:11 | * ... indirection | funcsLocal.c:46:7:46:9 | gets output argument | funcsLocal.c:47:9:47:11 | * ... indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:46:7:46:9 | gets output argument | string read by gets |
-| funcsLocal.c:53:9:53:11 | * ... indirection | funcsLocal.c:52:8:52:11 | call to gets indirection | funcsLocal.c:53:9:53:11 | * ... indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:52:8:52:11 | call to gets indirection | string read by gets |
-| funcsLocal.c:58:9:58:10 | e1 indirection | funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:58:9:58:10 | e1 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:16:8:16:9 | fread output argument | string read by fread |
+| funcsLocal.c:17:9:17:10 | *i1 | funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:17:9:17:10 | *i1 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:16:8:16:9 | fread output argument | string read by fread |
+| funcsLocal.c:27:9:27:10 | *i3 | funcsLocal.c:26:8:26:9 | fgets output argument | funcsLocal.c:27:9:27:10 | *i3 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:26:8:26:9 | fgets output argument | string read by fgets |
+| funcsLocal.c:32:9:32:10 | *i4 | funcsLocal.c:31:13:31:17 | *call to fgets | funcsLocal.c:32:9:32:10 | *i4 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:31:13:31:17 | *call to fgets | string read by fgets |
+| funcsLocal.c:37:9:37:10 | *i5 | funcsLocal.c:36:7:36:8 | gets output argument | funcsLocal.c:37:9:37:10 | *i5 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:36:7:36:8 | gets output argument | string read by gets |
+| funcsLocal.c:42:9:42:10 | *i6 | funcsLocal.c:41:13:41:16 | *call to gets | funcsLocal.c:42:9:42:10 | *i6 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:41:13:41:16 | *call to gets | string read by gets |
+| funcsLocal.c:47:9:47:11 | ** ... | funcsLocal.c:46:7:46:9 | gets output argument | funcsLocal.c:47:9:47:11 | ** ... | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:46:7:46:9 | gets output argument | string read by gets |
+| funcsLocal.c:53:9:53:11 | ** ... | funcsLocal.c:52:8:52:11 | *call to gets | funcsLocal.c:53:9:53:11 | ** ... | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:52:8:52:11 | *call to gets | string read by gets |
+| funcsLocal.c:58:9:58:10 | *e1 | funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:58:9:58:10 | *e1 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:16:8:16:9 | fread output argument | string read by fread |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/globalVars/UncontrolledFormatString.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/globalVars/UncontrolledFormatString.expected
@@ -1,32 +1,32 @@
 edges
-| globalVars.c:8:7:8:10 | copy indirection | globalVars.c:27:9:27:12 | copy indirection |
-| globalVars.c:8:7:8:10 | copy indirection | globalVars.c:30:15:30:18 | copy indirection |
-| globalVars.c:8:7:8:10 | copy indirection | globalVars.c:35:11:35:14 | copy indirection |
-| globalVars.c:9:7:9:11 | copy2 indirection | globalVars.c:38:9:38:13 | copy2 indirection |
-| globalVars.c:9:7:9:11 | copy2 indirection | globalVars.c:41:15:41:19 | copy2 indirection |
-| globalVars.c:9:7:9:11 | copy2 indirection | globalVars.c:50:9:50:13 | copy2 indirection |
-| globalVars.c:11:22:11:25 | argv indirection | globalVars.c:8:7:8:10 | copy indirection |
-| globalVars.c:15:21:15:23 | val indirection | globalVars.c:9:7:9:11 | copy2 indirection |
-| globalVars.c:23:27:23:30 | argv indirection | globalVars.c:24:11:24:14 | argv indirection |
-| globalVars.c:24:11:24:14 | argv indirection | globalVars.c:11:22:11:25 | argv indirection |
-| globalVars.c:35:11:35:14 | copy indirection | globalVars.c:15:21:15:23 | val indirection |
+| globalVars.c:8:7:8:10 | **copy | globalVars.c:27:9:27:12 | *copy |
+| globalVars.c:8:7:8:10 | **copy | globalVars.c:30:15:30:18 | *copy |
+| globalVars.c:8:7:8:10 | **copy | globalVars.c:35:11:35:14 | *copy |
+| globalVars.c:9:7:9:11 | **copy2 | globalVars.c:38:9:38:13 | *copy2 |
+| globalVars.c:9:7:9:11 | **copy2 | globalVars.c:41:15:41:19 | *copy2 |
+| globalVars.c:9:7:9:11 | **copy2 | globalVars.c:50:9:50:13 | *copy2 |
+| globalVars.c:11:22:11:25 | **argv | globalVars.c:8:7:8:10 | **copy |
+| globalVars.c:15:21:15:23 | *val | globalVars.c:9:7:9:11 | **copy2 |
+| globalVars.c:23:27:23:30 | **argv | globalVars.c:24:11:24:14 | **argv |
+| globalVars.c:24:11:24:14 | **argv | globalVars.c:11:22:11:25 | **argv |
+| globalVars.c:35:11:35:14 | *copy | globalVars.c:15:21:15:23 | *val |
 nodes
-| globalVars.c:8:7:8:10 | copy indirection | semmle.label | copy indirection |
-| globalVars.c:9:7:9:11 | copy2 indirection | semmle.label | copy2 indirection |
-| globalVars.c:11:22:11:25 | argv indirection | semmle.label | argv indirection |
-| globalVars.c:15:21:15:23 | val indirection | semmle.label | val indirection |
-| globalVars.c:23:27:23:30 | argv indirection | semmle.label | argv indirection |
-| globalVars.c:24:11:24:14 | argv indirection | semmle.label | argv indirection |
-| globalVars.c:27:9:27:12 | copy indirection | semmle.label | copy indirection |
-| globalVars.c:30:15:30:18 | copy indirection | semmle.label | copy indirection |
-| globalVars.c:35:11:35:14 | copy indirection | semmle.label | copy indirection |
-| globalVars.c:38:9:38:13 | copy2 indirection | semmle.label | copy2 indirection |
-| globalVars.c:41:15:41:19 | copy2 indirection | semmle.label | copy2 indirection |
-| globalVars.c:50:9:50:13 | copy2 indirection | semmle.label | copy2 indirection |
+| globalVars.c:8:7:8:10 | **copy | semmle.label | **copy |
+| globalVars.c:9:7:9:11 | **copy2 | semmle.label | **copy2 |
+| globalVars.c:11:22:11:25 | **argv | semmle.label | **argv |
+| globalVars.c:15:21:15:23 | *val | semmle.label | *val |
+| globalVars.c:23:27:23:30 | **argv | semmle.label | **argv |
+| globalVars.c:24:11:24:14 | **argv | semmle.label | **argv |
+| globalVars.c:27:9:27:12 | *copy | semmle.label | *copy |
+| globalVars.c:30:15:30:18 | *copy | semmle.label | *copy |
+| globalVars.c:35:11:35:14 | *copy | semmle.label | *copy |
+| globalVars.c:38:9:38:13 | *copy2 | semmle.label | *copy2 |
+| globalVars.c:41:15:41:19 | *copy2 | semmle.label | *copy2 |
+| globalVars.c:50:9:50:13 | *copy2 | semmle.label | *copy2 |
 subpaths
 #select
-| globalVars.c:27:9:27:12 | copy indirection | globalVars.c:23:27:23:30 | argv indirection | globalVars.c:27:9:27:12 | copy indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | globalVars.c:23:27:23:30 | argv indirection | a command-line argument |
-| globalVars.c:30:15:30:18 | copy indirection | globalVars.c:23:27:23:30 | argv indirection | globalVars.c:30:15:30:18 | copy indirection | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(str), which calls printf(format). | globalVars.c:23:27:23:30 | argv indirection | a command-line argument |
-| globalVars.c:38:9:38:13 | copy2 indirection | globalVars.c:23:27:23:30 | argv indirection | globalVars.c:38:9:38:13 | copy2 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | globalVars.c:23:27:23:30 | argv indirection | a command-line argument |
-| globalVars.c:41:15:41:19 | copy2 indirection | globalVars.c:23:27:23:30 | argv indirection | globalVars.c:41:15:41:19 | copy2 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(str), which calls printf(format). | globalVars.c:23:27:23:30 | argv indirection | a command-line argument |
-| globalVars.c:50:9:50:13 | copy2 indirection | globalVars.c:23:27:23:30 | argv indirection | globalVars.c:50:9:50:13 | copy2 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | globalVars.c:23:27:23:30 | argv indirection | a command-line argument |
+| globalVars.c:27:9:27:12 | *copy | globalVars.c:23:27:23:30 | **argv | globalVars.c:27:9:27:12 | *copy | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | globalVars.c:23:27:23:30 | **argv | a command-line argument |
+| globalVars.c:30:15:30:18 | *copy | globalVars.c:23:27:23:30 | **argv | globalVars.c:30:15:30:18 | *copy | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(str), which calls printf(format). | globalVars.c:23:27:23:30 | **argv | a command-line argument |
+| globalVars.c:38:9:38:13 | *copy2 | globalVars.c:23:27:23:30 | **argv | globalVars.c:38:9:38:13 | *copy2 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | globalVars.c:23:27:23:30 | **argv | a command-line argument |
+| globalVars.c:41:15:41:19 | *copy2 | globalVars.c:23:27:23:30 | **argv | globalVars.c:41:15:41:19 | *copy2 | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(str), which calls printf(format). | globalVars.c:23:27:23:30 | **argv | a command-line argument |
+| globalVars.c:50:9:50:13 | *copy2 | globalVars.c:23:27:23:30 | **argv | globalVars.c:50:9:50:13 | *copy2 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | globalVars.c:23:27:23:30 | **argv | a command-line argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/ifs/ifs.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/ifs/ifs.expected
@@ -1,38 +1,38 @@
 edges
-| ifs.c:16:27:16:30 | argv indirection | ifs.c:62:9:62:10 | c7 indirection |
-| ifs.c:16:27:16:30 | argv indirection | ifs.c:69:9:69:10 | c8 indirection |
-| ifs.c:16:27:16:30 | argv indirection | ifs.c:75:9:75:10 | i1 indirection |
-| ifs.c:16:27:16:30 | argv indirection | ifs.c:81:9:81:10 | i2 indirection |
-| ifs.c:16:27:16:30 | argv indirection | ifs.c:87:9:87:10 | i3 indirection |
-| ifs.c:16:27:16:30 | argv indirection | ifs.c:93:9:93:10 | i4 indirection |
-| ifs.c:16:27:16:30 | argv indirection | ifs.c:99:9:99:10 | i5 indirection |
-| ifs.c:16:27:16:30 | argv indirection | ifs.c:106:9:106:10 | i6 indirection |
-| ifs.c:16:27:16:30 | argv indirection | ifs.c:112:9:112:10 | i7 indirection |
-| ifs.c:16:27:16:30 | argv indirection | ifs.c:118:9:118:10 | i8 indirection |
-| ifs.c:16:27:16:30 | argv indirection | ifs.c:124:9:124:10 | i9 indirection |
+| ifs.c:16:27:16:30 | **argv | ifs.c:62:9:62:10 | *c7 |
+| ifs.c:16:27:16:30 | **argv | ifs.c:69:9:69:10 | *c8 |
+| ifs.c:16:27:16:30 | **argv | ifs.c:75:9:75:10 | *i1 |
+| ifs.c:16:27:16:30 | **argv | ifs.c:81:9:81:10 | *i2 |
+| ifs.c:16:27:16:30 | **argv | ifs.c:87:9:87:10 | *i3 |
+| ifs.c:16:27:16:30 | **argv | ifs.c:93:9:93:10 | *i4 |
+| ifs.c:16:27:16:30 | **argv | ifs.c:99:9:99:10 | *i5 |
+| ifs.c:16:27:16:30 | **argv | ifs.c:106:9:106:10 | *i6 |
+| ifs.c:16:27:16:30 | **argv | ifs.c:112:9:112:10 | *i7 |
+| ifs.c:16:27:16:30 | **argv | ifs.c:118:9:118:10 | *i8 |
+| ifs.c:16:27:16:30 | **argv | ifs.c:124:9:124:10 | *i9 |
 nodes
-| ifs.c:16:27:16:30 | argv indirection | semmle.label | argv indirection |
-| ifs.c:62:9:62:10 | c7 indirection | semmle.label | c7 indirection |
-| ifs.c:69:9:69:10 | c8 indirection | semmle.label | c8 indirection |
-| ifs.c:75:9:75:10 | i1 indirection | semmle.label | i1 indirection |
-| ifs.c:81:9:81:10 | i2 indirection | semmle.label | i2 indirection |
-| ifs.c:87:9:87:10 | i3 indirection | semmle.label | i3 indirection |
-| ifs.c:93:9:93:10 | i4 indirection | semmle.label | i4 indirection |
-| ifs.c:99:9:99:10 | i5 indirection | semmle.label | i5 indirection |
-| ifs.c:106:9:106:10 | i6 indirection | semmle.label | i6 indirection |
-| ifs.c:112:9:112:10 | i7 indirection | semmle.label | i7 indirection |
-| ifs.c:118:9:118:10 | i8 indirection | semmle.label | i8 indirection |
-| ifs.c:124:9:124:10 | i9 indirection | semmle.label | i9 indirection |
+| ifs.c:16:27:16:30 | **argv | semmle.label | **argv |
+| ifs.c:62:9:62:10 | *c7 | semmle.label | *c7 |
+| ifs.c:69:9:69:10 | *c8 | semmle.label | *c8 |
+| ifs.c:75:9:75:10 | *i1 | semmle.label | *i1 |
+| ifs.c:81:9:81:10 | *i2 | semmle.label | *i2 |
+| ifs.c:87:9:87:10 | *i3 | semmle.label | *i3 |
+| ifs.c:93:9:93:10 | *i4 | semmle.label | *i4 |
+| ifs.c:99:9:99:10 | *i5 | semmle.label | *i5 |
+| ifs.c:106:9:106:10 | *i6 | semmle.label | *i6 |
+| ifs.c:112:9:112:10 | *i7 | semmle.label | *i7 |
+| ifs.c:118:9:118:10 | *i8 | semmle.label | *i8 |
+| ifs.c:124:9:124:10 | *i9 | semmle.label | *i9 |
 subpaths
 #select
-| ifs.c:62:9:62:10 | c7 indirection | ifs.c:16:27:16:30 | argv indirection | ifs.c:62:9:62:10 | c7 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | argv indirection | a command-line argument |
-| ifs.c:69:9:69:10 | c8 indirection | ifs.c:16:27:16:30 | argv indirection | ifs.c:69:9:69:10 | c8 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | argv indirection | a command-line argument |
-| ifs.c:75:9:75:10 | i1 indirection | ifs.c:16:27:16:30 | argv indirection | ifs.c:75:9:75:10 | i1 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | argv indirection | a command-line argument |
-| ifs.c:81:9:81:10 | i2 indirection | ifs.c:16:27:16:30 | argv indirection | ifs.c:81:9:81:10 | i2 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | argv indirection | a command-line argument |
-| ifs.c:87:9:87:10 | i3 indirection | ifs.c:16:27:16:30 | argv indirection | ifs.c:87:9:87:10 | i3 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | argv indirection | a command-line argument |
-| ifs.c:93:9:93:10 | i4 indirection | ifs.c:16:27:16:30 | argv indirection | ifs.c:93:9:93:10 | i4 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | argv indirection | a command-line argument |
-| ifs.c:99:9:99:10 | i5 indirection | ifs.c:16:27:16:30 | argv indirection | ifs.c:99:9:99:10 | i5 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | argv indirection | a command-line argument |
-| ifs.c:106:9:106:10 | i6 indirection | ifs.c:16:27:16:30 | argv indirection | ifs.c:106:9:106:10 | i6 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | argv indirection | a command-line argument |
-| ifs.c:112:9:112:10 | i7 indirection | ifs.c:16:27:16:30 | argv indirection | ifs.c:112:9:112:10 | i7 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | argv indirection | a command-line argument |
-| ifs.c:118:9:118:10 | i8 indirection | ifs.c:16:27:16:30 | argv indirection | ifs.c:118:9:118:10 | i8 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | argv indirection | a command-line argument |
-| ifs.c:124:9:124:10 | i9 indirection | ifs.c:16:27:16:30 | argv indirection | ifs.c:124:9:124:10 | i9 indirection | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | argv indirection | a command-line argument |
+| ifs.c:62:9:62:10 | *c7 | ifs.c:16:27:16:30 | **argv | ifs.c:62:9:62:10 | *c7 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | **argv | a command-line argument |
+| ifs.c:69:9:69:10 | *c8 | ifs.c:16:27:16:30 | **argv | ifs.c:69:9:69:10 | *c8 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | **argv | a command-line argument |
+| ifs.c:75:9:75:10 | *i1 | ifs.c:16:27:16:30 | **argv | ifs.c:75:9:75:10 | *i1 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | **argv | a command-line argument |
+| ifs.c:81:9:81:10 | *i2 | ifs.c:16:27:16:30 | **argv | ifs.c:81:9:81:10 | *i2 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | **argv | a command-line argument |
+| ifs.c:87:9:87:10 | *i3 | ifs.c:16:27:16:30 | **argv | ifs.c:87:9:87:10 | *i3 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | **argv | a command-line argument |
+| ifs.c:93:9:93:10 | *i4 | ifs.c:16:27:16:30 | **argv | ifs.c:93:9:93:10 | *i4 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | **argv | a command-line argument |
+| ifs.c:99:9:99:10 | *i5 | ifs.c:16:27:16:30 | **argv | ifs.c:99:9:99:10 | *i5 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | **argv | a command-line argument |
+| ifs.c:106:9:106:10 | *i6 | ifs.c:16:27:16:30 | **argv | ifs.c:106:9:106:10 | *i6 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | **argv | a command-line argument |
+| ifs.c:112:9:112:10 | *i7 | ifs.c:16:27:16:30 | **argv | ifs.c:112:9:112:10 | *i7 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | **argv | a command-line argument |
+| ifs.c:118:9:118:10 | *i8 | ifs.c:16:27:16:30 | **argv | ifs.c:118:9:118:10 | *i8 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | **argv | a command-line argument |
+| ifs.c:124:9:124:10 | *i9 | ifs.c:16:27:16:30 | **argv | ifs.c:124:9:124:10 | *i9 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | ifs.c:16:27:16:30 | **argv | a command-line argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/ArithmeticUncontrolled/ArithmeticUncontrolled.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/ArithmeticUncontrolled/ArithmeticUncontrolled.expected
@@ -10,12 +10,12 @@ edges
 | test.c:131:13:131:16 | call to rand | test.c:133:5:133:5 | r |
 | test.c:137:13:137:16 | call to rand | test.c:139:10:139:10 | r |
 | test.c:155:22:155:27 | call to rand | test.c:157:9:157:9 | r |
-| test.cpp:6:5:6:12 | get_rand indirection | test.cpp:24:11:24:18 | call to get_rand |
-| test.cpp:8:9:8:12 | call to rand | test.cpp:6:5:6:12 | get_rand indirection |
-| test.cpp:11:21:11:24 | dest | test.cpp:30:13:30:14 | get_rand2 output argument |
-| test.cpp:13:10:13:13 | call to rand | test.cpp:11:21:11:24 | dest |
-| test.cpp:16:21:16:24 | dest | test.cpp:36:13:36:13 | get_rand3 output argument |
-| test.cpp:18:9:18:12 | call to rand | test.cpp:16:21:16:24 | dest |
+| test.cpp:6:5:6:12 | *get_rand | test.cpp:24:11:24:18 | call to get_rand |
+| test.cpp:8:9:8:12 | call to rand | test.cpp:6:5:6:12 | *get_rand |
+| test.cpp:11:21:11:24 | *dest | test.cpp:30:13:30:14 | get_rand2 output argument |
+| test.cpp:13:10:13:13 | call to rand | test.cpp:11:21:11:24 | *dest |
+| test.cpp:16:21:16:24 | *dest | test.cpp:36:13:36:13 | get_rand3 output argument |
+| test.cpp:18:9:18:12 | call to rand | test.cpp:16:21:16:24 | *dest |
 | test.cpp:24:11:24:18 | call to get_rand | test.cpp:25:7:25:7 | r |
 | test.cpp:30:13:30:14 | get_rand2 output argument | test.cpp:31:7:31:7 | r |
 | test.cpp:36:13:36:13 | get_rand3 output argument | test.cpp:37:7:37:7 | r |
@@ -52,11 +52,11 @@ nodes
 | test.c:139:10:139:10 | r | semmle.label | r |
 | test.c:155:22:155:27 | call to rand | semmle.label | call to rand |
 | test.c:157:9:157:9 | r | semmle.label | r |
-| test.cpp:6:5:6:12 | get_rand indirection | semmle.label | get_rand indirection |
+| test.cpp:6:5:6:12 | *get_rand | semmle.label | *get_rand |
 | test.cpp:8:9:8:12 | call to rand | semmle.label | call to rand |
-| test.cpp:11:21:11:24 | dest | semmle.label | dest |
+| test.cpp:11:21:11:24 | *dest | semmle.label | *dest |
 | test.cpp:13:10:13:13 | call to rand | semmle.label | call to rand |
-| test.cpp:16:21:16:24 | dest | semmle.label | dest |
+| test.cpp:16:21:16:24 | *dest | semmle.label | *dest |
 | test.cpp:18:9:18:12 | call to rand | semmle.label | call to rand |
 | test.cpp:24:11:24:18 | call to get_rand | semmle.label | call to get_rand |
 | test.cpp:25:7:25:7 | r | semmle.label | r |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
@@ -1,79 +1,79 @@
 edges
-| test.cpp:39:27:39:30 | argv indirection | test.cpp:43:38:43:44 | tainted |
-| test.cpp:39:27:39:30 | argv indirection | test.cpp:44:38:44:63 | ... * ... |
-| test.cpp:39:27:39:30 | argv indirection | test.cpp:46:38:46:63 | ... + ... |
-| test.cpp:39:27:39:30 | argv indirection | test.cpp:49:32:49:35 | size |
-| test.cpp:39:27:39:30 | argv indirection | test.cpp:50:17:50:30 | size |
-| test.cpp:39:27:39:30 | argv indirection | test.cpp:53:35:53:60 | ... * ... |
-| test.cpp:124:18:124:31 | call to getenv indirection | test.cpp:128:24:128:41 | ... * ... |
-| test.cpp:133:19:133:32 | call to getenv indirection | test.cpp:135:10:135:27 | ... * ... |
-| test.cpp:148:20:148:33 | call to getenv indirection | test.cpp:152:11:152:28 | ... * ... |
-| test.cpp:209:8:209:23 | get_tainted_size indirection | test.cpp:241:9:241:24 | call to get_tainted_size |
-| test.cpp:211:14:211:27 | call to getenv indirection | test.cpp:209:8:209:23 | get_tainted_size indirection |
+| test.cpp:39:27:39:30 | **argv | test.cpp:43:38:43:44 | tainted |
+| test.cpp:39:27:39:30 | **argv | test.cpp:44:38:44:63 | ... * ... |
+| test.cpp:39:27:39:30 | **argv | test.cpp:46:38:46:63 | ... + ... |
+| test.cpp:39:27:39:30 | **argv | test.cpp:49:32:49:35 | size |
+| test.cpp:39:27:39:30 | **argv | test.cpp:50:17:50:30 | size |
+| test.cpp:39:27:39:30 | **argv | test.cpp:53:35:53:60 | ... * ... |
+| test.cpp:124:18:124:31 | *call to getenv | test.cpp:128:24:128:41 | ... * ... |
+| test.cpp:133:19:133:32 | *call to getenv | test.cpp:135:10:135:27 | ... * ... |
+| test.cpp:148:20:148:33 | *call to getenv | test.cpp:152:11:152:28 | ... * ... |
+| test.cpp:209:8:209:23 | *get_tainted_size | test.cpp:241:9:241:24 | call to get_tainted_size |
+| test.cpp:211:14:211:27 | *call to getenv | test.cpp:209:8:209:23 | *get_tainted_size |
 | test.cpp:230:21:230:21 | s | test.cpp:231:21:231:21 | s |
-| test.cpp:237:24:237:37 | call to getenv indirection | test.cpp:239:9:239:18 | local_size |
-| test.cpp:237:24:237:37 | call to getenv indirection | test.cpp:245:11:245:20 | local_size |
-| test.cpp:237:24:237:37 | call to getenv indirection | test.cpp:247:10:247:19 | local_size |
+| test.cpp:237:24:237:37 | *call to getenv | test.cpp:239:9:239:18 | local_size |
+| test.cpp:237:24:237:37 | *call to getenv | test.cpp:245:11:245:20 | local_size |
+| test.cpp:237:24:237:37 | *call to getenv | test.cpp:247:10:247:19 | local_size |
 | test.cpp:247:10:247:19 | local_size | test.cpp:230:21:230:21 | s |
-| test.cpp:250:20:250:27 | out_size | test.cpp:289:17:289:20 | get_size output argument |
-| test.cpp:250:20:250:27 | out_size | test.cpp:305:18:305:21 | get_size output argument |
-| test.cpp:251:18:251:31 | call to getenv indirection | test.cpp:250:20:250:27 | out_size |
-| test.cpp:259:20:259:33 | call to getenv indirection | test.cpp:263:11:263:29 | ... * ... |
+| test.cpp:250:20:250:27 | *out_size | test.cpp:289:17:289:20 | get_size output argument |
+| test.cpp:250:20:250:27 | *out_size | test.cpp:305:18:305:21 | get_size output argument |
+| test.cpp:251:18:251:31 | *call to getenv | test.cpp:250:20:250:27 | *out_size |
+| test.cpp:259:20:259:33 | *call to getenv | test.cpp:263:11:263:29 | ... * ... |
 | test.cpp:289:17:289:20 | get_size output argument | test.cpp:291:11:291:28 | ... * ... |
 | test.cpp:305:18:305:21 | get_size output argument | test.cpp:308:10:308:27 | ... * ... |
-| test.cpp:353:18:353:31 | call to getenv indirection | test.cpp:355:35:355:38 | size |
-| test.cpp:353:18:353:31 | call to getenv indirection | test.cpp:356:35:356:38 | size |
+| test.cpp:353:18:353:31 | *call to getenv | test.cpp:355:35:355:38 | size |
+| test.cpp:353:18:353:31 | *call to getenv | test.cpp:356:35:356:38 | size |
 nodes
-| test.cpp:39:27:39:30 | argv indirection | semmle.label | argv indirection |
+| test.cpp:39:27:39:30 | **argv | semmle.label | **argv |
 | test.cpp:43:38:43:44 | tainted | semmle.label | tainted |
 | test.cpp:44:38:44:63 | ... * ... | semmle.label | ... * ... |
 | test.cpp:46:38:46:63 | ... + ... | semmle.label | ... + ... |
 | test.cpp:49:32:49:35 | size | semmle.label | size |
 | test.cpp:50:17:50:30 | size | semmle.label | size |
 | test.cpp:53:35:53:60 | ... * ... | semmle.label | ... * ... |
-| test.cpp:124:18:124:31 | call to getenv indirection | semmle.label | call to getenv indirection |
+| test.cpp:124:18:124:31 | *call to getenv | semmle.label | *call to getenv |
 | test.cpp:128:24:128:41 | ... * ... | semmle.label | ... * ... |
-| test.cpp:133:19:133:32 | call to getenv indirection | semmle.label | call to getenv indirection |
+| test.cpp:133:19:133:32 | *call to getenv | semmle.label | *call to getenv |
 | test.cpp:135:10:135:27 | ... * ... | semmle.label | ... * ... |
-| test.cpp:148:20:148:33 | call to getenv indirection | semmle.label | call to getenv indirection |
+| test.cpp:148:20:148:33 | *call to getenv | semmle.label | *call to getenv |
 | test.cpp:152:11:152:28 | ... * ... | semmle.label | ... * ... |
-| test.cpp:209:8:209:23 | get_tainted_size indirection | semmle.label | get_tainted_size indirection |
-| test.cpp:211:14:211:27 | call to getenv indirection | semmle.label | call to getenv indirection |
+| test.cpp:209:8:209:23 | *get_tainted_size | semmle.label | *get_tainted_size |
+| test.cpp:211:14:211:27 | *call to getenv | semmle.label | *call to getenv |
 | test.cpp:230:21:230:21 | s | semmle.label | s |
 | test.cpp:231:21:231:21 | s | semmle.label | s |
-| test.cpp:237:24:237:37 | call to getenv indirection | semmle.label | call to getenv indirection |
+| test.cpp:237:24:237:37 | *call to getenv | semmle.label | *call to getenv |
 | test.cpp:239:9:239:18 | local_size | semmle.label | local_size |
 | test.cpp:241:9:241:24 | call to get_tainted_size | semmle.label | call to get_tainted_size |
 | test.cpp:245:11:245:20 | local_size | semmle.label | local_size |
 | test.cpp:247:10:247:19 | local_size | semmle.label | local_size |
-| test.cpp:250:20:250:27 | out_size | semmle.label | out_size |
-| test.cpp:251:18:251:31 | call to getenv indirection | semmle.label | call to getenv indirection |
-| test.cpp:259:20:259:33 | call to getenv indirection | semmle.label | call to getenv indirection |
+| test.cpp:250:20:250:27 | *out_size | semmle.label | *out_size |
+| test.cpp:251:18:251:31 | *call to getenv | semmle.label | *call to getenv |
+| test.cpp:259:20:259:33 | *call to getenv | semmle.label | *call to getenv |
 | test.cpp:263:11:263:29 | ... * ... | semmle.label | ... * ... |
 | test.cpp:289:17:289:20 | get_size output argument | semmle.label | get_size output argument |
 | test.cpp:291:11:291:28 | ... * ... | semmle.label | ... * ... |
 | test.cpp:305:18:305:21 | get_size output argument | semmle.label | get_size output argument |
 | test.cpp:308:10:308:27 | ... * ... | semmle.label | ... * ... |
-| test.cpp:353:18:353:31 | call to getenv indirection | semmle.label | call to getenv indirection |
+| test.cpp:353:18:353:31 | *call to getenv | semmle.label | *call to getenv |
 | test.cpp:355:35:355:38 | size | semmle.label | size |
 | test.cpp:356:35:356:38 | size | semmle.label | size |
 subpaths
 #select
-| test.cpp:43:31:43:36 | call to malloc | test.cpp:39:27:39:30 | argv indirection | test.cpp:43:38:43:44 | tainted | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | argv indirection | user input (a command-line argument) |
-| test.cpp:44:31:44:36 | call to malloc | test.cpp:39:27:39:30 | argv indirection | test.cpp:44:38:44:63 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | argv indirection | user input (a command-line argument) |
-| test.cpp:46:31:46:36 | call to malloc | test.cpp:39:27:39:30 | argv indirection | test.cpp:46:38:46:63 | ... + ... | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | argv indirection | user input (a command-line argument) |
-| test.cpp:49:25:49:30 | call to malloc | test.cpp:39:27:39:30 | argv indirection | test.cpp:49:32:49:35 | size | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | argv indirection | user input (a command-line argument) |
-| test.cpp:50:17:50:30 | new[] | test.cpp:39:27:39:30 | argv indirection | test.cpp:50:17:50:30 | size | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | argv indirection | user input (a command-line argument) |
-| test.cpp:53:21:53:27 | call to realloc | test.cpp:39:27:39:30 | argv indirection | test.cpp:53:35:53:60 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | argv indirection | user input (a command-line argument) |
-| test.cpp:128:17:128:22 | call to malloc | test.cpp:124:18:124:31 | call to getenv indirection | test.cpp:128:24:128:41 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:124:18:124:31 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:135:3:135:8 | call to malloc | test.cpp:133:19:133:32 | call to getenv indirection | test.cpp:135:10:135:27 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:133:19:133:32 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:152:4:152:9 | call to malloc | test.cpp:148:20:148:33 | call to getenv indirection | test.cpp:152:11:152:28 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:148:20:148:33 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:231:14:231:19 | call to malloc | test.cpp:237:24:237:37 | call to getenv indirection | test.cpp:231:21:231:21 | s | This allocation size is derived from $@ and might overflow. | test.cpp:237:24:237:37 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:239:2:239:7 | call to malloc | test.cpp:237:24:237:37 | call to getenv indirection | test.cpp:239:9:239:18 | local_size | This allocation size is derived from $@ and might overflow. | test.cpp:237:24:237:37 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:241:2:241:7 | call to malloc | test.cpp:211:14:211:27 | call to getenv indirection | test.cpp:241:9:241:24 | call to get_tainted_size | This allocation size is derived from $@ and might overflow. | test.cpp:211:14:211:27 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:245:2:245:9 | call to my_alloc | test.cpp:237:24:237:37 | call to getenv indirection | test.cpp:245:11:245:20 | local_size | This allocation size is derived from $@ and might overflow. | test.cpp:237:24:237:37 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:263:4:263:9 | call to malloc | test.cpp:259:20:259:33 | call to getenv indirection | test.cpp:263:11:263:29 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:259:20:259:33 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:291:4:291:9 | call to malloc | test.cpp:251:18:251:31 | call to getenv indirection | test.cpp:291:11:291:28 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:251:18:251:31 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:308:3:308:8 | call to malloc | test.cpp:251:18:251:31 | call to getenv indirection | test.cpp:308:10:308:27 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:251:18:251:31 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:355:25:355:33 | call to MyMalloc1 | test.cpp:353:18:353:31 | call to getenv indirection | test.cpp:355:35:355:38 | size | This allocation size is derived from $@ and might overflow. | test.cpp:353:18:353:31 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:356:25:356:33 | call to MyMalloc2 | test.cpp:353:18:353:31 | call to getenv indirection | test.cpp:356:35:356:38 | size | This allocation size is derived from $@ and might overflow. | test.cpp:353:18:353:31 | call to getenv indirection | user input (an environment variable) |
+| test.cpp:43:31:43:36 | call to malloc | test.cpp:39:27:39:30 | **argv | test.cpp:43:38:43:44 | tainted | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | **argv | user input (a command-line argument) |
+| test.cpp:44:31:44:36 | call to malloc | test.cpp:39:27:39:30 | **argv | test.cpp:44:38:44:63 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | **argv | user input (a command-line argument) |
+| test.cpp:46:31:46:36 | call to malloc | test.cpp:39:27:39:30 | **argv | test.cpp:46:38:46:63 | ... + ... | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | **argv | user input (a command-line argument) |
+| test.cpp:49:25:49:30 | call to malloc | test.cpp:39:27:39:30 | **argv | test.cpp:49:32:49:35 | size | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | **argv | user input (a command-line argument) |
+| test.cpp:50:17:50:30 | new[] | test.cpp:39:27:39:30 | **argv | test.cpp:50:17:50:30 | size | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | **argv | user input (a command-line argument) |
+| test.cpp:53:21:53:27 | call to realloc | test.cpp:39:27:39:30 | **argv | test.cpp:53:35:53:60 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | **argv | user input (a command-line argument) |
+| test.cpp:128:17:128:22 | call to malloc | test.cpp:124:18:124:31 | *call to getenv | test.cpp:128:24:128:41 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:124:18:124:31 | *call to getenv | user input (an environment variable) |
+| test.cpp:135:3:135:8 | call to malloc | test.cpp:133:19:133:32 | *call to getenv | test.cpp:135:10:135:27 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:133:19:133:32 | *call to getenv | user input (an environment variable) |
+| test.cpp:152:4:152:9 | call to malloc | test.cpp:148:20:148:33 | *call to getenv | test.cpp:152:11:152:28 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:148:20:148:33 | *call to getenv | user input (an environment variable) |
+| test.cpp:231:14:231:19 | call to malloc | test.cpp:237:24:237:37 | *call to getenv | test.cpp:231:21:231:21 | s | This allocation size is derived from $@ and might overflow. | test.cpp:237:24:237:37 | *call to getenv | user input (an environment variable) |
+| test.cpp:239:2:239:7 | call to malloc | test.cpp:237:24:237:37 | *call to getenv | test.cpp:239:9:239:18 | local_size | This allocation size is derived from $@ and might overflow. | test.cpp:237:24:237:37 | *call to getenv | user input (an environment variable) |
+| test.cpp:241:2:241:7 | call to malloc | test.cpp:211:14:211:27 | *call to getenv | test.cpp:241:9:241:24 | call to get_tainted_size | This allocation size is derived from $@ and might overflow. | test.cpp:211:14:211:27 | *call to getenv | user input (an environment variable) |
+| test.cpp:245:2:245:9 | call to my_alloc | test.cpp:237:24:237:37 | *call to getenv | test.cpp:245:11:245:20 | local_size | This allocation size is derived from $@ and might overflow. | test.cpp:237:24:237:37 | *call to getenv | user input (an environment variable) |
+| test.cpp:263:4:263:9 | call to malloc | test.cpp:259:20:259:33 | *call to getenv | test.cpp:263:11:263:29 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:259:20:259:33 | *call to getenv | user input (an environment variable) |
+| test.cpp:291:4:291:9 | call to malloc | test.cpp:251:18:251:31 | *call to getenv | test.cpp:291:11:291:28 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:251:18:251:31 | *call to getenv | user input (an environment variable) |
+| test.cpp:308:3:308:8 | call to malloc | test.cpp:251:18:251:31 | *call to getenv | test.cpp:308:10:308:27 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:251:18:251:31 | *call to getenv | user input (an environment variable) |
+| test.cpp:355:25:355:33 | call to MyMalloc1 | test.cpp:353:18:353:31 | *call to getenv | test.cpp:355:35:355:38 | size | This allocation size is derived from $@ and might overflow. | test.cpp:353:18:353:31 | *call to getenv | user input (an environment variable) |
+| test.cpp:356:25:356:33 | call to MyMalloc2 | test.cpp:353:18:353:31 | *call to getenv | test.cpp:356:35:356:38 | size | This allocation size is derived from $@ and might overflow. | test.cpp:353:18:353:31 | *call to getenv | user input (an environment variable) |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/ArithmeticTainted.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/ArithmeticTainted.expected
@@ -4,16 +4,16 @@ edges
 | test2.cpp:27:13:27:13 | v | test2.cpp:12:21:12:21 | v |
 | test2.cpp:36:9:36:14 | fgets output argument | test2.cpp:39:9:39:11 | num |
 | test2.cpp:36:9:36:14 | fgets output argument | test2.cpp:40:3:40:5 | num |
-| test3.c:10:27:10:30 | argv indirection | test.c:14:15:14:28 | maxConnections |
-| test3.c:10:27:10:30 | argv indirection | test.c:44:7:44:10 | len2 |
-| test3.c:10:27:10:30 | argv indirection | test.c:54:7:54:10 | len3 |
-| test5.cpp:5:5:5:17 | getTaintedInt indirection | test5.cpp:17:6:17:18 | call to getTaintedInt |
-| test5.cpp:5:5:5:17 | getTaintedInt indirection | test5.cpp:18:6:18:18 | call to getTaintedInt |
-| test5.cpp:9:7:9:9 | gets output argument | test5.cpp:5:5:5:17 | getTaintedInt indirection |
+| test3.c:10:27:10:30 | **argv | test.c:14:15:14:28 | maxConnections |
+| test3.c:10:27:10:30 | **argv | test.c:44:7:44:10 | len2 |
+| test3.c:10:27:10:30 | **argv | test.c:54:7:54:10 | len3 |
+| test5.cpp:5:5:5:17 | *getTaintedInt | test5.cpp:17:6:17:18 | call to getTaintedInt |
+| test5.cpp:5:5:5:17 | *getTaintedInt | test5.cpp:18:6:18:18 | call to getTaintedInt |
+| test5.cpp:9:7:9:9 | gets output argument | test5.cpp:5:5:5:17 | *getTaintedInt |
 | test5.cpp:18:6:18:18 | call to getTaintedInt | test5.cpp:19:6:19:6 | y |
-| test.c:10:27:10:30 | argv indirection | test.c:14:15:14:28 | maxConnections |
-| test.c:10:27:10:30 | argv indirection | test.c:44:7:44:10 | len2 |
-| test.c:10:27:10:30 | argv indirection | test.c:54:7:54:10 | len3 |
+| test.c:10:27:10:30 | **argv | test.c:14:15:14:28 | maxConnections |
+| test.c:10:27:10:30 | **argv | test.c:44:7:44:10 | len2 |
+| test.c:10:27:10:30 | **argv | test.c:54:7:54:10 | len3 |
 nodes
 | test2.cpp:12:21:12:21 | v | semmle.label | v |
 | test2.cpp:14:11:14:11 | v | semmle.label | v |
@@ -22,13 +22,13 @@ nodes
 | test2.cpp:36:9:36:14 | fgets output argument | semmle.label | fgets output argument |
 | test2.cpp:39:9:39:11 | num | semmle.label | num |
 | test2.cpp:40:3:40:5 | num | semmle.label | num |
-| test3.c:10:27:10:30 | argv indirection | semmle.label | argv indirection |
-| test5.cpp:5:5:5:17 | getTaintedInt indirection | semmle.label | getTaintedInt indirection |
+| test3.c:10:27:10:30 | **argv | semmle.label | **argv |
+| test5.cpp:5:5:5:17 | *getTaintedInt | semmle.label | *getTaintedInt |
 | test5.cpp:9:7:9:9 | gets output argument | semmle.label | gets output argument |
 | test5.cpp:17:6:17:18 | call to getTaintedInt | semmle.label | call to getTaintedInt |
 | test5.cpp:18:6:18:18 | call to getTaintedInt | semmle.label | call to getTaintedInt |
 | test5.cpp:19:6:19:6 | y | semmle.label | y |
-| test.c:10:27:10:30 | argv indirection | semmle.label | argv indirection |
+| test.c:10:27:10:30 | **argv | semmle.label | **argv |
 | test.c:14:15:14:28 | maxConnections | semmle.label | maxConnections |
 | test.c:44:7:44:10 | len2 | semmle.label | len2 |
 | test.c:54:7:54:10 | len3 | semmle.label | len3 |
@@ -41,19 +41,19 @@ subpaths
 | test5.cpp:17:6:17:18 | call to getTaintedInt | test5.cpp:9:7:9:9 | gets output argument | test5.cpp:17:6:17:18 | call to getTaintedInt | $@ flows to an operand of an arithmetic expression, potentially causing an overflow. | test5.cpp:9:7:9:9 | gets output argument | string read by gets |
 | test5.cpp:19:6:19:6 | y | test5.cpp:9:7:9:9 | gets output argument | test5.cpp:19:6:19:6 | y | $@ flows to an operand of an arithmetic expression, potentially causing an overflow. | test5.cpp:9:7:9:9 | gets output argument | string read by gets |
 | test5.cpp:19:6:19:6 | y | test5.cpp:9:7:9:9 | gets output argument | test5.cpp:19:6:19:6 | y | $@ flows to an operand of an arithmetic expression, potentially causing an underflow. | test5.cpp:9:7:9:9 | gets output argument | string read by gets |
-| test.c:14:15:14:28 | maxConnections | test3.c:10:27:10:30 | argv indirection | test.c:14:15:14:28 | maxConnections | $@ flows to an operand of an arithmetic expression, potentially causing an overflow. | test3.c:10:27:10:30 | argv indirection | a command-line argument |
-| test.c:14:15:14:28 | maxConnections | test3.c:10:27:10:30 | argv indirection | test.c:14:15:14:28 | maxConnections | $@ flows to an operand of an arithmetic expression, potentially causing an overflow. | test.c:10:27:10:30 | argv indirection | a command-line argument |
-| test.c:14:15:14:28 | maxConnections | test3.c:10:27:10:30 | argv indirection | test.c:14:15:14:28 | maxConnections | $@ flows to an operand of an arithmetic expression, potentially causing an underflow. | test3.c:10:27:10:30 | argv indirection | a command-line argument |
-| test.c:14:15:14:28 | maxConnections | test3.c:10:27:10:30 | argv indirection | test.c:14:15:14:28 | maxConnections | $@ flows to an operand of an arithmetic expression, potentially causing an underflow. | test.c:10:27:10:30 | argv indirection | a command-line argument |
-| test.c:14:15:14:28 | maxConnections | test.c:10:27:10:30 | argv indirection | test.c:14:15:14:28 | maxConnections | $@ flows to an operand of an arithmetic expression, potentially causing an overflow. | test3.c:10:27:10:30 | argv indirection | a command-line argument |
-| test.c:14:15:14:28 | maxConnections | test.c:10:27:10:30 | argv indirection | test.c:14:15:14:28 | maxConnections | $@ flows to an operand of an arithmetic expression, potentially causing an overflow. | test.c:10:27:10:30 | argv indirection | a command-line argument |
-| test.c:14:15:14:28 | maxConnections | test.c:10:27:10:30 | argv indirection | test.c:14:15:14:28 | maxConnections | $@ flows to an operand of an arithmetic expression, potentially causing an underflow. | test3.c:10:27:10:30 | argv indirection | a command-line argument |
-| test.c:14:15:14:28 | maxConnections | test.c:10:27:10:30 | argv indirection | test.c:14:15:14:28 | maxConnections | $@ flows to an operand of an arithmetic expression, potentially causing an underflow. | test.c:10:27:10:30 | argv indirection | a command-line argument |
-| test.c:44:7:44:10 | len2 | test3.c:10:27:10:30 | argv indirection | test.c:44:7:44:10 | len2 | $@ flows to an operand of an arithmetic expression, potentially causing an underflow. | test3.c:10:27:10:30 | argv indirection | a command-line argument |
-| test.c:44:7:44:10 | len2 | test3.c:10:27:10:30 | argv indirection | test.c:44:7:44:10 | len2 | $@ flows to an operand of an arithmetic expression, potentially causing an underflow. | test.c:10:27:10:30 | argv indirection | a command-line argument |
-| test.c:44:7:44:10 | len2 | test.c:10:27:10:30 | argv indirection | test.c:44:7:44:10 | len2 | $@ flows to an operand of an arithmetic expression, potentially causing an underflow. | test3.c:10:27:10:30 | argv indirection | a command-line argument |
-| test.c:44:7:44:10 | len2 | test.c:10:27:10:30 | argv indirection | test.c:44:7:44:10 | len2 | $@ flows to an operand of an arithmetic expression, potentially causing an underflow. | test.c:10:27:10:30 | argv indirection | a command-line argument |
-| test.c:54:7:54:10 | len3 | test3.c:10:27:10:30 | argv indirection | test.c:54:7:54:10 | len3 | $@ flows to an operand of an arithmetic expression, potentially causing an underflow. | test3.c:10:27:10:30 | argv indirection | a command-line argument |
-| test.c:54:7:54:10 | len3 | test3.c:10:27:10:30 | argv indirection | test.c:54:7:54:10 | len3 | $@ flows to an operand of an arithmetic expression, potentially causing an underflow. | test.c:10:27:10:30 | argv indirection | a command-line argument |
-| test.c:54:7:54:10 | len3 | test.c:10:27:10:30 | argv indirection | test.c:54:7:54:10 | len3 | $@ flows to an operand of an arithmetic expression, potentially causing an underflow. | test3.c:10:27:10:30 | argv indirection | a command-line argument |
-| test.c:54:7:54:10 | len3 | test.c:10:27:10:30 | argv indirection | test.c:54:7:54:10 | len3 | $@ flows to an operand of an arithmetic expression, potentially causing an underflow. | test.c:10:27:10:30 | argv indirection | a command-line argument |
+| test.c:14:15:14:28 | maxConnections | test3.c:10:27:10:30 | **argv | test.c:14:15:14:28 | maxConnections | $@ flows to an operand of an arithmetic expression, potentially causing an overflow. | test3.c:10:27:10:30 | **argv | a command-line argument |
+| test.c:14:15:14:28 | maxConnections | test3.c:10:27:10:30 | **argv | test.c:14:15:14:28 | maxConnections | $@ flows to an operand of an arithmetic expression, potentially causing an overflow. | test.c:10:27:10:30 | **argv | a command-line argument |
+| test.c:14:15:14:28 | maxConnections | test3.c:10:27:10:30 | **argv | test.c:14:15:14:28 | maxConnections | $@ flows to an operand of an arithmetic expression, potentially causing an underflow. | test3.c:10:27:10:30 | **argv | a command-line argument |
+| test.c:14:15:14:28 | maxConnections | test3.c:10:27:10:30 | **argv | test.c:14:15:14:28 | maxConnections | $@ flows to an operand of an arithmetic expression, potentially causing an underflow. | test.c:10:27:10:30 | **argv | a command-line argument |
+| test.c:14:15:14:28 | maxConnections | test.c:10:27:10:30 | **argv | test.c:14:15:14:28 | maxConnections | $@ flows to an operand of an arithmetic expression, potentially causing an overflow. | test3.c:10:27:10:30 | **argv | a command-line argument |
+| test.c:14:15:14:28 | maxConnections | test.c:10:27:10:30 | **argv | test.c:14:15:14:28 | maxConnections | $@ flows to an operand of an arithmetic expression, potentially causing an overflow. | test.c:10:27:10:30 | **argv | a command-line argument |
+| test.c:14:15:14:28 | maxConnections | test.c:10:27:10:30 | **argv | test.c:14:15:14:28 | maxConnections | $@ flows to an operand of an arithmetic expression, potentially causing an underflow. | test3.c:10:27:10:30 | **argv | a command-line argument |
+| test.c:14:15:14:28 | maxConnections | test.c:10:27:10:30 | **argv | test.c:14:15:14:28 | maxConnections | $@ flows to an operand of an arithmetic expression, potentially causing an underflow. | test.c:10:27:10:30 | **argv | a command-line argument |
+| test.c:44:7:44:10 | len2 | test3.c:10:27:10:30 | **argv | test.c:44:7:44:10 | len2 | $@ flows to an operand of an arithmetic expression, potentially causing an underflow. | test3.c:10:27:10:30 | **argv | a command-line argument |
+| test.c:44:7:44:10 | len2 | test3.c:10:27:10:30 | **argv | test.c:44:7:44:10 | len2 | $@ flows to an operand of an arithmetic expression, potentially causing an underflow. | test.c:10:27:10:30 | **argv | a command-line argument |
+| test.c:44:7:44:10 | len2 | test.c:10:27:10:30 | **argv | test.c:44:7:44:10 | len2 | $@ flows to an operand of an arithmetic expression, potentially causing an underflow. | test3.c:10:27:10:30 | **argv | a command-line argument |
+| test.c:44:7:44:10 | len2 | test.c:10:27:10:30 | **argv | test.c:44:7:44:10 | len2 | $@ flows to an operand of an arithmetic expression, potentially causing an underflow. | test.c:10:27:10:30 | **argv | a command-line argument |
+| test.c:54:7:54:10 | len3 | test3.c:10:27:10:30 | **argv | test.c:54:7:54:10 | len3 | $@ flows to an operand of an arithmetic expression, potentially causing an underflow. | test3.c:10:27:10:30 | **argv | a command-line argument |
+| test.c:54:7:54:10 | len3 | test3.c:10:27:10:30 | **argv | test.c:54:7:54:10 | len3 | $@ flows to an operand of an arithmetic expression, potentially causing an underflow. | test.c:10:27:10:30 | **argv | a command-line argument |
+| test.c:54:7:54:10 | len3 | test.c:10:27:10:30 | **argv | test.c:54:7:54:10 | len3 | $@ flows to an operand of an arithmetic expression, potentially causing an underflow. | test3.c:10:27:10:30 | **argv | a command-line argument |
+| test.c:54:7:54:10 | len3 | test.c:10:27:10:30 | **argv | test.c:54:7:54:10 | len3 | $@ flows to an operand of an arithmetic expression, potentially causing an underflow. | test.c:10:27:10:30 | **argv | a command-line argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/IntegerOverflowTainted.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/IntegerOverflowTainted.expected
@@ -4,20 +4,20 @@
 | test2.cpp:17:11:17:22 | ... * ... | $@ flows an expression which might overflow. | test2.cpp:25:22:25:23 | fscanf output argument | value read by fscanf |
 | test2.cpp:39:9:39:18 | ... + ... | $@ flows an expression which might overflow. | test2.cpp:36:9:36:14 | fgets output argument | string read by fgets |
 | test2.cpp:40:3:40:13 | ... += ... | $@ flows an expression which might overflow. | test2.cpp:36:9:36:14 | fgets output argument | string read by fgets |
-| test3.c:12:11:12:34 | * ... | $@ flows an expression which might overflow negatively. | test3.c:10:27:10:30 | argv indirection | a command-line argument |
-| test3.c:12:11:12:34 | * ... | $@ flows an expression which might overflow negatively. | test.c:10:27:10:30 | argv indirection | a command-line argument |
-| test3.c:13:11:13:20 | * ... | $@ flows an expression which might overflow negatively. | test3.c:10:27:10:30 | argv indirection | a command-line argument |
-| test3.c:13:11:13:20 | * ... | $@ flows an expression which might overflow negatively. | test.c:10:27:10:30 | argv indirection | a command-line argument |
-| test4.cpp:13:7:13:20 | access to array | $@ flows an expression which might overflow negatively. | test4.cpp:8:27:8:30 | argv indirection | a command-line argument |
+| test3.c:12:11:12:34 | * ... | $@ flows an expression which might overflow negatively. | test3.c:10:27:10:30 | **argv | a command-line argument |
+| test3.c:12:11:12:34 | * ... | $@ flows an expression which might overflow negatively. | test.c:10:27:10:30 | **argv | a command-line argument |
+| test3.c:13:11:13:20 | * ... | $@ flows an expression which might overflow negatively. | test3.c:10:27:10:30 | **argv | a command-line argument |
+| test3.c:13:11:13:20 | * ... | $@ flows an expression which might overflow negatively. | test.c:10:27:10:30 | **argv | a command-line argument |
+| test4.cpp:13:7:13:20 | access to array | $@ flows an expression which might overflow negatively. | test4.cpp:8:27:8:30 | **argv | a command-line argument |
 | test5.cpp:10:9:10:27 | call to strtoul | $@ flows an expression which might overflow. | test5.cpp:9:7:9:9 | gets output argument | string read by gets |
 | test5.cpp:17:6:17:27 | ... * ... | $@ flows an expression which might overflow. | test5.cpp:9:7:9:9 | gets output argument | string read by gets |
 | test5.cpp:19:6:19:13 | ... * ... | $@ flows an expression which might overflow. | test5.cpp:9:7:9:9 | gets output argument | string read by gets |
 | test6.cpp:11:10:11:15 | s | $@ flows an expression which might overflow. | test6.cpp:39:23:39:24 | fscanf output argument | value read by fscanf |
 | test6.cpp:16:10:16:15 | s | $@ flows an expression which might overflow. | test6.cpp:39:23:39:24 | fscanf output argument | value read by fscanf |
 | test6.cpp:30:11:30:16 | s | $@ flows an expression which might overflow. | test6.cpp:39:23:39:24 | fscanf output argument | value read by fscanf |
-| test.c:14:15:14:35 | ... * ... | $@ flows an expression which might overflow. | test3.c:10:27:10:30 | argv indirection | a command-line argument |
-| test.c:14:15:14:35 | ... * ... | $@ flows an expression which might overflow. | test.c:10:27:10:30 | argv indirection | a command-line argument |
-| test.c:44:7:44:12 | ... -- | $@ flows an expression which might overflow negatively. | test3.c:10:27:10:30 | argv indirection | a command-line argument |
-| test.c:44:7:44:12 | ... -- | $@ flows an expression which might overflow negatively. | test.c:10:27:10:30 | argv indirection | a command-line argument |
-| test.c:54:7:54:12 | ... -- | $@ flows an expression which might overflow negatively. | test3.c:10:27:10:30 | argv indirection | a command-line argument |
-| test.c:54:7:54:12 | ... -- | $@ flows an expression which might overflow negatively. | test.c:10:27:10:30 | argv indirection | a command-line argument |
+| test.c:14:15:14:35 | ... * ... | $@ flows an expression which might overflow. | test3.c:10:27:10:30 | **argv | a command-line argument |
+| test.c:14:15:14:35 | ... * ... | $@ flows an expression which might overflow. | test.c:10:27:10:30 | **argv | a command-line argument |
+| test.c:44:7:44:12 | ... -- | $@ flows an expression which might overflow negatively. | test3.c:10:27:10:30 | **argv | a command-line argument |
+| test.c:44:7:44:12 | ... -- | $@ flows an expression which might overflow negatively. | test.c:10:27:10:30 | **argv | a command-line argument |
+| test.c:54:7:54:12 | ... -- | $@ flows an expression which might overflow negatively. | test3.c:10:27:10:30 | **argv | a command-line argument |
+| test.c:54:7:54:12 | ... -- | $@ flows an expression which might overflow negatively. | test.c:10:27:10:30 | **argv | a command-line argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-193/InvalidPointerDeref.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-193/InvalidPointerDeref.expected
@@ -18,9 +18,9 @@ edges
 | test.cpp:29:15:29:28 | ... + ... | test.cpp:32:14:32:21 | * ... |
 | test.cpp:29:15:29:28 | ... + ... | test.cpp:32:14:32:21 | * ... |
 | test.cpp:30:14:30:15 | * ... | test.cpp:32:14:32:21 | * ... |
-| test.cpp:51:33:51:35 | end | test.cpp:60:34:60:37 | mk_array output argument |
+| test.cpp:51:33:51:35 | *end | test.cpp:60:34:60:37 | mk_array output argument |
 | test.cpp:52:19:52:37 | call to malloc | test.cpp:53:12:53:23 | ... + ... |
-| test.cpp:53:12:53:23 | ... + ... | test.cpp:51:33:51:35 | end |
+| test.cpp:53:12:53:23 | ... + ... | test.cpp:51:33:51:35 | *end |
 | test.cpp:60:34:60:37 | mk_array output argument | test.cpp:67:9:67:14 | ... = ... |
 | test.cpp:205:15:205:33 | call to malloc | test.cpp:206:17:206:23 | ... + ... |
 | test.cpp:206:17:206:23 | ... + ... | test.cpp:206:17:206:23 | ... + ... |
@@ -40,14 +40,14 @@ edges
 | test.cpp:271:14:271:21 | ... + ... | test.cpp:274:5:274:10 | ... = ... |
 | test.cpp:355:14:355:27 | new[] | test.cpp:356:15:356:23 | ... + ... |
 | test.cpp:356:15:356:23 | ... + ... | test.cpp:356:15:356:23 | ... + ... |
-| test.cpp:356:15:356:23 | ... + ... | test.cpp:358:14:358:26 | end_plus_one indirection |
-| test.cpp:356:15:356:23 | ... + ... | test.cpp:358:14:358:26 | end_plus_one indirection |
-| test.cpp:356:15:356:23 | ... + ... | test.cpp:359:14:359:32 | ... + ... indirection |
-| test.cpp:356:15:356:23 | ... + ... | test.cpp:359:14:359:32 | ... + ... indirection |
+| test.cpp:356:15:356:23 | ... + ... | test.cpp:358:14:358:26 | * ... |
+| test.cpp:356:15:356:23 | ... + ... | test.cpp:358:14:358:26 | * ... |
+| test.cpp:356:15:356:23 | ... + ... | test.cpp:359:14:359:32 | * ... |
+| test.cpp:356:15:356:23 | ... + ... | test.cpp:359:14:359:32 | * ... |
 | test.cpp:377:14:377:27 | new[] | test.cpp:378:15:378:23 | ... + ... |
 | test.cpp:378:15:378:23 | ... + ... | test.cpp:378:15:378:23 | ... + ... |
-| test.cpp:378:15:378:23 | ... + ... | test.cpp:384:13:384:16 | end indirection |
-| test.cpp:378:15:378:23 | ... + ... | test.cpp:384:13:384:16 | end indirection |
+| test.cpp:378:15:378:23 | ... + ... | test.cpp:384:13:384:16 | * ... |
+| test.cpp:378:15:378:23 | ... + ... | test.cpp:384:13:384:16 | * ... |
 | test.cpp:410:14:410:27 | new[] | test.cpp:411:15:411:23 | & ... |
 | test.cpp:410:14:410:27 | new[] | test.cpp:415:7:415:15 | ... = ... |
 | test.cpp:411:15:411:23 | & ... | test.cpp:411:15:411:23 | & ... |
@@ -85,10 +85,10 @@ edges
 | test.cpp:754:18:754:31 | new[] | test.cpp:772:16:772:29 | access to array |
 | test.cpp:754:18:754:31 | new[] | test.cpp:772:16:772:29 | access to array |
 | test.cpp:781:14:781:27 | new[] | test.cpp:786:18:786:27 | access to array |
-| test.cpp:792:60:792:62 | end | test.cpp:800:40:800:43 | mk_array_no_field_flow output argument |
-| test.cpp:792:60:792:62 | end | test.cpp:832:40:832:43 | mk_array_no_field_flow output argument |
+| test.cpp:792:60:792:62 | *end | test.cpp:800:40:800:43 | mk_array_no_field_flow output argument |
+| test.cpp:792:60:792:62 | *end | test.cpp:832:40:832:43 | mk_array_no_field_flow output argument |
 | test.cpp:793:14:793:32 | call to malloc | test.cpp:794:12:794:24 | ... + ... |
-| test.cpp:794:12:794:24 | ... + ... | test.cpp:792:60:792:62 | end |
+| test.cpp:794:12:794:24 | ... + ... | test.cpp:792:60:792:62 | *end |
 | test.cpp:800:40:800:43 | mk_array_no_field_flow output argument | test.cpp:807:7:807:12 | ... = ... |
 | test.cpp:815:52:815:54 | end | test.cpp:815:52:815:54 | end |
 | test.cpp:815:52:815:54 | end | test.cpp:821:7:821:12 | ... = ... |
@@ -116,7 +116,7 @@ nodes
 | test.cpp:30:14:30:15 | * ... | semmle.label | * ... |
 | test.cpp:30:14:30:15 | * ... | semmle.label | * ... |
 | test.cpp:32:14:32:21 | * ... | semmle.label | * ... |
-| test.cpp:51:33:51:35 | end | semmle.label | end |
+| test.cpp:51:33:51:35 | *end | semmle.label | *end |
 | test.cpp:52:19:52:37 | call to malloc | semmle.label | call to malloc |
 | test.cpp:53:12:53:23 | ... + ... | semmle.label | ... + ... |
 | test.cpp:60:34:60:37 | mk_array output argument | semmle.label | mk_array output argument |
@@ -137,12 +137,12 @@ nodes
 | test.cpp:355:14:355:27 | new[] | semmle.label | new[] |
 | test.cpp:356:15:356:23 | ... + ... | semmle.label | ... + ... |
 | test.cpp:356:15:356:23 | ... + ... | semmle.label | ... + ... |
-| test.cpp:358:14:358:26 | end_plus_one indirection | semmle.label | end_plus_one indirection |
-| test.cpp:359:14:359:32 | ... + ... indirection | semmle.label | ... + ... indirection |
+| test.cpp:358:14:358:26 | * ... | semmle.label | * ... |
+| test.cpp:359:14:359:32 | * ... | semmle.label | * ... |
 | test.cpp:377:14:377:27 | new[] | semmle.label | new[] |
 | test.cpp:378:15:378:23 | ... + ... | semmle.label | ... + ... |
 | test.cpp:378:15:378:23 | ... + ... | semmle.label | ... + ... |
-| test.cpp:384:13:384:16 | end indirection | semmle.label | end indirection |
+| test.cpp:384:13:384:16 | * ... | semmle.label | * ... |
 | test.cpp:410:14:410:27 | new[] | semmle.label | new[] |
 | test.cpp:411:15:411:23 | & ... | semmle.label | & ... |
 | test.cpp:411:15:411:23 | & ... | semmle.label | & ... |
@@ -180,7 +180,7 @@ nodes
 | test.cpp:772:16:772:29 | access to array | semmle.label | access to array |
 | test.cpp:781:14:781:27 | new[] | semmle.label | new[] |
 | test.cpp:786:18:786:27 | access to array | semmle.label | access to array |
-| test.cpp:792:60:792:62 | end | semmle.label | end |
+| test.cpp:792:60:792:62 | *end | semmle.label | *end |
 | test.cpp:793:14:793:32 | call to malloc | semmle.label | call to malloc |
 | test.cpp:794:12:794:24 | ... + ... | semmle.label | ... + ... |
 | test.cpp:800:40:800:43 | mk_array_no_field_flow output argument | semmle.label | mk_array_no_field_flow output argument |
@@ -209,9 +209,9 @@ subpaths
 | test.cpp:213:5:213:13 | ... = ... | test.cpp:205:15:205:33 | call to malloc | test.cpp:213:5:213:13 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:205:15:205:33 | call to malloc | call to malloc | test.cpp:206:21:206:23 | len | len |
 | test.cpp:264:13:264:14 | * ... | test.cpp:260:13:260:24 | new[] | test.cpp:264:13:264:14 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:260:13:260:24 | new[] | new[] | test.cpp:261:19:261:21 | len | len |
 | test.cpp:274:5:274:10 | ... = ... | test.cpp:270:13:270:24 | new[] | test.cpp:274:5:274:10 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:270:13:270:24 | new[] | new[] | test.cpp:271:19:271:21 | len | len |
-| test.cpp:358:14:358:26 | end_plus_one indirection | test.cpp:355:14:355:27 | new[] | test.cpp:358:14:358:26 | end_plus_one indirection | This read might be out of bounds, as the pointer might be equal to $@ + $@ + 1. | test.cpp:355:14:355:27 | new[] | new[] | test.cpp:356:20:356:23 | size | size |
-| test.cpp:359:14:359:32 | ... + ... indirection | test.cpp:355:14:355:27 | new[] | test.cpp:359:14:359:32 | ... + ... indirection | This read might be out of bounds, as the pointer might be equal to $@ + $@ + 2. | test.cpp:355:14:355:27 | new[] | new[] | test.cpp:356:20:356:23 | size | size |
-| test.cpp:384:13:384:16 | end indirection | test.cpp:377:14:377:27 | new[] | test.cpp:384:13:384:16 | end indirection | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:377:14:377:27 | new[] | new[] | test.cpp:378:20:378:23 | size | size |
+| test.cpp:358:14:358:26 | * ... | test.cpp:355:14:355:27 | new[] | test.cpp:358:14:358:26 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@ + 1. | test.cpp:355:14:355:27 | new[] | new[] | test.cpp:356:20:356:23 | size | size |
+| test.cpp:359:14:359:32 | * ... | test.cpp:355:14:355:27 | new[] | test.cpp:359:14:359:32 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@ + 2. | test.cpp:355:14:355:27 | new[] | new[] | test.cpp:356:20:356:23 | size | size |
+| test.cpp:384:13:384:16 | * ... | test.cpp:377:14:377:27 | new[] | test.cpp:384:13:384:16 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:377:14:377:27 | new[] | new[] | test.cpp:378:20:378:23 | size | size |
 | test.cpp:415:7:415:15 | ... = ... | test.cpp:410:14:410:27 | new[] | test.cpp:415:7:415:15 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:410:14:410:27 | new[] | new[] | test.cpp:411:19:411:22 | size | size |
 | test.cpp:426:7:426:15 | ... = ... | test.cpp:421:14:421:27 | new[] | test.cpp:426:7:426:15 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:421:14:421:27 | new[] | new[] | test.cpp:422:19:422:22 | size | size |
 | test.cpp:438:7:438:15 | ... = ... | test.cpp:432:14:432:27 | new[] | test.cpp:438:7:438:15 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:432:14:432:27 | new[] | new[] | test.cpp:433:19:433:22 | size | size |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-290/semmle/AuthenticationBypass/AuthenticationBypass.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-290/semmle/AuthenticationBypass/AuthenticationBypass.expected
@@ -1,26 +1,26 @@
 edges
-| test.cpp:16:25:16:42 | call to getenv indirection | test.cpp:20:14:20:20 | address indirection |
-| test.cpp:27:25:27:42 | call to getenv indirection | test.cpp:31:14:31:20 | address indirection |
-| test.cpp:38:25:38:42 | call to getenv indirection | test.cpp:42:14:42:20 | address indirection |
-| test.cpp:49:25:49:42 | call to getenv indirection | test.cpp:52:14:52:20 | address indirection |
-| test.cpp:49:25:49:42 | call to getenv indirection | test.cpp:56:14:56:20 | address indirection |
-| test.cpp:49:25:49:42 | call to getenv indirection | test.cpp:60:14:60:20 | address indirection |
+| test.cpp:16:25:16:42 | *call to getenv | test.cpp:20:14:20:20 | *address |
+| test.cpp:27:25:27:42 | *call to getenv | test.cpp:31:14:31:20 | *address |
+| test.cpp:38:25:38:42 | *call to getenv | test.cpp:42:14:42:20 | *address |
+| test.cpp:49:25:49:42 | *call to getenv | test.cpp:52:14:52:20 | *address |
+| test.cpp:49:25:49:42 | *call to getenv | test.cpp:56:14:56:20 | *address |
+| test.cpp:49:25:49:42 | *call to getenv | test.cpp:60:14:60:20 | *address |
 nodes
-| test.cpp:16:25:16:42 | call to getenv indirection | semmle.label | call to getenv indirection |
-| test.cpp:20:14:20:20 | address indirection | semmle.label | address indirection |
-| test.cpp:27:25:27:42 | call to getenv indirection | semmle.label | call to getenv indirection |
-| test.cpp:31:14:31:20 | address indirection | semmle.label | address indirection |
-| test.cpp:38:25:38:42 | call to getenv indirection | semmle.label | call to getenv indirection |
-| test.cpp:42:14:42:20 | address indirection | semmle.label | address indirection |
-| test.cpp:49:25:49:42 | call to getenv indirection | semmle.label | call to getenv indirection |
-| test.cpp:52:14:52:20 | address indirection | semmle.label | address indirection |
-| test.cpp:56:14:56:20 | address indirection | semmle.label | address indirection |
-| test.cpp:60:14:60:20 | address indirection | semmle.label | address indirection |
+| test.cpp:16:25:16:42 | *call to getenv | semmle.label | *call to getenv |
+| test.cpp:20:14:20:20 | *address | semmle.label | *address |
+| test.cpp:27:25:27:42 | *call to getenv | semmle.label | *call to getenv |
+| test.cpp:31:14:31:20 | *address | semmle.label | *address |
+| test.cpp:38:25:38:42 | *call to getenv | semmle.label | *call to getenv |
+| test.cpp:42:14:42:20 | *address | semmle.label | *address |
+| test.cpp:49:25:49:42 | *call to getenv | semmle.label | *call to getenv |
+| test.cpp:52:14:52:20 | *address | semmle.label | *address |
+| test.cpp:56:14:56:20 | *address | semmle.label | *address |
+| test.cpp:60:14:60:20 | *address | semmle.label | *address |
 subpaths
 #select
-| test.cpp:20:7:20:12 | call to strcmp | test.cpp:16:25:16:42 | call to getenv indirection | test.cpp:20:14:20:20 | address indirection | Untrusted input $@ might be vulnerable to a spoofing attack. | test.cpp:16:25:16:42 | call to getenv indirection | an environment variable |
-| test.cpp:31:7:31:12 | call to strcmp | test.cpp:27:25:27:42 | call to getenv indirection | test.cpp:31:14:31:20 | address indirection | Untrusted input $@ might be vulnerable to a spoofing attack. | test.cpp:27:25:27:42 | call to getenv indirection | an environment variable |
-| test.cpp:42:7:42:12 | call to strcmp | test.cpp:38:25:38:42 | call to getenv indirection | test.cpp:42:14:42:20 | address indirection | Untrusted input $@ might be vulnerable to a spoofing attack. | test.cpp:38:25:38:42 | call to getenv indirection | an environment variable |
-| test.cpp:52:7:52:12 | call to strcmp | test.cpp:49:25:49:42 | call to getenv indirection | test.cpp:52:14:52:20 | address indirection | Untrusted input $@ might be vulnerable to a spoofing attack. | test.cpp:49:25:49:42 | call to getenv indirection | an environment variable |
-| test.cpp:56:7:56:12 | call to strcmp | test.cpp:49:25:49:42 | call to getenv indirection | test.cpp:56:14:56:20 | address indirection | Untrusted input $@ might be vulnerable to a spoofing attack. | test.cpp:49:25:49:42 | call to getenv indirection | an environment variable |
-| test.cpp:60:7:60:12 | call to strcmp | test.cpp:49:25:49:42 | call to getenv indirection | test.cpp:60:14:60:20 | address indirection | Untrusted input $@ might be vulnerable to a spoofing attack. | test.cpp:49:25:49:42 | call to getenv indirection | an environment variable |
+| test.cpp:20:7:20:12 | call to strcmp | test.cpp:16:25:16:42 | *call to getenv | test.cpp:20:14:20:20 | *address | Untrusted input $@ might be vulnerable to a spoofing attack. | test.cpp:16:25:16:42 | *call to getenv | an environment variable |
+| test.cpp:31:7:31:12 | call to strcmp | test.cpp:27:25:27:42 | *call to getenv | test.cpp:31:14:31:20 | *address | Untrusted input $@ might be vulnerable to a spoofing attack. | test.cpp:27:25:27:42 | *call to getenv | an environment variable |
+| test.cpp:42:7:42:12 | call to strcmp | test.cpp:38:25:38:42 | *call to getenv | test.cpp:42:14:42:20 | *address | Untrusted input $@ might be vulnerable to a spoofing attack. | test.cpp:38:25:38:42 | *call to getenv | an environment variable |
+| test.cpp:52:7:52:12 | call to strcmp | test.cpp:49:25:49:42 | *call to getenv | test.cpp:52:14:52:20 | *address | Untrusted input $@ might be vulnerable to a spoofing attack. | test.cpp:49:25:49:42 | *call to getenv | an environment variable |
+| test.cpp:56:7:56:12 | call to strcmp | test.cpp:49:25:49:42 | *call to getenv | test.cpp:56:14:56:20 | *address | Untrusted input $@ might be vulnerable to a spoofing attack. | test.cpp:49:25:49:42 | *call to getenv | an environment variable |
+| test.cpp:60:7:60:12 | call to strcmp | test.cpp:49:25:49:42 | *call to getenv | test.cpp:60:14:60:20 | *address | Untrusted input $@ might be vulnerable to a spoofing attack. | test.cpp:49:25:49:42 | *call to getenv | an environment variable |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextBufferWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextBufferWrite.expected
@@ -1,10 +1,10 @@
 edges
-| test.cpp:53:27:53:30 | argv indirection | test.cpp:58:25:58:29 | input indirection |
+| test.cpp:53:27:53:30 | **argv | test.cpp:58:25:58:29 | *input |
 nodes
-| test2.cpp:110:3:110:6 | call to gets indirection | semmle.label | call to gets indirection |
-| test.cpp:53:27:53:30 | argv indirection | semmle.label | argv indirection |
-| test.cpp:58:25:58:29 | input indirection | semmle.label | input indirection |
+| test2.cpp:110:3:110:6 | *call to gets | semmle.label | *call to gets |
+| test.cpp:53:27:53:30 | **argv | semmle.label | **argv |
+| test.cpp:58:25:58:29 | *input | semmle.label | *input |
 subpaths
 #select
-| test2.cpp:110:3:110:6 | call to gets | test2.cpp:110:3:110:6 | call to gets indirection | test2.cpp:110:3:110:6 | call to gets indirection | This write into buffer 'password' may contain unencrypted data from $@. | test2.cpp:110:3:110:6 | call to gets indirection | user input (string read by gets) |
-| test.cpp:58:3:58:9 | call to sprintf | test.cpp:53:27:53:30 | argv indirection | test.cpp:58:25:58:29 | input indirection | This write into buffer 'passwd' may contain unencrypted data from $@. | test.cpp:53:27:53:30 | argv indirection | user input (a command-line argument) |
+| test2.cpp:110:3:110:6 | call to gets | test2.cpp:110:3:110:6 | *call to gets | test2.cpp:110:3:110:6 | *call to gets | This write into buffer 'password' may contain unencrypted data from $@. | test2.cpp:110:3:110:6 | *call to gets | user input (string read by gets) |
+| test.cpp:58:3:58:9 | call to sprintf | test.cpp:53:27:53:30 | **argv | test.cpp:58:25:58:29 | *input | This write into buffer 'passwd' may contain unencrypted data from $@. | test.cpp:53:27:53:30 | **argv | user input (a command-line argument) |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
@@ -1,8 +1,8 @@
 edges
 | test2.cpp:62:18:62:25 | password | test2.cpp:65:31:65:34 | cpy1 |
-| test2.cpp:72:15:72:24 | password | test2.cpp:73:30:73:32 | buf indirection |
-| test2.cpp:72:15:72:24 | password | test2.cpp:76:30:76:32 | buf indirection |
-| test2.cpp:98:45:98:52 | password | test2.cpp:99:27:99:32 | buffer indirection |
+| test2.cpp:72:15:72:24 | password | test2.cpp:73:30:73:32 | *buf |
+| test2.cpp:72:15:72:24 | password | test2.cpp:76:30:76:32 | *buf |
+| test2.cpp:98:45:98:52 | password | test2.cpp:99:27:99:32 | *buffer |
 | test.cpp:70:38:70:48 | thePassword | test.cpp:73:43:73:53 | thePassword |
 | test.cpp:73:63:73:73 | thePassword | test.cpp:73:43:73:53 | thePassword |
 nodes
@@ -16,10 +16,10 @@ nodes
 | test2.cpp:62:18:62:25 | password | semmle.label | password |
 | test2.cpp:65:31:65:34 | cpy1 | semmle.label | cpy1 |
 | test2.cpp:72:15:72:24 | password | semmle.label | password |
-| test2.cpp:73:30:73:32 | buf indirection | semmle.label | buf indirection |
-| test2.cpp:76:30:76:32 | buf indirection | semmle.label | buf indirection |
+| test2.cpp:73:30:73:32 | *buf | semmle.label | *buf |
+| test2.cpp:76:30:76:32 | *buf | semmle.label | *buf |
 | test2.cpp:98:45:98:52 | password | semmle.label | password |
-| test2.cpp:99:27:99:32 | buffer indirection | semmle.label | buffer indirection |
+| test2.cpp:99:27:99:32 | *buffer | semmle.label | *buffer |
 | test.cpp:45:9:45:19 | thePassword | semmle.label | thePassword |
 | test.cpp:70:38:70:48 | thePassword | semmle.label | thePassword |
 | test.cpp:70:38:70:48 | thePassword | semmle.label | thePassword |
@@ -35,9 +35,9 @@ subpaths
 | test2.cpp:55:2:55:8 | call to fprintf | test2.cpp:55:40:55:51 | widepassword | test2.cpp:55:40:55:51 | widepassword | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:55:40:55:51 | widepassword | this source. |
 | test2.cpp:57:2:57:8 | call to fprintf | test2.cpp:57:39:57:49 | call to getPassword | test2.cpp:57:39:57:49 | call to getPassword | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:57:39:57:49 | call to getPassword | this source. |
 | test2.cpp:65:3:65:9 | call to fprintf | test2.cpp:62:18:62:25 | password | test2.cpp:65:31:65:34 | cpy1 | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:62:18:62:25 | password | this source. |
-| test2.cpp:73:3:73:9 | call to fprintf | test2.cpp:72:15:72:24 | password | test2.cpp:73:30:73:32 | buf indirection | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:72:17:72:24 | password | this source. |
-| test2.cpp:76:3:76:9 | call to fprintf | test2.cpp:72:15:72:24 | password | test2.cpp:76:30:76:32 | buf indirection | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:72:17:72:24 | password | this source. |
-| test2.cpp:99:3:99:9 | call to fprintf | test2.cpp:98:45:98:52 | password | test2.cpp:99:27:99:32 | buffer indirection | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:98:45:98:52 | password | this source. |
+| test2.cpp:73:3:73:9 | call to fprintf | test2.cpp:72:15:72:24 | password | test2.cpp:73:30:73:32 | *buf | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:72:17:72:24 | password | this source. |
+| test2.cpp:76:3:76:9 | call to fprintf | test2.cpp:72:15:72:24 | password | test2.cpp:76:30:76:32 | *buf | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:72:17:72:24 | password | this source. |
+| test2.cpp:99:3:99:9 | call to fprintf | test2.cpp:98:45:98:52 | password | test2.cpp:99:27:99:32 | *buffer | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:98:45:98:52 | password | this source. |
 | test.cpp:45:3:45:7 | call to fputs | test.cpp:45:9:45:19 | thePassword | test.cpp:45:9:45:19 | thePassword | This write into file 'file' may contain unencrypted data from $@. | test.cpp:45:9:45:19 | thePassword | this source. |
 | test.cpp:70:35:70:35 | call to operator<< | test.cpp:70:38:70:48 | thePassword | test.cpp:70:38:70:48 | thePassword | This write into file 'mystream' may contain unencrypted data from $@. | test.cpp:70:38:70:48 | thePassword | this source. |
 | test.cpp:73:37:73:41 | call to write | test.cpp:70:38:70:48 | thePassword | test.cpp:73:43:73:53 | thePassword | This write into file 'mystream' may contain unencrypted data from $@. | test.cpp:70:38:70:48 | thePassword | this source. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
@@ -2,16 +2,16 @@ edges
 | test3.cpp:74:21:74:29 | password1 | test3.cpp:76:15:76:17 | ptr |
 | test3.cpp:81:15:81:22 | password | test3.cpp:83:15:83:17 | ptr |
 | test3.cpp:112:20:112:25 | buffer | test3.cpp:114:14:114:19 | buffer |
-| test3.cpp:117:28:117:33 | buffer | test3.cpp:117:13:117:14 | id indirection |
-| test3.cpp:124:7:124:20 | get_global_str indirection | test3.cpp:144:16:144:29 | call to get_global_str |
-| test3.cpp:126:9:126:23 | global_password | test3.cpp:124:7:124:20 | get_global_str indirection |
+| test3.cpp:117:28:117:33 | buffer | test3.cpp:117:13:117:14 | *id |
+| test3.cpp:124:7:124:20 | *get_global_str | test3.cpp:144:16:144:29 | call to get_global_str |
+| test3.cpp:126:9:126:23 | global_password | test3.cpp:124:7:124:20 | *get_global_str |
 | test3.cpp:134:11:134:18 | password | test3.cpp:112:20:112:25 | buffer |
 | test3.cpp:138:21:138:22 | call to id | test3.cpp:140:15:140:17 | ptr |
 | test3.cpp:138:24:138:32 | password1 | test3.cpp:117:28:117:33 | buffer |
 | test3.cpp:138:24:138:32 | password1 | test3.cpp:138:21:138:22 | call to id |
 | test3.cpp:144:16:144:29 | call to get_global_str | test3.cpp:146:15:146:18 | data |
-| test3.cpp:157:19:157:26 | password | test3.cpp:159:15:159:20 | buffer indirection |
-| test3.cpp:270:16:270:23 | password | test3.cpp:272:15:272:18 | data indirection |
+| test3.cpp:157:19:157:26 | password | test3.cpp:159:15:159:20 | *buffer |
+| test3.cpp:270:16:270:23 | password | test3.cpp:272:15:272:18 | *data |
 | test3.cpp:278:20:278:23 | data | test3.cpp:280:14:280:17 | data |
 | test3.cpp:283:20:283:23 | data | test3.cpp:285:14:285:17 | data |
 | test3.cpp:288:20:288:23 | data | test3.cpp:290:14:290:17 | data |
@@ -25,10 +25,10 @@ edges
 | test3.cpp:322:16:322:24 | password2 | test3.cpp:325:11:325:14 | data |
 | test3.cpp:324:11:324:14 | data | test3.cpp:293:20:293:23 | data |
 | test3.cpp:325:11:325:14 | data | test3.cpp:298:20:298:23 | data |
-| test3.cpp:526:44:526:54 | my_latitude | test3.cpp:527:15:527:20 | buffer indirection |
-| test3.cpp:532:45:532:58 | home_longitude | test3.cpp:533:15:533:20 | buffer indirection |
-| test3.cpp:551:47:551:58 | salaryString | test3.cpp:552:15:552:20 | buffer indirection |
-| test3.cpp:556:19:556:30 | salaryString | test3.cpp:559:15:559:20 | buffer indirection |
+| test3.cpp:526:44:526:54 | my_latitude | test3.cpp:527:15:527:20 | *buffer |
+| test3.cpp:532:45:532:58 | home_longitude | test3.cpp:533:15:533:20 | *buffer |
+| test3.cpp:551:47:551:58 | salaryString | test3.cpp:552:15:552:20 | *buffer |
+| test3.cpp:556:19:556:30 | salaryString | test3.cpp:559:15:559:20 | *buffer |
 | test3.cpp:571:8:571:21 | call to get_home_phone | test3.cpp:572:14:572:16 | str |
 | test3.cpp:577:8:577:23 | call to get_home_address | test3.cpp:578:14:578:16 | str |
 nodes
@@ -43,9 +43,9 @@ nodes
 | test3.cpp:101:12:101:19 | password | semmle.label | password |
 | test3.cpp:112:20:112:25 | buffer | semmle.label | buffer |
 | test3.cpp:114:14:114:19 | buffer | semmle.label | buffer |
-| test3.cpp:117:13:117:14 | id indirection | semmle.label | id indirection |
+| test3.cpp:117:13:117:14 | *id | semmle.label | *id |
 | test3.cpp:117:28:117:33 | buffer | semmle.label | buffer |
-| test3.cpp:124:7:124:20 | get_global_str indirection | semmle.label | get_global_str indirection |
+| test3.cpp:124:7:124:20 | *get_global_str | semmle.label | *get_global_str |
 | test3.cpp:126:9:126:23 | global_password | semmle.label | global_password |
 | test3.cpp:134:11:134:18 | password | semmle.label | password |
 | test3.cpp:138:21:138:22 | call to id | semmle.label | call to id |
@@ -54,7 +54,7 @@ nodes
 | test3.cpp:144:16:144:29 | call to get_global_str | semmle.label | call to get_global_str |
 | test3.cpp:146:15:146:18 | data | semmle.label | data |
 | test3.cpp:157:19:157:26 | password | semmle.label | password |
-| test3.cpp:159:15:159:20 | buffer indirection | semmle.label | buffer indirection |
+| test3.cpp:159:15:159:20 | *buffer | semmle.label | *buffer |
 | test3.cpp:173:15:173:22 | password | semmle.label | password |
 | test3.cpp:181:15:181:22 | password | semmle.label | password |
 | test3.cpp:191:15:191:22 | password | semmle.label | password |
@@ -66,7 +66,7 @@ nodes
 | test3.cpp:254:15:254:23 | password1 | semmle.label | password1 |
 | test3.cpp:264:15:264:23 | password2 | semmle.label | password2 |
 | test3.cpp:270:16:270:23 | password | semmle.label | password |
-| test3.cpp:272:15:272:18 | data indirection | semmle.label | data indirection |
+| test3.cpp:272:15:272:18 | *data | semmle.label | *data |
 | test3.cpp:278:20:278:23 | data | semmle.label | data |
 | test3.cpp:280:14:280:17 | data | semmle.label | data |
 | test3.cpp:283:20:283:23 | data | semmle.label | data |
@@ -105,19 +105,19 @@ nodes
 | test3.cpp:517:14:517:29 | medical_info | semmle.label | medical_info |
 | test3.cpp:518:14:518:28 | license_key | semmle.label | license_key |
 | test3.cpp:526:44:526:54 | my_latitude | semmle.label | my_latitude |
-| test3.cpp:527:15:527:20 | buffer indirection | semmle.label | buffer indirection |
+| test3.cpp:527:15:527:20 | *buffer | semmle.label | *buffer |
 | test3.cpp:532:45:532:58 | home_longitude | semmle.label | home_longitude |
-| test3.cpp:533:15:533:20 | buffer indirection | semmle.label | buffer indirection |
+| test3.cpp:533:15:533:20 | *buffer | semmle.label | *buffer |
 | test3.cpp:551:47:551:58 | salaryString | semmle.label | salaryString |
-| test3.cpp:552:15:552:20 | buffer indirection | semmle.label | buffer indirection |
+| test3.cpp:552:15:552:20 | *buffer | semmle.label | *buffer |
 | test3.cpp:556:19:556:30 | salaryString | semmle.label | salaryString |
-| test3.cpp:559:15:559:20 | buffer indirection | semmle.label | buffer indirection |
+| test3.cpp:559:15:559:20 | *buffer | semmle.label | *buffer |
 | test3.cpp:571:8:571:21 | call to get_home_phone | semmle.label | call to get_home_phone |
 | test3.cpp:572:14:572:16 | str | semmle.label | str |
 | test3.cpp:577:8:577:23 | call to get_home_address | semmle.label | call to get_home_address |
 | test3.cpp:578:14:578:16 | str | semmle.label | str |
 subpaths
-| test3.cpp:138:24:138:32 | password1 | test3.cpp:117:28:117:33 | buffer | test3.cpp:117:13:117:14 | id indirection | test3.cpp:138:21:138:22 | call to id |
+| test3.cpp:138:24:138:32 | password1 | test3.cpp:117:28:117:33 | buffer | test3.cpp:117:13:117:14 | *id | test3.cpp:138:21:138:22 | call to id |
 #select
 | test3.cpp:22:3:22:6 | call to send | test3.cpp:22:15:22:23 | password1 | test3.cpp:22:15:22:23 | password1 | This operation transmits 'password1', which may contain unencrypted sensitive data from $@. | test3.cpp:22:15:22:23 | password1 | password1 |
 | test3.cpp:26:3:26:6 | call to send | test3.cpp:26:15:26:23 | password2 | test3.cpp:26:15:26:23 | password2 | This operation transmits 'password2', which may contain unencrypted sensitive data from $@. | test3.cpp:26:15:26:23 | password2 | password2 |
@@ -129,10 +129,10 @@ subpaths
 | test3.cpp:114:2:114:5 | call to recv | test3.cpp:134:11:134:18 | password | test3.cpp:114:14:114:19 | buffer | This operation receives into 'buffer', which may put unencrypted sensitive data into $@. | test3.cpp:134:11:134:18 | password | password |
 | test3.cpp:140:3:140:6 | call to send | test3.cpp:138:24:138:32 | password1 | test3.cpp:140:15:140:17 | ptr | This operation transmits 'ptr', which may contain unencrypted sensitive data from $@. | test3.cpp:138:24:138:32 | password1 | password1 |
 | test3.cpp:146:3:146:6 | call to send | test3.cpp:126:9:126:23 | global_password | test3.cpp:146:15:146:18 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@. | test3.cpp:126:9:126:23 | global_password | global_password |
-| test3.cpp:159:3:159:6 | call to send | test3.cpp:157:19:157:26 | password | test3.cpp:159:15:159:20 | buffer indirection | This operation transmits 'buffer indirection', which may contain unencrypted sensitive data from $@. | test3.cpp:157:19:157:26 | password | password |
+| test3.cpp:159:3:159:6 | call to send | test3.cpp:157:19:157:26 | password | test3.cpp:159:15:159:20 | *buffer | This operation transmits '*buffer', which may contain unencrypted sensitive data from $@. | test3.cpp:157:19:157:26 | password | password |
 | test3.cpp:228:2:228:5 | call to send | test3.cpp:228:26:228:33 | password | test3.cpp:228:26:228:33 | password | This operation transmits 'password', which may contain unencrypted sensitive data from $@. | test3.cpp:228:26:228:33 | password | password |
 | test3.cpp:241:2:241:6 | call to fgets | test3.cpp:241:8:241:15 | password | test3.cpp:241:8:241:15 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@. | test3.cpp:241:8:241:15 | password | password |
-| test3.cpp:272:3:272:6 | call to send | test3.cpp:270:16:270:23 | password | test3.cpp:272:15:272:18 | data indirection | This operation transmits 'data indirection', which may contain unencrypted sensitive data from $@. | test3.cpp:270:16:270:23 | password | password |
+| test3.cpp:272:3:272:6 | call to send | test3.cpp:270:16:270:23 | password | test3.cpp:272:15:272:18 | *data | This operation transmits '*data', which may contain unencrypted sensitive data from $@. | test3.cpp:270:16:270:23 | password | password |
 | test3.cpp:290:2:290:5 | call to send | test3.cpp:317:11:317:19 | password1 | test3.cpp:290:14:290:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@. | test3.cpp:317:11:317:19 | password1 | password1 |
 | test3.cpp:295:2:295:5 | call to send | test3.cpp:322:16:322:24 | password2 | test3.cpp:295:14:295:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@. | test3.cpp:322:16:322:24 | password2 | password2 |
 | test3.cpp:300:2:300:5 | call to send | test3.cpp:322:16:322:24 | password2 | test3.cpp:300:14:300:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@. | test3.cpp:322:16:322:24 | password2 | password2 |
@@ -153,9 +153,9 @@ subpaths
 | test3.cpp:516:2:516:5 | call to send | test3.cpp:516:14:516:29 | employerName | test3.cpp:516:14:516:29 | employerName | This operation transmits 'employerName', which may contain unencrypted sensitive data from $@. | test3.cpp:516:14:516:29 | employerName | employerName |
 | test3.cpp:517:2:517:5 | call to send | test3.cpp:517:14:517:29 | medical_info | test3.cpp:517:14:517:29 | medical_info | This operation transmits 'medical_info', which may contain unencrypted sensitive data from $@. | test3.cpp:517:14:517:29 | medical_info | medical_info |
 | test3.cpp:518:2:518:5 | call to send | test3.cpp:518:14:518:28 | license_key | test3.cpp:518:14:518:28 | license_key | This operation transmits 'license_key', which may contain unencrypted sensitive data from $@. | test3.cpp:518:14:518:28 | license_key | license_key |
-| test3.cpp:527:3:527:6 | call to send | test3.cpp:526:44:526:54 | my_latitude | test3.cpp:527:15:527:20 | buffer indirection | This operation transmits 'buffer indirection', which may contain unencrypted sensitive data from $@. | test3.cpp:526:44:526:54 | my_latitude | my_latitude |
-| test3.cpp:533:3:533:6 | call to send | test3.cpp:532:45:532:58 | home_longitude | test3.cpp:533:15:533:20 | buffer indirection | This operation transmits 'buffer indirection', which may contain unencrypted sensitive data from $@. | test3.cpp:532:45:532:58 | home_longitude | home_longitude |
-| test3.cpp:552:3:552:6 | call to send | test3.cpp:551:47:551:58 | salaryString | test3.cpp:552:15:552:20 | buffer indirection | This operation transmits 'buffer indirection', which may contain unencrypted sensitive data from $@. | test3.cpp:551:47:551:58 | salaryString | salaryString |
-| test3.cpp:559:3:559:6 | call to send | test3.cpp:556:19:556:30 | salaryString | test3.cpp:559:15:559:20 | buffer indirection | This operation transmits 'buffer indirection', which may contain unencrypted sensitive data from $@. | test3.cpp:556:19:556:30 | salaryString | salaryString |
+| test3.cpp:527:3:527:6 | call to send | test3.cpp:526:44:526:54 | my_latitude | test3.cpp:527:15:527:20 | *buffer | This operation transmits '*buffer', which may contain unencrypted sensitive data from $@. | test3.cpp:526:44:526:54 | my_latitude | my_latitude |
+| test3.cpp:533:3:533:6 | call to send | test3.cpp:532:45:532:58 | home_longitude | test3.cpp:533:15:533:20 | *buffer | This operation transmits '*buffer', which may contain unencrypted sensitive data from $@. | test3.cpp:532:45:532:58 | home_longitude | home_longitude |
+| test3.cpp:552:3:552:6 | call to send | test3.cpp:551:47:551:58 | salaryString | test3.cpp:552:15:552:20 | *buffer | This operation transmits '*buffer', which may contain unencrypted sensitive data from $@. | test3.cpp:551:47:551:58 | salaryString | salaryString |
+| test3.cpp:559:3:559:6 | call to send | test3.cpp:556:19:556:30 | salaryString | test3.cpp:559:15:559:20 | *buffer | This operation transmits '*buffer', which may contain unencrypted sensitive data from $@. | test3.cpp:556:19:556:30 | salaryString | salaryString |
 | test3.cpp:572:2:572:5 | call to send | test3.cpp:571:8:571:21 | call to get_home_phone | test3.cpp:572:14:572:16 | str | This operation transmits 'str', which may contain unencrypted sensitive data from $@. | test3.cpp:571:8:571:21 | call to get_home_phone | call to get_home_phone |
 | test3.cpp:578:2:578:5 | call to send | test3.cpp:577:8:577:23 | call to get_home_address | test3.cpp:578:14:578:16 | str | This operation transmits 'str', which may contain unencrypted sensitive data from $@. | test3.cpp:577:8:577:23 | call to get_home_address | call to get_home_address |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-319/UseOfHttp/UseOfHttp.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-319/UseOfHttp/UseOfHttp.expected
@@ -1,37 +1,37 @@
 edges
-| test.cpp:11:26:11:28 | url indirection | test.cpp:15:30:15:32 | url indirection |
-| test.cpp:24:13:24:17 | url_g indirection | test.cpp:38:11:38:15 | url_g indirection |
-| test.cpp:24:21:24:40 | http://example.com indirection | test.cpp:24:13:24:17 | url_g indirection |
-| test.cpp:28:10:28:29 | http://example.com indirection | test.cpp:11:26:11:28 | url indirection |
-| test.cpp:35:23:35:42 | http://example.com indirection | test.cpp:39:11:39:15 | url_l indirection |
-| test.cpp:36:26:36:45 | http://example.com indirection | test.cpp:40:11:40:17 | access to array indirection |
-| test.cpp:38:11:38:15 | url_g indirection | test.cpp:11:26:11:28 | url indirection |
-| test.cpp:39:11:39:15 | url_l indirection | test.cpp:11:26:11:28 | url indirection |
-| test.cpp:40:11:40:17 | access to array indirection | test.cpp:11:26:11:28 | url indirection |
-| test.cpp:46:18:46:26 | http:// indirection | test.cpp:49:11:49:16 | buffer indirection |
-| test.cpp:49:11:49:16 | buffer indirection | test.cpp:11:26:11:28 | url indirection |
-| test.cpp:110:21:110:40 | http://example.com indirection | test.cpp:121:11:121:13 | ptr indirection |
-| test.cpp:121:11:121:13 | ptr indirection | test.cpp:11:26:11:28 | url indirection |
+| test.cpp:11:26:11:28 | *url | test.cpp:15:30:15:32 | *url |
+| test.cpp:24:13:24:17 | **url_g | test.cpp:38:11:38:15 | *url_g |
+| test.cpp:24:21:24:40 | *http://example.com | test.cpp:24:13:24:17 | **url_g |
+| test.cpp:28:10:28:29 | *http://example.com | test.cpp:11:26:11:28 | *url |
+| test.cpp:35:23:35:42 | *http://example.com | test.cpp:39:11:39:15 | *url_l |
+| test.cpp:36:26:36:45 | *http://example.com | test.cpp:40:11:40:17 | *access to array |
+| test.cpp:38:11:38:15 | *url_g | test.cpp:11:26:11:28 | *url |
+| test.cpp:39:11:39:15 | *url_l | test.cpp:11:26:11:28 | *url |
+| test.cpp:40:11:40:17 | *access to array | test.cpp:11:26:11:28 | *url |
+| test.cpp:46:18:46:26 | *http:// | test.cpp:49:11:49:16 | *buffer |
+| test.cpp:49:11:49:16 | *buffer | test.cpp:11:26:11:28 | *url |
+| test.cpp:110:21:110:40 | *http://example.com | test.cpp:121:11:121:13 | *ptr |
+| test.cpp:121:11:121:13 | *ptr | test.cpp:11:26:11:28 | *url |
 nodes
-| test.cpp:11:26:11:28 | url indirection | semmle.label | url indirection |
-| test.cpp:15:30:15:32 | url indirection | semmle.label | url indirection |
-| test.cpp:24:13:24:17 | url_g indirection | semmle.label | url_g indirection |
-| test.cpp:24:21:24:40 | http://example.com indirection | semmle.label | http://example.com indirection |
-| test.cpp:28:10:28:29 | http://example.com indirection | semmle.label | http://example.com indirection |
-| test.cpp:35:23:35:42 | http://example.com indirection | semmle.label | http://example.com indirection |
-| test.cpp:36:26:36:45 | http://example.com indirection | semmle.label | http://example.com indirection |
-| test.cpp:38:11:38:15 | url_g indirection | semmle.label | url_g indirection |
-| test.cpp:39:11:39:15 | url_l indirection | semmle.label | url_l indirection |
-| test.cpp:40:11:40:17 | access to array indirection | semmle.label | access to array indirection |
-| test.cpp:46:18:46:26 | http:// indirection | semmle.label | http:// indirection |
-| test.cpp:49:11:49:16 | buffer indirection | semmle.label | buffer indirection |
-| test.cpp:110:21:110:40 | http://example.com indirection | semmle.label | http://example.com indirection |
-| test.cpp:121:11:121:13 | ptr indirection | semmle.label | ptr indirection |
+| test.cpp:11:26:11:28 | *url | semmle.label | *url |
+| test.cpp:15:30:15:32 | *url | semmle.label | *url |
+| test.cpp:24:13:24:17 | **url_g | semmle.label | **url_g |
+| test.cpp:24:21:24:40 | *http://example.com | semmle.label | *http://example.com |
+| test.cpp:28:10:28:29 | *http://example.com | semmle.label | *http://example.com |
+| test.cpp:35:23:35:42 | *http://example.com | semmle.label | *http://example.com |
+| test.cpp:36:26:36:45 | *http://example.com | semmle.label | *http://example.com |
+| test.cpp:38:11:38:15 | *url_g | semmle.label | *url_g |
+| test.cpp:39:11:39:15 | *url_l | semmle.label | *url_l |
+| test.cpp:40:11:40:17 | *access to array | semmle.label | *access to array |
+| test.cpp:46:18:46:26 | *http:// | semmle.label | *http:// |
+| test.cpp:49:11:49:16 | *buffer | semmle.label | *buffer |
+| test.cpp:110:21:110:40 | *http://example.com | semmle.label | *http://example.com |
+| test.cpp:121:11:121:13 | *ptr | semmle.label | *ptr |
 subpaths
 #select
-| test.cpp:24:21:24:40 | http://example.com | test.cpp:24:21:24:40 | http://example.com indirection | test.cpp:15:30:15:32 | url indirection | This URL may be constructed with the HTTP protocol. |
-| test.cpp:28:10:28:29 | http://example.com | test.cpp:28:10:28:29 | http://example.com indirection | test.cpp:15:30:15:32 | url indirection | This URL may be constructed with the HTTP protocol. |
-| test.cpp:35:23:35:42 | http://example.com | test.cpp:35:23:35:42 | http://example.com indirection | test.cpp:15:30:15:32 | url indirection | This URL may be constructed with the HTTP protocol. |
-| test.cpp:36:26:36:45 | http://example.com | test.cpp:36:26:36:45 | http://example.com indirection | test.cpp:15:30:15:32 | url indirection | This URL may be constructed with the HTTP protocol. |
-| test.cpp:46:18:46:26 | http:// | test.cpp:46:18:46:26 | http:// indirection | test.cpp:15:30:15:32 | url indirection | This URL may be constructed with the HTTP protocol. |
-| test.cpp:110:21:110:40 | http://example.com | test.cpp:110:21:110:40 | http://example.com indirection | test.cpp:15:30:15:32 | url indirection | This URL may be constructed with the HTTP protocol. |
+| test.cpp:24:21:24:40 | http://example.com | test.cpp:24:21:24:40 | *http://example.com | test.cpp:15:30:15:32 | *url | This URL may be constructed with the HTTP protocol. |
+| test.cpp:28:10:28:29 | http://example.com | test.cpp:28:10:28:29 | *http://example.com | test.cpp:15:30:15:32 | *url | This URL may be constructed with the HTTP protocol. |
+| test.cpp:35:23:35:42 | http://example.com | test.cpp:35:23:35:42 | *http://example.com | test.cpp:15:30:15:32 | *url | This URL may be constructed with the HTTP protocol. |
+| test.cpp:36:26:36:45 | http://example.com | test.cpp:36:26:36:45 | *http://example.com | test.cpp:15:30:15:32 | *url | This URL may be constructed with the HTTP protocol. |
+| test.cpp:46:18:46:26 | http:// | test.cpp:46:18:46:26 | *http:// | test.cpp:15:30:15:32 | *url | This URL may be constructed with the HTTP protocol. |
+| test.cpp:110:21:110:40 | http://example.com | test.cpp:110:21:110:40 | *http://example.com | test.cpp:15:30:15:32 | *url | This URL may be constructed with the HTTP protocol. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-497/SAMATE/PotentiallyExposedSystemData.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-497/SAMATE/PotentiallyExposedSystemData.expected
@@ -1,8 +1,8 @@
 edges
-| tests.c:57:21:57:28 | password indirection | tests.c:70:70:70:77 | password indirection |
+| tests.c:57:21:57:28 | *password | tests.c:70:70:70:77 | *password |
 nodes
-| tests.c:57:21:57:28 | password indirection | semmle.label | password indirection |
-| tests.c:70:70:70:77 | password indirection | semmle.label | password indirection |
+| tests.c:57:21:57:28 | *password | semmle.label | *password |
+| tests.c:70:70:70:77 | *password | semmle.label | *password |
 subpaths
 #select
-| tests.c:70:70:70:77 | password indirection | tests.c:57:21:57:28 | password indirection | tests.c:70:70:70:77 | password indirection | This operation potentially exposes sensitive system data from $@. | tests.c:57:21:57:28 | password indirection | password indirection |
+| tests.c:70:70:70:77 | *password | tests.c:57:21:57:28 | *password | tests.c:70:70:70:77 | *password | This operation potentially exposes sensitive system data from $@. | tests.c:57:21:57:28 | *password | *password |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-497/semmle/tests/ExposedSystemData.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-497/semmle/tests/ExposedSystemData.expected
@@ -1,63 +1,63 @@
 edges
-| tests2.cpp:50:13:50:19 | global1 indirection | tests2.cpp:82:14:82:20 | global1 indirection |
-| tests2.cpp:50:23:50:43 | call to mysql_get_client_info indirection | tests2.cpp:50:13:50:19 | global1 indirection |
-| tests2.cpp:78:18:78:38 | call to mysql_get_client_info indirection | tests2.cpp:81:14:81:19 | buffer indirection |
-| tests2.cpp:91:42:91:45 | str1 indirection | tests2.cpp:93:14:93:17 | str1 indirection |
-| tests2.cpp:101:8:101:15 | call to getpwuid indirection | tests2.cpp:102:14:102:15 | pw indirection |
-| tests2.cpp:109:3:109:4 | c1 indirection [post update] [ptr indirection] | tests2.cpp:111:14:111:15 | c1 indirection [ptr indirection] |
-| tests2.cpp:109:3:109:36 | ... = ... indirection | tests2.cpp:109:3:109:4 | c1 indirection [post update] [ptr indirection] |
-| tests2.cpp:109:12:109:17 | call to getenv indirection | tests2.cpp:109:3:109:36 | ... = ... indirection |
-| tests2.cpp:111:14:111:15 | c1 indirection [ptr indirection] | tests2.cpp:111:14:111:19 | ptr indirection |
-| tests2.cpp:111:14:111:15 | c1 indirection [ptr indirection] | tests2.cpp:111:17:111:19 | ptr indirection |
-| tests2.cpp:111:17:111:19 | ptr indirection | tests2.cpp:111:14:111:19 | ptr indirection |
-| tests_sockets.cpp:26:15:26:20 | call to getenv indirection | tests_sockets.cpp:39:19:39:22 | path indirection |
-| tests_sockets.cpp:26:15:26:20 | call to getenv indirection | tests_sockets.cpp:43:20:43:23 | path indirection |
-| tests_sockets.cpp:63:15:63:20 | call to getenv indirection | tests_sockets.cpp:76:19:76:22 | path indirection |
-| tests_sockets.cpp:63:15:63:20 | call to getenv indirection | tests_sockets.cpp:80:20:80:23 | path indirection |
-| tests_sysconf.cpp:36:21:36:27 | confstr output argument | tests_sysconf.cpp:39:19:39:25 | pathbuf indirection |
+| tests2.cpp:50:13:50:19 | **global1 | tests2.cpp:82:14:82:20 | *global1 |
+| tests2.cpp:50:23:50:43 | *call to mysql_get_client_info | tests2.cpp:50:13:50:19 | **global1 |
+| tests2.cpp:78:18:78:38 | *call to mysql_get_client_info | tests2.cpp:81:14:81:19 | *buffer |
+| tests2.cpp:91:42:91:45 | *str1 | tests2.cpp:93:14:93:17 | *str1 |
+| tests2.cpp:101:8:101:15 | *call to getpwuid | tests2.cpp:102:14:102:15 | *pw |
+| tests2.cpp:109:3:109:4 | *c1 [post update] [*ptr] | tests2.cpp:111:14:111:15 | *c1 [*ptr] |
+| tests2.cpp:109:3:109:36 | *... = ... | tests2.cpp:109:3:109:4 | *c1 [post update] [*ptr] |
+| tests2.cpp:109:12:109:17 | *call to getenv | tests2.cpp:109:3:109:36 | *... = ... |
+| tests2.cpp:111:14:111:15 | *c1 [*ptr] | tests2.cpp:111:14:111:19 | *ptr |
+| tests2.cpp:111:14:111:15 | *c1 [*ptr] | tests2.cpp:111:17:111:19 | *ptr |
+| tests2.cpp:111:17:111:19 | *ptr | tests2.cpp:111:14:111:19 | *ptr |
+| tests_sockets.cpp:26:15:26:20 | *call to getenv | tests_sockets.cpp:39:19:39:22 | *path |
+| tests_sockets.cpp:26:15:26:20 | *call to getenv | tests_sockets.cpp:43:20:43:23 | *path |
+| tests_sockets.cpp:63:15:63:20 | *call to getenv | tests_sockets.cpp:76:19:76:22 | *path |
+| tests_sockets.cpp:63:15:63:20 | *call to getenv | tests_sockets.cpp:80:20:80:23 | *path |
+| tests_sysconf.cpp:36:21:36:27 | confstr output argument | tests_sysconf.cpp:39:19:39:25 | *pathbuf |
 nodes
-| tests2.cpp:50:13:50:19 | global1 indirection | semmle.label | global1 indirection |
-| tests2.cpp:50:23:50:43 | call to mysql_get_client_info indirection | semmle.label | call to mysql_get_client_info indirection |
-| tests2.cpp:63:13:63:26 | call to getenv indirection | semmle.label | call to getenv indirection |
-| tests2.cpp:64:13:64:26 | call to getenv indirection | semmle.label | call to getenv indirection |
-| tests2.cpp:65:13:65:30 | call to getenv indirection | semmle.label | call to getenv indirection |
-| tests2.cpp:66:13:66:34 | call to getenv indirection | semmle.label | call to getenv indirection |
-| tests2.cpp:78:18:78:38 | call to mysql_get_client_info indirection | semmle.label | call to mysql_get_client_info indirection |
-| tests2.cpp:80:14:80:34 | call to mysql_get_client_info indirection | semmle.label | call to mysql_get_client_info indirection |
-| tests2.cpp:81:14:81:19 | buffer indirection | semmle.label | buffer indirection |
-| tests2.cpp:82:14:82:20 | global1 indirection | semmle.label | global1 indirection |
-| tests2.cpp:91:42:91:45 | str1 indirection | semmle.label | str1 indirection |
-| tests2.cpp:93:14:93:17 | str1 indirection | semmle.label | str1 indirection |
-| tests2.cpp:101:8:101:15 | call to getpwuid indirection | semmle.label | call to getpwuid indirection |
-| tests2.cpp:102:14:102:15 | pw indirection | semmle.label | pw indirection |
-| tests2.cpp:109:3:109:4 | c1 indirection [post update] [ptr indirection] | semmle.label | c1 indirection [post update] [ptr indirection] |
-| tests2.cpp:109:3:109:36 | ... = ... indirection | semmle.label | ... = ... indirection |
-| tests2.cpp:109:12:109:17 | call to getenv indirection | semmle.label | call to getenv indirection |
-| tests2.cpp:111:14:111:15 | c1 indirection [ptr indirection] | semmle.label | c1 indirection [ptr indirection] |
-| tests2.cpp:111:14:111:19 | ptr indirection | semmle.label | ptr indirection |
-| tests2.cpp:111:17:111:19 | ptr indirection | semmle.label | ptr indirection |
-| tests_sockets.cpp:26:15:26:20 | call to getenv indirection | semmle.label | call to getenv indirection |
-| tests_sockets.cpp:39:19:39:22 | path indirection | semmle.label | path indirection |
-| tests_sockets.cpp:43:20:43:23 | path indirection | semmle.label | path indirection |
-| tests_sockets.cpp:63:15:63:20 | call to getenv indirection | semmle.label | call to getenv indirection |
-| tests_sockets.cpp:76:19:76:22 | path indirection | semmle.label | path indirection |
-| tests_sockets.cpp:80:20:80:23 | path indirection | semmle.label | path indirection |
+| tests2.cpp:50:13:50:19 | **global1 | semmle.label | **global1 |
+| tests2.cpp:50:23:50:43 | *call to mysql_get_client_info | semmle.label | *call to mysql_get_client_info |
+| tests2.cpp:63:13:63:26 | *call to getenv | semmle.label | *call to getenv |
+| tests2.cpp:64:13:64:26 | *call to getenv | semmle.label | *call to getenv |
+| tests2.cpp:65:13:65:30 | *call to getenv | semmle.label | *call to getenv |
+| tests2.cpp:66:13:66:34 | *call to getenv | semmle.label | *call to getenv |
+| tests2.cpp:78:18:78:38 | *call to mysql_get_client_info | semmle.label | *call to mysql_get_client_info |
+| tests2.cpp:80:14:80:34 | *call to mysql_get_client_info | semmle.label | *call to mysql_get_client_info |
+| tests2.cpp:81:14:81:19 | *buffer | semmle.label | *buffer |
+| tests2.cpp:82:14:82:20 | *global1 | semmle.label | *global1 |
+| tests2.cpp:91:42:91:45 | *str1 | semmle.label | *str1 |
+| tests2.cpp:93:14:93:17 | *str1 | semmle.label | *str1 |
+| tests2.cpp:101:8:101:15 | *call to getpwuid | semmle.label | *call to getpwuid |
+| tests2.cpp:102:14:102:15 | *pw | semmle.label | *pw |
+| tests2.cpp:109:3:109:4 | *c1 [post update] [*ptr] | semmle.label | *c1 [post update] [*ptr] |
+| tests2.cpp:109:3:109:36 | *... = ... | semmle.label | *... = ... |
+| tests2.cpp:109:12:109:17 | *call to getenv | semmle.label | *call to getenv |
+| tests2.cpp:111:14:111:15 | *c1 [*ptr] | semmle.label | *c1 [*ptr] |
+| tests2.cpp:111:14:111:19 | *ptr | semmle.label | *ptr |
+| tests2.cpp:111:17:111:19 | *ptr | semmle.label | *ptr |
+| tests_sockets.cpp:26:15:26:20 | *call to getenv | semmle.label | *call to getenv |
+| tests_sockets.cpp:39:19:39:22 | *path | semmle.label | *path |
+| tests_sockets.cpp:43:20:43:23 | *path | semmle.label | *path |
+| tests_sockets.cpp:63:15:63:20 | *call to getenv | semmle.label | *call to getenv |
+| tests_sockets.cpp:76:19:76:22 | *path | semmle.label | *path |
+| tests_sockets.cpp:80:20:80:23 | *path | semmle.label | *path |
 | tests_sysconf.cpp:36:21:36:27 | confstr output argument | semmle.label | confstr output argument |
-| tests_sysconf.cpp:39:19:39:25 | pathbuf indirection | semmle.label | pathbuf indirection |
+| tests_sysconf.cpp:39:19:39:25 | *pathbuf | semmle.label | *pathbuf |
 subpaths
 #select
-| tests2.cpp:63:13:63:26 | call to getenv indirection | tests2.cpp:63:13:63:26 | call to getenv indirection | tests2.cpp:63:13:63:26 | call to getenv indirection | This operation exposes system data from $@. | tests2.cpp:63:13:63:26 | call to getenv indirection | call to getenv indirection |
-| tests2.cpp:64:13:64:26 | call to getenv indirection | tests2.cpp:64:13:64:26 | call to getenv indirection | tests2.cpp:64:13:64:26 | call to getenv indirection | This operation exposes system data from $@. | tests2.cpp:64:13:64:26 | call to getenv indirection | call to getenv indirection |
-| tests2.cpp:65:13:65:30 | call to getenv indirection | tests2.cpp:65:13:65:30 | call to getenv indirection | tests2.cpp:65:13:65:30 | call to getenv indirection | This operation exposes system data from $@. | tests2.cpp:65:13:65:30 | call to getenv indirection | call to getenv indirection |
-| tests2.cpp:66:13:66:34 | call to getenv indirection | tests2.cpp:66:13:66:34 | call to getenv indirection | tests2.cpp:66:13:66:34 | call to getenv indirection | This operation exposes system data from $@. | tests2.cpp:66:13:66:34 | call to getenv indirection | call to getenv indirection |
-| tests2.cpp:80:14:80:34 | call to mysql_get_client_info indirection | tests2.cpp:80:14:80:34 | call to mysql_get_client_info indirection | tests2.cpp:80:14:80:34 | call to mysql_get_client_info indirection | This operation exposes system data from $@. | tests2.cpp:80:14:80:34 | call to mysql_get_client_info indirection | call to mysql_get_client_info indirection |
-| tests2.cpp:81:14:81:19 | buffer indirection | tests2.cpp:78:18:78:38 | call to mysql_get_client_info indirection | tests2.cpp:81:14:81:19 | buffer indirection | This operation exposes system data from $@. | tests2.cpp:78:18:78:38 | call to mysql_get_client_info indirection | call to mysql_get_client_info indirection |
-| tests2.cpp:82:14:82:20 | global1 indirection | tests2.cpp:50:23:50:43 | call to mysql_get_client_info indirection | tests2.cpp:82:14:82:20 | global1 indirection | This operation exposes system data from $@. | tests2.cpp:50:23:50:43 | call to mysql_get_client_info indirection | call to mysql_get_client_info indirection |
-| tests2.cpp:93:14:93:17 | str1 indirection | tests2.cpp:91:42:91:45 | str1 indirection | tests2.cpp:93:14:93:17 | str1 indirection | This operation exposes system data from $@. | tests2.cpp:91:42:91:45 | str1 indirection | str1 indirection |
-| tests2.cpp:102:14:102:15 | pw indirection | tests2.cpp:101:8:101:15 | call to getpwuid indirection | tests2.cpp:102:14:102:15 | pw indirection | This operation exposes system data from $@. | tests2.cpp:101:8:101:15 | call to getpwuid indirection | call to getpwuid indirection |
-| tests2.cpp:111:14:111:19 | ptr indirection | tests2.cpp:109:12:109:17 | call to getenv indirection | tests2.cpp:111:14:111:19 | ptr indirection | This operation exposes system data from $@. | tests2.cpp:109:12:109:17 | call to getenv indirection | call to getenv indirection |
-| tests_sockets.cpp:39:19:39:22 | path indirection | tests_sockets.cpp:26:15:26:20 | call to getenv indirection | tests_sockets.cpp:39:19:39:22 | path indirection | This operation exposes system data from $@. | tests_sockets.cpp:26:15:26:20 | call to getenv indirection | call to getenv indirection |
-| tests_sockets.cpp:43:20:43:23 | path indirection | tests_sockets.cpp:26:15:26:20 | call to getenv indirection | tests_sockets.cpp:43:20:43:23 | path indirection | This operation exposes system data from $@. | tests_sockets.cpp:26:15:26:20 | call to getenv indirection | call to getenv indirection |
-| tests_sockets.cpp:76:19:76:22 | path indirection | tests_sockets.cpp:63:15:63:20 | call to getenv indirection | tests_sockets.cpp:76:19:76:22 | path indirection | This operation exposes system data from $@. | tests_sockets.cpp:63:15:63:20 | call to getenv indirection | call to getenv indirection |
-| tests_sockets.cpp:80:20:80:23 | path indirection | tests_sockets.cpp:63:15:63:20 | call to getenv indirection | tests_sockets.cpp:80:20:80:23 | path indirection | This operation exposes system data from $@. | tests_sockets.cpp:63:15:63:20 | call to getenv indirection | call to getenv indirection |
-| tests_sysconf.cpp:39:19:39:25 | pathbuf indirection | tests_sysconf.cpp:36:21:36:27 | confstr output argument | tests_sysconf.cpp:39:19:39:25 | pathbuf indirection | This operation exposes system data from $@. | tests_sysconf.cpp:36:21:36:27 | confstr output argument | confstr output argument |
+| tests2.cpp:63:13:63:26 | *call to getenv | tests2.cpp:63:13:63:26 | *call to getenv | tests2.cpp:63:13:63:26 | *call to getenv | This operation exposes system data from $@. | tests2.cpp:63:13:63:26 | *call to getenv | *call to getenv |
+| tests2.cpp:64:13:64:26 | *call to getenv | tests2.cpp:64:13:64:26 | *call to getenv | tests2.cpp:64:13:64:26 | *call to getenv | This operation exposes system data from $@. | tests2.cpp:64:13:64:26 | *call to getenv | *call to getenv |
+| tests2.cpp:65:13:65:30 | *call to getenv | tests2.cpp:65:13:65:30 | *call to getenv | tests2.cpp:65:13:65:30 | *call to getenv | This operation exposes system data from $@. | tests2.cpp:65:13:65:30 | *call to getenv | *call to getenv |
+| tests2.cpp:66:13:66:34 | *call to getenv | tests2.cpp:66:13:66:34 | *call to getenv | tests2.cpp:66:13:66:34 | *call to getenv | This operation exposes system data from $@. | tests2.cpp:66:13:66:34 | *call to getenv | *call to getenv |
+| tests2.cpp:80:14:80:34 | *call to mysql_get_client_info | tests2.cpp:80:14:80:34 | *call to mysql_get_client_info | tests2.cpp:80:14:80:34 | *call to mysql_get_client_info | This operation exposes system data from $@. | tests2.cpp:80:14:80:34 | *call to mysql_get_client_info | *call to mysql_get_client_info |
+| tests2.cpp:81:14:81:19 | *buffer | tests2.cpp:78:18:78:38 | *call to mysql_get_client_info | tests2.cpp:81:14:81:19 | *buffer | This operation exposes system data from $@. | tests2.cpp:78:18:78:38 | *call to mysql_get_client_info | *call to mysql_get_client_info |
+| tests2.cpp:82:14:82:20 | *global1 | tests2.cpp:50:23:50:43 | *call to mysql_get_client_info | tests2.cpp:82:14:82:20 | *global1 | This operation exposes system data from $@. | tests2.cpp:50:23:50:43 | *call to mysql_get_client_info | *call to mysql_get_client_info |
+| tests2.cpp:93:14:93:17 | *str1 | tests2.cpp:91:42:91:45 | *str1 | tests2.cpp:93:14:93:17 | *str1 | This operation exposes system data from $@. | tests2.cpp:91:42:91:45 | *str1 | *str1 |
+| tests2.cpp:102:14:102:15 | *pw | tests2.cpp:101:8:101:15 | *call to getpwuid | tests2.cpp:102:14:102:15 | *pw | This operation exposes system data from $@. | tests2.cpp:101:8:101:15 | *call to getpwuid | *call to getpwuid |
+| tests2.cpp:111:14:111:19 | *ptr | tests2.cpp:109:12:109:17 | *call to getenv | tests2.cpp:111:14:111:19 | *ptr | This operation exposes system data from $@. | tests2.cpp:109:12:109:17 | *call to getenv | *call to getenv |
+| tests_sockets.cpp:39:19:39:22 | *path | tests_sockets.cpp:26:15:26:20 | *call to getenv | tests_sockets.cpp:39:19:39:22 | *path | This operation exposes system data from $@. | tests_sockets.cpp:26:15:26:20 | *call to getenv | *call to getenv |
+| tests_sockets.cpp:43:20:43:23 | *path | tests_sockets.cpp:26:15:26:20 | *call to getenv | tests_sockets.cpp:43:20:43:23 | *path | This operation exposes system data from $@. | tests_sockets.cpp:26:15:26:20 | *call to getenv | *call to getenv |
+| tests_sockets.cpp:76:19:76:22 | *path | tests_sockets.cpp:63:15:63:20 | *call to getenv | tests_sockets.cpp:76:19:76:22 | *path | This operation exposes system data from $@. | tests_sockets.cpp:63:15:63:20 | *call to getenv | *call to getenv |
+| tests_sockets.cpp:80:20:80:23 | *path | tests_sockets.cpp:63:15:63:20 | *call to getenv | tests_sockets.cpp:80:20:80:23 | *path | This operation exposes system data from $@. | tests_sockets.cpp:63:15:63:20 | *call to getenv | *call to getenv |
+| tests_sysconf.cpp:39:19:39:25 | *pathbuf | tests_sysconf.cpp:36:21:36:27 | confstr output argument | tests_sysconf.cpp:39:19:39:25 | *pathbuf | This operation exposes system data from $@. | tests_sysconf.cpp:36:21:36:27 | confstr output argument | confstr output argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-497/semmle/tests/PotentiallyExposedSystemData.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-497/semmle/tests/PotentiallyExposedSystemData.expected
@@ -1,64 +1,64 @@
 edges
-| tests.cpp:62:7:62:18 | global_token indirection | tests.cpp:71:27:71:38 | global_token indirection |
-| tests.cpp:62:7:62:18 | global_token indirection | tests.cpp:73:27:73:31 | maybe indirection |
-| tests.cpp:62:22:62:27 | call to getenv indirection | tests.cpp:62:7:62:18 | global_token indirection |
-| tests.cpp:86:29:86:31 | msg indirection | tests.cpp:88:15:88:17 | msg indirection |
-| tests.cpp:97:13:97:34 | call to getenv indirection | tests.cpp:86:29:86:31 | msg indirection |
-| tests.cpp:107:30:107:32 | msg indirection | tests.cpp:111:15:111:17 | tmp indirection |
-| tests.cpp:114:30:114:32 | msg indirection | tests.cpp:119:7:119:12 | buffer indirection |
-| tests.cpp:122:30:122:32 | msg indirection | tests.cpp:124:15:124:17 | msg indirection |
-| tests.cpp:131:14:131:35 | call to getenv indirection | tests.cpp:107:30:107:32 | msg indirection |
-| tests.cpp:132:14:132:35 | call to getenv indirection | tests.cpp:114:30:114:32 | msg indirection |
-| tests.cpp:133:14:133:35 | call to getenv indirection | tests.cpp:122:30:122:32 | msg indirection |
-| tests.cpp:139:17:139:22 | call to getenv indirection | tests.cpp:141:15:141:20 | secret indirection |
-| tests_passwd.cpp:16:8:16:15 | call to getpwnam indirection | tests_passwd.cpp:18:29:18:31 | pwd indirection |
-| tests_passwd.cpp:16:8:16:15 | call to getpwnam indirection | tests_passwd.cpp:19:26:19:28 | pwd indirection |
+| tests.cpp:62:7:62:18 | **global_token | tests.cpp:71:27:71:38 | *global_token |
+| tests.cpp:62:7:62:18 | **global_token | tests.cpp:73:27:73:31 | *maybe |
+| tests.cpp:62:22:62:27 | *call to getenv | tests.cpp:62:7:62:18 | **global_token |
+| tests.cpp:86:29:86:31 | *msg | tests.cpp:88:15:88:17 | *msg |
+| tests.cpp:97:13:97:34 | *call to getenv | tests.cpp:86:29:86:31 | *msg |
+| tests.cpp:107:30:107:32 | *msg | tests.cpp:111:15:111:17 | *tmp |
+| tests.cpp:114:30:114:32 | *msg | tests.cpp:119:7:119:12 | *buffer |
+| tests.cpp:122:30:122:32 | *msg | tests.cpp:124:15:124:17 | *msg |
+| tests.cpp:131:14:131:35 | *call to getenv | tests.cpp:107:30:107:32 | *msg |
+| tests.cpp:132:14:132:35 | *call to getenv | tests.cpp:114:30:114:32 | *msg |
+| tests.cpp:133:14:133:35 | *call to getenv | tests.cpp:122:30:122:32 | *msg |
+| tests.cpp:139:17:139:22 | *call to getenv | tests.cpp:141:15:141:20 | *secret |
+| tests_passwd.cpp:16:8:16:15 | *call to getpwnam | tests_passwd.cpp:18:29:18:31 | *pwd |
+| tests_passwd.cpp:16:8:16:15 | *call to getpwnam | tests_passwd.cpp:19:26:19:28 | *pwd |
 nodes
-| tests.cpp:48:15:48:36 | call to getenv indirection | semmle.label | call to getenv indirection |
-| tests.cpp:49:15:49:36 | call to getenv indirection | semmle.label | call to getenv indirection |
-| tests.cpp:50:15:50:36 | call to getenv indirection | semmle.label | call to getenv indirection |
-| tests.cpp:57:18:57:39 | call to getenv indirection | semmle.label | call to getenv indirection |
-| tests.cpp:58:41:58:62 | call to getenv indirection | semmle.label | call to getenv indirection |
-| tests.cpp:59:43:59:64 | call to getenv indirection | semmle.label | call to getenv indirection |
-| tests.cpp:62:7:62:18 | global_token indirection | semmle.label | global_token indirection |
-| tests.cpp:62:22:62:27 | call to getenv indirection | semmle.label | call to getenv indirection |
-| tests.cpp:71:27:71:38 | global_token indirection | semmle.label | global_token indirection |
-| tests.cpp:73:27:73:31 | maybe indirection | semmle.label | maybe indirection |
-| tests.cpp:86:29:86:31 | msg indirection | semmle.label | msg indirection |
-| tests.cpp:88:15:88:17 | msg indirection | semmle.label | msg indirection |
-| tests.cpp:97:13:97:34 | call to getenv indirection | semmle.label | call to getenv indirection |
-| tests.cpp:97:13:97:34 | call to getenv indirection | semmle.label | call to getenv indirection |
-| tests.cpp:107:30:107:32 | msg indirection | semmle.label | msg indirection |
-| tests.cpp:111:15:111:17 | tmp indirection | semmle.label | tmp indirection |
-| tests.cpp:114:30:114:32 | msg indirection | semmle.label | msg indirection |
-| tests.cpp:119:7:119:12 | buffer indirection | semmle.label | buffer indirection |
-| tests.cpp:122:30:122:32 | msg indirection | semmle.label | msg indirection |
-| tests.cpp:124:15:124:17 | msg indirection | semmle.label | msg indirection |
-| tests.cpp:131:14:131:35 | call to getenv indirection | semmle.label | call to getenv indirection |
-| tests.cpp:132:14:132:35 | call to getenv indirection | semmle.label | call to getenv indirection |
-| tests.cpp:133:14:133:35 | call to getenv indirection | semmle.label | call to getenv indirection |
-| tests.cpp:133:14:133:35 | call to getenv indirection | semmle.label | call to getenv indirection |
-| tests.cpp:139:17:139:22 | call to getenv indirection | semmle.label | call to getenv indirection |
-| tests.cpp:141:15:141:20 | secret indirection | semmle.label | secret indirection |
-| tests_passwd.cpp:16:8:16:15 | call to getpwnam indirection | semmle.label | call to getpwnam indirection |
-| tests_passwd.cpp:18:29:18:31 | pwd indirection | semmle.label | pwd indirection |
-| tests_passwd.cpp:19:26:19:28 | pwd indirection | semmle.label | pwd indirection |
+| tests.cpp:48:15:48:36 | *call to getenv | semmle.label | *call to getenv |
+| tests.cpp:49:15:49:36 | *call to getenv | semmle.label | *call to getenv |
+| tests.cpp:50:15:50:36 | *call to getenv | semmle.label | *call to getenv |
+| tests.cpp:57:18:57:39 | *call to getenv | semmle.label | *call to getenv |
+| tests.cpp:58:41:58:62 | *call to getenv | semmle.label | *call to getenv |
+| tests.cpp:59:43:59:64 | *call to getenv | semmle.label | *call to getenv |
+| tests.cpp:62:7:62:18 | **global_token | semmle.label | **global_token |
+| tests.cpp:62:22:62:27 | *call to getenv | semmle.label | *call to getenv |
+| tests.cpp:71:27:71:38 | *global_token | semmle.label | *global_token |
+| tests.cpp:73:27:73:31 | *maybe | semmle.label | *maybe |
+| tests.cpp:86:29:86:31 | *msg | semmle.label | *msg |
+| tests.cpp:88:15:88:17 | *msg | semmle.label | *msg |
+| tests.cpp:97:13:97:34 | *call to getenv | semmle.label | *call to getenv |
+| tests.cpp:97:13:97:34 | *call to getenv | semmle.label | *call to getenv |
+| tests.cpp:107:30:107:32 | *msg | semmle.label | *msg |
+| tests.cpp:111:15:111:17 | *tmp | semmle.label | *tmp |
+| tests.cpp:114:30:114:32 | *msg | semmle.label | *msg |
+| tests.cpp:119:7:119:12 | *buffer | semmle.label | *buffer |
+| tests.cpp:122:30:122:32 | *msg | semmle.label | *msg |
+| tests.cpp:124:15:124:17 | *msg | semmle.label | *msg |
+| tests.cpp:131:14:131:35 | *call to getenv | semmle.label | *call to getenv |
+| tests.cpp:132:14:132:35 | *call to getenv | semmle.label | *call to getenv |
+| tests.cpp:133:14:133:35 | *call to getenv | semmle.label | *call to getenv |
+| tests.cpp:133:14:133:35 | *call to getenv | semmle.label | *call to getenv |
+| tests.cpp:139:17:139:22 | *call to getenv | semmle.label | *call to getenv |
+| tests.cpp:141:15:141:20 | *secret | semmle.label | *secret |
+| tests_passwd.cpp:16:8:16:15 | *call to getpwnam | semmle.label | *call to getpwnam |
+| tests_passwd.cpp:18:29:18:31 | *pwd | semmle.label | *pwd |
+| tests_passwd.cpp:19:26:19:28 | *pwd | semmle.label | *pwd |
 subpaths
 #select
-| tests.cpp:48:15:48:36 | call to getenv indirection | tests.cpp:48:15:48:36 | call to getenv indirection | tests.cpp:48:15:48:36 | call to getenv indirection | This operation potentially exposes sensitive system data from $@. | tests.cpp:48:15:48:36 | call to getenv indirection | call to getenv indirection |
-| tests.cpp:49:15:49:36 | call to getenv indirection | tests.cpp:49:15:49:36 | call to getenv indirection | tests.cpp:49:15:49:36 | call to getenv indirection | This operation potentially exposes sensitive system data from $@. | tests.cpp:49:15:49:36 | call to getenv indirection | call to getenv indirection |
-| tests.cpp:50:15:50:36 | call to getenv indirection | tests.cpp:50:15:50:36 | call to getenv indirection | tests.cpp:50:15:50:36 | call to getenv indirection | This operation potentially exposes sensitive system data from $@. | tests.cpp:50:15:50:36 | call to getenv indirection | call to getenv indirection |
-| tests.cpp:57:18:57:39 | call to getenv indirection | tests.cpp:57:18:57:39 | call to getenv indirection | tests.cpp:57:18:57:39 | call to getenv indirection | This operation potentially exposes sensitive system data from $@. | tests.cpp:57:18:57:39 | call to getenv indirection | call to getenv indirection |
-| tests.cpp:58:41:58:62 | call to getenv indirection | tests.cpp:58:41:58:62 | call to getenv indirection | tests.cpp:58:41:58:62 | call to getenv indirection | This operation potentially exposes sensitive system data from $@. | tests.cpp:58:41:58:62 | call to getenv indirection | call to getenv indirection |
-| tests.cpp:59:43:59:64 | call to getenv indirection | tests.cpp:59:43:59:64 | call to getenv indirection | tests.cpp:59:43:59:64 | call to getenv indirection | This operation potentially exposes sensitive system data from $@. | tests.cpp:59:43:59:64 | call to getenv indirection | call to getenv indirection |
-| tests.cpp:71:27:71:38 | global_token indirection | tests.cpp:62:22:62:27 | call to getenv indirection | tests.cpp:71:27:71:38 | global_token indirection | This operation potentially exposes sensitive system data from $@. | tests.cpp:62:22:62:27 | call to getenv indirection | call to getenv indirection |
-| tests.cpp:73:27:73:31 | maybe indirection | tests.cpp:62:22:62:27 | call to getenv indirection | tests.cpp:73:27:73:31 | maybe indirection | This operation potentially exposes sensitive system data from $@. | tests.cpp:62:22:62:27 | call to getenv indirection | call to getenv indirection |
-| tests.cpp:88:15:88:17 | msg indirection | tests.cpp:97:13:97:34 | call to getenv indirection | tests.cpp:88:15:88:17 | msg indirection | This operation potentially exposes sensitive system data from $@. | tests.cpp:97:13:97:34 | call to getenv indirection | call to getenv indirection |
-| tests.cpp:97:13:97:34 | call to getenv indirection | tests.cpp:97:13:97:34 | call to getenv indirection | tests.cpp:97:13:97:34 | call to getenv indirection | This operation potentially exposes sensitive system data from $@. | tests.cpp:97:13:97:34 | call to getenv indirection | call to getenv indirection |
-| tests.cpp:111:15:111:17 | tmp indirection | tests.cpp:131:14:131:35 | call to getenv indirection | tests.cpp:111:15:111:17 | tmp indirection | This operation potentially exposes sensitive system data from $@. | tests.cpp:131:14:131:35 | call to getenv indirection | call to getenv indirection |
-| tests.cpp:119:7:119:12 | buffer indirection | tests.cpp:132:14:132:35 | call to getenv indirection | tests.cpp:119:7:119:12 | buffer indirection | This operation potentially exposes sensitive system data from $@. | tests.cpp:132:14:132:35 | call to getenv indirection | call to getenv indirection |
-| tests.cpp:124:15:124:17 | msg indirection | tests.cpp:133:14:133:35 | call to getenv indirection | tests.cpp:124:15:124:17 | msg indirection | This operation potentially exposes sensitive system data from $@. | tests.cpp:133:14:133:35 | call to getenv indirection | call to getenv indirection |
-| tests.cpp:133:14:133:35 | call to getenv indirection | tests.cpp:133:14:133:35 | call to getenv indirection | tests.cpp:133:14:133:35 | call to getenv indirection | This operation potentially exposes sensitive system data from $@. | tests.cpp:133:14:133:35 | call to getenv indirection | call to getenv indirection |
-| tests.cpp:141:15:141:20 | secret indirection | tests.cpp:139:17:139:22 | call to getenv indirection | tests.cpp:141:15:141:20 | secret indirection | This operation potentially exposes sensitive system data from $@. | tests.cpp:139:17:139:22 | call to getenv indirection | call to getenv indirection |
-| tests_passwd.cpp:18:29:18:31 | pwd indirection | tests_passwd.cpp:16:8:16:15 | call to getpwnam indirection | tests_passwd.cpp:18:29:18:31 | pwd indirection | This operation potentially exposes sensitive system data from $@. | tests_passwd.cpp:16:8:16:15 | call to getpwnam indirection | call to getpwnam indirection |
-| tests_passwd.cpp:19:26:19:28 | pwd indirection | tests_passwd.cpp:16:8:16:15 | call to getpwnam indirection | tests_passwd.cpp:19:26:19:28 | pwd indirection | This operation potentially exposes sensitive system data from $@. | tests_passwd.cpp:16:8:16:15 | call to getpwnam indirection | call to getpwnam indirection |
+| tests.cpp:48:15:48:36 | *call to getenv | tests.cpp:48:15:48:36 | *call to getenv | tests.cpp:48:15:48:36 | *call to getenv | This operation potentially exposes sensitive system data from $@. | tests.cpp:48:15:48:36 | *call to getenv | *call to getenv |
+| tests.cpp:49:15:49:36 | *call to getenv | tests.cpp:49:15:49:36 | *call to getenv | tests.cpp:49:15:49:36 | *call to getenv | This operation potentially exposes sensitive system data from $@. | tests.cpp:49:15:49:36 | *call to getenv | *call to getenv |
+| tests.cpp:50:15:50:36 | *call to getenv | tests.cpp:50:15:50:36 | *call to getenv | tests.cpp:50:15:50:36 | *call to getenv | This operation potentially exposes sensitive system data from $@. | tests.cpp:50:15:50:36 | *call to getenv | *call to getenv |
+| tests.cpp:57:18:57:39 | *call to getenv | tests.cpp:57:18:57:39 | *call to getenv | tests.cpp:57:18:57:39 | *call to getenv | This operation potentially exposes sensitive system data from $@. | tests.cpp:57:18:57:39 | *call to getenv | *call to getenv |
+| tests.cpp:58:41:58:62 | *call to getenv | tests.cpp:58:41:58:62 | *call to getenv | tests.cpp:58:41:58:62 | *call to getenv | This operation potentially exposes sensitive system data from $@. | tests.cpp:58:41:58:62 | *call to getenv | *call to getenv |
+| tests.cpp:59:43:59:64 | *call to getenv | tests.cpp:59:43:59:64 | *call to getenv | tests.cpp:59:43:59:64 | *call to getenv | This operation potentially exposes sensitive system data from $@. | tests.cpp:59:43:59:64 | *call to getenv | *call to getenv |
+| tests.cpp:71:27:71:38 | *global_token | tests.cpp:62:22:62:27 | *call to getenv | tests.cpp:71:27:71:38 | *global_token | This operation potentially exposes sensitive system data from $@. | tests.cpp:62:22:62:27 | *call to getenv | *call to getenv |
+| tests.cpp:73:27:73:31 | *maybe | tests.cpp:62:22:62:27 | *call to getenv | tests.cpp:73:27:73:31 | *maybe | This operation potentially exposes sensitive system data from $@. | tests.cpp:62:22:62:27 | *call to getenv | *call to getenv |
+| tests.cpp:88:15:88:17 | *msg | tests.cpp:97:13:97:34 | *call to getenv | tests.cpp:88:15:88:17 | *msg | This operation potentially exposes sensitive system data from $@. | tests.cpp:97:13:97:34 | *call to getenv | *call to getenv |
+| tests.cpp:97:13:97:34 | *call to getenv | tests.cpp:97:13:97:34 | *call to getenv | tests.cpp:97:13:97:34 | *call to getenv | This operation potentially exposes sensitive system data from $@. | tests.cpp:97:13:97:34 | *call to getenv | *call to getenv |
+| tests.cpp:111:15:111:17 | *tmp | tests.cpp:131:14:131:35 | *call to getenv | tests.cpp:111:15:111:17 | *tmp | This operation potentially exposes sensitive system data from $@. | tests.cpp:131:14:131:35 | *call to getenv | *call to getenv |
+| tests.cpp:119:7:119:12 | *buffer | tests.cpp:132:14:132:35 | *call to getenv | tests.cpp:119:7:119:12 | *buffer | This operation potentially exposes sensitive system data from $@. | tests.cpp:132:14:132:35 | *call to getenv | *call to getenv |
+| tests.cpp:124:15:124:17 | *msg | tests.cpp:133:14:133:35 | *call to getenv | tests.cpp:124:15:124:17 | *msg | This operation potentially exposes sensitive system data from $@. | tests.cpp:133:14:133:35 | *call to getenv | *call to getenv |
+| tests.cpp:133:14:133:35 | *call to getenv | tests.cpp:133:14:133:35 | *call to getenv | tests.cpp:133:14:133:35 | *call to getenv | This operation potentially exposes sensitive system data from $@. | tests.cpp:133:14:133:35 | *call to getenv | *call to getenv |
+| tests.cpp:141:15:141:20 | *secret | tests.cpp:139:17:139:22 | *call to getenv | tests.cpp:141:15:141:20 | *secret | This operation potentially exposes sensitive system data from $@. | tests.cpp:139:17:139:22 | *call to getenv | *call to getenv |
+| tests_passwd.cpp:18:29:18:31 | *pwd | tests_passwd.cpp:16:8:16:15 | *call to getpwnam | tests_passwd.cpp:18:29:18:31 | *pwd | This operation potentially exposes sensitive system data from $@. | tests_passwd.cpp:16:8:16:15 | *call to getpwnam | *call to getpwnam |
+| tests_passwd.cpp:19:26:19:28 | *pwd | tests_passwd.cpp:16:8:16:15 | *call to getpwnam | tests_passwd.cpp:19:26:19:28 | *pwd | This operation potentially exposes sensitive system data from $@. | tests_passwd.cpp:16:8:16:15 | *call to getpwnam | *call to getpwnam |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-611/XXE.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-611/XXE.expected
@@ -1,157 +1,157 @@
 edges
-| tests2.cpp:20:17:20:31 | call to SAXParser | tests2.cpp:22:2:22:2 | p indirection |
-| tests2.cpp:33:17:33:31 | call to SAXParser | tests2.cpp:37:2:37:2 | p indirection |
-| tests2.cpp:49:12:49:12 | call to SAXParser | tests2.cpp:51:2:51:2 | p indirection |
-| tests3.cpp:23:21:23:53 | call to createXMLReader indirection | tests3.cpp:25:2:25:2 | p indirection |
-| tests3.cpp:35:16:35:20 | p_3_3 indirection | tests3.cpp:38:2:38:6 | p_3_3 indirection |
-| tests3.cpp:35:24:35:56 | call to createXMLReader indirection | tests3.cpp:35:16:35:20 | p_3_3 indirection |
-| tests3.cpp:48:16:48:20 | p_3_5 indirection | tests3.cpp:56:2:56:6 | p_3_5 indirection |
-| tests3.cpp:48:24:48:56 | call to createXMLReader indirection | tests3.cpp:48:16:48:20 | p_3_5 indirection |
-| tests3.cpp:60:21:60:53 | call to createXMLReader indirection | tests3.cpp:63:2:63:2 | p indirection |
-| tests3.cpp:67:21:67:53 | call to createXMLReader indirection | tests3.cpp:70:2:70:2 | p indirection |
-| tests5.cpp:27:25:27:38 | call to createLSParser indirection | tests5.cpp:29:2:29:2 | p indirection |
-| tests5.cpp:40:25:40:38 | call to createLSParser indirection | tests5.cpp:43:2:43:2 | p indirection |
-| tests5.cpp:55:25:55:38 | call to createLSParser indirection | tests5.cpp:59:2:59:2 | p indirection |
-| tests5.cpp:63:21:63:24 | g_p2 indirection | tests5.cpp:77:2:77:5 | g_p2 indirection |
-| tests5.cpp:70:17:70:30 | call to createLSParser indirection | tests5.cpp:63:21:63:24 | g_p2 indirection |
-| tests5.cpp:81:25:81:38 | call to createLSParser indirection | tests5.cpp:83:2:83:2 | p indirection |
-| tests5.cpp:81:25:81:38 | call to createLSParser indirection | tests5.cpp:83:2:83:2 | p indirection |
-| tests5.cpp:83:2:83:2 | p indirection | tests5.cpp:85:2:85:2 | p indirection |
-| tests5.cpp:85:2:85:2 | p indirection | tests5.cpp:86:2:86:2 | p indirection |
-| tests5.cpp:86:2:86:2 | p indirection | tests5.cpp:88:2:88:2 | p indirection |
-| tests5.cpp:88:2:88:2 | p indirection | tests5.cpp:89:2:89:2 | p indirection |
-| tests.cpp:15:23:15:43 | call to XercesDOMParser | tests.cpp:17:2:17:2 | p indirection |
-| tests.cpp:28:23:28:43 | call to XercesDOMParser | tests.cpp:31:2:31:2 | p indirection |
-| tests.cpp:35:23:35:43 | call to XercesDOMParser | tests.cpp:37:2:37:2 | p indirection |
-| tests.cpp:37:2:37:2 | p indirection | tests.cpp:37:2:37:2 | p indirection |
-| tests.cpp:37:2:37:2 | p indirection | tests.cpp:38:2:38:2 | p indirection |
-| tests.cpp:38:2:38:2 | p indirection | tests.cpp:38:2:38:2 | p indirection |
-| tests.cpp:38:2:38:2 | p indirection | tests.cpp:39:2:39:2 | p indirection |
-| tests.cpp:51:23:51:43 | call to XercesDOMParser | tests.cpp:53:2:53:2 | p indirection |
-| tests.cpp:53:2:53:2 | p indirection | tests.cpp:53:2:53:2 | p indirection |
-| tests.cpp:53:2:53:2 | p indirection | tests.cpp:55:2:55:2 | p indirection |
-| tests.cpp:55:2:55:2 | p indirection | tests.cpp:55:2:55:2 | p indirection |
-| tests.cpp:55:2:55:2 | p indirection | tests.cpp:56:2:56:2 | p indirection |
-| tests.cpp:55:2:55:2 | p indirection | tests.cpp:57:2:57:2 | p indirection |
-| tests.cpp:57:2:57:2 | p indirection | tests.cpp:57:2:57:2 | p indirection |
-| tests.cpp:57:2:57:2 | p indirection | tests.cpp:59:2:59:2 | p indirection |
-| tests.cpp:59:2:59:2 | p indirection | tests.cpp:59:2:59:2 | p indirection |
-| tests.cpp:59:2:59:2 | p indirection | tests.cpp:60:2:60:2 | p indirection |
-| tests.cpp:66:23:66:43 | call to XercesDOMParser | tests.cpp:69:2:69:2 | p indirection |
-| tests.cpp:73:23:73:43 | call to XercesDOMParser | tests.cpp:80:2:80:2 | p indirection |
-| tests.cpp:85:24:85:44 | call to XercesDOMParser | tests.cpp:88:3:88:3 | q indirection |
-| tests.cpp:100:24:100:44 | call to XercesDOMParser | tests.cpp:104:3:104:3 | q indirection |
-| tests.cpp:112:39:112:39 | p indirection | tests.cpp:113:2:113:2 | p indirection |
-| tests.cpp:116:39:116:39 | p indirection | tests.cpp:117:2:117:2 | p indirection |
-| tests.cpp:122:23:122:43 | call to XercesDOMParser | tests.cpp:126:18:126:18 | q indirection |
-| tests.cpp:122:23:122:43 | call to XercesDOMParser | tests.cpp:128:18:128:18 | q indirection |
-| tests.cpp:126:18:126:18 | q indirection | tests.cpp:112:39:112:39 | p indirection |
-| tests.cpp:128:18:128:18 | q indirection | tests.cpp:116:39:116:39 | p indirection |
+| tests2.cpp:20:17:20:31 | call to SAXParser | tests2.cpp:22:2:22:2 | *p |
+| tests2.cpp:33:17:33:31 | call to SAXParser | tests2.cpp:37:2:37:2 | *p |
+| tests2.cpp:49:12:49:12 | call to SAXParser | tests2.cpp:51:2:51:2 | *p |
+| tests3.cpp:23:21:23:53 | *call to createXMLReader | tests3.cpp:25:2:25:2 | *p |
+| tests3.cpp:35:16:35:20 | **p_3_3 | tests3.cpp:38:2:38:6 | *p_3_3 |
+| tests3.cpp:35:24:35:56 | *call to createXMLReader | tests3.cpp:35:16:35:20 | **p_3_3 |
+| tests3.cpp:48:16:48:20 | **p_3_5 | tests3.cpp:56:2:56:6 | *p_3_5 |
+| tests3.cpp:48:24:48:56 | *call to createXMLReader | tests3.cpp:48:16:48:20 | **p_3_5 |
+| tests3.cpp:60:21:60:53 | *call to createXMLReader | tests3.cpp:63:2:63:2 | *p |
+| tests3.cpp:67:21:67:53 | *call to createXMLReader | tests3.cpp:70:2:70:2 | *p |
+| tests5.cpp:27:25:27:38 | *call to createLSParser | tests5.cpp:29:2:29:2 | *p |
+| tests5.cpp:40:25:40:38 | *call to createLSParser | tests5.cpp:43:2:43:2 | *p |
+| tests5.cpp:55:25:55:38 | *call to createLSParser | tests5.cpp:59:2:59:2 | *p |
+| tests5.cpp:63:21:63:24 | **g_p2 | tests5.cpp:77:2:77:5 | *g_p2 |
+| tests5.cpp:70:17:70:30 | *call to createLSParser | tests5.cpp:63:21:63:24 | **g_p2 |
+| tests5.cpp:81:25:81:38 | *call to createLSParser | tests5.cpp:83:2:83:2 | *p |
+| tests5.cpp:81:25:81:38 | *call to createLSParser | tests5.cpp:83:2:83:2 | *p |
+| tests5.cpp:83:2:83:2 | *p | tests5.cpp:85:2:85:2 | *p |
+| tests5.cpp:85:2:85:2 | *p | tests5.cpp:86:2:86:2 | *p |
+| tests5.cpp:86:2:86:2 | *p | tests5.cpp:88:2:88:2 | *p |
+| tests5.cpp:88:2:88:2 | *p | tests5.cpp:89:2:89:2 | *p |
+| tests.cpp:15:23:15:43 | call to XercesDOMParser | tests.cpp:17:2:17:2 | *p |
+| tests.cpp:28:23:28:43 | call to XercesDOMParser | tests.cpp:31:2:31:2 | *p |
+| tests.cpp:35:23:35:43 | call to XercesDOMParser | tests.cpp:37:2:37:2 | *p |
+| tests.cpp:37:2:37:2 | *p | tests.cpp:37:2:37:2 | *p |
+| tests.cpp:37:2:37:2 | *p | tests.cpp:38:2:38:2 | *p |
+| tests.cpp:38:2:38:2 | *p | tests.cpp:38:2:38:2 | *p |
+| tests.cpp:38:2:38:2 | *p | tests.cpp:39:2:39:2 | *p |
+| tests.cpp:51:23:51:43 | call to XercesDOMParser | tests.cpp:53:2:53:2 | *p |
+| tests.cpp:53:2:53:2 | *p | tests.cpp:53:2:53:2 | *p |
+| tests.cpp:53:2:53:2 | *p | tests.cpp:55:2:55:2 | *p |
+| tests.cpp:55:2:55:2 | *p | tests.cpp:55:2:55:2 | *p |
+| tests.cpp:55:2:55:2 | *p | tests.cpp:56:2:56:2 | *p |
+| tests.cpp:55:2:55:2 | *p | tests.cpp:57:2:57:2 | *p |
+| tests.cpp:57:2:57:2 | *p | tests.cpp:57:2:57:2 | *p |
+| tests.cpp:57:2:57:2 | *p | tests.cpp:59:2:59:2 | *p |
+| tests.cpp:59:2:59:2 | *p | tests.cpp:59:2:59:2 | *p |
+| tests.cpp:59:2:59:2 | *p | tests.cpp:60:2:60:2 | *p |
+| tests.cpp:66:23:66:43 | call to XercesDOMParser | tests.cpp:69:2:69:2 | *p |
+| tests.cpp:73:23:73:43 | call to XercesDOMParser | tests.cpp:80:2:80:2 | *p |
+| tests.cpp:85:24:85:44 | call to XercesDOMParser | tests.cpp:88:3:88:3 | *q |
+| tests.cpp:100:24:100:44 | call to XercesDOMParser | tests.cpp:104:3:104:3 | *q |
+| tests.cpp:112:39:112:39 | *p | tests.cpp:113:2:113:2 | *p |
+| tests.cpp:116:39:116:39 | *p | tests.cpp:117:2:117:2 | *p |
+| tests.cpp:122:23:122:43 | call to XercesDOMParser | tests.cpp:126:18:126:18 | *q |
+| tests.cpp:122:23:122:43 | call to XercesDOMParser | tests.cpp:128:18:128:18 | *q |
+| tests.cpp:126:18:126:18 | *q | tests.cpp:112:39:112:39 | *p |
+| tests.cpp:128:18:128:18 | *q | tests.cpp:116:39:116:39 | *p |
 nodes
 | tests2.cpp:20:17:20:31 | call to SAXParser | semmle.label | call to SAXParser |
-| tests2.cpp:22:2:22:2 | p indirection | semmle.label | p indirection |
+| tests2.cpp:22:2:22:2 | *p | semmle.label | *p |
 | tests2.cpp:33:17:33:31 | call to SAXParser | semmle.label | call to SAXParser |
-| tests2.cpp:37:2:37:2 | p indirection | semmle.label | p indirection |
+| tests2.cpp:37:2:37:2 | *p | semmle.label | *p |
 | tests2.cpp:49:12:49:12 | call to SAXParser | semmle.label | call to SAXParser |
-| tests2.cpp:51:2:51:2 | p indirection | semmle.label | p indirection |
-| tests3.cpp:23:21:23:53 | call to createXMLReader indirection | semmle.label | call to createXMLReader indirection |
-| tests3.cpp:25:2:25:2 | p indirection | semmle.label | p indirection |
-| tests3.cpp:35:16:35:20 | p_3_3 indirection | semmle.label | p_3_3 indirection |
-| tests3.cpp:35:24:35:56 | call to createXMLReader indirection | semmle.label | call to createXMLReader indirection |
-| tests3.cpp:38:2:38:6 | p_3_3 indirection | semmle.label | p_3_3 indirection |
-| tests3.cpp:48:16:48:20 | p_3_5 indirection | semmle.label | p_3_5 indirection |
-| tests3.cpp:48:24:48:56 | call to createXMLReader indirection | semmle.label | call to createXMLReader indirection |
-| tests3.cpp:56:2:56:6 | p_3_5 indirection | semmle.label | p_3_5 indirection |
-| tests3.cpp:60:21:60:53 | call to createXMLReader indirection | semmle.label | call to createXMLReader indirection |
-| tests3.cpp:63:2:63:2 | p indirection | semmle.label | p indirection |
-| tests3.cpp:67:21:67:53 | call to createXMLReader indirection | semmle.label | call to createXMLReader indirection |
-| tests3.cpp:70:2:70:2 | p indirection | semmle.label | p indirection |
+| tests2.cpp:51:2:51:2 | *p | semmle.label | *p |
+| tests3.cpp:23:21:23:53 | *call to createXMLReader | semmle.label | *call to createXMLReader |
+| tests3.cpp:25:2:25:2 | *p | semmle.label | *p |
+| tests3.cpp:35:16:35:20 | **p_3_3 | semmle.label | **p_3_3 |
+| tests3.cpp:35:24:35:56 | *call to createXMLReader | semmle.label | *call to createXMLReader |
+| tests3.cpp:38:2:38:6 | *p_3_3 | semmle.label | *p_3_3 |
+| tests3.cpp:48:16:48:20 | **p_3_5 | semmle.label | **p_3_5 |
+| tests3.cpp:48:24:48:56 | *call to createXMLReader | semmle.label | *call to createXMLReader |
+| tests3.cpp:56:2:56:6 | *p_3_5 | semmle.label | *p_3_5 |
+| tests3.cpp:60:21:60:53 | *call to createXMLReader | semmle.label | *call to createXMLReader |
+| tests3.cpp:63:2:63:2 | *p | semmle.label | *p |
+| tests3.cpp:67:21:67:53 | *call to createXMLReader | semmle.label | *call to createXMLReader |
+| tests3.cpp:70:2:70:2 | *p | semmle.label | *p |
 | tests4.cpp:26:34:26:48 | XML_PARSE_NOENT | semmle.label | XML_PARSE_NOENT |
 | tests4.cpp:36:34:36:50 | XML_PARSE_DTDLOAD | semmle.label | XML_PARSE_DTDLOAD |
 | tests4.cpp:46:34:46:68 | ... \| ... | semmle.label | ... \| ... |
 | tests4.cpp:77:34:77:38 | flags | semmle.label | flags |
 | tests4.cpp:130:39:130:55 | XML_PARSE_DTDLOAD | semmle.label | XML_PARSE_DTDLOAD |
-| tests5.cpp:27:25:27:38 | call to createLSParser indirection | semmle.label | call to createLSParser indirection |
-| tests5.cpp:29:2:29:2 | p indirection | semmle.label | p indirection |
-| tests5.cpp:40:25:40:38 | call to createLSParser indirection | semmle.label | call to createLSParser indirection |
-| tests5.cpp:43:2:43:2 | p indirection | semmle.label | p indirection |
-| tests5.cpp:55:25:55:38 | call to createLSParser indirection | semmle.label | call to createLSParser indirection |
-| tests5.cpp:59:2:59:2 | p indirection | semmle.label | p indirection |
-| tests5.cpp:63:21:63:24 | g_p2 indirection | semmle.label | g_p2 indirection |
-| tests5.cpp:70:17:70:30 | call to createLSParser indirection | semmle.label | call to createLSParser indirection |
-| tests5.cpp:77:2:77:5 | g_p2 indirection | semmle.label | g_p2 indirection |
-| tests5.cpp:81:25:81:38 | call to createLSParser indirection | semmle.label | call to createLSParser indirection |
-| tests5.cpp:83:2:83:2 | p indirection | semmle.label | p indirection |
-| tests5.cpp:83:2:83:2 | p indirection | semmle.label | p indirection |
-| tests5.cpp:85:2:85:2 | p indirection | semmle.label | p indirection |
-| tests5.cpp:86:2:86:2 | p indirection | semmle.label | p indirection |
-| tests5.cpp:88:2:88:2 | p indirection | semmle.label | p indirection |
-| tests5.cpp:89:2:89:2 | p indirection | semmle.label | p indirection |
+| tests5.cpp:27:25:27:38 | *call to createLSParser | semmle.label | *call to createLSParser |
+| tests5.cpp:29:2:29:2 | *p | semmle.label | *p |
+| tests5.cpp:40:25:40:38 | *call to createLSParser | semmle.label | *call to createLSParser |
+| tests5.cpp:43:2:43:2 | *p | semmle.label | *p |
+| tests5.cpp:55:25:55:38 | *call to createLSParser | semmle.label | *call to createLSParser |
+| tests5.cpp:59:2:59:2 | *p | semmle.label | *p |
+| tests5.cpp:63:21:63:24 | **g_p2 | semmle.label | **g_p2 |
+| tests5.cpp:70:17:70:30 | *call to createLSParser | semmle.label | *call to createLSParser |
+| tests5.cpp:77:2:77:5 | *g_p2 | semmle.label | *g_p2 |
+| tests5.cpp:81:25:81:38 | *call to createLSParser | semmle.label | *call to createLSParser |
+| tests5.cpp:83:2:83:2 | *p | semmle.label | *p |
+| tests5.cpp:83:2:83:2 | *p | semmle.label | *p |
+| tests5.cpp:85:2:85:2 | *p | semmle.label | *p |
+| tests5.cpp:86:2:86:2 | *p | semmle.label | *p |
+| tests5.cpp:88:2:88:2 | *p | semmle.label | *p |
+| tests5.cpp:89:2:89:2 | *p | semmle.label | *p |
 | tests.cpp:15:23:15:43 | call to XercesDOMParser | semmle.label | call to XercesDOMParser |
-| tests.cpp:17:2:17:2 | p indirection | semmle.label | p indirection |
+| tests.cpp:17:2:17:2 | *p | semmle.label | *p |
 | tests.cpp:28:23:28:43 | call to XercesDOMParser | semmle.label | call to XercesDOMParser |
-| tests.cpp:31:2:31:2 | p indirection | semmle.label | p indirection |
+| tests.cpp:31:2:31:2 | *p | semmle.label | *p |
 | tests.cpp:35:23:35:43 | call to XercesDOMParser | semmle.label | call to XercesDOMParser |
-| tests.cpp:37:2:37:2 | p indirection | semmle.label | p indirection |
-| tests.cpp:37:2:37:2 | p indirection | semmle.label | p indirection |
-| tests.cpp:38:2:38:2 | p indirection | semmle.label | p indirection |
-| tests.cpp:38:2:38:2 | p indirection | semmle.label | p indirection |
-| tests.cpp:39:2:39:2 | p indirection | semmle.label | p indirection |
+| tests.cpp:37:2:37:2 | *p | semmle.label | *p |
+| tests.cpp:37:2:37:2 | *p | semmle.label | *p |
+| tests.cpp:38:2:38:2 | *p | semmle.label | *p |
+| tests.cpp:38:2:38:2 | *p | semmle.label | *p |
+| tests.cpp:39:2:39:2 | *p | semmle.label | *p |
 | tests.cpp:51:23:51:43 | call to XercesDOMParser | semmle.label | call to XercesDOMParser |
-| tests.cpp:53:2:53:2 | p indirection | semmle.label | p indirection |
-| tests.cpp:53:2:53:2 | p indirection | semmle.label | p indirection |
-| tests.cpp:55:2:55:2 | p indirection | semmle.label | p indirection |
-| tests.cpp:55:2:55:2 | p indirection | semmle.label | p indirection |
-| tests.cpp:56:2:56:2 | p indirection | semmle.label | p indirection |
-| tests.cpp:57:2:57:2 | p indirection | semmle.label | p indirection |
-| tests.cpp:57:2:57:2 | p indirection | semmle.label | p indirection |
-| tests.cpp:59:2:59:2 | p indirection | semmle.label | p indirection |
-| tests.cpp:59:2:59:2 | p indirection | semmle.label | p indirection |
-| tests.cpp:60:2:60:2 | p indirection | semmle.label | p indirection |
+| tests.cpp:53:2:53:2 | *p | semmle.label | *p |
+| tests.cpp:53:2:53:2 | *p | semmle.label | *p |
+| tests.cpp:55:2:55:2 | *p | semmle.label | *p |
+| tests.cpp:55:2:55:2 | *p | semmle.label | *p |
+| tests.cpp:56:2:56:2 | *p | semmle.label | *p |
+| tests.cpp:57:2:57:2 | *p | semmle.label | *p |
+| tests.cpp:57:2:57:2 | *p | semmle.label | *p |
+| tests.cpp:59:2:59:2 | *p | semmle.label | *p |
+| tests.cpp:59:2:59:2 | *p | semmle.label | *p |
+| tests.cpp:60:2:60:2 | *p | semmle.label | *p |
 | tests.cpp:66:23:66:43 | call to XercesDOMParser | semmle.label | call to XercesDOMParser |
-| tests.cpp:69:2:69:2 | p indirection | semmle.label | p indirection |
+| tests.cpp:69:2:69:2 | *p | semmle.label | *p |
 | tests.cpp:73:23:73:43 | call to XercesDOMParser | semmle.label | call to XercesDOMParser |
-| tests.cpp:80:2:80:2 | p indirection | semmle.label | p indirection |
+| tests.cpp:80:2:80:2 | *p | semmle.label | *p |
 | tests.cpp:85:24:85:44 | call to XercesDOMParser | semmle.label | call to XercesDOMParser |
-| tests.cpp:88:3:88:3 | q indirection | semmle.label | q indirection |
+| tests.cpp:88:3:88:3 | *q | semmle.label | *q |
 | tests.cpp:100:24:100:44 | call to XercesDOMParser | semmle.label | call to XercesDOMParser |
-| tests.cpp:104:3:104:3 | q indirection | semmle.label | q indirection |
-| tests.cpp:112:39:112:39 | p indirection | semmle.label | p indirection |
-| tests.cpp:113:2:113:2 | p indirection | semmle.label | p indirection |
-| tests.cpp:116:39:116:39 | p indirection | semmle.label | p indirection |
-| tests.cpp:117:2:117:2 | p indirection | semmle.label | p indirection |
+| tests.cpp:104:3:104:3 | *q | semmle.label | *q |
+| tests.cpp:112:39:112:39 | *p | semmle.label | *p |
+| tests.cpp:113:2:113:2 | *p | semmle.label | *p |
+| tests.cpp:116:39:116:39 | *p | semmle.label | *p |
+| tests.cpp:117:2:117:2 | *p | semmle.label | *p |
 | tests.cpp:122:23:122:43 | call to XercesDOMParser | semmle.label | call to XercesDOMParser |
-| tests.cpp:126:18:126:18 | q indirection | semmle.label | q indirection |
-| tests.cpp:128:18:128:18 | q indirection | semmle.label | q indirection |
+| tests.cpp:126:18:126:18 | *q | semmle.label | *q |
+| tests.cpp:128:18:128:18 | *q | semmle.label | *q |
 subpaths
 #select
-| tests2.cpp:22:2:22:2 | p indirection | tests2.cpp:20:17:20:31 | call to SAXParser | tests2.cpp:22:2:22:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests2.cpp:20:17:20:31 | call to SAXParser | XML parser |
-| tests2.cpp:37:2:37:2 | p indirection | tests2.cpp:33:17:33:31 | call to SAXParser | tests2.cpp:37:2:37:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests2.cpp:33:17:33:31 | call to SAXParser | XML parser |
-| tests2.cpp:51:2:51:2 | p indirection | tests2.cpp:49:12:49:12 | call to SAXParser | tests2.cpp:51:2:51:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests2.cpp:49:12:49:12 | call to SAXParser | XML parser |
-| tests3.cpp:25:2:25:2 | p indirection | tests3.cpp:23:21:23:53 | call to createXMLReader indirection | tests3.cpp:25:2:25:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests3.cpp:23:21:23:53 | call to createXMLReader indirection | XML parser |
-| tests3.cpp:38:2:38:6 | p_3_3 indirection | tests3.cpp:35:24:35:56 | call to createXMLReader indirection | tests3.cpp:38:2:38:6 | p_3_3 indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests3.cpp:35:24:35:56 | call to createXMLReader indirection | XML parser |
-| tests3.cpp:56:2:56:6 | p_3_5 indirection | tests3.cpp:48:24:48:56 | call to createXMLReader indirection | tests3.cpp:56:2:56:6 | p_3_5 indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests3.cpp:48:24:48:56 | call to createXMLReader indirection | XML parser |
-| tests3.cpp:63:2:63:2 | p indirection | tests3.cpp:60:21:60:53 | call to createXMLReader indirection | tests3.cpp:63:2:63:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests3.cpp:60:21:60:53 | call to createXMLReader indirection | XML parser |
-| tests3.cpp:70:2:70:2 | p indirection | tests3.cpp:67:21:67:53 | call to createXMLReader indirection | tests3.cpp:70:2:70:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests3.cpp:67:21:67:53 | call to createXMLReader indirection | XML parser |
+| tests2.cpp:22:2:22:2 | *p | tests2.cpp:20:17:20:31 | call to SAXParser | tests2.cpp:22:2:22:2 | *p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests2.cpp:20:17:20:31 | call to SAXParser | XML parser |
+| tests2.cpp:37:2:37:2 | *p | tests2.cpp:33:17:33:31 | call to SAXParser | tests2.cpp:37:2:37:2 | *p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests2.cpp:33:17:33:31 | call to SAXParser | XML parser |
+| tests2.cpp:51:2:51:2 | *p | tests2.cpp:49:12:49:12 | call to SAXParser | tests2.cpp:51:2:51:2 | *p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests2.cpp:49:12:49:12 | call to SAXParser | XML parser |
+| tests3.cpp:25:2:25:2 | *p | tests3.cpp:23:21:23:53 | *call to createXMLReader | tests3.cpp:25:2:25:2 | *p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests3.cpp:23:21:23:53 | *call to createXMLReader | XML parser |
+| tests3.cpp:38:2:38:6 | *p_3_3 | tests3.cpp:35:24:35:56 | *call to createXMLReader | tests3.cpp:38:2:38:6 | *p_3_3 | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests3.cpp:35:24:35:56 | *call to createXMLReader | XML parser |
+| tests3.cpp:56:2:56:6 | *p_3_5 | tests3.cpp:48:24:48:56 | *call to createXMLReader | tests3.cpp:56:2:56:6 | *p_3_5 | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests3.cpp:48:24:48:56 | *call to createXMLReader | XML parser |
+| tests3.cpp:63:2:63:2 | *p | tests3.cpp:60:21:60:53 | *call to createXMLReader | tests3.cpp:63:2:63:2 | *p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests3.cpp:60:21:60:53 | *call to createXMLReader | XML parser |
+| tests3.cpp:70:2:70:2 | *p | tests3.cpp:67:21:67:53 | *call to createXMLReader | tests3.cpp:70:2:70:2 | *p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests3.cpp:67:21:67:53 | *call to createXMLReader | XML parser |
 | tests4.cpp:26:34:26:48 | XML_PARSE_NOENT | tests4.cpp:26:34:26:48 | XML_PARSE_NOENT | tests4.cpp:26:34:26:48 | XML_PARSE_NOENT | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests4.cpp:26:34:26:48 | XML_PARSE_NOENT | XML parser |
 | tests4.cpp:36:34:36:50 | XML_PARSE_DTDLOAD | tests4.cpp:36:34:36:50 | XML_PARSE_DTDLOAD | tests4.cpp:36:34:36:50 | XML_PARSE_DTDLOAD | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests4.cpp:36:34:36:50 | XML_PARSE_DTDLOAD | XML parser |
 | tests4.cpp:46:34:46:68 | ... \| ... | tests4.cpp:46:34:46:68 | ... \| ... | tests4.cpp:46:34:46:68 | ... \| ... | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests4.cpp:46:34:46:68 | ... \| ... | XML parser |
 | tests4.cpp:77:34:77:38 | flags | tests4.cpp:77:34:77:38 | flags | tests4.cpp:77:34:77:38 | flags | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests4.cpp:77:34:77:38 | flags | XML parser |
 | tests4.cpp:130:39:130:55 | XML_PARSE_DTDLOAD | tests4.cpp:130:39:130:55 | XML_PARSE_DTDLOAD | tests4.cpp:130:39:130:55 | XML_PARSE_DTDLOAD | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests4.cpp:130:39:130:55 | XML_PARSE_DTDLOAD | XML parser |
-| tests5.cpp:29:2:29:2 | p indirection | tests5.cpp:27:25:27:38 | call to createLSParser indirection | tests5.cpp:29:2:29:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:27:25:27:38 | call to createLSParser indirection | XML parser |
-| tests5.cpp:43:2:43:2 | p indirection | tests5.cpp:40:25:40:38 | call to createLSParser indirection | tests5.cpp:43:2:43:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:40:25:40:38 | call to createLSParser indirection | XML parser |
-| tests5.cpp:59:2:59:2 | p indirection | tests5.cpp:55:25:55:38 | call to createLSParser indirection | tests5.cpp:59:2:59:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:55:25:55:38 | call to createLSParser indirection | XML parser |
-| tests5.cpp:77:2:77:5 | g_p2 indirection | tests5.cpp:70:17:70:30 | call to createLSParser indirection | tests5.cpp:77:2:77:5 | g_p2 indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:70:17:70:30 | call to createLSParser indirection | XML parser |
-| tests5.cpp:83:2:83:2 | p indirection | tests5.cpp:81:25:81:38 | call to createLSParser indirection | tests5.cpp:83:2:83:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:81:25:81:38 | call to createLSParser indirection | XML parser |
-| tests5.cpp:89:2:89:2 | p indirection | tests5.cpp:81:25:81:38 | call to createLSParser indirection | tests5.cpp:89:2:89:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:81:25:81:38 | call to createLSParser indirection | XML parser |
-| tests.cpp:17:2:17:2 | p indirection | tests.cpp:15:23:15:43 | call to XercesDOMParser | tests.cpp:17:2:17:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:15:23:15:43 | call to XercesDOMParser | XML parser |
-| tests.cpp:31:2:31:2 | p indirection | tests.cpp:28:23:28:43 | call to XercesDOMParser | tests.cpp:31:2:31:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:28:23:28:43 | call to XercesDOMParser | XML parser |
-| tests.cpp:39:2:39:2 | p indirection | tests.cpp:35:23:35:43 | call to XercesDOMParser | tests.cpp:39:2:39:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:35:23:35:43 | call to XercesDOMParser | XML parser |
-| tests.cpp:56:2:56:2 | p indirection | tests.cpp:51:23:51:43 | call to XercesDOMParser | tests.cpp:56:2:56:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:51:23:51:43 | call to XercesDOMParser | XML parser |
-| tests.cpp:60:2:60:2 | p indirection | tests.cpp:51:23:51:43 | call to XercesDOMParser | tests.cpp:60:2:60:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:51:23:51:43 | call to XercesDOMParser | XML parser |
-| tests.cpp:69:2:69:2 | p indirection | tests.cpp:66:23:66:43 | call to XercesDOMParser | tests.cpp:69:2:69:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:66:23:66:43 | call to XercesDOMParser | XML parser |
-| tests.cpp:80:2:80:2 | p indirection | tests.cpp:73:23:73:43 | call to XercesDOMParser | tests.cpp:80:2:80:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:73:23:73:43 | call to XercesDOMParser | XML parser |
-| tests.cpp:88:3:88:3 | q indirection | tests.cpp:85:24:85:44 | call to XercesDOMParser | tests.cpp:88:3:88:3 | q indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:85:24:85:44 | call to XercesDOMParser | XML parser |
-| tests.cpp:104:3:104:3 | q indirection | tests.cpp:100:24:100:44 | call to XercesDOMParser | tests.cpp:104:3:104:3 | q indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:100:24:100:44 | call to XercesDOMParser | XML parser |
-| tests.cpp:113:2:113:2 | p indirection | tests.cpp:122:23:122:43 | call to XercesDOMParser | tests.cpp:113:2:113:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:122:23:122:43 | call to XercesDOMParser | XML parser |
-| tests.cpp:117:2:117:2 | p indirection | tests.cpp:122:23:122:43 | call to XercesDOMParser | tests.cpp:117:2:117:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:122:23:122:43 | call to XercesDOMParser | XML parser |
+| tests5.cpp:29:2:29:2 | *p | tests5.cpp:27:25:27:38 | *call to createLSParser | tests5.cpp:29:2:29:2 | *p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:27:25:27:38 | *call to createLSParser | XML parser |
+| tests5.cpp:43:2:43:2 | *p | tests5.cpp:40:25:40:38 | *call to createLSParser | tests5.cpp:43:2:43:2 | *p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:40:25:40:38 | *call to createLSParser | XML parser |
+| tests5.cpp:59:2:59:2 | *p | tests5.cpp:55:25:55:38 | *call to createLSParser | tests5.cpp:59:2:59:2 | *p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:55:25:55:38 | *call to createLSParser | XML parser |
+| tests5.cpp:77:2:77:5 | *g_p2 | tests5.cpp:70:17:70:30 | *call to createLSParser | tests5.cpp:77:2:77:5 | *g_p2 | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:70:17:70:30 | *call to createLSParser | XML parser |
+| tests5.cpp:83:2:83:2 | *p | tests5.cpp:81:25:81:38 | *call to createLSParser | tests5.cpp:83:2:83:2 | *p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:81:25:81:38 | *call to createLSParser | XML parser |
+| tests5.cpp:89:2:89:2 | *p | tests5.cpp:81:25:81:38 | *call to createLSParser | tests5.cpp:89:2:89:2 | *p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:81:25:81:38 | *call to createLSParser | XML parser |
+| tests.cpp:17:2:17:2 | *p | tests.cpp:15:23:15:43 | call to XercesDOMParser | tests.cpp:17:2:17:2 | *p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:15:23:15:43 | call to XercesDOMParser | XML parser |
+| tests.cpp:31:2:31:2 | *p | tests.cpp:28:23:28:43 | call to XercesDOMParser | tests.cpp:31:2:31:2 | *p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:28:23:28:43 | call to XercesDOMParser | XML parser |
+| tests.cpp:39:2:39:2 | *p | tests.cpp:35:23:35:43 | call to XercesDOMParser | tests.cpp:39:2:39:2 | *p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:35:23:35:43 | call to XercesDOMParser | XML parser |
+| tests.cpp:56:2:56:2 | *p | tests.cpp:51:23:51:43 | call to XercesDOMParser | tests.cpp:56:2:56:2 | *p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:51:23:51:43 | call to XercesDOMParser | XML parser |
+| tests.cpp:60:2:60:2 | *p | tests.cpp:51:23:51:43 | call to XercesDOMParser | tests.cpp:60:2:60:2 | *p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:51:23:51:43 | call to XercesDOMParser | XML parser |
+| tests.cpp:69:2:69:2 | *p | tests.cpp:66:23:66:43 | call to XercesDOMParser | tests.cpp:69:2:69:2 | *p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:66:23:66:43 | call to XercesDOMParser | XML parser |
+| tests.cpp:80:2:80:2 | *p | tests.cpp:73:23:73:43 | call to XercesDOMParser | tests.cpp:80:2:80:2 | *p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:73:23:73:43 | call to XercesDOMParser | XML parser |
+| tests.cpp:88:3:88:3 | *q | tests.cpp:85:24:85:44 | call to XercesDOMParser | tests.cpp:88:3:88:3 | *q | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:85:24:85:44 | call to XercesDOMParser | XML parser |
+| tests.cpp:104:3:104:3 | *q | tests.cpp:100:24:100:44 | call to XercesDOMParser | tests.cpp:104:3:104:3 | *q | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:100:24:100:44 | call to XercesDOMParser | XML parser |
+| tests.cpp:113:2:113:2 | *p | tests.cpp:122:23:122:43 | call to XercesDOMParser | tests.cpp:113:2:113:2 | *p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:122:23:122:43 | call to XercesDOMParser | XML parser |
+| tests.cpp:117:2:117:2 | *p | tests.cpp:122:23:122:43 | call to XercesDOMParser | tests.cpp:117:2:117:2 | *p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:122:23:122:43 | call to XercesDOMParser | XML parser |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-807/semmle/TaintedCondition/TaintedCondition.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-807/semmle/TaintedCondition/TaintedCondition.expected
@@ -1,8 +1,8 @@
 edges
-| test.cpp:20:29:20:47 | call to getenv indirection | test.cpp:24:10:24:35 | ! ... |
+| test.cpp:20:29:20:47 | *call to getenv | test.cpp:24:10:24:35 | ! ... |
 nodes
-| test.cpp:20:29:20:47 | call to getenv indirection | semmle.label | call to getenv indirection |
+| test.cpp:20:29:20:47 | *call to getenv | semmle.label | *call to getenv |
 | test.cpp:24:10:24:35 | ! ... | semmle.label | ! ... |
 subpaths
 #select
-| test.cpp:24:10:24:35 | ! ... | test.cpp:20:29:20:47 | call to getenv indirection | test.cpp:24:10:24:35 | ! ... | Reliance on $@ to raise privilege at $@. | test.cpp:20:29:20:47 | call to getenv indirection | an environment variable | test.cpp:25:9:25:27 | ... = ... | ... = ... |
+| test.cpp:24:10:24:35 | ! ... | test.cpp:20:29:20:47 | *call to getenv | test.cpp:24:10:24:35 | ! ... | Reliance on $@ to raise privilege at $@. | test.cpp:20:29:20:47 | *call to getenv | an environment variable | test.cpp:25:9:25:27 | ... = ... | ... = ... |


### PR DESCRIPTION
This PR improves the `toString` on dataflow nodes so that it outputs the number of indirections instead of just appending the word `indirection` to the output.