### PR TITLE
JavaScript: Add support for XML attributes in the data flow graph

### DIFF
--- a/javascript/ql/lib/semmle/javascript/PrintAst.qll
+++ b/javascript/ql/lib/semmle/javascript/PrintAst.qll
@@ -83,7 +83,8 @@ private newtype TPrintAstNode =
     shouldPrint(term, _) and
     term.isUsedAsRegExp() and
     any(RegExpLiteral lit).getRoot() = term.getRootTerm()
-  }
+  } or
+  TXmlAttributeNode(XmlAttribute attr) { shouldPrint(attr, _) and not isNotNeeded(attr) }
 
 /**
  * A node in the output tree.

--- a/javascript/ql/lib/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/DataFlow.qll
@@ -973,6 +973,28 @@ module DataFlow {
   }
 
   /**
+   * A data flow node representing an XML attribute.
+   */
+  class XmlAttributeNode extends DataFlow::Node, TXmlAttributeNode {
+    XmlAttribute attr;
+
+    XmlAttributeNode() { this = TXmlAttributeNode(attr) }
+
+    override string toString() { result = attr.toString() }
+
+    override predicate hasLocationInfo(
+      string filepath, int startline, int startcolumn, int endline, int endcolumn
+    ) {
+      attr.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    }
+
+    /** Gets the attribute corresponding to this data flow node. */
+    XmlAttribute getAttribute() { result = attr }
+
+    override File getFile() { result = attr.getLocation().getFile() }
+  }
+
+  /**
    * A data flow node representing the exceptions thrown by a function.
    */
   class ExceptionalFunctionReturnNode extends DataFlow::Node, TExceptionalFunctionReturnNode {

--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/DataFlowNode.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/DataFlowNode.qll
@@ -27,6 +27,7 @@ newtype TNode =
     exists(decl.getASpecifier().getImportedName())
   } or
   THtmlAttributeNode(HTML::Attribute attr) or
+  TXmlAttributeNode(XmlAttribute attr) or
   TFunctionReturnNode(Function f) or
   TExceptionalFunctionReturnNode(Function f) or
   TExceptionalInvocationReturnNode(InvokeExpr e) or


### PR DESCRIPTION
Model XML attributes similar to HTML attributes so we can reason about values flowing from/to XML attributes.

This is necessary for supporting Web frameworks relying on XML to define views such as SAP UI5.