### PR TITLE
Ruby: Model `Typhoeus::Request.new`

### DIFF
--- a/ruby/ql/lib/change-notes/2024-03-01-typhoeus-request.md
+++ b/ruby/ql/lib/change-notes/2024-03-01-typhoeus-request.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-Calls to `Typhoeus::Request.new` are now considered as instances of the `Http::Client::Request` concept, with the response body being treated as a remote flow source.
+* Calls to `Typhoeus::Request.new` are now considered as instances of the `Http::Client::Request` concept, with the response body being treated as a remote flow source.

--- a/ruby/ql/lib/change-notes/2024-03-01-typhoeus-request.md
+++ b/ruby/ql/lib/change-notes/2024-03-01-typhoeus-request.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+Calls to `Typhoeus::Request.new` are now considered as instances of the `Http::Client::Request` concept, with the response body being treated as a remote flow source.

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Typhoeus.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Typhoeus.qll
@@ -91,7 +91,7 @@ private API::Node getResponseFromRequest(API::Node requestNode) {
     ]
 }
 
-/** Gets the body from the given `responseNode` representing a Typhoeus request */
+/** Gets the body from the given `responseNode` representing a Typhoeus response */
 private DataFlow::Node getBodyFromResponse(API::Node responseNode) {
   result = responseNode.getAMethodCall(["body", "response_body"])
 }

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Typhoeus.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Typhoeus.qll
@@ -70,6 +70,8 @@ private module TyphoeusDisablesCertificateValidationFlow =
   DataFlow::Global<TyphoeusDisablesCertificateValidationConfig>;
 
 /** Gets the body from the given `requestNode` representing a Typhoeus request */
