### PR TITLE
C#: Enable standalone extraction via `--build-mode`

### DIFF
--- a/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
@@ -116,9 +116,8 @@ namespace Semmle.Autobuild.CSharp.Tests
 
         string? IBuildActions.GetEnvironmentVariable(string name)
         {
-            if (!GetEnvironmentVariable.ContainsKey(name))
-                return null;
-            return GetEnvironmentVariable[name];
+            GetEnvironmentVariable.TryGetValue(name, out var ret);
+            return ret;
         }
 
         public string GetCurrentDirectory { get; set; } = "";

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
@@ -116,10 +116,9 @@ namespace Semmle.Autobuild.CSharp.Tests
 
         string? IBuildActions.GetEnvironmentVariable(string name)
         {
-            if (!GetEnvironmentVariable.TryGetValue(name, out var ret))
-                throw new ArgumentException("Missing GetEnvironmentVariable " + name);
-
-            return ret;
+            if (!GetEnvironmentVariable.ContainsKey(name))
+                return null;
+            return GetEnvironmentVariable[name];
         }
 
         public string GetCurrentDirectory { get; set; } = "";

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp/CSharpAutobuilder.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp/CSharpAutobuilder.cs
@@ -11,6 +11,7 @@ namespace Semmle.Autobuild.CSharp
     /// </summary>
     public class CSharpAutobuildOptions : AutobuildOptionsShared
     {
+        private const string buildModeEnvironmentVariable = "CODEQL_EXTRACTOR_CSHARP_BUILD_MODE";
         private const string extractorOptionPrefix = "CODEQL_EXTRACTOR_CSHARP_OPTION_";
 
         public bool Buildless { get; }
@@ -25,7 +26,8 @@ namespace Semmle.Autobuild.CSharp
         public CSharpAutobuildOptions(IBuildActions actions) : base(actions)
         {
             Buildless = actions.GetEnvironmentVariable(lgtmPrefix + "BUILDLESS").AsBool("buildless", false) ||
-                actions.GetEnvironmentVariable(extractorOptionPrefix + "BUILDLESS").AsBool("buildless", false);
+                actions.GetEnvironmentVariable(extractorOptionPrefix + "BUILDLESS").AsBool("buildless", false) ||
+                actions.GetEnvironmentVariable(buildModeEnvironmentVariable) == "none";
         }
     }
 

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp/CSharpAutobuilder.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp/CSharpAutobuilder.cs
@@ -27,7 +27,7 @@ namespace Semmle.Autobuild.CSharp
         {
             Buildless = actions.GetEnvironmentVariable(lgtmPrefix + "BUILDLESS").AsBool("buildless", false) ||
                 actions.GetEnvironmentVariable(extractorOptionPrefix + "BUILDLESS").AsBool("buildless", false) ||
-                actions.GetEnvironmentVariable(buildModeEnvironmentVariable) == "none";
+                actions.GetEnvironmentVariable(buildModeEnvironmentVariable)?.ToLower() == "none";
         }
     }
 


### PR DESCRIPTION
This PR enables standalone extraction when `CODEQL_EXTRACTOR_CSHARP_BUILD_MODE` is `none`.  This enables triggering standalone extraction via the upcoming `--build-mode` CLI option and its integration into the CodeQL Action.

Tested by creating a database locally with `--build-mode none` and verifying that "Running C# standalone extractor" appears in the build logs.