### PR TITLE
Automodel: Do not consider `@FunctionalInterface`-typed expressions as candidates.

### DIFF
--- a/java/ql/automodel/src/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/automodel/src/AutomodelApplicationModeCharacteristics.qll
@@ -601,6 +601,15 @@ private class OtherArgumentToModeledMethodCharacteristic extends Characteristics
 }
 
 /**
+ * Holds if the type of the given expression is annotated with `@FunctionalInterface`.
+ */
+predicate hasFunctionalInterfaceType(Expr e) {
+  exists(RefType tp | tp = e.getType().getErasure() |
+    tp.getAnAssociatedAnnotation().getType().hasQualifiedName("java.lang", "FunctionalInterface")
+  )
+}
+
+/**
  * A characteristic that marks functional expression as likely not sinks.
  *
  * These expressions may well _contain_ sinks, but rarely are sinks themselves.
@@ -608,7 +617,11 @@ private class OtherArgumentToModeledMethodCharacteristic extends Characteristics
 private class FunctionValueCharacteristic extends CharacteristicsImpl::LikelyNotASinkCharacteristic {
   FunctionValueCharacteristic() { this = "function value" }
 
-  override predicate appliesToEndpoint(Endpoint e) { e.asNode().asExpr() instanceof FunctionalExpr }
+  override predicate appliesToEndpoint(Endpoint e) {
+    exists(Expr expr | expr = e.asNode().asExpr() |
+      expr instanceof FunctionalExpr or hasFunctionalInterfaceType(expr)
+    )
+  }
 }
 
 /**

--- a/java/ql/automodel/test/AutomodelApplicationModeExtraction/Test.java
+++ b/java/ql/automodel/test/AutomodelApplicationModeExtraction/Test.java
@@ -9,6 +9,7 @@ import java.nio.file.Paths;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.io.File;
+import java.io.FileFilter;
 import java.nio.file.FileVisitOption;
 import java.net.URLConnection;
 import java.util.concurrent.FutureTask;
@@ -22,7 +23,7 @@ class Test {
 	}
 
 	public static void callSupplier(Supplier<String> supplier) {
-		supplier.get(); // $ sourceModelCandidate=get():ReturnValue sinkModelCandidate=get():Argument[this]
+		supplier.get(); // $ sourceModelCandidate=get():ReturnValue
 	}
 
 	public static void copyFiles(Path source, Path target, CopyOption option) throws Exception {
@@ -64,6 +65,12 @@ class Test {
 
 	public static void WebSocketExample(URLConnection c) throws Exception {
 		c.getInputStream(); // $ sinkModelCandidate=getInputStream():Argument[this] positiveSourceExample=getInputStream():ReturnValue(remote) // not a source candidate (manual modeling)
+	}
+
+	public static void fileFilterExample(File f, FileFilter ff) {
+		f.listFiles( // $ sinkModelCandidate=listFiles(FileFilter):Argument[this]
+			ff
+		); // $ sourceModelCandidate=listFiles(FileFilter):ReturnValue
 	}
 }
 


### PR DESCRIPTION
We were already filtering lambda expressions; this is a bit more general. I left the lambda-expression filtering in anyway, just in case we get weird type information.