### PR TITLE
Go: Allow 1.22 as a supported version

### DIFF
--- a/go/extractor/autobuilder/build-environment.go
+++ b/go/extractor/autobuilder/build-environment.go
@@ -12,7 +12,7 @@ import (
 )
 
 const minGoVersion = "1.11"
-const maxGoVersion = "1.21"
+const maxGoVersion = "1.22"
 
 type versionInfo struct {
 	goModVersion      string // The version of Go found in the go directive in the `go.mod` file.


### PR DESCRIPTION
This PR updates the `maxGoVersion` constant to `1.22` so that we allow this as a version to be recommended by resolve build environment functionality in e.g. default setup workflows. 

Enabled by having merged #15361.