### PR TITLE
Ruby: Update Kernel.qll to include `Object.send` aliases

### DIFF
--- a/ruby/ql/lib/codeql/ruby/frameworks/core/Kernel.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/core/Kernel.qll
@@ -43,7 +43,7 @@ module Kernel {
    * ```
    */
   private predicate isPublicKernelMethod(string method) {
-    method in ["class", "clone", "frozen?", "tap", "then", "yield_self", "send"]
+    method in ["class", "clone", "frozen?", "tap", "then", "yield_self", "send", "public_send", "__send__"]
   }
 
   /**
@@ -167,7 +167,7 @@ module Kernel {
    * ```
    */
   class SendCallCodeExecution extends CodeExecution::Range, KernelMethodCall {
-    SendCallCodeExecution() { this.getMethodName() = "send" }
+    SendCallCodeExecution() { this.getMethodName() = ["send", "public_send", "__send__"] }
 
     override DataFlow::Node getCode() { result = this.getArgument(0) }
 

--- a/ruby/ql/lib/codeql/ruby/frameworks/core/Kernel.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/core/Kernel.qll
@@ -43,7 +43,9 @@ module Kernel {
    * ```
    */
   private predicate isPublicKernelMethod(string method) {
-    method in ["class", "clone", "frozen?", "tap", "then", "yield_self", "send", "public_send", "__send__"]
+    method in [
+        "class", "clone", "frozen?", "tap", "then", "yield_self", "send", "public_send", "__send__"
+      ]
   }
 
   /**


### PR DESCRIPTION
Add `public_send` and `__send__` as Code Injection sinks as proposed by @vcsjones