### PR TITLE
C#: Add `build_modes: none` to `codeql-extractor.yml`

### DIFF
--- a/csharp/codeql-extractor.yml
+++ b/csharp/codeql-extractor.yml
@@ -9,6 +9,7 @@ extra_env_vars:
 build_modes:
   - autobuild
   - manual
+  - none
 github_api_languages:
   - C#
 scc_languages:
@@ -33,8 +34,10 @@ options:
         type: string
         pattern: "^(none|gzip|brotli)$"
   buildless:
-    title: Whether to use buildless (standalone) extraction.
+    title: DEPRECATED - Whether to use buildless (standalone) extraction.
     description: >
+      DEPRECATED: Use `--build-mode none` instead.
+
       A value indicating, which type of extraction the autobuilder should perform.
       If 'true', then the standalone extractor will be used, otherwise tracing extraction
       will be performed.

--- a/csharp/ql/integration-tests/all-platforms/cshtml_standalone/test.py
+++ b/csharp/ql/integration-tests/all-platforms/cshtml_standalone/test.py
@@ -1,4 +1,4 @@
 import os
 from create_database_utils import *
 
-run_codeql_database_create(lang="csharp", extra_args=["--extractor-option=buildless=true"])
+run_codeql_database_create(lang="csharp", extra_args=["--build-mode=none"])

--- a/csharp/ql/integration-tests/all-platforms/cshtml_standalone_disabled/test.py
+++ b/csharp/ql/integration-tests/all-platforms/cshtml_standalone_disabled/test.py
@@ -2,4 +2,4 @@ import os
 from create_database_utils import *
 
 os.environ['CODEQL_EXTRACTOR_CSHARP_BUILDLESS_EXTRACT_WEB_VIEWS'] = 'false'
-run_codeql_database_create(lang="csharp", extra_args=["--extractor-option=buildless=true"])
+run_codeql_database_create(lang="csharp", extra_args=["--build-mode=none"])

--- a/csharp/ql/integration-tests/all-platforms/cshtml_standalone_flowsteps/test.py
+++ b/csharp/ql/integration-tests/all-platforms/cshtml_standalone_flowsteps/test.py
@@ -1,4 +1,4 @@
 import os
 from create_database_utils import *
 
-run_codeql_database_create(lang="csharp", extra_args=["--extractor-option=buildless=true"])
+run_codeql_database_create(lang="csharp", extra_args=["--build-mode=none"])

--- a/csharp/ql/integration-tests/all-platforms/cshtml_standalone_net6/test.py
+++ b/csharp/ql/integration-tests/all-platforms/cshtml_standalone_net6/test.py
@@ -1,4 +1,4 @@
 import os
 from create_database_utils import *
 
-run_codeql_database_create(lang="csharp", extra_args=["--extractor-option=buildless=true"])
+run_codeql_database_create(lang="csharp", extra_args=["--build-mode=none"])

--- a/csharp/ql/integration-tests/all-platforms/standalone/test.py
+++ b/csharp/ql/integration-tests/all-platforms/standalone/test.py
@@ -1,3 +1,3 @@
 from create_database_utils import *
 
-run_codeql_database_create([], lang="csharp", extra_args=["--extractor-option=buildless=true"])
+run_codeql_database_create([], lang="csharp", extra_args=["--build-mode=none"])

--- a/csharp/ql/integration-tests/all-platforms/standalone_dependencies_net48/test.py
+++ b/csharp/ql/integration-tests/all-platforms/standalone_dependencies_net48/test.py
@@ -1,3 +1,3 @@
 from create_database_utils import *
 
-run_codeql_database_create([], lang="csharp", extra_args=["--extractor-option=buildless=true"])
+run_codeql_database_create([], lang="csharp", extra_args=["--build-mode=none"])

