### PR TITLE
Ruby: add additional sources on the request object of Rails

### DIFF
--- a/ruby/ql/lib/codeql/ruby/frameworks/actiondispatch/internal/Request.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/actiondispatch/internal/Request.qll
@@ -38,8 +38,8 @@ module Request {
     ParametersCall() {
       this.getMethodName() =
         [
-          "parameters", "params", "GET", "POST", "query_parameters", "request_parameters",
-          "filtered_parameters"
+          "parameters", "params", "[]", "GET", "POST", "query_parameters", "request_parameters",
+          "filtered_parameters", "query_string"
         ]
     }
 
@@ -64,7 +64,7 @@ module Request {
       this.getMethodName() =
         [
           "authorization", "script_name", "path_info", "user_agent", "referer", "referrer",
-          "host_authority", "content_type", "host", "hostname", "accept_encoding",
+          "headers", "cookies", "cookie_jar", "content_type", "accept", "accept_encoding",
           "accept_language", "if_none_match", "if_none_match_etags", "content_mime_type"
         ]
       or
@@ -86,8 +86,9 @@ module Request {
     HostCall() {
       this.getMethodName() =
         [
-          "authority", "host", "host_authority", "host_with_port", "hostname", "forwarded_for",
-          "forwarded_host", "port", "forwarded_port"
+          "authority", "host", "host_authority", "host_with_port", "raw_host_with_port", "hostname",
+          "forwarded_for", "forwarded_host", "port", "forwarded_port", "port_string", "domain",
+          "subdomain", "subdomains"
         ]
     }
 

--- a/ruby/ql/src/change-notes/2024-02-13-rails-more-request-sources.md
+++ b/ruby/ql/src/change-notes/2024-02-13-rails-more-request-sources.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added additional request sources for Ruby on Rails.

--- a/ruby/ql/test/library-tests/frameworks/action_controller/ActionController.expected
+++ b/ruby/ql/test/library-tests/frameworks/action_controller/ActionController.expected
@@ -11,7 +11,7 @@ actionControllerControllerClasses
 | filter_flow.rb:42:1:57:3 | ThreeController |
 | filter_flow.rb:59:1:73:3 | FourController |
 | filter_flow.rb:75:1:93:3 | FiveController |
-| input_access.rb:1:1:50:3 | UsersController |
+| input_access.rb:1:1:58:3 | UsersController |
 | params_flow.rb:1:1:162:3 | MyController |
 | params_flow.rb:170:1:178:3 | Subclass |
 actionControllerActionMethods
@@ -48,7 +48,7 @@ actionControllerActionMethods
 | filter_flow.rb:83:3:84:5 | b |
 | filter_flow.rb:86:3:88:5 | c |
 | filter_flow.rb:90:3:92:5 | taint_foo |
-| input_access.rb:2:3:49:5 | index |
+| input_access.rb:2:3:57:5 | index |
 | logging.rb:2:5:8:7 | index |
 | params_flow.rb:2:3:4:5 | m1 |
 | params_flow.rb:6:3:8:5 | m2 |
@@ -230,43 +230,51 @@ httpInputAccesses
 | filter_flow.rb:91:12:91:17 | call to params | ActionController::Metal#params |
 | input_access.rb:3:5:3:18 | call to params | ActionDispatch::Request#params |
 | input_access.rb:4:5:4:22 | call to parameters | ActionDispatch::Request#parameters |
-| input_access.rb:5:5:5:15 | call to GET | ActionDispatch::Request#GET |
-| input_access.rb:6:5:6:16 | call to POST | ActionDispatch::Request#POST |
-| input_access.rb:7:5:7:28 | call to query_parameters | ActionDispatch::Request#query_parameters |
-| input_access.rb:8:5:8:30 | call to request_parameters | ActionDispatch::Request#request_parameters |
-| input_access.rb:9:5:9:31 | call to filtered_parameters | ActionDispatch::Request#filtered_parameters |
-| input_access.rb:11:5:11:25 | call to authorization | ActionDispatch::Request#authorization |
-| input_access.rb:12:5:12:23 | call to script_name | ActionDispatch::Request#script_name |
-| input_access.rb:13:5:13:21 | call to path_info | ActionDispatch::Request#path_info |
-| input_access.rb:14:5:14:22 | call to user_agent | ActionDispatch::Request#user_agent |
-| input_access.rb:15:5:15:19 | call to referer | ActionDispatch::Request#referer |
-| input_access.rb:16:5:16:20 | call to referrer | ActionDispatch::Request#referrer |
-| input_access.rb:17:5:17:26 | call to host_authority | ActionDispatch::Request#host_authority |
-| input_access.rb:18:5:18:24 | call to content_type | ActionDispatch::Request#content_type |
-| input_access.rb:19:5:19:16 | call to host | ActionDispatch::Request#host |
-| input_access.rb:20:5:20:20 | call to hostname | ActionDispatch::Request#hostname |
-| input_access.rb:21:5:21:27 | call to accept_encoding | ActionDispatch::Request#accept_encoding |
-| input_access.rb:22:5:22:27 | call to accept_language | ActionDispatch::Request#accept_language |
-| input_access.rb:23:5:23:25 | call to if_none_match | ActionDispatch::Request#if_none_match |
-| input_access.rb:24:5:24:31 | call to if_none_match_etags | ActionDispatch::Request#if_none_match_etags |
-| input_access.rb:25:5:25:29 | call to content_mime_type | ActionDispatch::Request#content_mime_type |
-| input_access.rb:27:5:27:21 | call to authority | ActionDispatch::Request#authority |
-| input_access.rb:28:5:28:16 | call to host | ActionDispatch::Request#host |
-| input_access.rb:29:5:29:26 | call to host_authority | ActionDispatch::Request#host_authority |
-| input_access.rb:30:5:30:26 | call to host_with_port | ActionDispatch::Request#host_with_port |
-| input_access.rb:31:5:31:20 | call to hostname | ActionDispatch::Request#hostname |
-| input_access.rb:32:5:32:25 | call to forwarded_for | ActionDispatch::Request#forwarded_for |
-| input_access.rb:33:5:33:26 | call to forwarded_host | ActionDispatch::Request#forwarded_host |
-| input_access.rb:34:5:34:16 | call to port | ActionDispatch::Request#port |
-| input_access.rb:35:5:35:26 | call to forwarded_port | ActionDispatch::Request#forwarded_port |
-| input_access.rb:37:5:37:22 | call to media_type | ActionDispatch::Request#media_type |
-| input_access.rb:38:5:38:29 | call to media_type_params | ActionDispatch::Request#media_type_params |
-| input_access.rb:39:5:39:27 | call to content_charset | ActionDispatch::Request#content_charset |
-| input_access.rb:40:5:40:20 | call to base_url | ActionDispatch::Request#base_url |
-| input_access.rb:42:5:42:16 | call to body | ActionDispatch::Request#body |
-| input_access.rb:43:5:43:20 | call to raw_post | ActionDispatch::Request#raw_post |
-| input_access.rb:45:5:45:30 | ...[...] | ActionDispatch::Request#env[] |
-| input_access.rb:47:5:47:39 | ...[...] | ActionDispatch::Request#env[] |
+| input_access.rb:5:5:5:29 | ...[...] | ActionDispatch::Request#[] |
+| input_access.rb:6:5:6:15 | call to GET | ActionDispatch::Request#GET |
+| input_access.rb:7:5:7:16 | call to POST | ActionDispatch::Request#POST |
+| input_access.rb:8:5:8:28 | call to query_parameters | ActionDispatch::Request#query_parameters |
+| input_access.rb:9:5:9:30 | call to request_parameters | ActionDispatch::Request#request_parameters |
+| input_access.rb:10:5:10:31 | call to filtered_parameters | ActionDispatch::Request#filtered_parameters |
+| input_access.rb:11:5:11:24 | call to query_string | ActionDispatch::Request#query_string |
+| input_access.rb:13:5:13:25 | call to authorization | ActionDispatch::Request#authorization |
+| input_access.rb:14:5:14:23 | call to script_name | ActionDispatch::Request#script_name |
+| input_access.rb:15:5:15:21 | call to path_info | ActionDispatch::Request#path_info |
+| input_access.rb:16:5:16:22 | call to user_agent | ActionDispatch::Request#user_agent |
+| input_access.rb:17:5:17:19 | call to referer | ActionDispatch::Request#referer |
+| input_access.rb:18:5:18:20 | call to referrer | ActionDispatch::Request#referrer |
+| input_access.rb:19:5:19:19 | call to headers | ActionDispatch::Request#headers |
+| input_access.rb:20:5:20:19 | call to cookies | ActionDispatch::Request#cookies |
+| input_access.rb:21:5:21:22 | call to cookie_jar | ActionDispatch::Request#cookie_jar |
+| input_access.rb:22:5:22:24 | call to content_type | ActionDispatch::Request#content_type |
+| input_access.rb:23:5:23:18 | call to accept | ActionDispatch::Request#accept |
+| input_access.rb:24:5:24:27 | call to accept_encoding | ActionDispatch::Request#accept_encoding |
+| input_access.rb:25:5:25:27 | call to accept_language | ActionDispatch::Request#accept_language |
+| input_access.rb:26:5:26:25 | call to if_none_match | ActionDispatch::Request#if_none_match |
+| input_access.rb:27:5:27:31 | call to if_none_match_etags | ActionDispatch::Request#if_none_match_etags |
+| input_access.rb:28:5:28:29 | call to content_mime_type | ActionDispatch::Request#content_mime_type |
+| input_access.rb:30:5:30:21 | call to authority | ActionDispatch::Request#authority |
+| input_access.rb:31:5:31:16 | call to host | ActionDispatch::Request#host |
+| input_access.rb:32:5:32:26 | call to host_authority | ActionDispatch::Request#host_authority |
+| input_access.rb:33:5:33:26 | call to host_with_port | ActionDispatch::Request#host_with_port |
+| input_access.rb:34:5:34:30 | call to raw_host_with_port | ActionDispatch::Request#raw_host_with_port |
+| input_access.rb:35:5:35:20 | call to hostname | ActionDispatch::Request#hostname |
+| input_access.rb:36:5:36:25 | call to forwarded_for | ActionDispatch::Request#forwarded_for |
+| input_access.rb:37:5:37:26 | call to forwarded_host | ActionDispatch::Request#forwarded_host |
+| input_access.rb:38:5:38:16 | call to port | ActionDispatch::Request#port |
+| input_access.rb:39:5:39:26 | call to forwarded_port | ActionDispatch::Request#forwarded_port |
+| input_access.rb:40:5:40:23 | call to port_string | ActionDispatch::Request#port_string |
+| input_access.rb:41:5:41:18 | call to domain | ActionDispatch::Request#domain |
+| input_access.rb:42:5:42:21 | call to subdomain | ActionDispatch::Request#subdomain |
+| input_access.rb:43:5:43:22 | call to subdomains | ActionDispatch::Request#subdomains |
+| input_access.rb:45:5:45:22 | call to media_type | ActionDispatch::Request#media_type |
+| input_access.rb:46:5:46:29 | call to media_type_params | ActionDispatch::Request#media_type_params |
+| input_access.rb:47:5:47:27 | call to content_charset | ActionDispatch::Request#content_charset |
+| input_access.rb:48:5:48:20 | call to base_url | ActionDispatch::Request#base_url |
+| input_access.rb:50:5:50:16 | call to body | ActionDispatch::Request#body |
+| input_access.rb:51:5:51:20 | call to raw_post | ActionDispatch::Request#raw_post |
+| input_access.rb:53:5:53:30 | ...[...] | ActionDispatch::Request#env[] |
+| input_access.rb:55:5:55:39 | ...[...] | ActionDispatch::Request#env[] |
 | logging.rb:5:22:5:35 | call to params | ActionDispatch::Request#params |
 | params_flow.rb:3:10:3:15 | call to params | ActionController::Metal#params |
 | params_flow.rb:7:10:7:15 | call to params | ActionController::Metal#params |

--- a/ruby/ql/test/library-tests/frameworks/action_controller/input_access.rb
+++ b/ruby/ql/test/library-tests/frameworks/action_controller/input_access.rb
@@ -2,11 +2,13 @@ class UsersController < ActionController::Base
   def index
     request.params
     request.parameters
+    request["parameter_name"]
     request.GET
     request.POST
     request.query_parameters
     request.request_parameters
     request.filtered_parameters
+    request.query_string
 
     request.authorization
     request.script_name
@@ -14,10 +16,11 @@ class UsersController < ActionController::Base
     request.user_agent
     request.referer
     request.referrer
-    request.host_authority
+    request.headers
+    request.cookies
+    request.cookie_jar
     request.content_type
-    request.host
-    request.hostname
+    request.accept
     request.accept_encoding
     request.accept_language
     request.if_none_match
@@ -28,11 +31,16 @@ class UsersController < ActionController::Base
     request.host
     request.host_authority
     request.host_with_port
+    request.raw_host_with_port
     request.hostname
     request.forwarded_for
     request.forwarded_host
     request.port
     request.forwarded_port
+    request.port_string
+    request.domain
+    request.subdomain
+    request.subdomains
 
     request.media_type
     request.media_type_params


### PR DESCRIPTION
This PR adds some missing sources on the `request` object of Ruby on Rails (e.g. when used in an `ActionController`). E.g. the possibility of accessing a parameter directly via the request object `request["parameter_name"]` or accessing a header via `request.headers['Accept']`.

There is some overlap with the [request properties](https://github.com/github/codeql/blob/main/ruby/ql/lib/codeql/ruby/frameworks/rack/internal/Request.qll) as modelled for Rack and I am not sure if the original intent was that these sources should be provided by the Rack additions. (Currently they are not however.)

Additionally, I removed the three host related properties `"host_authority", "host", "hostname"` inside of `HeadersCall` as they were listed twice. (once in `HeadersCall` and once in `HostCall`). Maybe there's a reason why they were duplicated...
