### PR TITLE
Show lines of code data in debug mode only

### DIFF
--- a/cpp/ql/src/Summary/LinesOfUserCode.ql
+++ b/cpp/ql/src/Summary/LinesOfUserCode.ql
@@ -4,6 +4,7 @@
  * @kind metric
  * @tags summary
  *       lines-of-code
+ *       telemetry
  * @id cpp/summary/lines-of-user-code
  */
 

--- a/cpp/ql/src/Summary/LinesOfUserCode.ql
+++ b/cpp/ql/src/Summary/LinesOfUserCode.ql
@@ -4,7 +4,7 @@
  * @kind metric
  * @tags summary
  *       lines-of-code
- *       telemetry
+ *       debug
  * @id cpp/summary/lines-of-user-code
  */
 

--- a/csharp/ql/src/Metrics/Summaries/LinesOfCode.ql
+++ b/csharp/ql/src/Metrics/Summaries/LinesOfCode.ql
@@ -5,7 +5,7 @@
  * @kind metric
  * @tags summary
  *       lines-of-code
- *       telemetry
+ *       debug
  */
 
 import csharp

--- a/csharp/ql/src/Metrics/Summaries/LinesOfCode.ql
+++ b/csharp/ql/src/Metrics/Summaries/LinesOfCode.ql
@@ -5,6 +5,7 @@
  * @kind metric
  * @tags summary
  *       lines-of-code
+ *       telemetry
  */
 
 import csharp

--- a/go/ql/src/Summary/LinesOfCode.ql
+++ b/go/ql/src/Summary/LinesOfCode.ql
@@ -5,6 +5,7 @@
  * @kind metric
  * @tags summary
  *       lines-of-code
+ *       telemetry
  */
 
 import go

--- a/go/ql/src/Summary/LinesOfCode.ql
+++ b/go/ql/src/Summary/LinesOfCode.ql
@@ -5,7 +5,7 @@
  * @kind metric
  * @tags summary
  *       lines-of-code
- *       telemetry
+ *       debug
  */
 
 import go

--- a/java/ql/src/Metrics/Summaries/LinesOfCode.ql
+++ b/java/ql/src/Metrics/Summaries/LinesOfCode.ql
@@ -7,6 +7,7 @@
  * @kind metric
  * @tags summary
  *       lines-of-code
+ *       telemetry
  */
 
 import java

--- a/java/ql/src/Metrics/Summaries/LinesOfCode.ql
+++ b/java/ql/src/Metrics/Summaries/LinesOfCode.ql
@@ -7,7 +7,7 @@
  * @kind metric
  * @tags summary
  *       lines-of-code
- *       telemetry
+ *       debug
  */
 
 import java

--- a/javascript/ql/src/Summary/LinesOfUserCode.ql
+++ b/javascript/ql/src/Summary/LinesOfUserCode.ql
@@ -6,7 +6,7 @@
  * @kind metric
  * @tags summary
  *       lines-of-code
- *       telemetry
+ *       debug
  * @id js/summary/lines-of-user-code
  */
 

--- a/javascript/ql/src/Summary/LinesOfUserCode.ql
+++ b/javascript/ql/src/Summary/LinesOfUserCode.ql
@@ -6,6 +6,7 @@
  * @kind metric
  * @tags summary
  *       lines-of-code
+ *       telemetry
  * @id js/summary/lines-of-user-code
  */
 

--- a/python/ql/src/Summary/LinesOfUserCode.ql
+++ b/python/ql/src/Summary/LinesOfUserCode.ql
@@ -8,7 +8,7 @@
  * @kind metric
  * @tags summary
  *       lines-of-code
- *       telemetry
+ *       debug
  * @id py/summary/lines-of-user-code
  */
 

--- a/python/ql/src/Summary/LinesOfUserCode.ql
+++ b/python/ql/src/Summary/LinesOfUserCode.ql
@@ -8,6 +8,7 @@
  * @kind metric
  * @tags summary
  *       lines-of-code
+ *       telemetry
  * @id py/summary/lines-of-user-code
  */
 

