### PR TITLE
C#: Logging

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/AssemblyLookupLocation.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/AssemblyLookupLocation.cs
@@ -43,7 +43,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                     }
                     else
                     {
-                        logger.LogInfo($"AssemblyLookupLocation: Skipping {dll.FullName}.");
+                        logger.LogDebug($"AssemblyLookupLocation: Skipping {dll.FullName}.");
                     }
                 }
             }
@@ -68,19 +68,19 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 }
                 else
                 {
-                    logger.LogInfo($"AssemblyLookupLocation: Skipping {path}.");
+                    logger.LogDebug($"AssemblyLookupLocation: Skipping {path}.");
                 }
                 return dllsToIndex;
             }
 
             if (Directory.Exists(path))
             {
-                logger.LogInfo($"AssemblyLookupLocation: Finding reference DLLs in {path}...");
+                logger.LogDebug($"AssemblyLookupLocation: Finding reference DLLs in {path}...");
                 AddReferenceDirectory(dllsToIndex, logger);
             }
             else
             {
-                logger.LogInfo("AssemblyLookupLocation: Path not found: " + path);
+                logger.LogDebug("AssemblyLookupLocation: Path not found: " + path);
             }
             return dllsToIndex;
         }

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
@@ -141,12 +141,12 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             // Output the findings
             foreach (var r in usedReferences.Keys.OrderBy(r => r))
             {
-                logger.LogInfo($"Resolved reference {r}");
+                logger.LogDebug($"Resolved reference {r}");
             }
 
             foreach (var r in unresolvedReferences.OrderBy(r => r.Key))
             {
-                logger.LogInfo($"Unresolved reference {r.Key} in project {r.Value}");
+                logger.LogDebug($"Unresolved reference {r.Key} in project {r.Value}");
             }
 
             var webViewExtractionOption = Environment.GetEnvironmentVariable(EnvironmentVariableNames.WebViewGeneration);
@@ -253,7 +253,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                     if (isInAnalyzersFolder)
                     {
                         usedReferences.Remove(filename);
-                        logger.LogInfo($"Removed analyzer reference {filename}");
+                        logger.LogDebug($"Removed analyzer reference {filename}");
                     }
                 }
             }
@@ -265,19 +265,19 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             if (versionFolders.Length > 1)
             {
                 var versions = string.Join(", ", versionFolders.Select(d => d.Name));
-                logger.LogInfo($"Found multiple {frameworkType} DLLs in NuGet packages at {frameworkPath}. Using the latest version ({versionFolders[0].Name}) from: {versions}.");
+                logger.LogDebug($"Found multiple {frameworkType} DLLs in NuGet packages at {frameworkPath}. Using the latest version ({versionFolders[0].Name}) from: {versions}.");
             }
 
             var selectedFrameworkFolder = versionFolders.FirstOrDefault()?.FullName;
             if (selectedFrameworkFolder is null)
             {
-                logger.LogInfo($"Found {frameworkType} DLLs in NuGet packages at {frameworkPath}, but no version folder was found.");
+                logger.LogDebug($"Found {frameworkType} DLLs in NuGet packages at {frameworkPath}, but no version folder was found.");
                 selectedFrameworkFolder = frameworkPath;
             }
 
             dllLocations.Add(selectedFrameworkFolder);
             frameworkLocations.Add(selectedFrameworkFolder);
-            logger.LogInfo($"Found {frameworkType} DLLs in NuGet packages at {selectedFrameworkFolder}.");
+            logger.LogDebug($"Found {frameworkType} DLLs in NuGet packages at {selectedFrameworkFolder}.");
         }
 
         private static DirectoryInfo[] GetPackageVersionSubDirectories(string packagePath)
@@ -361,7 +361,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             foreach (var path in toRemove)
             {
                 dllLocations.Remove(path);
-                logger.LogInfo($"Removed reference {path}");
+                logger.LogDebug($"Removed reference {path}");
             }
         }
 
