### PR TITLE
C#: Add a few more sanitizers to `cs/web/unvalidated-url-redirection`

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/UrlRedirectQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/UrlRedirectQuery.qll
@@ -167,7 +167,7 @@ class ContainsUrlSanitizer extends Sanitizer {
 private predicate isRelativeUrlSanitizer(Guard guard, Expr e, AbstractValue v) {
   exists(PropertyAccess access | access = guard |
     access.getProperty().getName() = "IsAbsoluteUri" and
-    // TOOD: type = URL?
+    access.getQualifier().getType().getFullyQualifiedName() = "System.Uri" and
     e = access.getQualifier() and
     v.(AbstractValues::BooleanValue).getValue() = false
   )
@@ -190,6 +190,7 @@ private predicate isHostComparisonSanitizer(Guard guard, Expr e, AbstractValue v
   exists(EqualityOperation comparison | comparison = guard |
     exists(PropertyAccess access | access = comparison.getAnOperand() |
       access.getProperty().getName() = "Host" and
+      access.getQualifier().getType().getFullyQualifiedName() = "System.Uri" and
       e = access.getQualifier()
     ) and
     if comparison instanceof EQExpr

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/UrlRedirectQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/UrlRedirectQuery.qll
@@ -183,6 +183,31 @@ class RelativeUrlSanitizer extends Sanitizer {
 }
 
 /**
+ * A comparison on the `Host` property of a url, that is a sanitizer for URL redirects.
+ * E.g. `url.Host == "example.org"`
+ */
+private predicate isHostComparisonSanitizer(Guard guard, Expr e, AbstractValue v) {
+  exists(EqualityOperation comparison | comparison = guard |
+    exists(PropertyAccess access | access = comparison.getAnOperand() |
+      access.getProperty().getName() = "Host" and
+      e = access.getQualifier()
+    ) and
+    if comparison instanceof EQExpr
+    then v.(AbstractValues::BooleanValue).getValue() = true
+    else v.(AbstractValues::BooleanValue).getValue() = false
+  )
+}
+
+/**
+ * A comparison on the `Host` property of a url, that is a sanitizer for URL redirects.
+ */
+class HostComparisonSanitizer extends Sanitizer {
+  HostComparisonSanitizer() {
+    this = DataFlow::BarrierGuard<isHostComparisonSanitizer/3>::getABarrierNode()
+  }
+}
+
+/**
  * A call to the getter of the RawUrl property, whose value is considered to be safe for URL
  * redirects.
  */

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/UrlRedirectQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/UrlRedirectQuery.qll
@@ -162,6 +162,27 @@ class ContainsUrlSanitizer extends Sanitizer {
 }
 
 /**
+ * A check that the URL is relative, and therefore safe for URL redirects.
+ */
+private predicate isRelativeUrlSanitizer(Guard guard, Expr e, AbstractValue v) {
+  exists(PropertyAccess access | access = guard |
+    access.getProperty().getName() = "IsAbsoluteUri" and
+    // TOOD: type = URL?
+    e = access.getQualifier() and
+    v.(AbstractValues::BooleanValue).getValue() = false
+  )
+}
+
+/**
+ * A check that the URL is relative, and therefore safe for URL redirects.
+ */
+class RelativeUrlSanitizer extends Sanitizer {
+  RelativeUrlSanitizer() {
+    this = DataFlow::BarrierGuard<isRelativeUrlSanitizer/3>::getABarrierNode()
+  }
+}
+
+/**
  * A call to the getter of the RawUrl property, whose value is considered to be safe for URL
  * redirects.
  */

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/UrlRedirectQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/UrlRedirectQuery.qll
@@ -140,6 +140,28 @@ class LocalUrlSanitizer extends Sanitizer {
 }
 
 /**
+ * A argument to a call to `List.Contains()` that is a sanitizer for URL redirects.
+ */
+private predicate isContainsUrlSanitizer(Guard guard, Expr e, AbstractValue v) {
+  exists(MethodCall method | method = guard |
+    exists(Method m | m = method.getTarget() |
+      m.hasName("Contains") and
+      e = method.getArgument(0)
+    ) and
+    v.(AbstractValues::BooleanValue).getValue() = true
+  )
+}
+
+/**
+ * A URL argument to a call to `List.Contains()` that is a sanitizer for URL redirects.
+ */
+class ContainsUrlSanitizer extends Sanitizer {
+  ContainsUrlSanitizer() {
+    this = DataFlow::BarrierGuard<isContainsUrlSanitizer/3>::getABarrierNode()
+  }
+}
+
+/**
  * A call to the getter of the RawUrl property, whose value is considered to be safe for URL
  * redirects.
  */

--- a/csharp/ql/src/change-notes/2024-02-14-url-sanitizers.md
+++ b/csharp/ql/src/change-notes/2024-02-14-url-sanitizers.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added sanitizers for relative URLs, `List.Contains()`, and checking the `.Host` property on an URI to the `cs/web/unvalidated-url-redirection` query.

--- a/csharp/ql/test/query-tests/Security Features/CWE-601/UrlRedirect/UrlRedirect.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-601/UrlRedirect/UrlRedirect.expected
@@ -1,4 +1,5 @@
 edges
+| UrlRedirect2.cs:14:31:14:53 | access to property QueryString : NameValueCollection | UrlRedirect2.cs:14:31:14:61 | access to indexer | provenance |  |
 | UrlRedirect.cs:13:31:13:53 | access to property QueryString : NameValueCollection | UrlRedirect.cs:13:31:13:61 | access to indexer | provenance |  |
 | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:23:22:23:52 | access to indexer : String | provenance |  |
 | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | UrlRedirect.cs:48:29:48:31 | access to local variable url | provenance |  |
@@ -28,6 +29,8 @@ edges
 | UrlRedirectCore.cs:45:51:45:55 | value : String | UrlRedirectCore.cs:56:31:56:35 | access to parameter value | provenance |  |
 | UrlRedirectCore.cs:53:40:53:44 | access to parameter value : String | UrlRedirectCore.cs:53:32:53:45 | object creation of type Uri | provenance |  |
 nodes
+| UrlRedirect2.cs:14:31:14:53 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
+| UrlRedirect2.cs:14:31:14:61 | access to indexer | semmle.label | access to indexer |
 | UrlRedirect.cs:13:31:13:53 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
 | UrlRedirect.cs:13:31:13:61 | access to indexer | semmle.label | access to indexer |
 | UrlRedirect.cs:23:22:23:44 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
@@ -58,6 +61,7 @@ nodes
 | UrlRedirectCore.cs:56:31:56:35 | access to parameter value | semmle.label | access to parameter value |
 subpaths
 #select
+| UrlRedirect2.cs:14:31:14:61 | access to indexer | UrlRedirect2.cs:14:31:14:53 | access to property QueryString : NameValueCollection | UrlRedirect2.cs:14:31:14:61 | access to indexer | Untrusted URL redirection due to $@. | UrlRedirect2.cs:14:31:14:53 | access to property QueryString | user-provided value |
 | UrlRedirect.cs:13:31:13:61 | access to indexer | UrlRedirect.cs:13:31:13:53 | access to property QueryString : NameValueCollection | UrlRedirect.cs:13:31:13:61 | access to indexer | Untrusted URL redirection due to $@. | UrlRedirect.cs:13:31:13:53 | access to property QueryString | user-provided value |
 | UrlRedirect.cs:38:44:38:74 | access to indexer | UrlRedirect.cs:38:44:38:66 | access to property QueryString : NameValueCollection | UrlRedirect.cs:38:44:38:74 | access to indexer | Untrusted URL redirection due to $@. | UrlRedirect.cs:38:44:38:66 | access to property QueryString | user-provided value |
 | UrlRedirect.cs:39:47:39:77 | access to indexer | UrlRedirect.cs:39:47:39:69 | access to property QueryString : NameValueCollection | UrlRedirect.cs:39:47:39:77 | access to indexer | Untrusted URL redirection due to $@. | UrlRedirect.cs:39:47:39:69 | access to property QueryString | user-provided value |

--- a/csharp/ql/test/query-tests/Security Features/CWE-601/UrlRedirect/UrlRedirect2.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-601/UrlRedirect/UrlRedirect2.cs
@@ -6,14 +6,13 @@ using System.Collections.Generic;
 
 public class UrlRedirectHandler2 : IHttpHandler
 {
-    private const String VALID_REDIRECT = "http://cwe.mitre.org/data/definitions/601.html";
+    private List<string> VALID_REDIRECTS = new List<string>{ "http://cwe.mitre.org/data/definitions/601.html", "http://cwe.mitre.org/data/definitions/79.html" };
 
     public void ProcessRequest(HttpContext ctx)
     {
         // BAD: a request parameter is incorporated without validation into a URL redirect
         ctx.Response.Redirect(ctx.Request.QueryString["page"]);
 
-        List<string> VALID_REDIRECTS = new List<string>{ "http://cwe.mitre.org/data/definitions/601.html", "http://cwe.mitre.org/data/definitions/79.html" };
         var redirectUrl = ctx.Request.QueryString["page"];
         if (VALID_REDIRECTS.Contains(redirectUrl))
         {

--- a/csharp/ql/test/query-tests/Security Features/CWE-601/UrlRedirect/UrlRedirect2.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-601/UrlRedirect/UrlRedirect2.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Web;
+using System.Web.Mvc;
+using System.Web.WebPages;
+using System.Collections.Generic;
+
+public class UrlRedirectHandler2 : IHttpHandler
+{
+    private const String VALID_REDIRECT = "http://cwe.mitre.org/data/definitions/601.html";
+
+    public void ProcessRequest(HttpContext ctx)
+    {
+        // BAD: a request parameter is incorporated without validation into a URL redirect
+        ctx.Response.Redirect(ctx.Request.QueryString["page"]);
+
+        List<string> VALID_REDIRECTS = new List<string>{ "http://cwe.mitre.org/data/definitions/601.html", "http://cwe.mitre.org/data/definitions/79.html" };
+        
+    }
+}

--- a/csharp/ql/test/query-tests/Security Features/CWE-601/UrlRedirect/UrlRedirect2.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-601/UrlRedirect/UrlRedirect2.cs
@@ -14,6 +14,12 @@ public class UrlRedirectHandler2 : IHttpHandler
         ctx.Response.Redirect(ctx.Request.QueryString["page"]);
 
         List<string> VALID_REDIRECTS = new List<string>{ "http://cwe.mitre.org/data/definitions/601.html", "http://cwe.mitre.org/data/definitions/79.html" };
+        var redirectUrl = ctx.Request.QueryString["page"];
+        if (VALID_REDIRECTS.Contains(redirectUrl))
+        {
+            // GOOD: the request parameter is validated against set of known fixed strings
+            ctx.Response.Redirect(redirectUrl);
+        }
         
     }
 }

--- a/csharp/ql/test/query-tests/Security Features/CWE-601/UrlRedirect/UrlRedirect2.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-601/UrlRedirect/UrlRedirect2.cs
@@ -26,6 +26,10 @@ public class UrlRedirectHandler2 : IHttpHandler
             // GOOD: The redirect is to a relative URL
             ctx.Response.Redirect(url.ToString());
         }
-        
+
+        if (url.Host == "example.org") {
+            // GOOD: The redirect is to a known host
+            ctx.Response.Redirect(url.ToString());
+        }
     }
 }

--- a/csharp/ql/test/query-tests/Security Features/CWE-601/UrlRedirect/UrlRedirect2.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-601/UrlRedirect/UrlRedirect2.cs
@@ -20,6 +20,12 @@ public class UrlRedirectHandler2 : IHttpHandler
             // GOOD: the request parameter is validated against set of known fixed strings
             ctx.Response.Redirect(redirectUrl);
         }
+
+        var url = new Uri(redirectUrl, UriKind.RelativeOrAbsolute);
+        if (!url.IsAbsoluteUri) {
+            // GOOD: The redirect is to a relative URL
+            ctx.Response.Redirect(url.ToString());
+        }
         
     }
 }


### PR DESCRIPTION
I was looking at the QHelp for `cs/web/unvalidated-url-redirection`, but it was hard to write good fix examples that weren't flagged by the query.  

So I've added a few new sanitizers to the query.  

I've worked very little with queries that use the shared dataflow library, and I think this might be my first "real" C# PR.  
What I'm saying is to look closely, because I might have made some silly mistake.  