### PR TITLE
C#: Remove `AddLocalSource` classes from queries

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/CodeInjectionQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/CodeInjectionQuery.qll
@@ -68,8 +68,6 @@ deprecated class RemoteSource extends DataFlow::Node instanceof RemoteFlowSource
  */
 deprecated class LocalSource extends DataFlow::Node instanceof LocalFlowSource { }
 
-private class AddLocalSource extends Source instanceof LocalFlowSource { }
-
 /** A source supported by the current threat model. */
 class ThreatModelSource extends Source instanceof ThreatModelFlowSource { }
 

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/ResourceInjectionQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/ResourceInjectionQuery.qll
@@ -67,8 +67,6 @@ deprecated class RemoteSource extends DataFlow::Node instanceof RemoteFlowSource
  */
 deprecated class LocalSource extends DataFlow::Node instanceof LocalFlowSource { }
 
-private class AddLocalSource extends Source instanceof LocalFlowSource { }
-
 /** A source supported by the current threat model. */
 class ThreatModelSource extends Source instanceof ThreatModelFlowSource { }
 

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/SqlInjectionQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/SqlInjectionQuery.qll
@@ -78,8 +78,6 @@ deprecated class RemoteSource extends DataFlow::Node instanceof RemoteFlowSource
  */
 deprecated class LocalSource extends DataFlow::Node instanceof LocalFlowSource { }
 
-private class AddLocalSource extends Source instanceof LocalFlowSource { }
-
 /** A source supported by the current threat model. */
 class ThreatModelSource extends Source instanceof ThreatModelFlowSource { }
 

--- a/csharp/ql/src/change-notes/2024-03-06-remove-default-local-sources.md
+++ b/csharp/ql/src/change-notes/2024-03-06-remove-default-local-sources.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+* Data flow queries that track flow from *local* flow sources now use the current *threat model* configuration instead. This may lead to changes in the produced alerts if the threat model configuration only uses *remote* flow sources. The changed queries are `cs/code-injection`, `cs/resource-injection`, `cs/sql-injection`, and `cs/uncontrolled-format-string`.
+

--- a/csharp/ql/test/query-tests/Security Features/CWE-094/CodeInjection.ext.yml
+++ b/csharp/ql/test/query-tests/Security Features/CWE-094/CodeInjection.ext.yml
@@ -1,0 +1,7 @@
+extensions:
+
+  - addsTo:
+      pack: codeql/threat-models
+      extensible: threatModelConfiguration
+    data:
+      - ["local", true, 0]


### PR DESCRIPTION
The `AddLocalSource` classes were added in https://github.com/github/codeql/pull/15419 to make deprecating `LocalSource` classes easier.

This removes them so that queries rely on `ThreatModelFlowSource`.