### PR TITLE
C#: Try fallback `dotnet restore` without nuget.config

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNet.cs
@@ -72,7 +72,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         private static IEnumerable<string> GetRestoredProjects(IEnumerable<string> lines) =>
             GetFirstGroupOnMatch(RestoredProjectRegex(), lines);
 
-        public bool RestoreProjectToDirectory(string projectFile, string packageDirectory, bool forceDotnetRefAssemblyFetching, out IEnumerable<string> assets, string? pathToNugetConfig = null)
+        public bool RestoreProjectToDirectory(string projectFile, string packageDirectory, bool forceDotnetRefAssemblyFetching, out IEnumerable<string> assets, out IList<string> outputLines, string? pathToNugetConfig = null, bool force = false)
         {
             var args = GetRestoreArgs(projectFile, packageDirectory, forceDotnetRefAssemblyFetching);
             if (pathToNugetConfig != null)
@@ -80,8 +80,13 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 args += $" --configfile \"{pathToNugetConfig}\"";
             }
 
-            var success = dotnetCliInvoker.RunCommand(args, out var output);
-            assets = success ? GetAssetsFilePaths(output) : Array.Empty<string>();
+            if (force)
+            {
+                args += " --force";
+            }
+
+            var success = dotnetCliInvoker.RunCommand(args, out outputLines);
+            assets = success ? GetAssetsFilePaths(outputLines) : Array.Empty<string>();
             return success;
         }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/IDotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/IDotNet.cs
