### PR TITLE
Python: Add consistency check for `PhaseDependentFlow`

### DIFF
--- a/python/ql/consistency-queries/PhaseDependentFlowConsistency.ql
+++ b/python/ql/consistency-queries/PhaseDependentFlowConsistency.ql
@@ -8,7 +8,7 @@ where
   not exists(node.getScope()) and
   exists(Node nodeFrom, Node nodeTo | node in [nodeFrom, nodeTo] |
     // the list of step relations used with PhaseDependentFlow has been compiled
-    // manually, and there isn't really a good way to do so manually :|
+    // manually, and there isn't really a good way to do so automatically :|
     DataFlowPrivate::LocalFlow::definitionFlowStep(nodeFrom, nodeTo)
     or
     DataFlowPrivate::LocalFlow::expressionFlowStep(nodeFrom, nodeTo)

--- a/python/ql/consistency-queries/PhaseDependentFlowConsistency.ql
+++ b/python/ql/consistency-queries/PhaseDependentFlowConsistency.ql
@@ -1,0 +1,21 @@
+private import python
+private import semmle.python.dataflow.new.DataFlow::DataFlow
+private import semmle.python.dataflow.new.internal.DataFlowPrivate as DataFlowPrivate
+private import semmle.python.dataflow.new.internal.VariableCapture as VariableCapture
+
+from Node node
+where
+  not exists(node.getScope()) and
+  exists(Node nodeFrom, Node nodeTo | node in [nodeFrom, nodeTo] |
+    // the list of step relations used with PhaseDependentFlow has been compiled
+    // manually, and there isn't really a good way to do so manually :|
+    DataFlowPrivate::LocalFlow::definitionFlowStep(nodeFrom, nodeTo)
+    or
+    DataFlowPrivate::LocalFlow::expressionFlowStep(nodeFrom, nodeTo)
+    or
+    DataFlowPrivate::LocalFlow::useUseFlowStep(nodeFrom, nodeTo)
+    or
+    VariableCapture::valueStep(nodeFrom, nodeTo)
+  )
+select node,
+  "Node being used in PhaseDependentFlow does not have result for .getScope(), so will not work properly (since division into run-time/import-time is based on .getScope result)"


### PR DESCRIPTION
This would have found the problem fixed in
https://github.com/github/codeql/pull/15755.

As highlighted in the comment in the code, it's not a perfect solution
since we don't have an automatic way to ensure we don't introduce a new
PhaseDependentFlow use with a new step relation and forget to add it to
this consistency check... but I think this consistency check still adds
value!