### PR TITLE
Add supported build modes to extractor metadata

### DIFF
--- a/csharp/codeql-extractor.yml
+++ b/csharp/codeql-extractor.yml
@@ -6,6 +6,9 @@ version: 1.22.1
 column_kind: "utf16"
 extra_env_vars:
   DOTNET_GENERATE_ASPNET_CERTIFICATE: "false"
+build_modes:
+  - autobuild
+  - manual
 github_api_languages:
   - C#
 scc_languages:

--- a/go/codeql-extractor.yml
+++ b/go/codeql-extractor.yml
@@ -6,6 +6,9 @@ pull_request_triggers:
   - "**/glide.yaml"
   - "**/Gopkg.toml"
 column_kind: "utf8"
+build_modes:
+  - autobuild
+  - manual
 github_api_languages:
   - Go
 scc_languages:

--- a/ql/codeql-extractor.yml
+++ b/ql/codeql-extractor.yml
@@ -3,6 +3,8 @@ display_name: "QL"
 version: 0.0.1
 column_kind: "utf8"
 legacy_qltest_extraction: true
+build_modes:
+  - none
 github_api_languages:
   - CodeQL
 scc_languages:

--- a/ruby/codeql-extractor.yml
+++ b/ruby/codeql-extractor.yml
@@ -3,6 +3,8 @@ display_name: "Ruby"
 version: 0.1.0
 column_kind: "utf8"
 legacy_qltest_extraction: true
+build_modes:
+  - none
 github_api_languages:
   - Ruby
 scc_languages:

--- a/swift/codeql-extractor.yml
+++ b/swift/codeql-extractor.yml
@@ -3,6 +3,9 @@ display_name: "Swift"
 version: 0.1.0
 column_kind: "utf8"
 legacy_qltest_extraction: true
+build_modes:
+  - autobuild
+  - manual
 github_api_languages:
   - Swift
 scc_languages:


### PR DESCRIPTION
This is in preparation for the new starter workflow described in the buildless experience ADR where we will specify the build mode for each language explicitly.  This metadata only affects runs where a `--build-mode` option is specified, which currently does not impact production.