### PR TITLE
Shared: Fill some QLDoc holes

### DIFF
--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -206,7 +206,9 @@ signature module InputSig {
   predicate parameterMatch(ParameterPosition ppos, ArgumentPosition apos);
 
   /**
-   * Holds if there is a simple local flow step from `node1` to `node2`.
+   * Holds if there is a simple local flow step from `node1` to `node2`. This
+   * is the local flow predicate that's used as a building block in global
+   * data flow. It may have less flow than the `localFlowStep` predicate.
    */
   predicate simpleLocalFlowStep(Node node1, Node node2);
 

--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -50,9 +50,8 @@ signature module InputSig {
    */
   class PostUpdateNode extends Node {
     /**
-     * Gets the node that represents the same value prior to the operation.
-     *
-     * @return The pre-update node.
+     * Gets the pre-update node, that is, the node that represents the same
+     * value prior to the operation.
      */
     Node getPreUpdateNode();
   }
@@ -153,9 +152,7 @@ signature module InputSig {
   }
 
   /**
-   * Holds if high precision should be used for the given content.
-   *
-   * @param c The content to force high precision for.
+   * Holds if high precision should be used for the content `c`.
    */
   predicate forceHighPrecision(Content c);
 
@@ -199,16 +196,13 @@ signature module InputSig {
   }
 
   /**
-   * Holds if the given parameter position matches the argument position.
-   *
-   * @param ppos The parameter position.
+   * Holds if the parameter position `ppos` matches the argument position
+   * `apos`.
    */
   predicate parameterMatch(ParameterPosition ppos, ArgumentPosition apos);
 
   /**
-   * Holds if there is a simple local flow step between two nodes.
-   *
-   * @param node1 The first node in the flow step.
+   * Holds if there is a simple local flow step from `node1` to `node2`.
    */
   predicate simpleLocalFlowStep(Node node1, Node node2);
 

--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -153,7 +153,10 @@ signature module InputSig {
   }
 
   /**
-   * Holds if high precision should be used for the content `c`.
+   * Holds if access paths with `c` at their head always should be tracked at
+   * high precision. This disables adaptive access path precision for such
+   * access paths. This may be beneficial for content that indicates an
+   * element of an array or container.
    */
   predicate forceHighPrecision(Content c);
 

--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -40,7 +40,8 @@ signature module InputSig {
 
   /**
    * A node in the data flow graph representing the value of an argument after
-   * an operation that might have changed its state. For example, consider the following C++ code:
+   * an operation that might have changed its state. For example, consider the
+   * following C++ code:
    * ```
    * int a = 1;
    * increment(&a);

--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -40,7 +40,7 @@ signature module InputSig {
 
   /**
    * A node in the data flow graph representing the value of an argument after
-   * a function call returns. For example, consider the following C++ code:
+   * an operation that might have changed its state. For example, consider the following C++ code:
    * ```
    * int a = 1;
    * increment(&a);

--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -178,13 +178,18 @@ signature module InputSig {
   }
 
   /**
-   * A content approximation.
+   * A content approximation. A content approximation corresponds with one or
+   * more `Content`s, and is used to provide an in-between level of precision
+   * for pruning.
    */
   class ContentApprox {
     /** Gets a textual representation of this element. */
     string toString();
   }
 
+  /**
+   * Gets the content approximation for content `c`.
+   */
   ContentApprox getContentApprox(Content c);
 
   class ParameterPosition {

--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -178,7 +178,7 @@ signature module InputSig {
   }
 
   /**
-   * A content approximation. A content approximation corresponds with one or
+   * A content approximation. A content approximation corresponds to one or
    * more `Content`s, and is used to provide an in-between level of precision
    * for pruning.
    */

--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -7,7 +7,7 @@
 /** Provides language-specific data flow parameters. */
 signature module InputSig {
   /**
-   * Represents a node in the data flow graph.
+   * A node in the data flow graph.
    */
   class Node {
     /** Gets a textual representation of this element. */
@@ -34,16 +34,23 @@ signature module InputSig {
   }
 
   /**
-   * Represents a node in the data flow graph that represents an output.
+   * A node in the data flow graph that represents an output.
    */
   class OutNode extends Node;
 
   /**
-   * Represents a node in the data flow graph that corresponds to a post-update operation.
+   * A node in the data flow graph representing the value of an argument after
+   * a function call returns. For example, consider the following C++ code:
+   * ```
+   * int a = 1;
+   * increment(&a);
+   * ```
+   * The post-update node for `&a` represents the value of `&a` after
+   * modification by the call to `increment`.
    */
   class PostUpdateNode extends Node {
     /**
-     * Gets the node that represents the pre-update operation.
+     * Gets the node that represents the same value prior to the operation.
      *
      * @return The pre-update node.
      */
@@ -170,7 +177,7 @@ signature module InputSig {
   }
 
   /**
-   * Represents a content approximation.
+   * A content approximation.
    */
   class ContentApprox {
     /** Gets a textual representation of this element. */

--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -34,20 +34,20 @@ signature module InputSig {
   }
 
   /**
-   * A node in the data flow graph that represents an output.
+   * A node in the data flow graph that represents an output of a call.
    */
   class OutNode extends Node;
 
   /**
-   * A node in the data flow graph representing the value of an argument after
-   * an operation that might have changed its state. For example, consider the
-   * following C++ code:
+   * A node in the data flow graph representing the value of some other node
+   * after an operation that might have changed its state. A typical example is
+   * an argument, which may have been modified by the callee. For example,
+   * consider the following code calling a setter method:
    * ```
-   * int a = 1;
-   * increment(&a);
+   * x.setFoo(y);
    * ```
-   * The post-update node for `&a` represents the value of `&a` after
-   * modification by the call to `increment`.
+   * The post-update node for the argument node `x` is the node representing the
+   * value of `x` after the field `foo` has been updated.
    */
   class PostUpdateNode extends Node {
     /**
@@ -206,9 +206,8 @@ signature module InputSig {
   predicate parameterMatch(ParameterPosition ppos, ArgumentPosition apos);
 
   /**
-   * Holds if there is a simple local flow step from `node1` to `node2`. This
-   * is the local flow predicate that's used as a building block in global
-   * data flow. It may have less flow than the `localFlowStep` predicate.
+   * Holds if there is a simple local flow step from `node1` to `node2`. These
+   * are the value-preserving intra-callable flow steps.
    */
   predicate simpleLocalFlowStep(Node node1, Node node2);
 

--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -6,21 +6,24 @@
 
 /** Provides language-specific data flow parameters. */
 signature module InputSig {
-  class Node {
-    /** Gets a textual representation of this element. */
-    string toString();
-
-    /**
-     * Holds if this element is at the specified location.
-     * The location spans column `startcolumn` of line `startline` to
-     * column `endcolumn` of line `endline` in file `filepath`.
-     * For more information, see
-     * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
+  /**
+     * Represents a node in the data flow graph.
      */
-    predicate hasLocationInfo(
-      string filepath, int startline, int startcolumn, int endline, int endcolumn
-    );
-  }
+    class Node {
+      /** Gets a textual representation of this element. */
+      string toString();
+
+      /**
+       * Holds if this element is at the specified location.
+       * The location spans column `startcolumn` of line `startline` to
+       * column `endcolumn` of line `endline` in file `filepath`.
+       * For more information, see
+       * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
+       */
+      predicate hasLocationInfo(
+        string filepath, int startline, int startcolumn, int endline, int endcolumn
+      );
+    }
 
   class ParameterNode extends Node;
 
@@ -30,9 +33,19 @@ signature module InputSig {
     ReturnKind getKind();
   }
 
+  /**
+   * Represents a node in the data flow graph that represents an output.
+   */
   class OutNode extends Node;
 
+  /**
+   * Represents a node in the data flow graph that corresponds to a post-update operation.
+   */
   class PostUpdateNode extends Node {
+    /**
+     * Retrieves the node that represents the pre-update operation.
+     * @return The pre-update node.
+     */
     Node getPreUpdateNode();
   }
 
@@ -131,6 +144,12 @@ signature module InputSig {
     string toString();
   }
 
+  /**
+   * Predicate to force high precision for the given content.
+   *
+   * @param c The content to force high precision for.
+   * @return True if high precision is forced for the content, false otherwise.
+   */
   predicate forceHighPrecision(Content c);
 
   /**
@@ -150,10 +169,16 @@ signature module InputSig {
     Content getAReadContent();
   }
 
-  class ContentApprox {
-    /** Gets a textual representation of this element. */
-    string toString();
-  }
+  /**
+     * Represents a content approximation.
+     */
+    class ContentApprox {
+      /** 
+       * Gets a textual representation of this element.
+       * @return The textual representation of this element.
+       */
+      string toString();
+    }
 
   ContentApprox getContentApprox(Content c);
 
@@ -169,8 +194,22 @@ signature module InputSig {
     string toString();
   }
 
+  /**
+   * Checks if the given parameter position matches the argument position.
+   *
+   * @param ppos The parameter position.
+   * @param apos The argument position.
+   * @return True if the parameter position matches the argument position, false otherwise.
+   */
   predicate parameterMatch(ParameterPosition ppos, ArgumentPosition apos);
 
+  /**
+   * Represents a simple local flow step between two nodes.
+   *
+   * @param node1 The first node in the flow step.
+   * @param node2 The second node in the flow step.
+   * @return True if there is a simple local flow step between node1 and node2, false otherwise.
+   */
   predicate simpleLocalFlowStep(Node node1, Node node2);
 
   /**

--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -43,7 +43,7 @@ signature module InputSig {
    */
   class PostUpdateNode extends Node {
     /**
-     * Retrieves the node that represents the pre-update operation.
+     * Gets the node that represents the pre-update operation.
      * @return The pre-update node.
      */
     Node getPreUpdateNode();
@@ -145,7 +145,7 @@ signature module InputSig {
   }
 
   /**
-   * Predicate to force high precision for the given content.
+   * Holds if high precision should be used for the given content.
    *
    * @param c The content to force high precision for.
    */
@@ -191,7 +191,7 @@ signature module InputSig {
   }
 
   /**
-   * Checks if the given parameter position matches the argument position.
+   * Holds if the given parameter position matches the argument position.
    *
    * @param ppos The parameter position.
    * @param apos The argument position.
@@ -199,7 +199,7 @@ signature module InputSig {
   predicate parameterMatch(ParameterPosition ppos, ArgumentPosition apos);
 
   /**
-   * Represents a simple local flow step between two nodes.
+   * Holds if there is a simple local flow step between two nodes.
    *
    * @param node1 The first node in the flow step.
    * @param node2 The second node in the flow step.

--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -148,7 +148,6 @@ signature module InputSig {
    * Predicate to force high precision for the given content.
    *
    * @param c The content to force high precision for.
-   * @return True if high precision is forced for the content, false otherwise.
    */
   predicate forceHighPrecision(Content c);
 
@@ -196,7 +195,6 @@ signature module InputSig {
    *
    * @param ppos The parameter position.
    * @param apos The argument position.
-   * @return True if the parameter position matches the argument position, false otherwise.
    */
   predicate parameterMatch(ParameterPosition ppos, ArgumentPosition apos);
 
@@ -205,7 +203,6 @@ signature module InputSig {
    *
    * @param node1 The first node in the flow step.
    * @param node2 The second node in the flow step.
-   * @return True if there is a simple local flow step between node1 and node2, false otherwise.
    */
   predicate simpleLocalFlowStep(Node node1, Node node2);
 

--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -9,21 +9,21 @@ signature module InputSig {
   /**
      * Represents a node in the data flow graph.
      */
-    class Node {
-      /** Gets a textual representation of this element. */
-      string toString();
+  class Node {
+    /** Gets a textual representation of this element. */
+    string toString();
 
-      /**
-       * Holds if this element is at the specified location.
-       * The location spans column `startcolumn` of line `startline` to
-       * column `endcolumn` of line `endline` in file `filepath`.
-       * For more information, see
-       * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
-       */
-      predicate hasLocationInfo(
-        string filepath, int startline, int startcolumn, int endline, int endcolumn
-      );
-    }
+    /**
+     * Holds if this element is at the specified location.
+     * The location spans column `startcolumn` of line `startline` to
+     * column `endcolumn` of line `endline` in file `filepath`.
+     * For more information, see
+     * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
+     */
+    predicate hasLocationInfo(
+      string filepath, int startline, int startcolumn, int endline, int endcolumn
+    );
+  }
 
   class ParameterNode extends Node;
 
@@ -172,13 +172,10 @@ signature module InputSig {
   /**
      * Represents a content approximation.
      */
-    class ContentApprox {
-      /** 
-       * Gets a textual representation of this element.
-       * @return The textual representation of this element.
-       */
-      string toString();
-    }
+  class ContentApprox {
+    /** Gets a textual representation of this element. */
+    string toString();
+  }
 
   ContentApprox getContentApprox(Content c);
 

--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -7,8 +7,8 @@
 /** Provides language-specific data flow parameters. */
 signature module InputSig {
   /**
-     * Represents a node in the data flow graph.
-     */
+   * Represents a node in the data flow graph.
+   */
   class Node {
     /** Gets a textual representation of this element. */
     string toString();
@@ -44,6 +44,7 @@ signature module InputSig {
   class PostUpdateNode extends Node {
     /**
      * Gets the node that represents the pre-update operation.
+     *
      * @return The pre-update node.
      */
     Node getPreUpdateNode();
@@ -169,8 +170,8 @@ signature module InputSig {
   }
 
   /**
-     * Represents a content approximation.
-     */
+   * Represents a content approximation.
+   */
   class ContentApprox {
     /** Gets a textual representation of this element. */
     string toString();
@@ -194,7 +195,6 @@ signature module InputSig {
    * Holds if the given parameter position matches the argument position.
    *
    * @param ppos The parameter position.
-   * @param apos The argument position.
    */
   predicate parameterMatch(ParameterPosition ppos, ArgumentPosition apos);
 
@@ -202,7 +202,6 @@ signature module InputSig {
    * Holds if there is a simple local flow step between two nodes.
    *
    * @param node1 The first node in the flow step.
-   * @param node2 The second node in the flow step.
    */
   predicate simpleLocalFlowStep(Node node1, Node node2);
 

--- a/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
+++ b/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
@@ -189,6 +189,8 @@ signature module Semantic {
      *   Console.WriteLine("x is greater than y");
      * }
      * ```
+     * `branch` indicates whether the basic block is entered when the guard
+     * evaluates to `true` or when it evaluates to `false`.
      */
     predicate directlyControls(BasicBlock controlled, boolean branch);
 
@@ -211,6 +213,8 @@ signature module Semantic {
      *   printf("x is not greater than y\n");
      * }
      * ```
+     * `branch` indicates whether the second basic block is the one entered
+     * when the guard evaluates to `true` or when it evaluates to `false`.
      */
     predicate hasBranchEdge(BasicBlock bb1, BasicBlock bb2, boolean branch);
   }

--- a/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
+++ b/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
@@ -393,7 +393,10 @@ signature module BoundSig<LocationSig Location, Semantic Sem, DeltaSig D> {
     Location getLocation();
 
     /**
-     * Gets the expression associated with the semantic bound, given a delta.
+     * Gets an expression that equals this bound plus `delta`.
+     *
+     * For the zero-bound this gets integer constants equal to `delta`, and for
+     * other bounds this gets expressions equal to the bound while `delta = 0`.
      */
     Sem::Expr getExpr(D::Delta delta);
   }

--- a/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
+++ b/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
@@ -189,8 +189,6 @@ signature module Semantic {
      *   Console.WriteLine("x is greater than y");
      * }
      * ```
-     *
-     * @param controlled The basic block to check.
      */
     predicate directlyControls(BasicBlock controlled, boolean branch);
 
@@ -213,8 +211,6 @@ signature module Semantic {
      *   printf("x is not greater than y\n");
      * }
      * ```
-     *
-     * @param bb1 The first basic block.
      */
     predicate hasBranchEdge(BasicBlock bb1, BasicBlock bb2, boolean branch);
   }
@@ -280,9 +276,8 @@ signature module Semantic {
    */
   class SsaExplicitUpdate extends SsaVariable {
     /**
-     * Gets the expression that defines the value of the variable in this update.
-     *
-     * @return The defining expression.
+     * Gets the expression that defines the value of the variable in this
+     * update.
      */
     Expr getDefiningExpr();
   }
@@ -391,8 +386,6 @@ signature module BoundSig<LocationSig Location, Semantic Sem, DeltaSig D> {
 
     /**
      * Gets the expression associated with the semantic bound, given a delta.
-     *
-     * @param delta - The delta value.
      */
     Sem::Expr getExpr(D::Delta delta);
   }

--- a/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
+++ b/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
@@ -257,7 +257,18 @@ signature module Semantic {
   /**
    * A phi node in the SSA form. A phi node is a kind of node in the SSA form
    * that represents a merge point where multiple control flow paths converge
-   * and the value of a variable needs to be selected.
+   * and the value of a variable needs to be selected according to which
+   * control flow path was taken. For example, in the following Ruby code:
+   * ```rb
+   * if b
+   *   x = 0
+   * else
+   *   x = 1
+   * end
+   * puts x
+   * ```
+   * A phi node for `x` is inserted just before the call `puts x`, since the
+   * value of `x` may come from either `x = 0` or `x = 1`.
    */
   class SsaPhiNode extends SsaVariable {
     /** Holds if `inp` is an input to the phi node along the edge originating in `bb`. */

--- a/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
+++ b/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
@@ -175,7 +175,7 @@ signature module Semantic {
     BasicBlock getBasicBlock();
 
     /**
-     * Gets the guard as an expression.
+     * Gets the guard as an expression, if any.
      */
     Expr asExpr();
 
@@ -240,11 +240,11 @@ signature module Semantic {
   Type getExprType(Expr e);
 
   /**
-   * A single static single assignment (SSA) variable.
+   * A static single-assignment (SSA) variable.
    */
   class SsaVariable {
     /**
-     * Gets the expression where this SSA variable is used.
+     * Gets an expression reading the value of this SSA variable.
      */
     Expr getAUse();
 

--- a/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
+++ b/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
@@ -276,7 +276,7 @@ signature module Semantic {
   }
 
   /**
-   * A single update to a variable in the SSA form.
+   * An SSA variable representing the value of an explicit update of the source variable.
    */
   class SsaExplicitUpdate extends SsaVariable {
     /**
@@ -374,17 +374,21 @@ signature module LangSig<Semantic Sem, DeltaSig D> {
 
 signature module BoundSig<LocationSig Location, Semantic Sem, DeltaSig D> {
   /**
-   * A semantic bound, which defines a constraint on the possible values of an
-   * expression.
+   * A bound that the range analysis can infer for a variable. This includes
+   * constant bounds represented by the abstract value zero, SSA bounds for when
+   * a variable is bounded by the value of a different variable, and possibly
+   * other abstract values that may be useful variable bounds. Since all bounds
+   * are combined with an integer delta there's no need to represent constant
+   * bounds other than zero.
    */
   class SemBound {
     /**
-     * Gets a string representation of the semantic bound.
+     * Gets a string representation of this bound.
      */
     string toString();
 
     /**
-     * Gets the location of the semantic bound.
+     * Gets the location of this bound.
      */
     Location getLocation();
 

--- a/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
+++ b/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
@@ -195,9 +195,9 @@ signature module Semantic {
     predicate directlyControls(BasicBlock controlled, boolean branch);
 
     /**
-     * Holds if the guard represents an equality between two expressions.
-     *
-     * @param e1 The first expression.
+     * Holds if this guard is an equality test between `e1` and `e2`. If the
+     * test is negated, that is `!=`, then `polarity` is false, otherwise
+     * `polarity` is true.
      */
     predicate isEquality(Expr e1, Expr e2, boolean polarity);
 

--- a/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
+++ b/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
@@ -393,12 +393,11 @@ signature module BoundSig<LocationSig Location, Semantic Sem, DeltaSig D> {
     Location getLocation();
 
     /**
-     * Gets an expression that equals this bound plus `delta`. For example given
-     * the expression `x = foo() + 1` the variable `x` has a bound with
-     * expression `call to foo()` and delta `-1`.
+     * Gets an expression that equals this bound plus `delta`.
      *
-     * For the zero-bound this gets integer constants equal to `delta`, and for
-     * other bounds this gets expressions equal to the bound while `delta = 0`.
+     * For the zero-bound this gets integer constants equal to `delta`, for any
+     * value `delta`. For other bounds this gets expressions equal to the bound
+     * and `delta = 0`.
      */
     Sem::Expr getExpr(D::Delta delta);
   }

--- a/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
+++ b/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
@@ -393,7 +393,9 @@ signature module BoundSig<LocationSig Location, Semantic Sem, DeltaSig D> {
     Location getLocation();
 
     /**
-     * Gets an expression that equals this bound plus `delta`.
+     * Gets an expression that equals this bound plus `delta`. For example given
+     * the expression `x = foo() + 1` the variable `x` has a bound with
+     * expression `call to foo()` and delta `-1`.
      *
      * For the zero-bound this gets integer constants equal to `delta`, and for
      * other bounds this gets expressions equal to the bound while `delta = 0`.

--- a/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
+++ b/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
@@ -161,7 +161,7 @@ signature module Semantic {
   default string getBlockId2(BasicBlock bb) { result = "" }
 
   /**
-   * Represents a guard in the range analysis.
+   * A guard in the range analysis.
    */
   class Guard {
     /**
@@ -180,7 +180,15 @@ signature module Semantic {
     Expr asExpr();
 
     /**
-     * Holds if the guard directly controls a given basic block.
+     * Holds if the guard directly controls a given basic block. For example in
+     * the following code, the guard `(x > y)` directly controls the block
+     * beneath it:
+     * ```
+     * if (x > y)
+     * {
+     *   Console.WriteLine("x is greater than y");
+     * }
+     * ```
      *
      * @param controlled The basic block to check.
      */
@@ -194,7 +202,17 @@ signature module Semantic {
     predicate isEquality(Expr e1, Expr e2, boolean polarity);
 
     /**
-     * Holds if there is a branch edge between two basic blocks.
+     * Holds if there is a branch edge between two basic blocks. For example
+     * in the following C code, there are two branch edges from the basic block
+     * containing the condition `(x > y)` to the beginnings of the true and
+     * false blocks that follow:
+     * ```
+     * if (x > y) {
+     *   printf("x is greater than y\n");
+     * } else {
+     *   printf("x is not greater than y\n");
+     * }
+     * ```
      *
      * @param bb1 The first basic block.
      */
@@ -222,7 +240,7 @@ signature module Semantic {
   Type getExprType(Expr e);
 
   /**
-   * Represents a single static single assignment (SSA) variable.
+   * A single static single assignment (SSA) variable.
    */
   class SsaVariable {
     /**
@@ -237,7 +255,9 @@ signature module Semantic {
   }
 
   /**
-   * Represents a phi node in the SSA form.
+   * A phi node in the SSA form. A phi node is a kind of node in the SSA form
+   * that represents a merge point where multiple control flow paths converge
+   * and the value of a variable needs to be selected.
    */
   class SsaPhiNode extends SsaVariable {
     /** Holds if `inp` is an input to the phi node along the edge originating in `bb`. */
@@ -245,7 +265,7 @@ signature module Semantic {
   }
 
   /**
-   * Represents a single update to a variable in the SSA form.
+   * A single update to a variable in the SSA form.
    */
   class SsaExplicitUpdate extends SsaVariable {
     /**
@@ -344,7 +364,8 @@ signature module LangSig<Semantic Sem, DeltaSig D> {
 
 signature module BoundSig<LocationSig Location, Semantic Sem, DeltaSig D> {
   /**
-   * Represents a semantic bound.
+   * A semantic bound, which defines a constraint on the possible values of an
+   * expression.
    */
   class SemBound {
     /**

--- a/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
+++ b/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
@@ -183,7 +183,6 @@ signature module Semantic {
      * Checks if the guard directly controls a given basic block.
      * @param controlled The basic block to check.
      * @param branch Indicates if the control is a branch or not.
-     * @returns True if the guard directly controls the basic block, false otherwise.
      */
     predicate directlyControls(BasicBlock controlled, boolean branch);
 
@@ -192,7 +191,6 @@ signature module Semantic {
      * @param e1 The first expression.
      * @param e2 The second expression.
      * @param polarity The polarity of the equality.
-     * @returns True if the guard represents the equality, false otherwise.
      */
     predicate isEquality(Expr e1, Expr e2, boolean polarity);
 
@@ -201,7 +199,6 @@ signature module Semantic {
      * @param bb1 The first basic block.
      * @param bb2 The second basic block.
      * @param branch Indicates if the edge is a branch or not.
-     * @returns True if there is a branch edge between the basic blocks, false otherwise.
      */
     predicate hasBranchEdge(BasicBlock bb1, BasicBlock bb2, boolean branch);
   }

--- a/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
+++ b/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
@@ -245,12 +245,7 @@ signature module Semantic {
    * Represents a phi node in the SSA form.
    */
   class SsaPhiNode extends SsaVariable {
-    /**
-     * Holds if `inp` is an input to the phi node along the edge originating in `bb`.
-     * @param inp The input variable.
-     * @param bb The basic block.
-     * @return True if `inp` is an input to the phi node along the edge originating in `bb`, false otherwise.
-     */
+    /** Holds if `inp` is an input to the phi node along the edge originating in `bb`. */
     predicate hasInputFromBlock(SsaVariable inp, BasicBlock bb);
   }
 

--- a/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
+++ b/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
@@ -165,29 +165,29 @@ signature module Semantic {
    */
   class Guard {
     /**
-     * Returns a string representation of the guard.
+     * Gets a string representation of the guard.
      */
     string toString();
 
     /**
-     * Returns the basic block associated with the guard.
+     * Gets the basic block associated with the guard.
      */
     BasicBlock getBasicBlock();
 
     /**
-     * Returns the guard as an expression.
+     * Gets the guard as an expression.
      */
     Expr asExpr();
 
     /**
-     * Checks if the guard directly controls a given basic block.
+     * Holds if the guard directly controls a given basic block.
      * @param controlled The basic block to check.
      * @param branch Indicates if the control is a branch or not.
      */
     predicate directlyControls(BasicBlock controlled, boolean branch);
 
     /**
-     * Checks if the guard represents an equality between two expressions.
+     * Holds if the guard represents an equality between two expressions.
      * @param e1 The first expression.
      * @param e2 The second expression.
      * @param polarity The polarity of the equality.
@@ -195,7 +195,7 @@ signature module Semantic {
     predicate isEquality(Expr e1, Expr e2, boolean polarity);
 
     /**
-     * Checks if there is a branch edge between two basic blocks.
+     * Holds if there is a branch edge between two basic blocks.
      * @param bb1 The first basic block.
      * @param bb2 The second basic block.
      * @param branch Indicates if the edge is a branch or not.
@@ -228,12 +228,12 @@ signature module Semantic {
    */
   class SsaVariable {
     /**
-     * Returns the expression where this SSA variable is used.
+     * Gets the expression where this SSA variable is used.
      */
     Expr getAUse();
 
     /**
-     * Returns the basic block where this SSA variable is defined.
+     * Gets the basic block where this SSA variable is defined.
      */
     BasicBlock getBasicBlock();
   }
@@ -251,7 +251,7 @@ signature module Semantic {
    */
   class SsaExplicitUpdate extends SsaVariable {
     /**
-     * Retrieves the expression that defines the value of the variable in this update.
+     * Gets the expression that defines the value of the variable in this update.
      *
      * @return The defining expression.
      */
@@ -350,17 +350,17 @@ signature module BoundSig<LocationSig Location, Semantic Sem, DeltaSig D> {
    */
   class SemBound {
     /**
-     * Returns a string representation of the semantic bound.
+     * Gets a string representation of the semantic bound.
      */
     string toString();
 
     /**
-     * Returns the location of the semantic bound.
+     * Gets the location of the semantic bound.
      */
     Location getLocation();
 
     /**
-     * Returns the expression associated with the semantic bound, given a delta.
+     * Gets the expression associated with the semantic bound, given a delta.
      * @param delta - The delta value.
      */
     Sem::Expr getExpr(D::Delta delta);

--- a/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
+++ b/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
@@ -181,24 +181,22 @@ signature module Semantic {
 
     /**
      * Holds if the guard directly controls a given basic block.
+     *
      * @param controlled The basic block to check.
-     * @param branch Indicates if the control is a branch or not.
      */
     predicate directlyControls(BasicBlock controlled, boolean branch);
 
     /**
      * Holds if the guard represents an equality between two expressions.
+     *
      * @param e1 The first expression.
-     * @param e2 The second expression.
-     * @param polarity The polarity of the equality.
      */
     predicate isEquality(Expr e1, Expr e2, boolean polarity);
 
     /**
      * Holds if there is a branch edge between two basic blocks.
+     *
      * @param bb1 The first basic block.
-     * @param bb2 The second basic block.
-     * @param branch Indicates if the edge is a branch or not.
      */
     predicate hasBranchEdge(BasicBlock bb1, BasicBlock bb2, boolean branch);
   }
@@ -361,6 +359,7 @@ signature module BoundSig<LocationSig Location, Semantic Sem, DeltaSig D> {
 
     /**
      * Gets the expression associated with the semantic bound, given a delta.
+     *
      * @param delta - The delta value.
      */
     Sem::Expr getExpr(D::Delta delta);

--- a/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
+++ b/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
@@ -160,17 +160,49 @@ signature module Semantic {
   /** Gets a tiebreaker id in case `getBlockId1` is not unique. */
   default string getBlockId2(BasicBlock bb) { result = "" }
 
+  /**
+   * Represents a guard in the range analysis.
+   */
   class Guard {
+    /**
+     * Returns a string representation of the guard.
+     */
     string toString();
 
+    /**
+     * Returns the basic block associated with the guard.
+     */
     BasicBlock getBasicBlock();
 
+    /**
+     * Returns the guard as an expression.
+     */
     Expr asExpr();
 
+    /**
+     * Checks if the guard directly controls a given basic block.
+     * @param controlled The basic block to check.
+     * @param branch Indicates if the control is a branch or not.
+     * @returns True if the guard directly controls the basic block, false otherwise.
+     */
     predicate directlyControls(BasicBlock controlled, boolean branch);
 
+    /**
+     * Checks if the guard represents an equality between two expressions.
+     * @param e1 The first expression.
+     * @param e2 The second expression.
+     * @param polarity The polarity of the equality.
+     * @returns True if the guard represents the equality, false otherwise.
+     */
     predicate isEquality(Expr e1, Expr e2, boolean polarity);
 
+    /**
+     * Checks if there is a branch edge between two basic blocks.
+     * @param bb1 The first basic block.
+     * @param bb2 The second basic block.
+     * @param branch Indicates if the edge is a branch or not.
+     * @returns True if there is a branch edge between the basic blocks, false otherwise.
+     */
     predicate hasBranchEdge(BasicBlock bb1, BasicBlock bb2, boolean branch);
   }
 
@@ -194,18 +226,43 @@ signature module Semantic {
   /** Gets the type of an expression. */
   Type getExprType(Expr e);
 
+  /**
+   * Represents a single static single assignment (SSA) variable.
+   */
   class SsaVariable {
+    /**
+     * Returns the expression where this SSA variable is used.
+     */
     Expr getAUse();
 
+    /**
+     * Returns the basic block where this SSA variable is defined.
+     */
     BasicBlock getBasicBlock();
   }
 
+  /**
+   * Represents a phi node in the SSA form.
+   */
   class SsaPhiNode extends SsaVariable {
-    /** Holds if `inp` is an input to the phi node along the edge originating in `bb`. */
+    /**
+     * Holds if `inp` is an input to the phi node along the edge originating in `bb`.
+     * @param inp The input variable.
+     * @param bb The basic block.
+     * @return True if `inp` is an input to the phi node along the edge originating in `bb`, false otherwise.
+     */
     predicate hasInputFromBlock(SsaVariable inp, BasicBlock bb);
   }
 
+  /**
+   * Represents a single update to a variable in the SSA form.
+   */
   class SsaExplicitUpdate extends SsaVariable {
+    /**
+     * Retrieves the expression that defines the value of the variable in this update.
+     *
+     * @return The defining expression.
+     */
     Expr getDefiningExpr();
   }
 
@@ -296,11 +353,24 @@ signature module LangSig<Semantic Sem, DeltaSig D> {
 }
 
 signature module BoundSig<LocationSig Location, Semantic Sem, DeltaSig D> {
+  /**
+   * Represents a semantic bound.
+   */
   class SemBound {
+    /**
+     * Returns a string representation of the semantic bound.
+     */
     string toString();
 
+    /**
+     * Returns the location of the semantic bound.
+     */
     Location getLocation();
 
+    /**
+     * Returns the expression associated with the semantic bound, given a delta.
+     * @param delta - The delta value.
+     */
     Sem::Expr getExpr(D::Delta delta);
   }
 


### PR DESCRIPTION
Similar to https://github.com/github/codeql/pull/15684 , I'm experimenting with using Copilot ("GitHub Copilot: Generate Docs" command) to help fill holes in our QLDoc comments.  To be honest I think the output is not quite good enough, even after a bit of manual cleanup - it tends to explain code in detail without ever stating what the purpose of the class / predicate is, and the latter is probably what the reader is after.  Hopefully though, this will be a good starting point for discussion...