### PR TITLE
C++: Show indirections when printing SSA variables

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -16,6 +16,15 @@ private module SourceVariables {
       ind = [0 .. countIndirectionsForCppType(base.getLanguageType()) + 1]
     }
 
+  private int maxNumberOfIndirections() { result = max(SourceVariable sv | | sv.getIndirection()) }
+
+  private string repeatStars(int n) {
+    n = 0 and result = ""
+    or
+    n = [1 .. maxNumberOfIndirections()] and
+    result = "*" + repeatStars(n - 1)
+  }
+
   class SourceVariable extends TSourceVariable {
     SsaInternals0::SourceVariable base;
     int ind;
@@ -32,13 +41,7 @@ private module SourceVariables {
     SsaInternals0::SourceVariable getBaseVariable() { result = base }
 
     /** Gets a textual representation of this element. */
-    string toString() {
-      ind = 0 and
-      result = this.getBaseVariable().toString()
-      or
-      ind > 0 and
-      result = this.getBaseVariable().toString() + " indirection"
-    }
+    string toString() { result = repeatStars(this.getIndirection()) }
 
     /**
      * Gets the number of loads performed on the base source variable


### PR DESCRIPTION
This is https://github.com/github/codeql/pull/15107, but for SSA variables.

This `toString` isn't actually used anywhere, but it can be helpful when debugging dataflow