### PR TITLE
Data flow: Fix bad join

### DIFF
--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -461,11 +461,14 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
     }
 
     pragma[nomagic]
+    private predicate hasReadStep(Content c) { read(_, c, _) }
+
+    pragma[nomagic]
     private predicate storeEx(
       NodeEx node1, Content c, NodeEx node2, DataFlowType contentType, DataFlowType containerType
     ) {
       storeExUnrestricted(node1, c, node2, contentType, containerType) and
-      read(_, c, _)
+      hasReadStep(c)
     }
 
     pragma[nomagic]


### PR DESCRIPTION
https://github.com/github/codeql/pull/16087 follow-up:

```
Evaluated relational algebra for predicate DataFlowImpl::Impl<PolynomialReDoSQuery::PolynomialReDoSFlow::C>::storeEx/5#34133ef9@0425e0m7 with tuple counts:
           2209132     ~1%    {6} r1 = SCAN `DataFlowImpl::Impl<PolynomialReDoSQuery::PolynomialReDoSFlow::C>::storeExUnrestricted/5#3a86a98e` OUTPUT In.1, In.0, In.1, In.2, In.3, In.4
        4338565685     ~1%    {6}    | JOIN WITH `DataFlowPublic::ContentSet.getAReadContent/0#dispred#e4acf74e_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5
          34811200  ~1428%    {5}    | JOIN WITH `project#DataFlowImpl::Impl<PolynomialReDoSQuery::PolynomialReDoSFlow::C>::readSetEx/3#35ac556a` ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5
                              return r1
```