### PR TITLE
JS: show test changes after #15823

### DIFF
--- a/javascript/ql/test/ApiGraphs/classes/VerifyAssertions.expected
+++ b/javascript/ql/test/ApiGraphs/classes/VerifyAssertions.expected
@@ -1,0 +1,4 @@
+| classes.js:31:28:31:122 | /* use= ... ce() */ | def moduleImport("classes").getMember("exports").getMember("MyThirdStream") has no outgoing edge labelled getInstance(); it does have outgoing edges labelled getReceiver(). |
+| classes.js:33:37:33:131 | /* use= ... ce() */ | def moduleImport("classes").getMember("exports").getMember("MyThirdStream") has no outgoing edge labelled getInstance(); it does have outgoing edges labelled getReceiver(). |
+| classes.js:40:28:40:112 | /* use= ... ce() */ | def moduleImport("classes").getMember("exports").getMember("bar") has no outgoing edge labelled getInstance(); it does have outgoing edges labelled getReceiver(). |
+| classes.js:45:26:45:110 | /* use= ... ce() */ | def moduleImport("classes").getMember("exports").getMember("bar") has no outgoing edge labelled getInstance(); it does have outgoing edges labelled getReceiver(). |

--- a/javascript/ql/test/ApiGraphs/classes/VerifyAssertions.expected
+++ b/javascript/ql/test/ApiGraphs/classes/VerifyAssertions.expected
@@ -1,4 +1,0 @@
-| classes.js:31:28:31:122 | /* use= ... ce() */ | def moduleImport("classes").getMember("exports").getMember("MyThirdStream") has no outgoing edge labelled getInstance(); it does have outgoing edges labelled getReceiver(). |
-| classes.js:33:37:33:131 | /* use= ... ce() */ | def moduleImport("classes").getMember("exports").getMember("MyThirdStream") has no outgoing edge labelled getInstance(); it does have outgoing edges labelled getReceiver(). |
-| classes.js:40:28:40:112 | /* use= ... ce() */ | def moduleImport("classes").getMember("exports").getMember("bar") has no outgoing edge labelled getInstance(); it does have outgoing edges labelled getReceiver(). |
-| classes.js:45:26:45:110 | /* use= ... ce() */ | def moduleImport("classes").getMember("exports").getMember("bar") has no outgoing edge labelled getInstance(); it does have outgoing edges labelled getReceiver(). |

--- a/javascript/ql/test/ApiGraphs/classes/classes.js
+++ b/javascript/ql/test/ApiGraphs/classes/classes.js
@@ -25,3 +25,24 @@ MyOtherStream.prototype.instanceProp = 1; /* def=moduleImport("classes").getMemb
 MyOtherStream.classProp = 1; /* def=moduleImport("classes").getMember("exports").getMember("MyOtherStream").getMember("classProp") */
 
 module.exports.MyOtherStream = MyOtherStream;
+
+
+// function-style class without .prototype reference
+function MyThirdStream() { /* use=moduleImport("classes").getMember("exports").getMember("MyThirdStream").getInstance() */
+}
+let instance = new MyThirdStream(); /* use=moduleImport("classes").getMember("exports").getMember("MyThirdStream").getInstance() */
+
+module.exports.MyThirdStream = MyThirdStream;
+
+
+// function-style class without .prototype reference (through global variable)
+(function(f) {
+    foo.bar = function() { /* use=moduleImport("classes").getMember("exports").getMember("bar").getInstance() */
+    }
+})(foo = foo || {});
+
+(function(f) {
+    let x = new f.bar(); /* use=moduleImport("classes").getMember("exports").getMember("bar").getInstance() */
+})(foo = foo || {});
+
+module.exports.bar = foo.bar;

--- a/javascript/ql/test/library-tests/TypeTracking/TypeTracking.expected
+++ b/javascript/ql/test/library-tests/TypeTracking/TypeTracking.expected
@@ -1,0 +1,3 @@
+| implicit-receiver.js:8:22:8:52 | // trac ... ver-obj | Failed to track implicit-receiver-obj here. |
+| implicit-receiver.js:9:24:9:84 | // trac ... er-prop | Failed to track implicit-receiver-obj here. |
+| implicit-receiver.js:9:24:9:84 | // trac ... er-prop | Failed to track implicit-receiver-prop here. |

--- a/javascript/ql/test/library-tests/TypeTracking/TypeTracking.expected
+++ b/javascript/ql/test/library-tests/TypeTracking/TypeTracking.expected
@@ -1,3 +1,1 @@
-| implicit-receiver.js:8:22:8:52 | // trac ... ver-obj | Failed to track implicit-receiver-obj here. |
-| implicit-receiver.js:9:24:9:84 | // trac ... er-prop | Failed to track implicit-receiver-obj here. |
-| implicit-receiver.js:9:24:9:84 | // trac ... er-prop | Failed to track implicit-receiver-prop here. |
+

--- a/javascript/ql/test/library-tests/TypeTracking/implicit-receiver.js
+++ b/javascript/ql/test/library-tests/TypeTracking/implicit-receiver.js
@@ -1,0 +1,27 @@
+import 'dummy';
+
+let trackedProp = "implicit-receiver-prop"; // name: implicit-receiver-prop
+
+function factory() {
+    let obj = unknown(); // name: implicit-receiver-obj
+    obj.foo = function() {
+        track(this); // track: implicit-receiver-obj
+        track(this.x); // track: implicit-receiver-obj track: implicit-receiver-prop
+    }
+    return obj;
+}
+let obj = factory();
+obj.x = trackedProp;
+
+
+function factory2() {
+    let obj2 = { // name: implicit-receiver-obj2
+        foo: function() {
+            track(this); // track: implicit-receiver-obj2
+            track(this.x); // track: implicit-receiver-obj2 track: implicit-receiver-prop
+        }
+    }
+    return obj2;
+}
+let obj2 = factory2()
+obj2.x = trackedProp;


### PR DESCRIPTION
This PR is a journey for me into better understanding the JS CodeQL analysis, by trying to write tests to show the effect of https://github.com/github/codeql/pull/15823. I've written some tests that initially fail on commit 245cd5c0b5965667858f903e9948ceb1f20ed63b (parent of PR merge commit), and then tested them again on 7c35309732dd2aa4dc0b4e2949922272ad448854 (PR merge commit)

I was able to highlight the effect of the [Detect more FunctionStyleClasses commit](https://github.com/github/codeql/pull/15823/commits/a54a73c9a2d473da215aaa94ad08cd14b816f190), see the change in `javascript/ql/test/ApiGraphs/classes/VerifyAssertions.expected`.

I had expected that the step defined here https://github.com/github/codeql/blob/13e3a5158eaa3f8c685ab342e2fba64cac10b296/javascript/ql/lib/semmle/javascript/dataflow/internal/StepSummary.qll#L120-L121 would cause at least the `obj_` type-tracking test to pass after the changes in the PR, but that was not the case.

So I wasn't able to write a test that highlights the impact of the change in https://github.com/github/codeql/pull/15823/commits/f5d014baa5666f58ea80538b9ae364626892091d, even though I can see the change in `impliedReceiverStep` when quick-eval'ing locally. @asgerf can you highlight the end-result impact of that commit? :confused: