### PR TITLE
Ruby: Consider additional arguments to certain `ActiveRecord` methods as sql injection sinks.

### DIFF
--- a/ruby/ql/lib/change-notes/2024-02-20-activerecord-sql-sink-arguments.md
+++ b/ruby/ql/lib/change-notes/2024-02-20-activerecord-sql-sink-arguments.md
@@ -1,0 +1,5 @@
+
+---
+category: minorAnalysis
+---
+* Additional arguments beyond the first of calls to the  `ActiveRecord` methods `select`, `reselect`, `order`, `reorder`, `joins`, `group`, and `pluck` are now recognized as sql injection sinks. 

--- a/ruby/ql/lib/codeql/ruby/frameworks/ActiveRecord.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActiveRecord.qll
@@ -176,10 +176,15 @@ private predicate sqlFragmentArgumentInner(DataFlow::CallNode call, DataFlow::No
     activeRecordQueryBuilderCall([
         "delete_all", "delete_by", "destroy_all", "destroy_by", "exists?", "find_by", "find_by!",
         "find_or_create_by", "find_or_create_by!", "find_or_initialize_by", "find_by_sql", "from",
-        "group", "having", "joins", "lock", "not", "order", "reorder", "pluck", "where", "rewhere",
-        "select", "reselect"
+        "having", "lock", "not", "where", "rewhere"
       ]) and
   sink = call.getArgument(0)
+  or
+  call =
+    activeRecordQueryBuilderCall([
+        "group", "joins", "order", "reorder", "pluck", "select", "reselect"
+      ]) and
+  sink = call.getArgument(_)
   or
   call = activeRecordQueryBuilderCall("calculate") and
   sink = call.getArgument(1)

--- a/ruby/ql/test/query-tests/security/cwe-089/ActiveRecordInjection.rb
+++ b/ruby/ql/test/query-tests/security/cwe-089/ActiveRecordInjection.rb
@@ -105,6 +105,14 @@ class FooController < ActionController::Base
 
     User.reorder(params[:direction])
 
+    User.select('a','b', params[:column])
+    User.reselect('a','b', params[:column])
+    User.order('a ASC', "b #{params[:direction]}")
+    User.reorder('a ASC', "b #{params[:direction]}")
+    User.group('a', params[:column])
+    User.pluck('a', params[:column])
+    User.joins(:a, params[:column])
+
     User.count_by_sql(params[:custom_sql_query])
   end
 end

--- a/ruby/ql/test/query-tests/security/cwe-089/SqlInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-089/SqlInjection.expected
@@ -34,35 +34,44 @@ edges
 | ActiveRecordInjection.rb:104:30:104:35 | call to params | ActiveRecordInjection.rb:104:30:104:51 | ...[...] | provenance |  |
 | ActiveRecordInjection.rb:104:30:104:51 | ...[...] | ActiveRecordInjection.rb:104:19:104:54 | "name = '#{...}'" | provenance |  |
 | ActiveRecordInjection.rb:106:18:106:23 | call to params | ActiveRecordInjection.rb:106:18:106:35 | ...[...] | provenance |  |
-| ActiveRecordInjection.rb:108:23:108:28 | call to params | ActiveRecordInjection.rb:108:23:108:47 | ...[...] | provenance |  |
-| ActiveRecordInjection.rb:114:5:114:6 | ps | ActiveRecordInjection.rb:115:11:115:12 | ps | provenance |  |
-| ActiveRecordInjection.rb:114:10:114:15 | call to params | ActiveRecordInjection.rb:114:5:114:6 | ps | provenance |  |
-| ActiveRecordInjection.rb:115:5:115:7 | uid | ActiveRecordInjection.rb:116:5:116:9 | uidEq | provenance |  |
-| ActiveRecordInjection.rb:115:11:115:12 | ps | ActiveRecordInjection.rb:115:11:115:17 | ...[...] | provenance |  |
-| ActiveRecordInjection.rb:115:11:115:17 | ...[...] | ActiveRecordInjection.rb:115:5:115:7 | uid | provenance |  |
-| ActiveRecordInjection.rb:116:5:116:9 | uidEq | ActiveRecordInjection.rb:120:20:120:32 | ... + ... | provenance |  |
-| ActiveRecordInjection.rb:116:5:116:9 | uidEq | ActiveRecordInjection.rb:120:28:120:32 | uidEq | provenance |  |
-| ActiveRecordInjection.rb:120:20:120:32 | ... + ... [element] | ActiveRecordInjection.rb:120:20:120:32 | ... + ... | provenance |  |
-| ActiveRecordInjection.rb:120:28:120:32 | uidEq | ActiveRecordInjection.rb:120:20:120:32 | ... + ... [element] | provenance |  |
-| ActiveRecordInjection.rb:153:21:153:26 | call to params | ActiveRecordInjection.rb:153:21:153:44 | ...[...] | provenance |  |
-| ActiveRecordInjection.rb:153:21:153:26 | call to params | ActiveRecordInjection.rb:153:21:153:44 | ...[...] | provenance |  |
-| ActiveRecordInjection.rb:153:21:153:44 | ...[...] | ActiveRecordInjection.rb:20:22:20:30 | condition | provenance |  |
-| ActiveRecordInjection.rb:167:59:167:64 | call to params | ActiveRecordInjection.rb:167:59:167:74 | ...[...] | provenance |  |
-| ActiveRecordInjection.rb:167:59:167:74 | ...[...] | ActiveRecordInjection.rb:167:27:167:76 | "this is an unsafe annotation:..." | provenance |  |
-| ActiveRecordInjection.rb:178:5:178:13 | my_params | ActiveRecordInjection.rb:179:47:179:55 | my_params | provenance |  |
-| ActiveRecordInjection.rb:178:17:178:32 | call to permitted_params | ActiveRecordInjection.rb:178:5:178:13 | my_params | provenance |  |
-| ActiveRecordInjection.rb:179:5:179:9 | query | ActiveRecordInjection.rb:180:37:180:41 | query | provenance |  |
-| ActiveRecordInjection.rb:179:47:179:55 | my_params | ActiveRecordInjection.rb:179:47:179:65 | ...[...] | provenance |  |
-| ActiveRecordInjection.rb:179:47:179:65 | ...[...] | ActiveRecordInjection.rb:179:5:179:9 | query | provenance |  |
-| ActiveRecordInjection.rb:185:5:185:10 | call to params | ActiveRecordInjection.rb:185:5:185:27 | call to require | provenance |  |
-| ActiveRecordInjection.rb:185:5:185:27 | call to require | ActiveRecordInjection.rb:185:5:185:59 | call to permit | provenance |  |
-| ActiveRecordInjection.rb:185:5:185:59 | call to permit | ActiveRecordInjection.rb:178:17:178:32 | call to permitted_params | provenance |  |
-| ActiveRecordInjection.rb:185:5:185:59 | call to permit | ActiveRecordInjection.rb:189:77:189:92 | call to permitted_params | provenance |  |
-| ActiveRecordInjection.rb:185:5:185:59 | call to permit | ActiveRecordInjection.rb:190:69:190:84 | call to permitted_params | provenance |  |
-| ActiveRecordInjection.rb:189:77:189:92 | call to permitted_params | ActiveRecordInjection.rb:189:77:189:102 | ...[...] | provenance |  |
-| ActiveRecordInjection.rb:189:77:189:102 | ...[...] | ActiveRecordInjection.rb:189:43:189:104 | "SELECT * FROM users WHERE id ..." | provenance |  |
-| ActiveRecordInjection.rb:190:69:190:84 | call to permitted_params | ActiveRecordInjection.rb:190:69:190:94 | ...[...] | provenance |  |
-| ActiveRecordInjection.rb:190:69:190:94 | ...[...] | ActiveRecordInjection.rb:190:35:190:96 | "SELECT * FROM users WHERE id ..." | provenance |  |
+| ActiveRecordInjection.rb:108:26:108:31 | call to params | ActiveRecordInjection.rb:108:26:108:40 | ...[...] | provenance |  |
+| ActiveRecordInjection.rb:109:28:109:33 | call to params | ActiveRecordInjection.rb:109:28:109:42 | ...[...] | provenance |  |
+| ActiveRecordInjection.rb:110:30:110:35 | call to params | ActiveRecordInjection.rb:110:30:110:47 | ...[...] | provenance |  |
+| ActiveRecordInjection.rb:110:30:110:47 | ...[...] | ActiveRecordInjection.rb:110:25:110:49 | "b #{...}" | provenance |  |
+| ActiveRecordInjection.rb:111:32:111:37 | call to params | ActiveRecordInjection.rb:111:32:111:49 | ...[...] | provenance |  |
+| ActiveRecordInjection.rb:111:32:111:49 | ...[...] | ActiveRecordInjection.rb:111:27:111:51 | "b #{...}" | provenance |  |
+| ActiveRecordInjection.rb:112:21:112:26 | call to params | ActiveRecordInjection.rb:112:21:112:35 | ...[...] | provenance |  |
+| ActiveRecordInjection.rb:113:21:113:26 | call to params | ActiveRecordInjection.rb:113:21:113:35 | ...[...] | provenance |  |
+| ActiveRecordInjection.rb:114:20:114:25 | call to params | ActiveRecordInjection.rb:114:20:114:34 | ...[...] | provenance |  |
+| ActiveRecordInjection.rb:116:23:116:28 | call to params | ActiveRecordInjection.rb:116:23:116:47 | ...[...] | provenance |  |
+| ActiveRecordInjection.rb:122:5:122:6 | ps | ActiveRecordInjection.rb:123:11:123:12 | ps | provenance |  |
+| ActiveRecordInjection.rb:122:10:122:15 | call to params | ActiveRecordInjection.rb:122:5:122:6 | ps | provenance |  |
+| ActiveRecordInjection.rb:123:5:123:7 | uid | ActiveRecordInjection.rb:124:5:124:9 | uidEq | provenance |  |
+| ActiveRecordInjection.rb:123:11:123:12 | ps | ActiveRecordInjection.rb:123:11:123:17 | ...[...] | provenance |  |
+| ActiveRecordInjection.rb:123:11:123:17 | ...[...] | ActiveRecordInjection.rb:123:5:123:7 | uid | provenance |  |
+| ActiveRecordInjection.rb:124:5:124:9 | uidEq | ActiveRecordInjection.rb:128:20:128:32 | ... + ... | provenance |  |
+| ActiveRecordInjection.rb:124:5:124:9 | uidEq | ActiveRecordInjection.rb:128:28:128:32 | uidEq | provenance |  |
+| ActiveRecordInjection.rb:128:20:128:32 | ... + ... [element] | ActiveRecordInjection.rb:128:20:128:32 | ... + ... | provenance |  |
+| ActiveRecordInjection.rb:128:28:128:32 | uidEq | ActiveRecordInjection.rb:128:20:128:32 | ... + ... [element] | provenance |  |
+| ActiveRecordInjection.rb:161:21:161:26 | call to params | ActiveRecordInjection.rb:161:21:161:44 | ...[...] | provenance |  |
+| ActiveRecordInjection.rb:161:21:161:26 | call to params | ActiveRecordInjection.rb:161:21:161:44 | ...[...] | provenance |  |
+| ActiveRecordInjection.rb:161:21:161:44 | ...[...] | ActiveRecordInjection.rb:20:22:20:30 | condition | provenance |  |
+| ActiveRecordInjection.rb:175:59:175:64 | call to params | ActiveRecordInjection.rb:175:59:175:74 | ...[...] | provenance |  |
+| ActiveRecordInjection.rb:175:59:175:74 | ...[...] | ActiveRecordInjection.rb:175:27:175:76 | "this is an unsafe annotation:..." | provenance |  |
+| ActiveRecordInjection.rb:186:5:186:13 | my_params | ActiveRecordInjection.rb:187:47:187:55 | my_params | provenance |  |
+| ActiveRecordInjection.rb:186:17:186:32 | call to permitted_params | ActiveRecordInjection.rb:186:5:186:13 | my_params | provenance |  |
+| ActiveRecordInjection.rb:187:5:187:9 | query | ActiveRecordInjection.rb:188:37:188:41 | query | provenance |  |
+| ActiveRecordInjection.rb:187:47:187:55 | my_params | ActiveRecordInjection.rb:187:47:187:65 | ...[...] | provenance |  |
+| ActiveRecordInjection.rb:187:47:187:65 | ...[...] | ActiveRecordInjection.rb:187:5:187:9 | query | provenance |  |
+| ActiveRecordInjection.rb:193:5:193:10 | call to params | ActiveRecordInjection.rb:193:5:193:27 | call to require | provenance |  |
+| ActiveRecordInjection.rb:193:5:193:27 | call to require | ActiveRecordInjection.rb:193:5:193:59 | call to permit | provenance |  |
+| ActiveRecordInjection.rb:193:5:193:59 | call to permit | ActiveRecordInjection.rb:186:17:186:32 | call to permitted_params | provenance |  |
+| ActiveRecordInjection.rb:193:5:193:59 | call to permit | ActiveRecordInjection.rb:197:77:197:92 | call to permitted_params | provenance |  |
+| ActiveRecordInjection.rb:193:5:193:59 | call to permit | ActiveRecordInjection.rb:198:69:198:84 | call to permitted_params | provenance |  |
+| ActiveRecordInjection.rb:197:77:197:92 | call to permitted_params | ActiveRecordInjection.rb:197:77:197:102 | ...[...] | provenance |  |
+| ActiveRecordInjection.rb:197:77:197:102 | ...[...] | ActiveRecordInjection.rb:197:43:197:104 | "SELECT * FROM users WHERE id ..." | provenance |  |
+| ActiveRecordInjection.rb:198:69:198:84 | call to permitted_params | ActiveRecordInjection.rb:198:69:198:94 | ...[...] | provenance |  |
+| ActiveRecordInjection.rb:198:69:198:94 | ...[...] | ActiveRecordInjection.rb:198:35:198:96 | "SELECT * FROM users WHERE id ..." | provenance |  |
 | ArelInjection.rb:4:5:4:8 | name | ArelInjection.rb:6:20:6:61 | "SELECT * FROM users WHERE nam..." | provenance |  |
 | ArelInjection.rb:4:12:4:17 | call to params | ArelInjection.rb:4:12:4:29 | ...[...] | provenance |  |
 | ArelInjection.rb:4:12:4:29 | ...[...] | ArelInjection.rb:4:5:4:8 | name | provenance |  |
@@ -133,38 +142,54 @@ nodes
 | ActiveRecordInjection.rb:104:30:104:51 | ...[...] | semmle.label | ...[...] |
 | ActiveRecordInjection.rb:106:18:106:23 | call to params | semmle.label | call to params |
 | ActiveRecordInjection.rb:106:18:106:35 | ...[...] | semmle.label | ...[...] |
-| ActiveRecordInjection.rb:108:23:108:28 | call to params | semmle.label | call to params |
-| ActiveRecordInjection.rb:108:23:108:47 | ...[...] | semmle.label | ...[...] |
-| ActiveRecordInjection.rb:114:5:114:6 | ps | semmle.label | ps |
-| ActiveRecordInjection.rb:114:10:114:15 | call to params | semmle.label | call to params |
-| ActiveRecordInjection.rb:115:5:115:7 | uid | semmle.label | uid |
-| ActiveRecordInjection.rb:115:11:115:12 | ps | semmle.label | ps |
-| ActiveRecordInjection.rb:115:11:115:17 | ...[...] | semmle.label | ...[...] |
-| ActiveRecordInjection.rb:116:5:116:9 | uidEq | semmle.label | uidEq |
-| ActiveRecordInjection.rb:120:20:120:32 | ... + ... | semmle.label | ... + ... |
-| ActiveRecordInjection.rb:120:20:120:32 | ... + ... [element] | semmle.label | ... + ... [element] |
-| ActiveRecordInjection.rb:120:28:120:32 | uidEq | semmle.label | uidEq |
-| ActiveRecordInjection.rb:153:21:153:26 | call to params | semmle.label | call to params |
-| ActiveRecordInjection.rb:153:21:153:44 | ...[...] | semmle.label | ...[...] |
-| ActiveRecordInjection.rb:153:21:153:44 | ...[...] | semmle.label | ...[...] |
-| ActiveRecordInjection.rb:167:27:167:76 | "this is an unsafe annotation:..." | semmle.label | "this is an unsafe annotation:..." |
-| ActiveRecordInjection.rb:167:59:167:64 | call to params | semmle.label | call to params |
-| ActiveRecordInjection.rb:167:59:167:74 | ...[...] | semmle.label | ...[...] |
-| ActiveRecordInjection.rb:178:5:178:13 | my_params | semmle.label | my_params |
-| ActiveRecordInjection.rb:178:17:178:32 | call to permitted_params | semmle.label | call to permitted_params |
-| ActiveRecordInjection.rb:179:5:179:9 | query | semmle.label | query |
-| ActiveRecordInjection.rb:179:47:179:55 | my_params | semmle.label | my_params |
-| ActiveRecordInjection.rb:179:47:179:65 | ...[...] | semmle.label | ...[...] |
-| ActiveRecordInjection.rb:180:37:180:41 | query | semmle.label | query |
-| ActiveRecordInjection.rb:185:5:185:10 | call to params | semmle.label | call to params |
-| ActiveRecordInjection.rb:185:5:185:27 | call to require | semmle.label | call to require |
-| ActiveRecordInjection.rb:185:5:185:59 | call to permit | semmle.label | call to permit |
-| ActiveRecordInjection.rb:189:43:189:104 | "SELECT * FROM users WHERE id ..." | semmle.label | "SELECT * FROM users WHERE id ..." |
-| ActiveRecordInjection.rb:189:77:189:92 | call to permitted_params | semmle.label | call to permitted_params |
-| ActiveRecordInjection.rb:189:77:189:102 | ...[...] | semmle.label | ...[...] |
-| ActiveRecordInjection.rb:190:35:190:96 | "SELECT * FROM users WHERE id ..." | semmle.label | "SELECT * FROM users WHERE id ..." |
-| ActiveRecordInjection.rb:190:69:190:84 | call to permitted_params | semmle.label | call to permitted_params |
-| ActiveRecordInjection.rb:190:69:190:94 | ...[...] | semmle.label | ...[...] |
+| ActiveRecordInjection.rb:108:26:108:31 | call to params | semmle.label | call to params |
+| ActiveRecordInjection.rb:108:26:108:40 | ...[...] | semmle.label | ...[...] |
+| ActiveRecordInjection.rb:109:28:109:33 | call to params | semmle.label | call to params |
+| ActiveRecordInjection.rb:109:28:109:42 | ...[...] | semmle.label | ...[...] |
+| ActiveRecordInjection.rb:110:25:110:49 | "b #{...}" | semmle.label | "b #{...}" |
+| ActiveRecordInjection.rb:110:30:110:35 | call to params | semmle.label | call to params |
+| ActiveRecordInjection.rb:110:30:110:47 | ...[...] | semmle.label | ...[...] |
+| ActiveRecordInjection.rb:111:27:111:51 | "b #{...}" | semmle.label | "b #{...}" |
+| ActiveRecordInjection.rb:111:32:111:37 | call to params | semmle.label | call to params |
+| ActiveRecordInjection.rb:111:32:111:49 | ...[...] | semmle.label | ...[...] |
+| ActiveRecordInjection.rb:112:21:112:26 | call to params | semmle.label | call to params |
+| ActiveRecordInjection.rb:112:21:112:35 | ...[...] | semmle.label | ...[...] |
+| ActiveRecordInjection.rb:113:21:113:26 | call to params | semmle.label | call to params |
+| ActiveRecordInjection.rb:113:21:113:35 | ...[...] | semmle.label | ...[...] |
+| ActiveRecordInjection.rb:114:20:114:25 | call to params | semmle.label | call to params |
+| ActiveRecordInjection.rb:114:20:114:34 | ...[...] | semmle.label | ...[...] |
+| ActiveRecordInjection.rb:116:23:116:28 | call to params | semmle.label | call to params |
+| ActiveRecordInjection.rb:116:23:116:47 | ...[...] | semmle.label | ...[...] |
+| ActiveRecordInjection.rb:122:5:122:6 | ps | semmle.label | ps |
+| ActiveRecordInjection.rb:122:10:122:15 | call to params | semmle.label | call to params |
+| ActiveRecordInjection.rb:123:5:123:7 | uid | semmle.label | uid |
+| ActiveRecordInjection.rb:123:11:123:12 | ps | semmle.label | ps |
+| ActiveRecordInjection.rb:123:11:123:17 | ...[...] | semmle.label | ...[...] |
+| ActiveRecordInjection.rb:124:5:124:9 | uidEq | semmle.label | uidEq |
+| ActiveRecordInjection.rb:128:20:128:32 | ... + ... | semmle.label | ... + ... |
+| ActiveRecordInjection.rb:128:20:128:32 | ... + ... [element] | semmle.label | ... + ... [element] |
+| ActiveRecordInjection.rb:128:28:128:32 | uidEq | semmle.label | uidEq |
+| ActiveRecordInjection.rb:161:21:161:26 | call to params | semmle.label | call to params |
+| ActiveRecordInjection.rb:161:21:161:44 | ...[...] | semmle.label | ...[...] |
+| ActiveRecordInjection.rb:161:21:161:44 | ...[...] | semmle.label | ...[...] |
+| ActiveRecordInjection.rb:175:27:175:76 | "this is an unsafe annotation:..." | semmle.label | "this is an unsafe annotation:..." |
+| ActiveRecordInjection.rb:175:59:175:64 | call to params | semmle.label | call to params |
+| ActiveRecordInjection.rb:175:59:175:74 | ...[...] | semmle.label | ...[...] |
+| ActiveRecordInjection.rb:186:5:186:13 | my_params | semmle.label | my_params |
+| ActiveRecordInjection.rb:186:17:186:32 | call to permitted_params | semmle.label | call to permitted_params |
+| ActiveRecordInjection.rb:187:5:187:9 | query | semmle.label | query |
+| ActiveRecordInjection.rb:187:47:187:55 | my_params | semmle.label | my_params |
+| ActiveRecordInjection.rb:187:47:187:65 | ...[...] | semmle.label | ...[...] |
+| ActiveRecordInjection.rb:188:37:188:41 | query | semmle.label | query |
+| ActiveRecordInjection.rb:193:5:193:10 | call to params | semmle.label | call to params |
+| ActiveRecordInjection.rb:193:5:193:27 | call to require | semmle.label | call to require |
+| ActiveRecordInjection.rb:193:5:193:59 | call to permit | semmle.label | call to permit |
+| ActiveRecordInjection.rb:197:43:197:104 | "SELECT * FROM users WHERE id ..." | semmle.label | "SELECT * FROM users WHERE id ..." |
+| ActiveRecordInjection.rb:197:77:197:92 | call to permitted_params | semmle.label | call to permitted_params |
+| ActiveRecordInjection.rb:197:77:197:102 | ...[...] | semmle.label | ...[...] |
+| ActiveRecordInjection.rb:198:35:198:96 | "SELECT * FROM users WHERE id ..." | semmle.label | "SELECT * FROM users WHERE id ..." |
+| ActiveRecordInjection.rb:198:69:198:84 | call to permitted_params | semmle.label | call to permitted_params |
+| ActiveRecordInjection.rb:198:69:198:94 | ...[...] | semmle.label | ...[...] |
 | ArelInjection.rb:4:5:4:8 | name | semmle.label | name |
 | ArelInjection.rb:4:12:4:17 | call to params | semmle.label | call to params |
 | ArelInjection.rb:4:12:4:29 | ...[...] | semmle.label | ...[...] |
@@ -186,7 +211,7 @@ subpaths
 #select
 | ActiveRecordInjection.rb:10:33:10:67 | "name='#{...}' and pass='#{...}'" | ActiveRecordInjection.rb:70:23:70:28 | call to params | ActiveRecordInjection.rb:10:33:10:67 | "name='#{...}' and pass='#{...}'" | This SQL query depends on a $@. | ActiveRecordInjection.rb:70:23:70:28 | call to params | user-provided value |
 | ActiveRecordInjection.rb:10:33:10:67 | "name='#{...}' and pass='#{...}'" | ActiveRecordInjection.rb:70:38:70:43 | call to params | ActiveRecordInjection.rb:10:33:10:67 | "name='#{...}' and pass='#{...}'" | This SQL query depends on a $@. | ActiveRecordInjection.rb:70:38:70:43 | call to params | user-provided value |
-| ActiveRecordInjection.rb:23:16:23:24 | condition | ActiveRecordInjection.rb:153:21:153:26 | call to params | ActiveRecordInjection.rb:23:16:23:24 | condition | This SQL query depends on a $@. | ActiveRecordInjection.rb:153:21:153:26 | call to params | user-provided value |
+| ActiveRecordInjection.rb:23:16:23:24 | condition | ActiveRecordInjection.rb:161:21:161:26 | call to params | ActiveRecordInjection.rb:23:16:23:24 | condition | This SQL query depends on a $@. | ActiveRecordInjection.rb:161:21:161:26 | call to params | user-provided value |
 | ActiveRecordInjection.rb:35:30:35:44 | ...[...] | ActiveRecordInjection.rb:35:30:35:35 | call to params | ActiveRecordInjection.rb:35:30:35:44 | ...[...] | This SQL query depends on a $@. | ActiveRecordInjection.rb:35:30:35:35 | call to params | user-provided value |
 | ActiveRecordInjection.rb:39:18:39:32 | ...[...] | ActiveRecordInjection.rb:39:18:39:23 | call to params | ActiveRecordInjection.rb:39:18:39:32 | ...[...] | This SQL query depends on a $@. | ActiveRecordInjection.rb:39:18:39:23 | call to params | user-provided value |
 | ActiveRecordInjection.rb:43:20:43:42 | "id = '#{...}'" | ActiveRecordInjection.rb:43:29:43:34 | call to params | ActiveRecordInjection.rb:43:20:43:42 | "id = '#{...}'" | This SQL query depends on a $@. | ActiveRecordInjection.rb:43:29:43:34 | call to params | user-provided value |
@@ -204,13 +229,20 @@ subpaths
 | ActiveRecordInjection.rb:100:20:100:55 | "name = '#{...}'" | ActiveRecordInjection.rb:100:31:100:36 | call to params | ActiveRecordInjection.rb:100:20:100:55 | "name = '#{...}'" | This SQL query depends on a $@. | ActiveRecordInjection.rb:100:31:100:36 | call to params | user-provided value |
 | ActiveRecordInjection.rb:104:19:104:54 | "name = '#{...}'" | ActiveRecordInjection.rb:104:30:104:35 | call to params | ActiveRecordInjection.rb:104:19:104:54 | "name = '#{...}'" | This SQL query depends on a $@. | ActiveRecordInjection.rb:104:30:104:35 | call to params | user-provided value |
 | ActiveRecordInjection.rb:106:18:106:35 | ...[...] | ActiveRecordInjection.rb:106:18:106:23 | call to params | ActiveRecordInjection.rb:106:18:106:35 | ...[...] | This SQL query depends on a $@. | ActiveRecordInjection.rb:106:18:106:23 | call to params | user-provided value |
-| ActiveRecordInjection.rb:108:23:108:47 | ...[...] | ActiveRecordInjection.rb:108:23:108:28 | call to params | ActiveRecordInjection.rb:108:23:108:47 | ...[...] | This SQL query depends on a $@. | ActiveRecordInjection.rb:108:23:108:28 | call to params | user-provided value |
-| ActiveRecordInjection.rb:120:20:120:32 | ... + ... | ActiveRecordInjection.rb:114:10:114:15 | call to params | ActiveRecordInjection.rb:120:20:120:32 | ... + ... | This SQL query depends on a $@. | ActiveRecordInjection.rb:114:10:114:15 | call to params | user-provided value |
-| ActiveRecordInjection.rb:153:21:153:44 | ...[...] | ActiveRecordInjection.rb:153:21:153:26 | call to params | ActiveRecordInjection.rb:153:21:153:44 | ...[...] | This SQL query depends on a $@. | ActiveRecordInjection.rb:153:21:153:26 | call to params | user-provided value |
-| ActiveRecordInjection.rb:167:27:167:76 | "this is an unsafe annotation:..." | ActiveRecordInjection.rb:167:59:167:64 | call to params | ActiveRecordInjection.rb:167:27:167:76 | "this is an unsafe annotation:..." | This SQL query depends on a $@. | ActiveRecordInjection.rb:167:59:167:64 | call to params | user-provided value |
-| ActiveRecordInjection.rb:180:37:180:41 | query | ActiveRecordInjection.rb:185:5:185:10 | call to params | ActiveRecordInjection.rb:180:37:180:41 | query | This SQL query depends on a $@. | ActiveRecordInjection.rb:185:5:185:10 | call to params | user-provided value |
-| ActiveRecordInjection.rb:189:43:189:104 | "SELECT * FROM users WHERE id ..." | ActiveRecordInjection.rb:185:5:185:10 | call to params | ActiveRecordInjection.rb:189:43:189:104 | "SELECT * FROM users WHERE id ..." | This SQL query depends on a $@. | ActiveRecordInjection.rb:185:5:185:10 | call to params | user-provided value |
-| ActiveRecordInjection.rb:190:35:190:96 | "SELECT * FROM users WHERE id ..." | ActiveRecordInjection.rb:185:5:185:10 | call to params | ActiveRecordInjection.rb:190:35:190:96 | "SELECT * FROM users WHERE id ..." | This SQL query depends on a $@. | ActiveRecordInjection.rb:185:5:185:10 | call to params | user-provided value |
+| ActiveRecordInjection.rb:108:26:108:40 | ...[...] | ActiveRecordInjection.rb:108:26:108:31 | call to params | ActiveRecordInjection.rb:108:26:108:40 | ...[...] | This SQL query depends on a $@. | ActiveRecordInjection.rb:108:26:108:31 | call to params | user-provided value |
+| ActiveRecordInjection.rb:109:28:109:42 | ...[...] | ActiveRecordInjection.rb:109:28:109:33 | call to params | ActiveRecordInjection.rb:109:28:109:42 | ...[...] | This SQL query depends on a $@. | ActiveRecordInjection.rb:109:28:109:33 | call to params | user-provided value |
+| ActiveRecordInjection.rb:110:25:110:49 | "b #{...}" | ActiveRecordInjection.rb:110:30:110:35 | call to params | ActiveRecordInjection.rb:110:25:110:49 | "b #{...}" | This SQL query depends on a $@. | ActiveRecordInjection.rb:110:30:110:35 | call to params | user-provided value |
+| ActiveRecordInjection.rb:111:27:111:51 | "b #{...}" | ActiveRecordInjection.rb:111:32:111:37 | call to params | ActiveRecordInjection.rb:111:27:111:51 | "b #{...}" | This SQL query depends on a $@. | ActiveRecordInjection.rb:111:32:111:37 | call to params | user-provided value |
+| ActiveRecordInjection.rb:112:21:112:35 | ...[...] | ActiveRecordInjection.rb:112:21:112:26 | call to params | ActiveRecordInjection.rb:112:21:112:35 | ...[...] | This SQL query depends on a $@. | ActiveRecordInjection.rb:112:21:112:26 | call to params | user-provided value |
+| ActiveRecordInjection.rb:113:21:113:35 | ...[...] | ActiveRecordInjection.rb:113:21:113:26 | call to params | ActiveRecordInjection.rb:113:21:113:35 | ...[...] | This SQL query depends on a $@. | ActiveRecordInjection.rb:113:21:113:26 | call to params | user-provided value |
+| ActiveRecordInjection.rb:114:20:114:34 | ...[...] | ActiveRecordInjection.rb:114:20:114:25 | call to params | ActiveRecordInjection.rb:114:20:114:34 | ...[...] | This SQL query depends on a $@. | ActiveRecordInjection.rb:114:20:114:25 | call to params | user-provided value |
+| ActiveRecordInjection.rb:116:23:116:47 | ...[...] | ActiveRecordInjection.rb:116:23:116:28 | call to params | ActiveRecordInjection.rb:116:23:116:47 | ...[...] | This SQL query depends on a $@. | ActiveRecordInjection.rb:116:23:116:28 | call to params | user-provided value |
+| ActiveRecordInjection.rb:128:20:128:32 | ... + ... | ActiveRecordInjection.rb:122:10:122:15 | call to params | ActiveRecordInjection.rb:128:20:128:32 | ... + ... | This SQL query depends on a $@. | ActiveRecordInjection.rb:122:10:122:15 | call to params | user-provided value |
+| ActiveRecordInjection.rb:161:21:161:44 | ...[...] | ActiveRecordInjection.rb:161:21:161:26 | call to params | ActiveRecordInjection.rb:161:21:161:44 | ...[...] | This SQL query depends on a $@. | ActiveRecordInjection.rb:161:21:161:26 | call to params | user-provided value |
+| ActiveRecordInjection.rb:175:27:175:76 | "this is an unsafe annotation:..." | ActiveRecordInjection.rb:175:59:175:64 | call to params | ActiveRecordInjection.rb:175:27:175:76 | "this is an unsafe annotation:..." | This SQL query depends on a $@. | ActiveRecordInjection.rb:175:59:175:64 | call to params | user-provided value |
+| ActiveRecordInjection.rb:188:37:188:41 | query | ActiveRecordInjection.rb:193:5:193:10 | call to params | ActiveRecordInjection.rb:188:37:188:41 | query | This SQL query depends on a $@. | ActiveRecordInjection.rb:193:5:193:10 | call to params | user-provided value |
+| ActiveRecordInjection.rb:197:43:197:104 | "SELECT * FROM users WHERE id ..." | ActiveRecordInjection.rb:193:5:193:10 | call to params | ActiveRecordInjection.rb:197:43:197:104 | "SELECT * FROM users WHERE id ..." | This SQL query depends on a $@. | ActiveRecordInjection.rb:193:5:193:10 | call to params | user-provided value |
+| ActiveRecordInjection.rb:198:35:198:96 | "SELECT * FROM users WHERE id ..." | ActiveRecordInjection.rb:193:5:193:10 | call to params | ActiveRecordInjection.rb:198:35:198:96 | "SELECT * FROM users WHERE id ..." | This SQL query depends on a $@. | ActiveRecordInjection.rb:193:5:193:10 | call to params | user-provided value |
 | ArelInjection.rb:6:20:6:61 | "SELECT * FROM users WHERE nam..." | ArelInjection.rb:4:12:4:17 | call to params | ArelInjection.rb:6:20:6:61 | "SELECT * FROM users WHERE nam..." | This SQL query depends on a $@. | ArelInjection.rb:4:12:4:17 | call to params | user-provided value |
 | PgInjection.rb:14:15:14:18 | qry1 | PgInjection.rb:6:12:6:17 | call to params | PgInjection.rb:14:15:14:18 | qry1 | This SQL query depends on a $@. | PgInjection.rb:6:12:6:17 | call to params | user-provided value |
 | PgInjection.rb:15:21:15:24 | qry1 | PgInjection.rb:6:12:6:17 | call to params | PgInjection.rb:15:21:15:24 | qry1 | This SQL query depends on a $@. | PgInjection.rb:6:12:6:17 | call to params | user-provided value |


### PR DESCRIPTION
Part of https://github.com/github/codeql-team/issues/2616 and https://github.com/github/codeql-team/issues/2559.

This PR considers additional arguments to the methods `group`, `joins`, `pluck`, `order`, `reorder`, `select`, and `reselect` as sql sinks. 