### PR TITLE
Java: Expand ExactPathSanitizer to work on the argument of 'equals' too

### DIFF
--- a/java/ql/lib/semmle/code/java/security/PathSanitizer.qll
+++ b/java/ql/lib/semmle/code/java/security/PathSanitizer.qll
@@ -56,7 +56,7 @@ private predicate exactPathMatchGuard(Guard g, Expr e, boolean branch) {
     t instanceof StringsKt or
     t instanceof FilesKt
   |
-    e = getVisualQualifier(ma).getUnderlyingExpr() and
+    e = [getVisualQualifier(ma).getUnderlyingExpr(), getVisualArgument(ma, 0)] and
     ma.getMethod().getDeclaringType() = t and
     ma = g and
     getSourceMethod(ma.getMethod()).hasName(["equals", "equalsIgnoreCase"]) and

--- a/java/ql/src/change-notes/2024-02-15-path-sanitizer-equals.md
+++ b/java/ql/src/change-notes/2024-02-15-path-sanitizer-equals.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The sanitizer for the path injection queries has been improved to handle more cases where `equals` is used to check an exact path match.

--- a/java/ql/test/library-tests/pathsanitizer/Test.java
+++ b/java/ql/test/library-tests/pathsanitizer/Test.java
@@ -26,6 +26,13 @@ public class Test {
                 sink(source); // $ hasTaintFlow
         }
         {
+            String source = (String) source();
+            if ("/safe/path".equals(source))
+                sink(source); // Safe
+            else
+                sink(source); // $ hasTaintFlow
+        }
+        {
             URI source = (URI) source();
             if (source.equals(new URI("http://safe/uri")))
                 sink(source); // Safe

--- a/java/ql/test/library-tests/pathsanitizer/TestKt.kt
+++ b/java/ql/test/library-tests/pathsanitizer/TestKt.kt
@@ -26,6 +26,13 @@ class TestKt {
                 sink(source) // $ hasTaintFlow
         }
         run {
+            val source = source() as String?
+            if ("/safe/path".equals(source))
+                sink(source) // Safe
+            else
+                sink(source) // $ hasTaintFlow
+        }
+        run {
             val source = source() as URI?
             if (source!!.equals(URI("http://safe/uri")))
                 sink(source) // Safe


### PR DESCRIPTION
Handles the pattern `"/safe/path".equals(tainted)` as a path injection sanitizer.