### PR TITLE
C#: Consider nullable simple types as sanitizers.

### DIFF
--- a/csharp/ql/lib/change-notes/2024-01-18-simpletype-sanitizer.md
+++ b/csharp/ql/lib/change-notes/2024-01-18-simpletype-sanitizer.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Fixed a Log forging false positive when logging the value of a nullable simple type. This fix also applies to all other queries that use the simple type sanitizer.

--- a/csharp/ql/lib/semmle/code/csharp/security/Sanitizers.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/Sanitizers.qll
@@ -55,7 +55,7 @@ class UrlSanitizedExpr extends Expr {
  */
 class SimpleTypeSanitizedExpr extends DataFlow::ExprNode {
   SimpleTypeSanitizedExpr() {
-    exists(Type t | t = this.getType() |
+    exists(Type t | t = this.getType() or t = this.getType().(NullableType).getUnderlyingType() |
       t instanceof SimpleType or
       t instanceof SystemDateTimeStruct
     )

--- a/csharp/ql/test/query-tests/Security Features/CWE-117/LogForging.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-117/LogForging.expected
@@ -7,6 +7,8 @@ edges
 | LogForging.cs:18:27:18:61 | access to indexer : String | LogForging.cs:29:50:29:72 | ... + ... |
 | LogForging.cs:18:27:18:61 | access to indexer : String | LogForging.cs:33:26:33:33 | access to local variable username |
 | LogForgingAsp.cs:8:32:8:39 | username : String | LogForgingAsp.cs:12:21:12:43 | ... + ... |
+| LogForgingAsp.cs:22:35:22:38 | date : Nullable<DateTime> | LogForgingAsp.cs:28:25:28:68 | $"..." |
+| LogForgingAsp.cs:32:31:32:31 | b : Nullable<Boolean> | LogForgingAsp.cs:38:25:38:54 | $"..." |
 nodes
 | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
 | LogForging.cs:18:27:18:61 | access to indexer : String | semmle.label | access to indexer : String |
@@ -15,9 +17,15 @@ nodes
 | LogForging.cs:33:26:33:33 | access to local variable username | semmle.label | access to local variable username |
 | LogForgingAsp.cs:8:32:8:39 | username : String | semmle.label | username : String |
 | LogForgingAsp.cs:12:21:12:43 | ... + ... | semmle.label | ... + ... |
+| LogForgingAsp.cs:22:35:22:38 | date : Nullable<DateTime> | semmle.label | date : Nullable<DateTime> |
+| LogForgingAsp.cs:28:25:28:68 | $"..." | semmle.label | $"..." |
+| LogForgingAsp.cs:32:31:32:31 | b : Nullable<Boolean> | semmle.label | b : Nullable<Boolean> |
+| LogForgingAsp.cs:38:25:38:54 | $"..." | semmle.label | $"..." |
 subpaths
 #select
 | LogForging.cs:21:21:21:43 | ... + ... | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:21:21:21:43 | ... + ... | This log entry depends on a $@. | LogForging.cs:18:27:18:49 | access to property QueryString | user-provided value |
 | LogForging.cs:29:50:29:72 | ... + ... | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:29:50:29:72 | ... + ... | This log entry depends on a $@. | LogForging.cs:18:27:18:49 | access to property QueryString | user-provided value |
 | LogForging.cs:33:26:33:33 | access to local variable username | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:33:26:33:33 | access to local variable username | This log entry depends on a $@. | LogForging.cs:18:27:18:49 | access to property QueryString | user-provided value |
 | LogForgingAsp.cs:12:21:12:43 | ... + ... | LogForgingAsp.cs:8:32:8:39 | username : String | LogForgingAsp.cs:12:21:12:43 | ... + ... | This log entry depends on a $@. | LogForgingAsp.cs:8:32:8:39 | username | user-provided value |
+| LogForgingAsp.cs:28:25:28:68 | $"..." | LogForgingAsp.cs:22:35:22:38 | date : Nullable<DateTime> | LogForgingAsp.cs:28:25:28:68 | $"..." | This log entry depends on a $@. | LogForgingAsp.cs:22:35:22:38 | date | user-provided value |
+| LogForgingAsp.cs:38:25:38:54 | $"..." | LogForgingAsp.cs:32:31:32:31 | b : Nullable<Boolean> | LogForgingAsp.cs:38:25:38:54 | $"..." | This log entry depends on a $@. | LogForgingAsp.cs:32:31:32:31 | b | user-provided value |

--- a/csharp/ql/test/query-tests/Security Features/CWE-117/LogForging.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-117/LogForging.expected
@@ -7,8 +7,6 @@ edges
 | LogForging.cs:18:27:18:61 | access to indexer : String | LogForging.cs:29:50:29:72 | ... + ... |
 | LogForging.cs:18:27:18:61 | access to indexer : String | LogForging.cs:33:26:33:33 | access to local variable username |
 | LogForgingAsp.cs:8:32:8:39 | username : String | LogForgingAsp.cs:12:21:12:43 | ... + ... |
-| LogForgingAsp.cs:22:35:22:38 | date : Nullable<DateTime> | LogForgingAsp.cs:28:25:28:68 | $"..." |
-| LogForgingAsp.cs:32:31:32:31 | b : Nullable<Boolean> | LogForgingAsp.cs:38:25:38:54 | $"..." |
 nodes
 | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
 | LogForging.cs:18:27:18:61 | access to indexer : String | semmle.label | access to indexer : String |
@@ -17,15 +15,9 @@ nodes
 | LogForging.cs:33:26:33:33 | access to local variable username | semmle.label | access to local variable username |
 | LogForgingAsp.cs:8:32:8:39 | username : String | semmle.label | username : String |
 | LogForgingAsp.cs:12:21:12:43 | ... + ... | semmle.label | ... + ... |
-| LogForgingAsp.cs:22:35:22:38 | date : Nullable<DateTime> | semmle.label | date : Nullable<DateTime> |
-| LogForgingAsp.cs:28:25:28:68 | $"..." | semmle.label | $"..." |
-| LogForgingAsp.cs:32:31:32:31 | b : Nullable<Boolean> | semmle.label | b : Nullable<Boolean> |
-| LogForgingAsp.cs:38:25:38:54 | $"..." | semmle.label | $"..." |
 subpaths
 #select
 | LogForging.cs:21:21:21:43 | ... + ... | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:21:21:21:43 | ... + ... | This log entry depends on a $@. | LogForging.cs:18:27:18:49 | access to property QueryString | user-provided value |
 | LogForging.cs:29:50:29:72 | ... + ... | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:29:50:29:72 | ... + ... | This log entry depends on a $@. | LogForging.cs:18:27:18:49 | access to property QueryString | user-provided value |
 | LogForging.cs:33:26:33:33 | access to local variable username | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:33:26:33:33 | access to local variable username | This log entry depends on a $@. | LogForging.cs:18:27:18:49 | access to property QueryString | user-provided value |
 | LogForgingAsp.cs:12:21:12:43 | ... + ... | LogForgingAsp.cs:8:32:8:39 | username : String | LogForgingAsp.cs:12:21:12:43 | ... + ... | This log entry depends on a $@. | LogForgingAsp.cs:8:32:8:39 | username | user-provided value |
-| LogForgingAsp.cs:28:25:28:68 | $"..." | LogForgingAsp.cs:22:35:22:38 | date : Nullable<DateTime> | LogForgingAsp.cs:28:25:28:68 | $"..." | This log entry depends on a $@. | LogForgingAsp.cs:22:35:22:38 | date | user-provided value |
-| LogForgingAsp.cs:38:25:38:54 | $"..." | LogForgingAsp.cs:32:31:32:31 | b : Nullable<Boolean> | LogForgingAsp.cs:38:25:38:54 | $"..." | This log entry depends on a $@. | LogForgingAsp.cs:32:31:32:31 | b | user-provided value |

--- a/csharp/ql/test/query-tests/Security Features/CWE-117/LogForgingAsp.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-117/LogForgingAsp.cs
@@ -18,4 +18,24 @@ public class AspController : ControllerBase
         // GOOD: DateTime is a sanitizer.
         logger.Warn($"Warning about the date: {date:yyyy-MM-dd}");
     }
+
+    public void Action2(DateTime? date)
+    {
+        var logger = new ILogger();
+        if (date is not null)
+        {
+            // GOOD: DateTime? is a sanitizer.
+            logger.Warn($"Warning about the date: {date:yyyy-MM-dd}");
+        }
+    }
+
+    public void Action2(bool? b)
+    {
+        var logger = new ILogger();
+        if (b is not null)
+        {
+            // GOOD: Boolean? is a sanitizer.
+            logger.Warn($"Warning about the bool: {b}");
+        }
+    }
 }


### PR DESCRIPTION
In this PR we fix a range of false positives for queries that use *simple* type sanitizers.

Before this change, the following action method in an ASP.NET controller would lead to log forging alert
```csharp
 public void Action(bool? b)
    {
        var logger = new ILogger();
        if (b is not null)
        {
            // GOOD: Boolean? is a sanitizer.
            logger.Warn($"Warning about the bool: {b}");
        }
    }
```
With the change in this PR, we now consider nullable *simple* types as sanitizers as well - removing the above alert.