### PR TITLE
RB: don't mention arrays in the qhelp for rb/shell-command-constructed-from-input

### DIFF
--- a/ruby/ql/src/queries/security/cwe-078/UnsafeShellCommandConstruction.qhelp
+++ b/ruby/ql/src/queries/security/cwe-078/UnsafeShellCommandConstruction.qhelp
@@ -20,9 +20,14 @@
 <recommendation>
 
 	<p>
-		If possible, provide the dynamic arguments to the shell as an array 
+		If possible, avoid concatenating shell strings
 		to APIs such as <code>system(..)</code> to avoid interpretation by the shell.
 	</p>
+
+    <p>
+        Instead, provide the arguments to the shell command as separate arguments to the
+        API, such as <code>system("echo", arg1, arg2)</code>.
+    </p>
 
 	<p>
 		Alternatively, if the shell command must be constructed

--- a/ruby/ql/src/queries/security/cwe-078/examples/unsafe-shell-command-construction_fixed.rb
+++ b/ruby/ql/src/queries/security/cwe-078/examples/unsafe-shell-command-construction_fixed.rb
@@ -1,6 +1,6 @@
 module Utils 
     def download(path)
-        # using an array to call `system` is safe
+        # using an API that doesn't interpret the path as a shell command
         system("wget", path) # OK
     end
 end


### PR DESCRIPTION
The `Kernel::system(...)` call does not accept an array as input, so the QHelp should not mention arrays.  