### PR TITLE
DataFlow: Cache `getSecondLevelScope`

### DIFF
--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -1119,9 +1119,10 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
     pragma[nomagic]
     private SndLevelScopeOption getScope(RetNodeEx ret) {
-      result = SndLevelScopeOption::some(getSecondLevelScope(ret.asNode()))
+      result = SndLevelScopeOption::some(getSecondLevelScopeCached(ret.asNode()))
       or
-      result instanceof SndLevelScopeOption::None and not exists(getSecondLevelScope(ret.asNode()))
+      result instanceof SndLevelScopeOption::None and
+      not exists(getSecondLevelScopeCached(ret.asNode()))
     }
 
     pragma[nomagic]

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
@@ -617,6 +617,9 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     predicate forceCachingInSameStage() { any() }
 
     cached
+    DataFlowSecondLevelScope getSecondLevelScopeCached(Node n) { result = getSecondLevelScope(n) }
+
+    cached
     predicate nodeEnclosingCallable(Node n, DataFlowCallable c) { c = nodeGetEnclosingCallable(n) }
 
     cached


### PR DESCRIPTION
I was seeing `getSecondLevelScope` evaluated 13 times when running security-and-quality on C++:
```ql
[2024-04-26 11:45:12] Evaluated non-recursive predicate DataFlowPrivate::getSecondLevelScope/1#14eac193@06c247lf in 6763ms (size: 17958858).
Evaluated relational algebra for predicate DataFlowPrivate::getSecondLevelScope/1#14eac193@06c247lf with tuple counts:
         17974438   ~0%    {2} r1 = SCAN `SSAConstruction::getInstructionAst/1#d0d95b50` OUTPUT In.1, In.0
         17007656   ~2%    {2}    | JOIN WITH `ControlFlowGraph::ControlFlowNode.getEnclosingStmt/0#dispred#fa57cf97` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
                       
        171579959   ~0%    {2} r2 = JOIN r1 WITH `boundedFastTC:Stmt::Stmt.getParentStmt/0#dispred#c84c2aca:_ControlFlowGraph::ControlFlowNode.getEnclosingStmt/0#dispred#fa57cf97_SSAConstruction::getInstructi__#higher_order_body` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
                       
        188587615   ~0%    {2} r3 = r1 UNION r2
         10692306   ~0%    {2}    | JOIN WITH `DataFlowPrivate::DataFlowSecondLevelScope.getAStmt/0#dispred#a01ddd53_10#join_rhs` ON FIRST 1 OUTPUT Lhs.1, Rhs.1
         18671793  ~17%    {2}    | JOIN WITH `DataFlowPrivate::getAnInstruction/1#db1ad56d_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
                           return r3
...
[2024-04-26 11:45:13] Evaluated non-recursive predicate DataFlowPrivate::getSecondLevelScope/1#14eac193@cff7d5oq in 6779ms (size: 17854084).
Evaluated relational algebra for predicate DataFlowPrivate::getSecondLevelScope/1#14eac193@cff7d5oq with tuple counts:
         17974438   ~0%    {2} r1 = SCAN `SSAConstruction::getInstructionAst/1#d0d95b50` OUTPUT In.1, In.0
         17007656   ~2%    {2}    | JOIN WITH `ControlFlowGraph::ControlFlowNode.getEnclosingStmt/0#dispred#fa57cf97` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
                       
        171579959   ~0%    {2} r2 = JOIN r1 WITH `boundedFastTC:Stmt::Stmt.getParentStmt/0#dispred#c84c2aca:_ControlFlowGraph::ControlFlowNode.getEnclosingStmt/0#dispred#fa57cf97_SSAConstruction::getInstructi__#higher_order_body` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
                       
        188587615   ~0%    {2} r3 = r1 UNION r2
         10692306   ~0%    {2}    | JOIN WITH `DataFlowPrivate::DataFlowSecondLevelScope.getAStmt/0#dispred#a01ddd53_10#join_rhs` ON FIRST 1 OUTPUT Lhs.1, Rhs.1
         18671793  ~17%    {2}    | JOIN WITH `DataFlowPrivate::getAnInstruction/1#db1ad56d_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
                           return r3
...
[2024-04-26 11:45:36] Evaluated non-recursive predicate DataFlowPrivate::getSecondLevelScope/1#14eac193@ce798187 in 23420ms (size: 18029768).
Evaluated relational algebra for predicate DataFlowPrivate::getSecondLevelScope/1#14eac193@ce798187 with tuple counts:
         17974438   ~0%    {2} r1 = SCAN `SSAConstruction::getInstructionAst/1#d0d95b50` OUTPUT In.1, In.0
         17007656   ~2%    {2}    | JOIN WITH `ControlFlowGraph::ControlFlowNode.getEnclosingStmt/0#dispred#fa57cf97` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
                       
        171579959   ~0%    {2} r2 = JOIN r1 WITH `boundedFastTC:Stmt::Stmt.getParentStmt/0#dispred#c84c2aca:_ControlFlowGraph::ControlFlowNode.getEnclosingStmt/0#dispred#fa57cf97_SSAConstruction::getInstructi__#higher_order_body` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
                       
        188587615   ~0%    {2} r3 = r1 UNION r2
         10692306   ~0%    {2}    | JOIN WITH `DataFlowPrivate::DataFlowSecondLevelScope.getAStmt/0#dispred#a01ddd53_10#join_rhs` ON FIRST 1 OUTPUT Lhs.1, Rhs.1
         18671793  ~17%    {2}    | JOIN WITH `DataFlowPrivate::getAnInstruction/1#db1ad56d_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
                           return r3
```
After this PR we just have:
```ql
[2024-04-26 13:02:04] Evaluated non-recursive predicate DataFlowImplCommon::Cached::getSecondLevelScopeCached/1#7c22811c@d8fc562i in 33857ms (size: 18161972).
Evaluated relational algebra for predicate DataFlowImplCommon::Cached::getSecondLevelScopeCached/1#7c22811c@d8fc562i with tuple counts:
         17974438   ~0%    {2} r1 = SCAN `SSAConstruction::getInstructionAst/1#d0d95b50` OUTPUT In.1, In.0
         17007656   ~0%    {2}    | JOIN WITH `ControlFlowGraph::ControlFlowNode.getEnclosingStmt/0#dispred#fa57cf97` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
                       
        171579959   ~1%    {2} r2 = JOIN r1 WITH `boundedFastTC:Stmt::Stmt.getParentStmt/0#dispred#c84c2aca:_ControlFlowGraph::ControlFlowNode.getEnclosingStmt/0#dispred#fa57cf97_SSAConstruction::getInstructi__#higher_order_body` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
                       
        188587615   ~0%    {2} r3 = r1 UNION r2
         10692306   ~0%    {2}    | JOIN WITH `DataFlowPrivate::DataFlowSecondLevelScope.getAStmt/0#dispred#a01ddd53_10#join_rhs` ON FIRST 1 OUTPUT Lhs.1, Rhs.1
         18671793  ~16%    {2}    | JOIN WITH `DataFlowPrivate::getAnInstruction/1#db1ad56d_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
                           return r3
```