### PR TITLE
Ruby: Handle captured `yield` calls

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
@@ -166,3 +166,4 @@ uniqueContentApprox
 identityLocalStep
 missingArgumentCall
 multipleArgumentCall
+lambdaCallEnclosingCallableMismatch

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-ir-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-ir-consistency.expected
@@ -31,3 +31,4 @@ uniqueContentApprox
 identityLocalStep
 missingArgumentCall
 multipleArgumentCall
+lambdaCallEnclosingCallableMismatch

--- a/cpp/ql/test/library-tests/dataflow/fields/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/dataflow-consistency.expected
@@ -193,3 +193,4 @@ uniqueContentApprox
 identityLocalStep
 missingArgumentCall
 multipleArgumentCall
+lambdaCallEnclosingCallableMismatch

--- a/cpp/ql/test/library-tests/dataflow/fields/dataflow-ir-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/dataflow-ir-consistency.expected
@@ -27,3 +27,4 @@ uniqueContentApprox
 identityLocalStep
 missingArgumentCall
 multipleArgumentCall
+lambdaCallEnclosingCallableMismatch

--- a/cpp/ql/test/library-tests/syntax-zoo/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/dataflow-consistency.expected
@@ -99,3 +99,4 @@ uniqueContentApprox
 identityLocalStep
 missingArgumentCall
 multipleArgumentCall
+lambdaCallEnclosingCallableMismatch

--- a/cpp/ql/test/library-tests/syntax-zoo/dataflow-ir-consistency.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/dataflow-ir-consistency.expected
@@ -42,3 +42,4 @@ uniqueContentApprox
 identityLocalStep
 missingArgumentCall
 multipleArgumentCall
+lambdaCallEnclosingCallableMismatch

--- a/ruby/ql/consistency-queries/DataFlowConsistency.ql
+++ b/ruby/ql/consistency-queries/DataFlowConsistency.ql
@@ -43,10 +43,6 @@ private module Input implements InputSig<RubyDataFlow> {
       arg.asExpr().getASuccessor(any(SuccessorTypes::ConditionalSuccessor c)).getASuccessor*() = n and
       n.getASplit() instanceof Split::ConditionalCompletionSplit
     )
-    or
-    // Synthetic block parameter nodes are passed directly as lambda-self reference
-    // arguments to all `yield` calls
-    arg instanceof ArgumentNodes::BlockParameterArgumentNode
   }
 }
 

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
@@ -208,7 +208,9 @@ private predicate moduleFlowsToMethodCallReceiver(RelevantCall call, Module m, s
   flowsToMethodCallReceiver(call, trackModuleAccess(m), method)
 }
 
