### PR TITLE
Ruby: Fix StringSubstitutionCall charpred

### DIFF
--- a/ruby/ql/lib/codeql/ruby/frameworks/core/String.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/core/String.qll
@@ -19,9 +19,11 @@ class StringSubstitutionCall extends DataFlow::CallNode {
   StringSubstitutionCall() {
     this.getMethodName() = ["sub", "sub!", "gsub", "gsub!"] and
     exists(this.getReceiver()) and
-    this.getNumberOfArguments() = 2
-    or
-    this.getNumberOfArguments() = 1 and exists(this.getBlock())
+    (
+      this.getNumberOfArguments() = 2
+      or
+      this.getNumberOfArguments() = 1 and exists(this.getBlock())
+    )
   }
 
   /**

--- a/ruby/ql/test/query-tests/security/cwe-116/IncompleteSanitization/tst.rb
+++ b/ruby/ql/test/query-tests/security/cwe-116/IncompleteSanitization/tst.rb
@@ -268,3 +268,8 @@ def bad_path_sanitizer(p1, p2)
   p1.sub! "/../", "" # NOT OK
   p2.sub  "/../", "" # NOT OK
 end
+
+def each_line_sanitizer(p1)
+  p1.each_line("\n") do |l| # OK - does no sanitization
+  end
+end


### PR DESCRIPTION
Some missing parens meant this class targeted way more things than
intended.
