### PR TITLE
Make customizing-library-models-for-javascript.rst visible to search and the docs TOC

### DIFF
--- a/docs/codeql/codeql-language-guides/codeql-for-javascript.rst
+++ b/docs/codeql/codeql-language-guides/codeql-for-javascript.rst
@@ -33,3 +33,5 @@ Experiment and learn how to write effective and efficient queries for CodeQL dat
 -  :doc:`Abstract syntax tree classes for working with JavaScript and TypeScript programs <abstract-syntax-tree-classes-for-working-with-javascript-and-typescript-programs>`: CodeQL has a large selection of classes for representing the abstract syntax tree of JavaScript and TypeScript programs.
 
 -  :doc:`Data flow cheat sheet for JavaScript <data-flow-cheat-sheet-for-javascript>`: This article describes parts of the JavaScript libraries commonly used for variant analysis and in data flow queries.
+
+- :doc:`Customizing library models for JavaScript <customizing-library-models-for-ruby>`: You can model frameworks and libraries that your codebase depends on using data extensions and publish them as CodeQL model packs.

--- a/docs/codeql/codeql-language-guides/codeql-for-javascript.rst
+++ b/docs/codeql/codeql-language-guides/codeql-for-javascript.rst
@@ -34,4 +34,4 @@ Experiment and learn how to write effective and efficient queries for CodeQL dat
 
 -  :doc:`Data flow cheat sheet for JavaScript <data-flow-cheat-sheet-for-javascript>`: This article describes parts of the JavaScript libraries commonly used for variant analysis and in data flow queries.
 
-- :doc:`Customizing library models for JavaScript <customizing-library-models-for-ruby>`: You can model frameworks and libraries that your codebase depends on using data extensions and publish them as CodeQL model packs.
+- :doc:`Customizing library models for JavaScript <customizing-library-models-for-javascript>`: You can model frameworks and libraries that your codebase depends on using data extensions and publish them as CodeQL model packs.

--- a/docs/codeql/codeql-language-guides/codeql-for-javascript.rst
+++ b/docs/codeql/codeql-language-guides/codeql-for-javascript.rst
@@ -17,6 +17,7 @@ Experiment and learn how to write effective and efficient queries for CodeQL dat
    using-type-tracking-for-api-modeling
    abstract-syntax-tree-classes-for-working-with-javascript-and-typescript-programs
    data-flow-cheat-sheet-for-javascript
+   customizing-library-models-for-javascript
 
 -  :doc:`Basic query for JavaScript and TypeScript code <basic-query-for-javascript-code>`: Learn to write and run a simple CodeQL query.
 

--- a/docs/codeql/codeql-language-guides/customizing-library-models-for-javascript.rst
+++ b/docs/codeql/codeql-language-guides/customizing-library-models-for-javascript.rst
@@ -1,8 +1,5 @@
 .. _customizing-library-models-for-javascript:
 
-:orphan:
-:nosearch:
-
 Customizing Library Models for JavaScript
 =========================================
 
@@ -29,8 +26,6 @@ The CodeQL library for JavaScript exposes the following extensible predicates:
 - **sinkModel**\(type, path, kind)
 - **typeModel**\(type1, type2, path)
 - **summaryModel**\(type, path, input, output, kind)
-
-See the `CLI documentation for how to load and use data extensions in a CodeQL evaluation run <https://docs.google.com/document/d/14IYCHX8wWuU-HTvJ2gPSdXQKHKYbWCHQKOgn8oLaa80/edit#heading=h.m0v53lpi6w2n>`__ (internal access required).
 
 We'll explain how to use these using a few examples, and provide some reference material at the end of this article.
 


### PR DESCRIPTION
This is the JS equivalent to https://github.com/github/codeql/pull/16073.

The content in customizing-library-models-for-javascript.rst is stable should be made more visible to users. This PR makes the article visible to search and the docs ToC. 

There are some other content changes that should probably be made, but they can take place in a follow up PR.