### PR TITLE
Java: test changes for making buildless' classpath ordering deterministic

### DIFF
--- a/java/ql/integration-tests/all-platforms/java/buildless-sibling-projects/buildless-fetches.expected
+++ b/java/ql/integration-tests/all-platforms/java/buildless-sibling-projects/buildless-fetches.expected
@@ -25,3 +25,4 @@ https://repo.maven.apache.org/maven2/org/minijax/minijax-example-websocket/0.5.1
 https://repo.maven.apache.org/maven2/org/scalamock/scalamock-examples_2.10/3.6.0/scalamock-examples_2.10-3.6.0.jar
 https://repo.maven.apache.org/maven2/org/somda/sdc/glue-examples/4.0.0/glue-examples-4.0.0.jar
 https://repo.maven.apache.org/maven2/us/fatehi/schemacrawler-examplecode/16.20.2/schemacrawler-examplecode-16.20.2.jar
+https://repo1.maven.org/maven2/junit/junit/4.11/junit-4.11.jar

--- a/java/ql/integration-tests/all-platforms/java/buildless-sibling-projects/diagnostics.expected
+++ b/java/ql/integration-tests/all-platforms/java/buildless-sibling-projects/diagnostics.expected
@@ -69,7 +69,7 @@
   }
 }
 {
-  "markdownMessage": "Reading the dependency graph from build files provided 3 classpath entries",
+  "markdownMessage": "Reading the dependency graph from build files provided 4 classpath entries",
   "severity": "unknown",
   "source": {
     "extractorName": "java",


### PR DESCRIPTION
Older / shadowed versions of dependencies are also added to the classpath, hence the change here