### PR TITLE
C#: Fix Log forging false positive.

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/frameworks/System.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/System.qll
@@ -346,11 +346,11 @@ class SystemStringClass extends StringType {
     result.hasName("==")
   }
 
-  /** Gets the `Replace(string/char, string/char)` method. */
+  /** Gets the `Replace(...)` method. */
   Method getReplaceMethod() {
     result.getDeclaringType() = this and
     result.hasName("Replace") and
-    result.getNumberOfParameters() = 2 and
+    result.getNumberOfParameters() in [2 .. 4] and
     result.getReturnType() instanceof StringType
   }
 

--- a/csharp/ql/src/change-notes/2024-01-03-logforging-false-positive.md
+++ b/csharp/ql/src/change-notes/2024-01-03-logforging-false-positive.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Fixed a Log forging false positive when using `String.Replace` to sanitize the input.    

--- a/csharp/ql/test/query-tests/Security Features/CWE-117/LogForging.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-117/LogForging.cs
@@ -21,6 +21,8 @@ public class LogForgingHandler : IHttpHandler
         logger.Warn(username + " logged in");
         // GOOD: New-lines removed
         logger.Warn(username.Replace(Environment.NewLine, "") + " logged in");
+        // GOOD: New-lines removed
+        logger.Warn(username.Replace(Environment.NewLine, "", StringComparison.InvariantCultureIgnoreCase) + " logged in");
         // GOOD: Html encoded
         logger.Warn(WebUtility.HtmlEncode(username) + " logged in");
         // BAD: Logged as-is to TraceSource

--- a/csharp/ql/test/query-tests/Security Features/CWE-117/LogForging.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-117/LogForging.expected
@@ -1,23 +1,16 @@
 edges
 | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:18:27:18:61 | access to indexer : String |
 | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:21:21:21:43 | ... + ... |
-| LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:25:21:25:28 | access to local variable username : String |
 | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:29:50:29:72 | ... + ... |
 | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:33:26:33:33 | access to local variable username |
 | LogForging.cs:18:27:18:61 | access to indexer : String | LogForging.cs:21:21:21:43 | ... + ... |
-| LogForging.cs:18:27:18:61 | access to indexer : String | LogForging.cs:25:21:25:28 | access to local variable username : String |
 | LogForging.cs:18:27:18:61 | access to indexer : String | LogForging.cs:29:50:29:72 | ... + ... |
 | LogForging.cs:18:27:18:61 | access to indexer : String | LogForging.cs:33:26:33:33 | access to local variable username |
-| LogForging.cs:25:21:25:28 | access to local variable username : String | LogForging.cs:25:21:25:106 | call to method Replace : String |
-| LogForging.cs:25:21:25:106 | call to method Replace : String | LogForging.cs:25:21:25:121 | ... + ... |
 | LogForgingAsp.cs:8:32:8:39 | username : String | LogForgingAsp.cs:12:21:12:43 | ... + ... |
 nodes
 | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
 | LogForging.cs:18:27:18:61 | access to indexer : String | semmle.label | access to indexer : String |
 | LogForging.cs:21:21:21:43 | ... + ... | semmle.label | ... + ... |
-| LogForging.cs:25:21:25:28 | access to local variable username : String | semmle.label | access to local variable username : String |
-| LogForging.cs:25:21:25:106 | call to method Replace : String | semmle.label | call to method Replace : String |
-| LogForging.cs:25:21:25:121 | ... + ... | semmle.label | ... + ... |
 | LogForging.cs:29:50:29:72 | ... + ... | semmle.label | ... + ... |
 | LogForging.cs:33:26:33:33 | access to local variable username | semmle.label | access to local variable username |
 | LogForgingAsp.cs:8:32:8:39 | username : String | semmle.label | username : String |
@@ -25,7 +18,6 @@ nodes
 subpaths
 #select
 | LogForging.cs:21:21:21:43 | ... + ... | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:21:21:21:43 | ... + ... | This log entry depends on a $@. | LogForging.cs:18:27:18:49 | access to property QueryString | user-provided value |
-| LogForging.cs:25:21:25:121 | ... + ... | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:25:21:25:121 | ... + ... | This log entry depends on a $@. | LogForging.cs:18:27:18:49 | access to property QueryString | user-provided value |
 | LogForging.cs:29:50:29:72 | ... + ... | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:29:50:29:72 | ... + ... | This log entry depends on a $@. | LogForging.cs:18:27:18:49 | access to property QueryString | user-provided value |
 | LogForging.cs:33:26:33:33 | access to local variable username | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:33:26:33:33 | access to local variable username | This log entry depends on a $@. | LogForging.cs:18:27:18:49 | access to property QueryString | user-provided value |
 | LogForgingAsp.cs:12:21:12:43 | ... + ... | LogForgingAsp.cs:8:32:8:39 | username : String | LogForgingAsp.cs:12:21:12:43 | ... + ... | This log entry depends on a $@. | LogForgingAsp.cs:8:32:8:39 | username | user-provided value |

