### PR TITLE
Go: Add AwsLambda to the global context

### DIFF
--- a/go/ql/lib/go.qll
+++ b/go/ql/lib/go.qll
@@ -31,6 +31,7 @@ import semmle.go.dataflow.SSA
 import semmle.go.dataflow.TaintTracking
 import semmle.go.dataflow.TaintTracking2
 import semmle.go.frameworks.Afero
+import semmle.go.frameworks.AwsLambda
 import semmle.go.frameworks.Beego
 import semmle.go.frameworks.BeegoOrm
 import semmle.go.frameworks.Chi

--- a/go/ql/test/library-tests/semmle/go/frameworks/AwsLambda/test.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/AwsLambda/test.ql
@@ -1,5 +1,4 @@
 import go
-import semmle.go.frameworks.AwsLambda
 import TestUtilities.InlineFlowTest
 
 module Config implements DataFlow::ConfigSig {


### PR DESCRIPTION
We missed this in https://github.com/github/codeql/pull/15373.