### PR TITLE
Data flow: Account for hidden `subpath` wrappers

### DIFF
--- a/csharp/ql/test/library-tests/dataflow/external-models/ExternalFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/external-models/ExternalFlow.expected
@@ -52,6 +52,8 @@ edges
 | ExternalFlow.cs:84:17:84:21 | access to local variable objs2 : T[] [element] : Object | ExternalFlow.cs:85:18:85:22 | access to local variable objs2 : T[] [element] : Object | provenance |  |
 | ExternalFlow.cs:84:25:84:41 | call to method Map<Object,Object> : T[] [element] : Object | ExternalFlow.cs:84:17:84:21 | access to local variable objs2 : T[] [element] : Object | provenance |  |
 | ExternalFlow.cs:84:29:84:32 | access to local variable objs : null [element] : Object | ExternalFlow.cs:84:25:84:41 | call to method Map<Object,Object> : T[] [element] : Object | provenance |  |
+| ExternalFlow.cs:84:29:84:32 | access to local variable objs : null [element] : Object | ExternalFlow.cs:84:35:84:35 | o : Object | provenance |  |
+| ExternalFlow.cs:84:35:84:35 | o : Object | ExternalFlow.cs:84:40:84:40 | access to parameter o : Object | provenance |  |
 | ExternalFlow.cs:85:18:85:22 | access to local variable objs2 : T[] [element] : Object | ExternalFlow.cs:85:18:85:25 | access to array element | provenance |  |
 | ExternalFlow.cs:90:17:90:17 | access to local variable s : String | ExternalFlow.cs:91:19:91:19 | access to local variable s : String | provenance |  |
 | ExternalFlow.cs:90:21:90:34 | object creation of type String : String | ExternalFlow.cs:90:17:90:17 | access to local variable s : String | provenance |  |
@@ -154,6 +156,8 @@ nodes
 | ExternalFlow.cs:84:17:84:21 | access to local variable objs2 : T[] [element] : Object | semmle.label | access to local variable objs2 : T[] [element] : Object |
 | ExternalFlow.cs:84:25:84:41 | call to method Map<Object,Object> : T[] [element] : Object | semmle.label | call to method Map<Object,Object> : T[] [element] : Object |
 | ExternalFlow.cs:84:29:84:32 | access to local variable objs : null [element] : Object | semmle.label | access to local variable objs : null [element] : Object |
+| ExternalFlow.cs:84:35:84:35 | o : Object | semmle.label | o : Object |
+| ExternalFlow.cs:84:40:84:40 | access to parameter o : Object | semmle.label | access to parameter o : Object |
 | ExternalFlow.cs:85:18:85:22 | access to local variable objs2 : T[] [element] : Object | semmle.label | access to local variable objs2 : T[] [element] : Object |
 | ExternalFlow.cs:85:18:85:25 | access to array element | semmle.label | access to array element |
 | ExternalFlow.cs:90:17:90:17 | access to local variable s : String | semmle.label | access to local variable s : String |
@@ -201,6 +205,7 @@ nodes
 | ExternalFlow.cs:263:30:263:30 | access to parameter a : MyInlineArray [element] : Object | semmle.label | access to parameter a : MyInlineArray [element] : Object |
 | ExternalFlow.cs:264:18:264:18 | access to local variable b | semmle.label | access to local variable b |
 subpaths
+| ExternalFlow.cs:84:29:84:32 | access to local variable objs : null [element] : Object | ExternalFlow.cs:84:35:84:35 | o : Object | ExternalFlow.cs:84:40:84:40 | access to parameter o : Object | ExternalFlow.cs:84:25:84:41 | call to method Map<Object,Object> : T[] [element] : Object |
 #select
 | ExternalFlow.cs:10:18:10:33 | call to method StepArgRes | ExternalFlow.cs:9:27:9:38 | object creation of type Object : Object | ExternalFlow.cs:10:18:10:33 | call to method StepArgRes | $@ | ExternalFlow.cs:9:27:9:38 | object creation of type Object : Object | object creation of type Object : Object |
 | ExternalFlow.cs:18:18:18:24 | access to local variable argOut1 | ExternalFlow.cs:15:29:15:40 | object creation of type Object : Object | ExternalFlow.cs:18:18:18:24 | access to local variable argOut1 | $@ | ExternalFlow.cs:15:29:15:40 | object creation of type Object : Object | object creation of type Object : Object |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
@@ -34,12 +34,18 @@ edges
 | Capture.cs:127:25:127:31 | tainted : String | Capture.cs:170:25:170:31 | access to parameter tainted : String | provenance |  |
 | Capture.cs:127:25:127:31 | tainted : String | Capture.cs:196:25:196:31 | access to parameter tainted : String | provenance |  |
 | Capture.cs:134:9:134:23 | [post] access to local function CaptureThrough1 : CaptureThrough1 [captured sink33] : String | Capture.cs:135:15:135:20 | access to local variable sink33 | provenance |  |
+| Capture.cs:134:9:134:23 | access to local function CaptureThrough1 : CaptureThrough1 [captured tainted] : String | Capture.cs:132:22:132:28 | access to parameter tainted : String | provenance |  |
 | Capture.cs:134:9:134:23 | access to local function CaptureThrough1 : CaptureThrough1 [captured tainted] : String | Capture.cs:134:9:134:23 | [post] access to local function CaptureThrough1 : CaptureThrough1 [captured sink33] : String | provenance |  |
+| Capture.cs:144:13:144:13 | access to local function M : M [captured tainted] : String | Capture.cs:142:26:142:32 | access to parameter tainted : String | provenance |  |
+| Capture.cs:144:13:144:13 | access to local function M : M [captured tainted] : String | Capture.cs:144:13:144:13 | [post] access to local function M : M [captured sink34] : String | provenance |  |
 | Capture.cs:146:9:146:23 | [post] access to local function CaptureThrough2 : CaptureThrough2 [captured sink34] : String | Capture.cs:147:15:147:20 | access to local variable sink34 | provenance |  |
+| Capture.cs:146:9:146:23 | access to local function CaptureThrough2 : CaptureThrough2 [captured tainted] : String | Capture.cs:144:13:144:13 | access to local function M : M [captured tainted] : String | provenance |  |
 | Capture.cs:146:9:146:23 | access to local function CaptureThrough2 : CaptureThrough2 [captured tainted] : String | Capture.cs:146:9:146:23 | [post] access to local function CaptureThrough2 : CaptureThrough2 [captured sink34] : String | provenance |  |
 | Capture.cs:155:30:155:44 | [post] access to local variable captureThrough3 : (...) => ... [captured sink35] : String | Capture.cs:156:15:156:20 | access to local variable sink35 | provenance |  |
+| Capture.cs:155:30:155:44 | access to local variable captureThrough3 : Func<String,String> [captured tainted] : String | Capture.cs:152:22:152:28 | access to parameter tainted : String | provenance |  |
 | Capture.cs:155:30:155:44 | access to local variable captureThrough3 : Func<String,String> [captured tainted] : String | Capture.cs:155:30:155:44 | [post] access to local variable captureThrough3 : (...) => ... [captured sink35] : String | provenance |  |
 | Capture.cs:162:13:162:18 | access to local variable sink36 : String | Capture.cs:163:15:163:20 | access to local variable sink36 | provenance |  |
+| Capture.cs:162:22:162:36 | access to local function CaptureThrough4 : CaptureThrough4 [captured tainted] : String | Capture.cs:160:20:160:26 | access to parameter tainted : String | provenance |  |
 | Capture.cs:162:22:162:36 | access to local function CaptureThrough4 : CaptureThrough4 [captured tainted] : String | Capture.cs:162:22:162:38 | call to local function CaptureThrough4 : String | provenance |  |
 | Capture.cs:162:22:162:38 | call to local function CaptureThrough4 : String | Capture.cs:162:13:162:18 | access to local variable sink36 : String | provenance |  |
 | Capture.cs:166:37:166:37 | p : String | Capture.cs:168:22:168:22 | access to parameter p : String | provenance |  |
@@ -47,6 +53,7 @@ edges
 | Capture.cs:170:25:170:31 | access to parameter tainted : String | Capture.cs:166:37:166:37 | p : String | provenance |  |
 | Capture.cs:170:25:170:31 | access to parameter tainted : String | Capture.cs:170:9:170:23 | [post] access to local function CaptureThrough5 : CaptureThrough5 [captured sink37] : String | provenance |  |
 | Capture.cs:190:26:190:26 | s : String | Capture.cs:193:20:193:20 | access to local function M : M [captured s] : String | provenance |  |
+| Capture.cs:193:20:193:20 | access to local function M : M [captured s] : String | Capture.cs:192:27:192:27 | access to parameter s : String | provenance |  |
 | Capture.cs:193:20:193:20 | access to local function M : M [captured s] : String | Capture.cs:193:20:193:22 | call to local function M : String | provenance |  |
 | Capture.cs:196:13:196:18 | access to local variable sink38 : String | Capture.cs:197:15:197:20 | access to local variable sink38 | provenance |  |
 | Capture.cs:196:22:196:32 | call to local function Id : String | Capture.cs:196:13:196:18 | access to local variable sink38 : String | provenance |  |
@@ -242,14 +249,18 @@ edges
 | GlobalDataFlow.cs:85:22:85:128 | call to method Zip<String,String,String> : IEnumerable<T> [element] : String | GlobalDataFlow.cs:85:22:85:136 | call to method First<String> : String | provenance |  |
 | GlobalDataFlow.cs:85:22:85:136 | call to method First<String> : String | GlobalDataFlow.cs:85:13:85:18 | access to local variable sink15 : String | provenance |  |
 | GlobalDataFlow.cs:85:23:85:66 | (...) ... : null [element] : String | GlobalDataFlow.cs:85:22:85:128 | call to method Zip<String,String,String> : IEnumerable<T> [element] : String | provenance |  |
+| GlobalDataFlow.cs:85:23:85:66 | (...) ... : null [element] : String | GlobalDataFlow.cs:85:118:85:118 | x : String | provenance |  |
 | GlobalDataFlow.cs:85:57:85:66 | { ..., ... } : null [element] : String | GlobalDataFlow.cs:85:23:85:66 | (...) ... : null [element] : String | provenance |  |
 | GlobalDataFlow.cs:85:59:85:64 | access to local variable sink14 : String | GlobalDataFlow.cs:85:57:85:66 | { ..., ... } : null [element] : String | provenance |  |
+| GlobalDataFlow.cs:85:118:85:118 | x : String | GlobalDataFlow.cs:85:127:85:127 | access to parameter x : String | provenance |  |
 | GlobalDataFlow.cs:87:13:87:18 | access to local variable sink16 : String | GlobalDataFlow.cs:88:15:88:20 | access to local variable sink16 | provenance |  |
 | GlobalDataFlow.cs:87:22:87:128 | call to method Zip<String,String,String> : IEnumerable<T> [element] : String | GlobalDataFlow.cs:87:22:87:136 | call to method First<String> : String | provenance |  |
 | GlobalDataFlow.cs:87:22:87:136 | call to method First<String> : String | GlobalDataFlow.cs:87:13:87:18 | access to local variable sink16 : String | provenance |  |
 | GlobalDataFlow.cs:87:70:87:113 | (...) ... : null [element] : String | GlobalDataFlow.cs:87:22:87:128 | call to method Zip<String,String,String> : IEnumerable<T> [element] : String | provenance |  |
+| GlobalDataFlow.cs:87:70:87:113 | (...) ... : null [element] : String | GlobalDataFlow.cs:87:121:87:121 | y : String | provenance |  |
 | GlobalDataFlow.cs:87:104:87:113 | { ..., ... } : null [element] : String | GlobalDataFlow.cs:87:70:87:113 | (...) ... : null [element] : String | provenance |  |
 | GlobalDataFlow.cs:87:106:87:111 | access to local variable sink15 : String | GlobalDataFlow.cs:87:104:87:113 | { ..., ... } : null [element] : String | provenance |  |
