### PR TITLE
Data flow: prune context-sensitivity relations

### DIFF
--- a/csharp/ql/test/library-tests/dataflow/collections/CollectionFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/collections/CollectionFlow.expected
@@ -4,12 +4,6 @@ edges
 | CollectionFlow.cs:14:52:14:53 | access to parameter ts : A[] [element] : A | CollectionFlow.cs:14:52:14:56 | access to array element | provenance |  |
 | CollectionFlow.cs:14:52:14:53 | access to parameter ts : null [element] : A | CollectionFlow.cs:14:52:14:56 | access to array element | provenance |  |
 | CollectionFlow.cs:16:49:16:52 | list : List<T> [element] : A | CollectionFlow.cs:16:63:16:66 | access to parameter list : List<T> [element] : A | provenance |  |
-| CollectionFlow.cs:16:49:16:52 | list : List<T> [element] : A | CollectionFlow.cs:16:63:16:66 | access to parameter list : List<T> [element] : A | provenance |  |
-| CollectionFlow.cs:16:49:16:52 | list : List<T> [element] : A | CollectionFlow.cs:16:63:16:66 | access to parameter list : List<T> [element] : A | provenance |  |
-| CollectionFlow.cs:16:49:16:52 | list : List<T> [element] : A | CollectionFlow.cs:16:63:16:66 | access to parameter list : List<T> [element] : A | provenance |  |
-| CollectionFlow.cs:16:63:16:66 | access to parameter list : List<T> [element] : A | CollectionFlow.cs:16:63:16:69 | access to indexer | provenance |  |
-| CollectionFlow.cs:16:63:16:66 | access to parameter list : List<T> [element] : A | CollectionFlow.cs:16:63:16:69 | access to indexer | provenance |  |
-| CollectionFlow.cs:16:63:16:66 | access to parameter list : List<T> [element] : A | CollectionFlow.cs:16:63:16:69 | access to indexer | provenance |  |
 | CollectionFlow.cs:16:63:16:66 | access to parameter list : List<T> [element] : A | CollectionFlow.cs:16:63:16:69 | access to indexer | provenance |  |
 | CollectionFlow.cs:18:61:18:64 | dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:18:75:18:78 | access to parameter dict : Dictionary<T,T> [element, property Value] : A | provenance |  |
 | CollectionFlow.cs:18:75:18:78 | access to parameter dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:18:75:18:81 | access to indexer | provenance |  |
@@ -21,12 +15,6 @@ edges
 | CollectionFlow.cs:22:41:22:42 | access to parameter ts : A[] [element] : A | CollectionFlow.cs:22:41:22:45 | access to array element : A | provenance |  |
 | CollectionFlow.cs:22:41:22:42 | access to parameter ts : null [element] : A | CollectionFlow.cs:22:41:22:45 | access to array element : A | provenance |  |
 | CollectionFlow.cs:24:43:24:46 | list : List<T> [element] : A | CollectionFlow.cs:24:52:24:55 | access to parameter list : List<T> [element] : A | provenance |  |
-| CollectionFlow.cs:24:43:24:46 | list : List<T> [element] : A | CollectionFlow.cs:24:52:24:55 | access to parameter list : List<T> [element] : A | provenance |  |
-| CollectionFlow.cs:24:43:24:46 | list : List<T> [element] : A | CollectionFlow.cs:24:52:24:55 | access to parameter list : List<T> [element] : A | provenance |  |
-| CollectionFlow.cs:24:43:24:46 | list : List<T> [element] : A | CollectionFlow.cs:24:52:24:55 | access to parameter list : List<T> [element] : A | provenance |  |
-| CollectionFlow.cs:24:52:24:55 | access to parameter list : List<T> [element] : A | CollectionFlow.cs:24:52:24:58 | access to indexer : A | provenance |  |
-| CollectionFlow.cs:24:52:24:55 | access to parameter list : List<T> [element] : A | CollectionFlow.cs:24:52:24:58 | access to indexer : A | provenance |  |
-| CollectionFlow.cs:24:52:24:55 | access to parameter list : List<T> [element] : A | CollectionFlow.cs:24:52:24:58 | access to indexer : A | provenance |  |
 | CollectionFlow.cs:24:52:24:55 | access to parameter list : List<T> [element] : A | CollectionFlow.cs:24:52:24:58 | access to indexer : A | provenance |  |
 | CollectionFlow.cs:26:58:26:61 | dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:26:67:26:70 | access to parameter dict : Dictionary<T,T> [element, property Value] : A | provenance |  |
 | CollectionFlow.cs:26:67:26:70 | access to parameter dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:26:67:26:73 | access to indexer : A | provenance |  |
@@ -324,12 +312,6 @@ nodes
 | CollectionFlow.cs:14:52:14:53 | access to parameter ts : null [element] : A | semmle.label | access to parameter ts : null [element] : A |
 | CollectionFlow.cs:14:52:14:56 | access to array element | semmle.label | access to array element |
 | CollectionFlow.cs:16:49:16:52 | list : List<T> [element] : A | semmle.label | list : List<T> [element] : A |
