### PR TITLE
Remove period from 'name' for Java query

### DIFF
--- a/java/ql/src/Security/CWE/CWE-200/AndroidSensitiveTextField.ql
+++ b/java/ql/src/Security/CWE/CWE-200/AndroidSensitiveTextField.ql
@@ -1,5 +1,5 @@
 /**
- * @name Exposure of sensitive information to UI text views.
+ * @name Exposure of sensitive information to UI text views
  * @id java/android/sensitive-text
  * @kind path-problem
  * @description Sensitive information displayed in UI text views should be properly masked.


### PR DESCRIPTION
This is an error for the Docs content linter and does not match the [style guide for metadata](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md#query-name-name).