### PR TITLE
C#: Improve arg-param mapping logic to better handle arguments passed to `params` parameters

### DIFF
--- a/csharp/ql/lib/change-notes/2023-12-20-arg-param-mapping.md
+++ b/csharp/ql/lib/change-notes/2023-12-20-arg-param-mapping.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+
+* The `Call::getArgumentForParameter` predicate has been reworked to add support for arguments passed to `params` parameters.

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -602,18 +602,6 @@ predicate simpleLocalFlowStep(Node nodeFrom, Node nodeTo) {
   nodeTo.(ObjectCreationNode).getPreUpdateNode() = nodeFrom.(ObjectInitializerNode)
 }
 
-pragma[noinline]
-private Expr getImplicitArgument(Call c, int pos) {
-  result = c.getArgument(pos) and
-  not exists(result.getExplicitArgumentName())
-}
-
-pragma[nomagic]
-private Expr getExplicitArgument(Call c, string name) {
-  result = c.getAnArgument() and
-  result.getExplicitArgumentName() = name
-}
-
 /**
  * Holds if `arg` is a `params` argument of `c`, for parameter `p`, and `arg` will
  * be wrapped in an array by the C# compiler.
@@ -624,11 +612,7 @@ private predicate isParamsArg(Call c, Expr arg, Parameter p) {
     p = target.getAParameter() and
     p.isParams() and
     numArgs = c.getNumberOfArguments() and
-    arg =
-      [
-        getImplicitArgument(c, [p.getPosition() .. numArgs - 1]),
-        getExplicitArgument(c, p.getName())
-      ]
+    arg = c.getArgumentForParameter(p)
   |
     numArgs > target.getNumberOfParameters()
     or

--- a/csharp/ql/lib/semmle/code/csharp/exprs/Call.qll
+++ b/csharp/ql/lib/semmle/code/csharp/exprs/Call.qll
@@ -66,8 +66,7 @@ class Call extends DotNet::Call, Expr, @call {
       result = this.getImplicitArgument(p)
       or
       // Appears in the named part of the call
-      result = this.getExplicitArgument(p.getName()) and
-      (p.(Parameter).isParams() implies isValidExplicitParamsType(p, result.getType()))
+      result = this.getExplicitArgument(p.getName())
     )
   }
 
@@ -222,28 +221,6 @@ class Call extends DotNet::Call, Expr, @call {
   predicate hasNoRuntimeArguments() { not exists(this.getARuntimeArgument()) }
 
   override string toString() { result = "call" }
-}
-
-/**
- * Holds if the type `t` is a valid argument type for passing an explicit array
- * to the `params` parameter `p`. For example, the types `object[]` and `string[]`
- * of the arguments on lines 4 and 5, respectively, are valid for the parameter
- * `args` on line 1 in
- *
- * ```csharp
- * void M(params object[] args) { ... }
- *
- * void CallM(object[] os, string[] ss, string s) {
- *   M(os);
- *   M(ss);
- *   M(s);
- * }
- * ```
- */
-pragma[nomagic]
-private predicate isValidExplicitParamsType(Parameter p, Type t) {
-  p.isParams() and
-  t.isImplicitlyConvertibleTo(p.getType())
 }
 
 /**

--- a/csharp/ql/test/library-tests/arguments/PrintAst.expected
+++ b/csharp/ql/test/library-tests/arguments/PrintAst.expected
@@ -117,137 +117,239 @@ arguments.cs:
 #   40|               0: [IntLiteral] 1
 #   40|               1: [IntLiteral] 2
 #   40|           1: [IntLiteral] 0
-#   43|   10: [Method] f4
-#   43|     -1: [TypeMention] Void
+#   41|       6: [LocalVariableDeclStmt] ... ...;
+#   41|         0: [LocalVariableDeclAndInitExpr] Int16 s1 = ...
+#   41|           -1: [TypeMention] short
+#   41|           0: [LocalVariableAccess] access to local variable s1
+#   41|           1: [CastExpr] (...) ...
+#   41|             1: [IntLiteral] 1
+#   41|         1: [LocalVariableDeclAndInitExpr] Int16 s2 = ...
+#   41|           -1: [TypeMention] short
+#   41|           0: [LocalVariableAccess] access to local variable s2
+#   41|           1: [CastExpr] (...) ...
+#   41|             1: [IntLiteral] 2
+#   42|       7: [ExprStmt] ...;
+#   42|         0: [MethodCall] call to method f3
+#   42|           0: [IntLiteral] 0
+#   42|           1: [CastExpr] (...) ...
+#   42|             1: [LocalVariableAccess] access to local variable s1
+#   42|           2: [CastExpr] (...) ...
+#   42|             1: [LocalVariableAccess] access to local variable s2
+#   45|   10: [Method] f4
+#   45|     -1: [TypeMention] Void
 #-----|     2: (Parameters)
-#   43|       0: [Parameter] args
-#   43|         -1: [TypeMention] Object[]
-#   43|           1: [TypeMention] object
-#   44|     4: [BlockStmt] {...}
-#   45|       0: [ExprStmt] ...;
-#   45|         0: [MethodCall] call to method f4
-#   45|           0: [ArrayCreation] array creation of type Object[]
-#   45|             -2: [TypeMention] Object[]
-#   45|               1: [TypeMention] object
-#   45|             -1: [ArrayInitializer] { ..., ... }
-#   45|               0: [NullLiteral] null
-#   45|           1: [NullLiteral] null
-#   48|   11: [Property] Prop
-#   48|     -1: [TypeMention] int
-#   48|     3: [Getter] get_Prop
-#   48|     4: [Setter] set_Prop
-#-----|       2: (Parameters)
-#   48|         0: [Parameter] value
-#   50|   12: [Indexer] Item
+#   45|       0: [Parameter] args
+#   45|         -1: [TypeMention] Object[]
+#   45|           1: [TypeMention] object
+#   46|     4: [BlockStmt] {...}
+#   47|       0: [ExprStmt] ...;
+#   47|         0: [MethodCall] call to method f4
+#   47|           0: [ArrayCreation] array creation of type Object[]
+#   47|             -2: [TypeMention] Object[]
+#   47|               1: [TypeMention] object
+#   47|             -1: [ArrayInitializer] { ..., ... }
+#   47|               0: [NullLiteral] null
+#   47|           1: [NullLiteral] null
+#   50|   11: [Property] Prop
 #   50|     -1: [TypeMention] int
+#   50|     3: [Getter] get_Prop
+#   50|     4: [Setter] set_Prop
+#-----|       2: (Parameters)
+#   50|         0: [Parameter] value
+#   52|   12: [Indexer] Item
+#   52|     -1: [TypeMention] int
 #-----|     1: (Parameters)
-#   50|       0: [Parameter] a
-#   50|         -1: [TypeMention] int
-#   50|       1: [Parameter] b
-#   50|         -1: [TypeMention] int
-#   50|     3: [Getter] get_Item
+#   52|       0: [Parameter] a
+#   52|         -1: [TypeMention] int
+#   52|       1: [Parameter] b
+#   52|         -1: [TypeMention] int
+#   52|     3: [Getter] get_Item
 #-----|       2: (Parameters)
-#   50|         0: [Parameter] a
-#   50|         1: [Parameter] b
-#   50|       4: [AddExpr] ... + ...
-#   50|         0: [ParameterAccess] access to parameter a
-#   50|         1: [ParameterAccess] access to parameter b
-#   50|     4: [Setter] set_Item
+#   52|         0: [Parameter] a
+#   52|         1: [Parameter] b
+#   52|       4: [AddExpr] ... + ...
+#   52|         0: [ParameterAccess] access to parameter a
+#   52|         1: [ParameterAccess] access to parameter b
+#   52|     4: [Setter] set_Item
 #-----|       2: (Parameters)
-#   50|         0: [Parameter] a
-#   50|         1: [Parameter] b
-#   50|         2: [Parameter] value
-#   50|       4: [BlockStmt] {...}
-#   52|   13: [Method] f5
-#   52|     -1: [TypeMention] Void
-#   53|     4: [BlockStmt] {...}
-#   54|       0: [ExprStmt] ...;
-#   54|         0: [AssignExpr] ... = ...
-#   54|           0: [PropertyCall] access to property Prop
-#   54|           1: [IntLiteral] 0
-#   55|       1: [ExprStmt] ...;
-#   55|         0: [AssignExpr] ... = ...
-#   55|           0: [PropertyCall] access to property Prop
-#   55|           1: [IndexerCall] access to indexer
-#   55|             -1: [ThisAccess] this access
-#   55|             0: [IntLiteral] 1
-#   55|             1: [IntLiteral] 2
-#   56|       2: [ExprStmt] ...;
+#   52|         0: [Parameter] a
+#   52|         1: [Parameter] b
+#   52|         2: [Parameter] value
+#   52|       4: [BlockStmt] {...}
+#   54|   13: [Method] f5
+#   54|     -1: [TypeMention] Void
+#   55|     4: [BlockStmt] {...}
+#   56|       0: [ExprStmt] ...;
 #   56|         0: [AssignExpr] ... = ...
-#   56|           0: [TupleExpr] (..., ...)
-#   56|             0: [PropertyCall] access to property Prop
-#   56|             1: [IndexerCall] access to indexer
-#   56|               -1: [ThisAccess] this access
-#   56|               0: [IntLiteral] 3
-#   56|               1: [IntLiteral] 4
-#   56|           1: [TupleExpr] (..., ...)
-#   56|             0: [IntLiteral] 5
-#   56|             1: [IntLiteral] 6
-#   57|       3: [ExprStmt] ...;
-#   57|         0: [PostIncrExpr] ...++
+#   56|           0: [PropertyCall] access to property Prop
+#   56|           1: [IntLiteral] 0
+#   57|       1: [ExprStmt] ...;
+#   57|         0: [AssignExpr] ... = ...
 #   57|           0: [PropertyCall] access to property Prop
-#   58|       4: [ExprStmt] ...;
-#   58|         0: [AssignAddExpr] ... += ...
-#   58|           0: [PropertyCall] access to property Prop
-#   58|           1: [IntLiteral] 7
-#   59|       5: [ExprStmt] ...;
+#   57|           1: [IndexerCall] access to indexer
+#   57|             -1: [ThisAccess] this access
+#   57|             0: [IntLiteral] 1
+#   57|             1: [IntLiteral] 2
+#   58|       2: [ExprStmt] ...;
+#   58|         0: [AssignExpr] ... = ...
+#   58|           0: [TupleExpr] (..., ...)
+#   58|             0: [PropertyCall] access to property Prop
+#   58|             1: [IndexerCall] access to indexer
+#   58|               -1: [ThisAccess] this access
+#   58|               0: [IntLiteral] 3
+#   58|               1: [IntLiteral] 4
+#   58|           1: [TupleExpr] (..., ...)
+#   58|             0: [IntLiteral] 5
+#   58|             1: [IntLiteral] 6
+#   59|       3: [ExprStmt] ...;
 #   59|         0: [PostIncrExpr] ...++
-#   59|           0: [IndexerCall] access to indexer
-#   59|             -1: [ThisAccess] this access
-#   59|             0: [IntLiteral] 8
-#   59|             1: [IntLiteral] 9
-#   60|       6: [ExprStmt] ...;
+#   59|           0: [PropertyCall] access to property Prop
+#   60|       4: [ExprStmt] ...;
 #   60|         0: [AssignAddExpr] ... += ...
-#   60|           0: [IndexerCall] access to indexer
-#   60|             -1: [ThisAccess] this access
-#   60|             0: [IntLiteral] 10
-#   60|             1: [IntLiteral] 11
-#   60|           1: [IntLiteral] 12
-#   61|       7: [LocalVariableDeclStmt] ... ...;
-#   61|         0: [LocalVariableDeclAndInitExpr] (Int32,Int32) tuple = ...
-#   61|           -1: [TypeMention] (int, int)
-#   61|           0: [LocalVariableAccess] access to local variable tuple
-#   61|           1: [TupleExpr] (..., ...)
-#   61|             0: [IntLiteral] 13
-#   61|             1: [IntLiteral] 14
-#   62|       8: [ExprStmt] ...;
-#   62|         0: [AssignExpr] ... = ...
-#   62|           0: [TupleExpr] (..., ...)
-#   62|             0: [PropertyCall] access to property Prop
-#   62|             1: [IndexerCall] access to indexer
-#   62|               -1: [ThisAccess] this access
-#   62|               0: [IntLiteral] 15
-#   62|               1: [IntLiteral] 16
-#   62|           1: [LocalVariableAccess] access to local variable tuple
-#   66|   14: [Method] f6
-#   66|     -1: [TypeMention] Void
+#   60|           0: [PropertyCall] access to property Prop
+#   60|           1: [IntLiteral] 7
+#   61|       5: [ExprStmt] ...;
+#   61|         0: [PostIncrExpr] ...++
+#   61|           0: [IndexerCall] access to indexer
+#   61|             -1: [ThisAccess] this access
+#   61|             0: [IntLiteral] 8
+#   61|             1: [IntLiteral] 9
+#   62|       6: [ExprStmt] ...;
+#   62|         0: [AssignAddExpr] ... += ...
+#   62|           0: [IndexerCall] access to indexer
+#   62|             -1: [ThisAccess] this access
+#   62|             0: [IntLiteral] 10
+#   62|             1: [IntLiteral] 11
+#   62|           1: [IntLiteral] 12
+#   63|       7: [LocalVariableDeclStmt] ... ...;
+#   63|         0: [LocalVariableDeclAndInitExpr] (Int32,Int32) tuple = ...
+#   63|           -1: [TypeMention] (int, int)
+#   63|           0: [LocalVariableAccess] access to local variable tuple
+#   63|           1: [TupleExpr] (..., ...)
+#   63|             0: [IntLiteral] 13
+#   63|             1: [IntLiteral] 14
+#   64|       8: [ExprStmt] ...;
+#   64|         0: [AssignExpr] ... = ...
+#   64|           0: [TupleExpr] (..., ...)
+#   64|             0: [PropertyCall] access to property Prop
+#   64|             1: [IndexerCall] access to indexer
+#   64|               -1: [ThisAccess] this access
+#   64|               0: [IntLiteral] 15
+#   64|               1: [IntLiteral] 16
+#   64|           1: [LocalVariableAccess] access to local variable tuple
+#   68|   14: [Method] f6
+#   68|     -1: [TypeMention] Void
 #-----|     0: (Attributes)
-#   65|       1: [DefaultAttribute] [My(...)]
-#   65|         -1: [TypeMention] MyAttribute
-#   65|         0: [BoolLiteral] false
-#   66|     4: [BlockStmt] {...}
-#   69|   15: [Method] f7
-#   69|     -1: [TypeMention] Void
+#   67|       1: [DefaultAttribute] [My(...)]
+#   67|         -1: [TypeMention] MyAttribute
+#   67|         0: [BoolLiteral] false
+#   68|     4: [BlockStmt] {...}
+#   71|   15: [Method] f7
+#   71|     -1: [TypeMention] Void
 #-----|     0: (Attributes)
-#   68|       1: [DefaultAttribute] [My(...)]
-#   68|         -1: [TypeMention] MyAttribute
-#   68|         0: [BoolLiteral] true
-#   68|         1: [StringLiteralUtf16] ""
-#   68|         2: [IntLiteral] 0
-#   69|     4: [BlockStmt] {...}
-#   72| [Class] MyAttribute
-#-----|   3: (Base types)
-#   72|     0: [TypeMention] Attribute
-#   74|   4: [Field] x
-#   74|     -1: [TypeMention] int
-#   75|   5: [Property] y
-#   75|     -1: [TypeMention] string
-#   75|     3: [Getter] get_y
-#   75|     4: [Setter] set_y
-#-----|       2: (Parameters)
-#   75|         0: [Parameter] value
-#   76|   6: [InstanceConstructor] MyAttribute
+#   70|       1: [DefaultAttribute] [My(...)]
+#   70|         -1: [TypeMention] MyAttribute
+#   70|         0: [BoolLiteral] true
+#   70|         1: [StringLiteralUtf16] ""
+#   70|         2: [IntLiteral] 0
+#   71|     4: [BlockStmt] {...}
+#   73|   17: [Method] f8`1
+#   73|     -1: [TypeMention] Void
+#-----|     1: (Type parameters)
+#   73|       0: [TypeParameter] T
 #-----|     2: (Parameters)
-#   76|       0: [Parameter] b
-#   76|         -1: [TypeMention] bool
-#   76|     4: [BlockStmt] {...}
+#   73|       0: [Parameter] o
+#   73|         -1: [TypeMention] int
+#   73|       1: [Parameter] args
+#   73|         -1: [TypeMention] T[]
+#   73|           1: [TypeMention] T
+#   74|     4: [BlockStmt] {...}
+#   75|       0: [ExprStmt] ...;
+#   75|         0: [MethodCall] call to method f8`1
+#   75|           0: [IntLiteral] 0
+#   75|           1: [ArrayAccess] access to array element
+#   75|             -1: [ParameterAccess] access to parameter args
+#   75|             0: [IntLiteral] 0
+#   75|           2: [ArrayAccess] access to array element
+#   75|             -1: [ParameterAccess] access to parameter args
+#   75|             0: [IntLiteral] 1
+#   76|       1: [ExprStmt] ...;
+#   76|         0: [MethodCall] call to method f8`1
+#   76|           0: [IntLiteral] 0
+#   76|           1: [ArrayCreation] array creation of type T[]
+#   76|             -2: [TypeMention] T[]
+#   76|               1: [TypeMention] T
+#   76|             -1: [ArrayInitializer] { ..., ... }
+#   76|               0: [ArrayAccess] access to array element
+#   76|                 -1: [ParameterAccess] access to parameter args
+#   76|                 0: [IntLiteral] 0
+#   76|               1: [ArrayAccess] access to array element
+#   76|                 -1: [ParameterAccess] access to parameter args
+#   76|                 0: [IntLiteral] 1
+#   77|       2: [ExprStmt] ...;
+#   77|         0: [MethodCall] call to method f8`1
+#   77|           0: [IntLiteral] 0
+#   77|           1: [ParameterAccess] access to parameter args
+#   78|       3: [ExprStmt] ...;
+#   78|         0: [MethodCall] call to method f8`1
+#   78|           0: [ParameterAccess] access to parameter args
+#   78|           1: [IntLiteral] 0
+#   80|       4: [ExprStmt] ...;
+#   80|         0: [MethodCall] call to method f8<Double>
+#   80|           0: [IntLiteral] 0
+#   80|           1: [DoubleLiteral] 1.1
+#   80|           2: [DoubleLiteral] 2.2
+#   81|       5: [ExprStmt] ...;
+#   81|         0: [MethodCall] call to method f8<Double>
+#   81|           0: [IntLiteral] 0
+#   81|           1: [ArrayCreation] array creation of type Double[]
+#   81|             -2: [TypeMention] Double[]
+#   81|               1: [TypeMention] double
+#   81|             -1: [ArrayInitializer] { ..., ... }
+#   81|               0: [DoubleLiteral] 1.1
+#   81|               1: [DoubleLiteral] 2.2
+#   83|       6: [ExprStmt] ...;
+#   83|         0: [MethodCall] call to method f8<Double>
+#   83|           0: [IntLiteral] 0
+#   83|           1: [CastExpr] (...) ...
+#   83|             1: [IntLiteral] 1
+#   83|           2: [CastExpr] (...) ...
+#   83|             1: [IntLiteral] 2
+#   84|       7: [ExprStmt] ...;
+#   84|         0: [MethodCall] call to method f8<Double>
+#   84|           0: [IntLiteral] 0
+#   84|           1: [ArrayCreation] array creation of type Double[]
+#   84|             -2: [TypeMention] Double[]
+#   84|               1: [TypeMention] double
+#   84|             -1: [ArrayInitializer] { ..., ... }
+#   84|               0: [CastExpr] (...) ...
+#   84|                 1: [IntLiteral] 1
+#   84|               1: [CastExpr] (...) ...
+#   84|                 1: [IntLiteral] 2
+#   85|       8: [ExprStmt] ...;
+#   85|         0: [MethodCall] call to method f8<Double>
+#   85|           0: [IntLiteral] 0
+#   85|           1: [ArrayCreation] array creation of type Double[]
+#   85|             -2: [TypeMention] Double[]
+#   85|               1: [TypeMention] double
+#   85|             -1: [ArrayInitializer] { ..., ... }
+#   85|               0: [CastExpr] (...) ...
+#   85|                 1: [IntLiteral] 1
+#   85|               1: [CastExpr] (...) ...
+#   85|                 1: [IntLiteral] 2
+#   89| [Class] MyAttribute
+#-----|   3: (Base types)
+#   89|     0: [TypeMention] Attribute
+#   91|   4: [Field] x
+#   91|     -1: [TypeMention] int
+#   92|   5: [Property] y
+#   92|     -1: [TypeMention] string
+#   92|     3: [Getter] get_y
+#   92|     4: [Setter] set_y
+#-----|       2: (Parameters)
+#   92|         0: [Parameter] value
+#   93|   6: [InstanceConstructor] MyAttribute
+#-----|     2: (Parameters)
+#   93|       0: [Parameter] b
+#   93|         -1: [TypeMention] bool
+#   93|     4: [BlockStmt] {...}

--- a/csharp/ql/test/library-tests/arguments/argumentByName.expected
+++ b/csharp/ql/test/library-tests/arguments/argumentByName.expected
@@ -17,21 +17,37 @@
 | arguments.cs:39:9:39:28 | call to method f3 | arguments.cs:39:27:39:27 | 0 | o |
 | arguments.cs:40:9:40:42 | call to method f3 | arguments.cs:40:18:40:35 | array creation of type Int32[] | args |
 | arguments.cs:40:9:40:42 | call to method f3 | arguments.cs:40:41:40:41 | 0 | o |
-| arguments.cs:54:9:54:12 | access to property Prop | arguments.cs:54:16:54:16 | 0 | value |
-| arguments.cs:55:9:55:12 | access to property Prop | arguments.cs:55:16:55:25 | access to indexer | value |
-| arguments.cs:55:16:55:25 | access to indexer | arguments.cs:55:21:55:21 | 1 | a |
-| arguments.cs:55:16:55:25 | access to indexer | arguments.cs:55:24:55:24 | 2 | b |
-| arguments.cs:56:10:56:13 | access to property Prop | arguments.cs:56:31:56:31 | 5 | value |
-| arguments.cs:56:16:56:25 | access to indexer | arguments.cs:56:21:56:21 | 3 | a |
-| arguments.cs:56:16:56:25 | access to indexer | arguments.cs:56:24:56:24 | 4 | b |
-| arguments.cs:56:16:56:25 | access to indexer | arguments.cs:56:34:56:34 | 6 | value |
-| arguments.cs:58:9:58:12 | access to property Prop | arguments.cs:58:9:58:17 | ... + ... | value |
-| arguments.cs:59:9:59:18 | access to indexer | arguments.cs:59:14:59:14 | 8 | a |
-| arguments.cs:59:9:59:18 | access to indexer | arguments.cs:59:17:59:17 | 9 | b |
-| arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:9:60:26 | ... + ... | value |
-| arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:14:60:15 | 10 | a |
-| arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:14:60:15 | 10 | a |
-| arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:18:60:19 | 11 | b |
-| arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:18:60:19 | 11 | b |
-| arguments.cs:62:16:62:27 | access to indexer | arguments.cs:62:21:62:22 | 15 | a |
-| arguments.cs:62:16:62:27 | access to indexer | arguments.cs:62:25:62:26 | 16 | b |
+| arguments.cs:42:9:42:21 | call to method f3 | arguments.cs:42:12:42:12 | 0 | o |
+| arguments.cs:56:9:56:12 | access to property Prop | arguments.cs:56:16:56:16 | 0 | value |
+| arguments.cs:57:9:57:12 | access to property Prop | arguments.cs:57:16:57:25 | access to indexer | value |
+| arguments.cs:57:16:57:25 | access to indexer | arguments.cs:57:21:57:21 | 1 | a |
+| arguments.cs:57:16:57:25 | access to indexer | arguments.cs:57:24:57:24 | 2 | b |
+| arguments.cs:58:10:58:13 | access to property Prop | arguments.cs:58:31:58:31 | 5 | value |
+| arguments.cs:58:16:58:25 | access to indexer | arguments.cs:58:21:58:21 | 3 | a |
+| arguments.cs:58:16:58:25 | access to indexer | arguments.cs:58:24:58:24 | 4 | b |
+| arguments.cs:58:16:58:25 | access to indexer | arguments.cs:58:34:58:34 | 6 | value |
+| arguments.cs:60:9:60:12 | access to property Prop | arguments.cs:60:9:60:17 | ... + ... | value |
+| arguments.cs:61:9:61:18 | access to indexer | arguments.cs:61:14:61:14 | 8 | a |
+| arguments.cs:61:9:61:18 | access to indexer | arguments.cs:61:17:61:17 | 9 | b |
+| arguments.cs:62:9:62:20 | access to indexer | arguments.cs:62:9:62:26 | ... + ... | value |
+| arguments.cs:62:9:62:20 | access to indexer | arguments.cs:62:14:62:15 | 10 | a |
+| arguments.cs:62:9:62:20 | access to indexer | arguments.cs:62:14:62:15 | 10 | a |
+| arguments.cs:62:9:62:20 | access to indexer | arguments.cs:62:18:62:19 | 11 | b |
+| arguments.cs:62:9:62:20 | access to indexer | arguments.cs:62:18:62:19 | 11 | b |
+| arguments.cs:64:16:64:27 | access to indexer | arguments.cs:64:21:64:22 | 15 | a |
+| arguments.cs:64:16:64:27 | access to indexer | arguments.cs:64:25:64:26 | 16 | b |
+| arguments.cs:75:9:75:31 | call to method f8`1 | arguments.cs:75:12:75:12 | 0 | o |
+| arguments.cs:76:9:76:43 | call to method f8`1 | arguments.cs:76:12:76:12 | 0 | o |
+| arguments.cs:76:9:76:43 | call to method f8`1 | arguments.cs:76:15:76:42 | array creation of type T[] | args |
+| arguments.cs:77:9:77:19 | call to method f8`1 | arguments.cs:77:12:77:12 | 0 | o |
+| arguments.cs:77:9:77:19 | call to method f8`1 | arguments.cs:77:15:77:18 | access to parameter args | args |
+| arguments.cs:78:9:78:28 | call to method f8`1 | arguments.cs:78:18:78:21 | access to parameter args | args |
+| arguments.cs:78:9:78:28 | call to method f8`1 | arguments.cs:78:27:78:27 | 0 | o |
+| arguments.cs:80:9:80:31 | call to method f8<Double> | arguments.cs:80:20:80:20 | 0 | o |
+| arguments.cs:81:9:81:48 | call to method f8<Double> | arguments.cs:81:20:81:20 | 0 | o |
+| arguments.cs:81:9:81:48 | call to method f8<Double> | arguments.cs:81:23:81:47 | array creation of type Double[] | args |
+| arguments.cs:83:9:83:27 | call to method f8<Double> | arguments.cs:83:20:83:20 | 0 | o |
+| arguments.cs:84:9:84:44 | call to method f8<Double> | arguments.cs:84:20:84:20 | 0 | o |
+| arguments.cs:84:9:84:44 | call to method f8<Double> | arguments.cs:84:23:84:43 | array creation of type Double[] | args |
+| arguments.cs:85:9:85:44 | call to method f8<Double> | arguments.cs:85:20:85:20 | 0 | o |
+| arguments.cs:85:9:85:44 | call to method f8<Double> | arguments.cs:85:23:85:43 | array creation of type Double[] | args |

--- a/csharp/ql/test/library-tests/arguments/argumentByName.expected
+++ b/csharp/ql/test/library-tests/arguments/argumentByName.expected
@@ -8,6 +8,8 @@
 | arguments.cs:30:9:30:38 | object creation of type ArgumentsTest | arguments.cs:30:30:30:31 | 10 | y |
 | arguments.cs:30:9:30:38 | object creation of type ArgumentsTest | arguments.cs:30:37:30:37 | 5 | x |
 | arguments.cs:35:9:35:19 | call to method f3 | arguments.cs:35:12:35:12 | 0 | o |
+| arguments.cs:35:9:35:19 | call to method f3 | arguments.cs:35:15:35:15 | 1 | args |
+| arguments.cs:35:9:35:19 | call to method f3 | arguments.cs:35:18:35:18 | 2 | args |
 | arguments.cs:36:9:36:33 | call to method f3 | arguments.cs:36:12:36:12 | 0 | o |
 | arguments.cs:36:9:36:33 | call to method f3 | arguments.cs:36:15:36:32 | array creation of type Int32[] | args |
 | arguments.cs:37:9:37:25 | call to method f3 | arguments.cs:37:24:37:24 | 0 | o |
@@ -18,6 +20,10 @@
 | arguments.cs:40:9:40:42 | call to method f3 | arguments.cs:40:18:40:35 | array creation of type Int32[] | args |
 | arguments.cs:40:9:40:42 | call to method f3 | arguments.cs:40:41:40:41 | 0 | o |
 | arguments.cs:42:9:42:21 | call to method f3 | arguments.cs:42:12:42:12 | 0 | o |
+| arguments.cs:42:9:42:21 | call to method f3 | arguments.cs:42:15:42:16 | (...) ... | args |
+| arguments.cs:42:9:42:21 | call to method f3 | arguments.cs:42:19:42:20 | (...) ... | args |
+| arguments.cs:47:9:47:39 | call to method f4 | arguments.cs:47:12:47:32 | array creation of type Object[] | args |
+| arguments.cs:47:9:47:39 | call to method f4 | arguments.cs:47:35:47:38 | null | args |
 | arguments.cs:56:9:56:12 | access to property Prop | arguments.cs:56:16:56:16 | 0 | value |
 | arguments.cs:57:9:57:12 | access to property Prop | arguments.cs:57:16:57:25 | access to indexer | value |
 | arguments.cs:57:16:57:25 | access to indexer | arguments.cs:57:21:57:21 | 1 | a |
@@ -37,6 +43,8 @@
 | arguments.cs:64:16:64:27 | access to indexer | arguments.cs:64:21:64:22 | 15 | a |
 | arguments.cs:64:16:64:27 | access to indexer | arguments.cs:64:25:64:26 | 16 | b |
 | arguments.cs:75:9:75:31 | call to method f8`1 | arguments.cs:75:12:75:12 | 0 | o |
+| arguments.cs:75:9:75:31 | call to method f8`1 | arguments.cs:75:15:75:21 | access to array element | args |
+| arguments.cs:75:9:75:31 | call to method f8`1 | arguments.cs:75:24:75:30 | access to array element | args |
 | arguments.cs:76:9:76:43 | call to method f8`1 | arguments.cs:76:12:76:12 | 0 | o |
 | arguments.cs:76:9:76:43 | call to method f8`1 | arguments.cs:76:15:76:42 | array creation of type T[] | args |
 | arguments.cs:77:9:77:19 | call to method f8`1 | arguments.cs:77:12:77:12 | 0 | o |
@@ -44,9 +52,13 @@
 | arguments.cs:78:9:78:28 | call to method f8`1 | arguments.cs:78:18:78:21 | access to parameter args | args |
 | arguments.cs:78:9:78:28 | call to method f8`1 | arguments.cs:78:27:78:27 | 0 | o |
 | arguments.cs:80:9:80:31 | call to method f8<Double> | arguments.cs:80:20:80:20 | 0 | o |
+| arguments.cs:80:9:80:31 | call to method f8<Double> | arguments.cs:80:23:80:25 | 1.1 | args |
+| arguments.cs:80:9:80:31 | call to method f8<Double> | arguments.cs:80:28:80:30 | 2.2 | args |
 | arguments.cs:81:9:81:48 | call to method f8<Double> | arguments.cs:81:20:81:20 | 0 | o |
 | arguments.cs:81:9:81:48 | call to method f8<Double> | arguments.cs:81:23:81:47 | array creation of type Double[] | args |
 | arguments.cs:83:9:83:27 | call to method f8<Double> | arguments.cs:83:20:83:20 | 0 | o |
+| arguments.cs:83:9:83:27 | call to method f8<Double> | arguments.cs:83:23:83:23 | (...) ... | args |
+| arguments.cs:83:9:83:27 | call to method f8<Double> | arguments.cs:83:26:83:26 | (...) ... | args |
 | arguments.cs:84:9:84:44 | call to method f8<Double> | arguments.cs:84:20:84:20 | 0 | o |
 | arguments.cs:84:9:84:44 | call to method f8<Double> | arguments.cs:84:23:84:43 | array creation of type Double[] | args |
 | arguments.cs:85:9:85:44 | call to method f8<Double> | arguments.cs:85:20:85:20 | 0 | o |

--- a/csharp/ql/test/library-tests/arguments/argumentByName.expected
+++ b/csharp/ql/test/library-tests/arguments/argumentByName.expected
@@ -12,6 +12,7 @@
 | arguments.cs:35:9:35:19 | call to method f3 | arguments.cs:35:18:35:18 | 2 | args |
 | arguments.cs:36:9:36:33 | call to method f3 | arguments.cs:36:12:36:12 | 0 | o |
 | arguments.cs:36:9:36:33 | call to method f3 | arguments.cs:36:15:36:32 | array creation of type Int32[] | args |
+| arguments.cs:37:9:37:25 | call to method f3 | arguments.cs:37:18:37:18 | 1 | args |
 | arguments.cs:37:9:37:25 | call to method f3 | arguments.cs:37:24:37:24 | 0 | o |
 | arguments.cs:38:9:38:19 | call to method f3 | arguments.cs:38:12:38:12 | 0 | o |
 | arguments.cs:38:9:38:19 | call to method f3 | arguments.cs:38:15:38:18 | access to parameter args | args |

--- a/csharp/ql/test/library-tests/arguments/argumentByParameter.expected
+++ b/csharp/ql/test/library-tests/arguments/argumentByParameter.expected
@@ -17,23 +17,39 @@
 | arguments.cs:39:9:39:28 | call to method f3 | arguments.cs:39:27:39:27 | 0 | arguments.cs:33:17:33:17 | o |
 | arguments.cs:40:9:40:42 | call to method f3 | arguments.cs:40:18:40:35 | array creation of type Int32[] | arguments.cs:33:33:33:36 | args |
 | arguments.cs:40:9:40:42 | call to method f3 | arguments.cs:40:41:40:41 | 0 | arguments.cs:33:17:33:17 | o |
-| arguments.cs:54:9:54:12 | access to property Prop | arguments.cs:54:16:54:16 | 0 | arguments.cs:48:21:48:23 | value |
-| arguments.cs:55:9:55:12 | access to property Prop | arguments.cs:55:16:55:25 | access to indexer | arguments.cs:48:21:48:23 | value |
-| arguments.cs:55:16:55:25 | access to indexer | arguments.cs:55:21:55:21 | 1 | arguments.cs:50:18:50:18 | a |
-| arguments.cs:55:16:55:25 | access to indexer | arguments.cs:55:24:55:24 | 2 | arguments.cs:50:25:50:25 | b |
-| arguments.cs:56:10:56:13 | access to property Prop | arguments.cs:56:31:56:31 | 5 | arguments.cs:48:21:48:23 | value |
-| arguments.cs:56:16:56:25 | access to indexer | arguments.cs:56:21:56:21 | 3 | arguments.cs:50:18:50:18 | a |
-| arguments.cs:56:16:56:25 | access to indexer | arguments.cs:56:24:56:24 | 4 | arguments.cs:50:25:50:25 | b |
-| arguments.cs:56:16:56:25 | access to indexer | arguments.cs:56:34:56:34 | 6 | arguments.cs:50:44:50:46 | value |
-| arguments.cs:58:9:58:12 | access to property Prop | arguments.cs:58:9:58:17 | ... + ... | arguments.cs:48:21:48:23 | value |
-| arguments.cs:59:9:59:18 | access to indexer | arguments.cs:59:14:59:14 | 8 | arguments.cs:50:18:50:18 | a |
-| arguments.cs:59:9:59:18 | access to indexer | arguments.cs:59:14:59:14 | 8 | arguments.cs:50:18:50:18 | a |
-| arguments.cs:59:9:59:18 | access to indexer | arguments.cs:59:17:59:17 | 9 | arguments.cs:50:25:50:25 | b |
-| arguments.cs:59:9:59:18 | access to indexer | arguments.cs:59:17:59:17 | 9 | arguments.cs:50:25:50:25 | b |
-| arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:9:60:26 | ... + ... | arguments.cs:50:44:50:46 | value |
-| arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:14:60:15 | 10 | arguments.cs:50:18:50:18 | a |
-| arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:14:60:15 | 10 | arguments.cs:50:18:50:18 | a |
-| arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:18:60:19 | 11 | arguments.cs:50:25:50:25 | b |
-| arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:18:60:19 | 11 | arguments.cs:50:25:50:25 | b |
-| arguments.cs:62:16:62:27 | access to indexer | arguments.cs:62:21:62:22 | 15 | arguments.cs:50:18:50:18 | a |
-| arguments.cs:62:16:62:27 | access to indexer | arguments.cs:62:25:62:26 | 16 | arguments.cs:50:25:50:25 | b |
+| arguments.cs:42:9:42:21 | call to method f3 | arguments.cs:42:12:42:12 | 0 | arguments.cs:33:17:33:17 | o |
+| arguments.cs:56:9:56:12 | access to property Prop | arguments.cs:56:16:56:16 | 0 | arguments.cs:50:21:50:23 | value |
+| arguments.cs:57:9:57:12 | access to property Prop | arguments.cs:57:16:57:25 | access to indexer | arguments.cs:50:21:50:23 | value |
+| arguments.cs:57:16:57:25 | access to indexer | arguments.cs:57:21:57:21 | 1 | arguments.cs:52:18:52:18 | a |
+| arguments.cs:57:16:57:25 | access to indexer | arguments.cs:57:24:57:24 | 2 | arguments.cs:52:25:52:25 | b |
+| arguments.cs:58:10:58:13 | access to property Prop | arguments.cs:58:31:58:31 | 5 | arguments.cs:50:21:50:23 | value |
+| arguments.cs:58:16:58:25 | access to indexer | arguments.cs:58:21:58:21 | 3 | arguments.cs:52:18:52:18 | a |
+| arguments.cs:58:16:58:25 | access to indexer | arguments.cs:58:24:58:24 | 4 | arguments.cs:52:25:52:25 | b |
+| arguments.cs:58:16:58:25 | access to indexer | arguments.cs:58:34:58:34 | 6 | arguments.cs:52:44:52:46 | value |
+| arguments.cs:60:9:60:12 | access to property Prop | arguments.cs:60:9:60:17 | ... + ... | arguments.cs:50:21:50:23 | value |
+| arguments.cs:61:9:61:18 | access to indexer | arguments.cs:61:14:61:14 | 8 | arguments.cs:52:18:52:18 | a |
+| arguments.cs:61:9:61:18 | access to indexer | arguments.cs:61:14:61:14 | 8 | arguments.cs:52:18:52:18 | a |
+| arguments.cs:61:9:61:18 | access to indexer | arguments.cs:61:17:61:17 | 9 | arguments.cs:52:25:52:25 | b |
+| arguments.cs:61:9:61:18 | access to indexer | arguments.cs:61:17:61:17 | 9 | arguments.cs:52:25:52:25 | b |
+| arguments.cs:62:9:62:20 | access to indexer | arguments.cs:62:9:62:26 | ... + ... | arguments.cs:52:44:52:46 | value |
+| arguments.cs:62:9:62:20 | access to indexer | arguments.cs:62:14:62:15 | 10 | arguments.cs:52:18:52:18 | a |
+| arguments.cs:62:9:62:20 | access to indexer | arguments.cs:62:14:62:15 | 10 | arguments.cs:52:18:52:18 | a |
+| arguments.cs:62:9:62:20 | access to indexer | arguments.cs:62:18:62:19 | 11 | arguments.cs:52:25:52:25 | b |
+| arguments.cs:62:9:62:20 | access to indexer | arguments.cs:62:18:62:19 | 11 | arguments.cs:52:25:52:25 | b |
+| arguments.cs:64:16:64:27 | access to indexer | arguments.cs:64:21:64:22 | 15 | arguments.cs:52:18:52:18 | a |
+| arguments.cs:64:16:64:27 | access to indexer | arguments.cs:64:25:64:26 | 16 | arguments.cs:52:25:52:25 | b |
+| arguments.cs:75:9:75:31 | call to method f8`1 | arguments.cs:75:12:75:12 | 0 | arguments.cs:73:20:73:20 | o |
+| arguments.cs:76:9:76:43 | call to method f8`1 | arguments.cs:76:12:76:12 | 0 | arguments.cs:73:20:73:20 | o |
+| arguments.cs:76:9:76:43 | call to method f8`1 | arguments.cs:76:15:76:42 | array creation of type T[] | arguments.cs:73:34:73:37 | args |
+| arguments.cs:77:9:77:19 | call to method f8`1 | arguments.cs:77:12:77:12 | 0 | arguments.cs:73:20:73:20 | o |
+| arguments.cs:77:9:77:19 | call to method f8`1 | arguments.cs:77:15:77:18 | access to parameter args | arguments.cs:73:34:73:37 | args |
+| arguments.cs:78:9:78:28 | call to method f8`1 | arguments.cs:78:18:78:21 | access to parameter args | arguments.cs:73:34:73:37 | args |
+| arguments.cs:78:9:78:28 | call to method f8`1 | arguments.cs:78:27:78:27 | 0 | arguments.cs:73:20:73:20 | o |
+| arguments.cs:80:9:80:31 | call to method f8<Double> | arguments.cs:80:20:80:20 | 0 | arguments.cs:73:20:73:20 | o |
+| arguments.cs:81:9:81:48 | call to method f8<Double> | arguments.cs:81:20:81:20 | 0 | arguments.cs:73:20:73:20 | o |
+| arguments.cs:81:9:81:48 | call to method f8<Double> | arguments.cs:81:23:81:47 | array creation of type Double[] | arguments.cs:73:34:73:37 | args |
+| arguments.cs:83:9:83:27 | call to method f8<Double> | arguments.cs:83:20:83:20 | 0 | arguments.cs:73:20:73:20 | o |
+| arguments.cs:84:9:84:44 | call to method f8<Double> | arguments.cs:84:20:84:20 | 0 | arguments.cs:73:20:73:20 | o |
+| arguments.cs:84:9:84:44 | call to method f8<Double> | arguments.cs:84:23:84:43 | array creation of type Double[] | arguments.cs:73:34:73:37 | args |
+| arguments.cs:85:9:85:44 | call to method f8<Double> | arguments.cs:85:20:85:20 | 0 | arguments.cs:73:20:73:20 | o |
+| arguments.cs:85:9:85:44 | call to method f8<Double> | arguments.cs:85:23:85:43 | array creation of type Double[] | arguments.cs:73:34:73:37 | args |

--- a/csharp/ql/test/library-tests/arguments/argumentByParameter.expected
+++ b/csharp/ql/test/library-tests/arguments/argumentByParameter.expected
@@ -12,6 +12,7 @@
 | arguments.cs:35:9:35:19 | call to method f3 | arguments.cs:35:18:35:18 | 2 | arguments.cs:33:33:33:36 | args |
 | arguments.cs:36:9:36:33 | call to method f3 | arguments.cs:36:12:36:12 | 0 | arguments.cs:33:17:33:17 | o |
 | arguments.cs:36:9:36:33 | call to method f3 | arguments.cs:36:15:36:32 | array creation of type Int32[] | arguments.cs:33:33:33:36 | args |
+| arguments.cs:37:9:37:25 | call to method f3 | arguments.cs:37:18:37:18 | 1 | arguments.cs:33:33:33:36 | args |
 | arguments.cs:37:9:37:25 | call to method f3 | arguments.cs:37:24:37:24 | 0 | arguments.cs:33:17:33:17 | o |
 | arguments.cs:38:9:38:19 | call to method f3 | arguments.cs:38:12:38:12 | 0 | arguments.cs:33:17:33:17 | o |
 | arguments.cs:38:9:38:19 | call to method f3 | arguments.cs:38:15:38:18 | access to parameter args | arguments.cs:33:33:33:36 | args |

--- a/csharp/ql/test/library-tests/arguments/argumentByParameter.expected
+++ b/csharp/ql/test/library-tests/arguments/argumentByParameter.expected
@@ -8,6 +8,8 @@
 | arguments.cs:30:9:30:38 | object creation of type ArgumentsTest | arguments.cs:30:30:30:31 | 10 | arguments.cs:5:41:5:41 | y |
 | arguments.cs:30:9:30:38 | object creation of type ArgumentsTest | arguments.cs:30:37:30:37 | 5 | arguments.cs:5:30:5:30 | x |
 | arguments.cs:35:9:35:19 | call to method f3 | arguments.cs:35:12:35:12 | 0 | arguments.cs:33:17:33:17 | o |
+| arguments.cs:35:9:35:19 | call to method f3 | arguments.cs:35:15:35:15 | 1 | arguments.cs:33:33:33:36 | args |
+| arguments.cs:35:9:35:19 | call to method f3 | arguments.cs:35:18:35:18 | 2 | arguments.cs:33:33:33:36 | args |
 | arguments.cs:36:9:36:33 | call to method f3 | arguments.cs:36:12:36:12 | 0 | arguments.cs:33:17:33:17 | o |
 | arguments.cs:36:9:36:33 | call to method f3 | arguments.cs:36:15:36:32 | array creation of type Int32[] | arguments.cs:33:33:33:36 | args |
 | arguments.cs:37:9:37:25 | call to method f3 | arguments.cs:37:24:37:24 | 0 | arguments.cs:33:17:33:17 | o |
@@ -18,6 +20,10 @@
 | arguments.cs:40:9:40:42 | call to method f3 | arguments.cs:40:18:40:35 | array creation of type Int32[] | arguments.cs:33:33:33:36 | args |
 | arguments.cs:40:9:40:42 | call to method f3 | arguments.cs:40:41:40:41 | 0 | arguments.cs:33:17:33:17 | o |
 | arguments.cs:42:9:42:21 | call to method f3 | arguments.cs:42:12:42:12 | 0 | arguments.cs:33:17:33:17 | o |
+| arguments.cs:42:9:42:21 | call to method f3 | arguments.cs:42:15:42:16 | (...) ... | arguments.cs:33:33:33:36 | args |
+| arguments.cs:42:9:42:21 | call to method f3 | arguments.cs:42:19:42:20 | (...) ... | arguments.cs:33:33:33:36 | args |
+| arguments.cs:47:9:47:39 | call to method f4 | arguments.cs:47:12:47:32 | array creation of type Object[] | arguments.cs:45:29:45:32 | args |
+| arguments.cs:47:9:47:39 | call to method f4 | arguments.cs:47:35:47:38 | null | arguments.cs:45:29:45:32 | args |
 | arguments.cs:56:9:56:12 | access to property Prop | arguments.cs:56:16:56:16 | 0 | arguments.cs:50:21:50:23 | value |
 | arguments.cs:57:9:57:12 | access to property Prop | arguments.cs:57:16:57:25 | access to indexer | arguments.cs:50:21:50:23 | value |
 | arguments.cs:57:16:57:25 | access to indexer | arguments.cs:57:21:57:21 | 1 | arguments.cs:52:18:52:18 | a |
@@ -39,6 +45,8 @@
 | arguments.cs:64:16:64:27 | access to indexer | arguments.cs:64:21:64:22 | 15 | arguments.cs:52:18:52:18 | a |
 | arguments.cs:64:16:64:27 | access to indexer | arguments.cs:64:25:64:26 | 16 | arguments.cs:52:25:52:25 | b |
 | arguments.cs:75:9:75:31 | call to method f8`1 | arguments.cs:75:12:75:12 | 0 | arguments.cs:73:20:73:20 | o |
+| arguments.cs:75:9:75:31 | call to method f8`1 | arguments.cs:75:15:75:21 | access to array element | arguments.cs:73:34:73:37 | args |
+| arguments.cs:75:9:75:31 | call to method f8`1 | arguments.cs:75:24:75:30 | access to array element | arguments.cs:73:34:73:37 | args |
 | arguments.cs:76:9:76:43 | call to method f8`1 | arguments.cs:76:12:76:12 | 0 | arguments.cs:73:20:73:20 | o |
 | arguments.cs:76:9:76:43 | call to method f8`1 | arguments.cs:76:15:76:42 | array creation of type T[] | arguments.cs:73:34:73:37 | args |
 | arguments.cs:77:9:77:19 | call to method f8`1 | arguments.cs:77:12:77:12 | 0 | arguments.cs:73:20:73:20 | o |
@@ -46,9 +54,13 @@
 | arguments.cs:78:9:78:28 | call to method f8`1 | arguments.cs:78:18:78:21 | access to parameter args | arguments.cs:73:34:73:37 | args |
 | arguments.cs:78:9:78:28 | call to method f8`1 | arguments.cs:78:27:78:27 | 0 | arguments.cs:73:20:73:20 | o |
 | arguments.cs:80:9:80:31 | call to method f8<Double> | arguments.cs:80:20:80:20 | 0 | arguments.cs:73:20:73:20 | o |
+| arguments.cs:80:9:80:31 | call to method f8<Double> | arguments.cs:80:23:80:25 | 1.1 | arguments.cs:73:34:73:37 | args |
+| arguments.cs:80:9:80:31 | call to method f8<Double> | arguments.cs:80:28:80:30 | 2.2 | arguments.cs:73:34:73:37 | args |
 | arguments.cs:81:9:81:48 | call to method f8<Double> | arguments.cs:81:20:81:20 | 0 | arguments.cs:73:20:73:20 | o |
 | arguments.cs:81:9:81:48 | call to method f8<Double> | arguments.cs:81:23:81:47 | array creation of type Double[] | arguments.cs:73:34:73:37 | args |
 | arguments.cs:83:9:83:27 | call to method f8<Double> | arguments.cs:83:20:83:20 | 0 | arguments.cs:73:20:73:20 | o |
+| arguments.cs:83:9:83:27 | call to method f8<Double> | arguments.cs:83:23:83:23 | (...) ... | arguments.cs:73:34:73:37 | args |
+| arguments.cs:83:9:83:27 | call to method f8<Double> | arguments.cs:83:26:83:26 | (...) ... | arguments.cs:73:34:73:37 | args |
 | arguments.cs:84:9:84:44 | call to method f8<Double> | arguments.cs:84:20:84:20 | 0 | arguments.cs:73:20:73:20 | o |
 | arguments.cs:84:9:84:44 | call to method f8<Double> | arguments.cs:84:23:84:43 | array creation of type Double[] | arguments.cs:73:34:73:37 | args |
 | arguments.cs:85:9:85:44 | call to method f8<Double> | arguments.cs:85:20:85:20 | 0 | arguments.cs:73:20:73:20 | o |

--- a/csharp/ql/test/library-tests/arguments/argumentName.expected
+++ b/csharp/ql/test/library-tests/arguments/argumentName.expected
@@ -7,5 +7,7 @@
 | arguments.cs:39:27:39:27 | 0 | o |
 | arguments.cs:40:18:40:35 | array creation of type Int32[] | args |
 | arguments.cs:40:41:40:41 | 0 | o |
-| arguments.cs:68:28:68:29 | "" | y |
-| arguments.cs:68:36:68:36 | 0 | x |
+| arguments.cs:70:28:70:29 | "" | y |
+| arguments.cs:70:36:70:36 | 0 | x |
+| arguments.cs:78:18:78:21 | access to parameter args | args |
+| arguments.cs:78:27:78:27 | 0 | o |

--- a/csharp/ql/test/library-tests/arguments/argumentType.expected
+++ b/csharp/ql/test/library-tests/arguments/argumentType.expected
@@ -20,25 +20,53 @@
 | arguments.cs:39:27:39:27 | 0 | 0 |
 | arguments.cs:40:18:40:35 | array creation of type Int32[] | 0 |
 | arguments.cs:40:41:40:41 | 0 | 0 |
-| arguments.cs:45:12:45:32 | array creation of type Object[] | 0 |
-| arguments.cs:45:35:45:38 | null | 0 |
-| arguments.cs:55:21:55:21 | 1 | 0 |
-| arguments.cs:55:24:55:24 | 2 | 0 |
-| arguments.cs:56:10:56:13 | access to property Prop | 0 |
-| arguments.cs:56:16:56:25 | access to indexer | 0 |
-| arguments.cs:56:21:56:21 | 3 | 0 |
-| arguments.cs:56:24:56:24 | 4 | 0 |
-| arguments.cs:56:31:56:31 | 5 | 0 |
-| arguments.cs:56:34:56:34 | 6 | 0 |
-| arguments.cs:59:14:59:14 | 8 | 0 |
-| arguments.cs:59:17:59:17 | 9 | 0 |
-| arguments.cs:60:14:60:15 | 10 | 0 |
-| arguments.cs:60:14:60:15 | 10 | 0 |
-| arguments.cs:60:18:60:19 | 11 | 0 |
-| arguments.cs:60:18:60:19 | 11 | 0 |
-| arguments.cs:61:22:61:23 | 13 | 0 |
-| arguments.cs:61:26:61:27 | 14 | 0 |
-| arguments.cs:62:10:62:13 | access to property Prop | 0 |
-| arguments.cs:62:16:62:27 | access to indexer | 0 |
-| arguments.cs:62:21:62:22 | 15 | 0 |
-| arguments.cs:62:25:62:26 | 16 | 0 |
+| arguments.cs:42:12:42:12 | 0 | 0 |
+| arguments.cs:42:15:42:16 | (...) ... | 0 |
+| arguments.cs:42:19:42:20 | (...) ... | 0 |
+| arguments.cs:47:12:47:32 | array creation of type Object[] | 0 |
+| arguments.cs:47:35:47:38 | null | 0 |
+| arguments.cs:57:21:57:21 | 1 | 0 |
+| arguments.cs:57:24:57:24 | 2 | 0 |
+| arguments.cs:58:10:58:13 | access to property Prop | 0 |
+| arguments.cs:58:16:58:25 | access to indexer | 0 |
+| arguments.cs:58:21:58:21 | 3 | 0 |
+| arguments.cs:58:24:58:24 | 4 | 0 |
+| arguments.cs:58:31:58:31 | 5 | 0 |
+| arguments.cs:58:34:58:34 | 6 | 0 |
+| arguments.cs:61:14:61:14 | 8 | 0 |
+| arguments.cs:61:17:61:17 | 9 | 0 |
+| arguments.cs:62:14:62:15 | 10 | 0 |
+| arguments.cs:62:14:62:15 | 10 | 0 |
+| arguments.cs:62:18:62:19 | 11 | 0 |
+| arguments.cs:62:18:62:19 | 11 | 0 |
+| arguments.cs:63:22:63:23 | 13 | 0 |
+| arguments.cs:63:26:63:27 | 14 | 0 |
+| arguments.cs:64:10:64:13 | access to property Prop | 0 |
+| arguments.cs:64:16:64:27 | access to indexer | 0 |
+| arguments.cs:64:21:64:22 | 15 | 0 |
+| arguments.cs:64:25:64:26 | 16 | 0 |
+| arguments.cs:75:12:75:12 | 0 | 0 |
+| arguments.cs:75:15:75:21 | access to array element | 0 |
+| arguments.cs:75:20:75:20 | 0 | 0 |
+| arguments.cs:75:24:75:30 | access to array element | 0 |
+| arguments.cs:75:29:75:29 | 1 | 0 |
+| arguments.cs:76:12:76:12 | 0 | 0 |
+| arguments.cs:76:15:76:42 | array creation of type T[] | 0 |
+| arguments.cs:76:30:76:30 | 0 | 0 |
+| arguments.cs:76:39:76:39 | 1 | 0 |
+| arguments.cs:77:12:77:12 | 0 | 0 |
+| arguments.cs:77:15:77:18 | access to parameter args | 0 |
+| arguments.cs:78:18:78:21 | access to parameter args | 0 |
+| arguments.cs:78:27:78:27 | 0 | 0 |
+| arguments.cs:80:20:80:20 | 0 | 0 |
+| arguments.cs:80:23:80:25 | 1.1 | 0 |
+| arguments.cs:80:28:80:30 | 2.2 | 0 |
+| arguments.cs:81:20:81:20 | 0 | 0 |
+| arguments.cs:81:23:81:47 | array creation of type Double[] | 0 |
+| arguments.cs:83:20:83:20 | 0 | 0 |
+| arguments.cs:83:23:83:23 | (...) ... | 0 |
+| arguments.cs:83:26:83:26 | (...) ... | 0 |
+| arguments.cs:84:20:84:20 | 0 | 0 |
+| arguments.cs:84:23:84:43 | array creation of type Double[] | 0 |
+| arguments.cs:85:20:85:20 | 0 | 0 |
+| arguments.cs:85:23:85:43 | array creation of type Double[] | 0 |

--- a/csharp/ql/test/library-tests/arguments/arguments.cs
+++ b/csharp/ql/test/library-tests/arguments/arguments.cs
@@ -38,6 +38,8 @@ class ArgumentsTest
         f3(0, args);
         f3(args: args, o: 0);
         f3(args: new int[] { 1, 2 }, o: 0);
+        short s1 = 1, s2 = 2;
+        f3(0, s1, s2);
     }
 
     void f4(params object[] args)
@@ -67,6 +69,21 @@ class ArgumentsTest
 
     [MyAttribute(true, y = "", x = 0)]
     void f7() { }
+
+    void f8<T>(int o, params T[] args)
+    {
+        f8(0, args[0], args[1]);
+        f8(0, new T[] { args[0], args[1] });
+        f8(0, args);
+        f8(args: args, o: 0);
+
+        f8<double>(0, 1.1, 2.2);
+        f8<double>(0, new double[] { 1.1, 2.2 });
+
+        f8<double>(0, 1, 2);
+        f8<double>(0, new double[] { 1, 2 });
+        f8<double>(0, new double[] { 1, 2 });
+    }
 }
 
 class MyAttribute : Attribute

--- a/csharp/ql/test/library-tests/arguments/parameterGetArguments.expected
+++ b/csharp/ql/test/library-tests/arguments/parameterGetArguments.expected
@@ -13,27 +13,43 @@
 | arguments.cs:33:17:33:17 | o | arguments.cs:38:12:38:12 | 0 |
 | arguments.cs:33:17:33:17 | o | arguments.cs:39:27:39:27 | 0 |
 | arguments.cs:33:17:33:17 | o | arguments.cs:40:41:40:41 | 0 |
+| arguments.cs:33:17:33:17 | o | arguments.cs:42:12:42:12 | 0 |
 | arguments.cs:33:33:33:36 | args | arguments.cs:36:15:36:32 | array creation of type Int32[] |
 | arguments.cs:33:33:33:36 | args | arguments.cs:38:15:38:18 | access to parameter args |
 | arguments.cs:33:33:33:36 | args | arguments.cs:39:18:39:21 | access to parameter args |
 | arguments.cs:33:33:33:36 | args | arguments.cs:40:18:40:35 | array creation of type Int32[] |
-| arguments.cs:48:21:48:23 | value | arguments.cs:54:16:54:16 | 0 |
-| arguments.cs:48:21:48:23 | value | arguments.cs:55:16:55:25 | access to indexer |
-| arguments.cs:48:21:48:23 | value | arguments.cs:56:31:56:31 | 5 |
-| arguments.cs:48:21:48:23 | value | arguments.cs:58:9:58:17 | ... + ... |
-| arguments.cs:50:18:50:18 | a | arguments.cs:55:21:55:21 | 1 |
-| arguments.cs:50:18:50:18 | a | arguments.cs:56:21:56:21 | 3 |
-| arguments.cs:50:18:50:18 | a | arguments.cs:59:14:59:14 | 8 |
-| arguments.cs:50:18:50:18 | a | arguments.cs:59:14:59:14 | 8 |
-| arguments.cs:50:18:50:18 | a | arguments.cs:60:14:60:15 | 10 |
-| arguments.cs:50:18:50:18 | a | arguments.cs:60:14:60:15 | 10 |
-| arguments.cs:50:18:50:18 | a | arguments.cs:62:21:62:22 | 15 |
-| arguments.cs:50:25:50:25 | b | arguments.cs:55:24:55:24 | 2 |
-| arguments.cs:50:25:50:25 | b | arguments.cs:56:24:56:24 | 4 |
-| arguments.cs:50:25:50:25 | b | arguments.cs:59:17:59:17 | 9 |
-| arguments.cs:50:25:50:25 | b | arguments.cs:59:17:59:17 | 9 |
-| arguments.cs:50:25:50:25 | b | arguments.cs:60:18:60:19 | 11 |
-| arguments.cs:50:25:50:25 | b | arguments.cs:60:18:60:19 | 11 |
-| arguments.cs:50:25:50:25 | b | arguments.cs:62:25:62:26 | 16 |
-| arguments.cs:50:44:50:46 | value | arguments.cs:56:34:56:34 | 6 |
-| arguments.cs:50:44:50:46 | value | arguments.cs:60:9:60:26 | ... + ... |
+| arguments.cs:50:21:50:23 | value | arguments.cs:56:16:56:16 | 0 |
+| arguments.cs:50:21:50:23 | value | arguments.cs:57:16:57:25 | access to indexer |
+| arguments.cs:50:21:50:23 | value | arguments.cs:58:31:58:31 | 5 |
+| arguments.cs:50:21:50:23 | value | arguments.cs:60:9:60:17 | ... + ... |
+| arguments.cs:52:18:52:18 | a | arguments.cs:57:21:57:21 | 1 |
+| arguments.cs:52:18:52:18 | a | arguments.cs:58:21:58:21 | 3 |
+| arguments.cs:52:18:52:18 | a | arguments.cs:61:14:61:14 | 8 |
+| arguments.cs:52:18:52:18 | a | arguments.cs:61:14:61:14 | 8 |
+| arguments.cs:52:18:52:18 | a | arguments.cs:62:14:62:15 | 10 |
+| arguments.cs:52:18:52:18 | a | arguments.cs:62:14:62:15 | 10 |
+| arguments.cs:52:18:52:18 | a | arguments.cs:64:21:64:22 | 15 |
+| arguments.cs:52:25:52:25 | b | arguments.cs:57:24:57:24 | 2 |
+| arguments.cs:52:25:52:25 | b | arguments.cs:58:24:58:24 | 4 |
+| arguments.cs:52:25:52:25 | b | arguments.cs:61:17:61:17 | 9 |
+| arguments.cs:52:25:52:25 | b | arguments.cs:61:17:61:17 | 9 |
+| arguments.cs:52:25:52:25 | b | arguments.cs:62:18:62:19 | 11 |
+| arguments.cs:52:25:52:25 | b | arguments.cs:62:18:62:19 | 11 |
+| arguments.cs:52:25:52:25 | b | arguments.cs:64:25:64:26 | 16 |
+| arguments.cs:52:44:52:46 | value | arguments.cs:58:34:58:34 | 6 |
+| arguments.cs:52:44:52:46 | value | arguments.cs:62:9:62:26 | ... + ... |
+| arguments.cs:73:20:73:20 | o | arguments.cs:75:12:75:12 | 0 |
+| arguments.cs:73:20:73:20 | o | arguments.cs:76:12:76:12 | 0 |
+| arguments.cs:73:20:73:20 | o | arguments.cs:77:12:77:12 | 0 |
+| arguments.cs:73:20:73:20 | o | arguments.cs:78:27:78:27 | 0 |
+| arguments.cs:73:20:73:20 | o | arguments.cs:80:20:80:20 | 0 |
+| arguments.cs:73:20:73:20 | o | arguments.cs:81:20:81:20 | 0 |
+| arguments.cs:73:20:73:20 | o | arguments.cs:83:20:83:20 | 0 |
+| arguments.cs:73:20:73:20 | o | arguments.cs:84:20:84:20 | 0 |
+| arguments.cs:73:20:73:20 | o | arguments.cs:85:20:85:20 | 0 |
+| arguments.cs:73:34:73:37 | args | arguments.cs:76:15:76:42 | array creation of type T[] |
+| arguments.cs:73:34:73:37 | args | arguments.cs:77:15:77:18 | access to parameter args |
+| arguments.cs:73:34:73:37 | args | arguments.cs:78:18:78:21 | access to parameter args |
+| arguments.cs:73:34:73:37 | args | arguments.cs:81:23:81:47 | array creation of type Double[] |
+| arguments.cs:73:34:73:37 | args | arguments.cs:84:23:84:43 | array creation of type Double[] |
+| arguments.cs:73:34:73:37 | args | arguments.cs:85:23:85:43 | array creation of type Double[] |

--- a/csharp/ql/test/library-tests/arguments/parameterGetArguments.expected
+++ b/csharp/ql/test/library-tests/arguments/parameterGetArguments.expected
@@ -14,10 +14,16 @@
 | arguments.cs:33:17:33:17 | o | arguments.cs:39:27:39:27 | 0 |
 | arguments.cs:33:17:33:17 | o | arguments.cs:40:41:40:41 | 0 |
 | arguments.cs:33:17:33:17 | o | arguments.cs:42:12:42:12 | 0 |
+| arguments.cs:33:33:33:36 | args | arguments.cs:35:15:35:15 | 1 |
+| arguments.cs:33:33:33:36 | args | arguments.cs:35:18:35:18 | 2 |
 | arguments.cs:33:33:33:36 | args | arguments.cs:36:15:36:32 | array creation of type Int32[] |
 | arguments.cs:33:33:33:36 | args | arguments.cs:38:15:38:18 | access to parameter args |
 | arguments.cs:33:33:33:36 | args | arguments.cs:39:18:39:21 | access to parameter args |
 | arguments.cs:33:33:33:36 | args | arguments.cs:40:18:40:35 | array creation of type Int32[] |
+| arguments.cs:33:33:33:36 | args | arguments.cs:42:15:42:16 | (...) ... |
+| arguments.cs:33:33:33:36 | args | arguments.cs:42:19:42:20 | (...) ... |
+| arguments.cs:45:29:45:32 | args | arguments.cs:47:12:47:32 | array creation of type Object[] |
+| arguments.cs:45:29:45:32 | args | arguments.cs:47:35:47:38 | null |
 | arguments.cs:50:21:50:23 | value | arguments.cs:56:16:56:16 | 0 |
 | arguments.cs:50:21:50:23 | value | arguments.cs:57:16:57:25 | access to indexer |
 | arguments.cs:50:21:50:23 | value | arguments.cs:58:31:58:31 | 5 |
@@ -47,9 +53,15 @@
 | arguments.cs:73:20:73:20 | o | arguments.cs:83:20:83:20 | 0 |
 | arguments.cs:73:20:73:20 | o | arguments.cs:84:20:84:20 | 0 |
 | arguments.cs:73:20:73:20 | o | arguments.cs:85:20:85:20 | 0 |
+| arguments.cs:73:34:73:37 | args | arguments.cs:75:15:75:21 | access to array element |
+| arguments.cs:73:34:73:37 | args | arguments.cs:75:24:75:30 | access to array element |
 | arguments.cs:73:34:73:37 | args | arguments.cs:76:15:76:42 | array creation of type T[] |
 | arguments.cs:73:34:73:37 | args | arguments.cs:77:15:77:18 | access to parameter args |
 | arguments.cs:73:34:73:37 | args | arguments.cs:78:18:78:21 | access to parameter args |
+| arguments.cs:73:34:73:37 | args | arguments.cs:80:23:80:25 | 1.1 |
+| arguments.cs:73:34:73:37 | args | arguments.cs:80:28:80:30 | 2.2 |
 | arguments.cs:73:34:73:37 | args | arguments.cs:81:23:81:47 | array creation of type Double[] |
+| arguments.cs:73:34:73:37 | args | arguments.cs:83:23:83:23 | (...) ... |
+| arguments.cs:73:34:73:37 | args | arguments.cs:83:26:83:26 | (...) ... |
 | arguments.cs:73:34:73:37 | args | arguments.cs:84:23:84:43 | array creation of type Double[] |
 | arguments.cs:73:34:73:37 | args | arguments.cs:85:23:85:43 | array creation of type Double[] |

--- a/csharp/ql/test/library-tests/arguments/parameterGetArguments.expected
+++ b/csharp/ql/test/library-tests/arguments/parameterGetArguments.expected
@@ -17,6 +17,7 @@
 | arguments.cs:33:33:33:36 | args | arguments.cs:35:15:35:15 | 1 |
 | arguments.cs:33:33:33:36 | args | arguments.cs:35:18:35:18 | 2 |
 | arguments.cs:33:33:33:36 | args | arguments.cs:36:15:36:32 | array creation of type Int32[] |
+| arguments.cs:33:33:33:36 | args | arguments.cs:37:18:37:18 | 1 |
 | arguments.cs:33:33:33:36 | args | arguments.cs:38:15:38:18 | access to parameter args |
 | arguments.cs:33:33:33:36 | args | arguments.cs:39:18:39:21 | access to parameter args |
 | arguments.cs:33:33:33:36 | args | arguments.cs:40:18:40:35 | array creation of type Int32[] |

--- a/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
+++ b/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
@@ -443,9 +443,7 @@ nodes
 | NullAlwaysBad.cs:9:30:9:30 | access to parameter s |
 | NullMaybeBad.cs:7:27:7:27 | access to parameter o |
 | NullMaybeBad.cs:13:17:13:20 | null |
-| Params.cs:9:17:9:20 | access to parameter args |
 | Params.cs:14:17:14:20 | access to parameter args |
-| Params.cs:19:27:19:30 | null |
 | Params.cs:20:12:20:15 | null |
 | StringConcatenation.cs:14:16:14:23 | SSA def(s) |
 | StringConcatenation.cs:15:16:15:16 | access to local variable s |
@@ -835,7 +833,6 @@ edges
 | GuardedString.cs:34:26:34:26 | 0 | GuardedString.cs:35:31:35:31 | access to local variable s |
 | NullAlwaysBad.cs:7:29:7:29 | SSA param(s) | NullAlwaysBad.cs:9:30:9:30 | access to parameter s |
 | NullMaybeBad.cs:13:17:13:20 | null | NullMaybeBad.cs:7:27:7:27 | access to parameter o |
-| Params.cs:19:27:19:30 | null | Params.cs:9:17:9:20 | access to parameter args |
 | Params.cs:20:12:20:15 | null | Params.cs:14:17:14:20 | access to parameter args |
 | StringConcatenation.cs:14:16:14:23 | SSA def(s) | StringConcatenation.cs:15:16:15:16 | access to local variable s |
 | StringConcatenation.cs:15:16:15:16 | access to local variable s | StringConcatenation.cs:16:17:16:17 | access to local variable s |
@@ -924,6 +921,5 @@ edges
 | E.cs:417:34:417:34 | access to parameter i | E.cs:417:24:417:40 | SSA capture def(i) | E.cs:417:34:417:34 | access to parameter i | Variable $@ may be null at this access because it has a nullable type. | E.cs:415:27:415:27 | i | i | E.cs:415:27:415:27 | i | this |
 | GuardedString.cs:35:31:35:31 | access to local variable s | GuardedString.cs:7:16:7:32 | SSA def(s) | GuardedString.cs:35:31:35:31 | access to local variable s | Variable $@ may be null at this access because of $@ assignment. | GuardedString.cs:7:16:7:16 | s | s | GuardedString.cs:7:16:7:32 | String s = ... | this |
 | NullMaybeBad.cs:7:27:7:27 | access to parameter o | NullMaybeBad.cs:13:17:13:20 | null | NullMaybeBad.cs:7:27:7:27 | access to parameter o | Variable $@ may be null at this access because of $@ null argument. | NullMaybeBad.cs:5:25:5:25 | o | o | NullMaybeBad.cs:13:17:13:20 | null | this |
-| Params.cs:9:17:9:20 | access to parameter args | Params.cs:19:27:19:30 | null | Params.cs:9:17:9:20 | access to parameter args | Variable $@ may be null at this access because of $@ null argument. | Params.cs:7:36:7:39 | args | args | Params.cs:19:27:19:30 | null | this |
 | Params.cs:14:17:14:20 | access to parameter args | Params.cs:20:12:20:15 | null | Params.cs:14:17:14:20 | access to parameter args | Variable $@ may be null at this access because of $@ null argument. | Params.cs:12:36:12:39 | args | args | Params.cs:20:12:20:15 | null | this |
 | StringConcatenation.cs:16:17:16:17 | access to local variable s | StringConcatenation.cs:14:16:14:23 | SSA def(s) | StringConcatenation.cs:16:17:16:17 | access to local variable s | Variable $@ may be null at this access because of $@ assignment. | StringConcatenation.cs:14:16:14:16 | s | s | StringConcatenation.cs:14:16:14:23 | String s = ... | this |

--- a/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
+++ b/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
@@ -443,6 +443,10 @@ nodes
 | NullAlwaysBad.cs:9:30:9:30 | access to parameter s |
 | NullMaybeBad.cs:7:27:7:27 | access to parameter o |
 | NullMaybeBad.cs:13:17:13:20 | null |
+| Params.cs:9:17:9:20 | access to parameter args |
+| Params.cs:14:17:14:20 | access to parameter args |
+| Params.cs:19:27:19:30 | null |
+| Params.cs:20:12:20:15 | null |
 | StringConcatenation.cs:14:16:14:23 | SSA def(s) |
 | StringConcatenation.cs:15:16:15:16 | access to local variable s |
 | StringConcatenation.cs:16:17:16:17 | access to local variable s |
@@ -831,6 +835,8 @@ edges
 | GuardedString.cs:34:26:34:26 | 0 | GuardedString.cs:35:31:35:31 | access to local variable s |
 | NullAlwaysBad.cs:7:29:7:29 | SSA param(s) | NullAlwaysBad.cs:9:30:9:30 | access to parameter s |
 | NullMaybeBad.cs:13:17:13:20 | null | NullMaybeBad.cs:7:27:7:27 | access to parameter o |
+| Params.cs:19:27:19:30 | null | Params.cs:9:17:9:20 | access to parameter args |
+| Params.cs:20:12:20:15 | null | Params.cs:14:17:14:20 | access to parameter args |
 | StringConcatenation.cs:14:16:14:23 | SSA def(s) | StringConcatenation.cs:15:16:15:16 | access to local variable s |
 | StringConcatenation.cs:15:16:15:16 | access to local variable s | StringConcatenation.cs:16:17:16:17 | access to local variable s |
 #select
@@ -918,4 +924,6 @@ edges
 | E.cs:417:34:417:34 | access to parameter i | E.cs:417:24:417:40 | SSA capture def(i) | E.cs:417:34:417:34 | access to parameter i | Variable $@ may be null at this access because it has a nullable type. | E.cs:415:27:415:27 | i | i | E.cs:415:27:415:27 | i | this |
 | GuardedString.cs:35:31:35:31 | access to local variable s | GuardedString.cs:7:16:7:32 | SSA def(s) | GuardedString.cs:35:31:35:31 | access to local variable s | Variable $@ may be null at this access because of $@ assignment. | GuardedString.cs:7:16:7:16 | s | s | GuardedString.cs:7:16:7:32 | String s = ... | this |
 | NullMaybeBad.cs:7:27:7:27 | access to parameter o | NullMaybeBad.cs:13:17:13:20 | null | NullMaybeBad.cs:7:27:7:27 | access to parameter o | Variable $@ may be null at this access because of $@ null argument. | NullMaybeBad.cs:5:25:5:25 | o | o | NullMaybeBad.cs:13:17:13:20 | null | this |
+| Params.cs:9:17:9:20 | access to parameter args | Params.cs:19:27:19:30 | null | Params.cs:9:17:9:20 | access to parameter args | Variable $@ may be null at this access because of $@ null argument. | Params.cs:7:36:7:39 | args | args | Params.cs:19:27:19:30 | null | this |
+| Params.cs:14:17:14:20 | access to parameter args | Params.cs:20:12:20:15 | null | Params.cs:14:17:14:20 | access to parameter args | Variable $@ may be null at this access because of $@ null argument. | Params.cs:12:36:12:39 | args | args | Params.cs:20:12:20:15 | null | this |
 | StringConcatenation.cs:16:17:16:17 | access to local variable s | StringConcatenation.cs:14:16:14:23 | SSA def(s) | StringConcatenation.cs:16:17:16:17 | access to local variable s | Variable $@ may be null at this access because of $@ assignment. | StringConcatenation.cs:14:16:14:16 | s | s | StringConcatenation.cs:14:16:14:23 | String s = ... | this |

--- a/csharp/ql/test/query-tests/Nullness/Params.cs
+++ b/csharp/ql/test/query-tests/Nullness/Params.cs
@@ -6,7 +6,7 @@ public class Params
 {
     public void M1(params string[] args)
     {
-        var l = args.Length; // FALSE POSITIVE
+        var l = args.Length; // Good, true negative
     }
 
     public void M2(params string[] args)

--- a/csharp/ql/test/query-tests/Nullness/Params.cs
+++ b/csharp/ql/test/query-tests/Nullness/Params.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Params
+{
+    public void M1(params string[] args)
+    {
+        var l = args.Length; // FALSE POSITIVE
+    }
+
+    public void M2(params string[] args)
+    {
+        var l = args.Length; // Good
+    }
+
+    public void M()
+    {
+        M1("a", "b", "c", null);
+        M2(null);
+    }
+}


### PR DESCRIPTION
This PR changes `Call::getArgumentForParameter` to better cover cases when arguments are passed to `params` parameters. 

Commit-by-commit review is suggested.