### PR TITLE
Swift: remove test sdk

### DIFF
--- a/swift/BUILD.bazel
+++ b/swift/BUILD.bazel
@@ -75,13 +75,6 @@ pkg_filegroup(
     visibility = ["//visibility:public"],
 )
 
-pkg_files(
-    name = "swift-test-sdk-arch",
-    srcs = ["//swift/third_party/swift-llvm-support:swift-test-sdk"],
-    prefix = "qltest/" + codeql_platform,
-    strip_prefix = strip_prefix.from_pkg(),
-)
-
 pkg_filegroup(
     name = "extractor-pack-arch",
     srcs = select({
@@ -89,7 +82,6 @@ pkg_filegroup(
         "//conditions:default": [
             ":extractor",
             ":resource-dir-arch",
-            ":swift-test-sdk-arch",
         ],
     }) + select({
         "@platforms//os:macos": [

--- a/swift/ql/test/extractor-tests/run_under/Strings.expected
+++ b/swift/ql/test/extractor-tests/run_under/Strings.expected
@@ -1,2 +1,2 @@
-| run_under: $CODEQL_EXTRACTOR_SWIFT_ROOT/tools/$CODEQL_PLATFORM/extractor -sdk $CODEQL_EXTRACTOR_SWIFT_ROOT/qltest/$CODEQL_PLATFORM/sdk -resource-dir $CODEQL_EXTRACTOR_SWIFT_ROOT/resource-dir/$CODEQL_PLATFORM -c -primary-file filtered_in.swift |
-| run_under: $CODEQL_EXTRACTOR_SWIFT_ROOT/tools/$CODEQL_PLATFORM/extractor -sdk $CODEQL_EXTRACTOR_SWIFT_ROOT/qltest/$CODEQL_PLATFORM/sdk -resource-dir $CODEQL_EXTRACTOR_SWIFT_ROOT/resource-dir/$CODEQL_PLATFORM -c -primary-file unfiltered.swift |
+| run_under: $CODEQL_EXTRACTOR_SWIFT_ROOT/tools/$CODEQL_PLATFORM/extractor -resource-dir $CODEQL_EXTRACTOR_SWIFT_ROOT/resource-dir/$CODEQL_PLATFORM -c -primary-file filtered_in.swift |
+| run_under: $CODEQL_EXTRACTOR_SWIFT_ROOT/tools/$CODEQL_PLATFORM/extractor -resource-dir $CODEQL_EXTRACTOR_SWIFT_ROOT/resource-dir/$CODEQL_PLATFORM -c -primary-file unfiltered.swift |

--- a/swift/third_party/BUILD.swift-llvm-support.bazel
+++ b/swift/third_party/BUILD.swift-llvm-support.bazel
@@ -32,12 +32,3 @@ cc_library(
     }),
     visibility = ["//visibility:public"],
 )
-
-pkg_files(
-    name = "swift-test-sdk",
-    srcs = glob([
-        "sdk/**/*",
-    ]),
-    strip_prefix = strip_prefix.from_pkg(),
-    visibility = ["//visibility:public"],
-)

--- a/swift/third_party/swift-llvm-support/BUILD.bazel
+++ b/swift/third_party/swift-llvm-support/BUILD.bazel
@@ -9,14 +9,6 @@ alias(
 )
 
 alias(
-    name = "swift-test-sdk",
-    actual = select({
-        "@bazel_tools//src/conditions:linux": "@swift_prebuilt_linux//:swift-test-sdk",
-        "@bazel_tools//src/conditions:darwin": "@swift_prebuilt_darwin_x86_64//:swift-test-sdk",
-    }),
-)
-
-alias(
     name = "swift-resource-dir",
     actual = select({
         "@bazel_tools//src/conditions:linux": "@swift_toolchain_linux//:resource-dir",

--- a/swift/tools/qltest.sh
+++ b/swift/tools/qltest.sh
@@ -5,12 +5,11 @@ mkdir -p "$CODEQL_EXTRACTOR_SWIFT_TRAP_DIR"
 QLTEST_LOG="$CODEQL_EXTRACTOR_SWIFT_LOG_DIR"/qltest.log
 
 EXTRACTOR="$CODEQL_EXTRACTOR_SWIFT_ROOT/tools/$CODEQL_PLATFORM/extractor"
-SDK="$CODEQL_EXTRACTOR_SWIFT_ROOT/qltest/$CODEQL_PLATFORM/sdk"
 RESOURCE_DIR="$CODEQL_EXTRACTOR_SWIFT_ROOT/resource-dir/$CODEQL_PLATFORM"
 export CODEQL_EXTRACTOR_SWIFT_LOG_LEVELS=${CODEQL_EXTRACTOR_SWIFT_LOG_LEVELS:-out:text:no_logs,out:console:info}
 for src in *.swift; do
   env=()
-  opts=(-sdk "$SDK" -resource-dir "$RESOURCE_DIR" -c -primary-file "$src")
+  opts=(-resource-dir "$RESOURCE_DIR" -c -primary-file "$src")
   opts+=($(sed -n '1 s=//codeql-extractor-options:==p' $src))
   expected_status=$(sed -n 's=//codeql-extractor-expected-status:[[:space:]]*==p' $src)
   expected_status=${expected_status:-0}

--- a/swift/tools/test/qltest/utils.py
+++ b/swift/tools/test/qltest/utils.py
@@ -60,8 +60,8 @@ def assert_extractor_executed_with(*flags):
         for actual, expected in itertools.zip_longest(execution, flags):
             if actual:
                 actual = actual.strip()
-                expected_prefix = f"-sdk {swift_root}/qltest/{platform}/sdk -resource-dir {swift_root}/resource-dir/{platform} -c -primary-file "
-                assert actual.startswith(expected_prefix), f"correct sdk option not found in\n{actual}"
+                expected_prefix = f"-resource-dir {swift_root}/resource-dir/{platform} -c -primary-file "
+                assert actual.startswith(expected_prefix), f"correct options not found in\n{actual}"
                 actual = actual[len(expected_prefix):]
             assert actual, f"\nnot encountered: {expected}"
             assert expected, f"\nunexpected: {actual}"


### PR DESCRIPTION
The test sdk that we were prebuilding to run ql tests is actually not needed, as the `resource-dir` we package for cross-version compatibility is enough for running qltests as well.