### PR TITLE
C#: Neutralize some `System.Diagnostics` generated models

### DIFF
--- a/csharp/ql/lib/ext/System.Diagnostics.model.yml
+++ b/csharp/ql/lib/ext/System.Diagnostics.model.yml
@@ -19,3 +19,12 @@ extensions:
       - ["System.Diagnostics", "TraceListenerCollection", False, "get_Item", "(System.Int32)", "", "Argument[this].Element", "ReturnValue", "value", "manual"]
       - ["System.Diagnostics", "TraceListenerCollection", False, "get_Item", "(System.String)", "", "Argument[this].Element", "ReturnValue", "value", "manual"]
       - ["System.Diagnostics", "TraceListenerCollection", False, "set_Item", "(System.Int32,System.Diagnostics.TraceListener)", "", "Argument[1]", "Argument[this].Element", "value", "manual"]
+  - addsTo:
+      pack: codeql/csharp-all
+      extensible: neutralModel
+    data:
+      - ["System.Diagnostics", "ProcessStartInfo", "set_Arguments", "(System.String)", "summary", "manual"]
+      - ["System.Diagnostics", "ProcessStartInfo", "set_FileName", "(System.String)", "summary", "manual"]
+      - ["System.Diagnostics", "ProcessStartInfo", "set_UserName", "(System.String)", "summary", "manual"]
+      - ["System.Diagnostics", "ProcessStartInfo", "set_Verb", "(System.String)", "summary", "manual"]
+      - ["System.Diagnostics", "ProcessStartInfo", "set_WorkingDirectory", "(System.String)", "summary", "manual"]

--- a/csharp/ql/test/library-tests/dataflow/library/FlowSummariesFiltered.expected
+++ b/csharp/ql/test/library-tests/dataflow/library/FlowSummariesFiltered.expected
@@ -7031,11 +7031,6 @@
 | System.Diagnostics;ProcessStartInfo;false;get_UserName;();;Argument[this];ReturnValue;taint;df-generated |
 | System.Diagnostics;ProcessStartInfo;false;get_Verb;();;Argument[this];ReturnValue;taint;df-generated |
 | System.Diagnostics;ProcessStartInfo;false;get_WorkingDirectory;();;Argument[this];ReturnValue;taint;df-generated |
-| System.Diagnostics;ProcessStartInfo;false;set_Arguments;(System.String);;Argument[0];Argument[this];taint;df-generated |
-| System.Diagnostics;ProcessStartInfo;false;set_FileName;(System.String);;Argument[0];Argument[this];taint;df-generated |
-| System.Diagnostics;ProcessStartInfo;false;set_UserName;(System.String);;Argument[0];Argument[this];taint;df-generated |
-| System.Diagnostics;ProcessStartInfo;false;set_Verb;(System.String);;Argument[0];Argument[this];taint;df-generated |
-| System.Diagnostics;ProcessStartInfo;false;set_WorkingDirectory;(System.String);;Argument[0];Argument[this];taint;df-generated |
 | System.Diagnostics;ProcessThreadCollection;false;Add;(System.Diagnostics.ProcessThread);;Argument[0];Argument[this].Element;value;manual |
 | System.Diagnostics;ProcessThreadCollection;false;CopyTo;(System.Diagnostics.ProcessThread[],System.Int32);;Argument[this].Element;Argument[0].Element;value;manual |
 | System.Diagnostics;SampleActivity<T>;false;BeginInvoke;(System.Diagnostics.ActivityCreationOptions<T>,System.AsyncCallback,System.Object);;Argument[1];Argument[1].Parameter[delegate-self];value;hq-generated |

--- a/csharp/ql/test/query-tests/Security Features/CWE-078/CommandInjection.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-078/CommandInjection.expected
@@ -6,23 +6,14 @@ edges
 | CommandInjection.cs:27:20:27:28 | access to local variable userInput : String | CommandInjection.cs:30:74:30:82 | access to local variable userInput | provenance |  |
 | CommandInjection.cs:27:20:27:28 | access to local variable userInput : String | CommandInjection.cs:30:74:30:82 | access to local variable userInput : String | provenance |  |
 | CommandInjection.cs:27:20:27:28 | access to local variable userInput : String | CommandInjection.cs:34:39:34:47 | access to local variable userInput | provenance |  |
