### PR TITLE
C++: Delete unused IR predicate

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
@@ -2126,13 +2126,6 @@ class ChiInstruction extends Instruction {
   final Instruction getPartial() { result = this.getPartialOperand().getDef() }
 
   /**
-   * Gets the bit range `[startBit, endBit)` updated by the partial operand of this `ChiInstruction`, relative to the start address of the total operand.
-   */
-  final predicate getUpdatedInterval(int startBit, int endBit) {
-    Construction::getIntervalUpdatedByChi(this, startBit, endBit)
-  }
-
-  /**
    * Holds if the `ChiPartialOperand` totally, but not exactly, overlaps with the `ChiTotalOperand`.
    * This means that the `ChiPartialOperand` will not override the entire memory associated with the
    * `ChiTotalOperand`.

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
@@ -234,20 +234,6 @@ private module Cached {
   }
 
   /**
-   * Holds if the partial operand of this `ChiInstruction` updates the bit range
-   * `[startBitOffset, endBitOffset)` of the total operand.
-   */
-  cached
-  predicate getIntervalUpdatedByChi(ChiInstruction chi, int startBitOffset, int endBitOffset) {
-    exists(Alias::MemoryLocation location, OldInstruction oldInstruction |
-      oldInstruction = getOldInstruction(chi.getPartial()) and
-      location = Alias::getResultMemoryLocation(oldInstruction) and
-      startBitOffset = Alias::getStartBitOffset(location) and
-      endBitOffset = Alias::getEndBitOffset(location)
-    )
-  }
-
-  /**
    * Holds if `operand` totally overlaps with its definition and consumes the bit range
    * `[startBitOffset, endBitOffset)`.
    */

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/Instruction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/Instruction.qll
@@ -2126,13 +2126,6 @@ class ChiInstruction extends Instruction {
   final Instruction getPartial() { result = this.getPartialOperand().getDef() }
 
   /**
-   * Gets the bit range `[startBit, endBit)` updated by the partial operand of this `ChiInstruction`, relative to the start address of the total operand.
-   */
-  final predicate getUpdatedInterval(int startBit, int endBit) {
-    Construction::getIntervalUpdatedByChi(this, startBit, endBit)
-  }
-
-  /**
    * Holds if the `ChiPartialOperand` totally, but not exactly, overlaps with the `ChiTotalOperand`.
    * This means that the `ChiPartialOperand` will not override the entire memory associated with the
    * `ChiTotalOperand`.

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/IRConstruction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/IRConstruction.qll
@@ -203,12 +203,6 @@ Instruction getMemoryOperandDefinition(
 }
 
 /**
- * Holds if the partial operand of this `ChiInstruction` updates the bit range
- * `[startBitOffset, endBitOffset)` of the total operand.
- */
-predicate getIntervalUpdatedByChi(ChiInstruction chi, int startBit, int endBit) { none() }
-
-/**
  * Holds if the operand totally overlaps with its definition and consumes the
  * bit range `[startBitOffset, endBitOffset)`.
  */

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
@@ -2126,13 +2126,6 @@ class ChiInstruction extends Instruction {
   final Instruction getPartial() { result = this.getPartialOperand().getDef() }
 
   /**
-   * Gets the bit range `[startBit, endBit)` updated by the partial operand of this `ChiInstruction`, relative to the start address of the total operand.
-   */
-  final predicate getUpdatedInterval(int startBit, int endBit) {
-    Construction::getIntervalUpdatedByChi(this, startBit, endBit)
-  }
-
-  /**
    * Holds if the `ChiPartialOperand` totally, but not exactly, overlaps with the `ChiTotalOperand`.
    * This means that the `ChiPartialOperand` will not override the entire memory associated with the
    * `ChiTotalOperand`.

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -234,20 +234,6 @@ private module Cached {
   }
 
   /**
-   * Holds if the partial operand of this `ChiInstruction` updates the bit range
-   * `[startBitOffset, endBitOffset)` of the total operand.
-   */
-  cached
-  predicate getIntervalUpdatedByChi(ChiInstruction chi, int startBitOffset, int endBitOffset) {
-    exists(Alias::MemoryLocation location, OldInstruction oldInstruction |
-      oldInstruction = getOldInstruction(chi.getPartial()) and
-      location = Alias::getResultMemoryLocation(oldInstruction) and
-      startBitOffset = Alias::getStartBitOffset(location) and
-      endBitOffset = Alias::getEndBitOffset(location)
-    )
-  }
-
-  /**
    * Holds if `operand` totally overlaps with its definition and consumes the bit range
    * `[startBitOffset, endBitOffset)`.
    */

--- a/csharp/ql/src/experimental/ir/implementation/raw/Instruction.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/Instruction.qll
@@ -2126,13 +2126,6 @@ class ChiInstruction extends Instruction {
   final Instruction getPartial() { result = this.getPartialOperand().getDef() }
 
   /**
-   * Gets the bit range `[startBit, endBit)` updated by the partial operand of this `ChiInstruction`, relative to the start address of the total operand.
-   */
-  final predicate getUpdatedInterval(int startBit, int endBit) {
-    Construction::getIntervalUpdatedByChi(this, startBit, endBit)
-  }
-
-  /**
    * Holds if the `ChiPartialOperand` totally, but not exactly, overlaps with the `ChiTotalOperand`.
    * This means that the `ChiPartialOperand` will not override the entire memory associated with the
    * `ChiTotalOperand`.

--- a/csharp/ql/src/experimental/ir/implementation/raw/internal/IRConstruction.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/internal/IRConstruction.qll
@@ -217,13 +217,6 @@ private module Cached {
   }
 
   /**
-   * Holds if the partial operand of this `ChiInstruction` updates the bit range
-   * `[startBitOffset, endBitOffset)` of the total operand.
-   */
-  cached
-  predicate getIntervalUpdatedByChi(ChiInstruction chi, int startBit, int endBit) { none() }
-
-  /**
    * Holds if the operand totally overlaps with its definition and consumes the
    * bit range `[startBitOffset, endBitOffset)`.
    */

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/Instruction.qll
@@ -2126,13 +2126,6 @@ class ChiInstruction extends Instruction {
   final Instruction getPartial() { result = this.getPartialOperand().getDef() }
 
   /**
-   * Gets the bit range `[startBit, endBit)` updated by the partial operand of this `ChiInstruction`, relative to the start address of the total operand.
-   */
-  final predicate getUpdatedInterval(int startBit, int endBit) {
-    Construction::getIntervalUpdatedByChi(this, startBit, endBit)
-  }
-
-  /**
    * Holds if the `ChiPartialOperand` totally, but not exactly, overlaps with the `ChiTotalOperand`.
    * This means that the `ChiPartialOperand` will not override the entire memory associated with the
    * `ChiTotalOperand`.

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -234,20 +234,6 @@ private module Cached {
   }
 
   /**
-   * Holds if the partial operand of this `ChiInstruction` updates the bit range
-   * `[startBitOffset, endBitOffset)` of the total operand.
-   */
-  cached
-  predicate getIntervalUpdatedByChi(ChiInstruction chi, int startBitOffset, int endBitOffset) {
-    exists(Alias::MemoryLocation location, OldInstruction oldInstruction |
-      oldInstruction = getOldInstruction(chi.getPartial()) and
-      location = Alias::getResultMemoryLocation(oldInstruction) and
-      startBitOffset = Alias::getStartBitOffset(location) and
-      endBitOffset = Alias::getEndBitOffset(location)
-    )
-  }
-
-  /**
    * Holds if `operand` totally overlaps with its definition and consumes the bit range
    * `[startBitOffset, endBitOffset)`.
    */


### PR DESCRIPTION
The `getIntervalUpdatedByChi` predicate used to be consumed by IR dataflow a long time ago, but this hasn't been the case for more than a year. We might as well just delete this predicate now.