### PR TITLE
Java: Add path-injection sink for `ParcelFileDescriptor::open`

### DIFF
--- a/java/ql/lib/change-notes/2024-03-11-add-parcelfiledescriptor-open-model.md
+++ b/java/ql/lib/change-notes/2024-03-11-add-parcelfiledescriptor-open-model.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added a `path-injection` sink for the `open` methods of the `android.os.ParcelFileDescriptor` class.

--- a/java/ql/lib/ext/android.os.model.yml
+++ b/java/ql/lib/ext/android.os.model.yml
@@ -132,3 +132,8 @@ extensions:
       - ["android.os", "Parcel", False, "readTypedList", "", "", "Argument[this]", "Argument[0]", "taint", "manual"]
       - ["android.os", "Parcel", False, "readTypedObject", "", "", "Argument[this]", "ReturnValue", "taint", "manual"]
       - ["android.os", "Parcel", False, "readValue", "", "", "Argument[this]", "ReturnValue", "taint", "manual"]
+  - addsTo:
+      pack: codeql/java-all
+      extensible: sinkModel
+    data:
+      - ["android.os", "ParcelFileDescriptor", False, "open", "", "", "Argument[0]", "path-injection", "manual"]


### PR DESCRIPTION
Adds a `path-injection` sink to for the [`android.os.ParcelFileDescriptor::open`] methods.

This covers a regression in the `java/path-injection` query.

[`android.os.ParcelFileDescriptor::open`]: https://developer.android.com/reference/android/os/ParcelFileDescriptor#open(java.io.File,%20int)