### PR TITLE
python: Add provenance column to MaD

### DIFF
--- a/python/ql/lib/semmle/python/frameworks/data/internal/ApiGraphModelsExtensions.qll
+++ b/python/ql/lib/semmle/python/frameworks/data/internal/ApiGraphModelsExtensions.qll
@@ -8,13 +8,13 @@
  *
  * The kind `remote` represents a general remote flow source.
  */
-extensible predicate sourceModel(string type, string path, string kind);
+extensible predicate sourceModel(string type, string path, string kind, string provenance);
 
 /**
  * Holds if the value at `(type, path)` should be seen as a sink
  * of the given `kind`.
  */
-extensible predicate sinkModel(string type, string path, string kind);
+extensible predicate sinkModel(string type, string path, string kind, string provenance);
 
 /**
  * Holds if in calls to `(type, path)`, the value referred to by `input`
@@ -23,21 +23,23 @@ extensible predicate sinkModel(string type, string path, string kind);
  * `kind` should be either `value` or `taint`, for value-preserving or taint-preserving steps,
  * respectively.
  */
-extensible predicate summaryModel(string type, string path, string input, string output, string kind);
+extensible predicate summaryModel(
+  string type, string path, string input, string output, string kind, string provenance
+);
 
 /**
  * Holds if calls to `(type, path)` should be considered neutral. The meaning of this depends on the `kind`.
  * If `kind` is `summary`, the call does not propagate data flow. If `kind` is `source`, the call is not a source.
  * If `kind` is `sink`, the call is not a sink.
  */
-extensible predicate neutralModel(string type, string path, string kind);
+extensible predicate neutralModel(string type, string path, string kind, string provenance);
 
 /**
  * Holds if `(type2, path)` should be seen as an instance of `type1`.
  */
-extensible predicate typeModel(string type1, string type2, string path);
+extensible predicate typeModel(string type1, string type2, string path, string provenance);
 
 /**
  * Holds if `path` can be substituted for a token `TypeVar[name]`.
  */
-extensible predicate typeVariableModel(string name, string path);
+extensible predicate typeVariableModel(string name, string path, string provenance);

--- a/python/ql/test/library-tests/frameworks/data/test.ext.yml
+++ b/python/ql/test/library-tests/frameworks/data/test.ext.yml
@@ -4,73 +4,73 @@ extensions:
       pack: codeql/python-all
       extensible: sourceModel
     data:
-      - ["testlib", "Member[getSource].ReturnValue", "test-source"]
-      - ["testlib.Alias", "", "test-source"]
+      - ["testlib", "Member[getSource].ReturnValue", "test-source", "manual"]
+      - ["testlib.Alias", "", "test-source", "manual"]
       # testing parameter syntax
-      - ["testlib", "Member[Callbacks].Member[first].Argument[0].Parameter[0]", "test-source"]
-      - ["testlib", "Member[Callbacks].Member[param1to3].Argument[0].Parameter[1..3]", "test-source"]
-      - ["testlib", "Member[Callbacks].Member[nonFirst].Argument[0].Parameter[1..]", "test-source"]
+      - ["testlib", "Member[Callbacks].Member[first].Argument[0].Parameter[0]", "test-source", "manual"]
+      - ["testlib", "Member[Callbacks].Member[param1to3].Argument[0].Parameter[1..3]", "test-source", "manual"]
+      - ["testlib", "Member[Callbacks].Member[nonFirst].Argument[0].Parameter[1..]", "test-source", "manual"]
       # Common tokens.
-      - ["testlib", "Member[CommonTokens].Member[makePromise].ReturnValue.Awaited", "test-source"]
-      - ["testlib", "Member[CommonTokens].Member[Class].Instance", "test-source"]
-      - ["testlib", "Member[CommonTokens].Member[Super].Subclass.Instance", "test-source"]
+      - ["testlib", "Member[CommonTokens].Member[makePromise].ReturnValue.Awaited", "test-source", "manual"]
+      - ["testlib", "Member[CommonTokens].Member[Class].Instance", "test-source", "manual"]
+      - ["testlib", "Member[CommonTokens].Member[Super].Subclass.Instance", "test-source", "manual"]
       # method
-      - ["testlib", "Member[CommonTokens].Member[Class].Instance.Method[foo]", "test-source"]
+      - ["testlib", "Member[CommonTokens].Member[Class].Instance.Method[foo]", "test-source", "manual"]
       # testing non-positional arguments
