### PR TITLE
Java: Add the `Map#replace` and `Map#replaceAll` methods to `MapMutator` in `Maps.qll`

### DIFF
--- a/java/ql/lib/change-notes/2023-12-19-add-replace-methods-to-mapmutator.md
+++ b/java/ql/lib/change-notes/2023-12-19-add-replace-methods-to-mapmutator.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added the `Map#replace` and `Map#replaceAll` methods to the `MapMutator` class in `semmle.code.java.Maps`.

--- a/java/ql/lib/semmle/code/java/Maps.qll
+++ b/java/ql/lib/semmle/code/java/Maps.qll
@@ -40,7 +40,9 @@ class MapMethod extends Method {
 
 /** A method that mutates the map it belongs to. */
 class MapMutator extends MapMethod {
-  MapMutator() { pragma[only_bind_into](this).getName().regexpMatch("(put.*|remove|clear)") }
+  MapMutator() {
+    pragma[only_bind_into](this).getName().regexpMatch("(put.*|remove|clear|replace.*)")
+  }
 }
 
 /** The `size` method of `java.util.Map`. */


### PR DESCRIPTION
Adds the `replace` and `replaceAll` methods of the `java.util.Map` interface to the `MapMutator` class in `Maps.qll`.