### PR TITLE
Data flow: Replace `hasLocationInfo` with `getLocation`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/DataFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/DataFlow.qll
@@ -28,6 +28,6 @@ import cpp
 deprecated module DataFlow {
   private import semmle.code.cpp.dataflow.internal.DataFlowImplSpecific
   private import codeql.dataflow.DataFlow
-  import DataFlowMake<CppOldDataFlow>
+  import DataFlowMake<Location, CppOldDataFlow>
   import semmle.code.cpp.dataflow.internal.DataFlowImpl1
 }

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/TaintTracking.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/TaintTracking.qll
@@ -29,6 +29,6 @@ deprecated module TaintTracking {
   private import semmle.code.cpp.dataflow.internal.DataFlowImplSpecific
   private import semmle.code.cpp.dataflow.internal.TaintTrackingImplSpecific
   private import codeql.dataflow.TaintTracking
-  import TaintFlowMake<CppOldDataFlow, CppOldTaintTracking>
+  import TaintFlowMake<Location, CppOldDataFlow, CppOldTaintTracking>
   import semmle.code.cpp.dataflow.internal.tainttracking1.TaintTrackingImpl
 }

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -2,6 +2,7 @@
  * DEPRECATED: Use `semmle.code.cpp.dataflow.new.DataFlow` instead.
  */
 
+private import semmle.code.cpp.Location
 private import DataFlowImplSpecific
 private import codeql.dataflow.internal.DataFlowImpl
-import MakeImpl<CppOldDataFlow>
+import MakeImpl<Location, CppOldDataFlow>

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
@@ -2,6 +2,7 @@
  * DEPRECATED: Use `semmle.code.cpp.dataflow.new.DataFlow` instead.
  */
 
+private import semmle.code.cpp.Location
 private import DataFlowImplSpecific
 private import codeql.dataflow.internal.DataFlowImplCommon
-import MakeImplCommon<CppOldDataFlow>
+import MakeImplCommon<Location, CppOldDataFlow>

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplConsistency.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplConsistency.qll
@@ -10,7 +10,7 @@ private import DataFlowImplSpecific
 private import TaintTrackingImplSpecific
 private import codeql.dataflow.internal.DataFlowImplConsistency
 
