### PR TITLE
JS/PY/JAVA/RB: mark the range [0-?] as good in the overly-large-range query

### DIFF
--- a/javascript/ql/test/query-tests/Security/CWE-020/SuspiciousRegexpRange/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-020/SuspiciousRegexpRange/tst.js
@@ -28,3 +28,5 @@ var overlapsWithClass2 = /[\w,.-?:*+]/; // NOT OK
 
 var tst2 = /^([ァ-ヾ]|[ｧ-ﾝﾞﾟ])+$/; // OK
 var tst3 = /[0-9０-９]/; // OK
+
+var question = /[0-?]/; // OK. matches one of: 0123456789:;<=>?

--- a/shared/regex/codeql/regex/OverlyLargeRangeQuery.qll
+++ b/shared/regex/codeql/regex/OverlyLargeRangeQuery.qll
@@ -129,6 +129,9 @@ module Make<RegexTreeViewSig TreeImpl> {
     or
     // starting from the zero byte is a good indication that it's purposely matching a large range.
     result.isRange(0.toUnicode(), _)
+    or
+    // the range 0123456789:;<=>? is intentional
+    result.isRange("0", "?")
   }
 
   /** Gets a char between (and including) `low` and `high`. */


### PR DESCRIPTION
Throwing the Python team is as reviewers because we found some FPs during some triage. 

Evaluations (see backrefs) look good. 