### PR TITLE
JS: Call graph improvements

### DIFF
--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/CallGraphs.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/CallGraphs.qll
@@ -250,7 +250,7 @@ module CallGraph {
       result = node.(DataFlow::ObjectLiteralNode).getPropertySetter(_)
     ) and
     not node.getTopLevel().isExterns() and
-    // Do not track instance methods on classes
+    // Ignore writes to `this` inside a constructor, since this is already handled by instance method tracking
     not exists(DataFlow::ClassNode cls |
       node = cls.getConstructor().getReceiver()
       or

--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/CallGraphs.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/CallGraphs.qll
@@ -249,7 +249,13 @@ module CallGraph {
       or
       result = node.(DataFlow::ObjectLiteralNode).getPropertySetter(_)
     ) and
-    not node.getTopLevel().isExterns()
+    not node.getTopLevel().isExterns() and
+    // Do not track instance methods on classes
+    not exists(DataFlow::ClassNode cls |
+      node = cls.getConstructor().getReceiver()
+      or
+      node = cls.(DataFlow::ClassNode::FunctionStyleClass).getAPrototypeReference()
+    )
   }
 
   private predicate shouldTrackObjectWithMethods(DataFlow::SourceNode node) {

--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/CallGraphs.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/CallGraphs.qll
@@ -241,13 +241,8 @@ module CallGraph {
     )
   }
 
