### PR TITLE
C#: Fix working directory structures in standalone

### DIFF
--- a/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
@@ -936,9 +936,9 @@ namespace Semmle.Autobuild.CSharp.Tests
         {
             actions.RunProcess["dotnet --list-sdks"] = 0;
             actions.RunProcessOut["dotnet --list-sdks"] = "2.1.2 [C:\\Program Files\\dotnet\\sdks]\n2.1.4 [C:\\Program Files\\dotnet\\sdks]";
-            actions.RunProcess[@"chmod u+x dotnet-install.sh"] = 0;
-            actions.RunProcess[@"./dotnet-install.sh --channel release --version 2.1.3 --install-dir scratch/.dotnet"] = 0;
-            actions.RunProcess[@"rm dotnet-install.sh"] = 0;
+            actions.RunProcess[@"chmod u+x scratch/.dotnet/dotnet-install.sh"] = 0;
+            actions.RunProcess[@"scratch/.dotnet/dotnet-install.sh --channel release --version 2.1.3 --install-dir scratch/.dotnet"] = 0;
+            actions.RunProcess[@"rm scratch/.dotnet/dotnet-install.sh"] = 0;
             actions.RunProcess[@"scratch/.dotnet/dotnet --info"] = 0;
             actions.RunProcess[@"scratch/.dotnet/dotnet clean C:\Project/test.csproj"] = 0;
             actions.RunProcess[@"scratch/.dotnet/dotnet restore C:\Project/test.csproj"] = 0;
@@ -960,7 +960,8 @@ namespace Semmle.Autobuild.CSharp.Tests
 
 </Project>");
             actions.LoadXml[@"C:\Project/test.csproj"] = xml;
-            actions.DownloadFiles.Add(("https://dot.net/v1/dotnet-install.sh", "dotnet-install.sh"));
+            actions.DownloadFiles.Add(("https://dot.net/v1/dotnet-install.sh", "scratch/.dotnet/dotnet-install.sh"));
+            actions.CreateDirectories.Add(@"scratch/.dotnet");
 
             var autobuilder = CreateAutoBuilder(false, dotnetVersion: "2.1.3");
             TestAutobuilderScript(autobuilder, 0, 8);
@@ -972,9 +973,9 @@ namespace Semmle.Autobuild.CSharp.Tests
             actions.RunProcess["dotnet --list-sdks"] = 0;
             actions.RunProcessOut["dotnet --list-sdks"] = @"2.1.3 [C:\Program Files\dotnet\sdks]
 2.1.4 [C:\Program Files\dotnet\sdks]";
-            actions.RunProcess[@"chmod u+x dotnet-install.sh"] = 0;
-            actions.RunProcess[@"./dotnet-install.sh --channel release --version 2.1.3 --install-dir scratch/.dotnet"] = 0;
-            actions.RunProcess[@"rm dotnet-install.sh"] = 0;
+            actions.RunProcess[@"chmod u+x scratch/.dotnet/dotnet-install.sh"] = 0;
+            actions.RunProcess[@"scratch/.dotnet/dotnet-install.sh --channel release --version 2.1.3 --install-dir scratch/.dotnet"] = 0;
+            actions.RunProcess[@"rm scratch/.dotnet/dotnet-install.sh"] = 0;
             actions.RunProcess[@"scratch/.dotnet/dotnet --info"] = 0;
             actions.RunProcess[@"scratch/.dotnet/dotnet clean C:\Project/test.csproj"] = 0;
             actions.RunProcess[@"scratch/.dotnet/dotnet restore C:\Project/test.csproj"] = 0;
@@ -996,7 +997,8 @@ namespace Semmle.Autobuild.CSharp.Tests
 
 </Project>");
             actions.LoadXml[@"C:\Project/test.csproj"] = xml;
-            actions.DownloadFiles.Add(("https://dot.net/v1/dotnet-install.sh", "dotnet-install.sh"));
+            actions.DownloadFiles.Add(("https://dot.net/v1/dotnet-install.sh", "scratch/.dotnet/dotnet-install.sh"));
+            actions.CreateDirectories.Add(@"scratch/.dotnet");
 
             var autobuilder = CreateAutoBuilder(false, dotnetVersion: "2.1.3");
             TestAutobuilderScript(autobuilder, 0, 8);

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
@@ -938,7 +938,6 @@ namespace Semmle.Autobuild.CSharp.Tests
             actions.RunProcessOut["dotnet --list-sdks"] = "2.1.2 [C:\\Program Files\\dotnet\\sdks]\n2.1.4 [C:\\Program Files\\dotnet\\sdks]";
             actions.RunProcess[@"chmod u+x scratch/.dotnet/dotnet-install.sh"] = 0;
             actions.RunProcess[@"scratch/.dotnet/dotnet-install.sh --channel release --version 2.1.3 --install-dir scratch/.dotnet"] = 0;
-            actions.RunProcess[@"rm scratch/.dotnet/dotnet-install.sh"] = 0;
             actions.RunProcess[@"scratch/.dotnet/dotnet --info"] = 0;
             actions.RunProcess[@"scratch/.dotnet/dotnet clean C:\Project/test.csproj"] = 0;
             actions.RunProcess[@"scratch/.dotnet/dotnet restore C:\Project/test.csproj"] = 0;
@@ -964,7 +963,7 @@ namespace Semmle.Autobuild.CSharp.Tests
             actions.CreateDirectories.Add(@"scratch/.dotnet");
 
             var autobuilder = CreateAutoBuilder(false, dotnetVersion: "2.1.3");
-            TestAutobuilderScript(autobuilder, 0, 8);
+            TestAutobuilderScript(autobuilder, 0, 7);
         }
 
         [Fact]
