### PR TITLE
Go: Stratify `CFG::succ` to avoid recursion

### DIFF
--- a/go/ql/lib/semmle/go/controlflow/ControlFlowGraphImpl.qll
+++ b/go/ql/lib/semmle/go/controlflow/ControlFlowGraphImpl.qll
@@ -2082,7 +2082,9 @@ module CFG {
 
   /** Gets a successor of `nd`, that is, a node that is executed after `nd`. */
   cached
-  ControlFlow::Node succ0(ControlFlow::Node nd) { any(ControlFlowTree tree).succ0(nd, result) }
+  private ControlFlow::Node succ0(ControlFlow::Node nd) {
+    any(ControlFlowTree tree).succ0(nd, result)
+  }
 
   /** Gets a successor of `nd`, that is, a node that is executed after `nd`. */
   cached

--- a/go/ql/lib/semmle/go/controlflow/ControlFlowGraphImpl.qll
+++ b/go/ql/lib/semmle/go/controlflow/ControlFlowGraphImpl.qll
@@ -623,14 +623,14 @@ module CFG {
       not cmpl.isNormal()
     }
 
-    predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
+    predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       exists(int i |
         lastNode(this.getChildTreeRanked(i), pred, normalCompletion()) and
         firstNode(this.getChildTreeRanked(i + 1), succ)
       )
     }
 
