### PR TITLE
C# 12: Support for lambda `param` parameter and parameter defaults.

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/OrdinaryMethod.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/OrdinaryMethod.cs
@@ -52,17 +52,12 @@ namespace Semmle.Extraction.CSharp.Entities
             ExtractCompilerGenerated(trapFile);
         }
 
-        private bool IsCompilerGeneratedDelegate()
-        {
+        private bool IsCompilerGeneratedDelegate() =>
             // Lambdas with parameter defaults or a `params` parameter are implemented
             // using compiler generated delegate types.
-            if (Symbol.MethodKind == MethodKind.DelegateInvoke &&
-                Symbol.ContainingType is INamedTypeSymbol nt)
-            {
-                return nt.TypeKind == TypeKind.Delegate && nt.IsImplicitlyDeclared;
-            }
-            return false;
-        }
+            Symbol.MethodKind == MethodKind.DelegateInvoke &&
+            Symbol.ContainingType is INamedTypeSymbol nt &&
+            nt.IsImplicitlyDeclared;
 
         public static new OrdinaryMethod Create(Context cx, IMethodSymbol method)
         {

--- a/csharp/ql/lib/change-notes/2024-01-10-lambda-param-defaults.md
+++ b/csharp/ql/lib/change-notes/2024-01-10-lambda-param-defaults.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* C# 12: Add extractor support for lambda expressions with parameter defaults like `(int x, int y = 1) => ...` and lambda expressions with a `param` parameter like `(params int[] x) => ...)`.

--- a/csharp/ql/lib/semmle/code/csharp/exprs/Call.qll
+++ b/csharp/ql/lib/semmle/code/csharp/exprs/Call.qll
@@ -182,12 +182,20 @@ class Call extends DotNet::Call, Expr, @call {
   /**
    * Gets the argument that corresponds to parameter `p` of a potential
    * run-time target of this call.
+   *
+   * Does not consider default arguments.
    */
   Expr getRuntimeArgumentForParameter(Parameter p) {
     exists(Callable c |
       c = this.getARuntimeTarget() and
       p = c.getAParameter() and
-      result = this.getRuntimeArgument(p.getPosition())
+      (
+        p.isParams() and
+        result = this.getRuntimeArgument(any(int i | i >= p.getPosition()))
+        or
+        not p.isParams() and
+        result = this.getRuntimeArgument(p.getPosition())
+      )
     )
   }
 

--- a/csharp/ql/lib/semmle/code/csharp/exprs/Call.qll
+++ b/csharp/ql/lib/semmle/code/csharp/exprs/Call.qll
@@ -183,7 +183,9 @@ class Call extends DotNet::Call, Expr, @call {
    * Gets the argument that corresponds to parameter `p` of a potential
    * run-time target of this call.
    *
-   * Does not consider default arguments.
+   * Does not consider
+   *   - default arguments,
+   *   - named arguments.
    */
   Expr getRuntimeArgumentForParameter(Parameter p) {
     exists(Callable c |

--- a/csharp/ql/test/library-tests/arguments/PrintAst.expected
+++ b/csharp/ql/test/library-tests/arguments/PrintAst.expected
@@ -353,3 +353,71 @@ arguments.cs:
 #   93|       0: [Parameter] b
 #   93|         -1: [TypeMention] bool
 #   93|     4: [BlockStmt] {...}
+lambdas.cs:
+#    3| [Class] LambdaArgumentsTest
+#    5|   5: [Method] M1
+#    5|     -1: [TypeMention] Void
+#    6|     4: [BlockStmt] {...}
+#    7|       0: [LocalVariableDeclStmt] ... ...;
+#    7|         0: [LocalVariableDeclAndInitExpr] Func<Int32,Int32> l1 = ...
+#    7|           -1: [TypeMention] Func<int, int>
+#    7|           0: [LocalVariableAccess] access to local variable l1
+#    7|           1: [LambdaExpr] (...) => ...
+#-----|             2: (Parameters)
+#    7|               0: [Parameter] x
+#    7|                 -1: [TypeMention] int
+#    7|             4: [AddExpr] ... + ...
+#    7|               0: [ParameterAccess] access to parameter x
+#    7|               1: [IntLiteral] 1
+#    8|       1: [ExprStmt] ...;
+#    8|         0: [DelegateCall] delegate call
+#    8|           -1: [LocalVariableAccess] access to local variable l1
+#    8|           0: [IntLiteral] 1
+#   10|       2: [LocalVariableDeclStmt] ... ...;
+#   10|         0: [LocalVariableDeclAndInitExpr] <>__AnonType0<> l2 = ...
+#   10|           -1: [TypeMention] <>__AnonType0<>
+#   10|           0: [LocalVariableAccess] access to local variable l2
+#   10|           1: [LambdaExpr] (...) => ...
+#-----|             2: (Parameters)
+#   10|               0: [Parameter] x
+#   10|                 -1: [TypeMention] int
+#   10|               1: [Parameter] y
+#   10|                 -1: [TypeMention] int
+#   10|                 1: [IntLiteral] 1
+#   10|             4: [AddExpr] ... + ...
+#   10|               0: [ParameterAccess] access to parameter x
+#   10|               1: [ParameterAccess] access to parameter y
+#   11|       3: [ExprStmt] ...;
+#   11|         0: [DelegateCall] delegate call
+#   11|           -1: [LocalVariableAccess] access to local variable l2
+#   11|           0: [IntLiteral] 2
+#   11|           1: [IntLiteral] 3
+#   12|       4: [ExprStmt] ...;
+#   12|         0: [DelegateCall] delegate call
+#   12|           -1: [LocalVariableAccess] access to local variable l2
+#   12|           0: [IntLiteral] 4
+#   13|       5: [ExprStmt] ...;
+#   13|         0: [DelegateCall] delegate call
+#   13|           -1: [LocalVariableAccess] access to local variable l2
+#   13|           0: [IntLiteral] 5
+#   13|           1: [IntLiteral] 6
+#   15|       6: [LocalVariableDeclStmt] ... ...;
+#   15|         0: [LocalVariableDeclAndInitExpr] <>__AnonType0<> l3 = ...
+#   15|           -1: [TypeMention] <>__AnonType0<>
+#   15|           0: [LocalVariableAccess] access to local variable l3
+#   15|           1: [LambdaExpr] (...) => ...
+#-----|             2: (Parameters)
+#   15|               0: [Parameter] x
+#   15|                 -1: [TypeMention] Int32[]
+#   15|                   1: [TypeMention] int
+#   15|             4: [PropertyCall] access to property Length
+#   15|               -1: [ParameterAccess] access to parameter x
+#   16|       7: [ExprStmt] ...;
+#   16|         0: [DelegateCall] delegate call
+#   16|           -1: [LocalVariableAccess] access to local variable l3
+#   17|       8: [ExprStmt] ...;
+#   17|         0: [DelegateCall] delegate call
+#   17|           -1: [LocalVariableAccess] access to local variable l3
+#   17|           0: [IntLiteral] 7
+#   17|           1: [IntLiteral] 8
+#   17|           2: [IntLiteral] 9

--- a/csharp/ql/test/library-tests/arguments/argumentType.expected
+++ b/csharp/ql/test/library-tests/arguments/argumentType.expected
@@ -70,3 +70,12 @@
 | arguments.cs:84:23:84:43 | array creation of type Double[] | 0 |
 | arguments.cs:85:20:85:20 | 0 | 0 |
 | arguments.cs:85:23:85:43 | array creation of type Double[] | 0 |
+| lambdas.cs:8:12:8:12 | 1 | 0 |
+| lambdas.cs:11:12:11:12 | 2 | 0 |
+| lambdas.cs:11:15:11:15 | 3 | 0 |
+| lambdas.cs:12:12:12:12 | 4 | 0 |
+| lambdas.cs:13:12:13:12 | 5 | 0 |
+| lambdas.cs:13:15:13:15 | 6 | 0 |
+| lambdas.cs:17:12:17:12 | 7 | 0 |
+| lambdas.cs:17:15:17:15 | 8 | 0 |
+| lambdas.cs:17:18:17:18 | 9 | 0 |

--- a/csharp/ql/test/library-tests/arguments/lambdaArgument.expected
+++ b/csharp/ql/test/library-tests/arguments/lambdaArgument.expected
@@ -5,3 +5,5 @@
 | lambdas.cs:13:9:13:16 | delegate call | lambdas.cs:10:23:10:23 | x | lambdas.cs:13:12:13:12 | 5 |
 | lambdas.cs:13:9:13:16 | delegate call | lambdas.cs:10:30:10:30 | y | lambdas.cs:13:15:13:15 | 6 |
 | lambdas.cs:17:9:17:19 | delegate call | lambdas.cs:15:32:15:32 | x | lambdas.cs:17:12:17:12 | 7 |
+| lambdas.cs:17:9:17:19 | delegate call | lambdas.cs:15:32:15:32 | x | lambdas.cs:17:15:17:15 | 8 |
+| lambdas.cs:17:9:17:19 | delegate call | lambdas.cs:15:32:15:32 | x | lambdas.cs:17:18:17:18 | 9 |

--- a/csharp/ql/test/library-tests/arguments/lambdaArgument.expected
+++ b/csharp/ql/test/library-tests/arguments/lambdaArgument.expected
@@ -1,0 +1,7 @@
+| lambdas.cs:8:9:8:13 | delegate call | lambdas.cs:7:23:7:23 | x | lambdas.cs:8:12:8:12 | 1 |
+| lambdas.cs:11:9:11:16 | delegate call | lambdas.cs:10:23:10:23 | x | lambdas.cs:11:12:11:12 | 2 |
+| lambdas.cs:11:9:11:16 | delegate call | lambdas.cs:10:30:10:30 | y | lambdas.cs:11:15:11:15 | 3 |
+| lambdas.cs:12:9:12:13 | delegate call | lambdas.cs:10:23:10:23 | x | lambdas.cs:12:12:12:12 | 4 |
+| lambdas.cs:13:9:13:16 | delegate call | lambdas.cs:10:23:10:23 | x | lambdas.cs:13:12:13:12 | 5 |
+| lambdas.cs:13:9:13:16 | delegate call | lambdas.cs:10:30:10:30 | y | lambdas.cs:13:15:13:15 | 6 |
+| lambdas.cs:17:9:17:19 | delegate call | lambdas.cs:15:32:15:32 | x | lambdas.cs:17:12:17:12 | 7 |

--- a/csharp/ql/test/library-tests/arguments/lambdaArgument.ql
+++ b/csharp/ql/test/library-tests/arguments/lambdaArgument.ql
@@ -1,0 +1,7 @@
+import csharp
+
+from Call call, Parameter p, Expr arg
+where
+  call.getARuntimeTarget() instanceof LambdaExpr and
+  arg = call.getRuntimeArgumentForParameter(p)
+select call, p, arg

--- a/csharp/ql/test/library-tests/arguments/lambdas.cs
+++ b/csharp/ql/test/library-tests/arguments/lambdas.cs
@@ -1,0 +1,19 @@
+using System;
+
+class LambdaArgumentsTest
+{
+    void M1()
+    {
+        var l1 = (int x) => x + 1;
+        l1(1);
+
+        var l2 = (int x, int y = 1) => x + y;
+        l2(2, 3);
+        l2(4);
+        l2(5, 6);
+
+        var l3 = (params int[] x) => x.Length;
+        l3();
+        l3(7, 8, 9);
+    }
+}

--- a/csharp/ql/test/library-tests/parameters/LambdaParameters.cs
+++ b/csharp/ql/test/library-tests/parameters/LambdaParameters.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+
+public class LambdaParameters
+{
+    public void M1()
+    {
+        var l1 = (int x, int y = 1) => x + y;
+        var l2 = (object? o = default) => o;
+        var l3 = (int x, int y = 1, int z = 2) => x + y + z;
+        var l4 = ([Optional, DefaultParameterValue(7)] int x) => x;
+        var l5 = ([Optional, DateTimeConstant(14L)] DateTime x) => x;
+    }
+}

--- a/csharp/ql/test/library-tests/parameters/Parameters.expected
+++ b/csharp/ql/test/library-tests/parameters/Parameters.expected
@@ -1,4 +1,6 @@
 noDefaultValue
+| LambdaParameters.cs:9:18:9:44 | (...) => ... | LambdaParameters.cs:9:23:9:23 | x | 0 |
+| LambdaParameters.cs:11:18:11:59 | (...) => ... | LambdaParameters.cs:11:23:11:23 | x | 0 |
 | Parameters.cs:7:17:7:18 | M1 | Parameters.cs:7:24:7:24 | a | 0 |
 | Parameters.cs:7:17:7:18 | M1 | Parameters.cs:7:34:7:34 | b | 1 |
 | Parameters.cs:7:17:7:18 | M1 | Parameters.cs:7:44:7:44 | c | 2 |
@@ -16,6 +18,12 @@ noDefaultValue
 | Parameters.dll:0:0:0:0 | implicit conversion | Parameters.dll:0:0:0:0 | i | 0 |
 | Parameters.dll:0:0:0:0 | implicit conversion | Parameters.dll:0:0:0:0 | s | 0 |
 withDefaultValue
+| LambdaParameters.cs:9:18:9:44 | (...) => ... | LambdaParameters.cs:9:30:9:30 | y | 1 | LambdaParameters.cs:9:34:9:34 | 1 | 1 |
+| LambdaParameters.cs:10:18:10:43 | (...) => ... | LambdaParameters.cs:10:27:10:27 | o | 0 | LambdaParameters.cs:10:31:10:37 | default | null |
+| LambdaParameters.cs:11:18:11:59 | (...) => ... | LambdaParameters.cs:11:30:11:30 | y | 1 | LambdaParameters.cs:11:34:11:34 | 1 | 1 |
+| LambdaParameters.cs:11:18:11:59 | (...) => ... | LambdaParameters.cs:11:41:11:41 | z | 2 | LambdaParameters.cs:11:45:11:45 | 2 | 2 |
+| LambdaParameters.cs:12:18:12:66 | (...) => ... | LambdaParameters.cs:12:60:12:60 | x | 0 | LambdaParameters.cs:12:19:12:60 | 7 | 7 |
+| LambdaParameters.cs:13:18:13:68 | (...) => ... | LambdaParameters.cs:13:62:13:62 | x | 0 | LambdaParameters.cs:13:19:13:62 | object creation of type DateTime | - |
 | Parameters.cs:8:17:8:18 | M2 | Parameters.cs:8:34:8:34 | b | 1 | Parameters.cs:8:38:8:41 | null | null |
 | Parameters.cs:8:17:8:18 | M2 | Parameters.cs:8:51:8:51 | c | 2 | Parameters.cs:8:55:8:70 | "default string" | default string |
 | Parameters.cs:9:17:9:18 | M3 | Parameters.cs:9:24:9:24 | a | 0 | Parameters.cs:9:28:9:28 | 1 | 1 |
@@ -81,6 +89,7 @@ withDefaultValue
 | Parameters.dll:0:0:0:0 | M23 | Parameters.dll:0:0:0:0 | arg12 | 0 | Parameters.dll:0:0:0:0 | (...) ... | 0 |
 | Parameters.dll:0:0:0:0 | M24 | Parameters.dll:0:0:0:0 | arg13 | 0 | Parameters.dll:0:0:0:0 | (...) ... | 7 |
 dateTimeDefaults
+| LambdaParameters.cs:13:18:13:68 | (...) => ... | LambdaParameters.cs:13:62:13:62 | x | LambdaParameters.cs:13:19:13:62 | object creation of type DateTime | DateTime(long) | 14 |
 | Parameters.cs:22:17:22:19 | M14 | Parameters.cs:22:64:22:67 | arg4 | Parameters.cs:22:21:22:67 | object creation of type DateTime | DateTime(long) | 14 |
 | Parameters.cs:23:17:23:19 | M15 | Parameters.cs:23:68:23:71 | arg5 | Parameters.cs:23:21:23:71 | object creation of type DateTime | DateTime(long) | 10001 |
 | Parameters.dll:0:0:0:0 | M14 | Parameters.dll:0:0:0:0 | arg4 | Parameters.dll:0:0:0:0 | object creation of type DateTime | DateTime(long) | 14 |


### PR DESCRIPTION
It turns out that the extractor "almost" works out of the box for `params` and default parameters for lambda expressions.
The implementation of "ordinary" lambdas are based on `System.Func` whereas the implementation of lambdas with parameter defaults or the use of `params` parameters are based on compiler generated delegates (as these features are already support by delegates).

Below is an example of some C# code that is compiled and de-compiled to illustrate the difference.
```csharp
class LambdaArgumentsTest
{
    void M1()
    {
        var l1 = (int x) => x + 1;
        var l2 = (int x, int y = 1) => x + y;
    }
}
```
Compiling and de-compiling yields
```csharp
[CompilerGenerated]
internal delegate TResult <>f__AnonymousDelegate0<T1, T2, TResult>(T1 arg1, T2 arg2 = 1);
internal class LambdaArgumentsTest
{
    [Serializable]
    [CompilerGenerated]
    private sealed class <>c
    {
        public static readonly <>c <>9 = new <>c();

        public static Func<int, int> <>9__0_0;

        public static <>f__AnonymousDelegate0<int, int, int> <>9__0_1;

        internal int <M1>b__0_0(int x)
        {
            return x + 1;
        }

        internal int <M1>b__0_1(int x, int y = 1)
        {
            return x + y;
        }
    }

    private void M1()
    {
        Func<int, int> func = <>c.<>9__0_0 ?? (<>c.<>9__0_0 = new Func<int, int>(<>c.<>9.<M1>b__0_0));
        <>f__AnonymousDelegate0<int, int, int> <>f__AnonymousDelegate = <>c.<>9__0_1 ?? (<>c.<>9__0_1 = new <>f__AnonymousDelegate0<int, int, int>(<>c.<>9.<M1>b__0_1));
    }
}

```


In this PR
- Add extractor support for creating methods from compiler generated delegates. The compiler generated code isn't identified as source code by the extractor and thus it won't be extracted correctly. A method `IsCompilerGeneratedDelegate` has been introduced to catch "exactly" these use-cases. As the `Invoke` method doesn't have any location, we use the containing types location (which appears to re-use the source location of the lambda even though itself is compiler generated).
- Add Code QL library support for getting the arguments provided by params for delegate like types (these are not considered static call targets and thus the implementation for `getRuntimeArgumentFromParameter` has been updated to handle this case).
- Add test for lambda arguments.
- Add test for lambda default parameters.