### PR TITLE
C++: Add `cpp/iterator-to-expired-container` FP test

### DIFF
--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-416/IteratorToExpiredContainer.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-416/IteratorToExpiredContainer.expected
@@ -12,3 +12,5 @@
 | test.cpp:727:23:727:23 | call to operator[] | This object is destroyed before $@ is called. | test.cpp:750:17:750:17 | call to end | call to end |
 | test.cpp:735:23:735:23 | call to operator[] | This object is destroyed before $@ is called. | test.cpp:759:17:759:17 | call to begin | call to begin |
 | test.cpp:735:23:735:23 | call to operator[] | This object is destroyed before $@ is called. | test.cpp:759:17:759:17 | call to end | call to end |
+| test.cpp:771:44:771:56 | temporary object | This object is destroyed before $@ is called. | test.cpp:772:35:772:35 | call to begin | call to begin |
+| test.cpp:771:44:771:56 | temporary object | This object is destroyed before $@ is called. | test.cpp:772:35:772:35 | call to end | call to end |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-416/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-416/test.cpp
@@ -766,3 +766,8 @@ void test2() {
   for (auto x : value) {}
   }
 }
+
+void test3() {
+  const std::vector<std::vector<int>>& v = returnValue(); // GOOD [FALSE POSITIVE]
+  for(const std::vector<int>& x : v) {}
+}


### PR DESCRIPTION
This represents the vast majority of FPs that we're seeing on MRVA for this query.