### PR TITLE
C++: Fix another FP in `cpp/incorrectly-checked-scanf`

### DIFF
--- a/cpp/ql/src/Critical/ScanfChecks.qll
+++ b/cpp/ql/src/Critical/ScanfChecks.qll
@@ -3,12 +3,15 @@ private import semmle.code.cpp.commons.Scanf
 private import semmle.code.cpp.controlflow.IRGuards
 private import semmle.code.cpp.ir.ValueNumbering
 
+private ConstantInstruction getZeroInstruction() { result.getValue() = "0" }
+
+private Operand zero() { result.getDef() = getZeroInstruction() }
+
 private predicate exprInBooleanContext(Expr e) {
   exists(IRGuardCondition gc |
-    exists(Instruction i, ConstantInstruction zero |
-      zero.getValue() = "0" and
+    exists(Instruction i |
       i.getUnconvertedResultExpression() = e and
-      gc.comparesEq(valueNumber(i).getAUse(), zero.getAUse(), 0, _, _)
+      gc.comparesEq(valueNumber(i).getAUse(), zero(), 0, _, _)
     )
     or
     gc.getUnconvertedResultExpression() = e
@@ -33,15 +36,21 @@ private string getEofValue() {
   )
 }
 
+private ConstantInstruction getEofInstruction() { result.getValue() = getEofValue() }
+
+private Operand eof() { result.getDef() = getEofInstruction() }
+
 /**
  * Holds if the value of `call` has been checked to not equal `EOF`.
  */
 private predicate checkedForEof(ScanfFunctionCall call) {
   exists(IRGuardCondition gc |
-    exists(Instruction i, ConstantInstruction eof |
-      eof.getValue() = getEofValue() and
-      i.getUnconvertedResultExpression() = call and
-      gc.comparesEq(valueNumber(i).getAUse(), eof.getAUse(), 0, _, _)
+    exists(Instruction i | i.getUnconvertedResultExpression() = call |
+      // call == EOF
+      gc.comparesEq(valueNumber(i).getAUse(), eof(), 0, _, _)
+      or
+      // call < 0 (EOF is guaranteed to be negative)
+      gc.comparesLt(valueNumber(i).getAUse(), zero(), 0, true, _)
     )
   )
 }

--- a/cpp/ql/src/change-notes/2024-01-29-incorrectly-checked-scanf-2.md
+++ b/cpp/ql/src/change-notes/2024-01-29-incorrectly-checked-scanf-2.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The "Incorrect return-value check for a 'scanf'-like function" query (`cpp/incorrectly-checked-scanf`) now recognizes more EOF checks.

--- a/cpp/ql/test/query-tests/Critical/MissingCheckScanf/IncorrectCheckScanf.expected
+++ b/cpp/ql/test/query-tests/Critical/MissingCheckScanf/IncorrectCheckScanf.expected
@@ -3,3 +3,4 @@
 | test.cpp:204:7:204:11 | call to scanf | The result of scanf is only checked against 0, but it can also return EOF. |
 | test.cpp:436:7:436:11 | call to scanf | The result of scanf is only checked against 0, but it can also return EOF. |
 | test.cpp:443:11:443:15 | call to scanf | The result of scanf is only checked against 0, but it can also return EOF. |
+| test.cpp:467:8:467:12 | call to scanf | The result of scanf is only checked against 0, but it can also return EOF. |

--- a/cpp/ql/test/query-tests/Critical/MissingCheckScanf/IncorrectCheckScanf.expected
+++ b/cpp/ql/test/query-tests/Critical/MissingCheckScanf/IncorrectCheckScanf.expected
@@ -3,4 +3,3 @@
 | test.cpp:204:7:204:11 | call to scanf | The result of scanf is only checked against 0, but it can also return EOF. |
 | test.cpp:436:7:436:11 | call to scanf | The result of scanf is only checked against 0, but it can also return EOF. |
 | test.cpp:443:11:443:15 | call to scanf | The result of scanf is only checked against 0, but it can also return EOF. |
-| test.cpp:467:8:467:12 | call to scanf | The result of scanf is only checked against 0, but it can also return EOF. |

--- a/cpp/ql/test/query-tests/Critical/MissingCheckScanf/MissingCheckScanf.expected
+++ b/cpp/ql/test/query-tests/Critical/MissingCheckScanf/MissingCheckScanf.expected
@@ -15,3 +15,4 @@
 | test.cpp:416:7:416:7 | i | This variable is read, but may not have been written. It should be guarded by a check that the $@ returns at least 1. | test.cpp:413:7:413:11 | call to scanf | call to scanf |
 | test.cpp:423:7:423:7 | i | This variable is read, but may not have been written. It should be guarded by a check that the $@ returns at least 1. | test.cpp:420:7:420:11 | call to scanf | call to scanf |
 | test.cpp:460:6:460:10 | value | This variable is read, but may not have been written. It should be guarded by a check that the $@ returns at least 1. | test.cpp:455:12:455:17 | call to sscanf | call to sscanf |
+| test.cpp:474:6:474:10 | value | This variable is read, but may not have been written. It should be guarded by a check that the $@ returns at least 1. | test.cpp:467:8:467:12 | call to scanf | call to scanf |

--- a/cpp/ql/test/query-tests/Critical/MissingCheckScanf/test.cpp
+++ b/cpp/ql/test/query-tests/Critical/MissingCheckScanf/test.cpp
@@ -459,3 +459,17 @@ void disjunct_boolean_condition(const char* modifier_data) {
 	}
 	use(value); // GOOD
 }
+
+void check_for_negative_test() {
+	int res;
+	int value;
+
+	res = scanf("%d", &value); // GOOD [FALSE POSITIVE]
+	if(res == 0) {
+		return;
+	}
+	if (res < 0) {
+		return;
+	}
+	use(value);
+}

--- a/cpp/ql/test/query-tests/Critical/MissingCheckScanf/test.cpp
+++ b/cpp/ql/test/query-tests/Critical/MissingCheckScanf/test.cpp
@@ -464,7 +464,7 @@ void check_for_negative_test() {
 	int res;
 	int value;
 
-	res = scanf("%d", &value); // GOOD [FALSE POSITIVE]
+	res = scanf("%d", &value); // GOOD
 	if(res == 0) {
 		return;
 	}


### PR DESCRIPTION
Fixes https://github.com/github/codeql/issues/15415 by correctly identifying that `scanf(...) >= 0` also implies that `scanf(...) != EOF` (because the C standard specifies that `EOF` is negative).

As with https://github.com/github/codeql/pull/15456, this moves the FP to the `cpp/missing-check-scanf` query. I suggest we fix that one in a future PR.