### PR TITLE
Go: Use shared integration test code

### DIFF
--- a/go/integration-tests-lib/go_integration_test.py
+++ b/go/integration-tests-lib/go_integration_test.py
@@ -9,10 +9,11 @@ def go_integration_test(source = "src"):
   goPath = os.path.join(os.path.abspath(os.getcwd()), ".go")
   os.environ['GOPATH'] = goPath
 
-  run_codeql_database_create([], lang="go", source=source)
+  try:
+    run_codeql_database_create([], lang="go", source=source)
 
-  check_diagnostics()
-
-  # Clean up the temporary GOPATH to prevent Bazel failures next
-  # time the tests are run; see https://github.com/golang/go/issues/27161
-  subprocess.call(["go", "clean", "-modcache"])
+    check_diagnostics()
+  finally:
+    # Clean up the temporary GOPATH to prevent Bazel failures next
+    # time the tests are run; see https://github.com/golang/go/issues/27161
+    subprocess.call(["go", "clean", "-modcache"])

--- a/go/integration-tests-lib/go_integration_test.py
+++ b/go/integration-tests-lib/go_integration_test.py
@@ -2,7 +2,7 @@ import os
 from create_database_utils import *
 from diagnostics_test_utils import *
 
-def go_integration_test(source = "src"):
+def go_integration_test(source = "src", db = "db", runFunction = runSuccessfully):
   # Set up a GOPATH relative to this test's root directory;
   # we set os.environ instead of using extra_env because we
   # need it to be set for the call to "go clean -modcache" later
@@ -10,7 +10,7 @@ def go_integration_test(source = "src"):
   os.environ['GOPATH'] = goPath
 
   try:
-    run_codeql_database_create([], lang="go", source=source)
+    run_codeql_database_create([], lang="go", source=source, db=db, runFunction=runFunction)
 
     check_diagnostics()
   finally:

--- a/go/ql/integration-tests/all-platforms/go/bazel-sample-1/test.py
+++ b/go/ql/integration-tests/all-platforms/go/bazel-sample-1/test.py
@@ -1,19 +1,3 @@
-import os
-import subprocess
+from go_integration_test import *
 
-from create_database_utils import *
-from diagnostics_test_utils import *
-
-# Set up a GOPATH relative to this test's root directory;
-# we set os.environ instead of using extra_env because we
-# need it to be set for the call to "go clean -modcache" later
-goPath = os.path.join(os.path.abspath(os.getcwd()), ".go")
-os.environ['GOPATH'] = goPath
-
-run_codeql_database_create([], lang="go", source="src")
-
-check_diagnostics()
-
-# Clean up the temporary GOPATH to prevent Bazel failures next
-# time the tests are run; see https://github.com/golang/go/issues/27161
-subprocess.call(["go", "clean", "-modcache"])
+go_integration_test()

--- a/go/ql/integration-tests/all-platforms/go/bazel-sample-2/test.py
+++ b/go/ql/integration-tests/all-platforms/go/bazel-sample-2/test.py
@@ -1,19 +1,3 @@
-import os
-import subprocess
+from go_integration_test import *
 
-from create_database_utils import *
-from diagnostics_test_utils import *
-
-# Set up a GOPATH relative to this test's root directory;
-# we set os.environ instead of using extra_env because we
-# need it to be set for the call to "go clean -modcache" later
-goPath = os.path.join(os.path.abspath(os.getcwd()), ".go")
-os.environ['GOPATH'] = goPath
-
-run_codeql_database_create([], lang="go", source="src")
-
-check_diagnostics()
-
-# Clean up the temporary GOPATH to prevent Bazel failures next
-# time the tests are run; see https://github.com/golang/go/issues/27161
-subprocess.call(["go", "clean", "-modcache"])
+go_integration_test()

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/build-constraints-exclude-all-go-files/test.py
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/build-constraints-exclude-all-go-files/test.py
@@ -1,19 +1,6 @@
 import os
-import subprocess
 
-from create_database_utils import *
-from diagnostics_test_utils import *
+from go_integration_test import *
 
