### PR TITLE
Automodel: Do not generate features for compiler-generated program elements.

### DIFF
--- a/java/ql/automodel/src/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/automodel/src/AutomodelApplicationModeCharacteristics.qll
@@ -26,14 +26,18 @@ newtype JavaRelatedLocationType =
 
 newtype TApplicationModeEndpoint =
   TExplicitArgument(Call call, DataFlow::Node arg) {
+    AutomodelJavaUtil::isFromSource(call) and
     exists(Argument argExpr |
       arg.asExpr() = argExpr and call = argExpr.getCall() and not argExpr.isVararg()
     )
   } or
   TInstanceArgument(Call call, DataFlow::Node arg) {
-    arg = DataFlow::getInstanceArgument(call) and not call instanceof ConstructorCall
+    AutomodelJavaUtil::isFromSource(call) and
+    arg = DataFlow::getInstanceArgument(call) and
+    not call instanceof ConstructorCall
   } or
   TImplicitVarargsArray(Call call, DataFlow::Node arg, int idx) {
+    AutomodelJavaUtil::isFromSource(call) and
     exists(Argument argExpr |
       arg.asExpr() = argExpr and
       call.getArgument(idx) = argExpr and
@@ -41,8 +45,12 @@ newtype TApplicationModeEndpoint =
       not exists(int i | i < idx and call.getArgument(i).(Argument).isVararg())
     )
   } or
-  TMethodReturnValue(Call call) { not call instanceof ConstructorCall } or
+  TMethodReturnValue(Call call) {
+    AutomodelJavaUtil::isFromSource(call) and
+    not call instanceof ConstructorCall
+  } or
   TOverriddenParameter(Parameter p, Method overriddenMethod) {
+    AutomodelJavaUtil::isFromSource(p) and
     not p.getCallable().callsConstructor(_) and
     p.getCallable().(Method).overrides(overriddenMethod)
   }

--- a/java/ql/automodel/src/AutomodelFrameworkModeCharacteristics.qll
+++ b/java/ql/automodel/src/AutomodelFrameworkModeCharacteristics.qll
@@ -25,14 +25,17 @@ newtype JavaRelatedLocationType =
 
 newtype TFrameworkModeEndpoint =
   TExplicitParameter(Parameter p) {
+    AutomodelJavaUtil::isFromSource(p) and
     not p.getType() instanceof PrimitiveType and
     not p.getType() instanceof BoxedType and
     not p.getType() instanceof NumberType
   } or
-  TQualifier(Callable c) { not c instanceof Constructor } or
+  TQualifier(Callable c) { AutomodelJavaUtil::isFromSource(c) and not c instanceof Constructor } or
   TReturnValue(Callable c) {
+    AutomodelJavaUtil::isFromSource(c) and
     c instanceof Constructor
     or
+    AutomodelJavaUtil::isFromSource(c) and
     c instanceof Method and
     (
       not c.getReturnType() instanceof VoidType and
@@ -40,6 +43,7 @@ newtype TFrameworkModeEndpoint =
     )
   } or
   TOverridableParameter(Method m, Parameter p) {
+    AutomodelJavaUtil::isFromSource(p) and
     p.getCallable() = m and
     m instanceof ModelExclusions::ModelApi and
     not m.getDeclaringType().isFinal() and
@@ -47,6 +51,7 @@ newtype TFrameworkModeEndpoint =
     not m.isStatic()
   } or
   TOverridableQualifier(Method m) {
+    AutomodelJavaUtil::isFromSource(m) and
     m instanceof ModelExclusions::ModelApi and
     not m.getDeclaringType().isFinal() and
     not m.isFinal() and

--- a/java/ql/automodel/src/AutomodelJavaUtil.qll
+++ b/java/ql/automodel/src/AutomodelJavaUtil.qll
@@ -82,3 +82,14 @@ predicate includeAutomodelCandidate(string package, string type, string name, st
   not automodelCandidateFilter(_, _, _, _) or
   automodelCandidateFilter(package, type, name, signature)
 }
+
+/**
+ * Holds if the given program element corresponds to a piece of source code,
+ * that is, it is not compiler-generated.
+ */
+predicate isFromSource(Element e) {
+  // not explicitly marked as compiler-generated
+  not e.isCompilerGenerated() and
+  // does not have a dummy location
+  not e.hasLocationInfo(_, 0, 0, 0, 0)
+}

--- a/java/ql/automodel/src/AutomodelJavaUtil.qll
+++ b/java/ql/automodel/src/AutomodelJavaUtil.qll
@@ -86,8 +86,15 @@ predicate includeAutomodelCandidate(string package, string type, string name, st
 /**
  * Holds if the given program element corresponds to a piece of source code,
  * that is, it is not compiler-generated.
+ *
+ * Note: This is a stricter check than `Element::fromSource`, which simply
+ * checks whether the element is in a source file as opposed to a JAR file.
+ * There can be compiler-generated elements in source files (especially for
+ * Kotlin), which we also want to exclude.
  */
 predicate isFromSource(Element e) {
+  // from a source file (not a JAR)
+  e.fromSource() and
   // not explicitly marked as compiler-generated
   not e.isCompilerGenerated() and
   // does not have a dummy location


### PR DESCRIPTION
These have dummy locations, which breaks certain invariants that break downstream processing.

Alternative to https://github.com/github/codeql/pull/15263; I think I prefer this approach since it's more targeted.