### PR TITLE
Shared: Permit '*' in access path tokens.

### DIFF
--- a/shared/dataflow/codeql/dataflow/internal/AccessPathSyntax.qll
+++ b/shared/dataflow/codeql/dataflow/internal/AccessPathSyntax.qll
@@ -149,7 +149,7 @@ module AccessPath<accessPathRangeSig/1 accessPathRange> {
     // Avoid splitting by '.' since tokens may contain dots, e.g. `Field[foo.Bar.x]`.
     // Instead use regexpFind to match valid tokens, and supplement with a final length
     // check (in `AccessPath.hasSyntaxError`) to ensure all characters were included in a token.
-    result = path.regexpFind("\\w+(?:\\[[^\\]]*\\])?(?=\\.|$)", n, _)
+    result = path.regexpFind("[a-zA-Z_*0-9]+(?:\\[[^\\]]*\\])?(?=\\.|$)", n, _)
   }
 
   /**


### PR DESCRIPTION
We're experimenting with using `*` in access paths in CPP to denote indirection (e.g. `*Argument[0]` for the value pointed to by the first argument).  At present such a string does not parse.  This change makes `*` a permitted character in access path tokens (before the `[`).

... thinking about this, it might be more robust to accept *any* character apart from `[` / `;` / `.` (?) before the `[`.  I'm not confident that won't have any unintended consequences, but if you are, I'm happy to make that change.

@MathiasVP FYI, this change will be required for the models-as-data work in its current direction.