### PR TITLE
Swift: Query for Use of an inappropriate cryptographic hashing algorithm on passwords

### DIFF
--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Security.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Security.qll
@@ -8,6 +8,6 @@ private import codeql.swift.dataflow.ExternalFlow
 
 private class SensitiveSources extends SourceModelCsv {
   override predicate row(string row) {
-    row = ";;false;SecKeyCopyExternalRepresentation(_:_:);;;ReturnValue;sensitive-credential"
+    row = ";;false;SecKeyCopyExternalRepresentation(_:_:);;;ReturnValue;sensitive-password"
   }
 }

--- a/swift/ql/lib/codeql/swift/security/SensitiveExprs.qll
+++ b/swift/ql/lib/codeql/swift/security/SensitiveExprs.qll
@@ -72,7 +72,8 @@ class SensitivePrivateInfo extends SensitiveDataType, TPrivateInfo {
         // Contact information, such as home addresses
         "post.?code|zip.?code|home.?addr|" +
         // and telephone numbers
-        "(mob(ile)?|home).?(num|no|tel|phone)|(tel|fax).?(num|no|phone)|" + "emergency.?contact|" +
+        "(mob(ile)?|home).?(num|no|tel|phone)|(tel|fax|phone).?(num|no)|telephone|" +
+        "emergency.?contact|" +
         // Geographic location - where the user is (or was)
         "l(atitude|ongitude)|nationality|" +
         // Financial data - such as credit card numbers, salary, bank accounts, and debts

--- a/swift/ql/lib/codeql/swift/security/SensitiveExprs.qll
+++ b/swift/ql/lib/codeql/swift/security/SensitiveExprs.qll
@@ -10,6 +10,7 @@ private import codeql.swift.dataflow.DataFlow
 private import codeql.swift.dataflow.ExternalFlow
 
 private newtype TSensitiveDataType =
+  TPassword() or
   TCredential() or
   TPrivateInfo()
 
@@ -26,18 +27,32 @@ abstract class SensitiveDataType extends TSensitiveDataType {
 }
 
 /**
- * The type of sensitive expression for passwords and other credentials.
+ * The type of sensitive expression for passwords.
+ */
+class SensitivePassword extends SensitiveDataType, TPassword {
+  override string toString() { result = "password" }
+
+  override string getRegexp() {
+    result = HeuristicNames::maybeSensitiveRegexp(SensitiveDataClassification::password())
+    or
+    result = "(?is).*pass.?phrase.*"
+  }
+}
+
+/**
+ * The type of sensitive expression for credentials and secrets other than passwords.
  */
 class SensitiveCredential extends SensitiveDataType, TCredential {
   override string toString() { result = "credential" }
 
   override string getRegexp() {
     exists(SensitiveDataClassification classification |
+      not classification = SensitiveDataClassification::password() and // covered by `SensitivePassword`
       not classification = SensitiveDataClassification::id() and // not accurate enough
       result = HeuristicNames::maybeSensitiveRegexp(classification)
     )
     or
-    result = "(?is).*((account|accnt|licen(se|ce)).?(id|key)|one.?time.?code|pass.?phrase).*"
+    result = "(?is).*((account|accnt|licen(se|ce)).?(id|key)|one.?time.?code).*"
   }
 }
 
@@ -176,6 +191,11 @@ class SensitiveExpr extends Expr {
     not label.regexpMatch(regexpProbablySafe())
     or
     (
+      // modeled sensitive password
+      sourceNode(DataFlow::exprNode(this), "sensitive-password") and
+      sensitiveType = TPassword() and
+      label = "password"
+      or
       // modeled sensitive credential
       sourceNode(DataFlow::exprNode(this), "sensitive-credential") and
       sensitiveType = TCredential() and

--- a/swift/ql/lib/codeql/swift/security/WeakPasswordHashingExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakPasswordHashingExtensions.qll
@@ -43,11 +43,62 @@ class WeakPasswordHashingAdditionalFlowStep extends Unit {
  * hashing as well.
  */
 private class InheritedWeakPasswordHashingSink extends WeakPasswordHashingSink {
- InheritedWeakPasswordHashingSink() {
-   this instanceof WeakSensitiveDataHashingSink
- }
+  InheritedWeakPasswordHashingSink() { this instanceof WeakSensitiveDataHashingSink }
 
- override string getAlgorithm() { result = this.(WeakSensitiveDataHashingSink).getAlgorithm() }
+  override string getAlgorithm() { result = this.(WeakSensitiveDataHashingSink).getAlgorithm() }
+}
+
+private class WeakSensitiveDataHashingSinks extends SinkModelCsv {
+  override predicate row(string row) {
+    row =
+      [
+        // CryptoKit
+        // (SHA-256, SHA-384 and SHA-512 are all variants of the SHA-2 algorithm)
+        ";SHA256;true;hash(data:);;;Argument[0];weak-password-hash-input-SHA256",
+        ";SHA256;true;update(data:);;;Argument[0];weak-password-hash-input-SHA256",
+        ";SHA256;true;update(bufferPointer:);;;Argument[0];weak-password-hash-input-SHA256",
+        ";SHA384;true;hash(data:);;;Argument[0];weak-password-hash-input-SHA384",
+        ";SHA384;true;update(data:);;;Argument[0];weak-password-hash-input-SHA384",
+        ";SHA384;true;update(bufferPointer:);;;Argument[0];weak-password-hash-input-SHA384",
+        ";SHA512;true;hash(data:);;;Argument[0];weak-password-hash-input-SHA512",
+        ";SHA512;true;update(data:);;;Argument[0];weak-password-hash-input-SHA512",
+        ";SHA512;true;update(bufferPointer:);;;Argument[0];weak-password-hash-input-SHA512",
+        // CryptoSwift
+        ";SHA2;true;calculate(for:);;;Argument[0];weak-password-hash-input-SHA2",
+        ";SHA2;true;callAsFunction(_:);;;Argument[0];weak-password-hash-input-SHA2",
+        ";SHA2;true;process64(block:currentHash:);;;Argument[0];weak-password-hash-input-SHA2",
+        ";SHA2;true;process32(block:currentHash:);;;Argument[0];weak-password-hash-input-SHA2",
+        ";SHA2;true;update(withBytes:isLast:);;;Argument[0];weak-password-hash-input-SHA2",
+        ";SHA3;true;calculate(for:);;;Argument[0];weak-password-hash-input-SHA2",
+        ";SHA3;true;callAsFunction(_:);;;Argument[0];weak-password-hash-input-SHA2",
+        ";SHA3;true;process(block:currentHash:);;;Argument[0];weak-password-hash-input-SHA2",
+        ";SHA3;true;update(withBytes:isLast:);;;Argument[0];weak-password-hash-input-SHA2",
+        ";Digest;true;sha2(_:variant:);;;Argument[0];weak-password-hash-input-SHA2",
+        ";Digest;true;sha3(_:variant:);;;Argument[0];weak-password-hash-input-SHA3",
+        ";Digest;true;sha224(_:);;;Argument[0];weak-password-hash-input-SHA224",
+        ";Digest;true;sha256(_:);;;Argument[0];weak-password-hash-input-SHA256",
+        ";Digest;true;sha384(_:);;;Argument[0];weak-password-hash-input-SHA384",
+        ";Digest;true;sha512(_:);;;Argument[0];weak-password-hash-input-SHA512",
+        ";Array;true;sha2(_:);;;Argument[-1];weak-password-hash-input-SHA2",
+        ";Array;true;sha3(_:);;;Argument[-1];weak-password-hash-input-SHA3",
+        ";Array;true;sha224();;;Argument[-1];weak-password-hash-input-SHA224",
+        ";Array;true;sha256();;;Argument[-1];weak-password-hash-input-SHA256",
+        ";Array;true;sha384();;;Argument[-1];weak-password-hash-input-SHA384",
+        ";Array;true;sha512();;;Argument[-1];weak-password-hash-input-SHA512",
+        ";Data;true;sha2(_:);;;Argument[-1];weak-password-hash-input-SHA2",
+        ";Data;true;sha3(_:);;;Argument[-1];weak-password-hash-input-SHA3",
+        ";Data;true;sha224();;;Argument[-1];weak-password-hash-input-SHA224",
+        ";Data;true;sha256();;;Argument[-1];weak-password-hash-input-SHA256",
+        ";Data;true;sha384();;;Argument[-1];weak-password-hash-input-SHA384",
+        ";Data;true;sha512();;;Argument[-1];weak-password-hash-input-SHA512",
+        ";String;true;sha2(_:);;;Argument[-1];weak-password-hash-input-SHA2",
+        ";String;true;sha3(_:);;;Argument[-1];weak-password-hash-input-SHA3",
+        ";String;true;sha224();;;Argument[-1];weak-password-hash-input-SHA224",
+        ";String;true;sha256();;;Argument[-1];weak-password-hash-input-SHA256",
+        ";String;true;sha384();;;Argument[-1];weak-password-hash-input-SHA384",
+        ";String;true;sha512();;;Argument[-1];weak-password-hash-input-SHA512",
+      ]
+  }
 }
 
 /**
@@ -56,9 +107,7 @@ private class InheritedWeakPasswordHashingSink extends WeakPasswordHashingSink {
 private class DefaultWeakPasswordHashingSink extends WeakPasswordHashingSink {
   string algorithm;
 
-  DefaultWeakPasswordHashingSink() {
-    sinkNode(this, "weak-password-hash-input-" + algorithm)
-  }
+  DefaultWeakPasswordHashingSink() { sinkNode(this, "weak-password-hash-input-" + algorithm) }
 
   override string getAlgorithm() { result = algorithm }
 }

--- a/swift/ql/lib/codeql/swift/security/WeakPasswordHashingExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakPasswordHashingExtensions.qll
@@ -111,3 +111,18 @@ private class DefaultWeakPasswordHashingSink extends WeakPasswordHashingSink {
 
   override string getAlgorithm() { result = algorithm }
 }
+
+/**
+ * A barrier for weak password hashing, when it occurs inside of
+ * certain cryptographic algorithms as part of their design.
+ */
+class WeakPasswordHashingImplementationBarrier extends WeakPasswordHashingBarrier {
+  WeakPasswordHashingImplementationBarrier() {
+    this.asParameter()
+        .getDeclaringFunction()
+        .(Function)
+        .getDeclaringDecl*()
+        .(NominalTypeDecl)
+        .getName() = ["HMAC", "PBKDF1", "PBKDF2"]
+  }
+}

--- a/swift/ql/lib/codeql/swift/security/WeakPasswordHashingExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakPasswordHashingExtensions.qll
@@ -1,0 +1,36 @@
+/**
+ * Provides classes and predicates for reasoning about use of inappropriate
+ * cryptographic hashing algorithms on passwords.
+ */
+
+import swift
+import codeql.swift.security.SensitiveExprs
+import codeql.swift.dataflow.DataFlow
+import codeql.swift.dataflow.TaintTracking
+
+class WeakPasswordHashingSink extends DataFlow::Node {
+  string algorithm;
+
+  WeakPasswordHashingSink() {
+    // a call to System.Security.Cryptography.MD5/SHA*.ComputeHash/ComputeHashAsync/HashData/HashDataAsync
+    exists(MethodCall call, string name |
+      (
+        call.getTarget().getName() = name
+        and name in ["ComputeHash", "ComputeHashAsync", "HashData", "HashDataAsync"]
+      )
+      // with this as the first argument - not arg 0, since arg 0 is 'this' for methods
+      and call.getArgument(0) = this.asExpr()
+      and
+      // the call is to a method in the System.Security.Cryptography.MD* class
+      // or the System.Security.Cryptography.SHA* classes
+      (
+        call.getQualifier().getType().getName() = algorithm
+        and algorithm.matches(["MD%","SHA%"])
+      )
+    )
+  }
+
+  string getAlgorithm() {
+    result = algorithm
+  }
+}

--- a/swift/ql/lib/codeql/swift/security/WeakPasswordHashingExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakPasswordHashingExtensions.qll
@@ -42,9 +42,8 @@ class WeakPasswordHashingAdditionalFlowStep extends Unit {
  * for the weak sensitive data hashing query is a sink for weak password
  * hashing as well.
  */
-private class InheritedWeakPasswordHashingSink extends WeakPasswordHashingSink {
-  InheritedWeakPasswordHashingSink() { this instanceof WeakSensitiveDataHashingSink }
-
+private class InheritedWeakPasswordHashingSink extends WeakPasswordHashingSink instanceof WeakSensitiveDataHashingSink
+{
   override string getAlgorithm() { result = this.(WeakSensitiveDataHashingSink).getAlgorithm() }
 }
 

--- a/swift/ql/lib/codeql/swift/security/WeakPasswordHashingExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakPasswordHashingExtensions.qll
@@ -4,33 +4,61 @@
  */
 
 import swift
-import codeql.swift.security.SensitiveExprs
 import codeql.swift.dataflow.DataFlow
-import codeql.swift.dataflow.TaintTracking
+import codeql.swift.dataflow.ExternalFlow
+private import codeql.swift.security.WeakSensitiveDataHashingExtensions
 
-class WeakPasswordHashingSink extends DataFlow::Node {
+/**
+ * A dataflow sink for weak password hashing vulnerabilities. That is,
+ * a `DataFlow::Node` that is passed into a weak password hashing function.
+ */
+abstract class WeakPasswordHashingSink extends DataFlow::Node {
+  /**
+   * Gets the name of the hashing algorithm, for display.
+   */
+  abstract string getAlgorithm();
+}
+
+/**
+ * A barrier for weak password hashing vulnerabilities.
+ */
+abstract class WeakPasswordHashingBarrier extends DataFlow::Node { }
+
+/**
+ * A unit class for adding additional flow steps.
+ */
+class WeakPasswordHashingAdditionalFlowStep extends Unit {
+  /**
+   * Holds if the step from `node1` to `node2` should be considered a flow
+   * step for paths related to weak password hashing vulnerabilities.
+   */
+  abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);
+}
+
+/**
+ * A sink inherited from weak sensitive data hashing. Password hashing has
+ * stronger requirements than sensitive data hashing, since (in addition to
+ * its particular qualities) a password *is* sensitive data. Thus, any sink
+ * for the weak sensitive data hashing query is a sink for weak password
+ * hashing as well.
+ */
+private class InheritedWeakPasswordHashingSink extends WeakPasswordHashingSink {
+ InheritedWeakPasswordHashingSink() {
+   this instanceof WeakSensitiveDataHashingSink
+ }
+
+ override string getAlgorithm() { result = this.(WeakSensitiveDataHashingSink).getAlgorithm() }
+}
+
+/**
+ * A sink defined in a CSV model.
+ */
+private class DefaultWeakPasswordHashingSink extends WeakPasswordHashingSink {
   string algorithm;
 
-  WeakPasswordHashingSink() {
-    // a call to System.Security.Cryptography.MD5/SHA*.ComputeHash/ComputeHashAsync/HashData/HashDataAsync
-    exists(MethodCall call, string name |
-      (
-        call.getTarget().getName() = name
-        and name in ["ComputeHash", "ComputeHashAsync", "HashData", "HashDataAsync"]
-      )
-      // with this as the first argument - not arg 0, since arg 0 is 'this' for methods
-      and call.getArgument(0) = this.asExpr()
-      and
-      // the call is to a method in the System.Security.Cryptography.MD* class
-      // or the System.Security.Cryptography.SHA* classes
-      (
-        call.getQualifier().getType().getName() = algorithm
-        and algorithm.matches(["MD%","SHA%"])
-      )
-    )
+  DefaultWeakPasswordHashingSink() {
+    sinkNode(this, "weak-password-hash-input-" + algorithm)
   }
 
-  string getAlgorithm() {
-    result = algorithm
-  }
+  override string getAlgorithm() { result = algorithm }
 }

--- a/swift/ql/lib/codeql/swift/security/WeakPasswordHashingQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakPasswordHashingQuery.qll
@@ -1,0 +1,59 @@
+/**
+ * Provides a taint tracking configuration to find use of inappropriate
+ * cryptographic hashing algorithms on passwords.
+ */
+
+import csharp
+import semmle.code.csharp.security.SensitiveActions
+import semmle.code.csharp.dataflow.DataFlow
+import semmle.code.csharp.dataflow.TaintTracking
+
+/**
+ * A taint tracking configuration from password expressions to inappropriate
+ * hashing sinks.
+ */
+module WeakHashingPasswordConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node node) { node.asExpr() instanceof PasswordExpr }
+
+  predicate isSink(DataFlow::Node node) { node instanceof WeakPasswordHashingSink }
+
+  predicate isBarrierIn(DataFlow::Node node) {
+    // make sources barriers so that we only report the closest instance
+    isSource(node)
+  }
+
+  predicate isBarrierOut(DataFlow::Node node) {
+    // make sinks barriers so that we only report the closest instance
+    isSink(node)
+  }
+}
+
+module WeakHashingFlow = TaintTracking::Global<WeakHashingPasswordConfig>;
+
+// TODO: rewrite with data extensions in mind, ref the Swift implementation
+class WeakPasswordHashingSink extends DataFlow::Node {   
+  string algorithm;
+
+  WeakPasswordHashingSink() {
+    // a call to System.Security.Cryptography.MD5/SHA*.ComputeHash/ComputeHashAsync/HashData/HashDataAsync
+    exists(MethodCall call, string name |
+      (
+        call.getTarget().getName() = name
+        and name in ["ComputeHash", "ComputeHashAsync", "HashData", "HashDataAsync"]
+      )
+      // with this as the first argument - not arg 0, since arg 0 is 'this' for methods
+      and call.getArgument(0) = this.asExpr()
+      and
+      // the call is to a method in the System.Security.Cryptography.MD* class
+      // or the System.Security.Cryptography.SHA* classes
+      (
+        call.getQualifier().getType().getName() = algorithm
+        and algorithm.matches(["MD%","SHA%"])
+      )
+    )
+  }
+
+  string getAlgorithm() {
+    result = algorithm
+  }
+}

--- a/swift/ql/lib/codeql/swift/security/WeakPasswordHashingQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakPasswordHashingQuery.qll
@@ -13,7 +13,7 @@ import codeql.swift.security.WeakPasswordHashingExtensions
  * A taint tracking configuration from password expressions to inappropriate
  * hashing sinks.
  */
-module WeakHashingPasswordConfig implements DataFlow::ConfigSig {
+module WeakPasswordHashingConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node node) {
     exists(SensitiveExpr se |
       node.asExpr() = se and
@@ -40,4 +40,4 @@ module WeakHashingPasswordConfig implements DataFlow::ConfigSig {
   }
 }
 
-module WeakHashingFlow = TaintTracking::Global<WeakHashingPasswordConfig>;
+module WeakPasswordHashingFlow = TaintTracking::Global<WeakPasswordHashingConfig>;

--- a/swift/ql/lib/codeql/swift/security/WeakPasswordHashingQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakPasswordHashingQuery.qll
@@ -3,10 +3,10 @@
  * cryptographic hashing algorithms on passwords.
  */
 
-import csharp
-import semmle.code.csharp.security.SensitiveActions
-import semmle.code.csharp.dataflow.DataFlow
-import semmle.code.csharp.dataflow.TaintTracking
+import swift
+import codeql.swift.security.SensitiveExprs
+import codeql.swift.dataflow.DataFlow
+import codeql.swift.dataflow.TaintTracking
 
 /**
  * A taint tracking configuration from password expressions to inappropriate
@@ -31,7 +31,7 @@ module WeakHashingPasswordConfig implements DataFlow::ConfigSig {
 module WeakHashingFlow = TaintTracking::Global<WeakHashingPasswordConfig>;
 
 // TODO: rewrite with data extensions in mind, ref the Swift implementation
-class WeakPasswordHashingSink extends DataFlow::Node {   
+class WeakPasswordHashingSink extends DataFlow::Node {
   string algorithm;
 
   WeakPasswordHashingSink() {

--- a/swift/ql/lib/codeql/swift/security/WeakPasswordHashingQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakPasswordHashingQuery.qll
@@ -18,6 +18,8 @@ module WeakHashingPasswordConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node node) { node instanceof WeakPasswordHashingSink }
 
+  predicate isBarrier(DataFlow::Node node) { node instanceof WeakPasswordHashingBarrier }
+
   predicate isBarrierIn(DataFlow::Node node) {
     // make sources barriers so that we only report the closest instance
     isSource(node)
@@ -26,6 +28,10 @@ module WeakHashingPasswordConfig implements DataFlow::ConfigSig {
   predicate isBarrierOut(DataFlow::Node node) {
     // make sinks barriers so that we only report the closest instance
     isSink(node)
+  }
+
+  predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
+    any(WeakPasswordHashingAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
 }
 

--- a/swift/ql/lib/codeql/swift/security/WeakPasswordHashingQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakPasswordHashingQuery.qll
@@ -5,7 +5,6 @@
 
 import swift
 import codeql.swift.security.SensitiveExprs
-import codeql.swift.dataflow.DataFlow
 import codeql.swift.dataflow.TaintTracking
 import codeql.swift.security.WeakPasswordHashingExtensions
 

--- a/swift/ql/lib/codeql/swift/security/WeakPasswordHashingQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakPasswordHashingQuery.qll
@@ -14,7 +14,12 @@ import codeql.swift.security.WeakPasswordHashingExtensions
  * hashing sinks.
  */
 module WeakHashingPasswordConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node node) { node.asExpr() instanceof PasswordExpr }
+  predicate isSource(DataFlow::Node node) {
+    exists(SensitiveExpr se |
+      node.asExpr() = se and
+      se.getSensitiveType() instanceof SensitivePassword
+    )
+  }
 
   predicate isSink(DataFlow::Node node) { node instanceof WeakPasswordHashingSink }
 

--- a/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingExtensions.qll
@@ -48,9 +48,11 @@ private class WeakSensitiveDataHashingSinks extends SinkModelCsv {
         // CryptoSwift
         ";MD5;true;calculate(for:);;;Argument[0];weak-hash-input-MD5",
         ";MD5;true;callAsFunction(_:);;;Argument[0];weak-hash-input-MD5",
+        ";MD5;true;process(block:currentHash:);;;Argument[0];weak-hash-input-MD5",
         ";MD5;true;update(withBytes:isLast:);;;Argument[0];weak-hash-input-MD5",
         ";SHA1;true;calculate(for:);;;Argument[0];weak-hash-input-SHA1",
         ";SHA1;true;callAsFunction(_:);;;Argument[0];weak-hash-input-SHA1",
+        ";SHA1;true;process(block:currentHash:);;;Argument[0];weak-hash-input-SHA1",
         ";SHA1;true;update(withBytes:isLast:);;;Argument[0];weak-hash-input-SHA1",
         ";Digest;true;md5(_:);;;Argument[0];weak-hash-input-MD5",
         ";Digest;true;sha1(_:);;;Argument[0];weak-hash-input-SHA1",

--- a/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingExtensions.qll
@@ -4,7 +4,6 @@
  */
 
 import swift
-import codeql.swift.security.SensitiveExprs
 import codeql.swift.dataflow.DataFlow
 import codeql.swift.dataflow.ExternalFlow
 
@@ -35,7 +34,7 @@ class WeakSensitiveDataHashingAdditionalFlowStep extends Unit {
   abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);
 }
 
-private class WeakHashingSinks extends SinkModelCsv {
+private class WeakSensitiveDataHashingSinks extends SinkModelCsv {
   override predicate row(string row) {
     row =
       [
@@ -68,10 +67,10 @@ private class WeakHashingSinks extends SinkModelCsv {
 /**
  * A sink defined in a CSV model.
  */
-private class DefaultWeakHashingSink extends WeakSensitiveDataHashingSink {
+private class DefaultWeakSenitiveDataHashingSink extends WeakSensitiveDataHashingSink {
   string algorithm;
 
-  DefaultWeakHashingSink() { sinkNode(this, "weak-hash-input-" + algorithm) }
+  DefaultWeakSenitiveDataHashingSink() { sinkNode(this, "weak-hash-input-" + algorithm) }
 
   override string getAlgorithm() { result = algorithm }
 }

--- a/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingQuery.qll
@@ -14,7 +14,12 @@ import codeql.swift.security.WeakSensitiveDataHashingExtensions
  * hashing sinks.
  */
 module WeakSensitiveDataHashingConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node node) { node.asExpr() instanceof SensitiveExpr }
+  predicate isSource(DataFlow::Node node) {
+    exists(SensitiveExpr se |
+      node.asExpr() = se and
+      not se.getSensitiveType() instanceof SensitivePassword // responsibility of the weak password hashing query
+    )
+  }
 
   predicate isSink(DataFlow::Node node) { node instanceof WeakSensitiveDataHashingSink }
 

--- a/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingQuery.qll
@@ -13,7 +13,7 @@ import codeql.swift.security.WeakSensitiveDataHashingExtensions
  * A taint tracking configuration from sensitive expressions to broken or weak
  * hashing sinks.
  */
-module WeakHashingConfig implements DataFlow::ConfigSig {
+module WeakSensitiveDataHashingConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node node) { node.asExpr() instanceof SensitiveExpr }
 
   predicate isSink(DataFlow::Node node) { node instanceof WeakSensitiveDataHashingSink }
@@ -35,4 +35,8 @@ module WeakHashingConfig implements DataFlow::ConfigSig {
   }
 }
 
-module WeakHashingFlow = TaintTracking::Global<WeakHashingConfig>;
+deprecated module WeakHashingConfig = WeakSensitiveDataHashingConfig;
+
+module WeakSensitiveDataHashingFlow = TaintTracking::Global<WeakSensitiveDataHashingConfig>;
+
+deprecated module WeakHashingFlow = WeakSensitiveDataHashingFlow;

--- a/swift/ql/src/change-notes/2023-12-15-weak-password-hashing.md
+++ b/swift/ql/src/change-notes/2023-12-15-weak-password-hashing.md
@@ -1,0 +1,5 @@
+---
+category: newQuery
+---
+
+* Added new query "Use of an inappropriate cryptographic hashing algorithm on passwords" (`swift/weak-password-hashing`). This query detects use of inappropriate hashing algorithms for password hashing. Some of the results of this query are new, others would previously have been reported by the "Use of a broken or weak cryptographic hashing algorithm on sensitive data" (`swift/weak-sensitive-data-hashing`) query.

--- a/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashing.qhelp
+++ b/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashing.qhelp
@@ -1,0 +1,100 @@
+<!DOCTYPE qhelp PUBLIC
+        "-//Semmle//qhelp//EN"
+        "qhelp.dtd">
+<qhelp>
+    <overview>
+        <p>
+            Using a insufficiently computationally hard hash function can leave data
+            vulnerable, and should not be used for password hashing.
+        </p>
+
+        <p>
+            A strong cryptographic hash function should be resistant to:
+        </p>
+        <ul>
+            <li>
+                <strong>Pre-image attacks</strong>. If you know a hash value <code>h(x)</code>,
+                you should not be able to easily find the input <code>x</code>.
+            </li>
+            <li>
+                <strong>Collision attacks</strong>. If you know a hash value <code>h(x)</code>,
+                you should not be able to easily find a different input
+                <code>y</code>
+                with the same hash value <code>h(x) = h(y)</code>.
+            </li>
+            <li>
+                <strong>Brute force</strong>. If you know a hash value <code>h(x)</code>,
+                you should not be able to find an input <code>y</code> that computes to that hash value
+                using brute force attacks without significant computational effort.
+            <li>
+        </ul>
+
+        <p>
+            All of MD5, SHA-1, SHA-2 and SHA-3 are weak against offline brute forcing, since they are not computationally hard.
+        </p>
+
+        <p>
+            Password hashing algorithms are designed to be slow and/or memory intenstive to compute, which makes brute force attacks more difficult.
+        </p>
+
+    </overview>
+    <recommendation>
+
+        <p>
+            Ensure that for password storage you should use a computationally hard cryptographic hash function, such as:
+        </p>
+
+        <ul>
+            <li>
+                Argon2
+            </li>
+            <li>
+                scrypt
+            </li>
+                bcrypt
+            <li>
+                PBKDF2
+            </li>
+        </ul>
+
+    </recommendation>
+    <example>
+
+        <p>
+            The following examples show a function that hashes a password using a cryptographic hashing algorithm.
+
+            In the first case the SHA-512 hashing algorithm is used. It is vulnerable to offline brute force attacks:
+        </p>
+        <sample src="WeakPasswordHashingBad.csharp"/>
+        <p>
+
+            Here is the same function using Argon2, which is suitable for password hashing:
+        </p>
+        <sample src="WeakPasswordHashingGood.csharp"/>
+
+    </example>
+    <references>
+        <li>
+            OWASP:
+            <a href="https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html">Password Storage
+                Cheat Sheet
+            </a>
+        </li>
+        <li>
+            nuget: <a href="https://www.nuget.org/packages/Konscious.Security.Cryptography.Argon2/">Konscious.Security.Cryptography.Argon2</a>
+        </li>
+        <li>
+            nuget: <a href="https://www.nuget.org/packages/Isopoh.Cryptography.Argon2">Isopoh.Cryptography.Argon</a>
+        </li>
+        <li>
+            libsodium: <a href="https://doc.libsodium.org/bindings_for_other_languages#bindings-programming-languages">libsodium bindings for other languages</a>
+        </li>
+        <li>
+            nuget: <a href="https://www.nuget.org/packages/BCrypt.Net-Core/">BCrypt.Net-Core</a>
+        </li>
+        <li>
+            nuget: <a href="https://www.nuget.org/packages/CryptSharpOfficial/">Scrypt and PBKDF2</a>
+        </li>
+    </references>
+
+</qhelp>

--- a/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashing.qhelp
+++ b/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashing.qhelp
@@ -30,7 +30,7 @@
         </ul>
 
         <p>
-            All of MD5, SHA-1, SHA-2 and SHA-3 are weak against offline brute forcing, since they are not computationally hard.
+            All of MD5, SHA-1, SHA-2 and SHA-3 are weak against offline brute forcing, since they are not computationally hard. This includes SHA-224, SHA-256, SHA-384 and SHA-512, which are in the SHA-2 family.
         </p>
 
         <p>
@@ -51,7 +51,9 @@
             <li>
                 scrypt
             </li>
+            <li>
                 bcrypt
+            </li>
             <li>
                 PBKDF2
             </li>
@@ -81,19 +83,10 @@
             </a>
         </li>
         <li>
-            nuget: <a href="https://www.nuget.org/packages/Konscious.Security.Cryptography.Argon2/">Konscious.Security.Cryptography.Argon2</a>
-        </li>
-        <li>
-            nuget: <a href="https://www.nuget.org/packages/Isopoh.Cryptography.Argon2">Isopoh.Cryptography.Argon</a>
-        </li>
-        <li>
             libsodium: <a href="https://doc.libsodium.org/bindings_for_other_languages#bindings-programming-languages">libsodium bindings for other languages</a>
         </li>
         <li>
-            nuget: <a href="https://www.nuget.org/packages/BCrypt.Net-Core/">BCrypt.Net-Core</a>
-        </li>
-        <li>
-            nuget: <a href="https://www.nuget.org/packages/CryptSharpOfficial/">Scrypt and PBKDF2</a>
+            GitHub: <a href="https://github.com/tmthecoder/Argon2Swift">Argon2Swift</a>
         </li>
     </references>
 

--- a/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashing.qhelp
+++ b/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashing.qhelp
@@ -4,8 +4,7 @@
 <qhelp>
     <overview>
         <p>
-            Using a insufficiently computationally hard hash function can leave data
-            vulnerable, and should not be used for password hashing.
+            Hash functions that are not sufficiently computationally hard can leave data vulnerable. You should not use such functions for password hashing.
         </p>
 
         <p>
@@ -34,14 +33,14 @@
         </p>
 
         <p>
-            Password hashing algorithms are designed to be slow and/or memory intenstive to compute, which makes brute force attacks more difficult.
+            Password hashing algorithms should be slow and/or memory intensive to compute, to make brute force attacks more difficult.
         </p>
 
     </overview>
     <recommendation>
 
         <p>
-            Ensure that for password storage you should use a computationally hard cryptographic hash function, such as:
+            For password storage, you should use a computationally hard cryptographic hash function, such as one of the following:
         </p>
 
         <ul>
@@ -63,9 +62,9 @@
     <example>
 
         <p>
-            The following examples show a function that hashes a password using a cryptographic hashing algorithm.
+            The following examples show two versions of the same function. In both cases, a password is hashed using a cryptographic hashing algorithm.
 
-            In the first case the SHA-512 hashing algorithm is used. It is vulnerable to offline brute force attacks:
+            In the first case, the SHA-512 hashing algorithm is used. It is vulnerable to offline brute force attacks:
         </p>
         <sample src="WeakPasswordHashingBad.swift"/>
         <p>

--- a/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashing.qhelp
+++ b/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashing.qhelp
@@ -65,12 +65,12 @@
 
             In the first case the SHA-512 hashing algorithm is used. It is vulnerable to offline brute force attacks:
         </p>
-        <sample src="WeakPasswordHashingBad.csharp"/>
+        <sample src="WeakPasswordHashingBad.swift"/>
         <p>
 
             Here is the same function using Argon2, which is suitable for password hashing:
         </p>
-        <sample src="WeakPasswordHashingGood.csharp"/>
+        <sample src="WeakPasswordHashingGood.swift"/>
 
     </example>
     <references>

--- a/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashing.qhelp
+++ b/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashing.qhelp
@@ -29,7 +29,7 @@
         </ul>
 
         <p>
-            All of MD5, SHA-1, SHA-2 and SHA-3 are weak against offline brute forcing, since they are not computationally hard. This includes SHA-224, SHA-256, SHA-384 and SHA-512, which are in the SHA-2 family.
+            All of MD5, SHA-1, SHA-2 and SHA-3 are weak against offline brute forcing, since they are not sufficiently computationally hard. This includes SHA-224, SHA-256, SHA-384 and SHA-512, which are in the SHA-2 family.
         </p>
 
         <p>
@@ -40,7 +40,7 @@
     <recommendation>
 
         <p>
-            For password storage, you should use a computationally hard cryptographic hash function, such as one of the following:
+            For password storage, you should use a sufficiently computationally hard cryptographic hash function, such as one of the following:
         </p>
 
         <ul>

--- a/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashing.qhelp
+++ b/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashing.qhelp
@@ -83,6 +83,9 @@
             </a>
         </li>
         <li>
+            GitHub: <a href="https://github.com/krzyzanowskim/CryptoSwift/blob/main/README.md#password-based-key-derivation-function">CryptoSwift README - Password-Based Key Derivation Function</a>
+        </li>
+        <li>
             libsodium: <a href="https://doc.libsodium.org/bindings_for_other_languages#bindings-programming-languages">libsodium bindings for other languages</a>
         </li>
         <li>

--- a/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashing.qhelp
+++ b/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashing.qhelp
@@ -26,7 +26,7 @@
                 <strong>Brute force</strong>. If you know a hash value <code>h(x)</code>,
                 you should not be able to find an input <code>y</code> that computes to that hash value
                 using brute force attacks without significant computational effort.
-            <li>
+            </li>
         </ul>
 
         <p>

--- a/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashing.ql
+++ b/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashing.ql
@@ -1,0 +1,28 @@
+/**
+ * @name Use of an inappropriate cryptographic hashing algorithm on passwords
+ * @description Using inappropriate cryptographic hashing algorithms with passwords can compromise security.
+ * @kind path-problem
+ * @problem.severity warning
+ * @security-severity 7.5
+ * @precision high
+ * @id csharp/weak-password-hashing
+ * @tags security
+ *       external/cwe/cwe-327
+ *       external/cwe/cwe-328
+ *       external/cwe/cwe-916
+ */
+
+import csharp
+import WeakPasswordHashingQuery
+import WeakHashingFlow::PathGraph
+
+from
+  WeakHashingFlow::PathNode source, WeakHashingFlow::PathNode sink, string algorithm,
+  PasswordExpr expr
+where
+  WeakHashingFlow::flowPath(source, sink) and
+  algorithm = sink.getNode().(WeakPasswordHashingSink).getAlgorithm() and
+  expr = source.getNode().asExpr()
+select sink.getNode(), source, sink,
+  "Insecure hashing algorithm (" + algorithm + ") depends on $@.", source.getNode(),
+  "password (" + expr + ")"

--- a/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashing.ql
+++ b/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashing.ql
@@ -14,11 +14,11 @@
 
 import swift
 import codeql.swift.security.WeakPasswordHashingQuery
-import WeakHashingFlow::PathGraph
+import WeakPasswordHashingFlow::PathGraph
 
-from WeakHashingFlow::PathNode source, WeakHashingFlow::PathNode sink, string algorithm
+from WeakPasswordHashingFlow::PathNode source, WeakPasswordHashingFlow::PathNode sink, string algorithm
 where
-  WeakHashingFlow::flowPath(source, sink) and
+WeakPasswordHashingFlow::flowPath(source, sink) and
   algorithm = sink.getNode().(WeakPasswordHashingSink).getAlgorithm()
 select sink.getNode(), source, sink,
   "Insecure hashing algorithm (" + algorithm + ") depends on $@.", source.getNode(),

--- a/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashing.ql
+++ b/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashing.ql
@@ -5,15 +5,15 @@
  * @problem.severity warning
  * @security-severity 7.5
  * @precision high
- * @id csharp/weak-password-hashing
+ * @id swift/weak-password-hashing
  * @tags security
  *       external/cwe/cwe-327
  *       external/cwe/cwe-328
  *       external/cwe/cwe-916
  */
 
-import csharp
-import WeakPasswordHashingQuery
+import swift
+import codeql.swift.security.WeakPasswordHashingQuery
 import WeakHashingFlow::PathGraph
 
 from

--- a/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashing.ql
+++ b/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashing.ql
@@ -16,13 +16,10 @@ import swift
 import codeql.swift.security.WeakPasswordHashingQuery
 import WeakHashingFlow::PathGraph
 
-from
-  WeakHashingFlow::PathNode source, WeakHashingFlow::PathNode sink, string algorithm,
-  PasswordExpr expr
+from WeakHashingFlow::PathNode source, WeakHashingFlow::PathNode sink, string algorithm
 where
   WeakHashingFlow::flowPath(source, sink) and
-  algorithm = sink.getNode().(WeakPasswordHashingSink).getAlgorithm() and
-  expr = source.getNode().asExpr()
+  algorithm = sink.getNode().(WeakPasswordHashingSink).getAlgorithm()
 select sink.getNode(), source, sink,
   "Insecure hashing algorithm (" + algorithm + ") depends on $@.", source.getNode(),
-  "password (" + expr + ")"
+  "password (" + source.getNode().asExpr() + ")"

--- a/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashing.ql
+++ b/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashing.ql
@@ -16,9 +16,10 @@ import swift
 import codeql.swift.security.WeakPasswordHashingQuery
 import WeakPasswordHashingFlow::PathGraph
 
-from WeakPasswordHashingFlow::PathNode source, WeakPasswordHashingFlow::PathNode sink, string algorithm
+from
+  WeakPasswordHashingFlow::PathNode source, WeakPasswordHashingFlow::PathNode sink, string algorithm
 where
-WeakPasswordHashingFlow::flowPath(source, sink) and
+  WeakPasswordHashingFlow::flowPath(source, sink) and
   algorithm = sink.getNode().(WeakPasswordHashingSink).getAlgorithm()
 select sink.getNode(), source, sink,
   "Insecure hashing algorithm (" + algorithm + ") depends on $@.", source.getNode(),

--- a/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashingBad.swift
+++ b/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashingBad.swift
@@ -1,0 +1,3 @@
+using var sha512 = System.Security.Cryptography.SHA512.Create();
+
+var data = sha512.ComputeHash(Encoding.UTF8.GetBytes(content));    // BAD

--- a/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashingBad.swift
+++ b/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashingBad.swift
@@ -1,3 +1,8 @@
-using var sha512 = System.Security.Cryptography.SHA512.Create();
+let passwordData = Data(passwordString.utf8)
+let passwordHash = Crypto.SHA512.hash(data: passwordData)
 
-var data = sha512.ComputeHash(Encoding.UTF8.GetBytes(content));    // BAD
+// ...
+
+if Crypto.SHA512.hash(data: Data(passwordString.utf8)) == passwordHash {
+    // ...
+}

--- a/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashingBad.swift
+++ b/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashingBad.swift
@@ -1,5 +1,5 @@
 let passwordData = Data(passwordString.utf8)
-let passwordHash = Crypto.SHA512.hash(data: passwordData)
+let passwordHash = Crypto.SHA512.hash(data: passwordData) // BAD: SHA-512 is not suitable for password hashing.
 
 // ...
 

--- a/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashingGood.swift
+++ b/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashingGood.swift
@@ -1,0 +1,51 @@
+using System.Security.Cryptography;
+using Konscious.Security.Cryptography;  // use NuGet package Konscious.Security.Cryptography.Argon2
+
+// See https://github.com/kmaragon/Konscious.Security.Cryptography#konscioussecuritycryptographyargon2
+
+public class Argon2Hasher
+{
+    public byte[] ComputeHash(byte[] password, byte[] salt)
+    {
+        // choose Argon2i, Argon2id or Argon2d as appropriate
+        using var argon2 = new Argon2id(password);
+        argon2.Salt = salt;
+
+        // read the Argon2 documentation to understand these parameters, and reference:
+        // https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id
+        argon2.DegreeOfParallelism = 4;  // number of threads you can spawn on your system - the higher, the better
+        argon2.Iterations = 5;           // set as high as your system can manage, within time constraints
+        argon2.MemorySize = 1024 * 2048; // 2GB RAM, for example - set this as high as you can, within memory limits on your system
+
+        return argon2.GetBytes(32);                
+    }
+
+    // use a fixed-time comparison to avoid timing attacks
+    public bool Equals(byte[] hash1, byte[] hash2) => CryptographicOperations.FixedTimeEquals(hash1, hash2);
+
+    // generate a salt securely with a cryptographic random number generator
+    public static byte[] GenerateSalt()
+    {
+        var buffer = new byte[32];
+        using var rng = new RNGCryptoServiceProvider();
+        rng.GetBytes(buffer);
+        return buffer;
+    }
+}
+
+var argon2 = new Argon2Hasher();
+
+// Create the hash
+var bytes = Encoding.UTF8.GetBytes("this is a password");    // it should not be hardcoded in reality, but this is just a demo
+var salt = Argon2Hasher.GenerateSalt();                      // salt is kept with hash; it is not secret, just unique per hash
+var hash = argon2.ComputeHash(bytes, salt);
+
+// Check the hash - this will trivially always pass, but in reality you would have to retrieve the hash for the comparison
+if(argon2id.Equals(argon2.ComputeHash(bytes, salt), hash))
+{
+    Console.WriteLine("PASS");
+}
+else
+{
+    Console.WriteLine("FAIL");
+}

--- a/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashingGood.swift
+++ b/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashingGood.swift
@@ -1,51 +1,11 @@
-using System.Security.Cryptography;
-using Konscious.Security.Cryptography;  // use NuGet package Konscious.Security.Cryptography.Argon2
+import Argon2Swift
 
-// See https://github.com/kmaragon/Konscious.Security.Cryptography#konscioussecuritycryptographyargon2
+let salt = Salt.newSalt()
+let result = try! Argon2Swift.hashPasswordString(password: passwordString, salt: salt)
+let passwordHash = result.encodedString()
 
-public class Argon2Hasher
-{
-    public byte[] ComputeHash(byte[] password, byte[] salt)
-    {
-        // choose Argon2i, Argon2id or Argon2d as appropriate
-        using var argon2 = new Argon2id(password);
-        argon2.Salt = salt;
+// ...
 
-        // read the Argon2 documentation to understand these parameters, and reference:
-        // https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id
-        argon2.DegreeOfParallelism = 4;  // number of threads you can spawn on your system - the higher, the better
-        argon2.Iterations = 5;           // set as high as your system can manage, within time constraints
-        argon2.MemorySize = 1024 * 2048; // 2GB RAM, for example - set this as high as you can, within memory limits on your system
-
-        return argon2.GetBytes(32);                
-    }
-
-    // use a fixed-time comparison to avoid timing attacks
-    public bool Equals(byte[] hash1, byte[] hash2) => CryptographicOperations.FixedTimeEquals(hash1, hash2);
-
-    // generate a salt securely with a cryptographic random number generator
-    public static byte[] GenerateSalt()
-    {
-        var buffer = new byte[32];
-        using var rng = new RNGCryptoServiceProvider();
-        rng.GetBytes(buffer);
-        return buffer;
-    }
-}
-
-var argon2 = new Argon2Hasher();
-
-// Create the hash
-var bytes = Encoding.UTF8.GetBytes("this is a password");    // it should not be hardcoded in reality, but this is just a demo
-var salt = Argon2Hasher.GenerateSalt();                      // salt is kept with hash; it is not secret, just unique per hash
-var hash = argon2.ComputeHash(bytes, salt);
-
-// Check the hash - this will trivially always pass, but in reality you would have to retrieve the hash for the comparison
-if(argon2id.Equals(argon2.ComputeHash(bytes, salt), hash))
-{
-    Console.WriteLine("PASS");
-}
-else
-{
-    Console.WriteLine("FAIL");
+if try! Argon2Swift.verifyHashString(password: passwordString, hash: passwordHash) {
+    // ...
 }

--- a/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashingGood.swift
+++ b/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashingGood.swift
@@ -1,7 +1,7 @@
 import Argon2Swift
 
 let salt = Salt.newSalt()
-let result = try! Argon2Swift.hashPasswordString(password: passwordString, salt: salt)
+let result = try! Argon2Swift.hashPasswordString(password: passwordString, salt: salt) // GOOD: Argon2 is suitable for password hashing.
 let passwordHash = result.encodedString()
 
 // ...

--- a/swift/ql/src/queries/Security/CWE-328/WeakSensitiveDataHashing.ql
+++ b/swift/ql/src/queries/Security/CWE-328/WeakSensitiveDataHashing.ql
@@ -13,13 +13,13 @@
 
 import swift
 import codeql.swift.security.WeakSensitiveDataHashingQuery
-import WeakHashingFlow::PathGraph
+import WeakSensitiveDataHashingFlow::PathGraph
 
 from
-  WeakHashingFlow::PathNode source, WeakHashingFlow::PathNode sink, string algorithm,
-  SensitiveExpr expr
+  WeakSensitiveDataHashingFlow::PathNode source, WeakSensitiveDataHashingFlow::PathNode sink,
+  string algorithm, SensitiveExpr expr
 where
-  WeakHashingFlow::flowPath(source, sink) and
+  WeakSensitiveDataHashingFlow::flowPath(source, sink) and
   algorithm = sink.getNode().(WeakSensitiveDataHashingSink).getAlgorithm() and
   expr = source.getNode().asExpr()
 select sink.getNode(), source, sink,

--- a/swift/ql/src/queries/Security/CWE-328/WeakSensitiveDataHashingBad.swift
+++ b/swift/ql/src/queries/Security/CWE-328/WeakSensitiveDataHashingBad.swift
@@ -3,7 +3,7 @@ func getContentsAndHash(url: URL) -> (Data, String)? {
         return nil
     }
 
-    let digest = Insecure.MD5.hash(data: data)
+    let digest = Insecure.MD5.hash(data: data) // BAD: MD5 is not suitable for hashing sensitive data.
     let hash = digest.map { String(format: "%02hhx", $0) }.joined()
 
     return (data, hash)

--- a/swift/ql/src/queries/Security/CWE-328/WeakSensitiveDataHashingGood.swift
+++ b/swift/ql/src/queries/Security/CWE-328/WeakSensitiveDataHashingGood.swift
@@ -3,7 +3,7 @@ func getContentsAndHash(url: URL) -> (Data, String)? {
         return nil
     }
 
-    let digest = SHA512.hash(data: data)
+    let digest = SHA512.hash(data: data) // GOOD: SHA-512 is suitable for hashing sensitive data.
     let hash = digest.map { String(format: "%02hhx", $0) }.joined()
 
     return (data, hash)

--- a/swift/ql/src/queries/Summary/QuerySinks.ql
+++ b/swift/ql/src/queries/Summary/QuerySinks.ql
@@ -66,9 +66,11 @@ string queryForSink(DataFlow::Node sink) {
   or
   EcbEncryptionConfig::isSink(sink) and result = "swift/ecb-encryption"
   or
-  WeakSensitiveDataHashingQuery::WeakSensitiveDataHashingConfig::isSink(sink) and result = "swift/weak-sensitive-data-hashing"
+  WeakSensitiveDataHashingQuery::WeakSensitiveDataHashingConfig::isSink(sink) and
+  result = "swift/weak-sensitive-data-hashing"
   or
-  WeakPasswordHashingQuery::WeakPasswordHashingConfig::isSink(sink) and result = "swift/weak-password-hashing"
+  WeakPasswordHashingQuery::WeakPasswordHashingConfig::isSink(sink) and
+  result = "swift/weak-password-hashing"
   or
   XxeConfig::isSink(sink) and result = "swift/xxe"
   or

--- a/swift/ql/src/queries/Summary/QuerySinks.ql
+++ b/swift/ql/src/queries/Summary/QuerySinks.ql
@@ -30,7 +30,8 @@ import codeql.swift.security.CleartextLoggingQuery
 import codeql.swift.security.CleartextStoragePreferencesQuery
 import codeql.swift.security.HardcodedEncryptionKeyQuery
 import codeql.swift.security.ECBEncryptionQuery
-import codeql.swift.security.WeakSensitiveDataHashingQuery
+import codeql.swift.security.WeakSensitiveDataHashingQuery as WeakSensitiveDataHashingQuery
+import codeql.swift.security.WeakPasswordHashingQuery as WeakPasswordHashingQuery
 import codeql.swift.security.XXEQuery
 import codeql.swift.security.InsecureTLSQuery
 import codeql.swift.security.ConstantSaltQuery
@@ -65,7 +66,9 @@ string queryForSink(DataFlow::Node sink) {
   or
   EcbEncryptionConfig::isSink(sink) and result = "swift/ecb-encryption"
   or
-  WeakHashingConfig::isSink(sink) and result = "swift/weak-sensitive-data-hashing"
+  WeakSensitiveDataHashingQuery::WeakSensitiveDataHashingConfig::isSink(sink) and result = "swift/weak-sensitive-data-hashing"
+  or
+  WeakPasswordHashingQuery::WeakPasswordHashingConfig::isSink(sink) and result = "swift/weak-password-hashing"
   or
   XxeConfig::isSink(sink) and result = "swift/xxe"
   or

--- a/swift/ql/test/query-tests/Security/CWE-311/SensitiveExprs.expected
+++ b/swift/ql/test/query-tests/Security/CWE-311/SensitiveExprs.expected
@@ -175,4 +175,4 @@
 | testURL.swift:73:52:73:67 | call to get_secret_key() | label:get_secret_key, type:credential |
 | testURL.swift:75:53:75:69 | call to get_cert_string() | label:get_cert_string, type:credential |
 | testURL.swift:96:51:96:51 | certificate | label:certificate, type:credential |
-| testURL.swift:104:16:104:57 | call to SecKeyCopyExternalRepresentation(_:_:) | label:credential, type:credential |
+| testURL.swift:104:16:104:57 | call to SecKeyCopyExternalRepresentation(_:_:) | label:password, type:password |

--- a/swift/ql/test/query-tests/Security/CWE-311/SensitiveExprs.expected
+++ b/swift/ql/test/query-tests/Security/CWE-311/SensitiveExprs.expected
@@ -26,16 +26,16 @@
 | sqlite3_c_api.swift:42:69:42:69 | medicalNotes | label:medicalNotes, type:private information |
 | sqlite3_c_api.swift:43:49:43:49 | medicalNotes | label:medicalNotes, type:private information |
 | sqlite3_c_api.swift:58:36:58:36 | medicalNotes | label:medicalNotes, type:private information |
-| testAlamofire.swift:150:45:150:45 | password | label:password, type:credential |
-| testAlamofire.swift:152:51:152:51 | password | label:password, type:credential |
+| testAlamofire.swift:150:45:150:45 | password | label:password, type:password |
+| testAlamofire.swift:152:51:152:51 | password | label:password, type:password |
 | testAlamofire.swift:154:38:154:38 | email | label:email, type:private information |
 | testAlamofire.swift:159:26:159:26 | email | label:email, type:private information |
 | testAlamofire.swift:171:35:171:35 | email | label:email, type:private information |
 | testAlamofire.swift:177:35:177:35 | email | label:email, type:private information |
-| testAlamofire.swift:187:65:187:65 | password | label:password, type:credential |
-| testAlamofire.swift:195:64:195:64 | password | label:password, type:credential |
-| testAlamofire.swift:205:62:205:62 | password | label:password, type:credential |
-| testAlamofire.swift:213:65:213:65 | password | label:password, type:credential |
+| testAlamofire.swift:187:65:187:65 | password | label:password, type:password |
+| testAlamofire.swift:195:64:195:64 | password | label:password, type:password |
+| testAlamofire.swift:205:62:205:62 | password | label:password, type:password |
+| testAlamofire.swift:213:65:213:65 | password | label:password, type:password |
 | testCoreData2.swift:37:16:37:16 | bankAccountNo | label:bankAccountNo, type:private information |
 | testCoreData2.swift:38:2:38:6 | .myBankAccountNumber | label:myBankAccountNumber, type:private information |
 | testCoreData2.swift:39:2:39:6 | .myBankAccountNumber | label:myBankAccountNumber, type:private information |
@@ -76,99 +76,99 @@
 | testCoreData2.swift:91:10:91:10 | bankAccountNo | label:bankAccountNo, type:private information |
 | testCoreData2.swift:95:10:95:10 | bankAccountNo | label:bankAccountNo, type:private information |
 | testCoreData2.swift:101:10:101:10 | bankAccountNo | label:bankAccountNo, type:private information |
-| testCoreData.swift:48:15:48:15 | password | label:password, type:credential |
-| testCoreData.swift:51:24:51:24 | password | label:password, type:credential |
-| testCoreData.swift:58:15:58:15 | password | label:password, type:credential |
-| testCoreData.swift:61:25:61:25 | password | label:password, type:credential |
-| testCoreData.swift:64:16:64:16 | password | label:password, type:credential |
-| testCoreData.swift:77:24:77:24 | x | label:password, type:credential |
-| testCoreData.swift:80:10:80:22 | call to getPassword() | label:getPassword, type:credential |
-| testCoreData.swift:85:15:85:17 | .password | label:password, type:credential |
-| testCoreData.swift:91:10:91:10 | passwd | label:passwd, type:credential |
-| testCoreData.swift:92:10:92:10 | passwd | label:passwd, type:credential |
-| testCoreData.swift:93:10:93:10 | passwd | label:passwd, type:credential |
+| testCoreData.swift:48:15:48:15 | password | label:password, type:password |
+| testCoreData.swift:51:24:51:24 | password | label:password, type:password |
+| testCoreData.swift:58:15:58:15 | password | label:password, type:password |
+| testCoreData.swift:61:25:61:25 | password | label:password, type:password |
+| testCoreData.swift:64:16:64:16 | password | label:password, type:password |
+| testCoreData.swift:77:24:77:24 | x | label:password, type:password |
+| testCoreData.swift:80:10:80:22 | call to getPassword() | label:getPassword, type:password |
+| testCoreData.swift:85:15:85:17 | .password | label:password, type:password |
+| testCoreData.swift:91:10:91:10 | passwd | label:passwd, type:password |
+| testCoreData.swift:92:10:92:10 | passwd | label:passwd, type:password |
+| testCoreData.swift:93:10:93:10 | passwd | label:passwd, type:password |
 | testCoreData.swift:128:15:128:33 | call to generateSecretKey() | label:generateSecretKey, type:credential |
 | testCoreData.swift:129:15:129:30 | call to getCertificate() | label:getCertificate, type:credential |
-| testGRDB.swift:73:57:73:57 | password | label:password, type:credential |
-| testGRDB.swift:76:43:76:43 | password | label:password, type:credential |
-| testGRDB.swift:81:45:81:45 | password | label:password, type:credential |
-| testGRDB.swift:83:45:83:45 | password | label:password, type:credential |
-| testGRDB.swift:85:45:85:45 | password | label:password, type:credential |
-| testGRDB.swift:87:45:87:45 | password | label:password, type:credential |
-| testGRDB.swift:92:38:92:38 | password | label:password, type:credential |
-| testGRDB.swift:95:37:95:37 | password | label:password, type:credential |
-| testGRDB.swift:100:73:100:73 | password | label:password, type:credential |
-| testGRDB.swift:101:73:101:73 | password | label:password, type:credential |
-| testGRDB.swift:107:53:107:53 | password | label:password, type:credential |
-| testGRDB.swift:109:53:109:53 | password | label:password, type:credential |
-| testGRDB.swift:111:52:111:52 | password | label:password, type:credential |
-| testGRDB.swift:116:48:116:48 | password | label:password, type:credential |
-| testGRDB.swift:118:48:118:48 | password | label:password, type:credential |
-| testGRDB.swift:121:45:121:45 | password | label:password, type:credential |
-| testGRDB.swift:123:45:123:45 | password | label:password, type:credential |
-| testGRDB.swift:126:45:126:45 | password | label:password, type:credential |
-| testGRDB.swift:128:45:128:45 | password | label:password, type:credential |
-| testGRDB.swift:131:45:131:45 | password | label:password, type:credential |
-| testGRDB.swift:133:45:133:45 | password | label:password, type:credential |
-| testGRDB.swift:138:69:138:69 | password | label:password, type:credential |
-| testGRDB.swift:140:69:140:69 | password | label:password, type:credential |
-| testGRDB.swift:143:66:143:66 | password | label:password, type:credential |
-| testGRDB.swift:145:66:145:66 | password | label:password, type:credential |
-| testGRDB.swift:148:66:148:66 | password | label:password, type:credential |
-| testGRDB.swift:150:66:150:66 | password | label:password, type:credential |
-| testGRDB.swift:153:66:153:66 | password | label:password, type:credential |
-| testGRDB.swift:155:66:155:66 | password | label:password, type:credential |
-| testGRDB.swift:160:60:160:60 | password | label:password, type:credential |
-| testGRDB.swift:161:51:161:51 | password | label:password, type:credential |
-| testGRDB.swift:164:60:164:60 | password | label:password, type:credential |
-| testGRDB.swift:165:51:165:51 | password | label:password, type:credential |
-| testGRDB.swift:169:57:169:57 | password | label:password, type:credential |
-| testGRDB.swift:170:48:170:48 | password | label:password, type:credential |
-| testGRDB.swift:173:57:173:57 | password | label:password, type:credential |
-| testGRDB.swift:174:48:174:48 | password | label:password, type:credential |
-| testGRDB.swift:178:57:178:57 | password | label:password, type:credential |
-| testGRDB.swift:179:48:179:48 | password | label:password, type:credential |
-| testGRDB.swift:182:57:182:57 | password | label:password, type:credential |
-| testGRDB.swift:183:48:183:48 | password | label:password, type:credential |
-| testGRDB.swift:187:57:187:57 | password | label:password, type:credential |
-| testGRDB.swift:188:48:188:48 | password | label:password, type:credential |
-| testGRDB.swift:191:57:191:57 | password | label:password, type:credential |
-| testGRDB.swift:192:48:192:48 | password | label:password, type:credential |
-| testGRDB.swift:198:30:198:30 | password | label:password, type:credential |
-| testGRDB.swift:201:24:201:24 | password | label:password, type:credential |
-| testGRDB.swift:206:67:206:67 | password | label:password, type:credential |
-| testGRDB.swift:208:81:208:81 | password | label:password, type:credential |
-| testGRDB.swift:210:85:210:85 | password | label:password, type:credential |
-| testGRDB.swift:212:99:212:99 | password | label:password, type:credential |
-| testRealm2.swift:18:11:18:11 | myPassword | label:myPassword, type:credential |
-| testRealm.swift:31:20:31:20 | .password | label:password, type:credential |
-| testRealm.swift:41:11:41:11 | myPassword | label:myPassword, type:credential |
-| testRealm.swift:49:11:49:11 | myPassword | label:myPassword, type:credential |
-| testRealm.swift:59:12:59:12 | myPassword | label:myPassword, type:credential |
-| testRealm.swift:66:11:66:11 | myPassword | label:myPassword, type:credential |
-| testRealm.swift:73:2:73:4 | .password | label:password, type:credential |
-| testRealm.swift:73:15:73:15 | myPassword | label:myPassword, type:credential |
-| testSend.swift:29:19:29:19 | passwordPlain | label:passwordPlain, type:credential |
-| testSend.swift:33:19:33:19 | passwordPlain | label:passwordPlain, type:credential |
-| testSend.swift:58:13:58:13 | password | label:password, type:credential |
-| testSend.swift:59:13:59:13 | password | label:password, type:credential |
-| testSend.swift:60:17:60:17 | password | label:password, type:credential |
-| testSend.swift:61:23:61:23 | password | label:password, type:credential |
-| testSend.swift:62:27:62:27 | password | label:password, type:credential |
-| testSend.swift:63:27:63:27 | password | label:password, type:credential |
+| testGRDB.swift:73:57:73:57 | password | label:password, type:password |
+| testGRDB.swift:76:43:76:43 | password | label:password, type:password |
+| testGRDB.swift:81:45:81:45 | password | label:password, type:password |
+| testGRDB.swift:83:45:83:45 | password | label:password, type:password |
+| testGRDB.swift:85:45:85:45 | password | label:password, type:password |
+| testGRDB.swift:87:45:87:45 | password | label:password, type:password |
+| testGRDB.swift:92:38:92:38 | password | label:password, type:password |
+| testGRDB.swift:95:37:95:37 | password | label:password, type:password |
+| testGRDB.swift:100:73:100:73 | password | label:password, type:password |
+| testGRDB.swift:101:73:101:73 | password | label:password, type:password |
+| testGRDB.swift:107:53:107:53 | password | label:password, type:password |
+| testGRDB.swift:109:53:109:53 | password | label:password, type:password |
+| testGRDB.swift:111:52:111:52 | password | label:password, type:password |
+| testGRDB.swift:116:48:116:48 | password | label:password, type:password |
+| testGRDB.swift:118:48:118:48 | password | label:password, type:password |
+| testGRDB.swift:121:45:121:45 | password | label:password, type:password |
+| testGRDB.swift:123:45:123:45 | password | label:password, type:password |
+| testGRDB.swift:126:45:126:45 | password | label:password, type:password |
+| testGRDB.swift:128:45:128:45 | password | label:password, type:password |
+| testGRDB.swift:131:45:131:45 | password | label:password, type:password |
+| testGRDB.swift:133:45:133:45 | password | label:password, type:password |
+| testGRDB.swift:138:69:138:69 | password | label:password, type:password |
+| testGRDB.swift:140:69:140:69 | password | label:password, type:password |
+| testGRDB.swift:143:66:143:66 | password | label:password, type:password |
+| testGRDB.swift:145:66:145:66 | password | label:password, type:password |
+| testGRDB.swift:148:66:148:66 | password | label:password, type:password |
+| testGRDB.swift:150:66:150:66 | password | label:password, type:password |
+| testGRDB.swift:153:66:153:66 | password | label:password, type:password |
+| testGRDB.swift:155:66:155:66 | password | label:password, type:password |
+| testGRDB.swift:160:60:160:60 | password | label:password, type:password |
+| testGRDB.swift:161:51:161:51 | password | label:password, type:password |
+| testGRDB.swift:164:60:164:60 | password | label:password, type:password |
+| testGRDB.swift:165:51:165:51 | password | label:password, type:password |
+| testGRDB.swift:169:57:169:57 | password | label:password, type:password |
+| testGRDB.swift:170:48:170:48 | password | label:password, type:password |
+| testGRDB.swift:173:57:173:57 | password | label:password, type:password |
+| testGRDB.swift:174:48:174:48 | password | label:password, type:password |
+| testGRDB.swift:178:57:178:57 | password | label:password, type:password |
+| testGRDB.swift:179:48:179:48 | password | label:password, type:password |
+| testGRDB.swift:182:57:182:57 | password | label:password, type:password |
+| testGRDB.swift:183:48:183:48 | password | label:password, type:password |
+| testGRDB.swift:187:57:187:57 | password | label:password, type:password |
+| testGRDB.swift:188:48:188:48 | password | label:password, type:password |
+| testGRDB.swift:191:57:191:57 | password | label:password, type:password |
+| testGRDB.swift:192:48:192:48 | password | label:password, type:password |
+| testGRDB.swift:198:30:198:30 | password | label:password, type:password |
+| testGRDB.swift:201:24:201:24 | password | label:password, type:password |
+| testGRDB.swift:206:67:206:67 | password | label:password, type:password |
+| testGRDB.swift:208:81:208:81 | password | label:password, type:password |
+| testGRDB.swift:210:85:210:85 | password | label:password, type:password |
+| testGRDB.swift:212:99:212:99 | password | label:password, type:password |
+| testRealm2.swift:18:11:18:11 | myPassword | label:myPassword, type:password |
+| testRealm.swift:31:20:31:20 | .password | label:password, type:password |
+| testRealm.swift:41:11:41:11 | myPassword | label:myPassword, type:password |
+| testRealm.swift:49:11:49:11 | myPassword | label:myPassword, type:password |
+| testRealm.swift:59:12:59:12 | myPassword | label:myPassword, type:password |
+| testRealm.swift:66:11:66:11 | myPassword | label:myPassword, type:password |
+| testRealm.swift:73:2:73:4 | .password | label:password, type:password |
+| testRealm.swift:73:15:73:15 | myPassword | label:myPassword, type:password |
+| testSend.swift:29:19:29:19 | passwordPlain | label:passwordPlain, type:password |
+| testSend.swift:33:19:33:19 | passwordPlain | label:passwordPlain, type:password |
+| testSend.swift:58:13:58:13 | password | label:password, type:password |
+| testSend.swift:59:13:59:13 | password | label:password, type:password |
+| testSend.swift:60:17:60:17 | password | label:password, type:password |
+| testSend.swift:61:23:61:23 | password | label:password, type:password |
+| testSend.swift:62:27:62:27 | password | label:password, type:password |
+| testSend.swift:63:27:63:27 | password | label:password, type:password |
 | testSend.swift:71:27:71:27 | license_key | label:license_key, type:credential |
 | testSend.swift:72:27:72:30 | .mobileNumber | label:mobileNumber, type:private information |
-| testSend.swift:75:27:75:30 | .passwordFeatureEnabled | label:passwordFeatureEnabled, type:credential |
+| testSend.swift:75:27:75:30 | .passwordFeatureEnabled | label:passwordFeatureEnabled, type:password |
 | testSend.swift:76:27:76:30 | .Telephone | label:Telephone, type:private information |
 | testSend.swift:77:27:77:30 | .birth_day | label:birth_day, type:private information |
 | testSend.swift:78:27:78:30 | .CarePlanID | label:CarePlanID, type:private information |
 | testSend.swift:79:27:79:30 | .BankCardNo | label:BankCardNo, type:private information |
 | testSend.swift:80:27:80:30 | .MyCreditRating | label:MyCreditRating, type:private information |
-| testSend.swift:94:27:94:30 | .password | label:password, type:credential |
-| testURL.swift:39:50:39:50 | passwd | label:passwd, type:credential |
+| testSend.swift:94:27:94:30 | .password | label:password, type:password |
+| testURL.swift:39:50:39:50 | passwd | label:passwd, type:password |
 | testURL.swift:41:51:41:51 | account_no | label:account_no, type:private information |
 | testURL.swift:42:51:42:51 | credit_card_no | label:credit_card_no, type:private information |
-| testURL.swift:46:22:46:22 | passwd | label:passwd, type:credential |
+| testURL.swift:46:22:46:22 | passwd | label:passwd, type:password |
 | testURL.swift:50:51:50:51 | e_mail | label:e_mail, type:private information |
 | testURL.swift:52:53:52:53 | a_homeaddr_z | label:a_homeaddr_z, type:private information |
 | testURL.swift:54:51:54:51 | resident_ID | label:resident_ID, type:private information |

--- a/swift/ql/test/query-tests/Security/CWE-328/WeakPasswordHashing.expected
+++ b/swift/ql/test/query-tests/Security/CWE-328/WeakPasswordHashing.expected
@@ -1,20 +1,26 @@
 edges
+| testCryptoKit.swift:193:38:193:38 | passwordString | testCryptoKit.swift:193:38:193:53 | .utf8 |
+| testCryptoKit.swift:193:38:193:53 | .utf8 | testCryptoKit.swift:193:33:193:57 | call to Data.init(_:) |
 nodes
-| testCryptoKit.swift:56:47:56:47 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:63:44:63:44 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:69:37:69:37 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:75:37:75:37 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:81:37:81:37 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:90:23:90:23 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:99:23:99:23 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:108:23:108:23 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:117:23:117:23 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:126:23:126:23 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:135:32:135:32 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:144:32:144:32 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:153:32:153:32 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:162:32:162:32 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:171:32:171:32 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:65:47:65:47 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:71:44:71:44 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:77:37:77:37 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:83:37:83:37 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:89:37:89:37 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:98:23:98:23 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:107:23:107:23 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:116:23:116:23 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:125:23:125:23 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:134:23:134:23 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:143:32:143:32 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:152:32:152:32 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:161:32:161:32 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:170:32:170:32 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:179:32:179:32 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:189:49:189:49 | passwordData | semmle.label | passwordData |
+| testCryptoKit.swift:193:33:193:57 | call to Data.init(_:) | semmle.label | call to Data.init(_:) |
+| testCryptoKit.swift:193:38:193:38 | passwordString | semmle.label | passwordString |
+| testCryptoKit.swift:193:38:193:53 | .utf8 | semmle.label | .utf8 |
 | testCryptoSwift.swift:154:30:154:30 | passwdArray | semmle.label | passwdArray |
 | testCryptoSwift.swift:157:31:157:31 | passwdArray | semmle.label | passwdArray |
 | testCryptoSwift.swift:160:47:160:47 | passwdArray | semmle.label | passwdArray |
@@ -41,21 +47,23 @@ nodes
 | testCryptoSwift.swift:231:9:231:9 | passwd | semmle.label | passwd |
 subpaths
 #select
-| testCryptoKit.swift:56:47:56:47 | passwd | testCryptoKit.swift:56:47:56:47 | passwd | testCryptoKit.swift:56:47:56:47 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:56:47:56:47 | passwd | password (passwd) |
-| testCryptoKit.swift:63:44:63:44 | passwd | testCryptoKit.swift:63:44:63:44 | passwd | testCryptoKit.swift:63:44:63:44 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:63:44:63:44 | passwd | password (passwd) |
-| testCryptoKit.swift:69:37:69:37 | passwd | testCryptoKit.swift:69:37:69:37 | passwd | testCryptoKit.swift:69:37:69:37 | passwd | Insecure hashing algorithm (SHA256) depends on $@. | testCryptoKit.swift:69:37:69:37 | passwd | password (passwd) |
-| testCryptoKit.swift:75:37:75:37 | passwd | testCryptoKit.swift:75:37:75:37 | passwd | testCryptoKit.swift:75:37:75:37 | passwd | Insecure hashing algorithm (SHA384) depends on $@. | testCryptoKit.swift:75:37:75:37 | passwd | password (passwd) |
-| testCryptoKit.swift:81:37:81:37 | passwd | testCryptoKit.swift:81:37:81:37 | passwd | testCryptoKit.swift:81:37:81:37 | passwd | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:81:37:81:37 | passwd | password (passwd) |
-| testCryptoKit.swift:90:23:90:23 | passwd | testCryptoKit.swift:90:23:90:23 | passwd | testCryptoKit.swift:90:23:90:23 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:90:23:90:23 | passwd | password (passwd) |
-| testCryptoKit.swift:99:23:99:23 | passwd | testCryptoKit.swift:99:23:99:23 | passwd | testCryptoKit.swift:99:23:99:23 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:99:23:99:23 | passwd | password (passwd) |
-| testCryptoKit.swift:108:23:108:23 | passwd | testCryptoKit.swift:108:23:108:23 | passwd | testCryptoKit.swift:108:23:108:23 | passwd | Insecure hashing algorithm (SHA256) depends on $@. | testCryptoKit.swift:108:23:108:23 | passwd | password (passwd) |
-| testCryptoKit.swift:117:23:117:23 | passwd | testCryptoKit.swift:117:23:117:23 | passwd | testCryptoKit.swift:117:23:117:23 | passwd | Insecure hashing algorithm (SHA384) depends on $@. | testCryptoKit.swift:117:23:117:23 | passwd | password (passwd) |
-| testCryptoKit.swift:126:23:126:23 | passwd | testCryptoKit.swift:126:23:126:23 | passwd | testCryptoKit.swift:126:23:126:23 | passwd | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:126:23:126:23 | passwd | password (passwd) |
-| testCryptoKit.swift:135:32:135:32 | passwd | testCryptoKit.swift:135:32:135:32 | passwd | testCryptoKit.swift:135:32:135:32 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:135:32:135:32 | passwd | password (passwd) |
-| testCryptoKit.swift:144:32:144:32 | passwd | testCryptoKit.swift:144:32:144:32 | passwd | testCryptoKit.swift:144:32:144:32 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:144:32:144:32 | passwd | password (passwd) |
-| testCryptoKit.swift:153:32:153:32 | passwd | testCryptoKit.swift:153:32:153:32 | passwd | testCryptoKit.swift:153:32:153:32 | passwd | Insecure hashing algorithm (SHA256) depends on $@. | testCryptoKit.swift:153:32:153:32 | passwd | password (passwd) |
-| testCryptoKit.swift:162:32:162:32 | passwd | testCryptoKit.swift:162:32:162:32 | passwd | testCryptoKit.swift:162:32:162:32 | passwd | Insecure hashing algorithm (SHA384) depends on $@. | testCryptoKit.swift:162:32:162:32 | passwd | password (passwd) |
-| testCryptoKit.swift:171:32:171:32 | passwd | testCryptoKit.swift:171:32:171:32 | passwd | testCryptoKit.swift:171:32:171:32 | passwd | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:171:32:171:32 | passwd | password (passwd) |
+| testCryptoKit.swift:65:47:65:47 | passwd | testCryptoKit.swift:65:47:65:47 | passwd | testCryptoKit.swift:65:47:65:47 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:65:47:65:47 | passwd | password (passwd) |
+| testCryptoKit.swift:71:44:71:44 | passwd | testCryptoKit.swift:71:44:71:44 | passwd | testCryptoKit.swift:71:44:71:44 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:71:44:71:44 | passwd | password (passwd) |
+| testCryptoKit.swift:77:37:77:37 | passwd | testCryptoKit.swift:77:37:77:37 | passwd | testCryptoKit.swift:77:37:77:37 | passwd | Insecure hashing algorithm (SHA256) depends on $@. | testCryptoKit.swift:77:37:77:37 | passwd | password (passwd) |
+| testCryptoKit.swift:83:37:83:37 | passwd | testCryptoKit.swift:83:37:83:37 | passwd | testCryptoKit.swift:83:37:83:37 | passwd | Insecure hashing algorithm (SHA384) depends on $@. | testCryptoKit.swift:83:37:83:37 | passwd | password (passwd) |
+| testCryptoKit.swift:89:37:89:37 | passwd | testCryptoKit.swift:89:37:89:37 | passwd | testCryptoKit.swift:89:37:89:37 | passwd | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:89:37:89:37 | passwd | password (passwd) |
+| testCryptoKit.swift:98:23:98:23 | passwd | testCryptoKit.swift:98:23:98:23 | passwd | testCryptoKit.swift:98:23:98:23 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:98:23:98:23 | passwd | password (passwd) |
+| testCryptoKit.swift:107:23:107:23 | passwd | testCryptoKit.swift:107:23:107:23 | passwd | testCryptoKit.swift:107:23:107:23 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:107:23:107:23 | passwd | password (passwd) |
+| testCryptoKit.swift:116:23:116:23 | passwd | testCryptoKit.swift:116:23:116:23 | passwd | testCryptoKit.swift:116:23:116:23 | passwd | Insecure hashing algorithm (SHA256) depends on $@. | testCryptoKit.swift:116:23:116:23 | passwd | password (passwd) |
+| testCryptoKit.swift:125:23:125:23 | passwd | testCryptoKit.swift:125:23:125:23 | passwd | testCryptoKit.swift:125:23:125:23 | passwd | Insecure hashing algorithm (SHA384) depends on $@. | testCryptoKit.swift:125:23:125:23 | passwd | password (passwd) |
+| testCryptoKit.swift:134:23:134:23 | passwd | testCryptoKit.swift:134:23:134:23 | passwd | testCryptoKit.swift:134:23:134:23 | passwd | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:134:23:134:23 | passwd | password (passwd) |
+| testCryptoKit.swift:143:32:143:32 | passwd | testCryptoKit.swift:143:32:143:32 | passwd | testCryptoKit.swift:143:32:143:32 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:143:32:143:32 | passwd | password (passwd) |
+| testCryptoKit.swift:152:32:152:32 | passwd | testCryptoKit.swift:152:32:152:32 | passwd | testCryptoKit.swift:152:32:152:32 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:152:32:152:32 | passwd | password (passwd) |
+| testCryptoKit.swift:161:32:161:32 | passwd | testCryptoKit.swift:161:32:161:32 | passwd | testCryptoKit.swift:161:32:161:32 | passwd | Insecure hashing algorithm (SHA256) depends on $@. | testCryptoKit.swift:161:32:161:32 | passwd | password (passwd) |
+| testCryptoKit.swift:170:32:170:32 | passwd | testCryptoKit.swift:170:32:170:32 | passwd | testCryptoKit.swift:170:32:170:32 | passwd | Insecure hashing algorithm (SHA384) depends on $@. | testCryptoKit.swift:170:32:170:32 | passwd | password (passwd) |
+| testCryptoKit.swift:179:32:179:32 | passwd | testCryptoKit.swift:179:32:179:32 | passwd | testCryptoKit.swift:179:32:179:32 | passwd | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:179:32:179:32 | passwd | password (passwd) |
+| testCryptoKit.swift:189:49:189:49 | passwordData | testCryptoKit.swift:189:49:189:49 | passwordData | testCryptoKit.swift:189:49:189:49 | passwordData | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:189:49:189:49 | passwordData | password (passwordData) |
+| testCryptoKit.swift:193:33:193:57 | call to Data.init(_:) | testCryptoKit.swift:193:38:193:38 | passwordString | testCryptoKit.swift:193:33:193:57 | call to Data.init(_:) | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:193:38:193:38 | passwordString | password (passwordString) |
 | testCryptoSwift.swift:154:30:154:30 | passwdArray | testCryptoSwift.swift:154:30:154:30 | passwdArray | testCryptoSwift.swift:154:30:154:30 | passwdArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:154:30:154:30 | passwdArray | password (passwdArray) |
 | testCryptoSwift.swift:157:31:157:31 | passwdArray | testCryptoSwift.swift:157:31:157:31 | passwdArray | testCryptoSwift.swift:157:31:157:31 | passwdArray | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:157:31:157:31 | passwdArray | password (passwdArray) |
 | testCryptoSwift.swift:160:47:160:47 | passwdArray | testCryptoSwift.swift:160:47:160:47 | passwdArray | testCryptoSwift.swift:160:47:160:47 | passwdArray | Insecure hashing algorithm (SHA2) depends on $@. | testCryptoSwift.swift:160:47:160:47 | passwdArray | password (passwdArray) |

--- a/swift/ql/test/query-tests/Security/CWE-328/WeakPasswordHashing.expected
+++ b/swift/ql/test/query-tests/Security/CWE-328/WeakPasswordHashing.expected
@@ -6,16 +6,16 @@ nodes
 | testCryptoKit.swift:99:23:99:23 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:132:32:132:32 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:141:32:141:32 | passwd | semmle.label | passwd |
-| testCryptoSwift.swift:113:30:113:30 | passwdArray | semmle.label | passwdArray |
-| testCryptoSwift.swift:115:31:115:31 | passwdArray | semmle.label | passwdArray |
-| testCryptoSwift.swift:120:20:120:20 | passwdArray | semmle.label | passwdArray |
-| testCryptoSwift.swift:122:21:122:21 | passwdArray | semmle.label | passwdArray |
-| testCryptoSwift.swift:127:9:127:9 | passwdArray | semmle.label | passwdArray |
-| testCryptoSwift.swift:129:9:129:9 | passwdArray | semmle.label | passwdArray |
-| testCryptoSwift.swift:136:9:136:9 | passwdData | semmle.label | passwdData |
-| testCryptoSwift.swift:138:9:138:9 | passwdData | semmle.label | passwdData |
-| testCryptoSwift.swift:145:9:145:9 | passwd | semmle.label | passwd |
-| testCryptoSwift.swift:147:9:147:9 | passwd | semmle.label | passwd |
+| testCryptoSwift.swift:154:30:154:30 | passwdArray | semmle.label | passwdArray |
+| testCryptoSwift.swift:157:31:157:31 | passwdArray | semmle.label | passwdArray |
+| testCryptoSwift.swift:167:20:167:20 | passwdArray | semmle.label | passwdArray |
+| testCryptoSwift.swift:170:21:170:21 | passwdArray | semmle.label | passwdArray |
+| testCryptoSwift.swift:183:9:183:9 | passwdArray | semmle.label | passwdArray |
+| testCryptoSwift.swift:186:9:186:9 | passwdArray | semmle.label | passwdArray |
+| testCryptoSwift.swift:201:9:201:9 | passwdData | semmle.label | passwdData |
+| testCryptoSwift.swift:204:9:204:9 | passwdData | semmle.label | passwdData |
+| testCryptoSwift.swift:219:9:219:9 | passwd | semmle.label | passwd |
+| testCryptoSwift.swift:222:9:222:9 | passwd | semmle.label | passwd |
 subpaths
 #select
 | testCryptoKit.swift:56:47:56:47 | passwd | testCryptoKit.swift:56:47:56:47 | passwd | testCryptoKit.swift:56:47:56:47 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:56:47:56:47 | passwd | password (passwd) |
@@ -24,13 +24,13 @@ subpaths
 | testCryptoKit.swift:99:23:99:23 | passwd | testCryptoKit.swift:99:23:99:23 | passwd | testCryptoKit.swift:99:23:99:23 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:99:23:99:23 | passwd | password (passwd) |
 | testCryptoKit.swift:132:32:132:32 | passwd | testCryptoKit.swift:132:32:132:32 | passwd | testCryptoKit.swift:132:32:132:32 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:132:32:132:32 | passwd | password (passwd) |
 | testCryptoKit.swift:141:32:141:32 | passwd | testCryptoKit.swift:141:32:141:32 | passwd | testCryptoKit.swift:141:32:141:32 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:141:32:141:32 | passwd | password (passwd) |
-| testCryptoSwift.swift:113:30:113:30 | passwdArray | testCryptoSwift.swift:113:30:113:30 | passwdArray | testCryptoSwift.swift:113:30:113:30 | passwdArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:113:30:113:30 | passwdArray | password (passwdArray) |
-| testCryptoSwift.swift:115:31:115:31 | passwdArray | testCryptoSwift.swift:115:31:115:31 | passwdArray | testCryptoSwift.swift:115:31:115:31 | passwdArray | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:115:31:115:31 | passwdArray | password (passwdArray) |
-| testCryptoSwift.swift:120:20:120:20 | passwdArray | testCryptoSwift.swift:120:20:120:20 | passwdArray | testCryptoSwift.swift:120:20:120:20 | passwdArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:120:20:120:20 | passwdArray | password (passwdArray) |
-| testCryptoSwift.swift:122:21:122:21 | passwdArray | testCryptoSwift.swift:122:21:122:21 | passwdArray | testCryptoSwift.swift:122:21:122:21 | passwdArray | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:122:21:122:21 | passwdArray | password (passwdArray) |
-| testCryptoSwift.swift:127:9:127:9 | passwdArray | testCryptoSwift.swift:127:9:127:9 | passwdArray | testCryptoSwift.swift:127:9:127:9 | passwdArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:127:9:127:9 | passwdArray | password (passwdArray) |
-| testCryptoSwift.swift:129:9:129:9 | passwdArray | testCryptoSwift.swift:129:9:129:9 | passwdArray | testCryptoSwift.swift:129:9:129:9 | passwdArray | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:129:9:129:9 | passwdArray | password (passwdArray) |
-| testCryptoSwift.swift:136:9:136:9 | passwdData | testCryptoSwift.swift:136:9:136:9 | passwdData | testCryptoSwift.swift:136:9:136:9 | passwdData | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:136:9:136:9 | passwdData | password (passwdData) |
-| testCryptoSwift.swift:138:9:138:9 | passwdData | testCryptoSwift.swift:138:9:138:9 | passwdData | testCryptoSwift.swift:138:9:138:9 | passwdData | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:138:9:138:9 | passwdData | password (passwdData) |
-| testCryptoSwift.swift:145:9:145:9 | passwd | testCryptoSwift.swift:145:9:145:9 | passwd | testCryptoSwift.swift:145:9:145:9 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:145:9:145:9 | passwd | password (passwd) |
-| testCryptoSwift.swift:147:9:147:9 | passwd | testCryptoSwift.swift:147:9:147:9 | passwd | testCryptoSwift.swift:147:9:147:9 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:147:9:147:9 | passwd | password (passwd) |
+| testCryptoSwift.swift:154:30:154:30 | passwdArray | testCryptoSwift.swift:154:30:154:30 | passwdArray | testCryptoSwift.swift:154:30:154:30 | passwdArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:154:30:154:30 | passwdArray | password (passwdArray) |
+| testCryptoSwift.swift:157:31:157:31 | passwdArray | testCryptoSwift.swift:157:31:157:31 | passwdArray | testCryptoSwift.swift:157:31:157:31 | passwdArray | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:157:31:157:31 | passwdArray | password (passwdArray) |
+| testCryptoSwift.swift:167:20:167:20 | passwdArray | testCryptoSwift.swift:167:20:167:20 | passwdArray | testCryptoSwift.swift:167:20:167:20 | passwdArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:167:20:167:20 | passwdArray | password (passwdArray) |
+| testCryptoSwift.swift:170:21:170:21 | passwdArray | testCryptoSwift.swift:170:21:170:21 | passwdArray | testCryptoSwift.swift:170:21:170:21 | passwdArray | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:170:21:170:21 | passwdArray | password (passwdArray) |
+| testCryptoSwift.swift:183:9:183:9 | passwdArray | testCryptoSwift.swift:183:9:183:9 | passwdArray | testCryptoSwift.swift:183:9:183:9 | passwdArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:183:9:183:9 | passwdArray | password (passwdArray) |
+| testCryptoSwift.swift:186:9:186:9 | passwdArray | testCryptoSwift.swift:186:9:186:9 | passwdArray | testCryptoSwift.swift:186:9:186:9 | passwdArray | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:186:9:186:9 | passwdArray | password (passwdArray) |
+| testCryptoSwift.swift:201:9:201:9 | passwdData | testCryptoSwift.swift:201:9:201:9 | passwdData | testCryptoSwift.swift:201:9:201:9 | passwdData | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:201:9:201:9 | passwdData | password (passwdData) |
+| testCryptoSwift.swift:204:9:204:9 | passwdData | testCryptoSwift.swift:204:9:204:9 | passwdData | testCryptoSwift.swift:204:9:204:9 | passwdData | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:204:9:204:9 | passwdData | password (passwdData) |
+| testCryptoSwift.swift:219:9:219:9 | passwd | testCryptoSwift.swift:219:9:219:9 | passwd | testCryptoSwift.swift:219:9:219:9 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:219:9:219:9 | passwd | password (passwd) |
+| testCryptoSwift.swift:222:9:222:9 | passwd | testCryptoSwift.swift:222:9:222:9 | passwd | testCryptoSwift.swift:222:9:222:9 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:222:9:222:9 | passwd | password (passwd) |

--- a/swift/ql/test/query-tests/Security/CWE-328/WeakPasswordHashing.expected
+++ b/swift/ql/test/query-tests/Security/CWE-328/WeakPasswordHashing.expected
@@ -2,35 +2,81 @@ edges
 nodes
 | testCryptoKit.swift:56:47:56:47 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:63:44:63:44 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:69:37:69:37 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:75:37:75:37 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:81:37:81:37 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:90:23:90:23 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:99:23:99:23 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:108:23:108:23 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:116:23:116:23 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:124:23:124:23 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:132:32:132:32 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:141:32:141:32 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:150:32:150:32 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:158:32:158:32 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:166:32:166:32 | passwd | semmle.label | passwd |
 | testCryptoSwift.swift:154:30:154:30 | passwdArray | semmle.label | passwdArray |
 | testCryptoSwift.swift:157:31:157:31 | passwdArray | semmle.label | passwdArray |
+| testCryptoSwift.swift:160:47:160:47 | passwdArray | semmle.label | passwdArray |
+| testCryptoSwift.swift:163:47:163:47 | passwdArray | semmle.label | passwdArray |
 | testCryptoSwift.swift:167:20:167:20 | passwdArray | semmle.label | passwdArray |
 | testCryptoSwift.swift:170:21:170:21 | passwdArray | semmle.label | passwdArray |
+| testCryptoSwift.swift:173:23:173:23 | passwdArray | semmle.label | passwdArray |
+| testCryptoSwift.swift:176:21:176:21 | passwdArray | semmle.label | passwdArray |
+| testCryptoSwift.swift:179:21:179:21 | passwdArray | semmle.label | passwdArray |
 | testCryptoSwift.swift:183:9:183:9 | passwdArray | semmle.label | passwdArray |
 | testCryptoSwift.swift:186:9:186:9 | passwdArray | semmle.label | passwdArray |
+| testCryptoSwift.swift:189:9:189:9 | passwdArray | semmle.label | passwdArray |
+| testCryptoSwift.swift:192:9:192:9 | passwdArray | semmle.label | passwdArray |
+| testCryptoSwift.swift:195:9:195:9 | passwdArray | semmle.label | passwdArray |
 | testCryptoSwift.swift:201:9:201:9 | passwdData | semmle.label | passwdData |
 | testCryptoSwift.swift:204:9:204:9 | passwdData | semmle.label | passwdData |
+| testCryptoSwift.swift:207:9:207:9 | passwdData | semmle.label | passwdData |
+| testCryptoSwift.swift:210:9:210:9 | passwdData | semmle.label | passwdData |
+| testCryptoSwift.swift:213:9:213:9 | passwdData | semmle.label | passwdData |
 | testCryptoSwift.swift:219:9:219:9 | passwd | semmle.label | passwd |
 | testCryptoSwift.swift:222:9:222:9 | passwd | semmle.label | passwd |
+| testCryptoSwift.swift:225:9:225:9 | passwd | semmle.label | passwd |
+| testCryptoSwift.swift:228:9:228:9 | passwd | semmle.label | passwd |
+| testCryptoSwift.swift:231:9:231:9 | passwd | semmle.label | passwd |
 subpaths
 #select
 | testCryptoKit.swift:56:47:56:47 | passwd | testCryptoKit.swift:56:47:56:47 | passwd | testCryptoKit.swift:56:47:56:47 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:56:47:56:47 | passwd | password (passwd) |
 | testCryptoKit.swift:63:44:63:44 | passwd | testCryptoKit.swift:63:44:63:44 | passwd | testCryptoKit.swift:63:44:63:44 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:63:44:63:44 | passwd | password (passwd) |
+| testCryptoKit.swift:69:37:69:37 | passwd | testCryptoKit.swift:69:37:69:37 | passwd | testCryptoKit.swift:69:37:69:37 | passwd | Insecure hashing algorithm (SHA256) depends on $@. | testCryptoKit.swift:69:37:69:37 | passwd | password (passwd) |
+| testCryptoKit.swift:75:37:75:37 | passwd | testCryptoKit.swift:75:37:75:37 | passwd | testCryptoKit.swift:75:37:75:37 | passwd | Insecure hashing algorithm (SHA384) depends on $@. | testCryptoKit.swift:75:37:75:37 | passwd | password (passwd) |
+| testCryptoKit.swift:81:37:81:37 | passwd | testCryptoKit.swift:81:37:81:37 | passwd | testCryptoKit.swift:81:37:81:37 | passwd | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:81:37:81:37 | passwd | password (passwd) |
 | testCryptoKit.swift:90:23:90:23 | passwd | testCryptoKit.swift:90:23:90:23 | passwd | testCryptoKit.swift:90:23:90:23 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:90:23:90:23 | passwd | password (passwd) |
 | testCryptoKit.swift:99:23:99:23 | passwd | testCryptoKit.swift:99:23:99:23 | passwd | testCryptoKit.swift:99:23:99:23 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:99:23:99:23 | passwd | password (passwd) |
+| testCryptoKit.swift:108:23:108:23 | passwd | testCryptoKit.swift:108:23:108:23 | passwd | testCryptoKit.swift:108:23:108:23 | passwd | Insecure hashing algorithm (SHA256) depends on $@. | testCryptoKit.swift:108:23:108:23 | passwd | password (passwd) |
+| testCryptoKit.swift:116:23:116:23 | passwd | testCryptoKit.swift:116:23:116:23 | passwd | testCryptoKit.swift:116:23:116:23 | passwd | Insecure hashing algorithm (SHA384) depends on $@. | testCryptoKit.swift:116:23:116:23 | passwd | password (passwd) |
+| testCryptoKit.swift:124:23:124:23 | passwd | testCryptoKit.swift:124:23:124:23 | passwd | testCryptoKit.swift:124:23:124:23 | passwd | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:124:23:124:23 | passwd | password (passwd) |
 | testCryptoKit.swift:132:32:132:32 | passwd | testCryptoKit.swift:132:32:132:32 | passwd | testCryptoKit.swift:132:32:132:32 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:132:32:132:32 | passwd | password (passwd) |
 | testCryptoKit.swift:141:32:141:32 | passwd | testCryptoKit.swift:141:32:141:32 | passwd | testCryptoKit.swift:141:32:141:32 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:141:32:141:32 | passwd | password (passwd) |
+| testCryptoKit.swift:150:32:150:32 | passwd | testCryptoKit.swift:150:32:150:32 | passwd | testCryptoKit.swift:150:32:150:32 | passwd | Insecure hashing algorithm (SHA256) depends on $@. | testCryptoKit.swift:150:32:150:32 | passwd | password (passwd) |
+| testCryptoKit.swift:158:32:158:32 | passwd | testCryptoKit.swift:158:32:158:32 | passwd | testCryptoKit.swift:158:32:158:32 | passwd | Insecure hashing algorithm (SHA384) depends on $@. | testCryptoKit.swift:158:32:158:32 | passwd | password (passwd) |
+| testCryptoKit.swift:166:32:166:32 | passwd | testCryptoKit.swift:166:32:166:32 | passwd | testCryptoKit.swift:166:32:166:32 | passwd | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:166:32:166:32 | passwd | password (passwd) |
 | testCryptoSwift.swift:154:30:154:30 | passwdArray | testCryptoSwift.swift:154:30:154:30 | passwdArray | testCryptoSwift.swift:154:30:154:30 | passwdArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:154:30:154:30 | passwdArray | password (passwdArray) |
 | testCryptoSwift.swift:157:31:157:31 | passwdArray | testCryptoSwift.swift:157:31:157:31 | passwdArray | testCryptoSwift.swift:157:31:157:31 | passwdArray | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:157:31:157:31 | passwdArray | password (passwdArray) |
+| testCryptoSwift.swift:160:47:160:47 | passwdArray | testCryptoSwift.swift:160:47:160:47 | passwdArray | testCryptoSwift.swift:160:47:160:47 | passwdArray | Insecure hashing algorithm (SHA2) depends on $@. | testCryptoSwift.swift:160:47:160:47 | passwdArray | password (passwdArray) |
+| testCryptoSwift.swift:163:47:163:47 | passwdArray | testCryptoSwift.swift:163:47:163:47 | passwdArray | testCryptoSwift.swift:163:47:163:47 | passwdArray | Insecure hashing algorithm (SHA2) depends on $@. | testCryptoSwift.swift:163:47:163:47 | passwdArray | password (passwdArray) |
 | testCryptoSwift.swift:167:20:167:20 | passwdArray | testCryptoSwift.swift:167:20:167:20 | passwdArray | testCryptoSwift.swift:167:20:167:20 | passwdArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:167:20:167:20 | passwdArray | password (passwdArray) |
 | testCryptoSwift.swift:170:21:170:21 | passwdArray | testCryptoSwift.swift:170:21:170:21 | passwdArray | testCryptoSwift.swift:170:21:170:21 | passwdArray | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:170:21:170:21 | passwdArray | password (passwdArray) |
+| testCryptoSwift.swift:173:23:173:23 | passwdArray | testCryptoSwift.swift:173:23:173:23 | passwdArray | testCryptoSwift.swift:173:23:173:23 | passwdArray | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoSwift.swift:173:23:173:23 | passwdArray | password (passwdArray) |
+| testCryptoSwift.swift:176:21:176:21 | passwdArray | testCryptoSwift.swift:176:21:176:21 | passwdArray | testCryptoSwift.swift:176:21:176:21 | passwdArray | Insecure hashing algorithm (SHA2) depends on $@. | testCryptoSwift.swift:176:21:176:21 | passwdArray | password (passwdArray) |
+| testCryptoSwift.swift:179:21:179:21 | passwdArray | testCryptoSwift.swift:179:21:179:21 | passwdArray | testCryptoSwift.swift:179:21:179:21 | passwdArray | Insecure hashing algorithm (SHA3) depends on $@. | testCryptoSwift.swift:179:21:179:21 | passwdArray | password (passwdArray) |
 | testCryptoSwift.swift:183:9:183:9 | passwdArray | testCryptoSwift.swift:183:9:183:9 | passwdArray | testCryptoSwift.swift:183:9:183:9 | passwdArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:183:9:183:9 | passwdArray | password (passwdArray) |
 | testCryptoSwift.swift:186:9:186:9 | passwdArray | testCryptoSwift.swift:186:9:186:9 | passwdArray | testCryptoSwift.swift:186:9:186:9 | passwdArray | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:186:9:186:9 | passwdArray | password (passwdArray) |
+| testCryptoSwift.swift:189:9:189:9 | passwdArray | testCryptoSwift.swift:189:9:189:9 | passwdArray | testCryptoSwift.swift:189:9:189:9 | passwdArray | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoSwift.swift:189:9:189:9 | passwdArray | password (passwdArray) |
+| testCryptoSwift.swift:192:9:192:9 | passwdArray | testCryptoSwift.swift:192:9:192:9 | passwdArray | testCryptoSwift.swift:192:9:192:9 | passwdArray | Insecure hashing algorithm (SHA2) depends on $@. | testCryptoSwift.swift:192:9:192:9 | passwdArray | password (passwdArray) |
+| testCryptoSwift.swift:195:9:195:9 | passwdArray | testCryptoSwift.swift:195:9:195:9 | passwdArray | testCryptoSwift.swift:195:9:195:9 | passwdArray | Insecure hashing algorithm (SHA3) depends on $@. | testCryptoSwift.swift:195:9:195:9 | passwdArray | password (passwdArray) |
 | testCryptoSwift.swift:201:9:201:9 | passwdData | testCryptoSwift.swift:201:9:201:9 | passwdData | testCryptoSwift.swift:201:9:201:9 | passwdData | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:201:9:201:9 | passwdData | password (passwdData) |
 | testCryptoSwift.swift:204:9:204:9 | passwdData | testCryptoSwift.swift:204:9:204:9 | passwdData | testCryptoSwift.swift:204:9:204:9 | passwdData | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:204:9:204:9 | passwdData | password (passwdData) |
+| testCryptoSwift.swift:207:9:207:9 | passwdData | testCryptoSwift.swift:207:9:207:9 | passwdData | testCryptoSwift.swift:207:9:207:9 | passwdData | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoSwift.swift:207:9:207:9 | passwdData | password (passwdData) |
+| testCryptoSwift.swift:210:9:210:9 | passwdData | testCryptoSwift.swift:210:9:210:9 | passwdData | testCryptoSwift.swift:210:9:210:9 | passwdData | Insecure hashing algorithm (SHA2) depends on $@. | testCryptoSwift.swift:210:9:210:9 | passwdData | password (passwdData) |
+| testCryptoSwift.swift:213:9:213:9 | passwdData | testCryptoSwift.swift:213:9:213:9 | passwdData | testCryptoSwift.swift:213:9:213:9 | passwdData | Insecure hashing algorithm (SHA3) depends on $@. | testCryptoSwift.swift:213:9:213:9 | passwdData | password (passwdData) |
 | testCryptoSwift.swift:219:9:219:9 | passwd | testCryptoSwift.swift:219:9:219:9 | passwd | testCryptoSwift.swift:219:9:219:9 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:219:9:219:9 | passwd | password (passwd) |
 | testCryptoSwift.swift:222:9:222:9 | passwd | testCryptoSwift.swift:222:9:222:9 | passwd | testCryptoSwift.swift:222:9:222:9 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:222:9:222:9 | passwd | password (passwd) |
+| testCryptoSwift.swift:225:9:225:9 | passwd | testCryptoSwift.swift:225:9:225:9 | passwd | testCryptoSwift.swift:225:9:225:9 | passwd | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoSwift.swift:225:9:225:9 | passwd | password (passwd) |
+| testCryptoSwift.swift:228:9:228:9 | passwd | testCryptoSwift.swift:228:9:228:9 | passwd | testCryptoSwift.swift:228:9:228:9 | passwd | Insecure hashing algorithm (SHA2) depends on $@. | testCryptoSwift.swift:228:9:228:9 | passwd | password (passwd) |
+| testCryptoSwift.swift:231:9:231:9 | passwd | testCryptoSwift.swift:231:9:231:9 | passwd | testCryptoSwift.swift:231:9:231:9 | passwd | Insecure hashing algorithm (SHA3) depends on $@. | testCryptoSwift.swift:231:9:231:9 | passwd | password (passwd) |

--- a/swift/ql/test/query-tests/Security/CWE-328/WeakPasswordHashing.expected
+++ b/swift/ql/test/query-tests/Security/CWE-328/WeakPasswordHashing.expected
@@ -1,0 +1,36 @@
+edges
+nodes
+| testCryptoKit.swift:56:47:56:47 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:63:44:63:44 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:90:23:90:23 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:99:23:99:23 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:132:32:132:32 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:141:32:141:32 | passwd | semmle.label | passwd |
+| testCryptoSwift.swift:113:30:113:30 | passwdArray | semmle.label | passwdArray |
+| testCryptoSwift.swift:115:31:115:31 | passwdArray | semmle.label | passwdArray |
+| testCryptoSwift.swift:120:20:120:20 | passwdArray | semmle.label | passwdArray |
+| testCryptoSwift.swift:122:21:122:21 | passwdArray | semmle.label | passwdArray |
+| testCryptoSwift.swift:127:9:127:9 | passwdArray | semmle.label | passwdArray |
+| testCryptoSwift.swift:129:9:129:9 | passwdArray | semmle.label | passwdArray |
+| testCryptoSwift.swift:136:9:136:9 | passwdData | semmle.label | passwdData |
+| testCryptoSwift.swift:138:9:138:9 | passwdData | semmle.label | passwdData |
+| testCryptoSwift.swift:145:9:145:9 | passwd | semmle.label | passwd |
+| testCryptoSwift.swift:147:9:147:9 | passwd | semmle.label | passwd |
+subpaths
+#select
+| testCryptoKit.swift:56:47:56:47 | passwd | testCryptoKit.swift:56:47:56:47 | passwd | testCryptoKit.swift:56:47:56:47 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:56:47:56:47 | passwd | password (passwd) |
+| testCryptoKit.swift:63:44:63:44 | passwd | testCryptoKit.swift:63:44:63:44 | passwd | testCryptoKit.swift:63:44:63:44 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:63:44:63:44 | passwd | password (passwd) |
+| testCryptoKit.swift:90:23:90:23 | passwd | testCryptoKit.swift:90:23:90:23 | passwd | testCryptoKit.swift:90:23:90:23 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:90:23:90:23 | passwd | password (passwd) |
+| testCryptoKit.swift:99:23:99:23 | passwd | testCryptoKit.swift:99:23:99:23 | passwd | testCryptoKit.swift:99:23:99:23 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:99:23:99:23 | passwd | password (passwd) |
+| testCryptoKit.swift:132:32:132:32 | passwd | testCryptoKit.swift:132:32:132:32 | passwd | testCryptoKit.swift:132:32:132:32 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:132:32:132:32 | passwd | password (passwd) |
+| testCryptoKit.swift:141:32:141:32 | passwd | testCryptoKit.swift:141:32:141:32 | passwd | testCryptoKit.swift:141:32:141:32 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:141:32:141:32 | passwd | password (passwd) |
+| testCryptoSwift.swift:113:30:113:30 | passwdArray | testCryptoSwift.swift:113:30:113:30 | passwdArray | testCryptoSwift.swift:113:30:113:30 | passwdArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:113:30:113:30 | passwdArray | password (passwdArray) |
+| testCryptoSwift.swift:115:31:115:31 | passwdArray | testCryptoSwift.swift:115:31:115:31 | passwdArray | testCryptoSwift.swift:115:31:115:31 | passwdArray | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:115:31:115:31 | passwdArray | password (passwdArray) |
+| testCryptoSwift.swift:120:20:120:20 | passwdArray | testCryptoSwift.swift:120:20:120:20 | passwdArray | testCryptoSwift.swift:120:20:120:20 | passwdArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:120:20:120:20 | passwdArray | password (passwdArray) |
+| testCryptoSwift.swift:122:21:122:21 | passwdArray | testCryptoSwift.swift:122:21:122:21 | passwdArray | testCryptoSwift.swift:122:21:122:21 | passwdArray | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:122:21:122:21 | passwdArray | password (passwdArray) |
+| testCryptoSwift.swift:127:9:127:9 | passwdArray | testCryptoSwift.swift:127:9:127:9 | passwdArray | testCryptoSwift.swift:127:9:127:9 | passwdArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:127:9:127:9 | passwdArray | password (passwdArray) |
+| testCryptoSwift.swift:129:9:129:9 | passwdArray | testCryptoSwift.swift:129:9:129:9 | passwdArray | testCryptoSwift.swift:129:9:129:9 | passwdArray | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:129:9:129:9 | passwdArray | password (passwdArray) |
+| testCryptoSwift.swift:136:9:136:9 | passwdData | testCryptoSwift.swift:136:9:136:9 | passwdData | testCryptoSwift.swift:136:9:136:9 | passwdData | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:136:9:136:9 | passwdData | password (passwdData) |
+| testCryptoSwift.swift:138:9:138:9 | passwdData | testCryptoSwift.swift:138:9:138:9 | passwdData | testCryptoSwift.swift:138:9:138:9 | passwdData | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:138:9:138:9 | passwdData | password (passwdData) |
+| testCryptoSwift.swift:145:9:145:9 | passwd | testCryptoSwift.swift:145:9:145:9 | passwd | testCryptoSwift.swift:145:9:145:9 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:145:9:145:9 | passwd | password (passwd) |
+| testCryptoSwift.swift:147:9:147:9 | passwd | testCryptoSwift.swift:147:9:147:9 | passwd | testCryptoSwift.swift:147:9:147:9 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:147:9:147:9 | passwd | password (passwd) |

--- a/swift/ql/test/query-tests/Security/CWE-328/WeakPasswordHashing.expected
+++ b/swift/ql/test/query-tests/Security/CWE-328/WeakPasswordHashing.expected
@@ -8,13 +8,13 @@ nodes
 | testCryptoKit.swift:90:23:90:23 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:99:23:99:23 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:108:23:108:23 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:116:23:116:23 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:124:23:124:23 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:132:32:132:32 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:141:32:141:32 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:150:32:150:32 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:158:32:158:32 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:166:32:166:32 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:117:23:117:23 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:126:23:126:23 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:135:32:135:32 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:144:32:144:32 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:153:32:153:32 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:162:32:162:32 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:171:32:171:32 | passwd | semmle.label | passwd |
 | testCryptoSwift.swift:154:30:154:30 | passwdArray | semmle.label | passwdArray |
 | testCryptoSwift.swift:157:31:157:31 | passwdArray | semmle.label | passwdArray |
 | testCryptoSwift.swift:160:47:160:47 | passwdArray | semmle.label | passwdArray |
@@ -49,13 +49,13 @@ subpaths
 | testCryptoKit.swift:90:23:90:23 | passwd | testCryptoKit.swift:90:23:90:23 | passwd | testCryptoKit.swift:90:23:90:23 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:90:23:90:23 | passwd | password (passwd) |
 | testCryptoKit.swift:99:23:99:23 | passwd | testCryptoKit.swift:99:23:99:23 | passwd | testCryptoKit.swift:99:23:99:23 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:99:23:99:23 | passwd | password (passwd) |
 | testCryptoKit.swift:108:23:108:23 | passwd | testCryptoKit.swift:108:23:108:23 | passwd | testCryptoKit.swift:108:23:108:23 | passwd | Insecure hashing algorithm (SHA256) depends on $@. | testCryptoKit.swift:108:23:108:23 | passwd | password (passwd) |
-| testCryptoKit.swift:116:23:116:23 | passwd | testCryptoKit.swift:116:23:116:23 | passwd | testCryptoKit.swift:116:23:116:23 | passwd | Insecure hashing algorithm (SHA384) depends on $@. | testCryptoKit.swift:116:23:116:23 | passwd | password (passwd) |
-| testCryptoKit.swift:124:23:124:23 | passwd | testCryptoKit.swift:124:23:124:23 | passwd | testCryptoKit.swift:124:23:124:23 | passwd | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:124:23:124:23 | passwd | password (passwd) |
-| testCryptoKit.swift:132:32:132:32 | passwd | testCryptoKit.swift:132:32:132:32 | passwd | testCryptoKit.swift:132:32:132:32 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:132:32:132:32 | passwd | password (passwd) |
-| testCryptoKit.swift:141:32:141:32 | passwd | testCryptoKit.swift:141:32:141:32 | passwd | testCryptoKit.swift:141:32:141:32 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:141:32:141:32 | passwd | password (passwd) |
-| testCryptoKit.swift:150:32:150:32 | passwd | testCryptoKit.swift:150:32:150:32 | passwd | testCryptoKit.swift:150:32:150:32 | passwd | Insecure hashing algorithm (SHA256) depends on $@. | testCryptoKit.swift:150:32:150:32 | passwd | password (passwd) |
-| testCryptoKit.swift:158:32:158:32 | passwd | testCryptoKit.swift:158:32:158:32 | passwd | testCryptoKit.swift:158:32:158:32 | passwd | Insecure hashing algorithm (SHA384) depends on $@. | testCryptoKit.swift:158:32:158:32 | passwd | password (passwd) |
-| testCryptoKit.swift:166:32:166:32 | passwd | testCryptoKit.swift:166:32:166:32 | passwd | testCryptoKit.swift:166:32:166:32 | passwd | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:166:32:166:32 | passwd | password (passwd) |
+| testCryptoKit.swift:117:23:117:23 | passwd | testCryptoKit.swift:117:23:117:23 | passwd | testCryptoKit.swift:117:23:117:23 | passwd | Insecure hashing algorithm (SHA384) depends on $@. | testCryptoKit.swift:117:23:117:23 | passwd | password (passwd) |
+| testCryptoKit.swift:126:23:126:23 | passwd | testCryptoKit.swift:126:23:126:23 | passwd | testCryptoKit.swift:126:23:126:23 | passwd | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:126:23:126:23 | passwd | password (passwd) |
+| testCryptoKit.swift:135:32:135:32 | passwd | testCryptoKit.swift:135:32:135:32 | passwd | testCryptoKit.swift:135:32:135:32 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:135:32:135:32 | passwd | password (passwd) |
+| testCryptoKit.swift:144:32:144:32 | passwd | testCryptoKit.swift:144:32:144:32 | passwd | testCryptoKit.swift:144:32:144:32 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:144:32:144:32 | passwd | password (passwd) |
+| testCryptoKit.swift:153:32:153:32 | passwd | testCryptoKit.swift:153:32:153:32 | passwd | testCryptoKit.swift:153:32:153:32 | passwd | Insecure hashing algorithm (SHA256) depends on $@. | testCryptoKit.swift:153:32:153:32 | passwd | password (passwd) |
+| testCryptoKit.swift:162:32:162:32 | passwd | testCryptoKit.swift:162:32:162:32 | passwd | testCryptoKit.swift:162:32:162:32 | passwd | Insecure hashing algorithm (SHA384) depends on $@. | testCryptoKit.swift:162:32:162:32 | passwd | password (passwd) |
+| testCryptoKit.swift:171:32:171:32 | passwd | testCryptoKit.swift:171:32:171:32 | passwd | testCryptoKit.swift:171:32:171:32 | passwd | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:171:32:171:32 | passwd | password (passwd) |
 | testCryptoSwift.swift:154:30:154:30 | passwdArray | testCryptoSwift.swift:154:30:154:30 | passwdArray | testCryptoSwift.swift:154:30:154:30 | passwdArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:154:30:154:30 | passwdArray | password (passwdArray) |
 | testCryptoSwift.swift:157:31:157:31 | passwdArray | testCryptoSwift.swift:157:31:157:31 | passwdArray | testCryptoSwift.swift:157:31:157:31 | passwdArray | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:157:31:157:31 | passwdArray | password (passwdArray) |
 | testCryptoSwift.swift:160:47:160:47 | passwdArray | testCryptoSwift.swift:160:47:160:47 | passwdArray | testCryptoSwift.swift:160:47:160:47 | passwdArray | Insecure hashing algorithm (SHA2) depends on $@. | testCryptoSwift.swift:160:47:160:47 | passwdArray | password (passwdArray) |

--- a/swift/ql/test/query-tests/Security/CWE-328/WeakPasswordHashing.qlref
+++ b/swift/ql/test/query-tests/Security/CWE-328/WeakPasswordHashing.qlref
@@ -1,0 +1,1 @@
+queries/Security/CWE-328/WeakPasswordHashing.ql

--- a/swift/ql/test/query-tests/Security/CWE-328/WeakSensitiveDataHashing.expected
+++ b/swift/ql/test/query-tests/Security/CWE-328/WeakSensitiveDataHashing.expected
@@ -3,7 +3,6 @@ nodes
 | testCryptoKit.swift:57:43:57:43 | cert | semmle.label | cert |
 | testCryptoKit.swift:59:43:59:43 | account_no | semmle.label | account_no |
 | testCryptoKit.swift:60:43:60:43 | credit_card_no | semmle.label | credit_card_no |
-| testCryptoKit.swift:61:43:61:43 | credit_card_no | semmle.label | credit_card_no |
 | testCryptoKit.swift:64:44:64:44 | cert | semmle.label | cert |
 | testCryptoKit.swift:66:44:66:44 | account_no | semmle.label | account_no |
 | testCryptoKit.swift:67:44:67:44 | credit_card_no | semmle.label | credit_card_no |
@@ -13,12 +12,12 @@ nodes
 | testCryptoKit.swift:100:23:100:23 | cert | semmle.label | cert |
 | testCryptoKit.swift:102:23:102:23 | account_no | semmle.label | account_no |
 | testCryptoKit.swift:103:23:103:23 | credit_card_no | semmle.label | credit_card_no |
-| testCryptoKit.swift:133:32:133:32 | cert | semmle.label | cert |
-| testCryptoKit.swift:135:32:135:32 | account_no | semmle.label | account_no |
-| testCryptoKit.swift:136:32:136:32 | credit_card_no | semmle.label | credit_card_no |
-| testCryptoKit.swift:142:32:142:32 | cert | semmle.label | cert |
-| testCryptoKit.swift:144:32:144:32 | account_no | semmle.label | account_no |
-| testCryptoKit.swift:145:32:145:32 | credit_card_no | semmle.label | credit_card_no |
+| testCryptoKit.swift:136:32:136:32 | cert | semmle.label | cert |
+| testCryptoKit.swift:138:32:138:32 | account_no | semmle.label | account_no |
+| testCryptoKit.swift:139:32:139:32 | credit_card_no | semmle.label | credit_card_no |
+| testCryptoKit.swift:145:32:145:32 | cert | semmle.label | cert |
+| testCryptoKit.swift:147:32:147:32 | account_no | semmle.label | account_no |
+| testCryptoKit.swift:148:32:148:32 | credit_card_no | semmle.label | credit_card_no |
 | testCryptoSwift.swift:153:30:153:30 | phoneNumberArray | semmle.label | phoneNumberArray |
 | testCryptoSwift.swift:156:31:156:31 | phoneNumberArray | semmle.label | phoneNumberArray |
 | testCryptoSwift.swift:166:20:166:20 | phoneNumberArray | semmle.label | phoneNumberArray |
@@ -34,7 +33,6 @@ subpaths
 | testCryptoKit.swift:57:43:57:43 | cert | testCryptoKit.swift:57:43:57:43 | cert | testCryptoKit.swift:57:43:57:43 | cert | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:57:43:57:43 | cert | sensitive data (credential cert) |
 | testCryptoKit.swift:59:43:59:43 | account_no | testCryptoKit.swift:59:43:59:43 | account_no | testCryptoKit.swift:59:43:59:43 | account_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:59:43:59:43 | account_no | sensitive data (private information account_no) |
 | testCryptoKit.swift:60:43:60:43 | credit_card_no | testCryptoKit.swift:60:43:60:43 | credit_card_no | testCryptoKit.swift:60:43:60:43 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:60:43:60:43 | credit_card_no | sensitive data (private information credit_card_no) |
-| testCryptoKit.swift:61:43:61:43 | credit_card_no | testCryptoKit.swift:61:43:61:43 | credit_card_no | testCryptoKit.swift:61:43:61:43 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:61:43:61:43 | credit_card_no | sensitive data (private information credit_card_no) |
 | testCryptoKit.swift:64:44:64:44 | cert | testCryptoKit.swift:64:44:64:44 | cert | testCryptoKit.swift:64:44:64:44 | cert | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:64:44:64:44 | cert | sensitive data (credential cert) |
 | testCryptoKit.swift:66:44:66:44 | account_no | testCryptoKit.swift:66:44:66:44 | account_no | testCryptoKit.swift:66:44:66:44 | account_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:66:44:66:44 | account_no | sensitive data (private information account_no) |
 | testCryptoKit.swift:67:44:67:44 | credit_card_no | testCryptoKit.swift:67:44:67:44 | credit_card_no | testCryptoKit.swift:67:44:67:44 | credit_card_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:67:44:67:44 | credit_card_no | sensitive data (private information credit_card_no) |
@@ -44,12 +42,12 @@ subpaths
 | testCryptoKit.swift:100:23:100:23 | cert | testCryptoKit.swift:100:23:100:23 | cert | testCryptoKit.swift:100:23:100:23 | cert | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:100:23:100:23 | cert | sensitive data (credential cert) |
 | testCryptoKit.swift:102:23:102:23 | account_no | testCryptoKit.swift:102:23:102:23 | account_no | testCryptoKit.swift:102:23:102:23 | account_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:102:23:102:23 | account_no | sensitive data (private information account_no) |
 | testCryptoKit.swift:103:23:103:23 | credit_card_no | testCryptoKit.swift:103:23:103:23 | credit_card_no | testCryptoKit.swift:103:23:103:23 | credit_card_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:103:23:103:23 | credit_card_no | sensitive data (private information credit_card_no) |
-| testCryptoKit.swift:133:32:133:32 | cert | testCryptoKit.swift:133:32:133:32 | cert | testCryptoKit.swift:133:32:133:32 | cert | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:133:32:133:32 | cert | sensitive data (credential cert) |
-| testCryptoKit.swift:135:32:135:32 | account_no | testCryptoKit.swift:135:32:135:32 | account_no | testCryptoKit.swift:135:32:135:32 | account_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:135:32:135:32 | account_no | sensitive data (private information account_no) |
-| testCryptoKit.swift:136:32:136:32 | credit_card_no | testCryptoKit.swift:136:32:136:32 | credit_card_no | testCryptoKit.swift:136:32:136:32 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:136:32:136:32 | credit_card_no | sensitive data (private information credit_card_no) |
-| testCryptoKit.swift:142:32:142:32 | cert | testCryptoKit.swift:142:32:142:32 | cert | testCryptoKit.swift:142:32:142:32 | cert | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:142:32:142:32 | cert | sensitive data (credential cert) |
-| testCryptoKit.swift:144:32:144:32 | account_no | testCryptoKit.swift:144:32:144:32 | account_no | testCryptoKit.swift:144:32:144:32 | account_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:144:32:144:32 | account_no | sensitive data (private information account_no) |
-| testCryptoKit.swift:145:32:145:32 | credit_card_no | testCryptoKit.swift:145:32:145:32 | credit_card_no | testCryptoKit.swift:145:32:145:32 | credit_card_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:145:32:145:32 | credit_card_no | sensitive data (private information credit_card_no) |
+| testCryptoKit.swift:136:32:136:32 | cert | testCryptoKit.swift:136:32:136:32 | cert | testCryptoKit.swift:136:32:136:32 | cert | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:136:32:136:32 | cert | sensitive data (credential cert) |
+| testCryptoKit.swift:138:32:138:32 | account_no | testCryptoKit.swift:138:32:138:32 | account_no | testCryptoKit.swift:138:32:138:32 | account_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:138:32:138:32 | account_no | sensitive data (private information account_no) |
+| testCryptoKit.swift:139:32:139:32 | credit_card_no | testCryptoKit.swift:139:32:139:32 | credit_card_no | testCryptoKit.swift:139:32:139:32 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:139:32:139:32 | credit_card_no | sensitive data (private information credit_card_no) |
+| testCryptoKit.swift:145:32:145:32 | cert | testCryptoKit.swift:145:32:145:32 | cert | testCryptoKit.swift:145:32:145:32 | cert | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:145:32:145:32 | cert | sensitive data (credential cert) |
+| testCryptoKit.swift:147:32:147:32 | account_no | testCryptoKit.swift:147:32:147:32 | account_no | testCryptoKit.swift:147:32:147:32 | account_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:147:32:147:32 | account_no | sensitive data (private information account_no) |
+| testCryptoKit.swift:148:32:148:32 | credit_card_no | testCryptoKit.swift:148:32:148:32 | credit_card_no | testCryptoKit.swift:148:32:148:32 | credit_card_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:148:32:148:32 | credit_card_no | sensitive data (private information credit_card_no) |
 | testCryptoSwift.swift:153:30:153:30 | phoneNumberArray | testCryptoSwift.swift:153:30:153:30 | phoneNumberArray | testCryptoSwift.swift:153:30:153:30 | phoneNumberArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:153:30:153:30 | phoneNumberArray | sensitive data (private information phoneNumberArray) |
 | testCryptoSwift.swift:156:31:156:31 | phoneNumberArray | testCryptoSwift.swift:156:31:156:31 | phoneNumberArray | testCryptoSwift.swift:156:31:156:31 | phoneNumberArray | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:156:31:156:31 | phoneNumberArray | sensitive data (private information phoneNumberArray) |
 | testCryptoSwift.swift:166:20:166:20 | phoneNumberArray | testCryptoSwift.swift:166:20:166:20 | phoneNumberArray | testCryptoSwift.swift:166:20:166:20 | phoneNumberArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:166:20:166:20 | phoneNumberArray | sensitive data (private information phoneNumberArray) |

--- a/swift/ql/test/query-tests/Security/CWE-328/WeakSensitiveDataHashing.expected
+++ b/swift/ql/test/query-tests/Security/CWE-328/WeakSensitiveDataHashing.expected
@@ -19,6 +19,10 @@ nodes
 | testCryptoKit.swift:142:32:142:32 | cert | semmle.label | cert |
 | testCryptoKit.swift:144:32:144:32 | account_no | semmle.label | account_no |
 | testCryptoKit.swift:145:32:145:32 | credit_card_no | semmle.label | credit_card_no |
+| testCryptoSwift.swift:200:9:200:9 | medicalData | semmle.label | medicalData |
+| testCryptoSwift.swift:203:9:203:9 | medicalData | semmle.label | medicalData |
+| testCryptoSwift.swift:218:9:218:9 | creditCardNumber | semmle.label | creditCardNumber |
+| testCryptoSwift.swift:221:9:221:9 | creditCardNumber | semmle.label | creditCardNumber |
 subpaths
 #select
 | testCryptoKit.swift:57:43:57:43 | cert | testCryptoKit.swift:57:43:57:43 | cert | testCryptoKit.swift:57:43:57:43 | cert | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:57:43:57:43 | cert | sensitive data (credential cert) |
@@ -40,3 +44,7 @@ subpaths
 | testCryptoKit.swift:142:32:142:32 | cert | testCryptoKit.swift:142:32:142:32 | cert | testCryptoKit.swift:142:32:142:32 | cert | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:142:32:142:32 | cert | sensitive data (credential cert) |
 | testCryptoKit.swift:144:32:144:32 | account_no | testCryptoKit.swift:144:32:144:32 | account_no | testCryptoKit.swift:144:32:144:32 | account_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:144:32:144:32 | account_no | sensitive data (private information account_no) |
 | testCryptoKit.swift:145:32:145:32 | credit_card_no | testCryptoKit.swift:145:32:145:32 | credit_card_no | testCryptoKit.swift:145:32:145:32 | credit_card_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:145:32:145:32 | credit_card_no | sensitive data (private information credit_card_no) |
+| testCryptoSwift.swift:200:9:200:9 | medicalData | testCryptoSwift.swift:200:9:200:9 | medicalData | testCryptoSwift.swift:200:9:200:9 | medicalData | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:200:9:200:9 | medicalData | sensitive data (private information medicalData) |
+| testCryptoSwift.swift:203:9:203:9 | medicalData | testCryptoSwift.swift:203:9:203:9 | medicalData | testCryptoSwift.swift:203:9:203:9 | medicalData | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:203:9:203:9 | medicalData | sensitive data (private information medicalData) |
+| testCryptoSwift.swift:218:9:218:9 | creditCardNumber | testCryptoSwift.swift:218:9:218:9 | creditCardNumber | testCryptoSwift.swift:218:9:218:9 | creditCardNumber | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:218:9:218:9 | creditCardNumber | sensitive data (private information creditCardNumber) |
+| testCryptoSwift.swift:221:9:221:9 | creditCardNumber | testCryptoSwift.swift:221:9:221:9 | creditCardNumber | testCryptoSwift.swift:221:9:221:9 | creditCardNumber | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:221:9:221:9 | creditCardNumber | sensitive data (private information creditCardNumber) |

--- a/swift/ql/test/query-tests/Security/CWE-328/WeakSensitiveDataHashing.expected
+++ b/swift/ql/test/query-tests/Security/CWE-328/WeakSensitiveDataHashing.expected
@@ -1,74 +1,42 @@
 edges
 nodes
-| testCryptoKit.swift:56:47:56:47 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:57:43:57:43 | cert | semmle.label | cert |
 | testCryptoKit.swift:59:43:59:43 | account_no | semmle.label | account_no |
 | testCryptoKit.swift:60:43:60:43 | credit_card_no | semmle.label | credit_card_no |
 | testCryptoKit.swift:61:43:61:43 | credit_card_no | semmle.label | credit_card_no |
-| testCryptoKit.swift:63:44:63:44 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:64:44:64:44 | cert | semmle.label | cert |
 | testCryptoKit.swift:66:44:66:44 | account_no | semmle.label | account_no |
 | testCryptoKit.swift:67:44:67:44 | credit_card_no | semmle.label | credit_card_no |
-| testCryptoKit.swift:90:23:90:23 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:91:23:91:23 | cert | semmle.label | cert |
 | testCryptoKit.swift:93:23:93:23 | account_no | semmle.label | account_no |
 | testCryptoKit.swift:94:23:94:23 | credit_card_no | semmle.label | credit_card_no |
-| testCryptoKit.swift:99:23:99:23 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:100:23:100:23 | cert | semmle.label | cert |
 | testCryptoKit.swift:102:23:102:23 | account_no | semmle.label | account_no |
 | testCryptoKit.swift:103:23:103:23 | credit_card_no | semmle.label | credit_card_no |
-| testCryptoKit.swift:132:32:132:32 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:133:32:133:32 | cert | semmle.label | cert |
 | testCryptoKit.swift:135:32:135:32 | account_no | semmle.label | account_no |
 | testCryptoKit.swift:136:32:136:32 | credit_card_no | semmle.label | credit_card_no |
-| testCryptoKit.swift:141:32:141:32 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:142:32:142:32 | cert | semmle.label | cert |
 | testCryptoKit.swift:144:32:144:32 | account_no | semmle.label | account_no |
 | testCryptoKit.swift:145:32:145:32 | credit_card_no | semmle.label | credit_card_no |
-| testCryptoSwift.swift:113:30:113:30 | passwdArray | semmle.label | passwdArray |
-| testCryptoSwift.swift:115:31:115:31 | passwdArray | semmle.label | passwdArray |
-| testCryptoSwift.swift:120:20:120:20 | passwdArray | semmle.label | passwdArray |
-| testCryptoSwift.swift:122:21:122:21 | passwdArray | semmle.label | passwdArray |
-| testCryptoSwift.swift:127:9:127:9 | passwdArray | semmle.label | passwdArray |
-| testCryptoSwift.swift:129:9:129:9 | passwdArray | semmle.label | passwdArray |
-| testCryptoSwift.swift:136:9:136:9 | passwdData | semmle.label | passwdData |
-| testCryptoSwift.swift:138:9:138:9 | passwdData | semmle.label | passwdData |
-| testCryptoSwift.swift:145:9:145:9 | passwd | semmle.label | passwd |
-| testCryptoSwift.swift:147:9:147:9 | passwd | semmle.label | passwd |
 subpaths
 #select
-| testCryptoKit.swift:56:47:56:47 | passwd | testCryptoKit.swift:56:47:56:47 | passwd | testCryptoKit.swift:56:47:56:47 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:56:47:56:47 | passwd | sensitive data (credential passwd) |
 | testCryptoKit.swift:57:43:57:43 | cert | testCryptoKit.swift:57:43:57:43 | cert | testCryptoKit.swift:57:43:57:43 | cert | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:57:43:57:43 | cert | sensitive data (credential cert) |
 | testCryptoKit.swift:59:43:59:43 | account_no | testCryptoKit.swift:59:43:59:43 | account_no | testCryptoKit.swift:59:43:59:43 | account_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:59:43:59:43 | account_no | sensitive data (private information account_no) |
 | testCryptoKit.swift:60:43:60:43 | credit_card_no | testCryptoKit.swift:60:43:60:43 | credit_card_no | testCryptoKit.swift:60:43:60:43 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:60:43:60:43 | credit_card_no | sensitive data (private information credit_card_no) |
 | testCryptoKit.swift:61:43:61:43 | credit_card_no | testCryptoKit.swift:61:43:61:43 | credit_card_no | testCryptoKit.swift:61:43:61:43 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:61:43:61:43 | credit_card_no | sensitive data (private information credit_card_no) |
-| testCryptoKit.swift:63:44:63:44 | passwd | testCryptoKit.swift:63:44:63:44 | passwd | testCryptoKit.swift:63:44:63:44 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:63:44:63:44 | passwd | sensitive data (credential passwd) |
 | testCryptoKit.swift:64:44:64:44 | cert | testCryptoKit.swift:64:44:64:44 | cert | testCryptoKit.swift:64:44:64:44 | cert | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:64:44:64:44 | cert | sensitive data (credential cert) |
 | testCryptoKit.swift:66:44:66:44 | account_no | testCryptoKit.swift:66:44:66:44 | account_no | testCryptoKit.swift:66:44:66:44 | account_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:66:44:66:44 | account_no | sensitive data (private information account_no) |
 | testCryptoKit.swift:67:44:67:44 | credit_card_no | testCryptoKit.swift:67:44:67:44 | credit_card_no | testCryptoKit.swift:67:44:67:44 | credit_card_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:67:44:67:44 | credit_card_no | sensitive data (private information credit_card_no) |
-| testCryptoKit.swift:90:23:90:23 | passwd | testCryptoKit.swift:90:23:90:23 | passwd | testCryptoKit.swift:90:23:90:23 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:90:23:90:23 | passwd | sensitive data (credential passwd) |
 | testCryptoKit.swift:91:23:91:23 | cert | testCryptoKit.swift:91:23:91:23 | cert | testCryptoKit.swift:91:23:91:23 | cert | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:91:23:91:23 | cert | sensitive data (credential cert) |
 | testCryptoKit.swift:93:23:93:23 | account_no | testCryptoKit.swift:93:23:93:23 | account_no | testCryptoKit.swift:93:23:93:23 | account_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:93:23:93:23 | account_no | sensitive data (private information account_no) |
 | testCryptoKit.swift:94:23:94:23 | credit_card_no | testCryptoKit.swift:94:23:94:23 | credit_card_no | testCryptoKit.swift:94:23:94:23 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:94:23:94:23 | credit_card_no | sensitive data (private information credit_card_no) |
-| testCryptoKit.swift:99:23:99:23 | passwd | testCryptoKit.swift:99:23:99:23 | passwd | testCryptoKit.swift:99:23:99:23 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:99:23:99:23 | passwd | sensitive data (credential passwd) |
 | testCryptoKit.swift:100:23:100:23 | cert | testCryptoKit.swift:100:23:100:23 | cert | testCryptoKit.swift:100:23:100:23 | cert | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:100:23:100:23 | cert | sensitive data (credential cert) |
 | testCryptoKit.swift:102:23:102:23 | account_no | testCryptoKit.swift:102:23:102:23 | account_no | testCryptoKit.swift:102:23:102:23 | account_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:102:23:102:23 | account_no | sensitive data (private information account_no) |
 | testCryptoKit.swift:103:23:103:23 | credit_card_no | testCryptoKit.swift:103:23:103:23 | credit_card_no | testCryptoKit.swift:103:23:103:23 | credit_card_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:103:23:103:23 | credit_card_no | sensitive data (private information credit_card_no) |
-| testCryptoKit.swift:132:32:132:32 | passwd | testCryptoKit.swift:132:32:132:32 | passwd | testCryptoKit.swift:132:32:132:32 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:132:32:132:32 | passwd | sensitive data (credential passwd) |
 | testCryptoKit.swift:133:32:133:32 | cert | testCryptoKit.swift:133:32:133:32 | cert | testCryptoKit.swift:133:32:133:32 | cert | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:133:32:133:32 | cert | sensitive data (credential cert) |
 | testCryptoKit.swift:135:32:135:32 | account_no | testCryptoKit.swift:135:32:135:32 | account_no | testCryptoKit.swift:135:32:135:32 | account_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:135:32:135:32 | account_no | sensitive data (private information account_no) |
 | testCryptoKit.swift:136:32:136:32 | credit_card_no | testCryptoKit.swift:136:32:136:32 | credit_card_no | testCryptoKit.swift:136:32:136:32 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:136:32:136:32 | credit_card_no | sensitive data (private information credit_card_no) |
-| testCryptoKit.swift:141:32:141:32 | passwd | testCryptoKit.swift:141:32:141:32 | passwd | testCryptoKit.swift:141:32:141:32 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:141:32:141:32 | passwd | sensitive data (credential passwd) |
 | testCryptoKit.swift:142:32:142:32 | cert | testCryptoKit.swift:142:32:142:32 | cert | testCryptoKit.swift:142:32:142:32 | cert | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:142:32:142:32 | cert | sensitive data (credential cert) |
 | testCryptoKit.swift:144:32:144:32 | account_no | testCryptoKit.swift:144:32:144:32 | account_no | testCryptoKit.swift:144:32:144:32 | account_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:144:32:144:32 | account_no | sensitive data (private information account_no) |
 | testCryptoKit.swift:145:32:145:32 | credit_card_no | testCryptoKit.swift:145:32:145:32 | credit_card_no | testCryptoKit.swift:145:32:145:32 | credit_card_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:145:32:145:32 | credit_card_no | sensitive data (private information credit_card_no) |
-| testCryptoSwift.swift:113:30:113:30 | passwdArray | testCryptoSwift.swift:113:30:113:30 | passwdArray | testCryptoSwift.swift:113:30:113:30 | passwdArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:113:30:113:30 | passwdArray | sensitive data (credential passwdArray) |
-| testCryptoSwift.swift:115:31:115:31 | passwdArray | testCryptoSwift.swift:115:31:115:31 | passwdArray | testCryptoSwift.swift:115:31:115:31 | passwdArray | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:115:31:115:31 | passwdArray | sensitive data (credential passwdArray) |
-| testCryptoSwift.swift:120:20:120:20 | passwdArray | testCryptoSwift.swift:120:20:120:20 | passwdArray | testCryptoSwift.swift:120:20:120:20 | passwdArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:120:20:120:20 | passwdArray | sensitive data (credential passwdArray) |
-| testCryptoSwift.swift:122:21:122:21 | passwdArray | testCryptoSwift.swift:122:21:122:21 | passwdArray | testCryptoSwift.swift:122:21:122:21 | passwdArray | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:122:21:122:21 | passwdArray | sensitive data (credential passwdArray) |
-| testCryptoSwift.swift:127:9:127:9 | passwdArray | testCryptoSwift.swift:127:9:127:9 | passwdArray | testCryptoSwift.swift:127:9:127:9 | passwdArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:127:9:127:9 | passwdArray | sensitive data (credential passwdArray) |
-| testCryptoSwift.swift:129:9:129:9 | passwdArray | testCryptoSwift.swift:129:9:129:9 | passwdArray | testCryptoSwift.swift:129:9:129:9 | passwdArray | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:129:9:129:9 | passwdArray | sensitive data (credential passwdArray) |
-| testCryptoSwift.swift:136:9:136:9 | passwdData | testCryptoSwift.swift:136:9:136:9 | passwdData | testCryptoSwift.swift:136:9:136:9 | passwdData | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:136:9:136:9 | passwdData | sensitive data (credential passwdData) |
-| testCryptoSwift.swift:138:9:138:9 | passwdData | testCryptoSwift.swift:138:9:138:9 | passwdData | testCryptoSwift.swift:138:9:138:9 | passwdData | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:138:9:138:9 | passwdData | sensitive data (credential passwdData) |
-| testCryptoSwift.swift:145:9:145:9 | passwd | testCryptoSwift.swift:145:9:145:9 | passwd | testCryptoSwift.swift:145:9:145:9 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:145:9:145:9 | passwd | sensitive data (credential passwd) |
-| testCryptoSwift.swift:147:9:147:9 | passwd | testCryptoSwift.swift:147:9:147:9 | passwd | testCryptoSwift.swift:147:9:147:9 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:147:9:147:9 | passwd | sensitive data (credential passwd) |

--- a/swift/ql/test/query-tests/Security/CWE-328/WeakSensitiveDataHashing.expected
+++ b/swift/ql/test/query-tests/Security/CWE-328/WeakSensitiveDataHashing.expected
@@ -1,23 +1,23 @@
 edges
 nodes
-| testCryptoKit.swift:57:43:57:43 | cert | semmle.label | cert |
-| testCryptoKit.swift:59:43:59:43 | account_no | semmle.label | account_no |
-| testCryptoKit.swift:60:43:60:43 | credit_card_no | semmle.label | credit_card_no |
-| testCryptoKit.swift:64:44:64:44 | cert | semmle.label | cert |
-| testCryptoKit.swift:66:44:66:44 | account_no | semmle.label | account_no |
-| testCryptoKit.swift:67:44:67:44 | credit_card_no | semmle.label | credit_card_no |
-| testCryptoKit.swift:91:23:91:23 | cert | semmle.label | cert |
-| testCryptoKit.swift:93:23:93:23 | account_no | semmle.label | account_no |
-| testCryptoKit.swift:94:23:94:23 | credit_card_no | semmle.label | credit_card_no |
-| testCryptoKit.swift:100:23:100:23 | cert | semmle.label | cert |
-| testCryptoKit.swift:102:23:102:23 | account_no | semmle.label | account_no |
-| testCryptoKit.swift:103:23:103:23 | credit_card_no | semmle.label | credit_card_no |
-| testCryptoKit.swift:136:32:136:32 | cert | semmle.label | cert |
-| testCryptoKit.swift:138:32:138:32 | account_no | semmle.label | account_no |
-| testCryptoKit.swift:139:32:139:32 | credit_card_no | semmle.label | credit_card_no |
-| testCryptoKit.swift:145:32:145:32 | cert | semmle.label | cert |
-| testCryptoKit.swift:147:32:147:32 | account_no | semmle.label | account_no |
-| testCryptoKit.swift:148:32:148:32 | credit_card_no | semmle.label | credit_card_no |
+| testCryptoKit.swift:66:43:66:43 | cert | semmle.label | cert |
+| testCryptoKit.swift:68:43:68:43 | account_no | semmle.label | account_no |
+| testCryptoKit.swift:69:43:69:43 | credit_card_no | semmle.label | credit_card_no |
+| testCryptoKit.swift:72:44:72:44 | cert | semmle.label | cert |
+| testCryptoKit.swift:74:44:74:44 | account_no | semmle.label | account_no |
+| testCryptoKit.swift:75:44:75:44 | credit_card_no | semmle.label | credit_card_no |
+| testCryptoKit.swift:99:23:99:23 | cert | semmle.label | cert |
+| testCryptoKit.swift:101:23:101:23 | account_no | semmle.label | account_no |
+| testCryptoKit.swift:102:23:102:23 | credit_card_no | semmle.label | credit_card_no |
+| testCryptoKit.swift:108:23:108:23 | cert | semmle.label | cert |
+| testCryptoKit.swift:110:23:110:23 | account_no | semmle.label | account_no |
+| testCryptoKit.swift:111:23:111:23 | credit_card_no | semmle.label | credit_card_no |
+| testCryptoKit.swift:144:32:144:32 | cert | semmle.label | cert |
+| testCryptoKit.swift:146:32:146:32 | account_no | semmle.label | account_no |
+| testCryptoKit.swift:147:32:147:32 | credit_card_no | semmle.label | credit_card_no |
+| testCryptoKit.swift:153:32:153:32 | cert | semmle.label | cert |
+| testCryptoKit.swift:155:32:155:32 | account_no | semmle.label | account_no |
+| testCryptoKit.swift:156:32:156:32 | credit_card_no | semmle.label | credit_card_no |
 | testCryptoSwift.swift:153:30:153:30 | phoneNumberArray | semmle.label | phoneNumberArray |
 | testCryptoSwift.swift:156:31:156:31 | phoneNumberArray | semmle.label | phoneNumberArray |
 | testCryptoSwift.swift:166:20:166:20 | phoneNumberArray | semmle.label | phoneNumberArray |
@@ -30,24 +30,24 @@ nodes
 | testCryptoSwift.swift:221:9:221:9 | creditCardNumber | semmle.label | creditCardNumber |
 subpaths
 #select
-| testCryptoKit.swift:57:43:57:43 | cert | testCryptoKit.swift:57:43:57:43 | cert | testCryptoKit.swift:57:43:57:43 | cert | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:57:43:57:43 | cert | sensitive data (credential cert) |
-| testCryptoKit.swift:59:43:59:43 | account_no | testCryptoKit.swift:59:43:59:43 | account_no | testCryptoKit.swift:59:43:59:43 | account_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:59:43:59:43 | account_no | sensitive data (private information account_no) |
-| testCryptoKit.swift:60:43:60:43 | credit_card_no | testCryptoKit.swift:60:43:60:43 | credit_card_no | testCryptoKit.swift:60:43:60:43 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:60:43:60:43 | credit_card_no | sensitive data (private information credit_card_no) |
-| testCryptoKit.swift:64:44:64:44 | cert | testCryptoKit.swift:64:44:64:44 | cert | testCryptoKit.swift:64:44:64:44 | cert | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:64:44:64:44 | cert | sensitive data (credential cert) |
-| testCryptoKit.swift:66:44:66:44 | account_no | testCryptoKit.swift:66:44:66:44 | account_no | testCryptoKit.swift:66:44:66:44 | account_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:66:44:66:44 | account_no | sensitive data (private information account_no) |
-| testCryptoKit.swift:67:44:67:44 | credit_card_no | testCryptoKit.swift:67:44:67:44 | credit_card_no | testCryptoKit.swift:67:44:67:44 | credit_card_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:67:44:67:44 | credit_card_no | sensitive data (private information credit_card_no) |
-| testCryptoKit.swift:91:23:91:23 | cert | testCryptoKit.swift:91:23:91:23 | cert | testCryptoKit.swift:91:23:91:23 | cert | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:91:23:91:23 | cert | sensitive data (credential cert) |
-| testCryptoKit.swift:93:23:93:23 | account_no | testCryptoKit.swift:93:23:93:23 | account_no | testCryptoKit.swift:93:23:93:23 | account_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:93:23:93:23 | account_no | sensitive data (private information account_no) |
-| testCryptoKit.swift:94:23:94:23 | credit_card_no | testCryptoKit.swift:94:23:94:23 | credit_card_no | testCryptoKit.swift:94:23:94:23 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:94:23:94:23 | credit_card_no | sensitive data (private information credit_card_no) |
-| testCryptoKit.swift:100:23:100:23 | cert | testCryptoKit.swift:100:23:100:23 | cert | testCryptoKit.swift:100:23:100:23 | cert | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:100:23:100:23 | cert | sensitive data (credential cert) |
-| testCryptoKit.swift:102:23:102:23 | account_no | testCryptoKit.swift:102:23:102:23 | account_no | testCryptoKit.swift:102:23:102:23 | account_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:102:23:102:23 | account_no | sensitive data (private information account_no) |
-| testCryptoKit.swift:103:23:103:23 | credit_card_no | testCryptoKit.swift:103:23:103:23 | credit_card_no | testCryptoKit.swift:103:23:103:23 | credit_card_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:103:23:103:23 | credit_card_no | sensitive data (private information credit_card_no) |
-| testCryptoKit.swift:136:32:136:32 | cert | testCryptoKit.swift:136:32:136:32 | cert | testCryptoKit.swift:136:32:136:32 | cert | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:136:32:136:32 | cert | sensitive data (credential cert) |
-| testCryptoKit.swift:138:32:138:32 | account_no | testCryptoKit.swift:138:32:138:32 | account_no | testCryptoKit.swift:138:32:138:32 | account_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:138:32:138:32 | account_no | sensitive data (private information account_no) |
-| testCryptoKit.swift:139:32:139:32 | credit_card_no | testCryptoKit.swift:139:32:139:32 | credit_card_no | testCryptoKit.swift:139:32:139:32 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:139:32:139:32 | credit_card_no | sensitive data (private information credit_card_no) |
-| testCryptoKit.swift:145:32:145:32 | cert | testCryptoKit.swift:145:32:145:32 | cert | testCryptoKit.swift:145:32:145:32 | cert | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:145:32:145:32 | cert | sensitive data (credential cert) |
-| testCryptoKit.swift:147:32:147:32 | account_no | testCryptoKit.swift:147:32:147:32 | account_no | testCryptoKit.swift:147:32:147:32 | account_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:147:32:147:32 | account_no | sensitive data (private information account_no) |
-| testCryptoKit.swift:148:32:148:32 | credit_card_no | testCryptoKit.swift:148:32:148:32 | credit_card_no | testCryptoKit.swift:148:32:148:32 | credit_card_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:148:32:148:32 | credit_card_no | sensitive data (private information credit_card_no) |
+| testCryptoKit.swift:66:43:66:43 | cert | testCryptoKit.swift:66:43:66:43 | cert | testCryptoKit.swift:66:43:66:43 | cert | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:66:43:66:43 | cert | sensitive data (credential cert) |
+| testCryptoKit.swift:68:43:68:43 | account_no | testCryptoKit.swift:68:43:68:43 | account_no | testCryptoKit.swift:68:43:68:43 | account_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:68:43:68:43 | account_no | sensitive data (private information account_no) |
+| testCryptoKit.swift:69:43:69:43 | credit_card_no | testCryptoKit.swift:69:43:69:43 | credit_card_no | testCryptoKit.swift:69:43:69:43 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:69:43:69:43 | credit_card_no | sensitive data (private information credit_card_no) |
+| testCryptoKit.swift:72:44:72:44 | cert | testCryptoKit.swift:72:44:72:44 | cert | testCryptoKit.swift:72:44:72:44 | cert | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:72:44:72:44 | cert | sensitive data (credential cert) |
+| testCryptoKit.swift:74:44:74:44 | account_no | testCryptoKit.swift:74:44:74:44 | account_no | testCryptoKit.swift:74:44:74:44 | account_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:74:44:74:44 | account_no | sensitive data (private information account_no) |
+| testCryptoKit.swift:75:44:75:44 | credit_card_no | testCryptoKit.swift:75:44:75:44 | credit_card_no | testCryptoKit.swift:75:44:75:44 | credit_card_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:75:44:75:44 | credit_card_no | sensitive data (private information credit_card_no) |
+| testCryptoKit.swift:99:23:99:23 | cert | testCryptoKit.swift:99:23:99:23 | cert | testCryptoKit.swift:99:23:99:23 | cert | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:99:23:99:23 | cert | sensitive data (credential cert) |
+| testCryptoKit.swift:101:23:101:23 | account_no | testCryptoKit.swift:101:23:101:23 | account_no | testCryptoKit.swift:101:23:101:23 | account_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:101:23:101:23 | account_no | sensitive data (private information account_no) |
+| testCryptoKit.swift:102:23:102:23 | credit_card_no | testCryptoKit.swift:102:23:102:23 | credit_card_no | testCryptoKit.swift:102:23:102:23 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:102:23:102:23 | credit_card_no | sensitive data (private information credit_card_no) |
+| testCryptoKit.swift:108:23:108:23 | cert | testCryptoKit.swift:108:23:108:23 | cert | testCryptoKit.swift:108:23:108:23 | cert | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:108:23:108:23 | cert | sensitive data (credential cert) |
+| testCryptoKit.swift:110:23:110:23 | account_no | testCryptoKit.swift:110:23:110:23 | account_no | testCryptoKit.swift:110:23:110:23 | account_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:110:23:110:23 | account_no | sensitive data (private information account_no) |
+| testCryptoKit.swift:111:23:111:23 | credit_card_no | testCryptoKit.swift:111:23:111:23 | credit_card_no | testCryptoKit.swift:111:23:111:23 | credit_card_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:111:23:111:23 | credit_card_no | sensitive data (private information credit_card_no) |
+| testCryptoKit.swift:144:32:144:32 | cert | testCryptoKit.swift:144:32:144:32 | cert | testCryptoKit.swift:144:32:144:32 | cert | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:144:32:144:32 | cert | sensitive data (credential cert) |
+| testCryptoKit.swift:146:32:146:32 | account_no | testCryptoKit.swift:146:32:146:32 | account_no | testCryptoKit.swift:146:32:146:32 | account_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:146:32:146:32 | account_no | sensitive data (private information account_no) |
+| testCryptoKit.swift:147:32:147:32 | credit_card_no | testCryptoKit.swift:147:32:147:32 | credit_card_no | testCryptoKit.swift:147:32:147:32 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:147:32:147:32 | credit_card_no | sensitive data (private information credit_card_no) |
+| testCryptoKit.swift:153:32:153:32 | cert | testCryptoKit.swift:153:32:153:32 | cert | testCryptoKit.swift:153:32:153:32 | cert | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:153:32:153:32 | cert | sensitive data (credential cert) |
+| testCryptoKit.swift:155:32:155:32 | account_no | testCryptoKit.swift:155:32:155:32 | account_no | testCryptoKit.swift:155:32:155:32 | account_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:155:32:155:32 | account_no | sensitive data (private information account_no) |
+| testCryptoKit.swift:156:32:156:32 | credit_card_no | testCryptoKit.swift:156:32:156:32 | credit_card_no | testCryptoKit.swift:156:32:156:32 | credit_card_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:156:32:156:32 | credit_card_no | sensitive data (private information credit_card_no) |
 | testCryptoSwift.swift:153:30:153:30 | phoneNumberArray | testCryptoSwift.swift:153:30:153:30 | phoneNumberArray | testCryptoSwift.swift:153:30:153:30 | phoneNumberArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:153:30:153:30 | phoneNumberArray | sensitive data (private information phoneNumberArray) |
 | testCryptoSwift.swift:156:31:156:31 | phoneNumberArray | testCryptoSwift.swift:156:31:156:31 | phoneNumberArray | testCryptoSwift.swift:156:31:156:31 | phoneNumberArray | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:156:31:156:31 | phoneNumberArray | sensitive data (private information phoneNumberArray) |
 | testCryptoSwift.swift:166:20:166:20 | phoneNumberArray | testCryptoSwift.swift:166:20:166:20 | phoneNumberArray | testCryptoSwift.swift:166:20:166:20 | phoneNumberArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:166:20:166:20 | phoneNumberArray | sensitive data (private information phoneNumberArray) |

--- a/swift/ql/test/query-tests/Security/CWE-328/WeakSensitiveDataHashing.expected
+++ b/swift/ql/test/query-tests/Security/CWE-328/WeakSensitiveDataHashing.expected
@@ -19,6 +19,12 @@ nodes
 | testCryptoKit.swift:142:32:142:32 | cert | semmle.label | cert |
 | testCryptoKit.swift:144:32:144:32 | account_no | semmle.label | account_no |
 | testCryptoKit.swift:145:32:145:32 | credit_card_no | semmle.label | credit_card_no |
+| testCryptoSwift.swift:153:30:153:30 | phoneNumberArray | semmle.label | phoneNumberArray |
+| testCryptoSwift.swift:156:31:156:31 | phoneNumberArray | semmle.label | phoneNumberArray |
+| testCryptoSwift.swift:166:20:166:20 | phoneNumberArray | semmle.label | phoneNumberArray |
+| testCryptoSwift.swift:169:21:169:21 | phoneNumberArray | semmle.label | phoneNumberArray |
+| testCryptoSwift.swift:182:9:182:9 | phoneNumberArray | semmle.label | phoneNumberArray |
+| testCryptoSwift.swift:185:9:185:9 | phoneNumberArray | semmle.label | phoneNumberArray |
 | testCryptoSwift.swift:200:9:200:9 | medicalData | semmle.label | medicalData |
 | testCryptoSwift.swift:203:9:203:9 | medicalData | semmle.label | medicalData |
 | testCryptoSwift.swift:218:9:218:9 | creditCardNumber | semmle.label | creditCardNumber |
@@ -44,6 +50,12 @@ subpaths
 | testCryptoKit.swift:142:32:142:32 | cert | testCryptoKit.swift:142:32:142:32 | cert | testCryptoKit.swift:142:32:142:32 | cert | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:142:32:142:32 | cert | sensitive data (credential cert) |
 | testCryptoKit.swift:144:32:144:32 | account_no | testCryptoKit.swift:144:32:144:32 | account_no | testCryptoKit.swift:144:32:144:32 | account_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:144:32:144:32 | account_no | sensitive data (private information account_no) |
 | testCryptoKit.swift:145:32:145:32 | credit_card_no | testCryptoKit.swift:145:32:145:32 | credit_card_no | testCryptoKit.swift:145:32:145:32 | credit_card_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:145:32:145:32 | credit_card_no | sensitive data (private information credit_card_no) |
+| testCryptoSwift.swift:153:30:153:30 | phoneNumberArray | testCryptoSwift.swift:153:30:153:30 | phoneNumberArray | testCryptoSwift.swift:153:30:153:30 | phoneNumberArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:153:30:153:30 | phoneNumberArray | sensitive data (private information phoneNumberArray) |
+| testCryptoSwift.swift:156:31:156:31 | phoneNumberArray | testCryptoSwift.swift:156:31:156:31 | phoneNumberArray | testCryptoSwift.swift:156:31:156:31 | phoneNumberArray | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:156:31:156:31 | phoneNumberArray | sensitive data (private information phoneNumberArray) |
+| testCryptoSwift.swift:166:20:166:20 | phoneNumberArray | testCryptoSwift.swift:166:20:166:20 | phoneNumberArray | testCryptoSwift.swift:166:20:166:20 | phoneNumberArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:166:20:166:20 | phoneNumberArray | sensitive data (private information phoneNumberArray) |
+| testCryptoSwift.swift:169:21:169:21 | phoneNumberArray | testCryptoSwift.swift:169:21:169:21 | phoneNumberArray | testCryptoSwift.swift:169:21:169:21 | phoneNumberArray | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:169:21:169:21 | phoneNumberArray | sensitive data (private information phoneNumberArray) |
+| testCryptoSwift.swift:182:9:182:9 | phoneNumberArray | testCryptoSwift.swift:182:9:182:9 | phoneNumberArray | testCryptoSwift.swift:182:9:182:9 | phoneNumberArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:182:9:182:9 | phoneNumberArray | sensitive data (private information phoneNumberArray) |
+| testCryptoSwift.swift:185:9:185:9 | phoneNumberArray | testCryptoSwift.swift:185:9:185:9 | phoneNumberArray | testCryptoSwift.swift:185:9:185:9 | phoneNumberArray | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:185:9:185:9 | phoneNumberArray | sensitive data (private information phoneNumberArray) |
 | testCryptoSwift.swift:200:9:200:9 | medicalData | testCryptoSwift.swift:200:9:200:9 | medicalData | testCryptoSwift.swift:200:9:200:9 | medicalData | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:200:9:200:9 | medicalData | sensitive data (private information medicalData) |
 | testCryptoSwift.swift:203:9:203:9 | medicalData | testCryptoSwift.swift:203:9:203:9 | medicalData | testCryptoSwift.swift:203:9:203:9 | medicalData | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:203:9:203:9 | medicalData | sensitive data (private information medicalData) |
 | testCryptoSwift.swift:218:9:218:9 | creditCardNumber | testCryptoSwift.swift:218:9:218:9 | creditCardNumber | testCryptoSwift.swift:218:9:218:9 | creditCardNumber | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:218:9:218:9 | creditCardNumber | sensitive data (private information creditCardNumber) |

--- a/swift/ql/test/query-tests/Security/CWE-328/testArgon2Swift.swift
+++ b/swift/ql/test/query-tests/Security/CWE-328/testArgon2Swift.swift
@@ -1,0 +1,49 @@
+
+// --- stubs ---
+
+class Data
+{
+    init<S>(_ elements: S) {}
+}
+
+class Salt {
+	init(bytes: Data) { }
+
+    static func newSalt(length: Int = 16) -> Salt {
+        return Salt(bytes: Data(0))
+    }
+}
+
+class Argon2SwiftResult {
+	init(hashBytes: [Int8], encodedBytes: [Int8]) { }
+
+    func encodedString() -> String {
+        return ""
+    }
+}
+
+class Argon2Swift {
+	// slightly simplified (type and version changed to Int)
+	static func hashPasswordString(password: String, salt: Salt, iterations: Int = 32, memory: Int = 256, parallelism: Int = 2, length: Int = 32, type: Int = 1, version: Int = 13) throws -> Argon2SwiftResult {
+		return Argon2SwiftResult(hashBytes: [], encodedBytes: [])
+	}
+
+	static func verifyHashString(password: String, hash: String, type: Int = 1) throws -> Bool {
+		return false
+	}
+}
+
+// --- tests ---
+
+func testGoodExample(passwordString: String) {
+    // this is the "good" example from the .qhelp
+    let salt = Salt.newSalt()
+    let result = try! Argon2Swift.hashPasswordString(password: passwordString, salt: salt) // GOOD (suitable password hash)
+    let passwordHash = result.encodedString()
+
+    // ...
+
+    if try! Argon2Swift.verifyHashString(password: passwordString, hash: passwordHash) {
+	    // ...
+    }
+}

--- a/swift/ql/test/query-tests/Security/CWE-328/testCryptoKit.swift
+++ b/swift/ql/test/query-tests/Security/CWE-328/testCryptoKit.swift
@@ -1,5 +1,12 @@
 //codeql-extractor-options: -module-name Crypto
 
+// --- stubs ---
+
+class Data
+{
+    init<S>(_ elements: S) {}
+}
+
 struct SHA256 {
     static func hash<D>(data: D) -> [UInt8] {
         return []
@@ -52,13 +59,14 @@ enum Insecure {
     }
 }
 
+// --- tests ---
+
 func testHashMethods(passwd : UnsafeRawBufferPointer, cert: String, encrypted_passwd : String, account_no : String, credit_card_no : String) {
     var hash = Crypto.Insecure.MD5.hash(data: passwd)  // BAD
     hash = Crypto.Insecure.MD5.hash(data: cert)   // BAD
     hash = Crypto.Insecure.MD5.hash(data: encrypted_passwd)  // GOOD  (not sensitive)
     hash = Crypto.Insecure.MD5.hash(data: account_no)   // BAD
     hash = Crypto.Insecure.MD5.hash(data: credit_card_no)   // BAD
-
 
     hash = Crypto.Insecure.SHA1.hash(data: passwd)  // BAD
     hash = Crypto.Insecure.SHA1.hash(data: cert)   // BAD
@@ -173,4 +181,16 @@ func testSHA512UpdateWithUnsafeRawBufferPointer(passwd : UnsafeRawBufferPointer,
     hash.update(bufferPointer: encrypted_passwd)  // GOOD  (not sensitive)
     hash.update(bufferPointer: account_no)   // GOOD
     hash.update(bufferPointer: credit_card_no)   // GOOD
+}
+
+func tesBadExample(passwordString: String) {
+    // this is the "bad" example from the .qhelp
+    let passwordData = Data(passwordString.utf8)
+    let passwordHash = Crypto.SHA512.hash(data: passwordData) // BAD, not a computationally expensive hash
+
+    // ...
+
+    if Crypto.SHA512.hash(data: Data(passwordString.utf8)) == passwordHash { // BAD, not a computationally expensive hash
+	    // ...
+    }
 }

--- a/swift/ql/test/query-tests/Security/CWE-328/testCryptoKit.swift
+++ b/swift/ql/test/query-tests/Security/CWE-328/testCryptoKit.swift
@@ -58,7 +58,7 @@ func testHashMethods(passwd : UnsafeRawBufferPointer, cert: String, encrypted_pa
     hash = Crypto.Insecure.MD5.hash(data: encrypted_passwd)  // GOOD  (not sensitive)
     hash = Crypto.Insecure.MD5.hash(data: account_no)   // BAD
     hash = Crypto.Insecure.MD5.hash(data: credit_card_no)   // BAD
-    hash = Crypto.Insecure.MD5.hash(data: credit_card_no)   // BAD
+
 
     hash = Crypto.Insecure.SHA1.hash(data: passwd)  // BAD
     hash = Crypto.Insecure.SHA1.hash(data: cert)   // BAD
@@ -68,20 +68,20 @@ func testHashMethods(passwd : UnsafeRawBufferPointer, cert: String, encrypted_pa
 
     hash = Crypto.SHA256.hash(data: passwd)   // BAD, not a computationally expensive hash
     hash = Crypto.SHA256.hash(data: cert)   // GOOD, computationally expensive hash not required
+    hash = Crypto.SHA256.hash(data: encrypted_passwd)   // GOOD, not sensitive
     hash = Crypto.SHA256.hash(data: account_no)   // GOOD, computationally expensive hash not required
-    hash = Crypto.SHA256.hash(data: credit_card_no)   // GOOD, computationally expensive hash not required
     hash = Crypto.SHA256.hash(data: credit_card_no)   // GOOD, computationally expensive hash not required
 
     hash = Crypto.SHA384.hash(data: passwd)   // BAD, not a computationally expensive hash
     hash = Crypto.SHA384.hash(data: cert)   // GOOD, computationally expensive hash not required
+    hash = Crypto.SHA384.hash(data: encrypted_passwd)   // GOOD, not sensitive
     hash = Crypto.SHA384.hash(data: account_no)   // GOOD, computationally expensive hash not required
-    hash = Crypto.SHA384.hash(data: credit_card_no)   // GOOD, computationally expensive hash not required
     hash = Crypto.SHA384.hash(data: credit_card_no)   // GOOD, computationally expensive hash not required
 
     hash = Crypto.SHA512.hash(data: passwd)   // BAD, not a computationally expensive hash
     hash = Crypto.SHA512.hash(data: cert)   // GOOD, computationally expensive hash not required
+    hash = Crypto.SHA512.hash(data: encrypted_passwd)   // GOOD, not sensitive
     hash = Crypto.SHA512.hash(data: account_no)   // GOOD, computationally expensive hash not required
-    hash = Crypto.SHA512.hash(data: credit_card_no)   // GOOD, computationally expensive hash not required
     hash = Crypto.SHA512.hash(data: credit_card_no)   // GOOD, computationally expensive hash not required
 }
 
@@ -107,6 +107,7 @@ func testSHA256UpdateWithData(passwd : String, cert: String, encrypted_passwd : 
     var hash = Crypto.SHA256()
     hash.update(data: passwd)  // BAD, not a computationally expensive hash
     hash.update(data: cert)  // GOOD
+    hash.update(data: encrypted_passwd)   // GOOD  (not sensitive)
     hash.update(data: account_no)   // GOOD
     hash.update(data: credit_card_no)   // GOOD
 }
@@ -115,6 +116,7 @@ func testSHA384UpdateWithData(passwd : String, cert: String, encrypted_passwd : 
     var hash = Crypto.SHA384()
     hash.update(data: passwd)  // BAD, not a computationally expensive hash
     hash.update(data: cert)  // GOOD
+    hash.update(data: encrypted_passwd)   // GOOD  (not sensitive)
     hash.update(data: account_no)   // GOOD
     hash.update(data: credit_card_no)   // GOOD
 }
@@ -123,6 +125,7 @@ func testSHA512UpdateWithData(passwd : String, cert: String, encrypted_passwd : 
     var hash = Crypto.SHA512()
     hash.update(data: passwd)  // BAD, not a computationally expensive hash
     hash.update(data: cert)  // GOOD
+    hash.update(data: encrypted_passwd)   // GOOD  (not sensitive)
     hash.update(data: account_no)   // GOOD
     hash.update(data: credit_card_no)   // GOOD
 }
@@ -149,6 +152,7 @@ func testSHA256UpdateWithUnsafeRawBufferPointer(passwd : UnsafeRawBufferPointer,
     var hash = Crypto.SHA256()
     hash.update(bufferPointer: passwd)  // BAD, not a computationally expensive hash
     hash.update(bufferPointer: cert)  // GOOD
+    hash.update(bufferPointer: encrypted_passwd)  // GOOD  (not sensitive)
     hash.update(bufferPointer: account_no)   // GOOD
     hash.update(bufferPointer: credit_card_no)   // GOOD
 }
@@ -157,6 +161,7 @@ func testSHA384UpdateWithUnsafeRawBufferPointer(passwd : UnsafeRawBufferPointer,
     var hash = Crypto.SHA384()
     hash.update(bufferPointer: passwd)  // BAD, not a computationally expensive hash
     hash.update(bufferPointer: cert)  // GOOD
+    hash.update(bufferPointer: encrypted_passwd)  // GOOD  (not sensitive)
     hash.update(bufferPointer: account_no)   // GOOD
     hash.update(bufferPointer: credit_card_no)   // GOOD
 }
@@ -165,6 +170,7 @@ func testSHA512UpdateWithUnsafeRawBufferPointer(passwd : UnsafeRawBufferPointer,
     var hash = Crypto.SHA512()
     hash.update(bufferPointer: passwd)  // BAD, not a computationally expensive hash
     hash.update(bufferPointer: cert)  // GOOD
+    hash.update(bufferPointer: encrypted_passwd)  // GOOD  (not sensitive)
     hash.update(bufferPointer: account_no)   // GOOD
     hash.update(bufferPointer: credit_card_no)   // GOOD
 }

--- a/swift/ql/test/query-tests/Security/CWE-328/testCryptoKit.swift
+++ b/swift/ql/test/query-tests/Security/CWE-328/testCryptoKit.swift
@@ -66,19 +66,19 @@ func testHashMethods(passwd : UnsafeRawBufferPointer, cert: String, encrypted_pa
     hash = Crypto.Insecure.SHA1.hash(data: account_no)   // BAD
     hash = Crypto.Insecure.SHA1.hash(data: credit_card_no)   // BAD
 
-    hash = Crypto.SHA256.hash(data: passwd)   // BAD [NOT DETECTED] not a computationally expensive hash
+    hash = Crypto.SHA256.hash(data: passwd)   // BAD, not a computationally expensive hash
     hash = Crypto.SHA256.hash(data: cert)   // GOOD, computationally expensive hash not required
     hash = Crypto.SHA256.hash(data: account_no)   // GOOD, computationally expensive hash not required
     hash = Crypto.SHA256.hash(data: credit_card_no)   // GOOD, computationally expensive hash not required
     hash = Crypto.SHA256.hash(data: credit_card_no)   // GOOD, computationally expensive hash not required
 
-    hash = Crypto.SHA384.hash(data: passwd)   // BAD [NOT DETECTED] not a computationally expensive hash
+    hash = Crypto.SHA384.hash(data: passwd)   // BAD, not a computationally expensive hash
     hash = Crypto.SHA384.hash(data: cert)   // GOOD, computationally expensive hash not required
     hash = Crypto.SHA384.hash(data: account_no)   // GOOD, computationally expensive hash not required
     hash = Crypto.SHA384.hash(data: credit_card_no)   // GOOD, computationally expensive hash not required
     hash = Crypto.SHA384.hash(data: credit_card_no)   // GOOD, computationally expensive hash not required
 
-    hash = Crypto.SHA512.hash(data: passwd)   // BAD [NOT DETECTED] not a computationally expensive hash
+    hash = Crypto.SHA512.hash(data: passwd)   // BAD, not a computationally expensive hash
     hash = Crypto.SHA512.hash(data: cert)   // GOOD, computationally expensive hash not required
     hash = Crypto.SHA512.hash(data: account_no)   // GOOD, computationally expensive hash not required
     hash = Crypto.SHA512.hash(data: credit_card_no)   // GOOD, computationally expensive hash not required
@@ -105,7 +105,7 @@ func testSHA1UpdateWithData(passwd : String, cert: String, encrypted_passwd : St
 
 func testSHA256UpdateWithData(passwd : String, cert: String, encrypted_passwd : String, account_no : String, credit_card_no : String) {
     var hash = Crypto.SHA256()
-    hash.update(data: passwd)  // BAD [NOT DETECTED] not a computationally expensive hash
+    hash.update(data: passwd)  // BAD, not a computationally expensive hash
     hash.update(data: cert)  // GOOD
     hash.update(data: account_no)   // GOOD
     hash.update(data: credit_card_no)   // GOOD
@@ -113,7 +113,7 @@ func testSHA256UpdateWithData(passwd : String, cert: String, encrypted_passwd : 
 
 func testSHA384UpdateWithData(passwd : String, cert: String, encrypted_passwd : String, account_no : String, credit_card_no : String) {
     var hash = Crypto.SHA384()
-    hash.update(data: passwd)  // BAD [NOT DETECTED] not a computationally expensive hash
+    hash.update(data: passwd)  // BAD, not a computationally expensive hash
     hash.update(data: cert)  // GOOD
     hash.update(data: account_no)   // GOOD
     hash.update(data: credit_card_no)   // GOOD
@@ -121,7 +121,7 @@ func testSHA384UpdateWithData(passwd : String, cert: String, encrypted_passwd : 
 
 func testSHA512UpdateWithData(passwd : String, cert: String, encrypted_passwd : String, account_no : String, credit_card_no : String) {
     var hash = Crypto.SHA512()
-    hash.update(data: passwd)  // BAD [NOT DETECTED] not a computationally expensive hash
+    hash.update(data: passwd)  // BAD, not a computationally expensive hash
     hash.update(data: cert)  // GOOD
     hash.update(data: account_no)   // GOOD
     hash.update(data: credit_card_no)   // GOOD
@@ -147,7 +147,7 @@ func testSHA1UpdateWithUnsafeRawBufferPointer(passwd : UnsafeRawBufferPointer, c
 
 func testSHA256UpdateWithUnsafeRawBufferPointer(passwd : UnsafeRawBufferPointer, cert: UnsafeRawBufferPointer, encrypted_passwd : UnsafeRawBufferPointer, account_no : UnsafeRawBufferPointer, credit_card_no : UnsafeRawBufferPointer) {
     var hash = Crypto.SHA256()
-    hash.update(bufferPointer: passwd)  // BAD [NOT DETECTED] not a computationally expensive hash
+    hash.update(bufferPointer: passwd)  // BAD, not a computationally expensive hash
     hash.update(bufferPointer: cert)  // GOOD
     hash.update(bufferPointer: account_no)   // GOOD
     hash.update(bufferPointer: credit_card_no)   // GOOD
@@ -155,7 +155,7 @@ func testSHA256UpdateWithUnsafeRawBufferPointer(passwd : UnsafeRawBufferPointer,
 
 func testSHA384UpdateWithUnsafeRawBufferPointer(passwd : UnsafeRawBufferPointer, cert: UnsafeRawBufferPointer, encrypted_passwd : UnsafeRawBufferPointer, account_no : UnsafeRawBufferPointer, credit_card_no : UnsafeRawBufferPointer) {
     var hash = Crypto.SHA384()
-    hash.update(bufferPointer: passwd)  // BAD [NOT DETECTED] not a computationally expensive hash
+    hash.update(bufferPointer: passwd)  // BAD, not a computationally expensive hash
     hash.update(bufferPointer: cert)  // GOOD
     hash.update(bufferPointer: account_no)   // GOOD
     hash.update(bufferPointer: credit_card_no)   // GOOD
@@ -163,7 +163,7 @@ func testSHA384UpdateWithUnsafeRawBufferPointer(passwd : UnsafeRawBufferPointer,
 
 func testSHA512UpdateWithUnsafeRawBufferPointer(passwd : UnsafeRawBufferPointer, cert: UnsafeRawBufferPointer, encrypted_passwd : UnsafeRawBufferPointer, account_no : UnsafeRawBufferPointer, credit_card_no : UnsafeRawBufferPointer) {
     var hash = Crypto.SHA512()
-    hash.update(bufferPointer: passwd)  // BAD [NOT DETECTED] not a computationally expensive hash
+    hash.update(bufferPointer: passwd)  // BAD, not a computationally expensive hash
     hash.update(bufferPointer: cert)  // GOOD
     hash.update(bufferPointer: account_no)   // GOOD
     hash.update(bufferPointer: credit_card_no)   // GOOD

--- a/swift/ql/test/query-tests/Security/CWE-328/testCryptoSwift.swift
+++ b/swift/ql/test/query-tests/Security/CWE-328/testCryptoSwift.swift
@@ -157,10 +157,10 @@ func testArrays(harmlessArray: Array<UInt8>, phoneNumberArray: Array<UInt8>, pas
     _ = SHA1().calculate(for: passwdArray) // BAD
     _ = SHA2(variant: .sha512).calculate(for: harmlessArray) // GOOD
     _ = SHA2(variant: .sha512).calculate(for: phoneNumberArray) // GOOD
-    _ = SHA2(variant: .sha512).calculate(for: passwdArray) // BAD [NOT DETECTED]
+    _ = SHA2(variant: .sha512).calculate(for: passwdArray) // BAD
     _ = SHA3(variant: .sha512).calculate(for: harmlessArray) // GOOD
     _ = SHA3(variant: .sha512).calculate(for: phoneNumberArray) // GOOD
-    _ = SHA3(variant: .sha512).calculate(for: passwdArray) // BAD [NOT DETECTED]
+    _ = SHA3(variant: .sha512).calculate(for: passwdArray) // BAD
 
     _ = Digest.md5(harmlessArray) // GOOD (not sensitive)
     _ = Digest.md5(phoneNumberArray) // BAD
@@ -170,13 +170,13 @@ func testArrays(harmlessArray: Array<UInt8>, phoneNumberArray: Array<UInt8>, pas
     _ = Digest.sha1(passwdArray) // BAD
     _ = Digest.sha512(harmlessArray) // GOOD (not sensitive)
     _ = Digest.sha512(phoneNumberArray) // GOOD
-    _ = Digest.sha512(passwdArray) // BAD [NOT DETECTED]
+    _ = Digest.sha512(passwdArray) // BAD
     _ = Digest.sha2(harmlessArray, variant: .sha512) // GOOD (not sensitive)
     _ = Digest.sha2(phoneNumberArray, variant: .sha512) // GOOD
-    _ = Digest.sha2(passwdArray, variant: .sha512) // BAD [NOT DETECTED]
+    _ = Digest.sha2(passwdArray, variant: .sha512) // BAD
     _ = Digest.sha3(harmlessArray, variant: .sha512) // GOOD (not sensitive)
     _ = Digest.sha3(phoneNumberArray, variant: .sha512) // GOOD
-    _ = Digest.sha3(passwdArray, variant: .sha512) // BAD [NOT DETECTED]
+    _ = Digest.sha3(passwdArray, variant: .sha512) // BAD
 
     _ = harmlessArray.md5() // GOOD (not sensitive)
     _ = phoneNumberArray.md5() // BAD
@@ -186,13 +186,13 @@ func testArrays(harmlessArray: Array<UInt8>, phoneNumberArray: Array<UInt8>, pas
     _ = passwdArray.sha1() // BAD
     _ = harmlessArray.sha512() // GOOD
     _ = phoneNumberArray.sha512() // GOOD
-    _ = passwdArray.sha512() // BAD [NOT DETECTED]
+    _ = passwdArray.sha512() // BAD
     _ = harmlessArray.sha2(.sha512) // GOOD
     _ = phoneNumberArray.sha2(.sha512) // GOOD
-    _ = passwdArray.sha2(.sha512) // BAD [NOT DETECTED]
+    _ = passwdArray.sha2(.sha512) // BAD
     _ = harmlessArray.sha3(.sha512) // GOOD
     _ = phoneNumberArray.sha3(.sha512) // GOOD
-    _ = passwdArray.sha3(.sha512) // BAD [NOT DETECTED]
+    _ = passwdArray.sha3(.sha512) // BAD
 }
 
 func testData(harmlessData: Data, medicalData: Data, passwdData: Data) {
@@ -204,13 +204,13 @@ func testData(harmlessData: Data, medicalData: Data, passwdData: Data) {
     _ = passwdData.sha1() // BAD
     _ = harmlessData.sha512() // GOOD
     _ = medicalData.sha512() // GOOD
-    _ = passwdData.sha512() // BAD [NOT DETECTED]
+    _ = passwdData.sha512() // BAD
     _ = harmlessData.sha2(.sha512) // GOOD
     _ = medicalData.sha2(.sha512) // GOOD
-    _ = passwdData.sha2(.sha512) // BAD [NOT DETECTED]
+    _ = passwdData.sha2(.sha512) // BAD
     _ = harmlessData.sha3(.sha512) // GOOD
     _ = medicalData.sha3(.sha512) // GOOD
-    _ = passwdData.sha3(.sha512) // BAD [NOT DETECTED]
+    _ = passwdData.sha3(.sha512) // BAD
 }
 
 func testStrings(creditCardNumber: String, passwd: String) {
@@ -222,11 +222,11 @@ func testStrings(creditCardNumber: String, passwd: String) {
     _ = passwd.sha1() // BAD
     _ = "harmless".sha512() // GOOD
     _ = creditCardNumber.sha512() // GOOD
-    _ = passwd.sha512() // BAD [NOT DETECTED]
+    _ = passwd.sha512() // BAD
     _ = "harmless".sha2(.sha512) // GOOD
     _ = creditCardNumber.sha2(.sha512) // GOOD
-    _ = passwd.sha2(.sha512) // BAD [NOT DETECTED]
+    _ = passwd.sha2(.sha512) // BAD
     _ = "harmless".sha3(.sha512) // GOOD
     _ = creditCardNumber.sha3(.sha512) // GOOD
-    _ = passwd.sha3(.sha512) // BAD [NOT DETECTED]
+    _ = passwd.sha3(.sha512) // BAD
 }

--- a/swift/ql/test/query-tests/Security/CWE-328/testCryptoSwift.swift
+++ b/swift/ql/test/query-tests/Security/CWE-328/testCryptoSwift.swift
@@ -150,10 +150,10 @@ extension String {
 
 func testArrays(harmlessArray: Array<UInt8>, phoneNumberArray: Array<UInt8>, passwdArray: Array<UInt8>) {
     _ = MD5().calculate(for: harmlessArray) // GOOD (not sensitive)
-    _ = MD5().calculate(for: phoneNumberArray) // BAD [NOT DETECTED]
+    _ = MD5().calculate(for: phoneNumberArray) // BAD
     _ = MD5().calculate(for: passwdArray) // BAD
     _ = SHA1().calculate(for: harmlessArray) // GOOD (not sensitive)
-    _ = SHA1().calculate(for: phoneNumberArray) // BAD [NOT DETECTED]
+    _ = SHA1().calculate(for: phoneNumberArray) // BAD
     _ = SHA1().calculate(for: passwdArray) // BAD
     _ = SHA2(variant: .sha512).calculate(for: harmlessArray) // GOOD
     _ = SHA2(variant: .sha512).calculate(for: phoneNumberArray) // GOOD
@@ -163,10 +163,10 @@ func testArrays(harmlessArray: Array<UInt8>, phoneNumberArray: Array<UInt8>, pas
     _ = SHA3(variant: .sha512).calculate(for: passwdArray) // BAD [NOT DETECTED]
 
     _ = Digest.md5(harmlessArray) // GOOD (not sensitive)
-    _ = Digest.md5(phoneNumberArray) // BAD [NOT DETECTED]
+    _ = Digest.md5(phoneNumberArray) // BAD
     _ = Digest.md5(passwdArray) // BAD
     _ = Digest.sha1(harmlessArray) // GOOD (not sensitive)
-    _ = Digest.sha1(phoneNumberArray) // BAD [NOT DETECTED]
+    _ = Digest.sha1(phoneNumberArray) // BAD
     _ = Digest.sha1(passwdArray) // BAD
     _ = Digest.sha512(harmlessArray) // GOOD (not sensitive)
     _ = Digest.sha512(phoneNumberArray) // GOOD
@@ -179,10 +179,10 @@ func testArrays(harmlessArray: Array<UInt8>, phoneNumberArray: Array<UInt8>, pas
     _ = Digest.sha3(passwdArray, variant: .sha512) // BAD [NOT DETECTED]
 
     _ = harmlessArray.md5() // GOOD (not sensitive)
-    _ = phoneNumberArray.md5() // BAD [NOT DETECTED]
+    _ = phoneNumberArray.md5() // BAD
     _ = passwdArray.md5() // BAD
     _ = harmlessArray.sha1() // GOOD (not sensitive)
-    _ = phoneNumberArray.sha1() // BAD [NOT DETECTED]
+    _ = phoneNumberArray.sha1() // BAD
     _ = passwdArray.sha1() // BAD
     _ = harmlessArray.sha512() // GOOD
     _ = phoneNumberArray.sha512() // GOOD

--- a/swift/ql/test/query-tests/Security/CWE-328/testCryptoSwift.swift
+++ b/swift/ql/test/query-tests/Security/CWE-328/testCryptoSwift.swift
@@ -34,6 +34,18 @@ class SHA2 : DigestType {
     }
 }
 
+class SHA3 : DigestType {
+    public enum Variant {
+        case sha512
+    }
+
+    public init(variant: SHA3.Variant) {}
+
+    public func calculate(for bytes: Array<UInt8>) -> Array<UInt8> {
+        return Array<UInt8>()
+    }
+}
+
 struct Digest {
     static func md5(_ bytes: Array<UInt8>) -> Array<UInt8> {
         return MD5().calculate(for: bytes)
@@ -49,6 +61,10 @@ struct Digest {
 
     static func sha2(_ bytes: Array<UInt8>, variant: SHA2.Variant) -> Array<UInt8> {
         return SHA2(variant: variant).calculate(for: bytes)
+    }
+
+    static func sha3(_ bytes: Array<UInt8>, variant: SHA3.Variant) -> Array<UInt8> {
+        return SHA3(variant: variant).calculate(for: bytes)
     }
 }
 
@@ -68,6 +84,14 @@ extension Array where Element == UInt8 {
     func sha512() -> [Element] {
         return Digest.sha512(self)
     }
+
+    func sha2(_ variant: SHA2.Variant) -> [Element] {
+        return Digest.sha2(self, variant: variant)
+    }
+
+    func sha3(_ variant: SHA3.Variant) -> [Element] {
+        return Digest.sha3(self, variant: variant)
+    }
 }
 
 extension Data {
@@ -85,6 +109,14 @@ extension Data {
 
     func sha512() -> Data {
         return Data(Digest.sha512(bytes))
+    }
+
+    func sha2(_ variant: SHA2.Variant) -> Data {
+        return Data(Digest.sha2(bytes, variant: variant))
+    }
+
+    func sha3(_ variant: SHA3.Variant) -> Data {
+        return Data(Digest.sha3(bytes, variant: variant))
     }
 }
 
@@ -104,47 +136,97 @@ extension String {
     func sha512() -> String {
         return self.bytes.sha512().toHexString()
     }
+
+    func sha2(_ variant: SHA2.Variant) -> String {
+        return self.bytes.sha2(variant).toHexString()
+    }
+
+    func sha3(_ variant: SHA3.Variant) -> String {
+        return self.bytes.sha3(variant).toHexString()
+    }
 }
 
 // --- tests ---
 
-func testArrays(harmlessArray: Array<UInt8>, passwdArray: Array<UInt8>) {
+func testArrays(harmlessArray: Array<UInt8>, phoneNumberArray: Array<UInt8>, passwdArray: Array<UInt8>) {
     _ = MD5().calculate(for: harmlessArray) // GOOD (not sensitive)
+    _ = MD5().calculate(for: phoneNumberArray) // BAD [NOT DETECTED]
     _ = MD5().calculate(for: passwdArray) // BAD
     _ = SHA1().calculate(for: harmlessArray) // GOOD (not sensitive)
+    _ = SHA1().calculate(for: phoneNumberArray) // BAD [NOT DETECTED]
     _ = SHA1().calculate(for: passwdArray) // BAD
     _ = SHA2(variant: .sha512).calculate(for: harmlessArray) // GOOD
-    _ = SHA2(variant: .sha512).calculate(for: passwdArray) // GOOD
+    _ = SHA2(variant: .sha512).calculate(for: phoneNumberArray) // GOOD
+    _ = SHA2(variant: .sha512).calculate(for: passwdArray) // BAD [NOT DETECTED]
+    _ = SHA3(variant: .sha512).calculate(for: harmlessArray) // GOOD
+    _ = SHA3(variant: .sha512).calculate(for: phoneNumberArray) // GOOD
+    _ = SHA3(variant: .sha512).calculate(for: passwdArray) // BAD [NOT DETECTED]
 
     _ = Digest.md5(harmlessArray) // GOOD (not sensitive)
+    _ = Digest.md5(phoneNumberArray) // BAD [NOT DETECTED]
     _ = Digest.md5(passwdArray) // BAD
     _ = Digest.sha1(harmlessArray) // GOOD (not sensitive)
+    _ = Digest.sha1(phoneNumberArray) // BAD [NOT DETECTED]
     _ = Digest.sha1(passwdArray) // BAD
-    _ = Digest.sha512(harmlessArray) // GOOD
-    _ = Digest.sha512(passwdArray) // GOOD
+    _ = Digest.sha512(harmlessArray) // GOOD (not sensitive)
+    _ = Digest.sha512(phoneNumberArray) // GOOD
+    _ = Digest.sha512(passwdArray) // BAD [NOT DETECTED]
+    _ = Digest.sha2(harmlessArray, variant: .sha512) // GOOD (not sensitive)
+    _ = Digest.sha2(phoneNumberArray, variant: .sha512) // GOOD
+    _ = Digest.sha2(passwdArray, variant: .sha512) // BAD [NOT DETECTED]
+    _ = Digest.sha3(harmlessArray, variant: .sha512) // GOOD (not sensitive)
+    _ = Digest.sha3(phoneNumberArray, variant: .sha512) // GOOD
+    _ = Digest.sha3(passwdArray, variant: .sha512) // BAD [NOT DETECTED]
 
     _ = harmlessArray.md5() // GOOD (not sensitive)
+    _ = phoneNumberArray.md5() // BAD [NOT DETECTED]
     _ = passwdArray.md5() // BAD
     _ = harmlessArray.sha1() // GOOD (not sensitive)
+    _ = phoneNumberArray.sha1() // BAD [NOT DETECTED]
     _ = passwdArray.sha1() // BAD
     _ = harmlessArray.sha512() // GOOD
-    _ = passwdArray.sha512() // GOOD
+    _ = phoneNumberArray.sha512() // GOOD
+    _ = passwdArray.sha512() // BAD [NOT DETECTED]
+    _ = harmlessArray.sha2(.sha512) // GOOD
+    _ = phoneNumberArray.sha2(.sha512) // GOOD
+    _ = passwdArray.sha2(.sha512) // BAD [NOT DETECTED]
+    _ = harmlessArray.sha3(.sha512) // GOOD
+    _ = phoneNumberArray.sha3(.sha512) // GOOD
+    _ = passwdArray.sha3(.sha512) // BAD [NOT DETECTED]
 }
 
-func testData(harmlessData: Data, passwdData: Data) {
+func testData(harmlessData: Data, medicalData: Data, passwdData: Data) {
     _ = harmlessData.md5() // GOOD (not sensitive)
+    _ = medicalData.md5() // BAD
     _ = passwdData.md5() // BAD
     _ = harmlessData.sha1() // GOOD (not sensitive)
+    _ = medicalData.sha1() // BAD
     _ = passwdData.sha1() // BAD
     _ = harmlessData.sha512() // GOOD
-    _ = passwdData.sha512() // GOOD
+    _ = medicalData.sha512() // GOOD
+    _ = passwdData.sha512() // BAD [NOT DETECTED]
+    _ = harmlessData.sha2(.sha512) // GOOD
+    _ = medicalData.sha2(.sha512) // GOOD
+    _ = passwdData.sha2(.sha512) // BAD [NOT DETECTED]
+    _ = harmlessData.sha3(.sha512) // GOOD
+    _ = medicalData.sha3(.sha512) // GOOD
+    _ = passwdData.sha3(.sha512) // BAD [NOT DETECTED]
 }
 
-func testStrings(passwd: String) {
+func testStrings(creditCardNumber: String, passwd: String) {
     _ = "harmless".md5() // GOOD (not sensitive)
+    _ = creditCardNumber.md5() // BAD
     _ = passwd.md5() // BAD
     _ = "harmless".sha1() // GOOD (not sensitive)
+    _ = creditCardNumber.sha1() // BAD
     _ = passwd.sha1() // BAD
     _ = "harmless".sha512() // GOOD
-    _ = passwd.sha512() // GOOD
+    _ = creditCardNumber.sha512() // GOOD
+    _ = passwd.sha512() // BAD [NOT DETECTED]
+    _ = "harmless".sha2(.sha512) // GOOD
+    _ = creditCardNumber.sha2(.sha512) // GOOD
+    _ = passwd.sha2(.sha512) // BAD [NOT DETECTED]
+    _ = "harmless".sha3(.sha512) // GOOD
+    _ = creditCardNumber.sha3(.sha512) // GOOD
+    _ = passwd.sha3(.sha512) // BAD [NOT DETECTED]
 }


### PR DESCRIPTION
New query for Use of an inappropriate cryptographic hashing algorithm on passwords.

This query is designed to be used alongside the existing `swift/weak-sensitive-data-hashing` query, and I've made some adjustments to that query to avoid duplication and to make sure results are reported by the most appropriate query.  Previously:
```
swift/weak-sensitive-data-hashing: password, credential or private info -> MD5 or SHA1 hash
```
Now:
```
swift/weak-sensitive-data-hashing: non-password credential or private info -> MD5 or SHA1 hash
swift/weak-password-hashing: password -> MD5, SHA1, SHA2 (including variants such as SHA-512), SHA3 hash
```

To do this I had to make passwords an explicit kind of sensitive data in Swift (`SensitivePassword`), and I added MAD syntax for it (`sensitive-password`).  I also fixed the sensitive data regular expressions for mobile phone numbers, added a couple of missing sinks for sensitive data hashing, and made some class names consistent while I was working in this area.

TODO:
- [x] team review
- [x] docs review
- [x] DCA run