### PR TITLE
Declare permissions

### DIFF
--- a/.github/workflows/check-change-note.yml
+++ b/.github/workflows/check-change-note.yml
@@ -1,5 +1,8 @@
 name: Check change note
 
+permissions:
+  pull-requests: read
+
 on:
   pull_request_target:
     types: [labeled, unlabeled, opened, synchronize, reopened, ready_for_review]

--- a/.github/workflows/check-implicit-this.yml
+++ b/.github/workflows/check-implicit-this.yml
@@ -9,6 +9,9 @@ on:
       - main
       - "rc/*"
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-qldoc.yml
+++ b/.github/workflows/check-qldoc.yml
@@ -10,6 +10,9 @@ on:
       - main
       - "rc/*"
 
+permissions:
+  contents: read
+
 jobs:
   qldoc:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-query-ids.yml
+++ b/.github/workflows/check-query-ids.yml
@@ -11,6 +11,9 @@ on:
       - "rc/*"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Check query IDs

--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "30 1 * * *"
 
+permissions:
+  issues: write
+
 jobs:
   stale:
     if: github.repository == 'github/codeql'

--- a/.github/workflows/compile-queries.yml
+++ b/.github/workflows/compile-queries.yml
@@ -8,6 +8,9 @@ on:
       - "codeql-cli-*"
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   compile-queries:
     if: github.repository_owner == 'github'

--- a/.github/workflows/csharp-qltest.yml
+++ b/.github/workflows/csharp-qltest.yml
@@ -25,6 +25,9 @@ defaults:
   run:
     working-directory: csharp
 
+permissions:
+  contents: read
+
 jobs:
   qlupgrade:
     runs-on: ubuntu-latest

--- a/.github/workflows/csv-coverage-metrics.yml
+++ b/.github/workflows/csv-coverage-metrics.yml
@@ -14,6 +14,10 @@ on:
       - ".github/workflows/csv-coverage-metrics.yml"
       - ".github/actions/fetch-codeql/action.yml"
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   publish-java:
     runs-on: ubuntu-latest

--- a/.github/workflows/csv-coverage-pr-artifacts.yml
+++ b/.github/workflows/csv-coverage-pr-artifacts.yml
@@ -19,6 +19,10 @@ on:
       - main
       - "rc/*"
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   generate:
     name: Generate framework coverage artifacts

--- a/.github/workflows/csv-coverage-pr-comment.yml
+++ b/.github/workflows/csv-coverage-pr-comment.yml
@@ -6,6 +6,10 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   check:
     name: Check framework coverage differences and comment

--- a/.github/workflows/csv-coverage-timeseries.yml
+++ b/.github/workflows/csv-coverage-timeseries.yml
@@ -3,6 +3,9 @@ name: Build framework coverage timeseries reports
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/csv-coverage-update.yml
+++ b/.github/workflows/csv-coverage-update.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   update:
     name: Update framework coverage report

--- a/.github/workflows/csv-coverage.yml
+++ b/.github/workflows/csv-coverage.yml
@@ -7,6 +7,9 @@ on:
         description: "github/codeql repo SHA used for looking up the CSV models"
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -7,13 +7,14 @@ name: Fast-forward tracking branch for selected CodeQL version
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   fast-forward:
     name: Fast-forward tracking branch for selected CodeQL version
     runs-on: ubuntu-latest
     if: github.repository == 'github/codeql'
-    permissions:
-      contents: write
     env:
       BRANCH_NAME: 'lgtm.com'
     steps:

--- a/.github/workflows/go-tests-other-os.yml
+++ b/.github/workflows/go-tests-other-os.yml
@@ -9,6 +9,10 @@ on:
       - codeql-workspace.yml
 env:
   GO_VERSION: '~1.21.0'
+
+permissions:
+  contents: read
+
 jobs:
   test-mac:
     name: Test MacOS

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -15,8 +15,13 @@ on:
       - .github/workflows/go-tests.yml
       - .github/actions/**
       - codeql-workspace.yml
+
 env:
   GO_VERSION: '~1.21.0'
+
+permissions:
+  contents: read
+
 jobs:
   test-linux:
     if: github.repository_owner == 'github'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,11 +2,12 @@ name: "Pull Request Labeler"
 on:
 - pull_request_target
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   triage:
-    permissions:
-      contents: read
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v4

--- a/.github/workflows/mad_regenerate-models.yml
+++ b/.github/workflows/mad_regenerate-models.yml
@@ -11,6 +11,9 @@ on:
       - ".github/workflows/mad_regenerate-models.yml"
       - ".github/actions/fetch-codeql/action.yml"
 
+permissions:
+  contents: read
+
 jobs:
   regenerate-models:
     runs-on: ubuntu-latest

--- a/.github/workflows/ql-for-ql-build.yml
+++ b/.github/workflows/ql-for-ql-build.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
       - name: Find codeql
         id: find-codeql
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@main
         with:
           languages: javascript # does not matter
       - uses: ./.github/actions/os-version
@@ -66,7 +66,7 @@ jobs:
             exclude:*/ql/lib/upgrades/
             exclude:java/ql/integration-tests
       - name: Upload sarif to code-scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@main
         with:
           sarif_file: ql-for-ql.sarif
           category: ql-for-ql

