### PR TITLE
JS: more implied receiver steps

### DIFF
--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.expected
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.expected
@@ -2,6 +2,7 @@ spuriousCallee
 missingCallee
 | constructor-field.ts:40:5:40:14 | f3.build() | constructor-field.ts:13:3:13:12 | build() {} | -1 | calls |
 | constructor-field.ts:71:1:71:11 | bf3.build() | constructor-field.ts:13:3:13:12 | build() {} | -1 | calls |
+| implied-receiver.js:7:13:7:25 | this.member() | implied-receiver.js:17:22:19:1 | functio ... n 42;\\n} | -1 | calls |
 badAnnotation
 accessorCall
 | accessors.js:12:1:12:5 | obj.f | accessors.js:5:8:5:12 | () {} |

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.expected
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.expected
@@ -2,7 +2,6 @@ spuriousCallee
 missingCallee
 | constructor-field.ts:40:5:40:14 | f3.build() | constructor-field.ts:13:3:13:12 | build() {} | -1 | calls |
 | constructor-field.ts:71:1:71:11 | bf3.build() | constructor-field.ts:13:3:13:12 | build() {} | -1 | calls |
-| implied-receiver.js:7:13:7:25 | this.member() | implied-receiver.js:17:22:19:1 | functio ... n 42;\\n} | -1 | calls |
 badAnnotation
 accessorCall
 | accessors.js:12:1:12:5 | obj.f | accessors.js:5:8:5:12 | () {} |

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/implied-receiver.js
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/implied-receiver.js
@@ -1,0 +1,19 @@
+import 'dummy';
+
+function fooFactoryFactory() {
+    return function fooFactory() {
+        return function foo() {
+            /** calls:F.member */
+            this.member();
+        }
+    }
+}
+
+function F() {
+    this.foo = fooFactoryFactory()();
+}
+
+/** name:F.member */
+F.prototype.member = function() {
+    return 42;
+};


### PR DESCRIPTION
Propagates `this` into functions that are installed on objects in a non-trivial way, e.g:

```js
function fooFactoryFactory() {
    return function fooFactory() {
        return function foo() {
            /** calls:F.member */
            this.member();
        }
    }
}

function F() {
    this.foo = fooFactoryFactory()();
}
```
