### PR TITLE
C#: Fix cleanup logic in dependency manager

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
@@ -564,9 +564,12 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
         public void Dispose()
         {
-            tempWorkingDirectory?.Dispose();
-            diagnosticsWriter?.Dispose();
             nugetPackageRestorer?.Dispose();
+            if (cleanupTempWorkingDirectory)
+            {
+                tempWorkingDirectory?.Dispose();
+            }
+            diagnosticsWriter?.Dispose();
         }
     }
 }


### PR DESCRIPTION
This PR is fixing a bug introduced in https://github.com/github/codeql/pull/16195. (The order of the `Dispose` calls matter, also, I accidentally removed the check for `cleanupTempWorkingDirectory`.)