### PR TITLE
Ruby: Extend barrier guards to handle phi inputs

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -72,47 +72,51 @@ CfgNodes::ExprCfgNode getAPostUpdateNodeForArg(Argument arg) {
   not exists(getALastEvalNode(result))
 }
 
-/** Provides predicates related to local data flow. */
-module LocalFlow {
-  private import codeql.ruby.dataflow.internal.SsaImpl
-
-  /** An SSA definition into which another SSA definition may flow. */
-  private class SsaInputDefinitionExtNode extends SsaDefinitionExtNode {
-    SsaInputDefinitionExtNode() {
-      def instanceof Ssa::PhiNode
-      or
-      def instanceof SsaImpl::PhiReadNode
-    }
+/** An SSA definition into which another SSA definition may flow. */
+class SsaInputDefinitionExt extends SsaImpl::DefinitionExt {
+  SsaInputDefinitionExt() {
+    this instanceof Ssa::PhiNode
+    or
+    this instanceof SsaImpl::PhiReadNode
   }
 
+  predicate hasInputFromBlock(SsaImpl::DefinitionExt def, BasicBlock bb, int i, BasicBlock input) {
+    SsaImpl::lastRefBeforeRedefExt(def, bb, i, input, this)
+  }
+}
+
+/** Provides predicates related to local data flow. */
+module LocalFlow {
   /**
    * Holds if `nodeFrom` is a node for SSA definition `def`, which can reach `next`.
    */
   pragma[nomagic]
   private predicate localFlowSsaInputFromDef(
-    SsaDefinitionExtNode nodeFrom, SsaImpl::DefinitionExt def, SsaInputDefinitionExtNode next
+    SsaDefinitionExtNode nodeFrom, SsaImpl::DefinitionExt def, SsaInputNode nodeTo
   ) {
-    exists(BasicBlock bb, int i |
-      lastRefBeforeRedefExt(def, bb, i, next.getDefinitionExt()) and
+    exists(BasicBlock bb, int i, BasicBlock input, SsaInputDefinitionExt next |
+      next.hasInputFromBlock(def, bb, i, input) and
       def = nodeFrom.getDefinitionExt() and
       def.definesAt(_, bb, i, _) and
-      nodeFrom != next
+      nodeTo = TSsaInputNode(next, input)
     )
   }
 
   /**
    * Holds if `nodeFrom` is a last read of SSA definition `def`, which
-   * can reach `next`.
+   * can reach `nodeTo`.
    */
   pragma[nomagic]
-  predicate localFlowSsaInputFromRead(
-    SsaImpl::DefinitionExt def, Node nodeFrom, SsaInputDefinitionExtNode next
-  ) {
-    exists(BasicBlock bb, int i, CfgNodes::ExprCfgNode exprFrom |
-      SsaImpl::lastRefBeforeRedefExt(def, bb, i, next.getDefinitionExt()) and
+  predicate localFlowSsaInputFromRead(SsaImpl::DefinitionExt def, Node nodeFrom, SsaInputNode nodeTo) {
+    exists(
+      BasicBlock bb, int i, CfgNodes::ExprCfgNode exprFrom, BasicBlock input,
+      SsaInputDefinitionExt next
+    |
+      next.hasInputFromBlock(def, bb, i, input) and
       exprFrom = bb.getNode(i) and
       exprFrom.getExpr() instanceof VariableReadAccess and
-      exprFrom = [nodeFrom.asExpr(), nodeFrom.(PostUpdateNodeImpl).getPreUpdateNode().asExpr()]
+      exprFrom = [nodeFrom.asExpr(), nodeFrom.(PostUpdateNodeImpl).getPreUpdateNode().asExpr()] and
+      nodeTo = TSsaInputNode(next, input)
     )
   }
 
@@ -181,13 +185,16 @@ module LocalFlow {
     or
     // Flow from SSA definition to first read
     def = nodeFrom.(SsaDefinitionExtNode).getDefinitionExt() and
-    firstReadExt(def, nodeTo.asExpr())
+    SsaImpl::firstReadExt(def, nodeTo.asExpr())
     or
     // Flow from post-update read to next read
     localSsaFlowStepUseUse(def, nodeFrom.(PostUpdateNodeImpl).getPreUpdateNode(), nodeTo)
     or
     // Flow into phi (read) SSA definition node from def
     localFlowSsaInputFromDef(nodeFrom, def, nodeTo)
+    or
+    nodeTo.(SsaDefinitionExtNode).getDefinitionExt() = def and
+    def = nodeFrom.(SsaInputNode).getDefinitionExt()
     or
     localFlowSsaParamInput(nodeFrom, nodeTo) and
     def = nodeTo.(SsaDefinitionExtNode).getDefinitionExt()
@@ -530,6 +537,9 @@ private module Cached {
     TExprNode(CfgNodes::ExprCfgNode n) or
     TReturningNode(CfgNodes::ReturningCfgNode n) { exists(n.getReturnedValueNode()) } or
     TSsaDefinitionExtNode(SsaImpl::DefinitionExt def) or
+    TSsaInputNode(SsaInputDefinitionExt def, BasicBlock input) {
+      def.hasInputFromBlock(_, _, _, input)
+    } or
     TCapturedVariableNode(VariableCapture::CapturedVariable v) or
     TNormalParameterNode(Parameter p) {
       p instanceof SimpleParameter or
@@ -802,6 +812,8 @@ import Cached
 predicate nodeIsHidden(Node n) {
   n.(SsaDefinitionExtNode).isHidden()
   or
+  n instanceof SsaInputNode
+  or
   n = LocalFlow::getParameterDefNode(_)
   or
   exists(AstNode desug |
@@ -861,6 +873,57 @@ class SsaDefinitionExtNode extends NodeImpl, TSsaDefinitionExtNode {
   override Location getLocationImpl() { result = def.getLocation() }
 
   override string toStringImpl() { result = def.toString() }
+}
+
+/**
+ * A node that represents an input to an SSA phi (read) definition.
+ *
+ * This allows for barrier guards to filter input to phi nodes. For example, in
+ *
+ * ```rb
+ * x = taint
+ * if x != "safe" then
+ *     x = "safe"
+ * end
+ * sink x
+ * ```
+ *
+ * the `false` edge out of `x != "safe"` guards the input from `x = taint` into the
+ * `phi` node after the condition.
+ *
+ * It is also relevant to filter input into phi read nodes:
+ *
+ * ```rb
+ * x = taint
+ * if b then
+ *     if x != "safe1" then
+ *         return
+ *     end
+ * else
+ *     if x != "safe2" then
+ *         return
+ *     end
+ * end
+ *
+ * sink x
+ * ```
+ *
+ * both inputs into the phi read node after the outer condition are guarded.
+ */
+class SsaInputNode extends NodeImpl, TSsaInputNode {
+  SsaImpl::DefinitionExt def;
+  BasicBlock input;
+
+  SsaInputNode() { this = TSsaInputNode(def, input) }
+
+  /** Gets the underlying SSA definition. */
+  SsaImpl::DefinitionExt getDefinitionExt() { result = def }
+
+  override CfgScope getCfgScope() { result = input.getScope() }
+
+  override Location getLocationImpl() { result = input.getLastNode().getLocation() }
+
+  override string toStringImpl() { result = "[input] " + def }
 }
 
 /** An SSA definition for a `self` variable. */

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
@@ -856,24 +856,52 @@ private predicate sameSourceVariable(Ssa::Definition def1, Ssa::Definition def2)
  * in data flow and taint tracking.
  */
 module BarrierGuard<guardChecksSig/3 guardChecks> {
+  private import SsaImpl as SsaImpl
+
   pragma[nomagic]
   private predicate guardChecksSsaDef(CfgNodes::AstCfgNode g, boolean branch, Ssa::Definition def) {
     guardChecks(g, def.getARead(), branch)
   }
 
   pragma[nomagic]
-  private predicate guardControlsSsaDef(
+  private predicate guardControlsSsaRead(
     CfgNodes::AstCfgNode g, boolean branch, Ssa::Definition def, Node n
   ) {
     def.getARead() = n.asExpr() and
     guardControlsBlock(g, n.asExpr().getBasicBlock(), branch)
   }
 
+  pragma[nomagic]
+  private predicate guardControlsPhiInput(
+    CfgNodes::AstCfgNode g, boolean branch, Ssa::Definition def, BasicBlock input,
+    SsaInputDefinitionExt phi
+  ) {
+    phi.hasInputFromBlock(def, _, _, input) and
+    (
+      guardControlsBlock(g, input, branch)
+      or
+      exists(SuccessorTypes::ConditionalSuccessor s |
+        g = input.getLastNode() and
+        s.getValue() = branch and
+        input.getASuccessor(s) = phi.getBasicBlock()
+      )
+    )
+  }
+
   /** Gets a node that is safely guarded by the given guard check. */
   Node getABarrierNode() {
     exists(CfgNodes::AstCfgNode g, boolean branch, Ssa::Definition def |
       guardChecksSsaDef(g, branch, def) and
-      guardControlsSsaDef(g, branch, def, result)
+      guardControlsSsaRead(g, branch, def, result)
+    )
+    or
+    exists(
+      CfgNodes::AstCfgNode g, boolean branch, Ssa::Definition def, BasicBlock input,
+      SsaInputDefinitionExt phi
+    |
+      guardChecksSsaDef(g, branch, def) and
+      guardControlsPhiInput(g, branch, def, input, phi) and
+      result = TSsaInputNode(phi, input)
     )
     or
     result.asExpr() = getAMaybeGuardedCapturedDef().getARead()

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
@@ -459,14 +459,16 @@ private module Cached {
    * The reference is either a read of `def` or `def` itself.
    */
   cached
-  predicate lastRefBeforeRedefExt(DefinitionExt def, Cfg::BasicBlock bb, int i, DefinitionExt next) {
+  predicate lastRefBeforeRedefExt(
+    DefinitionExt def, Cfg::BasicBlock bb, int i, Cfg::BasicBlock input, DefinitionExt next
+  ) {
     exists(LocalVariable v |
-      Impl::lastRefRedefExt(def, v, bb, i, next) and
+      Impl::lastRefRedefExt(def, v, bb, i, input, next) and
       not SsaInput::variableRead(bb, i, v, false)
     )
     or
     exists(SsaInput::BasicBlock bb0, int i0 |
-      Impl::lastRefRedefExt(def, _, bb0, i0, next) and
+      Impl::lastRefRedefExt(def, _, bb0, i0, input, next) and
       adjacentDefReachesUncertainReadExt(def, bb, i, bb0, i0)
     )
   }

--- a/ruby/ql/test/library-tests/dataflow/barrier-guards/barrier-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/barrier-guards/barrier-flow.expected
@@ -6,14 +6,6 @@ edges
 | barrier_flow.rb:8:9:8:17 | call to source | barrier_flow.rb:8:5:8:5 | x | provenance |  |
 | barrier_flow.rb:24:5:24:5 | x | barrier_flow.rb:26:10:26:10 | x | provenance |  |
 | barrier_flow.rb:24:9:24:17 | call to source | barrier_flow.rb:24:5:24:5 | x | provenance |  |
-| barrier_flow.rb:36:5:36:5 | x | barrier_flow.rb:42:10:42:10 | x | provenance |  |
-| barrier_flow.rb:36:9:36:17 | call to source | barrier_flow.rb:36:5:36:5 | x | provenance |  |
-| barrier_flow.rb:46:5:46:5 | x | barrier_flow.rb:50:10:50:10 | x | provenance |  |
-| barrier_flow.rb:46:9:46:17 | call to source | barrier_flow.rb:46:5:46:5 | x | provenance |  |
-| barrier_flow.rb:54:5:54:5 | x | barrier_flow.rb:62:10:62:10 | x | provenance |  |
-| barrier_flow.rb:54:9:54:17 | call to source | barrier_flow.rb:54:5:54:5 | x | provenance |  |
-| barrier_flow.rb:66:5:66:5 | x | barrier_flow.rb:78:10:78:10 | x | provenance |  |
-| barrier_flow.rb:66:9:66:17 | call to source | barrier_flow.rb:66:5:66:5 | x | provenance |  |
 nodes
 | barrier_flow.rb:2:5:2:5 | x | semmle.label | x |
 | barrier_flow.rb:2:9:2:17 | call to source | semmle.label | call to source |
@@ -24,24 +16,8 @@ nodes
 | barrier_flow.rb:24:5:24:5 | x | semmle.label | x |
 | barrier_flow.rb:24:9:24:17 | call to source | semmle.label | call to source |
 | barrier_flow.rb:26:10:26:10 | x | semmle.label | x |
-| barrier_flow.rb:36:5:36:5 | x | semmle.label | x |
-| barrier_flow.rb:36:9:36:17 | call to source | semmle.label | call to source |
-| barrier_flow.rb:42:10:42:10 | x | semmle.label | x |
-| barrier_flow.rb:46:5:46:5 | x | semmle.label | x |
-| barrier_flow.rb:46:9:46:17 | call to source | semmle.label | call to source |
-| barrier_flow.rb:50:10:50:10 | x | semmle.label | x |
-| barrier_flow.rb:54:5:54:5 | x | semmle.label | x |
-| barrier_flow.rb:54:9:54:17 | call to source | semmle.label | call to source |
-| barrier_flow.rb:62:10:62:10 | x | semmle.label | x |
-| barrier_flow.rb:66:5:66:5 | x | semmle.label | x |
-| barrier_flow.rb:66:9:66:17 | call to source | semmle.label | call to source |
-| barrier_flow.rb:78:10:78:10 | x | semmle.label | x |
 subpaths
 #select
 | barrier_flow.rb:4:10:4:10 | x | barrier_flow.rb:2:9:2:17 | call to source | barrier_flow.rb:4:10:4:10 | x | $@ | barrier_flow.rb:2:9:2:17 | call to source | call to source |
 | barrier_flow.rb:11:14:11:14 | x | barrier_flow.rb:8:9:8:17 | call to source | barrier_flow.rb:11:14:11:14 | x | $@ | barrier_flow.rb:8:9:8:17 | call to source | call to source |
 | barrier_flow.rb:26:10:26:10 | x | barrier_flow.rb:24:9:24:17 | call to source | barrier_flow.rb:26:10:26:10 | x | $@ | barrier_flow.rb:24:9:24:17 | call to source | call to source |
-| barrier_flow.rb:42:10:42:10 | x | barrier_flow.rb:36:9:36:17 | call to source | barrier_flow.rb:42:10:42:10 | x | $@ | barrier_flow.rb:36:9:36:17 | call to source | call to source |
-| barrier_flow.rb:50:10:50:10 | x | barrier_flow.rb:46:9:46:17 | call to source | barrier_flow.rb:50:10:50:10 | x | $@ | barrier_flow.rb:46:9:46:17 | call to source | call to source |
-| barrier_flow.rb:62:10:62:10 | x | barrier_flow.rb:54:9:54:17 | call to source | barrier_flow.rb:62:10:62:10 | x | $@ | barrier_flow.rb:54:9:54:17 | call to source | call to source |
-| barrier_flow.rb:78:10:78:10 | x | barrier_flow.rb:66:9:66:17 | call to source | barrier_flow.rb:78:10:78:10 | x | $@ | barrier_flow.rb:66:9:66:17 | call to source | call to source |

--- a/ruby/ql/test/library-tests/dataflow/barrier-guards/barrier-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/barrier-guards/barrier-flow.expected
@@ -1,0 +1,47 @@
+testFailures
+edges
+| barrier_flow.rb:2:5:2:5 | x | barrier_flow.rb:4:10:4:10 | x | provenance |  |
+| barrier_flow.rb:2:9:2:17 | call to source | barrier_flow.rb:2:5:2:5 | x | provenance |  |
+| barrier_flow.rb:8:5:8:5 | x | barrier_flow.rb:11:14:11:14 | x | provenance |  |
+| barrier_flow.rb:8:9:8:17 | call to source | barrier_flow.rb:8:5:8:5 | x | provenance |  |
+| barrier_flow.rb:24:5:24:5 | x | barrier_flow.rb:26:10:26:10 | x | provenance |  |
+| barrier_flow.rb:24:9:24:17 | call to source | barrier_flow.rb:24:5:24:5 | x | provenance |  |
+| barrier_flow.rb:36:5:36:5 | x | barrier_flow.rb:42:10:42:10 | x | provenance |  |
+| barrier_flow.rb:36:9:36:17 | call to source | barrier_flow.rb:36:5:36:5 | x | provenance |  |
+| barrier_flow.rb:46:5:46:5 | x | barrier_flow.rb:50:10:50:10 | x | provenance |  |
+| barrier_flow.rb:46:9:46:17 | call to source | barrier_flow.rb:46:5:46:5 | x | provenance |  |
+| barrier_flow.rb:54:5:54:5 | x | barrier_flow.rb:62:10:62:10 | x | provenance |  |
+| barrier_flow.rb:54:9:54:17 | call to source | barrier_flow.rb:54:5:54:5 | x | provenance |  |
+| barrier_flow.rb:66:5:66:5 | x | barrier_flow.rb:78:10:78:10 | x | provenance |  |
+| barrier_flow.rb:66:9:66:17 | call to source | barrier_flow.rb:66:5:66:5 | x | provenance |  |
+nodes
+| barrier_flow.rb:2:5:2:5 | x | semmle.label | x |
+| barrier_flow.rb:2:9:2:17 | call to source | semmle.label | call to source |
+| barrier_flow.rb:4:10:4:10 | x | semmle.label | x |
+| barrier_flow.rb:8:5:8:5 | x | semmle.label | x |
+| barrier_flow.rb:8:9:8:17 | call to source | semmle.label | call to source |
+| barrier_flow.rb:11:14:11:14 | x | semmle.label | x |
+| barrier_flow.rb:24:5:24:5 | x | semmle.label | x |
+| barrier_flow.rb:24:9:24:17 | call to source | semmle.label | call to source |
+| barrier_flow.rb:26:10:26:10 | x | semmle.label | x |
+| barrier_flow.rb:36:5:36:5 | x | semmle.label | x |
+| barrier_flow.rb:36:9:36:17 | call to source | semmle.label | call to source |
+| barrier_flow.rb:42:10:42:10 | x | semmle.label | x |
+| barrier_flow.rb:46:5:46:5 | x | semmle.label | x |
+| barrier_flow.rb:46:9:46:17 | call to source | semmle.label | call to source |
+| barrier_flow.rb:50:10:50:10 | x | semmle.label | x |
+| barrier_flow.rb:54:5:54:5 | x | semmle.label | x |
+| barrier_flow.rb:54:9:54:17 | call to source | semmle.label | call to source |
+| barrier_flow.rb:62:10:62:10 | x | semmle.label | x |
+| barrier_flow.rb:66:5:66:5 | x | semmle.label | x |
+| barrier_flow.rb:66:9:66:17 | call to source | semmle.label | call to source |
+| barrier_flow.rb:78:10:78:10 | x | semmle.label | x |
+subpaths
+#select
+| barrier_flow.rb:4:10:4:10 | x | barrier_flow.rb:2:9:2:17 | call to source | barrier_flow.rb:4:10:4:10 | x | $@ | barrier_flow.rb:2:9:2:17 | call to source | call to source |
+| barrier_flow.rb:11:14:11:14 | x | barrier_flow.rb:8:9:8:17 | call to source | barrier_flow.rb:11:14:11:14 | x | $@ | barrier_flow.rb:8:9:8:17 | call to source | call to source |
+| barrier_flow.rb:26:10:26:10 | x | barrier_flow.rb:24:9:24:17 | call to source | barrier_flow.rb:26:10:26:10 | x | $@ | barrier_flow.rb:24:9:24:17 | call to source | call to source |
+| barrier_flow.rb:42:10:42:10 | x | barrier_flow.rb:36:9:36:17 | call to source | barrier_flow.rb:42:10:42:10 | x | $@ | barrier_flow.rb:36:9:36:17 | call to source | call to source |
+| barrier_flow.rb:50:10:50:10 | x | barrier_flow.rb:46:9:46:17 | call to source | barrier_flow.rb:50:10:50:10 | x | $@ | barrier_flow.rb:46:9:46:17 | call to source | call to source |
+| barrier_flow.rb:62:10:62:10 | x | barrier_flow.rb:54:9:54:17 | call to source | barrier_flow.rb:62:10:62:10 | x | $@ | barrier_flow.rb:54:9:54:17 | call to source | call to source |
+| barrier_flow.rb:78:10:78:10 | x | barrier_flow.rb:66:9:66:17 | call to source | barrier_flow.rb:78:10:78:10 | x | $@ | barrier_flow.rb:66:9:66:17 | call to source | call to source |

--- a/ruby/ql/test/library-tests/dataflow/barrier-guards/barrier-flow.ql
+++ b/ruby/ql/test/library-tests/dataflow/barrier-guards/barrier-flow.ql
@@ -1,0 +1,23 @@
+/**
+ * @kind path-problem
+ */
+
+import codeql.ruby.AST
+import codeql.ruby.CFG
+import TestUtilities.InlineFlowTest
+import codeql.ruby.dataflow.BarrierGuards
+import PathGraph
+
+module FlowConfig implements DataFlow::ConfigSig {
+  predicate isSource = DefaultFlowConfig::isSource/1;
+
+  predicate isSink = DefaultFlowConfig::isSink/1;
+
+  predicate isBarrier(DataFlow::Node n) { n instanceof StringConstCompareBarrier }
+}
+
+import ValueFlowTest<FlowConfig>
+
+from PathNode source, PathNode sink
+where flowPath(source, sink)
+select sink, source, sink, "$@", source, source.toString()

--- a/ruby/ql/test/library-tests/dataflow/barrier-guards/barrier-guards.expected
+++ b/ruby/ql/test/library-tests/dataflow/barrier-guards/barrier-guards.expected
@@ -36,6 +36,8 @@ newStyleBarrierGuards
 | barrier-guards.rb:276:5:276:7 | foo |
 | barrier-guards.rb:282:5:282:7 | foo |
 | barrier-guards.rb:292:5:292:7 | foo |
+| barrier_flow.rb:19:14:19:14 | x |
+| barrier_flow.rb:32:10:32:10 | x |
 controls
 | barrier-guards.rb:3:4:3:15 | ... == ... | barrier-guards.rb:4:5:4:7 | foo | true |
 | barrier-guards.rb:3:4:3:15 | ... == ... | barrier-guards.rb:6:5:6:7 | foo | false |
@@ -331,3 +333,29 @@ controls
 | barrier-guards.rb:291:6:291:6 | g | barrier-guards.rb:291:1:292:19 | [no-match] when ... | no-match |
 | barrier-guards.rb:291:6:291:6 | g | barrier-guards.rb:292:5:292:7 | foo | match |
 | barrier-guards.rb:291:6:291:6 | g | barrier-guards.rb:294:5:294:7 | foo | no-match |
+| barrier_flow.rb:10:8:10:18 | ... != ... | barrier_flow.rb:11:9:11:14 | self | true |
+| barrier_flow.rb:18:8:18:18 | ... == ... | barrier_flow.rb:19:9:19:14 | self | true |
+| barrier_flow.rb:26:19:26:29 | ... == ... | barrier_flow.rb:26:5:26:10 | self | false |
+| barrier_flow.rb:32:19:32:29 | ... != ... | barrier_flow.rb:32:5:32:10 | self | false |
+| barrier_flow.rb:38:8:38:18 | ... != ... | barrier_flow.rb:39:9:39:9 | x | true |
+| barrier_flow.rb:48:23:48:33 | ... == ... | barrier_flow.rb:48:5:48:5 | x | false |
+| barrier_flow.rb:56:8:56:8 | b | barrier_flow.rb:57:9:57:14 | return | true |
+| barrier_flow.rb:56:8:56:8 | b | barrier_flow.rb:57:9:57:34 | ... unless ... | true |
+| barrier_flow.rb:56:8:56:8 | b | barrier_flow.rb:57:23:57:23 | x | true |
+| barrier_flow.rb:56:8:56:8 | b | barrier_flow.rb:59:9:59:14 | return | false |
+| barrier_flow.rb:56:8:56:8 | b | barrier_flow.rb:59:9:59:34 | ... unless ... | false |
+| barrier_flow.rb:56:8:56:8 | b | barrier_flow.rb:59:23:59:23 | x | false |
+| barrier_flow.rb:57:23:57:34 | ... == ... | barrier_flow.rb:57:9:57:14 | return | false |
+| barrier_flow.rb:57:23:57:34 | ... == ... | barrier_flow.rb:57:9:57:34 | ... unless ... | true |
+| barrier_flow.rb:59:23:59:34 | ... == ... | barrier_flow.rb:59:9:59:14 | return | false |
+| barrier_flow.rb:59:23:59:34 | ... == ... | barrier_flow.rb:59:9:59:34 | ... unless ... | true |
+| barrier_flow.rb:68:8:68:8 | b | barrier_flow.rb:69:9:71:11 | if ... | true |
+| barrier_flow.rb:68:8:68:8 | b | barrier_flow.rb:69:12:69:12 | x | true |
+| barrier_flow.rb:68:8:68:8 | b | barrier_flow.rb:70:13:70:18 | return | true |
+| barrier_flow.rb:68:8:68:8 | b | barrier_flow.rb:73:9:75:11 | if ... | false |
+| barrier_flow.rb:68:8:68:8 | b | barrier_flow.rb:73:12:73:12 | x | false |
+| barrier_flow.rb:68:8:68:8 | b | barrier_flow.rb:74:13:74:18 | return | false |
+| barrier_flow.rb:69:12:69:23 | ... != ... | barrier_flow.rb:69:9:71:11 | if ... | false |
+| barrier_flow.rb:69:12:69:23 | ... != ... | barrier_flow.rb:70:13:70:18 | return | true |
+| barrier_flow.rb:73:12:73:23 | ... != ... | barrier_flow.rb:73:9:75:11 | if ... | false |
+| barrier_flow.rb:73:12:73:23 | ... != ... | barrier_flow.rb:74:13:74:18 | return | true |

--- a/ruby/ql/test/library-tests/dataflow/barrier-guards/barrier-guards.expected
+++ b/ruby/ql/test/library-tests/dataflow/barrier-guards/barrier-guards.expected
@@ -1,6 +1,7 @@
 testFailures
 failures
 newStyleBarrierGuards
+| barrier-guards.rb:3:16:4:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:4:5:4:7 | foo |
 | barrier-guards.rb:10:5:10:7 | foo |
 | barrier-guards.rb:18:5:18:7 | foo |
@@ -8,6 +9,7 @@ newStyleBarrierGuards
 | barrier-guards.rb:28:5:28:7 | foo |
 | barrier-guards.rb:38:5:38:7 | foo |
 | barrier-guards.rb:45:9:45:11 | foo |
+| barrier-guards.rb:70:22:71:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:71:5:71:7 | foo |
 | barrier-guards.rb:83:5:83:7 | foo |
 | barrier-guards.rb:91:5:91:7 | foo |
@@ -38,6 +40,12 @@ newStyleBarrierGuards
 | barrier-guards.rb:292:5:292:7 | foo |
 | barrier_flow.rb:19:14:19:14 | x |
 | barrier_flow.rb:32:10:32:10 | x |
+| barrier_flow.rb:38:8:38:18 | [input] phi |
+| barrier_flow.rb:48:23:48:33 | [input] phi |
+| barrier_flow.rb:56:10:57:34 | [input] SSA phi read(x) |
+| barrier_flow.rb:58:5:59:34 | [input] SSA phi read(x) |
+| barrier_flow.rb:68:10:71:11 | [input] SSA phi read(x) |
+| barrier_flow.rb:72:5:75:11 | [input] SSA phi read(x) |
 controls
 | barrier-guards.rb:3:4:3:15 | ... == ... | barrier-guards.rb:4:5:4:7 | foo | true |
 | barrier-guards.rb:3:4:3:15 | ... == ... | barrier-guards.rb:6:5:6:7 | foo | false |

--- a/ruby/ql/test/library-tests/dataflow/barrier-guards/barrier-guards.ql
+++ b/ruby/ql/test/library-tests/dataflow/barrier-guards/barrier-guards.ql
@@ -1,3 +1,4 @@
+import codeql.ruby.dataflow.internal.DataFlowPrivate
 import codeql.ruby.dataflow.internal.DataFlowPublic
 import codeql.ruby.dataflow.BarrierGuards
 import codeql.ruby.controlflow.CfgNodes
@@ -25,6 +26,7 @@ module BarrierGuardTest implements TestSig {
     tag = "guarded" and
     exists(DataFlow::Node n |
       newStyleBarrierGuards(n) and
+      not n instanceof SsaInputNode and
       location = n.getLocation() and
       element = n.toString() and
       value = ""

--- a/ruby/ql/test/library-tests/dataflow/barrier-guards/barrier_flow.rb
+++ b/ruby/ql/test/library-tests/dataflow/barrier-guards/barrier_flow.rb
@@ -1,0 +1,79 @@
+def m1
+    x = source(1)
+
+    sink x # $ hasValueFlow=1
+end
+
+def m2
+    x = source(2)
+
+    if x != "safe" then
+        sink x # $ hasValueFlow=2
+    end
+end
+
+def m3
+    x = source(3)
+
+    if x == "safe" then
+        sink x # $ guarded
+    end
+end
+
+def m4
+    x = source(4)
+
+    sink x unless x == "safe" # $ hasValueFlow=4
+end
+
+def m5
+    x = source(5)
+
+    sink x unless x != "safe" # $ guarded
+end
+
+def m6
+    x = source(6)
+
+    if x != "safe" then
+        x = "safe"
+    end
+
+    sink x # $ SPURIOUS hasValueFlow=6
+end
+
+def m7
+    x = source(7)
+
+    x = "safe" unless x == "safe"
+
+    sink x # $ SPURIOUS hasValueFlow=7
+end
+
+def m8(b)
+    x = source(8)
+
+    if b then
+        return unless x == "safe1"
+    else
+        return unless x == "safe2"
+    end
+
+    sink x # $ SPURIOUS hasValueFlow=8
+end
+
+def m9(b)
+    x = source(9)
+
+    if b then
+        if x != "safe1" then
+            return
+        end
+    else
+        if x != "safe2" then
+            return
+        end
+    end
+
+    sink x # $ SPURIOUS hasValueFlow=9
+end

--- a/ruby/ql/test/library-tests/dataflow/barrier-guards/barrier_flow.rb
+++ b/ruby/ql/test/library-tests/dataflow/barrier-guards/barrier_flow.rb
@@ -39,7 +39,7 @@ def m6
         x = "safe"
     end
 
-    sink x # $ SPURIOUS hasValueFlow=6
+    sink x
 end
 
 def m7
@@ -47,7 +47,7 @@ def m7
 
     x = "safe" unless x == "safe"
 
-    sink x # $ SPURIOUS hasValueFlow=7
+    sink x
 end
 
 def m8(b)
@@ -59,7 +59,7 @@ def m8(b)
         return unless x == "safe2"
     end
 
-    sink x # $ SPURIOUS hasValueFlow=8
+    sink x
 end
 
 def m9(b)
@@ -75,5 +75,5 @@ def m9(b)
         end
     end
 
-    sink x # $ SPURIOUS hasValueFlow=9
+    sink x
 end

--- a/ruby/ql/test/library-tests/dataflow/local/DataflowStep.expected
+++ b/ruby/ql/test/library-tests/dataflow/local/DataflowStep.expected
@@ -1,6 +1,6 @@
 | UseUseExplosion.rb:18:5:22:7 | self (m) | UseUseExplosion.rb:20:13:20:17 | self |
 | UseUseExplosion.rb:18:5:22:7 | self in m | UseUseExplosion.rb:18:5:22:7 | self (m) |
-| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2081:20:2116 | SSA phi read(x) |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2096:20:2099 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2111:20:2111 | x |
 | UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2127:20:2127 | x |
 | UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2143:20:2143 | x |
@@ -210,9 +210,11 @@
 | UseUseExplosion.rb:20:13:20:17 | self | UseUseExplosion.rb:20:3691:20:3696 | self |
 | UseUseExplosion.rb:20:13:20:23 | ... > ... | UseUseExplosion.rb:20:12:20:24 | [false] ( ... ) |
 | UseUseExplosion.rb:20:13:20:23 | ... > ... | UseUseExplosion.rb:20:12:20:24 | [true] ( ... ) |
+| UseUseExplosion.rb:20:26:20:3684 | [input] SSA phi read(self) | UseUseExplosion.rb:20:9:20:3700 | SSA phi read(self) |
+| UseUseExplosion.rb:20:26:20:3684 | [input] SSA phi read(x) | UseUseExplosion.rb:20:9:20:3700 | SSA phi read(x) |
 | UseUseExplosion.rb:20:26:20:3684 | then ... | UseUseExplosion.rb:20:9:20:3700 | if ... |
-| UseUseExplosion.rb:20:31:20:3684 | SSA phi read(self) | UseUseExplosion.rb:20:9:20:3700 | SSA phi read(self) |
-| UseUseExplosion.rb:20:31:20:3684 | SSA phi read(x) | UseUseExplosion.rb:20:9:20:3700 | SSA phi read(x) |
+| UseUseExplosion.rb:20:31:20:3684 | SSA phi read(self) | UseUseExplosion.rb:20:26:20:3684 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:31:20:3684 | SSA phi read(x) | UseUseExplosion.rb:20:26:20:3684 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:31:20:3684 | if ... | UseUseExplosion.rb:20:26:20:3684 | then ... |
 | UseUseExplosion.rb:20:35:20:39 | [post] self | UseUseExplosion.rb:20:56:20:60 | self |
 | UseUseExplosion.rb:20:35:20:39 | [post] self | UseUseExplosion.rb:20:3675:20:3680 | self |
@@ -220,9 +222,11 @@
 | UseUseExplosion.rb:20:35:20:39 | self | UseUseExplosion.rb:20:3675:20:3680 | self |
 | UseUseExplosion.rb:20:35:20:44 | ... > ... | UseUseExplosion.rb:20:34:20:45 | [false] ( ... ) |
 | UseUseExplosion.rb:20:35:20:44 | ... > ... | UseUseExplosion.rb:20:34:20:45 | [true] ( ... ) |
+| UseUseExplosion.rb:20:47:20:3668 | [input] SSA phi read(self) | UseUseExplosion.rb:20:31:20:3684 | SSA phi read(self) |
+| UseUseExplosion.rb:20:47:20:3668 | [input] SSA phi read(x) | UseUseExplosion.rb:20:31:20:3684 | SSA phi read(x) |
 | UseUseExplosion.rb:20:47:20:3668 | then ... | UseUseExplosion.rb:20:31:20:3684 | if ... |
-| UseUseExplosion.rb:20:52:20:3668 | SSA phi read(self) | UseUseExplosion.rb:20:31:20:3684 | SSA phi read(self) |
-| UseUseExplosion.rb:20:52:20:3668 | SSA phi read(x) | UseUseExplosion.rb:20:31:20:3684 | SSA phi read(x) |
+| UseUseExplosion.rb:20:52:20:3668 | SSA phi read(self) | UseUseExplosion.rb:20:47:20:3668 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:52:20:3668 | SSA phi read(x) | UseUseExplosion.rb:20:47:20:3668 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:52:20:3668 | if ... | UseUseExplosion.rb:20:47:20:3668 | then ... |
 | UseUseExplosion.rb:20:56:20:60 | [post] self | UseUseExplosion.rb:20:77:20:81 | self |
 | UseUseExplosion.rb:20:56:20:60 | [post] self | UseUseExplosion.rb:20:3659:20:3664 | self |
@@ -230,9 +234,11 @@
 | UseUseExplosion.rb:20:56:20:60 | self | UseUseExplosion.rb:20:3659:20:3664 | self |
 | UseUseExplosion.rb:20:56:20:65 | ... > ... | UseUseExplosion.rb:20:55:20:66 | [false] ( ... ) |
 | UseUseExplosion.rb:20:56:20:65 | ... > ... | UseUseExplosion.rb:20:55:20:66 | [true] ( ... ) |
+| UseUseExplosion.rb:20:68:20:3652 | [input] SSA phi read(self) | UseUseExplosion.rb:20:52:20:3668 | SSA phi read(self) |
+| UseUseExplosion.rb:20:68:20:3652 | [input] SSA phi read(x) | UseUseExplosion.rb:20:52:20:3668 | SSA phi read(x) |
 | UseUseExplosion.rb:20:68:20:3652 | then ... | UseUseExplosion.rb:20:52:20:3668 | if ... |
-| UseUseExplosion.rb:20:73:20:3652 | SSA phi read(self) | UseUseExplosion.rb:20:52:20:3668 | SSA phi read(self) |
-| UseUseExplosion.rb:20:73:20:3652 | SSA phi read(x) | UseUseExplosion.rb:20:52:20:3668 | SSA phi read(x) |
+| UseUseExplosion.rb:20:73:20:3652 | SSA phi read(self) | UseUseExplosion.rb:20:68:20:3652 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:73:20:3652 | SSA phi read(x) | UseUseExplosion.rb:20:68:20:3652 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:73:20:3652 | if ... | UseUseExplosion.rb:20:68:20:3652 | then ... |
 | UseUseExplosion.rb:20:77:20:81 | [post] self | UseUseExplosion.rb:20:98:20:102 | self |
 | UseUseExplosion.rb:20:77:20:81 | [post] self | UseUseExplosion.rb:20:3643:20:3648 | self |
@@ -240,9 +246,11 @@
 | UseUseExplosion.rb:20:77:20:81 | self | UseUseExplosion.rb:20:3643:20:3648 | self |
 | UseUseExplosion.rb:20:77:20:86 | ... > ... | UseUseExplosion.rb:20:76:20:87 | [false] ( ... ) |
 | UseUseExplosion.rb:20:77:20:86 | ... > ... | UseUseExplosion.rb:20:76:20:87 | [true] ( ... ) |
+| UseUseExplosion.rb:20:89:20:3636 | [input] SSA phi read(self) | UseUseExplosion.rb:20:73:20:3652 | SSA phi read(self) |
+| UseUseExplosion.rb:20:89:20:3636 | [input] SSA phi read(x) | UseUseExplosion.rb:20:73:20:3652 | SSA phi read(x) |
 | UseUseExplosion.rb:20:89:20:3636 | then ... | UseUseExplosion.rb:20:73:20:3652 | if ... |
-| UseUseExplosion.rb:20:94:20:3636 | SSA phi read(self) | UseUseExplosion.rb:20:73:20:3652 | SSA phi read(self) |
-| UseUseExplosion.rb:20:94:20:3636 | SSA phi read(x) | UseUseExplosion.rb:20:73:20:3652 | SSA phi read(x) |
+| UseUseExplosion.rb:20:94:20:3636 | SSA phi read(self) | UseUseExplosion.rb:20:89:20:3636 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:94:20:3636 | SSA phi read(x) | UseUseExplosion.rb:20:89:20:3636 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:94:20:3636 | if ... | UseUseExplosion.rb:20:89:20:3636 | then ... |
 | UseUseExplosion.rb:20:98:20:102 | [post] self | UseUseExplosion.rb:20:119:20:123 | self |
 | UseUseExplosion.rb:20:98:20:102 | [post] self | UseUseExplosion.rb:20:3627:20:3632 | self |
@@ -250,9 +258,11 @@
 | UseUseExplosion.rb:20:98:20:102 | self | UseUseExplosion.rb:20:3627:20:3632 | self |
 | UseUseExplosion.rb:20:98:20:107 | ... > ... | UseUseExplosion.rb:20:97:20:108 | [false] ( ... ) |
 | UseUseExplosion.rb:20:98:20:107 | ... > ... | UseUseExplosion.rb:20:97:20:108 | [true] ( ... ) |
+| UseUseExplosion.rb:20:110:20:3620 | [input] SSA phi read(self) | UseUseExplosion.rb:20:94:20:3636 | SSA phi read(self) |
+| UseUseExplosion.rb:20:110:20:3620 | [input] SSA phi read(x) | UseUseExplosion.rb:20:94:20:3636 | SSA phi read(x) |
 | UseUseExplosion.rb:20:110:20:3620 | then ... | UseUseExplosion.rb:20:94:20:3636 | if ... |
-| UseUseExplosion.rb:20:115:20:3620 | SSA phi read(self) | UseUseExplosion.rb:20:94:20:3636 | SSA phi read(self) |
-| UseUseExplosion.rb:20:115:20:3620 | SSA phi read(x) | UseUseExplosion.rb:20:94:20:3636 | SSA phi read(x) |
+| UseUseExplosion.rb:20:115:20:3620 | SSA phi read(self) | UseUseExplosion.rb:20:110:20:3620 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:115:20:3620 | SSA phi read(x) | UseUseExplosion.rb:20:110:20:3620 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:115:20:3620 | if ... | UseUseExplosion.rb:20:110:20:3620 | then ... |
 | UseUseExplosion.rb:20:119:20:123 | [post] self | UseUseExplosion.rb:20:140:20:144 | self |
 | UseUseExplosion.rb:20:119:20:123 | [post] self | UseUseExplosion.rb:20:3611:20:3616 | self |
@@ -260,9 +270,11 @@
 | UseUseExplosion.rb:20:119:20:123 | self | UseUseExplosion.rb:20:3611:20:3616 | self |
 | UseUseExplosion.rb:20:119:20:128 | ... > ... | UseUseExplosion.rb:20:118:20:129 | [false] ( ... ) |
 | UseUseExplosion.rb:20:119:20:128 | ... > ... | UseUseExplosion.rb:20:118:20:129 | [true] ( ... ) |
+| UseUseExplosion.rb:20:131:20:3604 | [input] SSA phi read(self) | UseUseExplosion.rb:20:115:20:3620 | SSA phi read(self) |
+| UseUseExplosion.rb:20:131:20:3604 | [input] SSA phi read(x) | UseUseExplosion.rb:20:115:20:3620 | SSA phi read(x) |
 | UseUseExplosion.rb:20:131:20:3604 | then ... | UseUseExplosion.rb:20:115:20:3620 | if ... |
-| UseUseExplosion.rb:20:136:20:3604 | SSA phi read(self) | UseUseExplosion.rb:20:115:20:3620 | SSA phi read(self) |
-| UseUseExplosion.rb:20:136:20:3604 | SSA phi read(x) | UseUseExplosion.rb:20:115:20:3620 | SSA phi read(x) |
+| UseUseExplosion.rb:20:136:20:3604 | SSA phi read(self) | UseUseExplosion.rb:20:131:20:3604 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:136:20:3604 | SSA phi read(x) | UseUseExplosion.rb:20:131:20:3604 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:136:20:3604 | if ... | UseUseExplosion.rb:20:131:20:3604 | then ... |
 | UseUseExplosion.rb:20:140:20:144 | [post] self | UseUseExplosion.rb:20:161:20:165 | self |
 | UseUseExplosion.rb:20:140:20:144 | [post] self | UseUseExplosion.rb:20:3595:20:3600 | self |
@@ -270,9 +282,11 @@
 | UseUseExplosion.rb:20:140:20:144 | self | UseUseExplosion.rb:20:3595:20:3600 | self |
 | UseUseExplosion.rb:20:140:20:149 | ... > ... | UseUseExplosion.rb:20:139:20:150 | [false] ( ... ) |
 | UseUseExplosion.rb:20:140:20:149 | ... > ... | UseUseExplosion.rb:20:139:20:150 | [true] ( ... ) |
+| UseUseExplosion.rb:20:152:20:3588 | [input] SSA phi read(self) | UseUseExplosion.rb:20:136:20:3604 | SSA phi read(self) |
+| UseUseExplosion.rb:20:152:20:3588 | [input] SSA phi read(x) | UseUseExplosion.rb:20:136:20:3604 | SSA phi read(x) |
 | UseUseExplosion.rb:20:152:20:3588 | then ... | UseUseExplosion.rb:20:136:20:3604 | if ... |
-| UseUseExplosion.rb:20:157:20:3588 | SSA phi read(self) | UseUseExplosion.rb:20:136:20:3604 | SSA phi read(self) |
-| UseUseExplosion.rb:20:157:20:3588 | SSA phi read(x) | UseUseExplosion.rb:20:136:20:3604 | SSA phi read(x) |
+| UseUseExplosion.rb:20:157:20:3588 | SSA phi read(self) | UseUseExplosion.rb:20:152:20:3588 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:157:20:3588 | SSA phi read(x) | UseUseExplosion.rb:20:152:20:3588 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:157:20:3588 | if ... | UseUseExplosion.rb:20:152:20:3588 | then ... |
 | UseUseExplosion.rb:20:161:20:165 | [post] self | UseUseExplosion.rb:20:182:20:186 | self |
 | UseUseExplosion.rb:20:161:20:165 | [post] self | UseUseExplosion.rb:20:3579:20:3584 | self |
@@ -280,9 +294,11 @@
 | UseUseExplosion.rb:20:161:20:165 | self | UseUseExplosion.rb:20:3579:20:3584 | self |
 | UseUseExplosion.rb:20:161:20:170 | ... > ... | UseUseExplosion.rb:20:160:20:171 | [false] ( ... ) |
 | UseUseExplosion.rb:20:161:20:170 | ... > ... | UseUseExplosion.rb:20:160:20:171 | [true] ( ... ) |
+| UseUseExplosion.rb:20:173:20:3572 | [input] SSA phi read(self) | UseUseExplosion.rb:20:157:20:3588 | SSA phi read(self) |
+| UseUseExplosion.rb:20:173:20:3572 | [input] SSA phi read(x) | UseUseExplosion.rb:20:157:20:3588 | SSA phi read(x) |
 | UseUseExplosion.rb:20:173:20:3572 | then ... | UseUseExplosion.rb:20:157:20:3588 | if ... |
-| UseUseExplosion.rb:20:178:20:3572 | SSA phi read(self) | UseUseExplosion.rb:20:157:20:3588 | SSA phi read(self) |
-| UseUseExplosion.rb:20:178:20:3572 | SSA phi read(x) | UseUseExplosion.rb:20:157:20:3588 | SSA phi read(x) |
+| UseUseExplosion.rb:20:178:20:3572 | SSA phi read(self) | UseUseExplosion.rb:20:173:20:3572 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:178:20:3572 | SSA phi read(x) | UseUseExplosion.rb:20:173:20:3572 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:178:20:3572 | if ... | UseUseExplosion.rb:20:173:20:3572 | then ... |
 | UseUseExplosion.rb:20:182:20:186 | [post] self | UseUseExplosion.rb:20:203:20:207 | self |
 | UseUseExplosion.rb:20:182:20:186 | [post] self | UseUseExplosion.rb:20:3563:20:3568 | self |
@@ -290,9 +306,11 @@
 | UseUseExplosion.rb:20:182:20:186 | self | UseUseExplosion.rb:20:3563:20:3568 | self |
 | UseUseExplosion.rb:20:182:20:191 | ... > ... | UseUseExplosion.rb:20:181:20:192 | [false] ( ... ) |
 | UseUseExplosion.rb:20:182:20:191 | ... > ... | UseUseExplosion.rb:20:181:20:192 | [true] ( ... ) |
+| UseUseExplosion.rb:20:194:20:3556 | [input] SSA phi read(self) | UseUseExplosion.rb:20:178:20:3572 | SSA phi read(self) |
+| UseUseExplosion.rb:20:194:20:3556 | [input] SSA phi read(x) | UseUseExplosion.rb:20:178:20:3572 | SSA phi read(x) |
 | UseUseExplosion.rb:20:194:20:3556 | then ... | UseUseExplosion.rb:20:178:20:3572 | if ... |
-| UseUseExplosion.rb:20:199:20:3556 | SSA phi read(self) | UseUseExplosion.rb:20:178:20:3572 | SSA phi read(self) |
-| UseUseExplosion.rb:20:199:20:3556 | SSA phi read(x) | UseUseExplosion.rb:20:178:20:3572 | SSA phi read(x) |
+| UseUseExplosion.rb:20:199:20:3556 | SSA phi read(self) | UseUseExplosion.rb:20:194:20:3556 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:199:20:3556 | SSA phi read(x) | UseUseExplosion.rb:20:194:20:3556 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:199:20:3556 | if ... | UseUseExplosion.rb:20:194:20:3556 | then ... |
 | UseUseExplosion.rb:20:203:20:207 | [post] self | UseUseExplosion.rb:20:224:20:228 | self |
 | UseUseExplosion.rb:20:203:20:207 | [post] self | UseUseExplosion.rb:20:3547:20:3552 | self |
@@ -300,9 +318,11 @@
 | UseUseExplosion.rb:20:203:20:207 | self | UseUseExplosion.rb:20:3547:20:3552 | self |
 | UseUseExplosion.rb:20:203:20:212 | ... > ... | UseUseExplosion.rb:20:202:20:213 | [false] ( ... ) |
 | UseUseExplosion.rb:20:203:20:212 | ... > ... | UseUseExplosion.rb:20:202:20:213 | [true] ( ... ) |
+| UseUseExplosion.rb:20:215:20:3540 | [input] SSA phi read(self) | UseUseExplosion.rb:20:199:20:3556 | SSA phi read(self) |
+| UseUseExplosion.rb:20:215:20:3540 | [input] SSA phi read(x) | UseUseExplosion.rb:20:199:20:3556 | SSA phi read(x) |
 | UseUseExplosion.rb:20:215:20:3540 | then ... | UseUseExplosion.rb:20:199:20:3556 | if ... |
-| UseUseExplosion.rb:20:220:20:3540 | SSA phi read(self) | UseUseExplosion.rb:20:199:20:3556 | SSA phi read(self) |
-| UseUseExplosion.rb:20:220:20:3540 | SSA phi read(x) | UseUseExplosion.rb:20:199:20:3556 | SSA phi read(x) |
+| UseUseExplosion.rb:20:220:20:3540 | SSA phi read(self) | UseUseExplosion.rb:20:215:20:3540 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:220:20:3540 | SSA phi read(x) | UseUseExplosion.rb:20:215:20:3540 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:220:20:3540 | if ... | UseUseExplosion.rb:20:215:20:3540 | then ... |
 | UseUseExplosion.rb:20:224:20:228 | [post] self | UseUseExplosion.rb:20:245:20:249 | self |
 | UseUseExplosion.rb:20:224:20:228 | [post] self | UseUseExplosion.rb:20:3531:20:3536 | self |
@@ -310,9 +330,11 @@
 | UseUseExplosion.rb:20:224:20:228 | self | UseUseExplosion.rb:20:3531:20:3536 | self |
 | UseUseExplosion.rb:20:224:20:233 | ... > ... | UseUseExplosion.rb:20:223:20:234 | [false] ( ... ) |
 | UseUseExplosion.rb:20:224:20:233 | ... > ... | UseUseExplosion.rb:20:223:20:234 | [true] ( ... ) |
+| UseUseExplosion.rb:20:236:20:3524 | [input] SSA phi read(self) | UseUseExplosion.rb:20:220:20:3540 | SSA phi read(self) |
+| UseUseExplosion.rb:20:236:20:3524 | [input] SSA phi read(x) | UseUseExplosion.rb:20:220:20:3540 | SSA phi read(x) |
 | UseUseExplosion.rb:20:236:20:3524 | then ... | UseUseExplosion.rb:20:220:20:3540 | if ... |
-| UseUseExplosion.rb:20:241:20:3524 | SSA phi read(self) | UseUseExplosion.rb:20:220:20:3540 | SSA phi read(self) |
-| UseUseExplosion.rb:20:241:20:3524 | SSA phi read(x) | UseUseExplosion.rb:20:220:20:3540 | SSA phi read(x) |
+| UseUseExplosion.rb:20:241:20:3524 | SSA phi read(self) | UseUseExplosion.rb:20:236:20:3524 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:241:20:3524 | SSA phi read(x) | UseUseExplosion.rb:20:236:20:3524 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:241:20:3524 | if ... | UseUseExplosion.rb:20:236:20:3524 | then ... |
 | UseUseExplosion.rb:20:245:20:249 | [post] self | UseUseExplosion.rb:20:266:20:270 | self |
 | UseUseExplosion.rb:20:245:20:249 | [post] self | UseUseExplosion.rb:20:3515:20:3520 | self |
@@ -320,9 +342,11 @@
 | UseUseExplosion.rb:20:245:20:249 | self | UseUseExplosion.rb:20:3515:20:3520 | self |
 | UseUseExplosion.rb:20:245:20:254 | ... > ... | UseUseExplosion.rb:20:244:20:255 | [false] ( ... ) |
 | UseUseExplosion.rb:20:245:20:254 | ... > ... | UseUseExplosion.rb:20:244:20:255 | [true] ( ... ) |
+| UseUseExplosion.rb:20:257:20:3508 | [input] SSA phi read(self) | UseUseExplosion.rb:20:241:20:3524 | SSA phi read(self) |
+| UseUseExplosion.rb:20:257:20:3508 | [input] SSA phi read(x) | UseUseExplosion.rb:20:241:20:3524 | SSA phi read(x) |
 | UseUseExplosion.rb:20:257:20:3508 | then ... | UseUseExplosion.rb:20:241:20:3524 | if ... |
-| UseUseExplosion.rb:20:262:20:3508 | SSA phi read(self) | UseUseExplosion.rb:20:241:20:3524 | SSA phi read(self) |
-| UseUseExplosion.rb:20:262:20:3508 | SSA phi read(x) | UseUseExplosion.rb:20:241:20:3524 | SSA phi read(x) |
+| UseUseExplosion.rb:20:262:20:3508 | SSA phi read(self) | UseUseExplosion.rb:20:257:20:3508 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:262:20:3508 | SSA phi read(x) | UseUseExplosion.rb:20:257:20:3508 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:262:20:3508 | if ... | UseUseExplosion.rb:20:257:20:3508 | then ... |
 | UseUseExplosion.rb:20:266:20:270 | [post] self | UseUseExplosion.rb:20:287:20:291 | self |
 | UseUseExplosion.rb:20:266:20:270 | [post] self | UseUseExplosion.rb:20:3499:20:3504 | self |
@@ -330,9 +354,11 @@
 | UseUseExplosion.rb:20:266:20:270 | self | UseUseExplosion.rb:20:3499:20:3504 | self |
 | UseUseExplosion.rb:20:266:20:275 | ... > ... | UseUseExplosion.rb:20:265:20:276 | [false] ( ... ) |
 | UseUseExplosion.rb:20:266:20:275 | ... > ... | UseUseExplosion.rb:20:265:20:276 | [true] ( ... ) |
+| UseUseExplosion.rb:20:278:20:3492 | [input] SSA phi read(self) | UseUseExplosion.rb:20:262:20:3508 | SSA phi read(self) |
+| UseUseExplosion.rb:20:278:20:3492 | [input] SSA phi read(x) | UseUseExplosion.rb:20:262:20:3508 | SSA phi read(x) |
 | UseUseExplosion.rb:20:278:20:3492 | then ... | UseUseExplosion.rb:20:262:20:3508 | if ... |
-| UseUseExplosion.rb:20:283:20:3492 | SSA phi read(self) | UseUseExplosion.rb:20:262:20:3508 | SSA phi read(self) |
-| UseUseExplosion.rb:20:283:20:3492 | SSA phi read(x) | UseUseExplosion.rb:20:262:20:3508 | SSA phi read(x) |
+| UseUseExplosion.rb:20:283:20:3492 | SSA phi read(self) | UseUseExplosion.rb:20:278:20:3492 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:283:20:3492 | SSA phi read(x) | UseUseExplosion.rb:20:278:20:3492 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:283:20:3492 | if ... | UseUseExplosion.rb:20:278:20:3492 | then ... |
 | UseUseExplosion.rb:20:287:20:291 | [post] self | UseUseExplosion.rb:20:308:20:312 | self |
 | UseUseExplosion.rb:20:287:20:291 | [post] self | UseUseExplosion.rb:20:3483:20:3488 | self |
@@ -340,9 +366,11 @@
 | UseUseExplosion.rb:20:287:20:291 | self | UseUseExplosion.rb:20:3483:20:3488 | self |
 | UseUseExplosion.rb:20:287:20:296 | ... > ... | UseUseExplosion.rb:20:286:20:297 | [false] ( ... ) |
 | UseUseExplosion.rb:20:287:20:296 | ... > ... | UseUseExplosion.rb:20:286:20:297 | [true] ( ... ) |
+| UseUseExplosion.rb:20:299:20:3476 | [input] SSA phi read(self) | UseUseExplosion.rb:20:283:20:3492 | SSA phi read(self) |
+| UseUseExplosion.rb:20:299:20:3476 | [input] SSA phi read(x) | UseUseExplosion.rb:20:283:20:3492 | SSA phi read(x) |
 | UseUseExplosion.rb:20:299:20:3476 | then ... | UseUseExplosion.rb:20:283:20:3492 | if ... |
-| UseUseExplosion.rb:20:304:20:3476 | SSA phi read(self) | UseUseExplosion.rb:20:283:20:3492 | SSA phi read(self) |
-| UseUseExplosion.rb:20:304:20:3476 | SSA phi read(x) | UseUseExplosion.rb:20:283:20:3492 | SSA phi read(x) |
+| UseUseExplosion.rb:20:304:20:3476 | SSA phi read(self) | UseUseExplosion.rb:20:299:20:3476 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:304:20:3476 | SSA phi read(x) | UseUseExplosion.rb:20:299:20:3476 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:304:20:3476 | if ... | UseUseExplosion.rb:20:299:20:3476 | then ... |
 | UseUseExplosion.rb:20:308:20:312 | [post] self | UseUseExplosion.rb:20:329:20:333 | self |
 | UseUseExplosion.rb:20:308:20:312 | [post] self | UseUseExplosion.rb:20:3467:20:3472 | self |
@@ -350,9 +378,11 @@
 | UseUseExplosion.rb:20:308:20:312 | self | UseUseExplosion.rb:20:3467:20:3472 | self |
 | UseUseExplosion.rb:20:308:20:317 | ... > ... | UseUseExplosion.rb:20:307:20:318 | [false] ( ... ) |
 | UseUseExplosion.rb:20:308:20:317 | ... > ... | UseUseExplosion.rb:20:307:20:318 | [true] ( ... ) |
+| UseUseExplosion.rb:20:320:20:3460 | [input] SSA phi read(self) | UseUseExplosion.rb:20:304:20:3476 | SSA phi read(self) |
+| UseUseExplosion.rb:20:320:20:3460 | [input] SSA phi read(x) | UseUseExplosion.rb:20:304:20:3476 | SSA phi read(x) |
 | UseUseExplosion.rb:20:320:20:3460 | then ... | UseUseExplosion.rb:20:304:20:3476 | if ... |
-| UseUseExplosion.rb:20:325:20:3460 | SSA phi read(self) | UseUseExplosion.rb:20:304:20:3476 | SSA phi read(self) |
-| UseUseExplosion.rb:20:325:20:3460 | SSA phi read(x) | UseUseExplosion.rb:20:304:20:3476 | SSA phi read(x) |
+| UseUseExplosion.rb:20:325:20:3460 | SSA phi read(self) | UseUseExplosion.rb:20:320:20:3460 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:325:20:3460 | SSA phi read(x) | UseUseExplosion.rb:20:320:20:3460 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:325:20:3460 | if ... | UseUseExplosion.rb:20:320:20:3460 | then ... |
 | UseUseExplosion.rb:20:329:20:333 | [post] self | UseUseExplosion.rb:20:350:20:354 | self |
 | UseUseExplosion.rb:20:329:20:333 | [post] self | UseUseExplosion.rb:20:3451:20:3456 | self |
@@ -360,9 +390,11 @@
 | UseUseExplosion.rb:20:329:20:333 | self | UseUseExplosion.rb:20:3451:20:3456 | self |
 | UseUseExplosion.rb:20:329:20:338 | ... > ... | UseUseExplosion.rb:20:328:20:339 | [false] ( ... ) |
 | UseUseExplosion.rb:20:329:20:338 | ... > ... | UseUseExplosion.rb:20:328:20:339 | [true] ( ... ) |
+| UseUseExplosion.rb:20:341:20:3444 | [input] SSA phi read(self) | UseUseExplosion.rb:20:325:20:3460 | SSA phi read(self) |
+| UseUseExplosion.rb:20:341:20:3444 | [input] SSA phi read(x) | UseUseExplosion.rb:20:325:20:3460 | SSA phi read(x) |
 | UseUseExplosion.rb:20:341:20:3444 | then ... | UseUseExplosion.rb:20:325:20:3460 | if ... |
-| UseUseExplosion.rb:20:346:20:3444 | SSA phi read(self) | UseUseExplosion.rb:20:325:20:3460 | SSA phi read(self) |
-| UseUseExplosion.rb:20:346:20:3444 | SSA phi read(x) | UseUseExplosion.rb:20:325:20:3460 | SSA phi read(x) |
+| UseUseExplosion.rb:20:346:20:3444 | SSA phi read(self) | UseUseExplosion.rb:20:341:20:3444 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:346:20:3444 | SSA phi read(x) | UseUseExplosion.rb:20:341:20:3444 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:346:20:3444 | if ... | UseUseExplosion.rb:20:341:20:3444 | then ... |
 | UseUseExplosion.rb:20:350:20:354 | [post] self | UseUseExplosion.rb:20:371:20:375 | self |
 | UseUseExplosion.rb:20:350:20:354 | [post] self | UseUseExplosion.rb:20:3435:20:3440 | self |
@@ -370,9 +402,11 @@
 | UseUseExplosion.rb:20:350:20:354 | self | UseUseExplosion.rb:20:3435:20:3440 | self |
 | UseUseExplosion.rb:20:350:20:359 | ... > ... | UseUseExplosion.rb:20:349:20:360 | [false] ( ... ) |
 | UseUseExplosion.rb:20:350:20:359 | ... > ... | UseUseExplosion.rb:20:349:20:360 | [true] ( ... ) |
+| UseUseExplosion.rb:20:362:20:3428 | [input] SSA phi read(self) | UseUseExplosion.rb:20:346:20:3444 | SSA phi read(self) |
+| UseUseExplosion.rb:20:362:20:3428 | [input] SSA phi read(x) | UseUseExplosion.rb:20:346:20:3444 | SSA phi read(x) |
 | UseUseExplosion.rb:20:362:20:3428 | then ... | UseUseExplosion.rb:20:346:20:3444 | if ... |
-| UseUseExplosion.rb:20:367:20:3428 | SSA phi read(self) | UseUseExplosion.rb:20:346:20:3444 | SSA phi read(self) |
-| UseUseExplosion.rb:20:367:20:3428 | SSA phi read(x) | UseUseExplosion.rb:20:346:20:3444 | SSA phi read(x) |
+| UseUseExplosion.rb:20:367:20:3428 | SSA phi read(self) | UseUseExplosion.rb:20:362:20:3428 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:367:20:3428 | SSA phi read(x) | UseUseExplosion.rb:20:362:20:3428 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:367:20:3428 | if ... | UseUseExplosion.rb:20:362:20:3428 | then ... |
 | UseUseExplosion.rb:20:371:20:375 | [post] self | UseUseExplosion.rb:20:392:20:396 | self |
 | UseUseExplosion.rb:20:371:20:375 | [post] self | UseUseExplosion.rb:20:3419:20:3424 | self |
@@ -380,9 +414,11 @@
 | UseUseExplosion.rb:20:371:20:375 | self | UseUseExplosion.rb:20:3419:20:3424 | self |
 | UseUseExplosion.rb:20:371:20:380 | ... > ... | UseUseExplosion.rb:20:370:20:381 | [false] ( ... ) |
 | UseUseExplosion.rb:20:371:20:380 | ... > ... | UseUseExplosion.rb:20:370:20:381 | [true] ( ... ) |
+| UseUseExplosion.rb:20:383:20:3412 | [input] SSA phi read(self) | UseUseExplosion.rb:20:367:20:3428 | SSA phi read(self) |
+| UseUseExplosion.rb:20:383:20:3412 | [input] SSA phi read(x) | UseUseExplosion.rb:20:367:20:3428 | SSA phi read(x) |
 | UseUseExplosion.rb:20:383:20:3412 | then ... | UseUseExplosion.rb:20:367:20:3428 | if ... |
-| UseUseExplosion.rb:20:388:20:3412 | SSA phi read(self) | UseUseExplosion.rb:20:367:20:3428 | SSA phi read(self) |
-| UseUseExplosion.rb:20:388:20:3412 | SSA phi read(x) | UseUseExplosion.rb:20:367:20:3428 | SSA phi read(x) |
+| UseUseExplosion.rb:20:388:20:3412 | SSA phi read(self) | UseUseExplosion.rb:20:383:20:3412 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:388:20:3412 | SSA phi read(x) | UseUseExplosion.rb:20:383:20:3412 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:388:20:3412 | if ... | UseUseExplosion.rb:20:383:20:3412 | then ... |
 | UseUseExplosion.rb:20:392:20:396 | [post] self | UseUseExplosion.rb:20:413:20:417 | self |
 | UseUseExplosion.rb:20:392:20:396 | [post] self | UseUseExplosion.rb:20:3403:20:3408 | self |
@@ -390,9 +426,11 @@
 | UseUseExplosion.rb:20:392:20:396 | self | UseUseExplosion.rb:20:3403:20:3408 | self |
 | UseUseExplosion.rb:20:392:20:401 | ... > ... | UseUseExplosion.rb:20:391:20:402 | [false] ( ... ) |
 | UseUseExplosion.rb:20:392:20:401 | ... > ... | UseUseExplosion.rb:20:391:20:402 | [true] ( ... ) |
+| UseUseExplosion.rb:20:404:20:3396 | [input] SSA phi read(self) | UseUseExplosion.rb:20:388:20:3412 | SSA phi read(self) |
+| UseUseExplosion.rb:20:404:20:3396 | [input] SSA phi read(x) | UseUseExplosion.rb:20:388:20:3412 | SSA phi read(x) |
 | UseUseExplosion.rb:20:404:20:3396 | then ... | UseUseExplosion.rb:20:388:20:3412 | if ... |
-| UseUseExplosion.rb:20:409:20:3396 | SSA phi read(self) | UseUseExplosion.rb:20:388:20:3412 | SSA phi read(self) |
-| UseUseExplosion.rb:20:409:20:3396 | SSA phi read(x) | UseUseExplosion.rb:20:388:20:3412 | SSA phi read(x) |
+| UseUseExplosion.rb:20:409:20:3396 | SSA phi read(self) | UseUseExplosion.rb:20:404:20:3396 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:409:20:3396 | SSA phi read(x) | UseUseExplosion.rb:20:404:20:3396 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:409:20:3396 | if ... | UseUseExplosion.rb:20:404:20:3396 | then ... |
 | UseUseExplosion.rb:20:413:20:417 | [post] self | UseUseExplosion.rb:20:434:20:438 | self |
 | UseUseExplosion.rb:20:413:20:417 | [post] self | UseUseExplosion.rb:20:3387:20:3392 | self |
@@ -400,9 +438,11 @@
 | UseUseExplosion.rb:20:413:20:417 | self | UseUseExplosion.rb:20:3387:20:3392 | self |
 | UseUseExplosion.rb:20:413:20:422 | ... > ... | UseUseExplosion.rb:20:412:20:423 | [false] ( ... ) |
 | UseUseExplosion.rb:20:413:20:422 | ... > ... | UseUseExplosion.rb:20:412:20:423 | [true] ( ... ) |
+| UseUseExplosion.rb:20:425:20:3380 | [input] SSA phi read(self) | UseUseExplosion.rb:20:409:20:3396 | SSA phi read(self) |
+| UseUseExplosion.rb:20:425:20:3380 | [input] SSA phi read(x) | UseUseExplosion.rb:20:409:20:3396 | SSA phi read(x) |
 | UseUseExplosion.rb:20:425:20:3380 | then ... | UseUseExplosion.rb:20:409:20:3396 | if ... |
-| UseUseExplosion.rb:20:430:20:3380 | SSA phi read(self) | UseUseExplosion.rb:20:409:20:3396 | SSA phi read(self) |
-| UseUseExplosion.rb:20:430:20:3380 | SSA phi read(x) | UseUseExplosion.rb:20:409:20:3396 | SSA phi read(x) |
+| UseUseExplosion.rb:20:430:20:3380 | SSA phi read(self) | UseUseExplosion.rb:20:425:20:3380 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:430:20:3380 | SSA phi read(x) | UseUseExplosion.rb:20:425:20:3380 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:430:20:3380 | if ... | UseUseExplosion.rb:20:425:20:3380 | then ... |
 | UseUseExplosion.rb:20:434:20:438 | [post] self | UseUseExplosion.rb:20:455:20:459 | self |
 | UseUseExplosion.rb:20:434:20:438 | [post] self | UseUseExplosion.rb:20:3371:20:3376 | self |
@@ -410,9 +450,11 @@
 | UseUseExplosion.rb:20:434:20:438 | self | UseUseExplosion.rb:20:3371:20:3376 | self |
 | UseUseExplosion.rb:20:434:20:443 | ... > ... | UseUseExplosion.rb:20:433:20:444 | [false] ( ... ) |
 | UseUseExplosion.rb:20:434:20:443 | ... > ... | UseUseExplosion.rb:20:433:20:444 | [true] ( ... ) |
+| UseUseExplosion.rb:20:446:20:3364 | [input] SSA phi read(self) | UseUseExplosion.rb:20:430:20:3380 | SSA phi read(self) |
+| UseUseExplosion.rb:20:446:20:3364 | [input] SSA phi read(x) | UseUseExplosion.rb:20:430:20:3380 | SSA phi read(x) |
 | UseUseExplosion.rb:20:446:20:3364 | then ... | UseUseExplosion.rb:20:430:20:3380 | if ... |
-| UseUseExplosion.rb:20:451:20:3364 | SSA phi read(self) | UseUseExplosion.rb:20:430:20:3380 | SSA phi read(self) |
-| UseUseExplosion.rb:20:451:20:3364 | SSA phi read(x) | UseUseExplosion.rb:20:430:20:3380 | SSA phi read(x) |
+| UseUseExplosion.rb:20:451:20:3364 | SSA phi read(self) | UseUseExplosion.rb:20:446:20:3364 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:451:20:3364 | SSA phi read(x) | UseUseExplosion.rb:20:446:20:3364 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:451:20:3364 | if ... | UseUseExplosion.rb:20:446:20:3364 | then ... |
 | UseUseExplosion.rb:20:455:20:459 | [post] self | UseUseExplosion.rb:20:476:20:480 | self |
 | UseUseExplosion.rb:20:455:20:459 | [post] self | UseUseExplosion.rb:20:3355:20:3360 | self |
@@ -420,9 +462,11 @@
 | UseUseExplosion.rb:20:455:20:459 | self | UseUseExplosion.rb:20:3355:20:3360 | self |
 | UseUseExplosion.rb:20:455:20:464 | ... > ... | UseUseExplosion.rb:20:454:20:465 | [false] ( ... ) |
 | UseUseExplosion.rb:20:455:20:464 | ... > ... | UseUseExplosion.rb:20:454:20:465 | [true] ( ... ) |
+| UseUseExplosion.rb:20:467:20:3348 | [input] SSA phi read(self) | UseUseExplosion.rb:20:451:20:3364 | SSA phi read(self) |
+| UseUseExplosion.rb:20:467:20:3348 | [input] SSA phi read(x) | UseUseExplosion.rb:20:451:20:3364 | SSA phi read(x) |
 | UseUseExplosion.rb:20:467:20:3348 | then ... | UseUseExplosion.rb:20:451:20:3364 | if ... |
-| UseUseExplosion.rb:20:472:20:3348 | SSA phi read(self) | UseUseExplosion.rb:20:451:20:3364 | SSA phi read(self) |
-| UseUseExplosion.rb:20:472:20:3348 | SSA phi read(x) | UseUseExplosion.rb:20:451:20:3364 | SSA phi read(x) |
+| UseUseExplosion.rb:20:472:20:3348 | SSA phi read(self) | UseUseExplosion.rb:20:467:20:3348 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:472:20:3348 | SSA phi read(x) | UseUseExplosion.rb:20:467:20:3348 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:472:20:3348 | if ... | UseUseExplosion.rb:20:467:20:3348 | then ... |
 | UseUseExplosion.rb:20:476:20:480 | [post] self | UseUseExplosion.rb:20:497:20:501 | self |
 | UseUseExplosion.rb:20:476:20:480 | [post] self | UseUseExplosion.rb:20:3339:20:3344 | self |
@@ -430,9 +474,11 @@
 | UseUseExplosion.rb:20:476:20:480 | self | UseUseExplosion.rb:20:3339:20:3344 | self |
 | UseUseExplosion.rb:20:476:20:485 | ... > ... | UseUseExplosion.rb:20:475:20:486 | [false] ( ... ) |
 | UseUseExplosion.rb:20:476:20:485 | ... > ... | UseUseExplosion.rb:20:475:20:486 | [true] ( ... ) |
+| UseUseExplosion.rb:20:488:20:3332 | [input] SSA phi read(self) | UseUseExplosion.rb:20:472:20:3348 | SSA phi read(self) |
+| UseUseExplosion.rb:20:488:20:3332 | [input] SSA phi read(x) | UseUseExplosion.rb:20:472:20:3348 | SSA phi read(x) |
 | UseUseExplosion.rb:20:488:20:3332 | then ... | UseUseExplosion.rb:20:472:20:3348 | if ... |
-| UseUseExplosion.rb:20:493:20:3332 | SSA phi read(self) | UseUseExplosion.rb:20:472:20:3348 | SSA phi read(self) |
-| UseUseExplosion.rb:20:493:20:3332 | SSA phi read(x) | UseUseExplosion.rb:20:472:20:3348 | SSA phi read(x) |
+| UseUseExplosion.rb:20:493:20:3332 | SSA phi read(self) | UseUseExplosion.rb:20:488:20:3332 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:493:20:3332 | SSA phi read(x) | UseUseExplosion.rb:20:488:20:3332 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:493:20:3332 | if ... | UseUseExplosion.rb:20:488:20:3332 | then ... |
 | UseUseExplosion.rb:20:497:20:501 | [post] self | UseUseExplosion.rb:20:518:20:522 | self |
 | UseUseExplosion.rb:20:497:20:501 | [post] self | UseUseExplosion.rb:20:3323:20:3328 | self |
@@ -440,9 +486,11 @@
 | UseUseExplosion.rb:20:497:20:501 | self | UseUseExplosion.rb:20:3323:20:3328 | self |
 | UseUseExplosion.rb:20:497:20:506 | ... > ... | UseUseExplosion.rb:20:496:20:507 | [false] ( ... ) |
 | UseUseExplosion.rb:20:497:20:506 | ... > ... | UseUseExplosion.rb:20:496:20:507 | [true] ( ... ) |
+| UseUseExplosion.rb:20:509:20:3316 | [input] SSA phi read(self) | UseUseExplosion.rb:20:493:20:3332 | SSA phi read(self) |
+| UseUseExplosion.rb:20:509:20:3316 | [input] SSA phi read(x) | UseUseExplosion.rb:20:493:20:3332 | SSA phi read(x) |
 | UseUseExplosion.rb:20:509:20:3316 | then ... | UseUseExplosion.rb:20:493:20:3332 | if ... |
-| UseUseExplosion.rb:20:514:20:3316 | SSA phi read(self) | UseUseExplosion.rb:20:493:20:3332 | SSA phi read(self) |
-| UseUseExplosion.rb:20:514:20:3316 | SSA phi read(x) | UseUseExplosion.rb:20:493:20:3332 | SSA phi read(x) |
+| UseUseExplosion.rb:20:514:20:3316 | SSA phi read(self) | UseUseExplosion.rb:20:509:20:3316 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:514:20:3316 | SSA phi read(x) | UseUseExplosion.rb:20:509:20:3316 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:514:20:3316 | if ... | UseUseExplosion.rb:20:509:20:3316 | then ... |
 | UseUseExplosion.rb:20:518:20:522 | [post] self | UseUseExplosion.rb:20:539:20:543 | self |
 | UseUseExplosion.rb:20:518:20:522 | [post] self | UseUseExplosion.rb:20:3307:20:3312 | self |
@@ -450,9 +498,11 @@
 | UseUseExplosion.rb:20:518:20:522 | self | UseUseExplosion.rb:20:3307:20:3312 | self |
 | UseUseExplosion.rb:20:518:20:527 | ... > ... | UseUseExplosion.rb:20:517:20:528 | [false] ( ... ) |
 | UseUseExplosion.rb:20:518:20:527 | ... > ... | UseUseExplosion.rb:20:517:20:528 | [true] ( ... ) |
+| UseUseExplosion.rb:20:530:20:3300 | [input] SSA phi read(self) | UseUseExplosion.rb:20:514:20:3316 | SSA phi read(self) |
+| UseUseExplosion.rb:20:530:20:3300 | [input] SSA phi read(x) | UseUseExplosion.rb:20:514:20:3316 | SSA phi read(x) |
 | UseUseExplosion.rb:20:530:20:3300 | then ... | UseUseExplosion.rb:20:514:20:3316 | if ... |
-| UseUseExplosion.rb:20:535:20:3300 | SSA phi read(self) | UseUseExplosion.rb:20:514:20:3316 | SSA phi read(self) |
-| UseUseExplosion.rb:20:535:20:3300 | SSA phi read(x) | UseUseExplosion.rb:20:514:20:3316 | SSA phi read(x) |
+| UseUseExplosion.rb:20:535:20:3300 | SSA phi read(self) | UseUseExplosion.rb:20:530:20:3300 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:535:20:3300 | SSA phi read(x) | UseUseExplosion.rb:20:530:20:3300 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:535:20:3300 | if ... | UseUseExplosion.rb:20:530:20:3300 | then ... |
 | UseUseExplosion.rb:20:539:20:543 | [post] self | UseUseExplosion.rb:20:560:20:564 | self |
 | UseUseExplosion.rb:20:539:20:543 | [post] self | UseUseExplosion.rb:20:3291:20:3296 | self |
@@ -460,9 +510,11 @@
 | UseUseExplosion.rb:20:539:20:543 | self | UseUseExplosion.rb:20:3291:20:3296 | self |
 | UseUseExplosion.rb:20:539:20:548 | ... > ... | UseUseExplosion.rb:20:538:20:549 | [false] ( ... ) |
 | UseUseExplosion.rb:20:539:20:548 | ... > ... | UseUseExplosion.rb:20:538:20:549 | [true] ( ... ) |
+| UseUseExplosion.rb:20:551:20:3284 | [input] SSA phi read(self) | UseUseExplosion.rb:20:535:20:3300 | SSA phi read(self) |
+| UseUseExplosion.rb:20:551:20:3284 | [input] SSA phi read(x) | UseUseExplosion.rb:20:535:20:3300 | SSA phi read(x) |
 | UseUseExplosion.rb:20:551:20:3284 | then ... | UseUseExplosion.rb:20:535:20:3300 | if ... |
-| UseUseExplosion.rb:20:556:20:3284 | SSA phi read(self) | UseUseExplosion.rb:20:535:20:3300 | SSA phi read(self) |
-| UseUseExplosion.rb:20:556:20:3284 | SSA phi read(x) | UseUseExplosion.rb:20:535:20:3300 | SSA phi read(x) |
+| UseUseExplosion.rb:20:556:20:3284 | SSA phi read(self) | UseUseExplosion.rb:20:551:20:3284 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:556:20:3284 | SSA phi read(x) | UseUseExplosion.rb:20:551:20:3284 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:556:20:3284 | if ... | UseUseExplosion.rb:20:551:20:3284 | then ... |
 | UseUseExplosion.rb:20:560:20:564 | [post] self | UseUseExplosion.rb:20:581:20:585 | self |
 | UseUseExplosion.rb:20:560:20:564 | [post] self | UseUseExplosion.rb:20:3275:20:3280 | self |
@@ -470,9 +522,11 @@
 | UseUseExplosion.rb:20:560:20:564 | self | UseUseExplosion.rb:20:3275:20:3280 | self |
 | UseUseExplosion.rb:20:560:20:569 | ... > ... | UseUseExplosion.rb:20:559:20:570 | [false] ( ... ) |
 | UseUseExplosion.rb:20:560:20:569 | ... > ... | UseUseExplosion.rb:20:559:20:570 | [true] ( ... ) |
+| UseUseExplosion.rb:20:572:20:3268 | [input] SSA phi read(self) | UseUseExplosion.rb:20:556:20:3284 | SSA phi read(self) |
+| UseUseExplosion.rb:20:572:20:3268 | [input] SSA phi read(x) | UseUseExplosion.rb:20:556:20:3284 | SSA phi read(x) |
 | UseUseExplosion.rb:20:572:20:3268 | then ... | UseUseExplosion.rb:20:556:20:3284 | if ... |
-| UseUseExplosion.rb:20:577:20:3268 | SSA phi read(self) | UseUseExplosion.rb:20:556:20:3284 | SSA phi read(self) |
-| UseUseExplosion.rb:20:577:20:3268 | SSA phi read(x) | UseUseExplosion.rb:20:556:20:3284 | SSA phi read(x) |
+| UseUseExplosion.rb:20:577:20:3268 | SSA phi read(self) | UseUseExplosion.rb:20:572:20:3268 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:577:20:3268 | SSA phi read(x) | UseUseExplosion.rb:20:572:20:3268 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:577:20:3268 | if ... | UseUseExplosion.rb:20:572:20:3268 | then ... |
 | UseUseExplosion.rb:20:581:20:585 | [post] self | UseUseExplosion.rb:20:602:20:606 | self |
 | UseUseExplosion.rb:20:581:20:585 | [post] self | UseUseExplosion.rb:20:3259:20:3264 | self |
@@ -480,9 +534,11 @@
 | UseUseExplosion.rb:20:581:20:585 | self | UseUseExplosion.rb:20:3259:20:3264 | self |
 | UseUseExplosion.rb:20:581:20:590 | ... > ... | UseUseExplosion.rb:20:580:20:591 | [false] ( ... ) |
 | UseUseExplosion.rb:20:581:20:590 | ... > ... | UseUseExplosion.rb:20:580:20:591 | [true] ( ... ) |
+| UseUseExplosion.rb:20:593:20:3252 | [input] SSA phi read(self) | UseUseExplosion.rb:20:577:20:3268 | SSA phi read(self) |
+| UseUseExplosion.rb:20:593:20:3252 | [input] SSA phi read(x) | UseUseExplosion.rb:20:577:20:3268 | SSA phi read(x) |
 | UseUseExplosion.rb:20:593:20:3252 | then ... | UseUseExplosion.rb:20:577:20:3268 | if ... |
-| UseUseExplosion.rb:20:598:20:3252 | SSA phi read(self) | UseUseExplosion.rb:20:577:20:3268 | SSA phi read(self) |
-| UseUseExplosion.rb:20:598:20:3252 | SSA phi read(x) | UseUseExplosion.rb:20:577:20:3268 | SSA phi read(x) |
+| UseUseExplosion.rb:20:598:20:3252 | SSA phi read(self) | UseUseExplosion.rb:20:593:20:3252 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:598:20:3252 | SSA phi read(x) | UseUseExplosion.rb:20:593:20:3252 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:598:20:3252 | if ... | UseUseExplosion.rb:20:593:20:3252 | then ... |
 | UseUseExplosion.rb:20:602:20:606 | [post] self | UseUseExplosion.rb:20:623:20:627 | self |
 | UseUseExplosion.rb:20:602:20:606 | [post] self | UseUseExplosion.rb:20:3243:20:3248 | self |
@@ -490,9 +546,11 @@
 | UseUseExplosion.rb:20:602:20:606 | self | UseUseExplosion.rb:20:3243:20:3248 | self |
 | UseUseExplosion.rb:20:602:20:611 | ... > ... | UseUseExplosion.rb:20:601:20:612 | [false] ( ... ) |
 | UseUseExplosion.rb:20:602:20:611 | ... > ... | UseUseExplosion.rb:20:601:20:612 | [true] ( ... ) |
+| UseUseExplosion.rb:20:614:20:3236 | [input] SSA phi read(self) | UseUseExplosion.rb:20:598:20:3252 | SSA phi read(self) |
+| UseUseExplosion.rb:20:614:20:3236 | [input] SSA phi read(x) | UseUseExplosion.rb:20:598:20:3252 | SSA phi read(x) |
 | UseUseExplosion.rb:20:614:20:3236 | then ... | UseUseExplosion.rb:20:598:20:3252 | if ... |
-| UseUseExplosion.rb:20:619:20:3236 | SSA phi read(self) | UseUseExplosion.rb:20:598:20:3252 | SSA phi read(self) |
-| UseUseExplosion.rb:20:619:20:3236 | SSA phi read(x) | UseUseExplosion.rb:20:598:20:3252 | SSA phi read(x) |
+| UseUseExplosion.rb:20:619:20:3236 | SSA phi read(self) | UseUseExplosion.rb:20:614:20:3236 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:619:20:3236 | SSA phi read(x) | UseUseExplosion.rb:20:614:20:3236 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:619:20:3236 | if ... | UseUseExplosion.rb:20:614:20:3236 | then ... |
 | UseUseExplosion.rb:20:623:20:627 | [post] self | UseUseExplosion.rb:20:644:20:648 | self |
 | UseUseExplosion.rb:20:623:20:627 | [post] self | UseUseExplosion.rb:20:3227:20:3232 | self |
@@ -500,9 +558,11 @@
 | UseUseExplosion.rb:20:623:20:627 | self | UseUseExplosion.rb:20:3227:20:3232 | self |
 | UseUseExplosion.rb:20:623:20:632 | ... > ... | UseUseExplosion.rb:20:622:20:633 | [false] ( ... ) |
 | UseUseExplosion.rb:20:623:20:632 | ... > ... | UseUseExplosion.rb:20:622:20:633 | [true] ( ... ) |
+| UseUseExplosion.rb:20:635:20:3220 | [input] SSA phi read(self) | UseUseExplosion.rb:20:619:20:3236 | SSA phi read(self) |
+| UseUseExplosion.rb:20:635:20:3220 | [input] SSA phi read(x) | UseUseExplosion.rb:20:619:20:3236 | SSA phi read(x) |
 | UseUseExplosion.rb:20:635:20:3220 | then ... | UseUseExplosion.rb:20:619:20:3236 | if ... |
-| UseUseExplosion.rb:20:640:20:3220 | SSA phi read(self) | UseUseExplosion.rb:20:619:20:3236 | SSA phi read(self) |
-| UseUseExplosion.rb:20:640:20:3220 | SSA phi read(x) | UseUseExplosion.rb:20:619:20:3236 | SSA phi read(x) |
+| UseUseExplosion.rb:20:640:20:3220 | SSA phi read(self) | UseUseExplosion.rb:20:635:20:3220 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:640:20:3220 | SSA phi read(x) | UseUseExplosion.rb:20:635:20:3220 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:640:20:3220 | if ... | UseUseExplosion.rb:20:635:20:3220 | then ... |
 | UseUseExplosion.rb:20:644:20:648 | [post] self | UseUseExplosion.rb:20:665:20:669 | self |
 | UseUseExplosion.rb:20:644:20:648 | [post] self | UseUseExplosion.rb:20:3211:20:3216 | self |
@@ -510,9 +570,11 @@
 | UseUseExplosion.rb:20:644:20:648 | self | UseUseExplosion.rb:20:3211:20:3216 | self |
 | UseUseExplosion.rb:20:644:20:653 | ... > ... | UseUseExplosion.rb:20:643:20:654 | [false] ( ... ) |
 | UseUseExplosion.rb:20:644:20:653 | ... > ... | UseUseExplosion.rb:20:643:20:654 | [true] ( ... ) |
+| UseUseExplosion.rb:20:656:20:3204 | [input] SSA phi read(self) | UseUseExplosion.rb:20:640:20:3220 | SSA phi read(self) |
+| UseUseExplosion.rb:20:656:20:3204 | [input] SSA phi read(x) | UseUseExplosion.rb:20:640:20:3220 | SSA phi read(x) |
 | UseUseExplosion.rb:20:656:20:3204 | then ... | UseUseExplosion.rb:20:640:20:3220 | if ... |
-| UseUseExplosion.rb:20:661:20:3204 | SSA phi read(self) | UseUseExplosion.rb:20:640:20:3220 | SSA phi read(self) |
-| UseUseExplosion.rb:20:661:20:3204 | SSA phi read(x) | UseUseExplosion.rb:20:640:20:3220 | SSA phi read(x) |
+| UseUseExplosion.rb:20:661:20:3204 | SSA phi read(self) | UseUseExplosion.rb:20:656:20:3204 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:661:20:3204 | SSA phi read(x) | UseUseExplosion.rb:20:656:20:3204 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:661:20:3204 | if ... | UseUseExplosion.rb:20:656:20:3204 | then ... |
 | UseUseExplosion.rb:20:665:20:669 | [post] self | UseUseExplosion.rb:20:686:20:690 | self |
 | UseUseExplosion.rb:20:665:20:669 | [post] self | UseUseExplosion.rb:20:3195:20:3200 | self |
@@ -520,9 +582,11 @@
 | UseUseExplosion.rb:20:665:20:669 | self | UseUseExplosion.rb:20:3195:20:3200 | self |
 | UseUseExplosion.rb:20:665:20:674 | ... > ... | UseUseExplosion.rb:20:664:20:675 | [false] ( ... ) |
 | UseUseExplosion.rb:20:665:20:674 | ... > ... | UseUseExplosion.rb:20:664:20:675 | [true] ( ... ) |
+| UseUseExplosion.rb:20:677:20:3188 | [input] SSA phi read(self) | UseUseExplosion.rb:20:661:20:3204 | SSA phi read(self) |
+| UseUseExplosion.rb:20:677:20:3188 | [input] SSA phi read(x) | UseUseExplosion.rb:20:661:20:3204 | SSA phi read(x) |
 | UseUseExplosion.rb:20:677:20:3188 | then ... | UseUseExplosion.rb:20:661:20:3204 | if ... |
-| UseUseExplosion.rb:20:682:20:3188 | SSA phi read(self) | UseUseExplosion.rb:20:661:20:3204 | SSA phi read(self) |
-| UseUseExplosion.rb:20:682:20:3188 | SSA phi read(x) | UseUseExplosion.rb:20:661:20:3204 | SSA phi read(x) |
+| UseUseExplosion.rb:20:682:20:3188 | SSA phi read(self) | UseUseExplosion.rb:20:677:20:3188 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:682:20:3188 | SSA phi read(x) | UseUseExplosion.rb:20:677:20:3188 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:682:20:3188 | if ... | UseUseExplosion.rb:20:677:20:3188 | then ... |
 | UseUseExplosion.rb:20:686:20:690 | [post] self | UseUseExplosion.rb:20:707:20:711 | self |
 | UseUseExplosion.rb:20:686:20:690 | [post] self | UseUseExplosion.rb:20:3179:20:3184 | self |
@@ -530,9 +594,11 @@
 | UseUseExplosion.rb:20:686:20:690 | self | UseUseExplosion.rb:20:3179:20:3184 | self |
 | UseUseExplosion.rb:20:686:20:695 | ... > ... | UseUseExplosion.rb:20:685:20:696 | [false] ( ... ) |
 | UseUseExplosion.rb:20:686:20:695 | ... > ... | UseUseExplosion.rb:20:685:20:696 | [true] ( ... ) |
+| UseUseExplosion.rb:20:698:20:3172 | [input] SSA phi read(self) | UseUseExplosion.rb:20:682:20:3188 | SSA phi read(self) |
+| UseUseExplosion.rb:20:698:20:3172 | [input] SSA phi read(x) | UseUseExplosion.rb:20:682:20:3188 | SSA phi read(x) |
 | UseUseExplosion.rb:20:698:20:3172 | then ... | UseUseExplosion.rb:20:682:20:3188 | if ... |
-| UseUseExplosion.rb:20:703:20:3172 | SSA phi read(self) | UseUseExplosion.rb:20:682:20:3188 | SSA phi read(self) |
-| UseUseExplosion.rb:20:703:20:3172 | SSA phi read(x) | UseUseExplosion.rb:20:682:20:3188 | SSA phi read(x) |
+| UseUseExplosion.rb:20:703:20:3172 | SSA phi read(self) | UseUseExplosion.rb:20:698:20:3172 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:703:20:3172 | SSA phi read(x) | UseUseExplosion.rb:20:698:20:3172 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:703:20:3172 | if ... | UseUseExplosion.rb:20:698:20:3172 | then ... |
 | UseUseExplosion.rb:20:707:20:711 | [post] self | UseUseExplosion.rb:20:728:20:732 | self |
 | UseUseExplosion.rb:20:707:20:711 | [post] self | UseUseExplosion.rb:20:3163:20:3168 | self |
@@ -540,9 +606,11 @@
 | UseUseExplosion.rb:20:707:20:711 | self | UseUseExplosion.rb:20:3163:20:3168 | self |
 | UseUseExplosion.rb:20:707:20:716 | ... > ... | UseUseExplosion.rb:20:706:20:717 | [false] ( ... ) |
 | UseUseExplosion.rb:20:707:20:716 | ... > ... | UseUseExplosion.rb:20:706:20:717 | [true] ( ... ) |
+| UseUseExplosion.rb:20:719:20:3156 | [input] SSA phi read(self) | UseUseExplosion.rb:20:703:20:3172 | SSA phi read(self) |
+| UseUseExplosion.rb:20:719:20:3156 | [input] SSA phi read(x) | UseUseExplosion.rb:20:703:20:3172 | SSA phi read(x) |
 | UseUseExplosion.rb:20:719:20:3156 | then ... | UseUseExplosion.rb:20:703:20:3172 | if ... |
-| UseUseExplosion.rb:20:724:20:3156 | SSA phi read(self) | UseUseExplosion.rb:20:703:20:3172 | SSA phi read(self) |
-| UseUseExplosion.rb:20:724:20:3156 | SSA phi read(x) | UseUseExplosion.rb:20:703:20:3172 | SSA phi read(x) |
+| UseUseExplosion.rb:20:724:20:3156 | SSA phi read(self) | UseUseExplosion.rb:20:719:20:3156 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:724:20:3156 | SSA phi read(x) | UseUseExplosion.rb:20:719:20:3156 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:724:20:3156 | if ... | UseUseExplosion.rb:20:719:20:3156 | then ... |
 | UseUseExplosion.rb:20:728:20:732 | [post] self | UseUseExplosion.rb:20:749:20:753 | self |
 | UseUseExplosion.rb:20:728:20:732 | [post] self | UseUseExplosion.rb:20:3147:20:3152 | self |
@@ -550,9 +618,11 @@
 | UseUseExplosion.rb:20:728:20:732 | self | UseUseExplosion.rb:20:3147:20:3152 | self |
 | UseUseExplosion.rb:20:728:20:737 | ... > ... | UseUseExplosion.rb:20:727:20:738 | [false] ( ... ) |
 | UseUseExplosion.rb:20:728:20:737 | ... > ... | UseUseExplosion.rb:20:727:20:738 | [true] ( ... ) |
+| UseUseExplosion.rb:20:740:20:3140 | [input] SSA phi read(self) | UseUseExplosion.rb:20:724:20:3156 | SSA phi read(self) |
+| UseUseExplosion.rb:20:740:20:3140 | [input] SSA phi read(x) | UseUseExplosion.rb:20:724:20:3156 | SSA phi read(x) |
 | UseUseExplosion.rb:20:740:20:3140 | then ... | UseUseExplosion.rb:20:724:20:3156 | if ... |
-| UseUseExplosion.rb:20:745:20:3140 | SSA phi read(self) | UseUseExplosion.rb:20:724:20:3156 | SSA phi read(self) |
-| UseUseExplosion.rb:20:745:20:3140 | SSA phi read(x) | UseUseExplosion.rb:20:724:20:3156 | SSA phi read(x) |
+| UseUseExplosion.rb:20:745:20:3140 | SSA phi read(self) | UseUseExplosion.rb:20:740:20:3140 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:745:20:3140 | SSA phi read(x) | UseUseExplosion.rb:20:740:20:3140 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:745:20:3140 | if ... | UseUseExplosion.rb:20:740:20:3140 | then ... |
 | UseUseExplosion.rb:20:749:20:753 | [post] self | UseUseExplosion.rb:20:770:20:774 | self |
 | UseUseExplosion.rb:20:749:20:753 | [post] self | UseUseExplosion.rb:20:3131:20:3136 | self |
@@ -560,9 +630,11 @@
 | UseUseExplosion.rb:20:749:20:753 | self | UseUseExplosion.rb:20:3131:20:3136 | self |
 | UseUseExplosion.rb:20:749:20:758 | ... > ... | UseUseExplosion.rb:20:748:20:759 | [false] ( ... ) |
 | UseUseExplosion.rb:20:749:20:758 | ... > ... | UseUseExplosion.rb:20:748:20:759 | [true] ( ... ) |
+| UseUseExplosion.rb:20:761:20:3124 | [input] SSA phi read(self) | UseUseExplosion.rb:20:745:20:3140 | SSA phi read(self) |
+| UseUseExplosion.rb:20:761:20:3124 | [input] SSA phi read(x) | UseUseExplosion.rb:20:745:20:3140 | SSA phi read(x) |
 | UseUseExplosion.rb:20:761:20:3124 | then ... | UseUseExplosion.rb:20:745:20:3140 | if ... |
-| UseUseExplosion.rb:20:766:20:3124 | SSA phi read(self) | UseUseExplosion.rb:20:745:20:3140 | SSA phi read(self) |
-| UseUseExplosion.rb:20:766:20:3124 | SSA phi read(x) | UseUseExplosion.rb:20:745:20:3140 | SSA phi read(x) |
+| UseUseExplosion.rb:20:766:20:3124 | SSA phi read(self) | UseUseExplosion.rb:20:761:20:3124 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:766:20:3124 | SSA phi read(x) | UseUseExplosion.rb:20:761:20:3124 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:766:20:3124 | if ... | UseUseExplosion.rb:20:761:20:3124 | then ... |
 | UseUseExplosion.rb:20:770:20:774 | [post] self | UseUseExplosion.rb:20:791:20:795 | self |
 | UseUseExplosion.rb:20:770:20:774 | [post] self | UseUseExplosion.rb:20:3115:20:3120 | self |
@@ -570,9 +642,11 @@
 | UseUseExplosion.rb:20:770:20:774 | self | UseUseExplosion.rb:20:3115:20:3120 | self |
 | UseUseExplosion.rb:20:770:20:779 | ... > ... | UseUseExplosion.rb:20:769:20:780 | [false] ( ... ) |
 | UseUseExplosion.rb:20:770:20:779 | ... > ... | UseUseExplosion.rb:20:769:20:780 | [true] ( ... ) |
+| UseUseExplosion.rb:20:782:20:3108 | [input] SSA phi read(self) | UseUseExplosion.rb:20:766:20:3124 | SSA phi read(self) |
+| UseUseExplosion.rb:20:782:20:3108 | [input] SSA phi read(x) | UseUseExplosion.rb:20:766:20:3124 | SSA phi read(x) |
 | UseUseExplosion.rb:20:782:20:3108 | then ... | UseUseExplosion.rb:20:766:20:3124 | if ... |
-| UseUseExplosion.rb:20:787:20:3108 | SSA phi read(self) | UseUseExplosion.rb:20:766:20:3124 | SSA phi read(self) |
-| UseUseExplosion.rb:20:787:20:3108 | SSA phi read(x) | UseUseExplosion.rb:20:766:20:3124 | SSA phi read(x) |
+| UseUseExplosion.rb:20:787:20:3108 | SSA phi read(self) | UseUseExplosion.rb:20:782:20:3108 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:787:20:3108 | SSA phi read(x) | UseUseExplosion.rb:20:782:20:3108 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:787:20:3108 | if ... | UseUseExplosion.rb:20:782:20:3108 | then ... |
 | UseUseExplosion.rb:20:791:20:795 | [post] self | UseUseExplosion.rb:20:812:20:816 | self |
 | UseUseExplosion.rb:20:791:20:795 | [post] self | UseUseExplosion.rb:20:3099:20:3104 | self |
@@ -580,9 +654,11 @@
 | UseUseExplosion.rb:20:791:20:795 | self | UseUseExplosion.rb:20:3099:20:3104 | self |
 | UseUseExplosion.rb:20:791:20:800 | ... > ... | UseUseExplosion.rb:20:790:20:801 | [false] ( ... ) |
 | UseUseExplosion.rb:20:791:20:800 | ... > ... | UseUseExplosion.rb:20:790:20:801 | [true] ( ... ) |
+| UseUseExplosion.rb:20:803:20:3092 | [input] SSA phi read(self) | UseUseExplosion.rb:20:787:20:3108 | SSA phi read(self) |
+| UseUseExplosion.rb:20:803:20:3092 | [input] SSA phi read(x) | UseUseExplosion.rb:20:787:20:3108 | SSA phi read(x) |
 | UseUseExplosion.rb:20:803:20:3092 | then ... | UseUseExplosion.rb:20:787:20:3108 | if ... |
-| UseUseExplosion.rb:20:808:20:3092 | SSA phi read(self) | UseUseExplosion.rb:20:787:20:3108 | SSA phi read(self) |
-| UseUseExplosion.rb:20:808:20:3092 | SSA phi read(x) | UseUseExplosion.rb:20:787:20:3108 | SSA phi read(x) |
+| UseUseExplosion.rb:20:808:20:3092 | SSA phi read(self) | UseUseExplosion.rb:20:803:20:3092 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:808:20:3092 | SSA phi read(x) | UseUseExplosion.rb:20:803:20:3092 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:808:20:3092 | if ... | UseUseExplosion.rb:20:803:20:3092 | then ... |
 | UseUseExplosion.rb:20:812:20:816 | [post] self | UseUseExplosion.rb:20:833:20:837 | self |
 | UseUseExplosion.rb:20:812:20:816 | [post] self | UseUseExplosion.rb:20:3083:20:3088 | self |
@@ -590,9 +666,11 @@
 | UseUseExplosion.rb:20:812:20:816 | self | UseUseExplosion.rb:20:3083:20:3088 | self |
 | UseUseExplosion.rb:20:812:20:821 | ... > ... | UseUseExplosion.rb:20:811:20:822 | [false] ( ... ) |
 | UseUseExplosion.rb:20:812:20:821 | ... > ... | UseUseExplosion.rb:20:811:20:822 | [true] ( ... ) |
+| UseUseExplosion.rb:20:824:20:3076 | [input] SSA phi read(self) | UseUseExplosion.rb:20:808:20:3092 | SSA phi read(self) |
+| UseUseExplosion.rb:20:824:20:3076 | [input] SSA phi read(x) | UseUseExplosion.rb:20:808:20:3092 | SSA phi read(x) |
 | UseUseExplosion.rb:20:824:20:3076 | then ... | UseUseExplosion.rb:20:808:20:3092 | if ... |
-| UseUseExplosion.rb:20:829:20:3076 | SSA phi read(self) | UseUseExplosion.rb:20:808:20:3092 | SSA phi read(self) |
-| UseUseExplosion.rb:20:829:20:3076 | SSA phi read(x) | UseUseExplosion.rb:20:808:20:3092 | SSA phi read(x) |
+| UseUseExplosion.rb:20:829:20:3076 | SSA phi read(self) | UseUseExplosion.rb:20:824:20:3076 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:829:20:3076 | SSA phi read(x) | UseUseExplosion.rb:20:824:20:3076 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:829:20:3076 | if ... | UseUseExplosion.rb:20:824:20:3076 | then ... |
 | UseUseExplosion.rb:20:833:20:837 | [post] self | UseUseExplosion.rb:20:854:20:858 | self |
 | UseUseExplosion.rb:20:833:20:837 | [post] self | UseUseExplosion.rb:20:3067:20:3072 | self |
@@ -600,9 +678,11 @@
 | UseUseExplosion.rb:20:833:20:837 | self | UseUseExplosion.rb:20:3067:20:3072 | self |
 | UseUseExplosion.rb:20:833:20:842 | ... > ... | UseUseExplosion.rb:20:832:20:843 | [false] ( ... ) |
 | UseUseExplosion.rb:20:833:20:842 | ... > ... | UseUseExplosion.rb:20:832:20:843 | [true] ( ... ) |
+| UseUseExplosion.rb:20:845:20:3060 | [input] SSA phi read(self) | UseUseExplosion.rb:20:829:20:3076 | SSA phi read(self) |
+| UseUseExplosion.rb:20:845:20:3060 | [input] SSA phi read(x) | UseUseExplosion.rb:20:829:20:3076 | SSA phi read(x) |
 | UseUseExplosion.rb:20:845:20:3060 | then ... | UseUseExplosion.rb:20:829:20:3076 | if ... |
-| UseUseExplosion.rb:20:850:20:3060 | SSA phi read(self) | UseUseExplosion.rb:20:829:20:3076 | SSA phi read(self) |
-| UseUseExplosion.rb:20:850:20:3060 | SSA phi read(x) | UseUseExplosion.rb:20:829:20:3076 | SSA phi read(x) |
+| UseUseExplosion.rb:20:850:20:3060 | SSA phi read(self) | UseUseExplosion.rb:20:845:20:3060 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:850:20:3060 | SSA phi read(x) | UseUseExplosion.rb:20:845:20:3060 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:850:20:3060 | if ... | UseUseExplosion.rb:20:845:20:3060 | then ... |
 | UseUseExplosion.rb:20:854:20:858 | [post] self | UseUseExplosion.rb:20:875:20:879 | self |
 | UseUseExplosion.rb:20:854:20:858 | [post] self | UseUseExplosion.rb:20:3051:20:3056 | self |
@@ -610,9 +690,11 @@
 | UseUseExplosion.rb:20:854:20:858 | self | UseUseExplosion.rb:20:3051:20:3056 | self |
 | UseUseExplosion.rb:20:854:20:863 | ... > ... | UseUseExplosion.rb:20:853:20:864 | [false] ( ... ) |
 | UseUseExplosion.rb:20:854:20:863 | ... > ... | UseUseExplosion.rb:20:853:20:864 | [true] ( ... ) |
+| UseUseExplosion.rb:20:866:20:3044 | [input] SSA phi read(self) | UseUseExplosion.rb:20:850:20:3060 | SSA phi read(self) |
+| UseUseExplosion.rb:20:866:20:3044 | [input] SSA phi read(x) | UseUseExplosion.rb:20:850:20:3060 | SSA phi read(x) |
 | UseUseExplosion.rb:20:866:20:3044 | then ... | UseUseExplosion.rb:20:850:20:3060 | if ... |
-| UseUseExplosion.rb:20:871:20:3044 | SSA phi read(self) | UseUseExplosion.rb:20:850:20:3060 | SSA phi read(self) |
-| UseUseExplosion.rb:20:871:20:3044 | SSA phi read(x) | UseUseExplosion.rb:20:850:20:3060 | SSA phi read(x) |
+| UseUseExplosion.rb:20:871:20:3044 | SSA phi read(self) | UseUseExplosion.rb:20:866:20:3044 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:871:20:3044 | SSA phi read(x) | UseUseExplosion.rb:20:866:20:3044 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:871:20:3044 | if ... | UseUseExplosion.rb:20:866:20:3044 | then ... |
 | UseUseExplosion.rb:20:875:20:879 | [post] self | UseUseExplosion.rb:20:896:20:900 | self |
 | UseUseExplosion.rb:20:875:20:879 | [post] self | UseUseExplosion.rb:20:3035:20:3040 | self |
@@ -620,9 +702,11 @@
 | UseUseExplosion.rb:20:875:20:879 | self | UseUseExplosion.rb:20:3035:20:3040 | self |
 | UseUseExplosion.rb:20:875:20:884 | ... > ... | UseUseExplosion.rb:20:874:20:885 | [false] ( ... ) |
 | UseUseExplosion.rb:20:875:20:884 | ... > ... | UseUseExplosion.rb:20:874:20:885 | [true] ( ... ) |
+| UseUseExplosion.rb:20:887:20:3028 | [input] SSA phi read(self) | UseUseExplosion.rb:20:871:20:3044 | SSA phi read(self) |
+| UseUseExplosion.rb:20:887:20:3028 | [input] SSA phi read(x) | UseUseExplosion.rb:20:871:20:3044 | SSA phi read(x) |
 | UseUseExplosion.rb:20:887:20:3028 | then ... | UseUseExplosion.rb:20:871:20:3044 | if ... |
-| UseUseExplosion.rb:20:892:20:3028 | SSA phi read(self) | UseUseExplosion.rb:20:871:20:3044 | SSA phi read(self) |
-| UseUseExplosion.rb:20:892:20:3028 | SSA phi read(x) | UseUseExplosion.rb:20:871:20:3044 | SSA phi read(x) |
+| UseUseExplosion.rb:20:892:20:3028 | SSA phi read(self) | UseUseExplosion.rb:20:887:20:3028 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:892:20:3028 | SSA phi read(x) | UseUseExplosion.rb:20:887:20:3028 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:892:20:3028 | if ... | UseUseExplosion.rb:20:887:20:3028 | then ... |
 | UseUseExplosion.rb:20:896:20:900 | [post] self | UseUseExplosion.rb:20:917:20:921 | self |
 | UseUseExplosion.rb:20:896:20:900 | [post] self | UseUseExplosion.rb:20:3019:20:3024 | self |
@@ -630,9 +714,11 @@
 | UseUseExplosion.rb:20:896:20:900 | self | UseUseExplosion.rb:20:3019:20:3024 | self |
 | UseUseExplosion.rb:20:896:20:905 | ... > ... | UseUseExplosion.rb:20:895:20:906 | [false] ( ... ) |
 | UseUseExplosion.rb:20:896:20:905 | ... > ... | UseUseExplosion.rb:20:895:20:906 | [true] ( ... ) |
+| UseUseExplosion.rb:20:908:20:3012 | [input] SSA phi read(self) | UseUseExplosion.rb:20:892:20:3028 | SSA phi read(self) |
+| UseUseExplosion.rb:20:908:20:3012 | [input] SSA phi read(x) | UseUseExplosion.rb:20:892:20:3028 | SSA phi read(x) |
 | UseUseExplosion.rb:20:908:20:3012 | then ... | UseUseExplosion.rb:20:892:20:3028 | if ... |
-| UseUseExplosion.rb:20:913:20:3012 | SSA phi read(self) | UseUseExplosion.rb:20:892:20:3028 | SSA phi read(self) |
-| UseUseExplosion.rb:20:913:20:3012 | SSA phi read(x) | UseUseExplosion.rb:20:892:20:3028 | SSA phi read(x) |
+| UseUseExplosion.rb:20:913:20:3012 | SSA phi read(self) | UseUseExplosion.rb:20:908:20:3012 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:913:20:3012 | SSA phi read(x) | UseUseExplosion.rb:20:908:20:3012 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:913:20:3012 | if ... | UseUseExplosion.rb:20:908:20:3012 | then ... |
 | UseUseExplosion.rb:20:917:20:921 | [post] self | UseUseExplosion.rb:20:938:20:942 | self |
 | UseUseExplosion.rb:20:917:20:921 | [post] self | UseUseExplosion.rb:20:3003:20:3008 | self |
@@ -640,9 +726,11 @@
 | UseUseExplosion.rb:20:917:20:921 | self | UseUseExplosion.rb:20:3003:20:3008 | self |
 | UseUseExplosion.rb:20:917:20:926 | ... > ... | UseUseExplosion.rb:20:916:20:927 | [false] ( ... ) |
 | UseUseExplosion.rb:20:917:20:926 | ... > ... | UseUseExplosion.rb:20:916:20:927 | [true] ( ... ) |
+| UseUseExplosion.rb:20:929:20:2996 | [input] SSA phi read(self) | UseUseExplosion.rb:20:913:20:3012 | SSA phi read(self) |
+| UseUseExplosion.rb:20:929:20:2996 | [input] SSA phi read(x) | UseUseExplosion.rb:20:913:20:3012 | SSA phi read(x) |
 | UseUseExplosion.rb:20:929:20:2996 | then ... | UseUseExplosion.rb:20:913:20:3012 | if ... |
-| UseUseExplosion.rb:20:934:20:2996 | SSA phi read(self) | UseUseExplosion.rb:20:913:20:3012 | SSA phi read(self) |
-| UseUseExplosion.rb:20:934:20:2996 | SSA phi read(x) | UseUseExplosion.rb:20:913:20:3012 | SSA phi read(x) |
+| UseUseExplosion.rb:20:934:20:2996 | SSA phi read(self) | UseUseExplosion.rb:20:929:20:2996 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:934:20:2996 | SSA phi read(x) | UseUseExplosion.rb:20:929:20:2996 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:934:20:2996 | if ... | UseUseExplosion.rb:20:929:20:2996 | then ... |
 | UseUseExplosion.rb:20:938:20:942 | [post] self | UseUseExplosion.rb:20:959:20:963 | self |
 | UseUseExplosion.rb:20:938:20:942 | [post] self | UseUseExplosion.rb:20:2987:20:2992 | self |
@@ -650,9 +738,11 @@
 | UseUseExplosion.rb:20:938:20:942 | self | UseUseExplosion.rb:20:2987:20:2992 | self |
 | UseUseExplosion.rb:20:938:20:947 | ... > ... | UseUseExplosion.rb:20:937:20:948 | [false] ( ... ) |
 | UseUseExplosion.rb:20:938:20:947 | ... > ... | UseUseExplosion.rb:20:937:20:948 | [true] ( ... ) |
+| UseUseExplosion.rb:20:950:20:2980 | [input] SSA phi read(self) | UseUseExplosion.rb:20:934:20:2996 | SSA phi read(self) |
+| UseUseExplosion.rb:20:950:20:2980 | [input] SSA phi read(x) | UseUseExplosion.rb:20:934:20:2996 | SSA phi read(x) |
 | UseUseExplosion.rb:20:950:20:2980 | then ... | UseUseExplosion.rb:20:934:20:2996 | if ... |
-| UseUseExplosion.rb:20:955:20:2980 | SSA phi read(self) | UseUseExplosion.rb:20:934:20:2996 | SSA phi read(self) |
-| UseUseExplosion.rb:20:955:20:2980 | SSA phi read(x) | UseUseExplosion.rb:20:934:20:2996 | SSA phi read(x) |
+| UseUseExplosion.rb:20:955:20:2980 | SSA phi read(self) | UseUseExplosion.rb:20:950:20:2980 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:955:20:2980 | SSA phi read(x) | UseUseExplosion.rb:20:950:20:2980 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:955:20:2980 | if ... | UseUseExplosion.rb:20:950:20:2980 | then ... |
 | UseUseExplosion.rb:20:959:20:963 | [post] self | UseUseExplosion.rb:20:980:20:984 | self |
 | UseUseExplosion.rb:20:959:20:963 | [post] self | UseUseExplosion.rb:20:2971:20:2976 | self |
@@ -660,9 +750,11 @@
 | UseUseExplosion.rb:20:959:20:963 | self | UseUseExplosion.rb:20:2971:20:2976 | self |
 | UseUseExplosion.rb:20:959:20:968 | ... > ... | UseUseExplosion.rb:20:958:20:969 | [false] ( ... ) |
 | UseUseExplosion.rb:20:959:20:968 | ... > ... | UseUseExplosion.rb:20:958:20:969 | [true] ( ... ) |
+| UseUseExplosion.rb:20:971:20:2964 | [input] SSA phi read(self) | UseUseExplosion.rb:20:955:20:2980 | SSA phi read(self) |
+| UseUseExplosion.rb:20:971:20:2964 | [input] SSA phi read(x) | UseUseExplosion.rb:20:955:20:2980 | SSA phi read(x) |
 | UseUseExplosion.rb:20:971:20:2964 | then ... | UseUseExplosion.rb:20:955:20:2980 | if ... |
-| UseUseExplosion.rb:20:976:20:2964 | SSA phi read(self) | UseUseExplosion.rb:20:955:20:2980 | SSA phi read(self) |
-| UseUseExplosion.rb:20:976:20:2964 | SSA phi read(x) | UseUseExplosion.rb:20:955:20:2980 | SSA phi read(x) |
+| UseUseExplosion.rb:20:976:20:2964 | SSA phi read(self) | UseUseExplosion.rb:20:971:20:2964 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:976:20:2964 | SSA phi read(x) | UseUseExplosion.rb:20:971:20:2964 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:976:20:2964 | if ... | UseUseExplosion.rb:20:971:20:2964 | then ... |
 | UseUseExplosion.rb:20:980:20:984 | [post] self | UseUseExplosion.rb:20:1001:20:1005 | self |
 | UseUseExplosion.rb:20:980:20:984 | [post] self | UseUseExplosion.rb:20:2955:20:2960 | self |
@@ -670,9 +762,11 @@
 | UseUseExplosion.rb:20:980:20:984 | self | UseUseExplosion.rb:20:2955:20:2960 | self |
 | UseUseExplosion.rb:20:980:20:989 | ... > ... | UseUseExplosion.rb:20:979:20:990 | [false] ( ... ) |
 | UseUseExplosion.rb:20:980:20:989 | ... > ... | UseUseExplosion.rb:20:979:20:990 | [true] ( ... ) |
+| UseUseExplosion.rb:20:992:20:2948 | [input] SSA phi read(self) | UseUseExplosion.rb:20:976:20:2964 | SSA phi read(self) |
+| UseUseExplosion.rb:20:992:20:2948 | [input] SSA phi read(x) | UseUseExplosion.rb:20:976:20:2964 | SSA phi read(x) |
 | UseUseExplosion.rb:20:992:20:2948 | then ... | UseUseExplosion.rb:20:976:20:2964 | if ... |
-| UseUseExplosion.rb:20:997:20:2948 | SSA phi read(self) | UseUseExplosion.rb:20:976:20:2964 | SSA phi read(self) |
-| UseUseExplosion.rb:20:997:20:2948 | SSA phi read(x) | UseUseExplosion.rb:20:976:20:2964 | SSA phi read(x) |
+| UseUseExplosion.rb:20:997:20:2948 | SSA phi read(self) | UseUseExplosion.rb:20:992:20:2948 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:997:20:2948 | SSA phi read(x) | UseUseExplosion.rb:20:992:20:2948 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:997:20:2948 | if ... | UseUseExplosion.rb:20:992:20:2948 | then ... |
 | UseUseExplosion.rb:20:1001:20:1005 | [post] self | UseUseExplosion.rb:20:1022:20:1026 | self |
 | UseUseExplosion.rb:20:1001:20:1005 | [post] self | UseUseExplosion.rb:20:2939:20:2944 | self |
@@ -680,9 +774,11 @@
 | UseUseExplosion.rb:20:1001:20:1005 | self | UseUseExplosion.rb:20:2939:20:2944 | self |
 | UseUseExplosion.rb:20:1001:20:1010 | ... > ... | UseUseExplosion.rb:20:1000:20:1011 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1001:20:1010 | ... > ... | UseUseExplosion.rb:20:1000:20:1011 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1013:20:2932 | [input] SSA phi read(self) | UseUseExplosion.rb:20:997:20:2948 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1013:20:2932 | [input] SSA phi read(x) | UseUseExplosion.rb:20:997:20:2948 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1013:20:2932 | then ... | UseUseExplosion.rb:20:997:20:2948 | if ... |
-| UseUseExplosion.rb:20:1018:20:2932 | SSA phi read(self) | UseUseExplosion.rb:20:997:20:2948 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1018:20:2932 | SSA phi read(x) | UseUseExplosion.rb:20:997:20:2948 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1018:20:2932 | SSA phi read(self) | UseUseExplosion.rb:20:1013:20:2932 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1018:20:2932 | SSA phi read(x) | UseUseExplosion.rb:20:1013:20:2932 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1018:20:2932 | if ... | UseUseExplosion.rb:20:1013:20:2932 | then ... |
 | UseUseExplosion.rb:20:1022:20:1026 | [post] self | UseUseExplosion.rb:20:1043:20:1047 | self |
 | UseUseExplosion.rb:20:1022:20:1026 | [post] self | UseUseExplosion.rb:20:2923:20:2928 | self |
@@ -690,9 +786,11 @@
 | UseUseExplosion.rb:20:1022:20:1026 | self | UseUseExplosion.rb:20:2923:20:2928 | self |
 | UseUseExplosion.rb:20:1022:20:1031 | ... > ... | UseUseExplosion.rb:20:1021:20:1032 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1022:20:1031 | ... > ... | UseUseExplosion.rb:20:1021:20:1032 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1034:20:2916 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1018:20:2932 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1034:20:2916 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1018:20:2932 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1034:20:2916 | then ... | UseUseExplosion.rb:20:1018:20:2932 | if ... |
-| UseUseExplosion.rb:20:1039:20:2916 | SSA phi read(self) | UseUseExplosion.rb:20:1018:20:2932 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1039:20:2916 | SSA phi read(x) | UseUseExplosion.rb:20:1018:20:2932 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1039:20:2916 | SSA phi read(self) | UseUseExplosion.rb:20:1034:20:2916 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1039:20:2916 | SSA phi read(x) | UseUseExplosion.rb:20:1034:20:2916 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1039:20:2916 | if ... | UseUseExplosion.rb:20:1034:20:2916 | then ... |
 | UseUseExplosion.rb:20:1043:20:1047 | [post] self | UseUseExplosion.rb:20:1064:20:1068 | self |
 | UseUseExplosion.rb:20:1043:20:1047 | [post] self | UseUseExplosion.rb:20:2907:20:2912 | self |
@@ -700,9 +798,11 @@
 | UseUseExplosion.rb:20:1043:20:1047 | self | UseUseExplosion.rb:20:2907:20:2912 | self |
 | UseUseExplosion.rb:20:1043:20:1052 | ... > ... | UseUseExplosion.rb:20:1042:20:1053 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1043:20:1052 | ... > ... | UseUseExplosion.rb:20:1042:20:1053 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1055:20:2900 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1039:20:2916 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1055:20:2900 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1039:20:2916 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1055:20:2900 | then ... | UseUseExplosion.rb:20:1039:20:2916 | if ... |
-| UseUseExplosion.rb:20:1060:20:2900 | SSA phi read(self) | UseUseExplosion.rb:20:1039:20:2916 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1060:20:2900 | SSA phi read(x) | UseUseExplosion.rb:20:1039:20:2916 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1060:20:2900 | SSA phi read(self) | UseUseExplosion.rb:20:1055:20:2900 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1060:20:2900 | SSA phi read(x) | UseUseExplosion.rb:20:1055:20:2900 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1060:20:2900 | if ... | UseUseExplosion.rb:20:1055:20:2900 | then ... |
 | UseUseExplosion.rb:20:1064:20:1068 | [post] self | UseUseExplosion.rb:20:1085:20:1089 | self |
 | UseUseExplosion.rb:20:1064:20:1068 | [post] self | UseUseExplosion.rb:20:2891:20:2896 | self |
@@ -710,9 +810,11 @@
 | UseUseExplosion.rb:20:1064:20:1068 | self | UseUseExplosion.rb:20:2891:20:2896 | self |
 | UseUseExplosion.rb:20:1064:20:1073 | ... > ... | UseUseExplosion.rb:20:1063:20:1074 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1064:20:1073 | ... > ... | UseUseExplosion.rb:20:1063:20:1074 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1076:20:2884 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1060:20:2900 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1076:20:2884 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1060:20:2900 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1076:20:2884 | then ... | UseUseExplosion.rb:20:1060:20:2900 | if ... |
-| UseUseExplosion.rb:20:1081:20:2884 | SSA phi read(self) | UseUseExplosion.rb:20:1060:20:2900 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1081:20:2884 | SSA phi read(x) | UseUseExplosion.rb:20:1060:20:2900 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1081:20:2884 | SSA phi read(self) | UseUseExplosion.rb:20:1076:20:2884 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1081:20:2884 | SSA phi read(x) | UseUseExplosion.rb:20:1076:20:2884 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1081:20:2884 | if ... | UseUseExplosion.rb:20:1076:20:2884 | then ... |
 | UseUseExplosion.rb:20:1085:20:1089 | [post] self | UseUseExplosion.rb:20:1106:20:1110 | self |
 | UseUseExplosion.rb:20:1085:20:1089 | [post] self | UseUseExplosion.rb:20:2875:20:2880 | self |
@@ -720,9 +822,11 @@
 | UseUseExplosion.rb:20:1085:20:1089 | self | UseUseExplosion.rb:20:2875:20:2880 | self |
 | UseUseExplosion.rb:20:1085:20:1094 | ... > ... | UseUseExplosion.rb:20:1084:20:1095 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1085:20:1094 | ... > ... | UseUseExplosion.rb:20:1084:20:1095 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1097:20:2868 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1081:20:2884 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1097:20:2868 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1081:20:2884 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1097:20:2868 | then ... | UseUseExplosion.rb:20:1081:20:2884 | if ... |
-| UseUseExplosion.rb:20:1102:20:2868 | SSA phi read(self) | UseUseExplosion.rb:20:1081:20:2884 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1102:20:2868 | SSA phi read(x) | UseUseExplosion.rb:20:1081:20:2884 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1102:20:2868 | SSA phi read(self) | UseUseExplosion.rb:20:1097:20:2868 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1102:20:2868 | SSA phi read(x) | UseUseExplosion.rb:20:1097:20:2868 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1102:20:2868 | if ... | UseUseExplosion.rb:20:1097:20:2868 | then ... |
 | UseUseExplosion.rb:20:1106:20:1110 | [post] self | UseUseExplosion.rb:20:1127:20:1131 | self |
 | UseUseExplosion.rb:20:1106:20:1110 | [post] self | UseUseExplosion.rb:20:2859:20:2864 | self |
@@ -730,9 +834,11 @@
 | UseUseExplosion.rb:20:1106:20:1110 | self | UseUseExplosion.rb:20:2859:20:2864 | self |
 | UseUseExplosion.rb:20:1106:20:1115 | ... > ... | UseUseExplosion.rb:20:1105:20:1116 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1106:20:1115 | ... > ... | UseUseExplosion.rb:20:1105:20:1116 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1118:20:2852 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1102:20:2868 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1118:20:2852 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1102:20:2868 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1118:20:2852 | then ... | UseUseExplosion.rb:20:1102:20:2868 | if ... |
-| UseUseExplosion.rb:20:1123:20:2852 | SSA phi read(self) | UseUseExplosion.rb:20:1102:20:2868 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1123:20:2852 | SSA phi read(x) | UseUseExplosion.rb:20:1102:20:2868 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1123:20:2852 | SSA phi read(self) | UseUseExplosion.rb:20:1118:20:2852 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1123:20:2852 | SSA phi read(x) | UseUseExplosion.rb:20:1118:20:2852 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1123:20:2852 | if ... | UseUseExplosion.rb:20:1118:20:2852 | then ... |
 | UseUseExplosion.rb:20:1127:20:1131 | [post] self | UseUseExplosion.rb:20:1148:20:1152 | self |
 | UseUseExplosion.rb:20:1127:20:1131 | [post] self | UseUseExplosion.rb:20:2843:20:2848 | self |
@@ -740,9 +846,11 @@
 | UseUseExplosion.rb:20:1127:20:1131 | self | UseUseExplosion.rb:20:2843:20:2848 | self |
 | UseUseExplosion.rb:20:1127:20:1136 | ... > ... | UseUseExplosion.rb:20:1126:20:1137 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1127:20:1136 | ... > ... | UseUseExplosion.rb:20:1126:20:1137 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1139:20:2836 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1123:20:2852 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1139:20:2836 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1123:20:2852 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1139:20:2836 | then ... | UseUseExplosion.rb:20:1123:20:2852 | if ... |
-| UseUseExplosion.rb:20:1144:20:2836 | SSA phi read(self) | UseUseExplosion.rb:20:1123:20:2852 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1144:20:2836 | SSA phi read(x) | UseUseExplosion.rb:20:1123:20:2852 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1144:20:2836 | SSA phi read(self) | UseUseExplosion.rb:20:1139:20:2836 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1144:20:2836 | SSA phi read(x) | UseUseExplosion.rb:20:1139:20:2836 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1144:20:2836 | if ... | UseUseExplosion.rb:20:1139:20:2836 | then ... |
 | UseUseExplosion.rb:20:1148:20:1152 | [post] self | UseUseExplosion.rb:20:1169:20:1173 | self |
 | UseUseExplosion.rb:20:1148:20:1152 | [post] self | UseUseExplosion.rb:20:2827:20:2832 | self |
@@ -750,9 +858,11 @@
 | UseUseExplosion.rb:20:1148:20:1152 | self | UseUseExplosion.rb:20:2827:20:2832 | self |
 | UseUseExplosion.rb:20:1148:20:1157 | ... > ... | UseUseExplosion.rb:20:1147:20:1158 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1148:20:1157 | ... > ... | UseUseExplosion.rb:20:1147:20:1158 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1160:20:2820 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1144:20:2836 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1160:20:2820 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1144:20:2836 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1160:20:2820 | then ... | UseUseExplosion.rb:20:1144:20:2836 | if ... |
-| UseUseExplosion.rb:20:1165:20:2820 | SSA phi read(self) | UseUseExplosion.rb:20:1144:20:2836 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1165:20:2820 | SSA phi read(x) | UseUseExplosion.rb:20:1144:20:2836 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1165:20:2820 | SSA phi read(self) | UseUseExplosion.rb:20:1160:20:2820 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1165:20:2820 | SSA phi read(x) | UseUseExplosion.rb:20:1160:20:2820 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1165:20:2820 | if ... | UseUseExplosion.rb:20:1160:20:2820 | then ... |
 | UseUseExplosion.rb:20:1169:20:1173 | [post] self | UseUseExplosion.rb:20:1190:20:1194 | self |
 | UseUseExplosion.rb:20:1169:20:1173 | [post] self | UseUseExplosion.rb:20:2811:20:2816 | self |
@@ -760,9 +870,11 @@
 | UseUseExplosion.rb:20:1169:20:1173 | self | UseUseExplosion.rb:20:2811:20:2816 | self |
 | UseUseExplosion.rb:20:1169:20:1178 | ... > ... | UseUseExplosion.rb:20:1168:20:1179 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1169:20:1178 | ... > ... | UseUseExplosion.rb:20:1168:20:1179 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1181:20:2804 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1165:20:2820 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1181:20:2804 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1165:20:2820 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1181:20:2804 | then ... | UseUseExplosion.rb:20:1165:20:2820 | if ... |
-| UseUseExplosion.rb:20:1186:20:2804 | SSA phi read(self) | UseUseExplosion.rb:20:1165:20:2820 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1186:20:2804 | SSA phi read(x) | UseUseExplosion.rb:20:1165:20:2820 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1186:20:2804 | SSA phi read(self) | UseUseExplosion.rb:20:1181:20:2804 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1186:20:2804 | SSA phi read(x) | UseUseExplosion.rb:20:1181:20:2804 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1186:20:2804 | if ... | UseUseExplosion.rb:20:1181:20:2804 | then ... |
 | UseUseExplosion.rb:20:1190:20:1194 | [post] self | UseUseExplosion.rb:20:1211:20:1215 | self |
 | UseUseExplosion.rb:20:1190:20:1194 | [post] self | UseUseExplosion.rb:20:2795:20:2800 | self |
@@ -770,9 +882,11 @@
 | UseUseExplosion.rb:20:1190:20:1194 | self | UseUseExplosion.rb:20:2795:20:2800 | self |
 | UseUseExplosion.rb:20:1190:20:1199 | ... > ... | UseUseExplosion.rb:20:1189:20:1200 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1190:20:1199 | ... > ... | UseUseExplosion.rb:20:1189:20:1200 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1202:20:2788 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1186:20:2804 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1202:20:2788 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1186:20:2804 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1202:20:2788 | then ... | UseUseExplosion.rb:20:1186:20:2804 | if ... |
-| UseUseExplosion.rb:20:1207:20:2788 | SSA phi read(self) | UseUseExplosion.rb:20:1186:20:2804 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1207:20:2788 | SSA phi read(x) | UseUseExplosion.rb:20:1186:20:2804 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1207:20:2788 | SSA phi read(self) | UseUseExplosion.rb:20:1202:20:2788 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1207:20:2788 | SSA phi read(x) | UseUseExplosion.rb:20:1202:20:2788 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1207:20:2788 | if ... | UseUseExplosion.rb:20:1202:20:2788 | then ... |
 | UseUseExplosion.rb:20:1211:20:1215 | [post] self | UseUseExplosion.rb:20:1232:20:1236 | self |
 | UseUseExplosion.rb:20:1211:20:1215 | [post] self | UseUseExplosion.rb:20:2779:20:2784 | self |
@@ -780,9 +894,11 @@
 | UseUseExplosion.rb:20:1211:20:1215 | self | UseUseExplosion.rb:20:2779:20:2784 | self |
 | UseUseExplosion.rb:20:1211:20:1220 | ... > ... | UseUseExplosion.rb:20:1210:20:1221 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1211:20:1220 | ... > ... | UseUseExplosion.rb:20:1210:20:1221 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1223:20:2772 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1207:20:2788 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1223:20:2772 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1207:20:2788 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1223:20:2772 | then ... | UseUseExplosion.rb:20:1207:20:2788 | if ... |
-| UseUseExplosion.rb:20:1228:20:2772 | SSA phi read(self) | UseUseExplosion.rb:20:1207:20:2788 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1228:20:2772 | SSA phi read(x) | UseUseExplosion.rb:20:1207:20:2788 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1228:20:2772 | SSA phi read(self) | UseUseExplosion.rb:20:1223:20:2772 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1228:20:2772 | SSA phi read(x) | UseUseExplosion.rb:20:1223:20:2772 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1228:20:2772 | if ... | UseUseExplosion.rb:20:1223:20:2772 | then ... |
 | UseUseExplosion.rb:20:1232:20:1236 | [post] self | UseUseExplosion.rb:20:1253:20:1257 | self |
 | UseUseExplosion.rb:20:1232:20:1236 | [post] self | UseUseExplosion.rb:20:2763:20:2768 | self |
@@ -790,9 +906,11 @@
 | UseUseExplosion.rb:20:1232:20:1236 | self | UseUseExplosion.rb:20:2763:20:2768 | self |
 | UseUseExplosion.rb:20:1232:20:1241 | ... > ... | UseUseExplosion.rb:20:1231:20:1242 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1232:20:1241 | ... > ... | UseUseExplosion.rb:20:1231:20:1242 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1244:20:2756 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1228:20:2772 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1244:20:2756 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1228:20:2772 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1244:20:2756 | then ... | UseUseExplosion.rb:20:1228:20:2772 | if ... |
-| UseUseExplosion.rb:20:1249:20:2756 | SSA phi read(self) | UseUseExplosion.rb:20:1228:20:2772 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1249:20:2756 | SSA phi read(x) | UseUseExplosion.rb:20:1228:20:2772 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1249:20:2756 | SSA phi read(self) | UseUseExplosion.rb:20:1244:20:2756 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1249:20:2756 | SSA phi read(x) | UseUseExplosion.rb:20:1244:20:2756 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1249:20:2756 | if ... | UseUseExplosion.rb:20:1244:20:2756 | then ... |
 | UseUseExplosion.rb:20:1253:20:1257 | [post] self | UseUseExplosion.rb:20:1274:20:1278 | self |
 | UseUseExplosion.rb:20:1253:20:1257 | [post] self | UseUseExplosion.rb:20:2747:20:2752 | self |
@@ -800,9 +918,11 @@
 | UseUseExplosion.rb:20:1253:20:1257 | self | UseUseExplosion.rb:20:2747:20:2752 | self |
 | UseUseExplosion.rb:20:1253:20:1262 | ... > ... | UseUseExplosion.rb:20:1252:20:1263 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1253:20:1262 | ... > ... | UseUseExplosion.rb:20:1252:20:1263 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1265:20:2740 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1249:20:2756 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1265:20:2740 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1249:20:2756 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1265:20:2740 | then ... | UseUseExplosion.rb:20:1249:20:2756 | if ... |
-| UseUseExplosion.rb:20:1270:20:2740 | SSA phi read(self) | UseUseExplosion.rb:20:1249:20:2756 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1270:20:2740 | SSA phi read(x) | UseUseExplosion.rb:20:1249:20:2756 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1270:20:2740 | SSA phi read(self) | UseUseExplosion.rb:20:1265:20:2740 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1270:20:2740 | SSA phi read(x) | UseUseExplosion.rb:20:1265:20:2740 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1270:20:2740 | if ... | UseUseExplosion.rb:20:1265:20:2740 | then ... |
 | UseUseExplosion.rb:20:1274:20:1278 | [post] self | UseUseExplosion.rb:20:1295:20:1299 | self |
 | UseUseExplosion.rb:20:1274:20:1278 | [post] self | UseUseExplosion.rb:20:2731:20:2736 | self |
@@ -810,9 +930,11 @@
 | UseUseExplosion.rb:20:1274:20:1278 | self | UseUseExplosion.rb:20:2731:20:2736 | self |
 | UseUseExplosion.rb:20:1274:20:1283 | ... > ... | UseUseExplosion.rb:20:1273:20:1284 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1274:20:1283 | ... > ... | UseUseExplosion.rb:20:1273:20:1284 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1286:20:2724 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1270:20:2740 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1286:20:2724 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1270:20:2740 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1286:20:2724 | then ... | UseUseExplosion.rb:20:1270:20:2740 | if ... |
-| UseUseExplosion.rb:20:1291:20:2724 | SSA phi read(self) | UseUseExplosion.rb:20:1270:20:2740 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1291:20:2724 | SSA phi read(x) | UseUseExplosion.rb:20:1270:20:2740 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1291:20:2724 | SSA phi read(self) | UseUseExplosion.rb:20:1286:20:2724 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1291:20:2724 | SSA phi read(x) | UseUseExplosion.rb:20:1286:20:2724 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1291:20:2724 | if ... | UseUseExplosion.rb:20:1286:20:2724 | then ... |
 | UseUseExplosion.rb:20:1295:20:1299 | [post] self | UseUseExplosion.rb:20:1316:20:1320 | self |
 | UseUseExplosion.rb:20:1295:20:1299 | [post] self | UseUseExplosion.rb:20:2715:20:2720 | self |
@@ -820,9 +942,11 @@
 | UseUseExplosion.rb:20:1295:20:1299 | self | UseUseExplosion.rb:20:2715:20:2720 | self |
 | UseUseExplosion.rb:20:1295:20:1304 | ... > ... | UseUseExplosion.rb:20:1294:20:1305 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1295:20:1304 | ... > ... | UseUseExplosion.rb:20:1294:20:1305 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1307:20:2708 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1291:20:2724 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1307:20:2708 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1291:20:2724 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1307:20:2708 | then ... | UseUseExplosion.rb:20:1291:20:2724 | if ... |
-| UseUseExplosion.rb:20:1312:20:2708 | SSA phi read(self) | UseUseExplosion.rb:20:1291:20:2724 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1312:20:2708 | SSA phi read(x) | UseUseExplosion.rb:20:1291:20:2724 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1312:20:2708 | SSA phi read(self) | UseUseExplosion.rb:20:1307:20:2708 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1312:20:2708 | SSA phi read(x) | UseUseExplosion.rb:20:1307:20:2708 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1312:20:2708 | if ... | UseUseExplosion.rb:20:1307:20:2708 | then ... |
 | UseUseExplosion.rb:20:1316:20:1320 | [post] self | UseUseExplosion.rb:20:1337:20:1341 | self |
 | UseUseExplosion.rb:20:1316:20:1320 | [post] self | UseUseExplosion.rb:20:2699:20:2704 | self |
@@ -830,9 +954,11 @@
 | UseUseExplosion.rb:20:1316:20:1320 | self | UseUseExplosion.rb:20:2699:20:2704 | self |
 | UseUseExplosion.rb:20:1316:20:1325 | ... > ... | UseUseExplosion.rb:20:1315:20:1326 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1316:20:1325 | ... > ... | UseUseExplosion.rb:20:1315:20:1326 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1328:20:2692 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1312:20:2708 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1328:20:2692 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1312:20:2708 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1328:20:2692 | then ... | UseUseExplosion.rb:20:1312:20:2708 | if ... |
-| UseUseExplosion.rb:20:1333:20:2692 | SSA phi read(self) | UseUseExplosion.rb:20:1312:20:2708 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1333:20:2692 | SSA phi read(x) | UseUseExplosion.rb:20:1312:20:2708 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1333:20:2692 | SSA phi read(self) | UseUseExplosion.rb:20:1328:20:2692 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1333:20:2692 | SSA phi read(x) | UseUseExplosion.rb:20:1328:20:2692 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1333:20:2692 | if ... | UseUseExplosion.rb:20:1328:20:2692 | then ... |
 | UseUseExplosion.rb:20:1337:20:1341 | [post] self | UseUseExplosion.rb:20:1358:20:1362 | self |
 | UseUseExplosion.rb:20:1337:20:1341 | [post] self | UseUseExplosion.rb:20:2683:20:2688 | self |
@@ -840,9 +966,11 @@
 | UseUseExplosion.rb:20:1337:20:1341 | self | UseUseExplosion.rb:20:2683:20:2688 | self |
 | UseUseExplosion.rb:20:1337:20:1346 | ... > ... | UseUseExplosion.rb:20:1336:20:1347 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1337:20:1346 | ... > ... | UseUseExplosion.rb:20:1336:20:1347 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1349:20:2676 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1333:20:2692 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1349:20:2676 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1333:20:2692 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1349:20:2676 | then ... | UseUseExplosion.rb:20:1333:20:2692 | if ... |
-| UseUseExplosion.rb:20:1354:20:2676 | SSA phi read(self) | UseUseExplosion.rb:20:1333:20:2692 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1354:20:2676 | SSA phi read(x) | UseUseExplosion.rb:20:1333:20:2692 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1354:20:2676 | SSA phi read(self) | UseUseExplosion.rb:20:1349:20:2676 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1354:20:2676 | SSA phi read(x) | UseUseExplosion.rb:20:1349:20:2676 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1354:20:2676 | if ... | UseUseExplosion.rb:20:1349:20:2676 | then ... |
 | UseUseExplosion.rb:20:1358:20:1362 | [post] self | UseUseExplosion.rb:20:1379:20:1383 | self |
 | UseUseExplosion.rb:20:1358:20:1362 | [post] self | UseUseExplosion.rb:20:2667:20:2672 | self |
@@ -850,9 +978,11 @@
 | UseUseExplosion.rb:20:1358:20:1362 | self | UseUseExplosion.rb:20:2667:20:2672 | self |
 | UseUseExplosion.rb:20:1358:20:1367 | ... > ... | UseUseExplosion.rb:20:1357:20:1368 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1358:20:1367 | ... > ... | UseUseExplosion.rb:20:1357:20:1368 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1370:20:2660 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1354:20:2676 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1370:20:2660 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1354:20:2676 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1370:20:2660 | then ... | UseUseExplosion.rb:20:1354:20:2676 | if ... |
-| UseUseExplosion.rb:20:1375:20:2660 | SSA phi read(self) | UseUseExplosion.rb:20:1354:20:2676 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1375:20:2660 | SSA phi read(x) | UseUseExplosion.rb:20:1354:20:2676 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1375:20:2660 | SSA phi read(self) | UseUseExplosion.rb:20:1370:20:2660 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1375:20:2660 | SSA phi read(x) | UseUseExplosion.rb:20:1370:20:2660 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1375:20:2660 | if ... | UseUseExplosion.rb:20:1370:20:2660 | then ... |
 | UseUseExplosion.rb:20:1379:20:1383 | [post] self | UseUseExplosion.rb:20:1400:20:1404 | self |
 | UseUseExplosion.rb:20:1379:20:1383 | [post] self | UseUseExplosion.rb:20:2651:20:2656 | self |
@@ -860,9 +990,11 @@
 | UseUseExplosion.rb:20:1379:20:1383 | self | UseUseExplosion.rb:20:2651:20:2656 | self |
 | UseUseExplosion.rb:20:1379:20:1388 | ... > ... | UseUseExplosion.rb:20:1378:20:1389 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1379:20:1388 | ... > ... | UseUseExplosion.rb:20:1378:20:1389 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1391:20:2644 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1375:20:2660 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1391:20:2644 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1375:20:2660 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1391:20:2644 | then ... | UseUseExplosion.rb:20:1375:20:2660 | if ... |
-| UseUseExplosion.rb:20:1396:20:2644 | SSA phi read(self) | UseUseExplosion.rb:20:1375:20:2660 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1396:20:2644 | SSA phi read(x) | UseUseExplosion.rb:20:1375:20:2660 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1396:20:2644 | SSA phi read(self) | UseUseExplosion.rb:20:1391:20:2644 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1396:20:2644 | SSA phi read(x) | UseUseExplosion.rb:20:1391:20:2644 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1396:20:2644 | if ... | UseUseExplosion.rb:20:1391:20:2644 | then ... |
 | UseUseExplosion.rb:20:1400:20:1404 | [post] self | UseUseExplosion.rb:20:1421:20:1425 | self |
 | UseUseExplosion.rb:20:1400:20:1404 | [post] self | UseUseExplosion.rb:20:2635:20:2640 | self |
@@ -870,9 +1002,11 @@
 | UseUseExplosion.rb:20:1400:20:1404 | self | UseUseExplosion.rb:20:2635:20:2640 | self |
 | UseUseExplosion.rb:20:1400:20:1409 | ... > ... | UseUseExplosion.rb:20:1399:20:1410 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1400:20:1409 | ... > ... | UseUseExplosion.rb:20:1399:20:1410 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1412:20:2628 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1396:20:2644 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1412:20:2628 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1396:20:2644 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1412:20:2628 | then ... | UseUseExplosion.rb:20:1396:20:2644 | if ... |
-| UseUseExplosion.rb:20:1417:20:2628 | SSA phi read(self) | UseUseExplosion.rb:20:1396:20:2644 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1417:20:2628 | SSA phi read(x) | UseUseExplosion.rb:20:1396:20:2644 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1417:20:2628 | SSA phi read(self) | UseUseExplosion.rb:20:1412:20:2628 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1417:20:2628 | SSA phi read(x) | UseUseExplosion.rb:20:1412:20:2628 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1417:20:2628 | if ... | UseUseExplosion.rb:20:1412:20:2628 | then ... |
 | UseUseExplosion.rb:20:1421:20:1425 | [post] self | UseUseExplosion.rb:20:1442:20:1446 | self |
 | UseUseExplosion.rb:20:1421:20:1425 | [post] self | UseUseExplosion.rb:20:2619:20:2624 | self |
@@ -880,9 +1014,11 @@
 | UseUseExplosion.rb:20:1421:20:1425 | self | UseUseExplosion.rb:20:2619:20:2624 | self |
 | UseUseExplosion.rb:20:1421:20:1430 | ... > ... | UseUseExplosion.rb:20:1420:20:1431 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1421:20:1430 | ... > ... | UseUseExplosion.rb:20:1420:20:1431 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1433:20:2612 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1417:20:2628 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1433:20:2612 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1417:20:2628 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1433:20:2612 | then ... | UseUseExplosion.rb:20:1417:20:2628 | if ... |
-| UseUseExplosion.rb:20:1438:20:2612 | SSA phi read(self) | UseUseExplosion.rb:20:1417:20:2628 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1438:20:2612 | SSA phi read(x) | UseUseExplosion.rb:20:1417:20:2628 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1438:20:2612 | SSA phi read(self) | UseUseExplosion.rb:20:1433:20:2612 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1438:20:2612 | SSA phi read(x) | UseUseExplosion.rb:20:1433:20:2612 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1438:20:2612 | if ... | UseUseExplosion.rb:20:1433:20:2612 | then ... |
 | UseUseExplosion.rb:20:1442:20:1446 | [post] self | UseUseExplosion.rb:20:1463:20:1467 | self |
 | UseUseExplosion.rb:20:1442:20:1446 | [post] self | UseUseExplosion.rb:20:2603:20:2608 | self |
@@ -890,9 +1026,11 @@
 | UseUseExplosion.rb:20:1442:20:1446 | self | UseUseExplosion.rb:20:2603:20:2608 | self |
 | UseUseExplosion.rb:20:1442:20:1451 | ... > ... | UseUseExplosion.rb:20:1441:20:1452 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1442:20:1451 | ... > ... | UseUseExplosion.rb:20:1441:20:1452 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1454:20:2596 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1438:20:2612 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1454:20:2596 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1438:20:2612 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1454:20:2596 | then ... | UseUseExplosion.rb:20:1438:20:2612 | if ... |
-| UseUseExplosion.rb:20:1459:20:2596 | SSA phi read(self) | UseUseExplosion.rb:20:1438:20:2612 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1459:20:2596 | SSA phi read(x) | UseUseExplosion.rb:20:1438:20:2612 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1459:20:2596 | SSA phi read(self) | UseUseExplosion.rb:20:1454:20:2596 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1459:20:2596 | SSA phi read(x) | UseUseExplosion.rb:20:1454:20:2596 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1459:20:2596 | if ... | UseUseExplosion.rb:20:1454:20:2596 | then ... |
 | UseUseExplosion.rb:20:1463:20:1467 | [post] self | UseUseExplosion.rb:20:1484:20:1488 | self |
 | UseUseExplosion.rb:20:1463:20:1467 | [post] self | UseUseExplosion.rb:20:2587:20:2592 | self |
@@ -900,9 +1038,11 @@
 | UseUseExplosion.rb:20:1463:20:1467 | self | UseUseExplosion.rb:20:2587:20:2592 | self |
 | UseUseExplosion.rb:20:1463:20:1472 | ... > ... | UseUseExplosion.rb:20:1462:20:1473 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1463:20:1472 | ... > ... | UseUseExplosion.rb:20:1462:20:1473 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1475:20:2580 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1459:20:2596 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1475:20:2580 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1459:20:2596 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1475:20:2580 | then ... | UseUseExplosion.rb:20:1459:20:2596 | if ... |
-| UseUseExplosion.rb:20:1480:20:2580 | SSA phi read(self) | UseUseExplosion.rb:20:1459:20:2596 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1480:20:2580 | SSA phi read(x) | UseUseExplosion.rb:20:1459:20:2596 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1480:20:2580 | SSA phi read(self) | UseUseExplosion.rb:20:1475:20:2580 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1480:20:2580 | SSA phi read(x) | UseUseExplosion.rb:20:1475:20:2580 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1480:20:2580 | if ... | UseUseExplosion.rb:20:1475:20:2580 | then ... |
 | UseUseExplosion.rb:20:1484:20:1488 | [post] self | UseUseExplosion.rb:20:1505:20:1509 | self |
 | UseUseExplosion.rb:20:1484:20:1488 | [post] self | UseUseExplosion.rb:20:2571:20:2576 | self |
@@ -910,9 +1050,11 @@
 | UseUseExplosion.rb:20:1484:20:1488 | self | UseUseExplosion.rb:20:2571:20:2576 | self |
 | UseUseExplosion.rb:20:1484:20:1493 | ... > ... | UseUseExplosion.rb:20:1483:20:1494 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1484:20:1493 | ... > ... | UseUseExplosion.rb:20:1483:20:1494 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1496:20:2564 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1480:20:2580 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1496:20:2564 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1480:20:2580 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1496:20:2564 | then ... | UseUseExplosion.rb:20:1480:20:2580 | if ... |
-| UseUseExplosion.rb:20:1501:20:2564 | SSA phi read(self) | UseUseExplosion.rb:20:1480:20:2580 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1501:20:2564 | SSA phi read(x) | UseUseExplosion.rb:20:1480:20:2580 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1501:20:2564 | SSA phi read(self) | UseUseExplosion.rb:20:1496:20:2564 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1501:20:2564 | SSA phi read(x) | UseUseExplosion.rb:20:1496:20:2564 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1501:20:2564 | if ... | UseUseExplosion.rb:20:1496:20:2564 | then ... |
 | UseUseExplosion.rb:20:1505:20:1509 | [post] self | UseUseExplosion.rb:20:1526:20:1530 | self |
 | UseUseExplosion.rb:20:1505:20:1509 | [post] self | UseUseExplosion.rb:20:2555:20:2560 | self |
@@ -920,9 +1062,11 @@
 | UseUseExplosion.rb:20:1505:20:1509 | self | UseUseExplosion.rb:20:2555:20:2560 | self |
 | UseUseExplosion.rb:20:1505:20:1514 | ... > ... | UseUseExplosion.rb:20:1504:20:1515 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1505:20:1514 | ... > ... | UseUseExplosion.rb:20:1504:20:1515 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1517:20:2548 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1501:20:2564 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1517:20:2548 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1501:20:2564 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1517:20:2548 | then ... | UseUseExplosion.rb:20:1501:20:2564 | if ... |
-| UseUseExplosion.rb:20:1522:20:2548 | SSA phi read(self) | UseUseExplosion.rb:20:1501:20:2564 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1522:20:2548 | SSA phi read(x) | UseUseExplosion.rb:20:1501:20:2564 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1522:20:2548 | SSA phi read(self) | UseUseExplosion.rb:20:1517:20:2548 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1522:20:2548 | SSA phi read(x) | UseUseExplosion.rb:20:1517:20:2548 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1522:20:2548 | if ... | UseUseExplosion.rb:20:1517:20:2548 | then ... |
 | UseUseExplosion.rb:20:1526:20:1530 | [post] self | UseUseExplosion.rb:20:1547:20:1551 | self |
 | UseUseExplosion.rb:20:1526:20:1530 | [post] self | UseUseExplosion.rb:20:2539:20:2544 | self |
@@ -930,9 +1074,11 @@
 | UseUseExplosion.rb:20:1526:20:1530 | self | UseUseExplosion.rb:20:2539:20:2544 | self |
 | UseUseExplosion.rb:20:1526:20:1535 | ... > ... | UseUseExplosion.rb:20:1525:20:1536 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1526:20:1535 | ... > ... | UseUseExplosion.rb:20:1525:20:1536 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1538:20:2532 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1522:20:2548 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1538:20:2532 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1522:20:2548 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1538:20:2532 | then ... | UseUseExplosion.rb:20:1522:20:2548 | if ... |
-| UseUseExplosion.rb:20:1543:20:2532 | SSA phi read(self) | UseUseExplosion.rb:20:1522:20:2548 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1543:20:2532 | SSA phi read(x) | UseUseExplosion.rb:20:1522:20:2548 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1543:20:2532 | SSA phi read(self) | UseUseExplosion.rb:20:1538:20:2532 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1543:20:2532 | SSA phi read(x) | UseUseExplosion.rb:20:1538:20:2532 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1543:20:2532 | if ... | UseUseExplosion.rb:20:1538:20:2532 | then ... |
 | UseUseExplosion.rb:20:1547:20:1551 | [post] self | UseUseExplosion.rb:20:1568:20:1572 | self |
 | UseUseExplosion.rb:20:1547:20:1551 | [post] self | UseUseExplosion.rb:20:2523:20:2528 | self |
@@ -940,9 +1086,11 @@
 | UseUseExplosion.rb:20:1547:20:1551 | self | UseUseExplosion.rb:20:2523:20:2528 | self |
 | UseUseExplosion.rb:20:1547:20:1556 | ... > ... | UseUseExplosion.rb:20:1546:20:1557 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1547:20:1556 | ... > ... | UseUseExplosion.rb:20:1546:20:1557 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1559:20:2516 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1543:20:2532 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1559:20:2516 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1543:20:2532 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1559:20:2516 | then ... | UseUseExplosion.rb:20:1543:20:2532 | if ... |
-| UseUseExplosion.rb:20:1564:20:2516 | SSA phi read(self) | UseUseExplosion.rb:20:1543:20:2532 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1564:20:2516 | SSA phi read(x) | UseUseExplosion.rb:20:1543:20:2532 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1564:20:2516 | SSA phi read(self) | UseUseExplosion.rb:20:1559:20:2516 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1564:20:2516 | SSA phi read(x) | UseUseExplosion.rb:20:1559:20:2516 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1564:20:2516 | if ... | UseUseExplosion.rb:20:1559:20:2516 | then ... |
 | UseUseExplosion.rb:20:1568:20:1572 | [post] self | UseUseExplosion.rb:20:1589:20:1593 | self |
 | UseUseExplosion.rb:20:1568:20:1572 | [post] self | UseUseExplosion.rb:20:2507:20:2512 | self |
@@ -950,9 +1098,11 @@
 | UseUseExplosion.rb:20:1568:20:1572 | self | UseUseExplosion.rb:20:2507:20:2512 | self |
 | UseUseExplosion.rb:20:1568:20:1577 | ... > ... | UseUseExplosion.rb:20:1567:20:1578 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1568:20:1577 | ... > ... | UseUseExplosion.rb:20:1567:20:1578 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1580:20:2500 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1564:20:2516 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1580:20:2500 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1564:20:2516 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1580:20:2500 | then ... | UseUseExplosion.rb:20:1564:20:2516 | if ... |
-| UseUseExplosion.rb:20:1585:20:2500 | SSA phi read(self) | UseUseExplosion.rb:20:1564:20:2516 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1585:20:2500 | SSA phi read(x) | UseUseExplosion.rb:20:1564:20:2516 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1585:20:2500 | SSA phi read(self) | UseUseExplosion.rb:20:1580:20:2500 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1585:20:2500 | SSA phi read(x) | UseUseExplosion.rb:20:1580:20:2500 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1585:20:2500 | if ... | UseUseExplosion.rb:20:1580:20:2500 | then ... |
 | UseUseExplosion.rb:20:1589:20:1593 | [post] self | UseUseExplosion.rb:20:1610:20:1614 | self |
 | UseUseExplosion.rb:20:1589:20:1593 | [post] self | UseUseExplosion.rb:20:2491:20:2496 | self |
@@ -960,9 +1110,11 @@
 | UseUseExplosion.rb:20:1589:20:1593 | self | UseUseExplosion.rb:20:2491:20:2496 | self |
 | UseUseExplosion.rb:20:1589:20:1598 | ... > ... | UseUseExplosion.rb:20:1588:20:1599 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1589:20:1598 | ... > ... | UseUseExplosion.rb:20:1588:20:1599 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1601:20:2484 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1585:20:2500 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1601:20:2484 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1585:20:2500 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1601:20:2484 | then ... | UseUseExplosion.rb:20:1585:20:2500 | if ... |
-| UseUseExplosion.rb:20:1606:20:2484 | SSA phi read(self) | UseUseExplosion.rb:20:1585:20:2500 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1606:20:2484 | SSA phi read(x) | UseUseExplosion.rb:20:1585:20:2500 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1606:20:2484 | SSA phi read(self) | UseUseExplosion.rb:20:1601:20:2484 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1606:20:2484 | SSA phi read(x) | UseUseExplosion.rb:20:1601:20:2484 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1606:20:2484 | if ... | UseUseExplosion.rb:20:1601:20:2484 | then ... |
 | UseUseExplosion.rb:20:1610:20:1614 | [post] self | UseUseExplosion.rb:20:1631:20:1635 | self |
 | UseUseExplosion.rb:20:1610:20:1614 | [post] self | UseUseExplosion.rb:20:2475:20:2480 | self |
@@ -970,9 +1122,11 @@
 | UseUseExplosion.rb:20:1610:20:1614 | self | UseUseExplosion.rb:20:2475:20:2480 | self |
 | UseUseExplosion.rb:20:1610:20:1619 | ... > ... | UseUseExplosion.rb:20:1609:20:1620 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1610:20:1619 | ... > ... | UseUseExplosion.rb:20:1609:20:1620 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1622:20:2468 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1606:20:2484 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1622:20:2468 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1606:20:2484 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1622:20:2468 | then ... | UseUseExplosion.rb:20:1606:20:2484 | if ... |
-| UseUseExplosion.rb:20:1627:20:2468 | SSA phi read(self) | UseUseExplosion.rb:20:1606:20:2484 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1627:20:2468 | SSA phi read(x) | UseUseExplosion.rb:20:1606:20:2484 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1627:20:2468 | SSA phi read(self) | UseUseExplosion.rb:20:1622:20:2468 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1627:20:2468 | SSA phi read(x) | UseUseExplosion.rb:20:1622:20:2468 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1627:20:2468 | if ... | UseUseExplosion.rb:20:1622:20:2468 | then ... |
 | UseUseExplosion.rb:20:1631:20:1635 | [post] self | UseUseExplosion.rb:20:1652:20:1656 | self |
 | UseUseExplosion.rb:20:1631:20:1635 | [post] self | UseUseExplosion.rb:20:2459:20:2464 | self |
@@ -980,9 +1134,11 @@
 | UseUseExplosion.rb:20:1631:20:1635 | self | UseUseExplosion.rb:20:2459:20:2464 | self |
 | UseUseExplosion.rb:20:1631:20:1640 | ... > ... | UseUseExplosion.rb:20:1630:20:1641 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1631:20:1640 | ... > ... | UseUseExplosion.rb:20:1630:20:1641 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1643:20:2452 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1627:20:2468 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1643:20:2452 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1627:20:2468 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1643:20:2452 | then ... | UseUseExplosion.rb:20:1627:20:2468 | if ... |
-| UseUseExplosion.rb:20:1648:20:2452 | SSA phi read(self) | UseUseExplosion.rb:20:1627:20:2468 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1648:20:2452 | SSA phi read(x) | UseUseExplosion.rb:20:1627:20:2468 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1648:20:2452 | SSA phi read(self) | UseUseExplosion.rb:20:1643:20:2452 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1648:20:2452 | SSA phi read(x) | UseUseExplosion.rb:20:1643:20:2452 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1648:20:2452 | if ... | UseUseExplosion.rb:20:1643:20:2452 | then ... |
 | UseUseExplosion.rb:20:1652:20:1656 | [post] self | UseUseExplosion.rb:20:1673:20:1677 | self |
 | UseUseExplosion.rb:20:1652:20:1656 | [post] self | UseUseExplosion.rb:20:2443:20:2448 | self |
@@ -990,9 +1146,11 @@
 | UseUseExplosion.rb:20:1652:20:1656 | self | UseUseExplosion.rb:20:2443:20:2448 | self |
 | UseUseExplosion.rb:20:1652:20:1661 | ... > ... | UseUseExplosion.rb:20:1651:20:1662 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1652:20:1661 | ... > ... | UseUseExplosion.rb:20:1651:20:1662 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1664:20:2436 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1648:20:2452 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1664:20:2436 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1648:20:2452 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1664:20:2436 | then ... | UseUseExplosion.rb:20:1648:20:2452 | if ... |
-| UseUseExplosion.rb:20:1669:20:2436 | SSA phi read(self) | UseUseExplosion.rb:20:1648:20:2452 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1669:20:2436 | SSA phi read(x) | UseUseExplosion.rb:20:1648:20:2452 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1669:20:2436 | SSA phi read(self) | UseUseExplosion.rb:20:1664:20:2436 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1669:20:2436 | SSA phi read(x) | UseUseExplosion.rb:20:1664:20:2436 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1669:20:2436 | if ... | UseUseExplosion.rb:20:1664:20:2436 | then ... |
 | UseUseExplosion.rb:20:1673:20:1677 | [post] self | UseUseExplosion.rb:20:1694:20:1698 | self |
 | UseUseExplosion.rb:20:1673:20:1677 | [post] self | UseUseExplosion.rb:20:2427:20:2432 | self |
@@ -1000,9 +1158,11 @@
 | UseUseExplosion.rb:20:1673:20:1677 | self | UseUseExplosion.rb:20:2427:20:2432 | self |
 | UseUseExplosion.rb:20:1673:20:1682 | ... > ... | UseUseExplosion.rb:20:1672:20:1683 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1673:20:1682 | ... > ... | UseUseExplosion.rb:20:1672:20:1683 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1685:20:2420 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1669:20:2436 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1685:20:2420 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1669:20:2436 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1685:20:2420 | then ... | UseUseExplosion.rb:20:1669:20:2436 | if ... |
-| UseUseExplosion.rb:20:1690:20:2420 | SSA phi read(self) | UseUseExplosion.rb:20:1669:20:2436 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1690:20:2420 | SSA phi read(x) | UseUseExplosion.rb:20:1669:20:2436 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1690:20:2420 | SSA phi read(self) | UseUseExplosion.rb:20:1685:20:2420 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1690:20:2420 | SSA phi read(x) | UseUseExplosion.rb:20:1685:20:2420 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1690:20:2420 | if ... | UseUseExplosion.rb:20:1685:20:2420 | then ... |
 | UseUseExplosion.rb:20:1694:20:1698 | [post] self | UseUseExplosion.rb:20:1715:20:1719 | self |
 | UseUseExplosion.rb:20:1694:20:1698 | [post] self | UseUseExplosion.rb:20:2411:20:2416 | self |
@@ -1010,9 +1170,11 @@
 | UseUseExplosion.rb:20:1694:20:1698 | self | UseUseExplosion.rb:20:2411:20:2416 | self |
 | UseUseExplosion.rb:20:1694:20:1703 | ... > ... | UseUseExplosion.rb:20:1693:20:1704 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1694:20:1703 | ... > ... | UseUseExplosion.rb:20:1693:20:1704 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1706:20:2404 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1690:20:2420 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1706:20:2404 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1690:20:2420 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1706:20:2404 | then ... | UseUseExplosion.rb:20:1690:20:2420 | if ... |
-| UseUseExplosion.rb:20:1711:20:2404 | SSA phi read(self) | UseUseExplosion.rb:20:1690:20:2420 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1711:20:2404 | SSA phi read(x) | UseUseExplosion.rb:20:1690:20:2420 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1711:20:2404 | SSA phi read(self) | UseUseExplosion.rb:20:1706:20:2404 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1711:20:2404 | SSA phi read(x) | UseUseExplosion.rb:20:1706:20:2404 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1711:20:2404 | if ... | UseUseExplosion.rb:20:1706:20:2404 | then ... |
 | UseUseExplosion.rb:20:1715:20:1719 | [post] self | UseUseExplosion.rb:20:1736:20:1740 | self |
 | UseUseExplosion.rb:20:1715:20:1719 | [post] self | UseUseExplosion.rb:20:2395:20:2400 | self |
@@ -1020,9 +1182,11 @@
 | UseUseExplosion.rb:20:1715:20:1719 | self | UseUseExplosion.rb:20:2395:20:2400 | self |
 | UseUseExplosion.rb:20:1715:20:1724 | ... > ... | UseUseExplosion.rb:20:1714:20:1725 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1715:20:1724 | ... > ... | UseUseExplosion.rb:20:1714:20:1725 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1727:20:2388 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1711:20:2404 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1727:20:2388 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1711:20:2404 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1727:20:2388 | then ... | UseUseExplosion.rb:20:1711:20:2404 | if ... |
-| UseUseExplosion.rb:20:1732:20:2388 | SSA phi read(self) | UseUseExplosion.rb:20:1711:20:2404 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1732:20:2388 | SSA phi read(x) | UseUseExplosion.rb:20:1711:20:2404 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1732:20:2388 | SSA phi read(self) | UseUseExplosion.rb:20:1727:20:2388 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1732:20:2388 | SSA phi read(x) | UseUseExplosion.rb:20:1727:20:2388 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1732:20:2388 | if ... | UseUseExplosion.rb:20:1727:20:2388 | then ... |
 | UseUseExplosion.rb:20:1736:20:1740 | [post] self | UseUseExplosion.rb:20:1757:20:1761 | self |
 | UseUseExplosion.rb:20:1736:20:1740 | [post] self | UseUseExplosion.rb:20:2379:20:2384 | self |
@@ -1030,9 +1194,11 @@
 | UseUseExplosion.rb:20:1736:20:1740 | self | UseUseExplosion.rb:20:2379:20:2384 | self |
 | UseUseExplosion.rb:20:1736:20:1745 | ... > ... | UseUseExplosion.rb:20:1735:20:1746 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1736:20:1745 | ... > ... | UseUseExplosion.rb:20:1735:20:1746 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1748:20:2372 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1732:20:2388 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1748:20:2372 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1732:20:2388 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1748:20:2372 | then ... | UseUseExplosion.rb:20:1732:20:2388 | if ... |
-| UseUseExplosion.rb:20:1753:20:2372 | SSA phi read(self) | UseUseExplosion.rb:20:1732:20:2388 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1753:20:2372 | SSA phi read(x) | UseUseExplosion.rb:20:1732:20:2388 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1753:20:2372 | SSA phi read(self) | UseUseExplosion.rb:20:1748:20:2372 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1753:20:2372 | SSA phi read(x) | UseUseExplosion.rb:20:1748:20:2372 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1753:20:2372 | if ... | UseUseExplosion.rb:20:1748:20:2372 | then ... |
 | UseUseExplosion.rb:20:1757:20:1761 | [post] self | UseUseExplosion.rb:20:1778:20:1782 | self |
 | UseUseExplosion.rb:20:1757:20:1761 | [post] self | UseUseExplosion.rb:20:2363:20:2368 | self |
@@ -1040,9 +1206,11 @@
 | UseUseExplosion.rb:20:1757:20:1761 | self | UseUseExplosion.rb:20:2363:20:2368 | self |
 | UseUseExplosion.rb:20:1757:20:1766 | ... > ... | UseUseExplosion.rb:20:1756:20:1767 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1757:20:1766 | ... > ... | UseUseExplosion.rb:20:1756:20:1767 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1769:20:2356 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1753:20:2372 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1769:20:2356 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1753:20:2372 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1769:20:2356 | then ... | UseUseExplosion.rb:20:1753:20:2372 | if ... |
-| UseUseExplosion.rb:20:1774:20:2356 | SSA phi read(self) | UseUseExplosion.rb:20:1753:20:2372 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1774:20:2356 | SSA phi read(x) | UseUseExplosion.rb:20:1753:20:2372 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1774:20:2356 | SSA phi read(self) | UseUseExplosion.rb:20:1769:20:2356 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1774:20:2356 | SSA phi read(x) | UseUseExplosion.rb:20:1769:20:2356 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1774:20:2356 | if ... | UseUseExplosion.rb:20:1769:20:2356 | then ... |
 | UseUseExplosion.rb:20:1778:20:1782 | [post] self | UseUseExplosion.rb:20:1799:20:1803 | self |
 | UseUseExplosion.rb:20:1778:20:1782 | [post] self | UseUseExplosion.rb:20:2347:20:2352 | self |
@@ -1050,9 +1218,11 @@
 | UseUseExplosion.rb:20:1778:20:1782 | self | UseUseExplosion.rb:20:2347:20:2352 | self |
 | UseUseExplosion.rb:20:1778:20:1787 | ... > ... | UseUseExplosion.rb:20:1777:20:1788 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1778:20:1787 | ... > ... | UseUseExplosion.rb:20:1777:20:1788 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1790:20:2340 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1774:20:2356 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1790:20:2340 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1774:20:2356 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1790:20:2340 | then ... | UseUseExplosion.rb:20:1774:20:2356 | if ... |
-| UseUseExplosion.rb:20:1795:20:2340 | SSA phi read(self) | UseUseExplosion.rb:20:1774:20:2356 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1795:20:2340 | SSA phi read(x) | UseUseExplosion.rb:20:1774:20:2356 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1795:20:2340 | SSA phi read(self) | UseUseExplosion.rb:20:1790:20:2340 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1795:20:2340 | SSA phi read(x) | UseUseExplosion.rb:20:1790:20:2340 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1795:20:2340 | if ... | UseUseExplosion.rb:20:1790:20:2340 | then ... |
 | UseUseExplosion.rb:20:1799:20:1803 | [post] self | UseUseExplosion.rb:20:1820:20:1824 | self |
 | UseUseExplosion.rb:20:1799:20:1803 | [post] self | UseUseExplosion.rb:20:2331:20:2336 | self |
@@ -1060,9 +1230,11 @@
 | UseUseExplosion.rb:20:1799:20:1803 | self | UseUseExplosion.rb:20:2331:20:2336 | self |
 | UseUseExplosion.rb:20:1799:20:1808 | ... > ... | UseUseExplosion.rb:20:1798:20:1809 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1799:20:1808 | ... > ... | UseUseExplosion.rb:20:1798:20:1809 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1811:20:2324 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1795:20:2340 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1811:20:2324 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1795:20:2340 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1811:20:2324 | then ... | UseUseExplosion.rb:20:1795:20:2340 | if ... |
-| UseUseExplosion.rb:20:1816:20:2324 | SSA phi read(self) | UseUseExplosion.rb:20:1795:20:2340 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1816:20:2324 | SSA phi read(x) | UseUseExplosion.rb:20:1795:20:2340 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1816:20:2324 | SSA phi read(self) | UseUseExplosion.rb:20:1811:20:2324 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1816:20:2324 | SSA phi read(x) | UseUseExplosion.rb:20:1811:20:2324 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1816:20:2324 | if ... | UseUseExplosion.rb:20:1811:20:2324 | then ... |
 | UseUseExplosion.rb:20:1820:20:1824 | [post] self | UseUseExplosion.rb:20:1841:20:1845 | self |
 | UseUseExplosion.rb:20:1820:20:1824 | [post] self | UseUseExplosion.rb:20:2315:20:2320 | self |
@@ -1070,9 +1242,11 @@
 | UseUseExplosion.rb:20:1820:20:1824 | self | UseUseExplosion.rb:20:2315:20:2320 | self |
 | UseUseExplosion.rb:20:1820:20:1829 | ... > ... | UseUseExplosion.rb:20:1819:20:1830 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1820:20:1829 | ... > ... | UseUseExplosion.rb:20:1819:20:1830 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1832:20:2308 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1816:20:2324 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1832:20:2308 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1816:20:2324 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1832:20:2308 | then ... | UseUseExplosion.rb:20:1816:20:2324 | if ... |
-| UseUseExplosion.rb:20:1837:20:2308 | SSA phi read(self) | UseUseExplosion.rb:20:1816:20:2324 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1837:20:2308 | SSA phi read(x) | UseUseExplosion.rb:20:1816:20:2324 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1837:20:2308 | SSA phi read(self) | UseUseExplosion.rb:20:1832:20:2308 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1837:20:2308 | SSA phi read(x) | UseUseExplosion.rb:20:1832:20:2308 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1837:20:2308 | if ... | UseUseExplosion.rb:20:1832:20:2308 | then ... |
 | UseUseExplosion.rb:20:1841:20:1845 | [post] self | UseUseExplosion.rb:20:1862:20:1866 | self |
 | UseUseExplosion.rb:20:1841:20:1845 | [post] self | UseUseExplosion.rb:20:2299:20:2304 | self |
@@ -1080,9 +1254,11 @@
 | UseUseExplosion.rb:20:1841:20:1845 | self | UseUseExplosion.rb:20:2299:20:2304 | self |
 | UseUseExplosion.rb:20:1841:20:1850 | ... > ... | UseUseExplosion.rb:20:1840:20:1851 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1841:20:1850 | ... > ... | UseUseExplosion.rb:20:1840:20:1851 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1853:20:2292 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1837:20:2308 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1853:20:2292 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1837:20:2308 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1853:20:2292 | then ... | UseUseExplosion.rb:20:1837:20:2308 | if ... |
-| UseUseExplosion.rb:20:1858:20:2292 | SSA phi read(self) | UseUseExplosion.rb:20:1837:20:2308 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1858:20:2292 | SSA phi read(x) | UseUseExplosion.rb:20:1837:20:2308 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1858:20:2292 | SSA phi read(self) | UseUseExplosion.rb:20:1853:20:2292 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1858:20:2292 | SSA phi read(x) | UseUseExplosion.rb:20:1853:20:2292 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1858:20:2292 | if ... | UseUseExplosion.rb:20:1853:20:2292 | then ... |
 | UseUseExplosion.rb:20:1862:20:1866 | [post] self | UseUseExplosion.rb:20:1883:20:1887 | self |
 | UseUseExplosion.rb:20:1862:20:1866 | [post] self | UseUseExplosion.rb:20:2283:20:2288 | self |
@@ -1090,9 +1266,11 @@
 | UseUseExplosion.rb:20:1862:20:1866 | self | UseUseExplosion.rb:20:2283:20:2288 | self |
 | UseUseExplosion.rb:20:1862:20:1871 | ... > ... | UseUseExplosion.rb:20:1861:20:1872 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1862:20:1871 | ... > ... | UseUseExplosion.rb:20:1861:20:1872 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1874:20:2276 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1858:20:2292 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1874:20:2276 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1858:20:2292 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1874:20:2276 | then ... | UseUseExplosion.rb:20:1858:20:2292 | if ... |
-| UseUseExplosion.rb:20:1879:20:2276 | SSA phi read(self) | UseUseExplosion.rb:20:1858:20:2292 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1879:20:2276 | SSA phi read(x) | UseUseExplosion.rb:20:1858:20:2292 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1879:20:2276 | SSA phi read(self) | UseUseExplosion.rb:20:1874:20:2276 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1879:20:2276 | SSA phi read(x) | UseUseExplosion.rb:20:1874:20:2276 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1879:20:2276 | if ... | UseUseExplosion.rb:20:1874:20:2276 | then ... |
 | UseUseExplosion.rb:20:1883:20:1887 | [post] self | UseUseExplosion.rb:20:1904:20:1908 | self |
 | UseUseExplosion.rb:20:1883:20:1887 | [post] self | UseUseExplosion.rb:20:2267:20:2272 | self |
@@ -1100,9 +1278,11 @@
 | UseUseExplosion.rb:20:1883:20:1887 | self | UseUseExplosion.rb:20:2267:20:2272 | self |
 | UseUseExplosion.rb:20:1883:20:1892 | ... > ... | UseUseExplosion.rb:20:1882:20:1893 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1883:20:1892 | ... > ... | UseUseExplosion.rb:20:1882:20:1893 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1895:20:2260 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1879:20:2276 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1895:20:2260 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1879:20:2276 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1895:20:2260 | then ... | UseUseExplosion.rb:20:1879:20:2276 | if ... |
-| UseUseExplosion.rb:20:1900:20:2260 | SSA phi read(self) | UseUseExplosion.rb:20:1879:20:2276 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1900:20:2260 | SSA phi read(x) | UseUseExplosion.rb:20:1879:20:2276 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1900:20:2260 | SSA phi read(self) | UseUseExplosion.rb:20:1895:20:2260 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1900:20:2260 | SSA phi read(x) | UseUseExplosion.rb:20:1895:20:2260 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1900:20:2260 | if ... | UseUseExplosion.rb:20:1895:20:2260 | then ... |
 | UseUseExplosion.rb:20:1904:20:1908 | [post] self | UseUseExplosion.rb:20:1925:20:1929 | self |
 | UseUseExplosion.rb:20:1904:20:1908 | [post] self | UseUseExplosion.rb:20:2251:20:2256 | self |
@@ -1110,9 +1290,11 @@
 | UseUseExplosion.rb:20:1904:20:1908 | self | UseUseExplosion.rb:20:2251:20:2256 | self |
 | UseUseExplosion.rb:20:1904:20:1913 | ... > ... | UseUseExplosion.rb:20:1903:20:1914 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1904:20:1913 | ... > ... | UseUseExplosion.rb:20:1903:20:1914 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1916:20:2244 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1900:20:2260 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1916:20:2244 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1900:20:2260 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1916:20:2244 | then ... | UseUseExplosion.rb:20:1900:20:2260 | if ... |
-| UseUseExplosion.rb:20:1921:20:2244 | SSA phi read(self) | UseUseExplosion.rb:20:1900:20:2260 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1921:20:2244 | SSA phi read(x) | UseUseExplosion.rb:20:1900:20:2260 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1921:20:2244 | SSA phi read(self) | UseUseExplosion.rb:20:1916:20:2244 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1921:20:2244 | SSA phi read(x) | UseUseExplosion.rb:20:1916:20:2244 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1921:20:2244 | if ... | UseUseExplosion.rb:20:1916:20:2244 | then ... |
 | UseUseExplosion.rb:20:1925:20:1929 | [post] self | UseUseExplosion.rb:20:1945:20:1949 | self |
 | UseUseExplosion.rb:20:1925:20:1929 | [post] self | UseUseExplosion.rb:20:2235:20:2240 | self |
@@ -1120,9 +1302,11 @@
 | UseUseExplosion.rb:20:1925:20:1929 | self | UseUseExplosion.rb:20:2235:20:2240 | self |
 | UseUseExplosion.rb:20:1925:20:1933 | ... > ... | UseUseExplosion.rb:20:1924:20:1934 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1925:20:1933 | ... > ... | UseUseExplosion.rb:20:1924:20:1934 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1936:20:2228 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1921:20:2244 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1936:20:2228 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1921:20:2244 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1936:20:2228 | then ... | UseUseExplosion.rb:20:1921:20:2244 | if ... |
-| UseUseExplosion.rb:20:1941:20:2228 | SSA phi read(self) | UseUseExplosion.rb:20:1921:20:2244 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1941:20:2228 | SSA phi read(x) | UseUseExplosion.rb:20:1921:20:2244 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1941:20:2228 | SSA phi read(self) | UseUseExplosion.rb:20:1936:20:2228 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1941:20:2228 | SSA phi read(x) | UseUseExplosion.rb:20:1936:20:2228 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1941:20:2228 | if ... | UseUseExplosion.rb:20:1936:20:2228 | then ... |
 | UseUseExplosion.rb:20:1945:20:1949 | [post] self | UseUseExplosion.rb:20:1965:20:1969 | self |
 | UseUseExplosion.rb:20:1945:20:1949 | [post] self | UseUseExplosion.rb:20:2219:20:2224 | self |
@@ -1130,9 +1314,11 @@
 | UseUseExplosion.rb:20:1945:20:1949 | self | UseUseExplosion.rb:20:2219:20:2224 | self |
 | UseUseExplosion.rb:20:1945:20:1953 | ... > ... | UseUseExplosion.rb:20:1944:20:1954 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1945:20:1953 | ... > ... | UseUseExplosion.rb:20:1944:20:1954 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1956:20:2212 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1941:20:2228 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1956:20:2212 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1941:20:2228 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1956:20:2212 | then ... | UseUseExplosion.rb:20:1941:20:2228 | if ... |
-| UseUseExplosion.rb:20:1961:20:2212 | SSA phi read(self) | UseUseExplosion.rb:20:1941:20:2228 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1961:20:2212 | SSA phi read(x) | UseUseExplosion.rb:20:1941:20:2228 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1961:20:2212 | SSA phi read(self) | UseUseExplosion.rb:20:1956:20:2212 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1961:20:2212 | SSA phi read(x) | UseUseExplosion.rb:20:1956:20:2212 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1961:20:2212 | if ... | UseUseExplosion.rb:20:1956:20:2212 | then ... |
 | UseUseExplosion.rb:20:1965:20:1969 | [post] self | UseUseExplosion.rb:20:1985:20:1989 | self |
 | UseUseExplosion.rb:20:1965:20:1969 | [post] self | UseUseExplosion.rb:20:2203:20:2208 | self |
@@ -1140,9 +1326,11 @@
 | UseUseExplosion.rb:20:1965:20:1969 | self | UseUseExplosion.rb:20:2203:20:2208 | self |
 | UseUseExplosion.rb:20:1965:20:1973 | ... > ... | UseUseExplosion.rb:20:1964:20:1974 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1965:20:1973 | ... > ... | UseUseExplosion.rb:20:1964:20:1974 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1976:20:2196 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1961:20:2212 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1976:20:2196 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1961:20:2212 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1976:20:2196 | then ... | UseUseExplosion.rb:20:1961:20:2212 | if ... |
-| UseUseExplosion.rb:20:1981:20:2196 | SSA phi read(self) | UseUseExplosion.rb:20:1961:20:2212 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1981:20:2196 | SSA phi read(x) | UseUseExplosion.rb:20:1961:20:2212 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1981:20:2196 | SSA phi read(self) | UseUseExplosion.rb:20:1976:20:2196 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1981:20:2196 | SSA phi read(x) | UseUseExplosion.rb:20:1976:20:2196 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1981:20:2196 | if ... | UseUseExplosion.rb:20:1976:20:2196 | then ... |
 | UseUseExplosion.rb:20:1985:20:1989 | [post] self | UseUseExplosion.rb:20:2005:20:2009 | self |
 | UseUseExplosion.rb:20:1985:20:1989 | [post] self | UseUseExplosion.rb:20:2187:20:2192 | self |
@@ -1150,9 +1338,11 @@
 | UseUseExplosion.rb:20:1985:20:1989 | self | UseUseExplosion.rb:20:2187:20:2192 | self |
 | UseUseExplosion.rb:20:1985:20:1993 | ... > ... | UseUseExplosion.rb:20:1984:20:1994 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1985:20:1993 | ... > ... | UseUseExplosion.rb:20:1984:20:1994 | [true] ( ... ) |
+| UseUseExplosion.rb:20:1996:20:2180 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1981:20:2196 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1996:20:2180 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1981:20:2196 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1996:20:2180 | then ... | UseUseExplosion.rb:20:1981:20:2196 | if ... |
-| UseUseExplosion.rb:20:2001:20:2180 | SSA phi read(self) | UseUseExplosion.rb:20:1981:20:2196 | SSA phi read(self) |
-| UseUseExplosion.rb:20:2001:20:2180 | SSA phi read(x) | UseUseExplosion.rb:20:1981:20:2196 | SSA phi read(x) |
+| UseUseExplosion.rb:20:2001:20:2180 | SSA phi read(self) | UseUseExplosion.rb:20:1996:20:2180 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:2001:20:2180 | SSA phi read(x) | UseUseExplosion.rb:20:1996:20:2180 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:2001:20:2180 | if ... | UseUseExplosion.rb:20:1996:20:2180 | then ... |
 | UseUseExplosion.rb:20:2005:20:2009 | [post] self | UseUseExplosion.rb:20:2025:20:2029 | self |
 | UseUseExplosion.rb:20:2005:20:2009 | [post] self | UseUseExplosion.rb:20:2171:20:2176 | self |
@@ -1160,9 +1350,11 @@
 | UseUseExplosion.rb:20:2005:20:2009 | self | UseUseExplosion.rb:20:2171:20:2176 | self |
 | UseUseExplosion.rb:20:2005:20:2013 | ... > ... | UseUseExplosion.rb:20:2004:20:2014 | [false] ( ... ) |
 | UseUseExplosion.rb:20:2005:20:2013 | ... > ... | UseUseExplosion.rb:20:2004:20:2014 | [true] ( ... ) |
+| UseUseExplosion.rb:20:2016:20:2164 | [input] SSA phi read(self) | UseUseExplosion.rb:20:2001:20:2180 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2016:20:2164 | [input] SSA phi read(x) | UseUseExplosion.rb:20:2001:20:2180 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2016:20:2164 | then ... | UseUseExplosion.rb:20:2001:20:2180 | if ... |
-| UseUseExplosion.rb:20:2021:20:2164 | SSA phi read(self) | UseUseExplosion.rb:20:2001:20:2180 | SSA phi read(self) |
-| UseUseExplosion.rb:20:2021:20:2164 | SSA phi read(x) | UseUseExplosion.rb:20:2001:20:2180 | SSA phi read(x) |
+| UseUseExplosion.rb:20:2021:20:2164 | SSA phi read(self) | UseUseExplosion.rb:20:2016:20:2164 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:2021:20:2164 | SSA phi read(x) | UseUseExplosion.rb:20:2016:20:2164 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:2021:20:2164 | if ... | UseUseExplosion.rb:20:2016:20:2164 | then ... |
 | UseUseExplosion.rb:20:2025:20:2029 | [post] self | UseUseExplosion.rb:20:2045:20:2049 | self |
 | UseUseExplosion.rb:20:2025:20:2029 | [post] self | UseUseExplosion.rb:20:2155:20:2160 | self |
@@ -1170,9 +1362,11 @@
 | UseUseExplosion.rb:20:2025:20:2029 | self | UseUseExplosion.rb:20:2155:20:2160 | self |
 | UseUseExplosion.rb:20:2025:20:2033 | ... > ... | UseUseExplosion.rb:20:2024:20:2034 | [false] ( ... ) |
 | UseUseExplosion.rb:20:2025:20:2033 | ... > ... | UseUseExplosion.rb:20:2024:20:2034 | [true] ( ... ) |
+| UseUseExplosion.rb:20:2036:20:2148 | [input] SSA phi read(self) | UseUseExplosion.rb:20:2021:20:2164 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2036:20:2148 | [input] SSA phi read(x) | UseUseExplosion.rb:20:2021:20:2164 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2036:20:2148 | then ... | UseUseExplosion.rb:20:2021:20:2164 | if ... |
-| UseUseExplosion.rb:20:2041:20:2148 | SSA phi read(self) | UseUseExplosion.rb:20:2021:20:2164 | SSA phi read(self) |
-| UseUseExplosion.rb:20:2041:20:2148 | SSA phi read(x) | UseUseExplosion.rb:20:2021:20:2164 | SSA phi read(x) |
+| UseUseExplosion.rb:20:2041:20:2148 | SSA phi read(self) | UseUseExplosion.rb:20:2036:20:2148 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:2041:20:2148 | SSA phi read(x) | UseUseExplosion.rb:20:2036:20:2148 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:2041:20:2148 | if ... | UseUseExplosion.rb:20:2036:20:2148 | then ... |
 | UseUseExplosion.rb:20:2045:20:2049 | [post] self | UseUseExplosion.rb:20:2065:20:2069 | self |
 | UseUseExplosion.rb:20:2045:20:2049 | [post] self | UseUseExplosion.rb:20:2139:20:2144 | self |
@@ -1180,9 +1374,11 @@
 | UseUseExplosion.rb:20:2045:20:2049 | self | UseUseExplosion.rb:20:2139:20:2144 | self |
 | UseUseExplosion.rb:20:2045:20:2053 | ... > ... | UseUseExplosion.rb:20:2044:20:2054 | [false] ( ... ) |
 | UseUseExplosion.rb:20:2045:20:2053 | ... > ... | UseUseExplosion.rb:20:2044:20:2054 | [true] ( ... ) |
+| UseUseExplosion.rb:20:2056:20:2132 | [input] SSA phi read(self) | UseUseExplosion.rb:20:2041:20:2148 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2056:20:2132 | [input] SSA phi read(x) | UseUseExplosion.rb:20:2041:20:2148 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2056:20:2132 | then ... | UseUseExplosion.rb:20:2041:20:2148 | if ... |
-| UseUseExplosion.rb:20:2061:20:2132 | SSA phi read(self) | UseUseExplosion.rb:20:2041:20:2148 | SSA phi read(self) |
-| UseUseExplosion.rb:20:2061:20:2132 | SSA phi read(x) | UseUseExplosion.rb:20:2041:20:2148 | SSA phi read(x) |
+| UseUseExplosion.rb:20:2061:20:2132 | SSA phi read(self) | UseUseExplosion.rb:20:2056:20:2132 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:2061:20:2132 | SSA phi read(x) | UseUseExplosion.rb:20:2056:20:2132 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:2061:20:2132 | if ... | UseUseExplosion.rb:20:2056:20:2132 | then ... |
 | UseUseExplosion.rb:20:2065:20:2069 | [post] self | UseUseExplosion.rb:20:2085:20:2089 | self |
 | UseUseExplosion.rb:20:2065:20:2069 | [post] self | UseUseExplosion.rb:20:2123:20:2128 | self |
@@ -1190,213 +1386,417 @@
 | UseUseExplosion.rb:20:2065:20:2069 | self | UseUseExplosion.rb:20:2123:20:2128 | self |
 | UseUseExplosion.rb:20:2065:20:2073 | ... > ... | UseUseExplosion.rb:20:2064:20:2074 | [false] ( ... ) |
 | UseUseExplosion.rb:20:2065:20:2073 | ... > ... | UseUseExplosion.rb:20:2064:20:2074 | [true] ( ... ) |
+| UseUseExplosion.rb:20:2076:20:2116 | [input] SSA phi read(self) | UseUseExplosion.rb:20:2061:20:2132 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2076:20:2116 | [input] SSA phi read(x) | UseUseExplosion.rb:20:2061:20:2132 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2076:20:2116 | then ... | UseUseExplosion.rb:20:2061:20:2132 | if ... |
-| UseUseExplosion.rb:20:2081:20:2116 | SSA phi read(self) | UseUseExplosion.rb:20:2061:20:2132 | SSA phi read(self) |
-| UseUseExplosion.rb:20:2081:20:2116 | SSA phi read(x) | UseUseExplosion.rb:20:2061:20:2132 | SSA phi read(x) |
+| UseUseExplosion.rb:20:2081:20:2116 | SSA phi read(self) | UseUseExplosion.rb:20:2076:20:2116 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:2081:20:2116 | SSA phi read(x) | UseUseExplosion.rb:20:2076:20:2116 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:2081:20:2116 | if ... | UseUseExplosion.rb:20:2076:20:2116 | then ... |
 | UseUseExplosion.rb:20:2085:20:2089 | [post] self | UseUseExplosion.rb:20:2107:20:2112 | self |
 | UseUseExplosion.rb:20:2085:20:2089 | self | UseUseExplosion.rb:20:2107:20:2112 | self |
 | UseUseExplosion.rb:20:2085:20:2093 | ... > ... | UseUseExplosion.rb:20:2084:20:2094 | [false] ( ... ) |
 | UseUseExplosion.rb:20:2085:20:2093 | ... > ... | UseUseExplosion.rb:20:2084:20:2094 | [true] ( ... ) |
+| UseUseExplosion.rb:20:2096:20:2099 | [input] SSA phi read(self) | UseUseExplosion.rb:20:2081:20:2116 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2096:20:2099 | [input] SSA phi read(x) | UseUseExplosion.rb:20:2081:20:2116 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2096:20:2099 | then ... | UseUseExplosion.rb:20:2081:20:2116 | if ... |
+| UseUseExplosion.rb:20:2102:20:2112 | [input] SSA phi read(self) | UseUseExplosion.rb:20:2081:20:2116 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2102:20:2112 | [input] SSA phi read(x) | UseUseExplosion.rb:20:2081:20:2116 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2102:20:2112 | else ... | UseUseExplosion.rb:20:2081:20:2116 | if ... |
 | UseUseExplosion.rb:20:2107:20:2112 | call to use | UseUseExplosion.rb:20:2102:20:2112 | else ... |
+| UseUseExplosion.rb:20:2118:20:2128 | [input] SSA phi read(self) | UseUseExplosion.rb:20:2061:20:2132 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2118:20:2128 | [input] SSA phi read(x) | UseUseExplosion.rb:20:2061:20:2132 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2118:20:2128 | else ... | UseUseExplosion.rb:20:2061:20:2132 | if ... |
 | UseUseExplosion.rb:20:2123:20:2128 | call to use | UseUseExplosion.rb:20:2118:20:2128 | else ... |
+| UseUseExplosion.rb:20:2134:20:2144 | [input] SSA phi read(self) | UseUseExplosion.rb:20:2041:20:2148 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2134:20:2144 | [input] SSA phi read(x) | UseUseExplosion.rb:20:2041:20:2148 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2134:20:2144 | else ... | UseUseExplosion.rb:20:2041:20:2148 | if ... |
 | UseUseExplosion.rb:20:2139:20:2144 | call to use | UseUseExplosion.rb:20:2134:20:2144 | else ... |
+| UseUseExplosion.rb:20:2150:20:2160 | [input] SSA phi read(self) | UseUseExplosion.rb:20:2021:20:2164 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2150:20:2160 | [input] SSA phi read(x) | UseUseExplosion.rb:20:2021:20:2164 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2150:20:2160 | else ... | UseUseExplosion.rb:20:2021:20:2164 | if ... |
 | UseUseExplosion.rb:20:2155:20:2160 | call to use | UseUseExplosion.rb:20:2150:20:2160 | else ... |
+| UseUseExplosion.rb:20:2166:20:2176 | [input] SSA phi read(self) | UseUseExplosion.rb:20:2001:20:2180 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2166:20:2176 | [input] SSA phi read(x) | UseUseExplosion.rb:20:2001:20:2180 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2166:20:2176 | else ... | UseUseExplosion.rb:20:2001:20:2180 | if ... |
 | UseUseExplosion.rb:20:2171:20:2176 | call to use | UseUseExplosion.rb:20:2166:20:2176 | else ... |
+| UseUseExplosion.rb:20:2182:20:2192 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1981:20:2196 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2182:20:2192 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1981:20:2196 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2182:20:2192 | else ... | UseUseExplosion.rb:20:1981:20:2196 | if ... |
 | UseUseExplosion.rb:20:2187:20:2192 | call to use | UseUseExplosion.rb:20:2182:20:2192 | else ... |
+| UseUseExplosion.rb:20:2198:20:2208 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1961:20:2212 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2198:20:2208 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1961:20:2212 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2198:20:2208 | else ... | UseUseExplosion.rb:20:1961:20:2212 | if ... |
 | UseUseExplosion.rb:20:2203:20:2208 | call to use | UseUseExplosion.rb:20:2198:20:2208 | else ... |
+| UseUseExplosion.rb:20:2214:20:2224 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1941:20:2228 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2214:20:2224 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1941:20:2228 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2214:20:2224 | else ... | UseUseExplosion.rb:20:1941:20:2228 | if ... |
 | UseUseExplosion.rb:20:2219:20:2224 | call to use | UseUseExplosion.rb:20:2214:20:2224 | else ... |
+| UseUseExplosion.rb:20:2230:20:2240 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1921:20:2244 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2230:20:2240 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1921:20:2244 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2230:20:2240 | else ... | UseUseExplosion.rb:20:1921:20:2244 | if ... |
 | UseUseExplosion.rb:20:2235:20:2240 | call to use | UseUseExplosion.rb:20:2230:20:2240 | else ... |
+| UseUseExplosion.rb:20:2246:20:2256 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1900:20:2260 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2246:20:2256 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1900:20:2260 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2246:20:2256 | else ... | UseUseExplosion.rb:20:1900:20:2260 | if ... |
 | UseUseExplosion.rb:20:2251:20:2256 | call to use | UseUseExplosion.rb:20:2246:20:2256 | else ... |
+| UseUseExplosion.rb:20:2262:20:2272 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1879:20:2276 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2262:20:2272 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1879:20:2276 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2262:20:2272 | else ... | UseUseExplosion.rb:20:1879:20:2276 | if ... |
 | UseUseExplosion.rb:20:2267:20:2272 | call to use | UseUseExplosion.rb:20:2262:20:2272 | else ... |
+| UseUseExplosion.rb:20:2278:20:2288 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1858:20:2292 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2278:20:2288 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1858:20:2292 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2278:20:2288 | else ... | UseUseExplosion.rb:20:1858:20:2292 | if ... |
 | UseUseExplosion.rb:20:2283:20:2288 | call to use | UseUseExplosion.rb:20:2278:20:2288 | else ... |
+| UseUseExplosion.rb:20:2294:20:2304 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1837:20:2308 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2294:20:2304 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1837:20:2308 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2294:20:2304 | else ... | UseUseExplosion.rb:20:1837:20:2308 | if ... |
 | UseUseExplosion.rb:20:2299:20:2304 | call to use | UseUseExplosion.rb:20:2294:20:2304 | else ... |
+| UseUseExplosion.rb:20:2310:20:2320 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1816:20:2324 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2310:20:2320 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1816:20:2324 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2310:20:2320 | else ... | UseUseExplosion.rb:20:1816:20:2324 | if ... |
 | UseUseExplosion.rb:20:2315:20:2320 | call to use | UseUseExplosion.rb:20:2310:20:2320 | else ... |
+| UseUseExplosion.rb:20:2326:20:2336 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1795:20:2340 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2326:20:2336 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1795:20:2340 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2326:20:2336 | else ... | UseUseExplosion.rb:20:1795:20:2340 | if ... |
 | UseUseExplosion.rb:20:2331:20:2336 | call to use | UseUseExplosion.rb:20:2326:20:2336 | else ... |
+| UseUseExplosion.rb:20:2342:20:2352 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1774:20:2356 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2342:20:2352 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1774:20:2356 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2342:20:2352 | else ... | UseUseExplosion.rb:20:1774:20:2356 | if ... |
 | UseUseExplosion.rb:20:2347:20:2352 | call to use | UseUseExplosion.rb:20:2342:20:2352 | else ... |
+| UseUseExplosion.rb:20:2358:20:2368 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1753:20:2372 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2358:20:2368 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1753:20:2372 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2358:20:2368 | else ... | UseUseExplosion.rb:20:1753:20:2372 | if ... |
 | UseUseExplosion.rb:20:2363:20:2368 | call to use | UseUseExplosion.rb:20:2358:20:2368 | else ... |
+| UseUseExplosion.rb:20:2374:20:2384 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1732:20:2388 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2374:20:2384 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1732:20:2388 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2374:20:2384 | else ... | UseUseExplosion.rb:20:1732:20:2388 | if ... |
 | UseUseExplosion.rb:20:2379:20:2384 | call to use | UseUseExplosion.rb:20:2374:20:2384 | else ... |
+| UseUseExplosion.rb:20:2390:20:2400 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1711:20:2404 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2390:20:2400 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1711:20:2404 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2390:20:2400 | else ... | UseUseExplosion.rb:20:1711:20:2404 | if ... |
 | UseUseExplosion.rb:20:2395:20:2400 | call to use | UseUseExplosion.rb:20:2390:20:2400 | else ... |
+| UseUseExplosion.rb:20:2406:20:2416 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1690:20:2420 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2406:20:2416 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1690:20:2420 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2406:20:2416 | else ... | UseUseExplosion.rb:20:1690:20:2420 | if ... |
 | UseUseExplosion.rb:20:2411:20:2416 | call to use | UseUseExplosion.rb:20:2406:20:2416 | else ... |
+| UseUseExplosion.rb:20:2422:20:2432 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1669:20:2436 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2422:20:2432 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1669:20:2436 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2422:20:2432 | else ... | UseUseExplosion.rb:20:1669:20:2436 | if ... |
 | UseUseExplosion.rb:20:2427:20:2432 | call to use | UseUseExplosion.rb:20:2422:20:2432 | else ... |
+| UseUseExplosion.rb:20:2438:20:2448 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1648:20:2452 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2438:20:2448 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1648:20:2452 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2438:20:2448 | else ... | UseUseExplosion.rb:20:1648:20:2452 | if ... |
 | UseUseExplosion.rb:20:2443:20:2448 | call to use | UseUseExplosion.rb:20:2438:20:2448 | else ... |
+| UseUseExplosion.rb:20:2454:20:2464 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1627:20:2468 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2454:20:2464 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1627:20:2468 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2454:20:2464 | else ... | UseUseExplosion.rb:20:1627:20:2468 | if ... |
 | UseUseExplosion.rb:20:2459:20:2464 | call to use | UseUseExplosion.rb:20:2454:20:2464 | else ... |
+| UseUseExplosion.rb:20:2470:20:2480 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1606:20:2484 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2470:20:2480 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1606:20:2484 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2470:20:2480 | else ... | UseUseExplosion.rb:20:1606:20:2484 | if ... |
 | UseUseExplosion.rb:20:2475:20:2480 | call to use | UseUseExplosion.rb:20:2470:20:2480 | else ... |
+| UseUseExplosion.rb:20:2486:20:2496 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1585:20:2500 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2486:20:2496 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1585:20:2500 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2486:20:2496 | else ... | UseUseExplosion.rb:20:1585:20:2500 | if ... |
 | UseUseExplosion.rb:20:2491:20:2496 | call to use | UseUseExplosion.rb:20:2486:20:2496 | else ... |
+| UseUseExplosion.rb:20:2502:20:2512 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1564:20:2516 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2502:20:2512 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1564:20:2516 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2502:20:2512 | else ... | UseUseExplosion.rb:20:1564:20:2516 | if ... |
 | UseUseExplosion.rb:20:2507:20:2512 | call to use | UseUseExplosion.rb:20:2502:20:2512 | else ... |
+| UseUseExplosion.rb:20:2518:20:2528 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1543:20:2532 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2518:20:2528 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1543:20:2532 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2518:20:2528 | else ... | UseUseExplosion.rb:20:1543:20:2532 | if ... |
 | UseUseExplosion.rb:20:2523:20:2528 | call to use | UseUseExplosion.rb:20:2518:20:2528 | else ... |
+| UseUseExplosion.rb:20:2534:20:2544 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1522:20:2548 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2534:20:2544 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1522:20:2548 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2534:20:2544 | else ... | UseUseExplosion.rb:20:1522:20:2548 | if ... |
 | UseUseExplosion.rb:20:2539:20:2544 | call to use | UseUseExplosion.rb:20:2534:20:2544 | else ... |
+| UseUseExplosion.rb:20:2550:20:2560 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1501:20:2564 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2550:20:2560 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1501:20:2564 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2550:20:2560 | else ... | UseUseExplosion.rb:20:1501:20:2564 | if ... |
 | UseUseExplosion.rb:20:2555:20:2560 | call to use | UseUseExplosion.rb:20:2550:20:2560 | else ... |
+| UseUseExplosion.rb:20:2566:20:2576 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1480:20:2580 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2566:20:2576 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1480:20:2580 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2566:20:2576 | else ... | UseUseExplosion.rb:20:1480:20:2580 | if ... |
 | UseUseExplosion.rb:20:2571:20:2576 | call to use | UseUseExplosion.rb:20:2566:20:2576 | else ... |
+| UseUseExplosion.rb:20:2582:20:2592 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1459:20:2596 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2582:20:2592 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1459:20:2596 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2582:20:2592 | else ... | UseUseExplosion.rb:20:1459:20:2596 | if ... |
 | UseUseExplosion.rb:20:2587:20:2592 | call to use | UseUseExplosion.rb:20:2582:20:2592 | else ... |
+| UseUseExplosion.rb:20:2598:20:2608 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1438:20:2612 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2598:20:2608 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1438:20:2612 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2598:20:2608 | else ... | UseUseExplosion.rb:20:1438:20:2612 | if ... |
 | UseUseExplosion.rb:20:2603:20:2608 | call to use | UseUseExplosion.rb:20:2598:20:2608 | else ... |
+| UseUseExplosion.rb:20:2614:20:2624 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1417:20:2628 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2614:20:2624 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1417:20:2628 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2614:20:2624 | else ... | UseUseExplosion.rb:20:1417:20:2628 | if ... |
 | UseUseExplosion.rb:20:2619:20:2624 | call to use | UseUseExplosion.rb:20:2614:20:2624 | else ... |
+| UseUseExplosion.rb:20:2630:20:2640 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1396:20:2644 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2630:20:2640 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1396:20:2644 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2630:20:2640 | else ... | UseUseExplosion.rb:20:1396:20:2644 | if ... |
 | UseUseExplosion.rb:20:2635:20:2640 | call to use | UseUseExplosion.rb:20:2630:20:2640 | else ... |
+| UseUseExplosion.rb:20:2646:20:2656 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1375:20:2660 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2646:20:2656 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1375:20:2660 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2646:20:2656 | else ... | UseUseExplosion.rb:20:1375:20:2660 | if ... |
 | UseUseExplosion.rb:20:2651:20:2656 | call to use | UseUseExplosion.rb:20:2646:20:2656 | else ... |
+| UseUseExplosion.rb:20:2662:20:2672 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1354:20:2676 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2662:20:2672 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1354:20:2676 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2662:20:2672 | else ... | UseUseExplosion.rb:20:1354:20:2676 | if ... |
 | UseUseExplosion.rb:20:2667:20:2672 | call to use | UseUseExplosion.rb:20:2662:20:2672 | else ... |
+| UseUseExplosion.rb:20:2678:20:2688 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1333:20:2692 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2678:20:2688 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1333:20:2692 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2678:20:2688 | else ... | UseUseExplosion.rb:20:1333:20:2692 | if ... |
 | UseUseExplosion.rb:20:2683:20:2688 | call to use | UseUseExplosion.rb:20:2678:20:2688 | else ... |
+| UseUseExplosion.rb:20:2694:20:2704 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1312:20:2708 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2694:20:2704 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1312:20:2708 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2694:20:2704 | else ... | UseUseExplosion.rb:20:1312:20:2708 | if ... |
 | UseUseExplosion.rb:20:2699:20:2704 | call to use | UseUseExplosion.rb:20:2694:20:2704 | else ... |
+| UseUseExplosion.rb:20:2710:20:2720 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1291:20:2724 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2710:20:2720 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1291:20:2724 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2710:20:2720 | else ... | UseUseExplosion.rb:20:1291:20:2724 | if ... |
 | UseUseExplosion.rb:20:2715:20:2720 | call to use | UseUseExplosion.rb:20:2710:20:2720 | else ... |
+| UseUseExplosion.rb:20:2726:20:2736 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1270:20:2740 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2726:20:2736 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1270:20:2740 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2726:20:2736 | else ... | UseUseExplosion.rb:20:1270:20:2740 | if ... |
 | UseUseExplosion.rb:20:2731:20:2736 | call to use | UseUseExplosion.rb:20:2726:20:2736 | else ... |
+| UseUseExplosion.rb:20:2742:20:2752 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1249:20:2756 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2742:20:2752 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1249:20:2756 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2742:20:2752 | else ... | UseUseExplosion.rb:20:1249:20:2756 | if ... |
 | UseUseExplosion.rb:20:2747:20:2752 | call to use | UseUseExplosion.rb:20:2742:20:2752 | else ... |
+| UseUseExplosion.rb:20:2758:20:2768 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1228:20:2772 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2758:20:2768 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1228:20:2772 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2758:20:2768 | else ... | UseUseExplosion.rb:20:1228:20:2772 | if ... |
 | UseUseExplosion.rb:20:2763:20:2768 | call to use | UseUseExplosion.rb:20:2758:20:2768 | else ... |
+| UseUseExplosion.rb:20:2774:20:2784 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1207:20:2788 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2774:20:2784 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1207:20:2788 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2774:20:2784 | else ... | UseUseExplosion.rb:20:1207:20:2788 | if ... |
 | UseUseExplosion.rb:20:2779:20:2784 | call to use | UseUseExplosion.rb:20:2774:20:2784 | else ... |
+| UseUseExplosion.rb:20:2790:20:2800 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1186:20:2804 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2790:20:2800 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1186:20:2804 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2790:20:2800 | else ... | UseUseExplosion.rb:20:1186:20:2804 | if ... |
 | UseUseExplosion.rb:20:2795:20:2800 | call to use | UseUseExplosion.rb:20:2790:20:2800 | else ... |
+| UseUseExplosion.rb:20:2806:20:2816 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1165:20:2820 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2806:20:2816 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1165:20:2820 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2806:20:2816 | else ... | UseUseExplosion.rb:20:1165:20:2820 | if ... |
 | UseUseExplosion.rb:20:2811:20:2816 | call to use | UseUseExplosion.rb:20:2806:20:2816 | else ... |
+| UseUseExplosion.rb:20:2822:20:2832 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1144:20:2836 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2822:20:2832 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1144:20:2836 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2822:20:2832 | else ... | UseUseExplosion.rb:20:1144:20:2836 | if ... |
 | UseUseExplosion.rb:20:2827:20:2832 | call to use | UseUseExplosion.rb:20:2822:20:2832 | else ... |
+| UseUseExplosion.rb:20:2838:20:2848 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1123:20:2852 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2838:20:2848 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1123:20:2852 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2838:20:2848 | else ... | UseUseExplosion.rb:20:1123:20:2852 | if ... |
 | UseUseExplosion.rb:20:2843:20:2848 | call to use | UseUseExplosion.rb:20:2838:20:2848 | else ... |
+| UseUseExplosion.rb:20:2854:20:2864 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1102:20:2868 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2854:20:2864 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1102:20:2868 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2854:20:2864 | else ... | UseUseExplosion.rb:20:1102:20:2868 | if ... |
 | UseUseExplosion.rb:20:2859:20:2864 | call to use | UseUseExplosion.rb:20:2854:20:2864 | else ... |
+| UseUseExplosion.rb:20:2870:20:2880 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1081:20:2884 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2870:20:2880 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1081:20:2884 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2870:20:2880 | else ... | UseUseExplosion.rb:20:1081:20:2884 | if ... |
 | UseUseExplosion.rb:20:2875:20:2880 | call to use | UseUseExplosion.rb:20:2870:20:2880 | else ... |
+| UseUseExplosion.rb:20:2886:20:2896 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1060:20:2900 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2886:20:2896 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1060:20:2900 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2886:20:2896 | else ... | UseUseExplosion.rb:20:1060:20:2900 | if ... |
 | UseUseExplosion.rb:20:2891:20:2896 | call to use | UseUseExplosion.rb:20:2886:20:2896 | else ... |
+| UseUseExplosion.rb:20:2902:20:2912 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1039:20:2916 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2902:20:2912 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1039:20:2916 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2902:20:2912 | else ... | UseUseExplosion.rb:20:1039:20:2916 | if ... |
 | UseUseExplosion.rb:20:2907:20:2912 | call to use | UseUseExplosion.rb:20:2902:20:2912 | else ... |
+| UseUseExplosion.rb:20:2918:20:2928 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1018:20:2932 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2918:20:2928 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1018:20:2932 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2918:20:2928 | else ... | UseUseExplosion.rb:20:1018:20:2932 | if ... |
 | UseUseExplosion.rb:20:2923:20:2928 | call to use | UseUseExplosion.rb:20:2918:20:2928 | else ... |
+| UseUseExplosion.rb:20:2934:20:2944 | [input] SSA phi read(self) | UseUseExplosion.rb:20:997:20:2948 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2934:20:2944 | [input] SSA phi read(x) | UseUseExplosion.rb:20:997:20:2948 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2934:20:2944 | else ... | UseUseExplosion.rb:20:997:20:2948 | if ... |
 | UseUseExplosion.rb:20:2939:20:2944 | call to use | UseUseExplosion.rb:20:2934:20:2944 | else ... |
+| UseUseExplosion.rb:20:2950:20:2960 | [input] SSA phi read(self) | UseUseExplosion.rb:20:976:20:2964 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2950:20:2960 | [input] SSA phi read(x) | UseUseExplosion.rb:20:976:20:2964 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2950:20:2960 | else ... | UseUseExplosion.rb:20:976:20:2964 | if ... |
 | UseUseExplosion.rb:20:2955:20:2960 | call to use | UseUseExplosion.rb:20:2950:20:2960 | else ... |
+| UseUseExplosion.rb:20:2966:20:2976 | [input] SSA phi read(self) | UseUseExplosion.rb:20:955:20:2980 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2966:20:2976 | [input] SSA phi read(x) | UseUseExplosion.rb:20:955:20:2980 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2966:20:2976 | else ... | UseUseExplosion.rb:20:955:20:2980 | if ... |
 | UseUseExplosion.rb:20:2971:20:2976 | call to use | UseUseExplosion.rb:20:2966:20:2976 | else ... |
+| UseUseExplosion.rb:20:2982:20:2992 | [input] SSA phi read(self) | UseUseExplosion.rb:20:934:20:2996 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2982:20:2992 | [input] SSA phi read(x) | UseUseExplosion.rb:20:934:20:2996 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2982:20:2992 | else ... | UseUseExplosion.rb:20:934:20:2996 | if ... |
 | UseUseExplosion.rb:20:2987:20:2992 | call to use | UseUseExplosion.rb:20:2982:20:2992 | else ... |
+| UseUseExplosion.rb:20:2998:20:3008 | [input] SSA phi read(self) | UseUseExplosion.rb:20:913:20:3012 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2998:20:3008 | [input] SSA phi read(x) | UseUseExplosion.rb:20:913:20:3012 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2998:20:3008 | else ... | UseUseExplosion.rb:20:913:20:3012 | if ... |
 | UseUseExplosion.rb:20:3003:20:3008 | call to use | UseUseExplosion.rb:20:2998:20:3008 | else ... |
+| UseUseExplosion.rb:20:3014:20:3024 | [input] SSA phi read(self) | UseUseExplosion.rb:20:892:20:3028 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3014:20:3024 | [input] SSA phi read(x) | UseUseExplosion.rb:20:892:20:3028 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3014:20:3024 | else ... | UseUseExplosion.rb:20:892:20:3028 | if ... |
 | UseUseExplosion.rb:20:3019:20:3024 | call to use | UseUseExplosion.rb:20:3014:20:3024 | else ... |
+| UseUseExplosion.rb:20:3030:20:3040 | [input] SSA phi read(self) | UseUseExplosion.rb:20:871:20:3044 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3030:20:3040 | [input] SSA phi read(x) | UseUseExplosion.rb:20:871:20:3044 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3030:20:3040 | else ... | UseUseExplosion.rb:20:871:20:3044 | if ... |
 | UseUseExplosion.rb:20:3035:20:3040 | call to use | UseUseExplosion.rb:20:3030:20:3040 | else ... |
+| UseUseExplosion.rb:20:3046:20:3056 | [input] SSA phi read(self) | UseUseExplosion.rb:20:850:20:3060 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3046:20:3056 | [input] SSA phi read(x) | UseUseExplosion.rb:20:850:20:3060 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3046:20:3056 | else ... | UseUseExplosion.rb:20:850:20:3060 | if ... |
 | UseUseExplosion.rb:20:3051:20:3056 | call to use | UseUseExplosion.rb:20:3046:20:3056 | else ... |
+| UseUseExplosion.rb:20:3062:20:3072 | [input] SSA phi read(self) | UseUseExplosion.rb:20:829:20:3076 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3062:20:3072 | [input] SSA phi read(x) | UseUseExplosion.rb:20:829:20:3076 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3062:20:3072 | else ... | UseUseExplosion.rb:20:829:20:3076 | if ... |
 | UseUseExplosion.rb:20:3067:20:3072 | call to use | UseUseExplosion.rb:20:3062:20:3072 | else ... |
+| UseUseExplosion.rb:20:3078:20:3088 | [input] SSA phi read(self) | UseUseExplosion.rb:20:808:20:3092 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3078:20:3088 | [input] SSA phi read(x) | UseUseExplosion.rb:20:808:20:3092 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3078:20:3088 | else ... | UseUseExplosion.rb:20:808:20:3092 | if ... |
 | UseUseExplosion.rb:20:3083:20:3088 | call to use | UseUseExplosion.rb:20:3078:20:3088 | else ... |
+| UseUseExplosion.rb:20:3094:20:3104 | [input] SSA phi read(self) | UseUseExplosion.rb:20:787:20:3108 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3094:20:3104 | [input] SSA phi read(x) | UseUseExplosion.rb:20:787:20:3108 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3094:20:3104 | else ... | UseUseExplosion.rb:20:787:20:3108 | if ... |
 | UseUseExplosion.rb:20:3099:20:3104 | call to use | UseUseExplosion.rb:20:3094:20:3104 | else ... |
+| UseUseExplosion.rb:20:3110:20:3120 | [input] SSA phi read(self) | UseUseExplosion.rb:20:766:20:3124 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3110:20:3120 | [input] SSA phi read(x) | UseUseExplosion.rb:20:766:20:3124 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3110:20:3120 | else ... | UseUseExplosion.rb:20:766:20:3124 | if ... |
 | UseUseExplosion.rb:20:3115:20:3120 | call to use | UseUseExplosion.rb:20:3110:20:3120 | else ... |
+| UseUseExplosion.rb:20:3126:20:3136 | [input] SSA phi read(self) | UseUseExplosion.rb:20:745:20:3140 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3126:20:3136 | [input] SSA phi read(x) | UseUseExplosion.rb:20:745:20:3140 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3126:20:3136 | else ... | UseUseExplosion.rb:20:745:20:3140 | if ... |
 | UseUseExplosion.rb:20:3131:20:3136 | call to use | UseUseExplosion.rb:20:3126:20:3136 | else ... |
+| UseUseExplosion.rb:20:3142:20:3152 | [input] SSA phi read(self) | UseUseExplosion.rb:20:724:20:3156 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3142:20:3152 | [input] SSA phi read(x) | UseUseExplosion.rb:20:724:20:3156 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3142:20:3152 | else ... | UseUseExplosion.rb:20:724:20:3156 | if ... |
 | UseUseExplosion.rb:20:3147:20:3152 | call to use | UseUseExplosion.rb:20:3142:20:3152 | else ... |
+| UseUseExplosion.rb:20:3158:20:3168 | [input] SSA phi read(self) | UseUseExplosion.rb:20:703:20:3172 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3158:20:3168 | [input] SSA phi read(x) | UseUseExplosion.rb:20:703:20:3172 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3158:20:3168 | else ... | UseUseExplosion.rb:20:703:20:3172 | if ... |
 | UseUseExplosion.rb:20:3163:20:3168 | call to use | UseUseExplosion.rb:20:3158:20:3168 | else ... |
+| UseUseExplosion.rb:20:3174:20:3184 | [input] SSA phi read(self) | UseUseExplosion.rb:20:682:20:3188 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3174:20:3184 | [input] SSA phi read(x) | UseUseExplosion.rb:20:682:20:3188 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3174:20:3184 | else ... | UseUseExplosion.rb:20:682:20:3188 | if ... |
 | UseUseExplosion.rb:20:3179:20:3184 | call to use | UseUseExplosion.rb:20:3174:20:3184 | else ... |
+| UseUseExplosion.rb:20:3190:20:3200 | [input] SSA phi read(self) | UseUseExplosion.rb:20:661:20:3204 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3190:20:3200 | [input] SSA phi read(x) | UseUseExplosion.rb:20:661:20:3204 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3190:20:3200 | else ... | UseUseExplosion.rb:20:661:20:3204 | if ... |
 | UseUseExplosion.rb:20:3195:20:3200 | call to use | UseUseExplosion.rb:20:3190:20:3200 | else ... |
+| UseUseExplosion.rb:20:3206:20:3216 | [input] SSA phi read(self) | UseUseExplosion.rb:20:640:20:3220 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3206:20:3216 | [input] SSA phi read(x) | UseUseExplosion.rb:20:640:20:3220 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3206:20:3216 | else ... | UseUseExplosion.rb:20:640:20:3220 | if ... |
 | UseUseExplosion.rb:20:3211:20:3216 | call to use | UseUseExplosion.rb:20:3206:20:3216 | else ... |
+| UseUseExplosion.rb:20:3222:20:3232 | [input] SSA phi read(self) | UseUseExplosion.rb:20:619:20:3236 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3222:20:3232 | [input] SSA phi read(x) | UseUseExplosion.rb:20:619:20:3236 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3222:20:3232 | else ... | UseUseExplosion.rb:20:619:20:3236 | if ... |
 | UseUseExplosion.rb:20:3227:20:3232 | call to use | UseUseExplosion.rb:20:3222:20:3232 | else ... |
+| UseUseExplosion.rb:20:3238:20:3248 | [input] SSA phi read(self) | UseUseExplosion.rb:20:598:20:3252 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3238:20:3248 | [input] SSA phi read(x) | UseUseExplosion.rb:20:598:20:3252 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3238:20:3248 | else ... | UseUseExplosion.rb:20:598:20:3252 | if ... |
 | UseUseExplosion.rb:20:3243:20:3248 | call to use | UseUseExplosion.rb:20:3238:20:3248 | else ... |
+| UseUseExplosion.rb:20:3254:20:3264 | [input] SSA phi read(self) | UseUseExplosion.rb:20:577:20:3268 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3254:20:3264 | [input] SSA phi read(x) | UseUseExplosion.rb:20:577:20:3268 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3254:20:3264 | else ... | UseUseExplosion.rb:20:577:20:3268 | if ... |
 | UseUseExplosion.rb:20:3259:20:3264 | call to use | UseUseExplosion.rb:20:3254:20:3264 | else ... |
+| UseUseExplosion.rb:20:3270:20:3280 | [input] SSA phi read(self) | UseUseExplosion.rb:20:556:20:3284 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3270:20:3280 | [input] SSA phi read(x) | UseUseExplosion.rb:20:556:20:3284 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3270:20:3280 | else ... | UseUseExplosion.rb:20:556:20:3284 | if ... |
 | UseUseExplosion.rb:20:3275:20:3280 | call to use | UseUseExplosion.rb:20:3270:20:3280 | else ... |
+| UseUseExplosion.rb:20:3286:20:3296 | [input] SSA phi read(self) | UseUseExplosion.rb:20:535:20:3300 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3286:20:3296 | [input] SSA phi read(x) | UseUseExplosion.rb:20:535:20:3300 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3286:20:3296 | else ... | UseUseExplosion.rb:20:535:20:3300 | if ... |
 | UseUseExplosion.rb:20:3291:20:3296 | call to use | UseUseExplosion.rb:20:3286:20:3296 | else ... |
+| UseUseExplosion.rb:20:3302:20:3312 | [input] SSA phi read(self) | UseUseExplosion.rb:20:514:20:3316 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3302:20:3312 | [input] SSA phi read(x) | UseUseExplosion.rb:20:514:20:3316 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3302:20:3312 | else ... | UseUseExplosion.rb:20:514:20:3316 | if ... |
 | UseUseExplosion.rb:20:3307:20:3312 | call to use | UseUseExplosion.rb:20:3302:20:3312 | else ... |
+| UseUseExplosion.rb:20:3318:20:3328 | [input] SSA phi read(self) | UseUseExplosion.rb:20:493:20:3332 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3318:20:3328 | [input] SSA phi read(x) | UseUseExplosion.rb:20:493:20:3332 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3318:20:3328 | else ... | UseUseExplosion.rb:20:493:20:3332 | if ... |
 | UseUseExplosion.rb:20:3323:20:3328 | call to use | UseUseExplosion.rb:20:3318:20:3328 | else ... |
+| UseUseExplosion.rb:20:3334:20:3344 | [input] SSA phi read(self) | UseUseExplosion.rb:20:472:20:3348 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3334:20:3344 | [input] SSA phi read(x) | UseUseExplosion.rb:20:472:20:3348 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3334:20:3344 | else ... | UseUseExplosion.rb:20:472:20:3348 | if ... |
 | UseUseExplosion.rb:20:3339:20:3344 | call to use | UseUseExplosion.rb:20:3334:20:3344 | else ... |
+| UseUseExplosion.rb:20:3350:20:3360 | [input] SSA phi read(self) | UseUseExplosion.rb:20:451:20:3364 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3350:20:3360 | [input] SSA phi read(x) | UseUseExplosion.rb:20:451:20:3364 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3350:20:3360 | else ... | UseUseExplosion.rb:20:451:20:3364 | if ... |
 | UseUseExplosion.rb:20:3355:20:3360 | call to use | UseUseExplosion.rb:20:3350:20:3360 | else ... |
+| UseUseExplosion.rb:20:3366:20:3376 | [input] SSA phi read(self) | UseUseExplosion.rb:20:430:20:3380 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3366:20:3376 | [input] SSA phi read(x) | UseUseExplosion.rb:20:430:20:3380 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3366:20:3376 | else ... | UseUseExplosion.rb:20:430:20:3380 | if ... |
 | UseUseExplosion.rb:20:3371:20:3376 | call to use | UseUseExplosion.rb:20:3366:20:3376 | else ... |
+| UseUseExplosion.rb:20:3382:20:3392 | [input] SSA phi read(self) | UseUseExplosion.rb:20:409:20:3396 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3382:20:3392 | [input] SSA phi read(x) | UseUseExplosion.rb:20:409:20:3396 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3382:20:3392 | else ... | UseUseExplosion.rb:20:409:20:3396 | if ... |
 | UseUseExplosion.rb:20:3387:20:3392 | call to use | UseUseExplosion.rb:20:3382:20:3392 | else ... |
+| UseUseExplosion.rb:20:3398:20:3408 | [input] SSA phi read(self) | UseUseExplosion.rb:20:388:20:3412 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3398:20:3408 | [input] SSA phi read(x) | UseUseExplosion.rb:20:388:20:3412 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3398:20:3408 | else ... | UseUseExplosion.rb:20:388:20:3412 | if ... |
 | UseUseExplosion.rb:20:3403:20:3408 | call to use | UseUseExplosion.rb:20:3398:20:3408 | else ... |
+| UseUseExplosion.rb:20:3414:20:3424 | [input] SSA phi read(self) | UseUseExplosion.rb:20:367:20:3428 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3414:20:3424 | [input] SSA phi read(x) | UseUseExplosion.rb:20:367:20:3428 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3414:20:3424 | else ... | UseUseExplosion.rb:20:367:20:3428 | if ... |
 | UseUseExplosion.rb:20:3419:20:3424 | call to use | UseUseExplosion.rb:20:3414:20:3424 | else ... |
+| UseUseExplosion.rb:20:3430:20:3440 | [input] SSA phi read(self) | UseUseExplosion.rb:20:346:20:3444 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3430:20:3440 | [input] SSA phi read(x) | UseUseExplosion.rb:20:346:20:3444 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3430:20:3440 | else ... | UseUseExplosion.rb:20:346:20:3444 | if ... |
 | UseUseExplosion.rb:20:3435:20:3440 | call to use | UseUseExplosion.rb:20:3430:20:3440 | else ... |
+| UseUseExplosion.rb:20:3446:20:3456 | [input] SSA phi read(self) | UseUseExplosion.rb:20:325:20:3460 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3446:20:3456 | [input] SSA phi read(x) | UseUseExplosion.rb:20:325:20:3460 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3446:20:3456 | else ... | UseUseExplosion.rb:20:325:20:3460 | if ... |
 | UseUseExplosion.rb:20:3451:20:3456 | call to use | UseUseExplosion.rb:20:3446:20:3456 | else ... |
+| UseUseExplosion.rb:20:3462:20:3472 | [input] SSA phi read(self) | UseUseExplosion.rb:20:304:20:3476 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3462:20:3472 | [input] SSA phi read(x) | UseUseExplosion.rb:20:304:20:3476 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3462:20:3472 | else ... | UseUseExplosion.rb:20:304:20:3476 | if ... |
 | UseUseExplosion.rb:20:3467:20:3472 | call to use | UseUseExplosion.rb:20:3462:20:3472 | else ... |
+| UseUseExplosion.rb:20:3478:20:3488 | [input] SSA phi read(self) | UseUseExplosion.rb:20:283:20:3492 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3478:20:3488 | [input] SSA phi read(x) | UseUseExplosion.rb:20:283:20:3492 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3478:20:3488 | else ... | UseUseExplosion.rb:20:283:20:3492 | if ... |
 | UseUseExplosion.rb:20:3483:20:3488 | call to use | UseUseExplosion.rb:20:3478:20:3488 | else ... |
+| UseUseExplosion.rb:20:3494:20:3504 | [input] SSA phi read(self) | UseUseExplosion.rb:20:262:20:3508 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3494:20:3504 | [input] SSA phi read(x) | UseUseExplosion.rb:20:262:20:3508 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3494:20:3504 | else ... | UseUseExplosion.rb:20:262:20:3508 | if ... |
 | UseUseExplosion.rb:20:3499:20:3504 | call to use | UseUseExplosion.rb:20:3494:20:3504 | else ... |
+| UseUseExplosion.rb:20:3510:20:3520 | [input] SSA phi read(self) | UseUseExplosion.rb:20:241:20:3524 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3510:20:3520 | [input] SSA phi read(x) | UseUseExplosion.rb:20:241:20:3524 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3510:20:3520 | else ... | UseUseExplosion.rb:20:241:20:3524 | if ... |
 | UseUseExplosion.rb:20:3515:20:3520 | call to use | UseUseExplosion.rb:20:3510:20:3520 | else ... |
+| UseUseExplosion.rb:20:3526:20:3536 | [input] SSA phi read(self) | UseUseExplosion.rb:20:220:20:3540 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3526:20:3536 | [input] SSA phi read(x) | UseUseExplosion.rb:20:220:20:3540 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3526:20:3536 | else ... | UseUseExplosion.rb:20:220:20:3540 | if ... |
 | UseUseExplosion.rb:20:3531:20:3536 | call to use | UseUseExplosion.rb:20:3526:20:3536 | else ... |
+| UseUseExplosion.rb:20:3542:20:3552 | [input] SSA phi read(self) | UseUseExplosion.rb:20:199:20:3556 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3542:20:3552 | [input] SSA phi read(x) | UseUseExplosion.rb:20:199:20:3556 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3542:20:3552 | else ... | UseUseExplosion.rb:20:199:20:3556 | if ... |
 | UseUseExplosion.rb:20:3547:20:3552 | call to use | UseUseExplosion.rb:20:3542:20:3552 | else ... |
+| UseUseExplosion.rb:20:3558:20:3568 | [input] SSA phi read(self) | UseUseExplosion.rb:20:178:20:3572 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3558:20:3568 | [input] SSA phi read(x) | UseUseExplosion.rb:20:178:20:3572 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3558:20:3568 | else ... | UseUseExplosion.rb:20:178:20:3572 | if ... |
 | UseUseExplosion.rb:20:3563:20:3568 | call to use | UseUseExplosion.rb:20:3558:20:3568 | else ... |
+| UseUseExplosion.rb:20:3574:20:3584 | [input] SSA phi read(self) | UseUseExplosion.rb:20:157:20:3588 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3574:20:3584 | [input] SSA phi read(x) | UseUseExplosion.rb:20:157:20:3588 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3574:20:3584 | else ... | UseUseExplosion.rb:20:157:20:3588 | if ... |
 | UseUseExplosion.rb:20:3579:20:3584 | call to use | UseUseExplosion.rb:20:3574:20:3584 | else ... |
+| UseUseExplosion.rb:20:3590:20:3600 | [input] SSA phi read(self) | UseUseExplosion.rb:20:136:20:3604 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3590:20:3600 | [input] SSA phi read(x) | UseUseExplosion.rb:20:136:20:3604 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3590:20:3600 | else ... | UseUseExplosion.rb:20:136:20:3604 | if ... |
 | UseUseExplosion.rb:20:3595:20:3600 | call to use | UseUseExplosion.rb:20:3590:20:3600 | else ... |
+| UseUseExplosion.rb:20:3606:20:3616 | [input] SSA phi read(self) | UseUseExplosion.rb:20:115:20:3620 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3606:20:3616 | [input] SSA phi read(x) | UseUseExplosion.rb:20:115:20:3620 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3606:20:3616 | else ... | UseUseExplosion.rb:20:115:20:3620 | if ... |
 | UseUseExplosion.rb:20:3611:20:3616 | call to use | UseUseExplosion.rb:20:3606:20:3616 | else ... |
+| UseUseExplosion.rb:20:3622:20:3632 | [input] SSA phi read(self) | UseUseExplosion.rb:20:94:20:3636 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3622:20:3632 | [input] SSA phi read(x) | UseUseExplosion.rb:20:94:20:3636 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3622:20:3632 | else ... | UseUseExplosion.rb:20:94:20:3636 | if ... |
 | UseUseExplosion.rb:20:3627:20:3632 | call to use | UseUseExplosion.rb:20:3622:20:3632 | else ... |
+| UseUseExplosion.rb:20:3638:20:3648 | [input] SSA phi read(self) | UseUseExplosion.rb:20:73:20:3652 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3638:20:3648 | [input] SSA phi read(x) | UseUseExplosion.rb:20:73:20:3652 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3638:20:3648 | else ... | UseUseExplosion.rb:20:73:20:3652 | if ... |
 | UseUseExplosion.rb:20:3643:20:3648 | call to use | UseUseExplosion.rb:20:3638:20:3648 | else ... |
+| UseUseExplosion.rb:20:3654:20:3664 | [input] SSA phi read(self) | UseUseExplosion.rb:20:52:20:3668 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3654:20:3664 | [input] SSA phi read(x) | UseUseExplosion.rb:20:52:20:3668 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3654:20:3664 | else ... | UseUseExplosion.rb:20:52:20:3668 | if ... |
 | UseUseExplosion.rb:20:3659:20:3664 | call to use | UseUseExplosion.rb:20:3654:20:3664 | else ... |
+| UseUseExplosion.rb:20:3670:20:3680 | [input] SSA phi read(self) | UseUseExplosion.rb:20:31:20:3684 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3670:20:3680 | [input] SSA phi read(x) | UseUseExplosion.rb:20:31:20:3684 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3670:20:3680 | else ... | UseUseExplosion.rb:20:31:20:3684 | if ... |
 | UseUseExplosion.rb:20:3675:20:3680 | call to use | UseUseExplosion.rb:20:3670:20:3680 | else ... |
+| UseUseExplosion.rb:20:3686:20:3696 | [input] SSA phi read(self) | UseUseExplosion.rb:20:9:20:3700 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3686:20:3696 | [input] SSA phi read(x) | UseUseExplosion.rb:20:9:20:3700 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3686:20:3696 | else ... | UseUseExplosion.rb:20:9:20:3700 | if ... |
 | UseUseExplosion.rb:20:3691:20:3696 | call to use | UseUseExplosion.rb:20:3686:20:3696 | else ... |
 | UseUseExplosion.rb:21:13:21:17 | [post] self | UseUseExplosion.rb:21:35:21:39 | self |
@@ -2436,9 +2836,11 @@
 | local_dataflow.rb:10:5:13:3 | __synth__0__1 | local_dataflow.rb:10:9:10:9 | x |
 | local_dataflow.rb:10:5:13:3 | call to each | local_dataflow.rb:10:5:13:3 | ... |
 | local_dataflow.rb:10:9:10:9 | ... = ... | local_dataflow.rb:10:9:10:9 | if ... |
+| local_dataflow.rb:10:9:10:9 | [input] phi | local_dataflow.rb:10:9:10:9 | phi |
+| local_dataflow.rb:10:9:10:9 | [input] phi | local_dataflow.rb:10:9:10:9 | phi |
 | local_dataflow.rb:10:9:10:9 | nil | local_dataflow.rb:10:9:10:9 | ... = ... |
 | local_dataflow.rb:10:9:10:9 | nil | local_dataflow.rb:10:9:10:9 | x |
-| local_dataflow.rb:10:9:10:9 | x | local_dataflow.rb:10:9:10:9 | phi |
+| local_dataflow.rb:10:9:10:9 | x | local_dataflow.rb:10:9:10:9 | [input] phi |
 | local_dataflow.rb:10:9:10:9 | x | local_dataflow.rb:12:5:12:5 | x |
 | local_dataflow.rb:10:14:10:18 | [post] array | local_dataflow.rb:15:10:15:14 | array |
 | local_dataflow.rb:10:14:10:18 | array | local_dataflow.rb:15:10:15:14 | array |
@@ -2451,9 +2853,11 @@
 | local_dataflow.rb:15:1:17:3 | __synth__0__1 | local_dataflow.rb:15:5:15:5 | x |
 | local_dataflow.rb:15:1:17:3 | call to each | local_dataflow.rb:15:1:17:3 | ... |
 | local_dataflow.rb:15:5:15:5 | ... = ... | local_dataflow.rb:15:5:15:5 | if ... |
+| local_dataflow.rb:15:5:15:5 | [input] phi | local_dataflow.rb:15:5:15:5 | phi |
+| local_dataflow.rb:15:5:15:5 | [input] phi | local_dataflow.rb:15:5:15:5 | phi |
 | local_dataflow.rb:15:5:15:5 | nil | local_dataflow.rb:15:5:15:5 | ... = ... |
 | local_dataflow.rb:15:5:15:5 | nil | local_dataflow.rb:15:5:15:5 | x |
-| local_dataflow.rb:15:5:15:5 | x | local_dataflow.rb:15:5:15:5 | phi |
+| local_dataflow.rb:15:5:15:5 | x | local_dataflow.rb:15:5:15:5 | [input] phi |
 | local_dataflow.rb:15:10:15:14 | [post] array | local_dataflow.rb:19:10:19:14 | array |
 | local_dataflow.rb:15:10:15:14 | array | local_dataflow.rb:19:10:19:14 | array |
 | local_dataflow.rb:16:9:16:10 | 10 | local_dataflow.rb:16:3:16:10 | break |
@@ -2463,9 +2867,11 @@
 | local_dataflow.rb:19:1:21:3 | __synth__0__1 | local_dataflow.rb:19:5:19:5 | x |
 | local_dataflow.rb:19:1:21:3 | call to each | local_dataflow.rb:19:1:21:3 | ... |
 | local_dataflow.rb:19:5:19:5 | ... = ... | local_dataflow.rb:19:5:19:5 | if ... |
+| local_dataflow.rb:19:5:19:5 | [input] phi | local_dataflow.rb:19:5:19:5 | phi |
+| local_dataflow.rb:19:5:19:5 | [input] phi | local_dataflow.rb:19:5:19:5 | phi |
 | local_dataflow.rb:19:5:19:5 | nil | local_dataflow.rb:19:5:19:5 | ... = ... |
 | local_dataflow.rb:19:5:19:5 | nil | local_dataflow.rb:19:5:19:5 | x |
-| local_dataflow.rb:19:5:19:5 | x | local_dataflow.rb:19:5:19:5 | phi |
+| local_dataflow.rb:19:5:19:5 | x | local_dataflow.rb:19:5:19:5 | [input] phi |
 | local_dataflow.rb:19:5:19:5 | x | local_dataflow.rb:20:6:20:6 | x |
 | local_dataflow.rb:24:2:24:8 | break | local_dataflow.rb:23:1:25:3 | while ... |
 | local_dataflow.rb:24:8:24:8 | 5 | local_dataflow.rb:24:2:24:8 | break |
@@ -2499,12 +2905,16 @@
 | local_dataflow.rb:61:12:61:12 | x | local_dataflow.rb:63:15:63:15 | x |
 | local_dataflow.rb:61:12:61:12 | x | local_dataflow.rb:65:6:65:6 | x |
 | local_dataflow.rb:61:12:61:12 | x | local_dataflow.rb:67:5:67:5 | x |
+| local_dataflow.rb:62:10:62:15 | [input] SSA phi read(x) | local_dataflow.rb:61:7:68:5 | SSA phi read(x) |
 | local_dataflow.rb:62:10:62:15 | then ... | local_dataflow.rb:61:7:68:5 | case ... |
 | local_dataflow.rb:62:15:62:15 | 3 | local_dataflow.rb:62:10:62:15 | then ... |
+| local_dataflow.rb:63:10:63:15 | [input] SSA phi read(x) | local_dataflow.rb:61:7:68:5 | SSA phi read(x) |
 | local_dataflow.rb:63:10:63:15 | then ... | local_dataflow.rb:61:7:68:5 | case ... |
 | local_dataflow.rb:63:15:63:15 | x | local_dataflow.rb:63:10:63:15 | then ... |
+| local_dataflow.rb:64:9:65:6 | [input] SSA phi read(x) | local_dataflow.rb:61:7:68:5 | SSA phi read(x) |
 | local_dataflow.rb:64:9:65:6 | then ... | local_dataflow.rb:61:7:68:5 | case ... |
 | local_dataflow.rb:65:6:65:6 | x | local_dataflow.rb:64:9:65:6 | then ... |
+| local_dataflow.rb:66:3:67:5 | [input] SSA phi read(x) | local_dataflow.rb:61:7:68:5 | SSA phi read(x) |
 | local_dataflow.rb:66:3:67:5 | else ... | local_dataflow.rb:61:7:68:5 | case ... |
 | local_dataflow.rb:67:5:67:5 | x | local_dataflow.rb:66:3:67:5 | else ... |
 | local_dataflow.rb:69:7:76:5 | case ... | local_dataflow.rb:69:3:76:5 | ... = ... |
@@ -2538,16 +2948,19 @@
 | local_dataflow.rb:78:12:78:20 | self | local_dataflow.rb:86:28:86:34 | self |
 | local_dataflow.rb:78:12:78:20 | self | local_dataflow.rb:87:20:87:26 | self |
 | local_dataflow.rb:79:13:79:13 | b | local_dataflow.rb:79:25:79:25 | b |
+| local_dataflow.rb:79:15:79:45 | [input] SSA phi read(self) | local_dataflow.rb:78:7:88:5 | SSA phi read(self) |
 | local_dataflow.rb:79:15:79:45 | then ... | local_dataflow.rb:78:7:88:5 | case ... |
 | local_dataflow.rb:79:20:79:26 | call to sink | local_dataflow.rb:79:15:79:45 | then ... |
 | local_dataflow.rb:80:8:80:8 | a | local_dataflow.rb:80:13:80:13 | a |
 | local_dataflow.rb:80:13:80:13 | [post] a | local_dataflow.rb:80:29:80:29 | a |
 | local_dataflow.rb:80:13:80:13 | a | local_dataflow.rb:80:29:80:29 | a |
+| local_dataflow.rb:80:19:80:49 | [input] SSA phi read(self) | local_dataflow.rb:78:7:88:5 | SSA phi read(self) |
 | local_dataflow.rb:80:19:80:49 | then ... | local_dataflow.rb:78:7:88:5 | case ... |
 | local_dataflow.rb:80:24:80:30 | call to sink | local_dataflow.rb:80:19:80:49 | then ... |
 | local_dataflow.rb:81:9:81:9 | c | local_dataflow.rb:82:12:82:12 | c |
 | local_dataflow.rb:81:13:81:13 | d | local_dataflow.rb:83:12:83:12 | d |
 | local_dataflow.rb:81:16:81:16 | e | local_dataflow.rb:84:12:84:12 | e |
+| local_dataflow.rb:81:20:84:33 | [input] SSA phi read(self) | local_dataflow.rb:78:7:88:5 | SSA phi read(self) |
 | local_dataflow.rb:81:20:84:33 | then ... | local_dataflow.rb:78:7:88:5 | case ... |
 | local_dataflow.rb:81:25:84:14 | call to [] | local_dataflow.rb:81:20:84:33 | then ... |
 | local_dataflow.rb:81:25:84:14 | synthetic splat argument | local_dataflow.rb:81:25:84:14 | call to [] |
@@ -2556,12 +2969,15 @@
 | local_dataflow.rb:83:7:83:13 | [post] self | local_dataflow.rb:84:7:84:13 | self |
 | local_dataflow.rb:83:7:83:13 | self | local_dataflow.rb:84:7:84:13 | self |
 | local_dataflow.rb:85:13:85:13 | f | local_dataflow.rb:85:27:85:27 | f |
+| local_dataflow.rb:85:17:85:47 | [input] SSA phi read(self) | local_dataflow.rb:78:7:88:5 | SSA phi read(self) |
 | local_dataflow.rb:85:17:85:47 | then ... | local_dataflow.rb:78:7:88:5 | case ... |
 | local_dataflow.rb:85:22:85:28 | call to sink | local_dataflow.rb:85:17:85:47 | then ... |
 | local_dataflow.rb:86:18:86:18 | g | local_dataflow.rb:86:33:86:33 | g |
+| local_dataflow.rb:86:23:86:53 | [input] SSA phi read(self) | local_dataflow.rb:78:7:88:5 | SSA phi read(self) |
 | local_dataflow.rb:86:23:86:53 | then ... | local_dataflow.rb:78:7:88:5 | case ... |
 | local_dataflow.rb:86:28:86:34 | call to sink | local_dataflow.rb:86:23:86:53 | then ... |
 | local_dataflow.rb:87:10:87:10 | x | local_dataflow.rb:87:25:87:25 | x |
+| local_dataflow.rb:87:15:87:48 | [input] SSA phi read(self) | local_dataflow.rb:78:7:88:5 | SSA phi read(self) |
 | local_dataflow.rb:87:15:87:48 | then ... | local_dataflow.rb:78:7:88:5 | case ... |
 | local_dataflow.rb:87:25:87:25 | [post] x | local_dataflow.rb:87:29:87:29 | x |
 | local_dataflow.rb:87:25:87:25 | x | local_dataflow.rb:87:29:87:29 | x |
@@ -2569,42 +2985,50 @@
 | local_dataflow.rb:92:1:109:3 | self (and_or) | local_dataflow.rb:93:7:93:15 | self |
 | local_dataflow.rb:92:1:109:3 | self in and_or | local_dataflow.rb:92:1:109:3 | self (and_or) |
 | local_dataflow.rb:93:3:93:3 | a | local_dataflow.rb:94:8:94:8 | a |
+| local_dataflow.rb:93:7:93:15 | [input] SSA phi read(self) | local_dataflow.rb:93:7:93:28 | SSA phi read(self) |
 | local_dataflow.rb:93:7:93:15 | [post] self | local_dataflow.rb:93:20:93:28 | self |
 | local_dataflow.rb:93:7:93:15 | call to source | local_dataflow.rb:93:7:93:28 | ... \|\| ... |
 | local_dataflow.rb:93:7:93:15 | self | local_dataflow.rb:93:20:93:28 | self |
 | local_dataflow.rb:93:7:93:28 | ... \|\| ... | local_dataflow.rb:93:3:93:3 | a |
 | local_dataflow.rb:93:7:93:28 | ... \|\| ... | local_dataflow.rb:93:3:93:28 | ... = ... |
 | local_dataflow.rb:93:7:93:28 | SSA phi read(self) | local_dataflow.rb:94:3:94:9 | self |
+| local_dataflow.rb:93:20:93:28 | [input] SSA phi read(self) | local_dataflow.rb:93:7:93:28 | SSA phi read(self) |
 | local_dataflow.rb:93:20:93:28 | call to source | local_dataflow.rb:93:7:93:28 | ... \|\| ... |
 | local_dataflow.rb:94:3:94:9 | [post] self | local_dataflow.rb:95:8:95:16 | self |
 | local_dataflow.rb:94:3:94:9 | self | local_dataflow.rb:95:8:95:16 | self |
 | local_dataflow.rb:95:3:95:3 | b | local_dataflow.rb:96:8:96:8 | b |
 | local_dataflow.rb:95:7:95:30 | ( ... ) | local_dataflow.rb:95:3:95:3 | b |
 | local_dataflow.rb:95:7:95:30 | ( ... ) | local_dataflow.rb:95:3:95:30 | ... = ... |
+| local_dataflow.rb:95:8:95:16 | [input] SSA phi read(self) | local_dataflow.rb:95:8:95:29 | SSA phi read(self) |
 | local_dataflow.rb:95:8:95:16 | [post] self | local_dataflow.rb:95:21:95:29 | self |
 | local_dataflow.rb:95:8:95:16 | call to source | local_dataflow.rb:95:8:95:29 | ... or ... |
 | local_dataflow.rb:95:8:95:16 | self | local_dataflow.rb:95:21:95:29 | self |
 | local_dataflow.rb:95:8:95:29 | ... or ... | local_dataflow.rb:95:7:95:30 | ( ... ) |
 | local_dataflow.rb:95:8:95:29 | SSA phi read(self) | local_dataflow.rb:96:3:96:9 | self |
+| local_dataflow.rb:95:21:95:29 | [input] SSA phi read(self) | local_dataflow.rb:95:8:95:29 | SSA phi read(self) |
 | local_dataflow.rb:95:21:95:29 | call to source | local_dataflow.rb:95:8:95:29 | ... or ... |
 | local_dataflow.rb:96:3:96:9 | [post] self | local_dataflow.rb:98:7:98:15 | self |
 | local_dataflow.rb:96:3:96:9 | self | local_dataflow.rb:98:7:98:15 | self |
 | local_dataflow.rb:98:3:98:3 | a | local_dataflow.rb:99:8:99:8 | a |
+| local_dataflow.rb:98:7:98:15 | [input] SSA phi read(self) | local_dataflow.rb:98:7:98:28 | SSA phi read(self) |
 | local_dataflow.rb:98:7:98:15 | [post] self | local_dataflow.rb:98:20:98:28 | self |
 | local_dataflow.rb:98:7:98:15 | self | local_dataflow.rb:98:20:98:28 | self |
 | local_dataflow.rb:98:7:98:28 | ... && ... | local_dataflow.rb:98:3:98:3 | a |
 | local_dataflow.rb:98:7:98:28 | ... && ... | local_dataflow.rb:98:3:98:28 | ... = ... |
 | local_dataflow.rb:98:7:98:28 | SSA phi read(self) | local_dataflow.rb:99:3:99:9 | self |
+| local_dataflow.rb:98:20:98:28 | [input] SSA phi read(self) | local_dataflow.rb:98:7:98:28 | SSA phi read(self) |
 | local_dataflow.rb:98:20:98:28 | call to source | local_dataflow.rb:98:7:98:28 | ... && ... |
 | local_dataflow.rb:99:3:99:9 | [post] self | local_dataflow.rb:100:8:100:16 | self |
 | local_dataflow.rb:99:3:99:9 | self | local_dataflow.rb:100:8:100:16 | self |
 | local_dataflow.rb:100:3:100:3 | b | local_dataflow.rb:101:8:101:8 | b |
 | local_dataflow.rb:100:7:100:31 | ( ... ) | local_dataflow.rb:100:3:100:3 | b |
 | local_dataflow.rb:100:7:100:31 | ( ... ) | local_dataflow.rb:100:3:100:31 | ... = ... |
+| local_dataflow.rb:100:8:100:16 | [input] SSA phi read(self) | local_dataflow.rb:100:8:100:30 | SSA phi read(self) |
 | local_dataflow.rb:100:8:100:16 | [post] self | local_dataflow.rb:100:22:100:30 | self |
 | local_dataflow.rb:100:8:100:16 | self | local_dataflow.rb:100:22:100:30 | self |
 | local_dataflow.rb:100:8:100:30 | ... and ... | local_dataflow.rb:100:7:100:31 | ( ... ) |
 | local_dataflow.rb:100:8:100:30 | SSA phi read(self) | local_dataflow.rb:101:3:101:9 | self |
+| local_dataflow.rb:100:22:100:30 | [input] SSA phi read(self) | local_dataflow.rb:100:8:100:30 | SSA phi read(self) |
 | local_dataflow.rb:100:22:100:30 | call to source | local_dataflow.rb:100:8:100:30 | ... and ... |
 | local_dataflow.rb:101:3:101:9 | [post] self | local_dataflow.rb:103:7:103:15 | self |
 | local_dataflow.rb:101:3:101:9 | self | local_dataflow.rb:103:7:103:15 | self |
@@ -2613,11 +3037,13 @@
 | local_dataflow.rb:103:7:103:15 | call to source | local_dataflow.rb:103:3:103:3 | a |
 | local_dataflow.rb:103:7:103:15 | call to source | local_dataflow.rb:103:3:103:15 | ... = ... |
 | local_dataflow.rb:103:7:103:15 | self | local_dataflow.rb:104:9:104:17 | self |
+| local_dataflow.rb:104:3:104:3 | [input] SSA phi read(self) | local_dataflow.rb:104:5:104:7 | SSA phi read(self) |
 | local_dataflow.rb:104:3:104:3 | a | local_dataflow.rb:104:5:104:7 | ... \|\| ... |
 | local_dataflow.rb:104:3:104:3 | a | local_dataflow.rb:105:8:105:8 | a |
 | local_dataflow.rb:104:5:104:7 | ... \|\| ... | local_dataflow.rb:104:3:104:3 | a |
 | local_dataflow.rb:104:5:104:7 | ... \|\| ... | local_dataflow.rb:104:3:104:17 | ... = ... |
 | local_dataflow.rb:104:5:104:7 | SSA phi read(self) | local_dataflow.rb:105:3:105:9 | self |
+| local_dataflow.rb:104:9:104:17 | [input] SSA phi read(self) | local_dataflow.rb:104:5:104:7 | SSA phi read(self) |
 | local_dataflow.rb:104:9:104:17 | call to source | local_dataflow.rb:104:5:104:7 | ... \|\| ... |
 | local_dataflow.rb:105:3:105:9 | [post] self | local_dataflow.rb:106:7:106:15 | self |
 | local_dataflow.rb:105:3:105:9 | self | local_dataflow.rb:106:7:106:15 | self |
@@ -2626,10 +3052,12 @@
 | local_dataflow.rb:106:7:106:15 | call to source | local_dataflow.rb:106:3:106:3 | b |
 | local_dataflow.rb:106:7:106:15 | call to source | local_dataflow.rb:106:3:106:15 | ... = ... |
 | local_dataflow.rb:106:7:106:15 | self | local_dataflow.rb:107:9:107:17 | self |
+| local_dataflow.rb:107:3:107:3 | [input] SSA phi read(self) | local_dataflow.rb:107:5:107:7 | SSA phi read(self) |
 | local_dataflow.rb:107:3:107:3 | b | local_dataflow.rb:108:8:108:8 | b |
 | local_dataflow.rb:107:5:107:7 | ... && ... | local_dataflow.rb:107:3:107:3 | b |
 | local_dataflow.rb:107:5:107:7 | ... && ... | local_dataflow.rb:107:3:107:17 | ... = ... |
 | local_dataflow.rb:107:5:107:7 | SSA phi read(self) | local_dataflow.rb:108:3:108:9 | self |
+| local_dataflow.rb:107:9:107:17 | [input] SSA phi read(self) | local_dataflow.rb:107:5:107:7 | SSA phi read(self) |
 | local_dataflow.rb:107:9:107:17 | call to source | local_dataflow.rb:107:5:107:7 | ... && ... |
 | local_dataflow.rb:111:1:114:3 | self (object_dup) | local_dataflow.rb:112:3:112:21 | self |
 | local_dataflow.rb:111:1:114:3 | self in object_dup | local_dataflow.rb:111:1:114:3 | self (object_dup) |
@@ -2681,6 +3109,8 @@
 | local_dataflow.rb:132:12:148:10 | then ... | local_dataflow.rb:132:3:149:5 | if ... |
 | local_dataflow.rb:133:5:139:7 | SSA phi read(self) | local_dataflow.rb:141:9:141:14 | self |
 | local_dataflow.rb:133:5:139:7 | SSA phi read(x) | local_dataflow.rb:141:13:141:13 | x |
+| local_dataflow.rb:133:8:133:13 | [input] SSA phi read(self) | local_dataflow.rb:133:8:133:23 | SSA phi read(self) |
+| local_dataflow.rb:133:8:133:13 | [input] SSA phi read(x) | local_dataflow.rb:133:8:133:23 | SSA phi read(x) |
 | local_dataflow.rb:133:8:133:13 | [post] self | local_dataflow.rb:133:18:133:23 | self |
 | local_dataflow.rb:133:8:133:13 | call to use | local_dataflow.rb:133:8:133:23 | [false] ... \|\| ... |
 | local_dataflow.rb:133:8:133:13 | call to use | local_dataflow.rb:133:8:133:23 | [true] ... \|\| ... |
@@ -2689,43 +3119,63 @@
 | local_dataflow.rb:133:8:133:23 | SSA phi read(x) | local_dataflow.rb:134:11:134:11 | x |
 | local_dataflow.rb:133:12:133:12 | [post] x | local_dataflow.rb:133:22:133:22 | x |
 | local_dataflow.rb:133:12:133:12 | x | local_dataflow.rb:133:22:133:22 | x |
+| local_dataflow.rb:133:18:133:23 | [input] SSA phi read(self) | local_dataflow.rb:133:8:133:23 | SSA phi read(self) |
+| local_dataflow.rb:133:18:133:23 | [input] SSA phi read(x) | local_dataflow.rb:133:8:133:23 | SSA phi read(x) |
 | local_dataflow.rb:133:18:133:23 | [post] self | local_dataflow.rb:136:7:136:12 | self |
 | local_dataflow.rb:133:18:133:23 | call to use | local_dataflow.rb:133:8:133:23 | [false] ... \|\| ... |
 | local_dataflow.rb:133:18:133:23 | call to use | local_dataflow.rb:133:8:133:23 | [true] ... \|\| ... |
 | local_dataflow.rb:133:18:133:23 | self | local_dataflow.rb:136:7:136:12 | self |
 | local_dataflow.rb:133:22:133:22 | [post] x | local_dataflow.rb:136:11:136:11 | x |
 | local_dataflow.rb:133:22:133:22 | x | local_dataflow.rb:136:11:136:11 | x |
+| local_dataflow.rb:133:24:134:12 | [input] SSA phi read(self) | local_dataflow.rb:133:5:139:7 | SSA phi read(self) |
+| local_dataflow.rb:133:24:134:12 | [input] SSA phi read(x) | local_dataflow.rb:133:5:139:7 | SSA phi read(x) |
 | local_dataflow.rb:133:24:134:12 | then ... | local_dataflow.rb:133:5:139:7 | if ... |
 | local_dataflow.rb:134:7:134:12 | call to use | local_dataflow.rb:133:24:134:12 | then ... |
+| local_dataflow.rb:135:5:138:9 | [input] SSA phi read(self) | local_dataflow.rb:133:5:139:7 | SSA phi read(self) |
+| local_dataflow.rb:135:5:138:9 | [input] SSA phi read(x) | local_dataflow.rb:133:5:139:7 | SSA phi read(x) |
 | local_dataflow.rb:135:5:138:9 | else ... | local_dataflow.rb:133:5:139:7 | if ... |
 | local_dataflow.rb:136:7:136:12 | [post] self | local_dataflow.rb:137:10:137:15 | self |
 | local_dataflow.rb:136:7:136:12 | self | local_dataflow.rb:137:10:137:15 | self |
 | local_dataflow.rb:136:11:136:11 | [post] x | local_dataflow.rb:137:14:137:14 | x |
 | local_dataflow.rb:136:11:136:11 | x | local_dataflow.rb:137:14:137:14 | x |
-| local_dataflow.rb:137:7:138:9 | SSA phi read(self) | local_dataflow.rb:133:5:139:7 | SSA phi read(self) |
-| local_dataflow.rb:137:7:138:9 | SSA phi read(x) | local_dataflow.rb:133:5:139:7 | SSA phi read(x) |
+| local_dataflow.rb:137:7:138:9 | SSA phi read(self) | local_dataflow.rb:135:5:138:9 | [input] SSA phi read(self) |
+| local_dataflow.rb:137:7:138:9 | SSA phi read(x) | local_dataflow.rb:135:5:138:9 | [input] SSA phi read(x) |
 | local_dataflow.rb:137:7:138:9 | if ... | local_dataflow.rb:135:5:138:9 | else ... |
+| local_dataflow.rb:137:10:137:15 | [input] SSA phi read(self) | local_dataflow.rb:137:10:137:26 | SSA phi read(self) |
+| local_dataflow.rb:137:10:137:15 | [input] SSA phi read(x) | local_dataflow.rb:137:10:137:26 | SSA phi read(x) |
 | local_dataflow.rb:137:10:137:15 | [post] self | local_dataflow.rb:137:21:137:26 | self |
 | local_dataflow.rb:137:10:137:15 | self | local_dataflow.rb:137:21:137:26 | self |
-| local_dataflow.rb:137:10:137:26 | SSA phi read(self) | local_dataflow.rb:137:7:138:9 | SSA phi read(self) |
-| local_dataflow.rb:137:10:137:26 | SSA phi read(x) | local_dataflow.rb:137:7:138:9 | SSA phi read(x) |
+| local_dataflow.rb:137:10:137:26 | SSA phi read(self) | local_dataflow.rb:137:10:137:26 | [input] SSA phi read(self) |
+| local_dataflow.rb:137:10:137:26 | SSA phi read(x) | local_dataflow.rb:137:10:137:26 | [input] SSA phi read(x) |
+| local_dataflow.rb:137:10:137:26 | [input] SSA phi read(self) | local_dataflow.rb:137:7:138:9 | SSA phi read(self) |
+| local_dataflow.rb:137:10:137:26 | [input] SSA phi read(self) | local_dataflow.rb:137:7:138:9 | SSA phi read(self) |
+| local_dataflow.rb:137:10:137:26 | [input] SSA phi read(x) | local_dataflow.rb:137:7:138:9 | SSA phi read(x) |
+| local_dataflow.rb:137:10:137:26 | [input] SSA phi read(x) | local_dataflow.rb:137:7:138:9 | SSA phi read(x) |
 | local_dataflow.rb:137:14:137:14 | [post] x | local_dataflow.rb:137:25:137:25 | x |
 | local_dataflow.rb:137:14:137:14 | x | local_dataflow.rb:137:25:137:25 | x |
 | local_dataflow.rb:137:20:137:26 | [false] ! ... | local_dataflow.rb:137:10:137:26 | [false] ... && ... |
+| local_dataflow.rb:137:20:137:26 | [input] SSA phi read(self) | local_dataflow.rb:137:10:137:26 | SSA phi read(self) |
+| local_dataflow.rb:137:20:137:26 | [input] SSA phi read(x) | local_dataflow.rb:137:10:137:26 | SSA phi read(x) |
 | local_dataflow.rb:137:20:137:26 | [true] ! ... | local_dataflow.rb:137:10:137:26 | [true] ... && ... |
 | local_dataflow.rb:141:5:145:7 | SSA phi read(self) | local_dataflow.rb:147:5:147:10 | self |
 | local_dataflow.rb:141:5:145:7 | SSA phi read(x) | local_dataflow.rb:147:9:147:9 | x |
 | local_dataflow.rb:141:8:141:14 | [false] ! ... | local_dataflow.rb:141:8:141:37 | [false] ... \|\| ... |
 | local_dataflow.rb:141:8:141:14 | [false] ! ... | local_dataflow.rb:141:8:141:37 | [true] ... \|\| ... |
+| local_dataflow.rb:141:8:141:14 | [input] SSA phi read(self) | local_dataflow.rb:141:8:141:37 | SSA phi read(self) |
+| local_dataflow.rb:141:8:141:14 | [input] SSA phi read(x) | local_dataflow.rb:141:8:141:37 | SSA phi read(x) |
 | local_dataflow.rb:141:8:141:14 | [true] ! ... | local_dataflow.rb:141:8:141:37 | [true] ... \|\| ... |
-| local_dataflow.rb:141:8:141:37 | SSA phi read(self) | local_dataflow.rb:141:5:145:7 | SSA phi read(self) |
-| local_dataflow.rb:141:8:141:37 | SSA phi read(x) | local_dataflow.rb:141:5:145:7 | SSA phi read(x) |
+| local_dataflow.rb:141:8:141:37 | SSA phi read(self) | local_dataflow.rb:141:38:142:9 | [input] SSA phi read(self) |
+| local_dataflow.rb:141:8:141:37 | SSA phi read(x) | local_dataflow.rb:141:38:142:9 | [input] SSA phi read(x) |
 | local_dataflow.rb:141:9:141:14 | [post] self | local_dataflow.rb:141:20:141:25 | self |
 | local_dataflow.rb:141:9:141:14 | self | local_dataflow.rb:141:20:141:25 | self |
 | local_dataflow.rb:141:13:141:13 | [post] x | local_dataflow.rb:141:24:141:24 | x |
 | local_dataflow.rb:141:13:141:13 | x | local_dataflow.rb:141:24:141:24 | x |
 | local_dataflow.rb:141:19:141:37 | [false] ( ... ) | local_dataflow.rb:141:8:141:37 | [false] ... \|\| ... |
+| local_dataflow.rb:141:19:141:37 | [input] SSA phi read(self) | local_dataflow.rb:141:8:141:37 | SSA phi read(self) |
+| local_dataflow.rb:141:19:141:37 | [input] SSA phi read(x) | local_dataflow.rb:141:8:141:37 | SSA phi read(x) |
 | local_dataflow.rb:141:19:141:37 | [true] ( ... ) | local_dataflow.rb:141:8:141:37 | [true] ... \|\| ... |
+| local_dataflow.rb:141:20:141:25 | [input] SSA phi read(self) | local_dataflow.rb:141:20:141:36 | SSA phi read(self) |
+| local_dataflow.rb:141:20:141:25 | [input] SSA phi read(x) | local_dataflow.rb:141:20:141:36 | SSA phi read(x) |
 | local_dataflow.rb:141:20:141:25 | [post] self | local_dataflow.rb:141:31:141:36 | self |
 | local_dataflow.rb:141:20:141:25 | self | local_dataflow.rb:141:31:141:36 | self |
 | local_dataflow.rb:141:20:141:36 | SSA phi read(self) | local_dataflow.rb:143:11:143:16 | self |
@@ -2735,22 +3185,36 @@
 | local_dataflow.rb:141:24:141:24 | [post] x | local_dataflow.rb:141:35:141:35 | x |
 | local_dataflow.rb:141:24:141:24 | x | local_dataflow.rb:141:35:141:35 | x |
 | local_dataflow.rb:141:30:141:36 | [false] ! ... | local_dataflow.rb:141:20:141:36 | [false] ... && ... |
+| local_dataflow.rb:141:30:141:36 | [input] SSA phi read(self) | local_dataflow.rb:141:20:141:36 | SSA phi read(self) |
+| local_dataflow.rb:141:30:141:36 | [input] SSA phi read(x) | local_dataflow.rb:141:20:141:36 | SSA phi read(x) |
 | local_dataflow.rb:141:30:141:36 | [true] ! ... | local_dataflow.rb:141:20:141:36 | [true] ... && ... |
+| local_dataflow.rb:141:38:142:9 | [input] SSA phi read(self) | local_dataflow.rb:141:5:145:7 | SSA phi read(self) |
+| local_dataflow.rb:141:38:142:9 | [input] SSA phi read(x) | local_dataflow.rb:141:5:145:7 | SSA phi read(x) |
 | local_dataflow.rb:141:38:142:9 | then ... | local_dataflow.rb:141:5:145:7 | if ... |
 | local_dataflow.rb:142:7:142:9 | nil | local_dataflow.rb:141:38:142:9 | then ... |
-| local_dataflow.rb:143:5:144:16 | SSA phi read(self) | local_dataflow.rb:141:5:145:7 | SSA phi read(self) |
-| local_dataflow.rb:143:5:144:16 | SSA phi read(x) | local_dataflow.rb:141:5:145:7 | SSA phi read(x) |
+| local_dataflow.rb:143:5:144:16 | SSA phi read(self) | local_dataflow.rb:143:5:144:16 | [input] SSA phi read(self) |
+| local_dataflow.rb:143:5:144:16 | SSA phi read(x) | local_dataflow.rb:143:5:144:16 | [input] SSA phi read(x) |
+| local_dataflow.rb:143:5:144:16 | [input] SSA phi read(self) | local_dataflow.rb:141:5:145:7 | SSA phi read(self) |
+| local_dataflow.rb:143:5:144:16 | [input] SSA phi read(x) | local_dataflow.rb:141:5:145:7 | SSA phi read(x) |
 | local_dataflow.rb:143:5:144:16 | elsif ... | local_dataflow.rb:141:5:145:7 | if ... |
+| local_dataflow.rb:143:11:143:16 | [input] SSA phi read(self) | local_dataflow.rb:143:11:143:26 | SSA phi read(self) |
+| local_dataflow.rb:143:11:143:16 | [input] SSA phi read(x) | local_dataflow.rb:143:11:143:26 | SSA phi read(x) |
 | local_dataflow.rb:143:11:143:16 | [post] self | local_dataflow.rb:143:21:143:26 | self |
 | local_dataflow.rb:143:11:143:16 | call to use | local_dataflow.rb:143:11:143:26 | [false] ... \|\| ... |
 | local_dataflow.rb:143:11:143:16 | call to use | local_dataflow.rb:143:11:143:26 | [true] ... \|\| ... |
 | local_dataflow.rb:143:11:143:16 | self | local_dataflow.rb:143:21:143:26 | self |
 | local_dataflow.rb:143:11:143:26 | SSA phi read(self) | local_dataflow.rb:144:11:144:16 | self |
 | local_dataflow.rb:143:11:143:26 | SSA phi read(x) | local_dataflow.rb:144:15:144:15 | x |
+| local_dataflow.rb:143:11:143:26 | [input] SSA phi read(self) | local_dataflow.rb:143:5:144:16 | SSA phi read(self) |
+| local_dataflow.rb:143:11:143:26 | [input] SSA phi read(x) | local_dataflow.rb:143:5:144:16 | SSA phi read(x) |
 | local_dataflow.rb:143:15:143:15 | [post] x | local_dataflow.rb:143:25:143:25 | x |
 | local_dataflow.rb:143:15:143:15 | x | local_dataflow.rb:143:25:143:25 | x |
+| local_dataflow.rb:143:21:143:26 | [input] SSA phi read(self) | local_dataflow.rb:143:11:143:26 | SSA phi read(self) |
+| local_dataflow.rb:143:21:143:26 | [input] SSA phi read(x) | local_dataflow.rb:143:11:143:26 | SSA phi read(x) |
 | local_dataflow.rb:143:21:143:26 | call to use | local_dataflow.rb:143:11:143:26 | [false] ... \|\| ... |
 | local_dataflow.rb:143:21:143:26 | call to use | local_dataflow.rb:143:11:143:26 | [true] ... \|\| ... |
+| local_dataflow.rb:143:27:144:16 | [input] SSA phi read(self) | local_dataflow.rb:143:5:144:16 | SSA phi read(self) |
+| local_dataflow.rb:143:27:144:16 | [input] SSA phi read(x) | local_dataflow.rb:143:5:144:16 | SSA phi read(x) |
 | local_dataflow.rb:143:27:144:16 | then ... | local_dataflow.rb:143:5:144:16 | elsif ... |
 | local_dataflow.rb:144:11:144:16 | call to use | local_dataflow.rb:143:27:144:16 | then ... |
 | local_dataflow.rb:147:5:147:10 | [post] self | local_dataflow.rb:148:5:148:10 | self |

--- a/ruby/ql/test/library-tests/dataflow/local/TaintStep.expected
+++ b/ruby/ql/test/library-tests/dataflow/local/TaintStep.expected
@@ -1,6 +1,6 @@
 | UseUseExplosion.rb:18:5:22:7 | self (m) | UseUseExplosion.rb:20:13:20:17 | self |
 | UseUseExplosion.rb:18:5:22:7 | self in m | UseUseExplosion.rb:18:5:22:7 | self (m) |
-| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2081:20:2116 | SSA phi read(x) |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2096:20:2099 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2111:20:2111 | x |
 | UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2127:20:2127 | x |
 | UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2143:20:2143 | x |
@@ -212,9 +212,11 @@
 | UseUseExplosion.rb:20:13:20:23 | ... > ... | UseUseExplosion.rb:20:12:20:24 | [false] ( ... ) |
 | UseUseExplosion.rb:20:13:20:23 | ... > ... | UseUseExplosion.rb:20:12:20:24 | [true] ( ... ) |
 | UseUseExplosion.rb:20:21:20:23 | 100 | UseUseExplosion.rb:20:13:20:23 | ... > ... |
+| UseUseExplosion.rb:20:26:20:3684 | [input] SSA phi read(self) | UseUseExplosion.rb:20:9:20:3700 | SSA phi read(self) |
+| UseUseExplosion.rb:20:26:20:3684 | [input] SSA phi read(x) | UseUseExplosion.rb:20:9:20:3700 | SSA phi read(x) |
 | UseUseExplosion.rb:20:26:20:3684 | then ... | UseUseExplosion.rb:20:9:20:3700 | if ... |
-| UseUseExplosion.rb:20:31:20:3684 | SSA phi read(self) | UseUseExplosion.rb:20:9:20:3700 | SSA phi read(self) |
-| UseUseExplosion.rb:20:31:20:3684 | SSA phi read(x) | UseUseExplosion.rb:20:9:20:3700 | SSA phi read(x) |
+| UseUseExplosion.rb:20:31:20:3684 | SSA phi read(self) | UseUseExplosion.rb:20:26:20:3684 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:31:20:3684 | SSA phi read(x) | UseUseExplosion.rb:20:26:20:3684 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:31:20:3684 | if ... | UseUseExplosion.rb:20:26:20:3684 | then ... |
 | UseUseExplosion.rb:20:35:20:39 | @prop | UseUseExplosion.rb:20:35:20:44 | ... > ... |
 | UseUseExplosion.rb:20:35:20:39 | [post] self | UseUseExplosion.rb:20:56:20:60 | self |
@@ -224,9 +226,11 @@
 | UseUseExplosion.rb:20:35:20:44 | ... > ... | UseUseExplosion.rb:20:34:20:45 | [false] ( ... ) |
 | UseUseExplosion.rb:20:35:20:44 | ... > ... | UseUseExplosion.rb:20:34:20:45 | [true] ( ... ) |
 | UseUseExplosion.rb:20:43:20:44 | 99 | UseUseExplosion.rb:20:35:20:44 | ... > ... |
+| UseUseExplosion.rb:20:47:20:3668 | [input] SSA phi read(self) | UseUseExplosion.rb:20:31:20:3684 | SSA phi read(self) |
+| UseUseExplosion.rb:20:47:20:3668 | [input] SSA phi read(x) | UseUseExplosion.rb:20:31:20:3684 | SSA phi read(x) |
 | UseUseExplosion.rb:20:47:20:3668 | then ... | UseUseExplosion.rb:20:31:20:3684 | if ... |
-| UseUseExplosion.rb:20:52:20:3668 | SSA phi read(self) | UseUseExplosion.rb:20:31:20:3684 | SSA phi read(self) |
-| UseUseExplosion.rb:20:52:20:3668 | SSA phi read(x) | UseUseExplosion.rb:20:31:20:3684 | SSA phi read(x) |
+| UseUseExplosion.rb:20:52:20:3668 | SSA phi read(self) | UseUseExplosion.rb:20:47:20:3668 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:52:20:3668 | SSA phi read(x) | UseUseExplosion.rb:20:47:20:3668 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:52:20:3668 | if ... | UseUseExplosion.rb:20:47:20:3668 | then ... |
 | UseUseExplosion.rb:20:56:20:60 | @prop | UseUseExplosion.rb:20:56:20:65 | ... > ... |
 | UseUseExplosion.rb:20:56:20:60 | [post] self | UseUseExplosion.rb:20:77:20:81 | self |
@@ -236,9 +240,11 @@
 | UseUseExplosion.rb:20:56:20:65 | ... > ... | UseUseExplosion.rb:20:55:20:66 | [false] ( ... ) |
 | UseUseExplosion.rb:20:56:20:65 | ... > ... | UseUseExplosion.rb:20:55:20:66 | [true] ( ... ) |
 | UseUseExplosion.rb:20:64:20:65 | 98 | UseUseExplosion.rb:20:56:20:65 | ... > ... |
+| UseUseExplosion.rb:20:68:20:3652 | [input] SSA phi read(self) | UseUseExplosion.rb:20:52:20:3668 | SSA phi read(self) |
+| UseUseExplosion.rb:20:68:20:3652 | [input] SSA phi read(x) | UseUseExplosion.rb:20:52:20:3668 | SSA phi read(x) |
 | UseUseExplosion.rb:20:68:20:3652 | then ... | UseUseExplosion.rb:20:52:20:3668 | if ... |
-| UseUseExplosion.rb:20:73:20:3652 | SSA phi read(self) | UseUseExplosion.rb:20:52:20:3668 | SSA phi read(self) |
-| UseUseExplosion.rb:20:73:20:3652 | SSA phi read(x) | UseUseExplosion.rb:20:52:20:3668 | SSA phi read(x) |
+| UseUseExplosion.rb:20:73:20:3652 | SSA phi read(self) | UseUseExplosion.rb:20:68:20:3652 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:73:20:3652 | SSA phi read(x) | UseUseExplosion.rb:20:68:20:3652 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:73:20:3652 | if ... | UseUseExplosion.rb:20:68:20:3652 | then ... |
 | UseUseExplosion.rb:20:77:20:81 | @prop | UseUseExplosion.rb:20:77:20:86 | ... > ... |
 | UseUseExplosion.rb:20:77:20:81 | [post] self | UseUseExplosion.rb:20:98:20:102 | self |
@@ -248,9 +254,11 @@
 | UseUseExplosion.rb:20:77:20:86 | ... > ... | UseUseExplosion.rb:20:76:20:87 | [false] ( ... ) |
 | UseUseExplosion.rb:20:77:20:86 | ... > ... | UseUseExplosion.rb:20:76:20:87 | [true] ( ... ) |
 | UseUseExplosion.rb:20:85:20:86 | 97 | UseUseExplosion.rb:20:77:20:86 | ... > ... |
+| UseUseExplosion.rb:20:89:20:3636 | [input] SSA phi read(self) | UseUseExplosion.rb:20:73:20:3652 | SSA phi read(self) |
+| UseUseExplosion.rb:20:89:20:3636 | [input] SSA phi read(x) | UseUseExplosion.rb:20:73:20:3652 | SSA phi read(x) |
 | UseUseExplosion.rb:20:89:20:3636 | then ... | UseUseExplosion.rb:20:73:20:3652 | if ... |
-| UseUseExplosion.rb:20:94:20:3636 | SSA phi read(self) | UseUseExplosion.rb:20:73:20:3652 | SSA phi read(self) |
-| UseUseExplosion.rb:20:94:20:3636 | SSA phi read(x) | UseUseExplosion.rb:20:73:20:3652 | SSA phi read(x) |
+| UseUseExplosion.rb:20:94:20:3636 | SSA phi read(self) | UseUseExplosion.rb:20:89:20:3636 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:94:20:3636 | SSA phi read(x) | UseUseExplosion.rb:20:89:20:3636 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:94:20:3636 | if ... | UseUseExplosion.rb:20:89:20:3636 | then ... |
 | UseUseExplosion.rb:20:98:20:102 | @prop | UseUseExplosion.rb:20:98:20:107 | ... > ... |
 | UseUseExplosion.rb:20:98:20:102 | [post] self | UseUseExplosion.rb:20:119:20:123 | self |
@@ -260,9 +268,11 @@
 | UseUseExplosion.rb:20:98:20:107 | ... > ... | UseUseExplosion.rb:20:97:20:108 | [false] ( ... ) |
 | UseUseExplosion.rb:20:98:20:107 | ... > ... | UseUseExplosion.rb:20:97:20:108 | [true] ( ... ) |
 | UseUseExplosion.rb:20:106:20:107 | 96 | UseUseExplosion.rb:20:98:20:107 | ... > ... |
+| UseUseExplosion.rb:20:110:20:3620 | [input] SSA phi read(self) | UseUseExplosion.rb:20:94:20:3636 | SSA phi read(self) |
+| UseUseExplosion.rb:20:110:20:3620 | [input] SSA phi read(x) | UseUseExplosion.rb:20:94:20:3636 | SSA phi read(x) |
 | UseUseExplosion.rb:20:110:20:3620 | then ... | UseUseExplosion.rb:20:94:20:3636 | if ... |
-| UseUseExplosion.rb:20:115:20:3620 | SSA phi read(self) | UseUseExplosion.rb:20:94:20:3636 | SSA phi read(self) |
-| UseUseExplosion.rb:20:115:20:3620 | SSA phi read(x) | UseUseExplosion.rb:20:94:20:3636 | SSA phi read(x) |
+| UseUseExplosion.rb:20:115:20:3620 | SSA phi read(self) | UseUseExplosion.rb:20:110:20:3620 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:115:20:3620 | SSA phi read(x) | UseUseExplosion.rb:20:110:20:3620 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:115:20:3620 | if ... | UseUseExplosion.rb:20:110:20:3620 | then ... |
 | UseUseExplosion.rb:20:119:20:123 | @prop | UseUseExplosion.rb:20:119:20:128 | ... > ... |
 | UseUseExplosion.rb:20:119:20:123 | [post] self | UseUseExplosion.rb:20:140:20:144 | self |
@@ -272,9 +282,11 @@
 | UseUseExplosion.rb:20:119:20:128 | ... > ... | UseUseExplosion.rb:20:118:20:129 | [false] ( ... ) |
 | UseUseExplosion.rb:20:119:20:128 | ... > ... | UseUseExplosion.rb:20:118:20:129 | [true] ( ... ) |
 | UseUseExplosion.rb:20:127:20:128 | 95 | UseUseExplosion.rb:20:119:20:128 | ... > ... |
+| UseUseExplosion.rb:20:131:20:3604 | [input] SSA phi read(self) | UseUseExplosion.rb:20:115:20:3620 | SSA phi read(self) |
+| UseUseExplosion.rb:20:131:20:3604 | [input] SSA phi read(x) | UseUseExplosion.rb:20:115:20:3620 | SSA phi read(x) |
 | UseUseExplosion.rb:20:131:20:3604 | then ... | UseUseExplosion.rb:20:115:20:3620 | if ... |
-| UseUseExplosion.rb:20:136:20:3604 | SSA phi read(self) | UseUseExplosion.rb:20:115:20:3620 | SSA phi read(self) |
-| UseUseExplosion.rb:20:136:20:3604 | SSA phi read(x) | UseUseExplosion.rb:20:115:20:3620 | SSA phi read(x) |
+| UseUseExplosion.rb:20:136:20:3604 | SSA phi read(self) | UseUseExplosion.rb:20:131:20:3604 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:136:20:3604 | SSA phi read(x) | UseUseExplosion.rb:20:131:20:3604 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:136:20:3604 | if ... | UseUseExplosion.rb:20:131:20:3604 | then ... |
 | UseUseExplosion.rb:20:140:20:144 | @prop | UseUseExplosion.rb:20:140:20:149 | ... > ... |
 | UseUseExplosion.rb:20:140:20:144 | [post] self | UseUseExplosion.rb:20:161:20:165 | self |
@@ -284,9 +296,11 @@
 | UseUseExplosion.rb:20:140:20:149 | ... > ... | UseUseExplosion.rb:20:139:20:150 | [false] ( ... ) |
 | UseUseExplosion.rb:20:140:20:149 | ... > ... | UseUseExplosion.rb:20:139:20:150 | [true] ( ... ) |
 | UseUseExplosion.rb:20:148:20:149 | 94 | UseUseExplosion.rb:20:140:20:149 | ... > ... |
+| UseUseExplosion.rb:20:152:20:3588 | [input] SSA phi read(self) | UseUseExplosion.rb:20:136:20:3604 | SSA phi read(self) |
+| UseUseExplosion.rb:20:152:20:3588 | [input] SSA phi read(x) | UseUseExplosion.rb:20:136:20:3604 | SSA phi read(x) |
 | UseUseExplosion.rb:20:152:20:3588 | then ... | UseUseExplosion.rb:20:136:20:3604 | if ... |
-| UseUseExplosion.rb:20:157:20:3588 | SSA phi read(self) | UseUseExplosion.rb:20:136:20:3604 | SSA phi read(self) |
-| UseUseExplosion.rb:20:157:20:3588 | SSA phi read(x) | UseUseExplosion.rb:20:136:20:3604 | SSA phi read(x) |
+| UseUseExplosion.rb:20:157:20:3588 | SSA phi read(self) | UseUseExplosion.rb:20:152:20:3588 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:157:20:3588 | SSA phi read(x) | UseUseExplosion.rb:20:152:20:3588 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:157:20:3588 | if ... | UseUseExplosion.rb:20:152:20:3588 | then ... |
 | UseUseExplosion.rb:20:161:20:165 | @prop | UseUseExplosion.rb:20:161:20:170 | ... > ... |
 | UseUseExplosion.rb:20:161:20:165 | [post] self | UseUseExplosion.rb:20:182:20:186 | self |
@@ -296,9 +310,11 @@
 | UseUseExplosion.rb:20:161:20:170 | ... > ... | UseUseExplosion.rb:20:160:20:171 | [false] ( ... ) |
 | UseUseExplosion.rb:20:161:20:170 | ... > ... | UseUseExplosion.rb:20:160:20:171 | [true] ( ... ) |
 | UseUseExplosion.rb:20:169:20:170 | 93 | UseUseExplosion.rb:20:161:20:170 | ... > ... |
+| UseUseExplosion.rb:20:173:20:3572 | [input] SSA phi read(self) | UseUseExplosion.rb:20:157:20:3588 | SSA phi read(self) |
+| UseUseExplosion.rb:20:173:20:3572 | [input] SSA phi read(x) | UseUseExplosion.rb:20:157:20:3588 | SSA phi read(x) |
 | UseUseExplosion.rb:20:173:20:3572 | then ... | UseUseExplosion.rb:20:157:20:3588 | if ... |
-| UseUseExplosion.rb:20:178:20:3572 | SSA phi read(self) | UseUseExplosion.rb:20:157:20:3588 | SSA phi read(self) |
-| UseUseExplosion.rb:20:178:20:3572 | SSA phi read(x) | UseUseExplosion.rb:20:157:20:3588 | SSA phi read(x) |
+| UseUseExplosion.rb:20:178:20:3572 | SSA phi read(self) | UseUseExplosion.rb:20:173:20:3572 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:178:20:3572 | SSA phi read(x) | UseUseExplosion.rb:20:173:20:3572 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:178:20:3572 | if ... | UseUseExplosion.rb:20:173:20:3572 | then ... |
 | UseUseExplosion.rb:20:182:20:186 | @prop | UseUseExplosion.rb:20:182:20:191 | ... > ... |
 | UseUseExplosion.rb:20:182:20:186 | [post] self | UseUseExplosion.rb:20:203:20:207 | self |
@@ -308,9 +324,11 @@
 | UseUseExplosion.rb:20:182:20:191 | ... > ... | UseUseExplosion.rb:20:181:20:192 | [false] ( ... ) |
 | UseUseExplosion.rb:20:182:20:191 | ... > ... | UseUseExplosion.rb:20:181:20:192 | [true] ( ... ) |
 | UseUseExplosion.rb:20:190:20:191 | 92 | UseUseExplosion.rb:20:182:20:191 | ... > ... |
+| UseUseExplosion.rb:20:194:20:3556 | [input] SSA phi read(self) | UseUseExplosion.rb:20:178:20:3572 | SSA phi read(self) |
+| UseUseExplosion.rb:20:194:20:3556 | [input] SSA phi read(x) | UseUseExplosion.rb:20:178:20:3572 | SSA phi read(x) |
 | UseUseExplosion.rb:20:194:20:3556 | then ... | UseUseExplosion.rb:20:178:20:3572 | if ... |
-| UseUseExplosion.rb:20:199:20:3556 | SSA phi read(self) | UseUseExplosion.rb:20:178:20:3572 | SSA phi read(self) |
-| UseUseExplosion.rb:20:199:20:3556 | SSA phi read(x) | UseUseExplosion.rb:20:178:20:3572 | SSA phi read(x) |
+| UseUseExplosion.rb:20:199:20:3556 | SSA phi read(self) | UseUseExplosion.rb:20:194:20:3556 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:199:20:3556 | SSA phi read(x) | UseUseExplosion.rb:20:194:20:3556 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:199:20:3556 | if ... | UseUseExplosion.rb:20:194:20:3556 | then ... |
 | UseUseExplosion.rb:20:203:20:207 | @prop | UseUseExplosion.rb:20:203:20:212 | ... > ... |
 | UseUseExplosion.rb:20:203:20:207 | [post] self | UseUseExplosion.rb:20:224:20:228 | self |
@@ -320,9 +338,11 @@
 | UseUseExplosion.rb:20:203:20:212 | ... > ... | UseUseExplosion.rb:20:202:20:213 | [false] ( ... ) |
 | UseUseExplosion.rb:20:203:20:212 | ... > ... | UseUseExplosion.rb:20:202:20:213 | [true] ( ... ) |
 | UseUseExplosion.rb:20:211:20:212 | 91 | UseUseExplosion.rb:20:203:20:212 | ... > ... |
+| UseUseExplosion.rb:20:215:20:3540 | [input] SSA phi read(self) | UseUseExplosion.rb:20:199:20:3556 | SSA phi read(self) |
+| UseUseExplosion.rb:20:215:20:3540 | [input] SSA phi read(x) | UseUseExplosion.rb:20:199:20:3556 | SSA phi read(x) |
 | UseUseExplosion.rb:20:215:20:3540 | then ... | UseUseExplosion.rb:20:199:20:3556 | if ... |
-| UseUseExplosion.rb:20:220:20:3540 | SSA phi read(self) | UseUseExplosion.rb:20:199:20:3556 | SSA phi read(self) |
-| UseUseExplosion.rb:20:220:20:3540 | SSA phi read(x) | UseUseExplosion.rb:20:199:20:3556 | SSA phi read(x) |
+| UseUseExplosion.rb:20:220:20:3540 | SSA phi read(self) | UseUseExplosion.rb:20:215:20:3540 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:220:20:3540 | SSA phi read(x) | UseUseExplosion.rb:20:215:20:3540 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:220:20:3540 | if ... | UseUseExplosion.rb:20:215:20:3540 | then ... |
 | UseUseExplosion.rb:20:224:20:228 | @prop | UseUseExplosion.rb:20:224:20:233 | ... > ... |
 | UseUseExplosion.rb:20:224:20:228 | [post] self | UseUseExplosion.rb:20:245:20:249 | self |
@@ -332,9 +352,11 @@
 | UseUseExplosion.rb:20:224:20:233 | ... > ... | UseUseExplosion.rb:20:223:20:234 | [false] ( ... ) |
 | UseUseExplosion.rb:20:224:20:233 | ... > ... | UseUseExplosion.rb:20:223:20:234 | [true] ( ... ) |
 | UseUseExplosion.rb:20:232:20:233 | 90 | UseUseExplosion.rb:20:224:20:233 | ... > ... |
+| UseUseExplosion.rb:20:236:20:3524 | [input] SSA phi read(self) | UseUseExplosion.rb:20:220:20:3540 | SSA phi read(self) |
+| UseUseExplosion.rb:20:236:20:3524 | [input] SSA phi read(x) | UseUseExplosion.rb:20:220:20:3540 | SSA phi read(x) |
 | UseUseExplosion.rb:20:236:20:3524 | then ... | UseUseExplosion.rb:20:220:20:3540 | if ... |
-| UseUseExplosion.rb:20:241:20:3524 | SSA phi read(self) | UseUseExplosion.rb:20:220:20:3540 | SSA phi read(self) |
-| UseUseExplosion.rb:20:241:20:3524 | SSA phi read(x) | UseUseExplosion.rb:20:220:20:3540 | SSA phi read(x) |
+| UseUseExplosion.rb:20:241:20:3524 | SSA phi read(self) | UseUseExplosion.rb:20:236:20:3524 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:241:20:3524 | SSA phi read(x) | UseUseExplosion.rb:20:236:20:3524 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:241:20:3524 | if ... | UseUseExplosion.rb:20:236:20:3524 | then ... |
 | UseUseExplosion.rb:20:245:20:249 | @prop | UseUseExplosion.rb:20:245:20:254 | ... > ... |
 | UseUseExplosion.rb:20:245:20:249 | [post] self | UseUseExplosion.rb:20:266:20:270 | self |
@@ -344,9 +366,11 @@
 | UseUseExplosion.rb:20:245:20:254 | ... > ... | UseUseExplosion.rb:20:244:20:255 | [false] ( ... ) |
 | UseUseExplosion.rb:20:245:20:254 | ... > ... | UseUseExplosion.rb:20:244:20:255 | [true] ( ... ) |
 | UseUseExplosion.rb:20:253:20:254 | 89 | UseUseExplosion.rb:20:245:20:254 | ... > ... |
+| UseUseExplosion.rb:20:257:20:3508 | [input] SSA phi read(self) | UseUseExplosion.rb:20:241:20:3524 | SSA phi read(self) |
+| UseUseExplosion.rb:20:257:20:3508 | [input] SSA phi read(x) | UseUseExplosion.rb:20:241:20:3524 | SSA phi read(x) |
 | UseUseExplosion.rb:20:257:20:3508 | then ... | UseUseExplosion.rb:20:241:20:3524 | if ... |
-| UseUseExplosion.rb:20:262:20:3508 | SSA phi read(self) | UseUseExplosion.rb:20:241:20:3524 | SSA phi read(self) |
-| UseUseExplosion.rb:20:262:20:3508 | SSA phi read(x) | UseUseExplosion.rb:20:241:20:3524 | SSA phi read(x) |
+| UseUseExplosion.rb:20:262:20:3508 | SSA phi read(self) | UseUseExplosion.rb:20:257:20:3508 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:262:20:3508 | SSA phi read(x) | UseUseExplosion.rb:20:257:20:3508 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:262:20:3508 | if ... | UseUseExplosion.rb:20:257:20:3508 | then ... |
 | UseUseExplosion.rb:20:266:20:270 | @prop | UseUseExplosion.rb:20:266:20:275 | ... > ... |
 | UseUseExplosion.rb:20:266:20:270 | [post] self | UseUseExplosion.rb:20:287:20:291 | self |
@@ -356,9 +380,11 @@
 | UseUseExplosion.rb:20:266:20:275 | ... > ... | UseUseExplosion.rb:20:265:20:276 | [false] ( ... ) |
 | UseUseExplosion.rb:20:266:20:275 | ... > ... | UseUseExplosion.rb:20:265:20:276 | [true] ( ... ) |
 | UseUseExplosion.rb:20:274:20:275 | 88 | UseUseExplosion.rb:20:266:20:275 | ... > ... |
+| UseUseExplosion.rb:20:278:20:3492 | [input] SSA phi read(self) | UseUseExplosion.rb:20:262:20:3508 | SSA phi read(self) |
+| UseUseExplosion.rb:20:278:20:3492 | [input] SSA phi read(x) | UseUseExplosion.rb:20:262:20:3508 | SSA phi read(x) |
 | UseUseExplosion.rb:20:278:20:3492 | then ... | UseUseExplosion.rb:20:262:20:3508 | if ... |
-| UseUseExplosion.rb:20:283:20:3492 | SSA phi read(self) | UseUseExplosion.rb:20:262:20:3508 | SSA phi read(self) |
-| UseUseExplosion.rb:20:283:20:3492 | SSA phi read(x) | UseUseExplosion.rb:20:262:20:3508 | SSA phi read(x) |
+| UseUseExplosion.rb:20:283:20:3492 | SSA phi read(self) | UseUseExplosion.rb:20:278:20:3492 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:283:20:3492 | SSA phi read(x) | UseUseExplosion.rb:20:278:20:3492 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:283:20:3492 | if ... | UseUseExplosion.rb:20:278:20:3492 | then ... |
 | UseUseExplosion.rb:20:287:20:291 | @prop | UseUseExplosion.rb:20:287:20:296 | ... > ... |
 | UseUseExplosion.rb:20:287:20:291 | [post] self | UseUseExplosion.rb:20:308:20:312 | self |
@@ -368,9 +394,11 @@
 | UseUseExplosion.rb:20:287:20:296 | ... > ... | UseUseExplosion.rb:20:286:20:297 | [false] ( ... ) |
 | UseUseExplosion.rb:20:287:20:296 | ... > ... | UseUseExplosion.rb:20:286:20:297 | [true] ( ... ) |
 | UseUseExplosion.rb:20:295:20:296 | 87 | UseUseExplosion.rb:20:287:20:296 | ... > ... |
+| UseUseExplosion.rb:20:299:20:3476 | [input] SSA phi read(self) | UseUseExplosion.rb:20:283:20:3492 | SSA phi read(self) |
+| UseUseExplosion.rb:20:299:20:3476 | [input] SSA phi read(x) | UseUseExplosion.rb:20:283:20:3492 | SSA phi read(x) |
 | UseUseExplosion.rb:20:299:20:3476 | then ... | UseUseExplosion.rb:20:283:20:3492 | if ... |
-| UseUseExplosion.rb:20:304:20:3476 | SSA phi read(self) | UseUseExplosion.rb:20:283:20:3492 | SSA phi read(self) |
-| UseUseExplosion.rb:20:304:20:3476 | SSA phi read(x) | UseUseExplosion.rb:20:283:20:3492 | SSA phi read(x) |
+| UseUseExplosion.rb:20:304:20:3476 | SSA phi read(self) | UseUseExplosion.rb:20:299:20:3476 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:304:20:3476 | SSA phi read(x) | UseUseExplosion.rb:20:299:20:3476 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:304:20:3476 | if ... | UseUseExplosion.rb:20:299:20:3476 | then ... |
 | UseUseExplosion.rb:20:308:20:312 | @prop | UseUseExplosion.rb:20:308:20:317 | ... > ... |
 | UseUseExplosion.rb:20:308:20:312 | [post] self | UseUseExplosion.rb:20:329:20:333 | self |
@@ -380,9 +408,11 @@
 | UseUseExplosion.rb:20:308:20:317 | ... > ... | UseUseExplosion.rb:20:307:20:318 | [false] ( ... ) |
 | UseUseExplosion.rb:20:308:20:317 | ... > ... | UseUseExplosion.rb:20:307:20:318 | [true] ( ... ) |
 | UseUseExplosion.rb:20:316:20:317 | 86 | UseUseExplosion.rb:20:308:20:317 | ... > ... |
+| UseUseExplosion.rb:20:320:20:3460 | [input] SSA phi read(self) | UseUseExplosion.rb:20:304:20:3476 | SSA phi read(self) |
+| UseUseExplosion.rb:20:320:20:3460 | [input] SSA phi read(x) | UseUseExplosion.rb:20:304:20:3476 | SSA phi read(x) |
 | UseUseExplosion.rb:20:320:20:3460 | then ... | UseUseExplosion.rb:20:304:20:3476 | if ... |
-| UseUseExplosion.rb:20:325:20:3460 | SSA phi read(self) | UseUseExplosion.rb:20:304:20:3476 | SSA phi read(self) |
-| UseUseExplosion.rb:20:325:20:3460 | SSA phi read(x) | UseUseExplosion.rb:20:304:20:3476 | SSA phi read(x) |
+| UseUseExplosion.rb:20:325:20:3460 | SSA phi read(self) | UseUseExplosion.rb:20:320:20:3460 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:325:20:3460 | SSA phi read(x) | UseUseExplosion.rb:20:320:20:3460 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:325:20:3460 | if ... | UseUseExplosion.rb:20:320:20:3460 | then ... |
 | UseUseExplosion.rb:20:329:20:333 | @prop | UseUseExplosion.rb:20:329:20:338 | ... > ... |
 | UseUseExplosion.rb:20:329:20:333 | [post] self | UseUseExplosion.rb:20:350:20:354 | self |
@@ -392,9 +422,11 @@
 | UseUseExplosion.rb:20:329:20:338 | ... > ... | UseUseExplosion.rb:20:328:20:339 | [false] ( ... ) |
 | UseUseExplosion.rb:20:329:20:338 | ... > ... | UseUseExplosion.rb:20:328:20:339 | [true] ( ... ) |
 | UseUseExplosion.rb:20:337:20:338 | 85 | UseUseExplosion.rb:20:329:20:338 | ... > ... |
+| UseUseExplosion.rb:20:341:20:3444 | [input] SSA phi read(self) | UseUseExplosion.rb:20:325:20:3460 | SSA phi read(self) |
+| UseUseExplosion.rb:20:341:20:3444 | [input] SSA phi read(x) | UseUseExplosion.rb:20:325:20:3460 | SSA phi read(x) |
 | UseUseExplosion.rb:20:341:20:3444 | then ... | UseUseExplosion.rb:20:325:20:3460 | if ... |
-| UseUseExplosion.rb:20:346:20:3444 | SSA phi read(self) | UseUseExplosion.rb:20:325:20:3460 | SSA phi read(self) |
-| UseUseExplosion.rb:20:346:20:3444 | SSA phi read(x) | UseUseExplosion.rb:20:325:20:3460 | SSA phi read(x) |
+| UseUseExplosion.rb:20:346:20:3444 | SSA phi read(self) | UseUseExplosion.rb:20:341:20:3444 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:346:20:3444 | SSA phi read(x) | UseUseExplosion.rb:20:341:20:3444 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:346:20:3444 | if ... | UseUseExplosion.rb:20:341:20:3444 | then ... |
 | UseUseExplosion.rb:20:350:20:354 | @prop | UseUseExplosion.rb:20:350:20:359 | ... > ... |
 | UseUseExplosion.rb:20:350:20:354 | [post] self | UseUseExplosion.rb:20:371:20:375 | self |
@@ -404,9 +436,11 @@
 | UseUseExplosion.rb:20:350:20:359 | ... > ... | UseUseExplosion.rb:20:349:20:360 | [false] ( ... ) |
 | UseUseExplosion.rb:20:350:20:359 | ... > ... | UseUseExplosion.rb:20:349:20:360 | [true] ( ... ) |
 | UseUseExplosion.rb:20:358:20:359 | 84 | UseUseExplosion.rb:20:350:20:359 | ... > ... |
+| UseUseExplosion.rb:20:362:20:3428 | [input] SSA phi read(self) | UseUseExplosion.rb:20:346:20:3444 | SSA phi read(self) |
+| UseUseExplosion.rb:20:362:20:3428 | [input] SSA phi read(x) | UseUseExplosion.rb:20:346:20:3444 | SSA phi read(x) |
 | UseUseExplosion.rb:20:362:20:3428 | then ... | UseUseExplosion.rb:20:346:20:3444 | if ... |
-| UseUseExplosion.rb:20:367:20:3428 | SSA phi read(self) | UseUseExplosion.rb:20:346:20:3444 | SSA phi read(self) |
-| UseUseExplosion.rb:20:367:20:3428 | SSA phi read(x) | UseUseExplosion.rb:20:346:20:3444 | SSA phi read(x) |
+| UseUseExplosion.rb:20:367:20:3428 | SSA phi read(self) | UseUseExplosion.rb:20:362:20:3428 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:367:20:3428 | SSA phi read(x) | UseUseExplosion.rb:20:362:20:3428 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:367:20:3428 | if ... | UseUseExplosion.rb:20:362:20:3428 | then ... |
 | UseUseExplosion.rb:20:371:20:375 | @prop | UseUseExplosion.rb:20:371:20:380 | ... > ... |
 | UseUseExplosion.rb:20:371:20:375 | [post] self | UseUseExplosion.rb:20:392:20:396 | self |
@@ -416,9 +450,11 @@
 | UseUseExplosion.rb:20:371:20:380 | ... > ... | UseUseExplosion.rb:20:370:20:381 | [false] ( ... ) |
 | UseUseExplosion.rb:20:371:20:380 | ... > ... | UseUseExplosion.rb:20:370:20:381 | [true] ( ... ) |
 | UseUseExplosion.rb:20:379:20:380 | 83 | UseUseExplosion.rb:20:371:20:380 | ... > ... |
+| UseUseExplosion.rb:20:383:20:3412 | [input] SSA phi read(self) | UseUseExplosion.rb:20:367:20:3428 | SSA phi read(self) |
+| UseUseExplosion.rb:20:383:20:3412 | [input] SSA phi read(x) | UseUseExplosion.rb:20:367:20:3428 | SSA phi read(x) |
 | UseUseExplosion.rb:20:383:20:3412 | then ... | UseUseExplosion.rb:20:367:20:3428 | if ... |
-| UseUseExplosion.rb:20:388:20:3412 | SSA phi read(self) | UseUseExplosion.rb:20:367:20:3428 | SSA phi read(self) |
-| UseUseExplosion.rb:20:388:20:3412 | SSA phi read(x) | UseUseExplosion.rb:20:367:20:3428 | SSA phi read(x) |
+| UseUseExplosion.rb:20:388:20:3412 | SSA phi read(self) | UseUseExplosion.rb:20:383:20:3412 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:388:20:3412 | SSA phi read(x) | UseUseExplosion.rb:20:383:20:3412 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:388:20:3412 | if ... | UseUseExplosion.rb:20:383:20:3412 | then ... |
 | UseUseExplosion.rb:20:392:20:396 | @prop | UseUseExplosion.rb:20:392:20:401 | ... > ... |
 | UseUseExplosion.rb:20:392:20:396 | [post] self | UseUseExplosion.rb:20:413:20:417 | self |
@@ -428,9 +464,11 @@
 | UseUseExplosion.rb:20:392:20:401 | ... > ... | UseUseExplosion.rb:20:391:20:402 | [false] ( ... ) |
 | UseUseExplosion.rb:20:392:20:401 | ... > ... | UseUseExplosion.rb:20:391:20:402 | [true] ( ... ) |
 | UseUseExplosion.rb:20:400:20:401 | 82 | UseUseExplosion.rb:20:392:20:401 | ... > ... |
+| UseUseExplosion.rb:20:404:20:3396 | [input] SSA phi read(self) | UseUseExplosion.rb:20:388:20:3412 | SSA phi read(self) |
+| UseUseExplosion.rb:20:404:20:3396 | [input] SSA phi read(x) | UseUseExplosion.rb:20:388:20:3412 | SSA phi read(x) |
 | UseUseExplosion.rb:20:404:20:3396 | then ... | UseUseExplosion.rb:20:388:20:3412 | if ... |
-| UseUseExplosion.rb:20:409:20:3396 | SSA phi read(self) | UseUseExplosion.rb:20:388:20:3412 | SSA phi read(self) |
-| UseUseExplosion.rb:20:409:20:3396 | SSA phi read(x) | UseUseExplosion.rb:20:388:20:3412 | SSA phi read(x) |
+| UseUseExplosion.rb:20:409:20:3396 | SSA phi read(self) | UseUseExplosion.rb:20:404:20:3396 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:409:20:3396 | SSA phi read(x) | UseUseExplosion.rb:20:404:20:3396 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:409:20:3396 | if ... | UseUseExplosion.rb:20:404:20:3396 | then ... |
 | UseUseExplosion.rb:20:413:20:417 | @prop | UseUseExplosion.rb:20:413:20:422 | ... > ... |
 | UseUseExplosion.rb:20:413:20:417 | [post] self | UseUseExplosion.rb:20:434:20:438 | self |
@@ -440,9 +478,11 @@
 | UseUseExplosion.rb:20:413:20:422 | ... > ... | UseUseExplosion.rb:20:412:20:423 | [false] ( ... ) |
 | UseUseExplosion.rb:20:413:20:422 | ... > ... | UseUseExplosion.rb:20:412:20:423 | [true] ( ... ) |
 | UseUseExplosion.rb:20:421:20:422 | 81 | UseUseExplosion.rb:20:413:20:422 | ... > ... |
+| UseUseExplosion.rb:20:425:20:3380 | [input] SSA phi read(self) | UseUseExplosion.rb:20:409:20:3396 | SSA phi read(self) |
+| UseUseExplosion.rb:20:425:20:3380 | [input] SSA phi read(x) | UseUseExplosion.rb:20:409:20:3396 | SSA phi read(x) |
 | UseUseExplosion.rb:20:425:20:3380 | then ... | UseUseExplosion.rb:20:409:20:3396 | if ... |
-| UseUseExplosion.rb:20:430:20:3380 | SSA phi read(self) | UseUseExplosion.rb:20:409:20:3396 | SSA phi read(self) |
-| UseUseExplosion.rb:20:430:20:3380 | SSA phi read(x) | UseUseExplosion.rb:20:409:20:3396 | SSA phi read(x) |
+| UseUseExplosion.rb:20:430:20:3380 | SSA phi read(self) | UseUseExplosion.rb:20:425:20:3380 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:430:20:3380 | SSA phi read(x) | UseUseExplosion.rb:20:425:20:3380 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:430:20:3380 | if ... | UseUseExplosion.rb:20:425:20:3380 | then ... |
 | UseUseExplosion.rb:20:434:20:438 | @prop | UseUseExplosion.rb:20:434:20:443 | ... > ... |
 | UseUseExplosion.rb:20:434:20:438 | [post] self | UseUseExplosion.rb:20:455:20:459 | self |
@@ -452,9 +492,11 @@
 | UseUseExplosion.rb:20:434:20:443 | ... > ... | UseUseExplosion.rb:20:433:20:444 | [false] ( ... ) |
 | UseUseExplosion.rb:20:434:20:443 | ... > ... | UseUseExplosion.rb:20:433:20:444 | [true] ( ... ) |
 | UseUseExplosion.rb:20:442:20:443 | 80 | UseUseExplosion.rb:20:434:20:443 | ... > ... |
+| UseUseExplosion.rb:20:446:20:3364 | [input] SSA phi read(self) | UseUseExplosion.rb:20:430:20:3380 | SSA phi read(self) |
+| UseUseExplosion.rb:20:446:20:3364 | [input] SSA phi read(x) | UseUseExplosion.rb:20:430:20:3380 | SSA phi read(x) |
 | UseUseExplosion.rb:20:446:20:3364 | then ... | UseUseExplosion.rb:20:430:20:3380 | if ... |
-| UseUseExplosion.rb:20:451:20:3364 | SSA phi read(self) | UseUseExplosion.rb:20:430:20:3380 | SSA phi read(self) |
-| UseUseExplosion.rb:20:451:20:3364 | SSA phi read(x) | UseUseExplosion.rb:20:430:20:3380 | SSA phi read(x) |
+| UseUseExplosion.rb:20:451:20:3364 | SSA phi read(self) | UseUseExplosion.rb:20:446:20:3364 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:451:20:3364 | SSA phi read(x) | UseUseExplosion.rb:20:446:20:3364 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:451:20:3364 | if ... | UseUseExplosion.rb:20:446:20:3364 | then ... |
 | UseUseExplosion.rb:20:455:20:459 | @prop | UseUseExplosion.rb:20:455:20:464 | ... > ... |
 | UseUseExplosion.rb:20:455:20:459 | [post] self | UseUseExplosion.rb:20:476:20:480 | self |
@@ -464,9 +506,11 @@
 | UseUseExplosion.rb:20:455:20:464 | ... > ... | UseUseExplosion.rb:20:454:20:465 | [false] ( ... ) |
 | UseUseExplosion.rb:20:455:20:464 | ... > ... | UseUseExplosion.rb:20:454:20:465 | [true] ( ... ) |
 | UseUseExplosion.rb:20:463:20:464 | 79 | UseUseExplosion.rb:20:455:20:464 | ... > ... |
+| UseUseExplosion.rb:20:467:20:3348 | [input] SSA phi read(self) | UseUseExplosion.rb:20:451:20:3364 | SSA phi read(self) |
+| UseUseExplosion.rb:20:467:20:3348 | [input] SSA phi read(x) | UseUseExplosion.rb:20:451:20:3364 | SSA phi read(x) |
 | UseUseExplosion.rb:20:467:20:3348 | then ... | UseUseExplosion.rb:20:451:20:3364 | if ... |
-| UseUseExplosion.rb:20:472:20:3348 | SSA phi read(self) | UseUseExplosion.rb:20:451:20:3364 | SSA phi read(self) |
-| UseUseExplosion.rb:20:472:20:3348 | SSA phi read(x) | UseUseExplosion.rb:20:451:20:3364 | SSA phi read(x) |
+| UseUseExplosion.rb:20:472:20:3348 | SSA phi read(self) | UseUseExplosion.rb:20:467:20:3348 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:472:20:3348 | SSA phi read(x) | UseUseExplosion.rb:20:467:20:3348 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:472:20:3348 | if ... | UseUseExplosion.rb:20:467:20:3348 | then ... |
 | UseUseExplosion.rb:20:476:20:480 | @prop | UseUseExplosion.rb:20:476:20:485 | ... > ... |
 | UseUseExplosion.rb:20:476:20:480 | [post] self | UseUseExplosion.rb:20:497:20:501 | self |
@@ -476,9 +520,11 @@
 | UseUseExplosion.rb:20:476:20:485 | ... > ... | UseUseExplosion.rb:20:475:20:486 | [false] ( ... ) |
 | UseUseExplosion.rb:20:476:20:485 | ... > ... | UseUseExplosion.rb:20:475:20:486 | [true] ( ... ) |
 | UseUseExplosion.rb:20:484:20:485 | 78 | UseUseExplosion.rb:20:476:20:485 | ... > ... |
+| UseUseExplosion.rb:20:488:20:3332 | [input] SSA phi read(self) | UseUseExplosion.rb:20:472:20:3348 | SSA phi read(self) |
+| UseUseExplosion.rb:20:488:20:3332 | [input] SSA phi read(x) | UseUseExplosion.rb:20:472:20:3348 | SSA phi read(x) |
 | UseUseExplosion.rb:20:488:20:3332 | then ... | UseUseExplosion.rb:20:472:20:3348 | if ... |
-| UseUseExplosion.rb:20:493:20:3332 | SSA phi read(self) | UseUseExplosion.rb:20:472:20:3348 | SSA phi read(self) |
-| UseUseExplosion.rb:20:493:20:3332 | SSA phi read(x) | UseUseExplosion.rb:20:472:20:3348 | SSA phi read(x) |
+| UseUseExplosion.rb:20:493:20:3332 | SSA phi read(self) | UseUseExplosion.rb:20:488:20:3332 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:493:20:3332 | SSA phi read(x) | UseUseExplosion.rb:20:488:20:3332 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:493:20:3332 | if ... | UseUseExplosion.rb:20:488:20:3332 | then ... |
 | UseUseExplosion.rb:20:497:20:501 | @prop | UseUseExplosion.rb:20:497:20:506 | ... > ... |
 | UseUseExplosion.rb:20:497:20:501 | [post] self | UseUseExplosion.rb:20:518:20:522 | self |
@@ -488,9 +534,11 @@
 | UseUseExplosion.rb:20:497:20:506 | ... > ... | UseUseExplosion.rb:20:496:20:507 | [false] ( ... ) |
 | UseUseExplosion.rb:20:497:20:506 | ... > ... | UseUseExplosion.rb:20:496:20:507 | [true] ( ... ) |
 | UseUseExplosion.rb:20:505:20:506 | 77 | UseUseExplosion.rb:20:497:20:506 | ... > ... |
+| UseUseExplosion.rb:20:509:20:3316 | [input] SSA phi read(self) | UseUseExplosion.rb:20:493:20:3332 | SSA phi read(self) |
+| UseUseExplosion.rb:20:509:20:3316 | [input] SSA phi read(x) | UseUseExplosion.rb:20:493:20:3332 | SSA phi read(x) |
 | UseUseExplosion.rb:20:509:20:3316 | then ... | UseUseExplosion.rb:20:493:20:3332 | if ... |
-| UseUseExplosion.rb:20:514:20:3316 | SSA phi read(self) | UseUseExplosion.rb:20:493:20:3332 | SSA phi read(self) |
-| UseUseExplosion.rb:20:514:20:3316 | SSA phi read(x) | UseUseExplosion.rb:20:493:20:3332 | SSA phi read(x) |
+| UseUseExplosion.rb:20:514:20:3316 | SSA phi read(self) | UseUseExplosion.rb:20:509:20:3316 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:514:20:3316 | SSA phi read(x) | UseUseExplosion.rb:20:509:20:3316 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:514:20:3316 | if ... | UseUseExplosion.rb:20:509:20:3316 | then ... |
 | UseUseExplosion.rb:20:518:20:522 | @prop | UseUseExplosion.rb:20:518:20:527 | ... > ... |
 | UseUseExplosion.rb:20:518:20:522 | [post] self | UseUseExplosion.rb:20:539:20:543 | self |
@@ -500,9 +548,11 @@
 | UseUseExplosion.rb:20:518:20:527 | ... > ... | UseUseExplosion.rb:20:517:20:528 | [false] ( ... ) |
 | UseUseExplosion.rb:20:518:20:527 | ... > ... | UseUseExplosion.rb:20:517:20:528 | [true] ( ... ) |
 | UseUseExplosion.rb:20:526:20:527 | 76 | UseUseExplosion.rb:20:518:20:527 | ... > ... |
+| UseUseExplosion.rb:20:530:20:3300 | [input] SSA phi read(self) | UseUseExplosion.rb:20:514:20:3316 | SSA phi read(self) |
+| UseUseExplosion.rb:20:530:20:3300 | [input] SSA phi read(x) | UseUseExplosion.rb:20:514:20:3316 | SSA phi read(x) |
 | UseUseExplosion.rb:20:530:20:3300 | then ... | UseUseExplosion.rb:20:514:20:3316 | if ... |
-| UseUseExplosion.rb:20:535:20:3300 | SSA phi read(self) | UseUseExplosion.rb:20:514:20:3316 | SSA phi read(self) |
-| UseUseExplosion.rb:20:535:20:3300 | SSA phi read(x) | UseUseExplosion.rb:20:514:20:3316 | SSA phi read(x) |
+| UseUseExplosion.rb:20:535:20:3300 | SSA phi read(self) | UseUseExplosion.rb:20:530:20:3300 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:535:20:3300 | SSA phi read(x) | UseUseExplosion.rb:20:530:20:3300 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:535:20:3300 | if ... | UseUseExplosion.rb:20:530:20:3300 | then ... |
 | UseUseExplosion.rb:20:539:20:543 | @prop | UseUseExplosion.rb:20:539:20:548 | ... > ... |
 | UseUseExplosion.rb:20:539:20:543 | [post] self | UseUseExplosion.rb:20:560:20:564 | self |
@@ -512,9 +562,11 @@
 | UseUseExplosion.rb:20:539:20:548 | ... > ... | UseUseExplosion.rb:20:538:20:549 | [false] ( ... ) |
 | UseUseExplosion.rb:20:539:20:548 | ... > ... | UseUseExplosion.rb:20:538:20:549 | [true] ( ... ) |
 | UseUseExplosion.rb:20:547:20:548 | 75 | UseUseExplosion.rb:20:539:20:548 | ... > ... |
+| UseUseExplosion.rb:20:551:20:3284 | [input] SSA phi read(self) | UseUseExplosion.rb:20:535:20:3300 | SSA phi read(self) |
+| UseUseExplosion.rb:20:551:20:3284 | [input] SSA phi read(x) | UseUseExplosion.rb:20:535:20:3300 | SSA phi read(x) |
 | UseUseExplosion.rb:20:551:20:3284 | then ... | UseUseExplosion.rb:20:535:20:3300 | if ... |
-| UseUseExplosion.rb:20:556:20:3284 | SSA phi read(self) | UseUseExplosion.rb:20:535:20:3300 | SSA phi read(self) |
-| UseUseExplosion.rb:20:556:20:3284 | SSA phi read(x) | UseUseExplosion.rb:20:535:20:3300 | SSA phi read(x) |
+| UseUseExplosion.rb:20:556:20:3284 | SSA phi read(self) | UseUseExplosion.rb:20:551:20:3284 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:556:20:3284 | SSA phi read(x) | UseUseExplosion.rb:20:551:20:3284 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:556:20:3284 | if ... | UseUseExplosion.rb:20:551:20:3284 | then ... |
 | UseUseExplosion.rb:20:560:20:564 | @prop | UseUseExplosion.rb:20:560:20:569 | ... > ... |
 | UseUseExplosion.rb:20:560:20:564 | [post] self | UseUseExplosion.rb:20:581:20:585 | self |
@@ -524,9 +576,11 @@
 | UseUseExplosion.rb:20:560:20:569 | ... > ... | UseUseExplosion.rb:20:559:20:570 | [false] ( ... ) |
 | UseUseExplosion.rb:20:560:20:569 | ... > ... | UseUseExplosion.rb:20:559:20:570 | [true] ( ... ) |
 | UseUseExplosion.rb:20:568:20:569 | 74 | UseUseExplosion.rb:20:560:20:569 | ... > ... |
+| UseUseExplosion.rb:20:572:20:3268 | [input] SSA phi read(self) | UseUseExplosion.rb:20:556:20:3284 | SSA phi read(self) |
+| UseUseExplosion.rb:20:572:20:3268 | [input] SSA phi read(x) | UseUseExplosion.rb:20:556:20:3284 | SSA phi read(x) |
 | UseUseExplosion.rb:20:572:20:3268 | then ... | UseUseExplosion.rb:20:556:20:3284 | if ... |
-| UseUseExplosion.rb:20:577:20:3268 | SSA phi read(self) | UseUseExplosion.rb:20:556:20:3284 | SSA phi read(self) |
-| UseUseExplosion.rb:20:577:20:3268 | SSA phi read(x) | UseUseExplosion.rb:20:556:20:3284 | SSA phi read(x) |
+| UseUseExplosion.rb:20:577:20:3268 | SSA phi read(self) | UseUseExplosion.rb:20:572:20:3268 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:577:20:3268 | SSA phi read(x) | UseUseExplosion.rb:20:572:20:3268 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:577:20:3268 | if ... | UseUseExplosion.rb:20:572:20:3268 | then ... |
 | UseUseExplosion.rb:20:581:20:585 | @prop | UseUseExplosion.rb:20:581:20:590 | ... > ... |
 | UseUseExplosion.rb:20:581:20:585 | [post] self | UseUseExplosion.rb:20:602:20:606 | self |
@@ -536,9 +590,11 @@
 | UseUseExplosion.rb:20:581:20:590 | ... > ... | UseUseExplosion.rb:20:580:20:591 | [false] ( ... ) |
 | UseUseExplosion.rb:20:581:20:590 | ... > ... | UseUseExplosion.rb:20:580:20:591 | [true] ( ... ) |
 | UseUseExplosion.rb:20:589:20:590 | 73 | UseUseExplosion.rb:20:581:20:590 | ... > ... |
+| UseUseExplosion.rb:20:593:20:3252 | [input] SSA phi read(self) | UseUseExplosion.rb:20:577:20:3268 | SSA phi read(self) |
+| UseUseExplosion.rb:20:593:20:3252 | [input] SSA phi read(x) | UseUseExplosion.rb:20:577:20:3268 | SSA phi read(x) |
 | UseUseExplosion.rb:20:593:20:3252 | then ... | UseUseExplosion.rb:20:577:20:3268 | if ... |
-| UseUseExplosion.rb:20:598:20:3252 | SSA phi read(self) | UseUseExplosion.rb:20:577:20:3268 | SSA phi read(self) |
-| UseUseExplosion.rb:20:598:20:3252 | SSA phi read(x) | UseUseExplosion.rb:20:577:20:3268 | SSA phi read(x) |
+| UseUseExplosion.rb:20:598:20:3252 | SSA phi read(self) | UseUseExplosion.rb:20:593:20:3252 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:598:20:3252 | SSA phi read(x) | UseUseExplosion.rb:20:593:20:3252 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:598:20:3252 | if ... | UseUseExplosion.rb:20:593:20:3252 | then ... |
 | UseUseExplosion.rb:20:602:20:606 | @prop | UseUseExplosion.rb:20:602:20:611 | ... > ... |
 | UseUseExplosion.rb:20:602:20:606 | [post] self | UseUseExplosion.rb:20:623:20:627 | self |
@@ -548,9 +604,11 @@
 | UseUseExplosion.rb:20:602:20:611 | ... > ... | UseUseExplosion.rb:20:601:20:612 | [false] ( ... ) |
 | UseUseExplosion.rb:20:602:20:611 | ... > ... | UseUseExplosion.rb:20:601:20:612 | [true] ( ... ) |
 | UseUseExplosion.rb:20:610:20:611 | 72 | UseUseExplosion.rb:20:602:20:611 | ... > ... |
+| UseUseExplosion.rb:20:614:20:3236 | [input] SSA phi read(self) | UseUseExplosion.rb:20:598:20:3252 | SSA phi read(self) |
+| UseUseExplosion.rb:20:614:20:3236 | [input] SSA phi read(x) | UseUseExplosion.rb:20:598:20:3252 | SSA phi read(x) |
 | UseUseExplosion.rb:20:614:20:3236 | then ... | UseUseExplosion.rb:20:598:20:3252 | if ... |
-| UseUseExplosion.rb:20:619:20:3236 | SSA phi read(self) | UseUseExplosion.rb:20:598:20:3252 | SSA phi read(self) |
-| UseUseExplosion.rb:20:619:20:3236 | SSA phi read(x) | UseUseExplosion.rb:20:598:20:3252 | SSA phi read(x) |
+| UseUseExplosion.rb:20:619:20:3236 | SSA phi read(self) | UseUseExplosion.rb:20:614:20:3236 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:619:20:3236 | SSA phi read(x) | UseUseExplosion.rb:20:614:20:3236 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:619:20:3236 | if ... | UseUseExplosion.rb:20:614:20:3236 | then ... |
 | UseUseExplosion.rb:20:623:20:627 | @prop | UseUseExplosion.rb:20:623:20:632 | ... > ... |
 | UseUseExplosion.rb:20:623:20:627 | [post] self | UseUseExplosion.rb:20:644:20:648 | self |
@@ -560,9 +618,11 @@
 | UseUseExplosion.rb:20:623:20:632 | ... > ... | UseUseExplosion.rb:20:622:20:633 | [false] ( ... ) |
 | UseUseExplosion.rb:20:623:20:632 | ... > ... | UseUseExplosion.rb:20:622:20:633 | [true] ( ... ) |
 | UseUseExplosion.rb:20:631:20:632 | 71 | UseUseExplosion.rb:20:623:20:632 | ... > ... |
+| UseUseExplosion.rb:20:635:20:3220 | [input] SSA phi read(self) | UseUseExplosion.rb:20:619:20:3236 | SSA phi read(self) |
+| UseUseExplosion.rb:20:635:20:3220 | [input] SSA phi read(x) | UseUseExplosion.rb:20:619:20:3236 | SSA phi read(x) |
 | UseUseExplosion.rb:20:635:20:3220 | then ... | UseUseExplosion.rb:20:619:20:3236 | if ... |
-| UseUseExplosion.rb:20:640:20:3220 | SSA phi read(self) | UseUseExplosion.rb:20:619:20:3236 | SSA phi read(self) |
-| UseUseExplosion.rb:20:640:20:3220 | SSA phi read(x) | UseUseExplosion.rb:20:619:20:3236 | SSA phi read(x) |
+| UseUseExplosion.rb:20:640:20:3220 | SSA phi read(self) | UseUseExplosion.rb:20:635:20:3220 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:640:20:3220 | SSA phi read(x) | UseUseExplosion.rb:20:635:20:3220 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:640:20:3220 | if ... | UseUseExplosion.rb:20:635:20:3220 | then ... |
 | UseUseExplosion.rb:20:644:20:648 | @prop | UseUseExplosion.rb:20:644:20:653 | ... > ... |
 | UseUseExplosion.rb:20:644:20:648 | [post] self | UseUseExplosion.rb:20:665:20:669 | self |
@@ -572,9 +632,11 @@
 | UseUseExplosion.rb:20:644:20:653 | ... > ... | UseUseExplosion.rb:20:643:20:654 | [false] ( ... ) |
 | UseUseExplosion.rb:20:644:20:653 | ... > ... | UseUseExplosion.rb:20:643:20:654 | [true] ( ... ) |
 | UseUseExplosion.rb:20:652:20:653 | 70 | UseUseExplosion.rb:20:644:20:653 | ... > ... |
+| UseUseExplosion.rb:20:656:20:3204 | [input] SSA phi read(self) | UseUseExplosion.rb:20:640:20:3220 | SSA phi read(self) |
+| UseUseExplosion.rb:20:656:20:3204 | [input] SSA phi read(x) | UseUseExplosion.rb:20:640:20:3220 | SSA phi read(x) |
 | UseUseExplosion.rb:20:656:20:3204 | then ... | UseUseExplosion.rb:20:640:20:3220 | if ... |
-| UseUseExplosion.rb:20:661:20:3204 | SSA phi read(self) | UseUseExplosion.rb:20:640:20:3220 | SSA phi read(self) |
-| UseUseExplosion.rb:20:661:20:3204 | SSA phi read(x) | UseUseExplosion.rb:20:640:20:3220 | SSA phi read(x) |
+| UseUseExplosion.rb:20:661:20:3204 | SSA phi read(self) | UseUseExplosion.rb:20:656:20:3204 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:661:20:3204 | SSA phi read(x) | UseUseExplosion.rb:20:656:20:3204 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:661:20:3204 | if ... | UseUseExplosion.rb:20:656:20:3204 | then ... |
 | UseUseExplosion.rb:20:665:20:669 | @prop | UseUseExplosion.rb:20:665:20:674 | ... > ... |
 | UseUseExplosion.rb:20:665:20:669 | [post] self | UseUseExplosion.rb:20:686:20:690 | self |
@@ -584,9 +646,11 @@
 | UseUseExplosion.rb:20:665:20:674 | ... > ... | UseUseExplosion.rb:20:664:20:675 | [false] ( ... ) |
 | UseUseExplosion.rb:20:665:20:674 | ... > ... | UseUseExplosion.rb:20:664:20:675 | [true] ( ... ) |
 | UseUseExplosion.rb:20:673:20:674 | 69 | UseUseExplosion.rb:20:665:20:674 | ... > ... |
+| UseUseExplosion.rb:20:677:20:3188 | [input] SSA phi read(self) | UseUseExplosion.rb:20:661:20:3204 | SSA phi read(self) |
+| UseUseExplosion.rb:20:677:20:3188 | [input] SSA phi read(x) | UseUseExplosion.rb:20:661:20:3204 | SSA phi read(x) |
 | UseUseExplosion.rb:20:677:20:3188 | then ... | UseUseExplosion.rb:20:661:20:3204 | if ... |
-| UseUseExplosion.rb:20:682:20:3188 | SSA phi read(self) | UseUseExplosion.rb:20:661:20:3204 | SSA phi read(self) |
-| UseUseExplosion.rb:20:682:20:3188 | SSA phi read(x) | UseUseExplosion.rb:20:661:20:3204 | SSA phi read(x) |
+| UseUseExplosion.rb:20:682:20:3188 | SSA phi read(self) | UseUseExplosion.rb:20:677:20:3188 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:682:20:3188 | SSA phi read(x) | UseUseExplosion.rb:20:677:20:3188 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:682:20:3188 | if ... | UseUseExplosion.rb:20:677:20:3188 | then ... |
 | UseUseExplosion.rb:20:686:20:690 | @prop | UseUseExplosion.rb:20:686:20:695 | ... > ... |
 | UseUseExplosion.rb:20:686:20:690 | [post] self | UseUseExplosion.rb:20:707:20:711 | self |
@@ -596,9 +660,11 @@
 | UseUseExplosion.rb:20:686:20:695 | ... > ... | UseUseExplosion.rb:20:685:20:696 | [false] ( ... ) |
 | UseUseExplosion.rb:20:686:20:695 | ... > ... | UseUseExplosion.rb:20:685:20:696 | [true] ( ... ) |
 | UseUseExplosion.rb:20:694:20:695 | 68 | UseUseExplosion.rb:20:686:20:695 | ... > ... |
+| UseUseExplosion.rb:20:698:20:3172 | [input] SSA phi read(self) | UseUseExplosion.rb:20:682:20:3188 | SSA phi read(self) |
+| UseUseExplosion.rb:20:698:20:3172 | [input] SSA phi read(x) | UseUseExplosion.rb:20:682:20:3188 | SSA phi read(x) |
 | UseUseExplosion.rb:20:698:20:3172 | then ... | UseUseExplosion.rb:20:682:20:3188 | if ... |
-| UseUseExplosion.rb:20:703:20:3172 | SSA phi read(self) | UseUseExplosion.rb:20:682:20:3188 | SSA phi read(self) |
-| UseUseExplosion.rb:20:703:20:3172 | SSA phi read(x) | UseUseExplosion.rb:20:682:20:3188 | SSA phi read(x) |
+| UseUseExplosion.rb:20:703:20:3172 | SSA phi read(self) | UseUseExplosion.rb:20:698:20:3172 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:703:20:3172 | SSA phi read(x) | UseUseExplosion.rb:20:698:20:3172 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:703:20:3172 | if ... | UseUseExplosion.rb:20:698:20:3172 | then ... |
 | UseUseExplosion.rb:20:707:20:711 | @prop | UseUseExplosion.rb:20:707:20:716 | ... > ... |
 | UseUseExplosion.rb:20:707:20:711 | [post] self | UseUseExplosion.rb:20:728:20:732 | self |
@@ -608,9 +674,11 @@
 | UseUseExplosion.rb:20:707:20:716 | ... > ... | UseUseExplosion.rb:20:706:20:717 | [false] ( ... ) |
 | UseUseExplosion.rb:20:707:20:716 | ... > ... | UseUseExplosion.rb:20:706:20:717 | [true] ( ... ) |
 | UseUseExplosion.rb:20:715:20:716 | 67 | UseUseExplosion.rb:20:707:20:716 | ... > ... |
+| UseUseExplosion.rb:20:719:20:3156 | [input] SSA phi read(self) | UseUseExplosion.rb:20:703:20:3172 | SSA phi read(self) |
+| UseUseExplosion.rb:20:719:20:3156 | [input] SSA phi read(x) | UseUseExplosion.rb:20:703:20:3172 | SSA phi read(x) |
 | UseUseExplosion.rb:20:719:20:3156 | then ... | UseUseExplosion.rb:20:703:20:3172 | if ... |
-| UseUseExplosion.rb:20:724:20:3156 | SSA phi read(self) | UseUseExplosion.rb:20:703:20:3172 | SSA phi read(self) |
-| UseUseExplosion.rb:20:724:20:3156 | SSA phi read(x) | UseUseExplosion.rb:20:703:20:3172 | SSA phi read(x) |
+| UseUseExplosion.rb:20:724:20:3156 | SSA phi read(self) | UseUseExplosion.rb:20:719:20:3156 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:724:20:3156 | SSA phi read(x) | UseUseExplosion.rb:20:719:20:3156 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:724:20:3156 | if ... | UseUseExplosion.rb:20:719:20:3156 | then ... |
 | UseUseExplosion.rb:20:728:20:732 | @prop | UseUseExplosion.rb:20:728:20:737 | ... > ... |
 | UseUseExplosion.rb:20:728:20:732 | [post] self | UseUseExplosion.rb:20:749:20:753 | self |
@@ -620,9 +688,11 @@
 | UseUseExplosion.rb:20:728:20:737 | ... > ... | UseUseExplosion.rb:20:727:20:738 | [false] ( ... ) |
 | UseUseExplosion.rb:20:728:20:737 | ... > ... | UseUseExplosion.rb:20:727:20:738 | [true] ( ... ) |
 | UseUseExplosion.rb:20:736:20:737 | 66 | UseUseExplosion.rb:20:728:20:737 | ... > ... |
+| UseUseExplosion.rb:20:740:20:3140 | [input] SSA phi read(self) | UseUseExplosion.rb:20:724:20:3156 | SSA phi read(self) |
+| UseUseExplosion.rb:20:740:20:3140 | [input] SSA phi read(x) | UseUseExplosion.rb:20:724:20:3156 | SSA phi read(x) |
 | UseUseExplosion.rb:20:740:20:3140 | then ... | UseUseExplosion.rb:20:724:20:3156 | if ... |
-| UseUseExplosion.rb:20:745:20:3140 | SSA phi read(self) | UseUseExplosion.rb:20:724:20:3156 | SSA phi read(self) |
-| UseUseExplosion.rb:20:745:20:3140 | SSA phi read(x) | UseUseExplosion.rb:20:724:20:3156 | SSA phi read(x) |
+| UseUseExplosion.rb:20:745:20:3140 | SSA phi read(self) | UseUseExplosion.rb:20:740:20:3140 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:745:20:3140 | SSA phi read(x) | UseUseExplosion.rb:20:740:20:3140 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:745:20:3140 | if ... | UseUseExplosion.rb:20:740:20:3140 | then ... |
 | UseUseExplosion.rb:20:749:20:753 | @prop | UseUseExplosion.rb:20:749:20:758 | ... > ... |
 | UseUseExplosion.rb:20:749:20:753 | [post] self | UseUseExplosion.rb:20:770:20:774 | self |
@@ -632,9 +702,11 @@
 | UseUseExplosion.rb:20:749:20:758 | ... > ... | UseUseExplosion.rb:20:748:20:759 | [false] ( ... ) |
 | UseUseExplosion.rb:20:749:20:758 | ... > ... | UseUseExplosion.rb:20:748:20:759 | [true] ( ... ) |
 | UseUseExplosion.rb:20:757:20:758 | 65 | UseUseExplosion.rb:20:749:20:758 | ... > ... |
+| UseUseExplosion.rb:20:761:20:3124 | [input] SSA phi read(self) | UseUseExplosion.rb:20:745:20:3140 | SSA phi read(self) |
+| UseUseExplosion.rb:20:761:20:3124 | [input] SSA phi read(x) | UseUseExplosion.rb:20:745:20:3140 | SSA phi read(x) |
 | UseUseExplosion.rb:20:761:20:3124 | then ... | UseUseExplosion.rb:20:745:20:3140 | if ... |
-| UseUseExplosion.rb:20:766:20:3124 | SSA phi read(self) | UseUseExplosion.rb:20:745:20:3140 | SSA phi read(self) |
-| UseUseExplosion.rb:20:766:20:3124 | SSA phi read(x) | UseUseExplosion.rb:20:745:20:3140 | SSA phi read(x) |
+| UseUseExplosion.rb:20:766:20:3124 | SSA phi read(self) | UseUseExplosion.rb:20:761:20:3124 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:766:20:3124 | SSA phi read(x) | UseUseExplosion.rb:20:761:20:3124 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:766:20:3124 | if ... | UseUseExplosion.rb:20:761:20:3124 | then ... |
 | UseUseExplosion.rb:20:770:20:774 | @prop | UseUseExplosion.rb:20:770:20:779 | ... > ... |
 | UseUseExplosion.rb:20:770:20:774 | [post] self | UseUseExplosion.rb:20:791:20:795 | self |
@@ -644,9 +716,11 @@
 | UseUseExplosion.rb:20:770:20:779 | ... > ... | UseUseExplosion.rb:20:769:20:780 | [false] ( ... ) |
 | UseUseExplosion.rb:20:770:20:779 | ... > ... | UseUseExplosion.rb:20:769:20:780 | [true] ( ... ) |
 | UseUseExplosion.rb:20:778:20:779 | 64 | UseUseExplosion.rb:20:770:20:779 | ... > ... |
+| UseUseExplosion.rb:20:782:20:3108 | [input] SSA phi read(self) | UseUseExplosion.rb:20:766:20:3124 | SSA phi read(self) |
+| UseUseExplosion.rb:20:782:20:3108 | [input] SSA phi read(x) | UseUseExplosion.rb:20:766:20:3124 | SSA phi read(x) |
 | UseUseExplosion.rb:20:782:20:3108 | then ... | UseUseExplosion.rb:20:766:20:3124 | if ... |
-| UseUseExplosion.rb:20:787:20:3108 | SSA phi read(self) | UseUseExplosion.rb:20:766:20:3124 | SSA phi read(self) |
-| UseUseExplosion.rb:20:787:20:3108 | SSA phi read(x) | UseUseExplosion.rb:20:766:20:3124 | SSA phi read(x) |
+| UseUseExplosion.rb:20:787:20:3108 | SSA phi read(self) | UseUseExplosion.rb:20:782:20:3108 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:787:20:3108 | SSA phi read(x) | UseUseExplosion.rb:20:782:20:3108 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:787:20:3108 | if ... | UseUseExplosion.rb:20:782:20:3108 | then ... |
 | UseUseExplosion.rb:20:791:20:795 | @prop | UseUseExplosion.rb:20:791:20:800 | ... > ... |
 | UseUseExplosion.rb:20:791:20:795 | [post] self | UseUseExplosion.rb:20:812:20:816 | self |
@@ -656,9 +730,11 @@
 | UseUseExplosion.rb:20:791:20:800 | ... > ... | UseUseExplosion.rb:20:790:20:801 | [false] ( ... ) |
 | UseUseExplosion.rb:20:791:20:800 | ... > ... | UseUseExplosion.rb:20:790:20:801 | [true] ( ... ) |
 | UseUseExplosion.rb:20:799:20:800 | 63 | UseUseExplosion.rb:20:791:20:800 | ... > ... |
+| UseUseExplosion.rb:20:803:20:3092 | [input] SSA phi read(self) | UseUseExplosion.rb:20:787:20:3108 | SSA phi read(self) |
+| UseUseExplosion.rb:20:803:20:3092 | [input] SSA phi read(x) | UseUseExplosion.rb:20:787:20:3108 | SSA phi read(x) |
 | UseUseExplosion.rb:20:803:20:3092 | then ... | UseUseExplosion.rb:20:787:20:3108 | if ... |
-| UseUseExplosion.rb:20:808:20:3092 | SSA phi read(self) | UseUseExplosion.rb:20:787:20:3108 | SSA phi read(self) |
-| UseUseExplosion.rb:20:808:20:3092 | SSA phi read(x) | UseUseExplosion.rb:20:787:20:3108 | SSA phi read(x) |
+| UseUseExplosion.rb:20:808:20:3092 | SSA phi read(self) | UseUseExplosion.rb:20:803:20:3092 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:808:20:3092 | SSA phi read(x) | UseUseExplosion.rb:20:803:20:3092 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:808:20:3092 | if ... | UseUseExplosion.rb:20:803:20:3092 | then ... |
 | UseUseExplosion.rb:20:812:20:816 | @prop | UseUseExplosion.rb:20:812:20:821 | ... > ... |
 | UseUseExplosion.rb:20:812:20:816 | [post] self | UseUseExplosion.rb:20:833:20:837 | self |
@@ -668,9 +744,11 @@
 | UseUseExplosion.rb:20:812:20:821 | ... > ... | UseUseExplosion.rb:20:811:20:822 | [false] ( ... ) |
 | UseUseExplosion.rb:20:812:20:821 | ... > ... | UseUseExplosion.rb:20:811:20:822 | [true] ( ... ) |
 | UseUseExplosion.rb:20:820:20:821 | 62 | UseUseExplosion.rb:20:812:20:821 | ... > ... |
+| UseUseExplosion.rb:20:824:20:3076 | [input] SSA phi read(self) | UseUseExplosion.rb:20:808:20:3092 | SSA phi read(self) |
+| UseUseExplosion.rb:20:824:20:3076 | [input] SSA phi read(x) | UseUseExplosion.rb:20:808:20:3092 | SSA phi read(x) |
 | UseUseExplosion.rb:20:824:20:3076 | then ... | UseUseExplosion.rb:20:808:20:3092 | if ... |
-| UseUseExplosion.rb:20:829:20:3076 | SSA phi read(self) | UseUseExplosion.rb:20:808:20:3092 | SSA phi read(self) |
-| UseUseExplosion.rb:20:829:20:3076 | SSA phi read(x) | UseUseExplosion.rb:20:808:20:3092 | SSA phi read(x) |
+| UseUseExplosion.rb:20:829:20:3076 | SSA phi read(self) | UseUseExplosion.rb:20:824:20:3076 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:829:20:3076 | SSA phi read(x) | UseUseExplosion.rb:20:824:20:3076 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:829:20:3076 | if ... | UseUseExplosion.rb:20:824:20:3076 | then ... |
 | UseUseExplosion.rb:20:833:20:837 | @prop | UseUseExplosion.rb:20:833:20:842 | ... > ... |
 | UseUseExplosion.rb:20:833:20:837 | [post] self | UseUseExplosion.rb:20:854:20:858 | self |
@@ -680,9 +758,11 @@
 | UseUseExplosion.rb:20:833:20:842 | ... > ... | UseUseExplosion.rb:20:832:20:843 | [false] ( ... ) |
 | UseUseExplosion.rb:20:833:20:842 | ... > ... | UseUseExplosion.rb:20:832:20:843 | [true] ( ... ) |
 | UseUseExplosion.rb:20:841:20:842 | 61 | UseUseExplosion.rb:20:833:20:842 | ... > ... |
+| UseUseExplosion.rb:20:845:20:3060 | [input] SSA phi read(self) | UseUseExplosion.rb:20:829:20:3076 | SSA phi read(self) |
+| UseUseExplosion.rb:20:845:20:3060 | [input] SSA phi read(x) | UseUseExplosion.rb:20:829:20:3076 | SSA phi read(x) |
 | UseUseExplosion.rb:20:845:20:3060 | then ... | UseUseExplosion.rb:20:829:20:3076 | if ... |
-| UseUseExplosion.rb:20:850:20:3060 | SSA phi read(self) | UseUseExplosion.rb:20:829:20:3076 | SSA phi read(self) |
-| UseUseExplosion.rb:20:850:20:3060 | SSA phi read(x) | UseUseExplosion.rb:20:829:20:3076 | SSA phi read(x) |
+| UseUseExplosion.rb:20:850:20:3060 | SSA phi read(self) | UseUseExplosion.rb:20:845:20:3060 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:850:20:3060 | SSA phi read(x) | UseUseExplosion.rb:20:845:20:3060 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:850:20:3060 | if ... | UseUseExplosion.rb:20:845:20:3060 | then ... |
 | UseUseExplosion.rb:20:854:20:858 | @prop | UseUseExplosion.rb:20:854:20:863 | ... > ... |
 | UseUseExplosion.rb:20:854:20:858 | [post] self | UseUseExplosion.rb:20:875:20:879 | self |
@@ -692,9 +772,11 @@
 | UseUseExplosion.rb:20:854:20:863 | ... > ... | UseUseExplosion.rb:20:853:20:864 | [false] ( ... ) |
 | UseUseExplosion.rb:20:854:20:863 | ... > ... | UseUseExplosion.rb:20:853:20:864 | [true] ( ... ) |
 | UseUseExplosion.rb:20:862:20:863 | 60 | UseUseExplosion.rb:20:854:20:863 | ... > ... |
+| UseUseExplosion.rb:20:866:20:3044 | [input] SSA phi read(self) | UseUseExplosion.rb:20:850:20:3060 | SSA phi read(self) |
+| UseUseExplosion.rb:20:866:20:3044 | [input] SSA phi read(x) | UseUseExplosion.rb:20:850:20:3060 | SSA phi read(x) |
 | UseUseExplosion.rb:20:866:20:3044 | then ... | UseUseExplosion.rb:20:850:20:3060 | if ... |
-| UseUseExplosion.rb:20:871:20:3044 | SSA phi read(self) | UseUseExplosion.rb:20:850:20:3060 | SSA phi read(self) |
-| UseUseExplosion.rb:20:871:20:3044 | SSA phi read(x) | UseUseExplosion.rb:20:850:20:3060 | SSA phi read(x) |
+| UseUseExplosion.rb:20:871:20:3044 | SSA phi read(self) | UseUseExplosion.rb:20:866:20:3044 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:871:20:3044 | SSA phi read(x) | UseUseExplosion.rb:20:866:20:3044 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:871:20:3044 | if ... | UseUseExplosion.rb:20:866:20:3044 | then ... |
 | UseUseExplosion.rb:20:875:20:879 | @prop | UseUseExplosion.rb:20:875:20:884 | ... > ... |
 | UseUseExplosion.rb:20:875:20:879 | [post] self | UseUseExplosion.rb:20:896:20:900 | self |
@@ -704,9 +786,11 @@
 | UseUseExplosion.rb:20:875:20:884 | ... > ... | UseUseExplosion.rb:20:874:20:885 | [false] ( ... ) |
 | UseUseExplosion.rb:20:875:20:884 | ... > ... | UseUseExplosion.rb:20:874:20:885 | [true] ( ... ) |
 | UseUseExplosion.rb:20:883:20:884 | 59 | UseUseExplosion.rb:20:875:20:884 | ... > ... |
+| UseUseExplosion.rb:20:887:20:3028 | [input] SSA phi read(self) | UseUseExplosion.rb:20:871:20:3044 | SSA phi read(self) |
+| UseUseExplosion.rb:20:887:20:3028 | [input] SSA phi read(x) | UseUseExplosion.rb:20:871:20:3044 | SSA phi read(x) |
 | UseUseExplosion.rb:20:887:20:3028 | then ... | UseUseExplosion.rb:20:871:20:3044 | if ... |
-| UseUseExplosion.rb:20:892:20:3028 | SSA phi read(self) | UseUseExplosion.rb:20:871:20:3044 | SSA phi read(self) |
-| UseUseExplosion.rb:20:892:20:3028 | SSA phi read(x) | UseUseExplosion.rb:20:871:20:3044 | SSA phi read(x) |
+| UseUseExplosion.rb:20:892:20:3028 | SSA phi read(self) | UseUseExplosion.rb:20:887:20:3028 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:892:20:3028 | SSA phi read(x) | UseUseExplosion.rb:20:887:20:3028 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:892:20:3028 | if ... | UseUseExplosion.rb:20:887:20:3028 | then ... |
 | UseUseExplosion.rb:20:896:20:900 | @prop | UseUseExplosion.rb:20:896:20:905 | ... > ... |
 | UseUseExplosion.rb:20:896:20:900 | [post] self | UseUseExplosion.rb:20:917:20:921 | self |
@@ -716,9 +800,11 @@
 | UseUseExplosion.rb:20:896:20:905 | ... > ... | UseUseExplosion.rb:20:895:20:906 | [false] ( ... ) |
 | UseUseExplosion.rb:20:896:20:905 | ... > ... | UseUseExplosion.rb:20:895:20:906 | [true] ( ... ) |
 | UseUseExplosion.rb:20:904:20:905 | 58 | UseUseExplosion.rb:20:896:20:905 | ... > ... |
+| UseUseExplosion.rb:20:908:20:3012 | [input] SSA phi read(self) | UseUseExplosion.rb:20:892:20:3028 | SSA phi read(self) |
+| UseUseExplosion.rb:20:908:20:3012 | [input] SSA phi read(x) | UseUseExplosion.rb:20:892:20:3028 | SSA phi read(x) |
 | UseUseExplosion.rb:20:908:20:3012 | then ... | UseUseExplosion.rb:20:892:20:3028 | if ... |
-| UseUseExplosion.rb:20:913:20:3012 | SSA phi read(self) | UseUseExplosion.rb:20:892:20:3028 | SSA phi read(self) |
-| UseUseExplosion.rb:20:913:20:3012 | SSA phi read(x) | UseUseExplosion.rb:20:892:20:3028 | SSA phi read(x) |
+| UseUseExplosion.rb:20:913:20:3012 | SSA phi read(self) | UseUseExplosion.rb:20:908:20:3012 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:913:20:3012 | SSA phi read(x) | UseUseExplosion.rb:20:908:20:3012 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:913:20:3012 | if ... | UseUseExplosion.rb:20:908:20:3012 | then ... |
 | UseUseExplosion.rb:20:917:20:921 | @prop | UseUseExplosion.rb:20:917:20:926 | ... > ... |
 | UseUseExplosion.rb:20:917:20:921 | [post] self | UseUseExplosion.rb:20:938:20:942 | self |
@@ -728,9 +814,11 @@
 | UseUseExplosion.rb:20:917:20:926 | ... > ... | UseUseExplosion.rb:20:916:20:927 | [false] ( ... ) |
 | UseUseExplosion.rb:20:917:20:926 | ... > ... | UseUseExplosion.rb:20:916:20:927 | [true] ( ... ) |
 | UseUseExplosion.rb:20:925:20:926 | 57 | UseUseExplosion.rb:20:917:20:926 | ... > ... |
+| UseUseExplosion.rb:20:929:20:2996 | [input] SSA phi read(self) | UseUseExplosion.rb:20:913:20:3012 | SSA phi read(self) |
+| UseUseExplosion.rb:20:929:20:2996 | [input] SSA phi read(x) | UseUseExplosion.rb:20:913:20:3012 | SSA phi read(x) |
 | UseUseExplosion.rb:20:929:20:2996 | then ... | UseUseExplosion.rb:20:913:20:3012 | if ... |
-| UseUseExplosion.rb:20:934:20:2996 | SSA phi read(self) | UseUseExplosion.rb:20:913:20:3012 | SSA phi read(self) |
-| UseUseExplosion.rb:20:934:20:2996 | SSA phi read(x) | UseUseExplosion.rb:20:913:20:3012 | SSA phi read(x) |
+| UseUseExplosion.rb:20:934:20:2996 | SSA phi read(self) | UseUseExplosion.rb:20:929:20:2996 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:934:20:2996 | SSA phi read(x) | UseUseExplosion.rb:20:929:20:2996 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:934:20:2996 | if ... | UseUseExplosion.rb:20:929:20:2996 | then ... |
 | UseUseExplosion.rb:20:938:20:942 | @prop | UseUseExplosion.rb:20:938:20:947 | ... > ... |
 | UseUseExplosion.rb:20:938:20:942 | [post] self | UseUseExplosion.rb:20:959:20:963 | self |
@@ -740,9 +828,11 @@
 | UseUseExplosion.rb:20:938:20:947 | ... > ... | UseUseExplosion.rb:20:937:20:948 | [false] ( ... ) |
 | UseUseExplosion.rb:20:938:20:947 | ... > ... | UseUseExplosion.rb:20:937:20:948 | [true] ( ... ) |
 | UseUseExplosion.rb:20:946:20:947 | 56 | UseUseExplosion.rb:20:938:20:947 | ... > ... |
+| UseUseExplosion.rb:20:950:20:2980 | [input] SSA phi read(self) | UseUseExplosion.rb:20:934:20:2996 | SSA phi read(self) |
+| UseUseExplosion.rb:20:950:20:2980 | [input] SSA phi read(x) | UseUseExplosion.rb:20:934:20:2996 | SSA phi read(x) |
 | UseUseExplosion.rb:20:950:20:2980 | then ... | UseUseExplosion.rb:20:934:20:2996 | if ... |
-| UseUseExplosion.rb:20:955:20:2980 | SSA phi read(self) | UseUseExplosion.rb:20:934:20:2996 | SSA phi read(self) |
-| UseUseExplosion.rb:20:955:20:2980 | SSA phi read(x) | UseUseExplosion.rb:20:934:20:2996 | SSA phi read(x) |
+| UseUseExplosion.rb:20:955:20:2980 | SSA phi read(self) | UseUseExplosion.rb:20:950:20:2980 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:955:20:2980 | SSA phi read(x) | UseUseExplosion.rb:20:950:20:2980 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:955:20:2980 | if ... | UseUseExplosion.rb:20:950:20:2980 | then ... |
 | UseUseExplosion.rb:20:959:20:963 | @prop | UseUseExplosion.rb:20:959:20:968 | ... > ... |
 | UseUseExplosion.rb:20:959:20:963 | [post] self | UseUseExplosion.rb:20:980:20:984 | self |
@@ -752,9 +842,11 @@
 | UseUseExplosion.rb:20:959:20:968 | ... > ... | UseUseExplosion.rb:20:958:20:969 | [false] ( ... ) |
 | UseUseExplosion.rb:20:959:20:968 | ... > ... | UseUseExplosion.rb:20:958:20:969 | [true] ( ... ) |
 | UseUseExplosion.rb:20:967:20:968 | 55 | UseUseExplosion.rb:20:959:20:968 | ... > ... |
+| UseUseExplosion.rb:20:971:20:2964 | [input] SSA phi read(self) | UseUseExplosion.rb:20:955:20:2980 | SSA phi read(self) |
+| UseUseExplosion.rb:20:971:20:2964 | [input] SSA phi read(x) | UseUseExplosion.rb:20:955:20:2980 | SSA phi read(x) |
 | UseUseExplosion.rb:20:971:20:2964 | then ... | UseUseExplosion.rb:20:955:20:2980 | if ... |
-| UseUseExplosion.rb:20:976:20:2964 | SSA phi read(self) | UseUseExplosion.rb:20:955:20:2980 | SSA phi read(self) |
-| UseUseExplosion.rb:20:976:20:2964 | SSA phi read(x) | UseUseExplosion.rb:20:955:20:2980 | SSA phi read(x) |
+| UseUseExplosion.rb:20:976:20:2964 | SSA phi read(self) | UseUseExplosion.rb:20:971:20:2964 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:976:20:2964 | SSA phi read(x) | UseUseExplosion.rb:20:971:20:2964 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:976:20:2964 | if ... | UseUseExplosion.rb:20:971:20:2964 | then ... |
 | UseUseExplosion.rb:20:980:20:984 | @prop | UseUseExplosion.rb:20:980:20:989 | ... > ... |
 | UseUseExplosion.rb:20:980:20:984 | [post] self | UseUseExplosion.rb:20:1001:20:1005 | self |
@@ -764,9 +856,11 @@
 | UseUseExplosion.rb:20:980:20:989 | ... > ... | UseUseExplosion.rb:20:979:20:990 | [false] ( ... ) |
 | UseUseExplosion.rb:20:980:20:989 | ... > ... | UseUseExplosion.rb:20:979:20:990 | [true] ( ... ) |
 | UseUseExplosion.rb:20:988:20:989 | 54 | UseUseExplosion.rb:20:980:20:989 | ... > ... |
+| UseUseExplosion.rb:20:992:20:2948 | [input] SSA phi read(self) | UseUseExplosion.rb:20:976:20:2964 | SSA phi read(self) |
+| UseUseExplosion.rb:20:992:20:2948 | [input] SSA phi read(x) | UseUseExplosion.rb:20:976:20:2964 | SSA phi read(x) |
 | UseUseExplosion.rb:20:992:20:2948 | then ... | UseUseExplosion.rb:20:976:20:2964 | if ... |
-| UseUseExplosion.rb:20:997:20:2948 | SSA phi read(self) | UseUseExplosion.rb:20:976:20:2964 | SSA phi read(self) |
-| UseUseExplosion.rb:20:997:20:2948 | SSA phi read(x) | UseUseExplosion.rb:20:976:20:2964 | SSA phi read(x) |
+| UseUseExplosion.rb:20:997:20:2948 | SSA phi read(self) | UseUseExplosion.rb:20:992:20:2948 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:997:20:2948 | SSA phi read(x) | UseUseExplosion.rb:20:992:20:2948 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:997:20:2948 | if ... | UseUseExplosion.rb:20:992:20:2948 | then ... |
 | UseUseExplosion.rb:20:1001:20:1005 | @prop | UseUseExplosion.rb:20:1001:20:1010 | ... > ... |
 | UseUseExplosion.rb:20:1001:20:1005 | [post] self | UseUseExplosion.rb:20:1022:20:1026 | self |
@@ -776,9 +870,11 @@
 | UseUseExplosion.rb:20:1001:20:1010 | ... > ... | UseUseExplosion.rb:20:1000:20:1011 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1001:20:1010 | ... > ... | UseUseExplosion.rb:20:1000:20:1011 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1009:20:1010 | 53 | UseUseExplosion.rb:20:1001:20:1010 | ... > ... |
+| UseUseExplosion.rb:20:1013:20:2932 | [input] SSA phi read(self) | UseUseExplosion.rb:20:997:20:2948 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1013:20:2932 | [input] SSA phi read(x) | UseUseExplosion.rb:20:997:20:2948 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1013:20:2932 | then ... | UseUseExplosion.rb:20:997:20:2948 | if ... |
-| UseUseExplosion.rb:20:1018:20:2932 | SSA phi read(self) | UseUseExplosion.rb:20:997:20:2948 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1018:20:2932 | SSA phi read(x) | UseUseExplosion.rb:20:997:20:2948 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1018:20:2932 | SSA phi read(self) | UseUseExplosion.rb:20:1013:20:2932 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1018:20:2932 | SSA phi read(x) | UseUseExplosion.rb:20:1013:20:2932 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1018:20:2932 | if ... | UseUseExplosion.rb:20:1013:20:2932 | then ... |
 | UseUseExplosion.rb:20:1022:20:1026 | @prop | UseUseExplosion.rb:20:1022:20:1031 | ... > ... |
 | UseUseExplosion.rb:20:1022:20:1026 | [post] self | UseUseExplosion.rb:20:1043:20:1047 | self |
@@ -788,9 +884,11 @@
 | UseUseExplosion.rb:20:1022:20:1031 | ... > ... | UseUseExplosion.rb:20:1021:20:1032 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1022:20:1031 | ... > ... | UseUseExplosion.rb:20:1021:20:1032 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1030:20:1031 | 52 | UseUseExplosion.rb:20:1022:20:1031 | ... > ... |
+| UseUseExplosion.rb:20:1034:20:2916 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1018:20:2932 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1034:20:2916 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1018:20:2932 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1034:20:2916 | then ... | UseUseExplosion.rb:20:1018:20:2932 | if ... |
-| UseUseExplosion.rb:20:1039:20:2916 | SSA phi read(self) | UseUseExplosion.rb:20:1018:20:2932 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1039:20:2916 | SSA phi read(x) | UseUseExplosion.rb:20:1018:20:2932 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1039:20:2916 | SSA phi read(self) | UseUseExplosion.rb:20:1034:20:2916 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1039:20:2916 | SSA phi read(x) | UseUseExplosion.rb:20:1034:20:2916 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1039:20:2916 | if ... | UseUseExplosion.rb:20:1034:20:2916 | then ... |
 | UseUseExplosion.rb:20:1043:20:1047 | @prop | UseUseExplosion.rb:20:1043:20:1052 | ... > ... |
 | UseUseExplosion.rb:20:1043:20:1047 | [post] self | UseUseExplosion.rb:20:1064:20:1068 | self |
@@ -800,9 +898,11 @@
 | UseUseExplosion.rb:20:1043:20:1052 | ... > ... | UseUseExplosion.rb:20:1042:20:1053 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1043:20:1052 | ... > ... | UseUseExplosion.rb:20:1042:20:1053 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1051:20:1052 | 51 | UseUseExplosion.rb:20:1043:20:1052 | ... > ... |
+| UseUseExplosion.rb:20:1055:20:2900 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1039:20:2916 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1055:20:2900 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1039:20:2916 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1055:20:2900 | then ... | UseUseExplosion.rb:20:1039:20:2916 | if ... |
-| UseUseExplosion.rb:20:1060:20:2900 | SSA phi read(self) | UseUseExplosion.rb:20:1039:20:2916 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1060:20:2900 | SSA phi read(x) | UseUseExplosion.rb:20:1039:20:2916 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1060:20:2900 | SSA phi read(self) | UseUseExplosion.rb:20:1055:20:2900 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1060:20:2900 | SSA phi read(x) | UseUseExplosion.rb:20:1055:20:2900 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1060:20:2900 | if ... | UseUseExplosion.rb:20:1055:20:2900 | then ... |
 | UseUseExplosion.rb:20:1064:20:1068 | @prop | UseUseExplosion.rb:20:1064:20:1073 | ... > ... |
 | UseUseExplosion.rb:20:1064:20:1068 | [post] self | UseUseExplosion.rb:20:1085:20:1089 | self |
@@ -812,9 +912,11 @@
 | UseUseExplosion.rb:20:1064:20:1073 | ... > ... | UseUseExplosion.rb:20:1063:20:1074 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1064:20:1073 | ... > ... | UseUseExplosion.rb:20:1063:20:1074 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1072:20:1073 | 50 | UseUseExplosion.rb:20:1064:20:1073 | ... > ... |
+| UseUseExplosion.rb:20:1076:20:2884 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1060:20:2900 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1076:20:2884 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1060:20:2900 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1076:20:2884 | then ... | UseUseExplosion.rb:20:1060:20:2900 | if ... |
-| UseUseExplosion.rb:20:1081:20:2884 | SSA phi read(self) | UseUseExplosion.rb:20:1060:20:2900 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1081:20:2884 | SSA phi read(x) | UseUseExplosion.rb:20:1060:20:2900 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1081:20:2884 | SSA phi read(self) | UseUseExplosion.rb:20:1076:20:2884 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1081:20:2884 | SSA phi read(x) | UseUseExplosion.rb:20:1076:20:2884 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1081:20:2884 | if ... | UseUseExplosion.rb:20:1076:20:2884 | then ... |
 | UseUseExplosion.rb:20:1085:20:1089 | @prop | UseUseExplosion.rb:20:1085:20:1094 | ... > ... |
 | UseUseExplosion.rb:20:1085:20:1089 | [post] self | UseUseExplosion.rb:20:1106:20:1110 | self |
@@ -824,9 +926,11 @@
 | UseUseExplosion.rb:20:1085:20:1094 | ... > ... | UseUseExplosion.rb:20:1084:20:1095 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1085:20:1094 | ... > ... | UseUseExplosion.rb:20:1084:20:1095 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1093:20:1094 | 49 | UseUseExplosion.rb:20:1085:20:1094 | ... > ... |
+| UseUseExplosion.rb:20:1097:20:2868 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1081:20:2884 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1097:20:2868 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1081:20:2884 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1097:20:2868 | then ... | UseUseExplosion.rb:20:1081:20:2884 | if ... |
-| UseUseExplosion.rb:20:1102:20:2868 | SSA phi read(self) | UseUseExplosion.rb:20:1081:20:2884 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1102:20:2868 | SSA phi read(x) | UseUseExplosion.rb:20:1081:20:2884 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1102:20:2868 | SSA phi read(self) | UseUseExplosion.rb:20:1097:20:2868 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1102:20:2868 | SSA phi read(x) | UseUseExplosion.rb:20:1097:20:2868 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1102:20:2868 | if ... | UseUseExplosion.rb:20:1097:20:2868 | then ... |
 | UseUseExplosion.rb:20:1106:20:1110 | @prop | UseUseExplosion.rb:20:1106:20:1115 | ... > ... |
 | UseUseExplosion.rb:20:1106:20:1110 | [post] self | UseUseExplosion.rb:20:1127:20:1131 | self |
@@ -836,9 +940,11 @@
 | UseUseExplosion.rb:20:1106:20:1115 | ... > ... | UseUseExplosion.rb:20:1105:20:1116 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1106:20:1115 | ... > ... | UseUseExplosion.rb:20:1105:20:1116 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1114:20:1115 | 48 | UseUseExplosion.rb:20:1106:20:1115 | ... > ... |
+| UseUseExplosion.rb:20:1118:20:2852 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1102:20:2868 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1118:20:2852 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1102:20:2868 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1118:20:2852 | then ... | UseUseExplosion.rb:20:1102:20:2868 | if ... |
-| UseUseExplosion.rb:20:1123:20:2852 | SSA phi read(self) | UseUseExplosion.rb:20:1102:20:2868 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1123:20:2852 | SSA phi read(x) | UseUseExplosion.rb:20:1102:20:2868 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1123:20:2852 | SSA phi read(self) | UseUseExplosion.rb:20:1118:20:2852 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1123:20:2852 | SSA phi read(x) | UseUseExplosion.rb:20:1118:20:2852 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1123:20:2852 | if ... | UseUseExplosion.rb:20:1118:20:2852 | then ... |
 | UseUseExplosion.rb:20:1127:20:1131 | @prop | UseUseExplosion.rb:20:1127:20:1136 | ... > ... |
 | UseUseExplosion.rb:20:1127:20:1131 | [post] self | UseUseExplosion.rb:20:1148:20:1152 | self |
@@ -848,9 +954,11 @@
 | UseUseExplosion.rb:20:1127:20:1136 | ... > ... | UseUseExplosion.rb:20:1126:20:1137 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1127:20:1136 | ... > ... | UseUseExplosion.rb:20:1126:20:1137 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1135:20:1136 | 47 | UseUseExplosion.rb:20:1127:20:1136 | ... > ... |
+| UseUseExplosion.rb:20:1139:20:2836 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1123:20:2852 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1139:20:2836 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1123:20:2852 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1139:20:2836 | then ... | UseUseExplosion.rb:20:1123:20:2852 | if ... |
-| UseUseExplosion.rb:20:1144:20:2836 | SSA phi read(self) | UseUseExplosion.rb:20:1123:20:2852 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1144:20:2836 | SSA phi read(x) | UseUseExplosion.rb:20:1123:20:2852 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1144:20:2836 | SSA phi read(self) | UseUseExplosion.rb:20:1139:20:2836 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1144:20:2836 | SSA phi read(x) | UseUseExplosion.rb:20:1139:20:2836 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1144:20:2836 | if ... | UseUseExplosion.rb:20:1139:20:2836 | then ... |
 | UseUseExplosion.rb:20:1148:20:1152 | @prop | UseUseExplosion.rb:20:1148:20:1157 | ... > ... |
 | UseUseExplosion.rb:20:1148:20:1152 | [post] self | UseUseExplosion.rb:20:1169:20:1173 | self |
@@ -860,9 +968,11 @@
 | UseUseExplosion.rb:20:1148:20:1157 | ... > ... | UseUseExplosion.rb:20:1147:20:1158 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1148:20:1157 | ... > ... | UseUseExplosion.rb:20:1147:20:1158 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1156:20:1157 | 46 | UseUseExplosion.rb:20:1148:20:1157 | ... > ... |
+| UseUseExplosion.rb:20:1160:20:2820 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1144:20:2836 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1160:20:2820 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1144:20:2836 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1160:20:2820 | then ... | UseUseExplosion.rb:20:1144:20:2836 | if ... |
-| UseUseExplosion.rb:20:1165:20:2820 | SSA phi read(self) | UseUseExplosion.rb:20:1144:20:2836 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1165:20:2820 | SSA phi read(x) | UseUseExplosion.rb:20:1144:20:2836 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1165:20:2820 | SSA phi read(self) | UseUseExplosion.rb:20:1160:20:2820 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1165:20:2820 | SSA phi read(x) | UseUseExplosion.rb:20:1160:20:2820 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1165:20:2820 | if ... | UseUseExplosion.rb:20:1160:20:2820 | then ... |
 | UseUseExplosion.rb:20:1169:20:1173 | @prop | UseUseExplosion.rb:20:1169:20:1178 | ... > ... |
 | UseUseExplosion.rb:20:1169:20:1173 | [post] self | UseUseExplosion.rb:20:1190:20:1194 | self |
@@ -872,9 +982,11 @@
 | UseUseExplosion.rb:20:1169:20:1178 | ... > ... | UseUseExplosion.rb:20:1168:20:1179 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1169:20:1178 | ... > ... | UseUseExplosion.rb:20:1168:20:1179 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1177:20:1178 | 45 | UseUseExplosion.rb:20:1169:20:1178 | ... > ... |
+| UseUseExplosion.rb:20:1181:20:2804 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1165:20:2820 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1181:20:2804 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1165:20:2820 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1181:20:2804 | then ... | UseUseExplosion.rb:20:1165:20:2820 | if ... |
-| UseUseExplosion.rb:20:1186:20:2804 | SSA phi read(self) | UseUseExplosion.rb:20:1165:20:2820 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1186:20:2804 | SSA phi read(x) | UseUseExplosion.rb:20:1165:20:2820 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1186:20:2804 | SSA phi read(self) | UseUseExplosion.rb:20:1181:20:2804 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1186:20:2804 | SSA phi read(x) | UseUseExplosion.rb:20:1181:20:2804 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1186:20:2804 | if ... | UseUseExplosion.rb:20:1181:20:2804 | then ... |
 | UseUseExplosion.rb:20:1190:20:1194 | @prop | UseUseExplosion.rb:20:1190:20:1199 | ... > ... |
 | UseUseExplosion.rb:20:1190:20:1194 | [post] self | UseUseExplosion.rb:20:1211:20:1215 | self |
@@ -884,9 +996,11 @@
 | UseUseExplosion.rb:20:1190:20:1199 | ... > ... | UseUseExplosion.rb:20:1189:20:1200 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1190:20:1199 | ... > ... | UseUseExplosion.rb:20:1189:20:1200 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1198:20:1199 | 44 | UseUseExplosion.rb:20:1190:20:1199 | ... > ... |
+| UseUseExplosion.rb:20:1202:20:2788 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1186:20:2804 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1202:20:2788 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1186:20:2804 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1202:20:2788 | then ... | UseUseExplosion.rb:20:1186:20:2804 | if ... |
-| UseUseExplosion.rb:20:1207:20:2788 | SSA phi read(self) | UseUseExplosion.rb:20:1186:20:2804 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1207:20:2788 | SSA phi read(x) | UseUseExplosion.rb:20:1186:20:2804 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1207:20:2788 | SSA phi read(self) | UseUseExplosion.rb:20:1202:20:2788 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1207:20:2788 | SSA phi read(x) | UseUseExplosion.rb:20:1202:20:2788 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1207:20:2788 | if ... | UseUseExplosion.rb:20:1202:20:2788 | then ... |
 | UseUseExplosion.rb:20:1211:20:1215 | @prop | UseUseExplosion.rb:20:1211:20:1220 | ... > ... |
 | UseUseExplosion.rb:20:1211:20:1215 | [post] self | UseUseExplosion.rb:20:1232:20:1236 | self |
@@ -896,9 +1010,11 @@
 | UseUseExplosion.rb:20:1211:20:1220 | ... > ... | UseUseExplosion.rb:20:1210:20:1221 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1211:20:1220 | ... > ... | UseUseExplosion.rb:20:1210:20:1221 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1219:20:1220 | 43 | UseUseExplosion.rb:20:1211:20:1220 | ... > ... |
+| UseUseExplosion.rb:20:1223:20:2772 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1207:20:2788 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1223:20:2772 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1207:20:2788 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1223:20:2772 | then ... | UseUseExplosion.rb:20:1207:20:2788 | if ... |
-| UseUseExplosion.rb:20:1228:20:2772 | SSA phi read(self) | UseUseExplosion.rb:20:1207:20:2788 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1228:20:2772 | SSA phi read(x) | UseUseExplosion.rb:20:1207:20:2788 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1228:20:2772 | SSA phi read(self) | UseUseExplosion.rb:20:1223:20:2772 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1228:20:2772 | SSA phi read(x) | UseUseExplosion.rb:20:1223:20:2772 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1228:20:2772 | if ... | UseUseExplosion.rb:20:1223:20:2772 | then ... |
 | UseUseExplosion.rb:20:1232:20:1236 | @prop | UseUseExplosion.rb:20:1232:20:1241 | ... > ... |
 | UseUseExplosion.rb:20:1232:20:1236 | [post] self | UseUseExplosion.rb:20:1253:20:1257 | self |
@@ -908,9 +1024,11 @@
 | UseUseExplosion.rb:20:1232:20:1241 | ... > ... | UseUseExplosion.rb:20:1231:20:1242 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1232:20:1241 | ... > ... | UseUseExplosion.rb:20:1231:20:1242 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1240:20:1241 | 42 | UseUseExplosion.rb:20:1232:20:1241 | ... > ... |
+| UseUseExplosion.rb:20:1244:20:2756 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1228:20:2772 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1244:20:2756 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1228:20:2772 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1244:20:2756 | then ... | UseUseExplosion.rb:20:1228:20:2772 | if ... |
-| UseUseExplosion.rb:20:1249:20:2756 | SSA phi read(self) | UseUseExplosion.rb:20:1228:20:2772 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1249:20:2756 | SSA phi read(x) | UseUseExplosion.rb:20:1228:20:2772 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1249:20:2756 | SSA phi read(self) | UseUseExplosion.rb:20:1244:20:2756 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1249:20:2756 | SSA phi read(x) | UseUseExplosion.rb:20:1244:20:2756 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1249:20:2756 | if ... | UseUseExplosion.rb:20:1244:20:2756 | then ... |
 | UseUseExplosion.rb:20:1253:20:1257 | @prop | UseUseExplosion.rb:20:1253:20:1262 | ... > ... |
 | UseUseExplosion.rb:20:1253:20:1257 | [post] self | UseUseExplosion.rb:20:1274:20:1278 | self |
@@ -920,9 +1038,11 @@
 | UseUseExplosion.rb:20:1253:20:1262 | ... > ... | UseUseExplosion.rb:20:1252:20:1263 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1253:20:1262 | ... > ... | UseUseExplosion.rb:20:1252:20:1263 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1261:20:1262 | 41 | UseUseExplosion.rb:20:1253:20:1262 | ... > ... |
+| UseUseExplosion.rb:20:1265:20:2740 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1249:20:2756 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1265:20:2740 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1249:20:2756 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1265:20:2740 | then ... | UseUseExplosion.rb:20:1249:20:2756 | if ... |
-| UseUseExplosion.rb:20:1270:20:2740 | SSA phi read(self) | UseUseExplosion.rb:20:1249:20:2756 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1270:20:2740 | SSA phi read(x) | UseUseExplosion.rb:20:1249:20:2756 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1270:20:2740 | SSA phi read(self) | UseUseExplosion.rb:20:1265:20:2740 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1270:20:2740 | SSA phi read(x) | UseUseExplosion.rb:20:1265:20:2740 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1270:20:2740 | if ... | UseUseExplosion.rb:20:1265:20:2740 | then ... |
 | UseUseExplosion.rb:20:1274:20:1278 | @prop | UseUseExplosion.rb:20:1274:20:1283 | ... > ... |
 | UseUseExplosion.rb:20:1274:20:1278 | [post] self | UseUseExplosion.rb:20:1295:20:1299 | self |
@@ -932,9 +1052,11 @@
 | UseUseExplosion.rb:20:1274:20:1283 | ... > ... | UseUseExplosion.rb:20:1273:20:1284 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1274:20:1283 | ... > ... | UseUseExplosion.rb:20:1273:20:1284 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1282:20:1283 | 40 | UseUseExplosion.rb:20:1274:20:1283 | ... > ... |
+| UseUseExplosion.rb:20:1286:20:2724 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1270:20:2740 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1286:20:2724 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1270:20:2740 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1286:20:2724 | then ... | UseUseExplosion.rb:20:1270:20:2740 | if ... |
-| UseUseExplosion.rb:20:1291:20:2724 | SSA phi read(self) | UseUseExplosion.rb:20:1270:20:2740 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1291:20:2724 | SSA phi read(x) | UseUseExplosion.rb:20:1270:20:2740 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1291:20:2724 | SSA phi read(self) | UseUseExplosion.rb:20:1286:20:2724 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1291:20:2724 | SSA phi read(x) | UseUseExplosion.rb:20:1286:20:2724 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1291:20:2724 | if ... | UseUseExplosion.rb:20:1286:20:2724 | then ... |
 | UseUseExplosion.rb:20:1295:20:1299 | @prop | UseUseExplosion.rb:20:1295:20:1304 | ... > ... |
 | UseUseExplosion.rb:20:1295:20:1299 | [post] self | UseUseExplosion.rb:20:1316:20:1320 | self |
@@ -944,9 +1066,11 @@
 | UseUseExplosion.rb:20:1295:20:1304 | ... > ... | UseUseExplosion.rb:20:1294:20:1305 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1295:20:1304 | ... > ... | UseUseExplosion.rb:20:1294:20:1305 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1303:20:1304 | 39 | UseUseExplosion.rb:20:1295:20:1304 | ... > ... |
+| UseUseExplosion.rb:20:1307:20:2708 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1291:20:2724 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1307:20:2708 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1291:20:2724 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1307:20:2708 | then ... | UseUseExplosion.rb:20:1291:20:2724 | if ... |
-| UseUseExplosion.rb:20:1312:20:2708 | SSA phi read(self) | UseUseExplosion.rb:20:1291:20:2724 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1312:20:2708 | SSA phi read(x) | UseUseExplosion.rb:20:1291:20:2724 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1312:20:2708 | SSA phi read(self) | UseUseExplosion.rb:20:1307:20:2708 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1312:20:2708 | SSA phi read(x) | UseUseExplosion.rb:20:1307:20:2708 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1312:20:2708 | if ... | UseUseExplosion.rb:20:1307:20:2708 | then ... |
 | UseUseExplosion.rb:20:1316:20:1320 | @prop | UseUseExplosion.rb:20:1316:20:1325 | ... > ... |
 | UseUseExplosion.rb:20:1316:20:1320 | [post] self | UseUseExplosion.rb:20:1337:20:1341 | self |
@@ -956,9 +1080,11 @@
 | UseUseExplosion.rb:20:1316:20:1325 | ... > ... | UseUseExplosion.rb:20:1315:20:1326 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1316:20:1325 | ... > ... | UseUseExplosion.rb:20:1315:20:1326 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1324:20:1325 | 38 | UseUseExplosion.rb:20:1316:20:1325 | ... > ... |
+| UseUseExplosion.rb:20:1328:20:2692 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1312:20:2708 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1328:20:2692 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1312:20:2708 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1328:20:2692 | then ... | UseUseExplosion.rb:20:1312:20:2708 | if ... |
-| UseUseExplosion.rb:20:1333:20:2692 | SSA phi read(self) | UseUseExplosion.rb:20:1312:20:2708 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1333:20:2692 | SSA phi read(x) | UseUseExplosion.rb:20:1312:20:2708 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1333:20:2692 | SSA phi read(self) | UseUseExplosion.rb:20:1328:20:2692 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1333:20:2692 | SSA phi read(x) | UseUseExplosion.rb:20:1328:20:2692 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1333:20:2692 | if ... | UseUseExplosion.rb:20:1328:20:2692 | then ... |
 | UseUseExplosion.rb:20:1337:20:1341 | @prop | UseUseExplosion.rb:20:1337:20:1346 | ... > ... |
 | UseUseExplosion.rb:20:1337:20:1341 | [post] self | UseUseExplosion.rb:20:1358:20:1362 | self |
@@ -968,9 +1094,11 @@
 | UseUseExplosion.rb:20:1337:20:1346 | ... > ... | UseUseExplosion.rb:20:1336:20:1347 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1337:20:1346 | ... > ... | UseUseExplosion.rb:20:1336:20:1347 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1345:20:1346 | 37 | UseUseExplosion.rb:20:1337:20:1346 | ... > ... |
+| UseUseExplosion.rb:20:1349:20:2676 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1333:20:2692 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1349:20:2676 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1333:20:2692 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1349:20:2676 | then ... | UseUseExplosion.rb:20:1333:20:2692 | if ... |
-| UseUseExplosion.rb:20:1354:20:2676 | SSA phi read(self) | UseUseExplosion.rb:20:1333:20:2692 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1354:20:2676 | SSA phi read(x) | UseUseExplosion.rb:20:1333:20:2692 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1354:20:2676 | SSA phi read(self) | UseUseExplosion.rb:20:1349:20:2676 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1354:20:2676 | SSA phi read(x) | UseUseExplosion.rb:20:1349:20:2676 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1354:20:2676 | if ... | UseUseExplosion.rb:20:1349:20:2676 | then ... |
 | UseUseExplosion.rb:20:1358:20:1362 | @prop | UseUseExplosion.rb:20:1358:20:1367 | ... > ... |
 | UseUseExplosion.rb:20:1358:20:1362 | [post] self | UseUseExplosion.rb:20:1379:20:1383 | self |
@@ -980,9 +1108,11 @@
 | UseUseExplosion.rb:20:1358:20:1367 | ... > ... | UseUseExplosion.rb:20:1357:20:1368 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1358:20:1367 | ... > ... | UseUseExplosion.rb:20:1357:20:1368 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1366:20:1367 | 36 | UseUseExplosion.rb:20:1358:20:1367 | ... > ... |
+| UseUseExplosion.rb:20:1370:20:2660 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1354:20:2676 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1370:20:2660 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1354:20:2676 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1370:20:2660 | then ... | UseUseExplosion.rb:20:1354:20:2676 | if ... |
-| UseUseExplosion.rb:20:1375:20:2660 | SSA phi read(self) | UseUseExplosion.rb:20:1354:20:2676 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1375:20:2660 | SSA phi read(x) | UseUseExplosion.rb:20:1354:20:2676 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1375:20:2660 | SSA phi read(self) | UseUseExplosion.rb:20:1370:20:2660 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1375:20:2660 | SSA phi read(x) | UseUseExplosion.rb:20:1370:20:2660 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1375:20:2660 | if ... | UseUseExplosion.rb:20:1370:20:2660 | then ... |
 | UseUseExplosion.rb:20:1379:20:1383 | @prop | UseUseExplosion.rb:20:1379:20:1388 | ... > ... |
 | UseUseExplosion.rb:20:1379:20:1383 | [post] self | UseUseExplosion.rb:20:1400:20:1404 | self |
@@ -992,9 +1122,11 @@
 | UseUseExplosion.rb:20:1379:20:1388 | ... > ... | UseUseExplosion.rb:20:1378:20:1389 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1379:20:1388 | ... > ... | UseUseExplosion.rb:20:1378:20:1389 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1387:20:1388 | 35 | UseUseExplosion.rb:20:1379:20:1388 | ... > ... |
+| UseUseExplosion.rb:20:1391:20:2644 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1375:20:2660 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1391:20:2644 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1375:20:2660 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1391:20:2644 | then ... | UseUseExplosion.rb:20:1375:20:2660 | if ... |
-| UseUseExplosion.rb:20:1396:20:2644 | SSA phi read(self) | UseUseExplosion.rb:20:1375:20:2660 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1396:20:2644 | SSA phi read(x) | UseUseExplosion.rb:20:1375:20:2660 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1396:20:2644 | SSA phi read(self) | UseUseExplosion.rb:20:1391:20:2644 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1396:20:2644 | SSA phi read(x) | UseUseExplosion.rb:20:1391:20:2644 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1396:20:2644 | if ... | UseUseExplosion.rb:20:1391:20:2644 | then ... |
 | UseUseExplosion.rb:20:1400:20:1404 | @prop | UseUseExplosion.rb:20:1400:20:1409 | ... > ... |
 | UseUseExplosion.rb:20:1400:20:1404 | [post] self | UseUseExplosion.rb:20:1421:20:1425 | self |
@@ -1004,9 +1136,11 @@
 | UseUseExplosion.rb:20:1400:20:1409 | ... > ... | UseUseExplosion.rb:20:1399:20:1410 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1400:20:1409 | ... > ... | UseUseExplosion.rb:20:1399:20:1410 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1408:20:1409 | 34 | UseUseExplosion.rb:20:1400:20:1409 | ... > ... |
+| UseUseExplosion.rb:20:1412:20:2628 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1396:20:2644 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1412:20:2628 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1396:20:2644 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1412:20:2628 | then ... | UseUseExplosion.rb:20:1396:20:2644 | if ... |
-| UseUseExplosion.rb:20:1417:20:2628 | SSA phi read(self) | UseUseExplosion.rb:20:1396:20:2644 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1417:20:2628 | SSA phi read(x) | UseUseExplosion.rb:20:1396:20:2644 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1417:20:2628 | SSA phi read(self) | UseUseExplosion.rb:20:1412:20:2628 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1417:20:2628 | SSA phi read(x) | UseUseExplosion.rb:20:1412:20:2628 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1417:20:2628 | if ... | UseUseExplosion.rb:20:1412:20:2628 | then ... |
 | UseUseExplosion.rb:20:1421:20:1425 | @prop | UseUseExplosion.rb:20:1421:20:1430 | ... > ... |
 | UseUseExplosion.rb:20:1421:20:1425 | [post] self | UseUseExplosion.rb:20:1442:20:1446 | self |
@@ -1016,9 +1150,11 @@
 | UseUseExplosion.rb:20:1421:20:1430 | ... > ... | UseUseExplosion.rb:20:1420:20:1431 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1421:20:1430 | ... > ... | UseUseExplosion.rb:20:1420:20:1431 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1429:20:1430 | 33 | UseUseExplosion.rb:20:1421:20:1430 | ... > ... |
+| UseUseExplosion.rb:20:1433:20:2612 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1417:20:2628 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1433:20:2612 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1417:20:2628 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1433:20:2612 | then ... | UseUseExplosion.rb:20:1417:20:2628 | if ... |
-| UseUseExplosion.rb:20:1438:20:2612 | SSA phi read(self) | UseUseExplosion.rb:20:1417:20:2628 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1438:20:2612 | SSA phi read(x) | UseUseExplosion.rb:20:1417:20:2628 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1438:20:2612 | SSA phi read(self) | UseUseExplosion.rb:20:1433:20:2612 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1438:20:2612 | SSA phi read(x) | UseUseExplosion.rb:20:1433:20:2612 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1438:20:2612 | if ... | UseUseExplosion.rb:20:1433:20:2612 | then ... |
 | UseUseExplosion.rb:20:1442:20:1446 | @prop | UseUseExplosion.rb:20:1442:20:1451 | ... > ... |
 | UseUseExplosion.rb:20:1442:20:1446 | [post] self | UseUseExplosion.rb:20:1463:20:1467 | self |
@@ -1028,9 +1164,11 @@
 | UseUseExplosion.rb:20:1442:20:1451 | ... > ... | UseUseExplosion.rb:20:1441:20:1452 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1442:20:1451 | ... > ... | UseUseExplosion.rb:20:1441:20:1452 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1450:20:1451 | 32 | UseUseExplosion.rb:20:1442:20:1451 | ... > ... |
+| UseUseExplosion.rb:20:1454:20:2596 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1438:20:2612 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1454:20:2596 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1438:20:2612 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1454:20:2596 | then ... | UseUseExplosion.rb:20:1438:20:2612 | if ... |
-| UseUseExplosion.rb:20:1459:20:2596 | SSA phi read(self) | UseUseExplosion.rb:20:1438:20:2612 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1459:20:2596 | SSA phi read(x) | UseUseExplosion.rb:20:1438:20:2612 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1459:20:2596 | SSA phi read(self) | UseUseExplosion.rb:20:1454:20:2596 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1459:20:2596 | SSA phi read(x) | UseUseExplosion.rb:20:1454:20:2596 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1459:20:2596 | if ... | UseUseExplosion.rb:20:1454:20:2596 | then ... |
 | UseUseExplosion.rb:20:1463:20:1467 | @prop | UseUseExplosion.rb:20:1463:20:1472 | ... > ... |
 | UseUseExplosion.rb:20:1463:20:1467 | [post] self | UseUseExplosion.rb:20:1484:20:1488 | self |
@@ -1040,9 +1178,11 @@
 | UseUseExplosion.rb:20:1463:20:1472 | ... > ... | UseUseExplosion.rb:20:1462:20:1473 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1463:20:1472 | ... > ... | UseUseExplosion.rb:20:1462:20:1473 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1471:20:1472 | 31 | UseUseExplosion.rb:20:1463:20:1472 | ... > ... |
+| UseUseExplosion.rb:20:1475:20:2580 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1459:20:2596 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1475:20:2580 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1459:20:2596 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1475:20:2580 | then ... | UseUseExplosion.rb:20:1459:20:2596 | if ... |
-| UseUseExplosion.rb:20:1480:20:2580 | SSA phi read(self) | UseUseExplosion.rb:20:1459:20:2596 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1480:20:2580 | SSA phi read(x) | UseUseExplosion.rb:20:1459:20:2596 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1480:20:2580 | SSA phi read(self) | UseUseExplosion.rb:20:1475:20:2580 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1480:20:2580 | SSA phi read(x) | UseUseExplosion.rb:20:1475:20:2580 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1480:20:2580 | if ... | UseUseExplosion.rb:20:1475:20:2580 | then ... |
 | UseUseExplosion.rb:20:1484:20:1488 | @prop | UseUseExplosion.rb:20:1484:20:1493 | ... > ... |
 | UseUseExplosion.rb:20:1484:20:1488 | [post] self | UseUseExplosion.rb:20:1505:20:1509 | self |
@@ -1052,9 +1192,11 @@
 | UseUseExplosion.rb:20:1484:20:1493 | ... > ... | UseUseExplosion.rb:20:1483:20:1494 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1484:20:1493 | ... > ... | UseUseExplosion.rb:20:1483:20:1494 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1492:20:1493 | 30 | UseUseExplosion.rb:20:1484:20:1493 | ... > ... |
+| UseUseExplosion.rb:20:1496:20:2564 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1480:20:2580 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1496:20:2564 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1480:20:2580 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1496:20:2564 | then ... | UseUseExplosion.rb:20:1480:20:2580 | if ... |
-| UseUseExplosion.rb:20:1501:20:2564 | SSA phi read(self) | UseUseExplosion.rb:20:1480:20:2580 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1501:20:2564 | SSA phi read(x) | UseUseExplosion.rb:20:1480:20:2580 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1501:20:2564 | SSA phi read(self) | UseUseExplosion.rb:20:1496:20:2564 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1501:20:2564 | SSA phi read(x) | UseUseExplosion.rb:20:1496:20:2564 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1501:20:2564 | if ... | UseUseExplosion.rb:20:1496:20:2564 | then ... |
 | UseUseExplosion.rb:20:1505:20:1509 | @prop | UseUseExplosion.rb:20:1505:20:1514 | ... > ... |
 | UseUseExplosion.rb:20:1505:20:1509 | [post] self | UseUseExplosion.rb:20:1526:20:1530 | self |
@@ -1064,9 +1206,11 @@
 | UseUseExplosion.rb:20:1505:20:1514 | ... > ... | UseUseExplosion.rb:20:1504:20:1515 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1505:20:1514 | ... > ... | UseUseExplosion.rb:20:1504:20:1515 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1513:20:1514 | 29 | UseUseExplosion.rb:20:1505:20:1514 | ... > ... |
+| UseUseExplosion.rb:20:1517:20:2548 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1501:20:2564 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1517:20:2548 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1501:20:2564 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1517:20:2548 | then ... | UseUseExplosion.rb:20:1501:20:2564 | if ... |
-| UseUseExplosion.rb:20:1522:20:2548 | SSA phi read(self) | UseUseExplosion.rb:20:1501:20:2564 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1522:20:2548 | SSA phi read(x) | UseUseExplosion.rb:20:1501:20:2564 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1522:20:2548 | SSA phi read(self) | UseUseExplosion.rb:20:1517:20:2548 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1522:20:2548 | SSA phi read(x) | UseUseExplosion.rb:20:1517:20:2548 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1522:20:2548 | if ... | UseUseExplosion.rb:20:1517:20:2548 | then ... |
 | UseUseExplosion.rb:20:1526:20:1530 | @prop | UseUseExplosion.rb:20:1526:20:1535 | ... > ... |
 | UseUseExplosion.rb:20:1526:20:1530 | [post] self | UseUseExplosion.rb:20:1547:20:1551 | self |
@@ -1076,9 +1220,11 @@
 | UseUseExplosion.rb:20:1526:20:1535 | ... > ... | UseUseExplosion.rb:20:1525:20:1536 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1526:20:1535 | ... > ... | UseUseExplosion.rb:20:1525:20:1536 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1534:20:1535 | 28 | UseUseExplosion.rb:20:1526:20:1535 | ... > ... |
+| UseUseExplosion.rb:20:1538:20:2532 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1522:20:2548 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1538:20:2532 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1522:20:2548 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1538:20:2532 | then ... | UseUseExplosion.rb:20:1522:20:2548 | if ... |
-| UseUseExplosion.rb:20:1543:20:2532 | SSA phi read(self) | UseUseExplosion.rb:20:1522:20:2548 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1543:20:2532 | SSA phi read(x) | UseUseExplosion.rb:20:1522:20:2548 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1543:20:2532 | SSA phi read(self) | UseUseExplosion.rb:20:1538:20:2532 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1543:20:2532 | SSA phi read(x) | UseUseExplosion.rb:20:1538:20:2532 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1543:20:2532 | if ... | UseUseExplosion.rb:20:1538:20:2532 | then ... |
 | UseUseExplosion.rb:20:1547:20:1551 | @prop | UseUseExplosion.rb:20:1547:20:1556 | ... > ... |
 | UseUseExplosion.rb:20:1547:20:1551 | [post] self | UseUseExplosion.rb:20:1568:20:1572 | self |
@@ -1088,9 +1234,11 @@
 | UseUseExplosion.rb:20:1547:20:1556 | ... > ... | UseUseExplosion.rb:20:1546:20:1557 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1547:20:1556 | ... > ... | UseUseExplosion.rb:20:1546:20:1557 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1555:20:1556 | 27 | UseUseExplosion.rb:20:1547:20:1556 | ... > ... |
+| UseUseExplosion.rb:20:1559:20:2516 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1543:20:2532 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1559:20:2516 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1543:20:2532 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1559:20:2516 | then ... | UseUseExplosion.rb:20:1543:20:2532 | if ... |
-| UseUseExplosion.rb:20:1564:20:2516 | SSA phi read(self) | UseUseExplosion.rb:20:1543:20:2532 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1564:20:2516 | SSA phi read(x) | UseUseExplosion.rb:20:1543:20:2532 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1564:20:2516 | SSA phi read(self) | UseUseExplosion.rb:20:1559:20:2516 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1564:20:2516 | SSA phi read(x) | UseUseExplosion.rb:20:1559:20:2516 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1564:20:2516 | if ... | UseUseExplosion.rb:20:1559:20:2516 | then ... |
 | UseUseExplosion.rb:20:1568:20:1572 | @prop | UseUseExplosion.rb:20:1568:20:1577 | ... > ... |
 | UseUseExplosion.rb:20:1568:20:1572 | [post] self | UseUseExplosion.rb:20:1589:20:1593 | self |
@@ -1100,9 +1248,11 @@
 | UseUseExplosion.rb:20:1568:20:1577 | ... > ... | UseUseExplosion.rb:20:1567:20:1578 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1568:20:1577 | ... > ... | UseUseExplosion.rb:20:1567:20:1578 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1576:20:1577 | 26 | UseUseExplosion.rb:20:1568:20:1577 | ... > ... |
+| UseUseExplosion.rb:20:1580:20:2500 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1564:20:2516 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1580:20:2500 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1564:20:2516 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1580:20:2500 | then ... | UseUseExplosion.rb:20:1564:20:2516 | if ... |
-| UseUseExplosion.rb:20:1585:20:2500 | SSA phi read(self) | UseUseExplosion.rb:20:1564:20:2516 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1585:20:2500 | SSA phi read(x) | UseUseExplosion.rb:20:1564:20:2516 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1585:20:2500 | SSA phi read(self) | UseUseExplosion.rb:20:1580:20:2500 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1585:20:2500 | SSA phi read(x) | UseUseExplosion.rb:20:1580:20:2500 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1585:20:2500 | if ... | UseUseExplosion.rb:20:1580:20:2500 | then ... |
 | UseUseExplosion.rb:20:1589:20:1593 | @prop | UseUseExplosion.rb:20:1589:20:1598 | ... > ... |
 | UseUseExplosion.rb:20:1589:20:1593 | [post] self | UseUseExplosion.rb:20:1610:20:1614 | self |
@@ -1112,9 +1262,11 @@
 | UseUseExplosion.rb:20:1589:20:1598 | ... > ... | UseUseExplosion.rb:20:1588:20:1599 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1589:20:1598 | ... > ... | UseUseExplosion.rb:20:1588:20:1599 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1597:20:1598 | 25 | UseUseExplosion.rb:20:1589:20:1598 | ... > ... |
+| UseUseExplosion.rb:20:1601:20:2484 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1585:20:2500 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1601:20:2484 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1585:20:2500 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1601:20:2484 | then ... | UseUseExplosion.rb:20:1585:20:2500 | if ... |
-| UseUseExplosion.rb:20:1606:20:2484 | SSA phi read(self) | UseUseExplosion.rb:20:1585:20:2500 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1606:20:2484 | SSA phi read(x) | UseUseExplosion.rb:20:1585:20:2500 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1606:20:2484 | SSA phi read(self) | UseUseExplosion.rb:20:1601:20:2484 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1606:20:2484 | SSA phi read(x) | UseUseExplosion.rb:20:1601:20:2484 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1606:20:2484 | if ... | UseUseExplosion.rb:20:1601:20:2484 | then ... |
 | UseUseExplosion.rb:20:1610:20:1614 | @prop | UseUseExplosion.rb:20:1610:20:1619 | ... > ... |
 | UseUseExplosion.rb:20:1610:20:1614 | [post] self | UseUseExplosion.rb:20:1631:20:1635 | self |
@@ -1124,9 +1276,11 @@
 | UseUseExplosion.rb:20:1610:20:1619 | ... > ... | UseUseExplosion.rb:20:1609:20:1620 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1610:20:1619 | ... > ... | UseUseExplosion.rb:20:1609:20:1620 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1618:20:1619 | 24 | UseUseExplosion.rb:20:1610:20:1619 | ... > ... |
+| UseUseExplosion.rb:20:1622:20:2468 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1606:20:2484 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1622:20:2468 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1606:20:2484 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1622:20:2468 | then ... | UseUseExplosion.rb:20:1606:20:2484 | if ... |
-| UseUseExplosion.rb:20:1627:20:2468 | SSA phi read(self) | UseUseExplosion.rb:20:1606:20:2484 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1627:20:2468 | SSA phi read(x) | UseUseExplosion.rb:20:1606:20:2484 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1627:20:2468 | SSA phi read(self) | UseUseExplosion.rb:20:1622:20:2468 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1627:20:2468 | SSA phi read(x) | UseUseExplosion.rb:20:1622:20:2468 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1627:20:2468 | if ... | UseUseExplosion.rb:20:1622:20:2468 | then ... |
 | UseUseExplosion.rb:20:1631:20:1635 | @prop | UseUseExplosion.rb:20:1631:20:1640 | ... > ... |
 | UseUseExplosion.rb:20:1631:20:1635 | [post] self | UseUseExplosion.rb:20:1652:20:1656 | self |
@@ -1136,9 +1290,11 @@
 | UseUseExplosion.rb:20:1631:20:1640 | ... > ... | UseUseExplosion.rb:20:1630:20:1641 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1631:20:1640 | ... > ... | UseUseExplosion.rb:20:1630:20:1641 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1639:20:1640 | 23 | UseUseExplosion.rb:20:1631:20:1640 | ... > ... |
+| UseUseExplosion.rb:20:1643:20:2452 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1627:20:2468 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1643:20:2452 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1627:20:2468 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1643:20:2452 | then ... | UseUseExplosion.rb:20:1627:20:2468 | if ... |
-| UseUseExplosion.rb:20:1648:20:2452 | SSA phi read(self) | UseUseExplosion.rb:20:1627:20:2468 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1648:20:2452 | SSA phi read(x) | UseUseExplosion.rb:20:1627:20:2468 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1648:20:2452 | SSA phi read(self) | UseUseExplosion.rb:20:1643:20:2452 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1648:20:2452 | SSA phi read(x) | UseUseExplosion.rb:20:1643:20:2452 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1648:20:2452 | if ... | UseUseExplosion.rb:20:1643:20:2452 | then ... |
 | UseUseExplosion.rb:20:1652:20:1656 | @prop | UseUseExplosion.rb:20:1652:20:1661 | ... > ... |
 | UseUseExplosion.rb:20:1652:20:1656 | [post] self | UseUseExplosion.rb:20:1673:20:1677 | self |
@@ -1148,9 +1304,11 @@
 | UseUseExplosion.rb:20:1652:20:1661 | ... > ... | UseUseExplosion.rb:20:1651:20:1662 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1652:20:1661 | ... > ... | UseUseExplosion.rb:20:1651:20:1662 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1660:20:1661 | 22 | UseUseExplosion.rb:20:1652:20:1661 | ... > ... |
+| UseUseExplosion.rb:20:1664:20:2436 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1648:20:2452 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1664:20:2436 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1648:20:2452 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1664:20:2436 | then ... | UseUseExplosion.rb:20:1648:20:2452 | if ... |
-| UseUseExplosion.rb:20:1669:20:2436 | SSA phi read(self) | UseUseExplosion.rb:20:1648:20:2452 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1669:20:2436 | SSA phi read(x) | UseUseExplosion.rb:20:1648:20:2452 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1669:20:2436 | SSA phi read(self) | UseUseExplosion.rb:20:1664:20:2436 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1669:20:2436 | SSA phi read(x) | UseUseExplosion.rb:20:1664:20:2436 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1669:20:2436 | if ... | UseUseExplosion.rb:20:1664:20:2436 | then ... |
 | UseUseExplosion.rb:20:1673:20:1677 | @prop | UseUseExplosion.rb:20:1673:20:1682 | ... > ... |
 | UseUseExplosion.rb:20:1673:20:1677 | [post] self | UseUseExplosion.rb:20:1694:20:1698 | self |
@@ -1160,9 +1318,11 @@
 | UseUseExplosion.rb:20:1673:20:1682 | ... > ... | UseUseExplosion.rb:20:1672:20:1683 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1673:20:1682 | ... > ... | UseUseExplosion.rb:20:1672:20:1683 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1681:20:1682 | 21 | UseUseExplosion.rb:20:1673:20:1682 | ... > ... |
+| UseUseExplosion.rb:20:1685:20:2420 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1669:20:2436 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1685:20:2420 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1669:20:2436 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1685:20:2420 | then ... | UseUseExplosion.rb:20:1669:20:2436 | if ... |
-| UseUseExplosion.rb:20:1690:20:2420 | SSA phi read(self) | UseUseExplosion.rb:20:1669:20:2436 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1690:20:2420 | SSA phi read(x) | UseUseExplosion.rb:20:1669:20:2436 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1690:20:2420 | SSA phi read(self) | UseUseExplosion.rb:20:1685:20:2420 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1690:20:2420 | SSA phi read(x) | UseUseExplosion.rb:20:1685:20:2420 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1690:20:2420 | if ... | UseUseExplosion.rb:20:1685:20:2420 | then ... |
 | UseUseExplosion.rb:20:1694:20:1698 | @prop | UseUseExplosion.rb:20:1694:20:1703 | ... > ... |
 | UseUseExplosion.rb:20:1694:20:1698 | [post] self | UseUseExplosion.rb:20:1715:20:1719 | self |
@@ -1172,9 +1332,11 @@
 | UseUseExplosion.rb:20:1694:20:1703 | ... > ... | UseUseExplosion.rb:20:1693:20:1704 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1694:20:1703 | ... > ... | UseUseExplosion.rb:20:1693:20:1704 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1702:20:1703 | 20 | UseUseExplosion.rb:20:1694:20:1703 | ... > ... |
+| UseUseExplosion.rb:20:1706:20:2404 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1690:20:2420 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1706:20:2404 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1690:20:2420 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1706:20:2404 | then ... | UseUseExplosion.rb:20:1690:20:2420 | if ... |
-| UseUseExplosion.rb:20:1711:20:2404 | SSA phi read(self) | UseUseExplosion.rb:20:1690:20:2420 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1711:20:2404 | SSA phi read(x) | UseUseExplosion.rb:20:1690:20:2420 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1711:20:2404 | SSA phi read(self) | UseUseExplosion.rb:20:1706:20:2404 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1711:20:2404 | SSA phi read(x) | UseUseExplosion.rb:20:1706:20:2404 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1711:20:2404 | if ... | UseUseExplosion.rb:20:1706:20:2404 | then ... |
 | UseUseExplosion.rb:20:1715:20:1719 | @prop | UseUseExplosion.rb:20:1715:20:1724 | ... > ... |
 | UseUseExplosion.rb:20:1715:20:1719 | [post] self | UseUseExplosion.rb:20:1736:20:1740 | self |
@@ -1184,9 +1346,11 @@
 | UseUseExplosion.rb:20:1715:20:1724 | ... > ... | UseUseExplosion.rb:20:1714:20:1725 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1715:20:1724 | ... > ... | UseUseExplosion.rb:20:1714:20:1725 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1723:20:1724 | 19 | UseUseExplosion.rb:20:1715:20:1724 | ... > ... |
+| UseUseExplosion.rb:20:1727:20:2388 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1711:20:2404 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1727:20:2388 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1711:20:2404 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1727:20:2388 | then ... | UseUseExplosion.rb:20:1711:20:2404 | if ... |
-| UseUseExplosion.rb:20:1732:20:2388 | SSA phi read(self) | UseUseExplosion.rb:20:1711:20:2404 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1732:20:2388 | SSA phi read(x) | UseUseExplosion.rb:20:1711:20:2404 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1732:20:2388 | SSA phi read(self) | UseUseExplosion.rb:20:1727:20:2388 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1732:20:2388 | SSA phi read(x) | UseUseExplosion.rb:20:1727:20:2388 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1732:20:2388 | if ... | UseUseExplosion.rb:20:1727:20:2388 | then ... |
 | UseUseExplosion.rb:20:1736:20:1740 | @prop | UseUseExplosion.rb:20:1736:20:1745 | ... > ... |
 | UseUseExplosion.rb:20:1736:20:1740 | [post] self | UseUseExplosion.rb:20:1757:20:1761 | self |
@@ -1196,9 +1360,11 @@
 | UseUseExplosion.rb:20:1736:20:1745 | ... > ... | UseUseExplosion.rb:20:1735:20:1746 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1736:20:1745 | ... > ... | UseUseExplosion.rb:20:1735:20:1746 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1744:20:1745 | 18 | UseUseExplosion.rb:20:1736:20:1745 | ... > ... |
+| UseUseExplosion.rb:20:1748:20:2372 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1732:20:2388 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1748:20:2372 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1732:20:2388 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1748:20:2372 | then ... | UseUseExplosion.rb:20:1732:20:2388 | if ... |
-| UseUseExplosion.rb:20:1753:20:2372 | SSA phi read(self) | UseUseExplosion.rb:20:1732:20:2388 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1753:20:2372 | SSA phi read(x) | UseUseExplosion.rb:20:1732:20:2388 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1753:20:2372 | SSA phi read(self) | UseUseExplosion.rb:20:1748:20:2372 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1753:20:2372 | SSA phi read(x) | UseUseExplosion.rb:20:1748:20:2372 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1753:20:2372 | if ... | UseUseExplosion.rb:20:1748:20:2372 | then ... |
 | UseUseExplosion.rb:20:1757:20:1761 | @prop | UseUseExplosion.rb:20:1757:20:1766 | ... > ... |
 | UseUseExplosion.rb:20:1757:20:1761 | [post] self | UseUseExplosion.rb:20:1778:20:1782 | self |
@@ -1208,9 +1374,11 @@
 | UseUseExplosion.rb:20:1757:20:1766 | ... > ... | UseUseExplosion.rb:20:1756:20:1767 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1757:20:1766 | ... > ... | UseUseExplosion.rb:20:1756:20:1767 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1765:20:1766 | 17 | UseUseExplosion.rb:20:1757:20:1766 | ... > ... |
+| UseUseExplosion.rb:20:1769:20:2356 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1753:20:2372 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1769:20:2356 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1753:20:2372 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1769:20:2356 | then ... | UseUseExplosion.rb:20:1753:20:2372 | if ... |
-| UseUseExplosion.rb:20:1774:20:2356 | SSA phi read(self) | UseUseExplosion.rb:20:1753:20:2372 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1774:20:2356 | SSA phi read(x) | UseUseExplosion.rb:20:1753:20:2372 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1774:20:2356 | SSA phi read(self) | UseUseExplosion.rb:20:1769:20:2356 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1774:20:2356 | SSA phi read(x) | UseUseExplosion.rb:20:1769:20:2356 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1774:20:2356 | if ... | UseUseExplosion.rb:20:1769:20:2356 | then ... |
 | UseUseExplosion.rb:20:1778:20:1782 | @prop | UseUseExplosion.rb:20:1778:20:1787 | ... > ... |
 | UseUseExplosion.rb:20:1778:20:1782 | [post] self | UseUseExplosion.rb:20:1799:20:1803 | self |
@@ -1220,9 +1388,11 @@
 | UseUseExplosion.rb:20:1778:20:1787 | ... > ... | UseUseExplosion.rb:20:1777:20:1788 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1778:20:1787 | ... > ... | UseUseExplosion.rb:20:1777:20:1788 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1786:20:1787 | 16 | UseUseExplosion.rb:20:1778:20:1787 | ... > ... |
+| UseUseExplosion.rb:20:1790:20:2340 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1774:20:2356 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1790:20:2340 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1774:20:2356 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1790:20:2340 | then ... | UseUseExplosion.rb:20:1774:20:2356 | if ... |
-| UseUseExplosion.rb:20:1795:20:2340 | SSA phi read(self) | UseUseExplosion.rb:20:1774:20:2356 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1795:20:2340 | SSA phi read(x) | UseUseExplosion.rb:20:1774:20:2356 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1795:20:2340 | SSA phi read(self) | UseUseExplosion.rb:20:1790:20:2340 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1795:20:2340 | SSA phi read(x) | UseUseExplosion.rb:20:1790:20:2340 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1795:20:2340 | if ... | UseUseExplosion.rb:20:1790:20:2340 | then ... |
 | UseUseExplosion.rb:20:1799:20:1803 | @prop | UseUseExplosion.rb:20:1799:20:1808 | ... > ... |
 | UseUseExplosion.rb:20:1799:20:1803 | [post] self | UseUseExplosion.rb:20:1820:20:1824 | self |
@@ -1232,9 +1402,11 @@
 | UseUseExplosion.rb:20:1799:20:1808 | ... > ... | UseUseExplosion.rb:20:1798:20:1809 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1799:20:1808 | ... > ... | UseUseExplosion.rb:20:1798:20:1809 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1807:20:1808 | 15 | UseUseExplosion.rb:20:1799:20:1808 | ... > ... |
+| UseUseExplosion.rb:20:1811:20:2324 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1795:20:2340 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1811:20:2324 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1795:20:2340 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1811:20:2324 | then ... | UseUseExplosion.rb:20:1795:20:2340 | if ... |
-| UseUseExplosion.rb:20:1816:20:2324 | SSA phi read(self) | UseUseExplosion.rb:20:1795:20:2340 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1816:20:2324 | SSA phi read(x) | UseUseExplosion.rb:20:1795:20:2340 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1816:20:2324 | SSA phi read(self) | UseUseExplosion.rb:20:1811:20:2324 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1816:20:2324 | SSA phi read(x) | UseUseExplosion.rb:20:1811:20:2324 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1816:20:2324 | if ... | UseUseExplosion.rb:20:1811:20:2324 | then ... |
 | UseUseExplosion.rb:20:1820:20:1824 | @prop | UseUseExplosion.rb:20:1820:20:1829 | ... > ... |
 | UseUseExplosion.rb:20:1820:20:1824 | [post] self | UseUseExplosion.rb:20:1841:20:1845 | self |
@@ -1244,9 +1416,11 @@
 | UseUseExplosion.rb:20:1820:20:1829 | ... > ... | UseUseExplosion.rb:20:1819:20:1830 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1820:20:1829 | ... > ... | UseUseExplosion.rb:20:1819:20:1830 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1828:20:1829 | 14 | UseUseExplosion.rb:20:1820:20:1829 | ... > ... |
+| UseUseExplosion.rb:20:1832:20:2308 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1816:20:2324 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1832:20:2308 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1816:20:2324 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1832:20:2308 | then ... | UseUseExplosion.rb:20:1816:20:2324 | if ... |
-| UseUseExplosion.rb:20:1837:20:2308 | SSA phi read(self) | UseUseExplosion.rb:20:1816:20:2324 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1837:20:2308 | SSA phi read(x) | UseUseExplosion.rb:20:1816:20:2324 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1837:20:2308 | SSA phi read(self) | UseUseExplosion.rb:20:1832:20:2308 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1837:20:2308 | SSA phi read(x) | UseUseExplosion.rb:20:1832:20:2308 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1837:20:2308 | if ... | UseUseExplosion.rb:20:1832:20:2308 | then ... |
 | UseUseExplosion.rb:20:1841:20:1845 | @prop | UseUseExplosion.rb:20:1841:20:1850 | ... > ... |
 | UseUseExplosion.rb:20:1841:20:1845 | [post] self | UseUseExplosion.rb:20:1862:20:1866 | self |
@@ -1256,9 +1430,11 @@
 | UseUseExplosion.rb:20:1841:20:1850 | ... > ... | UseUseExplosion.rb:20:1840:20:1851 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1841:20:1850 | ... > ... | UseUseExplosion.rb:20:1840:20:1851 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1849:20:1850 | 13 | UseUseExplosion.rb:20:1841:20:1850 | ... > ... |
+| UseUseExplosion.rb:20:1853:20:2292 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1837:20:2308 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1853:20:2292 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1837:20:2308 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1853:20:2292 | then ... | UseUseExplosion.rb:20:1837:20:2308 | if ... |
-| UseUseExplosion.rb:20:1858:20:2292 | SSA phi read(self) | UseUseExplosion.rb:20:1837:20:2308 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1858:20:2292 | SSA phi read(x) | UseUseExplosion.rb:20:1837:20:2308 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1858:20:2292 | SSA phi read(self) | UseUseExplosion.rb:20:1853:20:2292 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1858:20:2292 | SSA phi read(x) | UseUseExplosion.rb:20:1853:20:2292 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1858:20:2292 | if ... | UseUseExplosion.rb:20:1853:20:2292 | then ... |
 | UseUseExplosion.rb:20:1862:20:1866 | @prop | UseUseExplosion.rb:20:1862:20:1871 | ... > ... |
 | UseUseExplosion.rb:20:1862:20:1866 | [post] self | UseUseExplosion.rb:20:1883:20:1887 | self |
@@ -1268,9 +1444,11 @@
 | UseUseExplosion.rb:20:1862:20:1871 | ... > ... | UseUseExplosion.rb:20:1861:20:1872 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1862:20:1871 | ... > ... | UseUseExplosion.rb:20:1861:20:1872 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1870:20:1871 | 12 | UseUseExplosion.rb:20:1862:20:1871 | ... > ... |
+| UseUseExplosion.rb:20:1874:20:2276 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1858:20:2292 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1874:20:2276 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1858:20:2292 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1874:20:2276 | then ... | UseUseExplosion.rb:20:1858:20:2292 | if ... |
-| UseUseExplosion.rb:20:1879:20:2276 | SSA phi read(self) | UseUseExplosion.rb:20:1858:20:2292 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1879:20:2276 | SSA phi read(x) | UseUseExplosion.rb:20:1858:20:2292 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1879:20:2276 | SSA phi read(self) | UseUseExplosion.rb:20:1874:20:2276 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1879:20:2276 | SSA phi read(x) | UseUseExplosion.rb:20:1874:20:2276 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1879:20:2276 | if ... | UseUseExplosion.rb:20:1874:20:2276 | then ... |
 | UseUseExplosion.rb:20:1883:20:1887 | @prop | UseUseExplosion.rb:20:1883:20:1892 | ... > ... |
 | UseUseExplosion.rb:20:1883:20:1887 | [post] self | UseUseExplosion.rb:20:1904:20:1908 | self |
@@ -1280,9 +1458,11 @@
 | UseUseExplosion.rb:20:1883:20:1892 | ... > ... | UseUseExplosion.rb:20:1882:20:1893 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1883:20:1892 | ... > ... | UseUseExplosion.rb:20:1882:20:1893 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1891:20:1892 | 11 | UseUseExplosion.rb:20:1883:20:1892 | ... > ... |
+| UseUseExplosion.rb:20:1895:20:2260 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1879:20:2276 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1895:20:2260 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1879:20:2276 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1895:20:2260 | then ... | UseUseExplosion.rb:20:1879:20:2276 | if ... |
-| UseUseExplosion.rb:20:1900:20:2260 | SSA phi read(self) | UseUseExplosion.rb:20:1879:20:2276 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1900:20:2260 | SSA phi read(x) | UseUseExplosion.rb:20:1879:20:2276 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1900:20:2260 | SSA phi read(self) | UseUseExplosion.rb:20:1895:20:2260 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1900:20:2260 | SSA phi read(x) | UseUseExplosion.rb:20:1895:20:2260 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1900:20:2260 | if ... | UseUseExplosion.rb:20:1895:20:2260 | then ... |
 | UseUseExplosion.rb:20:1904:20:1908 | @prop | UseUseExplosion.rb:20:1904:20:1913 | ... > ... |
 | UseUseExplosion.rb:20:1904:20:1908 | [post] self | UseUseExplosion.rb:20:1925:20:1929 | self |
@@ -1292,9 +1472,11 @@
 | UseUseExplosion.rb:20:1904:20:1913 | ... > ... | UseUseExplosion.rb:20:1903:20:1914 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1904:20:1913 | ... > ... | UseUseExplosion.rb:20:1903:20:1914 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1912:20:1913 | 10 | UseUseExplosion.rb:20:1904:20:1913 | ... > ... |
+| UseUseExplosion.rb:20:1916:20:2244 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1900:20:2260 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1916:20:2244 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1900:20:2260 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1916:20:2244 | then ... | UseUseExplosion.rb:20:1900:20:2260 | if ... |
-| UseUseExplosion.rb:20:1921:20:2244 | SSA phi read(self) | UseUseExplosion.rb:20:1900:20:2260 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1921:20:2244 | SSA phi read(x) | UseUseExplosion.rb:20:1900:20:2260 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1921:20:2244 | SSA phi read(self) | UseUseExplosion.rb:20:1916:20:2244 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1921:20:2244 | SSA phi read(x) | UseUseExplosion.rb:20:1916:20:2244 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1921:20:2244 | if ... | UseUseExplosion.rb:20:1916:20:2244 | then ... |
 | UseUseExplosion.rb:20:1925:20:1929 | @prop | UseUseExplosion.rb:20:1925:20:1933 | ... > ... |
 | UseUseExplosion.rb:20:1925:20:1929 | [post] self | UseUseExplosion.rb:20:1945:20:1949 | self |
@@ -1304,9 +1486,11 @@
 | UseUseExplosion.rb:20:1925:20:1933 | ... > ... | UseUseExplosion.rb:20:1924:20:1934 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1925:20:1933 | ... > ... | UseUseExplosion.rb:20:1924:20:1934 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1933:20:1933 | 9 | UseUseExplosion.rb:20:1925:20:1933 | ... > ... |
+| UseUseExplosion.rb:20:1936:20:2228 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1921:20:2244 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1936:20:2228 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1921:20:2244 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1936:20:2228 | then ... | UseUseExplosion.rb:20:1921:20:2244 | if ... |
-| UseUseExplosion.rb:20:1941:20:2228 | SSA phi read(self) | UseUseExplosion.rb:20:1921:20:2244 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1941:20:2228 | SSA phi read(x) | UseUseExplosion.rb:20:1921:20:2244 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1941:20:2228 | SSA phi read(self) | UseUseExplosion.rb:20:1936:20:2228 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1941:20:2228 | SSA phi read(x) | UseUseExplosion.rb:20:1936:20:2228 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1941:20:2228 | if ... | UseUseExplosion.rb:20:1936:20:2228 | then ... |
 | UseUseExplosion.rb:20:1945:20:1949 | @prop | UseUseExplosion.rb:20:1945:20:1953 | ... > ... |
 | UseUseExplosion.rb:20:1945:20:1949 | [post] self | UseUseExplosion.rb:20:1965:20:1969 | self |
@@ -1316,9 +1500,11 @@
 | UseUseExplosion.rb:20:1945:20:1953 | ... > ... | UseUseExplosion.rb:20:1944:20:1954 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1945:20:1953 | ... > ... | UseUseExplosion.rb:20:1944:20:1954 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1953:20:1953 | 8 | UseUseExplosion.rb:20:1945:20:1953 | ... > ... |
+| UseUseExplosion.rb:20:1956:20:2212 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1941:20:2228 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1956:20:2212 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1941:20:2228 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1956:20:2212 | then ... | UseUseExplosion.rb:20:1941:20:2228 | if ... |
-| UseUseExplosion.rb:20:1961:20:2212 | SSA phi read(self) | UseUseExplosion.rb:20:1941:20:2228 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1961:20:2212 | SSA phi read(x) | UseUseExplosion.rb:20:1941:20:2228 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1961:20:2212 | SSA phi read(self) | UseUseExplosion.rb:20:1956:20:2212 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1961:20:2212 | SSA phi read(x) | UseUseExplosion.rb:20:1956:20:2212 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1961:20:2212 | if ... | UseUseExplosion.rb:20:1956:20:2212 | then ... |
 | UseUseExplosion.rb:20:1965:20:1969 | @prop | UseUseExplosion.rb:20:1965:20:1973 | ... > ... |
 | UseUseExplosion.rb:20:1965:20:1969 | [post] self | UseUseExplosion.rb:20:1985:20:1989 | self |
@@ -1328,9 +1514,11 @@
 | UseUseExplosion.rb:20:1965:20:1973 | ... > ... | UseUseExplosion.rb:20:1964:20:1974 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1965:20:1973 | ... > ... | UseUseExplosion.rb:20:1964:20:1974 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1973:20:1973 | 7 | UseUseExplosion.rb:20:1965:20:1973 | ... > ... |
+| UseUseExplosion.rb:20:1976:20:2196 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1961:20:2212 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1976:20:2196 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1961:20:2212 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1976:20:2196 | then ... | UseUseExplosion.rb:20:1961:20:2212 | if ... |
-| UseUseExplosion.rb:20:1981:20:2196 | SSA phi read(self) | UseUseExplosion.rb:20:1961:20:2212 | SSA phi read(self) |
-| UseUseExplosion.rb:20:1981:20:2196 | SSA phi read(x) | UseUseExplosion.rb:20:1961:20:2212 | SSA phi read(x) |
+| UseUseExplosion.rb:20:1981:20:2196 | SSA phi read(self) | UseUseExplosion.rb:20:1976:20:2196 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:1981:20:2196 | SSA phi read(x) | UseUseExplosion.rb:20:1976:20:2196 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:1981:20:2196 | if ... | UseUseExplosion.rb:20:1976:20:2196 | then ... |
 | UseUseExplosion.rb:20:1985:20:1989 | @prop | UseUseExplosion.rb:20:1985:20:1993 | ... > ... |
 | UseUseExplosion.rb:20:1985:20:1989 | [post] self | UseUseExplosion.rb:20:2005:20:2009 | self |
@@ -1340,9 +1528,11 @@
 | UseUseExplosion.rb:20:1985:20:1993 | ... > ... | UseUseExplosion.rb:20:1984:20:1994 | [false] ( ... ) |
 | UseUseExplosion.rb:20:1985:20:1993 | ... > ... | UseUseExplosion.rb:20:1984:20:1994 | [true] ( ... ) |
 | UseUseExplosion.rb:20:1993:20:1993 | 6 | UseUseExplosion.rb:20:1985:20:1993 | ... > ... |
+| UseUseExplosion.rb:20:1996:20:2180 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1981:20:2196 | SSA phi read(self) |
+| UseUseExplosion.rb:20:1996:20:2180 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1981:20:2196 | SSA phi read(x) |
 | UseUseExplosion.rb:20:1996:20:2180 | then ... | UseUseExplosion.rb:20:1981:20:2196 | if ... |
-| UseUseExplosion.rb:20:2001:20:2180 | SSA phi read(self) | UseUseExplosion.rb:20:1981:20:2196 | SSA phi read(self) |
-| UseUseExplosion.rb:20:2001:20:2180 | SSA phi read(x) | UseUseExplosion.rb:20:1981:20:2196 | SSA phi read(x) |
+| UseUseExplosion.rb:20:2001:20:2180 | SSA phi read(self) | UseUseExplosion.rb:20:1996:20:2180 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:2001:20:2180 | SSA phi read(x) | UseUseExplosion.rb:20:1996:20:2180 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:2001:20:2180 | if ... | UseUseExplosion.rb:20:1996:20:2180 | then ... |
 | UseUseExplosion.rb:20:2005:20:2009 | @prop | UseUseExplosion.rb:20:2005:20:2013 | ... > ... |
 | UseUseExplosion.rb:20:2005:20:2009 | [post] self | UseUseExplosion.rb:20:2025:20:2029 | self |
@@ -1352,9 +1542,11 @@
 | UseUseExplosion.rb:20:2005:20:2013 | ... > ... | UseUseExplosion.rb:20:2004:20:2014 | [false] ( ... ) |
 | UseUseExplosion.rb:20:2005:20:2013 | ... > ... | UseUseExplosion.rb:20:2004:20:2014 | [true] ( ... ) |
 | UseUseExplosion.rb:20:2013:20:2013 | 5 | UseUseExplosion.rb:20:2005:20:2013 | ... > ... |
+| UseUseExplosion.rb:20:2016:20:2164 | [input] SSA phi read(self) | UseUseExplosion.rb:20:2001:20:2180 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2016:20:2164 | [input] SSA phi read(x) | UseUseExplosion.rb:20:2001:20:2180 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2016:20:2164 | then ... | UseUseExplosion.rb:20:2001:20:2180 | if ... |
-| UseUseExplosion.rb:20:2021:20:2164 | SSA phi read(self) | UseUseExplosion.rb:20:2001:20:2180 | SSA phi read(self) |
-| UseUseExplosion.rb:20:2021:20:2164 | SSA phi read(x) | UseUseExplosion.rb:20:2001:20:2180 | SSA phi read(x) |
+| UseUseExplosion.rb:20:2021:20:2164 | SSA phi read(self) | UseUseExplosion.rb:20:2016:20:2164 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:2021:20:2164 | SSA phi read(x) | UseUseExplosion.rb:20:2016:20:2164 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:2021:20:2164 | if ... | UseUseExplosion.rb:20:2016:20:2164 | then ... |
 | UseUseExplosion.rb:20:2025:20:2029 | @prop | UseUseExplosion.rb:20:2025:20:2033 | ... > ... |
 | UseUseExplosion.rb:20:2025:20:2029 | [post] self | UseUseExplosion.rb:20:2045:20:2049 | self |
@@ -1364,9 +1556,11 @@
 | UseUseExplosion.rb:20:2025:20:2033 | ... > ... | UseUseExplosion.rb:20:2024:20:2034 | [false] ( ... ) |
 | UseUseExplosion.rb:20:2025:20:2033 | ... > ... | UseUseExplosion.rb:20:2024:20:2034 | [true] ( ... ) |
 | UseUseExplosion.rb:20:2033:20:2033 | 4 | UseUseExplosion.rb:20:2025:20:2033 | ... > ... |
+| UseUseExplosion.rb:20:2036:20:2148 | [input] SSA phi read(self) | UseUseExplosion.rb:20:2021:20:2164 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2036:20:2148 | [input] SSA phi read(x) | UseUseExplosion.rb:20:2021:20:2164 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2036:20:2148 | then ... | UseUseExplosion.rb:20:2021:20:2164 | if ... |
-| UseUseExplosion.rb:20:2041:20:2148 | SSA phi read(self) | UseUseExplosion.rb:20:2021:20:2164 | SSA phi read(self) |
-| UseUseExplosion.rb:20:2041:20:2148 | SSA phi read(x) | UseUseExplosion.rb:20:2021:20:2164 | SSA phi read(x) |
+| UseUseExplosion.rb:20:2041:20:2148 | SSA phi read(self) | UseUseExplosion.rb:20:2036:20:2148 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:2041:20:2148 | SSA phi read(x) | UseUseExplosion.rb:20:2036:20:2148 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:2041:20:2148 | if ... | UseUseExplosion.rb:20:2036:20:2148 | then ... |
 | UseUseExplosion.rb:20:2045:20:2049 | @prop | UseUseExplosion.rb:20:2045:20:2053 | ... > ... |
 | UseUseExplosion.rb:20:2045:20:2049 | [post] self | UseUseExplosion.rb:20:2065:20:2069 | self |
@@ -1376,9 +1570,11 @@
 | UseUseExplosion.rb:20:2045:20:2053 | ... > ... | UseUseExplosion.rb:20:2044:20:2054 | [false] ( ... ) |
 | UseUseExplosion.rb:20:2045:20:2053 | ... > ... | UseUseExplosion.rb:20:2044:20:2054 | [true] ( ... ) |
 | UseUseExplosion.rb:20:2053:20:2053 | 3 | UseUseExplosion.rb:20:2045:20:2053 | ... > ... |
+| UseUseExplosion.rb:20:2056:20:2132 | [input] SSA phi read(self) | UseUseExplosion.rb:20:2041:20:2148 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2056:20:2132 | [input] SSA phi read(x) | UseUseExplosion.rb:20:2041:20:2148 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2056:20:2132 | then ... | UseUseExplosion.rb:20:2041:20:2148 | if ... |
-| UseUseExplosion.rb:20:2061:20:2132 | SSA phi read(self) | UseUseExplosion.rb:20:2041:20:2148 | SSA phi read(self) |
-| UseUseExplosion.rb:20:2061:20:2132 | SSA phi read(x) | UseUseExplosion.rb:20:2041:20:2148 | SSA phi read(x) |
+| UseUseExplosion.rb:20:2061:20:2132 | SSA phi read(self) | UseUseExplosion.rb:20:2056:20:2132 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:2061:20:2132 | SSA phi read(x) | UseUseExplosion.rb:20:2056:20:2132 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:2061:20:2132 | if ... | UseUseExplosion.rb:20:2056:20:2132 | then ... |
 | UseUseExplosion.rb:20:2065:20:2069 | @prop | UseUseExplosion.rb:20:2065:20:2073 | ... > ... |
 | UseUseExplosion.rb:20:2065:20:2069 | [post] self | UseUseExplosion.rb:20:2085:20:2089 | self |
@@ -1388,9 +1584,11 @@
 | UseUseExplosion.rb:20:2065:20:2073 | ... > ... | UseUseExplosion.rb:20:2064:20:2074 | [false] ( ... ) |
 | UseUseExplosion.rb:20:2065:20:2073 | ... > ... | UseUseExplosion.rb:20:2064:20:2074 | [true] ( ... ) |
 | UseUseExplosion.rb:20:2073:20:2073 | 2 | UseUseExplosion.rb:20:2065:20:2073 | ... > ... |
+| UseUseExplosion.rb:20:2076:20:2116 | [input] SSA phi read(self) | UseUseExplosion.rb:20:2061:20:2132 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2076:20:2116 | [input] SSA phi read(x) | UseUseExplosion.rb:20:2061:20:2132 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2076:20:2116 | then ... | UseUseExplosion.rb:20:2061:20:2132 | if ... |
-| UseUseExplosion.rb:20:2081:20:2116 | SSA phi read(self) | UseUseExplosion.rb:20:2061:20:2132 | SSA phi read(self) |
-| UseUseExplosion.rb:20:2081:20:2116 | SSA phi read(x) | UseUseExplosion.rb:20:2061:20:2132 | SSA phi read(x) |
+| UseUseExplosion.rb:20:2081:20:2116 | SSA phi read(self) | UseUseExplosion.rb:20:2076:20:2116 | [input] SSA phi read(self) |
+| UseUseExplosion.rb:20:2081:20:2116 | SSA phi read(x) | UseUseExplosion.rb:20:2076:20:2116 | [input] SSA phi read(x) |
 | UseUseExplosion.rb:20:2081:20:2116 | if ... | UseUseExplosion.rb:20:2076:20:2116 | then ... |
 | UseUseExplosion.rb:20:2085:20:2089 | @prop | UseUseExplosion.rb:20:2085:20:2093 | ... > ... |
 | UseUseExplosion.rb:20:2085:20:2089 | [post] self | UseUseExplosion.rb:20:2107:20:2112 | self |
@@ -1398,205 +1596,407 @@
 | UseUseExplosion.rb:20:2085:20:2093 | ... > ... | UseUseExplosion.rb:20:2084:20:2094 | [false] ( ... ) |
 | UseUseExplosion.rb:20:2085:20:2093 | ... > ... | UseUseExplosion.rb:20:2084:20:2094 | [true] ( ... ) |
 | UseUseExplosion.rb:20:2093:20:2093 | 1 | UseUseExplosion.rb:20:2085:20:2093 | ... > ... |
+| UseUseExplosion.rb:20:2096:20:2099 | [input] SSA phi read(self) | UseUseExplosion.rb:20:2081:20:2116 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2096:20:2099 | [input] SSA phi read(x) | UseUseExplosion.rb:20:2081:20:2116 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2096:20:2099 | then ... | UseUseExplosion.rb:20:2081:20:2116 | if ... |
+| UseUseExplosion.rb:20:2102:20:2112 | [input] SSA phi read(self) | UseUseExplosion.rb:20:2081:20:2116 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2102:20:2112 | [input] SSA phi read(x) | UseUseExplosion.rb:20:2081:20:2116 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2102:20:2112 | else ... | UseUseExplosion.rb:20:2081:20:2116 | if ... |
 | UseUseExplosion.rb:20:2107:20:2112 | call to use | UseUseExplosion.rb:20:2102:20:2112 | else ... |
+| UseUseExplosion.rb:20:2118:20:2128 | [input] SSA phi read(self) | UseUseExplosion.rb:20:2061:20:2132 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2118:20:2128 | [input] SSA phi read(x) | UseUseExplosion.rb:20:2061:20:2132 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2118:20:2128 | else ... | UseUseExplosion.rb:20:2061:20:2132 | if ... |
 | UseUseExplosion.rb:20:2123:20:2128 | call to use | UseUseExplosion.rb:20:2118:20:2128 | else ... |
+| UseUseExplosion.rb:20:2134:20:2144 | [input] SSA phi read(self) | UseUseExplosion.rb:20:2041:20:2148 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2134:20:2144 | [input] SSA phi read(x) | UseUseExplosion.rb:20:2041:20:2148 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2134:20:2144 | else ... | UseUseExplosion.rb:20:2041:20:2148 | if ... |
 | UseUseExplosion.rb:20:2139:20:2144 | call to use | UseUseExplosion.rb:20:2134:20:2144 | else ... |
+| UseUseExplosion.rb:20:2150:20:2160 | [input] SSA phi read(self) | UseUseExplosion.rb:20:2021:20:2164 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2150:20:2160 | [input] SSA phi read(x) | UseUseExplosion.rb:20:2021:20:2164 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2150:20:2160 | else ... | UseUseExplosion.rb:20:2021:20:2164 | if ... |
 | UseUseExplosion.rb:20:2155:20:2160 | call to use | UseUseExplosion.rb:20:2150:20:2160 | else ... |
+| UseUseExplosion.rb:20:2166:20:2176 | [input] SSA phi read(self) | UseUseExplosion.rb:20:2001:20:2180 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2166:20:2176 | [input] SSA phi read(x) | UseUseExplosion.rb:20:2001:20:2180 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2166:20:2176 | else ... | UseUseExplosion.rb:20:2001:20:2180 | if ... |
 | UseUseExplosion.rb:20:2171:20:2176 | call to use | UseUseExplosion.rb:20:2166:20:2176 | else ... |
+| UseUseExplosion.rb:20:2182:20:2192 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1981:20:2196 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2182:20:2192 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1981:20:2196 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2182:20:2192 | else ... | UseUseExplosion.rb:20:1981:20:2196 | if ... |
 | UseUseExplosion.rb:20:2187:20:2192 | call to use | UseUseExplosion.rb:20:2182:20:2192 | else ... |
+| UseUseExplosion.rb:20:2198:20:2208 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1961:20:2212 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2198:20:2208 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1961:20:2212 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2198:20:2208 | else ... | UseUseExplosion.rb:20:1961:20:2212 | if ... |
 | UseUseExplosion.rb:20:2203:20:2208 | call to use | UseUseExplosion.rb:20:2198:20:2208 | else ... |
+| UseUseExplosion.rb:20:2214:20:2224 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1941:20:2228 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2214:20:2224 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1941:20:2228 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2214:20:2224 | else ... | UseUseExplosion.rb:20:1941:20:2228 | if ... |
 | UseUseExplosion.rb:20:2219:20:2224 | call to use | UseUseExplosion.rb:20:2214:20:2224 | else ... |
+| UseUseExplosion.rb:20:2230:20:2240 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1921:20:2244 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2230:20:2240 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1921:20:2244 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2230:20:2240 | else ... | UseUseExplosion.rb:20:1921:20:2244 | if ... |
 | UseUseExplosion.rb:20:2235:20:2240 | call to use | UseUseExplosion.rb:20:2230:20:2240 | else ... |
+| UseUseExplosion.rb:20:2246:20:2256 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1900:20:2260 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2246:20:2256 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1900:20:2260 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2246:20:2256 | else ... | UseUseExplosion.rb:20:1900:20:2260 | if ... |
 | UseUseExplosion.rb:20:2251:20:2256 | call to use | UseUseExplosion.rb:20:2246:20:2256 | else ... |
+| UseUseExplosion.rb:20:2262:20:2272 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1879:20:2276 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2262:20:2272 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1879:20:2276 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2262:20:2272 | else ... | UseUseExplosion.rb:20:1879:20:2276 | if ... |
 | UseUseExplosion.rb:20:2267:20:2272 | call to use | UseUseExplosion.rb:20:2262:20:2272 | else ... |
+| UseUseExplosion.rb:20:2278:20:2288 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1858:20:2292 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2278:20:2288 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1858:20:2292 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2278:20:2288 | else ... | UseUseExplosion.rb:20:1858:20:2292 | if ... |
 | UseUseExplosion.rb:20:2283:20:2288 | call to use | UseUseExplosion.rb:20:2278:20:2288 | else ... |
+| UseUseExplosion.rb:20:2294:20:2304 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1837:20:2308 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2294:20:2304 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1837:20:2308 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2294:20:2304 | else ... | UseUseExplosion.rb:20:1837:20:2308 | if ... |
 | UseUseExplosion.rb:20:2299:20:2304 | call to use | UseUseExplosion.rb:20:2294:20:2304 | else ... |
+| UseUseExplosion.rb:20:2310:20:2320 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1816:20:2324 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2310:20:2320 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1816:20:2324 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2310:20:2320 | else ... | UseUseExplosion.rb:20:1816:20:2324 | if ... |
 | UseUseExplosion.rb:20:2315:20:2320 | call to use | UseUseExplosion.rb:20:2310:20:2320 | else ... |
+| UseUseExplosion.rb:20:2326:20:2336 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1795:20:2340 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2326:20:2336 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1795:20:2340 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2326:20:2336 | else ... | UseUseExplosion.rb:20:1795:20:2340 | if ... |
 | UseUseExplosion.rb:20:2331:20:2336 | call to use | UseUseExplosion.rb:20:2326:20:2336 | else ... |
+| UseUseExplosion.rb:20:2342:20:2352 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1774:20:2356 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2342:20:2352 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1774:20:2356 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2342:20:2352 | else ... | UseUseExplosion.rb:20:1774:20:2356 | if ... |
 | UseUseExplosion.rb:20:2347:20:2352 | call to use | UseUseExplosion.rb:20:2342:20:2352 | else ... |
+| UseUseExplosion.rb:20:2358:20:2368 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1753:20:2372 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2358:20:2368 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1753:20:2372 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2358:20:2368 | else ... | UseUseExplosion.rb:20:1753:20:2372 | if ... |
 | UseUseExplosion.rb:20:2363:20:2368 | call to use | UseUseExplosion.rb:20:2358:20:2368 | else ... |
+| UseUseExplosion.rb:20:2374:20:2384 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1732:20:2388 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2374:20:2384 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1732:20:2388 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2374:20:2384 | else ... | UseUseExplosion.rb:20:1732:20:2388 | if ... |
 | UseUseExplosion.rb:20:2379:20:2384 | call to use | UseUseExplosion.rb:20:2374:20:2384 | else ... |
+| UseUseExplosion.rb:20:2390:20:2400 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1711:20:2404 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2390:20:2400 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1711:20:2404 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2390:20:2400 | else ... | UseUseExplosion.rb:20:1711:20:2404 | if ... |
 | UseUseExplosion.rb:20:2395:20:2400 | call to use | UseUseExplosion.rb:20:2390:20:2400 | else ... |
+| UseUseExplosion.rb:20:2406:20:2416 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1690:20:2420 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2406:20:2416 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1690:20:2420 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2406:20:2416 | else ... | UseUseExplosion.rb:20:1690:20:2420 | if ... |
 | UseUseExplosion.rb:20:2411:20:2416 | call to use | UseUseExplosion.rb:20:2406:20:2416 | else ... |
+| UseUseExplosion.rb:20:2422:20:2432 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1669:20:2436 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2422:20:2432 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1669:20:2436 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2422:20:2432 | else ... | UseUseExplosion.rb:20:1669:20:2436 | if ... |
 | UseUseExplosion.rb:20:2427:20:2432 | call to use | UseUseExplosion.rb:20:2422:20:2432 | else ... |
+| UseUseExplosion.rb:20:2438:20:2448 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1648:20:2452 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2438:20:2448 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1648:20:2452 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2438:20:2448 | else ... | UseUseExplosion.rb:20:1648:20:2452 | if ... |
 | UseUseExplosion.rb:20:2443:20:2448 | call to use | UseUseExplosion.rb:20:2438:20:2448 | else ... |
+| UseUseExplosion.rb:20:2454:20:2464 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1627:20:2468 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2454:20:2464 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1627:20:2468 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2454:20:2464 | else ... | UseUseExplosion.rb:20:1627:20:2468 | if ... |
 | UseUseExplosion.rb:20:2459:20:2464 | call to use | UseUseExplosion.rb:20:2454:20:2464 | else ... |
+| UseUseExplosion.rb:20:2470:20:2480 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1606:20:2484 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2470:20:2480 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1606:20:2484 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2470:20:2480 | else ... | UseUseExplosion.rb:20:1606:20:2484 | if ... |
 | UseUseExplosion.rb:20:2475:20:2480 | call to use | UseUseExplosion.rb:20:2470:20:2480 | else ... |
+| UseUseExplosion.rb:20:2486:20:2496 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1585:20:2500 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2486:20:2496 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1585:20:2500 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2486:20:2496 | else ... | UseUseExplosion.rb:20:1585:20:2500 | if ... |
 | UseUseExplosion.rb:20:2491:20:2496 | call to use | UseUseExplosion.rb:20:2486:20:2496 | else ... |
+| UseUseExplosion.rb:20:2502:20:2512 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1564:20:2516 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2502:20:2512 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1564:20:2516 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2502:20:2512 | else ... | UseUseExplosion.rb:20:1564:20:2516 | if ... |
 | UseUseExplosion.rb:20:2507:20:2512 | call to use | UseUseExplosion.rb:20:2502:20:2512 | else ... |
+| UseUseExplosion.rb:20:2518:20:2528 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1543:20:2532 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2518:20:2528 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1543:20:2532 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2518:20:2528 | else ... | UseUseExplosion.rb:20:1543:20:2532 | if ... |
 | UseUseExplosion.rb:20:2523:20:2528 | call to use | UseUseExplosion.rb:20:2518:20:2528 | else ... |
+| UseUseExplosion.rb:20:2534:20:2544 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1522:20:2548 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2534:20:2544 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1522:20:2548 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2534:20:2544 | else ... | UseUseExplosion.rb:20:1522:20:2548 | if ... |
 | UseUseExplosion.rb:20:2539:20:2544 | call to use | UseUseExplosion.rb:20:2534:20:2544 | else ... |
+| UseUseExplosion.rb:20:2550:20:2560 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1501:20:2564 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2550:20:2560 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1501:20:2564 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2550:20:2560 | else ... | UseUseExplosion.rb:20:1501:20:2564 | if ... |
 | UseUseExplosion.rb:20:2555:20:2560 | call to use | UseUseExplosion.rb:20:2550:20:2560 | else ... |
+| UseUseExplosion.rb:20:2566:20:2576 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1480:20:2580 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2566:20:2576 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1480:20:2580 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2566:20:2576 | else ... | UseUseExplosion.rb:20:1480:20:2580 | if ... |
 | UseUseExplosion.rb:20:2571:20:2576 | call to use | UseUseExplosion.rb:20:2566:20:2576 | else ... |
+| UseUseExplosion.rb:20:2582:20:2592 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1459:20:2596 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2582:20:2592 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1459:20:2596 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2582:20:2592 | else ... | UseUseExplosion.rb:20:1459:20:2596 | if ... |
 | UseUseExplosion.rb:20:2587:20:2592 | call to use | UseUseExplosion.rb:20:2582:20:2592 | else ... |
+| UseUseExplosion.rb:20:2598:20:2608 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1438:20:2612 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2598:20:2608 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1438:20:2612 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2598:20:2608 | else ... | UseUseExplosion.rb:20:1438:20:2612 | if ... |
 | UseUseExplosion.rb:20:2603:20:2608 | call to use | UseUseExplosion.rb:20:2598:20:2608 | else ... |
+| UseUseExplosion.rb:20:2614:20:2624 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1417:20:2628 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2614:20:2624 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1417:20:2628 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2614:20:2624 | else ... | UseUseExplosion.rb:20:1417:20:2628 | if ... |
 | UseUseExplosion.rb:20:2619:20:2624 | call to use | UseUseExplosion.rb:20:2614:20:2624 | else ... |
+| UseUseExplosion.rb:20:2630:20:2640 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1396:20:2644 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2630:20:2640 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1396:20:2644 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2630:20:2640 | else ... | UseUseExplosion.rb:20:1396:20:2644 | if ... |
 | UseUseExplosion.rb:20:2635:20:2640 | call to use | UseUseExplosion.rb:20:2630:20:2640 | else ... |
+| UseUseExplosion.rb:20:2646:20:2656 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1375:20:2660 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2646:20:2656 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1375:20:2660 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2646:20:2656 | else ... | UseUseExplosion.rb:20:1375:20:2660 | if ... |
 | UseUseExplosion.rb:20:2651:20:2656 | call to use | UseUseExplosion.rb:20:2646:20:2656 | else ... |
+| UseUseExplosion.rb:20:2662:20:2672 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1354:20:2676 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2662:20:2672 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1354:20:2676 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2662:20:2672 | else ... | UseUseExplosion.rb:20:1354:20:2676 | if ... |
 | UseUseExplosion.rb:20:2667:20:2672 | call to use | UseUseExplosion.rb:20:2662:20:2672 | else ... |
+| UseUseExplosion.rb:20:2678:20:2688 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1333:20:2692 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2678:20:2688 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1333:20:2692 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2678:20:2688 | else ... | UseUseExplosion.rb:20:1333:20:2692 | if ... |
 | UseUseExplosion.rb:20:2683:20:2688 | call to use | UseUseExplosion.rb:20:2678:20:2688 | else ... |
+| UseUseExplosion.rb:20:2694:20:2704 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1312:20:2708 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2694:20:2704 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1312:20:2708 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2694:20:2704 | else ... | UseUseExplosion.rb:20:1312:20:2708 | if ... |
 | UseUseExplosion.rb:20:2699:20:2704 | call to use | UseUseExplosion.rb:20:2694:20:2704 | else ... |
+| UseUseExplosion.rb:20:2710:20:2720 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1291:20:2724 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2710:20:2720 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1291:20:2724 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2710:20:2720 | else ... | UseUseExplosion.rb:20:1291:20:2724 | if ... |
 | UseUseExplosion.rb:20:2715:20:2720 | call to use | UseUseExplosion.rb:20:2710:20:2720 | else ... |
+| UseUseExplosion.rb:20:2726:20:2736 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1270:20:2740 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2726:20:2736 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1270:20:2740 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2726:20:2736 | else ... | UseUseExplosion.rb:20:1270:20:2740 | if ... |
 | UseUseExplosion.rb:20:2731:20:2736 | call to use | UseUseExplosion.rb:20:2726:20:2736 | else ... |
+| UseUseExplosion.rb:20:2742:20:2752 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1249:20:2756 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2742:20:2752 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1249:20:2756 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2742:20:2752 | else ... | UseUseExplosion.rb:20:1249:20:2756 | if ... |
 | UseUseExplosion.rb:20:2747:20:2752 | call to use | UseUseExplosion.rb:20:2742:20:2752 | else ... |
+| UseUseExplosion.rb:20:2758:20:2768 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1228:20:2772 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2758:20:2768 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1228:20:2772 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2758:20:2768 | else ... | UseUseExplosion.rb:20:1228:20:2772 | if ... |
 | UseUseExplosion.rb:20:2763:20:2768 | call to use | UseUseExplosion.rb:20:2758:20:2768 | else ... |
+| UseUseExplosion.rb:20:2774:20:2784 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1207:20:2788 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2774:20:2784 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1207:20:2788 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2774:20:2784 | else ... | UseUseExplosion.rb:20:1207:20:2788 | if ... |
 | UseUseExplosion.rb:20:2779:20:2784 | call to use | UseUseExplosion.rb:20:2774:20:2784 | else ... |
+| UseUseExplosion.rb:20:2790:20:2800 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1186:20:2804 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2790:20:2800 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1186:20:2804 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2790:20:2800 | else ... | UseUseExplosion.rb:20:1186:20:2804 | if ... |
 | UseUseExplosion.rb:20:2795:20:2800 | call to use | UseUseExplosion.rb:20:2790:20:2800 | else ... |
+| UseUseExplosion.rb:20:2806:20:2816 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1165:20:2820 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2806:20:2816 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1165:20:2820 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2806:20:2816 | else ... | UseUseExplosion.rb:20:1165:20:2820 | if ... |
 | UseUseExplosion.rb:20:2811:20:2816 | call to use | UseUseExplosion.rb:20:2806:20:2816 | else ... |
+| UseUseExplosion.rb:20:2822:20:2832 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1144:20:2836 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2822:20:2832 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1144:20:2836 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2822:20:2832 | else ... | UseUseExplosion.rb:20:1144:20:2836 | if ... |
 | UseUseExplosion.rb:20:2827:20:2832 | call to use | UseUseExplosion.rb:20:2822:20:2832 | else ... |
+| UseUseExplosion.rb:20:2838:20:2848 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1123:20:2852 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2838:20:2848 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1123:20:2852 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2838:20:2848 | else ... | UseUseExplosion.rb:20:1123:20:2852 | if ... |
 | UseUseExplosion.rb:20:2843:20:2848 | call to use | UseUseExplosion.rb:20:2838:20:2848 | else ... |
+| UseUseExplosion.rb:20:2854:20:2864 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1102:20:2868 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2854:20:2864 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1102:20:2868 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2854:20:2864 | else ... | UseUseExplosion.rb:20:1102:20:2868 | if ... |
 | UseUseExplosion.rb:20:2859:20:2864 | call to use | UseUseExplosion.rb:20:2854:20:2864 | else ... |
+| UseUseExplosion.rb:20:2870:20:2880 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1081:20:2884 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2870:20:2880 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1081:20:2884 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2870:20:2880 | else ... | UseUseExplosion.rb:20:1081:20:2884 | if ... |
 | UseUseExplosion.rb:20:2875:20:2880 | call to use | UseUseExplosion.rb:20:2870:20:2880 | else ... |
+| UseUseExplosion.rb:20:2886:20:2896 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1060:20:2900 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2886:20:2896 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1060:20:2900 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2886:20:2896 | else ... | UseUseExplosion.rb:20:1060:20:2900 | if ... |
 | UseUseExplosion.rb:20:2891:20:2896 | call to use | UseUseExplosion.rb:20:2886:20:2896 | else ... |
+| UseUseExplosion.rb:20:2902:20:2912 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1039:20:2916 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2902:20:2912 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1039:20:2916 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2902:20:2912 | else ... | UseUseExplosion.rb:20:1039:20:2916 | if ... |
 | UseUseExplosion.rb:20:2907:20:2912 | call to use | UseUseExplosion.rb:20:2902:20:2912 | else ... |
+| UseUseExplosion.rb:20:2918:20:2928 | [input] SSA phi read(self) | UseUseExplosion.rb:20:1018:20:2932 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2918:20:2928 | [input] SSA phi read(x) | UseUseExplosion.rb:20:1018:20:2932 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2918:20:2928 | else ... | UseUseExplosion.rb:20:1018:20:2932 | if ... |
 | UseUseExplosion.rb:20:2923:20:2928 | call to use | UseUseExplosion.rb:20:2918:20:2928 | else ... |
+| UseUseExplosion.rb:20:2934:20:2944 | [input] SSA phi read(self) | UseUseExplosion.rb:20:997:20:2948 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2934:20:2944 | [input] SSA phi read(x) | UseUseExplosion.rb:20:997:20:2948 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2934:20:2944 | else ... | UseUseExplosion.rb:20:997:20:2948 | if ... |
 | UseUseExplosion.rb:20:2939:20:2944 | call to use | UseUseExplosion.rb:20:2934:20:2944 | else ... |
+| UseUseExplosion.rb:20:2950:20:2960 | [input] SSA phi read(self) | UseUseExplosion.rb:20:976:20:2964 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2950:20:2960 | [input] SSA phi read(x) | UseUseExplosion.rb:20:976:20:2964 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2950:20:2960 | else ... | UseUseExplosion.rb:20:976:20:2964 | if ... |
 | UseUseExplosion.rb:20:2955:20:2960 | call to use | UseUseExplosion.rb:20:2950:20:2960 | else ... |
+| UseUseExplosion.rb:20:2966:20:2976 | [input] SSA phi read(self) | UseUseExplosion.rb:20:955:20:2980 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2966:20:2976 | [input] SSA phi read(x) | UseUseExplosion.rb:20:955:20:2980 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2966:20:2976 | else ... | UseUseExplosion.rb:20:955:20:2980 | if ... |
 | UseUseExplosion.rb:20:2971:20:2976 | call to use | UseUseExplosion.rb:20:2966:20:2976 | else ... |
+| UseUseExplosion.rb:20:2982:20:2992 | [input] SSA phi read(self) | UseUseExplosion.rb:20:934:20:2996 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2982:20:2992 | [input] SSA phi read(x) | UseUseExplosion.rb:20:934:20:2996 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2982:20:2992 | else ... | UseUseExplosion.rb:20:934:20:2996 | if ... |
 | UseUseExplosion.rb:20:2987:20:2992 | call to use | UseUseExplosion.rb:20:2982:20:2992 | else ... |
+| UseUseExplosion.rb:20:2998:20:3008 | [input] SSA phi read(self) | UseUseExplosion.rb:20:913:20:3012 | SSA phi read(self) |
+| UseUseExplosion.rb:20:2998:20:3008 | [input] SSA phi read(x) | UseUseExplosion.rb:20:913:20:3012 | SSA phi read(x) |
 | UseUseExplosion.rb:20:2998:20:3008 | else ... | UseUseExplosion.rb:20:913:20:3012 | if ... |
 | UseUseExplosion.rb:20:3003:20:3008 | call to use | UseUseExplosion.rb:20:2998:20:3008 | else ... |
+| UseUseExplosion.rb:20:3014:20:3024 | [input] SSA phi read(self) | UseUseExplosion.rb:20:892:20:3028 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3014:20:3024 | [input] SSA phi read(x) | UseUseExplosion.rb:20:892:20:3028 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3014:20:3024 | else ... | UseUseExplosion.rb:20:892:20:3028 | if ... |
 | UseUseExplosion.rb:20:3019:20:3024 | call to use | UseUseExplosion.rb:20:3014:20:3024 | else ... |
+| UseUseExplosion.rb:20:3030:20:3040 | [input] SSA phi read(self) | UseUseExplosion.rb:20:871:20:3044 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3030:20:3040 | [input] SSA phi read(x) | UseUseExplosion.rb:20:871:20:3044 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3030:20:3040 | else ... | UseUseExplosion.rb:20:871:20:3044 | if ... |
 | UseUseExplosion.rb:20:3035:20:3040 | call to use | UseUseExplosion.rb:20:3030:20:3040 | else ... |
+| UseUseExplosion.rb:20:3046:20:3056 | [input] SSA phi read(self) | UseUseExplosion.rb:20:850:20:3060 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3046:20:3056 | [input] SSA phi read(x) | UseUseExplosion.rb:20:850:20:3060 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3046:20:3056 | else ... | UseUseExplosion.rb:20:850:20:3060 | if ... |
 | UseUseExplosion.rb:20:3051:20:3056 | call to use | UseUseExplosion.rb:20:3046:20:3056 | else ... |
+| UseUseExplosion.rb:20:3062:20:3072 | [input] SSA phi read(self) | UseUseExplosion.rb:20:829:20:3076 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3062:20:3072 | [input] SSA phi read(x) | UseUseExplosion.rb:20:829:20:3076 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3062:20:3072 | else ... | UseUseExplosion.rb:20:829:20:3076 | if ... |
 | UseUseExplosion.rb:20:3067:20:3072 | call to use | UseUseExplosion.rb:20:3062:20:3072 | else ... |
+| UseUseExplosion.rb:20:3078:20:3088 | [input] SSA phi read(self) | UseUseExplosion.rb:20:808:20:3092 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3078:20:3088 | [input] SSA phi read(x) | UseUseExplosion.rb:20:808:20:3092 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3078:20:3088 | else ... | UseUseExplosion.rb:20:808:20:3092 | if ... |
 | UseUseExplosion.rb:20:3083:20:3088 | call to use | UseUseExplosion.rb:20:3078:20:3088 | else ... |
+| UseUseExplosion.rb:20:3094:20:3104 | [input] SSA phi read(self) | UseUseExplosion.rb:20:787:20:3108 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3094:20:3104 | [input] SSA phi read(x) | UseUseExplosion.rb:20:787:20:3108 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3094:20:3104 | else ... | UseUseExplosion.rb:20:787:20:3108 | if ... |
 | UseUseExplosion.rb:20:3099:20:3104 | call to use | UseUseExplosion.rb:20:3094:20:3104 | else ... |
+| UseUseExplosion.rb:20:3110:20:3120 | [input] SSA phi read(self) | UseUseExplosion.rb:20:766:20:3124 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3110:20:3120 | [input] SSA phi read(x) | UseUseExplosion.rb:20:766:20:3124 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3110:20:3120 | else ... | UseUseExplosion.rb:20:766:20:3124 | if ... |
 | UseUseExplosion.rb:20:3115:20:3120 | call to use | UseUseExplosion.rb:20:3110:20:3120 | else ... |
+| UseUseExplosion.rb:20:3126:20:3136 | [input] SSA phi read(self) | UseUseExplosion.rb:20:745:20:3140 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3126:20:3136 | [input] SSA phi read(x) | UseUseExplosion.rb:20:745:20:3140 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3126:20:3136 | else ... | UseUseExplosion.rb:20:745:20:3140 | if ... |
 | UseUseExplosion.rb:20:3131:20:3136 | call to use | UseUseExplosion.rb:20:3126:20:3136 | else ... |
+| UseUseExplosion.rb:20:3142:20:3152 | [input] SSA phi read(self) | UseUseExplosion.rb:20:724:20:3156 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3142:20:3152 | [input] SSA phi read(x) | UseUseExplosion.rb:20:724:20:3156 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3142:20:3152 | else ... | UseUseExplosion.rb:20:724:20:3156 | if ... |
 | UseUseExplosion.rb:20:3147:20:3152 | call to use | UseUseExplosion.rb:20:3142:20:3152 | else ... |
+| UseUseExplosion.rb:20:3158:20:3168 | [input] SSA phi read(self) | UseUseExplosion.rb:20:703:20:3172 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3158:20:3168 | [input] SSA phi read(x) | UseUseExplosion.rb:20:703:20:3172 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3158:20:3168 | else ... | UseUseExplosion.rb:20:703:20:3172 | if ... |
 | UseUseExplosion.rb:20:3163:20:3168 | call to use | UseUseExplosion.rb:20:3158:20:3168 | else ... |
+| UseUseExplosion.rb:20:3174:20:3184 | [input] SSA phi read(self) | UseUseExplosion.rb:20:682:20:3188 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3174:20:3184 | [input] SSA phi read(x) | UseUseExplosion.rb:20:682:20:3188 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3174:20:3184 | else ... | UseUseExplosion.rb:20:682:20:3188 | if ... |
 | UseUseExplosion.rb:20:3179:20:3184 | call to use | UseUseExplosion.rb:20:3174:20:3184 | else ... |
+| UseUseExplosion.rb:20:3190:20:3200 | [input] SSA phi read(self) | UseUseExplosion.rb:20:661:20:3204 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3190:20:3200 | [input] SSA phi read(x) | UseUseExplosion.rb:20:661:20:3204 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3190:20:3200 | else ... | UseUseExplosion.rb:20:661:20:3204 | if ... |
 | UseUseExplosion.rb:20:3195:20:3200 | call to use | UseUseExplosion.rb:20:3190:20:3200 | else ... |
+| UseUseExplosion.rb:20:3206:20:3216 | [input] SSA phi read(self) | UseUseExplosion.rb:20:640:20:3220 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3206:20:3216 | [input] SSA phi read(x) | UseUseExplosion.rb:20:640:20:3220 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3206:20:3216 | else ... | UseUseExplosion.rb:20:640:20:3220 | if ... |
 | UseUseExplosion.rb:20:3211:20:3216 | call to use | UseUseExplosion.rb:20:3206:20:3216 | else ... |
+| UseUseExplosion.rb:20:3222:20:3232 | [input] SSA phi read(self) | UseUseExplosion.rb:20:619:20:3236 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3222:20:3232 | [input] SSA phi read(x) | UseUseExplosion.rb:20:619:20:3236 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3222:20:3232 | else ... | UseUseExplosion.rb:20:619:20:3236 | if ... |
 | UseUseExplosion.rb:20:3227:20:3232 | call to use | UseUseExplosion.rb:20:3222:20:3232 | else ... |
+| UseUseExplosion.rb:20:3238:20:3248 | [input] SSA phi read(self) | UseUseExplosion.rb:20:598:20:3252 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3238:20:3248 | [input] SSA phi read(x) | UseUseExplosion.rb:20:598:20:3252 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3238:20:3248 | else ... | UseUseExplosion.rb:20:598:20:3252 | if ... |
 | UseUseExplosion.rb:20:3243:20:3248 | call to use | UseUseExplosion.rb:20:3238:20:3248 | else ... |
+| UseUseExplosion.rb:20:3254:20:3264 | [input] SSA phi read(self) | UseUseExplosion.rb:20:577:20:3268 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3254:20:3264 | [input] SSA phi read(x) | UseUseExplosion.rb:20:577:20:3268 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3254:20:3264 | else ... | UseUseExplosion.rb:20:577:20:3268 | if ... |
 | UseUseExplosion.rb:20:3259:20:3264 | call to use | UseUseExplosion.rb:20:3254:20:3264 | else ... |
+| UseUseExplosion.rb:20:3270:20:3280 | [input] SSA phi read(self) | UseUseExplosion.rb:20:556:20:3284 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3270:20:3280 | [input] SSA phi read(x) | UseUseExplosion.rb:20:556:20:3284 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3270:20:3280 | else ... | UseUseExplosion.rb:20:556:20:3284 | if ... |
 | UseUseExplosion.rb:20:3275:20:3280 | call to use | UseUseExplosion.rb:20:3270:20:3280 | else ... |
+| UseUseExplosion.rb:20:3286:20:3296 | [input] SSA phi read(self) | UseUseExplosion.rb:20:535:20:3300 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3286:20:3296 | [input] SSA phi read(x) | UseUseExplosion.rb:20:535:20:3300 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3286:20:3296 | else ... | UseUseExplosion.rb:20:535:20:3300 | if ... |
 | UseUseExplosion.rb:20:3291:20:3296 | call to use | UseUseExplosion.rb:20:3286:20:3296 | else ... |
+| UseUseExplosion.rb:20:3302:20:3312 | [input] SSA phi read(self) | UseUseExplosion.rb:20:514:20:3316 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3302:20:3312 | [input] SSA phi read(x) | UseUseExplosion.rb:20:514:20:3316 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3302:20:3312 | else ... | UseUseExplosion.rb:20:514:20:3316 | if ... |
 | UseUseExplosion.rb:20:3307:20:3312 | call to use | UseUseExplosion.rb:20:3302:20:3312 | else ... |
+| UseUseExplosion.rb:20:3318:20:3328 | [input] SSA phi read(self) | UseUseExplosion.rb:20:493:20:3332 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3318:20:3328 | [input] SSA phi read(x) | UseUseExplosion.rb:20:493:20:3332 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3318:20:3328 | else ... | UseUseExplosion.rb:20:493:20:3332 | if ... |
 | UseUseExplosion.rb:20:3323:20:3328 | call to use | UseUseExplosion.rb:20:3318:20:3328 | else ... |
+| UseUseExplosion.rb:20:3334:20:3344 | [input] SSA phi read(self) | UseUseExplosion.rb:20:472:20:3348 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3334:20:3344 | [input] SSA phi read(x) | UseUseExplosion.rb:20:472:20:3348 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3334:20:3344 | else ... | UseUseExplosion.rb:20:472:20:3348 | if ... |
 | UseUseExplosion.rb:20:3339:20:3344 | call to use | UseUseExplosion.rb:20:3334:20:3344 | else ... |
+| UseUseExplosion.rb:20:3350:20:3360 | [input] SSA phi read(self) | UseUseExplosion.rb:20:451:20:3364 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3350:20:3360 | [input] SSA phi read(x) | UseUseExplosion.rb:20:451:20:3364 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3350:20:3360 | else ... | UseUseExplosion.rb:20:451:20:3364 | if ... |
 | UseUseExplosion.rb:20:3355:20:3360 | call to use | UseUseExplosion.rb:20:3350:20:3360 | else ... |
+| UseUseExplosion.rb:20:3366:20:3376 | [input] SSA phi read(self) | UseUseExplosion.rb:20:430:20:3380 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3366:20:3376 | [input] SSA phi read(x) | UseUseExplosion.rb:20:430:20:3380 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3366:20:3376 | else ... | UseUseExplosion.rb:20:430:20:3380 | if ... |
 | UseUseExplosion.rb:20:3371:20:3376 | call to use | UseUseExplosion.rb:20:3366:20:3376 | else ... |
+| UseUseExplosion.rb:20:3382:20:3392 | [input] SSA phi read(self) | UseUseExplosion.rb:20:409:20:3396 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3382:20:3392 | [input] SSA phi read(x) | UseUseExplosion.rb:20:409:20:3396 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3382:20:3392 | else ... | UseUseExplosion.rb:20:409:20:3396 | if ... |
 | UseUseExplosion.rb:20:3387:20:3392 | call to use | UseUseExplosion.rb:20:3382:20:3392 | else ... |
+| UseUseExplosion.rb:20:3398:20:3408 | [input] SSA phi read(self) | UseUseExplosion.rb:20:388:20:3412 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3398:20:3408 | [input] SSA phi read(x) | UseUseExplosion.rb:20:388:20:3412 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3398:20:3408 | else ... | UseUseExplosion.rb:20:388:20:3412 | if ... |
 | UseUseExplosion.rb:20:3403:20:3408 | call to use | UseUseExplosion.rb:20:3398:20:3408 | else ... |
+| UseUseExplosion.rb:20:3414:20:3424 | [input] SSA phi read(self) | UseUseExplosion.rb:20:367:20:3428 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3414:20:3424 | [input] SSA phi read(x) | UseUseExplosion.rb:20:367:20:3428 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3414:20:3424 | else ... | UseUseExplosion.rb:20:367:20:3428 | if ... |
 | UseUseExplosion.rb:20:3419:20:3424 | call to use | UseUseExplosion.rb:20:3414:20:3424 | else ... |
+| UseUseExplosion.rb:20:3430:20:3440 | [input] SSA phi read(self) | UseUseExplosion.rb:20:346:20:3444 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3430:20:3440 | [input] SSA phi read(x) | UseUseExplosion.rb:20:346:20:3444 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3430:20:3440 | else ... | UseUseExplosion.rb:20:346:20:3444 | if ... |
 | UseUseExplosion.rb:20:3435:20:3440 | call to use | UseUseExplosion.rb:20:3430:20:3440 | else ... |
+| UseUseExplosion.rb:20:3446:20:3456 | [input] SSA phi read(self) | UseUseExplosion.rb:20:325:20:3460 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3446:20:3456 | [input] SSA phi read(x) | UseUseExplosion.rb:20:325:20:3460 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3446:20:3456 | else ... | UseUseExplosion.rb:20:325:20:3460 | if ... |
 | UseUseExplosion.rb:20:3451:20:3456 | call to use | UseUseExplosion.rb:20:3446:20:3456 | else ... |
+| UseUseExplosion.rb:20:3462:20:3472 | [input] SSA phi read(self) | UseUseExplosion.rb:20:304:20:3476 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3462:20:3472 | [input] SSA phi read(x) | UseUseExplosion.rb:20:304:20:3476 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3462:20:3472 | else ... | UseUseExplosion.rb:20:304:20:3476 | if ... |
 | UseUseExplosion.rb:20:3467:20:3472 | call to use | UseUseExplosion.rb:20:3462:20:3472 | else ... |
+| UseUseExplosion.rb:20:3478:20:3488 | [input] SSA phi read(self) | UseUseExplosion.rb:20:283:20:3492 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3478:20:3488 | [input] SSA phi read(x) | UseUseExplosion.rb:20:283:20:3492 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3478:20:3488 | else ... | UseUseExplosion.rb:20:283:20:3492 | if ... |
 | UseUseExplosion.rb:20:3483:20:3488 | call to use | UseUseExplosion.rb:20:3478:20:3488 | else ... |
+| UseUseExplosion.rb:20:3494:20:3504 | [input] SSA phi read(self) | UseUseExplosion.rb:20:262:20:3508 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3494:20:3504 | [input] SSA phi read(x) | UseUseExplosion.rb:20:262:20:3508 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3494:20:3504 | else ... | UseUseExplosion.rb:20:262:20:3508 | if ... |
 | UseUseExplosion.rb:20:3499:20:3504 | call to use | UseUseExplosion.rb:20:3494:20:3504 | else ... |
+| UseUseExplosion.rb:20:3510:20:3520 | [input] SSA phi read(self) | UseUseExplosion.rb:20:241:20:3524 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3510:20:3520 | [input] SSA phi read(x) | UseUseExplosion.rb:20:241:20:3524 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3510:20:3520 | else ... | UseUseExplosion.rb:20:241:20:3524 | if ... |
 | UseUseExplosion.rb:20:3515:20:3520 | call to use | UseUseExplosion.rb:20:3510:20:3520 | else ... |
+| UseUseExplosion.rb:20:3526:20:3536 | [input] SSA phi read(self) | UseUseExplosion.rb:20:220:20:3540 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3526:20:3536 | [input] SSA phi read(x) | UseUseExplosion.rb:20:220:20:3540 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3526:20:3536 | else ... | UseUseExplosion.rb:20:220:20:3540 | if ... |
 | UseUseExplosion.rb:20:3531:20:3536 | call to use | UseUseExplosion.rb:20:3526:20:3536 | else ... |
+| UseUseExplosion.rb:20:3542:20:3552 | [input] SSA phi read(self) | UseUseExplosion.rb:20:199:20:3556 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3542:20:3552 | [input] SSA phi read(x) | UseUseExplosion.rb:20:199:20:3556 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3542:20:3552 | else ... | UseUseExplosion.rb:20:199:20:3556 | if ... |
 | UseUseExplosion.rb:20:3547:20:3552 | call to use | UseUseExplosion.rb:20:3542:20:3552 | else ... |
+| UseUseExplosion.rb:20:3558:20:3568 | [input] SSA phi read(self) | UseUseExplosion.rb:20:178:20:3572 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3558:20:3568 | [input] SSA phi read(x) | UseUseExplosion.rb:20:178:20:3572 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3558:20:3568 | else ... | UseUseExplosion.rb:20:178:20:3572 | if ... |
 | UseUseExplosion.rb:20:3563:20:3568 | call to use | UseUseExplosion.rb:20:3558:20:3568 | else ... |
+| UseUseExplosion.rb:20:3574:20:3584 | [input] SSA phi read(self) | UseUseExplosion.rb:20:157:20:3588 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3574:20:3584 | [input] SSA phi read(x) | UseUseExplosion.rb:20:157:20:3588 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3574:20:3584 | else ... | UseUseExplosion.rb:20:157:20:3588 | if ... |
 | UseUseExplosion.rb:20:3579:20:3584 | call to use | UseUseExplosion.rb:20:3574:20:3584 | else ... |
+| UseUseExplosion.rb:20:3590:20:3600 | [input] SSA phi read(self) | UseUseExplosion.rb:20:136:20:3604 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3590:20:3600 | [input] SSA phi read(x) | UseUseExplosion.rb:20:136:20:3604 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3590:20:3600 | else ... | UseUseExplosion.rb:20:136:20:3604 | if ... |
 | UseUseExplosion.rb:20:3595:20:3600 | call to use | UseUseExplosion.rb:20:3590:20:3600 | else ... |
+| UseUseExplosion.rb:20:3606:20:3616 | [input] SSA phi read(self) | UseUseExplosion.rb:20:115:20:3620 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3606:20:3616 | [input] SSA phi read(x) | UseUseExplosion.rb:20:115:20:3620 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3606:20:3616 | else ... | UseUseExplosion.rb:20:115:20:3620 | if ... |
 | UseUseExplosion.rb:20:3611:20:3616 | call to use | UseUseExplosion.rb:20:3606:20:3616 | else ... |
+| UseUseExplosion.rb:20:3622:20:3632 | [input] SSA phi read(self) | UseUseExplosion.rb:20:94:20:3636 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3622:20:3632 | [input] SSA phi read(x) | UseUseExplosion.rb:20:94:20:3636 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3622:20:3632 | else ... | UseUseExplosion.rb:20:94:20:3636 | if ... |
 | UseUseExplosion.rb:20:3627:20:3632 | call to use | UseUseExplosion.rb:20:3622:20:3632 | else ... |
+| UseUseExplosion.rb:20:3638:20:3648 | [input] SSA phi read(self) | UseUseExplosion.rb:20:73:20:3652 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3638:20:3648 | [input] SSA phi read(x) | UseUseExplosion.rb:20:73:20:3652 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3638:20:3648 | else ... | UseUseExplosion.rb:20:73:20:3652 | if ... |
 | UseUseExplosion.rb:20:3643:20:3648 | call to use | UseUseExplosion.rb:20:3638:20:3648 | else ... |
+| UseUseExplosion.rb:20:3654:20:3664 | [input] SSA phi read(self) | UseUseExplosion.rb:20:52:20:3668 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3654:20:3664 | [input] SSA phi read(x) | UseUseExplosion.rb:20:52:20:3668 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3654:20:3664 | else ... | UseUseExplosion.rb:20:52:20:3668 | if ... |
 | UseUseExplosion.rb:20:3659:20:3664 | call to use | UseUseExplosion.rb:20:3654:20:3664 | else ... |
+| UseUseExplosion.rb:20:3670:20:3680 | [input] SSA phi read(self) | UseUseExplosion.rb:20:31:20:3684 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3670:20:3680 | [input] SSA phi read(x) | UseUseExplosion.rb:20:31:20:3684 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3670:20:3680 | else ... | UseUseExplosion.rb:20:31:20:3684 | if ... |
 | UseUseExplosion.rb:20:3675:20:3680 | call to use | UseUseExplosion.rb:20:3670:20:3680 | else ... |
+| UseUseExplosion.rb:20:3686:20:3696 | [input] SSA phi read(self) | UseUseExplosion.rb:20:9:20:3700 | SSA phi read(self) |
+| UseUseExplosion.rb:20:3686:20:3696 | [input] SSA phi read(x) | UseUseExplosion.rb:20:9:20:3700 | SSA phi read(x) |
 | UseUseExplosion.rb:20:3686:20:3696 | else ... | UseUseExplosion.rb:20:9:20:3700 | if ... |
 | UseUseExplosion.rb:20:3691:20:3696 | call to use | UseUseExplosion.rb:20:3686:20:3696 | else ... |
 | UseUseExplosion.rb:21:13:21:17 | @prop | UseUseExplosion.rb:21:13:21:23 | ... > ... |
@@ -2889,12 +3289,14 @@
 | local_dataflow.rb:10:5:13:3 | call to each | local_dataflow.rb:10:5:13:3 | ... |
 | local_dataflow.rb:10:5:13:3 | synthetic splat parameter | local_dataflow.rb:10:5:13:3 | __synth__0__1 |
 | local_dataflow.rb:10:9:10:9 | ... = ... | local_dataflow.rb:10:9:10:9 | if ... |
+| local_dataflow.rb:10:9:10:9 | [input] phi | local_dataflow.rb:10:9:10:9 | phi |
+| local_dataflow.rb:10:9:10:9 | [input] phi | local_dataflow.rb:10:9:10:9 | phi |
 | local_dataflow.rb:10:9:10:9 | defined? ... | local_dataflow.rb:10:9:10:9 | [false] ! ... |
 | local_dataflow.rb:10:9:10:9 | defined? ... | local_dataflow.rb:10:9:10:9 | [true] ! ... |
 | local_dataflow.rb:10:9:10:9 | nil | local_dataflow.rb:10:9:10:9 | ... = ... |
 | local_dataflow.rb:10:9:10:9 | nil | local_dataflow.rb:10:9:10:9 | x |
+| local_dataflow.rb:10:9:10:9 | x | local_dataflow.rb:10:9:10:9 | [input] phi |
 | local_dataflow.rb:10:9:10:9 | x | local_dataflow.rb:10:9:10:9 | defined? ... |
-| local_dataflow.rb:10:9:10:9 | x | local_dataflow.rb:10:9:10:9 | phi |
 | local_dataflow.rb:10:9:10:9 | x | local_dataflow.rb:12:5:12:5 | x |
 | local_dataflow.rb:10:14:10:18 | [post] array | local_dataflow.rb:15:10:15:14 | array |
 | local_dataflow.rb:10:14:10:18 | array | local_dataflow.rb:15:10:15:14 | array |
@@ -2908,12 +3310,14 @@
 | local_dataflow.rb:15:1:17:3 | call to each | local_dataflow.rb:15:1:17:3 | ... |
 | local_dataflow.rb:15:1:17:3 | synthetic splat parameter | local_dataflow.rb:15:1:17:3 | __synth__0__1 |
 | local_dataflow.rb:15:5:15:5 | ... = ... | local_dataflow.rb:15:5:15:5 | if ... |
+| local_dataflow.rb:15:5:15:5 | [input] phi | local_dataflow.rb:15:5:15:5 | phi |
+| local_dataflow.rb:15:5:15:5 | [input] phi | local_dataflow.rb:15:5:15:5 | phi |
 | local_dataflow.rb:15:5:15:5 | defined? ... | local_dataflow.rb:15:5:15:5 | [false] ! ... |
 | local_dataflow.rb:15:5:15:5 | defined? ... | local_dataflow.rb:15:5:15:5 | [true] ! ... |
 | local_dataflow.rb:15:5:15:5 | nil | local_dataflow.rb:15:5:15:5 | ... = ... |
 | local_dataflow.rb:15:5:15:5 | nil | local_dataflow.rb:15:5:15:5 | x |
+| local_dataflow.rb:15:5:15:5 | x | local_dataflow.rb:15:5:15:5 | [input] phi |
 | local_dataflow.rb:15:5:15:5 | x | local_dataflow.rb:15:5:15:5 | defined? ... |
-| local_dataflow.rb:15:5:15:5 | x | local_dataflow.rb:15:5:15:5 | phi |
 | local_dataflow.rb:15:10:15:14 | [post] array | local_dataflow.rb:19:10:19:14 | array |
 | local_dataflow.rb:15:10:15:14 | array | local_dataflow.rb:19:10:19:14 | array |
 | local_dataflow.rb:16:9:16:10 | 10 | local_dataflow.rb:16:3:16:10 | break |
@@ -2924,12 +3328,14 @@
 | local_dataflow.rb:19:1:21:3 | call to each | local_dataflow.rb:19:1:21:3 | ... |
 | local_dataflow.rb:19:1:21:3 | synthetic splat parameter | local_dataflow.rb:19:1:21:3 | __synth__0__1 |
 | local_dataflow.rb:19:5:19:5 | ... = ... | local_dataflow.rb:19:5:19:5 | if ... |
+| local_dataflow.rb:19:5:19:5 | [input] phi | local_dataflow.rb:19:5:19:5 | phi |
+| local_dataflow.rb:19:5:19:5 | [input] phi | local_dataflow.rb:19:5:19:5 | phi |
 | local_dataflow.rb:19:5:19:5 | defined? ... | local_dataflow.rb:19:5:19:5 | [false] ! ... |
 | local_dataflow.rb:19:5:19:5 | defined? ... | local_dataflow.rb:19:5:19:5 | [true] ! ... |
 | local_dataflow.rb:19:5:19:5 | nil | local_dataflow.rb:19:5:19:5 | ... = ... |
 | local_dataflow.rb:19:5:19:5 | nil | local_dataflow.rb:19:5:19:5 | x |
+| local_dataflow.rb:19:5:19:5 | x | local_dataflow.rb:19:5:19:5 | [input] phi |
 | local_dataflow.rb:19:5:19:5 | x | local_dataflow.rb:19:5:19:5 | defined? ... |
-| local_dataflow.rb:19:5:19:5 | x | local_dataflow.rb:19:5:19:5 | phi |
 | local_dataflow.rb:19:5:19:5 | x | local_dataflow.rb:20:6:20:6 | x |
 | local_dataflow.rb:20:6:20:6 | x | local_dataflow.rb:20:6:20:10 | ... > ... |
 | local_dataflow.rb:20:10:20:10 | 1 | local_dataflow.rb:20:6:20:10 | ... > ... |
@@ -2978,12 +3384,16 @@
 | local_dataflow.rb:61:12:61:12 | x | local_dataflow.rb:63:15:63:15 | x |
 | local_dataflow.rb:61:12:61:12 | x | local_dataflow.rb:65:6:65:6 | x |
 | local_dataflow.rb:61:12:61:12 | x | local_dataflow.rb:67:5:67:5 | x |
+| local_dataflow.rb:62:10:62:15 | [input] SSA phi read(x) | local_dataflow.rb:61:7:68:5 | SSA phi read(x) |
 | local_dataflow.rb:62:10:62:15 | then ... | local_dataflow.rb:61:7:68:5 | case ... |
 | local_dataflow.rb:62:15:62:15 | 3 | local_dataflow.rb:62:10:62:15 | then ... |
+| local_dataflow.rb:63:10:63:15 | [input] SSA phi read(x) | local_dataflow.rb:61:7:68:5 | SSA phi read(x) |
 | local_dataflow.rb:63:10:63:15 | then ... | local_dataflow.rb:61:7:68:5 | case ... |
 | local_dataflow.rb:63:15:63:15 | x | local_dataflow.rb:63:10:63:15 | then ... |
+| local_dataflow.rb:64:9:65:6 | [input] SSA phi read(x) | local_dataflow.rb:61:7:68:5 | SSA phi read(x) |
 | local_dataflow.rb:64:9:65:6 | then ... | local_dataflow.rb:61:7:68:5 | case ... |
 | local_dataflow.rb:65:6:65:6 | x | local_dataflow.rb:64:9:65:6 | then ... |
+| local_dataflow.rb:66:3:67:5 | [input] SSA phi read(x) | local_dataflow.rb:61:7:68:5 | SSA phi read(x) |
 | local_dataflow.rb:66:3:67:5 | else ... | local_dataflow.rb:61:7:68:5 | case ... |
 | local_dataflow.rb:67:5:67:5 | x | local_dataflow.rb:66:3:67:5 | else ... |
 | local_dataflow.rb:69:7:76:5 | case ... | local_dataflow.rb:69:3:76:5 | ... = ... |
@@ -3023,6 +3433,7 @@
 | local_dataflow.rb:78:12:78:20 | self | local_dataflow.rb:86:28:86:34 | self |
 | local_dataflow.rb:78:12:78:20 | self | local_dataflow.rb:87:20:87:26 | self |
 | local_dataflow.rb:79:13:79:13 | b | local_dataflow.rb:79:25:79:25 | b |
+| local_dataflow.rb:79:15:79:45 | [input] SSA phi read(self) | local_dataflow.rb:78:7:88:5 | SSA phi read(self) |
 | local_dataflow.rb:79:15:79:45 | then ... | local_dataflow.rb:78:7:88:5 | case ... |
 | local_dataflow.rb:79:20:79:26 | call to sink | local_dataflow.rb:79:15:79:45 | then ... |
 | local_dataflow.rb:80:8:80:8 | a | local_dataflow.rb:80:13:80:13 | a |
@@ -3030,11 +3441,13 @@
 | local_dataflow.rb:80:13:80:13 | a | local_dataflow.rb:80:13:80:17 | ... > ... |
 | local_dataflow.rb:80:13:80:13 | a | local_dataflow.rb:80:29:80:29 | a |
 | local_dataflow.rb:80:17:80:17 | 0 | local_dataflow.rb:80:13:80:17 | ... > ... |
+| local_dataflow.rb:80:19:80:49 | [input] SSA phi read(self) | local_dataflow.rb:78:7:88:5 | SSA phi read(self) |
 | local_dataflow.rb:80:19:80:49 | then ... | local_dataflow.rb:78:7:88:5 | case ... |
 | local_dataflow.rb:80:24:80:30 | call to sink | local_dataflow.rb:80:19:80:49 | then ... |
 | local_dataflow.rb:81:9:81:9 | c | local_dataflow.rb:82:12:82:12 | c |
 | local_dataflow.rb:81:13:81:13 | d | local_dataflow.rb:83:12:83:12 | d |
 | local_dataflow.rb:81:16:81:16 | e | local_dataflow.rb:84:12:84:12 | e |
+| local_dataflow.rb:81:20:84:33 | [input] SSA phi read(self) | local_dataflow.rb:78:7:88:5 | SSA phi read(self) |
 | local_dataflow.rb:81:20:84:33 | then ... | local_dataflow.rb:78:7:88:5 | case ... |
 | local_dataflow.rb:81:25:84:14 | Array | local_dataflow.rb:81:25:84:14 | call to [] |
 | local_dataflow.rb:81:25:84:14 | call to [] | local_dataflow.rb:81:20:84:33 | then ... |
@@ -3044,12 +3457,15 @@
 | local_dataflow.rb:83:7:83:13 | [post] self | local_dataflow.rb:84:7:84:13 | self |
 | local_dataflow.rb:83:7:83:13 | self | local_dataflow.rb:84:7:84:13 | self |
 | local_dataflow.rb:85:13:85:13 | f | local_dataflow.rb:85:27:85:27 | f |
+| local_dataflow.rb:85:17:85:47 | [input] SSA phi read(self) | local_dataflow.rb:78:7:88:5 | SSA phi read(self) |
 | local_dataflow.rb:85:17:85:47 | then ... | local_dataflow.rb:78:7:88:5 | case ... |
 | local_dataflow.rb:85:22:85:28 | call to sink | local_dataflow.rb:85:17:85:47 | then ... |
 | local_dataflow.rb:86:18:86:18 | g | local_dataflow.rb:86:33:86:33 | g |
+| local_dataflow.rb:86:23:86:53 | [input] SSA phi read(self) | local_dataflow.rb:78:7:88:5 | SSA phi read(self) |
 | local_dataflow.rb:86:23:86:53 | then ... | local_dataflow.rb:78:7:88:5 | case ... |
 | local_dataflow.rb:86:28:86:34 | call to sink | local_dataflow.rb:86:23:86:53 | then ... |
 | local_dataflow.rb:87:10:87:10 | x | local_dataflow.rb:87:25:87:25 | x |
+| local_dataflow.rb:87:15:87:48 | [input] SSA phi read(self) | local_dataflow.rb:78:7:88:5 | SSA phi read(self) |
 | local_dataflow.rb:87:15:87:48 | then ... | local_dataflow.rb:78:7:88:5 | case ... |
 | local_dataflow.rb:87:25:87:25 | [post] x | local_dataflow.rb:87:29:87:29 | x |
 | local_dataflow.rb:87:25:87:25 | x | local_dataflow.rb:87:29:87:29 | x |
@@ -3057,42 +3473,50 @@
 | local_dataflow.rb:92:1:109:3 | self (and_or) | local_dataflow.rb:93:7:93:15 | self |
 | local_dataflow.rb:92:1:109:3 | self in and_or | local_dataflow.rb:92:1:109:3 | self (and_or) |
 | local_dataflow.rb:93:3:93:3 | a | local_dataflow.rb:94:8:94:8 | a |
+| local_dataflow.rb:93:7:93:15 | [input] SSA phi read(self) | local_dataflow.rb:93:7:93:28 | SSA phi read(self) |
 | local_dataflow.rb:93:7:93:15 | [post] self | local_dataflow.rb:93:20:93:28 | self |
 | local_dataflow.rb:93:7:93:15 | call to source | local_dataflow.rb:93:7:93:28 | ... \|\| ... |
 | local_dataflow.rb:93:7:93:15 | self | local_dataflow.rb:93:20:93:28 | self |
 | local_dataflow.rb:93:7:93:28 | ... \|\| ... | local_dataflow.rb:93:3:93:3 | a |
 | local_dataflow.rb:93:7:93:28 | ... \|\| ... | local_dataflow.rb:93:3:93:28 | ... = ... |
 | local_dataflow.rb:93:7:93:28 | SSA phi read(self) | local_dataflow.rb:94:3:94:9 | self |
+| local_dataflow.rb:93:20:93:28 | [input] SSA phi read(self) | local_dataflow.rb:93:7:93:28 | SSA phi read(self) |
 | local_dataflow.rb:93:20:93:28 | call to source | local_dataflow.rb:93:7:93:28 | ... \|\| ... |
 | local_dataflow.rb:94:3:94:9 | [post] self | local_dataflow.rb:95:8:95:16 | self |
 | local_dataflow.rb:94:3:94:9 | self | local_dataflow.rb:95:8:95:16 | self |
 | local_dataflow.rb:95:3:95:3 | b | local_dataflow.rb:96:8:96:8 | b |
 | local_dataflow.rb:95:7:95:30 | ( ... ) | local_dataflow.rb:95:3:95:3 | b |
 | local_dataflow.rb:95:7:95:30 | ( ... ) | local_dataflow.rb:95:3:95:30 | ... = ... |
+| local_dataflow.rb:95:8:95:16 | [input] SSA phi read(self) | local_dataflow.rb:95:8:95:29 | SSA phi read(self) |
 | local_dataflow.rb:95:8:95:16 | [post] self | local_dataflow.rb:95:21:95:29 | self |
 | local_dataflow.rb:95:8:95:16 | call to source | local_dataflow.rb:95:8:95:29 | ... or ... |
 | local_dataflow.rb:95:8:95:16 | self | local_dataflow.rb:95:21:95:29 | self |
 | local_dataflow.rb:95:8:95:29 | ... or ... | local_dataflow.rb:95:7:95:30 | ( ... ) |
 | local_dataflow.rb:95:8:95:29 | SSA phi read(self) | local_dataflow.rb:96:3:96:9 | self |
+| local_dataflow.rb:95:21:95:29 | [input] SSA phi read(self) | local_dataflow.rb:95:8:95:29 | SSA phi read(self) |
 | local_dataflow.rb:95:21:95:29 | call to source | local_dataflow.rb:95:8:95:29 | ... or ... |
 | local_dataflow.rb:96:3:96:9 | [post] self | local_dataflow.rb:98:7:98:15 | self |
 | local_dataflow.rb:96:3:96:9 | self | local_dataflow.rb:98:7:98:15 | self |
 | local_dataflow.rb:98:3:98:3 | a | local_dataflow.rb:99:8:99:8 | a |
+| local_dataflow.rb:98:7:98:15 | [input] SSA phi read(self) | local_dataflow.rb:98:7:98:28 | SSA phi read(self) |
 | local_dataflow.rb:98:7:98:15 | [post] self | local_dataflow.rb:98:20:98:28 | self |
 | local_dataflow.rb:98:7:98:15 | self | local_dataflow.rb:98:20:98:28 | self |
 | local_dataflow.rb:98:7:98:28 | ... && ... | local_dataflow.rb:98:3:98:3 | a |
 | local_dataflow.rb:98:7:98:28 | ... && ... | local_dataflow.rb:98:3:98:28 | ... = ... |
 | local_dataflow.rb:98:7:98:28 | SSA phi read(self) | local_dataflow.rb:99:3:99:9 | self |
+| local_dataflow.rb:98:20:98:28 | [input] SSA phi read(self) | local_dataflow.rb:98:7:98:28 | SSA phi read(self) |
 | local_dataflow.rb:98:20:98:28 | call to source | local_dataflow.rb:98:7:98:28 | ... && ... |
 | local_dataflow.rb:99:3:99:9 | [post] self | local_dataflow.rb:100:8:100:16 | self |
 | local_dataflow.rb:99:3:99:9 | self | local_dataflow.rb:100:8:100:16 | self |
 | local_dataflow.rb:100:3:100:3 | b | local_dataflow.rb:101:8:101:8 | b |
 | local_dataflow.rb:100:7:100:31 | ( ... ) | local_dataflow.rb:100:3:100:3 | b |
 | local_dataflow.rb:100:7:100:31 | ( ... ) | local_dataflow.rb:100:3:100:31 | ... = ... |
+| local_dataflow.rb:100:8:100:16 | [input] SSA phi read(self) | local_dataflow.rb:100:8:100:30 | SSA phi read(self) |
 | local_dataflow.rb:100:8:100:16 | [post] self | local_dataflow.rb:100:22:100:30 | self |
 | local_dataflow.rb:100:8:100:16 | self | local_dataflow.rb:100:22:100:30 | self |
 | local_dataflow.rb:100:8:100:30 | ... and ... | local_dataflow.rb:100:7:100:31 | ( ... ) |
 | local_dataflow.rb:100:8:100:30 | SSA phi read(self) | local_dataflow.rb:101:3:101:9 | self |
+| local_dataflow.rb:100:22:100:30 | [input] SSA phi read(self) | local_dataflow.rb:100:8:100:30 | SSA phi read(self) |
 | local_dataflow.rb:100:22:100:30 | call to source | local_dataflow.rb:100:8:100:30 | ... and ... |
 | local_dataflow.rb:101:3:101:9 | [post] self | local_dataflow.rb:103:7:103:15 | self |
 | local_dataflow.rb:101:3:101:9 | self | local_dataflow.rb:103:7:103:15 | self |
@@ -3101,11 +3525,13 @@
 | local_dataflow.rb:103:7:103:15 | call to source | local_dataflow.rb:103:3:103:3 | a |
 | local_dataflow.rb:103:7:103:15 | call to source | local_dataflow.rb:103:3:103:15 | ... = ... |
 | local_dataflow.rb:103:7:103:15 | self | local_dataflow.rb:104:9:104:17 | self |
+| local_dataflow.rb:104:3:104:3 | [input] SSA phi read(self) | local_dataflow.rb:104:5:104:7 | SSA phi read(self) |
 | local_dataflow.rb:104:3:104:3 | a | local_dataflow.rb:104:5:104:7 | ... \|\| ... |
 | local_dataflow.rb:104:3:104:3 | a | local_dataflow.rb:105:8:105:8 | a |
 | local_dataflow.rb:104:5:104:7 | ... \|\| ... | local_dataflow.rb:104:3:104:3 | a |
 | local_dataflow.rb:104:5:104:7 | ... \|\| ... | local_dataflow.rb:104:3:104:17 | ... = ... |
 | local_dataflow.rb:104:5:104:7 | SSA phi read(self) | local_dataflow.rb:105:3:105:9 | self |
+| local_dataflow.rb:104:9:104:17 | [input] SSA phi read(self) | local_dataflow.rb:104:5:104:7 | SSA phi read(self) |
 | local_dataflow.rb:104:9:104:17 | call to source | local_dataflow.rb:104:5:104:7 | ... \|\| ... |
 | local_dataflow.rb:105:3:105:9 | [post] self | local_dataflow.rb:106:7:106:15 | self |
 | local_dataflow.rb:105:3:105:9 | self | local_dataflow.rb:106:7:106:15 | self |
@@ -3114,10 +3540,12 @@
 | local_dataflow.rb:106:7:106:15 | call to source | local_dataflow.rb:106:3:106:3 | b |
 | local_dataflow.rb:106:7:106:15 | call to source | local_dataflow.rb:106:3:106:15 | ... = ... |
 | local_dataflow.rb:106:7:106:15 | self | local_dataflow.rb:107:9:107:17 | self |
+| local_dataflow.rb:107:3:107:3 | [input] SSA phi read(self) | local_dataflow.rb:107:5:107:7 | SSA phi read(self) |
 | local_dataflow.rb:107:3:107:3 | b | local_dataflow.rb:108:8:108:8 | b |
 | local_dataflow.rb:107:5:107:7 | ... && ... | local_dataflow.rb:107:3:107:3 | b |
 | local_dataflow.rb:107:5:107:7 | ... && ... | local_dataflow.rb:107:3:107:17 | ... = ... |
 | local_dataflow.rb:107:5:107:7 | SSA phi read(self) | local_dataflow.rb:108:3:108:9 | self |
+| local_dataflow.rb:107:9:107:17 | [input] SSA phi read(self) | local_dataflow.rb:107:5:107:7 | SSA phi read(self) |
 | local_dataflow.rb:107:9:107:17 | call to source | local_dataflow.rb:107:5:107:7 | ... && ... |
 | local_dataflow.rb:111:1:114:3 | self (object_dup) | local_dataflow.rb:112:3:112:21 | self |
 | local_dataflow.rb:111:1:114:3 | self in object_dup | local_dataflow.rb:111:1:114:3 | self (object_dup) |
@@ -3172,6 +3600,8 @@
 | local_dataflow.rb:132:12:148:10 | then ... | local_dataflow.rb:132:3:149:5 | if ... |
 | local_dataflow.rb:133:5:139:7 | SSA phi read(self) | local_dataflow.rb:141:9:141:14 | self |
 | local_dataflow.rb:133:5:139:7 | SSA phi read(x) | local_dataflow.rb:141:13:141:13 | x |
+| local_dataflow.rb:133:8:133:13 | [input] SSA phi read(self) | local_dataflow.rb:133:8:133:23 | SSA phi read(self) |
+| local_dataflow.rb:133:8:133:13 | [input] SSA phi read(x) | local_dataflow.rb:133:8:133:23 | SSA phi read(x) |
 | local_dataflow.rb:133:8:133:13 | [post] self | local_dataflow.rb:133:18:133:23 | self |
 | local_dataflow.rb:133:8:133:13 | call to use | local_dataflow.rb:133:8:133:23 | [false] ... \|\| ... |
 | local_dataflow.rb:133:8:133:13 | call to use | local_dataflow.rb:133:8:133:23 | [true] ... \|\| ... |
@@ -3180,29 +3610,43 @@
 | local_dataflow.rb:133:8:133:23 | SSA phi read(x) | local_dataflow.rb:134:11:134:11 | x |
 | local_dataflow.rb:133:12:133:12 | [post] x | local_dataflow.rb:133:22:133:22 | x |
 | local_dataflow.rb:133:12:133:12 | x | local_dataflow.rb:133:22:133:22 | x |
+| local_dataflow.rb:133:18:133:23 | [input] SSA phi read(self) | local_dataflow.rb:133:8:133:23 | SSA phi read(self) |
+| local_dataflow.rb:133:18:133:23 | [input] SSA phi read(x) | local_dataflow.rb:133:8:133:23 | SSA phi read(x) |
 | local_dataflow.rb:133:18:133:23 | [post] self | local_dataflow.rb:136:7:136:12 | self |
 | local_dataflow.rb:133:18:133:23 | call to use | local_dataflow.rb:133:8:133:23 | [false] ... \|\| ... |
 | local_dataflow.rb:133:18:133:23 | call to use | local_dataflow.rb:133:8:133:23 | [true] ... \|\| ... |
 | local_dataflow.rb:133:18:133:23 | self | local_dataflow.rb:136:7:136:12 | self |
 | local_dataflow.rb:133:22:133:22 | [post] x | local_dataflow.rb:136:11:136:11 | x |
 | local_dataflow.rb:133:22:133:22 | x | local_dataflow.rb:136:11:136:11 | x |
+| local_dataflow.rb:133:24:134:12 | [input] SSA phi read(self) | local_dataflow.rb:133:5:139:7 | SSA phi read(self) |
+| local_dataflow.rb:133:24:134:12 | [input] SSA phi read(x) | local_dataflow.rb:133:5:139:7 | SSA phi read(x) |
 | local_dataflow.rb:133:24:134:12 | then ... | local_dataflow.rb:133:5:139:7 | if ... |
 | local_dataflow.rb:134:7:134:12 | call to use | local_dataflow.rb:133:24:134:12 | then ... |
+| local_dataflow.rb:135:5:138:9 | [input] SSA phi read(self) | local_dataflow.rb:133:5:139:7 | SSA phi read(self) |
+| local_dataflow.rb:135:5:138:9 | [input] SSA phi read(x) | local_dataflow.rb:133:5:139:7 | SSA phi read(x) |
 | local_dataflow.rb:135:5:138:9 | else ... | local_dataflow.rb:133:5:139:7 | if ... |
 | local_dataflow.rb:136:7:136:12 | [post] self | local_dataflow.rb:137:10:137:15 | self |
 | local_dataflow.rb:136:7:136:12 | self | local_dataflow.rb:137:10:137:15 | self |
 | local_dataflow.rb:136:11:136:11 | [post] x | local_dataflow.rb:137:14:137:14 | x |
 | local_dataflow.rb:136:11:136:11 | x | local_dataflow.rb:137:14:137:14 | x |
-| local_dataflow.rb:137:7:138:9 | SSA phi read(self) | local_dataflow.rb:133:5:139:7 | SSA phi read(self) |
-| local_dataflow.rb:137:7:138:9 | SSA phi read(x) | local_dataflow.rb:133:5:139:7 | SSA phi read(x) |
+| local_dataflow.rb:137:7:138:9 | SSA phi read(self) | local_dataflow.rb:135:5:138:9 | [input] SSA phi read(self) |
+| local_dataflow.rb:137:7:138:9 | SSA phi read(x) | local_dataflow.rb:135:5:138:9 | [input] SSA phi read(x) |
 | local_dataflow.rb:137:7:138:9 | if ... | local_dataflow.rb:135:5:138:9 | else ... |
+| local_dataflow.rb:137:10:137:15 | [input] SSA phi read(self) | local_dataflow.rb:137:10:137:26 | SSA phi read(self) |
+| local_dataflow.rb:137:10:137:15 | [input] SSA phi read(x) | local_dataflow.rb:137:10:137:26 | SSA phi read(x) |
 | local_dataflow.rb:137:10:137:15 | [post] self | local_dataflow.rb:137:21:137:26 | self |
 | local_dataflow.rb:137:10:137:15 | self | local_dataflow.rb:137:21:137:26 | self |
-| local_dataflow.rb:137:10:137:26 | SSA phi read(self) | local_dataflow.rb:137:7:138:9 | SSA phi read(self) |
-| local_dataflow.rb:137:10:137:26 | SSA phi read(x) | local_dataflow.rb:137:7:138:9 | SSA phi read(x) |
+| local_dataflow.rb:137:10:137:26 | SSA phi read(self) | local_dataflow.rb:137:10:137:26 | [input] SSA phi read(self) |
+| local_dataflow.rb:137:10:137:26 | SSA phi read(x) | local_dataflow.rb:137:10:137:26 | [input] SSA phi read(x) |
+| local_dataflow.rb:137:10:137:26 | [input] SSA phi read(self) | local_dataflow.rb:137:7:138:9 | SSA phi read(self) |
+| local_dataflow.rb:137:10:137:26 | [input] SSA phi read(self) | local_dataflow.rb:137:7:138:9 | SSA phi read(self) |
+| local_dataflow.rb:137:10:137:26 | [input] SSA phi read(x) | local_dataflow.rb:137:7:138:9 | SSA phi read(x) |
+| local_dataflow.rb:137:10:137:26 | [input] SSA phi read(x) | local_dataflow.rb:137:7:138:9 | SSA phi read(x) |
 | local_dataflow.rb:137:14:137:14 | [post] x | local_dataflow.rb:137:25:137:25 | x |
 | local_dataflow.rb:137:14:137:14 | x | local_dataflow.rb:137:25:137:25 | x |
 | local_dataflow.rb:137:20:137:26 | [false] ! ... | local_dataflow.rb:137:10:137:26 | [false] ... && ... |
+| local_dataflow.rb:137:20:137:26 | [input] SSA phi read(self) | local_dataflow.rb:137:10:137:26 | SSA phi read(self) |
+| local_dataflow.rb:137:20:137:26 | [input] SSA phi read(x) | local_dataflow.rb:137:10:137:26 | SSA phi read(x) |
 | local_dataflow.rb:137:20:137:26 | [true] ! ... | local_dataflow.rb:137:10:137:26 | [true] ... && ... |
 | local_dataflow.rb:137:21:137:26 | call to use | local_dataflow.rb:137:20:137:26 | [false] ! ... |
 | local_dataflow.rb:137:21:137:26 | call to use | local_dataflow.rb:137:20:137:26 | [true] ! ... |
@@ -3210,9 +3654,11 @@
 | local_dataflow.rb:141:5:145:7 | SSA phi read(x) | local_dataflow.rb:147:9:147:9 | x |
 | local_dataflow.rb:141:8:141:14 | [false] ! ... | local_dataflow.rb:141:8:141:37 | [false] ... \|\| ... |
 | local_dataflow.rb:141:8:141:14 | [false] ! ... | local_dataflow.rb:141:8:141:37 | [true] ... \|\| ... |
+| local_dataflow.rb:141:8:141:14 | [input] SSA phi read(self) | local_dataflow.rb:141:8:141:37 | SSA phi read(self) |
+| local_dataflow.rb:141:8:141:14 | [input] SSA phi read(x) | local_dataflow.rb:141:8:141:37 | SSA phi read(x) |
 | local_dataflow.rb:141:8:141:14 | [true] ! ... | local_dataflow.rb:141:8:141:37 | [true] ... \|\| ... |
-| local_dataflow.rb:141:8:141:37 | SSA phi read(self) | local_dataflow.rb:141:5:145:7 | SSA phi read(self) |
-| local_dataflow.rb:141:8:141:37 | SSA phi read(x) | local_dataflow.rb:141:5:145:7 | SSA phi read(x) |
+| local_dataflow.rb:141:8:141:37 | SSA phi read(self) | local_dataflow.rb:141:38:142:9 | [input] SSA phi read(self) |
+| local_dataflow.rb:141:8:141:37 | SSA phi read(x) | local_dataflow.rb:141:38:142:9 | [input] SSA phi read(x) |
 | local_dataflow.rb:141:9:141:14 | [post] self | local_dataflow.rb:141:20:141:25 | self |
 | local_dataflow.rb:141:9:141:14 | call to use | local_dataflow.rb:141:8:141:14 | [false] ! ... |
 | local_dataflow.rb:141:9:141:14 | call to use | local_dataflow.rb:141:8:141:14 | [true] ! ... |
@@ -3220,7 +3666,11 @@
 | local_dataflow.rb:141:13:141:13 | [post] x | local_dataflow.rb:141:24:141:24 | x |
 | local_dataflow.rb:141:13:141:13 | x | local_dataflow.rb:141:24:141:24 | x |
 | local_dataflow.rb:141:19:141:37 | [false] ( ... ) | local_dataflow.rb:141:8:141:37 | [false] ... \|\| ... |
+| local_dataflow.rb:141:19:141:37 | [input] SSA phi read(self) | local_dataflow.rb:141:8:141:37 | SSA phi read(self) |
+| local_dataflow.rb:141:19:141:37 | [input] SSA phi read(x) | local_dataflow.rb:141:8:141:37 | SSA phi read(x) |
 | local_dataflow.rb:141:19:141:37 | [true] ( ... ) | local_dataflow.rb:141:8:141:37 | [true] ... \|\| ... |
+| local_dataflow.rb:141:20:141:25 | [input] SSA phi read(self) | local_dataflow.rb:141:20:141:36 | SSA phi read(self) |
+| local_dataflow.rb:141:20:141:25 | [input] SSA phi read(x) | local_dataflow.rb:141:20:141:36 | SSA phi read(x) |
 | local_dataflow.rb:141:20:141:25 | [post] self | local_dataflow.rb:141:31:141:36 | self |
 | local_dataflow.rb:141:20:141:25 | self | local_dataflow.rb:141:31:141:36 | self |
 | local_dataflow.rb:141:20:141:36 | SSA phi read(self) | local_dataflow.rb:143:11:143:16 | self |
@@ -3230,24 +3680,38 @@
 | local_dataflow.rb:141:24:141:24 | [post] x | local_dataflow.rb:141:35:141:35 | x |
 | local_dataflow.rb:141:24:141:24 | x | local_dataflow.rb:141:35:141:35 | x |
 | local_dataflow.rb:141:30:141:36 | [false] ! ... | local_dataflow.rb:141:20:141:36 | [false] ... && ... |
+| local_dataflow.rb:141:30:141:36 | [input] SSA phi read(self) | local_dataflow.rb:141:20:141:36 | SSA phi read(self) |
+| local_dataflow.rb:141:30:141:36 | [input] SSA phi read(x) | local_dataflow.rb:141:20:141:36 | SSA phi read(x) |
 | local_dataflow.rb:141:30:141:36 | [true] ! ... | local_dataflow.rb:141:20:141:36 | [true] ... && ... |
 | local_dataflow.rb:141:31:141:36 | call to use | local_dataflow.rb:141:30:141:36 | [false] ! ... |
 | local_dataflow.rb:141:31:141:36 | call to use | local_dataflow.rb:141:30:141:36 | [true] ! ... |
+| local_dataflow.rb:141:38:142:9 | [input] SSA phi read(self) | local_dataflow.rb:141:5:145:7 | SSA phi read(self) |
+| local_dataflow.rb:141:38:142:9 | [input] SSA phi read(x) | local_dataflow.rb:141:5:145:7 | SSA phi read(x) |
 | local_dataflow.rb:141:38:142:9 | then ... | local_dataflow.rb:141:5:145:7 | if ... |
 | local_dataflow.rb:142:7:142:9 | nil | local_dataflow.rb:141:38:142:9 | then ... |
-| local_dataflow.rb:143:5:144:16 | SSA phi read(self) | local_dataflow.rb:141:5:145:7 | SSA phi read(self) |
-| local_dataflow.rb:143:5:144:16 | SSA phi read(x) | local_dataflow.rb:141:5:145:7 | SSA phi read(x) |
+| local_dataflow.rb:143:5:144:16 | SSA phi read(self) | local_dataflow.rb:143:5:144:16 | [input] SSA phi read(self) |
+| local_dataflow.rb:143:5:144:16 | SSA phi read(x) | local_dataflow.rb:143:5:144:16 | [input] SSA phi read(x) |
+| local_dataflow.rb:143:5:144:16 | [input] SSA phi read(self) | local_dataflow.rb:141:5:145:7 | SSA phi read(self) |
+| local_dataflow.rb:143:5:144:16 | [input] SSA phi read(x) | local_dataflow.rb:141:5:145:7 | SSA phi read(x) |
 | local_dataflow.rb:143:5:144:16 | elsif ... | local_dataflow.rb:141:5:145:7 | if ... |
+| local_dataflow.rb:143:11:143:16 | [input] SSA phi read(self) | local_dataflow.rb:143:11:143:26 | SSA phi read(self) |
+| local_dataflow.rb:143:11:143:16 | [input] SSA phi read(x) | local_dataflow.rb:143:11:143:26 | SSA phi read(x) |
 | local_dataflow.rb:143:11:143:16 | [post] self | local_dataflow.rb:143:21:143:26 | self |
 | local_dataflow.rb:143:11:143:16 | call to use | local_dataflow.rb:143:11:143:26 | [false] ... \|\| ... |
 | local_dataflow.rb:143:11:143:16 | call to use | local_dataflow.rb:143:11:143:26 | [true] ... \|\| ... |
 | local_dataflow.rb:143:11:143:16 | self | local_dataflow.rb:143:21:143:26 | self |
 | local_dataflow.rb:143:11:143:26 | SSA phi read(self) | local_dataflow.rb:144:11:144:16 | self |
 | local_dataflow.rb:143:11:143:26 | SSA phi read(x) | local_dataflow.rb:144:15:144:15 | x |
+| local_dataflow.rb:143:11:143:26 | [input] SSA phi read(self) | local_dataflow.rb:143:5:144:16 | SSA phi read(self) |
+| local_dataflow.rb:143:11:143:26 | [input] SSA phi read(x) | local_dataflow.rb:143:5:144:16 | SSA phi read(x) |
 | local_dataflow.rb:143:15:143:15 | [post] x | local_dataflow.rb:143:25:143:25 | x |
 | local_dataflow.rb:143:15:143:15 | x | local_dataflow.rb:143:25:143:25 | x |
+| local_dataflow.rb:143:21:143:26 | [input] SSA phi read(self) | local_dataflow.rb:143:11:143:26 | SSA phi read(self) |
+| local_dataflow.rb:143:21:143:26 | [input] SSA phi read(x) | local_dataflow.rb:143:11:143:26 | SSA phi read(x) |
 | local_dataflow.rb:143:21:143:26 | call to use | local_dataflow.rb:143:11:143:26 | [false] ... \|\| ... |
 | local_dataflow.rb:143:21:143:26 | call to use | local_dataflow.rb:143:11:143:26 | [true] ... \|\| ... |
+| local_dataflow.rb:143:27:144:16 | [input] SSA phi read(self) | local_dataflow.rb:143:5:144:16 | SSA phi read(self) |
+| local_dataflow.rb:143:27:144:16 | [input] SSA phi read(x) | local_dataflow.rb:143:5:144:16 | SSA phi read(x) |
 | local_dataflow.rb:143:27:144:16 | then ... | local_dataflow.rb:143:5:144:16 | elsif ... |
 | local_dataflow.rb:144:11:144:16 | call to use | local_dataflow.rb:143:27:144:16 | then ... |
 | local_dataflow.rb:147:5:147:10 | [post] self | local_dataflow.rb:148:5:148:10 | self |


### PR DESCRIPTION
Barrier guards are implemented using SSA; a node is guarded if it is a read of an SSA definition `def`, where `def` is also read in a controlling condition:

```rb
x = taint
if safe(x) then
    sink(x) # guarded
end
```

However, this approach does not work when a condition controls not a read, but instead input into a phi node:

```rb
x = taint # 1
if not safe(x) then
    x = safe # 2
end
# phi
sink(x)
```

In the above, the input into `phi` from `x = taint` (1) is controlled by the `true` edge out of `safe(x)`, but the read of `x` in `sink(x)` is not.

In order to handle this scenario (under-the-hood) with barrier guards, we add a new type of (hidden) data flow nodes that represent input into `phi` nodes, and then split the data flow step `x -> phi` into two steps `x -> [input 1] phi` and `[input 1] phi -> phi`, where `[input 1] phi` represents the input into `phi` from the basic block starting at `x = taint`. The barrier guard logic will then make sure to include `[input 1] phi` as a barrier node (but neither `phi` nor `[input 2] phi`).

A similar scenario can happen for [phi reads](https://github.com/github/codeql/pull/10035):

```rb
x = taint
if b then
    if not safe(x) then # 1
        return
    end
else
    if not safe(x) then # 2
        return
    end
end
#phi_read
sink(x)
```

In the above, `phi_read` (and `sink(x)`) is not controlled by a `safe(x)` condition. However, both inputs into `phi_read` are, so the solution is to treat phi reads exactly as normal phi nodes.