### PR TITLE
C++: Implement guards logic for switch statements

### DIFF
--- a/cpp/ql/lib/change-notes/2024-03-19-predicates-for-switches-as-guards.md
+++ b/cpp/ql/lib/change-notes/2024-03-19-predicates-for-switches-as-guards.md
@@ -1,0 +1,5 @@
+---
+category: feature
+---
+* Added a predicate `GuardCondition.comparesEq/4` to query whether an expression is compared to a constant. 
+* Added a predicate `GuardCondition.ensuresEq/4` to query whether a basic block is guarded by an expression being equal to a constant.

--- a/cpp/ql/lib/semmle/code/cpp/controlflow/IRGuards.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/IRGuards.qll
@@ -722,10 +722,12 @@ private predicate simple_comparison_eq(
 
 /** Rearrange various simple comparisons into `op == k` form. */
 private predicate simple_comparison_eq(Instruction test, Operand op, int k, AbstractValue value) {
-  exists(SwitchInstruction switch |
+  exists(SwitchInstruction switch, CaseEdge case |
     test = switch.getExpression() and
     op.getDef() = test and
-    value.(MatchValue).getCase().getValue().toInt() = k
+    case = value.(MatchValue).getCase() and
+    exists(switch.getSuccessor(case)) and
+    case.getValue().toInt() = k
   )
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/EdgeKind.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/EdgeKind.qll
@@ -90,6 +90,15 @@ class CaseEdge extends EdgeKind, TCaseEdge {
    * Gets the largest value of the switch expression for which control will flow along this edge.
    */
   final string getMaxValue() { result = maxValue }
+
+  /**
+   * Gets the unique value of the switch expression for which control will
+   * flow along this edge, if any.
+   */
+  final string getValue() {
+    minValue = maxValue and
+    result = minValue
+  }
 }
 
 /**

--- a/cpp/ql/src/Critical/ScanfChecks.qll
+++ b/cpp/ql/src/Critical/ScanfChecks.qll
@@ -11,7 +11,7 @@ private predicate exprInBooleanContext(Expr e) {
   exists(IRGuardCondition gc |
     exists(Instruction i |
       i.getUnconvertedResultExpression() = e and
-      gc.comparesEq(valueNumber(i).getAUse(), zero(), 0, _, _)
+      gc.comparesEq(valueNumber(i).getAUse(), 0, _, _)
     )
     or
     gc.getUnconvertedResultExpression() = e
@@ -36,10 +36,6 @@ private string getEofValue() {
   )
 }
 
-private ConstantInstruction getEofInstruction() { result.getValue() = getEofValue() }
-
-private Operand eof() { result.getDef() = getEofInstruction() }
-
 /**
  * Holds if the value of `call` has been checked to not equal `EOF`.
  */
@@ -47,7 +43,7 @@ private predicate checkedForEof(ScanfFunctionCall call) {
   exists(IRGuardCondition gc |
     exists(Instruction i | i.getUnconvertedResultExpression() = call |
       // call == EOF
-      gc.comparesEq(valueNumber(i).getAUse(), eof(), 0, _, _)
+      gc.comparesEq(valueNumber(i).getAUse(), getEofValue().toInt(), _, _)
       or
       // call < 0 (EOF is guaranteed to be negative)
       gc.comparesLt(valueNumber(i).getAUse(), zero(), 0, true, _)

--- a/cpp/ql/test/library-tests/controlflow/guards-ir/tests.expected
+++ b/cpp/ql/test/library-tests/controlflow/guards-ir/tests.expected
@@ -62,7 +62,9 @@ astGuardsCompare
 | 26 | x >= 0+1 when ... > ... is true |
 | 31 | - ... != x+0 when ... == ... is false |
 | 31 | - ... == x+0 when ... == ... is true |
+| 31 | x != -1 when ... == ... is false |
 | 31 | x != - ...+0 when ... == ... is false |
+| 31 | x == -1 when ... == ... is true |
 | 31 | x == - ...+0 when ... == ... is true |
 | 34 | 10 < j+1 when ... < ... is false |
 | 34 | 10 >= j+1 when ... < ... is true |
@@ -86,15 +88,20 @@ astGuardsCompare
 | 58 | 0 < y+1 when ... \|\| ... is false |
 | 58 | 0 == x+0 when ... == ... is true |
 | 58 | 0 >= y+1 when ... < ... is true |
+| 58 | x != 0 when ... == ... is false |
+| 58 | x != 0 when ... \|\| ... is false |
 | 58 | x != 0+0 when ... == ... is false |
 | 58 | x != 0+0 when ... \|\| ... is false |
+| 58 | x == 0 when ... == ... is true |
 | 58 | x == 0+0 when ... == ... is true |
 | 58 | y < 0+0 when ... < ... is true |
 | 58 | y >= 0+0 when ... < ... is false |
 | 58 | y >= 0+0 when ... \|\| ... is false |
 | 75 | 0 != x+0 when ... == ... is false |
 | 75 | 0 == x+0 when ... == ... is true |
+| 75 | x != 0 when ... == ... is false |
 | 75 | x != 0+0 when ... == ... is false |
+| 75 | x == 0 when ... == ... is true |
 | 75 | x == 0+0 when ... == ... is true |
 | 85 | 0 != x+0 when ... == ... is false |
 | 85 | 0 != y+0 when ... != ... is true |
@@ -102,15 +109,23 @@ astGuardsCompare
 | 85 | 0 == x+0 when ... && ... is true |
 | 85 | 0 == x+0 when ... == ... is true |
 | 85 | 0 == y+0 when ... != ... is false |
+| 85 | x != 0 when ... == ... is false |
 | 85 | x != 0+0 when ... == ... is false |
+| 85 | x == 0 when ... && ... is true |
+| 85 | x == 0 when ... == ... is true |
 | 85 | x == 0+0 when ... && ... is true |
 | 85 | x == 0+0 when ... == ... is true |
+| 85 | y != 0 when ... != ... is true |
+| 85 | y != 0 when ... && ... is true |
 | 85 | y != 0+0 when ... != ... is true |
 | 85 | y != 0+0 when ... && ... is true |
+| 85 | y == 0 when ... != ... is false |
 | 85 | y == 0+0 when ... != ... is false |
 | 94 | 0 != x+0 when ... != ... is true |
 | 94 | 0 == x+0 when ... != ... is false |
+| 94 | x != 0 when ... != ... is true |
 | 94 | x != 0+0 when ... != ... is true |
+| 94 | x == 0 when ... != ... is false |
 | 94 | x == 0+0 when ... != ... is false |
 | 102 | 10 < j+1 when ... < ... is false |
 | 102 | 10 >= j+1 when ... < ... is true |
@@ -122,8 +137,11 @@ astGuardsCompare
 | 109 | 0 < y+1 when ... \|\| ... is false |
 | 109 | 0 == x+0 when ... == ... is true |
 | 109 | 0 >= y+1 when ... < ... is true |
+| 109 | x != 0 when ... == ... is false |
+| 109 | x != 0 when ... \|\| ... is false |
 | 109 | x != 0+0 when ... == ... is false |
 | 109 | x != 0+0 when ... \|\| ... is false |
+| 109 | x == 0 when ... == ... is true |
 | 109 | x == 0+0 when ... == ... is true |
 | 109 | y < 0+0 when ... < ... is true |
 | 109 | y >= 0+0 when ... < ... is false |
@@ -162,7 +180,9 @@ astGuardsCompare
 | 165 | y >= x+43 when ... < ... is true |
 | 175 | 0 != call to foo+0 when ... == ... is false |
 | 175 | 0 == call to foo+0 when ... == ... is true |
+| 175 | call to foo != 0 when ... == ... is false |
 | 175 | call to foo != 0+0 when ... == ... is false |
+| 175 | call to foo == 0 when ... == ... is true |
 | 175 | call to foo == 0+0 when ... == ... is true |
 astGuardsControl
 | test.c:7:9:7:13 | ... > ... | false | 10 | 11 |
@@ -443,6 +463,34 @@ astGuardsEnsure
 | test.cpp:31:7:31:13 | ... == ... | test.cpp:31:12:31:13 | - ... | != | test.cpp:31:7:31:7 | x | 0 | 34 | 34 |
 | test.cpp:31:7:31:13 | ... == ... | test.cpp:31:12:31:13 | - ... | == | test.cpp:31:7:31:7 | x | 0 | 30 | 30 |
 | test.cpp:31:7:31:13 | ... == ... | test.cpp:31:12:31:13 | - ... | == | test.cpp:31:7:31:7 | x | 0 | 31 | 32 |
+astGuardsEnsure_const
+| test.c:58:9:58:14 | ... == ... | test.c:58:9:58:9 | x | != | 0 | 58 | 58 |
+| test.c:58:9:58:14 | ... == ... | test.c:58:9:58:9 | x | != | 0 | 62 | 62 |
+| test.c:58:9:58:23 | ... \|\| ... | test.c:58:9:58:9 | x | != | 0 | 62 | 62 |
+| test.c:75:9:75:14 | ... == ... | test.c:75:9:75:9 | x | != | 0 | 78 | 79 |
+| test.c:75:9:75:14 | ... == ... | test.c:75:9:75:9 | x | == | 0 | 75 | 77 |
+| test.c:85:8:85:13 | ... == ... | test.c:85:8:85:8 | x | == | 0 | 85 | 85 |
+| test.c:85:8:85:13 | ... == ... | test.c:85:8:85:8 | x | == | 0 | 86 | 86 |
+| test.c:85:8:85:23 | ... && ... | test.c:85:8:85:8 | x | == | 0 | 86 | 86 |
+| test.c:85:8:85:23 | ... && ... | test.c:85:18:85:18 | y | != | 0 | 86 | 86 |
+| test.c:85:18:85:23 | ... != ... | test.c:85:18:85:18 | y | != | 0 | 86 | 86 |
+| test.c:94:11:94:16 | ... != ... | test.c:94:11:94:11 | x | != | 0 | 94 | 96 |
+| test.c:94:11:94:16 | ... != ... | test.c:94:11:94:11 | x | == | 0 | 70 | 70 |
+| test.c:94:11:94:16 | ... != ... | test.c:94:11:94:11 | x | == | 0 | 99 | 102 |
+| test.c:94:11:94:16 | ... != ... | test.c:94:11:94:11 | x | == | 0 | 102 | 102 |
+| test.c:94:11:94:16 | ... != ... | test.c:94:11:94:11 | x | == | 0 | 107 | 109 |
+| test.c:94:11:94:16 | ... != ... | test.c:94:11:94:11 | x | == | 0 | 109 | 109 |
+| test.c:94:11:94:16 | ... != ... | test.c:94:11:94:11 | x | == | 0 | 109 | 117 |
+| test.c:94:11:94:16 | ... != ... | test.c:94:11:94:11 | x | == | 0 | 113 | 113 |
+| test.c:109:9:109:14 | ... == ... | test.c:109:9:109:9 | x | != | 0 | 109 | 109 |
+| test.c:109:9:109:14 | ... == ... | test.c:109:9:109:9 | x | != | 0 | 113 | 113 |
+| test.c:109:9:109:23 | ... \|\| ... | test.c:109:9:109:9 | x | != | 0 | 113 | 113 |
+| test.c:175:13:175:32 | ... == ... | test.c:175:13:175:15 | call to foo | != | 0 | 175 | 175 |
+| test.c:175:13:175:32 | ... == ... | test.c:175:13:175:15 | call to foo | == | 0 | 175 | 175 |
+| test.cpp:31:7:31:13 | ... == ... | test.cpp:31:7:31:7 | x | != | -1 | 30 | 30 |
+| test.cpp:31:7:31:13 | ... == ... | test.cpp:31:7:31:7 | x | != | -1 | 34 | 34 |
+| test.cpp:31:7:31:13 | ... == ... | test.cpp:31:7:31:7 | x | == | -1 | 30 | 30 |
+| test.cpp:31:7:31:13 | ... == ... | test.cpp:31:7:31:7 | x | == | -1 | 31 | 32 |
 irGuards
 | test.c:7:9:7:13 | CompareGT: ... > ... |
 | test.c:17:8:17:12 | CompareLT: ... < ... |
@@ -497,7 +545,9 @@ irGuardsCompare
 | 26 | x >= 0+1 when CompareGT: ... > ... is true |
 | 31 | - ... != x+0 when CompareEQ: ... == ... is false |
 | 31 | - ... == x+0 when CompareEQ: ... == ... is true |
+| 31 | x != -1 when CompareEQ: ... == ... is false |
 | 31 | x != - ...+0 when CompareEQ: ... == ... is false |
+| 31 | x == -1 when CompareEQ: ... == ... is true |
 | 31 | x == - ...+0 when CompareEQ: ... == ... is true |
 | 34 | 10 < j+1 when CompareLT: ... < ... is false |
 | 34 | 10 >= j+1 when CompareLT: ... < ... is true |
@@ -519,25 +569,35 @@ irGuardsCompare
 | 58 | 0 < y+1 when CompareLT: ... < ... is false |
 | 58 | 0 == x+0 when CompareEQ: ... == ... is true |
 | 58 | 0 >= y+1 when CompareLT: ... < ... is true |
+| 58 | x != 0 when CompareEQ: ... == ... is false |
 | 58 | x != 0+0 when CompareEQ: ... == ... is false |
+| 58 | x == 0 when CompareEQ: ... == ... is true |
 | 58 | x == 0+0 when CompareEQ: ... == ... is true |
 | 58 | y < 0+0 when CompareLT: ... < ... is true |
 | 58 | y >= 0+0 when CompareLT: ... < ... is false |
 | 75 | 0 != x+0 when CompareEQ: ... == ... is false |
 | 75 | 0 == x+0 when CompareEQ: ... == ... is true |
+| 75 | x != 0 when CompareEQ: ... == ... is false |
 | 75 | x != 0+0 when CompareEQ: ... == ... is false |
+| 75 | x == 0 when CompareEQ: ... == ... is true |
 | 75 | x == 0+0 when CompareEQ: ... == ... is true |
 | 85 | 0 != x+0 when CompareEQ: ... == ... is false |
 | 85 | 0 != y+0 when CompareNE: ... != ... is true |
 | 85 | 0 == x+0 when CompareEQ: ... == ... is true |
 | 85 | 0 == y+0 when CompareNE: ... != ... is false |
+| 85 | x != 0 when CompareEQ: ... == ... is false |
 | 85 | x != 0+0 when CompareEQ: ... == ... is false |
+| 85 | x == 0 when CompareEQ: ... == ... is true |
 | 85 | x == 0+0 when CompareEQ: ... == ... is true |
+| 85 | y != 0 when CompareNE: ... != ... is true |
 | 85 | y != 0+0 when CompareNE: ... != ... is true |
+| 85 | y == 0 when CompareNE: ... != ... is false |
 | 85 | y == 0+0 when CompareNE: ... != ... is false |
 | 94 | 0 != x+0 when CompareNE: ... != ... is true |
 | 94 | 0 == x+0 when CompareNE: ... != ... is false |
+| 94 | x != 0 when CompareNE: ... != ... is true |
 | 94 | x != 0+0 when CompareNE: ... != ... is true |
+| 94 | x == 0 when CompareNE: ... != ... is false |
 | 94 | x == 0+0 when CompareNE: ... != ... is false |
 | 102 | 10 < j+1 when CompareLT: ... < ... is false |
 | 102 | 10 >= j+1 when CompareLT: ... < ... is true |
@@ -547,7 +607,9 @@ irGuardsCompare
 | 109 | 0 < y+1 when CompareLT: ... < ... is false |
 | 109 | 0 == x+0 when CompareEQ: ... == ... is true |
 | 109 | 0 >= y+1 when CompareLT: ... < ... is true |
+| 109 | x != 0 when CompareEQ: ... == ... is false |
 | 109 | x != 0+0 when CompareEQ: ... == ... is false |
+| 109 | x == 0 when CompareEQ: ... == ... is true |
 | 109 | x == 0+0 when CompareEQ: ... == ... is true |
 | 109 | y < 0+0 when CompareLT: ... < ... is true |
 | 109 | y >= 0+0 when CompareLT: ... < ... is false |
@@ -585,7 +647,9 @@ irGuardsCompare
 | 165 | y >= x+43 when CompareLT: ... < ... is true |
 | 175 | 0 != call to foo+0 when CompareEQ: ... == ... is false |
 | 175 | 0 == call to foo+0 when CompareEQ: ... == ... is true |
+| 175 | call to foo != 0 when CompareEQ: ... == ... is false |
 | 175 | call to foo != 0+0 when CompareEQ: ... == ... is false |
+| 175 | call to foo == 0 when CompareEQ: ... == ... is true |
 | 175 | call to foo == 0+0 when CompareEQ: ... == ... is true |
 irGuardsControl
 | test.c:7:9:7:13 | CompareGT: ... > ... | false | 11 | 11 |
@@ -841,3 +905,27 @@ irGuardsEnsure
 | test.cpp:31:7:31:13 | CompareEQ: ... == ... | test.cpp:31:12:31:13 | Constant: - ... | != | test.cpp:31:7:31:7 | Load: x | 0 | 34 | 34 |
 | test.cpp:31:7:31:13 | CompareEQ: ... == ... | test.cpp:31:12:31:13 | Constant: - ... | == | test.cpp:31:7:31:7 | Load: x | 0 | 30 | 30 |
 | test.cpp:31:7:31:13 | CompareEQ: ... == ... | test.cpp:31:12:31:13 | Constant: - ... | == | test.cpp:31:7:31:7 | Load: x | 0 | 32 | 32 |
+irGuardsEnsure_const
+| test.c:58:9:58:14 | CompareEQ: ... == ... | test.c:58:9:58:9 | Load: x | != | 0 | 58 | 58 |
+| test.c:58:9:58:14 | CompareEQ: ... == ... | test.c:58:9:58:9 | Load: x | != | 0 | 62 | 62 |
+| test.c:75:9:75:14 | CompareEQ: ... == ... | test.c:75:9:75:9 | Load: x | != | 0 | 79 | 79 |
+| test.c:75:9:75:14 | CompareEQ: ... == ... | test.c:75:9:75:9 | Load: x | == | 0 | 76 | 76 |
+| test.c:85:8:85:13 | CompareEQ: ... == ... | test.c:85:8:85:8 | Load: x | == | 0 | 85 | 85 |
+| test.c:85:8:85:13 | CompareEQ: ... == ... | test.c:85:8:85:8 | Load: x | == | 0 | 86 | 86 |
+| test.c:85:18:85:23 | CompareNE: ... != ... | test.c:85:18:85:18 | Load: y | != | 0 | 86 | 86 |
+| test.c:94:11:94:16 | CompareNE: ... != ... | test.c:94:11:94:11 | Load: x | != | 0 | 95 | 95 |
+| test.c:94:11:94:16 | CompareNE: ... != ... | test.c:94:11:94:11 | Load: x | == | 0 | 70 | 70 |
+| test.c:94:11:94:16 | CompareNE: ... != ... | test.c:94:11:94:11 | Load: x | == | 0 | 99 | 99 |
+| test.c:94:11:94:16 | CompareNE: ... != ... | test.c:94:11:94:11 | Load: x | == | 0 | 102 | 102 |
+| test.c:94:11:94:16 | CompareNE: ... != ... | test.c:94:11:94:11 | Load: x | == | 0 | 103 | 103 |
+| test.c:94:11:94:16 | CompareNE: ... != ... | test.c:94:11:94:11 | Load: x | == | 0 | 107 | 107 |
+| test.c:94:11:94:16 | CompareNE: ... != ... | test.c:94:11:94:11 | Load: x | == | 0 | 109 | 109 |
+| test.c:94:11:94:16 | CompareNE: ... != ... | test.c:94:11:94:11 | Load: x | == | 0 | 110 | 110 |
+| test.c:94:11:94:16 | CompareNE: ... != ... | test.c:94:11:94:11 | Load: x | == | 0 | 113 | 113 |
+| test.c:109:9:109:14 | CompareEQ: ... == ... | test.c:109:9:109:9 | Load: x | != | 0 | 109 | 109 |
+| test.c:109:9:109:14 | CompareEQ: ... == ... | test.c:109:9:109:9 | Load: x | != | 0 | 113 | 113 |
+| test.c:175:13:175:32 | CompareEQ: ... == ... | test.c:175:13:175:15 | Call: call to foo | != | 0 | 175 | 175 |
+| test.c:175:13:175:32 | CompareEQ: ... == ... | test.c:175:13:175:15 | Call: call to foo | == | 0 | 175 | 175 |
+| test.cpp:31:7:31:13 | CompareEQ: ... == ... | test.cpp:31:7:31:7 | Load: x | != | -1 | 34 | 34 |
+| test.cpp:31:7:31:13 | CompareEQ: ... == ... | test.cpp:31:7:31:7 | Load: x | == | -1 | 30 | 30 |
+| test.cpp:31:7:31:13 | CompareEQ: ... == ... | test.cpp:31:7:31:7 | Load: x | == | -1 | 32 | 32 |

--- a/cpp/ql/test/library-tests/controlflow/guards-ir/tests.ql
+++ b/cpp/ql/test/library-tests/controlflow/guards-ir/tests.ql
@@ -4,22 +4,32 @@ import semmle.code.cpp.controlflow.IRGuards
 query predicate astGuards(GuardCondition guard) { any() }
 
 query predicate astGuardsCompare(int startLine, string msg) {
-  exists(GuardCondition guard, Expr left, Expr right, int k, string which, string op |
+  exists(GuardCondition guard, Expr left, int k, string which, string op |
     exists(boolean sense |
       sense = true and which = "true"
       or
       sense = false and which = "false"
     |
-      guard.comparesLt(left, right, k, true, sense) and op = " < "
+      exists(Expr right |
+        guard.comparesLt(left, right, k, true, sense) and op = " < "
+        or
+        guard.comparesLt(left, right, k, false, sense) and op = " >= "
+        or
+        guard.comparesEq(left, right, k, true, sense) and op = " == "
+        or
+        guard.comparesEq(left, right, k, false, sense) and op = " != "
+      |
+        msg = left + op + right + "+" + k + " when " + guard + " is " + which
+      )
       or
-      guard.comparesLt(left, right, k, false, sense) and op = " >= "
-      or
-      guard.comparesEq(left, right, k, true, sense) and op = " == "
-      or
-      guard.comparesEq(left, right, k, false, sense) and op = " != "
+      (
+        guard.comparesEq(left, k, true, sense) and op = " == "
+        or
+        guard.comparesEq(left, k, false, sense) and op = " != "
+      ) and
+      msg = left + op + k + " when " + guard + " is " + which
     ) and
-    startLine = guard.getLocation().getStartLine() and
-    msg = left + op + right + "+" + k + " when " + guard + " is " + which
+    startLine = guard.getLocation().getStartLine()
   )
 }
 
@@ -46,28 +56,52 @@ query predicate astGuardsEnsure(
   )
 }
 
+query predicate astGuardsEnsure_const(
+  GuardCondition guard, Expr left, string op, int k, int start, int end
+) {
+  exists(BasicBlock block |
+    guard.ensuresEq(left, k, block, true) and op = "=="
+    or
+    guard.ensuresEq(left, k, block, false) and op = "!="
+  |
+    block.hasLocationInfo(_, start, _, end, _)
+  )
+}
+
 query predicate irGuards(IRGuardCondition guard) { any() }
 
 query predicate irGuardsCompare(int startLine, string msg) {
-  exists(IRGuardCondition guard, Operand left, Operand right, int k, string which, string op |
+  exists(IRGuardCondition guard, Operand left, int k, string which, string op |
     exists(boolean sense |
       sense = true and which = "true"
       or
       sense = false and which = "false"
     |
-      guard.comparesLt(left, right, k, true, sense) and op = " < "
+      exists(Operand right |
+        guard.comparesLt(left, right, k, true, sense) and op = " < "
+        or
+        guard.comparesLt(left, right, k, false, sense) and op = " >= "
+        or
+        guard.comparesEq(left, right, k, true, sense) and op = " == "
+        or
+        guard.comparesEq(left, right, k, false, sense) and op = " != "
+      |
+        msg =
+          left.getAnyDef().getUnconvertedResultExpression() + op +
+            right.getAnyDef().getUnconvertedResultExpression() + "+" + k + " when " + guard + " is "
+            + which
+      )
       or
-      guard.comparesLt(left, right, k, false, sense) and op = " >= "
-      or
-      guard.comparesEq(left, right, k, true, sense) and op = " == "
-      or
-      guard.comparesEq(left, right, k, false, sense) and op = " != "
+      (
+        guard.comparesEq(left, k, true, sense) and op = " == "
+        or
+        guard.comparesEq(left, k, false, sense) and op = " != "
+      ) and
+      msg =
+        left.getAnyDef().getUnconvertedResultExpression() + op + k + " when " + guard + " is " +
+          which
     ) and
-    startLine = guard.getLocation().getStartLine() and
-    msg =
-      left.getAnyDef().getUnconvertedResultExpression() + op +
-        right.getAnyDef().getUnconvertedResultExpression() + "+" + k + " when " + guard + " is " +
-        which
+    startLine = guard.getLocation().getStartLine()
   )
 }
 
@@ -92,6 +126,19 @@ query predicate irGuardsEnsure(
   |
     leftOp = left.getAUse() and
     rightOp = right.getAUse() and
+    block.getLocation().hasLocationInfo(_, start, _, end, _)
+  )
+}
+
+query predicate irGuardsEnsure_const(
+  IRGuardCondition guard, Instruction left, string op, int k, int start, int end
+) {
+  exists(IRBlock block, Operand leftOp |
+    guard.ensuresEq(leftOp, k, block, true) and op = "=="
+    or
+    guard.ensuresEq(leftOp, k, block, false) and op = "!="
+  |
+    leftOp = left.getAUse() and
     block.getLocation().hasLocationInfo(_, start, _, end, _)
   )
 }

--- a/cpp/ql/test/library-tests/controlflow/guards/GuardsCompare.expected
+++ b/cpp/ql/test/library-tests/controlflow/guards/GuardsCompare.expected
@@ -20,7 +20,9 @@
 | 26 | x >= 0+1 when ... > ... is true |
 | 31 | - ... != x+0 when ... == ... is false |
 | 31 | - ... == x+0 when ... == ... is true |
+| 31 | x != -1 when ... == ... is false |
 | 31 | x != - ...+0 when ... == ... is false |
+| 31 | x == -1 when ... == ... is true |
 | 31 | x == - ...+0 when ... == ... is true |
 | 34 | 10 < j+1 when ... < ... is false |
 | 34 | 10 >= j+1 when ... < ... is true |
@@ -44,31 +46,53 @@
 | 58 | 0 < y+1 when ... \|\| ... is false |
 | 58 | 0 == x+0 when ... == ... is true |
 | 58 | 0 >= y+1 when ... < ... is true |
+| 58 | x != 0 when ... == ... is false |
+| 58 | x != 0 when ... \|\| ... is false |
 | 58 | x != 0+0 when ... == ... is false |
 | 58 | x != 0+0 when ... \|\| ... is false |
+| 58 | x == 0 when ... == ... is true |
 | 58 | x == 0+0 when ... == ... is true |
 | 58 | y < 0+0 when ... < ... is true |
 | 58 | y >= 0+0 when ... < ... is false |
 | 58 | y >= 0+0 when ... \|\| ... is false |
+| 61 | i == 0 when i is true |
+| 61 | i == 1 when i is true |
+| 61 | i == 2 when i is true |
+| 74 | i == 0 when i is true |
+| 74 | i == 1 when i is true |
+| 74 | i == 2 when i is true |
 | 75 | 0 != x+0 when ... == ... is false |
 | 75 | 0 == x+0 when ... == ... is true |
+| 75 | x != 0 when ... == ... is false |
 | 75 | x != 0+0 when ... == ... is false |
+| 75 | x == 0 when ... == ... is true |
 | 75 | x == 0+0 when ... == ... is true |
+| 84 | i == 0 when i is true |
+| 84 | i == 1 when i is true |
+| 84 | i == 2 when i is true |
 | 85 | 0 != x+0 when ... == ... is false |
 | 85 | 0 != y+0 when ... != ... is true |
 | 85 | 0 != y+0 when ... && ... is true |
 | 85 | 0 == x+0 when ... && ... is true |
 | 85 | 0 == x+0 when ... == ... is true |
 | 85 | 0 == y+0 when ... != ... is false |
+| 85 | x != 0 when ... == ... is false |
 | 85 | x != 0+0 when ... == ... is false |
+| 85 | x == 0 when ... && ... is true |
+| 85 | x == 0 when ... == ... is true |
 | 85 | x == 0+0 when ... && ... is true |
 | 85 | x == 0+0 when ... == ... is true |
+| 85 | y != 0 when ... != ... is true |
+| 85 | y != 0 when ... && ... is true |
 | 85 | y != 0+0 when ... != ... is true |
 | 85 | y != 0+0 when ... && ... is true |
+| 85 | y == 0 when ... != ... is false |
 | 85 | y == 0+0 when ... != ... is false |
 | 94 | 0 != x+0 when ... != ... is true |
 | 94 | 0 == x+0 when ... != ... is false |
+| 94 | x != 0 when ... != ... is true |
 | 94 | x != 0+0 when ... != ... is true |
+| 94 | x == 0 when ... != ... is false |
 | 94 | x == 0+0 when ... != ... is false |
 | 102 | 10 < j+1 when ... < ... is false |
 | 102 | 10 >= j+1 when ... < ... is true |
@@ -80,8 +104,11 @@
 | 109 | 0 < y+1 when ... \|\| ... is false |
 | 109 | 0 == x+0 when ... == ... is true |
 | 109 | 0 >= y+1 when ... < ... is true |
+| 109 | x != 0 when ... == ... is false |
+| 109 | x != 0 when ... \|\| ... is false |
 | 109 | x != 0+0 when ... == ... is false |
 | 109 | x != 0+0 when ... \|\| ... is false |
+| 109 | x == 0 when ... == ... is true |
 | 109 | x == 0+0 when ... == ... is true |
 | 109 | y < 0+0 when ... < ... is true |
 | 109 | y >= 0+0 when ... < ... is false |

--- a/cpp/ql/test/library-tests/controlflow/guards/GuardsCompare.expected
+++ b/cpp/ql/test/library-tests/controlflow/guards/GuardsCompare.expected
@@ -58,18 +58,12 @@
 | 61 | i == 0 when i is true |
 | 61 | i == 1 when i is true |
 | 61 | i == 2 when i is true |
-| 74 | i == 0 when i is true |
-| 74 | i == 1 when i is true |
-| 74 | i == 2 when i is true |
 | 75 | 0 != x+0 when ... == ... is false |
 | 75 | 0 == x+0 when ... == ... is true |
 | 75 | x != 0 when ... == ... is false |
 | 75 | x != 0+0 when ... == ... is false |
 | 75 | x == 0 when ... == ... is true |
 | 75 | x == 0+0 when ... == ... is true |
-| 84 | i == 0 when i is true |
-| 84 | i == 1 when i is true |
-| 84 | i == 2 when i is true |
 | 85 | 0 != x+0 when ... == ... is false |
 | 85 | 0 != y+0 when ... != ... is true |
 | 85 | 0 != y+0 when ... && ... is true |

--- a/cpp/ql/test/library-tests/controlflow/guards/GuardsCompare.ql
+++ b/cpp/ql/test/library-tests/controlflow/guards/GuardsCompare.ql
@@ -7,20 +7,30 @@
 import cpp
 import semmle.code.cpp.controlflow.Guards
 
-from GuardCondition guard, Expr left, Expr right, int k, string which, string op, string msg
+from GuardCondition guard, Expr left, int k, string which, string op, string msg
 where
   exists(boolean sense |
     sense = true and which = "true"
     or
     sense = false and which = "false"
   |
-    guard.comparesLt(left, right, k, true, sense) and op = " < "
+    exists(Expr right |
+      guard.comparesLt(left, right, k, true, sense) and op = " < "
+      or
+      guard.comparesLt(left, right, k, false, sense) and op = " >= "
+      or
+      guard.comparesEq(left, right, k, true, sense) and op = " == "
+      or
+      guard.comparesEq(left, right, k, false, sense) and op = " != "
+    |
+      msg = left + op + right + "+" + k + " when " + guard + " is " + which
+    )
     or
-    guard.comparesLt(left, right, k, false, sense) and op = " >= "
-    or
-    guard.comparesEq(left, right, k, true, sense) and op = " == "
-    or
-    guard.comparesEq(left, right, k, false, sense) and op = " != "
-  ) and
-  msg = left + op + right + "+" + k + " when " + guard + " is " + which
+    (
+      guard.comparesEq(left, k, true, sense) and op = " == "
+      or
+      guard.comparesEq(left, k, false, sense) and op = " != "
+    ) and
+    msg = left + op + k + " when " + guard + " is " + which
+  )
 select guard.getLocation().getStartLine(), msg


### PR DESCRIPTION
This PR is the follow-up to https://github.com/github/codeql/pull/15941 that addresses this comment I made in that PR:
> It's still possible to do more in this area. For example, GuardCondition.comparesEq still doesn't reason about switch statements since the interface on that predicate can't really support it (its columns include `(Expr left, Expr right, int k)` which holds if `left == right + k`, but the case label in a switch isn't an expression). So such changes are probably best done in a follow-up PR.

Commit-by-commit review recommended.

This PR only does the required API additions to support `GuardCondition.comparesEq` for `switch` statements. We also have a predicate `GuardCondition.comparesLt` which needs a similar treatment. I'm delaying that until a future PR