@@ -561,7 +561,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 if (resolvedInfo.Version != r.Version || resolvedInfo.NetCoreVersion != r.NetCoreVersion)
                 {
                     var asm = resolvedInfo.Id + (resolvedInfo.NetCoreVersion is null ? "" : $" (.NET Core {resolvedInfo.NetCoreVersion})");
-                    logger.LogInfo($"Resolved {r.Id} as {asm}");
+                    logger.LogDebug($"Resolved {r.Id} as {asm}");
 
                     ++conflictedReferences;
                 }

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNet.cs
@@ -35,7 +35,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
         private void Info()
         {
-            var res = dotnetCliInvoker.RunCommand("--info");
+            var res = dotnetCliInvoker.RunCommand("--info", silent: false);
             if (!res)
             {
                 throw new Exception($"{dotnetCliInvoker.Exec} --info failed.");
@@ -91,13 +91,13 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             return dotnetCliInvoker.RunCommand(args);
         }
 
-        public IList<string> GetListedRuntimes() => GetResultList("--list-runtimes");
+        public IList<string> GetListedRuntimes() => GetResultList("--list-runtimes", null, false);
 
-        public IList<string> GetListedSdks() => GetResultList("--list-sdks");
+        public IList<string> GetListedSdks() => GetResultList("--list-sdks", null, false);
 
-        private IList<string> GetResultList(string args, string? workingDirectory = null)
+        private IList<string> GetResultList(string args, string? workingDirectory = null, bool silent = true)
         {
-            if (dotnetCliInvoker.RunCommand(args, workingDirectory, out var results))
+            if (dotnetCliInvoker.RunCommand(args, workingDirectory, out var results, silent))
             {
                 return results;
             }

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNetCliInvoker.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNetCliInvoker.cs
@@ -40,13 +40,13 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             return startInfo;
         }
 
-        private bool RunCommandAux(string args, string? workingDirectory, out IList<string> output)
+        private bool RunCommandAux(string args, string? workingDirectory, out IList<string> output, bool silent)
         {
             var dirLog = string.IsNullOrWhiteSpace(workingDirectory) ? "" : $" in {workingDirectory}";
             logger.LogInfo($"Running {Exec} {args}{dirLog}");
             var pi = MakeDotnetStartInfo(args, workingDirectory);
             var threadId = Environment.CurrentManagedThreadId;
-            void onOut(string s) => logger.LogInfo(s, threadId);
+            void onOut(string s) => logger.Log(silent ? Severity.Debug : Severity.Info, s, threadId);
             void onError(string s) => logger.LogError(s, threadId);
             var exitCode = pi.ReadOutput(out output, onOut, onError);
             if (exitCode != 0)
@@ -57,13 +57,13 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             return true;
         }
 
-        public bool RunCommand(string args) =>
-            RunCommandAux(args, null, out _);
+        public bool RunCommand(string args, bool silent) =>
+            RunCommandAux(args, null, out _, silent);
 
-        public bool RunCommand(string args, out IList<string> output) =>
-            RunCommandAux(args, null, out output);
+        public bool RunCommand(string args, out IList<string> output, bool silent) =>
+            RunCommandAux(args, null, out output, silent);
 
-        public bool RunCommand(string args, string? workingDirectory, out IList<string> output) =>
-            RunCommandAux(args, workingDirectory, out output);
+        public bool RunCommand(string args, string? workingDirectory, out IList<string> output, bool silent) =>
+            RunCommandAux(args, workingDirectory, out output, silent);
     }
 }

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/IDotNetCliInvoker.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/IDotNetCliInvoker.cs
@@ -11,19 +11,22 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
         /// <summary>
         /// Execute `dotnet <args>` and return true if the command succeeded, otherwise false.
+        /// If `silent` is true the output of the command is logged as `debug` otherwise as `info`.
         /// </summary>
-        bool RunCommand(string args);
+        bool RunCommand(string args, bool silent = true);
 
         /// <summary>
         /// Execute `dotnet <args>` and return true if the command succeeded, otherwise false.
         /// The output of the command is returned in `output`.
+        /// If `silent` is true the output of the command is logged as `debug` otherwise as `info`.
         /// </summary>
-        bool RunCommand(string args, out IList<string> output);
+        bool RunCommand(string args, out IList<string> output, bool silent = true);
 
         /// <summary>
         /// Execute `dotnet <args>` in `<workingDirectory>` and return true if the command succeeded, otherwise false.
         /// The output of the command is returned in `output`.
+        /// If `silent` is true the output of the command is logged as `debug` otherwise as `info`.
         /// </summary>
-        bool RunCommand(string args, string? workingDirectory, out IList<string> output);
+        bool RunCommand(string args, string? workingDirectory, out IList<string> output, bool silent = true);
     }
 }

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetExeWrapper.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetExeWrapper.cs
@@ -175,7 +175,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             };
 
             var threadId = Environment.CurrentManagedThreadId;
-            void onOut(string s) => logger.LogInfo(s, threadId);
+            void onOut(string s) => logger.LogDebug(s, threadId);
             void onError(string s) => logger.LogError(s, threadId);
             var exitCode = pi.ReadOutput(out var _, onOut, onError);
             if (exitCode != 0)
@@ -235,7 +235,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             };
 
             var threadId = Environment.CurrentManagedThreadId;
