### PR TITLE
Java: Sensitive Logging: Simplify definition of source and improve QLDoc

### DIFF
--- a/java/ql/lib/semmle/code/java/security/SensitiveLoggingQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/SensitiveLoggingQuery.qll
@@ -8,12 +8,15 @@ import semmle.code.java.frameworks.android.Compose
 private import semmle.code.java.security.Sanitizers
 
 /** A variable that may hold sensitive information, judging by its name. */
-class CredentialExpr extends Expr {
+class VariableWithSensitiveName extends Variable {
+  VariableWithSensitiveName() { this.getName().regexpMatch(getCommonSensitiveInfoRegex()) }
+}
+
+/** A reference to a variable that may hold sensitive information, judging by its name. */
+class CredentialExpr extends VarAccess {
   CredentialExpr() {
-    exists(Variable v | this = v.getAnAccess() |
-      v.getName().regexpMatch(getCommonSensitiveInfoRegex()) and
-      not this instanceof CompileTimeConstantExpr
-    )
+    this.getVariable() instanceof VariableWithSensitiveName and
+    not this instanceof CompileTimeConstantExpr
   }
 }
 


### PR DESCRIPTION
This is also slightly faster to evaluate (217s instead of 228s on apache/geode on my machine).