### PR TITLE
Swift genrule: Replace local with no-sandbox.

### DIFF
--- a/swift/third_party/BUILD.swift-toolchain-linux.bazel
+++ b/swift/third_party/BUILD.swift-toolchain-linux.bazel
@@ -30,7 +30,7 @@ _pm_interface_files = [
             srcs = ["%s/%s/%s" % (_strip_prefix, dir, interface)],
             outs = [module],
             cmd = "$(location usr/bin/swift-frontend) -compile-module-from-interface $< -o $@ -I $$(dirname $<)",
-            local = True,
+            tags = ["no-sandbox"],
             tools = ["usr/bin/swift-frontend"],
         ),
         pkg_files(


### PR DESCRIPTION
This allows the bazel cache to cache this genrule invocation. It shouldn't depend on system-specific binaries, so I believe this is correct.
This is the only part of our build where we otherwise need to recompute parts after pulling in a full cache.