### PR TITLE
Java: Re-enable Widget.qll flow steps

### DIFF
--- a/java/ql/lib/change-notes/2024-02-23-widget-flowsteps.md
+++ b/java/ql/lib/change-notes/2024-02-23-widget-flowsteps.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* Some flow steps related to `android.text.Editable.toString` that were accidentally disabled have been re-enabled.

--- a/java/ql/lib/semmle/code/java/dataflow/FlowSteps.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/FlowSteps.qll
@@ -14,6 +14,7 @@ private module Frameworks {
   private import semmle.code.java.frameworks.android.Intent
   private import semmle.code.java.frameworks.android.Slice
   private import semmle.code.java.frameworks.android.SQLite
+  private import semmle.code.java.frameworks.android.Widget
   private import semmle.code.java.frameworks.apache.Lang
   private import semmle.code.java.frameworks.ApacheHttp
   private import semmle.code.java.frameworks.guava.Guava

--- a/java/ql/test/query-tests/security/CWE-312/android/CleartextStorage/CleartextStorageSharedPrefsTest.java
+++ b/java/ql/test/query-tests/security/CWE-312/android/CleartextStorage/CleartextStorageSharedPrefsTest.java
@@ -2,6 +2,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
+import android.widget.EditText;
 import androidx.security.crypto.MasterKey;
 import androidx.security.crypto.EncryptedSharedPreferences;
 import java.nio.charset.StandardCharsets;
@@ -100,5 +101,12 @@ public class CleartextStorageSharedPrefsTest extends Activity {
 				context.getSharedPreferences("user_prefs", Context.MODE_PRIVATE);
 		sharedPrefs.edit().putString("name", name).apply(); // Safe
 		sharedPrefs.edit().putString("password", password).apply(); // $hasCleartextStorageSharedPrefs
+	}
+
+	public void testSetSharedPrefs7(Context context, EditText name, EditText password) {
+		SharedPreferences sharedPrefs =
+				context.getSharedPreferences("user_prefs", Context.MODE_PRIVATE);
+		sharedPrefs.edit().putString("name", name.getText().toString()).apply(); // Safe
+		sharedPrefs.edit().putString("password", password.getText().toString()).apply(); // $hasCleartextStorageSharedPrefs
 	}
 }


### PR DESCRIPTION
The library Widget.qll was accidentally removed from the global context when its sources were migrated to models-as-data in #13136. This re-adds it so that its flow steps are enabled again.