### PR TITLE
Go: Use less confusing name for hardcoded credentials tests

### DIFF
--- a/go/ql/test/query-tests/Security/CWE-798/HardcodedCredentials.expected
+++ b/go/ql/test/query-tests/Security/CWE-798/HardcodedCredentials.expected
@@ -12,14 +12,14 @@
 | jwt.go:114:16:114:24 | sharedKey | Hard-coded credential. | jwt.go:113:22:113:27 | "key9" | password |
 | jwt.go:120:16:120:30 | sharedKeyglobal | Hard-coded credential. | jwt.go:117:30:117:36 | "key10" | password |
 | jwt.go:126:20:126:34 | type conversion | Hard-coded credential. | jwt.go:126:27:126:33 | "key11" | password |
-| jwt.go:143:39:143:46 | safeName | Hard-coded credential. | jwt.go:141:21:141:27 | "key12" | password |
-| jwt.go:152:11:152:18 | safeName | Hard-coded credential. | jwt.go:148:21:148:27 | "key13" | password |
-| jwt.go:160:34:160:41 | safeName | Hard-coded credential. | jwt.go:159:21:159:27 | "key14" | password |
-| jwt.go:166:32:166:39 | safeName | Hard-coded credential. | jwt.go:165:21:165:27 | "key15" | password |
-| jwt.go:172:41:172:48 | safeName | Hard-coded credential. | jwt.go:171:21:171:27 | "key16" | password |
-| jwt.go:178:51:178:58 | safeName | Hard-coded credential. | jwt.go:177:21:177:27 | "key17" | password |
-| jwt.go:184:42:184:49 | safeName | Hard-coded credential. | jwt.go:183:21:183:27 | "key18" | password |
-| jwt.go:192:33:192:40 | safeName | Hard-coded credential. | jwt.go:189:21:189:27 | "key19" | password |
+| jwt.go:143:39:143:41 | key | Hard-coded credential. | jwt.go:141:16:141:22 | "key12" | password |
+| jwt.go:152:11:152:13 | key | Hard-coded credential. | jwt.go:148:16:148:22 | "key13" | password |
+| jwt.go:160:34:160:36 | key | Hard-coded credential. | jwt.go:159:16:159:22 | "key14" | password |
+| jwt.go:166:32:166:34 | key | Hard-coded credential. | jwt.go:165:16:165:22 | "key15" | password |
+| jwt.go:172:41:172:43 | key | Hard-coded credential. | jwt.go:171:16:171:22 | "key16" | password |
+| jwt.go:178:51:178:53 | key | Hard-coded credential. | jwt.go:177:16:177:22 | "key17" | password |
+| jwt.go:184:42:184:44 | key | Hard-coded credential. | jwt.go:183:16:183:22 | "key18" | password |
+| jwt.go:192:33:192:35 | key | Hard-coded credential. | jwt.go:189:16:189:22 | "key19" | password |
 | main.go:6:14:6:23 | "p4ssw0rd" | Hard-coded $@. | main.go:6:14:6:23 | "p4ssw0rd" | password |
 | main.go:12:1:26:30 | `-----BEGIN RSA PRIVATE KEY-----\nMIICXQIBAAKBgQC/tzdtXKXcX6F3v3hR6+uYyZpIeXhhLflJkY2eILLQfAnwKlT5\nxIHW5QZcHQV9sCyZ8qSdPGif7PwgMbButMbByiZhCSugUFb6vjVqoktmslYF4LKH\niDgvmlwuJW0TvynxBLzDCwrRP+gpRT8wuAortWAx/03POTw7Mzi2cIPNsQIDAQAB\nAoGAMHCrqY9CPTdQhgAz94cDpTwzJmLCvtMt7J/BR5X9eF4O6MbZZ652HAUMIVQX\n4hUUf+VmIHB2AwqO/ddwO9ijaz04BslOSy/iYevHGlH65q4587NSlFWjvILMIQCM\nGBjfzJIxlLHVhjc2cFnyAE5YWjF/OMnJN0OhP9pxmCP/iM0CQQDxmQndQLdnV7+6\n8SvBHE8bg1LE8/BzTt68U3aWwiBjrHMFgzr//7Za4VF7h4ilFgmbh0F3sYz+C8iO\n0JrBRPeLAkEAyyTwnv/pgqTS/wuxIHUxRBpbdk3YvILAthNrGQg5uzA7eSeFu7Mv\nGtEkXsaqCDbdehgarFfNN8PB6OMRIbsXMwJBAOjhH8UJ0L/osYO9XPO0GfznRS1c\nBnbfm4vk1/bSAO6TF/xEVubU0i4f6q8sIecfqvskEVMS7lkjeptPMR0DIakCQE+7\nuQH/Wizf+r0GXshplyOu4LVHisk63N7aMlAJ7XbuUHmWLKRmiReSfR8CBNzig/2X\nFmkMsUyw9hwte5zsrQcCQQCrOkZvzUj9j1HKG+32EJ2E4kisJZmAgF9GI+z6oxpi\nExped5tp8EWytCjRwKhOcc0068SgaqhKvyyUWpbx32VQ\n-----END RSA PRIVATE KEY-----` | Hard-coded private key. | main.go:12:1:26:30 | `-----BEGIN RSA PRIVATE KEY-----\nMIICXQIBAAKBgQC/tzdtXKXcX6F3v3hR6+uYyZpIeXhhLflJkY2eILLQfAnwKlT5\nxIHW5QZcHQV9sCyZ8qSdPGif7PwgMbButMbByiZhCSugUFb6vjVqoktmslYF4LKH\niDgvmlwuJW0TvynxBLzDCwrRP+gpRT8wuAortWAx/03POTw7Mzi2cIPNsQIDAQAB\nAoGAMHCrqY9CPTdQhgAz94cDpTwzJmLCvtMt7J/BR5X9eF4O6MbZZ652HAUMIVQX\n4hUUf+VmIHB2AwqO/ddwO9ijaz04BslOSy/iYevHGlH65q4587NSlFWjvILMIQCM\nGBjfzJIxlLHVhjc2cFnyAE5YWjF/OMnJN0OhP9pxmCP/iM0CQQDxmQndQLdnV7+6\n8SvBHE8bg1LE8/BzTt68U3aWwiBjrHMFgzr//7Za4VF7h4ilFgmbh0F3sYz+C8iO\n0JrBRPeLAkEAyyTwnv/pgqTS/wuxIHUxRBpbdk3YvILAthNrGQg5uzA7eSeFu7Mv\nGtEkXsaqCDbdehgarFfNN8PB6OMRIbsXMwJBAOjhH8UJ0L/osYO9XPO0GfznRS1c\nBnbfm4vk1/bSAO6TF/xEVubU0i4f6q8sIecfqvskEVMS7lkjeptPMR0DIakCQE+7\nuQH/Wizf+r0GXshplyOu4LVHisk63N7aMlAJ7XbuUHmWLKRmiReSfR8CBNzig/2X\nFmkMsUyw9hwte5zsrQcCQQCrOkZvzUj9j1HKG+32EJ2E4kisJZmAgF9GI+z6oxpi\nExped5tp8EWytCjRwKhOcc0068SgaqhKvyyUWpbx32VQ\n-----END RSA PRIVATE KEY-----` | certificate |
 | main.go:44:14:44:19 | "p4ss" | Hard-coded $@. | main.go:44:14:44:19 | "p4ss" | password |

