### PR TITLE
Python: Update BUILD.bazel files.

### DIFF
--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_pkg//:mappings.bzl", "pkg_filegroup", "pkg_files")
+
 package(default_visibility = ["//visibility:public"])
 
 alias(
@@ -8,4 +10,21 @@ alias(
 alias(
     name = "dbscheme-stats",
     actual = "//python/ql/lib:dbscheme-stats",
+)
+
+pkg_files(
+    name = "dbscheme-group",
+    srcs = [
+        ":dbscheme",
+        ":dbscheme-stats",
+    ],
+    strip_prefix = None,
+)
+
+pkg_filegroup(
+    name = "db-files",
+    srcs = [
+        ":dbscheme-group",
+        "//python/downgrades",
+    ],
 )

--- a/python/downgrades/BUILD.bazel
+++ b/python/downgrades/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@rules_pkg//:mappings.bzl", "pkg_files", "strip_prefix")
+
+pkg_files(
+    name = "downgrades",
+    srcs = glob(
+        ["**"],
+        exclude = ["BUILD.bazel"],
+    ),
+    prefix = "downgrades",
+    strip_prefix = strip_prefix.from_pkg(),
+    visibility = ["//python:__pkg__"],
+)


### PR DESCRIPTION
This allows us to (later) build the whole python language pack with bazel.