### PR TITLE
Swift: add `shared/**` to CI triggers

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -6,6 +6,7 @@ on:
       - "swift/**"
       - "misc/bazel/**"
       - "misc/codegen/**"
+      - "shared/**"
       - "*.bazel*"
       - .github/workflows/swift.yml
       - .github/actions/**
@@ -22,10 +23,12 @@ on:
       - "swift/**"
       - "misc/bazel/**"
       - "misc/codegen/**"
+      - "shared/**"
       - "*.bazel*"
       - .github/workflows/swift.yml
       - .github/actions/**
       - codeql-workspace.yml
+      - .pre-commit-config.yaml
       - "!**/*.md"
       - "!**/*.qhelp"
     branches:


### PR DESCRIPTION
Not being triggered by changes in shared was making it possible to not notice changes in `shared` having effect on Swift tests. For example [this PR](https://github.com/github/codeql/pull/15501) introduced a test change that was fixed [here](https://github.com/github/codeql/pull/16197).