### PR TITLE
C++: Use interpolation to avoid a bad join order

### DIFF
--- a/cpp/ql/src/Critical/GlobalUseBeforeInit.ql
+++ b/cpp/ql/src/Critical/GlobalUseBeforeInit.ql
@@ -110,6 +110,5 @@ from GlobalVariable v, Function f
 where
   uninitialisedBefore(v, f) and
   useFunc(v, f)
-select f,
-  "The variable '" + v.getName() + "'" +
-    " is used in this function but may not be initialized when it is called."
+select f, "The variable $@ is used in this function but may not be initialized when it is called.",
+  v, v.getName()

--- a/cpp/ql/test/query-tests/Critical/GlobalUseBeforeInit/GlobalUseBeforeInit.expected
+++ b/cpp/ql/test/query-tests/Critical/GlobalUseBeforeInit/GlobalUseBeforeInit.expected
@@ -1,1 +1,1 @@
-| test.cpp:27:5:27:6 | f1 | The variable 'b' is used in this function but may not be initialized when it is called. |
+| test.cpp:27:5:27:6 | f1 | The variable $@ is used in this function but may not be initialized when it is called. | test.cpp:14:5:14:5 | b | b |


### PR DESCRIPTION
@nickrolfe highlighted this bad join:
```ql
Evaluated relational algebra for predicate #select@4dc5a3gq with tuple counts:
  1125  ~0%    {5} r1 = SCAN globalvariables OUTPUT In.0, _, In.2, _, _
  1125  ~2%    {2}    | REWRITE WITH Tmp.1 := "The variable '", Tmp.3 := "'", Tmp.4 := " is used in this function but may not be initialized when it is called.", Out.1 := (Tmp.1 ++ In.2 ++ Tmp.3 ++ Tmp.4) KEEPING 2
     6  ~0%    {3}    | JOIN WITH `GlobalUseBeforeInit::useFunc/2#81a8e7f2` ON FIRST 1 OUTPUT Lhs.0, Rhs.1, Lhs.1
     1  ~0%    {2}    | JOIN WITH `GlobalUseBeforeInit::uninitialisedBefore/2#8cd27ca7#bf` ON FIRST 2 OUTPUT Lhs.1, Lhs.2
               return r1
```
This is exactly the same kind of join order issue we've seen in https://github.com/github/codeql/pull/16089.

This query isn't in any security suite so it doesn't really make sense to run DCA on it