### PR TITLE
JS: Summarise store steps for type tracking

### DIFF
--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/StepSummary.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/StepSummary.qll
@@ -78,7 +78,7 @@ private module Cached {
   }
 
   /**
-   * Holds if `loadProp` of `parameter` is stored in the `storeProp` property of the return value of `fun`.
+   * Holds if `loadProp` of `param` is stored in the `storeProp` property of the return value of `fun`.
    */
   pragma[nomagic]
   private predicate summarizedLoadStoreStep(

--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/StepSummary.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/StepSummary.qll
@@ -156,6 +156,9 @@ private module Cached {
         exists(string prop |
           param.getAPropertyRead(prop).flowsTo(fun.getAReturn()) and
           summary = LoadStep(prop)
+          or
+          fun.getAReturn().getALocalSource().getAPropertySource(prop) = param and
+          summary = StoreStep(prop)
         )
       ) and
       if param = fun.getAParameter()

--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/StepSummary.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/StepSummary.qll
@@ -45,6 +45,8 @@ private module Cached {
       CopyStep(PropertyName prop) or
       LoadStoreStep(PropertyName fromProp, PropertyName toProp) {
         SharedTypeTrackingStep::loadStoreStep(_, _, fromProp, toProp)
+        or
+        summarizedLoadStoreStep(_, _, fromProp, toProp)
       } or
       WithoutPropStep(PropertySet props) { SharedTypeTrackingStep::withoutPropStep(_, _, props) }
   }
@@ -67,6 +69,26 @@ private module Cached {
   private DataFlow::Node getAGlobalStepSuccessor(string global) {
     result = AccessPath::getAReferenceTo(global) and
     AccessPath::isAssignedInUniqueFile(global)
+  }
+
+  bindingset[fun]
+  pragma[inline_late]
+  private DataFlow::PropRead getStoredPropRead(DataFlow::FunctionNode fun, string storeProp) {
+    result = fun.getAReturn().getALocalSource().getAPropertySource(storeProp)
+  }
+
+  /**
+   * Holds if `loadProp` of `parameter` is stored in the `storeProp` property of the return value of `fun`.
+   */
+  pragma[nomagic]
+  private predicate summarizedLoadStoreStep(
+    DataFlow::ParameterNode param, DataFlow::FunctionNode fun, string loadProp, string storeProp
+  ) {
+    exists(DataFlow::PropRead read |
+      read = getStoredPropRead(fun, storeProp) and
+      read.getBase().getALocalSource() = param and
+      read.getPropertyName() = loadProp
+    )
   }
 
   /**
@@ -159,6 +181,11 @@ private module Cached {
           or
           fun.getAReturn().getALocalSource().getAPropertySource(prop) = param and
           summary = StoreStep(prop)
+        )
+        or
+        exists(string loadProp, string storeProp |
+          summarizedLoadStoreStep(param, fun, loadProp, storeProp) and
+          summary = LoadStoreStep(loadProp, storeProp)
         )
       ) and
       if param = fun.getAParameter()

--- a/javascript/ql/test/library-tests/TypeTracking/TypeTracking.expected
+++ b/javascript/ql/test/library-tests/TypeTracking/TypeTracking.expected
@@ -1,2 +1,1 @@
-| summarize.js:30:14:30:26 | // track: obj | Failed to track obj here. |
 | summarize.js:33:14:33:26 | // track: obj | Failed to track obj here. |

--- a/javascript/ql/test/library-tests/TypeTracking/TypeTracking.expected
+++ b/javascript/ql/test/library-tests/TypeTracking/TypeTracking.expected
@@ -1,0 +1,2 @@
+| summarize.js:30:14:30:26 | // track: obj | Failed to track obj here. |
+| summarize.js:33:14:33:26 | // track: obj | Failed to track obj here. |

--- a/javascript/ql/test/library-tests/TypeTracking/TypeTracking.expected
+++ b/javascript/ql/test/library-tests/TypeTracking/TypeTracking.expected
@@ -1,1 +1,0 @@
-| summarize.js:33:14:33:26 | // track: obj | Failed to track obj here. |

--- a/javascript/ql/test/library-tests/TypeTracking/summarize.js
+++ b/javascript/ql/test/library-tests/TypeTracking/summarize.js
@@ -1,0 +1,33 @@
+import 'dummy';
+
+function identity(x) {
+    return x;
+}
+function load(x) {
+    return x.loadProp;
+}
+function store(x) {
+    return { storeProp: x };
+}
+function loadStore(x) {
+    return { storeProp: x.loadProp };
+}
+
+identity({});
+load({});
+store({});
+loadStore({});
+
+const obj = {}; // name: obj
+
+let x = identity(obj);
+x; // track: obj
+
+x = load({ loadProp: obj });
+x; // track: obj
+
+x = store(obj);
+x.storeProp; // track: obj
+
+x = loadStore({ loadProp: obj });
+x.storeProp; // track: obj

--- a/javascript/ql/test/library-tests/TypeTracking/summarize.js
+++ b/javascript/ql/test/library-tests/TypeTracking/summarize.js
@@ -12,11 +12,16 @@ function store(x) {
 function loadStore(x) {
     return { storeProp: x.loadProp };
 }
+function loadStore2(x) {
+    let mid = x.loadProp;
+    return { storeProp: mid };
+}
 
 identity({});
 load({});
 store({});
 loadStore({});
+loadStore2({});
 
 const obj = {}; // name: obj
 
@@ -30,4 +35,7 @@ x = store(obj);
 x.storeProp; // track: obj
 
 x = loadStore({ loadProp: obj });
+x.storeProp; // track: obj
+
+x = loadStore2({ loadProp: obj });
 x.storeProp; // track: obj


### PR DESCRIPTION
For type-tracking, we currently have a simple summarization of functions in two cases:
- Induce a local step when a parameter is returned, and
- Induce a load step when a property of a parameter is returned.

This PR adds two more summaries:
- Induce a store step when a parameter is stored on the returned object.
- Induce a load-store step when a property of a parameter is stored on the returned object.

I ran two evaluations, both of which are fairly quiet. The new call edges seem valid.
- [With store steps only](https://github.com/github/codeql-dca-main/tree/data/asgerf/summarised-tt-s__default__code-scanning/reports)
- [With both steps](https://github.com/github/codeql-dca-main/issues/19500)