### PR TITLE
Go: Use Go 1.22 for the extractor

### DIFF
--- a/go/extractor/go.mod
+++ b/go/extractor/go.mod
@@ -1,6 +1,6 @@
 module github.com/github/codeql-go/extractor
 
-go 1.21
+go 1.22.0
 
 require (
 	golang.org/x/mod v0.15.0

--- a/go/extractor/go.work.sum
+++ b/go/extractor/go.work.sum
@@ -1,1 +1,5 @@
+github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/net v0.20.0/go.mod h1:z8BVo6PvndSri0LbOE3hAn0apkU+1YvI6E70E9jsnvY=
+golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
+golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/telemetry v0.0.0-20240208230135-b75ee8823808/go.mod h1:KG1lNk5ZFNssSZLrpVb4sMXKMpGwGXOxSG3rnu2gZQQ=


### PR DESCRIPTION
Bumps the Go version in our `go.mod` file (and also updates the `go.work.sum` file which apparently missing some entries when we merged it in https://github.com/github/codeql/pull/15362).