### PR TITLE
Ruby: Add URI.open example to rb/kernel-open qhelp

### DIFF
--- a/ruby/ql/src/queries/security/cwe-078/examples/file_open.rb
+++ b/ruby/ql/src/queries/security/cwe-078/examples/file_open.rb
@@ -1,6 +1,9 @@
 class UsersController < ActionController::Base
-    def create
-      filename = params[:filename]
-      File.open(filename)
-    end
-  end  
+  def create
+    filename = params[:filename]
+    File.open(filename)
+
+    web_page = params[:web_page]
+    Net::HTTP.get(URI.parse(web_page))
+  end
+end

--- a/ruby/ql/src/queries/security/cwe-078/examples/kernel_open.rb
+++ b/ruby/ql/src/queries/security/cwe-078/examples/kernel_open.rb
@@ -1,6 +1,11 @@
+require "open-uri"
+
 class UsersController < ActionController::Base
   def create
     filename = params[:filename]
     open(filename) # BAD
+
+    web_page = params[:web_page]
+    URI.open(web_page) # BAD - calls `Kernel.open` internally
   end
-end  
+end


### PR DESCRIPTION
Update the examples for `rb/kernel-open` to show that `URI.open` is not good. Provide an alternative of `Net::HTTP.get(URI.parse(...))`, though there are many other good approaches too.