### PR TITLE
C#: Improve fallback nuget package restore in buildless

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FrameworkPackageNames.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FrameworkPackageNames.cs
@@ -4,7 +4,9 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 {
     internal static class FrameworkPackageNames
     {
-        public static string LatestNetFrameworkReferenceAssemblies { get; } = "microsoft.netframework.referenceassemblies.net481";
+        public const string LatestNetFrameworkMoniker = "net481";
+
+        public static string LatestNetFrameworkReferenceAssemblies { get; } = $"microsoft.netframework.referenceassemblies.{LatestNetFrameworkMoniker}";
 
         public static string AspNetCoreFramework { get; } = "microsoft.aspnetcore.app.ref";
 

--- a/csharp/extractor/Semmle.Extraction.Tests/FileContent.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/FileContent.cs
@@ -55,9 +55,9 @@ namespace Semmle.Extraction.Tests
             // Verify
             Assert.False(useAspNetDlls);
             Assert.Equal(3, allPackages.Count);
-            Assert.Contains("DotNetAnalyzers.DocumentationAnalyzers".ToLowerInvariant(), allPackages);
-            Assert.Contains("Microsoft.CodeAnalysis.NetAnalyzers".ToLowerInvariant(), allPackages);
-            Assert.Contains("StyleCop.Analyzers".ToLowerInvariant(), allPackages);
+            Assert.Contains(new PackageReference("DotNetAnalyzers.DocumentationAnalyzers".ToLowerInvariant(), PackageReferenceSource.SdkCsProj), allPackages);
+            Assert.Contains(new PackageReference("Microsoft.CodeAnalysis.NetAnalyzers".ToLowerInvariant(), PackageReferenceSource.SdkCsProj), allPackages);
+            Assert.Contains(new PackageReference("StyleCop.Analyzers".ToLowerInvariant(), PackageReferenceSource.SdkCsProj), allPackages);
         }
 
         [Fact]
@@ -80,8 +80,8 @@ namespace Semmle.Extraction.Tests
             // Verify
             Assert.True(useAspNetDlls);
             Assert.Equal(2, allPackages.Count);
-            Assert.Contains("Microsoft.CodeAnalysis.NetAnalyzers".ToLowerInvariant(), allPackages);
-            Assert.Contains("StyleCop.Analyzers".ToLowerInvariant(), allPackages);
+            Assert.Contains(new PackageReference("Microsoft.CodeAnalysis.NetAnalyzers".ToLowerInvariant(), PackageReferenceSource.SdkCsProj), allPackages);
+            Assert.Contains(new PackageReference("StyleCop.Analyzers".ToLowerInvariant(), PackageReferenceSource.SdkCsProj), allPackages);
         }
 
         private static void CsProjSettingsTest(string line, bool expected, Func<FileContent, bool> func)


### PR DESCRIPTION
Fallback cases coming from `<PackageReference />` and `packages.config` are now differentiated. In the latter case we're restoring the package through projects that target `net481`.

This change helps with restoring `EntityFramework` references. EF has different dependencies based on the target framework. If we're referencing `net481` reference assemblies and the .net core variant of EF, then duplicate type declarations are found due to the `System.Configuration.ConfigurationManager` and `System.Data.SqlClient` transitive dependencies.