+| GlobalDataFlow.cs:87:121:87:121 | y : String | GlobalDataFlow.cs:87:127:87:127 | access to parameter y : String | provenance |  |
 | GlobalDataFlow.cs:138:40:138:40 | x : String | GlobalDataFlow.cs:138:63:138:63 | access to parameter x : String | provenance |  |
 | GlobalDataFlow.cs:138:63:138:63 | access to parameter x : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String | provenance |  |
 | GlobalDataFlow.cs:138:63:138:63 | access to parameter x : String | GlobalDataFlow.cs:387:46:387:46 | x : String | provenance |  |
@@ -287,7 +298,9 @@ edges
 | GlobalDataFlow.cs:211:44:211:61 | { ..., ... } : null [element] : String | GlobalDataFlow.cs:211:38:211:61 | array creation of type String[] : null [element] : String | provenance |  |
 | GlobalDataFlow.cs:211:46:211:59 | "taint source" : String | GlobalDataFlow.cs:211:44:211:61 | { ..., ... } : null [element] : String | provenance |  |
 | GlobalDataFlow.cs:214:35:214:45 | sinkParam10 : String | GlobalDataFlow.cs:214:58:214:68 | access to parameter sinkParam10 | provenance |  |
+| GlobalDataFlow.cs:214:35:214:45 | sinkParam10 : String | GlobalDataFlow.cs:214:79:214:89 | access to parameter sinkParam10 : String | provenance |  |
 | GlobalDataFlow.cs:215:71:215:71 | x : String | GlobalDataFlow.cs:215:89:215:89 | access to parameter x : String | provenance |  |
+| GlobalDataFlow.cs:215:89:215:89 | access to parameter x : String | GlobalDataFlow.cs:215:76:215:90 | call to method ReturnCheck2<String> : String | provenance |  |
 | GlobalDataFlow.cs:215:89:215:89 | access to parameter x : String | GlobalDataFlow.cs:321:32:321:41 | sinkParam9 : String | provenance |  |
 | GlobalDataFlow.cs:216:13:216:18 | access to local variable sink24 : String | GlobalDataFlow.cs:217:15:217:20 | access to local variable sink24 | provenance |  |
 | GlobalDataFlow.cs:216:22:216:28 | access to local variable tainted : IQueryable<T> [element] : String | GlobalDataFlow.cs:214:35:214:45 | sinkParam10 : String | provenance |  |
@@ -332,8 +345,11 @@ edges
 | GlobalDataFlow.cs:304:32:304:32 | x : String | GlobalDataFlow.cs:306:9:306:9 | access to parameter y : String | provenance |  |
 | GlobalDataFlow.cs:310:32:310:32 | x : String | GlobalDataFlow.cs:312:9:312:9 | access to parameter y : String | provenance |  |
 | GlobalDataFlow.cs:315:31:315:40 | sinkParam8 : String | GlobalDataFlow.cs:317:15:317:24 | access to parameter sinkParam8 | provenance |  |
+| GlobalDataFlow.cs:315:31:315:40 | sinkParam8 : String | GlobalDataFlow.cs:318:16:318:25 | access to parameter sinkParam8 : String | provenance |  |
 | GlobalDataFlow.cs:321:32:321:41 | sinkParam9 : String | GlobalDataFlow.cs:323:15:323:24 | access to parameter sinkParam9 | provenance |  |
+| GlobalDataFlow.cs:321:32:321:41 | sinkParam9 : String | GlobalDataFlow.cs:324:16:324:25 | access to parameter sinkParam9 : String | provenance |  |
 | GlobalDataFlow.cs:327:32:327:42 | sinkParam11 : String | GlobalDataFlow.cs:329:15:329:25 | access to parameter sinkParam11 | provenance |  |
+| GlobalDataFlow.cs:327:32:327:42 | sinkParam11 : String | GlobalDataFlow.cs:330:16:330:26 | access to parameter sinkParam11 : String | provenance |  |
 | GlobalDataFlow.cs:341:16:341:29 | "taint source" : String | GlobalDataFlow.cs:157:21:157:25 | call to method Out : String | provenance |  |
 | GlobalDataFlow.cs:341:16:341:29 | "taint source" : String | GlobalDataFlow.cs:193:22:193:42 | object creation of type Lazy<String> : Lazy<T> [property Value] : String | provenance |  |
 | GlobalDataFlow.cs:346:9:346:9 | access to parameter x : String | GlobalDataFlow.cs:160:20:160:24 | access to local variable sink7 : String | provenance |  |
@@ -500,15 +516,21 @@ nodes
 | Capture.cs:123:9:123:33 | [post] access to local function CaptureOutMultipleLambdas : CaptureOutMultipleLambdas [captured sink40] : String | semmle.label | [post] access to local function CaptureOutMultipleLambdas : CaptureOutMultipleLambdas [captured sink40] : String |
 | Capture.cs:124:15:124:20 | access to local variable sink40 | semmle.label | access to local variable sink40 |
 | Capture.cs:127:25:127:31 | tainted : String | semmle.label | tainted : String |
+| Capture.cs:132:22:132:28 | access to parameter tainted : String | semmle.label | access to parameter tainted : String |
 | Capture.cs:134:9:134:23 | [post] access to local function CaptureThrough1 : CaptureThrough1 [captured sink33] : String | semmle.label | [post] access to local function CaptureThrough1 : CaptureThrough1 [captured sink33] : String |
 | Capture.cs:134:9:134:23 | access to local function CaptureThrough1 : CaptureThrough1 [captured tainted] : String | semmle.label | access to local function CaptureThrough1 : CaptureThrough1 [captured tainted] : String |
 | Capture.cs:135:15:135:20 | access to local variable sink33 | semmle.label | access to local variable sink33 |
+| Capture.cs:142:26:142:32 | access to parameter tainted : String | semmle.label | access to parameter tainted : String |
+| Capture.cs:144:13:144:13 | [post] access to local function M : M [captured sink34] : String | semmle.label | [post] access to local function M : M [captured sink34] : String |
+| Capture.cs:144:13:144:13 | access to local function M : M [captured tainted] : String | semmle.label | access to local function M : M [captured tainted] : String |
 | Capture.cs:146:9:146:23 | [post] access to local function CaptureThrough2 : CaptureThrough2 [captured sink34] : String | semmle.label | [post] access to local function CaptureThrough2 : CaptureThrough2 [captured sink34] : String |
 | Capture.cs:146:9:146:23 | access to local function CaptureThrough2 : CaptureThrough2 [captured tainted] : String | semmle.label | access to local function CaptureThrough2 : CaptureThrough2 [captured tainted] : String |
 | Capture.cs:147:15:147:20 | access to local variable sink34 | semmle.label | access to local variable sink34 |
+| Capture.cs:152:22:152:28 | access to parameter tainted : String | semmle.label | access to parameter tainted : String |
 | Capture.cs:155:30:155:44 | [post] access to local variable captureThrough3 : (...) => ... [captured sink35] : String | semmle.label | [post] access to local variable captureThrough3 : (...) => ... [captured sink35] : String |
 | Capture.cs:155:30:155:44 | access to local variable captureThrough3 : Func<String,String> [captured tainted] : String | semmle.label | access to local variable captureThrough3 : Func<String,String> [captured tainted] : String |
 | Capture.cs:156:15:156:20 | access to local variable sink35 | semmle.label | access to local variable sink35 |
+| Capture.cs:160:20:160:26 | access to parameter tainted : String | semmle.label | access to parameter tainted : String |
 | Capture.cs:162:13:162:18 | access to local variable sink36 : String | semmle.label | access to local variable sink36 : String |
 | Capture.cs:162:22:162:36 | access to local function CaptureThrough4 : CaptureThrough4 [captured tainted] : String | semmle.label | access to local function CaptureThrough4 : CaptureThrough4 [captured tainted] : String |
 | Capture.cs:162:22:162:38 | call to local function CaptureThrough4 : String | semmle.label | call to local function CaptureThrough4 : String |
@@ -519,6 +541,7 @@ nodes
 | Capture.cs:170:25:170:31 | access to parameter tainted : String | semmle.label | access to parameter tainted : String |
 | Capture.cs:171:15:171:20 | access to local variable sink37 | semmle.label | access to local variable sink37 |
 | Capture.cs:190:26:190:26 | s : String | semmle.label | s : String |
+| Capture.cs:192:27:192:27 | access to parameter s : String | semmle.label | access to parameter s : String |
 | Capture.cs:193:20:193:20 | access to local function M : M [captured s] : String | semmle.label | access to local function M : M [captured s] : String |
 | Capture.cs:193:20:193:22 | call to local function M : String | semmle.label | call to local function M : String |
 | Capture.cs:196:13:196:18 | access to local variable sink38 : String | semmle.label | access to local variable sink38 : String |
@@ -658,6 +681,8 @@ nodes
 | GlobalDataFlow.cs:85:23:85:66 | (...) ... : null [element] : String | semmle.label | (...) ... : null [element] : String |
 | GlobalDataFlow.cs:85:57:85:66 | { ..., ... } : null [element] : String | semmle.label | { ..., ... } : null [element] : String |
 | GlobalDataFlow.cs:85:59:85:64 | access to local variable sink14 : String | semmle.label | access to local variable sink14 : String |
+| GlobalDataFlow.cs:85:118:85:118 | x : String | semmle.label | x : String |
+| GlobalDataFlow.cs:85:127:85:127 | access to parameter x : String | semmle.label | access to parameter x : String |
 | GlobalDataFlow.cs:86:15:86:20 | access to local variable sink15 | semmle.label | access to local variable sink15 |
 | GlobalDataFlow.cs:87:13:87:18 | access to local variable sink16 : String | semmle.label | access to local variable sink16 : String |
 | GlobalDataFlow.cs:87:22:87:128 | call to method Zip<String,String,String> : IEnumerable<T> [element] : String | semmle.label | call to method Zip<String,String,String> : IEnumerable<T> [element] : String |
@@ -665,6 +690,8 @@ nodes
 | GlobalDataFlow.cs:87:70:87:113 | (...) ... : null [element] : String | semmle.label | (...) ... : null [element] : String |
 | GlobalDataFlow.cs:87:104:87:113 | { ..., ... } : null [element] : String | semmle.label | { ..., ... } : null [element] : String |
 | GlobalDataFlow.cs:87:106:87:111 | access to local variable sink15 : String | semmle.label | access to local variable sink15 : String |
+| GlobalDataFlow.cs:87:121:87:121 | y : String | semmle.label | y : String |
+| GlobalDataFlow.cs:87:127:87:127 | access to parameter y : String | semmle.label | access to parameter y : String |
 | GlobalDataFlow.cs:88:15:88:20 | access to local variable sink16 | semmle.label | access to local variable sink16 |
 | GlobalDataFlow.cs:138:40:138:40 | x : String | semmle.label | x : String |
 | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String | semmle.label | call to method ApplyFunc<String,String> : String |
@@ -709,7 +736,9 @@ nodes
 | GlobalDataFlow.cs:211:46:211:59 | "taint source" : String | semmle.label | "taint source" : String |
 | GlobalDataFlow.cs:214:35:214:45 | sinkParam10 : String | semmle.label | sinkParam10 : String |
 | GlobalDataFlow.cs:214:58:214:68 | access to parameter sinkParam10 | semmle.label | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:214:79:214:89 | access to parameter sinkParam10 : String | semmle.label | access to parameter sinkParam10 : String |
 | GlobalDataFlow.cs:215:71:215:71 | x : String | semmle.label | x : String |
