### PR TITLE
Add `security-events: write` permission in `ql-for-ql-build.yml`

### DIFF
--- a/.github/workflows/ql-for-ql-build.yml
+++ b/.github/workflows/ql-for-ql-build.yml
@@ -11,7 +11,7 @@ env:
 
 permissions:
   contents: read
-  security-events: read
+  security-events: write
 
 jobs:
   analyze:


### PR DESCRIPTION
We downgraded to `read` in https://github.com/github/codeql/pull/15493 but it looks like we need `write` to upload the SARIF. See [failure](https://github.com/github/codeql/actions/runs/7916238959/job/21635263983). 