### PR TITLE
C++: Don't strip specifiers away in `TFinalParameterUse`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -142,7 +142,7 @@ private newtype TDefOrUseImpl =
     exists(SsaInternals0::Def def |
       def.getSourceVariable().getBaseVariable().(BaseIRVariable).getIRVariable().getAst() = p and
       not def.getValue().asInstruction() instanceof InitializeParameterInstruction and
-      unspecifiedTypeIsModifiableAt(p.getUnspecifiedType(), indirectionIndex)
+      underlyingTypeIsModifiableAt(p.getUnderlyingType(), indirectionIndex)
     )
   }
 
@@ -172,11 +172,13 @@ private predicate isGlobalDefImpl(
   )
 }
 
-private predicate unspecifiedTypeIsModifiableAt(Type unspecified, int indirectionIndex) {
-  indirectionIndex = [1 .. getIndirectionForUnspecifiedType(unspecified).getNumberOfIndirections()] and
+private predicate underlyingTypeIsModifiableAt(Type underlying, int indirectionIndex) {
+  indirectionIndex =
+    [1 .. getIndirectionForUnspecifiedType(underlying.getUnspecifiedType())
+          .getNumberOfIndirections()] and
   exists(CppType cppType |
-    cppType.hasUnspecifiedType(unspecified, _) and
-    isModifiableAt(cppType, indirectionIndex + 1)
+    cppType.hasUnderlyingType(underlying, false) and
+    isModifiableAt(cppType, indirectionIndex)
   )
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
@@ -452,7 +452,7 @@ private module IsModifiableAtImpl {
   private predicate impl(CppType cppType, int indirectionIndex) {
     exists(Type pointerType, Type base |
       isUnderlyingIndirectionType(pointerType) and
-      cppType.hasUnderlyingType(pointerType, _) and
+      cppType.hasUnderlyingType(pointerType, false) and
       base = getTypeImpl(pointerType, indirectionIndex)
     |
       // The value cannot be modified if it has a const specifier,


### PR DESCRIPTION
This is a preparatory change to an upcoming PR I'm doing related to the "automatically block flow out of modelled functions" work. It won't really have any visible impact yet, so it should be a totally safe change.

The core of the change is that we were incorrectly calling `getUnspecifiedType` instead of `getUnderlyingType` when checking whether a parameter could be written to. Calling `getUnspecifiedType` is wrong since, in addition to resolve typedefs, it also strips off `const` specifiers.

Instead, we should be calling `getUnderlyingType` since that _only_ resolves typedefs.

DCA looks uneventful (as expected).