-| CommandInjection.cs:27:20:27:28 | access to local variable userInput : String | CommandInjection.cs:34:39:34:47 | access to local variable userInput : String | provenance |  |
 | CommandInjection.cs:27:20:27:28 | access to local variable userInput : String | CommandInjection.cs:35:40:35:48 | access to local variable userInput | provenance |  |
-| CommandInjection.cs:27:20:27:28 | access to local variable userInput : String | CommandInjection.cs:35:40:35:48 | access to local variable userInput : String | provenance |  |
 | CommandInjection.cs:27:20:27:28 | access to local variable userInput : String | CommandInjection.cs:36:47:36:55 | access to local variable userInput | provenance |  |
-| CommandInjection.cs:27:20:27:28 | access to local variable userInput : String | CommandInjection.cs:36:47:36:55 | access to local variable userInput : String | provenance |  |
 | CommandInjection.cs:27:32:27:46 | access to field categoryTextBox : TextBox | CommandInjection.cs:27:32:27:51 | access to property Text : String | provenance |  |
 | CommandInjection.cs:27:32:27:51 | access to property Text : String | CommandInjection.cs:27:20:27:28 | access to local variable userInput : String | provenance |  |
 | CommandInjection.cs:30:30:30:38 | access to local variable startInfo : ProcessStartInfo | CommandInjection.cs:31:27:31:35 | access to local variable startInfo | provenance |  |
 | CommandInjection.cs:30:42:30:83 | object creation of type ProcessStartInfo : ProcessStartInfo | CommandInjection.cs:30:30:30:38 | access to local variable startInfo : ProcessStartInfo | provenance |  |
 | CommandInjection.cs:30:63:30:71 | access to local variable userInput : String | CommandInjection.cs:30:42:30:83 | object creation of type ProcessStartInfo : ProcessStartInfo | provenance |  |
 | CommandInjection.cs:30:74:30:82 | access to local variable userInput : String | CommandInjection.cs:30:42:30:83 | object creation of type ProcessStartInfo : ProcessStartInfo | provenance |  |
-| CommandInjection.cs:34:13:34:26 | [post] access to local variable startInfoProps : ProcessStartInfo | CommandInjection.cs:37:27:37:40 | access to local variable startInfoProps | provenance |  |
-| CommandInjection.cs:34:39:34:47 | access to local variable userInput : String | CommandInjection.cs:34:13:34:26 | [post] access to local variable startInfoProps : ProcessStartInfo | provenance |  |
-| CommandInjection.cs:35:13:35:26 | [post] access to local variable startInfoProps : ProcessStartInfo | CommandInjection.cs:37:27:37:40 | access to local variable startInfoProps | provenance |  |
-| CommandInjection.cs:35:40:35:48 | access to local variable userInput : String | CommandInjection.cs:35:13:35:26 | [post] access to local variable startInfoProps : ProcessStartInfo | provenance |  |
-| CommandInjection.cs:36:13:36:26 | [post] access to local variable startInfoProps : ProcessStartInfo | CommandInjection.cs:37:27:37:40 | access to local variable startInfoProps | provenance |  |
-| CommandInjection.cs:36:47:36:55 | access to local variable userInput : String | CommandInjection.cs:36:13:36:26 | [post] access to local variable startInfoProps : ProcessStartInfo | provenance |  |
 | CommandInjection.cs:51:54:51:80 | call to method GetString : String | CommandInjection.cs:51:46:51:80 | ... + ... | provenance |  |
 nodes
 | CommandInjection.cs:27:20:27:28 | access to local variable userInput : String | semmle.label | access to local variable userInput : String |
