### PR TITLE
Java: sensitive logging query exclude null in variable name

### DIFF
--- a/java/ql/lib/semmle/code/java/security/SensitiveLoggingQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/SensitiveLoggingQuery.qll
@@ -9,7 +9,12 @@ private import semmle.code.java.security.Sanitizers
 
 /** A variable that may hold sensitive information, judging by its name. */
 class VariableWithSensitiveName extends Variable {
-  VariableWithSensitiveName() { this.getName().regexpMatch(getCommonSensitiveInfoRegex()) }
+  VariableWithSensitiveName() {
+    exists(string name | name = this.getName() |
+      name.regexpMatch(getCommonSensitiveInfoRegex()) and
+      not name.regexpMatch("(?i).*null.*")
+    )
+  }
 }
 
 /** A reference to a variable that may hold sensitive information, judging by its name. */

--- a/java/ql/src/change-notes/2024-03-04-sensitive-log-remove-null-from-sources.md
+++ b/java/ql/src/change-notes/2024-03-04-sensitive-log-remove-null-from-sources.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* To reduce the number of false positives in the query "Insertion of sensitive information into log files" (java/sensitive-log), variables with names that contain "null" (case-insensitively) will no longer considered sources of sensitive information.

--- a/java/ql/src/change-notes/2024-03-04-sensitive-log-remove-null-from-sources.md
+++ b/java/ql/src/change-notes/2024-03-04-sensitive-log-remove-null-from-sources.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* To reduce the number of false positives in the query "Insertion of sensitive information into log files" (java/sensitive-log), variables with names that contain "null" (case-insensitively) will no longer considered sources of sensitive information.
+* To reduce the number of false positives in the query "Insertion of sensitive information into log files" (`java/sensitive-log`), variables with names that contain "null" (case-insensitively) are no longer considered sources of sensitive information.

--- a/java/ql/test/query-tests/security/CWE-532/Test.java
+++ b/java/ql/test/query-tests/security/CWE-532/Test.java
@@ -19,4 +19,10 @@ class Test {
         logger.error("Auth failed for: " + username); // Safe
     }
 
+    void test4(String nullToken) {
+        Logger logger = null;
+
+        logger.error("Auth failed for: " + nullToken); // Safe
+    }
+
 }


### PR DESCRIPTION
I noticed some FPs in `apache/geode` where the source was a variable called `NULLTOKEN`. It is an easy fix to exclude variable names that match "null" (case-insensitively) from the sources.