### PR TITLE
Reduce severity of `java/relative-path-command`

### DIFF
--- a/java/ql/src/Security/CWE/CWE-078/ExecRelative.ql
+++ b/java/ql/src/Security/CWE/CWE-078/ExecRelative.ql
@@ -4,7 +4,7 @@
  *              malicious changes in the PATH environment variable.
  * @kind problem
  * @problem.severity warning
- * @security-severity 9.8
+ * @security-severity 5.4
  * @precision medium
  * @id java/relative-path-command
  * @tags security

--- a/java/ql/src/change-notes/2024-02-12-relative-exec-severity.md
+++ b/java/ql/src/change-notes/2024-02-12-relative-exec-severity.md
@@ -1,0 +1,4 @@
+---
+category: queryMetadata
+---
+* The `security-severity` score of the query `java/relative-path-command` has been reduced to better adjust it to the specific conditions needed for exploitation.


### PR DESCRIPTION
Significantly reduces the severity of `java/relative-path-command` from 9.8 to 5.4

https://www.first.org/cvss/calculator/4.0#CVSS:4.0/AV:L/AC:L/AT:P/PR:H/UI:P/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N

This is the result of a conversation between myself and @JarLob that can be found in the GitHub Security Ambassadors Slack channel here: https://github-partners.slack.com/archives/C01MF7QQK3P/p1706734093860739

@JarLob's opinion was that the severity should likely be even lower than a 5.4, possibly bringing it down as much as `low` given the attacker would have to have significant system control to exploit this.