-| CollectionFlow.cs:16:49:16:52 | list : List<T> [element] : A | semmle.label | list : List<T> [element] : A |
-| CollectionFlow.cs:16:49:16:52 | list : List<T> [element] : A | semmle.label | list : List<T> [element] : A |
-| CollectionFlow.cs:16:49:16:52 | list : List<T> [element] : A | semmle.label | list : List<T> [element] : A |
-| CollectionFlow.cs:16:63:16:66 | access to parameter list : List<T> [element] : A | semmle.label | access to parameter list : List<T> [element] : A |
-| CollectionFlow.cs:16:63:16:66 | access to parameter list : List<T> [element] : A | semmle.label | access to parameter list : List<T> [element] : A |
-| CollectionFlow.cs:16:63:16:66 | access to parameter list : List<T> [element] : A | semmle.label | access to parameter list : List<T> [element] : A |
 | CollectionFlow.cs:16:63:16:66 | access to parameter list : List<T> [element] : A | semmle.label | access to parameter list : List<T> [element] : A |
 | CollectionFlow.cs:16:63:16:69 | access to indexer | semmle.label | access to indexer |
 | CollectionFlow.cs:18:61:18:64 | dict : Dictionary<T,T> [element, property Value] : A | semmle.label | dict : Dictionary<T,T> [element, property Value] : A |
@@ -346,16 +328,7 @@ nodes
 | CollectionFlow.cs:22:41:22:45 | access to array element : A | semmle.label | access to array element : A |
 | CollectionFlow.cs:22:41:22:45 | access to array element : A | semmle.label | access to array element : A |
 | CollectionFlow.cs:24:43:24:46 | list : List<T> [element] : A | semmle.label | list : List<T> [element] : A |
-| CollectionFlow.cs:24:43:24:46 | list : List<T> [element] : A | semmle.label | list : List<T> [element] : A |
-| CollectionFlow.cs:24:43:24:46 | list : List<T> [element] : A | semmle.label | list : List<T> [element] : A |
-| CollectionFlow.cs:24:43:24:46 | list : List<T> [element] : A | semmle.label | list : List<T> [element] : A |
 | CollectionFlow.cs:24:52:24:55 | access to parameter list : List<T> [element] : A | semmle.label | access to parameter list : List<T> [element] : A |
-| CollectionFlow.cs:24:52:24:55 | access to parameter list : List<T> [element] : A | semmle.label | access to parameter list : List<T> [element] : A |
-| CollectionFlow.cs:24:52:24:55 | access to parameter list : List<T> [element] : A | semmle.label | access to parameter list : List<T> [element] : A |
-| CollectionFlow.cs:24:52:24:55 | access to parameter list : List<T> [element] : A | semmle.label | access to parameter list : List<T> [element] : A |
-| CollectionFlow.cs:24:52:24:58 | access to indexer : A | semmle.label | access to indexer : A |
-| CollectionFlow.cs:24:52:24:58 | access to indexer : A | semmle.label | access to indexer : A |
-| CollectionFlow.cs:24:52:24:58 | access to indexer : A | semmle.label | access to indexer : A |
 | CollectionFlow.cs:24:52:24:58 | access to indexer : A | semmle.label | access to indexer : A |
 | CollectionFlow.cs:26:58:26:61 | dict : Dictionary<T,T> [element, property Value] : A | semmle.label | dict : Dictionary<T,T> [element, property Value] : A |
 | CollectionFlow.cs:26:67:26:70 | access to parameter dict : Dictionary<T,T> [element, property Value] : A | semmle.label | access to parameter dict : Dictionary<T,T> [element, property Value] : A |

--- a/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
+++ b/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
@@ -20,14 +20,10 @@ edges
 | call_sensitivity.rb:44:26:44:33 | call to taint | call_sensitivity.rb:21:27:21:27 | x | provenance |  |
 | call_sensitivity.rb:50:15:50:15 | x | call_sensitivity.rb:51:10:51:10 | x | provenance |  |
 | call_sensitivity.rb:54:15:54:15 | x | call_sensitivity.rb:55:13:55:13 | x | provenance |  |
-| call_sensitivity.rb:54:15:54:15 | x | call_sensitivity.rb:55:13:55:13 | x | provenance |  |
-| call_sensitivity.rb:55:13:55:13 | x | call_sensitivity.rb:50:15:50:15 | x | provenance |  |
 | call_sensitivity.rb:55:13:55:13 | x | call_sensitivity.rb:50:15:50:15 | x | provenance |  |
 | call_sensitivity.rb:58:20:58:20 | x | call_sensitivity.rb:59:18:59:18 | x | provenance |  |
 | call_sensitivity.rb:59:18:59:18 | x | call_sensitivity.rb:54:15:54:15 | x | provenance |  |
 | call_sensitivity.rb:62:18:62:18 | y | call_sensitivity.rb:63:15:63:15 | y | provenance |  |
-| call_sensitivity.rb:62:18:62:18 | y | call_sensitivity.rb:63:15:63:15 | y | provenance |  |
-| call_sensitivity.rb:63:15:63:15 | y | call_sensitivity.rb:50:15:50:15 | x | provenance |  |
 | call_sensitivity.rb:63:15:63:15 | y | call_sensitivity.rb:50:15:50:15 | x | provenance |  |
 | call_sensitivity.rb:66:20:66:20 | x | call_sensitivity.rb:67:24:67:24 | x | provenance |  |
 | call_sensitivity.rb:67:24:67:24 | x | call_sensitivity.rb:62:18:62:18 | y | provenance |  |
@@ -40,26 +36,16 @@ edges
 | call_sensitivity.rb:85:18:85:27 | ( ... ) | call_sensitivity.rb:80:15:80:15 | x | provenance |  |
 | call_sensitivity.rb:85:19:85:26 | call to taint | call_sensitivity.rb:85:18:85:27 | ( ... ) | provenance |  |
 | call_sensitivity.rb:88:30:88:30 | x | call_sensitivity.rb:89:23:89:23 | x | provenance |  |
