### PR TITLE
Shared `View CFG` implementation

### DIFF
--- a/csharp/ql/lib/printCfg.ql
+++ b/csharp/ql/lib/printCfg.ql
@@ -1,0 +1,50 @@
+/**
+ * @name Print CFG
+ * @description Produces a representation of a file's Control Flow Graph.
+ *              This query is used by the VS Code extension.
+ * @id cs/print-cfg
+ * @kind graph
+ * @tags ide-contextual-queries/print-cfg
+ */
+
+private import semmle.code.csharp.controlflow.internal.ControlFlowGraphImpl
+
+external string selectedSourceFile();
+
+private predicate selectedSourceFileAlias = selectedSourceFile/0;
+
+external int selectedSourceLine();
+
+private predicate selectedSourceLineAlias = selectedSourceLine/0;
+
+external int selectedSourceColumn();
+
+private predicate selectedSourceColumnAlias = selectedSourceColumn/0;
+
+module ViewCfgQueryInput implements ViewCfgQueryInputSig<File> {
+  predicate selectedSourceFile = selectedSourceFileAlias/0;
+
+  predicate selectedSourceLine = selectedSourceLineAlias/0;
+
+  predicate selectedSourceColumn = selectedSourceColumnAlias/0;
+
+  predicate cfgScopeSpan(
+    CfgScope scope, File file, int startLine, int startColumn, int endLine, int endColumn
+  ) {
+    file = scope.getFile() and
+    scope.getLocation().getStartLine() = startLine and
+    scope.getLocation().getStartColumn() = startColumn and
+    exists(Location loc |
+      loc.getEndLine() = endLine and
+      loc.getEndColumn() = endColumn
+    |
+      loc = scope.(Callable).getBody().getLocation()
+      or
+      loc = scope.(Field).getInitializer().getLocation()
+      or
+      loc = scope.(Property).getInitializer().getLocation()
+    )
+  }
+}
+
+import ViewCfgQuery<File, ViewCfgQueryInput>

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.ql
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.ql
@@ -4,6 +4,9 @@
 
 import csharp
 import Common
-import semmle.code.csharp.controlflow.internal.ControlFlowGraphImpl::TestOutput
 
-private class MyRelevantNode extends RelevantNode, SourceControlFlowNode { }
+private class MyRelevantNode extends SourceControlFlowNode {
+  string getOrderDisambiguation() { result = "" }
+}
+
+import semmle.code.csharp.controlflow.internal.ControlFlowGraphImpl::TestOutput<MyRelevantNode>

--- a/ruby/ql/test/library-tests/controlflow/graph/Cfg.ql
+++ b/ruby/ql/test/library-tests/controlflow/graph/Cfg.ql
@@ -3,8 +3,9 @@
  */
 
 import codeql.ruby.CFG
-import codeql.ruby.controlflow.internal.ControlFlowGraphImpl::TestOutput
 
-class MyRelevantNode extends RelevantNode {
-  MyRelevantNode() { exists(this) }
+class MyRelevantNode extends CfgNode {
+  string getOrderDisambiguation() { result = "" }
 }
+
+import codeql.ruby.controlflow.internal.ControlFlowGraphImpl::TestOutput<MyRelevantNode>

--- a/swift/ql/lib/codeql/swift/elements/File.qll
+++ b/swift/ql/lib/codeql/swift/elements/File.qll
@@ -15,10 +15,63 @@ class File extends Generated::File {
   /** Gets the URL of this file. */
   string getURL() { result = "file://" + this.getAbsolutePath() + ":0:0:0:0" }
 
-  /** Gets the base name of this file. */
-  string getBaseName() {
-    result = this.getAbsolutePath().regexpCapture(".*/(([^/]*?)(?:\\.([^.]*))?)", 1)
+  /**
+   * Holds if either,
+   * - `part` is the base name of this container and `i = 1`, or
+   * - `part` is the stem of this container and `i = 2`, or
+   * - `part` is the extension of this container and `i = 3`.
+   */
+  cached
+  private predicate splitAbsolutePath(string part, int i) {
+    part = this.getAbsolutePath().regexpCapture(".*/(([^/]*?)(?:\\.([^.]*))?)", i)
   }
+
+  /** Gets the base name of this file. */
+  string getBaseName() { this.splitAbsolutePath(result, 1) }
+
+  /**
+   * Gets the extension of this container, that is, the suffix of its base name
+   * after the last dot character, if any.
+   *
+   * In particular,
+   *
+   *  - if the name does not include a dot, there is no extension, so this
+   *    predicate has no result;
+   *  - if the name ends in a dot, the extension is the empty string;
+   *  - if the name contains multiple dots, the extension follows the last dot.
+   *
+   * Here are some examples of absolute paths and the corresponding extensions
+   * (surrounded with quotes to avoid ambiguity):
+   *
+   * <table border="1">
+   * <tr><th>Absolute path</th><th>Extension</th></tr>
+   * <tr><td>"/tmp/tst.txt"</td><td>"txt"</td></tr>
+   * <tr><td>"/tmp/.classpath"</td><td>"classpath"</td></tr>
+   * <tr><td>"/bin/bash"</td><td>not defined</td></tr>
+   * <tr><td>"/tmp/tst2."</td><td>""</td></tr>
+   * <tr><td>"/tmp/x.tar.gz"</td><td>"gz"</td></tr>
+   * </table>
+   */
+  string getExtension() { this.splitAbsolutePath(result, 3) }
+
+  /**
+   * Gets the stem of this container, that is, the prefix of its base name up to
+   * (but not including) the last dot character if there is one, or the entire
+   * base name if there is not.
+   *
+   * Here are some examples of absolute paths and the corresponding stems
+   * (surrounded with quotes to avoid ambiguity):
+   *
+   * <table border="1">
+   * <tr><th>Absolute path</th><th>Stem</th></tr>
+   * <tr><td>"/tmp/tst.txt"</td><td>"tst"</td></tr>
+   * <tr><td>"/tmp/.classpath"</td><td>""</td></tr>
+   * <tr><td>"/bin/bash"</td><td>"bash"</td></tr>
+   * <tr><td>"/tmp/tst2."</td><td>"tst2"</td></tr>
+   * <tr><td>"/tmp/x.tar.gz"</td><td>"x.tar"</td></tr>
+   * </table>
+   */
+  string getStem() { this.splitAbsolutePath(result, 2) }
 
   /**
    * Gets the number of lines containing code in this file. This value

--- a/swift/ql/test/library-tests/controlflow/graph/Cfg.ql
+++ b/swift/ql/test/library-tests/controlflow/graph/Cfg.ql
@@ -4,16 +4,17 @@
 
 import swift
 import codeql.swift.controlflow.ControlFlowGraph
-import codeql.swift.controlflow.internal.ControlFlowGraphImpl::TestOutput
 
-class MyRelevantNode extends RelevantNode {
+class MyRelevantNode extends ControlFlowNode {
   MyRelevantNode() { this.getScope().getLocation().getFile().getName().matches("%swift/ql/test%") }
 
   private AstNode asAstNode() { result = this.getAstNode().asAstNode() }
 
-  override string getOrderDisambiguation() {
+  string getOrderDisambiguation() {
     result = this.asAstNode().getPrimaryQlClasses()
     or
     not exists(this.asAstNode()) and result = ""
   }
 }
+
+import codeql.swift.controlflow.internal.ControlFlowGraphImpl::TestOutput<MyRelevantNode>


### PR DESCRIPTION
This PR moves the existing `View CFG` implementations for Ruby and Swift into the shared CFG library, and subsequently instantiates the shared implementation in C#.