### PR TITLE
Dataflow: Misc performance fixes

### DIFF
--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -1904,11 +1904,11 @@ module MakeImpl<InputSig Lang> {
         pragma[nomagic]
         private predicate returnFlowsThrough(
           RetNodeEx ret, ReturnPosition pos, FlowState state, CcCall ccc, ParamNodeEx p, Typ argT,
-          Ap argAp, Ap ap
+          Ap argAp, ApApprox argApa, Ap ap
         ) {
-          exists(DataFlowCall call, ApApprox apa, boolean allowsFieldFlow, ApApprox innerArgApa |
-            returnFlowsThrough0(call, state, ccc, ap, apa, ret, p, argT, argAp, innerArgApa) and
-            flowThroughOutOfCall(call, ccc, ret, _, allowsFieldFlow, innerArgApa, apa) and
+          exists(DataFlowCall call, ApApprox apa, boolean allowsFieldFlow |
+            returnFlowsThrough0(call, state, ccc, ap, apa, ret, p, argT, argAp, argApa) and
+            flowThroughOutOfCall(call, ccc, ret, _, allowsFieldFlow, argApa, apa) and
             pos = ret.getReturnPosition() and
             if allowsFieldFlow = false then ap instanceof ApNil else any()
           )
@@ -1920,10 +1920,10 @@ module MakeImpl<InputSig Lang> {
         ) {
           exists(ApApprox argApa, Typ argT |
             returnFlowsThrough(_, _, _, _, pragma[only_bind_into](p), pragma[only_bind_into](argT),
-              pragma[only_bind_into](argAp), ap) and
+              pragma[only_bind_into](argAp), pragma[only_bind_into](argApa), ap) and
             flowIntoCallApaTaken(call, _, pragma[only_bind_into](arg), p, allowsFieldFlow, argApa) and
             fwdFlow(arg, _, _, _, _, _, pragma[only_bind_into](argT), pragma[only_bind_into](argAp),
-              argApa) and
+              pragma[only_bind_into](argApa)) and
             if allowsFieldFlow = false then argAp instanceof ApNil else any()
           )
         }
@@ -2027,7 +2027,7 @@ module MakeImpl<InputSig Lang> {
           // flow out of a callable
           exists(ReturnPosition pos |
             revFlowOut(_, node, pos, state, _, _, _, ap) and
-            if returnFlowsThrough(node, pos, state, _, _, _, _, ap)
+            if returnFlowsThrough(node, pos, state, _, _, _, _, _, ap)
             then (
               returnCtx = TReturnCtxMaybeFlowThrough(pos) and
               returnAp = apSome(ap)
@@ -2189,7 +2189,7 @@ module MakeImpl<InputSig Lang> {
         ) {
           exists(RetNodeEx ret, FlowState state, CcCall ccc |
             revFlowOut(call, ret, pos, state, returnCtx, _, returnAp, ap) and
-            returnFlowsThrough(ret, pos, state, ccc, _, _, _, ap) and
+            returnFlowsThrough(ret, pos, state, ccc, _, _, _, _, ap) and
             matchesCall(ccc, call)
           )
         }
@@ -2258,7 +2258,7 @@ module MakeImpl<InputSig Lang> {
         pragma[nomagic]
         predicate parameterMayFlowThrough(ParamNodeEx p, Ap ap) {
           exists(ReturnPosition pos |
-            returnFlowsThrough(_, pos, _, _, p, _, ap, _) and
+            returnFlowsThrough(_, pos, _, _, p, _, ap, _, _) and
             parameterFlowsThroughRev(p, ap, pos, _)
           )
         }
@@ -2266,7 +2266,7 @@ module MakeImpl<InputSig Lang> {
         pragma[nomagic]
         predicate returnMayFlowThrough(RetNodeEx ret, Ap argAp, Ap ap, ReturnKindExt kind) {
           exists(ParamNodeEx p, ReturnPosition pos |
-            returnFlowsThrough(ret, pos, _, _, p, _, argAp, ap) and
+            returnFlowsThrough(ret, pos, _, _, p, _, argAp, _, ap) and
             parameterFlowsThroughRev(p, argAp, pos, ap) and
             kind = pos.getKind()
           )

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -3986,8 +3986,8 @@ module MakeImpl<InputSig Lang> {
       AccessPath ap
     ) {
       exists(DataFlowType t0 |
-        pathStep0(mid, node, state, cc, sc, t0, ap) and
-        Stage5::revFlow(node, state, ap.getApprox()) and
+        pathStep0(mid, pragma[only_bind_into](node), pragma[only_bind_into](state), cc, sc, t0, ap) and
+        Stage5::revFlow(pragma[only_bind_into](node), pragma[only_bind_into](state), ap.getApprox()) and
         strengthenType(node, t0, t) and
         not inBarrier(node, state)
       )


### PR DESCRIPTION
Two commits fixing two separate problems.

The first commit improves the join of `returnFlowsThrough`, `flowIntoCallApaTaken`, and `fwdFlow`. The join must happen in that order (digging into the git history shows prior join-order tweaks in this predicate documenting this), but it still has an unfortunate blow-up, which we can fortunately cut substantially down by including the `argApa` column in the first join.

Improves from
```
2024-03-04 13:29:20] Evaluated non-recursive predicate DataFlowImpl::Impl<TaintedPath::TaintedPath::C>::Stage5::flowThroughIntoCall/6#b44155c7@6dd478n9 in 126ms (size: 398332).
Evaluated relational algebra for predicate DataFlowImpl::Impl<TaintedPath::TaintedPath::C>::Stage5::flowThroughIntoCall/6#b44155c7@6dd478n9 with tuple counts:
              1  ~0%    {2} r1 = SCAN `DataFlowImpl::Impl<TaintedPath::TaintedPath::C>::TAccessPathApproxNone#dom#04382804` OUTPUT _, _
              1  ~0%    {0}    | REWRITE WITH Tmp.0 := true, Tmp.1 := false, TEST Tmp.0 != Tmp.1 KEEPING 0
          83798  ~0%    {4}    | JOIN WITH `project#DataFlowImpl::Impl<TaintedPath::TaintedPath::C>::Stage5::returnFlowsThrough/8#ffafcf14` CARTESIAN PRODUCT OUTPUT Rhs.0, Rhs.3, Rhs.1, Rhs.2
        4044102  ~3%    {7}    | JOIN WITH `project#DataFlowImpl::Impl<TaintedPath::TaintedPath::C>::Stage5::flowIntoCallApaTaken/6#d989a8d1#cpe#12346_2013#join_rhs` ON FIRST 1 OUTPUT Rhs.2, Lhs.2, Lhs.3, Rhs.3, Lhs.1, Lhs.0, Rhs.1
         398332  ~3%    {6}    | JOIN WITH `project#DataFlowImpl::Impl<TaintedPath::TaintedPath::C>::Stage5::fwdFlow/9#00ae2fc8#2` ON FIRST 4 OUTPUT Lhs.6, Lhs.0, Lhs.5, _, Lhs.2, Lhs.4
         398332  ~1%    {6}    | REWRITE WITH Out.3 := true
                        return r1
```
to
```
[2024-03-04 15:20:26] Evaluated non-recursive predicate DataFlowImpl::Impl<TaintedPath::TaintedPath::C>::Stage5::flowThroughIntoCall/6#b44155c7@97bd358u in 35ms (size: 398332).
Evaluated relational algebra for predicate DataFlowImpl::Impl<TaintedPath::TaintedPath::C>::Stage5::flowThroughIntoCall/6#b44155c7@97bd358u with tuple counts:
         83798   ~0%    {7} r1 = SCAN `project#DataFlowImpl::Impl<TaintedPath::TaintedPath::C>::Stage5::returnFlowsThrough/9#53894c55` OUTPUT In.0, In.1, In.2, In.3, In.4, _, _
                        {5}    | REWRITE WITH Tmp.5 := true, Tmp.6 := false, TEST Tmp.5 != Tmp.6 KEEPING 5
         83798   ~3%    {5}    | SCAN OUTPUT In.0, In.3, In.4, In.1, In.2
        416847   ~2%    {7}    | JOIN WITH `project#DataFlowImpl::Impl<TaintedPath::TaintedPath::C>::Stage5::flowIntoCallApaTaken/6#d989a8d1#cpe#12346_2301#join_rhs` ON FIRST 2 OUTPUT Rhs.3, Lhs.3, Lhs.4, Lhs.1, Lhs.2, Lhs.0, Rhs.2
        398332   ~3%    {6}    | JOIN WITH `project#DataFlowImpl::Impl<TaintedPath::TaintedPath::C>::Stage5::fwdFlow/9#00ae2fc8#2` ON FIRST 4 OUTPUT Lhs.6, Lhs.0, Lhs.5, _, Lhs.2, Lhs.4
        398332   ~1%    {6}    | REWRITE WITH Out.3 := true
                        return r1
```

The second commit is a straight-forward join-order fix, where we need to join with the functional `getApprox` before filtering with `revFlow`, as we otherwise get a blowup.