### PR TITLE
C++: Fix joins in `isModifiableAtImpl`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -997,7 +997,8 @@ private Type getTypeImpl0(Type t, int indirectionIndex) {
  *
  * If `indirectionIndex` cannot be stripped off `t`, an `UnknownType` is returned.
  */
-bindingset[indirectionIndex]
+bindingset[t, indirectionIndex]
+pragma[inline_late]
 Type getTypeImpl(Type t, int indirectionIndex) {
   result = getTypeImpl0(t, indirectionIndex)
   or

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
@@ -418,6 +418,11 @@ class BaseCallVariable extends AbstractBaseSourceVariable, TBaseCallVariable {
 }
 
 private module IsModifiableAtImpl {
+  pragma[nomagic]
+  private predicate isUnderlyingIndirectionType(Type t) {
+    t = any(Indirection ind).getUnderlyingType()
+  }
+
   /**
    * Holds if the `indirectionIndex`'th dereference of a value of type
    * `cppType` is a type that can be modified (either by modifying the value
@@ -445,10 +450,9 @@ private module IsModifiableAtImpl {
   bindingset[cppType, indirectionIndex]
   pragma[inline_late]
   private predicate impl(CppType cppType, int indirectionIndex) {
-    exists(Type pointerType, Type base, Type t |
-      pointerType = t.getUnderlyingType() and
-      pointerType = any(Indirection ind).getUnderlyingType() and
-      cppType.hasType(t, _) and
+    exists(Type pointerType, Type base |
+      isUnderlyingIndirectionType(pointerType) and
+      cppType.hasUnderlyingType(pointerType, _) and
       base = getTypeImpl(pointerType, indirectionIndex)
     |
       // The value cannot be modified if it has a const specifier,

--- a/cpp/ql/lib/semmle/code/cpp/ir/internal/CppType.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/internal/CppType.qll
@@ -227,13 +227,25 @@ class CppType extends TCppType {
   predicate hasType(Type type, boolean isGLValue) { none() }
 
   /**
-   * Holds if this type represents the C++ type `type`. If `isGLValue` is `true`, then this type
+   * Holds if this type represents the C++ unspecified type `type`. If `isGLValue` is `true`, then this type
    * represents a glvalue of type `type`. Otherwise, it represents a prvalue of type `type`.
    */
   final predicate hasUnspecifiedType(Type type, boolean isGLValue) {
     exists(Type specifiedType |
       this.hasType(specifiedType, isGLValue) and
       type = specifiedType.getUnspecifiedType()
+    )
+  }
+
+  /**
+   * Holds if this type represents the C++ type `type` (after resolving
+   * typedefs). If `isGLValue` is `true`, then this type represents a glvalue
+   * of type `type`. Otherwise, it represents a prvalue of type `type`.
+   */
+  final predicate hasUnderlyingType(Type type, boolean isGLValue) {
+    exists(Type typedefType |
+      this.hasType(typedefType, isGLValue) and
+      type = typedefType.getUnderlyingType()
     )
   }
 }


### PR DESCRIPTION
Also highlighted by the DCA join order report. This on was actually quite bad 😅.

Before:
```
[2023-12-18 10:09:33] Evaluated non-recursive predicate SsaInternalsCommon::isModifiableAtImpl/2#2b25ad2f@b02f6ccj in 71404ms (size: 2842043).
Evaluated relational algebra for predicate SsaInternalsCommon::isModifiableAtImpl/2#2b25ad2f@b02f6ccj with tuple counts:
      4208191   ~1%    {2} r1 = JOIN CppType::TCppType#eff8d274 WITH `CppType::CppType.hasType/2#dispred#d3f6ee89` ON FIRST 1 OUTPUT Rhs.1, Lhs.0
      4207753   ~0%    {2} r2 = JOIN r1 WITH `Type::Type.getUnderlyingType/0#dispred#bd141f6a` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
   2914047693   ~0%    {3} r3 = JOIN r2 WITH `Type::Type.getUnderlyingType/0#dispred#bd141f6a_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.0
                  
      1280304   ~0%    {3} r4 = JOIN r3 WITH `SsaInternalsCommon::isIndirectionType/1#6f5ae315` ON FIRST 1 OUTPUT Lhs.2, _, Lhs.1
      1280304   ~0%    {3} r5 = REWRITE r4 WITH Out.1 := 0
      1280304   ~2%    {2} r6 = JOIN r5 WITH `DataFlowUtil::getTypeImpl0/2#26c3c2a8` ON FIRST 2 OUTPUT Rhs.2, Lhs.2
                  
      1280304   ~2%    {2} r7 = JOIN r3 WITH `SsaInternalsCommon::isIndirectionType/1#6f5ae315` ON FIRST 1 OUTPUT Lhs.2, Lhs.1
            0   ~0%    {2} r8 = r7 AND NOT `_project#DataFlowUtil::getTypeImpl0/2#26c3c2a8_10#join_rhs#antijoin_rhs`(FIRST 1)
                  
            0   ~0%    {2} r9 = JOIN r8 WITH Type::UnknownType#cbea2ba5 CARTESIAN PRODUCT OUTPUT Rhs.0, Lhs.1
                  
      1280304   ~2%    {2} r10 = r6 UNION r9
                        {2} r11 = r10 AND NOT `_Type::Type.hasSpecifier/1#dispred#d2911bb1#fb_10#join_rhs#antijoin_rhs`(FIRST 1)
      1280304   ~0%    {2} r12 = SCAN r11 OUTPUT In.1, _
      1280304   ~2%    {2} r13 = REWRITE r12 WITH Out.1 := 0
                  
            0   ~0%    {1} r14 = SCAN r8 OUTPUT In.1
            0   ~0%    {2} r15 = JOIN r14 WITH Type::UnknownType#cbea2ba5 CARTESIAN PRODUCT OUTPUT Rhs.0, Lhs.0
                  
      1280304   ~2%    {2} r16 = r6 UNION r15
      1279800   ~0%    {2} r17 = JOIN r16 WITH `Type::Type.stripType/0#dispred#e1299c1e` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
      212168   ~0%    {2} r18 = JOIN r17 WITH `project#Class::Class.getAField/0#dispred#19444341` ON FIRST 1 OUTPUT Lhs.1, _
      212168   ~0%    {2} r19 = REWRITE r18 WITH Out.1 := 0
                  
      1492472  ~19%    {2} r20 = r13 UNION r19
                  
      3054211   ~7%    {2} r21 = `SsaInternalsCommon::isModifiableAtImplAtLeast1/2#bae9353a` UNION r20
                        return r21
```

After:
```
[2023-12-18 11:59:51] Evaluated non-recursive predicate SsaInternalsCommon::isModifiableAtImpl/2#2b25ad2f@aa81f0vi in 995ms (size: 2842043).
Evaluated relational algebra for predicate SsaInternalsCommon::isModifiableAtImpl/2#2b25ad2f@aa81f0vi with tuple counts:
      4208191   ~1%    {2} r1 = JOIN CppType::TCppType#eff8d274 WITH `CppType::CppType.hasType/2#dispred#d3f6ee89` ON FIRST 1 OUTPUT Rhs.1, Lhs.0
      4207753   ~0%    {2} r2 = JOIN r1 WITH `Type::Type.getUnderlyingType/0#dispred#bd141f6a` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
      1280304   ~2%    {2} r3 = JOIN r2 WITH `SsaInternalsCommon::isUnderlyingIndirectionType/1#14660e47` ON FIRST 1 OUTPUT Lhs.0, Lhs.1
                  
      1280304   ~0%    {3} r4 = JOIN r3 WITH `ResolveClass::isType/1#eabb9878` ON FIRST 1 OUTPUT Lhs.0, _, Lhs.1
      1280304   ~0%    {3} r5 = REWRITE r4 WITH Out.1 := 0
      1280304   ~2%    {2} r6 = JOIN r5 WITH `DataFlowUtil::getTypeImpl0/2#26c3c2a8` ON FIRST 2 OUTPUT Rhs.2, Lhs.2
                  
      1280304   ~2%    {2} r7 = JOIN r3 WITH `ResolveClass::isType/1#eabb9878` ON FIRST 1 OUTPUT Lhs.0, Lhs.1
                        {2} r8 = r7 AND NOT `_project#DataFlowUtil::getTypeImpl0/2#26c3c2a8_10#join_rhs#antijoin_rhs`(FIRST 1)
            0   ~0%    {1} r9 = SCAN r8 OUTPUT In.1
            0   ~0%    {2} r10 = JOIN r9 WITH Type::UnknownType#cbea2ba5 CARTESIAN PRODUCT OUTPUT Rhs.0, Lhs.0
                  
      1280304   ~2%    {2} r11 = r6 UNION r10
      1280304   ~2%    {2} r12 = JOIN r11 WITH `ResolveClass::isType/1#eabb9878` ON FIRST 1 OUTPUT Lhs.0, Lhs.1
                  
                        {2} r13 = r12 AND NOT `_Type::Type.hasSpecifier/1#dispred#d2911bb1#fb_10#join_rhs#antijoin_rhs`(FIRST 1)
      1280304   ~0%    {2} r14 = SCAN r13 OUTPUT In.1, _
      1280304   ~2%    {2} r15 = REWRITE r14 WITH Out.1 := 0
                  
      1279800   ~0%    {2} r16 = JOIN r12 WITH `Type::Type.stripType/0#dispred#e1299c1e` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
      212168   ~0%    {2} r17 = JOIN r16 WITH `project#Class::Class.getAField/0#dispred#19444341` ON FIRST 1 OUTPUT Lhs.1, _
      212168   ~0%    {2} r18 = REWRITE r17 WITH Out.1 := 0
                  
      1492472  ~19%    {2} r19 = r15 UNION r18
                  
      3054211   ~7%    {2} r20 = `SsaInternalsCommon::isModifiableAtImplAtLeast1/2#bae9353a` UNION r19
                         return r20
```