### PR TITLE
C++: Improve handling of re-use expressions

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/exprs/Expr.qll
+++ b/cpp/ql/lib/semmle/code/cpp/exprs/Expr.qll
@@ -6,6 +6,7 @@ import semmle.code.cpp.Element
 private import semmle.code.cpp.Enclosing
 private import semmle.code.cpp.internal.ResolveClass
 private import semmle.code.cpp.internal.AddressConstantExpression
+private import semmle.code.cpp.internal.ExtractorVersion
 
 /**
  * A C/C++ expression.
@@ -1371,17 +1372,7 @@ class ReuseExpr extends Expr, @reuseexpr {
   /**
    * Gets the expression that is being re-used.
    */
-  Expr getReusedExpr() {
-    // In the case of a prvalue, the extractor outputs the expression
-    // before conversion, but the converted expression is intended.
-    if this.isPRValueCategory()
-    then result = this.getBaseReusedExpr().getFullyConverted()
-    else result = this.getBaseReusedExpr()
-  }
-
-  private Expr getBaseReusedExpr() {
-    expr_reuse(underlyingElement(this), unresolveElement(result), _)
-  }
+  Expr getReusedExpr() { expr_reuse(underlyingElement(this), unresolveElement(result), _) }
 
   override Type getType() { result = this.getReusedExpr().getType() }
 

--- a/cpp/ql/lib/semmle/code/cpp/exprs/Expr.qll
+++ b/cpp/ql/lib/semmle/code/cpp/exprs/Expr.qll
@@ -6,7 +6,6 @@ import semmle.code.cpp.Element
 private import semmle.code.cpp.Enclosing
 private import semmle.code.cpp.internal.ResolveClass
 private import semmle.code.cpp.internal.AddressConstantExpression
-private import semmle.code.cpp.internal.ExtractorVersion
 
 /**
  * A C/C++ expression.


### PR DESCRIPTION
This will slightly brake IR generation for databases created with CodeQL 2.17.1. There are two changes:
* Some type are different in the IR. This seems inconsequential.
* The IR becomes inconsistent when a null pointer is being deleted. This should hopefully not occur at all in real world code.