### PR TITLE
Go: Make `CODEQL_EXTRACTOR_GO_FAST_PACKAGE_INFO` on by default

### DIFF
--- a/go/extractor/extractor.go
+++ b/go/extractor/extractor.go
@@ -119,7 +119,7 @@ func ExtractWithFlags(buildFlags []string, patterns []string) error {
 	// root directories of packages that we want to extract
 	wantedRoots := make(map[string]bool)
 
-	if os.Getenv("CODEQL_EXTRACTOR_GO_FAST_PACKAGE_INFO") != "" {
+	if os.Getenv("CODEQL_EXTRACTOR_GO_FAST_PACKAGE_INFO") != "false" {
 		log.Printf("Running go list to resolve package and module directories.")
 		// get all packages information
 		pkgInfos, err = util.GetPkgsInfo(patterns, true, modFlags...)


### PR DESCRIPTION
This PR enables `CODEQL_EXTRACTOR_GO_FAST_PACKAGE_INFO` by default. This speeds up Go dependency extraction by only invoking `go list` once per logical workspace, rather than once per dependency. 

This has been tested with a QA experiment, which showed no regressions caused by turning this on by default and improvements in extraction times across the board.