### PR TITLE
C++: Accept test changes after frontend upgrade

### DIFF
--- a/cpp/ql/test/library-tests/special_members/generated_copy/functions.expected
+++ b/cpp/ql/test/library-tests/special_members/generated_copy/functions.expected
@@ -11,8 +11,7 @@
 | copy.cpp:13:9:13:9 | operator= | protected_cc::Sub2& protected_cc::Sub2::operator=(protected_cc::Sub2 const&) |  |  |
 | copy.cpp:13:9:13:9 | operator= | protected_cc::Sub2& protected_cc::Sub2::operator=(protected_cc::Sub2&&) |  |  |
 | copy.cpp:17:9:17:9 | HasMember | void protected_cc::HasMember::HasMember() | deleted |  |
-| copy.cpp:17:9:17:9 | HasMember | void protected_cc::HasMember::HasMember(protected_cc::HasMember const&) |  |  |
-| copy.cpp:17:9:17:9 | HasMember | void protected_cc::HasMember::HasMember(protected_cc::HasMember&&) |  |  |
+| copy.cpp:17:9:17:9 | HasMember | void protected_cc::HasMember::HasMember(protected_cc::HasMember const&) | deleted |  |
 | copy.cpp:17:9:17:9 | operator= | protected_cc::HasMember& protected_cc::HasMember::operator=(protected_cc::HasMember const&) |  |  |
 | copy.cpp:17:9:17:9 | operator= | protected_cc::HasMember& protected_cc::HasMember::operator=(protected_cc::HasMember&&) |  |  |
 | copy.cpp:25:5:25:5 | C | void deleted_cc::C::C(deleted_cc::C const&) | deleted |  |

--- a/cpp/ql/test/library-tests/specifiers2/specifiers2.expected
+++ b/cpp/ql/test/library-tests/specifiers2/specifiers2.expected
@@ -186,7 +186,6 @@
 | Variable | specifiers2pp.cpp:16:13:16:22 | privateInt | privateInt | private |
 | Variable | specifiers2pp.cpp:17:21:17:30 | mutableInt | mutableInt | private |
 | Variable | specifiers2pp.cpp:20:13:20:24 | protectedInt | protectedInt | protected |
-| Variable | specifiers2pp.cpp:52:25:52:27 | vci | vci | static |
 | VariableDeclarationEntry | specifiers2.c:5:12:5:12 | declaration of i | i | extern |
 | VariableDeclarationEntry | specifiers2.c:6:12:6:12 | declaration of i | i | extern |
 | VariableDeclarationEntry | specifiers2.c:8:12:8:12 | declaration of j | j | extern |


### PR DESCRIPTION
* The `specifiers2` tests have a different result now due to the implementation of CWG 2387.
* The `special_members/generated_copy` has improved results as the frontend has improved support for deleted copy constructors.