### PR TITLE
ensure `publish.sh` uses the latest `automodel` release

### DIFF
--- a/java/ql/automodel/publish.sh
+++ b/java/ql/automodel/publish.sh
@@ -75,8 +75,11 @@ else
   fi
 fi
 
+# Get the absolute path of the automodel repo
 AUTOMODEL_ROOT="$(readlink -f "$(dirname $0)")"
+# Get the absolute path of the workspace root
 WORKSPACE_ROOT="$AUTOMODEL_ROOT/../../.."
+# Specify the groups of queries to test and publish
 GRPS="automodel,-test"
 
 pushd "$AUTOMODEL_ROOT"

--- a/java/ql/automodel/publish.sh
+++ b/java/ql/automodel/publish.sh
@@ -9,6 +9,14 @@ if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
   exit 0
 fi
 
+# If there's an $1 argument, then check it's "override-release"
+if [ -n "${1:-}" ]; then
+  if [ "$1" != "override-release" ]; then
+    echo "Error: The only valid argument is 'override-release'"
+    exit 1
+  fi
+fi
+
 # If we're publishing the codeml-automodel release then we will checkout the sha specified in the release.
 # So we need to check that there are no uncommitted changes in the local branch.
 # And, if we're publishing the current HEAD, it's cleaner to ensure that there are no uncommitted changes.

--- a/java/ql/automodel/publish.sh
+++ b/java/ql/automodel/publish.sh
@@ -1,62 +1,118 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
-# Before running this, make sure
-# 1. there is an SSO-enabled token with package:write permissions to codeql supplied via the GITHUB_TOKEN environment variable
-# 2. the CODEQL_DIST environment variable is set to the path of a codeql distribution
-# 3. the gh command line tool is installed and authenticated with a token that has repo permissions to github/codeml-automodel
-# supplied via the GH_TOKEN environment variable
+# Add help message
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+  echo "Usage: ./publish [override-release]"
+  echo "By default we publish the version of the codeql repo specified by the latest official release defined by the codeml-automodel repo."
+  echo "Otherwise, the optional argument override-release forces your current HEAD to be published."
+  exit 0
+fi
 
-# Script to publish a new version of the automodel package to the package registry.
-# Usage: ./publish [override-release]
-# By default the sha of the codeql repo specified in the latest release of codeml-automodel will be published.
-# Otherwise, the optional argument override-release forces the current HEAD to be published.
+# If we're publishing the codeml-automodel release then we will checkout the sha specified in the release.
+# So we need to check that there are no uncommitted changes in the local branch.
+# And, if we're publishing the current HEAD, it's cleaner to ensure that there are no uncommitted changes.
+if ! git diff --quiet; then
+  echo "Error: Uncommitted changes exist. Please commit or stash your changes before publishing."
+  exit 1
+fi
 
-# If the first argument is empty, use the latest release of codeml-automodel
+# Check the above environment variables are set
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+  echo "Error: GITHUB_TOKEN environment variable not set. Please set this to a token with package:write permissions to codeql."
+  exit 1
+fi
+if [ -z "${CODEQL_DIST:-}" ]; then
+  echo "Error: CODEQL_DIST environment variable not set. Please set this to the path of a codeql distribution."
+  exit 1
+fi
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo "Error: GH_TOKEN environment variable not set. Please set this to a token with repo permissions to github/codeml-automodel."
+  exit 1
+fi
+
+# Get the sha of the previous release
+PREVIOUS_RELEASE_SHA=$(git rev-list -n 1 main -- ./src/qlpack.yml)
+if [ -z "$PREVIOUS_RELEASE_SHA" ]; then
+  echo "Error: Could not get the sha of the previous release of codeml-automodel query pack"
+  exit 1
+else
+  echo "Previous query-pack release sha: $PREVIOUS_RELEASE_SHA"
+fi
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+CURRENT_SHA=$(git rev-parse HEAD)
+
 if [ -z "${1:-}" ]; then
