### PR TITLE
Dataflow: Fix flow-feature bug for parameterless static functions

### DIFF
--- a/java/ql/test/library-tests/dataflow/flowfeature/A.java
+++ b/java/ql/test/library-tests/dataflow/flowfeature/A.java
@@ -1,0 +1,49 @@
+public class A {
+  static Object source(String s) { return null; }
+  static void sink(Object o) { }
+
+  static Object id(Object x) { return x; }
+
+  static void test1(int dummy) {
+    Object src = source("1");
+    Object a = src;
+    sink(a); // $ EqCc="1" SrcCc="1" SinkCc="1"
+  }
+
+  static void test2() {
+    Object src = source("2");
+    Object a = src;
+    sink(a); // $ EqCc="2" SrcCc="2" SinkCc="2"
+  }
+
+  void test3() {
+    Object src = source("3");
+    Object a = id(src);
+    sink(a); // $ EqCc="3" SrcCc="3" SinkCc="3"
+  }
+
+  static void test4() {
+    Object src = source("4");
+    Object a = id(src);
+    sink(a); // $ EqCc="4" SrcCc="4" SinkCc="4"
+  }
+
+  static Object test5src() {
+    return source("5");
+  }
+
+  static void test5() {
+    Object x = test5src();
+    Object y = id(x);
+    sink(y); // $ SinkCc="5"
+  }
+
+  static void test6sink(Object x) {
+    sink(x); // $ SrcCc="6"
+  }
+
+  static void test6() {
+    Object x = source("6");
+    test6sink(x);
+  }
+}

--- a/java/ql/test/library-tests/dataflow/flowfeature/flow.expected
+++ b/java/ql/test/library-tests/dataflow/flowfeature/flow.expected
@@ -1,7 +1,2 @@
 testFailures
-| A.java:16:14:16:47 | // $ EqCc="2" SrcCc="2" SinkCc="2" | Missing result:EqCc="2" |
-| A.java:16:14:16:47 | // $ EqCc="2" SrcCc="2" SinkCc="2" | Missing result:SrcCc="2" |
-| A.java:28:14:28:47 | // $ EqCc="4" SrcCc="4" SinkCc="4" | Missing result:EqCc="4" |
-| A.java:28:14:28:47 | // $ EqCc="4" SrcCc="4" SinkCc="4" | Missing result:SrcCc="4" |
-| A.java:42:14:42:27 | // $ SrcCc="6" | Missing result:SrcCc="6" |
 failures

--- a/java/ql/test/library-tests/dataflow/flowfeature/flow.expected
+++ b/java/ql/test/library-tests/dataflow/flowfeature/flow.expected
@@ -1,0 +1,7 @@
+testFailures
+| A.java:16:14:16:47 | // $ EqCc="2" SrcCc="2" SinkCc="2" | Missing result:EqCc="2" |
+| A.java:16:14:16:47 | // $ EqCc="2" SrcCc="2" SinkCc="2" | Missing result:SrcCc="2" |
+| A.java:28:14:28:47 | // $ EqCc="4" SrcCc="4" SinkCc="4" | Missing result:EqCc="4" |
+| A.java:28:14:28:47 | // $ EqCc="4" SrcCc="4" SinkCc="4" | Missing result:SrcCc="4" |
+| A.java:42:14:42:27 | // $ SrcCc="6" | Missing result:SrcCc="6" |
+failures

--- a/java/ql/test/library-tests/dataflow/flowfeature/flow.ql
+++ b/java/ql/test/library-tests/dataflow/flowfeature/flow.ql
@@ -1,0 +1,60 @@
+import java
+import semmle.code.java.dataflow.DataFlow
+import TestUtilities.InlineExpectationsTest
+
+module Base {
+  predicate isSource(DataFlow::Node n) { n.asExpr().(MethodCall).getMethod().hasName("source") }
+
+  predicate isSink(DataFlow::Node n) {
+    exists(MethodCall ma | ma.getMethod().hasName("sink") | n.asExpr() = ma.getAnArgument())
+  }
+}
+
+module ConfigSourceCc implements DataFlow::ConfigSig {
+  import Base
+
+  DataFlow::FlowFeature getAFeature() { result instanceof DataFlow::FeatureHasSourceCallContext }
+}
+
+module ConfigSinkCc implements DataFlow::ConfigSig {
+  import Base
+
+  DataFlow::FlowFeature getAFeature() { result instanceof DataFlow::FeatureHasSinkCallContext }
+}
+
+module ConfigEqualCc implements DataFlow::ConfigSig {
+  import Base
+
+  DataFlow::FlowFeature getAFeature() {
+    result instanceof DataFlow::FeatureEqualSourceSinkCallContext
+  }
+}
+
+module FlowSourceCc = DataFlow::Global<ConfigSourceCc>;
+
+module FlowSinkCc = DataFlow::Global<ConfigSinkCc>;
+
+module FlowEqualCc = DataFlow::Global<ConfigEqualCc>;
+
+module HasFlowTest implements TestSig {
+  string getARelevantTag() { result = ["SrcCc", "SinkCc", "EqCc"] }
+
+  predicate hasActualResult(Location location, string element, string tag, string value) {
+    exists(DataFlow::Node src, DataFlow::Node sink |
+      tag = "SrcCc" and
+      FlowSourceCc::flow(src, sink)
+      or
+      tag = "SinkCc" and
+      FlowSinkCc::flow(src, sink)
+      or
+      tag = "EqCc" and
+      FlowEqualCc::flow(src, sink)
+    |
+      sink.getLocation() = location and
+      element = sink.toString() and
+      value = src.asExpr().(MethodCall).getAnArgument().toString()
+    )
+  }
+}
+
+import MakeTest<HasFlowTest>

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
@@ -1551,9 +1551,7 @@ module MakeImplCommon<InputSig Lang> {
   class CallContextSomeCall extends CallContextCall, TSomeCall {
     override string toString() { result = "CcSomeCall" }
 
-    override predicate relevantFor(DataFlowCallable callable) {
-      exists(ParamNode p | getNodeEnclosingCallable(p) = callable)
-    }
+    override predicate relevantFor(DataFlowCallable callable) { any() }
 
     override predicate matchesCall(DataFlowCall call) { any() }
   }


### PR DESCRIPTION
The flow features `FeatureHasSourceCallContext` and `FeatureEqualSourceSinkCallContext` didn't work for parameterless static functions. This bug is fairly obscure, since most use-cases of those two features expect the source to be a parameter, and that's why it has gone undetected for quite some time.