### PR TITLE
C++: Fix FP in `cpp/incorrectly-checked-scanf`

### DIFF
--- a/cpp/ql/src/change-notes/2024-01-29-incorrectly-checked-scanf.md
+++ b/cpp/ql/src/change-notes/2024-01-29-incorrectly-checked-scanf.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The "Incorrect return-value check for a 'scanf'-like function" query (`cpp/incorrectly-checked-scanf`) no longer reports an alert when an explicit check for EOF is added.

--- a/cpp/ql/test/query-tests/Critical/MissingCheckScanf/IncorrectCheckScanf.expected
+++ b/cpp/ql/test/query-tests/Critical/MissingCheckScanf/IncorrectCheckScanf.expected
@@ -3,3 +3,4 @@
 | test.cpp:204:7:204:11 | call to scanf | The result of scanf is only checked against 0, but it can also return EOF. |
 | test.cpp:436:7:436:11 | call to scanf | The result of scanf is only checked against 0, but it can also return EOF. |
 | test.cpp:443:11:443:15 | call to scanf | The result of scanf is only checked against 0, but it can also return EOF. |
+| test.cpp:455:12:455:17 | call to sscanf | The result of scanf is only checked against 0, but it can also return EOF. |

--- a/cpp/ql/test/query-tests/Critical/MissingCheckScanf/IncorrectCheckScanf.expected
+++ b/cpp/ql/test/query-tests/Critical/MissingCheckScanf/IncorrectCheckScanf.expected
@@ -3,4 +3,3 @@
 | test.cpp:204:7:204:11 | call to scanf | The result of scanf is only checked against 0, but it can also return EOF. |
 | test.cpp:436:7:436:11 | call to scanf | The result of scanf is only checked against 0, but it can also return EOF. |
 | test.cpp:443:11:443:15 | call to scanf | The result of scanf is only checked against 0, but it can also return EOF. |
-| test.cpp:455:12:455:17 | call to sscanf | The result of scanf is only checked against 0, but it can also return EOF. |

--- a/cpp/ql/test/query-tests/Critical/MissingCheckScanf/MissingCheckScanf.expected
+++ b/cpp/ql/test/query-tests/Critical/MissingCheckScanf/MissingCheckScanf.expected
@@ -14,3 +14,4 @@
 | test.cpp:404:25:404:25 | u | This variable is read, but may not have been written. It should be guarded by a check that the $@ returns at least 1. | test.cpp:403:6:403:11 | call to sscanf | call to sscanf |
 | test.cpp:416:7:416:7 | i | This variable is read, but may not have been written. It should be guarded by a check that the $@ returns at least 1. | test.cpp:413:7:413:11 | call to scanf | call to scanf |
 | test.cpp:423:7:423:7 | i | This variable is read, but may not have been written. It should be guarded by a check that the $@ returns at least 1. | test.cpp:420:7:420:11 | call to scanf | call to scanf |
+| test.cpp:460:6:460:10 | value | This variable is read, but may not have been written. It should be guarded by a check that the $@ returns at least 1. | test.cpp:455:12:455:17 | call to sscanf | call to sscanf |

--- a/cpp/ql/test/query-tests/Critical/MissingCheckScanf/test.cpp
+++ b/cpp/ql/test/query-tests/Critical/MissingCheckScanf/test.cpp
@@ -447,3 +447,15 @@ void bad_check() {
 		use(i);  // GOOD [FALSE POSITIVE]: Technically no security issue, but code is incorrect.
 	}
 }
+
+#define EOF (-1)
+
+void disjunct_boolean_condition(const char* modifier_data) {
+	long value;
+	auto rc = sscanf(modifier_data, "%lx", &value);
+
+	if((rc == EOF) || (rc == 0)) {
+		return;
+	}
+	use(value); // GOOD
+}


### PR DESCRIPTION
Note that, because the `cpp/missing-check-scanf` query only raises an alert if `cpp/incorrectly-checked-scanf` doesn't, by fixing the FP in `cpp/incorrectly-checked-scanf` we're now moving the alert to the `cpp/missing-check-scanf` query.

This is a good trade-off since `cpp/incorrectly-checked-scanf` is a high-precision query, and `cpp/missing-check-scanf` is only at precision `medium`.

I tried to fix the FP in `cpp/incorrectly-checked-scanf` as well, but this is more difficult. So I think we should get this fix in first before trying to fix the `cpp/incorrectly-checked-scanf` case.