### PR TITLE
Data flow: Remove column from `mayBenefitFromCallContext`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowDispatch.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowDispatch.qll
@@ -54,18 +54,6 @@ private predicate functionSignature(Function f, string qualifiedName, int nparam
   not f.isStatic()
 }
 
-/**
- * Holds if the set of viable implementations that can be called by `call`
- * might be improved by knowing the call context.
- */
-predicate mayBenefitFromCallContext(DataFlowCall call, Function f) { none() }
-
-/**
- * Gets a viable dispatch target of `call` in the context `ctx`. This is
- * restricted to those `call`s for which a context might make a difference.
- */
-Function viableImplInCallContext(DataFlowCall call, DataFlowCall ctx) { none() }
-
 /** A parameter position represented by an integer. */
 class ParameterPosition extends int {
   ParameterPosition() { any(ParameterNode p).isParameterOf(_, this) }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowDispatch.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowDispatch.qll
@@ -249,9 +249,7 @@ private predicate functionSignature(Function f, string qualifiedName, int nparam
  * Holds if the set of viable implementations that can be called by `call`
  * might be improved by knowing the call context.
  */
-predicate mayBenefitFromCallContext(DataFlowCall call, DataFlowCallable f) {
-  mayBenefitFromCallContext(call, f, _)
-}
+predicate mayBenefitFromCallContext(DataFlowCall call) { mayBenefitFromCallContext(call, _, _) }
 
 /**
  * Holds if `call` is a call through a function pointer, and the pointer

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImplSpecific.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImplSpecific.qll
@@ -22,4 +22,8 @@ module CppDataFlow implements InputSig {
   predicate getAdditionalFlowIntoCallNodeTerm = Private::getAdditionalFlowIntoCallNodeTerm/2;
 
   predicate validParameterAliasStep = Private::validParameterAliasStep/2;
+
+  predicate mayBenefitFromCallContext = Private::mayBenefitFromCallContext/1;
+
+  predicate viableImplInCallContext = Private::viableImplInCallContext/2;
 }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowDispatch.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowDispatch.qll
@@ -148,16 +148,16 @@ private module Cached {
 import Cached
 
 private module DispatchImpl {
-  /**
-   * Holds if the set of viable implementations that can be called by `call`
-   * might be improved by knowing the call context. This is the case if the
-   * call is a delegate call, or if the qualifier accesses a parameter of
-   * the enclosing callable `c` (including the implicit `this` parameter).
-   */
-  predicate mayBenefitFromCallContext(DataFlowCall call, DataFlowCallable c) {
+  private predicate mayBenefitFromCallContext(DataFlowCall call, DataFlowCallable c) {
     c = call.getEnclosingCallable() and
     call.(NonDelegateDataFlowCall).getDispatchCall().mayBenefitFromCallContext()
   }
+
+  /**
+   * Holds if the set of viable implementations that can be called by `call`
+   * might be improved by knowing the call context.
+   */
+  predicate mayBenefitFromCallContext(DataFlowCall call) { mayBenefitFromCallContext(call, _) }
 
   /**
    * Gets a viable dispatch target of `call` in the context `ctx`. This is

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplSpecific.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplSpecific.qll
@@ -20,4 +20,8 @@ module CsharpDataFlow implements InputSig {
   Node exprNode(DataFlowExpr e) { result = Public::exprNode(e) }
 
   predicate accessPathLimit = Private::accessPathLimit/0;
+
+  predicate mayBenefitFromCallContext = Private::mayBenefitFromCallContext/1;
+
+  predicate viableImplInCallContext = Private::viableImplInCallContext/2;
 }

--- a/docs/ql-libraries/dataflow/dataflow.md
+++ b/docs/ql-libraries/dataflow/dataflow.md
@@ -588,18 +588,17 @@ However, joining the virtual dispatch relation with itself in this way is
 usually way too big to be feasible. Instead, the relation above should only be
 defined for those values of `call` for which the set of resulting dispatch
 targets might be reduced. To do this, define the set of `call`s that might for
-some reason benefit from a call context as the following predicate (the `c`
-column should be `call.getEnclosingCallable()`):
+some reason benefit from a call context as the following predicate:
 ```ql
-predicate mayBenefitFromCallContext(DataFlowCall call, DataFlowCallable c)
+predicate mayBenefitFromCallContext(DataFlowCall call)
 ```
 And then define `DataFlowCallable viableImplInCallContext(DataFlowCall call,
 DataFlowCall ctx)` as sketched above, but restricted to
-`mayBenefitFromCallContext(call, _)`.
+`mayBenefitFromCallContext(call)`.
 
 The shared implementation will then compare counts of virtual dispatch targets
 using `viableCallable` and `viableImplInCallContext` for each `call` in
-`mayBenefitFromCallContext(call, _)` and track call contexts during flow
+`mayBenefitFromCallContext(call)` and track call contexts during flow
 calculation when differences in these counts show an improved precision in
 further calls.
 

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowDispatch.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowDispatch.qll
@@ -104,18 +104,6 @@ DataFlowCallable viableCallable(DataFlowCall ma) {
   )
 }
 
-/**
- * Holds if the set of viable implementations that can be called by `call`
- * might be improved by knowing the call context.
- */
-predicate mayBenefitFromCallContext(DataFlowCall call, DataFlowCallable f) { none() }
-
-/**
- * Gets a viable dispatch target of `call` in the context `ctx`. This is
- * restricted to those `call`s for which a context might make a difference.
- */
-DataFlowCallable viableImplInCallContext(DataFlowCall call, DataFlowCall ctx) { none() }
-
 private int parameterPosition() {
   result = [-1 .. any(DataFlowCallable c).getType().getNumParameter()]
 }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowDispatch.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowDispatch.qll
@@ -116,10 +116,10 @@ private module DispatchImpl {
   /**
    * Holds if the set of viable implementations that can be called by `call`
    * might be improved by knowing the call context. This is the case if the
-   * qualifier is a parameter of the enclosing callable `c`.
+   * qualifier is a parameter of the enclosing callable of `call`.
    */
-  predicate mayBenefitFromCallContext(DataFlowCall call, DataFlowCallable c) {
-    mayBenefitFromCallContext(call.asCall(), c.asCallable(), _)
+  predicate mayBenefitFromCallContext(DataFlowCall call) {
+    mayBenefitFromCallContext(call.asCall(), _, _)
   }
 
   /**

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplSpecific.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplSpecific.qll
@@ -18,4 +18,8 @@ module JavaDataFlow implements InputSig {
   import Public
 
   Node exprNode(DataFlowExpr e) { result = Public::exprNode(e) }
+
+  predicate mayBenefitFromCallContext = Private::mayBenefitFromCallContext/1;
+
+  predicate viableImplInCallContext = Private::viableImplInCallContext/2;
 }

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -1009,22 +1009,6 @@ predicate attributeClearStep(Node n, AttributeContent c) {
  */
 predicate isUnreachableInCall(Node n, DataFlowCall call) { none() }
 
-//--------
-// Virtual dispatch with call context
-//--------
-/**
- * Gets a viable dispatch target of `call` in the context `ctx`. This is
- * restricted to those `call`s for which a context might make a difference.
- */
-DataFlowCallable viableImplInCallContext(DataFlowCall call, DataFlowCall ctx) { none() }
-
-/**
- * Holds if the set of viable implementations that can be called by `call`
- * might be improved by knowing the call context. This is the case if the qualifier accesses a parameter of
- * the enclosing callable `c` (including the implicit `this` parameter).
- */
-predicate mayBenefitFromCallContext(DataFlowCall call, DataFlowCallable c) { none() }
-
 /**
  * Holds if access paths with `c` at their head always should be tracked at high
  * precision. This disables adaptive access path precision for such access paths.

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplSpecific.qll
@@ -27,4 +27,8 @@ module RubyDataFlow implements InputSig {
   predicate neverSkipInPathGraph = Private::neverSkipInPathGraph/1;
 
   Node exprNode(DataFlowExpr e) { result = Public::exprNode(e) }
+
+  predicate mayBenefitFromCallContext = Private::mayBenefitFromCallContext/1;
+
+  predicate viableImplInCallContext = Private::viableImplInCallContext/2;
 }

--- a/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
+++ b/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
@@ -194,24 +194,24 @@ subpaths
 | call_sensitivity.rb:105:10:105:10 | x | call_sensitivity.rb:178:11:178:19 | call to taint | call_sensitivity.rb:105:10:105:10 | x | $@ | call_sensitivity.rb:178:11:178:19 | call to taint | call to taint |
 | call_sensitivity.rb:105:10:105:10 | x | call_sensitivity.rb:187:12:187:19 | call to taint | call_sensitivity.rb:105:10:105:10 | x | $@ | call_sensitivity.rb:187:12:187:19 | call to taint | call to taint |
 mayBenefitFromCallContext
-| call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:50:3:52:5 | method1 |
-| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:54:3:56:5 | method2 |
-| call_sensitivity.rb:59:5:59:18 | call to method2 | call_sensitivity.rb:58:3:60:5 | call_method2 |
-| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:62:3:64:5 | method3 |
-| call_sensitivity.rb:67:5:67:25 | call to method3 | call_sensitivity.rb:66:3:68:5 | call_method3 |
-| call_sensitivity.rb:81:5:81:18 | call to method1 | call_sensitivity.rb:80:3:82:5 | method5 |
-| call_sensitivity.rb:89:5:89:23 | call to singleton_method1 | call_sensitivity.rb:88:3:90:5 | singleton_method2 |
-| call_sensitivity.rb:93:5:93:28 | call to singleton_method2 | call_sensitivity.rb:92:3:94:5 | call_singleton_method2 |
-| call_sensitivity.rb:97:5:97:26 | call to singleton_method1 | call_sensitivity.rb:96:3:98:5 | singleton_method3 |
-| call_sensitivity.rb:101:5:101:35 | call to singleton_method3 | call_sensitivity.rb:100:3:102:5 | call_singleton_method3 |
-| call_sensitivity.rb:105:5:105:10 | call to sink | call_sensitivity.rb:104:3:107:5 | initialize |
-| call_sensitivity.rb:106:5:106:13 | call to method1 | call_sensitivity.rb:104:3:107:5 | initialize |
-| call_sensitivity.rb:110:5:110:9 | call to new | call_sensitivity.rb:109:3:111:5 | call_new |
-| call_sensitivity.rb:137:5:137:18 | call to method2 | call_sensitivity.rb:136:3:138:5 | call_method2 |
-| call_sensitivity.rb:141:5:141:25 | call to method3 | call_sensitivity.rb:140:3:142:5 | call_method3 |
-| call_sensitivity.rb:149:5:149:28 | call to singleton_method2 | call_sensitivity.rb:148:3:150:5 | call_singleton_method2 |
-| call_sensitivity.rb:153:5:153:35 | call to singleton_method3 | call_sensitivity.rb:152:3:154:5 | call_singleton_method3 |
-| call_sensitivity.rb:175:3:175:12 | call to new | call_sensitivity.rb:174:1:176:3 | create |
+| call_sensitivity.rb:51:5:51:10 | call to sink |
+| call_sensitivity.rb:55:5:55:13 | call to method1 |
+| call_sensitivity.rb:59:5:59:18 | call to method2 |
+| call_sensitivity.rb:63:5:63:16 | call to method1 |
+| call_sensitivity.rb:67:5:67:25 | call to method3 |
+| call_sensitivity.rb:81:5:81:18 | call to method1 |
+| call_sensitivity.rb:89:5:89:23 | call to singleton_method1 |
+| call_sensitivity.rb:93:5:93:28 | call to singleton_method2 |
+| call_sensitivity.rb:97:5:97:26 | call to singleton_method1 |
+| call_sensitivity.rb:101:5:101:35 | call to singleton_method3 |
+| call_sensitivity.rb:105:5:105:10 | call to sink |
+| call_sensitivity.rb:106:5:106:13 | call to method1 |
+| call_sensitivity.rb:110:5:110:9 | call to new |
+| call_sensitivity.rb:137:5:137:18 | call to method2 |
+| call_sensitivity.rb:141:5:141:25 | call to method3 |
+| call_sensitivity.rb:149:5:149:28 | call to singleton_method2 |
+| call_sensitivity.rb:153:5:153:35 | call to singleton_method3 |
+| call_sensitivity.rb:175:3:175:12 | call to new |
 viableImplInCallContext
 | call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:5:1:7:3 | sink |
 | call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:5:1:7:3 | sink |

--- a/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.ql
+++ b/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.ql
@@ -9,7 +9,7 @@ import DefaultFlowTest
 import TaintFlow::PathGraph
 import codeql.ruby.dataflow.internal.DataFlowDispatch as DataFlowDispatch
 
-query predicate mayBenefitFromCallContext = DataFlowDispatch::mayBenefitFromCallContext/2;
+query predicate mayBenefitFromCallContext = DataFlowDispatch::mayBenefitFromCallContext/1;
 
 query predicate viableImplInCallContext = DataFlowDispatch::viableImplInCallContext/2;
 

--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -77,13 +77,13 @@ signature module InputSig {
    * Holds if the set of viable implementations that can be called by `call`
    * might be improved by knowing the call context.
    */
-  predicate mayBenefitFromCallContext(DataFlowCall call, DataFlowCallable c);
+  default predicate mayBenefitFromCallContext(DataFlowCall call) { none() }
 
   /**
    * Gets a viable dispatch target of `call` in the context `ctx`. This is
    * restricted to those `call`s for which a context might make a difference.
    */
-  DataFlowCallable viableImplInCallContext(DataFlowCall call, DataFlowCall ctx);
+  default DataFlowCallable viableImplInCallContext(DataFlowCall call, DataFlowCall ctx) { none() }
 
   /**
    * Gets a node that can read the value returned from `call` with return kind

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
@@ -791,10 +791,12 @@ module MakeImplCommon<InputSig Lang> {
        */
       pragma[nomagic]
       private predicate mayBenefitFromCallContextExt(DataFlowCall call, DataFlowCallable callable) {
-        mayBenefitFromCallContext(call, callable)
-        or
-        callEnclosingCallable(call, callable) and
-        exists(viableCallableLambda(call, TDataFlowCallSome(_)))
+        (
+          mayBenefitFromCallContext(call)
+          or
+          exists(viableCallableLambda(call, TDataFlowCallSome(_)))
+        ) and
+        callEnclosingCallable(call, callable)
       }
 
       /**

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowDispatch.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowDispatch.qll
@@ -302,18 +302,6 @@ private module Cached {
 
 import Cached
 
-/**
- * Holds if the set of viable implementations that can be called by `call`
- * might be improved by knowing the call context.
- */
-predicate mayBenefitFromCallContext(DataFlowCall call, DataFlowCallable c) { none() }
-
-/**
- * Gets a viable dispatch target of `call` in the context `ctx`. This is
- * restricted to those `call`s for which a context might make a difference.
- */
-DataFlowCallable viableImplInCallContext(DataFlowCall call, DataFlowCall ctx) { none() }
-
 /** A parameter position. */
 class ParameterPosition extends TParameterPosition {
   /** Gets a textual representation of this position. */


### PR DESCRIPTION
Removes a redundant column from `mayBenefitFromCallContext`, and additionally makes `mayBenefitFromCallContext` and `viableImplInCallContext` optional in the API.