### PR TITLE
QL: Run diagnostics and summary metrics in code scanning

### DIFF
--- a/ql/ql/src/codeql-suites/ql-code-scanning.qls
+++ b/ql/ql/src/codeql-suites/ql-code-scanning.qls
@@ -14,6 +14,14 @@
     - error
     - warning
     - recommendation
+- include:
+    kind:
+    - diagnostic
+- include:
+    kind:
+    - metric
+    tags contain:
+    - summary
 - exclude:
     deprecated: //
 - exclude:


### PR DESCRIPTION
Add diagnostics and summary metric queries to the code scanning suite.  This means we'll see them in QL for QL runs on this repository.