### PR TITLE
JS: exclude tagged template literals from `js/superfluous-trailing-arguments`

### DIFF
--- a/javascript/ql/src/LanguageFeatures/SpuriousArguments.ql
+++ b/javascript/ql/src/LanguageFeatures/SpuriousArguments.ql
@@ -46,7 +46,8 @@ class SpuriousArguments extends Expr {
 
   SpuriousArguments() {
     this = invk.getArgument(maxArity(invk)).asExpr() and
-    not invk.isIncomplete()
+    not invk.isIncomplete() and
+    not invk.getAstNode() instanceof TaggedTemplateExpr
   }
 
   /**

--- a/javascript/ql/test/query-tests/LanguageFeatures/SpuriousArguments/tst.js
+++ b/javascript/ql/test/query-tests/LanguageFeatures/SpuriousArguments/tst.js
@@ -130,3 +130,12 @@ function sum2() {
 
 // OK
 sum2(1, 2, 3);
+
+const $ = function (x, arr) {
+  console.log(x, arr);
+};
+
+// OK
+async function tagThing(repoUrl, directory) {
+  await $`git clone ${repoUrl} ${directory}`;
+}


### PR DESCRIPTION
Fixes: https://github.com/github/codeql/issues/15286

[Evaluation looks OK](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/pr-15523-94b7bd__nightly-old__CustomSuite/reports).