### PR TITLE
JS: promote `PropsTaintStep` to a `PreCallGraphStep`

### DIFF
--- a/javascript/ql/lib/semmle/javascript/frameworks/React.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/React.qll
@@ -852,13 +852,13 @@ private class StateTaintStep extends TaintTracking::SharedTaintStep {
 }
 
 /**
- * A taint propagating data flow edge for assignments of the form `c1.props.p = v`,
+ * A data propagating data flow edge for assignments of the form `c1.props.p = v`,
  * where `c1` is an instance of React component `C`; in this case, we consider
- * taint to flow from `v` to any read of `c2.props.p`, where `c2`
+ * data to flow from `v` to any read of `c2.props.p`, where `c2`
  * also is an instance of `C`.
  */
-private class PropsTaintStep extends TaintTracking::SharedTaintStep {
-  override predicate viewComponentStep(DataFlow::Node pred, DataFlow::Node succ) {
+private class PropsTaintStep extends PreCallGraphStep {
+  override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
     exists(ReactComponent c, string name, DataFlow::PropRead prn |
       prn = c.getAPropRead(name) or
       prn = c.getAPreviousPropsSource().getAPropertyRead(name)

--- a/javascript/ql/lib/semmle/javascript/frameworks/React.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/React.qll
@@ -857,7 +857,7 @@ private class StateTaintStep extends TaintTracking::SharedTaintStep {
  * data to flow from `v` to any read of `c2.props.p`, where `c2`
  * also is an instance of `C`.
  */
-private class PropsTaintStep extends PreCallGraphStep {
+private class PropsFlowStep extends PreCallGraphStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
     exists(ReactComponent c, string name, DataFlow::PropRead prn |
       prn = c.getAPropRead(name) or

--- a/javascript/ql/test/library-tests/TaintTracking/DataFlowTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/DataFlowTracking.expected
@@ -70,6 +70,7 @@
 | getters-and-setters.js:79:20:79:27 | source() | getters-and-setters.js:92:14:92:16 | c.x |
 | getters-and-setters.js:79:20:79:27 | source() | getters-and-setters.js:100:10:100:22 | getX(new C()) |
 | getters-and-setters.js:89:17:89:24 | source() | getters-and-setters.js:82:18:82:22 | value |
+| importedReactComponent.jsx:4:40:4:47 | source() | exportedReactComponent.jsx:2:10:2:19 | props.text |
 | indexOf.js:4:11:4:18 | source() | indexOf.js:9:10:9:10 | x |
 | indexOf.js:4:11:4:18 | source() | indexOf.js:13:10:13:10 | x |
 | nested-props.js:4:13:4:20 | source() | nested-props.js:5:10:5:14 | obj.x |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
@@ -706,6 +706,18 @@ nodes
 | tooltip.jsx:11:25:11:30 | source |
 | tooltip.jsx:11:25:11:30 | source |
 | tooltip.jsx:11:25:11:30 | source |
+| tooltip.jsx:18:51:18:59 | provide() |
+| tooltip.jsx:18:51:18:59 | provide() |
+| tooltip.jsx:18:51:18:59 | provide() |
+| tooltip.jsx:18:51:18:59 | provide() |
+| tooltip.jsx:18:51:18:59 | provide() |
+| tooltip.jsx:22:11:22:30 | source |
+| tooltip.jsx:22:11:22:30 | source |
+| tooltip.jsx:22:20:22:30 | window.name |
+| tooltip.jsx:22:20:22:30 | window.name |
+| tooltip.jsx:22:20:22:30 | window.name |
+| tooltip.jsx:23:38:23:43 | source |
+| tooltip.jsx:23:38:23:43 | source |
 | translate.js:6:7:6:39 | target |
 | translate.js:6:16:6:39 | documen ... .search |
 | translate.js:6:16:6:39 | documen ... .search |
@@ -1882,6 +1894,20 @@ edges
 | tooltip.jsx:6:20:6:30 | window.name | tooltip.jsx:6:11:6:30 | source |
 | tooltip.jsx:6:20:6:30 | window.name | tooltip.jsx:6:11:6:30 | source |
 | tooltip.jsx:6:20:6:30 | window.name | tooltip.jsx:6:11:6:30 | source |
+| tooltip.jsx:22:11:22:30 | source | tooltip.jsx:18:51:18:59 | provide() |
+| tooltip.jsx:22:11:22:30 | source | tooltip.jsx:18:51:18:59 | provide() |
+| tooltip.jsx:22:11:22:30 | source | tooltip.jsx:18:51:18:59 | provide() |
+| tooltip.jsx:22:11:22:30 | source | tooltip.jsx:18:51:18:59 | provide() |
+| tooltip.jsx:22:11:22:30 | source | tooltip.jsx:23:38:23:43 | source |
+| tooltip.jsx:22:11:22:30 | source | tooltip.jsx:23:38:23:43 | source |
+| tooltip.jsx:22:20:22:30 | window.name | tooltip.jsx:22:11:22:30 | source |
+| tooltip.jsx:22:20:22:30 | window.name | tooltip.jsx:22:11:22:30 | source |
+| tooltip.jsx:22:20:22:30 | window.name | tooltip.jsx:22:11:22:30 | source |
+| tooltip.jsx:22:20:22:30 | window.name | tooltip.jsx:22:11:22:30 | source |
+| tooltip.jsx:23:38:23:43 | source | tooltip.jsx:18:51:18:59 | provide() |
+| tooltip.jsx:23:38:23:43 | source | tooltip.jsx:18:51:18:59 | provide() |
+| tooltip.jsx:23:38:23:43 | source | tooltip.jsx:18:51:18:59 | provide() |
+| tooltip.jsx:23:38:23:43 | source | tooltip.jsx:18:51:18:59 | provide() |
 | translate.js:6:7:6:39 | target | translate.js:7:42:7:47 | target |
 | translate.js:6:16:6:39 | documen ... .search | translate.js:6:7:6:39 | target |
 | translate.js:6:16:6:39 | documen ... .search | translate.js:6:7:6:39 | target |
@@ -2486,6 +2512,7 @@ edges
 | string-manipulations.js:10:16:10:45 | String( ... n.href) | string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) | Cross-site scripting vulnerability due to $@. | string-manipulations.js:10:23:10:44 | documen ... on.href | user-provided value |
 | tooltip.jsx:10:25:10:30 | source | tooltip.jsx:6:20:6:30 | window.name | tooltip.jsx:10:25:10:30 | source | Cross-site scripting vulnerability due to $@. | tooltip.jsx:6:20:6:30 | window.name | user-provided value |
 | tooltip.jsx:11:25:11:30 | source | tooltip.jsx:6:20:6:30 | window.name | tooltip.jsx:11:25:11:30 | source | Cross-site scripting vulnerability due to $@. | tooltip.jsx:6:20:6:30 | window.name | user-provided value |
+| tooltip.jsx:18:51:18:59 | provide() | tooltip.jsx:22:20:22:30 | window.name | tooltip.jsx:18:51:18:59 | provide() | Cross-site scripting vulnerability due to $@. | tooltip.jsx:22:20:22:30 | window.name | user-provided value |
 | translate.js:9:27:9:50 | searchP ... 'term') | translate.js:6:16:6:39 | documen ... .search | translate.js:9:27:9:50 | searchP ... 'term') | Cross-site scripting vulnerability due to $@. | translate.js:6:16:6:39 | documen ... .search | user-provided value |
 | trusted-types-lib.js:2:12:2:12 | x | trusted-types.js:13:20:13:30 | window.name | trusted-types-lib.js:2:12:2:12 | x | Cross-site scripting vulnerability due to $@. | trusted-types.js:13:20:13:30 | window.name | user-provided value |
 | trusted-types.js:3:67:3:67 | x | trusted-types.js:4:20:4:30 | window.name | trusted-types.js:3:67:3:67 | x | Cross-site scripting vulnerability due to $@. | trusted-types.js:4:20:4:30 | window.name | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
@@ -718,6 +718,18 @@ nodes
 | tooltip.jsx:11:25:11:30 | source |
 | tooltip.jsx:11:25:11:30 | source |
 | tooltip.jsx:11:25:11:30 | source |
+| tooltip.jsx:18:51:18:59 | provide() |
+| tooltip.jsx:18:51:18:59 | provide() |
+| tooltip.jsx:18:51:18:59 | provide() |
+| tooltip.jsx:18:51:18:59 | provide() |
+| tooltip.jsx:18:51:18:59 | provide() |
+| tooltip.jsx:22:11:22:30 | source |
+| tooltip.jsx:22:11:22:30 | source |
+| tooltip.jsx:22:20:22:30 | window.name |
+| tooltip.jsx:22:20:22:30 | window.name |
+| tooltip.jsx:22:20:22:30 | window.name |
+| tooltip.jsx:23:38:23:43 | source |
+| tooltip.jsx:23:38:23:43 | source |
 | translate.js:6:7:6:39 | target |
 | translate.js:6:16:6:39 | documen ... .search |
 | translate.js:6:16:6:39 | documen ... .search |
@@ -1944,6 +1956,20 @@ edges
 | tooltip.jsx:6:20:6:30 | window.name | tooltip.jsx:6:11:6:30 | source |
 | tooltip.jsx:6:20:6:30 | window.name | tooltip.jsx:6:11:6:30 | source |
 | tooltip.jsx:6:20:6:30 | window.name | tooltip.jsx:6:11:6:30 | source |
+| tooltip.jsx:22:11:22:30 | source | tooltip.jsx:18:51:18:59 | provide() |
+| tooltip.jsx:22:11:22:30 | source | tooltip.jsx:18:51:18:59 | provide() |
+| tooltip.jsx:22:11:22:30 | source | tooltip.jsx:18:51:18:59 | provide() |
+| tooltip.jsx:22:11:22:30 | source | tooltip.jsx:18:51:18:59 | provide() |
+| tooltip.jsx:22:11:22:30 | source | tooltip.jsx:23:38:23:43 | source |
+| tooltip.jsx:22:11:22:30 | source | tooltip.jsx:23:38:23:43 | source |
+| tooltip.jsx:22:20:22:30 | window.name | tooltip.jsx:22:11:22:30 | source |
+| tooltip.jsx:22:20:22:30 | window.name | tooltip.jsx:22:11:22:30 | source |
+| tooltip.jsx:22:20:22:30 | window.name | tooltip.jsx:22:11:22:30 | source |
+| tooltip.jsx:22:20:22:30 | window.name | tooltip.jsx:22:11:22:30 | source |
+| tooltip.jsx:23:38:23:43 | source | tooltip.jsx:18:51:18:59 | provide() |
+| tooltip.jsx:23:38:23:43 | source | tooltip.jsx:18:51:18:59 | provide() |
+| tooltip.jsx:23:38:23:43 | source | tooltip.jsx:18:51:18:59 | provide() |
+| tooltip.jsx:23:38:23:43 | source | tooltip.jsx:18:51:18:59 | provide() |
 | translate.js:6:7:6:39 | target | translate.js:7:42:7:47 | target |
 | translate.js:6:16:6:39 | documen ... .search | translate.js:6:7:6:39 | target |
 | translate.js:6:16:6:39 | documen ... .search | translate.js:6:7:6:39 | target |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/tooltip.jsx
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/tooltip.jsx
@@ -12,3 +12,13 @@ function tooltips() {
         <ReactTooltip />
     </span>
 }
+
+function MyElement(props) {
+    const provide = props.provide;
+    return <div dangerouslySetInnerHTML={{__html: provide()}} />; // NOT OK
+}
+
+function useMyElement() {
+    const source = window.name;
+    return <MyElement provide={() => source} />;
+}


### PR DESCRIPTION
Fixes https://github.com/github/codeql/issues/15207

Evaluations ([nightly](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/react-step__nightly-old__code-scanning__1/reports), [default](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/react-step__default__code-scanning/reports)) look good. 
No impact on performance.  
New call-edges and new results, all of which LGTM. 