### PR TITLE
Ruby: Add query for insecure mass assignment

### DIFF
--- a/ruby/ql/lib/codeql/ruby/frameworks/ActiveRecord.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActiveRecord.qll
@@ -797,30 +797,30 @@ class ActiveRecordScopeCallTarget extends AdditionalCallTarget {
 private module MassAssignmentSinks {
   private import codeql.ruby.security.MassAssignmentCustomizations
 
+  pragma[nomagic]
+  private predicate massAssignmentCall(DataFlow::CallNode call, string name) {
+    call = activeRecordBaseClass().getAMethodCall(name)
+    or
+    call instanceof ActiveRecordInstanceMethodCall and
+    call.getMethodName() = name
+  }
+
   /** A call to a method that sets attributes of an database record using a hash. */
   private class MassAssignmentCall extends MassAssignment::Sink {
     MassAssignmentCall() {
-      exists(DataFlow::CallNode call, string name |
-        (
-          call = activeRecordBaseClass().getAMethodCall(name)
-          or
-          call instanceof ActiveRecordInstanceMethodCall and
-          call.getMethodName() = name
-        ) and
-        (
-          name =
-            [
-              "build", "create", "create!", "create_with", "create_or_find_by",
-              "create_or_find_by!", "find_or_create_by", "find_or_create_by!",
-              "find_or_initialize_by", "insert", "insert!", "insert_all", "insert_all!",
-              "instantiate", "new", "update", "update!", "upsert", "upsert_all"
-            ] and
-          this = call.getArgument(0)
-          or
-          // These methods have an optional first id parameter.
-          name = ["update", "update!"] and
-          this = call.getArgument(1)
-        )
+      exists(DataFlow::CallNode call, string name | massAssignmentCall(call, name) |
+        name =
+          [
+            "build", "create", "create!", "create_with", "create_or_find_by", "create_or_find_by!",
+            "find_or_create_by", "find_or_create_by!", "find_or_initialize_by", "insert", "insert!",
+            "insert_all", "insert_all!", "instantiate", "new", "update", "update!", "upsert",
+            "upsert_all"
+          ] and
+        this = call.getArgument(0)
+        or
+        // These methods have an optional first id parameter.
+        name = ["update", "update!"] and
+        this = call.getArgument(1)
       )
     }
   }

--- a/ruby/ql/lib/codeql/ruby/frameworks/ActiveRecord.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActiveRecord.qll
@@ -806,8 +806,8 @@ private module MassAssignmentSinks {
   }
 
   /** A call to a method that sets attributes of an database record using a hash. */
-  private class MassAssignmentCall extends MassAssignment::Sink {
-    MassAssignmentCall() {
+  private class MassAssignmentSink extends MassAssignment::Sink {
+    MassAssignmentSink() {
       exists(DataFlow::CallNode call, string name | massAssignmentCall(call, name) |
         name =
           [

--- a/ruby/ql/lib/codeql/ruby/frameworks/ActiveRecord.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActiveRecord.qll
@@ -792,3 +792,36 @@ class ActiveRecordScopeCallTarget extends AdditionalCallTarget {
     )
   }
 }
+
+/** Sinks for the mass assignment query */
+private module MassAssignmentSinks {
+  private import codeql.ruby.security.MassAssignmentCustomizations
+
+  /** A call to a method that sets attributes of an database record using a hash. */
+  private class MassAssignmentCall extends MassAssignment::Sink {
+    MassAssignmentCall() {
+      exists(DataFlow::CallNode call, string name |
+        (
+          call = activeRecordBaseClass().getAMethodCall(name)
+          or
+          call instanceof ActiveRecordInstanceMethodCall and
+          call.getMethodName() = name
+        ) and
+        (
+          name =
+            [
+              "build", "create", "create!", "create_with", "create_or_find_by",
+              "create_or_find_by!", "find_or_create_by", "find_or_create_by!", "insert", "insert!",
+              "insert_all", "insert_all!", "instantiate", "new", "update", "update!", "upsert",
+              "upsert_all"
+            ] and
+          this = call.getArgument(0)
+          or
+          // These methods have an optional first id parameter.
+          name = ["update", "update!"] and
+          this = call.getArgument(1)
+        )
+      )
+    }
+  }
+}

--- a/ruby/ql/lib/codeql/ruby/frameworks/ActiveRecord.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActiveRecord.qll
@@ -793,7 +793,7 @@ class ActiveRecordScopeCallTarget extends AdditionalCallTarget {
   }
 }
 
-/** Sinks for the mass assignment query */
+/** Sinks for the mass assignment query. */
 private module MassAssignmentSinks {
   private import codeql.ruby.security.MassAssignmentCustomizations
 

--- a/ruby/ql/lib/codeql/ruby/frameworks/ActiveRecord.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActiveRecord.qll
@@ -811,9 +811,9 @@ private module MassAssignmentSinks {
           name =
             [
               "build", "create", "create!", "create_with", "create_or_find_by",
-              "create_or_find_by!", "find_or_create_by", "find_or_create_by!", "insert", "insert!",
-              "insert_all", "insert_all!", "instantiate", "new", "update", "update!", "upsert",
-              "upsert_all"
+              "create_or_find_by!", "find_or_create_by", "find_or_create_by!",
+              "find_or_initialize_by", "insert", "insert!", "insert_all", "insert_all!",
+              "instantiate", "new", "update", "update!", "upsert", "upsert_all"
             ] and
           this = call.getArgument(0)
           or

--- a/ruby/ql/lib/codeql/ruby/security/MassAssignmentCustomizations.qll
+++ b/ruby/ql/lib/codeql/ruby/security/MassAssignmentCustomizations.qll
@@ -57,7 +57,7 @@ module MassAssignment {
   /** Holds if `h` is an empty hash or contains an empty hash at one if its (possibly nested) values. */
   private predicate hasEmptyHash(Expr e) {
     e instanceof HashLiteral and
-    count(e.(HashLiteral).getAKeyValuePair()) = 0
+    not exists(e.(HashLiteral).getAKeyValuePair())
     or
     hasEmptyHash(e.(HashLiteral).getAKeyValuePair().getValue())
     or

--- a/ruby/ql/lib/codeql/ruby/security/MassAssignmentCustomizations.qll
+++ b/ruby/ql/lib/codeql/ruby/security/MassAssignmentCustomizations.qll
@@ -32,7 +32,7 @@ module MassAssignment {
    * A call that permits arbitrary parameters to be used for mass assignment.
    */
   abstract class MassPermit extends DataFlow::Node {
-    /** Gets the argument for the parameters to be permitted */
+    /** Gets the argument for the parameters to be permitted. */
     abstract DataFlow::Node getParamsArgument();
 
     /** Gets the result node of the permitted parameters. */

--- a/ruby/ql/lib/codeql/ruby/security/MassAssignmentCustomizations.qll
+++ b/ruby/ql/lib/codeql/ruby/security/MassAssignmentCustomizations.qll
@@ -1,0 +1,55 @@
+/**
+ * Provides default sources, sinks, sanitizers, and flow steps for
+ * detecting insecure mass assignment, as well as extension points for adding your own.
+ */
+
+private import codeql.ruby.AST
+private import codeql.ruby.DataFlow
+private import codeql.ruby.TaintTracking
+private import codeql.ruby.dataflow.RemoteFlowSources
+
+/**
+ * Provides default sources, sinks, sanitizers, and flow steps for
+ * detecting insecure mass assignment, as well as extension points for adding your own.
+ */
+module MassAssignment {
+  /**
+   * A data flow source for user input used for mass assignment.
+   */
+  abstract class Source extends DataFlow::Node { }
+
+  /**
+   * A data flow sink for user input used for mass assignment.
+   */
+  abstract class Sink extends DataFlow::Node { }
+
+  /**
+   * A sanitizer for insecure mass assignment.
+   */
+  abstract class Sanitizer extends DataFlow::Node { }
+
+  /**
+   * A call that permits arbitrary parameters to be used for mass assignment.
+   */
+  abstract class MassPermit extends DataFlow::Node {
+    /** Gets the argument for the parameters to be permitted */
+    abstract DataFlow::Node getParamsArgument();
+
+    /** Gets the result node of the permitted parameters. */
+    abstract DataFlow::Node getPermittedParamsResult();
+  }
+
+  private class RemoteSource extends Source instanceof RemoteFlowSource { }
+
+  private class PermitBangCall extends MassPermit instanceof DataFlow::CallNode {
+    PermitBangCall() { this.asExpr().getExpr().(MethodCall).getMethodName() = "permit!" }
+
+    override DataFlow::Node getParamsArgument() { result = this.(DataFlow::CallNode).getReceiver() }
+
+    override DataFlow::Node getPermittedParamsResult() {
+      result = this
+      or
+      result.(DataFlow::PostUpdateNode).getPreUpdateNode() = this.getParamsArgument()
+    }
+  }
+}

--- a/ruby/ql/lib/codeql/ruby/security/MassAssignmentQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/MassAssignmentQuery.qll
@@ -43,10 +43,9 @@ private module Config implements DataFlow::StateConfigSig {
     state instanceof FlowState::Permitted
   }
 
-  predicate isBarrierIn(DataFlow::Node node, FlowState state) {
-    node instanceof MassAssignment::Source and
-    state instanceof FlowState::Unpermitted
-  }
+  predicate isBarrierIn(DataFlow::Node node, FlowState state) { isSource(node, state) }
+
+  predicate isBarrierOut(DataFlow::Node node, FlowState state) { isSink(node, state) }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof MassAssignment::Sanitizer }
 

--- a/ruby/ql/lib/codeql/ruby/security/MassAssignmentQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/MassAssignmentQuery.qll
@@ -1,0 +1,104 @@
+/**
+ * Provides a taint tracking configuration for reasoning about insecure mass assignment.
+ */
+
+private import codeql.ruby.AST
+private import codeql.ruby.DataFlow
+private import codeql.ruby.TaintTracking
+private import codeql.ruby.dataflow.RemoteFlowSources
+
+/** Provides default sources and sinks for the mass assignment query. */
+module MassAssignment {
+  /**
+   * A data flow source for user input used for mass assignment.
+   */
+  abstract class Source extends DataFlow::Node { }
+
+  /**
+   * A data flow sink for user input used for mass assignment.
+   */
+  abstract class Sink extends DataFlow::Node { }
+
+  /**
+   * A call that permits arbitrary parameters to be used for mass assignment.
+   */
+  abstract class MassPermit extends DataFlow::Node {
+    /** Gets the argument for the parameters to be permitted */
+    abstract DataFlow::Node getParamsArgument();
+
+    /** Gets the result node of the permitted parameters. */
+    abstract DataFlow::Node getPermittedParamsResult();
+  }
+
+  private class RemoteSource extends Source instanceof RemoteFlowSource { }
+
+  private class CreateSink extends Sink {
+    CreateSink() {
+      exists(DataFlow::CallNode create |
+        create.asExpr().getExpr().(MethodCall).getMethodName() = ["create", "new", "update"] and
+        this = create.getArgument(0)
+      )
+    }
+  }
+
+  private class PermitCall extends MassPermit instanceof DataFlow::CallNode {
+    PermitCall() { this.asExpr().getExpr().(MethodCall).getMethodName() = "permit!" }
+
+    override DataFlow::Node getParamsArgument() { result = this.(DataFlow::CallNode).getReceiver() }
+
+    override DataFlow::Node getPermittedParamsResult() { result = this }
+  }
+}
+
+private module FlowState {
+  private newtype TState =
+    TUnpermitted() or
+    TPermitted()
+
+  /** A flow state used to distinguish whether arbitrary user parameters have been permitted to be used for mass assignment. */
+  class State extends TState {
+    string toString() {
+      this = TUnpermitted() and result = "unpermitted"
+      or
+      this = TPermitted() and result = "permitted"
+    }
+  }
+
+  /** A flow state used for user parameters for which arbitrary parameters have not been permitted to use for mass assignment. */
+  class Unpermitted extends State, TUnpermitted { }
+
+  /** A flow state used for user parameters for which arbitrary parameters have been permitted to use for mass assignment. */
+  class Permitted extends State, TPermitted { }
+}
+
+/** A flow configuration for reasoning about insecure mass assignment. */
+private module Config implements DataFlow::StateConfigSig {
+  class FlowState = FlowState::State;
+
+  predicate isSource(DataFlow::Node node, FlowState state) {
+    node instanceof MassAssignment::Source and
+    state instanceof FlowState::Unpermitted
+    // or
+    // node = any(MassAssignment::MassPermit p).getPermittedParamsResult() and
+    // state instanceof FlowState::Permitted
+  }
+
+  predicate isSink(DataFlow::Node node, FlowState state) {
+    node instanceof MassAssignment::Sink and
+    state instanceof FlowState::Permitted
+  }
+
+  predicate isAdditionalFlowStep(
+    DataFlow::Node node1, FlowState state1, DataFlow::Node node2, FlowState state2
+  ) {
+    exists(MassAssignment::MassPermit permit |
+      node1 = permit.getParamsArgument() and
+      state1 instanceof FlowState::Unpermitted and
+      node2 = permit.getPermittedParamsResult() and
+      state2 instanceof FlowState::Permitted
+    )
+  }
+}
+
+/** Taint tracking for reasoning about user input used for mass assignment. */
+module MassAssignmentFlow = TaintTracking::GlobalWithState<Config>;

--- a/ruby/ql/lib/codeql/ruby/security/MassAssignmentQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/MassAssignmentQuery.qll
@@ -43,6 +43,11 @@ private module Config implements DataFlow::StateConfigSig {
     state instanceof FlowState::Permitted
   }
 
+  predicate isBarrierIn(DataFlow::Node node, FlowState state) {
+    node instanceof MassAssignment::Source and
+    state instanceof FlowState::Unpermitted
+  }
+
   predicate isBarrier(DataFlow::Node node) { node instanceof MassAssignment::Sanitizer }
 
   predicate isAdditionalFlowStep(

--- a/ruby/ql/src/change-notes/2024-03-22-mass-assignment.md
+++ b/ruby/ql/src/change-notes/2024-03-22-mass-assignment.md
@@ -1,0 +1,4 @@
+---
+category: newQuery
+---
+* Added a new query, `ruby/insecure-mass-assignment`, for finding instances of mass assignment operations accepting arbitrary parameters from remote user input.

--- a/ruby/ql/src/change-notes/2024-03-22-mass-assignment.md
+++ b/ruby/ql/src/change-notes/2024-03-22-mass-assignment.md
@@ -1,4 +1,4 @@
 ---
 category: newQuery
 ---
-* Added a new query, `ruby/insecure-mass-assignment`, for finding instances of mass assignment operations accepting arbitrary parameters from remote user input.
+* Added a new query, `rb/insecure-mass-assignment`, for finding instances of mass assignment operations accepting arbitrary parameters from remote user input.

--- a/ruby/ql/src/queries/security/cwe-915/MassAssignment.qhelp
+++ b/ruby/ql/src/queries/security/cwe-915/MassAssignment.qhelp
@@ -1,0 +1,34 @@
+<!DOCTYPE qhelp PUBLIC
+"-//Semmle//qhelp//EN"
+"qhelp.dtd">
+<qhelp>
+	<overview>
+		<p>
+			Operations that allow for mass assignment (setting multiple attributes of an object using a hash), such as <code>ActiveRecord::Base.new</code>, should take care not to 
+            allow arbitrary parameters to be set by the user. Otherwise, unintended attributes may be set, such as an <code>isAdmin</code> feild for a <code>User</code> object.
+		</p>
+	</overview>
+	<recommendation>
+		<p>
+			When using a mass assignment operation from user supplied parameters, use <code>ActionController::Parameters#permit</code> to restrict the possible parameters
+            a user can supply, rather than <code>ActionController::Parameters#permit!</code>, which permits arbitrary parameters to be used for mass assignment.
+		</p>
+	</recommendation>
+	<example>
+		<p>
+			 In the following example, <code>permit!</code> is used which allows arbitrary parameters to be supplied by the user.
+		</p>
+		<sample src="examples/MassAssignmentBad.rb" />
+		<p>
+			
+		</p>
+		<p>
+            In the following example, only specific parameters are permitted, so the mass assignment is safe.
+		</p>
+		<sample src="examples/MassAssignmentGood.rb" />
+	</example>
+
+	<references>
+		
+	</references>
+</qhelp>

--- a/ruby/ql/src/queries/security/cwe-915/MassAssignment.qhelp
+++ b/ruby/ql/src/queries/security/cwe-915/MassAssignment.qhelp
@@ -5,7 +5,7 @@
 	<overview>
 		<p>
 			Operations that allow for mass assignment (setting multiple attributes of an object using a hash), such as <code>ActiveRecord::Base.new</code>, should take care not to 
-            allow arbitrary parameters to be set by the user. Otherwise, unintended attributes may be set, such as an <code>isAdmin</code> feild for a <code>User</code> object.
+            allow arbitrary parameters to be set by the user. Otherwise, unintended attributes may be set, such as an <code>is_admin</code> field for a <code>User</code> object.
 		</p>
 	</overview>
 	<recommendation>
@@ -29,6 +29,6 @@
 	</example>
 
 	<references>
-		
+		<li>Rails guides: <a href="https://guides.rubyonrails.org/action_controller_overview.html#strong-parameters">Strong Parameters</a>.</li>
 	</references>
 </qhelp>

--- a/ruby/ql/src/queries/security/cwe-915/MassAssignment.ql
+++ b/ruby/ql/src/queries/security/cwe-915/MassAssignment.ql
@@ -1,6 +1,6 @@
 /**
  * @name Insecure Mass Assignment
- * @description Using mass assignment with user-controlled keys allows unintended parameters to be set.
+ * @description Using mass assignment with user-controlled attributes allows unintended parameters to be set.
  * @kind path-problem
  * @problem.severity error
  * @security-severity 7.5
@@ -15,4 +15,6 @@ import MassAssignmentFlow::PathGraph
 
 from MassAssignmentFlow::PathNode source, MassAssignmentFlow::PathNode sink
 where MassAssignmentFlow::flowPath(source, sink)
-select sink.getNode(), source, sink, "mass assignment"
+select sink.getNode(), source, sink,
+  "This mass assignment operation can assign user-controlled attributes from $@.", source.getNode(),
+  "this remote flow source"

--- a/ruby/ql/src/queries/security/cwe-915/MassAssignment.ql
+++ b/ruby/ql/src/queries/security/cwe-915/MassAssignment.ql
@@ -3,7 +3,7 @@
  * @description Using mass assignment with user-controlled attributes allows unintended parameters to be set.
  * @kind path-problem
  * @problem.severity error
- * @security-severity 7.5
+ * @security-severity 9.8
  * @precision high
  * @id ruby/insecure-mass-assignment
  * @tags security

--- a/ruby/ql/src/queries/security/cwe-915/MassAssignment.ql
+++ b/ruby/ql/src/queries/security/cwe-915/MassAssignment.ql
@@ -5,7 +5,7 @@
  * @problem.severity error
  * @security-severity 9.8
  * @precision high
- * @id ruby/insecure-mass-assignment
+ * @id rb/insecure-mass-assignment
  * @tags security
  *       external/cwe/cwe-915
  */

--- a/ruby/ql/src/queries/security/cwe-915/MassAssignment.ql
+++ b/ruby/ql/src/queries/security/cwe-915/MassAssignment.ql
@@ -1,0 +1,18 @@
+/**
+ * @name Insecure Mass Assignment
+ * @description Using mass assignment with user-controlled keys allows unintended parameters to be set.
+ * @kind path-problem
+ * @problem.severity error
+ * @security-severity 7.5
+ * @precision high
+ * @id ruby/insecure-mass-assignment
+ * @tags security
+ *       external/cwe/cwe-915
+ */
+
+import codeql.ruby.security.MassAssignmentQuery
+import MassAssignmentFlow::PathGraph
+
+from MassAssignmentFlow::PathNode source, MassAssignmentFlow::PathNode sink
+where MassAssignmentFlow::flowPath(source, sink)
+select sink.getNode(), source, sink, "mass assignment"

--- a/ruby/ql/src/queries/security/cwe-915/examples/MassAssignmentBad.rb
+++ b/ruby/ql/src/queries/security/cwe-915/examples/MassAssignmentBad.rb
@@ -1,0 +1,10 @@
+class UserController < ActionController::Base
+    def create
+        # BAD: arbitrary params are permitted to be used for this assignment
+        User.new(user_params).save!
+    end
+
+    def user_params
+        params.require(:user).permit!
+    end
+end

--- a/ruby/ql/src/queries/security/cwe-915/examples/MassAssignmentGood.rb
+++ b/ruby/ql/src/queries/security/cwe-915/examples/MassAssignmentGood.rb
@@ -1,0 +1,10 @@
+class UserController < ActionController::Base
+    def create
+        # GOOD: the permitted parameters are explicitly specified
+        User.new(user_params).save!
+    end
+
+    def user_params
+        params.require(:user).permit(:name, :email)
+    end
+end

--- a/ruby/ql/test/query-tests/security/cwe-915/MassAssignment.expected
+++ b/ruby/ql/test/query-tests/security/cwe-915/MassAssignment.expected
@@ -1,0 +1,12 @@
+edges
+| test.rb:17:9:17:14 | call to params | test.rb:17:9:17:29 | call to require | provenance |  |
+| test.rb:17:9:17:29 | call to require | test.rb:17:9:17:37 | call to permit! | provenance |  |
+| test.rb:17:9:17:37 | call to permit! | test.rb:8:18:8:28 | call to user_params | provenance |  |
+nodes
+| test.rb:8:18:8:28 | call to user_params | semmle.label | call to user_params |
+| test.rb:17:9:17:14 | call to params | semmle.label | call to params |
+| test.rb:17:9:17:29 | call to require | semmle.label | call to require |
+| test.rb:17:9:17:37 | call to permit! | semmle.label | call to permit! |
+subpaths
+#select
+| test.rb:8:18:8:28 | call to user_params | test.rb:17:9:17:14 | call to params | test.rb:8:18:8:28 | call to user_params | mass assignment |

--- a/ruby/ql/test/query-tests/security/cwe-915/MassAssignment.expected
+++ b/ruby/ql/test/query-tests/security/cwe-915/MassAssignment.expected
@@ -9,4 +9,4 @@ nodes
 | test.rb:17:9:17:37 | call to permit! | semmle.label | call to permit! |
 subpaths
 #select
-| test.rb:8:18:8:28 | call to user_params | test.rb:17:9:17:14 | call to params | test.rb:8:18:8:28 | call to user_params | mass assignment |
+| test.rb:8:18:8:28 | call to user_params | test.rb:17:9:17:14 | call to params | test.rb:8:18:8:28 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:17:9:17:14 | call to params | this remote flow source |

--- a/ruby/ql/test/query-tests/security/cwe-915/MassAssignment.expected
+++ b/ruby/ql/test/query-tests/security/cwe-915/MassAssignment.expected
@@ -1,10 +1,4 @@
 edges
-| test.rb:23:25:23:37 | call to [] [element 0] | test.rb:23:25:23:37 | call to [] | provenance |  |
-| test.rb:23:26:23:36 | call to user_params | test.rb:23:25:23:37 | call to [] [element 0] | provenance |  |
-| test.rb:24:26:24:38 | call to [] [element 0] | test.rb:24:26:24:38 | call to [] | provenance |  |
-| test.rb:24:27:24:37 | call to user_params | test.rb:24:26:24:38 | call to [] [element 0] | provenance |  |
-| test.rb:30:21:30:33 | call to [] [element 0] | test.rb:30:21:30:33 | call to [] | provenance |  |
-| test.rb:30:22:30:32 | call to user_params | test.rb:30:21:30:33 | call to [] [element 0] | provenance |  |
 | test.rb:43:9:43:14 | call to params | test.rb:43:9:43:29 | call to require | provenance |  |
 | test.rb:43:9:43:29 | call to require | test.rb:43:9:43:37 | call to permit! | provenance |  |
 | test.rb:43:9:43:37 | call to permit! | test.rb:8:18:8:28 | call to user_params | provenance |  |
@@ -13,20 +7,25 @@ edges
 | test.rb:43:9:43:37 | call to permit! | test.rb:20:22:20:32 | call to user_params | provenance |  |
 | test.rb:43:9:43:37 | call to permit! | test.rb:21:21:21:31 | call to user_params | provenance |  |
 | test.rb:43:9:43:37 | call to permit! | test.rb:22:22:22:32 | call to user_params | provenance |  |
-| test.rb:43:9:43:37 | call to permit! | test.rb:23:26:23:36 | call to user_params | provenance |  |
-| test.rb:43:9:43:37 | call to permit! | test.rb:24:27:24:37 | call to user_params | provenance |  |
 | test.rb:43:9:43:37 | call to permit! | test.rb:25:21:25:31 | call to user_params | provenance |  |
 | test.rb:43:9:43:37 | call to permit! | test.rb:26:24:26:34 | call to user_params | provenance |  |
 | test.rb:43:9:43:37 | call to permit! | test.rb:27:22:27:32 | call to user_params | provenance |  |
 | test.rb:43:9:43:37 | call to permit! | test.rb:28:25:28:35 | call to user_params | provenance |  |
 | test.rb:43:9:43:37 | call to permit! | test.rb:29:21:29:31 | call to user_params | provenance |  |
-| test.rb:43:9:43:37 | call to permit! | test.rb:30:22:30:32 | call to user_params | provenance |  |
 | test.rb:43:9:43:37 | call to permit! | test.rb:31:32:31:42 | call to user_params | provenance |  |
 | test.rb:43:9:43:37 | call to permit! | test.rb:32:33:32:43 | call to user_params | provenance |  |
 | test.rb:43:9:43:37 | call to permit! | test.rb:33:36:33:46 | call to user_params | provenance |  |
 | test.rb:43:9:43:37 | call to permit! | test.rb:34:32:34:42 | call to user_params | provenance |  |
 | test.rb:43:9:43:37 | call to permit! | test.rb:35:33:35:43 | call to user_params | provenance |  |
 | test.rb:43:9:43:37 | call to permit! | test.rb:36:26:36:36 | call to user_params | provenance |  |
+| test.rb:47:9:47:9 | x | test.rb:48:9:48:9 | x | provenance |  |
+| test.rb:47:13:47:18 | call to params | test.rb:47:13:47:25 | ...[...] | provenance |  |
+| test.rb:47:13:47:25 | ...[...] | test.rb:47:9:47:9 | x | provenance |  |
+| test.rb:48:9:48:9 | [post] x | test.rb:49:18:49:18 | x | provenance |  |
+| test.rb:48:9:48:9 | x | test.rb:48:9:48:9 | [post] x | provenance |  |
+| test.rb:51:18:51:23 | call to params | test.rb:51:18:51:40 | call to permit | provenance |  |
+| test.rb:52:18:52:23 | call to params | test.rb:52:18:52:69 | call to permit | provenance |  |
+| test.rb:53:18:53:23 | call to params | test.rb:53:18:53:35 | call to to_unsafe_h | provenance |  |
 nodes
 | test.rb:8:18:8:28 | call to user_params | semmle.label | call to user_params |
 | test.rb:18:20:18:30 | call to user_params | semmle.label | call to user_params |
@@ -34,20 +33,11 @@ nodes
 | test.rb:20:22:20:32 | call to user_params | semmle.label | call to user_params |
 | test.rb:21:21:21:31 | call to user_params | semmle.label | call to user_params |
 | test.rb:22:22:22:32 | call to user_params | semmle.label | call to user_params |
-| test.rb:23:25:23:37 | call to [] | semmle.label | call to [] |
-| test.rb:23:25:23:37 | call to [] [element 0] | semmle.label | call to [] [element 0] |
-| test.rb:23:26:23:36 | call to user_params | semmle.label | call to user_params |
-| test.rb:24:26:24:38 | call to [] | semmle.label | call to [] |
-| test.rb:24:26:24:38 | call to [] [element 0] | semmle.label | call to [] [element 0] |
-| test.rb:24:27:24:37 | call to user_params | semmle.label | call to user_params |
 | test.rb:25:21:25:31 | call to user_params | semmle.label | call to user_params |
 | test.rb:26:24:26:34 | call to user_params | semmle.label | call to user_params |
 | test.rb:27:22:27:32 | call to user_params | semmle.label | call to user_params |
 | test.rb:28:25:28:35 | call to user_params | semmle.label | call to user_params |
 | test.rb:29:21:29:31 | call to user_params | semmle.label | call to user_params |
-| test.rb:30:21:30:33 | call to [] | semmle.label | call to [] |
-| test.rb:30:21:30:33 | call to [] [element 0] | semmle.label | call to [] [element 0] |
-| test.rb:30:22:30:32 | call to user_params | semmle.label | call to user_params |
 | test.rb:31:32:31:42 | call to user_params | semmle.label | call to user_params |
 | test.rb:32:33:32:43 | call to user_params | semmle.label | call to user_params |
 | test.rb:33:36:33:46 | call to user_params | semmle.label | call to user_params |
@@ -57,6 +47,18 @@ nodes
 | test.rb:43:9:43:14 | call to params | semmle.label | call to params |
 | test.rb:43:9:43:29 | call to require | semmle.label | call to require |
 | test.rb:43:9:43:37 | call to permit! | semmle.label | call to permit! |
+| test.rb:47:9:47:9 | x | semmle.label | x |
+| test.rb:47:13:47:18 | call to params | semmle.label | call to params |
+| test.rb:47:13:47:25 | ...[...] | semmle.label | ...[...] |
+| test.rb:48:9:48:9 | [post] x | semmle.label | [post] x |
+| test.rb:48:9:48:9 | x | semmle.label | x |
+| test.rb:49:18:49:18 | x | semmle.label | x |
+| test.rb:51:18:51:23 | call to params | semmle.label | call to params |
+| test.rb:51:18:51:40 | call to permit | semmle.label | call to permit |
+| test.rb:52:18:52:23 | call to params | semmle.label | call to params |
+| test.rb:52:18:52:69 | call to permit | semmle.label | call to permit |
+| test.rb:53:18:53:23 | call to params | semmle.label | call to params |
+| test.rb:53:18:53:35 | call to to_unsafe_h | semmle.label | call to to_unsafe_h |
 subpaths
 #select
 | test.rb:8:18:8:28 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:8:18:8:28 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
@@ -65,17 +67,18 @@ subpaths
 | test.rb:20:22:20:32 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:20:22:20:32 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
 | test.rb:21:21:21:31 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:21:21:21:31 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
 | test.rb:22:22:22:32 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:22:22:22:32 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
-| test.rb:23:25:23:37 | call to [] | test.rb:43:9:43:14 | call to params | test.rb:23:25:23:37 | call to [] | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
-| test.rb:24:26:24:38 | call to [] | test.rb:43:9:43:14 | call to params | test.rb:24:26:24:38 | call to [] | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
 | test.rb:25:21:25:31 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:25:21:25:31 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
 | test.rb:26:24:26:34 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:26:24:26:34 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
 | test.rb:27:22:27:32 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:27:22:27:32 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
 | test.rb:28:25:28:35 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:28:25:28:35 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
 | test.rb:29:21:29:31 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:29:21:29:31 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
-| test.rb:30:21:30:33 | call to [] | test.rb:43:9:43:14 | call to params | test.rb:30:21:30:33 | call to [] | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
 | test.rb:31:32:31:42 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:31:32:31:42 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
 | test.rb:32:33:32:43 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:32:33:32:43 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
 | test.rb:33:36:33:46 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:33:36:33:46 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
 | test.rb:34:32:34:42 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:34:32:34:42 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
 | test.rb:35:33:35:43 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:35:33:35:43 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
 | test.rb:36:26:36:36 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:36:26:36:36 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
+| test.rb:49:18:49:18 | x | test.rb:47:13:47:18 | call to params | test.rb:49:18:49:18 | x | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:47:13:47:18 | call to params | this remote flow source |
+| test.rb:51:18:51:40 | call to permit | test.rb:51:18:51:23 | call to params | test.rb:51:18:51:40 | call to permit | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:51:18:51:23 | call to params | this remote flow source |
+| test.rb:52:18:52:69 | call to permit | test.rb:52:18:52:23 | call to params | test.rb:52:18:52:69 | call to permit | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:52:18:52:23 | call to params | this remote flow source |
+| test.rb:53:18:53:35 | call to to_unsafe_h | test.rb:53:18:53:23 | call to params | test.rb:53:18:53:35 | call to to_unsafe_h | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:53:18:53:23 | call to params | this remote flow source |

--- a/ruby/ql/test/query-tests/security/cwe-915/MassAssignment.expected
+++ b/ruby/ql/test/query-tests/security/cwe-915/MassAssignment.expected
@@ -1,12 +1,81 @@
 edges
-| test.rb:17:9:17:14 | call to params | test.rb:17:9:17:29 | call to require | provenance |  |
-| test.rb:17:9:17:29 | call to require | test.rb:17:9:17:37 | call to permit! | provenance |  |
-| test.rb:17:9:17:37 | call to permit! | test.rb:8:18:8:28 | call to user_params | provenance |  |
+| test.rb:23:25:23:37 | call to [] [element 0] | test.rb:23:25:23:37 | call to [] | provenance |  |
+| test.rb:23:26:23:36 | call to user_params | test.rb:23:25:23:37 | call to [] [element 0] | provenance |  |
+| test.rb:24:26:24:38 | call to [] [element 0] | test.rb:24:26:24:38 | call to [] | provenance |  |
+| test.rb:24:27:24:37 | call to user_params | test.rb:24:26:24:38 | call to [] [element 0] | provenance |  |
+| test.rb:30:21:30:33 | call to [] [element 0] | test.rb:30:21:30:33 | call to [] | provenance |  |
+| test.rb:30:22:30:32 | call to user_params | test.rb:30:21:30:33 | call to [] [element 0] | provenance |  |
+| test.rb:43:9:43:14 | call to params | test.rb:43:9:43:29 | call to require | provenance |  |
+| test.rb:43:9:43:29 | call to require | test.rb:43:9:43:37 | call to permit! | provenance |  |
+| test.rb:43:9:43:37 | call to permit! | test.rb:8:18:8:28 | call to user_params | provenance |  |
+| test.rb:43:9:43:37 | call to permit! | test.rb:18:20:18:30 | call to user_params | provenance |  |
+| test.rb:43:9:43:37 | call to permit! | test.rb:19:21:19:31 | call to user_params | provenance |  |
+| test.rb:43:9:43:37 | call to permit! | test.rb:20:22:20:32 | call to user_params | provenance |  |
+| test.rb:43:9:43:37 | call to permit! | test.rb:21:21:21:31 | call to user_params | provenance |  |
+| test.rb:43:9:43:37 | call to permit! | test.rb:22:22:22:32 | call to user_params | provenance |  |
+| test.rb:43:9:43:37 | call to permit! | test.rb:23:26:23:36 | call to user_params | provenance |  |
+| test.rb:43:9:43:37 | call to permit! | test.rb:24:27:24:37 | call to user_params | provenance |  |
+| test.rb:43:9:43:37 | call to permit! | test.rb:25:21:25:31 | call to user_params | provenance |  |
+| test.rb:43:9:43:37 | call to permit! | test.rb:26:24:26:34 | call to user_params | provenance |  |
+| test.rb:43:9:43:37 | call to permit! | test.rb:27:22:27:32 | call to user_params | provenance |  |
+| test.rb:43:9:43:37 | call to permit! | test.rb:28:25:28:35 | call to user_params | provenance |  |
+| test.rb:43:9:43:37 | call to permit! | test.rb:29:21:29:31 | call to user_params | provenance |  |
+| test.rb:43:9:43:37 | call to permit! | test.rb:30:22:30:32 | call to user_params | provenance |  |
+| test.rb:43:9:43:37 | call to permit! | test.rb:31:32:31:42 | call to user_params | provenance |  |
+| test.rb:43:9:43:37 | call to permit! | test.rb:32:33:32:43 | call to user_params | provenance |  |
+| test.rb:43:9:43:37 | call to permit! | test.rb:33:36:33:46 | call to user_params | provenance |  |
+| test.rb:43:9:43:37 | call to permit! | test.rb:34:32:34:42 | call to user_params | provenance |  |
+| test.rb:43:9:43:37 | call to permit! | test.rb:35:33:35:43 | call to user_params | provenance |  |
+| test.rb:43:9:43:37 | call to permit! | test.rb:36:26:36:36 | call to user_params | provenance |  |
 nodes
 | test.rb:8:18:8:28 | call to user_params | semmle.label | call to user_params |
-| test.rb:17:9:17:14 | call to params | semmle.label | call to params |
-| test.rb:17:9:17:29 | call to require | semmle.label | call to require |
-| test.rb:17:9:17:37 | call to permit! | semmle.label | call to permit! |
+| test.rb:18:20:18:30 | call to user_params | semmle.label | call to user_params |
+| test.rb:19:21:19:31 | call to user_params | semmle.label | call to user_params |
+| test.rb:20:22:20:32 | call to user_params | semmle.label | call to user_params |
+| test.rb:21:21:21:31 | call to user_params | semmle.label | call to user_params |
+| test.rb:22:22:22:32 | call to user_params | semmle.label | call to user_params |
+| test.rb:23:25:23:37 | call to [] | semmle.label | call to [] |
+| test.rb:23:25:23:37 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| test.rb:23:26:23:36 | call to user_params | semmle.label | call to user_params |
+| test.rb:24:26:24:38 | call to [] | semmle.label | call to [] |
+| test.rb:24:26:24:38 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| test.rb:24:27:24:37 | call to user_params | semmle.label | call to user_params |
+| test.rb:25:21:25:31 | call to user_params | semmle.label | call to user_params |
+| test.rb:26:24:26:34 | call to user_params | semmle.label | call to user_params |
+| test.rb:27:22:27:32 | call to user_params | semmle.label | call to user_params |
+| test.rb:28:25:28:35 | call to user_params | semmle.label | call to user_params |
+| test.rb:29:21:29:31 | call to user_params | semmle.label | call to user_params |
+| test.rb:30:21:30:33 | call to [] | semmle.label | call to [] |
+| test.rb:30:21:30:33 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| test.rb:30:22:30:32 | call to user_params | semmle.label | call to user_params |
+| test.rb:31:32:31:42 | call to user_params | semmle.label | call to user_params |
+| test.rb:32:33:32:43 | call to user_params | semmle.label | call to user_params |
+| test.rb:33:36:33:46 | call to user_params | semmle.label | call to user_params |
+| test.rb:34:32:34:42 | call to user_params | semmle.label | call to user_params |
+| test.rb:35:33:35:43 | call to user_params | semmle.label | call to user_params |
+| test.rb:36:26:36:36 | call to user_params | semmle.label | call to user_params |
+| test.rb:43:9:43:14 | call to params | semmle.label | call to params |
+| test.rb:43:9:43:29 | call to require | semmle.label | call to require |
+| test.rb:43:9:43:37 | call to permit! | semmle.label | call to permit! |
 subpaths
 #select
-| test.rb:8:18:8:28 | call to user_params | test.rb:17:9:17:14 | call to params | test.rb:8:18:8:28 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:17:9:17:14 | call to params | this remote flow source |
+| test.rb:8:18:8:28 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:8:18:8:28 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
+| test.rb:18:20:18:30 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:18:20:18:30 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
+| test.rb:19:21:19:31 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:19:21:19:31 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
+| test.rb:20:22:20:32 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:20:22:20:32 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
+| test.rb:21:21:21:31 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:21:21:21:31 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
+| test.rb:22:22:22:32 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:22:22:22:32 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
+| test.rb:23:25:23:37 | call to [] | test.rb:43:9:43:14 | call to params | test.rb:23:25:23:37 | call to [] | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
+| test.rb:24:26:24:38 | call to [] | test.rb:43:9:43:14 | call to params | test.rb:24:26:24:38 | call to [] | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
+| test.rb:25:21:25:31 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:25:21:25:31 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
+| test.rb:26:24:26:34 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:26:24:26:34 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
+| test.rb:27:22:27:32 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:27:22:27:32 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
+| test.rb:28:25:28:35 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:28:25:28:35 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
+| test.rb:29:21:29:31 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:29:21:29:31 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
+| test.rb:30:21:30:33 | call to [] | test.rb:43:9:43:14 | call to params | test.rb:30:21:30:33 | call to [] | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
+| test.rb:31:32:31:42 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:31:32:31:42 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
+| test.rb:32:33:32:43 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:32:33:32:43 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
+| test.rb:33:36:33:46 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:33:36:33:46 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
+| test.rb:34:32:34:42 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:34:32:34:42 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
+| test.rb:35:33:35:43 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:35:33:35:43 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |
+| test.rb:36:26:36:36 | call to user_params | test.rb:43:9:43:14 | call to params | test.rb:36:26:36:36 | call to user_params | This mass assignment operation can assign user-controlled attributes from $@. | test.rb:43:9:43:14 | call to params | this remote flow source |

--- a/ruby/ql/test/query-tests/security/cwe-915/MassAssignment.qlref
+++ b/ruby/ql/test/query-tests/security/cwe-915/MassAssignment.qlref
@@ -1,0 +1,1 @@
+queries/security/cwe-915/MassAssignment.ql

--- a/ruby/ql/test/query-tests/security/cwe-915/test.rb
+++ b/ruby/ql/test/query-tests/security/cwe-915/test.rb
@@ -13,6 +13,32 @@ class UserController < ActionController::Base
         User.new(params[:user].permit(:name,:address))
     end
 
+    def create3
+        # each BAD
+        User.build(user_params)
+        User.create(user_params)
+        User.create!(user_params)
+        User.insert(user_params)
+        User.insert!(user_params)
+        User.insert_all([user_params])
+        User.insert_all!([user_params])
+        User.update(user_params)
+        User.update(7, user_params)
+        User.update!(user_params)
+        User.update!(7, user_params)
+        User.upsert(user_params)
+        User.upsert([user_params])
+        User.find_or_create_by(user_params)
+        User.find_or_create_by!(user_params)
+        User.find_or_initialize_by(user_params)
+        User.create_or_find_by(user_params)
+        User.create_or_find_by!(user_params)
+        User.create_with(user_params)
+
+        user = User.where(name:"abc")
+        user.update(user_params)
+    end
+
     def user_params
         params.require(:user).permit!
     end

--- a/ruby/ql/test/query-tests/security/cwe-915/test.rb
+++ b/ruby/ql/test/query-tests/security/cwe-915/test.rb
@@ -42,4 +42,15 @@ class UserController < ActionController::Base
     def user_params
         params.require(:user).permit!
     end
+
+    def create4
+        x = params[:user]
+        x.permit!
+        User.new(x) # BAD
+        User.new(x.permit(:name,:address)) # GOOD
+        User.new(params.permit(user: {})) # BAD
+        User.new(params.permit(user: [:name, :address, {friends:{}}])) # BAD
+        User.new(params.to_unsafe_h) # BAD
+        User.new(params.permit(user: [:name, :address]).to_unsafe_h) # GOOD
+     end
 end

--- a/ruby/ql/test/query-tests/security/cwe-915/test.rb
+++ b/ruby/ql/test/query-tests/security/cwe-915/test.rb
@@ -1,0 +1,19 @@
+class User < ApplicationRecord
+
+end
+
+class UserController < ActionController::Base
+    def create
+        # BAD: arbitrary params are permitted to be used for this assignment
+        User.new(user_params).save!
+    end
+
+    def create2
+        # GOOD: the permitted parameters are explicitly specified
+        User.new(params[:user].permit(:name,:address))
+    end
+
+    def user_params
+        params.require(:user).permit!
+    end
+end


### PR DESCRIPTION
This query looks for instances of request parameters having `permit!` called on them, which allows arbitrary parameters to be specified by the request, and then being used for a mass assignment operation.