### PR TITLE
C++: Show base variable in SSA variable `toString`s

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -41,7 +41,7 @@ private module SourceVariables {
     SsaInternals0::SourceVariable getBaseVariable() { result = base }
 
     /** Gets a textual representation of this element. */
-    string toString() { result = repeatStars(this.getIndirection()) }
+    string toString() { result = repeatStars(this.getIndirection()) + base.toString() }
 
     /**
      * Gets the number of loads performed on the base source variable


### PR DESCRIPTION
I forgot to include the actual variable name in https://github.com/github/codeql/pull/15185 :doh: