### PR TITLE
Go: Add integration test library

### DIFF
--- a/go/integration-tests-lib/go_integration_test.py
+++ b/go/integration-tests-lib/go_integration_test.py
@@ -1,0 +1,18 @@
+import os
+from create_database_utils import *
+from diagnostics_test_utils import *
+
+def go_integration_test(source = "src"):
+  # Set up a GOPATH relative to this test's root directory;
+  # we set os.environ instead of using extra_env because we
+  # need it to be set for the call to "go clean -modcache" later
+  goPath = os.path.join(os.path.abspath(os.getcwd()), ".go")
+  os.environ['GOPATH'] = goPath
+
+  run_codeql_database_create([], lang="go", source=source)
+
+  check_diagnostics()
+
+  # Clean up the temporary GOPATH to prevent Bazel failures next
+  # time the tests are run; see https://github.com/golang/go/issues/27161
+  subprocess.call(["go", "clean", "-modcache"])


### PR DESCRIPTION
We currently have a lot of code duplication in the Python sources for the Go integration tests. This PR adds some of the common Python code to a shared location, mirroring what is already done for Java. This shared code will later be usable by all integration tests to avoid code duplication. 

Note that there is an internal PR to accompany this one. However, this PR does not depend on the internal one (in the sense that it doesn't do anything either way) and can be merged without it.