### PR TITLE
Note AWS Lambda support

### DIFF
--- a/docs/codeql/reusables/supported-frameworks.rst
+++ b/docs/codeql/reusables/supported-frameworks.rst
@@ -51,6 +51,7 @@ and the CodeQL library pack ``codeql/go-all`` (`changelog <https://github.com/gi
    :widths: auto
 
    Name, Category
+   `AWS Lambda <https://docs.aws.amazon.com/lambda/latest/dg/lambda-golang.html>`_, Web framework
    `beego <https://beego.me/>`_, Web/logging/database framework
    `Chi <https://github.com/go-chi/chi>`_, Web framework
    Couchbase (`gocb <https://github.com/couchbase/gocb>`_ and `go-couchbase <http://www.github.com/couchbase/go-couchbase>`_), Database
@@ -144,6 +145,7 @@ and the CodeQL library pack ``codeql/javascript-all`` (`changelog <https://githu
    Name, Category
    angular (modern version), HTML framework
    angular.js (legacy version), HTML framework
+   AWS Lambda, Serverless framework
    axios, Network communicator
    browser, Runtime environment
    EJS, templating language
@@ -191,7 +193,7 @@ and the CodeQL library pack ``codeql/python-all`` (`changelog <https://github.co
    :widths: auto
 
    Name, Category
-   AWS Lambda, Web framework
+   AWS Lambda, Serverless framework
    aiohttp.web, Web framework
    Django, Web framework
    djangorestframework, Web framework

--- a/docs/codeql/reusables/supported-frameworks.rst
+++ b/docs/codeql/reusables/supported-frameworks.rst
@@ -51,7 +51,7 @@ and the CodeQL library pack ``codeql/go-all`` (`changelog <https://github.com/gi
    :widths: auto
 
    Name, Category
-   `AWS Lambda <https://docs.aws.amazon.com/lambda/latest/dg/lambda-golang.html>`_, Web framework
+   `AWS Lambda <https://docs.aws.amazon.com/lambda/latest/dg/lambda-golang.html>`_, Serverless framework
    `beego <https://beego.me/>`_, Web/logging/database framework
    `Chi <https://github.com/go-chi/chi>`_, Web framework
    Couchbase (`gocb <https://github.com/couchbase/gocb>`_ and `go-couchbase <http://www.github.com/couchbase/go-couchbase>`_), Database


### PR DESCRIPTION
JS/TS support is old; noting for symmetry with advertised support in Python. Golang support is new as of https://github.com/github/codeql/pull/15373

Describe it as a "serverless framework" for all, since it's a bit different from your typical web framework.