### PR TITLE
Go: Update workflows and expected test results for Go 1.22

### DIFF
--- a/.github/workflows/go-tests-other-os.yml
+++ b/.github/workflows/go-tests-other-os.yml
@@ -8,7 +8,7 @@ on:
       - .github/actions/**
       - codeql-workspace.yml
 env:
-  GO_VERSION: '~1.21.0'
+  GO_VERSION: '~1.22.0'
 
 permissions:
   contents: read

--- a/.github/workflows/go-tests-other-os.yml
+++ b/.github/workflows/go-tests-other-os.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false
         id: go
 
       - name: Check out code
@@ -58,6 +59,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false
         id: go
 
       - name: Check out code

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -17,7 +17,7 @@ on:
       - codeql-workspace.yml
 
 env:
-  GO_VERSION: '~1.21.0'
+  GO_VERSION: '~1.22.0'
 
 permissions:
   contents: read

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false
         id: go
 
       - name: Check out code

--- a/go/ql/test/library-tests/semmle/go/Function/TypeParamType.expected
+++ b/go/ql/test/library-tests/semmle/go/Function/TypeParamType.expected
@@ -1,3 +1,8 @@
+| E | Ordered |
+| E | comparable |
+| E | interface { } |
+| E1 | interface { } |
+| E2 | interface { } |
 | Edge | EdgeConstraint |
 | Edge | interface { } |
 | F | floaty |
@@ -5,8 +10,14 @@
 | Node | NodeConstraint |
 | Node | interface { } |
 | S | interface { } |
+| S | interface { ~[]E } |
+| S1 | interface { ~[]E1 } |
+| S2 | interface { ~[]E2 } |
 | SF2 | interface { } |
 | SG2 | interface { } |
+| T | Ordered |
+| T | comparable |
+| T | interface { string \| []uint8 } |
 | T | interface { } |
 | T1 | interface { } |
 | T2 | interface { } |


### PR DESCRIPTION
This bumps the version of Go used for our query tests to 1.22 and updates the expected test output for one test accordingly.