### PR TITLE
Java: Improve finding best type for models and lifting.

### DIFF
--- a/csharp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/csharp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -7,7 +7,7 @@ private import CaptureModelsSpecific
 private import CaptureModelsPrinting
 
 class DataFlowTargetApi extends TargetApiSpecific {
-  DataFlowTargetApi() { isRelevantForDataFlowModels(this) }
+  DataFlowTargetApi() { not isUninterestingForDataFlowModels(this) }
 }
 
 private module Printing implements PrintingSig {

--- a/csharp/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
+++ b/csharp/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
@@ -51,16 +51,18 @@ private predicate isRelevantForModels(CS::Callable api) {
 }
 
 /**
- * Holds if it is relevant to generate models for `api` based on data flow analysis.
+ * Holds if it is irrelevant to generate models for `api` based on data flow analysis.
+ *
+ * This serves as an extra filter for the `relevant` predicate.
  */
-predicate isRelevantForDataFlowModels(CS::Callable api) {
-  isRelevantForModels(api) and not isHigherOrder(api)
-}
+predicate isUninterestingForDataFlowModels(CS::Callable api) { isHigherOrder(api) }
 
 /**
- * Holds if it is relevant to generate models for `api` based on its type.
+ * Holds if it is irrelevant to generate models for `api` based on type-based analysis.
+ *
+ * This serves as an extra filter for the `relevant` predicate.
  */
-predicate isRelevantForTypeBasedFlowModels = isRelevantForModels/1;
+predicate isUninterestingForTypeBasedFlowModels(CS::Callable api) { none() }
 
 /**
  * A class of callables that are relevant generating summary, source and sinks models for.
@@ -71,7 +73,8 @@ predicate isRelevantForTypeBasedFlowModels = isRelevantForModels/1;
 class TargetApiSpecific extends CS::Callable {
   TargetApiSpecific() {
     this.fromSource() and
-    this.isUnboundDeclaration()
+    this.isUnboundDeclaration() and
+    isRelevantForModels(this)
   }
 }
 

--- a/csharp/ql/src/utils/modelgenerator/internal/CaptureTypeBasedSummaryModels.qll
+++ b/csharp/ql/src/utils/modelgenerator/internal/CaptureTypeBasedSummaryModels.qll
@@ -190,7 +190,7 @@ private module ModelPrinting = PrintingImpl<Printing>;
  * on the Theorems for Free approach.
  */
 class TypeBasedFlowTargetApi extends Specific::TargetApiSpecific {
-  TypeBasedFlowTargetApi() { Specific::isRelevantForTypeBasedFlowModels(this) }
+  TypeBasedFlowTargetApi() { not Specific::isUninterestingForTypeBasedFlowModels(this) }
 
   /**
    * Gets the string representation of all type based summaries for `this`

--- a/java/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -7,7 +7,7 @@ private import CaptureModelsSpecific
 private import CaptureModelsPrinting
 
 class DataFlowTargetApi extends TargetApiSpecific {
-  DataFlowTargetApi() { isRelevantForDataFlowModels(this) }
+  DataFlowTargetApi() { not isUninterestingForDataFlowModels(this) }
 }
 
 private module Printing implements PrintingSig {

--- a/java/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
@@ -63,13 +63,20 @@ private predicate hasManualModel(Callable api) {
 }
 
 /**
- * Holds if it is relevant to generate models for `api` based on data flow analysis.
+ * Holds if it is irrelevant to generate models for `api` based on data flow analysis.
+ *
+ * This serves as an extra filter for the `relevant` predicate.
  */
-predicate isRelevantForDataFlowModels(Callable api) {
-  (not api.getDeclaringType() instanceof J::Interface or exists(api.getBody()))
+predicate isUninterestingForDataFlowModels(Callable api) {
+  api.getDeclaringType() instanceof J::Interface and not exists(api.getBody())
 }
 
-predicate isRelevantForTypeBasedFlowModels(Callable api) { any() }
+/**
+ * Holds if it is irrelevant to generate models for `api` based on type-based analysis.
+ *
+ * This serves as an extra filter for the `relevant` predicate.
+ */
+predicate isUninterestingForTypeBasedFlowModels(Callable api) { none() }
 
 /**
  * A class of Callables that are relevant for generating summary, source and sinks models for.

--- a/java/ql/src/utils/modelgenerator/internal/CaptureTypeBasedSummaryModels.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureTypeBasedSummaryModels.qll
@@ -296,7 +296,7 @@ private module ModelPrinting = PrintingImpl<Printing>;
  * on the Theorems for Free approach.
  */
 class TypeBasedFlowTargetApi extends Specific::TargetApiSpecific {
-  TypeBasedFlowTargetApi() { Specific::isRelevantForTypeBasedFlowModels(this) }
+  TypeBasedFlowTargetApi() { not Specific::isUninterestingForTypeBasedFlowModels(this) }
 
   /**
    * Gets the string representation of all type based summaries for `this`

--- a/java/ql/test/utils/modelgenerator/dataflow/p/AbstractImplOfExternalSPI.java
+++ b/java/ql/test/utils/modelgenerator/dataflow/p/AbstractImplOfExternalSPI.java
@@ -5,9 +5,9 @@ import java.io.FileFilter;
 
 public abstract class AbstractImplOfExternalSPI implements FileFilter {
 
-    @Override
-    public boolean accept(File pathname) {
-        return false;
-    }
-
+  // neutral=p;AbstractImplOfExternalSPI;accept;(File);summary;df-generated
+  @Override
+  public boolean accept(File pathname) {
+    return false;
+  }
 }

--- a/java/ql/test/utils/modelgenerator/dataflow/p/ImplOfExternalSPI.java
+++ b/java/ql/test/utils/modelgenerator/dataflow/p/ImplOfExternalSPI.java
@@ -6,14 +6,15 @@ import java.nio.file.Files;
 
 public class ImplOfExternalSPI extends AbstractImplOfExternalSPI {
 
-    @Override
-    public boolean accept(File pathname) {
-        try {
-            Files.createFile(pathname.toPath());
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-        return false;
+  // sink=p;AbstractImplOfExternalSPI;true;accept;(File);;Argument[0];path-injection;df-generated
+  // neutral=p;AbstractImplOfExternalSPI;accept;(File);summary;df-generated
+  @Override
+  public boolean accept(File pathname) {
+    try {
+      Files.createFile(pathname.toPath());
+    } catch (IOException e) {
+      e.printStackTrace();
     }
-
+    return false;
+  }
 }

--- a/java/ql/test/utils/modelgenerator/dataflow/p/Inheritance.java
+++ b/java/ql/test/utils/modelgenerator/dataflow/p/Inheritance.java
@@ -10,7 +10,7 @@ public class Inheritance {
   }
 
   public class AImplBasePrivateImpl extends BasePrivate {
-    // SPURIOUS-summary=p;Inheritance$BasePrivate;true;id;(String);;Argument[0];ReturnValue;taint;df-generated
+    // summary=p;Inheritance$AImplBasePrivateImpl;true;id;(String);;Argument[0];ReturnValue;taint;df-generated
     @Override
     public String id(String s) {
       return s;
@@ -66,7 +66,7 @@ public class Inheritance {
   }
 
   public class CImpl extends C {
-    // SPURIOUS-summary=p;Inheritance$IPrivate1;true;id;(String);;Argument[0];ReturnValue;taint;df-generated
+    // summary=p;Inheritance$C;true;id;(String);;Argument[0];ReturnValue;taint;df-generated
     @Override
     public String id(String s) {
       return s;
@@ -82,7 +82,7 @@ public class Inheritance {
   }
 
   public class EImpl extends E {
-    // SPURIOUS-summary=p;Inheritance$IPrivate2;true;id;(String);;Argument[0];ReturnValue;taint;df-generated
+    // summary=p;Inheritance$EImpl;true;id;(String);;Argument[0];ReturnValue;taint;df-generated
     @Override
     public String id(String s) {
       return s;

--- a/java/ql/test/utils/modelgenerator/dataflow/p/Inheritance.java
+++ b/java/ql/test/utils/modelgenerator/dataflow/p/Inheritance.java
@@ -1,0 +1,91 @@
+package p;
+
+public class Inheritance {
+  private abstract class BasePrivate {
+    public abstract String id(String s);
+  }
+
+  public abstract class BasePublic {
+    public abstract String id(String s);
+  }
+
+  public class AImplBasePrivateImpl extends BasePrivate {
+    // SPURIOUS-summary=p;Inheritance$BasePrivate;true;id;(String);;Argument[0];ReturnValue;taint;df-generated
+    @Override
+    public String id(String s) {
+      return s;
+    }
+  }
+
+  public class AImplBasePublic extends BasePublic {
+    // summary=p;Inheritance$BasePublic;true;id;(String);;Argument[0];ReturnValue;taint;df-generated
+    @Override
+    public String id(String s) {
+      return s;
+    }
+  }
+
+  private interface IPrivate1 {
+    String id(String s);
+  }
+
+  private interface IPrivate2 {
+    String id(String s);
+  }
+
+  public interface IPublic1 {
+    String id(String s);
+  }
+
+  public interface IPublic2 {
+    String id(String s);
+  }
+
+  public abstract class B implements IPublic1 {
+    public abstract String id(String s);
+  }
+
+  public abstract class C implements IPrivate1 {
+    public abstract String id(String s);
+  }
+
+  private abstract class D implements IPublic2 {
+    public abstract String id(String s);
+  }
+
+  private abstract class E implements IPrivate2 {
+    public abstract String id(String s);
+  }
+
+  public class BImpl extends B {
+    // summary=p;Inheritance$IPublic1;true;id;(String);;Argument[0];ReturnValue;taint;df-generated
+    @Override
+    public String id(String s) {
+      return s;
+    }
+  }
+
+  public class CImpl extends C {
+    // SPURIOUS-summary=p;Inheritance$IPrivate1;true;id;(String);;Argument[0];ReturnValue;taint;df-generated
+    @Override
+    public String id(String s) {
+      return s;
+    }
+  }
+
+  public class DImpl extends D {
+    // summary=p;Inheritance$IPublic2;true;id;(String);;Argument[0];ReturnValue;taint;df-generated
+    @Override
+    public String id(String s) {
+      return s;
+    }
+  }
+
+  public class EImpl extends E {
+    // SPURIOUS-summary=p;Inheritance$IPrivate2;true;id;(String);;Argument[0];ReturnValue;taint;df-generated
+    @Override
+    public String id(String s) {
+      return s;
+    }
+  }
+}

--- a/java/ql/test/utils/modelgenerator/dataflow/p/MultipleImpls.java
+++ b/java/ql/test/utils/modelgenerator/dataflow/p/MultipleImpls.java
@@ -18,6 +18,7 @@ public class MultipleImpls {
   // implements in different library should not count as impl
   public static class Strat3 implements Callable<String> {
 
+    // neutral=p;MultipleImpls$Strat3;call;();summary;df-generated
     @Override
     public String call() throws Exception {
       return null;


### PR DESCRIPTION
In this PR 
- The logic for *lifting* models is improved (further explanation can be seen below).
- Fix a small issue with sink model exclusions (these were wrongly excluded based on summarized callables and neutrals with summary kind).
- Do some minor re-factoring.

The idea with the lifting logic is to make models as general as possible.
Assume that `B <: A` (`B` is a subtype of `A` or `B` is an implementation of `A`) and assume that we have 
 methods `B.M` and `A.M` where `B.M` is an override or implementation of `A.M`. In case the model generator finds a summary model `S` for `B.M` we *lift* the model to `A.M` (that is, we assume that `A.M` exhibits the same flow as `B.M` as this is perceived as a part of the override/implementation contract).

The old logic
- For lifting was dispersed throughout the code and it was slightly unsound (and unclear).
- Was not functional. The new implementation replaces `superImpl` with `liftedImpl`, which gives us a unique *best* callable to lift a model to (maybe the callable itself), if it is relevant to make a model for the callable.
- Lifted models to potential private/internal callables (this was identified by @owen-mc as a part of generating the java SDK models). Now models are only lifted to effectively public API endpoints.

Furthermore, we now only *lift* models to callables that are also in source. It seems a bit of stretch that if one implements an interface from an imported package and flow is identified for a method then we lift to the callable in the imported package (we could risk getting very odd models for stuff in the Java SDK).

As a test the models for the Java SDK were re-generated and it appears that
- Models for `internal` were not generated.
- Models for methods in eg. `AbstractStringBuilder` (which is package internal) will be *only* lifted to the relevant public endpoints.