### PR TITLE
Python: Fix flags test

### DIFF
--- a/python/ql/test/extractor-tests/flags/Flags.ql
+++ b/python/ql/test/extractor-tests/flags/Flags.ql
@@ -2,7 +2,7 @@ import python
 
 from string k, string v
 where
-  not k.matches("options.%") and
+  k.matches("options.%") and
   not k.matches("options.verbos%") and
   py_flags_versioned(k, v, _)
 select k, v


### PR DESCRIPTION
In https://github.com/github/codeql/commit/25cb52aa52b30744575e6e8bfc1ec03a70bd265d I accidentally introduced an extra `not` where none existed before. Whoops! This naturally caused the test to fail. Hopefully this fix should do the trick. (Note again that currently no CI is run on this test -- that'll come later -- but as far as I can see, this is the only failing test after having moved all the tests out.)