### PR TITLE
JS: Improve support for `export * as ...` declarations

### DIFF
--- a/javascript/ql/lib/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/lib/semmle/javascript/ApiGraphs.qll
@@ -773,7 +773,8 @@ module API {
           // In general, turn store steps into member steps for def-nodes
           exists(string prop |
             PreCallGraphStep::storeStep(rhs, pred, prop) and
-            lbl = Label::member(prop)
+            lbl = Label::member(prop) and
+            not DataFlow::PseudoProperties::isPseudoProperty(prop)
           )
           or
           exists(DataFlow::FunctionNode fn |
@@ -941,7 +942,6 @@ module API {
           (base instanceof TNonModuleDef or base instanceof TUse)
         )
         or
-        // invocations
         exists(DataFlow::SourceNode src, DataFlow::SourceNode pred |
           use(base, src) and pred = trackUseNode(src)
         |
@@ -961,6 +961,13 @@ module API {
             ref = cls.getAReceiverNode()
             or
             ref = cls.getAClassReference().getAnInstantiation()
+          )
+          or
+          exists(string prop |
+            PreCallGraphStep::loadStep(pred.getALocalUse(), ref, prop) and
+            lbl = Label::member(prop) and
+            // avoid generating member edges like "$arrayElement$"
+            not DataFlow::PseudoProperties::isPseudoProperty(prop)
           )
         )
         or

--- a/javascript/ql/lib/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/lib/semmle/javascript/ApiGraphs.qll
@@ -7,6 +7,7 @@
 
 import javascript
 private import semmle.javascript.dataflow.internal.FlowSteps as FlowSteps
+private import semmle.javascript.dataflow.internal.PreCallGraphStep
 private import internal.CachedStages
 
 /**
@@ -767,6 +768,12 @@ module API {
             m = imp.getImportedModule() and
             lbl = Label::member(prop) and
             rhs = m.getAnExportedValue(prop)
+          )
+          or
+          // In general, turn store steps into member steps for def-nodes
+          exists(string prop |
+            PreCallGraphStep::storeStep(rhs, pred, prop) and
+            lbl = Label::member(prop)
           )
           or
           exists(DataFlow::FunctionNode fn |

--- a/javascript/ql/lib/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/lib/semmle/javascript/ApiGraphs.qll
@@ -1536,7 +1536,9 @@ module API {
           prop = any(CanonicalName c).getName() or
           prop = any(DataFlow::PropRef p).getPropertyName() or
           exists(Impl::MkTypeUse(_, prop)) or
-          exists(any(Module m).getAnExportedValue(prop))
+          exists(any(Module m).getAnExportedValue(prop)) or
+          PreCallGraphStep::loadStep(_, _, prop) or
+          PreCallGraphStep::storeStep(_, _, prop)
         } or
         MkLabelUnknownMember() or
         MkLabelParameter(int i) {

--- a/javascript/ql/lib/semmle/javascript/ES2015Modules.qll
+++ b/javascript/ql/lib/semmle/javascript/ES2015Modules.qll
@@ -510,6 +510,9 @@ class ExportNamedDeclaration extends ExportDeclaration, @export_named_declaratio
       or
       exists(ReExportDeclaration red | red = this |
         result = red.getReExportedES2015Module().getAnExport().getSourceNode(spec.getLocalName())
+        or
+        spec instanceof ExportNamespaceSpecifier and
+        result = DataFlow::valueNode(spec)
       )
     )
   }
@@ -522,6 +525,19 @@ class ExportNamedDeclaration extends ExportDeclaration, @export_named_declaratio
 
   /** Gets an export specifier of this declaration. */
   ExportSpecifier getASpecifier() { result = this.getSpecifier(_) }
+}
+
+private import semmle.javascript.dataflow.internal.PreCallGraphStep
+
+private class ExportNamespaceStep extends PreCallGraphStep {
+  override predicate storeStep(DataFlow::Node pred, DataFlow::SourceNode succ, string prop) {
+    exists(ExportNamedDeclaration exprt, ExportNamespaceSpecifier spec |
+      spec = exprt.getASpecifier() and
+      pred =
+        exprt.(ReExportDeclaration).getReExportedES2015Module().getAnExport().getSourceNode(prop) and
+      succ = DataFlow::valueNode(spec)
+    )
+  }
 }
 
 /**

--- a/javascript/ql/lib/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/Configuration.qll
@@ -704,6 +704,10 @@ module SharedFlowStep {
  * For use with load/store steps in `DataFlow::SharedFlowStep` and TypeTracking.
  */
 module PseudoProperties {
+  /** Holds if `s` is a pseudo-property. */
+  bindingset[s]
+  predicate isPseudoProperty(string s) { s.matches("$%$") }
+
   bindingset[s]
   private string pseudoProperty(string s) { result = "$" + s + "$" }
 

--- a/javascript/ql/lib/semmle/javascript/dataflow/Sources.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/Sources.qll
@@ -322,6 +322,7 @@ module SourceNode {
         astNode instanceof FunctionBindExpr or
         astNode instanceof DynamicImportExpr or
         astNode instanceof ImportSpecifier or
+        astNode instanceof ExportNamespaceSpecifier or
         astNode instanceof ImportMetaExpr or
         astNode instanceof TaggedTemplateExpr or
         astNode instanceof Templating::PipeRefExpr or

--- a/javascript/ql/test/ApiGraphs/custom-use-steps/VerifyAssertions.ql
+++ b/javascript/ql/test/ApiGraphs/custom-use-steps/VerifyAssertions.ql
@@ -1,0 +1,13 @@
+import ApiGraphs.VerifyAssertions
+private import semmle.javascript.dataflow.internal.PreCallGraphStep
+
+class CustomUseStep extends PreCallGraphStep {
+  override predicate loadStep(DataFlow::Node pred, DataFlow::Node succ, string prop) {
+    exists(DataFlow::CallNode call |
+      call.getCalleeName() = "customLoad" and
+      pred = call.getArgument(0) and
+      succ = call and
+      prop = call.getArgument(1).getStringValue()
+    )
+  }
+}

--- a/javascript/ql/test/ApiGraphs/custom-use-steps/index.js
+++ b/javascript/ql/test/ApiGraphs/custom-use-steps/index.js
@@ -1,0 +1,4 @@
+const foo = require("foo");
+
+foo.bar; // use=moduleImport("foo").getMember("exports").getMember("bar")
+customLoad(foo, "baz") // use=moduleImport("foo").getMember("exports").getMember("baz")

--- a/javascript/ql/test/ApiGraphs/custom-use-steps/package.json
+++ b/javascript/ql/test/ApiGraphs/custom-use-steps/package.json
@@ -1,0 +1,3 @@
+{
+    "name": "custom-use-steps"
+}

--- a/javascript/ql/test/ApiGraphs/reexport/VerifyAssertions.expected
+++ b/javascript/ql/test/ApiGraphs/reexport/VerifyAssertions.expected
@@ -1,0 +1,1 @@
+| lib/esmodule-reexported2.js:1:26:1:137 | /* def= ... wo") */ | def moduleImport("reexport").getMember("exports").getMember("esmodule") has no outgoing edge labelled getMember("lib2"); it does have outgoing edges labelled getMember("one"). |

--- a/javascript/ql/test/ApiGraphs/reexport/VerifyAssertions.expected
+++ b/javascript/ql/test/ApiGraphs/reexport/VerifyAssertions.expected
@@ -1,1 +1,0 @@
-| lib/esmodule-reexported2.js:1:26:1:137 | /* def= ... wo") */ | def moduleImport("reexport").getMember("exports").getMember("esmodule") has no outgoing edge labelled getMember("lib2"); it does have outgoing edges labelled getMember("one"). |

--- a/javascript/ql/test/ApiGraphs/reexport/index.js
+++ b/javascript/ql/test/ApiGraphs/reexport/index.js
@@ -4,5 +4,6 @@ module.exports = {
     impl,
     util: require("./lib/utils"),
     other: require("./lib/stuff"),
-    util2: require("./lib/utils2")
+    util2: require("./lib/utils2"),
+    esmodule: require("./lib/esmodule-reexport"),
 };

--- a/javascript/ql/test/ApiGraphs/reexport/lib/esmodule-reexport.js
+++ b/javascript/ql/test/ApiGraphs/reexport/lib/esmodule-reexport.js
@@ -1,0 +1,2 @@
+export * from "./esmodule-reexported1";
+export * as lib2 from "./esmodule-reexported2";

--- a/javascript/ql/test/ApiGraphs/reexport/lib/esmodule-reexported1.js
+++ b/javascript/ql/test/ApiGraphs/reexport/lib/esmodule-reexported1.js
@@ -1,0 +1,1 @@
+export function one() {} /* def=moduleImport("reexport").getMember("exports").getMember("esmodule").getMember("one") */

--- a/javascript/ql/test/ApiGraphs/reexport/lib/esmodule-reexported2.js
+++ b/javascript/ql/test/ApiGraphs/reexport/lib/esmodule-reexported2.js
@@ -1,0 +1,1 @@
+export function two() {} /* def=moduleImport("reexport").getMember("exports").getMember("esmodule").getMember("lib2").getMember("two") */

--- a/javascript/ql/test/library-tests/Modules/tests.expected
+++ b/javascript/ql/test/library-tests/Modules/tests.expected
@@ -81,6 +81,7 @@ test_Module_exports
 | export-in-mjs.mjs:1:1:1:34 | <toplevel> | exported_from_mjs | export-in-mjs.mjs:1:32:1:33 | 42 |
 | f.ts:1:1:6:0 | <toplevel> | foo | f.ts:5:8:5:24 | function foo() {} |
 | m/c.js:1:1:6:0 | <toplevel> | h | b.js:5:10:5:10 | f |
+| reExportNamespace.js:1:1:2:0 | <toplevel> | ns | reExportNamespace.js:1:8:1:14 | * as ns |
 | tst.html:4:23:8:0 | <toplevel> | y | tst.html:7:20:7:21 | 42 |
 test_NamedImportSpecifier
 | d.js:1:10:1:21 | default as g |
@@ -149,4 +150,5 @@ test_getSourceNode
 | export-in-mjs.mjs:1:1:1:34 | export  ... s = 42; | exported_from_mjs | export-in-mjs.mjs:1:32:1:33 | 42 |
 | f.ts:5:1:5:24 | export  ... oo() {} | foo | f.ts:5:8:5:24 | function foo() {} |
 | m/c.js:5:1:5:30 | export  ... '../b'; | h | b.js:5:10:5:10 | f |
+| reExportNamespace.js:1:1:1:26 | export  ...  "./a"; | ns | reExportNamespace.js:1:8:1:14 | * as ns |
 | tst.html:7:3:7:22 | export const y = 42; | y | tst.html:7:20:7:21 | 42 |


### PR DESCRIPTION
We didn't properly support this in API graphs:
```js
export * as foo from "./bar"
```

When we can resolve `./bar` to a module, we now generate store steps into the `* as foo` specifier, and mark `* as foo` as the export named `foo` in the current module.

This also led to some general improvements to API graphs since it's quite convenient if API graphs generally converts load/store to member steps (something similar is already happening in Ruby).