### PR TITLE
Go: Use value flow instead of taint flow for `go/incorrect-integer-conversion`

### DIFF
--- a/go/ql/lib/semmle/go/security/IncorrectIntegerConversionLib.qll
+++ b/go/ql/lib/semmle/go/security/IncorrectIntegerConversionLib.qll
@@ -572,7 +572,7 @@ private module ConversionWithoutBoundsCheckConfig implements DataFlow::StateConf
  * Tracks taint flow from an integer obtained from parsing a string that flows
  * to a type conversion to a smaller integer type, which could cause data loss.
  */
-module Flow = TaintTracking::GlobalWithState<ConversionWithoutBoundsCheckConfig>;
+module Flow = DataFlow::GlobalWithState<ConversionWithoutBoundsCheckConfig>;
 
 /** Gets a string describing the size of the integer parsed. */
 deprecated string describeBitSize(int bitSize, int intTypeBitSize) {


### PR DESCRIPTION
This should remove some FPs and also improve performance, especially on projects with lots of FPs. I have done a DCA run and the results look good. I will do a DCA run.