### PR TITLE
C#: Classify test support files in model editor queries

### DIFF
--- a/csharp/ql/src/utils/modeleditor/FrameworkModeEndpointsQuery.qll
+++ b/csharp/ql/src/utils/modeleditor/FrameworkModeEndpointsQuery.qll
@@ -7,7 +7,7 @@ private import ModelEditor
  * A class of effectively public callables from source code.
  */
 class PublicEndpointFromSource extends Endpoint {
-  PublicEndpointFromSource() { this.fromSource() and not this.getFile() instanceof TestFile }
+  PublicEndpointFromSource() { this.fromSource() and not this.getFile() instanceof TestRelatedFile }
 
   override predicate isSource() { this instanceof SourceCallable }
 

--- a/csharp/ql/src/utils/modeleditor/FrameworkModeEndpointsQuery.qll
+++ b/csharp/ql/src/utils/modeleditor/FrameworkModeEndpointsQuery.qll
@@ -7,7 +7,11 @@ private import ModelEditor
  * A class of effectively public callables from source code.
  */
 class PublicEndpointFromSource extends Endpoint {
-  PublicEndpointFromSource() { this.fromSource() and not this.getFile() instanceof TestFile }
+  PublicEndpointFromSource() {
+    this.fromSource() and
+    not this.getFile() instanceof TestFile and
+    not this.getFile() instanceof TestSupportFile
+  }
 
   override predicate isSource() { this instanceof SourceCallable }
 

--- a/csharp/ql/src/utils/modeleditor/FrameworkModeEndpointsQuery.qll
+++ b/csharp/ql/src/utils/modeleditor/FrameworkModeEndpointsQuery.qll
@@ -7,11 +7,7 @@ private import ModelEditor
  * A class of effectively public callables from source code.
  */
 class PublicEndpointFromSource extends Endpoint {
-  PublicEndpointFromSource() {
-    this.fromSource() and
-    not this.getFile() instanceof TestFile and
-    not this.getFile() instanceof TestSupportFile
-  }
+  PublicEndpointFromSource() { this.fromSource() and not this.getFile() instanceof TestFile }
 
   override predicate isSource() { this instanceof SourceCallable }
 

--- a/csharp/ql/src/utils/modeleditor/ModelEditor.qll
+++ b/csharp/ql/src/utils/modeleditor/ModelEditor.qll
@@ -110,9 +110,11 @@ string supportedType(Endpoint endpoint) {
 }
 
 string methodClassification(Call method) {
-  method.getFile() instanceof TestFile and result = "test"
+  (method.getFile() instanceof TestFile or method.getFile() instanceof TestSupportFile) and
+  result = "test"
   or
   not method.getFile() instanceof TestFile and
+  not method.getFile() instanceof TestSupportFile and
   result = "source"
 }
 
@@ -128,4 +130,13 @@ private string qualifiedTypeName(string namespace, Type t) {
  */
 private string qualifiedCallableName(string namespace, string type, Callable c) {
   exists(string name | hasQualifiedMethodName(c, namespace, type, name) | result = name)
+}
+
+/** A file that doesn't contain tests itself, but is only used in tests. */
+class TestSupportFile extends File {
+  TestSupportFile() {
+    not this instanceof TestFile and
+    this.getAbsolutePath().matches(["%/test/%", "%/tests/%"]) and
+    not this.getAbsolutePath().matches("%/ql/test/%") // allows our test cases to work
+  }
 }

--- a/csharp/ql/src/utils/modeleditor/ModelEditor.qll
+++ b/csharp/ql/src/utils/modeleditor/ModelEditor.qll
@@ -110,11 +110,9 @@ string supportedType(Endpoint endpoint) {
 }
 
 string methodClassification(Call method) {
-  (method.getFile() instanceof TestFile or method.getFile() instanceof TestSupportFile) and
-  result = "test"
+  method.getFile() instanceof TestFile and result = "test"
   or
   not method.getFile() instanceof TestFile and
-  not method.getFile() instanceof TestSupportFile and
   result = "source"
 }
 
@@ -133,9 +131,8 @@ private string qualifiedCallableName(string namespace, string type, Callable c) 
 }
 
 /** A file that doesn't contain tests itself, but is only used in tests. */
-class TestSupportFile extends File {
+class TestSupportFile extends TestFile {
   TestSupportFile() {
-    not this instanceof TestFile and
     this.getAbsolutePath().matches(["%/test/%", "%/tests/%"]) and
     not this.getAbsolutePath().matches("%/ql/test/%") // allows our test cases to work
   }

--- a/csharp/ql/src/utils/modeleditor/ModelEditor.qll
+++ b/csharp/ql/src/utils/modeleditor/ModelEditor.qll
@@ -110,9 +110,9 @@ string supportedType(Endpoint endpoint) {
 }
 
 string methodClassification(Call method) {
-  method.getFile() instanceof TestFile and result = "test"
+  method.getFile() instanceof TestRelatedFile and result = "test"
   or
-  not method.getFile() instanceof TestFile and
+  not method.getFile() instanceof TestRelatedFile and
   result = "source"
 }
 
@@ -130,9 +130,11 @@ private string qualifiedCallableName(string namespace, string type, Callable c) 
   exists(string name | hasQualifiedMethodName(c, namespace, type, name) | result = name)
 }
 
-/** A file that doesn't contain tests itself, but is only used in tests. */
-class TestSupportFile extends TestFile {
-  TestSupportFile() {
+/** A file that is either a test file or is only used in tests. */
+class TestRelatedFile extends File {
+  TestRelatedFile() {
+    this instanceof TestFile
+    or
     this.getAbsolutePath().matches(["%/test/%", "%/tests/%"]) and
     not this.getAbsolutePath().matches("%/ql/test/%") // allows our test cases to work
   }


### PR DESCRIPTION
This adds files that are only used as "test support files" as test files in the model editor queries. The detection of these files is based on the [Java](https://github.com/github/codeql/blob/2305d55967d71ca13b06482f273ba9c6baa7240f/java/ql/lib/semmle/code/java/dataflow/internal/ModelExclusions.qll#L27-L31) and [Ruby](https://github.com/github/codeql/blob/2305d55967d71ca13b06482f273ba9c6baa7240f/ruby/ql/src/utils/modeleditor/ModelEditor.qll#L132-L137) methods.

Examples of test support files in [mongodb/mongo-csharp-driver](https://github.com/mongodb/mongo-csharp-driver):
- [`tests/MongoDB.Bson.TestHelpers/IO/NullBsonStream.cs`](https://github.com/mongodb/mongo-csharp-driver/blob/302640265d6db856fafad2254b19cdaa33d3d743/tests/MongoDB.Bson.TestHelpers/IO/NullBsonStream.cs)
- [`tests/MongoDB.Bson.TestHelpers/JsonDrivenTests/JsonDrivenTest.cs`](https://github.com/mongodb/mongo-csharp-driver/blob/302640265d6db856fafad2254b19cdaa33d3d743/tests/MongoDB.Bson.TestHelpers/JsonDrivenTests/JsonDrivenTest.cs)
- [`tests/MongoDB.Bson.TestHelpers/JsonDrivenTests/JsonDrivenTest.cs`](https://github.com/mongodb/mongo-csharp-driver/blob/302640265d6db856fafad2254b19cdaa33d3d743/tests/MongoDB.Bson.TestHelpers/JsonDrivenTests/JsonDrivenTest.cs)

These are not interesting in framework mode and should be classified as test files in application mode. This also helps in classifying unsupported or custom test frameworks/runners.