### PR TITLE
DataFlow: Fix join order

### DIFF
--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -1620,7 +1620,7 @@ module MakeImpl<InputSig Lang> {
               // type flow disabled: linear recursion
               fwdFlowInCandTypeFlowDisabled(call, arg, state, outercc, inner, p, summaryCtx, argT,
                 argAp, t, ap, apa, cc) and
-              fwdFlowInValidEdgeTypeFlowDisabled(call, inner, innercc, cc)
+              fwdFlowInValidEdgeTypeFlowDisabled(call, inner, innercc, pragma[only_bind_into](cc))
               or
               // type flow enabled: non-linear recursion
               exists(boolean emptyAp |


### PR DESCRIPTION
This fixes a bad join on a boolean that we're seeing in https://github.com/github/codeql/pull/15421.

Before:
```ql
Pipeline standard for DataFlowImpl::Impl<ExecTainted::ExecState::C>::Stage2::fwdFlowIn/6#c607111e@49e568w9 was evaluated in 542 iterations totaling 5390ms (delta sizes total: 2160).
      15796    ~3%    {8} r1 = SCAN `DataFlowImpl::Impl<ExecTainted::ExecState::C>::Stage2::fwdFlowIntoArg/11#f173ad92#prev_delta` OUTPUT In.10, In.0, In.1, In.2, In.6, In.7, In.8, In.9
   61741080    ~1%    {10}    | JOIN WITH `DataFlowImpl::Impl<ExecTainted::ExecState::C>::Stage2::FwdFlowIn<FwdFlowInNoRestriction>::fwdFlowInValidEdgeTypeFlowDisabled/4#6ab9ff68_3012#join_rhs` ON FIRST 1 OUTPUT Lhs.3, Lhs.1, Lhs.2, Lhs.4, Lhs.5, Lhs.6, Lhs.7, Rhs.1, Rhs.2, Rhs.3
                  
   41848245    ~1%    {10} r2 = JOIN r1 WITH DataFlowImplCommon::CallContextCall#class#8cfc05f9 ON FIRST 1 OUTPUT Lhs.7, Lhs.1, Lhs.2, Lhs.0, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.8, Lhs.9
       6716    ~0%    {10}    | JOIN WITH `project#DataFlowImpl::Impl<ExecTainted::ExecState::C>::Stage2::FwdFlowIn<FwdFlowInNoRestriction>::callEdgeArgParamRestricted/6#1bd9ae23` ON FIRST 2 OUTPUT Lhs.0, Lhs.3, Lhs.8, Lhs.1, Lhs.2, Lhs.4, Lhs.5, Lhs.6, Lhs.7, Lhs.9
          7    ~0%    {9}    | JOIN WITH `DataFlowImpl::Impl<ExecTainted::ExecState::C>::Stage2::FwdFlowIn<FwdFlowInNoRestriction>::viableImplCallContextReducedRestricted/2#c1fdb585` ON FIRST 3 OUTPUT Lhs.0, Lhs.2, Lhs.3, Lhs.8, Lhs.4, Lhs.5, Lhs.6, Lhs.7, Lhs.9
                  
   61741080    ~1%    {10} r3 = JOIN r1 WITH DataFlowImplCommon::Cached::TCallContext#7cf8348b ON FIRST 1 OUTPUT Lhs.7, Lhs.1, Lhs.2, Lhs.0, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.8, Lhs.9
      10316    ~0%    {10}    | JOIN WITH `project#DataFlowImpl::Impl<ExecTainted::ExecState::C>::Stage2::FwdFlowIn<FwdFlowInNoRestriction>::callEdgeArgParamRestricted/6#1bd9ae23` ON FIRST 2 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.7, Lhs.8, Lhs.9
      10316    ~0%    {10}    | JOIN WITH Instruction::CallInstruction#c775cdd2 ON FIRST 1 OUTPUT Lhs.3, Lhs.1, Lhs.2, Lhs.4, Lhs.5, Lhs.6, Lhs.7, Lhs.0, Lhs.8, Lhs.9
                  
       6371    ~0%    {9} r4 = JOIN r3 WITH DataFlowImplCommon::Cached::TSomeCall#4718863b ON FIRST 1 OUTPUT Lhs.7, Lhs.8, Lhs.1, Lhs.6, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.9
                  
       3516    ~0%    {9} r5 = JOIN r3 WITH DataFlowImplCommon::Cached::TAnyCallContext#7f926227 ON FIRST 1 OUTPUT Lhs.7, Lhs.8, Lhs.1, Lhs.6, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.9
                  
         84   ~64%    {9} r6 = JOIN r3 WITH DataFlowImplCommon::Cached::TReturn#f9e21859_2#join_rhs ON FIRST 1 OUTPUT Lhs.7, Lhs.8, Lhs.1, Lhs.6, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.9
                  
        345    ~0%    {10} r7 = JOIN r3 WITH DataFlowImplCommon::Cached::TSpecificCall#5ec84155_10#join_rhs ON FIRST 1 OUTPUT Lhs.7, Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.8, Lhs.9
                     {10}    | AND NOT `project#DataFlowImplCommon::Cached::DispatchWithCallContext::reducedViableImplInCallContext/3#788069fd`(FIRST 2)
        319  ~114%    {9}    | SCAN OUTPUT In.0, In.8, In.2, In.7, In.3, In.4, In.5, In.6, In.9
                  
      10297    ~4%    {9} r8 = r2 UNION r4 UNION r5 UNION r6 UNION r7
      10539   ~35%    {9}    | JOIN WITH `DataFlowImpl::Impl<ExecTainted::ExecState::C>::Stage2::FwdFlowIn<FwdFlowInNoRestriction>::callEdgeArgParamRestricted/6#1bd9ae23_012534#join_rhs` ON FIRST 4 OUTPUT Lhs.4, Lhs.5, Lhs.6, Lhs.7, Lhs.3, Lhs.8, Rhs.4, Rhs.5, _
                     {8}    | REWRITE WITH NOT [NOT [Tmp.8 := false, TEST InOut.7 = Tmp.8, Tmp.8 := true, TEST InOut.3 = Tmp.8], NOT [Tmp.8 := false, TEST InOut.7 != Tmp.8]] KEEPING 8
      10095   ~34%    {6}    | SCAN OUTPUT In.6, In.4, In.0, In.5, In.1, In.2
       2279   ~12%    {6}    | AND NOT `DataFlowImpl::Impl<ExecTainted::ExecState::C>::Stage2::fwdFlowIn/6#c607111e#prev`(FIRST 6)
                     return r8
```

After:
```ql
Pipeline standard for DataFlowImpl::Impl<ExecTainted::ExecState::C>::Stage2::fwdFlowIn/6#c607111e@7c40a8wu was evaluated in 542 iterations totaling 427ms (delta sizes total: 2112).
  15796    ~3%    {8} r1 = SCAN `DataFlowImpl::Impl<ExecTainted::ExecState::C>::Stage2::fwdFlowIntoArg/11#f173ad92#prev_delta` OUTPUT In.2, In.0, In.1, In.6, In.7, In.8, In.9, In.10
              
  10449    ~0%    {8} r2 = JOIN r1 WITH DataFlowImplCommon::CallContextCall#class#8cfc05f9 ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Lhs.0, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.7
   6691    ~0%    {9}    | JOIN WITH `project#DataFlowImpl::Impl<ExecTainted::ExecState::C>::Stage2::FwdFlowIn<FwdFlowInNoRestriction>::callEdgeArgParamRestricted/6#1bd9ae23_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.2, Lhs.0, Lhs.1, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.7
      7    ~0%    {9}    | JOIN WITH `DataFlowImpl::Impl<ExecTainted::ExecState::C>::Stage2::FwdFlowIn<FwdFlowInNoRestriction>::viableImplCallContextReducedRestricted/2#c1fdb585` ON FIRST 2 OUTPUT Lhs.0, Rhs.2, Lhs.8, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.7
      7    ~0%    {10}    | JOIN WITH `DataFlowImpl::Impl<ExecTainted::ExecState::C>::Stage2::FwdFlowIn<FwdFlowInNoRestriction>::fwdFlowInValidEdgeTypeFlowDisabled/4#6ab9ff68_0132#join_rhs` ON FIRST 3 OUTPUT Lhs.0, Lhs.1, Rhs.3, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.7, Lhs.8
              
  15416    ~0%    {8} r3 = JOIN r1 WITH DataFlowImplCommon::Cached::TCallContext#7cf8348b ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Lhs.0, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.7
  10237    ~0%    {9}    | JOIN WITH `project#DataFlowImpl::Impl<ExecTainted::ExecState::C>::Stage2::FwdFlowIn<FwdFlowInNoRestriction>::callEdgeArgParamRestricted/6#1bd9ae23_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.7
  10237    ~0%    {9}    | JOIN WITH Instruction::CallInstruction#c775cdd2 ON FIRST 1 OUTPUT Lhs.3, Lhs.1, Lhs.2, Lhs.4, Lhs.5, Lhs.6, Lhs.7, Lhs.8, Lhs.0
              
   6360    ~0%    {8} r4 = JOIN r3 WITH DataFlowImplCommon::Cached::TSomeCall#4718863b ON FIRST 1 OUTPUT Lhs.8, Lhs.7, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6
              
   3492    ~0%    {8} r5 = JOIN r3 WITH DataFlowImplCommon::Cached::TAnyCallContext#7f926227 ON FIRST 1 OUTPUT Lhs.8, Lhs.7, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6
              
     54   ~51%    {8} r6 = JOIN r3 WITH DataFlowImplCommon::Cached::TReturn#f9e21859_2#join_rhs ON FIRST 1 OUTPUT Lhs.8, Lhs.7, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6
              
    331    ~0%    {9} r7 = JOIN r3 WITH DataFlowImplCommon::Cached::TSpecificCall#5ec84155_10#join_rhs ON FIRST 1 OUTPUT Lhs.8, Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.7
                  {9}    | AND NOT `project#DataFlowImplCommon::Cached::DispatchWithCallContext::reducedViableImplInCallContext/3#788069fd`(FIRST 2)
    319  ~114%    {8}    | SCAN OUTPUT In.0, In.8, In.2, In.3, In.4, In.5, In.6, In.7
              
  10225    ~2%    {8} r8 = r4 UNION r5 UNION r6 UNION r7
  10159    ~1%    {10}    | JOIN WITH `DataFlowImpl::Impl<ExecTainted::ExecState::C>::Stage2::FwdFlowIn<FwdFlowInNoRestriction>::fwdFlowInValidEdgeTypeFlowDisabled/4#6ab9ff68_0312#join_rhs` ON FIRST 2 OUTPUT Lhs.0, Rhs.2, Rhs.3, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.7
              
  10166    ~1%    {10} r9 = r2 UNION r8
  10157    ~2%    {9}    | JOIN WITH `DataFlowImpl::Impl<ExecTainted::ExecState::C>::Stage2::FwdFlowIn<FwdFlowInNoRestriction>::fwdFlowInValidEdgeTypeFlowDisabled/4#6ab9ff68` ON FIRST 4 OUTPUT Lhs.0, Lhs.1, Lhs.4, Lhs.9, Lhs.5, Lhs.6, Lhs.7, Lhs.8, Lhs.2
  10364   ~33%    {9}    | JOIN WITH `DataFlowImpl::Impl<ExecTainted::ExecState::C>::Stage2::FwdFlowIn<FwdFlowInNoRestriction>::callEdgeArgParamRestricted/6#1bd9ae23_012534#join_rhs` ON FIRST 4 OUTPUT Lhs.4, Lhs.5, Lhs.6, Lhs.7, Lhs.3, Lhs.8, Rhs.4, Rhs.5, _
                  {8}    | REWRITE WITH NOT [NOT [Tmp.8 := false, TEST InOut.7 = Tmp.8, Tmp.8 := true, TEST InOut.3 = Tmp.8], NOT [Tmp.8 := false, TEST InOut.7 != Tmp.8]] KEEPING 8
   9927   ~31%    {6}    | SCAN OUTPUT In.6, In.4, In.0, In.5, In.1, In.2
   2112    ~0%    {6}    | AND NOT `DataFlowImpl::Impl<ExecTainted::ExecState::C>::Stage2::fwdFlowIn/6#c607111e#prev`(FIRST 6)
                  return r9
```