### PR TITLE
Python: Add example of missing use-use flow

### DIFF
--- a/python/ql/test/library-tests/essa/ssa-compute/test2.py
+++ b/python/ql/test/library-tests/essa/ssa-compute/test2.py
@@ -1,0 +1,29 @@
+def func(x): # $ def=x
+    try:
+        with Thing() as y: # $ def=y
+            y.foo(x, 0) # $ def-use=x:1 def-use=y:3
+            while not x.attribute: # $ use-use=x:4 use-use=x:7
+                y.bar() # $ use-use=y:4 use-use=y:6
+                print(x) # $ use-use=x:5
+    finally:
+        pass
+
+def func(x): # $ def=x
+    try:
+        with Thing() as y: # $ def=y
+            y.foo(x, some_var) # $ def-use=x:11 def-use=y:13
+            while not x.attribute: # $ use-use=x:14 use-use=x:17
+                y.bar() # $ use-use=y:16 MISSING: use-use=y:14
+                print(x) # $ use-use=x:15
+    finally:
+        pass
+
+def func(x): # $ def=x
+    try:
+        with Thing() as y: # $ def=y
+            y.foo(x, some_var.some_attr) # $ def-use=x:21 def-use=y:23
+            while not x.attribute: # $ use-use=x:27 MISSING: use-use=x:24
+                y.bar() # $ use-use=y:26 MISSING: use-use=y:24
+                print(x) # $ use-use=x:25
+    finally:
+        pass


### PR DESCRIPTION
Here is an interesting example where we lose use-use flow. I could not minimize the example any further, that is: removing the try-finally blocks made things work again, and converting `while -> if` made things work as well.

```py
def func(x):
    try:
        with Thing as y:
            y.foo(x, some_var.some_attr)
            while not x.attribute: # <-- missing flow to x
                y.bar() # <-- missing flow to y
                print(x)
    finally:
        pass
```

I noticed that by change `some_var.some_attr` to `0` the problem would also go away, and by changing to `some_var` we would only have missing flow for `y` but have proper flow for `x`...

I did spend some time looking into a fix in the SsaCompute.qll file, but did not reach a conclusion. While it shares some aspects with https://github.com/github/codeql/pull/10970 and https://github.com/github/codeql/pull/10998, it's also not entirely the same.

# Basic Blocks

One of my observations was that the basic blocks change when changing the argument, for the simple case where everything works:

1.
    <pre>
    def func(<b>x):
        try:
            with Thing</b>() as y:
                y.foo(x, 0)
                while not x.attribute:
                    y.bar()
                    print(x)
        finally:
            pass
    </pre>
2.
    <pre>
    def func(x):
        try:
            with <b>Thing()</b> as y:
                y.foo(x, 0)
                while not x.attribute:
                    y.bar()
                    print(x)
        finally:
            pass
    </pre>
3.
    <pre>
    def func(x):
        try:
            <b>with Thing() as y:
                y.foo</b>(x, 0)
                while not x.attribute:
                    y.bar()
                    print(x)
        finally:
            pass
    </pre>
4.
    <pre>
    def func(x):
        try:
            with Thing() as y:
                y.foo(<b>x, 0)</b>
                while not x.attribute:
                    y.bar()
                    print(x)
        finally:
            pass
    </pre>
5.
    <pre>
    def func(x):
        try:
            with Thing() as y:
                y.foo(x, 0)
                <b>while not x.attribute</b>:
                    y.bar()
                    print(x)
        finally:
            pass
    </pre>
1. ... (and so on) ...

...

## Variant `some_var`

The interesting bit is that if we do

```diff
-            y.foo(x, 0)
+            y.foo(x, some_var)
```

we get a new basic-block (for the whole line for the y.foo call)

4.
    <pre>
    def func(x):
        try:
            with Thing() as y:
                y.foo(<b>x, some_var</b>)
                while not x.attribute:
                    y.bar()
                    print(x)
        finally:
            pass
    </pre>
5.
    <pre>
    def func(x):
        try:
            with Thing() as y:
                <b>y.foo(x, some_var)</b>
                while not x.attribute:
                    y.bar()
                    print(x)
        finally:
            pass
    </pre>
6.
    <pre>
    def func(x):
        try:
            with Thing() as y:
                y.foo(x, some_var)
                <b>while not x.attribute</b>:
                    y.bar()
                    print(x)
        finally:
            pass
    </pre>
7. ...

AND we lose the use-use edge from `y.foo -> y.bar`

## Variant `some_var.some_attr`

and if we do


```diff
-            y.foo(x, some_var)
+            y.foo(x, some_var.some_attr)
```

we get another basic-block for the attribute lookup

4.
    <pre>
    def func(x):
        try:
            with Thing() as y:
                y.foo(<b>x, some_var</b>.some_attr)
                while not x.attribute:
                    y.bar()
                    print(x)
        finally:
            pass
    </pre>
5.
    <pre>
    def func(x):
        try:
            with Thing() as y:
                y.foo(x, <b>some_var.some_attr</b>)
                while not x.attribute:
                    y.bar()
                    print(x)
        finally:
            pass
    </pre>
6.
    <pre>
    def func(x):
        try:
            with Thing() as y:
                <b>y.foo(x, some_var.some_attr)</b>
                while not x.attribute:
                    y.bar()
                    print(x)
        finally:
            pass
    </pre>
7.
    <pre>
    def func(x):
        try:
            with Thing() as y:
                y.foo(x, some_var.some_attr)
                <b>while not x.attribute</b>:
                    y.bar()
                    print(x)
        finally:
            pass
    </pre>
8. ...

we also lose the use-use edge from `x` (in y.foo call) to `x.attribute`

### Idea

From doing quick-eval of the predicates in SsaCompute, I can see that we make the wrong conclusion around liveness.

I don't understand why we end up with a new basic-block for variant `some_var`, so if we ever want to get to the bottom of this (and we might simply start using shared SSA instead), figuring out why we get this new basic-bock would be a good next step.
