### PR TITLE
Allow `@param` tags to apply to record parameters

### DIFF
--- a/java/ql/src/Advisory/Documentation/SpuriousJavadocParam.ql
+++ b/java/ql/src/Advisory/Documentation/SpuriousJavadocParam.ql
@@ -32,12 +32,24 @@ where
     )
     or
     documentable instanceof ClassOrInterface and
+    not documentable instanceof Record and
     not exists(TypeVariable tv | tv.getGenericType() = documentable |
       "<" + tv.getName() + ">" = paramTag.getParamName()
     ) and
     msg =
       "@param tag \"" + paramTag.getParamName() +
         "\" does not match any actual type parameter of type \"" + documentable.getName() + "\"."
+    or
+    documentable instanceof Record and
+    not exists(TypeVariable tv | tv.getGenericType() = documentable |
+      "<" + tv.getName() + ">" = paramTag.getParamName()
+    ) and
+    not documentable.(Record).getCanonicalConstructor().getAParameter().getName() =
+      paramTag.getParamName() and
+    msg =
+      "@param tag \"" + paramTag.getParamName() +
+        "\" does not match any actual type parameter or record parameter of record \"" +
+        documentable.getName() + "\"."
   else
     // The tag has no value at all.
     msg = "This @param tag does not have a value."

--- a/java/ql/src/change-notes/2024-04-02-javadoc-records.md
+++ b/java/ql/src/change-notes/2024-04-02-javadoc-records.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+* The `java/unknown-javadoc-parameter` now accepts `@param` tags that apply to the parameters of a
+  record.

--- a/java/ql/test/query-tests/SpuriousJavadocParam/Test.java
+++ b/java/ql/test/query-tests/SpuriousJavadocParam/Test.java
@@ -120,5 +120,18 @@ public class Test<V> {
    */
   interface GenericInterface<T> {}
 
+  /**
+   * @param i exists
+   * @param k does not
+   */
+  static record SomeRecord(int i, int j) {}
+
+  /**
+   * @param <T> exists
+   * @param i exists
+   * @param k does not
+   */
+  static record GenericRecord<T>(int i, int j) {}
+
   // Diagnostic Matches: Incomplete inheritance relation for type java.lang.Object and supertype none
 }

--- a/java/ql/test/query-tests/SpuriousJavadocParam/options
+++ b/java/ql/test/query-tests/SpuriousJavadocParam/options
@@ -1,0 +1,1 @@
+//semmle-extractor-options: --javac-args -source 16 -target 16

--- a/java/ql/test/query-tests/SpuriousJavadocParam/test.expected
+++ b/java/ql/test/query-tests/SpuriousJavadocParam/test.expected
@@ -12,3 +12,5 @@
 | Test.java:112:6:112:12 | @param | @param tag "<X>" does not match any actual type parameter of type "GenericClass". |
 | Test.java:118:6:118:12 | @param | @param tag "T" does not match any actual type parameter of type "GenericInterface". |
 | Test.java:119:6:119:12 | @param | @param tag "<X>" does not match any actual type parameter of type "GenericInterface". |
+| Test.java:125:6:125:12 | @param | @param tag "k" does not match any actual type parameter or record parameter of record "SomeRecord". |
+| Test.java:132:6:132:12 | @param | @param tag "k" does not match any actual type parameter or record parameter of record "GenericRecord". |


### PR DESCRIPTION
According to [this JDK issue](https://bugs.openjdk.org/browse/JDK-8225055), `@param` Javadoc tags in the comment for a `record` can apply to either a type parameter or a record parameter. The `java/unknown-javadoc-parameter` query wasn't aware of this, and was firing a large number of false positives in our own internal repo.
