### PR TITLE
Bazel: `swift/third_party/load.bzl` cleanup and `bazel mod tidy` enablement

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -31,6 +31,8 @@ pip.parse(
 use_repo(pip, "codegen_deps")
 
 swift_deps = use_extension("//swift/third_party:load.bzl", "swift_deps")
+
+# following list can be kept in sync with `bazel mod tidy`
 use_repo(
     swift_deps,
     "binlog",

--- a/swift/third_party/load.bzl
+++ b/swift/third_party/load.bzl
@@ -40,7 +40,7 @@ def _get_toolchain_url(info):
         info.extension,
     )
 
-def _toolchains(repository_name):
+def _toolchains():
     rules = {
         "tar.gz": http_archive,
         "pkg": _pkg_archive,
@@ -51,7 +51,7 @@ def _toolchains(repository_name):
             name = "swift_toolchain_%s" % arch,
             url = _get_toolchain_url(info),
             sha256 = info.sha,
-            build_file = _build(repository_name, "swift-toolchain-%s" % arch),
+            build_file = _build % "swift-toolchain-%s" % arch,
             strip_prefix = "%s-%s" % (_swift_version, info.suffix),
         )
 
@@ -109,10 +109,9 @@ def _github_archive(*, name, repository, commit, build_file = None, sha256 = Non
         sha256 = sha256,
     )
 
-def _build(repository_name, package):
-    return "@%s//swift/third_party:BUILD.%s.bazel" % (repository_name, package)
+_build = "//swift/third_party:BUILD.%s.bazel"
 
-def load_dependencies(module_ctx = None, repository_name = "codeql"):
+def load_dependencies(module_ctx):
     for repo_arch, arch in _swift_arch_map.items():
         sha256 = _swift_sha_map[repo_arch]
 
@@ -122,15 +121,15 @@ def load_dependencies(module_ctx = None, repository_name = "codeql"):
                 _swift_prebuilt_version,
                 repo_arch,
             ),
-            build_file = _build(repository_name, "swift-llvm-support"),
+            build_file = _build % "swift-llvm-support",
             sha256 = sha256,
         )
 
-    _toolchains(repository_name)
+    _toolchains()
 
     _github_archive(
         name = "picosha2",
-        build_file = _build(repository_name, "picosha2"),
+        build_file = _build % "picosha2",
         repository = "okdshin/PicoSHA2",
         commit = "27fcf6979298949e8a462e16d09a0351c18fcaf2",
         sha256 = "d6647ca45a8b7bdaf027ecb68d041b22a899a0218b7206dee755c558a2725abb",
@@ -138,34 +137,15 @@ def load_dependencies(module_ctx = None, repository_name = "codeql"):
 
     _github_archive(
         name = "binlog",
-        build_file = _build(repository_name, "binlog"),
+        build_file = _build % "binlog",
         repository = "morganstanley/binlog",
         commit = "3fef8846f5ef98e64211e7982c2ead67e0b185a6",
         sha256 = "f5c61d90a6eff341bf91771f2f465be391fd85397023e1b391c17214f9cbd045",
     )
 
-    if module_ctx == None:
-        # legacy workspace loading, remove when transition is complete
-        _github_archive(
-            name = "absl",
-            repository = "abseil/abseil-cpp",
-            commit = "d2c5297a3c3948de765100cb7e5cccca1210d23c",
-            sha256 = "735a9efc673f30b3212bfd57f38d5deb152b543e35cd58b412d1363b15242049",
-        )
-
-        _github_archive(
-            name = "json",
-            repository = "nlohmann/json",
-            commit = "6af826d0bdb55e4b69e3ad817576745335f243ca",
-            sha256 = "702bb0231a5e21c0374230fed86c8ae3d07ee50f34ffd420e7f8249854b7d85b",
-        )
-
-        _github_archive(
-            name = "fmt",
-            repository = "fmtlib/fmt",
-            build_file = _build(repository_name, "fmt"),
-            commit = "a0b8a92e3d1532361c2f7feb63babc5c18d00ef2",
-            sha256 = "ccf872fd4aa9ab3d030d62cffcb258ca27f021b2023a0244b2cf476f984be955",
-        )
+    return module_ctx.extension_metadata(
+        root_module_direct_deps = "all",
+        root_module_direct_dev_deps = [],
+    )
 
 swift_deps = module_extension(load_dependencies)


### PR DESCRIPTION
The cleanup has to do with `repository_name` not being required any more, and some other unused code now that `semmle-code` is using bzlmod.