### PR TITLE
Ruby: Lower access path limit to 1 for `OrmTracking`

### DIFF
--- a/ruby/ql/lib/codeql/ruby/security/XSS.qll
+++ b/ruby/ql/lib/codeql/ruby/security/XSS.qll
@@ -299,6 +299,8 @@ private module OrmTracking {
     }
 
     predicate isBarrierIn(DataFlow::Node node) { node instanceof DataFlow::SelfParameterNode }
+
+    int accessPathLimit() { result = 1 }
   }
 
   import DataFlow::Global<Config>


### PR DESCRIPTION
The data flow loop used in `OrmTracking` is known to be quite slow/infeasible on some DBs, so this PR reduces the access path limit from 5 to 1. This is the same access path limit as used in type tracking, but flow precision is generally much better (call context sensitivity, full support for flow summaries, full support for captured variables, etc.).