### PR TITLE
Data flow: Avoid unnecessary non-linear recursion in `fwdFlowIn`

### DIFF
--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -1467,10 +1467,11 @@ module MakeImpl<InputSig Lang> {
         pragma[nomagic]
         private predicate fwdFlowIntoArg(
           ArgNodeEx arg, FlowState state, Cc outercc, ParamNodeOption summaryCtx, TypOption argT,
-          ApOption argAp, Typ t, Ap ap, ApApprox apa, boolean cc
+          ApOption argAp, Typ t, Ap ap, boolean emptyAp, ApApprox apa, boolean cc
         ) {
           fwdFlow(arg, state, outercc, summaryCtx, argT, argAp, t, ap, apa) and
-          if outercc instanceof CcCall then cc = true else cc = false
+          (if outercc instanceof CcCall then cc = true else cc = false) and
+          if ap instanceof ApNil then emptyAp = true else emptyAp = false
         }
 
         private signature module FwdFlowInInputSig {
@@ -1552,26 +1553,59 @@ module MakeImpl<InputSig Lang> {
             viableImplNotCallContextReducedInlineLate(call, outercc)
           }
 
-          pragma[nomagic]
+          pragma[inline]
           private predicate fwdFlowInCand(
-            DataFlowCall call, ArgNodeEx arg, Cc outercc, DataFlowCallable inner, ParamNodeEx p,
-            ApApprox apa, boolean allowsFieldFlow, boolean cc
+            DataFlowCall call, ArgNodeEx arg, FlowState state, Cc outercc, DataFlowCallable inner,
+            ParamNodeEx p, ParamNodeOption summaryCtx, TypOption argT, ApOption argAp, Typ t, Ap ap,
+            boolean emptyAp, ApApprox apa, boolean cc
           ) {
-            fwdFlowIntoArg(arg, _, outercc, _, _, _, _, _, apa, cc) and
-            (
-              inner = viableImplCallContextReducedInlineLate(call, arg, outercc)
-              or
-              viableImplArgNotCallContextReduced(call, arg, outercc)
-            ) and
-            callEdgeArgParamRestrictedInlineLate(call, inner, arg, p, allowsFieldFlow, apa)
+            exists(boolean allowsFieldFlow |
+              fwdFlowIntoArg(arg, state, outercc, summaryCtx, argT, argAp, t, ap, emptyAp, apa, cc) and
+              (
+                inner = viableImplCallContextReducedInlineLate(call, arg, outercc)
+                or
+                viableImplArgNotCallContextReduced(call, arg, outercc)
+              ) and
+              callEdgeArgParamRestrictedInlineLate(call, inner, arg, p, allowsFieldFlow, apa) and
+              if allowsFieldFlow = false then emptyAp = true else any()
+            )
+          }
+
+          pragma[inline]
+          private predicate fwdFlowInCandTypeFlowDisabled(
+            DataFlowCall call, ArgNodeEx arg, FlowState state, Cc outercc, DataFlowCallable inner,
+            ParamNodeEx p, ParamNodeOption summaryCtx, TypOption argT, ApOption argAp, Typ t, Ap ap,
+            ApApprox apa, boolean cc
+          ) {
+            not enableTypeFlow() and
+            fwdFlowInCand(call, arg, state, outercc, inner, p, summaryCtx, argT, argAp, t, ap, _,
+              apa, cc)
           }
 
           pragma[nomagic]
-          private predicate fwdFlowInValidEdge(
+          private predicate fwdFlowInCandTypeFlowEnabled(
             DataFlowCall call, ArgNodeEx arg, Cc outercc, DataFlowCallable inner, ParamNodeEx p,
-            CcCall innercc, ApApprox apa, boolean allowsFieldFlow, boolean cc
+            boolean emptyAp, ApApprox apa, boolean cc
           ) {
-            fwdFlowInCand(call, arg, outercc, inner, p, apa, allowsFieldFlow, cc) and
+            enableTypeFlow() and
+            fwdFlowInCand(call, arg, _, outercc, inner, p, _, _, _, _, _, emptyAp, apa, cc)
+          }
+
+          pragma[nomagic]
+          private predicate fwdFlowInValidEdgeTypeFlowDisabled(
+            DataFlowCall call, DataFlowCallable inner, CcCall innercc, boolean cc
+          ) {
+            not enableTypeFlow() and
+            FwdTypeFlow::typeFlowValidEdgeIn(call, inner, cc) and
+            innercc = getCallContextCall(call, inner)
+          }
+
+          pragma[nomagic]
+          private predicate fwdFlowInValidEdgeTypeFlowEnabled(
+            DataFlowCall call, ArgNodeEx arg, Cc outercc, DataFlowCallable inner, ParamNodeEx p,
+            CcCall innercc, boolean emptyAp, ApApprox apa, boolean cc
+          ) {
+            fwdFlowInCandTypeFlowEnabled(call, arg, outercc, inner, p, emptyAp, apa, cc) and
             FwdTypeFlow::typeFlowValidEdgeIn(call, inner, cc) and
             innercc = getCallContextCall(call, inner)
           }
@@ -1582,10 +1616,18 @@ module MakeImpl<InputSig Lang> {
             CcCall innercc, ParamNodeOption summaryCtx, TypOption argT, ApOption argAp, Typ t,
             Ap ap, ApApprox apa, boolean cc
           ) {
-            exists(ArgNodeEx arg, boolean allowsFieldFlow |
-              fwdFlowIntoArg(arg, state, outercc, summaryCtx, argT, argAp, t, ap, apa, cc) and
-              fwdFlowInValidEdge(call, arg, outercc, inner, p, innercc, apa, allowsFieldFlow, cc) and
-              if allowsFieldFlow = false then ap instanceof ApNil else any()
+            exists(ArgNodeEx arg |
+              // type flow disabled: linear recursion
+              fwdFlowInCandTypeFlowDisabled(call, arg, state, outercc, inner, p, summaryCtx, argT,
+                argAp, t, ap, apa, cc) and
+              fwdFlowInValidEdgeTypeFlowDisabled(call, inner, innercc, cc)
+              or
+              // type flow enabled: non-linear recursion
+              exists(boolean emptyAp |
+                fwdFlowIntoArg(arg, state, outercc, summaryCtx, argT, argAp, t, ap, emptyAp, apa, cc) and
+                fwdFlowInValidEdgeTypeFlowEnabled(call, arg, outercc, inner, p, innercc, emptyAp,
+                  apa, cc)
+              )
             )
           }
         }


### PR DESCRIPTION
Non-linear recursion is only needed when type flow is enabled, so this PR makes sure that we don't do unnecessary non-linear recursion in those pruning stages where type flow is disabled.

<details><summary>Example DIL before</summary>

```
noinline
nomagic
incremental
`DataFlowImpl::Impl<HttpClient::HttpClientDisablesCertificateValidationFlow::C>::Stage2::fwdFlowIn/6#e7e669eb`(
  /* DataFlowImpl::MakeImpl<DataFlowImplSpecific::RubyDataFlow>::Impl<DataFlow::DataFlowMake<DataFlowImplSpecific::RubyDataFlow>::Global<HttpClient::HttpClientDisablesCertificateValidationConfig>::C>::ParamNodeEx */ `DataFlowImpl#248dabc3::MakeImpl<DataFlowImplSpecific#21008cd7::RubyDataFlow>::Impl<DataFlow#167ac380::DataFlowMake<DataFlowImplSpecific#21008cd7::RubyDataFlow>::Global<HttpClient#d717370f::HttpClientDisablesCertificateValidationConfig>::C>::TNodeEx` p,
  /* Unit::Unit */ Unit#54592529::TUnit apa,
  /* Unit::Unit */ Unit#54592529::TUnit state,
  /* DataFlowImplCommon::MakeImplCommon<DataFlowImplSpecific::RubyDataFlow>::CallContextCall */ `DataFlowImplCommon#f7de413b::MakeImplCommon<DataFlowImplSpecific#21008cd7::RubyDataFlow>::Cached::TCallContext` innercc,
  /* Unit::Unit */ Unit#54592529::TUnit t, /* Boolean::Boolean */ boolean ap
)
{
  [base_case] false()
  [recursive_case]
  (
    exists(boolean allowsFieldFlow |
      exists(
        /* DataFlowImpl::MakeImpl<DataFlowImplSpecific::RubyDataFlow>::Impl<DataFlow::DataFlowMake<DataFlowImplSpecific::RubyDataFlow>::Global<HttpClient::HttpClientDisablesCertificateValidationConfig>::C>::ArgNodeEx */ `DataFlowImpl#248dabc3::MakeImpl<DataFlowImplSpecific#21008cd7::RubyDataFlow>::Impl<DataFlow#167ac380::DataFlowMake<DataFlowImplSpecific#21008cd7::RubyDataFlow>::Global<HttpClient#d717370f::HttpClientDisablesCertificateValidationConfig>::C>::TNodeEx` arg,
        /* DataFlowImplCommon::MakeImplCommon<DataFlowImplSpecific::RubyDataFlow>::CallContext */ `DataFlowImplCommon#f7de413b::MakeImplCommon<DataFlowImplSpecific#21008cd7::RubyDataFlow>::Cached::TCallContext` dummyField1,
        boolean dummyField
       |
        exists(
          /* DataFlowImplCommon::MakeImplCommon<DataFlowImplSpecific::RubyDataFlow>::BooleanOption */ dontcare `DataFlowImplCommon#f7de413b::MakeImplCommon<DataFlowImplSpecific#21008cd7::RubyDataFlow>::Cached::TBooleanOption` _,
          /* Option::Option<Unit::Unit>::Option */ dontcare `Option#8eb11f23::Option<Unit#54592529::Unit>::TOption` _1,
          /* DataFlowImplCommon::MakeImplCommon<DataFlowImplSpecific::RubyDataFlow>::ParamNodeOption */ dontcare `DataFlowImplCommon#f7de413b::MakeImplCommon<DataFlowImplSpecific#21008cd7::RubyDataFlow>::Cached::TParamNodeOption` _2
         |
          delta previous rec `DataFlowImpl::Impl<HttpClient::HttpClientDisablesCertificateValidationFlow::C>::Stage2::fwdFlowIntoArg/10#dbbd8af8`(arg,
            state, dummyField1, _2, _1, _, t, ap, apa, dummyField)
        ) and
        exists(
          /* DataFlowDispatch::DataFlowCallable */ dontcare DataFlowDispatch#36b84300::Cached::TDataFlowCallable _,
          /* DataFlowDispatch::DataFlowCall */ dontcare DataFlowDispatch#36b84300::Cached::TDataFlowCall _1
         |
          previous rec `DataFlowImpl::Impl<HttpClient::HttpClientDisablesCertificateValidationFlow::C>::Stage2::FwdFlowIn<FwdFlowInNoRestriction>::fwdFlowInValidEdge/9#af336f0f`(_1,
            arg, dummyField1, _, p, innercc, apa, allowsFieldFlow, dummyField)
        )
      ) and
      (
        (allowsFieldFlow = false and ap = false)
        or
        not(allowsFieldFlow = false)
      )
    )
    or
    exists(boolean allowsFieldFlow |
      exists(
        /* DataFlowImpl::MakeImpl<DataFlowImplSpecific::RubyDataFlow>::Impl<DataFlow::DataFlowMake<DataFlowImplSpecific::RubyDataFlow>::Global<HttpClient::HttpClientDisablesCertificateValidationConfig>::C>::ArgNodeEx */ `DataFlowImpl#248dabc3::MakeImpl<DataFlowImplSpecific#21008cd7::RubyDataFlow>::Impl<DataFlow#167ac380::DataFlowMake<DataFlowImplSpecific#21008cd7::RubyDataFlow>::Global<HttpClient#d717370f::HttpClientDisablesCertificateValidationConfig>::C>::TNodeEx` arg,
        /* DataFlowImplCommon::MakeImplCommon<DataFlowImplSpecific::RubyDataFlow>::CallContext */ `DataFlowImplCommon#f7de413b::MakeImplCommon<DataFlowImplSpecific#21008cd7::RubyDataFlow>::Cached::TCallContext` dummyField1,
        boolean dummyField
       |
        exists(
          /* DataFlowDispatch::DataFlowCallable */ dontcare DataFlowDispatch#36b84300::Cached::TDataFlowCallable _,
          /* DataFlowDispatch::DataFlowCall */ dontcare DataFlowDispatch#36b84300::Cached::TDataFlowCall _1
         |
          delta previous rec `DataFlowImpl::Impl<HttpClient::HttpClientDisablesCertificateValidationFlow::C>::Stage2::FwdFlowIn<FwdFlowInNoRestriction>::fwdFlowInValidEdge/9#af336f0f`(_1,
            arg, dummyField1, _, p, innercc, apa, allowsFieldFlow, dummyField)
        ) and
        exists(
          /* DataFlowImplCommon::MakeImplCommon<DataFlowImplSpecific::RubyDataFlow>::BooleanOption */ dontcare `DataFlowImplCommon#f7de413b::MakeImplCommon<DataFlowImplSpecific#21008cd7::RubyDataFlow>::Cached::TBooleanOption` _,
          /* Option::Option<Unit::Unit>::Option */ dontcare `Option#8eb11f23::Option<Unit#54592529::Unit>::TOption` _1,
          /* DataFlowImplCommon::MakeImplCommon<DataFlowImplSpecific::RubyDataFlow>::ParamNodeOption */ dontcare `DataFlowImplCommon#f7de413b::MakeImplCommon<DataFlowImplSpecific#21008cd7::RubyDataFlow>::Cached::TParamNodeOption` _2
         |
          previous rec `DataFlowImpl::Impl<HttpClient::HttpClientDisablesCertificateValidationFlow::C>::Stage2::fwdFlowIntoArg/10#dbbd8af8`(arg,
            state, dummyField1, _2, _1, _, t, ap, apa, dummyField)
        )
      ) and
      (
        (ap = false and allowsFieldFlow = false)
        or
        not(allowsFieldFlow = false)
      )
    )
  ) and
  not(
    previous rec `DataFlowImpl::Impl<HttpClient::HttpClientDisablesCertificateValidationFlow::C>::Stage2::fwdFlowIn/6#e7e669eb`(p,
      apa, state, innercc, t, ap)
  )
}
```

</details>

<details><summary>Example DIL after</summary>

```
noinline
nomagic
incremental
`DataFlowImpl::Impl<HttpClient::HttpClientDisablesCertificateValidationFlow::C>::Stage2::fwdFlowIn/6#e7e669eb`(
  /* DataFlowImpl::MakeImpl<DataFlowImplSpecific::RubyDataFlow>::Impl<DataFlow::DataFlowMake<DataFlowImplSpecific::RubyDataFlow>::Global<HttpClient::HttpClientDisablesCertificateValidationConfig>::C>::ParamNodeEx */ `DataFlowImpl#248dabc3::MakeImpl<DataFlowImplSpecific#21008cd7::RubyDataFlow>::Impl<DataFlow#167ac380::DataFlowMake<DataFlowImplSpecific#21008cd7::RubyDataFlow>::Global<HttpClient#d717370f::HttpClientDisablesCertificateValidationConfig>::C>::TNodeEx` p,
  /* Unit::Unit */ Unit#54592529::TUnit apa,
  /* Unit::Unit */ Unit#54592529::TUnit state,
  /* DataFlowImplCommon::MakeImplCommon<DataFlowImplSpecific::RubyDataFlow>::CallContextCall */ `DataFlowImplCommon#f7de413b::MakeImplCommon<DataFlowImplSpecific#21008cd7::RubyDataFlow>::Cached::TCallContext` innercc,
  /* Unit::Unit */ Unit#54592529::TUnit t, /* Boolean::Boolean */ boolean ap
)
{
  [base_case] false()
  [recursive_case]
  exists(boolean allowsFieldFlow, boolean emptyAp |
    exists(
      /* DataFlowDispatch::DataFlowCall */ DataFlowDispatch#36b84300::Cached::TDataFlowCall dummyField2,
      /* DataFlowDispatch::DataFlowCallable */ DataFlowDispatch#36b84300::Cached::TDataFlowCallable dummyField1,
      /* DataFlowImpl::MakeImpl<DataFlowImplSpecific::RubyDataFlow>::Impl<DataFlow::DataFlowMake<DataFlowImplSpecific::RubyDataFlow>::Global<HttpClient::HttpClientDisablesCertificateValidationConfig>::C>::ArgNodeEx */ `DataFlowImpl#248dabc3::MakeImpl<DataFlowImplSpecific#21008cd7::RubyDataFlow>::Impl<DataFlow#167ac380::DataFlowMake<DataFlowImplSpecific#21008cd7::RubyDataFlow>::Global<HttpClient#d717370f::HttpClientDisablesCertificateValidationConfig>::C>::TNodeEx` arg
     |
      exists(boolean dummyField |
        exists(
          /* DataFlowImplCommon::MakeImplCommon<DataFlowImplSpecific::RubyDataFlow>::CallContext */ `DataFlowImplCommon#f7de413b::MakeImplCommon<DataFlowImplSpecific#21008cd7::RubyDataFlow>::Cached::TCallContext` dummyField3
         |
          exists(
            /* DataFlowImplCommon::MakeImplCommon<DataFlowImplSpecific::RubyDataFlow>::BooleanOption */ dontcare `DataFlowImplCommon#f7de413b::MakeImplCommon<DataFlowImplSpecific#21008cd7::RubyDataFlow>::Cached::TBooleanOption` _,
            /* Option::Option<Unit::Unit>::Option */ dontcare `Option#8eb11f23::Option<Unit#54592529::Unit>::TOption` _1,
            /* DataFlowImplCommon::MakeImplCommon<DataFlowImplSpecific::RubyDataFlow>::ParamNodeOption */ dontcare `DataFlowImplCommon#f7de413b::MakeImplCommon<DataFlowImplSpecific#21008cd7::RubyDataFlow>::Cached::TParamNodeOption` _2
           |
            delta previous rec `DataFlowImpl::Impl<HttpClient::HttpClientDisablesCertificateValidationFlow::C>::Stage2::fwdFlowIntoArg/11#9c3d5d05`(arg,
              state, dummyField3, _2, _1, _, t, ap, emptyAp, apa, dummyField)
          ) and
          (
            (
              DataFlowImplCommon::CallContextCall#class#d7d23011(dummyField3) and
              `project#DataFlowImpl::Impl<HttpClient::HttpClientDisablesCertificateValidationFlow::C>::Stage2::FwdFlowIn<FwdFlowInNoRestriction>::callEdgeArgParamRestricted/6#e11f7cc7`(dummyField2,
                arg) and
              `DataFlowImpl::Impl<HttpClient::HttpClientDisablesCertificateValidationFlow::C>::Stage2::FwdFlowIn<FwdFlowInNoRestriction>::viableImplCallContextReducedRestricted/2#ae6fa78a`(dummyField2,
                dummyField3, dummyField1) and
              `DataFlowImpl::Impl<HttpClient::HttpClientDisablesCertificateValidationFlow::C>::Stage2::FwdFlowIn<FwdFlowInNoRestriction>::fwdFlowInValidEdgeTypeFlowDisabled/4#475ef90b`(dummyField2,
                dummyField1, innercc, dummyField)
            )
            or
            (
              `DataFlowImplCommon#f7de413b::MakeImplCommon<DataFlowImplSpecific#21008cd7::RubyDataFlow>::Cached::TCallContext`(dummyField3) and
              `project#DataFlowImpl::Impl<HttpClient::HttpClientDisablesCertificateValidationFlow::C>::Stage2::FwdFlowIn<FwdFlowInNoRestriction>::callEdgeArgParamRestricted/6#e11f7cc7`(dummyField2,
                arg) and
              DataFlowDispatch#36b84300::Cached::TDataFlowCall(dummyField2) and
              (
                exists(
                  /* DataFlowDispatch::DataFlowCall */ DataFlowDispatch#36b84300::Cached::TDataFlowCall outer
                 |
                  `DataFlowImplCommon#f7de413b::MakeImplCommon<DataFlowImplSpecific#21008cd7::RubyDataFlow>::Cached::TSpecificCall`(outer,
                    dummyField3) and
                  not(
                    `project#DataFlowImplCommon::Cached::DispatchWithCallContext::reducedViableImplInCallContext/3#1d75019d`(dummyField2,
                      outer)
                  )
                )
                or
                `DataFlowImplCommon#f7de413b::MakeImplCommon<DataFlowImplSpecific#21008cd7::RubyDataFlow>::Cached::TSomeCall`(dummyField3)
                or
                `DataFlowImplCommon#f7de413b::MakeImplCommon<DataFlowImplSpecific#21008cd7::RubyDataFlow>::Cached::TAnyCallContext`(dummyField3)
                or
                exists(
                  /* DataFlowDispatch::DataFlowCallable */ dontcare DataFlowDispatch#36b84300::Cached::TDataFlowCallable _,
                  /* DataFlowDispatch::DataFlowCall */ dontcare DataFlowDispatch#36b84300::Cached::TDataFlowCall _1
                 |
                  `DataFlowImplCommon#f7de413b::MakeImplCommon<DataFlowImplSpecific#21008cd7::RubyDataFlow>::Cached::TReturn`(_,
                    _1, dummyField3)
                )
              ) and
              `DataFlowImpl::Impl<HttpClient::HttpClientDisablesCertificateValidationFlow::C>::Stage2::FwdFlowIn<FwdFlowInNoRestriction>::fwdFlowInValidEdgeTypeFlowDisabled/4#475ef90b`(dummyField2,
                dummyField1, innercc, dummyField)
            )
          )
        ) and
        `DataFlowImpl::Impl<HttpClient::HttpClientDisablesCertificateValidationFlow::C>::Stage2::FwdFlowIn<FwdFlowInNoRestriction>::fwdFlowInValidEdgeTypeFlowDisabled/4#475ef90b`(dummyField2,
          dummyField1, innercc, dummyField)
      ) and
      `DataFlowImpl::Impl<HttpClient::HttpClientDisablesCertificateValidationFlow::C>::Stage2::FwdFlowIn<FwdFlowInNoRestriction>::callEdgeArgParamRestricted/6#e11f7cc7`(dummyField2,
        dummyField1, arg, p, allowsFieldFlow, apa)
    ) and
    not(
      previous rec `DataFlowImpl::Impl<HttpClient::HttpClientDisablesCertificateValidationFlow::C>::Stage2::fwdFlowIn/6#e7e669eb`(p,
        apa, state, innercc, t, ap)
    ) and
    (
      (allowsFieldFlow = false and emptyAp = true)
      or
      not(allowsFieldFlow = false)
    )
  )
}
```

</details>