### PR TITLE
C++: Remove a stage by properly caching `getResultIRType`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
@@ -247,8 +247,7 @@ class Instruction extends Construction::TStageInstruction {
    * Gets the type of the result produced by this instruction. If the instruction does not produce
    * a result, its result type will be `IRVoidType`.
    */
-  cached
-  final IRType getResultIRType() { result = this.getResultLanguageType().getIRType() }
+  final IRType getResultIRType() { result = Construction::getInstructionResultIRType(this) }
 
   /**
    * Gets the type of the result produced by this instruction. If the

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
@@ -429,6 +429,11 @@ private module Cached {
     instr = unreachedInstruction(_) and result = Language::getVoidType()
   }
 
+  cached
+  IRType getInstructionResultIRType(Instruction instr) {
+    result = instr.getResultLanguageType().getIRType()
+  }
+
   /**
    * Holds if `opcode` is the opcode that specifies the operation performed by `instr`.
    *

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/Instruction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/Instruction.qll
@@ -247,8 +247,7 @@ class Instruction extends Construction::TStageInstruction {
    * Gets the type of the result produced by this instruction. If the instruction does not produce
    * a result, its result type will be `IRVoidType`.
    */
-  cached
-  final IRType getResultIRType() { result = this.getResultLanguageType().getIRType() }
+  final IRType getResultIRType() { result = Construction::getInstructionResultIRType(this) }
 
   /**
    * Gets the type of the result produced by this instruction. If the

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/IRConstruction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/IRConstruction.qll
@@ -377,6 +377,10 @@ CppType getInstructionResultType(TStageInstruction instr) {
   result = getVoidType()
 }
 
+IRType getInstructionResultIRType(Instruction instr) {
+  result = instr.getResultLanguageType().getIRType()
+}
+
 predicate getInstructionOpcode(Opcode opcode, TStageInstruction instr) {
   getInstructionTranslatedElement(instr).hasInstruction(opcode, getInstructionTag(instr), _)
   or

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
@@ -247,8 +247,7 @@ class Instruction extends Construction::TStageInstruction {
    * Gets the type of the result produced by this instruction. If the instruction does not produce
    * a result, its result type will be `IRVoidType`.
    */
-  cached
-  final IRType getResultIRType() { result = this.getResultLanguageType().getIRType() }
+  final IRType getResultIRType() { result = Construction::getInstructionResultIRType(this) }
 
   /**
    * Gets the type of the result produced by this instruction. If the

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -429,6 +429,11 @@ private module Cached {
     instr = unreachedInstruction(_) and result = Language::getVoidType()
   }
 
+  cached
+  IRType getInstructionResultIRType(Instruction instr) {
+    result = instr.getResultLanguageType().getIRType()
+  }
+
   /**
    * Holds if `opcode` is the opcode that specifies the operation performed by `instr`.
    *


### PR DESCRIPTION
The `getResultIRType` was cached in a non-optimal way. The cached annotation was put on the top-level predicate (since we at some point identified that this predicate should be cached). However, by adding the `cached` keyword there instead of inside a `cached` module with all the other cached IR predicates the evaluator generated a whole evalaution stage just for this single predicate. This can be seen in evaluation logs such as:
```ql

Most expensive predicates for stage 15 of completed query TaintedPath.ql:
        time | evals | max @ iter | predicate
        -----|-------|------------|----------
         7ms |       |            | Declaration::Declaration#46770055@c8d6b3b5
         6ms |       |            | ExternalFlow::elementSpec/6#fd7bf2b1@8bed2a7i
         6ms |       |            | DataFlowPrivate::TSourceCallable#a13330bf@acbae1ds
         5ms |       |            | fun_decls_10#join_rhs@fb517a5h
         4ms |       |            | Class::Class.getCanonicalMember/1#dispred#e1747079@59460cq7
         3ms |       |            | DataFlowPrivate::TDataFlowCallable#9bdb3baf@62de378p
         2ms |       |            | DataFlowPrivate::TSourceCallable#dom#a3634ffd@f92f45qj
         1ms |       |            | TypedefType::TypedefType.getBaseType/0#dispred#671605ef@715e90n0
         1ms |     5 | 1ms @ 1    | Type::Type.getUnderlyingType/0#dispred#bd141f6a@3061fat4
         1ms |       |            | TypedefType::TypedefType.getBaseType/0#dispred#671605ef_10#join_rhs@a81930mc
         1ms |       |            | ExternalFlow::summaryModel/10#ed1acd3b#cpe#123456789@f0fe2d3l
         1ms |       |            | Class::Class.getCanonicalMember/1#dispred#e1747079_20#join_rhs@645b5ekd
         1ms |       |            | Type::Type.getUnderlyingType/0#fb0826e6@411784sq
         1ms |       |            | ExternalFlow::sinkModel/1#80d5b724@fecbeecu
         1ms |       |            | ResolveClass::resolveClass/1#ea47deee_10#join_rhs@74e000p5
         1ms |       |            | usertypes_20#join_rhs@ac4cbbos
         0ms |       |            | Class::Class#9afdbffd@2b40742v
         0ms |       |            | Declaration::Declaration.getATemplateArgument/0#dispred#260b9dcc@74d936hc
         0ms |       |            | ExternalFlow::elementSpec/6#fd7bf2b1_12034#join_rhs@9f5212l3
         0ms |       |            | Declaration::Declaration.getTemplateArgumentType/1#dispred#b0efb79c@032d2c5h
         0ms |       |            | Type::IntegralOrEnumType#39f31122@2584180f
         0ms |       |            | UserType::UserType#21e9e463@ea2864de
         0ms |       |            | ExternalFlow::sourceModel/1#f955af9f@57e397hq
         0ms |       |            | ExternalFlow::interpretElement0/5#abbcf1b1@70bf8big
         0ms |       |            | Declaration::Declaration.getTemplateArgumentValue/1#dispred#3eef4b7f@9ac79co4
         0ms |       |            | ExternalFlow::summaryModel/1#6340a8e5@551e94j0
         0ms |       |            | ExternalFlow::summaryModel/10#ed1acd3b#cpe#123456789_501234#join_rhs@623f28bv
         0ms |       |            | project#ExternalFlow::summaryModel/10#ed1acd3b#cpe#123456789#2@e222f4mm
         0ms |       |            | project#ExternalFlow::summaryModel/10#ed1acd3b#cpe#123456789@572fd5ba
         0ms |       |            | project#ExternalFlow::elementSpec/6#fd7bf2b1#3@d69b9fnt
         0ms |       |            | enumconstants_10#join_rhs@82707fql
         0ms |       |            | Function::Function.getClassAndName/1#27b7404e@552e4a6b
         0ms |       |            | FlowSummaryImpl::Public::SummarizedCallable#class#78e39c96@83faa3pr
         0ms |       |            | usertypes_02#join_rhs@3ddf5c3g
         0ms |       |            | project#ExternalFlow::elementSpec/6#fd7bf2b1#2@8c2fe5tu
         0ms |       |            | TypedefType::TypedefType#64088755@e44345s8
         0ms |       |            | usertypes_0#antijoin_rhs@e4754bn3

Most expensive predicates for stage 16 of completed query TaintedPath.ql:
        time  | predicate
        ------|----------
        515ms | Instruction::Instruction.getResultIRType/0#dispred#b64cb06b@d41601ad

Most expensive predicates for stage 17 of completed query TaintedPath.ql:
        time | predicate
        -----|----------
        99ms | SsaInternals::TMkSourceVariable#dom#7e669ef1@95b64cto
        41ms | SsaInternals::TMkSourceVariable#273109bd@1321788s
        18ms | num#SsaInternalsCommon::TBaseCallVariable#9ae7ff69@0bf409fq
        16ms | _IRType::TIRVoidType#ca101bce_Instruction::Instruction.getResultIRType/0#dispred#b64cb06b__SSAConstr__#antijoin_rhs@ef212dor
        13ms | num#TIRVariable::TIRUserVariable#d8389a6a@87fd13hd
        13ms | SsaInternalsCommon::AbstractBaseSourceVariable.getLanguageType/0#dispred#0706de3e@38b3247r
        12ms | IRVariable::IRVariable.getLanguageType/0#dispred#1fae4e11@44a7dd9i
        11ms | SsaInternals::TSourceVariable#db4c13f7@c9d8da3m
         8ms | IRVariable::IRVariable#37c241c4@97cddbbc
         6ms | SsaInternalsCommon::countIndirectionsForCppType/1#21060fdc@80e46e6v
         6ms | TIRVariable::TIRUserVariable#dom#79ed4a5f@555b0568
         6ms | num#SsaInternalsCommon::TBaseIRVariable#fb78d52a@6a2bb14o
         6ms | SsaInternalsCommon::BaseIRVariable#7cacba18@64e131mj
         5ms | num#TIRVariable::TIRTempVariable#d8b39899@7291caja
         4ms | QualifiedName::declarationHasQualifiedName/4#749d7d29_1203#join_rhs@d826d2cu
         4ms | CppType::CppType.hasType/2#dispred#d3f6ee89@2b497dhe
         4ms | num#TIRVariable::TIRStringLiteral#523b423c@15de08kp
         4ms | Type::Type.getUnspecifiedType/0#09579faa@8e318dub
         3ms | Type::DerivedType.getBaseType/0#dispred#b08b94f7@1101cbdn
         3ms | _SSAConstruction::getInstructionOpcode/2#3bb281a5_num#Opcode::TCall#26192cd8#shared@f381c662
         3ms | SsaInternalsCommon::TBaseCallVariable#dom#03b9b4c2@d4527egr
         2ms | CppType::CppWrappedType#1e29fcff#bf@988763rg
         2ms | CppType::CppType.hasType/2#dispred#d3f6ee89_120#join_rhs@56c4ef2q
         2ms | TIRVariable::TIRStringLiteral#dom#c2a32b41@c9a07f5u
         2ms | SsaInternalsCommon::TBaseIRVariable#dom#5baecebb@ece544q8
         2ms | m#CppType::CppWrappedType#1e29fcff#bf@b36369i6
         2ms | m#Class::Class.getAMember/0#dispred#6a0fc591#fb@418c6em1
         1ms | Type::Type.getUnderlyingType/0#fb0826e6@411784sq
         1ms | SsaInternalsCommon::PointerOrArrayOrReferenceType#797b00ff@f3bb7fs0
         1ms | TypedefType::TypedefType.getBaseType/0#dispred#671605ef@715e90n0
         1ms | TypedefType::TypedefType.getBaseType/0#dispred#671605ef_10#join_rhs@a81930mc
         1ms | member_201#join_rhs@4413c7pc
         1ms | Type::DerivedType.getBaseType/0#dispred#b08b94f7_10#join_rhs@d2e7dbjh
         1ms | SsaInternalsCommon::BaseCallVariable#fceddfe9@531dd7qi
         1ms | Iterator::Iterator.getValueType/0#dispred#9fcea90d@e23e6fre
         1ms | Type::PointerType#0751f31b@552569un
         0ms | Type::UnknownType#cbea2ba5@331347kv
         0ms | UserType::UserType#21e9e463@ea2864de
         0ms | TypedefType::TypedefType#64088755@e44345s8
         0ms | derivedtypes_02#join_rhs@a5719da1
         0ms | builtintypes_20#join_rhs@f5f4e54l
         0ms | UserType::UserType.getName/0#dispred#68e0aaf0#fb@660b75qs
         0ms | UserType::UserType.hasName/1#dispred#de6286ee#fb@7085fbj2
         0ms | num#TIRVariable::TIRDynamicInitializationFlag#0648209a@331e41nv
         0ms | m#Declaration::Declaration.getTemplateArgument/1#dispred#e3aa93eb#fbf@c8cc1f9j
         0ms | m#UserType::UserType.hasName/1#dispred#de6286ee#fb@01a1fdk6
         0ms | m#UserType::UserType.getName/0#dispred#68e0aaf0#fb@8a822be7
         0ms | usertypes_02#join_rhs@3ddf5c3g
         0ms | usertypes_0#antijoin_rhs@e4754bn3
         0ms | num#Opcode::TCall#26192cd8@43eb12o8
```
Instead, this PR moves the `cached` annotation to another predicate that we stuff inside the `cached` module with all the other `cached` IR predicates. This ensures that the evaluation of `getResultIRType` happens in the same stage as everything else. So now the evaluation is placed in stage 11 along with other `cached` IR-related predicates:
```ql
Most expensive predicates for stage 11 of completed query TaintedPath.ql:
        time  | evals |   max @ iter | predicate
        ------|-------|--------------|----------
         1.3s |    80 | 214ms @ 1    | TranslatedElement::TranslatedElement.getChildSuccessorInternal/2#dispred#72465fe7@e40cbw2m
         1.1s |       |              | Expr::Expr.getType/0#1bba7540@5c9e1d2p
           1s |       |              | SSAConstruction::DefUse::hasUse/4#69d16c00@b04dd01p
        986ms |       |              | SSAConstruction::getInstructionSuccessor/2#4698fe4a@512c03hh
        909ms |       |              | SSAConstruction::DefUse::hasNonPhiDefinition/4#7da496d1@152302s3
        876ms |       |              | boundedFastTC:IRConstruction::getNonPhiOperandDefOfIntermediate/1#e20c8cd5:IRConstruction::TStageInstruction#3fb23649@f4973fbe
        797ms |   187 | 420ms @ 1    | SSAConstruction::DefUse::locationLiveOnEntryToBlock/2#e533ef91@1e5b9wnl
        725ms |       |              | Expr::Expr.getParentWithConversions/0#dispred#885157de@a8aa34rt
        723ms |       |              | idominance@IRBlock::isEntryBlock/1#c739738b#1@IRBlock::Cached::blockSuccessor/2#376718b0#2@7288e80r
        713ms |       |              | shortestDistances@IRBlock::startsBasicBlock/1#87627033#1@IRBlock::adjacentInBlock/2#1de7c022#2@c399b49g
        687ms |       |              | SSAConstruction::DefUse::defUseRank/4#b00da839@07214ep8
        680ms |       |              | shortestDistances@IRBlock::startsBasicBlock/1#6944ea67#1@IRBlock::adjacentInBlock/2#0d89f953#2@7b8cf7dh
        672ms |       |              | TranslatedElement::TranslatedElement.getInstructionSuccessorInternal/2#dispred#a6e054ca@db294eab
        635ms |       |              | TranslatedElement::TranslatedElement.getInstructionRegisterOperand/2#dispred#845e6b68@08215a8e
        621ms |       |              | Expr::Expr.getParent/0#dispred#393b4f50@af4da4vu
        589ms |       |              | TranslatedElement::TranslatedElement.getChild/1#dispred#6aaf00cb_120#join_rhs@0806a459
        582ms |       |              | shortestDistances@IRBlock::startsBasicBlock/1#4c7be3ed#1@IRBlock::adjacentInBlock/2#c902cfba#2@63ab17re
        565ms |    79 |  61ms @ 16   | SSAConstruction::DefUse::definitionReachesEndOfBlock/4#634e3fbe@96051avp
        532ms |       |              | IRConstruction::getInstructionOpcode/2#7a2f4787@1971af6a
        524ms |       |              | boundedFastTC:IRBlock::Cached::forwardEdgeRaw/2#232b5f66:_IRBlock::Cached::blockIdentity/2#4e5abd86#higher_order_body@2e00772r
        508ms |       |              | SSAConstruction::getInstructionOpcode/2#3bb281a5@f54891di
        494ms |       |              | SSAConstruction::getInstructionResultIRType/1#bdc4ce95@b3761b2b
        489ms |    82 |  61ms @ 1    | TranslatedElement::TranslatedElement.getFirstInstruction/1#dispred#c118dc32@e40cb2wm
        483ms |       |              | _TranslatedElement::TranslatedElement.getChild/1#dispred#6aaf00cb_TranslatedElement::TranslatedEleme__#join_rhs@03684331
        478ms |       |              | TranslatedElement::TranslatedElement.getFunction/0#dispred#b7a14e3c_10#join_rhs@f6e120uf
        473ms |   186 |  38ms @ 2    | SSAConstruction::DefUse::locationLiveOnExitFromBlock/2#01e9ad4e@1e5b9xnl
        450ms |       |              | Literal::TextLiteral#c60dc64a@1a3b2869
        449ms |       |              | SSAConstruction::DefUse::exitRank/2#01f9fe88@b5178ca3
        429ms |       |              | TranslatedElement::TranslatedElement.getChild/1#dispred#6aaf00cb_10#join_rhs@ba62c1q4
        427ms |       |              | project#TranslatedElement::TranslatedElement.getChild/1#dispred#6aaf00cb_10#join_rhs@9e958aeq
        425ms |    82 |  67ms @ 3    | TranslatedElement::TranslatedElement.getChildSuccessor/2#0970d0ba@e40cbx2m
        417ms |       |              | boundedFastTC:IRBlock::blockImmediatelyPostDominates/2#66737676:IRBlock::Cached::TIRBlock#e4238d77@8f5709ed
        394ms |       |              | exprs_10#join_rhs@1396b79f
        394ms |       |              | Access::VariableAccess.getTarget/0#238a7818@9c8b71nj
        380ms |       |              | _project#TranslatedElement::TranslatedElement.getChild/1#dispred#6aaf00cb#2_project#TranslatedElemen__#join_rhs@5605243a
        370ms |       |              | idominance@IRBlock::blockFunctionExit/1#367d0578#1@IRBlock::blockPredecessor/2#dac15a27#2@a2148fek
        357ms |       |              | IRConstruction::getInstructionEnclosingIRFunction/1#8cbf5c14@0ea7d84f
        337ms |     5 | 205ms @ 1    | TranslatedExpr::TranslatedExpr.getResult/0#dispred#de0eec33@389db7id
        336ms |   100 |  28ms @ 5    | SSAConstruction::DefUse::definitionReachesEndOfBlock/4#9eaba1be@60efafng
        335ms |       |              | Expr::Expr.getUnspecifiedType/0#dispred#3ebd7f26@a20ba9ts
        334ms |       |              | TranslatedElement::getRealParent/1#fe4a635b_10#join_rhs@852657g2
        327ms |    63 | 180ms @ 1    | TranslatedElement::TranslatedElement.getALastInstructionInternal/0#dispred#4adef341#fb@37d20wnr
        325ms |       |              | project#SSAConstruction::getInstructionSuccessor/2#4698fe4a#2_10#unique_range@a3d909cp
        324ms |       |              | IRConstruction::Raw::getInstructionVariable/1#6aee085f@37db28v7
        304ms |       |              | Expr::Expr.getFullyConverted/0#dispred#411692d3_10#join_rhs@74ab5e9a
        302ms |       |              | SSAConstruction::DefUse::hasDefinition/4#7de389e1@b13eb0qg
        292ms |       |              | TranslatedElement::TranslatedElement.hasInstruction/3#dispred#904b68f4@a690b7ki
        291ms |       |              | boundedFastTC:IRBlock::Cached::forwardEdgeRaw/2#71c2c096:_IRBlock::Cached::blockIdentity/2#1f6c1d72#higher_order_body@5d06b732
        283ms |       |              | project#SSAConstruction::DefUse::hasDefinition/4#7de389e1@c676613r
        276ms |       |              | TranslatedExpr::TranslatedExpr.getChild/1#dispred#32f4a6b8_201#join_rhs@e4c14d2m
```
