### PR TITLE
Swift: Add `nomagic` to `Pattern.getMatchingExpr`

### DIFF
--- a/swift/ql/lib/codeql/swift/elements/pattern/Pattern.qll
+++ b/swift/ql/lib/codeql/swift/elements/pattern/Pattern.qll
@@ -54,6 +54,7 @@ class Pattern extends Generated::Pattern {
    * For example, in `switch .some(e) { case let .some(p): ... }`, the pattern `p`
    * is matched against the expression `e`.
    */
+  pragma[nomagic]
   Expr getMatchingExpr() {
     result = this.getImmediateMatchingExpr()
     or


### PR DESCRIPTION
This gets rid of the expensive magic here:
```ql
OIN `m#Pattern::Pattern.getMatchingExpr/0#a063c6af#bf#prev_delta` WITH `_Element::Generated::Element.getResolveStep/0#dispred#f0bb72ef_0#antijoin_rhs_Element::Generated::El__#join_rhs#2` ON FIRST 1 OUTPUT Rhs.1
                    
      399       ~1%    {1} r2 = JOIN `m#Pattern::Pattern.getMatchingExpr/0#a063c6af#bf#prev_delta` WITH `_Element::Generated::Element.getResolveStep/0#dispred#f0bb72ef_0#antijoin_rhs_Element::Generated::El__#join_rhs#1` ON FIRST 1 OUTPUT Rhs.1
                    
        54       ~0%    {1} r3 = JOIN `m#Pattern::Pattern.getMatchingExpr/0#a063c6af#bf#prev_delta` WITH `_Element::Generated::Element.getResolveStep/0#dispred#f0bb72ef_0#antijoin_rhs_Element::Generated::El__#join_rhs` ON FIRST 1 OUTPUT Rhs.1
                    
      1784       ~0%    {2} r4 = JOIN `m#Pattern::Pattern.getMatchingExpr/0#a063c6af#bf#prev_delta` WITH `TuplePattern::Generated::TuplePattern.getElement/1#dispred#6d8fa592_201#join_rhs` ON FIRST 1 OUTPUT Rhs.2, Rhs.1
  8436693      ~78%    {2}    | JOIN WITH `TupleExpr::Generated::TupleExpr.getImmediateElement/1#dispred#96eaeafe_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
                        {2}    | AND NOT `Expr::Expr.getResolveStep/0#dispred#4ec712a3_0#antijoin_rhs`(FIRST 1)
  8436655  ~906650%    {1}    | SCAN OUTPUT In.1
                    
  8488265   ~21502%    {1} r5 = r1 UNION r2 UNION r3 UNION r4
  3846965    ~7170%    {1}    | AND NOT `m#Pattern::Pattern.getMatchingExpr/0#a063c6af#bf#prev`(FIRST 1)
                        return r5
```
This was identified by the join-order analysis on the DCA run from [this PR](https://github.com/github/codeql/pull/15219).