+| GlobalDataFlow.cs:215:76:215:90 | call to method ReturnCheck2<String> : String | semmle.label | call to method ReturnCheck2<String> : String |
 | GlobalDataFlow.cs:215:89:215:89 | access to parameter x : String | semmle.label | access to parameter x : String |
 | GlobalDataFlow.cs:216:13:216:18 | access to local variable sink24 : String | semmle.label | access to local variable sink24 : String |
 | GlobalDataFlow.cs:216:22:216:28 | access to local variable tainted : IQueryable<T> [element] : String | semmle.label | access to local variable tainted : IQueryable<T> [element] : String |
@@ -765,10 +794,13 @@ nodes
 | GlobalDataFlow.cs:312:9:312:9 | access to parameter y : String | semmle.label | access to parameter y : String |
 | GlobalDataFlow.cs:315:31:315:40 | sinkParam8 : String | semmle.label | sinkParam8 : String |
 | GlobalDataFlow.cs:317:15:317:24 | access to parameter sinkParam8 | semmle.label | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:318:16:318:25 | access to parameter sinkParam8 : String | semmle.label | access to parameter sinkParam8 : String |
 | GlobalDataFlow.cs:321:32:321:41 | sinkParam9 : String | semmle.label | sinkParam9 : String |
 | GlobalDataFlow.cs:323:15:323:24 | access to parameter sinkParam9 | semmle.label | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:324:16:324:25 | access to parameter sinkParam9 : String | semmle.label | access to parameter sinkParam9 : String |
 | GlobalDataFlow.cs:327:32:327:42 | sinkParam11 : String | semmle.label | sinkParam11 : String |
 | GlobalDataFlow.cs:329:15:329:25 | access to parameter sinkParam11 | semmle.label | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:330:16:330:26 | access to parameter sinkParam11 : String | semmle.label | access to parameter sinkParam11 : String |
 | GlobalDataFlow.cs:341:16:341:29 | "taint source" : String | semmle.label | "taint source" : String |
 | GlobalDataFlow.cs:346:9:346:9 | access to parameter x : String | semmle.label | access to parameter x : String |
 | GlobalDataFlow.cs:346:13:346:26 | "taint source" : String | semmle.label | "taint source" : String |
@@ -903,7 +935,13 @@ nodes
 | Splitting.cs:50:19:50:19 | access to local variable s | semmle.label | access to local variable s |
 | Splitting.cs:52:19:52:19 | access to local variable s | semmle.label | access to local variable s |
 subpaths
+| Capture.cs:134:9:134:23 | access to local function CaptureThrough1 : CaptureThrough1 [captured tainted] : String | Capture.cs:132:22:132:28 | access to parameter tainted : String | Capture.cs:132:22:132:28 | access to parameter tainted : String | Capture.cs:134:9:134:23 | [post] access to local function CaptureThrough1 : CaptureThrough1 [captured sink33] : String |
+| Capture.cs:144:13:144:13 | access to local function M : M [captured tainted] : String | Capture.cs:142:26:142:32 | access to parameter tainted : String | Capture.cs:142:26:142:32 | access to parameter tainted : String | Capture.cs:144:13:144:13 | [post] access to local function M : M [captured sink34] : String |
+| Capture.cs:146:9:146:23 | access to local function CaptureThrough2 : CaptureThrough2 [captured tainted] : String | Capture.cs:144:13:144:13 | access to local function M : M [captured tainted] : String | Capture.cs:144:13:144:13 | [post] access to local function M : M [captured sink34] : String | Capture.cs:146:9:146:23 | [post] access to local function CaptureThrough2 : CaptureThrough2 [captured sink34] : String |
+| Capture.cs:155:30:155:44 | access to local variable captureThrough3 : Func<String,String> [captured tainted] : String | Capture.cs:152:22:152:28 | access to parameter tainted : String | Capture.cs:152:22:152:28 | access to parameter tainted : String | Capture.cs:155:30:155:44 | [post] access to local variable captureThrough3 : (...) => ... [captured sink35] : String |
+| Capture.cs:162:22:162:36 | access to local function CaptureThrough4 : CaptureThrough4 [captured tainted] : String | Capture.cs:160:20:160:26 | access to parameter tainted : String | Capture.cs:160:20:160:26 | access to parameter tainted : String | Capture.cs:162:22:162:38 | call to local function CaptureThrough4 : String |
 | Capture.cs:170:25:170:31 | access to parameter tainted : String | Capture.cs:166:37:166:37 | p : String | Capture.cs:168:22:168:22 | access to parameter p : String | Capture.cs:170:9:170:23 | [post] access to local function CaptureThrough5 : CaptureThrough5 [captured sink37] : String |
+| Capture.cs:193:20:193:20 | access to local function M : M [captured s] : String | Capture.cs:192:27:192:27 | access to parameter s : String | Capture.cs:192:27:192:27 | access to parameter s : String | Capture.cs:193:20:193:22 | call to local function M : String |
 | Capture.cs:196:25:196:31 | access to parameter tainted : String | Capture.cs:190:26:190:26 | s : String | Capture.cs:193:20:193:22 | call to local function M : String | Capture.cs:196:22:196:32 | call to local function Id : String |
 | Capture.cs:221:21:221:34 | "taint source" : String | Capture.cs:213:22:213:22 | s : String | Capture.cs:215:16:218:9 | (...) => ... : (...) => ... [captured s] : String | Capture.cs:221:18:221:35 | call to method M3 : (...) => ... [captured s] : String |
 | Capture.cs:223:31:223:44 | "taint source" : String | Capture.cs:213:22:213:22 | s : String | Capture.cs:215:16:218:9 | (...) => ... : (...) => ... [captured s] : String | Capture.cs:223:28:223:45 | call to method M3 : (...) => ... [captured s] : String |
@@ -912,9 +950,16 @@ subpaths
 | GlobalDataFlow.cs:76:19:76:23 | access to local variable sink1 : String | GlobalDataFlow.cs:304:32:304:32 | x : String | GlobalDataFlow.cs:306:9:306:9 | access to parameter y : String | GlobalDataFlow.cs:76:30:76:34 | access to local variable sink2 : String |
 | GlobalDataFlow.cs:79:19:79:23 | access to local variable sink2 : String | GlobalDataFlow.cs:310:32:310:32 | x : String | GlobalDataFlow.cs:312:9:312:9 | access to parameter y : String | GlobalDataFlow.cs:79:30:79:34 | access to local variable sink3 : String |
 | GlobalDataFlow.cs:81:23:81:65 | (...) ... : null [element] : String | GlobalDataFlow.cs:553:71:553:71 | e : null [element] : String | GlobalDataFlow.cs:558:44:558:47 | delegate call : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> : IEnumerable<T> [element] : String |
+| GlobalDataFlow.cs:83:23:83:66 | (...) ... : null [element] : String | GlobalDataFlow.cs:315:31:315:40 | sinkParam8 : String | GlobalDataFlow.cs:318:16:318:25 | access to parameter sinkParam8 : String | GlobalDataFlow.cs:83:22:83:87 | call to method Select<String,String> : IEnumerable<T> [element] : String |
+| GlobalDataFlow.cs:85:23:85:66 | (...) ... : null [element] : String | GlobalDataFlow.cs:85:118:85:118 | x : String | GlobalDataFlow.cs:85:127:85:127 | access to parameter x : String | GlobalDataFlow.cs:85:22:85:128 | call to method Zip<String,String,String> : IEnumerable<T> [element] : String |
+| GlobalDataFlow.cs:87:70:87:113 | (...) ... : null [element] : String | GlobalDataFlow.cs:87:121:87:121 | y : String | GlobalDataFlow.cs:87:127:87:127 | access to parameter y : String | GlobalDataFlow.cs:87:22:87:128 | call to method Zip<String,String,String> : IEnumerable<T> [element] : String |
 | GlobalDataFlow.cs:138:63:138:63 | access to parameter x : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String |
 | GlobalDataFlow.cs:139:29:139:33 | access to local variable sink3 : String | GlobalDataFlow.cs:138:40:138:40 | x : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String | GlobalDataFlow.cs:139:21:139:34 | delegate call : String |
 | GlobalDataFlow.cs:147:39:147:43 | access to local variable sink4 : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:147:21:147:44 | call to method ApplyFunc<String,String> : String |
+| GlobalDataFlow.cs:215:89:215:89 | access to parameter x : String | GlobalDataFlow.cs:321:32:321:41 | sinkParam9 : String | GlobalDataFlow.cs:324:16:324:25 | access to parameter sinkParam9 : String | GlobalDataFlow.cs:215:76:215:90 | call to method ReturnCheck2<String> : String |
+| GlobalDataFlow.cs:216:22:216:28 | access to local variable tainted : IQueryable<T> [element] : String | GlobalDataFlow.cs:214:35:214:45 | sinkParam10 : String | GlobalDataFlow.cs:214:79:214:89 | access to parameter sinkParam10 : String | GlobalDataFlow.cs:216:22:216:39 | call to method Select<String,String> : IEnumerable<T> [element] : String |
+| GlobalDataFlow.cs:218:22:218:28 | access to local variable tainted : IQueryable<T> [element] : String | GlobalDataFlow.cs:215:71:215:71 | x : String | GlobalDataFlow.cs:215:76:215:90 | call to method ReturnCheck2<String> : String | GlobalDataFlow.cs:218:22:218:39 | call to method Select<String,String> : IQueryable<T> [element] : String |
+| GlobalDataFlow.cs:220:22:220:28 | access to local variable tainted : IQueryable<T> [element] : String | GlobalDataFlow.cs:327:32:327:42 | sinkParam11 : String | GlobalDataFlow.cs:330:16:330:26 | access to parameter sinkParam11 : String | GlobalDataFlow.cs:220:22:220:49 | call to method Select<String,String> : IEnumerable<T> [element] : String |
 | GlobalDataFlow.cs:300:37:300:37 | access to parameter x : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:300:17:300:38 | call to method ApplyFunc<T,T> : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
@@ -34,12 +34,18 @@ edges
 | Capture.cs:127:25:127:31 | tainted : String | Capture.cs:170:25:170:31 | access to parameter tainted : String | provenance |  |
 | Capture.cs:127:25:127:31 | tainted : String | Capture.cs:196:25:196:31 | access to parameter tainted : String | provenance |  |
 | Capture.cs:134:9:134:23 | [post] access to local function CaptureThrough1 : CaptureThrough1 [captured sink33] : String | Capture.cs:135:15:135:20 | access to local variable sink33 | provenance |  |
+| Capture.cs:134:9:134:23 | access to local function CaptureThrough1 : CaptureThrough1 [captured tainted] : String | Capture.cs:132:22:132:28 | access to parameter tainted : String | provenance |  |
 | Capture.cs:134:9:134:23 | access to local function CaptureThrough1 : CaptureThrough1 [captured tainted] : String | Capture.cs:134:9:134:23 | [post] access to local function CaptureThrough1 : CaptureThrough1 [captured sink33] : String | provenance |  |
+| Capture.cs:144:13:144:13 | access to local function M : M [captured tainted] : String | Capture.cs:142:26:142:32 | access to parameter tainted : String | provenance |  |
+| Capture.cs:144:13:144:13 | access to local function M : M [captured tainted] : String | Capture.cs:144:13:144:13 | [post] access to local function M : M [captured sink34] : String | provenance |  |
 | Capture.cs:146:9:146:23 | [post] access to local function CaptureThrough2 : CaptureThrough2 [captured sink34] : String | Capture.cs:147:15:147:20 | access to local variable sink34 | provenance |  |
