### PR TITLE
C++: Divide CODEOWNERS responsibilities.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,6 @@
-/cpp/ @github/codeql-c-analysis
+/cpp/ @github/codeql-c-extractor
+/cpp/config/ @github/codeql-c-analysis
+/cpp/ql/ @github/codeql-c-analysis
 /csharp/ @github/codeql-csharp
 /go/ @github/codeql-go
 /java/ @github/codeql-java


### PR DESCRIPTION
Update `CODEOWNERS` responsibilities for the C team:
- previously all of `cpp` was assigned to @github/codeql-c-analysis.
- now directories are split between @github/codeql-c-analysis and @github/codeql-c-extractor (somewhat similarly to how the internal repo already is).
- note that later entries in the file override earlier ones.

As a member of the analysis but not extractor team I'm hoping to get slightly fewer notifications for things that aren't relevant to me after this change (e.g. changes to the autobuilder).  The same would apply to @MathiasVP and @rdmarsh2.  On the flip side, @AlexDenisov, @redsun82 and @sashabu may get slightly more (but relevant!) notifications as they are members of the extractor but not analysis team.