### PR TITLE
Python: Add `.copy()` method call as copy step

### DIFF
--- a/python/ql/lib/semmle/python/dataflow/new/internal/TaintTrackingPrivate.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/TaintTrackingPrivate.qll
@@ -195,6 +195,8 @@ predicate copyStep(DataFlow::CfgNode nodeFrom, DataFlow::CfgNode nodeTo) {
     call = API::moduleImport("copy").getMember(["copy", "deepcopy"]).getACall() and
     call.getArg(0) = nodeFrom
   )
+  or
+  nodeTo.(DataFlow::MethodCallNode).calls(nodeFrom, "copy")
 }
 
 /**

--- a/python/ql/test/query-tests/Functions/ModificationOfParameterWithDefault/ModificationOfParameterWithDefault.expected
+++ b/python/ql/test/query-tests/Functions/ModificationOfParameterWithDefault/ModificationOfParameterWithDefault.expected
@@ -40,10 +40,6 @@ edges
 | test.py:195:28:195:28 | ControlFlowNode for x | test.py:181:28:181:28 | ControlFlowNode for x | provenance |  |
 | test.py:197:18:197:18 | ControlFlowNode for x | test.py:198:28:198:28 | ControlFlowNode for x | provenance |  |
 | test.py:198:28:198:28 | ControlFlowNode for x | test.py:181:28:181:28 | ControlFlowNode for x | provenance |  |
-| test.py:222:26:222:26 | ControlFlowNode for x | test.py:223:9:223:9 | ControlFlowNode for x | provenance |  |
-| test.py:223:5:223:5 | ControlFlowNode for y | test.py:224:5:224:5 | ControlFlowNode for y | provenance |  |
-| test.py:223:9:223:9 | ControlFlowNode for x | test.py:223:9:223:16 | ControlFlowNode for Attribute() | provenance |  |
-| test.py:223:9:223:16 | ControlFlowNode for Attribute() | test.py:223:5:223:5 | ControlFlowNode for y | provenance |  |
 nodes
 | test.py:2:12:2:12 | ControlFlowNode for l | semmle.label | ControlFlowNode for l |
 | test.py:3:5:3:5 | ControlFlowNode for l | semmle.label | ControlFlowNode for l |
@@ -111,11 +107,6 @@ nodes
 | test.py:195:28:195:28 | ControlFlowNode for x | semmle.label | ControlFlowNode for x |
 | test.py:197:18:197:18 | ControlFlowNode for x | semmle.label | ControlFlowNode for x |
 | test.py:198:28:198:28 | ControlFlowNode for x | semmle.label | ControlFlowNode for x |
-| test.py:222:26:222:26 | ControlFlowNode for x | semmle.label | ControlFlowNode for x |
-| test.py:223:5:223:5 | ControlFlowNode for y | semmle.label | ControlFlowNode for y |
-| test.py:223:9:223:9 | ControlFlowNode for x | semmle.label | ControlFlowNode for x |
-| test.py:223:9:223:16 | ControlFlowNode for Attribute() | semmle.label | ControlFlowNode for Attribute() |
-| test.py:224:5:224:5 | ControlFlowNode for y | semmle.label | ControlFlowNode for y |
 subpaths
 #select
 | test.py:3:5:3:5 | ControlFlowNode for l | test.py:2:12:2:12 | ControlFlowNode for l | test.py:3:5:3:5 | ControlFlowNode for l | This expression mutates a $@. | test.py:2:12:2:12 | ControlFlowNode for l | default value |
@@ -147,4 +138,3 @@ subpaths
 | test.py:185:9:185:9 | ControlFlowNode for x | test.py:197:18:197:18 | ControlFlowNode for x | test.py:185:9:185:9 | ControlFlowNode for x | This expression mutates a $@. | test.py:197:18:197:18 | ControlFlowNode for x | default value |
 | test.py:187:9:187:9 | ControlFlowNode for x | test.py:194:18:194:18 | ControlFlowNode for x | test.py:187:9:187:9 | ControlFlowNode for x | This expression mutates a $@. | test.py:194:18:194:18 | ControlFlowNode for x | default value |
 | test.py:187:9:187:9 | ControlFlowNode for x | test.py:197:18:197:18 | ControlFlowNode for x | test.py:187:9:187:9 | ControlFlowNode for x | This expression mutates a $@. | test.py:197:18:197:18 | ControlFlowNode for x | default value |
-| test.py:224:5:224:5 | ControlFlowNode for y | test.py:222:26:222:26 | ControlFlowNode for x | test.py:224:5:224:5 | ControlFlowNode for y | This expression mutates a $@. | test.py:222:26:222:26 | ControlFlowNode for x | default value |

--- a/python/ql/test/query-tests/Functions/ModificationOfParameterWithDefault/ModificationOfParameterWithDefault.expected
+++ b/python/ql/test/query-tests/Functions/ModificationOfParameterWithDefault/ModificationOfParameterWithDefault.expected
@@ -40,6 +40,10 @@ edges
 | test.py:195:28:195:28 | ControlFlowNode for x | test.py:181:28:181:28 | ControlFlowNode for x | provenance |  |
 | test.py:197:18:197:18 | ControlFlowNode for x | test.py:198:28:198:28 | ControlFlowNode for x | provenance |  |
 | test.py:198:28:198:28 | ControlFlowNode for x | test.py:181:28:181:28 | ControlFlowNode for x | provenance |  |
+| test.py:222:26:222:26 | ControlFlowNode for x | test.py:223:9:223:9 | ControlFlowNode for x | provenance |  |
+| test.py:223:5:223:5 | ControlFlowNode for y | test.py:224:5:224:5 | ControlFlowNode for y | provenance |  |
+| test.py:223:9:223:9 | ControlFlowNode for x | test.py:223:9:223:16 | ControlFlowNode for Attribute() | provenance |  |
+| test.py:223:9:223:16 | ControlFlowNode for Attribute() | test.py:223:5:223:5 | ControlFlowNode for y | provenance |  |
 nodes
 | test.py:2:12:2:12 | ControlFlowNode for l | semmle.label | ControlFlowNode for l |
 | test.py:3:5:3:5 | ControlFlowNode for l | semmle.label | ControlFlowNode for l |
@@ -107,6 +111,11 @@ nodes
 | test.py:195:28:195:28 | ControlFlowNode for x | semmle.label | ControlFlowNode for x |
 | test.py:197:18:197:18 | ControlFlowNode for x | semmle.label | ControlFlowNode for x |
 | test.py:198:28:198:28 | ControlFlowNode for x | semmle.label | ControlFlowNode for x |
+| test.py:222:26:222:26 | ControlFlowNode for x | semmle.label | ControlFlowNode for x |
+| test.py:223:5:223:5 | ControlFlowNode for y | semmle.label | ControlFlowNode for y |
+| test.py:223:9:223:9 | ControlFlowNode for x | semmle.label | ControlFlowNode for x |
+| test.py:223:9:223:16 | ControlFlowNode for Attribute() | semmle.label | ControlFlowNode for Attribute() |
+| test.py:224:5:224:5 | ControlFlowNode for y | semmle.label | ControlFlowNode for y |
 subpaths
 #select
 | test.py:3:5:3:5 | ControlFlowNode for l | test.py:2:12:2:12 | ControlFlowNode for l | test.py:3:5:3:5 | ControlFlowNode for l | This expression mutates a $@. | test.py:2:12:2:12 | ControlFlowNode for l | default value |
@@ -138,3 +147,4 @@ subpaths
 | test.py:185:9:185:9 | ControlFlowNode for x | test.py:197:18:197:18 | ControlFlowNode for x | test.py:185:9:185:9 | ControlFlowNode for x | This expression mutates a $@. | test.py:197:18:197:18 | ControlFlowNode for x | default value |
 | test.py:187:9:187:9 | ControlFlowNode for x | test.py:194:18:194:18 | ControlFlowNode for x | test.py:187:9:187:9 | ControlFlowNode for x | This expression mutates a $@. | test.py:194:18:194:18 | ControlFlowNode for x | default value |
 | test.py:187:9:187:9 | ControlFlowNode for x | test.py:197:18:197:18 | ControlFlowNode for x | test.py:187:9:187:9 | ControlFlowNode for x | This expression mutates a $@. | test.py:197:18:197:18 | ControlFlowNode for x | default value |
+| test.py:224:5:224:5 | ControlFlowNode for y | test.py:222:26:222:26 | ControlFlowNode for x | test.py:224:5:224:5 | ControlFlowNode for y | This expression mutates a $@. | test.py:222:26:222:26 | ControlFlowNode for x | default value |

--- a/python/ql/test/query-tests/Functions/ModificationOfParameterWithDefault/test.py
+++ b/python/ql/test/query-tests/Functions/ModificationOfParameterWithDefault/test.py
@@ -221,4 +221,4 @@ def flow_through_deepcopy_fp(x=[]):
 
 def flow_through_copy_fp(x=[]):
     y = x.copy()
-    y.append(1) #$ SPURIOUS: modification=y
+    y.append(1)

--- a/python/ql/test/query-tests/Functions/ModificationOfParameterWithDefault/test.py
+++ b/python/ql/test/query-tests/Functions/ModificationOfParameterWithDefault/test.py
@@ -216,3 +216,9 @@ def flow_from_within_deepcopy_fp():
 def flow_through_deepcopy_fp(x=[]):
     y = deepcopy(x)
     y.append(1)
+
+# Use of copy method:
+
+def flow_through_copy_fp(x=[]):
+    y = x.copy()
+    y.append(1) #$ SPURIOUS: modification=y


### PR DESCRIPTION
This should fix the issue reported by @alex-slynko.

I think it's reasonable to just add these calls as copy steps in general. 

---

Does this warrant a change note? I opted not to add one, but I'm happy to add one if needed.