-| call_sensitivity.rb:88:30:88:30 | x | call_sensitivity.rb:89:23:89:23 | x | provenance |  |
-| call_sensitivity.rb:89:23:89:23 | x | call_sensitivity.rb:70:30:70:30 | x | provenance |  |
 | call_sensitivity.rb:89:23:89:23 | x | call_sensitivity.rb:70:30:70:30 | x | provenance |  |
 | call_sensitivity.rb:92:35:92:35 | x | call_sensitivity.rb:93:28:93:28 | x | provenance |  |
 | call_sensitivity.rb:93:28:93:28 | x | call_sensitivity.rb:88:30:88:30 | x | provenance |  |
 | call_sensitivity.rb:96:33:96:33 | y | call_sensitivity.rb:97:25:97:25 | y | provenance |  |
-| call_sensitivity.rb:96:33:96:33 | y | call_sensitivity.rb:97:25:97:25 | y | provenance |  |
-| call_sensitivity.rb:97:25:97:25 | y | call_sensitivity.rb:70:30:70:30 | x | provenance |  |
 | call_sensitivity.rb:97:25:97:25 | y | call_sensitivity.rb:70:30:70:30 | x | provenance |  |
 | call_sensitivity.rb:100:35:100:35 | x | call_sensitivity.rb:101:34:101:34 | x | provenance |  |
 | call_sensitivity.rb:101:34:101:34 | x | call_sensitivity.rb:96:33:96:33 | y | provenance |  |
 | call_sensitivity.rb:104:18:104:18 | x | call_sensitivity.rb:105:10:105:10 | x | provenance |  |
 | call_sensitivity.rb:104:18:104:18 | x | call_sensitivity.rb:105:10:105:10 | x | provenance |  |
-| call_sensitivity.rb:104:18:104:18 | x | call_sensitivity.rb:105:10:105:10 | x | provenance |  |
-| call_sensitivity.rb:104:18:104:18 | x | call_sensitivity.rb:105:10:105:10 | x | provenance |  |
 | call_sensitivity.rb:104:18:104:18 | x | call_sensitivity.rb:106:13:106:13 | x | provenance |  |
-| call_sensitivity.rb:104:18:104:18 | x | call_sensitivity.rb:106:13:106:13 | x | provenance |  |
-| call_sensitivity.rb:104:18:104:18 | x | call_sensitivity.rb:106:13:106:13 | x | provenance |  |
-| call_sensitivity.rb:106:13:106:13 | x | call_sensitivity.rb:50:15:50:15 | x | provenance |  |
-| call_sensitivity.rb:106:13:106:13 | x | call_sensitivity.rb:50:15:50:15 | x | provenance |  |
 | call_sensitivity.rb:106:13:106:13 | x | call_sensitivity.rb:50:15:50:15 | x | provenance |  |
 | call_sensitivity.rb:109:21:109:21 | x | call_sensitivity.rb:110:9:110:9 | x | provenance |  |
 | call_sensitivity.rb:110:9:110:9 | x | call_sensitivity.rb:104:18:104:18 | x | provenance |  |
@@ -124,14 +110,10 @@ nodes
 | call_sensitivity.rb:50:15:50:15 | x | semmle.label | x |
 | call_sensitivity.rb:51:10:51:10 | x | semmle.label | x |
 | call_sensitivity.rb:54:15:54:15 | x | semmle.label | x |
-| call_sensitivity.rb:54:15:54:15 | x | semmle.label | x |
-| call_sensitivity.rb:55:13:55:13 | x | semmle.label | x |
 | call_sensitivity.rb:55:13:55:13 | x | semmle.label | x |
 | call_sensitivity.rb:58:20:58:20 | x | semmle.label | x |
 | call_sensitivity.rb:59:18:59:18 | x | semmle.label | x |
 | call_sensitivity.rb:62:18:62:18 | y | semmle.label | y |
-| call_sensitivity.rb:62:18:62:18 | y | semmle.label | y |
-| call_sensitivity.rb:63:15:63:15 | y | semmle.label | y |
 | call_sensitivity.rb:63:15:63:15 | y | semmle.label | y |
 | call_sensitivity.rb:66:20:66:20 | x | semmle.label | x |
 | call_sensitivity.rb:67:24:67:24 | x | semmle.label | x |
@@ -145,24 +127,16 @@ nodes
 | call_sensitivity.rb:85:18:85:27 | ( ... ) | semmle.label | ( ... ) |
 | call_sensitivity.rb:85:19:85:26 | call to taint | semmle.label | call to taint |
 | call_sensitivity.rb:88:30:88:30 | x | semmle.label | x |
-| call_sensitivity.rb:88:30:88:30 | x | semmle.label | x |
-| call_sensitivity.rb:89:23:89:23 | x | semmle.label | x |
 | call_sensitivity.rb:89:23:89:23 | x | semmle.label | x |
 | call_sensitivity.rb:92:35:92:35 | x | semmle.label | x |
 | call_sensitivity.rb:93:28:93:28 | x | semmle.label | x |
 | call_sensitivity.rb:96:33:96:33 | y | semmle.label | y |
