### PR TITLE
C#: Add classes extending `SourceNode` for local and stored source models

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/flowsources/Local.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/flowsources/Local.qll
@@ -40,6 +40,10 @@ abstract class EnvironmentVariableSource extends LocalFlowSource {
   override string getSourceType() { result = "environment variable" }
 }
 
+private class ExternalEnvironmentVariableSource extends EnvironmentVariableSource {
+  ExternalEnvironmentVariableSource() { sourceNode(this, "environment") }
+}
+
 /**
  * A dataflow source that represents the access of a command line argument.
  */
@@ -47,6 +51,10 @@ abstract class CommandLineArgumentSource extends LocalFlowSource {
   override string getThreatModel() { result = "commandargs" }
 
   override string getSourceType() { result = "command line argument" }
+}
+
+private class ExternalCommandLineArgumentSource extends CommandLineArgumentSource {
+  ExternalCommandLineArgumentSource() { sourceNode(this, "command-line") }
 }
 
 /**

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/flowsources/Stored.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/flowsources/Stored.qll
@@ -73,6 +73,10 @@ deprecated class ORMMappedProperty extends DataFlow::Node {
   }
 }
 
+private class ExternalDatabaseInputSource extends DatabaseInputSource {
+  ExternalDatabaseInputSource() { sourceNode(this, "database") }
+}
+
 /** A file stream source is considered a stored flow source. */
 class FileStreamStoredFlowSource extends StoredFlowSource {
   FileStreamStoredFlowSource() { sourceNode(this, "file") }


### PR DESCRIPTION
Queries such as `cs/sql-injection` cast their source to a `SourceNode` in order to describe them. For example:

```ql
import semmle.code.csharp.security.dataflow.flowsources.FlowSources

string getSourceType(DataFlow::Node source) {
   result = source.(SourceNode).getSourceType()
}
```

Models as data source models are not included in `SourceNode` by default, they must be wrapped with a class extending `SourceNode`.

This adds such classes, which wrap the `sourceNode(DataFlow::Node,string)` predicate and assigns a `getSourceType`.