### PR TITLE
Data flow: Add `ConfigSig::accessPathLimit`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl1.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl1.qll
@@ -285,6 +285,8 @@ deprecated private module Config implements FullStateConfigSig {
 
   int fieldFlowBranchLimit() { result = min(any(Configuration config).fieldFlowBranchLimit()) }
 
+  int accessPathLimit() { result = 5 }
+
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate sourceGrouping(Node source, string sourceGroup) {

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -285,6 +285,8 @@ deprecated private module Config implements FullStateConfigSig {
 
   int fieldFlowBranchLimit() { result = min(any(Configuration config).fieldFlowBranchLimit()) }
 
+  int accessPathLimit() { result = 5 }
+
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate sourceGrouping(Node source, string sourceGroup) {

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -285,6 +285,8 @@ deprecated private module Config implements FullStateConfigSig {
 
   int fieldFlowBranchLimit() { result = min(any(Configuration config).fieldFlowBranchLimit()) }
 
+  int accessPathLimit() { result = 5 }
+
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate sourceGrouping(Node source, string sourceGroup) {

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -285,6 +285,8 @@ deprecated private module Config implements FullStateConfigSig {
 
   int fieldFlowBranchLimit() { result = min(any(Configuration config).fieldFlowBranchLimit()) }
 
+  int accessPathLimit() { result = 5 }
+
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate sourceGrouping(Node source, string sourceGroup) {

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -285,6 +285,8 @@ deprecated private module Config implements FullStateConfigSig {
 
   int fieldFlowBranchLimit() { result = min(any(Configuration config).fieldFlowBranchLimit()) }
 
+  int accessPathLimit() { result = 5 }
+
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate sourceGrouping(Node source, string sourceGroup) {

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl1.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl1.qll
@@ -285,6 +285,8 @@ deprecated private module Config implements FullStateConfigSig {
 
   int fieldFlowBranchLimit() { result = min(any(Configuration config).fieldFlowBranchLimit()) }
 
+  int accessPathLimit() { result = 5 }
+
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate sourceGrouping(Node source, string sourceGroup) {

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -285,6 +285,8 @@ deprecated private module Config implements FullStateConfigSig {
 
   int fieldFlowBranchLimit() { result = min(any(Configuration config).fieldFlowBranchLimit()) }
 
+  int accessPathLimit() { result = 5 }
+
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate sourceGrouping(Node source, string sourceGroup) {

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -285,6 +285,8 @@ deprecated private module Config implements FullStateConfigSig {
 
   int fieldFlowBranchLimit() { result = min(any(Configuration config).fieldFlowBranchLimit()) }
 
+  int accessPathLimit() { result = 5 }
+
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate sourceGrouping(Node source, string sourceGroup) {

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -285,6 +285,8 @@ deprecated private module Config implements FullStateConfigSig {
 
   int fieldFlowBranchLimit() { result = min(any(Configuration config).fieldFlowBranchLimit()) }
 
+  int accessPathLimit() { result = 5 }
+
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate sourceGrouping(Node source, string sourceGroup) {

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/ContentDataFlow.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/ContentDataFlow.qll
@@ -109,6 +109,8 @@ module Global<ConfigSig ContentConfig> {
 
     DataFlow::FlowFeature getAFeature() { result = ContentConfig::getAFeature() }
 
+    predicate accessPathLimit = ContentConfig::accessPathLimit/0;
+
     // needed to record reads/stores inside summarized callables
     predicate includeHiddenNodes() { any() }
   }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl1.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl1.qll
@@ -285,6 +285,8 @@ deprecated private module Config implements FullStateConfigSig {
 
   int fieldFlowBranchLimit() { result = min(any(Configuration config).fieldFlowBranchLimit()) }
 
+  int accessPathLimit() { result = 5 }
+
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate sourceGrouping(Node source, string sourceGroup) {

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -285,6 +285,8 @@ deprecated private module Config implements FullStateConfigSig {
 
   int fieldFlowBranchLimit() { result = min(any(Configuration config).fieldFlowBranchLimit()) }
 
+  int accessPathLimit() { result = 5 }
+
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate sourceGrouping(Node source, string sourceGroup) {

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -285,6 +285,8 @@ deprecated private module Config implements FullStateConfigSig {
 
   int fieldFlowBranchLimit() { result = min(any(Configuration config).fieldFlowBranchLimit()) }
 
+  int accessPathLimit() { result = 5 }
+
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate sourceGrouping(Node source, string sourceGroup) {

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -285,6 +285,8 @@ deprecated private module Config implements FullStateConfigSig {
 
   int fieldFlowBranchLimit() { result = min(any(Configuration config).fieldFlowBranchLimit()) }
 
+  int accessPathLimit() { result = 5 }
+
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate sourceGrouping(Node source, string sourceGroup) {

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -285,6 +285,8 @@ deprecated private module Config implements FullStateConfigSig {
 
   int fieldFlowBranchLimit() { result = min(any(Configuration config).fieldFlowBranchLimit()) }
 
+  int accessPathLimit() { result = 5 }
+
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate sourceGrouping(Node source, string sourceGroup) {

--- a/csharp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/csharp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -72,11 +72,11 @@ string captureQualifierFlow(TargetApiSpecific api) {
   result = ModelPrinting::asValueModel(api, qualifierString(), "ReturnValue")
 }
 
-private int accessPathLimit() { result = 2 }
+private int accessPathLimit0() { result = 2 }
 
 private newtype TTaintState =
-  TTaintRead(int n) { n in [0 .. accessPathLimit()] } or
-  TTaintStore(int n) { n in [1 .. accessPathLimit()] }
+  TTaintRead(int n) { n in [0 .. accessPathLimit0()] } or
+  TTaintStore(int n) { n in [1 .. accessPathLimit0()] }
 
 abstract private class TaintState extends TTaintState {
   abstract string toString();

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl1.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl1.qll
@@ -285,6 +285,8 @@ deprecated private module Config implements FullStateConfigSig {
 
   int fieldFlowBranchLimit() { result = min(any(Configuration config).fieldFlowBranchLimit()) }
 
+  int accessPathLimit() { result = 5 }
+
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate sourceGrouping(Node source, string sourceGroup) {

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl2.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl2.qll
@@ -285,6 +285,8 @@ deprecated private module Config implements FullStateConfigSig {
 
   int fieldFlowBranchLimit() { result = min(any(Configuration config).fieldFlowBranchLimit()) }
 
+  int accessPathLimit() { result = 5 }
+
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate sourceGrouping(Node source, string sourceGroup) {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl1.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl1.qll
@@ -285,6 +285,8 @@ deprecated private module Config implements FullStateConfigSig {
 
   int fieldFlowBranchLimit() { result = min(any(Configuration config).fieldFlowBranchLimit()) }
 
+  int accessPathLimit() { result = 5 }
+
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate sourceGrouping(Node source, string sourceGroup) {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -285,6 +285,8 @@ deprecated private module Config implements FullStateConfigSig {
 
   int fieldFlowBranchLimit() { result = min(any(Configuration config).fieldFlowBranchLimit()) }
 
+  int accessPathLimit() { result = 5 }
+
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate sourceGrouping(Node source, string sourceGroup) {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -285,6 +285,8 @@ deprecated private module Config implements FullStateConfigSig {
 
   int fieldFlowBranchLimit() { result = min(any(Configuration config).fieldFlowBranchLimit()) }
 
+  int accessPathLimit() { result = 5 }
+
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate sourceGrouping(Node source, string sourceGroup) {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -285,6 +285,8 @@ deprecated private module Config implements FullStateConfigSig {
 
   int fieldFlowBranchLimit() { result = min(any(Configuration config).fieldFlowBranchLimit()) }
 
+  int accessPathLimit() { result = 5 }
+
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate sourceGrouping(Node source, string sourceGroup) {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -285,6 +285,8 @@ deprecated private module Config implements FullStateConfigSig {
 
   int fieldFlowBranchLimit() { result = min(any(Configuration config).fieldFlowBranchLimit()) }
 
+  int accessPathLimit() { result = 5 }
+
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate sourceGrouping(Node source, string sourceGroup) {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
@@ -285,6 +285,8 @@ deprecated private module Config implements FullStateConfigSig {
 
   int fieldFlowBranchLimit() { result = min(any(Configuration config).fieldFlowBranchLimit()) }
 
+  int accessPathLimit() { result = 5 }
+
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate sourceGrouping(Node source, string sourceGroup) {

--- a/java/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -72,11 +72,11 @@ string captureQualifierFlow(TargetApiSpecific api) {
   result = ModelPrinting::asValueModel(api, qualifierString(), "ReturnValue")
 }
 
-private int accessPathLimit() { result = 2 }
+private int accessPathLimit0() { result = 2 }
 
 private newtype TTaintState =
-  TTaintRead(int n) { n in [0 .. accessPathLimit()] } or
-  TTaintStore(int n) { n in [1 .. accessPathLimit()] }
+  TTaintRead(int n) { n in [0 .. accessPathLimit0()] } or
+  TTaintStore(int n) { n in [1 .. accessPathLimit0()] }
 
 abstract private class TaintState extends TTaintState {
   abstract string toString();

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl1.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl1.qll
@@ -285,6 +285,8 @@ deprecated private module Config implements FullStateConfigSig {
 
   int fieldFlowBranchLimit() { result = min(any(Configuration config).fieldFlowBranchLimit()) }
 
+  int accessPathLimit() { result = 5 }
+
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate sourceGrouping(Node source, string sourceGroup) {

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
@@ -285,6 +285,8 @@ deprecated private module Config implements FullStateConfigSig {
 
   int fieldFlowBranchLimit() { result = min(any(Configuration config).fieldFlowBranchLimit()) }
 
+  int accessPathLimit() { result = 5 }
+
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate sourceGrouping(Node source, string sourceGroup) {

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
@@ -285,6 +285,8 @@ deprecated private module Config implements FullStateConfigSig {
 
   int fieldFlowBranchLimit() { result = min(any(Configuration config).fieldFlowBranchLimit()) }
 
+  int accessPathLimit() { result = 5 }
+
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate sourceGrouping(Node source, string sourceGroup) {

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
@@ -285,6 +285,8 @@ deprecated private module Config implements FullStateConfigSig {
 
   int fieldFlowBranchLimit() { result = min(any(Configuration config).fieldFlowBranchLimit()) }
 
+  int accessPathLimit() { result = 5 }
+
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate sourceGrouping(Node source, string sourceGroup) {

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl1.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl1.qll
@@ -285,6 +285,8 @@ deprecated private module Config implements FullStateConfigSig {
 
   int fieldFlowBranchLimit() { result = min(any(Configuration config).fieldFlowBranchLimit()) }
 
+  int accessPathLimit() { result = 5 }
+
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate sourceGrouping(Node source, string sourceGroup) {

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
@@ -285,6 +285,8 @@ deprecated private module Config implements FullStateConfigSig {
 
   int fieldFlowBranchLimit() { result = min(any(Configuration config).fieldFlowBranchLimit()) }
 
+  int accessPathLimit() { result = 5 }
+
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate sourceGrouping(Node source, string sourceGroup) {

--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -376,6 +376,9 @@ module Configs<InputSig Lang> {
      */
     default int fieldFlowBranchLimit() { result = 2 }
 
+    /** Gets the access path limit. */
+    default int accessPathLimit() { result = Lang::accessPathLimit() }
+
     /**
      * Gets a data flow configuration feature to add restrictions to the set of
      * valid flow paths.
@@ -495,6 +498,9 @@ module Configs<InputSig Lang> {
      */
     default int fieldFlowBranchLimit() { result = 2 }
 
+    /** Gets the access path limit. */
+    default int accessPathLimit() { result = Lang::accessPathLimit() }
+
     /**
      * Gets a data flow configuration feature to add restrictions to the set of
      * valid flow paths.
@@ -583,6 +589,8 @@ module DataFlowMake<InputSig Lang> {
     private module C implements FullStateConfigSig {
       import DefaultState<Config>
       import Config
+
+      predicate accessPathLimit = Config::accessPathLimit/0;
     }
 
     import Impl<C>
@@ -599,6 +607,8 @@ module DataFlowMake<InputSig Lang> {
   module GlobalWithState<StateConfigSig Config> implements GlobalFlowSig {
     private module C implements FullStateConfigSig {
       import Config
+
+      predicate accessPathLimit = Config::accessPathLimit/0;
     }
 
     import Impl<C>

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -1334,8 +1334,10 @@ module MakeImpl<InputSig Lang> {
         bindingset[c, t, tail]
         additional Ap apCons(Content c, Typ t, Ap tail) {
           result = Param::apCons(c, t, tail) and
-          Config::accessPathLimit() > 0 and
-          if tail instanceof ApNil then any() else Config::accessPathLimit() > 1
+          exists(int limit |
+            limit = Config::accessPathLimit() and
+            if tail instanceof ApNil then limit > 0 else limit > 1
+          )
         }
 
         pragma[nomagic]

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl1.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl1.qll
@@ -285,6 +285,8 @@ deprecated private module Config implements FullStateConfigSig {
 
   int fieldFlowBranchLimit() { result = min(any(Configuration config).fieldFlowBranchLimit()) }
 
+  int accessPathLimit() { result = 5 }
+
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate sourceGrouping(Node source, string sourceGroup) {


### PR DESCRIPTION
Adds an option to control the access path limit on a per-configuration basis. Needed for https://github.com/github/codeql/pull/15866.