### PR TITLE
C#: Add more santizers to the `cs/web/unvalidated-url-redirection` query.

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/frameworks/Format.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/Format.qll
@@ -134,7 +134,7 @@ class ValidFormatString extends StringLiteral {
     result = this.getValue().regexpFind(getValidFormatTokenRegex(), _, outPosition)
   }
 
-  /**Gets the insert number at the given position in the string. */
+  /** Gets the insert number at the given position in the string. */
   int getInsert(int position) {
     result = this.getToken(position).regexpCapture(getFormatInsertRegex(), 1).toInt()
   }

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/UrlRedirectQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/UrlRedirectQuery.qll
@@ -184,8 +184,12 @@ private class InterpolationSanitizer extends Sanitizer {
  */
 private class StringFormatSanitizer extends Sanitizer {
   StringFormatSanitizer() {
-    exists(FormatCall c, Expr e | c = this.getExpr() and e = c.getFormatExpr() |
-      e.(StringLiteral).getValue().splitAt("{0}", 0).matches("%?%")
+    exists(FormatCall c, Expr e, int index, string format |
+      c = this.getExpr() and e = c.getFormatExpr()
+    |
+      format = e.(StringLiteral).getValue() and
+      exists(format.regexpFind("\\{[0-9]+\\}", 0, index)) and
+      format.substring(0, index).matches("%?%")
     )
   }
 }

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/UrlRedirectQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/UrlRedirectQuery.qll
@@ -163,6 +163,18 @@ class ConcatenationSanitizer extends Sanitizer {
   }
 }
 
+/**
+ * A string interpolation expression, where the first part (before any inserts) of the
+ * expression contains the character "?".
+ *
+ * This is considered a sanitizer by the same reasoning as `ConcatenationSanitizer`.
+ */
+private class InterpolationSanitizer extends Sanitizer {
+  InterpolationSanitizer() {
+    this.getExpr().(InterpolatedStringExpr).getText(0).getValue().matches("%?%")
+  }
+}
+
 /** A call to an URL encoder. */
 class UrlEncodeSanitizer extends Sanitizer {
   UrlEncodeSanitizer() { this.getExpr() instanceof UrlSanitizedExpr }

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/UrlRedirectQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/UrlRedirectQuery.qll
@@ -5,6 +5,7 @@
 import csharp
 private import semmle.code.csharp.security.dataflow.flowsources.Remote
 private import semmle.code.csharp.controlflow.Guards
+private import semmle.code.csharp.frameworks.Format
 private import semmle.code.csharp.frameworks.system.Web
 private import semmle.code.csharp.frameworks.system.web.Mvc
 private import semmle.code.csharp.security.Sanitizers
@@ -172,6 +173,20 @@ class ConcatenationSanitizer extends Sanitizer {
 private class InterpolationSanitizer extends Sanitizer {
   InterpolationSanitizer() {
     this.getExpr().(InterpolatedStringExpr).getText(0).getValue().matches("%?%")
+  }
+}
+
+/**
+ * A call to `string.Format`, where the format expression (before any inserts)
+ * contains the character "?".
+ *
+ * This is considered a sanitizer by the same reasoning as `ConcatenationSanitizer`.
+ */
+private class StringFormatSanitizer extends Sanitizer {
+  StringFormatSanitizer() {
+    exists(FormatCall c, Expr e | c = this.getExpr() and e = c.getFormatExpr() |
+      e.(StringLiteral).getValue().splitAt("{0}", 0).matches("%?%")
+    )
   }
 }
 

--- a/csharp/ql/src/change-notes/2024-01-22-url-redirect-sanitizer.md
+++ b/csharp/ql/src/change-notes/2024-01-22-url-redirect-sanitizer.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added string interpolation expressions and `string.Format` as possible sanitizers for the `cs/web/unvalidated-url-redirection` query.

--- a/csharp/ql/test/query-tests/Security Features/CWE-601/UrlRedirect/UrlRedirect.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-601/UrlRedirect/UrlRedirect.cs
@@ -68,6 +68,12 @@ public class UrlRedirectHandler : IHttpHandler
 
         // BAD: The attacker can control the location
         ctx.Response.Redirect(string.Format("{0}.asp?param=foo", url));
+
+        // GOOD: The attacker can only control the parameters, not the location
+        ctx.Response.Redirect(string.Format("foo.asp?{1}param={0}", url, url));
+
+        // BAD: The attacker can control the location
+        ctx.Response.Redirect(string.Format("{1}.asp?{0}param=foo", url, url));
     }
 
     // Implementation as recommended by Microsoft.

--- a/csharp/ql/test/query-tests/Security Features/CWE-601/UrlRedirect/UrlRedirect.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-601/UrlRedirect/UrlRedirect.cs
@@ -41,7 +41,7 @@ public class UrlRedirectHandler : IHttpHandler
         // GOOD: Redirecting to the RawUrl only reloads the current Url
         ctx.Response.Redirect(ctx.Request.RawUrl);
 
-        // GOOD: The attacker can only control the parameters, not the locaiton
+        // GOOD: The attacker can only control the parameters, not the location
         ctx.Response.Redirect("foo.asp?param=" + url);
 
         // BAD: Using Transfer with unvalidated user input
@@ -56,6 +56,18 @@ public class UrlRedirectHandler : IHttpHandler
         {
             ctx.Response.Redirect(url3);
         }
+
+        // GOOD: The attacker can only control the parameters, not the location
+        ctx.Response.Redirect($"foo.asp?param={url}");
+
+        // BAD: The attacker can control the location
+        ctx.Response.Redirect($"{url}.asp?param=foo");
+
+        // GOOD: The attacker can only control the parameters, not the location
+        ctx.Response.Redirect(string.Format("foo.asp?param={0}", url));
+
+        // BAD: The attacker can control the location
+        ctx.Response.Redirect(string.Format("{0}.asp?param=foo", url));
     }
 
     // Implementation as recommended by Microsoft.

--- a/csharp/ql/test/query-tests/Security Features/CWE-601/UrlRedirect/UrlRedirect.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-601/UrlRedirect/UrlRedirect.expected
@@ -2,12 +2,10 @@ edges
 | UrlRedirect.cs:13:31:13:53 | access to property QueryString : NameValueCollection | UrlRedirect.cs:13:31:13:61 | access to indexer |
 | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:23:22:23:52 | access to indexer : String |
 | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:48:29:48:31 | access to local variable url |
-| UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:61:31:61:52 | $"..." |
 | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:64:31:64:52 | $"..." |
 | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:67:66:67:68 | access to local variable url : String |
 | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:70:66:70:68 | access to local variable url : String |
 | UrlRedirect.cs:23:22:23:52 | access to indexer : String | UrlRedirect.cs:48:29:48:31 | access to local variable url |
-| UrlRedirect.cs:23:22:23:52 | access to indexer : String | UrlRedirect.cs:61:31:61:52 | $"..." |
 | UrlRedirect.cs:23:22:23:52 | access to indexer : String | UrlRedirect.cs:64:31:64:52 | $"..." |
 | UrlRedirect.cs:23:22:23:52 | access to indexer : String | UrlRedirect.cs:67:66:67:68 | access to local variable url : String |
 | UrlRedirect.cs:23:22:23:52 | access to indexer : String | UrlRedirect.cs:70:66:70:68 | access to local variable url : String |
@@ -36,7 +34,6 @@ nodes
 | UrlRedirect.cs:39:47:39:69 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
 | UrlRedirect.cs:39:47:39:77 | access to indexer | semmle.label | access to indexer |
 | UrlRedirect.cs:48:29:48:31 | access to local variable url | semmle.label | access to local variable url |
-| UrlRedirect.cs:61:31:61:52 | $"..." | semmle.label | $"..." |
 | UrlRedirect.cs:64:31:64:52 | $"..." | semmle.label | $"..." |
 | UrlRedirect.cs:67:31:67:69 | call to method Format | semmle.label | call to method Format |
 | UrlRedirect.cs:67:66:67:68 | access to local variable url : String | semmle.label | access to local variable url : String |
@@ -61,7 +58,6 @@ subpaths
 | UrlRedirect.cs:38:44:38:74 | access to indexer | UrlRedirect.cs:38:44:38:66 | access to property QueryString : NameValueCollection | UrlRedirect.cs:38:44:38:74 | access to indexer | Untrusted URL redirection due to $@. | UrlRedirect.cs:38:44:38:66 | access to property QueryString | user-provided value |
 | UrlRedirect.cs:39:47:39:77 | access to indexer | UrlRedirect.cs:39:47:39:69 | access to property QueryString : NameValueCollection | UrlRedirect.cs:39:47:39:77 | access to indexer | Untrusted URL redirection due to $@. | UrlRedirect.cs:39:47:39:69 | access to property QueryString | user-provided value |
 | UrlRedirect.cs:48:29:48:31 | access to local variable url | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:48:29:48:31 | access to local variable url | Untrusted URL redirection due to $@. | UrlRedirect.cs:23:22:23:44 | access to property QueryString | user-provided value |
-| UrlRedirect.cs:61:31:61:52 | $"..." | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:61:31:61:52 | $"..." | Untrusted URL redirection due to $@. | UrlRedirect.cs:23:22:23:44 | access to property QueryString | user-provided value |
 | UrlRedirect.cs:64:31:64:52 | $"..." | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:64:31:64:52 | $"..." | Untrusted URL redirection due to $@. | UrlRedirect.cs:23:22:23:44 | access to property QueryString | user-provided value |
 | UrlRedirect.cs:67:31:67:69 | call to method Format | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:67:31:67:69 | call to method Format | Untrusted URL redirection due to $@. | UrlRedirect.cs:23:22:23:44 | access to property QueryString | user-provided value |
 | UrlRedirect.cs:70:31:70:69 | call to method Format | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:70:31:70:69 | call to method Format | Untrusted URL redirection due to $@. | UrlRedirect.cs:23:22:23:44 | access to property QueryString | user-provided value |

--- a/csharp/ql/test/query-tests/Security Features/CWE-601/UrlRedirect/UrlRedirect.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-601/UrlRedirect/UrlRedirect.expected
@@ -3,15 +3,12 @@ edges
 | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:23:22:23:52 | access to indexer : String |
 | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:48:29:48:31 | access to local variable url |
 | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:64:31:64:52 | $"..." |
-| UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:67:66:67:68 | access to local variable url : String |
 | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:70:66:70:68 | access to local variable url : String |
 | UrlRedirect.cs:23:22:23:52 | access to indexer : String | UrlRedirect.cs:48:29:48:31 | access to local variable url |
 | UrlRedirect.cs:23:22:23:52 | access to indexer : String | UrlRedirect.cs:64:31:64:52 | $"..." |
-| UrlRedirect.cs:23:22:23:52 | access to indexer : String | UrlRedirect.cs:67:66:67:68 | access to local variable url : String |
 | UrlRedirect.cs:23:22:23:52 | access to indexer : String | UrlRedirect.cs:70:66:70:68 | access to local variable url : String |
 | UrlRedirect.cs:38:44:38:66 | access to property QueryString : NameValueCollection | UrlRedirect.cs:38:44:38:74 | access to indexer |
 | UrlRedirect.cs:39:47:39:69 | access to property QueryString : NameValueCollection | UrlRedirect.cs:39:47:39:77 | access to indexer |
-| UrlRedirect.cs:67:66:67:68 | access to local variable url : String | UrlRedirect.cs:67:31:67:69 | call to method Format |
 | UrlRedirect.cs:70:66:70:68 | access to local variable url : String | UrlRedirect.cs:70:31:70:69 | call to method Format |
 | UrlRedirectCore.cs:13:44:13:48 | value : String | UrlRedirectCore.cs:16:22:16:26 | access to parameter value |
 | UrlRedirectCore.cs:13:44:13:48 | value : String | UrlRedirectCore.cs:19:44:19:48 | call to operator implicit conversion |
@@ -35,8 +32,6 @@ nodes
 | UrlRedirect.cs:39:47:39:77 | access to indexer | semmle.label | access to indexer |
 | UrlRedirect.cs:48:29:48:31 | access to local variable url | semmle.label | access to local variable url |
 | UrlRedirect.cs:64:31:64:52 | $"..." | semmle.label | $"..." |
-| UrlRedirect.cs:67:31:67:69 | call to method Format | semmle.label | call to method Format |
-| UrlRedirect.cs:67:66:67:68 | access to local variable url : String | semmle.label | access to local variable url : String |
 | UrlRedirect.cs:70:31:70:69 | call to method Format | semmle.label | call to method Format |
 | UrlRedirect.cs:70:66:70:68 | access to local variable url : String | semmle.label | access to local variable url : String |
 | UrlRedirectCore.cs:13:44:13:48 | value : String | semmle.label | value : String |
@@ -59,7 +54,6 @@ subpaths
 | UrlRedirect.cs:39:47:39:77 | access to indexer | UrlRedirect.cs:39:47:39:69 | access to property QueryString : NameValueCollection | UrlRedirect.cs:39:47:39:77 | access to indexer | Untrusted URL redirection due to $@. | UrlRedirect.cs:39:47:39:69 | access to property QueryString | user-provided value |
 | UrlRedirect.cs:48:29:48:31 | access to local variable url | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:48:29:48:31 | access to local variable url | Untrusted URL redirection due to $@. | UrlRedirect.cs:23:22:23:44 | access to property QueryString | user-provided value |
 | UrlRedirect.cs:64:31:64:52 | $"..." | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:64:31:64:52 | $"..." | Untrusted URL redirection due to $@. | UrlRedirect.cs:23:22:23:44 | access to property QueryString | user-provided value |
-| UrlRedirect.cs:67:31:67:69 | call to method Format | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:67:31:67:69 | call to method Format | Untrusted URL redirection due to $@. | UrlRedirect.cs:23:22:23:44 | access to property QueryString | user-provided value |
 | UrlRedirect.cs:70:31:70:69 | call to method Format | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:70:31:70:69 | call to method Format | Untrusted URL redirection due to $@. | UrlRedirect.cs:23:22:23:44 | access to property QueryString | user-provided value |
 | UrlRedirectCore.cs:16:22:16:26 | access to parameter value | UrlRedirectCore.cs:13:44:13:48 | value : String | UrlRedirectCore.cs:16:22:16:26 | access to parameter value | Untrusted URL redirection due to $@. | UrlRedirectCore.cs:13:44:13:48 | value | user-provided value |
 | UrlRedirectCore.cs:19:44:19:48 | call to operator implicit conversion | UrlRedirectCore.cs:13:44:13:48 | value : String | UrlRedirectCore.cs:19:44:19:48 | call to operator implicit conversion | Untrusted URL redirection due to $@. | UrlRedirectCore.cs:13:44:13:48 | value | user-provided value |

--- a/csharp/ql/test/query-tests/Security Features/CWE-601/UrlRedirect/UrlRedirect.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-601/UrlRedirect/UrlRedirect.expected
@@ -4,12 +4,18 @@ edges
 | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:48:29:48:31 | access to local variable url |
 | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:64:31:64:52 | $"..." |
 | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:70:66:70:68 | access to local variable url : String |
+| UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:76:69:76:71 | access to local variable url : String |
+| UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:76:74:76:76 | access to local variable url : String |
 | UrlRedirect.cs:23:22:23:52 | access to indexer : String | UrlRedirect.cs:48:29:48:31 | access to local variable url |
 | UrlRedirect.cs:23:22:23:52 | access to indexer : String | UrlRedirect.cs:64:31:64:52 | $"..." |
 | UrlRedirect.cs:23:22:23:52 | access to indexer : String | UrlRedirect.cs:70:66:70:68 | access to local variable url : String |
+| UrlRedirect.cs:23:22:23:52 | access to indexer : String | UrlRedirect.cs:76:69:76:71 | access to local variable url : String |
+| UrlRedirect.cs:23:22:23:52 | access to indexer : String | UrlRedirect.cs:76:74:76:76 | access to local variable url : String |
 | UrlRedirect.cs:38:44:38:66 | access to property QueryString : NameValueCollection | UrlRedirect.cs:38:44:38:74 | access to indexer |
 | UrlRedirect.cs:39:47:39:69 | access to property QueryString : NameValueCollection | UrlRedirect.cs:39:47:39:77 | access to indexer |
 | UrlRedirect.cs:70:66:70:68 | access to local variable url : String | UrlRedirect.cs:70:31:70:69 | call to method Format |
+| UrlRedirect.cs:76:69:76:71 | access to local variable url : String | UrlRedirect.cs:76:31:76:77 | call to method Format |
+| UrlRedirect.cs:76:74:76:76 | access to local variable url : String | UrlRedirect.cs:76:31:76:77 | call to method Format |
 | UrlRedirectCore.cs:13:44:13:48 | value : String | UrlRedirectCore.cs:16:22:16:26 | access to parameter value |
 | UrlRedirectCore.cs:13:44:13:48 | value : String | UrlRedirectCore.cs:19:44:19:48 | call to operator implicit conversion |
 | UrlRedirectCore.cs:13:44:13:48 | value : String | UrlRedirectCore.cs:25:46:25:50 | call to operator implicit conversion |
@@ -34,6 +40,9 @@ nodes
 | UrlRedirect.cs:64:31:64:52 | $"..." | semmle.label | $"..." |
 | UrlRedirect.cs:70:31:70:69 | call to method Format | semmle.label | call to method Format |
 | UrlRedirect.cs:70:66:70:68 | access to local variable url : String | semmle.label | access to local variable url : String |
+| UrlRedirect.cs:76:31:76:77 | call to method Format | semmle.label | call to method Format |
+| UrlRedirect.cs:76:69:76:71 | access to local variable url : String | semmle.label | access to local variable url : String |
+| UrlRedirect.cs:76:74:76:76 | access to local variable url : String | semmle.label | access to local variable url : String |
 | UrlRedirectCore.cs:13:44:13:48 | value : String | semmle.label | value : String |
 | UrlRedirectCore.cs:16:22:16:26 | access to parameter value | semmle.label | access to parameter value |
 | UrlRedirectCore.cs:19:44:19:48 | call to operator implicit conversion | semmle.label | call to operator implicit conversion |
@@ -55,6 +64,7 @@ subpaths
 | UrlRedirect.cs:48:29:48:31 | access to local variable url | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:48:29:48:31 | access to local variable url | Untrusted URL redirection due to $@. | UrlRedirect.cs:23:22:23:44 | access to property QueryString | user-provided value |
 | UrlRedirect.cs:64:31:64:52 | $"..." | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:64:31:64:52 | $"..." | Untrusted URL redirection due to $@. | UrlRedirect.cs:23:22:23:44 | access to property QueryString | user-provided value |
 | UrlRedirect.cs:70:31:70:69 | call to method Format | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:70:31:70:69 | call to method Format | Untrusted URL redirection due to $@. | UrlRedirect.cs:23:22:23:44 | access to property QueryString | user-provided value |
+| UrlRedirect.cs:76:31:76:77 | call to method Format | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:76:31:76:77 | call to method Format | Untrusted URL redirection due to $@. | UrlRedirect.cs:23:22:23:44 | access to property QueryString | user-provided value |
 | UrlRedirectCore.cs:16:22:16:26 | access to parameter value | UrlRedirectCore.cs:13:44:13:48 | value : String | UrlRedirectCore.cs:16:22:16:26 | access to parameter value | Untrusted URL redirection due to $@. | UrlRedirectCore.cs:13:44:13:48 | value | user-provided value |
 | UrlRedirectCore.cs:19:44:19:48 | call to operator implicit conversion | UrlRedirectCore.cs:13:44:13:48 | value : String | UrlRedirectCore.cs:19:44:19:48 | call to operator implicit conversion | Untrusted URL redirection due to $@. | UrlRedirectCore.cs:13:44:13:48 | value | user-provided value |
 | UrlRedirectCore.cs:25:46:25:50 | call to operator implicit conversion | UrlRedirectCore.cs:13:44:13:48 | value : String | UrlRedirectCore.cs:25:46:25:50 | call to operator implicit conversion | Untrusted URL redirection due to $@. | UrlRedirectCore.cs:13:44:13:48 | value | user-provided value |

--- a/csharp/ql/test/query-tests/Security Features/CWE-601/UrlRedirect/UrlRedirect.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-601/UrlRedirect/UrlRedirect.expected
@@ -2,9 +2,19 @@ edges
 | UrlRedirect.cs:13:31:13:53 | access to property QueryString : NameValueCollection | UrlRedirect.cs:13:31:13:61 | access to indexer |
 | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:23:22:23:52 | access to indexer : String |
 | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:48:29:48:31 | access to local variable url |
+| UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:61:31:61:52 | $"..." |
+| UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:64:31:64:52 | $"..." |
+| UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:67:66:67:68 | access to local variable url : String |
+| UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:70:66:70:68 | access to local variable url : String |
 | UrlRedirect.cs:23:22:23:52 | access to indexer : String | UrlRedirect.cs:48:29:48:31 | access to local variable url |
+| UrlRedirect.cs:23:22:23:52 | access to indexer : String | UrlRedirect.cs:61:31:61:52 | $"..." |
+| UrlRedirect.cs:23:22:23:52 | access to indexer : String | UrlRedirect.cs:64:31:64:52 | $"..." |
+| UrlRedirect.cs:23:22:23:52 | access to indexer : String | UrlRedirect.cs:67:66:67:68 | access to local variable url : String |
+| UrlRedirect.cs:23:22:23:52 | access to indexer : String | UrlRedirect.cs:70:66:70:68 | access to local variable url : String |
 | UrlRedirect.cs:38:44:38:66 | access to property QueryString : NameValueCollection | UrlRedirect.cs:38:44:38:74 | access to indexer |
 | UrlRedirect.cs:39:47:39:69 | access to property QueryString : NameValueCollection | UrlRedirect.cs:39:47:39:77 | access to indexer |
+| UrlRedirect.cs:67:66:67:68 | access to local variable url : String | UrlRedirect.cs:67:31:67:69 | call to method Format |
+| UrlRedirect.cs:70:66:70:68 | access to local variable url : String | UrlRedirect.cs:70:31:70:69 | call to method Format |
 | UrlRedirectCore.cs:13:44:13:48 | value : String | UrlRedirectCore.cs:16:22:16:26 | access to parameter value |
 | UrlRedirectCore.cs:13:44:13:48 | value : String | UrlRedirectCore.cs:19:44:19:48 | call to operator implicit conversion |
 | UrlRedirectCore.cs:13:44:13:48 | value : String | UrlRedirectCore.cs:25:46:25:50 | call to operator implicit conversion |
@@ -26,6 +36,12 @@ nodes
 | UrlRedirect.cs:39:47:39:69 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
 | UrlRedirect.cs:39:47:39:77 | access to indexer | semmle.label | access to indexer |
 | UrlRedirect.cs:48:29:48:31 | access to local variable url | semmle.label | access to local variable url |
+| UrlRedirect.cs:61:31:61:52 | $"..." | semmle.label | $"..." |
+| UrlRedirect.cs:64:31:64:52 | $"..." | semmle.label | $"..." |
+| UrlRedirect.cs:67:31:67:69 | call to method Format | semmle.label | call to method Format |
+| UrlRedirect.cs:67:66:67:68 | access to local variable url : String | semmle.label | access to local variable url : String |
+| UrlRedirect.cs:70:31:70:69 | call to method Format | semmle.label | call to method Format |
+| UrlRedirect.cs:70:66:70:68 | access to local variable url : String | semmle.label | access to local variable url : String |
 | UrlRedirectCore.cs:13:44:13:48 | value : String | semmle.label | value : String |
 | UrlRedirectCore.cs:16:22:16:26 | access to parameter value | semmle.label | access to parameter value |
 | UrlRedirectCore.cs:19:44:19:48 | call to operator implicit conversion | semmle.label | call to operator implicit conversion |
@@ -45,6 +61,10 @@ subpaths
 | UrlRedirect.cs:38:44:38:74 | access to indexer | UrlRedirect.cs:38:44:38:66 | access to property QueryString : NameValueCollection | UrlRedirect.cs:38:44:38:74 | access to indexer | Untrusted URL redirection due to $@. | UrlRedirect.cs:38:44:38:66 | access to property QueryString | user-provided value |
 | UrlRedirect.cs:39:47:39:77 | access to indexer | UrlRedirect.cs:39:47:39:69 | access to property QueryString : NameValueCollection | UrlRedirect.cs:39:47:39:77 | access to indexer | Untrusted URL redirection due to $@. | UrlRedirect.cs:39:47:39:69 | access to property QueryString | user-provided value |
 | UrlRedirect.cs:48:29:48:31 | access to local variable url | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:48:29:48:31 | access to local variable url | Untrusted URL redirection due to $@. | UrlRedirect.cs:23:22:23:44 | access to property QueryString | user-provided value |
+| UrlRedirect.cs:61:31:61:52 | $"..." | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:61:31:61:52 | $"..." | Untrusted URL redirection due to $@. | UrlRedirect.cs:23:22:23:44 | access to property QueryString | user-provided value |
+| UrlRedirect.cs:64:31:64:52 | $"..." | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:64:31:64:52 | $"..." | Untrusted URL redirection due to $@. | UrlRedirect.cs:23:22:23:44 | access to property QueryString | user-provided value |
+| UrlRedirect.cs:67:31:67:69 | call to method Format | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:67:31:67:69 | call to method Format | Untrusted URL redirection due to $@. | UrlRedirect.cs:23:22:23:44 | access to property QueryString | user-provided value |
+| UrlRedirect.cs:70:31:70:69 | call to method Format | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:70:31:70:69 | call to method Format | Untrusted URL redirection due to $@. | UrlRedirect.cs:23:22:23:44 | access to property QueryString | user-provided value |
 | UrlRedirectCore.cs:16:22:16:26 | access to parameter value | UrlRedirectCore.cs:13:44:13:48 | value : String | UrlRedirectCore.cs:16:22:16:26 | access to parameter value | Untrusted URL redirection due to $@. | UrlRedirectCore.cs:13:44:13:48 | value | user-provided value |
 | UrlRedirectCore.cs:19:44:19:48 | call to operator implicit conversion | UrlRedirectCore.cs:13:44:13:48 | value : String | UrlRedirectCore.cs:19:44:19:48 | call to operator implicit conversion | Untrusted URL redirection due to $@. | UrlRedirectCore.cs:13:44:13:48 | value | user-provided value |
 | UrlRedirectCore.cs:25:46:25:50 | call to operator implicit conversion | UrlRedirectCore.cs:13:44:13:48 | value : String | UrlRedirectCore.cs:25:46:25:50 | call to operator implicit conversion | Untrusted URL redirection due to $@. | UrlRedirectCore.cs:13:44:13:48 | value | user-provided value |


### PR DESCRIPTION
In this PR we improve the sanitizer for `cs/web/unvalidated-url-redirection` to also take string interpolation expressions and string.Format into account.
That is, the following cases are now identified correctly:
```csharp
// GOOD: The attacker can only control the parameters, not the location
ctx.Response.Redirect($"foo.asp?param={url}");

// BAD: The attacker can control the location
ctx.Response.Redirect($"{url}.asp?param=foo");

// GOOD: The attacker can only control the parameters, not the location
ctx.Response.Redirect(string.Format("foo.asp?param={0}", url));

// BAD: The attacker can control the location
ctx.Response.Redirect(string.Format("{0}.asp?param=foo", url));
```

Prior to this change all of the above would generate alerts. The sanitizers introduced in this PR are simple as we only consider a format string or string interpolation string "safe" if "?" occurs before any insertion.