### PR TITLE
C++: Add alias models for `fopen` and friends

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/models/Models.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/Models.qll
@@ -41,3 +41,4 @@ private import implementations.SqLite3
 private import implementations.PostgreSql
 private import implementations.System
 private import implementations.StructuredExceptionHandling
+private import implementations.Fopen

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Fopen.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Fopen.qll
@@ -3,7 +3,6 @@
  * functions. See `semmle.code.cpp.models.Models` for usage information.
  */
 
-import semmle.code.cpp.Function
 import semmle.code.cpp.models.interfaces.Alias
 import semmle.code.cpp.models.interfaces.SideEffect
 

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Fopen.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Fopen.qll
@@ -1,0 +1,51 @@
+/**
+ * Provides implementation classes modeling `fopen` and various similar
+ * functions. See `semmle.code.cpp.models.Models` for usage information.
+ */
+
+import semmle.code.cpp.Function
+import semmle.code.cpp.models.interfaces.Alias
+import semmle.code.cpp.models.interfaces.SideEffect
+
+/** The function `fopen` and friends. */
+private class Fopen extends Function, AliasFunction, SideEffectFunction {
+  Fopen() {
+    this.hasGlobalOrStdName(["fopen", "fopen_s", "freopen"])
+    or
+    this.hasGlobalName(["_open", "_wfopen", "_fsopen", "_wfsopen", "_wopen"])
+  }
+
+  override predicate hasOnlySpecificWriteSideEffects() { any() }
+
+  override predicate hasOnlySpecificReadSideEffects() { any() }
+
+  override predicate parameterEscapesOnlyViaReturn(int i) { none() }
+
+  override predicate parameterNeverEscapes(int index) {
+    // None of the parameters escape
+    this.getParameter(index).getUnspecifiedType() instanceof PointerType
+  }
+
+  override predicate hasSpecificReadSideEffect(ParameterIndex i, boolean buffer) {
+    (
+      this.hasGlobalOrStdName(["fopen", "fopen_s"])
+      or
+      this.hasGlobalName(["_wfopen", "_fsopen", "_wfsopen"])
+    ) and
+    i = [0, 1] and
+    buffer = true
+    or
+    this.hasGlobalOrStdName("freopen") and
+    (
+      i = [0, 1] and
+      buffer = true
+      or
+      i = 2 and
+      buffer = false
+    )
+    or
+    this.hasGlobalName(["_open", "_wopen"]) and
+    i = 0 and
+    buffer = true
+  }
+}


### PR DESCRIPTION
These will prevent the one query result regression I'm seeing when enabling sound IR.

I'm not adding any interesting taint here or anything. The class merely states that `fopen` and friends don't cause arguments to escape. A future PR could probably add taint flow for these functions, but I want to keep this PR minimal as it's blocking sound IR.

DCA shows some new FPs for `cpp/uninitialized-local`, but these will all disappear once sound IR is merged. I'll open that PR as soon as this one is merged.