@@ -975,7 +974,6 @@ namespace Semmle.Autobuild.CSharp.Tests
 2.1.4 [C:\Program Files\dotnet\sdks]";
             actions.RunProcess[@"chmod u+x scratch/.dotnet/dotnet-install.sh"] = 0;
             actions.RunProcess[@"scratch/.dotnet/dotnet-install.sh --channel release --version 2.1.3 --install-dir scratch/.dotnet"] = 0;
-            actions.RunProcess[@"rm scratch/.dotnet/dotnet-install.sh"] = 0;
             actions.RunProcess[@"scratch/.dotnet/dotnet --info"] = 0;
             actions.RunProcess[@"scratch/.dotnet/dotnet clean C:\Project/test.csproj"] = 0;
             actions.RunProcess[@"scratch/.dotnet/dotnet restore C:\Project/test.csproj"] = 0;
@@ -1001,7 +999,7 @@ namespace Semmle.Autobuild.CSharp.Tests
             actions.CreateDirectories.Add(@"scratch/.dotnet");
 
             var autobuilder = CreateAutoBuilder(false, dotnetVersion: "2.1.3");
-            TestAutobuilderScript(autobuilder, 0, 8);
+            TestAutobuilderScript(autobuilder, 0, 7);
         }
 
         private void TestDotnetVersionWindows(Action action, int commandsRun)

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp/DotNetRule.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp/DotNetRule.cs
@@ -190,18 +190,20 @@ namespace Semmle.Autobuild.CSharp
                     }
                     else
                     {
+                        var dotnetInstallPath = builder.Actions.PathCombine(FileUtils.GetTemporaryWorkingDirectory(builder.Actions.GetEnvironmentVariable, builder.Options.Language.UpperCaseName, out var _), ".dotnet", "dotnet-install.sh");
+
                         var downloadDotNetInstallSh = BuildScript.DownloadFile(
                             "https://dot.net/v1/dotnet-install.sh",
-                            "dotnet-install.sh",
+                            dotnetInstallPath,
                             e => builder.Log(Severity.Warning, $"Failed to download 'dotnet-install.sh': {e.Message}"));
 
                         var chmod = new CommandBuilder(builder.Actions).
                             RunCommand("chmod").
                             Argument("u+x").
-                            Argument("dotnet-install.sh");
+                            Argument(dotnetInstallPath);
 
                         var install = new CommandBuilder(builder.Actions).
-                            RunCommand("./dotnet-install.sh").
+                            RunCommand(dotnetInstallPath).
                             Argument("--channel").
                             Argument("release").
                             Argument("--version").
@@ -211,7 +213,7 @@ namespace Semmle.Autobuild.CSharp
 
                         var removeScript = new CommandBuilder(builder.Actions).
                             RunCommand("rm").
-                            Argument("dotnet-install.sh");
+                            Argument(dotnetInstallPath);
 
                         return downloadDotNetInstallSh & chmod.Script & install.Script & BuildScript.Try(removeScript.Script);
                     }

--- a/csharp/extractor/Semmle.Util/FileUtils.cs
+++ b/csharp/extractor/Semmle.Util/FileUtils.cs
@@ -144,7 +144,7 @@ namespace Semmle.Util
             return nested;
         }
 