-| call_sensitivity.rb:96:33:96:33 | y | semmle.label | y |
-| call_sensitivity.rb:97:25:97:25 | y | semmle.label | y |
 | call_sensitivity.rb:97:25:97:25 | y | semmle.label | y |
 | call_sensitivity.rb:100:35:100:35 | x | semmle.label | x |
 | call_sensitivity.rb:101:34:101:34 | x | semmle.label | x |
 | call_sensitivity.rb:104:18:104:18 | x | semmle.label | x |
 | call_sensitivity.rb:104:18:104:18 | x | semmle.label | x |
-| call_sensitivity.rb:104:18:104:18 | x | semmle.label | x |
-| call_sensitivity.rb:104:18:104:18 | x | semmle.label | x |
 | call_sensitivity.rb:105:10:105:10 | x | semmle.label | x |
-| call_sensitivity.rb:106:13:106:13 | x | semmle.label | x |
-| call_sensitivity.rb:106:13:106:13 | x | semmle.label | x |
 | call_sensitivity.rb:106:13:106:13 | x | semmle.label | x |
 | call_sensitivity.rb:109:21:109:21 | x | semmle.label | x |
 | call_sensitivity.rb:110:9:110:9 | x | semmle.label | x |

--- a/ruby/ql/test/library-tests/dataflow/global/Flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/global/Flow.expected
@@ -140,7 +140,6 @@ edges
 | instance_variables.rb:28:20:28:24 | field | instance_variables.rb:22:20:22:24 | field | provenance |  |
 | instance_variables.rb:28:20:28:24 | field | instance_variables.rb:28:9:28:25 | [post] self [@field] | provenance |  |
 | instance_variables.rb:31:18:31:18 | x | instance_variables.rb:33:13:33:13 | x | provenance |  |
-| instance_variables.rb:32:13:32:21 | call to taint | instance_variables.rb:22:20:22:24 | field | provenance |  |
 | instance_variables.rb:32:13:32:21 | call to taint | instance_variables.rb:48:20:48:20 | x | provenance |  |
 | instance_variables.rb:33:13:33:13 | x | instance_variables.rb:22:20:22:24 | field | provenance |  |
 | instance_variables.rb:33:13:33:13 | x | instance_variables.rb:33:9:33:14 | call to new [@field] | provenance |  |

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
@@ -393,6 +393,216 @@ module MakeImplCommon<InputSig Lang> {
     result = viableCallableLambda(call, _)
   }
 
