### PR TITLE
Python: Model the `psycopg` package

### DIFF
--- a/python/ql/lib/change-notes/2024-01-29-psycopg-modeling.md
+++ b/python/ql/lib/change-notes/2024-01-29-psycopg-modeling.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added modeling of the `psycopg` PyPI package as a SQL database library.

--- a/python/ql/lib/semmle/python/Frameworks.qll
+++ b/python/ql/lib/semmle/python/Frameworks.qll
@@ -48,6 +48,7 @@ private import semmle.python.frameworks.Oracledb
 private import semmle.python.frameworks.Pandas
 private import semmle.python.frameworks.Peewee
 private import semmle.python.frameworks.Phoenixdb
+private import semmle.python.frameworks.Psycopg
 private import semmle.python.frameworks.Psycopg2
 private import semmle.python.frameworks.Pycurl
 private import semmle.python.frameworks.Pydantic

--- a/python/ql/lib/semmle/python/frameworks/Psycopg.qll
+++ b/python/ql/lib/semmle/python/frameworks/Psycopg.qll
@@ -1,0 +1,32 @@
+/**
+ * Provides classes modeling security-relevant aspects of the `psycopg` PyPI package.
+ * See
+ * - https://www.psycopg.org/psycopg3/docs/
+ * - https://pypi.org/project/psycopg/
+ */
+
+private import python
+private import semmle.python.dataflow.new.DataFlow
+private import semmle.python.dataflow.new.RemoteFlowSources
+private import semmle.python.Concepts
+private import semmle.python.ApiGraphs
+private import semmle.python.frameworks.PEP249
+
+/**
+ * Provides models for the `psycopg` PyPI package.
+ * See
+ * - https://www.psycopg.org/psycopg3/docs/
+ * - https://pypi.org/project/psycopg/
+ */
+private module Psycopg {
+  // ---------------------------------------------------------------------------
+  // Psycopg
+  // ---------------------------------------------------------------------------
+  /**
+   * A model of `psycopg` as a module that implements PEP 249, providing ways to execute SQL statements
+   * against a database.
+   */
+  class Psycopg extends PEP249::PEP249ModuleApiNode {
+    Psycopg() { this = API::moduleImport("psycopg") }
+  }
+}

--- a/python/ql/test/library-tests/frameworks/psycopg/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/psycopg/ConceptsTest.expected
@@ -1,0 +1,2 @@
+testFailures
+failures

--- a/python/ql/test/library-tests/frameworks/psycopg/ConceptsTest.ql
+++ b/python/ql/test/library-tests/frameworks/psycopg/ConceptsTest.ql
@@ -1,0 +1,2 @@
+import python
+import experimental.meta.ConceptsTest

--- a/python/ql/test/library-tests/frameworks/psycopg/pep249.py
+++ b/python/ql/test/library-tests/frameworks/psycopg/pep249.py
@@ -1,0 +1,14 @@
+import psycopg
+
+conn = psycopg.connect(...)
+conn.execute("some sql", (42,))  # $ getSql="some sql"
+cursor = conn.cursor()
+cursor.execute("some sql", (42,))  # $ getSql="some sql"
+cursor.executemany("some sql", [(42,)])  # $ getSql="some sql"
+
+# as in their examples:
+with psycopg.connect(...) as conn:
+    conn.execute("some sql", (42,))  # $ getSql="some sql"
+    with conn.cursor() as cursor:
+        cursor.execute("some sql", (42,))  # $ getSql="some sql"
+        cursor.executemany("some sql", [(42,)])  # $ getSql="some sql"


### PR DESCRIPTION
Not as much used as the predecessor `psycopg2`, but since they're recommending using the newer version (v3) for new projects, that should change over time :blush: