### PR TITLE
C#: Avoid using TRAP stack in buildless mode

### DIFF
--- a/csharp/extractor/Semmle.Extraction/Context.cs
+++ b/csharp/extractor/Semmle.Extraction/Context.cs
@@ -274,28 +274,36 @@ namespace Semmle.Extraction
 
             bool duplicationGuard, deferred;
 
-            switch (entity.TrapStackBehaviour)
+            if (Extractor.Mode is ExtractorMode.Standalone)
             {
-                case TrapStackBehaviour.NeedsLabel:
-                    if (!tagStack.Any())
-                        ExtractionError("TagStack unexpectedly empty", optionalSymbol, entity);
-                    duplicationGuard = false;
-                    deferred = false;
-                    break;
-                case TrapStackBehaviour.NoLabel:
-                    duplicationGuard = false;
-                    deferred = tagStack.Any();
-                    break;
-                case TrapStackBehaviour.OptionalLabel:
-                    duplicationGuard = false;
-                    deferred = false;
-                    break;
-                case TrapStackBehaviour.PushesLabel:
-                    duplicationGuard = true;
-                    deferred = duplicationGuard && tagStack.Any();
-                    break;
-                default:
-                    throw new InternalError("Unexpected TrapStackBehaviour");
+                duplicationGuard = false;
+                deferred = false;
+            }
+            else
+            {
+                switch (entity.TrapStackBehaviour)
+                {
+                    case TrapStackBehaviour.NeedsLabel:
+                        if (!tagStack.Any())
+                            ExtractionError("TagStack unexpectedly empty", optionalSymbol, entity);
+                        duplicationGuard = false;
+                        deferred = false;
+                        break;
+                    case TrapStackBehaviour.NoLabel:
+                        duplicationGuard = false;
+                        deferred = tagStack.Any();
+                        break;
+                    case TrapStackBehaviour.OptionalLabel:
+                        duplicationGuard = false;
+                        deferred = false;
+                        break;
+                    case TrapStackBehaviour.PushesLabel:
+                        duplicationGuard = true;
+                        deferred = duplicationGuard && tagStack.Any();
+                        break;
+                    default:
+                        throw new InternalError("Unexpected TrapStackBehaviour");
+                }
             }
 
             var a = duplicationGuard && IsEntityDuplicationGuarded(entity, out var loc)


### PR DESCRIPTION
The TRAP stack is used to prevent duplicate entities in the DB, when the same source file is compiled multiple times. However, this can never happen in buildless mode, so there is no reason to emit `.push` and `.pop` instructions.

Reduces [TRAP size](https://github.com/github/codeql-dca-main/blob/data/hvitved/pr-15994-79dc7f__nightly-buildle__nightly/reports/summaries/space.theme.md#trap-size-per-source) and [TRAP import](https://github.com/github/codeql-dca-main/blob/data/hvitved/pr-15994-79dc7f__nightly-buildle__nightly/reports/summaries/time.theme.md#trap-import-time-per-source) a bit.