@@ -4,7 +4,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 {
     internal interface IDotNet
     {
-        bool RestoreProjectToDirectory(string project, string directory, bool forceDotnetRefAssemblyFetching, out IEnumerable<string> assets, string? pathToNugetConfig = null);
+        bool RestoreProjectToDirectory(string project, string directory, bool forceDotnetRefAssemblyFetching, out IEnumerable<string> assets, out IList<string> outputLines, string? pathToNugetConfig = null, bool force = false);
         bool RestoreSolutionToDirectory(string solutionFile, string packageDirectory, bool forceDotnetRefAssemblyFetching, out IEnumerable<string> projects, out IEnumerable<string> assets);
         bool New(string folder);
         bool AddPackage(string folder, string package);

--- a/csharp/extractor/Semmle.Extraction.Tests/DotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/DotNet.cs
@@ -101,7 +101,7 @@ namespace Semmle.Extraction.Tests
             var dotnet = MakeDotnet(dotnetCliInvoker);
 
             // Execute
-            dotnet.RestoreProjectToDirectory("myproject.csproj", "mypackages", false, out var assets);
+            dotnet.RestoreProjectToDirectory("myproject.csproj", "mypackages", false, out var assets, out var _);
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();
@@ -116,11 +116,29 @@ namespace Semmle.Extraction.Tests
             var dotnet = MakeDotnet(dotnetCliInvoker);
 
             // Execute
-            dotnet.RestoreProjectToDirectory("myproject.csproj", "mypackages", false, out var assets, "myconfig.config");
+            dotnet.RestoreProjectToDirectory("myproject.csproj", "mypackages", false, out var assets, out var _, pathToNugetConfig: "myconfig.config");
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();
             Assert.Equal("restore --no-dependencies \"myproject.csproj\" --packages \"mypackages\" /p:DisableImplicitNuGetFallbackFolder=true --verbosity normal --configfile \"myconfig.config\"", lastArgs);
+            Assert.Equal(2, assets.Count());
+            Assert.Contains("/path/to/project.assets.json", assets);
+            Assert.Contains("/path/to/project2.assets.json", assets);
+        }
+
+        [Fact]
+        public void TestDotnetRestoreProjectToDirectory3()
+        {
+            // Setup
+            var dotnetCliInvoker = new DotNetCliInvokerStub(MakeDotnetRestoreOutput());
+            var dotnet = MakeDotnet(dotnetCliInvoker);
+
+            // Execute
+            dotnet.RestoreProjectToDirectory("myproject.csproj", "mypackages", false, out var assets, out var _, pathToNugetConfig: "myconfig.config", force: true);
+
+            // Verify
+            var lastArgs = dotnetCliInvoker.GetLastArgs();
+            Assert.Equal("restore --no-dependencies \"myproject.csproj\" --packages \"mypackages\" /p:DisableImplicitNuGetFallbackFolder=true --verbosity normal --configfile \"myconfig.config\" --force", lastArgs);
             Assert.Equal(2, assets.Count());
             Assert.Contains("/path/to/project.assets.json", assets);
             Assert.Contains("/path/to/project2.assets.json", assets);

--- a/csharp/extractor/Semmle.Extraction.Tests/Runtime.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/Runtime.cs
@@ -19,9 +19,10 @@ namespace Semmle.Extraction.Tests
 
         public bool New(string folder) => true;
 
-        public bool RestoreProjectToDirectory(string project, string directory, bool forceDotnetRefAssemblyFetching, out IEnumerable<string> assets, string? pathToNugetConfig = null)
+        public bool RestoreProjectToDirectory(string project, string directory, bool forceDotnetRefAssemblyFetching, out IEnumerable<string> assets, out IList<string> outputLines, string? pathToNugetConfig = null, bool force = false)
         {
             assets = Array.Empty<string>();
+            outputLines = Array.Empty<string>();
             return true;
         }
 

--- a/csharp/ql/integration-tests/posix-only/standalone_dependencies_nuget_config_error/Assemblies.expected
+++ b/csharp/ql/integration-tests/posix-only/standalone_dependencies_nuget_config_error/Assemblies.expected
@@ -1,0 +1,1 @@
+| newtonsoft.json/13.0.3/lib/net6.0/Newtonsoft.Json.dll |

--- a/csharp/ql/integration-tests/posix-only/standalone_dependencies_nuget_config_error/Assemblies.ql
+++ b/csharp/ql/integration-tests/posix-only/standalone_dependencies_nuget_config_error/Assemblies.ql
@@ -1,0 +1,11 @@
+import csharp
+
+private string getPath(Assembly a) {
+  not a.getCompilation().getOutputAssembly() = a and
+  exists(string s | s = a.getFile().getAbsolutePath() |
+    result = s.substring(s.indexOf("newtonsoft.json"), s.length())
+  )
+}
+
+from Assembly a
+select getPath(a)

--- a/csharp/ql/integration-tests/posix-only/standalone_dependencies_nuget_config_error/proj/Program.cs
+++ b/csharp/ql/integration-tests/posix-only/standalone_dependencies_nuget_config_error/proj/Program.cs
@@ -1,0 +1,6 @@
+class Program
+{
+    static void Main(string[] args)
+    {
+    }
+}

--- a/csharp/ql/integration-tests/posix-only/standalone_dependencies_nuget_config_error/proj/nuget.config
+++ b/csharp/ql/integration-tests/posix-only/standalone_dependencies_nuget_config_error/proj/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="x" value="https://abc.abc/packages/" />
+  </packageSources>
+</configuration>

--- a/csharp/ql/integration-tests/posix-only/standalone_dependencies_nuget_config_error/proj/proj.csproj
+++ b/csharp/ql/integration-tests/posix-only/standalone_dependencies_nuget_config_error/proj/proj.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <Target Name="DeleteBinObjFolders" BeforeTargets="Clean">
+    <RemoveDir Directories=".\bin" />
+    <RemoveDir Directories=".\obj" />
+  </Target>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/integration-tests/posix-only/standalone_dependencies_nuget_config_error/standalone.sln
+++ b/csharp/ql/integration-tests/posix-only/standalone_dependencies_nuget_config_error/standalone.sln
@@ -1,0 +1,19 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "proj", "proj\proj.csproj", "{6ED00460-7666-4AE9-A405-4B6C8B02279A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4ED55A1C-066C-43DF-B32E-7EAA035985EE}
+	EndGlobalSection
+EndGlobal

--- a/csharp/ql/integration-tests/posix-only/standalone_dependencies_nuget_config_error/test.py
+++ b/csharp/ql/integration-tests/posix-only/standalone_dependencies_nuget_config_error/test.py
@@ -1,0 +1,3 @@
+from create_database_utils import *
+
+run_codeql_database_create([], lang="csharp", extra_args=["--extractor-option=buildless=true", "--extractor-option=cil=false"])


### PR DESCRIPTION
This PR slightly changes the package restore logic in the dependency manager. When a package couldn't be restored through `sln` or `csproj` files, we fall back to a dedicated `dotnet restore` on the package name. This fallback restore uses the `nuget.config` file in the repo. This PR changes the fallback logic to first try restoring with the `nuget.config`, and if that fails with `NU1301` error, then the restore is tried again without the `nuget.config`. 