### PR TITLE
C#: add hint regarding ECB to weak encryption QHelp

### DIFF
--- a/csharp/ql/src/Security Features/WeakEncryption.qhelp
+++ b/csharp/ql/src/Security Features/WeakEncryption.qhelp
@@ -7,7 +7,7 @@
 
 </overview>
 <recommendation>
-<p>You should switch to a more secure encryption algorithm, such as AES (Advanced Encryption Standard) and use a key length which is reasonable for the application for which it is being used.</p>
+<p>You should switch to a more secure encryption algorithm, such as AES (Advanced Encryption Standard) and use a key length which is reasonable for the application for which it is being used. Do not use the ECB encryption mode since it is vulnerable to replay and other attacks.</p>
 
 </recommendation>
 <example>


### PR DESCRIPTION
I've copied the sentence regarding the use of AES in ECB mode from the corresponding [Java query QHelp](https://codeql.github.com/codeql-query-help/java/java-potentially-weak-cryptographic-algorithm/) (`java/potentially-weak-cryptographic-algorithm`). 

