### PR TITLE
C++: Fill some QLDoc holes

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
@@ -114,15 +114,28 @@ abstract class OutNode extends Node {
   abstract DataFlowCall getCall();
 }
 
+/**
+ * Represents a private class that extends OutNode and ExprNode.
+ * This class is used for expressing data flow analysis in C++ code.
+ */
 private class ExprOutNode extends OutNode, ExprNode {
   ExprOutNode() { this.getExpr() instanceof Call }
 
-  /** Gets the underlying call. */
+  /**
+   * Gets the underlying call.
+   * @return The DataFlowCall representing the underlying call.
+   */
   override DataFlowCall getCall() { result = this.getExpr() }
 }
 
+/**
+ * Represents a private class RefOutNode that extends OutNode and DefinitionByReferenceOrIteratorNode.
+ */
 private class RefOutNode extends OutNode, DefinitionByReferenceOrIteratorNode {
-  /** Gets the underlying call. */
+  /**
+   * Gets the underlying call.
+   * @return The underlying call.
+   */
   override DataFlowCall getCall() { result = this.getArgument().getParent() }
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
@@ -121,10 +121,7 @@ abstract class OutNode extends Node {
 private class ExprOutNode extends OutNode, ExprNode {
   ExprOutNode() { this.getExpr() instanceof Call }
 
-  /**
-   * Gets the underlying call.
-   * @return The DataFlowCall representing the underlying call.
-   */
+  /** Gets the underlying call. */
   override DataFlowCall getCall() { result = this.getExpr() }
 }
 
@@ -132,10 +129,7 @@ private class ExprOutNode extends OutNode, ExprNode {
  * Represents a private class RefOutNode that extends OutNode and DefinitionByReferenceOrIteratorNode.
  */
 private class RefOutNode extends OutNode, DefinitionByReferenceOrIteratorNode {
-  /**
-   * Gets the underlying call.
-   * @return The underlying call.
-   */
+  /** Gets the underlying call. */
   override DataFlowCall getCall() { result = this.getArgument().getParent() }
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
@@ -166,6 +166,10 @@ class ExplicitParameterNode extends ParameterNode, TExplicitParameterNode {
   override predicate isParameterOf(Function f, int i) { f.getParameter(i) = param }
 }
 
+/**
+ * Represents an implicit parameter node in the data flow analysis.
+ * An implicit parameter node is a special kind of parameter node that represents the "this" parameter.
+ */
 class ImplicitParameterNode extends ParameterNode, TInstanceParameterNode {
   MemberFunction f;
 

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/TaintTrackingUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/TaintTrackingUtil.qll
@@ -167,7 +167,7 @@ private predicate noFlowFromChildExpr(Expr e) {
 }
 
 /**
- * This predicate checks if there is a data flow from `exprIn` to `exprOut` in the code.
+ * Holds if there is a data flow from `exprIn` to `exprOut` in the code.
  * The predicate also handles taint flows, where the data flow is from a tainted source to a sink.
  * It checks if there is a taint flow from `exprIn` to `exprOut` by considering the same cases as above.
  */
@@ -216,7 +216,7 @@ private predicate exprToExprStep(Expr exprIn, Expr exprOut) {
 }
 
 /**
- * This predicate checks if there is a data flow from an expression to a definition by reference.
+ * Holds if there is a data flow from an expression to a definition by reference.
  */
 private predicate exprToDefinitionByReferenceStep(Expr exprIn, Expr argOut) {
   exists(DataFlowFunction f, Call call, FunctionOutput outModel, int argOutIndex |
@@ -260,7 +260,7 @@ private predicate exprToDefinitionByReferenceStep(Expr exprIn, Expr argOut) {
 }
 
 /**
- * This predicate checks if there is a partial definition step between two expressions.
+ * Holds if there is a partial definition step between two expressions.
  */
 private predicate exprToPartialDefinitionStep(Expr exprIn, Expr exprOut) {
   exists(TaintFunction f, Call call, FunctionInput inModel, FunctionOutput outModel |

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/TaintTrackingUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/TaintTrackingUtil.qll
@@ -176,7 +176,6 @@ private predicate noFlowFromChildExpr(Expr e) {
  *
  * @param exprIn The input expression from which the data flow originates.
  * @param exprOut The output expression to which the data flow reaches.
- * @return `true` if there is a data flow from `exprIn` to `exprOut`, `false` otherwise.
  */
 private predicate exprToExprStep(Expr exprIn, Expr exprOut) {
   exists(DataFlowFunction f, Call call, FunctionOutput outModel |
@@ -229,7 +228,6 @@ private predicate exprToExprStep(Expr exprIn, Expr exprOut) {
  * For taint functions, it checks if the expression is an argument that is passed by reference or if it is the qualifier object.
  * @param exprIn The input expression.
  * @param argOut The output expression (definition by reference).
- * @return True if there is a data flow from exprIn to argOut by reference, false otherwise.
  */
 private predicate exprToDefinitionByReferenceStep(Expr exprIn, Expr argOut) {
   exists(DataFlowFunction f, Call call, FunctionOutput outModel, int argOutIndex |
@@ -274,7 +272,7 @@ private predicate exprToDefinitionByReferenceStep(Expr exprIn, Expr argOut) {
 
 /**
  * This predicate checks if there is a partial definition step between two expressions.
- * It returns true if there exists a TaintFunction call, with a corresponding inModel and outModel,
+ * It holds if there exists a TaintFunction call, with a corresponding inModel and outModel,
  * such that the exprOut is the qualifier of the call and outModel is a qualifier object.
  * Additionally, it checks if the TaintFunction has a taint flow between the inModel and outModel.
  * It also checks if there exists an argument index such that the exprIn matches the argument at that index,
@@ -284,7 +282,6 @@ private predicate exprToDefinitionByReferenceStep(Expr exprIn, Expr argOut) {
  *
  * @param exprIn The input expression.
  * @param exprOut The output expression.
- * @return True if there is a partial definition step between the expressions, false otherwise.
  */
 private predicate exprToPartialDefinitionStep(Expr exprIn, Expr exprOut) {
   exists(TaintFunction f, Call call, FunctionInput inModel, FunctionOutput outModel |

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/TaintTrackingUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/TaintTrackingUtil.qll
@@ -168,14 +168,8 @@ private predicate noFlowFromChildExpr(Expr e) {
 
 /**
  * This predicate checks if there is a data flow from `exprIn` to `exprOut` in the code.
- * It considers two cases:
- * 1. If `exprOut` is a function call and the return value is dereferenced, it checks if there is a data flow from an argument of the function call to the dereference.
- * 2. If `exprOut` is a function call and the return value is not dereferenced, it checks if there is a data flow from an argument of the function call to the return value.
  * The predicate also handles taint flows, where the data flow is from a tainted source to a sink.
  * It checks if there is a taint flow from `exprIn` to `exprOut` by considering the same cases as above.
- *
- * @param exprIn The input expression from which the data flow originates.
- * @param exprOut The output expression to which the data flow reaches.
  */
 private predicate exprToExprStep(Expr exprIn, Expr exprOut) {
   exists(DataFlowFunction f, Call call, FunctionOutput outModel |
@@ -223,11 +217,6 @@ private predicate exprToExprStep(Expr exprIn, Expr exprOut) {
 
 /**
  * This predicate checks if there is a data flow from an expression to a definition by reference.
- * It considers both function calls and taint functions.
- * For function calls, it checks if the expression is an argument that is passed by reference to the called function.
- * For taint functions, it checks if the expression is an argument that is passed by reference or if it is the qualifier object.
- * @param exprIn The input expression.
- * @param argOut The output expression (definition by reference).
  */
 private predicate exprToDefinitionByReferenceStep(Expr exprIn, Expr argOut) {
   exists(DataFlowFunction f, Call call, FunctionOutput outModel, int argOutIndex |
@@ -272,16 +261,6 @@ private predicate exprToDefinitionByReferenceStep(Expr exprIn, Expr argOut) {
 
 /**
  * This predicate checks if there is a partial definition step between two expressions.
- * It holds if there exists a TaintFunction call, with a corresponding inModel and outModel,
- * such that the exprOut is the qualifier of the call and outModel is a qualifier object.
- * Additionally, it checks if the TaintFunction has a taint flow between the inModel and outModel.
- * It also checks if there exists an argument index such that the exprIn matches the argument at that index,
- * either by direct assignment or by passing by reference.
- * Alternatively, it checks if there exists an Assignment where exprOut is an iterator dereference,
- * and the lValue of the assignment is exprOut and the rValue is exprIn.
- *
- * @param exprIn The input expression.
- * @param exprOut The output expression.
  */
 private predicate exprToPartialDefinitionStep(Expr exprIn, Expr exprOut) {
   exists(TaintFunction f, Call call, FunctionInput inModel, FunctionOutput outModel |

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/TaintTrackingUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/TaintTrackingUtil.qll
@@ -169,7 +169,6 @@ private predicate noFlowFromChildExpr(Expr e) {
 /**
  * Holds if there is a data flow from `exprIn` to `exprOut` in the code.
  * The predicate also handles taint flows, where the data flow is from a tainted source to a sink.
- * It checks if there is a taint flow from `exprIn` to `exprOut` by considering the same cases as above.
  */
 private predicate exprToExprStep(Expr exprIn, Expr exprOut) {
   exists(DataFlowFunction f, Call call, FunctionOutput outModel |


### PR DESCRIPTION
This is a small experiment to see whether we can use Copilot to help fill holes in our QLDoc comments.  I've moaned about this before, but on reflection I think we're actually *not* in a bad place when it comes to QLDoc coverage - though I am sometimes frustrated by rather minimal / mechanical comments, and abuse of the rule that QLDoc on private classes is optional (it is optional, but should only be left out if nothing needs explaining).  This PR only attempts to address a small part of the latter problem.
- in the first commit I've basically picked a few undocumented classes / predicates that I think could do with explanation, and hit the "GitHub Copilot: Generate Docs" command in my IDE.
- in the next four commits I've done some basic editing to remove obvious hallucinations, reduce verbosity, and standardize some phrasing towards how we like to do things.
- what I have not yet done is a "semantic pass" to make sure what the comments say is **correct** and **helpful**.  To be honest I think it mostly isn't.  But I'd like to do this together with one or more reviewers.