### PR TITLE
Docs: Add Go 1.22 to supported versions range

### DIFF
--- a/docs/codeql/reusables/supported-versions-compilers.rst
+++ b/docs/codeql/reusables/supported-versions-compilers.rst
@@ -16,7 +16,7 @@
    .NET Core up to 3.1
 
    .NET 5, .NET 6, .NET 7, .NET 8","``.sln``, ``.csproj``, ``.cs``, ``.cshtml``, ``.xaml``"
-   Go (aka Golang), "Go up to 1.21", "Go 1.11 or more recent", ``.go``
+   Go (aka Golang), "Go up to 1.22", "Go 1.11 or more recent", ``.go``
    Java,"Java 7 to 21 [5]_","javac (OpenJDK and Oracle JDK),
 
    Eclipse compiler for Java (ECJ) [6]_",``.java``


### PR DESCRIPTION
We shipped Go 1.22 support in CodeQL 2.16.4. This updates the documentation to include Go 1.22 in the range of supported versions.