### PR TITLE
Dataflow: Prevent bad join in FlowSummaryImpl::Private::Steps::summaryLocalStep.

### DIFF
--- a/shared/dataflow/codeql/dataflow/internal/FlowSummaryImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/FlowSummaryImpl.qll
@@ -1081,8 +1081,8 @@ module Make<DF::InputSig DataFlowLang, InputSig<DataFlowLang> Input> {
           SummaryComponentStack outputContents
         |
           summary(c, inputContents, outputContents, preservesValue) and
-          pred = summaryNodeInputState(c, inputContents) and
-          succ = summaryNodeOutputState(c, outputContents)
+          pred = summaryNodeInputState(pragma[only_bind_into](c), inputContents) and
+          succ = summaryNodeOutputState(pragma[only_bind_into](c), outputContents)
         |
           preservesValue = true
           or


### PR DESCRIPTION
Identified by the join-order metric. It mostly isn't too bad but @yoff had a case where it exploded:
```
        129348098   ~5%    {5} r5 = JOIN `FlowSummaryImpl::Private::summaryNodeInputState/2#f551a1f5` WITH `FlowSummaryImpl::Private::summaryNodeOutputState/2#34a54271` ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Rhs.1, Lhs.2, Rhs.2
            72581   ~2%    {6}    | JOIN WITH `FlowSummaryImpl::Private::summary/4#0b3df9ce#reorder_1_3_0_2_2031#join_rhs` ON FIRST 3 OUTPUT Lhs.0, Lhs.1, Lhs.3, Lhs.2, Lhs.4, Rhs.3
```
This change forces `summary` to be part of the first join.