### PR TITLE
CI: apply `setup-swift` workaround

### DIFF
--- a/swift/actions/run-integration-tests/action.yml
+++ b/swift/actions/run-integration-tests/action.yml
@@ -7,7 +7,7 @@ runs:
     - uses: actions/setup-python@v4
       with:
         python-version-file: 'swift/.python-version'
-    - uses: swift-actions/setup-swift@65540b95f51493d65f5e59e97dcef9629ddf11bf
+    - uses: redsun82/setup-swift@b2b6f77ab14f6a9b136b520dc53ec8eca27d2b99
       with:
         swift-version: "5.8"
     - uses: ./.github/actions/fetch-codeql


### PR DESCRIPTION
This uses [this workaround](https://github.com/redsun82/setup-swift/commit/b2b6f77ab14f6a9b136b520dc53ec8eca27d2b99) for https://github.com/swift-actions/setup-swift/issues/591.