### PR TITLE
C++: Use 'FeatureEqualSourceSinkCallContext' in `cpp/use-after-free` and `cpp/double-free`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/security/flowafterfree/FlowAfterFree.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/flowafterfree/FlowAfterFree.qll
@@ -51,6 +51,12 @@ signature module FlowFromFreeParamSig {
    */
   bindingset[source, sink]
   default predicate sourceSinkIsRelated(DataFlow::Node source, DataFlow::Node sink) { any() }
+
+  /**
+   * Gets a data flow configuration feature to add restrictions to the set of
+   * valid flow paths.
+   */
+  default DataFlow::FlowFeature getAFeature() { none() }
 }
 
 /**
@@ -97,6 +103,8 @@ module FlowFromFree<FlowFromFreeParamSig P> {
       or
       n.asExpr() instanceof ArrayExpr
     }
+
+    DataFlow::FlowFeature getAFeature() { result = P::getAFeature() }
   }
 
   import DataFlow::GlobalWithState<FlowFromFreeConfig>

--- a/cpp/ql/src/Critical/DoubleFree.ql
+++ b/cpp/ql/src/Critical/DoubleFree.ql
@@ -28,6 +28,10 @@ module DoubleFreeParam implements FlowFromFreeParamSig {
   predicate isExcluded = isExcludedMmFreePageFromMdl/2;
 
   predicate sourceSinkIsRelated = defaultSourceSinkIsRelated/2;
+
+  DataFlow::FlowFeature getAFeature() {
+    result instanceof DataFlow::FeatureEqualSourceSinkCallContext
+  }
 }
 
 module DoubleFree = FlowFromFree<DoubleFreeParam>;

--- a/cpp/ql/src/Critical/UseAfterFree.ql
+++ b/cpp/ql/src/Critical/UseAfterFree.ql
@@ -24,6 +24,10 @@ module UseAfterFreeParam implements FlowFromFreeParamSig {
   predicate isExcluded = isExcludedMmFreePageFromMdl/2;
 
   predicate sourceSinkIsRelated = defaultSourceSinkIsRelated/2;
+
+  DataFlow::FlowFeature getAFeature() {
+    result instanceof DataFlow::FeatureEqualSourceSinkCallContext
+  }
 }
 
 import UseAfterFreeParam


### PR DESCRIPTION
Since these queries are local only (because of the dominator/post-dominator check) we might as well tell the dataflow library this for some free speedups.