### PR TITLE
C++: Fix joins in `cpp/wrong-type-format-argument`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/models/interfaces/FormattingFunction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/interfaces/FormattingFunction.qll
@@ -9,8 +9,9 @@
 import semmle.code.cpp.models.interfaces.ArrayFunction
 import semmle.code.cpp.models.interfaces.Taint
 
+pragma[nomagic]
 private Type stripTopLevelSpecifiersOnly(Type t) {
-  result = stripTopLevelSpecifiersOnly(t.(SpecifiedType).getBaseType())
+  result = stripTopLevelSpecifiersOnly(pragma[only_bind_out](t.(SpecifiedType).getBaseType()))
   or
   result = t and
   not t instanceof SpecifiedType


### PR DESCRIPTION
This one also kept showing up on the nightly DCA run.

Before:
```ql
Pipeline standard for FormattingFunction::stripTopLevelSpecifiersOnly/1#c8bada68#bf@379a1xvo was evaluated in 4 iterations totaling 150ms (delta sizes total: 2262215).
                   {1} r1 = `m#FormattingFunction::stripTopLevelSpecifiersOnly/1#c8bada68#bf#prev_delta` AND NOT Type::SpecifiedType#e92ebe9d(FIRST 1)
  1931981  ~23%    {2} r2 = SCAN r1 OUTPUT In.0, In.0

   330478   ~0%    {2} r3 = JOIN `_Type::SpecifiedType#e92ebe9d_m#FormattingFunction::stripTopLevelSpecifiersOnly/1#c8bada68#bf#prev_d__#shared` WITH `Type::DerivedType.getBaseType/0#dispred#b08b94f7` ON FIRST 1 OUTPUT Rhs.1, Lhs.0
        0   ~0%    {2} r4 = JOIN r3 WITH `FormattingFunction::stripTopLevelSpecifiersOnly/1#c8bada68#bf#prev` ON FIRST 1 OUTPUT Lhs.1, Rhs.1
                
   330478   ~2%    {2} r5 = JOIN `_FormattingFunction::stripTopLevelSpecifiersOnly/1#c8bada68#bf#prev_delta_Type::DerivedType.getBaseT__#shared` WITH Type::SpecifiedType#e92ebe9d ON FIRST 1 OUTPUT Lhs.0, Lhs.1
   330478   ~2%    {2} r6 = JOIN r5 WITH `m#FormattingFunction::stripTopLevelSpecifiersOnly/1#c8bada68#bf#prev` ON FIRST 1 OUTPUT Lhs.0, Lhs.1
                
   330478   ~2%    {2} r7 = r4 UNION r6
  2262459  ~20%    {2} r8 = r2 UNION r7
  2262459  ~20%    {2} r9 = r8 AND NOT `FormattingFunction::stripTopLevelSpecifiersOnly/1#c8bada68#bf#prev`(FIRST 2)
                       return r9
```

After:
```ql
Pipeline base for FormattingFunction::stripTopLevelSpecifiersOnly/1#c8bada68@3536624r was evaluated in 1 iterations totaling 48ms (delta sizes total: 2091145).
                         {1} r1 = `ResolveClass::isType/1#eabb9878` AND NOT Type::SpecifiedType#e92ebe9d(FIRST 1)
        2091145   ~0%    {2} r2 = SCAN r1 OUTPUT In.0, In.0
                         return r2

Pipeline standard for FormattingFunction::stripTopLevelSpecifiersOnly/1#c8bada68@3536624r was evaluated in 2 iterations totaling 91ms (delta sizes total: 330478).
        330478  ~0%    {2} r1 = JOIN `FormattingFunction::stripTopLevelSpecifiersOnly/1#c8bada68#prev_delta` WITH `_Type::DerivedType.getBaseType/0#dispred#b08b94f7_Type::SpecifiedType#e92ebe9d#join_rhs` ON FIRST 1 OUTPUT Lhs.1, Rhs.1
        330478  ~2%    {2} r2 = JOIN r1 WITH `ResolveClass::isType/1#eabb9878` ON FIRST 1 OUTPUT Lhs.1, Lhs.0
        330478  ~2%    {2} r3 = r2 AND NOT `FormattingFunction::stripTopLevelSpecifiersOnly/1#c8bada68#prev`(FIRST 2)
                       return r3
```