--- a/csharp/ql/integration-tests/linux-only/standalone_dependencies_non_utf8_filename/test.py
+++ b/csharp/ql/integration-tests/linux-only/standalone_dependencies_non_utf8_filename/test.py
@@ -5,4 +5,4 @@ path = b'\xd2abcd.cs'
 with open(path, 'w') as file:
   file.write('class X { }\n')
 
-run_codeql_database_create([], lang="csharp", extra_args=["--extractor-option=buildless=true"])
+run_codeql_database_create([], lang="csharp", extra_args=["--build-mode=none"])

--- a/csharp/ql/integration-tests/posix-only/standalone_dependencies/test.py
+++ b/csharp/ql/integration-tests/posix-only/standalone_dependencies/test.py
@@ -1,3 +1,3 @@
 from create_database_utils import *
 
-run_codeql_database_create([], lang="csharp", extra_args=["--extractor-option=buildless=true"])
+run_codeql_database_create([], lang="csharp", extra_args=["--build-mode=none"])

--- a/csharp/ql/integration-tests/posix-only/standalone_dependencies_multi_target/test.py
+++ b/csharp/ql/integration-tests/posix-only/standalone_dependencies_multi_target/test.py
@@ -1,3 +1,3 @@
 from create_database_utils import *
 
-run_codeql_database_create([], lang="csharp", extra_args=["--extractor-option=buildless=true"])
+run_codeql_database_create([], lang="csharp", extra_args=["--build-mode=none"])

--- a/csharp/ql/integration-tests/posix-only/standalone_dependencies_no_framework/test.py
+++ b/csharp/ql/integration-tests/posix-only/standalone_dependencies_no_framework/test.py
@@ -2,4 +2,4 @@ from create_database_utils import *
 import os
 
 os.environ["CODEQL_EXTRACTOR_CSHARP_BUILDLESS_DOTNET_FRAMEWORK_REFERENCES"] = "/non-existent-path"
-run_codeql_database_create([], lang="csharp", extra_args=["--extractor-option=buildless=true"])
+run_codeql_database_create([], lang="csharp", extra_args=["--build-mode=none"])

--- a/csharp/ql/integration-tests/posix-only/standalone_dependencies_nuget/test.py
+++ b/csharp/ql/integration-tests/posix-only/standalone_dependencies_nuget/test.py
@@ -1,3 +1,3 @@
 from create_database_utils import *
 
-run_codeql_database_create([], lang="csharp", extra_args=["--extractor-option=buildless=true"])
+run_codeql_database_create([], lang="csharp", extra_args=["--build-mode=none"])

--- a/csharp/ql/integration-tests/posix-only/standalone_dependencies_nuget_config_error/test.py
+++ b/csharp/ql/integration-tests/posix-only/standalone_dependencies_nuget_config_error/test.py
@@ -1,3 +1,3 @@
 from create_database_utils import *
 
-run_codeql_database_create([], lang="csharp", extra_args=["--extractor-option=buildless=true"])
+run_codeql_database_create([], lang="csharp", extra_args=["--build-mode=none"])

--- a/csharp/ql/integration-tests/posix-only/standalone_dependencies_nuget_no_sources/test.py
+++ b/csharp/ql/integration-tests/posix-only/standalone_dependencies_nuget_no_sources/test.py
@@ -1,3 +1,3 @@
 from create_database_utils import *
 
-run_codeql_database_create([], source="proj", lang="csharp", extra_args=["--extractor-option=buildless=true"])
+run_codeql_database_create([], source="proj", lang="csharp", extra_args=["--build-mode=none"])

--- a/csharp/ql/integration-tests/windows-only/standalone_dependencies/test.py
+++ b/csharp/ql/integration-tests/windows-only/standalone_dependencies/test.py
@@ -1,3 +1,3 @@
 from create_database_utils import *
 
-run_codeql_database_create([], lang="csharp", extra_args=["--extractor-option=buildless=true"])
+run_codeql_database_create([], lang="csharp", extra_args=["--build-mode=none"])


### PR DESCRIPTION
`--build-mode none` replaces the existing `-Obuildless=true`.