+| Capture.cs:146:9:146:23 | access to local function CaptureThrough2 : CaptureThrough2 [captured tainted] : String | Capture.cs:144:13:144:13 | access to local function M : M [captured tainted] : String | provenance |  |
 | Capture.cs:146:9:146:23 | access to local function CaptureThrough2 : CaptureThrough2 [captured tainted] : String | Capture.cs:146:9:146:23 | [post] access to local function CaptureThrough2 : CaptureThrough2 [captured sink34] : String | provenance |  |
 | Capture.cs:155:30:155:44 | [post] access to local variable captureThrough3 : (...) => ... [captured sink35] : String | Capture.cs:156:15:156:20 | access to local variable sink35 | provenance |  |
+| Capture.cs:155:30:155:44 | access to local variable captureThrough3 : Func<String,String> [captured tainted] : String | Capture.cs:152:22:152:28 | access to parameter tainted : String | provenance |  |
 | Capture.cs:155:30:155:44 | access to local variable captureThrough3 : Func<String,String> [captured tainted] : String | Capture.cs:155:30:155:44 | [post] access to local variable captureThrough3 : (...) => ... [captured sink35] : String | provenance |  |
 | Capture.cs:162:13:162:18 | access to local variable sink36 : String | Capture.cs:163:15:163:20 | access to local variable sink36 | provenance |  |
+| Capture.cs:162:22:162:36 | access to local function CaptureThrough4 : CaptureThrough4 [captured tainted] : String | Capture.cs:160:20:160:26 | access to parameter tainted : String | provenance |  |
 | Capture.cs:162:22:162:36 | access to local function CaptureThrough4 : CaptureThrough4 [captured tainted] : String | Capture.cs:162:22:162:38 | call to local function CaptureThrough4 : String | provenance |  |
 | Capture.cs:162:22:162:38 | call to local function CaptureThrough4 : String | Capture.cs:162:13:162:18 | access to local variable sink36 : String | provenance |  |
 | Capture.cs:166:37:166:37 | p : String | Capture.cs:168:22:168:22 | access to parameter p : String | provenance |  |
@@ -47,6 +53,7 @@ edges
 | Capture.cs:170:25:170:31 | access to parameter tainted : String | Capture.cs:166:37:166:37 | p : String | provenance |  |
 | Capture.cs:170:25:170:31 | access to parameter tainted : String | Capture.cs:170:9:170:23 | [post] access to local function CaptureThrough5 : CaptureThrough5 [captured sink37] : String | provenance |  |
 | Capture.cs:190:26:190:26 | s : String | Capture.cs:193:20:193:20 | access to local function M : M [captured s] : String | provenance |  |
+| Capture.cs:193:20:193:20 | access to local function M : M [captured s] : String | Capture.cs:192:27:192:27 | access to parameter s : String | provenance |  |
 | Capture.cs:193:20:193:20 | access to local function M : M [captured s] : String | Capture.cs:193:20:193:22 | call to local function M : String | provenance |  |
 | Capture.cs:196:13:196:18 | access to local variable sink38 : String | Capture.cs:197:15:197:20 | access to local variable sink38 | provenance |  |
 | Capture.cs:196:22:196:32 | call to local function Id : String | Capture.cs:196:13:196:18 | access to local variable sink38 : String | provenance |  |
@@ -244,14 +251,18 @@ edges
 | GlobalDataFlow.cs:85:22:85:128 | call to method Zip<String,String,String> : IEnumerable<T> [element] : String | GlobalDataFlow.cs:85:22:85:136 | call to method First<String> : String | provenance |  |
 | GlobalDataFlow.cs:85:22:85:136 | call to method First<String> : String | GlobalDataFlow.cs:85:13:85:18 | access to local variable sink15 : String | provenance |  |
 | GlobalDataFlow.cs:85:23:85:66 | (...) ... : null [element] : String | GlobalDataFlow.cs:85:22:85:128 | call to method Zip<String,String,String> : IEnumerable<T> [element] : String | provenance |  |
+| GlobalDataFlow.cs:85:23:85:66 | (...) ... : null [element] : String | GlobalDataFlow.cs:85:118:85:118 | x : String | provenance |  |
 | GlobalDataFlow.cs:85:57:85:66 | { ..., ... } : null [element] : String | GlobalDataFlow.cs:85:23:85:66 | (...) ... : null [element] : String | provenance |  |
 | GlobalDataFlow.cs:85:59:85:64 | access to local variable sink14 : String | GlobalDataFlow.cs:85:57:85:66 | { ..., ... } : null [element] : String | provenance |  |
+| GlobalDataFlow.cs:85:118:85:118 | x : String | GlobalDataFlow.cs:85:127:85:127 | access to parameter x : String | provenance |  |
 | GlobalDataFlow.cs:87:13:87:18 | access to local variable sink16 : String | GlobalDataFlow.cs:88:15:88:20 | access to local variable sink16 | provenance |  |
 | GlobalDataFlow.cs:87:22:87:128 | call to method Zip<String,String,String> : IEnumerable<T> [element] : String | GlobalDataFlow.cs:87:22:87:136 | call to method First<String> : String | provenance |  |
 | GlobalDataFlow.cs:87:22:87:136 | call to method First<String> : String | GlobalDataFlow.cs:87:13:87:18 | access to local variable sink16 : String | provenance |  |
 | GlobalDataFlow.cs:87:70:87:113 | (...) ... : null [element] : String | GlobalDataFlow.cs:87:22:87:128 | call to method Zip<String,String,String> : IEnumerable<T> [element] : String | provenance |  |
+| GlobalDataFlow.cs:87:70:87:113 | (...) ... : null [element] : String | GlobalDataFlow.cs:87:121:87:121 | y : String | provenance |  |
 | GlobalDataFlow.cs:87:104:87:113 | { ..., ... } : null [element] : String | GlobalDataFlow.cs:87:70:87:113 | (...) ... : null [element] : String | provenance |  |
 | GlobalDataFlow.cs:87:106:87:111 | access to local variable sink15 : String | GlobalDataFlow.cs:87:104:87:113 | { ..., ... } : null [element] : String | provenance |  |
+| GlobalDataFlow.cs:87:121:87:121 | y : String | GlobalDataFlow.cs:87:127:87:127 | access to parameter y : String | provenance |  |
 | GlobalDataFlow.cs:89:13:89:18 | access to local variable sink17 : String | GlobalDataFlow.cs:90:15:90:20 | access to local variable sink17 | provenance |  |
 | GlobalDataFlow.cs:89:22:89:110 | call to method Aggregate<String,String,String> : String | GlobalDataFlow.cs:89:13:89:18 | access to local variable sink17 : String | provenance |  |
 | GlobalDataFlow.cs:89:23:89:66 | (...) ... : null [element] : String | GlobalDataFlow.cs:89:22:89:110 | call to method Aggregate<String,String,String> : String | provenance |  |
@@ -306,7 +317,9 @@ edges
 | GlobalDataFlow.cs:211:44:211:61 | { ..., ... } : null [element] : String | GlobalDataFlow.cs:211:38:211:61 | array creation of type String[] : null [element] : String | provenance |  |
 | GlobalDataFlow.cs:211:46:211:59 | "taint source" : String | GlobalDataFlow.cs:211:44:211:61 | { ..., ... } : null [element] : String | provenance |  |
 | GlobalDataFlow.cs:214:35:214:45 | sinkParam10 : String | GlobalDataFlow.cs:214:58:214:68 | access to parameter sinkParam10 | provenance |  |
+| GlobalDataFlow.cs:214:35:214:45 | sinkParam10 : String | GlobalDataFlow.cs:214:79:214:89 | access to parameter sinkParam10 : String | provenance |  |
 | GlobalDataFlow.cs:215:71:215:71 | x : String | GlobalDataFlow.cs:215:89:215:89 | access to parameter x : String | provenance |  |
+| GlobalDataFlow.cs:215:89:215:89 | access to parameter x : String | GlobalDataFlow.cs:215:76:215:90 | call to method ReturnCheck2<String> : String | provenance |  |
 | GlobalDataFlow.cs:215:89:215:89 | access to parameter x : String | GlobalDataFlow.cs:321:32:321:41 | sinkParam9 : String | provenance |  |
 | GlobalDataFlow.cs:216:13:216:18 | access to local variable sink24 : String | GlobalDataFlow.cs:217:15:217:20 | access to local variable sink24 | provenance |  |
 | GlobalDataFlow.cs:216:22:216:28 | access to local variable tainted : IQueryable<T> [element] : String | GlobalDataFlow.cs:214:35:214:45 | sinkParam10 : String | provenance |  |
@@ -351,8 +364,11 @@ edges
 | GlobalDataFlow.cs:304:32:304:32 | x : String | GlobalDataFlow.cs:306:9:306:9 | access to parameter y : String | provenance |  |
 | GlobalDataFlow.cs:310:32:310:32 | x : String | GlobalDataFlow.cs:312:9:312:9 | access to parameter y : String | provenance |  |
 | GlobalDataFlow.cs:315:31:315:40 | sinkParam8 : String | GlobalDataFlow.cs:317:15:317:24 | access to parameter sinkParam8 | provenance |  |
+| GlobalDataFlow.cs:315:31:315:40 | sinkParam8 : String | GlobalDataFlow.cs:318:16:318:25 | access to parameter sinkParam8 : String | provenance |  |
 | GlobalDataFlow.cs:321:32:321:41 | sinkParam9 : String | GlobalDataFlow.cs:323:15:323:24 | access to parameter sinkParam9 | provenance |  |
+| GlobalDataFlow.cs:321:32:321:41 | sinkParam9 : String | GlobalDataFlow.cs:324:16:324:25 | access to parameter sinkParam9 : String | provenance |  |
 | GlobalDataFlow.cs:327:32:327:42 | sinkParam11 : String | GlobalDataFlow.cs:329:15:329:25 | access to parameter sinkParam11 | provenance |  |
+| GlobalDataFlow.cs:327:32:327:42 | sinkParam11 : String | GlobalDataFlow.cs:330:16:330:26 | access to parameter sinkParam11 : String | provenance |  |
 | GlobalDataFlow.cs:341:16:341:29 | "taint source" : String | GlobalDataFlow.cs:157:21:157:25 | call to method Out : String | provenance |  |
 | GlobalDataFlow.cs:341:16:341:29 | "taint source" : String | GlobalDataFlow.cs:193:22:193:42 | object creation of type Lazy<String> : Lazy<T> [property Value] : String | provenance |  |
 | GlobalDataFlow.cs:346:9:346:9 | access to parameter x : String | GlobalDataFlow.cs:160:20:160:24 | access to local variable sink7 : String | provenance |  |
@@ -550,15 +566,21 @@ nodes
 | Capture.cs:123:9:123:33 | [post] access to local function CaptureOutMultipleLambdas : CaptureOutMultipleLambdas [captured sink40] : String | semmle.label | [post] access to local function CaptureOutMultipleLambdas : CaptureOutMultipleLambdas [captured sink40] : String |
 | Capture.cs:124:15:124:20 | access to local variable sink40 | semmle.label | access to local variable sink40 |
 | Capture.cs:127:25:127:31 | tainted : String | semmle.label | tainted : String |
+| Capture.cs:132:22:132:28 | access to parameter tainted : String | semmle.label | access to parameter tainted : String |
 | Capture.cs:134:9:134:23 | [post] access to local function CaptureThrough1 : CaptureThrough1 [captured sink33] : String | semmle.label | [post] access to local function CaptureThrough1 : CaptureThrough1 [captured sink33] : String |
 | Capture.cs:134:9:134:23 | access to local function CaptureThrough1 : CaptureThrough1 [captured tainted] : String | semmle.label | access to local function CaptureThrough1 : CaptureThrough1 [captured tainted] : String |
 | Capture.cs:135:15:135:20 | access to local variable sink33 | semmle.label | access to local variable sink33 |
