### PR TITLE
Go: Allow version suffixes

### DIFF
--- a/go/extractor/project/project.go
+++ b/go/extractor/project/project.go
@@ -575,7 +575,7 @@ func getModMode(depMode DependencyInstallerMode, baseDir string) ModMode {
 // Tries to open `go.mod` and read a go directive, returning the version and whether it was found.
 // The version string is returned in the "1.2.3" format.
 func tryReadGoDirective(path string) GoVersionInfo {
-	versionRe := regexp.MustCompile(`(?m)^go[ \t\r]+([0-9]+\.[0-9]+(\.[0-9]+)?)$`)
+	versionRe := regexp.MustCompile(`(?m)^go[ \t\r]+([0-9]+\.[0-9]+(\.[0-9]+)?)`)
 	goMod, err := os.ReadFile(path)
 	if err != nil {
 		log.Println("Failed to read go.mod to check for missing Go version")


### PR DESCRIPTION
This revives a commit from https://github.com/github/codeql/pull/14194 that hadn't made its way into the code yet. Note that:

- `tryReadGoDirective` is only used as a fallback these days, if parsing the `go.mod` file fails.
- The `go.mod` parser also parses version suffixes, so this just means we can tolerate them better if we reach this fallback. 