### PR TITLE
Kotlin 2: Accept location changes in library-tests/interface-delegate

### DIFF
--- a/java/ql/test-kotlin2/library-tests/interface-delegate/test.expected
+++ b/java/ql/test-kotlin2/library-tests/interface-delegate/test.expected
@@ -1,8 +1,8 @@
 fields
 | intfDelegate.kt:7:18:9:1 | $$delegate_0 | intfDelegate.kt:7:26:9:1 | <Stmt> |
 #select
+| intfDelegate.kt:0:0:0:0 | f | intfDelegate.kt:7:1:10:1 | Concrete |
 | intfDelegate.kt:3:3:3:15 | f | intfDelegate.kt:1:1:5:1 | Intf |
 | intfDelegate.kt:7:1:10:1 | Concrete | intfDelegate.kt:7:1:10:1 | Concrete |
-| intfDelegate.kt:7:1:10:1 | f | intfDelegate.kt:7:1:10:1 | Concrete |
 | intfDelegate.kt:7:26:9:1 |  | intfDelegate.kt:7:26:9:1 | new Intf(...) { ... } |
 | intfDelegate.kt:8:3:8:28 | f | intfDelegate.kt:7:26:9:1 | new Intf(...) { ... } |


### PR DESCRIPTION
We lose a location here, but this makes the Kotlin 2 results more similar to the Kotlin 1 results.