### PR TITLE
Automodel: Improve handling of varargs and overriding in extraction queries

### DIFF
--- a/java/ql/automodel/src/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/automodel/src/AutomodelApplicationModeCharacteristics.qll
@@ -35,14 +35,10 @@ newtype TApplicationModeEndpoint =
     arg = DataFlow::getInstanceArgument(call) and
     not call instanceof ConstructorCall
   } or
-  TImplicitVarargsArray(Call call, DataFlow::Node arg, int idx) {
+  TImplicitVarargsArray(Call call, DataFlow::ImplicitVarargsArray arg, int idx) {
     AutomodelJavaUtil::isFromSource(call) and
-    exists(Argument argExpr |
-      arg.asExpr() = argExpr and
-      call.getArgument(idx) = argExpr and
-      argExpr.isVararg() and
-      not exists(int i | i < idx and call.getArgument(i).(Argument).isVararg())
-    )
+    call = arg.getCall() and
+    idx = call.getCallee().getVaragsParameterIndex()
   } or
   TMethodReturnValue(Call call) {
     AutomodelJavaUtil::isFromSource(call) and

--- a/java/ql/automodel/src/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/automodel/src/AutomodelApplicationModeCharacteristics.qll
@@ -274,9 +274,14 @@ module ApplicationCandidatesImpl implements SharedCharacteristics::CandidateSig 
   }
 
   predicate isNeutral(Endpoint e) {
-    exists(string package, string type, string name, string signature |
+    exists(string package, string type, string name, string signature, string endpointType |
       sinkSpec(e, package, type, _, name, signature, _, _) and
-      ExternalFlow::neutralModel(package, type, name, [signature, ""], "sink", _)
+      endpointType = "sink"
+      or
+      sourceSpec(e, package, type, _, name, signature, _, _) and
+      endpointType = "source"
+    |
+      ExternalFlow::neutralModel(package, type, name, [signature, ""], endpointType, _)
     )
   }
 

--- a/java/ql/automodel/src/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/automodel/src/AutomodelApplicationModeCharacteristics.qll
@@ -256,7 +256,8 @@ module ApplicationCandidatesImpl implements SharedCharacteristics::CandidateSig 
       string input
     |
       sinkSpec(e, package, type, subtypes, name, signature, ext, input) and
-      ExternalFlow::sinkModel(package, type, _, name, [signature, ""], ext, input, kind, provenance)
+      ExternalFlow::sinkModel(package, type, subtypes, name, [signature, ""], ext, input, kind,
+        provenance)
     )
     or
     isCustomSink(e, kind) and provenance = "custom-sink"

--- a/java/ql/automodel/src/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/automodel/src/AutomodelApplicationModeCharacteristics.qll
@@ -251,8 +251,11 @@ module ApplicationCandidatesImpl implements SharedCharacteristics::CandidateSig 
   predicate isKnownKind = AutomodelJavaUtil::isKnownKind/2;
 
   predicate isSink(Endpoint e, string kind, string provenance) {
-    exists(string package, string type, string name, string signature, string ext, string input |
-      sinkSpec(e, package, type, name, signature, ext, input) and
+    exists(
+      string package, string type, boolean subtypes, string name, string signature, string ext,
+      string input
+    |
+      sinkSpec(e, package, type, subtypes, name, signature, ext, input) and
       ExternalFlow::sinkModel(package, type, _, name, [signature, ""], ext, input, kind, provenance)
     )
     or
@@ -260,36 +263,56 @@ module ApplicationCandidatesImpl implements SharedCharacteristics::CandidateSig 
   }
 
   predicate isSource(Endpoint e, string kind, string provenance) {
-    exists(string package, string type, string name, string signature, string ext, string output |
-      sourceSpec(e, package, type, name, signature, ext, output) and
-      ExternalFlow::sourceModel(package, type, _, name, [signature, ""], ext, output, kind,
+    exists(
+      string package, string type, boolean subtypes, string name, string signature, string ext,
+      string output
+    |
+      sourceSpec(e, package, type, subtypes, name, signature, ext, output) and
+      ExternalFlow::sourceModel(package, type, subtypes, name, [signature, ""], ext, output, kind,
         provenance)
     )
   }
 
   predicate isNeutral(Endpoint e) {
     exists(string package, string type, string name, string signature |
-      sinkSpec(e, package, type, name, signature, _, _) and
+      sinkSpec(e, package, type, _, name, signature, _, _) and
       ExternalFlow::neutralModel(package, type, name, [signature, ""], "sink", _)
     )
   }
 
-  // XXX how to extend to support sources?
-  additional predicate sinkSpec(
-    Endpoint e, string package, string type, string name, string signature, string ext, string input
+  /**
+   * Holds if the endpoint concerns a callable with the given package, type, name and signature.
+   *
+   * If `subtypes` is `false`, only the exact callable is considered. If `true`, the callable and
+   * all its overrides are considered.
+   */
+  additional predicate endpointCallable(
+    Endpoint e, string package, string type, boolean subtypes, string name, string signature
   ) {
-    e.getCallable().hasQualifiedName(package, type, name) and
-    signature = ExternalFlow::paramsString(e.getCallable()) and
+    exists(Callable c |
+      c = e.getCallable() and subtypes in [true, false]
+      or
+      e.getCallable().(Method).getSourceDeclaration().overrides+(c) and subtypes = true
+    |
+      c.hasQualifiedName(package, type, name) and
+      signature = ExternalFlow::paramsString(c)
+    )
+  }
+
+  additional predicate sinkSpec(
+    Endpoint e, string package, string type, boolean subtypes, string name, string signature,
+    string ext, string input
+  ) {
+    endpointCallable(e, package, type, subtypes, name, signature) and
     ext = "" and
     input = e.getMaDInput()
   }
 
   additional predicate sourceSpec(
-    Endpoint e, string package, string type, string name, string signature, string ext,
-    string output
+    Endpoint e, string package, string type, boolean subtypes, string name, string signature,
+    string ext, string output
   ) {
-    e.getCallable().hasQualifiedName(package, type, name) and
-    signature = ExternalFlow::paramsString(e.getCallable()) and
+    endpointCallable(e, package, type, subtypes, name, signature) and
     ext = "" and
     output = e.getMaDOutput()
   }

--- a/java/ql/automodel/src/AutomodelFrameworkModeCharacteristics.qll
+++ b/java/ql/automodel/src/AutomodelFrameworkModeCharacteristics.qll
@@ -230,12 +230,14 @@ module FrameworkCandidatesImpl implements SharedCharacteristics::CandidateSig {
   }
 
   predicate isNeutral(Endpoint e) {
-    exists(string package, string type, string name, string signature |
-      sinkSpec(e, package, type, _, name, signature, _, _)
+    exists(string package, string type, string name, string signature, string endpointType |
+      sinkSpec(e, package, type, _, name, signature, _, _) and
+      endpointType = "sink"
       or
-      sourceSpec(e, package, type, _, name, signature, _, _)
+      sourceSpec(e, package, type, _, name, signature, _, _) and
+      endpointType = "source"
     |
-      ExternalFlow::neutralModel(package, type, name, [signature, ""], "sink", _)
+      ExternalFlow::neutralModel(package, type, name, [signature, ""], endpointType, _)
     )
   }
 

--- a/java/ql/automodel/src/AutomodelFrameworkModeCharacteristics.qll
+++ b/java/ql/automodel/src/AutomodelFrameworkModeCharacteristics.qll
@@ -214,7 +214,8 @@ module FrameworkCandidatesImpl implements SharedCharacteristics::CandidateSig {
       string input
     |
       sinkSpec(e, package, type, subtypes, name, signature, ext, input) and
-      ExternalFlow::sinkModel(package, type, _, name, [signature, ""], ext, input, kind, provenance)
+      ExternalFlow::sinkModel(package, type, subtypes, name, [signature, ""], ext, input, kind,
+        provenance)
     )
   }
 

--- a/java/ql/automodel/test/AutomodelApplicationModeExtraction/Test.java
+++ b/java/ql/automodel/test/AutomodelApplicationModeExtraction/Test.java
@@ -40,11 +40,12 @@ class Test {
 		); // $ sourceModelCandidate=newInputStream(Path,OpenOption[]):ReturnValue
 	}
 
-	public static InputStream getInputStream(String openPath) throws Exception {
+	public static InputStream getInputStream(String openPath, String otherPath) throws Exception {
 		return Test.getInputStream( // the call is not a source candidate (argument to local call)
 			Paths.get(
-				openPath // $ negativeSinkExample=get(String,String[]):Argument[0] // modeled as a flow step
-			) // $ sourceModelCandidate=get(String,String[]):ReturnValue
+				openPath, // $ negativeSinkExample=get(String,String[]):Argument[0] // modeled as a flow step
+				otherPath
+			) // $ sourceModelCandidate=get(String,String[]):ReturnValue negativeSinkExample=get(String,String[]):Argument[1]
 		);
 	}
 

--- a/java/ql/automodel/test/AutomodelFrameworkModeExtraction/com/github/codeql/test/MyWriter.java
+++ b/java/ql/automodel/test/AutomodelFrameworkModeExtraction/com/github/codeql/test/MyWriter.java
@@ -2,7 +2,7 @@ package com.github.codeql.test;
 
 public class MyWriter extends java.io.Writer {
     @Override
-    public void write(char[] cbuf, int off, int len) { // $ sinkModelCandidate=write(char[],int,int):Argument[this] sourceModelCandidate=write(char[],int,int):Parameter[this] sourceModelCandidate=write(char[],int,int):Parameter[0] SPURIOUS: sinkModelCandidate=write(char[],int,int):Argument[0]
+    public void write(char[] cbuf, int off, int len) { // $ sinkModelCandidate=write(char[],int,int):Argument[this] sourceModelCandidate=write(char[],int,int):Parameter[this] sourceModelCandidate=write(char[],int,int):Parameter[0]
     }
 
     @Override

--- a/java/ql/automodel/test/AutomodelFrameworkModeExtraction/com/github/codeql/test/MyWriter.java
+++ b/java/ql/automodel/test/AutomodelFrameworkModeExtraction/com/github/codeql/test/MyWriter.java
@@ -1,0 +1,15 @@
+package com.github.codeql.test;
+
+public class MyWriter extends java.io.Writer {
+    @Override
+    public void write(char[] cbuf, int off, int len) { // $ sinkModelCandidate=write(char[],int,int):Argument[this] sourceModelCandidate=write(char[],int,int):Parameter[this] sourceModelCandidate=write(char[],int,int):Parameter[0] SPURIOUS: sinkModelCandidate=write(char[],int,int):Argument[0]
+    }
+
+    @Override
+    public void close() { // $ sinkModelCandidate=close():Argument[this] sourceModelCandidate=close():Parameter[this]
+    }
+
+    @Override
+    public void flush() { // $ sinkModelCandidate=flush():Argument[this] sourceModelCandidate=flush():Parameter[this]
+    }
+}

--- a/java/ql/automodel/test/AutomodelFrameworkModeExtraction/java/io/File.java
+++ b/java/ql/automodel/test/AutomodelFrameworkModeExtraction/java/io/File.java
@@ -1,8 +1,8 @@
 package java.io;
 
 public class File {
-    public int compareTo( // $ negativeSinkExample=compareTo(File):Argument[this] negativeSourceExample=compareTo(File):Parameter[this] // modeled as neutral
-        File pathname // $ negativeSinkExample=compareTo(File):Argument[0] negativeSourceExample=compareTo(File):Parameter[0] // modeled as neutral
+    public int compareTo( // $ negativeSinkExample=compareTo(File):Argument[this] sourceModelCandidate=compareTo(File):Parameter[this] // modeled as neutral for sinks
+        File pathname // $ negativeSinkExample=compareTo(File):Argument[0] sourceModelCandidate=compareTo(File):Parameter[0] // modeled as neutral for sinks
     ) {
         return 0;
     }


### PR DESCRIPTION
The two fixes are conceptually independent, but both came up during a recent triage (https://github.com/github/codeql/pull/15486).

The first one is to do with implicit varargs arrays: the extraction queries for mining endpoint candidates aim to exclude known models, but were previously failing to properly match up implicit varargs arrays in application mode. That's because we were using the data-flow nodes of the individual arguments collected into the varargs array to represent the endpoints, but the MaD models refer to the `ImplicitVarargsArray` node. We now do the latter as well.

The second one is to do with recognising existing models for method parameters and return values: if an existing model is marked as `subtypes=True`, we should consider overriding methods to also be covered by that model, but previously we did not handle this correctly.

Finally, the `isNeutral` predicate didn't look quite right, so I fixed that as well.

I did a comparison of results on `apache/geode` before and after this PR, and all changes seem reasonable:

- Application mode
  - Candidates: from 183659  down to 182409 (+2746, -1496)
    - most removed candidates are due to fixed treatment of implicit varargs
    - the rest are due to better treatment of overriding; in particular, the `org.apache.http.impl.client` endpoints called out in the triage PR are gone, and similar for PrintWriter and JarOutputStream
    - some of the removed candidates re-appear as added candidates, now with the correct modelling status ("ai-manual" vs unmodelled before)
  - Negative examples: from 460845 up to 463646
    - 21 removed: implicit varargs; not really removed, but representing node has changed, so they also appear as added results
    - 2822 added: implicit varargs
  - Positive examples: from 3231 up to 3284
    - 14 removed: implicit varargs; not really removed, representing node has changed
    - 67 added: mostly in `org.apache.http.impl.client` (cf above)
- Framework mode
  - Candidates: unchanged at 38950
  - Negative examples: unchanged at 6137
  - Positive examples: from 0 up to 13
    - New results are for parameters/return values of overriding methods where the corresponding parameter/return value of the overridden method is modelled as a sink/source (it's debatable how meaningful these candidates are)