### PR TITLE
Go: Respect `GOTOOLCHAIN` in `GetEnvGoVersion` if already set

### DIFF
--- a/go/extractor/toolchain/toolchain.go
+++ b/go/extractor/toolchain/toolchain.go
@@ -36,7 +36,14 @@ func GetEnvGoVersion() string {
 		// being told what's already in 'go.mod'. Setting 'GOTOOLCHAIN' to 'local' will force it
 		// to use the local Go toolchain instead.
 		cmd := Version()
-		cmd.Env = append(os.Environ(), "GOTOOLCHAIN=local")
+
+		// If 'GOTOOLCHAIN' is already set, then leave it as is. This allows us to force a specific
+		// Go version in tests and also allows users to override the system default more generally.
+		_, hasToolchainVar := os.LookupEnv("GOTOOLCHAIN")
+		if !hasToolchainVar {
+			cmd.Env = append(os.Environ(), "GOTOOLCHAIN=local")
+		}
+
 		out, err := cmd.CombinedOutput()
 
 		if err != nil {


### PR DESCRIPTION
A hopefully small change which changes the behaviour of `GetEnvGoVersion` to respect existing values for `GOTOOLCHAIN` if the environment variable is already set. This is primarily useful for testing, where we can use this to force a particular toolchain to be used for the purpose of a test. It may also be useful for users who wish to override whatever the system default is. 