### PR TITLE
Go: Deal with incorrect toolchain versions

### DIFF
--- a/go/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/go/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -475,7 +475,7 @@ func installDependencies(workspace project.GoWorkspace) {
 	} else {
 		if workspace.Modules == nil {
 			project.InitGoModForLegacyProject(workspace.BaseDir)
-			workspace.Modules = project.LoadGoModules([]string{filepath.Join(workspace.BaseDir, "go.mod")})
+			workspace.Modules = project.LoadGoModules(true, []string{filepath.Join(workspace.BaseDir, "go.mod")})
 		}
 
 		// get dependencies for all modules

--- a/go/extractor/diagnostics/diagnostics.go
+++ b/go/extractor/diagnostics/diagnostics.go
@@ -508,3 +508,18 @@ func EmitExtractionFailedForProjects(path []string) {
 		noLocation,
 	)
 }
+
+func EmitInvalidToolchainVersion(goModPath string, version string) {
+	emitDiagnostic(
+		"go/autobuilder/invalid-go-toolchain-version",
+		fmt.Sprintf("`%s` is not a valid Go toolchain version", version),
+		strings.Join([]string{
+			"As of Go 1.21, toolchain versions [must use the 1.N.P syntax](https://tip.golang.org/doc/toolchain#version).",
+			fmt.Sprintf("`%s` in `%s` does not match this syntax and there is no additional `toolchain` directive, which may cause some `go` commands to fail.", version, goModPath),
+		},
+			"\n\n"),
+		severityWarning,
+		fullVisibility,
+		&locationStruct{File: goModPath},
+	)
+}