--- a/csharp/ql/test/query-tests/Security Features/CWE-117/LogForging.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-117/LogForging.expected
@@ -1,23 +1,31 @@
 edges
 | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:18:27:18:61 | access to indexer : String |
 | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:21:21:21:43 | ... + ... |
-| LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:27:50:27:72 | ... + ... |
-| LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:31:26:31:33 | access to local variable username |
+| LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:25:21:25:28 | access to local variable username : String |
+| LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:29:50:29:72 | ... + ... |
+| LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:33:26:33:33 | access to local variable username |
 | LogForging.cs:18:27:18:61 | access to indexer : String | LogForging.cs:21:21:21:43 | ... + ... |
-| LogForging.cs:18:27:18:61 | access to indexer : String | LogForging.cs:27:50:27:72 | ... + ... |
-| LogForging.cs:18:27:18:61 | access to indexer : String | LogForging.cs:31:26:31:33 | access to local variable username |
+| LogForging.cs:18:27:18:61 | access to indexer : String | LogForging.cs:25:21:25:28 | access to local variable username : String |
+| LogForging.cs:18:27:18:61 | access to indexer : String | LogForging.cs:29:50:29:72 | ... + ... |
+| LogForging.cs:18:27:18:61 | access to indexer : String | LogForging.cs:33:26:33:33 | access to local variable username |
+| LogForging.cs:25:21:25:28 | access to local variable username : String | LogForging.cs:25:21:25:106 | call to method Replace : String |
+| LogForging.cs:25:21:25:106 | call to method Replace : String | LogForging.cs:25:21:25:121 | ... + ... |
 | LogForgingAsp.cs:8:32:8:39 | username : String | LogForgingAsp.cs:12:21:12:43 | ... + ... |
 nodes
 | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
 | LogForging.cs:18:27:18:61 | access to indexer : String | semmle.label | access to indexer : String |
 | LogForging.cs:21:21:21:43 | ... + ... | semmle.label | ... + ... |
-| LogForging.cs:27:50:27:72 | ... + ... | semmle.label | ... + ... |
-| LogForging.cs:31:26:31:33 | access to local variable username | semmle.label | access to local variable username |
+| LogForging.cs:25:21:25:28 | access to local variable username : String | semmle.label | access to local variable username : String |
+| LogForging.cs:25:21:25:106 | call to method Replace : String | semmle.label | call to method Replace : String |
+| LogForging.cs:25:21:25:121 | ... + ... | semmle.label | ... + ... |
+| LogForging.cs:29:50:29:72 | ... + ... | semmle.label | ... + ... |
+| LogForging.cs:33:26:33:33 | access to local variable username | semmle.label | access to local variable username |
 | LogForgingAsp.cs:8:32:8:39 | username : String | semmle.label | username : String |
 | LogForgingAsp.cs:12:21:12:43 | ... + ... | semmle.label | ... + ... |
 subpaths
 #select
 | LogForging.cs:21:21:21:43 | ... + ... | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:21:21:21:43 | ... + ... | This log entry depends on a $@. | LogForging.cs:18:27:18:49 | access to property QueryString | user-provided value |
-| LogForging.cs:27:50:27:72 | ... + ... | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:27:50:27:72 | ... + ... | This log entry depends on a $@. | LogForging.cs:18:27:18:49 | access to property QueryString | user-provided value |
-| LogForging.cs:31:26:31:33 | access to local variable username | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:31:26:31:33 | access to local variable username | This log entry depends on a $@. | LogForging.cs:18:27:18:49 | access to property QueryString | user-provided value |
+| LogForging.cs:25:21:25:121 | ... + ... | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:25:21:25:121 | ... + ... | This log entry depends on a $@. | LogForging.cs:18:27:18:49 | access to property QueryString | user-provided value |
+| LogForging.cs:29:50:29:72 | ... + ... | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:29:50:29:72 | ... + ... | This log entry depends on a $@. | LogForging.cs:18:27:18:49 | access to property QueryString | user-provided value |
+| LogForging.cs:33:26:33:33 | access to local variable username | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:33:26:33:33 | access to local variable username | This log entry depends on a $@. | LogForging.cs:18:27:18:49 | access to property QueryString | user-provided value |
 | LogForgingAsp.cs:12:21:12:43 | ... + ... | LogForgingAsp.cs:8:32:8:39 | username : String | LogForgingAsp.cs:12:21:12:43 | ... + ... | This log entry depends on a $@. | LogForgingAsp.cs:8:32:8:39 | username | user-provided value |


### PR DESCRIPTION
It turns out that there more overloads of the `String.Replace` method, which we didn't consider replace methods.