### PR TITLE
C++: Mark internal files in the old dataflow library as deprecated

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/controlflow/SubBasicBlocks.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/SubBasicBlocks.qll
@@ -1,6 +1,6 @@
 // NOTE: There are two copies of this file, and they must be kept identical:
 // - semmle/code/cpp/controlflow/SubBasicBlocks.qll
-// - semmle/code/cpp/dataflow/internal/SubBasicBlocks.qll
+// - semmle/code/cpp/dataflow/internal/SubBasicBlocks.qll [now DEPRECATED]
 //
 // The second one is a private copy of the `SubBasicBlocks` library for
 // internal use by the data flow library. Having an extra copy prevents

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/AddressFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/AddressFlow.qll
@@ -1,4 +1,6 @@
 /**
+ * DEPRECATED: Use `semmle.code.cpp.dataflow.new.DataFlow` instead.
+ *
  * Provides a local analysis for identifying where a variable address
  * is effectively taken. Array-like offsets are allowed to pass through but
  * not field-like offsets.

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowDispatch.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowDispatch.qll
@@ -1,3 +1,7 @@
+/**
+ * DEPRECATED: Use `semmle.code.cpp.dataflow.new.DataFlow` instead.
+ */
+
 private import cpp
 private import DataFlowPrivate
 private import DataFlowUtil

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -1,3 +1,7 @@
+/**
+ * DEPRECATED: Use `semmle.code.cpp.dataflow.new.DataFlow` instead.
+ */
+
 private import DataFlowImplSpecific
 private import codeql.dataflow.internal.DataFlowImpl
 import MakeImpl<CppOldDataFlow>

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
@@ -1,3 +1,7 @@
+/**
+ * DEPRECATED: Use `semmle.code.cpp.dataflow.new.DataFlow` instead.
+ */
+
 private import DataFlowImplSpecific
 private import codeql.dataflow.internal.DataFlowImplCommon
 import MakeImplCommon<CppOldDataFlow>

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplConsistency.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplConsistency.qll
@@ -1,4 +1,6 @@
 /**
+ * DEPRECATED: Use `semmle.code.cpp.dataflow.new.DataFlow` instead.
+ *
  * Provides consistency queries for checking invariants in the language-specific
  * data-flow classes and predicates.
  */

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplSpecific.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplSpecific.qll
@@ -1,4 +1,6 @@
 /**
+ * DEPRECATED: Use `semmle.code.cpp.dataflow.new.DataFlow` instead.
+ *
  * Provides C++-specific definitions for use in the data flow library.
  */
 

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
@@ -1,3 +1,7 @@
+/**
+ * DEPRECATED: Use `semmle.code.cpp.dataflow.new.DataFlow` instead.
+ */
+
 private import cpp
 private import DataFlowUtil
 private import DataFlowDispatch

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
@@ -1,4 +1,6 @@
 /**
+ * DEPRECATED: Use `semmle.code.cpp.dataflow.new.DataFlow` instead.
+ *
  * Provides C++-specific definitions for use in the data flow library.
  */
 

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/FlowVar.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/FlowVar.qll
@@ -1,4 +1,6 @@
 /**
+ * DEPRECATED: Use `semmle.code.cpp.dataflow.new.DataFlow` instead.
+ *
  * Provides a class for handling variables in the data flow analysis.
  */
 

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/SubBasicBlocks.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/SubBasicBlocks.qll
@@ -1,14 +1,12 @@
 // NOTE: There are two copies of this file, and they must be kept identical:
 // - semmle/code/cpp/controlflow/SubBasicBlocks.qll
-// - semmle/code/cpp/dataflow/internal/SubBasicBlocks.qll
+// - semmle/code/cpp/dataflow/internal/SubBasicBlocks.qll [now DEPRECATED]
 //
 // The second one is a private copy of the `SubBasicBlocks` library for
 // internal use by the data flow library. Having an extra copy prevents
 // non-monotonic recursion errors in queries that use both the data flow
 // library and the `SubBasicBlocks` library.
 /**
- * DEPRECATED: Use `semmle.code.cpp.dataflow.new.DataFlow` instead.
- *
  * Provides the `SubBasicBlock` class, used for partitioning basic blocks in
  * smaller pieces.
  */

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/SubBasicBlocks.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/SubBasicBlocks.qll
@@ -7,6 +7,8 @@
 // non-monotonic recursion errors in queries that use both the data flow
 // library and the `SubBasicBlocks` library.
 /**
+ * DEPRECATED: Use `semmle.code.cpp.dataflow.new.DataFlow` instead.
+ *
  * Provides the `SubBasicBlock` class, used for partitioning basic blocks in
  * smaller pieces.
  */

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/TaintTrackingImplSpecific.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/TaintTrackingImplSpecific.qll
@@ -1,4 +1,6 @@
 /**
+ * DEPRECATED: Use `semmle.code.cpp.dataflow.new.DataFlow` instead.
+ *
  * Provides C++-specific definitions for use in the taint tracking library.
  */
 

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/TaintTrackingUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/TaintTrackingUtil.qll
@@ -1,4 +1,6 @@
 /**
+ * DEPRECATED: Use `semmle.code.cpp.dataflow.new.DataFlow` instead.
+ *
  * Provides classes for performing local (intra-procedural) and
  * global (inter-procedural) taint-tracking analyses.
  *

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/tainttracking1/TaintTrackingParameter.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/tainttracking1/TaintTrackingParameter.qll
@@ -1,3 +1,7 @@
+/**
+ * DEPRECATED: Use `Global` and `GlobalWithState` instead.
+ */
+
 import semmle.code.cpp.dataflow.internal.TaintTrackingUtil as Public
 
 module Private {

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/tainttracking2/TaintTrackingParameter.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/tainttracking2/TaintTrackingParameter.qll
@@ -1,3 +1,7 @@
+/**
+ * DEPRECATED: Use `Global` and `GlobalWithState` instead.
+ */
+
 import semmle.code.cpp.dataflow.internal.TaintTrackingUtil as Public
 
 module Private {


### PR DESCRIPTION
Mark internal files in the old dataflow library as deprecated (the public imports already are).