### PR TITLE
C#: Change ID of buildless output assembly

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Assembly.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Assembly.cs
@@ -33,8 +33,13 @@ namespace Semmle.Extraction.CSharp.Entities
         {
             if (assemblyPath is not null)
             {
-                trapFile.assemblies(this, File.Create(Context, assemblyPath), assembly.ToString() ?? "",
-                    assembly.Identity.Name, assembly.Identity.Version.ToString());
+                var isBuildlessOutputAssembly = isOutputAssembly && Context.Extractor.Mode.HasFlag(ExtractorMode.Standalone);
+                var identifier = isBuildlessOutputAssembly
+                    ? ""
+                    : assembly.ToString() ?? "";
+                var name = isBuildlessOutputAssembly ? "" : assembly.Identity.Name;
+                var version = isBuildlessOutputAssembly ? "" : assembly.Identity.Version.ToString();
+                trapFile.assemblies(this, File.Create(Context, assemblyPath), identifier, name, version);
             }
         }
 


### PR DESCRIPTION
This PR changes the computed ID of the output assembly in buildless mode. The assembly ID typically looks like: `01szix0x.nzd.dll, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null`, but to compute this, Roslyn needs to process assembly attributes, which might fail on a set of source files that were not meant to be compiled together.