### PR TITLE
Add note about telemetry for CodeQL extension settings

### DIFF
--- a/docs/codeql/codeql-for-visual-studio-code/about-telemetry-in-codeql-for-visual-studio-code.rst
+++ b/docs/codeql/codeql-for-visual-studio-code/about-telemetry-in-codeql-for-visual-studio-code.rst
@@ -30,6 +30,7 @@ If you opt in, GitHub collects the following information related to the usage of
 - Randomly generated GUID that uniquely identifies a CodeQL extension installation. (Discarded before aggregation.)
 - IP address of the client sending the telemetry data. (Discarded before aggregation.)
 - Whether or not the ``codeQL.canary`` setting is enabled and set to ``true``.
+- Whether any :doc:`CodeQL extension settings <customizing-settings>` are configured.
 
 How long data is retained
 --------------------------


### PR DESCRIPTION
We plan to start collecting telemetry about which settings users are using in the CodeQL extension for VS Code, to help inform which features are useful or not. We currently only check for the `codeQL.canary` setting, but we'd like to extend this to others too, hence the slight change in wording!

For example, an upcoming change (https://github.com/github/vscode-codeql/pull/3238) will add telemetry for the `codeQL.addingDatabases.addDatabaseSourceToWorkspace` setting. 