### PR TITLE
C++: suppress destructors with reuse expressions until proper support is added

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedElement.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedElement.qll
@@ -99,6 +99,11 @@ private predicate ignoreExprAndDescendants(Expr expr) {
   or
   // suppress destructors of temporary variables until proper support is added for them.
   exists(Expr parent | parent.getAnImplicitDestructorCall() = expr)
+  or
+  exists(Stmt parent |
+    parent.getAnImplicitDestructorCall() = expr and
+    expr.(DestructorCall).getQualifier() instanceof ReuseExpr
+  )
 }
 
 /**


### PR DESCRIPTION
Final preparatory PR on the QL-side for the destructors of unnamed entities work.