### PR TITLE
JS: False negative - unsafe postMessage handler not detected

### DIFF
--- a/javascript/ql/src/change-notes/2024-02-09-missing-origin-check-quiery.md
+++ b/javascript/ql/src/change-notes/2024-02-09-missing-origin-check-quiery.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Fixed issue, when not all usafe postMessage handlers were detected.


### PR DESCRIPTION
**Description of the issue**

I tested CodeQL on JS, which handles postMessage validation. The rule for detecting the absence of an origin check in the postMessage handler function does not cover all possible ways to bypass that check.
Firstly, the rule doesn't identify cases where only `event.source` is checked. Such verification can be easily bypassed.

https://book.hacktricks.xyz/pentesting-web/postmessage-vulnerabilities#bypassing-e.source 

```
/** Gets a reference to the origin or the source of a postmessage event. */
DataFlow::SourceNode sourceOrOrigin(PostMessageHandler handler) {
  result = source(DataFlow::TypeTracker::end(), handler) or
  result = origin(DataFlow::TypeTracker::end(), handler)
}
```

Secondly, checks like `"safeOrigin".startsWith(event.origin)` and `"safeOrigin".endsWith(event.origin)` can also be bypassed.

Lastly, there are methods to bypass the equality operation as well, so it's only safe to use strict equality operators (`===`and `!==`).

For more details on bypassing origin checks, you can refer to: https://book.hacktricks.xyz/pentesting-web/postmessage-vulnerabilities#origin-check-bypasses, https://book.hacktricks.xyz/pentesting-web/postmessage-vulnerabilities#e.origin-window.origin-bypass

```
predicate hasOriginCheck(PostMessageHandler handler) {
  // event.origin === "constant"
  exists(EqualityTest test | sourceOrOrigin(handler).flowsToExpr(test.getAnOperand()))
  or
  // set.includes(event.source)
  exists(InclusionTest test | sourceOrOrigin(handler).flowsTo(test.getContainedNode()))
  or
  // "safeOrigin".startsWith(event.origin)
  exists(StringOps::StartsWith starts |
    origin(DataFlow::TypeTracker::end(), handler).flowsTo(starts.getSubstring())
  )
  or
  // "safeOrigin".endsWith(event.origin)
  exists(StringOps::EndsWith ends |
    origin(DataFlow::TypeTracker::end(), handler).flowsTo(ends.getSubstring())
  )
}
```

The only secure way to handle postMessage is to **always** check `event.origin`. 


**CodeQL Rule**
Rule: [MissingOriginCheck.ql](https://github.com/github/codeql/blob/main/javascript/ql/src/Security/CWE-020/MissingOriginCheck.ql)


**Thank you for your time!**