### PR TITLE
C#: Use primary constructors for record types for dataflow.

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -2075,11 +2075,10 @@ predicate storeStep(Node node1, ContentSet c, Node node2) {
     node1 = TExplicitParameterNode(p) and
     node2 = TPrimaryConstructorThisAccessNode(p, true) and
     exists(Type t | t = p.getCallable().getDeclaringType() |
-      not t instanceof RecordType and
-      c.(PrimaryConstructorParameterContent).getParameter() = p
-      or
-      t instanceof RecordType and
-      c.(PropertyContent).getProperty().getName() = p.getName()
+      if t instanceof RecordType then
+        c.(PropertyContent).getProperty().getName() = p.getName()
+      else
+        c.(PrimaryConstructorParameterContent).getParameter() = p
     )
   )
   or

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -2075,10 +2075,9 @@ predicate storeStep(Node node1, ContentSet c, Node node2) {
     node1 = TExplicitParameterNode(p) and
     node2 = TPrimaryConstructorThisAccessNode(p, true) and
     exists(Type t | t = p.getCallable().getDeclaringType() |
-      if t instanceof RecordType then
-        c.(PropertyContent).getProperty().getName() = p.getName()
-      else
-        c.(PrimaryConstructorParameterContent).getParameter() = p
+      if t instanceof RecordType
+      then c.(PropertyContent).getProperty().getName() = p.getName()
+      else c.(PrimaryConstructorParameterContent).getParameter() = p
     )
   )
   or

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -2074,11 +2074,9 @@ predicate storeStep(Node node1, ContentSet c, Node node2) {
   exists(Parameter p |
     node1 = TExplicitParameterNode(p) and
     node2 = TPrimaryConstructorThisAccessNode(p, true) and
-    exists(Type t | t = p.getCallable().getDeclaringType() |
-      if t instanceof RecordType
-      then c.(PropertyContent).getProperty().getName() = p.getName()
-      else c.(PrimaryConstructorParameterContent).getParameter() = p
-    )
+    if p.getCallable().getDeclaringType() instanceof RecordType
+    then c.(PropertyContent).getProperty().getName() = p.getName()
+    else c.(PrimaryConstructorParameterContent).getParameter() = p
   )
   or
   FlowSummaryImpl::Private::Steps::summaryStoreStep(node1.(FlowSummaryNode).getSummaryNode(), c,

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -2074,7 +2074,13 @@ predicate storeStep(Node node1, ContentSet c, Node node2) {
   exists(Parameter p |
     node1 = TExplicitParameterNode(p) and
     node2 = TPrimaryConstructorThisAccessNode(p, true) and
-    c.(PrimaryConstructorParameterContent).getParameter() = p
+    exists(Type t | t = p.getCallable().getDeclaringType() |
+      not t instanceof RecordType and
+      c.(PrimaryConstructorParameterContent).getParameter() = p
+      or
+      t instanceof RecordType and
+      c.(PropertyContent).getProperty().getName() = p.getName()
+    )
   )
   or
   FlowSummaryImpl::Private::Steps::summaryStoreStep(node1.(FlowSummaryNode).getSummaryNode(), c,

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
@@ -358,63 +358,6 @@ private module BidirectionalImports {
   private import semmle.code.csharp.frameworks.EntityFramework
 }
 
-private predicate recordConstructorFlow(Constructor c, int i, Property p) {
-  c = any(RecordType r).getAMember() and
-  exists(string name |
-    c.getParameter(i).getName() = name and
-    c.getDeclaringType().getAMember(name) = p
-  )
-}
-
-private class RecordConstructorFlow extends Impl::Private::SummarizedCallableImpl {
-  RecordConstructorFlow() { recordConstructorFlow(this, _, _) }
-
-  predicate propagatesFlowImpl(
-    Impl::Private::SummaryComponentStack input, Impl::Private::SummaryComponentStack output,
-    boolean preservesValue
-  ) {
-    exists(int i, Property p |
-      recordConstructorFlow(this, i, p) and
-      input = Private::SummaryComponentStack::argument(i) and
-      output =
-        Private::SummaryComponentStack::propertyOf(p, Private::SummaryComponentStack::return()) and
-      preservesValue = true
-    )
-  }
-
-  override predicate propagatesFlow(
-    Impl::Private::SummaryComponentStack input, Impl::Private::SummaryComponentStack output,
-    boolean preservesValue
-  ) {
-    this.propagatesFlowImpl(input, output, preservesValue)
-  }
-
-  override predicate hasProvenance(Public::Provenance provenance) { provenance = "manual" }
-}
-
-// see `SummarizedCallableImpl` qldoc
-private class RecordConstructorFlowAdapter extends Impl::Public::SummarizedCallable instanceof RecordConstructorFlow
-{
-  override predicate propagatesFlow(string input, string output, boolean preservesValue) { none() }
-
-  override predicate hasProvenance(Public::Provenance provenance) {
-    RecordConstructorFlow.super.hasProvenance(provenance)
-  }
-}
-
-private class RecordConstructorFlowRequiredSummaryComponentStack extends Impl::Private::RequiredSummaryComponentStack
-{
-  override predicate required(
-    Impl::Private::SummaryComponent head, Impl::Private::SummaryComponentStack tail
-  ) {
-    exists(Property p |
-      recordConstructorFlow(_, _, p) and
-      head = Private::SummaryComponent::property(p) and
-      tail = Private::SummaryComponentStack::return()
-    )
-  }
-}
-
 private import semmle.code.csharp.frameworks.system.linq.Expressions
 
 private predicate mayInvokeCallback(Callable c, int n) {

--- a/csharp/ql/test/library-tests/dataflow/constructors/ConstructorFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/constructors/ConstructorFlow.expected
@@ -78,6 +78,14 @@ edges
 | Constructors.cs:132:29:132:30 | access to local variable o2 : Object | Constructors.cs:132:18:132:31 | object creation of type C4 : C4 [property Obj2] : Object | provenance |  |
 | Constructors.cs:133:14:133:15 | access to local variable c4 : C4 [property Obj1] : Object | Constructors.cs:133:14:133:20 | access to property Obj1 | provenance |  |
 | Constructors.cs:134:14:134:15 | access to local variable c4 : C4 [property Obj2] : Object | Constructors.cs:134:14:134:20 | access to property Obj2 | provenance |  |
+| Constructors.cs:141:18:141:34 | call to method Source<Object> : Object | Constructors.cs:143:25:143:26 | access to local variable o1 : Object | provenance |  |
+| Constructors.cs:142:18:142:35 | call to method Source<Object> : Object | Constructors.cs:143:29:143:30 | access to local variable o2 : Object | provenance |  |
+| Constructors.cs:143:18:143:31 | object creation of type R1 : R1 [property Obj1] : Object | Constructors.cs:144:14:144:15 | access to local variable r1 : R1 [property Obj1] : Object | provenance |  |
+| Constructors.cs:143:18:143:31 | object creation of type R1 : R1 [property Obj2] : Object | Constructors.cs:145:14:145:15 | access to local variable r1 : R1 [property Obj2] : Object | provenance |  |
+| Constructors.cs:143:25:143:26 | access to local variable o1 : Object | Constructors.cs:143:18:143:31 | object creation of type R1 : R1 [property Obj1] : Object | provenance |  |
+| Constructors.cs:143:29:143:30 | access to local variable o2 : Object | Constructors.cs:143:18:143:31 | object creation of type R1 : R1 [property Obj2] : Object | provenance |  |
+| Constructors.cs:144:14:144:15 | access to local variable r1 : R1 [property Obj1] : Object | Constructors.cs:144:14:144:20 | access to property Obj1 | provenance |  |
+| Constructors.cs:145:14:145:15 | access to local variable r1 : R1 [property Obj2] : Object | Constructors.cs:145:14:145:20 | access to property Obj2 | provenance |  |
 nodes
 | Constructors.cs:5:24:5:25 | [post] this access : C_no_ctor [field s1] : Object | semmle.label | [post] this access : C_no_ctor [field s1] : Object |
 | Constructors.cs:5:29:5:45 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
@@ -164,6 +172,16 @@ nodes
 | Constructors.cs:133:14:133:20 | access to property Obj1 | semmle.label | access to property Obj1 |
 | Constructors.cs:134:14:134:15 | access to local variable c4 : C4 [property Obj2] : Object | semmle.label | access to local variable c4 : C4 [property Obj2] : Object |
 | Constructors.cs:134:14:134:20 | access to property Obj2 | semmle.label | access to property Obj2 |
+| Constructors.cs:141:18:141:34 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| Constructors.cs:142:18:142:35 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| Constructors.cs:143:18:143:31 | object creation of type R1 : R1 [property Obj1] : Object | semmle.label | object creation of type R1 : R1 [property Obj1] : Object |
+| Constructors.cs:143:18:143:31 | object creation of type R1 : R1 [property Obj2] : Object | semmle.label | object creation of type R1 : R1 [property Obj2] : Object |
+| Constructors.cs:143:25:143:26 | access to local variable o1 : Object | semmle.label | access to local variable o1 : Object |
+| Constructors.cs:143:29:143:30 | access to local variable o2 : Object | semmle.label | access to local variable o2 : Object |
+| Constructors.cs:144:14:144:15 | access to local variable r1 : R1 [property Obj1] : Object | semmle.label | access to local variable r1 : R1 [property Obj1] : Object |
+| Constructors.cs:144:14:144:20 | access to property Obj1 | semmle.label | access to property Obj1 |
+| Constructors.cs:145:14:145:15 | access to local variable r1 : R1 [property Obj2] : Object | semmle.label | access to local variable r1 : R1 [property Obj2] : Object |
+| Constructors.cs:145:14:145:20 | access to property Obj2 | semmle.label | access to property Obj2 |
 subpaths
 | Constructors.cs:64:37:64:37 | access to parameter o : Object | Constructors.cs:57:54:57:55 | o2 : Object | Constructors.cs:59:13:59:19 | SSA def(o1) : Object | Constructors.cs:64:27:64:34 | SSA def(o22param) : Object |
 | Constructors.cs:71:25:71:25 | access to local variable o : Object | Constructors.cs:41:26:41:26 | o : Object | Constructors.cs:41:32:41:34 | [post] this access : C1 [field Obj] : Object | Constructors.cs:71:18:71:26 | object creation of type C1 : C1 [field Obj] : Object |
@@ -191,3 +209,5 @@ subpaths
 | Constructors.cs:113:14:113:21 | access to property Obj31 | Constructors.cs:111:19:111:35 | call to method Source<Object> : Object | Constructors.cs:113:14:113:21 | access to property Obj31 | $@ | Constructors.cs:111:19:111:35 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | Constructors.cs:133:14:133:20 | access to property Obj1 | Constructors.cs:130:18:130:34 | call to method Source<Object> : Object | Constructors.cs:133:14:133:20 | access to property Obj1 | $@ | Constructors.cs:130:18:130:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | Constructors.cs:134:14:134:20 | access to property Obj2 | Constructors.cs:131:18:131:34 | call to method Source<Object> : Object | Constructors.cs:134:14:134:20 | access to property Obj2 | $@ | Constructors.cs:131:18:131:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| Constructors.cs:144:14:144:20 | access to property Obj1 | Constructors.cs:141:18:141:34 | call to method Source<Object> : Object | Constructors.cs:144:14:144:20 | access to property Obj1 | $@ | Constructors.cs:141:18:141:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| Constructors.cs:145:14:145:20 | access to property Obj2 | Constructors.cs:142:18:142:35 | call to method Source<Object> : Object | Constructors.cs:145:14:145:20 | access to property Obj2 | $@ | Constructors.cs:142:18:142:35 | call to method Source<Object> : Object | call to method Source<Object> : Object |

--- a/csharp/ql/test/library-tests/dataflow/constructors/ConstructorFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/constructors/ConstructorFlow.expected
@@ -1,6 +1,4 @@
 testFailures
-| Constructors.cs:144:24:144:42 | // ... | Missing result:hasValueFlow=9 |
-| Constructors.cs:145:24:145:43 | // ... | Missing result:hasValueFlow=10 |
 edges
 | Constructors.cs:5:24:5:25 | [post] this access : C_no_ctor [field s1] : Object | Constructors.cs:9:27:9:41 | object creation of type C_no_ctor : C_no_ctor [field s1] : Object | provenance |  |
 | Constructors.cs:5:29:5:45 | call to method Source<Object> : Object | Constructors.cs:5:24:5:25 | [post] this access : C_no_ctor [field s1] : Object | provenance |  |
@@ -80,6 +78,16 @@ edges
 | Constructors.cs:132:29:132:30 | access to local variable o2 : Object | Constructors.cs:132:18:132:31 | object creation of type C4 : C4 [property Obj2] : Object | provenance |  |
 | Constructors.cs:133:14:133:15 | access to local variable c4 : C4 [property Obj1] : Object | Constructors.cs:133:14:133:20 | access to property Obj1 | provenance |  |
 | Constructors.cs:134:14:134:15 | access to local variable c4 : C4 [property Obj2] : Object | Constructors.cs:134:14:134:20 | access to property Obj2 | provenance |  |
+| Constructors.cs:141:18:141:34 | call to method Source<Object> : Object | Constructors.cs:143:25:143:26 | access to local variable o1 : Object | provenance |  |
+| Constructors.cs:142:18:142:35 | call to method Source<Object> : Object | Constructors.cs:143:29:143:30 | access to local variable o2 : Object | provenance |  |
+| Constructors.cs:143:18:143:31 | object creation of type R1 : R1 [property Obj1] : Object | Constructors.cs:144:14:144:15 | access to local variable r1 : R1 [property Obj1] : Object | provenance |  |
+| Constructors.cs:143:18:143:31 | object creation of type R1 : R1 [property Obj2] : Object | Constructors.cs:145:14:145:15 | access to local variable r1 : R1 [property Obj2] : Object | provenance |  |
+| Constructors.cs:143:25:143:26 | access to local variable o1 : Object | Constructors.cs:137:29:137:32 | Obj1 : Object | provenance |  |
+| Constructors.cs:143:25:143:26 | access to local variable o1 : Object | Constructors.cs:143:18:143:31 | object creation of type R1 : R1 [property Obj1] : Object | provenance |  |
+| Constructors.cs:143:29:143:30 | access to local variable o2 : Object | Constructors.cs:137:42:137:45 | Obj2 : Object | provenance |  |
+| Constructors.cs:143:29:143:30 | access to local variable o2 : Object | Constructors.cs:143:18:143:31 | object creation of type R1 : R1 [property Obj2] : Object | provenance |  |
+| Constructors.cs:144:14:144:15 | access to local variable r1 : R1 [property Obj1] : Object | Constructors.cs:144:14:144:20 | access to property Obj1 | provenance |  |
+| Constructors.cs:145:14:145:15 | access to local variable r1 : R1 [property Obj2] : Object | Constructors.cs:145:14:145:20 | access to property Obj2 | provenance |  |
 nodes
 | Constructors.cs:5:24:5:25 | [post] this access : C_no_ctor [field s1] : Object | semmle.label | [post] this access : C_no_ctor [field s1] : Object |
 | Constructors.cs:5:29:5:45 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
@@ -166,6 +174,18 @@ nodes
 | Constructors.cs:133:14:133:20 | access to property Obj1 | semmle.label | access to property Obj1 |
 | Constructors.cs:134:14:134:15 | access to local variable c4 : C4 [property Obj2] : Object | semmle.label | access to local variable c4 : C4 [property Obj2] : Object |
 | Constructors.cs:134:14:134:20 | access to property Obj2 | semmle.label | access to property Obj2 |
+| Constructors.cs:137:29:137:32 | Obj1 : Object | semmle.label | Obj1 : Object |
+| Constructors.cs:137:42:137:45 | Obj2 : Object | semmle.label | Obj2 : Object |
+| Constructors.cs:141:18:141:34 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| Constructors.cs:142:18:142:35 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| Constructors.cs:143:18:143:31 | object creation of type R1 : R1 [property Obj1] : Object | semmle.label | object creation of type R1 : R1 [property Obj1] : Object |
+| Constructors.cs:143:18:143:31 | object creation of type R1 : R1 [property Obj2] : Object | semmle.label | object creation of type R1 : R1 [property Obj2] : Object |
+| Constructors.cs:143:25:143:26 | access to local variable o1 : Object | semmle.label | access to local variable o1 : Object |
+| Constructors.cs:143:29:143:30 | access to local variable o2 : Object | semmle.label | access to local variable o2 : Object |
+| Constructors.cs:144:14:144:15 | access to local variable r1 : R1 [property Obj1] : Object | semmle.label | access to local variable r1 : R1 [property Obj1] : Object |
+| Constructors.cs:144:14:144:20 | access to property Obj1 | semmle.label | access to property Obj1 |
+| Constructors.cs:145:14:145:15 | access to local variable r1 : R1 [property Obj2] : Object | semmle.label | access to local variable r1 : R1 [property Obj2] : Object |
+| Constructors.cs:145:14:145:20 | access to property Obj2 | semmle.label | access to property Obj2 |
 subpaths
 | Constructors.cs:64:37:64:37 | access to parameter o : Object | Constructors.cs:57:54:57:55 | o2 : Object | Constructors.cs:59:13:59:19 | SSA def(o1) : Object | Constructors.cs:64:27:64:34 | SSA def(o22param) : Object |
 | Constructors.cs:71:25:71:25 | access to local variable o : Object | Constructors.cs:41:26:41:26 | o : Object | Constructors.cs:41:32:41:34 | [post] this access : C1 [field Obj] : Object | Constructors.cs:71:18:71:26 | object creation of type C1 : C1 [field Obj] : Object |
@@ -181,6 +201,8 @@ subpaths
 | Constructors.cs:113:14:113:15 | access to local variable c3 : C3 [parameter o31param] : Object | Constructors.cs:106:32:106:39 | this : C3 [parameter o31param] : Object | Constructors.cs:106:32:106:39 | access to parameter o31param : Object | Constructors.cs:113:14:113:21 | access to property Obj31 |
 | Constructors.cs:132:25:132:26 | access to local variable o1 : Object | Constructors.cs:121:26:121:28 | oc1 : Object | Constructors.cs:123:13:123:16 | [post] this access : C4 [property Obj1] : Object | Constructors.cs:132:18:132:31 | object creation of type C4 : C4 [property Obj1] : Object |
 | Constructors.cs:132:29:132:30 | access to local variable o2 : Object | Constructors.cs:121:38:121:40 | oc2 : Object | Constructors.cs:124:13:124:16 | [post] this access : C4 [property Obj2] : Object | Constructors.cs:132:18:132:31 | object creation of type C4 : C4 [property Obj2] : Object |
+| Constructors.cs:143:25:143:26 | access to local variable o1 : Object | Constructors.cs:137:29:137:32 | Obj1 : Object | Constructors.cs:137:29:137:32 | Obj1 : Object | Constructors.cs:143:18:143:31 | object creation of type R1 : R1 [property Obj1] : Object |
+| Constructors.cs:143:29:143:30 | access to local variable o2 : Object | Constructors.cs:137:42:137:45 | Obj2 : Object | Constructors.cs:137:42:137:45 | Obj2 : Object | Constructors.cs:143:18:143:31 | object creation of type R1 : R1 [property Obj2] : Object |
 #select
 | Constructors.cs:15:18:15:19 | access to field s1 | Constructors.cs:5:29:5:45 | call to method Source<Object> : Object | Constructors.cs:15:18:15:19 | access to field s1 | $@ | Constructors.cs:5:29:5:45 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | Constructors.cs:33:18:33:19 | access to field s1 | Constructors.cs:21:29:21:45 | call to method Source<Object> : Object | Constructors.cs:33:18:33:19 | access to field s1 | $@ | Constructors.cs:21:29:21:45 | call to method Source<Object> : Object | call to method Source<Object> : Object |
@@ -193,3 +215,5 @@ subpaths
 | Constructors.cs:113:14:113:21 | access to property Obj31 | Constructors.cs:111:19:111:35 | call to method Source<Object> : Object | Constructors.cs:113:14:113:21 | access to property Obj31 | $@ | Constructors.cs:111:19:111:35 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | Constructors.cs:133:14:133:20 | access to property Obj1 | Constructors.cs:130:18:130:34 | call to method Source<Object> : Object | Constructors.cs:133:14:133:20 | access to property Obj1 | $@ | Constructors.cs:130:18:130:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | Constructors.cs:134:14:134:20 | access to property Obj2 | Constructors.cs:131:18:131:34 | call to method Source<Object> : Object | Constructors.cs:134:14:134:20 | access to property Obj2 | $@ | Constructors.cs:131:18:131:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| Constructors.cs:144:14:144:20 | access to property Obj1 | Constructors.cs:141:18:141:34 | call to method Source<Object> : Object | Constructors.cs:144:14:144:20 | access to property Obj1 | $@ | Constructors.cs:141:18:141:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| Constructors.cs:145:14:145:20 | access to property Obj2 | Constructors.cs:142:18:142:35 | call to method Source<Object> : Object | Constructors.cs:145:14:145:20 | access to property Obj2 | $@ | Constructors.cs:142:18:142:35 | call to method Source<Object> : Object | call to method Source<Object> : Object |

--- a/csharp/ql/test/library-tests/dataflow/constructors/ConstructorFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/constructors/ConstructorFlow.expected
@@ -1,4 +1,6 @@
 testFailures
+| Constructors.cs:144:24:144:42 | // ... | Missing result:hasValueFlow=9 |
+| Constructors.cs:145:24:145:43 | // ... | Missing result:hasValueFlow=10 |
 edges
 | Constructors.cs:5:24:5:25 | [post] this access : C_no_ctor [field s1] : Object | Constructors.cs:9:27:9:41 | object creation of type C_no_ctor : C_no_ctor [field s1] : Object | provenance |  |
 | Constructors.cs:5:29:5:45 | call to method Source<Object> : Object | Constructors.cs:5:24:5:25 | [post] this access : C_no_ctor [field s1] : Object | provenance |  |
@@ -78,14 +80,6 @@ edges
 | Constructors.cs:132:29:132:30 | access to local variable o2 : Object | Constructors.cs:132:18:132:31 | object creation of type C4 : C4 [property Obj2] : Object | provenance |  |
 | Constructors.cs:133:14:133:15 | access to local variable c4 : C4 [property Obj1] : Object | Constructors.cs:133:14:133:20 | access to property Obj1 | provenance |  |
 | Constructors.cs:134:14:134:15 | access to local variable c4 : C4 [property Obj2] : Object | Constructors.cs:134:14:134:20 | access to property Obj2 | provenance |  |
-| Constructors.cs:141:18:141:34 | call to method Source<Object> : Object | Constructors.cs:143:25:143:26 | access to local variable o1 : Object | provenance |  |
-| Constructors.cs:142:18:142:35 | call to method Source<Object> : Object | Constructors.cs:143:29:143:30 | access to local variable o2 : Object | provenance |  |
-| Constructors.cs:143:18:143:31 | object creation of type R1 : R1 [property Obj1] : Object | Constructors.cs:144:14:144:15 | access to local variable r1 : R1 [property Obj1] : Object | provenance |  |
-| Constructors.cs:143:18:143:31 | object creation of type R1 : R1 [property Obj2] : Object | Constructors.cs:145:14:145:15 | access to local variable r1 : R1 [property Obj2] : Object | provenance |  |
-| Constructors.cs:143:25:143:26 | access to local variable o1 : Object | Constructors.cs:143:18:143:31 | object creation of type R1 : R1 [property Obj1] : Object | provenance |  |
-| Constructors.cs:143:29:143:30 | access to local variable o2 : Object | Constructors.cs:143:18:143:31 | object creation of type R1 : R1 [property Obj2] : Object | provenance |  |
-| Constructors.cs:144:14:144:15 | access to local variable r1 : R1 [property Obj1] : Object | Constructors.cs:144:14:144:20 | access to property Obj1 | provenance |  |
-| Constructors.cs:145:14:145:15 | access to local variable r1 : R1 [property Obj2] : Object | Constructors.cs:145:14:145:20 | access to property Obj2 | provenance |  |
 nodes
 | Constructors.cs:5:24:5:25 | [post] this access : C_no_ctor [field s1] : Object | semmle.label | [post] this access : C_no_ctor [field s1] : Object |
 | Constructors.cs:5:29:5:45 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
@@ -172,16 +166,6 @@ nodes
 | Constructors.cs:133:14:133:20 | access to property Obj1 | semmle.label | access to property Obj1 |
 | Constructors.cs:134:14:134:15 | access to local variable c4 : C4 [property Obj2] : Object | semmle.label | access to local variable c4 : C4 [property Obj2] : Object |
 | Constructors.cs:134:14:134:20 | access to property Obj2 | semmle.label | access to property Obj2 |
-| Constructors.cs:141:18:141:34 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| Constructors.cs:142:18:142:35 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| Constructors.cs:143:18:143:31 | object creation of type R1 : R1 [property Obj1] : Object | semmle.label | object creation of type R1 : R1 [property Obj1] : Object |
-| Constructors.cs:143:18:143:31 | object creation of type R1 : R1 [property Obj2] : Object | semmle.label | object creation of type R1 : R1 [property Obj2] : Object |
-| Constructors.cs:143:25:143:26 | access to local variable o1 : Object | semmle.label | access to local variable o1 : Object |
-| Constructors.cs:143:29:143:30 | access to local variable o2 : Object | semmle.label | access to local variable o2 : Object |
-| Constructors.cs:144:14:144:15 | access to local variable r1 : R1 [property Obj1] : Object | semmle.label | access to local variable r1 : R1 [property Obj1] : Object |
-| Constructors.cs:144:14:144:20 | access to property Obj1 | semmle.label | access to property Obj1 |
-| Constructors.cs:145:14:145:15 | access to local variable r1 : R1 [property Obj2] : Object | semmle.label | access to local variable r1 : R1 [property Obj2] : Object |
-| Constructors.cs:145:14:145:20 | access to property Obj2 | semmle.label | access to property Obj2 |
 subpaths
 | Constructors.cs:64:37:64:37 | access to parameter o : Object | Constructors.cs:57:54:57:55 | o2 : Object | Constructors.cs:59:13:59:19 | SSA def(o1) : Object | Constructors.cs:64:27:64:34 | SSA def(o22param) : Object |
 | Constructors.cs:71:25:71:25 | access to local variable o : Object | Constructors.cs:41:26:41:26 | o : Object | Constructors.cs:41:32:41:34 | [post] this access : C1 [field Obj] : Object | Constructors.cs:71:18:71:26 | object creation of type C1 : C1 [field Obj] : Object |
@@ -209,5 +193,3 @@ subpaths
 | Constructors.cs:113:14:113:21 | access to property Obj31 | Constructors.cs:111:19:111:35 | call to method Source<Object> : Object | Constructors.cs:113:14:113:21 | access to property Obj31 | $@ | Constructors.cs:111:19:111:35 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | Constructors.cs:133:14:133:20 | access to property Obj1 | Constructors.cs:130:18:130:34 | call to method Source<Object> : Object | Constructors.cs:133:14:133:20 | access to property Obj1 | $@ | Constructors.cs:130:18:130:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | Constructors.cs:134:14:134:20 | access to property Obj2 | Constructors.cs:131:18:131:34 | call to method Source<Object> : Object | Constructors.cs:134:14:134:20 | access to property Obj2 | $@ | Constructors.cs:131:18:131:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
-| Constructors.cs:144:14:144:20 | access to property Obj1 | Constructors.cs:141:18:141:34 | call to method Source<Object> : Object | Constructors.cs:144:14:144:20 | access to property Obj1 | $@ | Constructors.cs:141:18:141:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
-| Constructors.cs:145:14:145:20 | access to property Obj2 | Constructors.cs:142:18:142:35 | call to method Source<Object> : Object | Constructors.cs:145:14:145:20 | access to property Obj2 | $@ | Constructors.cs:142:18:142:35 | call to method Source<Object> : Object | call to method Source<Object> : Object |

--- a/csharp/ql/test/library-tests/dataflow/constructors/Constructors.cs
+++ b/csharp/ql/test/library-tests/dataflow/constructors/Constructors.cs
@@ -134,6 +134,17 @@ public class Constructors
         Sink(c4.Obj2); // $ hasValueFlow=8
     }
 
+    public record R1(object Obj1, object Obj2);
+
+    public void M7()
+    {
+        var o1 = Source<object>(9);
+        var o2 = Source<object>(10);
+        var r1 = new R1(o1, o2);
+        Sink(r1.Obj1); // $ hasValueFlow=9
+        Sink(r1.Obj2); // $ hasValueFlow=10
+    }
+
     public static void Sink(object o) { }
 
     public static T Source<T>(object source) => throw null;

--- a/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
@@ -814,6 +814,8 @@ edges
 | J.cs:22:18:22:41 | object creation of type RecordClass : RecordClass [property Prop1] : Object | J.cs:27:14:27:15 | access to local variable r2 : RecordClass [property Prop1] : Object | provenance |  |
 | J.cs:22:18:22:41 | object creation of type RecordClass : RecordClass [property Prop1] : Object | J.cs:31:14:31:15 | access to local variable r3 : RecordClass [property Prop1] : Object | provenance |  |
 | J.cs:22:18:22:41 | object creation of type RecordClass : RecordClass [property Prop1] : Object | J.cs:31:14:31:15 | access to local variable r3 : RecordClass [property Prop1] : Object | provenance |  |
+| J.cs:22:34:22:34 | access to local variable o : Object | J.cs:6:40:6:44 | Prop1 : Object | provenance |  |
+| J.cs:22:34:22:34 | access to local variable o : Object | J.cs:6:40:6:44 | Prop1 : Object | provenance |  |
 | J.cs:22:34:22:34 | access to local variable o : Object | J.cs:22:18:22:41 | object creation of type RecordClass : RecordClass [property Prop1] : Object | provenance |  |
 | J.cs:22:34:22:34 | access to local variable o : Object | J.cs:22:18:22:41 | object creation of type RecordClass : RecordClass [property Prop1] : Object | provenance |  |
 | J.cs:23:14:23:15 | access to local variable r1 : RecordClass [property Prop1] : Object | J.cs:23:14:23:21 | access to property Prop1 | provenance |  |
@@ -836,6 +838,8 @@ edges
 | J.cs:42:18:42:42 | object creation of type RecordStruct : RecordStruct [property Prop1] : Object | J.cs:47:14:47:15 | access to local variable r2 : RecordStruct [property Prop1] : Object | provenance |  |
 | J.cs:42:18:42:42 | object creation of type RecordStruct : RecordStruct [property Prop1] : Object | J.cs:51:14:51:15 | access to local variable r3 : RecordStruct [property Prop1] : Object | provenance |  |
 | J.cs:42:18:42:42 | object creation of type RecordStruct : RecordStruct [property Prop1] : Object | J.cs:51:14:51:15 | access to local variable r3 : RecordStruct [property Prop1] : Object | provenance |  |
+| J.cs:42:35:42:35 | access to local variable o : Object | J.cs:8:42:8:46 | Prop1 : Object | provenance |  |
+| J.cs:42:35:42:35 | access to local variable o : Object | J.cs:8:42:8:46 | Prop1 : Object | provenance |  |
 | J.cs:42:35:42:35 | access to local variable o : Object | J.cs:42:18:42:42 | object creation of type RecordStruct : RecordStruct [property Prop1] : Object | provenance |  |
 | J.cs:42:35:42:35 | access to local variable o : Object | J.cs:42:18:42:42 | object creation of type RecordStruct : RecordStruct [property Prop1] : Object | provenance |  |
 | J.cs:43:14:43:15 | access to local variable r1 : RecordStruct [property Prop1] : Object | J.cs:43:14:43:21 | access to property Prop1 | provenance |  |
@@ -1781,6 +1785,10 @@ nodes
 | I.cs:40:14:40:14 | access to parameter i : I [field Field1] : Object | semmle.label | access to parameter i : I [field Field1] : Object |
 | I.cs:40:14:40:21 | access to field Field1 | semmle.label | access to field Field1 |
 | I.cs:40:14:40:21 | access to field Field1 | semmle.label | access to field Field1 |
+| J.cs:6:40:6:44 | Prop1 : Object | semmle.label | Prop1 : Object |
+| J.cs:6:40:6:44 | Prop1 : Object | semmle.label | Prop1 : Object |
+| J.cs:8:42:8:46 | Prop1 : Object | semmle.label | Prop1 : Object |
+| J.cs:8:42:8:46 | Prop1 : Object | semmle.label | Prop1 : Object |
 | J.cs:14:26:14:30 | field : Object | semmle.label | field : Object |
 | J.cs:14:26:14:30 | field : Object | semmle.label | field : Object |
 | J.cs:14:40:14:43 | prop : Object | semmle.label | prop : Object |
@@ -2022,6 +2030,10 @@ subpaths
 | H.cs:147:25:147:38 | call to method Source<A> : A | H.cs:138:27:138:27 | o : A | H.cs:142:16:142:34 | access to field FieldB : A | H.cs:147:17:147:39 | call to method Through : A |
 | H.cs:164:22:164:22 | access to local variable o : Object | H.cs:153:32:153:32 | o : Object | H.cs:157:9:157:9 | [post] access to parameter a : A [field FieldA, field FieldB] : Object | H.cs:164:19:164:19 | [post] access to local variable a : A [field FieldA, field FieldB] : Object |
 | H.cs:164:22:164:22 | access to local variable o : Object | H.cs:153:32:153:32 | o : Object | H.cs:157:9:157:9 | [post] access to parameter a : A [field FieldA, field FieldB] : Object | H.cs:164:19:164:19 | [post] access to local variable a : A [field FieldA, field FieldB] : Object |
+| J.cs:22:34:22:34 | access to local variable o : Object | J.cs:6:40:6:44 | Prop1 : Object | J.cs:6:40:6:44 | Prop1 : Object | J.cs:22:18:22:41 | object creation of type RecordClass : RecordClass [property Prop1] : Object |
+| J.cs:22:34:22:34 | access to local variable o : Object | J.cs:6:40:6:44 | Prop1 : Object | J.cs:6:40:6:44 | Prop1 : Object | J.cs:22:18:22:41 | object creation of type RecordClass : RecordClass [property Prop1] : Object |
+| J.cs:42:35:42:35 | access to local variable o : Object | J.cs:8:42:8:46 | Prop1 : Object | J.cs:8:42:8:46 | Prop1 : Object | J.cs:42:18:42:42 | object creation of type RecordStruct : RecordStruct [property Prop1] : Object |
+| J.cs:42:35:42:35 | access to local variable o : Object | J.cs:8:42:8:46 | Prop1 : Object | J.cs:8:42:8:46 | Prop1 : Object | J.cs:42:18:42:42 | object creation of type RecordStruct : RecordStruct [property Prop1] : Object |
 | J.cs:62:29:62:29 | access to local variable o : Object | J.cs:14:26:14:30 | field : Object | J.cs:14:50:14:54 | [post] this access : Struct [field Field] : Object | J.cs:62:18:62:36 | object creation of type Struct : Struct [field Field] : Object |
 | J.cs:62:29:62:29 | access to local variable o : Object | J.cs:14:26:14:30 | field : Object | J.cs:14:50:14:54 | [post] this access : Struct [field Field] : Object | J.cs:62:18:62:36 | object creation of type Struct : Struct [field Field] : Object |
 | J.cs:80:35:80:35 | access to local variable o : Object | J.cs:14:40:14:43 | prop : Object | J.cs:14:57:14:60 | [post] this access : Struct [property Prop] : Object | J.cs:80:18:80:36 | object creation of type Struct : Struct [property Prop] : Object |

--- a/csharp/ql/test/library-tests/dataflow/tuples/Tuples.expected
+++ b/csharp/ql/test/library-tests/dataflow/tuples/Tuples.expected
@@ -148,6 +148,8 @@ edges
 | Tuples.cs:99:17:99:33 | call to method Source<String> : String | Tuples.cs:100:24:100:24 | access to local variable o : String | provenance |  |
 | Tuples.cs:100:17:100:28 | object creation of type R1 : R1 [property i] : String | Tuples.cs:101:14:101:14 | access to local variable r : R1 [property i] : String | provenance |  |
 | Tuples.cs:100:17:100:28 | object creation of type R1 : R1 [property i] : String | Tuples.cs:101:14:101:14 | access to local variable r : R1 [property i] : String | provenance |  |
+| Tuples.cs:100:24:100:24 | access to local variable o : String | Tuples.cs:95:22:95:22 | i : String | provenance |  |
+| Tuples.cs:100:24:100:24 | access to local variable o : String | Tuples.cs:95:22:95:22 | i : String | provenance |  |
 | Tuples.cs:100:24:100:24 | access to local variable o : String | Tuples.cs:100:17:100:28 | object creation of type R1 : R1 [property i] : String | provenance |  |
 | Tuples.cs:100:24:100:24 | access to local variable o : String | Tuples.cs:100:17:100:28 | object creation of type R1 : R1 [property i] : String | provenance |  |
 | Tuples.cs:101:14:101:14 | access to local variable r : R1 [property i] : String | Tuples.cs:101:14:101:16 | access to property i | provenance |  |
@@ -359,6 +361,8 @@ nodes
 | Tuples.cs:89:18:89:18 | access to local variable p | semmle.label | access to local variable p |
 | Tuples.cs:90:18:90:18 | access to local variable r | semmle.label | access to local variable r |
 | Tuples.cs:90:18:90:18 | access to local variable r | semmle.label | access to local variable r |
+| Tuples.cs:95:22:95:22 | i : String | semmle.label | i : String |
+| Tuples.cs:95:22:95:22 | i : String | semmle.label | i : String |
 | Tuples.cs:99:17:99:33 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
 | Tuples.cs:99:17:99:33 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
 | Tuples.cs:100:17:100:28 | object creation of type R1 : R1 [property i] : String | semmle.label | object creation of type R1 : R1 [property i] : String |
@@ -412,6 +416,8 @@ nodes
 | Tuples.cs:134:14:134:15 | access to local variable y4 | semmle.label | access to local variable y4 |
 | Tuples.cs:134:14:134:15 | access to local variable y4 | semmle.label | access to local variable y4 |
 subpaths
+| Tuples.cs:100:24:100:24 | access to local variable o : String | Tuples.cs:95:22:95:22 | i : String | Tuples.cs:95:22:95:22 | i : String | Tuples.cs:100:17:100:28 | object creation of type R1 : R1 [property i] : String |
+| Tuples.cs:100:24:100:24 | access to local variable o : String | Tuples.cs:95:22:95:22 | i : String | Tuples.cs:95:22:95:22 | i : String | Tuples.cs:100:17:100:28 | object creation of type R1 : R1 [property i] : String |
 #select
 | Tuples.cs:12:14:12:14 | access to local variable a | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | Tuples.cs:12:14:12:14 | access to local variable a | $@ | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | Tuples.cs:12:14:12:14 | access to local variable a | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | Tuples.cs:12:14:12:14 | access to local variable a | $@ | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |


### PR DESCRIPTION
In this PR we re-factor the logic for data flow for record types from their (primary) constructor into the auto generated property.