### PR TITLE
Bazel: introduce buildifier formatting

### DIFF
--- a/.github/workflows/buildifier.yml
+++ b/.github/workflows/buildifier.yml
@@ -1,0 +1,26 @@
+name: Check bazel formatting
+
+on:
+  pull_request:
+    paths:
+      - "**.bazel"
+      - "**.bzl"
+    branches:
+      - main
+      - "rc/*"
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507
+        with:
+          extra_args: buildifier --all-files --show-diff-on-failure
+      - if: failure()
+        run: |
+          echo "In order to format all files, please run:"
+          echo "  bazel run //:buildifier"

--- a/.github/workflows/buildifier.yml
+++ b/.github/workflows/buildifier.yml
@@ -16,11 +16,15 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check bazel formatting
+        uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507
         with:
           extra_args: buildifier --all-files --show-diff-on-failure
-      - if: failure()
+      - name: Print rectifying command
+        if: failure()
         run: |
-          echo "In order to format all files, please run:"
+          echo "In order to format all bazel files, please run:"
           echo "  bazel run //:buildifier"
+          exit 1

--- a/.github/workflows/buildifier.yml
+++ b/.github/workflows/buildifier.yml
@@ -21,10 +21,11 @@ jobs:
       - name: Check bazel formatting
         uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507
         with:
-          extra_args: buildifier --all-files --show-diff-on-failure
-      - name: Print rectifying command
+          extra_args: buildifier --all-files 2>&1 | tee check_output
+      - name: Report
         if: failure()
         run: |
+          sed -ne '/diff --git/,$ p' check_output
           echo "In order to format all bazel files, please run:"
           echo "  bazel run //:buildifier"
           exit 1

--- a/.github/workflows/buildifier.yml
+++ b/.github/workflows/buildifier.yml
@@ -21,11 +21,8 @@ jobs:
       - name: Check bazel formatting
         uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507
         with:
-          extra_args: buildifier --all-files 2>&1 | tee check_output
-      - name: Report
-        if: failure()
-        run: |
-          sed -ne '/diff --git/,$ p' check_output
-          echo "In order to format all bazel files, please run:"
-          echo "  bazel run //:buildifier"
-          exit 1
+          extra_args: >
+            buildifier --all-files 2>&1 ||
+            (
+              echo -e "In order to format all bazel files, please run:\n  bazel run //:buildifier"; exit 1
+            )

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,13 +20,15 @@ repos:
       - id: autopep8
         files: ^misc/codegen/.*\.py
 
-  - repo: https://github.com/warchant/pre-commit-buildifier
-    rev: 0.0.2
-    hooks:
-      - id: buildifier
-
   - repo: local
     hooks:
+      - id: buildifier
+        name: Format bazel files
+        files: \.(bazel|bzl)
+        language: system
+        entry: bazel run //:buildifier
+        pass_filenames: false
+
       - id: codeql-format
         name: Fix QL file formatting
         files: \.qll?$

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@buildifier_prebuilt//:rules.bzl", "buildifier")
+
+buildifier(
+    name = "buildifier",
+    exclude_patterns = [
+        "./.git/*",
+    ],
+    lint_mode = "fix",
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,6 +22,8 @@ bazel_dep(name = "abseil-cpp", version = "20240116.0", repo_name = "absl")
 bazel_dep(name = "nlohmann_json", version = "3.11.3", repo_name = "json")
 bazel_dep(name = "fmt", version = "10.0.0")
 
+bazel_dep(name = "buildifier_prebuilt", version = "6.4.0", dev_dependency = True)
+
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(
     hub_name = "codegen_deps",

--- a/javascript/BUILD.bazel
+++ b/javascript/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@semmle_code//:dist.bzl", "dist")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+load("@semmle_code//:dist.bzl", "dist")
 load("@semmle_code//buildutils-internal:zipmerge.bzl", "zipmerge")
 
 package(default_visibility = ["//visibility:public"])

--- a/javascript/extractor/BUILD.bazel
+++ b/javascript/extractor/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@semmle_code//:common.bzl", "codeql_fat_jar", "codeql_java_project")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+load("@semmle_code//:common.bzl", "codeql_fat_jar", "codeql_java_project")
 
 java_library(
     name = "deps",

--- a/misc/codegen/BUILD.bazel
+++ b/misc/codegen/BUILD.bazel
@@ -1,5 +1,3 @@
-load("@codegen_deps//:requirements.bzl", "requirement")
-
 py_binary(
     name = "codegen",
     srcs = ["codegen.py"],

--- a/misc/codegen/generators/BUILD.bazel
+++ b/misc/codegen/generators/BUILD.bazel
@@ -1,5 +1,3 @@
-load("@codegen_deps//:requirements.bzl", "requirement")
-
 py_library(
     name = "generators",
     srcs = glob(["*.py"]),

--- a/python/extractor/tsg-python/tsp/BUILD.bazel
+++ b/python/extractor/tsg-python/tsp/BUILD.bazel
@@ -1,6 +1,6 @@
+load("@py_deps//:defs.bzl", "aliases", "all_crate_deps")
 load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 load("@rules_rust//rust:defs.bzl", "rust_library")
-load("@py_deps//:defs.bzl", "aliases", "all_crate_deps")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/swift/extractor/BUILD.bazel
+++ b/swift/extractor/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//swift:rules.bzl", "swift_cc_binary")
 load("//misc/bazel:pkg_runfiles.bzl", "pkg_runfiles")
+load("//swift:rules.bzl", "swift_cc_binary")
 
 swift_cc_binary(
     name = "extractor.real",
@@ -7,6 +7,10 @@ swift_cc_binary(
         "*.h",
         "*.cpp",
     ]),
+    linkopts = select({
+        "@platforms//os:macos": ["-headerpad_max_install_names"],
+        "//conditions:default": [],
+    }),
     visibility = ["//swift:__pkg__"],
     deps = [
         "//swift/extractor/config",
@@ -17,10 +21,6 @@ swift_cc_binary(
         "//swift/third_party/swift-llvm-support",
         "@absl//absl/strings",
     ],
-    linkopts = select({
-        "@platforms//os:macos": ["-headerpad_max_install_names"],
-        "//conditions:default": [],
-    }),
 )
 
 sh_binary(

--- a/swift/logging/BUILD.bazel
+++ b/swift/logging/BUILD.bazel
@@ -4,10 +4,10 @@ cc_library(
     hdrs = glob(["*.h"]),
     visibility = ["//visibility:public"],
     deps = [
+        "//shared/cpp:extractor_shared",
         "@absl//absl/strings",
         "@binlog",
         "@fmt",
         "@json",
-        "//shared/cpp:extractor_shared",
     ],
 )


### PR DESCRIPTION
This introduces tooling and enforcement for formatting bazel files.

The tooling is provided as a bazel run target from [keith/buildifier-prebuilt](https://github.com/keith/buildifier-prebuilt).

This is used in a [`pre-commit`](https://pre-commit.com/) hook for those having that installed. In turn this is used in a CI check. Relying on a `pre-commit` action gives us easy checking that buildifying did not change anything in the files and printing the diff, without having to hand-roll the check ourselves.