--- a/go/extractor/diagnostics/diagnostics.go
+++ b/go/extractor/diagnostics/diagnostics.go
@@ -497,7 +497,7 @@ func EmitNewerSystemGoRequired(requiredVersion string) {
 func EmitExtractionFailedForProjects(path []string) {
 	emitDiagnostic(
 		"go/autobuilder/extraction-failed-for-project",
-		fmt.Sprintf("Unable to extract %d Go projects", len(path)),
+		"Unable to extract some Go projects",
 		fmt.Sprintf(
 			"The following %d Go project%s could not be extracted successfully:\n\n`%s`\n",
 			len(path),
@@ -512,9 +512,9 @@ func EmitExtractionFailedForProjects(path []string) {
 func EmitInvalidToolchainVersion(goModPath string, version string) {
 	emitDiagnostic(
 		"go/autobuilder/invalid-go-toolchain-version",
-		fmt.Sprintf("`%s` is not a valid Go toolchain version", version),
+		"Invalid Go toolchain version",
 		strings.Join([]string{
-			"As of Go 1.21, toolchain versions [must use the 1.N.P syntax](https://tip.golang.org/doc/toolchain#version).",
+			"As of Go 1.21, toolchain versions [must use the 1.N.P syntax](https://go.dev/doc/toolchain#version).",
 			fmt.Sprintf("`%s` in `%s` does not match this syntax and there is no additional `toolchain` directive, which may cause some `go` commands to fail.", version, goModPath),
 		},
 			"\n\n"),

--- a/go/extractor/project/project.go
+++ b/go/extractor/project/project.go
@@ -212,6 +212,16 @@ func LoadGoModules(emitDiagnostics bool, goModFilePaths []string) []*GoModule {
 		if modFile.Toolchain == nil && modFile.Go != nil &&
 			!toolchainVersionRe.Match([]byte(modFile.Go.Version)) && semver.Compare("v"+modFile.Go.Version, "v1.21.0") >= 0 {
 			diagnostics.EmitInvalidToolchainVersion(goModFilePath, modFile.Go.Version)
+
+			modPath := filepath.Dir(goModFilePath)
+
+			log.Printf(
+				"`%s` is not a valid toolchain version, trying to install it explicitly using the canonical representation in `%s`.",
+				modFile.Go.Version,
+				modPath,
+			)
+
+			toolchain.InstallVersion(modPath, modFile.Go.Version)
 		}
 	}
 

--- a/go/extractor/toolchain/toolchain.go
+++ b/go/extractor/toolchain/toolchain.go
@@ -23,7 +23,7 @@ var goVersions = map[string]struct{}{}
 
 // Adds an entry to the set of installed Go versions for the normalised `version` number.
 func addGoVersion(version string) {
-	goVersions[semver.Canonical(version)] = struct{}{}
+	goVersions[semver.Canonical("v"+version)] = struct{}{}
 }
 
 // Returns the current Go version as returned by 'go version', e.g. go1.14.4
@@ -42,14 +42,14 @@ func GetEnvGoVersion() string {
 		}
 
 		goVersion = parseGoVersion(string(out))
-		addGoVersion(goVersion)
+		addGoVersion(goVersion[2:])
 	}
 	return goVersion
 }
 
 // Determines whether, to our knowledge, `version` is available on the current system.
 func HasGoVersion(version string) bool {
-	_, found := goVersions[semver.Canonical(version)]
+	_, found := goVersions[semver.Canonical("v"+version)]
 	return found
 }
 
@@ -63,7 +63,7 @@ func InstallVersion(workingDir string, version string) bool {
 	// Construct a command to invoke `go version` with `GOTOOLCHAIN=go1.N.0` to give
 	// Go a valid toolchain version to download the toolchain we need; subsequent commands
 	// should then work even with an invalid version that's still in `go.mod`
-	toolchainArg := "GOTOOLCHAIN=go" + semver.Canonical(version)
+	toolchainArg := "GOTOOLCHAIN=go" + semver.Canonical("v" + version)[1:]
 	versionCmd := Version()
 	versionCmd.Dir = workingDir
 	versionCmd.Env = append(os.Environ(), toolchainArg)

--- a/go/extractor/toolchain/toolchain.go
+++ b/go/extractor/toolchain/toolchain.go
@@ -67,6 +67,8 @@ func InstallVersion(workingDir string, version string) bool {
 	versionCmd := Version()
 	versionCmd.Dir = workingDir
 	versionCmd.Env = append(os.Environ(), toolchainArg)
+	versionCmd.Stdout = os.Stdout
+	versionCmd.Stderr = os.Stderr
 
 	log.Printf(
 		"Trying to install Go %s using its canonical representation in `%s`.",

--- a/go/extractor/toolchain/toolchain.go
+++ b/go/extractor/toolchain/toolchain.go
@@ -25,7 +25,7 @@ func GetEnvGoVersion() string {
 		// download the version of Go specified in there. That may either fail or result in us just
 		// being told what's already in 'go.mod'. Setting 'GOTOOLCHAIN' to 'local' will force it
 		// to use the local Go toolchain instead.
-		cmd := exec.Command("go", "version")
+		cmd := Version()
 		cmd.Env = append(os.Environ(), "GOTOOLCHAIN=local")
 		out, err := cmd.CombinedOutput()
 
@@ -91,4 +91,10 @@ func VendorModule(path string) *exec.Cmd {
 	modVendor := exec.Command("go", "mod", "vendor", "-e")
 	modVendor.Dir = path
 	return modVendor
+}
+
+// Constructs a command to run `go version`.
+func Version() *exec.Cmd {
+	version := exec.Command("go", "version")
+	return version
 }

--- a/go/extractor/toolchain/toolchain_test.go
+++ b/go/extractor/toolchain/toolchain_test.go
@@ -17,6 +17,6 @@ func TestParseGoVersion(t *testing.T) {
 
 func TestHasGoVersion(t *testing.T) {
 	if HasGoVersion("1.21") {
-		t.Error("Exepected HasGoVersion(\"1.21\") to be false, but got true")
+		t.Error("Expected HasGoVersion(\"1.21\") to be false, but got true")
 	}
 }

--- a/go/extractor/toolchain/toolchain_test.go
+++ b/go/extractor/toolchain/toolchain_test.go
@@ -14,3 +14,9 @@ func TestParseGoVersion(t *testing.T) {
 		}
 	}
 }
+
+func TestHasGoVersion(t *testing.T) {
+	if HasGoVersion("1.21") {
+		t.Error("Exepected HasGoVersion(\"1.21\" to be false, but got true)")
+	}
+}

--- a/go/extractor/toolchain/toolchain_test.go
+++ b/go/extractor/toolchain/toolchain_test.go
@@ -17,6 +17,6 @@ func TestParseGoVersion(t *testing.T) {
 
 func TestHasGoVersion(t *testing.T) {
 	if HasGoVersion("1.21") {
-		t.Error("Exepected HasGoVersion(\"1.21\" to be false, but got true)")
+		t.Error("Exepected HasGoVersion(\"1.21\") to be false, but got true")
 	}
 }

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/invalid-toolchain-version/diagnostics.expected
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/invalid-toolchain-version/diagnostics.expected
@@ -2,12 +2,12 @@
   "location": {
     "file": "go.mod"
   },
-  "markdownMessage": "As of Go 1.21, toolchain versions [must use the 1.N.P syntax](https://tip.golang.org/doc/toolchain#version).\n\n`1.21` in `go.mod` does not match this syntax and there is no additional `toolchain` directive, which may cause some `go` commands to fail.",
+  "markdownMessage": "As of Go 1.21, toolchain versions [must use the 1.N.P syntax](https://go.dev/doc/toolchain#version).\n\n`1.21` in `go.mod` does not match this syntax and there is no additional `toolchain` directive, which may cause some `go` commands to fail.",
   "severity": "warning",
   "source": {
     "extractorName": "go",
     "id": "go/autobuilder/invalid-go-toolchain-version",
-    "name": "`1.21` is not a valid Go toolchain version"
+    "name": "Invalid Go toolchain version"
   },
   "visibility": {
     "cliSummaryTable": true,

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/invalid-toolchain-version/diagnostics.expected
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/invalid-toolchain-version/diagnostics.expected
@@ -1,0 +1,31 @@
+{
+  "location": {
+    "file": "go.mod"
+  },
+  "markdownMessage": "As of Go 1.21, toolchain versions [must use the 1.N.P syntax](https://tip.golang.org/doc/toolchain#version).\n\n`1.21` in `go.mod` does not match this syntax and there is no additional `toolchain` directive, which may cause some `go` commands to fail.",
+  "severity": "warning",
+  "source": {
+    "extractorName": "go",
+    "id": "go/autobuilder/invalid-go-toolchain-version",
+    "name": "`1.21` is not a valid Go toolchain version"
+  },
+  "visibility": {
+    "cliSummaryTable": true,
+    "statusPage": true,
+    "telemetry": true
+  }
+}
+{
+  "markdownMessage": "A single `go.mod` file was found.\n\n`go.mod`",
+  "severity": "note",
+  "source": {
+    "extractorName": "go",
+    "id": "go/autobuilder/single-root-go-mod-found",
+    "name": "A single `go.mod` file was found in the root"
+  },
+  "visibility": {
+    "cliSummaryTable": false,
+    "statusPage": false,
+    "telemetry": true
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/invalid-toolchain-version/src/go.mod
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/invalid-toolchain-version/src/go.mod
@@ -1,0 +1,3 @@
+go 1.21
+
+module example

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/invalid-toolchain-version/src/main.go
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/invalid-toolchain-version/src/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+
+}

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/invalid-toolchain-version/test.py
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/invalid-toolchain-version/test.py
@@ -1,0 +1,19 @@
+import os
+import subprocess
+
+from create_database_utils import *
+from diagnostics_test_utils import *
+
+# Set up a GOPATH relative to this test's root directory;
+# we set os.environ instead of using extra_env because we
+# need it to be set for the call to "go clean -modcache" later
+goPath = os.path.join(os.path.abspath(os.getcwd()), ".go")
+os.environ['GOPATH'] = goPath
+os.environ['LGTM_INDEX_IMPORT_PATH'] = "test"
+run_codeql_database_create([], lang="go", source="src")
+
+check_diagnostics()
+
+# Clean up the temporary GOPATH to prevent Bazel failures next
+# time the tests are run; see https://github.com/golang/go/issues/27161
+subprocess.call(["go", "clean", "-modcache"])

--- a/go/ql/integration-tests/all-platforms/go/go-version-bump/diagnostics.expected
+++ b/go/ql/integration-tests/all-platforms/go/go-version-bump/diagnostics.expected
@@ -1,0 +1,31 @@
+{
+  "location": {
+    "file": "go.mod"
+  },
+  "markdownMessage": "As of Go 1.21, toolchain versions [must use the 1.N.P syntax](https://go.dev/doc/toolchain#version).\n\n`1.21` in `go.mod` does not match this syntax and there is no additional `toolchain` directive, which may cause some `go` commands to fail.",
+  "severity": "warning",
+  "source": {
+    "extractorName": "go",
+    "id": "go/autobuilder/invalid-go-toolchain-version",
+    "name": "Invalid Go toolchain version"
+  },
+  "visibility": {
+    "cliSummaryTable": true,
+    "statusPage": true,
+    "telemetry": true
+  }
+}
+{
+  "markdownMessage": "A single `go.mod` file was found.\n\n`go.mod`",
+  "severity": "note",
+  "source": {
+    "extractorName": "go",
+    "id": "go/autobuilder/single-root-go-mod-found",
+    "name": "A single `go.mod` file was found in the root"
+  },
+  "visibility": {
+    "cliSummaryTable": false,
+    "statusPage": false,
+    "telemetry": true
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/go-version-bump/src/go.mod
+++ b/go/ql/integration-tests/all-platforms/go/go-version-bump/src/go.mod
@@ -1,0 +1,3 @@
+go 1.21
+
+module test

--- a/go/ql/integration-tests/all-platforms/go/go-version-bump/src/main.go
+++ b/go/ql/integration-tests/all-platforms/go/go-version-bump/src/main.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}

--- a/go/ql/integration-tests/all-platforms/go/go-version-bump/test.py
+++ b/go/ql/integration-tests/all-platforms/go/go-version-bump/test.py
@@ -1,0 +1,18 @@
+import os
+import subprocess
+
+from create_database_utils import *
+from diagnostics_test_utils import *
+
+# Set up a GOPATH relative to this test's root directory;
+# we set os.environ instead of using extra_env because we
+# need it to be set for the call to "go clean -modcache" later
+goPath = os.path.join(os.path.abspath(os.getcwd()), ".go")
+os.environ['GOPATH'] = goPath
+run_codeql_database_create([], lang="go", source="src")
+
+check_diagnostics()
+
+# Clean up the temporary GOPATH to prevent Bazel failures next
+# time the tests are run; see https://github.com/golang/go/issues/27161
+subprocess.call(["go", "clean", "-modcache"])

--- a/go/ql/integration-tests/all-platforms/go/two-go-mods-one-failure/diagnostics.expected
+++ b/go/ql/integration-tests/all-platforms/go/two-go-mods-one-failure/diagnostics.expected
@@ -18,7 +18,7 @@
   "source": {
     "extractorName": "go",
     "id": "go/autobuilder/extraction-failed-for-project",
-    "name": "Unable to extract 1 Go projects"
+    "name": "Unable to extract some Go projects"
   },
   "visibility": {
     "cliSummaryTable": true,


### PR DESCRIPTION
Starting in Go 1.21, Go uses a new version format for toolchains which uses [the `1.N.P` syntax](https://tip.golang.org/doc/toolchain#version). This is a problem for our users when their `go.mod` files only contain a `go` directive that uses the old version format, e.g. `go 1.22`. `1.22` is a valid _language_ version, but not a valid _toolchain_ version. If there is no additional `toolchain` directive in the `go.mod` file, then `go` uses the _language_ version as the _toolchain_ version. In the example, `1.22` is _not_ a valid _toolchain_ version and certain `go` commands, particularly those which try to acquire the toolchain corresponding to that version, fail with an unhelpful error.

In this PR, we make two changes to the Go autobuilder:

1. We detect `go.mod` files where the _language_ version is `1.21` or greater, doesn't use the new toolchain version syntax, and there is no explicit `toolchain` directive. We emit a warning-level diagnostic in this case.
2. We explicitly invoke `go version` with `GOTOOLCHAIN=go1.N.P` (i.e. the correct representation of the toolchain version) to get `go` to install that version and avoid subsequent errors despite the incorrect version format. As an optimisation for repos with a lot of `go.mod` files, we now keep track of toolchain versions that we know are installed and only do this if we don't yet know that the corresponding version is installed.