### PR TITLE
Swift: Workaround for TypeDecl.getFullName issue.

### DIFF
--- a/swift/ql/lib/change-notes/2024-02-22-extension-patch.md
+++ b/swift/ql/lib/change-notes/2024-02-22-extension-patch.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* Fixed an issue where `TypeDecl.getFullName` would get stuck in an loop and fail when minor database inconsistencies are present.

--- a/swift/ql/lib/codeql/swift/elements/decl/ExtensionDecl.qll
+++ b/swift/ql/lib/codeql/swift/elements/decl/ExtensionDecl.qll
@@ -2,9 +2,10 @@ private import codeql.swift.generated.decl.ExtensionDecl
 
 class ExtensionDecl extends Generated::ExtensionDecl {
   override string toString() {
-    result = "extension of " + this.getExtendedTypeDecl().toString()
+    result =
+      "extension of " + unique(NominalTypeDecl td | td = this.getExtendedTypeDecl()).toString()
     or
-    not exists(this.getExtendedTypeDecl()) and
+    count(this.getExtendedTypeDecl()) != 1 and
     result = "extension"
   }
 }

--- a/swift/ql/lib/codeql/swift/elements/decl/TypeDecl.qll
+++ b/swift/ql/lib/codeql/swift/elements/decl/TypeDecl.qll
@@ -109,13 +109,13 @@ class TypeDecl extends Generated::TypeDecl {
   cached
   string getFullName() {
     not this.getEnclosingDecl() instanceof TypeDecl and
-    not this.getEnclosingDecl() instanceof ExtensionDecl and
+    not count(this.getEnclosingDecl().(ExtensionDecl).getExtendedTypeDecl()) = 1 and
     result = this.getName()
     or
     result = this.getEnclosingDecl().(TypeDecl).getFullName() + "." + this.getName()
     or
     result =
-      this.getEnclosingDecl().(ExtensionDecl).getExtendedTypeDecl().getFullName() + "." +
-        this.getName()
+      unique(NominalTypeDecl td | td = this.getEnclosingDecl().(ExtensionDecl).getExtendedTypeDecl())
+            .getFullName() + "." + this.getName()
   }
 }


### PR DESCRIPTION
Workaround for an issue where databases can contain `ExtensionDecl`s that extend multiple `TypeDecl`s (i.e. a database inconsistency), ultimately sometimes forming an infinite loop in `TypeDecl.getFullName`.  This fix makes the QL more robust, allowing evaluation to complete, though the database inconsistencies are still present.