### PR TITLE
C++: Fix upgrade delete directives

### DIFF
--- a/cpp/downgrades/cf72c8898d19eb1b3374432cf79d8276cb07ad43/upgrade.properties
+++ b/cpp/downgrades/cf72c8898d19eb1b3374432cf79d8276cb07ad43/upgrade.properties
@@ -1,5 +1,6 @@
 description: Support C++17 if and switch initializers
 compatibility: partial
+constexpr_if_initialization.rel: delete
 if_initialization.rel: delete
 switch_initialization.rel: delete
 exprparents.rel: run exprparents.qlo

--- a/cpp/ql/lib/upgrades/098850d25c4e9d417eb74c1bef9deb2f9d2dc417/upgrade.properties
+++ b/cpp/ql/lib/upgrades/098850d25c4e9d417eb74c1bef9deb2f9d2dc417/upgrade.properties
@@ -1,3 +1,6 @@
 description: Remove the old CFG tables
 compatibility: full
 
+falsecond.rel: delete
+successors.rel: delete
+truecond.rel: delete


### PR DESCRIPTION
This PR adds missing `delete` directives in upgrade and downgrade scripts.