### PR TITLE
C++: Add precision to `cpp/boost/tls-settings-misconfiguration` and `cpp/boost/use-of-deprecated-hardcoded-security-protocol`

### DIFF
--- a/cpp/ql/src/Likely Bugs/Protocols/TlsSettingsMisconfiguration.ql
+++ b/cpp/ql/src/Likely Bugs/Protocols/TlsSettingsMisconfiguration.ql
@@ -43,10 +43,9 @@ predicate isOptionSet(ConstructorCall cc, int flag, FunctionCall fcSetOptions) {
     ExistsAnyFlow::flow(source, sink) and
     f.getACallToThisFunction() = fcSetOptions and
     contextSetOptions = fcSetOptions.getQualifier() and
-    forall(Expr optionArgument, Expr optionArgumentSource |
+    forex(Expr optionArgument |
       optionArgument = fcSetOptions.getArgument(0) and
-      BoostorgAsio::SslOptionFlow::flow(DataFlow::exprNode(optionArgumentSource),
-        DataFlow::exprNode(optionArgument))
+      BoostorgAsio::SslOptionFlow::flowTo(DataFlow::exprNode(optionArgument))
     |
       optionArgument.getValue().toInt().bitShiftRight(16).bitAnd(flag) = flag
     )

--- a/cpp/ql/src/Likely Bugs/Protocols/TlsSettingsMisconfiguration.ql
+++ b/cpp/ql/src/Likely Bugs/Protocols/TlsSettingsMisconfiguration.ql
@@ -1,8 +1,9 @@
 /**
- * @name Boost_asio TLS Settings Misconfiguration
+ * @name boost::asio TLS settings misconfiguration
  * @description Using the TLS or SSLv23 protocol from the boost::asio library, but not disabling deprecated protocols, or disabling minimum-recommended protocols.
  * @kind problem
  * @problem.severity error
+ * @precision medium
  * @security-severity 7.5
  * @id cpp/boost/tls-settings-misconfiguration
  * @tags security

--- a/cpp/ql/src/Likely Bugs/Protocols/UseOfDeprecatedHardcodedProtocol.ql
+++ b/cpp/ql/src/Likely Bugs/Protocols/UseOfDeprecatedHardcodedProtocol.ql
@@ -1,8 +1,9 @@
 /**
- * @name boost::asio Use of deprecated hardcoded Protocol
+ * @name boost::asio use of deprecated hardcoded protocol
  * @description Using a deprecated hard-coded protocol using the boost::asio library.
  * @kind problem
  * @problem.severity error
+ * @precision medium
  * @security-severity 7.5
  * @id cpp/boost/use-of-deprecated-hardcoded-security-protocol
  * @tags security

--- a/cpp/ql/src/change-notes/2024-03-22-boost-ssl.md
+++ b/cpp/ql/src/change-notes/2024-03-22-boost-ssl.md
@@ -1,0 +1,4 @@
+---
+category: queryMetadata
+---
+* `@precision medium` metadata was added to the `cpp/boost/tls-settings-misconfiguration` and `cpp/boost/use-of-deprecated-hardcoded-security-protocol` queries, and these queries are now included in the security-extended suite. The `@name` metadata of these queries were also updated.


### PR DESCRIPTION
Also clean up the names of the queries while here.