### PR TITLE
Ruby: Only generate models for public methods

### DIFF
--- a/ruby/ql/src/queries/modeling/internal/Util.qll
+++ b/ruby/ql/src/queries/modeling/internal/Util.qll
@@ -43,6 +43,7 @@ string getArgumentPath(DataFlow::ParameterNode paramNode) {
  */
 predicate pathToMethod(DataFlow::MethodNode method, string type, string path) {
   method.getLocation().getFile() instanceof RelevantFile and
+  method.isPublic() and // only public methods are modeled
   exists(DataFlow::ModuleNode mod, string methodName |
     method = mod.getOwnInstanceMethod(methodName) and
     if methodName = "initialize"


### PR DESCRIPTION
When using the [`GenerateModel.ql`](https://github.com/github/codeql/blob/c265c15f3f4fa2058d9172d4f078fe6c7760eaf0/ruby/ql/src/queries/modeling/GenerateModel.ql) query, it was generating type models for private methods. These don't add any value for consumers of the library, so we don't need to model those. Therefore, this will only allow modeling of public methods.