-    TAG_NAME=$(gh api -H 'Accept: application/vnd.github+json' -H 'X-GitHub-Api-Version: 2022-11-28' /repos/github/codeml-automodel/releases/latest | jq -r .tag_name)
-    # Check TAG_NAME is not empty
-    if [ -z "$TAG_NAME" ]; then
-        echo "Error: Could not get latest release of codeml-automodel"
-        exit 1
-    fi
-    echo "Updating to latest automodel release: $TAG_NAME"
-    rm release.zip || true
-    gh release download $TAG_NAME -A zip -O release.zip --repo 'https://github.com/github/codeml-automodel'
-    unzip -o release.zip -d release 
-    REVISION=$(jq -r '.["codeql-sha"]' release/codeml-automodel*/codeml-automodel-release.json)
-    echo "The latest automodel release specifies a codeql revision of $REVISION"
-    if git diff --quiet; then
-      echo "Checking out CodeQL revision $REVISION"
-      git reset --hard "$REVISION"
-    else
-      echo "Error: Uncommitted changes exist. Please commit or stash your changes before resetting."
+  # If the first argument is empty, use the latest release of codeml-automodel
+  TAG_NAME=$(gh api -H 'Accept: application/vnd.github+json' -H 'X-GitHub-Api-Version: 2022-11-28' /repos/github/codeml-automodel/releases/latest | jq -r .tag_name)
+  # Check TAG_NAME is not empty
+  if [ -z "$TAG_NAME" ]; then
+      echo "Error: Could not get latest release of codeml-automodel"
       exit 1
-    fi
+  fi
+  echo "Updating to latest automodel release: $TAG_NAME"
+  rm release.zip || true
+  gh release download $TAG_NAME -A zip -O release.zip --repo 'https://github.com/github/codeml-automodel'
+  rm -rf release || true
+  unzip -o release.zip -d release 
+  REVISION=$(jq -r '.["codeql-sha"]' release/codeml-automodel*/codeml-automodel-release.json)
+  echo "The latest codeml-automodel release specifies the codeql sha $REVISION"
+  # Check that REVISION is downstream from PREVIOUS_RELEASE_SHA
+  if ! git merge-base --is-ancestor "$PREVIOUS_RELEASE_SHA" "$REVISION"; then
+    echo "Error: The codeql version $REVISION is not downstream of the query-pack version $PREVIOUS_RELEASE_SHA"
+    exit 1
+  fi
+  # Get the version of the codeql code specified by the codeml-automodel release
+  git checkout "$REVISION"
+else
+  # Check that the current HEAD is downstream from PREVIOUS_RELEASE_SHA
+  if ! git merge-base --is-ancestor "$PREVIOUS_RELEASE_SHA" "$CURRENT_SHA"; then
+    echo "Error: The current HEAD is not downstream from the previous release"
+    exit 1
+  fi
 fi
 
 AUTOMODEL_ROOT="$(readlink -f "$(dirname $0)")"
 WORKSPACE_ROOT="$AUTOMODEL_ROOT/../../.."
 GRPS="automodel,-test"
 
-if [ -z "$CODEQL_DIST" ]; then
-  echo "CODEQL_DIST not set"
-  exit -1
-fi
-
-cd "$AUTOMODEL_ROOT"
+pushd "$AUTOMODEL_ROOT"
 echo Testing automodel queries
 "${CODEQL_DIST}/codeql" test run test
+popd
 
-cd "$WORKSPACE_ROOT"
+pushd "$WORKSPACE_ROOT"
+echo "Preparing the release"
+"${CODEQL_DIST}/codeql" pack release --groups $GRPS -v
 
-echo Preparing release
-"${CODEQL_DIST}/codeql" pack release --groups $GRPS
+echo "Publishing the release"
+# Add --dry-run to test publishing
+"${CODEQL_DIST}/codeql" pack publish --groups $GRPS -v
 
-echo Publishing automodel
-"${CODEQL_DIST}/codeql" pack publish --groups $GRPS
+echo "Bumping versions"
+"${CODEQL_DIST}/codeql" pack post-release --groups $GRPS -v
+popd
 
-echo Bumping versions
-"${CODEQL_DIST}/codeql" pack post-release --groups $GRPS
+# The above commands update
+#  ./src/CHANGELOG.md
+#  ./src/codeql-pack.release.yml
+#  ./src/qlpack.yml
+# and add a new file
+#  ./src/change-notes/released/<version>.md
 