--- a/ql/ql/src/queries/summary/LinesOfCode.ql
+++ b/ql/ql/src/queries/summary/LinesOfCode.ql
@@ -8,7 +8,7 @@
  * @kind metric
  * @tags summary
  *       lines-of-code
- *       telemetry
+ *       debug
  */
 
 import ql

--- a/ql/ql/src/queries/summary/LinesOfCode.ql
+++ b/ql/ql/src/queries/summary/LinesOfCode.ql
@@ -8,6 +8,7 @@
  * @kind metric
  * @tags summary
  *       lines-of-code
+ *       telemetry
  */
 
 import ql

--- a/ql/ql/src/queries/summary/LinesOfUserCode.ql
+++ b/ql/ql/src/queries/summary/LinesOfUserCode.ql
@@ -6,6 +6,7 @@
  *   query counts the lines of code, excluding whitespace or comments.
  * @kind metric
  * @tags summary
+ *       telemetry
  */
 
 import ql

--- a/ql/ql/src/queries/summary/LinesOfUserCode.ql
+++ b/ql/ql/src/queries/summary/LinesOfUserCode.ql
@@ -6,7 +6,7 @@
  *   query counts the lines of code, excluding whitespace or comments.
  * @kind metric
  * @tags summary
- *       telemetry
+ *       debug
  */
 
 import ql

--- a/ruby/ql/src/queries/summary/LinesOfCode.ql
+++ b/ruby/ql/src/queries/summary/LinesOfCode.ql
@@ -8,7 +8,7 @@
  * @kind metric
  * @tags summary
  *       lines-of-code
- *       telemetry
+ *       debug
  */
 
 import codeql.ruby.AST

--- a/ruby/ql/src/queries/summary/LinesOfCode.ql
+++ b/ruby/ql/src/queries/summary/LinesOfCode.ql
@@ -8,6 +8,7 @@
  * @kind metric
  * @tags summary
  *       lines-of-code
+ *       telemetry
  */
 
 import codeql.ruby.AST

--- a/ruby/ql/src/queries/summary/LinesOfUserCode.ql
+++ b/ruby/ql/src/queries/summary/LinesOfUserCode.ql
@@ -6,7 +6,7 @@
  *   query counts the lines of code, excluding whitespace or comments.
  * @kind metric
  * @tags summary
- *       telemetry
+ *       debug
  */
 
 import codeql.ruby.AST

--- a/ruby/ql/src/queries/summary/LinesOfUserCode.ql
+++ b/ruby/ql/src/queries/summary/LinesOfUserCode.ql
@@ -6,6 +6,7 @@
  *   query counts the lines of code, excluding whitespace or comments.
  * @kind metric
  * @tags summary
+ *       telemetry
  */
 
 import codeql.ruby.AST

--- a/swift/ql/src/diagnostics/SuccessfullyExtractedLines.ql
+++ b/swift/ql/src/diagnostics/SuccessfullyExtractedLines.ql
@@ -4,6 +4,7 @@
  * @kind metric
  * @id swift/diagnostics/successfully-extracted-lines
  * @tags summary
+ *       telemetry
  */
 
 import swift

--- a/swift/ql/src/diagnostics/SuccessfullyExtractedLines.ql
+++ b/swift/ql/src/diagnostics/SuccessfullyExtractedLines.ql
@@ -4,7 +4,7 @@
  * @kind metric
  * @id swift/diagnostics/successfully-extracted-lines
  * @tags summary
- *       telemetry
+ *       debug
  */
 
 import swift


### PR DESCRIPTION
The new file coverage metrics are available in all supported GHES versions. This PR tags lines of code queries as `debug`.  This means that lines of code information will only be shown in the logging output of the CLI when running at higher verbosities (including the CodeQL Action debug mode).  Lines of code information will also still be available in the SARIF file.

The one exception is the metric queries for Java/Kotlin that provides separate lines of code information for Java and Kotlin. I've left these as non-debug level since separate file coverage information for languages like Java and Kotlin is only available for GHES 3.12 and later.