### PR TITLE
Ruby: Do not generate reverse stores from attribute reads

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -657,6 +657,7 @@ private module Cached {
   cached
   newtype TOptionalContentSet =
     TSingletonContent(Content c) or
+    TAttributeReaderContent(Content::FieldContent f) or
     TAnyElementContent() or
     TKnownOrUnknownElementContent(Content::KnownElementContent c) or
     TElementLowerBoundContent(int lower, boolean includeUnknown) {
@@ -669,8 +670,8 @@ private module Cached {
 
   cached
   class TContentSet =
-    TSingletonContent or TAnyElementContent or TKnownOrUnknownElementContent or
-        TElementLowerBoundContent or TElementContentOfTypeContent;
+    TSingletonContent or TAttributeReaderContent or TAnyElementContent or
+        TKnownOrUnknownElementContent or TElementLowerBoundContent or TElementContentOfTypeContent;
 
   private predicate trackKnownValue(ConstantValue cv) {
     not cv.isFloat(_) and
@@ -1822,7 +1823,7 @@ predicate readStep(Node node1, ContentSet c, Node node2) {
       node1.asExpr() =
         any(CfgNodes::ExprCfgNode e | e = call.getReceiver() and isNonConstantExpr(e)) and
       call.getNumberOfArguments() = 0 and
-      c.isSingleton(any(Content::FieldContent ct |
+      c.isAttributeReaderContent(any(Content::FieldContent ct |
           ct.getName() = "@" + call.getExpr().getMethodName()
         ))
     )

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
@@ -686,6 +686,13 @@ class ContentSet extends TContentSet {
   /** Holds if this content set is the singleton `{c}`. */
   predicate isSingleton(Content c) { this = TSingletonContent(c) }
 
+  /**
+   * Holds if this content set represents reading field `f` using an attribute reader.
+   *
+   * This differs from `isSingleton(f)` in that no reverse store steps are generated.
+   */
+  predicate isAttributeReaderContent(Content::FieldContent f) { this = TAttributeReaderContent(f) }
+
   /** Holds if this content set represents all `ElementContent`s. */
   predicate isAnyElement() { this = TAnyElementContent() }
 
@@ -734,6 +741,11 @@ class ContentSet extends TContentSet {
       result = c.toString()
     )
     or
+    exists(Content::FieldContent f |
+      this.isAttributeReaderContent(f) and
+      result = f.toString()
+    )
+    or
     this.isAnyElement() and
     result = "any element"
     or
@@ -767,6 +779,8 @@ class ContentSet extends TContentSet {
   Content getAStoreContent() {
     this.isSingleton(result)
     or
+    // no entry for `isAttributeReaderContent`
+    //
     // For reverse stores, `a[unknown][0] = x`, it is important that the read-step
     // from `a` to `a[unknown]` (which can read any element), gets translated into
     // a reverse store step that store only into `?`
@@ -793,6 +807,8 @@ class ContentSet extends TContentSet {
   /** Gets a content that may be read from when reading from this set. */
   Content getAReadContent() {
     this.isSingleton(result)
+    or
+    this.isAttributeReaderContent(result)
     or
     this.isAnyElement() and
     result instanceof Content::ElementContent


### PR DESCRIPTION
Attribute read steps are [not checked to actually be attribute reads](https://github.com/github/codeql/blob/main/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll#L1816-L1828), since they need to match up with a corresponding store. However, we did not take into account that they could still give rise to (incorrect) reverse stores, which this PR removes.