--- a/go/ql/test/query-tests/Security/CWE-798/jwt.go
+++ b/go/ql/test/query-tests/Security/CWE-798/jwt.go
@@ -138,56 +138,56 @@ func gogfjwt() interface{} {
 }
 
 func irisjwt() interface{} {
-	safeName := []byte("key12")
+	key := []byte("key12")
 	token := iris.NewTokenWithClaims(nil, nil)
-	tokenString, _ := token.SignedString(safeName) // BAD
+	tokenString, _ := token.SignedString(key) // BAD
 	return tokenString
 }
 
 func iris12jwt2() interface{} {
-	safeName := []byte("key13")
+	key := []byte("key13")
 
 	s := &iris12.Signer{
 		Alg:    nil,
-		Key:    safeName, // BAD
+		Key:    key, // BAD
 		MaxAge: 3 * time.Second,
 	}
 	return s
 }
 
 func irisjwt3() interface{} {
-	safeName := []byte("key14")
-	signer := iris12.NewSigner(nil, safeName, 3*time.Second) // BAD
+	key := []byte("key14")
+	signer := iris12.NewSigner(nil, key, 3*time.Second) // BAD
 	return signer
 }
 
 func katarasJwt() interface{} {
-	safeName := []byte("key15")
-	token, _ := kataras.Sign(nil, safeName, nil, nil) // BAD
+	key := []byte("key15")
+	token, _ := kataras.Sign(nil, key, nil, nil) // BAD
 	return token
 }
 
 func katarasJwt2() interface{} {
-	safeName := []byte("key16")
-	token, _ := kataras.SignEncrypted(nil, safeName, nil, nil) // BAD
+	key := []byte("key16")
+	token, _ := kataras.SignEncrypted(nil, key, nil, nil) // BAD
 	return token
 }
 
 func katarasJwt3() interface{} {
-	safeName := []byte("key17")
-	token, _ := kataras.SignEncryptedWithHeader(nil, safeName, nil, nil, nil) // BAD
+	key := []byte("key17")
+	token, _ := kataras.SignEncryptedWithHeader(nil, key, nil, nil, nil) // BAD
 	return token
 }
 
 func katarasJwt4() interface{} {
-	safeName := []byte("key18")
-	token, _ := kataras.SignWithHeader(nil, safeName, nil, nil) // BAD
+	key := []byte("key18")
+	token, _ := kataras.SignWithHeader(nil, key, nil, nil) // BAD
 	return token
 }
 
 func katarasJwt5() {
-	safeName := []byte("key19")
+	key := []byte("key19")
 	var keys kataras.Keys
 	var alg kataras.Alg
-	keys.Register(alg, "api", nil, safeName) // BAD
+	keys.Register(alg, "api", nil, key) // BAD
 }


### PR DESCRIPTION
We don't want name-based heuristics to pick these variable names, but also using something like 'safeName' may mislead readers into believing the test cases are intended to be GOOD cases (i.e. safe).