### PR TITLE
Swift: add `-headerpad_max_install_names` to link options

### DIFF
--- a/swift/extractor/BUILD.bazel
+++ b/swift/extractor/BUILD.bazel
@@ -17,6 +17,10 @@ swift_cc_binary(
         "//swift/third_party/swift-llvm-support",
         "@absl//absl/strings",
     ],
+    linkopts = select({
+        "@platforms//os:macos": ["-headerpad_max_install_names"],
+        "//conditions:default": [],
+    }),
 )
 
 sh_binary(


### PR DESCRIPTION
Our tracer has problems with relocating this specific extractor binary.