### PR TITLE
C++: Add PreprocBlock.qll library

### DIFF
--- a/cpp/ql/lib/change-notes/2024-01-30-preproc-block.md
+++ b/cpp/ql/lib/change-notes/2024-01-30-preproc-block.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added the `PreprocBlock.qll` library to this repository.  This library offers a view of `#if`, `#elif`, `#else` and similar directives as a tree with navigable parent-child relationships.

--- a/cpp/ql/lib/change-notes/2024-01-30-preproc-block.md
+++ b/cpp/ql/lib/change-notes/2024-01-30-preproc-block.md
@@ -1,4 +1,4 @@
 ---
-category: minorAnalysis
+category: feature
 ---
 * Added the `PreprocBlock.qll` library to this repository.  This library offers a view of `#if`, `#elif`, `#else` and similar directives as a tree with navigable parent-child relationships.

--- a/cpp/ql/lib/semmle/code/cpp/headers/PreprocBlock.qll
+++ b/cpp/ql/lib/semmle/code/cpp/headers/PreprocBlock.qll
@@ -1,3 +1,10 @@
+/**
+ * This library offers a view of preprocessor branches (`#if`, `#ifdef`,
+ * `#ifndef`, `#elif` and `#else`) as blocks of code between the opening and
+ * closing directives, with navigable parent-child relationships to other
+ * blocks. The main class is `PreprocessorBlock`.
+ */
+
 import cpp
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/headers/PreprocBlock.qll
+++ b/cpp/ql/lib/semmle/code/cpp/headers/PreprocBlock.qll
@@ -62,14 +62,26 @@ class PreprocessorBlock extends @element {
     endcolumn = 0
   }
 
+  /**
+   * Gets a textual representation of this element.
+   */
   string toString() { result = mkElement(this).toString() }
 
+  /**
+   * Gets the file this `PreprocessorBlock` is located in.
+   */
   cached
   File getFile() { result = mkElement(this).getFile() }
 
+  /**
+   * Gets the start line number of this `PreprocessorBlock`.
+   */
   cached
   int getStartLine() { result = mkElement(this).getLocation().getStartLine() }
 
