### PR TITLE
C++: Also clear the `0`'th argument of `swap`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Swap.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Swap.qll
@@ -20,7 +20,7 @@ private class Swap extends DataFlowFunction, FlowOutBarrierFunction {
     output.isParameterDeref(0)
   }
 
-  override predicate isFlowOutBarrier(FunctionInput input) { input.isParameterDeref(1) }
+  override predicate isFlowOutBarrier(FunctionInput input) { input.isParameterDeref([0, 1]) }
 }
 
 /**

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
@@ -212,7 +212,7 @@ void test_swap() {
 
 	std::swap(x, y);
 
-	sink(x); // $ SPURIOUS: ast,ir
+	sink(x); // $ SPURIOUS: ast
 	sink(y); // $ ast,ir
 }
 


### PR DESCRIPTION
In https://github.com/github/codeql/pull/15528 I forgot to model that `std::swap` also clears the 0'th argument. This PR fixes that.

DCA looks uneventful. There are two failing projects because of a known bug in DCA that is being worked on as we speak. This shouldn't block this PR, though.