-# Set up a GOPATH relative to this test's root directory;
-# we set os.environ instead of using extra_env because we
-# need it to be set for the call to "go clean -modcache" later
-goPath = os.path.join(os.path.abspath(os.getcwd()), ".go")
-os.environ['GOPATH'] = goPath
 os.environ['LGTM_INDEX_IMPORT_PATH'] = "test"
-run_codeql_database_create([], lang="go", source="work", db=None)
-
-check_diagnostics()
-
-# Clean up the temporary GOPATH to prevent Bazel failures next
-# time the tests are run; see https://github.com/golang/go/issues/27161
-subprocess.call(["go", "clean", "-modcache"])
+go_integration_test(source="work", db=None)

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/go-files-found-not-processed/test.py
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/go-files-found-not-processed/test.py
@@ -1,19 +1,6 @@
 import os
-import subprocess
 
-from create_database_utils import *
-from diagnostics_test_utils import *
+from go_integration_test import *
 
-# Set up a GOPATH relative to this test's root directory;
-# we set os.environ instead of using extra_env because we
-# need it to be set for the call to "go clean -modcache" later
-goPath = os.path.join(os.path.abspath(os.getcwd()), ".go")
-os.environ['GOPATH'] = goPath
 os.environ['LGTM_INDEX_IMPORT_PATH'] = "test"
-run_codeql_database_create([], lang="go", source="work")
-
-check_diagnostics()
-
-# Clean up the temporary GOPATH to prevent Bazel failures next
-# time the tests are run; see https://github.com/golang/go/issues/27161
-subprocess.call(["go", "clean", "-modcache"])
+go_integration_test(source="work")

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/invalid-toolchain-version/test.py
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/invalid-toolchain-version/test.py
@@ -1,19 +1,6 @@
 import os
-import subprocess
 
-from create_database_utils import *
-from diagnostics_test_utils import *
+from go_integration_test import *
 
-# Set up a GOPATH relative to this test's root directory;
-# we set os.environ instead of using extra_env because we
-# need it to be set for the call to "go clean -modcache" later
-goPath = os.path.join(os.path.abspath(os.getcwd()), ".go")
-os.environ['GOPATH'] = goPath
 os.environ['LGTM_INDEX_IMPORT_PATH'] = "test"
-run_codeql_database_create([], lang="go", source="src")
-
-check_diagnostics()
-
-# Clean up the temporary GOPATH to prevent Bazel failures next
-# time the tests are run; see https://github.com/golang/go/issues/27161
-subprocess.call(["go", "clean", "-modcache"])
+go_integration_test()

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/newer-go-version-needed/test.py
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/newer-go-version-needed/test.py
@@ -1,19 +1,6 @@
 import os
-import subprocess
 
-from create_database_utils import *
-from diagnostics_test_utils import *
+from go_integration_test import *
 
-# Set up a GOPATH relative to this test's root directory;
-# we set os.environ instead of using extra_env because we
-# need it to be set for the call to "go clean -modcache" later
-goPath = os.path.join(os.path.abspath(os.getcwd()), ".go")
-os.environ['GOPATH'] = goPath
 os.environ['LGTM_INDEX_IMPORT_PATH'] = "test"
-run_codeql_database_create([], lang="go", source="work", db=None, runFunction=runUnsuccessfully)
-
-check_diagnostics()
-
-# Clean up the temporary GOPATH to prevent Bazel failures next
-# time the tests are run; see https://github.com/golang/go/issues/27161
-subprocess.call(["go", "clean", "-modcache"])
+go_integration_test(source="work", db=None, runFunction=runUnsuccessfully)

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/no-go-files-found/test.py
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/no-go-files-found/test.py
@@ -1,19 +1,6 @@
 import os
-import subprocess
 
-from create_database_utils import *
-from diagnostics_test_utils import *
+from go_integration_test import *
 
-# Set up a GOPATH relative to this test's root directory;
-# we set os.environ instead of using extra_env because we
-# need it to be set for the call to "go clean -modcache" later
-goPath = os.path.join(os.path.abspath(os.getcwd()), ".go")
-os.environ['GOPATH'] = goPath
 os.environ['LGTM_INDEX_IMPORT_PATH'] = "test"