+  /**
+   * Gets the end line number of this `PreprocessorBlock`.
+   */
   cached
   int getEndLine() {
     result = mkElement(this).(File).getMetrics().getNumberOfLines() or

--- a/cpp/ql/lib/semmle/code/cpp/headers/PreprocBlock.qll
+++ b/cpp/ql/lib/semmle/code/cpp/headers/PreprocBlock.qll
@@ -10,7 +10,6 @@ import cpp
 /**
  * Gets the line of the `ix`th `PreprocessorBranchDirective` in file `f`.
  */
-cached
 private int getPreprocLineFromIndex(File f, int ix) {
   result =
     rank[ix](PreprocessorBranchDirective g | g.getFile() = f | g.getLocation().getStartLine())
@@ -70,26 +69,22 @@ class PreprocessorBlock extends @element {
   /**
    * Gets the file this `PreprocessorBlock` is located in.
    */
-  cached
   File getFile() { result = mkElement(this).getFile() }
 
   /**
    * Gets the start line number of this `PreprocessorBlock`.
    */
-  cached
   int getStartLine() { result = mkElement(this).getLocation().getStartLine() }
 
   /**
    * Gets the end line number of this `PreprocessorBlock`.
    */
-  cached
   int getEndLine() {
     result = mkElement(this).(File).getMetrics().getNumberOfLines() or
     result =
       mkElement(this).(PreprocessorBranchDirective).getNext().getLocation().getStartLine() - 1
   }
 
-  cached
   private PreprocessorBlock getParentInternal() {
     // find the `#ifdef` corresponding to this block and the
     // PreprocessorBranchDirective `prev` that came directly

--- a/cpp/ql/lib/semmle/code/cpp/headers/PreprocBlock.qll
+++ b/cpp/ql/lib/semmle/code/cpp/headers/PreprocBlock.qll
@@ -1,0 +1,151 @@
+import cpp
+
+/**
+ * Gets the line of the `ix`th `PreprocessorBranchDirective` in file `f`.
+ */
+private cached int getPreprocLineFromIndex(File f, int ix) {
+  result = rank[ix](
+    PreprocessorBranchDirective g |
+    g.getFile() = f |
+    g.getLocation().getStartLine()
+  )
+}
+
+/**
+ * Gets the `ix`th `PreprocessorBranchDirective` in file `f`.
+ */
+private PreprocessorBranchDirective getPreprocFromIndex(File f, int ix) {
+  result.getFile() = f and
+  result.getLocation().getStartLine() = getPreprocLineFromIndex(f, ix)
+}
+
+/**
+ * Get the index of a `PreprocessorBranchDirective` in its `file`.
+ */
+private int getPreprocIndex(PreprocessorBranchDirective directive)
+{
+  directive = getPreprocFromIndex(directive.getFile(), result)
+}
+
+/**
+ * A chunk of code from one preprocessor branch (`#if`, `#ifdef`,
+ * `#ifndef`, `#elif` or `#else`) to the directive that closes it
+ * (`#elif`, `#else` or `#endif`).  The `getParent()` method
+ * allows these blocks to be navigated as a tree, with the root
+ * being the entire file.
+ */
+class PreprocessorBlock extends @element {
+  PreprocessorBlock() {
+    mkElement(this) instanceof File or
+    mkElement(this) instanceof PreprocessorBranch or
+    mkElement(this) instanceof PreprocessorElse
+  }
+
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
+   */
+  predicate hasLocationInfo(string filepath,
+                            int startline, int startcolumn,
+                            int endline, int endcolumn) {
+    filepath = this.getFile().toString() and
+    startline = this.getStartLine() and
+    startcolumn = 0 and
+    endline = this.getEndLine() and
+    endcolumn = 0
+  }
+
+  string toString() {
+    result = mkElement(this).toString()
+  }
+
+  cached File getFile() {
+    result = mkElement(this).getFile()
+  }
+
+  cached int getStartLine() {
+    result = mkElement(this).getLocation().getStartLine()
+  }
+
+  cached int getEndLine() {
+    result = mkElement(this).(File).getMetrics().getNumberOfLines() or
+    result = mkElement(this).(PreprocessorBranchDirective).getNext().getLocation().getStartLine() - 1
+  }
+
+  private cached PreprocessorBlock getParentInternal() {
+    // find the `#ifdef` corresponding to this block and the
+    // PreprocessorBranchDirective `prev` that came directly
+    // before it in the source.
+    exists(int ix, PreprocessorBranchDirective prev |
+      ix = getPreprocIndex(mkElement(this).(PreprocessorBranchDirective).getIf()) and
+      prev = getPreprocFromIndex(getFile(), ix - 1) |
+      if (prev instanceof PreprocessorEndif) then (
+        // if we follow an #endif, we have the same parent
+        // as its corresponding `#if` has.
+        result = unresolveElement(prev.getIf()).(PreprocessorBlock).getParentInternal()
+      ) else (
+        // otherwise we directly follow an #if / #ifdef / #ifndef /
+        // #elif / #else that must be a level above and our parent
+        // block.
+        mkElement(result) = prev
+      )
+    )
+  }
+
+  /**
+   * Gets the `PreprocessorBlock` that's directly surrounding this one.
+   * Has no result if this is a file.
+   */
+  PreprocessorBlock getParent() {
+    not mkElement(this) instanceof File and
+    (
+      if exists(getParentInternal()) then (
+        // found parent directive
+        result = getParentInternal()
+      ) else (
+        // top level directive
+        mkElement(result) = getFile()
+      )
+    )
+  }
+  
+  /**
+   * Gets a `PreprocessorBlock` that's directly inside this one.
+   */
+  PreprocessorBlock getAChild() {
+    result.getParent() = this
+  }
+
+  private Include getAnEnclosedInclude() {
+    result.getFile() = getFile() and
+    result.getLocation().getStartLine() > getStartLine() and
+    result.getLocation().getStartLine() <= getEndLine()
+  }
+
+  /**
+   * Gets an include directive that is directly in this
+   * `PreprocessorBlock`.
+   */ 
+  Include getAnInclude() {
+    result = getAnEnclosedInclude() and
+    not result = getAChild().getAnEnclosedInclude()
+  }
+
+  private Macro getAnEnclosedMacro() {
+    result.getFile() = getFile() and
+    result.getLocation().getStartLine() > getStartLine() and
+    result.getLocation().getStartLine() <= getEndLine()
+  }
+
+  /**
+   * Gets a macro definition that is directly in this
+   * `PreprocessorBlock`.
+   */ 
+  Macro getAMacro() {
+    result = getAnEnclosedMacro() and
+    not result = getAChild().getAnEnclosedMacro()
+  }
+}

--- a/cpp/ql/lib/semmle/code/cpp/headers/PreprocBlock.qll
+++ b/cpp/ql/lib/semmle/code/cpp/headers/PreprocBlock.qll
@@ -3,12 +3,10 @@ import cpp
 /**
  * Gets the line of the `ix`th `PreprocessorBranchDirective` in file `f`.
  */
-private cached int getPreprocLineFromIndex(File f, int ix) {
-  result = rank[ix](
-    PreprocessorBranchDirective g |
-    g.getFile() = f |
-    g.getLocation().getStartLine()
-  )
+cached
+private int getPreprocLineFromIndex(File f, int ix) {
+  result =
+    rank[ix](PreprocessorBranchDirective g | g.getFile() = f | g.getLocation().getStartLine())
 }
 
 /**
@@ -22,8 +20,7 @@ private PreprocessorBranchDirective getPreprocFromIndex(File f, int ix) {
 /**
  * Get the index of a `PreprocessorBranchDirective` in its `file`.
  */
-private int getPreprocIndex(PreprocessorBranchDirective directive)
-{
+private int getPreprocIndex(PreprocessorBranchDirective directive) {
   directive = getPreprocFromIndex(directive.getFile(), result)
 }
 
@@ -48,9 +45,9 @@ class PreprocessorBlock extends @element {
    * For more information, see
    * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
    */
-  predicate hasLocationInfo(string filepath,
-                            int startline, int startcolumn,
-                            int endline, int endcolumn) {
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
     filepath = this.getFile().toString() and
     startline = this.getStartLine() and
     startcolumn = 0 and
@@ -58,40 +55,40 @@ class PreprocessorBlock extends @element {
     endcolumn = 0
   }
 
-  string toString() {
-    result = mkElement(this).toString()
-  }
+  string toString() { result = mkElement(this).toString() }
 
-  cached File getFile() {
-    result = mkElement(this).getFile()
-  }
+  cached
+  File getFile() { result = mkElement(this).getFile() }
 
-  cached int getStartLine() {
-    result = mkElement(this).getLocation().getStartLine()
-  }
+  cached
+  int getStartLine() { result = mkElement(this).getLocation().getStartLine() }
 
-  cached int getEndLine() {
+  cached
+  int getEndLine() {
     result = mkElement(this).(File).getMetrics().getNumberOfLines() or
-    result = mkElement(this).(PreprocessorBranchDirective).getNext().getLocation().getStartLine() - 1
+    result =
+      mkElement(this).(PreprocessorBranchDirective).getNext().getLocation().getStartLine() - 1
   }
 
-  private cached PreprocessorBlock getParentInternal() {
+  cached
+  private PreprocessorBlock getParentInternal() {
     // find the `#ifdef` corresponding to this block and the
     // PreprocessorBranchDirective `prev` that came directly
     // before it in the source.
     exists(int ix, PreprocessorBranchDirective prev |
       ix = getPreprocIndex(mkElement(this).(PreprocessorBranchDirective).getIf()) and
-      prev = getPreprocFromIndex(getFile(), ix - 1) |
-      if (prev instanceof PreprocessorEndif) then (
+      prev = getPreprocFromIndex(getFile(), ix - 1)
+    |
+      if prev instanceof PreprocessorEndif
+      then
         // if we follow an #endif, we have the same parent
         // as its corresponding `#if` has.
         result = unresolveElement(prev.getIf()).(PreprocessorBlock).getParentInternal()
-      ) else (
+      else
         // otherwise we directly follow an #if / #ifdef / #ifndef /
         // #elif / #else that must be a level above and our parent
         // block.
         mkElement(result) = prev
-      )
     )
   }
 
@@ -102,22 +99,20 @@ class PreprocessorBlock extends @element {
   PreprocessorBlock getParent() {
     not mkElement(this) instanceof File and
     (
-      if exists(getParentInternal()) then (
+      if exists(getParentInternal())
+      then
         // found parent directive
         result = getParentInternal()
-      ) else (
+      else
         // top level directive
         mkElement(result) = getFile()
-      )
     )
   }
-  
+
   /**
    * Gets a `PreprocessorBlock` that's directly inside this one.
    */
-  PreprocessorBlock getAChild() {
-    result.getParent() = this
-  }
+  PreprocessorBlock getAChild() { result.getParent() = this }
 
   private Include getAnEnclosedInclude() {
     result.getFile() = getFile() and
@@ -128,7 +123,7 @@ class PreprocessorBlock extends @element {
   /**
    * Gets an include directive that is directly in this
    * `PreprocessorBlock`.
-   */ 
+   */
   Include getAnInclude() {
     result = getAnEnclosedInclude() and
     not result = getAChild().getAnEnclosedInclude()
@@ -143,7 +138,7 @@ class PreprocessorBlock extends @element {
   /**
    * Gets a macro definition that is directly in this
    * `PreprocessorBlock`.
-   */ 
+   */
   Macro getAMacro() {
     result = getAnEnclosedMacro() and
     not result = getAChild().getAnEnclosedMacro()

--- a/cpp/ql/lib/semmle/code/cpp/headers/PreprocBlock.qll
+++ b/cpp/ql/lib/semmle/code/cpp/headers/PreprocBlock.qll
@@ -96,7 +96,7 @@ class PreprocessorBlock extends @element {
     // before it in the source.
     exists(int ix, PreprocessorBranchDirective prev |
       ix = getPreprocIndex(mkElement(this).(PreprocessorBranchDirective).getIf()) and
-      prev = getPreprocFromIndex(getFile(), ix - 1)
+      prev = getPreprocFromIndex(this.getFile(), ix - 1)
     |
       if prev instanceof PreprocessorEndif
       then
@@ -118,13 +118,13 @@ class PreprocessorBlock extends @element {
   PreprocessorBlock getParent() {
     not mkElement(this) instanceof File and
     (
-      if exists(getParentInternal())
+      if exists(this.getParentInternal())
       then
         // found parent directive
-        result = getParentInternal()
+        result = this.getParentInternal()
       else
         // top level directive
-        mkElement(result) = getFile()
+        mkElement(result) = this.getFile()
     )
   }
 
@@ -134,9 +134,9 @@ class PreprocessorBlock extends @element {
   PreprocessorBlock getAChild() { result.getParent() = this }
 
   private Include getAnEnclosedInclude() {
-    result.getFile() = getFile() and
-    result.getLocation().getStartLine() > getStartLine() and
-    result.getLocation().getStartLine() <= getEndLine()
+    result.getFile() = this.getFile() and
+    result.getLocation().getStartLine() > this.getStartLine() and
+    result.getLocation().getStartLine() <= this.getEndLine()
   }
 
   /**
@@ -144,14 +144,14 @@ class PreprocessorBlock extends @element {
    * `PreprocessorBlock`.
    */
   Include getAnInclude() {
-    result = getAnEnclosedInclude() and
-    not result = getAChild().getAnEnclosedInclude()
+    result = this.getAnEnclosedInclude() and
+    not result = this.getAChild().getAnEnclosedInclude()
   }
 
   private Macro getAnEnclosedMacro() {
-    result.getFile() = getFile() and
-    result.getLocation().getStartLine() > getStartLine() and
-    result.getLocation().getStartLine() <= getEndLine()
+    result.getFile() = this.getFile() and
+    result.getLocation().getStartLine() > this.getStartLine() and
+    result.getLocation().getStartLine() <= this.getEndLine()
   }
 
   /**
@@ -159,7 +159,7 @@ class PreprocessorBlock extends @element {
    * `PreprocessorBlock`.
    */
   Macro getAMacro() {
-    result = getAnEnclosedMacro() and
-    not result = getAChild().getAnEnclosedMacro()
+    result = this.getAnEnclosedMacro() and
+    not result = this.getAChild().getAnEnclosedMacro()
   }
 }

--- a/cpp/ql/test/library-tests/headers/preprocBlock/header.h
+++ b/cpp/ql/test/library-tests/headers/preprocBlock/header.h
@@ -1,0 +1,8 @@
+// header.h
+
+#ifndef HEADER_H
+#define HEADER_H
+
+	// ...
+
+#endif // HEADER_H

--- a/cpp/ql/test/library-tests/headers/preprocBlock/preprocblock.cpp
+++ b/cpp/ql/test/library-tests/headers/preprocBlock/preprocblock.cpp
@@ -1,0 +1,25 @@
+// preprocblock.cpp
+
+#include "header.h"
+#define GREEN
+
+#ifdef RED
+#elif defined GREEN
+	#include "header.h"
+
+	#ifndef BLUE
+		#include "header.h"
+	#endif
+
+	#if 0
+		#include "header.h" // not reached
+	#else
+		#include "header.h"
+	#endif
+
+	#include "header.h"
+#else
+
+	// ...
+
+#endif

--- a/cpp/ql/test/library-tests/headers/preprocBlock/preprocblock.expected
+++ b/cpp/ql/test/library-tests/headers/preprocBlock/preprocblock.expected
@@ -1,0 +1,10 @@
+| #elif defined GREEN | preprocblock.cpp:10:0:11:0 | #ifndef BLUE |
+| #elif defined GREEN | preprocblock.cpp:14:0:15:0 | #if 0 |
+| #elif defined GREEN | preprocblock.cpp:16:0:17:0 | #else |
+| (no parent) | file://:0:0:0:0 |  |
+| (no parent) | header.h:0:0:8:0 | header.h |
+| (no parent) | preprocblock.cpp:0:0:25:0 | preprocblock.cpp |
+| header.h | header.h:3:0:7:0 | #ifndef HEADER_H |
+| preprocblock.cpp | preprocblock.cpp:6:0:6:0 | #ifdef RED |
+| preprocblock.cpp | preprocblock.cpp:7:0:20:0 | #elif defined GREEN |
+| preprocblock.cpp | preprocblock.cpp:21:0:24:0 | #else |

--- a/cpp/ql/test/library-tests/headers/preprocBlock/preprocblock.ql
+++ b/cpp/ql/test/library-tests/headers/preprocBlock/preprocblock.ql
@@ -1,0 +1,6 @@
+import cpp
+import semmle.code.cpp.headers.PreprocBlock
+
+from PreprocessorBlock b, string parent
+where if exists(b.getParent()) then parent = b.getParent().toString() else parent = "(no parent)"
+select parent, b

--- a/cpp/ql/test/library-tests/headers/preprocBlock/preprocinclude.expected
+++ b/cpp/ql/test/library-tests/headers/preprocBlock/preprocinclude.expected
@@ -1,0 +1,5 @@
+| preprocblock.cpp:3:1:3:19 | #include "header.h" | preprocblock.cpp:0:0:25:0 | preprocblock.cpp |
+| preprocblock.cpp:8:2:8:20 | #include "header.h" | preprocblock.cpp:7:0:20:0 | #elif defined GREEN |
+| preprocblock.cpp:11:3:11:21 | #include "header.h" | preprocblock.cpp:10:0:11:0 | #ifndef BLUE |
+| preprocblock.cpp:17:3:17:21 | #include "header.h" | preprocblock.cpp:16:0:17:0 | #else |
+| preprocblock.cpp:20:2:20:20 | #include "header.h" | preprocblock.cpp:7:0:20:0 | #elif defined GREEN |

--- a/cpp/ql/test/library-tests/headers/preprocBlock/preprocinclude.ql
+++ b/cpp/ql/test/library-tests/headers/preprocBlock/preprocinclude.ql
@@ -1,0 +1,6 @@
+import cpp
+import semmle.code.cpp.headers.PreprocBlock
+
+from PreprocessorBlock b, Include i
+where b.getAnInclude() = i
+select i, b


### PR DESCRIPTION
The `PreprocBlock.qll` library offers a view of `#if`, `#elif`, `#else` and similar directives (and the code they contain) as a tree.  That is, there's a parent-child relationship between blocks (identified by their opening directive), as well as the ability to tell what include statements and macro definitions are contained within each block.

---

The `preprocblock.expected` test is a good place to start if the above isn't crystal clear.

This is actually an old library, but until now it's not been available in the codeql repo.