-echo Automodel packs successfully published. Please commit and push the version changes.
+if [ -z "${1:-}" ]; then
+  # If we used the latest release of codeml-automodel, then we need to return to the current branch
+  git checkout "$CURRENT_BRANCH"
+fi
+
+# Add the updated files to the current branch
+git add ./src/CHANGELOG.md
+git add ./src/codeql-pack.release.yml
+git add ./src/qlpack.yml
+git add ./src/change-notes/released/*
+echo "Added the following updated version files to the current branch:"
+git status -s
+
+echo "Automodel packs successfully published. Local files have been modified. Please commit and push the version changes and then merge into main."
+

--- a/java/ql/automodel/publish.sh
+++ b/java/ql/automodel/publish.sh
@@ -31,7 +31,7 @@ if [ -z "${GH_TOKEN}" ]; then
   exit 1
 fi
 
-# Get the sha of the previous release
+# Get the sha of the previous release, i.e. the last commit to the main branch that updated the query pack version
 PREVIOUS_RELEASE_SHA=$(git rev-list -n 1 main -- ./src/qlpack.yml)
 if [ -z "$PREVIOUS_RELEASE_SHA" ]; then
   echo "Error: Could not get the sha of the previous release of codeml-automodel query pack"

--- a/java/ql/automodel/publish.sh
+++ b/java/ql/automodel/publish.sh
@@ -18,15 +18,15 @@ if ! git diff --quiet; then
 fi
 
 # Check the above environment variables are set
-if [ -z "${GITHUB_TOKEN:-}" ]; then
+if [ -z "${GITHUB_TOKEN}" ]; then
   echo "Error: GITHUB_TOKEN environment variable not set. Please set this to a token with package:write permissions to codeql."
   exit 1
 fi
-if [ -z "${CODEQL_DIST:-}" ]; then
+if [ -z "${CODEQL_DIST}" ]; then
   echo "Error: CODEQL_DIST environment variable not set. Please set this to the path of a codeql distribution."
   exit 1
 fi
-if [ -z "${GH_TOKEN:-}" ]; then
+if [ -z "${GH_TOKEN}" ]; then
   echo "Error: GH_TOKEN environment variable not set. Please set this to a token with repo permissions to github/codeml-automodel."
   exit 1
 fi

--- a/java/ql/automodel/publish.sh
+++ b/java/ql/automodel/publish.sh
@@ -52,8 +52,10 @@ if [ -z "${1:-}" ]; then
       exit 1
   fi
   echo "Updating to latest automodel release: $TAG_NAME"
+  # Before downloading, delete any existing release.zip, and ignore failure if not present
   rm release.zip || true
   gh release download $TAG_NAME -A zip -O release.zip --repo 'https://github.com/github/codeml-automodel'
+  # Before unzipping, delete any existing release directory, and ignore failure if not present
   rm -rf release || true
   unzip -o release.zip -d release 
   REVISION=$(jq -r '.["codeql-sha"]' release/codeml-automodel*/codeml-automodel-release.json)

--- a/java/ql/automodel/publish.sh
+++ b/java/ql/automodel/publish.sh
@@ -9,12 +9,10 @@ if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
   exit 0
 fi
 
