### PR TITLE
CPP: Fix join ordering hints to make them do what they intend.

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -609,7 +609,10 @@ class GlobalDefImpl extends DefOrUseImpl, TGlobalDefImpl {
  */
 predicate adjacentDefRead(DefOrUse defOrUse1, UseOrPhi use) {
   exists(IRBlock bb1, int i1, SourceVariable v |
-    defOrUse1.asDefOrUse().hasIndexInBlock(bb1, i1, v)
+    defOrUse1
+        .asDefOrUse()
+        .hasIndexInBlock(pragma[only_bind_out](bb1), pragma[only_bind_out](i1),
+          pragma[only_bind_out](v))
   |
     exists(IRBlock bb2, int i2, DefinitionExt def |
       adjacentDefReadExt(pragma[only_bind_into](def), pragma[only_bind_into](bb1),
@@ -631,7 +634,11 @@ predicate adjacentDefRead(DefOrUse defOrUse1, UseOrPhi use) {
  * flows to `useOrPhi`.
  */
 private predicate globalDefToUse(GlobalDef globalDef, UseOrPhi useOrPhi) {
-  exists(IRBlock bb1, int i1, SourceVariable v | globalDef.hasIndexInBlock(bb1, i1, v) |
+  exists(IRBlock bb1, int i1, SourceVariable v |
+    globalDef
+        .hasIndexInBlock(pragma[only_bind_out](bb1), pragma[only_bind_out](i1),
+          pragma[only_bind_out](v))
+  |
     exists(IRBlock bb2, int i2 |
       adjacentDefReadExt(_, pragma[only_bind_into](bb1), pragma[only_bind_into](i1),
         pragma[only_bind_into](bb2), pragma[only_bind_into](i2)) and


### PR DESCRIPTION
Both of these cases are caused by the disjunction meaning that we join order seperately. When we have the disjunction we join order the outer join separately to the inner join. Currently we pick `hasIndexInBlock` first in the outer join. Then inside the block for every order we try we can't place `adjacentDefReadExt` without a CP (as we can never join with any argument), so basically we essentially ignore the `only_bind_into` pragmas and select that CP. Another optimisation comes along and removes the CP so it isn't awful in this case as joining on `bb1, i1` seems to be good enough but we are relying on that other optimisation and making the optimiser very confused.

This makes us actually pick the intended join order (from before the phi case was added). The other option is to remove `pragma[only_bind_into]` on `bb1` and `i1` as that means the join orderer can either choose the intended join order or the current join order (and currently chooses the current).