### PR TITLE
Check for large runners

### DIFF
--- a/.github/workflows/compile-queries.yml
+++ b/.github/workflows/compile-queries.yml
@@ -9,8 +9,26 @@ on:
   pull_request:
 
 jobs:
+  choose-runner:
+    runs-on: ubuntu-latest
+    outputs:
+      mac-12: ${{ steps.results.outputs.MAC_12 }}
+      ubuntu-latest: ${{ steps.results.outputs.UBUNTU_LATEST }}
+      windows-latest: ${{ steps.results.outputs.WINDOWS_LATEST }}
+    steps:
+      - id: results
+        run: |
+          echo "UBUNTU_LATEST=$UBUNTU_LATEST" >> $GITHUB_OUTPUT
+          echo "MAC_12=$MAC_12" >> $GITHUB_OUTPUT
+          echo "WINDOWS_LATEST=$WINDOWS_LATEST" >> $GITHUB_OUTPUT
+        env:
+          UBUNTU_LATEST: ${{ (github.repository_owner == 'github' || vars.use_large_linux_runners_for_speed) && 'ubuntu-latest-xl' || 'ubuntu-latest' }}
+          MAC_12: ${{ (github.repository_owner == 'github' || vars.use_large_mac_runners_for_speed) && 'macos-12-xl' || 'macos-12' }}
+          WINDOWS_LATEST: ${{ (github.repository_owner == 'github' || vars.use_large_win_runners_for_speed) && 'windows-latest-xl' || 'windows-latest' }}
+
   compile-queries:
-    runs-on: ubuntu-latest-xl
+    needs: choose-runner
+    runs-on: ${{ needs.choose-runner.outputs.ubuntu-latest }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/csharp-qltest.yml
+++ b/.github/workflows/csharp-qltest.yml
@@ -45,8 +45,30 @@ jobs:
            --dbscheme=ql/lib/semmlecode.csharp.dbscheme --target-dbscheme=downgrades/initial/semmlecode.csharp.dbscheme |
            xargs codeql execute upgrades testdb
           diff -q testdb/semmlecode.csharp.dbscheme downgrades/initial/semmlecode.csharp.dbscheme
+
+  choose-runner:
+    defaults:
+      run:
+        working-directory: /tmp
+    runs-on: ubuntu-latest
+    outputs:
+      mac-12: ${{ steps.results.outputs.MAC_12 }}
+      ubuntu-latest: ${{ steps.results.outputs.UBUNTU_LATEST }}
+      windows-latest: ${{ steps.results.outputs.WINDOWS_LATEST }}
+    steps:
+      - id: results
+        run: |
+          echo "UBUNTU_LATEST=$UBUNTU_LATEST" >> $GITHUB_OUTPUT
+          echo "MAC_12=$MAC_12" >> $GITHUB_OUTPUT
+          echo "WINDOWS_LATEST=$WINDOWS_LATEST" >> $GITHUB_OUTPUT
+        env:
+          UBUNTU_LATEST: ${{ (github.repository_owner == 'github' || vars.use_large_linux_runners_for_speed) && 'ubuntu-latest-xl' || 'ubuntu-latest' }}
+          MAC_12: ${{ (github.repository_owner == 'github' || vars.use_large_mac_runners_for_speed) && 'macos-12-xl' || 'macos-12' }}
+          WINDOWS_LATEST: ${{ (github.repository_owner == 'github' || vars.use_large_win_runners_for_speed) && 'windows-latest-xl' || 'windows-latest' }}
+
   qltest:
-    runs-on: ubuntu-latest-xl
+    needs: choose-runner
+    runs-on: ${{ needs.choose-runner.outputs.ubuntu-latest }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/go-tests-other-os.yml
+++ b/.github/workflows/go-tests-other-os.yml
@@ -45,9 +45,27 @@ jobs:
           cd go
           make test cache="${{ steps.query-cache.outputs.cache-dir }}"
 
+  choose-runner:
+    runs-on: ubuntu-latest
+    outputs:
+      mac-12: ${{ steps.results.outputs.MAC_12 }}
+      ubuntu-latest: ${{ steps.results.outputs.UBUNTU_LATEST }}
+      windows-latest: ${{ steps.results.outputs.WINDOWS_LATEST }}
+    steps:
+      - id: results
+        run: |
+          echo "UBUNTU_LATEST=$UBUNTU_LATEST" >> $GITHUB_OUTPUT
+          echo "MAC_12=$MAC_12" >> $GITHUB_OUTPUT
+          echo "WINDOWS_LATEST=$WINDOWS_LATEST" >> $GITHUB_OUTPUT
+        env:
+          UBUNTU_LATEST: ${{ (github.repository_owner == 'github' || vars.use_large_linux_runners_for_speed) && 'ubuntu-latest-xl' || 'ubuntu-latest' }}
+          MAC_12: ${{ (github.repository_owner == 'github' || vars.use_large_mac_runners_for_speed) && 'macos-12-xl' || 'macos-12' }}
+          WINDOWS_LATEST: ${{ (github.repository_owner == 'github' || vars.use_large_win_runners_for_speed) && 'windows-latest-xl' || 'windows-latest' }}
+
   test-win:
     name: Test Windows
-    runs-on: windows-latest-xl
+    needs: choose-runner
+    runs-on: ${{ needs.choose-runner.outputs.windows-latest }}
     steps:
       - name: Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v5

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -18,9 +18,27 @@ on:
 env:
   GO_VERSION: '~1.21.0'
 jobs:
+  choose-runner:
+    runs-on: ubuntu-latest
+    outputs:
+      mac-12: ${{ steps.results.outputs.MAC_12 }}
+      ubuntu-latest: ${{ steps.results.outputs.UBUNTU_LATEST }}
+      windows-latest: ${{ steps.results.outputs.WINDOWS_LATEST }}
+    steps:
+      - id: results
+        run: |
+          echo "UBUNTU_LATEST=$UBUNTU_LATEST" >> $GITHUB_OUTPUT
+          echo "MAC_12=$MAC_12" >> $GITHUB_OUTPUT
+          echo "WINDOWS_LATEST=$WINDOWS_LATEST" >> $GITHUB_OUTPUT
+        env:
+          UBUNTU_LATEST: ${{ (github.repository_owner == 'github' || vars.use_large_linux_runners_for_speed) && 'ubuntu-latest-xl' || 'ubuntu-latest' }}
+          MAC_12: ${{ (github.repository_owner == 'github' || vars.use_large_mac_runners_for_speed) && 'macos-12-xl' || 'macos-12' }}
+          WINDOWS_LATEST: ${{ (github.repository_owner == 'github' || vars.use_large_win_runners_for_speed) && 'windows-latest-xl' || 'windows-latest' }}
+
   test-linux:
     name: Test Linux (Ubuntu)
-    runs-on: ubuntu-latest-xl
+    needs: choose-runner
+    runs-on: ${{ needs.choose-runner.outputs.ubuntu-latest }}
     steps:
       - name: Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v5

--- a/.github/workflows/ql-for-ql-build.yml
+++ b/.github/workflows/ql-for-ql-build.yml
@@ -10,8 +10,26 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  choose-runner:
+    runs-on: ubuntu-latest
+    outputs:
+      mac-12: ${{ steps.results.outputs.MAC_12 }}
+      ubuntu-latest: ${{ steps.results.outputs.UBUNTU_LATEST }}
+      windows-latest: ${{ steps.results.outputs.WINDOWS_LATEST }}
+    steps:
+      - id: results
+        run: |
+          echo "UBUNTU_LATEST=$UBUNTU_LATEST" >> $GITHUB_OUTPUT
+          echo "MAC_12=$MAC_12" >> $GITHUB_OUTPUT
+          echo "WINDOWS_LATEST=$WINDOWS_LATEST" >> $GITHUB_OUTPUT
+        env:
+          UBUNTU_LATEST: ${{ (github.repository_owner == 'github' || vars.use_large_linux_runners_for_speed) && 'ubuntu-latest-xl' || 'ubuntu-latest' }}
+          MAC_12: ${{ (github.repository_owner == 'github' || vars.use_large_mac_runners_for_speed) && 'macos-12-xl' || 'macos-12' }}
+          WINDOWS_LATEST: ${{ (github.repository_owner == 'github' || vars.use_large_win_runners_for_speed) && 'windows-latest-xl' || 'windows-latest' }}
+
   analyze:
-    runs-on: ubuntu-latest-xl
+    needs: choose-runner
+    runs-on: ${{ needs.choose-runner.outputs.ubuntu-latest }}
     steps:
       ### Build the queries ###
       - uses: actions/checkout@v4

--- a/.github/workflows/ruby-build.yml
+++ b/.github/workflows/ruby-build.yml
@@ -110,8 +110,29 @@ jobs:
             ruby/extractor/target/release/codeql-extractor-ruby
             ruby/extractor/target/release/codeql-extractor-ruby.exe
           retention-days: 1
+  choose-runner:
+    defaults:
+      run:
+        working-directory: /tmp
+    runs-on: ubuntu-latest
+    outputs:
+      mac-12: ${{ steps.results.outputs.MAC_12 }}
+      ubuntu-latest: ${{ steps.results.outputs.UBUNTU_LATEST }}
+      windows-latest: ${{ steps.results.outputs.WINDOWS_LATEST }}
+    steps:
+      - id: results
+        run: |
+          echo "UBUNTU_LATEST=$UBUNTU_LATEST" >> $GITHUB_OUTPUT
+          echo "MAC_12=$MAC_12" >> $GITHUB_OUTPUT
+          echo "WINDOWS_LATEST=$WINDOWS_LATEST" >> $GITHUB_OUTPUT
+        env:
+          UBUNTU_LATEST: ${{ (github.repository_owner == 'github' || vars.use_large_linux_runners_for_speed) && 'ubuntu-latest-xl' || 'ubuntu-latest' }}
+          MAC_12: ${{ (github.repository_owner == 'github' || vars.use_large_mac_runners_for_speed) && 'macos-12-xl' || 'macos-12' }}
+          WINDOWS_LATEST: ${{ (github.repository_owner == 'github' || vars.use_large_win_runners_for_speed) && 'windows-latest-xl' || 'windows-latest' }}
+
   compile-queries:
-    runs-on: ubuntu-latest-xl
+    needs: choose-runner
+    runs-on: ${{ needs.choose-runner.outputs.ubuntu-latest }}
     steps:
       - uses: actions/checkout@v4
       - name: Fetch CodeQL

--- a/.github/workflows/ruby-qltest.yml
+++ b/.github/workflows/ruby-qltest.yml
@@ -49,8 +49,30 @@ jobs:
            --dbscheme=ql/lib/ruby.dbscheme --target-dbscheme=downgrades/initial/ruby.dbscheme |
            xargs codeql execute upgrades testdb
           diff -q testdb/ruby.dbscheme downgrades/initial/ruby.dbscheme
+
+  choose-runner:
+    defaults:
+      run:
+        working-directory: /tmp
+    runs-on: ubuntu-latest
+    outputs:
+      mac-12: ${{ steps.results.outputs.MAC_12 }}
+      ubuntu-latest: ${{ steps.results.outputs.UBUNTU_LATEST }}
+      windows-latest: ${{ steps.results.outputs.WINDOWS_LATEST }}
+    steps:
+      - id: results
+        run: |
+          echo "UBUNTU_LATEST=$UBUNTU_LATEST" >> $GITHUB_OUTPUT
+          echo "MAC_12=$MAC_12" >> $GITHUB_OUTPUT
+          echo "WINDOWS_LATEST=$WINDOWS_LATEST" >> $GITHUB_OUTPUT
+        env:
+          UBUNTU_LATEST: ${{ (github.repository_owner == 'github' || vars.use_large_linux_runners_for_speed) && 'ubuntu-latest-xl' || 'ubuntu-latest' }}
+          MAC_12: ${{ (github.repository_owner == 'github' || vars.use_large_mac_runners_for_speed) && 'macos-12-xl' || 'macos-12' }}
+          WINDOWS_LATEST: ${{ (github.repository_owner == 'github' || vars.use_large_win_runners_for_speed) && 'windows-latest-xl' || 'windows-latest' }}
+
   qltest:
-    runs-on: ubuntu-latest-xl
+    needs: choose-runner
+    runs-on: ${{ needs.choose-runner.outputs.ubuntu-latest }}
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -34,41 +34,68 @@ on:
       - codeql-cli-*
 
 jobs:
+  choose-runner:
+    runs-on: ubuntu-latest
+    outputs:
+      mac-12: ${{ steps.results.outputs.MAC_12 }}
+      ubuntu-latest: ${{ steps.results.outputs.UBUNTU_LATEST }}
+      windows-latest: ${{ steps.results.outputs.WINDOWS_LATEST }}
+    steps:
+      - id: results
+        run: |
+          echo "UBUNTU_LATEST=$UBUNTU_LATEST" >> $GITHUB_OUTPUT
+          echo "MAC_12=$MAC_12" >> $GITHUB_OUTPUT
+          echo "WINDOWS_LATEST=$WINDOWS_LATEST" >> $GITHUB_OUTPUT
+        env:
+          UBUNTU_LATEST: ${{ (github.repository_owner == 'github' || vars.use_large_linux_runners_for_speed) && 'ubuntu-latest-xl' || 'ubuntu-latest' }}
+          MAC_12: ${{ (github.repository_owner == 'github' || vars.use_large_mac_runners_for_speed) && 'macos-12-xl' || 'macos-12' }}
+          WINDOWS_LATEST: ${{ (github.repository_owner == 'github' || vars.use_large_win_runners_for_speed) && 'windows-latest-xl' || 'windows-latest' }}
+
   # not using a matrix as you cannot depend on a specific job in a matrix, and we want to start linux checks
   # without waiting for the macOS build
   build-and-test-macos:
-    runs-on: macos-12-xl
+    needs: choose-runner
+    runs-on: ${{ needs.choose-runner.outputs.mac-12 }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./swift/actions/build-and-test
   build-and-test-linux:
-    runs-on: ubuntu-latest-xl
+    needs: choose-runner
+    runs-on: ${{ needs.choose-runner.outputs.ubuntu-latest }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./swift/actions/build-and-test
   qltests-linux:
-    needs: build-and-test-linux
-    runs-on: ubuntu-latest-xl
+    needs:
+      - build-and-test-linux
+      - choose-runner
+    runs-on: ${{ needs.choose-runner.outputs.ubuntu-latest }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./swift/actions/run-ql-tests
   qltests-macos:
     if : ${{ github.event_name == 'pull_request' }}
-    needs: build-and-test-macos
-    runs-on: macos-12-xl
+    needs:
+      - build-and-test-macos
+      - choose-runner
+    runs-on: ${{ needs.choose-runner.outputs.mac-12 }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./swift/actions/run-ql-tests
   integration-tests-linux:
-    needs: build-and-test-linux
-    runs-on: ubuntu-latest-xl
+    needs:
+      - build-and-test-linux
+      - choose-runner
+    runs-on: ${{ needs.choose-runner.outputs.ubuntu-latest }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./swift/actions/run-integration-tests
   integration-tests-macos:
     if : ${{ github.event_name == 'pull_request' }}
-    needs: build-and-test-macos
-    runs-on: macos-12-xl
+    needs:
+      - build-and-test-macos
+      - choose-runner
+    runs-on: ${{ needs.choose-runner.outputs.mac-12 }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
fixes #15464

Variable | Runner to use if set to `1`
-|-
`use_large_linux_runners_for_speed` | `ubuntu-latest-xl`
`use_large_mac_runners_for_speed` | `macos-12-xl`
`use_large_win_runners_for_speed` | `windows-latest-xl`

For simplicity, I'm copy-pasting the entire block to each workflow that needs it, this means that updating the rules can be done w/ a search+replace instead of worrying about things getting out of sync. The cost of checking each of them is minimal (especially vs the cost of running on a slow runner or waiting forever for a runner that will never happen).