### PR TITLE
Shared: fix a bug in stateful outbarriers

### DIFF
--- a/java/ql/test/library-tests/dataflow/inoutbarriers/A.java
+++ b/java/ql/test/library-tests/dataflow/inoutbarriers/A.java
@@ -1,9 +1,16 @@
 class A {
   static String fsrc = "";
+  String fsink = "";
 
   String src(String s) { return s; }
 
   void sink(String s) { }
+
+  static String flowThroughSink(String s) {
+    A obj = new A();
+    obj.fsink = s;
+    return obj.fsink;
+  }
 
   void foo() {
     String s = fsrc;
@@ -12,6 +19,10 @@ class A {
     s = src(s);
     sink(s);
 
+    sink(s);
+
+    s = fsrc;
+    s = flowThroughSink(s);
     sink(s);
   }
 }

--- a/java/ql/test/library-tests/dataflow/inoutbarriers/test.expected
+++ b/java/ql/test/library-tests/dataflow/inoutbarriers/test.expected
@@ -1,7 +1,11 @@
 inconsistentFlow
+| A.java:24:9:24:12 | fsrc | A.java:26:10:26:10 | s | spurious state-flow in configuration both |
+| A.java:24:9:24:12 | fsrc | A.java:26:10:26:10 | s | spurious state-flow in configuration sinkbarrier |
 #select
-| A.java:9:16:9:19 | fsrc | A.java:13:10:13:10 | s | nobarrier, sinkbarrier |
-| A.java:9:16:9:19 | fsrc | A.java:15:10:15:10 | s | nobarrier |
-| A.java:10:10:10:13 | fsrc | A.java:10:10:10:13 | fsrc | both, nobarrier, sinkbarrier, srcbarrier |
-| A.java:12:9:12:14 | src(...) | A.java:13:10:13:10 | s | both, nobarrier, sinkbarrier, srcbarrier |
-| A.java:12:9:12:14 | src(...) | A.java:15:10:15:10 | s | nobarrier, srcbarrier |
+| A.java:16:16:16:19 | fsrc | A.java:20:10:20:10 | s | nobarrier, sinkbarrier |
+| A.java:16:16:16:19 | fsrc | A.java:22:10:22:10 | s | nobarrier |
+| A.java:17:10:17:13 | fsrc | A.java:17:10:17:13 | fsrc | both, nobarrier, sinkbarrier, srcbarrier |
+| A.java:19:9:19:14 | src(...) | A.java:20:10:20:10 | s | both, nobarrier, sinkbarrier, srcbarrier |
+| A.java:19:9:19:14 | src(...) | A.java:22:10:22:10 | s | nobarrier, srcbarrier |
+| A.java:24:9:24:12 | fsrc | A.java:11:17:11:17 | s | both, nobarrier, sinkbarrier, srcbarrier |
+| A.java:24:9:24:12 | fsrc | A.java:26:10:26:10 | s | nobarrier, srcbarrier |

--- a/java/ql/test/library-tests/dataflow/inoutbarriers/test.expected
+++ b/java/ql/test/library-tests/dataflow/inoutbarriers/test.expected
@@ -1,6 +1,4 @@
 inconsistentFlow
-| A.java:24:9:24:12 | fsrc | A.java:26:10:26:10 | s | spurious state-flow in configuration both |
-| A.java:24:9:24:12 | fsrc | A.java:26:10:26:10 | s | spurious state-flow in configuration sinkbarrier |
 #select
 | A.java:16:16:16:19 | fsrc | A.java:20:10:20:10 | s | nobarrier, sinkbarrier |
 | A.java:16:16:16:19 | fsrc | A.java:22:10:22:10 | s | nobarrier |

--- a/java/ql/test/library-tests/dataflow/inoutbarriers/test.ql
+++ b/java/ql/test/library-tests/dataflow/inoutbarriers/test.ql
@@ -12,6 +12,11 @@ predicate sink0(Node n) {
     sink.getMethod().hasName("sink") and
     sink.getAnArgument() = n.asExpr()
   )
+  or
+  exists(AssignExpr assign |
+    assign.getDest().(FieldAccess).getField().hasName("fsink") and
+    n.asExpr() = assign.getSource()
+  )
 }
 
 module Conf1 implements ConfigSig {

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -2682,6 +2682,7 @@ module MakeImpl<InputSig Lang> {
       ) {
         not isUnreachableInCall1(node2, cc) and
         not inBarrier(node2, state) and
+        not outBarrier(node1, state) and
         (
           localFlowEntry(node1, pragma[only_bind_into](state)) and
           (
@@ -3757,6 +3758,9 @@ module MakeImpl<InputSig Lang> {
 
       override NodeEx getNodeEx() { result = node }
 
+      pragma[inline]
+      final NodeEx getNodeExOutgoing() { result = node and not outBarrier(node, state) }
+
       override FlowState getState() { result = state }
 
       CallContext getCallContext() { result = cc }
@@ -3928,14 +3932,14 @@ module MakeImpl<InputSig Lang> {
         ap instanceof AccessPathNil
       )
       or
-      jumpStepEx(mid.getNodeEx(), node) and
+      jumpStepEx(mid.getNodeExOutgoing(), node) and
       state = mid.getState() and
       cc instanceof CallContextAny and
       sc instanceof SummaryCtxNone and
       t = mid.getType() and
       ap = mid.getAp()
       or
-      additionalJumpStep(mid.getNodeEx(), node) and
+      additionalJumpStep(mid.getNodeExOutgoing(), node) and
       state = mid.getState() and
       cc instanceof CallContextAny and
       sc instanceof SummaryCtxNone and
@@ -3943,7 +3947,7 @@ module MakeImpl<InputSig Lang> {
       t = node.getDataFlowType() and
       ap = TAccessPathNil()
       or
-      additionalJumpStateStep(mid.getNodeEx(), mid.getState(), node, state) and
+      additionalJumpStateStep(mid.getNodeExOutgoing(), mid.getState(), node, state) and
       cc instanceof CallContextAny and
       sc instanceof SummaryCtxNone and
       mid.getAp() instanceof AccessPathNil and
@@ -3978,7 +3982,7 @@ module MakeImpl<InputSig Lang> {
     ) {
       ap0 = mid.getAp() and
       c = ap0.getHead() and
-      Stage5::readStepCand(mid.getNodeEx(), c, node) and
+      Stage5::readStepCand(mid.getNodeExOutgoing(), c, node) and
       state = mid.getState() and
       cc = mid.getCallContext()
     }
@@ -3991,7 +3995,7 @@ module MakeImpl<InputSig Lang> {
       exists(DataFlowType contentType |
         t0 = mid.getType() and
         ap0 = mid.getAp() and
-        Stage5::storeStepCand(mid.getNodeEx(), _, c, node, contentType, t) and
+        Stage5::storeStepCand(mid.getNodeExOutgoing(), _, c, node, contentType, t) and
         state = mid.getState() and
         cc = mid.getCallContext() and
         compatibleTypes(t0, contentType)
@@ -4009,7 +4013,8 @@ module MakeImpl<InputSig Lang> {
         not outBarrier(retNode, state) and
         innercc = mid.getCallContext() and
         innercc instanceof CallContextNoCall and
-        apa = mid.getAp().getApprox()
+        apa = mid.getAp().getApprox() and
+        not outBarrier(retNode, state)
       )
     }
 
@@ -4130,7 +4135,8 @@ module MakeImpl<InputSig Lang> {
         pathNode(_, ret, state, cc, sc, t, ap, _) and
         kind = ret.getKind() and
         apa = ap.getApprox() and
-        parameterFlowThroughAllowed(sc.getParamNode(), kind)
+        parameterFlowThroughAllowed(sc.getParamNode(), kind) and
+        not outBarrier(ret, state)
       )
     }
 

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -3773,14 +3773,11 @@ module MakeImpl<InputSig Lang> {
       }
 
       override PathNodeImpl getASuccessorImpl() {
-        not outBarrier(node, state) and
-        (
-          // an intermediate step to another intermediate node
-          result = this.getSuccMid()
-          or
-          // a final step to a sink
-          result = this.getSuccMid().projectToSink()
-        )
+        // an intermediate step to another intermediate node
+        result = this.getSuccMid()
+        or
+        // a final step to a sink
+        result = this.getSuccMid().projectToSink()
       }
 
       override predicate isSource() {


### PR DESCRIPTION
Fixes a bug in the handling of stateful out-barriers.

These were initially handled at the very last pruning step, since they aren't relevant for pruning in practice.

However, `subpaths` is computed in a way that isn't affected by the pruning, whereas `edges` is affected. This can result in a tuple `subpaths(arg, par, ret, res)` where `edges*(par, ret)` does not hold.

This means we get a spurious `arg -> res` edge, which can result in a spurious alert. And this alert is missing its data flow path, because no path can be materialised for `par -> ret`.

The solution I've opted for is just to check the out-barrier when we generate the steps that feed into `pathStep`. I've verified (for one query) that when stateful out-barriers aren't in use, the DIL is unaffected.