### PR TITLE
Remove unused data extension in test

### DIFF
--- a/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest1.ext.yml
+++ b/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest1.ext.yml
@@ -2,11 +2,6 @@ extensions:
 
   - addsTo:
       pack: codeql/java-all
-      extensible: supportedThreatModels
-    data: []
-
-  - addsTo:
-      pack: codeql/java-all
       extensible: sourceModel
     data:
       - ["testlib", "TestSources", False, "executeQuery", "(String)", "", "ReturnValue", "database", "manual"]


### PR DESCRIPTION
We were extending a predicate that does not exist, but we weren't adding any data anyway. I think we might have removed that predicate early in the threat model work.

There's an in-flight CodeQL PR that will start emitting validation errors for data extensions in QL tests, just like we already do for regular data extensions.