-run_codeql_database_create([], lang="go", source="work", db=None, runFunction=runUnsuccessfully)
-
-check_diagnostics()
-
-# Clean up the temporary GOPATH to prevent Bazel failures next
-# time the tests are run; see https://github.com/golang/go/issues/27161
-subprocess.call(["go", "clean", "-modcache"])
+go_integration_test(source="work", db=None, runFunction=runUnsuccessfully)

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/package-not-found-with-go-mod/test.py
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/package-not-found-with-go-mod/test.py
@@ -1,19 +1,6 @@
 import os
-import subprocess
 
-from create_database_utils import *
-from diagnostics_test_utils import *
+from go_integration_test import *
 
-# Set up a GOPATH relative to this test's root directory;
-# we set os.environ instead of using extra_env because we
-# need it to be set for the call to "go clean -modcache" later
-goPath = os.path.join(os.path.abspath(os.getcwd()), ".go")
-os.environ['GOPATH'] = goPath
 os.environ['LGTM_INDEX_IMPORT_PATH'] = "test"
-run_codeql_database_create([], lang="go", source="work", db=None)
-
-check_diagnostics()
-
-# Clean up the temporary GOPATH to prevent Bazel failures next
-# time the tests are run; see https://github.com/golang/go/issues/27161
-subprocess.call(["go", "clean", "-modcache"])
+go_integration_test(source="work", db=None)

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/package-not-found-without-go-mod/test.py
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/package-not-found-without-go-mod/test.py
@@ -1,19 +1,6 @@
 import os
-import subprocess
 
-from create_database_utils import *
-from diagnostics_test_utils import *
+from go_integration_test import *
 
-# Set up a GOPATH relative to this test's root directory;
-# we set os.environ instead of using extra_env because we
-# need it to be set for the call to "go clean -modcache" later
-goPath = os.path.join(os.path.abspath(os.getcwd()), ".go")
-os.environ['GOPATH'] = goPath
 os.environ['LGTM_INDEX_IMPORT_PATH'] = "test"
-run_codeql_database_create([], lang="go", source="work", db=None)
-
-check_diagnostics()
-
-# Clean up the temporary GOPATH to prevent Bazel failures next
-# time the tests are run; see https://github.com/golang/go/issues/27161
-subprocess.call(["go", "clean", "-modcache"])
+go_integration_test(source="work", db=None)

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/unsupported-relative-path/test.py
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/unsupported-relative-path/test.py
@@ -1,19 +1,6 @@
 import os
-import subprocess
 
-from create_database_utils import *
-from diagnostics_test_utils import *
+from go_integration_test import *
 
-# Set up a GOPATH relative to this test's root directory;
-# we set os.environ instead of using extra_env because we
-# need it to be set for the call to "go clean -modcache" later
-goPath = os.path.join(os.path.abspath(os.getcwd()), ".go")
-os.environ['GOPATH'] = goPath
 os.environ['GITHUB_REPOSITORY'] = "a/b"
-run_codeql_database_create([], lang="go", source="work", db=None)
-
-check_diagnostics()
-
-# Clean up the temporary GOPATH to prevent Bazel failures next
-# time the tests are run; see https://github.com/golang/go/issues/27161
-subprocess.call(["go", "clean", "-modcache"])
+go_integration_test(source="work", db=None)

--- a/go/ql/integration-tests/all-platforms/go/go-get-without-modules-sample/test.py
+++ b/go/ql/integration-tests/all-platforms/go/go-get-without-modules-sample/test.py
@@ -1,15 +1,3 @@
-import os
-import subprocess
+from go_integration_test import *
 
-from create_database_utils import *
-
-# Set up a GOPATH relative to this test's root directory;
-# we set os.environ instead of using extra_env because we
-# need it to be set for the call to "go clean -modcache" later
-goPath = os.path.join(os.path.abspath(os.getcwd()), ".go")
-os.environ['GOPATH'] = goPath
-run_codeql_database_create([], lang="go", source="src")
-
-# Clean up the temporary GOPATH to prevent Bazel failures next
-# time the tests are run; see https://github.com/golang/go/issues/27161
-subprocess.call(["go", "clean", "-modcache"])
+go_integration_test()

