### PR TITLE
Java: Explicitly import Lock class

### DIFF
--- a/java/ql/test/ext/TopJdkApis/TopJdkApisTest.java
+++ b/java/ql/test/ext/TopJdkApis/TopJdkApisTest.java
@@ -37,6 +37,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;


### PR DESCRIPTION
As of the JDK22 extractor update, this will no longer be implicitly imported by other classes referenced in this file.