### PR TITLE
C++: Fix joins in `cpp/use-after-free`

### DIFF
--- a/cpp/ql/src/Critical/UseAfterFree.ql
+++ b/cpp/ql/src/Critical/UseAfterFree.ql
@@ -101,35 +101,43 @@ module ParameterSinks {
     )
   }
 
-  private CallInstruction getAnAlwaysReachedCallInstruction(IRFunction f) {
-    result.getBlock().postDominates(f.getEntryBlock())
+  private CallInstruction getAnAlwaysReachedCallInstruction() {
+    exists(IRFunction f | result.getBlock().postDominates(f.getEntryBlock()))
   }
 
   pragma[nomagic]
-  predicate callHasTargetAndArgument(Function f, int i, CallInstruction call, Instruction argument) {
-    call.getStaticCallTarget() = f and
-    call.getArgument(i) = argument
+  private predicate callHasTargetAndArgument(Function f, int i, Instruction argument) {
+    exists(CallInstruction call |
+      call.getStaticCallTarget() = f and
+      call.getArgument(i) = argument and
+      call = getAnAlwaysReachedCallInstruction()
+    )
   }
 
   pragma[nomagic]
-  predicate initializeParameterInFunction(Function f, int i, InitializeParameterInstruction init) {
-    pragma[only_bind_out](init.getEnclosingFunction()) = f and
-    init.hasIndex(i)
+  private predicate initializeParameterInFunction(Function f, int i) {
+    exists(InitializeParameterInstruction init |
+      pragma[only_bind_out](init.getEnclosingFunction()) = f and
+      init.hasIndex(i) and
+      init = getAnAlwaysDereferencedParameter()
+    )
+  }
+
+  pragma[nomagic]
+  private predicate alwaysDereferencedArgumentHasValueNumber(ValueNumber vn) {
+    exists(int i, Function f, Instruction argument |
+      callHasTargetAndArgument(f, i, argument) and
+      initializeParameterInFunction(pragma[only_bind_into](f), pragma[only_bind_into](i)) and
+      vn.getAnInstruction() = argument
+    )
   }
 
   InitializeParameterInstruction getAnAlwaysDereferencedParameter() {
     result = getAnAlwaysDereferencedParameter0()
     or
-    exists(
-      CallInstruction call, int i, InitializeParameterInstruction p, Instruction argument,
-      Function f
-    |
-      callHasTargetAndArgument(f, i, call, argument) and
-      initializeParameterInFunction(f, i, p) and
-      p = getAnAlwaysDereferencedParameter() and
-      result =
-        pragma[only_bind_out](pragma[only_bind_into](valueNumber(argument)).getAnInstruction()) and
-      call = getAnAlwaysReachedCallInstruction(_)
+    exists(ValueNumber vn |
+      alwaysDereferencedArgumentHasValueNumber(vn) and
+      vn.getAnInstruction() = result
     )
   }
 }


### PR DESCRIPTION
This was highlighted by the nightly C/C++ DCA.

Before:
```
Pipeline base for UseAfterFree::ParameterSinks::getAnAlwaysDereferencedParameter/0#bfd578a4@7c3b71t2 was evaluated in 1 iterations totaling 1ms (delta sizes total: 4868).
  4868  ~0%    {1} r1 = JOIN `UseAfterFree::ParameterSinks::getAnAlwaysDereferencedParameter0/0#2ee9f822` WITH project#Instruction::InitializeParameterInstruction#d726fcda ON FIRST 1 OUTPUT Lhs.0
               return r1

Pipeline standard for UseAfterFree::ParameterSinks::getAnAlwaysDereferencedParameter/0#bfd578a4@7c3b71t2 was evaluated in 5 iterations totaling 676ms (delta sizes total: 927).
                  {2} r1 = `_ValueNumberingInternal::tvalueNumber/1#f03b58f9_project#Instruction::InitializeParameterInstruction__#loop_invariant_prefix` AND NOT `UseAfterFree::ParameterSinks::getAnAlwaysDereferencedParameter/0#bfd578a4#prev`(FIRST 1)
  1541170   ~0%   {2} r2 = SCAN r1 OUTPUT In.1, In.0
  5825857   ~1%   {2} r3 = JOIN r2 WITH `ValueNumberingInternal::tvalueNumber/1#f03b58f9_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
   881300   ~0%   {4} r4 = JOIN r3 WITH `UseAfterFree::ParameterSinks::callHasTargetAndArgument/4#2549c98d_3012#join_rhs` ON FIRST 1 OUTPUT Rhs.3, Lhs.1, Rhs.1, Rhs.2
   642364   ~1%   {3} r5 = JOIN r4 WITH `project#UseAfterFree::ParameterSinks::getAnAlwaysReachedCallInstruction/1#30c9505a` ON FIRST 1 OUTPUT Lhs.2, Lhs.3, Lhs.1
   586991   ~0%   {2} r6 = JOIN r5 WITH `UseAfterFree::ParameterSinks::initializeParameterInFunction/3#0f75893b` ON FIRST 2 OUTPUT Rhs.2, Lhs.2
      948   ~3%   {1} r7 = JOIN r6 WITH `UseAfterFree::ParameterSinks::getAnAlwaysDereferencedParameter/0#bfd578a4#prev_delta` ON FIRST 1 OUTPUT Lhs.1
                  return r7
```

After:
```
Pipeline base for UseAfterFree::ParameterSinks::initializeParameterInFunction/2#29dff0d6@8b351y1h was evaluated in 1 iterations totaling 0ms (delta sizes total: 0).
  0  ~0%    {2} r1 = EMPTY(entity, int)
            return r1

Pipeline standard for UseAfterFree::ParameterSinks::initializeParameterInFunction/2#29dff0d6@8b351y1h was evaluated in 6 iterations totaling 3ms (delta sizes total: 5782).
  5782  ~0%    {2} r1 = JOIN `UseAfterFree::ParameterSinks::getAnAlwaysDereferencedParameter/0#bfd578a4#prev_delta` WITH `Instruction::InitializeParameterInstruction.hasIndex/1#0f90b0b3` ON FIRST 1 OUTPUT Lhs.0, Rhs.1
  5782  ~1%    {2} r2 = JOIN r1 WITH `Instruction::Instruction.getEnclosingFunction/0#dispred#cb8ccc56` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
  5782  ~1%    {2} r3 = JOIN r2 WITH functions ON FIRST 1 OUTPUT Lhs.0, Lhs.1
  5782  ~1%    {2} r4 = r3 AND NOT `UseAfterFree::ParameterSinks::initializeParameterInFunction/2#29dff0d6#prev`(FIRST 2)
               return r4

Pipeline base for UseAfterFree::ParameterSinks::alwaysDereferencedArgumentHasValueNumber/1#500ae075@8b351x1h was evaluated in 1 iterations totaling 0ms (delta sizes total: 0).
  0  ~0%    {1} r1 = EMPTY(unique numbered_tuple)
                return r1

Pipeline standard for UseAfterFree::ParameterSinks::alwaysDereferencedArgumentHasValueNumber/1#500ae075@8b351x1h was evaluated in 5 iterations totaling 5ms (delta sizes total: 4109).
  4370   ~5%    {1} r1 = JOIN `UseAfterFree::ParameterSinks::initializeParameterInFunction/2#29dff0d6#prev_delta` WITH `UseAfterFree::ParameterSinks::callHasTargetAndArgument/3#f5b63eb0` ON FIRST 2 OUTPUT Rhs.2
  4355  ~10%    {1} r2 = JOIN r1 WITH `ValueNumberingInternal::tvalueNumber/1#f03b58f9` ON FIRST 1 OUTPUT Rhs.1
  4109   ~3%    {1} r3 = r2 AND NOT `UseAfterFree::ParameterSinks::alwaysDereferencedArgumentHasValueNumber/1#500ae075#prev`(FIRST 1)
                    return r3

Pipeline base for UseAfterFree::ParameterSinks::getAnAlwaysDereferencedParameter/0#bfd578a4@8b351w1h was evaluated in 1 iterations totaling 1ms (delta sizes total: 4868).
  4868  ~0%    {1} r1 = JOIN `UseAfterFree::ParameterSinks::getAnAlwaysDereferencedParameter0/0#2ee9f822` WITH project#Instruction::InitializeParameterInstruction#d726fcda ON FIRST 1 OUTPUT Lhs.0
                return r1

Pipeline standard for UseAfterFree::ParameterSinks::getAnAlwaysDereferencedParameter/0#bfd578a4@8b351w1h was evaluated in 5 iterations totaling 6ms (delta sizes total: 914).
  10174  ~0%    {1} r1 = JOIN `UseAfterFree::ParameterSinks::alwaysDereferencedArgumentHasValueNumber/1#500ae075#prev_delta` WITH `ValueNumberingInternal::tvalueNumber/1#f03b58f9_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1
    973  ~0%    {1} r2 = JOIN r1 WITH project#Instruction::InitializeParameterInstruction#d726fcda ON FIRST 1 OUTPUT Lhs.0
    914  ~0%    {1} r3 = r2 AND NOT `UseAfterFree::ParameterSinks::getAnAlwaysDereferencedParameter/0#bfd578a4#prev`(FIRST 1)
                return r3
```