### PR TITLE
Ruby: Only model relevant files for type models

### DIFF
--- a/ruby/ql/src/queries/modeling/internal/Types.qll
+++ b/ruby/ql/src/queries/modeling/internal/Types.qll
@@ -48,7 +48,11 @@ module Types {
     // class Type2 < Type1
     // class Type2; include Type1
     exists(Module m1, Module m2 |
-      m2.getAnImmediateAncestor() = m1 and not m2.isBuiltin() and not m1.isBuiltin()
+      m2.getAnImmediateAncestor() = m1 and
+      not m2.isBuiltin() and
+      not m1.isBuiltin() and
+      m1.getLocation().getFile() instanceof Util::RelevantFile and
+      m2.getLocation().getFile() instanceof Util::RelevantFile
     |
       m1.getQualifiedName() = type1 and m2.getQualifiedName() = type2 and path = ""
     )

--- a/ruby/ql/src/queries/modeling/internal/Util.qll
+++ b/ruby/ql/src/queries/modeling/internal/Util.qll
@@ -6,12 +6,22 @@ private import ruby
 private import codeql.ruby.ApiGraphs
 
 /**
+ * A file that probably contains tests.
+ */
+class TestFile extends File {
+  TestFile() {
+    this.getRelativePath().regexpMatch(".*(test|spec|examples).+") and
+    not this.getAbsolutePath().matches("%/ql/test/%") // allows our test cases to work
+  }
+}
+
+/**
  * A file that is relevant in the context of library modeling.
  *
  * In practice, this means a file that is not part of test code.
  */
 class RelevantFile extends File {
-  RelevantFile() { not this.getRelativePath().regexpMatch(".*/?test(case)?s?/.*") }
+  RelevantFile() { not this instanceof TestFile }
 }
 
 /**


### PR DESCRIPTION
When we have a test like [`class BlankTest < Minitest::Test`](https://github.com/Shopify/liquid/blob/9b38a1528266aec36918a5188563d9c42b2500ea/test/integration/blank_test.rb#L12), we shouldn't create a model like `"Minitest::Test", "BlankTest", ""` since the `BlankTest` is irrelevant for consumers of the library. This fixes it by only considering these models where both modules are in relevant files (i.e. in non-test files).