### PR TITLE
Ruby: Model second argument of `ActiveRecord` `from`

### DIFF
--- a/ruby/ql/lib/change-notes/2024-03-08-activerecord-from.md
+++ b/ruby/ql/lib/change-notes/2024-03-08-activerecord-from.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The second argument, `subquery_name`, of the `ActiveRecord::QueryMethods::from` method, is now recognized as an sql injection sink.

--- a/ruby/ql/lib/codeql/ruby/frameworks/ActiveRecord.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActiveRecord.qll
@@ -175,14 +175,14 @@ private predicate sqlFragmentArgumentInner(DataFlow::CallNode call, DataFlow::No
   call =
     activeRecordQueryBuilderCall([
         "delete_all", "delete_by", "destroy_all", "destroy_by", "exists?", "find_by", "find_by!",
-        "find_or_create_by", "find_or_create_by!", "find_or_initialize_by", "find_by_sql", "from",
-        "having", "lock", "not", "where", "rewhere"
+        "find_or_create_by", "find_or_create_by!", "find_or_initialize_by", "find_by_sql", "having",
+        "lock", "not", "where", "rewhere"
       ]) and
   sink = call.getArgument(0)
   or
   call =
     activeRecordQueryBuilderCall([
-        "group", "joins", "order", "reorder", "pluck", "select", "reselect"
+        "from", "group", "joins", "order", "reorder", "pluck", "select", "reselect"
       ]) and
   sink = call.getArgument(_)
   or

--- a/ruby/ql/test/query-tests/security/cwe-089/ActiveRecordInjection.rb
+++ b/ruby/ql/test/query-tests/security/cwe-089/ActiveRecordInjection.rb
@@ -114,6 +114,12 @@ class FooController < ActionController::Base
     User.joins(:a, params[:column])
 
     User.count_by_sql(params[:custom_sql_query])
+
+    # BAD: executes `SELECT users.* FROM #{params[:tab]}`
+    # where `params[:tab]` is unsanitized
+    User.all.from(params[:tab]) 
+    # BAD: executes `SELECT "users".* FROM (SELECT "users".* FROM "users") #{params[:sq]}
+    User.all.from(User.all, params[:sq])
   end
 end
 

--- a/ruby/ql/test/query-tests/security/cwe-089/SqlInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-089/SqlInjection.expected
@@ -46,34 +46,36 @@ edges
 | ActiveRecordInjection.rb:113:21:113:26 | call to params | ActiveRecordInjection.rb:113:21:113:35 | ...[...] | provenance |  |
 | ActiveRecordInjection.rb:114:20:114:25 | call to params | ActiveRecordInjection.rb:114:20:114:34 | ...[...] | provenance |  |
 | ActiveRecordInjection.rb:116:23:116:28 | call to params | ActiveRecordInjection.rb:116:23:116:47 | ...[...] | provenance |  |
-| ActiveRecordInjection.rb:122:5:122:6 | ps | ActiveRecordInjection.rb:123:11:123:12 | ps | provenance |  |
-| ActiveRecordInjection.rb:122:10:122:15 | call to params | ActiveRecordInjection.rb:122:5:122:6 | ps | provenance |  |
-| ActiveRecordInjection.rb:123:5:123:7 | uid | ActiveRecordInjection.rb:124:5:124:9 | uidEq | provenance |  |
-| ActiveRecordInjection.rb:123:11:123:12 | ps | ActiveRecordInjection.rb:123:11:123:17 | ...[...] | provenance |  |
-| ActiveRecordInjection.rb:123:11:123:17 | ...[...] | ActiveRecordInjection.rb:123:5:123:7 | uid | provenance |  |
-| ActiveRecordInjection.rb:124:5:124:9 | uidEq | ActiveRecordInjection.rb:128:20:128:32 | ... + ... | provenance |  |
-| ActiveRecordInjection.rb:124:5:124:9 | uidEq | ActiveRecordInjection.rb:128:28:128:32 | uidEq | provenance |  |
-| ActiveRecordInjection.rb:128:20:128:32 | ... + ... [element] | ActiveRecordInjection.rb:128:20:128:32 | ... + ... | provenance |  |
-| ActiveRecordInjection.rb:128:28:128:32 | uidEq | ActiveRecordInjection.rb:128:20:128:32 | ... + ... [element] | provenance |  |
-| ActiveRecordInjection.rb:161:21:161:26 | call to params | ActiveRecordInjection.rb:161:21:161:44 | ...[...] | provenance |  |
-| ActiveRecordInjection.rb:161:21:161:26 | call to params | ActiveRecordInjection.rb:161:21:161:44 | ...[...] | provenance |  |
-| ActiveRecordInjection.rb:161:21:161:44 | ...[...] | ActiveRecordInjection.rb:20:22:20:30 | condition | provenance |  |
-| ActiveRecordInjection.rb:175:59:175:64 | call to params | ActiveRecordInjection.rb:175:59:175:74 | ...[...] | provenance |  |
-| ActiveRecordInjection.rb:175:59:175:74 | ...[...] | ActiveRecordInjection.rb:175:27:175:76 | "this is an unsafe annotation:..." | provenance |  |
-| ActiveRecordInjection.rb:186:5:186:13 | my_params | ActiveRecordInjection.rb:187:47:187:55 | my_params | provenance |  |
-| ActiveRecordInjection.rb:186:17:186:32 | call to permitted_params | ActiveRecordInjection.rb:186:5:186:13 | my_params | provenance |  |
-| ActiveRecordInjection.rb:187:5:187:9 | query | ActiveRecordInjection.rb:188:37:188:41 | query | provenance |  |
-| ActiveRecordInjection.rb:187:47:187:55 | my_params | ActiveRecordInjection.rb:187:47:187:65 | ...[...] | provenance |  |
-| ActiveRecordInjection.rb:187:47:187:65 | ...[...] | ActiveRecordInjection.rb:187:5:187:9 | query | provenance |  |
-| ActiveRecordInjection.rb:193:5:193:10 | call to params | ActiveRecordInjection.rb:193:5:193:27 | call to require | provenance |  |
-| ActiveRecordInjection.rb:193:5:193:27 | call to require | ActiveRecordInjection.rb:193:5:193:59 | call to permit | provenance |  |
-| ActiveRecordInjection.rb:193:5:193:59 | call to permit | ActiveRecordInjection.rb:186:17:186:32 | call to permitted_params | provenance |  |
-| ActiveRecordInjection.rb:193:5:193:59 | call to permit | ActiveRecordInjection.rb:197:77:197:92 | call to permitted_params | provenance |  |
-| ActiveRecordInjection.rb:193:5:193:59 | call to permit | ActiveRecordInjection.rb:198:69:198:84 | call to permitted_params | provenance |  |
-| ActiveRecordInjection.rb:197:77:197:92 | call to permitted_params | ActiveRecordInjection.rb:197:77:197:102 | ...[...] | provenance |  |
-| ActiveRecordInjection.rb:197:77:197:102 | ...[...] | ActiveRecordInjection.rb:197:43:197:104 | "SELECT * FROM users WHERE id ..." | provenance |  |
-| ActiveRecordInjection.rb:198:69:198:84 | call to permitted_params | ActiveRecordInjection.rb:198:69:198:94 | ...[...] | provenance |  |
-| ActiveRecordInjection.rb:198:69:198:94 | ...[...] | ActiveRecordInjection.rb:198:35:198:96 | "SELECT * FROM users WHERE id ..." | provenance |  |
+| ActiveRecordInjection.rb:120:19:120:24 | call to params | ActiveRecordInjection.rb:120:19:120:30 | ...[...] | provenance |  |
+| ActiveRecordInjection.rb:122:29:122:34 | call to params | ActiveRecordInjection.rb:122:29:122:39 | ...[...] | provenance |  |
+| ActiveRecordInjection.rb:128:5:128:6 | ps | ActiveRecordInjection.rb:129:11:129:12 | ps | provenance |  |
+| ActiveRecordInjection.rb:128:10:128:15 | call to params | ActiveRecordInjection.rb:128:5:128:6 | ps | provenance |  |
+| ActiveRecordInjection.rb:129:5:129:7 | uid | ActiveRecordInjection.rb:130:5:130:9 | uidEq | provenance |  |
+| ActiveRecordInjection.rb:129:11:129:12 | ps | ActiveRecordInjection.rb:129:11:129:17 | ...[...] | provenance |  |
+| ActiveRecordInjection.rb:129:11:129:17 | ...[...] | ActiveRecordInjection.rb:129:5:129:7 | uid | provenance |  |
+| ActiveRecordInjection.rb:130:5:130:9 | uidEq | ActiveRecordInjection.rb:134:20:134:32 | ... + ... | provenance |  |
+| ActiveRecordInjection.rb:130:5:130:9 | uidEq | ActiveRecordInjection.rb:134:28:134:32 | uidEq | provenance |  |
+| ActiveRecordInjection.rb:134:20:134:32 | ... + ... [element] | ActiveRecordInjection.rb:134:20:134:32 | ... + ... | provenance |  |
+| ActiveRecordInjection.rb:134:28:134:32 | uidEq | ActiveRecordInjection.rb:134:20:134:32 | ... + ... [element] | provenance |  |
+| ActiveRecordInjection.rb:167:21:167:26 | call to params | ActiveRecordInjection.rb:167:21:167:44 | ...[...] | provenance |  |
+| ActiveRecordInjection.rb:167:21:167:26 | call to params | ActiveRecordInjection.rb:167:21:167:44 | ...[...] | provenance |  |
+| ActiveRecordInjection.rb:167:21:167:44 | ...[...] | ActiveRecordInjection.rb:20:22:20:30 | condition | provenance |  |
+| ActiveRecordInjection.rb:181:59:181:64 | call to params | ActiveRecordInjection.rb:181:59:181:74 | ...[...] | provenance |  |
+| ActiveRecordInjection.rb:181:59:181:74 | ...[...] | ActiveRecordInjection.rb:181:27:181:76 | "this is an unsafe annotation:..." | provenance |  |
+| ActiveRecordInjection.rb:192:5:192:13 | my_params | ActiveRecordInjection.rb:193:47:193:55 | my_params | provenance |  |
+| ActiveRecordInjection.rb:192:17:192:32 | call to permitted_params | ActiveRecordInjection.rb:192:5:192:13 | my_params | provenance |  |
+| ActiveRecordInjection.rb:193:5:193:9 | query | ActiveRecordInjection.rb:194:37:194:41 | query | provenance |  |
+| ActiveRecordInjection.rb:193:47:193:55 | my_params | ActiveRecordInjection.rb:193:47:193:65 | ...[...] | provenance |  |
+| ActiveRecordInjection.rb:193:47:193:65 | ...[...] | ActiveRecordInjection.rb:193:5:193:9 | query | provenance |  |
+| ActiveRecordInjection.rb:199:5:199:10 | call to params | ActiveRecordInjection.rb:199:5:199:27 | call to require | provenance |  |
+| ActiveRecordInjection.rb:199:5:199:27 | call to require | ActiveRecordInjection.rb:199:5:199:59 | call to permit | provenance |  |
+| ActiveRecordInjection.rb:199:5:199:59 | call to permit | ActiveRecordInjection.rb:192:17:192:32 | call to permitted_params | provenance |  |
+| ActiveRecordInjection.rb:199:5:199:59 | call to permit | ActiveRecordInjection.rb:203:77:203:92 | call to permitted_params | provenance |  |
+| ActiveRecordInjection.rb:199:5:199:59 | call to permit | ActiveRecordInjection.rb:204:69:204:84 | call to permitted_params | provenance |  |
+| ActiveRecordInjection.rb:203:77:203:92 | call to permitted_params | ActiveRecordInjection.rb:203:77:203:102 | ...[...] | provenance |  |
+| ActiveRecordInjection.rb:203:77:203:102 | ...[...] | ActiveRecordInjection.rb:203:43:203:104 | "SELECT * FROM users WHERE id ..." | provenance |  |
+| ActiveRecordInjection.rb:204:69:204:84 | call to permitted_params | ActiveRecordInjection.rb:204:69:204:94 | ...[...] | provenance |  |
+| ActiveRecordInjection.rb:204:69:204:94 | ...[...] | ActiveRecordInjection.rb:204:35:204:96 | "SELECT * FROM users WHERE id ..." | provenance |  |
 | ArelInjection.rb:4:5:4:8 | name | ArelInjection.rb:6:20:6:61 | "SELECT * FROM users WHERE nam..." | provenance |  |
 | ArelInjection.rb:4:5:4:8 | name | ArelInjection.rb:7:39:7:80 | "SELECT * FROM users WHERE nam..." | provenance |  |
 | ArelInjection.rb:4:12:4:17 | call to params | ArelInjection.rb:4:12:4:29 | ...[...] | provenance |  |
@@ -165,36 +167,40 @@ nodes
 | ActiveRecordInjection.rb:114:20:114:34 | ...[...] | semmle.label | ...[...] |
 | ActiveRecordInjection.rb:116:23:116:28 | call to params | semmle.label | call to params |
 | ActiveRecordInjection.rb:116:23:116:47 | ...[...] | semmle.label | ...[...] |
-| ActiveRecordInjection.rb:122:5:122:6 | ps | semmle.label | ps |
-| ActiveRecordInjection.rb:122:10:122:15 | call to params | semmle.label | call to params |
-| ActiveRecordInjection.rb:123:5:123:7 | uid | semmle.label | uid |
-| ActiveRecordInjection.rb:123:11:123:12 | ps | semmle.label | ps |
-| ActiveRecordInjection.rb:123:11:123:17 | ...[...] | semmle.label | ...[...] |
-| ActiveRecordInjection.rb:124:5:124:9 | uidEq | semmle.label | uidEq |
-| ActiveRecordInjection.rb:128:20:128:32 | ... + ... | semmle.label | ... + ... |
-| ActiveRecordInjection.rb:128:20:128:32 | ... + ... [element] | semmle.label | ... + ... [element] |
-| ActiveRecordInjection.rb:128:28:128:32 | uidEq | semmle.label | uidEq |
-| ActiveRecordInjection.rb:161:21:161:26 | call to params | semmle.label | call to params |
-| ActiveRecordInjection.rb:161:21:161:44 | ...[...] | semmle.label | ...[...] |
-| ActiveRecordInjection.rb:161:21:161:44 | ...[...] | semmle.label | ...[...] |
-| ActiveRecordInjection.rb:175:27:175:76 | "this is an unsafe annotation:..." | semmle.label | "this is an unsafe annotation:..." |
-| ActiveRecordInjection.rb:175:59:175:64 | call to params | semmle.label | call to params |
-| ActiveRecordInjection.rb:175:59:175:74 | ...[...] | semmle.label | ...[...] |
-| ActiveRecordInjection.rb:186:5:186:13 | my_params | semmle.label | my_params |
-| ActiveRecordInjection.rb:186:17:186:32 | call to permitted_params | semmle.label | call to permitted_params |
-| ActiveRecordInjection.rb:187:5:187:9 | query | semmle.label | query |
-| ActiveRecordInjection.rb:187:47:187:55 | my_params | semmle.label | my_params |
-| ActiveRecordInjection.rb:187:47:187:65 | ...[...] | semmle.label | ...[...] |
-| ActiveRecordInjection.rb:188:37:188:41 | query | semmle.label | query |
-| ActiveRecordInjection.rb:193:5:193:10 | call to params | semmle.label | call to params |
-| ActiveRecordInjection.rb:193:5:193:27 | call to require | semmle.label | call to require |
-| ActiveRecordInjection.rb:193:5:193:59 | call to permit | semmle.label | call to permit |
-| ActiveRecordInjection.rb:197:43:197:104 | "SELECT * FROM users WHERE id ..." | semmle.label | "SELECT * FROM users WHERE id ..." |
-| ActiveRecordInjection.rb:197:77:197:92 | call to permitted_params | semmle.label | call to permitted_params |
-| ActiveRecordInjection.rb:197:77:197:102 | ...[...] | semmle.label | ...[...] |
-| ActiveRecordInjection.rb:198:35:198:96 | "SELECT * FROM users WHERE id ..." | semmle.label | "SELECT * FROM users WHERE id ..." |
-| ActiveRecordInjection.rb:198:69:198:84 | call to permitted_params | semmle.label | call to permitted_params |
-| ActiveRecordInjection.rb:198:69:198:94 | ...[...] | semmle.label | ...[...] |
+| ActiveRecordInjection.rb:120:19:120:24 | call to params | semmle.label | call to params |
+| ActiveRecordInjection.rb:120:19:120:30 | ...[...] | semmle.label | ...[...] |
+| ActiveRecordInjection.rb:122:29:122:34 | call to params | semmle.label | call to params |
+| ActiveRecordInjection.rb:122:29:122:39 | ...[...] | semmle.label | ...[...] |
+| ActiveRecordInjection.rb:128:5:128:6 | ps | semmle.label | ps |
+| ActiveRecordInjection.rb:128:10:128:15 | call to params | semmle.label | call to params |
+| ActiveRecordInjection.rb:129:5:129:7 | uid | semmle.label | uid |
+| ActiveRecordInjection.rb:129:11:129:12 | ps | semmle.label | ps |
+| ActiveRecordInjection.rb:129:11:129:17 | ...[...] | semmle.label | ...[...] |
+| ActiveRecordInjection.rb:130:5:130:9 | uidEq | semmle.label | uidEq |
+| ActiveRecordInjection.rb:134:20:134:32 | ... + ... | semmle.label | ... + ... |
+| ActiveRecordInjection.rb:134:20:134:32 | ... + ... [element] | semmle.label | ... + ... [element] |
+| ActiveRecordInjection.rb:134:28:134:32 | uidEq | semmle.label | uidEq |
+| ActiveRecordInjection.rb:167:21:167:26 | call to params | semmle.label | call to params |
+| ActiveRecordInjection.rb:167:21:167:44 | ...[...] | semmle.label | ...[...] |
+| ActiveRecordInjection.rb:167:21:167:44 | ...[...] | semmle.label | ...[...] |
+| ActiveRecordInjection.rb:181:27:181:76 | "this is an unsafe annotation:..." | semmle.label | "this is an unsafe annotation:..." |
+| ActiveRecordInjection.rb:181:59:181:64 | call to params | semmle.label | call to params |
+| ActiveRecordInjection.rb:181:59:181:74 | ...[...] | semmle.label | ...[...] |
+| ActiveRecordInjection.rb:192:5:192:13 | my_params | semmle.label | my_params |
+| ActiveRecordInjection.rb:192:17:192:32 | call to permitted_params | semmle.label | call to permitted_params |
+| ActiveRecordInjection.rb:193:5:193:9 | query | semmle.label | query |
+| ActiveRecordInjection.rb:193:47:193:55 | my_params | semmle.label | my_params |
+| ActiveRecordInjection.rb:193:47:193:65 | ...[...] | semmle.label | ...[...] |
+| ActiveRecordInjection.rb:194:37:194:41 | query | semmle.label | query |
+| ActiveRecordInjection.rb:199:5:199:10 | call to params | semmle.label | call to params |
+| ActiveRecordInjection.rb:199:5:199:27 | call to require | semmle.label | call to require |
+| ActiveRecordInjection.rb:199:5:199:59 | call to permit | semmle.label | call to permit |
+| ActiveRecordInjection.rb:203:43:203:104 | "SELECT * FROM users WHERE id ..." | semmle.label | "SELECT * FROM users WHERE id ..." |
+| ActiveRecordInjection.rb:203:77:203:92 | call to permitted_params | semmle.label | call to permitted_params |
+| ActiveRecordInjection.rb:203:77:203:102 | ...[...] | semmle.label | ...[...] |
+| ActiveRecordInjection.rb:204:35:204:96 | "SELECT * FROM users WHERE id ..." | semmle.label | "SELECT * FROM users WHERE id ..." |
+| ActiveRecordInjection.rb:204:69:204:84 | call to permitted_params | semmle.label | call to permitted_params |
+| ActiveRecordInjection.rb:204:69:204:94 | ...[...] | semmle.label | ...[...] |
 | ArelInjection.rb:4:5:4:8 | name | semmle.label | name |
 | ArelInjection.rb:4:12:4:17 | call to params | semmle.label | call to params |
 | ArelInjection.rb:4:12:4:29 | ...[...] | semmle.label | ...[...] |
@@ -217,7 +223,7 @@ subpaths
 #select
 | ActiveRecordInjection.rb:10:33:10:67 | "name='#{...}' and pass='#{...}'" | ActiveRecordInjection.rb:70:23:70:28 | call to params | ActiveRecordInjection.rb:10:33:10:67 | "name='#{...}' and pass='#{...}'" | This SQL query depends on a $@. | ActiveRecordInjection.rb:70:23:70:28 | call to params | user-provided value |
 | ActiveRecordInjection.rb:10:33:10:67 | "name='#{...}' and pass='#{...}'" | ActiveRecordInjection.rb:70:38:70:43 | call to params | ActiveRecordInjection.rb:10:33:10:67 | "name='#{...}' and pass='#{...}'" | This SQL query depends on a $@. | ActiveRecordInjection.rb:70:38:70:43 | call to params | user-provided value |
-| ActiveRecordInjection.rb:23:16:23:24 | condition | ActiveRecordInjection.rb:161:21:161:26 | call to params | ActiveRecordInjection.rb:23:16:23:24 | condition | This SQL query depends on a $@. | ActiveRecordInjection.rb:161:21:161:26 | call to params | user-provided value |
+| ActiveRecordInjection.rb:23:16:23:24 | condition | ActiveRecordInjection.rb:167:21:167:26 | call to params | ActiveRecordInjection.rb:23:16:23:24 | condition | This SQL query depends on a $@. | ActiveRecordInjection.rb:167:21:167:26 | call to params | user-provided value |
 | ActiveRecordInjection.rb:35:30:35:44 | ...[...] | ActiveRecordInjection.rb:35:30:35:35 | call to params | ActiveRecordInjection.rb:35:30:35:44 | ...[...] | This SQL query depends on a $@. | ActiveRecordInjection.rb:35:30:35:35 | call to params | user-provided value |
 | ActiveRecordInjection.rb:39:18:39:32 | ...[...] | ActiveRecordInjection.rb:39:18:39:23 | call to params | ActiveRecordInjection.rb:39:18:39:32 | ...[...] | This SQL query depends on a $@. | ActiveRecordInjection.rb:39:18:39:23 | call to params | user-provided value |
 | ActiveRecordInjection.rb:43:20:43:42 | "id = '#{...}'" | ActiveRecordInjection.rb:43:29:43:34 | call to params | ActiveRecordInjection.rb:43:20:43:42 | "id = '#{...}'" | This SQL query depends on a $@. | ActiveRecordInjection.rb:43:29:43:34 | call to params | user-provided value |
@@ -243,12 +249,14 @@ subpaths
 | ActiveRecordInjection.rb:113:21:113:35 | ...[...] | ActiveRecordInjection.rb:113:21:113:26 | call to params | ActiveRecordInjection.rb:113:21:113:35 | ...[...] | This SQL query depends on a $@. | ActiveRecordInjection.rb:113:21:113:26 | call to params | user-provided value |
 | ActiveRecordInjection.rb:114:20:114:34 | ...[...] | ActiveRecordInjection.rb:114:20:114:25 | call to params | ActiveRecordInjection.rb:114:20:114:34 | ...[...] | This SQL query depends on a $@. | ActiveRecordInjection.rb:114:20:114:25 | call to params | user-provided value |
 | ActiveRecordInjection.rb:116:23:116:47 | ...[...] | ActiveRecordInjection.rb:116:23:116:28 | call to params | ActiveRecordInjection.rb:116:23:116:47 | ...[...] | This SQL query depends on a $@. | ActiveRecordInjection.rb:116:23:116:28 | call to params | user-provided value |
-| ActiveRecordInjection.rb:128:20:128:32 | ... + ... | ActiveRecordInjection.rb:122:10:122:15 | call to params | ActiveRecordInjection.rb:128:20:128:32 | ... + ... | This SQL query depends on a $@. | ActiveRecordInjection.rb:122:10:122:15 | call to params | user-provided value |
-| ActiveRecordInjection.rb:161:21:161:44 | ...[...] | ActiveRecordInjection.rb:161:21:161:26 | call to params | ActiveRecordInjection.rb:161:21:161:44 | ...[...] | This SQL query depends on a $@. | ActiveRecordInjection.rb:161:21:161:26 | call to params | user-provided value |
-| ActiveRecordInjection.rb:175:27:175:76 | "this is an unsafe annotation:..." | ActiveRecordInjection.rb:175:59:175:64 | call to params | ActiveRecordInjection.rb:175:27:175:76 | "this is an unsafe annotation:..." | This SQL query depends on a $@. | ActiveRecordInjection.rb:175:59:175:64 | call to params | user-provided value |
-| ActiveRecordInjection.rb:188:37:188:41 | query | ActiveRecordInjection.rb:193:5:193:10 | call to params | ActiveRecordInjection.rb:188:37:188:41 | query | This SQL query depends on a $@. | ActiveRecordInjection.rb:193:5:193:10 | call to params | user-provided value |
-| ActiveRecordInjection.rb:197:43:197:104 | "SELECT * FROM users WHERE id ..." | ActiveRecordInjection.rb:193:5:193:10 | call to params | ActiveRecordInjection.rb:197:43:197:104 | "SELECT * FROM users WHERE id ..." | This SQL query depends on a $@. | ActiveRecordInjection.rb:193:5:193:10 | call to params | user-provided value |
-| ActiveRecordInjection.rb:198:35:198:96 | "SELECT * FROM users WHERE id ..." | ActiveRecordInjection.rb:193:5:193:10 | call to params | ActiveRecordInjection.rb:198:35:198:96 | "SELECT * FROM users WHERE id ..." | This SQL query depends on a $@. | ActiveRecordInjection.rb:193:5:193:10 | call to params | user-provided value |
+| ActiveRecordInjection.rb:120:19:120:30 | ...[...] | ActiveRecordInjection.rb:120:19:120:24 | call to params | ActiveRecordInjection.rb:120:19:120:30 | ...[...] | This SQL query depends on a $@. | ActiveRecordInjection.rb:120:19:120:24 | call to params | user-provided value |
+| ActiveRecordInjection.rb:122:29:122:39 | ...[...] | ActiveRecordInjection.rb:122:29:122:34 | call to params | ActiveRecordInjection.rb:122:29:122:39 | ...[...] | This SQL query depends on a $@. | ActiveRecordInjection.rb:122:29:122:34 | call to params | user-provided value |
+| ActiveRecordInjection.rb:134:20:134:32 | ... + ... | ActiveRecordInjection.rb:128:10:128:15 | call to params | ActiveRecordInjection.rb:134:20:134:32 | ... + ... | This SQL query depends on a $@. | ActiveRecordInjection.rb:128:10:128:15 | call to params | user-provided value |
+| ActiveRecordInjection.rb:167:21:167:44 | ...[...] | ActiveRecordInjection.rb:167:21:167:26 | call to params | ActiveRecordInjection.rb:167:21:167:44 | ...[...] | This SQL query depends on a $@. | ActiveRecordInjection.rb:167:21:167:26 | call to params | user-provided value |
+| ActiveRecordInjection.rb:181:27:181:76 | "this is an unsafe annotation:..." | ActiveRecordInjection.rb:181:59:181:64 | call to params | ActiveRecordInjection.rb:181:27:181:76 | "this is an unsafe annotation:..." | This SQL query depends on a $@. | ActiveRecordInjection.rb:181:59:181:64 | call to params | user-provided value |
+| ActiveRecordInjection.rb:194:37:194:41 | query | ActiveRecordInjection.rb:199:5:199:10 | call to params | ActiveRecordInjection.rb:194:37:194:41 | query | This SQL query depends on a $@. | ActiveRecordInjection.rb:199:5:199:10 | call to params | user-provided value |
+| ActiveRecordInjection.rb:203:43:203:104 | "SELECT * FROM users WHERE id ..." | ActiveRecordInjection.rb:199:5:199:10 | call to params | ActiveRecordInjection.rb:203:43:203:104 | "SELECT * FROM users WHERE id ..." | This SQL query depends on a $@. | ActiveRecordInjection.rb:199:5:199:10 | call to params | user-provided value |
+| ActiveRecordInjection.rb:204:35:204:96 | "SELECT * FROM users WHERE id ..." | ActiveRecordInjection.rb:199:5:199:10 | call to params | ActiveRecordInjection.rb:204:35:204:96 | "SELECT * FROM users WHERE id ..." | This SQL query depends on a $@. | ActiveRecordInjection.rb:199:5:199:10 | call to params | user-provided value |
 | ArelInjection.rb:6:20:6:61 | "SELECT * FROM users WHERE nam..." | ArelInjection.rb:4:12:4:17 | call to params | ArelInjection.rb:6:20:6:61 | "SELECT * FROM users WHERE nam..." | This SQL query depends on a $@. | ArelInjection.rb:4:12:4:17 | call to params | user-provided value |
 | ArelInjection.rb:7:39:7:80 | "SELECT * FROM users WHERE nam..." | ArelInjection.rb:4:12:4:17 | call to params | ArelInjection.rb:7:39:7:80 | "SELECT * FROM users WHERE nam..." | This SQL query depends on a $@. | ArelInjection.rb:4:12:4:17 | call to params | user-provided value |
 | PgInjection.rb:14:15:14:18 | qry1 | PgInjection.rb:6:12:6:17 | call to params | PgInjection.rb:14:15:14:18 | qry1 | This SQL query depends on a $@. | PgInjection.rb:6:12:6:17 | call to params | user-provided value |


### PR DESCRIPTION
This PR models the second argument, `subquery_name`, of the [`from`](https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-from) method, as an sqli sink. 
Part of https://github.com/github/codeql-team/issues/2864