### PR TITLE
C#: Fix upgrade delete directives

### DIFF
--- a/csharp/ql/lib/upgrades/6b8962d52bd5ed58edb163f78467074fd7e1a127/upgrade.properties
+++ b/csharp/ql/lib/upgrades/6b8962d52bd5ed58edb163f78467074fd7e1a127/upgrade.properties
@@ -1,2 +1,7 @@
 description: Remove unused VCS relations.
 compatibility: backwards
+
+svnaffectedfiles.rel: delete
+svnchurn.rel: delete
+svnentries.rel: delete
+svnentrymsg.rel: delete

--- a/csharp/ql/lib/upgrades/90fdbc8f87761f223ef7723e4b421c5b26ecc15e/upgrade.properties
+++ b/csharp/ql/lib/upgrades/90fdbc8f87761f223ef7723e4b421c5b26ecc15e/upgrade.properties
@@ -2,3 +2,5 @@ description: Support type annotations
 compatibility: backwards
 
 type_annotation.rel: run type_annotation.qlo
+ref_readonly_returns.rel: delete
+ref_returns.rel: delete

--- a/csharp/ql/lib/upgrades/f93793ee5f6b7bec615eaa1af0a1a4dea19472bb/upgrade.properties
+++ b/csharp/ql/lib/upgrades/f93793ee5f6b7bec615eaa1af0a1a4dea19472bb/upgrade.properties
@@ -1,2 +1,5 @@
 description: Implement structured nullability 
 compatibility: backwards
+
+specific_type_parameter_annotation.rel: delete
+type_argument_annotation.rel: delete


### PR DESCRIPTION
This PR adds missing `delete` directives in upgrade and downgrade scripts.