### PR TITLE
python: Rewrite `HardcodedCredentials` away from `PointsTo`

### DIFF
--- a/python/ql/src/Security/CWE-798/HardcodedCredentials.ql
+++ b/python/ql/src/Security/CWE-798/HardcodedCredentials.ql
@@ -16,6 +16,8 @@ import python
 import semmle.python.dataflow.new.DataFlow
 import semmle.python.dataflow.new.TaintTracking
 import semmle.python.filters.Tests
+private import semmle.python.dataflow.new.internal.DataFlowDispatch as DataFlowDispatch
+private import semmle.python.dataflow.new.internal.Builtins::Builtins as Builtins
 
 bindingset[char, fraction]
 predicate fewer_characters_than(StrConst str, string char, float fraction) {
@@ -30,15 +32,13 @@ predicate fewer_characters_than(StrConst str, string char, float fraction) {
 }
 
 predicate possible_reflective_name(string name) {
-  exists(any(ModuleValue m).attr(name))
+  any(Function f).getName() = name
   or
-  exists(any(ClassValue c).lookup(name))
+  any(Class c).getName() = name
   or
-  any(ClassValue c).getName() = name
+  any(Module m).getName() = name
   or
-  exists(Module::named(name))
-  or
-  exists(Value::named(name))
+  exists(Builtins::likelyBuiltin(name))
 }
 
 int char_count(StrConst str) { result = count(string c | c = str.getText().charAt(_)) }
@@ -84,7 +84,9 @@ class CredentialSink extends DataFlow::Node {
       name.regexpMatch(getACredentialRegex()) and
       not name.matches("%file")
     |
-      any(FunctionValue func).getNamedArgumentForCall(_, name) = this.asCfgNode()
+      exists(DataFlowDispatch::ArgumentPosition pos | pos.isKeyword(name) |
+        this.(DataFlow::ArgumentNode).argumentOf(_, pos)
+      )
       or
       exists(Keyword k | k.getArg() = name and k.getValue().getAFlowNode() = this.asCfgNode())
       or


### PR DESCRIPTION
- `ModuleValue.attr` and `ClassValue.lookup` are approximated by `Function.getName`
- `ClassValue.getName` is apprximated by `Class.getName`
- `Module::named` is approximated by `Module.getName`
- `Value::named` is approximated by `Builtins::likelyBuiltin`
- `FunctionValue.getNamedArgumentForCall` is approximated by `ArgumentNode.argumentOf`