### PR TITLE
C++: Add `asExpr` and `asIndirectExpr` library tests (and fix more duplication)

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -1484,10 +1484,15 @@ private module IndirectNodeToIndirectExpr<IndirectNodeToIndirectExprSig Sig> {
       indirectNodeHasIndirectExpr(node, e, n, indirectionIndex) and
       not exists(Expr conv, int adjustedIndirectionIndex |
         adjustForReference(e, indirectionIndex, conv, adjustedIndirectionIndex) and
-        indirectNodeHasIndirectExpr(_, conv, n + 1, adjustedIndirectionIndex)
+        indirectExprNodeShouldBe(conv, n + 1, adjustedIndirectionIndex)
       )
     )
   }
+}
+
+private predicate indirectExprNodeShouldBe(Expr e, int n, int indirectionIndex) {
+  indirectExprNodeShouldBeIndirectOperand(_, e, n, indirectionIndex) or
+  indirectExprNodeShouldBeIndirectInstruction(_, e, n, indirectionIndex)
 }
 
 private module IndirectOperandIndirectExprNodeImpl implements IndirectNodeToIndirectExprSig {

--- a/cpp/ql/test/library-tests/dataflow/asExpr/test-indirect.expected
+++ b/cpp/ql/test/library-tests/dataflow/asExpr/test-indirect.expected
@@ -1,0 +1,2 @@
+testFailures
+failures

--- a/cpp/ql/test/library-tests/dataflow/asExpr/test-indirect.ql
+++ b/cpp/ql/test/library-tests/dataflow/asExpr/test-indirect.ql
@@ -1,0 +1,40 @@
+import cpp
+import TestUtilities.InlineExpectationsTest
+import semmle.code.cpp.dataflow.new.DataFlow::DataFlow
+
+bindingset[s]
+string quote(string s) { if s.matches("% %") then result = "\"" + s + "\"" else result = s }
+
+string formatNumberOfNodesForIndirectExpr(Expr e) {
+  exists(int n | n = strictcount(Node node | node.asIndirectExpr() = e) |
+    n > 1 and result = ": " + n
+  )
+}
+
+module AsIndirectExprTest implements TestSig {
+  string getARelevantTag() { result = ["asIndirectExpr", "numberOfIndirectNodes"] }
+
+  predicate hasActualResult(Location location, string element, string tag, string value) {
+    exists(Node n, Expr e, string exprString |
+      e = n.asIndirectExpr() and
+      location = e.getLocation() and
+      element = n.toString() and
+      exprString = e.toString()
+    |
+      tag = "asIndirectExpr" and
+      (
+        // The toString on an indirect is often formatted like `***myExpr`.
+        // If the node's `toString` is of that form then we don't show it in
+        // the expected output.
+        if element.matches("%" + exprString)
+        then value = quote(exprString)
+        else value = quote(exprString + "(" + element + ")")
+      )
+      or
+      tag = "numberOfIndirectNodes" and
+      value = quote(exprString + formatNumberOfNodesForIndirectExpr(e))
+    )
+  }
+}
+
+import MakeTest<AsIndirectExprTest>

--- a/cpp/ql/test/library-tests/dataflow/asExpr/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/asExpr/test.cpp
@@ -2,7 +2,7 @@ void take_const_ref_int(const int &);
 
 void test_materialize_temp_int()
 {
-  take_const_ref_int(42); // $ asExpr=42 numberOfNodes="42: 2" asIndirectExpr=42 numberOfIndirectNodes="42: 2"
+  take_const_ref_int(42); // $ asExpr=42 numberOfNodes="42: 2" asIndirectExpr=42
 }
 
 struct A {};
@@ -11,7 +11,7 @@ A get();
 void take_const_ref(const A &);
 
 void test1(){
-  take_const_ref(get()); // $ asExpr="call to get" numberOfNodes="call to get: 2" asIndirectExpr="call to get" numberOfIndirectNodes="call to get: 2"
+  take_const_ref(get()); // $ asExpr="call to get" numberOfNodes="call to get: 2" asIndirectExpr="call to get"
 }
 
 void take_ref(A &);

--- a/cpp/ql/test/library-tests/dataflow/asExpr/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/asExpr/test.cpp
@@ -1,0 +1,23 @@
+void take_const_ref_int(const int &);
+
+void test_materialize_temp_int()
+{
+  take_const_ref_int(42); // $ asExpr=42 numberOfNodes="42: 2" asIndirectExpr=42 numberOfIndirectNodes="42: 2"
+}
+
+struct A {};
+
+A get();
+void take_const_ref(const A &);
+
+void test1(){
+  take_const_ref(get()); // $ asExpr="call to get" numberOfNodes="call to get: 2" asIndirectExpr="call to get" numberOfIndirectNodes="call to get: 2"
+}
+
+void take_ref(A &);
+
+A& get_ref();
+
+void test2() {
+  take_ref(get_ref()); // $ asExpr="call to get_ref" asIndirectExpr="call to get_ref"
+}

--- a/cpp/ql/test/library-tests/dataflow/asExpr/test.expected
+++ b/cpp/ql/test/library-tests/dataflow/asExpr/test.expected
@@ -1,0 +1,2 @@
+testFailures
+failures

--- a/cpp/ql/test/library-tests/dataflow/asExpr/test.ql
+++ b/cpp/ql/test/library-tests/dataflow/asExpr/test.ql
@@ -1,0 +1,37 @@
+import cpp
+import TestUtilities.InlineExpectationsTest
+import semmle.code.cpp.dataflow.new.DataFlow::DataFlow
+
+bindingset[s]
+string quote(string s) { if s.matches("% %") then result = "\"" + s + "\"" else result = s }
+
+string formatNumberOfNodesForExpr(Expr e) {
+  exists(int n | n = strictcount(Node node | node.asExpr() = e) | n > 1 and result = ": " + n)
+}
+
+module AsExprTest implements TestSig {
+  string getARelevantTag() { result = ["asExpr", "numberOfNodes"] }
+
+  predicate hasActualResult(Location location, string element, string tag, string value) {
+    exists(Node n, Expr e, string exprString |
+      e = n.asExpr() and
+      location = e.getLocation() and
+      element = n.toString() and
+      exprString = e.toString()
+    |
+      tag = "asExpr" and
+      (
+        // If the `toString` on the node is identical to the `toString` of the
+        // expression then we don't show it in the expected output.
+        if exprString = element
+        then value = quote(exprString)
+        else value = quote(exprString + "(" + element + ")")
+      )
+      or
+      tag = "numberOfNodes" and
+      value = quote(exprString + formatNumberOfNodesForExpr(e))
+    )
+  }
+}
+
+import MakeTest<AsExprTest>


### PR DESCRIPTION
The first commit adds an inline expectations test for testing the behavior of `asExpr` and `asIndirectExpr`. The next commit fixes some `asIndirectExpr` duplication similar to how it was fixed for `asExpr` in https://github.com/github/codeql/pull/15410.

(DCA looks uneventful)