### PR TITLE
Go: Avoid magic in `TSynthLocation` definition

### DIFF
--- a/go/ql/lib/semmle/go/internal/Locations.qll
+++ b/go/ql/lib/semmle/go/internal/Locations.qll
@@ -11,11 +11,18 @@ newtype TLocation =
   TSynthLocation(string filepath, int startline, int startcolumn, int endline, int endcolumn) {
     any(DataFlow::Node n).hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn) and
     // avoid overlap with existing DB locations
-    not exists(File f |
-      locations_default(_, f, startline, startcolumn, endline, endcolumn) and
-      f.getAbsolutePath() = filepath
-    )
+    not existingDBLocation(filepath, startline, startcolumn, endline, endcolumn)
   }
+
+pragma[nomagic]
+private predicate existingDBLocation(
+  string filepath, int startline, int startcolumn, int endline, int endcolumn
+) {
+  exists(File f |
+    locations_default(_, f, startline, startcolumn, endline, endcolumn) and
+    f.getAbsolutePath() = filepath
+  )
+}
 
 /**
  * A location as given by a file, a start line, a start column,


### PR DESCRIPTION
This fixes a performance problem in code introduced in https://github.com/github/codeql/pull/15853. The below numbers were obtained on `dolthub/go-mysql-server`, but I have seen the evaluator do the same optimizations on other projects.

Before:
```
[2024-04-10 11:18:51] Evaluated non-recursive predicate _Files::File#0e2ffa35_files_locations_default_23451#join_rhs_project#DataFlowUtil::Node.hasLocationI__#antijoin_rhs@212c1fm6 in 23595ms (size: 14907567).
Evaluated relational algebra for predicate _Files::File#0e2ffa35_files_locations_default_23451#join_rhs_project#DataFlowUtil::Node.hasLocationI__#antijoin_rhs@212c1fm6 with tuple counts:
          15168020  ~1%    {5} r1 = SCAN `project#DataFlowUtil::Node.hasLocationInfo/5#dispred#c7d73140` OUTPUT In.1, In.2, In.3, In.4, In.0
        1109162913  ~0%    {6}    | JOIN WITH locations_default_23451#join_rhs ON FIRST 4 OUTPUT Rhs.4, Lhs.4, Lhs.0, Lhs.1, Lhs.2, Lhs.3
        1109162913  ~0%    {6}    | JOIN WITH Files::File#0e2ffa35 ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5
          14907567  ~3%    {5}    | JOIN WITH files ON FIRST 2 OUTPUT Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5
                           return r1

[2024-04-10 11:18:51] Evaluated non-recursive predicate Locations::TSynthLocation#dom#f60a866c@e1167267 in 185ms (size: 260453).
Evaluated relational algebra for predicate Locations::TSynthLocation#dom#f60a866c@e1167267 with tuple counts:
        260453  ~0%    {5} r1 = `project#DataFlowUtil::Node.hasLocationInfo/5#dispred#c7d73140` AND NOT `_Files::File#0e2ffa35_files_locations_default_23451#join_rhs_project#DataFlowUtil::Node.hasLocationI__#antijoin_rhs`(FIRST 5)
                       return r1
```

After:
```
[2024-04-10 11:25:05] Evaluated non-recursive predicate Locations::existingDBLocation/5#b5f0485e@3d82ceb2 in 1124ms (size: 15766196).
Evaluated relational algebra for predicate Locations::existingDBLocation/5#b5f0485e@3d82ceb2 with tuple counts:
            1085  ~2%    {2} r1 = JOIN files WITH Files::File#0e2ffa35 ON FIRST 1 OUTPUT Lhs.0, Lhs.1
        15766196  ~2%    {5}    | JOIN WITH locations_default_12345#join_rhs ON FIRST 1 OUTPUT Lhs.1, Rhs.1, Rhs.2, Rhs.3, Rhs.4
                         return r1
```
and
```
[2024-04-10 11:25:06] Evaluated non-recursive predicate Locations::TSynthLocation#dom#f60a866c@c135e0ga in 248ms (size: 260453).
Evaluated relational algebra for predicate Locations::TSynthLocation#dom#f60a866c@c135e0ga with tuple counts:
        260453  ~0%    {5} r1 = `project#DataFlowUtil::Node.hasLocationInfo/5#dispred#c7d73140` AND NOT `Locations::existingDBLocation/5#b5f0485e`(FIRST 5)
                       return r1
```