### PR TITLE
Python: Add `html.escape` as HTML sanitizer

### DIFF
--- a/python/ql/lib/change-notes/2024-01-22-html-escape.md
+++ b/python/ql/lib/change-notes/2024-01-22-html-escape.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added `html.escape` as a sanitizer for HTML.

--- a/python/ql/lib/semmle/python/frameworks/Stdlib.qll
+++ b/python/ql/lib/semmle/python/frameworks/Stdlib.qll
@@ -4851,7 +4851,19 @@ module StdlibPrivate {
    * See https://docs.python.org/3/library/html.html#html.escape
    */
   private class HtmlEscapeCall extends Escaping::Range, API::CallNode {
-    HtmlEscapeCall() { this = API::moduleImport("html").getMember("escape").getACall() }
+    HtmlEscapeCall() {
+      this = API::moduleImport("html").getMember("escape").getACall() and
+      // if quote escaping is disabled, that might lead to XSS if the result is inserted
+      // in the attribute value of a tag, such as `<foo bar="escape_result">`. Since we
+      // don't know how values are being inserted, and we don't want to lose these
+      // results (FNs), we require quote escaping to be enabled. This might lead to some
+      // FPs, so we might need to revisit this in the future.
+      not this.getParameter(1, "quote")
+          .getAValueReachingSink()
+          .asExpr()
+          .(ImmutableLiteral)
+          .booleanValue() = false
+    }
 
     override DataFlow::Node getAnInput() { result = this.getParameter(0, "s").asSink() }
 

--- a/python/ql/lib/semmle/python/frameworks/Stdlib.qll
+++ b/python/ql/lib/semmle/python/frameworks/Stdlib.qll
@@ -4842,6 +4842,23 @@ module StdlibPrivate {
       override predicate isShellInterpreted(DataFlow::Node arg) { arg = this.getCommand() }
     }
   }
+
+  // ---------------------------------------------------------------------------
+  // html
+  // ---------------------------------------------------------------------------
+  /**
+   * A call to 'html.escape'.
+   * See https://docs.python.org/3/library/html.html#html.escape
+   */
+  private class HtmlEscapeCall extends Escaping::Range, API::CallNode {
+    HtmlEscapeCall() { this = API::moduleImport("html").getMember("escape").getACall() }
+
+    override DataFlow::Node getAnInput() { result = this.getParameter(0, "s").asSink() }
+
+    override DataFlow::Node getOutput() { result = this }
+
+    override string getKind() { result = Escaping::getHtmlKind() }
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/python/ql/test/library-tests/frameworks/stdlib/test_html.py
+++ b/python/ql/test/library-tests/frameworks/stdlib/test_html.py
@@ -1,0 +1,8 @@
+import html
+
+s = "tainted"
+
+html.escape(s) # $ escapeInput=s escapeKind=html escapeOutput=html.escape(..)
+html.escape(s, True) # $ escapeInput=s escapeKind=html escapeOutput=html.escape(..)
+html.escape(s, False) # $ escapeInput=s escapeKind=html escapeOutput=html.escape(..)
+html.escape(s, quote=False) # $ escapeInput=s escapeKind=html escapeOutput=html.escape(..)

--- a/python/ql/test/library-tests/frameworks/stdlib/test_html.py
+++ b/python/ql/test/library-tests/frameworks/stdlib/test_html.py
@@ -4,5 +4,6 @@ s = "tainted"
 
 html.escape(s) # $ escapeInput=s escapeKind=html escapeOutput=html.escape(..)
 html.escape(s, True) # $ escapeInput=s escapeKind=html escapeOutput=html.escape(..)
-html.escape(s, False) # $ escapeInput=s escapeKind=html escapeOutput=html.escape(..)
-html.escape(s, quote=False) # $ escapeInput=s escapeKind=html escapeOutput=html.escape(..)
+# not considered html escapes, since they don't escape all relevant characters
+html.escape(s, False)
+html.escape(s, quote=False)


### PR DESCRIPTION
I've seen a few FPs related to XSS where `html.escape` has been used. When quotes are not escaped, it could end up being used in a dangerous way such as this example:

```py
html = '<foo attr="' + html.escape(user_input, quote=False) + '">...</foo>'
```

I couldn't really decide whether we should allow this as a sanitizer when quotes are not escaped, but ended up allowing it as a sanitizer, since it was easier this way. (Let me know if you think not doing so was not the right choice)

We should check how JS approaches this, I think they have a more sophisticated way of handling it.

