### PR TITLE
False positive fix for cpp/uninitialized-local

### DIFF
--- a/cpp/ql/src/Likely Bugs/Memory Management/UninitializedLocal.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/UninitializedLocal.ql
@@ -56,6 +56,8 @@ VariableAccess commonException() {
   // Finally, exclude functions that contain assembly blocks. It's
   // anyone's guess what happens in those.
   containsInlineAssembly(result.getEnclosingFunction())
+  or
+  exists(Call c | c.getQualifier() = result | c.getTarget().isStatic())
 }
 
 predicate isSinkImpl(Instruction sink, VariableAccess va) {
@@ -86,10 +88,5 @@ from
 where
   conf.hasFlowPath(source, sink) and
   isSinkImpl(sink.getInstruction(), va) and
-  v = va.getTarget() and
-  (
-    exists(Call c | c.getQualifier() = va)
-    implies
-    exists(Call c | c.getQualifier() = va and not c.getTarget().isStatic())
-  )
+  v = va.getTarget()
 select va, "The variable $@ may not be initialized at this access.", v, v.getName()

--- a/cpp/ql/src/Likely Bugs/Memory Management/UninitializedLocal.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/UninitializedLocal.ql
@@ -86,5 +86,10 @@ from
 where
   conf.hasFlowPath(source, sink) and
   isSinkImpl(sink.getInstruction(), va) and
-  v = va.getTarget()
+  v = va.getTarget() and
+  (
+    exists(Call c | c.getQualifier() = va)
+    implies
+    exists(Call c | c.getQualifier() = va and not c.getTarget().isStatic())
+  )
 select va, "The variable $@ may not be initialized at this access.", v, v.getName()

--- a/cpp/ql/src/change-notes/2024-01-29-uninitialized-local-false-positive.md
+++ b/cpp/ql/src/change-notes/2024-01-29-uninitialized-local-false-positive.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Corrected a false positive with `cpp/uninitialized-local`: `a->func()` is a false positive if `func` is static regardless of if `a` is initializeed.

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-457/semmle/tests/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-457/semmle/tests/test.cpp
@@ -533,3 +533,15 @@ int non_exhaustive_switch_2(State s) {
 	}
 	return 0;
 }
+
+class StaticMethodClass{
+    public:
+    static int get(){
+        return 1;
+    }
+};
+
+int static_method_false_positive(){
+    StaticMethodClass *t;
+	int i = t->get(); // GOOD: the `get` method is static and this is equivalent to StaticMethodClass::get()
+}


### PR DESCRIPTION
False positive fix for cpp/uninitialized-local to address unallocated pointer access to static methods. 