-            void onOut(string s) => logger.LogInfo(s, threadId);
+            void onOut(string s) => logger.LogDebug(s, threadId);
             void onError(string s) => logger.LogError(s, threadId);
             pi.ReadOutput(out stdout, onOut, onError);
         }

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
@@ -361,7 +361,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             allPackageDirectories
                 .Where(package => !dependencies.Packages.Contains(package))
                 .Order()
-                .ForEach(package => logger.LogInfo($"Unused package: {package}"));
+                .ForEach(package => logger.LogDebug($"Unused package: {package}"));
         }
 
         private ICollection<string> GetAllPackageDirectories()

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
@@ -623,13 +623,9 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
         private (HashSet<string> explicitFeeds, HashSet<string> allFeeds) GetAllFeeds()
         {
-            IList<string> GetNugetFeeds(string nugetConfig) => dotnet.GetNugetFeeds(nugetConfig);
-
-            IList<string> GetNugetFeedsFromFolder(string folderPath) => dotnet.GetNugetFeedsFromFolder(folderPath);
-
             var nugetConfigs = fileProvider.NugetConfigs;
             var explicitFeeds = nugetConfigs
-                .SelectMany(config => GetFeeds(() => GetNugetFeeds(config)))
+                .SelectMany(config => GetFeeds(() => dotnet.GetNugetFeeds(config)))
                 .ToHashSet();
 
             if (explicitFeeds.Count > 0)
@@ -657,7 +653,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                     return null;
                 })
                 .Where(folder => folder != null)
-                .SelectMany(folder => GetFeeds(() => GetNugetFeedsFromFolder(folder!)))
+                .SelectMany(folder => GetFeeds(() => dotnet.GetNugetFeedsFromFolder(folder!)))
                 .ToHashSet();
 
             logger.LogInfo($"Found {allFeeds.Count} Nuget feeds (with inherited ones) in nuget.config files: {string.Join(", ", allFeeds.OrderBy(f => f))}");

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/Razor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/Razor.cs
@@ -64,9 +64,10 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
             try
             {
+                logger.LogInfo("Produce analyzer config content.");
                 GenerateAnalyzerConfig(cshtmls, analyzerConfig);
 
-                logger.LogInfo($"Analyzer config content: {File.ReadAllText(analyzerConfig)}");
+                logger.LogDebug($"Analyzer config content: {File.ReadAllText(analyzerConfig)}");
 
                 var args = new StringBuilder();
                 args.Append($"/target:exe /generatedfilesout:\"{outputFolder}\" /out:\"{dllPath}\" /analyzerconfig:\"{analyzerConfig}\" ");
@@ -88,7 +89,8 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
                 var argsString = args.ToString();
 
-                logger.LogInfo($"Running CSC to generate Razor source files with arguments: {argsString}.");
+                logger.LogInfo($"Running CSC to generate Razor source files.");
+                logger.LogDebug($"Running CSC to generate Razor source files with arguments: {argsString}.");
 
                 using (var sw = new StreamWriter(cscArgsPath))
                 {

--- a/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Extractor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Extractor.cs
@@ -111,12 +111,12 @@ namespace Semmle.Extraction.CSharp.Standalone
                     AnalysisAction.UpToDate => "up to date",
                     _ => "unknown action"
                 };
-                logger.LogInfo($"[{item}/{total}] {source} ({extra})");
+                logger.LogDebug($"[{item}/{total}] {source} ({extra})");
             }
 
             public void Started(int item, int total, string source)
             {
-                logger.LogInfo($"[{item}/{total}] {source} (processing started)");
+                logger.LogDebug($"[{item}/{total}] {source} (processing started)");
             }
 
             public void MissingType(string type)

--- a/csharp/extractor/Semmle.Extraction.Tests/DotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/DotNet.cs
@@ -20,23 +20,23 @@ namespace Semmle.Extraction.Tests
 
         public string Exec => "dotnet";
 
-        public bool RunCommand(string args)
+        public bool RunCommand(string args, bool silent)
         {
             lastArgs = args;
             return Success;
         }
 
-        public bool RunCommand(string args, out IList<string> output)
+        public bool RunCommand(string args, out IList<string> output, bool silent)
         {
             lastArgs = args;
             output = this.output;
             return Success;
         }
 
-        public bool RunCommand(string args, string? workingDirectory, out IList<string> output)
+        public bool RunCommand(string args, string? workingDirectory, out IList<string> output, bool silent)
         {
             WorkingDirectory = workingDirectory ?? "";
-            return RunCommand(args, out output);
+            return RunCommand(args, out output, silent);
         }
 
         public string GetLastArgs() => lastArgs;


### PR DESCRIPTION
Replaced some `LogInfo` with `LogDebug` (some of the more chatty `LogInfo`).

@tamasvajk : Should we consider to use `LogDebug` when executing commands (most of the `onOut` callbacks - prints as Info)?