### PR TITLE
C++: Fix joins in `AV Rule 145`

### DIFF
--- a/cpp/ql/src/jsf/4.16 Initialization/AV Rule 145.ql
+++ b/cpp/ql/src/jsf/4.16 Initialization/AV Rule 145.ql
@@ -39,10 +39,12 @@ predicate hasReferenceInitializer(EnumConstant c) {
  */
 EnumConstant getNonReferenceInitializedEnumConstantByRank(Enum e, int rnk) {
   result =
-    rank[rnk](EnumConstant cand, int pos |
-      e.getEnumConstant(pos) = cand and not hasReferenceInitializer(cand)
+    rank[rnk](EnumConstant cand, int pos, string filepath, int startline, int startcolumn |
+      e.getEnumConstant(pos) = cand and
+      not hasReferenceInitializer(cand) and
+      cand.getLocation().hasLocationInfo(filepath, startline, startcolumn, _, _)
     |
-      cand order by pos
+      cand order by pos, filepath, startline, startcolumn
     )
 }
 

--- a/cpp/ql/src/jsf/4.16 Initialization/AV Rule 145.ql
+++ b/cpp/ql/src/jsf/4.16 Initialization/AV Rule 145.ql
@@ -32,18 +32,39 @@ predicate hasReferenceInitializer(EnumConstant c) {
   )
 }
 
+/**
+ * Gets the `rnk`'th (1-based) enumeration constant in `e` that does not have a
+ * reference initializer (i.e., an initializer that refers to an enumeration
+ * constant from the same enumeration).
+ */
+EnumConstant getNonReferenceInitializedEnumConstantByRank(Enum e, int rnk) {
+  result =
+    rank[rnk](EnumConstant cand, int pos |
+      e.getEnumConstant(pos) = cand and not hasReferenceInitializer(cand)
+    |
+      cand order by pos
+    )
+}
+
+/**
+ * Holds if `ec` is not the last enumeration constant in `e` that has a non-
+ * reference initializer.
+ */
+predicate hasNextWithoutReferenceInitializer(Enum e, EnumConstant ec) {
+  exists(int rnk |
+    ec = getNonReferenceInitializedEnumConstantByRank(e, rnk) and
+    exists(getNonReferenceInitializedEnumConstantByRank(e, rnk + 1))
+  )
+}
+
 // There exists another constant whose value is implicit, but it's
 // not the last one: the last value is okay to use to get the highest
 // enum value automatically. It can be followed by aliases though.
 predicate enumThatHasConstantWithImplicitValue(Enum e) {
-  exists(EnumConstant ec, int pos |
-    ec = e.getEnumConstant(pos) and
+  exists(EnumConstant ec |
+    ec = e.getAnEnumConstant() and
     not hasInitializer(ec) and
-    exists(EnumConstant ec2, int pos2 |
-      ec2 = e.getEnumConstant(pos2) and
-      pos2 > pos and
-      not hasReferenceInitializer(ec2)
-    )
+    hasNextWithoutReferenceInitializer(e, ec)
   )
 }
 


### PR DESCRIPTION
Another join order issue reported by the C++ nightly DCA run.

Before:
```
[2023-12-15 11:55:06] Evaluated non-recursive predicate AVRule145::enumThatHasConstantWithImplicitValue/1#42617793@cb2a023l in 124ms (size: 512).
Evaluated relational algebra for predicate AVRule145::enumThatHasConstantWithImplicitValue/1#42617793@cb2a023l with tuple counts:
                      {3} r1 = `Enum::Enum.getEnumConstant/1#dispred#8bfe8fc8` AND NOT `_Enum::Enum.getEnumConstant/1#dispred#8bfe8fc8_Enum::EnumConstant.getInitializer/0#dispred#ee634a2f___#antijoin_rhs`(FIRST 3)
    12570      ~1%    {2} r2 = SCAN r1 OUTPUT In.0, In.1
    12557      ~1%    {2} r3 = STREAM DEDUP r2
  8703841      ~3%    {4} r4 = JOIN r3 WITH `Enum::Enum.getEnumConstant/1#dispred#8bfe8fc8` ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Rhs.1, Rhs.2
                      {4} r5 = REWRITE r4 WITH TEST InOut.2 > InOut.1
  4352791  ~35629%    {2} r6 = SCAN r5 OUTPUT In.3, In.0
                      {2} r7 = r6 AND NOT `AVRule145::hasReferenceInitializer/1#29d4de8d`(FIRST 1)
    31927   ~6556%    {1} r8 = SCAN r7 OUTPUT In.1
                      return r8
```

After:
```
[2023-12-15 12:43:19] Evaluated non-recursive predicate AVRule145::hasNextWithoutReferenceInitializer/2#e96837d9@6b51958n in 3ms (size: 18233).
Evaluated relational algebra for predicate AVRule145::hasNextWithoutReferenceInitializer/2#e96837d9@6b51958n with tuple counts:
  19733  ~1%    {3} r1 = SCAN `project#AVRule145::getNonReferenceInitializedEnumConstantByRank/2#f5f4d30a` OUTPUT In.0, _, In.1
  19733  ~5%    {2} r2 = REWRITE r1 WITH Tmp.1 := 1, Out.1 := (In.2 - Tmp.1) KEEPING 2
  18233  ~1%    {2} r3 = JOIN r2 WITH `AVRule145::getNonReferenceInitializedEnumConstantByRank/2#f5f4d30a` ON FIRST 2 OUTPUT Lhs.0, Rhs.2
                return r3

[2023-12-15 12:43:19] Evaluated non-recursive predicate _AVRule145::hasNextWithoutReferenceInitializer/2#e96837d9_Enum::EnumConstant.getDeclaringEnum/0#disp__#antijoin_rhs@6725679k in 10ms (size: 6200).
Evaluated relational algebra for predicate _AVRule145::hasNextWithoutReferenceInitializer/2#e96837d9_Enum::EnumConstant.getDeclaringEnum/0#disp__#antijoin_rhs@6725679k with tuple counts:
  18233    ~0%    {2} r1 = SCAN `AVRule145::hasNextWithoutReferenceInitializer/2#e96837d9` OUTPUT In.1, In.0
  18233    ~0%    {2} r2 = JOIN r1 WITH `Enum::EnumConstant.getDeclaringEnum/0#dispred#499b6219` ON FIRST 2 OUTPUT Lhs.0, Lhs.1
  51467    ~4%    {3} r3 = JOIN r2 WITH `Enum::EnumConstant.getInitializer/0#dispred#ee634a2f` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.0
  25092  ~302%    {2} r4 = JOIN r3 WITH `Initializer::Initializer.fromSource/0#dispred#f0cb3831#b` ON FIRST 1 OUTPUT Lhs.1, Lhs.2
                  return r4

[2023-12-15 12:43:19] Evaluated non-recursive predicate AVRule145::enumThatHasConstantWithImplicitValue/1#42617793@0f4a1eds in 3ms (size: 512).
Evaluated relational algebra for predicate AVRule145::enumThatHasConstantWithImplicitValue/1#42617793@0f4a1eds with tuple counts:
  18233     ~0%    {2} r1 = SCAN `AVRule145::hasNextWithoutReferenceInitializer/2#e96837d9` OUTPUT In.1, In.0
  18233     ~1%    {2} r2 = JOIN r1 WITH `Enum::EnumConstant.getDeclaringEnum/0#dispred#499b6219` ON FIRST 2 OUTPUT Lhs.1, Lhs.0
                   {2} r3 = r2 AND NOT `_AVRule145::hasNextWithoutReferenceInitializer/2#e96837d9_Enum::EnumConstant.getDeclaringEnum/0#disp__#antijoin_rhs`(FIRST 2)
  12033  ~2409%    {1} r4 = SCAN r3 OUTPUT In.0
                   return r4
```