### PR TITLE
Docs: Remove Swift version in footnote

### DIFF
--- a/docs/codeql/reusables/supported-versions-compilers.rst
+++ b/docs/codeql/reusables/supported-versions-compilers.rst
@@ -39,5 +39,5 @@
     .. [8] JSX and Flow code, YAML, JSON, HTML, and XML files may also be analyzed with JavaScript files.
     .. [9] The extractor requires Python 3 to run. To analyze Python 2.7 you should install both versions of Python.
     .. [10] Requires glibc 2.17.
-    .. [11] Swift support is currently in beta. Support for the analysis of Swift 5.4-5.8.1 requires macOS or Linux.
+    .. [11] Swift support is currently in beta. Support for the analysis of Swift requires macOS or Linux.
     .. [12] TypeScript analysis is performed by running the JavaScript extractor with TypeScript enabled. This is the default.


### PR DESCRIPTION
The footnote wasn't properly updated in https://github.com/github/codeql/pull/16133. @turbo suggested that we simply remove the version number from the footnote to avoid making this mistake again.