### PR TITLE
Swift extractor: Generalise SwiftDiagnostics

### DIFF
--- a/swift/extractor/main.cpp
+++ b/swift/extractor/main.cpp
@@ -25,6 +25,7 @@ using namespace std::string_literals;
 using namespace codeql::main_logger;
 
 const std::string_view codeql::programName = "extractor";
+const std::string_view codeql::extractorName = "swift";
 
 // must be called before processFrontendOptions modifies output paths
 static void lockOutputSwiftModuleTraps(codeql::SwiftExtractorState& state,

--- a/swift/logging/SwiftDiagnostics.cpp
+++ b/swift/logging/SwiftDiagnostics.cpp
@@ -3,14 +3,12 @@
 #include <binlog/Entries.hpp>
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_cat.h"
-#include "absl/strings/str_split.h"
-#include "swift/logging/SwiftAssert.h"
 
 namespace codeql {
 
 namespace {
-std::string_view severityToString(SwiftDiagnostic::Severity severity) {
-  using S = SwiftDiagnostic::Severity;
+std::string_view severityToString(Diagnostic::Severity severity) {
+  using S = Diagnostic::Severity;
   switch (severity) {
     case S::note:
       return "note";
@@ -24,8 +22,8 @@ std::string_view severityToString(SwiftDiagnostic::Severity severity) {
 }
 }  // namespace
 
-nlohmann::json SwiftDiagnostic::json(const std::chrono::system_clock::time_point& timestamp,
-                                     std::string_view message) const {
+nlohmann::json Diagnostic::json(const std::chrono::system_clock::time_point& timestamp,
+                                std::string_view message) const {
   nlohmann::json ret{
       {"source",
        {
@@ -49,18 +47,18 @@ nlohmann::json SwiftDiagnostic::json(const std::chrono::system_clock::time_point
   return ret;
 }
 
-std::string SwiftDiagnostic::abbreviation() const {
+std::string Diagnostic::abbreviation() const {
   if (location) {
     return absl::StrCat(id, "@", location->str());
   }
   return std::string{id};
 }
 
-bool SwiftDiagnostic::has(SwiftDiagnostic::Visibility v) const {
+bool Diagnostic::has(Visibility v) const {
   return (visibility & v) != Visibility::none;
 }
 
-nlohmann::json SwiftDiagnosticsLocation::json() const {
+nlohmann::json DiagnosticsLocation::json() const {
   nlohmann::json ret{{"file", file}};
   if (startLine) ret["startLine"] = startLine;
   if (startColumn) ret["startColumn"] = startColumn;
@@ -69,7 +67,7 @@ nlohmann::json SwiftDiagnosticsLocation::json() const {
   return ret;
 }
 
-std::string SwiftDiagnosticsLocation::str() const {
+std::string DiagnosticsLocation::str() const {
   return absl::StrJoin(std::tuple{file, startLine, startColumn, endLine, endColumn}, ":");
 }
 }  // namespace codeql

--- a/swift/logging/SwiftDiagnostics.h
+++ b/swift/logging/SwiftDiagnostics.h
@@ -97,13 +97,15 @@ inline constexpr Diagnostic::Visibility operator&(Diagnostic::Visibility lhs,
                                              static_cast<unsigned char>(rhs));
 }
 
-constexpr Diagnostic internalError = Diagnostic{
-      .id="internal-error", .name="Internal error",
-      .action="Some or all of the Swift analysis may have failed.\n"
-      "\n"
-      "If the error persists, contact support, quoting the error message and describing what "
-      "happened, or [open an issue in our open source repository][1].\n"
-      "\n"
-      "[1]: https://github.com/github/codeql/issues/new?labels=bug&template=ql---general.md",
-      .severity=Diagnostic::Severity::warning};
+constexpr Diagnostic internalError{
+    .id = "internal-error",
+    .name = "Internal error",
+    .action =
+        "Some or all of the Swift analysis may have failed.\n"
+        "\n"
+        "If the error persists, contact support, quoting the error message and describing what "
+        "happened, or [open an issue in our open source repository][1].\n"
+        "\n"
+        "[1]: https://github.com/github/codeql/issues/new?labels=bug&template=ql---general.md",
+    .severity = Diagnostic::Severity::warning};
 }  // namespace codeql

--- a/swift/logging/SwiftDiagnostics.h
+++ b/swift/logging/SwiftDiagnostics.h
@@ -20,7 +20,7 @@ namespace codeql {
 
 extern const std::string_view programName;
 
-struct SwiftDiagnosticsLocation {
+struct DiagnosticsLocation {
   std::string_view file;
   unsigned startLine;
   unsigned startColumn;
@@ -34,7 +34,8 @@ struct SwiftDiagnosticsLocation {
 // Models a diagnostic source for Swift, holding static information that goes out into a diagnostic
 // These are internally stored into a map on id's. A specific error log can use binlog's category
 // as id, which will then be used to recover the diagnostic source while dumping.
-struct SwiftDiagnostic {
+class Diagnostic {
+ public:
   enum class Visibility : unsigned char {
     none = 0b000,
     statusPage = 0b001,
@@ -51,7 +52,14 @@ struct SwiftDiagnostic {
     error,
   };
 
-  static constexpr std::string_view extractorName = "swift";
+  constexpr Diagnostic(std::string_view extractorName,
+                       std::string_view id,
+                       std::string_view name,
+                       std::string_view action,
+                       Severity severity)
+      : extractorName(extractorName), id(id), name(name), action(action), severity(severity) {}
+
+  std::string_view extractorName;
 
   std::string_view id;
   std::string_view name;
@@ -60,7 +68,7 @@ struct SwiftDiagnostic {
   Visibility visibility{Visibility::all};
   Severity severity{Severity::error};
 
-  std::optional<SwiftDiagnosticsLocation> location{};
+  std::optional<DiagnosticsLocation> location{};
 
   // create a JSON diagnostics for this source with the given `timestamp` and Markdown `message`
   // A markdownMessage is emitted that includes both the message and the action to take. The id is
@@ -71,13 +79,13 @@ struct SwiftDiagnostic {
   // returns <id> or <id>@<location> if a location is present
   std::string abbreviation() const;
 
-  SwiftDiagnostic withLocation(std::string_view file,
-                               unsigned startLine = 0,
-                               unsigned startColumn = 0,
-                               unsigned endLine = 0,
-                               unsigned endColumn = 0) const {
+  Diagnostic withLocation(std::string_view file,
+                          unsigned startLine = 0,
+                          unsigned startColumn = 0,
+                          unsigned endLine = 0,
+                          unsigned endColumn = 0) const {
     auto ret = *this;
-    ret.location = SwiftDiagnosticsLocation{file, startLine, startColumn, endLine, endColumn};
+    ret.location = DiagnosticsLocation{file, startLine, startColumn, endLine, endColumn};
     return ret;
   }
 
@@ -85,28 +93,32 @@ struct SwiftDiagnostic {
   bool has(Visibility v) const;
 };
 
-inline constexpr SwiftDiagnostic::Visibility operator|(SwiftDiagnostic::Visibility lhs,
-                                                       SwiftDiagnostic::Visibility rhs) {
-  return static_cast<SwiftDiagnostic::Visibility>(static_cast<unsigned char>(lhs) |
-                                                  static_cast<unsigned char>(rhs));
+inline constexpr Diagnostic::Visibility operator|(Diagnostic::Visibility lhs,
+                                                  Diagnostic::Visibility rhs) {
+  return static_cast<Diagnostic::Visibility>(static_cast<unsigned char>(lhs) |
+                                             static_cast<unsigned char>(rhs));
 }
 
-inline constexpr SwiftDiagnostic::Visibility operator&(SwiftDiagnostic::Visibility lhs,
-                                                       SwiftDiagnostic::Visibility rhs) {
-  return static_cast<SwiftDiagnostic::Visibility>(static_cast<unsigned char>(lhs) &
-                                                  static_cast<unsigned char>(rhs));
+inline constexpr Diagnostic::Visibility operator&(Diagnostic::Visibility lhs,
+                                                  Diagnostic::Visibility rhs) {
+  return static_cast<Diagnostic::Visibility>(static_cast<unsigned char>(lhs) &
+                                             static_cast<unsigned char>(rhs));
 }
 
-constexpr SwiftDiagnostic internalError{
-    .id = "internal-error",
-    .name = "Internal error",
-    .action =
-        "Some or all of the Swift analysis may have failed.\n"
-        "\n"
-        "If the error persists, contact support, quoting the error message and describing what "
-        "happened, or [open an issue in our open source repository][1].\n"
-        "\n"
-        "[1]: https://github.com/github/codeql/issues/new?labels=bug&template=ql---general.md",
-    .severity = SwiftDiagnostic::Severity::warning,
-};
+constexpr Diagnostic swiftDiagnostic(std::string_view id,
+                                     std::string_view name,
+                                     std::string_view action,
+                                     Diagnostic::Severity severity = Diagnostic::Severity::error) {
+  return Diagnostic("swift", id, name, action, severity);
+}
+
+constexpr Diagnostic internalError = swiftDiagnostic(
+      "internal-error", "Internal error",
+      "Some or all of the Swift analysis may have failed.\n"
+      "\n"
+      "If the error persists, contact support, quoting the error message and describing what "
+      "happened, or [open an issue in our open source repository][1].\n"
+      "\n"
+      "[1]: https://github.com/github/codeql/issues/new?labels=bug&template=ql---general.md",
+      Diagnostic::Severity::warning);
 }  // namespace codeql

--- a/swift/logging/SwiftDiagnostics.h
+++ b/swift/logging/SwiftDiagnostics.h
@@ -19,6 +19,7 @@
 namespace codeql {
 
 extern const std::string_view programName;
+extern const std::string_view extractorName;
 
 struct DiagnosticsLocation {
   std::string_view file;
@@ -51,15 +52,6 @@ class Diagnostic {
     warning,
     error,
   };
-
-  constexpr Diagnostic(std::string_view extractorName,
-                       std::string_view id,
-                       std::string_view name,
-                       std::string_view action,
-                       Severity severity)
-      : extractorName(extractorName), id(id), name(name), action(action), severity(severity) {}
-
-  std::string_view extractorName;
 
   std::string_view id;
   std::string_view name;
@@ -105,20 +97,13 @@ inline constexpr Diagnostic::Visibility operator&(Diagnostic::Visibility lhs,
                                              static_cast<unsigned char>(rhs));
 }
 
-constexpr Diagnostic swiftDiagnostic(std::string_view id,
-                                     std::string_view name,
-                                     std::string_view action,
-                                     Diagnostic::Severity severity = Diagnostic::Severity::error) {
-  return Diagnostic("swift", id, name, action, severity);
-}
-
-constexpr Diagnostic internalError = swiftDiagnostic(
-      "internal-error", "Internal error",
-      "Some or all of the Swift analysis may have failed.\n"
+constexpr Diagnostic internalError = Diagnostic{
+      .id="internal-error", .name="Internal error",
+      .action="Some or all of the Swift analysis may have failed.\n"
       "\n"
       "If the error persists, contact support, quoting the error message and describing what "
       "happened, or [open an issue in our open source repository][1].\n"
       "\n"
       "[1]: https://github.com/github/codeql/issues/new?labels=bug&template=ql---general.md",
-      Diagnostic::Severity::warning);
+      .severity=Diagnostic::Severity::warning};
 }  // namespace codeql

--- a/swift/logging/SwiftLogging.cpp
+++ b/swift/logging/SwiftLogging.cpp
@@ -173,7 +173,7 @@ void Log::flushImpl() {
   }
 }
 
-void Log::diagnoseImpl(const SwiftDiagnostic& source,
+void Log::diagnoseImpl(const Diagnostic& source,
                        const std::chrono::nanoseconds& elapsed,
                        std::string_view message) {
   using Clock = std::chrono::system_clock;

--- a/swift/logging/SwiftLogging.h
+++ b/swift/logging/SwiftLogging.h
@@ -58,7 +58,7 @@
 #define DIAGNOSE_WITH_LEVEL(LEVEL, ID, FORMAT, ...)                                  \
   do {                                                                               \
     auto _now = ::binlog::clockNow();                                                \
-    const ::codeql::SwiftDiagnostic& _id = ID;                                       \
+    const ::codeql::Diagnostic& _id = ID;                                       \
     ::codeql::Log::diagnose(_id, std::chrono::nanoseconds{_now},                     \
                             fmt::format(FORMAT __VA_OPT__(, ) __VA_ARGS__));         \
     LOG_WITH_LEVEL_AND_TIME(LEVEL, _now, CODEQL_DIAGNOSTIC_LOG_FORMAT_PREFIX FORMAT, \
@@ -132,7 +132,7 @@ class Log {
     return instance().getLoggerConfigurationImpl(name);
   }
 
-  static void diagnose(const SwiftDiagnostic& source,
+  static void diagnose(const Diagnostic& source,
                        const std::chrono::nanoseconds& elapsed,
                        std::string_view message) {
     instance().diagnoseImpl(source, elapsed, message);
@@ -153,7 +153,7 @@ class Log {
 
   void configure();
   void flushImpl();
-  void diagnoseImpl(const SwiftDiagnostic& source,
+  void diagnoseImpl(const Diagnostic& source,
                     const std::chrono::nanoseconds& elapsed,
                     std::string_view message);
 

--- a/swift/logging/tests/assertion-diagnostics/AssertFalse.cpp
+++ b/swift/logging/tests/assertion-diagnostics/AssertFalse.cpp
@@ -1,6 +1,7 @@
 #include "swift/logging/SwiftAssert.h"
 
 const std::string_view codeql::programName = "test";
+const std::string_view codeql::extractorName = "swift";
 
 static codeql::Logger& logger() {
   static codeql::Logger ret{"main"};

--- a/swift/swift-autobuilder/BuildRunner.cpp
+++ b/swift/swift-autobuilder/BuildRunner.cpp
@@ -8,11 +8,10 @@
 #include "swift/logging/SwiftLogging.h"
 #include "swift/swift-autobuilder/CustomizingBuildLink.h"
 
-constexpr codeql::SwiftDiagnostic buildCommandFailed{
-    .id = "build-command-failed",
-    .name = "Detected build command failed",
-    .action = "Set up a [manual build command][1] or [check the logs of the autobuild step][2].\n"
-              "\n[1]: " MANUAL_BUILD_COMMAND_HELP_LINK "\n[2]: " CHECK_LOGS_HELP_LINK};
+constexpr codeql::Diagnostic buildCommandFailed = codeql::swiftDiagnostic(
+    "build-command-failed", "Detected build command failed",
+    "Set up a [manual build command][1] or [check the logs of the autobuild step][2].\n"
+    "\n[1]: " MANUAL_BUILD_COMMAND_HELP_LINK "\n[2]: " CHECK_LOGS_HELP_LINK);
 
 static codeql::Logger& logger() {
   static codeql::Logger ret{"build"};

--- a/swift/swift-autobuilder/BuildRunner.cpp
+++ b/swift/swift-autobuilder/BuildRunner.cpp
@@ -8,10 +8,10 @@
 #include "swift/logging/SwiftLogging.h"
 #include "swift/swift-autobuilder/CustomizingBuildLink.h"
 
-constexpr codeql::Diagnostic buildCommandFailed = codeql::swiftDiagnostic(
-    "build-command-failed", "Detected build command failed",
-    "Set up a [manual build command][1] or [check the logs of the autobuild step][2].\n"
-    "\n[1]: " MANUAL_BUILD_COMMAND_HELP_LINK "\n[2]: " CHECK_LOGS_HELP_LINK);
+constexpr codeql::Diagnostic buildCommandFailed = codeql::Diagnostic{
+    .id="build-command-failed", .name="Detected build command failed",
+    .action="Set up a [manual build command][1] or [check the logs of the autobuild step][2].\n"
+    "\n[1]: " MANUAL_BUILD_COMMAND_HELP_LINK "\n[2]: " CHECK_LOGS_HELP_LINK};
 
 static codeql::Logger& logger() {
   static codeql::Logger ret{"build"};

--- a/swift/swift-autobuilder/BuildRunner.cpp
+++ b/swift/swift-autobuilder/BuildRunner.cpp
@@ -8,10 +8,11 @@
 #include "swift/logging/SwiftLogging.h"
 #include "swift/swift-autobuilder/CustomizingBuildLink.h"
 
-constexpr codeql::Diagnostic buildCommandFailed = codeql::Diagnostic{
-    .id="build-command-failed", .name="Detected build command failed",
-    .action="Set up a [manual build command][1] or [check the logs of the autobuild step][2].\n"
-    "\n[1]: " MANUAL_BUILD_COMMAND_HELP_LINK "\n[2]: " CHECK_LOGS_HELP_LINK};
+constexpr codeql::Diagnostic buildCommandFailed{
+    .id = "build-command-failed",
+    .name = "Detected build command failed",
+    .action = "Set up a [manual build command][1] or [check the logs of the autobuild step][2].\n"
+              "\n[1]: " MANUAL_BUILD_COMMAND_HELP_LINK "\n[2]: " CHECK_LOGS_HELP_LINK};
 
 static codeql::Logger& logger() {
   static codeql::Logger ret{"build"};

--- a/swift/swift-autobuilder/swift-autobuilder.cpp
+++ b/swift/swift-autobuilder/swift-autobuilder.cpp
@@ -13,16 +13,16 @@ static constexpr std::string_view unknownType = "<unknown_target_type>";
 
 const std::string_view codeql::programName = "autobuilder";
 
-constexpr codeql::SwiftDiagnostic noProjectFound{
-    .id = "no-project-found",
-    .name = "No Xcode project or workspace found",
-    .action = "Set up a [manual build command][1].\n\n[1]: " MANUAL_BUILD_COMMAND_HELP_LINK};
+constexpr codeql::Diagnostic noProjectFound = codeql::swiftDiagnostic(
+    "no-project-found",
+    "No Xcode project or workspace found",
+    "Set up a [manual build command][1].\n\n[1]: " MANUAL_BUILD_COMMAND_HELP_LINK);
 
-constexpr codeql::SwiftDiagnostic noSwiftTarget{
-    .id = "no-swift-target",
-    .name = "No Swift compilation target found",
-    .action = "To analyze a custom set of source files, set up a [manual build "
-              "command][1].\n\n[1]: " MANUAL_BUILD_COMMAND_HELP_LINK};
+constexpr codeql::Diagnostic noSwiftTarget = codeql::swiftDiagnostic(
+    "no-swift-target",
+    "No Swift compilation target found",
+    "To analyze a custom set of source files, set up a [manual build "
+              "command][1].\n\n[1]: " MANUAL_BUILD_COMMAND_HELP_LINK);
 
 static codeql::Logger& logger() {
   static codeql::Logger ret{"main"};

--- a/swift/swift-autobuilder/swift-autobuilder.cpp
+++ b/swift/swift-autobuilder/swift-autobuilder.cpp
@@ -14,15 +14,15 @@ static constexpr std::string_view unknownType = "<unknown_target_type>";
 const std::string_view codeql::programName = "autobuilder";
 const std::string_view codeql::extractorName = "swift";
 
-constexpr codeql::Diagnostic noProjectFound = codeql::Diagnostic{
-    .id="no-project-found",
-    .name="No Xcode project or workspace found",
-    .action="Set up a [manual build command][1].\n\n[1]: " MANUAL_BUILD_COMMAND_HELP_LINK};
+constexpr codeql::Diagnostic noProjectFound{
+    .id = "no-project-found",
+    .name = "No Xcode project or workspace found",
+    .action = "Set up a [manual build command][1].\n\n[1]: " MANUAL_BUILD_COMMAND_HELP_LINK};
 
-constexpr codeql::Diagnostic noSwiftTarget = codeql::Diagnostic{
-    .id="no-swift-target",
-    .name="No Swift compilation target found",
-    .action="To analyze a custom set of source files, set up a [manual build "
+constexpr codeql::Diagnostic noSwiftTarget{
+    .id = "no-swift-target",
+    .name = "No Swift compilation target found",
+    .action = "To analyze a custom set of source files, set up a [manual build "
               "command][1].\n\n[1]: " MANUAL_BUILD_COMMAND_HELP_LINK};
 
 static codeql::Logger& logger() {

--- a/swift/swift-autobuilder/swift-autobuilder.cpp
+++ b/swift/swift-autobuilder/swift-autobuilder.cpp
@@ -12,17 +12,18 @@ static constexpr std::string_view unitTest = "com.apple.product-type.bundle.unit
 static constexpr std::string_view unknownType = "<unknown_target_type>";
 
 const std::string_view codeql::programName = "autobuilder";
+const std::string_view codeql::extractorName = "swift";
 
-constexpr codeql::Diagnostic noProjectFound = codeql::swiftDiagnostic(
-    "no-project-found",
-    "No Xcode project or workspace found",
-    "Set up a [manual build command][1].\n\n[1]: " MANUAL_BUILD_COMMAND_HELP_LINK);
+constexpr codeql::Diagnostic noProjectFound = codeql::Diagnostic{
+    .id="no-project-found",
+    .name="No Xcode project or workspace found",
+    .action="Set up a [manual build command][1].\n\n[1]: " MANUAL_BUILD_COMMAND_HELP_LINK};
 
-constexpr codeql::Diagnostic noSwiftTarget = codeql::swiftDiagnostic(
-    "no-swift-target",
-    "No Swift compilation target found",
-    "To analyze a custom set of source files, set up a [manual build "
-              "command][1].\n\n[1]: " MANUAL_BUILD_COMMAND_HELP_LINK);
+constexpr codeql::Diagnostic noSwiftTarget = codeql::Diagnostic{
+    .id="no-swift-target",
+    .name="No Swift compilation target found",
+    .action="To analyze a custom set of source files, set up a [manual build "
+              "command][1].\n\n[1]: " MANUAL_BUILD_COMMAND_HELP_LINK};
 
 static codeql::Logger& logger() {
   static codeql::Logger ret{"main"};

--- a/swift/tools/diagnostics/AutobuilderIncompatibleOs.cpp
+++ b/swift/tools/diagnostics/AutobuilderIncompatibleOs.cpp
@@ -9,7 +9,7 @@
 const std::string_view codeql::programName = "autobuilder";
 const std::string_view codeql::extractorName = "swift";
 
-constexpr codeql::Diagnostic incompatibleOs = codeql::Diagnostic{
+constexpr codeql::Diagnostic incompatibleOs{
     .id = "incompatible-os",
     .name = "Incompatible operating system (expected macOS)",
     .action =

--- a/swift/tools/diagnostics/AutobuilderIncompatibleOs.cpp
+++ b/swift/tools/diagnostics/AutobuilderIncompatibleOs.cpp
@@ -8,23 +8,22 @@
 
 const std::string_view codeql::programName = "autobuilder";
 
-constexpr codeql::SwiftDiagnostic incompatibleOs{
-    .id = "incompatible-os",
-    .name = "Incompatible operating system (expected macOS)",
-    .action =
-        "[Change the Actions runner][1] to run on macOS.\n"
-        "\n"
-        "You may be able to run analysis on Linux by setting up a [manual build command][2].\n"
-        "\n"
-        "[1]: "
-        "https://docs.github.com/en/actions/using-workflows/"
-        "workflow-syntax-for-github-actions#jobsjob_idruns-on\n"
-        "[2]: "
-        "https://docs.github.com/en/enterprise-server/code-security/code-scanning/"
-        "automatically-scanning-your-code-for-vulnerabilities-and-errors/"
-        "configuring-the-codeql-workflow-for-compiled-languages#adding-build-steps-for-a-compiled-"
-        "language",
-};
+constexpr codeql::Diagnostic incompatibleOs = codeql::swiftDiagnostic(
+    "incompatible-os",
+    "Incompatible operating system (expected macOS)",
+    "[Change the Actions runner][1] to run on macOS.\n"
+    "\n"
+    "You may be able to run analysis on Linux by setting up a [manual build command][2].\n"
+    "\n"
+    "[1]: "
+    "https://docs.github.com/en/actions/using-workflows/"
+    "workflow-syntax-for-github-actions#jobsjob_idruns-on\n"
+    "[2]: "
+    "https://docs.github.com/en/enterprise-server/code-security/code-scanning/"
+    "automatically-scanning-your-code-for-vulnerabilities-and-errors/"
+    "configuring-the-codeql-workflow-for-compiled-languages#adding-build-steps-for-a-"
+    "compiled-"
+    "language");
 
 static codeql::Logger& logger() {
   static codeql::Logger ret{"main"};

--- a/swift/tools/diagnostics/AutobuilderIncompatibleOs.cpp
+++ b/swift/tools/diagnostics/AutobuilderIncompatibleOs.cpp
@@ -9,22 +9,23 @@
 const std::string_view codeql::programName = "autobuilder";
 const std::string_view codeql::extractorName = "swift";
 
-constexpr codeql::Diagnostic incompatibleOs = codeql::Diagnostic(
-    .id="incompatible-os",
-    .name="Incompatible operating system (expected macOS)",
-    .action="[Change the Actions runner][1] to run on macOS.\n"
-    "\n"
-    "You may be able to run analysis on Linux by setting up a [manual build command][2].\n"
-    "\n"
-    "[1]: "
-    "https://docs.github.com/en/actions/using-workflows/"
-    "workflow-syntax-for-github-actions#jobsjob_idruns-on\n"
-    "[2]: "
-    "https://docs.github.com/en/enterprise-server/code-security/code-scanning/"
-    "automatically-scanning-your-code-for-vulnerabilities-and-errors/"
-    "configuring-the-codeql-workflow-for-compiled-languages#adding-build-steps-for-a-"
-    "compiled-"
-    "language");
+constexpr codeql::Diagnostic incompatibleOs = codeql::Diagnostic{
+    .id = "incompatible-os",
+    .name = "Incompatible operating system (expected macOS)",
+    .action =
+        "[Change the Actions runner][1] to run on macOS.\n"
+        "\n"
+        "You may be able to run analysis on Linux by setting up a [manual build command][2].\n"
+        "\n"
+        "[1]: "
+        "https://docs.github.com/en/actions/using-workflows/"
+        "workflow-syntax-for-github-actions#jobsjob_idruns-on\n"
+        "[2]: "
+        "https://docs.github.com/en/enterprise-server/code-security/code-scanning/"
+        "automatically-scanning-your-code-for-vulnerabilities-and-errors/"
+        "configuring-the-codeql-workflow-for-compiled-languages#adding-build-steps-for-a-"
+        "compiled-"
+        "language"};
 
 static codeql::Logger& logger() {
   static codeql::Logger ret{"main"};

--- a/swift/tools/diagnostics/AutobuilderIncompatibleOs.cpp
+++ b/swift/tools/diagnostics/AutobuilderIncompatibleOs.cpp
@@ -7,11 +7,12 @@
 #include "swift/logging/SwiftLogging.h"
 
 const std::string_view codeql::programName = "autobuilder";
+const std::string_view codeql::extractorName = "swift";
 
-constexpr codeql::Diagnostic incompatibleOs = codeql::swiftDiagnostic(
-    "incompatible-os",
-    "Incompatible operating system (expected macOS)",
-    "[Change the Actions runner][1] to run on macOS.\n"
+constexpr codeql::Diagnostic incompatibleOs = codeql::Diagnostic(
+    .id="incompatible-os",
+    .name="Incompatible operating system (expected macOS)",
+    .action="[Change the Actions runner][1] to run on macOS.\n"
     "\n"
     "You may be able to run analysis on Linux by setting up a [manual build command][2].\n"
     "\n"


### PR DESCRIPTION
In preparation for reusing this code for the C++ extractor telemetry,

* Rename `codeql::SwiftDiagnostic` to `codeql::Diagnostic`
* Provide `codeql::swiftDiagnostic()` to construct a Swift diagnostic.
