### PR TITLE
C#: Deduplicate not yet restored package names

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
@@ -924,6 +924,17 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 return;
             }
 
+            var multipleVersions = notYetDownloadedPackages
+                .GroupBy(p => p.Name)
+                .Where(g => g.Count() > 1)
+                .Select(g => g.Key);
+
+            foreach (var package in multipleVersions)
+            {
+                logger.LogWarning($"Found multiple not yet restored packages with name '{package}'.");
+                notYetDownloadedPackages.Remove(new(package, PackageReferenceSource.PackagesConfig));
+            }
+
             logger.LogInfo($"Found {notYetDownloadedPackages.Count} packages that are not yet restored");
 
             var nugetConfigs = allFiles.SelectFileNamesByName("nuget.config").ToArray();

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
@@ -927,7 +927,8 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             var multipleVersions = notYetDownloadedPackages
                 .GroupBy(p => p.Name)
                 .Where(g => g.Count() > 1)
-                .Select(g => g.Key);
+                .Select(g => g.Key)
+                .ToList();
 
             foreach (var package in multipleVersions)
             {


### PR DESCRIPTION
This PR makes sure that we deduplicate by name the package reference list, which might contain `("abc", csproj)` and `("abc", packagesconfig)`. We prefer the `csproj` variant.

I found this issue in `mono/mono` which occasionally failed with:
```
Unhandled exception. System.AggregateException: One or more errors occurred. (Could not find a part of the path '/home/runner/work/_temp/codeql_databases/csharp/working/1692ca4ce0441bb2/missingpackages_workingdir'.)
 ---> System.IO.DirectoryNotFoundException: Could not find a part of the path '/home/runner/work/_temp/codeql_databases/csharp/working/1692ca4ce0441bb2/missingpackages_workingdir'.
   at System.IO.FileSystem.RemoveEmptyDirectory(String fullPath, Boolean topLevel, Boolean throwWhenNotEmpty)
   at Semmle.Util.TemporaryDirectory.Dispose() in .../ql/csharp/extractor/Semmle.Util/TemporaryDirectory.cs:line 22
   at Semmle.Extraction.CSharp.DependencyFetching.DependencyManager.TryRestorePackageManually(String package, String nugetConfig, PackageReferenceSource packageReferenceSource) in .../ql/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs:line 1021
   ...
```
