### PR TITLE
Data flow: Allow for direct stores into nodes with `clearsContent`

### DIFF
--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -3999,10 +3999,8 @@ module MakeImpl<InputSig Lang> {
           isStoreStep) and
         Stage5::revFlow(pragma[only_bind_into](node), pragma[only_bind_into](state), ap.getApprox()) and
         strengthenType(node, t0, t) and
-        not inBarrier(node, state)
-      |
-        isStoreStep = true or
-        not ap.storeTargetIsClearedAt(node)
+        not inBarrier(node, state) and
+        if ap.storeTargetIsClearedAt(node) then isStoreStep = true else any()
       )
     }
 


### PR DESCRIPTION
Before this PR, store steps where the target node would clear the stored content via `clearsContent` would get filtered away. However, it is convenient to be able to only filter away _earlier_ store steps, which is what this PR changes. The old semantics can be still be maintained on a per-language basis, as it is simply a matter of removing such store steps up front.

Needed in preparation for https://github.com/github/codeql/pull/15802. 