+| Capture.cs:142:26:142:32 | access to parameter tainted : String | semmle.label | access to parameter tainted : String |
+| Capture.cs:144:13:144:13 | [post] access to local function M : M [captured sink34] : String | semmle.label | [post] access to local function M : M [captured sink34] : String |
+| Capture.cs:144:13:144:13 | access to local function M : M [captured tainted] : String | semmle.label | access to local function M : M [captured tainted] : String |
 | Capture.cs:146:9:146:23 | [post] access to local function CaptureThrough2 : CaptureThrough2 [captured sink34] : String | semmle.label | [post] access to local function CaptureThrough2 : CaptureThrough2 [captured sink34] : String |
 | Capture.cs:146:9:146:23 | access to local function CaptureThrough2 : CaptureThrough2 [captured tainted] : String | semmle.label | access to local function CaptureThrough2 : CaptureThrough2 [captured tainted] : String |
 | Capture.cs:147:15:147:20 | access to local variable sink34 | semmle.label | access to local variable sink34 |
+| Capture.cs:152:22:152:28 | access to parameter tainted : String | semmle.label | access to parameter tainted : String |
 | Capture.cs:155:30:155:44 | [post] access to local variable captureThrough3 : (...) => ... [captured sink35] : String | semmle.label | [post] access to local variable captureThrough3 : (...) => ... [captured sink35] : String |
 | Capture.cs:155:30:155:44 | access to local variable captureThrough3 : Func<String,String> [captured tainted] : String | semmle.label | access to local variable captureThrough3 : Func<String,String> [captured tainted] : String |
 | Capture.cs:156:15:156:20 | access to local variable sink35 | semmle.label | access to local variable sink35 |
+| Capture.cs:160:20:160:26 | access to parameter tainted : String | semmle.label | access to parameter tainted : String |
 | Capture.cs:162:13:162:18 | access to local variable sink36 : String | semmle.label | access to local variable sink36 : String |
 | Capture.cs:162:22:162:36 | access to local function CaptureThrough4 : CaptureThrough4 [captured tainted] : String | semmle.label | access to local function CaptureThrough4 : CaptureThrough4 [captured tainted] : String |
 | Capture.cs:162:22:162:38 | call to local function CaptureThrough4 : String | semmle.label | call to local function CaptureThrough4 : String |
@@ -569,6 +591,7 @@ nodes
 | Capture.cs:170:25:170:31 | access to parameter tainted : String | semmle.label | access to parameter tainted : String |
 | Capture.cs:171:15:171:20 | access to local variable sink37 | semmle.label | access to local variable sink37 |
 | Capture.cs:190:26:190:26 | s : String | semmle.label | s : String |
+| Capture.cs:192:27:192:27 | access to parameter s : String | semmle.label | access to parameter s : String |
 | Capture.cs:193:20:193:20 | access to local function M : M [captured s] : String | semmle.label | access to local function M : M [captured s] : String |
 | Capture.cs:193:20:193:22 | call to local function M : String | semmle.label | call to local function M : String |
 | Capture.cs:196:13:196:18 | access to local variable sink38 : String | semmle.label | access to local variable sink38 : String |
@@ -708,6 +731,8 @@ nodes
 | GlobalDataFlow.cs:85:23:85:66 | (...) ... : null [element] : String | semmle.label | (...) ... : null [element] : String |
 | GlobalDataFlow.cs:85:57:85:66 | { ..., ... } : null [element] : String | semmle.label | { ..., ... } : null [element] : String |
 | GlobalDataFlow.cs:85:59:85:64 | access to local variable sink14 : String | semmle.label | access to local variable sink14 : String |
+| GlobalDataFlow.cs:85:118:85:118 | x : String | semmle.label | x : String |
+| GlobalDataFlow.cs:85:127:85:127 | access to parameter x : String | semmle.label | access to parameter x : String |
 | GlobalDataFlow.cs:86:15:86:20 | access to local variable sink15 | semmle.label | access to local variable sink15 |
 | GlobalDataFlow.cs:87:13:87:18 | access to local variable sink16 : String | semmle.label | access to local variable sink16 : String |
 | GlobalDataFlow.cs:87:22:87:128 | call to method Zip<String,String,String> : IEnumerable<T> [element] : String | semmle.label | call to method Zip<String,String,String> : IEnumerable<T> [element] : String |
@@ -715,6 +740,8 @@ nodes
 | GlobalDataFlow.cs:87:70:87:113 | (...) ... : null [element] : String | semmle.label | (...) ... : null [element] : String |
 | GlobalDataFlow.cs:87:104:87:113 | { ..., ... } : null [element] : String | semmle.label | { ..., ... } : null [element] : String |
 | GlobalDataFlow.cs:87:106:87:111 | access to local variable sink15 : String | semmle.label | access to local variable sink15 : String |
+| GlobalDataFlow.cs:87:121:87:121 | y : String | semmle.label | y : String |
+| GlobalDataFlow.cs:87:127:87:127 | access to parameter y : String | semmle.label | access to parameter y : String |
 | GlobalDataFlow.cs:88:15:88:20 | access to local variable sink16 | semmle.label | access to local variable sink16 |
 | GlobalDataFlow.cs:89:13:89:18 | access to local variable sink17 : String | semmle.label | access to local variable sink17 : String |
 | GlobalDataFlow.cs:89:22:89:110 | call to method Aggregate<String,String,String> : String | semmle.label | call to method Aggregate<String,String,String> : String |
@@ -778,7 +805,9 @@ nodes
 | GlobalDataFlow.cs:211:46:211:59 | "taint source" : String | semmle.label | "taint source" : String |
 | GlobalDataFlow.cs:214:35:214:45 | sinkParam10 : String | semmle.label | sinkParam10 : String |
 | GlobalDataFlow.cs:214:58:214:68 | access to parameter sinkParam10 | semmle.label | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:214:79:214:89 | access to parameter sinkParam10 : String | semmle.label | access to parameter sinkParam10 : String |
 | GlobalDataFlow.cs:215:71:215:71 | x : String | semmle.label | x : String |
+| GlobalDataFlow.cs:215:76:215:90 | call to method ReturnCheck2<String> : String | semmle.label | call to method ReturnCheck2<String> : String |
 | GlobalDataFlow.cs:215:89:215:89 | access to parameter x : String | semmle.label | access to parameter x : String |
 | GlobalDataFlow.cs:216:13:216:18 | access to local variable sink24 : String | semmle.label | access to local variable sink24 : String |
 | GlobalDataFlow.cs:216:22:216:28 | access to local variable tainted : IQueryable<T> [element] : String | semmle.label | access to local variable tainted : IQueryable<T> [element] : String |
@@ -834,10 +863,13 @@ nodes
 | GlobalDataFlow.cs:312:9:312:9 | access to parameter y : String | semmle.label | access to parameter y : String |
 | GlobalDataFlow.cs:315:31:315:40 | sinkParam8 : String | semmle.label | sinkParam8 : String |
 | GlobalDataFlow.cs:317:15:317:24 | access to parameter sinkParam8 | semmle.label | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:318:16:318:25 | access to parameter sinkParam8 : String | semmle.label | access to parameter sinkParam8 : String |
 | GlobalDataFlow.cs:321:32:321:41 | sinkParam9 : String | semmle.label | sinkParam9 : String |
 | GlobalDataFlow.cs:323:15:323:24 | access to parameter sinkParam9 | semmle.label | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:324:16:324:25 | access to parameter sinkParam9 : String | semmle.label | access to parameter sinkParam9 : String |
 | GlobalDataFlow.cs:327:32:327:42 | sinkParam11 : String | semmle.label | sinkParam11 : String |
 | GlobalDataFlow.cs:329:15:329:25 | access to parameter sinkParam11 | semmle.label | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:330:16:330:26 | access to parameter sinkParam11 : String | semmle.label | access to parameter sinkParam11 : String |
 | GlobalDataFlow.cs:341:16:341:29 | "taint source" : String | semmle.label | "taint source" : String |
 | GlobalDataFlow.cs:346:9:346:9 | access to parameter x : String | semmle.label | access to parameter x : String |
 | GlobalDataFlow.cs:346:13:346:26 | "taint source" : String | semmle.label | "taint source" : String |
@@ -1006,7 +1038,13 @@ nodes
 | Splitting.cs:50:19:50:19 | access to local variable s | semmle.label | access to local variable s |
 | Splitting.cs:52:19:52:19 | access to local variable s | semmle.label | access to local variable s |
 subpaths
+| Capture.cs:134:9:134:23 | access to local function CaptureThrough1 : CaptureThrough1 [captured tainted] : String | Capture.cs:132:22:132:28 | access to parameter tainted : String | Capture.cs:132:22:132:28 | access to parameter tainted : String | Capture.cs:134:9:134:23 | [post] access to local function CaptureThrough1 : CaptureThrough1 [captured sink33] : String |
+| Capture.cs:144:13:144:13 | access to local function M : M [captured tainted] : String | Capture.cs:142:26:142:32 | access to parameter tainted : String | Capture.cs:142:26:142:32 | access to parameter tainted : String | Capture.cs:144:13:144:13 | [post] access to local function M : M [captured sink34] : String |
+| Capture.cs:146:9:146:23 | access to local function CaptureThrough2 : CaptureThrough2 [captured tainted] : String | Capture.cs:144:13:144:13 | access to local function M : M [captured tainted] : String | Capture.cs:144:13:144:13 | [post] access to local function M : M [captured sink34] : String | Capture.cs:146:9:146:23 | [post] access to local function CaptureThrough2 : CaptureThrough2 [captured sink34] : String |
+| Capture.cs:155:30:155:44 | access to local variable captureThrough3 : Func<String,String> [captured tainted] : String | Capture.cs:152:22:152:28 | access to parameter tainted : String | Capture.cs:152:22:152:28 | access to parameter tainted : String | Capture.cs:155:30:155:44 | [post] access to local variable captureThrough3 : (...) => ... [captured sink35] : String |
+| Capture.cs:162:22:162:36 | access to local function CaptureThrough4 : CaptureThrough4 [captured tainted] : String | Capture.cs:160:20:160:26 | access to parameter tainted : String | Capture.cs:160:20:160:26 | access to parameter tainted : String | Capture.cs:162:22:162:38 | call to local function CaptureThrough4 : String |
 | Capture.cs:170:25:170:31 | access to parameter tainted : String | Capture.cs:166:37:166:37 | p : String | Capture.cs:168:22:168:22 | access to parameter p : String | Capture.cs:170:9:170:23 | [post] access to local function CaptureThrough5 : CaptureThrough5 [captured sink37] : String |
+| Capture.cs:193:20:193:20 | access to local function M : M [captured s] : String | Capture.cs:192:27:192:27 | access to parameter s : String | Capture.cs:192:27:192:27 | access to parameter s : String | Capture.cs:193:20:193:22 | call to local function M : String |
 | Capture.cs:196:25:196:31 | access to parameter tainted : String | Capture.cs:190:26:190:26 | s : String | Capture.cs:193:20:193:22 | call to local function M : String | Capture.cs:196:22:196:32 | call to local function Id : String |
 | Capture.cs:221:21:221:34 | "taint source" : String | Capture.cs:213:22:213:22 | s : String | Capture.cs:215:16:218:9 | (...) => ... : (...) => ... [captured s] : String | Capture.cs:221:18:221:35 | call to method M3 : (...) => ... [captured s] : String |
 | Capture.cs:223:31:223:44 | "taint source" : String | Capture.cs:213:22:213:22 | s : String | Capture.cs:215:16:218:9 | (...) => ... : (...) => ... [captured s] : String | Capture.cs:223:28:223:45 | call to method M3 : (...) => ... [captured s] : String |
