### PR TITLE
C#: Inter-procedural dataflow for `ref` structs when used as arguments.

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -2017,6 +2017,14 @@ predicate clearsContent(Node n, ContentSet c) {
     f = oi.getAMemberInitializer().getInitializedMember() and
     c = f.getContent()
   )
+  or
+  exists(Argument a, Struct s, Field f |
+    a = n.(PostUpdateNode).getPreUpdateNode().asExpr() and
+    a.getType() = s and
+    f = s.getAField() and
+    c.(FieldContent).getField() = f.getUnboundDeclaration() and
+    not f.isRef()
+  )
 }
 
 /**

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -540,6 +540,8 @@ module LocalFlow {
       not t instanceof NullType
       or
       t = any(TypeParameter tp | not tp.isValueType())
+      or
+      t.(Struct).isRef()
     ) and
     not exists(getALastEvalNode(result))
   }

--- a/csharp/ql/test/library-tests/dataflow/fields/E.cs
+++ b/csharp/ql/test/library-tests/dataflow/fields/E.cs
@@ -17,7 +17,7 @@ public class E
         s.Field = o;
     }
 
-    private void M()
+    private void M1()
     {
         var o = Source<object>(1);
         var s = CreateS(o);
@@ -26,6 +26,35 @@ public class E
         s = new S();
         NotASetter(s, o);
         Sink(s.Field); // no flow
+    }
+
+    ref struct RefS
+    {
+        public object Field;
+        public ref object RefField;
+
+        public RefS(object o1, ref object o2)
+        {
+            Field = o1;
+            RefField = ref o2;
+        }
+    }
+
+    static void PartialSetter(RefS s, object o)
+    {
+        s.Field = o;
+        s.RefField = o;
+    }
+
+    private void M2()
+    {
+        var o1 = new object();
+        var o2 = new object();
+        var refs = new RefS(o1, ref o2);
+        var taint = Source<object>(2);
+        PartialSetter(refs, taint);
+        Sink(refs.Field); // no flow
+        Sink(refs.RefField); // $ hasValueFlow=2
     }
 
     public static void Sink(object o) { }

--- a/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
@@ -1,4 +1,5 @@
 testFailures
+| E.cs:57:30:57:48 | // ... | Missing result:hasValueFlow=2 |
 edges
 | A.cs:5:17:5:28 | call to method Source<C> : C | A.cs:6:24:6:24 | access to local variable c : C |
 | A.cs:5:17:5:28 | call to method Source<C> : C | A.cs:6:24:6:24 | access to local variable c : C |

--- a/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
@@ -1,5 +1,4 @@
 testFailures
-| E.cs:57:30:57:48 | // ... | Missing result:hasValueFlow=2 |
 edges
 | A.cs:5:17:5:28 | call to method Source<C> : C | A.cs:6:24:6:24 | access to local variable c : C |
 | A.cs:5:17:5:28 | call to method Source<C> : C | A.cs:6:24:6:24 | access to local variable c : C |
@@ -439,6 +438,20 @@ edges
 | E.cs:23:25:23:25 | access to local variable o : Object | E.cs:23:17:23:26 | call to method CreateS : S [field Field] : Object |
 | E.cs:24:14:24:14 | access to local variable s : S [field Field] : Object | E.cs:24:14:24:20 | access to field Field |
 | E.cs:24:14:24:14 | access to local variable s : S [field Field] : Object | E.cs:24:14:24:20 | access to field Field |
+| E.cs:43:46:43:46 | o : Object | E.cs:46:22:46:22 | access to parameter o : Object |
+| E.cs:43:46:43:46 | o : Object | E.cs:46:22:46:22 | access to parameter o : Object |
+| E.cs:46:22:46:22 | access to parameter o : Object | E.cs:46:9:46:9 | [post] access to parameter s : RefS [field RefField] : Object |
+| E.cs:46:22:46:22 | access to parameter o : Object | E.cs:46:9:46:9 | [post] access to parameter s : RefS [field RefField] : Object |
+| E.cs:54:21:54:37 | call to method Source<Object> : Object | E.cs:55:29:55:33 | access to local variable taint : Object |
+| E.cs:54:21:54:37 | call to method Source<Object> : Object | E.cs:55:29:55:33 | access to local variable taint : Object |
+| E.cs:55:23:55:26 | [post] access to local variable refs : RefS [field RefField] : Object | E.cs:57:14:57:17 | access to local variable refs : RefS [field RefField] : Object |
+| E.cs:55:23:55:26 | [post] access to local variable refs : RefS [field RefField] : Object | E.cs:57:14:57:17 | access to local variable refs : RefS [field RefField] : Object |
+| E.cs:55:29:55:33 | access to local variable taint : Object | E.cs:43:46:43:46 | o : Object |
+| E.cs:55:29:55:33 | access to local variable taint : Object | E.cs:43:46:43:46 | o : Object |
+| E.cs:55:29:55:33 | access to local variable taint : Object | E.cs:55:23:55:26 | [post] access to local variable refs : RefS [field RefField] : Object |
+| E.cs:55:29:55:33 | access to local variable taint : Object | E.cs:55:23:55:26 | [post] access to local variable refs : RefS [field RefField] : Object |
+| E.cs:57:14:57:17 | access to local variable refs : RefS [field RefField] : Object | E.cs:57:14:57:26 | access to field RefField |
+| E.cs:57:14:57:17 | access to local variable refs : RefS [field RefField] : Object | E.cs:57:14:57:26 | access to field RefField |
 | F.cs:6:28:6:29 | o1 : Object | F.cs:6:65:6:66 | access to parameter o1 : Object |
 | F.cs:6:28:6:29 | o1 : Object | F.cs:6:65:6:66 | access to parameter o1 : Object |
 | F.cs:6:39:6:40 | o2 : Object | F.cs:6:78:6:79 | access to parameter o2 : Object |
@@ -1404,6 +1417,22 @@ nodes
 | E.cs:24:14:24:14 | access to local variable s : S [field Field] : Object | semmle.label | access to local variable s : S [field Field] : Object |
 | E.cs:24:14:24:20 | access to field Field | semmle.label | access to field Field |
 | E.cs:24:14:24:20 | access to field Field | semmle.label | access to field Field |
+| E.cs:43:46:43:46 | o : Object | semmle.label | o : Object |
+| E.cs:43:46:43:46 | o : Object | semmle.label | o : Object |
+| E.cs:46:9:46:9 | [post] access to parameter s : RefS [field RefField] : Object | semmle.label | [post] access to parameter s : RefS [field RefField] : Object |
+| E.cs:46:9:46:9 | [post] access to parameter s : RefS [field RefField] : Object | semmle.label | [post] access to parameter s : RefS [field RefField] : Object |
+| E.cs:46:22:46:22 | access to parameter o : Object | semmle.label | access to parameter o : Object |
+| E.cs:46:22:46:22 | access to parameter o : Object | semmle.label | access to parameter o : Object |
+| E.cs:54:21:54:37 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| E.cs:54:21:54:37 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| E.cs:55:23:55:26 | [post] access to local variable refs : RefS [field RefField] : Object | semmle.label | [post] access to local variable refs : RefS [field RefField] : Object |
+| E.cs:55:23:55:26 | [post] access to local variable refs : RefS [field RefField] : Object | semmle.label | [post] access to local variable refs : RefS [field RefField] : Object |
+| E.cs:55:29:55:33 | access to local variable taint : Object | semmle.label | access to local variable taint : Object |
+| E.cs:55:29:55:33 | access to local variable taint : Object | semmle.label | access to local variable taint : Object |
+| E.cs:57:14:57:17 | access to local variable refs : RefS [field RefField] : Object | semmle.label | access to local variable refs : RefS [field RefField] : Object |
+| E.cs:57:14:57:17 | access to local variable refs : RefS [field RefField] : Object | semmle.label | access to local variable refs : RefS [field RefField] : Object |
+| E.cs:57:14:57:26 | access to field RefField | semmle.label | access to field RefField |
+| E.cs:57:14:57:26 | access to field RefField | semmle.label | access to field RefField |
 | F.cs:6:28:6:29 | o1 : Object | semmle.label | o1 : Object |
 | F.cs:6:28:6:29 | o1 : Object | semmle.label | o1 : Object |
 | F.cs:6:39:6:40 | o2 : Object | semmle.label | o2 : Object |
@@ -2005,6 +2034,8 @@ subpaths
 | D.cs:47:14:47:14 | access to local variable d : D [field trivialPropField] : Object | D.cs:14:9:14:11 | this : D [field trivialPropField] : Object | D.cs:14:22:14:42 | access to field trivialPropField : Object | D.cs:47:14:47:26 | access to property ComplexProp |
 | E.cs:23:25:23:25 | access to local variable o : Object | E.cs:8:29:8:29 | o : Object | E.cs:12:16:12:18 | access to local variable ret : S [field Field] : Object | E.cs:23:17:23:26 | call to method CreateS : S [field Field] : Object |
 | E.cs:23:25:23:25 | access to local variable o : Object | E.cs:8:29:8:29 | o : Object | E.cs:12:16:12:18 | access to local variable ret : S [field Field] : Object | E.cs:23:17:23:26 | call to method CreateS : S [field Field] : Object |
+| E.cs:55:29:55:33 | access to local variable taint : Object | E.cs:43:46:43:46 | o : Object | E.cs:46:9:46:9 | [post] access to parameter s : RefS [field RefField] : Object | E.cs:55:23:55:26 | [post] access to local variable refs : RefS [field RefField] : Object |
+| E.cs:55:29:55:33 | access to local variable taint : Object | E.cs:43:46:43:46 | o : Object | E.cs:46:9:46:9 | [post] access to parameter s : RefS [field RefField] : Object | E.cs:55:23:55:26 | [post] access to local variable refs : RefS [field RefField] : Object |
 | F.cs:11:24:11:24 | access to local variable o : Object | F.cs:6:28:6:29 | o1 : Object | F.cs:6:46:6:81 | object creation of type F : F [field Field1] : Object | F.cs:11:17:11:31 | call to method Create : F [field Field1] : Object |
 | F.cs:11:24:11:24 | access to local variable o : Object | F.cs:6:28:6:29 | o1 : Object | F.cs:6:46:6:81 | object creation of type F : F [field Field1] : Object | F.cs:11:17:11:31 | call to method Create : F [field Field1] : Object |
 | F.cs:15:26:15:42 | call to method Source<Object> : Object | F.cs:6:39:6:40 | o2 : Object | F.cs:6:46:6:81 | object creation of type F : F [field Field2] : Object | F.cs:15:13:15:43 | call to method Create : F [field Field2] : Object |
@@ -2110,6 +2141,8 @@ subpaths
 | D.cs:47:14:47:26 | access to property ComplexProp | D.cs:43:32:43:48 | call to method Source<Object> : Object | D.cs:47:14:47:26 | access to property ComplexProp | $@ | D.cs:43:32:43:48 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | E.cs:24:14:24:20 | access to field Field | E.cs:22:17:22:33 | call to method Source<Object> : Object | E.cs:24:14:24:20 | access to field Field | $@ | E.cs:22:17:22:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | E.cs:24:14:24:20 | access to field Field | E.cs:22:17:22:33 | call to method Source<Object> : Object | E.cs:24:14:24:20 | access to field Field | $@ | E.cs:22:17:22:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| E.cs:57:14:57:26 | access to field RefField | E.cs:54:21:54:37 | call to method Source<Object> : Object | E.cs:57:14:57:26 | access to field RefField | $@ | E.cs:54:21:54:37 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| E.cs:57:14:57:26 | access to field RefField | E.cs:54:21:54:37 | call to method Source<Object> : Object | E.cs:57:14:57:26 | access to field RefField | $@ | E.cs:54:21:54:37 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | F.cs:12:14:12:21 | access to field Field1 | F.cs:10:17:10:33 | call to method Source<Object> : Object | F.cs:12:14:12:21 | access to field Field1 | $@ | F.cs:10:17:10:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | F.cs:12:14:12:21 | access to field Field1 | F.cs:10:17:10:33 | call to method Source<Object> : Object | F.cs:12:14:12:21 | access to field Field1 | $@ | F.cs:10:17:10:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | F.cs:17:14:17:21 | access to field Field2 | F.cs:15:26:15:42 | call to method Source<Object> : Object | F.cs:17:14:17:21 | access to field Field2 | $@ | F.cs:15:26:15:42 | call to method Source<Object> : Object | call to method Source<Object> : Object |


### PR DESCRIPTION
In this PR we introduce inter-procedural dataflow for `ref` structs when used as arguments to calls.

Until now, the C# dataflow library assumed that if `s` is a struct then the following was safe as structs have value type semantics (that is, calling `DoStuff` could not have the side effect of changing `Field` on `s`).
```csharp
s.Field = "safe";
DoStuff(s);
Sink(s.Field);
```

However, for `ref` structs we can have `ref` fields, which means that the observable state of the struct can be altered.
This is solved by adding post update nodes for arguments of type ref struct. However, this might also introduce false positive flow for non-ref fields - therefore we exclude these.
This is an imperfect solution, but these are already corner case scenarios.

This PR is a pre-requisite for adding flow summaries for `Span<T>` and `ReadOnlySpan<T>`.