### PR TITLE
C++: Fix duplicate "final global value" nodes

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -149,11 +149,16 @@ private newtype TDefOrUseImpl =
 private predicate isGlobalUse(
   GlobalLikeVariable v, IRFunction f, int indirection, int indirectionIndex
 ) {
-  exists(VariableAddressInstruction vai |
-    vai.getEnclosingIRFunction() = f and
-    vai.getAstVariable() = v and
-    isDef(_, _, _, vai, indirection, indirectionIndex)
-  )
+  // Generate a "global use" at the end of the function body if there's a
+  // direct definition somewhere in the body of the function
+  indirection =
+    min(int cand, VariableAddressInstruction vai |
+      vai.getEnclosingIRFunction() = f and
+      vai.getAstVariable() = v and
+      isDef(_, _, _, vai, cand, indirectionIndex)
+    |
+      cand
+    )
 }
 
 private predicate isGlobalDefImpl(

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -496,7 +496,7 @@ class FinalParameterUse extends UseImpl, TFinalParameterUse {
  *  sink(global); // (4)
  * }
  * ```
- * and flow from `source()` to the argument of `sink` is then modelled as
+ * and flow from `source()` to the argument of `sink` is then modeled as
  * follows:
  * 1. Flow from `source()` to `(2)` (via SSA).
  * 2. Flow from `(2)` to `(1)` (via a `jumpStep`).

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
@@ -159,6 +159,9 @@ postWithInFlow
 | test.cpp:808:5:808:21 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:808:6:808:21 | global_indirect1 [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:832:5:832:17 | global_direct [post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:931:5:931:18 | global_pointer [post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:932:5:932:19 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:932:6:932:19 | global_pointer [inner post update] | PostUpdateNode should not be the target of local flow. |
 viableImplInCallContextTooLarge
 uniqueParameterNodeAtPosition
 uniqueParameterNodePosition

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-ir-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-ir-consistency.expected
@@ -4,6 +4,8 @@ uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
+| test.cpp:930:8:930:10 | Use of **global_pointer | Node should have one toString but has 2. |
+| test.cpp:930:8:930:10 | Use of *global_pointer | Node should have one toString but has 2. |
 parameterCallable
 localFlowIsLocal
 readStepIsLocal

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-ir-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-ir-consistency.expected
@@ -4,8 +4,6 @@ uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
-| test.cpp:930:8:930:10 | Use of **global_pointer | Node should have one toString but has 2. |
-| test.cpp:930:8:930:10 | Use of *global_pointer | Node should have one toString but has 2. |
 parameterCallable
 localFlowIsLocal
 readStepIsLocal

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test-source-sink.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test-source-sink.expected
@@ -300,6 +300,8 @@ irFlow
 | test.cpp:902:56:902:75 | *indirect_source(2) | test.cpp:911:19:911:48 | *global_array_static_indirect_2 |
 | test.cpp:914:46:914:53 | source | test.cpp:919:10:919:30 | global_pointer_static |
 | test.cpp:915:57:915:76 | *indirect_source(1) | test.cpp:921:19:921:50 | *global_pointer_static_indirect_1 |
+| test.cpp:932:23:932:28 | call to source | test.cpp:936:10:936:23 | global_pointer |
+| test.cpp:932:23:932:28 | call to source | test.cpp:937:10:937:24 | * ... |
 | true_upon_entry.cpp:9:11:9:16 | call to source | true_upon_entry.cpp:13:8:13:8 | x |
 | true_upon_entry.cpp:17:11:17:16 | call to source | true_upon_entry.cpp:21:8:21:8 | x |
 | true_upon_entry.cpp:27:9:27:14 | call to source | true_upon_entry.cpp:29:8:29:8 | x |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test-source-sink.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test-source-sink.expected
@@ -300,7 +300,6 @@ irFlow
 | test.cpp:902:56:902:75 | *indirect_source(2) | test.cpp:911:19:911:48 | *global_array_static_indirect_2 |
 | test.cpp:914:46:914:53 | source | test.cpp:919:10:919:30 | global_pointer_static |
 | test.cpp:915:57:915:76 | *indirect_source(1) | test.cpp:921:19:921:50 | *global_pointer_static_indirect_1 |
-| test.cpp:932:23:932:28 | call to source | test.cpp:936:10:936:23 | global_pointer |
 | test.cpp:932:23:932:28 | call to source | test.cpp:937:10:937:24 | * ... |
 | true_upon_entry.cpp:9:11:9:16 | call to source | true_upon_entry.cpp:13:8:13:8 | x |
 | true_upon_entry.cpp:17:11:17:16 | call to source | true_upon_entry.cpp:21:8:21:8 | x |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
@@ -933,7 +933,7 @@ namespace global_variable_conflation_test {
   }
 
   void use() {
-    sink(global_pointer); // $ SPURIOUS: ir
+    sink(global_pointer); // clean
     sink(*global_pointer); // $ ir MISSING: ast
   }
 }

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
@@ -923,3 +923,17 @@ namespace GlobalArrays {
     indirect_sink(global_pointer_static_indirect_2); // clean: global_pointer_static_indirect_2 does not have 2 indirections
   }
 }
+
+namespace global_variable_conflation_test {
+  int* global_pointer;
+
+  void def() {
+    global_pointer = nullptr;
+    *global_pointer = source();
+  }
+
+  void use() {
+    sink(global_pointer); // $ SPURIOUS: ir
+    sink(*global_pointer); // $ ir MISSING: ast
+  }
+}


### PR DESCRIPTION
I had hoped that this would fix the performance problems in https://github.com/github/codeql/pull/15194, but it doesn't look like it. Nevertheless, I think we should get this fix in since it may still be a (small) performance optimization _and_ it fixes more pointer/pointee conflation of global variables.

I've verified that all the lost results are due to pointer/pointee conflation being removed from global variables 🎉