### PR TITLE
Ruby: No `fieldFlowBranchLimit` for `SummarizedCallable`s

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplSpecific.qll
@@ -31,4 +31,6 @@ module RubyDataFlow implements InputSig {
   predicate mayBenefitFromCallContext = Private::mayBenefitFromCallContext/1;
 
   predicate viableImplInCallContext = Private::viableImplInCallContext/2;
+
+  predicate ignoreFieldFlowBranchLimit(DataFlowCallable c) { exists(c.asLibraryCallable()) }
 }

--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -273,6 +273,9 @@ signature module InputSig {
   ) {
     any()
   }
+
+  /** Holds if `fieldFlowBranchLimit` should be ignored for flow going into/out of `c`. */
+  default predicate ignoreFieldFlowBranchLimit(DataFlowCallable c) { none() }
 }
 
 module Configs<InputSig Lang> {

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -1117,7 +1117,9 @@ module MakeImpl<InputSig Lang> {
       exists(int b, int j |
         b = branch(ret) and
         j = join(out) and
-        if b.minimum(j) <= Config::fieldFlowBranchLimit()
+        if
+          b.minimum(j) <= Config::fieldFlowBranchLimit() or
+          ignoreFieldFlowBranchLimit(ret.getEnclosingCallable())
         then allowsFieldFlow = true
         else allowsFieldFlow = false
       )
@@ -1136,7 +1138,9 @@ module MakeImpl<InputSig Lang> {
       exists(int b, int j |
         b = branch(arg) and
         j = join(p) and
-        if b.minimum(j) <= Config::fieldFlowBranchLimit()
+        if
+          b.minimum(j) <= Config::fieldFlowBranchLimit() or
+          ignoreFieldFlowBranchLimit(p.getEnclosingCallable())
         then allowsFieldFlow = true
         else allowsFieldFlow = false
       )


### PR DESCRIPTION
This PR adds a hook to the data flow library to allow for certain callables to excluded from the field-flow-branch-limit restriction.

For Ruby, we want to always include flow into/out of summarized callables, as these are expected to have high precision, which will ultimately reduce false negatives.