### PR TITLE
Ruby: Rework hidden synthetic data-flow nodes

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -800,7 +800,17 @@ predicate nodeIsHidden(Node n) {
   or
   n = LocalFlow::getParameterDefNode(_)
   or
-  isDesugarNode(n.(ExprNode).getExprNode().getExpr())
+  exists(AstNode desug |
+    isDesugarNode(desug) and
+    desug.isSynthesized() and
+    not desug = [any(ArrayLiteral al).getDesugared(), any(HashLiteral hl).getDesugared()]
+  |
+    desug = n.asExpr().getExpr()
+    or
+    desug = n.(PostUpdateNode).getPreUpdateNode().asExpr().getExpr()
+    or
+    desug = n.(ParameterNode).getParameter()
+  )
   or
   n instanceof FlowSummaryNode
   or

--- a/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
@@ -8,7 +8,8 @@ edges
 | array_flow.rb:5:10:5:10 | a [element 0] | array_flow.rb:5:10:5:13 | ...[...] | provenance |  |
 | array_flow.rb:9:5:9:5 | a [element 1] | array_flow.rb:11:10:11:10 | a [element 1] | provenance |  |
 | array_flow.rb:9:5:9:5 | a [element 1] | array_flow.rb:13:10:13:10 | a [element 1] | provenance |  |
-| array_flow.rb:9:13:9:21 | call to source | array_flow.rb:9:5:9:5 | a [element 1] | provenance |  |
+| array_flow.rb:9:9:9:25 | call to [] [element 1] | array_flow.rb:9:5:9:5 | a [element 1] | provenance |  |
+| array_flow.rb:9:13:9:21 | call to source | array_flow.rb:9:9:9:25 | call to [] [element 1] | provenance |  |
 | array_flow.rb:11:10:11:10 | a [element 1] | array_flow.rb:11:10:11:13 | ...[...] | provenance |  |
 | array_flow.rb:13:10:13:10 | a [element 1] | array_flow.rb:13:10:13:13 | ...[...] | provenance |  |
 | array_flow.rb:17:5:17:5 | a [element] | array_flow.rb:18:10:18:10 | a [element] | provenance |  |
@@ -31,15 +32,18 @@ edges
 | array_flow.rb:28:10:28:10 | c [element] | array_flow.rb:28:10:28:13 | ...[...] | provenance |  |
 | array_flow.rb:29:10:29:10 | c [element] | array_flow.rb:29:10:29:13 | ...[...] | provenance |  |
 | array_flow.rb:33:5:33:5 | a [element 0] | array_flow.rb:34:27:34:27 | a [element 0] | provenance |  |
-| array_flow.rb:33:10:33:18 | call to source | array_flow.rb:33:5:33:5 | a [element 0] | provenance |  |
+| array_flow.rb:33:9:33:22 | call to [] [element 0] | array_flow.rb:33:5:33:5 | a [element 0] | provenance |  |
+| array_flow.rb:33:10:33:18 | call to source | array_flow.rb:33:9:33:22 | call to [] [element 0] | provenance |  |
 | array_flow.rb:34:5:34:5 | b [element 0] | array_flow.rb:35:10:35:10 | b [element 0] | provenance |  |
 | array_flow.rb:34:9:34:28 | call to try_convert [element 0] | array_flow.rb:34:5:34:5 | b [element 0] | provenance |  |
 | array_flow.rb:34:27:34:27 | a [element 0] | array_flow.rb:34:9:34:28 | call to try_convert [element 0] | provenance |  |
 | array_flow.rb:35:10:35:10 | b [element 0] | array_flow.rb:35:10:35:13 | ...[...] | provenance |  |
 | array_flow.rb:40:5:40:5 | a [element 0] | array_flow.rb:42:9:42:9 | a [element 0] | provenance |  |
-| array_flow.rb:40:10:40:20 | call to source | array_flow.rb:40:5:40:5 | a [element 0] | provenance |  |
+| array_flow.rb:40:9:40:24 | call to [] [element 0] | array_flow.rb:40:5:40:5 | a [element 0] | provenance |  |
+| array_flow.rb:40:10:40:20 | call to source | array_flow.rb:40:9:40:24 | call to [] [element 0] | provenance |  |
 | array_flow.rb:41:5:41:5 | b [element 2] | array_flow.rb:42:13:42:13 | b [element 2] | provenance |  |
-| array_flow.rb:41:16:41:26 | call to source | array_flow.rb:41:5:41:5 | b [element 2] | provenance |  |
+| array_flow.rb:41:9:41:27 | call to [] [element 2] | array_flow.rb:41:5:41:5 | b [element 2] | provenance |  |
+| array_flow.rb:41:16:41:26 | call to source | array_flow.rb:41:9:41:27 | call to [] [element 2] | provenance |  |
 | array_flow.rb:42:5:42:5 | c [element] | array_flow.rb:43:10:43:10 | c [element] | provenance |  |
 | array_flow.rb:42:5:42:5 | c [element] | array_flow.rb:44:10:44:10 | c [element] | provenance |  |
 | array_flow.rb:42:9:42:9 | a [element 0] | array_flow.rb:42:9:42:13 | ... & ... [element] | provenance |  |
@@ -48,7 +52,8 @@ edges
 | array_flow.rb:43:10:43:10 | c [element] | array_flow.rb:43:10:43:13 | ...[...] | provenance |  |
 | array_flow.rb:44:10:44:10 | c [element] | array_flow.rb:44:10:44:13 | ...[...] | provenance |  |
 | array_flow.rb:48:5:48:5 | a [element 0] | array_flow.rb:49:9:49:9 | a [element 0] | provenance |  |
-| array_flow.rb:48:10:48:18 | call to source | array_flow.rb:48:5:48:5 | a [element 0] | provenance |  |
+| array_flow.rb:48:9:48:22 | call to [] [element 0] | array_flow.rb:48:5:48:5 | a [element 0] | provenance |  |
+| array_flow.rb:48:10:48:18 | call to source | array_flow.rb:48:9:48:22 | call to [] [element 0] | provenance |  |
 | array_flow.rb:49:5:49:5 | b [element] | array_flow.rb:50:10:50:10 | b [element] | provenance |  |
 | array_flow.rb:49:5:49:5 | b [element] | array_flow.rb:51:10:51:10 | b [element] | provenance |  |
 | array_flow.rb:49:9:49:9 | a [element 0] | array_flow.rb:49:9:49:13 | ... * ... [element] | provenance |  |
@@ -56,9 +61,11 @@ edges
 | array_flow.rb:50:10:50:10 | b [element] | array_flow.rb:50:10:50:13 | ...[...] | provenance |  |
 | array_flow.rb:51:10:51:10 | b [element] | array_flow.rb:51:10:51:13 | ...[...] | provenance |  |
 | array_flow.rb:55:5:55:5 | a [element 0] | array_flow.rb:57:9:57:9 | a [element 0] | provenance |  |
-| array_flow.rb:55:10:55:20 | call to source | array_flow.rb:55:5:55:5 | a [element 0] | provenance |  |
+| array_flow.rb:55:9:55:24 | call to [] [element 0] | array_flow.rb:55:5:55:5 | a [element 0] | provenance |  |
+| array_flow.rb:55:10:55:20 | call to source | array_flow.rb:55:9:55:24 | call to [] [element 0] | provenance |  |
 | array_flow.rb:56:5:56:5 | b [element 1] | array_flow.rb:57:13:57:13 | b [element 1] | provenance |  |
-| array_flow.rb:56:13:56:23 | call to source | array_flow.rb:56:5:56:5 | b [element 1] | provenance |  |
+| array_flow.rb:56:9:56:24 | call to [] [element 1] | array_flow.rb:56:5:56:5 | b [element 1] | provenance |  |
+| array_flow.rb:56:13:56:23 | call to source | array_flow.rb:56:9:56:24 | call to [] [element 1] | provenance |  |
 | array_flow.rb:57:5:57:5 | c [element 0] | array_flow.rb:58:10:58:10 | c [element 0] | provenance |  |
 | array_flow.rb:57:5:57:5 | c [element] | array_flow.rb:58:10:58:10 | c [element] | provenance |  |
 | array_flow.rb:57:5:57:5 | c [element] | array_flow.rb:59:10:59:10 | c [element] | provenance |  |
@@ -70,7 +77,8 @@ edges
 | array_flow.rb:58:10:58:10 | c [element] | array_flow.rb:58:10:58:13 | ...[...] | provenance |  |
 | array_flow.rb:59:10:59:10 | c [element] | array_flow.rb:59:10:59:13 | ...[...] | provenance |  |
 | array_flow.rb:63:5:63:5 | a [element 0] | array_flow.rb:65:9:65:9 | a [element 0] | provenance |  |
-| array_flow.rb:63:10:63:20 | call to source | array_flow.rb:63:5:63:5 | a [element 0] | provenance |  |
+| array_flow.rb:63:9:63:24 | call to [] [element 0] | array_flow.rb:63:5:63:5 | a [element 0] | provenance |  |
+| array_flow.rb:63:10:63:20 | call to source | array_flow.rb:63:9:63:24 | call to [] [element 0] | provenance |  |
 | array_flow.rb:65:5:65:5 | c [element] | array_flow.rb:66:10:66:10 | c [element] | provenance |  |
 | array_flow.rb:65:5:65:5 | c [element] | array_flow.rb:67:10:67:10 | c [element] | provenance |  |
 | array_flow.rb:65:9:65:9 | a [element 0] | array_flow.rb:65:9:65:13 | ... - ... [element] | provenance |  |
@@ -79,7 +87,8 @@ edges
 | array_flow.rb:67:10:67:10 | c [element] | array_flow.rb:67:10:67:13 | ...[...] | provenance |  |
 | array_flow.rb:71:5:71:5 | a [element 0] | array_flow.rb:72:9:72:9 | a [element 0] | provenance |  |
 | array_flow.rb:71:5:71:5 | a [element 0] | array_flow.rb:73:10:73:10 | a [element 0] | provenance |  |
-| array_flow.rb:71:10:71:20 | call to source | array_flow.rb:71:5:71:5 | a [element 0] | provenance |  |
+| array_flow.rb:71:9:71:24 | call to [] [element 0] | array_flow.rb:71:5:71:5 | a [element 0] | provenance |  |
+| array_flow.rb:71:10:71:20 | call to source | array_flow.rb:71:9:71:24 | call to [] [element 0] | provenance |  |
 | array_flow.rb:72:5:72:5 | b [element 0] | array_flow.rb:75:10:75:10 | b [element 0] | provenance |  |
 | array_flow.rb:72:5:72:5 | b [element] | array_flow.rb:75:10:75:10 | b [element] | provenance |  |
 | array_flow.rb:72:5:72:5 | b [element] | array_flow.rb:76:10:76:10 | b [element] | provenance |  |
@@ -97,11 +106,13 @@ edges
 | array_flow.rb:75:10:75:10 | b [element] | array_flow.rb:75:10:75:13 | ...[...] | provenance |  |
 | array_flow.rb:76:10:76:10 | b [element] | array_flow.rb:76:10:76:13 | ...[...] | provenance |  |
 | array_flow.rb:80:5:80:5 | a [element 1] | array_flow.rb:81:15:81:15 | a [element 1] | provenance |  |
-| array_flow.rb:80:13:80:21 | call to source | array_flow.rb:80:5:80:5 | a [element 1] | provenance |  |
+| array_flow.rb:80:9:80:25 | call to [] [element 1] | array_flow.rb:80:5:80:5 | a [element 1] | provenance |  |
+| array_flow.rb:80:13:80:21 | call to source | array_flow.rb:80:9:80:25 | call to [] [element 1] | provenance |  |
 | array_flow.rb:81:8:81:8 | c | array_flow.rb:83:10:83:10 | c | provenance |  |
 | array_flow.rb:81:15:81:15 | a [element 1] | array_flow.rb:81:8:81:8 | c | provenance |  |
 | array_flow.rb:88:5:88:5 | a [element 1] | array_flow.rb:89:9:89:9 | a [element 1] | provenance |  |
-| array_flow.rb:88:13:88:22 | call to source | array_flow.rb:88:5:88:5 | a [element 1] | provenance |  |
+| array_flow.rb:88:9:88:26 | call to [] [element 1] | array_flow.rb:88:5:88:5 | a [element 1] | provenance |  |
+| array_flow.rb:88:13:88:22 | call to source | array_flow.rb:88:9:88:26 | call to [] [element 1] | provenance |  |
 | array_flow.rb:89:5:89:5 | b [element 1] | array_flow.rb:91:10:91:10 | b [element 1] | provenance |  |
 | array_flow.rb:89:5:89:5 | b [element 1] | array_flow.rb:92:10:92:10 | b [element 1] | provenance |  |
 | array_flow.rb:89:9:89:9 | a [element 1] | array_flow.rb:89:9:89:15 | ...[...] [element 1] | provenance |  |
@@ -109,7 +120,8 @@ edges
 | array_flow.rb:91:10:91:10 | b [element 1] | array_flow.rb:91:10:91:13 | ...[...] | provenance |  |
 | array_flow.rb:92:10:92:10 | b [element 1] | array_flow.rb:92:10:92:13 | ...[...] | provenance |  |
 | array_flow.rb:96:5:96:5 | a [element 1] | array_flow.rb:97:9:97:9 | a [element 1] | provenance |  |
-| array_flow.rb:96:13:96:22 | call to source | array_flow.rb:96:5:96:5 | a [element 1] | provenance |  |
+| array_flow.rb:96:9:96:26 | call to [] [element 1] | array_flow.rb:96:5:96:5 | a [element 1] | provenance |  |
+| array_flow.rb:96:13:96:22 | call to source | array_flow.rb:96:9:96:26 | call to [] [element 1] | provenance |  |
 | array_flow.rb:97:5:97:5 | b [element 1] | array_flow.rb:99:10:99:10 | b [element 1] | provenance |  |
 | array_flow.rb:97:5:97:5 | b [element 1] | array_flow.rb:101:10:101:10 | b [element 1] | provenance |  |
 | array_flow.rb:97:9:97:9 | a [element 1] | array_flow.rb:97:9:97:15 | ...[...] [element 1] | provenance |  |
@@ -117,7 +129,8 @@ edges
 | array_flow.rb:99:10:99:10 | b [element 1] | array_flow.rb:99:10:99:13 | ...[...] | provenance |  |
 | array_flow.rb:101:10:101:10 | b [element 1] | array_flow.rb:101:10:101:13 | ...[...] | provenance |  |
 | array_flow.rb:103:5:103:5 | a [element 1] | array_flow.rb:104:9:104:9 | a [element 1] | provenance |  |
-| array_flow.rb:103:13:103:24 | call to source | array_flow.rb:103:5:103:5 | a [element 1] | provenance |  |
+| array_flow.rb:103:9:103:39 | call to [] [element 1] | array_flow.rb:103:5:103:5 | a [element 1] | provenance |  |
+| array_flow.rb:103:13:103:24 | call to source | array_flow.rb:103:9:103:39 | call to [] [element 1] | provenance |  |
 | array_flow.rb:104:5:104:5 | b [element 1] | array_flow.rb:106:10:106:10 | b [element 1] | provenance |  |
 | array_flow.rb:104:9:104:9 | a [element 1] | array_flow.rb:104:9:104:16 | ...[...] [element 1] | provenance |  |
 | array_flow.rb:104:9:104:16 | ...[...] [element 1] | array_flow.rb:104:5:104:5 | b [element 1] | provenance |  |
@@ -126,8 +139,10 @@ edges
 | array_flow.rb:109:5:109:5 | a [element 1] | array_flow.rb:114:9:114:9 | a [element 1] | provenance |  |
 | array_flow.rb:109:5:109:5 | a [element 3] | array_flow.rb:110:9:110:9 | a [element 3] | provenance |  |
 | array_flow.rb:109:5:109:5 | a [element 3] | array_flow.rb:114:9:114:9 | a [element 3] | provenance |  |
-| array_flow.rb:109:13:109:24 | call to source | array_flow.rb:109:5:109:5 | a [element 1] | provenance |  |
-| array_flow.rb:109:30:109:41 | call to source | array_flow.rb:109:5:109:5 | a [element 3] | provenance |  |
+| array_flow.rb:109:9:109:42 | call to [] [element 1] | array_flow.rb:109:5:109:5 | a [element 1] | provenance |  |
+| array_flow.rb:109:9:109:42 | call to [] [element 3] | array_flow.rb:109:5:109:5 | a [element 3] | provenance |  |
+| array_flow.rb:109:13:109:24 | call to source | array_flow.rb:109:9:109:42 | call to [] [element 1] | provenance |  |
+| array_flow.rb:109:30:109:41 | call to source | array_flow.rb:109:9:109:42 | call to [] [element 3] | provenance |  |
 | array_flow.rb:110:5:110:5 | b [element] | array_flow.rb:111:10:111:10 | b [element] | provenance |  |
 | array_flow.rb:110:5:110:5 | b [element] | array_flow.rb:112:10:112:10 | b [element] | provenance |  |
 | array_flow.rb:110:9:110:9 | a [element 1] | array_flow.rb:110:9:110:18 | ...[...] [element] | provenance |  |
@@ -152,7 +167,8 @@ edges
 | array_flow.rb:129:5:129:5 | [post] a [element] | array_flow.rb:130:10:130:10 | a [element] | provenance |  |
 | array_flow.rb:129:5:129:5 | [post] a [element] | array_flow.rb:131:10:131:10 | a [element] | provenance |  |
 | array_flow.rb:129:5:129:5 | [post] a [element] | array_flow.rb:132:10:132:10 | a [element] | provenance |  |
-| array_flow.rb:129:19:129:28 | call to source | array_flow.rb:129:5:129:5 | [post] a [element] | provenance |  |
+| array_flow.rb:129:15:129:32 | call to [] [element 1] | array_flow.rb:129:5:129:5 | [post] a [element] | provenance |  |
+| array_flow.rb:129:19:129:28 | call to source | array_flow.rb:129:15:129:32 | call to [] [element 1] | provenance |  |
 | array_flow.rb:130:10:130:10 | a [element] | array_flow.rb:130:10:130:13 | ...[...] | provenance |  |
 | array_flow.rb:131:10:131:10 | a [element] | array_flow.rb:131:10:131:13 | ...[...] | provenance |  |
 | array_flow.rb:132:10:132:10 | a [element] | array_flow.rb:132:10:132:13 | ...[...] | provenance |  |
@@ -166,21 +182,25 @@ edges
 | array_flow.rb:145:5:145:5 | [post] a [element] | array_flow.rb:146:10:146:10 | a [element] | provenance |  |
 | array_flow.rb:145:5:145:5 | [post] a [element] | array_flow.rb:147:10:147:10 | a [element] | provenance |  |
 | array_flow.rb:145:5:145:5 | [post] a [element] | array_flow.rb:148:10:148:10 | a [element] | provenance |  |
-| array_flow.rb:145:19:145:28 | call to source | array_flow.rb:145:5:145:5 | [post] a [element] | provenance |  |
+| array_flow.rb:145:15:145:32 | call to [] [element 1] | array_flow.rb:145:5:145:5 | [post] a [element] | provenance |  |
+| array_flow.rb:145:19:145:28 | call to source | array_flow.rb:145:15:145:32 | call to [] [element 1] | provenance |  |
 | array_flow.rb:146:10:146:10 | a [element] | array_flow.rb:146:10:146:13 | ...[...] | provenance |  |
 | array_flow.rb:147:10:147:10 | a [element] | array_flow.rb:147:10:147:13 | ...[...] | provenance |  |
 | array_flow.rb:148:10:148:10 | a [element] | array_flow.rb:148:10:148:13 | ...[...] | provenance |  |
 | array_flow.rb:152:5:152:5 | a [element 2] | array_flow.rb:153:5:153:5 | a [element 2] | provenance |  |
-| array_flow.rb:152:16:152:25 | call to source | array_flow.rb:152:5:152:5 | a [element 2] | provenance |  |
+| array_flow.rb:152:9:152:26 | call to [] [element 2] | array_flow.rb:152:5:152:5 | a [element 2] | provenance |  |
+| array_flow.rb:152:16:152:25 | call to source | array_flow.rb:152:9:152:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:153:5:153:5 | a [element 2] | array_flow.rb:153:16:153:16 | x | provenance |  |
 | array_flow.rb:153:16:153:16 | x | array_flow.rb:154:14:154:14 | x | provenance |  |
 | array_flow.rb:159:5:159:5 | a [element 2] | array_flow.rb:160:5:160:5 | a [element 2] | provenance |  |
-| array_flow.rb:159:16:159:25 | call to source | array_flow.rb:159:5:159:5 | a [element 2] | provenance |  |
+| array_flow.rb:159:9:159:26 | call to [] [element 2] | array_flow.rb:159:5:159:5 | a [element 2] | provenance |  |
+| array_flow.rb:159:16:159:25 | call to source | array_flow.rb:159:9:159:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:160:5:160:5 | a [element 2] | array_flow.rb:160:16:160:16 | x | provenance |  |
 | array_flow.rb:160:16:160:16 | x | array_flow.rb:161:14:161:14 | x | provenance |  |
 | array_flow.rb:166:5:166:5 | a [element 0] | array_flow.rb:167:9:167:9 | a [element 0] | provenance |  |
 | array_flow.rb:166:5:166:5 | a [element 0] | array_flow.rb:168:10:168:10 | a [element 0] | provenance |  |
-| array_flow.rb:166:10:166:21 | call to source | array_flow.rb:166:5:166:5 | a [element 0] | provenance |  |
+| array_flow.rb:166:9:166:25 | call to [] [element 0] | array_flow.rb:166:5:166:5 | a [element 0] | provenance |  |
+| array_flow.rb:166:10:166:21 | call to source | array_flow.rb:166:9:166:25 | call to [] [element 0] | provenance |  |
 | array_flow.rb:167:5:167:5 | b [element 0] | array_flow.rb:170:10:170:10 | b [element 0] | provenance |  |
 | array_flow.rb:167:5:167:5 | b [element] | array_flow.rb:170:10:170:10 | b [element] | provenance |  |
 | array_flow.rb:167:5:167:5 | b [element] | array_flow.rb:171:10:171:10 | b [element] | provenance |  |
@@ -200,10 +220,12 @@ edges
 | array_flow.rb:170:10:170:10 | b [element] | array_flow.rb:170:10:170:13 | ...[...] | provenance |  |
 | array_flow.rb:171:10:171:10 | b [element] | array_flow.rb:171:10:171:13 | ...[...] | provenance |  |
 | array_flow.rb:177:5:177:5 | c [element 1] | array_flow.rb:178:16:178:16 | c [element 1] | provenance |  |
-| array_flow.rb:177:15:177:24 | call to source | array_flow.rb:177:5:177:5 | c [element 1] | provenance |  |
+| array_flow.rb:177:9:177:25 | call to [] [element 1] | array_flow.rb:177:5:177:5 | c [element 1] | provenance |  |
+| array_flow.rb:177:15:177:24 | call to source | array_flow.rb:177:9:177:25 | call to [] [element 1] | provenance |  |
 | array_flow.rb:178:5:178:5 | d [element 2, element 1] | array_flow.rb:179:11:179:11 | d [element 2, element 1] | provenance |  |
 | array_flow.rb:178:5:178:5 | d [element 2, element 1] | array_flow.rb:180:11:180:11 | d [element 2, element 1] | provenance |  |
-| array_flow.rb:178:16:178:16 | c [element 1] | array_flow.rb:178:5:178:5 | d [element 2, element 1] | provenance |  |
+| array_flow.rb:178:9:178:17 | call to [] [element 2, element 1] | array_flow.rb:178:5:178:5 | d [element 2, element 1] | provenance |  |
+| array_flow.rb:178:16:178:16 | c [element 1] | array_flow.rb:178:9:178:17 | call to [] [element 2, element 1] | provenance |  |
 | array_flow.rb:179:11:179:11 | d [element 2, element 1] | array_flow.rb:179:11:179:22 | call to assoc [element 1] | provenance |  |
 | array_flow.rb:179:11:179:22 | call to assoc [element 1] | array_flow.rb:179:11:179:25 | ...[...] | provenance |  |
 | array_flow.rb:179:11:179:25 | ...[...] | array_flow.rb:179:10:179:26 | ( ... ) | provenance |  |
@@ -212,28 +234,34 @@ edges
 | array_flow.rb:180:11:180:25 | ...[...] | array_flow.rb:180:10:180:26 | ( ... ) | provenance |  |
 | array_flow.rb:184:5:184:5 | a [element 1] | array_flow.rb:186:10:186:10 | a [element 1] | provenance |  |
 | array_flow.rb:184:5:184:5 | a [element 1] | array_flow.rb:188:10:188:10 | a [element 1] | provenance |  |
-| array_flow.rb:184:13:184:22 | call to source | array_flow.rb:184:5:184:5 | a [element 1] | provenance |  |
+| array_flow.rb:184:9:184:26 | call to [] [element 1] | array_flow.rb:184:5:184:5 | a [element 1] | provenance |  |
+| array_flow.rb:184:13:184:22 | call to source | array_flow.rb:184:9:184:26 | call to [] [element 1] | provenance |  |
 | array_flow.rb:186:10:186:10 | a [element 1] | array_flow.rb:186:10:186:16 | call to at | provenance |  |
 | array_flow.rb:188:10:188:10 | a [element 1] | array_flow.rb:188:10:188:16 | call to at | provenance |  |
 | array_flow.rb:192:5:192:5 | a [element 2] | array_flow.rb:193:9:193:9 | a [element 2] | provenance |  |
-| array_flow.rb:192:16:192:25 | call to source | array_flow.rb:192:5:192:5 | a [element 2] | provenance |  |
+| array_flow.rb:192:9:192:26 | call to [] [element 2] | array_flow.rb:192:5:192:5 | a [element 2] | provenance |  |
+| array_flow.rb:192:16:192:25 | call to source | array_flow.rb:192:9:192:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:193:5:193:5 | b | array_flow.rb:196:10:196:10 | b | provenance |  |
 | array_flow.rb:193:9:193:9 | a [element 2] | array_flow.rb:193:9:195:7 | call to bsearch | provenance |  |
 | array_flow.rb:193:9:193:9 | a [element 2] | array_flow.rb:193:23:193:23 | x | provenance |  |
 | array_flow.rb:193:9:195:7 | call to bsearch | array_flow.rb:193:5:193:5 | b | provenance |  |
 | array_flow.rb:193:23:193:23 | x | array_flow.rb:194:14:194:14 | x | provenance |  |
 | array_flow.rb:200:5:200:5 | a [element 2] | array_flow.rb:201:9:201:9 | a [element 2] | provenance |  |
-| array_flow.rb:200:16:200:25 | call to source | array_flow.rb:200:5:200:5 | a [element 2] | provenance |  |
+| array_flow.rb:200:9:200:26 | call to [] [element 2] | array_flow.rb:200:5:200:5 | a [element 2] | provenance |  |
+| array_flow.rb:200:16:200:25 | call to source | array_flow.rb:200:9:200:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:201:9:201:9 | a [element 2] | array_flow.rb:201:29:201:29 | x | provenance |  |
 | array_flow.rb:201:29:201:29 | x | array_flow.rb:202:14:202:14 | x | provenance |  |
 | array_flow.rb:208:5:208:5 | a [element 2] | array_flow.rb:209:5:209:5 | a [element 2] | provenance |  |
-| array_flow.rb:208:16:208:25 | call to source | array_flow.rb:208:5:208:5 | a [element 2] | provenance |  |
+| array_flow.rb:208:9:208:26 | call to [] [element 2] | array_flow.rb:208:5:208:5 | a [element 2] | provenance |  |
+| array_flow.rb:208:16:208:25 | call to source | array_flow.rb:208:9:208:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:209:5:209:5 | a [element 2] | array_flow.rb:209:17:209:17 | x | provenance |  |
 | array_flow.rb:209:17:209:17 | x | array_flow.rb:210:14:210:14 | x | provenance |  |
 | array_flow.rb:215:5:215:5 | a [element 2] | array_flow.rb:216:9:216:9 | a [element 2] | provenance |  |
 | array_flow.rb:215:5:215:5 | a [element 3] | array_flow.rb:216:9:216:9 | a [element 3] | provenance |  |
-| array_flow.rb:215:16:215:27 | call to source | array_flow.rb:215:5:215:5 | a [element 2] | provenance |  |
-| array_flow.rb:215:30:215:41 | call to source | array_flow.rb:215:5:215:5 | a [element 3] | provenance |  |
+| array_flow.rb:215:9:215:42 | call to [] [element 2] | array_flow.rb:215:5:215:5 | a [element 2] | provenance |  |
+| array_flow.rb:215:9:215:42 | call to [] [element 3] | array_flow.rb:215:5:215:5 | a [element 3] | provenance |  |
+| array_flow.rb:215:16:215:27 | call to source | array_flow.rb:215:9:215:42 | call to [] [element 2] | provenance |  |
+| array_flow.rb:215:30:215:41 | call to source | array_flow.rb:215:9:215:42 | call to [] [element 3] | provenance |  |
 | array_flow.rb:216:9:216:9 | a [element 2] | array_flow.rb:216:27:216:27 | x | provenance |  |
 | array_flow.rb:216:9:216:9 | a [element 2] | array_flow.rb:216:30:216:30 | y | provenance |  |
 | array_flow.rb:216:9:216:9 | a [element 3] | array_flow.rb:216:27:216:27 | x | provenance |  |
@@ -241,7 +269,8 @@ edges
 | array_flow.rb:216:27:216:27 | x | array_flow.rb:217:14:217:14 | x | provenance |  |
 | array_flow.rb:216:30:216:30 | y | array_flow.rb:218:14:218:14 | y | provenance |  |
 | array_flow.rb:231:5:231:5 | a [element 2] | array_flow.rb:232:9:232:9 | a [element 2] | provenance |  |
-| array_flow.rb:231:16:231:27 | call to source | array_flow.rb:231:5:231:5 | a [element 2] | provenance |  |
+| array_flow.rb:231:9:231:28 | call to [] [element 2] | array_flow.rb:231:5:231:5 | a [element 2] | provenance |  |
+| array_flow.rb:231:16:231:27 | call to source | array_flow.rb:231:9:231:28 | call to [] [element 2] | provenance |  |
 | array_flow.rb:232:5:232:5 | b [element] | array_flow.rb:236:10:236:10 | b [element] | provenance |  |
 | array_flow.rb:232:9:232:9 | a [element 2] | array_flow.rb:232:23:232:23 | x | provenance |  |
 | array_flow.rb:232:9:235:7 | call to collect [element] | array_flow.rb:232:5:232:5 | b [element] | provenance |  |
@@ -249,7 +278,8 @@ edges
 | array_flow.rb:234:9:234:19 | call to source | array_flow.rb:232:9:235:7 | call to collect [element] | provenance |  |
 | array_flow.rb:236:10:236:10 | b [element] | array_flow.rb:236:10:236:13 | ...[...] | provenance |  |
 | array_flow.rb:240:5:240:5 | a [element 2] | array_flow.rb:241:9:241:9 | a [element 2] | provenance |  |
-| array_flow.rb:240:16:240:27 | call to source | array_flow.rb:240:5:240:5 | a [element 2] | provenance |  |
+| array_flow.rb:240:9:240:28 | call to [] [element 2] | array_flow.rb:240:5:240:5 | a [element 2] | provenance |  |
+| array_flow.rb:240:16:240:27 | call to source | array_flow.rb:240:9:240:28 | call to [] [element 2] | provenance |  |
 | array_flow.rb:241:5:241:5 | b [element] | array_flow.rb:246:10:246:10 | b [element] | provenance |  |
 | array_flow.rb:241:9:241:9 | [post] a [element] | array_flow.rb:245:10:245:10 | a [element] | provenance |  |
 | array_flow.rb:241:9:241:9 | a [element 2] | array_flow.rb:241:24:241:24 | x | provenance |  |
@@ -261,13 +291,15 @@ edges
 | array_flow.rb:246:10:246:10 | b [element] | array_flow.rb:246:10:246:13 | ...[...] | provenance |  |
 | array_flow.rb:250:5:250:5 | a [element 2] | array_flow.rb:251:9:251:9 | a [element 2] | provenance |  |
 | array_flow.rb:250:5:250:5 | a [element 2] | array_flow.rb:256:9:256:9 | a [element 2] | provenance |  |
-| array_flow.rb:250:16:250:27 | call to source | array_flow.rb:250:5:250:5 | a [element 2] | provenance |  |
+| array_flow.rb:250:9:250:28 | call to [] [element 2] | array_flow.rb:250:5:250:5 | a [element 2] | provenance |  |
+| array_flow.rb:250:16:250:27 | call to source | array_flow.rb:250:9:250:28 | call to [] [element 2] | provenance |  |
 | array_flow.rb:251:5:251:5 | b [element] | array_flow.rb:255:10:255:10 | b [element] | provenance |  |
 | array_flow.rb:251:9:251:9 | a [element 2] | array_flow.rb:251:9:254:7 | call to collect_concat [element] | provenance |  |
 | array_flow.rb:251:9:251:9 | a [element 2] | array_flow.rb:251:30:251:30 | x | provenance |  |
 | array_flow.rb:251:9:254:7 | call to collect_concat [element] | array_flow.rb:251:5:251:5 | b [element] | provenance |  |
 | array_flow.rb:251:30:251:30 | x | array_flow.rb:252:14:252:14 | x | provenance |  |
-| array_flow.rb:253:13:253:24 | call to source | array_flow.rb:251:9:254:7 | call to collect_concat [element] | provenance |  |
+| array_flow.rb:253:9:253:25 | call to [] [element 1] | array_flow.rb:251:9:254:7 | call to collect_concat [element] | provenance |  |
+| array_flow.rb:253:13:253:24 | call to source | array_flow.rb:253:9:253:25 | call to [] [element 1] | provenance |  |
 | array_flow.rb:255:10:255:10 | b [element] | array_flow.rb:255:10:255:13 | ...[...] | provenance |  |
 | array_flow.rb:256:5:256:5 | b [element] | array_flow.rb:260:10:260:10 | b [element] | provenance |  |
 | array_flow.rb:256:9:256:9 | a [element 2] | array_flow.rb:256:30:256:30 | x | provenance |  |
@@ -276,7 +308,8 @@ edges
 | array_flow.rb:258:9:258:20 | call to source | array_flow.rb:256:9:259:7 | call to collect_concat [element] | provenance |  |
 | array_flow.rb:260:10:260:10 | b [element] | array_flow.rb:260:10:260:13 | ...[...] | provenance |  |
 | array_flow.rb:264:5:264:5 | a [element 2] | array_flow.rb:265:9:265:9 | a [element 2] | provenance |  |
-| array_flow.rb:264:16:264:25 | call to source | array_flow.rb:264:5:264:5 | a [element 2] | provenance |  |
+| array_flow.rb:264:9:264:26 | call to [] [element 2] | array_flow.rb:264:5:264:5 | a [element 2] | provenance |  |
+| array_flow.rb:264:16:264:25 | call to source | array_flow.rb:264:9:264:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:265:5:265:5 | b [element 2] | array_flow.rb:269:10:269:10 | b [element 2] | provenance |  |
 | array_flow.rb:265:9:265:9 | a [element 2] | array_flow.rb:265:9:267:7 | call to combination [element 2] | provenance |  |
 | array_flow.rb:265:9:265:9 | a [element 2] | array_flow.rb:265:30:265:30 | x [element] | provenance |  |
@@ -285,13 +318,15 @@ edges
 | array_flow.rb:266:14:266:14 | x [element] | array_flow.rb:266:14:266:17 | ...[...] | provenance |  |
 | array_flow.rb:269:10:269:10 | b [element 2] | array_flow.rb:269:10:269:13 | ...[...] | provenance |  |
 | array_flow.rb:273:5:273:5 | a [element 2] | array_flow.rb:274:9:274:9 | a [element 2] | provenance |  |
-| array_flow.rb:273:16:273:25 | call to source | array_flow.rb:273:5:273:5 | a [element 2] | provenance |  |
+| array_flow.rb:273:9:273:26 | call to [] [element 2] | array_flow.rb:273:5:273:5 | a [element 2] | provenance |  |
+| array_flow.rb:273:16:273:25 | call to source | array_flow.rb:273:9:273:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:274:5:274:5 | b [element] | array_flow.rb:275:10:275:10 | b [element] | provenance |  |
 | array_flow.rb:274:9:274:9 | a [element 2] | array_flow.rb:274:9:274:17 | call to compact [element] | provenance |  |
 | array_flow.rb:274:9:274:17 | call to compact [element] | array_flow.rb:274:5:274:5 | b [element] | provenance |  |
 | array_flow.rb:275:10:275:10 | b [element] | array_flow.rb:275:10:275:13 | ...[...] | provenance |  |
 | array_flow.rb:279:5:279:5 | a [element 2] | array_flow.rb:280:9:280:9 | a [element 2] | provenance |  |
-| array_flow.rb:279:16:279:25 | call to source | array_flow.rb:279:5:279:5 | a [element 2] | provenance |  |
+| array_flow.rb:279:9:279:26 | call to [] [element 2] | array_flow.rb:279:5:279:5 | a [element 2] | provenance |  |
+| array_flow.rb:279:16:279:25 | call to source | array_flow.rb:279:9:279:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:280:5:280:5 | b [element] | array_flow.rb:282:10:282:10 | b [element] | provenance |  |
 | array_flow.rb:280:9:280:9 | [post] a [element] | array_flow.rb:281:10:281:10 | a [element] | provenance |  |
 | array_flow.rb:280:9:280:9 | a [element 2] | array_flow.rb:280:9:280:9 | [post] a [element] | provenance |  |
@@ -300,9 +335,11 @@ edges
 | array_flow.rb:281:10:281:10 | a [element] | array_flow.rb:281:10:281:13 | ...[...] | provenance |  |
 | array_flow.rb:282:10:282:10 | b [element] | array_flow.rb:282:10:282:13 | ...[...] | provenance |  |
 | array_flow.rb:286:5:286:5 | a [element 2] | array_flow.rb:290:10:290:10 | a [element 2] | provenance |  |
-| array_flow.rb:286:16:286:27 | call to source | array_flow.rb:286:5:286:5 | a [element 2] | provenance |  |
+| array_flow.rb:286:9:286:28 | call to [] [element 2] | array_flow.rb:286:5:286:5 | a [element 2] | provenance |  |
+| array_flow.rb:286:16:286:27 | call to source | array_flow.rb:286:9:286:28 | call to [] [element 2] | provenance |  |
 | array_flow.rb:287:5:287:5 | b [element 2] | array_flow.rb:288:14:288:14 | b [element 2] | provenance |  |
-| array_flow.rb:287:16:287:27 | call to source | array_flow.rb:287:5:287:5 | b [element 2] | provenance |  |
+| array_flow.rb:287:9:287:28 | call to [] [element 2] | array_flow.rb:287:5:287:5 | b [element 2] | provenance |  |
+| array_flow.rb:287:16:287:27 | call to source | array_flow.rb:287:9:287:28 | call to [] [element 2] | provenance |  |
 | array_flow.rb:288:5:288:5 | [post] a [element] | array_flow.rb:289:10:289:10 | a [element] | provenance |  |
 | array_flow.rb:288:5:288:5 | [post] a [element] | array_flow.rb:290:10:290:10 | a [element] | provenance |  |
 | array_flow.rb:288:14:288:14 | b [element 2] | array_flow.rb:288:5:288:5 | [post] a [element] | provenance |  |
@@ -310,29 +347,35 @@ edges
 | array_flow.rb:290:10:290:10 | a [element 2] | array_flow.rb:290:10:290:13 | ...[...] | provenance |  |
 | array_flow.rb:290:10:290:10 | a [element] | array_flow.rb:290:10:290:13 | ...[...] | provenance |  |
 | array_flow.rb:294:5:294:5 | a [element 2] | array_flow.rb:295:5:295:5 | a [element 2] | provenance |  |
-| array_flow.rb:294:16:294:25 | call to source | array_flow.rb:294:5:294:5 | a [element 2] | provenance |  |
+| array_flow.rb:294:9:294:26 | call to [] [element 2] | array_flow.rb:294:5:294:5 | a [element 2] | provenance |  |
+| array_flow.rb:294:16:294:25 | call to source | array_flow.rb:294:9:294:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:295:5:295:5 | a [element 2] | array_flow.rb:295:17:295:17 | x | provenance |  |
 | array_flow.rb:295:17:295:17 | x | array_flow.rb:296:14:296:14 | x | provenance |  |
 | array_flow.rb:301:5:301:5 | a [element 2] | array_flow.rb:302:5:302:5 | a [element 2] | provenance |  |
-| array_flow.rb:301:16:301:25 | call to source | array_flow.rb:301:5:301:5 | a [element 2] | provenance |  |
+| array_flow.rb:301:9:301:26 | call to [] [element 2] | array_flow.rb:301:5:301:5 | a [element 2] | provenance |  |
+| array_flow.rb:301:16:301:25 | call to source | array_flow.rb:301:9:301:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:302:5:302:5 | a [element 2] | array_flow.rb:302:20:302:20 | x | provenance |  |
 | array_flow.rb:302:20:302:20 | x | array_flow.rb:303:14:303:14 | x | provenance |  |
 | array_flow.rb:308:5:308:5 | a [element 2] | array_flow.rb:309:9:309:9 | a [element 2] | provenance |  |
-| array_flow.rb:308:16:308:25 | call to source | array_flow.rb:308:5:308:5 | a [element 2] | provenance |  |
+| array_flow.rb:308:9:308:26 | call to [] [element 2] | array_flow.rb:308:5:308:5 | a [element 2] | provenance |  |
+| array_flow.rb:308:16:308:25 | call to source | array_flow.rb:308:9:308:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:309:5:309:5 | b [element 2] | array_flow.rb:312:10:312:10 | b [element 2] | provenance |  |
 | array_flow.rb:309:9:309:9 | a [element 2] | array_flow.rb:309:9:309:21 | call to deconstruct [element 2] | provenance |  |
 | array_flow.rb:309:9:309:21 | call to deconstruct [element 2] | array_flow.rb:309:5:309:5 | b [element 2] | provenance |  |
 | array_flow.rb:312:10:312:10 | b [element 2] | array_flow.rb:312:10:312:13 | ...[...] | provenance |  |
 | array_flow.rb:316:5:316:5 | a [element 2] | array_flow.rb:317:9:317:9 | a [element 2] | provenance |  |
-| array_flow.rb:316:16:316:27 | call to source | array_flow.rb:316:5:316:5 | a [element 2] | provenance |  |
+| array_flow.rb:316:9:316:28 | call to [] [element 2] | array_flow.rb:316:5:316:5 | a [element 2] | provenance |  |
+| array_flow.rb:316:16:316:27 | call to source | array_flow.rb:316:9:316:28 | call to [] [element 2] | provenance |  |
 | array_flow.rb:317:5:317:5 | b | array_flow.rb:318:10:318:10 | b | provenance |  |
 | array_flow.rb:317:9:317:9 | a [element 2] | array_flow.rb:317:9:317:36 | call to delete | provenance |  |
 | array_flow.rb:317:9:317:36 | call to delete | array_flow.rb:317:5:317:5 | b | provenance |  |
 | array_flow.rb:317:23:317:34 | call to source | array_flow.rb:317:9:317:36 | call to delete | provenance |  |
 | array_flow.rb:325:5:325:5 | a [element 2] | array_flow.rb:326:9:326:9 | a [element 2] | provenance |  |
 | array_flow.rb:325:5:325:5 | a [element 3] | array_flow.rb:326:9:326:9 | a [element 3] | provenance |  |
-| array_flow.rb:325:16:325:27 | call to source | array_flow.rb:325:5:325:5 | a [element 2] | provenance |  |
-| array_flow.rb:325:30:325:41 | call to source | array_flow.rb:325:5:325:5 | a [element 3] | provenance |  |
+| array_flow.rb:325:9:325:42 | call to [] [element 2] | array_flow.rb:325:5:325:5 | a [element 2] | provenance |  |
+| array_flow.rb:325:9:325:42 | call to [] [element 3] | array_flow.rb:325:5:325:5 | a [element 3] | provenance |  |
+| array_flow.rb:325:16:325:27 | call to source | array_flow.rb:325:9:325:42 | call to [] [element 2] | provenance |  |
+| array_flow.rb:325:30:325:41 | call to source | array_flow.rb:325:9:325:42 | call to [] [element 3] | provenance |  |
 | array_flow.rb:326:5:326:5 | b | array_flow.rb:327:10:327:10 | b | provenance |  |
 | array_flow.rb:326:9:326:9 | [post] a [element 2] | array_flow.rb:328:10:328:10 | a [element 2] | provenance |  |
 | array_flow.rb:326:9:326:9 | a [element 2] | array_flow.rb:326:9:326:22 | call to delete_at | provenance |  |
@@ -341,8 +384,10 @@ edges
 | array_flow.rb:328:10:328:10 | a [element 2] | array_flow.rb:328:10:328:13 | ...[...] | provenance |  |
 | array_flow.rb:330:5:330:5 | a [element 2] | array_flow.rb:331:9:331:9 | a [element 2] | provenance |  |
 | array_flow.rb:330:5:330:5 | a [element 3] | array_flow.rb:331:9:331:9 | a [element 3] | provenance |  |
-| array_flow.rb:330:16:330:27 | call to source | array_flow.rb:330:5:330:5 | a [element 2] | provenance |  |
-| array_flow.rb:330:30:330:41 | call to source | array_flow.rb:330:5:330:5 | a [element 3] | provenance |  |
+| array_flow.rb:330:9:330:42 | call to [] [element 2] | array_flow.rb:330:5:330:5 | a [element 2] | provenance |  |
+| array_flow.rb:330:9:330:42 | call to [] [element 3] | array_flow.rb:330:5:330:5 | a [element 3] | provenance |  |
+| array_flow.rb:330:16:330:27 | call to source | array_flow.rb:330:9:330:42 | call to [] [element 2] | provenance |  |
+| array_flow.rb:330:30:330:41 | call to source | array_flow.rb:330:9:330:42 | call to [] [element 3] | provenance |  |
 | array_flow.rb:331:5:331:5 | b | array_flow.rb:332:10:332:10 | b | provenance |  |
 | array_flow.rb:331:9:331:9 | [post] a [element] | array_flow.rb:333:10:333:10 | a [element] | provenance |  |
 | array_flow.rb:331:9:331:9 | [post] a [element] | array_flow.rb:334:10:334:10 | a [element] | provenance |  |
@@ -354,7 +399,8 @@ edges
 | array_flow.rb:333:10:333:10 | a [element] | array_flow.rb:333:10:333:13 | ...[...] | provenance |  |
 | array_flow.rb:334:10:334:10 | a [element] | array_flow.rb:334:10:334:13 | ...[...] | provenance |  |
 | array_flow.rb:338:5:338:5 | a [element 2] | array_flow.rb:339:9:339:9 | a [element 2] | provenance |  |
-| array_flow.rb:338:16:338:25 | call to source | array_flow.rb:338:5:338:5 | a [element 2] | provenance |  |
+| array_flow.rb:338:9:338:26 | call to [] [element 2] | array_flow.rb:338:5:338:5 | a [element 2] | provenance |  |
+| array_flow.rb:338:16:338:25 | call to source | array_flow.rb:338:9:338:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:339:5:339:5 | b [element] | array_flow.rb:342:10:342:10 | b [element] | provenance |  |
 | array_flow.rb:339:9:339:9 | [post] a [element] | array_flow.rb:343:10:343:10 | a [element] | provenance |  |
 | array_flow.rb:339:9:339:9 | [post] a [element] | array_flow.rb:344:10:344:10 | a [element] | provenance |  |
@@ -369,7 +415,8 @@ edges
 | array_flow.rb:344:10:344:10 | a [element] | array_flow.rb:344:10:344:13 | ...[...] | provenance |  |
 | array_flow.rb:345:10:345:10 | a [element] | array_flow.rb:345:10:345:13 | ...[...] | provenance |  |
 | array_flow.rb:349:5:349:5 | a [element 2] | array_flow.rb:350:9:350:9 | a [element 2] | provenance |  |
-| array_flow.rb:349:16:349:25 | call to source | array_flow.rb:349:5:349:5 | a [element 2] | provenance |  |
+| array_flow.rb:349:9:349:26 | call to [] [element 2] | array_flow.rb:349:5:349:5 | a [element 2] | provenance |  |
+| array_flow.rb:349:16:349:25 | call to source | array_flow.rb:349:9:349:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:350:5:350:5 | b [element] | array_flow.rb:351:10:351:10 | b [element] | provenance |  |
 | array_flow.rb:350:9:350:9 | a [element 2] | array_flow.rb:350:9:350:25 | call to difference [element] | provenance |  |
 | array_flow.rb:350:9:350:25 | call to difference [element] | array_flow.rb:350:5:350:5 | b [element] | provenance |  |
@@ -377,13 +424,17 @@ edges
 | array_flow.rb:355:5:355:5 | a [element 2] | array_flow.rb:357:10:357:10 | a [element 2] | provenance |  |
 | array_flow.rb:355:5:355:5 | a [element 2] | array_flow.rb:358:10:358:10 | a [element 2] | provenance |  |
 | array_flow.rb:355:5:355:5 | a [element 3, element 1] | array_flow.rb:360:10:360:10 | a [element 3, element 1] | provenance |  |
-| array_flow.rb:355:16:355:27 | call to source | array_flow.rb:355:5:355:5 | a [element 2] | provenance |  |
-| array_flow.rb:355:34:355:45 | call to source | array_flow.rb:355:5:355:5 | a [element 3, element 1] | provenance |  |
+| array_flow.rb:355:9:355:47 | call to [] [element 2] | array_flow.rb:355:5:355:5 | a [element 2] | provenance |  |
+| array_flow.rb:355:9:355:47 | call to [] [element 3, element 1] | array_flow.rb:355:5:355:5 | a [element 3, element 1] | provenance |  |
+| array_flow.rb:355:16:355:27 | call to source | array_flow.rb:355:9:355:47 | call to [] [element 2] | provenance |  |
+| array_flow.rb:355:30:355:46 | call to [] [element 1] | array_flow.rb:355:9:355:47 | call to [] [element 3, element 1] | provenance |  |
+| array_flow.rb:355:34:355:45 | call to source | array_flow.rb:355:30:355:46 | call to [] [element 1] | provenance |  |
 | array_flow.rb:357:10:357:10 | a [element 2] | array_flow.rb:357:10:357:17 | call to dig | provenance |  |
 | array_flow.rb:358:10:358:10 | a [element 2] | array_flow.rb:358:10:358:17 | call to dig | provenance |  |
 | array_flow.rb:360:10:360:10 | a [element 3, element 1] | array_flow.rb:360:10:360:19 | call to dig | provenance |  |
 | array_flow.rb:364:5:364:5 | a [element 2] | array_flow.rb:365:9:365:9 | a [element 2] | provenance |  |
-| array_flow.rb:364:16:364:27 | call to source | array_flow.rb:364:5:364:5 | a [element 2] | provenance |  |
+| array_flow.rb:364:9:364:28 | call to [] [element 2] | array_flow.rb:364:5:364:5 | a [element 2] | provenance |  |
+| array_flow.rb:364:16:364:27 | call to source | array_flow.rb:364:9:364:28 | call to [] [element 2] | provenance |  |
 | array_flow.rb:365:5:365:5 | b | array_flow.rb:368:10:368:10 | b | provenance |  |
 | array_flow.rb:365:9:365:9 | a [element 2] | array_flow.rb:365:9:367:7 | call to detect | provenance |  |
 | array_flow.rb:365:9:365:9 | a [element 2] | array_flow.rb:365:43:365:43 | x | provenance |  |
@@ -395,8 +446,10 @@ edges
 | array_flow.rb:372:5:372:5 | a [element 2] | array_flow.rb:380:9:380:9 | a [element 2] | provenance |  |
 | array_flow.rb:372:5:372:5 | a [element 3] | array_flow.rb:373:9:373:9 | a [element 3] | provenance |  |
 | array_flow.rb:372:5:372:5 | a [element 3] | array_flow.rb:375:9:375:9 | a [element 3] | provenance |  |
-| array_flow.rb:372:16:372:27 | call to source | array_flow.rb:372:5:372:5 | a [element 2] | provenance |  |
-| array_flow.rb:372:30:372:41 | call to source | array_flow.rb:372:5:372:5 | a [element 3] | provenance |  |
+| array_flow.rb:372:9:372:42 | call to [] [element 2] | array_flow.rb:372:5:372:5 | a [element 2] | provenance |  |
+| array_flow.rb:372:9:372:42 | call to [] [element 3] | array_flow.rb:372:5:372:5 | a [element 3] | provenance |  |
+| array_flow.rb:372:16:372:27 | call to source | array_flow.rb:372:9:372:42 | call to [] [element 2] | provenance |  |
+| array_flow.rb:372:30:372:41 | call to source | array_flow.rb:372:9:372:42 | call to [] [element 3] | provenance |  |
 | array_flow.rb:373:5:373:5 | b [element] | array_flow.rb:374:10:374:10 | b [element] | provenance |  |
 | array_flow.rb:373:9:373:9 | a [element 2] | array_flow.rb:373:9:373:17 | call to drop [element] | provenance |  |
 | array_flow.rb:373:9:373:9 | a [element 3] | array_flow.rb:373:9:373:17 | call to drop [element] | provenance |  |
@@ -429,8 +482,10 @@ edges
 | array_flow.rb:383:10:383:10 | c [element] | array_flow.rb:383:10:383:13 | ...[...] | provenance |  |
 | array_flow.rb:387:5:387:5 | a [element 2] | array_flow.rb:388:9:388:9 | a [element 2] | provenance |  |
 | array_flow.rb:387:5:387:5 | a [element 3] | array_flow.rb:388:9:388:9 | a [element 3] | provenance |  |
-| array_flow.rb:387:16:387:27 | call to source | array_flow.rb:387:5:387:5 | a [element 2] | provenance |  |
-| array_flow.rb:387:30:387:41 | call to source | array_flow.rb:387:5:387:5 | a [element 3] | provenance |  |
+| array_flow.rb:387:9:387:42 | call to [] [element 2] | array_flow.rb:387:5:387:5 | a [element 2] | provenance |  |
+| array_flow.rb:387:9:387:42 | call to [] [element 3] | array_flow.rb:387:5:387:5 | a [element 3] | provenance |  |
+| array_flow.rb:387:16:387:27 | call to source | array_flow.rb:387:9:387:42 | call to [] [element 2] | provenance |  |
+| array_flow.rb:387:30:387:41 | call to source | array_flow.rb:387:9:387:42 | call to [] [element 3] | provenance |  |
 | array_flow.rb:388:5:388:5 | b [element] | array_flow.rb:391:10:391:10 | b [element] | provenance |  |
 | array_flow.rb:388:9:388:9 | a [element 2] | array_flow.rb:388:9:390:7 | call to drop_while [element] | provenance |  |
 | array_flow.rb:388:9:388:9 | a [element 2] | array_flow.rb:388:26:388:26 | x | provenance |  |
@@ -440,7 +495,8 @@ edges
 | array_flow.rb:388:26:388:26 | x | array_flow.rb:389:14:389:14 | x | provenance |  |
 | array_flow.rb:391:10:391:10 | b [element] | array_flow.rb:391:10:391:13 | ...[...] | provenance |  |
 | array_flow.rb:395:5:395:5 | a [element 2] | array_flow.rb:396:9:396:9 | a [element 2] | provenance |  |
-| array_flow.rb:395:16:395:25 | call to source | array_flow.rb:395:5:395:5 | a [element 2] | provenance |  |
+| array_flow.rb:395:9:395:26 | call to [] [element 2] | array_flow.rb:395:5:395:5 | a [element 2] | provenance |  |
+| array_flow.rb:395:16:395:25 | call to source | array_flow.rb:395:9:395:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:396:5:396:5 | b [element 2] | array_flow.rb:399:10:399:10 | b [element 2] | provenance |  |
 | array_flow.rb:396:9:396:9 | a [element 2] | array_flow.rb:396:9:398:7 | call to each [element 2] | provenance |  |
 | array_flow.rb:396:9:396:9 | a [element 2] | array_flow.rb:396:20:396:20 | x | provenance |  |
@@ -448,22 +504,23 @@ edges
 | array_flow.rb:396:20:396:20 | x | array_flow.rb:397:14:397:14 | x | provenance |  |
 | array_flow.rb:399:10:399:10 | b [element 2] | array_flow.rb:399:10:399:13 | ...[...] | provenance |  |
 | array_flow.rb:403:5:403:5 | a [element 2] | array_flow.rb:404:18:404:18 | a [element 2] | provenance |  |
-| array_flow.rb:403:16:403:25 | call to source | array_flow.rb:403:5:403:5 | a [element 2] | provenance |  |
+| array_flow.rb:403:9:403:26 | call to [] [element 2] | array_flow.rb:403:5:403:5 | a [element 2] | provenance |  |
+| array_flow.rb:403:16:403:25 | call to source | array_flow.rb:403:9:403:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:404:5:404:5 | b [element 2] | array_flow.rb:408:10:408:10 | b [element 2] | provenance |  |
-| array_flow.rb:404:9:406:7 | [post] { ... } [captured x] | array_flow.rb:407:10:407:10 | x | provenance |  |
-| array_flow.rb:404:9:406:7 | __synth__0__1 | array_flow.rb:405:14:405:14 | x | provenance |  |
 | array_flow.rb:404:18:404:18 | a [element 2] | array_flow.rb:404:5:404:5 | b [element 2] | provenance |  |
-| array_flow.rb:404:18:404:18 | a [element 2] | array_flow.rb:404:9:406:7 | [post] { ... } [captured x] | provenance |  |
-| array_flow.rb:404:18:404:18 | a [element 2] | array_flow.rb:404:9:406:7 | __synth__0__1 | provenance |  |
+| array_flow.rb:404:18:404:18 | a [element 2] | array_flow.rb:405:14:405:14 | x | provenance |  |
+| array_flow.rb:404:18:404:18 | a [element 2] | array_flow.rb:407:10:407:10 | x | provenance |  |
 | array_flow.rb:408:10:408:10 | b [element 2] | array_flow.rb:408:10:408:13 | ...[...] | provenance |  |
 | array_flow.rb:412:5:412:5 | a [element 2] | array_flow.rb:413:5:413:5 | a [element 2] | provenance |  |
-| array_flow.rb:412:16:412:25 | call to source | array_flow.rb:412:5:412:5 | a [element 2] | provenance |  |
+| array_flow.rb:412:9:412:26 | call to [] [element 2] | array_flow.rb:412:5:412:5 | a [element 2] | provenance |  |
+| array_flow.rb:412:16:412:25 | call to source | array_flow.rb:412:9:412:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:413:5:413:5 | a [element 2] | array_flow.rb:413:24:413:24 | x [element] | provenance |  |
 | array_flow.rb:413:24:413:24 | x [element] | array_flow.rb:414:15:414:15 | x [element] | provenance |  |
 | array_flow.rb:414:15:414:15 | x [element] | array_flow.rb:414:15:414:18 | ...[...] | provenance |  |
 | array_flow.rb:414:15:414:18 | ...[...] | array_flow.rb:414:14:414:19 | ( ... ) | provenance |  |
 | array_flow.rb:419:5:419:5 | a [element 2] | array_flow.rb:420:9:420:9 | a [element 2] | provenance |  |
-| array_flow.rb:419:16:419:25 | call to source | array_flow.rb:419:5:419:5 | a [element 2] | provenance |  |
+| array_flow.rb:419:9:419:26 | call to [] [element 2] | array_flow.rb:419:5:419:5 | a [element 2] | provenance |  |
+| array_flow.rb:419:16:419:25 | call to source | array_flow.rb:419:9:419:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:420:5:420:5 | b [element 2] | array_flow.rb:423:10:423:10 | b [element 2] | provenance |  |
 | array_flow.rb:420:9:420:9 | a [element 2] | array_flow.rb:420:9:422:7 | call to each_entry [element 2] | provenance |  |
 | array_flow.rb:420:9:420:9 | a [element 2] | array_flow.rb:420:26:420:26 | x | provenance |  |
@@ -471,18 +528,21 @@ edges
 | array_flow.rb:420:26:420:26 | x | array_flow.rb:421:14:421:14 | x | provenance |  |
 | array_flow.rb:423:10:423:10 | b [element 2] | array_flow.rb:423:10:423:13 | ...[...] | provenance |  |
 | array_flow.rb:427:5:427:5 | a [element 2] | array_flow.rb:428:9:428:9 | a [element 2] | provenance |  |
-| array_flow.rb:427:16:427:25 | call to source | array_flow.rb:427:5:427:5 | a [element 2] | provenance |  |
+| array_flow.rb:427:9:427:26 | call to [] [element 2] | array_flow.rb:427:5:427:5 | a [element 2] | provenance |  |
+| array_flow.rb:427:16:427:25 | call to source | array_flow.rb:427:9:427:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:428:5:428:5 | b [element 2] | array_flow.rb:431:10:431:10 | b [element 2] | provenance |  |
 | array_flow.rb:428:9:428:9 | a [element 2] | array_flow.rb:428:9:430:7 | call to each_index [element 2] | provenance |  |
 | array_flow.rb:428:9:430:7 | call to each_index [element 2] | array_flow.rb:428:5:428:5 | b [element 2] | provenance |  |
 | array_flow.rb:431:10:431:10 | b [element 2] | array_flow.rb:431:10:431:13 | ...[...] | provenance |  |
 | array_flow.rb:435:5:435:5 | a [element 3] | array_flow.rb:436:5:436:5 | a [element 3] | provenance |  |
-| array_flow.rb:435:19:435:28 | call to source | array_flow.rb:435:5:435:5 | a [element 3] | provenance |  |
+| array_flow.rb:435:9:435:29 | call to [] [element 3] | array_flow.rb:435:5:435:5 | a [element 3] | provenance |  |
+| array_flow.rb:435:19:435:28 | call to source | array_flow.rb:435:9:435:29 | call to [] [element 3] | provenance |  |
 | array_flow.rb:436:5:436:5 | a [element 3] | array_flow.rb:436:25:436:25 | x [element] | provenance |  |
 | array_flow.rb:436:25:436:25 | x [element] | array_flow.rb:437:14:437:14 | x [element] | provenance |  |
 | array_flow.rb:437:14:437:14 | x [element] | array_flow.rb:437:14:437:17 | ...[...] | provenance |  |
 | array_flow.rb:442:5:442:5 | a [element 3] | array_flow.rb:443:9:443:9 | a [element 3] | provenance |  |
-| array_flow.rb:442:19:442:28 | call to source | array_flow.rb:442:5:442:5 | a [element 3] | provenance |  |
+| array_flow.rb:442:9:442:29 | call to [] [element 3] | array_flow.rb:442:5:442:5 | a [element 3] | provenance |  |
+| array_flow.rb:442:19:442:28 | call to source | array_flow.rb:442:9:442:29 | call to [] [element 3] | provenance |  |
 | array_flow.rb:443:5:443:5 | b [element 3] | array_flow.rb:447:10:447:10 | b [element 3] | provenance |  |
 | array_flow.rb:443:9:443:9 | a [element 3] | array_flow.rb:443:9:446:7 | call to each_with_index [element 3] | provenance |  |
 | array_flow.rb:443:9:443:9 | a [element 3] | array_flow.rb:443:31:443:31 | x | provenance |  |
@@ -490,7 +550,8 @@ edges
 | array_flow.rb:443:31:443:31 | x | array_flow.rb:444:14:444:14 | x | provenance |  |
 | array_flow.rb:447:10:447:10 | b [element 3] | array_flow.rb:447:10:447:13 | ...[...] | provenance |  |
 | array_flow.rb:451:5:451:5 | a [element 3] | array_flow.rb:452:9:452:9 | a [element 3] | provenance |  |
-| array_flow.rb:451:19:451:30 | call to source | array_flow.rb:451:5:451:5 | a [element 3] | provenance |  |
+| array_flow.rb:451:9:451:31 | call to [] [element 3] | array_flow.rb:451:5:451:5 | a [element 3] | provenance |  |
+| array_flow.rb:451:19:451:30 | call to source | array_flow.rb:451:9:451:31 | call to [] [element 3] | provenance |  |
 | array_flow.rb:452:5:452:5 | b | array_flow.rb:456:10:456:10 | b | provenance |  |
 | array_flow.rb:452:9:452:9 | a [element 3] | array_flow.rb:452:46:452:46 | x | provenance |  |
 | array_flow.rb:452:9:455:7 | call to each_with_object | array_flow.rb:452:5:452:5 | b | provenance |  |
@@ -499,7 +560,8 @@ edges
 | array_flow.rb:452:46:452:46 | x | array_flow.rb:453:14:453:14 | x | provenance |  |
 | array_flow.rb:452:48:452:48 | a | array_flow.rb:454:14:454:14 | a | provenance |  |
 | array_flow.rb:460:5:460:5 | a [element 3] | array_flow.rb:461:9:461:9 | a [element 3] | provenance |  |
-| array_flow.rb:460:19:460:28 | call to source | array_flow.rb:460:5:460:5 | a [element 3] | provenance |  |
+| array_flow.rb:460:9:460:29 | call to [] [element 3] | array_flow.rb:460:5:460:5 | a [element 3] | provenance |  |
+| array_flow.rb:460:19:460:28 | call to source | array_flow.rb:460:9:460:29 | call to [] [element 3] | provenance |  |
 | array_flow.rb:461:5:461:5 | b [element 3] | array_flow.rb:462:10:462:10 | b [element 3] | provenance |  |
 | array_flow.rb:461:9:461:9 | a [element 3] | array_flow.rb:461:9:461:17 | call to entries [element 3] | provenance |  |
 | array_flow.rb:461:9:461:17 | call to entries [element 3] | array_flow.rb:461:5:461:5 | b [element 3] | provenance |  |
@@ -510,8 +572,10 @@ edges
 | array_flow.rb:466:5:466:5 | a [element 3] | array_flow.rb:477:9:477:9 | a [element 3] | provenance |  |
 | array_flow.rb:466:5:466:5 | a [element 4] | array_flow.rb:467:9:467:9 | a [element 4] | provenance |  |
 | array_flow.rb:466:5:466:5 | a [element 4] | array_flow.rb:477:9:477:9 | a [element 4] | provenance |  |
-| array_flow.rb:466:19:466:30 | call to source | array_flow.rb:466:5:466:5 | a [element 3] | provenance |  |
-| array_flow.rb:466:33:466:44 | call to source | array_flow.rb:466:5:466:5 | a [element 4] | provenance |  |
+| array_flow.rb:466:9:466:45 | call to [] [element 3] | array_flow.rb:466:5:466:5 | a [element 3] | provenance |  |
+| array_flow.rb:466:9:466:45 | call to [] [element 4] | array_flow.rb:466:5:466:5 | a [element 4] | provenance |  |
+| array_flow.rb:466:19:466:30 | call to source | array_flow.rb:466:9:466:45 | call to [] [element 3] | provenance |  |
+| array_flow.rb:466:33:466:44 | call to source | array_flow.rb:466:9:466:45 | call to [] [element 4] | provenance |  |
 | array_flow.rb:467:5:467:5 | b | array_flow.rb:470:10:470:10 | b | provenance |  |
 | array_flow.rb:467:9:467:9 | a [element 3] | array_flow.rb:467:9:469:7 | call to fetch | provenance |  |
 | array_flow.rb:467:9:467:9 | a [element 4] | array_flow.rb:467:9:469:7 | call to fetch | provenance |  |
@@ -534,7 +598,8 @@ edges
 | array_flow.rb:477:9:477:32 | call to fetch | array_flow.rb:477:5:477:5 | b | provenance |  |
 | array_flow.rb:477:20:477:31 | call to source | array_flow.rb:477:9:477:32 | call to fetch | provenance |  |
 | array_flow.rb:482:5:482:5 | a [element 3] | array_flow.rb:484:10:484:10 | a [element 3] | provenance |  |
-| array_flow.rb:482:19:482:30 | call to source | array_flow.rb:482:5:482:5 | a [element 3] | provenance |  |
+| array_flow.rb:482:9:482:31 | call to [] [element 3] | array_flow.rb:482:5:482:5 | a [element 3] | provenance |  |
+| array_flow.rb:482:19:482:30 | call to source | array_flow.rb:482:9:482:31 | call to [] [element 3] | provenance |  |
 | array_flow.rb:483:5:483:5 | [post] a [element] | array_flow.rb:484:10:484:10 | a [element] | provenance |  |
 | array_flow.rb:483:12:483:23 | call to source | array_flow.rb:483:5:483:5 | [post] a [element] | provenance |  |
 | array_flow.rb:484:10:484:10 | a [element 3] | array_flow.rb:484:10:484:13 | ...[...] | provenance |  |
@@ -550,7 +615,8 @@ edges
 | array_flow.rb:492:9:492:20 | call to source | array_flow.rb:491:5:491:5 | [post] a [element] | provenance |  |
 | array_flow.rb:494:10:494:10 | a [element] | array_flow.rb:494:10:494:13 | ...[...] | provenance |  |
 | array_flow.rb:498:5:498:5 | a [element 3] | array_flow.rb:499:9:499:9 | a [element 3] | provenance |  |
-| array_flow.rb:498:19:498:28 | call to source | array_flow.rb:498:5:498:5 | a [element 3] | provenance |  |
+| array_flow.rb:498:9:498:29 | call to [] [element 3] | array_flow.rb:498:5:498:5 | a [element 3] | provenance |  |
+| array_flow.rb:498:19:498:28 | call to source | array_flow.rb:498:9:498:29 | call to [] [element 3] | provenance |  |
 | array_flow.rb:499:5:499:5 | b [element] | array_flow.rb:502:10:502:10 | b [element] | provenance |  |
 | array_flow.rb:499:9:499:9 | a [element 3] | array_flow.rb:499:9:501:7 | call to filter [element] | provenance |  |
 | array_flow.rb:499:9:499:9 | a [element 3] | array_flow.rb:499:22:499:22 | x | provenance |  |
@@ -558,7 +624,8 @@ edges
 | array_flow.rb:499:22:499:22 | x | array_flow.rb:500:14:500:14 | x | provenance |  |
 | array_flow.rb:502:10:502:10 | b [element] | array_flow.rb:502:10:502:13 | ...[...] | provenance |  |
 | array_flow.rb:506:5:506:5 | a [element 3] | array_flow.rb:507:9:507:9 | a [element 3] | provenance |  |
-| array_flow.rb:506:19:506:28 | call to source | array_flow.rb:506:5:506:5 | a [element 3] | provenance |  |
+| array_flow.rb:506:9:506:29 | call to [] [element 3] | array_flow.rb:506:5:506:5 | a [element 3] | provenance |  |
+| array_flow.rb:506:19:506:28 | call to source | array_flow.rb:506:9:506:29 | call to [] [element 3] | provenance |  |
 | array_flow.rb:507:5:507:5 | b [element] | array_flow.rb:511:10:511:10 | b [element] | provenance |  |
 | array_flow.rb:507:9:507:9 | a [element 3] | array_flow.rb:507:9:510:7 | call to filter_map [element] | provenance |  |
 | array_flow.rb:507:9:507:9 | a [element 3] | array_flow.rb:507:26:507:26 | x | provenance |  |
@@ -570,7 +637,8 @@ edges
 | array_flow.rb:519:9:519:20 | call to source | array_flow.rb:518:9:520:7 | call to filter_map [element] | provenance |  |
 | array_flow.rb:521:10:521:10 | d [element] | array_flow.rb:521:10:521:13 | ...[...] | provenance |  |
 | array_flow.rb:525:5:525:5 | a [element 3] | array_flow.rb:526:9:526:9 | a [element 3] | provenance |  |
-| array_flow.rb:525:19:525:28 | call to source | array_flow.rb:525:5:525:5 | a [element 3] | provenance |  |
+| array_flow.rb:525:9:525:29 | call to [] [element 3] | array_flow.rb:525:5:525:5 | a [element 3] | provenance |  |
+| array_flow.rb:525:19:525:28 | call to source | array_flow.rb:525:9:525:29 | call to [] [element 3] | provenance |  |
 | array_flow.rb:526:5:526:5 | b [element] | array_flow.rb:531:10:531:10 | b [element] | provenance |  |
 | array_flow.rb:526:9:526:9 | [post] a [element] | array_flow.rb:530:10:530:10 | a [element] | provenance |  |
 | array_flow.rb:526:9:526:9 | a [element 3] | array_flow.rb:526:9:526:9 | [post] a [element] | provenance |  |
@@ -581,7 +649,8 @@ edges
 | array_flow.rb:530:10:530:10 | a [element] | array_flow.rb:530:10:530:13 | ...[...] | provenance |  |
 | array_flow.rb:531:10:531:10 | b [element] | array_flow.rb:531:10:531:13 | ...[...] | provenance |  |
 | array_flow.rb:535:5:535:5 | a [element 3] | array_flow.rb:536:9:536:9 | a [element 3] | provenance |  |
-| array_flow.rb:535:19:535:30 | call to source | array_flow.rb:535:5:535:5 | a [element 3] | provenance |  |
+| array_flow.rb:535:9:535:31 | call to [] [element 3] | array_flow.rb:535:5:535:5 | a [element 3] | provenance |  |
+| array_flow.rb:535:19:535:30 | call to source | array_flow.rb:535:9:535:31 | call to [] [element 3] | provenance |  |
 | array_flow.rb:536:5:536:5 | b | array_flow.rb:539:10:539:10 | b | provenance |  |
 | array_flow.rb:536:9:536:9 | a [element 3] | array_flow.rb:536:9:538:7 | call to find | provenance |  |
 | array_flow.rb:536:9:536:9 | a [element 3] | array_flow.rb:536:41:536:41 | x | provenance |  |
@@ -589,7 +658,8 @@ edges
 | array_flow.rb:536:21:536:32 | call to source | array_flow.rb:536:9:538:7 | call to find | provenance |  |
 | array_flow.rb:536:41:536:41 | x | array_flow.rb:537:14:537:14 | x | provenance |  |
 | array_flow.rb:543:5:543:5 | a [element 3] | array_flow.rb:544:9:544:9 | a [element 3] | provenance |  |
-| array_flow.rb:543:19:543:28 | call to source | array_flow.rb:543:5:543:5 | a [element 3] | provenance |  |
+| array_flow.rb:543:9:543:29 | call to [] [element 3] | array_flow.rb:543:5:543:5 | a [element 3] | provenance |  |
+| array_flow.rb:543:19:543:28 | call to source | array_flow.rb:543:9:543:29 | call to [] [element 3] | provenance |  |
 | array_flow.rb:544:5:544:5 | b [element] | array_flow.rb:547:10:547:10 | b [element] | provenance |  |
 | array_flow.rb:544:9:544:9 | a [element 3] | array_flow.rb:544:9:546:7 | call to find_all [element] | provenance |  |
 | array_flow.rb:544:9:544:9 | a [element 3] | array_flow.rb:544:24:544:24 | x | provenance |  |
@@ -597,15 +667,18 @@ edges
 | array_flow.rb:544:24:544:24 | x | array_flow.rb:545:14:545:14 | x | provenance |  |
 | array_flow.rb:547:10:547:10 | b [element] | array_flow.rb:547:10:547:13 | ...[...] | provenance |  |
 | array_flow.rb:551:5:551:5 | a [element 3] | array_flow.rb:552:5:552:5 | a [element 3] | provenance |  |
-| array_flow.rb:551:19:551:28 | call to source | array_flow.rb:551:5:551:5 | a [element 3] | provenance |  |
+| array_flow.rb:551:9:551:29 | call to [] [element 3] | array_flow.rb:551:5:551:5 | a [element 3] | provenance |  |
+| array_flow.rb:551:19:551:28 | call to source | array_flow.rb:551:9:551:29 | call to [] [element 3] | provenance |  |
 | array_flow.rb:552:5:552:5 | a [element 3] | array_flow.rb:552:22:552:22 | x | provenance |  |
 | array_flow.rb:552:22:552:22 | x | array_flow.rb:553:14:553:14 | x | provenance |  |
 | array_flow.rb:558:5:558:5 | a [element 0] | array_flow.rb:560:10:560:10 | a [element 0] | provenance |  |
 | array_flow.rb:558:5:558:5 | a [element 0] | array_flow.rb:561:9:561:9 | a [element 0] | provenance |  |
 | array_flow.rb:558:5:558:5 | a [element 0] | array_flow.rb:564:9:564:9 | a [element 0] | provenance |  |
 | array_flow.rb:558:5:558:5 | a [element 3] | array_flow.rb:564:9:564:9 | a [element 3] | provenance |  |
-| array_flow.rb:558:10:558:21 | call to source | array_flow.rb:558:5:558:5 | a [element 0] | provenance |  |
-| array_flow.rb:558:30:558:41 | call to source | array_flow.rb:558:5:558:5 | a [element 3] | provenance |  |
+| array_flow.rb:558:9:558:42 | call to [] [element 0] | array_flow.rb:558:5:558:5 | a [element 0] | provenance |  |
+| array_flow.rb:558:9:558:42 | call to [] [element 3] | array_flow.rb:558:5:558:5 | a [element 3] | provenance |  |
+| array_flow.rb:558:10:558:21 | call to source | array_flow.rb:558:9:558:42 | call to [] [element 0] | provenance |  |
+| array_flow.rb:558:30:558:41 | call to source | array_flow.rb:558:9:558:42 | call to [] [element 3] | provenance |  |
 | array_flow.rb:559:5:559:5 | [post] a [element] | array_flow.rb:560:10:560:10 | a [element] | provenance |  |
 | array_flow.rb:559:5:559:5 | [post] a [element] | array_flow.rb:561:9:561:9 | a [element] | provenance |  |
 | array_flow.rb:559:5:559:5 | [post] a [element] | array_flow.rb:564:9:564:9 | a [element] | provenance |  |
@@ -638,13 +711,15 @@ edges
 | array_flow.rb:566:10:566:10 | c [element] | array_flow.rb:566:10:566:13 | ...[...] | provenance |  |
 | array_flow.rb:570:5:570:5 | a [element 2] | array_flow.rb:571:9:571:9 | a [element 2] | provenance |  |
 | array_flow.rb:570:5:570:5 | a [element 2] | array_flow.rb:576:9:576:9 | a [element 2] | provenance |  |
-| array_flow.rb:570:16:570:27 | call to source | array_flow.rb:570:5:570:5 | a [element 2] | provenance |  |
+| array_flow.rb:570:9:570:28 | call to [] [element 2] | array_flow.rb:570:5:570:5 | a [element 2] | provenance |  |
+| array_flow.rb:570:16:570:27 | call to source | array_flow.rb:570:9:570:28 | call to [] [element 2] | provenance |  |
 | array_flow.rb:571:5:571:5 | b [element] | array_flow.rb:575:10:575:10 | b [element] | provenance |  |
 | array_flow.rb:571:9:571:9 | a [element 2] | array_flow.rb:571:9:574:7 | call to flat_map [element] | provenance |  |
 | array_flow.rb:571:9:571:9 | a [element 2] | array_flow.rb:571:24:571:24 | x | provenance |  |
 | array_flow.rb:571:9:574:7 | call to flat_map [element] | array_flow.rb:571:5:571:5 | b [element] | provenance |  |
 | array_flow.rb:571:24:571:24 | x | array_flow.rb:572:14:572:14 | x | provenance |  |
-| array_flow.rb:573:13:573:24 | call to source | array_flow.rb:571:9:574:7 | call to flat_map [element] | provenance |  |
+| array_flow.rb:573:9:573:25 | call to [] [element 1] | array_flow.rb:571:9:574:7 | call to flat_map [element] | provenance |  |
+| array_flow.rb:573:13:573:24 | call to source | array_flow.rb:573:9:573:25 | call to [] [element 1] | provenance |  |
 | array_flow.rb:575:10:575:10 | b [element] | array_flow.rb:575:10:575:13 | ...[...] | provenance |  |
 | array_flow.rb:576:5:576:5 | b [element] | array_flow.rb:580:10:580:10 | b [element] | provenance |  |
 | array_flow.rb:576:9:576:9 | a [element 2] | array_flow.rb:576:24:576:24 | x | provenance |  |
@@ -653,14 +728,18 @@ edges
 | array_flow.rb:578:9:578:20 | call to source | array_flow.rb:576:9:579:7 | call to flat_map [element] | provenance |  |
 | array_flow.rb:580:10:580:10 | b [element] | array_flow.rb:580:10:580:13 | ...[...] | provenance |  |
 | array_flow.rb:584:5:584:5 | a [element 2, element 1] | array_flow.rb:585:9:585:9 | a [element 2, element 1] | provenance |  |
-| array_flow.rb:584:20:584:29 | call to source | array_flow.rb:584:5:584:5 | a [element 2, element 1] | provenance |  |
+| array_flow.rb:584:9:584:31 | call to [] [element 2, element 1] | array_flow.rb:584:5:584:5 | a [element 2, element 1] | provenance |  |
+| array_flow.rb:584:16:584:30 | call to [] [element 1] | array_flow.rb:584:9:584:31 | call to [] [element 2, element 1] | provenance |  |
+| array_flow.rb:584:20:584:29 | call to source | array_flow.rb:584:16:584:30 | call to [] [element 1] | provenance |  |
 | array_flow.rb:585:5:585:5 | b [element] | array_flow.rb:586:10:586:10 | b [element] | provenance |  |
 | array_flow.rb:585:9:585:9 | a [element 2, element 1] | array_flow.rb:585:9:585:17 | call to flatten [element] | provenance |  |
 | array_flow.rb:585:9:585:17 | call to flatten [element] | array_flow.rb:585:5:585:5 | b [element] | provenance |  |
 | array_flow.rb:586:10:586:10 | b [element] | array_flow.rb:586:10:586:13 | ...[...] | provenance |  |
 | array_flow.rb:590:5:590:5 | a [element 2, element 1] | array_flow.rb:591:10:591:10 | a [element 2, element 1] | provenance |  |
 | array_flow.rb:590:5:590:5 | a [element 2, element 1] | array_flow.rb:592:9:592:9 | a [element 2, element 1] | provenance |  |
-| array_flow.rb:590:20:590:29 | call to source | array_flow.rb:590:5:590:5 | a [element 2, element 1] | provenance |  |
+| array_flow.rb:590:9:590:31 | call to [] [element 2, element 1] | array_flow.rb:590:5:590:5 | a [element 2, element 1] | provenance |  |
+| array_flow.rb:590:16:590:30 | call to [] [element 1] | array_flow.rb:590:9:590:31 | call to [] [element 2, element 1] | provenance |  |
+| array_flow.rb:590:20:590:29 | call to source | array_flow.rb:590:16:590:30 | call to [] [element 1] | provenance |  |
 | array_flow.rb:591:10:591:10 | a [element 2, element 1] | array_flow.rb:591:10:591:13 | ...[...] [element 1] | provenance |  |
 | array_flow.rb:591:10:591:13 | ...[...] [element 1] | array_flow.rb:591:10:591:16 | ...[...] | provenance |  |
 | array_flow.rb:592:5:592:5 | b [element, element 1] | array_flow.rb:596:10:596:10 | b [element, element 1] | provenance |  |
@@ -681,7 +760,8 @@ edges
 | array_flow.rb:596:10:596:13 | ...[...] [element 1] | array_flow.rb:596:10:596:16 | ...[...] | provenance |  |
 | array_flow.rb:600:5:600:5 | a [element 3] | array_flow.rb:601:9:601:9 | a [element 3] | provenance |  |
 | array_flow.rb:600:5:600:5 | a [element 3] | array_flow.rb:603:9:603:9 | a [element 3] | provenance |  |
-| array_flow.rb:600:19:600:30 | call to source | array_flow.rb:600:5:600:5 | a [element 3] | provenance |  |
+| array_flow.rb:600:9:600:31 | call to [] [element 3] | array_flow.rb:600:5:600:5 | a [element 3] | provenance |  |
+| array_flow.rb:600:19:600:30 | call to source | array_flow.rb:600:9:600:31 | call to [] [element 3] | provenance |  |
 | array_flow.rb:601:5:601:5 | b [element] | array_flow.rb:602:10:602:10 | b [element] | provenance |  |
 | array_flow.rb:601:9:601:9 | a [element 3] | array_flow.rb:601:9:601:20 | call to grep [element] | provenance |  |
 | array_flow.rb:601:9:601:20 | call to grep [element] | array_flow.rb:601:5:601:5 | b [element] | provenance |  |
@@ -694,7 +774,8 @@ edges
 | array_flow.rb:607:10:607:10 | b [element] | array_flow.rb:607:10:607:13 | ...[...] | provenance |  |
 | array_flow.rb:611:5:611:5 | a [element 3] | array_flow.rb:612:9:612:9 | a [element 3] | provenance |  |
 | array_flow.rb:611:5:611:5 | a [element 3] | array_flow.rb:614:9:614:9 | a [element 3] | provenance |  |
-| array_flow.rb:611:19:611:30 | call to source | array_flow.rb:611:5:611:5 | a [element 3] | provenance |  |
+| array_flow.rb:611:9:611:31 | call to [] [element 3] | array_flow.rb:611:5:611:5 | a [element 3] | provenance |  |
+| array_flow.rb:611:19:611:30 | call to source | array_flow.rb:611:9:611:31 | call to [] [element 3] | provenance |  |
 | array_flow.rb:612:5:612:5 | b [element] | array_flow.rb:613:10:613:10 | b [element] | provenance |  |
 | array_flow.rb:612:9:612:9 | a [element 3] | array_flow.rb:612:9:612:21 | call to grep_v [element] | provenance |  |
 | array_flow.rb:612:9:612:21 | call to grep_v [element] | array_flow.rb:612:5:612:5 | b [element] | provenance |  |
@@ -706,19 +787,23 @@ edges
 | array_flow.rb:616:9:616:20 | call to source | array_flow.rb:614:9:617:7 | call to grep_v [element] | provenance |  |
 | array_flow.rb:618:10:618:10 | b [element] | array_flow.rb:618:10:618:13 | ...[...] | provenance |  |
 | array_flow.rb:622:5:622:5 | a [element 3] | array_flow.rb:623:9:623:9 | a [element 3] | provenance |  |
-| array_flow.rb:622:19:622:30 | call to source | array_flow.rb:622:5:622:5 | a [element 3] | provenance |  |
+| array_flow.rb:622:9:622:31 | call to [] [element 3] | array_flow.rb:622:5:622:5 | a [element 3] | provenance |  |
+| array_flow.rb:622:19:622:30 | call to source | array_flow.rb:622:9:622:31 | call to [] [element 3] | provenance |  |
 | array_flow.rb:623:9:623:9 | a [element 3] | array_flow.rb:623:24:623:24 | x | provenance |  |
 | array_flow.rb:623:24:623:24 | x | array_flow.rb:624:14:624:14 | x | provenance |  |
 | array_flow.rb:631:5:631:5 | a [element 3] | array_flow.rb:632:5:632:5 | a [element 3] | provenance |  |
-| array_flow.rb:631:19:631:28 | call to source | array_flow.rb:631:5:631:5 | a [element 3] | provenance |  |
+| array_flow.rb:631:9:631:29 | call to [] [element 3] | array_flow.rb:631:5:631:5 | a [element 3] | provenance |  |
+| array_flow.rb:631:19:631:28 | call to source | array_flow.rb:631:9:631:29 | call to [] [element 3] | provenance |  |
 | array_flow.rb:632:5:632:5 | a [element 3] | array_flow.rb:632:17:632:17 | x | provenance |  |
 | array_flow.rb:632:17:632:17 | x | array_flow.rb:633:14:633:14 | x | provenance |  |
 | array_flow.rb:638:5:638:5 | a [element 0] | array_flow.rb:639:9:639:9 | a [element 0] | provenance |  |
 | array_flow.rb:638:5:638:5 | a [element 0] | array_flow.rb:645:9:645:9 | a [element 0] | provenance |  |
 | array_flow.rb:638:5:638:5 | a [element 2] | array_flow.rb:639:9:639:9 | a [element 2] | provenance |  |
 | array_flow.rb:638:5:638:5 | a [element 2] | array_flow.rb:645:9:645:9 | a [element 2] | provenance |  |
-| array_flow.rb:638:10:638:21 | call to source | array_flow.rb:638:5:638:5 | a [element 0] | provenance |  |
-| array_flow.rb:638:27:638:38 | call to source | array_flow.rb:638:5:638:5 | a [element 2] | provenance |  |
+| array_flow.rb:638:9:638:39 | call to [] [element 0] | array_flow.rb:638:5:638:5 | a [element 0] | provenance |  |
+| array_flow.rb:638:9:638:39 | call to [] [element 2] | array_flow.rb:638:5:638:5 | a [element 2] | provenance |  |
+| array_flow.rb:638:10:638:21 | call to source | array_flow.rb:638:9:638:39 | call to [] [element 0] | provenance |  |
+| array_flow.rb:638:27:638:38 | call to source | array_flow.rb:638:9:638:39 | call to [] [element 2] | provenance |  |
 | array_flow.rb:639:5:639:5 | b | array_flow.rb:644:10:644:10 | b | provenance |  |
 | array_flow.rb:639:9:639:9 | a [element 0] | array_flow.rb:639:22:639:22 | x | provenance |  |
 | array_flow.rb:639:9:639:9 | a [element 2] | array_flow.rb:639:25:639:25 | y | provenance |  |
@@ -733,7 +818,8 @@ edges
 | array_flow.rb:645:28:645:28 | y | array_flow.rb:647:14:647:14 | y | provenance |  |
 | array_flow.rb:648:9:648:19 | call to source | array_flow.rb:645:9:649:7 | call to inject | provenance |  |
 | array_flow.rb:655:5:655:5 | a [element 2] | array_flow.rb:656:9:656:9 | a [element 2] | provenance |  |
-| array_flow.rb:655:16:655:27 | call to source | array_flow.rb:655:5:655:5 | a [element 2] | provenance |  |
+| array_flow.rb:655:9:655:28 | call to [] [element 2] | array_flow.rb:655:5:655:5 | a [element 2] | provenance |  |
+| array_flow.rb:655:16:655:27 | call to source | array_flow.rb:655:9:655:28 | call to [] [element 2] | provenance |  |
 | array_flow.rb:656:5:656:5 | b [element 1] | array_flow.rb:663:10:663:10 | b [element 1] | provenance |  |
 | array_flow.rb:656:5:656:5 | b [element 2] | array_flow.rb:664:10:664:10 | b [element 2] | provenance |  |
 | array_flow.rb:656:5:656:5 | b [element 4] | array_flow.rb:666:10:666:10 | b [element 4] | provenance |  |
@@ -756,7 +842,8 @@ edges
 | array_flow.rb:664:10:664:10 | b [element 2] | array_flow.rb:664:10:664:13 | ...[...] | provenance |  |
 | array_flow.rb:666:10:666:10 | b [element 4] | array_flow.rb:666:10:666:13 | ...[...] | provenance |  |
 | array_flow.rb:669:5:669:5 | c [element 2] | array_flow.rb:670:9:670:9 | c [element 2] | provenance |  |
-| array_flow.rb:669:16:669:27 | call to source | array_flow.rb:669:5:669:5 | c [element 2] | provenance |  |
+| array_flow.rb:669:9:669:28 | call to [] [element 2] | array_flow.rb:669:5:669:5 | c [element 2] | provenance |  |
+| array_flow.rb:669:16:669:27 | call to source | array_flow.rb:669:9:669:28 | call to [] [element 2] | provenance |  |
 | array_flow.rb:670:5:670:5 | d [element] | array_flow.rb:672:10:672:10 | d [element] | provenance |  |
 | array_flow.rb:670:9:670:9 | [post] c [element] | array_flow.rb:671:10:671:10 | c [element] | provenance |  |
 | array_flow.rb:670:9:670:9 | c [element 2] | array_flow.rb:670:9:670:9 | [post] c [element] | provenance |  |
@@ -769,15 +856,19 @@ edges
 | array_flow.rb:671:10:671:10 | c [element] | array_flow.rb:671:10:671:13 | ...[...] | provenance |  |
 | array_flow.rb:672:10:672:10 | d [element] | array_flow.rb:672:10:672:13 | ...[...] | provenance |  |
 | array_flow.rb:683:5:683:5 | a [element 2] | array_flow.rb:684:9:684:9 | a [element 2] | provenance |  |
-| array_flow.rb:683:16:683:27 | call to source | array_flow.rb:683:5:683:5 | a [element 2] | provenance |  |
+| array_flow.rb:683:9:683:28 | call to [] [element 2] | array_flow.rb:683:5:683:5 | a [element 2] | provenance |  |
+| array_flow.rb:683:16:683:27 | call to source | array_flow.rb:683:9:683:28 | call to [] [element 2] | provenance |  |
 | array_flow.rb:684:5:684:5 | b [element] | array_flow.rb:685:10:685:10 | b [element] | provenance |  |
 | array_flow.rb:684:9:684:9 | a [element 2] | array_flow.rb:684:9:684:60 | call to intersection [element] | provenance |  |
 | array_flow.rb:684:9:684:60 | call to intersection [element] | array_flow.rb:684:5:684:5 | b [element] | provenance |  |
-| array_flow.rb:684:31:684:42 | call to source | array_flow.rb:684:9:684:60 | call to intersection [element] | provenance |  |
-| array_flow.rb:684:47:684:58 | call to source | array_flow.rb:684:9:684:60 | call to intersection [element] | provenance |  |
+| array_flow.rb:684:24:684:43 | call to [] [element 2] | array_flow.rb:684:9:684:60 | call to intersection [element] | provenance |  |
+| array_flow.rb:684:31:684:42 | call to source | array_flow.rb:684:24:684:43 | call to [] [element 2] | provenance |  |
+| array_flow.rb:684:46:684:59 | call to [] [element 0] | array_flow.rb:684:9:684:60 | call to intersection [element] | provenance |  |
+| array_flow.rb:684:47:684:58 | call to source | array_flow.rb:684:46:684:59 | call to [] [element 0] | provenance |  |
 | array_flow.rb:685:10:685:10 | b [element] | array_flow.rb:685:10:685:13 | ...[...] | provenance |  |
 | array_flow.rb:689:5:689:5 | a [element 2] | array_flow.rb:690:9:690:9 | a [element 2] | provenance |  |
-| array_flow.rb:689:16:689:25 | call to source | array_flow.rb:689:5:689:5 | a [element 2] | provenance |  |
+| array_flow.rb:689:9:689:26 | call to [] [element 2] | array_flow.rb:689:5:689:5 | a [element 2] | provenance |  |
+| array_flow.rb:689:16:689:25 | call to source | array_flow.rb:689:9:689:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:690:5:690:5 | b [element] | array_flow.rb:695:10:695:10 | b [element] | provenance |  |
 | array_flow.rb:690:9:690:9 | [post] a [element] | array_flow.rb:694:10:694:10 | a [element] | provenance |  |
 | array_flow.rb:690:9:690:9 | a [element 2] | array_flow.rb:690:9:690:9 | [post] a [element] | provenance |  |
@@ -789,7 +880,8 @@ edges
 | array_flow.rb:695:10:695:10 | b [element] | array_flow.rb:695:10:695:13 | ...[...] | provenance |  |
 | array_flow.rb:699:5:699:5 | a [element 2] | array_flow.rb:701:10:701:10 | a [element 2] | provenance |  |
 | array_flow.rb:699:5:699:5 | a [element 2] | array_flow.rb:702:9:702:9 | a [element 2] | provenance |  |
-| array_flow.rb:699:16:699:27 | call to source | array_flow.rb:699:5:699:5 | a [element 2] | provenance |  |
+| array_flow.rb:699:9:699:28 | call to [] [element 2] | array_flow.rb:699:5:699:5 | a [element 2] | provenance |  |
+| array_flow.rb:699:16:699:27 | call to source | array_flow.rb:699:9:699:28 | call to [] [element 2] | provenance |  |
 | array_flow.rb:700:5:700:5 | [post] a [element] | array_flow.rb:701:10:701:10 | a [element] | provenance |  |
 | array_flow.rb:700:5:700:5 | [post] a [element] | array_flow.rb:702:9:702:9 | a [element] | provenance |  |
 | array_flow.rb:700:12:700:23 | call to source | array_flow.rb:700:5:700:5 | [post] a [element] | provenance |  |
@@ -803,7 +895,8 @@ edges
 | array_flow.rb:703:10:703:10 | b [element] | array_flow.rb:703:10:703:13 | ...[...] | provenance |  |
 | array_flow.rb:704:10:704:10 | b [element] | array_flow.rb:704:10:704:13 | ...[...] | provenance |  |
 | array_flow.rb:708:5:708:5 | a [element 2] | array_flow.rb:709:9:709:9 | a [element 2] | provenance |  |
-| array_flow.rb:708:16:708:27 | call to source | array_flow.rb:708:5:708:5 | a [element 2] | provenance |  |
+| array_flow.rb:708:9:708:28 | call to [] [element 2] | array_flow.rb:708:5:708:5 | a [element 2] | provenance |  |
+| array_flow.rb:708:16:708:27 | call to source | array_flow.rb:708:9:708:28 | call to [] [element 2] | provenance |  |
 | array_flow.rb:709:5:709:5 | b [element] | array_flow.rb:713:10:713:10 | b [element] | provenance |  |
 | array_flow.rb:709:9:709:9 | a [element 2] | array_flow.rb:709:19:709:19 | x | provenance |  |
 | array_flow.rb:709:9:712:7 | call to map [element] | array_flow.rb:709:5:709:5 | b [element] | provenance |  |
@@ -811,7 +904,8 @@ edges
 | array_flow.rb:711:9:711:19 | call to source | array_flow.rb:709:9:712:7 | call to map [element] | provenance |  |
 | array_flow.rb:713:10:713:10 | b [element] | array_flow.rb:713:10:713:13 | ...[...] | provenance |  |
 | array_flow.rb:717:5:717:5 | a [element 2] | array_flow.rb:718:9:718:9 | a [element 2] | provenance |  |
-| array_flow.rb:717:16:717:27 | call to source | array_flow.rb:717:5:717:5 | a [element 2] | provenance |  |
+| array_flow.rb:717:9:717:28 | call to [] [element 2] | array_flow.rb:717:5:717:5 | a [element 2] | provenance |  |
+| array_flow.rb:717:16:717:27 | call to source | array_flow.rb:717:9:717:28 | call to [] [element 2] | provenance |  |
 | array_flow.rb:718:5:718:5 | b [element] | array_flow.rb:722:10:722:10 | b [element] | provenance |  |
 | array_flow.rb:718:9:718:9 | a [element 2] | array_flow.rb:718:20:718:20 | x | provenance |  |
 | array_flow.rb:718:9:721:7 | call to map! [element] | array_flow.rb:718:5:718:5 | b [element] | provenance |  |
@@ -822,7 +916,8 @@ edges
 | array_flow.rb:726:5:726:5 | a [element 2] | array_flow.rb:733:9:733:9 | a [element 2] | provenance |  |
 | array_flow.rb:726:5:726:5 | a [element 2] | array_flow.rb:737:9:737:9 | a [element 2] | provenance |  |
 | array_flow.rb:726:5:726:5 | a [element 2] | array_flow.rb:745:9:745:9 | a [element 2] | provenance |  |
-| array_flow.rb:726:16:726:25 | call to source | array_flow.rb:726:5:726:5 | a [element 2] | provenance |  |
+| array_flow.rb:726:9:726:26 | call to [] [element 2] | array_flow.rb:726:5:726:5 | a [element 2] | provenance |  |
+| array_flow.rb:726:16:726:25 | call to source | array_flow.rb:726:9:726:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:729:5:729:5 | b | array_flow.rb:730:10:730:10 | b | provenance |  |
 | array_flow.rb:729:9:729:9 | a [element 2] | array_flow.rb:729:9:729:13 | call to max | provenance |  |
 | array_flow.rb:729:9:729:13 | call to max | array_flow.rb:729:5:729:5 | b | provenance |  |
@@ -847,7 +942,8 @@ edges
 | array_flow.rb:750:10:750:10 | e [element] | array_flow.rb:750:10:750:13 | ...[...] | provenance |  |
 | array_flow.rb:754:5:754:5 | a [element 2] | array_flow.rb:757:9:757:9 | a [element 2] | provenance |  |
 | array_flow.rb:754:5:754:5 | a [element 2] | array_flow.rb:764:9:764:9 | a [element 2] | provenance |  |
-| array_flow.rb:754:16:754:25 | call to source | array_flow.rb:754:5:754:5 | a [element 2] | provenance |  |
+| array_flow.rb:754:9:754:26 | call to [] [element 2] | array_flow.rb:754:5:754:5 | a [element 2] | provenance |  |
+| array_flow.rb:754:16:754:25 | call to source | array_flow.rb:754:9:754:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:757:5:757:5 | b | array_flow.rb:761:10:761:10 | b | provenance |  |
 | array_flow.rb:757:9:757:9 | a [element 2] | array_flow.rb:757:9:760:7 | call to max_by | provenance |  |
 | array_flow.rb:757:9:757:9 | a [element 2] | array_flow.rb:757:22:757:22 | x | provenance |  |
@@ -863,7 +959,8 @@ edges
 | array_flow.rb:772:5:772:5 | a [element 2] | array_flow.rb:779:9:779:9 | a [element 2] | provenance |  |
 | array_flow.rb:772:5:772:5 | a [element 2] | array_flow.rb:783:9:783:9 | a [element 2] | provenance |  |
 | array_flow.rb:772:5:772:5 | a [element 2] | array_flow.rb:791:9:791:9 | a [element 2] | provenance |  |
-| array_flow.rb:772:16:772:25 | call to source | array_flow.rb:772:5:772:5 | a [element 2] | provenance |  |
+| array_flow.rb:772:9:772:26 | call to [] [element 2] | array_flow.rb:772:5:772:5 | a [element 2] | provenance |  |
+| array_flow.rb:772:16:772:25 | call to source | array_flow.rb:772:9:772:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:775:5:775:5 | b | array_flow.rb:776:10:776:10 | b | provenance |  |
 | array_flow.rb:775:9:775:9 | a [element 2] | array_flow.rb:775:9:775:13 | call to min | provenance |  |
 | array_flow.rb:775:9:775:13 | call to min | array_flow.rb:775:5:775:5 | b | provenance |  |
@@ -888,7 +985,8 @@ edges
 | array_flow.rb:796:10:796:10 | e [element] | array_flow.rb:796:10:796:13 | ...[...] | provenance |  |
 | array_flow.rb:800:5:800:5 | a [element 2] | array_flow.rb:803:9:803:9 | a [element 2] | provenance |  |
 | array_flow.rb:800:5:800:5 | a [element 2] | array_flow.rb:810:9:810:9 | a [element 2] | provenance |  |
-| array_flow.rb:800:16:800:25 | call to source | array_flow.rb:800:5:800:5 | a [element 2] | provenance |  |
+| array_flow.rb:800:9:800:26 | call to [] [element 2] | array_flow.rb:800:5:800:5 | a [element 2] | provenance |  |
+| array_flow.rb:800:16:800:25 | call to source | array_flow.rb:800:9:800:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:803:5:803:5 | b | array_flow.rb:807:10:807:10 | b | provenance |  |
 | array_flow.rb:803:9:803:9 | a [element 2] | array_flow.rb:803:9:806:7 | call to min_by | provenance |  |
 | array_flow.rb:803:9:803:9 | a [element 2] | array_flow.rb:803:22:803:22 | x | provenance |  |
@@ -902,7 +1000,8 @@ edges
 | array_flow.rb:814:10:814:10 | c [element] | array_flow.rb:814:10:814:13 | ...[...] | provenance |  |
 | array_flow.rb:818:5:818:5 | a [element 2] | array_flow.rb:820:9:820:9 | a [element 2] | provenance |  |
 | array_flow.rb:818:5:818:5 | a [element 2] | array_flow.rb:824:9:824:9 | a [element 2] | provenance |  |
-| array_flow.rb:818:16:818:25 | call to source | array_flow.rb:818:5:818:5 | a [element 2] | provenance |  |
+| array_flow.rb:818:9:818:26 | call to [] [element 2] | array_flow.rb:818:5:818:5 | a [element 2] | provenance |  |
+| array_flow.rb:818:16:818:25 | call to source | array_flow.rb:818:9:818:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:820:5:820:5 | b [element] | array_flow.rb:821:10:821:10 | b [element] | provenance |  |
 | array_flow.rb:820:5:820:5 | b [element] | array_flow.rb:822:10:822:10 | b [element] | provenance |  |
 | array_flow.rb:820:9:820:9 | a [element 2] | array_flow.rb:820:9:820:16 | call to minmax [element] | provenance |  |
@@ -920,7 +1019,8 @@ edges
 | array_flow.rb:829:10:829:10 | c [element] | array_flow.rb:829:10:829:13 | ...[...] | provenance |  |
 | array_flow.rb:830:10:830:10 | c [element] | array_flow.rb:830:10:830:13 | ...[...] | provenance |  |
 | array_flow.rb:834:5:834:5 | a [element 2] | array_flow.rb:835:9:835:9 | a [element 2] | provenance |  |
-| array_flow.rb:834:16:834:25 | call to source | array_flow.rb:834:5:834:5 | a [element 2] | provenance |  |
+| array_flow.rb:834:9:834:26 | call to [] [element 2] | array_flow.rb:834:5:834:5 | a [element 2] | provenance |  |
+| array_flow.rb:834:16:834:25 | call to source | array_flow.rb:834:9:834:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:835:5:835:5 | b [element] | array_flow.rb:839:10:839:10 | b [element] | provenance |  |
 | array_flow.rb:835:5:835:5 | b [element] | array_flow.rb:840:10:840:10 | b [element] | provenance |  |
 | array_flow.rb:835:9:835:9 | a [element 2] | array_flow.rb:835:9:838:7 | call to minmax_by [element] | provenance |  |
@@ -930,15 +1030,18 @@ edges
 | array_flow.rb:839:10:839:10 | b [element] | array_flow.rb:839:10:839:13 | ...[...] | provenance |  |
 | array_flow.rb:840:10:840:10 | b [element] | array_flow.rb:840:10:840:13 | ...[...] | provenance |  |
 | array_flow.rb:844:5:844:5 | a [element 2] | array_flow.rb:845:5:845:5 | a [element 2] | provenance |  |
-| array_flow.rb:844:16:844:25 | call to source | array_flow.rb:844:5:844:5 | a [element 2] | provenance |  |
+| array_flow.rb:844:9:844:26 | call to [] [element 2] | array_flow.rb:844:5:844:5 | a [element 2] | provenance |  |
+| array_flow.rb:844:16:844:25 | call to source | array_flow.rb:844:9:844:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:845:5:845:5 | a [element 2] | array_flow.rb:845:17:845:17 | x | provenance |  |
 | array_flow.rb:845:17:845:17 | x | array_flow.rb:846:14:846:14 | x | provenance |  |
 | array_flow.rb:853:5:853:5 | a [element 2] | array_flow.rb:854:5:854:5 | a [element 2] | provenance |  |
-| array_flow.rb:853:16:853:25 | call to source | array_flow.rb:853:5:853:5 | a [element 2] | provenance |  |
+| array_flow.rb:853:9:853:26 | call to [] [element 2] | array_flow.rb:853:5:853:5 | a [element 2] | provenance |  |
+| array_flow.rb:853:16:853:25 | call to source | array_flow.rb:853:9:853:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:854:5:854:5 | a [element 2] | array_flow.rb:854:16:854:16 | x | provenance |  |
 | array_flow.rb:854:16:854:16 | x | array_flow.rb:855:14:855:14 | x | provenance |  |
 | array_flow.rb:866:5:866:5 | a [element 2] | array_flow.rb:867:9:867:9 | a [element 2] | provenance |  |
-| array_flow.rb:866:16:866:25 | call to source | array_flow.rb:866:5:866:5 | a [element 2] | provenance |  |
+| array_flow.rb:866:9:866:26 | call to [] [element 2] | array_flow.rb:866:5:866:5 | a [element 2] | provenance |  |
+| array_flow.rb:866:16:866:25 | call to source | array_flow.rb:866:9:866:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:867:5:867:5 | b [element, element] | array_flow.rb:871:10:871:10 | b [element, element] | provenance |  |
 | array_flow.rb:867:5:867:5 | b [element, element] | array_flow.rb:872:10:872:10 | b [element, element] | provenance |  |
 | array_flow.rb:867:9:867:9 | a [element 2] | array_flow.rb:867:9:870:7 | call to partition [element, element] | provenance |  |
@@ -952,7 +1055,8 @@ edges
 | array_flow.rb:876:5:876:5 | a [element 2] | array_flow.rb:878:9:878:9 | a [element 2] | provenance |  |
 | array_flow.rb:876:5:876:5 | a [element 2] | array_flow.rb:886:9:886:9 | a [element 2] | provenance |  |
 | array_flow.rb:876:5:876:5 | a [element 2] | array_flow.rb:893:9:893:9 | a [element 2] | provenance |  |
-| array_flow.rb:876:16:876:25 | call to source | array_flow.rb:876:5:876:5 | a [element 2] | provenance |  |
+| array_flow.rb:876:9:876:26 | call to [] [element 2] | array_flow.rb:876:5:876:5 | a [element 2] | provenance |  |
+| array_flow.rb:876:16:876:25 | call to source | array_flow.rb:876:9:876:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:878:5:878:5 | b [element 2] | array_flow.rb:884:10:884:10 | b [element 2] | provenance |  |
 | array_flow.rb:878:9:878:9 | a [element 2] | array_flow.rb:878:9:882:7 | call to permutation [element 2] | provenance |  |
 | array_flow.rb:878:9:878:9 | a [element 2] | array_flow.rb:878:27:878:27 | x [element] | provenance |  |
@@ -984,8 +1088,10 @@ edges
 | array_flow.rb:905:5:905:5 | a [element 1] | array_flow.rb:909:10:909:10 | a [element 1] | provenance |  |
 | array_flow.rb:905:5:905:5 | a [element 3] | array_flow.rb:906:9:906:9 | a [element 3] | provenance |  |
 | array_flow.rb:905:5:905:5 | a [element 3] | array_flow.rb:911:10:911:10 | a [element 3] | provenance |  |
-| array_flow.rb:905:13:905:24 | call to source | array_flow.rb:905:5:905:5 | a [element 1] | provenance |  |
-| array_flow.rb:905:30:905:41 | call to source | array_flow.rb:905:5:905:5 | a [element 3] | provenance |  |
+| array_flow.rb:905:9:905:42 | call to [] [element 1] | array_flow.rb:905:5:905:5 | a [element 1] | provenance |  |
+| array_flow.rb:905:9:905:42 | call to [] [element 3] | array_flow.rb:905:5:905:5 | a [element 3] | provenance |  |
+| array_flow.rb:905:13:905:24 | call to source | array_flow.rb:905:9:905:42 | call to [] [element 1] | provenance |  |
+| array_flow.rb:905:30:905:41 | call to source | array_flow.rb:905:9:905:42 | call to [] [element 3] | provenance |  |
 | array_flow.rb:906:5:906:5 | b | array_flow.rb:907:10:907:10 | b | provenance |  |
 | array_flow.rb:906:9:906:9 | a [element 1] | array_flow.rb:906:9:906:13 | call to pop | provenance |  |
 | array_flow.rb:906:9:906:9 | a [element 3] | array_flow.rb:906:9:906:13 | call to pop | provenance |  |
@@ -996,8 +1102,10 @@ edges
 | array_flow.rb:913:5:913:5 | a [element 1] | array_flow.rb:918:10:918:10 | a [element 1] | provenance |  |
 | array_flow.rb:913:5:913:5 | a [element 3] | array_flow.rb:914:9:914:9 | a [element 3] | provenance |  |
 | array_flow.rb:913:5:913:5 | a [element 3] | array_flow.rb:920:10:920:10 | a [element 3] | provenance |  |
-| array_flow.rb:913:13:913:24 | call to source | array_flow.rb:913:5:913:5 | a [element 1] | provenance |  |
-| array_flow.rb:913:30:913:41 | call to source | array_flow.rb:913:5:913:5 | a [element 3] | provenance |  |
+| array_flow.rb:913:9:913:42 | call to [] [element 1] | array_flow.rb:913:5:913:5 | a [element 1] | provenance |  |
+| array_flow.rb:913:9:913:42 | call to [] [element 3] | array_flow.rb:913:5:913:5 | a [element 3] | provenance |  |
+| array_flow.rb:913:13:913:24 | call to source | array_flow.rb:913:9:913:42 | call to [] [element 1] | provenance |  |
+| array_flow.rb:913:30:913:41 | call to source | array_flow.rb:913:9:913:42 | call to [] [element 3] | provenance |  |
 | array_flow.rb:914:5:914:5 | b [element] | array_flow.rb:915:10:915:10 | b [element] | provenance |  |
 | array_flow.rb:914:5:914:5 | b [element] | array_flow.rb:916:10:916:10 | b [element] | provenance |  |
 | array_flow.rb:914:9:914:9 | a [element 1] | array_flow.rb:914:9:914:16 | call to pop [element] | provenance |  |
@@ -1008,7 +1116,8 @@ edges
 | array_flow.rb:918:10:918:10 | a [element 1] | array_flow.rb:918:10:918:13 | ...[...] | provenance |  |
 | array_flow.rb:920:10:920:10 | a [element 3] | array_flow.rb:920:10:920:13 | ...[...] | provenance |  |
 | array_flow.rb:924:5:924:5 | a [element 2] | array_flow.rb:925:5:925:5 | a [element 2] | provenance |  |
-| array_flow.rb:924:16:924:27 | call to source | array_flow.rb:924:5:924:5 | a [element 2] | provenance |  |
+| array_flow.rb:924:9:924:28 | call to [] [element 2] | array_flow.rb:924:5:924:5 | a [element 2] | provenance |  |
+| array_flow.rb:924:16:924:27 | call to source | array_flow.rb:924:9:924:28 | call to [] [element 2] | provenance |  |
 | array_flow.rb:925:5:925:5 | [post] a [element 2] | array_flow.rb:928:10:928:10 | a [element 2] | provenance |  |
 | array_flow.rb:925:5:925:5 | [post] a [element 5] | array_flow.rb:931:10:931:10 | a [element 5] | provenance |  |
 | array_flow.rb:925:5:925:5 | a [element 2] | array_flow.rb:925:5:925:5 | [post] a [element 5] | provenance |  |
@@ -1016,11 +1125,14 @@ edges
 | array_flow.rb:928:10:928:10 | a [element 2] | array_flow.rb:928:10:928:13 | ...[...] | provenance |  |
 | array_flow.rb:931:10:931:10 | a [element 5] | array_flow.rb:931:10:931:13 | ...[...] | provenance |  |
 | array_flow.rb:935:5:935:5 | a [element 2] | array_flow.rb:938:9:938:9 | a [element 2] | provenance |  |
-| array_flow.rb:935:16:935:27 | call to source | array_flow.rb:935:5:935:5 | a [element 2] | provenance |  |
+| array_flow.rb:935:9:935:28 | call to [] [element 2] | array_flow.rb:935:5:935:5 | a [element 2] | provenance |  |
+| array_flow.rb:935:16:935:27 | call to source | array_flow.rb:935:9:935:28 | call to [] [element 2] | provenance |  |
 | array_flow.rb:936:5:936:5 | b [element 1] | array_flow.rb:938:19:938:19 | b [element 1] | provenance |  |
-| array_flow.rb:936:13:936:24 | call to source | array_flow.rb:936:5:936:5 | b [element 1] | provenance |  |
+| array_flow.rb:936:9:936:28 | call to [] [element 1] | array_flow.rb:936:5:936:5 | b [element 1] | provenance |  |
+| array_flow.rb:936:13:936:24 | call to source | array_flow.rb:936:9:936:28 | call to [] [element 1] | provenance |  |
 | array_flow.rb:937:5:937:5 | c [element 0] | array_flow.rb:938:22:938:22 | c [element 0] | provenance |  |
-| array_flow.rb:937:10:937:21 | call to source | array_flow.rb:937:5:937:5 | c [element 0] | provenance |  |
+| array_flow.rb:937:9:937:28 | call to [] [element 0] | array_flow.rb:937:5:937:5 | c [element 0] | provenance |  |
+| array_flow.rb:937:10:937:21 | call to source | array_flow.rb:937:9:937:28 | call to [] [element 0] | provenance |  |
 | array_flow.rb:938:5:938:5 | d [element, element] | array_flow.rb:939:10:939:10 | d [element, element] | provenance |  |
 | array_flow.rb:938:5:938:5 | d [element, element] | array_flow.rb:940:10:940:10 | d [element, element] | provenance |  |
 | array_flow.rb:938:9:938:9 | a [element 2] | array_flow.rb:938:9:938:22 | call to product [element, element] | provenance |  |
@@ -1033,7 +1145,8 @@ edges
 | array_flow.rb:940:10:940:13 | ...[...] [element] | array_flow.rb:940:10:940:16 | ...[...] | provenance |  |
 | array_flow.rb:944:5:944:5 | a [element 0] | array_flow.rb:945:9:945:9 | a [element 0] | provenance |  |
 | array_flow.rb:944:5:944:5 | a [element 0] | array_flow.rb:946:10:946:10 | a [element 0] | provenance |  |
-| array_flow.rb:944:10:944:21 | call to source | array_flow.rb:944:5:944:5 | a [element 0] | provenance |  |
+| array_flow.rb:944:9:944:25 | call to [] [element 0] | array_flow.rb:944:5:944:5 | a [element 0] | provenance |  |
+| array_flow.rb:944:10:944:21 | call to source | array_flow.rb:944:9:944:25 | call to [] [element 0] | provenance |  |
 | array_flow.rb:945:5:945:5 | b [element 0] | array_flow.rb:948:10:948:10 | b [element 0] | provenance |  |
 | array_flow.rb:945:5:945:5 | b [element] | array_flow.rb:948:10:948:10 | b [element] | provenance |  |
 | array_flow.rb:945:5:945:5 | b [element] | array_flow.rb:949:10:949:10 | b [element] | provenance |  |
@@ -1053,10 +1166,12 @@ edges
 | array_flow.rb:948:10:948:10 | b [element] | array_flow.rb:948:10:948:13 | ...[...] | provenance |  |
 | array_flow.rb:949:10:949:10 | b [element] | array_flow.rb:949:10:949:13 | ...[...] | provenance |  |
 | array_flow.rb:955:5:955:5 | c [element 0] | array_flow.rb:956:16:956:16 | c [element 0] | provenance |  |
-| array_flow.rb:955:10:955:19 | call to source | array_flow.rb:955:5:955:5 | c [element 0] | provenance |  |
+| array_flow.rb:955:9:955:25 | call to [] [element 0] | array_flow.rb:955:5:955:5 | c [element 0] | provenance |  |
+| array_flow.rb:955:10:955:19 | call to source | array_flow.rb:955:9:955:25 | call to [] [element 0] | provenance |  |
 | array_flow.rb:956:5:956:5 | d [element 2, element 0] | array_flow.rb:957:10:957:10 | d [element 2, element 0] | provenance |  |
 | array_flow.rb:956:5:956:5 | d [element 2, element 0] | array_flow.rb:958:10:958:10 | d [element 2, element 0] | provenance |  |
-| array_flow.rb:956:16:956:16 | c [element 0] | array_flow.rb:956:5:956:5 | d [element 2, element 0] | provenance |  |
+| array_flow.rb:956:9:956:17 | call to [] [element 2, element 0] | array_flow.rb:956:5:956:5 | d [element 2, element 0] | provenance |  |
+| array_flow.rb:956:16:956:16 | c [element 0] | array_flow.rb:956:9:956:17 | call to [] [element 2, element 0] | provenance |  |
 | array_flow.rb:957:10:957:10 | d [element 2, element 0] | array_flow.rb:957:10:957:22 | call to rassoc [element 0] | provenance |  |
 | array_flow.rb:957:10:957:22 | call to rassoc [element 0] | array_flow.rb:957:10:957:25 | ...[...] | provenance |  |
 | array_flow.rb:958:10:958:10 | d [element 2, element 0] | array_flow.rb:958:10:958:22 | call to rassoc [element 0] | provenance |  |
@@ -1065,8 +1180,10 @@ edges
 | array_flow.rb:962:5:962:5 | a [element 0] | array_flow.rb:968:9:968:9 | a [element 0] | provenance |  |
 | array_flow.rb:962:5:962:5 | a [element 2] | array_flow.rb:963:9:963:9 | a [element 2] | provenance |  |
 | array_flow.rb:962:5:962:5 | a [element 2] | array_flow.rb:968:9:968:9 | a [element 2] | provenance |  |
-| array_flow.rb:962:10:962:21 | call to source | array_flow.rb:962:5:962:5 | a [element 0] | provenance |  |
-| array_flow.rb:962:27:962:38 | call to source | array_flow.rb:962:5:962:5 | a [element 2] | provenance |  |
+| array_flow.rb:962:9:962:39 | call to [] [element 0] | array_flow.rb:962:5:962:5 | a [element 0] | provenance |  |
+| array_flow.rb:962:9:962:39 | call to [] [element 2] | array_flow.rb:962:5:962:5 | a [element 2] | provenance |  |
+| array_flow.rb:962:10:962:21 | call to source | array_flow.rb:962:9:962:39 | call to [] [element 0] | provenance |  |
+| array_flow.rb:962:27:962:38 | call to source | array_flow.rb:962:9:962:39 | call to [] [element 2] | provenance |  |
 | array_flow.rb:963:9:963:9 | a [element 0] | array_flow.rb:963:22:963:22 | x | provenance |  |
 | array_flow.rb:963:9:963:9 | a [element 2] | array_flow.rb:963:25:963:25 | y | provenance |  |
 | array_flow.rb:963:22:963:22 | x | array_flow.rb:964:14:964:14 | x | provenance |  |
@@ -1075,7 +1192,8 @@ edges
 | array_flow.rb:968:9:968:9 | a [element 2] | array_flow.rb:968:28:968:28 | y | provenance |  |
 | array_flow.rb:968:28:968:28 | y | array_flow.rb:970:14:970:14 | y | provenance |  |
 | array_flow.rb:976:5:976:5 | a [element 2] | array_flow.rb:977:9:977:9 | a [element 2] | provenance |  |
-| array_flow.rb:976:16:976:25 | call to source | array_flow.rb:976:5:976:5 | a [element 2] | provenance |  |
+| array_flow.rb:976:9:976:26 | call to [] [element 2] | array_flow.rb:976:5:976:5 | a [element 2] | provenance |  |
+| array_flow.rb:976:16:976:25 | call to source | array_flow.rb:976:9:976:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:977:5:977:5 | b [element] | array_flow.rb:981:10:981:10 | b [element] | provenance |  |
 | array_flow.rb:977:9:977:9 | a [element 2] | array_flow.rb:977:9:980:7 | call to reject [element] | provenance |  |
 | array_flow.rb:977:9:977:9 | a [element 2] | array_flow.rb:977:22:977:22 | x | provenance |  |
@@ -1083,7 +1201,8 @@ edges
 | array_flow.rb:977:22:977:22 | x | array_flow.rb:978:14:978:14 | x | provenance |  |
 | array_flow.rb:981:10:981:10 | b [element] | array_flow.rb:981:10:981:13 | ...[...] | provenance |  |
 | array_flow.rb:985:5:985:5 | a [element 2] | array_flow.rb:986:9:986:9 | a [element 2] | provenance |  |
-| array_flow.rb:985:16:985:25 | call to source | array_flow.rb:985:5:985:5 | a [element 2] | provenance |  |
+| array_flow.rb:985:9:985:26 | call to [] [element 2] | array_flow.rb:985:5:985:5 | a [element 2] | provenance |  |
+| array_flow.rb:985:16:985:25 | call to source | array_flow.rb:985:9:985:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:986:5:986:5 | b [element] | array_flow.rb:991:10:991:10 | b [element] | provenance |  |
 | array_flow.rb:986:9:986:9 | [post] a [element] | array_flow.rb:990:10:990:10 | a [element] | provenance |  |
 | array_flow.rb:986:9:986:9 | a [element 2] | array_flow.rb:986:9:986:9 | [post] a [element] | provenance |  |
@@ -1094,7 +1213,8 @@ edges
 | array_flow.rb:990:10:990:10 | a [element] | array_flow.rb:990:10:990:13 | ...[...] | provenance |  |
 | array_flow.rb:991:10:991:10 | b [element] | array_flow.rb:991:10:991:13 | ...[...] | provenance |  |
 | array_flow.rb:995:5:995:5 | a [element 2] | array_flow.rb:996:9:996:9 | a [element 2] | provenance |  |
-| array_flow.rb:995:16:995:25 | call to source | array_flow.rb:995:5:995:5 | a [element 2] | provenance |  |
+| array_flow.rb:995:9:995:26 | call to [] [element 2] | array_flow.rb:995:5:995:5 | a [element 2] | provenance |  |
+| array_flow.rb:995:16:995:25 | call to source | array_flow.rb:995:9:995:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:996:5:996:5 | b [element 2] | array_flow.rb:1001:10:1001:10 | b [element 2] | provenance |  |
 | array_flow.rb:996:9:996:9 | a [element 2] | array_flow.rb:996:9:999:7 | call to repeated_combination [element 2] | provenance |  |
 | array_flow.rb:996:9:996:9 | a [element 2] | array_flow.rb:996:39:996:39 | x [element] | provenance |  |
@@ -1105,7 +1225,8 @@ edges
 | array_flow.rb:998:14:998:14 | x [element] | array_flow.rb:998:14:998:17 | ...[...] | provenance |  |
 | array_flow.rb:1001:10:1001:10 | b [element 2] | array_flow.rb:1001:10:1001:13 | ...[...] | provenance |  |
 | array_flow.rb:1005:5:1005:5 | a [element 2] | array_flow.rb:1006:9:1006:9 | a [element 2] | provenance |  |
-| array_flow.rb:1005:16:1005:25 | call to source | array_flow.rb:1005:5:1005:5 | a [element 2] | provenance |  |
+| array_flow.rb:1005:9:1005:26 | call to [] [element 2] | array_flow.rb:1005:5:1005:5 | a [element 2] | provenance |  |
+| array_flow.rb:1005:16:1005:25 | call to source | array_flow.rb:1005:9:1005:26 | call to [] [element 2] | provenance |  |
 | array_flow.rb:1006:5:1006:5 | b [element 2] | array_flow.rb:1011:10:1011:10 | b [element 2] | provenance |  |
 | array_flow.rb:1006:9:1006:9 | a [element 2] | array_flow.rb:1006:9:1009:7 | call to repeated_permutation [element 2] | provenance |  |
 | array_flow.rb:1006:9:1006:9 | a [element 2] | array_flow.rb:1006:39:1006:39 | x [element] | provenance |  |
@@ -1118,16 +1239,19 @@ edges
 | array_flow.rb:1017:5:1017:5 | b [element 0] | array_flow.rb:1019:10:1019:10 | b [element 0] | provenance |  |
 | array_flow.rb:1017:9:1017:9 | [post] a [element 0] | array_flow.rb:1018:10:1018:10 | a [element 0] | provenance |  |
 | array_flow.rb:1017:9:1017:33 | call to replace [element 0] | array_flow.rb:1017:5:1017:5 | b [element 0] | provenance |  |
-| array_flow.rb:1017:20:1017:31 | call to source | array_flow.rb:1017:9:1017:9 | [post] a [element 0] | provenance |  |
-| array_flow.rb:1017:20:1017:31 | call to source | array_flow.rb:1017:9:1017:33 | call to replace [element 0] | provenance |  |
+| array_flow.rb:1017:19:1017:32 | call to [] [element 0] | array_flow.rb:1017:9:1017:9 | [post] a [element 0] | provenance |  |
+| array_flow.rb:1017:19:1017:32 | call to [] [element 0] | array_flow.rb:1017:9:1017:33 | call to replace [element 0] | provenance |  |
+| array_flow.rb:1017:20:1017:31 | call to source | array_flow.rb:1017:19:1017:32 | call to [] [element 0] | provenance |  |
 | array_flow.rb:1018:10:1018:10 | a [element 0] | array_flow.rb:1018:10:1018:13 | ...[...] | provenance |  |
 | array_flow.rb:1019:10:1019:10 | b [element 0] | array_flow.rb:1019:10:1019:13 | ...[...] | provenance |  |
 | array_flow.rb:1023:5:1023:5 | a [element 2] | array_flow.rb:1024:9:1024:9 | a [element 2] | provenance |  |
 | array_flow.rb:1023:5:1023:5 | a [element 2] | array_flow.rb:1029:10:1029:10 | a [element 2] | provenance |  |
 | array_flow.rb:1023:5:1023:5 | a [element 3] | array_flow.rb:1024:9:1024:9 | a [element 3] | provenance |  |
 | array_flow.rb:1023:5:1023:5 | a [element 3] | array_flow.rb:1030:10:1030:10 | a [element 3] | provenance |  |
-| array_flow.rb:1023:16:1023:28 | call to source | array_flow.rb:1023:5:1023:5 | a [element 2] | provenance |  |
-| array_flow.rb:1023:31:1023:43 | call to source | array_flow.rb:1023:5:1023:5 | a [element 3] | provenance |  |
+| array_flow.rb:1023:9:1023:44 | call to [] [element 2] | array_flow.rb:1023:5:1023:5 | a [element 2] | provenance |  |
+| array_flow.rb:1023:9:1023:44 | call to [] [element 3] | array_flow.rb:1023:5:1023:5 | a [element 3] | provenance |  |
+| array_flow.rb:1023:16:1023:28 | call to source | array_flow.rb:1023:9:1023:44 | call to [] [element 2] | provenance |  |
+| array_flow.rb:1023:31:1023:43 | call to source | array_flow.rb:1023:9:1023:44 | call to [] [element 3] | provenance |  |
 | array_flow.rb:1024:5:1024:5 | b [element] | array_flow.rb:1025:10:1025:10 | b [element] | provenance |  |
 | array_flow.rb:1024:5:1024:5 | b [element] | array_flow.rb:1026:10:1026:10 | b [element] | provenance |  |
 | array_flow.rb:1024:5:1024:5 | b [element] | array_flow.rb:1027:10:1027:10 | b [element] | provenance |  |
@@ -1143,8 +1267,10 @@ edges
 | array_flow.rb:1034:5:1034:5 | a [element 2] | array_flow.rb:1040:10:1040:10 | a [element 2] | provenance |  |
 | array_flow.rb:1034:5:1034:5 | a [element 3] | array_flow.rb:1035:9:1035:9 | a [element 3] | provenance |  |
 | array_flow.rb:1034:5:1034:5 | a [element 3] | array_flow.rb:1041:10:1041:10 | a [element 3] | provenance |  |
-| array_flow.rb:1034:16:1034:28 | call to source | array_flow.rb:1034:5:1034:5 | a [element 2] | provenance |  |
-| array_flow.rb:1034:31:1034:43 | call to source | array_flow.rb:1034:5:1034:5 | a [element 3] | provenance |  |
+| array_flow.rb:1034:9:1034:44 | call to [] [element 2] | array_flow.rb:1034:5:1034:5 | a [element 2] | provenance |  |
+| array_flow.rb:1034:9:1034:44 | call to [] [element 3] | array_flow.rb:1034:5:1034:5 | a [element 3] | provenance |  |
+| array_flow.rb:1034:16:1034:28 | call to source | array_flow.rb:1034:9:1034:44 | call to [] [element 2] | provenance |  |
+| array_flow.rb:1034:31:1034:43 | call to source | array_flow.rb:1034:9:1034:44 | call to [] [element 3] | provenance |  |
 | array_flow.rb:1035:5:1035:5 | b [element] | array_flow.rb:1036:10:1036:10 | b [element] | provenance |  |
 | array_flow.rb:1035:5:1035:5 | b [element] | array_flow.rb:1037:10:1037:10 | b [element] | provenance |  |
 | array_flow.rb:1035:5:1035:5 | b [element] | array_flow.rb:1038:10:1038:10 | b [element] | provenance |  |
@@ -1165,7 +1291,8 @@ edges
 | array_flow.rb:1041:10:1041:10 | a [element 3] | array_flow.rb:1041:10:1041:13 | ...[...] | provenance |  |
 | array_flow.rb:1041:10:1041:10 | a [element] | array_flow.rb:1041:10:1041:13 | ...[...] | provenance |  |
 | array_flow.rb:1045:5:1045:5 | a [element 2] | array_flow.rb:1046:9:1046:9 | a [element 2] | provenance |  |
-| array_flow.rb:1045:16:1045:26 | call to source | array_flow.rb:1045:5:1045:5 | a [element 2] | provenance |  |
+| array_flow.rb:1045:9:1045:27 | call to [] [element 2] | array_flow.rb:1045:5:1045:5 | a [element 2] | provenance |  |
+| array_flow.rb:1045:16:1045:26 | call to source | array_flow.rb:1045:9:1045:27 | call to [] [element 2] | provenance |  |
 | array_flow.rb:1046:5:1046:5 | b [element 2] | array_flow.rb:1049:10:1049:10 | b [element 2] | provenance |  |
 | array_flow.rb:1046:9:1046:9 | a [element 2] | array_flow.rb:1046:9:1048:7 | call to reverse_each [element 2] | provenance |  |
 | array_flow.rb:1046:9:1046:9 | a [element 2] | array_flow.rb:1046:28:1046:28 | x | provenance |  |
@@ -1173,7 +1300,8 @@ edges
 | array_flow.rb:1046:28:1046:28 | x | array_flow.rb:1047:14:1047:14 | x | provenance |  |
 | array_flow.rb:1049:10:1049:10 | b [element 2] | array_flow.rb:1049:10:1049:13 | ...[...] | provenance |  |
 | array_flow.rb:1053:5:1053:5 | a [element 2] | array_flow.rb:1054:5:1054:5 | a [element 2] | provenance |  |
-| array_flow.rb:1053:16:1053:26 | call to source | array_flow.rb:1053:5:1053:5 | a [element 2] | provenance |  |
+| array_flow.rb:1053:9:1053:27 | call to [] [element 2] | array_flow.rb:1053:5:1053:5 | a [element 2] | provenance |  |
+| array_flow.rb:1053:16:1053:26 | call to source | array_flow.rb:1053:9:1053:27 | call to [] [element 2] | provenance |  |
 | array_flow.rb:1054:5:1054:5 | a [element 2] | array_flow.rb:1054:18:1054:18 | x | provenance |  |
 | array_flow.rb:1054:18:1054:18 | x | array_flow.rb:1055:14:1055:14 | x | provenance |  |
 | array_flow.rb:1063:5:1063:5 | a [element 0] | array_flow.rb:1065:9:1065:9 | a [element 0] | provenance |  |
@@ -1188,9 +1316,12 @@ edges
 | array_flow.rb:1063:5:1063:5 | a [element 3] | array_flow.rb:1071:9:1071:9 | a [element 3] | provenance |  |
 | array_flow.rb:1063:5:1063:5 | a [element 3] | array_flow.rb:1077:9:1077:9 | a [element 3] | provenance |  |
 | array_flow.rb:1063:5:1063:5 | a [element 3] | array_flow.rb:1083:9:1083:9 | a [element 3] | provenance |  |
-| array_flow.rb:1063:10:1063:22 | call to source | array_flow.rb:1063:5:1063:5 | a [element 0] | provenance |  |
-| array_flow.rb:1063:28:1063:40 | call to source | array_flow.rb:1063:5:1063:5 | a [element 2] | provenance |  |
-| array_flow.rb:1063:43:1063:55 | call to source | array_flow.rb:1063:5:1063:5 | a [element 3] | provenance |  |
+| array_flow.rb:1063:9:1063:56 | call to [] [element 0] | array_flow.rb:1063:5:1063:5 | a [element 0] | provenance |  |
+| array_flow.rb:1063:9:1063:56 | call to [] [element 2] | array_flow.rb:1063:5:1063:5 | a [element 2] | provenance |  |
+| array_flow.rb:1063:9:1063:56 | call to [] [element 3] | array_flow.rb:1063:5:1063:5 | a [element 3] | provenance |  |
+| array_flow.rb:1063:10:1063:22 | call to source | array_flow.rb:1063:9:1063:56 | call to [] [element 0] | provenance |  |
+| array_flow.rb:1063:28:1063:40 | call to source | array_flow.rb:1063:9:1063:56 | call to [] [element 2] | provenance |  |
+| array_flow.rb:1063:43:1063:55 | call to source | array_flow.rb:1063:9:1063:56 | call to [] [element 3] | provenance |  |
 | array_flow.rb:1065:5:1065:5 | b [element 1] | array_flow.rb:1067:10:1067:10 | b [element 1] | provenance |  |
 | array_flow.rb:1065:5:1065:5 | b [element 2] | array_flow.rb:1068:10:1068:10 | b [element 2] | provenance |  |
 | array_flow.rb:1065:5:1065:5 | b [element] | array_flow.rb:1066:10:1066:10 | b [element] | provenance |  |
@@ -1254,9 +1385,12 @@ edges
 | array_flow.rb:1095:5:1095:5 | a [element 0] | array_flow.rb:1096:9:1096:9 | a [element 0] | provenance |  |
 | array_flow.rb:1095:5:1095:5 | a [element 2] | array_flow.rb:1096:9:1096:9 | a [element 2] | provenance |  |
 | array_flow.rb:1095:5:1095:5 | a [element 3] | array_flow.rb:1096:9:1096:9 | a [element 3] | provenance |  |
-| array_flow.rb:1095:10:1095:22 | call to source | array_flow.rb:1095:5:1095:5 | a [element 0] | provenance |  |
-| array_flow.rb:1095:28:1095:40 | call to source | array_flow.rb:1095:5:1095:5 | a [element 2] | provenance |  |
-| array_flow.rb:1095:43:1095:55 | call to source | array_flow.rb:1095:5:1095:5 | a [element 3] | provenance |  |
+| array_flow.rb:1095:9:1095:56 | call to [] [element 0] | array_flow.rb:1095:5:1095:5 | a [element 0] | provenance |  |
+| array_flow.rb:1095:9:1095:56 | call to [] [element 2] | array_flow.rb:1095:5:1095:5 | a [element 2] | provenance |  |
+| array_flow.rb:1095:9:1095:56 | call to [] [element 3] | array_flow.rb:1095:5:1095:5 | a [element 3] | provenance |  |
+| array_flow.rb:1095:10:1095:22 | call to source | array_flow.rb:1095:9:1095:56 | call to [] [element 0] | provenance |  |
+| array_flow.rb:1095:28:1095:40 | call to source | array_flow.rb:1095:9:1095:56 | call to [] [element 2] | provenance |  |
+| array_flow.rb:1095:43:1095:55 | call to source | array_flow.rb:1095:9:1095:56 | call to [] [element 3] | provenance |  |
 | array_flow.rb:1096:5:1096:5 | b [element 1] | array_flow.rb:1102:10:1102:10 | b [element 1] | provenance |  |
 | array_flow.rb:1096:5:1096:5 | b [element 2] | array_flow.rb:1103:10:1103:10 | b [element 2] | provenance |  |
 | array_flow.rb:1096:5:1096:5 | b [element] | array_flow.rb:1101:10:1101:10 | b [element] | provenance |  |
@@ -1293,9 +1427,12 @@ edges
 | array_flow.rb:1106:5:1106:5 | a [element 0] | array_flow.rb:1107:9:1107:9 | a [element 0] | provenance |  |
 | array_flow.rb:1106:5:1106:5 | a [element 2] | array_flow.rb:1107:9:1107:9 | a [element 2] | provenance |  |
 | array_flow.rb:1106:5:1106:5 | a [element 3] | array_flow.rb:1107:9:1107:9 | a [element 3] | provenance |  |
-| array_flow.rb:1106:10:1106:22 | call to source | array_flow.rb:1106:5:1106:5 | a [element 0] | provenance |  |
-| array_flow.rb:1106:28:1106:40 | call to source | array_flow.rb:1106:5:1106:5 | a [element 2] | provenance |  |
-| array_flow.rb:1106:43:1106:55 | call to source | array_flow.rb:1106:5:1106:5 | a [element 3] | provenance |  |
+| array_flow.rb:1106:9:1106:56 | call to [] [element 0] | array_flow.rb:1106:5:1106:5 | a [element 0] | provenance |  |
+| array_flow.rb:1106:9:1106:56 | call to [] [element 2] | array_flow.rb:1106:5:1106:5 | a [element 2] | provenance |  |
+| array_flow.rb:1106:9:1106:56 | call to [] [element 3] | array_flow.rb:1106:5:1106:5 | a [element 3] | provenance |  |
+| array_flow.rb:1106:10:1106:22 | call to source | array_flow.rb:1106:9:1106:56 | call to [] [element 0] | provenance |  |
+| array_flow.rb:1106:28:1106:40 | call to source | array_flow.rb:1106:9:1106:56 | call to [] [element 2] | provenance |  |
+| array_flow.rb:1106:43:1106:55 | call to source | array_flow.rb:1106:9:1106:56 | call to [] [element 3] | provenance |  |
 | array_flow.rb:1107:5:1107:5 | b [element 0] | array_flow.rb:1112:10:1112:10 | b [element 0] | provenance |  |
 | array_flow.rb:1107:5:1107:5 | b [element 1] | array_flow.rb:1113:10:1113:10 | b [element 1] | provenance |  |
 | array_flow.rb:1107:5:1107:5 | b [element] | array_flow.rb:1112:10:1112:10 | b [element] | provenance |  |
@@ -1332,9 +1469,12 @@ edges
 | array_flow.rb:1117:5:1117:5 | a [element 0] | array_flow.rb:1118:9:1118:9 | a [element 0] | provenance |  |
 | array_flow.rb:1117:5:1117:5 | a [element 2] | array_flow.rb:1118:9:1118:9 | a [element 2] | provenance |  |
 | array_flow.rb:1117:5:1117:5 | a [element 3] | array_flow.rb:1118:9:1118:9 | a [element 3] | provenance |  |
-| array_flow.rb:1117:10:1117:22 | call to source | array_flow.rb:1117:5:1117:5 | a [element 0] | provenance |  |
-| array_flow.rb:1117:28:1117:40 | call to source | array_flow.rb:1117:5:1117:5 | a [element 2] | provenance |  |
-| array_flow.rb:1117:43:1117:55 | call to source | array_flow.rb:1117:5:1117:5 | a [element 3] | provenance |  |
+| array_flow.rb:1117:9:1117:56 | call to [] [element 0] | array_flow.rb:1117:5:1117:5 | a [element 0] | provenance |  |
+| array_flow.rb:1117:9:1117:56 | call to [] [element 2] | array_flow.rb:1117:5:1117:5 | a [element 2] | provenance |  |
+| array_flow.rb:1117:9:1117:56 | call to [] [element 3] | array_flow.rb:1117:5:1117:5 | a [element 3] | provenance |  |
+| array_flow.rb:1117:10:1117:22 | call to source | array_flow.rb:1117:9:1117:56 | call to [] [element 0] | provenance |  |
+| array_flow.rb:1117:28:1117:40 | call to source | array_flow.rb:1117:9:1117:56 | call to [] [element 2] | provenance |  |
+| array_flow.rb:1117:43:1117:55 | call to source | array_flow.rb:1117:9:1117:56 | call to [] [element 3] | provenance |  |
 | array_flow.rb:1118:5:1118:5 | b [element 0] | array_flow.rb:1123:10:1123:10 | b [element 0] | provenance |  |
 | array_flow.rb:1118:5:1118:5 | b [element 2] | array_flow.rb:1125:10:1125:10 | b [element 2] | provenance |  |
 | array_flow.rb:1118:5:1118:5 | b [element 3] | array_flow.rb:1126:10:1126:10 | b [element 3] | provenance |  |
@@ -1359,9 +1499,12 @@ edges
 | array_flow.rb:1128:5:1128:5 | a [element 0] | array_flow.rb:1129:9:1129:9 | a [element 0] | provenance |  |
 | array_flow.rb:1128:5:1128:5 | a [element 2] | array_flow.rb:1129:9:1129:9 | a [element 2] | provenance |  |
 | array_flow.rb:1128:5:1128:5 | a [element 3] | array_flow.rb:1129:9:1129:9 | a [element 3] | provenance |  |
-| array_flow.rb:1128:10:1128:22 | call to source | array_flow.rb:1128:5:1128:5 | a [element 0] | provenance |  |
-| array_flow.rb:1128:28:1128:40 | call to source | array_flow.rb:1128:5:1128:5 | a [element 2] | provenance |  |
-| array_flow.rb:1128:43:1128:55 | call to source | array_flow.rb:1128:5:1128:5 | a [element 3] | provenance |  |
+| array_flow.rb:1128:9:1128:56 | call to [] [element 0] | array_flow.rb:1128:5:1128:5 | a [element 0] | provenance |  |
+| array_flow.rb:1128:9:1128:56 | call to [] [element 2] | array_flow.rb:1128:5:1128:5 | a [element 2] | provenance |  |
+| array_flow.rb:1128:9:1128:56 | call to [] [element 3] | array_flow.rb:1128:5:1128:5 | a [element 3] | provenance |  |
+| array_flow.rb:1128:10:1128:22 | call to source | array_flow.rb:1128:9:1128:56 | call to [] [element 0] | provenance |  |
+| array_flow.rb:1128:28:1128:40 | call to source | array_flow.rb:1128:9:1128:56 | call to [] [element 2] | provenance |  |
+| array_flow.rb:1128:43:1128:55 | call to source | array_flow.rb:1128:9:1128:56 | call to [] [element 3] | provenance |  |
 | array_flow.rb:1129:5:1129:5 | b [element] | array_flow.rb:1134:10:1134:10 | b [element] | provenance |  |
 | array_flow.rb:1129:5:1129:5 | b [element] | array_flow.rb:1135:10:1135:10 | b [element] | provenance |  |
 | array_flow.rb:1129:5:1129:5 | b [element] | array_flow.rb:1136:10:1136:10 | b [element] | provenance |  |
@@ -1386,7 +1529,8 @@ edges
 | array_flow.rb:1136:10:1136:10 | b [element] | array_flow.rb:1136:10:1136:13 | ...[...] | provenance |  |
 | array_flow.rb:1137:10:1137:10 | b [element] | array_flow.rb:1137:10:1137:13 | ...[...] | provenance |  |
 | array_flow.rb:1141:5:1141:5 | a [element 3] | array_flow.rb:1142:9:1142:9 | a [element 3] | provenance |  |
-| array_flow.rb:1141:19:1141:29 | call to source | array_flow.rb:1141:5:1141:5 | a [element 3] | provenance |  |
+| array_flow.rb:1141:9:1141:30 | call to [] [element 3] | array_flow.rb:1141:5:1141:5 | a [element 3] | provenance |  |
+| array_flow.rb:1141:19:1141:29 | call to source | array_flow.rb:1141:9:1141:30 | call to [] [element 3] | provenance |  |
 | array_flow.rb:1142:5:1142:5 | b [element] | array_flow.rb:1145:10:1145:10 | b [element] | provenance |  |
 | array_flow.rb:1142:9:1142:9 | a [element 3] | array_flow.rb:1142:9:1144:7 | call to select [element] | provenance |  |
 | array_flow.rb:1142:9:1142:9 | a [element 3] | array_flow.rb:1142:22:1142:22 | x | provenance |  |
@@ -1394,7 +1538,8 @@ edges
 | array_flow.rb:1142:22:1142:22 | x | array_flow.rb:1143:14:1143:14 | x | provenance |  |
 | array_flow.rb:1145:10:1145:10 | b [element] | array_flow.rb:1145:10:1145:13 | ...[...] | provenance |  |
 | array_flow.rb:1149:5:1149:5 | a [element 2] | array_flow.rb:1150:9:1150:9 | a [element 2] | provenance |  |
-| array_flow.rb:1149:16:1149:26 | call to source | array_flow.rb:1149:5:1149:5 | a [element 2] | provenance |  |
+| array_flow.rb:1149:9:1149:27 | call to [] [element 2] | array_flow.rb:1149:5:1149:5 | a [element 2] | provenance |  |
+| array_flow.rb:1149:16:1149:26 | call to source | array_flow.rb:1149:9:1149:27 | call to [] [element 2] | provenance |  |
 | array_flow.rb:1150:5:1150:5 | b [element] | array_flow.rb:1155:10:1155:10 | b [element] | provenance |  |
 | array_flow.rb:1150:9:1150:9 | [post] a [element] | array_flow.rb:1154:10:1154:10 | a [element] | provenance |  |
 | array_flow.rb:1150:9:1150:9 | a [element 2] | array_flow.rb:1150:9:1150:9 | [post] a [element] | provenance |  |
@@ -1406,8 +1551,10 @@ edges
 | array_flow.rb:1155:10:1155:10 | b [element] | array_flow.rb:1155:10:1155:13 | ...[...] | provenance |  |
 | array_flow.rb:1159:5:1159:5 | a [element 0] | array_flow.rb:1160:9:1160:9 | a [element 0] | provenance |  |
 | array_flow.rb:1159:5:1159:5 | a [element 2] | array_flow.rb:1160:9:1160:9 | a [element 2] | provenance |  |
-| array_flow.rb:1159:10:1159:22 | call to source | array_flow.rb:1159:5:1159:5 | a [element 0] | provenance |  |
-| array_flow.rb:1159:28:1159:40 | call to source | array_flow.rb:1159:5:1159:5 | a [element 2] | provenance |  |
+| array_flow.rb:1159:9:1159:41 | call to [] [element 0] | array_flow.rb:1159:5:1159:5 | a [element 0] | provenance |  |
+| array_flow.rb:1159:9:1159:41 | call to [] [element 2] | array_flow.rb:1159:5:1159:5 | a [element 2] | provenance |  |
+| array_flow.rb:1159:10:1159:22 | call to source | array_flow.rb:1159:9:1159:41 | call to [] [element 0] | provenance |  |
+| array_flow.rb:1159:28:1159:40 | call to source | array_flow.rb:1159:9:1159:41 | call to [] [element 2] | provenance |  |
 | array_flow.rb:1160:5:1160:5 | b | array_flow.rb:1161:10:1161:10 | b | provenance |  |
 | array_flow.rb:1160:9:1160:9 | [post] a [element 1] | array_flow.rb:1163:10:1163:10 | a [element 1] | provenance |  |
 | array_flow.rb:1160:9:1160:9 | a [element 0] | array_flow.rb:1160:9:1160:15 | call to shift | provenance |  |
@@ -1416,8 +1563,10 @@ edges
 | array_flow.rb:1163:10:1163:10 | a [element 1] | array_flow.rb:1163:10:1163:13 | ...[...] | provenance |  |
 | array_flow.rb:1166:5:1166:5 | a [element 0] | array_flow.rb:1167:9:1167:9 | a [element 0] | provenance |  |
 | array_flow.rb:1166:5:1166:5 | a [element 2] | array_flow.rb:1167:9:1167:9 | a [element 2] | provenance |  |
-| array_flow.rb:1166:10:1166:22 | call to source | array_flow.rb:1166:5:1166:5 | a [element 0] | provenance |  |
-| array_flow.rb:1166:28:1166:40 | call to source | array_flow.rb:1166:5:1166:5 | a [element 2] | provenance |  |
+| array_flow.rb:1166:9:1166:41 | call to [] [element 0] | array_flow.rb:1166:5:1166:5 | a [element 0] | provenance |  |
+| array_flow.rb:1166:9:1166:41 | call to [] [element 2] | array_flow.rb:1166:5:1166:5 | a [element 2] | provenance |  |
+| array_flow.rb:1166:10:1166:22 | call to source | array_flow.rb:1166:9:1166:41 | call to [] [element 0] | provenance |  |
+| array_flow.rb:1166:28:1166:40 | call to source | array_flow.rb:1166:9:1166:41 | call to [] [element 2] | provenance |  |
 | array_flow.rb:1167:5:1167:5 | b [element 0] | array_flow.rb:1168:10:1168:10 | b [element 0] | provenance |  |
 | array_flow.rb:1167:9:1167:9 | [post] a [element 0] | array_flow.rb:1170:10:1170:10 | a [element 0] | provenance |  |
 | array_flow.rb:1167:9:1167:9 | a [element 0] | array_flow.rb:1167:9:1167:18 | call to shift [element 0] | provenance |  |
@@ -1429,8 +1578,10 @@ edges
 | array_flow.rb:1174:5:1174:5 | a [element 0] | array_flow.rb:1178:10:1178:10 | a [element 0] | provenance |  |
 | array_flow.rb:1174:5:1174:5 | a [element 2] | array_flow.rb:1175:9:1175:9 | a [element 2] | provenance |  |
 | array_flow.rb:1174:5:1174:5 | a [element 2] | array_flow.rb:1180:10:1180:10 | a [element 2] | provenance |  |
-| array_flow.rb:1174:10:1174:22 | call to source | array_flow.rb:1174:5:1174:5 | a [element 0] | provenance |  |
-| array_flow.rb:1174:28:1174:40 | call to source | array_flow.rb:1174:5:1174:5 | a [element 2] | provenance |  |
+| array_flow.rb:1174:9:1174:41 | call to [] [element 0] | array_flow.rb:1174:5:1174:5 | a [element 0] | provenance |  |
+| array_flow.rb:1174:9:1174:41 | call to [] [element 2] | array_flow.rb:1174:5:1174:5 | a [element 2] | provenance |  |
+| array_flow.rb:1174:10:1174:22 | call to source | array_flow.rb:1174:9:1174:41 | call to [] [element 0] | provenance |  |
+| array_flow.rb:1174:28:1174:40 | call to source | array_flow.rb:1174:9:1174:41 | call to [] [element 2] | provenance |  |
 | array_flow.rb:1175:5:1175:5 | b [element] | array_flow.rb:1176:10:1176:10 | b [element] | provenance |  |
 | array_flow.rb:1175:5:1175:5 | b [element] | array_flow.rb:1177:10:1177:10 | b [element] | provenance |  |
 | array_flow.rb:1175:9:1175:9 | [post] a [element] | array_flow.rb:1178:10:1178:10 | a [element] | provenance |  |
@@ -1450,7 +1601,8 @@ edges
 | array_flow.rb:1180:10:1180:10 | a [element] | array_flow.rb:1180:10:1180:13 | ...[...] | provenance |  |
 | array_flow.rb:1184:5:1184:5 | a [element 2] | array_flow.rb:1185:9:1185:9 | a [element 2] | provenance |  |
 | array_flow.rb:1184:5:1184:5 | a [element 2] | array_flow.rb:1188:10:1188:10 | a [element 2] | provenance |  |
-| array_flow.rb:1184:16:1184:26 | call to source | array_flow.rb:1184:5:1184:5 | a [element 2] | provenance |  |
+| array_flow.rb:1184:9:1184:27 | call to [] [element 2] | array_flow.rb:1184:5:1184:5 | a [element 2] | provenance |  |
+| array_flow.rb:1184:16:1184:26 | call to source | array_flow.rb:1184:9:1184:27 | call to [] [element 2] | provenance |  |
 | array_flow.rb:1185:5:1185:5 | b [element] | array_flow.rb:1189:10:1189:10 | b [element] | provenance |  |
 | array_flow.rb:1185:5:1185:5 | b [element] | array_flow.rb:1190:10:1190:10 | b [element] | provenance |  |
 | array_flow.rb:1185:5:1185:5 | b [element] | array_flow.rb:1191:10:1191:10 | b [element] | provenance |  |
@@ -1462,7 +1614,8 @@ edges
 | array_flow.rb:1191:10:1191:10 | b [element] | array_flow.rb:1191:10:1191:13 | ...[...] | provenance |  |
 | array_flow.rb:1195:5:1195:5 | a [element 2] | array_flow.rb:1196:9:1196:9 | a [element 2] | provenance |  |
 | array_flow.rb:1195:5:1195:5 | a [element 2] | array_flow.rb:1199:10:1199:10 | a [element 2] | provenance |  |
-| array_flow.rb:1195:16:1195:26 | call to source | array_flow.rb:1195:5:1195:5 | a [element 2] | provenance |  |
+| array_flow.rb:1195:9:1195:27 | call to [] [element 2] | array_flow.rb:1195:5:1195:5 | a [element 2] | provenance |  |
+| array_flow.rb:1195:16:1195:26 | call to source | array_flow.rb:1195:9:1195:27 | call to [] [element 2] | provenance |  |
 | array_flow.rb:1196:5:1196:5 | b [element] | array_flow.rb:1200:10:1200:10 | b [element] | provenance |  |
 | array_flow.rb:1196:5:1196:5 | b [element] | array_flow.rb:1201:10:1201:10 | b [element] | provenance |  |
 | array_flow.rb:1196:5:1196:5 | b [element] | array_flow.rb:1202:10:1202:10 | b [element] | provenance |  |
@@ -1497,8 +1650,10 @@ edges
 | array_flow.rb:1206:5:1206:5 | a [element 4] | array_flow.rb:1240:9:1240:9 | a [element 4] | provenance |  |
 | array_flow.rb:1206:5:1206:5 | a [element 4] | array_flow.rb:1244:9:1244:9 | a [element 4] | provenance |  |
 | array_flow.rb:1206:5:1206:5 | a [element 4] | array_flow.rb:1253:9:1253:9 | a [element 4] | provenance |  |
-| array_flow.rb:1206:16:1206:28 | call to source | array_flow.rb:1206:5:1206:5 | a [element 2] | provenance |  |
-| array_flow.rb:1206:34:1206:46 | call to source | array_flow.rb:1206:5:1206:5 | a [element 4] | provenance |  |
+| array_flow.rb:1206:9:1206:47 | call to [] [element 2] | array_flow.rb:1206:5:1206:5 | a [element 2] | provenance |  |
+| array_flow.rb:1206:9:1206:47 | call to [] [element 4] | array_flow.rb:1206:5:1206:5 | a [element 4] | provenance |  |
+| array_flow.rb:1206:16:1206:28 | call to source | array_flow.rb:1206:9:1206:47 | call to [] [element 2] | provenance |  |
+| array_flow.rb:1206:34:1206:46 | call to source | array_flow.rb:1206:9:1206:47 | call to [] [element 4] | provenance |  |
 | array_flow.rb:1208:5:1208:5 | b | array_flow.rb:1209:10:1209:10 | b | provenance |  |
 | array_flow.rb:1208:9:1208:9 | a [element 4] | array_flow.rb:1208:9:1208:17 | call to slice | provenance |  |
 | array_flow.rb:1208:9:1208:17 | call to slice | array_flow.rb:1208:5:1208:5 | b | provenance |  |
@@ -1562,8 +1717,10 @@ edges
 | array_flow.rb:1256:10:1256:10 | b [element] | array_flow.rb:1256:10:1256:13 | ...[...] | provenance |  |
 | array_flow.rb:1260:5:1260:5 | a [element 2] | array_flow.rb:1261:9:1261:9 | a [element 2] | provenance |  |
 | array_flow.rb:1260:5:1260:5 | a [element 4] | array_flow.rb:1261:9:1261:9 | a [element 4] | provenance |  |
-| array_flow.rb:1260:16:1260:28 | call to source | array_flow.rb:1260:5:1260:5 | a [element 2] | provenance |  |
-| array_flow.rb:1260:34:1260:46 | call to source | array_flow.rb:1260:5:1260:5 | a [element 4] | provenance |  |
+| array_flow.rb:1260:9:1260:47 | call to [] [element 2] | array_flow.rb:1260:5:1260:5 | a [element 2] | provenance |  |
+| array_flow.rb:1260:9:1260:47 | call to [] [element 4] | array_flow.rb:1260:5:1260:5 | a [element 4] | provenance |  |
+| array_flow.rb:1260:16:1260:28 | call to source | array_flow.rb:1260:9:1260:47 | call to [] [element 2] | provenance |  |
+| array_flow.rb:1260:34:1260:46 | call to source | array_flow.rb:1260:9:1260:47 | call to [] [element 4] | provenance |  |
 | array_flow.rb:1261:5:1261:5 | b | array_flow.rb:1262:10:1262:10 | b | provenance |  |
 | array_flow.rb:1261:9:1261:9 | [post] a [element 3] | array_flow.rb:1266:10:1266:10 | a [element 3] | provenance |  |
 | array_flow.rb:1261:9:1261:9 | a [element 2] | array_flow.rb:1261:9:1261:19 | call to slice! | provenance |  |
@@ -1572,8 +1729,10 @@ edges
 | array_flow.rb:1266:10:1266:10 | a [element 3] | array_flow.rb:1266:10:1266:13 | ...[...] | provenance |  |
 | array_flow.rb:1268:5:1268:5 | a [element 2] | array_flow.rb:1269:9:1269:9 | a [element 2] | provenance |  |
 | array_flow.rb:1268:5:1268:5 | a [element 4] | array_flow.rb:1269:9:1269:9 | a [element 4] | provenance |  |
-| array_flow.rb:1268:16:1268:28 | call to source | array_flow.rb:1268:5:1268:5 | a [element 2] | provenance |  |
-| array_flow.rb:1268:34:1268:46 | call to source | array_flow.rb:1268:5:1268:5 | a [element 4] | provenance |  |
+| array_flow.rb:1268:9:1268:47 | call to [] [element 2] | array_flow.rb:1268:5:1268:5 | a [element 2] | provenance |  |
+| array_flow.rb:1268:9:1268:47 | call to [] [element 4] | array_flow.rb:1268:5:1268:5 | a [element 4] | provenance |  |
+| array_flow.rb:1268:16:1268:28 | call to source | array_flow.rb:1268:9:1268:47 | call to [] [element 2] | provenance |  |
+| array_flow.rb:1268:34:1268:46 | call to source | array_flow.rb:1268:9:1268:47 | call to [] [element 4] | provenance |  |
 | array_flow.rb:1269:5:1269:5 | b | array_flow.rb:1275:10:1275:10 | b | provenance |  |
 | array_flow.rb:1269:5:1269:5 | b [element] | array_flow.rb:1277:10:1277:10 | b [element] | provenance |  |
 | array_flow.rb:1269:9:1269:9 | [post] a [element] | array_flow.rb:1270:10:1270:10 | a [element] | provenance |  |
@@ -1595,8 +1754,10 @@ edges
 | array_flow.rb:1277:10:1277:10 | b [element] | array_flow.rb:1277:10:1277:13 | ...[...] | provenance |  |
 | array_flow.rb:1279:5:1279:5 | a [element 2] | array_flow.rb:1280:9:1280:9 | a [element 2] | provenance |  |
 | array_flow.rb:1279:5:1279:5 | a [element 4] | array_flow.rb:1280:9:1280:9 | a [element 4] | provenance |  |
-| array_flow.rb:1279:16:1279:28 | call to source | array_flow.rb:1279:5:1279:5 | a [element 2] | provenance |  |
-| array_flow.rb:1279:34:1279:46 | call to source | array_flow.rb:1279:5:1279:5 | a [element 4] | provenance |  |
+| array_flow.rb:1279:9:1279:47 | call to [] [element 2] | array_flow.rb:1279:5:1279:5 | a [element 2] | provenance |  |
+| array_flow.rb:1279:9:1279:47 | call to [] [element 4] | array_flow.rb:1279:5:1279:5 | a [element 4] | provenance |  |
+| array_flow.rb:1279:16:1279:28 | call to source | array_flow.rb:1279:9:1279:47 | call to [] [element 2] | provenance |  |
+| array_flow.rb:1279:34:1279:46 | call to source | array_flow.rb:1279:9:1279:47 | call to [] [element 4] | provenance |  |
 | array_flow.rb:1280:5:1280:5 | b [element 0] | array_flow.rb:1281:10:1281:10 | b [element 0] | provenance |  |
 | array_flow.rb:1280:5:1280:5 | b [element 2] | array_flow.rb:1283:10:1283:10 | b [element 2] | provenance |  |
 | array_flow.rb:1280:9:1280:9 | a [element 2] | array_flow.rb:1280:9:1280:22 | call to slice! [element 0] | provenance |  |
@@ -1607,8 +1768,10 @@ edges
 | array_flow.rb:1283:10:1283:10 | b [element 2] | array_flow.rb:1283:10:1283:13 | ...[...] | provenance |  |
 | array_flow.rb:1290:5:1290:5 | a [element 2] | array_flow.rb:1291:9:1291:9 | a [element 2] | provenance |  |
 | array_flow.rb:1290:5:1290:5 | a [element 4] | array_flow.rb:1291:9:1291:9 | a [element 4] | provenance |  |
-| array_flow.rb:1290:16:1290:28 | call to source | array_flow.rb:1290:5:1290:5 | a [element 2] | provenance |  |
-| array_flow.rb:1290:34:1290:46 | call to source | array_flow.rb:1290:5:1290:5 | a [element 4] | provenance |  |
+| array_flow.rb:1290:9:1290:47 | call to [] [element 2] | array_flow.rb:1290:5:1290:5 | a [element 2] | provenance |  |
+| array_flow.rb:1290:9:1290:47 | call to [] [element 4] | array_flow.rb:1290:5:1290:5 | a [element 4] | provenance |  |
+| array_flow.rb:1290:16:1290:28 | call to source | array_flow.rb:1290:9:1290:47 | call to [] [element 2] | provenance |  |
+| array_flow.rb:1290:34:1290:46 | call to source | array_flow.rb:1290:9:1290:47 | call to [] [element 4] | provenance |  |
 | array_flow.rb:1291:5:1291:5 | b [element 0] | array_flow.rb:1292:10:1292:10 | b [element 0] | provenance |  |
 | array_flow.rb:1291:9:1291:9 | [post] a [element 2] | array_flow.rb:1297:10:1297:10 | a [element 2] | provenance |  |
 | array_flow.rb:1291:9:1291:9 | a [element 2] | array_flow.rb:1291:9:1291:22 | call to slice! [element 0] | provenance |  |
@@ -1618,8 +1781,10 @@ edges
 | array_flow.rb:1297:10:1297:10 | a [element 2] | array_flow.rb:1297:10:1297:13 | ...[...] | provenance |  |
 | array_flow.rb:1301:5:1301:5 | a [element 2] | array_flow.rb:1302:9:1302:9 | a [element 2] | provenance |  |
 | array_flow.rb:1301:5:1301:5 | a [element 4] | array_flow.rb:1302:9:1302:9 | a [element 4] | provenance |  |
-| array_flow.rb:1301:16:1301:28 | call to source | array_flow.rb:1301:5:1301:5 | a [element 2] | provenance |  |
-| array_flow.rb:1301:34:1301:46 | call to source | array_flow.rb:1301:5:1301:5 | a [element 4] | provenance |  |
+| array_flow.rb:1301:9:1301:47 | call to [] [element 2] | array_flow.rb:1301:5:1301:5 | a [element 2] | provenance |  |
+| array_flow.rb:1301:9:1301:47 | call to [] [element 4] | array_flow.rb:1301:5:1301:5 | a [element 4] | provenance |  |
+| array_flow.rb:1301:16:1301:28 | call to source | array_flow.rb:1301:9:1301:47 | call to [] [element 2] | provenance |  |
+| array_flow.rb:1301:34:1301:46 | call to source | array_flow.rb:1301:9:1301:47 | call to [] [element 4] | provenance |  |
 | array_flow.rb:1302:5:1302:5 | b [element 0] | array_flow.rb:1303:10:1303:10 | b [element 0] | provenance |  |
 | array_flow.rb:1302:9:1302:9 | [post] a [element 2] | array_flow.rb:1308:10:1308:10 | a [element 2] | provenance |  |
 | array_flow.rb:1302:9:1302:9 | a [element 2] | array_flow.rb:1302:9:1302:23 | call to slice! [element 0] | provenance |  |
@@ -1629,8 +1794,10 @@ edges
 | array_flow.rb:1308:10:1308:10 | a [element 2] | array_flow.rb:1308:10:1308:13 | ...[...] | provenance |  |
 | array_flow.rb:1312:5:1312:5 | a [element 2] | array_flow.rb:1313:9:1313:9 | a [element 2] | provenance |  |
 | array_flow.rb:1312:5:1312:5 | a [element 4] | array_flow.rb:1313:9:1313:9 | a [element 4] | provenance |  |
-| array_flow.rb:1312:16:1312:28 | call to source | array_flow.rb:1312:5:1312:5 | a [element 2] | provenance |  |
-| array_flow.rb:1312:34:1312:46 | call to source | array_flow.rb:1312:5:1312:5 | a [element 4] | provenance |  |
+| array_flow.rb:1312:9:1312:47 | call to [] [element 2] | array_flow.rb:1312:5:1312:5 | a [element 2] | provenance |  |
+| array_flow.rb:1312:9:1312:47 | call to [] [element 4] | array_flow.rb:1312:5:1312:5 | a [element 4] | provenance |  |
+| array_flow.rb:1312:16:1312:28 | call to source | array_flow.rb:1312:9:1312:47 | call to [] [element 2] | provenance |  |
+| array_flow.rb:1312:34:1312:46 | call to source | array_flow.rb:1312:9:1312:47 | call to [] [element 4] | provenance |  |
 | array_flow.rb:1313:5:1313:5 | b [element] | array_flow.rb:1314:10:1314:10 | b [element] | provenance |  |
 | array_flow.rb:1313:5:1313:5 | b [element] | array_flow.rb:1315:10:1315:10 | b [element] | provenance |  |
 | array_flow.rb:1313:5:1313:5 | b [element] | array_flow.rb:1316:10:1316:10 | b [element] | provenance |  |
@@ -1650,8 +1817,10 @@ edges
 | array_flow.rb:1319:10:1319:10 | a [element] | array_flow.rb:1319:10:1319:13 | ...[...] | provenance |  |
 | array_flow.rb:1321:5:1321:5 | a [element 2] | array_flow.rb:1322:9:1322:9 | a [element 2] | provenance |  |
 | array_flow.rb:1321:5:1321:5 | a [element 4] | array_flow.rb:1322:9:1322:9 | a [element 4] | provenance |  |
-| array_flow.rb:1321:16:1321:28 | call to source | array_flow.rb:1321:5:1321:5 | a [element 2] | provenance |  |
-| array_flow.rb:1321:34:1321:46 | call to source | array_flow.rb:1321:5:1321:5 | a [element 4] | provenance |  |
+| array_flow.rb:1321:9:1321:47 | call to [] [element 2] | array_flow.rb:1321:5:1321:5 | a [element 2] | provenance |  |
+| array_flow.rb:1321:9:1321:47 | call to [] [element 4] | array_flow.rb:1321:5:1321:5 | a [element 4] | provenance |  |
+| array_flow.rb:1321:16:1321:28 | call to source | array_flow.rb:1321:9:1321:47 | call to [] [element 2] | provenance |  |
+| array_flow.rb:1321:34:1321:46 | call to source | array_flow.rb:1321:9:1321:47 | call to [] [element 4] | provenance |  |
 | array_flow.rb:1322:5:1322:5 | b [element] | array_flow.rb:1323:10:1323:10 | b [element] | provenance |  |
 | array_flow.rb:1322:5:1322:5 | b [element] | array_flow.rb:1324:10:1324:10 | b [element] | provenance |  |
 | array_flow.rb:1322:5:1322:5 | b [element] | array_flow.rb:1325:10:1325:10 | b [element] | provenance |  |
@@ -1671,8 +1840,10 @@ edges
 | array_flow.rb:1328:10:1328:10 | a [element] | array_flow.rb:1328:10:1328:13 | ...[...] | provenance |  |
 | array_flow.rb:1330:5:1330:5 | a [element 2] | array_flow.rb:1331:9:1331:9 | a [element 2] | provenance |  |
 | array_flow.rb:1330:5:1330:5 | a [element 4] | array_flow.rb:1331:9:1331:9 | a [element 4] | provenance |  |
-| array_flow.rb:1330:16:1330:28 | call to source | array_flow.rb:1330:5:1330:5 | a [element 2] | provenance |  |
-| array_flow.rb:1330:34:1330:46 | call to source | array_flow.rb:1330:5:1330:5 | a [element 4] | provenance |  |
+| array_flow.rb:1330:9:1330:47 | call to [] [element 2] | array_flow.rb:1330:5:1330:5 | a [element 2] | provenance |  |
+| array_flow.rb:1330:9:1330:47 | call to [] [element 4] | array_flow.rb:1330:5:1330:5 | a [element 4] | provenance |  |
+| array_flow.rb:1330:16:1330:28 | call to source | array_flow.rb:1330:9:1330:47 | call to [] [element 2] | provenance |  |
+| array_flow.rb:1330:34:1330:46 | call to source | array_flow.rb:1330:9:1330:47 | call to [] [element 4] | provenance |  |
 | array_flow.rb:1331:5:1331:5 | b [element] | array_flow.rb:1332:10:1332:10 | b [element] | provenance |  |
 | array_flow.rb:1331:5:1331:5 | b [element] | array_flow.rb:1333:10:1333:10 | b [element] | provenance |  |
 | array_flow.rb:1331:5:1331:5 | b [element] | array_flow.rb:1334:10:1334:10 | b [element] | provenance |  |
@@ -1692,8 +1863,10 @@ edges
 | array_flow.rb:1337:10:1337:10 | a [element] | array_flow.rb:1337:10:1337:13 | ...[...] | provenance |  |
 | array_flow.rb:1339:5:1339:5 | a [element 2] | array_flow.rb:1340:9:1340:9 | a [element 2] | provenance |  |
 | array_flow.rb:1339:5:1339:5 | a [element 4] | array_flow.rb:1340:9:1340:9 | a [element 4] | provenance |  |
-| array_flow.rb:1339:16:1339:28 | call to source | array_flow.rb:1339:5:1339:5 | a [element 2] | provenance |  |
-| array_flow.rb:1339:34:1339:46 | call to source | array_flow.rb:1339:5:1339:5 | a [element 4] | provenance |  |
+| array_flow.rb:1339:9:1339:47 | call to [] [element 2] | array_flow.rb:1339:5:1339:5 | a [element 2] | provenance |  |
+| array_flow.rb:1339:9:1339:47 | call to [] [element 4] | array_flow.rb:1339:5:1339:5 | a [element 4] | provenance |  |
+| array_flow.rb:1339:16:1339:28 | call to source | array_flow.rb:1339:9:1339:47 | call to [] [element 2] | provenance |  |
+| array_flow.rb:1339:34:1339:46 | call to source | array_flow.rb:1339:9:1339:47 | call to [] [element 4] | provenance |  |
 | array_flow.rb:1340:5:1340:5 | b [element 2] | array_flow.rb:1343:10:1343:10 | b [element 2] | provenance |  |
 | array_flow.rb:1340:9:1340:9 | [post] a [element 1] | array_flow.rb:1345:10:1345:10 | a [element 1] | provenance |  |
 | array_flow.rb:1340:9:1340:9 | a [element 2] | array_flow.rb:1340:9:1340:21 | call to slice! [element 2] | provenance |  |
@@ -1703,8 +1876,10 @@ edges
 | array_flow.rb:1345:10:1345:10 | a [element 1] | array_flow.rb:1345:10:1345:13 | ...[...] | provenance |  |
 | array_flow.rb:1348:5:1348:5 | a [element 2] | array_flow.rb:1349:9:1349:9 | a [element 2] | provenance |  |
 | array_flow.rb:1348:5:1348:5 | a [element 4] | array_flow.rb:1349:9:1349:9 | a [element 4] | provenance |  |
-| array_flow.rb:1348:16:1348:28 | call to source | array_flow.rb:1348:5:1348:5 | a [element 2] | provenance |  |
-| array_flow.rb:1348:34:1348:46 | call to source | array_flow.rb:1348:5:1348:5 | a [element 4] | provenance |  |
+| array_flow.rb:1348:9:1348:47 | call to [] [element 2] | array_flow.rb:1348:5:1348:5 | a [element 2] | provenance |  |
+| array_flow.rb:1348:9:1348:47 | call to [] [element 4] | array_flow.rb:1348:5:1348:5 | a [element 4] | provenance |  |
+| array_flow.rb:1348:16:1348:28 | call to source | array_flow.rb:1348:9:1348:47 | call to [] [element 2] | provenance |  |
+| array_flow.rb:1348:34:1348:46 | call to source | array_flow.rb:1348:9:1348:47 | call to [] [element 4] | provenance |  |
 | array_flow.rb:1349:5:1349:5 | b [element] | array_flow.rb:1350:10:1350:10 | b [element] | provenance |  |
 | array_flow.rb:1349:5:1349:5 | b [element] | array_flow.rb:1351:10:1351:10 | b [element] | provenance |  |
 | array_flow.rb:1349:5:1349:5 | b [element] | array_flow.rb:1352:10:1352:10 | b [element] | provenance |  |
@@ -1723,22 +1898,26 @@ edges
 | array_flow.rb:1354:10:1354:10 | a [element] | array_flow.rb:1354:10:1354:13 | ...[...] | provenance |  |
 | array_flow.rb:1355:10:1355:10 | a [element] | array_flow.rb:1355:10:1355:13 | ...[...] | provenance |  |
 | array_flow.rb:1359:5:1359:5 | a [element 2] | array_flow.rb:1360:9:1360:9 | a [element 2] | provenance |  |
-| array_flow.rb:1359:16:1359:26 | call to source | array_flow.rb:1359:5:1359:5 | a [element 2] | provenance |  |
+| array_flow.rb:1359:9:1359:27 | call to [] [element 2] | array_flow.rb:1359:5:1359:5 | a [element 2] | provenance |  |
+| array_flow.rb:1359:16:1359:26 | call to source | array_flow.rb:1359:9:1359:27 | call to [] [element 2] | provenance |  |
 | array_flow.rb:1360:9:1360:9 | a [element 2] | array_flow.rb:1360:27:1360:27 | x | provenance |  |
 | array_flow.rb:1360:27:1360:27 | x | array_flow.rb:1361:14:1361:14 | x | provenance |  |
 | array_flow.rb:1367:5:1367:5 | a [element 2] | array_flow.rb:1368:9:1368:9 | a [element 2] | provenance |  |
-| array_flow.rb:1367:16:1367:26 | call to source | array_flow.rb:1367:5:1367:5 | a [element 2] | provenance |  |
+| array_flow.rb:1367:9:1367:27 | call to [] [element 2] | array_flow.rb:1367:5:1367:5 | a [element 2] | provenance |  |
+| array_flow.rb:1367:16:1367:26 | call to source | array_flow.rb:1367:9:1367:27 | call to [] [element 2] | provenance |  |
 | array_flow.rb:1368:9:1368:9 | a [element 2] | array_flow.rb:1368:28:1368:28 | x | provenance |  |
 | array_flow.rb:1368:28:1368:28 | x | array_flow.rb:1369:14:1369:14 | x | provenance |  |
 | array_flow.rb:1375:5:1375:5 | a [element 2] | array_flow.rb:1376:9:1376:9 | a [element 2] | provenance |  |
-| array_flow.rb:1375:16:1375:26 | call to source | array_flow.rb:1375:5:1375:5 | a [element 2] | provenance |  |
+| array_flow.rb:1375:9:1375:27 | call to [] [element 2] | array_flow.rb:1375:5:1375:5 | a [element 2] | provenance |  |
+| array_flow.rb:1375:16:1375:26 | call to source | array_flow.rb:1375:9:1375:27 | call to [] [element 2] | provenance |  |
 | array_flow.rb:1376:9:1376:9 | a [element 2] | array_flow.rb:1376:26:1376:26 | x | provenance |  |
 | array_flow.rb:1376:9:1376:9 | a [element 2] | array_flow.rb:1376:29:1376:29 | y | provenance |  |
 | array_flow.rb:1376:26:1376:26 | x | array_flow.rb:1377:14:1377:14 | x | provenance |  |
 | array_flow.rb:1376:29:1376:29 | y | array_flow.rb:1378:14:1378:14 | y | provenance |  |
 | array_flow.rb:1383:5:1383:5 | a [element 2] | array_flow.rb:1384:9:1384:9 | a [element 2] | provenance |  |
 | array_flow.rb:1383:5:1383:5 | a [element 2] | array_flow.rb:1387:9:1387:9 | a [element 2] | provenance |  |
-| array_flow.rb:1383:16:1383:26 | call to source | array_flow.rb:1383:5:1383:5 | a [element 2] | provenance |  |
+| array_flow.rb:1383:9:1383:27 | call to [] [element 2] | array_flow.rb:1383:5:1383:5 | a [element 2] | provenance |  |
+| array_flow.rb:1383:16:1383:26 | call to source | array_flow.rb:1383:9:1383:27 | call to [] [element 2] | provenance |  |
 | array_flow.rb:1384:5:1384:5 | b [element] | array_flow.rb:1385:10:1385:10 | b [element] | provenance |  |
 | array_flow.rb:1384:5:1384:5 | b [element] | array_flow.rb:1386:10:1386:10 | b [element] | provenance |  |
 | array_flow.rb:1384:9:1384:9 | a [element 2] | array_flow.rb:1384:9:1384:14 | call to sort [element] | provenance |  |
@@ -1756,7 +1935,8 @@ edges
 | array_flow.rb:1392:10:1392:10 | c [element] | array_flow.rb:1392:10:1392:13 | ...[...] | provenance |  |
 | array_flow.rb:1393:10:1393:10 | c [element] | array_flow.rb:1393:10:1393:13 | ...[...] | provenance |  |
 | array_flow.rb:1397:5:1397:5 | a [element 2] | array_flow.rb:1398:9:1398:9 | a [element 2] | provenance |  |
-| array_flow.rb:1397:16:1397:26 | call to source | array_flow.rb:1397:5:1397:5 | a [element 2] | provenance |  |
+| array_flow.rb:1397:9:1397:27 | call to [] [element 2] | array_flow.rb:1397:5:1397:5 | a [element 2] | provenance |  |
+| array_flow.rb:1397:16:1397:26 | call to source | array_flow.rb:1397:9:1397:27 | call to [] [element 2] | provenance |  |
 | array_flow.rb:1398:5:1398:5 | b [element] | array_flow.rb:1399:10:1399:10 | b [element] | provenance |  |
 | array_flow.rb:1398:5:1398:5 | b [element] | array_flow.rb:1400:10:1400:10 | b [element] | provenance |  |
 | array_flow.rb:1398:9:1398:9 | [post] a [element] | array_flow.rb:1401:10:1401:10 | a [element] | provenance |  |
@@ -1769,7 +1949,8 @@ edges
 | array_flow.rb:1401:10:1401:10 | a [element] | array_flow.rb:1401:10:1401:13 | ...[...] | provenance |  |
 | array_flow.rb:1402:10:1402:10 | a [element] | array_flow.rb:1402:10:1402:13 | ...[...] | provenance |  |
 | array_flow.rb:1404:5:1404:5 | a [element 2] | array_flow.rb:1405:9:1405:9 | a [element 2] | provenance |  |
-| array_flow.rb:1404:16:1404:26 | call to source | array_flow.rb:1404:5:1404:5 | a [element 2] | provenance |  |
+| array_flow.rb:1404:9:1404:27 | call to [] [element 2] | array_flow.rb:1404:5:1404:5 | a [element 2] | provenance |  |
+| array_flow.rb:1404:16:1404:26 | call to source | array_flow.rb:1404:9:1404:27 | call to [] [element 2] | provenance |  |
 | array_flow.rb:1405:5:1405:5 | b [element] | array_flow.rb:1410:10:1410:10 | b [element] | provenance |  |
 | array_flow.rb:1405:5:1405:5 | b [element] | array_flow.rb:1411:10:1411:10 | b [element] | provenance |  |
 | array_flow.rb:1405:9:1405:9 | [post] a [element] | array_flow.rb:1412:10:1412:10 | a [element] | provenance |  |
@@ -1786,7 +1967,8 @@ edges
 | array_flow.rb:1412:10:1412:10 | a [element] | array_flow.rb:1412:10:1412:13 | ...[...] | provenance |  |
 | array_flow.rb:1413:10:1413:10 | a [element] | array_flow.rb:1413:10:1413:13 | ...[...] | provenance |  |
 | array_flow.rb:1417:5:1417:5 | a [element 2] | array_flow.rb:1418:9:1418:9 | a [element 2] | provenance |  |
-| array_flow.rb:1417:16:1417:26 | call to source | array_flow.rb:1417:5:1417:5 | a [element 2] | provenance |  |
+| array_flow.rb:1417:9:1417:27 | call to [] [element 2] | array_flow.rb:1417:5:1417:5 | a [element 2] | provenance |  |
+| array_flow.rb:1417:16:1417:26 | call to source | array_flow.rb:1417:9:1417:27 | call to [] [element 2] | provenance |  |
 | array_flow.rb:1418:5:1418:5 | b [element] | array_flow.rb:1422:10:1422:10 | b [element] | provenance |  |
 | array_flow.rb:1418:5:1418:5 | b [element] | array_flow.rb:1423:10:1423:10 | b [element] | provenance |  |
 | array_flow.rb:1418:9:1418:9 | a [element 2] | array_flow.rb:1418:9:1421:7 | call to sort_by [element] | provenance |  |
@@ -1796,7 +1978,8 @@ edges
 | array_flow.rb:1422:10:1422:10 | b [element] | array_flow.rb:1422:10:1422:13 | ...[...] | provenance |  |
 | array_flow.rb:1423:10:1423:10 | b [element] | array_flow.rb:1423:10:1423:13 | ...[...] | provenance |  |
 | array_flow.rb:1427:5:1427:5 | a [element 2] | array_flow.rb:1428:9:1428:9 | a [element 2] | provenance |  |
-| array_flow.rb:1427:16:1427:26 | call to source | array_flow.rb:1427:5:1427:5 | a [element 2] | provenance |  |
+| array_flow.rb:1427:9:1427:27 | call to [] [element 2] | array_flow.rb:1427:5:1427:5 | a [element 2] | provenance |  |
+| array_flow.rb:1427:16:1427:26 | call to source | array_flow.rb:1427:9:1427:27 | call to [] [element 2] | provenance |  |
 | array_flow.rb:1428:5:1428:5 | b [element] | array_flow.rb:1434:10:1434:10 | b [element] | provenance |  |
 | array_flow.rb:1428:5:1428:5 | b [element] | array_flow.rb:1435:10:1435:10 | b [element] | provenance |  |
 | array_flow.rb:1428:9:1428:9 | [post] a [element] | array_flow.rb:1432:10:1432:10 | a [element] | provenance |  |
@@ -1811,7 +1994,8 @@ edges
 | array_flow.rb:1434:10:1434:10 | b [element] | array_flow.rb:1434:10:1434:13 | ...[...] | provenance |  |
 | array_flow.rb:1435:10:1435:10 | b [element] | array_flow.rb:1435:10:1435:13 | ...[...] | provenance |  |
 | array_flow.rb:1439:5:1439:5 | a [element 2] | array_flow.rb:1440:9:1440:9 | a [element 2] | provenance |  |
-| array_flow.rb:1439:16:1439:26 | call to source | array_flow.rb:1439:5:1439:5 | a [element 2] | provenance |  |
+| array_flow.rb:1439:9:1439:27 | call to [] [element 2] | array_flow.rb:1439:5:1439:5 | a [element 2] | provenance |  |
+| array_flow.rb:1439:16:1439:26 | call to source | array_flow.rb:1439:9:1439:27 | call to [] [element 2] | provenance |  |
 | array_flow.rb:1440:9:1440:9 | a [element 2] | array_flow.rb:1440:19:1440:19 | x | provenance |  |
 | array_flow.rb:1440:19:1440:19 | x | array_flow.rb:1441:14:1441:14 | x | provenance |  |
 | array_flow.rb:1447:5:1447:5 | a [element 2] | array_flow.rb:1448:9:1448:9 | a [element 2] | provenance |  |
@@ -1820,8 +2004,10 @@ edges
 | array_flow.rb:1447:5:1447:5 | a [element 2] | array_flow.rb:1466:9:1466:9 | a [element 2] | provenance |  |
 | array_flow.rb:1447:5:1447:5 | a [element 3] | array_flow.rb:1448:9:1448:9 | a [element 3] | provenance |  |
 | array_flow.rb:1447:5:1447:5 | a [element 3] | array_flow.rb:1459:9:1459:9 | a [element 3] | provenance |  |
-| array_flow.rb:1447:16:1447:28 | call to source | array_flow.rb:1447:5:1447:5 | a [element 2] | provenance |  |
-| array_flow.rb:1447:31:1447:43 | call to source | array_flow.rb:1447:5:1447:5 | a [element 3] | provenance |  |
+| array_flow.rb:1447:9:1447:44 | call to [] [element 2] | array_flow.rb:1447:5:1447:5 | a [element 2] | provenance |  |
+| array_flow.rb:1447:9:1447:44 | call to [] [element 3] | array_flow.rb:1447:5:1447:5 | a [element 3] | provenance |  |
+| array_flow.rb:1447:16:1447:28 | call to source | array_flow.rb:1447:9:1447:44 | call to [] [element 2] | provenance |  |
+| array_flow.rb:1447:31:1447:43 | call to source | array_flow.rb:1447:9:1447:44 | call to [] [element 3] | provenance |  |
 | array_flow.rb:1448:5:1448:5 | b [element 2] | array_flow.rb:1451:10:1451:10 | b [element 2] | provenance |  |
 | array_flow.rb:1448:5:1448:5 | b [element 3] | array_flow.rb:1452:10:1452:10 | b [element 3] | provenance |  |
 | array_flow.rb:1448:9:1448:9 | a [element 2] | array_flow.rb:1448:9:1448:17 | call to take [element 2] | provenance |  |
@@ -1859,7 +2045,8 @@ edges
 | array_flow.rb:1467:10:1467:10 | b [element 2] | array_flow.rb:1467:10:1467:13 | ...[...] | provenance |  |
 | array_flow.rb:1467:10:1467:10 | b [element] | array_flow.rb:1467:10:1467:13 | ...[...] | provenance |  |
 | array_flow.rb:1471:5:1471:5 | a [element 2] | array_flow.rb:1472:9:1472:9 | a [element 2] | provenance |  |
-| array_flow.rb:1471:16:1471:26 | call to source | array_flow.rb:1471:5:1471:5 | a [element 2] | provenance |  |
+| array_flow.rb:1471:9:1471:27 | call to [] [element 2] | array_flow.rb:1471:5:1471:5 | a [element 2] | provenance |  |
+| array_flow.rb:1471:16:1471:26 | call to source | array_flow.rb:1471:9:1471:27 | call to [] [element 2] | provenance |  |
 | array_flow.rb:1472:5:1472:5 | b [element 2] | array_flow.rb:1478:10:1478:10 | b [element 2] | provenance |  |
 | array_flow.rb:1472:9:1472:9 | a [element 2] | array_flow.rb:1472:9:1475:7 | call to take_while [element 2] | provenance |  |
 | array_flow.rb:1472:9:1472:9 | a [element 2] | array_flow.rb:1472:26:1472:26 | x | provenance |  |
@@ -1867,13 +2054,15 @@ edges
 | array_flow.rb:1472:26:1472:26 | x | array_flow.rb:1473:14:1473:14 | x | provenance |  |
 | array_flow.rb:1478:10:1478:10 | b [element 2] | array_flow.rb:1478:10:1478:13 | ...[...] | provenance |  |
 | array_flow.rb:1484:5:1484:5 | a [element 3] | array_flow.rb:1485:9:1485:9 | a [element 3] | provenance |  |
-| array_flow.rb:1484:19:1484:29 | call to source | array_flow.rb:1484:5:1484:5 | a [element 3] | provenance |  |
+| array_flow.rb:1484:9:1484:30 | call to [] [element 3] | array_flow.rb:1484:5:1484:5 | a [element 3] | provenance |  |
+| array_flow.rb:1484:19:1484:29 | call to source | array_flow.rb:1484:9:1484:30 | call to [] [element 3] | provenance |  |
 | array_flow.rb:1485:5:1485:5 | b [element 3] | array_flow.rb:1486:10:1486:10 | b [element 3] | provenance |  |
 | array_flow.rb:1485:9:1485:9 | a [element 3] | array_flow.rb:1485:9:1485:14 | call to to_a [element 3] | provenance |  |
 | array_flow.rb:1485:9:1485:14 | call to to_a [element 3] | array_flow.rb:1485:5:1485:5 | b [element 3] | provenance |  |
 | array_flow.rb:1486:10:1486:10 | b [element 3] | array_flow.rb:1486:10:1486:13 | ...[...] | provenance |  |
 | array_flow.rb:1490:5:1490:5 | a [element 2] | array_flow.rb:1491:9:1491:9 | a [element 2] | provenance |  |
-| array_flow.rb:1490:16:1490:26 | call to source | array_flow.rb:1490:5:1490:5 | a [element 2] | provenance |  |
+| array_flow.rb:1490:9:1490:27 | call to [] [element 2] | array_flow.rb:1490:5:1490:5 | a [element 2] | provenance |  |
+| array_flow.rb:1490:16:1490:26 | call to source | array_flow.rb:1490:9:1490:27 | call to [] [element 2] | provenance |  |
 | array_flow.rb:1491:5:1491:5 | b [element 2] | array_flow.rb:1494:10:1494:10 | b [element 2] | provenance |  |
 | array_flow.rb:1491:9:1491:9 | a [element 2] | array_flow.rb:1491:9:1491:16 | call to to_ary [element 2] | provenance |  |
 | array_flow.rb:1491:9:1491:16 | call to to_ary [element 2] | array_flow.rb:1491:5:1491:5 | b [element 2] | provenance |  |
@@ -1881,9 +2070,15 @@ edges
 | array_flow.rb:1507:5:1507:5 | a [element 0, element 1] | array_flow.rb:1508:9:1508:9 | a [element 0, element 1] | provenance |  |
 | array_flow.rb:1507:5:1507:5 | a [element 1, element 1] | array_flow.rb:1508:9:1508:9 | a [element 1, element 1] | provenance |  |
 | array_flow.rb:1507:5:1507:5 | a [element 2, element 1] | array_flow.rb:1508:9:1508:9 | a [element 2, element 1] | provenance |  |
-| array_flow.rb:1507:14:1507:26 | call to source | array_flow.rb:1507:5:1507:5 | a [element 0, element 1] | provenance |  |
-| array_flow.rb:1507:34:1507:46 | call to source | array_flow.rb:1507:5:1507:5 | a [element 1, element 1] | provenance |  |
-| array_flow.rb:1507:54:1507:66 | call to source | array_flow.rb:1507:5:1507:5 | a [element 2, element 1] | provenance |  |
+| array_flow.rb:1507:9:1507:68 | call to [] [element 0, element 1] | array_flow.rb:1507:5:1507:5 | a [element 0, element 1] | provenance |  |
+| array_flow.rb:1507:9:1507:68 | call to [] [element 1, element 1] | array_flow.rb:1507:5:1507:5 | a [element 1, element 1] | provenance |  |
+| array_flow.rb:1507:9:1507:68 | call to [] [element 2, element 1] | array_flow.rb:1507:5:1507:5 | a [element 2, element 1] | provenance |  |
+| array_flow.rb:1507:10:1507:27 | call to [] [element 1] | array_flow.rb:1507:9:1507:68 | call to [] [element 0, element 1] | provenance |  |
+| array_flow.rb:1507:14:1507:26 | call to source | array_flow.rb:1507:10:1507:27 | call to [] [element 1] | provenance |  |
+| array_flow.rb:1507:30:1507:47 | call to [] [element 1] | array_flow.rb:1507:9:1507:68 | call to [] [element 1, element 1] | provenance |  |
+| array_flow.rb:1507:34:1507:46 | call to source | array_flow.rb:1507:30:1507:47 | call to [] [element 1] | provenance |  |
+| array_flow.rb:1507:50:1507:67 | call to [] [element 1] | array_flow.rb:1507:9:1507:68 | call to [] [element 2, element 1] | provenance |  |
+| array_flow.rb:1507:54:1507:66 | call to source | array_flow.rb:1507:50:1507:67 | call to [] [element 1] | provenance |  |
 | array_flow.rb:1508:5:1508:5 | b [element 1, element 0] | array_flow.rb:1512:10:1512:10 | b [element 1, element 0] | provenance |  |
 | array_flow.rb:1508:5:1508:5 | b [element 1, element 1] | array_flow.rb:1513:10:1513:10 | b [element 1, element 1] | provenance |  |
 | array_flow.rb:1508:5:1508:5 | b [element 1, element 2] | array_flow.rb:1514:10:1514:10 | b [element 1, element 2] | provenance |  |
@@ -1900,11 +2095,14 @@ edges
 | array_flow.rb:1514:10:1514:10 | b [element 1, element 2] | array_flow.rb:1514:10:1514:13 | ...[...] [element 2] | provenance |  |
 | array_flow.rb:1514:10:1514:13 | ...[...] [element 2] | array_flow.rb:1514:10:1514:16 | ...[...] | provenance |  |
 | array_flow.rb:1518:5:1518:5 | a [element 2] | array_flow.rb:1521:9:1521:9 | a [element 2] | provenance |  |
-| array_flow.rb:1518:16:1518:28 | call to source | array_flow.rb:1518:5:1518:5 | a [element 2] | provenance |  |
+| array_flow.rb:1518:9:1518:29 | call to [] [element 2] | array_flow.rb:1518:5:1518:5 | a [element 2] | provenance |  |
+| array_flow.rb:1518:16:1518:28 | call to source | array_flow.rb:1518:9:1518:29 | call to [] [element 2] | provenance |  |
 | array_flow.rb:1519:5:1519:5 | b [element 1] | array_flow.rb:1521:17:1521:17 | b [element 1] | provenance |  |
-| array_flow.rb:1519:13:1519:25 | call to source | array_flow.rb:1519:5:1519:5 | b [element 1] | provenance |  |
+| array_flow.rb:1519:9:1519:26 | call to [] [element 1] | array_flow.rb:1519:5:1519:5 | b [element 1] | provenance |  |
+| array_flow.rb:1519:13:1519:25 | call to source | array_flow.rb:1519:9:1519:26 | call to [] [element 1] | provenance |  |
 | array_flow.rb:1520:5:1520:5 | c [element 1] | array_flow.rb:1521:20:1521:20 | c [element 1] | provenance |  |
-| array_flow.rb:1520:13:1520:25 | call to source | array_flow.rb:1520:5:1520:5 | c [element 1] | provenance |  |
+| array_flow.rb:1520:9:1520:26 | call to [] [element 1] | array_flow.rb:1520:5:1520:5 | c [element 1] | provenance |  |
+| array_flow.rb:1520:13:1520:25 | call to source | array_flow.rb:1520:9:1520:26 | call to [] [element 1] | provenance |  |
 | array_flow.rb:1521:5:1521:5 | d [element] | array_flow.rb:1522:10:1522:10 | d [element] | provenance |  |
 | array_flow.rb:1521:5:1521:5 | d [element] | array_flow.rb:1523:10:1523:10 | d [element] | provenance |  |
 | array_flow.rb:1521:5:1521:5 | d [element] | array_flow.rb:1524:10:1524:10 | d [element] | provenance |  |
@@ -1919,8 +2117,10 @@ edges
 | array_flow.rb:1528:5:1528:5 | a [element 3] | array_flow.rb:1534:9:1534:9 | a [element 3] | provenance |  |
 | array_flow.rb:1528:5:1528:5 | a [element 4] | array_flow.rb:1530:9:1530:9 | a [element 4] | provenance |  |
 | array_flow.rb:1528:5:1528:5 | a [element 4] | array_flow.rb:1534:9:1534:9 | a [element 4] | provenance |  |
-| array_flow.rb:1528:19:1528:31 | call to source | array_flow.rb:1528:5:1528:5 | a [element 3] | provenance |  |
-| array_flow.rb:1528:34:1528:46 | call to source | array_flow.rb:1528:5:1528:5 | a [element 4] | provenance |  |
+| array_flow.rb:1528:9:1528:47 | call to [] [element 3] | array_flow.rb:1528:5:1528:5 | a [element 3] | provenance |  |
+| array_flow.rb:1528:9:1528:47 | call to [] [element 4] | array_flow.rb:1528:5:1528:5 | a [element 4] | provenance |  |
+| array_flow.rb:1528:19:1528:31 | call to source | array_flow.rb:1528:9:1528:47 | call to [] [element 3] | provenance |  |
+| array_flow.rb:1528:34:1528:46 | call to source | array_flow.rb:1528:9:1528:47 | call to [] [element 4] | provenance |  |
 | array_flow.rb:1530:5:1530:5 | b [element] | array_flow.rb:1531:10:1531:10 | b [element] | provenance |  |
 | array_flow.rb:1530:5:1530:5 | b [element] | array_flow.rb:1532:10:1532:10 | b [element] | provenance |  |
 | array_flow.rb:1530:9:1530:9 | a [element 3] | array_flow.rb:1530:9:1530:14 | call to uniq [element] | provenance |  |
@@ -1938,8 +2138,10 @@ edges
 | array_flow.rb:1538:10:1538:10 | c [element] | array_flow.rb:1538:10:1538:13 | ...[...] | provenance |  |
 | array_flow.rb:1542:5:1542:5 | a [element 2] | array_flow.rb:1543:9:1543:9 | a [element 2] | provenance |  |
 | array_flow.rb:1542:5:1542:5 | a [element 3] | array_flow.rb:1543:9:1543:9 | a [element 3] | provenance |  |
-| array_flow.rb:1542:16:1542:28 | call to source | array_flow.rb:1542:5:1542:5 | a [element 2] | provenance |  |
-| array_flow.rb:1542:31:1542:43 | call to source | array_flow.rb:1542:5:1542:5 | a [element 3] | provenance |  |
+| array_flow.rb:1542:9:1542:44 | call to [] [element 2] | array_flow.rb:1542:5:1542:5 | a [element 2] | provenance |  |
+| array_flow.rb:1542:9:1542:44 | call to [] [element 3] | array_flow.rb:1542:5:1542:5 | a [element 3] | provenance |  |
+| array_flow.rb:1542:16:1542:28 | call to source | array_flow.rb:1542:9:1542:44 | call to [] [element 2] | provenance |  |
+| array_flow.rb:1542:31:1542:43 | call to source | array_flow.rb:1542:9:1542:44 | call to [] [element 3] | provenance |  |
 | array_flow.rb:1543:5:1543:5 | b [element] | array_flow.rb:1544:10:1544:10 | b [element] | provenance |  |
 | array_flow.rb:1543:5:1543:5 | b [element] | array_flow.rb:1545:10:1545:10 | b [element] | provenance |  |
 | array_flow.rb:1543:9:1543:9 | [post] a [element] | array_flow.rb:1546:10:1546:10 | a [element] | provenance |  |
@@ -1955,8 +2157,10 @@ edges
 | array_flow.rb:1547:10:1547:10 | a [element] | array_flow.rb:1547:10:1547:13 | ...[...] | provenance |  |
 | array_flow.rb:1549:5:1549:5 | a [element 2] | array_flow.rb:1550:9:1550:9 | a [element 2] | provenance |  |
 | array_flow.rb:1549:5:1549:5 | a [element 3] | array_flow.rb:1550:9:1550:9 | a [element 3] | provenance |  |
-| array_flow.rb:1549:16:1549:28 | call to source | array_flow.rb:1549:5:1549:5 | a [element 2] | provenance |  |
-| array_flow.rb:1549:31:1549:43 | call to source | array_flow.rb:1549:5:1549:5 | a [element 3] | provenance |  |
+| array_flow.rb:1549:9:1549:44 | call to [] [element 2] | array_flow.rb:1549:5:1549:5 | a [element 2] | provenance |  |
+| array_flow.rb:1549:9:1549:44 | call to [] [element 3] | array_flow.rb:1549:5:1549:5 | a [element 3] | provenance |  |
+| array_flow.rb:1549:16:1549:28 | call to source | array_flow.rb:1549:9:1549:44 | call to [] [element 2] | provenance |  |
+| array_flow.rb:1549:31:1549:43 | call to source | array_flow.rb:1549:9:1549:44 | call to [] [element 3] | provenance |  |
 | array_flow.rb:1550:5:1550:5 | b [element] | array_flow.rb:1554:10:1554:10 | b [element] | provenance |  |
 | array_flow.rb:1550:5:1550:5 | b [element] | array_flow.rb:1555:10:1555:10 | b [element] | provenance |  |
 | array_flow.rb:1550:9:1550:9 | [post] a [element] | array_flow.rb:1556:10:1556:10 | a [element] | provenance |  |
@@ -1974,7 +2178,8 @@ edges
 | array_flow.rb:1556:10:1556:10 | a [element] | array_flow.rb:1556:10:1556:13 | ...[...] | provenance |  |
 | array_flow.rb:1557:10:1557:10 | a [element] | array_flow.rb:1557:10:1557:13 | ...[...] | provenance |  |
 | array_flow.rb:1561:5:1561:5 | a [element 2] | array_flow.rb:1562:5:1562:5 | a [element 2] | provenance |  |
-| array_flow.rb:1561:16:1561:28 | call to source | array_flow.rb:1561:5:1561:5 | a [element 2] | provenance |  |
+| array_flow.rb:1561:9:1561:29 | call to [] [element 2] | array_flow.rb:1561:5:1561:5 | a [element 2] | provenance |  |
+| array_flow.rb:1561:16:1561:28 | call to source | array_flow.rb:1561:9:1561:29 | call to [] [element 2] | provenance |  |
 | array_flow.rb:1562:5:1562:5 | [post] a [element 2] | array_flow.rb:1565:10:1565:10 | a [element 2] | provenance |  |
 | array_flow.rb:1562:5:1562:5 | [post] a [element 5] | array_flow.rb:1568:10:1568:10 | a [element 5] | provenance |  |
 | array_flow.rb:1562:5:1562:5 | a [element 2] | array_flow.rb:1562:5:1562:5 | [post] a [element 5] | provenance |  |
@@ -1988,8 +2193,10 @@ edges
 | array_flow.rb:1572:5:1572:5 | a [element 3] | array_flow.rb:1580:9:1580:9 | a [element 3] | provenance |  |
 | array_flow.rb:1572:5:1572:5 | a [element 3] | array_flow.rb:1584:9:1584:9 | a [element 3] | provenance |  |
 | array_flow.rb:1572:5:1572:5 | a [element 3] | array_flow.rb:1588:9:1588:9 | a [element 3] | provenance |  |
-| array_flow.rb:1572:13:1572:25 | call to source | array_flow.rb:1572:5:1572:5 | a [element 1] | provenance |  |
-| array_flow.rb:1572:31:1572:43 | call to source | array_flow.rb:1572:5:1572:5 | a [element 3] | provenance |  |
+| array_flow.rb:1572:9:1572:44 | call to [] [element 1] | array_flow.rb:1572:5:1572:5 | a [element 1] | provenance |  |
+| array_flow.rb:1572:9:1572:44 | call to [] [element 3] | array_flow.rb:1572:5:1572:5 | a [element 3] | provenance |  |
+| array_flow.rb:1572:13:1572:25 | call to source | array_flow.rb:1572:9:1572:44 | call to [] [element 1] | provenance |  |
+| array_flow.rb:1572:31:1572:43 | call to source | array_flow.rb:1572:9:1572:44 | call to [] [element 3] | provenance |  |
 | array_flow.rb:1574:5:1574:5 | b [element 1] | array_flow.rb:1576:10:1576:10 | b [element 1] | provenance |  |
 | array_flow.rb:1574:5:1574:5 | b [element 3] | array_flow.rb:1578:10:1578:10 | b [element 3] | provenance |  |
 | array_flow.rb:1574:9:1574:9 | a [element 1] | array_flow.rb:1574:9:1574:31 | call to values_at [element 1] | provenance |  |
@@ -2029,13 +2236,16 @@ edges
 | array_flow.rb:1592:10:1592:10 | b [element] | array_flow.rb:1592:10:1592:13 | ...[...] | provenance |  |
 | array_flow.rb:1596:5:1596:5 | a [element 2] | array_flow.rb:1599:9:1599:9 | a [element 2] | provenance |  |
 | array_flow.rb:1596:5:1596:5 | a [element 2] | array_flow.rb:1604:5:1604:5 | a [element 2] | provenance |  |
-| array_flow.rb:1596:16:1596:28 | call to source | array_flow.rb:1596:5:1596:5 | a [element 2] | provenance |  |
+| array_flow.rb:1596:9:1596:29 | call to [] [element 2] | array_flow.rb:1596:5:1596:5 | a [element 2] | provenance |  |
+| array_flow.rb:1596:16:1596:28 | call to source | array_flow.rb:1596:9:1596:29 | call to [] [element 2] | provenance |  |
 | array_flow.rb:1597:5:1597:5 | b [element 1] | array_flow.rb:1599:15:1599:15 | b [element 1] | provenance |  |
 | array_flow.rb:1597:5:1597:5 | b [element 1] | array_flow.rb:1604:11:1604:11 | b [element 1] | provenance |  |
-| array_flow.rb:1597:13:1597:25 | call to source | array_flow.rb:1597:5:1597:5 | b [element 1] | provenance |  |
+| array_flow.rb:1597:9:1597:29 | call to [] [element 1] | array_flow.rb:1597:5:1597:5 | b [element 1] | provenance |  |
+| array_flow.rb:1597:13:1597:25 | call to source | array_flow.rb:1597:9:1597:29 | call to [] [element 1] | provenance |  |
 | array_flow.rb:1598:5:1598:5 | c [element 0] | array_flow.rb:1599:18:1599:18 | c [element 0] | provenance |  |
 | array_flow.rb:1598:5:1598:5 | c [element 0] | array_flow.rb:1604:14:1604:14 | c [element 0] | provenance |  |
-| array_flow.rb:1598:10:1598:22 | call to source | array_flow.rb:1598:5:1598:5 | c [element 0] | provenance |  |
+| array_flow.rb:1598:9:1598:29 | call to [] [element 0] | array_flow.rb:1598:5:1598:5 | c [element 0] | provenance |  |
+| array_flow.rb:1598:10:1598:22 | call to source | array_flow.rb:1598:9:1598:29 | call to [] [element 0] | provenance |  |
 | array_flow.rb:1599:5:1599:5 | d [element 0, element 2] | array_flow.rb:1601:10:1601:10 | d [element 0, element 2] | provenance |  |
 | array_flow.rb:1599:5:1599:5 | d [element 1, element 1] | array_flow.rb:1602:10:1602:10 | d [element 1, element 1] | provenance |  |
 | array_flow.rb:1599:5:1599:5 | d [element 2, element 0] | array_flow.rb:1603:10:1603:10 | d [element 2, element 0] | provenance |  |
@@ -2061,9 +2271,11 @@ edges
 | array_flow.rb:1606:14:1606:14 | x [element 1] | array_flow.rb:1606:14:1606:17 | ...[...] | provenance |  |
 | array_flow.rb:1607:14:1607:14 | x [element 2] | array_flow.rb:1607:14:1607:17 | ...[...] | provenance |  |
 | array_flow.rb:1612:5:1612:5 | a [element 2] | array_flow.rb:1614:9:1614:9 | a [element 2] | provenance |  |
-| array_flow.rb:1612:16:1612:28 | call to source | array_flow.rb:1612:5:1612:5 | a [element 2] | provenance |  |
+| array_flow.rb:1612:9:1612:29 | call to [] [element 2] | array_flow.rb:1612:5:1612:5 | a [element 2] | provenance |  |
+| array_flow.rb:1612:16:1612:28 | call to source | array_flow.rb:1612:9:1612:29 | call to [] [element 2] | provenance |  |
 | array_flow.rb:1613:5:1613:5 | b [element 1] | array_flow.rb:1614:13:1614:13 | b [element 1] | provenance |  |
-| array_flow.rb:1613:13:1613:25 | call to source | array_flow.rb:1613:5:1613:5 | b [element 1] | provenance |  |
+| array_flow.rb:1613:9:1613:26 | call to [] [element 1] | array_flow.rb:1613:5:1613:5 | b [element 1] | provenance |  |
+| array_flow.rb:1613:13:1613:25 | call to source | array_flow.rb:1613:9:1613:26 | call to [] [element 1] | provenance |  |
 | array_flow.rb:1614:5:1614:5 | c [element] | array_flow.rb:1615:10:1615:10 | c [element] | provenance |  |
 | array_flow.rb:1614:5:1614:5 | c [element] | array_flow.rb:1616:10:1616:10 | c [element] | provenance |  |
 | array_flow.rb:1614:5:1614:5 | c [element] | array_flow.rb:1617:10:1617:10 | c [element] | provenance |  |
@@ -2121,15 +2333,18 @@ edges
 | array_flow.rb:1670:14:1670:15 | a2 [element 1] | array_flow.rb:1670:14:1670:18 | ...[...] | provenance |  |
 | array_flow.rb:1672:14:1672:15 | a2 [element 1] | array_flow.rb:1672:14:1672:18 | ...[...] | provenance |  |
 | array_flow.rb:1677:5:1677:5 | a [element 2] | array_flow.rb:1678:9:1678:9 | a [element 2] | provenance |  |
-| array_flow.rb:1677:16:1677:28 | call to source | array_flow.rb:1677:5:1677:5 | a [element 2] | provenance |  |
+| array_flow.rb:1677:9:1677:29 | call to [] [element 2] | array_flow.rb:1677:5:1677:5 | a [element 2] | provenance |  |
+| array_flow.rb:1677:16:1677:28 | call to source | array_flow.rb:1677:9:1677:29 | call to [] [element 2] | provenance |  |
 | array_flow.rb:1678:5:1678:5 | b [element] | array_flow.rb:1681:10:1681:10 | b [element] | provenance |  |
 | array_flow.rb:1678:9:1678:9 | a [element 2] | array_flow.rb:1678:9:1680:7 | call to map [element] | provenance |  |
 | array_flow.rb:1678:9:1680:7 | call to map [element] | array_flow.rb:1678:5:1678:5 | b [element] | provenance |  |
 | array_flow.rb:1681:10:1681:10 | b [element] | array_flow.rb:1681:10:1681:13 | ...[...] | provenance |  |
 | array_flow.rb:1685:5:1685:5 | a [element 2] | array_flow.rb:1686:18:1686:18 | a [element 2] | provenance |  |
 | array_flow.rb:1685:5:1685:5 | a [element 3] | array_flow.rb:1686:18:1686:18 | a [element 3] | provenance |  |
-| array_flow.rb:1685:16:1685:28 | call to source | array_flow.rb:1685:5:1685:5 | a [element 2] | provenance |  |
-| array_flow.rb:1685:31:1685:43 | call to source | array_flow.rb:1685:5:1685:5 | a [element 3] | provenance |  |
+| array_flow.rb:1685:9:1685:44 | call to [] [element 2] | array_flow.rb:1685:5:1685:5 | a [element 2] | provenance |  |
+| array_flow.rb:1685:9:1685:44 | call to [] [element 3] | array_flow.rb:1685:5:1685:5 | a [element 3] | provenance |  |
+| array_flow.rb:1685:16:1685:28 | call to source | array_flow.rb:1685:9:1685:44 | call to [] [element 2] | provenance |  |
+| array_flow.rb:1685:31:1685:43 | call to source | array_flow.rb:1685:9:1685:44 | call to [] [element 3] | provenance |  |
 | array_flow.rb:1686:11:1686:11 | z | array_flow.rb:1689:10:1689:10 | z | provenance |  |
 | array_flow.rb:1686:14:1686:14 | w | array_flow.rb:1690:10:1690:10 | w | provenance |  |
 | array_flow.rb:1686:18:1686:18 | a [element 2] | array_flow.rb:1686:11:1686:11 | z | provenance |  |
@@ -2143,6 +2358,7 @@ nodes
 | array_flow.rb:5:10:5:10 | a [element 0] | semmle.label | a [element 0] |
 | array_flow.rb:5:10:5:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:9:5:9:5 | a [element 1] | semmle.label | a [element 1] |
+| array_flow.rb:9:9:9:25 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | array_flow.rb:9:13:9:21 | call to source | semmle.label | call to source |
 | array_flow.rb:11:10:11:10 | a [element 1] | semmle.label | a [element 1] |
 | array_flow.rb:11:10:11:13 | ...[...] | semmle.label | ...[...] |
@@ -2170,6 +2386,7 @@ nodes
 | array_flow.rb:29:10:29:10 | c [element] | semmle.label | c [element] |
 | array_flow.rb:29:10:29:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:33:5:33:5 | a [element 0] | semmle.label | a [element 0] |
+| array_flow.rb:33:9:33:22 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | array_flow.rb:33:10:33:18 | call to source | semmle.label | call to source |
 | array_flow.rb:34:5:34:5 | b [element 0] | semmle.label | b [element 0] |
 | array_flow.rb:34:9:34:28 | call to try_convert [element 0] | semmle.label | call to try_convert [element 0] |
@@ -2177,8 +2394,10 @@ nodes
 | array_flow.rb:35:10:35:10 | b [element 0] | semmle.label | b [element 0] |
 | array_flow.rb:35:10:35:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:40:5:40:5 | a [element 0] | semmle.label | a [element 0] |
+| array_flow.rb:40:9:40:24 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | array_flow.rb:40:10:40:20 | call to source | semmle.label | call to source |
 | array_flow.rb:41:5:41:5 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:41:9:41:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:41:16:41:26 | call to source | semmle.label | call to source |
 | array_flow.rb:42:5:42:5 | c [element] | semmle.label | c [element] |
 | array_flow.rb:42:9:42:9 | a [element 0] | semmle.label | a [element 0] |
@@ -2189,6 +2408,7 @@ nodes
 | array_flow.rb:44:10:44:10 | c [element] | semmle.label | c [element] |
 | array_flow.rb:44:10:44:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:48:5:48:5 | a [element 0] | semmle.label | a [element 0] |
+| array_flow.rb:48:9:48:22 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | array_flow.rb:48:10:48:18 | call to source | semmle.label | call to source |
 | array_flow.rb:49:5:49:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:49:9:49:9 | a [element 0] | semmle.label | a [element 0] |
@@ -2198,8 +2418,10 @@ nodes
 | array_flow.rb:51:10:51:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:51:10:51:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:55:5:55:5 | a [element 0] | semmle.label | a [element 0] |
+| array_flow.rb:55:9:55:24 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | array_flow.rb:55:10:55:20 | call to source | semmle.label | call to source |
 | array_flow.rb:56:5:56:5 | b [element 1] | semmle.label | b [element 1] |
+| array_flow.rb:56:9:56:24 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | array_flow.rb:56:13:56:23 | call to source | semmle.label | call to source |
 | array_flow.rb:57:5:57:5 | c [element 0] | semmle.label | c [element 0] |
 | array_flow.rb:57:5:57:5 | c [element] | semmle.label | c [element] |
@@ -2213,6 +2435,7 @@ nodes
 | array_flow.rb:59:10:59:10 | c [element] | semmle.label | c [element] |
 | array_flow.rb:59:10:59:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:63:5:63:5 | a [element 0] | semmle.label | a [element 0] |
+| array_flow.rb:63:9:63:24 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | array_flow.rb:63:10:63:20 | call to source | semmle.label | call to source |
 | array_flow.rb:65:5:65:5 | c [element] | semmle.label | c [element] |
 | array_flow.rb:65:9:65:9 | a [element 0] | semmle.label | a [element 0] |
@@ -2222,6 +2445,7 @@ nodes
 | array_flow.rb:67:10:67:10 | c [element] | semmle.label | c [element] |
 | array_flow.rb:67:10:67:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:71:5:71:5 | a [element 0] | semmle.label | a [element 0] |
+| array_flow.rb:71:9:71:24 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | array_flow.rb:71:10:71:20 | call to source | semmle.label | call to source |
 | array_flow.rb:72:5:72:5 | b [element 0] | semmle.label | b [element 0] |
 | array_flow.rb:72:5:72:5 | b [element] | semmle.label | b [element] |
@@ -2241,11 +2465,13 @@ nodes
 | array_flow.rb:76:10:76:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:76:10:76:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:80:5:80:5 | a [element 1] | semmle.label | a [element 1] |
+| array_flow.rb:80:9:80:25 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | array_flow.rb:80:13:80:21 | call to source | semmle.label | call to source |
 | array_flow.rb:81:8:81:8 | c | semmle.label | c |
 | array_flow.rb:81:15:81:15 | a [element 1] | semmle.label | a [element 1] |
 | array_flow.rb:83:10:83:10 | c | semmle.label | c |
 | array_flow.rb:88:5:88:5 | a [element 1] | semmle.label | a [element 1] |
+| array_flow.rb:88:9:88:26 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | array_flow.rb:88:13:88:22 | call to source | semmle.label | call to source |
 | array_flow.rb:89:5:89:5 | b [element 1] | semmle.label | b [element 1] |
 | array_flow.rb:89:9:89:9 | a [element 1] | semmle.label | a [element 1] |
@@ -2255,6 +2481,7 @@ nodes
 | array_flow.rb:92:10:92:10 | b [element 1] | semmle.label | b [element 1] |
 | array_flow.rb:92:10:92:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:96:5:96:5 | a [element 1] | semmle.label | a [element 1] |
+| array_flow.rb:96:9:96:26 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | array_flow.rb:96:13:96:22 | call to source | semmle.label | call to source |
 | array_flow.rb:97:5:97:5 | b [element 1] | semmle.label | b [element 1] |
 | array_flow.rb:97:9:97:9 | a [element 1] | semmle.label | a [element 1] |
@@ -2264,6 +2491,7 @@ nodes
 | array_flow.rb:101:10:101:10 | b [element 1] | semmle.label | b [element 1] |
 | array_flow.rb:101:10:101:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:103:5:103:5 | a [element 1] | semmle.label | a [element 1] |
+| array_flow.rb:103:9:103:39 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | array_flow.rb:103:13:103:24 | call to source | semmle.label | call to source |
 | array_flow.rb:104:5:104:5 | b [element 1] | semmle.label | b [element 1] |
 | array_flow.rb:104:9:104:9 | a [element 1] | semmle.label | a [element 1] |
@@ -2272,6 +2500,8 @@ nodes
 | array_flow.rb:106:10:106:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:109:5:109:5 | a [element 1] | semmle.label | a [element 1] |
 | array_flow.rb:109:5:109:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:109:9:109:42 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| array_flow.rb:109:9:109:42 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:109:13:109:24 | call to source | semmle.label | call to source |
 | array_flow.rb:109:30:109:41 | call to source | semmle.label | call to source |
 | array_flow.rb:110:5:110:5 | b [element] | semmle.label | b [element] |
@@ -2299,6 +2529,7 @@ nodes
 | array_flow.rb:124:10:124:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:124:10:124:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:129:5:129:5 | [post] a [element] | semmle.label | [post] a [element] |
+| array_flow.rb:129:15:129:32 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | array_flow.rb:129:19:129:28 | call to source | semmle.label | call to source |
 | array_flow.rb:130:10:130:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:130:10:130:13 | ...[...] | semmle.label | ...[...] |
@@ -2315,6 +2546,7 @@ nodes
 | array_flow.rb:140:10:140:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:140:10:140:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:145:5:145:5 | [post] a [element] | semmle.label | [post] a [element] |
+| array_flow.rb:145:15:145:32 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | array_flow.rb:145:19:145:28 | call to source | semmle.label | call to source |
 | array_flow.rb:146:10:146:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:146:10:146:13 | ...[...] | semmle.label | ...[...] |
@@ -2323,16 +2555,19 @@ nodes
 | array_flow.rb:148:10:148:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:148:10:148:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:152:5:152:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:152:9:152:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:152:16:152:25 | call to source | semmle.label | call to source |
 | array_flow.rb:153:5:153:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:153:16:153:16 | x | semmle.label | x |
 | array_flow.rb:154:14:154:14 | x | semmle.label | x |
 | array_flow.rb:159:5:159:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:159:9:159:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:159:16:159:25 | call to source | semmle.label | call to source |
 | array_flow.rb:160:5:160:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:160:16:160:16 | x | semmle.label | x |
 | array_flow.rb:161:14:161:14 | x | semmle.label | x |
 | array_flow.rb:166:5:166:5 | a [element 0] | semmle.label | a [element 0] |
+| array_flow.rb:166:9:166:25 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | array_flow.rb:166:10:166:21 | call to source | semmle.label | call to source |
 | array_flow.rb:167:5:167:5 | b [element 0] | semmle.label | b [element 0] |
 | array_flow.rb:167:5:167:5 | b [element] | semmle.label | b [element] |
@@ -2353,8 +2588,10 @@ nodes
 | array_flow.rb:171:10:171:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:171:10:171:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:177:5:177:5 | c [element 1] | semmle.label | c [element 1] |
+| array_flow.rb:177:9:177:25 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | array_flow.rb:177:15:177:24 | call to source | semmle.label | call to source |
 | array_flow.rb:178:5:178:5 | d [element 2, element 1] | semmle.label | d [element 2, element 1] |
+| array_flow.rb:178:9:178:17 | call to [] [element 2, element 1] | semmle.label | call to [] [element 2, element 1] |
 | array_flow.rb:178:16:178:16 | c [element 1] | semmle.label | c [element 1] |
 | array_flow.rb:179:10:179:26 | ( ... ) | semmle.label | ( ... ) |
 | array_flow.rb:179:11:179:11 | d [element 2, element 1] | semmle.label | d [element 2, element 1] |
@@ -2365,12 +2602,14 @@ nodes
 | array_flow.rb:180:11:180:22 | call to assoc [element 1] | semmle.label | call to assoc [element 1] |
 | array_flow.rb:180:11:180:25 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:184:5:184:5 | a [element 1] | semmle.label | a [element 1] |
+| array_flow.rb:184:9:184:26 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | array_flow.rb:184:13:184:22 | call to source | semmle.label | call to source |
 | array_flow.rb:186:10:186:10 | a [element 1] | semmle.label | a [element 1] |
 | array_flow.rb:186:10:186:16 | call to at | semmle.label | call to at |
 | array_flow.rb:188:10:188:10 | a [element 1] | semmle.label | a [element 1] |
 | array_flow.rb:188:10:188:16 | call to at | semmle.label | call to at |
 | array_flow.rb:192:5:192:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:192:9:192:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:192:16:192:25 | call to source | semmle.label | call to source |
 | array_flow.rb:193:5:193:5 | b | semmle.label | b |
 | array_flow.rb:193:9:193:9 | a [element 2] | semmle.label | a [element 2] |
@@ -2379,17 +2618,21 @@ nodes
 | array_flow.rb:194:14:194:14 | x | semmle.label | x |
 | array_flow.rb:196:10:196:10 | b | semmle.label | b |
 | array_flow.rb:200:5:200:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:200:9:200:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:200:16:200:25 | call to source | semmle.label | call to source |
 | array_flow.rb:201:9:201:9 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:201:29:201:29 | x | semmle.label | x |
 | array_flow.rb:202:14:202:14 | x | semmle.label | x |
 | array_flow.rb:208:5:208:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:208:9:208:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:208:16:208:25 | call to source | semmle.label | call to source |
 | array_flow.rb:209:5:209:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:209:17:209:17 | x | semmle.label | x |
 | array_flow.rb:210:14:210:14 | x | semmle.label | x |
 | array_flow.rb:215:5:215:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:215:5:215:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:215:9:215:42 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:215:9:215:42 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:215:16:215:27 | call to source | semmle.label | call to source |
 | array_flow.rb:215:30:215:41 | call to source | semmle.label | call to source |
 | array_flow.rb:216:9:216:9 | a [element 2] | semmle.label | a [element 2] |
@@ -2399,6 +2642,7 @@ nodes
 | array_flow.rb:217:14:217:14 | x | semmle.label | x |
 | array_flow.rb:218:14:218:14 | y | semmle.label | y |
 | array_flow.rb:231:5:231:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:231:9:231:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:231:16:231:27 | call to source | semmle.label | call to source |
 | array_flow.rb:232:5:232:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:232:9:232:9 | a [element 2] | semmle.label | a [element 2] |
@@ -2409,6 +2653,7 @@ nodes
 | array_flow.rb:236:10:236:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:236:10:236:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:240:5:240:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:240:9:240:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:240:16:240:27 | call to source | semmle.label | call to source |
 | array_flow.rb:241:5:241:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:241:9:241:9 | [post] a [element] | semmle.label | [post] a [element] |
@@ -2422,12 +2667,14 @@ nodes
 | array_flow.rb:246:10:246:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:246:10:246:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:250:5:250:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:250:9:250:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:250:16:250:27 | call to source | semmle.label | call to source |
 | array_flow.rb:251:5:251:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:251:9:251:9 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:251:9:254:7 | call to collect_concat [element] | semmle.label | call to collect_concat [element] |
 | array_flow.rb:251:30:251:30 | x | semmle.label | x |
 | array_flow.rb:252:14:252:14 | x | semmle.label | x |
+| array_flow.rb:253:9:253:25 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | array_flow.rb:253:13:253:24 | call to source | semmle.label | call to source |
 | array_flow.rb:255:10:255:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:255:10:255:13 | ...[...] | semmle.label | ...[...] |
@@ -2440,6 +2687,7 @@ nodes
 | array_flow.rb:260:10:260:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:260:10:260:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:264:5:264:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:264:9:264:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:264:16:264:25 | call to source | semmle.label | call to source |
 | array_flow.rb:265:5:265:5 | b [element 2] | semmle.label | b [element 2] |
 | array_flow.rb:265:9:265:9 | a [element 2] | semmle.label | a [element 2] |
@@ -2450,6 +2698,7 @@ nodes
 | array_flow.rb:269:10:269:10 | b [element 2] | semmle.label | b [element 2] |
 | array_flow.rb:269:10:269:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:273:5:273:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:273:9:273:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:273:16:273:25 | call to source | semmle.label | call to source |
 | array_flow.rb:274:5:274:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:274:9:274:9 | a [element 2] | semmle.label | a [element 2] |
@@ -2457,6 +2706,7 @@ nodes
 | array_flow.rb:275:10:275:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:275:10:275:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:279:5:279:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:279:9:279:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:279:16:279:25 | call to source | semmle.label | call to source |
 | array_flow.rb:280:5:280:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:280:9:280:9 | [post] a [element] | semmle.label | [post] a [element] |
@@ -2467,8 +2717,10 @@ nodes
 | array_flow.rb:282:10:282:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:282:10:282:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:286:5:286:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:286:9:286:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:286:16:286:27 | call to source | semmle.label | call to source |
 | array_flow.rb:287:5:287:5 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:287:9:287:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:287:16:287:27 | call to source | semmle.label | call to source |
 | array_flow.rb:288:5:288:5 | [post] a [element] | semmle.label | [post] a [element] |
 | array_flow.rb:288:14:288:14 | b [element 2] | semmle.label | b [element 2] |
@@ -2478,16 +2730,19 @@ nodes
 | array_flow.rb:290:10:290:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:290:10:290:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:294:5:294:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:294:9:294:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:294:16:294:25 | call to source | semmle.label | call to source |
 | array_flow.rb:295:5:295:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:295:17:295:17 | x | semmle.label | x |
 | array_flow.rb:296:14:296:14 | x | semmle.label | x |
 | array_flow.rb:301:5:301:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:301:9:301:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:301:16:301:25 | call to source | semmle.label | call to source |
 | array_flow.rb:302:5:302:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:302:20:302:20 | x | semmle.label | x |
 | array_flow.rb:303:14:303:14 | x | semmle.label | x |
 | array_flow.rb:308:5:308:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:308:9:308:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:308:16:308:25 | call to source | semmle.label | call to source |
 | array_flow.rb:309:5:309:5 | b [element 2] | semmle.label | b [element 2] |
 | array_flow.rb:309:9:309:9 | a [element 2] | semmle.label | a [element 2] |
@@ -2495,6 +2750,7 @@ nodes
 | array_flow.rb:312:10:312:10 | b [element 2] | semmle.label | b [element 2] |
 | array_flow.rb:312:10:312:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:316:5:316:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:316:9:316:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:316:16:316:27 | call to source | semmle.label | call to source |
 | array_flow.rb:317:5:317:5 | b | semmle.label | b |
 | array_flow.rb:317:9:317:9 | a [element 2] | semmle.label | a [element 2] |
@@ -2503,6 +2759,8 @@ nodes
 | array_flow.rb:318:10:318:10 | b | semmle.label | b |
 | array_flow.rb:325:5:325:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:325:5:325:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:325:9:325:42 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:325:9:325:42 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:325:16:325:27 | call to source | semmle.label | call to source |
 | array_flow.rb:325:30:325:41 | call to source | semmle.label | call to source |
 | array_flow.rb:326:5:326:5 | b | semmle.label | b |
@@ -2515,6 +2773,8 @@ nodes
 | array_flow.rb:328:10:328:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:330:5:330:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:330:5:330:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:330:9:330:42 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:330:9:330:42 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:330:16:330:27 | call to source | semmle.label | call to source |
 | array_flow.rb:330:30:330:41 | call to source | semmle.label | call to source |
 | array_flow.rb:331:5:331:5 | b | semmle.label | b |
@@ -2528,6 +2788,7 @@ nodes
 | array_flow.rb:334:10:334:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:334:10:334:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:338:5:338:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:338:9:338:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:338:16:338:25 | call to source | semmle.label | call to source |
 | array_flow.rb:339:5:339:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:339:9:339:9 | [post] a [element] | semmle.label | [post] a [element] |
@@ -2544,6 +2805,7 @@ nodes
 | array_flow.rb:345:10:345:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:345:10:345:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:349:5:349:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:349:9:349:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:349:16:349:25 | call to source | semmle.label | call to source |
 | array_flow.rb:350:5:350:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:350:9:350:9 | a [element 2] | semmle.label | a [element 2] |
@@ -2552,7 +2814,10 @@ nodes
 | array_flow.rb:351:10:351:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:355:5:355:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:355:5:355:5 | a [element 3, element 1] | semmle.label | a [element 3, element 1] |
+| array_flow.rb:355:9:355:47 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:355:9:355:47 | call to [] [element 3, element 1] | semmle.label | call to [] [element 3, element 1] |
 | array_flow.rb:355:16:355:27 | call to source | semmle.label | call to source |
+| array_flow.rb:355:30:355:46 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | array_flow.rb:355:34:355:45 | call to source | semmle.label | call to source |
 | array_flow.rb:357:10:357:10 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:357:10:357:17 | call to dig | semmle.label | call to dig |
@@ -2561,6 +2826,7 @@ nodes
 | array_flow.rb:360:10:360:10 | a [element 3, element 1] | semmle.label | a [element 3, element 1] |
 | array_flow.rb:360:10:360:19 | call to dig | semmle.label | call to dig |
 | array_flow.rb:364:5:364:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:364:9:364:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:364:16:364:27 | call to source | semmle.label | call to source |
 | array_flow.rb:365:5:365:5 | b | semmle.label | b |
 | array_flow.rb:365:9:365:9 | a [element 2] | semmle.label | a [element 2] |
@@ -2571,6 +2837,8 @@ nodes
 | array_flow.rb:368:10:368:10 | b | semmle.label | b |
 | array_flow.rb:372:5:372:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:372:5:372:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:372:9:372:42 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:372:9:372:42 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:372:16:372:27 | call to source | semmle.label | call to source |
 | array_flow.rb:372:30:372:41 | call to source | semmle.label | call to source |
 | array_flow.rb:373:5:373:5 | b [element] | semmle.label | b [element] |
@@ -2608,6 +2876,8 @@ nodes
 | array_flow.rb:383:10:383:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:387:5:387:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:387:5:387:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:387:9:387:42 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:387:9:387:42 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:387:16:387:27 | call to source | semmle.label | call to source |
 | array_flow.rb:387:30:387:41 | call to source | semmle.label | call to source |
 | array_flow.rb:388:5:388:5 | b [element] | semmle.label | b [element] |
@@ -2619,6 +2889,7 @@ nodes
 | array_flow.rb:391:10:391:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:391:10:391:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:395:5:395:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:395:9:395:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:395:16:395:25 | call to source | semmle.label | call to source |
 | array_flow.rb:396:5:396:5 | b [element 2] | semmle.label | b [element 2] |
 | array_flow.rb:396:9:396:9 | a [element 2] | semmle.label | a [element 2] |
@@ -2628,16 +2899,16 @@ nodes
 | array_flow.rb:399:10:399:10 | b [element 2] | semmle.label | b [element 2] |
 | array_flow.rb:399:10:399:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:403:5:403:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:403:9:403:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:403:16:403:25 | call to source | semmle.label | call to source |
 | array_flow.rb:404:5:404:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:404:9:406:7 | [post] { ... } [captured x] | semmle.label | [post] { ... } [captured x] |
-| array_flow.rb:404:9:406:7 | __synth__0__1 | semmle.label | __synth__0__1 |
 | array_flow.rb:404:18:404:18 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:405:14:405:14 | x | semmle.label | x |
 | array_flow.rb:407:10:407:10 | x | semmle.label | x |
 | array_flow.rb:408:10:408:10 | b [element 2] | semmle.label | b [element 2] |
 | array_flow.rb:408:10:408:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:412:5:412:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:412:9:412:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:412:16:412:25 | call to source | semmle.label | call to source |
 | array_flow.rb:413:5:413:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:413:24:413:24 | x [element] | semmle.label | x [element] |
@@ -2645,6 +2916,7 @@ nodes
 | array_flow.rb:414:15:414:15 | x [element] | semmle.label | x [element] |
 | array_flow.rb:414:15:414:18 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:419:5:419:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:419:9:419:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:419:16:419:25 | call to source | semmle.label | call to source |
 | array_flow.rb:420:5:420:5 | b [element 2] | semmle.label | b [element 2] |
 | array_flow.rb:420:9:420:9 | a [element 2] | semmle.label | a [element 2] |
@@ -2654,6 +2926,7 @@ nodes
 | array_flow.rb:423:10:423:10 | b [element 2] | semmle.label | b [element 2] |
 | array_flow.rb:423:10:423:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:427:5:427:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:427:9:427:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:427:16:427:25 | call to source | semmle.label | call to source |
 | array_flow.rb:428:5:428:5 | b [element 2] | semmle.label | b [element 2] |
 | array_flow.rb:428:9:428:9 | a [element 2] | semmle.label | a [element 2] |
@@ -2661,12 +2934,14 @@ nodes
 | array_flow.rb:431:10:431:10 | b [element 2] | semmle.label | b [element 2] |
 | array_flow.rb:431:10:431:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:435:5:435:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:435:9:435:29 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:435:19:435:28 | call to source | semmle.label | call to source |
 | array_flow.rb:436:5:436:5 | a [element 3] | semmle.label | a [element 3] |
 | array_flow.rb:436:25:436:25 | x [element] | semmle.label | x [element] |
 | array_flow.rb:437:14:437:14 | x [element] | semmle.label | x [element] |
 | array_flow.rb:437:14:437:17 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:442:5:442:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:442:9:442:29 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:442:19:442:28 | call to source | semmle.label | call to source |
 | array_flow.rb:443:5:443:5 | b [element 3] | semmle.label | b [element 3] |
 | array_flow.rb:443:9:443:9 | a [element 3] | semmle.label | a [element 3] |
@@ -2676,6 +2951,7 @@ nodes
 | array_flow.rb:447:10:447:10 | b [element 3] | semmle.label | b [element 3] |
 | array_flow.rb:447:10:447:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:451:5:451:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:451:9:451:31 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:451:19:451:30 | call to source | semmle.label | call to source |
 | array_flow.rb:452:5:452:5 | b | semmle.label | b |
 | array_flow.rb:452:9:452:9 | a [element 3] | semmle.label | a [element 3] |
@@ -2687,6 +2963,7 @@ nodes
 | array_flow.rb:454:14:454:14 | a | semmle.label | a |
 | array_flow.rb:456:10:456:10 | b | semmle.label | b |
 | array_flow.rb:460:5:460:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:460:9:460:29 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:460:19:460:28 | call to source | semmle.label | call to source |
 | array_flow.rb:461:5:461:5 | b [element 3] | semmle.label | b [element 3] |
 | array_flow.rb:461:9:461:9 | a [element 3] | semmle.label | a [element 3] |
@@ -2695,6 +2972,8 @@ nodes
 | array_flow.rb:462:10:462:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:466:5:466:5 | a [element 3] | semmle.label | a [element 3] |
 | array_flow.rb:466:5:466:5 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:466:9:466:45 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:466:9:466:45 | call to [] [element 4] | semmle.label | call to [] [element 4] |
 | array_flow.rb:466:19:466:30 | call to source | semmle.label | call to source |
 | array_flow.rb:466:33:466:44 | call to source | semmle.label | call to source |
 | array_flow.rb:467:5:467:5 | b | semmle.label | b |
@@ -2725,6 +3004,7 @@ nodes
 | array_flow.rb:477:20:477:31 | call to source | semmle.label | call to source |
 | array_flow.rb:478:10:478:10 | b | semmle.label | b |
 | array_flow.rb:482:5:482:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:482:9:482:31 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:482:19:482:30 | call to source | semmle.label | call to source |
 | array_flow.rb:483:5:483:5 | [post] a [element] | semmle.label | [post] a [element] |
 | array_flow.rb:483:12:483:23 | call to source | semmle.label | call to source |
@@ -2744,6 +3024,7 @@ nodes
 | array_flow.rb:494:10:494:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:494:10:494:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:498:5:498:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:498:9:498:29 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:498:19:498:28 | call to source | semmle.label | call to source |
 | array_flow.rb:499:5:499:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:499:9:499:9 | a [element 3] | semmle.label | a [element 3] |
@@ -2753,6 +3034,7 @@ nodes
 | array_flow.rb:502:10:502:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:502:10:502:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:506:5:506:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:506:9:506:29 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:506:19:506:28 | call to source | semmle.label | call to source |
 | array_flow.rb:507:5:507:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:507:9:507:9 | a [element 3] | semmle.label | a [element 3] |
@@ -2767,6 +3049,7 @@ nodes
 | array_flow.rb:521:10:521:10 | d [element] | semmle.label | d [element] |
 | array_flow.rb:521:10:521:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:525:5:525:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:525:9:525:29 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:525:19:525:28 | call to source | semmle.label | call to source |
 | array_flow.rb:526:5:526:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:526:9:526:9 | [post] a [element] | semmle.label | [post] a [element] |
@@ -2779,6 +3062,7 @@ nodes
 | array_flow.rb:531:10:531:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:531:10:531:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:535:5:535:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:535:9:535:31 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:535:19:535:30 | call to source | semmle.label | call to source |
 | array_flow.rb:536:5:536:5 | b | semmle.label | b |
 | array_flow.rb:536:9:536:9 | a [element 3] | semmle.label | a [element 3] |
@@ -2788,6 +3072,7 @@ nodes
 | array_flow.rb:537:14:537:14 | x | semmle.label | x |
 | array_flow.rb:539:10:539:10 | b | semmle.label | b |
 | array_flow.rb:543:5:543:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:543:9:543:29 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:543:19:543:28 | call to source | semmle.label | call to source |
 | array_flow.rb:544:5:544:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:544:9:544:9 | a [element 3] | semmle.label | a [element 3] |
@@ -2797,12 +3082,15 @@ nodes
 | array_flow.rb:547:10:547:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:547:10:547:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:551:5:551:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:551:9:551:29 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:551:19:551:28 | call to source | semmle.label | call to source |
 | array_flow.rb:552:5:552:5 | a [element 3] | semmle.label | a [element 3] |
 | array_flow.rb:552:22:552:22 | x | semmle.label | x |
 | array_flow.rb:553:14:553:14 | x | semmle.label | x |
 | array_flow.rb:558:5:558:5 | a [element 0] | semmle.label | a [element 0] |
 | array_flow.rb:558:5:558:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:558:9:558:42 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| array_flow.rb:558:9:558:42 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:558:10:558:21 | call to source | semmle.label | call to source |
 | array_flow.rb:558:30:558:41 | call to source | semmle.label | call to source |
 | array_flow.rb:559:5:559:5 | [post] a [element] | semmle.label | [post] a [element] |
@@ -2837,12 +3125,14 @@ nodes
 | array_flow.rb:566:10:566:10 | c [element] | semmle.label | c [element] |
 | array_flow.rb:566:10:566:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:570:5:570:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:570:9:570:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:570:16:570:27 | call to source | semmle.label | call to source |
 | array_flow.rb:571:5:571:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:571:9:571:9 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:571:9:574:7 | call to flat_map [element] | semmle.label | call to flat_map [element] |
 | array_flow.rb:571:24:571:24 | x | semmle.label | x |
 | array_flow.rb:572:14:572:14 | x | semmle.label | x |
+| array_flow.rb:573:9:573:25 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | array_flow.rb:573:13:573:24 | call to source | semmle.label | call to source |
 | array_flow.rb:575:10:575:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:575:10:575:13 | ...[...] | semmle.label | ...[...] |
@@ -2855,6 +3145,8 @@ nodes
 | array_flow.rb:580:10:580:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:580:10:580:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:584:5:584:5 | a [element 2, element 1] | semmle.label | a [element 2, element 1] |
+| array_flow.rb:584:9:584:31 | call to [] [element 2, element 1] | semmle.label | call to [] [element 2, element 1] |
+| array_flow.rb:584:16:584:30 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | array_flow.rb:584:20:584:29 | call to source | semmle.label | call to source |
 | array_flow.rb:585:5:585:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:585:9:585:9 | a [element 2, element 1] | semmle.label | a [element 2, element 1] |
@@ -2862,6 +3154,8 @@ nodes
 | array_flow.rb:586:10:586:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:586:10:586:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:590:5:590:5 | a [element 2, element 1] | semmle.label | a [element 2, element 1] |
+| array_flow.rb:590:9:590:31 | call to [] [element 2, element 1] | semmle.label | call to [] [element 2, element 1] |
+| array_flow.rb:590:16:590:30 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | array_flow.rb:590:20:590:29 | call to source | semmle.label | call to source |
 | array_flow.rb:591:10:591:10 | a [element 2, element 1] | semmle.label | a [element 2, element 1] |
 | array_flow.rb:591:10:591:13 | ...[...] [element 1] | semmle.label | ...[...] [element 1] |
@@ -2884,6 +3178,7 @@ nodes
 | array_flow.rb:596:10:596:13 | ...[...] [element 1] | semmle.label | ...[...] [element 1] |
 | array_flow.rb:596:10:596:16 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:600:5:600:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:600:9:600:31 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:600:19:600:30 | call to source | semmle.label | call to source |
 | array_flow.rb:601:5:601:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:601:9:601:9 | a [element 3] | semmle.label | a [element 3] |
@@ -2899,6 +3194,7 @@ nodes
 | array_flow.rb:607:10:607:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:607:10:607:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:611:5:611:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:611:9:611:31 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:611:19:611:30 | call to source | semmle.label | call to source |
 | array_flow.rb:612:5:612:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:612:9:612:9 | a [element 3] | semmle.label | a [element 3] |
@@ -2914,17 +3210,21 @@ nodes
 | array_flow.rb:618:10:618:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:618:10:618:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:622:5:622:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:622:9:622:31 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:622:19:622:30 | call to source | semmle.label | call to source |
 | array_flow.rb:623:9:623:9 | a [element 3] | semmle.label | a [element 3] |
 | array_flow.rb:623:24:623:24 | x | semmle.label | x |
 | array_flow.rb:624:14:624:14 | x | semmle.label | x |
 | array_flow.rb:631:5:631:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:631:9:631:29 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:631:19:631:28 | call to source | semmle.label | call to source |
 | array_flow.rb:632:5:632:5 | a [element 3] | semmle.label | a [element 3] |
 | array_flow.rb:632:17:632:17 | x | semmle.label | x |
 | array_flow.rb:633:14:633:14 | x | semmle.label | x |
 | array_flow.rb:638:5:638:5 | a [element 0] | semmle.label | a [element 0] |
 | array_flow.rb:638:5:638:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:638:9:638:39 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| array_flow.rb:638:9:638:39 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:638:10:638:21 | call to source | semmle.label | call to source |
 | array_flow.rb:638:27:638:38 | call to source | semmle.label | call to source |
 | array_flow.rb:639:5:639:5 | b | semmle.label | b |
@@ -2946,6 +3246,7 @@ nodes
 | array_flow.rb:648:9:648:19 | call to source | semmle.label | call to source |
 | array_flow.rb:650:10:650:10 | c | semmle.label | c |
 | array_flow.rb:655:5:655:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:655:9:655:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:655:16:655:27 | call to source | semmle.label | call to source |
 | array_flow.rb:656:5:656:5 | b [element 1] | semmle.label | b [element 1] |
 | array_flow.rb:656:5:656:5 | b [element 2] | semmle.label | b [element 2] |
@@ -2972,6 +3273,7 @@ nodes
 | array_flow.rb:666:10:666:10 | b [element 4] | semmle.label | b [element 4] |
 | array_flow.rb:666:10:666:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:669:5:669:5 | c [element 2] | semmle.label | c [element 2] |
+| array_flow.rb:669:9:669:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:669:16:669:27 | call to source | semmle.label | call to source |
 | array_flow.rb:670:5:670:5 | d [element] | semmle.label | d [element] |
 | array_flow.rb:670:9:670:9 | [post] c [element] | semmle.label | [post] c [element] |
@@ -2984,15 +3286,19 @@ nodes
 | array_flow.rb:672:10:672:10 | d [element] | semmle.label | d [element] |
 | array_flow.rb:672:10:672:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:683:5:683:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:683:9:683:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:683:16:683:27 | call to source | semmle.label | call to source |
 | array_flow.rb:684:5:684:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:684:9:684:9 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:684:9:684:60 | call to intersection [element] | semmle.label | call to intersection [element] |
+| array_flow.rb:684:24:684:43 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:684:31:684:42 | call to source | semmle.label | call to source |
+| array_flow.rb:684:46:684:59 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | array_flow.rb:684:47:684:58 | call to source | semmle.label | call to source |
 | array_flow.rb:685:10:685:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:685:10:685:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:689:5:689:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:689:9:689:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:689:16:689:25 | call to source | semmle.label | call to source |
 | array_flow.rb:690:5:690:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:690:9:690:9 | [post] a [element] | semmle.label | [post] a [element] |
@@ -3005,6 +3311,7 @@ nodes
 | array_flow.rb:695:10:695:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:695:10:695:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:699:5:699:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:699:9:699:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:699:16:699:27 | call to source | semmle.label | call to source |
 | array_flow.rb:700:5:700:5 | [post] a [element] | semmle.label | [post] a [element] |
 | array_flow.rb:700:12:700:23 | call to source | semmle.label | call to source |
@@ -3020,6 +3327,7 @@ nodes
 | array_flow.rb:704:10:704:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:704:10:704:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:708:5:708:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:708:9:708:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:708:16:708:27 | call to source | semmle.label | call to source |
 | array_flow.rb:709:5:709:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:709:9:709:9 | a [element 2] | semmle.label | a [element 2] |
@@ -3030,6 +3338,7 @@ nodes
 | array_flow.rb:713:10:713:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:713:10:713:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:717:5:717:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:717:9:717:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:717:16:717:27 | call to source | semmle.label | call to source |
 | array_flow.rb:718:5:718:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:718:9:718:9 | a [element 2] | semmle.label | a [element 2] |
@@ -3040,6 +3349,7 @@ nodes
 | array_flow.rb:722:10:722:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:722:10:722:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:726:5:726:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:726:9:726:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:726:16:726:25 | call to source | semmle.label | call to source |
 | array_flow.rb:729:5:729:5 | b | semmle.label | b |
 | array_flow.rb:729:9:729:9 | a [element 2] | semmle.label | a [element 2] |
@@ -3068,6 +3378,7 @@ nodes
 | array_flow.rb:750:10:750:10 | e [element] | semmle.label | e [element] |
 | array_flow.rb:750:10:750:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:754:5:754:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:754:9:754:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:754:16:754:25 | call to source | semmle.label | call to source |
 | array_flow.rb:757:5:757:5 | b | semmle.label | b |
 | array_flow.rb:757:9:757:9 | a [element 2] | semmle.label | a [element 2] |
@@ -3083,6 +3394,7 @@ nodes
 | array_flow.rb:768:10:768:10 | c [element] | semmle.label | c [element] |
 | array_flow.rb:768:10:768:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:772:5:772:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:772:9:772:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:772:16:772:25 | call to source | semmle.label | call to source |
 | array_flow.rb:775:5:775:5 | b | semmle.label | b |
 | array_flow.rb:775:9:775:9 | a [element 2] | semmle.label | a [element 2] |
@@ -3111,6 +3423,7 @@ nodes
 | array_flow.rb:796:10:796:10 | e [element] | semmle.label | e [element] |
 | array_flow.rb:796:10:796:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:800:5:800:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:800:9:800:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:800:16:800:25 | call to source | semmle.label | call to source |
 | array_flow.rb:803:5:803:5 | b | semmle.label | b |
 | array_flow.rb:803:9:803:9 | a [element 2] | semmle.label | a [element 2] |
@@ -3126,6 +3439,7 @@ nodes
 | array_flow.rb:814:10:814:10 | c [element] | semmle.label | c [element] |
 | array_flow.rb:814:10:814:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:818:5:818:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:818:9:818:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:818:16:818:25 | call to source | semmle.label | call to source |
 | array_flow.rb:820:5:820:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:820:9:820:9 | a [element 2] | semmle.label | a [element 2] |
@@ -3146,6 +3460,7 @@ nodes
 | array_flow.rb:830:10:830:10 | c [element] | semmle.label | c [element] |
 | array_flow.rb:830:10:830:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:834:5:834:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:834:9:834:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:834:16:834:25 | call to source | semmle.label | call to source |
 | array_flow.rb:835:5:835:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:835:9:835:9 | a [element 2] | semmle.label | a [element 2] |
@@ -3157,16 +3472,19 @@ nodes
 | array_flow.rb:840:10:840:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:840:10:840:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:844:5:844:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:844:9:844:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:844:16:844:25 | call to source | semmle.label | call to source |
 | array_flow.rb:845:5:845:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:845:17:845:17 | x | semmle.label | x |
 | array_flow.rb:846:14:846:14 | x | semmle.label | x |
 | array_flow.rb:853:5:853:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:853:9:853:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:853:16:853:25 | call to source | semmle.label | call to source |
 | array_flow.rb:854:5:854:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:854:16:854:16 | x | semmle.label | x |
 | array_flow.rb:855:14:855:14 | x | semmle.label | x |
 | array_flow.rb:866:5:866:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:866:9:866:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:866:16:866:25 | call to source | semmle.label | call to source |
 | array_flow.rb:867:5:867:5 | b [element, element] | semmle.label | b [element, element] |
 | array_flow.rb:867:9:867:9 | a [element 2] | semmle.label | a [element 2] |
@@ -3180,6 +3498,7 @@ nodes
 | array_flow.rb:872:10:872:13 | ...[...] [element] | semmle.label | ...[...] [element] |
 | array_flow.rb:872:10:872:16 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:876:5:876:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:876:9:876:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:876:16:876:25 | call to source | semmle.label | call to source |
 | array_flow.rb:878:5:878:5 | b [element 2] | semmle.label | b [element 2] |
 | array_flow.rb:878:9:878:9 | a [element 2] | semmle.label | a [element 2] |
@@ -3213,6 +3532,8 @@ nodes
 | array_flow.rb:898:10:898:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:905:5:905:5 | a [element 1] | semmle.label | a [element 1] |
 | array_flow.rb:905:5:905:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:905:9:905:42 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| array_flow.rb:905:9:905:42 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:905:13:905:24 | call to source | semmle.label | call to source |
 | array_flow.rb:905:30:905:41 | call to source | semmle.label | call to source |
 | array_flow.rb:906:5:906:5 | b | semmle.label | b |
@@ -3226,6 +3547,8 @@ nodes
 | array_flow.rb:911:10:911:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:913:5:913:5 | a [element 1] | semmle.label | a [element 1] |
 | array_flow.rb:913:5:913:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:913:9:913:42 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| array_flow.rb:913:9:913:42 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:913:13:913:24 | call to source | semmle.label | call to source |
 | array_flow.rb:913:30:913:41 | call to source | semmle.label | call to source |
 | array_flow.rb:914:5:914:5 | b [element] | semmle.label | b [element] |
@@ -3241,6 +3564,7 @@ nodes
 | array_flow.rb:920:10:920:10 | a [element 3] | semmle.label | a [element 3] |
 | array_flow.rb:920:10:920:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:924:5:924:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:924:9:924:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:924:16:924:27 | call to source | semmle.label | call to source |
 | array_flow.rb:925:5:925:5 | [post] a [element 2] | semmle.label | [post] a [element 2] |
 | array_flow.rb:925:5:925:5 | [post] a [element 5] | semmle.label | [post] a [element 5] |
@@ -3251,10 +3575,13 @@ nodes
 | array_flow.rb:931:10:931:10 | a [element 5] | semmle.label | a [element 5] |
 | array_flow.rb:931:10:931:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:935:5:935:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:935:9:935:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:935:16:935:27 | call to source | semmle.label | call to source |
 | array_flow.rb:936:5:936:5 | b [element 1] | semmle.label | b [element 1] |
+| array_flow.rb:936:9:936:28 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | array_flow.rb:936:13:936:24 | call to source | semmle.label | call to source |
 | array_flow.rb:937:5:937:5 | c [element 0] | semmle.label | c [element 0] |
+| array_flow.rb:937:9:937:28 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | array_flow.rb:937:10:937:21 | call to source | semmle.label | call to source |
 | array_flow.rb:938:5:938:5 | d [element, element] | semmle.label | d [element, element] |
 | array_flow.rb:938:9:938:9 | a [element 2] | semmle.label | a [element 2] |
@@ -3268,6 +3595,7 @@ nodes
 | array_flow.rb:940:10:940:13 | ...[...] [element] | semmle.label | ...[...] [element] |
 | array_flow.rb:940:10:940:16 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:944:5:944:5 | a [element 0] | semmle.label | a [element 0] |
+| array_flow.rb:944:9:944:25 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | array_flow.rb:944:10:944:21 | call to source | semmle.label | call to source |
 | array_flow.rb:945:5:945:5 | b [element 0] | semmle.label | b [element 0] |
 | array_flow.rb:945:5:945:5 | b [element] | semmle.label | b [element] |
@@ -3288,8 +3616,10 @@ nodes
 | array_flow.rb:949:10:949:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:949:10:949:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:955:5:955:5 | c [element 0] | semmle.label | c [element 0] |
+| array_flow.rb:955:9:955:25 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | array_flow.rb:955:10:955:19 | call to source | semmle.label | call to source |
 | array_flow.rb:956:5:956:5 | d [element 2, element 0] | semmle.label | d [element 2, element 0] |
+| array_flow.rb:956:9:956:17 | call to [] [element 2, element 0] | semmle.label | call to [] [element 2, element 0] |
 | array_flow.rb:956:16:956:16 | c [element 0] | semmle.label | c [element 0] |
 | array_flow.rb:957:10:957:10 | d [element 2, element 0] | semmle.label | d [element 2, element 0] |
 | array_flow.rb:957:10:957:22 | call to rassoc [element 0] | semmle.label | call to rassoc [element 0] |
@@ -3299,6 +3629,8 @@ nodes
 | array_flow.rb:958:10:958:25 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:962:5:962:5 | a [element 0] | semmle.label | a [element 0] |
 | array_flow.rb:962:5:962:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:962:9:962:39 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| array_flow.rb:962:9:962:39 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:962:10:962:21 | call to source | semmle.label | call to source |
 | array_flow.rb:962:27:962:38 | call to source | semmle.label | call to source |
 | array_flow.rb:963:9:963:9 | a [element 0] | semmle.label | a [element 0] |
@@ -3312,6 +3644,7 @@ nodes
 | array_flow.rb:968:28:968:28 | y | semmle.label | y |
 | array_flow.rb:970:14:970:14 | y | semmle.label | y |
 | array_flow.rb:976:5:976:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:976:9:976:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:976:16:976:25 | call to source | semmle.label | call to source |
 | array_flow.rb:977:5:977:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:977:9:977:9 | a [element 2] | semmle.label | a [element 2] |
@@ -3321,6 +3654,7 @@ nodes
 | array_flow.rb:981:10:981:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:981:10:981:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:985:5:985:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:985:9:985:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:985:16:985:25 | call to source | semmle.label | call to source |
 | array_flow.rb:986:5:986:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:986:9:986:9 | [post] a [element] | semmle.label | [post] a [element] |
@@ -3333,6 +3667,7 @@ nodes
 | array_flow.rb:991:10:991:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:991:10:991:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:995:5:995:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:995:9:995:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:995:16:995:25 | call to source | semmle.label | call to source |
 | array_flow.rb:996:5:996:5 | b [element 2] | semmle.label | b [element 2] |
 | array_flow.rb:996:9:996:9 | a [element 2] | semmle.label | a [element 2] |
@@ -3345,6 +3680,7 @@ nodes
 | array_flow.rb:1001:10:1001:10 | b [element 2] | semmle.label | b [element 2] |
 | array_flow.rb:1001:10:1001:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1005:5:1005:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1005:9:1005:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:1005:16:1005:25 | call to source | semmle.label | call to source |
 | array_flow.rb:1006:5:1006:5 | b [element 2] | semmle.label | b [element 2] |
 | array_flow.rb:1006:9:1006:9 | a [element 2] | semmle.label | a [element 2] |
@@ -3359,6 +3695,7 @@ nodes
 | array_flow.rb:1017:5:1017:5 | b [element 0] | semmle.label | b [element 0] |
 | array_flow.rb:1017:9:1017:9 | [post] a [element 0] | semmle.label | [post] a [element 0] |
 | array_flow.rb:1017:9:1017:33 | call to replace [element 0] | semmle.label | call to replace [element 0] |
+| array_flow.rb:1017:19:1017:32 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | array_flow.rb:1017:20:1017:31 | call to source | semmle.label | call to source |
 | array_flow.rb:1018:10:1018:10 | a [element 0] | semmle.label | a [element 0] |
 | array_flow.rb:1018:10:1018:13 | ...[...] | semmle.label | ...[...] |
@@ -3366,6 +3703,8 @@ nodes
 | array_flow.rb:1019:10:1019:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1023:5:1023:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:1023:5:1023:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1023:9:1023:44 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1023:9:1023:44 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:1023:16:1023:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1023:31:1023:43 | call to source | semmle.label | call to source |
 | array_flow.rb:1024:5:1024:5 | b [element] | semmle.label | b [element] |
@@ -3384,6 +3723,8 @@ nodes
 | array_flow.rb:1030:10:1030:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1034:5:1034:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:1034:5:1034:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1034:9:1034:44 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1034:9:1034:44 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:1034:16:1034:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1034:31:1034:43 | call to source | semmle.label | call to source |
 | array_flow.rb:1035:5:1035:5 | b [element] | semmle.label | b [element] |
@@ -3406,6 +3747,7 @@ nodes
 | array_flow.rb:1041:10:1041:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:1041:10:1041:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1045:5:1045:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1045:9:1045:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:1045:16:1045:26 | call to source | semmle.label | call to source |
 | array_flow.rb:1046:5:1046:5 | b [element 2] | semmle.label | b [element 2] |
 | array_flow.rb:1046:9:1046:9 | a [element 2] | semmle.label | a [element 2] |
@@ -3415,6 +3757,7 @@ nodes
 | array_flow.rb:1049:10:1049:10 | b [element 2] | semmle.label | b [element 2] |
 | array_flow.rb:1049:10:1049:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1053:5:1053:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1053:9:1053:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:1053:16:1053:26 | call to source | semmle.label | call to source |
 | array_flow.rb:1054:5:1054:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:1054:18:1054:18 | x | semmle.label | x |
@@ -3422,6 +3765,9 @@ nodes
 | array_flow.rb:1063:5:1063:5 | a [element 0] | semmle.label | a [element 0] |
 | array_flow.rb:1063:5:1063:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:1063:5:1063:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1063:9:1063:56 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| array_flow.rb:1063:9:1063:56 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1063:9:1063:56 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:1063:10:1063:22 | call to source | semmle.label | call to source |
 | array_flow.rb:1063:28:1063:40 | call to source | semmle.label | call to source |
 | array_flow.rb:1063:43:1063:55 | call to source | semmle.label | call to source |
@@ -3494,6 +3840,9 @@ nodes
 | array_flow.rb:1095:5:1095:5 | a [element 0] | semmle.label | a [element 0] |
 | array_flow.rb:1095:5:1095:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:1095:5:1095:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1095:9:1095:56 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| array_flow.rb:1095:9:1095:56 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1095:9:1095:56 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:1095:10:1095:22 | call to source | semmle.label | call to source |
 | array_flow.rb:1095:28:1095:40 | call to source | semmle.label | call to source |
 | array_flow.rb:1095:43:1095:55 | call to source | semmle.label | call to source |
@@ -3532,6 +3881,9 @@ nodes
 | array_flow.rb:1106:5:1106:5 | a [element 0] | semmle.label | a [element 0] |
 | array_flow.rb:1106:5:1106:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:1106:5:1106:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1106:9:1106:56 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| array_flow.rb:1106:9:1106:56 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1106:9:1106:56 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:1106:10:1106:22 | call to source | semmle.label | call to source |
 | array_flow.rb:1106:28:1106:40 | call to source | semmle.label | call to source |
 | array_flow.rb:1106:43:1106:55 | call to source | semmle.label | call to source |
@@ -3570,6 +3922,9 @@ nodes
 | array_flow.rb:1117:5:1117:5 | a [element 0] | semmle.label | a [element 0] |
 | array_flow.rb:1117:5:1117:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:1117:5:1117:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1117:9:1117:56 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| array_flow.rb:1117:9:1117:56 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1117:9:1117:56 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:1117:10:1117:22 | call to source | semmle.label | call to source |
 | array_flow.rb:1117:28:1117:40 | call to source | semmle.label | call to source |
 | array_flow.rb:1117:43:1117:55 | call to source | semmle.label | call to source |
@@ -3600,6 +3955,9 @@ nodes
 | array_flow.rb:1128:5:1128:5 | a [element 0] | semmle.label | a [element 0] |
 | array_flow.rb:1128:5:1128:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:1128:5:1128:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1128:9:1128:56 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| array_flow.rb:1128:9:1128:56 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1128:9:1128:56 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:1128:10:1128:22 | call to source | semmle.label | call to source |
 | array_flow.rb:1128:28:1128:40 | call to source | semmle.label | call to source |
 | array_flow.rb:1128:43:1128:55 | call to source | semmle.label | call to source |
@@ -3626,6 +3984,7 @@ nodes
 | array_flow.rb:1137:10:1137:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1137:10:1137:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1141:5:1141:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1141:9:1141:30 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:1141:19:1141:29 | call to source | semmle.label | call to source |
 | array_flow.rb:1142:5:1142:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1142:9:1142:9 | a [element 3] | semmle.label | a [element 3] |
@@ -3635,6 +3994,7 @@ nodes
 | array_flow.rb:1145:10:1145:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1145:10:1145:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1149:5:1149:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1149:9:1149:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:1149:16:1149:26 | call to source | semmle.label | call to source |
 | array_flow.rb:1150:5:1150:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1150:9:1150:9 | [post] a [element] | semmle.label | [post] a [element] |
@@ -3648,6 +4008,8 @@ nodes
 | array_flow.rb:1155:10:1155:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1159:5:1159:5 | a [element 0] | semmle.label | a [element 0] |
 | array_flow.rb:1159:5:1159:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1159:9:1159:41 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| array_flow.rb:1159:9:1159:41 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:1159:10:1159:22 | call to source | semmle.label | call to source |
 | array_flow.rb:1159:28:1159:40 | call to source | semmle.label | call to source |
 | array_flow.rb:1160:5:1160:5 | b | semmle.label | b |
@@ -3660,6 +4022,8 @@ nodes
 | array_flow.rb:1163:10:1163:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1166:5:1166:5 | a [element 0] | semmle.label | a [element 0] |
 | array_flow.rb:1166:5:1166:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1166:9:1166:41 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| array_flow.rb:1166:9:1166:41 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:1166:10:1166:22 | call to source | semmle.label | call to source |
 | array_flow.rb:1166:28:1166:40 | call to source | semmle.label | call to source |
 | array_flow.rb:1167:5:1167:5 | b [element 0] | semmle.label | b [element 0] |
@@ -3673,6 +4037,8 @@ nodes
 | array_flow.rb:1170:10:1170:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1174:5:1174:5 | a [element 0] | semmle.label | a [element 0] |
 | array_flow.rb:1174:5:1174:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1174:9:1174:41 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| array_flow.rb:1174:9:1174:41 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:1174:10:1174:22 | call to source | semmle.label | call to source |
 | array_flow.rb:1174:28:1174:40 | call to source | semmle.label | call to source |
 | array_flow.rb:1175:5:1175:5 | b [element] | semmle.label | b [element] |
@@ -3693,6 +4059,7 @@ nodes
 | array_flow.rb:1180:10:1180:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:1180:10:1180:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1184:5:1184:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1184:9:1184:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:1184:16:1184:26 | call to source | semmle.label | call to source |
 | array_flow.rb:1185:5:1185:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1185:9:1185:9 | a [element 2] | semmle.label | a [element 2] |
@@ -3706,6 +4073,7 @@ nodes
 | array_flow.rb:1191:10:1191:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1191:10:1191:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1195:5:1195:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1195:9:1195:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:1195:16:1195:26 | call to source | semmle.label | call to source |
 | array_flow.rb:1196:5:1196:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1196:9:1196:9 | [post] a [element] | semmle.label | [post] a [element] |
@@ -3726,6 +4094,8 @@ nodes
 | array_flow.rb:1202:10:1202:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1206:5:1206:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:1206:5:1206:5 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1206:9:1206:47 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1206:9:1206:47 | call to [] [element 4] | semmle.label | call to [] [element 4] |
 | array_flow.rb:1206:16:1206:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1206:34:1206:46 | call to source | semmle.label | call to source |
 | array_flow.rb:1208:5:1208:5 | b | semmle.label | b |
@@ -3803,6 +4173,8 @@ nodes
 | array_flow.rb:1256:10:1256:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1260:5:1260:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:1260:5:1260:5 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1260:9:1260:47 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1260:9:1260:47 | call to [] [element 4] | semmle.label | call to [] [element 4] |
 | array_flow.rb:1260:16:1260:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1260:34:1260:46 | call to source | semmle.label | call to source |
 | array_flow.rb:1261:5:1261:5 | b | semmle.label | b |
@@ -3815,6 +4187,8 @@ nodes
 | array_flow.rb:1266:10:1266:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1268:5:1268:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:1268:5:1268:5 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1268:9:1268:47 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1268:9:1268:47 | call to [] [element 4] | semmle.label | call to [] [element 4] |
 | array_flow.rb:1268:16:1268:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1268:34:1268:46 | call to source | semmle.label | call to source |
 | array_flow.rb:1269:5:1269:5 | b | semmle.label | b |
@@ -3837,6 +4211,8 @@ nodes
 | array_flow.rb:1277:10:1277:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1279:5:1279:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:1279:5:1279:5 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1279:9:1279:47 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1279:9:1279:47 | call to [] [element 4] | semmle.label | call to [] [element 4] |
 | array_flow.rb:1279:16:1279:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1279:34:1279:46 | call to source | semmle.label | call to source |
 | array_flow.rb:1280:5:1280:5 | b [element 0] | semmle.label | b [element 0] |
@@ -3851,6 +4227,8 @@ nodes
 | array_flow.rb:1283:10:1283:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1290:5:1290:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:1290:5:1290:5 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1290:9:1290:47 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1290:9:1290:47 | call to [] [element 4] | semmle.label | call to [] [element 4] |
 | array_flow.rb:1290:16:1290:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1290:34:1290:46 | call to source | semmle.label | call to source |
 | array_flow.rb:1291:5:1291:5 | b [element 0] | semmle.label | b [element 0] |
@@ -3864,6 +4242,8 @@ nodes
 | array_flow.rb:1297:10:1297:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1301:5:1301:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:1301:5:1301:5 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1301:9:1301:47 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1301:9:1301:47 | call to [] [element 4] | semmle.label | call to [] [element 4] |
 | array_flow.rb:1301:16:1301:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1301:34:1301:46 | call to source | semmle.label | call to source |
 | array_flow.rb:1302:5:1302:5 | b [element 0] | semmle.label | b [element 0] |
@@ -3877,6 +4257,8 @@ nodes
 | array_flow.rb:1308:10:1308:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1312:5:1312:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:1312:5:1312:5 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1312:9:1312:47 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1312:9:1312:47 | call to [] [element 4] | semmle.label | call to [] [element 4] |
 | array_flow.rb:1312:16:1312:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1312:34:1312:46 | call to source | semmle.label | call to source |
 | array_flow.rb:1313:5:1313:5 | b [element] | semmle.label | b [element] |
@@ -3898,6 +4280,8 @@ nodes
 | array_flow.rb:1319:10:1319:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1321:5:1321:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:1321:5:1321:5 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1321:9:1321:47 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1321:9:1321:47 | call to [] [element 4] | semmle.label | call to [] [element 4] |
 | array_flow.rb:1321:16:1321:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1321:34:1321:46 | call to source | semmle.label | call to source |
 | array_flow.rb:1322:5:1322:5 | b [element] | semmle.label | b [element] |
@@ -3919,6 +4303,8 @@ nodes
 | array_flow.rb:1328:10:1328:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1330:5:1330:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:1330:5:1330:5 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1330:9:1330:47 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1330:9:1330:47 | call to [] [element 4] | semmle.label | call to [] [element 4] |
 | array_flow.rb:1330:16:1330:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1330:34:1330:46 | call to source | semmle.label | call to source |
 | array_flow.rb:1331:5:1331:5 | b [element] | semmle.label | b [element] |
@@ -3940,6 +4326,8 @@ nodes
 | array_flow.rb:1337:10:1337:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1339:5:1339:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:1339:5:1339:5 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1339:9:1339:47 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1339:9:1339:47 | call to [] [element 4] | semmle.label | call to [] [element 4] |
 | array_flow.rb:1339:16:1339:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1339:34:1339:46 | call to source | semmle.label | call to source |
 | array_flow.rb:1340:5:1340:5 | b [element 2] | semmle.label | b [element 2] |
@@ -3953,6 +4341,8 @@ nodes
 | array_flow.rb:1345:10:1345:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1348:5:1348:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:1348:5:1348:5 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1348:9:1348:47 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1348:9:1348:47 | call to [] [element 4] | semmle.label | call to [] [element 4] |
 | array_flow.rb:1348:16:1348:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1348:34:1348:46 | call to source | semmle.label | call to source |
 | array_flow.rb:1349:5:1349:5 | b [element] | semmle.label | b [element] |
@@ -3973,16 +4363,19 @@ nodes
 | array_flow.rb:1355:10:1355:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:1355:10:1355:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1359:5:1359:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1359:9:1359:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:1359:16:1359:26 | call to source | semmle.label | call to source |
 | array_flow.rb:1360:9:1360:9 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:1360:27:1360:27 | x | semmle.label | x |
 | array_flow.rb:1361:14:1361:14 | x | semmle.label | x |
 | array_flow.rb:1367:5:1367:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1367:9:1367:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:1367:16:1367:26 | call to source | semmle.label | call to source |
 | array_flow.rb:1368:9:1368:9 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:1368:28:1368:28 | x | semmle.label | x |
 | array_flow.rb:1369:14:1369:14 | x | semmle.label | x |
 | array_flow.rb:1375:5:1375:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1375:9:1375:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:1375:16:1375:26 | call to source | semmle.label | call to source |
 | array_flow.rb:1376:9:1376:9 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:1376:26:1376:26 | x | semmle.label | x |
@@ -3990,6 +4383,7 @@ nodes
 | array_flow.rb:1377:14:1377:14 | x | semmle.label | x |
 | array_flow.rb:1378:14:1378:14 | y | semmle.label | y |
 | array_flow.rb:1383:5:1383:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1383:9:1383:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:1383:16:1383:26 | call to source | semmle.label | call to source |
 | array_flow.rb:1384:5:1384:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1384:9:1384:9 | a [element 2] | semmle.label | a [element 2] |
@@ -4010,6 +4404,7 @@ nodes
 | array_flow.rb:1393:10:1393:10 | c [element] | semmle.label | c [element] |
 | array_flow.rb:1393:10:1393:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1397:5:1397:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1397:9:1397:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:1397:16:1397:26 | call to source | semmle.label | call to source |
 | array_flow.rb:1398:5:1398:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1398:9:1398:9 | [post] a [element] | semmle.label | [post] a [element] |
@@ -4024,6 +4419,7 @@ nodes
 | array_flow.rb:1402:10:1402:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:1402:10:1402:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1404:5:1404:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1404:9:1404:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:1404:16:1404:26 | call to source | semmle.label | call to source |
 | array_flow.rb:1405:5:1405:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1405:9:1405:9 | [post] a [element] | semmle.label | [post] a [element] |
@@ -4042,6 +4438,7 @@ nodes
 | array_flow.rb:1413:10:1413:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:1413:10:1413:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1417:5:1417:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1417:9:1417:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:1417:16:1417:26 | call to source | semmle.label | call to source |
 | array_flow.rb:1418:5:1418:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1418:9:1418:9 | a [element 2] | semmle.label | a [element 2] |
@@ -4053,6 +4450,7 @@ nodes
 | array_flow.rb:1423:10:1423:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1423:10:1423:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1427:5:1427:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1427:9:1427:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:1427:16:1427:26 | call to source | semmle.label | call to source |
 | array_flow.rb:1428:5:1428:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1428:9:1428:9 | [post] a [element] | semmle.label | [post] a [element] |
@@ -4069,12 +4467,15 @@ nodes
 | array_flow.rb:1435:10:1435:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1435:10:1435:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1439:5:1439:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1439:9:1439:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:1439:16:1439:26 | call to source | semmle.label | call to source |
 | array_flow.rb:1440:9:1440:9 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:1440:19:1440:19 | x | semmle.label | x |
 | array_flow.rb:1441:14:1441:14 | x | semmle.label | x |
 | array_flow.rb:1447:5:1447:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:1447:5:1447:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1447:9:1447:44 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1447:9:1447:44 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:1447:16:1447:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1447:31:1447:43 | call to source | semmle.label | call to source |
 | array_flow.rb:1448:5:1448:5 | b [element 2] | semmle.label | b [element 2] |
@@ -4119,6 +4520,7 @@ nodes
 | array_flow.rb:1467:10:1467:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1467:10:1467:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1471:5:1471:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1471:9:1471:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:1471:16:1471:26 | call to source | semmle.label | call to source |
 | array_flow.rb:1472:5:1472:5 | b [element 2] | semmle.label | b [element 2] |
 | array_flow.rb:1472:9:1472:9 | a [element 2] | semmle.label | a [element 2] |
@@ -4128,6 +4530,7 @@ nodes
 | array_flow.rb:1478:10:1478:10 | b [element 2] | semmle.label | b [element 2] |
 | array_flow.rb:1478:10:1478:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1484:5:1484:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1484:9:1484:30 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:1484:19:1484:29 | call to source | semmle.label | call to source |
 | array_flow.rb:1485:5:1485:5 | b [element 3] | semmle.label | b [element 3] |
 | array_flow.rb:1485:9:1485:9 | a [element 3] | semmle.label | a [element 3] |
@@ -4135,6 +4538,7 @@ nodes
 | array_flow.rb:1486:10:1486:10 | b [element 3] | semmle.label | b [element 3] |
 | array_flow.rb:1486:10:1486:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1490:5:1490:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1490:9:1490:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:1490:16:1490:26 | call to source | semmle.label | call to source |
 | array_flow.rb:1491:5:1491:5 | b [element 2] | semmle.label | b [element 2] |
 | array_flow.rb:1491:9:1491:9 | a [element 2] | semmle.label | a [element 2] |
@@ -4144,8 +4548,14 @@ nodes
 | array_flow.rb:1507:5:1507:5 | a [element 0, element 1] | semmle.label | a [element 0, element 1] |
 | array_flow.rb:1507:5:1507:5 | a [element 1, element 1] | semmle.label | a [element 1, element 1] |
 | array_flow.rb:1507:5:1507:5 | a [element 2, element 1] | semmle.label | a [element 2, element 1] |
+| array_flow.rb:1507:9:1507:68 | call to [] [element 0, element 1] | semmle.label | call to [] [element 0, element 1] |
+| array_flow.rb:1507:9:1507:68 | call to [] [element 1, element 1] | semmle.label | call to [] [element 1, element 1] |
+| array_flow.rb:1507:9:1507:68 | call to [] [element 2, element 1] | semmle.label | call to [] [element 2, element 1] |
+| array_flow.rb:1507:10:1507:27 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | array_flow.rb:1507:14:1507:26 | call to source | semmle.label | call to source |
+| array_flow.rb:1507:30:1507:47 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | array_flow.rb:1507:34:1507:46 | call to source | semmle.label | call to source |
+| array_flow.rb:1507:50:1507:67 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | array_flow.rb:1507:54:1507:66 | call to source | semmle.label | call to source |
 | array_flow.rb:1508:5:1508:5 | b [element 1, element 0] | semmle.label | b [element 1, element 0] |
 | array_flow.rb:1508:5:1508:5 | b [element 1, element 1] | semmle.label | b [element 1, element 1] |
@@ -4166,10 +4576,13 @@ nodes
 | array_flow.rb:1514:10:1514:13 | ...[...] [element 2] | semmle.label | ...[...] [element 2] |
 | array_flow.rb:1514:10:1514:16 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1518:5:1518:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1518:9:1518:29 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:1518:16:1518:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1519:5:1519:5 | b [element 1] | semmle.label | b [element 1] |
+| array_flow.rb:1519:9:1519:26 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | array_flow.rb:1519:13:1519:25 | call to source | semmle.label | call to source |
 | array_flow.rb:1520:5:1520:5 | c [element 1] | semmle.label | c [element 1] |
+| array_flow.rb:1520:9:1520:26 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | array_flow.rb:1520:13:1520:25 | call to source | semmle.label | call to source |
 | array_flow.rb:1521:5:1521:5 | d [element] | semmle.label | d [element] |
 | array_flow.rb:1521:9:1521:9 | a [element 2] | semmle.label | a [element 2] |
@@ -4184,6 +4597,8 @@ nodes
 | array_flow.rb:1524:10:1524:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1528:5:1528:5 | a [element 3] | semmle.label | a [element 3] |
 | array_flow.rb:1528:5:1528:5 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1528:9:1528:47 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:1528:9:1528:47 | call to [] [element 4] | semmle.label | call to [] [element 4] |
 | array_flow.rb:1528:19:1528:31 | call to source | semmle.label | call to source |
 | array_flow.rb:1528:34:1528:46 | call to source | semmle.label | call to source |
 | array_flow.rb:1530:5:1530:5 | b [element] | semmle.label | b [element] |
@@ -4204,6 +4619,8 @@ nodes
 | array_flow.rb:1538:10:1538:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1542:5:1542:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:1542:5:1542:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1542:9:1542:44 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1542:9:1542:44 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:1542:16:1542:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1542:31:1542:43 | call to source | semmle.label | call to source |
 | array_flow.rb:1543:5:1543:5 | b [element] | semmle.label | b [element] |
@@ -4221,6 +4638,8 @@ nodes
 | array_flow.rb:1547:10:1547:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1549:5:1549:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:1549:5:1549:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1549:9:1549:44 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1549:9:1549:44 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:1549:16:1549:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1549:31:1549:43 | call to source | semmle.label | call to source |
 | array_flow.rb:1550:5:1550:5 | b [element] | semmle.label | b [element] |
@@ -4239,6 +4658,7 @@ nodes
 | array_flow.rb:1557:10:1557:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:1557:10:1557:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1561:5:1561:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1561:9:1561:29 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:1561:16:1561:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1562:5:1562:5 | [post] a [element 2] | semmle.label | [post] a [element 2] |
 | array_flow.rb:1562:5:1562:5 | [post] a [element 5] | semmle.label | [post] a [element 5] |
@@ -4250,6 +4670,8 @@ nodes
 | array_flow.rb:1568:10:1568:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1572:5:1572:5 | a [element 1] | semmle.label | a [element 1] |
 | array_flow.rb:1572:5:1572:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1572:9:1572:44 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| array_flow.rb:1572:9:1572:44 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:1572:13:1572:25 | call to source | semmle.label | call to source |
 | array_flow.rb:1572:31:1572:43 | call to source | semmle.label | call to source |
 | array_flow.rb:1574:5:1574:5 | b [element 1] | semmle.label | b [element 1] |
@@ -4293,10 +4715,13 @@ nodes
 | array_flow.rb:1592:10:1592:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1592:10:1592:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1596:5:1596:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1596:9:1596:29 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:1596:16:1596:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1597:5:1597:5 | b [element 1] | semmle.label | b [element 1] |
+| array_flow.rb:1597:9:1597:29 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | array_flow.rb:1597:13:1597:25 | call to source | semmle.label | call to source |
 | array_flow.rb:1598:5:1598:5 | c [element 0] | semmle.label | c [element 0] |
+| array_flow.rb:1598:9:1598:29 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | array_flow.rb:1598:10:1598:22 | call to source | semmle.label | call to source |
 | array_flow.rb:1599:5:1599:5 | d [element 0, element 2] | semmle.label | d [element 0, element 2] |
 | array_flow.rb:1599:5:1599:5 | d [element 1, element 1] | semmle.label | d [element 1, element 1] |
@@ -4329,8 +4754,10 @@ nodes
 | array_flow.rb:1607:14:1607:14 | x [element 2] | semmle.label | x [element 2] |
 | array_flow.rb:1607:14:1607:17 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1612:5:1612:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1612:9:1612:29 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:1612:16:1612:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1613:5:1613:5 | b [element 1] | semmle.label | b [element 1] |
+| array_flow.rb:1613:9:1613:26 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | array_flow.rb:1613:13:1613:25 | call to source | semmle.label | call to source |
 | array_flow.rb:1614:5:1614:5 | c [element] | semmle.label | c [element] |
 | array_flow.rb:1614:9:1614:9 | a [element 2] | semmle.label | a [element 2] |
@@ -4389,6 +4816,7 @@ nodes
 | array_flow.rb:1672:14:1672:15 | a2 [element 1] | semmle.label | a2 [element 1] |
 | array_flow.rb:1672:14:1672:18 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1677:5:1677:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1677:9:1677:29 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | array_flow.rb:1677:16:1677:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1678:5:1678:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1678:9:1678:9 | a [element 2] | semmle.label | a [element 2] |
@@ -4397,6 +4825,8 @@ nodes
 | array_flow.rb:1681:10:1681:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1685:5:1685:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:1685:5:1685:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1685:9:1685:44 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1685:9:1685:44 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | array_flow.rb:1685:16:1685:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1685:31:1685:43 | call to source | semmle.label | call to source |
 | array_flow.rb:1686:11:1686:11 | z | semmle.label | z |

--- a/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
@@ -2120,6 +2120,20 @@ edges
 | array_flow.rb:1668:25:1668:37 | call to source | array_flow.rb:1668:14:1668:41 | ...[...] [element 1] | provenance |  |
 | array_flow.rb:1670:14:1670:15 | a2 [element 1] | array_flow.rb:1670:14:1670:18 | ...[...] | provenance |  |
 | array_flow.rb:1672:14:1672:15 | a2 [element 1] | array_flow.rb:1672:14:1672:18 | ...[...] | provenance |  |
+| array_flow.rb:1677:5:1677:5 | a [element 2] | array_flow.rb:1678:9:1678:9 | a [element 2] | provenance |  |
+| array_flow.rb:1677:16:1677:28 | call to source | array_flow.rb:1677:5:1677:5 | a [element 2] | provenance |  |
+| array_flow.rb:1678:5:1678:5 | b [element] | array_flow.rb:1681:10:1681:10 | b [element] | provenance |  |
+| array_flow.rb:1678:9:1678:9 | a [element 2] | array_flow.rb:1678:9:1680:7 | call to map [element] | provenance |  |
+| array_flow.rb:1678:9:1680:7 | call to map [element] | array_flow.rb:1678:5:1678:5 | b [element] | provenance |  |
+| array_flow.rb:1681:10:1681:10 | b [element] | array_flow.rb:1681:10:1681:13 | ...[...] | provenance |  |
+| array_flow.rb:1685:5:1685:5 | a [element 2] | array_flow.rb:1686:18:1686:18 | a [element 2] | provenance |  |
+| array_flow.rb:1685:5:1685:5 | a [element 3] | array_flow.rb:1686:18:1686:18 | a [element 3] | provenance |  |
+| array_flow.rb:1685:16:1685:28 | call to source | array_flow.rb:1685:5:1685:5 | a [element 2] | provenance |  |
+| array_flow.rb:1685:31:1685:43 | call to source | array_flow.rb:1685:5:1685:5 | a [element 3] | provenance |  |
+| array_flow.rb:1686:11:1686:11 | z | array_flow.rb:1689:10:1689:10 | z | provenance |  |
+| array_flow.rb:1686:14:1686:14 | w | array_flow.rb:1690:10:1690:10 | w | provenance |  |
+| array_flow.rb:1686:18:1686:18 | a [element 2] | array_flow.rb:1686:11:1686:11 | z | provenance |  |
+| array_flow.rb:1686:18:1686:18 | a [element 3] | array_flow.rb:1686:14:1686:14 | w | provenance |  |
 nodes
 | array_flow.rb:2:5:2:5 | a [element 0] | semmle.label | a [element 0] |
 | array_flow.rb:2:9:2:20 | * ... [element 0] | semmle.label | * ... [element 0] |
@@ -4374,6 +4388,23 @@ nodes
 | array_flow.rb:1670:14:1670:18 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1672:14:1672:15 | a2 [element 1] | semmle.label | a2 [element 1] |
 | array_flow.rb:1672:14:1672:18 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1677:5:1677:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1677:16:1677:28 | call to source | semmle.label | call to source |
+| array_flow.rb:1678:5:1678:5 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1678:9:1678:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1678:9:1680:7 | call to map [element] | semmle.label | call to map [element] |
+| array_flow.rb:1681:10:1681:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1681:10:1681:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1685:5:1685:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1685:5:1685:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1685:16:1685:28 | call to source | semmle.label | call to source |
+| array_flow.rb:1685:31:1685:43 | call to source | semmle.label | call to source |
+| array_flow.rb:1686:11:1686:11 | z | semmle.label | z |
+| array_flow.rb:1686:14:1686:14 | w | semmle.label | w |
+| array_flow.rb:1686:18:1686:18 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1686:18:1686:18 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1689:10:1689:10 | z | semmle.label | z |
+| array_flow.rb:1690:10:1690:10 | w | semmle.label | w |
 subpaths
 arrayLiteral
 | array_flow.rb:9:9:9:25 | call to [] |
@@ -4564,6 +4595,8 @@ arrayLiteral
 | array_flow.rb:1621:10:1621:12 | call to [] |
 | array_flow.rb:1647:9:1647:32 | ...[...] |
 | array_flow.rb:1668:14:1668:41 | ...[...] |
+| array_flow.rb:1677:9:1677:29 | call to [] |
+| array_flow.rb:1685:9:1685:44 | call to [] |
 #select
 | array_flow.rb:3:10:3:13 | ...[...] | array_flow.rb:2:10:2:20 | call to source | array_flow.rb:3:10:3:13 | ...[...] | $@ | array_flow.rb:2:10:2:20 | call to source | call to source |
 | array_flow.rb:5:10:5:13 | ...[...] | array_flow.rb:2:10:2:20 | call to source | array_flow.rb:5:10:5:13 | ...[...] | $@ | array_flow.rb:2:10:2:20 | call to source | call to source |
@@ -5264,3 +5297,6 @@ arrayLiteral
 | array_flow.rb:1651:10:1651:13 | ...[...] | array_flow.rb:1647:18:1647:28 | call to source | array_flow.rb:1651:10:1651:13 | ...[...] | $@ | array_flow.rb:1647:18:1647:28 | call to source | call to source |
 | array_flow.rb:1670:14:1670:18 | ...[...] | array_flow.rb:1668:25:1668:37 | call to source | array_flow.rb:1670:14:1670:18 | ...[...] | $@ | array_flow.rb:1668:25:1668:37 | call to source | call to source |
 | array_flow.rb:1672:14:1672:18 | ...[...] | array_flow.rb:1668:25:1668:37 | call to source | array_flow.rb:1672:14:1672:18 | ...[...] | $@ | array_flow.rb:1668:25:1668:37 | call to source | call to source |
+| array_flow.rb:1681:10:1681:13 | ...[...] | array_flow.rb:1677:16:1677:28 | call to source | array_flow.rb:1681:10:1681:13 | ...[...] | $@ | array_flow.rb:1677:16:1677:28 | call to source | call to source |
+| array_flow.rb:1689:10:1689:10 | z | array_flow.rb:1685:16:1685:28 | call to source | array_flow.rb:1689:10:1689:10 | z | $@ | array_flow.rb:1685:16:1685:28 | call to source | call to source |
+| array_flow.rb:1690:10:1690:10 | w | array_flow.rb:1685:31:1685:43 | call to source | array_flow.rb:1690:10:1690:10 | w | $@ | array_flow.rb:1685:31:1685:43 | call to source | call to source |

--- a/ruby/ql/test/library-tests/dataflow/array-flow/array_flow.rb
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/array_flow.rb
@@ -1672,3 +1672,20 @@ class M139
         sink(a2[i]) # $ hasValueFlow=139.2
     end
 end
+
+def m139
+    a = [0, 1, source(139.1)]
+    b = a.map do |x|
+        x
+    end
+    sink b[2] # $ hasValueFlow=139.1
+end
+
+def m140
+    a = [0, 1, source(140.1), source(140.2)]
+    x, y, z, w = a
+    sink x
+    sink y
+    sink z # $ hasValueFlow=140.1
+    sink w # $ hasValueFlow=140.2
+end

--- a/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.expected
+++ b/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.expected
@@ -162,8 +162,10 @@ edges
 | semantics.rb:116:5:116:5 | h [element :a] | semantics.rb:117:16:117:16 | h [element :a] | provenance |  |
 | semantics.rb:116:5:116:5 | h [element :a] | semantics.rb:121:22:121:22 | h [element :a] | provenance |  |
 | semantics.rb:116:5:116:5 | h [element :a] | semantics.rb:121:22:121:22 | h [element :a] | provenance |  |
-| semantics.rb:116:14:116:14 | a | semantics.rb:116:5:116:5 | h [element :a] | provenance |  |
-| semantics.rb:116:14:116:14 | a | semantics.rb:116:5:116:5 | h [element :a] | provenance |  |
+| semantics.rb:116:9:116:22 | call to [] [element :a] | semantics.rb:116:5:116:5 | h [element :a] | provenance |  |
+| semantics.rb:116:9:116:22 | call to [] [element :a] | semantics.rb:116:5:116:5 | h [element :a] | provenance |  |
+| semantics.rb:116:14:116:14 | a | semantics.rb:116:9:116:22 | call to [] [element :a] | provenance |  |
+| semantics.rb:116:14:116:14 | a | semantics.rb:116:9:116:22 | call to [] [element :a] | provenance |  |
 | semantics.rb:117:14:117:16 | ** ... [element :a] | semantics.rb:117:10:117:17 | call to s16 | provenance |  |
 | semantics.rb:117:14:117:16 | ** ... [element :a] | semantics.rb:117:10:117:17 | call to s16 | provenance |  |
 | semantics.rb:117:16:117:16 | h [element :a] | semantics.rb:117:14:117:16 | ** ... [element :a] | provenance |  |
@@ -212,10 +214,14 @@ edges
 | semantics.rb:135:5:135:7 | arr [element 0] | semantics.rb:136:15:136:17 | arr [element 0] | provenance |  |
 | semantics.rb:135:5:135:7 | arr [element 1] | semantics.rb:136:15:136:17 | arr [element 1] | provenance |  |
 | semantics.rb:135:5:135:7 | arr [element 1] | semantics.rb:136:15:136:17 | arr [element 1] | provenance |  |
-| semantics.rb:135:12:135:12 | a | semantics.rb:135:5:135:7 | arr [element 0] | provenance |  |
-| semantics.rb:135:12:135:12 | a | semantics.rb:135:5:135:7 | arr [element 0] | provenance |  |
-| semantics.rb:135:15:135:15 | b | semantics.rb:135:5:135:7 | arr [element 1] | provenance |  |
-| semantics.rb:135:15:135:15 | b | semantics.rb:135:5:135:7 | arr [element 1] | provenance |  |
+| semantics.rb:135:11:135:16 | call to [] [element 0] | semantics.rb:135:5:135:7 | arr [element 0] | provenance |  |
+| semantics.rb:135:11:135:16 | call to [] [element 0] | semantics.rb:135:5:135:7 | arr [element 0] | provenance |  |
+| semantics.rb:135:11:135:16 | call to [] [element 1] | semantics.rb:135:5:135:7 | arr [element 1] | provenance |  |
+| semantics.rb:135:11:135:16 | call to [] [element 1] | semantics.rb:135:5:135:7 | arr [element 1] | provenance |  |
+| semantics.rb:135:12:135:12 | a | semantics.rb:135:11:135:16 | call to [] [element 0] | provenance |  |
+| semantics.rb:135:12:135:12 | a | semantics.rb:135:11:135:16 | call to [] [element 0] | provenance |  |
+| semantics.rb:135:15:135:15 | b | semantics.rb:135:11:135:16 | call to [] [element 1] | provenance |  |
+| semantics.rb:135:15:135:15 | b | semantics.rb:135:11:135:16 | call to [] [element 1] | provenance |  |
 | semantics.rb:136:14:136:17 | * ... [element 0] | semantics.rb:136:10:136:18 | call to s18 | provenance |  |
 | semantics.rb:136:14:136:17 | * ... [element 0] | semantics.rb:136:10:136:18 | call to s18 | provenance |  |
 | semantics.rb:136:14:136:17 | * ... [element 1] | semantics.rb:136:10:136:18 | call to s18 | provenance |  |
@@ -1275,6 +1281,8 @@ nodes
 | semantics.rb:115:9:115:18 | call to source | semmle.label | call to source |
 | semantics.rb:116:5:116:5 | h [element :a] | semmle.label | h [element :a] |
 | semantics.rb:116:5:116:5 | h [element :a] | semmle.label | h [element :a] |
+| semantics.rb:116:9:116:22 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| semantics.rb:116:9:116:22 | call to [] [element :a] | semmle.label | call to [] [element :a] |
 | semantics.rb:116:14:116:14 | a | semmle.label | a |
 | semantics.rb:116:14:116:14 | a | semmle.label | a |
 | semantics.rb:117:10:117:17 | call to s16 | semmle.label | call to s16 |
@@ -1332,6 +1340,10 @@ nodes
 | semantics.rb:135:5:135:7 | arr [element 0] | semmle.label | arr [element 0] |
 | semantics.rb:135:5:135:7 | arr [element 1] | semmle.label | arr [element 1] |
 | semantics.rb:135:5:135:7 | arr [element 1] | semmle.label | arr [element 1] |
+| semantics.rb:135:11:135:16 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| semantics.rb:135:11:135:16 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| semantics.rb:135:11:135:16 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| semantics.rb:135:11:135:16 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | semantics.rb:135:12:135:12 | a | semmle.label | a |
 | semantics.rb:135:12:135:12 | a | semmle.label | a |
 | semantics.rb:135:15:135:15 | b | semmle.label | b |

--- a/ruby/ql/test/library-tests/dataflow/hash-flow/hash-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/hash-flow/hash-flow.expected
@@ -5,11 +5,16 @@ edges
 | hash_flow.rb:10:5:10:8 | hash [element :c] | hash_flow.rb:24:10:24:13 | hash [element :c] | provenance |  |
 | hash_flow.rb:10:5:10:8 | hash [element e] | hash_flow.rb:26:10:26:13 | hash [element e] | provenance |  |
 | hash_flow.rb:10:5:10:8 | hash [element g] | hash_flow.rb:28:10:28:13 | hash [element g] | provenance |  |
-| hash_flow.rb:11:15:11:24 | call to taint | hash_flow.rb:10:5:10:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:13:12:13:21 | call to taint | hash_flow.rb:10:5:10:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:15:14:15:23 | call to taint | hash_flow.rb:10:5:10:8 | hash [element e] | provenance |  |
-| hash_flow.rb:17:16:17:25 | call to taint | hash_flow.rb:10:5:10:8 | hash [element g] | provenance |  |
-| hash_flow.rb:19:14:19:23 | call to taint | hash_flow.rb:10:5:10:8 | hash [element 0] | provenance |  |
+| hash_flow.rb:10:12:21:5 | call to [] [element 0] | hash_flow.rb:10:5:10:8 | hash [element 0] | provenance |  |
+| hash_flow.rb:10:12:21:5 | call to [] [element :a] | hash_flow.rb:10:5:10:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:10:12:21:5 | call to [] [element :c] | hash_flow.rb:10:5:10:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:10:12:21:5 | call to [] [element e] | hash_flow.rb:10:5:10:8 | hash [element e] | provenance |  |
+| hash_flow.rb:10:12:21:5 | call to [] [element g] | hash_flow.rb:10:5:10:8 | hash [element g] | provenance |  |
+| hash_flow.rb:11:15:11:24 | call to taint | hash_flow.rb:10:12:21:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:13:12:13:21 | call to taint | hash_flow.rb:10:12:21:5 | call to [] [element :c] | provenance |  |
+| hash_flow.rb:15:14:15:23 | call to taint | hash_flow.rb:10:12:21:5 | call to [] [element e] | provenance |  |
+| hash_flow.rb:17:16:17:25 | call to taint | hash_flow.rb:10:12:21:5 | call to [] [element g] | provenance |  |
+| hash_flow.rb:19:14:19:23 | call to taint | hash_flow.rb:10:12:21:5 | call to [] [element 0] | provenance |  |
 | hash_flow.rb:22:10:22:13 | hash [element :a] | hash_flow.rb:22:10:22:17 | ...[...] | provenance |  |
 | hash_flow.rb:24:10:24:13 | hash [element :c] | hash_flow.rb:24:10:24:17 | ...[...] | provenance |  |
 | hash_flow.rb:26:10:26:13 | hash [element e] | hash_flow.rb:26:10:26:18 | ...[...] | provenance |  |
@@ -47,7 +52,8 @@ edges
 | hash_flow.rb:55:21:55:30 | call to taint | hash_flow.rb:55:13:55:37 | ...[...] [element :a] | provenance |  |
 | hash_flow.rb:56:10:56:14 | hash1 [element :a] | hash_flow.rb:56:10:56:18 | ...[...] | provenance |  |
 | hash_flow.rb:59:5:59:5 | x [element :a] | hash_flow.rb:60:18:60:18 | x [element :a] | provenance |  |
-| hash_flow.rb:59:13:59:22 | call to taint | hash_flow.rb:59:5:59:5 | x [element :a] | provenance |  |
+| hash_flow.rb:59:9:59:29 | call to [] [element :a] | hash_flow.rb:59:5:59:5 | x [element :a] | provenance |  |
+| hash_flow.rb:59:13:59:22 | call to taint | hash_flow.rb:59:9:59:29 | call to [] [element :a] | provenance |  |
 | hash_flow.rb:60:5:60:9 | hash2 [element :a] | hash_flow.rb:61:10:61:14 | hash2 [element :a] | provenance |  |
 | hash_flow.rb:60:13:60:19 | ...[...] [element :a] | hash_flow.rb:60:5:60:9 | hash2 [element :a] | provenance |  |
 | hash_flow.rb:60:18:60:18 | x [element :a] | hash_flow.rb:60:13:60:19 | ...[...] [element :a] | provenance |  |
@@ -55,7 +61,9 @@ edges
 | hash_flow.rb:64:5:64:9 | hash3 [element] | hash_flow.rb:65:10:65:14 | hash3 [element] | provenance |  |
 | hash_flow.rb:64:5:64:9 | hash3 [element] | hash_flow.rb:66:10:66:14 | hash3 [element] | provenance |  |
 | hash_flow.rb:64:13:64:45 | ...[...] [element] | hash_flow.rb:64:5:64:9 | hash3 [element] | provenance |  |
-| hash_flow.rb:64:24:64:33 | call to taint | hash_flow.rb:64:13:64:45 | ...[...] [element] | provenance |  |
+| hash_flow.rb:64:18:64:44 | call to [] [element 0, element 1] | hash_flow.rb:64:13:64:45 | ...[...] [element] | provenance |  |
+| hash_flow.rb:64:19:64:34 | call to [] [element 1] | hash_flow.rb:64:18:64:44 | call to [] [element 0, element 1] | provenance |  |
+| hash_flow.rb:64:24:64:33 | call to taint | hash_flow.rb:64:19:64:34 | call to [] [element 1] | provenance |  |
 | hash_flow.rb:65:10:65:14 | hash3 [element] | hash_flow.rb:65:10:65:18 | ...[...] | provenance |  |
 | hash_flow.rb:66:10:66:14 | hash3 [element] | hash_flow.rb:66:10:66:18 | ...[...] | provenance |  |
 | hash_flow.rb:68:5:68:9 | hash4 [element :a] | hash_flow.rb:69:10:69:14 | hash4 [element :a] | provenance |  |
@@ -68,14 +76,16 @@ edges
 | hash_flow.rb:73:10:73:14 | hash5 [element a] | hash_flow.rb:73:10:73:19 | ...[...] | provenance |  |
 | hash_flow.rb:76:5:76:9 | hash6 [element a] | hash_flow.rb:77:10:77:14 | hash6 [element a] | provenance |  |
 | hash_flow.rb:76:13:76:47 | ...[...] [element a] | hash_flow.rb:76:5:76:9 | hash6 [element a] | provenance |  |
-| hash_flow.rb:76:26:76:35 | call to taint | hash_flow.rb:76:13:76:47 | ...[...] [element a] | provenance |  |
+| hash_flow.rb:76:18:76:46 | call to [] [element a] | hash_flow.rb:76:13:76:47 | ...[...] [element a] | provenance |  |
+| hash_flow.rb:76:26:76:35 | call to taint | hash_flow.rb:76:18:76:46 | call to [] [element a] | provenance |  |
 | hash_flow.rb:77:10:77:14 | hash6 [element a] | hash_flow.rb:77:10:77:19 | ...[...] | provenance |  |
 | hash_flow.rb:84:5:84:9 | hash1 [element :a] | hash_flow.rb:85:10:85:14 | hash1 [element :a] | provenance |  |
 | hash_flow.rb:84:13:84:42 | call to [] [element :a] | hash_flow.rb:84:5:84:9 | hash1 [element :a] | provenance |  |
 | hash_flow.rb:84:26:84:35 | call to taint | hash_flow.rb:84:13:84:42 | call to [] [element :a] | provenance |  |
 | hash_flow.rb:85:10:85:14 | hash1 [element :a] | hash_flow.rb:85:10:85:18 | ...[...] | provenance |  |
 | hash_flow.rb:92:5:92:8 | hash [element :a] | hash_flow.rb:96:30:96:33 | hash [element :a] | provenance |  |
-| hash_flow.rb:93:15:93:24 | call to taint | hash_flow.rb:92:5:92:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:92:12:95:5 | call to [] [element :a] | hash_flow.rb:92:5:92:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:93:15:93:24 | call to taint | hash_flow.rb:92:12:95:5 | call to [] [element :a] | provenance |  |
 | hash_flow.rb:96:5:96:9 | hash2 [element :a] | hash_flow.rb:97:10:97:14 | hash2 [element :a] | provenance |  |
 | hash_flow.rb:96:13:96:34 | call to try_convert [element :a] | hash_flow.rb:96:5:96:9 | hash2 [element :a] | provenance |  |
 | hash_flow.rb:96:30:96:33 | hash [element :a] | hash_flow.rb:96:13:96:34 | call to try_convert [element :a] | provenance |  |
@@ -98,14 +108,16 @@ edges
 | hash_flow.rb:120:10:120:13 | hash [element] | hash_flow.rb:120:10:120:17 | ...[...] | provenance |  |
 | hash_flow.rb:127:5:127:8 | hash [element :a] | hash_flow.rb:131:5:131:8 | hash [element :a] | provenance |  |
 | hash_flow.rb:127:5:127:8 | hash [element :a] | hash_flow.rb:134:5:134:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:128:15:128:24 | call to taint | hash_flow.rb:127:5:127:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:127:12:130:5 | call to [] [element :a] | hash_flow.rb:127:5:127:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:128:15:128:24 | call to taint | hash_flow.rb:127:12:130:5 | call to [] [element :a] | provenance |  |
 | hash_flow.rb:131:5:131:8 | hash [element :a] | hash_flow.rb:131:18:131:29 | key_or_value | provenance |  |
 | hash_flow.rb:131:18:131:29 | key_or_value | hash_flow.rb:132:14:132:25 | key_or_value | provenance |  |
 | hash_flow.rb:134:5:134:8 | hash [element :a] | hash_flow.rb:134:22:134:26 | value | provenance |  |
 | hash_flow.rb:134:22:134:26 | value | hash_flow.rb:136:14:136:18 | value | provenance |  |
 | hash_flow.rb:143:5:143:8 | hash [element :a] | hash_flow.rb:147:9:147:12 | hash [element :a] | provenance |  |
 | hash_flow.rb:143:5:143:8 | hash [element :a] | hash_flow.rb:151:9:151:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:144:15:144:25 | call to taint | hash_flow.rb:143:5:143:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:143:12:146:5 | call to [] [element :a] | hash_flow.rb:143:5:143:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:144:15:144:25 | call to taint | hash_flow.rb:143:12:146:5 | call to [] [element :a] | provenance |  |
 | hash_flow.rb:147:5:147:5 | b [element 1] | hash_flow.rb:149:10:149:10 | b [element 1] | provenance |  |
 | hash_flow.rb:147:5:147:5 | b [element 1] | hash_flow.rb:150:10:150:10 | b [element 1] | provenance |  |
 | hash_flow.rb:147:9:147:12 | hash [element :a] | hash_flow.rb:147:9:147:22 | call to assoc [element 1] | provenance |  |
@@ -117,18 +129,21 @@ edges
 | hash_flow.rb:151:9:151:21 | call to assoc [element 1] | hash_flow.rb:151:5:151:5 | c [element 1] | provenance |  |
 | hash_flow.rb:152:10:152:10 | c [element 1] | hash_flow.rb:152:10:152:13 | ...[...] | provenance |  |
 | hash_flow.rb:169:5:169:8 | hash [element :a] | hash_flow.rb:173:9:173:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:170:15:170:25 | call to taint | hash_flow.rb:169:5:169:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:169:12:172:5 | call to [] [element :a] | hash_flow.rb:169:5:169:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:170:15:170:25 | call to taint | hash_flow.rb:169:12:172:5 | call to [] [element :a] | provenance |  |
 | hash_flow.rb:173:5:173:5 | a [element :a] | hash_flow.rb:174:10:174:10 | a [element :a] | provenance |  |
 | hash_flow.rb:173:9:173:12 | hash [element :a] | hash_flow.rb:173:9:173:20 | call to compact [element :a] | provenance |  |
 | hash_flow.rb:173:9:173:20 | call to compact [element :a] | hash_flow.rb:173:5:173:5 | a [element :a] | provenance |  |
 | hash_flow.rb:174:10:174:10 | a [element :a] | hash_flow.rb:174:10:174:14 | ...[...] | provenance |  |
 | hash_flow.rb:181:5:181:8 | hash [element :a] | hash_flow.rb:185:9:185:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:182:15:182:25 | call to taint | hash_flow.rb:181:5:181:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:181:12:184:5 | call to [] [element :a] | hash_flow.rb:181:5:181:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:182:15:182:25 | call to taint | hash_flow.rb:181:12:184:5 | call to [] [element :a] | provenance |  |
 | hash_flow.rb:185:5:185:5 | a | hash_flow.rb:186:10:186:10 | a | provenance |  |
 | hash_flow.rb:185:9:185:12 | hash [element :a] | hash_flow.rb:185:9:185:23 | call to delete | provenance |  |
 | hash_flow.rb:185:9:185:23 | call to delete | hash_flow.rb:185:5:185:5 | a | provenance |  |
 | hash_flow.rb:193:5:193:8 | hash [element :a] | hash_flow.rb:197:9:197:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:194:15:194:25 | call to taint | hash_flow.rb:193:5:193:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:193:12:196:5 | call to [] [element :a] | hash_flow.rb:193:5:193:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:194:15:194:25 | call to taint | hash_flow.rb:193:12:196:5 | call to [] [element :a] | provenance |  |
 | hash_flow.rb:197:5:197:5 | a [element :a] | hash_flow.rb:201:10:201:10 | a [element :a] | provenance |  |
 | hash_flow.rb:197:9:197:12 | [post] hash [element :a] | hash_flow.rb:202:10:202:13 | hash [element :a] | provenance |  |
 | hash_flow.rb:197:9:197:12 | hash [element :a] | hash_flow.rb:197:9:197:12 | [post] hash [element :a] | provenance |  |
@@ -140,12 +155,16 @@ edges
 | hash_flow.rb:202:10:202:13 | hash [element :a] | hash_flow.rb:202:10:202:17 | ...[...] | provenance |  |
 | hash_flow.rb:209:5:209:8 | hash [element :a] | hash_flow.rb:217:10:217:13 | hash [element :a] | provenance |  |
 | hash_flow.rb:209:5:209:8 | hash [element :c, element :d] | hash_flow.rb:219:10:219:13 | hash [element :c, element :d] | provenance |  |
-| hash_flow.rb:210:15:210:25 | call to taint | hash_flow.rb:209:5:209:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:213:19:213:29 | call to taint | hash_flow.rb:209:5:209:8 | hash [element :c, element :d] | provenance |  |
+| hash_flow.rb:209:12:216:5 | call to [] [element :a] | hash_flow.rb:209:5:209:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:209:12:216:5 | call to [] [element :c, element :d] | hash_flow.rb:209:5:209:8 | hash [element :c, element :d] | provenance |  |
+| hash_flow.rb:210:15:210:25 | call to taint | hash_flow.rb:209:12:216:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:212:15:215:9 | call to [] [element :d] | hash_flow.rb:209:12:216:5 | call to [] [element :c, element :d] | provenance |  |
+| hash_flow.rb:213:19:213:29 | call to taint | hash_flow.rb:212:15:215:9 | call to [] [element :d] | provenance |  |
 | hash_flow.rb:217:10:217:13 | hash [element :a] | hash_flow.rb:217:10:217:21 | call to dig | provenance |  |
 | hash_flow.rb:219:10:219:13 | hash [element :c, element :d] | hash_flow.rb:219:10:219:24 | call to dig | provenance |  |
 | hash_flow.rb:226:5:226:8 | hash [element :a] | hash_flow.rb:230:9:230:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:227:15:227:25 | call to taint | hash_flow.rb:226:5:226:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:226:12:229:5 | call to [] [element :a] | hash_flow.rb:226:5:226:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:227:15:227:25 | call to taint | hash_flow.rb:226:12:229:5 | call to [] [element :a] | provenance |  |
 | hash_flow.rb:230:5:230:5 | x [element :a] | hash_flow.rb:234:10:234:10 | x [element :a] | provenance |  |
 | hash_flow.rb:230:9:230:12 | hash [element :a] | hash_flow.rb:230:9:233:7 | call to each [element :a] | provenance |  |
 | hash_flow.rb:230:9:230:12 | hash [element :a] | hash_flow.rb:230:28:230:32 | value | provenance |  |
@@ -153,13 +172,15 @@ edges
 | hash_flow.rb:230:28:230:32 | value | hash_flow.rb:232:14:232:18 | value | provenance |  |
 | hash_flow.rb:234:10:234:10 | x [element :a] | hash_flow.rb:234:10:234:14 | ...[...] | provenance |  |
 | hash_flow.rb:241:5:241:8 | hash [element :a] | hash_flow.rb:245:9:245:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:242:15:242:25 | call to taint | hash_flow.rb:241:5:241:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:241:12:244:5 | call to [] [element :a] | hash_flow.rb:241:5:241:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:242:15:242:25 | call to taint | hash_flow.rb:241:12:244:5 | call to [] [element :a] | provenance |  |
 | hash_flow.rb:245:5:245:5 | x [element :a] | hash_flow.rb:248:10:248:10 | x [element :a] | provenance |  |
 | hash_flow.rb:245:9:245:12 | hash [element :a] | hash_flow.rb:245:9:247:7 | call to each_key [element :a] | provenance |  |
 | hash_flow.rb:245:9:247:7 | call to each_key [element :a] | hash_flow.rb:245:5:245:5 | x [element :a] | provenance |  |
 | hash_flow.rb:248:10:248:10 | x [element :a] | hash_flow.rb:248:10:248:14 | ...[...] | provenance |  |
 | hash_flow.rb:255:5:255:8 | hash [element :a] | hash_flow.rb:259:9:259:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:256:15:256:25 | call to taint | hash_flow.rb:255:5:255:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:255:12:258:5 | call to [] [element :a] | hash_flow.rb:255:5:255:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:256:15:256:25 | call to taint | hash_flow.rb:255:12:258:5 | call to [] [element :a] | provenance |  |
 | hash_flow.rb:259:5:259:5 | x [element :a] | hash_flow.rb:263:10:263:10 | x [element :a] | provenance |  |
 | hash_flow.rb:259:9:259:12 | hash [element :a] | hash_flow.rb:259:9:262:7 | call to each_pair [element :a] | provenance |  |
 | hash_flow.rb:259:9:259:12 | hash [element :a] | hash_flow.rb:259:33:259:37 | value | provenance |  |
@@ -167,7 +188,8 @@ edges
 | hash_flow.rb:259:33:259:37 | value | hash_flow.rb:261:14:261:18 | value | provenance |  |
 | hash_flow.rb:263:10:263:10 | x [element :a] | hash_flow.rb:263:10:263:14 | ...[...] | provenance |  |
 | hash_flow.rb:270:5:270:8 | hash [element :a] | hash_flow.rb:274:9:274:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:271:15:271:25 | call to taint | hash_flow.rb:270:5:270:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:270:12:273:5 | call to [] [element :a] | hash_flow.rb:270:5:270:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:271:15:271:25 | call to taint | hash_flow.rb:270:12:273:5 | call to [] [element :a] | provenance |  |
 | hash_flow.rb:274:5:274:5 | x [element :a] | hash_flow.rb:277:10:277:10 | x [element :a] | provenance |  |
 | hash_flow.rb:274:9:274:12 | hash [element :a] | hash_flow.rb:274:9:276:7 | call to each_value [element :a] | provenance |  |
 | hash_flow.rb:274:9:274:12 | hash [element :a] | hash_flow.rb:274:29:274:33 | value | provenance |  |
@@ -175,7 +197,8 @@ edges
 | hash_flow.rb:274:29:274:33 | value | hash_flow.rb:275:14:275:18 | value | provenance |  |
 | hash_flow.rb:277:10:277:10 | x [element :a] | hash_flow.rb:277:10:277:14 | ...[...] | provenance |  |
 | hash_flow.rb:284:5:284:8 | hash [element :c] | hash_flow.rb:290:9:290:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:287:15:287:25 | call to taint | hash_flow.rb:284:5:284:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:284:12:289:5 | call to [] [element :c] | hash_flow.rb:284:5:284:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:287:15:287:25 | call to taint | hash_flow.rb:284:12:289:5 | call to [] [element :c] | provenance |  |
 | hash_flow.rb:290:5:290:5 | x [element :c] | hash_flow.rb:293:10:293:10 | x [element :c] | provenance |  |
 | hash_flow.rb:290:9:290:12 | hash [element :c] | hash_flow.rb:290:9:290:28 | call to except [element :c] | provenance |  |
 | hash_flow.rb:290:9:290:28 | call to except [element :c] | hash_flow.rb:290:5:290:5 | x [element :c] | provenance |  |
@@ -186,8 +209,10 @@ edges
 | hash_flow.rb:300:5:300:8 | hash [element :a] | hash_flow.rb:315:9:315:12 | hash [element :a] | provenance |  |
 | hash_flow.rb:300:5:300:8 | hash [element :c] | hash_flow.rb:305:9:305:12 | hash [element :c] | provenance |  |
 | hash_flow.rb:300:5:300:8 | hash [element :c] | hash_flow.rb:315:9:315:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:301:15:301:25 | call to taint | hash_flow.rb:300:5:300:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:303:15:303:25 | call to taint | hash_flow.rb:300:5:300:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:300:12:304:5 | call to [] [element :a] | hash_flow.rb:300:5:300:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:300:12:304:5 | call to [] [element :c] | hash_flow.rb:300:5:300:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:301:15:301:25 | call to taint | hash_flow.rb:300:12:304:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:303:15:303:25 | call to taint | hash_flow.rb:300:12:304:5 | call to [] [element :c] | provenance |  |
 | hash_flow.rb:305:5:305:5 | b | hash_flow.rb:308:10:308:10 | b | provenance |  |
 | hash_flow.rb:305:9:305:12 | hash [element :a] | hash_flow.rb:305:9:307:7 | call to fetch | provenance |  |
 | hash_flow.rb:305:9:305:12 | hash [element :c] | hash_flow.rb:305:9:307:7 | call to fetch | provenance |  |
@@ -214,8 +239,10 @@ edges
 | hash_flow.rb:322:5:322:8 | hash [element :a] | hash_flow.rb:334:9:334:12 | hash [element :a] | provenance |  |
 | hash_flow.rb:322:5:322:8 | hash [element :c] | hash_flow.rb:327:9:327:12 | hash [element :c] | provenance |  |
 | hash_flow.rb:322:5:322:8 | hash [element :c] | hash_flow.rb:334:9:334:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:323:15:323:25 | call to taint | hash_flow.rb:322:5:322:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:325:15:325:25 | call to taint | hash_flow.rb:322:5:322:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:322:12:326:5 | call to [] [element :a] | hash_flow.rb:322:5:322:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:322:12:326:5 | call to [] [element :c] | hash_flow.rb:322:5:322:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:323:15:323:25 | call to taint | hash_flow.rb:322:12:326:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:325:15:325:25 | call to taint | hash_flow.rb:322:12:326:5 | call to [] [element :c] | provenance |  |
 | hash_flow.rb:327:5:327:5 | b [element] | hash_flow.rb:331:10:331:10 | b [element] | provenance |  |
 | hash_flow.rb:327:9:327:12 | hash [element :a] | hash_flow.rb:327:9:330:7 | call to fetch_values [element] | provenance |  |
 | hash_flow.rb:327:9:327:12 | hash [element :c] | hash_flow.rb:327:9:330:7 | call to fetch_values [element] | provenance |  |
@@ -235,8 +262,10 @@ edges
 | hash_flow.rb:335:10:335:10 | b [element] | hash_flow.rb:335:10:335:13 | ...[...] | provenance |  |
 | hash_flow.rb:341:5:341:8 | hash [element :a] | hash_flow.rb:346:9:346:12 | hash [element :a] | provenance |  |
 | hash_flow.rb:341:5:341:8 | hash [element :c] | hash_flow.rb:346:9:346:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:342:15:342:25 | call to taint | hash_flow.rb:341:5:341:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:344:15:344:25 | call to taint | hash_flow.rb:341:5:341:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:341:12:345:5 | call to [] [element :a] | hash_flow.rb:341:5:341:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:341:12:345:5 | call to [] [element :c] | hash_flow.rb:341:5:341:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:342:15:342:25 | call to taint | hash_flow.rb:341:12:345:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:344:15:344:25 | call to taint | hash_flow.rb:341:12:345:5 | call to [] [element :c] | provenance |  |
 | hash_flow.rb:346:5:346:5 | b [element :a] | hash_flow.rb:351:11:351:11 | b [element :a] | provenance |  |
 | hash_flow.rb:346:9:346:12 | hash [element :a] | hash_flow.rb:346:9:350:7 | call to filter [element :a] | provenance |  |
 | hash_flow.rb:346:9:346:12 | hash [element :a] | hash_flow.rb:346:30:346:34 | value | provenance |  |
@@ -247,8 +276,10 @@ edges
 | hash_flow.rb:351:11:351:15 | ...[...] | hash_flow.rb:351:10:351:16 | ( ... ) | provenance |  |
 | hash_flow.rb:357:5:357:8 | hash [element :a] | hash_flow.rb:362:5:362:8 | hash [element :a] | provenance |  |
 | hash_flow.rb:357:5:357:8 | hash [element :c] | hash_flow.rb:362:5:362:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:358:15:358:25 | call to taint | hash_flow.rb:357:5:357:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:360:15:360:25 | call to taint | hash_flow.rb:357:5:357:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:357:12:361:5 | call to [] [element :a] | hash_flow.rb:357:5:357:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:357:12:361:5 | call to [] [element :c] | hash_flow.rb:357:5:357:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:358:15:358:25 | call to taint | hash_flow.rb:357:12:361:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:360:15:360:25 | call to taint | hash_flow.rb:357:12:361:5 | call to [] [element :c] | provenance |  |
 | hash_flow.rb:362:5:362:8 | [post] hash [element :a] | hash_flow.rb:367:11:367:14 | hash [element :a] | provenance |  |
 | hash_flow.rb:362:5:362:8 | hash [element :a] | hash_flow.rb:362:5:362:8 | [post] hash [element :a] | provenance |  |
 | hash_flow.rb:362:5:362:8 | hash [element :a] | hash_flow.rb:362:27:362:31 | value | provenance |  |
@@ -258,8 +289,10 @@ edges
 | hash_flow.rb:367:11:367:18 | ...[...] | hash_flow.rb:367:10:367:19 | ( ... ) | provenance |  |
 | hash_flow.rb:373:5:373:8 | hash [element :a] | hash_flow.rb:378:9:378:12 | hash [element :a] | provenance |  |
 | hash_flow.rb:373:5:373:8 | hash [element :c] | hash_flow.rb:378:9:378:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:374:15:374:25 | call to taint | hash_flow.rb:373:5:373:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:376:15:376:25 | call to taint | hash_flow.rb:373:5:373:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:373:12:377:5 | call to [] [element :a] | hash_flow.rb:373:5:373:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:373:12:377:5 | call to [] [element :c] | hash_flow.rb:373:5:373:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:374:15:374:25 | call to taint | hash_flow.rb:373:12:377:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:376:15:376:25 | call to taint | hash_flow.rb:373:12:377:5 | call to [] [element :c] | provenance |  |
 | hash_flow.rb:378:5:378:5 | b [element] | hash_flow.rb:379:11:379:11 | b [element] | provenance |  |
 | hash_flow.rb:378:9:378:12 | hash [element :a] | hash_flow.rb:378:9:378:20 | call to flatten [element] | provenance |  |
 | hash_flow.rb:378:9:378:12 | hash [element :c] | hash_flow.rb:378:9:378:20 | call to flatten [element] | provenance |  |
@@ -268,8 +301,10 @@ edges
 | hash_flow.rb:379:11:379:14 | ...[...] | hash_flow.rb:379:10:379:15 | ( ... ) | provenance |  |
 | hash_flow.rb:385:5:385:8 | hash [element :a] | hash_flow.rb:390:9:390:12 | hash [element :a] | provenance |  |
 | hash_flow.rb:385:5:385:8 | hash [element :c] | hash_flow.rb:390:9:390:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:386:15:386:25 | call to taint | hash_flow.rb:385:5:385:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:388:15:388:25 | call to taint | hash_flow.rb:385:5:385:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:385:12:389:5 | call to [] [element :a] | hash_flow.rb:385:5:385:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:385:12:389:5 | call to [] [element :c] | hash_flow.rb:385:5:385:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:386:15:386:25 | call to taint | hash_flow.rb:385:12:389:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:388:15:388:25 | call to taint | hash_flow.rb:385:12:389:5 | call to [] [element :c] | provenance |  |
 | hash_flow.rb:390:5:390:5 | b [element :a] | hash_flow.rb:396:11:396:11 | b [element :a] | provenance |  |
 | hash_flow.rb:390:9:390:12 | [post] hash [element :a] | hash_flow.rb:395:11:395:14 | hash [element :a] | provenance |  |
 | hash_flow.rb:390:9:390:12 | hash [element :a] | hash_flow.rb:390:9:390:12 | [post] hash [element :a] | provenance |  |
@@ -284,12 +319,16 @@ edges
 | hash_flow.rb:396:11:396:15 | ...[...] | hash_flow.rb:396:10:396:16 | ( ... ) | provenance |  |
 | hash_flow.rb:402:5:402:9 | hash1 [element :a] | hash_flow.rb:412:12:412:16 | hash1 [element :a] | provenance |  |
 | hash_flow.rb:402:5:402:9 | hash1 [element :c] | hash_flow.rb:412:12:412:16 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:403:15:403:25 | call to taint | hash_flow.rb:402:5:402:9 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:405:15:405:25 | call to taint | hash_flow.rb:402:5:402:9 | hash1 [element :c] | provenance |  |
+| hash_flow.rb:402:13:406:5 | call to [] [element :a] | hash_flow.rb:402:5:402:9 | hash1 [element :a] | provenance |  |
+| hash_flow.rb:402:13:406:5 | call to [] [element :c] | hash_flow.rb:402:5:402:9 | hash1 [element :c] | provenance |  |
+| hash_flow.rb:403:15:403:25 | call to taint | hash_flow.rb:402:13:406:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:405:15:405:25 | call to taint | hash_flow.rb:402:13:406:5 | call to [] [element :c] | provenance |  |
 | hash_flow.rb:407:5:407:9 | hash2 [element :d] | hash_flow.rb:412:24:412:28 | hash2 [element :d] | provenance |  |
 | hash_flow.rb:407:5:407:9 | hash2 [element :f] | hash_flow.rb:412:24:412:28 | hash2 [element :f] | provenance |  |
-| hash_flow.rb:408:15:408:25 | call to taint | hash_flow.rb:407:5:407:9 | hash2 [element :d] | provenance |  |
-| hash_flow.rb:410:15:410:25 | call to taint | hash_flow.rb:407:5:407:9 | hash2 [element :f] | provenance |  |
+| hash_flow.rb:407:13:411:5 | call to [] [element :d] | hash_flow.rb:407:5:407:9 | hash2 [element :d] | provenance |  |
+| hash_flow.rb:407:13:411:5 | call to [] [element :f] | hash_flow.rb:407:5:407:9 | hash2 [element :f] | provenance |  |
+| hash_flow.rb:408:15:408:25 | call to taint | hash_flow.rb:407:13:411:5 | call to [] [element :d] | provenance |  |
+| hash_flow.rb:410:15:410:25 | call to taint | hash_flow.rb:407:13:411:5 | call to [] [element :f] | provenance |  |
 | hash_flow.rb:412:5:412:8 | hash [element :a] | hash_flow.rb:417:11:417:14 | hash [element :a] | provenance |  |
 | hash_flow.rb:412:5:412:8 | hash [element :c] | hash_flow.rb:419:11:419:14 | hash [element :c] | provenance |  |
 | hash_flow.rb:412:5:412:8 | hash [element :d] | hash_flow.rb:420:11:420:14 | hash [element :d] | provenance |  |
@@ -322,12 +361,16 @@ edges
 | hash_flow.rb:422:11:422:18 | ...[...] | hash_flow.rb:422:10:422:19 | ( ... ) | provenance |  |
 | hash_flow.rb:428:5:428:9 | hash1 [element :a] | hash_flow.rb:438:12:438:16 | hash1 [element :a] | provenance |  |
 | hash_flow.rb:428:5:428:9 | hash1 [element :c] | hash_flow.rb:438:12:438:16 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:429:15:429:25 | call to taint | hash_flow.rb:428:5:428:9 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:431:15:431:25 | call to taint | hash_flow.rb:428:5:428:9 | hash1 [element :c] | provenance |  |
+| hash_flow.rb:428:13:432:5 | call to [] [element :a] | hash_flow.rb:428:5:428:9 | hash1 [element :a] | provenance |  |
+| hash_flow.rb:428:13:432:5 | call to [] [element :c] | hash_flow.rb:428:5:428:9 | hash1 [element :c] | provenance |  |
+| hash_flow.rb:429:15:429:25 | call to taint | hash_flow.rb:428:13:432:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:431:15:431:25 | call to taint | hash_flow.rb:428:13:432:5 | call to [] [element :c] | provenance |  |
 | hash_flow.rb:433:5:433:9 | hash2 [element :d] | hash_flow.rb:438:25:438:29 | hash2 [element :d] | provenance |  |
 | hash_flow.rb:433:5:433:9 | hash2 [element :f] | hash_flow.rb:438:25:438:29 | hash2 [element :f] | provenance |  |
-| hash_flow.rb:434:15:434:25 | call to taint | hash_flow.rb:433:5:433:9 | hash2 [element :d] | provenance |  |
-| hash_flow.rb:436:15:436:25 | call to taint | hash_flow.rb:433:5:433:9 | hash2 [element :f] | provenance |  |
+| hash_flow.rb:433:13:437:5 | call to [] [element :d] | hash_flow.rb:433:5:433:9 | hash2 [element :d] | provenance |  |
+| hash_flow.rb:433:13:437:5 | call to [] [element :f] | hash_flow.rb:433:5:433:9 | hash2 [element :f] | provenance |  |
+| hash_flow.rb:434:15:434:25 | call to taint | hash_flow.rb:433:13:437:5 | call to [] [element :d] | provenance |  |
+| hash_flow.rb:436:15:436:25 | call to taint | hash_flow.rb:433:13:437:5 | call to [] [element :f] | provenance |  |
 | hash_flow.rb:438:5:438:8 | hash [element :a] | hash_flow.rb:443:11:443:14 | hash [element :a] | provenance |  |
 | hash_flow.rb:438:5:438:8 | hash [element :c] | hash_flow.rb:445:11:445:14 | hash [element :c] | provenance |  |
 | hash_flow.rb:438:5:438:8 | hash [element :d] | hash_flow.rb:446:11:446:14 | hash [element :d] | provenance |  |
@@ -375,13 +418,15 @@ edges
 | hash_flow.rb:455:11:455:15 | hash1 [element :f] | hash_flow.rb:455:11:455:19 | ...[...] | provenance |  |
 | hash_flow.rb:455:11:455:19 | ...[...] | hash_flow.rb:455:10:455:20 | ( ... ) | provenance |  |
 | hash_flow.rb:461:5:461:8 | hash [element :a] | hash_flow.rb:465:9:465:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:462:15:462:25 | call to taint | hash_flow.rb:461:5:461:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:461:12:464:5 | call to [] [element :a] | hash_flow.rb:461:5:461:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:462:15:462:25 | call to taint | hash_flow.rb:461:12:464:5 | call to [] [element :a] | provenance |  |
 | hash_flow.rb:465:5:465:5 | b [element 1] | hash_flow.rb:467:10:467:10 | b [element 1] | provenance |  |
 | hash_flow.rb:465:9:465:12 | hash [element :a] | hash_flow.rb:465:9:465:22 | call to rassoc [element 1] | provenance |  |
 | hash_flow.rb:465:9:465:22 | call to rassoc [element 1] | hash_flow.rb:465:5:465:5 | b [element 1] | provenance |  |
 | hash_flow.rb:467:10:467:10 | b [element 1] | hash_flow.rb:467:10:467:13 | ...[...] | provenance |  |
 | hash_flow.rb:473:5:473:8 | hash [element :a] | hash_flow.rb:477:9:477:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:474:15:474:25 | call to taint | hash_flow.rb:473:5:473:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:473:12:476:5 | call to [] [element :a] | hash_flow.rb:473:5:473:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:474:15:474:25 | call to taint | hash_flow.rb:473:12:476:5 | call to [] [element :a] | provenance |  |
 | hash_flow.rb:477:5:477:5 | b [element :a] | hash_flow.rb:482:10:482:10 | b [element :a] | provenance |  |
 | hash_flow.rb:477:9:477:12 | hash [element :a] | hash_flow.rb:477:9:481:7 | call to reject [element :a] | provenance |  |
 | hash_flow.rb:477:9:477:12 | hash [element :a] | hash_flow.rb:477:29:477:33 | value | provenance |  |
@@ -389,7 +434,8 @@ edges
 | hash_flow.rb:477:29:477:33 | value | hash_flow.rb:479:14:479:18 | value | provenance |  |
 | hash_flow.rb:482:10:482:10 | b [element :a] | hash_flow.rb:482:10:482:14 | ...[...] | provenance |  |
 | hash_flow.rb:488:5:488:8 | hash [element :a] | hash_flow.rb:492:9:492:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:489:15:489:25 | call to taint | hash_flow.rb:488:5:488:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:488:12:491:5 | call to [] [element :a] | hash_flow.rb:488:5:488:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:489:15:489:25 | call to taint | hash_flow.rb:488:12:491:5 | call to [] [element :a] | provenance |  |
 | hash_flow.rb:492:5:492:5 | b [element :a] | hash_flow.rb:497:10:497:10 | b [element :a] | provenance |  |
 | hash_flow.rb:492:9:492:12 | [post] hash [element :a] | hash_flow.rb:498:10:498:13 | hash [element :a] | provenance |  |
 | hash_flow.rb:492:9:492:12 | hash [element :a] | hash_flow.rb:492:9:492:12 | [post] hash [element :a] | provenance |  |
@@ -401,8 +447,10 @@ edges
 | hash_flow.rb:498:10:498:13 | hash [element :a] | hash_flow.rb:498:10:498:17 | ...[...] | provenance |  |
 | hash_flow.rb:504:5:504:8 | hash [element :a] | hash_flow.rb:512:19:512:22 | hash [element :a] | provenance |  |
 | hash_flow.rb:504:5:504:8 | hash [element :c] | hash_flow.rb:512:19:512:22 | hash [element :c] | provenance |  |
-| hash_flow.rb:505:15:505:25 | call to taint | hash_flow.rb:504:5:504:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:507:15:507:25 | call to taint | hash_flow.rb:504:5:504:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:504:12:508:5 | call to [] [element :a] | hash_flow.rb:504:5:504:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:504:12:508:5 | call to [] [element :c] | hash_flow.rb:504:5:504:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:505:15:505:25 | call to taint | hash_flow.rb:504:12:508:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:507:15:507:25 | call to taint | hash_flow.rb:504:12:508:5 | call to [] [element :c] | provenance |  |
 | hash_flow.rb:512:5:512:9 | [post] hash2 [element :a] | hash_flow.rb:513:11:513:15 | hash2 [element :a] | provenance |  |
 | hash_flow.rb:512:5:512:9 | [post] hash2 [element :c] | hash_flow.rb:515:11:515:15 | hash2 [element :c] | provenance |  |
 | hash_flow.rb:512:19:512:22 | hash [element :a] | hash_flow.rb:512:5:512:9 | [post] hash2 [element :a] | provenance |  |
@@ -413,8 +461,10 @@ edges
 | hash_flow.rb:515:11:515:19 | ...[...] | hash_flow.rb:515:10:515:20 | ( ... ) | provenance |  |
 | hash_flow.rb:519:5:519:8 | hash [element :a] | hash_flow.rb:524:9:524:12 | hash [element :a] | provenance |  |
 | hash_flow.rb:519:5:519:8 | hash [element :c] | hash_flow.rb:524:9:524:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:520:15:520:25 | call to taint | hash_flow.rb:519:5:519:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:522:15:522:25 | call to taint | hash_flow.rb:519:5:519:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:519:12:523:5 | call to [] [element :a] | hash_flow.rb:519:5:519:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:519:12:523:5 | call to [] [element :c] | hash_flow.rb:519:5:519:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:520:15:520:25 | call to taint | hash_flow.rb:519:12:523:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:522:15:522:25 | call to taint | hash_flow.rb:519:12:523:5 | call to [] [element :c] | provenance |  |
 | hash_flow.rb:524:5:524:5 | b [element :a] | hash_flow.rb:529:11:529:11 | b [element :a] | provenance |  |
 | hash_flow.rb:524:9:524:12 | hash [element :a] | hash_flow.rb:524:9:528:7 | call to select [element :a] | provenance |  |
 | hash_flow.rb:524:9:524:12 | hash [element :a] | hash_flow.rb:524:30:524:34 | value | provenance |  |
@@ -425,8 +475,10 @@ edges
 | hash_flow.rb:529:11:529:15 | ...[...] | hash_flow.rb:529:10:529:16 | ( ... ) | provenance |  |
 | hash_flow.rb:535:5:535:8 | hash [element :a] | hash_flow.rb:540:5:540:8 | hash [element :a] | provenance |  |
 | hash_flow.rb:535:5:535:8 | hash [element :c] | hash_flow.rb:540:5:540:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:536:15:536:25 | call to taint | hash_flow.rb:535:5:535:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:538:15:538:25 | call to taint | hash_flow.rb:535:5:535:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:535:12:539:5 | call to [] [element :a] | hash_flow.rb:535:5:535:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:535:12:539:5 | call to [] [element :c] | hash_flow.rb:535:5:535:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:536:15:536:25 | call to taint | hash_flow.rb:535:12:539:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:538:15:538:25 | call to taint | hash_flow.rb:535:12:539:5 | call to [] [element :c] | provenance |  |
 | hash_flow.rb:540:5:540:8 | [post] hash [element :a] | hash_flow.rb:545:11:545:14 | hash [element :a] | provenance |  |
 | hash_flow.rb:540:5:540:8 | hash [element :a] | hash_flow.rb:540:5:540:8 | [post] hash [element :a] | provenance |  |
 | hash_flow.rb:540:5:540:8 | hash [element :a] | hash_flow.rb:540:27:540:31 | value | provenance |  |
@@ -436,8 +488,10 @@ edges
 | hash_flow.rb:545:11:545:18 | ...[...] | hash_flow.rb:545:10:545:19 | ( ... ) | provenance |  |
 | hash_flow.rb:551:5:551:8 | hash [element :a] | hash_flow.rb:556:9:556:12 | hash [element :a] | provenance |  |
 | hash_flow.rb:551:5:551:8 | hash [element :c] | hash_flow.rb:556:9:556:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:552:15:552:25 | call to taint | hash_flow.rb:551:5:551:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:554:15:554:25 | call to taint | hash_flow.rb:551:5:551:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:551:12:555:5 | call to [] [element :a] | hash_flow.rb:551:5:551:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:551:12:555:5 | call to [] [element :c] | hash_flow.rb:551:5:551:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:552:15:552:25 | call to taint | hash_flow.rb:551:12:555:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:554:15:554:25 | call to taint | hash_flow.rb:551:12:555:5 | call to [] [element :c] | provenance |  |
 | hash_flow.rb:556:5:556:5 | b [element 1] | hash_flow.rb:559:11:559:11 | b [element 1] | provenance |  |
 | hash_flow.rb:556:9:556:12 | [post] hash [element :a] | hash_flow.rb:557:11:557:14 | hash [element :a] | provenance |  |
 | hash_flow.rb:556:9:556:12 | hash [element :a] | hash_flow.rb:556:9:556:12 | [post] hash [element :a] | provenance |  |
@@ -451,8 +505,10 @@ edges
 | hash_flow.rb:565:5:565:8 | hash [element :a] | hash_flow.rb:570:9:570:12 | hash [element :a] | provenance |  |
 | hash_flow.rb:565:5:565:8 | hash [element :a] | hash_flow.rb:575:9:575:12 | hash [element :a] | provenance |  |
 | hash_flow.rb:565:5:565:8 | hash [element :c] | hash_flow.rb:575:9:575:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:566:15:566:25 | call to taint | hash_flow.rb:565:5:565:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:568:15:568:25 | call to taint | hash_flow.rb:565:5:565:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:565:12:569:5 | call to [] [element :a] | hash_flow.rb:565:5:565:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:565:12:569:5 | call to [] [element :c] | hash_flow.rb:565:5:565:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:566:15:566:25 | call to taint | hash_flow.rb:565:12:569:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:568:15:568:25 | call to taint | hash_flow.rb:565:12:569:5 | call to [] [element :c] | provenance |  |
 | hash_flow.rb:570:5:570:5 | b [element :a] | hash_flow.rb:571:11:571:11 | b [element :a] | provenance |  |
 | hash_flow.rb:570:9:570:12 | hash [element :a] | hash_flow.rb:570:9:570:26 | call to slice [element :a] | provenance |  |
 | hash_flow.rb:570:9:570:26 | call to slice [element :a] | hash_flow.rb:570:5:570:5 | b [element :a] | provenance |  |
@@ -470,8 +526,10 @@ edges
 | hash_flow.rb:578:11:578:15 | ...[...] | hash_flow.rb:578:10:578:16 | ( ... ) | provenance |  |
 | hash_flow.rb:584:5:584:8 | hash [element :a] | hash_flow.rb:589:9:589:12 | hash [element :a] | provenance |  |
 | hash_flow.rb:584:5:584:8 | hash [element :c] | hash_flow.rb:589:9:589:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:585:15:585:25 | call to taint | hash_flow.rb:584:5:584:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:587:15:587:25 | call to taint | hash_flow.rb:584:5:584:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:584:12:588:5 | call to [] [element :a] | hash_flow.rb:584:5:584:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:584:12:588:5 | call to [] [element :c] | hash_flow.rb:584:5:584:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:585:15:585:25 | call to taint | hash_flow.rb:584:12:588:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:587:15:587:25 | call to taint | hash_flow.rb:584:12:588:5 | call to [] [element :c] | provenance |  |
 | hash_flow.rb:589:5:589:5 | a [element, element 1] | hash_flow.rb:591:11:591:11 | a [element, element 1] | provenance |  |
 | hash_flow.rb:589:9:589:12 | hash [element :a] | hash_flow.rb:589:9:589:17 | call to to_a [element, element 1] | provenance |  |
 | hash_flow.rb:589:9:589:12 | hash [element :c] | hash_flow.rb:589:9:589:17 | call to to_a [element, element 1] | provenance |  |
@@ -483,8 +541,10 @@ edges
 | hash_flow.rb:597:5:597:8 | hash [element :a] | hash_flow.rb:607:9:607:12 | hash [element :a] | provenance |  |
 | hash_flow.rb:597:5:597:8 | hash [element :c] | hash_flow.rb:602:9:602:12 | hash [element :c] | provenance |  |
 | hash_flow.rb:597:5:597:8 | hash [element :c] | hash_flow.rb:607:9:607:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:598:15:598:25 | call to taint | hash_flow.rb:597:5:597:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:600:15:600:25 | call to taint | hash_flow.rb:597:5:597:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:597:12:601:5 | call to [] [element :a] | hash_flow.rb:597:5:597:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:597:12:601:5 | call to [] [element :c] | hash_flow.rb:597:5:597:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:598:15:598:25 | call to taint | hash_flow.rb:597:12:601:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:600:15:600:25 | call to taint | hash_flow.rb:597:12:601:5 | call to [] [element :c] | provenance |  |
 | hash_flow.rb:602:5:602:5 | a [element :a] | hash_flow.rb:603:11:603:11 | a [element :a] | provenance |  |
 | hash_flow.rb:602:5:602:5 | a [element :c] | hash_flow.rb:605:11:605:11 | a [element :c] | provenance |  |
 | hash_flow.rb:602:9:602:12 | hash [element :a] | hash_flow.rb:602:9:602:17 | call to to_h [element :a] | provenance |  |
@@ -500,13 +560,16 @@ edges
 | hash_flow.rb:607:9:607:12 | hash [element :c] | hash_flow.rb:607:28:607:32 | value | provenance |  |
 | hash_flow.rb:607:9:611:7 | call to to_h [element] | hash_flow.rb:607:5:607:5 | b [element] | provenance |  |
 | hash_flow.rb:607:28:607:32 | value | hash_flow.rb:609:14:609:18 | value | provenance |  |
-| hash_flow.rb:610:14:610:24 | call to taint | hash_flow.rb:607:9:611:7 | call to to_h [element] | provenance |  |
+| hash_flow.rb:610:9:610:25 | call to [] [element 1] | hash_flow.rb:607:9:611:7 | call to to_h [element] | provenance |  |
+| hash_flow.rb:610:14:610:24 | call to taint | hash_flow.rb:610:9:610:25 | call to [] [element 1] | provenance |  |
 | hash_flow.rb:612:11:612:11 | b [element] | hash_flow.rb:612:11:612:15 | ...[...] | provenance |  |
 | hash_flow.rb:612:11:612:15 | ...[...] | hash_flow.rb:612:10:612:16 | ( ... ) | provenance |  |
 | hash_flow.rb:618:5:618:8 | hash [element :a] | hash_flow.rb:623:9:623:12 | hash [element :a] | provenance |  |
 | hash_flow.rb:618:5:618:8 | hash [element :c] | hash_flow.rb:623:9:623:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:619:15:619:25 | call to taint | hash_flow.rb:618:5:618:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:621:15:621:25 | call to taint | hash_flow.rb:618:5:618:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:618:12:622:5 | call to [] [element :a] | hash_flow.rb:618:5:618:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:618:12:622:5 | call to [] [element :c] | hash_flow.rb:618:5:618:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:619:15:619:25 | call to taint | hash_flow.rb:618:12:622:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:621:15:621:25 | call to taint | hash_flow.rb:618:12:622:5 | call to [] [element :c] | provenance |  |
 | hash_flow.rb:623:5:623:5 | a [element] | hash_flow.rb:624:11:624:11 | a [element] | provenance |  |
 | hash_flow.rb:623:5:623:5 | a [element] | hash_flow.rb:625:11:625:11 | a [element] | provenance |  |
 | hash_flow.rb:623:5:623:5 | a [element] | hash_flow.rb:626:11:626:11 | a [element] | provenance |  |
@@ -521,8 +584,10 @@ edges
 | hash_flow.rb:626:11:626:16 | ...[...] | hash_flow.rb:626:10:626:17 | ( ... ) | provenance |  |
 | hash_flow.rb:632:5:632:8 | hash [element :a] | hash_flow.rb:639:5:639:8 | hash [element :a] | provenance |  |
 | hash_flow.rb:632:5:632:8 | hash [element :c] | hash_flow.rb:639:5:639:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:633:15:633:25 | call to taint | hash_flow.rb:632:5:632:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:635:15:635:25 | call to taint | hash_flow.rb:632:5:632:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:632:12:636:5 | call to [] [element :a] | hash_flow.rb:632:5:632:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:632:12:636:5 | call to [] [element :c] | hash_flow.rb:632:5:632:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:633:15:633:25 | call to taint | hash_flow.rb:632:12:636:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:635:15:635:25 | call to taint | hash_flow.rb:632:12:636:5 | call to [] [element :c] | provenance |  |
 | hash_flow.rb:637:5:637:8 | [post] hash [element] | hash_flow.rb:639:5:639:8 | hash [element] | provenance |  |
 | hash_flow.rb:637:5:637:8 | [post] hash [element] | hash_flow.rb:640:11:640:14 | hash [element] | provenance |  |
 | hash_flow.rb:637:5:637:8 | [post] hash [element] | hash_flow.rb:641:11:641:14 | hash [element] | provenance |  |
@@ -543,8 +608,10 @@ edges
 | hash_flow.rb:648:5:648:8 | hash [element :a] | hash_flow.rb:653:9:653:12 | hash [element :a] | provenance |  |
 | hash_flow.rb:648:5:648:8 | hash [element :a] | hash_flow.rb:657:11:657:14 | hash [element :a] | provenance |  |
 | hash_flow.rb:648:5:648:8 | hash [element :c] | hash_flow.rb:653:9:653:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:649:15:649:25 | call to taint | hash_flow.rb:648:5:648:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:651:15:651:25 | call to taint | hash_flow.rb:648:5:648:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:648:12:652:5 | call to [] [element :a] | hash_flow.rb:648:5:648:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:648:12:652:5 | call to [] [element :c] | hash_flow.rb:648:5:648:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:649:15:649:25 | call to taint | hash_flow.rb:648:12:652:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:651:15:651:25 | call to taint | hash_flow.rb:648:12:652:5 | call to [] [element :c] | provenance |  |
 | hash_flow.rb:653:5:653:5 | b [element] | hash_flow.rb:658:11:658:11 | b [element] | provenance |  |
 | hash_flow.rb:653:9:653:12 | hash [element :a] | hash_flow.rb:653:35:653:39 | value | provenance |  |
 | hash_flow.rb:653:9:653:12 | hash [element :c] | hash_flow.rb:653:35:653:39 | value | provenance |  |
@@ -557,8 +624,10 @@ edges
 | hash_flow.rb:658:11:658:15 | ...[...] | hash_flow.rb:658:10:658:16 | ( ... ) | provenance |  |
 | hash_flow.rb:664:5:664:8 | hash [element :a] | hash_flow.rb:669:5:669:8 | hash [element :a] | provenance |  |
 | hash_flow.rb:664:5:664:8 | hash [element :c] | hash_flow.rb:669:5:669:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:665:15:665:25 | call to taint | hash_flow.rb:664:5:664:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:667:15:667:25 | call to taint | hash_flow.rb:664:5:664:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:664:12:668:5 | call to [] [element :a] | hash_flow.rb:664:5:664:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:664:12:668:5 | call to [] [element :c] | hash_flow.rb:664:5:664:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:665:15:665:25 | call to taint | hash_flow.rb:664:12:668:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:667:15:667:25 | call to taint | hash_flow.rb:664:12:668:5 | call to [] [element :c] | provenance |  |
 | hash_flow.rb:669:5:669:8 | [post] hash [element] | hash_flow.rb:673:11:673:14 | hash [element] | provenance |  |
 | hash_flow.rb:669:5:669:8 | hash [element :a] | hash_flow.rb:669:32:669:36 | value | provenance |  |
 | hash_flow.rb:669:5:669:8 | hash [element :c] | hash_flow.rb:669:32:669:36 | value | provenance |  |
@@ -568,12 +637,16 @@ edges
 | hash_flow.rb:673:11:673:18 | ...[...] | hash_flow.rb:673:10:673:19 | ( ... ) | provenance |  |
 | hash_flow.rb:679:5:679:9 | hash1 [element :a] | hash_flow.rb:689:12:689:16 | hash1 [element :a] | provenance |  |
 | hash_flow.rb:679:5:679:9 | hash1 [element :c] | hash_flow.rb:689:12:689:16 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:680:15:680:25 | call to taint | hash_flow.rb:679:5:679:9 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:682:15:682:25 | call to taint | hash_flow.rb:679:5:679:9 | hash1 [element :c] | provenance |  |
+| hash_flow.rb:679:13:683:5 | call to [] [element :a] | hash_flow.rb:679:5:679:9 | hash1 [element :a] | provenance |  |
+| hash_flow.rb:679:13:683:5 | call to [] [element :c] | hash_flow.rb:679:5:679:9 | hash1 [element :c] | provenance |  |
+| hash_flow.rb:680:15:680:25 | call to taint | hash_flow.rb:679:13:683:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:682:15:682:25 | call to taint | hash_flow.rb:679:13:683:5 | call to [] [element :c] | provenance |  |
 | hash_flow.rb:684:5:684:9 | hash2 [element :d] | hash_flow.rb:689:25:689:29 | hash2 [element :d] | provenance |  |
 | hash_flow.rb:684:5:684:9 | hash2 [element :f] | hash_flow.rb:689:25:689:29 | hash2 [element :f] | provenance |  |
-| hash_flow.rb:685:15:685:25 | call to taint | hash_flow.rb:684:5:684:9 | hash2 [element :d] | provenance |  |
-| hash_flow.rb:687:15:687:25 | call to taint | hash_flow.rb:684:5:684:9 | hash2 [element :f] | provenance |  |
+| hash_flow.rb:684:13:688:5 | call to [] [element :d] | hash_flow.rb:684:5:684:9 | hash2 [element :d] | provenance |  |
+| hash_flow.rb:684:13:688:5 | call to [] [element :f] | hash_flow.rb:684:5:684:9 | hash2 [element :f] | provenance |  |
+| hash_flow.rb:685:15:685:25 | call to taint | hash_flow.rb:684:13:688:5 | call to [] [element :d] | provenance |  |
+| hash_flow.rb:687:15:687:25 | call to taint | hash_flow.rb:684:13:688:5 | call to [] [element :f] | provenance |  |
 | hash_flow.rb:689:5:689:8 | hash [element :a] | hash_flow.rb:694:11:694:14 | hash [element :a] | provenance |  |
 | hash_flow.rb:689:5:689:8 | hash [element :c] | hash_flow.rb:696:11:696:14 | hash [element :c] | provenance |  |
 | hash_flow.rb:689:5:689:8 | hash [element :d] | hash_flow.rb:697:11:697:14 | hash [element :d] | provenance |  |
@@ -622,8 +695,10 @@ edges
 | hash_flow.rb:706:11:706:19 | ...[...] | hash_flow.rb:706:10:706:20 | ( ... ) | provenance |  |
 | hash_flow.rb:712:5:712:8 | hash [element :a] | hash_flow.rb:717:9:717:12 | hash [element :a] | provenance |  |
 | hash_flow.rb:712:5:712:8 | hash [element :c] | hash_flow.rb:717:9:717:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:713:15:713:25 | call to taint | hash_flow.rb:712:5:712:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:715:15:715:25 | call to taint | hash_flow.rb:712:5:712:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:712:12:716:5 | call to [] [element :a] | hash_flow.rb:712:5:712:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:712:12:716:5 | call to [] [element :c] | hash_flow.rb:712:5:712:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:713:15:713:25 | call to taint | hash_flow.rb:712:12:716:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:715:15:715:25 | call to taint | hash_flow.rb:712:12:716:5 | call to [] [element :c] | provenance |  |
 | hash_flow.rb:717:5:717:5 | a [element] | hash_flow.rb:718:11:718:11 | a [element] | provenance |  |
 | hash_flow.rb:717:9:717:12 | hash [element :a] | hash_flow.rb:717:9:717:19 | call to values [element] | provenance |  |
 | hash_flow.rb:717:9:717:12 | hash [element :c] | hash_flow.rb:717:9:717:19 | call to values [element] | provenance |  |
@@ -633,8 +708,10 @@ edges
 | hash_flow.rb:724:5:724:8 | hash [element :a] | hash_flow.rb:729:9:729:12 | hash [element :a] | provenance |  |
 | hash_flow.rb:724:5:724:8 | hash [element :a] | hash_flow.rb:731:9:731:12 | hash [element :a] | provenance |  |
 | hash_flow.rb:724:5:724:8 | hash [element :c] | hash_flow.rb:731:9:731:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:725:15:725:25 | call to taint | hash_flow.rb:724:5:724:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:727:15:727:25 | call to taint | hash_flow.rb:724:5:724:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:724:12:728:5 | call to [] [element :a] | hash_flow.rb:724:5:724:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:724:12:728:5 | call to [] [element :c] | hash_flow.rb:724:5:724:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:725:15:725:25 | call to taint | hash_flow.rb:724:12:728:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:727:15:727:25 | call to taint | hash_flow.rb:724:12:728:5 | call to [] [element :c] | provenance |  |
 | hash_flow.rb:729:5:729:5 | b [element 0] | hash_flow.rb:730:10:730:10 | b [element 0] | provenance |  |
 | hash_flow.rb:729:9:729:12 | hash [element :a] | hash_flow.rb:729:9:729:26 | call to values_at [element 0] | provenance |  |
 | hash_flow.rb:729:9:729:26 | call to values_at [element 0] | hash_flow.rb:729:5:729:5 | b [element 0] | provenance |  |
@@ -646,24 +723,33 @@ edges
 | hash_flow.rb:732:10:732:10 | b [element] | hash_flow.rb:732:10:732:13 | ...[...] | provenance |  |
 | hash_flow.rb:738:5:738:9 | hash1 [element :a] | hash_flow.rb:748:16:748:20 | hash1 [element :a] | provenance |  |
 | hash_flow.rb:738:5:738:9 | hash1 [element :c] | hash_flow.rb:748:16:748:20 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:739:15:739:25 | call to taint | hash_flow.rb:738:5:738:9 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:741:15:741:25 | call to taint | hash_flow.rb:738:5:738:9 | hash1 [element :c] | provenance |  |
+| hash_flow.rb:738:13:742:5 | call to [] [element :a] | hash_flow.rb:738:5:738:9 | hash1 [element :a] | provenance |  |
+| hash_flow.rb:738:13:742:5 | call to [] [element :c] | hash_flow.rb:738:5:738:9 | hash1 [element :c] | provenance |  |
+| hash_flow.rb:739:15:739:25 | call to taint | hash_flow.rb:738:13:742:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:741:15:741:25 | call to taint | hash_flow.rb:738:13:742:5 | call to [] [element :c] | provenance |  |
 | hash_flow.rb:743:5:743:9 | hash2 [element :d] | hash_flow.rb:748:44:748:48 | hash2 [element :d] | provenance |  |
 | hash_flow.rb:743:5:743:9 | hash2 [element :f] | hash_flow.rb:748:44:748:48 | hash2 [element :f] | provenance |  |
-| hash_flow.rb:744:15:744:25 | call to taint | hash_flow.rb:743:5:743:9 | hash2 [element :d] | provenance |  |
-| hash_flow.rb:746:15:746:25 | call to taint | hash_flow.rb:743:5:743:9 | hash2 [element :f] | provenance |  |
+| hash_flow.rb:743:13:747:5 | call to [] [element :d] | hash_flow.rb:743:5:743:9 | hash2 [element :d] | provenance |  |
+| hash_flow.rb:743:13:747:5 | call to [] [element :f] | hash_flow.rb:743:5:743:9 | hash2 [element :f] | provenance |  |
+| hash_flow.rb:744:15:744:25 | call to taint | hash_flow.rb:743:13:747:5 | call to [] [element :d] | provenance |  |
+| hash_flow.rb:746:15:746:25 | call to taint | hash_flow.rb:743:13:747:5 | call to [] [element :f] | provenance |  |
 | hash_flow.rb:748:5:748:8 | hash [element :a] | hash_flow.rb:749:10:749:13 | hash [element :a] | provenance |  |
 | hash_flow.rb:748:5:748:8 | hash [element :c] | hash_flow.rb:751:10:751:13 | hash [element :c] | provenance |  |
 | hash_flow.rb:748:5:748:8 | hash [element :d] | hash_flow.rb:752:10:752:13 | hash [element :d] | provenance |  |
 | hash_flow.rb:748:5:748:8 | hash [element :f] | hash_flow.rb:754:10:754:13 | hash [element :f] | provenance |  |
 | hash_flow.rb:748:5:748:8 | hash [element :g] | hash_flow.rb:755:10:755:13 | hash [element :g] | provenance |  |
-| hash_flow.rb:748:14:748:20 | ** ... [element :a] | hash_flow.rb:748:5:748:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:748:14:748:20 | ** ... [element :c] | hash_flow.rb:748:5:748:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:748:12:748:59 | call to [] [element :a] | hash_flow.rb:748:5:748:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:748:12:748:59 | call to [] [element :c] | hash_flow.rb:748:5:748:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:748:12:748:59 | call to [] [element :d] | hash_flow.rb:748:5:748:8 | hash [element :d] | provenance |  |
+| hash_flow.rb:748:12:748:59 | call to [] [element :f] | hash_flow.rb:748:5:748:8 | hash [element :f] | provenance |  |
+| hash_flow.rb:748:12:748:59 | call to [] [element :g] | hash_flow.rb:748:5:748:8 | hash [element :g] | provenance |  |
+| hash_flow.rb:748:14:748:20 | ** ... [element :a] | hash_flow.rb:748:12:748:59 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:748:14:748:20 | ** ... [element :c] | hash_flow.rb:748:12:748:59 | call to [] [element :c] | provenance |  |
 | hash_flow.rb:748:16:748:20 | hash1 [element :a] | hash_flow.rb:748:14:748:20 | ** ... [element :a] | provenance |  |
 | hash_flow.rb:748:16:748:20 | hash1 [element :c] | hash_flow.rb:748:14:748:20 | ** ... [element :c] | provenance |  |
-| hash_flow.rb:748:29:748:39 | call to taint | hash_flow.rb:748:5:748:8 | hash [element :g] | provenance |  |
-| hash_flow.rb:748:42:748:48 | ** ... [element :d] | hash_flow.rb:748:5:748:8 | hash [element :d] | provenance |  |
-| hash_flow.rb:748:42:748:48 | ** ... [element :f] | hash_flow.rb:748:5:748:8 | hash [element :f] | provenance |  |
+| hash_flow.rb:748:29:748:39 | call to taint | hash_flow.rb:748:12:748:59 | call to [] [element :g] | provenance |  |
+| hash_flow.rb:748:42:748:48 | ** ... [element :d] | hash_flow.rb:748:12:748:59 | call to [] [element :d] | provenance |  |
+| hash_flow.rb:748:42:748:48 | ** ... [element :f] | hash_flow.rb:748:12:748:59 | call to [] [element :f] | provenance |  |
 | hash_flow.rb:748:44:748:48 | hash2 [element :d] | hash_flow.rb:748:42:748:48 | ** ... [element :d] | provenance |  |
 | hash_flow.rb:748:44:748:48 | hash2 [element :f] | hash_flow.rb:748:42:748:48 | ** ... [element :f] | provenance |  |
 | hash_flow.rb:749:10:749:13 | hash [element :a] | hash_flow.rb:749:10:749:17 | ...[...] | provenance |  |
@@ -675,9 +761,12 @@ edges
 | hash_flow.rb:762:5:762:8 | hash [element :c] | hash_flow.rb:771:10:771:13 | hash [element :c] | provenance |  |
 | hash_flow.rb:762:5:762:8 | hash [element :c] | hash_flow.rb:774:9:774:12 | hash [element :c] | provenance |  |
 | hash_flow.rb:762:5:762:8 | hash [element :d] | hash_flow.rb:772:10:772:13 | hash [element :d] | provenance |  |
-| hash_flow.rb:763:15:763:25 | call to taint | hash_flow.rb:762:5:762:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:765:15:765:25 | call to taint | hash_flow.rb:762:5:762:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:766:15:766:25 | call to taint | hash_flow.rb:762:5:762:8 | hash [element :d] | provenance |  |
+| hash_flow.rb:762:12:767:5 | call to [] [element :a] | hash_flow.rb:762:5:762:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:762:12:767:5 | call to [] [element :c] | hash_flow.rb:762:5:762:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:762:12:767:5 | call to [] [element :d] | hash_flow.rb:762:5:762:8 | hash [element :d] | provenance |  |
+| hash_flow.rb:763:15:763:25 | call to taint | hash_flow.rb:762:12:767:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:765:15:765:25 | call to taint | hash_flow.rb:762:12:767:5 | call to [] [element :c] | provenance |  |
+| hash_flow.rb:766:15:766:25 | call to taint | hash_flow.rb:762:12:767:5 | call to [] [element :d] | provenance |  |
 | hash_flow.rb:769:10:769:13 | hash [element :a] | hash_flow.rb:769:10:769:17 | ...[...] | provenance |  |
 | hash_flow.rb:771:10:771:13 | hash [element :c] | hash_flow.rb:771:10:771:17 | ...[...] | provenance |  |
 | hash_flow.rb:772:10:772:13 | hash [element :d] | hash_flow.rb:772:10:772:17 | ...[...] | provenance |  |
@@ -690,12 +779,16 @@ edges
 | hash_flow.rb:783:10:783:13 | hash [element :c] | hash_flow.rb:783:10:783:17 | ...[...] | provenance |  |
 | hash_flow.rb:790:5:790:9 | hash1 [element :a] | hash_flow.rb:800:12:800:16 | hash1 [element :a] | provenance |  |
 | hash_flow.rb:790:5:790:9 | hash1 [element :c] | hash_flow.rb:800:12:800:16 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:791:15:791:25 | call to taint | hash_flow.rb:790:5:790:9 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:793:15:793:25 | call to taint | hash_flow.rb:790:5:790:9 | hash1 [element :c] | provenance |  |
+| hash_flow.rb:790:13:794:5 | call to [] [element :a] | hash_flow.rb:790:5:790:9 | hash1 [element :a] | provenance |  |
+| hash_flow.rb:790:13:794:5 | call to [] [element :c] | hash_flow.rb:790:5:790:9 | hash1 [element :c] | provenance |  |
+| hash_flow.rb:791:15:791:25 | call to taint | hash_flow.rb:790:13:794:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:793:15:793:25 | call to taint | hash_flow.rb:790:13:794:5 | call to [] [element :c] | provenance |  |
 | hash_flow.rb:795:5:795:9 | hash2 [element :d] | hash_flow.rb:800:29:800:33 | hash2 [element :d] | provenance |  |
 | hash_flow.rb:795:5:795:9 | hash2 [element :f] | hash_flow.rb:800:29:800:33 | hash2 [element :f] | provenance |  |
-| hash_flow.rb:796:15:796:25 | call to taint | hash_flow.rb:795:5:795:9 | hash2 [element :d] | provenance |  |
-| hash_flow.rb:798:15:798:25 | call to taint | hash_flow.rb:795:5:795:9 | hash2 [element :f] | provenance |  |
+| hash_flow.rb:795:13:799:5 | call to [] [element :d] | hash_flow.rb:795:5:795:9 | hash2 [element :d] | provenance |  |
+| hash_flow.rb:795:13:799:5 | call to [] [element :f] | hash_flow.rb:795:5:795:9 | hash2 [element :f] | provenance |  |
+| hash_flow.rb:796:15:796:25 | call to taint | hash_flow.rb:795:13:799:5 | call to [] [element :d] | provenance |  |
+| hash_flow.rb:798:15:798:25 | call to taint | hash_flow.rb:795:13:799:5 | call to [] [element :f] | provenance |  |
 | hash_flow.rb:800:5:800:8 | hash [element :a] | hash_flow.rb:805:11:805:14 | hash [element :a] | provenance |  |
 | hash_flow.rb:800:5:800:8 | hash [element :c] | hash_flow.rb:807:11:807:14 | hash [element :c] | provenance |  |
 | hash_flow.rb:800:5:800:8 | hash [element :d] | hash_flow.rb:808:11:808:14 | hash [element :d] | provenance |  |
@@ -728,12 +821,16 @@ edges
 | hash_flow.rb:810:11:810:18 | ...[...] | hash_flow.rb:810:10:810:19 | ( ... ) | provenance |  |
 | hash_flow.rb:816:5:816:9 | hash1 [element :a] | hash_flow.rb:826:12:826:16 | hash1 [element :a] | provenance |  |
 | hash_flow.rb:816:5:816:9 | hash1 [element :c] | hash_flow.rb:826:12:826:16 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:817:15:817:25 | call to taint | hash_flow.rb:816:5:816:9 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:819:15:819:25 | call to taint | hash_flow.rb:816:5:816:9 | hash1 [element :c] | provenance |  |
+| hash_flow.rb:816:13:820:5 | call to [] [element :a] | hash_flow.rb:816:5:816:9 | hash1 [element :a] | provenance |  |
+| hash_flow.rb:816:13:820:5 | call to [] [element :c] | hash_flow.rb:816:5:816:9 | hash1 [element :c] | provenance |  |
+| hash_flow.rb:817:15:817:25 | call to taint | hash_flow.rb:816:13:820:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:819:15:819:25 | call to taint | hash_flow.rb:816:13:820:5 | call to [] [element :c] | provenance |  |
 | hash_flow.rb:821:5:821:9 | hash2 [element :d] | hash_flow.rb:826:30:826:34 | hash2 [element :d] | provenance |  |
 | hash_flow.rb:821:5:821:9 | hash2 [element :f] | hash_flow.rb:826:30:826:34 | hash2 [element :f] | provenance |  |
-| hash_flow.rb:822:15:822:25 | call to taint | hash_flow.rb:821:5:821:9 | hash2 [element :d] | provenance |  |
-| hash_flow.rb:824:15:824:25 | call to taint | hash_flow.rb:821:5:821:9 | hash2 [element :f] | provenance |  |
+| hash_flow.rb:821:13:825:5 | call to [] [element :d] | hash_flow.rb:821:5:821:9 | hash2 [element :d] | provenance |  |
+| hash_flow.rb:821:13:825:5 | call to [] [element :f] | hash_flow.rb:821:5:821:9 | hash2 [element :f] | provenance |  |
+| hash_flow.rb:822:15:822:25 | call to taint | hash_flow.rb:821:13:825:5 | call to [] [element :d] | provenance |  |
+| hash_flow.rb:824:15:824:25 | call to taint | hash_flow.rb:821:13:825:5 | call to [] [element :f] | provenance |  |
 | hash_flow.rb:826:5:826:8 | hash [element :a] | hash_flow.rb:831:11:831:14 | hash [element :a] | provenance |  |
 | hash_flow.rb:826:5:826:8 | hash [element :c] | hash_flow.rb:833:11:833:14 | hash [element :c] | provenance |  |
 | hash_flow.rb:826:5:826:8 | hash [element :d] | hash_flow.rb:834:11:834:14 | hash [element :d] | provenance |  |
@@ -784,14 +881,18 @@ edges
 | hash_flow.rb:849:5:849:9 | hash1 [element :a] | hash_flow.rb:869:13:869:17 | hash1 [element :a] | provenance |  |
 | hash_flow.rb:849:5:849:9 | hash1 [element :c] | hash_flow.rb:860:13:860:17 | hash1 [element :c] | provenance |  |
 | hash_flow.rb:849:5:849:9 | hash1 [element :c] | hash_flow.rb:869:13:869:17 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:850:12:850:22 | call to taint | hash_flow.rb:849:5:849:9 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:852:12:852:22 | call to taint | hash_flow.rb:849:5:849:9 | hash1 [element :c] | provenance |  |
+| hash_flow.rb:849:13:853:5 | call to [] [element :a] | hash_flow.rb:849:5:849:9 | hash1 [element :a] | provenance |  |
+| hash_flow.rb:849:13:853:5 | call to [] [element :c] | hash_flow.rb:849:5:849:9 | hash1 [element :c] | provenance |  |
+| hash_flow.rb:850:12:850:22 | call to taint | hash_flow.rb:849:13:853:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:852:12:852:22 | call to taint | hash_flow.rb:849:13:853:5 | call to [] [element :c] | provenance |  |
 | hash_flow.rb:854:5:854:9 | hash2 [element :d] | hash_flow.rb:860:33:860:37 | hash2 [element :d] | provenance |  |
 | hash_flow.rb:854:5:854:9 | hash2 [element :d] | hash_flow.rb:869:33:869:37 | hash2 [element :d] | provenance |  |
 | hash_flow.rb:854:5:854:9 | hash2 [element :f] | hash_flow.rb:860:33:860:37 | hash2 [element :f] | provenance |  |
 | hash_flow.rb:854:5:854:9 | hash2 [element :f] | hash_flow.rb:869:33:869:37 | hash2 [element :f] | provenance |  |
-| hash_flow.rb:855:12:855:22 | call to taint | hash_flow.rb:854:5:854:9 | hash2 [element :d] | provenance |  |
-| hash_flow.rb:857:12:857:22 | call to taint | hash_flow.rb:854:5:854:9 | hash2 [element :f] | provenance |  |
+| hash_flow.rb:854:13:858:5 | call to [] [element :d] | hash_flow.rb:854:5:854:9 | hash2 [element :d] | provenance |  |
+| hash_flow.rb:854:13:858:5 | call to [] [element :f] | hash_flow.rb:854:5:854:9 | hash2 [element :f] | provenance |  |
+| hash_flow.rb:855:12:855:22 | call to taint | hash_flow.rb:854:13:858:5 | call to [] [element :d] | provenance |  |
+| hash_flow.rb:857:12:857:22 | call to taint | hash_flow.rb:854:13:858:5 | call to [] [element :f] | provenance |  |
 | hash_flow.rb:860:5:860:9 | hash3 [element :a] | hash_flow.rb:861:11:861:15 | hash3 [element :a] | provenance |  |
 | hash_flow.rb:860:5:860:9 | hash3 [element :c] | hash_flow.rb:863:11:863:15 | hash3 [element :c] | provenance |  |
 | hash_flow.rb:860:5:860:9 | hash3 [element :d] | hash_flow.rb:864:11:864:15 | hash3 [element :d] | provenance |  |
@@ -834,12 +935,16 @@ edges
 | hash_flow.rb:875:11:875:19 | ...[...] | hash_flow.rb:875:10:875:20 | ( ... ) | provenance |  |
 | hash_flow.rb:881:5:881:9 | hash1 [element :a] | hash_flow.rb:892:12:892:16 | hash1 [element :a] | provenance |  |
 | hash_flow.rb:881:5:881:9 | hash1 [element :c] | hash_flow.rb:892:12:892:16 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:882:12:882:22 | call to taint | hash_flow.rb:881:5:881:9 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:884:12:884:22 | call to taint | hash_flow.rb:881:5:881:9 | hash1 [element :c] | provenance |  |
+| hash_flow.rb:881:13:885:5 | call to [] [element :a] | hash_flow.rb:881:5:881:9 | hash1 [element :a] | provenance |  |
+| hash_flow.rb:881:13:885:5 | call to [] [element :c] | hash_flow.rb:881:5:881:9 | hash1 [element :c] | provenance |  |
+| hash_flow.rb:882:12:882:22 | call to taint | hash_flow.rb:881:13:885:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:884:12:884:22 | call to taint | hash_flow.rb:881:13:885:5 | call to [] [element :c] | provenance |  |
 | hash_flow.rb:886:5:886:9 | hash2 [element :d] | hash_flow.rb:892:33:892:37 | hash2 [element :d] | provenance |  |
 | hash_flow.rb:886:5:886:9 | hash2 [element :f] | hash_flow.rb:892:33:892:37 | hash2 [element :f] | provenance |  |
-| hash_flow.rb:887:12:887:22 | call to taint | hash_flow.rb:886:5:886:9 | hash2 [element :d] | provenance |  |
-| hash_flow.rb:889:12:889:22 | call to taint | hash_flow.rb:886:5:886:9 | hash2 [element :f] | provenance |  |
+| hash_flow.rb:886:13:890:5 | call to [] [element :d] | hash_flow.rb:886:5:886:9 | hash2 [element :d] | provenance |  |
+| hash_flow.rb:886:13:890:5 | call to [] [element :f] | hash_flow.rb:886:5:886:9 | hash2 [element :f] | provenance |  |
+| hash_flow.rb:887:12:887:22 | call to taint | hash_flow.rb:886:13:890:5 | call to [] [element :d] | provenance |  |
+| hash_flow.rb:889:12:889:22 | call to taint | hash_flow.rb:886:13:890:5 | call to [] [element :f] | provenance |  |
 | hash_flow.rb:892:5:892:8 | hash [element :a] | hash_flow.rb:893:11:893:14 | hash [element :a] | provenance |  |
 | hash_flow.rb:892:5:892:8 | hash [element :c] | hash_flow.rb:895:11:895:14 | hash [element :c] | provenance |  |
 | hash_flow.rb:892:5:892:8 | hash [element :d] | hash_flow.rb:896:11:896:14 | hash [element :d] | provenance |  |
@@ -878,12 +983,16 @@ edges
 | hash_flow.rb:905:11:905:19 | ...[...] | hash_flow.rb:905:10:905:20 | ( ... ) | provenance |  |
 | hash_flow.rb:911:5:911:9 | hash1 [element :a] | hash_flow.rb:922:12:922:16 | hash1 [element :a] | provenance |  |
 | hash_flow.rb:911:5:911:9 | hash1 [element :c] | hash_flow.rb:922:12:922:16 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:912:12:912:22 | call to taint | hash_flow.rb:911:5:911:9 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:914:12:914:22 | call to taint | hash_flow.rb:911:5:911:9 | hash1 [element :c] | provenance |  |
+| hash_flow.rb:911:13:915:5 | call to [] [element :a] | hash_flow.rb:911:5:911:9 | hash1 [element :a] | provenance |  |
+| hash_flow.rb:911:13:915:5 | call to [] [element :c] | hash_flow.rb:911:5:911:9 | hash1 [element :c] | provenance |  |
+| hash_flow.rb:912:12:912:22 | call to taint | hash_flow.rb:911:13:915:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:914:12:914:22 | call to taint | hash_flow.rb:911:13:915:5 | call to [] [element :c] | provenance |  |
 | hash_flow.rb:916:5:916:9 | hash2 [element :d] | hash_flow.rb:922:33:922:37 | hash2 [element :d] | provenance |  |
 | hash_flow.rb:916:5:916:9 | hash2 [element :f] | hash_flow.rb:922:33:922:37 | hash2 [element :f] | provenance |  |
-| hash_flow.rb:917:12:917:22 | call to taint | hash_flow.rb:916:5:916:9 | hash2 [element :d] | provenance |  |
-| hash_flow.rb:919:12:919:22 | call to taint | hash_flow.rb:916:5:916:9 | hash2 [element :f] | provenance |  |
+| hash_flow.rb:916:13:920:5 | call to [] [element :d] | hash_flow.rb:916:5:916:9 | hash2 [element :d] | provenance |  |
+| hash_flow.rb:916:13:920:5 | call to [] [element :f] | hash_flow.rb:916:5:916:9 | hash2 [element :f] | provenance |  |
+| hash_flow.rb:917:12:917:22 | call to taint | hash_flow.rb:916:13:920:5 | call to [] [element :d] | provenance |  |
+| hash_flow.rb:919:12:919:22 | call to taint | hash_flow.rb:916:13:920:5 | call to [] [element :f] | provenance |  |
 | hash_flow.rb:922:5:922:8 | hash [element :a] | hash_flow.rb:923:11:923:14 | hash [element :a] | provenance |  |
 | hash_flow.rb:922:5:922:8 | hash [element :c] | hash_flow.rb:925:11:925:14 | hash [element :c] | provenance |  |
 | hash_flow.rb:922:5:922:8 | hash [element :d] | hash_flow.rb:926:11:926:14 | hash [element :d] | provenance |  |
@@ -922,12 +1031,16 @@ edges
 | hash_flow.rb:935:11:935:19 | ...[...] | hash_flow.rb:935:10:935:20 | ( ... ) | provenance |  |
 | hash_flow.rb:941:5:941:9 | hash1 [element :a] | hash_flow.rb:952:12:952:16 | hash1 [element :a] | provenance |  |
 | hash_flow.rb:941:5:941:9 | hash1 [element :c] | hash_flow.rb:952:12:952:16 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:942:12:942:22 | call to taint | hash_flow.rb:941:5:941:9 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:944:12:944:22 | call to taint | hash_flow.rb:941:5:941:9 | hash1 [element :c] | provenance |  |
+| hash_flow.rb:941:13:945:5 | call to [] [element :a] | hash_flow.rb:941:5:941:9 | hash1 [element :a] | provenance |  |
+| hash_flow.rb:941:13:945:5 | call to [] [element :c] | hash_flow.rb:941:5:941:9 | hash1 [element :c] | provenance |  |
+| hash_flow.rb:942:12:942:22 | call to taint | hash_flow.rb:941:13:945:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:944:12:944:22 | call to taint | hash_flow.rb:941:13:945:5 | call to [] [element :c] | provenance |  |
 | hash_flow.rb:946:5:946:9 | hash2 [element :d] | hash_flow.rb:952:33:952:37 | hash2 [element :d] | provenance |  |
 | hash_flow.rb:946:5:946:9 | hash2 [element :f] | hash_flow.rb:952:33:952:37 | hash2 [element :f] | provenance |  |
-| hash_flow.rb:947:12:947:22 | call to taint | hash_flow.rb:946:5:946:9 | hash2 [element :d] | provenance |  |
-| hash_flow.rb:949:12:949:22 | call to taint | hash_flow.rb:946:5:946:9 | hash2 [element :f] | provenance |  |
+| hash_flow.rb:946:13:950:5 | call to [] [element :d] | hash_flow.rb:946:5:946:9 | hash2 [element :d] | provenance |  |
+| hash_flow.rb:946:13:950:5 | call to [] [element :f] | hash_flow.rb:946:5:946:9 | hash2 [element :f] | provenance |  |
+| hash_flow.rb:947:12:947:22 | call to taint | hash_flow.rb:946:13:950:5 | call to [] [element :d] | provenance |  |
+| hash_flow.rb:949:12:949:22 | call to taint | hash_flow.rb:946:13:950:5 | call to [] [element :f] | provenance |  |
 | hash_flow.rb:952:5:952:8 | hash [element :a] | hash_flow.rb:953:11:953:14 | hash [element :a] | provenance |  |
 | hash_flow.rb:952:5:952:8 | hash [element :c] | hash_flow.rb:955:11:955:14 | hash [element :c] | provenance |  |
 | hash_flow.rb:952:5:952:8 | hash [element :d] | hash_flow.rb:956:11:956:14 | hash [element :d] | provenance |  |
@@ -982,6 +1095,11 @@ nodes
 | hash_flow.rb:10:5:10:8 | hash [element :c] | semmle.label | hash [element :c] |
 | hash_flow.rb:10:5:10:8 | hash [element e] | semmle.label | hash [element e] |
 | hash_flow.rb:10:5:10:8 | hash [element g] | semmle.label | hash [element g] |
+| hash_flow.rb:10:12:21:5 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| hash_flow.rb:10:12:21:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:10:12:21:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:10:12:21:5 | call to [] [element e] | semmle.label | call to [] [element e] |
+| hash_flow.rb:10:12:21:5 | call to [] [element g] | semmle.label | call to [] [element g] |
 | hash_flow.rb:11:15:11:24 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:13:12:13:21 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:15:14:15:23 | call to taint | semmle.label | call to taint |
@@ -1033,6 +1151,7 @@ nodes
 | hash_flow.rb:56:10:56:14 | hash1 [element :a] | semmle.label | hash1 [element :a] |
 | hash_flow.rb:56:10:56:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:59:5:59:5 | x [element :a] | semmle.label | x [element :a] |
+| hash_flow.rb:59:9:59:29 | call to [] [element :a] | semmle.label | call to [] [element :a] |
 | hash_flow.rb:59:13:59:22 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:60:5:60:9 | hash2 [element :a] | semmle.label | hash2 [element :a] |
 | hash_flow.rb:60:13:60:19 | ...[...] [element :a] | semmle.label | ...[...] [element :a] |
@@ -1041,6 +1160,8 @@ nodes
 | hash_flow.rb:61:10:61:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:64:5:64:9 | hash3 [element] | semmle.label | hash3 [element] |
 | hash_flow.rb:64:13:64:45 | ...[...] [element] | semmle.label | ...[...] [element] |
+| hash_flow.rb:64:18:64:44 | call to [] [element 0, element 1] | semmle.label | call to [] [element 0, element 1] |
+| hash_flow.rb:64:19:64:34 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | hash_flow.rb:64:24:64:33 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:65:10:65:14 | hash3 [element] | semmle.label | hash3 [element] |
 | hash_flow.rb:65:10:65:18 | ...[...] | semmle.label | ...[...] |
@@ -1058,6 +1179,7 @@ nodes
 | hash_flow.rb:73:10:73:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:76:5:76:9 | hash6 [element a] | semmle.label | hash6 [element a] |
 | hash_flow.rb:76:13:76:47 | ...[...] [element a] | semmle.label | ...[...] [element a] |
+| hash_flow.rb:76:18:76:46 | call to [] [element a] | semmle.label | call to [] [element a] |
 | hash_flow.rb:76:26:76:35 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:77:10:77:14 | hash6 [element a] | semmle.label | hash6 [element a] |
 | hash_flow.rb:77:10:77:19 | ...[...] | semmle.label | ...[...] |
@@ -1067,6 +1189,7 @@ nodes
 | hash_flow.rb:85:10:85:14 | hash1 [element :a] | semmle.label | hash1 [element :a] |
 | hash_flow.rb:85:10:85:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:92:5:92:8 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:92:12:95:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
 | hash_flow.rb:93:15:93:24 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:96:5:96:9 | hash2 [element :a] | semmle.label | hash2 [element :a] |
 | hash_flow.rb:96:13:96:34 | call to try_convert [element :a] | semmle.label | call to try_convert [element :a] |
@@ -1093,6 +1216,7 @@ nodes
 | hash_flow.rb:120:10:120:17 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:121:10:121:10 | c | semmle.label | c |
 | hash_flow.rb:127:5:127:8 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:127:12:130:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
 | hash_flow.rb:128:15:128:24 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:131:5:131:8 | hash [element :a] | semmle.label | hash [element :a] |
 | hash_flow.rb:131:18:131:29 | key_or_value | semmle.label | key_or_value |
@@ -1101,6 +1225,7 @@ nodes
 | hash_flow.rb:134:22:134:26 | value | semmle.label | value |
 | hash_flow.rb:136:14:136:18 | value | semmle.label | value |
 | hash_flow.rb:143:5:143:8 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:143:12:146:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
 | hash_flow.rb:144:15:144:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:147:5:147:5 | b [element 1] | semmle.label | b [element 1] |
 | hash_flow.rb:147:9:147:12 | hash [element :a] | semmle.label | hash [element :a] |
@@ -1115,6 +1240,7 @@ nodes
 | hash_flow.rb:152:10:152:10 | c [element 1] | semmle.label | c [element 1] |
 | hash_flow.rb:152:10:152:13 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:169:5:169:8 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:169:12:172:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
 | hash_flow.rb:170:15:170:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:173:5:173:5 | a [element :a] | semmle.label | a [element :a] |
 | hash_flow.rb:173:9:173:12 | hash [element :a] | semmle.label | hash [element :a] |
@@ -1122,12 +1248,14 @@ nodes
 | hash_flow.rb:174:10:174:10 | a [element :a] | semmle.label | a [element :a] |
 | hash_flow.rb:174:10:174:14 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:181:5:181:8 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:181:12:184:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
 | hash_flow.rb:182:15:182:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:185:5:185:5 | a | semmle.label | a |
 | hash_flow.rb:185:9:185:12 | hash [element :a] | semmle.label | hash [element :a] |
 | hash_flow.rb:185:9:185:23 | call to delete | semmle.label | call to delete |
 | hash_flow.rb:186:10:186:10 | a | semmle.label | a |
 | hash_flow.rb:193:5:193:8 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:193:12:196:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
 | hash_flow.rb:194:15:194:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:197:5:197:5 | a [element :a] | semmle.label | a [element :a] |
 | hash_flow.rb:197:9:197:12 | [post] hash [element :a] | semmle.label | [post] hash [element :a] |
@@ -1141,13 +1269,17 @@ nodes
 | hash_flow.rb:202:10:202:17 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:209:5:209:8 | hash [element :a] | semmle.label | hash [element :a] |
 | hash_flow.rb:209:5:209:8 | hash [element :c, element :d] | semmle.label | hash [element :c, element :d] |
+| hash_flow.rb:209:12:216:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:209:12:216:5 | call to [] [element :c, element :d] | semmle.label | call to [] [element :c, element :d] |
 | hash_flow.rb:210:15:210:25 | call to taint | semmle.label | call to taint |
+| hash_flow.rb:212:15:215:9 | call to [] [element :d] | semmle.label | call to [] [element :d] |
 | hash_flow.rb:213:19:213:29 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:217:10:217:13 | hash [element :a] | semmle.label | hash [element :a] |
 | hash_flow.rb:217:10:217:21 | call to dig | semmle.label | call to dig |
 | hash_flow.rb:219:10:219:13 | hash [element :c, element :d] | semmle.label | hash [element :c, element :d] |
 | hash_flow.rb:219:10:219:24 | call to dig | semmle.label | call to dig |
 | hash_flow.rb:226:5:226:8 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:226:12:229:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
 | hash_flow.rb:227:15:227:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:230:5:230:5 | x [element :a] | semmle.label | x [element :a] |
 | hash_flow.rb:230:9:230:12 | hash [element :a] | semmle.label | hash [element :a] |
@@ -1157,6 +1289,7 @@ nodes
 | hash_flow.rb:234:10:234:10 | x [element :a] | semmle.label | x [element :a] |
 | hash_flow.rb:234:10:234:14 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:241:5:241:8 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:241:12:244:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
 | hash_flow.rb:242:15:242:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:245:5:245:5 | x [element :a] | semmle.label | x [element :a] |
 | hash_flow.rb:245:9:245:12 | hash [element :a] | semmle.label | hash [element :a] |
@@ -1164,6 +1297,7 @@ nodes
 | hash_flow.rb:248:10:248:10 | x [element :a] | semmle.label | x [element :a] |
 | hash_flow.rb:248:10:248:14 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:255:5:255:8 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:255:12:258:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
 | hash_flow.rb:256:15:256:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:259:5:259:5 | x [element :a] | semmle.label | x [element :a] |
 | hash_flow.rb:259:9:259:12 | hash [element :a] | semmle.label | hash [element :a] |
@@ -1173,6 +1307,7 @@ nodes
 | hash_flow.rb:263:10:263:10 | x [element :a] | semmle.label | x [element :a] |
 | hash_flow.rb:263:10:263:14 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:270:5:270:8 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:270:12:273:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
 | hash_flow.rb:271:15:271:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:274:5:274:5 | x [element :a] | semmle.label | x [element :a] |
 | hash_flow.rb:274:9:274:12 | hash [element :a] | semmle.label | hash [element :a] |
@@ -1182,6 +1317,7 @@ nodes
 | hash_flow.rb:277:10:277:10 | x [element :a] | semmle.label | x [element :a] |
 | hash_flow.rb:277:10:277:14 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:284:5:284:8 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:284:12:289:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
 | hash_flow.rb:287:15:287:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:290:5:290:5 | x [element :c] | semmle.label | x [element :c] |
 | hash_flow.rb:290:9:290:12 | hash [element :c] | semmle.label | hash [element :c] |
@@ -1190,6 +1326,8 @@ nodes
 | hash_flow.rb:293:10:293:14 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:300:5:300:8 | hash [element :a] | semmle.label | hash [element :a] |
 | hash_flow.rb:300:5:300:8 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:300:12:304:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:300:12:304:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
 | hash_flow.rb:301:15:301:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:303:15:303:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:305:5:305:5 | b | semmle.label | b |
@@ -1221,6 +1359,8 @@ nodes
 | hash_flow.rb:316:10:316:10 | b | semmle.label | b |
 | hash_flow.rb:322:5:322:8 | hash [element :a] | semmle.label | hash [element :a] |
 | hash_flow.rb:322:5:322:8 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:322:12:326:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:322:12:326:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
 | hash_flow.rb:323:15:323:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:325:15:325:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:327:5:327:5 | b [element] | semmle.label | b [element] |
@@ -1246,6 +1386,8 @@ nodes
 | hash_flow.rb:335:10:335:13 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:341:5:341:8 | hash [element :a] | semmle.label | hash [element :a] |
 | hash_flow.rb:341:5:341:8 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:341:12:345:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:341:12:345:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
 | hash_flow.rb:342:15:342:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:344:15:344:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:346:5:346:5 | b [element :a] | semmle.label | b [element :a] |
@@ -1259,6 +1401,8 @@ nodes
 | hash_flow.rb:351:11:351:15 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:357:5:357:8 | hash [element :a] | semmle.label | hash [element :a] |
 | hash_flow.rb:357:5:357:8 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:357:12:361:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:357:12:361:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
 | hash_flow.rb:358:15:358:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:360:15:360:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:362:5:362:8 | [post] hash [element :a] | semmle.label | [post] hash [element :a] |
@@ -1271,6 +1415,8 @@ nodes
 | hash_flow.rb:367:11:367:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:373:5:373:8 | hash [element :a] | semmle.label | hash [element :a] |
 | hash_flow.rb:373:5:373:8 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:373:12:377:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:373:12:377:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
 | hash_flow.rb:374:15:374:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:376:15:376:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:378:5:378:5 | b [element] | semmle.label | b [element] |
@@ -1282,6 +1428,8 @@ nodes
 | hash_flow.rb:379:11:379:14 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:385:5:385:8 | hash [element :a] | semmle.label | hash [element :a] |
 | hash_flow.rb:385:5:385:8 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:385:12:389:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:385:12:389:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
 | hash_flow.rb:386:15:386:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:388:15:388:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:390:5:390:5 | b [element :a] | semmle.label | b [element :a] |
@@ -1299,10 +1447,14 @@ nodes
 | hash_flow.rb:396:11:396:15 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:402:5:402:9 | hash1 [element :a] | semmle.label | hash1 [element :a] |
 | hash_flow.rb:402:5:402:9 | hash1 [element :c] | semmle.label | hash1 [element :c] |
+| hash_flow.rb:402:13:406:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:402:13:406:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
 | hash_flow.rb:403:15:403:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:405:15:405:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:407:5:407:9 | hash2 [element :d] | semmle.label | hash2 [element :d] |
 | hash_flow.rb:407:5:407:9 | hash2 [element :f] | semmle.label | hash2 [element :f] |
+| hash_flow.rb:407:13:411:5 | call to [] [element :d] | semmle.label | call to [] [element :d] |
+| hash_flow.rb:407:13:411:5 | call to [] [element :f] | semmle.label | call to [] [element :f] |
 | hash_flow.rb:408:15:408:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:410:15:410:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:412:5:412:8 | hash [element :a] | semmle.label | hash [element :a] |
@@ -1335,10 +1487,14 @@ nodes
 | hash_flow.rb:422:11:422:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:428:5:428:9 | hash1 [element :a] | semmle.label | hash1 [element :a] |
 | hash_flow.rb:428:5:428:9 | hash1 [element :c] | semmle.label | hash1 [element :c] |
+| hash_flow.rb:428:13:432:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:428:13:432:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
 | hash_flow.rb:429:15:429:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:431:15:431:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:433:5:433:9 | hash2 [element :d] | semmle.label | hash2 [element :d] |
 | hash_flow.rb:433:5:433:9 | hash2 [element :f] | semmle.label | hash2 [element :f] |
+| hash_flow.rb:433:13:437:5 | call to [] [element :d] | semmle.label | call to [] [element :d] |
+| hash_flow.rb:433:13:437:5 | call to [] [element :f] | semmle.label | call to [] [element :f] |
 | hash_flow.rb:434:15:434:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:436:15:436:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:438:5:438:8 | hash [element :a] | semmle.label | hash [element :a] |
@@ -1386,6 +1542,7 @@ nodes
 | hash_flow.rb:455:11:455:15 | hash1 [element :f] | semmle.label | hash1 [element :f] |
 | hash_flow.rb:455:11:455:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:461:5:461:8 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:461:12:464:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
 | hash_flow.rb:462:15:462:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:465:5:465:5 | b [element 1] | semmle.label | b [element 1] |
 | hash_flow.rb:465:9:465:12 | hash [element :a] | semmle.label | hash [element :a] |
@@ -1393,6 +1550,7 @@ nodes
 | hash_flow.rb:467:10:467:10 | b [element 1] | semmle.label | b [element 1] |
 | hash_flow.rb:467:10:467:13 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:473:5:473:8 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:473:12:476:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
 | hash_flow.rb:474:15:474:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:477:5:477:5 | b [element :a] | semmle.label | b [element :a] |
 | hash_flow.rb:477:9:477:12 | hash [element :a] | semmle.label | hash [element :a] |
@@ -1402,6 +1560,7 @@ nodes
 | hash_flow.rb:482:10:482:10 | b [element :a] | semmle.label | b [element :a] |
 | hash_flow.rb:482:10:482:14 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:488:5:488:8 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:488:12:491:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
 | hash_flow.rb:489:15:489:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:492:5:492:5 | b [element :a] | semmle.label | b [element :a] |
 | hash_flow.rb:492:9:492:12 | [post] hash [element :a] | semmle.label | [post] hash [element :a] |
@@ -1415,6 +1574,8 @@ nodes
 | hash_flow.rb:498:10:498:17 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:504:5:504:8 | hash [element :a] | semmle.label | hash [element :a] |
 | hash_flow.rb:504:5:504:8 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:504:12:508:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:504:12:508:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
 | hash_flow.rb:505:15:505:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:507:15:507:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:512:5:512:9 | [post] hash2 [element :a] | semmle.label | [post] hash2 [element :a] |
@@ -1429,6 +1590,8 @@ nodes
 | hash_flow.rb:515:11:515:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:519:5:519:8 | hash [element :a] | semmle.label | hash [element :a] |
 | hash_flow.rb:519:5:519:8 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:519:12:523:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:519:12:523:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
 | hash_flow.rb:520:15:520:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:522:15:522:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:524:5:524:5 | b [element :a] | semmle.label | b [element :a] |
@@ -1442,6 +1605,8 @@ nodes
 | hash_flow.rb:529:11:529:15 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:535:5:535:8 | hash [element :a] | semmle.label | hash [element :a] |
 | hash_flow.rb:535:5:535:8 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:535:12:539:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:535:12:539:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
 | hash_flow.rb:536:15:536:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:538:15:538:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:540:5:540:8 | [post] hash [element :a] | semmle.label | [post] hash [element :a] |
@@ -1454,6 +1619,8 @@ nodes
 | hash_flow.rb:545:11:545:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:551:5:551:8 | hash [element :a] | semmle.label | hash [element :a] |
 | hash_flow.rb:551:5:551:8 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:551:12:555:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:551:12:555:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
 | hash_flow.rb:552:15:552:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:554:15:554:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:556:5:556:5 | b [element 1] | semmle.label | b [element 1] |
@@ -1469,6 +1636,8 @@ nodes
 | hash_flow.rb:559:11:559:14 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:565:5:565:8 | hash [element :a] | semmle.label | hash [element :a] |
 | hash_flow.rb:565:5:565:8 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:565:12:569:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:565:12:569:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
 | hash_flow.rb:566:15:566:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:568:15:568:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:570:5:570:5 | b [element :a] | semmle.label | b [element :a] |
@@ -1491,6 +1660,8 @@ nodes
 | hash_flow.rb:578:11:578:15 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:584:5:584:8 | hash [element :a] | semmle.label | hash [element :a] |
 | hash_flow.rb:584:5:584:8 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:584:12:588:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:584:12:588:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
 | hash_flow.rb:585:15:585:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:587:15:587:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:589:5:589:5 | a [element, element 1] | semmle.label | a [element, element 1] |
@@ -1503,6 +1674,8 @@ nodes
 | hash_flow.rb:591:11:591:17 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:597:5:597:8 | hash [element :a] | semmle.label | hash [element :a] |
 | hash_flow.rb:597:5:597:8 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:597:12:601:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:597:12:601:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
 | hash_flow.rb:598:15:598:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:600:15:600:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:602:5:602:5 | a [element :a] | semmle.label | a [element :a] |
@@ -1523,12 +1696,15 @@ nodes
 | hash_flow.rb:607:9:611:7 | call to to_h [element] | semmle.label | call to to_h [element] |
 | hash_flow.rb:607:28:607:32 | value | semmle.label | value |
 | hash_flow.rb:609:14:609:18 | value | semmle.label | value |
+| hash_flow.rb:610:9:610:25 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | hash_flow.rb:610:14:610:24 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:612:10:612:16 | ( ... ) | semmle.label | ( ... ) |
 | hash_flow.rb:612:11:612:11 | b [element] | semmle.label | b [element] |
 | hash_flow.rb:612:11:612:15 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:618:5:618:8 | hash [element :a] | semmle.label | hash [element :a] |
 | hash_flow.rb:618:5:618:8 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:618:12:622:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:618:12:622:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
 | hash_flow.rb:619:15:619:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:621:15:621:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:623:5:623:5 | a [element] | semmle.label | a [element] |
@@ -1546,6 +1722,8 @@ nodes
 | hash_flow.rb:626:11:626:16 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:632:5:632:8 | hash [element :a] | semmle.label | hash [element :a] |
 | hash_flow.rb:632:5:632:8 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:632:12:636:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:632:12:636:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
 | hash_flow.rb:633:15:633:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:635:15:635:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:637:5:637:8 | [post] hash [element] | semmle.label | [post] hash [element] |
@@ -1565,6 +1743,8 @@ nodes
 | hash_flow.rb:642:11:642:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:648:5:648:8 | hash [element :a] | semmle.label | hash [element :a] |
 | hash_flow.rb:648:5:648:8 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:648:12:652:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:648:12:652:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
 | hash_flow.rb:649:15:649:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:651:15:651:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:653:5:653:5 | b [element] | semmle.label | b [element] |
@@ -1582,6 +1762,8 @@ nodes
 | hash_flow.rb:658:11:658:15 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:664:5:664:8 | hash [element :a] | semmle.label | hash [element :a] |
 | hash_flow.rb:664:5:664:8 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:664:12:668:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:664:12:668:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
 | hash_flow.rb:665:15:665:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:667:15:667:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:669:5:669:8 | [post] hash [element] | semmle.label | [post] hash [element] |
@@ -1595,10 +1777,14 @@ nodes
 | hash_flow.rb:673:11:673:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:679:5:679:9 | hash1 [element :a] | semmle.label | hash1 [element :a] |
 | hash_flow.rb:679:5:679:9 | hash1 [element :c] | semmle.label | hash1 [element :c] |
+| hash_flow.rb:679:13:683:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:679:13:683:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
 | hash_flow.rb:680:15:680:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:682:15:682:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:684:5:684:9 | hash2 [element :d] | semmle.label | hash2 [element :d] |
 | hash_flow.rb:684:5:684:9 | hash2 [element :f] | semmle.label | hash2 [element :f] |
+| hash_flow.rb:684:13:688:5 | call to [] [element :d] | semmle.label | call to [] [element :d] |
+| hash_flow.rb:684:13:688:5 | call to [] [element :f] | semmle.label | call to [] [element :f] |
 | hash_flow.rb:685:15:685:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:687:15:687:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:689:5:689:8 | hash [element :a] | semmle.label | hash [element :a] |
@@ -1647,6 +1833,8 @@ nodes
 | hash_flow.rb:706:11:706:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:712:5:712:8 | hash [element :a] | semmle.label | hash [element :a] |
 | hash_flow.rb:712:5:712:8 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:712:12:716:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:712:12:716:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
 | hash_flow.rb:713:15:713:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:715:15:715:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:717:5:717:5 | a [element] | semmle.label | a [element] |
@@ -1658,6 +1846,8 @@ nodes
 | hash_flow.rb:718:11:718:14 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:724:5:724:8 | hash [element :a] | semmle.label | hash [element :a] |
 | hash_flow.rb:724:5:724:8 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:724:12:728:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:724:12:728:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
 | hash_flow.rb:725:15:725:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:727:15:727:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:729:5:729:5 | b [element 0] | semmle.label | b [element 0] |
@@ -1673,10 +1863,14 @@ nodes
 | hash_flow.rb:732:10:732:13 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:738:5:738:9 | hash1 [element :a] | semmle.label | hash1 [element :a] |
 | hash_flow.rb:738:5:738:9 | hash1 [element :c] | semmle.label | hash1 [element :c] |
+| hash_flow.rb:738:13:742:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:738:13:742:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
 | hash_flow.rb:739:15:739:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:741:15:741:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:743:5:743:9 | hash2 [element :d] | semmle.label | hash2 [element :d] |
 | hash_flow.rb:743:5:743:9 | hash2 [element :f] | semmle.label | hash2 [element :f] |
+| hash_flow.rb:743:13:747:5 | call to [] [element :d] | semmle.label | call to [] [element :d] |
+| hash_flow.rb:743:13:747:5 | call to [] [element :f] | semmle.label | call to [] [element :f] |
 | hash_flow.rb:744:15:744:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:746:15:746:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:748:5:748:8 | hash [element :a] | semmle.label | hash [element :a] |
@@ -1684,6 +1878,11 @@ nodes
 | hash_flow.rb:748:5:748:8 | hash [element :d] | semmle.label | hash [element :d] |
 | hash_flow.rb:748:5:748:8 | hash [element :f] | semmle.label | hash [element :f] |
 | hash_flow.rb:748:5:748:8 | hash [element :g] | semmle.label | hash [element :g] |
+| hash_flow.rb:748:12:748:59 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:748:12:748:59 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:748:12:748:59 | call to [] [element :d] | semmle.label | call to [] [element :d] |
+| hash_flow.rb:748:12:748:59 | call to [] [element :f] | semmle.label | call to [] [element :f] |
+| hash_flow.rb:748:12:748:59 | call to [] [element :g] | semmle.label | call to [] [element :g] |
 | hash_flow.rb:748:14:748:20 | ** ... [element :a] | semmle.label | ** ... [element :a] |
 | hash_flow.rb:748:14:748:20 | ** ... [element :c] | semmle.label | ** ... [element :c] |
 | hash_flow.rb:748:16:748:20 | hash1 [element :a] | semmle.label | hash1 [element :a] |
@@ -1706,6 +1905,9 @@ nodes
 | hash_flow.rb:762:5:762:8 | hash [element :a] | semmle.label | hash [element :a] |
 | hash_flow.rb:762:5:762:8 | hash [element :c] | semmle.label | hash [element :c] |
 | hash_flow.rb:762:5:762:8 | hash [element :d] | semmle.label | hash [element :d] |
+| hash_flow.rb:762:12:767:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:762:12:767:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:762:12:767:5 | call to [] [element :d] | semmle.label | call to [] [element :d] |
 | hash_flow.rb:763:15:763:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:765:15:765:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:766:15:766:25 | call to taint | semmle.label | call to taint |
@@ -1725,10 +1927,14 @@ nodes
 | hash_flow.rb:783:10:783:17 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:790:5:790:9 | hash1 [element :a] | semmle.label | hash1 [element :a] |
 | hash_flow.rb:790:5:790:9 | hash1 [element :c] | semmle.label | hash1 [element :c] |
+| hash_flow.rb:790:13:794:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:790:13:794:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
 | hash_flow.rb:791:15:791:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:793:15:793:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:795:5:795:9 | hash2 [element :d] | semmle.label | hash2 [element :d] |
 | hash_flow.rb:795:5:795:9 | hash2 [element :f] | semmle.label | hash2 [element :f] |
+| hash_flow.rb:795:13:799:5 | call to [] [element :d] | semmle.label | call to [] [element :d] |
+| hash_flow.rb:795:13:799:5 | call to [] [element :f] | semmle.label | call to [] [element :f] |
 | hash_flow.rb:796:15:796:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:798:15:798:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:800:5:800:8 | hash [element :a] | semmle.label | hash [element :a] |
@@ -1761,10 +1967,14 @@ nodes
 | hash_flow.rb:810:11:810:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:816:5:816:9 | hash1 [element :a] | semmle.label | hash1 [element :a] |
 | hash_flow.rb:816:5:816:9 | hash1 [element :c] | semmle.label | hash1 [element :c] |
+| hash_flow.rb:816:13:820:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:816:13:820:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
 | hash_flow.rb:817:15:817:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:819:15:819:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:821:5:821:9 | hash2 [element :d] | semmle.label | hash2 [element :d] |
 | hash_flow.rb:821:5:821:9 | hash2 [element :f] | semmle.label | hash2 [element :f] |
+| hash_flow.rb:821:13:825:5 | call to [] [element :d] | semmle.label | call to [] [element :d] |
+| hash_flow.rb:821:13:825:5 | call to [] [element :f] | semmle.label | call to [] [element :f] |
 | hash_flow.rb:822:15:822:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:824:15:824:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:826:5:826:8 | hash [element :a] | semmle.label | hash [element :a] |
@@ -1813,10 +2023,14 @@ nodes
 | hash_flow.rb:843:11:843:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:849:5:849:9 | hash1 [element :a] | semmle.label | hash1 [element :a] |
 | hash_flow.rb:849:5:849:9 | hash1 [element :c] | semmle.label | hash1 [element :c] |
+| hash_flow.rb:849:13:853:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:849:13:853:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
 | hash_flow.rb:850:12:850:22 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:852:12:852:22 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:854:5:854:9 | hash2 [element :d] | semmle.label | hash2 [element :d] |
 | hash_flow.rb:854:5:854:9 | hash2 [element :f] | semmle.label | hash2 [element :f] |
+| hash_flow.rb:854:13:858:5 | call to [] [element :d] | semmle.label | call to [] [element :d] |
+| hash_flow.rb:854:13:858:5 | call to [] [element :f] | semmle.label | call to [] [element :f] |
 | hash_flow.rb:855:12:855:22 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:857:12:857:22 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:860:5:860:9 | hash3 [element :a] | semmle.label | hash3 [element :a] |
@@ -1869,10 +2083,14 @@ nodes
 | hash_flow.rb:875:11:875:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:881:5:881:9 | hash1 [element :a] | semmle.label | hash1 [element :a] |
 | hash_flow.rb:881:5:881:9 | hash1 [element :c] | semmle.label | hash1 [element :c] |
+| hash_flow.rb:881:13:885:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:881:13:885:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
 | hash_flow.rb:882:12:882:22 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:884:12:884:22 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:886:5:886:9 | hash2 [element :d] | semmle.label | hash2 [element :d] |
 | hash_flow.rb:886:5:886:9 | hash2 [element :f] | semmle.label | hash2 [element :f] |
+| hash_flow.rb:886:13:890:5 | call to [] [element :d] | semmle.label | call to [] [element :d] |
+| hash_flow.rb:886:13:890:5 | call to [] [element :f] | semmle.label | call to [] [element :f] |
 | hash_flow.rb:887:12:887:22 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:889:12:889:22 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:892:5:892:8 | hash [element :a] | semmle.label | hash [element :a] |
@@ -1917,10 +2135,14 @@ nodes
 | hash_flow.rb:905:11:905:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:911:5:911:9 | hash1 [element :a] | semmle.label | hash1 [element :a] |
 | hash_flow.rb:911:5:911:9 | hash1 [element :c] | semmle.label | hash1 [element :c] |
+| hash_flow.rb:911:13:915:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:911:13:915:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
 | hash_flow.rb:912:12:912:22 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:914:12:914:22 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:916:5:916:9 | hash2 [element :d] | semmle.label | hash2 [element :d] |
 | hash_flow.rb:916:5:916:9 | hash2 [element :f] | semmle.label | hash2 [element :f] |
+| hash_flow.rb:916:13:920:5 | call to [] [element :d] | semmle.label | call to [] [element :d] |
+| hash_flow.rb:916:13:920:5 | call to [] [element :f] | semmle.label | call to [] [element :f] |
 | hash_flow.rb:917:12:917:22 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:919:12:919:22 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:922:5:922:8 | hash [element :a] | semmle.label | hash [element :a] |
@@ -1965,10 +2187,14 @@ nodes
 | hash_flow.rb:935:11:935:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:941:5:941:9 | hash1 [element :a] | semmle.label | hash1 [element :a] |
 | hash_flow.rb:941:5:941:9 | hash1 [element :c] | semmle.label | hash1 [element :c] |
+| hash_flow.rb:941:13:945:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:941:13:945:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
 | hash_flow.rb:942:12:942:22 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:944:12:944:22 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:946:5:946:9 | hash2 [element :d] | semmle.label | hash2 [element :d] |
 | hash_flow.rb:946:5:946:9 | hash2 [element :f] | semmle.label | hash2 [element :f] |
+| hash_flow.rb:946:13:950:5 | call to [] [element :d] | semmle.label | call to [] [element :d] |
+| hash_flow.rb:946:13:950:5 | call to [] [element :f] | semmle.label | call to [] [element :f] |
 | hash_flow.rb:947:12:947:22 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:949:12:949:22 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:952:5:952:8 | hash [element :a] | semmle.label | hash [element :a] |

--- a/ruby/ql/test/library-tests/dataflow/params/params-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/params/params-flow.expected
@@ -27,32 +27,39 @@ edges
 | params_flow.rb:33:26:33:34 | call to taint | params_flow.rb:25:17:25:24 | **kwargs [hash-splat position :p2] | provenance |  |
 | params_flow.rb:33:41:33:49 | call to taint | params_flow.rb:25:17:25:24 | **kwargs [hash-splat position :p3] | provenance |  |
 | params_flow.rb:34:1:34:4 | args [element :p3] | params_flow.rb:35:25:35:28 | args [element :p3] | provenance |  |
-| params_flow.rb:34:14:34:22 | call to taint | params_flow.rb:34:1:34:4 | args [element :p3] | provenance |  |
+| params_flow.rb:34:8:34:32 | call to [] [element :p3] | params_flow.rb:34:1:34:4 | args [element :p3] | provenance |  |
+| params_flow.rb:34:14:34:22 | call to taint | params_flow.rb:34:8:34:32 | call to [] [element :p3] | provenance |  |
 | params_flow.rb:35:12:35:20 | call to taint | params_flow.rb:25:12:25:13 | p1 | provenance |  |
 | params_flow.rb:35:23:35:28 | ** ... [element :p3] | params_flow.rb:25:17:25:24 | **kwargs [element :p3] | provenance |  |
 | params_flow.rb:35:25:35:28 | args [element :p3] | params_flow.rb:35:23:35:28 | ** ... [element :p3] | provenance |  |
 | params_flow.rb:37:1:37:4 | args [element :p1] | params_flow.rb:38:10:38:13 | args [element :p1] | provenance |  |
 | params_flow.rb:37:1:37:4 | args [element :p2] | params_flow.rb:38:10:38:13 | args [element :p2] | provenance |  |
-| params_flow.rb:37:16:37:24 | call to taint | params_flow.rb:37:1:37:4 | args [element :p1] | provenance |  |
-| params_flow.rb:37:34:37:42 | call to taint | params_flow.rb:37:1:37:4 | args [element :p2] | provenance |  |
+| params_flow.rb:37:8:37:44 | call to [] [element :p1] | params_flow.rb:37:1:37:4 | args [element :p1] | provenance |  |
+| params_flow.rb:37:8:37:44 | call to [] [element :p2] | params_flow.rb:37:1:37:4 | args [element :p2] | provenance |  |
+| params_flow.rb:37:16:37:24 | call to taint | params_flow.rb:37:8:37:44 | call to [] [element :p1] | provenance |  |
+| params_flow.rb:37:34:37:42 | call to taint | params_flow.rb:37:8:37:44 | call to [] [element :p2] | provenance |  |
 | params_flow.rb:38:8:38:13 | ** ... [element :p1] | params_flow.rb:25:12:25:13 | p1 | provenance |  |
 | params_flow.rb:38:8:38:13 | ** ... [element :p2] | params_flow.rb:25:17:25:24 | **kwargs [element :p2] | provenance |  |
 | params_flow.rb:38:10:38:13 | args [element :p1] | params_flow.rb:38:8:38:13 | ** ... [element :p1] | provenance |  |
 | params_flow.rb:38:10:38:13 | args [element :p2] | params_flow.rb:38:8:38:13 | ** ... [element :p2] | provenance |  |
 | params_flow.rb:40:1:40:4 | args [element :p1] | params_flow.rb:41:26:41:29 | args [element :p1] | provenance |  |
-| params_flow.rb:40:16:40:24 | call to taint | params_flow.rb:40:1:40:4 | args [element :p1] | provenance |  |
+| params_flow.rb:40:8:40:26 | call to [] [element :p1] | params_flow.rb:40:1:40:4 | args [element :p1] | provenance |  |
+| params_flow.rb:40:16:40:24 | call to taint | params_flow.rb:40:8:40:26 | call to [] [element :p1] | provenance |  |
 | params_flow.rb:41:13:41:21 | call to taint | params_flow.rb:16:18:16:19 | p2 | provenance |  |
 | params_flow.rb:41:24:41:29 | ** ... [element :p1] | params_flow.rb:16:13:16:14 | p1 | provenance |  |
 | params_flow.rb:41:26:41:29 | args [element :p1] | params_flow.rb:41:24:41:29 | ** ... [element :p1] | provenance |  |
 | params_flow.rb:43:1:43:4 | args [element 0] | params_flow.rb:44:24:44:27 | args [element 0] | provenance |  |
-| params_flow.rb:43:9:43:17 | call to taint | params_flow.rb:43:1:43:4 | args [element 0] | provenance |  |
+| params_flow.rb:43:8:43:18 | call to [] [element 0] | params_flow.rb:43:1:43:4 | args [element 0] | provenance |  |
+| params_flow.rb:43:9:43:17 | call to taint | params_flow.rb:43:8:43:18 | call to [] [element 0] | provenance |  |
 | params_flow.rb:44:12:44:20 | call to taint | params_flow.rb:9:16:9:17 | p1 | provenance |  |
 | params_flow.rb:44:23:44:27 | * ... [element 0] | params_flow.rb:9:20:9:21 | p2 | provenance |  |
 | params_flow.rb:44:24:44:27 | args [element 0] | params_flow.rb:44:23:44:27 | * ... [element 0] | provenance |  |
 | params_flow.rb:46:1:46:4 | args [element 0] | params_flow.rb:47:13:47:16 | args [element 0] | provenance |  |
 | params_flow.rb:46:1:46:4 | args [element 1] | params_flow.rb:47:13:47:16 | args [element 1] | provenance |  |
-| params_flow.rb:46:9:46:17 | call to taint | params_flow.rb:46:1:46:4 | args [element 0] | provenance |  |
-| params_flow.rb:46:20:46:28 | call to taint | params_flow.rb:46:1:46:4 | args [element 1] | provenance |  |
+| params_flow.rb:46:8:46:29 | call to [] [element 0] | params_flow.rb:46:1:46:4 | args [element 0] | provenance |  |
+| params_flow.rb:46:8:46:29 | call to [] [element 1] | params_flow.rb:46:1:46:4 | args [element 1] | provenance |  |
+| params_flow.rb:46:9:46:17 | call to taint | params_flow.rb:46:8:46:29 | call to [] [element 0] | provenance |  |
+| params_flow.rb:46:20:46:28 | call to taint | params_flow.rb:46:8:46:29 | call to [] [element 1] | provenance |  |
 | params_flow.rb:47:12:47:16 | * ... [element 0] | params_flow.rb:9:16:9:17 | p1 | provenance |  |
 | params_flow.rb:47:12:47:16 | * ... [element 1] | params_flow.rb:9:20:9:21 | p2 | provenance |  |
 | params_flow.rb:47:13:47:16 | args [element 0] | params_flow.rb:47:12:47:16 | * ... [element 0] | provenance |  |
@@ -66,15 +73,18 @@ edges
 | params_flow.rb:55:9:55:17 | call to taint | params_flow.rb:49:13:49:14 | p1 | provenance |  |
 | params_flow.rb:55:20:55:28 | call to taint | params_flow.rb:49:17:49:24 | *posargs [element 0] | provenance |  |
 | params_flow.rb:57:1:57:4 | args [element 0] | params_flow.rb:58:21:58:24 | args [element 0] | provenance |  |
-| params_flow.rb:57:9:57:17 | call to taint | params_flow.rb:57:1:57:4 | args [element 0] | provenance |  |
+| params_flow.rb:57:8:57:18 | call to [] [element 0] | params_flow.rb:57:1:57:4 | args [element 0] | provenance |  |
+| params_flow.rb:57:9:57:17 | call to taint | params_flow.rb:57:8:57:18 | call to [] [element 0] | provenance |  |
 | params_flow.rb:58:9:58:17 | call to taint | params_flow.rb:49:13:49:14 | p1 | provenance |  |
 | params_flow.rb:58:20:58:24 | * ... [element 0] | params_flow.rb:49:17:49:24 | *posargs [element 0] | provenance |  |
 | params_flow.rb:58:20:58:24 | * ... [element 0] | params_flow.rb:49:17:49:24 | *posargs [element 0] | provenance |  |
 | params_flow.rb:58:21:58:24 | args [element 0] | params_flow.rb:58:20:58:24 | * ... [element 0] | provenance |  |
 | params_flow.rb:60:1:60:4 | args [element 0] | params_flow.rb:61:10:61:13 | args [element 0] | provenance |  |
 | params_flow.rb:60:1:60:4 | args [element 1] | params_flow.rb:61:10:61:13 | args [element 1] | provenance |  |
-| params_flow.rb:60:9:60:17 | call to taint | params_flow.rb:60:1:60:4 | args [element 0] | provenance |  |
-| params_flow.rb:60:20:60:28 | call to taint | params_flow.rb:60:1:60:4 | args [element 1] | provenance |  |
+| params_flow.rb:60:8:60:29 | call to [] [element 0] | params_flow.rb:60:1:60:4 | args [element 0] | provenance |  |
+| params_flow.rb:60:8:60:29 | call to [] [element 1] | params_flow.rb:60:1:60:4 | args [element 1] | provenance |  |
+| params_flow.rb:60:9:60:17 | call to taint | params_flow.rb:60:8:60:29 | call to [] [element 0] | provenance |  |
+| params_flow.rb:60:20:60:28 | call to taint | params_flow.rb:60:8:60:29 | call to [] [element 1] | provenance |  |
 | params_flow.rb:61:9:61:13 | * ... [element 0] | params_flow.rb:49:13:49:14 | p1 | provenance |  |
 | params_flow.rb:61:9:61:13 | * ... [element 1] | params_flow.rb:49:17:49:24 | *posargs [element 0] | provenance |  |
 | params_flow.rb:61:10:61:13 | args [element 0] | params_flow.rb:61:9:61:13 | * ... [element 0] | provenance |  |
@@ -94,7 +104,8 @@ edges
 | params_flow.rb:78:43:78:51 | call to taint | params_flow.rb:69:24:69:24 | w | provenance |  |
 | params_flow.rb:78:54:78:62 | call to taint | params_flow.rb:69:27:69:27 | r | provenance |  |
 | params_flow.rb:80:1:80:4 | args [element 0] | params_flow.rb:81:22:81:25 | args [element 0] | provenance |  |
-| params_flow.rb:80:9:80:17 | call to taint | params_flow.rb:80:1:80:4 | args [element 0] | provenance |  |
+| params_flow.rb:80:8:80:51 | call to [] [element 0] | params_flow.rb:80:1:80:4 | args [element 0] | provenance |  |
+| params_flow.rb:80:9:80:17 | call to taint | params_flow.rb:80:8:80:51 | call to [] [element 0] | provenance |  |
 | params_flow.rb:81:10:81:18 | call to taint | params_flow.rb:69:14:69:14 | x | provenance |  |
 | params_flow.rb:81:21:81:25 | * ... [element 0] | params_flow.rb:69:17:69:17 | y | provenance |  |
 | params_flow.rb:81:22:81:25 | args [element 0] | params_flow.rb:81:21:81:25 | * ... [element 0] | provenance |  |
@@ -108,10 +119,14 @@ edges
 | params_flow.rb:93:1:93:4 | args [element 1] | params_flow.rb:94:33:94:36 | args [element 1] | provenance |  |
 | params_flow.rb:93:1:93:4 | args [element 2] | params_flow.rb:94:33:94:36 | args [element 2] | provenance |  |
 | params_flow.rb:93:1:93:4 | args [element 3] | params_flow.rb:94:33:94:36 | args [element 3] | provenance |  |
-| params_flow.rb:93:9:93:17 | call to taint | params_flow.rb:93:1:93:4 | args [element 0] | provenance |  |
-| params_flow.rb:93:20:93:28 | call to taint | params_flow.rb:93:1:93:4 | args [element 1] | provenance |  |
-| params_flow.rb:93:31:93:39 | call to taint | params_flow.rb:93:1:93:4 | args [element 2] | provenance |  |
-| params_flow.rb:93:42:93:50 | call to taint | params_flow.rb:93:1:93:4 | args [element 3] | provenance |  |
+| params_flow.rb:93:8:93:51 | call to [] [element 0] | params_flow.rb:93:1:93:4 | args [element 0] | provenance |  |
+| params_flow.rb:93:8:93:51 | call to [] [element 1] | params_flow.rb:93:1:93:4 | args [element 1] | provenance |  |
+| params_flow.rb:93:8:93:51 | call to [] [element 2] | params_flow.rb:93:1:93:4 | args [element 2] | provenance |  |
+| params_flow.rb:93:8:93:51 | call to [] [element 3] | params_flow.rb:93:1:93:4 | args [element 3] | provenance |  |
+| params_flow.rb:93:9:93:17 | call to taint | params_flow.rb:93:8:93:51 | call to [] [element 0] | provenance |  |
+| params_flow.rb:93:20:93:28 | call to taint | params_flow.rb:93:8:93:51 | call to [] [element 1] | provenance |  |
+| params_flow.rb:93:31:93:39 | call to taint | params_flow.rb:93:8:93:51 | call to [] [element 2] | provenance |  |
+| params_flow.rb:93:42:93:50 | call to taint | params_flow.rb:93:8:93:51 | call to [] [element 3] | provenance |  |
 | params_flow.rb:94:10:94:18 | call to taint | params_flow.rb:83:14:83:14 | t | provenance |  |
 | params_flow.rb:94:21:94:29 | call to taint | params_flow.rb:83:17:83:17 | u | provenance |  |
 | params_flow.rb:94:32:94:36 | * ... [element 0] | params_flow.rb:83:20:83:20 | v | provenance |  |
@@ -146,8 +161,10 @@ edges
 | params_flow.rb:118:13:118:13 | x [element] | params_flow.rb:118:12:118:13 | * ... [element] | provenance |  |
 | params_flow.rb:130:1:130:4 | args [element 0] | params_flow.rb:131:11:131:14 | args [element 0] | provenance |  |
 | params_flow.rb:130:1:130:4 | args [element 1] | params_flow.rb:131:11:131:14 | args [element 1] | provenance |  |
-| params_flow.rb:130:9:130:17 | call to taint | params_flow.rb:130:1:130:4 | args [element 0] | provenance |  |
-| params_flow.rb:130:20:130:28 | call to taint | params_flow.rb:130:1:130:4 | args [element 1] | provenance |  |
+| params_flow.rb:130:8:130:29 | call to [] [element 0] | params_flow.rb:130:1:130:4 | args [element 0] | provenance |  |
+| params_flow.rb:130:8:130:29 | call to [] [element 1] | params_flow.rb:130:1:130:4 | args [element 1] | provenance |  |
+| params_flow.rb:130:9:130:17 | call to taint | params_flow.rb:130:8:130:29 | call to [] [element 0] | provenance |  |
+| params_flow.rb:130:20:130:28 | call to taint | params_flow.rb:130:8:130:29 | call to [] [element 1] | provenance |  |
 | params_flow.rb:131:10:131:14 | * ... [element 0] | params_flow.rb:83:14:83:14 | t | provenance |  |
 | params_flow.rb:131:10:131:14 | * ... [element 1] | params_flow.rb:83:17:83:17 | u | provenance |  |
 | params_flow.rb:131:11:131:14 | args [element 0] | params_flow.rb:131:10:131:14 | * ... [element 0] | provenance |  |
@@ -156,7 +173,8 @@ edges
 | params_flow.rb:133:14:133:18 | *args [element 1] | params_flow.rb:134:10:134:13 | args [element 1] | provenance |  |
 | params_flow.rb:134:10:134:13 | args [element 1] | params_flow.rb:134:10:134:16 | ...[...] | provenance |  |
 | params_flow.rb:137:10:137:43 | * ... [element 1] | params_flow.rb:133:14:133:18 | *args [element 1] | provenance |  |
-| params_flow.rb:137:23:137:31 | call to taint | params_flow.rb:137:10:137:43 | * ... [element 1] | provenance |  |
+| params_flow.rb:137:11:137:43 | call to [] [element 1] | params_flow.rb:137:10:137:43 | * ... [element 1] | provenance |  |
+| params_flow.rb:137:23:137:31 | call to taint | params_flow.rb:137:11:137:43 | call to [] [element 1] | provenance |  |
 | params_flow.rb:153:28:153:29 | p2 | params_flow.rb:154:18:154:19 | p2 | provenance |  |
 | params_flow.rb:154:18:154:19 | p2 | params_flow.rb:154:5:154:6 | [post] p1 [element 0] | provenance |  |
 | params_flow.rb:164:23:164:24 | [post] p1 [element 0] | params_flow.rb:165:6:165:7 | p1 [element 0] | provenance |  |
@@ -204,12 +222,15 @@ nodes
 | params_flow.rb:33:26:33:34 | call to taint | semmle.label | call to taint |
 | params_flow.rb:33:41:33:49 | call to taint | semmle.label | call to taint |
 | params_flow.rb:34:1:34:4 | args [element :p3] | semmle.label | args [element :p3] |
+| params_flow.rb:34:8:34:32 | call to [] [element :p3] | semmle.label | call to [] [element :p3] |
 | params_flow.rb:34:14:34:22 | call to taint | semmle.label | call to taint |
 | params_flow.rb:35:12:35:20 | call to taint | semmle.label | call to taint |
 | params_flow.rb:35:23:35:28 | ** ... [element :p3] | semmle.label | ** ... [element :p3] |
 | params_flow.rb:35:25:35:28 | args [element :p3] | semmle.label | args [element :p3] |
 | params_flow.rb:37:1:37:4 | args [element :p1] | semmle.label | args [element :p1] |
 | params_flow.rb:37:1:37:4 | args [element :p2] | semmle.label | args [element :p2] |
+| params_flow.rb:37:8:37:44 | call to [] [element :p1] | semmle.label | call to [] [element :p1] |
+| params_flow.rb:37:8:37:44 | call to [] [element :p2] | semmle.label | call to [] [element :p2] |
 | params_flow.rb:37:16:37:24 | call to taint | semmle.label | call to taint |
 | params_flow.rb:37:34:37:42 | call to taint | semmle.label | call to taint |
 | params_flow.rb:38:8:38:13 | ** ... [element :p1] | semmle.label | ** ... [element :p1] |
@@ -217,17 +238,21 @@ nodes
 | params_flow.rb:38:10:38:13 | args [element :p1] | semmle.label | args [element :p1] |
 | params_flow.rb:38:10:38:13 | args [element :p2] | semmle.label | args [element :p2] |
 | params_flow.rb:40:1:40:4 | args [element :p1] | semmle.label | args [element :p1] |
+| params_flow.rb:40:8:40:26 | call to [] [element :p1] | semmle.label | call to [] [element :p1] |
 | params_flow.rb:40:16:40:24 | call to taint | semmle.label | call to taint |
 | params_flow.rb:41:13:41:21 | call to taint | semmle.label | call to taint |
 | params_flow.rb:41:24:41:29 | ** ... [element :p1] | semmle.label | ** ... [element :p1] |
 | params_flow.rb:41:26:41:29 | args [element :p1] | semmle.label | args [element :p1] |
 | params_flow.rb:43:1:43:4 | args [element 0] | semmle.label | args [element 0] |
+| params_flow.rb:43:8:43:18 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | params_flow.rb:43:9:43:17 | call to taint | semmle.label | call to taint |
 | params_flow.rb:44:12:44:20 | call to taint | semmle.label | call to taint |
 | params_flow.rb:44:23:44:27 | * ... [element 0] | semmle.label | * ... [element 0] |
 | params_flow.rb:44:24:44:27 | args [element 0] | semmle.label | args [element 0] |
 | params_flow.rb:46:1:46:4 | args [element 0] | semmle.label | args [element 0] |
 | params_flow.rb:46:1:46:4 | args [element 1] | semmle.label | args [element 1] |
+| params_flow.rb:46:8:46:29 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| params_flow.rb:46:8:46:29 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | params_flow.rb:46:9:46:17 | call to taint | semmle.label | call to taint |
 | params_flow.rb:46:20:46:28 | call to taint | semmle.label | call to taint |
 | params_flow.rb:47:12:47:16 | * ... [element 0] | semmle.label | * ... [element 0] |
@@ -245,12 +270,15 @@ nodes
 | params_flow.rb:55:9:55:17 | call to taint | semmle.label | call to taint |
 | params_flow.rb:55:20:55:28 | call to taint | semmle.label | call to taint |
 | params_flow.rb:57:1:57:4 | args [element 0] | semmle.label | args [element 0] |
+| params_flow.rb:57:8:57:18 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | params_flow.rb:57:9:57:17 | call to taint | semmle.label | call to taint |
 | params_flow.rb:58:9:58:17 | call to taint | semmle.label | call to taint |
 | params_flow.rb:58:20:58:24 | * ... [element 0] | semmle.label | * ... [element 0] |
 | params_flow.rb:58:21:58:24 | args [element 0] | semmle.label | args [element 0] |
 | params_flow.rb:60:1:60:4 | args [element 0] | semmle.label | args [element 0] |
 | params_flow.rb:60:1:60:4 | args [element 1] | semmle.label | args [element 1] |
+| params_flow.rb:60:8:60:29 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| params_flow.rb:60:8:60:29 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | params_flow.rb:60:9:60:17 | call to taint | semmle.label | call to taint |
 | params_flow.rb:60:20:60:28 | call to taint | semmle.label | call to taint |
 | params_flow.rb:61:9:61:13 | * ... [element 0] | semmle.label | * ... [element 0] |
@@ -277,6 +305,7 @@ nodes
 | params_flow.rb:78:43:78:51 | call to taint | semmle.label | call to taint |
 | params_flow.rb:78:54:78:62 | call to taint | semmle.label | call to taint |
 | params_flow.rb:80:1:80:4 | args [element 0] | semmle.label | args [element 0] |
+| params_flow.rb:80:8:80:51 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | params_flow.rb:80:9:80:17 | call to taint | semmle.label | call to taint |
 | params_flow.rb:81:10:81:18 | call to taint | semmle.label | call to taint |
 | params_flow.rb:81:21:81:25 | * ... [element 0] | semmle.label | * ... [element 0] |
@@ -297,6 +326,10 @@ nodes
 | params_flow.rb:93:1:93:4 | args [element 1] | semmle.label | args [element 1] |
 | params_flow.rb:93:1:93:4 | args [element 2] | semmle.label | args [element 2] |
 | params_flow.rb:93:1:93:4 | args [element 3] | semmle.label | args [element 3] |
+| params_flow.rb:93:8:93:51 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| params_flow.rb:93:8:93:51 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| params_flow.rb:93:8:93:51 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| params_flow.rb:93:8:93:51 | call to [] [element 3] | semmle.label | call to [] [element 3] |
 | params_flow.rb:93:9:93:17 | call to taint | semmle.label | call to taint |
 | params_flow.rb:93:20:93:28 | call to taint | semmle.label | call to taint |
 | params_flow.rb:93:31:93:39 | call to taint | semmle.label | call to taint |
@@ -339,6 +372,8 @@ nodes
 | params_flow.rb:118:13:118:13 | x [element] | semmle.label | x [element] |
 | params_flow.rb:130:1:130:4 | args [element 0] | semmle.label | args [element 0] |
 | params_flow.rb:130:1:130:4 | args [element 1] | semmle.label | args [element 1] |
+| params_flow.rb:130:8:130:29 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| params_flow.rb:130:8:130:29 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | params_flow.rb:130:9:130:17 | call to taint | semmle.label | call to taint |
 | params_flow.rb:130:20:130:28 | call to taint | semmle.label | call to taint |
 | params_flow.rb:131:10:131:14 | * ... [element 0] | semmle.label | * ... [element 0] |
@@ -350,6 +385,7 @@ nodes
 | params_flow.rb:134:10:134:13 | args [element 1] | semmle.label | args [element 1] |
 | params_flow.rb:134:10:134:16 | ...[...] | semmle.label | ...[...] |
 | params_flow.rb:137:10:137:43 | * ... [element 1] | semmle.label | * ... [element 1] |
+| params_flow.rb:137:11:137:43 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | params_flow.rb:137:23:137:31 | call to taint | semmle.label | call to taint |
 | params_flow.rb:153:28:153:29 | p2 | semmle.label | p2 |
 | params_flow.rb:154:5:154:6 | [post] p1 [element 0] | semmle.label | [post] p1 [element 0] |

--- a/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
+++ b/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
@@ -93,7 +93,8 @@ edges
 | summaries.rb:48:24:48:41 | call to source | summaries.rb:48:8:48:42 | call to preserveTaint | provenance |  |
 | summaries.rb:51:24:51:30 | tainted | summaries.rb:51:6:51:31 | call to namedArg | provenance |  |
 | summaries.rb:53:1:53:4 | args [element :foo] | summaries.rb:54:21:54:24 | args [element :foo] | provenance |  |
-| summaries.rb:53:15:53:31 | call to source | summaries.rb:53:1:53:4 | args [element :foo] | provenance |  |
+| summaries.rb:53:8:53:33 | call to [] [element :foo] | summaries.rb:53:1:53:4 | args [element :foo] | provenance |  |
+| summaries.rb:53:15:53:31 | call to source | summaries.rb:53:8:53:33 | call to [] [element :foo] | provenance |  |
 | summaries.rb:54:19:54:24 | ** ... [element :foo] | summaries.rb:54:6:54:25 | call to namedArg | provenance |  |
 | summaries.rb:54:21:54:24 | args [element :foo] | summaries.rb:54:19:54:24 | ** ... [element :foo] | provenance |  |
 | summaries.rb:56:22:56:28 | tainted | summaries.rb:56:6:56:29 | call to anyArg | provenance |  |
@@ -118,10 +119,14 @@ edges
 | summaries.rb:79:1:79:1 | a [element 2] | summaries.rb:86:6:86:6 | a [element 2] | provenance |  |
 | summaries.rb:79:1:79:1 | a [element 2] | summaries.rb:95:1:95:1 | a [element 2] | provenance |  |
 | summaries.rb:79:1:79:1 | a [element 2] | summaries.rb:95:1:95:1 | a [element 2] | provenance |  |
-| summaries.rb:79:15:79:29 | call to source | summaries.rb:79:1:79:1 | a [element 1] | provenance |  |
-| summaries.rb:79:15:79:29 | call to source | summaries.rb:79:1:79:1 | a [element 1] | provenance |  |
-| summaries.rb:79:32:79:46 | call to source | summaries.rb:79:1:79:1 | a [element 2] | provenance |  |
-| summaries.rb:79:32:79:46 | call to source | summaries.rb:79:1:79:1 | a [element 2] | provenance |  |
+| summaries.rb:79:5:79:47 | call to [] [element 1] | summaries.rb:79:1:79:1 | a [element 1] | provenance |  |
+| summaries.rb:79:5:79:47 | call to [] [element 1] | summaries.rb:79:1:79:1 | a [element 1] | provenance |  |
+| summaries.rb:79:5:79:47 | call to [] [element 2] | summaries.rb:79:1:79:1 | a [element 2] | provenance |  |
+| summaries.rb:79:5:79:47 | call to [] [element 2] | summaries.rb:79:1:79:1 | a [element 2] | provenance |  |
+| summaries.rb:79:15:79:29 | call to source | summaries.rb:79:5:79:47 | call to [] [element 1] | provenance |  |
+| summaries.rb:79:15:79:29 | call to source | summaries.rb:79:5:79:47 | call to [] [element 1] | provenance |  |
+| summaries.rb:79:32:79:46 | call to source | summaries.rb:79:5:79:47 | call to [] [element 2] | provenance |  |
+| summaries.rb:79:32:79:46 | call to source | summaries.rb:79:5:79:47 | call to [] [element 2] | provenance |  |
 | summaries.rb:81:1:81:1 | [post] a [element] | summaries.rb:82:6:82:6 | a [element] | provenance |  |
 | summaries.rb:81:1:81:1 | [post] a [element] | summaries.rb:82:6:82:6 | a [element] | provenance |  |
 | summaries.rb:81:1:81:1 | [post] a [element] | summaries.rb:84:6:84:6 | a [element] | provenance |  |
@@ -317,6 +322,7 @@ nodes
 | summaries.rb:51:6:51:31 | call to namedArg | semmle.label | call to namedArg |
 | summaries.rb:51:24:51:30 | tainted | semmle.label | tainted |
 | summaries.rb:53:1:53:4 | args [element :foo] | semmle.label | args [element :foo] |
+| summaries.rb:53:8:53:33 | call to [] [element :foo] | semmle.label | call to [] [element :foo] |
 | summaries.rb:53:15:53:31 | call to source | semmle.label | call to source |
 | summaries.rb:54:6:54:25 | call to namedArg | semmle.label | call to namedArg |
 | summaries.rb:54:19:54:24 | ** ... [element :foo] | semmle.label | ** ... [element :foo] |
@@ -340,6 +346,10 @@ nodes
 | summaries.rb:79:1:79:1 | a [element 1] | semmle.label | a [element 1] |
 | summaries.rb:79:1:79:1 | a [element 2] | semmle.label | a [element 2] |
 | summaries.rb:79:1:79:1 | a [element 2] | semmle.label | a [element 2] |
+| summaries.rb:79:5:79:47 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| summaries.rb:79:5:79:47 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| summaries.rb:79:5:79:47 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| summaries.rb:79:5:79:47 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | summaries.rb:79:15:79:29 | call to source | semmle.label | call to source |
 | summaries.rb:79:15:79:29 | call to source | semmle.label | call to source |
 | summaries.rb:79:32:79:46 | call to source | semmle.label | call to source |

--- a/ruby/ql/test/library-tests/frameworks/active_support/ActiveSupportDataFlow.expected
+++ b/ruby/ql/test/library-tests/frameworks/active_support/ActiveSupportDataFlow.expected
@@ -2,32 +2,37 @@ testFailures
 | hash_extensions.rb:126:10:126:19 | call to sole | Unexpected result: hasValueFlow=b |
 edges
 | active_support.rb:180:5:180:5 | x [element 0] | active_support.rb:181:9:181:9 | x [element 0] | provenance |  |
-| active_support.rb:180:10:180:17 | call to source | active_support.rb:180:5:180:5 | x [element 0] | provenance |  |
+| active_support.rb:180:9:180:18 | call to [] [element 0] | active_support.rb:180:5:180:5 | x [element 0] | provenance |  |
+| active_support.rb:180:10:180:17 | call to source | active_support.rb:180:9:180:18 | call to [] [element 0] | provenance |  |
 | active_support.rb:181:5:181:5 | y [element] | active_support.rb:182:10:182:10 | y [element] | provenance |  |
 | active_support.rb:181:9:181:9 | x [element 0] | active_support.rb:181:9:181:23 | call to compact_blank [element] | provenance |  |
 | active_support.rb:181:9:181:23 | call to compact_blank [element] | active_support.rb:181:5:181:5 | y [element] | provenance |  |
 | active_support.rb:182:10:182:10 | y [element] | active_support.rb:182:10:182:13 | ...[...] | provenance |  |
 | active_support.rb:186:5:186:5 | x [element 0] | active_support.rb:187:9:187:9 | x [element 0] | provenance |  |
-| active_support.rb:186:10:186:18 | call to source | active_support.rb:186:5:186:5 | x [element 0] | provenance |  |
+| active_support.rb:186:9:186:22 | call to [] [element 0] | active_support.rb:186:5:186:5 | x [element 0] | provenance |  |
+| active_support.rb:186:10:186:18 | call to source | active_support.rb:186:9:186:22 | call to [] [element 0] | provenance |  |
 | active_support.rb:187:5:187:5 | y [element] | active_support.rb:188:10:188:10 | y [element] | provenance |  |
 | active_support.rb:187:9:187:9 | x [element 0] | active_support.rb:187:9:187:21 | call to excluding [element] | provenance |  |
 | active_support.rb:187:9:187:21 | call to excluding [element] | active_support.rb:187:5:187:5 | y [element] | provenance |  |
 | active_support.rb:188:10:188:10 | y [element] | active_support.rb:188:10:188:13 | ...[...] | provenance |  |
 | active_support.rb:192:5:192:5 | x [element 0] | active_support.rb:193:9:193:9 | x [element 0] | provenance |  |
-| active_support.rb:192:10:192:18 | call to source | active_support.rb:192:5:192:5 | x [element 0] | provenance |  |
+| active_support.rb:192:9:192:22 | call to [] [element 0] | active_support.rb:192:5:192:5 | x [element 0] | provenance |  |
+| active_support.rb:192:10:192:18 | call to source | active_support.rb:192:9:192:22 | call to [] [element 0] | provenance |  |
 | active_support.rb:193:5:193:5 | y [element] | active_support.rb:194:10:194:10 | y [element] | provenance |  |
 | active_support.rb:193:9:193:9 | x [element 0] | active_support.rb:193:9:193:19 | call to without [element] | provenance |  |
 | active_support.rb:193:9:193:19 | call to without [element] | active_support.rb:193:5:193:5 | y [element] | provenance |  |
 | active_support.rb:194:10:194:10 | y [element] | active_support.rb:194:10:194:13 | ...[...] | provenance |  |
 | active_support.rb:198:5:198:5 | x [element 0] | active_support.rb:199:9:199:9 | x [element 0] | provenance |  |
-| active_support.rb:198:10:198:18 | call to source | active_support.rb:198:5:198:5 | x [element 0] | provenance |  |
+| active_support.rb:198:9:198:22 | call to [] [element 0] | active_support.rb:198:5:198:5 | x [element 0] | provenance |  |
+| active_support.rb:198:10:198:18 | call to source | active_support.rb:198:9:198:22 | call to [] [element 0] | provenance |  |
 | active_support.rb:199:5:199:5 | y [element] | active_support.rb:200:10:200:10 | y [element] | provenance |  |
 | active_support.rb:199:9:199:9 | x [element 0] | active_support.rb:199:9:199:37 | call to in_order_of [element] | provenance |  |
 | active_support.rb:199:9:199:37 | call to in_order_of [element] | active_support.rb:199:5:199:5 | y [element] | provenance |  |
 | active_support.rb:200:10:200:10 | y [element] | active_support.rb:200:10:200:13 | ...[...] | provenance |  |
 | active_support.rb:204:5:204:5 | a [element 0] | active_support.rb:205:9:205:9 | a [element 0] | provenance |  |
 | active_support.rb:204:5:204:5 | a [element 0] | active_support.rb:206:10:206:10 | a [element 0] | provenance |  |
-| active_support.rb:204:10:204:18 | call to source | active_support.rb:204:5:204:5 | a [element 0] | provenance |  |
+| active_support.rb:204:9:204:22 | call to [] [element 0] | active_support.rb:204:5:204:5 | a [element 0] | provenance |  |
+| active_support.rb:204:10:204:18 | call to source | active_support.rb:204:9:204:22 | call to [] [element 0] | provenance |  |
 | active_support.rb:205:5:205:5 | b [element 0] | active_support.rb:208:10:208:10 | b [element 0] | provenance |  |
 | active_support.rb:205:5:205:5 | b [element] | active_support.rb:208:10:208:10 | b [element] | provenance |  |
 | active_support.rb:205:5:205:5 | b [element] | active_support.rb:209:10:209:10 | b [element] | provenance |  |
@@ -54,37 +59,43 @@ edges
 | active_support.rb:290:7:290:16 | call to source | active_support.rb:290:3:290:3 | x | provenance |  |
 | active_support.rb:291:8:291:8 | x | active_support.rb:291:8:291:17 | call to deep_dup | provenance |  |
 | hash_extensions.rb:2:5:2:5 | h [element :a] | hash_extensions.rb:3:9:3:9 | h [element :a] | provenance |  |
-| hash_extensions.rb:2:14:2:24 | call to source | hash_extensions.rb:2:5:2:5 | h [element :a] | provenance |  |
+| hash_extensions.rb:2:9:2:26 | call to [] [element :a] | hash_extensions.rb:2:5:2:5 | h [element :a] | provenance |  |
+| hash_extensions.rb:2:14:2:24 | call to source | hash_extensions.rb:2:9:2:26 | call to [] [element :a] | provenance |  |
 | hash_extensions.rb:3:5:3:5 | x [element] | hash_extensions.rb:4:10:4:10 | x [element] | provenance |  |
 | hash_extensions.rb:3:9:3:9 | h [element :a] | hash_extensions.rb:3:9:3:24 | call to stringify_keys [element] | provenance |  |
 | hash_extensions.rb:3:9:3:24 | call to stringify_keys [element] | hash_extensions.rb:3:5:3:5 | x [element] | provenance |  |
 | hash_extensions.rb:4:10:4:10 | x [element] | hash_extensions.rb:4:10:4:14 | ...[...] | provenance |  |
 | hash_extensions.rb:10:5:10:5 | h [element :a] | hash_extensions.rb:11:9:11:9 | h [element :a] | provenance |  |
-| hash_extensions.rb:10:14:10:24 | call to source | hash_extensions.rb:10:5:10:5 | h [element :a] | provenance |  |
+| hash_extensions.rb:10:9:10:26 | call to [] [element :a] | hash_extensions.rb:10:5:10:5 | h [element :a] | provenance |  |
+| hash_extensions.rb:10:14:10:24 | call to source | hash_extensions.rb:10:9:10:26 | call to [] [element :a] | provenance |  |
 | hash_extensions.rb:11:5:11:5 | x [element] | hash_extensions.rb:12:10:12:10 | x [element] | provenance |  |
 | hash_extensions.rb:11:9:11:9 | h [element :a] | hash_extensions.rb:11:9:11:20 | call to to_options [element] | provenance |  |
 | hash_extensions.rb:11:9:11:20 | call to to_options [element] | hash_extensions.rb:11:5:11:5 | x [element] | provenance |  |
 | hash_extensions.rb:12:10:12:10 | x [element] | hash_extensions.rb:12:10:12:14 | ...[...] | provenance |  |
 | hash_extensions.rb:18:5:18:5 | h [element :a] | hash_extensions.rb:19:9:19:9 | h [element :a] | provenance |  |
-| hash_extensions.rb:18:14:18:24 | call to source | hash_extensions.rb:18:5:18:5 | h [element :a] | provenance |  |
+| hash_extensions.rb:18:9:18:26 | call to [] [element :a] | hash_extensions.rb:18:5:18:5 | h [element :a] | provenance |  |
+| hash_extensions.rb:18:14:18:24 | call to source | hash_extensions.rb:18:9:18:26 | call to [] [element :a] | provenance |  |
 | hash_extensions.rb:19:5:19:5 | x [element] | hash_extensions.rb:20:10:20:10 | x [element] | provenance |  |
 | hash_extensions.rb:19:9:19:9 | h [element :a] | hash_extensions.rb:19:9:19:24 | call to symbolize_keys [element] | provenance |  |
 | hash_extensions.rb:19:9:19:24 | call to symbolize_keys [element] | hash_extensions.rb:19:5:19:5 | x [element] | provenance |  |
 | hash_extensions.rb:20:10:20:10 | x [element] | hash_extensions.rb:20:10:20:14 | ...[...] | provenance |  |
 | hash_extensions.rb:26:5:26:5 | h [element :a] | hash_extensions.rb:27:9:27:9 | h [element :a] | provenance |  |
-| hash_extensions.rb:26:14:26:24 | call to source | hash_extensions.rb:26:5:26:5 | h [element :a] | provenance |  |
+| hash_extensions.rb:26:9:26:26 | call to [] [element :a] | hash_extensions.rb:26:5:26:5 | h [element :a] | provenance |  |
+| hash_extensions.rb:26:14:26:24 | call to source | hash_extensions.rb:26:9:26:26 | call to [] [element :a] | provenance |  |
 | hash_extensions.rb:27:5:27:5 | x [element] | hash_extensions.rb:28:10:28:10 | x [element] | provenance |  |
 | hash_extensions.rb:27:9:27:9 | h [element :a] | hash_extensions.rb:27:9:27:29 | call to deep_stringify_keys [element] | provenance |  |
 | hash_extensions.rb:27:9:27:29 | call to deep_stringify_keys [element] | hash_extensions.rb:27:5:27:5 | x [element] | provenance |  |
 | hash_extensions.rb:28:10:28:10 | x [element] | hash_extensions.rb:28:10:28:14 | ...[...] | provenance |  |
 | hash_extensions.rb:34:5:34:5 | h [element :a] | hash_extensions.rb:35:9:35:9 | h [element :a] | provenance |  |
-| hash_extensions.rb:34:14:34:24 | call to source | hash_extensions.rb:34:5:34:5 | h [element :a] | provenance |  |
+| hash_extensions.rb:34:9:34:26 | call to [] [element :a] | hash_extensions.rb:34:5:34:5 | h [element :a] | provenance |  |
+| hash_extensions.rb:34:14:34:24 | call to source | hash_extensions.rb:34:9:34:26 | call to [] [element :a] | provenance |  |
 | hash_extensions.rb:35:5:35:5 | x [element] | hash_extensions.rb:36:10:36:10 | x [element] | provenance |  |
 | hash_extensions.rb:35:9:35:9 | h [element :a] | hash_extensions.rb:35:9:35:29 | call to deep_symbolize_keys [element] | provenance |  |
 | hash_extensions.rb:35:9:35:29 | call to deep_symbolize_keys [element] | hash_extensions.rb:35:5:35:5 | x [element] | provenance |  |
 | hash_extensions.rb:36:10:36:10 | x [element] | hash_extensions.rb:36:10:36:14 | ...[...] | provenance |  |
 | hash_extensions.rb:42:5:42:5 | h [element :a] | hash_extensions.rb:43:9:43:9 | h [element :a] | provenance |  |
-| hash_extensions.rb:42:14:42:24 | call to source | hash_extensions.rb:42:5:42:5 | h [element :a] | provenance |  |
+| hash_extensions.rb:42:9:42:26 | call to [] [element :a] | hash_extensions.rb:42:5:42:5 | h [element :a] | provenance |  |
+| hash_extensions.rb:42:14:42:24 | call to source | hash_extensions.rb:42:9:42:26 | call to [] [element :a] | provenance |  |
 | hash_extensions.rb:43:5:43:5 | x [element] | hash_extensions.rb:44:10:44:10 | x [element] | provenance |  |
 | hash_extensions.rb:43:9:43:9 | h [element :a] | hash_extensions.rb:43:9:43:33 | call to with_indifferent_access [element] | provenance |  |
 | hash_extensions.rb:43:9:43:33 | call to with_indifferent_access [element] | hash_extensions.rb:43:5:43:5 | x [element] | provenance |  |
@@ -92,9 +103,12 @@ edges
 | hash_extensions.rb:50:5:50:5 | h [element :a] | hash_extensions.rb:51:9:51:9 | h [element :a] | provenance |  |
 | hash_extensions.rb:50:5:50:5 | h [element :b] | hash_extensions.rb:51:9:51:9 | h [element :b] | provenance |  |
 | hash_extensions.rb:50:5:50:5 | h [element :d] | hash_extensions.rb:51:9:51:9 | h [element :d] | provenance |  |
-| hash_extensions.rb:50:14:50:23 | call to taint | hash_extensions.rb:50:5:50:5 | h [element :a] | provenance |  |
-| hash_extensions.rb:50:29:50:38 | call to taint | hash_extensions.rb:50:5:50:5 | h [element :b] | provenance |  |
-| hash_extensions.rb:50:52:50:61 | call to taint | hash_extensions.rb:50:5:50:5 | h [element :d] | provenance |  |
+| hash_extensions.rb:50:9:50:63 | call to [] [element :a] | hash_extensions.rb:50:5:50:5 | h [element :a] | provenance |  |
+| hash_extensions.rb:50:9:50:63 | call to [] [element :b] | hash_extensions.rb:50:5:50:5 | h [element :b] | provenance |  |
+| hash_extensions.rb:50:9:50:63 | call to [] [element :d] | hash_extensions.rb:50:5:50:5 | h [element :d] | provenance |  |
+| hash_extensions.rb:50:14:50:23 | call to taint | hash_extensions.rb:50:9:50:63 | call to [] [element :a] | provenance |  |
+| hash_extensions.rb:50:29:50:38 | call to taint | hash_extensions.rb:50:9:50:63 | call to [] [element :b] | provenance |  |
+| hash_extensions.rb:50:52:50:61 | call to taint | hash_extensions.rb:50:9:50:63 | call to [] [element :d] | provenance |  |
 | hash_extensions.rb:51:5:51:5 | x [element :a] | hash_extensions.rb:58:10:58:10 | x [element :a] | provenance |  |
 | hash_extensions.rb:51:5:51:5 | x [element :b] | hash_extensions.rb:59:10:59:10 | x [element :b] | provenance |  |
 | hash_extensions.rb:51:9:51:9 | [post] h [element :d] | hash_extensions.rb:56:10:56:10 | h [element :d] | provenance |  |
@@ -109,9 +123,12 @@ edges
 | hash_extensions.rb:67:5:67:10 | values [element 0] | hash_extensions.rb:68:9:68:14 | values [element 0] | provenance |  |
 | hash_extensions.rb:67:5:67:10 | values [element 1] | hash_extensions.rb:68:9:68:14 | values [element 1] | provenance |  |
 | hash_extensions.rb:67:5:67:10 | values [element 2] | hash_extensions.rb:68:9:68:14 | values [element 2] | provenance |  |
-| hash_extensions.rb:67:15:67:25 | call to source | hash_extensions.rb:67:5:67:10 | values [element 0] | provenance |  |
-| hash_extensions.rb:67:28:67:38 | call to source | hash_extensions.rb:67:5:67:10 | values [element 1] | provenance |  |
-| hash_extensions.rb:67:41:67:51 | call to source | hash_extensions.rb:67:5:67:10 | values [element 2] | provenance |  |
+| hash_extensions.rb:67:14:67:52 | call to [] [element 0] | hash_extensions.rb:67:5:67:10 | values [element 0] | provenance |  |
+| hash_extensions.rb:67:14:67:52 | call to [] [element 1] | hash_extensions.rb:67:5:67:10 | values [element 1] | provenance |  |
+| hash_extensions.rb:67:14:67:52 | call to [] [element 2] | hash_extensions.rb:67:5:67:10 | values [element 2] | provenance |  |
+| hash_extensions.rb:67:15:67:25 | call to source | hash_extensions.rb:67:14:67:52 | call to [] [element 0] | provenance |  |
+| hash_extensions.rb:67:28:67:38 | call to source | hash_extensions.rb:67:14:67:52 | call to [] [element 1] | provenance |  |
+| hash_extensions.rb:67:41:67:51 | call to source | hash_extensions.rb:67:14:67:52 | call to [] [element 2] | provenance |  |
 | hash_extensions.rb:68:5:68:5 | h [element] | hash_extensions.rb:73:10:73:10 | h [element] | provenance |  |
 | hash_extensions.rb:68:5:68:5 | h [element] | hash_extensions.rb:74:10:74:10 | h [element] | provenance |  |
 | hash_extensions.rb:68:9:68:14 | values [element 0] | hash_extensions.rb:68:9:71:7 | call to index_by [element] | provenance |  |
@@ -127,9 +144,12 @@ edges
 | hash_extensions.rb:80:5:80:10 | values [element 0] | hash_extensions.rb:81:9:81:14 | values [element 0] | provenance |  |
 | hash_extensions.rb:80:5:80:10 | values [element 1] | hash_extensions.rb:81:9:81:14 | values [element 1] | provenance |  |
 | hash_extensions.rb:80:5:80:10 | values [element 2] | hash_extensions.rb:81:9:81:14 | values [element 2] | provenance |  |
-| hash_extensions.rb:80:15:80:25 | call to source | hash_extensions.rb:80:5:80:10 | values [element 0] | provenance |  |
-| hash_extensions.rb:80:28:80:38 | call to source | hash_extensions.rb:80:5:80:10 | values [element 1] | provenance |  |
-| hash_extensions.rb:80:41:80:51 | call to source | hash_extensions.rb:80:5:80:10 | values [element 2] | provenance |  |
+| hash_extensions.rb:80:14:80:52 | call to [] [element 0] | hash_extensions.rb:80:5:80:10 | values [element 0] | provenance |  |
+| hash_extensions.rb:80:14:80:52 | call to [] [element 1] | hash_extensions.rb:80:5:80:10 | values [element 1] | provenance |  |
+| hash_extensions.rb:80:14:80:52 | call to [] [element 2] | hash_extensions.rb:80:5:80:10 | values [element 2] | provenance |  |
+| hash_extensions.rb:80:15:80:25 | call to source | hash_extensions.rb:80:14:80:52 | call to [] [element 0] | provenance |  |
+| hash_extensions.rb:80:28:80:38 | call to source | hash_extensions.rb:80:14:80:52 | call to [] [element 1] | provenance |  |
+| hash_extensions.rb:80:41:80:51 | call to source | hash_extensions.rb:80:14:80:52 | call to [] [element 2] | provenance |  |
 | hash_extensions.rb:81:5:81:5 | h [element] | hash_extensions.rb:86:10:86:10 | h [element] | provenance |  |
 | hash_extensions.rb:81:5:81:5 | h [element] | hash_extensions.rb:87:10:87:10 | h [element] | provenance |  |
 | hash_extensions.rb:81:9:81:14 | values [element 0] | hash_extensions.rb:81:31:81:33 | key | provenance |  |
@@ -152,8 +172,12 @@ edges
 | hash_extensions.rb:98:5:98:10 | values [element 0, element :name] | hash_extensions.rb:100:10:100:15 | values [element 0, element :name] | provenance |  |
 | hash_extensions.rb:98:5:98:10 | values [element 0, element :name] | hash_extensions.rb:102:10:102:15 | values [element 0, element :name] | provenance |  |
 | hash_extensions.rb:98:5:98:10 | values [element 0, element :name] | hash_extensions.rb:103:10:103:15 | values [element 0, element :name] | provenance |  |
-| hash_extensions.rb:98:21:98:31 | call to source | hash_extensions.rb:98:5:98:10 | values [element 0, element :id] | provenance |  |
-| hash_extensions.rb:98:40:98:54 | call to source | hash_extensions.rb:98:5:98:10 | values [element 0, element :name] | provenance |  |
+| hash_extensions.rb:98:14:98:102 | call to [] [element 0, element :id] | hash_extensions.rb:98:5:98:10 | values [element 0, element :id] | provenance |  |
+| hash_extensions.rb:98:14:98:102 | call to [] [element 0, element :name] | hash_extensions.rb:98:5:98:10 | values [element 0, element :name] | provenance |  |
+| hash_extensions.rb:98:15:98:56 | call to [] [element :id] | hash_extensions.rb:98:14:98:102 | call to [] [element 0, element :id] | provenance |  |
+| hash_extensions.rb:98:15:98:56 | call to [] [element :name] | hash_extensions.rb:98:14:98:102 | call to [] [element 0, element :name] | provenance |  |
+| hash_extensions.rb:98:21:98:31 | call to source | hash_extensions.rb:98:15:98:56 | call to [] [element :id] | provenance |  |
+| hash_extensions.rb:98:40:98:54 | call to source | hash_extensions.rb:98:15:98:56 | call to [] [element :name] | provenance |  |
 | hash_extensions.rb:99:10:99:15 | values [element 0, element :id] | hash_extensions.rb:99:10:99:25 | call to pick | provenance |  |
 | hash_extensions.rb:100:10:100:15 | values [element 0, element :name] | hash_extensions.rb:100:10:100:27 | call to pick | provenance |  |
 | hash_extensions.rb:101:10:101:15 | values [element 0, element :id] | hash_extensions.rb:101:10:101:32 | call to pick [element 0] | provenance |  |
@@ -174,10 +198,18 @@ edges
 | hash_extensions.rb:110:5:110:10 | values [element 1, element :name] | hash_extensions.rb:111:10:111:15 | values [element 1, element :name] | provenance |  |
 | hash_extensions.rb:110:5:110:10 | values [element 1, element :name] | hash_extensions.rb:113:10:113:15 | values [element 1, element :name] | provenance |  |
 | hash_extensions.rb:110:5:110:10 | values [element 1, element :name] | hash_extensions.rb:114:10:114:15 | values [element 1, element :name] | provenance |  |
-| hash_extensions.rb:110:21:110:31 | call to source | hash_extensions.rb:110:5:110:10 | values [element 0, element :id] | provenance |  |
-| hash_extensions.rb:110:40:110:54 | call to source | hash_extensions.rb:110:5:110:10 | values [element 0, element :name] | provenance |  |
-| hash_extensions.rb:110:65:110:75 | call to source | hash_extensions.rb:110:5:110:10 | values [element 1, element :id] | provenance |  |
-| hash_extensions.rb:110:84:110:99 | call to source | hash_extensions.rb:110:5:110:10 | values [element 1, element :name] | provenance |  |
+| hash_extensions.rb:110:14:110:102 | call to [] [element 0, element :id] | hash_extensions.rb:110:5:110:10 | values [element 0, element :id] | provenance |  |
+| hash_extensions.rb:110:14:110:102 | call to [] [element 0, element :name] | hash_extensions.rb:110:5:110:10 | values [element 0, element :name] | provenance |  |
+| hash_extensions.rb:110:14:110:102 | call to [] [element 1, element :id] | hash_extensions.rb:110:5:110:10 | values [element 1, element :id] | provenance |  |
+| hash_extensions.rb:110:14:110:102 | call to [] [element 1, element :name] | hash_extensions.rb:110:5:110:10 | values [element 1, element :name] | provenance |  |
+| hash_extensions.rb:110:15:110:56 | call to [] [element :id] | hash_extensions.rb:110:14:110:102 | call to [] [element 0, element :id] | provenance |  |
+| hash_extensions.rb:110:15:110:56 | call to [] [element :name] | hash_extensions.rb:110:14:110:102 | call to [] [element 0, element :name] | provenance |  |
+| hash_extensions.rb:110:21:110:31 | call to source | hash_extensions.rb:110:15:110:56 | call to [] [element :id] | provenance |  |
+| hash_extensions.rb:110:40:110:54 | call to source | hash_extensions.rb:110:15:110:56 | call to [] [element :name] | provenance |  |
+| hash_extensions.rb:110:59:110:101 | call to [] [element :id] | hash_extensions.rb:110:14:110:102 | call to [] [element 1, element :id] | provenance |  |
+| hash_extensions.rb:110:59:110:101 | call to [] [element :name] | hash_extensions.rb:110:14:110:102 | call to [] [element 1, element :name] | provenance |  |
+| hash_extensions.rb:110:65:110:75 | call to source | hash_extensions.rb:110:59:110:101 | call to [] [element :id] | provenance |  |
+| hash_extensions.rb:110:84:110:99 | call to source | hash_extensions.rb:110:59:110:101 | call to [] [element :name] | provenance |  |
 | hash_extensions.rb:111:10:111:15 | values [element 0, element :name] | hash_extensions.rb:111:10:111:28 | call to pluck [element] | provenance |  |
 | hash_extensions.rb:111:10:111:15 | values [element 1, element :name] | hash_extensions.rb:111:10:111:28 | call to pluck [element] | provenance |  |
 | hash_extensions.rb:111:10:111:28 | call to pluck [element] | hash_extensions.rb:111:10:111:31 | ...[...] | provenance |  |
@@ -198,13 +230,16 @@ edges
 | hash_extensions.rb:115:10:115:33 | call to pluck [element, element 1] | hash_extensions.rb:115:10:115:36 | ...[...] [element 1] | provenance |  |
 | hash_extensions.rb:115:10:115:36 | ...[...] [element 1] | hash_extensions.rb:115:10:115:39 | ...[...] | provenance |  |
 | hash_extensions.rb:122:5:122:10 | single [element 0] | hash_extensions.rb:125:10:125:15 | single [element 0] | provenance |  |
-| hash_extensions.rb:122:15:122:25 | call to source | hash_extensions.rb:122:5:122:10 | single [element 0] | provenance |  |
+| hash_extensions.rb:122:14:122:26 | call to [] [element 0] | hash_extensions.rb:122:5:122:10 | single [element 0] | provenance |  |
+| hash_extensions.rb:122:15:122:25 | call to source | hash_extensions.rb:122:14:122:26 | call to [] [element 0] | provenance |  |
 | hash_extensions.rb:123:5:123:9 | multi [element 0] | hash_extensions.rb:126:10:126:14 | multi [element 0] | provenance |  |
-| hash_extensions.rb:123:14:123:24 | call to source | hash_extensions.rb:123:5:123:9 | multi [element 0] | provenance |  |
+| hash_extensions.rb:123:13:123:38 | call to [] [element 0] | hash_extensions.rb:123:5:123:9 | multi [element 0] | provenance |  |
+| hash_extensions.rb:123:14:123:24 | call to source | hash_extensions.rb:123:13:123:38 | call to [] [element 0] | provenance |  |
 | hash_extensions.rb:125:10:125:15 | single [element 0] | hash_extensions.rb:125:10:125:20 | call to sole | provenance |  |
 | hash_extensions.rb:126:10:126:14 | multi [element 0] | hash_extensions.rb:126:10:126:19 | call to sole | provenance |  |
 nodes
 | active_support.rb:180:5:180:5 | x [element 0] | semmle.label | x [element 0] |
+| active_support.rb:180:9:180:18 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | active_support.rb:180:10:180:17 | call to source | semmle.label | call to source |
 | active_support.rb:181:5:181:5 | y [element] | semmle.label | y [element] |
 | active_support.rb:181:9:181:9 | x [element 0] | semmle.label | x [element 0] |
@@ -212,6 +247,7 @@ nodes
 | active_support.rb:182:10:182:10 | y [element] | semmle.label | y [element] |
 | active_support.rb:182:10:182:13 | ...[...] | semmle.label | ...[...] |
 | active_support.rb:186:5:186:5 | x [element 0] | semmle.label | x [element 0] |
+| active_support.rb:186:9:186:22 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | active_support.rb:186:10:186:18 | call to source | semmle.label | call to source |
 | active_support.rb:187:5:187:5 | y [element] | semmle.label | y [element] |
 | active_support.rb:187:9:187:9 | x [element 0] | semmle.label | x [element 0] |
@@ -219,6 +255,7 @@ nodes
 | active_support.rb:188:10:188:10 | y [element] | semmle.label | y [element] |
 | active_support.rb:188:10:188:13 | ...[...] | semmle.label | ...[...] |
 | active_support.rb:192:5:192:5 | x [element 0] | semmle.label | x [element 0] |
+| active_support.rb:192:9:192:22 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | active_support.rb:192:10:192:18 | call to source | semmle.label | call to source |
 | active_support.rb:193:5:193:5 | y [element] | semmle.label | y [element] |
 | active_support.rb:193:9:193:9 | x [element 0] | semmle.label | x [element 0] |
@@ -226,6 +263,7 @@ nodes
 | active_support.rb:194:10:194:10 | y [element] | semmle.label | y [element] |
 | active_support.rb:194:10:194:13 | ...[...] | semmle.label | ...[...] |
 | active_support.rb:198:5:198:5 | x [element 0] | semmle.label | x [element 0] |
+| active_support.rb:198:9:198:22 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | active_support.rb:198:10:198:18 | call to source | semmle.label | call to source |
 | active_support.rb:199:5:199:5 | y [element] | semmle.label | y [element] |
 | active_support.rb:199:9:199:9 | x [element 0] | semmle.label | x [element 0] |
@@ -233,6 +271,7 @@ nodes
 | active_support.rb:200:10:200:10 | y [element] | semmle.label | y [element] |
 | active_support.rb:200:10:200:13 | ...[...] | semmle.label | ...[...] |
 | active_support.rb:204:5:204:5 | a [element 0] | semmle.label | a [element 0] |
+| active_support.rb:204:9:204:22 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | active_support.rb:204:10:204:18 | call to source | semmle.label | call to source |
 | active_support.rb:205:5:205:5 | b [element 0] | semmle.label | b [element 0] |
 | active_support.rb:205:5:205:5 | b [element] | semmle.label | b [element] |
@@ -265,6 +304,7 @@ nodes
 | active_support.rb:291:8:291:8 | x | semmle.label | x |
 | active_support.rb:291:8:291:17 | call to deep_dup | semmle.label | call to deep_dup |
 | hash_extensions.rb:2:5:2:5 | h [element :a] | semmle.label | h [element :a] |
+| hash_extensions.rb:2:9:2:26 | call to [] [element :a] | semmle.label | call to [] [element :a] |
 | hash_extensions.rb:2:14:2:24 | call to source | semmle.label | call to source |
 | hash_extensions.rb:3:5:3:5 | x [element] | semmle.label | x [element] |
 | hash_extensions.rb:3:9:3:9 | h [element :a] | semmle.label | h [element :a] |
@@ -272,6 +312,7 @@ nodes
 | hash_extensions.rb:4:10:4:10 | x [element] | semmle.label | x [element] |
 | hash_extensions.rb:4:10:4:14 | ...[...] | semmle.label | ...[...] |
 | hash_extensions.rb:10:5:10:5 | h [element :a] | semmle.label | h [element :a] |
+| hash_extensions.rb:10:9:10:26 | call to [] [element :a] | semmle.label | call to [] [element :a] |
 | hash_extensions.rb:10:14:10:24 | call to source | semmle.label | call to source |
 | hash_extensions.rb:11:5:11:5 | x [element] | semmle.label | x [element] |
 | hash_extensions.rb:11:9:11:9 | h [element :a] | semmle.label | h [element :a] |
@@ -279,6 +320,7 @@ nodes
 | hash_extensions.rb:12:10:12:10 | x [element] | semmle.label | x [element] |
 | hash_extensions.rb:12:10:12:14 | ...[...] | semmle.label | ...[...] |
 | hash_extensions.rb:18:5:18:5 | h [element :a] | semmle.label | h [element :a] |
+| hash_extensions.rb:18:9:18:26 | call to [] [element :a] | semmle.label | call to [] [element :a] |
 | hash_extensions.rb:18:14:18:24 | call to source | semmle.label | call to source |
 | hash_extensions.rb:19:5:19:5 | x [element] | semmle.label | x [element] |
 | hash_extensions.rb:19:9:19:9 | h [element :a] | semmle.label | h [element :a] |
@@ -286,6 +328,7 @@ nodes
 | hash_extensions.rb:20:10:20:10 | x [element] | semmle.label | x [element] |
 | hash_extensions.rb:20:10:20:14 | ...[...] | semmle.label | ...[...] |
 | hash_extensions.rb:26:5:26:5 | h [element :a] | semmle.label | h [element :a] |
+| hash_extensions.rb:26:9:26:26 | call to [] [element :a] | semmle.label | call to [] [element :a] |
 | hash_extensions.rb:26:14:26:24 | call to source | semmle.label | call to source |
 | hash_extensions.rb:27:5:27:5 | x [element] | semmle.label | x [element] |
 | hash_extensions.rb:27:9:27:9 | h [element :a] | semmle.label | h [element :a] |
@@ -293,6 +336,7 @@ nodes
 | hash_extensions.rb:28:10:28:10 | x [element] | semmle.label | x [element] |
 | hash_extensions.rb:28:10:28:14 | ...[...] | semmle.label | ...[...] |
 | hash_extensions.rb:34:5:34:5 | h [element :a] | semmle.label | h [element :a] |
+| hash_extensions.rb:34:9:34:26 | call to [] [element :a] | semmle.label | call to [] [element :a] |
 | hash_extensions.rb:34:14:34:24 | call to source | semmle.label | call to source |
 | hash_extensions.rb:35:5:35:5 | x [element] | semmle.label | x [element] |
 | hash_extensions.rb:35:9:35:9 | h [element :a] | semmle.label | h [element :a] |
@@ -300,6 +344,7 @@ nodes
 | hash_extensions.rb:36:10:36:10 | x [element] | semmle.label | x [element] |
 | hash_extensions.rb:36:10:36:14 | ...[...] | semmle.label | ...[...] |
 | hash_extensions.rb:42:5:42:5 | h [element :a] | semmle.label | h [element :a] |
+| hash_extensions.rb:42:9:42:26 | call to [] [element :a] | semmle.label | call to [] [element :a] |
 | hash_extensions.rb:42:14:42:24 | call to source | semmle.label | call to source |
 | hash_extensions.rb:43:5:43:5 | x [element] | semmle.label | x [element] |
 | hash_extensions.rb:43:9:43:9 | h [element :a] | semmle.label | h [element :a] |
@@ -309,6 +354,9 @@ nodes
 | hash_extensions.rb:50:5:50:5 | h [element :a] | semmle.label | h [element :a] |
 | hash_extensions.rb:50:5:50:5 | h [element :b] | semmle.label | h [element :b] |
 | hash_extensions.rb:50:5:50:5 | h [element :d] | semmle.label | h [element :d] |
+| hash_extensions.rb:50:9:50:63 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_extensions.rb:50:9:50:63 | call to [] [element :b] | semmle.label | call to [] [element :b] |
+| hash_extensions.rb:50:9:50:63 | call to [] [element :d] | semmle.label | call to [] [element :d] |
 | hash_extensions.rb:50:14:50:23 | call to taint | semmle.label | call to taint |
 | hash_extensions.rb:50:29:50:38 | call to taint | semmle.label | call to taint |
 | hash_extensions.rb:50:52:50:61 | call to taint | semmle.label | call to taint |
@@ -329,6 +377,9 @@ nodes
 | hash_extensions.rb:67:5:67:10 | values [element 0] | semmle.label | values [element 0] |
 | hash_extensions.rb:67:5:67:10 | values [element 1] | semmle.label | values [element 1] |
 | hash_extensions.rb:67:5:67:10 | values [element 2] | semmle.label | values [element 2] |
+| hash_extensions.rb:67:14:67:52 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| hash_extensions.rb:67:14:67:52 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| hash_extensions.rb:67:14:67:52 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | hash_extensions.rb:67:15:67:25 | call to source | semmle.label | call to source |
 | hash_extensions.rb:67:28:67:38 | call to source | semmle.label | call to source |
 | hash_extensions.rb:67:41:67:51 | call to source | semmle.label | call to source |
@@ -346,6 +397,9 @@ nodes
 | hash_extensions.rb:80:5:80:10 | values [element 0] | semmle.label | values [element 0] |
 | hash_extensions.rb:80:5:80:10 | values [element 1] | semmle.label | values [element 1] |
 | hash_extensions.rb:80:5:80:10 | values [element 2] | semmle.label | values [element 2] |
+| hash_extensions.rb:80:14:80:52 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| hash_extensions.rb:80:14:80:52 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| hash_extensions.rb:80:14:80:52 | call to [] [element 2] | semmle.label | call to [] [element 2] |
 | hash_extensions.rb:80:15:80:25 | call to source | semmle.label | call to source |
 | hash_extensions.rb:80:28:80:38 | call to source | semmle.label | call to source |
 | hash_extensions.rb:80:41:80:51 | call to source | semmle.label | call to source |
@@ -370,6 +424,10 @@ nodes
 | hash_extensions.rb:92:10:92:16 | ...[...] | semmle.label | ...[...] |
 | hash_extensions.rb:98:5:98:10 | values [element 0, element :id] | semmle.label | values [element 0, element :id] |
 | hash_extensions.rb:98:5:98:10 | values [element 0, element :name] | semmle.label | values [element 0, element :name] |
+| hash_extensions.rb:98:14:98:102 | call to [] [element 0, element :id] | semmle.label | call to [] [element 0, element :id] |
+| hash_extensions.rb:98:14:98:102 | call to [] [element 0, element :name] | semmle.label | call to [] [element 0, element :name] |
+| hash_extensions.rb:98:15:98:56 | call to [] [element :id] | semmle.label | call to [] [element :id] |
+| hash_extensions.rb:98:15:98:56 | call to [] [element :name] | semmle.label | call to [] [element :name] |
 | hash_extensions.rb:98:21:98:31 | call to source | semmle.label | call to source |
 | hash_extensions.rb:98:40:98:54 | call to source | semmle.label | call to source |
 | hash_extensions.rb:99:10:99:15 | values [element 0, element :id] | semmle.label | values [element 0, element :id] |
@@ -392,8 +450,16 @@ nodes
 | hash_extensions.rb:110:5:110:10 | values [element 0, element :name] | semmle.label | values [element 0, element :name] |
 | hash_extensions.rb:110:5:110:10 | values [element 1, element :id] | semmle.label | values [element 1, element :id] |
 | hash_extensions.rb:110:5:110:10 | values [element 1, element :name] | semmle.label | values [element 1, element :name] |
+| hash_extensions.rb:110:14:110:102 | call to [] [element 0, element :id] | semmle.label | call to [] [element 0, element :id] |
+| hash_extensions.rb:110:14:110:102 | call to [] [element 0, element :name] | semmle.label | call to [] [element 0, element :name] |
+| hash_extensions.rb:110:14:110:102 | call to [] [element 1, element :id] | semmle.label | call to [] [element 1, element :id] |
+| hash_extensions.rb:110:14:110:102 | call to [] [element 1, element :name] | semmle.label | call to [] [element 1, element :name] |
+| hash_extensions.rb:110:15:110:56 | call to [] [element :id] | semmle.label | call to [] [element :id] |
+| hash_extensions.rb:110:15:110:56 | call to [] [element :name] | semmle.label | call to [] [element :name] |
 | hash_extensions.rb:110:21:110:31 | call to source | semmle.label | call to source |
 | hash_extensions.rb:110:40:110:54 | call to source | semmle.label | call to source |
+| hash_extensions.rb:110:59:110:101 | call to [] [element :id] | semmle.label | call to [] [element :id] |
+| hash_extensions.rb:110:59:110:101 | call to [] [element :name] | semmle.label | call to [] [element :name] |
 | hash_extensions.rb:110:65:110:75 | call to source | semmle.label | call to source |
 | hash_extensions.rb:110:84:110:99 | call to source | semmle.label | call to source |
 | hash_extensions.rb:111:10:111:15 | values [element 0, element :name] | semmle.label | values [element 0, element :name] |
@@ -421,8 +487,10 @@ nodes
 | hash_extensions.rb:115:10:115:36 | ...[...] [element 1] | semmle.label | ...[...] [element 1] |
 | hash_extensions.rb:115:10:115:39 | ...[...] | semmle.label | ...[...] |
 | hash_extensions.rb:122:5:122:10 | single [element 0] | semmle.label | single [element 0] |
+| hash_extensions.rb:122:14:122:26 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | hash_extensions.rb:122:15:122:25 | call to source | semmle.label | call to source |
 | hash_extensions.rb:123:5:123:9 | multi [element 0] | semmle.label | multi [element 0] |
+| hash_extensions.rb:123:13:123:38 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | hash_extensions.rb:123:14:123:24 | call to source | semmle.label | call to source |
 | hash_extensions.rb:125:10:125:15 | single [element 0] | semmle.label | single [element 0] |
 | hash_extensions.rb:125:10:125:20 | call to sole | semmle.label | call to sole |

--- a/ruby/ql/test/library-tests/frameworks/sinatra/Flow.expected
+++ b/ruby/ql/test/library-tests/frameworks/sinatra/Flow.expected
@@ -4,12 +4,14 @@ edges
 | app.rb:75:5:75:8 | [post] self [@foo] | app.rb:76:32:76:35 | self [@foo] | provenance |  |
 | app.rb:75:12:75:17 | call to params | app.rb:75:12:75:24 | ...[...] | provenance |  |
 | app.rb:75:12:75:24 | ...[...] | app.rb:75:5:75:8 | [post] self [@foo] | provenance |  |
-| app.rb:76:32:76:35 | @foo | views/index.erb:2:10:2:12 | call to foo | provenance |  |
+| app.rb:76:25:76:36 | call to [] [element :foo] | views/index.erb:2:10:2:12 | call to foo | provenance |  |
+| app.rb:76:32:76:35 | @foo | app.rb:76:25:76:36 | call to [] [element :foo] | provenance |  |
 | app.rb:76:32:76:35 | self [@foo] | app.rb:76:32:76:35 | @foo | provenance |  |
 nodes
 | app.rb:75:5:75:8 | [post] self [@foo] | semmle.label | [post] self [@foo] |
 | app.rb:75:12:75:17 | call to params | semmle.label | call to params |
 | app.rb:75:12:75:24 | ...[...] | semmle.label | ...[...] |
+| app.rb:76:25:76:36 | call to [] [element :foo] | semmle.label | call to [] [element :foo] |
 | app.rb:76:32:76:35 | @foo | semmle.label | @foo |
 | app.rb:76:32:76:35 | self [@foo] | semmle.label | self [@foo] |
 | views/index.erb:2:10:2:12 | call to foo | semmle.label | call to foo |

--- a/ruby/ql/test/query-tests/experimental/LdapInjection/Ldapinjection.expected
+++ b/ruby/ql/test/query-tests/experimental/LdapInjection/Ldapinjection.expected
@@ -6,7 +6,9 @@ edges
 | LdapInjection.rb:9:5:9:8 | name | LdapInjection.rb:33:88:33:91 | name | provenance |  |
 | LdapInjection.rb:9:12:9:17 | call to params | LdapInjection.rb:9:12:9:29 | ...[...] | provenance |  |
 | LdapInjection.rb:9:12:9:29 | ...[...] | LdapInjection.rb:9:5:9:8 | name | provenance |  |
+| LdapInjection.rb:33:87:33:92 | call to [] [element 0] | LdapInjection.rb:33:87:33:92 | call to [] | provenance |  |
 | LdapInjection.rb:33:88:33:91 | name | LdapInjection.rb:33:87:33:92 | call to [] | provenance |  |
+| LdapInjection.rb:33:88:33:91 | name | LdapInjection.rb:33:87:33:92 | call to [] [element 0] | provenance |  |
 | LdapInjection.rb:33:88:33:91 | name | LdapInjection.rb:37:41:37:44 | name | provenance |  |
 | LdapInjection.rb:37:5:37:10 | filter | LdapInjection.rb:38:62:38:67 | filter | provenance |  |
 | LdapInjection.rb:37:14:37:45 | call to eq | LdapInjection.rb:37:5:37:10 | filter | provenance |  |
@@ -21,6 +23,7 @@ nodes
 | LdapInjection.rb:25:23:25:49 | "ou=people,dc=#{...},dc=com" | semmle.label | "ou=people,dc=#{...},dc=com" |
 | LdapInjection.rb:29:62:29:73 | "cn=#{...}" | semmle.label | "cn=#{...}" |
 | LdapInjection.rb:33:87:33:92 | call to [] | semmle.label | call to [] |
+| LdapInjection.rb:33:87:33:92 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | LdapInjection.rb:33:88:33:91 | name | semmle.label | name |
 | LdapInjection.rb:37:5:37:10 | filter | semmle.label | filter |
 | LdapInjection.rb:37:14:37:45 | call to eq | semmle.label | call to eq |

--- a/ruby/ql/test/query-tests/security/cwe-079/ReflectedXSS.expected
+++ b/ruby/ql/test/query-tests/security/cwe-079/ReflectedXSS.expected
@@ -15,13 +15,14 @@ edges
 | app/controllers/foo/bars_controller.rb:19:22:19:23 | dt | app/views/foo/bars/show.html.erb:40:3:40:16 | @instance_text | provenance |  |
 | app/controllers/foo/bars_controller.rb:24:39:24:44 | call to params | app/controllers/foo/bars_controller.rb:24:39:24:59 | ...[...] | provenance |  |
 | app/controllers/foo/bars_controller.rb:24:39:24:59 | ...[...] | app/controllers/foo/bars_controller.rb:24:39:24:59 | ... = ... | provenance |  |
-| app/controllers/foo/bars_controller.rb:26:53:26:54 | dt | app/views/foo/bars/show.html.erb:5:9:5:20 | call to display_text | provenance |  |
-| app/controllers/foo/bars_controller.rb:26:53:26:54 | dt | app/views/foo/bars/show.html.erb:8:9:8:21 | call to local_assigns [element :display_text] | provenance |  |
-| app/controllers/foo/bars_controller.rb:26:53:26:54 | dt | app/views/foo/bars/show.html.erb:12:9:12:21 | call to local_assigns [element :display_text] | provenance |  |
-| app/controllers/foo/bars_controller.rb:26:53:26:54 | dt | app/views/foo/bars/show.html.erb:17:15:17:27 | call to local_assigns [element :display_text] | provenance |  |
-| app/controllers/foo/bars_controller.rb:26:53:26:54 | dt | app/views/foo/bars/show.html.erb:35:3:35:14 | call to display_text | provenance |  |
-| app/controllers/foo/bars_controller.rb:26:53:26:54 | dt | app/views/foo/bars/show.html.erb:43:76:43:87 | call to display_text | provenance |  |
-| app/controllers/foo/bars_controller.rb:26:53:26:54 | dt | app/views/foo/bars/show.html.erb:82:6:82:17 | call to display_text | provenance |  |
+| app/controllers/foo/bars_controller.rb:26:37:26:76 | call to [] [element :display_text] | app/views/foo/bars/show.html.erb:5:9:5:20 | call to display_text | provenance |  |
+| app/controllers/foo/bars_controller.rb:26:37:26:76 | call to [] [element :display_text] | app/views/foo/bars/show.html.erb:8:9:8:21 | call to local_assigns [element :display_text] | provenance |  |
+| app/controllers/foo/bars_controller.rb:26:37:26:76 | call to [] [element :display_text] | app/views/foo/bars/show.html.erb:12:9:12:21 | call to local_assigns [element :display_text] | provenance |  |
+| app/controllers/foo/bars_controller.rb:26:37:26:76 | call to [] [element :display_text] | app/views/foo/bars/show.html.erb:17:15:17:27 | call to local_assigns [element :display_text] | provenance |  |
+| app/controllers/foo/bars_controller.rb:26:37:26:76 | call to [] [element :display_text] | app/views/foo/bars/show.html.erb:35:3:35:14 | call to display_text | provenance |  |
+| app/controllers/foo/bars_controller.rb:26:37:26:76 | call to [] [element :display_text] | app/views/foo/bars/show.html.erb:43:76:43:87 | call to display_text | provenance |  |
+| app/controllers/foo/bars_controller.rb:26:37:26:76 | call to [] [element :display_text] | app/views/foo/bars/show.html.erb:82:6:82:17 | call to display_text | provenance |  |
+| app/controllers/foo/bars_controller.rb:26:53:26:54 | dt | app/controllers/foo/bars_controller.rb:26:37:26:76 | call to [] [element :display_text] | provenance |  |
 | app/controllers/foo/bars_controller.rb:30:5:30:7 | str | app/controllers/foo/bars_controller.rb:31:5:31:7 | str | provenance |  |
 | app/controllers/foo/bars_controller.rb:30:11:30:16 | call to params | app/controllers/foo/bars_controller.rb:30:11:30:28 | ...[...] | provenance |  |
 | app/controllers/foo/bars_controller.rb:30:11:30:28 | ...[...] | app/controllers/foo/bars_controller.rb:30:5:30:7 | str | provenance |  |
@@ -32,10 +33,12 @@ edges
 | app/views/foo/bars/show.html.erb:8:9:8:21 | call to local_assigns [element :display_text] | app/views/foo/bars/show.html.erb:8:9:8:36 | ...[...] | provenance |  |
 | app/views/foo/bars/show.html.erb:12:9:12:21 | call to local_assigns [element :display_text] | app/views/foo/bars/show.html.erb:12:9:12:26 | ...[...] | provenance |  |
 | app/views/foo/bars/show.html.erb:17:15:17:27 | call to local_assigns [element :display_text] | app/views/foo/bars/show.html.erb:17:15:17:32 | ...[...] | provenance |  |
-| app/views/foo/bars/show.html.erb:43:64:43:87 | ... + ... | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text | provenance |  |
-| app/views/foo/bars/show.html.erb:43:64:43:87 | ... + ... | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text] | provenance |  |
-| app/views/foo/bars/show.html.erb:43:64:43:87 | ... + ... [element] | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text [element] | provenance |  |
-| app/views/foo/bars/show.html.erb:43:64:43:87 | ... + ... [element] | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text, element] | provenance |  |
+| app/views/foo/bars/show.html.erb:43:48:43:89 | call to [] [element :display_text, element] | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text [element] | provenance |  |
+| app/views/foo/bars/show.html.erb:43:48:43:89 | call to [] [element :display_text, element] | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text, element] | provenance |  |
+| app/views/foo/bars/show.html.erb:43:48:43:89 | call to [] [element :display_text] | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text | provenance |  |
+| app/views/foo/bars/show.html.erb:43:48:43:89 | call to [] [element :display_text] | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text] | provenance |  |
+| app/views/foo/bars/show.html.erb:43:64:43:87 | ... + ... | app/views/foo/bars/show.html.erb:43:48:43:89 | call to [] [element :display_text] | provenance |  |
+| app/views/foo/bars/show.html.erb:43:64:43:87 | ... + ... [element] | app/views/foo/bars/show.html.erb:43:48:43:89 | call to [] [element :display_text, element] | provenance |  |
 | app/views/foo/bars/show.html.erb:43:76:43:87 | call to display_text | app/views/foo/bars/show.html.erb:43:64:43:87 | ... + ... | provenance |  |
 | app/views/foo/bars/show.html.erb:43:76:43:87 | call to display_text | app/views/foo/bars/show.html.erb:43:64:43:87 | ... + ... [element] | provenance |  |
 | app/views/foo/bars/show.html.erb:53:29:53:34 | call to params | app/views/foo/bars/show.html.erb:53:29:53:44 | ...[...] | provenance |  |
@@ -57,6 +60,7 @@ nodes
 | app/controllers/foo/bars_controller.rb:24:39:24:44 | call to params | semmle.label | call to params |
 | app/controllers/foo/bars_controller.rb:24:39:24:59 | ... = ... | semmle.label | ... = ... |
 | app/controllers/foo/bars_controller.rb:24:39:24:59 | ...[...] | semmle.label | ...[...] |
+| app/controllers/foo/bars_controller.rb:26:37:26:76 | call to [] [element :display_text] | semmle.label | call to [] [element :display_text] |
 | app/controllers/foo/bars_controller.rb:26:53:26:54 | dt | semmle.label | dt |
 | app/controllers/foo/bars_controller.rb:30:5:30:7 | str | semmle.label | str |
 | app/controllers/foo/bars_controller.rb:30:11:30:16 | call to params | semmle.label | call to params |
@@ -78,6 +82,8 @@ nodes
 | app/views/foo/bars/show.html.erb:17:15:17:32 | ...[...] | semmle.label | ...[...] |
 | app/views/foo/bars/show.html.erb:35:3:35:14 | call to display_text | semmle.label | call to display_text |
 | app/views/foo/bars/show.html.erb:40:3:40:16 | @instance_text | semmle.label | @instance_text |
+| app/views/foo/bars/show.html.erb:43:48:43:89 | call to [] [element :display_text, element] | semmle.label | call to [] [element :display_text, element] |
+| app/views/foo/bars/show.html.erb:43:48:43:89 | call to [] [element :display_text] | semmle.label | call to [] [element :display_text] |
 | app/views/foo/bars/show.html.erb:43:64:43:87 | ... + ... | semmle.label | ... + ... |
 | app/views/foo/bars/show.html.erb:43:64:43:87 | ... + ... [element] | semmle.label | ... + ... [element] |
 | app/views/foo/bars/show.html.erb:43:76:43:87 | call to display_text | semmle.label | call to display_text |

--- a/ruby/ql/test/query-tests/security/cwe-079/StoredXSS.expected
+++ b/ruby/ql/test/query-tests/security/cwe-079/StoredXSS.expected
@@ -3,12 +3,13 @@ edges
 | app/controllers/foo/stores_controller.rb:8:10:8:29 | call to read | app/controllers/foo/stores_controller.rb:8:5:8:6 | dt | provenance |  |
 | app/controllers/foo/stores_controller.rb:9:22:9:23 | dt | app/controllers/foo/stores_controller.rb:13:55:13:56 | dt | provenance |  |
 | app/controllers/foo/stores_controller.rb:9:22:9:23 | dt | app/views/foo/stores/show.html.erb:37:3:37:16 | @instance_text | provenance |  |
-| app/controllers/foo/stores_controller.rb:13:55:13:56 | dt | app/views/foo/stores/show.html.erb:2:9:2:20 | call to display_text | provenance |  |
-| app/controllers/foo/stores_controller.rb:13:55:13:56 | dt | app/views/foo/stores/show.html.erb:5:9:5:21 | call to local_assigns [element :display_text] | provenance |  |
-| app/controllers/foo/stores_controller.rb:13:55:13:56 | dt | app/views/foo/stores/show.html.erb:9:9:9:21 | call to local_assigns [element :display_text] | provenance |  |
-| app/controllers/foo/stores_controller.rb:13:55:13:56 | dt | app/views/foo/stores/show.html.erb:14:15:14:27 | call to local_assigns [element :display_text] | provenance |  |
-| app/controllers/foo/stores_controller.rb:13:55:13:56 | dt | app/views/foo/stores/show.html.erb:32:3:32:14 | call to display_text | provenance |  |
-| app/controllers/foo/stores_controller.rb:13:55:13:56 | dt | app/views/foo/stores/show.html.erb:40:76:40:87 | call to display_text | provenance |  |
+| app/controllers/foo/stores_controller.rb:13:39:13:78 | call to [] [element :display_text] | app/views/foo/stores/show.html.erb:2:9:2:20 | call to display_text | provenance |  |
+| app/controllers/foo/stores_controller.rb:13:39:13:78 | call to [] [element :display_text] | app/views/foo/stores/show.html.erb:5:9:5:21 | call to local_assigns [element :display_text] | provenance |  |
+| app/controllers/foo/stores_controller.rb:13:39:13:78 | call to [] [element :display_text] | app/views/foo/stores/show.html.erb:9:9:9:21 | call to local_assigns [element :display_text] | provenance |  |
+| app/controllers/foo/stores_controller.rb:13:39:13:78 | call to [] [element :display_text] | app/views/foo/stores/show.html.erb:14:15:14:27 | call to local_assigns [element :display_text] | provenance |  |
+| app/controllers/foo/stores_controller.rb:13:39:13:78 | call to [] [element :display_text] | app/views/foo/stores/show.html.erb:32:3:32:14 | call to display_text | provenance |  |
+| app/controllers/foo/stores_controller.rb:13:39:13:78 | call to [] [element :display_text] | app/views/foo/stores/show.html.erb:40:76:40:87 | call to display_text | provenance |  |
+| app/controllers/foo/stores_controller.rb:13:55:13:56 | dt | app/controllers/foo/stores_controller.rb:13:39:13:78 | call to [] [element :display_text] | provenance |  |
 | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text [element] | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text | provenance |  |
 | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text, element] | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] [element] | provenance |  |
 | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text] | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] | provenance |  |
@@ -16,10 +17,12 @@ edges
 | app/views/foo/stores/show.html.erb:5:9:5:21 | call to local_assigns [element :display_text] | app/views/foo/stores/show.html.erb:5:9:5:36 | ...[...] | provenance |  |
 | app/views/foo/stores/show.html.erb:9:9:9:21 | call to local_assigns [element :display_text] | app/views/foo/stores/show.html.erb:9:9:9:26 | ...[...] | provenance |  |
 | app/views/foo/stores/show.html.erb:14:15:14:27 | call to local_assigns [element :display_text] | app/views/foo/stores/show.html.erb:14:15:14:32 | ...[...] | provenance |  |
-| app/views/foo/stores/show.html.erb:40:64:40:87 | ... + ... | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text | provenance |  |
-| app/views/foo/stores/show.html.erb:40:64:40:87 | ... + ... | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text] | provenance |  |
-| app/views/foo/stores/show.html.erb:40:64:40:87 | ... + ... [element] | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text [element] | provenance |  |
-| app/views/foo/stores/show.html.erb:40:64:40:87 | ... + ... [element] | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text, element] | provenance |  |
+| app/views/foo/stores/show.html.erb:40:48:40:89 | call to [] [element :display_text, element] | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text [element] | provenance |  |
+| app/views/foo/stores/show.html.erb:40:48:40:89 | call to [] [element :display_text, element] | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text, element] | provenance |  |
+| app/views/foo/stores/show.html.erb:40:48:40:89 | call to [] [element :display_text] | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text | provenance |  |
+| app/views/foo/stores/show.html.erb:40:48:40:89 | call to [] [element :display_text] | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text] | provenance |  |
+| app/views/foo/stores/show.html.erb:40:64:40:87 | ... + ... | app/views/foo/stores/show.html.erb:40:48:40:89 | call to [] [element :display_text] | provenance |  |
+| app/views/foo/stores/show.html.erb:40:64:40:87 | ... + ... [element] | app/views/foo/stores/show.html.erb:40:48:40:89 | call to [] [element :display_text, element] | provenance |  |
 | app/views/foo/stores/show.html.erb:40:76:40:87 | call to display_text | app/views/foo/stores/show.html.erb:40:64:40:87 | ... + ... | provenance |  |
 | app/views/foo/stores/show.html.erb:40:76:40:87 | call to display_text | app/views/foo/stores/show.html.erb:40:64:40:87 | ... + ... [element] | provenance |  |
 | app/views/foo/stores/show.html.erb:86:17:86:28 | call to handle | app/views/foo/stores/show.html.erb:86:3:86:29 | call to sprintf | provenance |  |
@@ -27,6 +30,7 @@ nodes
 | app/controllers/foo/stores_controller.rb:8:5:8:6 | dt | semmle.label | dt |
 | app/controllers/foo/stores_controller.rb:8:10:8:29 | call to read | semmle.label | call to read |
 | app/controllers/foo/stores_controller.rb:9:22:9:23 | dt | semmle.label | dt |
+| app/controllers/foo/stores_controller.rb:13:39:13:78 | call to [] [element :display_text] | semmle.label | call to [] [element :display_text] |
 | app/controllers/foo/stores_controller.rb:13:55:13:56 | dt | semmle.label | dt |
 | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text | semmle.label | call to display_text |
 | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text [element] | semmle.label | call to display_text [element] |
@@ -43,6 +47,8 @@ nodes
 | app/views/foo/stores/show.html.erb:14:15:14:32 | ...[...] | semmle.label | ...[...] |
 | app/views/foo/stores/show.html.erb:32:3:32:14 | call to display_text | semmle.label | call to display_text |
 | app/views/foo/stores/show.html.erb:37:3:37:16 | @instance_text | semmle.label | @instance_text |
+| app/views/foo/stores/show.html.erb:40:48:40:89 | call to [] [element :display_text, element] | semmle.label | call to [] [element :display_text, element] |
+| app/views/foo/stores/show.html.erb:40:48:40:89 | call to [] [element :display_text] | semmle.label | call to [] [element :display_text] |
 | app/views/foo/stores/show.html.erb:40:64:40:87 | ... + ... | semmle.label | ... + ... |
 | app/views/foo/stores/show.html.erb:40:64:40:87 | ... + ... [element] | semmle.label | ... + ... [element] |
 | app/views/foo/stores/show.html.erb:40:76:40:87 | call to display_text | semmle.label | call to display_text |

--- a/ruby/ql/test/query-tests/security/cwe-089/SqlInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-089/SqlInjection.expected
@@ -8,10 +8,12 @@ edges
 | ActiveRecordInjection.rb:43:29:43:39 | ...[...] | ActiveRecordInjection.rb:43:20:43:42 | "id = '#{...}'" | provenance |  |
 | ActiveRecordInjection.rb:48:30:48:35 | call to params | ActiveRecordInjection.rb:48:30:48:40 | ...[...] | provenance |  |
 | ActiveRecordInjection.rb:48:30:48:40 | ...[...] | ActiveRecordInjection.rb:48:21:48:43 | "id = '#{...}'" | provenance |  |
-| ActiveRecordInjection.rb:52:22:52:44 | "id = '#{...}'" | ActiveRecordInjection.rb:52:21:52:45 | call to [] | provenance |  |
+| ActiveRecordInjection.rb:52:21:52:45 | call to [] [element 0] | ActiveRecordInjection.rb:52:21:52:45 | call to [] | provenance |  |
+| ActiveRecordInjection.rb:52:22:52:44 | "id = '#{...}'" | ActiveRecordInjection.rb:52:21:52:45 | call to [] [element 0] | provenance |  |
 | ActiveRecordInjection.rb:52:31:52:36 | call to params | ActiveRecordInjection.rb:52:31:52:41 | ...[...] | provenance |  |
 | ActiveRecordInjection.rb:52:31:52:41 | ...[...] | ActiveRecordInjection.rb:52:22:52:44 | "id = '#{...}'" | provenance |  |
-| ActiveRecordInjection.rb:57:23:57:45 | "id = '#{...}'" | ActiveRecordInjection.rb:57:22:57:46 | call to [] | provenance |  |
+| ActiveRecordInjection.rb:57:22:57:46 | call to [] [element 0] | ActiveRecordInjection.rb:57:22:57:46 | call to [] | provenance |  |
+| ActiveRecordInjection.rb:57:23:57:45 | "id = '#{...}'" | ActiveRecordInjection.rb:57:22:57:46 | call to [] [element 0] | provenance |  |
 | ActiveRecordInjection.rb:57:32:57:37 | call to params | ActiveRecordInjection.rb:57:32:57:42 | ...[...] | provenance |  |
 | ActiveRecordInjection.rb:57:32:57:42 | ...[...] | ActiveRecordInjection.rb:57:23:57:45 | "id = '#{...}'" | provenance |  |
 | ActiveRecordInjection.rb:62:21:62:26 | call to params | ActiveRecordInjection.rb:62:21:62:35 | ...[...] | provenance |  |
@@ -105,10 +107,12 @@ nodes
 | ActiveRecordInjection.rb:48:30:48:35 | call to params | semmle.label | call to params |
 | ActiveRecordInjection.rb:48:30:48:40 | ...[...] | semmle.label | ...[...] |
 | ActiveRecordInjection.rb:52:21:52:45 | call to [] | semmle.label | call to [] |
+| ActiveRecordInjection.rb:52:21:52:45 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | ActiveRecordInjection.rb:52:22:52:44 | "id = '#{...}'" | semmle.label | "id = '#{...}'" |
 | ActiveRecordInjection.rb:52:31:52:36 | call to params | semmle.label | call to params |
 | ActiveRecordInjection.rb:52:31:52:41 | ...[...] | semmle.label | ...[...] |
 | ActiveRecordInjection.rb:57:22:57:46 | call to [] | semmle.label | call to [] |
+| ActiveRecordInjection.rb:57:22:57:46 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | ActiveRecordInjection.rb:57:23:57:45 | "id = '#{...}'" | semmle.label | "id = '#{...}'" |
 | ActiveRecordInjection.rb:57:32:57:37 | call to params | semmle.label | call to params |
 | ActiveRecordInjection.rb:57:32:57:42 | ...[...] | semmle.label | ...[...] |

--- a/ruby/ql/test/query-tests/security/cwe-094/UnsafeCodeConstruction/UnsafeCodeConstruction.expected
+++ b/ruby/ql/test/query-tests/security/cwe-094/UnsafeCodeConstruction/UnsafeCodeConstruction.expected
@@ -5,7 +5,8 @@ edges
 | impl/unsafeCode.rb:28:17:28:22 | my_arr | impl/unsafeCode.rb:29:10:29:15 | my_arr | provenance |  |
 | impl/unsafeCode.rb:32:21:32:21 | x | impl/unsafeCode.rb:33:12:33:12 | x | provenance |  |
 | impl/unsafeCode.rb:33:5:33:7 | arr [element 0] | impl/unsafeCode.rb:34:10:34:12 | arr | provenance |  |
-| impl/unsafeCode.rb:33:12:33:12 | x | impl/unsafeCode.rb:33:5:33:7 | arr [element 0] | provenance |  |
+| impl/unsafeCode.rb:33:11:33:23 | call to [] [element 0] | impl/unsafeCode.rb:33:5:33:7 | arr [element 0] | provenance |  |
+| impl/unsafeCode.rb:33:12:33:12 | x | impl/unsafeCode.rb:33:11:33:23 | call to [] [element 0] | provenance |  |
 | impl/unsafeCode.rb:37:15:37:15 | x | impl/unsafeCode.rb:39:14:39:14 | x | provenance |  |
 | impl/unsafeCode.rb:39:5:39:7 | [post] arr [element] | impl/unsafeCode.rb:40:10:40:12 | arr | provenance |  |
 | impl/unsafeCode.rb:39:5:39:7 | [post] arr [element] | impl/unsafeCode.rb:44:10:44:12 | arr | provenance |  |
@@ -18,9 +19,11 @@ edges
 | impl/unsafeCode.rb:60:11:60:18 | call to Array [element 0] | impl/unsafeCode.rb:60:5:60:7 | arr [element 0] | provenance |  |
 | impl/unsafeCode.rb:60:17:60:17 | x | impl/unsafeCode.rb:60:11:60:18 | call to Array [element 0] | provenance |  |
 | impl/unsafeCode.rb:63:5:63:8 | arr2 [element 0] | impl/unsafeCode.rb:64:10:64:13 | arr2 | provenance |  |
+| impl/unsafeCode.rb:63:12:63:43 | call to [] [element 0] | impl/unsafeCode.rb:63:5:63:8 | arr2 [element 0] | provenance |  |
 | impl/unsafeCode.rb:63:13:63:32 | call to Array [element 1] | impl/unsafeCode.rb:63:13:63:42 | call to join | provenance |  |
-| impl/unsafeCode.rb:63:13:63:42 | call to join | impl/unsafeCode.rb:63:5:63:8 | arr2 [element 0] | provenance |  |
-| impl/unsafeCode.rb:63:30:63:30 | y | impl/unsafeCode.rb:63:13:63:32 | call to Array [element 1] | provenance |  |
+| impl/unsafeCode.rb:63:13:63:42 | call to join | impl/unsafeCode.rb:63:12:63:43 | call to [] [element 0] | provenance |  |
+| impl/unsafeCode.rb:63:19:63:31 | call to [] [element 1] | impl/unsafeCode.rb:63:13:63:32 | call to Array [element 1] | provenance |  |
+| impl/unsafeCode.rb:63:30:63:30 | y | impl/unsafeCode.rb:63:19:63:31 | call to [] [element 1] | provenance |  |
 nodes
 | impl/unsafeCode.rb:2:12:2:17 | target | semmle.label | target |
 | impl/unsafeCode.rb:3:17:3:25 | #{...} | semmle.label | #{...} |
@@ -32,6 +35,7 @@ nodes
 | impl/unsafeCode.rb:29:10:29:15 | my_arr | semmle.label | my_arr |
 | impl/unsafeCode.rb:32:21:32:21 | x | semmle.label | x |
 | impl/unsafeCode.rb:33:5:33:7 | arr [element 0] | semmle.label | arr [element 0] |
+| impl/unsafeCode.rb:33:11:33:23 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | impl/unsafeCode.rb:33:12:33:12 | x | semmle.label | x |
 | impl/unsafeCode.rb:34:10:34:12 | arr | semmle.label | arr |
 | impl/unsafeCode.rb:37:15:37:15 | x | semmle.label | x |
@@ -50,8 +54,10 @@ nodes
 | impl/unsafeCode.rb:60:17:60:17 | x | semmle.label | x |
 | impl/unsafeCode.rb:61:10:61:12 | arr | semmle.label | arr |
 | impl/unsafeCode.rb:63:5:63:8 | arr2 [element 0] | semmle.label | arr2 [element 0] |
+| impl/unsafeCode.rb:63:12:63:43 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | impl/unsafeCode.rb:63:13:63:32 | call to Array [element 1] | semmle.label | call to Array [element 1] |
 | impl/unsafeCode.rb:63:13:63:42 | call to join | semmle.label | call to join |
+| impl/unsafeCode.rb:63:19:63:31 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | impl/unsafeCode.rb:63:30:63:30 | y | semmle.label | y |
 | impl/unsafeCode.rb:64:10:64:13 | arr2 | semmle.label | arr2 |
 subpaths

--- a/ruby/ql/test/query-tests/security/cwe-312/CleartextLogging.expected
+++ b/ruby/ql/test/query-tests/security/cwe-312/CleartextLogging.expected
@@ -12,7 +12,8 @@ edges
 | logging.rb:3:1:3:8 | password | logging.rb:28:26:28:33 | password | provenance |  |
 | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | logging.rb:3:1:3:8 | password | provenance |  |
 | logging.rb:30:1:30:4 | hsh1 [element :password] | logging.rb:38:20:38:23 | hsh1 [element :password] | provenance |  |
-| logging.rb:30:20:30:53 | "aec5058e61f7f122998b1a30ee2c66b6" | logging.rb:30:1:30:4 | hsh1 [element :password] | provenance |  |
+| logging.rb:30:8:30:55 | call to [] [element :password] | logging.rb:30:1:30:4 | hsh1 [element :password] | provenance |  |
+| logging.rb:30:20:30:53 | "aec5058e61f7f122998b1a30ee2c66b6" | logging.rb:30:8:30:55 | call to [] [element :password] | provenance |  |
 | logging.rb:34:1:34:4 | [post] hsh2 [element :password] | logging.rb:35:1:35:4 | hsh3 [element :password] | provenance |  |
 | logging.rb:34:1:34:4 | [post] hsh2 [element :password] | logging.rb:40:20:40:23 | hsh2 [element :password] | provenance |  |
 | logging.rb:34:19:34:52 | "beeda625d7306b45784d91ea0336e201" | logging.rb:34:1:34:4 | [post] hsh2 [element :password] | provenance |  |
@@ -53,6 +54,7 @@ nodes
 | logging.rb:26:18:26:34 | "pw: #{...}" | semmle.label | "pw: #{...}" |
 | logging.rb:28:26:28:33 | password | semmle.label | password |
 | logging.rb:30:1:30:4 | hsh1 [element :password] | semmle.label | hsh1 [element :password] |
+| logging.rb:30:8:30:55 | call to [] [element :password] | semmle.label | call to [] [element :password] |
 | logging.rb:30:20:30:53 | "aec5058e61f7f122998b1a30ee2c66b6" | semmle.label | "aec5058e61f7f122998b1a30ee2c66b6" |
 | logging.rb:34:1:34:4 | [post] hsh2 [element :password] | semmle.label | [post] hsh2 [element :password] |
 | logging.rb:34:19:34:52 | "beeda625d7306b45784d91ea0336e201" | semmle.label | "beeda625d7306b45784d91ea0336e201" |

--- a/ruby/ql/test/query-tests/security/cwe-506/HardcodedDataInterpretedAsCode.expected
+++ b/ruby/ql/test/query-tests/security/cwe-506/HardcodedDataInterpretedAsCode.expected
@@ -1,6 +1,7 @@
 edges
 | tst.rb:1:7:1:7 | r | tst.rb:2:4:2:4 | r | provenance |  |
-| tst.rb:2:4:2:4 | r | tst.rb:2:3:2:15 | call to pack | provenance |  |
+| tst.rb:2:3:2:5 | call to [] [element 0] | tst.rb:2:3:2:15 | call to pack | provenance |  |
+| tst.rb:2:4:2:4 | r | tst.rb:2:3:2:5 | call to [] [element 0] | provenance |  |
 | tst.rb:5:1:5:23 | totally_harmless_string | tst.rb:7:8:7:30 | totally_harmless_string | provenance |  |
 | tst.rb:5:27:5:72 | "707574732822636f646520696e6a6..." | tst.rb:5:1:5:23 | totally_harmless_string | provenance |  |
 | tst.rb:7:8:7:30 | totally_harmless_string | tst.rb:1:7:1:7 | r | provenance |  |
@@ -12,6 +13,7 @@ edges
 | tst.rb:17:6:17:32 | another_questionable_string | tst.rb:17:6:17:38 | call to strip | provenance |  |
 nodes
 | tst.rb:1:7:1:7 | r | semmle.label | r |
+| tst.rb:2:3:2:5 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | tst.rb:2:3:2:15 | call to pack | semmle.label | call to pack |
 | tst.rb:2:4:2:4 | r | semmle.label | r |
 | tst.rb:5:1:5:23 | totally_harmless_string | semmle.label | totally_harmless_string |


### PR DESCRIPTION
Hides more synthetic nodes (such as synthetic block parameters), unhides all array/hash literal creations.