### PR TITLE
C++: Robustify the IR by ensuring that a write side effect never has more than 10 types

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedCall.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedCall.qll
@@ -577,7 +577,16 @@ class TranslatedStructorQualifierSideEffect extends TranslatedArgumentSideEffect
   /** DEPRECATED: Alias for getAst */
   deprecated override Locatable getAST() { result = this.getAst() }
 
-  final override Type getIndirectionType() { result = call.getTarget().getDeclaringType() }
+  private Type getIndirectionType0() { result = call.getTarget().getDeclaringType() }
+
+  final override Type getIndirectionType() {
+    result = this.getIndirectionType0() and
+    // Ideally, each function should only belong to one class, but we've seen
+    // functions that belong to thousands of declaring classes. That
+    // causes a problem for later analyses (in particular, the aliased SSA
+    // analysis).
+    strictcount(this.getIndirectionType0()) < 10
+  }
 
   final override string getArgString() { result = "this" }
 


### PR DESCRIPTION
For some reason, after we merged https://github.com/github/codeql/pull/12125 we suddenly saw a few (templated) member functions belonging to thousands of (templated) classes.

If a member call belongs to many thousands of classes, the write side effect for the qualifier associated with the call has thousands of types (as the type of the write side effect is computed from the type of the qualifier).

This PR limits the impact of such a problem by requiring the set of types to be less than 10. I've picked the number 10 quite arbitrarily as I've seen 6 projects with types (even before we merged https://github.com/github/codeql/pull/12125). 