### PR TITLE
Go: Consider more strings as hardcoded credentials

### DIFF
--- a/go/ql/lib/semmle/go/security/HardcodedCredentials.qll
+++ b/go/ql/lib/semmle/go/security/HardcodedCredentials.qll
@@ -37,11 +37,7 @@ module HardcodedCredentials {
 
   /** A hardcoded string literal as a source for hardcoded credentials. */
   private class HardcodedStringSource extends Source {
-    HardcodedStringSource() {
-      exists(StringLit val | this.asExpr() = val |
-        not PasswordHeuristics::isDummyPassword(val.getStringValue())
-      )
-    }
+    HardcodedStringSource() { this.asExpr() instanceof StringLit }
   }
 
   /** A use of a credential. */

--- a/go/ql/src/Security/CWE-798/HardcodedCredentials.ql
+++ b/go/ql/src/Security/CWE-798/HardcodedCredentials.ql
@@ -60,6 +60,6 @@ where
   message = "Hard-coded private key."
   or
   HardcodedCredentials::Flow::flow(source, sink) and
-  type = SensitiveExpr::password() and
-  message = "Hard-coded credential."
+  type = SensitiveExpr::secret() and
+  message = "Hard-coded $@."
 select sink, message, source, type.toString()

--- a/go/ql/src/change-notes/2024-03-14-hardcoded-credentials-more-sources.md
+++ b/go/ql/src/change-notes/2024-03-14-hardcoded-credentials-more-sources.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The query `go/hardcoded-credentials` no longer discards string literals based on "weak password" heuristics.

--- a/go/ql/test/query-tests/Security/CWE-798/HardcodedCredentials.expected
+++ b/go/ql/test/query-tests/Security/CWE-798/HardcodedCredentials.expected
@@ -1,28 +1,28 @@
 | AlertSuppressionExample.go:11:14:11:40 | "horsebatterystaplecorrect" | Hard-coded $@. | AlertSuppressionExample.go:11:14:11:40 | "horsebatterystaplecorrect" | password |
 | HardcodedCredentials.go:10:13:10:28 | "s3cretp4ssword" | Hard-coded $@. | HardcodedCredentials.go:10:13:10:28 | "s3cretp4ssword" | password |
-| HardcodedKeysBad.go:19:28:19:39 | mySigningKey | Hard-coded credential. | HardcodedKeysBad.go:11:25:11:37 | "AllYourBase" | password |
-| jwt.go:42:28:42:39 | mySigningKey | Hard-coded credential. | jwt.go:33:25:33:30 | "key1" | password |
-| jwt.go:49:16:49:29 | type conversion | Hard-coded credential. | jwt.go:49:23:49:28 | "key2" | password |
-| jwt.go:68:44:68:46 | key | Hard-coded credential. | jwt.go:67:16:67:21 | `key3` | password |
-| jwt.go:73:66:73:68 | key | Hard-coded credential. | jwt.go:72:16:72:21 | "key4" | password |
-| jwt.go:81:15:81:18 | key2 | Hard-coded credential. | jwt.go:76:17:76:22 | "key5" | password |
-| jwt.go:91:41:91:43 | key | Hard-coded credential. | jwt.go:87:16:87:21 | "key6" | password |
-| jwt.go:98:66:98:69 | key2 | Hard-coded credential. | jwt.go:96:17:96:22 | "key7" | password |
-| jwt.go:109:30:109:32 | key | Hard-coded credential. | jwt.go:104:16:104:21 | "key8" | password |
-| jwt.go:114:16:114:24 | sharedKey | Hard-coded credential. | jwt.go:113:22:113:27 | "key9" | password |
-| jwt.go:120:16:120:30 | sharedKeyglobal | Hard-coded credential. | jwt.go:117:30:117:36 | "key10" | password |
-| jwt.go:126:20:126:34 | type conversion | Hard-coded credential. | jwt.go:126:27:126:33 | "key11" | password |
-| jwt.go:143:39:143:41 | key | Hard-coded credential. | jwt.go:141:16:141:22 | "key12" | password |
-| jwt.go:152:11:152:13 | key | Hard-coded credential. | jwt.go:148:16:148:22 | "key13" | password |
-| jwt.go:160:34:160:36 | key | Hard-coded credential. | jwt.go:159:16:159:22 | "key14" | password |
-| jwt.go:166:32:166:34 | key | Hard-coded credential. | jwt.go:165:16:165:22 | "key15" | password |
-| jwt.go:172:41:172:43 | key | Hard-coded credential. | jwt.go:171:16:171:22 | "key16" | password |
-| jwt.go:178:51:178:53 | key | Hard-coded credential. | jwt.go:177:16:177:22 | "key17" | password |
-| jwt.go:184:42:184:44 | key | Hard-coded credential. | jwt.go:183:16:183:22 | "key18" | password |
-| jwt.go:192:33:192:35 | key | Hard-coded credential. | jwt.go:189:16:189:22 | "key19" | password |
+| HardcodedKeysBad.go:19:28:19:39 | mySigningKey | Hard-coded $@. | HardcodedKeysBad.go:11:25:11:37 | "AllYourBase" | secret |
+| jwt.go:42:28:42:39 | mySigningKey | Hard-coded $@. | jwt.go:33:25:33:30 | "key1" | secret |
+| jwt.go:49:16:49:29 | type conversion | Hard-coded $@. | jwt.go:49:23:49:28 | "key2" | secret |
+| jwt.go:68:44:68:46 | key | Hard-coded $@. | jwt.go:67:16:67:21 | `key3` | secret |
+| jwt.go:73:66:73:68 | key | Hard-coded $@. | jwt.go:72:16:72:21 | "key4" | secret |
+| jwt.go:81:15:81:18 | key2 | Hard-coded $@. | jwt.go:76:17:76:22 | "key5" | secret |
+| jwt.go:91:41:91:43 | key | Hard-coded $@. | jwt.go:87:16:87:21 | "key6" | secret |
+| jwt.go:98:66:98:69 | key2 | Hard-coded $@. | jwt.go:96:17:96:22 | "key7" | secret |
+| jwt.go:109:30:109:32 | key | Hard-coded $@. | jwt.go:104:16:104:21 | "key8" | secret |
+| jwt.go:114:16:114:24 | sharedKey | Hard-coded $@. | jwt.go:113:22:113:27 | "key9" | secret |
+| jwt.go:120:16:120:30 | sharedKeyglobal | Hard-coded $@. | jwt.go:117:30:117:36 | "key10" | secret |
+| jwt.go:126:20:126:34 | type conversion | Hard-coded $@. | jwt.go:126:27:126:33 | "key11" | secret |
+| jwt.go:143:39:143:41 | key | Hard-coded $@. | jwt.go:141:16:141:22 | "key12" | secret |
+| jwt.go:152:11:152:13 | key | Hard-coded $@. | jwt.go:148:16:148:22 | "key13" | secret |
+| jwt.go:160:34:160:36 | key | Hard-coded $@. | jwt.go:159:16:159:22 | "key14" | secret |
+| jwt.go:166:32:166:34 | key | Hard-coded $@. | jwt.go:165:16:165:22 | "key15" | secret |
+| jwt.go:172:41:172:43 | key | Hard-coded $@. | jwt.go:171:16:171:22 | "key16" | secret |
+| jwt.go:178:51:178:53 | key | Hard-coded $@. | jwt.go:177:16:177:22 | "key17" | secret |
+| jwt.go:184:42:184:44 | key | Hard-coded $@. | jwt.go:183:16:183:22 | "key18" | secret |
+| jwt.go:192:33:192:35 | key | Hard-coded $@. | jwt.go:189:16:189:22 | "key19" | secret |
 | main.go:6:14:6:23 | "p4ssw0rd" | Hard-coded $@. | main.go:6:14:6:23 | "p4ssw0rd" | password |
 | main.go:12:1:26:30 | `-----BEGIN RSA PRIVATE KEY-----\nMIICXQIBAAKBgQC/tzdtXKXcX6F3v3hR6+uYyZpIeXhhLflJkY2eILLQfAnwKlT5\nxIHW5QZcHQV9sCyZ8qSdPGif7PwgMbButMbByiZhCSugUFb6vjVqoktmslYF4LKH\niDgvmlwuJW0TvynxBLzDCwrRP+gpRT8wuAortWAx/03POTw7Mzi2cIPNsQIDAQAB\nAoGAMHCrqY9CPTdQhgAz94cDpTwzJmLCvtMt7J/BR5X9eF4O6MbZZ652HAUMIVQX\n4hUUf+VmIHB2AwqO/ddwO9ijaz04BslOSy/iYevHGlH65q4587NSlFWjvILMIQCM\nGBjfzJIxlLHVhjc2cFnyAE5YWjF/OMnJN0OhP9pxmCP/iM0CQQDxmQndQLdnV7+6\n8SvBHE8bg1LE8/BzTt68U3aWwiBjrHMFgzr//7Za4VF7h4ilFgmbh0F3sYz+C8iO\n0JrBRPeLAkEAyyTwnv/pgqTS/wuxIHUxRBpbdk3YvILAthNrGQg5uzA7eSeFu7Mv\nGtEkXsaqCDbdehgarFfNN8PB6OMRIbsXMwJBAOjhH8UJ0L/osYO9XPO0GfznRS1c\nBnbfm4vk1/bSAO6TF/xEVubU0i4f6q8sIecfqvskEVMS7lkjeptPMR0DIakCQE+7\nuQH/Wizf+r0GXshplyOu4LVHisk63N7aMlAJ7XbuUHmWLKRmiReSfR8CBNzig/2X\nFmkMsUyw9hwte5zsrQcCQQCrOkZvzUj9j1HKG+32EJ2E4kisJZmAgF9GI+z6oxpi\nExped5tp8EWytCjRwKhOcc0068SgaqhKvyyUWpbx32VQ\n-----END RSA PRIVATE KEY-----` | Hard-coded private key. | main.go:12:1:26:30 | `-----BEGIN RSA PRIVATE KEY-----\nMIICXQIBAAKBgQC/tzdtXKXcX6F3v3hR6+uYyZpIeXhhLflJkY2eILLQfAnwKlT5\nxIHW5QZcHQV9sCyZ8qSdPGif7PwgMbButMbByiZhCSugUFb6vjVqoktmslYF4LKH\niDgvmlwuJW0TvynxBLzDCwrRP+gpRT8wuAortWAx/03POTw7Mzi2cIPNsQIDAQAB\nAoGAMHCrqY9CPTdQhgAz94cDpTwzJmLCvtMt7J/BR5X9eF4O6MbZZ652HAUMIVQX\n4hUUf+VmIHB2AwqO/ddwO9ijaz04BslOSy/iYevHGlH65q4587NSlFWjvILMIQCM\nGBjfzJIxlLHVhjc2cFnyAE5YWjF/OMnJN0OhP9pxmCP/iM0CQQDxmQndQLdnV7+6\n8SvBHE8bg1LE8/BzTt68U3aWwiBjrHMFgzr//7Za4VF7h4ilFgmbh0F3sYz+C8iO\n0JrBRPeLAkEAyyTwnv/pgqTS/wuxIHUxRBpbdk3YvILAthNrGQg5uzA7eSeFu7Mv\nGtEkXsaqCDbdehgarFfNN8PB6OMRIbsXMwJBAOjhH8UJ0L/osYO9XPO0GfznRS1c\nBnbfm4vk1/bSAO6TF/xEVubU0i4f6q8sIecfqvskEVMS7lkjeptPMR0DIakCQE+7\nuQH/Wizf+r0GXshplyOu4LVHisk63N7aMlAJ7XbuUHmWLKRmiReSfR8CBNzig/2X\nFmkMsUyw9hwte5zsrQcCQQCrOkZvzUj9j1HKG+32EJ2E4kisJZmAgF9GI+z6oxpi\nExped5tp8EWytCjRwKhOcc0068SgaqhKvyyUWpbx32VQ\n-----END RSA PRIVATE KEY-----` | certificate |
 | main.go:44:14:44:19 | "p4ss" | Hard-coded $@. | main.go:44:14:44:19 | "p4ss" | password |
 | main.go:48:13:48:15 | tmp | Hard-coded $@. | main.go:44:14:44:19 | "p4ss" | password |
 | main.go:50:15:50:21 | "p4ss2" | Hard-coded $@. | main.go:50:15:50:21 | "p4ss2" | password |
-| sanitizer.go:18:44:18:46 | key | Hard-coded credential. | sanitizer.go:17:16:17:25 | `some_key` | password |
+| sanitizer.go:18:44:18:46 | key | Hard-coded $@. | sanitizer.go:17:16:17:25 | `some_key` | secret |


### PR DESCRIPTION
Using the heuristic for dummy passwords to discard sources in this query makes us miss sources like [this one](https://github.com/1Panel-dev/KubePi/blob/2fb4f6961217204561abb34952e9f05d9ca02476/internal/api/v1/session/session.go#L35), so I think it's a good idea to remove the limitation.