### PR TITLE
JS: Improve detection of classes with escaping instances

### DIFF
--- a/javascript/ql/lib/semmle/javascript/endpoints/EndpointNaming.qll
+++ b/javascript/ql/lib/semmle/javascript/endpoints/EndpointNaming.qll
@@ -277,9 +277,16 @@ private predicate nameFromGlobal(DataFlow::Node node, string package, string nam
   (if node.getTopLevel().isExterns() then badness = -10 else badness = 10)
 }
 
+/** Gets an API node whose value is exposed to client code. */
+private API::Node exposedNode() {
+  result = API::moduleExport(_)
+  or
+  result = exposedNode().getASuccessor()
+}
+
 /** Holds if an instance of `cls` can be exposed to client code. */
 private predicate hasEscapingInstance(DataFlow::ClassNode cls) {
-  cls.getAnInstanceReference().flowsTo(any(API::Node n).asSink())
+  cls.getAnInstanceReference().flowsTo(exposedNode().asSink())
 }
 
 private predicate sourceNodeHasNameCandidate(

--- a/javascript/ql/test/library-tests/EndpointNaming/EndpointNaming.expected
+++ b/javascript/ql/test/library-tests/EndpointNaming/EndpointNaming.expected
@@ -1,4 +1,5 @@
 testFailures
+| pack1/main.js:19:6:19:10 |  | Unexpected result: name=(pack1).InternalClass.prototype.m |
 ambiguousPreferredPredecessor
 | pack2/lib.js:1:1:3:1 | def moduleImport("pack2").getMember("exports").getMember("lib").getMember("LibClass").getInstance() |
 | pack2/lib.js:8:22:8:34 | def moduleImport("pack2").getMember("exports").getMember("lib").getMember("LibClass").getMember("foo") |

--- a/javascript/ql/test/library-tests/EndpointNaming/EndpointNaming.expected
+++ b/javascript/ql/test/library-tests/EndpointNaming/EndpointNaming.expected
@@ -1,5 +1,4 @@
 testFailures
-| pack1/main.js:19:6:19:10 |  | Unexpected result: name=(pack1).InternalClass.prototype.m |
 ambiguousPreferredPredecessor
 | pack2/lib.js:1:1:3:1 | def moduleImport("pack2").getMember("exports").getMember("lib").getMember("LibClass").getInstance() |
 | pack2/lib.js:8:22:8:34 | def moduleImport("pack2").getMember("exports").getMember("lib").getMember("LibClass").getMember("foo") |

--- a/javascript/ql/test/library-tests/EndpointNaming/pack1/main.js
+++ b/javascript/ql/test/library-tests/EndpointNaming/pack1/main.js
@@ -13,3 +13,9 @@ export function getEscapingInstance() {
 } // $ name=(pack1).getEscapingInstance
 
 export function publicFunction() {} // $ name=(pack1).publicFunction
+
+// Escapes into an upstream library, but is not exposed downstream
+class InternalClass {
+    m() {}
+}
+require('foo').bar(new InternalClass());


### PR DESCRIPTION
A class was erroneously considered to escape into client code if it escaping into a upstream library:
```js
class A {}
module.exports = new A(); // Correct: escapes downstream

class B {}
require('foo')(new B()); // Wrong: escapes upstream, does not need a synthetic name
```
