### PR TITLE
Use correct model pack name in qltest data extension

### DIFF
--- a/java/ql/integration-tests/all-platforms/kotlin/default-parameter-mad-flow/test.ext.yml
+++ b/java/ql/integration-tests/all-platforms/kotlin/default-parameter-mad-flow/test.ext.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
-      pack: integrationtest-default-parameter-mad-flow
+      pack: codeql/java-all
       extensible: summaryModel
     data:
       - ["", "ConstructorWithDefaults", True, "ConstructorWithDefaults", "(int,int)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
@@ -11,14 +11,14 @@ extensions:
       - ["", "LibClass", True, "multiParameterTest", "(int,int,int,int)", "", "Argument[0..1]", "ReturnValue", "value", "manual"]
       - ["", "LibClass", True, "multiParameterExtensionTest", "(int,int,int,int)", "", "Argument[0, 1]", "ReturnValue", "value", "manual"]
   - addsTo:
-      pack: integrationtest-default-parameter-mad-flow
+      pack: codeql/java-all
       extensible: sourceModel
     data:
       - ["", "LibKt", True, "topLevelArgSource", "(SomeToken,int)", "", "Argument[0]", "kotlinMadFlowTest", "manual"]
       - ["", "LibKt", True, "extensionArgSource", "(String,SomeToken,int)", "", "Argument[1]", "kotlinMadFlowTest", "manual"]
       - ["", "SourceClass", True, "memberArgSource", "(SomeToken,int)", "", "Argument[0]", "kotlinMadFlowTest", "manual"]
   - addsTo:
-      pack: integrationtest-default-parameter-mad-flow
+      pack: codeql/java-all
       extensible: sinkModel
     data:
       - ["", "SinkClass", True, "SinkClass", "(int,int)", "", "Argument[0]", "kotlinMadFlowTest", "manual"]


### PR DESCRIPTION
An upcoming CLI change will start validating test-specific data extensions more thoroughly, and this test was using the wrong pack name in its `addsTo:` property.
