### PR TITLE
JS: Improvements to endpoint naming

### DIFF
--- a/javascript/ql/lib/semmle/javascript/endpoints/EndpointNaming.qll
+++ b/javascript/ql/lib/semmle/javascript/endpoints/EndpointNaming.qll
@@ -47,14 +47,7 @@ private predicate relevantEdge(API::Node pred, API::Node succ) {
 private int distanceFromPackageExport(API::Node nd) =
   shortestDistances(isPackageExport/1, relevantEdge/2)(_, nd, result)
 
-private predicate isExported(API::Node node) {
-  isPackageExport(node)
-  or
-  exists(API::Node pred |
-    isExported(pred) and
-    relevantEdge(pred, node)
-  )
-}
+private predicate isExported(API::Node node) { exists(distanceFromPackageExport(node)) }
 
 /**
  * Holds if `node` is a default export that can be reinterpreted as a namespace export,

--- a/javascript/ql/lib/semmle/javascript/endpoints/EndpointNaming.qll
+++ b/javascript/ql/lib/semmle/javascript/endpoints/EndpointNaming.qll
@@ -121,7 +121,7 @@ private int distanceFromRoot(API::Node nd) {
   result = 100 + distanceFromFallbackName(nd)
 }
 
-/** Holds if `nd` can be given a name. */
+/** Holds if `node` can be given a name. */
 private predicate isRelevant(API::Node node) { exists(distanceFromRoot(node)) }
 
 /**

--- a/javascript/ql/lib/semmle/javascript/endpoints/EndpointNaming.qll
+++ b/javascript/ql/lib/semmle/javascript/endpoints/EndpointNaming.qll
@@ -39,7 +39,7 @@ private string join(string x, string y) {
 private predicate isPackageExport(API::Node node) { node = API::moduleExport(_) }
 
 private predicate relevantEdge(API::Node pred, API::Node succ) {
-  succ = pred.getAMember() and
+  succ = pred.getMember(_) and
   not isPrivateLike(succ)
 }
 

--- a/javascript/ql/lib/semmle/javascript/endpoints/EndpointNaming.qll
+++ b/javascript/ql/lib/semmle/javascript/endpoints/EndpointNaming.qll
@@ -185,9 +185,24 @@ private predicate sinkHasAlias(API::Node sink, string package, string name) {
   )
 }
 
+/** Gets a source node that can flow to `sink` without using a return step. */
+private DataFlow::SourceNode nodeReachingSink(API::Node sink, DataFlow::TypeBackTracker t) {
+  t.start() and
+  result = sink.asSink().getALocalSource()
+  or
+  exists(DataFlow::TypeBackTracker t2 |
+    result = nodeReachingSink(sink, t2).backtrack(t2, t) and
+    t.hasReturn() = false
+  )
+}
+
+/** Gets a source node that can flow to `sink` without using a return step. */
+DataFlow::SourceNode nodeReachingSink(API::Node sink) {
+  result = nodeReachingSink(sink, DataFlow::TypeBackTracker::end())
+}
+
 /** Gets a sink node reachable from `node`. */
-bindingset[node]
-private API::Node getASinkNode(DataFlow::SourceNode node) { result.getAValueReachingSink() = node }
+private API::Node getASinkNode(DataFlow::SourceNode node) { node = nodeReachingSink(result) }
 
 /**
  * Holds if `node` is a declaration in an externs file.

--- a/javascript/ql/test/library-tests/EndpointNaming/EndpointNaming.expected
+++ b/javascript/ql/test/library-tests/EndpointNaming/EndpointNaming.expected
@@ -1,13 +1,8 @@
 testFailures
-| pack11/index.ts:33:1:33:16 |  | Unexpected result: method=(pack11).C3.privateField |
-| pack11/index.ts:33:18:33:69 | // $ me ... ng.name | Missing result:method=(pack11).C3.publicField.really.long.name |
-| pack11/index.ts:41:23:41:24 |  | Unexpected result: alias=(pack11).C3.publicField.really.long.name==(pack11).C3.privateField |
-failures
 ambiguousPreferredPredecessor
 | pack2/lib.js:1:1:3:1 | def moduleImport("pack2").getMember("exports").getMember("lib").getMember("LibClass").getInstance() |
 | pack2/lib.js:8:22:8:34 | def moduleImport("pack2").getMember("exports").getMember("lib").getMember("LibClass").getMember("foo") |
 | pack2/main.js:1:1:3:1 | def moduleImport("pack2").getMember("exports").getMember("MainClass").getInstance() |
 ambiguousSinkName
-ambiguousClassObjectName
-ambiguousClassInstanceName
 ambiguousFunctionName
+failures

--- a/javascript/ql/test/library-tests/EndpointNaming/EndpointNaming.expected
+++ b/javascript/ql/test/library-tests/EndpointNaming/EndpointNaming.expected
@@ -1,4 +1,8 @@
 testFailures
+| pack11/index.ts:2:12:2:65 | // $ me ... .name.m | Missing result:method=(pack11).C1.publicField.really.long.name.m |
+| pack11/index.ts:33:1:33:16 |  | Unexpected result: method=(pack11).C3.privateField |
+| pack11/index.ts:33:18:33:69 | // $ me ... ng.name | Missing result:method=(pack11).C3.publicField.really.long.name |
+| pack11/index.ts:41:23:41:24 |  | Unexpected result: alias=(pack11).C3.publicField.really.long.name==(pack11).C3.privateField |
 ambiguousPreferredPredecessor
 | pack2/lib.js:8:22:8:34 | def moduleImport("pack2").getMember("exports").getMember("lib").getMember("LibClass").getMember("foo") |
 ambiguousSinkName

--- a/javascript/ql/test/library-tests/EndpointNaming/EndpointNaming.expected
+++ b/javascript/ql/test/library-tests/EndpointNaming/EndpointNaming.expected
@@ -2,7 +2,6 @@ testFailures
 | pack11/index.ts:33:1:33:16 |  | Unexpected result: method=(pack11).C3.privateField |
 | pack11/index.ts:33:18:33:69 | // $ me ... ng.name | Missing result:method=(pack11).C3.publicField.really.long.name |
 | pack11/index.ts:41:23:41:24 |  | Unexpected result: alias=(pack11).C3.publicField.really.long.name==(pack11).C3.privateField |
-| pack11/index.ts:49:12:49:53 | // $ me ... .name.m | Missing result:method=(pack11).C4.really.long.name.m |
 ambiguousPreferredPredecessor
 | pack2/lib.js:8:22:8:34 | def moduleImport("pack2").getMember("exports").getMember("lib").getMember("LibClass").getMember("foo") |
 ambiguousSinkName

--- a/javascript/ql/test/library-tests/EndpointNaming/EndpointNaming.expected
+++ b/javascript/ql/test/library-tests/EndpointNaming/EndpointNaming.expected
@@ -3,7 +3,9 @@ testFailures
 | pack11/index.ts:33:18:33:69 | // $ me ... ng.name | Missing result:method=(pack11).C3.publicField.really.long.name |
 | pack11/index.ts:41:23:41:24 |  | Unexpected result: alias=(pack11).C3.publicField.really.long.name==(pack11).C3.privateField |
 ambiguousPreferredPredecessor
+| pack2/lib.js:1:1:3:1 | def moduleImport("pack2").getMember("exports").getMember("lib").getMember("LibClass").getInstance() |
 | pack2/lib.js:8:22:8:34 | def moduleImport("pack2").getMember("exports").getMember("lib").getMember("LibClass").getMember("foo") |
+| pack2/main.js:1:1:3:1 | def moduleImport("pack2").getMember("exports").getMember("MainClass").getInstance() |
 ambiguousSinkName
 ambiguousClassObjectName
 failures

--- a/javascript/ql/test/library-tests/EndpointNaming/EndpointNaming.expected
+++ b/javascript/ql/test/library-tests/EndpointNaming/EndpointNaming.expected
@@ -2,6 +2,7 @@ testFailures
 | pack11/index.ts:33:1:33:16 |  | Unexpected result: method=(pack11).C3.privateField |
 | pack11/index.ts:33:18:33:69 | // $ me ... ng.name | Missing result:method=(pack11).C3.publicField.really.long.name |
 | pack11/index.ts:41:23:41:24 |  | Unexpected result: alias=(pack11).C3.publicField.really.long.name==(pack11).C3.privateField |
+| pack11/index.ts:49:12:49:53 | // $ me ... .name.m | Missing result:method=(pack11).C4.really.long.name.m |
 ambiguousPreferredPredecessor
 | pack2/lib.js:8:22:8:34 | def moduleImport("pack2").getMember("exports").getMember("lib").getMember("LibClass").getMember("foo") |
 ambiguousSinkName

--- a/javascript/ql/test/library-tests/EndpointNaming/EndpointNaming.expected
+++ b/javascript/ql/test/library-tests/EndpointNaming/EndpointNaming.expected
@@ -1,5 +1,4 @@
 testFailures
-| pack11/index.ts:2:12:2:65 | // $ me ... .name.m | Missing result:method=(pack11).C1.publicField.really.long.name.m |
 | pack11/index.ts:33:1:33:16 |  | Unexpected result: method=(pack11).C3.privateField |
 | pack11/index.ts:33:18:33:69 | // $ me ... ng.name | Missing result:method=(pack11).C3.publicField.really.long.name |
 | pack11/index.ts:41:23:41:24 |  | Unexpected result: alias=(pack11).C3.publicField.really.long.name==(pack11).C3.privateField |
@@ -7,6 +6,6 @@ ambiguousPreferredPredecessor
 | pack2/lib.js:8:22:8:34 | def moduleImport("pack2").getMember("exports").getMember("lib").getMember("LibClass").getMember("foo") |
 ambiguousSinkName
 ambiguousClassObjectName
-ambiguousClassInstanceName
 failures
+ambiguousClassInstanceName
 ambiguousFunctionName

--- a/javascript/ql/test/library-tests/EndpointNaming/EndpointNaming.expected
+++ b/javascript/ql/test/library-tests/EndpointNaming/EndpointNaming.expected
@@ -2,12 +2,6 @@ testFailures
 | pack11/index.ts:33:1:33:16 |  | Unexpected result: method=(pack11).C3.privateField |
 | pack11/index.ts:33:18:33:69 | // $ me ... ng.name | Missing result:method=(pack11).C3.publicField.really.long.name |
 | pack11/index.ts:41:23:41:24 |  | Unexpected result: alias=(pack11).C3.publicField.really.long.name==(pack11).C3.privateField |
-| pack12/index.js:2:12:2:21 |  | Unexpected result: method=(pack12).f1 |
-| pack12/index.js:6:28:6:50 | // $ me ... k12).f1 | Missing result:method=(pack12).f1 |
-| pack12/index.js:7:19:7:25 |  | Unexpected result: alias=(pack12).f2==(pack12).f1 |
-| pack12/index.js:7:28:7:50 | // $ me ... k12).f2 | Missing result:method=(pack12).f2 |
-| pack12/index.js:10:19:10:25 |  | Unexpected result: alias=(pack12).g1==(pack12).f1 |
-| pack12/index.js:10:28:10:50 | // $ me ... k12).g1 | Missing result:method=(pack12).g1 |
 failures
 ambiguousPreferredPredecessor
 | pack2/lib.js:1:1:3:1 | def moduleImport("pack2").getMember("exports").getMember("lib").getMember("LibClass").getInstance() |

--- a/javascript/ql/test/library-tests/EndpointNaming/EndpointNaming.expected
+++ b/javascript/ql/test/library-tests/EndpointNaming/EndpointNaming.expected
@@ -8,6 +8,7 @@ testFailures
 | pack12/index.js:7:28:7:50 | // $ me ... k12).f2 | Missing result:method=(pack12).f2 |
 | pack12/index.js:10:19:10:25 |  | Unexpected result: alias=(pack12).g1==(pack12).f1 |
 | pack12/index.js:10:28:10:50 | // $ me ... k12).g1 | Missing result:method=(pack12).g1 |
+failures
 ambiguousPreferredPredecessor
 | pack2/lib.js:1:1:3:1 | def moduleImport("pack2").getMember("exports").getMember("lib").getMember("LibClass").getInstance() |
 | pack2/lib.js:8:22:8:34 | def moduleImport("pack2").getMember("exports").getMember("lib").getMember("LibClass").getMember("foo") |
@@ -16,4 +17,3 @@ ambiguousSinkName
 ambiguousClassObjectName
 ambiguousClassInstanceName
 ambiguousFunctionName
-failures

--- a/javascript/ql/test/library-tests/EndpointNaming/EndpointNaming.expected
+++ b/javascript/ql/test/library-tests/EndpointNaming/EndpointNaming.expected
@@ -1,7 +1,8 @@
 testFailures
 ambiguousPreferredPredecessor
+| pack2/lib.js:8:22:8:34 | def moduleImport("pack2").getMember("exports").getMember("lib").getMember("LibClass").getMember("foo") |
 ambiguousSinkName
 ambiguousClassObjectName
 ambiguousClassInstanceName
-ambiguousFunctionName
 failures
+ambiguousFunctionName

--- a/javascript/ql/test/library-tests/EndpointNaming/EndpointNaming.expected
+++ b/javascript/ql/test/library-tests/EndpointNaming/EndpointNaming.expected
@@ -2,12 +2,18 @@ testFailures
 | pack11/index.ts:33:1:33:16 |  | Unexpected result: method=(pack11).C3.privateField |
 | pack11/index.ts:33:18:33:69 | // $ me ... ng.name | Missing result:method=(pack11).C3.publicField.really.long.name |
 | pack11/index.ts:41:23:41:24 |  | Unexpected result: alias=(pack11).C3.publicField.really.long.name==(pack11).C3.privateField |
+| pack12/index.js:2:12:2:21 |  | Unexpected result: method=(pack12).f1 |
+| pack12/index.js:6:28:6:50 | // $ me ... k12).f1 | Missing result:method=(pack12).f1 |
+| pack12/index.js:7:19:7:25 |  | Unexpected result: alias=(pack12).f2==(pack12).f1 |
+| pack12/index.js:7:28:7:50 | // $ me ... k12).f2 | Missing result:method=(pack12).f2 |
+| pack12/index.js:10:19:10:25 |  | Unexpected result: alias=(pack12).g1==(pack12).f1 |
+| pack12/index.js:10:28:10:50 | // $ me ... k12).g1 | Missing result:method=(pack12).g1 |
 ambiguousPreferredPredecessor
 | pack2/lib.js:1:1:3:1 | def moduleImport("pack2").getMember("exports").getMember("lib").getMember("LibClass").getInstance() |
 | pack2/lib.js:8:22:8:34 | def moduleImport("pack2").getMember("exports").getMember("lib").getMember("LibClass").getMember("foo") |
 | pack2/main.js:1:1:3:1 | def moduleImport("pack2").getMember("exports").getMember("MainClass").getInstance() |
 ambiguousSinkName
 ambiguousClassObjectName
-failures
 ambiguousClassInstanceName
 ambiguousFunctionName
+failures

--- a/javascript/ql/test/library-tests/EndpointNaming/EndpointNaming.ql
+++ b/javascript/ql/test/library-tests/EndpointNaming/EndpointNaming.ql
@@ -35,7 +35,7 @@ module TestConfig implements TestSig {
       API::Node aliasDef, string primaryPackage, string primaryName, string aliasPackage,
       string aliasName
     |
-      EndpointNaming::aliasDefinition(primaryPackage, primaryName, aliasPackage, aliasName, aliasDef) and
+      EndpointNaming::aliasDefinition(aliasPackage, aliasName, primaryPackage, primaryName, aliasDef) and
       value =
         EndpointNaming::renderName(aliasPackage, aliasName) + "==" +
           EndpointNaming::renderName(primaryPackage, primaryName) and

--- a/javascript/ql/test/library-tests/EndpointNaming/EndpointNaming.ql
+++ b/javascript/ql/test/library-tests/EndpointNaming/EndpointNaming.ql
@@ -10,28 +10,16 @@ private predicate isIgnored(DataFlow::FunctionNode function) {
 }
 
 module TestConfig implements TestSig {
-  string getARelevantTag() { result = ["instance", "class", "method", "alias"] }
+  string getARelevantTag() { result = ["name", "alias"] }
 
   predicate hasActualResult(Location location, string element, string tag, string value) {
-    exists(string package, string name |
-      element = "" and
+    element = "" and
+    tag = "name" and
+    exists(DataFlow::SourceNode function, string package, string name |
+      EndpointNaming::functionHasPrimaryName(function, package, name) and
+      not isIgnored(function) and
+      location = function.getAstNode().getLocation() and
       value = EndpointNaming::renderName(package, name)
-    |
-      exists(DataFlow::ClassNode cls | location = cls.getAstNode().getLocation() |
-        tag = "class" and
-        EndpointNaming::classObjectHasPrimaryName(cls, package, name)
-        or
-        tag = "instance" and
-        EndpointNaming::classInstanceHasPrimaryName(cls, package, name)
-      )
-      or
-      exists(DataFlow::SourceNode function |
-        not isIgnored(function) and
-        location = function.getAstNode().getLocation() and
-        tag = "method" and
-        EndpointNaming::functionHasPrimaryName(function, package, name) and
-        not function instanceof DataFlow::ClassNode // reported with class tag
-      )
     )
     or
     element = "" and

--- a/javascript/ql/test/library-tests/EndpointNaming/pack1/main.js
+++ b/javascript/ql/test/library-tests/EndpointNaming/pack1/main.js
@@ -4,7 +4,9 @@ class PrivateClass {}
 
 export const ExportedConst = class ExportedConstClass {} // $ name=(pack1).ExportedConst
 
-class ClassWithEscapingInstance {}
+class ClassWithEscapingInstance {
+    m() {} // $ name=(pack1).ClassWithEscapingInstance.prototype.m
+}
 
 export function getEscapingInstance() {
     return new ClassWithEscapingInstance();

--- a/javascript/ql/test/library-tests/EndpointNaming/pack1/main.js
+++ b/javascript/ql/test/library-tests/EndpointNaming/pack1/main.js
@@ -1,13 +1,13 @@
-export class PublicClass {} // $ class=(pack1).PublicClass instance=(pack1).PublicClass.prototype
+export class PublicClass {} // $ name=(pack1).PublicClass
 
 class PrivateClass {}
 
-export const ExportedConst = class ExportedConstClass {} // $ class=(pack1).ExportedConst instance=(pack1).ExportedConst.prototype
+export const ExportedConst = class ExportedConstClass {} // $ name=(pack1).ExportedConst
 
-class ClassWithEscapingInstance {} // $ instance=(pack1).ClassWithEscapingInstance.prototype
+class ClassWithEscapingInstance {}
 
 export function getEscapingInstance() {
     return new ClassWithEscapingInstance();
-} // $ method=(pack1).getEscapingInstance
+} // $ name=(pack1).getEscapingInstance
 
-export function publicFunction() {} // $ method=(pack1).publicFunction
+export function publicFunction() {} // $ name=(pack1).publicFunction

--- a/javascript/ql/test/library-tests/EndpointNaming/pack10/foo.js
+++ b/javascript/ql/test/library-tests/EndpointNaming/pack10/foo.js
@@ -1,1 +1,1 @@
-export default class FooClass {} // $ class=(pack10).Foo instance=(pack10).Foo.prototype
+export default class FooClass {} // $ name=(pack10).Foo

--- a/javascript/ql/test/library-tests/EndpointNaming/pack11/index.ts
+++ b/javascript/ql/test/library-tests/EndpointNaming/pack11/index.ts
@@ -1,0 +1,45 @@
+const f1 = {
+    m() {} // $ method=(pack11).C1.publicField.really.long.name.m
+};
+
+export class C1 {
+    private static privateField = f1;
+
+    public static publicField = {
+        really: {
+            long: {
+                name: f1
+            }
+        }
+    }
+} // $ class=(pack11).C1 instance=(pack11).C1.prototype
+
+const f2 = {
+    m() {} // $ method=(pack11).C2.publicField.really.long.name.m
+}
+
+export class C2 {
+    static #privateField = f2;
+
+    static publicField = {
+        really: {
+            long: {
+                name: f2
+            }
+        }
+    }
+} // $ class=(pack11).C2 instance=(pack11).C2.prototype
+
+function f3() {} // $ method=(pack11).C3.publicField.really.long.name
+
+export class C3 {
+    private static privateField = f3;
+
+    public static publicField = {
+        really: {
+            long: {
+                name: f3
+            }
+        }
+    }
+} // $ class=(pack11).C3 instance=(pack11).C3.prototype

--- a/javascript/ql/test/library-tests/EndpointNaming/pack11/index.ts
+++ b/javascript/ql/test/library-tests/EndpointNaming/pack11/index.ts
@@ -43,3 +43,17 @@ export class C3 {
         }
     }
 } // $ class=(pack11).C3 instance=(pack11).C3.prototype
+
+
+const f4 = {
+    m() {} // $ method=(pack11).C4.really.long.name.m
+};
+
+export const C4 = {
+    [Math.random()]: f4,
+    really: {
+        long: {
+            name: f4
+        }
+    }
+}

--- a/javascript/ql/test/library-tests/EndpointNaming/pack11/index.ts
+++ b/javascript/ql/test/library-tests/EndpointNaming/pack11/index.ts
@@ -1,5 +1,5 @@
 const f1 = {
-    m() {} // $ method=(pack11).C1.publicField.really.long.name.m
+    m() {} // $ name=(pack11).C1.publicField.really.long.name.m
 };
 
 export class C1 {
@@ -12,10 +12,10 @@ export class C1 {
             }
         }
     }
-} // $ class=(pack11).C1 instance=(pack11).C1.prototype
+} // $ name=(pack11).C1
 
 const f2 = {
-    m() {} // $ method=(pack11).C2.publicField.really.long.name.m
+    m() {} // $ name=(pack11).C2.publicField.really.long.name.m
 }
 
 export class C2 {
@@ -28,9 +28,9 @@ export class C2 {
             }
         }
     }
-} // $ class=(pack11).C2 instance=(pack11).C2.prototype
+} // $ name=(pack11).C2
 
-function f3() {} // $ method=(pack11).C3.publicField.really.long.name
+function f3() {} // $ name=(pack11).C3.publicField.really.long.name
 
 export class C3 {
     private static privateField = f3;
@@ -42,11 +42,11 @@ export class C3 {
             }
         }
     }
-} // $ class=(pack11).C3 instance=(pack11).C3.prototype
+} // $ name=(pack11).C3
 
 
 const f4 = {
-    m() {} // $ method=(pack11).C4.really.long.name.m
+    m() {} // $ name=(pack11).C4.really.long.name.m
 };
 
 export const C4 = {

--- a/javascript/ql/test/library-tests/EndpointNaming/pack11/package.json
+++ b/javascript/ql/test/library-tests/EndpointNaming/pack11/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "pack11",
+    "main": "./index.js"
+}

--- a/javascript/ql/test/library-tests/EndpointNaming/pack12/index.js
+++ b/javascript/ql/test/library-tests/EndpointNaming/pack12/index.js
@@ -1,0 +1,10 @@
+function wrap(fn) {
+    return x => fn(x);
+}
+
+function f() {}
+export const f1 = wrap(f); // $ method=(pack12).f1
+export const f2 = wrap(f); // $ method=(pack12).f2
+
+function g() {}
+export const g1 = wrap(g); // $ method=(pack12).g1

--- a/javascript/ql/test/library-tests/EndpointNaming/pack12/index.js
+++ b/javascript/ql/test/library-tests/EndpointNaming/pack12/index.js
@@ -3,8 +3,8 @@ function wrap(fn) {
 }
 
 function f() {}
-export const f1 = wrap(f); // $ method=(pack12).f1
-export const f2 = wrap(f); // $ method=(pack12).f2
+export const f1 = wrap(f); // $ name=(pack12).f1
+export const f2 = wrap(f); // $ name=(pack12).f2
 
 function g() {}
-export const g1 = wrap(g); // $ method=(pack12).g1
+export const g1 = wrap(g); // $ name=(pack12).g1

--- a/javascript/ql/test/library-tests/EndpointNaming/pack12/package.json
+++ b/javascript/ql/test/library-tests/EndpointNaming/pack12/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "pack12",
+    "main": "./index.js"
+}

--- a/javascript/ql/test/library-tests/EndpointNaming/pack2/lib.js
+++ b/javascript/ql/test/library-tests/EndpointNaming/pack2/lib.js
@@ -4,3 +4,5 @@ class AmbiguousClass {
 
 export default AmbiguousClass; // $ alias=(pack2).lib.default==(pack2).lib.LibClass
 export { AmbiguousClass as LibClass }
+
+AmbiguousClass.foo = function() {} // $ method=(pack2).lib.LibClass.foo alias=(pack2).lib.default.foo==(pack2).lib.LibClass.foo

--- a/javascript/ql/test/library-tests/EndpointNaming/pack2/lib.js
+++ b/javascript/ql/test/library-tests/EndpointNaming/pack2/lib.js
@@ -5,4 +5,4 @@ class AmbiguousClass {
 export default AmbiguousClass; // $ alias=(pack2).lib.default==(pack2).lib.LibClass
 export { AmbiguousClass as LibClass }
 
-AmbiguousClass.foo = function() {} // $ method=(pack2).lib.LibClass.foo alias=(pack2).lib.default.foo==(pack2).lib.LibClass.foo
+AmbiguousClass.foo = function() {} // $ method=(pack2).lib.LibClass.foo

--- a/javascript/ql/test/library-tests/EndpointNaming/pack2/lib.js
+++ b/javascript/ql/test/library-tests/EndpointNaming/pack2/lib.js
@@ -1,8 +1,8 @@
 class AmbiguousClass {
-    instanceMethod(foo) {} // $ method=(pack2).lib.LibClass.prototype.instanceMethod
-} // $ class=(pack2).lib.LibClass instance=(pack2).lib.LibClass.prototype
+    instanceMethod(foo) {} // $ name=(pack2).lib.LibClass.prototype.instanceMethod
+} // $ name=(pack2).lib.LibClass
 
 export default AmbiguousClass; // $ alias=(pack2).lib.default==(pack2).lib.LibClass
 export { AmbiguousClass as LibClass }
 
-AmbiguousClass.foo = function() {} // $ method=(pack2).lib.LibClass.foo
+AmbiguousClass.foo = function() {} // $ name=(pack2).lib.LibClass.foo

--- a/javascript/ql/test/library-tests/EndpointNaming/pack2/main.js
+++ b/javascript/ql/test/library-tests/EndpointNaming/pack2/main.js
@@ -1,6 +1,6 @@
 class AmbiguousClass {
-    instanceMethod() {} // $ method=(pack2).MainClass.prototype.instanceMethod
-} // $ class=(pack2).MainClass instance=(pack2).MainClass.prototype
+    instanceMethod() {} // $ name=(pack2).MainClass.prototype.instanceMethod
+} // $ name=(pack2).MainClass
 
 export default AmbiguousClass; // $ alias=(pack2).default==(pack2).MainClass
 export { AmbiguousClass as MainClass }

--- a/javascript/ql/test/library-tests/EndpointNaming/pack3/lib.js
+++ b/javascript/ql/test/library-tests/EndpointNaming/pack3/lib.js
@@ -1,1 +1,1 @@
-export default function(x,y,z) {} // $ method=(pack3).libFunction alias=(pack3).libFunction.default==(pack3).libFunction
+export default function(x,y,z) {} // $ name=(pack3).libFunction alias=(pack3).libFunction.default==(pack3).libFunction

--- a/javascript/ql/test/library-tests/EndpointNaming/pack3/main.js
+++ b/javascript/ql/test/library-tests/EndpointNaming/pack3/main.js
@@ -1,4 +1,4 @@
-function ambiguousFunction(x, y, z) {} // $ method=(pack3).namedFunction
+function ambiguousFunction(x, y, z) {} // $ name=(pack3).namedFunction
 
 export default ambiguousFunction; // $ alias=(pack3).default==(pack3).namedFunction
 export { ambiguousFunction as namedFunction };

--- a/javascript/ql/test/library-tests/EndpointNaming/pack4/index.js
+++ b/javascript/ql/test/library-tests/EndpointNaming/pack4/index.js
@@ -1,1 +1,1 @@
-export default class C {} // $ class=(pack4) instance=(pack4).prototype
+export default class C {} // $ name=(pack4)

--- a/javascript/ql/test/library-tests/EndpointNaming/pack5/src/index.js
+++ b/javascript/ql/test/library-tests/EndpointNaming/pack5/src/index.js
@@ -1,1 +1,1 @@
-export default class C {} // $ class=(pack5) instance=(pack5).prototype
+export default class C {} // $ name=(pack5)

--- a/javascript/ql/test/library-tests/EndpointNaming/pack6/index.js
+++ b/javascript/ql/test/library-tests/EndpointNaming/pack6/index.js
@@ -1,6 +1,6 @@
 class C {
-    instanceMethod() {} // $ method=(pack6).instanceMethod
+    instanceMethod() {} // $ name=(pack6).instanceMethod
     static staticMethod() {} // not accessible
-} // $ instance=(pack6)
+}
 
 export default new C();

--- a/javascript/ql/test/library-tests/EndpointNaming/pack7/index.js
+++ b/javascript/ql/test/library-tests/EndpointNaming/pack7/index.js
@@ -1,6 +1,6 @@
-export class D {} // $ class=(pack7).D instance=(pack7).D.prototype
+export class D {} // $ name=(pack7).D
 
 // In this case we are forced to include ".default" to avoid ambiguity with class D above.
 export default {
-    D: class {} // $ class=(pack7).default.D instance=(pack7).default.D.prototype
+    D: class {} // $ name=(pack7).default.D
 };

--- a/javascript/ql/test/library-tests/EndpointNaming/pack8/foo.js
+++ b/javascript/ql/test/library-tests/EndpointNaming/pack8/foo.js
@@ -1,4 +1,4 @@
-class Foo {} // $ class=(pack8).Foo instance=(pack8).Foo.prototype
+class Foo {} // $ name=(pack8).Foo
 
 module.exports = Foo;
 module.exports.default = Foo; // $ alias=(pack8).Foo.default==(pack8).Foo

--- a/javascript/ql/test/library-tests/EndpointNaming/pack8/index.js
+++ b/javascript/ql/test/library-tests/EndpointNaming/pack8/index.js
@@ -1,4 +1,4 @@
-class Main {} // $ class=(pack8) instance=(pack8).prototype
+class Main {} // $ name=(pack8)
 
 Main.Foo = require('./foo');
 

--- a/javascript/ql/test/library-tests/EndpointNaming/pack9/foo.js
+++ b/javascript/ql/test/library-tests/EndpointNaming/pack9/foo.js
@@ -1,1 +1,1 @@
-export class Foo {} // $ instance=(pack9/foo).Foo.prototype
+export class Foo {}

--- a/javascript/ql/test/library-tests/EndpointNaming/pack9/index.ts
+++ b/javascript/ql/test/library-tests/EndpointNaming/pack9/index.ts
@@ -6,4 +6,4 @@ import * as foo from "./foo";
 
 export function expose() {
     return new foo.Foo(); // expose an instance of Foo but not the class
-} // $ method=(pack9).expose
+} // $ name=(pack9).expose


### PR DESCRIPTION
This fixes some bugs in endpoint naming and makes it more robust at handling higher-order functions.

Previously it was a two-phase naming process: first we named every API node sink, and then named functions/classes that flow to those sinks. However, this made it difficult to work with functions generated by a higher-order function call, e.g. `exports.foo = makeFoo(baseFoo)` or functions generated by `new Function()`. Instead, the logic for naming functions/classes is now weaved into the first phase, mainly via the inclusion of instance edges.

Aliasing logic is now based on finding `SourceNodes` that flow to a multiple sinks, and has been separated from name generation. The old aliasing rule was basically "any candidate name that didn't get picked is an alias" but this was not sound; it got confused by things like `exports.foo = bar || baz` which could be reported as an alias for both `bar` and `baz`. Aliasing was harder than it seemed at first, and it's still not great, but I think I'll keep it like this for future iteration.

The interface has also been simplified a bit. We're not distinguishing between class-object names, and function names, they're just SourceNode names. Class-instance names also don't exist anymore, they are just a special case of sink names now.

[Updated example output](https://github.com/github/codeql-javascript-internal-tests/pull/1/commits/8442bc992e9f57b00a6742b1c31e24458a9c12cd#diff-294f71c37dd61f7245569f810495f46025f39bbdaaa10267c199e9ede652219a)


