### PR TITLE
C++: Fix QLDoc on `cmpWithLinearBound`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/RangeAnalysisUtils.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/RangeAnalysisUtils.qll
@@ -355,13 +355,13 @@ private predicate linearAccessImpl(Expr expr, VariableAccess v, float p, float q
  * `cmpWithLinearBound(guard, v, Greater(), true)` and
  * `cmpWithLinearBound(guard, v, Lesser(),  false)` hold.
  * If `guard` is `4 - v > 5` then
- * `cmpWithLinearBound(guard, v, Lesser(),  false)` and
- * `cmpWithLinearBound(guard, v, Greater(), true)` hold.
+ * `cmpWithLinearBound(guard, v, Lesser(),  true)` and
+ * `cmpWithLinearBound(guard, v, Greater(), false)` hold.
  *
- * A more sophisticated predicate, such as `boundFromGuard`, is needed
- * to compute an actual bound for `v`. This predicate can be used if
- * you just want to check whether a variable is bounded, or to restrict
- * a more expensive analysis to just guards that bound a variable.
+ * If an actual bound for `v` is needed, use `upperBound` or `lowerBound`.
+ * This predicate can be used if you just want to check whether a variable
+ * is bounded, or to restrict a more expensive analysis to just guards that
+ * bound a variable.
  */
 predicate cmpWithLinearBound(
   ComparisonOperation guard, VariableAccess v,


### PR DESCRIPTION
This PR addresses the two comments on the QLDoc for `cmpWithLinearBound` mentioned in https://github.com/github/codeql/issues/15248.