### PR TITLE
Ruby: prototype instantiation of graph export

### DIFF
--- a/config/identical-files.json
+++ b/config/identical-files.json
@@ -333,6 +333,10 @@
     "ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModelsExtensions.qll",
     "python/ql/lib/semmle/python/frameworks/data/internal/ApiGraphModelsExtensions.qll"
   ],
+  "ApiGraphModelsExport": [
+    "javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsExport.qll",
+    "ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModelsExport.qll"
+  ],
   "Swift declarations test file": [
     "swift/ql/test/extractor-tests/declarations/declarations.swift",
     "swift/ql/test/library-tests/ast/declarations.swift"

--- a/javascript/ql/test/library-tests/ModelGeneration/ModelGeneration.expected
+++ b/javascript/ql/test/library-tests/ModelGeneration/ModelGeneration.expected
@@ -7,9 +7,8 @@ typeModel
 | (aliases).Alias1.prototype | (aliases).Alias1 | Instance |
 | (aliases).Alias1.prototype | (aliases).Alias1.prototype.foo | ReturnValue |
 | (aliases).Alias1.prototype.foo | (aliases).Alias1.prototype | Member[foo] |
-| (long-access-path).a.shortcut.d | (long-access-path) | Member[a].Member[b].Member[c].Member[d] |
-| (long-access-path).a.shortcut.d | (long-access-path) | Member[a].Member[shortcut].Member[d] |
-| (long-access-path).a.shortcut.d.e | (long-access-path).a.shortcut.d | Member[e] |
+| (long-access-path).a.shortcut.d.e | (long-access-path) | Member[a].Member[b].Member[c].Member[d].Member[e] |
+| (long-access-path).a.shortcut.d.e | (long-access-path) | Member[a].Member[shortcut].Member[d].Member[e] |
 | (reexport).func | (reexport) | Member[func] |
 | (return-this).FluentInterface | (return-this) | Member[FluentInterface] |
 | (return-this).FluentInterface.prototype | (return-this).FluentInterface | Instance |

--- a/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
+++ b/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
@@ -1047,15 +1047,29 @@ module API {
 
     import MkShared
 
-    /** Gets the API node corresponding to the module/class object for `mod`. */
+    /** Gets the API node corresponding to the module/class object for `mod`, with epsilon edges to descendent modules/classes. */
     bindingset[mod]
     pragma[inline_late]
     Node getModuleNode(DataFlow::ModuleNode mod) { result = Impl::MkModuleObjectDown(mod) }
 
-    /** Gets the API node corresponding to instances of `mod`. */
+    /** Gets the API node corresponding to instances of `mod`, with epsilon edges to instances of descendent modules/classes. */
     bindingset[mod]
     pragma[inline_late]
     Node getModuleInstance(DataFlow::ModuleNode mod) { result = getModuleNode(mod).getInstance() }
+
+    /** Gets the API node corresponding to instances of `mod` with epsilon edges to ancestor modules/classes. */
+    bindingset[mod]
+    pragma[inline_late]
+    Node getModuleNodeUp(DataFlow::ModuleNode mod) { result = Impl::MkModuleObjectUp(mod) }
+
+    /** Gets the API node corresponding to instances of `mod`, with epsilon edges to instances of ancestor modules/classes. */
+    bindingset[mod]
+    pragma[inline_late]
+    Node getModuleInstanceUp(DataFlow::ModuleNode mod) {
+      result = getModuleNodeUp(mod).getInstance()
+    }
+
+    import Impl
   }
 
   private import Internal

--- a/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModelsExport.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModelsExport.qll
@@ -1,0 +1,124 @@
+/**
+ * Contains an extension of `GraphExport` that relies on API graph specific functionality.
+ */
+
+private import ApiGraphModels as Shared
+private import codeql.mad.dynamic.GraphExport
+private import ApiGraphModelsSpecific as Specific
+
+private module API = Specific::API;
+
+private import Shared
+
+/**
+ * Holds if some proper prefix of `(type, path)` evaluated to `node`, where `remainingPath`
+ * is bound to the suffix of `path` that was not evaluated yet.
+ */
+bindingset[type, path]
+predicate partiallyEvaluatedModel(string type, string path, API::Node node, string remainingPath) {
+  exists(int n, AccessPath accessPath |
+    accessPath = path and
+    getNodeFromPath(type, accessPath, n) = node and
+    n > 0 and
+    // Note that `n < accessPath.getNumToken()` is implied by the use of strictconcat()
+    remainingPath =
+      strictconcat(int k |
+        k = [n .. accessPath.getNumToken() - 1]
+      |
+        accessPath.getToken(k), "." order by k
+      )
+  )
+}
+
+/**
+ * Holds if `type` and all types leading to `type` should be re-exported.
+ */
+signature predicate shouldContainTypeSig(string type);
+
+/**
+ * Wrapper around `GraphExport` that also exports information about re-exported types.
+ *
+ * ### JavaScript example 1
+ * For example, suppose `shouldContainType("foo")` holds, and the following is the entry point for a package `bar`:
+ * ```js
+ * // bar.js
+ * module.exports.xxx = require('foo');
+ * ```
+ * then this would generate the following type model:
+ * ```
+ * foo; bar; Member[xxx]
+ * ```
+ *
+ * ### JavaScript example 2
+ * For a more complex case, suppose the following type model exists:
+ * ```
+ * foo.XYZ; foo; Member[x].Member[y].Member[z]
+ * ```
+ * And the package exports something that matches a prefix of the access path above:
+ * ```js
+ * module.exports.blah = require('foo').x.y;
+ * ```
+ * This would result in the following type model:
+ * ```
+ * foo.XYZ; bar; Member[blah].Member[z]
+ * ```
+ * Notice that the access path `Member[blah].Member[z]` consists of an access path generated from the API
+ * graph, with pieces of the access path from the original type model appended to it.
+ */
+module TypeGraphExport<
+  GraphExportSig<Specific::Location, API::Node> S, shouldContainTypeSig/1 shouldContainType>
+{
+  /** Like `shouldContainType` but includes types that lead to `type` via type models. */
+  private predicate shouldContainTypeEx(string type) {
+    shouldContainType(type)
+    or
+    exists(string prevType |
+      shouldContainType(prevType) and
+      Shared::typeModel(prevType, type, _)
+    )
+  }
+
+  private module Config implements GraphExportSig<Specific::Location, API::Node> {
+    import S
+
+    predicate shouldContain(API::Node node) {
+      S::shouldContain(node)
+      or
+      exists(string type1 | shouldContainTypeEx(type1) |
+        ModelOutput::getATypeNode(type1).getAValueReachableFromSource() = node.asSink()
+        or
+        exists(string type2, string path |
+          Shared::typeModel(type1, type2, path) and
+          getNodeFromPath(type2, path, _).getAValueReachableFromSource() = node.asSink()
+        )
+      )
+    }
+  }
+
+  private module ExportedGraph = GraphExport<Specific::Location, API::Node, Config>;
+
+  import ExportedGraph
+
+  /**
+   * Holds if `type1, type2, path` should be emitted as a type model, that is `(type2, path)` leads to an instance of `type1`.
+   */
+  predicate typeModel(string type1, string type2, string path) {
+    ExportedGraph::typeModel(type1, type2, path)
+    or
+    shouldContainTypeEx(type1) and
+    exists(API::Node node |
+      // A relevant type is exported directly
+      Specific::sourceFlowsToSink(ModelOutput::getATypeNode(type1), node) and
+      ExportedGraph::pathToNode(type2, path, node)
+      or
+      // Something that leads to a relevant type, but didn't finish its access path, is exported
+      exists(string midType, string midPath, string remainingPath, string prefix, API::Node source |
+        Shared::typeModel(type1, midType, midPath) and
+        partiallyEvaluatedModel(midType, midPath, source, remainingPath) and
+        Specific::sourceFlowsToSink(source, node) and
+        ExportedGraph::pathToNode(type2, prefix, node) and
+        path = join(prefix, remainingPath)
+      )
+    )
+  }
+}

--- a/ruby/ql/lib/codeql/ruby/typetracking/ApiGraphShared.qll
+++ b/ruby/ql/lib/codeql/ruby/typetracking/ApiGraphShared.qll
@@ -144,6 +144,8 @@ module ApiGraphShared<ApiGraphSharedSig S> {
 
   private import Cached
 
+  predicate epsilonEdge = Cached::epsilonEdge/2;
+
   /** Gets an API node corresponding to the end of forward-tracking to `localSource`. */
   pragma[nomagic]
   private ApiNode forwardEndNode(DataFlow::LocalSourceNode localSource) {

--- a/ruby/ql/test/query-tests/utils/modeleditor/GenerateModel.expected
+++ b/ruby/ql/test/query-tests/utils/modeleditor/GenerateModel.expected
@@ -1,7 +1,8 @@
 sourceModel
 sinkModel
+summaryModel
+| A! | Method[new] | Argument[0] | ReturnValue | value |
 typeVariableModel
 typeModel
 | M1 | B |  |
-summaryModel
-| A! | Method[new] | Argument[0] | ReturnValue | value |
+| M1! | B! |  |

--- a/shared/mad/codeql/mad/dynamic/GraphExport.qll
+++ b/shared/mad/codeql/mad/dynamic/GraphExport.qll
@@ -301,4 +301,30 @@ module GraphExport<
       kind = "type"
     )
   }
+
+  /** Predicates for debugging purposes. */
+  private module Debug {
+    private predicate edgeToUnnamedNode(RelevantNode pred, RelevantNode succ) {
+      exposedEdge(pred, _, succ) and
+      not nodeMustBeNamed(succ)
+    }
+
+    /**
+     * Holds if `node` is part of a cycle with a non-empty path string that is not broken
+     * by a named node -- this leads to divergence in `pathToNode`.
+     */
+    predicate cycle(RelevantNode pred, string step, RelevantNode succ) {
+      exposedEdge(pred, step, succ) and
+      step != "" and
+      not nodeMustBeNamed(pred) and
+      not nodeMustBeNamed(succ) and
+      edgeToUnnamedNode*(succ, pred)
+    }
+
+    /** Holds if `node` should be named could not be named. */
+    predicate missingNodeName(RelevantNode node) {
+      nodeMustBeNamed(node) and
+      not exists(getNodeName(node))
+    }
+  }
 }


### PR DESCRIPTION
Based on [this PR](https://github.com/github/codeql/pull/15386). Contains a prototype instantiation of Ruby.