-      - ["testlib", "Member[ArgPos].Member[MyClass].Subclass.Member[foo].Parameter[self]", "test-source"]
-      - ["testlib", "Member[ArgPos].Member[MyClass].Subclass.Member[foo].Parameter[named:]", "test-source"]
-      - ["testlib", "Member[ArgPos].Member[MyClass].Subclass.Member[secondAndAfter].Parameter[1..]", "test-source"]
-      - ["testlib", "Member[ArgPos].Member[MyClass].Subclass.Member[otherSelfTest].Parameter[0]", "test-source"]
-      - ["testlib", "Member[ArgPos].Member[MyClass].Subclass.Member[anyParam].Parameter[any]", "test-source"]
-      - ["testlib", "Member[ArgPos].Member[MyClass].Subclass.Member[anyNamed].Parameter[any-named]", "test-source"]
+      - ["testlib", "Member[ArgPos].Member[MyClass].Subclass.Member[foo].Parameter[self]", "test-source", "manual"]
+      - ["testlib", "Member[ArgPos].Member[MyClass].Subclass.Member[foo].Parameter[named:]", "test-source", "manual"]
+      - ["testlib", "Member[ArgPos].Member[MyClass].Subclass.Member[secondAndAfter].Parameter[1..]", "test-source", "manual"]
+      - ["testlib", "Member[ArgPos].Member[MyClass].Subclass.Member[otherSelfTest].Parameter[0]", "test-source", "manual"]
+      - ["testlib", "Member[ArgPos].Member[MyClass].Subclass.Member[anyParam].Parameter[any]", "test-source", "manual"]
+      - ["testlib", "Member[ArgPos].Member[MyClass].Subclass.Member[anyNamed].Parameter[any-named]", "test-source", "manual"]
 
   - addsTo:
       pack: codeql/python-all
       extensible: sinkModel
     data:
-      - ["testlib", "Member[mySink].Argument[0,sinkName:]", "test-sink"]
+      - ["testlib", "Member[mySink].Argument[0,sinkName:]", "test-sink", "manual"]
       # testing argument syntax
-      - ["testlib", "Member[Args].Member[arg0].Argument[0]", "test-sink"]
-      - ["testlib", "Member[Args].Member[arg1to3].Argument[1..3]", "test-sink"]
-      - ["testlib", "Member[Args].Member[lastarg].Argument[N-1]", "test-sink"]
-      - ["testlib", "Member[Args].Member[nonFist].Argument[1..]", "test-sink"]
+      - ["testlib", "Member[Args].Member[arg0].Argument[0]", "test-sink", "manual"]
+      - ["testlib", "Member[Args].Member[arg1to3].Argument[1..3]", "test-sink", "manual"]
+      - ["testlib", "Member[Args].Member[lastarg].Argument[N-1]", "test-sink", "manual"]
+      - ["testlib", "Member[Args].Member[nonFist].Argument[1..]", "test-sink", "manual"]
       # callsite filter.
-      - ["testlib", "Member[CallFilter].Member[arityOne].WithArity[1].Argument[any]", "test-sink"]
-      - ["testlib", "Member[CallFilter].Member[twoOrMore].WithArity[2..].Argument[0..]", "test-sink"]
+      - ["testlib", "Member[CallFilter].Member[arityOne].WithArity[1].Argument[any]", "test-sink", "manual"]
+      - ["testlib", "Member[CallFilter].Member[twoOrMore].WithArity[2..].Argument[0..]", "test-sink", "manual"]
       # testing non-positional arguments
-      - ["testlib", "Member[ArgPos].Instance.Member[self_thing].Argument[self]", "test-sink"]
+      - ["testlib", "Member[ArgPos].Instance.Member[self_thing].Argument[self]", "test-sink", "manual"]
       # any argument
-      - ["testlib", "Member[ArgPos].Member[anyParam].Argument[any]", "test-sink"]
-      - ["testlib", "Member[ArgPos].Member[anyNamed].Argument[any-named]", "test-sink"]
+      - ["testlib", "Member[ArgPos].Member[anyParam].Argument[any]", "test-sink", "manual"]
+      - ["testlib", "Member[ArgPos].Member[anyNamed].Argument[any-named]", "test-sink", "manual"]
       # testing package syntax