--- a/go/ql/integration-tests/all-platforms/go/go-mod-sample/diagnostics.expected
+++ b/go/ql/integration-tests/all-platforms/go/go-mod-sample/diagnostics.expected
@@ -1,0 +1,14 @@
+{
+  "markdownMessage": "A single `go.mod` file was found.\n\n`go.mod`",
+  "severity": "note",
+  "source": {
+    "extractorName": "go",
+    "id": "go/autobuilder/single-root-go-mod-found",
+    "name": "A single `go.mod` file was found in the root"
+  },
+  "visibility": {
+    "cliSummaryTable": false,
+    "statusPage": false,
+    "telemetry": true
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/go-mod-sample/test.py
+++ b/go/ql/integration-tests/all-platforms/go/go-mod-sample/test.py
@@ -1,15 +1,3 @@
-import os
-import subprocess
+from go_integration_test import *
 
-from create_database_utils import *
-
-# Set up a GOPATH relative to this test's root directory;
-# we set os.environ instead of using extra_env because we
-# need it to be set for the call to "go clean -modcache" later
-goPath = os.path.join(os.path.abspath(os.getcwd()), ".go")
-os.environ['GOPATH'] = goPath
-run_codeql_database_create([], lang="go", source="src")
-
-# Clean up the temporary GOPATH to prevent Bazel failures next
-# time the tests are run; see https://github.com/golang/go/issues/27161
-subprocess.call(["go", "clean", "-modcache"])
+go_integration_test()

--- a/go/ql/integration-tests/all-platforms/go/go-mod-without-version/test.py
+++ b/go/ql/integration-tests/all-platforms/go/go-mod-without-version/test.py
@@ -1,18 +1,3 @@
-import os
-import subprocess
+from go_integration_test import *
 
-from create_database_utils import *
-from diagnostics_test_utils import *
-
-# Set up a GOPATH relative to this test's root directory;
-# we set os.environ instead of using extra_env because we
-# need it to be set for the call to "go clean -modcache" later
-goPath = os.path.join(os.path.abspath(os.getcwd()), ".go")
-os.environ['GOPATH'] = goPath
-run_codeql_database_create([], lang="go", source="src")
-
-check_diagnostics()
-
-# Clean up the temporary GOPATH to prevent Bazel failures next
-# time the tests are run; see https://github.com/golang/go/issues/27161
-subprocess.call(["go", "clean", "-modcache"])
+go_integration_test()

--- a/go/ql/integration-tests/all-platforms/go/go-version-bump/test.py
+++ b/go/ql/integration-tests/all-platforms/go/go-version-bump/test.py
@@ -1,18 +1,3 @@
-import os
-import subprocess
+from go_integration_test import *
 
-from create_database_utils import *
-from diagnostics_test_utils import *
-
-# Set up a GOPATH relative to this test's root directory;
-# we set os.environ instead of using extra_env because we
-# need it to be set for the call to "go clean -modcache" later
-goPath = os.path.join(os.path.abspath(os.getcwd()), ".go")
-os.environ['GOPATH'] = goPath
-run_codeql_database_create([], lang="go", source="src")
-
-check_diagnostics()
-
-# Clean up the temporary GOPATH to prevent Bazel failures next
-# time the tests are run; see https://github.com/golang/go/issues/27161
-subprocess.call(["go", "clean", "-modcache"])
+go_integration_test()

--- a/go/ql/integration-tests/all-platforms/go/make-sample/diagnostics.expected
+++ b/go/ql/integration-tests/all-platforms/go/make-sample/diagnostics.expected
@@ -1,0 +1,14 @@
+{
+  "markdownMessage": "A single `go.mod` file was found.\n\n`go.mod`",
+  "severity": "note",
+  "source": {
+    "extractorName": "go",
+    "id": "go/autobuilder/single-root-go-mod-found",
+    "name": "A single `go.mod` file was found in the root"
+  },
+  "visibility": {
+    "cliSummaryTable": false,
+    "statusPage": false,
+    "telemetry": true
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/make-sample/test.py
+++ b/go/ql/integration-tests/all-platforms/go/make-sample/test.py
@@ -1,15 +1,3 @@
-import os
-import subprocess
+from go_integration_test import *
 
-from create_database_utils import *
-
-# Set up a GOPATH relative to this test's root directory;
-# we set os.environ instead of using extra_env because we
-# need it to be set for the call to "go clean -modcache" later
-goPath = os.path.join(os.path.abspath(os.getcwd()), ".go")
-os.environ['GOPATH'] = goPath
-run_codeql_database_create([], lang="go", source="src")
-
-# Clean up the temporary GOPATH to prevent Bazel failures next
-# time the tests are run; see https://github.com/golang/go/issues/27161
-subprocess.call(["go", "clean", "-modcache"])
+go_integration_test()

--- a/go/ql/integration-tests/all-platforms/go/mixed-layout/test.py
+++ b/go/ql/integration-tests/all-platforms/go/mixed-layout/test.py
@@ -1,18 +1,3 @@
-import os
-import subprocess
+from go_integration_test import *
 
-from create_database_utils import *
-from diagnostics_test_utils import *
-
-# Set up a GOPATH relative to this test's root directory;
-# we set os.environ instead of using extra_env because we
-# need it to be set for the call to "go clean -modcache" later
-goPath = os.path.join(os.path.abspath(os.getcwd()), ".go")
-os.environ['GOPATH'] = goPath
-run_codeql_database_create([], lang="go", source="src")
-
-check_diagnostics()
-
-# Clean up the temporary GOPATH to prevent Bazel failures next
-# time the tests are run; see https://github.com/golang/go/issues/27161
-subprocess.call(["go", "clean", "-modcache"])
+go_integration_test()

--- a/go/ql/integration-tests/all-platforms/go/ninja-sample/diagnostics.expected
+++ b/go/ql/integration-tests/all-platforms/go/ninja-sample/diagnostics.expected
@@ -1,0 +1,14 @@
+{
+  "markdownMessage": "A single `go.mod` file was found.\n\n`go.mod`",
+  "severity": "note",
+  "source": {
+    "extractorName": "go",
+    "id": "go/autobuilder/single-root-go-mod-found",
+    "name": "A single `go.mod` file was found in the root"
+  },
+  "visibility": {
+    "cliSummaryTable": false,
+    "statusPage": false,
+    "telemetry": true
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/ninja-sample/test.py
+++ b/go/ql/integration-tests/all-platforms/go/ninja-sample/test.py
@@ -1,15 +1,3 @@
-import os
-import subprocess
+from go_integration_test import *
 
-from create_database_utils import *
-
-# Set up a GOPATH relative to this test's root directory;
-# we set os.environ instead of using extra_env because we
-# need it to be set for the call to "go clean -modcache" later
-goPath = os.path.join(os.path.abspath(os.getcwd()), ".go")
-os.environ['GOPATH'] = goPath
-run_codeql_database_create([], lang="go", source="src")
-
-# Clean up the temporary GOPATH to prevent Bazel failures next
-# time the tests are run; see https://github.com/golang/go/issues/27161
-subprocess.call(["go", "clean", "-modcache"])
+go_integration_test()

--- a/go/ql/integration-tests/all-platforms/go/single-go-mod-and-go-files-not-under-it/test.py
+++ b/go/ql/integration-tests/all-platforms/go/single-go-mod-and-go-files-not-under-it/test.py
@@ -1,18 +1,3 @@
-import os
-import subprocess
+from go_integration_test import *
 
-from create_database_utils import *
-from diagnostics_test_utils import *
-
-# Set up a GOPATH relative to this test's root directory;
-# we set os.environ instead of using extra_env because we
-# need it to be set for the call to "go clean -modcache" later
-goPath = os.path.join(os.path.abspath(os.getcwd()), ".go")
-os.environ['GOPATH'] = goPath
-run_codeql_database_create([], lang="go", source="src")
-
-check_diagnostics()
-
-# Clean up the temporary GOPATH to prevent Bazel failures next
-# time the tests are run; see https://github.com/golang/go/issues/27161
-subprocess.call(["go", "clean", "-modcache"])
+go_integration_test()

--- a/go/ql/integration-tests/all-platforms/go/single-go-mod-in-root/test.py
+++ b/go/ql/integration-tests/all-platforms/go/single-go-mod-in-root/test.py
@@ -1,18 +1,3 @@
-import os
-import subprocess
+from go_integration_test import *
 
-from create_database_utils import *
-from diagnostics_test_utils import *
-
-# Set up a GOPATH relative to this test's root directory;
-# we set os.environ instead of using extra_env because we
-# need it to be set for the call to "go clean -modcache" later
-goPath = os.path.join(os.path.abspath(os.getcwd()), ".go")
-os.environ['GOPATH'] = goPath
-run_codeql_database_create([], lang="go", source="src")
-
-check_diagnostics()
-
-# Clean up the temporary GOPATH to prevent Bazel failures next
-# time the tests are run; see https://github.com/golang/go/issues/27161
-subprocess.call(["go", "clean", "-modcache"])
+go_integration_test()

--- a/go/ql/integration-tests/all-platforms/go/single-go-mod-not-in-root/test.py
+++ b/go/ql/integration-tests/all-platforms/go/single-go-mod-not-in-root/test.py
@@ -1,18 +1,3 @@
-import os
-import subprocess
+from go_integration_test import *
 
-from create_database_utils import *
-from diagnostics_test_utils import *
-
-# Set up a GOPATH relative to this test's root directory;
-# we set os.environ instead of using extra_env because we
-# need it to be set for the call to "go clean -modcache" later
-goPath = os.path.join(os.path.abspath(os.getcwd()), ".go")
-os.environ['GOPATH'] = goPath
-run_codeql_database_create([], lang="go", source="src")
-
-check_diagnostics()
-
-# Clean up the temporary GOPATH to prevent Bazel failures next
-# time the tests are run; see https://github.com/golang/go/issues/27161
-subprocess.call(["go", "clean", "-modcache"])
+go_integration_test()

--- a/go/ql/integration-tests/all-platforms/go/single-go-work-not-in-root/test.py
+++ b/go/ql/integration-tests/all-platforms/go/single-go-work-not-in-root/test.py
@@ -1,18 +1,3 @@
-import os
-import subprocess
+from go_integration_test import *
 
-from create_database_utils import *
-from diagnostics_test_utils import *
-
-# Set up a GOPATH relative to this test's root directory;
-# we set os.environ instead of using extra_env because we
-# need it to be set for the call to "go clean -modcache" later
-goPath = os.path.join(os.path.abspath(os.getcwd()), ".go")
-os.environ['GOPATH'] = goPath
-run_codeql_database_create([], lang="go", source="src")
-
-check_diagnostics()
-
-# Clean up the temporary GOPATH to prevent Bazel failures next
-# time the tests are run; see https://github.com/golang/go/issues/27161
-subprocess.call(["go", "clean", "-modcache"])
+go_integration_test()

--- a/go/ql/integration-tests/all-platforms/go/two-go-mods-nested-none-in-root/test.py
+++ b/go/ql/integration-tests/all-platforms/go/two-go-mods-nested-none-in-root/test.py
@@ -1,18 +1,3 @@
-import os
-import subprocess
+from go_integration_test import *
 
-from create_database_utils import *
-from diagnostics_test_utils import *
-
-# Set up a GOPATH relative to this test's root directory;
-# we set os.environ instead of using extra_env because we
-# need it to be set for the call to "go clean -modcache" later
-goPath = os.path.join(os.path.abspath(os.getcwd()), ".go")
-os.environ['GOPATH'] = goPath
-run_codeql_database_create([], lang="go", source="src")
-
-check_diagnostics()
-
-# Clean up the temporary GOPATH to prevent Bazel failures next
-# time the tests are run; see https://github.com/golang/go/issues/27161
-subprocess.call(["go", "clean", "-modcache"])
+go_integration_test()

--- a/go/ql/integration-tests/all-platforms/go/two-go-mods-nested-one-in-root/test.py
+++ b/go/ql/integration-tests/all-platforms/go/two-go-mods-nested-one-in-root/test.py
@@ -1,18 +1,3 @@
-import os
-import subprocess
+from go_integration_test import *
 
-from create_database_utils import *
-from diagnostics_test_utils import *
-
-# Set up a GOPATH relative to this test's root directory;
-# we set os.environ instead of using extra_env because we
-# need it to be set for the call to "go clean -modcache" later
-goPath = os.path.join(os.path.abspath(os.getcwd()), ".go")
-os.environ['GOPATH'] = goPath
-run_codeql_database_create([], lang="go", source="src")
-
-check_diagnostics()
-
-# Clean up the temporary GOPATH to prevent Bazel failures next
-# time the tests are run; see https://github.com/golang/go/issues/27161
-subprocess.call(["go", "clean", "-modcache"])
+go_integration_test()

--- a/go/ql/integration-tests/all-platforms/go/two-go-mods-not-nested/test.py
+++ b/go/ql/integration-tests/all-platforms/go/two-go-mods-not-nested/test.py
@@ -1,18 +1,3 @@
-import os
-import subprocess
+from go_integration_test import *
 
-from create_database_utils import *
-from diagnostics_test_utils import *
-
-# Set up a GOPATH relative to this test's root directory;
-# we set os.environ instead of using extra_env because we
-# need it to be set for the call to "go clean -modcache" later
-goPath = os.path.join(os.path.abspath(os.getcwd()), ".go")
-os.environ['GOPATH'] = goPath
-run_codeql_database_create([], lang="go", source="src")
-
-check_diagnostics()
-
-# Clean up the temporary GOPATH to prevent Bazel failures next
-# time the tests are run; see https://github.com/golang/go/issues/27161
-subprocess.call(["go", "clean", "-modcache"])
+go_integration_test()

--- a/go/ql/integration-tests/all-platforms/go/two-go-mods-one-failure/test.py
+++ b/go/ql/integration-tests/all-platforms/go/two-go-mods-one-failure/test.py
@@ -1,18 +1,3 @@
-import os
-import subprocess
+from go_integration_test import *
 
-from create_database_utils import *
-from diagnostics_test_utils import *
-
-# Set up a GOPATH relative to this test's root directory;
-# we set os.environ instead of using extra_env because we
-# need it to be set for the call to "go clean -modcache" later
-goPath = os.path.join(os.path.abspath(os.getcwd()), ".go")
-os.environ['GOPATH'] = goPath
-run_codeql_database_create([], lang="go", source="src")
-
-check_diagnostics()
-
-# Clean up the temporary GOPATH to prevent Bazel failures next
-# time the tests are run; see https://github.com/golang/go/issues/27161
-subprocess.call(["go", "clean", "-modcache"])
+go_integration_test()

--- a/go/ql/integration-tests/linux-only/go/dep-sample/test.py
+++ b/go/ql/integration-tests/linux-only/go/dep-sample/test.py
@@ -1,10 +1,6 @@
 import os
-import sys
 
-from create_database_utils import *
-from diagnostics_test_utils import *
+from go_integration_test import *
 
 os.environ['LGTM_INDEX_IMPORT_PATH'] = "deptest"
-run_codeql_database_create([], lang="go", source="work")
-
-check_diagnostics()
+go_integration_test(source="work")

--- a/go/ql/integration-tests/linux-only/go/glide-sample/test.py
+++ b/go/ql/integration-tests/linux-only/go/glide-sample/test.py
@@ -1,10 +1,6 @@
 import os
-import sys
 
-from create_database_utils import *
-from diagnostics_test_utils import *
+from go_integration_test import *
 
 os.environ['LGTM_INDEX_IMPORT_PATH'] = "glidetest"
-run_codeql_database_create([], lang="go", source="work")
-
-check_diagnostics()
+go_integration_test(source="work")


### PR DESCRIPTION
This PR updates the Python code for the integration tests to use the new shared integration test library that was added in #16184.

The shared integration test library is extended with some additional parameters to accommodate the needs of all existing integration tests.

Since the shared test code checks that the expected diagnostics were generated, I added `diagnostics.expected` files for integration tests which didn't already have them.