### PR TITLE
Fix Markdown formatting on Ruby changenotes

### DIFF
--- a/ruby/ql/lib/change-notes/2024-02-26-arel-sqlliteral.md
+++ b/ruby/ql/lib/change-notes/2024-02-26-arel-sqlliteral.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-Calls to `Arel::Nodes::SqlLiteral.new` are now modeled as instances of the `SqlConstruction` concept, as well as propagating taint from their argument.
+* Calls to `Arel::Nodes::SqlLiteral.new` are now modeled as instances of the `SqlConstruction` concept, as well as propagating taint from their argument.

--- a/ruby/ql/lib/change-notes/2024-02-29-i18n-translate.md
+++ b/ruby/ql/lib/change-notes/2024-02-29-i18n-translate.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-Calls to `I18n.translate` as well as Rails helper translate methods now propagate taint from their keyword arguments. The Rails translate methods are also recognized as XSS sanitizers when using keys marked as html safe.
+* Calls to `I18n.translate` as well as Rails helper translate methods now propagate taint from their keyword arguments. The Rails translate methods are also recognized as XSS sanitizers when using keys marked as html safe.


### PR DESCRIPTION
Fixed the Markdown formatting for two changenotes so that the pack changelogs will render appropriately!