### PR TITLE
Ruby: Fix change note formatting

### DIFF
--- a/ruby/ql/lib/change-notes/2024-02-20-activerecord-sql-sink-arguments.md
+++ b/ruby/ql/lib/change-notes/2024-02-20-activerecord-sql-sink-arguments.md
@@ -1,4 +1,3 @@
-
 ---
 category: minorAnalysis
 ---


### PR DESCRIPTION
Removes an erroneous blank line.