### PR TITLE
Ruby: update tree-sitter-ruby

### DIFF
--- a/ruby/extractor/Cargo.lock
+++ b/ruby/extractor/Cargo.lock
@@ -18,6 +18,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +86,16 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bstr"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c48f0051a4b4c5e0b6d365cd04af53aeaa209e3cc15ec2cdb69e73cc87fbd0dc"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -156,11 +175,12 @@ checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 
 [[package]]
 name = "codeql-extractor"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "encoding",
  "flate2",
+ "globset",
  "lazy_static",
  "num_cpus",
  "rayon",
@@ -417,6 +437,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+dependencies = [
+ "aho-corasick 1.1.2",
+ "bstr",
+ "log",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,12 +561,9 @@ checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "matchers"
@@ -541,14 +571,14 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memoffset"
@@ -671,9 +701,9 @@ version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 0.7.20",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -682,7 +712,18 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "regex-syntax",
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+dependencies = [
+ "aho-corasick 1.1.2",
+ "memchr",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -690,6 +731,12 @@ name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rustix"
@@ -911,7 +958,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-ruby"
 version = "0.20.0"
-source = "git+https://github.com/tree-sitter/tree-sitter-ruby.git?rev=2edbd437ee901b8fa95861ec538e56efe3ebd127#2edbd437ee901b8fa95861ec538e56efe3ebd127"
+source = "git+https://github.com/tree-sitter/tree-sitter-ruby.git?rev=4d9ad3f010fdc47a8433adcf9ae30c8eb8475ae7#4d9ad3f010fdc47a8433adcf9ae30c8eb8475ae7"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/ruby/extractor/Cargo.toml
+++ b/ruby/extractor/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 [dependencies]
 tree-sitter = "0.20"
 tree-sitter-embedded-template = { git = "https://github.com/tree-sitter/tree-sitter-embedded-template.git", rev = "203f7bd3c1bbfbd98fc19add4b8fcb213c059205" }
-tree-sitter-ruby = { git = "https://github.com/tree-sitter/tree-sitter-ruby.git", rev = "2edbd437ee901b8fa95861ec538e56efe3ebd127" }
+tree-sitter-ruby = { git = "https://github.com/tree-sitter/tree-sitter-ruby.git", rev = "4d9ad3f010fdc47a8433adcf9ae30c8eb8475ae7" }
 clap = { version = "4.2", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }

--- a/ruby/ql/lib/change-notes/2024-01-05-division-newline.md
+++ b/ruby/ql/lib/change-notes/2024-01-05-division-newline.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+* Parsing of division operators (`/`) at the end of a line has been improved. Before they were wrongly interpreted as the start of a regular expression literal (`/.../`) leading to syntax errors.
+* Parsing of `case` statements that are formatted with the value expression on a different line than the `case` keyword  has been improved and should no longer lead to syntax errors.

--- a/ruby/ql/test/library-tests/ast/Ast.expected
+++ b/ruby/ql/test/library-tests/ast/Ast.expected
@@ -1275,6 +1275,19 @@ control/cases.rb:
 #  162|       getKey: [SymbolLiteral] :y
 #  162|         getComponent: [StringTextComponent] y
 #  162|       getValue: [IntegerLiteral] 1
+#  164|   getStmt: [CaseExpr] case ...
+#  165|     getValue: [LocalVariableAccess] foo
+#  166|     getBranch: [WhenClause] when ...
+#  166|       getPattern: [IntegerLiteral] 1
+#  166|       getBody: [StmtSequence] then ...
+#  166|         getStmt: [IntegerLiteral] 2
+#  169|   getStmt: [CaseExpr] case ...
+#  170|     getValue: [LocalVariableAccess] foo
+#  171|     getBranch: [InClause] in ... then ...
+#  171|       getPattern: [IntegerLiteral] 3
+#  171|       getBody: [StmtSequence] then ...
+#  171|         getStmt: [StringLiteral] "three"
+#  171|           getComponent: [StringTextComponent] three
 modules/classes.rb:
 #    2| [Toplevel] classes.rb
 #    3|   getStmt: [ClassDeclaration] Foo
@@ -2888,6 +2901,9 @@ operations/operations.rb:
 #  104|       getElement: [IntegerLiteral] 1
 #  104|       getElement: [IntegerLiteral] 2
 #  104|       getElement: [IntegerLiteral] 3
+#  106|   getStmt: [DivExpr] ... / ...
+#  106|     getAnOperand/getLeftOperand/getReceiver: [LocalVariableAccess] foo
+#  107|     getAnOperand/getArgument/getRightOperand: [IntegerLiteral] 5
 params/params.rb:
 #    1| [Toplevel] params.rb
 #    4|   getStmt: [Method] identifier_method_params

--- a/ruby/ql/test/library-tests/ast/TreeSitter.expected
+++ b/ruby/ql/test/library-tests/ast/TreeSitter.expected
@@ -2756,6 +2756,30 @@ control/cases.rb:
 #  162|         1: [ReservedWord] :
 #  162|         2: [Integer] 1
 #  162|       4: [ReservedWord] }
+#  164|   19: [Case] Case
+#  164|     0: [ReservedWord] case
+#  165|     1: [Identifier] foo
+#  166|     2: [When] When
+#  166|       0: [ReservedWord] when
+#  166|       1: [Pattern] Pattern
+#  166|         0: [Integer] 1
+#  166|       2: [Then] Then
+#  166|         0: [ReservedWord] then
+#  166|         1: [Integer] 2
+#  167|     3: [ReservedWord] end
+#  169|   20: [CaseMatch] CaseMatch
+#  169|     0: [ReservedWord] case
+#  170|     1: [Identifier] foo
+#  171|     2: [InClause] InClause
+#  171|       0: [ReservedWord] in
+#  171|       1: [Integer] 3
+#  171|       2: [Then] Then
+#  171|         0: [ReservedWord] then
+#  171|         1: [String] String
+#  171|           0: [ReservedWord] "
+#  171|           1: [StringContent] three
+#  171|           2: [ReservedWord] "
+#  172|     3: [ReservedWord] end
 #    1| [Comment] # Define some variables used below
 #    7| [Comment] # A case expr with a value and an else branch
 #   17| [Comment] # A case expr without a value or else branch
@@ -5636,6 +5660,10 @@ operations/operations.rb:
 #  104|       4: [ReservedWord] ,
 #  104|       5: [Integer] 3
 #  104|       6: [ReservedWord] ]
+#  106|   73: [Binary] Binary
+#  106|     0: [Identifier] foo
+#  106|     1: [ReservedWord] /
+#  107|     2: [Integer] 5
 #    1| [Comment] # Start with assignments to all the identifiers used below, so that they are
 #    2| [Comment] # interpreted as variables.
 #   22| [Comment] # Unary operations

--- a/ruby/ql/test/library-tests/ast/ValueText.expected
+++ b/ruby/ql/test/library-tests/ast/ValueText.expected
@@ -276,6 +276,12 @@ exprValue
 | control/cases.rb:162:10:162:10 | :x | :x | symbol |
 | control/cases.rb:162:16:162:16 | :y | :y | symbol |
 | control/cases.rb:162:19:162:19 | 1 | 1 | int |
+| control/cases.rb:165:3:165:5 | foo | 42 | int |
+| control/cases.rb:166:6:166:6 | 1 | 1 | int |
+| control/cases.rb:166:13:166:13 | 2 | 2 | int |
+| control/cases.rb:170:3:170:5 | foo | 42 | int |
+| control/cases.rb:171:4:171:4 | 3 | 3 | int |
+| control/cases.rb:171:11:171:17 | "three" | three | string |
 | control/conditionals.rb:2:5:2:5 | 0 | 0 | int |
 | control/conditionals.rb:3:5:3:5 | 0 | 0 | int |
 | control/conditionals.rb:4:5:4:5 | 0 | 0 | int |
@@ -921,6 +927,7 @@ exprValue
 | operations/operations.rb:104:25:104:25 | 1 | 1 | int |
 | operations/operations.rb:104:28:104:28 | 2 | 2 | int |
 | operations/operations.rb:104:31:104:31 | 3 | 3 | int |
+| operations/operations.rb:107:1:107:1 | 5 | 5 | int |
 | params/params.rb:41:46:41:46 | 7 | 7 | int |
 | params/params.rb:47:19:47:21 | :bar | :bar | symbol |
 | params/params.rb:47:24:47:24 | 2 | 2 | int |
@@ -1184,6 +1191,12 @@ exprCfgNodeValue
 | control/cases.rb:160:13:160:13 | 2 | 2 | int |
 | control/cases.rb:162:1:162:20 | nil | nil | nil |
 | control/cases.rb:162:19:162:19 | 1 | 1 | int |
+| control/cases.rb:165:3:165:5 | foo | 42 | int |
+| control/cases.rb:166:6:166:6 | 1 | 1 | int |
+| control/cases.rb:166:13:166:13 | 2 | 2 | int |
+| control/cases.rb:170:3:170:5 | foo | 42 | int |
+| control/cases.rb:171:4:171:4 | 3 | 3 | int |
+| control/cases.rb:171:11:171:17 | "three" | three | string |
 | control/conditionals.rb:2:5:2:5 | 0 | 0 | int |
 | control/conditionals.rb:3:5:3:5 | 0 | 0 | int |
 | control/conditionals.rb:4:5:4:5 | 0 | 0 | int |
@@ -1828,6 +1841,7 @@ exprCfgNodeValue
 | operations/operations.rb:104:25:104:25 | 1 | 1 | int |
 | operations/operations.rb:104:28:104:28 | 2 | 2 | int |
 | operations/operations.rb:104:31:104:31 | 3 | 3 | int |
+| operations/operations.rb:107:1:107:1 | 5 | 5 | int |
 | params/params.rb:41:46:41:46 | 7 | 7 | int |
 | params/params.rb:47:19:47:21 | :bar | :bar | symbol |
 | params/params.rb:47:24:47:24 | 2 | 2 | int |

--- a/ruby/ql/test/library-tests/ast/control/CaseExpr.expected
+++ b/ruby/ql/test/library-tests/ast/control/CaseExpr.expected
@@ -12,6 +12,8 @@ caseValues
 | cases.rb:154:1:158:3 | case ... | cases.rb:154:6:154:9 | call to expr |
 | cases.rb:160:1:160:14 | case ... | cases.rb:160:1:160:4 | call to expr |
 | cases.rb:162:1:162:20 | case ... | cases.rb:162:1:162:4 | call to expr |
+| cases.rb:164:1:167:3 | case ... | cases.rb:165:3:165:5 | foo |
+| cases.rb:169:1:172:3 | case ... | cases.rb:170:3:170:5 | foo |
 caseNoValues
 | cases.rb:18:1:22:3 | case ... |
 caseElseBranches
@@ -30,6 +32,8 @@ caseNoElseBranches
 | cases.rb:147:1:152:3 | case ... |
 | cases.rb:154:1:158:3 | case ... |
 | cases.rb:162:1:162:20 | case ... |
+| cases.rb:164:1:167:3 | case ... |
+| cases.rb:169:1:172:3 | case ... |
 caseWhenBranches
 | cases.rb:8:1:15:3 | case ... | cases.rb:9:1:10:7 | when ... | 0 | cases.rb:9:6:9:6 | b | cases.rb:9:7:10:7 | then ... |
 | cases.rb:8:1:15:3 | case ... | cases.rb:11:1:12:7 | when ... | 0 | cases.rb:11:6:11:6 | c | cases.rb:11:10:12:7 | then ... |
@@ -37,6 +41,7 @@ caseWhenBranches
 | cases.rb:18:1:22:3 | case ... | cases.rb:19:1:19:19 | when ... | 0 | cases.rb:19:6:19:10 | ... > ... | cases.rb:19:13:19:19 | then ... |
 | cases.rb:18:1:22:3 | case ... | cases.rb:20:1:20:19 | when ... | 0 | cases.rb:20:6:20:11 | ... == ... | cases.rb:20:13:20:19 | then ... |
 | cases.rb:18:1:22:3 | case ... | cases.rb:21:1:21:19 | when ... | 0 | cases.rb:21:6:21:10 | ... < ... | cases.rb:21:13:21:19 | then ... |
+| cases.rb:164:1:167:3 | case ... | cases.rb:166:1:166:13 | when ... | 0 | cases.rb:166:6:166:6 | 1 | cases.rb:166:8:166:13 | then ... |
 caseAllBranches
 | cases.rb:8:1:15:3 | case ... | 0 | cases.rb:9:1:10:7 | when ... |
 | cases.rb:8:1:15:3 | case ... | 1 | cases.rb:11:1:12:7 | when ... |
@@ -139,3 +144,5 @@ caseAllBranches
 | cases.rb:160:1:160:14 | case ... | 0 | cases.rb:160:1:160:14 | in ... then ... |
 | cases.rb:160:1:160:14 | case ... | 1 | cases.rb:160:1:160:14 | else ... |
 | cases.rb:162:1:162:20 | case ... | 0 | cases.rb:162:1:162:20 | in ... then ... |
+| cases.rb:164:1:167:3 | case ... | 0 | cases.rb:166:1:166:13 | when ... |
+| cases.rb:169:1:172:3 | case ... | 0 | cases.rb:171:1:171:17 | in ... then ... |

--- a/ruby/ql/test/library-tests/ast/control/ControlExpr.expected
+++ b/ruby/ql/test/library-tests/ast/control/ControlExpr.expected
@@ -12,6 +12,8 @@
 | cases.rb:154:1:158:3 | case ... | CaseExpr |
 | cases.rb:160:1:160:14 | case ... | CaseExpr |
 | cases.rb:162:1:162:20 | case ... | CaseExpr |
+| cases.rb:164:1:167:3 | case ... | CaseExpr |
+| cases.rb:169:1:172:3 | case ... | CaseExpr |
 | conditionals.rb:10:1:12:3 | if ... | IfExpr |
 | conditionals.rb:15:1:19:3 | if ... | IfExpr |
 | conditionals.rb:22:1:30:3 | if ... | IfExpr |

--- a/ruby/ql/test/library-tests/ast/control/cases.rb
+++ b/ruby/ql/test/library-tests/ast/control/cases.rb
@@ -160,3 +160,13 @@ end
 expr in [1, 2]
 
 expr => {x: v, y: 1}
+
+case 
+  foo
+when 1 then 2
+end
+
+case
+  foo
+in 3 then "three"
+end

--- a/ruby/ql/test/library-tests/ast/operations/binary.expected
+++ b/ruby/ql/test/library-tests/ast/operations/binary.expected
@@ -45,6 +45,7 @@ binaryOperations
 | operations.rb:101:21:101:23 | ... \|\| ... | \|\| | operations.rb:101:1:101:19 | MemberConstant | operations.rb:101:25:101:25 | 8 | LogicalOrExpr |
 | operations.rb:102:27:102:29 | ... \|\| ... | \|\| | operations.rb:102:1:102:25 | OtherConstant | operations.rb:102:31:102:31 | 7 | LogicalOrExpr |
 | operations.rb:103:13:103:15 | ... \|\| ... | \|\| | operations.rb:103:1:103:11 | CONSTANT4 | operations.rb:103:17:103:17 | 7 | LogicalOrExpr |
+| operations.rb:106:1:107:1 | ... / ... | / | operations.rb:106:1:106:3 | foo | operations.rb:107:1:107:1 | 5 | DivExpr |
 binaryArithmeticOperations
 | operations.rb:32:1:32:7 | ... + ... | + | operations.rb:32:1:32:1 | w | operations.rb:32:5:32:7 | 234 | AddExpr |
 | operations.rb:33:1:33:6 | ... - ... | - | operations.rb:33:1:33:1 | x | operations.rb:33:5:33:6 | 17 | SubExpr |
@@ -62,6 +63,7 @@ binaryArithmeticOperations
 | operations.rb:92:7:92:8 | ... / ... | / | operations.rb:92:3:92:5 | @@y | operations.rb:92:10:92:10 | 4 | DivExpr |
 | operations.rb:96:13:96:14 | ... * ... | * | operations.rb:96:1:96:11 | $global_var | operations.rb:96:16:96:16 | 6 | MulExpr |
 | operations.rb:99:11:99:12 | ... + ... | + | operations.rb:99:1:99:9 | CONSTANT2 | operations.rb:99:14:99:14 | 6 | AddExpr |
+| operations.rb:106:1:107:1 | ... / ... | / | operations.rb:106:1:106:3 | foo | operations.rb:107:1:107:1 | 5 | DivExpr |
 binaryLogicalOperations
 | operations.rb:40:1:40:10 | ... && ... | && | operations.rb:40:1:40:3 | foo | operations.rb:40:8:40:10 | bar | LogicalAndExpr |
 | operations.rb:41:1:41:11 | ... and ... | and | operations.rb:41:1:41:3 | baz | operations.rb:41:9:41:11 | qux | LogicalAndExpr |

--- a/ruby/ql/test/library-tests/ast/operations/operation.expected
+++ b/ruby/ql/test/library-tests/ast/operations/operation.expected
@@ -243,3 +243,5 @@
 | operations.rb:104:24:104:32 | * ... | * | operations.rb:104:24:104:32 | [...] | SplatExpr |
 | operations.rb:104:24:104:32 | ... = ... | = | operations.rb:104:24:104:32 | * ... | AssignExpr |
 | operations.rb:104:24:104:32 | ... = ... | = | operations.rb:104:24:104:32 | __synth__3 | AssignExpr |
+| operations.rb:106:1:107:1 | ... / ... | / | operations.rb:106:1:106:3 | foo | DivExpr |
+| operations.rb:106:1:107:1 | ... / ... | / | operations.rb:107:1:107:1 | 5 | DivExpr |

--- a/ruby/ql/test/library-tests/ast/operations/operations.rb
+++ b/ruby/ql/test/library-tests/ast/operations/operations.rb
@@ -102,3 +102,6 @@ Foo::MemberConstant ||= 8
 foo(1).bar::OtherConstant ||= 7
 ::CONSTANT4 ||= 7
 FOO, ::BAR, foo::FOO = [1, 2, 3]
+
+foo /
+5


### PR DESCRIPTION
This updates the grammar to include https://github.com/tree-sitter/tree-sitter-ruby/pull/246 and https://github.com/tree-sitter/tree-sitter-ruby/pull/247

@hmac 