### PR TITLE
Java: Switch helper flow from Global to SimpleGlobal in StaticInitializationVectorQuery.

### DIFF
--- a/shared/typetracking/codeql/typetracking/internal/TypeTrackingImpl.qll
+++ b/shared/typetracking/codeql/typetracking/internal/TypeTrackingImpl.qll
@@ -785,24 +785,26 @@ module TypeTracking<TypeTrackingInput I> {
         )
       }
 
+      private Node getNodeMid(PathNodeFwd n) { n = TPathNodeMid(result, _) }
+
+      private Node getNodeSink(PathNodeFwd n) { n = TPathNodeSink(result) }
+
       private predicate edgeCand(PathNodeFwd n1, PathNodeFwd n2) {
         exists(PathNodeFwd tgt |
-          edgeCand(n1.getNode(), n1.getTypeTracker(), tgt.getNode(), tgt.getTypeTracker())
+          edgeCand(getNodeMid(n1), n1.getTypeTracker(), getNodeMid(tgt), tgt.getTypeTracker())
         |
           n2 = tgt
           or
-          n2 = TPathNodeSink(tgt.getNode()) and tgt.getTypeTracker().end()
+          n2 = TPathNodeSink(getNodeMid(tgt)) and tgt.getTypeTracker().end()
         )
         or
         n1.getTypeTracker().end() and
-        flowsTo(n1.getNode(), n2.getNode()) and
-        n1.getNode() != n2.getNode() and
-        n2 instanceof TPathNodeSink
+        flowsTo(getNodeMid(n1), getNodeSink(n2)) and
+        getNodeMid(n1) != getNodeSink(n2)
         or
-        sourceSimpleLocalSmallSteps(n1.getNode(), n2.getNode()) and
-        n1.getNode() != n2.getNode() and
-        n1.isSource() and
-        n2.isSink()
+        sourceSimpleLocalSmallSteps(n1.getNode(), getNodeSink(n2)) and
+        n1.getNode() != getNodeSink(n2) and
+        n1.isSource()
       }
 
       private predicate reachRev(PathNodeFwd n) {


### PR DESCRIPTION
Using a full global data flow instance is overkill and prone to performance issues: In my fieldFlowBranchLimit experiments I noticed this particular configuration suddenly taking an additional 3.6 hours to compute in the dca run.
I expect that the SimpleGlobal flow will be mostly comparable for the level of precision needed here, so I don't expect much in the way of alert changes, but let's see if dca finds something.