### PR TITLE
Ruby: remove isString from TSymbol

### DIFF
--- a/ruby/ql/lib/codeql/ruby/ast/internal/Constant.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/internal/Constant.qll
@@ -423,7 +423,7 @@ private module Cached {
       or
       s = any(StringComponentImpl c).getValue()
     } or
-    TSymbol(string s) { isString(_, s) or isSymbolExpr(_, s) } or
+    TSymbol(string s) { isSymbolExpr(_, s) } or
     TRegExp(string s, string flags) {
       isRegExp(_, s, flags)
       or


### PR DESCRIPTION
This gives a nice little speedup with no apparent loss of results.