### PR TITLE
Python: remove assignments handled by capture library

### DIFF
--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -297,7 +297,8 @@ module LocalFlow {
     //   nodeTo is `x`
     exists(AssignmentDefinition def |
       nodeFrom.(CfgNode).getNode() = def.getValue() and
-      nodeTo.(CfgNode).getNode() = def.getDefiningNode()
+      nodeTo.(CfgNode).getNode() = def.getDefiningNode() and
+      not exists(VariableCapture::CapturedVariable v | v.getAStore() = nodeTo.asExpr())
     )
     or
     // With definition


### PR DESCRIPTION
Addresses https://github.com/github/codeql-python-team/issues/764

The following quick-query, run on top 100 Python projects, consistently reported about 1% of assignments can be removed:
```codeql
import python
import semmle.python.dataflow.new.DataFlow
import semmle.python.dataflow.new.internal.VariableCapture

predicate superflous(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
  exists(AssignmentDefinition def |
    nodeFrom.(DataFlow::CfgNode).getNode() = def.getValue() and
    nodeTo.(DataFlow::CfgNode).getNode() = def.getDefiningNode() and
    exists(CapturedVariable v | v.getAStore() = nodeTo.asExpr())
  )
}

predicate allConsidered(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
  exists(AssignmentDefinition def |
    nodeFrom.(DataFlow::CfgNode).getNode() = def.getValue() and
    nodeTo.(DataFlow::CfgNode).getNode() = def.getDefiningNode()
  )
}

from int s, int a, int p
where
  s = count(DataFlow::Node nodeFrom, DataFlow::Node nodeTo | superflous(nodeFrom, nodeTo)) and
  a = count(DataFlow::Node nodeFrom, DataFlow::Node nodeTo | allConsidered(nodeFrom, nodeTo)) and
  p = 100 * s / a
select s, a, p
```