### PR TITLE
C++: Fix interface for `GuardCondition.comparesEq` and `GuardCondition.ensuresEq`

### DIFF
--- a/cpp/ql/test/library-tests/controlflow/guards-ir/tests.ql
+++ b/cpp/ql/test/library-tests/controlflow/guards-ir/tests.ql
@@ -4,8 +4,8 @@ import semmle.code.cpp.controlflow.IRGuards
 query predicate astGuards(GuardCondition guard) { any() }
 
 query predicate astGuardsCompare(int startLine, string msg) {
-  exists(GuardCondition guard, Expr left, int k, string which, string op |
-    exists(boolean sense |
+  exists(GuardCondition guard, Expr left, int k, string op |
+    exists(boolean sense, string which |
       sense = true and which = "true"
       or
       sense = false and which = "false"
@@ -21,14 +21,16 @@ query predicate astGuardsCompare(int startLine, string msg) {
       |
         msg = left + op + right + "+" + k + " when " + guard + " is " + which
       )
+    )
+    or
+    exists(AbstractValue value |
+      guard.comparesEq(left, k, true, value) and op = " == "
       or
-      (
-        guard.comparesEq(left, k, true, sense) and op = " == "
-        or
-        guard.comparesEq(left, k, false, sense) and op = " != "
-      ) and
-      msg = left + op + k + " when " + guard + " is " + which
-    ) and
+      guard.comparesEq(left, k, false, value) and op = " != "
+    |
+      msg = left + op + k + " when " + guard + " is " + value
+    )
+  |
     startLine = guard.getLocation().getStartLine()
   )
 }
@@ -71,8 +73,8 @@ query predicate astGuardsEnsure_const(
 query predicate irGuards(IRGuardCondition guard) { any() }
 
 query predicate irGuardsCompare(int startLine, string msg) {
-  exists(IRGuardCondition guard, Operand left, int k, string which, string op |
-    exists(boolean sense |
+  exists(IRGuardCondition guard, Operand left, int k, string op |
+    exists(boolean sense, string which |
       sense = true and which = "true"
       or
       sense = false and which = "false"
@@ -91,16 +93,18 @@ query predicate irGuardsCompare(int startLine, string msg) {
             right.getAnyDef().getUnconvertedResultExpression() + "+" + k + " when " + guard + " is "
             + which
       )
+    )
+    or
+    exists(AbstractValue value |
+      guard.comparesEq(left, k, true, value) and op = " == "
       or
-      (
-        guard.comparesEq(left, k, true, sense) and op = " == "
-        or
-        guard.comparesEq(left, k, false, sense) and op = " != "
-      ) and
+      guard.comparesEq(left, k, false, value) and op = " != "
+    |
       msg =
         left.getAnyDef().getUnconvertedResultExpression() + op + k + " when " + guard + " is " +
-          which
-    ) and
+          value
+    )
+  |
     startLine = guard.getLocation().getStartLine()
   )
 }

--- a/cpp/ql/test/library-tests/controlflow/guards/GuardsCompare.expected
+++ b/cpp/ql/test/library-tests/controlflow/guards/GuardsCompare.expected
@@ -55,9 +55,9 @@
 | 58 | y < 0+0 when ... < ... is true |
 | 58 | y >= 0+0 when ... < ... is false |
 | 58 | y >= 0+0 when ... \|\| ... is false |
-| 61 | i == 0 when i is true |
-| 61 | i == 1 when i is true |
-| 61 | i == 2 when i is true |
+| 61 | i == 0 when i is Case[0] |
+| 61 | i == 1 when i is Case[1] |
+| 61 | i == 2 when i is Case[2] |
 | 75 | 0 != x+0 when ... == ... is false |
 | 75 | 0 == x+0 when ... == ... is true |
 | 75 | x != 0 when ... == ... is false |

--- a/cpp/ql/test/library-tests/controlflow/guards/GuardsCompare.ql
+++ b/cpp/ql/test/library-tests/controlflow/guards/GuardsCompare.ql
@@ -7,9 +7,9 @@
 import cpp
 import semmle.code.cpp.controlflow.Guards
 
-from GuardCondition guard, Expr left, int k, string which, string op, string msg
+from GuardCondition guard, Expr left, int k, string op, string msg
 where
-  exists(boolean sense |
+  exists(boolean sense, string which |
     sense = true and which = "true"
     or
     sense = false and which = "false"
@@ -25,12 +25,13 @@ where
     |
       msg = left + op + right + "+" + k + " when " + guard + " is " + which
     )
+  )
+  or
+  exists(AbstractValue value |
+    guard.comparesEq(left, k, true, value) and op = " == "
     or
-    (
-      guard.comparesEq(left, k, true, sense) and op = " == "
-      or
-      guard.comparesEq(left, k, false, sense) and op = " != "
-    ) and
-    msg = left + op + k + " when " + guard + " is " + which
+    guard.comparesEq(left, k, false, value) and op = " != "
+  |
+    msg = left + op + k + " when " + guard + " is " + value
   )
 select guard.getLocation().getStartLine(), msg


### PR DESCRIPTION
I got the interface slightly wrong in https://github.com/github/codeql/pull/15958: In https://github.com/github/codeql/blob/219cd4e41514b53447a098c398b00047bf6e53b2/cpp/ql/lib/semmle/code/cpp/controlflow/IRGuards.qll#L143 it doesn't make sense to simply have a boolean to determine whether "the test was true or false" since the "test" may be the scrutinee of a `switch`. So instead, this PR updates the newly added predicates to instead have an `AbstractValue` column. The effect of this is visible in the [second commit](c640bd67e934de2efcbbb3c26abe4bc77afdcd45) where we previously had:
```
| 61 | i == 0 when i is true |
| 61 | i == 1 when i is true |
| 61 | i == 2 when i is true |
```
which made no sense.

Note that this isn't a breaking change since the new predicates has only been there for about ... 30 minutes 😂