### PR TITLE
C#: Add references to threat modeling to C# Models-as-Data documentation

### DIFF
--- a/docs/codeql/codeql-language-guides/customizing-library-models-for-csharp.rst
+++ b/docs/codeql/codeql-language-guides/customizing-library-models-for-csharp.rst
@@ -144,7 +144,7 @@ The sixth value should be left empty and is out of scope for this documentation.
 The remaining values are used to define the ``access path``, the ``kind``, and the ``provenance`` (origin) of the source.
 
 - The seventh value ``ReturnValue`` is the access path to the return of the method, which means that it is the return value that should be considered a source of tainted input.
-- The eighth value ``remote`` is the kind of the source. The source kind is used to define the threat model where the source is in scope. ``remote`` applies to many of the security related queries as it means a remote source of untrusted data. As an example the SQL injection query uses ``remote`` sources. For more information, see ":ref:`Threat models <threat-models>`."
+- The eighth value ``remote`` is the kind of the source. The source kind is used to define the threat model where the source is in scope. ``remote`` applies to many of the security related queries as it means a remote source of untrusted data. As an example the SQL injection query uses ``remote`` sources. For more information, see ":ref:`Threat models <threat-models-csharp>`."
 - The ninth value ``manual`` is the provenance of the source, which is used to identify the origin of the source.
 
 Example: Add flow through the ``Concat`` method

