### PR TITLE
C++: add `.def` to exceptions to AV rule 32

### DIFF
--- a/cpp/ql/src/change-notes/2024-01-09-add-exception-to-av-rule-32.md
+++ b/cpp/ql/src/change-notes/2024-01-09-add-exception-to-av-rule-32.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `cpp/include-non-header` style query will now ignore the `.def` extension for textual header inclusions.

--- a/cpp/ql/src/jsf/4.06 Pre-Processing Directives/AV Rule 32.ql
+++ b/cpp/ql/src/jsf/4.06 Pre-Processing Directives/AV Rule 32.ql
@@ -18,6 +18,7 @@ from Include i, File f, string extension
 where
   f = i.getIncludedFile() and
   extension = f.getExtension().toLowerCase() and
+  extension != "def" and
   extension != "inc" and
   extension != "inl" and
   extension != "tcc" and

--- a/cpp/ql/test/query-tests/jsf/4.06 Pre-Processing Directives/AV Rule 32/test.c
+++ b/cpp/ql/test/query-tests/jsf/4.06 Pre-Processing Directives/AV Rule 32/test.c
@@ -1,3 +1,4 @@
-#include "test.H"
-#include "test.xpm"
-#include "test2.c"
+#include "test.H"    // GOOD
+#include "test.xpm"  // GOOD
+#include "test2.c"   // BAD
+#include "test.def"  // GOOD


### PR DESCRIPTION
This is used as textual includes in several projects for macro metaprogramming, for example in `llvm-project` and in `swift` (and since some time in our internal codebase as well).