### PR TITLE
C#: Download latest dotnet SDK when missing

### DIFF
--- a/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
@@ -558,8 +558,8 @@ namespace Semmle.Autobuild.CSharp.Tests
         [Fact]
         public void TestLinuxBuildlessExtractionSuccess()
         {
-            actions.RunProcess["dotnet --info"] = 0;
-            actions.RunProcessOut["dotnet --info"] = "";
+            actions.RunProcess["dotnet --list-sdks"] = 0;
+            actions.RunProcessOut["dotnet --list-sdks"] = "any version";
             actions.RunProcess[@"C:\codeql\csharp/tools/linux64/Semmle.Extraction.CSharp.Standalone"] = 0;
             actions.FileExists["csharp.log"] = true;
             actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
@@ -575,8 +575,8 @@ namespace Semmle.Autobuild.CSharp.Tests
         [Fact]
         public void TestLinuxBuildlessExtractionFailed()
         {
-            actions.RunProcess["dotnet --info"] = 0;
-            actions.RunProcessOut["dotnet --info"] = "";
+            actions.RunProcess["dotnet --list-sdks"] = 0;
+            actions.RunProcessOut["dotnet --list-sdks"] = "any version";
             actions.RunProcess[@"C:\codeql\csharp/tools/linux64/Semmle.Extraction.CSharp.Standalone"] = 10;
             actions.FileExists["csharp.log"] = true;
             actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
@@ -592,8 +592,8 @@ namespace Semmle.Autobuild.CSharp.Tests
         [Fact]
         public void TestLinuxBuildlessExtractionSolution()
         {
-            actions.RunProcess["dotnet --info"] = 0;
-            actions.RunProcessOut["dotnet --info"] = "";
+            actions.RunProcess["dotnet --list-sdks"] = 0;
+            actions.RunProcessOut["dotnet --list-sdks"] = "any version";
             actions.RunProcess[@"C:\codeql\csharp/tools/linux64/Semmle.Extraction.CSharp.Standalone"] = 0;
             actions.FileExists["csharp.log"] = true;
             actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
@@ -609,8 +609,8 @@ namespace Semmle.Autobuild.CSharp.Tests
         [Fact]
         public void TestLinuxBuildlessExtractionNoDotnet()
         {
-            actions.RunProcess["dotnet --info"] = 1;
-            actions.RunProcessOut["dotnet --info"] = "";
+            actions.RunProcess["dotnet --list-sdks"] = 1;
+            actions.RunProcessOut["dotnet --list-sdks"] = "";
             actions.RunProcess[@"chmod u+x scratch/.dotnet/dotnet-install.sh"] = 0;
             actions.RunProcess[@"scratch/.dotnet/dotnet-install.sh --channel release --version 8.0.101 --install-dir scratch/.dotnet"] = 0;
             actions.RunProcess[@"C:\codeql\csharp/tools/linux64/Semmle.Extraction.CSharp.Standalone --dotnet scratch/.dotnet"] = 0;
@@ -915,8 +915,8 @@ namespace Semmle.Autobuild.CSharp.Tests
         [Fact]
         public void TestSkipNugetBuildless()
         {
-            actions.RunProcess["dotnet --info"] = 0;
-            actions.RunProcessOut["dotnet --info"] = "";
+            actions.RunProcess["dotnet --list-sdks"] = 0;
+            actions.RunProcessOut["dotnet --list-sdks"] = "any version";
             actions.RunProcess[@"C:\codeql\csharp/tools/linux64/Semmle.Extraction.CSharp.Standalone"] = 0;
             actions.FileExists["csharp.log"] = true;
             actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
@@ -558,6 +558,8 @@ namespace Semmle.Autobuild.CSharp.Tests
         [Fact]
         public void TestLinuxBuildlessExtractionSuccess()
         {
+            actions.RunProcess["dotnet --info"] = 0;
+            actions.RunProcessOut["dotnet --info"] = "";
             actions.RunProcess[@"C:\codeql\csharp/tools/linux64/Semmle.Extraction.CSharp.Standalone"] = 0;
             actions.FileExists["csharp.log"] = true;
             actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
@@ -567,12 +569,14 @@ namespace Semmle.Autobuild.CSharp.Tests
             actions.EnumerateDirectories[@"C:\Project"] = "";
 
             var autobuilder = CreateAutoBuilder(false, buildless: "true");
-            TestAutobuilderScript(autobuilder, 0, 1);
+            TestAutobuilderScript(autobuilder, 0, 2);
         }
 
         [Fact]
         public void TestLinuxBuildlessExtractionFailed()
         {
+            actions.RunProcess["dotnet --info"] = 0;
+            actions.RunProcessOut["dotnet --info"] = "";
             actions.RunProcess[@"C:\codeql\csharp/tools/linux64/Semmle.Extraction.CSharp.Standalone"] = 10;
             actions.FileExists["csharp.log"] = true;
             actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
@@ -582,12 +586,14 @@ namespace Semmle.Autobuild.CSharp.Tests
             actions.EnumerateDirectories[@"C:\Project"] = "";
 
             var autobuilder = CreateAutoBuilder(false, buildless: "true");
-            TestAutobuilderScript(autobuilder, 10, 1);
+            TestAutobuilderScript(autobuilder, 10, 2);
         }
 
         [Fact]
         public void TestLinuxBuildlessExtractionSolution()
         {
+            actions.RunProcess["dotnet --info"] = 0;
+            actions.RunProcessOut["dotnet --info"] = "";
             actions.RunProcess[@"C:\codeql\csharp/tools/linux64/Semmle.Extraction.CSharp.Standalone"] = 0;
             actions.FileExists["csharp.log"] = true;
             actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
@@ -597,7 +603,30 @@ namespace Semmle.Autobuild.CSharp.Tests
             actions.EnumerateDirectories[@"C:\Project"] = "";
 
             var autobuilder = CreateAutoBuilder(false, buildless: "true");
-            TestAutobuilderScript(autobuilder, 0, 1);
+            TestAutobuilderScript(autobuilder, 0, 2);
+        }
+
+        [Fact]
+        public void TestLinuxBuildlessExtractionNoDotnet()
+        {
+            actions.RunProcess["dotnet --info"] = 1;
+            actions.RunProcessOut["dotnet --info"] = "";
+            actions.RunProcess["dotnet --list-sdks"] = 1;
+            actions.RunProcessOut["dotnet --list-sdks"] = "";
+            actions.RunProcess[@"chmod u+x scratch/.dotnet/dotnet-install.sh"] = 0;
+            actions.RunProcess[@"scratch/.dotnet/dotnet-install.sh --channel release --version 8.0.101 --install-dir scratch/.dotnet"] = 0;
+            actions.RunProcess[@"C:\codeql\csharp/tools/linux64/Semmle.Extraction.CSharp.Standalone --dotnet scratch/.dotnet"] = 0;
+            actions.FileExists["csharp.log"] = true;
+            actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
+            actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_SOURCE_ARCHIVE_DIR"] = "";
+            actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_SCRATCH_DIR"] = "scratch";
+            actions.EnumerateFiles[@"C:\Project"] = "foo.cs\ntest.sln";
+            actions.EnumerateDirectories[@"C:\Project"] = "";
+            actions.DownloadFiles.Add(("https://dot.net/v1/dotnet-install.sh", "scratch/.dotnet/dotnet-install.sh"));
+            actions.CreateDirectories.Add(@"scratch/.dotnet");
+
+            var autobuilder = CreateAutoBuilder(false, buildless: "true");
+            TestAutobuilderScript(autobuilder, 0, 5);
         }
 
         private void SkipVsWhere()
@@ -888,6 +917,8 @@ namespace Semmle.Autobuild.CSharp.Tests
         [Fact]
         public void TestSkipNugetBuildless()
         {
+            actions.RunProcess["dotnet --info"] = 0;
+            actions.RunProcessOut["dotnet --info"] = "";
             actions.RunProcess[@"C:\codeql\csharp/tools/linux64/Semmle.Extraction.CSharp.Standalone"] = 0;
             actions.FileExists["csharp.log"] = true;
             actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
@@ -897,7 +928,7 @@ namespace Semmle.Autobuild.CSharp.Tests
             actions.EnumerateDirectories[@"C:\Project"] = "";
 
             var autobuilder = CreateAutoBuilder(false, buildless: "true");
-            TestAutobuilderScript(autobuilder, 0, 1);
+            TestAutobuilderScript(autobuilder, 0, 2);
         }
 
 

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
@@ -611,8 +611,6 @@ namespace Semmle.Autobuild.CSharp.Tests
         {
             actions.RunProcess["dotnet --info"] = 1;
             actions.RunProcessOut["dotnet --info"] = "";
-            actions.RunProcess["dotnet --list-sdks"] = 1;
-            actions.RunProcessOut["dotnet --list-sdks"] = "";
             actions.RunProcess[@"chmod u+x scratch/.dotnet/dotnet-install.sh"] = 0;
             actions.RunProcess[@"scratch/.dotnet/dotnet-install.sh --channel release --version 8.0.101 --install-dir scratch/.dotnet"] = 0;
             actions.RunProcess[@"C:\codeql\csharp/tools/linux64/Semmle.Extraction.CSharp.Standalone --dotnet scratch/.dotnet"] = 0;
@@ -626,7 +624,7 @@ namespace Semmle.Autobuild.CSharp.Tests
             actions.CreateDirectories.Add(@"scratch/.dotnet");
 
             var autobuilder = CreateAutoBuilder(false, buildless: "true");
-            TestAutobuilderScript(autobuilder, 0, 5);
+            TestAutobuilderScript(autobuilder, 0, 4);
         }
 
         private void SkipVsWhere()

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp/CSharpAutobuilder.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp/CSharpAutobuilder.cs
@@ -53,7 +53,7 @@ namespace Semmle.Autobuild.CSharp
                     attempt = DotNetRule.WithDotNet(this, ensureDotNetAvailable: true, (dotNetPath, env) =>
                         {
                             // No need to check that the extractor has been executed in buildless mode
-                            return new StandaloneBuildRule(dotNetPath, env).Analyse(this, false);
+                            return new StandaloneBuildRule(dotNetPath).Analyse(this, false);
                         });
                     break;
                 case CSharpBuildStrategy.MSBuild:

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp/CSharpAutobuilder.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp/CSharpAutobuilder.cs
@@ -50,10 +50,10 @@ namespace Semmle.Autobuild.CSharp
                     attempt = new BuildCommandRule(DotNetRule.WithDotNet).Analyse(this, false) & CheckExtractorRun(true);
                     break;
                 case CSharpBuildStrategy.Buildless:
-                    attempt = DotNetRule.WithDotNet(this, (dotNetPath, env) =>
+                    attempt = DotNetRule.WithDotNet(this, ensureDotNetAvailable: true, (dotNetPath, env) =>
                         {
                             // No need to check that the extractor has been executed in buildless mode
-                            return new StandaloneBuildRule(dotNetPath).Analyse(this, false);
+                            return new StandaloneBuildRule(dotNetPath, env).Analyse(this, false);
                         });
                     break;
                 case CSharpBuildStrategy.MSBuild:

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp/Constants.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp/Constants.cs
@@ -1,0 +1,8 @@
+namespace Semmle.Autobuild.CSharp
+{
+    internal static class Constants
+    {
+        // The version number should be kept in sync with the version .NET version used for building the application.
+        public const string LatestDotNetSdkVersion = "8.0.101";
+    }
+}

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp/DotNetRule.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp/DotNetRule.cs
@@ -85,27 +85,23 @@ namespace Semmle.Autobuild.CSharp
             var installScript = DownloadDotNet(builder, installDir, ensureDotNetAvailable);
             return BuildScript.Bind(installScript, installed =>
             {
-                Dictionary<string, string>? env;
+                var env = new Dictionary<string, string>
+                {
+                    { "DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "true" },
+                    { "MSBUILDDISABLENODEREUSE", "1" }
+                };
                 if (installed == 0)
                 {
                     // The installation succeeded, so use the newly installed .NET Core
                     var path = builder.Actions.GetEnvironmentVariable("PATH");
                     var delim = builder.Actions.IsWindows() ? ";" : ":";
-                    env = new Dictionary<string, string>{
-                            { "DOTNET_MULTILEVEL_LOOKUP", "false" }, // prevent look up of other .NET Core SDKs
-                            { "DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "true" },
-                            { "MSBUILDDISABLENODEREUSE", "1" },
-                            { "PATH", installDir + delim + path }
-                        };
+                    env.Add("DOTNET_MULTILEVEL_LOOKUP", "false"); // prevent look up of other .NET Core SDKs
+                    env.Add("PATH", installDir + delim + path);
                 }
                 else
                 {
                     // The .NET SDK was not installed, either because the installation failed or because it was already installed.
                     installDir = null;
-                    env = new Dictionary<string, string> {
-                            { "DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "true" },
-                            { "MSBUILDDISABLENODEREUSE", "1" }
-                        };
                 }
 
                 return f(installDir, env);
@@ -163,8 +159,7 @@ namespace Semmle.Autobuild.CSharp
 
             if (ensureDotNetAvailable)
             {
-                const string latestDotNetSdkVersion = "8.0.101";
-                return DownloadDotNetVersion(builder, installDir, latestDotNetSdkVersion, needExactVersion: false);
+                return DownloadDotNetVersion(builder, installDir, Constants.LatestDotNetSdkVersion, needExactVersion: false);
             }
 
             return BuildScript.Failure;

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp/StandaloneBuildRule.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp/StandaloneBuildRule.cs
@@ -16,8 +16,7 @@ namespace Semmle.Autobuild.CSharp
 
         public BuildScript Analyse(IAutobuilder<CSharpAutobuildOptions> builder, bool auto)
         {
-            if (!builder.Options.Buildless
-                || builder.CodeQLExtractorLangRoot is null
+            if (builder.CodeQLExtractorLangRoot is null
                 || builder.CodeQlPlatform is null)
             {
                 return BuildScript.Failure;

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp/StandaloneBuildRule.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp/StandaloneBuildRule.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Semmle.Autobuild.Shared;
+﻿using Semmle.Autobuild.Shared;
 
 namespace Semmle.Autobuild.CSharp
 {

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp/StandaloneBuildRule.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp/StandaloneBuildRule.cs
@@ -9,12 +9,10 @@ namespace Semmle.Autobuild.CSharp
     internal class StandaloneBuildRule : IBuildRule<CSharpAutobuildOptions>
     {
         private readonly string? dotNetPath;
-        private readonly IDictionary<string, string>? env;
 
-        internal StandaloneBuildRule(string? dotNetPath, IDictionary<string, string>? env)
+        internal StandaloneBuildRule(string? dotNetPath)
         {
             this.dotNetPath = dotNetPath;
-            this.env = env;
         }
 
         public BuildScript Analyse(IAutobuilder<CSharpAutobuildOptions> builder, bool auto)
@@ -27,7 +25,7 @@ namespace Semmle.Autobuild.CSharp
             }
 
             var standalone = builder.Actions.PathCombine(builder.CodeQLExtractorLangRoot, "tools", builder.CodeQlPlatform, "Semmle.Extraction.CSharp.Standalone");
-            var cmd = new CommandBuilder(builder.Actions, environment: this.env);
+            var cmd = new CommandBuilder(builder.Actions);
             cmd.RunCommand(standalone);
 
             if (!string.IsNullOrEmpty(this.dotNetPath))


### PR DESCRIPTION
This PR extends the dotnet SDK downloading in buildless mode. If there's no `dotnet` CLI on the machine, it downloads the latest one as if that version was specified in the `global.json`. This way buildless extraction doesn't depend on `dotnet` being installed beforehand onto the machine.