### PR TITLE
C++: Make IR generation robust against functions with many declaring types

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedCall.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedCall.qll
@@ -577,7 +577,20 @@ class TranslatedStructorQualifierSideEffect extends TranslatedArgumentSideEffect
   /** DEPRECATED: Alias for getAst */
   deprecated override Locatable getAST() { result = this.getAst() }
 
-  final override Type getIndirectionType() { result = call.getTarget().getDeclaringType() }
+  private Type getIndirectionType0() { result = call.getTarget().getDeclaringType() }
+
+  final override Type getIndirectionType() {
+    // Ideally, each function should only belong to one class, but we've seen
+    // functions that belong to thousands of declaring classes. That
+    // causes a problem for later analyses (in particular, the aliased SSA
+    // analysis).
+    // By returning `Void` in this predicate, the caller in
+    // `TranslatedArgumentSideEffect` will ensure that the resulting
+    // `WriteSideEffect` instruction returns an unknown type.
+    if strictcount(this.getIndirectionType0()) < 10
+    then result = this.getIndirectionType0()
+    else result instanceof VoidType
+  }
 
   final override string getArgString() { result = "this" }
 


### PR DESCRIPTION
When we merged https://github.com/github/codeql/pull/12125 we started seeing a few (templated) member functions with many 1000s of (templated) declaring types.

We use the type of the declaring function to infer the result type of a write side effect on the qualifier of a member function call. And when there are `N` declaring types for a member function call, the write side effect has `N` result types 😱. This causes massive slowdowns in the IR alias analysis.

This PR changes the IR generation of these write side effect instructions so that we return an "unknown type" rather than a large number of types if we're ever in a situation where there are more than 10 declaring types.

I picked 10 rather arbitrarily as the project I was testing this on had cases where there were 6 declaring types even before we merged https://github.com/github/codeql/pull/12125.


I haven't been able to reproduce this in a test, but on a project that exhibited this performance problem I'm seeing a difference in the output of PrintIR: https://www.diffchecker.com/CQ6UH8IN/

See the backlink(s)s for performance evaluation(s).