### PR TITLE
Extend permissions in `csv-coverage-update.yml`

### DIFF
--- a/.github/workflows/csv-coverage-update.yml
+++ b/.github/workflows/csv-coverage-update.yml
@@ -6,7 +6,7 @@ on:
     - cron: "0 0 * * *"
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/csv-coverage-update.yml` file. The permissions for `contents` have been updated from `read` to `write`. This change allows the workflow to modify the repository's contents. The workflow currently fails when it pushes a new commit to a specific branch in the repo.