### PR TITLE
Go: Fix FPs in `go/incorrect-integer-conversion` query

### DIFF
--- a/go/ql/lib/semmle/go/security/IncorrectIntegerConversionLib.qll
+++ b/go/ql/lib/semmle/go/security/IncorrectIntegerConversionLib.qll
@@ -431,6 +431,26 @@ class TypeAssertionCheck extends DataFlow::ExprNode, FlowStateTransformer {
 }
 
 /**
+ * The implicit definition of a variable with integer type for a case clause of
+ * a type switch statement which declares a variable in its guard, which has
+ * effectively had a checked type assertion.
+ */
+class TypeSwitchVarFlowStateTransformer extends DataFlow::SsaNode, FlowStateTransformer {
+  IntegerType it;
+
+  TypeSwitchVarFlowStateTransformer() {
+    exists(IR::TypeSwitchImplicitVariableInstruction insn, LocalVariable lv | insn.writes(lv, _) |
+      this.getSourceVariable() = lv and
+      it = lv.getType()
+    )
+  }
+
+  override predicate barrierFor(int bitSize, int architectureBitSize) {
+    integerTypeBound(it, bitSize, architectureBitSize)
+  }
+}
+
+/**
  * Holds if `source` is the result of a call to `strconv.Atoi`,
  * `strconv.ParseInt`, or `strconv.ParseUint`, `bitSize` is the `bitSize`
  * argument to that call (or 0 for `strconv.Atoi`) and hence must be between 0

--- a/go/ql/lib/semmle/go/security/IncorrectIntegerConversionLib.qll
+++ b/go/ql/lib/semmle/go/security/IncorrectIntegerConversionLib.qll
@@ -260,7 +260,8 @@ private class MaxValueState extends TMaxValueState {
  */
 abstract class FlowStateTransformer extends DataFlow::Node {
   /**
-   * Holds if this should be a barrier for `flowstate`.
+   * Holds if this should be a barrier for a flow state with bit size `bitSize`
+   * and architecture bit size `architectureBitSize`.
    *
    * This includes flow states which are transformed into other flow states.
    */

--- a/go/ql/src/change-notes/2024-04-17-incorrect-integer-conversion-barriers.md
+++ b/go/ql/src/change-notes/2024-04-17-incorrect-integer-conversion-barriers.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added some more barriers to flow for `go/incorrect-integer-conversion` to reduce false positives, especially around type switches.

--- a/go/ql/test/query-tests/Security/CWE-681/IncorrectIntegerConversion.go
+++ b/go/ql/test/query-tests/Security/CWE-681/IncorrectIntegerConversion.go
@@ -482,16 +482,6 @@ func parsePositiveInt2(value string) (int, error) {
 	return int(i64), nil
 }
 
-func typeAssertion(s string) {
-	n, err := strconv.ParseInt(s, 10, 0)
-	if err == nil {
-		var itf interface{} = n
-		i32 := itf.(int32)
-		println(i32)
-	}
-
-}
-
 func dealWithArchSizeCorrectly(s string) uint {
 	if i, err := strconv.ParseUint(s, 10, 64); err == nil && i < math.MaxUint {
 		return uint(i)

--- a/go/ql/test/query-tests/Security/CWE-681/IncorrectIntegerConversion.go
+++ b/go/ql/test/query-tests/Security/CWE-681/IncorrectIntegerConversion.go
@@ -510,8 +510,8 @@ func typeSwitch1(s string) {
 		_ = int16(v.(int16))
 		_ = int8(v.(int16)) // $ hasValueFlow="type assertion"
 	case int32:
-		_ = int32(v) // $ SPURIOUS: hasValueFlow="v"
-		_ = int8(v)  // $ hasValueFlow="v"
+		_ = int32(v)
+		_ = int8(v) // $ hasValueFlow="v"
 	case int64:
 		_ = int8(v) // $ hasValueFlow="v"
 	default:

--- a/go/ql/test/query-tests/Security/CWE-681/IncorrectIntegerConversion.go
+++ b/go/ql/test/query-tests/Security/CWE-681/IncorrectIntegerConversion.go
@@ -507,8 +507,8 @@ func typeSwitch1(s string) {
 		if _, ok := input.(string); ok {
 			return
 		}
-		_ = int16(v.(int16)) // $ SPURIOUS: hasValueFlow="type assertion"
-		_ = int8(v.(int16))  // $ hasValueFlow="type assertion"
+		_ = int16(v.(int16))
+		_ = int8(v.(int16)) // $ hasValueFlow="type assertion"
 	case int32:
 		_ = int32(v) // $ SPURIOUS: hasValueFlow="v"
 		_ = int8(v)  // $ hasValueFlow="v"
@@ -527,11 +527,11 @@ func typeSwitch2(s string) {
 		if _, ok := input.(string); ok {
 			return
 		}
-		_ = int16(input.(int16)) // $ SPURIOUS: hasValueFlow="type assertion"
-		_ = int8(input.(int16))  // $ hasValueFlow="type assertion"
+		_ = int16(input.(int16))
+		_ = int8(input.(int16)) // $ hasValueFlow="type assertion"
 	case int32:
-		_ = int32(input.(int32)) // $ SPURIOUS: hasValueFlow="type assertion"
-		_ = int8(input.(int32))  // $ hasValueFlow="type assertion"
+		_ = int32(input.(int32))
+		_ = int8(input.(int32)) // $ hasValueFlow="type assertion"
 	case int64:
 		_ = int8(input.(int64)) // $ hasValueFlow="type assertion"
 	default:
@@ -544,8 +544,8 @@ func checkedTypeAssertion(s string) {
 	var input any = i64
 	if v, ok := input.(int16); ok {
 		// Need to account for the fact that within this case clause, v is an int16
-		_ = int16(v) // $ SPURIOUS: hasValueFlow="v"
-		_ = int8(v)  // $ hasValueFlow="v"
+		_ = int16(v)
+		_ = int8(v) // $ hasValueFlow="v"
 	} else if v, ok := input.(int32); ok {
 		_ = int16(v) // $ hasValueFlow="v"
 	}


### PR DESCRIPTION
I found the type switch FPs while looking at the results for https://github.com/github/codeql/pull/16120, which fixed some broken flow into type switch clauses. While thinking about how best to fix them I also realised that any type assertion should transform the flow state, so I implemented that as well.

A before and after MRVA run suggests that on the top 1000 repos this PR removes 218 FPs, but the more detailed picture is more nuanced. On a very small number of repos it increased the number of alerts. This seems counter-intuitive, as this PR only adds barriers and hence should only remove results. I investigated and found that this was because removing some flow allowed us to find more results within the default limit for `fieldFlowBranchLimit`.