### PR TITLE
Revert "Swift: separate installation of dependencies and autobuilding"

### DIFF
--- a/swift/swift-autobuilder/swift-autobuilder.cpp
+++ b/swift/swift-autobuilder/swift-autobuilder.cpp
@@ -54,11 +54,6 @@ static bool buildSwiftPackages(const std::vector<std::filesystem::path>& swiftPa
   return any_successful;
 }
 
-static void installDependencies(const CLIArgs& args) {
-  auto structure = scanProjectStructure(args.workingDir);
-  installDependencies(structure, args.dryRun);
-}
-
 static bool autobuild(const CLIArgs& args) {
   auto structure = scanProjectStructure(args.workingDir);
   auto& xcodeTargets = structure.xcodeTargets;
@@ -87,6 +82,7 @@ static bool autobuild(const CLIArgs& args) {
     return false;
   } else if (!xcodeTargets.empty()) {
     LOG_INFO("Building Xcode target: {}", xcodeTargets.front());
+    installDependencies(structure, args.dryRun);
     auto buildSucceeded = buildXcodeTarget(xcodeTargets.front(), args.dryRun);
     // If build failed, try to build Swift packages
     if (!buildSucceeded && !swiftPackages.empty()) {
@@ -117,7 +113,6 @@ static CLIArgs parseCLIArgs(int argc, char** argv) {
 
 int main(int argc, char** argv) {
   auto args = parseCLIArgs(argc, argv);
-  installDependencies(args);
   auto success = autobuild(args);
   codeql::Log::flush();
   if (!success) {


### PR DESCRIPTION
This reverts commit dd13ea3d0a41764b065f6e50efff40aa4fc8ffca.

Reverting https://github.com/github/codeql/pull/15116 as it caused regression.