-private Block blockCall(RelevantCall call) { lambdaSourceCall(call, _, trackBlock(result)) }
+private Block blockCall(RelevantCall call) {
+  lambdaSourceCall(call, _, trackBlock(result).(DataFlow::LocalSourceNode).getALocalUse())
+}
 
 pragma[nomagic]
 private predicate superCall(RelevantCall call, Module cls, string method) {

--- a/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
+++ b/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
@@ -1,4 +1,5 @@
 testFailures
+| call_sensitivity.rb:200:10:200:28 | # $ hasValueFlow=37 | Missing result:hasValueFlow=37 |
 edges
 | call_sensitivity.rb:9:7:9:13 | call to taint | call_sensitivity.rb:9:6:9:14 | ( ... ) |
 | call_sensitivity.rb:11:13:11:13 | x | call_sensitivity.rb:12:11:12:11 | x |
@@ -212,6 +213,7 @@ mayBenefitFromCallContext
 | call_sensitivity.rb:149:5:149:28 | call to singleton_method2 |
 | call_sensitivity.rb:153:5:153:35 | call to singleton_method3 |
 | call_sensitivity.rb:175:3:175:12 | call to new |
+| call_sensitivity.rb:194:3:196:5 | call to invoke_block1 |
 viableImplInCallContext
 | call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:5:1:7:3 | sink |
 | call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:5:1:7:3 | sink |
@@ -267,3 +269,5 @@ viableImplInCallContext
 | call_sensitivity.rb:153:5:153:35 | call to singleton_method3 | call_sensitivity.rb:171:1:171:34 | call to call_singleton_method3 | call_sensitivity.rb:96:3:98:5 | singleton_method3 |
 | call_sensitivity.rb:175:3:175:12 | call to new | call_sensitivity.rb:178:1:178:20 | call to create | call_sensitivity.rb:104:3:107:5 | initialize |
 | call_sensitivity.rb:175:3:175:12 | call to new | call_sensitivity.rb:179:1:179:20 | call to create | call_sensitivity.rb:156:3:158:5 | initialize |
+| call_sensitivity.rb:194:3:196:5 | call to invoke_block1 | call_sensitivity.rb:199:1:201:3 | call to invoke_block2 | call_sensitivity.rb:189:1:191:3 | invoke_block1 |
+| call_sensitivity.rb:194:3:196:5 | call to invoke_block1 | call_sensitivity.rb:203:1:205:3 | call to invoke_block2 | call_sensitivity.rb:189:1:191:3 | invoke_block1 |

--- a/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
+++ b/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
@@ -1,5 +1,4 @@
 testFailures
-| call_sensitivity.rb:200:10:200:28 | # $ hasValueFlow=37 | Missing result:hasValueFlow=37 |
 edges
 | call_sensitivity.rb:9:7:9:13 | call to taint | call_sensitivity.rb:9:6:9:14 | ( ... ) |
 | call_sensitivity.rb:11:13:11:13 | x | call_sensitivity.rb:12:11:12:11 | x |
@@ -82,6 +81,17 @@ edges
 | call_sensitivity.rb:178:11:178:19 | call to taint | call_sensitivity.rb:174:19:174:19 | x |
 | call_sensitivity.rb:187:11:187:20 | ( ... ) | call_sensitivity.rb:104:18:104:18 | x |
 | call_sensitivity.rb:187:12:187:19 | call to taint | call_sensitivity.rb:187:11:187:20 | ( ... ) |
+| call_sensitivity.rb:189:19:189:19 | x | call_sensitivity.rb:190:9:190:9 | x |
+| call_sensitivity.rb:190:9:190:9 | x | call_sensitivity.rb:194:23:194:23 | x |
+| call_sensitivity.rb:193:19:193:19 | x | call_sensitivity.rb:194:17:194:17 | x |
+| call_sensitivity.rb:194:17:194:17 | x | call_sensitivity.rb:189:19:189:19 | x |
+| call_sensitivity.rb:194:23:194:23 | x | call_sensitivity.rb:195:11:195:11 | x |
+| call_sensitivity.rb:195:11:195:11 | x | call_sensitivity.rb:199:30:199:30 | x |
+| call_sensitivity.rb:195:11:195:11 | x | call_sensitivity.rb:203:26:203:26 | x |
+| call_sensitivity.rb:199:15:199:24 | ( ... ) | call_sensitivity.rb:193:19:193:19 | x |
+| call_sensitivity.rb:199:16:199:23 | call to taint | call_sensitivity.rb:199:15:199:24 | ( ... ) |
+| call_sensitivity.rb:199:30:199:30 | x | call_sensitivity.rb:200:8:200:8 | x |
+| call_sensitivity.rb:203:26:203:26 | x | call_sensitivity.rb:204:8:204:8 | x |
 nodes
 | call_sensitivity.rb:9:6:9:14 | ( ... ) | semmle.label | ( ... ) |
 | call_sensitivity.rb:9:7:9:13 | call to taint | semmle.label | call to taint |
@@ -169,6 +179,18 @@ nodes
 | call_sensitivity.rb:178:11:178:19 | call to taint | semmle.label | call to taint |
 | call_sensitivity.rb:187:11:187:20 | ( ... ) | semmle.label | ( ... ) |
 | call_sensitivity.rb:187:12:187:19 | call to taint | semmle.label | call to taint |
+| call_sensitivity.rb:189:19:189:19 | x | semmle.label | x |
+| call_sensitivity.rb:190:9:190:9 | x | semmle.label | x |
+| call_sensitivity.rb:193:19:193:19 | x | semmle.label | x |
+| call_sensitivity.rb:194:17:194:17 | x | semmle.label | x |
+| call_sensitivity.rb:194:23:194:23 | x | semmle.label | x |
+| call_sensitivity.rb:195:11:195:11 | x | semmle.label | x |
+| call_sensitivity.rb:199:15:199:24 | ( ... ) | semmle.label | ( ... ) |
+| call_sensitivity.rb:199:16:199:23 | call to taint | semmle.label | call to taint |
+| call_sensitivity.rb:199:30:199:30 | x | semmle.label | x |
+| call_sensitivity.rb:200:8:200:8 | x | semmle.label | x |
+| call_sensitivity.rb:203:26:203:26 | x | semmle.label | x |
+| call_sensitivity.rb:204:8:204:8 | x | semmle.label | x |
 subpaths
 #select
 | call_sensitivity.rb:9:6:9:14 | ( ... ) | call_sensitivity.rb:9:7:9:13 | call to taint | call_sensitivity.rb:9:6:9:14 | ( ... ) | $@ | call_sensitivity.rb:9:7:9:13 | call to taint | call to taint |
@@ -194,6 +216,8 @@ subpaths
 | call_sensitivity.rb:105:10:105:10 | x | call_sensitivity.rb:125:12:125:19 | call to taint | call_sensitivity.rb:105:10:105:10 | x | $@ | call_sensitivity.rb:125:12:125:19 | call to taint | call to taint |
 | call_sensitivity.rb:105:10:105:10 | x | call_sensitivity.rb:178:11:178:19 | call to taint | call_sensitivity.rb:105:10:105:10 | x | $@ | call_sensitivity.rb:178:11:178:19 | call to taint | call to taint |
 | call_sensitivity.rb:105:10:105:10 | x | call_sensitivity.rb:187:12:187:19 | call to taint | call_sensitivity.rb:105:10:105:10 | x | $@ | call_sensitivity.rb:187:12:187:19 | call to taint | call to taint |
+| call_sensitivity.rb:200:8:200:8 | x | call_sensitivity.rb:199:16:199:23 | call to taint | call_sensitivity.rb:200:8:200:8 | x | $@ | call_sensitivity.rb:199:16:199:23 | call to taint | call to taint |
+| call_sensitivity.rb:204:8:204:8 | x | call_sensitivity.rb:199:16:199:23 | call to taint | call_sensitivity.rb:204:8:204:8 | x | $@ | call_sensitivity.rb:199:16:199:23 | call to taint | call to taint |
 mayBenefitFromCallContext
 | call_sensitivity.rb:51:5:51:10 | call to sink |
 | call_sensitivity.rb:55:5:55:13 | call to method1 |

--- a/ruby/ql/test/library-tests/dataflow/call-sensitivity/call_sensitivity.rb
+++ b/ruby/ql/test/library-tests/dataflow/call-sensitivity/call_sensitivity.rb
@@ -201,5 +201,5 @@ invoke_block2 (taint 37) do |x|
 end
 
 invoke_block2 "safe" do |x|
-  sink x
+  sink x # $ SPURIOUS hasValueFlow=37
 end

--- a/ruby/ql/test/library-tests/dataflow/call-sensitivity/call_sensitivity.rb
+++ b/ruby/ql/test/library-tests/dataflow/call-sensitivity/call_sensitivity.rb
@@ -185,3 +185,21 @@ class C < A
 end
 
 c = C.new (taint 32)
+
+def invoke_block1 x
+  yield x
+end
+
+def invoke_block2 x
+  invoke_block1 x do |x|
+    yield x
+  end
+end
+
+invoke_block2 (taint 37) do |x|
+  sink x # $ hasValueFlow=37
+end
+
+invoke_block2 "safe" do |x|
+  sink x
+end

--- a/ruby/ql/test/library-tests/dataflow/global/TypeTrackingInlineTest.expected
+++ b/ruby/ql/test/library-tests/dataflow/global/TypeTrackingInlineTest.expected
@@ -1,4 +1,5 @@
 testFailures
+| blocks.rb:4:10:4:10 | r | Fixed missing result:hasValueFlow=1 |
 | captured_variables.rb:50:10:50:10 | x | Fixed missing result:hasValueFlow=2 |
 | captured_variables.rb:68:25:68:68 | # $ hasValueFlow=3 $ MISSING: hasValueFlow=4 | Missing result:hasValueFlow=3 |
 | captured_variables.rb:72:21:72:66 | # $ hasValueFlow=4 $ SPURIOUS: hasValueFlow=3  | Fixed spurious result:hasValueFlow=3 |

--- a/ruby/ql/test/library-tests/dataflow/global/blocks.rb
+++ b/ruby/ql/test/library-tests/dataflow/global/blocks.rb
@@ -1,7 +1,7 @@
 class A
   def m1(&block)
-    r = block.call() # $ MISSING: hasValueFlow=1
-    sink r
+    r = block.call()
+    sink r # $ MISSING: hasValueFlow=1
   end
 
   def m2

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplConsistency.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplConsistency.qll
@@ -319,4 +319,9 @@ module MakeConsistency<
     strictcount(DataFlowCall call0 | multipleArgumentCallInclude(arg, call0)) > 1 and
     msg = "Multiple calls for argument node."
   }
+
+  query predicate lambdaCallEnclosingCallableMismatch(DataFlowCall call, Node receiver) {
+    lambdaCall(call, _, receiver) and
+    not nodeGetEnclosingCallable(receiver) = call.getEnclosingCallable()
+  }
 }


### PR DESCRIPTION
Before this PR, we incorrectly assumed that all `yield` calls happen inside the CFG scope that is the method, to which the (implicit) block parameter belongs. However, that need not be the case:
```rb
def invoke_block1 x
  yield x
end

def invoke_block2 x
  invoke_block1 x do |x|
    yield x # refers to the implicit block parameter of `invoke_block2`
  end
end
```