### PR TITLE
C++: Fix joins in `cpp/resource-not-released-in-destructor`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/Function.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Function.qll
@@ -339,10 +339,6 @@ class Function extends Declaration, ControlFlowNode, AccessHolder, @function {
     exists(FunctionCall call |
       call.getEnclosingFunction() = this and call.getTarget() = f and call = l
     )
-    or
-    exists(DestructorCall call |
-      call.getEnclosingFunction() = this and call.getTarget() = f and call = l
-    )
   }
 
   /** Holds if this function accesses a function or variable or enumerator `a`. */

--- a/cpp/ql/lib/semmle/code/cpp/Function.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Function.qll
@@ -328,6 +328,7 @@ class Function extends Declaration, ControlFlowNode, AccessHolder, @function {
   MetricFunction getMetrics() { result = this }
 
   /** Holds if this function calls the function `f`. */
+  pragma[nomagic]
   predicate calls(Function f) { this.calls(f, _) }
 
   /**

--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 79.ql
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 79.ql
@@ -126,13 +126,13 @@ class Resource extends MemberVariable {
   }
 
   private predicate calledFromDestructor(Function f) {
-    f instanceof Destructor and f.getDeclaringType() = this.getDeclaringType()
+    pragma[only_bind_into](f) instanceof Destructor and
+    f.getDeclaringType() = this.getDeclaringType()
     or
-    exists(Function mid, FunctionCall fc |
+    exists(Function mid |
       this.calledFromDestructor(mid) and
-      fc.getEnclosingFunction() = mid and
-      fc.getTarget() = f and
-      f.getDeclaringType() = this.getDeclaringType()
+      mid.calls(f) and
+      pragma[only_bind_out](f.getDeclaringType()) = pragma[only_bind_out](this.getDeclaringType())
     )
   }
 


### PR DESCRIPTION
This was reported by the nightly C++ DCA run. There was a join order issue in both the base case and the recursive case 🙈.

Before:
```
Pipeline base for AVRule79::Resource.calledFromDestructor/1#c82b6f08@31f21b02 was evaluated in 1 iterations totaling 33ms (delta sizes total: 7823).
    39806  ~3%    {2} r1 = JOIN AVRule79::Resource#8f0c844b WITH `Declaration::Declaration.getDeclaringType/0#dispred#6d415a62` ON FIRST 1 OUTPUT Rhs.1, Lhs.0
  2278593  ~1%    {2} r2 = JOIN r1 WITH `Declaration::Declaration.getDeclaringType/0#dispred#6d415a62_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
     7823  ~3%    {2} r3 = JOIN r2 WITH MemberFunction::Destructor#3b34c0ea ON FIRST 1 OUTPUT Lhs.1, Lhs.0
                  return r3

Pipeline standard for AVRule79::Resource.calledFromDestructor/1#c82b6f08@31f21b02 was evaluated in 5 iterations totaling 1138ms (delta sizes total: 6268).
     13788   ~1%    {2} r1 = JOIN `AVRule79::Resource.calledFromDestructor/1#c82b6f08#prev_delta` WITH AVRule79::Resource#8f0c844b ON FIRST 1 OUTPUT Lhs.0, Lhs.1
     13788   ~0%    {3} r2 = JOIN r1 WITH `Declaration::Declaration.getDeclaringType/0#dispred#6d415a62` ON FIRST 1 OUTPUT Rhs.1, Lhs.0, Lhs.1
   4311567   ~6%    {3} r3 = JOIN r2 WITH `Declaration::Declaration.getDeclaringType/0#dispred#6d415a62_10#join_rhs` ON FIRST 1 OUTPUT Lhs.1, Rhs.1, Lhs.2
                    {3} r4 = r3 AND NOT `AVRule79::Resource.calledFromDestructor/1#c82b6f08#prev`(FIRST 2)
   4236843   ~0%    {3} r5 = SCAN r4 OUTPUT In.1, In.0, In.2
  16990023   ~0%    {4} r6 = JOIN r5 WITH `Call::FunctionCall.getTarget/0#dispred#935da4c5_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.2, Lhs.1, Lhs.0
      7228  ~24%    {2} r7 = JOIN r6 WITH `Expr::Expr.getEnclosingFunction/0#dispred#3960f06c` ON FIRST 2 OUTPUT Lhs.2, Lhs.3
                    return r7
```

After:
```
Pipeline base for AVRule79::Resource.calledFromDestructor/1#c82b6f08@3916ff8i was evaluated in 1 iterations totaling 4ms (delta sizes total: 7823).
   2107  ~3%    {2} r1 = JOIN MemberFunction::Destructor#3b34c0ea WITH `Declaration::Declaration.getDeclaringType/0#dispred#6d415a62` ON FIRST 1 OUTPUT Rhs.1, Lhs.0
  57205  ~0%    {2} r2 = JOIN r1 WITH `Declaration::Declaration.getDeclaringType/0#dispred#6d415a62_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
   7823  ~3%    {2} r3 = JOIN r2 WITH AVRule79::Resource#8f0c844b ON FIRST 1 OUTPUT Lhs.0, Lhs.1
                return r3

Pipeline standard for AVRule79::Resource.calledFromDestructor/1#c82b6f08@3916ff8i was evaluated in 5 iterations totaling 10ms (delta sizes total: 6068).
  13788   ~1%    {2} r1 = JOIN `AVRule79::Resource.calledFromDestructor/1#c82b6f08#prev_delta` WITH AVRule79::Resource#8f0c844b ON FIRST 1 OUTPUT Lhs.0, Lhs.1
  13788   ~3%    {3} r2 = JOIN r1 WITH `Declaration::Declaration.getDeclaringType/0#dispred#6d415a62` ON FIRST 1 OUTPUT Lhs.1, Lhs.0, Rhs.1
  35845   ~1%    {3} r3 = JOIN r2 WITH `Function::Function.calls/1#3886ce43` ON FIRST 1 OUTPUT Lhs.1, Rhs.1, Lhs.2
                 {3} r4 = r3 AND NOT `AVRule79::Resource.calledFromDestructor/1#c82b6f08#prev`(FIRST 2)
  35159   ~5%    {3} r5 = SCAN r4 OUTPUT In.1, In.2, In.0
   6137   ~0%    {2} r6 = JOIN r5 WITH `Declaration::Declaration.getDeclaringType/0#dispred#6d415a62` ON FIRST 2 OUTPUT Lhs.2, Lhs.0
                 return r6
```

The first commit fixes the actual joins, and the second is a drive-by cleaning commit I snuck in there for good measure 😄