-  private DataFlow::FunctionNode getAMethodOnPlainObject(DataFlow::SourceNode node) {
+  private DataFlow::FunctionNode getAMethodOnObject(DataFlow::SourceNode node) {
     (
-      (
-        node instanceof DataFlow::ObjectLiteralNode
-        or
-        node instanceof DataFlow::FunctionNode
-      ) and
       result = node.getAPropertySource()
       or
       result = node.(DataFlow::ObjectLiteralNode).getPropertyGetter(_)
@@ -258,7 +253,7 @@ module CallGraph {
   }
 
   private predicate shouldTrackObjectWithMethods(DataFlow::SourceNode node) {
-    exists(getAMethodOnPlainObject(node))
+    exists(getAMethodOnObject(node))
   }
 
   /**
@@ -292,7 +287,7 @@ module CallGraph {
   predicate impliedReceiverStep(DataFlow::SourceNode pred, DataFlow::SourceNode succ) {
     exists(DataFlow::SourceNode host |
       pred = getAnAllocationSiteRef(host) and
-      succ = getAMethodOnPlainObject(host).getReceiver()
+      succ = getAMethodOnObject(host).getReceiver()
     )
   }
 }

--- a/javascript/ql/src/change-notes/2024-03-07-lift-cg-restriction.md
+++ b/javascript/ql/src/change-notes/2024-03-07-lift-cg-restriction.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The call graph has been improved, leading to more alerts for data flow based queries.

--- a/javascript/ql/test/library-tests/CallGraphs/FullTest/tests.expected
+++ b/javascript/ql/test/library-tests/CallGraphs/FullTest/tests.expected
@@ -135,6 +135,7 @@ test_getAFunctionValue
 | tst.js:3:1:3:1 | h | tst.js:3:5:3:17 | function() {} |
 | tst.js:3:1:3:17 | h = function() {} | tst.js:3:5:3:17 | function() {} |
 | tst.js:3:5:3:17 | function() {} | tst.js:3:5:3:17 | function() {} |
+| tst.js:4:1:4:1 | k | tst.js:2:9:2:21 | function() {} |
 | tst.js:4:1:4:5 | k = g | tst.js:2:9:2:21 | function() {} |
 | tst.js:4:5:4:5 | g | tst.js:2:9:2:21 | function() {} |
 | tst.js:6:1:6:1 | f | tst.js:1:1:1:15 | function f() {} |
@@ -142,13 +143,23 @@ test_getAFunctionValue
 | tst.js:8:1:8:1 | h | tst.js:3:5:3:17 | function() {} |
 | tst.js:9:1:9:1 | k | tst.js:2:9:2:21 | function() {} |
 | tst.js:11:1:20:1 | functio ... \\tf();\\n} | tst.js:11:1:20:1 | functio ... \\tf();\\n} |
+| tst.js:11:12:11:12 | m | tst.js:2:9:2:21 | function() {} |
+| tst.js:11:12:11:12 | m | tst.js:2:9:2:21 | function() {} |
+| tst.js:12:6:12:6 | m | tst.js:2:9:2:21 | function() {} |
+| tst.js:12:6:12:27 | n | tst.js:2:9:2:21 | function() {} |
 | tst.js:12:6:12:27 | n | tst.js:12:15:12:27 | function() {} |
+| tst.js:12:10:12:10 | m | tst.js:2:9:2:21 | function() {} |
+| tst.js:12:10:12:10 | m | tst.js:2:9:2:21 | function() {} |
+| tst.js:12:10:12:10 | m | tst.js:2:9:2:21 | function() {} |
+| tst.js:12:10:12:27 | m \|\| function() {} | tst.js:2:9:2:21 | function() {} |
 | tst.js:12:10:12:27 | m \|\| function() {} | tst.js:12:15:12:27 | function() {} |
 | tst.js:12:15:12:27 | function() {} | tst.js:12:15:12:27 | function() {} |
 | tst.js:13:2:13:16 | function p() {} | tst.js:13:2:13:16 | function p() {} |
 | tst.js:13:11:13:11 | p | tst.js:13:2:13:16 | function p() {} |
+| tst.js:14:2:14:2 | m | tst.js:2:9:2:21 | function() {} |
 | tst.js:15:2:15:2 | l | tst.js:11:1:20:1 | functio ... \\tf();\\n} |
 | tst.js:16:2:16:17 | arguments.callee | tst.js:11:1:20:1 | functio ... \\tf();\\n} |
+| tst.js:17:2:17:2 | n | tst.js:2:9:2:21 | function() {} |
 | tst.js:17:2:17:2 | n | tst.js:12:15:12:27 | function() {} |
 | tst.js:18:2:18:2 | p | tst.js:13:2:13:16 | function p() {} |
 | tst.js:19:2:19:2 | f | tst.js:1:1:1:15 | function f() {} |
@@ -463,8 +474,10 @@ test_getACallee
 | tst.js:7:1:7:3 | g() | tst.js:2:9:2:21 | function() {} |
 | tst.js:8:1:8:3 | h() | tst.js:3:5:3:17 | function() {} |
 | tst.js:9:1:9:3 | k() | tst.js:2:9:2:21 | function() {} |
+| tst.js:14:2:14:4 | m() | tst.js:2:9:2:21 | function() {} |
 | tst.js:15:2:15:4 | l() | tst.js:11:1:20:1 | functio ... \\tf();\\n} |
 | tst.js:16:2:16:19 | arguments.callee() | tst.js:11:1:20:1 | functio ... \\tf();\\n} |
+| tst.js:17:2:17:4 | n() | tst.js:2:9:2:21 | function() {} |
 | tst.js:17:2:17:4 | n() | tst.js:12:15:12:27 | function() {} |
 | tst.js:18:2:18:4 | p() | tst.js:13:2:13:16 | function p() {} |
 | tst.js:19:2:19:4 | f() | tst.js:1:1:1:15 | function f() {} |


### PR DESCRIPTION
Does two things:
- Loosens the restriction for when to track objects with methods. Previously the object had to be an allocation site, now it can be any `SourceNode` other than `this` inside a constructor (functions stored on that are instead seen as instance methods).
- Improves detection of function-style classes, by looking for functions that are invoked with `new`.

The tracking of objects affects the call graph directly, and also contributes to the `impliedReceiverStep`, which causes the host object to flow into `this` in the body of method:
```js
bar().foo = function() { 
  this; // <- value of bar() now flows here
}
```

[Evaluation](https://github.com/github/codeql-dca-main/issues/19658) shows neutral performance and about 24k new call edges and a few new alerts. The alerts I've looked at are due new TP call edges.