### PR TITLE
C++: Handle `switch` statements in the guards library

### DIFF
--- a/cpp/ql/lib/change-notes/2024-03-15-switches-in-guard-conditions.md
+++ b/cpp/ql/lib/change-notes/2024-03-15-switches-in-guard-conditions.md
@@ -1,0 +1,4 @@
+---
+category: feature
+---
+* Added a predicate `GuardCondition.valueControls` to query whether a basic block is guarded by a particular `case` of a `switch` statement.

--- a/cpp/ql/lib/semmle/code/cpp/controlflow/IRGuards.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/IRGuards.qll
@@ -249,10 +249,10 @@ private predicate nonExcludedIRAndBasicBlock(IRBlock irb, BasicBlock controlled)
  */
 cached
 class IRGuardCondition extends Instruction {
-  ConditionalBranchInstruction branch;
+  Instruction branch;
 
   cached
-  IRGuardCondition() { branch = get_branch_for_condition(this) }
+  IRGuardCondition() { branch = getBranchForCondition(this) }
 
   /**
    * Holds if this condition controls `controlled`, meaning that `controlled` is only
@@ -302,7 +302,7 @@ class IRGuardCondition extends Instruction {
     this.controls(pred, testIsTrue)
     or
     succ = this.getBranchSuccessor(testIsTrue) and
-    branch.getCondition() = this and
+    branch.(ConditionalBranchInstruction).getCondition() = this and
     branch.getBlock() = pred
   }
 
@@ -322,13 +322,13 @@ class IRGuardCondition extends Instruction {
    * ```
    */
   private IRBlock getBranchSuccessor(boolean testIsTrue) {
-    branch.getCondition() = this and
+    branch.(ConditionalBranchInstruction).getCondition() = this and
     (
       testIsTrue = true and
-      result.getFirstInstruction() = branch.getTrueSuccessor()
+      result.getFirstInstruction() = branch.(ConditionalBranchInstruction).getTrueSuccessor()
       or
       testIsTrue = false and
-      result.getFirstInstruction() = branch.getFalseSuccessor()
+      result.getFirstInstruction() = branch.(ConditionalBranchInstruction).getFalseSuccessor()
     )
   }
 
@@ -476,12 +476,14 @@ class IRGuardCondition extends Instruction {
   private IRBlock getBranchBlock() { result = branch.getBlock() }
 }
 
-private ConditionalBranchInstruction get_branch_for_condition(Instruction guard) {
-  result.getCondition() = guard
+private Instruction getBranchForCondition(Instruction guard) {
+  result.(ConditionalBranchInstruction).getCondition() = guard
   or
   exists(LogicalNotInstruction cond |
-    result = get_branch_for_condition(cond) and cond.getUnary() = guard
+    result = getBranchForCondition(cond) and cond.getUnary() = guard
   )
+  or
+  result.(SwitchInstruction).getExpression() = guard
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/controlflow/IRGuards.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/IRGuards.qll
@@ -20,6 +20,44 @@ private predicate isUnreachedBlock(IRBlock block) {
   block.getFirstInstruction() instanceof UnreachedInstruction
 }
 
+private newtype TAbstractValue =
+  TBooleanValue(boolean b) { b = true or b = false } or
+  TMatchValue(CaseEdge c)
+
+/**
+ * An abstract value. This is either a boolean value, or a `switch` case.
+ */
+abstract class AbstractValue extends TAbstractValue {
+  /** Gets an abstract value that represents the dual of this value, if any. */
+  abstract AbstractValue getDualValue();
+
+  /** Gets a textual representation of this abstract value. */
+  abstract string toString();
+}
+
+/** A Boolean value. */
+class BooleanValue extends AbstractValue, TBooleanValue {
+  /** Gets the underlying Boolean value. */
+  boolean getValue() { this = TBooleanValue(result) }
+
+  override BooleanValue getDualValue() { result.getValue() = this.getValue().booleanNot() }
+
+  override string toString() { result = this.getValue().toString() }
+}
+
+/** A value that represents a match against a specific `switch` case. */
+class MatchValue extends AbstractValue, TMatchValue {
+  /** Gets the case. */
+  CaseEdge getCase() { this = TMatchValue(result) }
+
+  override MatchValue getDualValue() {
+    // A `MatchValue` has no dual.
+    none()
+  }
+
+  override string toString() { result = this.getCase().toString() }
+}
+
 /**
  * A Boolean condition in the AST that guards one or more basic blocks. This includes
  * operands of logical operators but not switch statements.

--- a/cpp/ql/lib/semmle/code/cpp/controlflow/IRGuards.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/IRGuards.qll
@@ -359,14 +359,20 @@ class IRGuardCondition extends Instruction {
    * return x;
    * ```
    */
-  private IRBlock getBranchSuccessor(boolean testIsTrue) {
+  private IRBlock getBranchSuccessor(AbstractValue v) {
     branch.(ConditionalBranchInstruction).getCondition() = this and
-    (
-      testIsTrue = true and
+    exists(BooleanValue bv | bv = v |
+      bv.getValue() = true and
       result.getFirstInstruction() = branch.(ConditionalBranchInstruction).getTrueSuccessor()
       or
-      testIsTrue = false and
+      bv.getValue() = false and
       result.getFirstInstruction() = branch.(ConditionalBranchInstruction).getFalseSuccessor()
+    )
+    or
+    exists(SwitchInstruction switch, CaseEdge kind | switch = branch |
+      switch.getExpression() = this and
+      result.getFirstInstruction() = switch.getSuccessor(kind) and
+      kind = v.(MatchValue).getCase()
     )
   }
 

--- a/cpp/ql/test/library-tests/controlflow/guards/Guards.expected
+++ b/cpp/ql/test/library-tests/controlflow/guards/Guards.expected
@@ -29,3 +29,6 @@
 | test.cpp:18:8:18:10 | call to get |
 | test.cpp:31:7:31:13 | ... == ... |
 | test.cpp:42:13:42:20 | call to getABool |
+| test.cpp:61:10:61:10 | i |
+| test.cpp:74:10:74:10 | i |
+| test.cpp:84:10:84:10 | i |

--- a/cpp/ql/test/library-tests/controlflow/guards/GuardsControl.expected
+++ b/cpp/ql/test/library-tests/controlflow/guards/GuardsControl.expected
@@ -86,3 +86,7 @@
 | test.cpp:31:7:31:13 | ... == ... | true | 31 | 32 |
 | test.cpp:42:13:42:20 | call to getABool | false | 53 | 53 |
 | test.cpp:42:13:42:20 | call to getABool | true | 43 | 45 |
+| test.cpp:61:10:61:10 | i | Case[0] | 62 | 64 |
+| test.cpp:61:10:61:10 | i | Case[1] | 65 | 66 |
+| test.cpp:74:10:74:10 | i | Case[0..10] | 75 | 77 |
+| test.cpp:74:10:74:10 | i | Case[11..20] | 78 | 79 |

--- a/cpp/ql/test/library-tests/controlflow/guards/GuardsControl.ql
+++ b/cpp/ql/test/library-tests/controlflow/guards/GuardsControl.ql
@@ -7,10 +7,10 @@
 import cpp
 import semmle.code.cpp.controlflow.Guards
 
-from GuardCondition guard, boolean sense, int start, int end
+from GuardCondition guard, AbstractValue value, int start, int end
 where
   exists(BasicBlock block |
-    guard.controls(block, sense) and
+    guard.valueControls(block, value) and
     block.hasLocationInfo(_, start, _, end, _)
   )
-select guard, sense, start, end
+select guard, value, start, end

--- a/cpp/ql/test/library-tests/controlflow/guards/test.cpp
+++ b/cpp/ql/test/library-tests/controlflow/guards/test.cpp
@@ -52,3 +52,37 @@ bool testWithCatch0(int v)
 
     return false;
 }
+
+void use1(int);
+void use2(int);
+void use3(int);
+
+void test_switches_simple(int i) {
+  switch(i) {
+    case 0:
+      use1(i);
+      break;
+    case 1:
+      use2(i);
+      /* NOTE: fallthrough */
+    case 2:
+      use3(i);
+  }
+}
+
+void test_switches_range(int i) {
+  switch(i) {
+    case 0 ... 10:
+      use1(i);
+      break;
+    case 11 ... 20:
+      use2(i);
+  }
+}
+
+void test_switches_default(int i) {
+  switch(i) {
+    default:
+      use1(i);
+  }
+}


### PR DESCRIPTION
This PR introduces the minimal changes necessary to support `switch` statements in the guards library. After this PR, it's now possible to ask if a block is controlled by a particular `case` in a switch statement.

It's still possible to do more in this area. For example, `GuardCondition.comparesEq` still doesn't reason about `switch` statements since the interface on that predicate can't really support it (its columns include `(Expr left, Expr right, int k)` which holds if `left == right + k`, but the `case` label in a switch isn't an expression). So such changes are probably best done in a follow-up PR.

Commit-by-commit review recommended.

DCA looks good. The removed results are clear FPs that now disappear. And the new results is because the medium precision query now shows these results since they're no longer results in the high precision query (😭).