### PR TITLE
Go: Fix file info extraction for dummy files

### DIFF
--- a/go/extractor/extractor.go
+++ b/go/extractor/extractor.go
@@ -551,7 +551,7 @@ func (extraction *Extraction) extractError(tw *trap.Writer, err packages.Error, 
 			log.Printf("Warning: failed to evaluate symlinks for %s", wd)
 		}
 		file = filepath.Join(ewd, "-")
-		extraction.extractFileInfo(tw, file)
+		extraction.extractFileInfo(tw, file, true)
 	} else {
 		var rawfile string
 		if parts := threePartPos.FindStringSubmatch(pos); parts != nil {
@@ -586,7 +586,7 @@ func (extraction *Extraction) extractError(tw *trap.Writer, err packages.Error, 
 			file = afile
 		}
 
-		extraction.extractFileInfo(tw, file)
+		extraction.extractFileInfo(tw, file, false)
 	}
 
 	extraction.Lock.Lock()
@@ -655,7 +655,7 @@ func (extraction *Extraction) extractFile(ast *ast.File, pkg *packages.Package) 
 		return err
 	}
 
-	extraction.extractFileInfo(tw, path)
+	extraction.extractFileInfo(tw, path, false)
 
 	extractScopes(tw, ast, pkg)
 
@@ -673,7 +673,7 @@ func (extraction *Extraction) extractFile(ast *ast.File, pkg *packages.Package) 
 
 // extractFileInfo extracts file-system level information for the given file, populating
 // the `files` and `containerparent` tables
-func (extraction *Extraction) extractFileInfo(tw *trap.Writer, file string) {
+func (extraction *Extraction) extractFileInfo(tw *trap.Writer, file string, isDummy bool) {
 	// We may visit the same file twice because `extractError` calls this function to describe files containing
 	// compilation errors. It is also called for user source files being extracted.
 	extraction.Lock.Lock()
@@ -705,7 +705,9 @@ func (extraction *Extraction) extractFileInfo(tw *trap.Writer, file string) {
 			dbscheme.HasLocationTable.Emit(tw, lbl, emitLocation(tw, lbl, 0, 0, 0, 0))
 			extraction.Lock.Lock()
 			slbl := extraction.StatWriter.Labeler.FileLabelFor(file)
-			dbscheme.CompilationCompilingFilesTable.Emit(extraction.StatWriter, extraction.Label, extraction.GetFileIdx(file), slbl)
+			if !isDummy {
+				dbscheme.CompilationCompilingFilesTable.Emit(extraction.StatWriter, extraction.Label, extraction.GetFileIdx(file), slbl)
+			}
 			extraction.Lock.Unlock()
 			break
 		}

--- a/go/extractor/extractor.go
+++ b/go/extractor/extractor.go
@@ -551,6 +551,7 @@ func (extraction *Extraction) extractError(tw *trap.Writer, err packages.Error, 
 			log.Printf("Warning: failed to evaluate symlinks for %s", wd)
 		}
 		file = filepath.Join(ewd, "-")
+		extraction.extractFileInfo(tw, file)
 	} else {
 		var rawfile string
 		if parts := threePartPos.FindStringSubmatch(pos); parts != nil {

--- a/go/extractor/gomodextractor.go
+++ b/go/extractor/gomodextractor.go
@@ -40,7 +40,7 @@ func (extraction *Extraction) extractGoMod(path string) error {
 		return err
 	}
 
-	extraction.extractFileInfo(tw, path)
+	extraction.extractFileInfo(tw, path, false)
 
 	file, err := os.Open(path)
 	if err != nil {

--- a/go/ql/lib/semmle/go/Files.qll
+++ b/go/ql/lib/semmle/go/Files.qll
@@ -124,6 +124,7 @@ class ExtractedOrExternalFile extends Container, Impl::File, Documentable, ExprP
 /** A file that has been extracted. */
 class File extends ExtractedOrExternalFile {
   File() {
+    not this.getBaseName() = "-" and
     // getAChild is specifically for the Go AST and so does not apply to non-go files
     // we care about all non-go extracted files, as only go files can have `@file` entries due to requiring a file entry for diagnostic errors
     not this.getExtension() = "go"

--- a/go/ql/lib/semmle/go/Files.qll
+++ b/go/ql/lib/semmle/go/Files.qll
@@ -142,6 +142,13 @@ class GoFile extends File {
   override string getAPrimaryQlClass() { result = "GoFile" }
 }
 
+/** A dummy file. */
+class DummyFile extends ExtractedOrExternalFile {
+  DummyFile() { this.getBaseName() = "-" }
+
+  override string getAPrimaryQlClass() { result = "DummyFile" }
+}
+
 /** An HTML file. */
 class HtmlFile extends File {
   HtmlFile() { this.getExtension().regexpMatch("x?html?") }


### PR DESCRIPTION
We do not currently call `extractFileInfo` for dummy files (used e.g. when emitting diagnostics that do not relate to a particular file/location), which leads to a database inconsistency when it happens because the dummy file that is referenced is does not exist in the database. This PR inserts that missing `extractFileInfo` call and ensures that the dummy file does not end up in `CompilationCompilingFilesTable`. 

Note that this currently results in the dummy file appearing in e.g. `File` queries and we should decide whether this is OK (since it is obviously a dummy file) or modify the database schema or QL library so that the dummy files are hidden.