+bindingset[requestNode]
+pragma[inline_late]
 private DataFlow::Node getBodyFromRequest(API::Node requestNode) {
   result =
     [
@@ -79,6 +81,8 @@ private DataFlow::Node getBodyFromRequest(API::Node requestNode) {
 }
 
 /** Gets the response from the given `requestNode` representing a Typhoeus request */
+bindingset[requestNode]
+pragma[inline_late]
 private API::Node getResponseFromRequest(API::Node requestNode) {
   result =
     [
@@ -92,6 +96,8 @@ private API::Node getResponseFromRequest(API::Node requestNode) {
 }
 
 /** Gets the body from the given `responseNode` representing a Typhoeus response */
+bindingset[responseNode]
+pragma[inline_late]
 private DataFlow::Node getBodyFromResponse(API::Node responseNode) {
   result = responseNode.getAMethodCall(["body", "response_body"])
 }

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Typhoeus.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Typhoeus.qll
@@ -27,7 +27,7 @@ class TyphoeusHttpRequest extends Http::Client::Request::Range, DataFlow::CallNo
             .getReturn(["get", "head", "delete", "options", "post", "put", "patch"])
       or
       directResponse = false and
-      requestNode = API::getTopLevelMember("Typhoeus").getMember("Request").getReturn("new")
+      requestNode = API::getTopLevelMember("Typhoeus").getMember("Request").getInstance()
     )
   }
 
@@ -38,7 +38,7 @@ class TyphoeusHttpRequest extends Http::Client::Request::Range, DataFlow::CallNo
     result = getBodyFromResponse(requestNode)
     or
     directResponse = false and
-    result = getBodyFromRequest(requestNode)
+    result = getResponseBodyFromRequest(requestNode)
   }
 
   /** Gets the value that controls certificate validation, if any. */
@@ -69,10 +69,10 @@ private module TyphoeusDisablesCertificateValidationConfig implements DataFlow::
 private module TyphoeusDisablesCertificateValidationFlow =
   DataFlow::Global<TyphoeusDisablesCertificateValidationConfig>;
 
-/** Gets the body from the given `requestNode` representing a Typhoeus request */
+/** Gets the response body from the given `requestNode` representing a Typhoeus request */
 bindingset[requestNode]
 pragma[inline_late]
-private DataFlow::Node getBodyFromRequest(API::Node requestNode) {
+private DataFlow::Node getResponseBodyFromRequest(API::Node requestNode) {
   result =
     [
       getBodyFromResponse(getResponseFromRequest(requestNode)),
@@ -95,7 +95,7 @@ private API::Node getResponseFromRequest(API::Node requestNode) {
     ]
 }
 
-/** Gets the body from the given `responseNode` representing a Typhoeus response */
+/** Gets the response body from the given `responseNode` representing a Typhoeus response */
 bindingset[responseNode]
 pragma[inline_late]
 private DataFlow::Node getBodyFromResponse(API::Node responseNode) {

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Typhoeus.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Typhoeus.qll
@@ -69,6 +69,7 @@ private module TyphoeusDisablesCertificateValidationConfig implements DataFlow::
 private module TyphoeusDisablesCertificateValidationFlow =
   DataFlow::Global<TyphoeusDisablesCertificateValidationConfig>;
 
+/** Gets the body from the given `requestNode` representing a Typhoeus request */
 private DataFlow::Node getBodyFromRequest(API::Node requestNode) {
   result =
     [
@@ -77,17 +78,20 @@ private DataFlow::Node getBodyFromRequest(API::Node requestNode) {
     ]
 }
 
+/** Gets the response from the given `requestNode` representing a Typhoeus request */
 private API::Node getResponseFromRequest(API::Node requestNode) {
   result =
     [
       requestNode.getReturn(["run", "response"]),
       requestNode
-          .getMethod(["on_complete", "on_success", "on_headers", "on_failure", "on_progress"])
+          // on_headers does not carry a response body
+          .getMethod(["on_complete", "on_success", "on_failure", "on_progress"])
           .getBlock()
           .getParameter(0)
     ]
 }
 
+/** Gets the body from the given `responseNode` representing a Typhoeus request */
 private DataFlow::Node getBodyFromResponse(API::Node responseNode) {
   result = responseNode.getAMethodCall(["body", "response_body"])
 }

--- a/ruby/ql/test/library-tests/frameworks/http_clients/HttpClients.expected
+++ b/ruby/ql/test/library-tests/frameworks/http_clients/HttpClients.expected
@@ -67,6 +67,14 @@ httpRequests
 | Typhoeus.rb:15:9:15:46 | call to delete |
 | Typhoeus.rb:18:9:18:44 | call to head |
 | Typhoeus.rb:21:9:21:47 | call to options |
+| Typhoeus.rb:24:8:24:50 | call to new |
+| Typhoeus.rb:27:8:27:50 | call to new |
+| Typhoeus.rb:31:9:31:51 | call to new |
+| Typhoeus.rb:34:9:34:51 | call to new |
+| Typhoeus.rb:39:9:39:51 | call to new |
+| Typhoeus.rb:44:9:44:51 | call to new |
+| Typhoeus.rb:49:9:49:51 | call to new |
+| Typhoeus.rb:54:9:54:51 | call to new |
 getFramework
 | Excon.rb:3:9:3:40 | call to get | Excon |
 | Excon.rb:6:9:6:60 | call to post | Excon |
@@ -136,6 +144,14 @@ getFramework
 | Typhoeus.rb:15:9:15:46 | call to delete | Typhoeus |
 | Typhoeus.rb:18:9:18:44 | call to head | Typhoeus |
 | Typhoeus.rb:21:9:21:47 | call to options | Typhoeus |
+| Typhoeus.rb:24:8:24:50 | call to new | Typhoeus |
+| Typhoeus.rb:27:8:27:50 | call to new | Typhoeus |
+| Typhoeus.rb:31:9:31:51 | call to new | Typhoeus |
+| Typhoeus.rb:34:9:34:51 | call to new | Typhoeus |
+| Typhoeus.rb:39:9:39:51 | call to new | Typhoeus |
+| Typhoeus.rb:44:9:44:51 | call to new | Typhoeus |
+| Typhoeus.rb:49:9:49:51 | call to new | Typhoeus |
+| Typhoeus.rb:54:9:54:51 | call to new | Typhoeus |
 getResponseBody
 | Excon.rb:3:9:3:40 | call to get | Excon.rb:4:1:4:10 | call to body |
 | Excon.rb:6:9:6:60 | call to post | Excon.rb:7:1:7:10 | call to body |
@@ -205,6 +221,14 @@ getResponseBody
 | Typhoeus.rb:15:9:15:46 | call to delete | Typhoeus.rb:16:1:16:10 | call to body |
 | Typhoeus.rb:18:9:18:44 | call to head | Typhoeus.rb:19:1:19:10 | call to body |
 | Typhoeus.rb:21:9:21:47 | call to options | Typhoeus.rb:22:1:22:10 | call to body |
+| Typhoeus.rb:24:8:24:50 | call to new | Typhoeus.rb:25:1:25:13 | call to body |
+| Typhoeus.rb:27:8:27:50 | call to new | Typhoeus.rb:29:1:29:18 | call to body |
+| Typhoeus.rb:31:9:31:51 | call to new | Typhoeus.rb:32:1:32:23 | call to response_body |
+| Typhoeus.rb:34:9:34:51 | call to new | Typhoeus.rb:36:5:36:15 | call to body |
+| Typhoeus.rb:39:9:39:51 | call to new | Typhoeus.rb:41:5:41:15 | call to body |
+| Typhoeus.rb:44:9:44:51 | call to new | Typhoeus.rb:46:5:46:15 | call to body |
+| Typhoeus.rb:49:9:49:51 | call to new | Typhoeus.rb:51:5:51:15 | call to body |
+| Typhoeus.rb:54:9:54:51 | call to new | Typhoeus.rb:55:19:55:24 | body15 |
 getAUrlPart
 | Excon.rb:3:9:3:40 | call to get | Excon.rb:3:19:3:39 | "http://example.com/" |
 | Excon.rb:6:9:6:60 | call to post | Excon.rb:6:20:6:40 | "http://example.com/" |
@@ -287,3 +311,11 @@ getAUrlPart
 | Typhoeus.rb:15:9:15:46 | call to delete | Typhoeus.rb:15:25:15:45 | "http://example.com/" |
 | Typhoeus.rb:18:9:18:44 | call to head | Typhoeus.rb:18:23:18:43 | "http://example.com/" |
 | Typhoeus.rb:21:9:21:47 | call to options | Typhoeus.rb:21:26:21:46 | "http://example.com/" |
+| Typhoeus.rb:24:8:24:50 | call to new | Typhoeus.rb:24:30:24:49 | "http://example.com" |
+| Typhoeus.rb:27:8:27:50 | call to new | Typhoeus.rb:27:30:27:49 | "http://example.com" |
+| Typhoeus.rb:31:9:31:51 | call to new | Typhoeus.rb:31:31:31:50 | "http://example.com" |
+| Typhoeus.rb:34:9:34:51 | call to new | Typhoeus.rb:34:31:34:50 | "http://example.com" |
+| Typhoeus.rb:39:9:39:51 | call to new | Typhoeus.rb:39:31:39:50 | "http://example.com" |
+| Typhoeus.rb:44:9:44:51 | call to new | Typhoeus.rb:44:31:44:50 | "http://example.com" |
+| Typhoeus.rb:49:9:49:51 | call to new | Typhoeus.rb:49:31:49:50 | "http://example.com" |
+| Typhoeus.rb:54:9:54:51 | call to new | Typhoeus.rb:54:31:54:50 | "http://example.com" |

--- a/ruby/ql/test/library-tests/frameworks/http_clients/Typhoeus.rb
+++ b/ruby/ql/test/library-tests/frameworks/http_clients/Typhoeus.rb
@@ -20,3 +20,38 @@ resp6.body
 
 resp7 = Typhoeus.options("http://example.com/")
 resp7.body
+
+req8 = Typhoeus::Request.new("http://example.com")
+req8.run.body
+
+req9 = Typhoeus::Request.new("http://example.com")
+req9.run
+req9.response.body
+
+req10 = Typhoeus::Request.new("http://example.com")
+req10.run.response_body
+
+req11 = Typhoeus::Request.new("http://example.com")
+req11.on_complete do |resp11| 
+    resp11.body
+end
+
+req12 = Typhoeus::Request.new("http://example.com")
+req12.on_success do |resp12| 
+    resp12.body
+end
+
+req13 = Typhoeus::Request.new("http://example.com")
+req13.on_failure do |resp13| 
+    resp13.body
+end
+
+req14 = Typhoeus::Request.new("http://example.com")
+req14.on_progress do |resp14| 
+    resp14.body
+end
+
+req15 = Typhoeus::Request.new("http://example.com")
+req15.on_body do |body15| 
+    # ...
+end


### PR DESCRIPTION
Closes https://github.com/github/codeql-team/issues/618
Part of https://github.com/github/codeql-team/issues/2616

This PR adds modelling for `Typhoeus::Request.new` as an http client request, and tracks flow to the response body either directly (`req.run.body`) or through callbacks (`req.on_complete do |resp| { ... resp.body ...}`).