### PR TITLE
[cpp-docs] Fix 404 link in guards library doc.

### DIFF
--- a/docs/codeql/codeql-language-guides/using-the-guards-library-in-cpp.rst
+++ b/docs/codeql/codeql-language-guides/using-the-guards-library-in-cpp.rst
@@ -8,7 +8,7 @@ You can use the CodeQL guards library to identify conditional expressions that c
 About the guards library
 ------------------------
 
-The guards library (defined in ``semmle.code.cpp.controlflow.Guards``) provides a class `GuardCondition <https://codeql.github.com/codeql-standard-libraries/cpp/semmle/code/cpp/controlflow/Guards.qll/type.Guards$GuardCondition.html>`__ representing Boolean values that are used to make control flow decisions.
+The guards library (defined in ``semmle.code.cpp.controlflow.Guards``) provides a class `GuardCondition <https://codeql.github.com/codeql-standard-libraries/cpp/semmle/code/cpp/controlflow/IRGuards.qll/type.IRGuards$GuardCondition.html>`__ representing Boolean values that are used to make control flow decisions.
 A ``GuardCondition`` is considered to guard a basic block if the block can only be reached if the ``GuardCondition`` is evaluated a certain way. For instance, in the following code, ``x < 10`` is a ``GuardCondition``, and it guards all the code before the return statement.
 
 .. code-block:: cpp


### PR DESCRIPTION
Old link returns 404 for me.