### PR TITLE
C#: Disable msbuild node reuse in dependency fetcher

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNetCliInvoker.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNetCliInvoker.cs
@@ -31,6 +31,8 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             };
             // Set the .NET CLI language to English to avoid localized output.
             startInfo.EnvironmentVariables["DOTNET_CLI_UI_LANGUAGE"] = "en";
+            startInfo.EnvironmentVariables["MSBUILDDISABLENODEREUSE"] = "1";
+            startInfo.EnvironmentVariables["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "true";
             return startInfo;
         }
 


### PR DESCRIPTION
Same as https://github.com/github/codeql/pull/15491, but for the dependency fetcher used in buildless mode.