@@ -37,16 +28,9 @@ nodes
 | CommandInjection.cs:30:74:30:82 | access to local variable userInput | semmle.label | access to local variable userInput |
 | CommandInjection.cs:30:74:30:82 | access to local variable userInput : String | semmle.label | access to local variable userInput : String |
 | CommandInjection.cs:31:27:31:35 | access to local variable startInfo | semmle.label | access to local variable startInfo |
-| CommandInjection.cs:34:13:34:26 | [post] access to local variable startInfoProps : ProcessStartInfo | semmle.label | [post] access to local variable startInfoProps : ProcessStartInfo |
 | CommandInjection.cs:34:39:34:47 | access to local variable userInput | semmle.label | access to local variable userInput |
-| CommandInjection.cs:34:39:34:47 | access to local variable userInput : String | semmle.label | access to local variable userInput : String |
-| CommandInjection.cs:35:13:35:26 | [post] access to local variable startInfoProps : ProcessStartInfo | semmle.label | [post] access to local variable startInfoProps : ProcessStartInfo |
 | CommandInjection.cs:35:40:35:48 | access to local variable userInput | semmle.label | access to local variable userInput |
-| CommandInjection.cs:35:40:35:48 | access to local variable userInput : String | semmle.label | access to local variable userInput : String |
-| CommandInjection.cs:36:13:36:26 | [post] access to local variable startInfoProps : ProcessStartInfo | semmle.label | [post] access to local variable startInfoProps : ProcessStartInfo |
 | CommandInjection.cs:36:47:36:55 | access to local variable userInput | semmle.label | access to local variable userInput |
-| CommandInjection.cs:36:47:36:55 | access to local variable userInput : String | semmle.label | access to local variable userInput : String |
-| CommandInjection.cs:37:27:37:40 | access to local variable startInfoProps | semmle.label | access to local variable startInfoProps |
 | CommandInjection.cs:51:46:51:80 | ... + ... | semmle.label | ... + ... |
 | CommandInjection.cs:51:54:51:80 | call to method GetString : String | semmle.label | call to method GetString : String |
 subpaths
@@ -59,5 +43,4 @@ subpaths
 | CommandInjection.cs:34:39:34:47 | access to local variable userInput | CommandInjection.cs:27:32:27:46 | access to field categoryTextBox : TextBox | CommandInjection.cs:34:39:34:47 | access to local variable userInput | This command line depends on a $@. | CommandInjection.cs:27:32:27:46 | access to field categoryTextBox | user-provided value |
 | CommandInjection.cs:35:40:35:48 | access to local variable userInput | CommandInjection.cs:27:32:27:46 | access to field categoryTextBox : TextBox | CommandInjection.cs:35:40:35:48 | access to local variable userInput | This command line depends on a $@. | CommandInjection.cs:27:32:27:46 | access to field categoryTextBox | user-provided value |
 | CommandInjection.cs:36:47:36:55 | access to local variable userInput | CommandInjection.cs:27:32:27:46 | access to field categoryTextBox : TextBox | CommandInjection.cs:36:47:36:55 | access to local variable userInput | This command line depends on a $@. | CommandInjection.cs:27:32:27:46 | access to field categoryTextBox | user-provided value |
-| CommandInjection.cs:37:27:37:40 | access to local variable startInfoProps | CommandInjection.cs:27:32:27:46 | access to field categoryTextBox : TextBox | CommandInjection.cs:37:27:37:40 | access to local variable startInfoProps | This command line depends on a $@. | CommandInjection.cs:27:32:27:46 | access to field categoryTextBox | user-provided value |
 | CommandInjection.cs:51:46:51:80 | ... + ... | CommandInjection.cs:51:54:51:80 | call to method GetString : String | CommandInjection.cs:51:46:51:80 | ... + ... | This command line depends on a $@. | CommandInjection.cs:51:54:51:80 | call to method GetString | user-provided value |


### PR DESCRIPTION
I don't think we'd ever want taint summaries for property setters, as they should be store steps instead (at least once https://github.com/github/codeql/pull/16088 is merged). This PR removes a few such taint summaries.