### PR TITLE
C# 12: Type alias [Test only]

### DIFF
--- a/csharp/ql/test/library-tests/typealias/alias.cs
+++ b/csharp/ql/test/library-tests/typealias/alias.cs
@@ -1,0 +1,30 @@
+using System;
+
+using TupleType1 = (int, object);
+using TupleType2 = (int, string);
+using TupleType3 = (int, object);
+using Point = (int x, int y);
+
+public class TupleMethods
+{
+    public void M1(TupleType1 t)
+    {
+        var x = t.Item1;
+        var y = t.Item2;
+    }
+
+    public void M2(TupleType2 t)
+    {
+        var x = t.Item1;
+        var y = t.Item2;
+        M1(t);
+    }
+
+    public void M3(Point p)
+    {
+        var x = p.x;
+        var y = p.y;
+    }
+
+    public void M4(TupleType3 t) { }
+}

--- a/csharp/ql/test/library-tests/typealias/alias.expected
+++ b/csharp/ql/test/library-tests/typealias/alias.expected
@@ -1,0 +1,4 @@
+| alias.cs:10:17:10:18 | M1 | alias.cs:10:31:10:31 | t | (Int32,Object) |
+| alias.cs:16:17:16:18 | M2 | alias.cs:16:31:16:31 | t | (Int32,String) |
+| alias.cs:23:17:23:18 | M3 | alias.cs:23:26:23:26 | p | (Int32,Int32) |
+| alias.cs:29:17:29:18 | M4 | alias.cs:29:31:29:31 | t | (Int32,Object) |

--- a/csharp/ql/test/library-tests/typealias/alias.ql
+++ b/csharp/ql/test/library-tests/typealias/alias.ql
@@ -1,0 +1,8 @@
+import csharp
+
+from Method m, Parameter p, Type t
+where
+  m.fromSource() and
+  p = m.getAParameter() and
+  p.getType() = t
+select m, p, t.toString()


### PR DESCRIPTION
It turns out that type aliasing works out of the box.
The semantic model already contains the substituted types.
Should we consider to extract the alias directives (we have not done so up until now)?