### PR TITLE
Go: Include versions in newer Go version needed diagnostic

### DIFF
--- a/go/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/go/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -546,7 +546,7 @@ func installDependenciesAndBuild() {
 	// This diagnostic is not required if the system Go version is 1.21 or greater, since the
 	// Go tooling should install required Go versions as needed.
 	if semver.Compare(getEnvGoSemVer(), "v1.21.0") < 0 && goVersionInfo.Found && semver.Compare("v"+goVersionInfo.Version, getEnvGoSemVer()) > 0 {
-		diagnostics.EmitNewerGoVersionNeeded()
+		diagnostics.EmitNewerGoVersionNeeded(getEnvGoSemVer(), "v"+goVersionInfo.Version)
 		if val, _ := os.LookupEnv("GITHUB_ACTIONS"); val == "true" {
 			log.Printf("The go.mod version is newer than the installed version of Go. Consider adding an actions/setup-go step to your workflow.\n")
 		}

--- a/go/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/go/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -548,7 +548,10 @@ func installDependenciesAndBuild() {
 	if semver.Compare(getEnvGoSemVer(), "v1.21.0") < 0 && goVersionInfo.Found && semver.Compare("v"+goVersionInfo.Version, getEnvGoSemVer()) > 0 {
 		diagnostics.EmitNewerGoVersionNeeded(getEnvGoSemVer(), "v"+goVersionInfo.Version)
 		if val, _ := os.LookupEnv("GITHUB_ACTIONS"); val == "true" {
-			log.Printf("The go.mod version is newer than the installed version of Go. Consider adding an actions/setup-go step to your workflow.\n")
+			log.Printf(
+				"The go.mod file requires version %s of Go, but version %s is installed. Consider adding an actions/setup-go step to your workflow.\n",
+				"v"+goVersionInfo.Version,
+				getEnvGoSemVer())
 		}
 	}
 

--- a/go/extractor/diagnostics/diagnostics.go
+++ b/go/extractor/diagnostics/diagnostics.go
@@ -168,11 +168,11 @@ func EmitCannotFindPackages(pkgPaths []string) {
 	)
 }
 
-func EmitNewerGoVersionNeeded() {
+func EmitNewerGoVersionNeeded(installedVersion string, requiredVersion string) {
 	emitDiagnostic(
 		"go/autobuilder/newer-go-version-needed",
 		"Newer Go version needed",
-		"The detected version of Go is lower than the version specified in `go.mod`. [Install a newer version](https://github.com/actions/setup-go#basic).",
+		"Version `"+installedVersion+"` of Go is installed, but this is lower than `"+requiredVersion+"` required by your project's `go.mod`. [Install a newer version of Go before analyzing your project](https://github.com/actions/setup-go#basic).",
 		severityError,
 		fullVisibility,
 		noLocation,


### PR DESCRIPTION
This PR slightly improves the `go/autobuilder/newer-go-version-needed` diagnostic by including version information as well making it clearer what the versions relate to.