### PR TITLE
C++: Improve documentation for `cpp/iterator-to-expired-container`

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-416/IteratorToExpiredContainer.qhelp
+++ b/cpp/ql/src/Security/CWE/CWE-416/IteratorToExpiredContainer.qhelp
@@ -30,6 +30,12 @@ This is because the temporary container is not bound to a rvalue reference.
 </p>
 <sample src="IteratorToExpiredContainerExtendedLifetime.cpp" />
 
+<p>
+To fix <code>lifetime_of_temp_not_extended</code> consider rewriting the code so that the temporary's lifetime is extended.
+In <code>fixed_lifetime_of_temp_not_extended</code> the lifetime of the temporary object has been extended by storing it in an rvalue reference.
+</p>
+<sample src="IteratorToExpiredContainerExtendedLifetime-fixed.cpp" />
+
 </example>
 <references>
 

--- a/cpp/ql/src/Security/CWE/CWE-416/IteratorToExpiredContainer.qhelp
+++ b/cpp/ql/src/Security/CWE/CWE-416/IteratorToExpiredContainer.qhelp
@@ -32,7 +32,7 @@ This is because the temporary container is not bound to a rvalue reference.
 
 <p>
 To fix <code>lifetime_of_temp_not_extended</code>, consider rewriting the code so that the lifetime of the temporary object is extended.
-In <code>fixed_lifetime_of_temp_not_extended</code> the lifetime of the temporary object has been extended by storing it in an rvalue reference.
+In <code>fixed_lifetime_of_temp_not_extended</code>, the lifetime of the temporary object has been extended by storing it in an rvalue reference.
 </p>
 <sample src="IteratorToExpiredContainerExtendedLifetime-fixed.cpp" />
 

--- a/cpp/ql/src/Security/CWE/CWE-416/IteratorToExpiredContainer.qhelp
+++ b/cpp/ql/src/Security/CWE/CWE-416/IteratorToExpiredContainer.qhelp
@@ -31,7 +31,7 @@ This is because the temporary container is not bound to a rvalue reference.
 <sample src="IteratorToExpiredContainerExtendedLifetime.cpp" />
 
 <p>
-To fix <code>lifetime_of_temp_not_extended</code> consider rewriting the code so that the temporary's lifetime is extended.
+To fix <code>lifetime_of_temp_not_extended</code>, consider rewriting the code so that the lifetime of the temporary object is extended.
 In <code>fixed_lifetime_of_temp_not_extended</code> the lifetime of the temporary object has been extended by storing it in an rvalue reference.
 </p>
 <sample src="IteratorToExpiredContainerExtendedLifetime-fixed.cpp" />

--- a/cpp/ql/src/Security/CWE/CWE-416/IteratorToExpiredContainerExtendedLifetime-fixed.cpp
+++ b/cpp/ql/src/Security/CWE/CWE-416/IteratorToExpiredContainerExtendedLifetime-fixed.cpp
@@ -1,0 +1,6 @@
+void fixed_lifetime_of_temp_not_extended() {
+  auto&& v = get_vector();
+  for(auto x : log_and_return_argument(v)) {
+    use(x); // GOOD: The lifetime of the container returned by `get_vector()` has been extended to the lifetime of `v`.
+  }
+}

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/IteratorToExpiredContainer/IteratorToExpiredContainer.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/IteratorToExpiredContainer/IteratorToExpiredContainer.expected
@@ -1,11 +1,6 @@
-| test.cpp:680:30:680:30 | call to operator[] | This object is destroyed before $@ is called. | test.cpp:680:17:680:17 | call to begin | call to begin |
-| test.cpp:680:30:680:30 | call to operator[] | This object is destroyed before $@ is called. | test.cpp:680:17:680:17 | call to end | call to end |
-| test.cpp:683:31:683:32 | call to at | This object is destroyed before $@ is called. | test.cpp:683:17:683:17 | call to begin | call to begin |
-| test.cpp:683:31:683:32 | call to at | This object is destroyed before $@ is called. | test.cpp:683:17:683:17 | call to end | call to end |
-| test.cpp:689:46:689:58 | pointer to ~vector output argument | This object is destroyed before $@ is called. | test.cpp:689:60:689:62 | call to end | call to end |
-| test.cpp:702:27:702:27 | call to operator[] | This object is destroyed before $@ is called. | test.cpp:703:19:703:23 | call to begin | call to begin |
-| test.cpp:702:27:702:27 | call to operator[] | This object is destroyed before $@ is called. | test.cpp:703:36:703:38 | call to end | call to end |
-| test.cpp:727:23:727:23 | call to operator[] | This object is destroyed before $@ is called. | test.cpp:750:17:750:17 | call to begin | call to begin |
-| test.cpp:727:23:727:23 | call to operator[] | This object is destroyed before $@ is called. | test.cpp:750:17:750:17 | call to end | call to end |
-| test.cpp:735:23:735:23 | call to operator[] | This object is destroyed before $@ is called. | test.cpp:759:17:759:17 | call to begin | call to begin |
-| test.cpp:735:23:735:23 | call to operator[] | This object is destroyed before $@ is called. | test.cpp:759:17:759:17 | call to end | call to end |
+| test.cpp:680:30:680:30 | call to operator[] | This object is destroyed at the end of the full-expression. |
+| test.cpp:683:31:683:32 | call to at | This object is destroyed at the end of the full-expression. |
+| test.cpp:689:46:689:58 | pointer to ~vector output argument | This object is destroyed at the end of the full-expression. |
+| test.cpp:702:27:702:27 | call to operator[] | This object is destroyed at the end of the full-expression. |
+| test.cpp:727:23:727:23 | call to operator[] | This object is destroyed at the end of the full-expression. |
+| test.cpp:735:23:735:23 | call to operator[] | This object is destroyed at the end of the full-expression. |


### PR DESCRIPTION
This PR does two things that should hopefully make the results from the new `cpp/iterator-to-expired-container` query easier to understand:
- It updates the alert message to more correctly reflect what's going on
- It updates the qhelp file so that it contains an example of a fix.

Note that, because of the first fix, we only get half the number of alerts since we no longer include the call to begin in the alert message. Previously, we'd often get an alert on the same location with two alert messages such as:
- This object is destroyed before `call to begin` is called.
- This object is destroyed before `call to end` is called.

Other than the alert being wrong, it was also quite annoying to have two alerts on the same element explaining the same problem.