--- a/docs/codeql/codeql-language-guides/customizing-library-models-for-csharp.rst
+++ b/docs/codeql/codeql-language-guides/customizing-library-models-for-csharp.rst
@@ -340,3 +340,19 @@ The first four values identify the callable (in this case the getter of the ``No
 - The fourth value ``()`` is the method input type signature.
 - The fifth value ``summary`` is the kind of the neutral.
 - The sixth value ``manual`` is the provenance of the neutral.
+
+.. _threat-models-csharp:
+
+Threat models
+-------------
+
+.. include:: ../reusables/beta-note-threat-models.rst
+
+A threat model is a named class of dataflow sources that can be enabled or disabled independently. Threat models allow you to control the set of dataflow sources that you want to consider unsafe. For example, one codebase may only consider remote HTTP requests to be tainted, whereas another may also consider data from local files to be unsafe. You can use threat models to ensure that the relevant taint sources are used in a CodeQL analysis.
+
+The ``kind`` property of the ``sourceModel`` determines which threat model a source is associated with. There are two main categories:
+
+- ``remote`` which represents requests and responses from the network. 
+- ``local`` which represents data from local files (``file``), command-line arguments (``commandargs``), database reads (``database``), and environment variables(``environment``).
+ 
+When running a CodeQL analysis, the ``remote`` threat model is included by default. You can optionally include other threat models as appropriate when using the CodeQL CLI and in GitHub code scanning. For more information, see `Analyzing your code with CodeQL queries <https://docs.github.com/code-security/codeql-cli/getting-started-with-the-codeql-cli/analyzing-your-code-with-codeql-queries#including-model-packs-to-add-potential-sources-of-tainted-data>`__ and `Customizing your advanced setup for code scanning <https://docs.github.com/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#extending-codeql-coverage-with-threat-models>`__.

--- a/docs/codeql/codeql-language-guides/customizing-library-models-for-csharp.rst
+++ b/docs/codeql/codeql-language-guides/customizing-library-models-for-csharp.rst
@@ -55,7 +55,7 @@ Extensible predicates used to create custom models in C#
 
 The CodeQL library for C# analysis exposes the following extensible predicates:
 
-- ``sourceModel(namespace, type, subtypes, name, signature, ext, output, kind, provenance)``. This is used to model sources of potentially tainted data.
+- ``sourceModel(namespace, type, subtypes, name, signature, ext, output, kind, provenance)``. This is used to model sources of potentially tainted data. The ``kind`` of the sources defined using this predicate determine which threat model they are associated with. Different threat models can be used to customize the sources used in an analysis. For more information, see ":ref:`Threat models <threat-models-csharp>`."
 - ``sinkModel(namespace, type, subtypes, name, signature, ext, input, kind, provenance)``. This is used to model sinks where tainted data may be used in a way that makes the code vulnerable.
 - ``summaryModel(namespace, type, subtypes, name, signature, ext, input, output, kind, provenance)``. This is used to model flow through elements.
 - ``neutralModel(namespace, type, name, signature, kind, provenance)``. This is similar to a summary model but used to model the flow of values that have only a minor impact on the dataflow analysis. Manual neutral models (those with a provenance such as ``manual`` or ``ai-manual``) can be used to override generated summary models (those with a provenance such as ``df-generated``), so that the summary model will be ignored. Other than that, neutral models have no effect.
@@ -144,7 +144,7 @@ The sixth value should be left empty and is out of scope for this documentation.
 The remaining values are used to define the ``access path``, the ``kind``, and the ``provenance`` (origin) of the source.
 
 - The seventh value ``ReturnValue`` is the access path to the return of the method, which means that it is the return value that should be considered a source of tainted input.
-- The eighth value ``remote`` is the kind of the source. The source kind is used to define the threat model where the source is in scope. ``remote`` applies to many of the security related queries as it means a remote source of untrusted data. As an example the SQL injection query uses ``remote`` sources.
+- The eighth value ``remote`` is the kind of the source. The source kind is used to define the threat model where the source is in scope. ``remote`` applies to many of the security related queries as it means a remote source of untrusted data. As an example the SQL injection query uses ``remote`` sources. For more information, see ":ref:`Threat models <threat-models>`."
 - The ninth value ``manual`` is the provenance of the source, which is used to identify the origin of the source.
 
 Example: Add flow through the ``Concat`` method

--- a/docs/codeql/codeql-language-guides/customizing-library-models-for-csharp.rst
+++ b/docs/codeql/codeql-language-guides/customizing-library-models-for-csharp.rst
@@ -350,7 +350,7 @@ Threat models
 
 A threat model is a named class of dataflow sources that can be enabled or disabled independently. Threat models allow you to control the set of dataflow sources that you want to consider unsafe. For example, one codebase may only consider remote HTTP requests to be tainted, whereas another may also consider data from local files to be unsafe. You can use threat models to ensure that the relevant taint sources are used in a CodeQL analysis.
 
-The ``kind`` property of the ``sourceModel`` determines which threat model a source is associated with. There are two main categories:
+The ``kind`` property of ``sourceModel`` determines which threat model a source is associated with. There are two main categories:
 
 - ``remote`` which represents requests and responses from the network. 
 - ``local`` which represents data from local files (``file``), command-line arguments (``commandargs``), database reads (``database``), and environment variables(``environment``).

--- a/docs/codeql/codeql-language-guides/customizing-library-models-for-java-and-kotlin.rst
+++ b/docs/codeql/codeql-language-guides/customizing-library-models-for-java-and-kotlin.rst
@@ -297,7 +297,7 @@ The first four values identify the callable (in this case a method) to be modele
 Threat models
 -------------
 
-.. include:: ../reusables/beta-note-threat-models-java.rst
+.. include:: ../reusables/beta-note-threat-models.rst
 
 A threat model is a named class of dataflow sources that can be enabled or disabled independently. Threat models allow you to control the set of dataflow sources that you want to consider unsafe. For example, one codebase may only consider remote HTTP requests to be tainted, whereas another may also consider data from local files to be unsafe. You can use threat models to ensure that the relevant taint sources are used in a CodeQL analysis.
 

--- a/docs/codeql/reusables/beta-note-threat-models-java.rst
+++ b/docs/codeql/reusables/beta-note-threat-models-java.rst
@@ -1,5 +1,0 @@
-.. pull-quote::
-
-    Note
-
-    Threat models are currently in beta and subject to change. During the beta, threat models are supported only by Java analysis.

--- a/docs/codeql/reusables/beta-note-threat-models.rst
+++ b/docs/codeql/reusables/beta-note-threat-models.rst
@@ -1,0 +1,5 @@
+.. pull-quote::
+
+    Note
+
+    Threat models are currently in beta and subject to change. During the beta, threat models are supported only by Java and C# analysis.


### PR DESCRIPTION
Adds information about threat modeling to the C# MaD docs.