### PR TITLE
JS: TypeScript extractor fixes into rc/3.12

### DIFF
--- a/javascript/extractor/lib/typescript/src/ast_extractor.ts
+++ b/javascript/extractor/lib/typescript/src/ast_extractor.ts
@@ -192,7 +192,7 @@ export function augmentAst(ast: AugmentedSourceFile, code: string, project: Proj
         }
 
         if (typeChecker != null) {
-            if (isTypedNode(node)) {
+            if (isTypedNode(node) && !typeTable.skipExtractingTypes) {
                 let contextualType = isContextuallyTypedNode(node)
                     ? typeChecker.getContextualType(node)
                     : null;

--- a/javascript/extractor/lib/typescript/src/main.ts
+++ b/javascript/extractor/lib/typescript/src/main.ts
@@ -886,6 +886,7 @@ if (process.argv.length > 2) {
     if (argument === "--version") {
         console.log("parser-wrapper with TypeScript " + ts.version);
     } else if (pathlib.basename(argument) === "tsconfig.json") {
+        reset();
         handleOpenProjectCommand({
             command: "open-project",
             tsConfig: argument,

--- a/javascript/extractor/lib/typescript/src/main.ts
+++ b/javascript/extractor/lib/typescript/src/main.ts
@@ -808,7 +808,7 @@ function handleGetMetadataCommand(command: GetMetadataCommand) {
 function reset() {
     state = new State();
     state.typeTable.restrictedExpansion = getEnvironmentVariable("SEMMLE_TYPESCRIPT_NO_EXPANSION", Boolean, true);
-    state.typeTable.skipExtractingTypes = getEnvironmentVariable("SEMMLE_TYPESCRIPT_SKIP_EXTRACTING_TYPES", Boolean, false);
+    state.typeTable.skipExtractingTypes = getEnvironmentVariable("CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_SKIP_TYPES", Boolean, false);
 }
 
 function getEnvironmentVariable<T>(name: string, parse: (x: string) => T, defaultValue: T) {

--- a/javascript/extractor/lib/typescript/src/main.ts
+++ b/javascript/extractor/lib/typescript/src/main.ts
@@ -808,6 +808,7 @@ function handleGetMetadataCommand(command: GetMetadataCommand) {
 function reset() {
     state = new State();
     state.typeTable.restrictedExpansion = getEnvironmentVariable("SEMMLE_TYPESCRIPT_NO_EXPANSION", Boolean, true);
+    state.typeTable.skipExtractingTypes = getEnvironmentVariable("SEMMLE_TYPESCRIPT_SKIP_EXTRACTING_TYPES", Boolean, false);
 }
 
 function getEnvironmentVariable<T>(name: string, parse: (x: string) => T, defaultValue: T) {

--- a/javascript/extractor/lib/typescript/src/main.ts
+++ b/javascript/extractor/lib/typescript/src/main.ts
@@ -554,7 +554,7 @@ function handleOpenProjectCommand(command: OpenProjectCommand) {
     let program = project.program;
     let typeChecker = program.getTypeChecker();
 
-    let shouldReportDiagnostics = getEnvironmentVariable("SEMMLE_TYPESCRIPT_REPORT_DIAGNOSTICS", v => JSON.parse(v.toLowerCase()), false);
+    let shouldReportDiagnostics = getEnvironmentVariable("SEMMLE_TYPESCRIPT_REPORT_DIAGNOSTICS", v => v.trim().toLowerCase() === "true", false);
     let diagnostics = shouldReportDiagnostics
         ? program.getSemanticDiagnostics().filter(d => d.category === ts.DiagnosticCategory.Error)
         : [];
@@ -807,8 +807,8 @@ function handleGetMetadataCommand(command: GetMetadataCommand) {
 
 function reset() {
     state = new State();
-    state.typeTable.restrictedExpansion = getEnvironmentVariable("SEMMLE_TYPESCRIPT_NO_EXPANSION", v => JSON.parse(v.toLowerCase()), true);
-    state.typeTable.skipExtractingTypes = getEnvironmentVariable("CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_SKIP_TYPES", v => JSON.parse(v.toLowerCase()), false);
+    state.typeTable.restrictedExpansion = getEnvironmentVariable("SEMMLE_TYPESCRIPT_NO_EXPANSION", v => v.trim().toLowerCase() === "true", true);
+    state.typeTable.skipExtractingTypes = getEnvironmentVariable("CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_SKIP_TYPES", v => v.trim().toLowerCase() === "true", false);
 }
 
 function getEnvironmentVariable<T>(name: string, parse: (x: string) => T, defaultValue: T) {

--- a/javascript/extractor/lib/typescript/src/main.ts
+++ b/javascript/extractor/lib/typescript/src/main.ts
@@ -554,7 +554,7 @@ function handleOpenProjectCommand(command: OpenProjectCommand) {
     let program = project.program;
     let typeChecker = program.getTypeChecker();
 
-    let shouldReportDiagnostics = getEnvironmentVariable("SEMMLE_TYPESCRIPT_REPORT_DIAGNOSTICS", Boolean, false);
+    let shouldReportDiagnostics = getEnvironmentVariable("SEMMLE_TYPESCRIPT_REPORT_DIAGNOSTICS", v => JSON.parse(v.toLowerCase()), false);
     let diagnostics = shouldReportDiagnostics
         ? program.getSemanticDiagnostics().filter(d => d.category === ts.DiagnosticCategory.Error)
         : [];
@@ -807,8 +807,8 @@ function handleGetMetadataCommand(command: GetMetadataCommand) {
 
 function reset() {
     state = new State();
-    state.typeTable.restrictedExpansion = getEnvironmentVariable("SEMMLE_TYPESCRIPT_NO_EXPANSION", Boolean, true);
-    state.typeTable.skipExtractingTypes = getEnvironmentVariable("CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_SKIP_TYPES", Boolean, false);
+    state.typeTable.restrictedExpansion = getEnvironmentVariable("SEMMLE_TYPESCRIPT_NO_EXPANSION", v => JSON.parse(v.toLowerCase()), true);
+    state.typeTable.skipExtractingTypes = getEnvironmentVariable("CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_SKIP_TYPES", v => JSON.parse(v.toLowerCase()), false);
 }
 
 function getEnvironmentVariable<T>(name: string, parse: (x: string) => T, defaultValue: T) {

--- a/javascript/extractor/lib/typescript/src/main.ts
+++ b/javascript/extractor/lib/typescript/src/main.ts
@@ -895,7 +895,7 @@ if (process.argv.length > 2) {
             virtualSourceRoot: null,
         });
         for (let sf of state.project.program.getSourceFiles()) {
-            if (pathlib.basename(sf.fileName) === "lib.d.ts") continue;
+            if (/lib\..*\.d\.ts/.test(pathlib.basename(sf.fileName)) || pathlib.basename(sf.fileName) === "lib.d.ts") continue;
             handleParseCommand({
                 command: "parse",
                 filename: sf.fileName,

--- a/javascript/extractor/lib/typescript/src/type_table.ts
+++ b/javascript/extractor/lib/typescript/src/type_table.ts
@@ -383,6 +383,11 @@ export class TypeTable {
    */
   public restrictedExpansion = false;
 
+  /**
+   * If set to true, skip extracting types.
+   */
+  public skipExtractingTypes = false;
+
   private virtualSourceRoot: VirtualSourceRoot;
 
   /**

--- a/javascript/extractor/lib/typescript/src/type_table.ts
+++ b/javascript/extractor/lib/typescript/src/type_table.ts
@@ -1241,7 +1241,7 @@ export class TypeTable {
       stack.push(id);
 
       for (let symbol of type.getProperties()) {
-        let propertyType = this.tryGetTypeOfSymbol(symbol);
+        let propertyType = typeTable.tryGetTypeOfSymbol(symbol);
         if (propertyType == null) continue;
         traverseType(propertyType);
       }

--- a/javascript/extractor/lib/typescript/src/type_table.ts
+++ b/javascript/extractor/lib/typescript/src/type_table.ts
@@ -1240,6 +1240,13 @@ export class TypeTable {
       let indexOnStack = stack.length;
       stack.push(id);
 
+      /** Indicates if a type contains no type variables, is a type variable, or strictly contains type variables. */
+      const enum TypeVarDepth {
+        noTypeVar = 0,
+        isTypeVar = 1,
+        containsTypeVar = 2,
+      }
+
       for (let symbol of type.getProperties()) {
         let propertyType = typeTable.tryGetTypeOfSymbol(symbol);
         if (propertyType == null) continue;
@@ -1266,13 +1273,6 @@ export class TypeTable {
       }
 
       return lowlinkTable.get(id);
-
-      /** Indicates if a type contains no type variables, is a type variable, or strictly contains type variables. */
-      const enum TypeVarDepth {
-        noTypeVar = 0,
-        isTypeVar = 1,
-        containsTypeVar = 2,
-      }
 
       function traverseType(type: ts.Type): TypeVarDepth {
         if (isTypeVariable(type)) return TypeVarDepth.isTypeVar;


### PR DESCRIPTION
Cherry-picking the commits from https://github.com/github/codeql/pull/15105 and https://github.com/github/codeql/pull/15105 into `rc/3.12` such that they should be part of the next release.  

The internal PR (`codeql-extractor.yml`) is just for documentation. So that PR doesn't need to be merged to the release branch.  

I'm doing an evaluation (see backref), just to make sure everything looks OK. 