-      - ["foo1.bar", "Member[baz1].Argument[any]", "test-sink"]
-      - ["foo2", "Member[bar].Member[baz2].Argument[any]", "test-sink"]
+      - ["foo1.bar", "Member[baz1].Argument[any]", "test-sink", "manual"]
+      - ["foo2", "Member[bar].Member[baz2].Argument[any]", "test-sink", "manual"]
       # testing fuzzy
-      - ["testlib", "Fuzzy.Member[fuzzyCall].Argument[0]", "test-sink"]
+      - ["testlib", "Fuzzy.Member[fuzzyCall].Argument[0]", "test-sink", "manual"]
       # testing syntax errors
-      - ["testlib", "Member[foo],Member[bar]", "test-sink"]
-      - ["testlib", "Member[foo] Member[bar]", "test-sink"]
-      - ["testlib", "Member[foo]. Member[bar]", "test-sink"]
-      - ["testlib", "Member[foo], Member[bar]", "test-sink"]
-      - ["testlib", "Member[foo]..Member[bar]", "test-sink"]
-      - ["testlib", "Member[foo] .Member[bar]", "test-sink"]
-      - ["testlib", "Member[foo]Member[bar]", "test-sink"]
-      - ["testlib", "Member[foo", "test-sink"]
-      - ["testlib", "Member[foo]]", "test-sink"]
-      - ["testlib", "Member[foo]].Member[bar]", "test-sink"]
+      - ["testlib", "Member[foo],Member[bar]", "test-sink", "manual"]
+      - ["testlib", "Member[foo] Member[bar]", "test-sink", "manual"]
+      - ["testlib", "Member[foo]. Member[bar]", "test-sink", "manual"]
+      - ["testlib", "Member[foo], Member[bar]", "test-sink", "manual"]
+      - ["testlib", "Member[foo]..Member[bar]", "test-sink", "manual"]
+      - ["testlib", "Member[foo] .Member[bar]", "test-sink", "manual"]
+      - ["testlib", "Member[foo]Member[bar]", "test-sink", "manual"]
+      - ["testlib", "Member[foo", "test-sink", "manual"]
+      - ["testlib", "Member[foo]]", "test-sink", "manual"]
+      - ["testlib", "Member[foo]].Member[bar]", "test-sink", "manual"]
 
   - addsTo:
       pack: codeql/python-all
       extensible: summaryModel
     data:
-      - ["testlib", "Member[Steps].Member[preserveTaint].Call", "Argument[0]", "ReturnValue", "taint"]
-      - ["testlib", "Member[Steps].Member[taintIntoCallback]", "Argument[0]", "Argument[1..2].Parameter[0]", "taint"]
-      - ["testlib", "Member[Steps].Member[preserveArgZeroAndTwo]", "Argument[0,2]", "ReturnValue", "taint"]
-      - ["testlib", "Member[Steps].Member[preserveAllButFirstArgument].Call", "Argument[1..]", "ReturnValue", "taint"]
+      - ["testlib", "Member[Steps].Member[preserveTaint].Call", "Argument[0]", "ReturnValue", "taint", "manual"]
+      - ["testlib", "Member[Steps].Member[taintIntoCallback]", "Argument[0]", "Argument[1..2].Parameter[0]", "taint", "manual"]
+      - ["testlib", "Member[Steps].Member[preserveArgZeroAndTwo]", "Argument[0,2]", "ReturnValue", "taint", "manual"]
+      - ["testlib", "Member[Steps].Member[preserveAllButFirstArgument].Call", "Argument[1..]", "ReturnValue", "taint", "manual"]
 
   - addsTo:
       pack: codeql/python-all
       extensible: typeModel
     data:
-     - ["testlib.Alias", "testlib", "Member[alias].ReturnValue"]
-     - ["testlib.Alias", "testlib.Alias", "Member[chain].ReturnValue"]
+     - ["testlib.Alias", "testlib", "Member[alias].ReturnValue", "manual"]
+     - ["testlib.Alias", "testlib.Alias", "Member[chain].ReturnValue", "manual"]


### PR DESCRIPTION
In preparation for a future where models are generated from the ModelEditor and via AI (as well as the bespoke internal tools we are already building..).

I would like to know if all the rows in `python/ql/lib/semmle/python/frameworks/data/internal/subclass-capture/ALL.model.yml` should be labeled as `manual`.

TODO: Add preference for manual models.
