### PR TITLE
Go: Only check strings of length <= 100 for dummy password with <= 2 unique characters

### DIFF
--- a/go/ql/lib/semmle/go/security/SensitiveActions.qll
+++ b/go/ql/lib/semmle/go/security/SensitiveActions.qll
@@ -233,6 +233,7 @@ module PasswordHeuristics {
   predicate isDummyPassword(string password) {
     password.length() < 4
     or
+    password.length() <= 100 and
     count(password.charAt(_)) <= 2 // aaaaaaaa or bBbBbB or ghghghghghgh or the like
     or
     password


### PR DESCRIPTION
This avoids high memory usage on projects with lots of very long strings.