### PR TITLE
C#: Do not call `CSharpCompilation.Clone`

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Extractor/Analyser.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Extractor/Analyser.cs
@@ -146,14 +146,9 @@ namespace Semmle.Extraction.CSharp
                      * still be correct.
                      */
 
-                    // compilation.Clone() reduces memory footprint by allowing the symbols
-                    // in c to be garbage collected.
-                    Compilation c = compilation.Clone();
-
-
-                    if (c.GetAssemblyOrModuleSymbol(r) is IAssemblySymbol assembly)
+                    if (compilation.GetAssemblyOrModuleSymbol(r) is IAssemblySymbol assembly)
                     {
-                        var cx = new Context(extractor, c, trapWriter, new AssemblyScope(assembly, assemblyPath), addAssemblyTrapPrefix);
+                        var cx = new Context(extractor, compilation, trapWriter, new AssemblyScope(assembly, assemblyPath), addAssemblyTrapPrefix);
 
                         foreach (var module in assembly.Modules)
                         {
@@ -196,7 +191,7 @@ namespace Semmle.Extraction.CSharp
 
                 if (!upToDate)
                 {
-                    var cx = new Context(extractor, compilation.Clone(), trapWriter, new SourceScope(tree), addAssemblyTrapPrefix);
+                    var cx = new Context(extractor, compilation, trapWriter, new SourceScope(tree), addAssemblyTrapPrefix);
                     // Ensure that the file itself is populated in case the source file is totally empty
                     var root = tree.GetRoot();
                     Entities.File.Create(cx, root.SyntaxTree.FilePath);
@@ -236,7 +231,7 @@ namespace Semmle.Extraction.CSharp
                 var assembly = compilation.Assembly;
                 var trapWriter = transformedAssemblyPath.CreateTrapWriter(Logger, options.TrapCompression, discardDuplicates: false);
                 compilationTrapFile = trapWriter;  // Dispose later
-                var cx = new Context(extractor, compilation.Clone(), trapWriter, new AssemblyScope(assembly, assemblyPath), addAssemblyTrapPrefix);
+                var cx = new Context(extractor, compilation, trapWriter, new AssemblyScope(assembly, assemblyPath), addAssemblyTrapPrefix);
 
                 compilationEntity = Entities.Compilation.Create(cx);
 


### PR DESCRIPTION
Despite what the original comment said, calling `CSharpCompilation.Clone` actually makes the extractor consume _more_ memory instead of less memory, at least when running in buildless mode, where all `.cs` files are included in one single compilation.

Running buildless extraction on `dotnet/roslyn` locally with `/usr/bin/time -l` reported a `maximum resident set size` of `51,035,299,840` before this PR and `15,477,882,880` after.

DCA confirms that this is an improvement, as the database build time for `mono/mono` and `OrchardCMS/OrchardCore` decrease by 70% in buildless mode.