--- a/.github/workflows/ql-for-ql-build.yml
+++ b/.github/workflows/ql-for-ql-build.yml
@@ -9,6 +9,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+  security-events: read
+
 jobs:
   analyze:
     if: github.repository_owner == 'github'

--- a/.github/workflows/ql-for-ql-dataset_measure.yml
+++ b/.github/workflows/ql-for-ql-dataset_measure.yml
@@ -11,6 +11,10 @@ on:
       - ql/ql/src/ql.dbscheme
   workflow_dispatch:
 
+permissions:
+  contents: read
+  security-events: read
+
 jobs:
   measure:
     env:

--- a/.github/workflows/ql-for-ql-dataset_measure.yml
+++ b/.github/workflows/ql-for-ql-dataset_measure.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Find codeql
         id: find-codeql
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@main
         with:
           languages: javascript # does not matter
       - uses: ./.github/actions/os-version

--- a/.github/workflows/ql-for-ql-tests.yml
+++ b/.github/workflows/ql-for-ql-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Find codeql
         id: find-codeql
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@main
         with:
           languages: javascript # does not matter
       - uses: ./.github/actions/os-version
@@ -69,7 +69,7 @@ jobs:
           echo "/usr/local/opt/gnu-tar/libexec/gnubin" >> $GITHUB_PATH
       - name: Find codeql
         id: find-codeql
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@main
         with:
           languages: javascript # does not matter
       - uses: ./.github/actions/os-version

--- a/.github/workflows/ql-for-ql-tests.yml
+++ b/.github/workflows/ql-for-ql-tests.yml
@@ -17,6 +17,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   qltest:
     runs-on: ubuntu-latest

--- a/.github/workflows/query-list.yml
+++ b/.github/workflows/query-list.yml
@@ -13,6 +13,9 @@ on:
       - '.github/actions/fetch-codeql/action.yml'
       - 'misc/scripts/generate-code-scanning-query-list.py'
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/ruby-build.yml
+++ b/.github/workflows/ruby-build.yml
@@ -32,6 +32,9 @@ defaults:
   run:
     working-directory: ruby
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/ruby-dataset-measure.yml
+++ b/.github/workflows/ruby-dataset-measure.yml
@@ -17,6 +17,9 @@ on:
       - .github/workflows/ruby-dataset-measure.yml
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   measure:
     env:

--- a/.github/workflows/ruby-qltest.yml
+++ b/.github/workflows/ruby-qltest.yml
@@ -29,6 +29,9 @@ defaults:
   run:
     working-directory: ruby
 
+permissions:
+  contents: read
+
 jobs:
   qlupgrade:
     runs-on: ubuntu-latest

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -33,6 +33,9 @@ on:
       - rc/*
       - codeql-cli-*
 
+permissions:
+  contents: read
+
 jobs:
   # not using a matrix as you cannot depend on a specific job in a matrix, and we want to start linux checks
   # without waiting for the macOS build

--- a/.github/workflows/sync-files.yml
+++ b/.github/workflows/sync-files.yml
@@ -10,6 +10,9 @@ on:
       - main
       - 'rc/*'
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/tree-sitter-extractor-test.yml
+++ b/.github/workflows/tree-sitter-extractor-test.yml
@@ -23,6 +23,9 @@ defaults:
   run:
     working-directory: shared/tree-sitter-extractor
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-change-notes.yml
+++ b/.github/workflows/validate-change-notes.yml
@@ -15,6 +15,9 @@ on:
       - ".github/workflows/validate-change-notes.yml"
       - ".github/actions/fetch-codeql/action.yml"
 
+permissions:
+  contents: read
+
 jobs:
   check-change-note:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Repositories can be configured with Default access (restricted) https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token

Best practice says that workflows should declare the minimal permissions they require. Without declaring permissions, paranoid forks fail miserably.

closes #15462