### PR TITLE
C#: Add missing query precision

### DIFF
--- a/csharp/ql/src/Security Features/CWE-016/ASPNetPagesValidateRequest.ql
+++ b/csharp/ql/src/Security Features/CWE-016/ASPNetPagesValidateRequest.ql
@@ -3,6 +3,7 @@
  * @description ASP.NET pages should not disable the built-in request validation.
  * @kind problem
  * @problem.severity warning
+ * @precision medium
  * @security-severity 7.5
  * @id cs/web/request-validation-disabled
  * @tags security


### PR DESCRIPTION
Adds `precision medium` to `cs/web/request-validation-disabled`