+  signature module CallContextSensitivityInputSig {
+    /** Holds if the edge is possibly needed in the direction `call` to `c`. */
+    predicate relevantCallEdgeIn(DataFlowCall call, DataFlowCallable c);
+
+    /** Holds if the edge is possibly needed in the direction `c` to `call`. */
+    predicate relevantCallEdgeOut(DataFlowCall call, DataFlowCallable c);
+
+    /**
+     * Holds if the call context `ctx` may reduce the set of viable run-time
+     * dispatch targets of call `call` in `c`.
+     */
+    default predicate reducedViableImplInCallContextCand(
+      DataFlowCall call, DataFlowCallable c, DataFlowCall ctx
+    ) {
+      relevantCallEdgeIn(ctx, c) and
+      mayBenefitFromCallContextExt(call, c)
+    }
+
+    /**
+     * Holds if flow returning from callable `c` to call `call` might return
+     * further and if this path may restrict the set of call sites that can be
+     * returned to.
+     */
+    default predicate reducedViableImplInReturnCand(DataFlowCallable c, DataFlowCall call) {
+      relevantCallEdgeOut(call, c) and
+      mayBenefitFromCallContextExt(call, _)
+    }
+  }
+
+  /** Provides predicates releated to call-context sensitivity. */
+  module CallContextSensitivity<CallContextSensitivityInputSig Input> {
+    private import Input
+
+    pragma[nomagic]
+    DataFlowCallable viableImplInCallContextExtIn(DataFlowCall call, DataFlowCall ctx) {
+      reducedViableImplInCallContextCand(call, _, ctx) and
+      result = viableImplInCallContextExt(call, ctx) and
+      relevantCallEdgeIn(call, result)
+    }
+
+    /**
+     * Holds if the call context `ctx` reduces the set of viable run-time
+     * dispatch targets of call `call` in `c`.
+     */
+    pragma[nomagic]
+    predicate reducedViableImplInCallContext(DataFlowCall call, DataFlowCallable c, DataFlowCall ctx) {
+      exists(int tgts, int ctxtgts |
+        reducedViableImplInCallContextCand(call, c, ctx) and
+        ctxtgts = count(viableImplInCallContextExtIn(call, ctx)) and
+        tgts = strictcount(DataFlowCallable tgt | relevantCallEdgeIn(call, tgt)) and
+        ctxtgts < tgts
+      )
+    }
+
+    /**
+     * Holds if the call context `call` allows us to prune unreachable nodes in `callable`.
+     */
+    pragma[nomagic]
+    predicate recordDataFlowCallSiteUnreachable(DataFlowCall call, DataFlowCallable callable) {
+      exists(Node n |
+        relevantCallEdgeIn(call, callable) and
+        getNodeEnclosingCallable(n) = callable and
+        isUnreachableInCallCached(n, call)
+      )
+    }
+
+    pragma[nomagic]
+    DataFlowCallable viableImplInCallContextExtOut(DataFlowCall call, DataFlowCall ctx) {
+      exists(DataFlowCallable c |
+        reducedViableImplInReturnCand(result, call) and
+        result = viableImplInCallContextExt(call, ctx) and
+        mayBenefitFromCallContextExt(call, c) and
+        relevantCallEdgeOut(ctx, c)
+      )
+    }
+
+    /**
+     * Holds if flow returning from callable `c` to call `call` might return
+     * further and if this path restricts the set of call sites that can be
+     * returned to.
+     */
+    pragma[nomagic]
+    predicate reducedViableImplInReturn(DataFlowCallable c, DataFlowCall call) {
+      exists(int tgts, int ctxtgts |
+        reducedViableImplInReturnCand(c, call) and
+        ctxtgts = count(DataFlowCall ctx | c = viableImplInCallContextExtOut(call, ctx)) and
+        tgts =
+          strictcount(DataFlowCall ctx |
+            callEnclosingCallable(call, any(DataFlowCallable encl | relevantCallEdgeOut(ctx, encl)))
+          ) and
+        ctxtgts < tgts
+      )
+    }
+
+    signature module PrunedViableImplInputSig {
+      predicate reducedViableImplInCallContext(
+        DataFlowCall call, DataFlowCallable c, DataFlowCall ctx
+      );
+
+      predicate reducedViableImplInReturn(DataFlowCallable c, DataFlowCall call);
+
+      predicate recordDataFlowCallSiteUnreachable(DataFlowCall call, DataFlowCallable c);
+    }
+
+    /**
+     * This module is only parameterized so that we can refer to cached versions
+     * of the input predicates in `CachedCallContextSensitivity`.
+     */
+    module PrunedViableImpl<PrunedViableImplInputSig Input2> {
+      /**
+       * Gets a viable run-time dispatch target for the call `call` in the
+       * context `ctx`. This is restricted to those calls for which a context
+       * makes a difference.
+       */
+      pragma[nomagic]
+      DataFlowCallable prunedViableImplInCallContext(DataFlowCall call, CallContextSpecificCall ctx) {
+        exists(DataFlowCall outer | ctx = TSpecificCall(outer) |
+          result = viableImplInCallContextExtIn(call, outer) and
+          Input2::reducedViableImplInCallContext(call, _, outer)
+        )
+      }
+
+      /** Holds if `call` does not have a reduced set of dispatch targets in call context `ctx`. */
+      bindingset[call, ctx]
+      predicate noPrunedViableImplInCallContext(DataFlowCall call, CallContext ctx) {
+        exists(DataFlowCall outer | ctx = TSpecificCall(outer) |
+          not Input2::reducedViableImplInCallContext(call, _, outer)
+        )
+        or
+        ctx instanceof CallContextSomeCall
+        or
+        ctx instanceof CallContextAny
+        or
+        ctx instanceof CallContextReturn
+      }
+
+      /**
+       * Resolves a call from `call` in `cc` to `result`, where `result` is
+       * restricted by `relevantResolveTarget`.
+       */
+      bindingset[call, cc]
+      DataFlowCallable resolveCall(DataFlowCall call, CallContext cc) {
+        result = prunedViableImplInCallContext(call, cc)
+        or
+        noPrunedViableImplInCallContext(call, cc) and
+        relevantCallEdgeIn(call, result)
+      }
+
+      /**
+       * Gets a viable call site for the return from `callable` in call context
+       * `ctx`. This is restricted to those callables and contexts for which
+       * the possible call sites are restricted.
+       */
+      pragma[nomagic]
+      DataFlowCall prunedViableImplInCallContextReverse(
+        DataFlowCallable callable, CallContextReturn ctx
+      ) {
+        exists(DataFlowCallable c0, DataFlowCall call0 |
+          callEnclosingCallable(call0, callable) and
+          ctx = TReturn(c0, call0) and
+          c0 = viableImplInCallContextExtOut(call0, result) and
+          Input2::reducedViableImplInReturn(c0, call0)
+        )
+      }
+
+      /**
+       * Resolves a return from `callable` in `cc` to `call`.
+       */
+      bindingset[cc, callable]
+      predicate resolveReturn(CallContextNoCall cc, DataFlowCallable callable, DataFlowCall call) {
+        cc instanceof CallContextAny and relevantCallEdgeOut(call, callable)
+        or
+        call = prunedViableImplInCallContextReverse(callable, cc)
+      }
+
+      /**
+       * Holds if the call context `call` improves virtual dispatch in `callable`.
+       */
+      pragma[nomagic]
+      predicate recordDataFlowCallSiteDispatch(DataFlowCall call, DataFlowCallable callable) {
+        Input2::reducedViableImplInCallContext(_, callable, call)
+      }
+
+      /**
+       * Holds if the call context `call` either improves virtual dispatch in
+       * `callable` or if it allows us to prune unreachable nodes in `callable`.
+       */
+      predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable c) {
+        Input2::recordDataFlowCallSiteUnreachable(call, c) or
+        recordDataFlowCallSiteDispatch(call, c)
+      }
+    }
+
+    private predicate reducedViableImplInCallContextAlias = reducedViableImplInCallContext/3;
+
+    private predicate reducedViableImplInReturnAlias = reducedViableImplInReturn/2;
+
+    private predicate recordDataFlowCallSiteUnreachableAlias = recordDataFlowCallSiteUnreachable/2;
+
+    private module DefaultPrunedViableImplInput implements PrunedViableImplInputSig {
+      predicate reducedViableImplInCallContext = reducedViableImplInCallContextAlias/3;
+
+      predicate reducedViableImplInReturn = reducedViableImplInReturnAlias/2;
+
+      predicate recordDataFlowCallSiteUnreachable = recordDataFlowCallSiteUnreachableAlias/2;
+    }
+
+    import PrunedViableImpl<DefaultPrunedViableImplInput>
+  }
+
   cached
   private module Cached {
     /**
@@ -496,6 +706,102 @@ module MakeImplCommon<InputSig Lang> {
         LambdaFlow::revLambdaFlow(call, kind, creation, _, _, _, lastCall) and
         lambdaCreation(creation, kind, result)
       )
+    }
+
+    /**
+     * Holds if the set of viable implementations that can be called by `call`
+     * might be improved by knowing the call context.
+     */
+    cached
+    predicate mayBenefitFromCallContextExt(DataFlowCall call, DataFlowCallable callable) {
+      (
+        mayBenefitFromCallContext(call)
+        or
+        exists(viableCallableLambda(call, TDataFlowCallSome(_)))
+      ) and
+      callEnclosingCallable(call, callable)
+    }
+
+    /**
+     * Gets a viable dispatch target of `call` in the context `ctx`. This is
+     * restricted to those `call`s for which a context might make a difference.
+     */
+    cached
+    DataFlowCallable viableImplInCallContextExt(DataFlowCall call, DataFlowCall ctx) {
+      result = viableImplInCallContext(call, ctx) and
+      result = viableCallable(call)
+      or
+      result = viableCallableLambda(call, TDataFlowCallSome(ctx))
+      or
+      exists(DataFlowCallable enclosing |
+        mayBenefitFromCallContextExt(call, enclosing) and
+        enclosing = viableCallableExt(ctx) and
+        result = viableCallableLambda(call, TDataFlowCallNone())
+      )
+    }
+
+    /**
+     * A cached version of the `CallContextSensitivity` module. Only used in
+     * pruning stages 1+2 and flow exploration; all subsequent pruning stages use a
+     * pruned version, based on the relevant call edges from the previous stage.
+     */
+    cached
+    module CachedCallContextSensitivity {
+      private module CallContextSensitivityInput implements CallContextSensitivityInputSig {
+        predicate relevantCallEdgeIn(DataFlowCall call, DataFlowCallable c) {
+          c = viableCallableExt(call)
+        }
+
+        predicate relevantCallEdgeOut(DataFlowCall call, DataFlowCallable c) {
+          c = viableCallableExt(call)
+        }
+      }
+
+      private module Impl1 = CallContextSensitivity<CallContextSensitivityInput>;
+
+      cached
+      predicate reducedViableImplInCallContext(
+        DataFlowCall call, DataFlowCallable c, DataFlowCall ctx
+      ) {
+        Impl1::reducedViableImplInCallContext(call, c, ctx)
+      }
+
+      cached
+      predicate recordDataFlowCallSiteUnreachable(DataFlowCall call, DataFlowCallable c) {
+        Impl1::recordDataFlowCallSiteUnreachable(call, c)
+      }
+
+      cached
+      predicate reducedViableImplInReturn(DataFlowCallable c, DataFlowCall call) {
+        Impl1::reducedViableImplInReturn(c, call)
+      }
+
+      private module PrunedViableImplInput implements Impl1::PrunedViableImplInputSig {
+        predicate reducedViableImplInCallContext =
+          CachedCallContextSensitivity::reducedViableImplInCallContext/3;
+
+        predicate reducedViableImplInReturn =
+          CachedCallContextSensitivity::reducedViableImplInReturn/2;
+
+        predicate recordDataFlowCallSiteUnreachable =
+          CachedCallContextSensitivity::recordDataFlowCallSiteUnreachable/2;
+      }
+
+      private module Impl2 = Impl1::PrunedViableImpl<PrunedViableImplInput>;
+
+      import Impl2
+
+      cached
+      DataFlowCallable prunedViableImplInCallContext(DataFlowCall call, CallContextSpecificCall ctx) {
+        result = Impl2::prunedViableImplInCallContext(call, ctx)
+      }
+
+      cached
+      DataFlowCall prunedViableImplInCallContextReverse(
+        DataFlowCallable callable, CallContextReturn ctx
+      ) {
+        result = Impl2::prunedViableImplInCallContextReverse(callable, ctx)
+      }
     }
 
     /**
@@ -788,106 +1094,6 @@ module MakeImplCommon<InputSig Lang> {
 
     import FlowThrough
 
-    cached
-    private module DispatchWithCallContext {
-      /**
-       * Holds if the set of viable implementations that can be called by `call`
-       * might be improved by knowing the call context.
-       */
-      pragma[nomagic]
-      private predicate mayBenefitFromCallContextExt(DataFlowCall call, DataFlowCallable callable) {
-        (
-          mayBenefitFromCallContext(call)
-          or
-          exists(viableCallableLambda(call, TDataFlowCallSome(_)))
-        ) and
-        callEnclosingCallable(call, callable)
-      }
-
-      /**
-       * Gets a viable dispatch target of `call` in the context `ctx`. This is
-       * restricted to those `call`s for which a context might make a difference.
-       */
-      cached
-      DataFlowCallable viableImplInCallContextExt(DataFlowCall call, DataFlowCall ctx) {
-        result = viableImplInCallContext(call, ctx) and
-        result = viableCallable(call)
-        or
-        result = viableCallableLambda(call, TDataFlowCallSome(ctx))
-        or
-        exists(DataFlowCallable enclosing |
-          mayBenefitFromCallContextExt(call, enclosing) and
-          enclosing = viableCallableExt(ctx) and
-          result = viableCallableLambda(call, TDataFlowCallNone())
-        )
-      }
-
-      /**
-       * Holds if the call context `ctx` reduces the set of viable run-time
-       * dispatch targets of call `call` in `c`.
-       */
-      cached
-      predicate reducedViableImplInCallContext(
-        DataFlowCall call, DataFlowCallable c, DataFlowCall ctx
-      ) {
-        exists(int tgts, int ctxtgts |
-          mayBenefitFromCallContextExt(call, c) and
-          c = viableCallableExt(ctx) and
-          ctxtgts = count(viableImplInCallContextExt(call, ctx)) and
-          tgts = strictcount(viableCallableExt(call)) and
-          ctxtgts < tgts
-        )
-      }
-
-      /**
-       * Gets a viable run-time dispatch target for the call `call` in the
-       * context `ctx`. This is restricted to those calls for which a context
-       * makes a difference.
-       */
-      cached
-      DataFlowCallable prunedViableImplInCallContext(DataFlowCall call, CallContextSpecificCall ctx) {
-        exists(DataFlowCall outer | ctx = TSpecificCall(outer) |
-          result = viableImplInCallContextExt(call, outer) and
-          reducedViableImplInCallContext(call, _, outer)
-        )
-      }
-
-      /**
-       * Holds if flow returning from callable `c` to call `call` might return
-       * further and if this path restricts the set of call sites that can be
-       * returned to.
-       */
-      cached
-      predicate reducedViableImplInReturn(DataFlowCallable c, DataFlowCall call) {
-        exists(int tgts, int ctxtgts |
-          mayBenefitFromCallContextExt(call, _) and
-          c = viableCallableExt(call) and
-          ctxtgts = count(DataFlowCall ctx | c = viableImplInCallContextExt(call, ctx)) and
-          tgts = strictcount(DataFlowCall ctx | callEnclosingCallable(call, viableCallableExt(ctx))) and
-          ctxtgts < tgts
-        )
-      }
-
-      /**
-       * Gets a viable call site for the return from `callable` in call context
-       * `ctx`. This is restricted to those callables and contexts for which
-       * the possible call sites are restricted.
-       */
-      cached
-      DataFlowCall prunedViableImplInCallContextReverse(
-        DataFlowCallable callable, CallContextReturn ctx
-      ) {
-        exists(DataFlowCallable c0, DataFlowCall call0 |
-          callEnclosingCallable(call0, callable) and
-          ctx = TReturn(c0, call0) and
-          c0 = viableImplInCallContextExt(call0, result) and
-          reducedViableImplInReturn(c0, call0)
-        )
-      }
-    }
-
-    import DispatchWithCallContext
-
     /**
      * Holds if `p` can flow to the pre-update node associated with post-update
      * node `n`, in the same callable, using only value-preserving steps.
@@ -966,22 +1172,6 @@ module MakeImplCommon<InputSig Lang> {
       reverseStepThroughInputOutputAlias(node1, node2)
     }
 
-    /**
-     * Holds if the call context `call` improves virtual dispatch in `callable`.
-     */
-    cached
-    predicate recordDataFlowCallSiteDispatch(DataFlowCall call, DataFlowCallable callable) {
-      reducedViableImplInCallContext(_, callable, call)
-    }
-
-    /**
-     * Holds if the call context `call` allows us to prune unreachable nodes in `callable`.
-     */
-    cached
-    predicate recordDataFlowCallSiteUnreachable(DataFlowCall call, DataFlowCallable callable) {
-      exists(Node n | getNodeEnclosingCallable(n) = callable | isUnreachableInCallCached(n, call))
-    }
-
     cached
     predicate allowParameterReturnInSelfCached(ParamNode p) { allowParameterReturnInSelf(p) }
 
