### PR TITLE
C#: Include all non-source-code properties in data flow

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -1997,6 +1997,8 @@ class FieldOrProperty extends Assignable, Modifiable {
           or
           p.getDeclaringType() instanceof AnonymousClass
         )
+        or
+        p.fromLibrary()
       )
   }
 


### PR DESCRIPTION
In the name of reducing false negatives, this PR assumes that all properties defined in non-source-code behave like fields when tracking data flow.