-private module Input implements InputSig<CppOldDataFlow> {
+private module Input implements InputSig<Location, CppOldDataFlow> {
   predicate argHasPostUpdateExclude(Private::ArgumentNode n) {
     // Is the null pointer (or something that's not really a pointer)
     exists(n.asExpr().getValue())
@@ -26,4 +26,4 @@ private module Input implements InputSig<CppOldDataFlow> {
   }
 }
 
-module Consistency = MakeConsistency<CppOldDataFlow, CppOldTaintTracking, Input>;
+module Consistency = MakeConsistency<Location, CppOldDataFlow, CppOldTaintTracking, Input>;

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplSpecific.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplSpecific.qll
@@ -4,6 +4,7 @@
  * Provides C++-specific definitions for use in the data flow library.
  */
 
+private import semmle.code.cpp.Location
 private import codeql.dataflow.DataFlow
 
 module Private {
@@ -15,7 +16,7 @@ module Public {
   import DataFlowUtil
 }
 
-module CppOldDataFlow implements InputSig {
+module CppOldDataFlow implements InputSig<Location> {
   import Private
   import Public
 

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
@@ -105,7 +105,7 @@ class Node extends TNode {
    * For more information, see
    * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
    */
-  predicate hasLocationInfo(
+  deprecated predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
     this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/TaintTrackingImplSpecific.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/TaintTrackingImplSpecific.qll
@@ -4,9 +4,10 @@
  * Provides C++-specific definitions for use in the taint tracking library.
  */
 
+private import semmle.code.cpp.Location
 private import codeql.dataflow.TaintTracking
 private import DataFlowImplSpecific
 
-module CppOldTaintTracking implements InputSig<CppOldDataFlow> {
+module CppOldTaintTracking implements InputSig<Location, CppOldDataFlow> {
   import TaintTrackingUtil
 }

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/new/DataFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/new/DataFlow.qll
@@ -28,6 +28,6 @@ import cpp
 module DataFlow {
   private import semmle.code.cpp.ir.dataflow.internal.DataFlowImplSpecific
   private import codeql.dataflow.DataFlow
-  import DataFlowMake<CppDataFlow>
+  import DataFlowMake<Location, CppDataFlow>
   import semmle.code.cpp.ir.dataflow.internal.DataFlowImpl1
 }

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/new/TaintTracking.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/new/TaintTracking.qll
@@ -27,6 +27,7 @@ module TaintTracking {
   private import semmle.code.cpp.ir.dataflow.internal.DataFlowImplSpecific
   private import semmle.code.cpp.ir.dataflow.internal.TaintTrackingImplSpecific
   private import codeql.dataflow.TaintTracking
-  import TaintFlowMake<CppDataFlow, CppTaintTracking>
+  private import semmle.code.cpp.Location
+  import TaintFlowMake<Location, CppDataFlow, CppTaintTracking>
   import semmle.code.cpp.ir.dataflow.internal.tainttracking1.TaintTrackingImpl
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/DataFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/DataFlow.qll
@@ -24,6 +24,6 @@ import cpp
 module DataFlow {
   private import semmle.code.cpp.ir.dataflow.internal.DataFlowImplSpecific
   private import codeql.dataflow.DataFlow
-  import DataFlowMake<CppDataFlow>
+  import DataFlowMake<Location, CppDataFlow>
   import semmle.code.cpp.ir.dataflow.internal.DataFlowImpl1
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/TaintTracking.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/TaintTracking.qll
@@ -23,6 +23,6 @@ module TaintTracking {
   private import semmle.code.cpp.ir.dataflow.internal.DataFlowImplSpecific
   private import semmle.code.cpp.ir.dataflow.internal.TaintTrackingImplSpecific
   private import codeql.dataflow.TaintTracking
-  import TaintFlowMake<CppDataFlow, CppTaintTracking>
+  import TaintFlowMake<Location, CppDataFlow, CppTaintTracking>
   import semmle.code.cpp.ir.dataflow.internal.tainttracking1.TaintTrackingImpl
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -1,3 +1,4 @@
+private import semmle.code.cpp.Location
 private import DataFlowImplSpecific
 private import codeql.dataflow.internal.DataFlowImpl
-import MakeImpl<CppDataFlow>
+import MakeImpl<Location, CppDataFlow>

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
@@ -1,3 +1,4 @@
+private import semmle.code.cpp.Location
 private import DataFlowImplSpecific
 private import codeql.dataflow.internal.DataFlowImplCommon
-import MakeImplCommon<CppDataFlow>
+import MakeImplCommon<Location, CppDataFlow>

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImplConsistency.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImplConsistency.qll
@@ -8,7 +8,7 @@ private import DataFlowImplSpecific
 private import TaintTrackingImplSpecific
 private import codeql.dataflow.internal.DataFlowImplConsistency
 
-private module Input implements InputSig<CppDataFlow> {
+private module Input implements InputSig<Location, CppDataFlow> {
   predicate argHasPostUpdateExclude(Private::ArgumentNode n) {
     // The rules for whether an IR argument gets a post-update node are too
     // complex to model here.
@@ -16,4 +16,4 @@ private module Input implements InputSig<CppDataFlow> {
   }
 }
 
-module Consistency = MakeConsistency<CppDataFlow, CppTaintTracking, Input>;
+module Consistency = MakeConsistency<Location, CppDataFlow, CppTaintTracking, Input>;

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImplSpecific.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImplSpecific.qll
@@ -3,6 +3,7 @@
  */
 
 private import codeql.dataflow.DataFlow
+private import semmle.code.cpp.Location
 
 module Private {
   import DataFlowPrivate
@@ -13,7 +14,7 @@ module Public {
   import DataFlowUtil
 }
 
-module CppDataFlow implements InputSig {
+module CppDataFlow implements InputSig<Location> {
   import Private
   import Public
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -448,7 +448,7 @@ class Node extends TIRDataFlowNode {
    * For more information, see
    * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
    */
-  predicate hasLocationInfo(
+  deprecated predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
     this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/TaintTrackingImplSpecific.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/TaintTrackingImplSpecific.qll
@@ -4,7 +4,8 @@
 
 private import codeql.dataflow.TaintTracking
 private import DataFlowImplSpecific
+private import semmle.code.cpp.Location
 
-module CppTaintTracking implements InputSig<CppDataFlow> {
+module CppTaintTracking implements InputSig<Location, CppDataFlow> {
   import TaintTrackingUtil
 }

--- a/csharp/ql/consistency-queries/DataFlowConsistency.ql
+++ b/csharp/ql/consistency-queries/DataFlowConsistency.ql
@@ -4,7 +4,7 @@ private import semmle.code.csharp.dataflow.internal.DataFlowImplSpecific
 private import semmle.code.csharp.dataflow.internal.TaintTrackingImplSpecific
 private import codeql.dataflow.internal.DataFlowImplConsistency
 
-private module Input implements InputSig<CsharpDataFlow> {
+private module Input implements InputSig<Location, CsharpDataFlow> {
   private import CsharpDataFlow
 
   private predicate isStaticAssignable(Assignable a) { a.(Modifiable).isStatic() }
@@ -99,4 +99,4 @@ private module Input implements InputSig<CsharpDataFlow> {
   }
 }
 
-import MakeConsistency<CsharpDataFlow, CsharpTaintTracking, Input>
+import MakeConsistency<Location, CsharpDataFlow, CsharpTaintTracking, Input>

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/DataFlow.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/DataFlow.qll
@@ -8,6 +8,6 @@ import csharp
 module DataFlow {
   private import semmle.code.csharp.dataflow.internal.DataFlowImplSpecific
   private import codeql.dataflow.DataFlow
-  import DataFlowMake<CsharpDataFlow>
+  import DataFlowMake<Location, CsharpDataFlow>
   import semmle.code.csharp.dataflow.internal.DataFlowImpl1
 }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/TaintTracking.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/TaintTracking.qll
@@ -10,6 +10,6 @@ module TaintTracking {
   private import semmle.code.csharp.dataflow.internal.DataFlowImplSpecific
   private import semmle.code.csharp.dataflow.internal.TaintTrackingImplSpecific
   private import codeql.dataflow.TaintTracking
-  import TaintFlowMake<CsharpDataFlow, CsharpTaintTracking>
+  import TaintFlowMake<Location, CsharpDataFlow, CsharpTaintTracking>
   import semmle.code.csharp.dataflow.internal.tainttracking1.TaintTrackingImpl
 }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -1,3 +1,4 @@
+private import semmle.code.csharp.Location
 private import DataFlowImplSpecific
 private import codeql.dataflow.internal.DataFlowImpl
-import MakeImpl<CsharpDataFlow>
+import MakeImpl<Location, CsharpDataFlow>

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
@@ -1,3 +1,4 @@
+private import semmle.code.csharp.Location
 private import DataFlowImplSpecific
 private import codeql.dataflow.internal.DataFlowImplCommon
-import MakeImplCommon<CsharpDataFlow>
+import MakeImplCommon<Location, CsharpDataFlow>

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplSpecific.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplSpecific.qll
@@ -2,6 +2,7 @@
  * Provides C#-specific definitions for use in the data flow library.
  */
 
+private import semmle.code.csharp.Location
 private import codeql.dataflow.DataFlow
 
 module Private {
@@ -13,7 +14,7 @@ module Public {
   import DataFlowPublic
 }
 
-module CsharpDataFlow implements InputSig {
+module CsharpDataFlow implements InputSig<Location> {
   import Private
   import Public
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPublic.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPublic.qll
@@ -58,7 +58,7 @@ class Node extends TNode {
    * For more information, see
    * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
    */
-  predicate hasLocationInfo(
+  deprecated predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
     this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
@@ -12,7 +12,7 @@ private import DataFlowImplSpecific::Public
 private import semmle.code.csharp.Unification
 private import semmle.code.csharp.dataflow.internal.ExternalFlow
 
-module Input implements InputSig<DataFlowImplSpecific::CsharpDataFlow> {
+module Input implements InputSig<Location, DataFlowImplSpecific::CsharpDataFlow> {
   class SummarizedCallableBase = UnboundCallable;
 
   ArgumentPosition callbackSelfParameterPosition() { result.isDelegateSelf() }
@@ -80,7 +80,7 @@ module Input implements InputSig<DataFlowImplSpecific::CsharpDataFlow> {
   }
 }
 
-private import Make<DataFlowImplSpecific::CsharpDataFlow, Input> as Impl
+private import Make<Location, DataFlowImplSpecific::CsharpDataFlow, Input> as Impl
 
 private module TypesInput implements Impl::Private::TypesInputSig {
   DataFlowType getSyntheticGlobalType(Impl::Private::SyntheticGlobal sg) {
@@ -154,7 +154,7 @@ private module StepsInput implements Impl::Private::StepsInputSig {
 }
 
 module SourceSinkInterpretationInput implements
-  Impl::Private::External::SourceSinkInterpretationInputSig<Location>
+  Impl::Private::External::SourceSinkInterpretationInputSig
 {
   private import csharp as Cs
 
@@ -252,7 +252,7 @@ module Private {
 
   module External {
     import Impl::Private::External
-    import Impl::Private::External::SourceSinkInterpretation<Location, SourceSinkInterpretationInput>
+    import Impl::Private::External::SourceSinkInterpretation<SourceSinkInterpretationInput>
   }
 
   private module SummaryComponentInternal = Impl::Private::SummaryComponent;

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/TaintTrackingImplSpecific.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/TaintTrackingImplSpecific.qll
@@ -2,9 +2,10 @@
  * Provides C#-specific definitions for use in the taint tracking library.
  */
 
+private import semmle.code.csharp.Location
 private import codeql.dataflow.TaintTracking
 private import DataFlowImplSpecific
 
-module CsharpTaintTracking implements InputSig<CsharpDataFlow> {
+module CsharpTaintTracking implements InputSig<Location, CsharpDataFlow> {
   import TaintTrackingPrivate
 }

--- a/csharp/ql/test/TestUtilities/InlineFlowTest.qll
+++ b/csharp/ql/test/TestUtilities/InlineFlowTest.qll
@@ -9,7 +9,7 @@ private import semmle.code.csharp.dataflow.internal.DataFlowImplSpecific
 private import semmle.code.csharp.dataflow.internal.TaintTrackingImplSpecific
 private import internal.InlineExpectationsTestImpl
 
-private module FlowTestImpl implements InputSig<CsharpDataFlow> {
+private module FlowTestImpl implements InputSig<Location, CsharpDataFlow> {
   predicate defaultSource(DataFlow::Node source) {
     source.asExpr().(MethodCall).getTarget().getUndecoratedName() = ["Source", "Taint"]
   }
@@ -35,4 +35,4 @@ private module FlowTestImpl implements InputSig<CsharpDataFlow> {
   }
 }
 
-import InlineFlowTestMake<CsharpDataFlow, CsharpTaintTracking, Impl, FlowTestImpl>
+import InlineFlowTestMake<Location, CsharpDataFlow, CsharpTaintTracking, Impl, FlowTestImpl>

--- a/go/ql/lib/semmle/go/DiagnosticsReporting.qll
+++ b/go/ql/lib/semmle/go/DiagnosticsReporting.qll
@@ -1,6 +1,7 @@
 /** Provides classes for working with errors and warnings recorded during extraction. */
 
 import go
+private import semmle.go.internal.Locations
 
 /** Gets the SARIF severity level that indicates an error. */
 private int getErrorSeverity() { result = 2 }
@@ -29,7 +30,7 @@ private class Diagnostic extends @diagnostic {
    * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
    */
   predicate hasLocationInfo(string path, int sl, int sc, int el, int ec) {
-    exists(Location l | diagnostics(this, _, _, _, _, l) | l.hasLocationInfo(path, sl, sc, el, ec))
+    getDiagnosticLocation(this).hasLocationInfo(path, sl, sc, el, ec)
   }
 
   string toString() { result = this.getMessage() }

--- a/go/ql/lib/semmle/go/Files.qll
+++ b/go/ql/lib/semmle/go/Files.qll
@@ -50,8 +50,6 @@ class Folder extends Container, Impl::Folder {
 class ExtractedOrExternalFile extends Container, Impl::File, Documentable, ExprParent,
   GoModExprParent, DeclParent, ScopeNode
 {
-  override Location getLocation() { has_location(this, result) }
-
   /** Gets the number of lines in this file. */
   int getNumberOfLines() { numlines(this, result, _, _) }
 

--- a/go/ql/lib/semmle/go/HTML.qll
+++ b/go/ql/lib/semmle/go/HTML.qll
@@ -15,8 +15,6 @@ module HTML {
   class Element extends Locatable, @xmlelement {
     Element() { exists(HtmlFile f | xmlElements(this, _, _, _, f)) }
 
-    override Location getLocation() { xmllocations(this, result) }
-
     /**
      * Gets the name of this HTML element.
      *
@@ -96,8 +94,6 @@ module HTML {
    */
   class Attribute extends Locatable, @xmlattribute {
     Attribute() { xmlAttrs(this, _, _, _, _, any(HtmlFile f)) }
-
-    override Location getLocation() { xmllocations(this, result) }
 
     /**
      * Gets the element to which this attribute belongs.
@@ -180,8 +176,6 @@ module HTML {
      * Holds if this text node is inside a `CDATA` tag.
      */
     predicate isCData() { xmlChars(this, _, _, _, 1, _) }
-
-    override Location getLocation() { xmllocations(this, result) }
   }
 
   /**
@@ -203,7 +197,5 @@ module HTML {
     string getText() { result = this.toString().regexpCapture("(?s)<!--(.*)-->", 1) }
 
     override string toString() { xmlComments(this, result, _, _) }
-
-    override Location getLocation() { xmllocations(this, result) }
   }
 }

--- a/go/ql/lib/semmle/go/Locations.qll
+++ b/go/ql/lib/semmle/go/Locations.qll
@@ -1,28 +1,31 @@
 /** Provides classes for working with locations and program elements that have locations. */
 
 import go
+private import internal.Locations
 
 /**
  * A location as given by a file, a start line, a start column,
  * an end line, and an end column.
  *
+ * This class is restricted to locations created by the extractor.
+ *
  * For more information about locations see [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
  */
-class Location extends @location {
+class DbLocation extends TDbLocation {
   /** Gets the file for this location. */
-  File getFile() { locations_default(this, result, _, _, _, _) }
+  File getFile() { dbLocationInfo(this, result, _, _, _, _) }
 
   /** Gets the 1-based line number (inclusive) where this location starts. */
-  int getStartLine() { locations_default(this, _, result, _, _, _) }
+  int getStartLine() { dbLocationInfo(this, _, result, _, _, _) }
 
   /** Gets the 1-based column number (inclusive) where this location starts. */
-  int getStartColumn() { locations_default(this, _, _, result, _, _) }
+  int getStartColumn() { dbLocationInfo(this, _, _, result, _, _) }
 
   /** Gets the 1-based line number (inclusive) where this location ends. */
-  int getEndLine() { locations_default(this, _, _, _, result, _) }
+  int getEndLine() { dbLocationInfo(this, _, _, _, result, _) }
 
   /** Gets the 1-based column number (inclusive) where this location ends. */
-  int getEndColumn() { locations_default(this, _, _, _, _, result) }
+  int getEndColumn() { dbLocationInfo(this, _, _, _, _, result) }
 
   /** Gets the number of lines covered by this location. */
   int getNumLines() { result = this.getEndLine() - this.getStartLine() + 1 }
@@ -46,11 +49,13 @@ class Location extends @location {
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
     exists(File f |
-      locations_default(this, f, startline, startcolumn, endline, endcolumn) and
+      dbLocationInfo(this, f, startline, startcolumn, endline, endcolumn) and
       filepath = f.getAbsolutePath()
     )
   }
 }
+
+final class Location = LocationImpl;
 
 /** A program element with a location. */
 class Locatable extends @locatable {
@@ -58,7 +63,7 @@ class Locatable extends @locatable {
   File getFile() { result = this.getLocation().getFile() }
 
   /** Gets this element's location. */
-  Location getLocation() { has_location(this, result) }
+  final DbLocation getLocation() { result = getLocatableLocation(this) }
 
   /** Gets the number of lines covered by this element. */
   int getNumLines() { result = this.getLocation().getNumLines() }

--- a/go/ql/lib/semmle/go/dataflow/DataFlow.qll
+++ b/go/ql/lib/semmle/go/dataflow/DataFlow.qll
@@ -24,7 +24,7 @@ import go
 module DataFlow {
   private import semmle.go.dataflow.internal.DataFlowImplSpecific
   private import codeql.dataflow.DataFlow
-  import DataFlowMake<GoDataFlow>
+  import DataFlowMake<Location, GoDataFlow>
   import semmle.go.dataflow.internal.DataFlowImpl1
   import Properties
 }

--- a/go/ql/lib/semmle/go/dataflow/TaintTracking.qll
+++ b/go/ql/lib/semmle/go/dataflow/TaintTracking.qll
@@ -13,7 +13,8 @@ module TaintTracking {
   import semmle.go.dataflow.internal.tainttracking1.TaintTrackingParameter::Public
   private import semmle.go.dataflow.internal.DataFlowImplSpecific
   private import semmle.go.dataflow.internal.TaintTrackingImplSpecific
+  private import semmle.go.Locations
   private import codeql.dataflow.TaintTracking
-  import TaintFlowMake<GoDataFlow, GoTaintTracking>
+  import TaintFlowMake<Location, GoDataFlow, GoTaintTracking>
   import semmle.go.dataflow.internal.tainttracking1.TaintTrackingImpl
 }

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl.qll
@@ -1,3 +1,4 @@
 private import DataFlowImplSpecific
 private import codeql.dataflow.internal.DataFlowImpl
-import MakeImpl<GoDataFlow>
+private import semmle.go.Locations
+import MakeImpl<Location, GoDataFlow>

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImplCommon.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImplCommon.qll
@@ -1,3 +1,4 @@
 private import DataFlowImplSpecific
 private import codeql.dataflow.internal.DataFlowImplCommon
-import MakeImplCommon<GoDataFlow>
+private import semmle.go.Locations
+import MakeImplCommon<Location, GoDataFlow>

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImplConsistency.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImplConsistency.qll
@@ -7,7 +7,8 @@ private import go
 private import DataFlowImplSpecific
 private import TaintTrackingImplSpecific
 private import codeql.dataflow.internal.DataFlowImplConsistency
+private import semmle.go.dataflow.internal.DataFlowNodes
 
-private module Input implements InputSig<GoDataFlow> { }
+private module Input implements InputSig<Location, GoDataFlow> { }
 
-module Consistency = MakeConsistency<GoDataFlow, GoTaintTracking, Input>;
+module Consistency = MakeConsistency<Location, GoDataFlow, GoTaintTracking, Input>;

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImplSpecific.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImplSpecific.qll
@@ -3,6 +3,7 @@
  */
 
 private import codeql.dataflow.DataFlow
+private import semmle.go.Locations
 
 module Private {
   import DataFlowPrivate
@@ -13,7 +14,7 @@ module Public {
   import DataFlowUtil
 }
 
-module GoDataFlow implements InputSig {
+module GoDataFlow implements InputSig<Location> {
   import Private
   import Public
 

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowNodes.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowNodes.qll
@@ -157,6 +157,14 @@ module Public {
       endcolumn = 0
     }
 
+    /** Gets the location of this node. */
+    Location getLocation() {
+      exists(string filepath, int startline, int startcolumn, int endline, int endcolumn |
+        this.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn) and
+        result.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+      )
+    }
+
     /** Gets the file in which this node appears. */
     File getFile() { this.hasLocationInfo(result.getAbsolutePath(), _, _, _, _) }
 

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowPrivate.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowPrivate.qll
@@ -251,8 +251,6 @@ class DataFlowType extends TDataFlowType {
   string toString() { result = "" }
 }
 
-class DataFlowLocation = Location;
-
 private newtype TDataFlowCallable =
   TCallable(Callable c) or
   TFileScope(File f) or

--- a/go/ql/lib/semmle/go/dataflow/internal/FlowSummaryImpl.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/FlowSummaryImpl.qll
@@ -15,7 +15,7 @@ private module FlowSummaries {
   private import semmle.go.dataflow.FlowSummary as F
 }
 
-module Input implements InputSig<DataFlowImplSpecific::GoDataFlow> {
+module Input implements InputSig<Location, DataFlowImplSpecific::GoDataFlow> {
   class SummarizedCallableBase = Callable;
 
   ArgumentPosition callbackSelfParameterPosition() { result = -1 }
@@ -83,7 +83,7 @@ module Input implements InputSig<DataFlowImplSpecific::GoDataFlow> {
   }
 }
 
-private import Make<DataFlowImplSpecific::GoDataFlow, Input> as Impl
+private import Make<Location, DataFlowImplSpecific::GoDataFlow, Input> as Impl
 
 private module StepsInput implements Impl::Private::StepsInputSig {
   DataFlowCall getACall(Public::SummarizedCallable sc) {
@@ -95,7 +95,7 @@ private module StepsInput implements Impl::Private::StepsInputSig {
 }
 
 module SourceSinkInterpretationInput implements
-  Impl::Private::External::SourceSinkInterpretationInputSig<Location>
+  Impl::Private::External::SourceSinkInterpretationInputSig
 {
   class Element = SourceOrSinkElement;
 
@@ -264,7 +264,7 @@ module Private {
 
   module External {
     import Impl::Private::External
-    import Impl::Private::External::SourceSinkInterpretation<Location, SourceSinkInterpretationInput>
+    import Impl::Private::External::SourceSinkInterpretation<SourceSinkInterpretationInput>
   }
 
   /**

--- a/go/ql/lib/semmle/go/dataflow/internal/TaintTrackingImplSpecific.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/TaintTrackingImplSpecific.qll
@@ -4,7 +4,8 @@
 
 private import codeql.dataflow.TaintTracking
 private import DataFlowImplSpecific
+private import semmle.go.Locations
 
-module GoTaintTracking implements InputSig<GoDataFlow> {
+module GoTaintTracking implements InputSig<Location, GoDataFlow> {
   import TaintTrackingUtil
 }

--- a/go/ql/lib/semmle/go/internal/Locations.qll
+++ b/go/ql/lib/semmle/go/internal/Locations.qll
@@ -1,0 +1,143 @@
+/** Provides classes for working with locations and program elements that have locations. */
+
+import go
+
+// Should _not_ be cached, as that would require the data flow stage to be evaluated
+// in order to evaluate the AST stage. Ideally, we would cache each injector separately,
+// but that's not possible. Instead, we cache all predicates that need the injectors
+// to be tuple numbered.
+newtype TLocation =
+  TDbLocation(@location loc) or
+  TSynthLocation(string filepath, int startline, int startcolumn, int endline, int endcolumn) {
+    any(DataFlow::Node n).hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn) and
+    // avoid overlap with existing DB locations
+    not exists(File f |
+      locations_default(_, f, startline, startcolumn, endline, endcolumn) and
+      f.getAbsolutePath() = filepath
+    )
+  }
+
+/**
+ * A location as given by a file, a start line, a start column,
+ * an end line, and an end column.
+ *
+ * For more information about locations see [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
+ */
+abstract class LocationImpl extends TLocation {
+  /** Gets the file for this location. */
+  abstract File getFile();
+
+  /** Gets the 1-based line number (inclusive) where this location starts. */
+  abstract int getStartLine();
+
+  /** Gets the 1-based column number (inclusive) where this location starts. */
+  abstract int getStartColumn();
+
+  /** Gets the 1-based line number (inclusive) where this location ends. */
+  abstract int getEndLine();
+
+  /** Gets the 1-based column number (inclusive) where this location ends. */
+  abstract int getEndColumn();
+
+  /** Gets the number of lines covered by this location. */
+  int getNumLines() { result = this.getEndLine() - this.getStartLine() + 1 }
+
+  /** Gets a textual representation of this element. */
+  string toString() {
+    exists(string filepath, int startline, int startcolumn, int endline, int endcolumn |
+      this.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn) and
+      result = filepath + "@" + startline + ":" + startcolumn + ":" + endline + ":" + endcolumn
+    )
+  }
+
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
+   */
+  abstract predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  );
+}
+
+class DbLocationImpl extends LocationImpl instanceof DbLocation {
+  private @location loc;
+
+  DbLocationImpl() { this = TDbLocation(loc) }
+
+  override File getFile() { result = DbLocation.super.getFile() }
+
+  override int getStartLine() { result = DbLocation.super.getStartLine() }
+
+  override int getStartColumn() { result = DbLocation.super.getStartColumn() }
+
+  override int getEndLine() { result = DbLocation.super.getEndLine() }
+
+  override int getEndColumn() { result = DbLocation.super.getEndColumn() }
+
+  override predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    DbLocation.super.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+}
+
+class SynthLocationImpl extends LocationImpl, TSynthLocation {
+  override File getFile() { synthLocationInfo(this, result.getAbsolutePath(), _, _, _, _) }
+
+  override int getStartLine() { synthLocationInfo(this, _, result, _, _, _) }
+
+  override int getStartColumn() { synthLocationInfo(this, _, _, result, _, _) }
+
+  override int getEndLine() { synthLocationInfo(this, _, _, _, result, _) }
+
+  override int getEndColumn() { synthLocationInfo(this, _, _, _, _, result) }
+
+  override predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    synthLocationInfo(this, filepath, startline, startcolumn, endline, endcolumn)
+  }
+}
+
+cached
+private module Cached {
+  cached
+  DbLocation getLocatableLocation(@locatable l) {
+    exists(@location loc |
+      has_location(l, loc) or
+      xmllocations(l, loc)
+    |
+      result = TDbLocation(loc)
+    )
+  }
+
+  cached
+  DbLocation getDiagnosticLocation(@diagnostic d) {
+    exists(@location loc |
+      diagnostics(d, _, _, _, _, loc) and
+      result = TDbLocation(loc)
+    )
+  }
+
+  cached
+  predicate dbLocationInfo(
+    DbLocation l, File f, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    exists(@location loc |
+      l = TDbLocation(loc) and
+      locations_default(loc, f, startline, startcolumn, endline, endcolumn)
+    )
+  }
+}
+
+import Cached
+
+cached
+private predicate synthLocationInfo(
+  SynthLocationImpl l, string filepath, int startline, int startcolumn, int endline, int endcolumn
+) {
+  l = TSynthLocation(filepath, startline, startcolumn, endline, endcolumn)
+}

--- a/go/ql/src/Security/CWE-338/InsecureRandomness.ql
+++ b/go/ql/src/Security/CWE-338/InsecureRandomness.ql
@@ -25,7 +25,7 @@ where
       min(InsecureRandomness::Flow::PathNode sink2, int line |
         InsecureRandomness::Flow::flowPath(_, sink2) and
         sink2.getNode().getRoot() = sink.getNode().getRoot() and
-        sink2.hasLocationInfo(_, line, _, _, _)
+        line = sink2.getLocation().getStartLine()
       |
         sink2 order by line
       )

--- a/go/ql/test/TestUtilities/InlineFlowTest.qll
+++ b/go/ql/test/TestUtilities/InlineFlowTest.qll
@@ -9,7 +9,7 @@ private import semmle.go.dataflow.internal.DataFlowImplSpecific
 private import semmle.go.dataflow.internal.TaintTrackingImplSpecific
 private import internal.InlineExpectationsTestImpl
 
-private module FlowTestImpl implements InputSig<GoDataFlow> {
+private module FlowTestImpl implements InputSig<Location, GoDataFlow> {
   predicate defaultSource(DataFlow::Node source) {
     exists(Function fn | fn.hasQualifiedName(_, ["source", "taint"]) |
       source = fn.getACall().getResult()
@@ -26,4 +26,4 @@ private module FlowTestImpl implements InputSig<GoDataFlow> {
   }
 }
 
-import InlineFlowTestMake<GoDataFlow, GoTaintTracking, Impl, FlowTestImpl>
+import InlineFlowTestMake<Location, GoDataFlow, GoTaintTracking, Impl, FlowTestImpl>

--- a/go/ql/test/TestUtilities/internal/InlineExpectationsTestImpl.qll
+++ b/go/ql/test/TestUtilities/internal/InlineExpectationsTestImpl.qll
@@ -2,13 +2,18 @@ private import go as G
 private import codeql.util.test.InlineExpectationsTest
 
 module Impl implements InlineExpectationsTestSig {
+  final private class CommentFinal = G::Comment;
+
   /**
    * A class representing line comments in the Go style, including the
    * preceding comment marker (`//`).
    */
-  class ExpectationComment extends G::Comment {
+  class ExpectationComment extends CommentFinal {
     /** Returns the contents of the given comment, _without_ the preceding comment marker (`//`). */
     string getContents() { result = this.getText() }
+
+    /** Gets this element's location. */
+    G::Location getLocation() { result = super.getLocation() }
   }
 
   class Location = G::Location;

--- a/go/ql/test/extractor-tests/diagnostics/Diagnostics.ql
+++ b/go/ql/test/extractor-tests/diagnostics/Diagnostics.ql
@@ -1,4 +1,5 @@
 import go
+private import semmle.go.internal.Locations
 
 bindingset[path]
 string baseName(string path) { result = path.regexpCapture(".*(/|\\\\)([^/\\\\]+)(/|\\\\)?$", 2) }
@@ -30,7 +31,12 @@ class Diagnostic extends @diagnostic {
     diagnostic_for(this, c, fileNum, idx)
   }
 
-  Location getLocation() { diagnostics(this, _, _, _, _, result) }
+  DbLocation getLocation() {
+    exists(@location loc |
+      diagnostics(this, _, _, _, _, loc) and
+      result = TDbLocation(loc)
+    )
+  }
 
   // string getTag() {
   //   diagnostics(this, _, result, _, _, _)

--- a/java/ql/lib/semmle/code/java/dataflow/DataFlow.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/DataFlow.qll
@@ -8,6 +8,6 @@ import java
 module DataFlow {
   private import semmle.code.java.dataflow.internal.DataFlowImplSpecific
   private import codeql.dataflow.DataFlow
-  import DataFlowMake<JavaDataFlow>
+  import DataFlowMake<Location, JavaDataFlow>
   import semmle.code.java.dataflow.internal.DataFlowImpl1
 }

--- a/java/ql/lib/semmle/code/java/dataflow/TaintTracking.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/TaintTracking.qll
@@ -12,6 +12,6 @@ module TaintTracking {
   private import semmle.code.java.dataflow.internal.DataFlowImplSpecific
   private import semmle.code.java.dataflow.internal.TaintTrackingImplSpecific
   private import codeql.dataflow.TaintTracking
-  import TaintFlowMake<JavaDataFlow, JavaTaintTracking>
+  import TaintFlowMake<Location, JavaDataFlow, JavaTaintTracking>
   import semmle.code.java.dataflow.internal.tainttracking1.TaintTrackingImpl
 }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -1,3 +1,4 @@
 private import DataFlowImplSpecific
 private import codeql.dataflow.internal.DataFlowImpl
-import MakeImpl<JavaDataFlow>
+private import semmle.code.Location
+import MakeImpl<Location, JavaDataFlow>

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
@@ -1,3 +1,4 @@
 private import DataFlowImplSpecific
+private import semmle.code.Location
 private import codeql.dataflow.internal.DataFlowImplCommon
-import MakeImplCommon<JavaDataFlow>
+import MakeImplCommon<Location, JavaDataFlow>

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplConsistency.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplConsistency.qll
@@ -8,10 +8,10 @@ private import DataFlowImplSpecific
 private import TaintTrackingImplSpecific
 private import codeql.dataflow.internal.DataFlowImplConsistency
 
-private module Input implements InputSig<JavaDataFlow> {
+private module Input implements InputSig<Location, JavaDataFlow> {
   predicate argHasPostUpdateExclude(JavaDataFlow::ArgumentNode n) {
     n.getType() instanceof ImmutableType or n instanceof Public::ImplicitVarargsArray
   }
 }
 
-module Consistency = MakeConsistency<JavaDataFlow, JavaTaintTracking, Input>;
+module Consistency = MakeConsistency<Location, JavaDataFlow, JavaTaintTracking, Input>;

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplSpecific.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplSpecific.qll
@@ -2,6 +2,7 @@
  * Provides Java-specific definitions for use in the data flow library.
  */
 
+private import semmle.code.Location
 private import codeql.dataflow.DataFlow
 
 module Private {
@@ -13,7 +14,7 @@ module Public {
   import DataFlowUtil
 }
 
-module JavaDataFlow implements InputSig {
+module JavaDataFlow implements InputSig<Location> {
   import Private
   import Public
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowNodes.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowNodes.qll
@@ -163,7 +163,7 @@ module Public {
      * For more information, see
      * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
      */
-    predicate hasLocationInfo(
+    deprecated predicate hasLocationInfo(
       string filepath, int startline, int startcolumn, int endline, int endcolumn
     ) {
       this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)

--- a/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
@@ -26,7 +26,7 @@ private string positionToString(int pos) {
   if pos = -1 then result = "this" else result = pos.toString()
 }
 
-module Input implements InputSig<DataFlowImplSpecific::JavaDataFlow> {
+module Input implements InputSig<Location, DataFlowImplSpecific::JavaDataFlow> {
   class SummarizedCallableBase = FlowSummary::SummarizedCallableBase;
 
   ArgumentPosition callbackSelfParameterPosition() { result = -1 }
@@ -85,7 +85,7 @@ module Input implements InputSig<DataFlowImplSpecific::JavaDataFlow> {
   }
 }
 
-private import Make<DataFlowImplSpecific::JavaDataFlow, Input> as Impl
+private import Make<Location, DataFlowImplSpecific::JavaDataFlow, Input> as Impl
 
 private module TypesInput implements Impl::Private::TypesInputSig {
   DataFlowType getSyntheticGlobalType(Impl::Private::SyntheticGlobal sg) {
@@ -186,7 +186,7 @@ private predicate correspondingKotlinParameterDefaultsArgSpec(
 }
 
 module SourceSinkInterpretationInput implements
-  Impl::Private::External::SourceSinkInterpretationInputSig<Location>
+  Impl::Private::External::SourceSinkInterpretationInputSig
 {
   private import java as J
 
@@ -294,7 +294,7 @@ module Private {
 
   module External {
     import Impl::Private::External
-    import Impl::Private::External::SourceSinkInterpretation<Location, SourceSinkInterpretationInput>
+    import Impl::Private::External::SourceSinkInterpretation<SourceSinkInterpretationInput>
 
     /**
      * Holds if an external flow summary exists for `c` with input specification

--- a/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingImplSpecific.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingImplSpecific.qll
@@ -4,7 +4,8 @@
 
 private import codeql.dataflow.TaintTracking
 private import DataFlowImplSpecific
+private import semmle.code.Location
 
-module JavaTaintTracking implements InputSig<JavaDataFlow> {
+module JavaTaintTracking implements InputSig<Location, JavaDataFlow> {
   import TaintTrackingUtil
 }

--- a/java/ql/test-kotlin1/TestUtilities/InlineFlowTest.qll
+++ b/java/ql/test-kotlin1/TestUtilities/InlineFlowTest.qll
@@ -10,7 +10,7 @@ private import semmle.code.java.dataflow.internal.DataFlowImplSpecific
 private import semmle.code.java.dataflow.internal.TaintTrackingImplSpecific
 private import internal.InlineExpectationsTestImpl
 
-private module FlowTestImpl implements InputSig<JavaDataFlow> {
+private module FlowTestImpl implements InputSig<Location, JavaDataFlow> {
   predicate defaultSource(DataFlow::Node source) {
     source.asExpr().(MethodCall).getMethod().getName() = ["source", "taint"]
   }
@@ -30,4 +30,4 @@ private module FlowTestImpl implements InputSig<JavaDataFlow> {
   }
 }
 
-import InlineFlowTestMake<JavaDataFlow, JavaTaintTracking, Impl, FlowTestImpl>
+import InlineFlowTestMake<Location, JavaDataFlow, JavaTaintTracking, Impl, FlowTestImpl>

--- a/java/ql/test/TestUtilities/InlineFlowTest.qll
+++ b/java/ql/test/TestUtilities/InlineFlowTest.qll
@@ -10,7 +10,7 @@ private import semmle.code.java.dataflow.internal.DataFlowImplSpecific
 private import semmle.code.java.dataflow.internal.TaintTrackingImplSpecific
 private import internal.InlineExpectationsTestImpl
 
-private module FlowTestImpl implements InputSig<JavaDataFlow> {
+private module FlowTestImpl implements InputSig<Location, JavaDataFlow> {
   predicate defaultSource(DataFlow::Node source) {
     source.asExpr().(MethodCall).getMethod().getName() = ["source", "taint"]
   }
@@ -30,4 +30,4 @@ private module FlowTestImpl implements InputSig<JavaDataFlow> {
   }
 }
 
-import InlineFlowTestMake<JavaDataFlow, JavaTaintTracking, Impl, FlowTestImpl>
+import InlineFlowTestMake<Location, JavaDataFlow, JavaTaintTracking, Impl, FlowTestImpl>

--- a/python/ql/consistency-queries/DataFlowConsistency.ql
+++ b/python/ql/consistency-queries/DataFlowConsistency.ql
@@ -10,11 +10,15 @@ private import semmle.python.dataflow.new.internal.DataFlowDispatch
 private import semmle.python.dataflow.new.internal.TaintTrackingImplSpecific
 private import codeql.dataflow.internal.DataFlowImplConsistency
 
-private module Input implements InputSig<PythonDataFlow> {
+private module Input implements InputSig<Location, PythonDataFlow> {
   private import Private
   private import Public
 
   predicate postWithInFlowExclude(Node n) { n instanceof FlowSummaryNode }
+
+  predicate uniqueNodeLocationExclude(Node n) { n instanceof FlowSummaryNode }
+
+  predicate missingLocationExclude(Node n) { n instanceof FlowSummaryNode }
 
   predicate argHasPostUpdateExclude(ArgumentNode n) {
     // TODO: Implement post-updates for *args, see tests added in https://github.com/github/codeql/pull/14936
@@ -132,4 +136,4 @@ private module Input implements InputSig<PythonDataFlow> {
   }
 }
 
-import MakeConsistency<PythonDataFlow, PythonTaintTracking, Input>
+import MakeConsistency<Location, PythonDataFlow, PythonTaintTracking, Input>

--- a/python/ql/lib/semmle/python/ApiGraphs.qll
+++ b/python/ql/lib/semmle/python/ApiGraphs.qll
@@ -328,6 +328,9 @@ module API {
      */
     DataFlow::Node getInducingNode() { this = Impl::MkUse(result) or this = Impl::MkDef(result) }
 
+    /** Gets the location of this node */
+    PY::Location getLocation() { result = this.getInducingNode().getLocation() }
+
     /**
      * Holds if this element is at the specified location.
      * The location spans column `startcolumn` of line `startline` to
@@ -335,7 +338,7 @@ module API {
      * For more information, see
      * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
      */
-    predicate hasLocationInfo(
+    deprecated predicate hasLocationInfo(
       string filepath, int startline, int startcolumn, int endline, int endcolumn
     ) {
       this.getInducingNode().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)

--- a/python/ql/lib/semmle/python/dataflow/new/DataFlow.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/DataFlow.qll
@@ -24,6 +24,6 @@ private import python
 module DataFlow {
   private import internal.DataFlowImplSpecific
   private import codeql.dataflow.DataFlow
-  import DataFlowMake<PythonDataFlow>
+  import DataFlowMake<Location, PythonDataFlow>
   import internal.DataFlowImpl1
 }

--- a/python/ql/lib/semmle/python/dataflow/new/TaintTracking.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/TaintTracking.qll
@@ -19,6 +19,6 @@ module TaintTracking {
   private import semmle.python.dataflow.new.internal.DataFlowImplSpecific
   private import semmle.python.dataflow.new.internal.TaintTrackingImplSpecific
   private import codeql.dataflow.TaintTracking
-  import TaintFlowMake<PythonDataFlow, PythonTaintTracking>
+  import TaintFlowMake<Location, PythonDataFlow, PythonTaintTracking>
   import internal.tainttracking1.TaintTrackingImpl
 }

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowDispatch.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowDispatch.qll
@@ -1595,7 +1595,7 @@ class FlowSummaryNode extends Node, TFlowSummaryNode {
   override string toString() { result = this.getSummaryNode().toString() }
 
   // Hack to return "empty location"
-  override predicate hasLocationInfo(
+  deprecated override predicate hasLocationInfo(
     string file, int startline, int startcolumn, int endline, int endcolumn
   ) {
     file = "" and

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -1,3 +1,4 @@
 private import DataFlowImplSpecific
 private import codeql.dataflow.internal.DataFlowImpl
-import MakeImpl<PythonDataFlow>
+private import semmle.python.Files
+import MakeImpl<Location, PythonDataFlow>

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImplCommon.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImplCommon.qll
@@ -1,3 +1,4 @@
 private import DataFlowImplSpecific
 private import codeql.dataflow.internal.DataFlowImplCommon
-import MakeImplCommon<PythonDataFlow>
+private import semmle.python.Files
+import MakeImplCommon<Location, PythonDataFlow>

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImplSpecific.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImplSpecific.qll
@@ -15,7 +15,7 @@ module Public {
   import DataFlowUtil
 }
 
-module PythonDataFlow implements InputSig {
+module PythonDataFlow implements InputSig<Python::Location> {
   import Private
   import Public
 

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPublic.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPublic.qll
@@ -148,6 +148,7 @@ class Node extends TNode {
   DataFlowCallable getEnclosingCallable() { result = getCallableScope(this.getScope()) }
 
   /** Gets the location of this node */
+  cached
   Location getLocation() { none() }
 
   /**
@@ -157,8 +158,7 @@ class Node extends TNode {
    * For more information, see
    * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
    */
-  cached
-  predicate hasLocationInfo(
+  deprecated predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
     Stages::DataFlow::ref() and

--- a/python/ql/lib/semmle/python/dataflow/new/internal/FlowSummaryImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/FlowSummaryImpl.qll
@@ -9,7 +9,7 @@ private import DataFlowImplSpecific as DataFlowImplSpecific
 private import DataFlowImplSpecific::Private
 private import DataFlowImplSpecific::Public
 
-module Input implements InputSig<DataFlowImplSpecific::PythonDataFlow> {
+module Input implements InputSig<Location, DataFlowImplSpecific::PythonDataFlow> {
   class SummarizedCallableBase = string;
 
   ArgumentPosition callbackSelfParameterPosition() { result.isLambdaSelf() }
@@ -83,7 +83,7 @@ module Input implements InputSig<DataFlowImplSpecific::PythonDataFlow> {
   }
 }
 
-private import Make<DataFlowImplSpecific::PythonDataFlow, Input> as Impl
+private import Make<Location, DataFlowImplSpecific::PythonDataFlow, Input> as Impl
 
 private module StepsInput implements Impl::Private::StepsInputSig {
   DataFlowCall getACall(Public::SummarizedCallable sc) {

--- a/python/ql/lib/semmle/python/dataflow/new/internal/TaintTrackingImplSpecific.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/TaintTrackingImplSpecific.qll
@@ -4,7 +4,8 @@
 
 private import codeql.dataflow.TaintTracking
 private import DataFlowImplSpecific
+private import semmle.python.Files
 
-module PythonTaintTracking implements InputSig<PythonDataFlow> {
+module PythonTaintTracking implements InputSig<Location, PythonDataFlow> {
   import TaintTrackingPrivate
 }

--- a/python/ql/lib/semmle/python/internal/CachedStages.qll
+++ b/python/ql/lib/semmle/python/internal/CachedStages.qll
@@ -194,7 +194,7 @@ module Stages {
       or
       exists(any(DataFlowPublic::Node node).toString())
       or
-      any(DataFlowPublic::Node node).hasLocationInfo(_, _, _, _, _)
+      exists(any(DataFlowPublic::Node node).getLocation())
       or
       DataFlowDispatch::resolveCall(_, _, _)
       or

--- a/ruby/ql/consistency-queries/DataFlowConsistency.ql
+++ b/ruby/ql/consistency-queries/DataFlowConsistency.ql
@@ -5,7 +5,7 @@ private import codeql.ruby.dataflow.internal.DataFlowImplSpecific
 private import codeql.ruby.dataflow.internal.TaintTrackingImplSpecific
 private import codeql.dataflow.internal.DataFlowImplConsistency
 
-private module Input implements InputSig<RubyDataFlow> {
+private module Input implements InputSig<Location, RubyDataFlow> {
   private import RubyDataFlow
 
   predicate postWithInFlowExclude(Node n) { n instanceof FlowSummaryNode }
@@ -46,4 +46,4 @@ private module Input implements InputSig<RubyDataFlow> {
   }
 }
 
-import MakeConsistency<RubyDataFlow, RubyTaintTracking, Input>
+import MakeConsistency<Location, RubyDataFlow, RubyTaintTracking, Input>

--- a/ruby/ql/lib/codeql/ruby/DataFlow.qll
+++ b/ruby/ql/lib/codeql/ruby/DataFlow.qll
@@ -12,6 +12,6 @@ import codeql.Locations
 module DataFlow {
   private import codeql.ruby.dataflow.internal.DataFlowImplSpecific
   private import codeql.dataflow.DataFlow
-  import DataFlowMake<RubyDataFlow>
+  import DataFlowMake<Location, RubyDataFlow>
   import codeql.ruby.dataflow.internal.DataFlowImpl1
 }

--- a/ruby/ql/lib/codeql/ruby/TaintTracking.qll
+++ b/ruby/ql/lib/codeql/ruby/TaintTracking.qll
@@ -7,6 +7,7 @@ module TaintTracking {
   private import codeql.ruby.dataflow.internal.DataFlowImplSpecific
   private import codeql.ruby.dataflow.internal.TaintTrackingImplSpecific
   private import codeql.dataflow.TaintTracking
-  import TaintFlowMake<RubyDataFlow, RubyTaintTracking>
+  private import codeql.Locations
+  import TaintFlowMake<Location, RubyDataFlow, RubyTaintTracking>
   import codeql.ruby.dataflow.internal.tainttracking1.TaintTrackingImpl
 }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
@@ -1,3 +1,4 @@
+private import codeql.Locations
 private import DataFlowImplSpecific
 private import codeql.dataflow.internal.DataFlowImpl
-import MakeImpl<RubyDataFlow>
+import MakeImpl<Location, RubyDataFlow>

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplCommon.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplCommon.qll
@@ -1,3 +1,4 @@
+private import codeql.Locations
 private import DataFlowImplSpecific
 private import codeql.dataflow.internal.DataFlowImplCommon
-import MakeImplCommon<RubyDataFlow>
+import MakeImplCommon<Location, RubyDataFlow>

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplSpecific.qll
@@ -2,6 +2,7 @@
  * Provides Ruby-specific definitions for use in the data flow library.
  */
 
+private import codeql.Locations
 private import codeql.dataflow.DataFlow
 
 module Private {
@@ -13,7 +14,7 @@ module Public {
   import DataFlowPublic
 }
 
-module RubyDataFlow implements InputSig {
+module RubyDataFlow implements InputSig<Location> {
   import Private
   import Public
 

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
@@ -35,7 +35,7 @@ class Node extends TNode {
    * For more information, see
    * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
    */
-  predicate hasLocationInfo(
+  deprecated predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
     this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
@@ -9,7 +9,7 @@ private import codeql.ruby.dataflow.internal.DataFlowImplSpecific as DataFlowImp
 private import DataFlowImplSpecific::Private
 private import DataFlowImplSpecific::Public
 
-module Input implements InputSig<DataFlowImplSpecific::RubyDataFlow> {
+module Input implements InputSig<Location, DataFlowImplSpecific::RubyDataFlow> {
   class SummarizedCallableBase = string;
 
   ArgumentPosition callbackSelfParameterPosition() { result.isLambdaSelf() }
@@ -146,7 +146,7 @@ module Input implements InputSig<DataFlowImplSpecific::RubyDataFlow> {
   }
 }
 
-private import Make<DataFlowImplSpecific::RubyDataFlow, Input> as Impl
+private import Make<Location, DataFlowImplSpecific::RubyDataFlow, Input> as Impl
 
 private module StepsInput implements Impl::Private::StepsInputSig {
   DataFlowCall getACall(Public::SummarizedCallable sc) {

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/TaintTrackingImplSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/TaintTrackingImplSpecific.qll
@@ -2,9 +2,10 @@
  * Provides Ruby-specific definitions for use in the taint tracking library.
  */
 
+private import codeql.Locations
 private import codeql.dataflow.TaintTracking
 private import DataFlowImplSpecific
 
-module RubyTaintTracking implements InputSig<RubyDataFlow> {
+module RubyTaintTracking implements InputSig<Location, RubyDataFlow> {
   import TaintTrackingPrivate
 }

--- a/ruby/ql/test/TestUtilities/InlineFlowTest.qll
+++ b/ruby/ql/test/TestUtilities/InlineFlowTest.qll
@@ -4,12 +4,13 @@
  */
 
 import ruby
+private import codeql.Locations
 private import codeql.dataflow.test.InlineFlowTest
 private import codeql.ruby.dataflow.internal.DataFlowImplSpecific
 private import codeql.ruby.dataflow.internal.TaintTrackingImplSpecific
 private import internal.InlineExpectationsTestImpl
 
-private module FlowTestImpl implements InputSig<RubyDataFlow> {
+private module FlowTestImpl implements InputSig<Location, RubyDataFlow> {
   import TestUtilities.InlineFlowTestUtil
 
   bindingset[src, sink]
@@ -19,4 +20,4 @@ private module FlowTestImpl implements InputSig<RubyDataFlow> {
   }
 }
 
-import InlineFlowTestMake<RubyDataFlow, RubyTaintTracking, Impl, FlowTestImpl>
+import InlineFlowTestMake<Location, RubyDataFlow, RubyTaintTracking, Impl, FlowTestImpl>

--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -4,8 +4,10 @@
  * modules.
  */
 
+private import codeql.util.Location
+
 /** Provides language-specific data flow parameters. */
-signature module InputSig {
+signature module InputSig<LocationSig Location> {
   /**
    * A node in the data flow graph.
    */
@@ -13,16 +15,8 @@ signature module InputSig {
     /** Gets a textual representation of this element. */
     string toString();
 
-    /**
-     * Holds if this element is at the specified location.
-     * The location spans column `startcolumn` of line `startline` to
-     * column `endcolumn` of line `endline` in file `filepath`.
-     * For more information, see
-     * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
-     */
-    predicate hasLocationInfo(
-      string filepath, int startline, int startcolumn, int endline, int endcolumn
-    );
+    /** Gets the location of this node. */
+    Location getLocation();
   }
 
   class ParameterNode extends Node;
@@ -321,9 +315,9 @@ signature module InputSig {
   default predicate ignoreFieldFlowBranchLimit(DataFlowCallable c) { none() }
 }
 
-module Configs<InputSig Lang> {
+module Configs<LocationSig Location, InputSig<Location> Lang> {
   private import Lang
-  private import internal.DataFlowImplCommon::MakeImplCommon<Lang>
+  private import internal.DataFlowImplCommon::MakeImplCommon<Location, Lang>
   import DataFlowImplCommonPublic
 
   /** An input configuration for data flow. */
@@ -531,10 +525,10 @@ module Configs<InputSig Lang> {
   }
 }
 
-module DataFlowMake<InputSig Lang> {
+module DataFlowMake<LocationSig Location, InputSig<Location> Lang> {
   private import Lang
-  private import internal.DataFlowImpl::MakeImpl<Lang>
-  import Configs<Lang>
+  private import internal.DataFlowImpl::MakeImpl<Location, Lang>
+  import Configs<Location, Lang>
 
   /**
    * Gets the exploration limit for `partialFlow` and `partialFlowRev`
@@ -613,19 +607,11 @@ module DataFlowMake<InputSig Lang> {
     /** Gets a textual representation of this element. */
     string toString();
 
-    /**
-     * Holds if this element is at the specified location.
-     * The location spans column `startcolumn` of line `startline` to
-     * column `endcolumn` of line `endline` in file `filepath`.
-     * For more information, see
-     * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
-     */
-    predicate hasLocationInfo(
-      string filepath, int startline, int startcolumn, int endline, int endcolumn
-    );
-
     /** Gets the underlying `Node`. */
     Node getNode();
+
+    /** Gets the location of this node. */
+    Location getLocation();
   }
 
   signature module PathGraphSig<PathNodeSig PathNode> {
@@ -668,6 +654,15 @@ module DataFlowMake<InputSig Lang> {
         result = this.asPathNode2().toString()
       }
 
+      /** Gets the underlying `Node`. */
+      Node getNode() {
+        result = this.asPathNode1().getNode() or
+        result = this.asPathNode2().getNode()
+      }
+
+      /** Gets the location of this node. */
+      Location getLocation() { result = this.getNode().getLocation() }
+
       /**
        * Holds if this element is at the specified location.
        * The location spans column `startcolumn` of line `startline` to
@@ -675,17 +670,10 @@ module DataFlowMake<InputSig Lang> {
        * For more information, see
        * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
        */
-      predicate hasLocationInfo(
+      deprecated predicate hasLocationInfo(
         string filepath, int startline, int startcolumn, int endline, int endcolumn
       ) {
-        this.asPathNode1().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn) or
-        this.asPathNode2().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-      }
-
-      /** Gets the underlying `Node`. */
-      Node getNode() {
-        result = this.asPathNode1().getNode() or
-        result = this.asPathNode2().getNode()
+        this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
       }
     }
 
@@ -750,7 +738,7 @@ module DataFlowMake<InputSig Lang> {
        * For more information, see
        * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
        */
-      predicate hasLocationInfo(
+      deprecated predicate hasLocationInfo(
         string filepath, int startline, int startcolumn, int endline, int endcolumn
       ) {
         super.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
@@ -758,6 +746,9 @@ module DataFlowMake<InputSig Lang> {
 
       /** Gets the underlying `Node`. */
       Node getNode() { result = super.getNode() }
+
+      /** Gets the location of this node. */
+      Location getLocation() { result = super.getLocation() }
     }
 
     /**

--- a/shared/dataflow/codeql/dataflow/TaintTracking.qll
+++ b/shared/dataflow/codeql/dataflow/TaintTracking.qll
@@ -5,11 +5,12 @@
 
 private import DataFlow as DF
 private import internal.DataFlowImpl
+private import codeql.util.Location
 
 /**
  * Provides language-specific taint-tracking parameters.
  */
-signature module InputSig<DF::InputSig Lang> {
+signature module InputSig<LocationSig Location, DF::InputSig<Location> Lang> {
   /**
    * Holds if `node` should be a sanitizer in all global taint flow configurations
    * but not in local taint.
@@ -33,10 +34,13 @@ signature module InputSig<DF::InputSig Lang> {
 /**
  * Construct the modules for taint-tracking analyses.
  */
-module TaintFlowMake<DF::InputSig DataFlowLang, InputSig<DataFlowLang> TaintTrackingLang> {
+module TaintFlowMake<
+  LocationSig Location, DF::InputSig<Location> DataFlowLang,
+  InputSig<Location, DataFlowLang> TaintTrackingLang>
+{
   private import TaintTrackingLang
-  private import DF::DataFlowMake<DataFlowLang> as DataFlow
-  private import MakeImpl<DataFlowLang> as DataFlowInternal
+  private import DF::DataFlowMake<Location, DataFlowLang> as DataFlow
+  private import MakeImpl<Location, DataFlowLang> as DataFlowInternal
 
   private module AddTaintDefaults<DataFlowInternal::FullStateConfigSig Config> implements
     DataFlowInternal::FullStateConfigSig

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -7,12 +7,13 @@
 private import codeql.util.Unit
 private import codeql.util.Option
 private import codeql.util.Boolean
+private import codeql.util.Location
 private import codeql.dataflow.DataFlow
 
-module MakeImpl<InputSig Lang> {
+module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
   private import Lang
-  private import DataFlowMake<Lang>
-  private import DataFlowImplCommon::MakeImplCommon<Lang>
+  private import DataFlowMake<Location, Lang>
+  private import DataFlowImplCommon::MakeImplCommon<Location, Lang>
   private import DataFlowImplCommonPublic
 
   /**
@@ -192,11 +193,7 @@ module MakeImpl<InputSig Lang> {
         pragma[only_bind_out](this).getDataFlowType0() = pragma[only_bind_into](result)
       }
 
-      predicate hasLocationInfo(
-        string filepath, int startline, int startcolumn, int endline, int endcolumn
-      ) {
-        this.projectToNode().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-      }
+      Location getLocation() { result = this.projectToNode().getLocation() }
     }
 
     private class ArgNodeEx extends NodeEx {
@@ -3305,11 +3302,7 @@ module MakeImpl<InputSig Lang> {
 
       override string toString() { result = p + concat(" : " + ppReprType(t)) + " " + ap }
 
-      predicate hasLocationInfo(
-        string filepath, int startline, int startcolumn, int endline, int endcolumn
-      ) {
-        p.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-      }
+      Location getLocation() { result = p.getLocation() }
     }
 
     /**
@@ -3727,18 +3720,8 @@ module MakeImpl<InputSig Lang> {
             this.ppSummaryCtx()
       }
 
-      /**
-       * Holds if this element is at the specified location.
-       * The location spans column `startcolumn` of line `startline` to
-       * column `endcolumn` of line `endline` in file `filepath`.
-       * For more information, see
-       * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
-       */
-      predicate hasLocationInfo(
-        string filepath, int startline, int startcolumn, int endline, int endcolumn
-      ) {
-        this.getNodeEx().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-      }
+      /** Gets the location of this node. */
+      Location getLocation() { result = this.getNodeEx().getLocation() }
     }
 
     /** Holds if `n` can reach a sink. */
@@ -3774,6 +3757,9 @@ module MakeImpl<InputSig Lang> {
        */
       final string toStringWithContext() { result = super.toStringWithContext() }
 
+      /** Gets the location of this node. */
+      Location getLocation() { result = super.getLocation() }
+
       /**
        * Holds if this element is at the specified location.
        * The location spans column `startcolumn` of line `startline` to
@@ -3781,10 +3767,11 @@ module MakeImpl<InputSig Lang> {
        * For more information, see
        * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
        */
-      final predicate hasLocationInfo(
+      pragma[inline]
+      deprecated final predicate hasLocationInfo(
         string filepath, int startline, int startcolumn, int endline, int endcolumn
       ) {
-        super.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+        this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
       }
 
       /** Gets the underlying `Node`. */
@@ -3945,12 +3932,6 @@ module MakeImpl<InputSig Lang> {
       override predicate isSource() { none() }
 
       override string toString() { result = sourceGroup }
-
-      override predicate hasLocationInfo(
-        string filepath, int startline, int startcolumn, int endline, int endcolumn
-      ) {
-        filepath = "" and startline = 0 and startcolumn = 0 and endline = 0 and endcolumn = 0
-      }
     }
 
     private class PathNodeSinkGroup extends PathNodeImpl, TPathNodeSinkGroup {
@@ -3967,12 +3948,6 @@ module MakeImpl<InputSig Lang> {
       override predicate isSource() { none() }
 
       override string toString() { result = sinkGroup }
-
-      override predicate hasLocationInfo(
-        string filepath, int startline, int startcolumn, int endline, int endcolumn
-      ) {
-        filepath = "" and startline = 0 and startcolumn = 0 and endline = 0 and endcolumn = 0
-      }
     }
 
     private predicate pathNode(
@@ -4801,6 +4776,9 @@ module MakeImpl<InputSig Lang> {
             result = this.getNodeEx().toString() + this.ppType() + this.ppAp() + this.ppCtx()
           }
 
+          /** Gets the location of this node. */
+          Location getLocation() { result = this.getNodeEx().getLocation() }
+
           /**
            * Holds if this element is at the specified location.
            * The location spans column `startcolumn` of line `startline` to
@@ -4808,10 +4786,11 @@ module MakeImpl<InputSig Lang> {
            * For more information, see
            * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
            */
-          predicate hasLocationInfo(
+          pragma[inline]
+          deprecated predicate hasLocationInfo(
             string filepath, int startline, int startcolumn, int endline, int endcolumn
           ) {
-            this.getNodeEx().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+            this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
           }
 
           /** Gets the underlying `Node`. */

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -3932,6 +3932,8 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       override predicate isSource() { none() }
 
       override string toString() { result = sourceGroup }
+
+      override Location getLocation() { result.hasLocationInfo("", 0, 0, 0, 0) }
     }
 
     private class PathNodeSinkGroup extends PathNodeImpl, TPathNodeSinkGroup {
@@ -3948,6 +3950,8 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       override predicate isSource() { none() }
 
       override string toString() { result = sinkGroup }
+
+      override Location getLocation() { result.hasLocationInfo("", 0, 0, 0, 0) }
     }
 
     private predicate pathNode(

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
@@ -1650,8 +1650,6 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
    */
   class CastingNode extends NodeFinal {
     CastingNode() { castingNode(this) }
-
-    string toString() { result = super.toString() }
   }
 
   private predicate readStepWithTypes(
@@ -1800,8 +1798,6 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
   class ParamNode extends NodeFinal {
     ParamNode() { parameterNode(this, _, _) }
 
-    string toString() { result = super.toString() }
-
     /**
      * Holds if this node is the parameter of callable `c` at the specified
      * position.
@@ -1814,8 +1810,6 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
   /** A data-flow node that represents a call argument. */
   class ArgNode extends NodeFinal {
     ArgNode() { argumentNode(this, _, _) }
-
-    string toString() { result = super.toString() }
 
     /** Holds if this argument occurs at the given position in the given call. */
     final predicate argumentOf(DataFlowCall call, ArgumentPosition pos) {
@@ -1830,8 +1824,6 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
   class ReturnNodeExt extends NodeFinal {
     ReturnNodeExt() { returnNodeExt(this, _) }
 
-    string toString() { result = super.toString() }
-
     /** Gets the kind of this returned value. */
     ReturnKindExt getKind() { returnNodeExt(this, result) }
   }
@@ -1842,8 +1834,6 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
    */
   class OutNodeExt extends NodeFinal {
     OutNodeExt() { outNodeExt(this) }
-
-    string toString() { result = super.toString() }
   }
 
   /**

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
@@ -1,8 +1,9 @@
 private import codeql.dataflow.DataFlow
 private import codeql.typetracking.TypeTracking as Tt
+private import codeql.util.Location
 private import codeql.util.Unit
 
-module MakeImplCommon<InputSig Lang> {
+module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
   private import Lang
   import Cached
 
@@ -1642,19 +1643,15 @@ module MakeImplCommon<InputSig Lang> {
     }
   }
 
+  final private class NodeFinal = Node;
+
   /**
    * A `Node` at which a cast can occur such that the type should be checked.
    */
-  class CastingNode instanceof Node {
+  class CastingNode extends NodeFinal {
     CastingNode() { castingNode(this) }
 
     string toString() { result = super.toString() }
-
-    predicate hasLocationInfo(
-      string filepath, int startline, int startcolumn, int endline, int endcolumn
-    ) {
-      super.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-    }
   }
 
   private predicate readStepWithTypes(
@@ -1800,16 +1797,10 @@ module MakeImplCommon<InputSig Lang> {
    * The value of a parameter at function entry, viewed as a node in a data
    * flow graph.
    */
-  class ParamNode instanceof Node {
+  class ParamNode extends NodeFinal {
     ParamNode() { parameterNode(this, _, _) }
 
     string toString() { result = super.toString() }
-
-    predicate hasLocationInfo(
-      string filepath, int startline, int startcolumn, int endline, int endcolumn
-    ) {
-      super.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-    }
 
     /**
      * Holds if this node is the parameter of callable `c` at the specified
@@ -1821,16 +1812,10 @@ module MakeImplCommon<InputSig Lang> {
   }
 
   /** A data-flow node that represents a call argument. */
-  class ArgNode instanceof Node {
+  class ArgNode extends NodeFinal {
     ArgNode() { argumentNode(this, _, _) }
 
     string toString() { result = super.toString() }
-
-    predicate hasLocationInfo(
-      string filepath, int startline, int startcolumn, int endline, int endcolumn
-    ) {
-      super.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-    }
 
     /** Holds if this argument occurs at the given position in the given call. */
     final predicate argumentOf(DataFlowCall call, ArgumentPosition pos) {
@@ -1842,16 +1827,10 @@ module MakeImplCommon<InputSig Lang> {
    * A node from which flow can return to the caller. This is either a regular
    * `ReturnNode` or a `PostUpdateNode` corresponding to the value of a parameter.
    */
-  class ReturnNodeExt instanceof Node {
+  class ReturnNodeExt extends NodeFinal {
     ReturnNodeExt() { returnNodeExt(this, _) }
 
     string toString() { result = super.toString() }
-
-    predicate hasLocationInfo(
-      string filepath, int startline, int startcolumn, int endline, int endcolumn
-    ) {
-      super.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-    }
 
     /** Gets the kind of this returned value. */
     ReturnKindExt getKind() { returnNodeExt(this, result) }
@@ -1861,16 +1840,10 @@ module MakeImplCommon<InputSig Lang> {
    * A node to which data can flow from a call. Either an ordinary out node
    * or a post-update node associated with a call argument.
    */
-  class OutNodeExt instanceof Node {
+  class OutNodeExt extends NodeFinal {
     OutNodeExt() { outNodeExt(this) }
 
     string toString() { result = super.toString() }
-
-    predicate hasLocationInfo(
-      string filepath, int startline, int startcolumn, int endline, int endcolumn
-    ) {
-      super.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-    }
   }
 
   /**

--- a/shared/dataflow/codeql/dataflow/internal/FlowSummaryImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/FlowSummaryImpl.qll
@@ -10,7 +10,7 @@ private import AccessPathSyntax as AccessPathSyntax
 /**
  * Provides language-specific parameters.
  */
-signature module InputSig<DF::InputSig Lang> {
+signature module InputSig<LocationSig Location, DF::InputSig<Location> Lang> {
   /**
    * A base class of callables that are candidates for flow summary modeling.
    */
@@ -139,10 +139,12 @@ signature module InputSig<DF::InputSig Lang> {
   }
 }
 
-module Make<DF::InputSig DataFlowLang, InputSig<DataFlowLang> Input> {
+module Make<
+  LocationSig Location, DF::InputSig<Location> DataFlowLang, InputSig<Location, DataFlowLang> Input>
+{
   private import DataFlowLang
   private import Input
-  private import codeql.dataflow.internal.DataFlowImplCommon::MakeImplCommon<DataFlowLang>
+  private import codeql.dataflow.internal.DataFlowImplCommon::MakeImplCommon<Location, DataFlowLang>
   private import codeql.util.Unit
 
   final private class SummarizedCallableBaseFinal = SummarizedCallableBase;
@@ -1457,7 +1459,7 @@ module Make<DF::InputSig DataFlowLang, InputSig<DataFlowLang> Input> {
         AccessPathSyntax::parseInt(part.getArgumentList()) < 0
       }
 
-      signature module SourceSinkInterpretationInputSig<LocationSig Location> {
+      signature module SourceSinkInterpretationInputSig {
         class Element {
           string toString();
 
@@ -1523,8 +1525,7 @@ module Make<DF::InputSig DataFlowLang, InputSig<DataFlowLang> Input> {
        * Should eventually be replaced with API graphs like in dynamic languages.
        */
       module SourceSinkInterpretation<
-        LocationSig Location,
-        SourceSinkInterpretationInputSig<Location> SourceSinkInterpretationInput>
+        SourceSinkInterpretationInputSig SourceSinkInterpretationInput>
       {
         private import SourceSinkInterpretationInput
 

--- a/shared/dataflow/codeql/dataflow/test/InlineFlowTest.qll
+++ b/shared/dataflow/codeql/dataflow/test/InlineFlowTest.qll
@@ -29,8 +29,9 @@
 private import codeql.dataflow.DataFlow as DF
 private import codeql.dataflow.TaintTracking as TT
 private import codeql.util.test.InlineExpectationsTest as IET
+private import codeql.util.Location
 
-signature module InputSig<DF::InputSig DataFlowLang> {
+signature module InputSig<LocationSig Location, DF::InputSig<Location> DataFlowLang> {
   predicate defaultSource(DataFlowLang::Node source);
 
   predicate defaultSink(DataFlowLang::Node source);
@@ -40,12 +41,13 @@ signature module InputSig<DF::InputSig DataFlowLang> {
 }
 
 module InlineFlowTestMake<
-  DF::InputSig DataFlowLang, TT::InputSig<DataFlowLang> TaintTrackingLang,
-  IET::InlineExpectationsTestSig Test, InputSig<DataFlowLang> Impl>
+  LocationSig Location, DF::InputSig<Location> DataFlowLang,
+  TT::InputSig<Location, DataFlowLang> TaintTrackingLang, IET::InlineExpectationsTestSig Test,
+  InputSig<Location, DataFlowLang> Impl>
 {
-  private module DataFlow = DF::DataFlowMake<DataFlowLang>;
+  private module DataFlow = DF::DataFlowMake<Location, DataFlowLang>;
 
-  private module TaintTracking = TT::TaintFlowMake<DataFlowLang, TaintTrackingLang>;
+  private module TaintTracking = TT::TaintFlowMake<Location, DataFlowLang, TaintTrackingLang>;
 
   private module InlineExpectationsTest = IET::Make<Test>;
 
@@ -76,7 +78,7 @@ module InlineFlowTestMake<
 
     private predicate hasLocationInfo(DataFlowLang::Node node, Test::Location location) {
       exists(string filepath, int startline, int startcolumn, int endline, int endcolumn |
-        node.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn) and
+        node.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn) and
         location.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
       )
     }

--- a/swift/ql/lib/codeql/swift/dataflow/DataFlow.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/DataFlow.qll
@@ -5,6 +5,7 @@
 module DataFlow {
   private import internal.DataFlowImplSpecific
   private import codeql.dataflow.DataFlow
-  import DataFlowMake<SwiftDataFlow>
+  private import codeql.swift.elements.Location
+  import DataFlowMake<Location, SwiftDataFlow>
   import internal.DataFlowImpl1
 }

--- a/swift/ql/lib/codeql/swift/dataflow/TaintTracking.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/TaintTracking.qll
@@ -7,6 +7,7 @@ module TaintTracking {
   private import codeql.swift.dataflow.internal.DataFlowImplSpecific
   private import codeql.swift.dataflow.internal.TaintTrackingImplSpecific
   private import codeql.dataflow.TaintTracking
-  import TaintFlowMake<SwiftDataFlow, SwiftTaintTracking>
+  private import codeql.swift.elements.Location
+  import TaintFlowMake<Location, SwiftDataFlow, SwiftTaintTracking>
   import codeql.swift.dataflow.internal.tainttracking1.TaintTrackingImpl
 }

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
@@ -1,3 +1,4 @@
 private import DataFlowImplSpecific
 private import codeql.dataflow.internal.DataFlowImpl
-import MakeImpl<SwiftDataFlow>
+private import codeql.swift.elements.Location
+import MakeImpl<Location, SwiftDataFlow>

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImplCommon.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImplCommon.qll
@@ -1,3 +1,4 @@
 private import DataFlowImplSpecific
 private import codeql.dataflow.internal.DataFlowImplCommon
-import MakeImplCommon<SwiftDataFlow>
+import codeql.swift.elements.Location
+import MakeImplCommon<Location, SwiftDataFlow>

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImplConsistency.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImplConsistency.qll
@@ -8,6 +8,6 @@ private import DataFlowImplSpecific
 private import TaintTrackingImplSpecific
 private import codeql.dataflow.internal.DataFlowImplConsistency
 
-private module Input implements InputSig<SwiftDataFlow> { }
+private module Input implements InputSig<Location, SwiftDataFlow> { }
 
-module Consistency = MakeConsistency<SwiftDataFlow, SwiftTaintTracking, Input>;
+module Consistency = MakeConsistency<Location, SwiftDataFlow, SwiftTaintTracking, Input>;

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImplSpecific.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImplSpecific.qll
@@ -15,7 +15,7 @@ module Public {
   import DataFlowPublic
 }
 
-module SwiftDataFlow implements InputSig {
+module SwiftDataFlow implements InputSig<Swift::Location> {
   import Private
   import Public
 

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPublic.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPublic.qll
@@ -26,7 +26,7 @@ class Node extends TNode {
    * For more information, see
    * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
    */
-  predicate hasLocationInfo(
+  deprecated predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
     this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)

--- a/swift/ql/lib/codeql/swift/dataflow/internal/FlowSummaryImpl.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/FlowSummaryImpl.qll
@@ -11,7 +11,7 @@ private import DataFlowImplSpecific::Public
 private import DataFlowImplCommon
 private import codeql.swift.dataflow.ExternalFlow
 
-module Input implements InputSig<DataFlowImplSpecific::SwiftDataFlow> {
+module Input implements InputSig<Location, DataFlowImplSpecific::SwiftDataFlow> {
   class SummarizedCallableBase = Function;
 
   ArgumentPosition callbackSelfParameterPosition() { result instanceof ThisArgumentPosition }
@@ -102,14 +102,14 @@ module Input implements InputSig<DataFlowImplSpecific::SwiftDataFlow> {
   }
 }
 
-private import Make<DataFlowImplSpecific::SwiftDataFlow, Input> as Impl
+private import Make<Location, DataFlowImplSpecific::SwiftDataFlow, Input> as Impl
 
 private module StepsInput implements Impl::Private::StepsInputSig {
   DataFlowCall getACall(Public::SummarizedCallable sc) { result.asCall().getStaticTarget() = sc }
 }
 
 module SourceSinkInterpretationInput implements
-  Impl::Private::External::SourceSinkInterpretationInputSig<Location>
+  Impl::Private::External::SourceSinkInterpretationInputSig
 {
   class Element = AstNode;
 
@@ -222,7 +222,7 @@ module Private {
 
   module External {
     import Impl::Private::External
-    import Impl::Private::External::SourceSinkInterpretation<Location, SourceSinkInterpretationInput>
+    import Impl::Private::External::SourceSinkInterpretation<SourceSinkInterpretationInput>
   }
 
   /**

--- a/swift/ql/lib/codeql/swift/dataflow/internal/TaintTrackingImplSpecific.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/TaintTrackingImplSpecific.qll
@@ -4,8 +4,9 @@
 
 private import codeql.dataflow.TaintTracking
 private import DataFlowImplSpecific
+private import codeql.swift.elements.Location
 
-module SwiftTaintTracking implements InputSig<SwiftDataFlow> {
+module SwiftTaintTracking implements InputSig<Location, SwiftDataFlow> {
   import TaintTrackingPrivate
   import TaintTrackingPublic
 }


### PR DESCRIPTION
This PR changes the API of the shared data flow library from using `hasLocationInfo`, to instead use `getLocation` via the existing `LocationSig` signature for locations. In addition to having a nicer API, it also makes for a small performance improvement, as the 5-column `hasLocationInfo` predicate no longer needs to be materialized for all (`Path`)`Node`s arising from instantiating the data flow library, we only ever need to materialize `Location.hasLocationInfo`.

The transformation is mostly straightforward, except for Go, where we need to account for the fact that not all existing tuples in `Node.hasLocationInfo` may correspond to an extracted location. This is handled by backing `Location` up by a `newtype`, which can represent both extracted and synthetic locations. In order to avoid a dependency on `Node.hasLocationInfo` in `Locatable.getLocation`, `Locatable.getLocation` returns not a `Location`, but instead a `DbLocation`, which can be cast to a `Location`, but does not extend `Location`.