### PR TITLE
Java: Cache interpretElement.

### DIFF
--- a/java/ql/lib/semmle/code/java/dataflow/ExternalFlow.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/ExternalFlow.qll
@@ -430,6 +430,7 @@ private Element interpretElement0(
 }
 
 /** Gets the source/sink/summary/neutral element corresponding to the supplied parameters. */
+cached
 Element interpretElement(
   string package, string type, boolean subtypes, string name, string signature, string ext
 ) {


### PR DESCRIPTION
Henning noticed a lot of fastTC duplication (29x at the DIL level across a query suite). Cachaca has been saving us somewhat, but not completely, so this PR should eliminate the duplication.