### PR TITLE
Tiny docs fix

### DIFF
--- a/ruby/ql/lib/codeql/ruby/security/CodeInjectionCustomizations.qll
+++ b/ruby/ql/lib/codeql/ruby/security/CodeInjectionCustomizations.qll
@@ -16,7 +16,7 @@ module CodeInjection {
   module FlowState {
     /**
      * Flow state used for normal tainted data, where an attacker might only control a substring.
-     * DEPRECATED: Use `Full()`
+     * DEPRECATED: Use `SubString()`
      */
     deprecated DataFlow::FlowState substring() { result = "substring" }
 


### PR DESCRIPTION
Noticed the mistake when browsing the docs [here](https://codeql.github.com/codeql-standard-libraries/ruby/codeql/ruby/security/CodeInjectionCustomizations.qll/module.CodeInjectionCustomizations$CodeInjection$FlowState.html).