### PR TITLE
RB: fix language specifier typo in qhelp for rb/multi-char-san

### DIFF
--- a/ruby/ql/src/queries/security/cwe-116/IncompleteMultiCharacterSanitization.qhelp
+++ b/ruby/ql/src/queries/security/cwe-116/IncompleteMultiCharacterSanitization.qhelp
@@ -90,7 +90,7 @@ end
 Another potential fix is to use the popular <code>sanitize</code> gem. 
 It keeps most of the safe HTML tags while removing all unsafe tags and attributes.
 </p>
-<sample language="javascript">
+<sample language="ruby">
 require 'sanitize'
 
 def sanitize_html(input)


### PR DESCRIPTION
I haven't checked `git blame`, but I just assume that I made the mistake myself.  