### PR TITLE
Kotlin: Catch/ignore a IllegalArgumentException exception

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -990,21 +990,26 @@ open class KotlinFileExtractor(
                             }
                         }
                     } else {
-                        c.declarations.forEach {
-                            extractDeclaration(
-                                it,
-                                extractPrivateMembers = extractPrivateMembers,
-                                extractFunctionBodies = extractFunctionBodies,
-                                extractAnnotations = true
+                        try {
+                            c.declarations.forEach {
+                                extractDeclaration(
+                                    it,
+                                    extractPrivateMembers = extractPrivateMembers,
+                                    extractFunctionBodies = extractFunctionBodies,
+                                    extractAnnotations = true
+                                )
+                            }
+                            if (extractStaticInitializer) extractStaticInitializer(c, { id })
+                            extractJvmStaticProxyMethods(
+                                c,
+                                id,
+                                extractPrivateMembers,
+                                extractFunctionBodies
                             )
+                        } catch (e: IllegalArgumentException) {
+                            // A Kotlin bug causes this to throw: https://youtrack.jetbrains.com/issue/KT-63847/K2-IllegalStateException-IrFieldPublicSymbolImpl-for-java.time-Clock.OffsetClock.offset0-is-already-bound
+                            // TODO: This should either be removed or log something, once the bug is fixed
                         }
-                        if (extractStaticInitializer) extractStaticInitializer(c, { id })
-                        extractJvmStaticProxyMethods(
-                            c,
-                            id,
-                            extractPrivateMembers,
-                            extractFunctionBodies
-                        )
                     }
                 }
                 if (c.isNonCompanionObject) {


### PR DESCRIPTION
This works around
    https://youtrack.jetbrains.com/issue/KT-63847/K2-IllegalStateException-IrFieldPublicSymbolImpl-for-java.time-Clock.OffsetClock.offset0-is-already-bound