### PR TITLE
RB: Tiny fixes to log-injection QHelp

### DIFF
--- a/ruby/ql/src/queries/security/cwe-117/examples/log_injection_good.rb
+++ b/ruby/ql/src/queries/security/cwe-117/examples/log_injection_good.rb
@@ -5,9 +5,8 @@ class UsersController < ApplicationController
     logger = Logger.new STDOUT
     username = params[:username]
 
-    # GOOD: log message constructed with unsanitized user input
-    sanitized_username = username.gsub("\n", "")
-    logger.info "attempting to login user: " + sanitized_username
+    # GOOD: log message constructed with sanitized user input
+    logger.info "attempting to login user: " + sanitized_username.gsub("\n", "")
 
     # ... login logic ...
   end


### PR DESCRIPTION
Adding a new variable is very verbose, and not what a realistic fix looks like. 
Autofix currently add a new variable on all `rb/log-injection` fixes, which does not look nice. 