### PR TITLE
C++: Fix typo.

### DIFF
--- a/cpp/ql/src/experimental/Security/CWE/CWE-125/DangerousWorksWithMultibyteOrWideCharacters.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-125/DangerousWorksWithMultibyteOrWideCharacters.ql
@@ -24,7 +24,7 @@ predicate exprMayBeString(Expr exp) {
         fctmp.getAnArgument().(VariableAccess).getTarget() = exp.(VariableAccess).getTarget() or
         globalValueNumber(fctmp.getAnArgument()) = globalValueNumber(exp)
       ) and
-      fctmp.getTarget().hasName(["strlen", "strcat", "strncat", "strcpy", "sptintf", "printf"])
+      fctmp.getTarget().hasName(["strlen", "strcat", "strncat", "strcpy", "sprintf", "printf"])
     )
     or
     exists(AssignExpr astmp |


### PR DESCRIPTION
Fix typo in experimental query `cpp/dangerous-use-convert-function`.