### PR TITLE
csharp update MaD for HttpRequestMessage

### DIFF
--- a/csharp/ql/lib/change-notes/2024-03-07-update-system.net.http.httprequestmessage-models.md
+++ b/csharp/ql/lib/change-notes/2024-03-07-update-system.net.http.httprequestmessage-models.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The models for `System.Net.Http.HttpRequestMessage` have been modified to better model the flow of tainted URIs.

--- a/csharp/ql/lib/ext/System.Net.Http.model.yml
+++ b/csharp/ql/lib/ext/System.Net.Http.model.yml
@@ -8,6 +8,8 @@ extensions:
       pack: codeql/csharp-all
       extensible: summaryModel
     data:
+      - ["System.Net.Http", "HttpRequestMessage", False, "HttpRequestMessage", "(System.Net.Http.HttpMethod,System.String)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
+      - ["System.Net.Http", "HttpRequestMessage", False, "HttpRequestMessage", "(System.Net.Http.HttpMethod,System.String)", "", "Argument[1]", "Argument[this]", "taint", "manual"]
       - ["System.Net.Http", "HttpRequestOptions", False, "Add", "(System.Collections.Generic.KeyValuePair<System.String,System.Object>)", "", "Argument[0].Property[System.Collections.Generic.KeyValuePair`2.Key]", "Argument[this].Element.Property[System.Collections.Generic.KeyValuePair`2.Key]", "value", "manual"]
       - ["System.Net.Http", "HttpRequestOptions", False, "Add", "(System.Collections.Generic.KeyValuePair<System.String,System.Object>)", "", "Argument[0].Property[System.Collections.Generic.KeyValuePair`2.Value]", "Argument[this].Element.Property[System.Collections.Generic.KeyValuePair`2.Value]", "value", "manual"]
       - ["System.Net.Http", "MultipartContent", False, "Add", "(System.Net.Http.HttpContent)", "", "Argument[0]", "Argument[this].Element", "value", "manual"]

--- a/csharp/ql/test/library-tests/dataflow/library/FlowSummariesFiltered.expected
+++ b/csharp/ql/test/library-tests/dataflow/library/FlowSummariesFiltered.expected
@@ -9414,6 +9414,8 @@ summary
 | System.Net.Http;HttpMethod;false;HttpMethod;(System.String);;Argument[0];Argument[this];taint;df-generated |
 | System.Net.Http;HttpMethod;false;ToString;();;Argument[this];ReturnValue;taint;df-generated |
 | System.Net.Http;HttpMethod;false;get_Method;();;Argument[this];ReturnValue;taint;df-generated |
+| System.Net.Http;HttpRequestMessage;false;HttpRequestMessage;(System.Net.Http.HttpMethod,System.String);;Argument[0];Argument[this];taint;manual |
+| System.Net.Http;HttpRequestMessage;false;HttpRequestMessage;(System.Net.Http.HttpMethod,System.String);;Argument[1];Argument[this];taint;manual |
 | System.Net.Http;HttpRequestMessage;false;HttpRequestMessage;(System.Net.Http.HttpMethod,System.Uri);;Argument[0];Argument[this];taint;df-generated |
 | System.Net.Http;HttpRequestMessage;false;HttpRequestMessage;(System.Net.Http.HttpMethod,System.Uri);;Argument[1];Argument[this];taint;df-generated |
 | System.Net.Http;HttpRequestMessage;false;ToString;();;Argument[this];ReturnValue;taint;df-generated |


### PR DESCRIPTION
There is an autogenerated MaD for System.Net.Http.HttpRequestMessage constructor where `Uri` class is one of the parameters. However, it's missing the overloaded constructor where the parameter is a string URL.
- https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httprequestmessage.-ctor?view=net-8.0

Both versions of the constructor can have taint flow, such as for SSRF. This PR adds the missing MaD for the overloaded constructor.