### PR TITLE
Support dry-run of publishing script

### DIFF
--- a/java/ql/automodel/publish.sh
+++ b/java/ql/automodel/publish.sh
@@ -158,14 +158,19 @@ popd
 # This will be the file for the new release
 NEW_CHANGE_NOTES_FILE=$(ls -t ./src/change-notes/released/*.md | head -n 1)
 
+# Make a copy of the modified files
 mv ./src/CHANGELOG.md ./src/CHANGELOG.md.dry-run
 mv ./src/codeql-pack.release.yml ./src/codeql-pack.release.yml.dry-run
 mv ./src/qlpack.yml ./src/qlpack.yml.dry-run
 mv "$NEW_CHANGE_NOTES_FILE" ./src/change-notes/released.md.dry-run
 
-# If --override-release was not specified, then we need to checkout the original branch
-if [ $OVERRIDE_RELEASE != 1 ]; then
-  echo "Checking out the original branch"
+if [ $OVERRIDE_RELEASE = 1 ]; then
+  # Restore the original files
+  git checkout ./src/CHANGELOG.md
+  git checkout ./src/codeql-pack.release.yml
+  git checkout ./src/qlpack.yml
+else
+  # Restore the original files
   git checkout "$CURRENT_BRANCH" --force
 fi
 

--- a/java/ql/automodel/publish.sh
+++ b/java/ql/automodel/publish.sh
@@ -131,23 +131,28 @@ GRPS="automodel,-test"
 
 pushd "$AUTOMODEL_ROOT"
 echo Testing automodel queries
-"${CODEQL_DIST}/codeql" test run test
+#"${CODEQL_DIST}/codeql" test run test
+gh codeql test run test
 popd
 
 pushd "$WORKSPACE_ROOT"
 echo "Preparing the release"
-"${CODEQL_DIST}/codeql" pack release --groups $GRPS -v
+#"${CODEQL_DIST}/codeql" pack release --groups $GRPS -v
+gh codeql pack release --groups $GRPS -v
 
 if [ $DRY_RUN = 1 ]; then
   echo "Dry run: not publishing the query pack"
-  "${CODEQL_DIST}/codeql" pack publish --groups $GRPS --dry-run -v
+  #"${CODEQL_DIST}/codeql" pack publish --groups $GRPS --dry-run -v
+  gh codeql pack publish --groups $GRPS --dry-run -v
 else
   echo "Not a dry run! Publishing the query pack"
-  "${CODEQL_DIST}/codeql" pack publish --groups $GRPS -v
+  #"${CODEQL_DIST}/codeql" pack publish --groups $GRPS -v
+  gh codeql pack publish --groups $GRPS -v
 fi
 
 echo "Bumping versions"
-"${CODEQL_DIST}/codeql" pack post-release --groups $GRPS -v
+#"${CODEQL_DIST}/codeql" pack post-release --groups $GRPS -v
+gh codeql pack post-release --groups $GRPS -v
 popd
 
 # The above commands update

--- a/java/ql/automodel/publish.sh
+++ b/java/ql/automodel/publish.sh
@@ -129,6 +129,9 @@ WORKSPACE_ROOT="$AUTOMODEL_ROOT/../../.."
 # Specify the groups of queries to test and publish
 GRPS="automodel,-test"
 
+# Install the codeql gh extension
+gh extensions install github/gh-codeql
+
 pushd "$AUTOMODEL_ROOT"
 echo Testing automodel queries
 #"${CODEQL_DIST}/codeql" test run test

--- a/java/ql/automodel/publish.sh
+++ b/java/ql/automodel/publish.sh
@@ -115,7 +115,8 @@ else
   # Check that REVISION is downstream from PREVIOUS_RELEASE_SHA
   if ! git merge-base --is-ancestor "$PREVIOUS_RELEASE_SHA" "$REVISION"; then
     echo "Error: The codeql version $REVISION is not downstream of the query-pack version $PREVIOUS_RELEASE_SHA"
-    exit 1
+    echo "Ignoring"
+    #exit 1
   fi
   # Get the version of the codeql code specified by the codeml-automodel release
   git checkout "$REVISION"

--- a/java/ql/automodel/publish.sh
+++ b/java/ql/automodel/publish.sh
@@ -67,10 +67,6 @@ if [ -z "${GITHUB_TOKEN}" ]; then
   echo "Error: GITHUB_TOKEN environment variable not set. Please set this to a token with package:write permissions to codeql."
   exit 1
 fi
-if [ -z "${CODEQL_DIST}" ]; then
-  echo "Error: CODEQL_DIST environment variable not set. Please set this to the path of a codeql distribution."
-  exit 1
-fi
 if [ -z "${GH_TOKEN}" ]; then
   echo "Error: GH_TOKEN environment variable not set. Please set this to a token with repo permissions to github/codeml-automodel."
   exit 1
@@ -134,27 +130,22 @@ gh extensions install github/gh-codeql
 
 pushd "$AUTOMODEL_ROOT"
 echo Testing automodel queries
-#"${CODEQL_DIST}/codeql" test run test
 gh codeql test run test
 popd
 
 pushd "$WORKSPACE_ROOT"
 echo "Preparing the release"
-#"${CODEQL_DIST}/codeql" pack release --groups $GRPS -v
 gh codeql pack release --groups $GRPS -v
 
 if [ $DRY_RUN = 1 ]; then
   echo "Dry run: not publishing the query pack"
-  #"${CODEQL_DIST}/codeql" pack publish --groups $GRPS --dry-run -v
   gh codeql pack publish --groups $GRPS --dry-run -v
 else
   echo "Not a dry run! Publishing the query pack"
-  #"${CODEQL_DIST}/codeql" pack publish --groups $GRPS -v
   gh codeql pack publish --groups $GRPS -v
 fi
 
 echo "Bumping versions"
-#"${CODEQL_DIST}/codeql" pack post-release --groups $GRPS -v
 gh codeql pack post-release --groups $GRPS -v
 popd
 

--- a/java/ql/automodel/publish.sh
+++ b/java/ql/automodel/publish.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-help="Usage: ./publish --[override-release] --[dry-run]
+help="Usage: ./publish [--override-release] [--dry-run]
 Publish the automodel query pack.
 
 If no arguments are provided, publish the version of the codeql repo specified by the latest official release of the codeml-automodel repo.

--- a/java/ql/automodel/publish.sh
+++ b/java/ql/automodel/publish.sh
@@ -88,8 +88,7 @@ if [ $OVERRIDE_RELEASE = 1 ]; then
   # Check that the current HEAD is downstream from PREVIOUS_RELEASE_SHA
   if ! git merge-base --is-ancestor "$PREVIOUS_RELEASE_SHA" "$CURRENT_SHA"; then
     echo "Error: The current HEAD is not downstream from the previous release"
-    echo "Ignoring"
-    #exit 1
+    exit 1
   fi
 else
   # Get the latest release of codeml-automodel
@@ -111,8 +110,7 @@ else
   # Check that REVISION is downstream from PREVIOUS_RELEASE_SHA
   if ! git merge-base --is-ancestor "$PREVIOUS_RELEASE_SHA" "$REVISION"; then
     echo "Error: The codeql version $REVISION is not downstream of the query-pack version $PREVIOUS_RELEASE_SHA"
-    echo "Ignoring"
-    #exit 1
+    exit 1
   fi
   # Get the version of the codeql code specified by the codeml-automodel release
   git checkout "$REVISION"

--- a/java/ql/automodel/publish.sh
+++ b/java/ql/automodel/publish.sh
@@ -92,7 +92,8 @@ if [ $OVERRIDE_RELEASE = 1 ]; then
   # Check that the current HEAD is downstream from PREVIOUS_RELEASE_SHA
   if ! git merge-base --is-ancestor "$PREVIOUS_RELEASE_SHA" "$CURRENT_SHA"; then
     echo "Error: The current HEAD is not downstream from the previous release"
-    exit 1
+    echo "Ignoring"
+    #exit 1
   fi
 else
   # Get the latest release of codeml-automodel


### PR DESCRIPTION
Adds ability to "dry-run" the `automodel` query pack publication. Useful to test prior to a proper release.
- More command-line control
- Some copying around of files to support dry-run and non-dry-run use-cases

Successfully tested locally (with a dry-run).