### PR TITLE
Go: Revert `go version` call in `LoadGoModules`

### DIFF
--- a/go/extractor/project/project.go
+++ b/go/extractor/project/project.go
@@ -212,16 +212,6 @@ func LoadGoModules(emitDiagnostics bool, goModFilePaths []string) []*GoModule {
 		if modFile.Toolchain == nil && modFile.Go != nil &&
 			!toolchainVersionRe.Match([]byte(modFile.Go.Version)) && semver.Compare("v"+modFile.Go.Version, "v1.21.0") >= 0 {
 			diagnostics.EmitInvalidToolchainVersion(goModFilePath, modFile.Go.Version)
-
-			modPath := filepath.Dir(goModFilePath)
-
-			log.Printf(
-				"`%s` is not a valid toolchain version, trying to install it explicitly using the canonical representation in `%s`.",
-				modFile.Go.Version,
-				modPath,
-			)
-
-			toolchain.InstallVersion(modPath, modFile.Go.Version)
 		}
 	}
 


### PR DESCRIPTION
This removes a problematic change introduced in https://github.com/github/codeql/pull/15979 which invokes `go version` in the `LoadGoModules` function with a suitable `GOTOOLCHAIN` environment variable to try and force Go to install a particular version of Go. This does not seem to work correctly and, additionally, breaks the `resolve build-environment` functionality for Go. Therefore, we are temporarily removing the call until those issues are addressed. 