### PR TITLE
C#: Fully qualified name.

### DIFF
--- a/csharp/ql/integration-tests/all-platforms/diag_recursive_generics/Types.ql
+++ b/csharp/ql/integration-tests/all-platforms/diag_recursive_generics/Types.ql
@@ -1,6 +1,5 @@
 import csharp
-import semmle.code.csharp.commons.QualifiedName
 
-from Class c, string qualifier, string name
-where c.fromSource() and c.getBaseClass().hasFullyQualifiedName(qualifier, name)
-select c, getQualifiedName(qualifier, name)
+from Class c
+where c.fromSource()
+select c, c.getBaseClass().getFullyQualifiedNameDebug()

--- a/csharp/ql/integration-tests/all-platforms/diag_recursive_generics/Types.ql
+++ b/csharp/ql/integration-tests/all-platforms/diag_recursive_generics/Types.ql
@@ -1,5 +1,6 @@
 import csharp
+import semmle.code.csharp.commons.QualifiedName
 
-from Class c
-where c.fromSource()
-select c, c.getBaseClass().getFullyQualifiedName()
+from Class c, string qualifier, string name
+where c.fromSource() and c.getBaseClass().hasFullyQualifiedName(qualifier, name)
+select c, getQualifiedName(qualifier, name)

--- a/csharp/ql/lib/semmle/code/csharp/Element.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Element.qll
@@ -118,7 +118,6 @@ class NamedElement extends Element, @named_element {
    * Unbound generic types, such as `IList<T>`, are represented as
    * ``System.Collections.Generic.IList`1``.
    */
-  cached
   deprecated final string getFullyQualifiedName() {
     exists(string qualifier, string name | this.hasFullyQualifiedName(qualifier, name) |
       if qualifier = "" then result = name else result = qualifier + "." + name

--- a/csharp/ql/lib/semmle/code/csharp/Element.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Element.qll
@@ -102,6 +102,8 @@ class NamedElement extends Element, @named_element {
   final predicate hasName(string name) { name = this.getName() }
 
   /**
+   * DEPRECATED: Use `hasFullyQualifiedName` instead.
+   *
    * Gets the fully qualified name of this element, for example the
    * fully qualified name of `M` on line 3 is `N.C.M` in
    *
@@ -117,7 +119,7 @@ class NamedElement extends Element, @named_element {
    * ``System.Collections.Generic.IList`1``.
    */
   cached
-  final string getFullyQualifiedName() {
+  deprecated final string getFullyQualifiedName() {
     exists(string qualifier, string name | this.hasFullyQualifiedName(qualifier, name) |
       if qualifier = "" then result = name else result = qualifier + "." + name
     )

--- a/csharp/ql/lib/semmle/code/csharp/Element.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Element.qll
@@ -112,25 +112,6 @@ class NamedElement extends Element, @named_element {
    *   }
    * }
    * ```
-   */
-  cached
-  deprecated final string getQualifiedName() {
-    exists(string qualifier, string name | this.hasQualifiedName(qualifier, name) |
-      if qualifier = "" then result = name else result = qualifier + "." + name
-    )
-  }
-
-  /**
-   * Gets the fully qualified name of this element, for example the
-   * fully qualified name of `M` on line 3 is `N.C.M` in
-   *
-   * ```csharp
-   * namespace N {
-   *   class C {
-   *     void M(int i, string s) { }
-   *   }
-   * }
-   * ```
    *
    * Unbound generic types, such as `IList<T>`, are represented as
    * ``System.Collections.Generic.IList`1``.
@@ -140,16 +121,6 @@ class NamedElement extends Element, @named_element {
     exists(string qualifier, string name | this.hasFullyQualifiedName(qualifier, name) |
       if qualifier = "" then result = name else result = qualifier + "." + name
     )
-  }
-
-  /**
-   * DEPRECATED: Use `hasFullyQualifiedName` instead.
-   *
-   * Holds if this element has the qualified name `qualifier`.`name`.
-   */
-  cached
-  deprecated predicate hasQualifiedName(string qualifier, string name) {
-    qualifier = "" and name = this.getName()
   }
 
   /** Holds if this element has the fully qualified name `qualifier`.`name`. */

--- a/csharp/ql/lib/semmle/code/csharp/Element.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Element.qll
@@ -124,6 +124,33 @@ class NamedElement extends Element, @named_element {
     )
   }
 
+  /**
+   * INTERNAL: Do not use.
+   *
+   * This is intended for DEBUG ONLY.
+   * Constructing the fully qualified name for all elements in a large codebase
+   * puts severe stress on the string pool.
+   *
+   * Gets the fully qualified name of this element, for example the
+   * fully qualified name of `M` on line 3 is `N.C.M` in
+   *
+   * ```csharp
+   * namespace N {
+   *   class C {
+   *     void M(int i, string s) { }
+   *   }
+   * }
+   * ```
+   *
+   * Unbound generic types, such as `IList<T>`, are represented as
+   * ``System.Collections.Generic.IList`1``.
+   */
+  final string getFullyQualifiedNameDebug() {
+    exists(string qualifier, string name | this.hasFullyQualifiedName(qualifier, name) |
+      if qualifier = "" then result = name else result = qualifier + "." + name
+    )
+  }
+
   /** Holds if this element has the fully qualified name `qualifier`.`name`. */
   cached
   predicate hasFullyQualifiedName(string qualifier, string name) {

--- a/csharp/ql/lib/semmle/code/csharp/Element.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Element.qll
@@ -145,6 +145,8 @@ class NamedElement extends Element, @named_element {
    * Unbound generic types, such as `IList<T>`, are represented as
    * ``System.Collections.Generic.IList`1``.
    */
+  bindingset[this]
+  pragma[inline_late]
   final string getFullyQualifiedNameDebug() {
     exists(string qualifier, string name | this.hasFullyQualifiedName(qualifier, name) |
       if qualifier = "" then result = name else result = qualifier + "." + name

--- a/csharp/ql/lib/semmle/code/csharp/Member.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Member.qll
@@ -71,35 +71,8 @@ class Declaration extends NamedElement, @declaration {
 
   override string toString() { result = this.getName() }
 
-  deprecated override predicate hasQualifiedName(string qualifier, string name) {
-    QualifiedName<QualifiedNameInput>::hasQualifiedName(this, qualifier, name)
-  }
-
   override predicate hasFullyQualifiedName(string qualifier, string name) {
     QualifiedName<FullyQualifiedNameInput>::hasQualifiedName(this, qualifier, name)
-  }
-
-  /**
-   * DEPRECATED: Use `getFullyQualifiedNameWithTypes` instead.
-   *
-   * Gets the fully qualified name of this declaration, including types, for example
-   * the fully qualified name with types of `M` on line 3 is `N.C.M(int, string)` in
-   *
-   * ```csharp
-   * namespace N {
-   *   class C {
-   *     void M(int i, string s) { }
-   *   }
-   * }
-   * ```
-   */
-  deprecated string getQualifiedNameWithTypes() {
-    exists(string qual |
-      qual = this.getDeclaringType().getQualifiedName() and
-      if this instanceof NestedType
-      then result = qual + "+" + this.toStringWithTypes()
-      else result = qual + "." + this.toStringWithTypes()
-    )
   }
 
   /**
@@ -262,17 +235,6 @@ class Modifiable extends Declaration, @modifiable {
 class Member extends Modifiable, @member {
   /** Gets an access to this member. */
   MemberAccess getAnAccess() { result.getTarget() = this }
-
-  /**
-   * DEPRECATED: Use `hasFullyQualifiedName` instead.
-   *
-   * Holds if this member has name `name` and is defined in type `type`
-   * with namespace `namespace`.
-   */
-  cached
-  deprecated final predicate hasQualifiedName(string namespace, string type, string name) {
-    QualifiedName<QualifiedNameInput>::hasQualifiedName(this, namespace, type, name)
-  }
 
   /**
    * Holds if this member has name `name` and is defined in type `type`

--- a/csharp/ql/lib/semmle/code/csharp/Member.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Member.qll
@@ -87,7 +87,7 @@ class Declaration extends NamedElement, @declaration {
    * }
    * ```
    */
-  string getFullyQualifiedNameWithTypes() {
+  deprecated string getFullyQualifiedNameWithTypes() {
     exists(string fullqual, string qual, string name |
       this.getDeclaringType().hasFullyQualifiedName(qual, name) and
       fullqual = getQualifiedName(qual, name) and

--- a/csharp/ql/lib/semmle/code/csharp/Member.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Member.qll
@@ -88,11 +88,12 @@ class Declaration extends NamedElement, @declaration {
    * ```
    */
   string getFullyQualifiedNameWithTypes() {
-    exists(string qual |
-      qual = this.getDeclaringType().getFullyQualifiedName() and
+    exists(string fullqual, string qual, string name |
+      this.getDeclaringType().hasFullyQualifiedName(qual, name) and
+      fullqual = getQualifiedName(qual, name) and
       if this instanceof NestedType
-      then result = qual + "+" + this.toStringWithTypes()
-      else result = qual + "." + this.toStringWithTypes()
+      then result = fullqual + "+" + this.toStringWithTypes()
+      else result = fullqual + "." + this.toStringWithTypes()
     )
   }
 

--- a/csharp/ql/lib/semmle/code/csharp/Namespace.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Namespace.qll
@@ -44,16 +44,6 @@ class Namespace extends TypeContainer, Declaration, @namespace {
    * For example if the qualified name is `System.Collections.Generic`, then
    * `qualifier`=`System.Collections` and `name`=`Generic`.
    */
-  deprecated override predicate hasQualifiedName(string qualifier, string name) {
-    namespaceHasQualifiedName(this, qualifier, name)
-  }
-
-  /**
-   * Holds if this namespace has the qualified name `qualifier`.`name`.
-   *
-   * For example if the qualified name is `System.Collections.Generic`, then
-   * `qualifier`=`System.Collections` and `name`=`Generic`.
-   */
   override predicate hasFullyQualifiedName(string qualifier, string name) {
     namespaceHasQualifiedName(this, qualifier, name)
   }

--- a/csharp/ql/lib/semmle/code/csharp/commons/QualifiedName.qll
+++ b/csharp/ql/lib/semmle/code/csharp/commons/QualifiedName.qll
@@ -219,3 +219,28 @@ predicate splitQualifiedName(string qualifiedName, string qualifier, string name
     name = qualifiedName
   )
 }
+
+/**
+ * INTERNAL: Do not use.
+ *
+ * Gets the fully qualified name of this declaration, including types, for example
+ * the fully qualified name with types of `M` on line 3 is `N.C.M(int, string)` in
+ *
+ * ```csharp
+ * namespace N {
+ *   class C {
+ *     void M(int i, string s) { }
+ *   }
+ * }
+ * ```
+ */
+bindingset[d]
+string getFullyQualifiedNameWithTypes(Declaration d) {
+  exists(string fullqual, string qual, string name |
+    d.getDeclaringType().hasFullyQualifiedName(qual, name) and
+    fullqual = getQualifiedName(qual, name) and
+    if d instanceof NestedType
+    then result = fullqual + "+" + d.toStringWithTypes()
+    else result = fullqual + "." + d.toStringWithTypes()
+  )
+}

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/SSA.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/SSA.qll
@@ -3,6 +3,7 @@
  */
 
 import csharp
+private import semmle.code.csharp.commons.QualifiedName
 
 /**
  * Provides classes for working with static single assignment (SSA) form.
@@ -120,7 +121,12 @@ module Ssa {
           result = prefix + "." + this.getAssignable()
         |
           if f.(Modifiable).isStatic()
-          then prefix = f.getDeclaringType().getFullyQualifiedName()
+          then
+            exists(string qualifier, string name |
+              f.getDeclaringType().hasFullyQualifiedName(qualifier, name)
+            |
+              prefix = getQualifiedName(qualifier, name)
+            )
           else prefix = "this"
         )
       }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/SSA.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/SSA.qll
@@ -3,7 +3,6 @@
  */
 
 import csharp
-private import semmle.code.csharp.commons.QualifiedName
 
 /**
  * Provides classes for working with static single assignment (SSA) form.
@@ -121,12 +120,7 @@ module Ssa {
           result = prefix + "." + this.getAssignable()
         |
           if f.(Modifiable).isStatic()
-          then
-            exists(string qualifier, string name |
-              f.getDeclaringType().hasFullyQualifiedName(qualifier, name)
-            |
-              prefix = getQualifiedName(qualifier, name)
-            )
+          then prefix = f.getDeclaringType().getName()
           else prefix = "this"
         )
       }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
@@ -3,6 +3,7 @@
  */
 
 private import csharp
+private import semmle.code.csharp.commons.QualifiedName
 private import semmle.code.csharp.frameworks.system.linq.Expressions
 private import codeql.dataflow.internal.FlowSummaryImpl
 private import codeql.dataflow.internal.AccessPathSyntax as AccessPath
@@ -42,10 +43,18 @@ module Input implements InputSig<Location, DataFlowImplSpecific::CsharpDataFlow>
   string encodeContent(ContentSet c, string arg) {
     c = TElementContent() and result = "Element" and arg = ""
     or
-    exists(Field f | c = TFieldContent(f) and result = "Field" and arg = f.getFullyQualifiedName())
+    exists(Field f, string qualifier, string name |
+      c = TFieldContent(f) and
+      f.hasFullyQualifiedName(qualifier, name) and
+      arg = getQualifiedName(qualifier, name) and
+      result = "Field"
+    )
     or
-    exists(Property p |
-      c = TPropertyContent(p) and result = "Property" and arg = p.getFullyQualifiedName()
+    exists(Property p, string qualifier, string name |
+      c = TPropertyContent(p) and
+      p.hasFullyQualifiedName(qualifier, name) and
+      arg = getQualifiedName(qualifier, name) and
+      result = "Property"
     )
     or
     exists(SyntheticField f |

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/ExternalAPIsQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/ExternalAPIsQuery.qll
@@ -139,13 +139,13 @@ class ExternalApiUsedWithUntrustedData extends TExternalApi {
 
   /** Gets a textual representation of this element. */
   string toString() {
-    exists(Callable m, int index, string indexString |
+    exists(Callable m, int index, string indexString, string qualifier, string name |
       if index = -1 then indexString = "qualifier" else indexString = "param " + index
     |
       this = TExternalApiParameter(m, index) and
+      m.getDeclaringType().hasFullyQualifiedName(qualifier, name) and
       result =
-        m.getDeclaringType().getFullyQualifiedName() + "." + m.toStringWithTypes() + " [" +
-          indexString + "]"
+        getQualifiedName(qualifier, name) + "." + m.toStringWithTypes() + " [" + indexString + "]"
     )
   }
 }

--- a/csharp/ql/test/library-tests/attributes/AttributeElements.ql
+++ b/csharp/ql/test/library-tests/attributes/AttributeElements.ql
@@ -1,9 +1,7 @@
 import csharp
-import semmle.code.csharp.commons.QualifiedName
 
-from Attributable element, Attribute attribute, string qualifier, string name
+from Attributable element, Attribute attribute
 where
   attribute = element.getAnAttribute() and
-  (attribute.fromSource() or element.(Assembly).getName() in ["attributes", "Assembly1"]) and
-  attribute.getType().hasFullyQualifiedName(qualifier, name)
-select element, attribute, getQualifiedName(qualifier, name)
+  (attribute.fromSource() or element.(Assembly).getName() in ["attributes", "Assembly1"])
+select element, attribute, attribute.getType().getFullyQualifiedNameDebug()

--- a/csharp/ql/test/library-tests/constructors/Destructors1.ql
+++ b/csharp/ql/test/library-tests/constructors/Destructors1.ql
@@ -3,11 +3,10 @@
  */
 
 import csharp
-import semmle.code.csharp.commons.QualifiedName
 
 from Destructor c, string qualifier, string name
 where
   c.getDeclaringType().hasFullyQualifiedName(qualifier, name) and
   qualifier = "Constructors" and
   name = "Class"
-select c, getQualifiedName(qualifier, name)
+select c, c.getDeclaringType().getFullyQualifiedNameDebug()

--- a/csharp/ql/test/library-tests/constructors/Destructors1.ql
+++ b/csharp/ql/test/library-tests/constructors/Destructors1.ql
@@ -10,4 +10,4 @@ where
   c.getDeclaringType().hasFullyQualifiedName(qualifier, name) and
   qualifier = "Constructors" and
   name = "Class"
-select c, c.getDeclaringType().getFullyQualifiedName()
+select c, getQualifiedName(qualifier, name)

--- a/csharp/ql/test/library-tests/csharp11/fileScoped.ql
+++ b/csharp/ql/test/library-tests/csharp11/fileScoped.ql
@@ -1,5 +1,4 @@
 import csharp
-private import semmle.code.csharp.commons.QualifiedName
 
 private predicate isInteresting(Type t) {
   (
@@ -20,10 +19,7 @@ query predicate typemodifiers(Type t, string modifier) {
 
 query predicate qualifiedtypes(Type t, string qualifiedName) {
   isInteresting(t) and
-  exists(string qualifier, string name |
-    t.hasFullyQualifiedName(qualifier, name) and
-    qualifiedName = getQualifiedName(qualifier, name)
-  )
+  qualifiedName = t.getFullyQualifiedNameDebug()
 }
 
 query predicate filetypes(Type t) {

--- a/csharp/ql/test/library-tests/csharp11/nativeInt.ql
+++ b/csharp/ql/test/library-tests/csharp11/nativeInt.ql
@@ -1,12 +1,10 @@
 import csharp
-import semmle.code.csharp.commons.QualifiedName
 
-from LocalVariable v1, LocalVariable v2, Type t, string qualifier, string name
+from LocalVariable v1, LocalVariable v2, Type t
 where
   v1.getFile().getStem() = "NativeInt" and
   v2.getFile().getStem() = "NativeInt" and
   t = v1.getType() and
   t = v2.getType() and
-  t.hasFullyQualifiedName(qualifier, name) and
   v1 != v2
-select v1, v2, getQualifiedName(qualifier, name)
+select v1, v2, t.getFullyQualifiedNameDebug()

--- a/csharp/ql/test/library-tests/csharp9/covariantReturn.ql
+++ b/csharp/ql/test/library-tests/csharp9/covariantReturn.ql
@@ -1,13 +1,8 @@
 import csharp
-import semmle.code.csharp.commons.QualifiedName
 
-from
-  Method m, Method overrider, string mnamespace, string mtype, string mname, string onamespace,
-  string otype, string oname
+from Method m, Method overrider
 where
   m.getAnOverrider() = overrider and
-  m.getFile().getStem() = "CovariantReturn" and
-  m.hasFullyQualifiedName(mnamespace, mtype, mname) and
-  overrider.hasFullyQualifiedName(onamespace, otype, oname)
-select getQualifiedName(mnamespace, mtype, mname), m.getReturnType().toString(),
-  getQualifiedName(onamespace, otype, oname), overrider.getReturnType().toString()
+  m.getFile().getStem() = "CovariantReturn"
+select m.getFullyQualifiedNameDebug(), m.getReturnType().toString(),
+  overrider.getFullyQualifiedNameDebug(), overrider.getReturnType().toString()

--- a/csharp/ql/test/library-tests/csharp9/foreach.ql
+++ b/csharp/ql/test/library-tests/csharp9/foreach.ql
@@ -1,5 +1,4 @@
 import csharp
-import semmle.code.csharp.commons.QualifiedName
 
 private string getLocation(Member m) {
   if m.fromSource() then result = m.getALocation().(SourceLocation).toString() else result = "-"
@@ -9,13 +8,9 @@ private string getIsAsync(ForeachStmt f) {
   if f.isAsync() then result = "async" else result = "sync"
 }
 
-from
-  ForeachStmt f, string qualifier1, string type1, string qualifier2, string type2,
-  string qualifier3, string type3
-where
-  f.getGetEnumerator().getDeclaringType().hasFullyQualifiedName(qualifier1, type1) and
-  f.getCurrent().getDeclaringType().hasFullyQualifiedName(qualifier2, type2) and
-  f.getMoveNext().getDeclaringType().hasFullyQualifiedName(qualifier3, type3)
-select f, f.getElementType().toString(), getIsAsync(f), getQualifiedName(qualifier1, type1),
-  getLocation(f.getGetEnumerator()), getQualifiedName(qualifier2, type2),
-  getLocation(f.getCurrent()), getQualifiedName(qualifier3, type3), getLocation(f.getMoveNext())
+from ForeachStmt f
+select f, f.getElementType().toString(), getIsAsync(f),
+  f.getGetEnumerator().getDeclaringType().getFullyQualifiedNameDebug(),
+  getLocation(f.getGetEnumerator()), f.getCurrent().getDeclaringType().getFullyQualifiedNameDebug(),
+  getLocation(f.getCurrent()), f.getMoveNext().getDeclaringType().getFullyQualifiedNameDebug(),
+  getLocation(f.getMoveNext())

--- a/csharp/ql/test/library-tests/csharp9/record.ql
+++ b/csharp/ql/test/library-tests/csharp9/record.ql
@@ -7,18 +7,10 @@ query predicate records(RecordClass t, string i, RecordCloneMethod clone) {
   t.fromSource()
 }
 
-private string getMemberName(Member m) {
-  exists(string qualifier, string name |
-    m.getDeclaringType().hasFullyQualifiedName(qualifier, name)
-  |
-    result = getQualifiedName(qualifier, name) + "." + m.toStringWithTypes()
-  )
-}
-
 query predicate members(RecordClass t, string ms, string l) {
   t.fromSource() and
   exists(Member m | t.hasMember(m) |
-    ms = getMemberName(m) and
+    ms = getFullyQualifiedNameWithTypes(m) and
     if m.fromSource() then l = m.getLocation().toString() else l = "no location"
   )
 }

--- a/csharp/ql/test/library-tests/csharp9/withExpr.ql
+++ b/csharp/ql/test/library-tests/csharp9/withExpr.ql
@@ -1,19 +1,11 @@
 import csharp
 import semmle.code.csharp.commons.QualifiedName
 
-private string getSignature(Method m) {
-  exists(string qualifier, string name |
-    m.getDeclaringType().hasFullyQualifiedName(qualifier, name)
-  |
-    result = getQualifiedName(qualifier, name) + "." + m.toStringWithTypes()
-  )
-}
-
 query predicate withExpr(WithExpr with, string type, Expr expr, ObjectInitializer init, string clone) {
   type = with.getType().toStringWithTypes() and
   expr = with.getExpr() and
   init = with.getInitializer() and
-  clone = getSignature(with.getCloneMethod())
+  clone = getFullyQualifiedNameWithTypes(with.getCloneMethod())
 }
 
 query predicate withTarget(WithExpr with, RecordCloneMethod clone, Constructor ctor) {
@@ -25,7 +17,7 @@ query predicate cloneOverrides(string b, string o) {
   exists(RecordCloneMethod base, RecordCloneMethod overrider |
     base.getDeclaringType().fromSource() and
     base.getAnOverrider() = overrider and
-    b = getSignature(base) and
-    o = getSignature(overrider)
+    b = getFullyQualifiedNameWithTypes(base) and
+    o = getFullyQualifiedNameWithTypes(overrider)
   )
 }

--- a/csharp/ql/test/library-tests/dispatch/GetADynamicTarget.ql
+++ b/csharp/ql/test/library-tests/dispatch/GetADynamicTarget.ql
@@ -1,8 +1,9 @@
 import csharp
+import semmle.code.csharp.commons.QualifiedName
 import semmle.code.csharp.dispatch.Dispatch
 
 from DispatchCall call, Callable callable
 where
   callable = call.getADynamicTarget() and
   callable.fromSource()
-select call, callable.getFullyQualifiedNameWithTypes()
+select call, getFullyQualifiedNameWithTypes(callable)

--- a/csharp/ql/test/library-tests/enums/Enums3.ql
+++ b/csharp/ql/test/library-tests/enums/Enums3.ql
@@ -3,13 +3,11 @@
  */
 
 import csharp
-import semmle.code.csharp.commons.QualifiedName
 
-from EnumConstant c, string namespace, string name
+from EnumConstant c
 where
   c.getName() = "Green" and
   c.getDeclaringType().hasFullyQualifiedName("Enums", "LongColor") and
   c.getType() = c.getDeclaringType() and
-  c.getValue() = "1" and
-  c.getDeclaringType().getBaseClass().hasFullyQualifiedName(namespace, name)
-select c, getQualifiedName(namespace, name)
+  c.getValue() = "1"
+select c, c.getDeclaringType().getBaseClass().getFullyQualifiedNameDebug()

--- a/csharp/ql/test/library-tests/frameworks/system/Dispose/Dispose.ql
+++ b/csharp/ql/test/library-tests/frameworks/system/Dispose/Dispose.ql
@@ -1,4 +1,5 @@
 import csharp
+import semmle.code.csharp.commons.QualifiedName
 import semmle.code.csharp.frameworks.System
 
 from ValueOrRefType t, Method m, boolean b
@@ -6,4 +7,4 @@ where
   t.fromSource() and
   m = getInvokedDisposeMethod(t) and
   if implementsDispose(t) then b = true else b = false
-select t, m.getFullyQualifiedNameWithTypes(), b
+select t, getFullyQualifiedNameWithTypes(m), b

--- a/csharp/ql/test/library-tests/frameworks/system/Equals/Equals.ql
+++ b/csharp/ql/test/library-tests/frameworks/system/Equals/Equals.ql
@@ -1,4 +1,5 @@
 import csharp
+import semmle.code.csharp.commons.QualifiedName
 import semmle.code.csharp.frameworks.System
 
 from ValueOrRefType t, Method m, boolean b
@@ -6,4 +7,4 @@ where
   t.fromSource() and
   m = getInvokedEqualsMethod(t) and
   if implementsEquals(t) then b = true else b = false
-select t, m.getFullyQualifiedNameWithTypes(), b
+select t, getFullyQualifiedNameWithTypes(m), b

--- a/csharp/ql/test/library-tests/generics/Generics.ql
+++ b/csharp/ql/test/library-tests/generics/Generics.ql
@@ -268,16 +268,12 @@ query predicate test33(ConstructedMethod cm, string s1, string s2) {
 
 query predicate test34(UnboundGeneric ug, string s1, string s2) {
   ug.fromSource() and
-  exists(string qualifier, string name |
-    ug.hasFullyQualifiedName(qualifier, name) and s1 = getQualifiedName(qualifier, name)
-  ) and
-  getFullyQualifiedNameWithTypes(ug) = s2
+  s1 = ug.getFullyQualifiedNameDebug() and
+  s2 = getFullyQualifiedNameWithTypes(ug)
 }
 
 query predicate test35(UnboundGenericMethod gm, string s1, string s2) {
   gm.fromSource() and
-  exists(string namespace, string type, string name |
-    gm.hasFullyQualifiedName(namespace, type, name) and s1 = getQualifiedName(namespace, type, name)
-  ) and
-  getFullyQualifiedNameWithTypes(gm) = s2
+  s1 = gm.getFullyQualifiedNameDebug() and
+  s2 = getFullyQualifiedNameWithTypes(gm)
 }

--- a/csharp/ql/test/library-tests/generics/Generics.ql
+++ b/csharp/ql/test/library-tests/generics/Generics.ql
@@ -231,18 +231,18 @@ query predicate test27(ConstructedType ct, UnboundGenericType ugt, UnboundGeneri
 
 query predicate test28(UnboundGeneric ug, string s) {
   ug.fromSource() and
-  s = ug.getFullyQualifiedNameWithTypes()
+  s = getFullyQualifiedNameWithTypes(ug)
 }
 
 query predicate test29(ConstructedGeneric cg, string s) {
   cg.fromSource() and
-  s = cg.getFullyQualifiedNameWithTypes()
+  s = getFullyQualifiedNameWithTypes(cg)
 }
 
 query predicate test30(Declaration d, string s) {
   d.fromSource() and
   d instanceof @generic and
-  s = d.getFullyQualifiedNameWithTypes() and
+  s = getFullyQualifiedNameWithTypes(d) and
   d != d.getUnboundDeclaration() and
   not d instanceof Generic
 }
@@ -263,7 +263,7 @@ query predicate test33(ConstructedMethod cm, string s1, string s2) {
   exists(string namespace, string type, string name |
     cm.hasFullyQualifiedName(namespace, type, name) and s1 = getQualifiedName(namespace, type, name)
   ) and
-  cm.getFullyQualifiedNameWithTypes() = s2
+  getFullyQualifiedNameWithTypes(cm) = s2
 }
 
 query predicate test34(UnboundGeneric ug, string s1, string s2) {
@@ -271,7 +271,7 @@ query predicate test34(UnboundGeneric ug, string s1, string s2) {
   exists(string qualifier, string name |
     ug.hasFullyQualifiedName(qualifier, name) and s1 = getQualifiedName(qualifier, name)
   ) and
-  ug.getFullyQualifiedNameWithTypes() = s2
+  getFullyQualifiedNameWithTypes(ug) = s2
 }
 
 query predicate test35(UnboundGenericMethod gm, string s1, string s2) {
@@ -279,5 +279,5 @@ query predicate test35(UnboundGenericMethod gm, string s1, string s2) {
   exists(string namespace, string type, string name |
     gm.hasFullyQualifiedName(namespace, type, name) and s1 = getQualifiedName(namespace, type, name)
   ) and
-  gm.getFullyQualifiedNameWithTypes() = s2
+  getFullyQualifiedNameWithTypes(gm) = s2
 }

--- a/csharp/ql/test/library-tests/overrides/Overrides22.ql
+++ b/csharp/ql/test/library-tests/overrides/Overrides22.ql
@@ -1,4 +1,5 @@
 import csharp
+import semmle.code.csharp.commons.QualifiedName
 
 from Overridable v1, Overridable v2, string kind
 where
@@ -9,4 +10,4 @@ where
   ) and
   v1.fromSource() and
   v2.fromSource()
-select v1.getFullyQualifiedNameWithTypes(), v2.getFullyQualifiedNameWithTypes(), kind
+select getFullyQualifiedNameWithTypes(v1), getFullyQualifiedNameWithTypes(v2), kind

--- a/csharp/ql/test/library-tests/unification/Unification.ql
+++ b/csharp/ql/test/library-tests/unification/Unification.ql
@@ -1,3 +1,4 @@
+import semmle.code.csharp.commons.QualifiedName
 import semmle.code.csharp.Unification
 
 class InterestingType extends @type {
@@ -7,9 +8,9 @@ class InterestingType extends @type {
   }
 
   string toString() {
-    result = this.(Type).getFullyQualifiedNameWithTypes()
+    result = getFullyQualifiedNameWithTypes(this.(Type))
     or
-    not exists(this.(Type).getFullyQualifiedNameWithTypes()) and
+    not exists(getFullyQualifiedNameWithTypes(this.(Type))) and
     result = this.(Type).toStringWithTypes()
   }
 


### PR DESCRIPTION
In this PR we replace the last uses of `getFullyQualifiedName` and `getFullyQualifiedNameWithTypes` (and deprecate and uncache these) with their `hasFully..` counterparts to avoid unneeded string concatenation (and thus pressure on the string pool).
Further more we delete some of the deprecated caches predicates.