### PR TITLE
C#: Remove hard-coded local sources from the uncontrolled-format-string query.

### DIFF
--- a/csharp/ql/src/Security Features/CWE-134/UncontrolledFormatString.ql
+++ b/csharp/ql/src/Security Features/CWE-134/UncontrolledFormatString.ql
@@ -17,9 +17,7 @@ import semmle.code.csharp.frameworks.Format
 import FormatString::PathGraph
 
 module FormatStringConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) {
-    source instanceof ThreatModelFlowSource or source instanceof LocalFlowSource
-  }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) {
     sink.asExpr() = any(FormatCall call | call.hasInsertions()).getFormatExpr()


### PR DESCRIPTION


Follow up for https://github.com/github/codeql/pull/15756