### PR TITLE
Java: sql-injection sink in org.apache.ibatis.mapping::BoundSql

### DIFF
--- a/java/ql/lib/ext/org.apache.ibatis.mapping.model.yml
+++ b/java/ql/lib/ext/org.apache.ibatis.mapping.model.yml
@@ -1,6 +1,11 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
+      extensible: sinkModel
+    data:
+      - ["org.apache.ibatis.mapping", "BoundSql", True, "BoundSql", "(Configuration,String,List,Object)", "", "Argument[1]", "sql-injection", "ai-manual"]
+  - addsTo:
+      pack: codeql/java-all
       extensible: summaryModel
     data:
       - ["org.apache.ibatis.mapping", "BoundSql", True, "getSql", "()", "", "Argument[this]", "ReturnValue", "taint", "ai-manual"]


### PR DESCRIPTION
This is contributing a model and should also fix a mis-classification on our end.

Documentation: https://mybatis.org/mybatis-3/apidocs/org/apache/ibatis/mapping/BoundSql.html#%3Cinit%3E(org.apache.ibatis.session.Configuration,java.lang.String,java.util.List,java.lang.Object)