### PR TITLE
Go: Allow `BuildScript`s to have multiple build commands and add `yarn build`

### DIFF
--- a/go/extractor/autobuilder/autobuilder.go
+++ b/go/extractor/autobuilder/autobuilder.go
@@ -91,6 +91,10 @@ type BuildCommand struct {
 // An array of build scripts to check for and corresponding commands that we can execute
 // if they exist.
 var BuildScripts = []BuildScript{
+	{Filename: "yarn.lock", Commands: []BuildCommand{
+		{Command: "yarn", Args: []string{"install"}},
+		{Command: "yarn", Args: []string{"build"}}},
+	},
 	{Filename: "Makefile", Commands: []BuildCommand{{Command: "make"}}},
 	{Filename: "makefile", Commands: []BuildCommand{{Command: "make"}}},
 	{Filename: "GNUmakefile", Commands: []BuildCommand{{Command: "make"}}},


### PR DESCRIPTION
This was just a quick experiment to see if adding `yarn build` would help us build some repos.

