### PR TITLE
Go: Add an example specific to domain names in missing-regexp-anchor

### DIFF
--- a/go/ql/src/Security/CWE-020/MissingRegexpAnchor.qhelp
+++ b/go/ql/src/Security/CWE-020/MissingRegexpAnchor.qhelp
@@ -47,7 +47,7 @@ one of the alternatives. As an example, the regular expression
 </p>
 
 <p>
-When checking for a domain name with subdomains, it is important to anchor the regular expression
+When checking for a domain name that may have subdomains, it is important to anchor the regular expression
 or ensure that the domain name is prefixed with a dot.
 </p>
 <sample src="MissingRegexpAnchorGoodDomain.go"/>

--- a/go/ql/src/Security/CWE-020/MissingRegexpAnchor.qhelp
+++ b/go/ql/src/Security/CWE-020/MissingRegexpAnchor.qhelp
@@ -45,6 +45,12 @@ one of the alternatives. As an example, the regular expression
 <code>(^www\.example\.com)|(beta\.example\.com)/</code>, so the second alternative
 <code>beta\.example\.com</code> is not anchored at the beginning of the string.
 </p>
+
+<p>
+When checking for a domain name with subdomains, it is important to anchor the regular expression
+or ensure that the domain name is prefixed with a dot.
+</p>
+<sample src="MissingRegexpAnchorGoodDomain.go"/>
 </example>
 
 <references>

--- a/go/ql/src/Security/CWE-020/MissingRegexpAnchorGoodDomain.go
+++ b/go/ql/src/Security/CWE-020/MissingRegexpAnchorGoodDomain.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"regexp"
+)
+
+func checkSubdomain(domain String) {
+	// Checking strictly that the domain is `example.com`.
+	re := "^example\\.com$"
+	if matched, _ := regexp.MatchString(re, domain); matched {
+		// domain is good.
+	}
+
+	// GOOD: Alternatively, check the domain is `example.com` or a subdomain of `example.com`.
+	re2 := "(^|\\.)example\\.com$"
+
+	if matched, _ := regexp.MatchString(re2, domain); matched {
+		// domain is good.
+	}
+}


### PR DESCRIPTION
It didn't seem clear what to do when the vulnerable regular expression is only for a hostname.

Some fixes ended up just inserting an end-anchor, and ignoring the beginning.  
So e.g. the "fix" `github.com$` could still be bypassed with e.g. `totallynotafakegithub.com`.  