-    predicate succ(ControlFlow::Node pred, ControlFlow::Node succ) { this.succSimple(pred, succ) }
+    predicate succ(ControlFlow::Node pred, ControlFlow::Node succ) { this.succ0(pred, succ) }
 
     final ControlFlowTree getChildTreeRanked(int i) {
       exists(int j |
@@ -729,8 +729,8 @@ module CFG {
       last = this.getNode() and cmpl = this.getCompletion()
     }
 
-    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
-      super.succSimple(pred, succ)
+    override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
+      super.succ0(pred, succ)
       or
       lastNode(this.getLastChildTree(), pred, normalCompletion()) and
       succ = this.getNode()
@@ -752,8 +752,8 @@ module CFG {
       cmpl = Done()
     }
 
-    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
-      super.succSimple(pred, succ)
+    override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
+      super.succ0(pred, succ)
       or
       pred = this.getNode() and
       firstNode(this.getFirstChildTree(), succ)
@@ -855,8 +855,8 @@ module CFG {
       cmpl = Done()
     }
 
-    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
-      ControlFlowTree.super.succSimple(pred, succ)
+    override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
+      ControlFlowTree.super.succ0(pred, succ)
       or
       exists(int i | lastNode(this.getLhs(i), pred, normalCompletion()) |
         firstNode(this.getLhs(i + 1), succ)
@@ -980,7 +980,7 @@ module CFG {
       )
     }
 
-    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
+    override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       exists(Completion lcmpl |
         lastNode(this.getLeftOperand(), pred, lcmpl) and
         succ = this.getGuard(lcmpl.getOutcome())
@@ -1030,11 +1030,11 @@ module CFG {
       not result instanceof TypeExpr
     }
 
-    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
+    override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       // interpose implicit argument destructuring nodes between last argument
       // and call itself; this is for cases like `f(g())` where `g` has multiple
       // results
-      exists(ControlFlow::Node mid | PostOrderTree.super.succSimple(pred, mid) |
+      exists(ControlFlow::Node mid | PostOrderTree.super.succ0(pred, mid) |
         if mid = this.getNode() then succ = this.getEpilogueNode(0) else succ = mid
       )
       or
@@ -1104,8 +1104,8 @@ module CFG {
       lastNode(this.getStmt(this.getNumStmt() - 1), last, cmpl)
     }
 
-    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
-      ControlFlowTree.super.succSimple(pred, succ)
+    override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
+      ControlFlowTree.super.succ0(pred, succ)
       or
       exists(int i |
         lastNode(this.getExpr(i), pred, normalCompletion()) and
@@ -1174,7 +1174,7 @@ module CFG {
       cmpl = Done()
     }
 
-    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
+    override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       this.firstNode(pred) and
       succ = this.getElementStart(0)
       or
@@ -1252,7 +1252,7 @@ module CFG {
       cmpl = Done()
     }
 
-    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
+    override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       lastNode(this.getInit(), pred, normalCompletion()) and
       firstNode(this.getCond(), succ)
       or
@@ -1283,7 +1283,7 @@ module CFG {
       (cmpl = Done() or cmpl = Panic())
     }
 
-    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
+    override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       lastNode(this.getBase(), pred, normalCompletion()) and
       (
         succ = MkImplicitDeref(this.getBase())
@@ -1320,8 +1320,8 @@ module CFG {
 
     override predicate lastNode(ControlFlow::Node last, Completion cmpl) { none() }
 
-    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
-      ControlFlowTree.super.succSimple(pred, succ)
+    override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
+      ControlFlowTree.super.succ0(pred, succ)
       or
       pred = MkEntryNode(this) and
       firstNode(this.getDecl(0), succ)
@@ -1376,7 +1376,7 @@ module CFG {
       i = 5 and result = this.getBody()
     }
 
-    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
+    override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       exists(int i, ControlFlowTree predTree, Completion cmpl |
         predTree = this.getChildTreeRanked(i) and
         lastNode(predTree, pred, cmpl) and
@@ -1442,13 +1442,13 @@ module CFG {
         // `defer` can be the first `defer` statement executed
         // there is always a predecessor node because the `defer`'s call is always
         // evaluated before the defer statement itself
-        MkDeferNode(defer) = succSimple(notDeferSuccSimple*(this.getEntry()))
+        MkDeferNode(defer) = succ0(notDefersucc0*(this.getEntry()))
       )
     }
 
     override predicate lastNode(ControlFlow::Node last, Completion cmpl) { none() }
 
-    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
+    override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       exists(int i |
         pred = this.getPrologueNode(i) and
         succ = this.getPrologueNode(i + 1)
@@ -1469,12 +1469,12 @@ module CFG {
     }
 
     override predicate succ(ControlFlow::Node pred, ControlFlow::Node succ) {
-      this.succSimple(pred, succ)
+      this.succ0(pred, succ)
       or
       exists(Completion cmpl |
         lastNode(this.getBody(), pred, cmpl) and
         // last node of function body can be reached without going through a `defer` statement
-        pred = notDeferSuccSimple*(this.getEntry())
+        pred = notDefersucc0*(this.getEntry())
       |
         // panic goes directly to exit, non-panic reads result variables first
         if cmpl = Panic() then succ = MkExitNode(this) else succ = this.getEpilogueNode(0)
@@ -1484,7 +1484,7 @@ module CFG {
       exists(DeferStmt defer | defer = this.getADeferStmt() |
         succ = MkExprNode(defer.getCall()) and
         // the last `DeferStmt` executed before pred is this `defer`
-        pred = notDeferSuccSimple*(MkDeferNode(defer))
+        pred = notDefersucc0*(MkDeferNode(defer))
       )
       or
       exists(DeferStmt predDefer, DeferStmt succDefer |
@@ -1522,7 +1522,7 @@ module CFG {
       cmpl = Done()
     }
 
-    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
+    override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       lastNode(this.getOperand(), pred, normalCompletion()) and
       succ = MkImplicitOne(this)
       or
@@ -1553,7 +1553,7 @@ module CFG {
       not cmpl.isNormal()
     }
 
-    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
+    override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       lastNode(this.getDomain(), pred, normalCompletion()) and
       succ = MkNextNode(this)
       or
@@ -1628,7 +1628,7 @@ module CFG {
 
     override Completion getCompletion() { result = Return() }
 
-    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
+    override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       exists(int i |
         lastNode(this.getExpr(i), pred, normalCompletion()) and
         succ = this.complete(i)
@@ -1684,8 +1684,8 @@ module CFG {
       )
     }
 
-    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
-      ControlFlowTree.super.succSimple(pred, succ)
+    override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
+      ControlFlowTree.super.succ0(pred, succ)
       or
       exists(CommClause cc, int i, Stmt comm |
         cc = this.getNonDefaultCommClause(i) and
@@ -1783,7 +1783,7 @@ module CFG {
       cmpl = Done()
     }
 
-    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
+    override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       exists(int i | pred = this.getStepWithRank(i) and succ = this.getStepWithRank(i + 1))
     }
 
@@ -1820,8 +1820,8 @@ module CFG {
       (cmpl = Done() or cmpl = Panic())
     }
 
-    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
-      ControlFlowTree.super.succSimple(pred, succ)
+    override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
+      ControlFlowTree.super.succ0(pred, succ)
       or
       not this = any(CommClause cc).getComm() and
       lastNode(this.getValue(), pred, normalCompletion()) and
@@ -1849,8 +1849,8 @@ module CFG {
       (cmpl = Done() or cmpl = Panic())
     }
 
-    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
-      ControlFlowTree.super.succSimple(pred, succ)
+    override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
+      ControlFlowTree.super.succ0(pred, succ)
       or
       lastNode(this.getBase(), pred, normalCompletion()) and
       (
@@ -1936,8 +1936,8 @@ module CFG {
       )
     }
 
-    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
-      ControlFlowTree.super.succSimple(pred, succ)
+    override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
+      ControlFlowTree.super.succ0(pred, succ)
       or
       lastNode(this.getInit(), pred, normalCompletion()) and
       (
@@ -2010,8 +2010,8 @@ module CFG {
       )
     }
 
-    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
-      ControlFlowTree.super.succSimple(pred, succ)
+    override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
+      ControlFlowTree.super.succ0(pred, succ)
       or
       not this = any(RecvStmt recv).getExpr() and
       lastNode(this.getOperand(), pred, normalCompletion()) and
@@ -2039,9 +2039,9 @@ module CFG {
   }
 
   /** Gets a successor of `nd` that is not a `defer` node */
-  private ControlFlow::Node notDeferSuccSimple(ControlFlow::Node nd) {
+  private ControlFlow::Node notDefersucc0(ControlFlow::Node nd) {
     not result = MkDeferNode(_) and
-    result = succSimple(nd)
+    result = succ0(nd)
   }
 
   /** Gets `defer` statements that can be the first defer statement after `nd` in the CFG */
@@ -2049,9 +2049,9 @@ module CFG {
     nd = MkDeferNode(_) and
     result = MkDeferNode(_) and
     (
-      result = succSimple(nd)
+      result = succ0(nd)
       or
-      result = succSimple(notDeferSuccSimple+(nd))
+      result = succ0(notDefersucc0+(nd))
     )
   }
 
@@ -2082,9 +2082,7 @@ module CFG {
 
   /** Gets a successor of `nd`, that is, a node that is executed after `nd`. */
   cached
-  ControlFlow::Node succSimple(ControlFlow::Node nd) {
-    any(ControlFlowTree tree).succSimple(nd, result)
-  }
+  ControlFlow::Node succ0(ControlFlow::Node nd) { any(ControlFlowTree tree).succ0(nd, result) }
 
   /** Gets a successor of `nd`, that is, a node that is executed after `nd`. */
   cached

--- a/go/ql/lib/semmle/go/controlflow/ControlFlowGraphImpl.qll
+++ b/go/ql/lib/semmle/go/controlflow/ControlFlowGraphImpl.qll
@@ -627,6 +627,7 @@ module CFG {
      * Holds if `succ` is a successor of `pred`, ignoring the execution of any
      * deferred functions when a function ends.
      */
+    pragma[nomagic]
     predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       exists(int i |
         lastNode(this.getChildTreeRanked(i), pred, normalCompletion()) and
@@ -734,6 +735,7 @@ module CFG {
       last = this.getNode() and cmpl = this.getCompletion()
     }
 
+    pragma[nomagic]
     override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       super.succ0(pred, succ)
       or
@@ -757,6 +759,7 @@ module CFG {
       cmpl = Done()
     }
 
+    pragma[nomagic]
     override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       super.succ0(pred, succ)
       or
@@ -860,6 +863,7 @@ module CFG {
       cmpl = Done()
     }
 
+    pragma[nomagic]
     override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       ControlFlowTree.super.succ0(pred, succ)
       or
@@ -985,6 +989,7 @@ module CFG {
       )
     }
 
+    pragma[nomagic]
     override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       exists(Completion lcmpl |
         lastNode(this.getLeftOperand(), pred, lcmpl) and
@@ -1035,6 +1040,7 @@ module CFG {
       not result instanceof TypeExpr
     }
 
+    pragma[nomagic]
     override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       // interpose implicit argument destructuring nodes between last argument
       // and call itself; this is for cases like `f(g())` where `g` has multiple
@@ -1109,6 +1115,7 @@ module CFG {
       lastNode(this.getStmt(this.getNumStmt() - 1), last, cmpl)
     }
 
+    pragma[nomagic]
     override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       ControlFlowTree.super.succ0(pred, succ)
       or
@@ -1179,6 +1186,7 @@ module CFG {
       cmpl = Done()
     }
 
+    pragma[nomagic]
     override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       this.firstNode(pred) and
       succ = this.getElementStart(0)
@@ -1257,6 +1265,7 @@ module CFG {
       cmpl = Done()
     }
 
+    pragma[nomagic]
     override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       lastNode(this.getInit(), pred, normalCompletion()) and
       firstNode(this.getCond(), succ)
@@ -1288,6 +1297,7 @@ module CFG {
       (cmpl = Done() or cmpl = Panic())
     }
 
+    pragma[nomagic]
     override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       lastNode(this.getBase(), pred, normalCompletion()) and
       (
@@ -1325,6 +1335,7 @@ module CFG {
 
     override predicate lastNode(ControlFlow::Node last, Completion cmpl) { none() }
 
+    pragma[nomagic]
     override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       ControlFlowTree.super.succ0(pred, succ)
       or
@@ -1381,6 +1392,7 @@ module CFG {
       i = 5 and result = this.getBody()
     }
 
+    pragma[nomagic]
     override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       exists(int i, ControlFlowTree predTree, Completion cmpl |
         predTree = this.getChildTreeRanked(i) and
@@ -1453,6 +1465,7 @@ module CFG {
 
     override predicate lastNode(ControlFlow::Node last, Completion cmpl) { none() }
 
+    pragma[nomagic]
     override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       exists(int i |
         pred = this.getPrologueNode(i) and
@@ -1527,6 +1540,7 @@ module CFG {
       cmpl = Done()
     }
 
+    pragma[nomagic]
     override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       lastNode(this.getOperand(), pred, normalCompletion()) and
       succ = MkImplicitOne(this)
@@ -1558,6 +1572,7 @@ module CFG {
       not cmpl.isNormal()
     }
 
+    pragma[nomagic]
     override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       lastNode(this.getDomain(), pred, normalCompletion()) and
       succ = MkNextNode(this)
@@ -1633,6 +1648,7 @@ module CFG {
 
     override Completion getCompletion() { result = Return() }
 
+    pragma[nomagic]
     override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       exists(int i |
         lastNode(this.getExpr(i), pred, normalCompletion()) and
@@ -1689,6 +1705,7 @@ module CFG {
       )
     }
 
+    pragma[nomagic]
     override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       ControlFlowTree.super.succ0(pred, succ)
       or
@@ -1788,6 +1805,7 @@ module CFG {
       cmpl = Done()
     }
 
+    pragma[nomagic]
     override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       exists(int i | pred = this.getStepWithRank(i) and succ = this.getStepWithRank(i + 1))
     }
@@ -1825,6 +1843,7 @@ module CFG {
       (cmpl = Done() or cmpl = Panic())
     }
 
+    pragma[nomagic]
     override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       ControlFlowTree.super.succ0(pred, succ)
       or
@@ -1854,6 +1873,7 @@ module CFG {
       (cmpl = Done() or cmpl = Panic())
     }
 
+    pragma[nomagic]
     override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       ControlFlowTree.super.succ0(pred, succ)
       or
@@ -1941,6 +1961,7 @@ module CFG {
       )
     }
 
+    pragma[nomagic]
     override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       ControlFlowTree.super.succ0(pred, succ)
       or
@@ -2015,6 +2036,7 @@ module CFG {
       )
     }
 
+    pragma[nomagic]
     override predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       ControlFlowTree.super.succ0(pred, succ)
       or

--- a/go/ql/lib/semmle/go/controlflow/ControlFlowGraphImpl.qll
+++ b/go/ql/lib/semmle/go/controlflow/ControlFlowGraphImpl.qll
@@ -2111,7 +2111,7 @@ module CFG {
    * Gets a successor of `nd`, that is, a node that is executed after `nd`,
    * ignoring the execution of any deferred functions when a function ends.
    */
-  cached
+  pragma[nomagic]
   private ControlFlow::Node succ0(ControlFlow::Node nd) {
     any(ControlFlowTree tree).succ0(nd, result)
   }

--- a/go/ql/lib/semmle/go/controlflow/ControlFlowGraphImpl.qll
+++ b/go/ql/lib/semmle/go/controlflow/ControlFlowGraphImpl.qll
@@ -623,12 +623,14 @@ module CFG {
       not cmpl.isNormal()
     }
 
-    predicate succ(ControlFlow::Node pred, ControlFlow::Node succ) {
+    predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
       exists(int i |
         lastNode(this.getChildTreeRanked(i), pred, normalCompletion()) and
         firstNode(this.getChildTreeRanked(i + 1), succ)
       )
     }
+
+    predicate succ(ControlFlow::Node pred, ControlFlow::Node succ) { this.succSimple(pred, succ) }
 
     final ControlFlowTree getChildTreeRanked(int i) {
       exists(int j |
@@ -727,8 +729,8 @@ module CFG {
       last = this.getNode() and cmpl = this.getCompletion()
     }
 
-    override predicate succ(ControlFlow::Node pred, ControlFlow::Node succ) {
-      super.succ(pred, succ)
+    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
+      super.succSimple(pred, succ)
       or
       lastNode(this.getLastChildTree(), pred, normalCompletion()) and
       succ = this.getNode()
@@ -750,8 +752,8 @@ module CFG {
       cmpl = Done()
     }
 
-    override predicate succ(ControlFlow::Node pred, ControlFlow::Node succ) {
-      super.succ(pred, succ)
+    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
+      super.succSimple(pred, succ)
       or
       pred = this.getNode() and
       firstNode(this.getFirstChildTree(), succ)
@@ -853,8 +855,8 @@ module CFG {
       cmpl = Done()
     }
 
-    override predicate succ(ControlFlow::Node pred, ControlFlow::Node succ) {
-      ControlFlowTree.super.succ(pred, succ)
+    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
+      ControlFlowTree.super.succSimple(pred, succ)
       or
       exists(int i | lastNode(this.getLhs(i), pred, normalCompletion()) |
         firstNode(this.getLhs(i + 1), succ)
@@ -978,7 +980,7 @@ module CFG {
       )
     }
 
-    override predicate succ(ControlFlow::Node pred, ControlFlow::Node succ) {
+    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
       exists(Completion lcmpl |
         lastNode(this.getLeftOperand(), pred, lcmpl) and
         succ = this.getGuard(lcmpl.getOutcome())
@@ -1028,11 +1030,11 @@ module CFG {
       not result instanceof TypeExpr
     }
 
-    override predicate succ(ControlFlow::Node pred, ControlFlow::Node succ) {
+    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
       // interpose implicit argument destructuring nodes between last argument
       // and call itself; this is for cases like `f(g())` where `g` has multiple
       // results
-      exists(ControlFlow::Node mid | PostOrderTree.super.succ(pred, mid) |
+      exists(ControlFlow::Node mid | PostOrderTree.super.succSimple(pred, mid) |
         if mid = this.getNode() then succ = this.getEpilogueNode(0) else succ = mid
       )
       or
@@ -1102,8 +1104,8 @@ module CFG {
       lastNode(this.getStmt(this.getNumStmt() - 1), last, cmpl)
     }
 
-    override predicate succ(ControlFlow::Node pred, ControlFlow::Node succ) {
-      ControlFlowTree.super.succ(pred, succ)
+    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
+      ControlFlowTree.super.succSimple(pred, succ)
       or
       exists(int i |
         lastNode(this.getExpr(i), pred, normalCompletion()) and
@@ -1172,7 +1174,7 @@ module CFG {
       cmpl = Done()
     }
 
-    override predicate succ(ControlFlow::Node pred, ControlFlow::Node succ) {
+    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
       this.firstNode(pred) and
       succ = this.getElementStart(0)
       or
@@ -1250,7 +1252,7 @@ module CFG {
       cmpl = Done()
     }
 
-    override predicate succ(ControlFlow::Node pred, ControlFlow::Node succ) {
+    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
       lastNode(this.getInit(), pred, normalCompletion()) and
       firstNode(this.getCond(), succ)
       or
@@ -1281,7 +1283,7 @@ module CFG {
       (cmpl = Done() or cmpl = Panic())
     }
 
-    override predicate succ(ControlFlow::Node pred, ControlFlow::Node succ) {
+    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
       lastNode(this.getBase(), pred, normalCompletion()) and
       (
         succ = MkImplicitDeref(this.getBase())
@@ -1318,8 +1320,8 @@ module CFG {
 
     override predicate lastNode(ControlFlow::Node last, Completion cmpl) { none() }
 
-    override predicate succ(ControlFlow::Node pred, ControlFlow::Node succ) {
-      ControlFlowTree.super.succ(pred, succ)
+    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
+      ControlFlowTree.super.succSimple(pred, succ)
       or
       pred = MkEntryNode(this) and
       firstNode(this.getDecl(0), succ)
@@ -1374,7 +1376,7 @@ module CFG {
       i = 5 and result = this.getBody()
     }
 
-    override predicate succ(ControlFlow::Node pred, ControlFlow::Node succ) {
+    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
       exists(int i, ControlFlowTree predTree, Completion cmpl |
         predTree = this.getChildTreeRanked(i) and
         lastNode(predTree, pred, cmpl) and
@@ -1440,13 +1442,13 @@ module CFG {
         // `defer` can be the first `defer` statement executed
         // there is always a predecessor node because the `defer`'s call is always
         // evaluated before the defer statement itself
-        MkDeferNode(defer) = succ(notDeferSucc*(this.getEntry()))
+        MkDeferNode(defer) = succSimple(notDeferSuccSimple*(this.getEntry()))
       )
     }
 
     override predicate lastNode(ControlFlow::Node last, Completion cmpl) { none() }
 
-    override predicate succ(ControlFlow::Node pred, ControlFlow::Node succ) {
+    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
       exists(int i |
         pred = this.getPrologueNode(i) and
         succ = this.getPrologueNode(i + 1)
@@ -1460,10 +1462,19 @@ module CFG {
         firstNode(ls, succ)
       )
       or
+      exists(int i |
+        pred = this.getEpilogueNode(i) and
+        succ = this.getEpilogueNode(i + 1)
+      )
+    }
+
+    override predicate succ(ControlFlow::Node pred, ControlFlow::Node succ) {
+      this.succSimple(pred, succ)
+      or
       exists(Completion cmpl |
         lastNode(this.getBody(), pred, cmpl) and
         // last node of function body can be reached without going through a `defer` statement
-        pred = notDeferSucc*(this.getEntry())
+        pred = notDeferSuccSimple*(this.getEntry())
       |
         // panic goes directly to exit, non-panic reads result variables first
         if cmpl = Panic() then succ = MkExitNode(this) else succ = this.getEpilogueNode(0)
@@ -1473,7 +1484,7 @@ module CFG {
       exists(DeferStmt defer | defer = this.getADeferStmt() |
         succ = MkExprNode(defer.getCall()) and
         // the last `DeferStmt` executed before pred is this `defer`
-        pred = notDeferSucc*(MkDeferNode(defer))
+        pred = notDeferSuccSimple*(MkDeferNode(defer))
       )
       or
       exists(DeferStmt predDefer, DeferStmt succDefer |
@@ -1494,11 +1505,6 @@ module CFG {
         or
         succ = this.getEpilogueNode(0)
       )
-      or
-      exists(int i |
-        pred = this.getEpilogueNode(i) and
-        succ = this.getEpilogueNode(i + 1)
-      )
     }
   }
 
@@ -1516,7 +1522,7 @@ module CFG {
       cmpl = Done()
     }
 
-    override predicate succ(ControlFlow::Node pred, ControlFlow::Node succ) {
+    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
       lastNode(this.getOperand(), pred, normalCompletion()) and
       succ = MkImplicitOne(this)
       or
@@ -1547,7 +1553,7 @@ module CFG {
       not cmpl.isNormal()
     }
 
-    override predicate succ(ControlFlow::Node pred, ControlFlow::Node succ) {
+    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
       lastNode(this.getDomain(), pred, normalCompletion()) and
       succ = MkNextNode(this)
       or
@@ -1622,7 +1628,7 @@ module CFG {
 
     override Completion getCompletion() { result = Return() }
 
-    override predicate succ(ControlFlow::Node pred, ControlFlow::Node succ) {
+    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
       exists(int i |
         lastNode(this.getExpr(i), pred, normalCompletion()) and
         succ = this.complete(i)
@@ -1678,8 +1684,8 @@ module CFG {
       )
     }
 
-    override predicate succ(ControlFlow::Node pred, ControlFlow::Node succ) {
-      ControlFlowTree.super.succ(pred, succ)
+    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
+      ControlFlowTree.super.succSimple(pred, succ)
       or
       exists(CommClause cc, int i, Stmt comm |
         cc = this.getNonDefaultCommClause(i) and
@@ -1777,7 +1783,7 @@ module CFG {
       cmpl = Done()
     }
 
-    override predicate succ(ControlFlow::Node pred, ControlFlow::Node succ) {
+    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
       exists(int i | pred = this.getStepWithRank(i) and succ = this.getStepWithRank(i + 1))
     }
 
@@ -1814,8 +1820,8 @@ module CFG {
       (cmpl = Done() or cmpl = Panic())
     }
 
-    override predicate succ(ControlFlow::Node pred, ControlFlow::Node succ) {
-      ControlFlowTree.super.succ(pred, succ)
+    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
+      ControlFlowTree.super.succSimple(pred, succ)
       or
       not this = any(CommClause cc).getComm() and
       lastNode(this.getValue(), pred, normalCompletion()) and
@@ -1843,8 +1849,8 @@ module CFG {
       (cmpl = Done() or cmpl = Panic())
     }
 
-    override predicate succ(ControlFlow::Node pred, ControlFlow::Node succ) {
-      ControlFlowTree.super.succ(pred, succ)
+    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
+      ControlFlowTree.super.succSimple(pred, succ)
       or
       lastNode(this.getBase(), pred, normalCompletion()) and
       (
@@ -1930,8 +1936,8 @@ module CFG {
       )
     }
 
-    override predicate succ(ControlFlow::Node pred, ControlFlow::Node succ) {
-      ControlFlowTree.super.succ(pred, succ)
+    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
+      ControlFlowTree.super.succSimple(pred, succ)
       or
       lastNode(this.getInit(), pred, normalCompletion()) and
       (
@@ -2004,8 +2010,8 @@ module CFG {
       )
     }
 
-    override predicate succ(ControlFlow::Node pred, ControlFlow::Node succ) {
-      ControlFlowTree.super.succ(pred, succ)
+    override predicate succSimple(ControlFlow::Node pred, ControlFlow::Node succ) {
+      ControlFlowTree.super.succSimple(pred, succ)
       or
       not this = any(RecvStmt recv).getExpr() and
       lastNode(this.getOperand(), pred, normalCompletion()) and
@@ -2033,9 +2039,9 @@ module CFG {
   }
 
   /** Gets a successor of `nd` that is not a `defer` node */
-  private ControlFlow::Node notDeferSucc(ControlFlow::Node nd) {
+  private ControlFlow::Node notDeferSuccSimple(ControlFlow::Node nd) {
     not result = MkDeferNode(_) and
-    result = succ(nd)
+    result = succSimple(nd)
   }
 
   /** Gets `defer` statements that can be the first defer statement after `nd` in the CFG */
@@ -2043,9 +2049,9 @@ module CFG {
     nd = MkDeferNode(_) and
     result = MkDeferNode(_) and
     (
-      result = succ(nd)
+      result = succSimple(nd)
       or
-      result = succ(notDeferSucc+(nd))
+      result = succSimple(notDeferSuccSimple+(nd))
     )
   }
 
@@ -2072,6 +2078,12 @@ module CFG {
     exists(ExpressionSwitchStmt ess | ess.getExpr() = switchExpr |
       ess.getACase().(CaseClauseTree).isPassingEdge(_, pred, succ, testExpr)
     )
+  }
+
+  /** Gets a successor of `nd`, that is, a node that is executed after `nd`. */
+  cached
+  ControlFlow::Node succSimple(ControlFlow::Node nd) {
+    any(ControlFlowTree tree).succSimple(nd, result)
   }
 
   /** Gets a successor of `nd`, that is, a node that is executed after `nd`. */

--- a/go/ql/lib/semmle/go/controlflow/ControlFlowGraphImpl.qll
+++ b/go/ql/lib/semmle/go/controlflow/ControlFlowGraphImpl.qll
@@ -1459,7 +1459,7 @@ module CFG {
         // `defer` can be the first `defer` statement executed
         // there is always a predecessor node because the `defer`'s call is always
         // evaluated before the defer statement itself
-        MkDeferNode(defer) = succ0(notDefersucc0*(this.getEntry()))
+        MkDeferNode(defer) = succ0(notDeferSucc0*(this.getEntry()))
       )
     }
 
@@ -1492,7 +1492,7 @@ module CFG {
       exists(Completion cmpl |
         lastNode(this.getBody(), pred, cmpl) and
         // last node of function body can be reached without going through a `defer` statement
-        pred = notDefersucc0*(this.getEntry())
+        pred = notDeferSucc0*(this.getEntry())
       |
         // panic goes directly to exit, non-panic reads result variables first
         if cmpl = Panic() then succ = MkExitNode(this) else succ = this.getEpilogueNode(0)
@@ -1502,7 +1502,7 @@ module CFG {
       exists(DeferStmt defer | defer = this.getADeferStmt() |
         succ = MkExprNode(defer.getCall()) and
         // the last `DeferStmt` executed before pred is this `defer`
-        pred = notDefersucc0*(MkDeferNode(defer))
+        pred = notDeferSucc0*(MkDeferNode(defer))
       )
       or
       exists(DeferStmt predDefer, DeferStmt succDefer |
@@ -2066,7 +2066,7 @@ module CFG {
   }
 
   /** Gets a successor of `nd` that is not a `defer` node */
-  private ControlFlow::Node notDefersucc0(ControlFlow::Node nd) {
+  private ControlFlow::Node notDeferSucc0(ControlFlow::Node nd) {
     not result = MkDeferNode(_) and
     result = succ0(nd)
   }
@@ -2078,7 +2078,7 @@ module CFG {
     (
       result = succ0(nd)
       or
-      result = succ0(notDefersucc0+(nd))
+      result = succ0(notDeferSucc0+(nd))
     )
   }
 

--- a/go/ql/lib/semmle/go/controlflow/ControlFlowGraphImpl.qll
+++ b/go/ql/lib/semmle/go/controlflow/ControlFlowGraphImpl.qll
@@ -623,6 +623,10 @@ module CFG {
       not cmpl.isNormal()
     }
 
+    /**
+     * Holds if `succ` is a successor of `pred`, ignoring the execution of any
+     * deferred functions when a function ends.
+     */
     predicate succ0(ControlFlow::Node pred, ControlFlow::Node succ) {
       exists(int i |
         lastNode(this.getChildTreeRanked(i), pred, normalCompletion()) and
@@ -630,6 +634,7 @@ module CFG {
       )
     }
 
+    /** Holds if `succ` is a successor of `pred`. */
     predicate succ(ControlFlow::Node pred, ControlFlow::Node succ) { this.succ0(pred, succ) }
 
     final ControlFlowTree getChildTreeRanked(int i) {
@@ -2080,7 +2085,10 @@ module CFG {
     )
   }
 
-  /** Gets a successor of `nd`, that is, a node that is executed after `nd`. */
+  /**
+   * Gets a successor of `nd`, that is, a node that is executed after `nd`,
+   * ignoring the execution of any deferred functions when a function ends.
+   */
   cached
   private ControlFlow::Node succ0(ControlFlow::Node nd) {
     any(ControlFlowTree tree).succ0(nd, result)


### PR DESCRIPTION
The first level doesn't deal with defer statements properly. The second level uses the first level to deal with them properly.