### PR TITLE
Automodel: Exclude features from Kotlin files.

### DIFF
--- a/java/ql/automodel/src/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/automodel/src/AutomodelApplicationModeCharacteristics.qll
@@ -89,6 +89,13 @@ abstract private class ApplicationModeEndpoint extends TApplicationModeEndpoint 
   }
 
   abstract string toString();
+
+  /**
+   * Holds if this endpoint is from a Kotlin source file.
+   */
+  predicate isInKotlinSourceFile() {
+    this.asNode().getLocation().getFile().isKotlinSourceFile()
+  }
 }
 
 /**

--- a/java/ql/automodel/src/AutomodelApplicationModeExtractCandidates.ql
+++ b/java/ql/automodel/src/AutomodelApplicationModeExtractCandidates.ql
@@ -79,7 +79,9 @@ where
     CharacteristicsImpl::isModeled(endpoint, _, _, alreadyAiModeled)
   ) and
   meta.hasMetadata(endpoint, package, type, subtypes, name, signature, input, output, isVarargsArray) and
-  includeAutomodelCandidate(package, type, name, signature)
+  includeAutomodelCandidate(package, type, name, signature) and
+  // exclude features from Kotlin files since they are missing context regions
+  not endpoint.isInKotlinSourceFile()
 select endpoint.asNode(),
   "Related locations: $@, $@, $@." + "\nmetadata: $@, $@, $@, $@, $@, $@, $@, $@, $@, $@.", //
   CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, CallContext()), "CallContext", //

--- a/java/ql/automodel/src/AutomodelApplicationModeExtractNegativeExamples.ql
+++ b/java/ql/automodel/src/AutomodelApplicationModeExtractNegativeExamples.ql
@@ -61,7 +61,9 @@ where
     confidence2 >= SharedCharacteristics::maximalConfidence() and
     characteristic2.hasImplications(positiveType, true, confidence2)
   ) and
-  message = characteristic
+  message = characteristic and
+  // exclude features from Kotlin files since they are missing context regions
+  not endpoint.isInKotlinSourceFile()
 select endpoint.asNode(),
   message + "\nrelated locations: $@, $@, $@." + "\nmetadata: $@, $@, $@, $@, $@, $@, $@, $@, $@.", //
   CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, CallContext()), "CallContext", //

--- a/java/ql/automodel/src/AutomodelApplicationModeExtractPositiveExamples.ql
+++ b/java/ql/automodel/src/AutomodelApplicationModeExtractPositiveExamples.ql
@@ -22,7 +22,9 @@ where
   meta.hasMetadata(endpoint, package, type, subtypes, name, signature, input, output, isVarargsArray) and
   // Extract positive examples of sinks belonging to the existing ATM query configurations.
   CharacteristicsImpl::isKnownAs(endpoint, endpointType, _) and
-  exists(CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, CallContext()))
+  exists(CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, CallContext())) and
+  // exclude features from Kotlin files since they are missing context regions
+  not endpoint.isInKotlinSourceFile()
 select endpoint.asNode(),
   endpointType + "\nrelated locations: $@, $@, $@." +
     "\nmetadata: $@, $@, $@, $@, $@, $@, $@, $@, $@.", //

--- a/java/ql/automodel/src/AutomodelFrameworkModeCharacteristics.qll
+++ b/java/ql/automodel/src/AutomodelFrameworkModeCharacteristics.qll
@@ -88,6 +88,13 @@ abstract class FrameworkModeEndpoint extends TFrameworkModeEndpoint {
   string toString() { result = this.asTop().toString() }
 
   Location getLocation() { result = this.asTop().getLocation() }
+
+  /**
+   * Holds if this endpoint is in a Kotlin source file.
+   */
+  predicate isInKotlinSourceFile() {
+    this.getLocation().getFile().isKotlinSourceFile()
+  }
 }
 
 class ExplicitParameterEndpoint extends FrameworkModeEndpoint, TExplicitParameter {

--- a/java/ql/automodel/src/AutomodelFrameworkModeExtractCandidates.ql
+++ b/java/ql/automodel/src/AutomodelFrameworkModeExtractCandidates.ql
@@ -38,7 +38,9 @@ where
     CharacteristicsImpl::isSink(endpoint, _, alreadyAiModeled)
   ) and
   meta.hasMetadata(endpoint, package, type, subtypes, name, signature, input, output, parameterName) and
-  includeAutomodelCandidate(package, type, name, signature)
+  includeAutomodelCandidate(package, type, name, signature) and
+  // exclude features from Kotlin files since they are missing context regions
+  not endpoint.isInKotlinSourceFile()
 select endpoint,
   "Related locations: $@, $@." + "\nmetadata: $@, $@, $@, $@, $@, $@, $@, $@, $@, $@.", //
   CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, MethodDoc()), "MethodDoc", //

--- a/java/ql/automodel/src/AutomodelFrameworkModeExtractNegativeExamples.ql
+++ b/java/ql/automodel/src/AutomodelFrameworkModeExtractNegativeExamples.ql
@@ -34,7 +34,9 @@ where
     confidence2 >= SharedCharacteristics::maximalConfidence() and
     characteristic2.hasImplications(positiveType, true, confidence2)
   ) and
-  message = characteristic
+  message = characteristic and
+  // exclude features from Kotlin files since they are missing context regions
+  not endpoint.isInKotlinSourceFile()
 select endpoint,
   message + "\nrelated locations: $@, $@." + "\nmetadata: $@, $@, $@, $@, $@, $@, $@, $@, $@.", //
   CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, MethodDoc()), "MethodDoc", //

--- a/java/ql/automodel/src/AutomodelFrameworkModeExtractPositiveExamples.ql
+++ b/java/ql/automodel/src/AutomodelFrameworkModeExtractPositiveExamples.ql
@@ -21,7 +21,9 @@ where
   endpoint.getExtensibleType() = extensibleType and
   meta.hasMetadata(endpoint, package, type, subtypes, name, signature, input, output, parameterName) and
   // Extract positive examples of sinks belonging to the existing ATM query configurations.
-  CharacteristicsImpl::isKnownAs(endpoint, endpointType, _)
+  CharacteristicsImpl::isKnownAs(endpoint, endpointType, _) and
+  // exclude features from Kotlin files since they are missing context regions
+  not endpoint.isInKotlinSourceFile()
 select endpoint,
   endpointType + "\nrelated locations: $@, $@." + "\nmetadata: $@, $@, $@, $@, $@, $@, $@, $@, $@.", //
   CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, MethodDoc()), "MethodDoc", //


### PR DESCRIPTION
It turns out there is a handy predicate `File::isKotlinSourceFile()` we can use for this purpose (it literally just checks whether the extension is `.kt`, but using the standard library is of course better than rolling our own).

In terms of approach, I can see two basic ways of going about this:

1. Don't construct `Endpoint`s from Kotlin code.
2. Exclude `Endpoint`s arising from Kotling code in the extraction queries.

In this PR, I'm going with option 2: I don't think there is anything wrong with the Kotlin features per se, it's just that their SARIF representation is sometimes unhelpful. Hence I think it's more logical to exclude them in the queries, even though that requires us to repeat the check in six different queries ($\\{\text{application}, \text{framework}\\} \times\\{\text{candidate},\text{positive},\text{negative}\\}$).

I have verified that for a snapshot of `square/okhttp` we no longer get any candidates from Kotlin files, and indeed no longer any candidate locations without `contextRegion`s (which is what we are trying to avoid).