### PR TITLE
Go: fix FP in incorrect integer conversion query relating to strict comparisons with MaxInt and MaxUint

### DIFF
--- a/go/ql/lib/semmle/go/security/IncorrectIntegerConversionLib.qll
+++ b/go/ql/lib/semmle/go/security/IncorrectIntegerConversionLib.qll
@@ -15,15 +15,11 @@ abstract private class MaxIntOrMaxUint extends DeclaredConstant {
    */
   predicate isBoundFor(int b, int architectureBitSize, float strictnessOffset) {
     // 2.pow(x) - 1 - strictnessOffset <= 2.pow(b) - 1
-    exists(int x |
-      x = this.getOrder(architectureBitSize) and
-      b = validBitSize() and
-      (
-        strictnessOffset = 0 and x <= b
-        or
-        strictnessOffset = 1 and x <= b - 1
-      )
-    )
+    // For the values that we are restricting `b` to, `strictnessOffset` has no
+    // effect on the result, so we can ignore it.
+    b = validBitSize() and
+    strictnessOffset = [0, 1] and
+    this.getOrder(architectureBitSize) <= b
   }
 }
 

--- a/go/ql/src/change-notes/2023-12-17-incorrect-integer-conversion-fix.md
+++ b/go/ql/src/change-notes/2023-12-17-incorrect-integer-conversion-fix.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* There was a bug which meant that upper bound checks using a strict inequality (`<`) and comparing against `math.MaxInt` or `math.MaxUint` were not considered correctly, which led to false positives. This has now been fixed.
+* There was a bug in the query `go/incorrect-integer-conversion` which meant that upper bound checks using a strict inequality (`<`) and comparing against `math.MaxInt` or `math.MaxUint` were not considered correctly, which led to false positives. This has now been fixed.

--- a/go/ql/src/change-notes/2023-12-17-incorrect-integer-conversion-fix.md
+++ b/go/ql/src/change-notes/2023-12-17-incorrect-integer-conversion-fix.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* There was a bug which meant that upper bound checks using a strict inequality (`<`) and comparing against `math.MaxInt` or `math.MaxUint` were not considered correctly, which led to false positives. This has now been fixed.

--- a/go/ql/test/query-tests/Security/CWE-681/IncorrectIntegerConversion.expected
+++ b/go/ql/test/query-tests/Security/CWE-681/IncorrectIntegerConversion.expected
@@ -1,3 +1,2 @@
 testFailures
-| IncorrectIntegerConversion.go:497:15:497:15 | i | Unexpected result: hasValueFlow="i" |
 failures

--- a/go/ql/test/query-tests/Security/CWE-681/IncorrectIntegerConversion.expected
+++ b/go/ql/test/query-tests/Security/CWE-681/IncorrectIntegerConversion.expected
@@ -1,2 +1,3 @@
-failures
 testFailures
+| IncorrectIntegerConversion.go:497:15:497:15 | i | Unexpected result: hasValueFlow="i" |
+failures

--- a/go/ql/test/query-tests/Security/CWE-681/IncorrectIntegerConversion.go
+++ b/go/ql/test/query-tests/Security/CWE-681/IncorrectIntegerConversion.go
@@ -491,3 +491,10 @@ func typeAssertion(s string) {
 	}
 
 }
+
+func dealWithArchSizeCorrectly(s string) uint {
+	if i, err := strconv.ParseUint(s, 10, 64); err == nil && i < math.MaxUint {
+		return uint(i)
+	}
+	return 0
+}


### PR DESCRIPTION
The new logic for comparing with MaxInt and MaxUint had a logic error which affected strict inequailities. So `x <= MaxUint` would work but `x < MaxUint` wouldn't.