@@ -1015,9 +1053,16 @@ subpaths
 | GlobalDataFlow.cs:76:19:76:23 | access to local variable sink1 : String | GlobalDataFlow.cs:304:32:304:32 | x : String | GlobalDataFlow.cs:306:9:306:9 | access to parameter y : String | GlobalDataFlow.cs:76:30:76:34 | access to local variable sink2 : String |
 | GlobalDataFlow.cs:79:19:79:23 | access to local variable sink2 : String | GlobalDataFlow.cs:310:32:310:32 | x : String | GlobalDataFlow.cs:312:9:312:9 | access to parameter y : String | GlobalDataFlow.cs:79:30:79:34 | access to local variable sink3 : String |
 | GlobalDataFlow.cs:81:23:81:65 | (...) ... : null [element] : String | GlobalDataFlow.cs:553:71:553:71 | e : null [element] : String | GlobalDataFlow.cs:558:44:558:47 | delegate call : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> : IEnumerable<T> [element] : String |
+| GlobalDataFlow.cs:83:23:83:66 | (...) ... : null [element] : String | GlobalDataFlow.cs:315:31:315:40 | sinkParam8 : String | GlobalDataFlow.cs:318:16:318:25 | access to parameter sinkParam8 : String | GlobalDataFlow.cs:83:22:83:87 | call to method Select<String,String> : IEnumerable<T> [element] : String |
+| GlobalDataFlow.cs:85:23:85:66 | (...) ... : null [element] : String | GlobalDataFlow.cs:85:118:85:118 | x : String | GlobalDataFlow.cs:85:127:85:127 | access to parameter x : String | GlobalDataFlow.cs:85:22:85:128 | call to method Zip<String,String,String> : IEnumerable<T> [element] : String |
+| GlobalDataFlow.cs:87:70:87:113 | (...) ... : null [element] : String | GlobalDataFlow.cs:87:121:87:121 | y : String | GlobalDataFlow.cs:87:127:87:127 | access to parameter y : String | GlobalDataFlow.cs:87:22:87:128 | call to method Zip<String,String,String> : IEnumerable<T> [element] : String |
 | GlobalDataFlow.cs:138:63:138:63 | access to parameter x : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String |
 | GlobalDataFlow.cs:139:29:139:33 | access to local variable sink3 : String | GlobalDataFlow.cs:138:40:138:40 | x : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String | GlobalDataFlow.cs:139:21:139:34 | delegate call : String |
 | GlobalDataFlow.cs:147:39:147:43 | access to local variable sink4 : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:147:21:147:44 | call to method ApplyFunc<String,String> : String |
+| GlobalDataFlow.cs:215:89:215:89 | access to parameter x : String | GlobalDataFlow.cs:321:32:321:41 | sinkParam9 : String | GlobalDataFlow.cs:324:16:324:25 | access to parameter sinkParam9 : String | GlobalDataFlow.cs:215:76:215:90 | call to method ReturnCheck2<String> : String |
+| GlobalDataFlow.cs:216:22:216:28 | access to local variable tainted : IQueryable<T> [element] : String | GlobalDataFlow.cs:214:35:214:45 | sinkParam10 : String | GlobalDataFlow.cs:214:79:214:89 | access to parameter sinkParam10 : String | GlobalDataFlow.cs:216:22:216:39 | call to method Select<String,String> : IEnumerable<T> [element] : String |
+| GlobalDataFlow.cs:218:22:218:28 | access to local variable tainted : IQueryable<T> [element] : String | GlobalDataFlow.cs:215:71:215:71 | x : String | GlobalDataFlow.cs:215:76:215:90 | call to method ReturnCheck2<String> : String | GlobalDataFlow.cs:218:22:218:39 | call to method Select<String,String> : IQueryable<T> [element] : String |
+| GlobalDataFlow.cs:220:22:220:28 | access to local variable tainted : IQueryable<T> [element] : String | GlobalDataFlow.cs:327:32:327:42 | sinkParam11 : String | GlobalDataFlow.cs:330:16:330:26 | access to parameter sinkParam11 : String | GlobalDataFlow.cs:220:22:220:49 | call to method Select<String,String> : IEnumerable<T> [element] : String |
 | GlobalDataFlow.cs:300:37:300:37 | access to parameter x : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:300:17:300:38 | call to method ApplyFunc<T,T> : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |

--- a/python/ql/test/experimental/dataflow/summaries/summaries.expected
+++ b/python/ql/test/experimental/dataflow/summaries/summaries.expected
@@ -4,7 +4,9 @@ edges
 | summaries.py:32:20:32:25 | ControlFlowNode for SOURCE | summaries.py:32:11:32:26 | ControlFlowNode for identity() | provenance |  |
 | summaries.py:36:1:36:14 | ControlFlowNode for tainted_lambda | summaries.py:37:6:37:19 | ControlFlowNode for tainted_lambda | provenance |  |
 | summaries.py:36:18:36:54 | ControlFlowNode for apply_lambda() | summaries.py:36:1:36:14 | ControlFlowNode for tainted_lambda | provenance |  |
+| summaries.py:36:38:36:38 | ControlFlowNode for x | summaries.py:36:41:36:45 | ControlFlowNode for BinaryExpr | provenance |  |
 | summaries.py:36:48:36:53 | ControlFlowNode for SOURCE | summaries.py:36:18:36:54 | ControlFlowNode for apply_lambda() | provenance |  |
+| summaries.py:36:48:36:53 | ControlFlowNode for SOURCE | summaries.py:36:38:36:38 | ControlFlowNode for x | provenance |  |
 | summaries.py:44:1:44:12 | ControlFlowNode for tainted_list | summaries.py:45:6:45:20 | ControlFlowNode for Subscript | provenance |  |
 | summaries.py:44:1:44:12 | ControlFlowNode for tainted_list [List element] | summaries.py:45:6:45:17 | ControlFlowNode for tainted_list [List element] | provenance |  |
 | summaries.py:44:16:44:33 | ControlFlowNode for reversed() | summaries.py:44:1:44:12 | ControlFlowNode for tainted_list | provenance |  |
@@ -14,13 +16,17 @@ edges
 | summaries.py:44:26:44:31 | ControlFlowNode for SOURCE | summaries.py:44:25:44:32 | ControlFlowNode for List | provenance |  |
 | summaries.py:44:26:44:31 | ControlFlowNode for SOURCE | summaries.py:44:25:44:32 | ControlFlowNode for List [List element] | provenance |  |
 | summaries.py:45:6:45:17 | ControlFlowNode for tainted_list [List element] | summaries.py:45:6:45:20 | ControlFlowNode for Subscript | provenance |  |
+| summaries.py:48:15:48:15 | ControlFlowNode for x | summaries.py:49:12:49:18 | ControlFlowNode for BinaryExpr | provenance |  |
 | summaries.py:51:1:51:14 | ControlFlowNode for tainted_mapped [List element] | summaries.py:52:6:52:19 | ControlFlowNode for tainted_mapped [List element] | provenance |  |
 | summaries.py:51:18:51:46 | ControlFlowNode for list_map() [List element] | summaries.py:51:1:51:14 | ControlFlowNode for tainted_mapped [List element] | provenance |  |
+| summaries.py:51:38:51:45 | ControlFlowNode for List [List element] | summaries.py:48:15:48:15 | ControlFlowNode for x | provenance |  |
 | summaries.py:51:38:51:45 | ControlFlowNode for List [List element] | summaries.py:51:18:51:46 | ControlFlowNode for list_map() [List element] | provenance |  |
 | summaries.py:51:39:51:44 | ControlFlowNode for SOURCE | summaries.py:51:38:51:45 | ControlFlowNode for List [List element] | provenance |  |
 | summaries.py:52:6:52:19 | ControlFlowNode for tainted_mapped [List element] | summaries.py:52:6:52:22 | ControlFlowNode for Subscript | provenance |  |
+| summaries.py:54:23:54:23 | ControlFlowNode for x | summaries.py:55:12:55:12 | ControlFlowNode for x | provenance |  |
 | summaries.py:57:1:57:23 | ControlFlowNode for tainted_mapped_explicit [List element] | summaries.py:58:6:58:28 | ControlFlowNode for tainted_mapped_explicit [List element] | provenance |  |
 | summaries.py:57:27:57:63 | ControlFlowNode for list_map() [List element] | summaries.py:57:1:57:23 | ControlFlowNode for tainted_mapped_explicit [List element] | provenance |  |
+| summaries.py:57:55:57:62 | ControlFlowNode for List [List element] | summaries.py:54:23:54:23 | ControlFlowNode for x | provenance |  |
 | summaries.py:57:55:57:62 | ControlFlowNode for List [List element] | summaries.py:57:27:57:63 | ControlFlowNode for list_map() [List element] | provenance |  |
 | summaries.py:57:56:57:61 | ControlFlowNode for SOURCE | summaries.py:57:55:57:62 | ControlFlowNode for List [List element] | provenance |  |
 | summaries.py:58:6:58:28 | ControlFlowNode for tainted_mapped_explicit [List element] | summaries.py:58:6:58:31 | ControlFlowNode for Subscript | provenance |  |
@@ -46,6 +52,8 @@ nodes
 | summaries.py:33:6:33:12 | ControlFlowNode for tainted | semmle.label | ControlFlowNode for tainted |
 | summaries.py:36:1:36:14 | ControlFlowNode for tainted_lambda | semmle.label | ControlFlowNode for tainted_lambda |
 | summaries.py:36:18:36:54 | ControlFlowNode for apply_lambda() | semmle.label | ControlFlowNode for apply_lambda() |
+| summaries.py:36:38:36:38 | ControlFlowNode for x | semmle.label | ControlFlowNode for x |
+| summaries.py:36:41:36:45 | ControlFlowNode for BinaryExpr | semmle.label | ControlFlowNode for BinaryExpr |
 | summaries.py:36:48:36:53 | ControlFlowNode for SOURCE | semmle.label | ControlFlowNode for SOURCE |
 | summaries.py:37:6:37:19 | ControlFlowNode for tainted_lambda | semmle.label | ControlFlowNode for tainted_lambda |
 | summaries.py:44:1:44:12 | ControlFlowNode for tainted_list | semmle.label | ControlFlowNode for tainted_list |
@@ -57,12 +65,16 @@ nodes
 | summaries.py:44:26:44:31 | ControlFlowNode for SOURCE | semmle.label | ControlFlowNode for SOURCE |
 | summaries.py:45:6:45:17 | ControlFlowNode for tainted_list [List element] | semmle.label | ControlFlowNode for tainted_list [List element] |
 | summaries.py:45:6:45:20 | ControlFlowNode for Subscript | semmle.label | ControlFlowNode for Subscript |
+| summaries.py:48:15:48:15 | ControlFlowNode for x | semmle.label | ControlFlowNode for x |
+| summaries.py:49:12:49:18 | ControlFlowNode for BinaryExpr | semmle.label | ControlFlowNode for BinaryExpr |
 | summaries.py:51:1:51:14 | ControlFlowNode for tainted_mapped [List element] | semmle.label | ControlFlowNode for tainted_mapped [List element] |
 | summaries.py:51:18:51:46 | ControlFlowNode for list_map() [List element] | semmle.label | ControlFlowNode for list_map() [List element] |
 | summaries.py:51:38:51:45 | ControlFlowNode for List [List element] | semmle.label | ControlFlowNode for List [List element] |
 | summaries.py:51:39:51:44 | ControlFlowNode for SOURCE | semmle.label | ControlFlowNode for SOURCE |
 | summaries.py:52:6:52:19 | ControlFlowNode for tainted_mapped [List element] | semmle.label | ControlFlowNode for tainted_mapped [List element] |
 | summaries.py:52:6:52:22 | ControlFlowNode for Subscript | semmle.label | ControlFlowNode for Subscript |
