### PR TITLE
Java: add link to the source variable in the alert-message for `java/implicit-cast-in-compound-assignment`

### DIFF
--- a/java/ql/src/Likely Bugs/Arithmetic/InformationLoss.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/InformationLoss.ql
@@ -45,5 +45,5 @@ where
     v = a.getDest()
   )
 select a,
-  "Implicit cast of $@ to narrower destination type " + a.getDest().getType().getName() + ".", v,
-  "source type " + e.getType().getName()
+  "Implicit cast of source type " + e.getType().getName() + " to narrower destination type $@.", v,
+  a.getDest().getType().getName()

--- a/java/ql/src/Likely Bugs/Arithmetic/InformationLoss.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/InformationLoss.ql
@@ -27,10 +27,11 @@ class DangerousAssignOpExpr extends AssignOp {
 
 predicate problematicCasting(Type t, Expr e) { e.getType().(NumType).widerThan(t) }
 
-from DangerousAssignOpExpr a, Expr e
+from DangerousAssignOpExpr a, Expr e, Variable v
 where
   e = a.getSource() and
-  problematicCasting(a.getDest().getType(), e)
+  problematicCasting(a.getDest().getType(), e) and
+  v = a.getDest().(VarAccess).getVariable()
 select a,
-  "Implicit cast of source type " + e.getType().getName() + " to narrower destination type " +
-    a.getDest().getType().getName() + "."
+  "Implicit cast of source $@ to narrower destination type " + a.getDest().getType().getName() + ".",
+  v, "type " + e.getType().getName()

--- a/java/ql/src/Likely Bugs/Arithmetic/InformationLoss.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/InformationLoss.ql
@@ -27,11 +27,17 @@ class DangerousAssignOpExpr extends AssignOp {
 
 predicate problematicCasting(Type t, Expr e) { e.getType().(NumType).widerThan(t) }
 
+Variable getVariable(DangerousAssignOpExpr a) {
+  result = a.getDest().(VarAccess).getVariable()
+  or
+  result = a.getDest().(ArrayAccess).getArray().(VarAccess).getVariable()
+}
+
 from DangerousAssignOpExpr a, Expr e, Variable v
 where
   e = a.getSource() and
   problematicCasting(a.getDest().getType(), e) and
-  v = a.getDest().(VarAccess).getVariable()
+  v = getVariable(a)
 select a,
   "Implicit cast of source $@ to narrower destination type " + a.getDest().getType().getName() + ".",
   v, "type " + e.getType().getName()

--- a/java/ql/src/Likely Bugs/Arithmetic/InformationLoss.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/InformationLoss.ql
@@ -45,5 +45,5 @@ where
     v = a.getDest()
   )
 select a,
-  "Implicit cast of $@ to narrower destination type " + a.getDest().getType().getName() + ".",
-  v, "source type " + e.getType().getName()
+  "Implicit cast of $@ to narrower destination type " + a.getDest().getType().getName() + ".", v,
+  "source type " + e.getType().getName()

--- a/java/ql/test/query-tests/security/CWE-190/semmle/tests/InformationLoss.expected
+++ b/java/ql/test/query-tests/security/CWE-190/semmle/tests/InformationLoss.expected
@@ -1,2 +1,3 @@
 | Test.java:68:5:68:25 | ...+=... | Implicit cast of source $@ to narrower destination type int. | Test.java:64:4:64:13 | int i | type long |
 | Test.java:87:4:87:9 | ...+=... | Implicit cast of source $@ to narrower destination type int. | Test.java:81:4:81:13 | int i | type long |
+| Test.java:289:5:289:30 | ...+=... | Implicit cast of source $@ to narrower destination type int. | Test.java:285:4:285:27 | int[] arr | type long |

--- a/java/ql/test/query-tests/security/CWE-190/semmle/tests/InformationLoss.expected
+++ b/java/ql/test/query-tests/security/CWE-190/semmle/tests/InformationLoss.expected
@@ -1,3 +1,4 @@
-| Test.java:68:5:68:25 | ...+=... | Implicit cast of source $@ to narrower destination type int. | Test.java:64:4:64:13 | int i | type long |
-| Test.java:87:4:87:9 | ...+=... | Implicit cast of source $@ to narrower destination type int. | Test.java:81:4:81:13 | int i | type long |
-| Test.java:289:5:289:30 | ...+=... | Implicit cast of source $@ to narrower destination type int. | Test.java:285:4:285:27 | int[] arr | type long |
+| Test.java:68:5:68:25 | ...+=... | Implicit cast of $@ to narrower destination type int. | Test.java:64:4:64:13 | int i | source type long |
+| Test.java:87:4:87:9 | ...+=... | Implicit cast of $@ to narrower destination type int. | Test.java:81:4:81:13 | int i | source type long |
+| Test.java:289:5:289:30 | ...+=... | Implicit cast of $@ to narrower destination type int. | Test.java:285:4:285:27 | int[] arr | source type long |
+| Test.java:293:7:293:44 | ...+=... | Implicit cast of $@ to narrower destination type int. | Test.java:293:7:293:24 | ...[...] | source type long |

--- a/java/ql/test/query-tests/security/CWE-190/semmle/tests/InformationLoss.expected
+++ b/java/ql/test/query-tests/security/CWE-190/semmle/tests/InformationLoss.expected
@@ -1,4 +1,4 @@
-| Test.java:68:5:68:25 | ...+=... | Implicit cast of $@ to narrower destination type int. | Test.java:64:4:64:13 | int i | source type long |
-| Test.java:87:4:87:9 | ...+=... | Implicit cast of $@ to narrower destination type int. | Test.java:81:4:81:13 | int i | source type long |
-| Test.java:289:5:289:30 | ...+=... | Implicit cast of $@ to narrower destination type int. | Test.java:285:4:285:27 | int[] arr | source type long |
-| Test.java:293:7:293:44 | ...+=... | Implicit cast of $@ to narrower destination type int. | Test.java:293:7:293:24 | ...[...] | source type long |
+| Test.java:68:5:68:25 | ...+=... | Implicit cast of source type long to narrower destination type $@. | Test.java:64:4:64:13 | int i | int |
+| Test.java:87:4:87:9 | ...+=... | Implicit cast of source type long to narrower destination type $@. | Test.java:81:4:81:13 | int i | int |
+| Test.java:289:5:289:30 | ...+=... | Implicit cast of source type long to narrower destination type $@. | Test.java:285:4:285:27 | int[] arr | int |
+| Test.java:293:7:293:44 | ...+=... | Implicit cast of source type long to narrower destination type $@. | Test.java:293:7:293:24 | ...[...] | int |

--- a/java/ql/test/query-tests/security/CWE-190/semmle/tests/InformationLoss.expected
+++ b/java/ql/test/query-tests/security/CWE-190/semmle/tests/InformationLoss.expected
@@ -1,2 +1,2 @@
-| Test.java:68:5:68:25 | ...+=... | Implicit cast of source type long to narrower destination type int. |
-| Test.java:87:4:87:9 | ...+=... | Implicit cast of source type long to narrower destination type int. |
+| Test.java:68:5:68:25 | ...+=... | Implicit cast of source $@ to narrower destination type int. | Test.java:64:4:64:13 | int i | type long |
+| Test.java:87:4:87:9 | ...+=... | Implicit cast of source $@ to narrower destination type int. | Test.java:81:4:81:13 | int i | type long |

--- a/java/ql/test/query-tests/security/CWE-190/semmle/tests/Test.java
+++ b/java/ql/test/query-tests/security/CWE-190/semmle/tests/Test.java
@@ -279,6 +279,16 @@ class Test {
 			// subsequently cast to narrower type int
 			int widenedThenNarrowed = (int) (data2 + 10L);
 		}
+
+    // InformationLoss
+		{
+			int[] arr = new int[10];
+			while (arr[2] < 1000000) {
+				// BAD: getLargeNumber is implicitly narrowed to an integer
+				// which will result in overflows if it is large
+				arr[2] += getLargeNumber();
+			}
+		}
 	}
 
 	public static long getLargeNumber() {

--- a/java/ql/test/query-tests/security/CWE-190/semmle/tests/Test.java
+++ b/java/ql/test/query-tests/security/CWE-190/semmle/tests/Test.java
@@ -288,12 +288,19 @@ class Test {
 				// which will result in overflows if it is large
 				arr[2] += getLargeNumber();
 			}
+
+      // BAD.
+      getAnIntArray()[0] += getLargeNumber();
 		}
 	}
 
 	public static long getLargeNumber() {
 		return Long.MAX_VALUE / 2;
 	}
+
+  public static int[] getAnIntArray() {
+    return new int[10];
+  }
 
 	public static boolean properlyBounded(int i) {
 		return i < Integer.MAX_VALUE;


### PR DESCRIPTION
I'm not at all sure if this is the right approach.  

I saw an (internal) alert, where I noticed that the alert-location was very different from the location that needed to be modified to fix the alert, so I've tried to add a link that should link to the variable declaration (if relevant).  

[An evaluation](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/PR-16128-0-java__2/reports) confirms that there is no change in results or performance.  
The only thing that's changed is the alert-message.  

What do you think?