@@ -994,9 +1184,13 @@ module MakeImplCommon<InputSig Lang> {
     cached
     newtype TCallContext =
       TAnyCallContext() or
-      TSpecificCall(DataFlowCall call) { recordDataFlowCallSite(call, _) } or
+      TSpecificCall(DataFlowCall call) {
+        CachedCallContextSensitivity::recordDataFlowCallSite(call, _)
+      } or
       TSomeCall() or
-      TReturn(DataFlowCallable c, DataFlowCall call) { reducedViableImplInReturn(c, call) }
+      TReturn(DataFlowCallable c, DataFlowCall call) {
+        CachedCallContextSensitivity::reducedViableImplInReturn(c, call)
+      }
 
     cached
     newtype TReturnPosition =
@@ -1449,15 +1643,6 @@ module MakeImplCommon<InputSig Lang> {
   }
 
   /**
-   * Holds if the call context `call` either improves virtual dispatch in
-   * `callable` or if it allows us to prune unreachable nodes in `callable`.
-   */
-  predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
-    recordDataFlowCallSiteDispatch(call, callable) or
-    recordDataFlowCallSiteUnreachable(call, callable)
-  }
-
-  /**
    * A `Node` at which a cast can occur such that the type should be checked.
    */
   class CastingNode instanceof Node {
@@ -1542,7 +1727,7 @@ module MakeImplCommon<InputSig Lang> {
     }
 
     override predicate relevantFor(DataFlowCallable callable) {
-      recordDataFlowCallSite(this.getCall(), callable)
+      CachedCallContextSensitivity::recordDataFlowCallSite(this.getCall(), callable)
     }
 
     override predicate matchesCall(DataFlowCall call) { call = this.getCall() }
@@ -1771,58 +1956,6 @@ module MakeImplCommon<InputSig Lang> {
   pragma[noinline]
   ReturnPosition getReturnPosition(ReturnNodeExt ret) {
     result = getReturnPosition0(ret, ret.getKind())
-  }
-
-  /** Holds if `call` does not have a reduced set of dispatch targets in call context `ctx`. */
-  bindingset[call, ctx]
-  predicate noPrunedViableImplInCallContext(DataFlowCall call, CallContext ctx) {
-    exists(DataFlowCall outer | ctx = TSpecificCall(outer) |
-      not reducedViableImplInCallContext(call, _, outer)
-    )
-    or
-    ctx instanceof CallContextSomeCall
-    or
-    ctx instanceof CallContextAny
-    or
-    ctx instanceof CallContextReturn
-  }
-
-  /**
-   * Resolves a return from `callable` in `cc` to `call`.
-   */
-  bindingset[cc, callable]
-  predicate resolveReturn(CallContext cc, DataFlowCallable callable, DataFlowCall call) {
-    cc instanceof CallContextAny and callable = viableCallableExt(call)
-    or
-    call = prunedViableImplInCallContextReverse(callable, cc)
-  }
-
-  signature predicate relevantResolveTargetSig(DataFlowCallable c);
-
-  module ResolveCall<relevantResolveTargetSig/1 relevantResolveTarget> {
-    pragma[nomagic]
-    private DataFlowCallable prunedRelevantViableImplInCallContext(DataFlowCall call, CallContext cc) {
-      result = prunedViableImplInCallContext(call, cc) and
-      relevantResolveTarget(result)
-    }
-
-    pragma[nomagic]
-    private DataFlowCallable viableRelevantCallableExt(DataFlowCall call) {
-      result = viableCallableExt(call) and
-      relevantResolveTarget(result)
-    }
-
-    /**
-     * Resolves a call from `call` in `cc` to `result`, where `result` is
-     * restricted by `relevantResolveTarget`.
-     */
-    bindingset[call, cc]
-    DataFlowCallable resolveCall(DataFlowCall call, CallContext cc) {
-      result = prunedRelevantViableImplInCallContext(call, cc)
-      or
-      noPrunedViableImplInCallContext(call, cc) and
-      result = viableRelevantCallableExt(call)
-    }
   }
 
   /** An optional Boolean value. */

--- a/swift/ql/test/query-tests/Security/CWE-311/CleartextStorageDatabase.expected
+++ b/swift/ql/test/query-tests/Security/CWE-311/CleartextStorageDatabase.expected
@@ -164,7 +164,6 @@ edges
 | testCoreData2.swift:98:18:98:18 | d [value] | testCoreData2.swift:98:18:98:20 | .value | provenance |  |
 | testCoreData2.swift:98:18:98:20 | .value | testCoreData2.swift:98:2:98:2 | [post] dbObj [myValue] | provenance |  |
 | testCoreData2.swift:101:10:101:10 | bankAccountNo | testCoreData2.swift:103:13:103:13 | e | provenance |  |
-| testCoreData2.swift:103:13:103:13 | e | testCoreData2.swift:70:9:70:9 | self | provenance |  |
 | testCoreData2.swift:103:13:103:13 | e | testCoreData2.swift:104:18:104:18 | e | provenance |  |
 | testCoreData2.swift:104:2:104:2 | [post] dbObj [myValue] | testCoreData2.swift:104:2:104:2 | [post] dbObj | provenance |  |
 | testCoreData2.swift:104:18:104:18 | e | testCoreData2.swift:70:9:70:9 | self | provenance |  |


### PR DESCRIPTION
This PR parameterizes predicates related to context-sensitivity by the relevant call edges, in a new `CallContextSensitivity<CallContextSensitivityInputSig Input>` module. This enables us to compute those predicates based on the relevant call edges from the previous pruning stage, in turn allowing for potentially smaller tuple counts:

<details><summary>Example tuple counts before</summary>

\# | n | stage | nodes | fields | conscand | states | tuples | calledges | tfnodes | tftuples
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | 30 | 3 Fwd | 41,891 | 1,202 | 64,539 | 1 | 9,164,518 | 13,020 | 0 | 0
2 | 50 | 5 Fwd | 17,482 | 488 | 2,952 | 1 | 128,109 | 7,004 | 0 | 0
3 | 60 | 6 Fwd | 13,739 | 385 | 1,396 | 1 | 61,374 | -1 | -1 | -1
4 | 65 | 6 Rev | 860 | 35 | 43 | 1 | 1,108 | -1 | -1 | -1

</details>

<details><summary>Example tuple counts after</summary>

\# | n | stage | nodes | fields | conscand | states | tuples | calledges | tfnodes | tftuples
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | 30 | 3 Fwd | 41,891 | 1,202 | 64,539 | 1 | 8,990,350 | 13,020 | 0 | 0
2 | 50 | 5 Fwd | 17,482 | 488 | 2,952 | 1 | 126,516 | 7,004 | 0 | 0
3 | 60 | 6 Fwd | 13,739 | 385 | 1,396 | 1 | 60,628 | -1 | -1 | -1
4 | 65 | 6 Rev | 860 | 35 | 43 | 1 | 1,098 | -1 | -1 | -1



</details>