+| summaries.py:54:23:54:23 | ControlFlowNode for x | semmle.label | ControlFlowNode for x |
+| summaries.py:55:12:55:12 | ControlFlowNode for x | semmle.label | ControlFlowNode for x |
 | summaries.py:57:1:57:23 | ControlFlowNode for tainted_mapped_explicit [List element] | semmle.label | ControlFlowNode for tainted_mapped_explicit [List element] |
 | summaries.py:57:27:57:63 | ControlFlowNode for list_map() [List element] | semmle.label | ControlFlowNode for list_map() [List element] |
 | summaries.py:57:55:57:62 | ControlFlowNode for List [List element] | semmle.label | ControlFlowNode for List [List element] |
@@ -87,6 +99,9 @@ nodes
 | summaries.py:68:6:68:23 | ControlFlowNode for tainted_resultlist [List element] | semmle.label | ControlFlowNode for tainted_resultlist [List element] |
 | summaries.py:68:6:68:26 | ControlFlowNode for Subscript | semmle.label | ControlFlowNode for Subscript |
 subpaths
+| summaries.py:36:48:36:53 | ControlFlowNode for SOURCE | summaries.py:36:38:36:38 | ControlFlowNode for x | summaries.py:36:41:36:45 | ControlFlowNode for BinaryExpr | summaries.py:36:18:36:54 | ControlFlowNode for apply_lambda() |
+| summaries.py:51:38:51:45 | ControlFlowNode for List [List element] | summaries.py:48:15:48:15 | ControlFlowNode for x | summaries.py:49:12:49:18 | ControlFlowNode for BinaryExpr | summaries.py:51:18:51:46 | ControlFlowNode for list_map() [List element] |
+| summaries.py:57:55:57:62 | ControlFlowNode for List [List element] | summaries.py:54:23:54:23 | ControlFlowNode for x | summaries.py:55:12:55:12 | ControlFlowNode for x | summaries.py:57:27:57:63 | ControlFlowNode for list_map() [List element] |
 invalidSpecComponent
 #select
 | summaries.py:33:6:33:12 | ControlFlowNode for tainted | summaries.py:32:20:32:25 | ControlFlowNode for SOURCE | summaries.py:33:6:33:12 | ControlFlowNode for tainted | $@ | summaries.py:32:20:32:25 | ControlFlowNode for SOURCE | ControlFlowNode for SOURCE |

--- a/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
@@ -298,7 +298,9 @@ edges
 | array_flow.rb:251:9:251:9 | a [element 2] | array_flow.rb:251:30:251:30 | x | provenance |  |
 | array_flow.rb:251:9:254:7 | call to collect_concat [element] | array_flow.rb:251:5:251:5 | b [element] | provenance |  |
 | array_flow.rb:251:30:251:30 | x | array_flow.rb:252:14:252:14 | x | provenance |  |
+| array_flow.rb:251:30:251:30 | x | array_flow.rb:253:10:253:10 | x | provenance |  |
 | array_flow.rb:253:9:253:25 | call to [] [element 1] | array_flow.rb:251:9:254:7 | call to collect_concat [element] | provenance |  |
+| array_flow.rb:253:10:253:10 | x | array_flow.rb:253:9:253:25 | call to [] [element 0] | provenance |  |
 | array_flow.rb:253:13:253:24 | call to source | array_flow.rb:253:9:253:25 | call to [] [element 1] | provenance |  |
 | array_flow.rb:255:10:255:10 | b [element] | array_flow.rb:255:10:255:13 | ...[...] | provenance |  |
 | array_flow.rb:256:5:256:5 | b [element] | array_flow.rb:260:10:260:10 | b [element] | provenance |  |
@@ -631,6 +633,7 @@ edges
 | array_flow.rb:507:9:507:9 | a [element 3] | array_flow.rb:507:26:507:26 | x | provenance |  |
 | array_flow.rb:507:9:510:7 | call to filter_map [element] | array_flow.rb:507:5:507:5 | b [element] | provenance |  |
 | array_flow.rb:507:26:507:26 | x | array_flow.rb:508:14:508:14 | x | provenance |  |
+| array_flow.rb:507:26:507:26 | x | array_flow.rb:509:9:509:9 | x | provenance |  |
 | array_flow.rb:511:10:511:10 | b [element] | array_flow.rb:511:10:511:13 | ...[...] | provenance |  |
 | array_flow.rb:518:5:518:5 | d [element] | array_flow.rb:521:10:521:10 | d [element] | provenance |  |
 | array_flow.rb:518:9:520:7 | call to filter_map [element] | array_flow.rb:518:5:518:5 | d [element] | provenance |  |
@@ -718,7 +721,9 @@ edges
 | array_flow.rb:571:9:571:9 | a [element 2] | array_flow.rb:571:24:571:24 | x | provenance |  |
 | array_flow.rb:571:9:574:7 | call to flat_map [element] | array_flow.rb:571:5:571:5 | b [element] | provenance |  |
 | array_flow.rb:571:24:571:24 | x | array_flow.rb:572:14:572:14 | x | provenance |  |
+| array_flow.rb:571:24:571:24 | x | array_flow.rb:573:10:573:10 | x | provenance |  |
 | array_flow.rb:573:9:573:25 | call to [] [element 1] | array_flow.rb:571:9:574:7 | call to flat_map [element] | provenance |  |
+| array_flow.rb:573:10:573:10 | x | array_flow.rb:573:9:573:25 | call to [] [element 0] | provenance |  |
 | array_flow.rb:573:13:573:24 | call to source | array_flow.rb:573:9:573:25 | call to [] [element 1] | provenance |  |
 | array_flow.rb:575:10:575:10 | b [element] | array_flow.rb:575:10:575:13 | ...[...] | provenance |  |
 | array_flow.rb:576:5:576:5 | b [element] | array_flow.rb:580:10:580:10 | b [element] | provenance |  |
@@ -2337,7 +2342,9 @@ edges
 | array_flow.rb:1677:16:1677:28 | call to source | array_flow.rb:1677:9:1677:29 | call to [] [element 2] | provenance |  |
 | array_flow.rb:1678:5:1678:5 | b [element] | array_flow.rb:1681:10:1681:10 | b [element] | provenance |  |
 | array_flow.rb:1678:9:1678:9 | a [element 2] | array_flow.rb:1678:9:1680:7 | call to map [element] | provenance |  |
+| array_flow.rb:1678:9:1678:9 | a [element 2] | array_flow.rb:1678:19:1678:19 | x | provenance |  |
 | array_flow.rb:1678:9:1680:7 | call to map [element] | array_flow.rb:1678:5:1678:5 | b [element] | provenance |  |
+| array_flow.rb:1678:19:1678:19 | x | array_flow.rb:1679:9:1679:9 | x | provenance |  |
 | array_flow.rb:1681:10:1681:10 | b [element] | array_flow.rb:1681:10:1681:13 | ...[...] | provenance |  |
 | array_flow.rb:1685:5:1685:5 | a [element 2] | array_flow.rb:1686:18:1686:18 | a [element 2] | provenance |  |
 | array_flow.rb:1685:5:1685:5 | a [element 3] | array_flow.rb:1686:18:1686:18 | a [element 3] | provenance |  |
@@ -2674,7 +2681,9 @@ nodes
 | array_flow.rb:251:9:254:7 | call to collect_concat [element] | semmle.label | call to collect_concat [element] |
 | array_flow.rb:251:30:251:30 | x | semmle.label | x |
 | array_flow.rb:252:14:252:14 | x | semmle.label | x |
+| array_flow.rb:253:9:253:25 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | array_flow.rb:253:9:253:25 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| array_flow.rb:253:10:253:10 | x | semmle.label | x |
 | array_flow.rb:253:13:253:24 | call to source | semmle.label | call to source |
 | array_flow.rb:255:10:255:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:255:10:255:13 | ...[...] | semmle.label | ...[...] |
@@ -3041,6 +3050,7 @@ nodes
 | array_flow.rb:507:9:510:7 | call to filter_map [element] | semmle.label | call to filter_map [element] |
 | array_flow.rb:507:26:507:26 | x | semmle.label | x |
 | array_flow.rb:508:14:508:14 | x | semmle.label | x |
+| array_flow.rb:509:9:509:9 | x | semmle.label | x |
 | array_flow.rb:511:10:511:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:511:10:511:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:518:5:518:5 | d [element] | semmle.label | d [element] |
@@ -3132,7 +3142,9 @@ nodes
 | array_flow.rb:571:9:574:7 | call to flat_map [element] | semmle.label | call to flat_map [element] |
 | array_flow.rb:571:24:571:24 | x | semmle.label | x |
 | array_flow.rb:572:14:572:14 | x | semmle.label | x |
+| array_flow.rb:573:9:573:25 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | array_flow.rb:573:9:573:25 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| array_flow.rb:573:10:573:10 | x | semmle.label | x |
 | array_flow.rb:573:13:573:24 | call to source | semmle.label | call to source |
 | array_flow.rb:575:10:575:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:575:10:575:13 | ...[...] | semmle.label | ...[...] |
@@ -4821,6 +4833,8 @@ nodes
 | array_flow.rb:1678:5:1678:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1678:9:1678:9 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:1678:9:1680:7 | call to map [element] | semmle.label | call to map [element] |
+| array_flow.rb:1678:19:1678:19 | x | semmle.label | x |
+| array_flow.rb:1679:9:1679:9 | x | semmle.label | x |
 | array_flow.rb:1681:10:1681:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1681:10:1681:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1685:5:1685:5 | a [element 2] | semmle.label | a [element 2] |
@@ -4836,6 +4850,10 @@ nodes
 | array_flow.rb:1689:10:1689:10 | z | semmle.label | z |
 | array_flow.rb:1690:10:1690:10 | w | semmle.label | w |
 subpaths
+| array_flow.rb:251:9:251:9 | a [element 2] | array_flow.rb:251:30:251:30 | x | array_flow.rb:253:9:253:25 | call to [] [element 0] | array_flow.rb:251:9:254:7 | call to collect_concat [element] |
+| array_flow.rb:507:9:507:9 | a [element 3] | array_flow.rb:507:26:507:26 | x | array_flow.rb:509:9:509:9 | x | array_flow.rb:507:9:510:7 | call to filter_map [element] |
+| array_flow.rb:571:9:571:9 | a [element 2] | array_flow.rb:571:24:571:24 | x | array_flow.rb:573:9:573:25 | call to [] [element 0] | array_flow.rb:571:9:574:7 | call to flat_map [element] |
+| array_flow.rb:1678:9:1678:9 | a [element 2] | array_flow.rb:1678:19:1678:19 | x | array_flow.rb:1679:9:1679:9 | x | array_flow.rb:1678:9:1680:7 | call to map [element] |
 arrayLiteral
 | array_flow.rb:9:9:9:25 | call to [] |
 | array_flow.rb:33:9:33:22 | call to [] |

--- a/ruby/ql/test/library-tests/dataflow/global/Flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/global/Flow.expected
@@ -100,6 +100,7 @@ edges
 | captured_variables.rb:206:13:206:21 | call to taint | captured_variables.rb:208:14:208:14 | x | provenance |  |
 | captured_variables.rb:219:9:219:17 | call to taint | captured_variables.rb:226:5:226:7 | fn1 [captured x] | provenance |  |
 | captured_variables.rb:226:5:226:7 | [post] fn1 [captured y] | captured_variables.rb:227:10:227:10 | y | provenance |  |