-        private static Lazy<string> tempFolderPath = new Lazy<string>(() =>
+        private static readonly Lazy<string> tempFolderPath = new Lazy<string>(() =>
         {
             var tempPath = Path.GetTempPath();
             var name = Guid.NewGuid().ToString("N").ToUpper();

--- a/csharp/extractor/Semmle.Util/FileUtils.cs
+++ b/csharp/extractor/Semmle.Util/FileUtils.cs
@@ -144,40 +144,26 @@ namespace Semmle.Util
             return nested;
         }
 
-        private static string? tempFolderPath = null;
-        private static readonly object lockObject = new();
+        private static Lazy<string> tempFolderPath = new Lazy<string>(() =>
+        {
+            var tempPath = Path.GetTempPath();
+            var name = Guid.NewGuid().ToString("N").ToUpper();
+            var tempFolder = Path.Combine(tempPath, "GitHub", name);
+            Directory.CreateDirectory(tempFolder);
+            return tempFolder;
+        });
 
         public static string GetTemporaryWorkingDirectory(Func<string, string?> getEnvironmentVariable, string lang, out bool shouldCleanUp)
         {
-            shouldCleanUp = false;
             var tempFolder = getEnvironmentVariable($"CODEQL_EXTRACTOR_{lang}_SCRATCH_DIR");
             if (!string.IsNullOrEmpty(tempFolder))
             {
+                shouldCleanUp = false;
                 return tempFolder;
             }
 
-            if (!string.IsNullOrEmpty(tempFolderPath))
-            {
-                shouldCleanUp = true;
-                return tempFolderPath;
-            }
-
-            lock (lockObject)
-            {
-                if (!string.IsNullOrEmpty(tempFolderPath))
-                {
-                    shouldCleanUp = true;
-                    return tempFolderPath;
-                }
-
-                var tempPath = Path.GetTempPath();
-                var name = Guid.NewGuid().ToString("N").ToUpper();
-                tempFolder = Path.Combine(tempPath, "GitHub", name);
-                Directory.CreateDirectory(tempFolder);
-                tempFolderPath = tempFolder;
-                shouldCleanUp = true;
-                return tempFolder;
-            }
+            shouldCleanUp = true;
+            return tempFolderPath.Value;
         }
 
         public static string GetTemporaryWorkingDirectory(out bool shouldCleanUp) =>

--- a/csharp/ql/integration-tests/all-platforms/standalone_dependencies_net48/Assemblies.ql
+++ b/csharp/ql/integration-tests/all-platforms/standalone_dependencies_net48/Assemblies.ql
@@ -4,10 +4,11 @@ private string getPath(Assembly a) {
   not a.getCompilation().getOutputAssembly() = a and
   exists(string s | s = a.getFile().getAbsolutePath() |
     result =
-      s.substring(s.indexOf("GitHub/packages/") + "GitHub/packages/".length() + 16, s.length())
+      s.substring(s.indexOf("test-db/working/") + "test-db/working/".length() + 16 +
+          "/packages".length(), s.length())
     or
     result = s and
-    not exists(s.indexOf("GitHub/packages/"))
+    not exists(s.indexOf("test-db/working/"))
   )
 }
 

--- a/csharp/ql/integration-tests/posix-only/standalone_dependencies/Assemblies.ql
+++ b/csharp/ql/integration-tests/posix-only/standalone_dependencies/Assemblies.ql
@@ -4,10 +4,11 @@ private string getPath(Assembly a) {
   not a.getCompilation().getOutputAssembly() = a and
   exists(string s | s = a.getFile().getAbsolutePath() |
     result =
-      s.substring(s.indexOf("GitHub/packages/") + "GitHub/packages/".length() + 16, s.length())
+      s.substring(s.indexOf("test-db/working/") + "test-db/working/".length() + 16 +
+          "/packages".length(), s.length())
     or
     result = s and
-    not exists(s.indexOf("GitHub/packages/"))
+    not exists(s.indexOf("test-db/working/"))
   )
 }
 

--- a/csharp/ql/integration-tests/posix-only/standalone_dependencies_multi_target/Assemblies.ql
+++ b/csharp/ql/integration-tests/posix-only/standalone_dependencies_multi_target/Assemblies.ql
@@ -4,10 +4,11 @@ private string getPath(Assembly a) {
   not a.getCompilation().getOutputAssembly() = a and
   exists(string s | s = a.getFile().getAbsolutePath() |
     result =
-      s.substring(s.indexOf("GitHub/packages/") + "GitHub/packages/".length() + 16, s.length())
+      s.substring(s.indexOf("test-db/working/") + "test-db/working/".length() + 16 +
+          "/packages".length(), s.length())
     or
     result = s and
-    not exists(s.indexOf("GitHub/packages/"))
+    not exists(s.indexOf("test-db/working/"))
   )
 }
 

--- a/csharp/ql/integration-tests/posix-only/standalone_dependencies_nuget/Assemblies.ql
+++ b/csharp/ql/integration-tests/posix-only/standalone_dependencies_nuget/Assemblies.ql
@@ -4,19 +4,9 @@ private string getPath(Assembly a) {
   not a.getCompilation().getOutputAssembly() = a and
   exists(string s | s = a.getFile().getAbsolutePath() |
     result =
-      s.substring(s.indexOf("GitHub/packages/") + "GitHub/packages/".length() + 16, s.length())
-    or
-    result =
-      s.substring(s.indexOf("GitHub/legacypackages/") + "GitHub/legacypackages/".length() + 16,
-        s.length())
-    // TODO: excluding all other assemblies from the test result as mono installations seem problematic on ARM runners.
-    // or
-    // result = s.substring(s.indexOf("lib/mono/") + "lib/mono/".length(), s.length())
-    // or
-    // result = s and
-    // not exists(s.indexOf("GitHub/packages/")) and
-    // not exists(s.indexOf("GitHub/legacypackages/")) and
-    // not exists(s.indexOf("lib/mono/"))
+      s.substring(s.indexOf("test-db/working/") + "test-db/working/".length() + 16 +
+          "/legacypackages".length(), s.length())
+    // TODO: include all other assemblies from the test results. Initially disable because mono installations were problematic on ARM runners.
   )
 }
 

--- a/csharp/ql/integration-tests/windows-only/standalone_dependencies/Assemblies.ql
+++ b/csharp/ql/integration-tests/windows-only/standalone_dependencies/Assemblies.ql
@@ -4,10 +4,11 @@ private string getPath(Assembly a) {
   not a.getCompilation().getOutputAssembly() = a and
   exists(string s | s = a.getFile().getAbsolutePath() |
     result =
-      s.substring(s.indexOf("GitHub/packages/") + "GitHub/packages/".length() + 16, s.length())
+      s.substring(s.indexOf("test-db/working/") + "test-db/working/".length() + 16 +
+          "/packages".length(), s.length())
     or
     result = s and
-    not exists(s.indexOf("GitHub/packages/"))
+    not exists(s.indexOf("test-db/working/"))
   )
 }
 


### PR DESCRIPTION
This pull request primarily includes changes to the handling of temporary directories and the `dotnet-install.sh` script in the autobuilder and extraction process. The most significant changes are:

1. The `dotnet-install.sh` script is now downloaded to a temporary directory instead of the current working directory. This change affects the `TestDotnetVersionNotInstalled` and `TestDotnetVersionAlreadyInstalled` methods in `BuildScripts.cs` and the `DownloadDotNetVersion` method in `DotNetRule.cs`. The script is also now removed from its new location after use. <a href="diffhunk://#diff-960d40c5594b66712b00013de087f7c94ba4494d5a5d6512a45916b8c1f95ae6L939-R941">[1]</a> <a href="diffhunk://#diff-960d40c5594b66712b00013de087f7c94ba4494d5a5d6512a45916b8c1f95ae6L963-R964">[2]</a> <a href="diffhunk://#diff-960d40c5594b66712b00013de087f7c94ba4494d5a5d6512a45916b8c1f95ae6L975-R978">[3]</a> <a href="diffhunk://#diff-960d40c5594b66712b00013de087f7c94ba4494d5a5d6512a45916b8c1f95ae6L999-R1001">[4]</a> <a href="diffhunk://#diff-6a815312c10dfc86cbd8ca11a5a9df02a9106032f6f73677433f8793cfbd0e9eR193-R206">[5]</a> <a href="diffhunk://#diff-6a815312c10dfc86cbd8ca11a5a9df02a9106032f6f73677433f8793cfbd0e9eL214-R216">[6]</a>

2. Temporary directories for package extraction are now created in a more consistent manner. The `ComputeTempDirectory` method in `DependencyManager.cs` now takes a `subfolderName` parameter to specify the subdirectory within the temporary directory. This parameter is used in `DownloadMissingPackages` and the `DependencyManager` constructor. <a href="diffhunk://#diff-0179d8d74e2e78735e1d6cde08b1cff43d2a132f2c53a86c277cfdf3bbd95017L55-R55">[1]</a> <a href="diffhunk://#diff-0179d8d74e2e78735e1d6cde08b1cff43d2a132f2c53a86c277cfdf3bbd95017L470-R478">[2]</a> <a href="diffhunk://#diff-0179d8d74e2e78735e1d6cde08b1cff43d2a132f2c53a86c277cfdf3bbd95017L726-R726">[3]</a>

3. The `GetTemporaryWorkingDirectory` method in `FileUtils.cs` now creates and reuses a single temporary directory for the duration of the extraction process, unless an environment variable is set to specify a different directory.

4. Several integration tests have been updated to reflect the new structure of temporary directories. <a href="diffhunk://#diff-11cadc4b5f6d734e227fddfe607e0a3901928660b90f07bbcbbc758a46935400L7-R11">[1]</a> <a href="diffhunk://#diff-1c4ca6ea7099341c5b9b5bf747f9c96613ac591655ea3b5121dbe31c2e525142L7-R9">[2]</a>

(The above is generated by copilot)