-# If there's an $1 argument, then check it's "override-release"
-if [ -n "${1:-}" ]; then
-  if [ "$1" != "override-release" ]; then
-    echo "Error: The only valid argument is 'override-release'"
-    exit 1
-  fi
+# Check that either there are 0 or 1 arguments, and if 1 argument then check that it is "override-release"
+if [ $# -gt 1 ] || [ $# -eq 1 ] && [ "$1" != "override-release" ]; then
+  echo "Error: Invalid arguments. Please run './publish --help' for usage information."
+  exit 1
 fi
 
 # If we're publishing the codeml-automodel release then we will checkout the sha specified in the release.

--- a/java/ql/automodel/publish.sh
+++ b/java/ql/automodel/publish.sh
@@ -1,8 +1,39 @@
 #!/bin/sh
 set -e
 
-# Before running this, make sure there is an SSO-enabled token with package:write
-# permissions to codeql supplied via the GITHUB_TOKEN environment variable
+# Before running this, make sure
+# 1. there is an SSO-enabled token with package:write permissions to codeql supplied via the GITHUB_TOKEN environment variable
+# 2. the CODEQL_DIST environment variable is set to the path of a codeql distribution
+# 3. the gh command line tool is installed and authenticated with a token that has repo permissions to github/codeml-automodel
+# supplied via the GH_TOKEN environment variable
+
+# Script to publish a new version of the automodel package to the package registry.
+# Usage: ./publish [override-release]
+# By default the sha of the codeql repo specified in the latest release of codeml-automodel will be published.
+# Otherwise, the optional argument override-release forces the current HEAD to be published.
+
+# If the first argument is empty, use the latest release of codeml-automodel
+if [ -z "${1:-}" ]; then
+    TAG_NAME=$(gh api -H 'Accept: application/vnd.github+json' -H 'X-GitHub-Api-Version: 2022-11-28' /repos/github/codeml-automodel/releases/latest | jq -r .tag_name)
+    # Check TAG_NAME is not empty
+    if [ -z "$TAG_NAME" ]; then
+        echo "Error: Could not get latest release of codeml-automodel"
+        exit 1
+    fi
+    echo "Updating to latest automodel release: $TAG_NAME"
+    rm release.zip || true
+    gh release download $TAG_NAME -A zip -O release.zip --repo 'https://github.com/github/codeml-automodel'
+    unzip -o release.zip -d release 
+    REVISION=$(jq -r '.["codeql-sha"]' release/codeml-automodel*/codeml-automodel-release.json)
+    echo "The latest automodel release specifies a codeql revision of $REVISION"
+    if git diff --quiet; then
+      echo "Checking out CodeQL revision $REVISION"
+      git reset --hard "$REVISION"
+    else
+      echo "Error: Uncommitted changes exist. Please commit or stash your changes before resetting."
+      exit 1
+    fi
+fi
 
 AUTOMODEL_ROOT="$(readlink -f "$(dirname $0)")"
 WORKSPACE_ROOT="$AUTOMODEL_ROOT/../../.."

--- a/java/ql/automodel/src/README.md
+++ b/java/ql/automodel/src/README.md
@@ -65,7 +65,7 @@ A significant part of the behavior of extraction queries is implemented in share
 
 ## Packaging
 
-Automodel extraction queries come as a dedicated package. See [qlpack.yml](https://github.com/github/codeql/blob/main/java/ql/automodel/src/qlpack.yml). The [publish.sh](https://github.com/github/codeql/blob/main/java/ql/automodel/publish.sh) script is responsible for publishing a new version to the [package registry](https://github.com/orgs/codeql/packages/container/package/java-automodel-queries).
+Automodel extraction queries come as a dedicated package. See [qlpack.yml](https://github.com/github/codeql/blob/main/java/ql/automodel/src/qlpack.yml). The [publish.sh](https://github.com/github/codeql/blob/main/java/ql/automodel/publish.sh) script is responsible for publishing a new version to the [package registry](https://github.com/orgs/codeql/packages/container/package/java-automodel-queries). **The extraction queries are functionally coupled with other automodel components. Only publish the query pack as part of the automodel release process.**
 
 ### Backwards Compatibility
 


### PR DESCRIPTION
The `automodel` extraction queries (released as a `codeql` query pack), and `automodel` Python CLI (released as part of `turbomodel`) are functionally coupled. They must be released "together". The official releases of the `codeml-automodel` repo (see https://github.com/github/codeml-automodel/releases) specify coupled `sha`s. 

This PR upgrades the `publish.sh` script to default to publishing the version of the `automodel` extraction queries that correspond to the latest release of `codeml-automodel`; specifically, invoking `publish.sh` will:
- Check you don't have any uncommitted local changes
- Check that you have the required security tokens
- Check that you have a local `codeql` distribution (needed to package and publish the query pack)
- Check that the version of the `codeql` code you wish to publish is later than the current published pack
- Retrieves the latest `codeml-automodel` release, which specifies the `sha` of the `codeql` repo that should be published, and checks out this `sha`
- Packages and publishes the query pack
- `git add`s the local changes generated by the publication process, which the user must then commit and merge to `codeql` `main`

N.B. Users can override the default by specifying `publish.sh override-release` to publish the `HEAD` of their local version of the `automodel` extraction queries. (This conforms to the previous behavior of the script).

Addresses: https://github.com/github/codeql-team/issues/2467

See related PR: https://github.com/github/turbomodel/pull/208