+| captured_variables.rb:226:5:226:7 | fn1 [captured x] | captured_variables.rb:223:13:223:13 | x | provenance |  |
 | captured_variables.rb:226:5:226:7 | fn1 [captured x] | captured_variables.rb:226:5:226:7 | [post] fn1 [captured y] | provenance |  |
 | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:11:18:11:18 | x | provenance |  |
 | instance_variables.rb:11:18:11:18 | x | instance_variables.rb:11:9:11:14 | [post] self [@field] | provenance |  |
@@ -347,6 +348,7 @@ nodes
 | captured_variables.rb:206:13:206:21 | call to taint | semmle.label | call to taint |
 | captured_variables.rb:208:14:208:14 | x | semmle.label | x |
 | captured_variables.rb:219:9:219:17 | call to taint | semmle.label | call to taint |
+| captured_variables.rb:223:13:223:13 | x | semmle.label | x |
 | captured_variables.rb:226:5:226:7 | [post] fn1 [captured y] | semmle.label | [post] fn1 [captured y] |
 | captured_variables.rb:226:5:226:7 | fn1 [captured x] | semmle.label | fn1 [captured x] |
 | captured_variables.rb:227:10:227:10 | y | semmle.label | y |
@@ -470,6 +472,7 @@ subpaths
 | captured_variables.rb:83:6:83:8 | foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | captured_variables.rb:83:6:83:18 | call to get_field |
 | captured_variables.rb:83:6:83:8 | foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | captured_variables.rb:83:6:83:18 | call to get_field |
 | captured_variables.rb:98:13:98:20 | call to taint | captured_variables.rb:93:17:93:17 | x | captured_variables.rb:94:5:96:5 | -> { ... } [captured x] | captured_variables.rb:98:1:98:21 | call to capture_arg [captured x] |
+| captured_variables.rb:226:5:226:7 | fn1 [captured x] | captured_variables.rb:223:13:223:13 | x | captured_variables.rb:223:13:223:13 | x | captured_variables.rb:226:5:226:7 | [post] fn1 [captured y] |
 | instance_variables.rb:28:20:28:24 | field | instance_variables.rb:22:20:22:24 | field | instance_variables.rb:23:9:23:14 | [post] self [@field] | instance_variables.rb:28:9:28:25 | [post] self [@field] |
 | instance_variables.rb:33:13:33:13 | x | instance_variables.rb:22:20:22:24 | field | instance_variables.rb:23:9:23:14 | [post] self [@field] | instance_variables.rb:33:9:33:14 | call to new [@field] |
 | instance_variables.rb:36:10:36:23 | call to new [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:36:10:36:33 | call to get_field |

--- a/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
+++ b/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
@@ -65,8 +65,12 @@ edges
 | summaries.rb:4:24:4:30 | tainted | summaries.rb:4:36:4:36 | x | provenance |  |
 | summaries.rb:4:36:4:36 | x | summaries.rb:5:8:5:8 | x | provenance |  |
 | summaries.rb:4:36:4:36 | x | summaries.rb:5:8:5:8 | x | provenance |  |
+| summaries.rb:4:36:4:36 | x | summaries.rb:6:3:6:3 | x | provenance |  |
+| summaries.rb:4:36:4:36 | x | summaries.rb:6:3:6:3 | x | provenance |  |
 | summaries.rb:11:17:11:17 | x | summaries.rb:12:8:12:8 | x | provenance |  |
 | summaries.rb:11:17:11:17 | x | summaries.rb:12:8:12:8 | x | provenance |  |
+| summaries.rb:11:17:11:17 | x | summaries.rb:13:3:13:3 | x | provenance |  |
+| summaries.rb:11:17:11:17 | x | summaries.rb:13:3:13:3 | x | provenance |  |
 | summaries.rb:16:1:16:8 | tainted3 | summaries.rb:18:6:18:13 | tainted3 | provenance |  |
 | summaries.rb:16:1:16:8 | tainted3 | summaries.rb:18:6:18:13 | tainted3 | provenance |  |
 | summaries.rb:16:12:16:43 | call to apply_lambda | summaries.rb:16:1:16:8 | tainted3 | provenance |  |
@@ -275,12 +279,16 @@ nodes
 | summaries.rb:4:36:4:36 | x | semmle.label | x |
 | summaries.rb:5:8:5:8 | x | semmle.label | x |
 | summaries.rb:5:8:5:8 | x | semmle.label | x |
+| summaries.rb:6:3:6:3 | x | semmle.label | x |
+| summaries.rb:6:3:6:3 | x | semmle.label | x |
 | summaries.rb:9:6:9:13 | tainted2 | semmle.label | tainted2 |
 | summaries.rb:9:6:9:13 | tainted2 | semmle.label | tainted2 |
 | summaries.rb:11:17:11:17 | x | semmle.label | x |
 | summaries.rb:11:17:11:17 | x | semmle.label | x |
 | summaries.rb:12:8:12:8 | x | semmle.label | x |
 | summaries.rb:12:8:12:8 | x | semmle.label | x |
+| summaries.rb:13:3:13:3 | x | semmle.label | x |
+| summaries.rb:13:3:13:3 | x | semmle.label | x |
 | summaries.rb:16:1:16:8 | tainted3 | semmle.label | tainted3 |
 | summaries.rb:16:1:16:8 | tainted3 | semmle.label | tainted3 |
 | summaries.rb:16:12:16:43 | call to apply_lambda | semmle.label | call to apply_lambda |
@@ -514,6 +522,10 @@ nodes
 | summaries.rb:166:20:166:36 | call to source | semmle.label | call to source |
 | summaries.rb:166:20:166:36 | call to source | semmle.label | call to source |
 subpaths
+| summaries.rb:4:24:4:30 | tainted | summaries.rb:4:36:4:36 | x | summaries.rb:6:3:6:3 | x | summaries.rb:4:12:7:3 | call to apply_block |
+| summaries.rb:4:24:4:30 | tainted | summaries.rb:4:36:4:36 | x | summaries.rb:6:3:6:3 | x | summaries.rb:4:12:7:3 | call to apply_block |
+| summaries.rb:16:36:16:42 | tainted | summaries.rb:11:17:11:17 | x | summaries.rb:13:3:13:3 | x | summaries.rb:16:12:16:43 | call to apply_lambda |
+| summaries.rb:16:36:16:42 | tainted | summaries.rb:11:17:11:17 | x | summaries.rb:13:3:13:3 | x | summaries.rb:16:12:16:43 | call to apply_lambda |
 invalidSpecComponent
 #select
 | summaries.rb:2:6:2:12 | tainted | summaries.rb:1:20:1:36 | call to source | summaries.rb:2:6:2:12 | tainted | $@ | summaries.rb:1:20:1:36 | call to source | call to source |

--- a/shared/dataflow/change-notes/2024-02-28-hidden-subpaths.md
+++ b/shared/dataflow/change-notes/2024-02-28-hidden-subpaths.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* Path explanations now include flow that goes through callbacks passed into library functions. For example, if `map` is library function, then in `result = map(xs, x => x + 1)` we will now include the step from `x` to `x + 1` in the path explanation, instead og going directly from `xs` to `result`. Note that this change does not affect actual query results, but only how path explanations are computed.
+* Path explanations now include flow that goes through callbacks passed into library functions. For example, if `map` is a library function, then in `result = map(xs, x => x + 1)` we will now include the step from `x` to `x + 1` in the path explanation, instead og going directly from `xs` to `result`. Note that this change does not affect actual query results, but only how path explanations are computed.

--- a/shared/dataflow/change-notes/2024-02-28-hidden-subpaths.md
+++ b/shared/dataflow/change-notes/2024-02-28-hidden-subpaths.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* Path explanations now include flow that goes through callbacks passed into library functions. For example, if `map` is a library function, then in `result = map(xs, x => x + 1)` we will now include the step from `x` to `x + 1` in the path explanation, instead og going directly from `xs` to `result`. Note that this change does not affect actual query results, but only how path explanations are computed.
+* Path explanations now include flow that goes through callbacks passed into library functions. For example, if `map` is a library function, then in `result = map(xs, x => x + 1)` we will now include the step from `x` to `x + 1` in the path explanation, instead of going directly from `xs` to `result`. Note that this change does not affect actual query results, but only how path explanations are computed.

--- a/shared/dataflow/change-notes/2024-02-28-hidden-subpaths.md
+++ b/shared/dataflow/change-notes/2024-02-28-hidden-subpaths.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Path explanations now include flow that goes through callbacks passed into library functions. For example, if `map` is library function, then in `result = map(xs, x => x + 1)` we will now include the step from `x` to `x + 1` in the path explanation, instead og going directly from `xs` to `result`. Note that this change does not affect actual query results, but only how path explanations are computed.

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -4356,14 +4356,14 @@ module MakeImpl<InputSig Lang> {
         )
       }
 
-      private PathNodeImpl localStepToHidden(PathNodeImpl n) {
-        result = localStep(n) and
-        result.isHidden()
+      private predicate localStepToHidden(PathNodeImpl n1, PathNodeImpl n2) {
+        n2 = localStep(n1) and
+        n2.isHidden()
       }
 
-      private PathNodeImpl localStepFromHidden(PathNodeImpl n) {
-        n = localStep(result) and
-        result.isHidden()
+      private predicate localStepFromHidden(PathNodeImpl n1, PathNodeImpl n2) {
+        n2 = localStep(n1) and
+        n1.isHidden()
       }
 
       pragma[nomagic]
@@ -4404,7 +4404,8 @@ module MakeImpl<InputSig Lang> {
         PathNodeImpl arg, PathNodeImpl par, PathNodeImpl ret, PathNodeImpl out
       ) {
         // direct subpath
-        subpaths04(arg, localStepFromHidden*(par), localStepToHidden*(ret), out) and
+        subpaths04(arg, any(PathNodeImpl n | localStepFromHidden*(n, par)),
+          any(PathNodeImpl n | localStepToHidden*(ret, n)), out) and
         not par.isHidden() and
         not ret.isHidden() and
         ret = summaryCtxStep*(par)
@@ -4412,7 +4413,8 @@ module MakeImpl<InputSig Lang> {
         // wrapped subpath using hidden nodes, e.g. flow through a callback inside
         // a summarized callable
         exists(PathNodeImpl par0, PathNodeImpl ret0 |
-          subpaths05(localStepToHidden*(par0), par, ret, localStepFromHidden*(ret0)) and
+          subpaths05(any(PathNodeImpl n | localStepToHidden*(par0, n)), par, ret,
+            any(PathNodeImpl n | localStepFromHidden*(n, ret0))) and
           subpaths04(arg, par0, ret0, out)
         )
       }
@@ -4426,7 +4428,8 @@ module MakeImpl<InputSig Lang> {
        */
       pragma[nomagic]
       predicate subpaths(PathNodeImpl arg, PathNodeImpl par, PathNodeImpl ret, PathNodeImpl out) {
-        subpaths05(localStepToHidden*(arg), par, ret, localStepFromHidden*(out)) and
+        subpaths05(any(PathNodeImpl n | localStepToHidden*(arg, n)), par, ret,
+          any(PathNodeImpl n | localStepFromHidden*(n, out))) and
         not arg.isHidden() and
         not out.isHidden()
       }


### PR DESCRIPTION
Previously, we would not get `subpaths` computed for hidden wrappers, such as when flow passes through a callback passed into a library method with a flow summary:

```rb
a = [taint]
b = a.each do |x| # missing subpath: `a` (line 2) to `x` (line 2), `x` (line 2) to `x` (line 3), and `x` (line 3) to `b`
  x
end
sink x
```

This PR changes that to allow for an arbitrary number of hidden intermediate wrappers, and also takes into account that argument/out/parameter nodes may be hidden (we previously only took into account that return nodes could be hidden).