### PR TITLE
Ruby: Add type row for extends calls

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
@@ -335,7 +335,7 @@ DataFlowCallable viableLibraryCallable(DataFlowCall call) {
 
 /** Holds if there is a call like `receiver.extend(M)`. */
 pragma[nomagic]
-private predicate extendCall(DataFlow::ExprNode receiver, Module m) {
+predicate extendCall(DataFlow::ExprNode receiver, Module m) {
   exists(DataFlow::CallNode extendCall |
     extendCall.getMethodName() = "extend" and
     exists(DataFlow::LocalSourceNode sourceNode | sourceNode.flowsTo(extendCall.getArgument(_)) |

--- a/ruby/ql/src/queries/modeling/internal/Util.qll
+++ b/ruby/ql/src/queries/modeling/internal/Util.qll
@@ -11,7 +11,10 @@ private import codeql.ruby.ApiGraphs
  * In practice, this means a file that is not part of test code.
  */
 class RelevantFile extends File {
-  RelevantFile() { not this.getRelativePath().regexpMatch(".*/?test(case)?s?/.*") }
+  RelevantFile() {
+    not this.getRelativePath().regexpMatch(".*/?test(case)?s?/.*") or
+    this.getAbsolutePath().matches("%/ql/test/%") // allows our test cases to work
+  }
 }
 
 /**

--- a/ruby/ql/test/query-tests/utils/modeleditor/GenerateModel.expected
+++ b/ruby/ql/test/query-tests/utils/modeleditor/GenerateModel.expected
@@ -3,4 +3,5 @@ sinkModel
 typeVariableModel
 typeModel
 | M1 | B |  |
+| M1 | C! |  |
 summaryModel


### PR DESCRIPTION
A call to `extend M` adds all the instance methods of module `M` as class
methods to the receiver. For example:

```rb
module A
  def f; end
end

class B
  extend A
end

B.f # => targets A.f
```

To model this, we generate a `typeModel` row of the form

```
A, B!,
```

which can be interpreted as "the class `B` is an instance of the module
`A`". This is not strictly true, but means that class method calls on `B`
which are defined in `A` will be dispatched correctly.
