### PR TITLE
Go: Add changenote for `CODEQL_EXTRACTOR_GO_FAST_PACKAGE_INFO` change

### DIFF
--- a/go/ql/lib/change-notes/2024-03-20-dependecy-retrieval-improvement.md
+++ b/go/ql/lib/change-notes/2024-03-20-dependecy-retrieval-improvement.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `CODEQL_EXTRACTOR_GO_FAST_PACKAGE_INFO` option, which speeds up retrieval of dependency information, is now on by default. This was originally an external contribution by @xhd2015.


### PR DESCRIPTION
This adds a changenote for the change made in https://github.com/github/codeql/pull/15935.