### PR TITLE
Data flow: Synthesize parameter return nodes

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/ProductFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/ProductFlow.qll
@@ -546,7 +546,7 @@ module ProductFlow {
       Flow1::PathGraph::edges(pred1, succ1, _, _) and
       exists(ReturnKindExt returnKind |
         succ1.getNode() = returnKind.getAnOutNode(call) and
-        pred1.getNode().(ReturnNodeExt).getKind() = returnKind
+        paramReturnNode(_, pred1.asParameterReturnNode(), _, returnKind)
       )
     }
 
@@ -574,7 +574,7 @@ module ProductFlow {
       Flow2::PathGraph::edges(pred2, succ2, _, _) and
       exists(ReturnKindExt returnKind |
         succ2.getNode() = returnKind.getAnOutNode(call) and
-        pred2.getNode().(ReturnNodeExt).getKind() = returnKind
+        paramReturnNode(_, pred2.asParameterReturnNode(), _, returnKind)
       )
     }
 

--- a/cpp/ql/test/library-tests/dataflow/fields/ir-path-flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/ir-path-flow.expected
@@ -1,7 +1,9 @@
 edges
 | A.cpp:23:10:23:10 | c | A.cpp:25:7:25:17 | ... = ... | provenance |  |
+| A.cpp:25:7:25:10 | *this [post update] [c] | A.cpp:23:5:23:5 | *this [Return] [c] | provenance |  |
 | A.cpp:25:7:25:17 | ... = ... | A.cpp:25:7:25:10 | *this [post update] [c] | provenance |  |
 | A.cpp:27:17:27:17 | c | A.cpp:27:22:27:32 | ... = ... | provenance |  |
+| A.cpp:27:22:27:25 | *this [post update] [c] | A.cpp:27:10:27:12 | *this [Return] [c] | provenance |  |
 | A.cpp:27:22:27:32 | ... = ... | A.cpp:27:22:27:25 | *this [post update] [c] | provenance |  |
 | A.cpp:28:8:28:10 | *this [c] | A.cpp:28:23:28:26 | *this [c] | provenance |  |
 | A.cpp:28:23:28:26 | *this [c] | A.cpp:28:29:28:29 | c | provenance |  |
@@ -66,23 +68,28 @@ edges
 | A.cpp:112:7:112:13 | *... = ... [a] | A.cpp:118:18:118:39 | *cc [a] | provenance |  |
 | A.cpp:118:18:118:39 | *cc [a] | A.cpp:120:12:120:13 | *c1 [a] | provenance |  |
 | A.cpp:120:12:120:13 | *c1 [a] | A.cpp:120:12:120:16 | a | provenance |  |
+| A.cpp:124:14:124:14 | *b [Return] [c] | A.cpp:131:8:131:8 | f7 output argument [c] | provenance |  |
 | A.cpp:124:14:124:14 | *b [c] | A.cpp:131:8:131:8 | f7 output argument [c] | provenance |  |
+| A.cpp:126:5:126:5 | set output argument [c] | A.cpp:124:14:124:14 | *b [Return] [c] | provenance |  |
 | A.cpp:126:5:126:5 | set output argument [c] | A.cpp:124:14:124:14 | *b [c] | provenance |  |
-| A.cpp:126:5:126:5 | set output argument [c] | A.cpp:131:8:131:8 | f7 output argument [c] | provenance |  |
 | A.cpp:126:12:126:18 | new | A.cpp:27:17:27:17 | c | provenance |  |
 | A.cpp:126:12:126:18 | new | A.cpp:126:5:126:5 | set output argument [c] | provenance |  |
 | A.cpp:126:12:126:18 | new | A.cpp:126:12:126:18 | new | provenance |  |
 | A.cpp:131:8:131:8 | f7 output argument [c] | A.cpp:132:10:132:10 | *b [c] | provenance |  |
 | A.cpp:132:10:132:10 | *b [c] | A.cpp:132:10:132:13 | c | provenance |  |
+| A.cpp:140:5:140:5 | *this [Return] [*b, c] | A.cpp:151:12:151:24 | call to D [*b, c] | provenance |  |
+| A.cpp:140:5:140:5 | *this [Return] [b] | A.cpp:151:12:151:24 | call to D [b] | provenance |  |
+| A.cpp:140:13:140:13 | *b [Return] [c] | A.cpp:151:18:151:18 | D output argument [c] | provenance |  |
 | A.cpp:140:13:140:13 | *b [c] | A.cpp:151:18:151:18 | D output argument [c] | provenance |  |
 | A.cpp:140:13:140:13 | b | A.cpp:143:7:143:31 | ... = ... | provenance |  |
+| A.cpp:142:7:142:7 | *b [post update] [c] | A.cpp:140:13:140:13 | *b [Return] [c] | provenance |  |
 | A.cpp:142:7:142:7 | *b [post update] [c] | A.cpp:140:13:140:13 | *b [c] | provenance |  |
 | A.cpp:142:7:142:7 | *b [post update] [c] | A.cpp:143:7:143:31 | *... = ... [c] | provenance |  |
-| A.cpp:142:7:142:7 | *b [post update] [c] | A.cpp:151:18:151:18 | D output argument [c] | provenance |  |
 | A.cpp:142:7:142:20 | ... = ... | A.cpp:142:7:142:7 | *b [post update] [c] | provenance |  |
 | A.cpp:142:14:142:20 | new | A.cpp:142:7:142:20 | ... = ... | provenance |  |
-| A.cpp:143:7:143:10 | *this [post update] [*b, c] | A.cpp:151:12:151:24 | call to D [*b, c] | provenance |  |
-| A.cpp:143:7:143:10 | *this [post update] [b] | A.cpp:151:12:151:24 | call to D [b] | provenance |  |
+| A.cpp:143:7:143:10 | *this [post update] [*b, c] | A.cpp:140:5:140:5 | *this [Return] [*b, c] | provenance |  |
+| A.cpp:143:7:143:10 | *this [post update] [b] | A.cpp:140:5:140:5 | *this [Return] [b] | provenance |  |
+| A.cpp:143:7:143:10 | *this [post update] [b] | A.cpp:140:5:140:5 | *this [Return] [b] | provenance |  |
 | A.cpp:143:7:143:31 | *... = ... [c] | A.cpp:143:7:143:10 | *this [post update] [*b, c] | provenance |  |
 | A.cpp:143:7:143:31 | ... = ... | A.cpp:143:7:143:10 | *this [post update] [b] | provenance |  |
 | A.cpp:143:7:143:31 | ... = ... | A.cpp:143:7:143:10 | *this [post update] [b] | provenance |  |
@@ -138,7 +145,10 @@ edges
 | A.cpp:181:15:181:21 | newHead | A.cpp:183:7:183:20 | ... = ... | provenance |  |
 | A.cpp:181:32:181:35 | *next [*next, head] | A.cpp:184:7:184:23 | *... = ... [*next, head] | provenance |  |
 | A.cpp:181:32:181:35 | *next [head] | A.cpp:184:7:184:23 | *... = ... [head] | provenance |  |
+| A.cpp:183:7:183:10 | *this [post update] [head] | A.cpp:181:5:181:10 | *this [Return] [head] | provenance |  |
 | A.cpp:183:7:183:20 | ... = ... | A.cpp:183:7:183:10 | *this [post update] [head] | provenance |  |
+| A.cpp:184:7:184:10 | *this [post update] [*next, *next, head] | A.cpp:181:5:181:10 | *this [Return] [*next, *next, head] | provenance |  |
+| A.cpp:184:7:184:10 | *this [post update] [*next, head] | A.cpp:181:5:181:10 | *this [Return] [*next, head] | provenance |  |
 | A.cpp:184:7:184:23 | *... = ... [*next, head] | A.cpp:184:7:184:10 | *this [post update] [*next, *next, head] | provenance |  |
 | A.cpp:184:7:184:23 | *... = ... [head] | A.cpp:184:7:184:10 | *this [post update] [*next, head] | provenance |  |
 | B.cpp:6:15:6:24 | new | B.cpp:6:15:6:24 | new | provenance |  |
@@ -167,10 +177,14 @@ edges
 | B.cpp:19:14:19:17 | *box1 [elem2] | B.cpp:19:10:19:24 | elem2 | provenance |  |
 | B.cpp:33:16:33:17 | e1 | B.cpp:35:7:35:22 | ... = ... | provenance |  |
 | B.cpp:33:26:33:27 | e2 | B.cpp:36:7:36:22 | ... = ... | provenance |  |
+| B.cpp:35:7:35:10 | *this [post update] [elem1] | B.cpp:33:5:33:8 | *this [Return] [elem1] | provenance |  |
 | B.cpp:35:7:35:22 | ... = ... | B.cpp:35:7:35:10 | *this [post update] [elem1] | provenance |  |
+| B.cpp:36:7:36:10 | *this [post update] [elem2] | B.cpp:33:5:33:8 | *this [Return] [elem2] | provenance |  |
 | B.cpp:36:7:36:22 | ... = ... | B.cpp:36:7:36:10 | *this [post update] [elem2] | provenance |  |
 | B.cpp:44:16:44:17 | *b1 [elem1] | B.cpp:46:7:46:21 | *... = ... [elem1] | provenance |  |
 | B.cpp:44:16:44:17 | *b1 [elem2] | B.cpp:46:7:46:21 | *... = ... [elem2] | provenance |  |
+| B.cpp:46:7:46:10 | *this [post update] [*box1, elem1] | B.cpp:44:5:44:8 | *this [Return] [*box1, elem1] | provenance |  |
+| B.cpp:46:7:46:10 | *this [post update] [*box1, elem2] | B.cpp:44:5:44:8 | *this [Return] [*box1, elem2] | provenance |  |
 | B.cpp:46:7:46:21 | *... = ... [elem1] | B.cpp:46:7:46:10 | *this [post update] [*box1, elem1] | provenance |  |
 | B.cpp:46:7:46:21 | *... = ... [elem2] | B.cpp:46:7:46:10 | *this [post update] [*box1, elem2] | provenance |  |
 | C.cpp:18:12:18:18 | *new [s1] | C.cpp:19:5:19:5 | *c [s1] | provenance |  |
@@ -179,10 +193,12 @@ edges
 | C.cpp:18:12:18:18 | call to C [s3] | C.cpp:18:12:18:18 | *new [s3] | provenance |  |
 | C.cpp:19:5:19:5 | *c [s1] | C.cpp:27:8:27:11 | *this [s1] | provenance |  |
 | C.cpp:19:5:19:5 | *c [s3] | C.cpp:27:8:27:11 | *this [s3] | provenance |  |
-| C.cpp:22:3:22:3 | *this [post update] [s1] | C.cpp:18:12:18:18 | call to C [s1] | provenance |  |
+| C.cpp:22:3:22:3 | *this [Return] [s1] | C.cpp:18:12:18:18 | call to C [s1] | provenance |  |
+| C.cpp:22:3:22:3 | *this [Return] [s3] | C.cpp:18:12:18:18 | call to C [s3] | provenance |  |
+| C.cpp:22:3:22:3 | *this [post update] [s1] | C.cpp:22:3:22:3 | *this [Return] [s1] | provenance |  |
 | C.cpp:22:12:22:21 | new | C.cpp:22:3:22:3 | *this [post update] [s1] | provenance |  |
 | C.cpp:22:12:22:21 | new | C.cpp:22:12:22:21 | new | provenance |  |
-| C.cpp:24:5:24:8 | *this [post update] [s3] | C.cpp:18:12:18:18 | call to C [s3] | provenance |  |
+| C.cpp:24:5:24:8 | *this [post update] [s3] | C.cpp:22:3:22:3 | *this [Return] [s3] | provenance |  |
 | C.cpp:24:5:24:25 | ... = ... | C.cpp:24:5:24:8 | *this [post update] [s3] | provenance |  |
 | C.cpp:24:16:24:25 | new | C.cpp:24:5:24:25 | ... = ... | provenance |  |
 | C.cpp:27:8:27:11 | *this [s1] | C.cpp:29:10:29:11 | *this [s1] | provenance |  |
@@ -194,6 +210,7 @@ edges
 | D.cpp:10:30:10:33 | elem | D.cpp:10:11:10:17 | *getElem | provenance |  |
 | D.cpp:10:30:10:33 | elem | D.cpp:10:30:10:33 | elem | provenance |  |
 | D.cpp:11:24:11:24 | e | D.cpp:11:29:11:36 | ... = ... | provenance |  |
+| D.cpp:11:29:11:32 | *this [post update] [elem] | D.cpp:11:10:11:16 | *this [Return] [elem] | provenance |  |
 | D.cpp:11:29:11:36 | ... = ... | D.cpp:11:29:11:32 | *this [post update] [elem] | provenance |  |
 | D.cpp:17:11:17:17 | *this [*box, elem] | D.cpp:17:30:17:32 | *this [*box, elem] | provenance |  |
 | D.cpp:17:30:17:32 | *box [elem] | D.cpp:17:11:17:17 | **getBox1 [elem] | provenance |  |
@@ -252,14 +269,16 @@ edges
 | E.cpp:30:23:30:26 | *data [post update] [*buffer] | E.cpp:30:21:30:21 | *p [post update] [data, *buffer] | provenance |  |
 | E.cpp:32:10:32:10 | *b [*buffer] | E.cpp:32:13:32:18 | *buffer | provenance |  |
 | E.cpp:33:18:33:19 | *& ... [data, *buffer] | E.cpp:19:27:19:27 | *p [data, *buffer] | provenance |  |
+| aliasing.cpp:8:23:8:23 | *s [Return] [m1] | aliasing.cpp:25:17:25:19 | pointerSetter output argument [m1] | provenance |  |
 | aliasing.cpp:8:23:8:23 | *s [m1] | aliasing.cpp:25:17:25:19 | pointerSetter output argument [m1] | provenance |  |
+| aliasing.cpp:9:3:9:3 | *s [post update] [m1] | aliasing.cpp:8:23:8:23 | *s [Return] [m1] | provenance |  |
 | aliasing.cpp:9:3:9:3 | *s [post update] [m1] | aliasing.cpp:8:23:8:23 | *s [m1] | provenance |  |
-| aliasing.cpp:9:3:9:3 | *s [post update] [m1] | aliasing.cpp:25:17:25:19 | pointerSetter output argument [m1] | provenance |  |
 | aliasing.cpp:9:3:9:22 | ... = ... | aliasing.cpp:9:3:9:3 | *s [post update] [m1] | provenance |  |
 | aliasing.cpp:9:11:9:20 | call to user_input | aliasing.cpp:9:3:9:22 | ... = ... | provenance |  |
+| aliasing.cpp:12:25:12:25 | *s [Return] [m1] | aliasing.cpp:26:19:26:20 | referenceSetter output argument [m1] | provenance |  |
 | aliasing.cpp:12:25:12:25 | *s [m1] | aliasing.cpp:26:19:26:20 | referenceSetter output argument [m1] | provenance |  |
+| aliasing.cpp:13:3:13:3 | *s [post update] [m1] | aliasing.cpp:12:25:12:25 | *s [Return] [m1] | provenance |  |
 | aliasing.cpp:13:3:13:3 | *s [post update] [m1] | aliasing.cpp:12:25:12:25 | *s [m1] | provenance |  |
-| aliasing.cpp:13:3:13:3 | *s [post update] [m1] | aliasing.cpp:26:19:26:20 | referenceSetter output argument [m1] | provenance |  |
 | aliasing.cpp:13:3:13:21 | ... = ... | aliasing.cpp:13:3:13:3 | *s [post update] [m1] | provenance |  |
 | aliasing.cpp:13:10:13:19 | call to user_input | aliasing.cpp:13:3:13:21 | ... = ... | provenance |  |
 | aliasing.cpp:25:17:25:19 | pointerSetter output argument [m1] | aliasing.cpp:29:8:29:9 | *s1 [m1] | provenance |  |
@@ -376,14 +395,18 @@ edges
 | arrays.cpp:50:10:50:17 | *indirect [*ptr, data] | arrays.cpp:50:20:50:22 | *ptr [data] | provenance |  |
 | arrays.cpp:50:20:50:22 | *ptr [data] | arrays.cpp:50:8:50:25 | *access to array [data] | provenance |  |
 | by_reference.cpp:11:48:11:52 | value | by_reference.cpp:12:5:12:16 | ... = ... | provenance |  |
+| by_reference.cpp:12:5:12:5 | *s [post update] [a] | by_reference.cpp:11:39:11:39 | *s [Return] [a] | provenance |  |
 | by_reference.cpp:12:5:12:5 | *s [post update] [a] | by_reference.cpp:11:39:11:39 | *s [a] | provenance |  |
 | by_reference.cpp:12:5:12:16 | ... = ... | by_reference.cpp:12:5:12:5 | *s [post update] [a] | provenance |  |
 | by_reference.cpp:15:26:15:30 | value | by_reference.cpp:16:5:16:19 | ... = ... | provenance |  |
+| by_reference.cpp:16:5:16:8 | *this [post update] [a] | by_reference.cpp:15:8:15:18 | *this [Return] [a] | provenance |  |
 | by_reference.cpp:16:5:16:19 | ... = ... | by_reference.cpp:16:5:16:8 | *this [post update] [a] | provenance |  |
 | by_reference.cpp:19:28:19:32 | value | by_reference.cpp:20:23:20:27 | value | provenance |  |
+| by_reference.cpp:20:5:20:8 | setDirectly output argument [a] | by_reference.cpp:19:8:19:20 | *this [Return] [a] | provenance |  |
 | by_reference.cpp:20:23:20:27 | value | by_reference.cpp:15:26:15:30 | value | provenance |  |
 | by_reference.cpp:20:23:20:27 | value | by_reference.cpp:20:5:20:8 | setDirectly output argument [a] | provenance |  |
 | by_reference.cpp:23:34:23:38 | value | by_reference.cpp:24:25:24:29 | value | provenance |  |
+| by_reference.cpp:24:19:24:22 | nonMemberSetA output argument [a] | by_reference.cpp:23:8:23:26 | *this [Return] [a] | provenance |  |
 | by_reference.cpp:24:25:24:29 | value | by_reference.cpp:11:48:11:52 | value | provenance |  |
 | by_reference.cpp:24:25:24:29 | value | by_reference.cpp:24:19:24:22 | nonMemberSetA output argument [a] | provenance |  |
 | by_reference.cpp:31:46:31:46 | *s [a] | by_reference.cpp:32:12:32:12 | *s [a] | provenance |  |
@@ -424,26 +447,28 @@ edges
 | by_reference.cpp:68:21:68:30 | call to user_input | by_reference.cpp:68:17:68:18 | nonMemberSetA output argument [a] | provenance |  |
 | by_reference.cpp:69:22:69:23 | *& ... [a] | by_reference.cpp:31:46:31:46 | *s [a] | provenance |  |
 | by_reference.cpp:69:22:69:23 | *& ... [a] | by_reference.cpp:69:8:69:20 | call to nonMemberGetA | provenance |  |
+| by_reference.cpp:83:31:83:35 | *inner [Return] [a] | by_reference.cpp:102:21:102:39 | taint_inner_a_ptr output argument [a] | provenance |  |
+| by_reference.cpp:83:31:83:35 | *inner [Return] [a] | by_reference.cpp:103:27:103:35 | taint_inner_a_ptr output argument [a] | provenance |  |
+| by_reference.cpp:83:31:83:35 | *inner [Return] [a] | by_reference.cpp:106:21:106:41 | taint_inner_a_ptr output argument [a] | provenance |  |
+| by_reference.cpp:83:31:83:35 | *inner [Return] [a] | by_reference.cpp:107:29:107:37 | taint_inner_a_ptr output argument [a] | provenance |  |
 | by_reference.cpp:83:31:83:35 | *inner [a] | by_reference.cpp:102:21:102:39 | taint_inner_a_ptr output argument [a] | provenance |  |
 | by_reference.cpp:83:31:83:35 | *inner [a] | by_reference.cpp:103:27:103:35 | taint_inner_a_ptr output argument [a] | provenance |  |
 | by_reference.cpp:83:31:83:35 | *inner [a] | by_reference.cpp:106:21:106:41 | taint_inner_a_ptr output argument [a] | provenance |  |
 | by_reference.cpp:83:31:83:35 | *inner [a] | by_reference.cpp:107:29:107:37 | taint_inner_a_ptr output argument [a] | provenance |  |
+| by_reference.cpp:84:3:84:7 | *inner [post update] [a] | by_reference.cpp:83:31:83:35 | *inner [Return] [a] | provenance |  |
 | by_reference.cpp:84:3:84:7 | *inner [post update] [a] | by_reference.cpp:83:31:83:35 | *inner [a] | provenance |  |
-| by_reference.cpp:84:3:84:7 | *inner [post update] [a] | by_reference.cpp:102:21:102:39 | taint_inner_a_ptr output argument [a] | provenance |  |
-| by_reference.cpp:84:3:84:7 | *inner [post update] [a] | by_reference.cpp:103:27:103:35 | taint_inner_a_ptr output argument [a] | provenance |  |
-| by_reference.cpp:84:3:84:7 | *inner [post update] [a] | by_reference.cpp:106:21:106:41 | taint_inner_a_ptr output argument [a] | provenance |  |
-| by_reference.cpp:84:3:84:7 | *inner [post update] [a] | by_reference.cpp:107:29:107:37 | taint_inner_a_ptr output argument [a] | provenance |  |
 | by_reference.cpp:84:3:84:25 | ... = ... | by_reference.cpp:84:3:84:7 | *inner [post update] [a] | provenance |  |
 | by_reference.cpp:84:14:84:23 | call to user_input | by_reference.cpp:84:3:84:25 | ... = ... | provenance |  |
+| by_reference.cpp:87:31:87:35 | *inner [Return] [a] | by_reference.cpp:122:21:122:38 | taint_inner_a_ref output argument [a] | provenance |  |
+| by_reference.cpp:87:31:87:35 | *inner [Return] [a] | by_reference.cpp:123:21:123:36 | taint_inner_a_ref output argument [a] | provenance |  |
+| by_reference.cpp:87:31:87:35 | *inner [Return] [a] | by_reference.cpp:126:21:126:40 | taint_inner_a_ref output argument [a] | provenance |  |
+| by_reference.cpp:87:31:87:35 | *inner [Return] [a] | by_reference.cpp:127:21:127:38 | taint_inner_a_ref output argument [a] | provenance |  |
 | by_reference.cpp:87:31:87:35 | *inner [a] | by_reference.cpp:122:21:122:38 | taint_inner_a_ref output argument [a] | provenance |  |
 | by_reference.cpp:87:31:87:35 | *inner [a] | by_reference.cpp:123:21:123:36 | taint_inner_a_ref output argument [a] | provenance |  |
 | by_reference.cpp:87:31:87:35 | *inner [a] | by_reference.cpp:126:21:126:40 | taint_inner_a_ref output argument [a] | provenance |  |
 | by_reference.cpp:87:31:87:35 | *inner [a] | by_reference.cpp:127:21:127:38 | taint_inner_a_ref output argument [a] | provenance |  |
+| by_reference.cpp:88:3:88:7 | *inner [post update] [a] | by_reference.cpp:87:31:87:35 | *inner [Return] [a] | provenance |  |
 | by_reference.cpp:88:3:88:7 | *inner [post update] [a] | by_reference.cpp:87:31:87:35 | *inner [a] | provenance |  |
-| by_reference.cpp:88:3:88:7 | *inner [post update] [a] | by_reference.cpp:122:21:122:38 | taint_inner_a_ref output argument [a] | provenance |  |
-| by_reference.cpp:88:3:88:7 | *inner [post update] [a] | by_reference.cpp:123:21:123:36 | taint_inner_a_ref output argument [a] | provenance |  |
-| by_reference.cpp:88:3:88:7 | *inner [post update] [a] | by_reference.cpp:126:21:126:40 | taint_inner_a_ref output argument [a] | provenance |  |
-| by_reference.cpp:88:3:88:7 | *inner [post update] [a] | by_reference.cpp:127:21:127:38 | taint_inner_a_ref output argument [a] | provenance |  |
 | by_reference.cpp:88:3:88:24 | ... = ... | by_reference.cpp:88:3:88:7 | *inner [post update] [a] | provenance |  |
 | by_reference.cpp:88:13:88:22 | call to user_input | by_reference.cpp:88:3:88:24 | ... = ... | provenance |  |
 | by_reference.cpp:91:25:91:26 | *pa | by_reference.cpp:104:15:104:22 | taint_a_ptr output argument | provenance |  |
@@ -599,8 +624,10 @@ edges
 | complex.cpp:10:20:10:21 | b_ | complex.cpp:10:7:10:7 | *b | provenance |  |
 | complex.cpp:10:20:10:21 | b_ | complex.cpp:10:20:10:21 | b_ | provenance |  |
 | complex.cpp:11:17:11:17 | a | complex.cpp:11:22:11:27 | ... = ... | provenance |  |
+| complex.cpp:11:22:11:23 | *this [post update] [a_] | complex.cpp:11:8:11:11 | *this [Return] [a_] | provenance |  |
 | complex.cpp:11:22:11:27 | ... = ... | complex.cpp:11:22:11:23 | *this [post update] [a_] | provenance |  |
 | complex.cpp:12:17:12:17 | b | complex.cpp:12:22:12:27 | ... = ... | provenance |  |
+| complex.cpp:12:22:12:23 | *this [post update] [b_] | complex.cpp:12:8:12:11 | *this [Return] [b_] | provenance |  |
 | complex.cpp:12:22:12:27 | ... = ... | complex.cpp:12:22:12:23 | *this [post update] [b_] | provenance |  |
 | complex.cpp:40:17:40:17 | *b [inner, f, a_] | complex.cpp:42:8:42:8 | *b [inner, f, a_] | provenance |  |
 | complex.cpp:40:17:40:17 | *b [inner, f, b_] | complex.cpp:43:8:43:8 | *b [inner, f, b_] | provenance |  |
@@ -669,6 +696,8 @@ edges
 | constructors.cpp:19:22:19:23 | *this [b_] | constructors.cpp:19:22:19:23 | b_ | provenance |  |
 | constructors.cpp:19:22:19:23 | b_ | constructors.cpp:19:9:19:9 | *b | provenance |  |
 | constructors.cpp:19:22:19:23 | b_ | constructors.cpp:19:22:19:23 | b_ | provenance |  |
+| constructors.cpp:23:5:23:7 | *this [post update] [a_] | constructors.cpp:23:5:23:7 | *this [Return] [a_] | provenance |  |
+| constructors.cpp:23:5:23:7 | *this [post update] [b_] | constructors.cpp:23:5:23:7 | *this [Return] [b_] | provenance |  |
 | constructors.cpp:23:13:23:13 | a | constructors.cpp:23:28:23:28 | a | provenance |  |
 | constructors.cpp:23:20:23:20 | b | constructors.cpp:23:35:23:35 | b | provenance |  |
 | constructors.cpp:23:28:23:28 | a | constructors.cpp:23:5:23:7 | *this [post update] [a_] | provenance |  |
@@ -696,11 +725,14 @@ edges
 | constructors.cpp:46:9:46:9 | *h [a_] | constructors.cpp:26:15:26:15 | *f [a_] | provenance |  |
 | constructors.cpp:46:9:46:9 | *h [b_] | constructors.cpp:26:15:26:15 | *f [b_] | provenance |  |
 | qualifiers.cpp:9:21:9:25 | value | qualifiers.cpp:9:30:9:44 | ... = ... | provenance |  |
+| qualifiers.cpp:9:30:9:33 | *this [post update] [a] | qualifiers.cpp:9:10:9:13 | *this [Return] [a] | provenance |  |
 | qualifiers.cpp:9:30:9:44 | ... = ... | qualifiers.cpp:9:30:9:33 | *this [post update] [a] | provenance |  |
 | qualifiers.cpp:12:40:12:44 | value | qualifiers.cpp:12:49:12:64 | ... = ... | provenance |  |
+| qualifiers.cpp:12:49:12:53 | *inner [post update] [a] | qualifiers.cpp:12:27:12:31 | *inner [Return] [a] | provenance |  |
 | qualifiers.cpp:12:49:12:53 | *inner [post update] [a] | qualifiers.cpp:12:27:12:31 | *inner [a] | provenance |  |
 | qualifiers.cpp:12:49:12:64 | ... = ... | qualifiers.cpp:12:49:12:53 | *inner [post update] [a] | provenance |  |
 | qualifiers.cpp:13:42:13:46 | value | qualifiers.cpp:13:51:13:65 | ... = ... | provenance |  |
+| qualifiers.cpp:13:51:13:55 | *inner [post update] [a] | qualifiers.cpp:13:29:13:33 | *inner [Return] [a] | provenance |  |
 | qualifiers.cpp:13:51:13:55 | *inner [post update] [a] | qualifiers.cpp:13:29:13:33 | *inner [a] | provenance |  |
 | qualifiers.cpp:13:51:13:65 | ... = ... | qualifiers.cpp:13:51:13:55 | *inner [post update] [a] | provenance |  |
 | qualifiers.cpp:22:5:22:9 | getInner output argument [*inner, a] | qualifiers.cpp:23:10:23:14 | *outer [*inner, a] | provenance |  |
@@ -758,8 +790,10 @@ edges
 | simple.cpp:19:22:19:23 | b_ | simple.cpp:19:9:19:9 | *b | provenance |  |
 | simple.cpp:19:22:19:23 | b_ | simple.cpp:19:22:19:23 | b_ | provenance |  |
 | simple.cpp:20:19:20:19 | a | simple.cpp:20:24:20:29 | ... = ... | provenance |  |
+| simple.cpp:20:24:20:25 | *this [post update] [a_] | simple.cpp:20:10:20:13 | *this [Return] [a_] | provenance |  |
 | simple.cpp:20:24:20:29 | ... = ... | simple.cpp:20:24:20:25 | *this [post update] [a_] | provenance |  |
 | simple.cpp:21:19:21:19 | b | simple.cpp:21:24:21:29 | ... = ... | provenance |  |
+| simple.cpp:21:24:21:25 | *this [post update] [b_] | simple.cpp:21:10:21:13 | *this [Return] [b_] | provenance |  |
 | simple.cpp:21:24:21:29 | ... = ... | simple.cpp:21:24:21:25 | *this [post update] [b_] | provenance |  |
 | simple.cpp:26:15:26:15 | *f [a_] | simple.cpp:28:10:28:10 | *f [a_] | provenance |  |
 | simple.cpp:26:15:26:15 | *f [b_] | simple.cpp:29:10:29:10 | *f [b_] | provenance |  |
@@ -844,9 +878,11 @@ edges
 | struct_init.c:46:10:46:14 | *outer [*pointerAB, a] | struct_init.c:46:16:46:24 | *pointerAB [a] | provenance |  |
 | struct_init.c:46:16:46:24 | *pointerAB [a] | struct_init.c:14:24:14:25 | *ab [a] | provenance |  |
 nodes
+| A.cpp:23:5:23:5 | *this [Return] [c] | semmle.label | *this [Return] [c] |
 | A.cpp:23:10:23:10 | c | semmle.label | c |
 | A.cpp:25:7:25:10 | *this [post update] [c] | semmle.label | *this [post update] [c] |
 | A.cpp:25:7:25:17 | ... = ... | semmle.label | ... = ... |
+| A.cpp:27:10:27:12 | *this [Return] [c] | semmle.label | *this [Return] [c] |
 | A.cpp:27:17:27:17 | c | semmle.label | c |
 | A.cpp:27:22:27:25 | *this [post update] [c] | semmle.label | *this [post update] [c] |
 | A.cpp:27:22:27:32 | ... = ... | semmle.label | ... = ... |
@@ -914,6 +950,7 @@ nodes
 | A.cpp:118:18:118:39 | *cc [a] | semmle.label | *cc [a] |
 | A.cpp:120:12:120:13 | *c1 [a] | semmle.label | *c1 [a] |
 | A.cpp:120:12:120:16 | a | semmle.label | a |
+| A.cpp:124:14:124:14 | *b [Return] [c] | semmle.label | *b [Return] [c] |
 | A.cpp:124:14:124:14 | *b [c] | semmle.label | *b [c] |
 | A.cpp:126:5:126:5 | set output argument [c] | semmle.label | set output argument [c] |
 | A.cpp:126:12:126:18 | new | semmle.label | new |
@@ -921,6 +958,10 @@ nodes
 | A.cpp:131:8:131:8 | f7 output argument [c] | semmle.label | f7 output argument [c] |
 | A.cpp:132:10:132:10 | *b [c] | semmle.label | *b [c] |
 | A.cpp:132:10:132:13 | c | semmle.label | c |
+| A.cpp:140:5:140:5 | *this [Return] [*b, c] | semmle.label | *this [Return] [*b, c] |
+| A.cpp:140:5:140:5 | *this [Return] [b] | semmle.label | *this [Return] [b] |
+| A.cpp:140:5:140:5 | *this [Return] [b] | semmle.label | *this [Return] [b] |
+| A.cpp:140:13:140:13 | *b [Return] [c] | semmle.label | *b [Return] [c] |
 | A.cpp:140:13:140:13 | *b [c] | semmle.label | *b [c] |
 | A.cpp:140:13:140:13 | b | semmle.label | b |
 | A.cpp:142:7:142:7 | *b [post update] [c] | semmle.label | *b [post update] [c] |
@@ -979,6 +1020,9 @@ nodes
 | A.cpp:169:12:169:18 | head | semmle.label | head |
 | A.cpp:173:26:173:26 | *o [c] | semmle.label | *o [c] |
 | A.cpp:173:26:173:26 | *o [c] | semmle.label | *o [c] |
+| A.cpp:181:5:181:10 | *this [Return] [*next, *next, head] | semmle.label | *this [Return] [*next, *next, head] |
+| A.cpp:181:5:181:10 | *this [Return] [*next, head] | semmle.label | *this [Return] [*next, head] |
+| A.cpp:181:5:181:10 | *this [Return] [head] | semmle.label | *this [Return] [head] |
 | A.cpp:181:15:181:21 | newHead | semmle.label | newHead |
 | A.cpp:181:32:181:35 | *next [*next, head] | semmle.label | *next [*next, head] |
 | A.cpp:181:32:181:35 | *next [head] | semmle.label | *next [head] |
@@ -1010,12 +1054,16 @@ nodes
 | B.cpp:19:10:19:11 | *b2 [*box1, elem2] | semmle.label | *b2 [*box1, elem2] |
 | B.cpp:19:10:19:24 | elem2 | semmle.label | elem2 |
 | B.cpp:19:14:19:17 | *box1 [elem2] | semmle.label | *box1 [elem2] |
+| B.cpp:33:5:33:8 | *this [Return] [elem1] | semmle.label | *this [Return] [elem1] |
+| B.cpp:33:5:33:8 | *this [Return] [elem2] | semmle.label | *this [Return] [elem2] |
 | B.cpp:33:16:33:17 | e1 | semmle.label | e1 |
 | B.cpp:33:26:33:27 | e2 | semmle.label | e2 |
 | B.cpp:35:7:35:10 | *this [post update] [elem1] | semmle.label | *this [post update] [elem1] |
 | B.cpp:35:7:35:22 | ... = ... | semmle.label | ... = ... |
 | B.cpp:36:7:36:10 | *this [post update] [elem2] | semmle.label | *this [post update] [elem2] |
 | B.cpp:36:7:36:22 | ... = ... | semmle.label | ... = ... |
+| B.cpp:44:5:44:8 | *this [Return] [*box1, elem1] | semmle.label | *this [Return] [*box1, elem1] |
+| B.cpp:44:5:44:8 | *this [Return] [*box1, elem2] | semmle.label | *this [Return] [*box1, elem2] |
 | B.cpp:44:16:44:17 | *b1 [elem1] | semmle.label | *b1 [elem1] |
 | B.cpp:44:16:44:17 | *b1 [elem2] | semmle.label | *b1 [elem2] |
 | B.cpp:46:7:46:10 | *this [post update] [*box1, elem1] | semmle.label | *this [post update] [*box1, elem1] |
@@ -1028,6 +1076,8 @@ nodes
 | C.cpp:18:12:18:18 | call to C [s3] | semmle.label | call to C [s3] |
 | C.cpp:19:5:19:5 | *c [s1] | semmle.label | *c [s1] |
 | C.cpp:19:5:19:5 | *c [s3] | semmle.label | *c [s3] |
+| C.cpp:22:3:22:3 | *this [Return] [s1] | semmle.label | *this [Return] [s1] |
+| C.cpp:22:3:22:3 | *this [Return] [s3] | semmle.label | *this [Return] [s3] |
 | C.cpp:22:3:22:3 | *this [post update] [s1] | semmle.label | *this [post update] [s1] |
 | C.cpp:22:12:22:21 | new | semmle.label | new |
 | C.cpp:22:12:22:21 | new | semmle.label | new |
@@ -1045,6 +1095,7 @@ nodes
 | D.cpp:10:30:10:33 | *this [elem] | semmle.label | *this [elem] |
 | D.cpp:10:30:10:33 | elem | semmle.label | elem |
 | D.cpp:10:30:10:33 | elem | semmle.label | elem |
+| D.cpp:11:10:11:16 | *this [Return] [elem] | semmle.label | *this [Return] [elem] |
 | D.cpp:11:24:11:24 | e | semmle.label | e |
 | D.cpp:11:29:11:32 | *this [post update] [elem] | semmle.label | *this [post update] [elem] |
 | D.cpp:11:29:11:36 | ... = ... | semmle.label | ... = ... |
@@ -1107,10 +1158,12 @@ nodes
 | E.cpp:32:10:32:10 | *b [*buffer] | semmle.label | *b [*buffer] |
 | E.cpp:32:13:32:18 | *buffer | semmle.label | *buffer |
 | E.cpp:33:18:33:19 | *& ... [data, *buffer] | semmle.label | *& ... [data, *buffer] |
+| aliasing.cpp:8:23:8:23 | *s [Return] [m1] | semmle.label | *s [Return] [m1] |
 | aliasing.cpp:8:23:8:23 | *s [m1] | semmle.label | *s [m1] |
 | aliasing.cpp:9:3:9:3 | *s [post update] [m1] | semmle.label | *s [post update] [m1] |
 | aliasing.cpp:9:3:9:22 | ... = ... | semmle.label | ... = ... |
 | aliasing.cpp:9:11:9:20 | call to user_input | semmle.label | call to user_input |
+| aliasing.cpp:12:25:12:25 | *s [Return] [m1] | semmle.label | *s [Return] [m1] |
 | aliasing.cpp:12:25:12:25 | *s [m1] | semmle.label | *s [m1] |
 | aliasing.cpp:13:3:13:3 | *s [post update] [m1] | semmle.label | *s [post update] [m1] |
 | aliasing.cpp:13:3:13:21 | ... = ... | semmle.label | ... = ... |
@@ -1236,16 +1289,20 @@ nodes
 | arrays.cpp:50:10:50:17 | *indirect [*ptr, data] | semmle.label | *indirect [*ptr, data] |
 | arrays.cpp:50:20:50:22 | *ptr [data] | semmle.label | *ptr [data] |
 | arrays.cpp:50:27:50:30 | data | semmle.label | data |
+| by_reference.cpp:11:39:11:39 | *s [Return] [a] | semmle.label | *s [Return] [a] |
 | by_reference.cpp:11:39:11:39 | *s [a] | semmle.label | *s [a] |
 | by_reference.cpp:11:48:11:52 | value | semmle.label | value |
 | by_reference.cpp:12:5:12:5 | *s [post update] [a] | semmle.label | *s [post update] [a] |
 | by_reference.cpp:12:5:12:16 | ... = ... | semmle.label | ... = ... |
+| by_reference.cpp:15:8:15:18 | *this [Return] [a] | semmle.label | *this [Return] [a] |
 | by_reference.cpp:15:26:15:30 | value | semmle.label | value |
 | by_reference.cpp:16:5:16:8 | *this [post update] [a] | semmle.label | *this [post update] [a] |
 | by_reference.cpp:16:5:16:19 | ... = ... | semmle.label | ... = ... |
+| by_reference.cpp:19:8:19:20 | *this [Return] [a] | semmle.label | *this [Return] [a] |
 | by_reference.cpp:19:28:19:32 | value | semmle.label | value |
 | by_reference.cpp:20:5:20:8 | setDirectly output argument [a] | semmle.label | setDirectly output argument [a] |
 | by_reference.cpp:20:23:20:27 | value | semmle.label | value |
+| by_reference.cpp:23:8:23:26 | *this [Return] [a] | semmle.label | *this [Return] [a] |
 | by_reference.cpp:23:34:23:38 | value | semmle.label | value |
 | by_reference.cpp:24:19:24:22 | nonMemberSetA output argument [a] | semmle.label | nonMemberSetA output argument [a] |
 | by_reference.cpp:24:25:24:29 | value | semmle.label | value |
@@ -1285,10 +1342,12 @@ nodes
 | by_reference.cpp:68:21:68:30 | call to user_input | semmle.label | call to user_input |
 | by_reference.cpp:69:8:69:20 | call to nonMemberGetA | semmle.label | call to nonMemberGetA |
 | by_reference.cpp:69:22:69:23 | *& ... [a] | semmle.label | *& ... [a] |
+| by_reference.cpp:83:31:83:35 | *inner [Return] [a] | semmle.label | *inner [Return] [a] |
 | by_reference.cpp:83:31:83:35 | *inner [a] | semmle.label | *inner [a] |
 | by_reference.cpp:84:3:84:7 | *inner [post update] [a] | semmle.label | *inner [post update] [a] |
 | by_reference.cpp:84:3:84:25 | ... = ... | semmle.label | ... = ... |
 | by_reference.cpp:84:14:84:23 | call to user_input | semmle.label | call to user_input |
+| by_reference.cpp:87:31:87:35 | *inner [Return] [a] | semmle.label | *inner [Return] [a] |
 | by_reference.cpp:87:31:87:35 | *inner [a] | semmle.label | *inner [a] |
 | by_reference.cpp:88:3:88:7 | *inner [post update] [a] | semmle.label | *inner [post update] [a] |
 | by_reference.cpp:88:3:88:24 | ... = ... | semmle.label | ... = ... |
@@ -1454,9 +1513,11 @@ nodes
 | complex.cpp:10:20:10:21 | *this [b_] | semmle.label | *this [b_] |
 | complex.cpp:10:20:10:21 | b_ | semmle.label | b_ |
 | complex.cpp:10:20:10:21 | b_ | semmle.label | b_ |
+| complex.cpp:11:8:11:11 | *this [Return] [a_] | semmle.label | *this [Return] [a_] |
 | complex.cpp:11:17:11:17 | a | semmle.label | a |
 | complex.cpp:11:22:11:23 | *this [post update] [a_] | semmle.label | *this [post update] [a_] |
 | complex.cpp:11:22:11:27 | ... = ... | semmle.label | ... = ... |
+| complex.cpp:12:8:12:11 | *this [Return] [b_] | semmle.label | *this [Return] [b_] |
 | complex.cpp:12:17:12:17 | b | semmle.label | b |
 | complex.cpp:12:22:12:23 | *this [post update] [b_] | semmle.label | *this [post update] [b_] |
 | complex.cpp:12:22:12:27 | ... = ... | semmle.label | ... = ... |
@@ -1531,6 +1592,8 @@ nodes
 | constructors.cpp:19:22:19:23 | *this [b_] | semmle.label | *this [b_] |
 | constructors.cpp:19:22:19:23 | b_ | semmle.label | b_ |
 | constructors.cpp:19:22:19:23 | b_ | semmle.label | b_ |
+| constructors.cpp:23:5:23:7 | *this [Return] [a_] | semmle.label | *this [Return] [a_] |
+| constructors.cpp:23:5:23:7 | *this [Return] [b_] | semmle.label | *this [Return] [b_] |
 | constructors.cpp:23:5:23:7 | *this [post update] [a_] | semmle.label | *this [post update] [a_] |
 | constructors.cpp:23:5:23:7 | *this [post update] [b_] | semmle.label | *this [post update] [b_] |
 | constructors.cpp:23:13:23:13 | a | semmle.label | a |
@@ -1555,13 +1618,16 @@ nodes
 | constructors.cpp:43:9:43:9 | *g [b_] | semmle.label | *g [b_] |
 | constructors.cpp:46:9:46:9 | *h [a_] | semmle.label | *h [a_] |
 | constructors.cpp:46:9:46:9 | *h [b_] | semmle.label | *h [b_] |
+| qualifiers.cpp:9:10:9:13 | *this [Return] [a] | semmle.label | *this [Return] [a] |
 | qualifiers.cpp:9:21:9:25 | value | semmle.label | value |
 | qualifiers.cpp:9:30:9:33 | *this [post update] [a] | semmle.label | *this [post update] [a] |
 | qualifiers.cpp:9:30:9:44 | ... = ... | semmle.label | ... = ... |
+| qualifiers.cpp:12:27:12:31 | *inner [Return] [a] | semmle.label | *inner [Return] [a] |
 | qualifiers.cpp:12:27:12:31 | *inner [a] | semmle.label | *inner [a] |
 | qualifiers.cpp:12:40:12:44 | value | semmle.label | value |
 | qualifiers.cpp:12:49:12:53 | *inner [post update] [a] | semmle.label | *inner [post update] [a] |
 | qualifiers.cpp:12:49:12:64 | ... = ... | semmle.label | ... = ... |
+| qualifiers.cpp:13:29:13:33 | *inner [Return] [a] | semmle.label | *inner [Return] [a] |
 | qualifiers.cpp:13:29:13:33 | *inner [a] | semmle.label | *inner [a] |
 | qualifiers.cpp:13:42:13:46 | value | semmle.label | value |
 | qualifiers.cpp:13:51:13:55 | *inner [post update] [a] | semmle.label | *inner [post update] [a] |
@@ -1626,9 +1692,11 @@ nodes
 | simple.cpp:19:22:19:23 | *this [b_] | semmle.label | *this [b_] |
 | simple.cpp:19:22:19:23 | b_ | semmle.label | b_ |
 | simple.cpp:19:22:19:23 | b_ | semmle.label | b_ |
+| simple.cpp:20:10:20:13 | *this [Return] [a_] | semmle.label | *this [Return] [a_] |
 | simple.cpp:20:19:20:19 | a | semmle.label | a |
 | simple.cpp:20:24:20:25 | *this [post update] [a_] | semmle.label | *this [post update] [a_] |
 | simple.cpp:20:24:20:29 | ... = ... | semmle.label | ... = ... |
+| simple.cpp:21:10:21:13 | *this [Return] [b_] | semmle.label | *this [Return] [b_] |
 | simple.cpp:21:19:21:19 | b | semmle.label | b |
 | simple.cpp:21:24:21:25 | *this [post update] [b_] | semmle.label | *this [post update] [b_] |
 | simple.cpp:21:24:21:29 | ... = ... | semmle.label | ... = ... |
@@ -1715,67 +1783,67 @@ nodes
 | struct_init.c:46:10:46:14 | *outer [*pointerAB, a] | semmle.label | *outer [*pointerAB, a] |
 | struct_init.c:46:16:46:24 | *pointerAB [a] | semmle.label | *pointerAB [a] |
 subpaths
-| A.cpp:31:20:31:20 | c | A.cpp:23:10:23:10 | c | A.cpp:25:7:25:10 | *this [post update] [c] | A.cpp:31:14:31:21 | call to B [c] |
+| A.cpp:31:20:31:20 | c | A.cpp:23:10:23:10 | c | A.cpp:23:5:23:5 | *this [Return] [c] | A.cpp:31:14:31:21 | call to B [c] |
 | A.cpp:48:20:48:20 | c | A.cpp:29:23:29:23 | c | A.cpp:29:15:29:18 | **make [c] | A.cpp:48:12:48:18 | *call to make [c] |
-| A.cpp:55:12:55:19 | new | A.cpp:27:17:27:17 | c | A.cpp:27:22:27:25 | *this [post update] [c] | A.cpp:55:5:55:5 | set output argument [c] |
+| A.cpp:55:12:55:19 | new | A.cpp:27:17:27:17 | c | A.cpp:27:10:27:12 | *this [Return] [c] | A.cpp:55:5:55:5 | set output argument [c] |
 | A.cpp:56:10:56:10 | *b [c] | A.cpp:28:8:28:10 | *this [c] | A.cpp:28:8:28:10 | *get | A.cpp:56:10:56:17 | call to get |
 | A.cpp:57:11:57:24 | *new [c] | A.cpp:28:8:28:10 | *this [c] | A.cpp:28:8:28:10 | *get | A.cpp:57:10:57:32 | call to get |
-| A.cpp:57:17:57:23 | new | A.cpp:23:10:23:10 | c | A.cpp:25:7:25:10 | *this [post update] [c] | A.cpp:57:11:57:24 | call to B [c] |
+| A.cpp:57:17:57:23 | new | A.cpp:23:10:23:10 | c | A.cpp:23:5:23:5 | *this [Return] [c] | A.cpp:57:11:57:24 | call to B [c] |
 | A.cpp:64:21:64:28 | new | A.cpp:85:26:85:26 | c | A.cpp:85:9:85:14 | **setOnB [c] | A.cpp:64:10:64:15 | *call to setOnB [c] |
 | A.cpp:73:25:73:32 | new | A.cpp:78:27:78:27 | c | A.cpp:78:6:78:15 | **setOnBWrap [c] | A.cpp:73:10:73:19 | *call to setOnBWrap [c] |
 | A.cpp:81:21:81:21 | c | A.cpp:85:26:85:26 | c | A.cpp:85:9:85:14 | **setOnB [c] | A.cpp:81:10:81:15 | *call to setOnB [c] |
-| A.cpp:90:15:90:15 | c | A.cpp:27:17:27:17 | c | A.cpp:27:22:27:25 | *this [post update] [c] | A.cpp:90:7:90:8 | set output argument [c] |
-| A.cpp:126:12:126:18 | new | A.cpp:27:17:27:17 | c | A.cpp:27:22:27:25 | *this [post update] [c] | A.cpp:126:5:126:5 | set output argument [c] |
-| A.cpp:151:18:151:18 | b | A.cpp:140:13:140:13 | b | A.cpp:143:7:143:10 | *this [post update] [b] | A.cpp:151:12:151:24 | call to D [b] |
+| A.cpp:90:15:90:15 | c | A.cpp:27:17:27:17 | c | A.cpp:27:10:27:12 | *this [Return] [c] | A.cpp:90:7:90:8 | set output argument [c] |
+| A.cpp:126:12:126:18 | new | A.cpp:27:17:27:17 | c | A.cpp:27:10:27:12 | *this [Return] [c] | A.cpp:126:5:126:5 | set output argument [c] |
+| A.cpp:151:18:151:18 | b | A.cpp:140:13:140:13 | b | A.cpp:140:5:140:5 | *this [Return] [b] | A.cpp:151:12:151:24 | call to D [b] |
 | A.cpp:152:10:152:13 | *b [c] | A.cpp:173:26:173:26 | *o [c] | A.cpp:173:26:173:26 | *o [c] | A.cpp:152:10:152:13 | sink output argument [c] |
-| A.cpp:160:29:160:29 | b | A.cpp:181:15:181:21 | newHead | A.cpp:183:7:183:10 | *this [post update] [head] | A.cpp:160:18:160:60 | call to MyList [head] |
-| A.cpp:161:38:161:39 | *l1 [head] | A.cpp:181:32:181:35 | *next [head] | A.cpp:184:7:184:10 | *this [post update] [*next, head] | A.cpp:161:18:161:40 | call to MyList [*next, head] |
-| A.cpp:162:38:162:39 | *l2 [*next, head] | A.cpp:181:32:181:35 | *next [*next, head] | A.cpp:184:7:184:10 | *this [post update] [*next, *next, head] | A.cpp:162:18:162:40 | call to MyList [*next, *next, head] |
-| B.cpp:7:25:7:25 | e | B.cpp:33:16:33:17 | e1 | B.cpp:35:7:35:10 | *this [post update] [elem1] | B.cpp:7:16:7:35 | call to Box1 [elem1] |
-| B.cpp:8:25:8:26 | *b1 [elem1] | B.cpp:44:16:44:17 | *b1 [elem1] | B.cpp:46:7:46:10 | *this [post update] [*box1, elem1] | B.cpp:8:16:8:27 | call to Box2 [*box1, elem1] |
-| B.cpp:16:37:16:37 | e | B.cpp:33:26:33:27 | e2 | B.cpp:36:7:36:10 | *this [post update] [elem2] | B.cpp:16:16:16:38 | call to Box1 [elem2] |
-| B.cpp:17:25:17:26 | *b1 [elem2] | B.cpp:44:16:44:17 | *b1 [elem2] | B.cpp:46:7:46:10 | *this [post update] [*box1, elem2] | B.cpp:17:16:17:27 | call to Box2 [*box1, elem2] |
+| A.cpp:160:29:160:29 | b | A.cpp:181:15:181:21 | newHead | A.cpp:181:5:181:10 | *this [Return] [head] | A.cpp:160:18:160:60 | call to MyList [head] |
+| A.cpp:161:38:161:39 | *l1 [head] | A.cpp:181:32:181:35 | *next [head] | A.cpp:181:5:181:10 | *this [Return] [*next, head] | A.cpp:161:18:161:40 | call to MyList [*next, head] |
+| A.cpp:162:38:162:39 | *l2 [*next, head] | A.cpp:181:32:181:35 | *next [*next, head] | A.cpp:181:5:181:10 | *this [Return] [*next, *next, head] | A.cpp:162:18:162:40 | call to MyList [*next, *next, head] |
+| B.cpp:7:25:7:25 | e | B.cpp:33:16:33:17 | e1 | B.cpp:33:5:33:8 | *this [Return] [elem1] | B.cpp:7:16:7:35 | call to Box1 [elem1] |
+| B.cpp:8:25:8:26 | *b1 [elem1] | B.cpp:44:16:44:17 | *b1 [elem1] | B.cpp:44:5:44:8 | *this [Return] [*box1, elem1] | B.cpp:8:16:8:27 | call to Box2 [*box1, elem1] |
+| B.cpp:16:37:16:37 | e | B.cpp:33:26:33:27 | e2 | B.cpp:33:5:33:8 | *this [Return] [elem2] | B.cpp:16:16:16:38 | call to Box1 [elem2] |
+| B.cpp:17:25:17:26 | *b1 [elem2] | B.cpp:44:16:44:17 | *b1 [elem2] | B.cpp:44:5:44:8 | *this [Return] [*box1, elem2] | B.cpp:17:16:17:27 | call to Box2 [*box1, elem2] |
 | D.cpp:22:10:22:11 | *b2 [*box, elem] | D.cpp:17:11:17:17 | *this [*box, elem] | D.cpp:17:11:17:17 | **getBox1 [elem] | D.cpp:22:14:22:20 | *call to getBox1 [elem] |
 | D.cpp:22:14:22:20 | *call to getBox1 [elem] | D.cpp:10:11:10:17 | *this [elem] | D.cpp:10:11:10:17 | *getElem | D.cpp:22:10:22:33 | call to getElem |
-| D.cpp:37:21:37:21 | e | D.cpp:11:24:11:24 | e | D.cpp:11:29:11:32 | *this [post update] [elem] | D.cpp:37:8:37:10 | setElem output argument [elem] |
-| D.cpp:51:27:51:27 | e | D.cpp:11:24:11:24 | e | D.cpp:11:29:11:32 | *this [post update] [elem] | D.cpp:51:8:51:14 | setElem output argument [elem] |
-| by_reference.cpp:20:23:20:27 | value | by_reference.cpp:15:26:15:30 | value | by_reference.cpp:16:5:16:8 | *this [post update] [a] | by_reference.cpp:20:5:20:8 | setDirectly output argument [a] |
+| D.cpp:37:21:37:21 | e | D.cpp:11:24:11:24 | e | D.cpp:11:10:11:16 | *this [Return] [elem] | D.cpp:37:8:37:10 | setElem output argument [elem] |
+| D.cpp:51:27:51:27 | e | D.cpp:11:24:11:24 | e | D.cpp:11:10:11:16 | *this [Return] [elem] | D.cpp:51:8:51:14 | setElem output argument [elem] |
+| by_reference.cpp:20:23:20:27 | value | by_reference.cpp:15:26:15:30 | value | by_reference.cpp:15:8:15:18 | *this [Return] [a] | by_reference.cpp:20:5:20:8 | setDirectly output argument [a] |
+| by_reference.cpp:24:25:24:29 | value | by_reference.cpp:11:48:11:52 | value | by_reference.cpp:11:39:11:39 | *s [Return] [a] | by_reference.cpp:24:19:24:22 | nonMemberSetA output argument [a] |
 | by_reference.cpp:24:25:24:29 | value | by_reference.cpp:11:48:11:52 | value | by_reference.cpp:11:39:11:39 | *s [a] | by_reference.cpp:24:19:24:22 | nonMemberSetA output argument [a] |
-| by_reference.cpp:24:25:24:29 | value | by_reference.cpp:11:48:11:52 | value | by_reference.cpp:12:5:12:5 | *s [post update] [a] | by_reference.cpp:24:19:24:22 | nonMemberSetA output argument [a] |
 | by_reference.cpp:40:12:40:15 | *this [a] | by_reference.cpp:35:9:35:19 | *this [a] | by_reference.cpp:35:9:35:19 | *getDirectly | by_reference.cpp:40:18:40:28 | call to getDirectly |
 | by_reference.cpp:44:26:44:29 | *this [a] | by_reference.cpp:31:46:31:46 | *s [a] | by_reference.cpp:31:16:31:28 | *nonMemberGetA | by_reference.cpp:44:12:44:24 | call to nonMemberGetA |
-| by_reference.cpp:50:17:50:26 | call to user_input | by_reference.cpp:15:26:15:30 | value | by_reference.cpp:16:5:16:8 | *this [post update] [a] | by_reference.cpp:50:3:50:3 | setDirectly output argument [a] |
+| by_reference.cpp:50:17:50:26 | call to user_input | by_reference.cpp:15:26:15:30 | value | by_reference.cpp:15:8:15:18 | *this [Return] [a] | by_reference.cpp:50:3:50:3 | setDirectly output argument [a] |
 | by_reference.cpp:51:8:51:8 | *s [a] | by_reference.cpp:35:9:35:19 | *this [a] | by_reference.cpp:35:9:35:19 | *getDirectly | by_reference.cpp:51:10:51:20 | call to getDirectly |
-| by_reference.cpp:56:19:56:28 | call to user_input | by_reference.cpp:19:28:19:32 | value | by_reference.cpp:20:5:20:8 | setDirectly output argument [a] | by_reference.cpp:56:3:56:3 | setIndirectly output argument [a] |
+| by_reference.cpp:56:19:56:28 | call to user_input | by_reference.cpp:19:28:19:32 | value | by_reference.cpp:19:8:19:20 | *this [Return] [a] | by_reference.cpp:56:3:56:3 | setIndirectly output argument [a] |
 | by_reference.cpp:57:8:57:8 | *s [a] | by_reference.cpp:39:9:39:21 | *this [a] | by_reference.cpp:39:9:39:21 | *getIndirectly | by_reference.cpp:57:10:57:22 | call to getIndirectly |
-| by_reference.cpp:62:25:62:34 | call to user_input | by_reference.cpp:23:34:23:38 | value | by_reference.cpp:24:19:24:22 | nonMemberSetA output argument [a] | by_reference.cpp:62:3:62:3 | setThroughNonMember output argument [a] |
+| by_reference.cpp:62:25:62:34 | call to user_input | by_reference.cpp:23:34:23:38 | value | by_reference.cpp:23:8:23:26 | *this [Return] [a] | by_reference.cpp:62:3:62:3 | setThroughNonMember output argument [a] |
 | by_reference.cpp:63:8:63:8 | *s [a] | by_reference.cpp:43:9:43:27 | *this [a] | by_reference.cpp:43:9:43:27 | *getThroughNonMember | by_reference.cpp:63:10:63:28 | call to getThroughNonMember |
+| by_reference.cpp:68:21:68:30 | call to user_input | by_reference.cpp:11:48:11:52 | value | by_reference.cpp:11:39:11:39 | *s [Return] [a] | by_reference.cpp:68:17:68:18 | nonMemberSetA output argument [a] |
 | by_reference.cpp:68:21:68:30 | call to user_input | by_reference.cpp:11:48:11:52 | value | by_reference.cpp:11:39:11:39 | *s [a] | by_reference.cpp:68:17:68:18 | nonMemberSetA output argument [a] |
-| by_reference.cpp:68:21:68:30 | call to user_input | by_reference.cpp:11:48:11:52 | value | by_reference.cpp:12:5:12:5 | *s [post update] [a] | by_reference.cpp:68:17:68:18 | nonMemberSetA output argument [a] |
 | by_reference.cpp:69:22:69:23 | *& ... [a] | by_reference.cpp:31:46:31:46 | *s [a] | by_reference.cpp:31:16:31:28 | *nonMemberGetA | by_reference.cpp:69:8:69:20 | call to nonMemberGetA |
 | complex.cpp:42:16:42:16 | *f [a_] | complex.cpp:9:7:9:7 | *this [a_] | complex.cpp:9:7:9:7 | *a | complex.cpp:42:18:42:18 | call to a |
 | complex.cpp:43:16:43:16 | *f [b_] | complex.cpp:10:7:10:7 | *this [b_] | complex.cpp:10:7:10:7 | *b | complex.cpp:43:18:43:18 | call to b |
-| complex.cpp:53:19:53:28 | call to user_input | complex.cpp:11:17:11:17 | a | complex.cpp:11:22:11:23 | *this [post update] [a_] | complex.cpp:53:12:53:12 | setA output argument [a_] |
-| complex.cpp:54:19:54:28 | call to user_input | complex.cpp:12:17:12:17 | b | complex.cpp:12:22:12:23 | *this [post update] [b_] | complex.cpp:54:12:54:12 | setB output argument [b_] |
-| complex.cpp:55:19:55:28 | call to user_input | complex.cpp:11:17:11:17 | a | complex.cpp:11:22:11:23 | *this [post update] [a_] | complex.cpp:55:12:55:12 | setA output argument [a_] |
-| complex.cpp:56:19:56:28 | call to user_input | complex.cpp:12:17:12:17 | b | complex.cpp:12:22:12:23 | *this [post update] [b_] | complex.cpp:56:12:56:12 | setB output argument [b_] |
+| complex.cpp:53:19:53:28 | call to user_input | complex.cpp:11:17:11:17 | a | complex.cpp:11:8:11:11 | *this [Return] [a_] | complex.cpp:53:12:53:12 | setA output argument [a_] |
+| complex.cpp:54:19:54:28 | call to user_input | complex.cpp:12:17:12:17 | b | complex.cpp:12:8:12:11 | *this [Return] [b_] | complex.cpp:54:12:54:12 | setB output argument [b_] |
+| complex.cpp:55:19:55:28 | call to user_input | complex.cpp:11:17:11:17 | a | complex.cpp:11:8:11:11 | *this [Return] [a_] | complex.cpp:55:12:55:12 | setA output argument [a_] |
+| complex.cpp:56:19:56:28 | call to user_input | complex.cpp:12:17:12:17 | b | complex.cpp:12:8:12:11 | *this [Return] [b_] | complex.cpp:56:12:56:12 | setB output argument [b_] |
 | constructors.cpp:28:10:28:10 | *f [a_] | constructors.cpp:18:9:18:9 | *this [a_] | constructors.cpp:18:9:18:9 | *a | constructors.cpp:28:12:28:12 | call to a |
 | constructors.cpp:29:10:29:10 | *f [b_] | constructors.cpp:19:9:19:9 | *this [b_] | constructors.cpp:19:9:19:9 | *b | constructors.cpp:29:12:29:12 | call to b |
-| constructors.cpp:34:11:34:20 | call to user_input | constructors.cpp:23:13:23:13 | a | constructors.cpp:23:5:23:7 | *this [post update] [a_] | constructors.cpp:34:9:34:9 | call to Foo [a_] |
-| constructors.cpp:35:14:35:23 | call to user_input | constructors.cpp:23:20:23:20 | b | constructors.cpp:23:5:23:7 | *this [post update] [b_] | constructors.cpp:35:9:35:9 | call to Foo [b_] |
-| constructors.cpp:36:11:36:20 | call to user_input | constructors.cpp:23:13:23:13 | a | constructors.cpp:23:5:23:7 | *this [post update] [a_] | constructors.cpp:36:9:36:9 | call to Foo [a_] |
-| constructors.cpp:36:25:36:34 | call to user_input | constructors.cpp:23:20:23:20 | b | constructors.cpp:23:5:23:7 | *this [post update] [b_] | constructors.cpp:36:9:36:9 | call to Foo [b_] |
-| qualifiers.cpp:27:28:27:37 | call to user_input | qualifiers.cpp:9:21:9:25 | value | qualifiers.cpp:9:30:9:33 | *this [post update] [a] | qualifiers.cpp:27:11:27:18 | setA output argument [a] |
+| constructors.cpp:34:11:34:20 | call to user_input | constructors.cpp:23:13:23:13 | a | constructors.cpp:23:5:23:7 | *this [Return] [a_] | constructors.cpp:34:9:34:9 | call to Foo [a_] |
+| constructors.cpp:35:14:35:23 | call to user_input | constructors.cpp:23:20:23:20 | b | constructors.cpp:23:5:23:7 | *this [Return] [b_] | constructors.cpp:35:9:35:9 | call to Foo [b_] |
+| constructors.cpp:36:11:36:20 | call to user_input | constructors.cpp:23:13:23:13 | a | constructors.cpp:23:5:23:7 | *this [Return] [a_] | constructors.cpp:36:9:36:9 | call to Foo [a_] |
+| constructors.cpp:36:25:36:34 | call to user_input | constructors.cpp:23:20:23:20 | b | constructors.cpp:23:5:23:7 | *this [Return] [b_] | constructors.cpp:36:9:36:9 | call to Foo [b_] |
+| qualifiers.cpp:27:28:27:37 | call to user_input | qualifiers.cpp:9:21:9:25 | value | qualifiers.cpp:9:10:9:13 | *this [Return] [a] | qualifiers.cpp:27:11:27:18 | setA output argument [a] |
+| qualifiers.cpp:32:35:32:44 | call to user_input | qualifiers.cpp:12:40:12:44 | value | qualifiers.cpp:12:27:12:31 | *inner [Return] [a] | qualifiers.cpp:32:23:32:30 | pointerSetA output argument [a] |
 | qualifiers.cpp:32:35:32:44 | call to user_input | qualifiers.cpp:12:40:12:44 | value | qualifiers.cpp:12:27:12:31 | *inner [a] | qualifiers.cpp:32:23:32:30 | pointerSetA output argument [a] |
-| qualifiers.cpp:32:35:32:44 | call to user_input | qualifiers.cpp:12:40:12:44 | value | qualifiers.cpp:12:49:12:53 | *inner [post update] [a] | qualifiers.cpp:32:23:32:30 | pointerSetA output argument [a] |
+| qualifiers.cpp:37:38:37:47 | call to user_input | qualifiers.cpp:13:42:13:46 | value | qualifiers.cpp:13:29:13:33 | *inner [Return] [a] | qualifiers.cpp:37:19:37:35 | referenceSetA output argument [a] |
 | qualifiers.cpp:37:38:37:47 | call to user_input | qualifiers.cpp:13:42:13:46 | value | qualifiers.cpp:13:29:13:33 | *inner [a] | qualifiers.cpp:37:19:37:35 | referenceSetA output argument [a] |
-| qualifiers.cpp:37:38:37:47 | call to user_input | qualifiers.cpp:13:42:13:46 | value | qualifiers.cpp:13:51:13:55 | *inner [post update] [a] | qualifiers.cpp:37:19:37:35 | referenceSetA output argument [a] |
 | simple.cpp:28:10:28:10 | *f [a_] | simple.cpp:18:9:18:9 | *this [a_] | simple.cpp:18:9:18:9 | *a | simple.cpp:28:12:28:12 | call to a |
 | simple.cpp:29:10:29:10 | *f [b_] | simple.cpp:19:9:19:9 | *this [b_] | simple.cpp:19:9:19:9 | *b | simple.cpp:29:12:29:12 | call to b |
-| simple.cpp:39:12:39:21 | call to user_input | simple.cpp:20:19:20:19 | a | simple.cpp:20:24:20:25 | *this [post update] [a_] | simple.cpp:39:5:39:5 | setA output argument [a_] |
-| simple.cpp:40:12:40:21 | call to user_input | simple.cpp:21:19:21:19 | b | simple.cpp:21:24:21:25 | *this [post update] [b_] | simple.cpp:40:5:40:5 | setB output argument [b_] |
-| simple.cpp:41:12:41:21 | call to user_input | simple.cpp:20:19:20:19 | a | simple.cpp:20:24:20:25 | *this [post update] [a_] | simple.cpp:41:5:41:5 | setA output argument [a_] |
-| simple.cpp:42:12:42:21 | call to user_input | simple.cpp:21:19:21:19 | b | simple.cpp:21:24:21:25 | *this [post update] [b_] | simple.cpp:42:5:42:5 | setB output argument [b_] |
+| simple.cpp:39:12:39:21 | call to user_input | simple.cpp:20:19:20:19 | a | simple.cpp:20:10:20:13 | *this [Return] [a_] | simple.cpp:39:5:39:5 | setA output argument [a_] |
+| simple.cpp:40:12:40:21 | call to user_input | simple.cpp:21:19:21:19 | b | simple.cpp:21:10:21:13 | *this [Return] [b_] | simple.cpp:40:5:40:5 | setB output argument [b_] |
+| simple.cpp:41:12:41:21 | call to user_input | simple.cpp:20:19:20:19 | a | simple.cpp:20:10:20:13 | *this [Return] [a_] | simple.cpp:41:5:41:5 | setA output argument [a_] |
+| simple.cpp:42:12:42:21 | call to user_input | simple.cpp:21:19:21:19 | b | simple.cpp:21:10:21:13 | *this [Return] [b_] | simple.cpp:42:5:42:5 | setB output argument [b_] |
 | simple.cpp:84:14:84:20 | *this [f2, f1] | simple.cpp:78:9:78:15 | *this [f2, f1] | simple.cpp:78:9:78:15 | *getf2f1 | simple.cpp:84:14:84:20 | call to getf2f1 |
 | struct_init.c:24:10:24:12 | *& ... [a] | struct_init.c:14:24:14:25 | *ab [a] | struct_init.c:14:24:14:25 | *ab [a] | struct_init.c:24:10:24:12 | absink output argument [a] |
 #select

--- a/cpp/ql/test/library-tests/dataflow/fields/path-flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/path-flow.expected
@@ -1,7 +1,9 @@
 edges
 | A.cpp:23:10:23:10 | c | A.cpp:25:7:25:17 | ... = ... | provenance |  |
+| A.cpp:25:7:25:10 | this [post update] [c] | A.cpp:23:5:23:5 | this [Return] [c] | provenance |  |
 | A.cpp:25:7:25:17 | ... = ... | A.cpp:25:7:25:10 | this [post update] [c] | provenance |  |
 | A.cpp:27:17:27:17 | c | A.cpp:27:22:27:32 | ... = ... | provenance |  |
+| A.cpp:27:22:27:25 | this [post update] [c] | A.cpp:27:10:27:12 | this [Return] [c] | provenance |  |
 | A.cpp:27:22:27:32 | ... = ... | A.cpp:27:22:27:25 | this [post update] [c] | provenance |  |
 | A.cpp:28:8:28:10 | this [c] | A.cpp:28:23:28:26 | this [c] | provenance |  |
 | A.cpp:28:23:28:26 | this [c] | A.cpp:28:29:28:29 | c | provenance |  |
@@ -51,22 +53,27 @@ edges
 | A.cpp:103:14:103:14 | c [a] | A.cpp:120:12:120:13 | c1 [a] | provenance |  |
 | A.cpp:107:12:107:13 | c1 [a] | A.cpp:107:16:107:16 | a | provenance |  |
 | A.cpp:120:12:120:13 | c1 [a] | A.cpp:120:16:120:16 | a | provenance |  |
+| A.cpp:124:14:124:14 | b [Return] [c] | A.cpp:131:8:131:8 | ref arg b [c] | provenance |  |
 | A.cpp:124:14:124:14 | b [c] | A.cpp:131:8:131:8 | ref arg b [c] | provenance |  |
+| A.cpp:126:5:126:5 | ref arg b [c] | A.cpp:124:14:124:14 | b [Return] [c] | provenance |  |
 | A.cpp:126:5:126:5 | ref arg b [c] | A.cpp:124:14:124:14 | b [c] | provenance |  |
-| A.cpp:126:5:126:5 | ref arg b [c] | A.cpp:131:8:131:8 | ref arg b [c] | provenance |  |
 | A.cpp:126:12:126:18 | new | A.cpp:27:17:27:17 | c | provenance |  |
 | A.cpp:126:12:126:18 | new | A.cpp:126:5:126:5 | ref arg b [c] | provenance |  |
 | A.cpp:131:8:131:8 | ref arg b [c] | A.cpp:132:10:132:10 | b [c] | provenance |  |
 | A.cpp:132:10:132:10 | b [c] | A.cpp:132:13:132:13 | c | provenance |  |
+| A.cpp:140:5:140:5 | this [Return] [b, c] | A.cpp:151:12:151:24 | call to D [b, c] | provenance |  |
+| A.cpp:140:5:140:5 | this [Return] [b] | A.cpp:151:12:151:24 | call to D [b] | provenance |  |
 | A.cpp:140:13:140:13 | b | A.cpp:143:7:143:31 | ... = ... | provenance |  |
+| A.cpp:140:13:140:13 | b [Return] [c] | A.cpp:151:18:151:18 | ref arg b [c] | provenance |  |
 | A.cpp:140:13:140:13 | b [c] | A.cpp:151:18:151:18 | ref arg b [c] | provenance |  |
+| A.cpp:142:7:142:7 | b [post update] [c] | A.cpp:140:13:140:13 | b [Return] [c] | provenance |  |
 | A.cpp:142:7:142:7 | b [post update] [c] | A.cpp:140:13:140:13 | b [c] | provenance |  |
 | A.cpp:142:7:142:7 | b [post update] [c] | A.cpp:143:7:143:31 | ... = ... [c] | provenance |  |
-| A.cpp:142:7:142:7 | b [post update] [c] | A.cpp:151:18:151:18 | ref arg b [c] | provenance |  |
 | A.cpp:142:7:142:20 | ... = ... | A.cpp:142:7:142:7 | b [post update] [c] | provenance |  |
 | A.cpp:142:14:142:20 | new | A.cpp:142:7:142:20 | ... = ... | provenance |  |
-| A.cpp:143:7:143:10 | this [post update] [b, c] | A.cpp:151:12:151:24 | call to D [b, c] | provenance |  |
-| A.cpp:143:7:143:10 | this [post update] [b] | A.cpp:151:12:151:24 | call to D [b] | provenance |  |
+| A.cpp:143:7:143:10 | this [post update] [b, c] | A.cpp:140:5:140:5 | this [Return] [b, c] | provenance |  |
+| A.cpp:143:7:143:10 | this [post update] [b] | A.cpp:140:5:140:5 | this [Return] [b] | provenance |  |
+| A.cpp:143:7:143:10 | this [post update] [b] | A.cpp:140:5:140:5 | this [Return] [b] | provenance |  |
 | A.cpp:143:7:143:31 | ... = ... | A.cpp:143:7:143:10 | this [post update] [b] | provenance |  |
 | A.cpp:143:7:143:31 | ... = ... | A.cpp:143:7:143:10 | this [post update] [b] | provenance |  |
 | A.cpp:143:7:143:31 | ... = ... [c] | A.cpp:143:7:143:10 | this [post update] [b, c] | provenance |  |
@@ -118,7 +125,10 @@ edges
 | A.cpp:181:15:181:21 | newHead | A.cpp:183:7:183:20 | ... = ... | provenance |  |
 | A.cpp:181:32:181:35 | next [head] | A.cpp:184:7:184:23 | ... = ... [head] | provenance |  |
 | A.cpp:181:32:181:35 | next [next, head] | A.cpp:184:7:184:23 | ... = ... [next, head] | provenance |  |
+| A.cpp:183:7:183:10 | this [post update] [head] | A.cpp:181:5:181:10 | this [Return] [head] | provenance |  |
 | A.cpp:183:7:183:20 | ... = ... | A.cpp:183:7:183:10 | this [post update] [head] | provenance |  |
+| A.cpp:184:7:184:10 | this [post update] [next, head] | A.cpp:181:5:181:10 | this [Return] [next, head] | provenance |  |
+| A.cpp:184:7:184:10 | this [post update] [next, next, head] | A.cpp:181:5:181:10 | this [Return] [next, next, head] | provenance |  |
 | A.cpp:184:7:184:23 | ... = ... [head] | A.cpp:184:7:184:10 | this [post update] [next, head] | provenance |  |
 | A.cpp:184:7:184:23 | ... = ... [next, head] | A.cpp:184:7:184:10 | this [post update] [next, next, head] | provenance |  |
 | B.cpp:6:15:6:24 | new | B.cpp:7:25:7:25 | e | provenance |  |
@@ -141,19 +151,25 @@ edges
 | B.cpp:19:14:19:17 | box1 [elem2] | B.cpp:19:20:19:24 | elem2 | provenance |  |
 | B.cpp:33:16:33:17 | e1 | B.cpp:35:7:35:22 | ... = ... | provenance |  |
 | B.cpp:33:26:33:27 | e2 | B.cpp:36:7:36:22 | ... = ... | provenance |  |
+| B.cpp:35:7:35:10 | this [post update] [elem1] | B.cpp:33:5:33:8 | this [Return] [elem1] | provenance |  |
 | B.cpp:35:7:35:22 | ... = ... | B.cpp:35:7:35:10 | this [post update] [elem1] | provenance |  |
+| B.cpp:36:7:36:10 | this [post update] [elem2] | B.cpp:33:5:33:8 | this [Return] [elem2] | provenance |  |
 | B.cpp:36:7:36:22 | ... = ... | B.cpp:36:7:36:10 | this [post update] [elem2] | provenance |  |
 | B.cpp:44:16:44:17 | b1 [elem1] | B.cpp:46:7:46:21 | ... = ... [elem1] | provenance |  |
 | B.cpp:44:16:44:17 | b1 [elem2] | B.cpp:46:7:46:21 | ... = ... [elem2] | provenance |  |
+| B.cpp:46:7:46:10 | this [post update] [box1, elem1] | B.cpp:44:5:44:8 | this [Return] [box1, elem1] | provenance |  |
+| B.cpp:46:7:46:10 | this [post update] [box1, elem2] | B.cpp:44:5:44:8 | this [Return] [box1, elem2] | provenance |  |
 | B.cpp:46:7:46:21 | ... = ... [elem1] | B.cpp:46:7:46:10 | this [post update] [box1, elem1] | provenance |  |
 | B.cpp:46:7:46:21 | ... = ... [elem2] | B.cpp:46:7:46:10 | this [post update] [box1, elem2] | provenance |  |
 | C.cpp:18:12:18:18 | call to C [s1] | C.cpp:19:5:19:5 | c [s1] | provenance |  |
 | C.cpp:18:12:18:18 | call to C [s3] | C.cpp:19:5:19:5 | c [s3] | provenance |  |
 | C.cpp:19:5:19:5 | c [s1] | C.cpp:27:8:27:11 | this [s1] | provenance |  |
 | C.cpp:19:5:19:5 | c [s3] | C.cpp:27:8:27:11 | this [s3] | provenance |  |
-| C.cpp:22:9:22:22 | constructor init of field s1 [post-this] [s1] | C.cpp:18:12:18:18 | call to C [s1] | provenance |  |
+| C.cpp:22:3:22:3 | this [Return] [s1] | C.cpp:18:12:18:18 | call to C [s1] | provenance |  |
+| C.cpp:22:3:22:3 | this [Return] [s3] | C.cpp:18:12:18:18 | call to C [s3] | provenance |  |
+| C.cpp:22:9:22:22 | constructor init of field s1 [post-this] [s1] | C.cpp:22:3:22:3 | this [Return] [s1] | provenance |  |
 | C.cpp:22:12:22:21 | new | C.cpp:22:9:22:22 | constructor init of field s1 [post-this] [s1] | provenance |  |
-| C.cpp:24:5:24:8 | this [post update] [s3] | C.cpp:18:12:18:18 | call to C [s3] | provenance |  |
+| C.cpp:24:5:24:8 | this [post update] [s3] | C.cpp:22:3:22:3 | this [Return] [s3] | provenance |  |
 | C.cpp:24:5:24:25 | ... = ... | C.cpp:24:5:24:8 | this [post update] [s3] | provenance |  |
 | C.cpp:24:16:24:25 | new | C.cpp:24:5:24:25 | ... = ... | provenance |  |
 | C.cpp:27:8:27:11 | this [s1] | C.cpp:29:10:29:11 | this [s1] | provenance |  |
@@ -163,6 +179,7 @@ edges
 | D.cpp:10:11:10:17 | this [elem] | D.cpp:10:30:10:33 | this [elem] | provenance |  |
 | D.cpp:10:30:10:33 | this [elem] | D.cpp:10:30:10:33 | elem | provenance |  |
 | D.cpp:11:24:11:24 | e | D.cpp:11:29:11:36 | ... = ... | provenance |  |
+| D.cpp:11:29:11:32 | this [post update] [elem] | D.cpp:11:10:11:16 | this [Return] [elem] | provenance |  |
 | D.cpp:11:29:11:36 | ... = ... | D.cpp:11:29:11:32 | this [post update] [elem] | provenance |  |
 | D.cpp:17:11:17:17 | this [box, elem] | D.cpp:17:30:17:32 | this [box, elem] | provenance |  |
 | D.cpp:17:30:17:32 | this [box, elem] | D.cpp:17:30:17:32 | box [elem] | provenance |  |
@@ -215,14 +232,16 @@ edges
 | E.cpp:32:10:32:10 | b [buffer] | E.cpp:32:13:32:18 | buffer | provenance |  |
 | E.cpp:33:18:33:19 | & ... [data, buffer] | E.cpp:19:27:19:27 | p [data, buffer] | provenance |  |
 | E.cpp:33:19:33:19 | p [data, buffer] | E.cpp:33:18:33:19 | & ... [data, buffer] | provenance |  |
+| aliasing.cpp:8:23:8:23 | s [Return] [m1] | aliasing.cpp:25:17:25:19 | ref arg & ... [m1] | provenance |  |
 | aliasing.cpp:8:23:8:23 | s [m1] | aliasing.cpp:25:17:25:19 | ref arg & ... [m1] | provenance |  |
+| aliasing.cpp:9:3:9:3 | s [post update] [m1] | aliasing.cpp:8:23:8:23 | s [Return] [m1] | provenance |  |
 | aliasing.cpp:9:3:9:3 | s [post update] [m1] | aliasing.cpp:8:23:8:23 | s [m1] | provenance |  |
-| aliasing.cpp:9:3:9:3 | s [post update] [m1] | aliasing.cpp:25:17:25:19 | ref arg & ... [m1] | provenance |  |
 | aliasing.cpp:9:3:9:22 | ... = ... | aliasing.cpp:9:3:9:3 | s [post update] [m1] | provenance |  |
 | aliasing.cpp:9:11:9:20 | call to user_input | aliasing.cpp:9:3:9:22 | ... = ... | provenance |  |
+| aliasing.cpp:12:25:12:25 | s [Return] [m1] | aliasing.cpp:26:19:26:20 | ref arg s2 [m1] | provenance |  |
 | aliasing.cpp:12:25:12:25 | s [m1] | aliasing.cpp:26:19:26:20 | ref arg s2 [m1] | provenance |  |
+| aliasing.cpp:13:3:13:3 | s [post update] [m1] | aliasing.cpp:12:25:12:25 | s [Return] [m1] | provenance |  |
 | aliasing.cpp:13:3:13:3 | s [post update] [m1] | aliasing.cpp:12:25:12:25 | s [m1] | provenance |  |
-| aliasing.cpp:13:3:13:3 | s [post update] [m1] | aliasing.cpp:26:19:26:20 | ref arg s2 [m1] | provenance |  |
 | aliasing.cpp:13:3:13:21 | ... = ... | aliasing.cpp:13:3:13:3 | s [post update] [m1] | provenance |  |
 | aliasing.cpp:13:10:13:19 | call to user_input | aliasing.cpp:13:3:13:21 | ... = ... | provenance |  |
 | aliasing.cpp:25:17:25:19 | ref arg & ... [m1] | aliasing.cpp:29:8:29:9 | s1 [m1] | provenance |  |
@@ -244,13 +263,13 @@ edges
 | aliasing.cpp:105:23:105:24 | pa | aliasing.cpp:175:15:175:22 | ref arg & ... | provenance |  |
 | aliasing.cpp:105:23:105:24 | pa | aliasing.cpp:187:15:187:22 | ref arg & ... | provenance |  |
 | aliasing.cpp:105:23:105:24 | pa | aliasing.cpp:200:15:200:24 | ref arg & ... | provenance |  |
-| aliasing.cpp:106:4:106:5 | pa [inner post update] | aliasing.cpp:158:17:158:20 | ref arg data | provenance |  |
-| aliasing.cpp:106:4:106:5 | pa [inner post update] | aliasing.cpp:164:17:164:20 | ref arg data | provenance |  |
-| aliasing.cpp:106:4:106:5 | pa [inner post update] | aliasing.cpp:175:15:175:22 | ref arg & ... | provenance |  |
-| aliasing.cpp:106:4:106:5 | pa [inner post update] | aliasing.cpp:187:15:187:22 | ref arg & ... | provenance |  |
-| aliasing.cpp:106:4:106:5 | pa [inner post update] | aliasing.cpp:200:15:200:24 | ref arg & ... | provenance |  |
+| aliasing.cpp:105:23:105:24 | pa [Return] | aliasing.cpp:158:17:158:20 | ref arg data | provenance |  |
+| aliasing.cpp:105:23:105:24 | pa [Return] | aliasing.cpp:164:17:164:20 | ref arg data | provenance |  |
+| aliasing.cpp:105:23:105:24 | pa [Return] | aliasing.cpp:175:15:175:22 | ref arg & ... | provenance |  |
+| aliasing.cpp:105:23:105:24 | pa [Return] | aliasing.cpp:187:15:187:22 | ref arg & ... | provenance |  |
+| aliasing.cpp:105:23:105:24 | pa [Return] | aliasing.cpp:200:15:200:24 | ref arg & ... | provenance |  |
 | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:105:23:105:24 | pa | provenance |  |
-| aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:106:4:106:5 | pa [inner post update] | provenance |  |
+| aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:105:23:105:24 | pa [Return] | provenance |  |
 | aliasing.cpp:158:15:158:15 | s [post update] [data] | aliasing.cpp:159:9:159:9 | s [data] | provenance |  |
 | aliasing.cpp:158:17:158:20 | ref arg data | aliasing.cpp:158:15:158:15 | s [post update] [data] | provenance |  |
 | aliasing.cpp:159:9:159:9 | s [data] | aliasing.cpp:159:11:159:14 | data | provenance |  |
@@ -330,14 +349,18 @@ edges
 | arrays.cpp:44:10:44:17 | indirect [arr, data] | arrays.cpp:44:20:44:22 | arr [data] | provenance |  |
 | arrays.cpp:44:20:44:22 | arr [data] | arrays.cpp:44:8:44:25 | access to array [data] | provenance |  |
 | by_reference.cpp:11:48:11:52 | value | by_reference.cpp:12:5:12:16 | ... = ... | provenance |  |
+| by_reference.cpp:12:5:12:5 | s [post update] [a] | by_reference.cpp:11:39:11:39 | s [Return] [a] | provenance |  |
 | by_reference.cpp:12:5:12:5 | s [post update] [a] | by_reference.cpp:11:39:11:39 | s [a] | provenance |  |
 | by_reference.cpp:12:5:12:16 | ... = ... | by_reference.cpp:12:5:12:5 | s [post update] [a] | provenance |  |
 | by_reference.cpp:15:26:15:30 | value | by_reference.cpp:16:5:16:19 | ... = ... | provenance |  |
+| by_reference.cpp:16:5:16:8 | this [post update] [a] | by_reference.cpp:15:8:15:18 | this [Return] [a] | provenance |  |
 | by_reference.cpp:16:5:16:19 | ... = ... | by_reference.cpp:16:5:16:8 | this [post update] [a] | provenance |  |
 | by_reference.cpp:19:28:19:32 | value | by_reference.cpp:20:23:20:27 | value | provenance |  |
+| by_reference.cpp:20:5:20:8 | ref arg this [a] | by_reference.cpp:19:8:19:20 | this [Return] [a] | provenance |  |
 | by_reference.cpp:20:23:20:27 | value | by_reference.cpp:15:26:15:30 | value | provenance |  |
 | by_reference.cpp:20:23:20:27 | value | by_reference.cpp:20:5:20:8 | ref arg this [a] | provenance |  |
 | by_reference.cpp:23:34:23:38 | value | by_reference.cpp:24:25:24:29 | value | provenance |  |
+| by_reference.cpp:24:19:24:22 | ref arg this [a] | by_reference.cpp:23:8:23:26 | this [Return] [a] | provenance |  |
 | by_reference.cpp:24:25:24:29 | value | by_reference.cpp:11:48:11:52 | value | provenance |  |
 | by_reference.cpp:24:25:24:29 | value | by_reference.cpp:24:19:24:22 | ref arg this [a] | provenance |  |
 | by_reference.cpp:31:46:31:46 | s [a] | by_reference.cpp:32:12:32:12 | s [a] | provenance |  |
@@ -371,34 +394,36 @@ edges
 | by_reference.cpp:69:22:69:23 | & ... [a] | by_reference.cpp:31:46:31:46 | s [a] | provenance |  |
 | by_reference.cpp:69:22:69:23 | & ... [a] | by_reference.cpp:69:8:69:20 | call to nonMemberGetA | provenance |  |
 | by_reference.cpp:69:23:69:23 | s [a] | by_reference.cpp:69:22:69:23 | & ... [a] | provenance |  |
+| by_reference.cpp:83:31:83:35 | inner [Return] [a] | by_reference.cpp:102:21:102:39 | ref arg & ... [a] | provenance |  |
+| by_reference.cpp:83:31:83:35 | inner [Return] [a] | by_reference.cpp:103:27:103:35 | ref arg inner_ptr [a] | provenance |  |
+| by_reference.cpp:83:31:83:35 | inner [Return] [a] | by_reference.cpp:106:21:106:41 | ref arg & ... [a] | provenance |  |
+| by_reference.cpp:83:31:83:35 | inner [Return] [a] | by_reference.cpp:107:29:107:37 | ref arg inner_ptr [a] | provenance |  |
 | by_reference.cpp:83:31:83:35 | inner [a] | by_reference.cpp:102:21:102:39 | ref arg & ... [a] | provenance |  |
 | by_reference.cpp:83:31:83:35 | inner [a] | by_reference.cpp:103:27:103:35 | ref arg inner_ptr [a] | provenance |  |
 | by_reference.cpp:83:31:83:35 | inner [a] | by_reference.cpp:106:21:106:41 | ref arg & ... [a] | provenance |  |
 | by_reference.cpp:83:31:83:35 | inner [a] | by_reference.cpp:107:29:107:37 | ref arg inner_ptr [a] | provenance |  |
+| by_reference.cpp:84:3:84:7 | inner [post update] [a] | by_reference.cpp:83:31:83:35 | inner [Return] [a] | provenance |  |
 | by_reference.cpp:84:3:84:7 | inner [post update] [a] | by_reference.cpp:83:31:83:35 | inner [a] | provenance |  |
-| by_reference.cpp:84:3:84:7 | inner [post update] [a] | by_reference.cpp:102:21:102:39 | ref arg & ... [a] | provenance |  |
-| by_reference.cpp:84:3:84:7 | inner [post update] [a] | by_reference.cpp:103:27:103:35 | ref arg inner_ptr [a] | provenance |  |
-| by_reference.cpp:84:3:84:7 | inner [post update] [a] | by_reference.cpp:106:21:106:41 | ref arg & ... [a] | provenance |  |
-| by_reference.cpp:84:3:84:7 | inner [post update] [a] | by_reference.cpp:107:29:107:37 | ref arg inner_ptr [a] | provenance |  |
 | by_reference.cpp:84:3:84:25 | ... = ... | by_reference.cpp:84:3:84:7 | inner [post update] [a] | provenance |  |
 | by_reference.cpp:84:14:84:23 | call to user_input | by_reference.cpp:84:3:84:25 | ... = ... | provenance |  |
+| by_reference.cpp:87:31:87:35 | inner [Return] [a] | by_reference.cpp:122:27:122:38 | ref arg inner_nested [a] | provenance |  |
+| by_reference.cpp:87:31:87:35 | inner [Return] [a] | by_reference.cpp:123:21:123:36 | ref arg * ... [a] | provenance |  |
+| by_reference.cpp:87:31:87:35 | inner [Return] [a] | by_reference.cpp:126:29:126:40 | ref arg inner_nested [a] | provenance |  |
+| by_reference.cpp:87:31:87:35 | inner [Return] [a] | by_reference.cpp:127:21:127:38 | ref arg * ... [a] | provenance |  |
 | by_reference.cpp:87:31:87:35 | inner [a] | by_reference.cpp:122:27:122:38 | ref arg inner_nested [a] | provenance |  |
 | by_reference.cpp:87:31:87:35 | inner [a] | by_reference.cpp:123:21:123:36 | ref arg * ... [a] | provenance |  |
 | by_reference.cpp:87:31:87:35 | inner [a] | by_reference.cpp:126:29:126:40 | ref arg inner_nested [a] | provenance |  |
 | by_reference.cpp:87:31:87:35 | inner [a] | by_reference.cpp:127:21:127:38 | ref arg * ... [a] | provenance |  |
+| by_reference.cpp:88:3:88:7 | inner [post update] [a] | by_reference.cpp:87:31:87:35 | inner [Return] [a] | provenance |  |
 | by_reference.cpp:88:3:88:7 | inner [post update] [a] | by_reference.cpp:87:31:87:35 | inner [a] | provenance |  |
-| by_reference.cpp:88:3:88:7 | inner [post update] [a] | by_reference.cpp:122:27:122:38 | ref arg inner_nested [a] | provenance |  |
-| by_reference.cpp:88:3:88:7 | inner [post update] [a] | by_reference.cpp:123:21:123:36 | ref arg * ... [a] | provenance |  |
-| by_reference.cpp:88:3:88:7 | inner [post update] [a] | by_reference.cpp:126:29:126:40 | ref arg inner_nested [a] | provenance |  |
-| by_reference.cpp:88:3:88:7 | inner [post update] [a] | by_reference.cpp:127:21:127:38 | ref arg * ... [a] | provenance |  |
 | by_reference.cpp:88:3:88:24 | ... = ... | by_reference.cpp:88:3:88:7 | inner [post update] [a] | provenance |  |
 | by_reference.cpp:88:13:88:22 | call to user_input | by_reference.cpp:88:3:88:24 | ... = ... | provenance |  |
 | by_reference.cpp:91:25:91:26 | pa | by_reference.cpp:104:15:104:22 | ref arg & ... | provenance |  |
 | by_reference.cpp:91:25:91:26 | pa | by_reference.cpp:108:15:108:24 | ref arg & ... | provenance |  |
-| by_reference.cpp:92:4:92:5 | pa [inner post update] | by_reference.cpp:104:15:104:22 | ref arg & ... | provenance |  |
-| by_reference.cpp:92:4:92:5 | pa [inner post update] | by_reference.cpp:108:15:108:24 | ref arg & ... | provenance |  |
+| by_reference.cpp:91:25:91:26 | pa [Return] | by_reference.cpp:104:15:104:22 | ref arg & ... | provenance |  |
+| by_reference.cpp:91:25:91:26 | pa [Return] | by_reference.cpp:108:15:108:24 | ref arg & ... | provenance |  |
 | by_reference.cpp:92:9:92:18 | call to user_input | by_reference.cpp:91:25:91:26 | pa | provenance |  |
-| by_reference.cpp:92:9:92:18 | call to user_input | by_reference.cpp:92:4:92:5 | pa [inner post update] | provenance |  |
+| by_reference.cpp:92:9:92:18 | call to user_input | by_reference.cpp:91:25:91:26 | pa [Return] | provenance |  |
 | by_reference.cpp:95:25:95:26 | pa | by_reference.cpp:124:21:124:21 | ref arg a | provenance |  |
 | by_reference.cpp:95:25:95:26 | pa | by_reference.cpp:128:23:128:23 | ref arg a | provenance |  |
 | by_reference.cpp:96:8:96:17 | call to user_input | by_reference.cpp:95:25:95:26 | pa | provenance |  |
@@ -493,8 +518,10 @@ edges
 | complex.cpp:10:7:10:7 | this [b_] | complex.cpp:10:20:10:21 | this [b_] | provenance |  |
 | complex.cpp:10:20:10:21 | this [b_] | complex.cpp:10:20:10:21 | b_ | provenance |  |
 | complex.cpp:11:17:11:17 | a | complex.cpp:11:22:11:27 | ... = ... | provenance |  |
+| complex.cpp:11:22:11:23 | this [post update] [a_] | complex.cpp:11:8:11:11 | this [Return] [a_] | provenance |  |
 | complex.cpp:11:22:11:27 | ... = ... | complex.cpp:11:22:11:23 | this [post update] [a_] | provenance |  |
 | complex.cpp:12:17:12:17 | b | complex.cpp:12:22:12:27 | ... = ... | provenance |  |
+| complex.cpp:12:22:12:23 | this [post update] [b_] | complex.cpp:12:8:12:11 | this [Return] [b_] | provenance |  |
 | complex.cpp:12:22:12:27 | ... = ... | complex.cpp:12:22:12:23 | this [post update] [b_] | provenance |  |
 | complex.cpp:40:17:40:17 | b [inner, f, a_] | complex.cpp:42:8:42:8 | b [inner, f, a_] | provenance |  |
 | complex.cpp:40:17:40:17 | b [inner, f, b_] | complex.cpp:43:8:43:8 | b [inner, f, b_] | provenance |  |
@@ -557,7 +584,9 @@ edges
 | constructors.cpp:19:22:19:23 | this [b_] | constructors.cpp:19:22:19:23 | b_ | provenance |  |
 | constructors.cpp:23:13:23:13 | a | constructors.cpp:23:28:23:28 | a | provenance |  |
 | constructors.cpp:23:20:23:20 | b | constructors.cpp:23:35:23:35 | b | provenance |  |
+| constructors.cpp:23:25:23:29 | constructor init of field a_ [post-this] [a_] | constructors.cpp:23:5:23:7 | this [Return] [a_] | provenance |  |
 | constructors.cpp:23:28:23:28 | a | constructors.cpp:23:25:23:29 | constructor init of field a_ [post-this] [a_] | provenance |  |
+| constructors.cpp:23:32:23:36 | constructor init of field b_ [post-this] [b_] | constructors.cpp:23:5:23:7 | this [Return] [b_] | provenance |  |
 | constructors.cpp:23:35:23:35 | b | constructors.cpp:23:32:23:36 | constructor init of field b_ [post-this] [b_] | provenance |  |
 | constructors.cpp:26:15:26:15 | f [a_] | constructors.cpp:28:10:28:10 | f [a_] | provenance |  |
 | constructors.cpp:26:15:26:15 | f [b_] | constructors.cpp:29:10:29:10 | f [b_] | provenance |  |
@@ -582,11 +611,14 @@ edges
 | constructors.cpp:46:9:46:9 | h [a_] | constructors.cpp:26:15:26:15 | f [a_] | provenance |  |
 | constructors.cpp:46:9:46:9 | h [b_] | constructors.cpp:26:15:26:15 | f [b_] | provenance |  |
 | qualifiers.cpp:9:21:9:25 | value | qualifiers.cpp:9:30:9:44 | ... = ... | provenance |  |
+| qualifiers.cpp:9:30:9:33 | this [post update] [a] | qualifiers.cpp:9:10:9:13 | this [Return] [a] | provenance |  |
 | qualifiers.cpp:9:30:9:44 | ... = ... | qualifiers.cpp:9:30:9:33 | this [post update] [a] | provenance |  |
 | qualifiers.cpp:12:40:12:44 | value | qualifiers.cpp:12:49:12:64 | ... = ... | provenance |  |
+| qualifiers.cpp:12:49:12:53 | inner [post update] [a] | qualifiers.cpp:12:27:12:31 | inner [Return] [a] | provenance |  |
 | qualifiers.cpp:12:49:12:53 | inner [post update] [a] | qualifiers.cpp:12:27:12:31 | inner [a] | provenance |  |
 | qualifiers.cpp:12:49:12:64 | ... = ... | qualifiers.cpp:12:49:12:53 | inner [post update] [a] | provenance |  |
 | qualifiers.cpp:13:42:13:46 | value | qualifiers.cpp:13:51:13:65 | ... = ... | provenance |  |
+| qualifiers.cpp:13:51:13:55 | inner [post update] [a] | qualifiers.cpp:13:29:13:33 | inner [Return] [a] | provenance |  |
 | qualifiers.cpp:13:51:13:55 | inner [post update] [a] | qualifiers.cpp:13:29:13:33 | inner [a] | provenance |  |
 | qualifiers.cpp:13:51:13:65 | ... = ... | qualifiers.cpp:13:51:13:55 | inner [post update] [a] | provenance |  |
 | qualifiers.cpp:22:5:22:9 | ref arg outer [inner, a] | qualifiers.cpp:23:10:23:14 | outer [inner, a] | provenance |  |
@@ -654,8 +686,10 @@ edges
 | simple.cpp:19:9:19:9 | this [b_] | simple.cpp:19:22:19:23 | this [b_] | provenance |  |
 | simple.cpp:19:22:19:23 | this [b_] | simple.cpp:19:22:19:23 | b_ | provenance |  |
 | simple.cpp:20:19:20:19 | a | simple.cpp:20:24:20:29 | ... = ... | provenance |  |
+| simple.cpp:20:24:20:25 | this [post update] [a_] | simple.cpp:20:10:20:13 | this [Return] [a_] | provenance |  |
 | simple.cpp:20:24:20:29 | ... = ... | simple.cpp:20:24:20:25 | this [post update] [a_] | provenance |  |
 | simple.cpp:21:19:21:19 | b | simple.cpp:21:24:21:29 | ... = ... | provenance |  |
+| simple.cpp:21:24:21:25 | this [post update] [b_] | simple.cpp:21:10:21:13 | this [Return] [b_] | provenance |  |
 | simple.cpp:21:24:21:29 | ... = ... | simple.cpp:21:24:21:25 | this [post update] [b_] | provenance |  |
 | simple.cpp:26:15:26:15 | f [a_] | simple.cpp:28:10:28:10 | f [a_] | provenance |  |
 | simple.cpp:26:15:26:15 | f [b_] | simple.cpp:29:10:29:10 | f [b_] | provenance |  |
@@ -747,9 +781,11 @@ edges
 | struct_init.c:46:10:46:14 | outer [pointerAB, a] | struct_init.c:46:16:46:24 | pointerAB [a] | provenance |  |
 | struct_init.c:46:16:46:24 | pointerAB [a] | struct_init.c:14:24:14:25 | ab [a] | provenance |  |
 nodes
+| A.cpp:23:5:23:5 | this [Return] [c] | semmle.label | this [Return] [c] |
 | A.cpp:23:10:23:10 | c | semmle.label | c |
 | A.cpp:25:7:25:10 | this [post update] [c] | semmle.label | this [post update] [c] |
 | A.cpp:25:7:25:17 | ... = ... | semmle.label | ... = ... |
+| A.cpp:27:10:27:12 | this [Return] [c] | semmle.label | this [Return] [c] |
 | A.cpp:27:17:27:17 | c | semmle.label | c |
 | A.cpp:27:22:27:25 | this [post update] [c] | semmle.label | this [post update] [c] |
 | A.cpp:27:22:27:32 | ... = ... | semmle.label | ... = ... |
@@ -802,13 +838,18 @@ nodes
 | A.cpp:107:16:107:16 | a | semmle.label | a |
 | A.cpp:120:12:120:13 | c1 [a] | semmle.label | c1 [a] |
 | A.cpp:120:16:120:16 | a | semmle.label | a |
+| A.cpp:124:14:124:14 | b [Return] [c] | semmle.label | b [Return] [c] |
 | A.cpp:124:14:124:14 | b [c] | semmle.label | b [c] |
 | A.cpp:126:5:126:5 | ref arg b [c] | semmle.label | ref arg b [c] |
 | A.cpp:126:12:126:18 | new | semmle.label | new |
 | A.cpp:131:8:131:8 | ref arg b [c] | semmle.label | ref arg b [c] |
 | A.cpp:132:10:132:10 | b [c] | semmle.label | b [c] |
 | A.cpp:132:13:132:13 | c | semmle.label | c |
+| A.cpp:140:5:140:5 | this [Return] [b, c] | semmle.label | this [Return] [b, c] |
+| A.cpp:140:5:140:5 | this [Return] [b] | semmle.label | this [Return] [b] |
+| A.cpp:140:5:140:5 | this [Return] [b] | semmle.label | this [Return] [b] |
 | A.cpp:140:13:140:13 | b | semmle.label | b |
+| A.cpp:140:13:140:13 | b [Return] [c] | semmle.label | b [Return] [c] |
 | A.cpp:140:13:140:13 | b [c] | semmle.label | b [c] |
 | A.cpp:142:7:142:7 | b [post update] [c] | semmle.label | b [post update] [c] |
 | A.cpp:142:7:142:20 | ... = ... | semmle.label | ... = ... |
@@ -862,6 +903,9 @@ nodes
 | A.cpp:173:26:173:26 | o | semmle.label | o |
 | A.cpp:173:26:173:26 | o [c] | semmle.label | o [c] |
 | A.cpp:173:26:173:26 | o [c] | semmle.label | o [c] |
+| A.cpp:181:5:181:10 | this [Return] [head] | semmle.label | this [Return] [head] |
+| A.cpp:181:5:181:10 | this [Return] [next, head] | semmle.label | this [Return] [next, head] |
+| A.cpp:181:5:181:10 | this [Return] [next, next, head] | semmle.label | this [Return] [next, next, head] |
 | A.cpp:181:15:181:21 | newHead | semmle.label | newHead |
 | A.cpp:181:32:181:35 | next [head] | semmle.label | next [head] |
 | A.cpp:181:32:181:35 | next [next, head] | semmle.label | next [next, head] |
@@ -887,12 +931,16 @@ nodes
 | B.cpp:19:10:19:11 | b2 [box1, elem2] | semmle.label | b2 [box1, elem2] |
 | B.cpp:19:14:19:17 | box1 [elem2] | semmle.label | box1 [elem2] |
 | B.cpp:19:20:19:24 | elem2 | semmle.label | elem2 |
+| B.cpp:33:5:33:8 | this [Return] [elem1] | semmle.label | this [Return] [elem1] |
+| B.cpp:33:5:33:8 | this [Return] [elem2] | semmle.label | this [Return] [elem2] |
 | B.cpp:33:16:33:17 | e1 | semmle.label | e1 |
 | B.cpp:33:26:33:27 | e2 | semmle.label | e2 |
 | B.cpp:35:7:35:10 | this [post update] [elem1] | semmle.label | this [post update] [elem1] |
 | B.cpp:35:7:35:22 | ... = ... | semmle.label | ... = ... |
 | B.cpp:36:7:36:10 | this [post update] [elem2] | semmle.label | this [post update] [elem2] |
 | B.cpp:36:7:36:22 | ... = ... | semmle.label | ... = ... |
+| B.cpp:44:5:44:8 | this [Return] [box1, elem1] | semmle.label | this [Return] [box1, elem1] |
+| B.cpp:44:5:44:8 | this [Return] [box1, elem2] | semmle.label | this [Return] [box1, elem2] |
 | B.cpp:44:16:44:17 | b1 [elem1] | semmle.label | b1 [elem1] |
 | B.cpp:44:16:44:17 | b1 [elem2] | semmle.label | b1 [elem2] |
 | B.cpp:46:7:46:10 | this [post update] [box1, elem1] | semmle.label | this [post update] [box1, elem1] |
@@ -903,6 +951,8 @@ nodes
 | C.cpp:18:12:18:18 | call to C [s3] | semmle.label | call to C [s3] |
 | C.cpp:19:5:19:5 | c [s1] | semmle.label | c [s1] |
 | C.cpp:19:5:19:5 | c [s3] | semmle.label | c [s3] |
+| C.cpp:22:3:22:3 | this [Return] [s1] | semmle.label | this [Return] [s1] |
+| C.cpp:22:3:22:3 | this [Return] [s3] | semmle.label | this [Return] [s3] |
 | C.cpp:22:9:22:22 | constructor init of field s1 [post-this] [s1] | semmle.label | constructor init of field s1 [post-this] [s1] |
 | C.cpp:22:12:22:21 | new | semmle.label | new |
 | C.cpp:24:5:24:8 | this [post update] [s3] | semmle.label | this [post update] [s3] |
@@ -917,6 +967,7 @@ nodes
 | D.cpp:10:11:10:17 | this [elem] | semmle.label | this [elem] |
 | D.cpp:10:30:10:33 | elem | semmle.label | elem |
 | D.cpp:10:30:10:33 | this [elem] | semmle.label | this [elem] |
+| D.cpp:11:10:11:16 | this [Return] [elem] | semmle.label | this [Return] [elem] |
 | D.cpp:11:24:11:24 | e | semmle.label | e |
 | D.cpp:11:29:11:32 | this [post update] [elem] | semmle.label | this [post update] [elem] |
 | D.cpp:11:29:11:36 | ... = ... | semmle.label | ... = ... |
@@ -973,10 +1024,12 @@ nodes
 | E.cpp:32:13:32:18 | buffer | semmle.label | buffer |
 | E.cpp:33:18:33:19 | & ... [data, buffer] | semmle.label | & ... [data, buffer] |
 | E.cpp:33:19:33:19 | p [data, buffer] | semmle.label | p [data, buffer] |
+| aliasing.cpp:8:23:8:23 | s [Return] [m1] | semmle.label | s [Return] [m1] |
 | aliasing.cpp:8:23:8:23 | s [m1] | semmle.label | s [m1] |
 | aliasing.cpp:9:3:9:3 | s [post update] [m1] | semmle.label | s [post update] [m1] |
 | aliasing.cpp:9:3:9:22 | ... = ... | semmle.label | ... = ... |
 | aliasing.cpp:9:11:9:20 | call to user_input | semmle.label | call to user_input |
+| aliasing.cpp:12:25:12:25 | s [Return] [m1] | semmle.label | s [Return] [m1] |
 | aliasing.cpp:12:25:12:25 | s [m1] | semmle.label | s [m1] |
 | aliasing.cpp:13:3:13:3 | s [post update] [m1] | semmle.label | s [post update] [m1] |
 | aliasing.cpp:13:3:13:21 | ... = ... | semmle.label | ... = ... |
@@ -1000,7 +1053,7 @@ nodes
 | aliasing.cpp:93:10:93:10 | s [m1] | semmle.label | s [m1] |
 | aliasing.cpp:93:12:93:13 | m1 | semmle.label | m1 |
 | aliasing.cpp:105:23:105:24 | pa | semmle.label | pa |
-| aliasing.cpp:106:4:106:5 | pa [inner post update] | semmle.label | pa [inner post update] |
+| aliasing.cpp:105:23:105:24 | pa [Return] | semmle.label | pa [Return] |
 | aliasing.cpp:106:9:106:18 | call to user_input | semmle.label | call to user_input |
 | aliasing.cpp:158:15:158:15 | s [post update] [data] | semmle.label | s [post update] [data] |
 | aliasing.cpp:158:17:158:20 | ref arg data | semmle.label | ref arg data |
@@ -1085,16 +1138,20 @@ nodes
 | arrays.cpp:44:10:44:17 | indirect [arr, data] | semmle.label | indirect [arr, data] |
 | arrays.cpp:44:20:44:22 | arr [data] | semmle.label | arr [data] |
 | arrays.cpp:44:27:44:30 | data | semmle.label | data |
+| by_reference.cpp:11:39:11:39 | s [Return] [a] | semmle.label | s [Return] [a] |
 | by_reference.cpp:11:39:11:39 | s [a] | semmle.label | s [a] |
 | by_reference.cpp:11:48:11:52 | value | semmle.label | value |
 | by_reference.cpp:12:5:12:5 | s [post update] [a] | semmle.label | s [post update] [a] |
 | by_reference.cpp:12:5:12:16 | ... = ... | semmle.label | ... = ... |
+| by_reference.cpp:15:8:15:18 | this [Return] [a] | semmle.label | this [Return] [a] |
 | by_reference.cpp:15:26:15:30 | value | semmle.label | value |
 | by_reference.cpp:16:5:16:8 | this [post update] [a] | semmle.label | this [post update] [a] |
 | by_reference.cpp:16:5:16:19 | ... = ... | semmle.label | ... = ... |
+| by_reference.cpp:19:8:19:20 | this [Return] [a] | semmle.label | this [Return] [a] |
 | by_reference.cpp:19:28:19:32 | value | semmle.label | value |
 | by_reference.cpp:20:5:20:8 | ref arg this [a] | semmle.label | ref arg this [a] |
 | by_reference.cpp:20:23:20:27 | value | semmle.label | value |
+| by_reference.cpp:23:8:23:26 | this [Return] [a] | semmle.label | this [Return] [a] |
 | by_reference.cpp:23:34:23:38 | value | semmle.label | value |
 | by_reference.cpp:24:19:24:22 | ref arg this [a] | semmle.label | ref arg this [a] |
 | by_reference.cpp:24:25:24:29 | value | semmle.label | value |
@@ -1127,16 +1184,18 @@ nodes
 | by_reference.cpp:69:8:69:20 | call to nonMemberGetA | semmle.label | call to nonMemberGetA |
 | by_reference.cpp:69:22:69:23 | & ... [a] | semmle.label | & ... [a] |
 | by_reference.cpp:69:23:69:23 | s [a] | semmle.label | s [a] |
+| by_reference.cpp:83:31:83:35 | inner [Return] [a] | semmle.label | inner [Return] [a] |
 | by_reference.cpp:83:31:83:35 | inner [a] | semmle.label | inner [a] |
 | by_reference.cpp:84:3:84:7 | inner [post update] [a] | semmle.label | inner [post update] [a] |
 | by_reference.cpp:84:3:84:25 | ... = ... | semmle.label | ... = ... |
 | by_reference.cpp:84:14:84:23 | call to user_input | semmle.label | call to user_input |
+| by_reference.cpp:87:31:87:35 | inner [Return] [a] | semmle.label | inner [Return] [a] |
 | by_reference.cpp:87:31:87:35 | inner [a] | semmle.label | inner [a] |
 | by_reference.cpp:88:3:88:7 | inner [post update] [a] | semmle.label | inner [post update] [a] |
 | by_reference.cpp:88:3:88:24 | ... = ... | semmle.label | ... = ... |
 | by_reference.cpp:88:13:88:22 | call to user_input | semmle.label | call to user_input |
 | by_reference.cpp:91:25:91:26 | pa | semmle.label | pa |
-| by_reference.cpp:92:4:92:5 | pa [inner post update] | semmle.label | pa [inner post update] |
+| by_reference.cpp:91:25:91:26 | pa [Return] | semmle.label | pa [Return] |
 | by_reference.cpp:92:9:92:18 | call to user_input | semmle.label | call to user_input |
 | by_reference.cpp:95:25:95:26 | pa | semmle.label | pa |
 | by_reference.cpp:96:8:96:17 | call to user_input | semmle.label | call to user_input |
@@ -1253,9 +1312,11 @@ nodes
 | complex.cpp:10:7:10:7 | this [b_] | semmle.label | this [b_] |
 | complex.cpp:10:20:10:21 | b_ | semmle.label | b_ |
 | complex.cpp:10:20:10:21 | this [b_] | semmle.label | this [b_] |
+| complex.cpp:11:8:11:11 | this [Return] [a_] | semmle.label | this [Return] [a_] |
 | complex.cpp:11:17:11:17 | a | semmle.label | a |
 | complex.cpp:11:22:11:23 | this [post update] [a_] | semmle.label | this [post update] [a_] |
 | complex.cpp:11:22:11:27 | ... = ... | semmle.label | ... = ... |
+| complex.cpp:12:8:12:11 | this [Return] [b_] | semmle.label | this [Return] [b_] |
 | complex.cpp:12:17:12:17 | b | semmle.label | b |
 | complex.cpp:12:22:12:23 | this [post update] [b_] | semmle.label | this [post update] [b_] |
 | complex.cpp:12:22:12:27 | ... = ... | semmle.label | ... = ... |
@@ -1321,6 +1382,8 @@ nodes
 | constructors.cpp:19:9:19:9 | this [b_] | semmle.label | this [b_] |
 | constructors.cpp:19:22:19:23 | b_ | semmle.label | b_ |
 | constructors.cpp:19:22:19:23 | this [b_] | semmle.label | this [b_] |
+| constructors.cpp:23:5:23:7 | this [Return] [a_] | semmle.label | this [Return] [a_] |
+| constructors.cpp:23:5:23:7 | this [Return] [b_] | semmle.label | this [Return] [b_] |
 | constructors.cpp:23:13:23:13 | a | semmle.label | a |
 | constructors.cpp:23:20:23:20 | b | semmle.label | b |
 | constructors.cpp:23:25:23:29 | constructor init of field a_ [post-this] [a_] | semmle.label | constructor init of field a_ [post-this] [a_] |
@@ -1345,13 +1408,16 @@ nodes
 | constructors.cpp:43:9:43:9 | g [b_] | semmle.label | g [b_] |
 | constructors.cpp:46:9:46:9 | h [a_] | semmle.label | h [a_] |
 | constructors.cpp:46:9:46:9 | h [b_] | semmle.label | h [b_] |
+| qualifiers.cpp:9:10:9:13 | this [Return] [a] | semmle.label | this [Return] [a] |
 | qualifiers.cpp:9:21:9:25 | value | semmle.label | value |
 | qualifiers.cpp:9:30:9:33 | this [post update] [a] | semmle.label | this [post update] [a] |
 | qualifiers.cpp:9:30:9:44 | ... = ... | semmle.label | ... = ... |
+| qualifiers.cpp:12:27:12:31 | inner [Return] [a] | semmle.label | inner [Return] [a] |
 | qualifiers.cpp:12:27:12:31 | inner [a] | semmle.label | inner [a] |
 | qualifiers.cpp:12:40:12:44 | value | semmle.label | value |
 | qualifiers.cpp:12:49:12:53 | inner [post update] [a] | semmle.label | inner [post update] [a] |
 | qualifiers.cpp:12:49:12:64 | ... = ... | semmle.label | ... = ... |
+| qualifiers.cpp:13:29:13:33 | inner [Return] [a] | semmle.label | inner [Return] [a] |
 | qualifiers.cpp:13:29:13:33 | inner [a] | semmle.label | inner [a] |
 | qualifiers.cpp:13:42:13:46 | value | semmle.label | value |
 | qualifiers.cpp:13:51:13:55 | inner [post update] [a] | semmle.label | inner [post update] [a] |
@@ -1425,9 +1491,11 @@ nodes
 | simple.cpp:19:9:19:9 | this [b_] | semmle.label | this [b_] |
 | simple.cpp:19:22:19:23 | b_ | semmle.label | b_ |
 | simple.cpp:19:22:19:23 | this [b_] | semmle.label | this [b_] |
+| simple.cpp:20:10:20:13 | this [Return] [a_] | semmle.label | this [Return] [a_] |
 | simple.cpp:20:19:20:19 | a | semmle.label | a |
 | simple.cpp:20:24:20:25 | this [post update] [a_] | semmle.label | this [post update] [a_] |
 | simple.cpp:20:24:20:29 | ... = ... | semmle.label | ... = ... |
+| simple.cpp:21:10:21:13 | this [Return] [b_] | semmle.label | this [Return] [b_] |
 | simple.cpp:21:19:21:19 | b | semmle.label | b |
 | simple.cpp:21:24:21:25 | this [post update] [b_] | semmle.label | this [post update] [b_] |
 | simple.cpp:21:24:21:29 | ... = ... | semmle.label | ... = ... |
@@ -1513,71 +1581,71 @@ nodes
 | struct_init.c:46:10:46:14 | outer [pointerAB, a] | semmle.label | outer [pointerAB, a] |
 | struct_init.c:46:16:46:24 | pointerAB [a] | semmle.label | pointerAB [a] |
 subpaths
-| A.cpp:31:20:31:20 | c | A.cpp:23:10:23:10 | c | A.cpp:25:7:25:10 | this [post update] [c] | A.cpp:31:14:31:21 | call to B [c] |
+| A.cpp:31:20:31:20 | c | A.cpp:23:10:23:10 | c | A.cpp:23:5:23:5 | this [Return] [c] | A.cpp:31:14:31:21 | call to B [c] |
 | A.cpp:48:20:48:20 | c | A.cpp:29:23:29:23 | c | A.cpp:31:14:31:21 | new [c] | A.cpp:48:12:48:18 | call to make [c] |
-| A.cpp:55:12:55:19 | new | A.cpp:27:17:27:17 | c | A.cpp:27:22:27:25 | this [post update] [c] | A.cpp:55:5:55:5 | ref arg b [c] |
+| A.cpp:55:12:55:19 | new | A.cpp:27:17:27:17 | c | A.cpp:27:10:27:12 | this [Return] [c] | A.cpp:55:5:55:5 | ref arg b [c] |
 | A.cpp:56:10:56:10 | b [c] | A.cpp:28:8:28:10 | this [c] | A.cpp:28:29:28:29 | c | A.cpp:56:13:56:15 | call to get |
 | A.cpp:57:11:57:24 | new [c] | A.cpp:28:8:28:10 | this [c] | A.cpp:28:29:28:29 | c | A.cpp:57:28:57:30 | call to get |
-| A.cpp:57:17:57:23 | new | A.cpp:23:10:23:10 | c | A.cpp:25:7:25:10 | this [post update] [c] | A.cpp:57:11:57:24 | call to B [c] |
+| A.cpp:57:17:57:23 | new | A.cpp:23:10:23:10 | c | A.cpp:23:5:23:5 | this [Return] [c] | A.cpp:57:11:57:24 | call to B [c] |
 | A.cpp:64:21:64:28 | new | A.cpp:85:26:85:26 | c | A.cpp:91:14:91:15 | b2 [c] | A.cpp:64:10:64:15 | call to setOnB [c] |
 | A.cpp:73:25:73:32 | new | A.cpp:78:27:78:27 | c | A.cpp:82:12:82:24 | ... ? ... : ... [c] | A.cpp:73:10:73:19 | call to setOnBWrap [c] |
 | A.cpp:81:21:81:21 | c | A.cpp:85:26:85:26 | c | A.cpp:91:14:91:15 | b2 [c] | A.cpp:81:10:81:15 | call to setOnB [c] |
-| A.cpp:90:15:90:15 | c | A.cpp:27:17:27:17 | c | A.cpp:27:22:27:25 | this [post update] [c] | A.cpp:90:7:90:8 | ref arg b2 [c] |
-| A.cpp:126:12:126:18 | new | A.cpp:27:17:27:17 | c | A.cpp:27:22:27:25 | this [post update] [c] | A.cpp:126:5:126:5 | ref arg b [c] |
-| A.cpp:151:18:151:18 | b | A.cpp:140:13:140:13 | b | A.cpp:143:7:143:10 | this [post update] [b] | A.cpp:151:12:151:24 | call to D [b] |
+| A.cpp:90:15:90:15 | c | A.cpp:27:17:27:17 | c | A.cpp:27:10:27:12 | this [Return] [c] | A.cpp:90:7:90:8 | ref arg b2 [c] |
+| A.cpp:126:12:126:18 | new | A.cpp:27:17:27:17 | c | A.cpp:27:10:27:12 | this [Return] [c] | A.cpp:126:5:126:5 | ref arg b [c] |
+| A.cpp:151:18:151:18 | b | A.cpp:140:13:140:13 | b | A.cpp:140:5:140:5 | this [Return] [b] | A.cpp:151:12:151:24 | call to D [b] |
 | A.cpp:152:13:152:13 | b [c] | A.cpp:173:26:173:26 | o [c] | A.cpp:173:26:173:26 | o [c] | A.cpp:152:13:152:13 | ref arg b [c] |
-| A.cpp:160:29:160:29 | b | A.cpp:181:15:181:21 | newHead | A.cpp:183:7:183:10 | this [post update] [head] | A.cpp:160:18:160:60 | call to MyList [head] |
-| A.cpp:161:38:161:39 | l1 [head] | A.cpp:181:32:181:35 | next [head] | A.cpp:184:7:184:10 | this [post update] [next, head] | A.cpp:161:18:161:40 | call to MyList [next, head] |
-| A.cpp:162:38:162:39 | l2 [next, head] | A.cpp:181:32:181:35 | next [next, head] | A.cpp:184:7:184:10 | this [post update] [next, next, head] | A.cpp:162:18:162:40 | call to MyList [next, next, head] |
+| A.cpp:160:29:160:29 | b | A.cpp:181:15:181:21 | newHead | A.cpp:181:5:181:10 | this [Return] [head] | A.cpp:160:18:160:60 | call to MyList [head] |
+| A.cpp:161:38:161:39 | l1 [head] | A.cpp:181:32:181:35 | next [head] | A.cpp:181:5:181:10 | this [Return] [next, head] | A.cpp:161:18:161:40 | call to MyList [next, head] |
+| A.cpp:162:38:162:39 | l2 [next, head] | A.cpp:181:32:181:35 | next [next, head] | A.cpp:181:5:181:10 | this [Return] [next, next, head] | A.cpp:162:18:162:40 | call to MyList [next, next, head] |
 | A.cpp:165:26:165:29 | head | A.cpp:173:26:173:26 | o | A.cpp:173:26:173:26 | o | A.cpp:165:26:165:29 | ref arg head |
-| B.cpp:7:25:7:25 | e | B.cpp:33:16:33:17 | e1 | B.cpp:35:7:35:10 | this [post update] [elem1] | B.cpp:7:16:7:35 | call to Box1 [elem1] |
-| B.cpp:8:25:8:26 | b1 [elem1] | B.cpp:44:16:44:17 | b1 [elem1] | B.cpp:46:7:46:10 | this [post update] [box1, elem1] | B.cpp:8:16:8:27 | call to Box2 [box1, elem1] |
-| B.cpp:16:37:16:37 | e | B.cpp:33:26:33:27 | e2 | B.cpp:36:7:36:10 | this [post update] [elem2] | B.cpp:16:16:16:38 | call to Box1 [elem2] |
-| B.cpp:17:25:17:26 | b1 [elem2] | B.cpp:44:16:44:17 | b1 [elem2] | B.cpp:46:7:46:10 | this [post update] [box1, elem2] | B.cpp:17:16:17:27 | call to Box2 [box1, elem2] |
+| B.cpp:7:25:7:25 | e | B.cpp:33:16:33:17 | e1 | B.cpp:33:5:33:8 | this [Return] [elem1] | B.cpp:7:16:7:35 | call to Box1 [elem1] |
+| B.cpp:8:25:8:26 | b1 [elem1] | B.cpp:44:16:44:17 | b1 [elem1] | B.cpp:44:5:44:8 | this [Return] [box1, elem1] | B.cpp:8:16:8:27 | call to Box2 [box1, elem1] |
+| B.cpp:16:37:16:37 | e | B.cpp:33:26:33:27 | e2 | B.cpp:33:5:33:8 | this [Return] [elem2] | B.cpp:16:16:16:38 | call to Box1 [elem2] |
+| B.cpp:17:25:17:26 | b1 [elem2] | B.cpp:44:16:44:17 | b1 [elem2] | B.cpp:44:5:44:8 | this [Return] [box1, elem2] | B.cpp:17:16:17:27 | call to Box2 [box1, elem2] |
 | D.cpp:22:10:22:11 | b2 [box, elem] | D.cpp:17:11:17:17 | this [box, elem] | D.cpp:17:30:17:32 | box [elem] | D.cpp:22:14:22:20 | call to getBox1 [elem] |
 | D.cpp:22:14:22:20 | call to getBox1 [elem] | D.cpp:10:11:10:17 | this [elem] | D.cpp:10:30:10:33 | elem | D.cpp:22:25:22:31 | call to getElem |
-| D.cpp:37:21:37:21 | e | D.cpp:11:24:11:24 | e | D.cpp:11:29:11:32 | this [post update] [elem] | D.cpp:37:8:37:10 | ref arg box [elem] |
-| D.cpp:51:27:51:27 | e | D.cpp:11:24:11:24 | e | D.cpp:11:29:11:32 | this [post update] [elem] | D.cpp:51:8:51:14 | ref arg call to getBox1 [elem] |
+| D.cpp:37:21:37:21 | e | D.cpp:11:24:11:24 | e | D.cpp:11:10:11:16 | this [Return] [elem] | D.cpp:37:8:37:10 | ref arg box [elem] |
+| D.cpp:51:27:51:27 | e | D.cpp:11:24:11:24 | e | D.cpp:11:10:11:16 | this [Return] [elem] | D.cpp:51:8:51:14 | ref arg call to getBox1 [elem] |
 | arrays.cpp:37:24:37:27 | data | realistic.cpp:41:17:41:17 | o | realistic.cpp:41:17:41:17 | o | arrays.cpp:37:24:37:27 | ref arg data |
 | arrays.cpp:43:27:43:30 | data | realistic.cpp:41:17:41:17 | o | realistic.cpp:41:17:41:17 | o | arrays.cpp:43:27:43:30 | ref arg data |
-| by_reference.cpp:20:23:20:27 | value | by_reference.cpp:15:26:15:30 | value | by_reference.cpp:16:5:16:8 | this [post update] [a] | by_reference.cpp:20:5:20:8 | ref arg this [a] |
+| by_reference.cpp:20:23:20:27 | value | by_reference.cpp:15:26:15:30 | value | by_reference.cpp:15:8:15:18 | this [Return] [a] | by_reference.cpp:20:5:20:8 | ref arg this [a] |
+| by_reference.cpp:24:25:24:29 | value | by_reference.cpp:11:48:11:52 | value | by_reference.cpp:11:39:11:39 | s [Return] [a] | by_reference.cpp:24:19:24:22 | ref arg this [a] |
 | by_reference.cpp:24:25:24:29 | value | by_reference.cpp:11:48:11:52 | value | by_reference.cpp:11:39:11:39 | s [a] | by_reference.cpp:24:19:24:22 | ref arg this [a] |
-| by_reference.cpp:24:25:24:29 | value | by_reference.cpp:11:48:11:52 | value | by_reference.cpp:12:5:12:5 | s [post update] [a] | by_reference.cpp:24:19:24:22 | ref arg this [a] |
 | by_reference.cpp:40:12:40:15 | this [a] | by_reference.cpp:35:9:35:19 | this [a] | by_reference.cpp:36:18:36:18 | a | by_reference.cpp:40:18:40:28 | call to getDirectly |
 | by_reference.cpp:44:26:44:29 | this [a] | by_reference.cpp:31:46:31:46 | s [a] | by_reference.cpp:32:15:32:15 | a | by_reference.cpp:44:12:44:24 | call to nonMemberGetA |
-| by_reference.cpp:50:17:50:26 | call to user_input | by_reference.cpp:15:26:15:30 | value | by_reference.cpp:16:5:16:8 | this [post update] [a] | by_reference.cpp:50:3:50:3 | ref arg s [a] |
+| by_reference.cpp:50:17:50:26 | call to user_input | by_reference.cpp:15:26:15:30 | value | by_reference.cpp:15:8:15:18 | this [Return] [a] | by_reference.cpp:50:3:50:3 | ref arg s [a] |
 | by_reference.cpp:51:8:51:8 | s [a] | by_reference.cpp:35:9:35:19 | this [a] | by_reference.cpp:36:18:36:18 | a | by_reference.cpp:51:10:51:20 | call to getDirectly |
-| by_reference.cpp:56:19:56:28 | call to user_input | by_reference.cpp:19:28:19:32 | value | by_reference.cpp:20:5:20:8 | ref arg this [a] | by_reference.cpp:56:3:56:3 | ref arg s [a] |
+| by_reference.cpp:56:19:56:28 | call to user_input | by_reference.cpp:19:28:19:32 | value | by_reference.cpp:19:8:19:20 | this [Return] [a] | by_reference.cpp:56:3:56:3 | ref arg s [a] |
 | by_reference.cpp:57:8:57:8 | s [a] | by_reference.cpp:39:9:39:21 | this [a] | by_reference.cpp:40:18:40:28 | call to getDirectly | by_reference.cpp:57:10:57:22 | call to getIndirectly |
-| by_reference.cpp:62:25:62:34 | call to user_input | by_reference.cpp:23:34:23:38 | value | by_reference.cpp:24:19:24:22 | ref arg this [a] | by_reference.cpp:62:3:62:3 | ref arg s [a] |
+| by_reference.cpp:62:25:62:34 | call to user_input | by_reference.cpp:23:34:23:38 | value | by_reference.cpp:23:8:23:26 | this [Return] [a] | by_reference.cpp:62:3:62:3 | ref arg s [a] |
 | by_reference.cpp:63:8:63:8 | s [a] | by_reference.cpp:43:9:43:27 | this [a] | by_reference.cpp:44:12:44:24 | call to nonMemberGetA | by_reference.cpp:63:10:63:28 | call to getThroughNonMember |
+| by_reference.cpp:68:21:68:30 | call to user_input | by_reference.cpp:11:48:11:52 | value | by_reference.cpp:11:39:11:39 | s [Return] [a] | by_reference.cpp:68:17:68:18 | ref arg & ... [a] |
 | by_reference.cpp:68:21:68:30 | call to user_input | by_reference.cpp:11:48:11:52 | value | by_reference.cpp:11:39:11:39 | s [a] | by_reference.cpp:68:17:68:18 | ref arg & ... [a] |
-| by_reference.cpp:68:21:68:30 | call to user_input | by_reference.cpp:11:48:11:52 | value | by_reference.cpp:12:5:12:5 | s [post update] [a] | by_reference.cpp:68:17:68:18 | ref arg & ... [a] |
 | by_reference.cpp:69:22:69:23 | & ... [a] | by_reference.cpp:31:46:31:46 | s [a] | by_reference.cpp:32:15:32:15 | a | by_reference.cpp:69:8:69:20 | call to nonMemberGetA |
 | complex.cpp:42:16:42:16 | f [a_] | complex.cpp:9:7:9:7 | this [a_] | complex.cpp:9:20:9:21 | a_ | complex.cpp:42:18:42:18 | call to a |
 | complex.cpp:43:16:43:16 | f [b_] | complex.cpp:10:7:10:7 | this [b_] | complex.cpp:10:20:10:21 | b_ | complex.cpp:43:18:43:18 | call to b |
-| complex.cpp:53:19:53:28 | call to user_input | complex.cpp:11:17:11:17 | a | complex.cpp:11:22:11:23 | this [post update] [a_] | complex.cpp:53:12:53:12 | ref arg f [a_] |
-| complex.cpp:54:19:54:28 | call to user_input | complex.cpp:12:17:12:17 | b | complex.cpp:12:22:12:23 | this [post update] [b_] | complex.cpp:54:12:54:12 | ref arg f [b_] |
-| complex.cpp:55:19:55:28 | call to user_input | complex.cpp:11:17:11:17 | a | complex.cpp:11:22:11:23 | this [post update] [a_] | complex.cpp:55:12:55:12 | ref arg f [a_] |
-| complex.cpp:56:19:56:28 | call to user_input | complex.cpp:12:17:12:17 | b | complex.cpp:12:22:12:23 | this [post update] [b_] | complex.cpp:56:12:56:12 | ref arg f [b_] |
+| complex.cpp:53:19:53:28 | call to user_input | complex.cpp:11:17:11:17 | a | complex.cpp:11:8:11:11 | this [Return] [a_] | complex.cpp:53:12:53:12 | ref arg f [a_] |
+| complex.cpp:54:19:54:28 | call to user_input | complex.cpp:12:17:12:17 | b | complex.cpp:12:8:12:11 | this [Return] [b_] | complex.cpp:54:12:54:12 | ref arg f [b_] |
+| complex.cpp:55:19:55:28 | call to user_input | complex.cpp:11:17:11:17 | a | complex.cpp:11:8:11:11 | this [Return] [a_] | complex.cpp:55:12:55:12 | ref arg f [a_] |
+| complex.cpp:56:19:56:28 | call to user_input | complex.cpp:12:17:12:17 | b | complex.cpp:12:8:12:11 | this [Return] [b_] | complex.cpp:56:12:56:12 | ref arg f [b_] |
 | constructors.cpp:28:10:28:10 | f [a_] | constructors.cpp:18:9:18:9 | this [a_] | constructors.cpp:18:22:18:23 | a_ | constructors.cpp:28:12:28:12 | call to a |
 | constructors.cpp:29:10:29:10 | f [b_] | constructors.cpp:19:9:19:9 | this [b_] | constructors.cpp:19:22:19:23 | b_ | constructors.cpp:29:12:29:12 | call to b |
-| constructors.cpp:34:11:34:20 | call to user_input | constructors.cpp:23:13:23:13 | a | constructors.cpp:23:25:23:29 | constructor init of field a_ [post-this] [a_] | constructors.cpp:34:11:34:26 | call to Foo [a_] |
-| constructors.cpp:35:14:35:23 | call to user_input | constructors.cpp:23:20:23:20 | b | constructors.cpp:23:32:23:36 | constructor init of field b_ [post-this] [b_] | constructors.cpp:35:11:35:26 | call to Foo [b_] |
-| constructors.cpp:36:11:36:20 | call to user_input | constructors.cpp:23:13:23:13 | a | constructors.cpp:23:25:23:29 | constructor init of field a_ [post-this] [a_] | constructors.cpp:36:11:36:37 | call to Foo [a_] |
-| constructors.cpp:36:25:36:34 | call to user_input | constructors.cpp:23:20:23:20 | b | constructors.cpp:23:32:23:36 | constructor init of field b_ [post-this] [b_] | constructors.cpp:36:11:36:37 | call to Foo [b_] |
-| qualifiers.cpp:27:28:27:37 | call to user_input | qualifiers.cpp:9:21:9:25 | value | qualifiers.cpp:9:30:9:33 | this [post update] [a] | qualifiers.cpp:27:11:27:18 | ref arg call to getInner [a] |
+| constructors.cpp:34:11:34:20 | call to user_input | constructors.cpp:23:13:23:13 | a | constructors.cpp:23:5:23:7 | this [Return] [a_] | constructors.cpp:34:11:34:26 | call to Foo [a_] |
+| constructors.cpp:35:14:35:23 | call to user_input | constructors.cpp:23:20:23:20 | b | constructors.cpp:23:5:23:7 | this [Return] [b_] | constructors.cpp:35:11:35:26 | call to Foo [b_] |
+| constructors.cpp:36:11:36:20 | call to user_input | constructors.cpp:23:13:23:13 | a | constructors.cpp:23:5:23:7 | this [Return] [a_] | constructors.cpp:36:11:36:37 | call to Foo [a_] |
+| constructors.cpp:36:25:36:34 | call to user_input | constructors.cpp:23:20:23:20 | b | constructors.cpp:23:5:23:7 | this [Return] [b_] | constructors.cpp:36:11:36:37 | call to Foo [b_] |
+| qualifiers.cpp:27:28:27:37 | call to user_input | qualifiers.cpp:9:21:9:25 | value | qualifiers.cpp:9:10:9:13 | this [Return] [a] | qualifiers.cpp:27:11:27:18 | ref arg call to getInner [a] |
+| qualifiers.cpp:32:35:32:44 | call to user_input | qualifiers.cpp:12:40:12:44 | value | qualifiers.cpp:12:27:12:31 | inner [Return] [a] | qualifiers.cpp:32:23:32:30 | ref arg call to getInner [a] |
 | qualifiers.cpp:32:35:32:44 | call to user_input | qualifiers.cpp:12:40:12:44 | value | qualifiers.cpp:12:27:12:31 | inner [a] | qualifiers.cpp:32:23:32:30 | ref arg call to getInner [a] |
-| qualifiers.cpp:32:35:32:44 | call to user_input | qualifiers.cpp:12:40:12:44 | value | qualifiers.cpp:12:49:12:53 | inner [post update] [a] | qualifiers.cpp:32:23:32:30 | ref arg call to getInner [a] |
+| qualifiers.cpp:37:38:37:47 | call to user_input | qualifiers.cpp:13:42:13:46 | value | qualifiers.cpp:13:29:13:33 | inner [Return] [a] | qualifiers.cpp:37:19:37:35 | ref arg * ... [a] |
 | qualifiers.cpp:37:38:37:47 | call to user_input | qualifiers.cpp:13:42:13:46 | value | qualifiers.cpp:13:29:13:33 | inner [a] | qualifiers.cpp:37:19:37:35 | ref arg * ... [a] |
-| qualifiers.cpp:37:38:37:47 | call to user_input | qualifiers.cpp:13:42:13:46 | value | qualifiers.cpp:13:51:13:55 | inner [post update] [a] | qualifiers.cpp:37:19:37:35 | ref arg * ... [a] |
 | realistic.cpp:61:47:61:55 | bufferLen | realistic.cpp:41:17:41:17 | o | realistic.cpp:41:17:41:17 | o | realistic.cpp:61:47:61:55 | ref arg bufferLen |
 | simple.cpp:28:10:28:10 | f [a_] | simple.cpp:18:9:18:9 | this [a_] | simple.cpp:18:22:18:23 | a_ | simple.cpp:28:12:28:12 | call to a |
 | simple.cpp:29:10:29:10 | f [b_] | simple.cpp:19:9:19:9 | this [b_] | simple.cpp:19:22:19:23 | b_ | simple.cpp:29:12:29:12 | call to b |
-| simple.cpp:39:12:39:21 | call to user_input | simple.cpp:20:19:20:19 | a | simple.cpp:20:24:20:25 | this [post update] [a_] | simple.cpp:39:5:39:5 | ref arg f [a_] |
-| simple.cpp:40:12:40:21 | call to user_input | simple.cpp:21:19:21:19 | b | simple.cpp:21:24:21:25 | this [post update] [b_] | simple.cpp:40:5:40:5 | ref arg g [b_] |
-| simple.cpp:41:12:41:21 | call to user_input | simple.cpp:20:19:20:19 | a | simple.cpp:20:24:20:25 | this [post update] [a_] | simple.cpp:41:5:41:5 | ref arg h [a_] |
-| simple.cpp:42:12:42:21 | call to user_input | simple.cpp:21:19:21:19 | b | simple.cpp:21:24:21:25 | this [post update] [b_] | simple.cpp:42:5:42:5 | ref arg h [b_] |
+| simple.cpp:39:12:39:21 | call to user_input | simple.cpp:20:19:20:19 | a | simple.cpp:20:10:20:13 | this [Return] [a_] | simple.cpp:39:5:39:5 | ref arg f [a_] |
+| simple.cpp:40:12:40:21 | call to user_input | simple.cpp:21:19:21:19 | b | simple.cpp:21:10:21:13 | this [Return] [b_] | simple.cpp:40:5:40:5 | ref arg g [b_] |
+| simple.cpp:41:12:41:21 | call to user_input | simple.cpp:20:19:20:19 | a | simple.cpp:20:10:20:13 | this [Return] [a_] | simple.cpp:41:5:41:5 | ref arg h [a_] |
+| simple.cpp:42:12:42:21 | call to user_input | simple.cpp:21:19:21:19 | b | simple.cpp:21:10:21:13 | this [Return] [b_] | simple.cpp:42:5:42:5 | ref arg h [b_] |
 | simple.cpp:84:14:84:20 | this [f2, f1] | simple.cpp:78:9:78:15 | this [f2, f1] | simple.cpp:79:19:79:20 | f1 | simple.cpp:84:14:84:20 | call to getf2f1 |
 | struct_init.c:15:12:15:12 | a | realistic.cpp:41:17:41:17 | o | realistic.cpp:41:17:41:17 | o | struct_init.c:15:12:15:12 | ref arg a |
 | struct_init.c:22:11:22:11 | a | realistic.cpp:41:17:41:17 | o | realistic.cpp:41:17:41:17 | o | struct_init.c:22:11:22:11 | ref arg a |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-078/semmle/ExecTainted/ExecTainted.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-078/semmle/ExecTainted/ExecTainted.expected
@@ -51,6 +51,8 @@ edges
 | test.cpp:187:18:187:25 | *filename | test.cpp:187:11:187:15 | strncat output argument | provenance | TaintFunction |
 | test.cpp:188:11:188:17 | strncat output argument | test.cpp:186:19:186:25 | *command | provenance |  |
 | test.cpp:188:11:188:17 | strncat output argument | test.cpp:186:19:186:25 | *command | provenance |  |
+| test.cpp:188:11:188:17 | strncat output argument | test.cpp:186:19:186:25 | *command [Return] | provenance |  |
+| test.cpp:188:11:188:17 | strncat output argument | test.cpp:186:19:186:25 | *command [Return] | provenance |  |
 | test.cpp:188:20:188:24 | *flags | test.cpp:188:11:188:17 | strncat output argument | provenance |  |
 | test.cpp:188:20:188:24 | *flags | test.cpp:188:11:188:17 | strncat output argument | provenance | TaintFunction |
 | test.cpp:194:9:194:16 | fread output argument | test.cpp:196:26:196:33 | *filename | provenance |  |
@@ -125,6 +127,8 @@ nodes
 | test.cpp:183:32:183:38 | *command | semmle.label | *command |
 | test.cpp:186:19:186:25 | *command | semmle.label | *command |
 | test.cpp:186:19:186:25 | *command | semmle.label | *command |
+| test.cpp:186:19:186:25 | *command [Return] | semmle.label | *command [Return] |
+| test.cpp:186:19:186:25 | *command [Return] | semmle.label | *command [Return] |
 | test.cpp:186:47:186:54 | *filename | semmle.label | *filename |
 | test.cpp:187:11:187:15 | strncat output argument | semmle.label | strncat output argument |
 | test.cpp:187:11:187:15 | strncat output argument | semmle.label | strncat output argument |
@@ -151,8 +155,8 @@ nodes
 subpaths
 | test.cpp:196:26:196:33 | *filename | test.cpp:186:47:186:54 | *filename | test.cpp:186:19:186:25 | *command | test.cpp:196:10:196:16 | concat output argument |
 | test.cpp:196:26:196:33 | *filename | test.cpp:186:47:186:54 | *filename | test.cpp:186:19:186:25 | *command | test.cpp:196:10:196:16 | concat output argument |
-| test.cpp:196:26:196:33 | *filename | test.cpp:186:47:186:54 | *filename | test.cpp:188:11:188:17 | strncat output argument | test.cpp:196:10:196:16 | concat output argument |
-| test.cpp:196:26:196:33 | *filename | test.cpp:186:47:186:54 | *filename | test.cpp:188:11:188:17 | strncat output argument | test.cpp:196:10:196:16 | concat output argument |
+| test.cpp:196:26:196:33 | *filename | test.cpp:186:47:186:54 | *filename | test.cpp:186:19:186:25 | *command [Return] | test.cpp:196:10:196:16 | concat output argument |
+| test.cpp:196:26:196:33 | *filename | test.cpp:186:47:186:54 | *filename | test.cpp:186:19:186:25 | *command [Return] | test.cpp:196:10:196:16 | concat output argument |
 #select
 | test.cpp:23:12:23:19 | command1 | test.cpp:15:27:15:30 | **argv | test.cpp:23:12:23:19 | *command1 | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:15:27:15:30 | **argv | user input (a command-line argument) | test.cpp:22:13:22:20 | sprintf output argument | sprintf output argument |
 | test.cpp:51:10:51:16 | command | test.cpp:47:21:47:26 | *call to getenv | test.cpp:51:10:51:16 | *command | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:47:21:47:26 | *call to getenv | user input (an environment variable) | test.cpp:50:11:50:17 | sprintf output argument | sprintf output argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/SAMATE/OverrunWriteProductFlow.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/SAMATE/OverrunWriteProductFlow.expected
@@ -53,6 +53,7 @@ edges
 | test.cpp:228:27:228:54 | call to malloc | test.cpp:228:27:228:54 | call to malloc | provenance |  |
 | test.cpp:228:27:228:54 | call to malloc | test.cpp:232:10:232:15 | buffer | provenance |  |
 | test.cpp:235:40:235:45 | buffer | test.cpp:236:5:236:26 | ... = ... | provenance |  |
+| test.cpp:236:5:236:9 | *p_str [post update] [string] | test.cpp:235:27:235:31 | *p_str [Return] [string] | provenance |  |
 | test.cpp:236:5:236:9 | *p_str [post update] [string] | test.cpp:235:27:235:31 | *p_str [string] | provenance |  |
 | test.cpp:236:5:236:26 | ... = ... | test.cpp:236:5:236:9 | *p_str [post update] [string] | provenance |  |
 | test.cpp:241:20:241:38 | call to malloc | test.cpp:241:20:241:38 | call to malloc | provenance |  |
@@ -128,6 +129,7 @@ nodes
 | test.cpp:228:27:228:54 | call to malloc | semmle.label | call to malloc |
 | test.cpp:228:27:228:54 | call to malloc | semmle.label | call to malloc |
 | test.cpp:232:10:232:15 | buffer | semmle.label | buffer |
+| test.cpp:235:27:235:31 | *p_str [Return] [string] | semmle.label | *p_str [Return] [string] |
 | test.cpp:235:27:235:31 | *p_str [string] | semmle.label | *p_str [string] |
 | test.cpp:235:40:235:45 | buffer | semmle.label | buffer |
 | test.cpp:236:5:236:9 | *p_str [post update] [string] | semmle.label | *p_str [post update] [string] |
@@ -150,8 +152,8 @@ nodes
 | test.cpp:264:13:264:30 | call to malloc | semmle.label | call to malloc |
 | test.cpp:266:12:266:12 | p | semmle.label | p |
 subpaths
+| test.cpp:242:22:242:27 | buffer | test.cpp:235:40:235:45 | buffer | test.cpp:235:27:235:31 | *p_str [Return] [string] | test.cpp:242:16:242:19 | set_string output argument [string] |
 | test.cpp:242:22:242:27 | buffer | test.cpp:235:40:235:45 | buffer | test.cpp:235:27:235:31 | *p_str [string] | test.cpp:242:16:242:19 | set_string output argument [string] |
-| test.cpp:242:22:242:27 | buffer | test.cpp:235:40:235:45 | buffer | test.cpp:236:5:236:9 | *p_str [post update] [string] | test.cpp:242:16:242:19 | set_string output argument [string] |
 #select
 | test.cpp:42:5:42:11 | call to strncpy | test.cpp:18:19:18:24 | call to malloc | test.cpp:42:18:42:23 | string | This write may overflow $@ by 1 element. | test.cpp:42:18:42:23 | string | string |
 | test.cpp:72:9:72:15 | call to strncpy | test.cpp:18:19:18:24 | call to malloc | test.cpp:72:22:72:27 | string | This write may overflow $@ by 1 element. | test.cpp:72:22:72:27 | string | string |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-497/semmle/tests/ExposedSystemData.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-497/semmle/tests/ExposedSystemData.expected
@@ -12,7 +12,7 @@ edges
 | tests2.cpp:111:14:111:15 | *c1 [*ptr] | tests2.cpp:111:14:111:19 | *ptr | provenance |  |
 | tests2.cpp:111:14:111:15 | *c1 [*ptr] | tests2.cpp:111:17:111:19 | *ptr | provenance |  |
 | tests2.cpp:111:17:111:19 | *ptr | tests2.cpp:111:14:111:19 | *ptr | provenance |  |
-| tests2.cpp:120:5:120:21 | [summary param] 1 indirection in zmq_msg_init_data | tests2.cpp:120:5:120:21 | [summary] to write: Argument[0 indirection] in zmq_msg_init_data | provenance |  |
+| tests2.cpp:120:5:120:21 | [summary param] 1 indirection in zmq_msg_init_data | tests2.cpp:120:5:120:21 | [summary param] 0 indirection in zmq_msg_init_data [Return] | provenance |  |
 | tests2.cpp:134:2:134:30 | *... = ... | tests2.cpp:138:23:138:34 | *message_data | provenance |  |
 | tests2.cpp:134:2:134:30 | *... = ... | tests2.cpp:143:34:143:45 | *message_data | provenance |  |
 | tests2.cpp:134:17:134:22 | *call to getenv | tests2.cpp:134:2:134:30 | *... = ... | provenance |  |
@@ -52,8 +52,8 @@ nodes
 | tests2.cpp:111:14:111:15 | *c1 [*ptr] | semmle.label | *c1 [*ptr] |
 | tests2.cpp:111:14:111:19 | *ptr | semmle.label | *ptr |
 | tests2.cpp:111:17:111:19 | *ptr | semmle.label | *ptr |
+| tests2.cpp:120:5:120:21 | [summary param] 0 indirection in zmq_msg_init_data [Return] | semmle.label | [summary param] 0 indirection in zmq_msg_init_data [Return] |
 | tests2.cpp:120:5:120:21 | [summary param] 1 indirection in zmq_msg_init_data | semmle.label | [summary param] 1 indirection in zmq_msg_init_data |
-| tests2.cpp:120:5:120:21 | [summary] to write: Argument[0 indirection] in zmq_msg_init_data | semmle.label | [summary] to write: Argument[0 indirection] in zmq_msg_init_data |
 | tests2.cpp:134:2:134:30 | *... = ... | semmle.label | *... = ... |
 | tests2.cpp:134:17:134:22 | *call to getenv | semmle.label | *call to getenv |
 | tests2.cpp:138:23:138:34 | *message_data | semmle.label | *message_data |
@@ -74,7 +74,7 @@ nodes
 | tests_sysconf.cpp:36:21:36:27 | confstr output argument | semmle.label | confstr output argument |
 | tests_sysconf.cpp:39:19:39:25 | *pathbuf | semmle.label | *pathbuf |
 subpaths
-| tests2.cpp:143:34:143:45 | *message_data | tests2.cpp:120:5:120:21 | [summary param] 1 indirection in zmq_msg_init_data | tests2.cpp:120:5:120:21 | [summary] to write: Argument[0 indirection] in zmq_msg_init_data | tests2.cpp:143:24:143:31 | zmq_msg_init_data output argument |
+| tests2.cpp:143:34:143:45 | *message_data | tests2.cpp:120:5:120:21 | [summary param] 1 indirection in zmq_msg_init_data | tests2.cpp:120:5:120:21 | [summary param] 0 indirection in zmq_msg_init_data [Return] | tests2.cpp:143:24:143:31 | zmq_msg_init_data output argument |
 #select
 | tests2.cpp:63:13:63:26 | *call to getenv | tests2.cpp:63:13:63:26 | *call to getenv | tests2.cpp:63:13:63:26 | *call to getenv | This operation exposes system data from $@. | tests2.cpp:63:13:63:26 | *call to getenv | *call to getenv |
 | tests2.cpp:64:13:64:26 | *call to getenv | tests2.cpp:64:13:64:26 | *call to getenv | tests2.cpp:64:13:64:26 | *call to getenv | This operation exposes system data from $@. | tests2.cpp:64:13:64:26 | *call to getenv | *call to getenv |

--- a/csharp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/csharp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -6,6 +6,29 @@
 private import CaptureModelsSpecific
 private import CaptureModelsPrinting
 
+/**
+ * A node from which flow can return to the caller. This is either a regular
+ * `ReturnNode` or a `PostUpdateNode` corresponding to the value of a parameter.
+ */
+private class ReturnNodeExt extends DataFlow::Node {
+  private DataFlowImplCommon::ReturnKindExt kind;
+
+  ReturnNodeExt() {
+    kind = DataFlowImplCommon::getValueReturnPosition(this).getKind() or
+    kind = DataFlowImplCommon::getParamReturnPosition(this, _).getKind()
+  }
+
+  string getOutput() {
+    kind instanceof DataFlowImplCommon::ValueReturnKind and
+    result = "ReturnValue"
+    or
+    exists(ParameterPosition pos |
+      pos = kind.(DataFlowImplCommon::ParamUpdateReturnKind).getPosition() and
+      result = paramReturnNodeAsOutput(returnNodeEnclosingCallable(this), pos)
+    )
+  }
+}
+
 class DataFlowTargetApi extends TargetApiSpecific {
   DataFlowTargetApi() { not isUninterestingForDataFlowModels(this) }
 }
@@ -65,7 +88,7 @@ string asInputArgument(DataFlow::Node source) { result = asInputArgumentSpecific
  * Gets the summary model of `api`, if it follows the `fluent` programming pattern (returns `this`).
  */
 string captureQualifierFlow(TargetApiSpecific api) {
-  exists(DataFlowImplCommon::ReturnNodeExt ret |
+  exists(ReturnNodeExt ret |
     api = returnNodeEnclosingCallable(ret) and
     isOwnInstanceAccessNode(ret)
   ) and
@@ -130,7 +153,7 @@ module ThroughFlowConfig implements DataFlow::StateConfigSig {
   }
 
   predicate isSink(DataFlow::Node sink, FlowState state) {
-    sink instanceof DataFlowImplCommon::ReturnNodeExt and
+    sink instanceof ReturnNodeExt and
     not isOwnInstanceAccessNode(sink) and
     not exists(captureQualifierFlow(sink.asExpr().getEnclosingCallable())) and
     (state instanceof TaintRead or state instanceof TaintStore)
@@ -171,14 +194,11 @@ private module ThroughFlow = TaintTracking::GlobalWithState<ThroughFlowConfig>;
  * Gets the summary model(s) of `api`, if there is flow from parameters to return value or parameter.
  */
 string captureThroughFlow(DataFlowTargetApi api) {
-  exists(
-    DataFlow::ParameterNode p, DataFlowImplCommon::ReturnNodeExt returnNodeExt, string input,
-    string output
-  |
+  exists(DataFlow::ParameterNode p, ReturnNodeExt returnNodeExt, string input, string output |
     ThroughFlow::flow(p, returnNodeExt) and
     returnNodeExt.(DataFlow::Node).getEnclosingCallable() = api and
     input = parameterNodeAsInput(p) and
-    output = returnNodeAsOutput(returnNodeExt) and
+    output = returnNodeExt.getOutput() and
     input != output and
     result = ModelPrinting::asTaintModel(api, input, output)
   )
@@ -196,7 +216,7 @@ module FromSourceConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node sink) {
     exists(DataFlowTargetApi c |
-      sink instanceof DataFlowImplCommon::ReturnNodeExt and
+      sink instanceof ReturnNodeExt and
       sink.getEnclosingCallable() = c
     )
   }
@@ -214,12 +234,12 @@ private module FromSource = TaintTracking::Global<FromSourceConfig>;
  * Gets the source model(s) of `api`, if there is flow from an existing known source to the return of `api`.
  */
 string captureSource(DataFlowTargetApi api) {
-  exists(DataFlow::Node source, DataFlow::Node sink, string kind |
+  exists(DataFlow::Node source, ReturnNodeExt sink, string kind |
     FromSource::flow(source, sink) and
     ExternalFlow::sourceNode(source, kind) and
     api = sink.getEnclosingCallable() and
     isRelevantSourceKind(kind) and
-    result = ModelPrinting::asSourceModel(api, returnNodeAsOutput(sink), kind)
+    result = ModelPrinting::asSourceModel(api, sink.getOutput(), kind)
   )
 }
 

--- a/csharp/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
+++ b/csharp/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
@@ -11,6 +11,7 @@ private import semmle.code.csharp.frameworks.system.linq.Expressions
 import semmle.code.csharp.dataflow.internal.ExternalFlow as ExternalFlow
 import semmle.code.csharp.dataflow.internal.DataFlowImplCommon as DataFlowImplCommon
 import semmle.code.csharp.dataflow.internal.DataFlowPrivate as DataFlowPrivate
+import semmle.code.csharp.dataflow.internal.DataFlowDispatch as DataFlowDispatch
 
 module DataFlow = CS::DataFlow;
 
@@ -133,32 +134,24 @@ string parameterAccess(CS::Parameter p) {
 
 class InstanceParameterNode = DataFlowPrivate::InstanceParameterNode;
 
-pragma[nomagic]
-private CS::Parameter getParameter(DataFlowImplCommon::ReturnNodeExt node, ParameterPosition pos) {
-  result = node.(DataFlow::Node).getEnclosingCallable().getParameter(pos.getPosition())
-}
+class ParameterPosition = DataFlowDispatch::ParameterPosition;
 
 /**
- * Gets the MaD string representation of the the return node `node`.
+ * Gets the MaD string represention of return through parameter at position
+ * `pos` of callable `c`.
  */
-string returnNodeAsOutput(DataFlowImplCommon::ReturnNodeExt node) {
-  if node.getKind() instanceof DataFlowImplCommon::ValueReturnKind
-  then result = "ReturnValue"
-  else
-    exists(ParameterPosition pos |
-      pos = node.getKind().(DataFlowImplCommon::ParamUpdateReturnKind).getPosition()
-    |
-      result = parameterAccess(getParameter(node, pos))
-      or
-      pos.isThisParameter() and
-      result = qualifierString()
-    )
+bindingset[c]
+string paramReturnNodeAsOutput(CS::Callable c, ParameterPosition pos) {
+  result = parameterAccess(c.getParameter(pos.getPosition()))
+  or
+  pos.isThisParameter() and
+  result = qualifierString()
 }
 
 /**
  * Gets the enclosing callable of `ret`.
  */
-CS::Callable returnNodeEnclosingCallable(DataFlowImplCommon::ReturnNodeExt ret) {
+CS::Callable returnNodeEnclosingCallable(DataFlow::Node ret) {
   result = DataFlowImplCommon::getNodeEnclosingCallable(ret).asCallable()
 }
 

--- a/csharp/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
+++ b/csharp/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
@@ -137,7 +137,7 @@ class InstanceParameterNode = DataFlowPrivate::InstanceParameterNode;
 class ParameterPosition = DataFlowDispatch::ParameterPosition;
 
 /**
- * Gets the MaD string represention of return through parameter at position
+ * Gets the MaD string representation of return through parameter at position
  * `pos` of callable `c`.
  */
 bindingset[c]

--- a/csharp/ql/test/library-tests/dataflow/collections/CollectionFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/collections/CollectionFlow.expected
@@ -216,6 +216,7 @@ edges
 | CollectionFlow.cs:309:21:309:23 | kvp : KeyValuePair<T,T> [property Key] : A | CollectionFlow.cs:311:18:311:20 | access to parameter kvp : KeyValuePair<T,T> [property Key] : A | provenance |  |
 | CollectionFlow.cs:311:18:311:20 | access to parameter kvp : KeyValuePair<T,T> [property Key] : A | CollectionFlow.cs:311:18:311:24 | access to property Key | provenance |  |
 | CollectionFlow.cs:328:32:328:38 | element : A | CollectionFlow.cs:328:55:328:61 | access to parameter element : A | provenance |  |
+| CollectionFlow.cs:328:44:328:48 | [post] access to parameter array : A[] [element] : A | CollectionFlow.cs:328:23:328:27 | array [Return] : A[] [element] : A | provenance |  |
 | CollectionFlow.cs:328:55:328:61 | access to parameter element : A | CollectionFlow.cs:328:44:328:48 | [post] access to parameter array : A[] [element] : A | provenance |  |
 | CollectionFlow.cs:332:13:332:13 | access to local variable a : A | CollectionFlow.cs:334:23:334:23 | access to local variable a : A | provenance |  |
 | CollectionFlow.cs:332:17:332:23 | object creation of type A : A | CollectionFlow.cs:332:13:332:13 | access to local variable a : A | provenance |  |
@@ -229,6 +230,7 @@ edges
 | CollectionFlow.cs:337:20:337:22 | access to local variable as : A[] [element] : A | CollectionFlow.cs:22:34:22:35 | ts : A[] [element] : A | provenance |  |
 | CollectionFlow.cs:337:20:337:22 | access to local variable as : A[] [element] : A | CollectionFlow.cs:337:14:337:23 | call to method First<A> | provenance |  |
 | CollectionFlow.cs:350:34:350:40 | element : A | CollectionFlow.cs:350:55:350:61 | access to parameter element : A | provenance |  |
+| CollectionFlow.cs:350:46:350:49 | [post] access to parameter list : List<T> [element] : A | CollectionFlow.cs:350:26:350:29 | list [Return] : List<T> [element] : A | provenance |  |
 | CollectionFlow.cs:350:55:350:61 | access to parameter element : A | CollectionFlow.cs:350:46:350:49 | [post] access to parameter list : List<T> [element] : A | provenance | MaD:605 |
 | CollectionFlow.cs:354:13:354:13 | access to local variable a : A | CollectionFlow.cs:356:23:356:23 | access to local variable a : A | provenance |  |
 | CollectionFlow.cs:354:17:354:23 | object creation of type A : A | CollectionFlow.cs:354:13:354:13 | access to local variable a : A | provenance |  |
@@ -520,6 +522,7 @@ nodes
 | CollectionFlow.cs:309:21:309:23 | kvp : KeyValuePair<T,T> [property Key] : A | semmle.label | kvp : KeyValuePair<T,T> [property Key] : A |
 | CollectionFlow.cs:311:18:311:20 | access to parameter kvp : KeyValuePair<T,T> [property Key] : A | semmle.label | access to parameter kvp : KeyValuePair<T,T> [property Key] : A |
 | CollectionFlow.cs:311:18:311:24 | access to property Key | semmle.label | access to property Key |
+| CollectionFlow.cs:328:23:328:27 | array [Return] : A[] [element] : A | semmle.label | array [Return] : A[] [element] : A |
 | CollectionFlow.cs:328:32:328:38 | element : A | semmle.label | element : A |
 | CollectionFlow.cs:328:44:328:48 | [post] access to parameter array : A[] [element] : A | semmle.label | [post] access to parameter array : A[] [element] : A |
 | CollectionFlow.cs:328:55:328:61 | access to parameter element : A | semmle.label | access to parameter element : A |
@@ -532,6 +535,7 @@ nodes
 | CollectionFlow.cs:336:18:336:20 | access to local variable as : A[] [element] : A | semmle.label | access to local variable as : A[] [element] : A |
 | CollectionFlow.cs:337:14:337:23 | call to method First<A> | semmle.label | call to method First<A> |
 | CollectionFlow.cs:337:20:337:22 | access to local variable as : A[] [element] : A | semmle.label | access to local variable as : A[] [element] : A |
+| CollectionFlow.cs:350:26:350:29 | list [Return] : List<T> [element] : A | semmle.label | list [Return] : List<T> [element] : A |
 | CollectionFlow.cs:350:34:350:40 | element : A | semmle.label | element : A |
 | CollectionFlow.cs:350:46:350:49 | [post] access to parameter list : List<T> [element] : A | semmle.label | [post] access to parameter list : List<T> [element] : A |
 | CollectionFlow.cs:350:55:350:61 | access to parameter element : A | semmle.label | access to parameter element : A |
@@ -640,9 +644,9 @@ subpaths
 | CollectionFlow.cs:222:27:222:30 | access to local variable dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:34:57:34:60 | dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:34:66:34:81 | access to property Key : A | CollectionFlow.cs:222:14:222:31 | call to method DictFirstKey<A> |
 | CollectionFlow.cs:240:28:240:31 | access to local variable dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:32:58:32:61 | dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:32:67:32:83 | call to method First<T> : A | CollectionFlow.cs:240:14:240:32 | call to method DictKeysFirst<A> |
 | CollectionFlow.cs:241:27:241:30 | access to local variable dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:34:57:34:60 | dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:34:66:34:81 | access to property Key : A | CollectionFlow.cs:241:14:241:31 | call to method DictFirstKey<A> |
-| CollectionFlow.cs:334:23:334:23 | access to local variable a : A | CollectionFlow.cs:328:32:328:38 | element : A | CollectionFlow.cs:328:44:328:48 | [post] access to parameter array : A[] [element] : A | CollectionFlow.cs:334:18:334:20 | [post] access to local variable as : A[] [element] : A |
+| CollectionFlow.cs:334:23:334:23 | access to local variable a : A | CollectionFlow.cs:328:32:328:38 | element : A | CollectionFlow.cs:328:23:328:27 | array [Return] : A[] [element] : A | CollectionFlow.cs:334:18:334:20 | [post] access to local variable as : A[] [element] : A |
 | CollectionFlow.cs:337:20:337:22 | access to local variable as : A[] [element] : A | CollectionFlow.cs:22:34:22:35 | ts : A[] [element] : A | CollectionFlow.cs:22:41:22:45 | access to array element : A | CollectionFlow.cs:337:14:337:23 | call to method First<A> |
-| CollectionFlow.cs:356:23:356:23 | access to local variable a : A | CollectionFlow.cs:350:34:350:40 | element : A | CollectionFlow.cs:350:46:350:49 | [post] access to parameter list : List<T> [element] : A | CollectionFlow.cs:356:17:356:20 | [post] access to local variable list : List<T> [element] : A |
+| CollectionFlow.cs:356:23:356:23 | access to local variable a : A | CollectionFlow.cs:350:34:350:40 | element : A | CollectionFlow.cs:350:26:350:29 | list [Return] : List<T> [element] : A | CollectionFlow.cs:356:17:356:20 | [post] access to local variable list : List<T> [element] : A |
 | CollectionFlow.cs:359:24:359:27 | access to local variable list : List<T> [element] : A | CollectionFlow.cs:24:43:24:46 | list : List<T> [element] : A | CollectionFlow.cs:24:52:24:58 | access to indexer : A | CollectionFlow.cs:359:14:359:28 | call to method ListFirst<A> |
 #select
 | CollectionFlow.cs:40:17:40:23 | object creation of type A : A | CollectionFlow.cs:40:17:40:23 | object creation of type A : A | CollectionFlow.cs:14:52:14:56 | access to array element | $@ | CollectionFlow.cs:14:52:14:56 | access to array element | access to array element |

--- a/csharp/ql/test/library-tests/dataflow/constructors/ConstructorFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/constructors/ConstructorFlow.expected
@@ -7,25 +7,31 @@ edges
 | Constructors.cs:10:13:10:13 | access to local variable c : C_no_ctor [field s1] : Object | Constructors.cs:13:21:13:22 | this : C_no_ctor [field s1] : Object | provenance |  |
 | Constructors.cs:13:21:13:22 | this : C_no_ctor [field s1] : Object | Constructors.cs:15:18:15:19 | this access : C_no_ctor [field s1] : Object | provenance |  |
 | Constructors.cs:15:18:15:19 | this access : C_no_ctor [field s1] : Object | Constructors.cs:15:18:15:19 | access to field s1 | provenance |  |
-| Constructors.cs:21:24:21:25 | [post] this access : C_with_ctor [field s1] : Object | Constructors.cs:25:29:25:45 | object creation of type C_with_ctor : C_with_ctor [field s1] : Object | provenance |  |
+| Constructors.cs:21:24:21:25 | [post] this access : C_with_ctor [field s1] : Object | Constructors.cs:29:16:29:26 | this [Return] : C_with_ctor [field s1] : Object | provenance |  |
 | Constructors.cs:21:29:21:45 | call to method Source<Object> : Object | Constructors.cs:21:24:21:25 | [post] this access : C_with_ctor [field s1] : Object | provenance |  |
 | Constructors.cs:25:25:25:25 | access to local variable c : C_with_ctor [field s1] : Object | Constructors.cs:26:13:26:13 | access to local variable c : C_with_ctor [field s1] : Object | provenance |  |
 | Constructors.cs:25:29:25:45 | object creation of type C_with_ctor : C_with_ctor [field s1] : Object | Constructors.cs:25:25:25:25 | access to local variable c : C_with_ctor [field s1] : Object | provenance |  |
 | Constructors.cs:26:13:26:13 | access to local variable c : C_with_ctor [field s1] : Object | Constructors.cs:31:21:31:22 | this : C_with_ctor [field s1] : Object | provenance |  |
+| Constructors.cs:29:16:29:26 | this [Return] : C_with_ctor [field s1] : Object | Constructors.cs:25:29:25:45 | object creation of type C_with_ctor : C_with_ctor [field s1] : Object | provenance |  |
 | Constructors.cs:31:21:31:22 | this : C_with_ctor [field s1] : Object | Constructors.cs:33:18:33:19 | this access : C_with_ctor [field s1] : Object | provenance |  |
 | Constructors.cs:33:18:33:19 | this access : C_with_ctor [field s1] : Object | Constructors.cs:33:18:33:19 | access to field s1 | provenance |  |
 | Constructors.cs:41:26:41:26 | o : Object | Constructors.cs:41:38:41:38 | access to parameter o : Object | provenance |  |
+| Constructors.cs:41:32:41:34 | [post] this access : C1 [field Obj] : Object | Constructors.cs:41:16:41:17 | this [Return] : C1 [field Obj] : Object | provenance |  |
 | Constructors.cs:41:38:41:38 | access to parameter o : Object | Constructors.cs:41:32:41:34 | [post] this access : C1 [field Obj] : Object | provenance |  |
 | Constructors.cs:44:28:44:35 | o21param : Object | Constructors.cs:46:23:46:27 | this access : C2 [parameter o21param] : Object | provenance |  |
 | Constructors.cs:44:28:44:35 | o21param : Object | Constructors.cs:46:31:46:38 | access to parameter o21param : Object | provenance |  |
+| Constructors.cs:44:45:44:52 | o22param : Object | Constructors.cs:44:18:44:19 | this [Return] : C2 [parameter o22param] : Object | provenance |  |
+| Constructors.cs:46:23:46:27 | [post] this access : C2 [field Obj21] : Object | Constructors.cs:44:18:44:19 | this [Return] : C2 [field Obj21] : Object | provenance |  |
 | Constructors.cs:46:23:46:27 | this access : C2 [parameter o21param] : Object | Constructors.cs:46:31:46:38 | access to parameter o21param : Object | provenance |  |
 | Constructors.cs:46:31:46:38 | access to parameter o21param : Object | Constructors.cs:46:23:46:27 | [post] this access : C2 [field Obj21] : Object | provenance |  |
 | Constructors.cs:48:32:48:39 | this : C2 [parameter o22param] : Object | Constructors.cs:48:32:48:39 | access to parameter o22param : Object | provenance |  |
 | Constructors.cs:50:32:50:36 | this : C2 [field Obj21] : Object | Constructors.cs:50:32:50:36 | this access : C2 [field Obj21] : Object | provenance |  |
 | Constructors.cs:50:32:50:36 | this access : C2 [field Obj21] : Object | Constructors.cs:50:32:50:36 | access to field Obj21 : Object | provenance |  |
 | Constructors.cs:52:35:52:35 | o : Object | Constructors.cs:54:13:54:20 | access to parameter o22param : Object | provenance |  |
+| Constructors.cs:54:13:54:20 | access to parameter o22param : Object | Constructors.cs:52:21:52:26 | this [Return] : C2 [parameter o22param] : Object | provenance |  |
 | Constructors.cs:57:54:57:55 | o2 : Object | Constructors.cs:59:13:59:14 | access to parameter o1 : Object | provenance |  |
 | Constructors.cs:62:41:62:41 | o : Object | Constructors.cs:64:37:64:37 | access to parameter o : Object | provenance |  |
+| Constructors.cs:64:27:64:34 | access to parameter o22param : Object | Constructors.cs:62:21:62:32 | this [Return] : C2 [parameter o22param] : Object | provenance |  |
 | Constructors.cs:64:37:64:37 | access to parameter o : Object | Constructors.cs:57:54:57:55 | o2 : Object | provenance |  |
 | Constructors.cs:64:37:64:37 | access to parameter o : Object | Constructors.cs:64:27:64:34 | access to parameter o22param : Object | provenance |  |
 | Constructors.cs:70:13:70:13 | access to local variable o : Object | Constructors.cs:71:25:71:25 | access to local variable o : Object | provenance |  |
@@ -67,6 +73,7 @@ edges
 | Constructors.cs:100:25:100:29 | access to local variable taint : Object | Constructors.cs:100:9:100:10 | [post] access to local variable c2 : C2 [parameter o22param] : Object | provenance |  |
 | Constructors.cs:101:14:101:15 | access to local variable c2 : C2 [parameter o22param] : Object | Constructors.cs:48:32:48:39 | this : C2 [parameter o22param] : Object | provenance |  |
 | Constructors.cs:101:14:101:15 | access to local variable c2 : C2 [parameter o22param] : Object | Constructors.cs:101:14:101:21 | access to property Obj22 | provenance |  |
+| Constructors.cs:104:28:104:35 | o31param : Object | Constructors.cs:104:18:104:19 | this [Return] : C3 [parameter o31param] : Object | provenance |  |
 | Constructors.cs:106:32:106:39 | this : C3 [parameter o31param] : Object | Constructors.cs:106:32:106:39 | access to parameter o31param : Object | provenance |  |
 | Constructors.cs:111:13:111:15 | access to local variable o31 : Object | Constructors.cs:112:25:112:27 | access to local variable o31 : Object | provenance |  |
 | Constructors.cs:111:19:111:35 | call to method Source<Object> : Object | Constructors.cs:111:13:111:15 | access to local variable o31 : Object | provenance |  |
@@ -78,7 +85,9 @@ edges
 | Constructors.cs:113:14:113:15 | access to local variable c3 : C3 [parameter o31param] : Object | Constructors.cs:113:14:113:21 | access to property Obj31 | provenance |  |
 | Constructors.cs:121:26:121:28 | oc1 : Object | Constructors.cs:123:20:123:22 | access to parameter oc1 : Object | provenance |  |
 | Constructors.cs:121:38:121:40 | oc2 : Object | Constructors.cs:124:20:124:22 | access to parameter oc2 : Object | provenance |  |
+| Constructors.cs:123:13:123:16 | [post] this access : C4 [property Obj1] : Object | Constructors.cs:121:16:121:17 | this [Return] : C4 [property Obj1] : Object | provenance |  |
 | Constructors.cs:123:20:123:22 | access to parameter oc1 : Object | Constructors.cs:123:13:123:16 | [post] this access : C4 [property Obj1] : Object | provenance |  |
+| Constructors.cs:124:13:124:16 | [post] this access : C4 [property Obj2] : Object | Constructors.cs:121:16:121:17 | this [Return] : C4 [property Obj2] : Object | provenance |  |
 | Constructors.cs:124:20:124:22 | access to parameter oc2 : Object | Constructors.cs:124:13:124:16 | [post] this access : C4 [property Obj2] : Object | provenance |  |
 | Constructors.cs:130:13:130:14 | access to local variable o1 : Object | Constructors.cs:132:25:132:26 | access to local variable o1 : Object | provenance |  |
 | Constructors.cs:130:18:130:34 | call to method Source<Object> : Object | Constructors.cs:130:13:130:14 | access to local variable o1 : Object | provenance |  |
@@ -94,6 +103,8 @@ edges
 | Constructors.cs:132:29:132:30 | access to local variable o2 : Object | Constructors.cs:132:18:132:31 | object creation of type C4 : C4 [property Obj2] : Object | provenance |  |
 | Constructors.cs:133:14:133:15 | access to local variable c4 : C4 [property Obj1] : Object | Constructors.cs:133:14:133:20 | access to property Obj1 | provenance |  |
 | Constructors.cs:134:14:134:15 | access to local variable c4 : C4 [property Obj2] : Object | Constructors.cs:134:14:134:20 | access to property Obj2 | provenance |  |
+| Constructors.cs:137:29:137:32 | Obj1 : Object | Constructors.cs:137:19:137:20 | this [Return] : R1 [property Obj1] : Object | provenance |  |
+| Constructors.cs:137:42:137:45 | Obj2 : Object | Constructors.cs:137:19:137:20 | this [Return] : R1 [property Obj2] : Object | provenance |  |
 | Constructors.cs:141:13:141:14 | access to local variable o1 : Object | Constructors.cs:143:25:143:26 | access to local variable o1 : Object | provenance |  |
 | Constructors.cs:141:18:141:34 | call to method Source<Object> : Object | Constructors.cs:141:13:141:14 | access to local variable o1 : Object | provenance |  |
 | Constructors.cs:142:13:142:14 | access to local variable o2 : Object | Constructors.cs:143:29:143:30 | access to local variable o2 : Object | provenance |  |
@@ -122,12 +133,16 @@ nodes
 | Constructors.cs:25:25:25:25 | access to local variable c : C_with_ctor [field s1] : Object | semmle.label | access to local variable c : C_with_ctor [field s1] : Object |
 | Constructors.cs:25:29:25:45 | object creation of type C_with_ctor : C_with_ctor [field s1] : Object | semmle.label | object creation of type C_with_ctor : C_with_ctor [field s1] : Object |
 | Constructors.cs:26:13:26:13 | access to local variable c : C_with_ctor [field s1] : Object | semmle.label | access to local variable c : C_with_ctor [field s1] : Object |
+| Constructors.cs:29:16:29:26 | this [Return] : C_with_ctor [field s1] : Object | semmle.label | this [Return] : C_with_ctor [field s1] : Object |
 | Constructors.cs:31:21:31:22 | this : C_with_ctor [field s1] : Object | semmle.label | this : C_with_ctor [field s1] : Object |
 | Constructors.cs:33:18:33:19 | access to field s1 | semmle.label | access to field s1 |
 | Constructors.cs:33:18:33:19 | this access : C_with_ctor [field s1] : Object | semmle.label | this access : C_with_ctor [field s1] : Object |
+| Constructors.cs:41:16:41:17 | this [Return] : C1 [field Obj] : Object | semmle.label | this [Return] : C1 [field Obj] : Object |
 | Constructors.cs:41:26:41:26 | o : Object | semmle.label | o : Object |
 | Constructors.cs:41:32:41:34 | [post] this access : C1 [field Obj] : Object | semmle.label | [post] this access : C1 [field Obj] : Object |
 | Constructors.cs:41:38:41:38 | access to parameter o : Object | semmle.label | access to parameter o : Object |
+| Constructors.cs:44:18:44:19 | this [Return] : C2 [field Obj21] : Object | semmle.label | this [Return] : C2 [field Obj21] : Object |
+| Constructors.cs:44:18:44:19 | this [Return] : C2 [parameter o22param] : Object | semmle.label | this [Return] : C2 [parameter o22param] : Object |
 | Constructors.cs:44:28:44:35 | o21param : Object | semmle.label | o21param : Object |
 | Constructors.cs:44:45:44:52 | o22param : Object | semmle.label | o22param : Object |
 | Constructors.cs:46:23:46:27 | [post] this access : C2 [field Obj21] : Object | semmle.label | [post] this access : C2 [field Obj21] : Object |
@@ -138,10 +153,12 @@ nodes
 | Constructors.cs:50:32:50:36 | access to field Obj21 : Object | semmle.label | access to field Obj21 : Object |
 | Constructors.cs:50:32:50:36 | this : C2 [field Obj21] : Object | semmle.label | this : C2 [field Obj21] : Object |
 | Constructors.cs:50:32:50:36 | this access : C2 [field Obj21] : Object | semmle.label | this access : C2 [field Obj21] : Object |
+| Constructors.cs:52:21:52:26 | this [Return] : C2 [parameter o22param] : Object | semmle.label | this [Return] : C2 [parameter o22param] : Object |
 | Constructors.cs:52:35:52:35 | o : Object | semmle.label | o : Object |
 | Constructors.cs:54:13:54:20 | access to parameter o22param : Object | semmle.label | access to parameter o22param : Object |
 | Constructors.cs:57:54:57:55 | o2 : Object | semmle.label | o2 : Object |
 | Constructors.cs:59:13:59:14 | access to parameter o1 : Object | semmle.label | access to parameter o1 : Object |
+| Constructors.cs:62:21:62:32 | this [Return] : C2 [parameter o22param] : Object | semmle.label | this [Return] : C2 [parameter o22param] : Object |
 | Constructors.cs:62:41:62:41 | o : Object | semmle.label | o : Object |
 | Constructors.cs:64:27:64:34 | access to parameter o22param : Object | semmle.label | access to parameter o22param : Object |
 | Constructors.cs:64:37:64:37 | access to parameter o : Object | semmle.label | access to parameter o : Object |
@@ -180,6 +197,7 @@ nodes
 | Constructors.cs:100:25:100:29 | access to local variable taint : Object | semmle.label | access to local variable taint : Object |
 | Constructors.cs:101:14:101:15 | access to local variable c2 : C2 [parameter o22param] : Object | semmle.label | access to local variable c2 : C2 [parameter o22param] : Object |
 | Constructors.cs:101:14:101:21 | access to property Obj22 | semmle.label | access to property Obj22 |
+| Constructors.cs:104:18:104:19 | this [Return] : C3 [parameter o31param] : Object | semmle.label | this [Return] : C3 [parameter o31param] : Object |
 | Constructors.cs:104:28:104:35 | o31param : Object | semmle.label | o31param : Object |
 | Constructors.cs:106:32:106:39 | access to parameter o31param : Object | semmle.label | access to parameter o31param : Object |
 | Constructors.cs:106:32:106:39 | this : C3 [parameter o31param] : Object | semmle.label | this : C3 [parameter o31param] : Object |
@@ -190,6 +208,8 @@ nodes
 | Constructors.cs:112:25:112:27 | access to local variable o31 : Object | semmle.label | access to local variable o31 : Object |
 | Constructors.cs:113:14:113:15 | access to local variable c3 : C3 [parameter o31param] : Object | semmle.label | access to local variable c3 : C3 [parameter o31param] : Object |
 | Constructors.cs:113:14:113:21 | access to property Obj31 | semmle.label | access to property Obj31 |
+| Constructors.cs:121:16:121:17 | this [Return] : C4 [property Obj1] : Object | semmle.label | this [Return] : C4 [property Obj1] : Object |
+| Constructors.cs:121:16:121:17 | this [Return] : C4 [property Obj2] : Object | semmle.label | this [Return] : C4 [property Obj2] : Object |
 | Constructors.cs:121:26:121:28 | oc1 : Object | semmle.label | oc1 : Object |
 | Constructors.cs:121:38:121:40 | oc2 : Object | semmle.label | oc2 : Object |
 | Constructors.cs:123:13:123:16 | [post] this access : C4 [property Obj1] : Object | semmle.label | [post] this access : C4 [property Obj1] : Object |
@@ -210,6 +230,8 @@ nodes
 | Constructors.cs:133:14:133:20 | access to property Obj1 | semmle.label | access to property Obj1 |
 | Constructors.cs:134:14:134:15 | access to local variable c4 : C4 [property Obj2] : Object | semmle.label | access to local variable c4 : C4 [property Obj2] : Object |
 | Constructors.cs:134:14:134:20 | access to property Obj2 | semmle.label | access to property Obj2 |
+| Constructors.cs:137:19:137:20 | this [Return] : R1 [property Obj1] : Object | semmle.label | this [Return] : R1 [property Obj1] : Object |
+| Constructors.cs:137:19:137:20 | this [Return] : R1 [property Obj2] : Object | semmle.label | this [Return] : R1 [property Obj2] : Object |
 | Constructors.cs:137:29:137:32 | Obj1 : Object | semmle.label | Obj1 : Object |
 | Constructors.cs:137:42:137:45 | Obj2 : Object | semmle.label | Obj2 : Object |
 | Constructors.cs:141:13:141:14 | access to local variable o1 : Object | semmle.label | access to local variable o1 : Object |
@@ -228,21 +250,21 @@ nodes
 | Constructors.cs:145:14:145:20 | access to property Obj2 | semmle.label | access to property Obj2 |
 subpaths
 | Constructors.cs:64:37:64:37 | access to parameter o : Object | Constructors.cs:57:54:57:55 | o2 : Object | Constructors.cs:59:13:59:14 | access to parameter o1 : Object | Constructors.cs:64:27:64:34 | access to parameter o22param : Object |
-| Constructors.cs:71:25:71:25 | access to local variable o : Object | Constructors.cs:41:26:41:26 | o : Object | Constructors.cs:41:32:41:34 | [post] this access : C1 [field Obj] : Object | Constructors.cs:71:18:71:26 | object creation of type C1 : C1 [field Obj] : Object |
-| Constructors.cs:79:25:79:27 | access to local variable o21 : Object | Constructors.cs:44:28:44:35 | o21param : Object | Constructors.cs:46:23:46:27 | [post] this access : C2 [field Obj21] : Object | Constructors.cs:79:18:79:33 | object creation of type C2 : C2 [field Obj21] : Object |
-| Constructors.cs:79:30:79:32 | access to local variable o22 : Object | Constructors.cs:44:45:44:52 | o22param : Object | Constructors.cs:44:45:44:52 | o22param : Object | Constructors.cs:79:18:79:33 | object creation of type C2 : C2 [parameter o22param] : Object |
+| Constructors.cs:71:25:71:25 | access to local variable o : Object | Constructors.cs:41:26:41:26 | o : Object | Constructors.cs:41:16:41:17 | this [Return] : C1 [field Obj] : Object | Constructors.cs:71:18:71:26 | object creation of type C1 : C1 [field Obj] : Object |
+| Constructors.cs:79:25:79:27 | access to local variable o21 : Object | Constructors.cs:44:28:44:35 | o21param : Object | Constructors.cs:44:18:44:19 | this [Return] : C2 [field Obj21] : Object | Constructors.cs:79:18:79:33 | object creation of type C2 : C2 [field Obj21] : Object |
+| Constructors.cs:79:30:79:32 | access to local variable o22 : Object | Constructors.cs:44:45:44:52 | o22param : Object | Constructors.cs:44:18:44:19 | this [Return] : C2 [parameter o22param] : Object | Constructors.cs:79:18:79:33 | object creation of type C2 : C2 [parameter o22param] : Object |
 | Constructors.cs:81:14:81:15 | access to local variable c2 : C2 [parameter o22param] : Object | Constructors.cs:48:32:48:39 | this : C2 [parameter o22param] : Object | Constructors.cs:48:32:48:39 | access to parameter o22param : Object | Constructors.cs:81:14:81:21 | access to property Obj22 |
 | Constructors.cs:82:14:82:15 | access to local variable c2 : C2 [field Obj21] : Object | Constructors.cs:50:32:50:36 | this : C2 [field Obj21] : Object | Constructors.cs:50:32:50:36 | access to field Obj21 : Object | Constructors.cs:82:14:82:21 | access to property Obj23 |
-| Constructors.cs:92:19:92:23 | access to local variable taint : Object | Constructors.cs:52:35:52:35 | o : Object | Constructors.cs:54:13:54:20 | access to parameter o22param : Object | Constructors.cs:92:9:92:10 | [post] access to local variable c2 : C2 [parameter o22param] : Object |
+| Constructors.cs:92:19:92:23 | access to local variable taint : Object | Constructors.cs:52:35:52:35 | o : Object | Constructors.cs:52:21:52:26 | this [Return] : C2 [parameter o22param] : Object | Constructors.cs:92:9:92:10 | [post] access to local variable c2 : C2 [parameter o22param] : Object |
 | Constructors.cs:93:14:93:15 | access to local variable c2 : C2 [parameter o22param] : Object | Constructors.cs:48:32:48:39 | this : C2 [parameter o22param] : Object | Constructors.cs:48:32:48:39 | access to parameter o22param : Object | Constructors.cs:93:14:93:21 | access to property Obj22 |
-| Constructors.cs:100:25:100:29 | access to local variable taint : Object | Constructors.cs:62:41:62:41 | o : Object | Constructors.cs:64:27:64:34 | access to parameter o22param : Object | Constructors.cs:100:9:100:10 | [post] access to local variable c2 : C2 [parameter o22param] : Object |
+| Constructors.cs:100:25:100:29 | access to local variable taint : Object | Constructors.cs:62:41:62:41 | o : Object | Constructors.cs:62:21:62:32 | this [Return] : C2 [parameter o22param] : Object | Constructors.cs:100:9:100:10 | [post] access to local variable c2 : C2 [parameter o22param] : Object |
 | Constructors.cs:101:14:101:15 | access to local variable c2 : C2 [parameter o22param] : Object | Constructors.cs:48:32:48:39 | this : C2 [parameter o22param] : Object | Constructors.cs:48:32:48:39 | access to parameter o22param : Object | Constructors.cs:101:14:101:21 | access to property Obj22 |
-| Constructors.cs:112:25:112:27 | access to local variable o31 : Object | Constructors.cs:104:28:104:35 | o31param : Object | Constructors.cs:104:28:104:35 | o31param : Object | Constructors.cs:112:18:112:28 | object creation of type C3 : C3 [parameter o31param] : Object |
+| Constructors.cs:112:25:112:27 | access to local variable o31 : Object | Constructors.cs:104:28:104:35 | o31param : Object | Constructors.cs:104:18:104:19 | this [Return] : C3 [parameter o31param] : Object | Constructors.cs:112:18:112:28 | object creation of type C3 : C3 [parameter o31param] : Object |
 | Constructors.cs:113:14:113:15 | access to local variable c3 : C3 [parameter o31param] : Object | Constructors.cs:106:32:106:39 | this : C3 [parameter o31param] : Object | Constructors.cs:106:32:106:39 | access to parameter o31param : Object | Constructors.cs:113:14:113:21 | access to property Obj31 |
-| Constructors.cs:132:25:132:26 | access to local variable o1 : Object | Constructors.cs:121:26:121:28 | oc1 : Object | Constructors.cs:123:13:123:16 | [post] this access : C4 [property Obj1] : Object | Constructors.cs:132:18:132:31 | object creation of type C4 : C4 [property Obj1] : Object |
-| Constructors.cs:132:29:132:30 | access to local variable o2 : Object | Constructors.cs:121:38:121:40 | oc2 : Object | Constructors.cs:124:13:124:16 | [post] this access : C4 [property Obj2] : Object | Constructors.cs:132:18:132:31 | object creation of type C4 : C4 [property Obj2] : Object |
-| Constructors.cs:143:25:143:26 | access to local variable o1 : Object | Constructors.cs:137:29:137:32 | Obj1 : Object | Constructors.cs:137:29:137:32 | Obj1 : Object | Constructors.cs:143:18:143:31 | object creation of type R1 : R1 [property Obj1] : Object |
-| Constructors.cs:143:29:143:30 | access to local variable o2 : Object | Constructors.cs:137:42:137:45 | Obj2 : Object | Constructors.cs:137:42:137:45 | Obj2 : Object | Constructors.cs:143:18:143:31 | object creation of type R1 : R1 [property Obj2] : Object |
+| Constructors.cs:132:25:132:26 | access to local variable o1 : Object | Constructors.cs:121:26:121:28 | oc1 : Object | Constructors.cs:121:16:121:17 | this [Return] : C4 [property Obj1] : Object | Constructors.cs:132:18:132:31 | object creation of type C4 : C4 [property Obj1] : Object |
+| Constructors.cs:132:29:132:30 | access to local variable o2 : Object | Constructors.cs:121:38:121:40 | oc2 : Object | Constructors.cs:121:16:121:17 | this [Return] : C4 [property Obj2] : Object | Constructors.cs:132:18:132:31 | object creation of type C4 : C4 [property Obj2] : Object |
+| Constructors.cs:143:25:143:26 | access to local variable o1 : Object | Constructors.cs:137:29:137:32 | Obj1 : Object | Constructors.cs:137:19:137:20 | this [Return] : R1 [property Obj1] : Object | Constructors.cs:143:18:143:31 | object creation of type R1 : R1 [property Obj1] : Object |
+| Constructors.cs:143:29:143:30 | access to local variable o2 : Object | Constructors.cs:137:42:137:45 | Obj2 : Object | Constructors.cs:137:19:137:20 | this [Return] : R1 [property Obj2] : Object | Constructors.cs:143:18:143:31 | object creation of type R1 : R1 [property Obj2] : Object |
 #select
 | Constructors.cs:15:18:15:19 | access to field s1 | Constructors.cs:5:29:5:45 | call to method Source<Object> : Object | Constructors.cs:15:18:15:19 | access to field s1 | $@ | Constructors.cs:5:29:5:45 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | Constructors.cs:33:18:33:19 | access to field s1 | Constructors.cs:21:29:21:45 | call to method Source<Object> : Object | Constructors.cs:33:18:33:19 | access to field s1 | $@ | Constructors.cs:21:29:21:45 | call to method Source<Object> : Object | call to method Source<Object> : Object |

--- a/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
@@ -84,8 +84,10 @@ edges
 | A.cs:60:22:60:22 | c : C1 [field a] : A | A.cs:64:19:64:23 | (...) ... : C1 [field a] : A | provenance |  |
 | A.cs:64:19:64:23 | (...) ... : C1 [field a] : A | A.cs:64:18:64:26 | access to field a | provenance |  |
 | A.cs:64:19:64:23 | (...) ... : C1 [field a] : A | A.cs:64:18:64:26 | access to field a | provenance |  |
-| A.cs:83:9:83:9 | [post] access to parameter b : B [field c] : C | A.cs:88:12:88:12 | [post] access to local variable b : B [field c] : C | provenance |  |
-| A.cs:83:9:83:9 | [post] access to parameter b : B [field c] : C | A.cs:88:12:88:12 | [post] access to local variable b : B [field c] : C | provenance |  |
+| A.cs:81:22:81:22 | b [Return] : B [field c] : C | A.cs:88:12:88:12 | [post] access to local variable b : B [field c] : C | provenance |  |
+| A.cs:81:22:81:22 | b [Return] : B [field c] : C | A.cs:88:12:88:12 | [post] access to local variable b : B [field c] : C | provenance |  |
+| A.cs:83:9:83:9 | [post] access to parameter b : B [field c] : C | A.cs:81:22:81:22 | b [Return] : B [field c] : C | provenance |  |
+| A.cs:83:9:83:9 | [post] access to parameter b : B [field c] : C | A.cs:81:22:81:22 | b [Return] : B [field c] : C | provenance |  |
 | A.cs:83:15:83:26 | call to method Source<C> : C | A.cs:83:9:83:9 | [post] access to parameter b : B [field c] : C | provenance |  |
 | A.cs:83:15:83:26 | call to method Source<C> : C | A.cs:83:9:83:9 | [post] access to parameter b : B [field c] : C | provenance |  |
 | A.cs:83:15:83:26 | call to method Source<C> : C | A.cs:145:27:145:27 | c : C | provenance |  |
@@ -94,20 +96,28 @@ edges
 | A.cs:88:12:88:12 | [post] access to local variable b : B [field c] : C | A.cs:89:14:89:14 | access to local variable b : B [field c] : C | provenance |  |
 | A.cs:89:14:89:14 | access to local variable b : B [field c] : C | A.cs:89:14:89:16 | access to field c | provenance |  |
 | A.cs:89:14:89:14 | access to local variable b : B [field c] : C | A.cs:89:14:89:16 | access to field c | provenance |  |
+| A.cs:95:16:95:16 | this [Return] : D [field b, field c] : C | A.cs:105:17:105:29 | object creation of type D : D [field b, field c] : C | provenance |  |
+| A.cs:95:16:95:16 | this [Return] : D [field b, field c] : C | A.cs:105:17:105:29 | object creation of type D : D [field b, field c] : C | provenance |  |
+| A.cs:95:16:95:16 | this [Return] : D [field b] : B | A.cs:105:17:105:29 | object creation of type D : D [field b] : B | provenance |  |
+| A.cs:95:16:95:16 | this [Return] : D [field b] : B | A.cs:105:17:105:29 | object creation of type D : D [field b] : B | provenance |  |
 | A.cs:95:20:95:20 | b : B | A.cs:97:13:97:13 | access to parameter b : B | provenance |  |
 | A.cs:95:20:95:20 | b : B | A.cs:97:13:97:13 | access to parameter b : B | provenance |  |
+| A.cs:95:20:95:20 | b [Return] : B [field c] : C | A.cs:105:23:105:23 | [post] access to local variable b : B [field c] : C | provenance |  |
+| A.cs:95:20:95:20 | b [Return] : B [field c] : C | A.cs:105:23:105:23 | [post] access to local variable b : B [field c] : C | provenance |  |
+| A.cs:97:13:97:13 | [post] access to parameter b : B [field c] : C | A.cs:95:20:95:20 | b [Return] : B [field c] : C | provenance |  |
+| A.cs:97:13:97:13 | [post] access to parameter b : B [field c] : C | A.cs:95:20:95:20 | b [Return] : B [field c] : C | provenance |  |
 | A.cs:97:13:97:13 | [post] access to parameter b : B [field c] : C | A.cs:98:22:98:43 | ... ? ... : ... : B [field c] : C | provenance |  |
 | A.cs:97:13:97:13 | [post] access to parameter b : B [field c] : C | A.cs:98:22:98:43 | ... ? ... : ... : B [field c] : C | provenance |  |
-| A.cs:97:13:97:13 | [post] access to parameter b : B [field c] : C | A.cs:105:23:105:23 | [post] access to local variable b : B [field c] : C | provenance |  |
-| A.cs:97:13:97:13 | [post] access to parameter b : B [field c] : C | A.cs:105:23:105:23 | [post] access to local variable b : B [field c] : C | provenance |  |
 | A.cs:97:13:97:13 | access to parameter b : B | A.cs:98:22:98:43 | ... ? ... : ... : B | provenance |  |
 | A.cs:97:13:97:13 | access to parameter b : B | A.cs:98:22:98:43 | ... ? ... : ... : B | provenance |  |
 | A.cs:97:19:97:32 | call to method Source<C> : C | A.cs:97:13:97:13 | [post] access to parameter b : B [field c] : C | provenance |  |
 | A.cs:97:19:97:32 | call to method Source<C> : C | A.cs:97:13:97:13 | [post] access to parameter b : B [field c] : C | provenance |  |
-| A.cs:98:13:98:16 | [post] this access : D [field b, field c] : C | A.cs:105:17:105:29 | object creation of type D : D [field b, field c] : C | provenance |  |
-| A.cs:98:13:98:16 | [post] this access : D [field b, field c] : C | A.cs:105:17:105:29 | object creation of type D : D [field b, field c] : C | provenance |  |
-| A.cs:98:13:98:16 | [post] this access : D [field b] : B | A.cs:105:17:105:29 | object creation of type D : D [field b] : B | provenance |  |
-| A.cs:98:13:98:16 | [post] this access : D [field b] : B | A.cs:105:17:105:29 | object creation of type D : D [field b] : B | provenance |  |
+| A.cs:98:13:98:16 | [post] this access : D [field b, field c] : C | A.cs:95:16:95:16 | this [Return] : D [field b, field c] : C | provenance |  |
+| A.cs:98:13:98:16 | [post] this access : D [field b, field c] : C | A.cs:95:16:95:16 | this [Return] : D [field b, field c] : C | provenance |  |
+| A.cs:98:13:98:16 | [post] this access : D [field b] : B | A.cs:95:16:95:16 | this [Return] : D [field b] : B | provenance |  |
+| A.cs:98:13:98:16 | [post] this access : D [field b] : B | A.cs:95:16:95:16 | this [Return] : D [field b] : B | provenance |  |
+| A.cs:98:13:98:16 | [post] this access : D [field b] : B | A.cs:95:16:95:16 | this [Return] : D [field b] : B | provenance |  |
+| A.cs:98:13:98:16 | [post] this access : D [field b] : B | A.cs:95:16:95:16 | this [Return] : D [field b] : B | provenance |  |
 | A.cs:98:22:98:43 | ... ? ... : ... : B | A.cs:98:13:98:16 | [post] this access : D [field b] : B | provenance |  |
 | A.cs:98:22:98:43 | ... ? ... : ... : B | A.cs:98:13:98:16 | [post] this access : D [field b] : B | provenance |  |
 | A.cs:98:22:98:43 | ... ? ... : ... : B | A.cs:98:13:98:16 | [post] this access : D [field b] : B | provenance |  |
@@ -196,6 +206,8 @@ edges
 | A.cs:123:18:123:18 | access to local variable l : MyList [field head] : B | A.cs:123:18:123:23 | access to field head | provenance |  |
 | A.cs:141:20:141:20 | c : C | A.cs:143:22:143:22 | access to parameter c : C | provenance |  |
 | A.cs:141:20:141:20 | c : C | A.cs:143:22:143:22 | access to parameter c : C | provenance |  |
+| A.cs:143:13:143:16 | [post] this access : B [field c] : C | A.cs:141:16:141:16 | this [Return] : B [field c] : C | provenance |  |
+| A.cs:143:13:143:16 | [post] this access : B [field c] : C | A.cs:141:16:141:16 | this [Return] : B [field c] : C | provenance |  |
 | A.cs:143:22:143:22 | access to parameter c : C | A.cs:143:13:143:16 | [post] this access : B [field c] : C | provenance |  |
 | A.cs:143:22:143:22 | access to parameter c : C | A.cs:143:13:143:16 | [post] this access : B [field c] : C | provenance |  |
 | A.cs:145:27:145:27 | c : C | A.cs:145:41:145:41 | access to parameter c : C | provenance |  |
@@ -204,6 +216,12 @@ edges
 | A.cs:145:27:145:27 | c : C1 | A.cs:145:41:145:41 | access to parameter c : C1 | provenance |  |
 | A.cs:145:27:145:27 | c : C2 | A.cs:145:41:145:41 | access to parameter c : C2 | provenance |  |
 | A.cs:145:27:145:27 | c : C2 | A.cs:145:41:145:41 | access to parameter c : C2 | provenance |  |
+| A.cs:145:32:145:35 | [post] this access : B [field c] : C | A.cs:145:21:145:23 | this [Return] : B [field c] : C | provenance |  |
+| A.cs:145:32:145:35 | [post] this access : B [field c] : C | A.cs:145:21:145:23 | this [Return] : B [field c] : C | provenance |  |
+| A.cs:145:32:145:35 | [post] this access : B [field c] : C1 | A.cs:145:21:145:23 | this [Return] : B [field c] : C1 | provenance |  |
+| A.cs:145:32:145:35 | [post] this access : B [field c] : C1 | A.cs:145:21:145:23 | this [Return] : B [field c] : C1 | provenance |  |
+| A.cs:145:32:145:35 | [post] this access : B [field c] : C2 | A.cs:145:21:145:23 | this [Return] : B [field c] : C2 | provenance |  |
+| A.cs:145:32:145:35 | [post] this access : B [field c] : C2 | A.cs:145:21:145:23 | this [Return] : B [field c] : C2 | provenance |  |
 | A.cs:145:41:145:41 | access to parameter c : C | A.cs:145:32:145:35 | [post] this access : B [field c] : C | provenance |  |
 | A.cs:145:41:145:41 | access to parameter c : C | A.cs:145:32:145:35 | [post] this access : B [field c] : C | provenance |  |
 | A.cs:145:41:145:41 | access to parameter c : C1 | A.cs:145:32:145:35 | [post] this access : B [field c] : C1 | provenance |  |
@@ -230,8 +248,14 @@ edges
 | A.cs:157:38:157:41 | next : MyList [field head] : B | A.cs:160:25:160:28 | access to parameter next : MyList [field head] : B | provenance |  |
 | A.cs:157:38:157:41 | next : MyList [field next, field head] : B | A.cs:160:25:160:28 | access to parameter next : MyList [field next, field head] : B | provenance |  |
 | A.cs:157:38:157:41 | next : MyList [field next, field head] : B | A.cs:160:25:160:28 | access to parameter next : MyList [field next, field head] : B | provenance |  |
+| A.cs:159:13:159:16 | [post] this access : MyList [field head] : B | A.cs:157:16:157:21 | this [Return] : MyList [field head] : B | provenance |  |
+| A.cs:159:13:159:16 | [post] this access : MyList [field head] : B | A.cs:157:16:157:21 | this [Return] : MyList [field head] : B | provenance |  |
 | A.cs:159:25:159:28 | access to parameter head : B | A.cs:159:13:159:16 | [post] this access : MyList [field head] : B | provenance |  |
 | A.cs:159:25:159:28 | access to parameter head : B | A.cs:159:13:159:16 | [post] this access : MyList [field head] : B | provenance |  |
+| A.cs:160:13:160:16 | [post] this access : MyList [field next, field head] : B | A.cs:157:16:157:21 | this [Return] : MyList [field next, field head] : B | provenance |  |
+| A.cs:160:13:160:16 | [post] this access : MyList [field next, field head] : B | A.cs:157:16:157:21 | this [Return] : MyList [field next, field head] : B | provenance |  |
+| A.cs:160:13:160:16 | [post] this access : MyList [field next, field next, field head] : B | A.cs:157:16:157:21 | this [Return] : MyList [field next, field next, field head] : B | provenance |  |
+| A.cs:160:13:160:16 | [post] this access : MyList [field next, field next, field head] : B | A.cs:157:16:157:21 | this [Return] : MyList [field next, field next, field head] : B | provenance |  |
 | A.cs:160:25:160:28 | access to parameter next : MyList [field head] : B | A.cs:160:13:160:16 | [post] this access : MyList [field next, field head] : B | provenance |  |
 | A.cs:160:25:160:28 | access to parameter next : MyList [field head] : B | A.cs:160:13:160:16 | [post] this access : MyList [field next, field head] : B | provenance |  |
 | A.cs:160:25:160:28 | access to parameter next : MyList [field next, field head] : B | A.cs:160:13:160:16 | [post] this access : MyList [field next, field next, field head] : B | provenance |  |
@@ -288,30 +312,38 @@ edges
 | B.cs:29:26:29:27 | e1 : Elem | B.cs:31:26:31:27 | access to parameter e1 : Elem | provenance |  |
 | B.cs:29:35:29:36 | e2 : Elem | B.cs:32:26:32:27 | access to parameter e2 : Elem | provenance |  |
 | B.cs:29:35:29:36 | e2 : Elem | B.cs:32:26:32:27 | access to parameter e2 : Elem | provenance |  |
+| B.cs:31:13:31:16 | [post] this access : Box1 [field elem1] : Elem | B.cs:29:16:29:19 | this [Return] : Box1 [field elem1] : Elem | provenance |  |
+| B.cs:31:13:31:16 | [post] this access : Box1 [field elem1] : Elem | B.cs:29:16:29:19 | this [Return] : Box1 [field elem1] : Elem | provenance |  |
 | B.cs:31:26:31:27 | access to parameter e1 : Elem | B.cs:31:13:31:16 | [post] this access : Box1 [field elem1] : Elem | provenance |  |
 | B.cs:31:26:31:27 | access to parameter e1 : Elem | B.cs:31:13:31:16 | [post] this access : Box1 [field elem1] : Elem | provenance |  |
+| B.cs:32:13:32:16 | [post] this access : Box1 [field elem2] : Elem | B.cs:29:16:29:19 | this [Return] : Box1 [field elem2] : Elem | provenance |  |
+| B.cs:32:13:32:16 | [post] this access : Box1 [field elem2] : Elem | B.cs:29:16:29:19 | this [Return] : Box1 [field elem2] : Elem | provenance |  |
 | B.cs:32:26:32:27 | access to parameter e2 : Elem | B.cs:32:13:32:16 | [post] this access : Box1 [field elem2] : Elem | provenance |  |
 | B.cs:32:26:32:27 | access to parameter e2 : Elem | B.cs:32:13:32:16 | [post] this access : Box1 [field elem2] : Elem | provenance |  |
 | B.cs:39:26:39:27 | b1 : Box1 [field elem1] : Elem | B.cs:41:25:41:26 | access to parameter b1 : Box1 [field elem1] : Elem | provenance |  |
 | B.cs:39:26:39:27 | b1 : Box1 [field elem1] : Elem | B.cs:41:25:41:26 | access to parameter b1 : Box1 [field elem1] : Elem | provenance |  |
 | B.cs:39:26:39:27 | b1 : Box1 [field elem2] : Elem | B.cs:41:25:41:26 | access to parameter b1 : Box1 [field elem2] : Elem | provenance |  |
 | B.cs:39:26:39:27 | b1 : Box1 [field elem2] : Elem | B.cs:41:25:41:26 | access to parameter b1 : Box1 [field elem2] : Elem | provenance |  |
+| B.cs:41:13:41:16 | [post] this access : Box2 [field box1, field elem1] : Elem | B.cs:39:16:39:19 | this [Return] : Box2 [field box1, field elem1] : Elem | provenance |  |
+| B.cs:41:13:41:16 | [post] this access : Box2 [field box1, field elem1] : Elem | B.cs:39:16:39:19 | this [Return] : Box2 [field box1, field elem1] : Elem | provenance |  |
+| B.cs:41:13:41:16 | [post] this access : Box2 [field box1, field elem2] : Elem | B.cs:39:16:39:19 | this [Return] : Box2 [field box1, field elem2] : Elem | provenance |  |
+| B.cs:41:13:41:16 | [post] this access : Box2 [field box1, field elem2] : Elem | B.cs:39:16:39:19 | this [Return] : Box2 [field box1, field elem2] : Elem | provenance |  |
 | B.cs:41:25:41:26 | access to parameter b1 : Box1 [field elem1] : Elem | B.cs:41:13:41:16 | [post] this access : Box2 [field box1, field elem1] : Elem | provenance |  |
 | B.cs:41:25:41:26 | access to parameter b1 : Box1 [field elem1] : Elem | B.cs:41:13:41:16 | [post] this access : Box2 [field box1, field elem1] : Elem | provenance |  |
 | B.cs:41:25:41:26 | access to parameter b1 : Box1 [field elem2] : Elem | B.cs:41:13:41:16 | [post] this access : Box2 [field box1, field elem2] : Elem | provenance |  |
 | B.cs:41:25:41:26 | access to parameter b1 : Box1 [field elem2] : Elem | B.cs:41:13:41:16 | [post] this access : Box2 [field box1, field elem2] : Elem | provenance |  |
-| C.cs:3:18:3:19 | [post] this access : C [field s1] : Elem | C.cs:12:15:12:21 | object creation of type C : C [field s1] : Elem | provenance |  |
-| C.cs:3:18:3:19 | [post] this access : C [field s1] : Elem | C.cs:12:15:12:21 | object creation of type C : C [field s1] : Elem | provenance |  |
+| C.cs:3:18:3:19 | [post] this access : C [field s1] : Elem | C.cs:16:13:16:13 | this [Return] : C [field s1] : Elem | provenance |  |
+| C.cs:3:18:3:19 | [post] this access : C [field s1] : Elem | C.cs:16:13:16:13 | this [Return] : C [field s1] : Elem | provenance |  |
 | C.cs:3:23:3:37 | call to method Source<Elem> : Elem | C.cs:3:18:3:19 | [post] this access : C [field s1] : Elem | provenance |  |
 | C.cs:3:23:3:37 | call to method Source<Elem> : Elem | C.cs:3:18:3:19 | [post] this access : C [field s1] : Elem | provenance |  |
-| C.cs:4:27:4:28 | [post] this access : C [field s2] : Elem | C.cs:12:15:12:21 | object creation of type C : C [field s2] : Elem | provenance |  |
-| C.cs:4:27:4:28 | [post] this access : C [field s2] : Elem | C.cs:12:15:12:21 | object creation of type C : C [field s2] : Elem | provenance |  |
+| C.cs:4:27:4:28 | [post] this access : C [field s2] : Elem | C.cs:16:13:16:13 | this [Return] : C [field s2] : Elem | provenance |  |
+| C.cs:4:27:4:28 | [post] this access : C [field s2] : Elem | C.cs:16:13:16:13 | this [Return] : C [field s2] : Elem | provenance |  |
 | C.cs:4:32:4:46 | call to method Source<Elem> : Elem | C.cs:4:27:4:28 | [post] this access : C [field s2] : Elem | provenance |  |
 | C.cs:4:32:4:46 | call to method Source<Elem> : Elem | C.cs:4:27:4:28 | [post] this access : C [field s2] : Elem | provenance |  |
 | C.cs:6:30:6:44 | call to method Source<Elem> : Elem | C.cs:26:14:26:15 | access to field s4 | provenance |  |
 | C.cs:6:30:6:44 | call to method Source<Elem> : Elem | C.cs:26:14:26:15 | access to field s4 | provenance |  |
-| C.cs:7:18:7:19 | [post] this access : C [property s5] : Elem | C.cs:12:15:12:21 | object creation of type C : C [property s5] : Elem | provenance |  |
-| C.cs:7:18:7:19 | [post] this access : C [property s5] : Elem | C.cs:12:15:12:21 | object creation of type C : C [property s5] : Elem | provenance |  |
+| C.cs:7:18:7:19 | [post] this access : C [property s5] : Elem | C.cs:16:13:16:13 | this [Return] : C [property s5] : Elem | provenance |  |
+| C.cs:7:18:7:19 | [post] this access : C [property s5] : Elem | C.cs:16:13:16:13 | this [Return] : C [property s5] : Elem | provenance |  |
 | C.cs:7:37:7:51 | call to method Source<Elem> : Elem | C.cs:7:18:7:19 | [post] this access : C [property s5] : Elem | provenance |  |
 | C.cs:7:37:7:51 | call to method Source<Elem> : Elem | C.cs:7:18:7:19 | [post] this access : C [property s5] : Elem | provenance |  |
 | C.cs:8:30:8:44 | call to method Source<Elem> : Elem | C.cs:28:14:28:15 | access to property s6 | provenance |  |
@@ -340,8 +372,16 @@ edges
 | C.cs:13:9:13:9 | access to local variable c : C [field s3] : Elem | C.cs:21:17:21:18 | this : C [field s3] : Elem | provenance |  |
 | C.cs:13:9:13:9 | access to local variable c : C [property s5] : Elem | C.cs:21:17:21:18 | this : C [property s5] : Elem | provenance |  |
 | C.cs:13:9:13:9 | access to local variable c : C [property s5] : Elem | C.cs:21:17:21:18 | this : C [property s5] : Elem | provenance |  |
-| C.cs:18:9:18:12 | [post] this access : C [field s3] : Elem | C.cs:12:15:12:21 | object creation of type C : C [field s3] : Elem | provenance |  |
-| C.cs:18:9:18:12 | [post] this access : C [field s3] : Elem | C.cs:12:15:12:21 | object creation of type C : C [field s3] : Elem | provenance |  |
+| C.cs:16:13:16:13 | this [Return] : C [field s1] : Elem | C.cs:12:15:12:21 | object creation of type C : C [field s1] : Elem | provenance |  |
+| C.cs:16:13:16:13 | this [Return] : C [field s1] : Elem | C.cs:12:15:12:21 | object creation of type C : C [field s1] : Elem | provenance |  |
+| C.cs:16:13:16:13 | this [Return] : C [field s2] : Elem | C.cs:12:15:12:21 | object creation of type C : C [field s2] : Elem | provenance |  |
+| C.cs:16:13:16:13 | this [Return] : C [field s2] : Elem | C.cs:12:15:12:21 | object creation of type C : C [field s2] : Elem | provenance |  |
+| C.cs:16:13:16:13 | this [Return] : C [field s3] : Elem | C.cs:12:15:12:21 | object creation of type C : C [field s3] : Elem | provenance |  |
+| C.cs:16:13:16:13 | this [Return] : C [field s3] : Elem | C.cs:12:15:12:21 | object creation of type C : C [field s3] : Elem | provenance |  |
+| C.cs:16:13:16:13 | this [Return] : C [property s5] : Elem | C.cs:12:15:12:21 | object creation of type C : C [property s5] : Elem | provenance |  |
+| C.cs:16:13:16:13 | this [Return] : C [property s5] : Elem | C.cs:12:15:12:21 | object creation of type C : C [property s5] : Elem | provenance |  |
+| C.cs:18:9:18:12 | [post] this access : C [field s3] : Elem | C.cs:16:13:16:13 | this [Return] : C [field s3] : Elem | provenance |  |
+| C.cs:18:9:18:12 | [post] this access : C [field s3] : Elem | C.cs:16:13:16:13 | this [Return] : C [field s3] : Elem | provenance |  |
 | C.cs:18:19:18:33 | call to method Source<Elem> : Elem | C.cs:18:9:18:12 | [post] this access : C [field s3] : Elem | provenance |  |
 | C.cs:18:19:18:33 | call to method Source<Elem> : Elem | C.cs:18:9:18:12 | [post] this access : C [field s3] : Elem | provenance |  |
 | C.cs:21:17:21:18 | this : C [field s1] : Elem | C.cs:23:14:23:15 | this access : C [field s1] : Elem | provenance |  |
@@ -366,6 +406,8 @@ edges
 | D.cs:8:22:8:25 | this access : D [field trivialPropField] : Object | D.cs:8:22:8:42 | access to field trivialPropField : Object | provenance |  |
 | D.cs:9:9:9:11 | value : Object | D.cs:9:39:9:43 | access to parameter value : Object | provenance |  |
 | D.cs:9:9:9:11 | value : Object | D.cs:9:39:9:43 | access to parameter value : Object | provenance |  |
+| D.cs:9:15:9:18 | [post] this access : D [field trivialPropField] : Object | D.cs:9:9:9:11 | this [Return] : D [field trivialPropField] : Object | provenance |  |
+| D.cs:9:15:9:18 | [post] this access : D [field trivialPropField] : Object | D.cs:9:9:9:11 | this [Return] : D [field trivialPropField] : Object | provenance |  |
 | D.cs:9:39:9:43 | access to parameter value : Object | D.cs:9:15:9:18 | [post] this access : D [field trivialPropField] : Object | provenance |  |
 | D.cs:9:39:9:43 | access to parameter value : Object | D.cs:9:15:9:18 | [post] this access : D [field trivialPropField] : Object | provenance |  |
 | D.cs:14:9:14:11 | this : D [field trivialPropField] : Object | D.cs:14:22:14:25 | this access : D [field trivialPropField] : Object | provenance |  |
@@ -374,6 +416,8 @@ edges
 | D.cs:14:22:14:25 | this access : D [field trivialPropField] : Object | D.cs:14:22:14:42 | access to field trivialPropField : Object | provenance |  |
 | D.cs:15:9:15:11 | value : Object | D.cs:15:34:15:38 | access to parameter value : Object | provenance |  |
 | D.cs:15:9:15:11 | value : Object | D.cs:15:34:15:38 | access to parameter value : Object | provenance |  |
+| D.cs:15:15:15:18 | [post] this access : D [field trivialPropField] : Object | D.cs:15:9:15:11 | this [Return] : D [field trivialPropField] : Object | provenance |  |
+| D.cs:15:15:15:18 | [post] this access : D [field trivialPropField] : Object | D.cs:15:9:15:11 | this [Return] : D [field trivialPropField] : Object | provenance |  |
 | D.cs:15:34:15:38 | access to parameter value : Object | D.cs:9:9:9:11 | value : Object | provenance |  |
 | D.cs:15:34:15:38 | access to parameter value : Object | D.cs:9:9:9:11 | value : Object | provenance |  |
 | D.cs:15:34:15:38 | access to parameter value : Object | D.cs:15:15:15:18 | [post] this access : D [field trivialPropField] : Object | provenance |  |
@@ -480,6 +524,8 @@ edges
 | E.cs:24:14:24:14 | access to local variable s : S [field Field] : Object | E.cs:24:14:24:20 | access to field Field | provenance |  |
 | E.cs:43:46:43:46 | o : Object | E.cs:46:22:46:22 | access to parameter o : Object | provenance |  |
 | E.cs:43:46:43:46 | o : Object | E.cs:46:22:46:22 | access to parameter o : Object | provenance |  |
+| E.cs:46:9:46:9 | [post] access to parameter s : RefS [field RefField] : Object | E.cs:43:36:43:36 | s [Return] : RefS [field RefField] : Object | provenance |  |
+| E.cs:46:9:46:9 | [post] access to parameter s : RefS [field RefField] : Object | E.cs:43:36:43:36 | s [Return] : RefS [field RefField] : Object | provenance |  |
 | E.cs:46:22:46:22 | access to parameter o : Object | E.cs:46:9:46:9 | [post] access to parameter s : RefS [field RefField] : Object | provenance |  |
 | E.cs:46:22:46:22 | access to parameter o : Object | E.cs:46:9:46:9 | [post] access to parameter s : RefS [field RefField] : Object | provenance |  |
 | E.cs:54:13:54:17 | access to local variable taint : Object | E.cs:55:29:55:33 | access to local variable taint : Object | provenance |  |
@@ -648,6 +694,8 @@ edges
 | G.cs:63:34:63:37 | this access : Box1 [field Elem] : Elem | G.cs:63:34:63:37 | access to field Elem : Elem | provenance |  |
 | G.cs:64:34:64:34 | e : Elem | G.cs:64:46:64:46 | access to parameter e : Elem | provenance |  |
 | G.cs:64:34:64:34 | e : Elem | G.cs:64:46:64:46 | access to parameter e : Elem | provenance |  |
+| G.cs:64:39:64:42 | [post] this access : Box1 [field Elem] : Elem | G.cs:64:21:64:27 | this [Return] : Box1 [field Elem] : Elem | provenance |  |
+| G.cs:64:39:64:42 | [post] this access : Box1 [field Elem] : Elem | G.cs:64:21:64:27 | this [Return] : Box1 [field Elem] : Elem | provenance |  |
 | G.cs:64:46:64:46 | access to parameter e : Elem | G.cs:64:39:64:42 | [post] this access : Box1 [field Elem] : Elem | provenance |  |
 | G.cs:64:46:64:46 | access to parameter e : Elem | G.cs:64:39:64:42 | [post] this access : Box1 [field Elem] : Elem | provenance |  |
 | G.cs:71:21:71:27 | this : Box2 [field Box1, field Elem] : Elem | G.cs:71:34:71:37 | this access : Box2 [field Box1, field Elem] : Elem | provenance |  |
@@ -708,6 +756,8 @@ edges
 | H.cs:45:14:45:14 | access to local variable b : B [field FieldB] : Object | H.cs:45:14:45:21 | access to field FieldB | provenance |  |
 | H.cs:53:25:53:25 | a : A [field FieldA] : Object | H.cs:55:21:55:21 | access to parameter a : A [field FieldA] : Object | provenance |  |
 | H.cs:53:25:53:25 | a : A [field FieldA] : Object | H.cs:55:21:55:21 | access to parameter a : A [field FieldA] : Object | provenance |  |
+| H.cs:55:9:55:10 | [post] access to parameter b1 : B [field FieldB] : Object | H.cs:53:30:53:31 | b1 [Return] : B [field FieldB] : Object | provenance |  |
+| H.cs:55:9:55:10 | [post] access to parameter b1 : B [field FieldB] : Object | H.cs:53:30:53:31 | b1 [Return] : B [field FieldB] : Object | provenance |  |
 | H.cs:55:21:55:21 | access to parameter a : A [field FieldA] : Object | H.cs:55:21:55:28 | access to field FieldA : Object | provenance |  |
 | H.cs:55:21:55:21 | access to parameter a : A [field FieldA] : Object | H.cs:55:21:55:28 | access to field FieldA : Object | provenance |  |
 | H.cs:55:21:55:28 | access to field FieldA : Object | H.cs:55:9:55:10 | [post] access to parameter b1 : B [field FieldB] : Object | provenance |  |
@@ -726,6 +776,8 @@ edges
 | H.cs:65:14:65:15 | access to local variable b1 : B [field FieldB] : Object | H.cs:65:14:65:22 | access to field FieldB | provenance |  |
 | H.cs:77:30:77:30 | o : Object | H.cs:79:20:79:20 | access to parameter o : Object | provenance |  |
 | H.cs:77:30:77:30 | o : Object | H.cs:79:20:79:20 | access to parameter o : Object | provenance |  |
+| H.cs:79:9:79:9 | [post] access to parameter a : A [field FieldA] : Object | H.cs:77:20:77:20 | a [Return] : A [field FieldA] : Object | provenance |  |
+| H.cs:79:9:79:9 | [post] access to parameter a : A [field FieldA] : Object | H.cs:77:20:77:20 | a [Return] : A [field FieldA] : Object | provenance |  |
 | H.cs:79:9:79:9 | [post] access to parameter a : A [field FieldA] : Object | H.cs:80:22:80:22 | access to parameter a : A [field FieldA] : Object | provenance |  |
 | H.cs:79:9:79:9 | [post] access to parameter a : A [field FieldA] : Object | H.cs:80:22:80:22 | access to parameter a : A [field FieldA] : Object | provenance |  |
 | H.cs:79:20:79:20 | access to parameter o : Object | H.cs:79:9:79:9 | [post] access to parameter a : A [field FieldA] : Object | provenance |  |
@@ -734,6 +786,8 @@ edges
 | H.cs:80:22:80:22 | access to parameter a : A [field FieldA] : Object | H.cs:53:25:53:25 | a : A [field FieldA] : Object | provenance |  |
 | H.cs:80:22:80:22 | access to parameter a : A [field FieldA] : Object | H.cs:80:25:80:26 | [post] access to parameter b1 : B [field FieldB] : Object | provenance |  |
 | H.cs:80:22:80:22 | access to parameter a : A [field FieldA] : Object | H.cs:80:25:80:26 | [post] access to parameter b1 : B [field FieldB] : Object | provenance |  |
+| H.cs:80:25:80:26 | [post] access to parameter b1 : B [field FieldB] : Object | H.cs:77:35:77:36 | b1 [Return] : B [field FieldB] : Object | provenance |  |
+| H.cs:80:25:80:26 | [post] access to parameter b1 : B [field FieldB] : Object | H.cs:77:35:77:36 | b1 [Return] : B [field FieldB] : Object | provenance |  |
 | H.cs:88:17:88:17 | [post] access to local variable a : A [field FieldA] : Object | H.cs:89:14:89:14 | access to local variable a : A [field FieldA] : Object | provenance |  |
 | H.cs:88:17:88:17 | [post] access to local variable a : A [field FieldA] : Object | H.cs:89:14:89:14 | access to local variable a : A [field FieldA] : Object | provenance |  |
 | H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:77:30:77:30 | o : Object | provenance |  |
@@ -812,6 +866,8 @@ edges
 | H.cs:147:25:147:38 | call to method Source<A> : A | H.cs:138:27:138:27 | o : A | provenance |  |
 | H.cs:147:25:147:38 | call to method Source<A> : A | H.cs:147:17:147:39 | call to method Through : A | provenance |  |
 | H.cs:147:25:147:38 | call to method Source<A> : A | H.cs:147:17:147:39 | call to method Through : A | provenance |  |
+| H.cs:153:22:153:22 | a [Return] : A [field FieldA] : B | H.cs:164:19:164:19 | [post] access to local variable a : A [field FieldA] : B | provenance |  |
+| H.cs:153:22:153:22 | a [Return] : A [field FieldA] : B | H.cs:164:19:164:19 | [post] access to local variable a : A [field FieldA] : B | provenance |  |
 | H.cs:153:32:153:32 | o : Object | H.cs:156:20:156:20 | access to parameter o : Object | provenance |  |
 | H.cs:153:32:153:32 | o : Object | H.cs:156:20:156:20 | access to parameter o : Object | provenance |  |
 | H.cs:155:13:155:13 | access to local variable b : B | H.cs:156:9:156:9 | access to local variable b : B | provenance |  |
@@ -824,8 +880,10 @@ edges
 | H.cs:156:9:156:9 | access to local variable b : B | H.cs:157:20:157:20 | access to local variable b : B | provenance |  |
 | H.cs:156:20:156:20 | access to parameter o : Object | H.cs:156:9:156:9 | [post] access to local variable b : B [field FieldB] : Object | provenance |  |
 | H.cs:156:20:156:20 | access to parameter o : Object | H.cs:156:9:156:9 | [post] access to local variable b : B [field FieldB] : Object | provenance |  |
-| H.cs:157:9:157:9 | [post] access to parameter a : A [field FieldA] : B | H.cs:164:19:164:19 | [post] access to local variable a : A [field FieldA] : B | provenance |  |
-| H.cs:157:9:157:9 | [post] access to parameter a : A [field FieldA] : B | H.cs:164:19:164:19 | [post] access to local variable a : A [field FieldA] : B | provenance |  |
+| H.cs:157:9:157:9 | [post] access to parameter a : A [field FieldA, field FieldB] : Object | H.cs:153:22:153:22 | a [Return] : A [field FieldA, field FieldB] : Object | provenance |  |
+| H.cs:157:9:157:9 | [post] access to parameter a : A [field FieldA, field FieldB] : Object | H.cs:153:22:153:22 | a [Return] : A [field FieldA, field FieldB] : Object | provenance |  |
+| H.cs:157:9:157:9 | [post] access to parameter a : A [field FieldA] : B | H.cs:153:22:153:22 | a [Return] : A [field FieldA] : B | provenance |  |
+| H.cs:157:9:157:9 | [post] access to parameter a : A [field FieldA] : B | H.cs:153:22:153:22 | a [Return] : A [field FieldA] : B | provenance |  |
 | H.cs:157:20:157:20 | access to local variable b : B | H.cs:157:9:157:9 | [post] access to parameter a : A [field FieldA] : B | provenance |  |
 | H.cs:157:20:157:20 | access to local variable b : B | H.cs:157:9:157:9 | [post] access to parameter a : A [field FieldA] : B | provenance |  |
 | H.cs:157:20:157:20 | access to local variable b : B [field FieldB] : Object | H.cs:157:9:157:9 | [post] access to parameter a : A [field FieldA, field FieldB] : Object | provenance |  |
@@ -860,10 +918,12 @@ edges
 | H.cs:165:20:165:27 | access to field FieldA : B [field FieldB] : Object | H.cs:165:17:165:27 | (...) ... : B [field FieldB] : Object | provenance |  |
 | H.cs:167:14:167:14 | access to local variable b : B [field FieldB] : Object | H.cs:167:14:167:21 | access to field FieldB | provenance |  |
 | H.cs:167:14:167:14 | access to local variable b : B [field FieldB] : Object | H.cs:167:14:167:21 | access to field FieldB | provenance |  |
-| I.cs:7:9:7:14 | [post] this access : I [field Field1] : Object | I.cs:21:13:21:19 | object creation of type I : I [field Field1] : Object | provenance |  |
-| I.cs:7:9:7:14 | [post] this access : I [field Field1] : Object | I.cs:21:13:21:19 | object creation of type I : I [field Field1] : Object | provenance |  |
-| I.cs:7:9:7:14 | [post] this access : I [field Field1] : Object | I.cs:26:13:26:37 | [pre-initializer] object creation of type I : I [field Field1] : Object | provenance |  |
-| I.cs:7:9:7:14 | [post] this access : I [field Field1] : Object | I.cs:26:13:26:37 | [pre-initializer] object creation of type I : I [field Field1] : Object | provenance |  |
+| I.cs:5:12:5:12 | this [Return] : I [field Field1] : Object | I.cs:21:13:21:19 | object creation of type I : I [field Field1] : Object | provenance |  |
+| I.cs:5:12:5:12 | this [Return] : I [field Field1] : Object | I.cs:21:13:21:19 | object creation of type I : I [field Field1] : Object | provenance |  |
+| I.cs:5:12:5:12 | this [Return] : I [field Field1] : Object | I.cs:26:13:26:37 | [pre-initializer] object creation of type I : I [field Field1] : Object | provenance |  |
+| I.cs:5:12:5:12 | this [Return] : I [field Field1] : Object | I.cs:26:13:26:37 | [pre-initializer] object creation of type I : I [field Field1] : Object | provenance |  |
+| I.cs:7:9:7:14 | [post] this access : I [field Field1] : Object | I.cs:5:12:5:12 | this [Return] : I [field Field1] : Object | provenance |  |
+| I.cs:7:9:7:14 | [post] this access : I [field Field1] : Object | I.cs:5:12:5:12 | this [Return] : I [field Field1] : Object | provenance |  |
 | I.cs:7:18:7:34 | call to method Source<Object> : Object | I.cs:7:9:7:14 | [post] this access : I [field Field1] : Object | provenance |  |
 | I.cs:7:18:7:34 | call to method Source<Object> : Object | I.cs:7:9:7:14 | [post] this access : I [field Field1] : Object | provenance |  |
 | I.cs:13:13:13:13 | access to local variable o : Object | I.cs:15:20:15:20 | access to local variable o : Object | provenance |  |
@@ -912,10 +972,18 @@ edges
 | I.cs:39:9:39:9 | access to parameter i : I [field Field1] : Object | I.cs:40:14:40:14 | access to parameter i : I [field Field1] : Object | provenance |  |
 | I.cs:40:14:40:14 | access to parameter i : I [field Field1] : Object | I.cs:40:14:40:21 | access to field Field1 | provenance |  |
 | I.cs:40:14:40:14 | access to parameter i : I [field Field1] : Object | I.cs:40:14:40:21 | access to field Field1 | provenance |  |
+| J.cs:6:40:6:44 | Prop1 : Object | J.cs:6:21:6:31 | this [Return] : RecordClass [property Prop1] : Object | provenance |  |
+| J.cs:6:40:6:44 | Prop1 : Object | J.cs:6:21:6:31 | this [Return] : RecordClass [property Prop1] : Object | provenance |  |
+| J.cs:8:42:8:46 | Prop1 : Object | J.cs:8:22:8:33 | this [Return] : RecordStruct [property Prop1] : Object | provenance |  |
+| J.cs:8:42:8:46 | Prop1 : Object | J.cs:8:22:8:33 | this [Return] : RecordStruct [property Prop1] : Object | provenance |  |
 | J.cs:14:26:14:30 | field : Object | J.cs:14:66:14:70 | access to parameter field : Object | provenance |  |
 | J.cs:14:26:14:30 | field : Object | J.cs:14:66:14:70 | access to parameter field : Object | provenance |  |
 | J.cs:14:40:14:43 | prop : Object | J.cs:14:73:14:76 | access to parameter prop : Object | provenance |  |
 | J.cs:14:40:14:43 | prop : Object | J.cs:14:73:14:76 | access to parameter prop : Object | provenance |  |
+| J.cs:14:50:14:54 | [post] this access : Struct [field Field] : Object | J.cs:14:12:14:17 | this [Return] : Struct [field Field] : Object | provenance |  |
+| J.cs:14:50:14:54 | [post] this access : Struct [field Field] : Object | J.cs:14:12:14:17 | this [Return] : Struct [field Field] : Object | provenance |  |
+| J.cs:14:57:14:60 | [post] this access : Struct [property Prop] : Object | J.cs:14:12:14:17 | this [Return] : Struct [property Prop] : Object | provenance |  |
+| J.cs:14:57:14:60 | [post] this access : Struct [property Prop] : Object | J.cs:14:12:14:17 | this [Return] : Struct [property Prop] : Object | provenance |  |
 | J.cs:14:66:14:70 | access to parameter field : Object | J.cs:14:50:14:54 | [post] this access : Struct [field Field] : Object | provenance |  |
 | J.cs:14:66:14:70 | access to parameter field : Object | J.cs:14:50:14:54 | [post] this access : Struct [field Field] : Object | provenance |  |
 | J.cs:14:73:14:76 | access to parameter prop : Object | J.cs:14:57:14:60 | [post] this access : Struct [property Prop] : Object | provenance |  |
@@ -1167,6 +1235,8 @@ nodes
 | A.cs:64:18:64:26 | access to field a | semmle.label | access to field a |
 | A.cs:64:19:64:23 | (...) ... : C1 [field a] : A | semmle.label | (...) ... : C1 [field a] : A |
 | A.cs:64:19:64:23 | (...) ... : C1 [field a] : A | semmle.label | (...) ... : C1 [field a] : A |
+| A.cs:81:22:81:22 | b [Return] : B [field c] : C | semmle.label | b [Return] : B [field c] : C |
+| A.cs:81:22:81:22 | b [Return] : B [field c] : C | semmle.label | b [Return] : B [field c] : C |
 | A.cs:83:9:83:9 | [post] access to parameter b : B [field c] : C | semmle.label | [post] access to parameter b : B [field c] : C |
 | A.cs:83:9:83:9 | [post] access to parameter b : B [field c] : C | semmle.label | [post] access to parameter b : B [field c] : C |
 | A.cs:83:15:83:26 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
@@ -1177,8 +1247,16 @@ nodes
 | A.cs:89:14:89:14 | access to local variable b : B [field c] : C | semmle.label | access to local variable b : B [field c] : C |
 | A.cs:89:14:89:16 | access to field c | semmle.label | access to field c |
 | A.cs:89:14:89:16 | access to field c | semmle.label | access to field c |
+| A.cs:95:16:95:16 | this [Return] : D [field b, field c] : C | semmle.label | this [Return] : D [field b, field c] : C |
+| A.cs:95:16:95:16 | this [Return] : D [field b, field c] : C | semmle.label | this [Return] : D [field b, field c] : C |
+| A.cs:95:16:95:16 | this [Return] : D [field b] : B | semmle.label | this [Return] : D [field b] : B |
+| A.cs:95:16:95:16 | this [Return] : D [field b] : B | semmle.label | this [Return] : D [field b] : B |
+| A.cs:95:16:95:16 | this [Return] : D [field b] : B | semmle.label | this [Return] : D [field b] : B |
+| A.cs:95:16:95:16 | this [Return] : D [field b] : B | semmle.label | this [Return] : D [field b] : B |
 | A.cs:95:20:95:20 | b : B | semmle.label | b : B |
 | A.cs:95:20:95:20 | b : B | semmle.label | b : B |
+| A.cs:95:20:95:20 | b [Return] : B [field c] : C | semmle.label | b [Return] : B [field c] : C |
+| A.cs:95:20:95:20 | b [Return] : B [field c] : C | semmle.label | b [Return] : B [field c] : C |
 | A.cs:97:13:97:13 | [post] access to parameter b : B [field c] : C | semmle.label | [post] access to parameter b : B [field c] : C |
 | A.cs:97:13:97:13 | [post] access to parameter b : B [field c] : C | semmle.label | [post] access to parameter b : B [field c] : C |
 | A.cs:97:13:97:13 | access to parameter b : B | semmle.label | access to parameter b : B |
@@ -1277,12 +1355,20 @@ nodes
 | A.cs:123:18:123:18 | access to local variable l : MyList [field head] : B | semmle.label | access to local variable l : MyList [field head] : B |
 | A.cs:123:18:123:23 | access to field head | semmle.label | access to field head |
 | A.cs:123:18:123:23 | access to field head | semmle.label | access to field head |
+| A.cs:141:16:141:16 | this [Return] : B [field c] : C | semmle.label | this [Return] : B [field c] : C |
+| A.cs:141:16:141:16 | this [Return] : B [field c] : C | semmle.label | this [Return] : B [field c] : C |
 | A.cs:141:20:141:20 | c : C | semmle.label | c : C |
 | A.cs:141:20:141:20 | c : C | semmle.label | c : C |
 | A.cs:143:13:143:16 | [post] this access : B [field c] : C | semmle.label | [post] this access : B [field c] : C |
 | A.cs:143:13:143:16 | [post] this access : B [field c] : C | semmle.label | [post] this access : B [field c] : C |
 | A.cs:143:22:143:22 | access to parameter c : C | semmle.label | access to parameter c : C |
 | A.cs:143:22:143:22 | access to parameter c : C | semmle.label | access to parameter c : C |
+| A.cs:145:21:145:23 | this [Return] : B [field c] : C | semmle.label | this [Return] : B [field c] : C |
+| A.cs:145:21:145:23 | this [Return] : B [field c] : C | semmle.label | this [Return] : B [field c] : C |
+| A.cs:145:21:145:23 | this [Return] : B [field c] : C1 | semmle.label | this [Return] : B [field c] : C1 |
+| A.cs:145:21:145:23 | this [Return] : B [field c] : C1 | semmle.label | this [Return] : B [field c] : C1 |
+| A.cs:145:21:145:23 | this [Return] : B [field c] : C2 | semmle.label | this [Return] : B [field c] : C2 |
+| A.cs:145:21:145:23 | this [Return] : B [field c] : C2 | semmle.label | this [Return] : B [field c] : C2 |
 | A.cs:145:27:145:27 | c : C | semmle.label | c : C |
 | A.cs:145:27:145:27 | c : C | semmle.label | c : C |
 | A.cs:145:27:145:27 | c : C1 | semmle.label | c : C1 |
@@ -1319,6 +1405,12 @@ nodes
 | A.cs:149:20:149:27 | object creation of type B : B [field c] : C | semmle.label | object creation of type B : B [field c] : C |
 | A.cs:149:26:149:26 | access to parameter c : C | semmle.label | access to parameter c : C |
 | A.cs:149:26:149:26 | access to parameter c : C | semmle.label | access to parameter c : C |
+| A.cs:157:16:157:21 | this [Return] : MyList [field head] : B | semmle.label | this [Return] : MyList [field head] : B |
+| A.cs:157:16:157:21 | this [Return] : MyList [field head] : B | semmle.label | this [Return] : MyList [field head] : B |
+| A.cs:157:16:157:21 | this [Return] : MyList [field next, field head] : B | semmle.label | this [Return] : MyList [field next, field head] : B |
+| A.cs:157:16:157:21 | this [Return] : MyList [field next, field head] : B | semmle.label | this [Return] : MyList [field next, field head] : B |
+| A.cs:157:16:157:21 | this [Return] : MyList [field next, field next, field head] : B | semmle.label | this [Return] : MyList [field next, field next, field head] : B |
+| A.cs:157:16:157:21 | this [Return] : MyList [field next, field next, field head] : B | semmle.label | this [Return] : MyList [field next, field next, field head] : B |
 | A.cs:157:25:157:28 | head : B | semmle.label | head : B |
 | A.cs:157:25:157:28 | head : B | semmle.label | head : B |
 | A.cs:157:38:157:41 | next : MyList [field head] : B | semmle.label | next : MyList [field head] : B |
@@ -1381,6 +1473,10 @@ nodes
 | B.cs:18:14:18:20 | access to field box1 : Box1 [field elem2] : Elem | semmle.label | access to field box1 : Box1 [field elem2] : Elem |
 | B.cs:18:14:18:26 | access to field elem2 | semmle.label | access to field elem2 |
 | B.cs:18:14:18:26 | access to field elem2 | semmle.label | access to field elem2 |
+| B.cs:29:16:29:19 | this [Return] : Box1 [field elem1] : Elem | semmle.label | this [Return] : Box1 [field elem1] : Elem |
+| B.cs:29:16:29:19 | this [Return] : Box1 [field elem1] : Elem | semmle.label | this [Return] : Box1 [field elem1] : Elem |
+| B.cs:29:16:29:19 | this [Return] : Box1 [field elem2] : Elem | semmle.label | this [Return] : Box1 [field elem2] : Elem |
+| B.cs:29:16:29:19 | this [Return] : Box1 [field elem2] : Elem | semmle.label | this [Return] : Box1 [field elem2] : Elem |
 | B.cs:29:26:29:27 | e1 : Elem | semmle.label | e1 : Elem |
 | B.cs:29:26:29:27 | e1 : Elem | semmle.label | e1 : Elem |
 | B.cs:29:35:29:36 | e2 : Elem | semmle.label | e2 : Elem |
@@ -1393,6 +1489,10 @@ nodes
 | B.cs:32:13:32:16 | [post] this access : Box1 [field elem2] : Elem | semmle.label | [post] this access : Box1 [field elem2] : Elem |
 | B.cs:32:26:32:27 | access to parameter e2 : Elem | semmle.label | access to parameter e2 : Elem |
 | B.cs:32:26:32:27 | access to parameter e2 : Elem | semmle.label | access to parameter e2 : Elem |
+| B.cs:39:16:39:19 | this [Return] : Box2 [field box1, field elem1] : Elem | semmle.label | this [Return] : Box2 [field box1, field elem1] : Elem |
+| B.cs:39:16:39:19 | this [Return] : Box2 [field box1, field elem1] : Elem | semmle.label | this [Return] : Box2 [field box1, field elem1] : Elem |
+| B.cs:39:16:39:19 | this [Return] : Box2 [field box1, field elem2] : Elem | semmle.label | this [Return] : Box2 [field box1, field elem2] : Elem |
+| B.cs:39:16:39:19 | this [Return] : Box2 [field box1, field elem2] : Elem | semmle.label | this [Return] : Box2 [field box1, field elem2] : Elem |
 | B.cs:39:26:39:27 | b1 : Box1 [field elem1] : Elem | semmle.label | b1 : Box1 [field elem1] : Elem |
 | B.cs:39:26:39:27 | b1 : Box1 [field elem1] : Elem | semmle.label | b1 : Box1 [field elem1] : Elem |
 | B.cs:39:26:39:27 | b1 : Box1 [field elem2] : Elem | semmle.label | b1 : Box1 [field elem2] : Elem |
@@ -1445,6 +1545,14 @@ nodes
 | C.cs:13:9:13:9 | access to local variable c : C [field s3] : Elem | semmle.label | access to local variable c : C [field s3] : Elem |
 | C.cs:13:9:13:9 | access to local variable c : C [property s5] : Elem | semmle.label | access to local variable c : C [property s5] : Elem |
 | C.cs:13:9:13:9 | access to local variable c : C [property s5] : Elem | semmle.label | access to local variable c : C [property s5] : Elem |
+| C.cs:16:13:16:13 | this [Return] : C [field s1] : Elem | semmle.label | this [Return] : C [field s1] : Elem |
+| C.cs:16:13:16:13 | this [Return] : C [field s1] : Elem | semmle.label | this [Return] : C [field s1] : Elem |
+| C.cs:16:13:16:13 | this [Return] : C [field s2] : Elem | semmle.label | this [Return] : C [field s2] : Elem |
+| C.cs:16:13:16:13 | this [Return] : C [field s2] : Elem | semmle.label | this [Return] : C [field s2] : Elem |
+| C.cs:16:13:16:13 | this [Return] : C [field s3] : Elem | semmle.label | this [Return] : C [field s3] : Elem |
+| C.cs:16:13:16:13 | this [Return] : C [field s3] : Elem | semmle.label | this [Return] : C [field s3] : Elem |
+| C.cs:16:13:16:13 | this [Return] : C [property s5] : Elem | semmle.label | this [Return] : C [property s5] : Elem |
+| C.cs:16:13:16:13 | this [Return] : C [property s5] : Elem | semmle.label | this [Return] : C [property s5] : Elem |
 | C.cs:18:9:18:12 | [post] this access : C [field s3] : Elem | semmle.label | [post] this access : C [field s3] : Elem |
 | C.cs:18:9:18:12 | [post] this access : C [field s3] : Elem | semmle.label | [post] this access : C [field s3] : Elem |
 | C.cs:18:19:18:33 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
@@ -1483,6 +1591,8 @@ nodes
 | D.cs:8:22:8:25 | this access : D [field trivialPropField] : Object | semmle.label | this access : D [field trivialPropField] : Object |
 | D.cs:8:22:8:42 | access to field trivialPropField : Object | semmle.label | access to field trivialPropField : Object |
 | D.cs:8:22:8:42 | access to field trivialPropField : Object | semmle.label | access to field trivialPropField : Object |
+| D.cs:9:9:9:11 | this [Return] : D [field trivialPropField] : Object | semmle.label | this [Return] : D [field trivialPropField] : Object |
+| D.cs:9:9:9:11 | this [Return] : D [field trivialPropField] : Object | semmle.label | this [Return] : D [field trivialPropField] : Object |
 | D.cs:9:9:9:11 | value : Object | semmle.label | value : Object |
 | D.cs:9:9:9:11 | value : Object | semmle.label | value : Object |
 | D.cs:9:15:9:18 | [post] this access : D [field trivialPropField] : Object | semmle.label | [post] this access : D [field trivialPropField] : Object |
@@ -1495,6 +1605,8 @@ nodes
 | D.cs:14:22:14:25 | this access : D [field trivialPropField] : Object | semmle.label | this access : D [field trivialPropField] : Object |
 | D.cs:14:22:14:42 | access to field trivialPropField : Object | semmle.label | access to field trivialPropField : Object |
 | D.cs:14:22:14:42 | access to field trivialPropField : Object | semmle.label | access to field trivialPropField : Object |
+| D.cs:15:9:15:11 | this [Return] : D [field trivialPropField] : Object | semmle.label | this [Return] : D [field trivialPropField] : Object |
+| D.cs:15:9:15:11 | this [Return] : D [field trivialPropField] : Object | semmle.label | this [Return] : D [field trivialPropField] : Object |
 | D.cs:15:9:15:11 | value : Object | semmle.label | value : Object |
 | D.cs:15:9:15:11 | value : Object | semmle.label | value : Object |
 | D.cs:15:15:15:18 | [post] this access : D [field trivialPropField] : Object | semmle.label | [post] this access : D [field trivialPropField] : Object |
@@ -1597,6 +1709,8 @@ nodes
 | E.cs:24:14:24:14 | access to local variable s : S [field Field] : Object | semmle.label | access to local variable s : S [field Field] : Object |
 | E.cs:24:14:24:20 | access to field Field | semmle.label | access to field Field |
 | E.cs:24:14:24:20 | access to field Field | semmle.label | access to field Field |
+| E.cs:43:36:43:36 | s [Return] : RefS [field RefField] : Object | semmle.label | s [Return] : RefS [field RefField] : Object |
+| E.cs:43:36:43:36 | s [Return] : RefS [field RefField] : Object | semmle.label | s [Return] : RefS [field RefField] : Object |
 | E.cs:43:46:43:46 | o : Object | semmle.label | o : Object |
 | E.cs:43:46:43:46 | o : Object | semmle.label | o : Object |
 | E.cs:46:9:46:9 | [post] access to parameter s : RefS [field RefField] : Object | semmle.label | [post] access to parameter s : RefS [field RefField] : Object |
@@ -1775,6 +1889,8 @@ nodes
 | G.cs:63:34:63:37 | access to field Elem : Elem | semmle.label | access to field Elem : Elem |
 | G.cs:63:34:63:37 | this access : Box1 [field Elem] : Elem | semmle.label | this access : Box1 [field Elem] : Elem |
 | G.cs:63:34:63:37 | this access : Box1 [field Elem] : Elem | semmle.label | this access : Box1 [field Elem] : Elem |
+| G.cs:64:21:64:27 | this [Return] : Box1 [field Elem] : Elem | semmle.label | this [Return] : Box1 [field Elem] : Elem |
+| G.cs:64:21:64:27 | this [Return] : Box1 [field Elem] : Elem | semmle.label | this [Return] : Box1 [field Elem] : Elem |
 | G.cs:64:34:64:34 | e : Elem | semmle.label | e : Elem |
 | G.cs:64:34:64:34 | e : Elem | semmle.label | e : Elem |
 | G.cs:64:39:64:42 | [post] this access : Box1 [field Elem] : Elem | semmle.label | [post] this access : Box1 [field Elem] : Elem |
@@ -1847,6 +1963,8 @@ nodes
 | H.cs:45:14:45:21 | access to field FieldB | semmle.label | access to field FieldB |
 | H.cs:53:25:53:25 | a : A [field FieldA] : Object | semmle.label | a : A [field FieldA] : Object |
 | H.cs:53:25:53:25 | a : A [field FieldA] : Object | semmle.label | a : A [field FieldA] : Object |
+| H.cs:53:30:53:31 | b1 [Return] : B [field FieldB] : Object | semmle.label | b1 [Return] : B [field FieldB] : Object |
+| H.cs:53:30:53:31 | b1 [Return] : B [field FieldB] : Object | semmle.label | b1 [Return] : B [field FieldB] : Object |
 | H.cs:55:9:55:10 | [post] access to parameter b1 : B [field FieldB] : Object | semmle.label | [post] access to parameter b1 : B [field FieldB] : Object |
 | H.cs:55:9:55:10 | [post] access to parameter b1 : B [field FieldB] : Object | semmle.label | [post] access to parameter b1 : B [field FieldB] : Object |
 | H.cs:55:21:55:21 | access to parameter a : A [field FieldA] : Object | semmle.label | access to parameter a : A [field FieldA] : Object |
@@ -1865,8 +1983,12 @@ nodes
 | H.cs:65:14:65:15 | access to local variable b1 : B [field FieldB] : Object | semmle.label | access to local variable b1 : B [field FieldB] : Object |
 | H.cs:65:14:65:22 | access to field FieldB | semmle.label | access to field FieldB |
 | H.cs:65:14:65:22 | access to field FieldB | semmle.label | access to field FieldB |
+| H.cs:77:20:77:20 | a [Return] : A [field FieldA] : Object | semmle.label | a [Return] : A [field FieldA] : Object |
+| H.cs:77:20:77:20 | a [Return] : A [field FieldA] : Object | semmle.label | a [Return] : A [field FieldA] : Object |
 | H.cs:77:30:77:30 | o : Object | semmle.label | o : Object |
 | H.cs:77:30:77:30 | o : Object | semmle.label | o : Object |
+| H.cs:77:35:77:36 | b1 [Return] : B [field FieldB] : Object | semmle.label | b1 [Return] : B [field FieldB] : Object |
+| H.cs:77:35:77:36 | b1 [Return] : B [field FieldB] : Object | semmle.label | b1 [Return] : B [field FieldB] : Object |
 | H.cs:79:9:79:9 | [post] access to parameter a : A [field FieldA] : Object | semmle.label | [post] access to parameter a : A [field FieldA] : Object |
 | H.cs:79:9:79:9 | [post] access to parameter a : A [field FieldA] : Object | semmle.label | [post] access to parameter a : A [field FieldA] : Object |
 | H.cs:79:20:79:20 | access to parameter o : Object | semmle.label | access to parameter o : Object |
@@ -1953,6 +2075,10 @@ nodes
 | H.cs:147:25:147:38 | call to method Source<A> : A | semmle.label | call to method Source<A> : A |
 | H.cs:148:14:148:14 | access to local variable a | semmle.label | access to local variable a |
 | H.cs:148:14:148:14 | access to local variable a | semmle.label | access to local variable a |
+| H.cs:153:22:153:22 | a [Return] : A [field FieldA, field FieldB] : Object | semmle.label | a [Return] : A [field FieldA, field FieldB] : Object |
+| H.cs:153:22:153:22 | a [Return] : A [field FieldA, field FieldB] : Object | semmle.label | a [Return] : A [field FieldA, field FieldB] : Object |
+| H.cs:153:22:153:22 | a [Return] : A [field FieldA] : B | semmle.label | a [Return] : A [field FieldA] : B |
+| H.cs:153:22:153:22 | a [Return] : A [field FieldA] : B | semmle.label | a [Return] : A [field FieldA] : B |
 | H.cs:153:32:153:32 | o : Object | semmle.label | o : Object |
 | H.cs:153:32:153:32 | o : Object | semmle.label | o : Object |
 | H.cs:155:13:155:13 | access to local variable b : B | semmle.label | access to local variable b : B |
@@ -2005,6 +2131,8 @@ nodes
 | H.cs:167:14:167:14 | access to local variable b : B [field FieldB] : Object | semmle.label | access to local variable b : B [field FieldB] : Object |
 | H.cs:167:14:167:21 | access to field FieldB | semmle.label | access to field FieldB |
 | H.cs:167:14:167:21 | access to field FieldB | semmle.label | access to field FieldB |
+| I.cs:5:12:5:12 | this [Return] : I [field Field1] : Object | semmle.label | this [Return] : I [field Field1] : Object |
+| I.cs:5:12:5:12 | this [Return] : I [field Field1] : Object | semmle.label | this [Return] : I [field Field1] : Object |
 | I.cs:7:9:7:14 | [post] this access : I [field Field1] : Object | semmle.label | [post] this access : I [field Field1] : Object |
 | I.cs:7:9:7:14 | [post] this access : I [field Field1] : Object | semmle.label | [post] this access : I [field Field1] : Object |
 | I.cs:7:18:7:34 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
@@ -2063,10 +2191,18 @@ nodes
 | I.cs:40:14:40:14 | access to parameter i : I [field Field1] : Object | semmle.label | access to parameter i : I [field Field1] : Object |
 | I.cs:40:14:40:21 | access to field Field1 | semmle.label | access to field Field1 |
 | I.cs:40:14:40:21 | access to field Field1 | semmle.label | access to field Field1 |
+| J.cs:6:21:6:31 | this [Return] : RecordClass [property Prop1] : Object | semmle.label | this [Return] : RecordClass [property Prop1] : Object |
+| J.cs:6:21:6:31 | this [Return] : RecordClass [property Prop1] : Object | semmle.label | this [Return] : RecordClass [property Prop1] : Object |
 | J.cs:6:40:6:44 | Prop1 : Object | semmle.label | Prop1 : Object |
 | J.cs:6:40:6:44 | Prop1 : Object | semmle.label | Prop1 : Object |
+| J.cs:8:22:8:33 | this [Return] : RecordStruct [property Prop1] : Object | semmle.label | this [Return] : RecordStruct [property Prop1] : Object |
+| J.cs:8:22:8:33 | this [Return] : RecordStruct [property Prop1] : Object | semmle.label | this [Return] : RecordStruct [property Prop1] : Object |
 | J.cs:8:42:8:46 | Prop1 : Object | semmle.label | Prop1 : Object |
 | J.cs:8:42:8:46 | Prop1 : Object | semmle.label | Prop1 : Object |
+| J.cs:14:12:14:17 | this [Return] : Struct [field Field] : Object | semmle.label | this [Return] : Struct [field Field] : Object |
+| J.cs:14:12:14:17 | this [Return] : Struct [field Field] : Object | semmle.label | this [Return] : Struct [field Field] : Object |
+| J.cs:14:12:14:17 | this [Return] : Struct [property Prop] : Object | semmle.label | this [Return] : Struct [property Prop] : Object |
+| J.cs:14:12:14:17 | this [Return] : Struct [property Prop] : Object | semmle.label | this [Return] : Struct [property Prop] : Object |
 | J.cs:14:26:14:30 | field : Object | semmle.label | field : Object |
 | J.cs:14:26:14:30 | field : Object | semmle.label | field : Object |
 | J.cs:14:40:14:43 | prop : Object | semmle.label | prop : Object |
@@ -2260,48 +2396,48 @@ nodes
 subpaths
 | A.cs:6:24:6:24 | access to local variable c : C | A.cs:147:32:147:32 | c : C | A.cs:149:20:149:27 | object creation of type B : B [field c] : C | A.cs:6:17:6:25 | call to method Make : B [field c] : C |
 | A.cs:6:24:6:24 | access to local variable c : C | A.cs:147:32:147:32 | c : C | A.cs:149:20:149:27 | object creation of type B : B [field c] : C | A.cs:6:17:6:25 | call to method Make : B [field c] : C |
-| A.cs:13:15:13:29 | call to method Source<C1> : C1 | A.cs:145:27:145:27 | c : C1 | A.cs:145:32:145:35 | [post] this access : B [field c] : C1 | A.cs:13:9:13:9 | [post] access to local variable b : B [field c] : C1 |
-| A.cs:13:15:13:29 | call to method Source<C1> : C1 | A.cs:145:27:145:27 | c : C1 | A.cs:145:32:145:35 | [post] this access : B [field c] : C1 | A.cs:13:9:13:9 | [post] access to local variable b : B [field c] : C1 |
+| A.cs:13:15:13:29 | call to method Source<C1> : C1 | A.cs:145:27:145:27 | c : C1 | A.cs:145:21:145:23 | this [Return] : B [field c] : C1 | A.cs:13:9:13:9 | [post] access to local variable b : B [field c] : C1 |
+| A.cs:13:15:13:29 | call to method Source<C1> : C1 | A.cs:145:27:145:27 | c : C1 | A.cs:145:21:145:23 | this [Return] : B [field c] : C1 | A.cs:13:9:13:9 | [post] access to local variable b : B [field c] : C1 |
 | A.cs:14:14:14:14 | access to local variable b : B [field c] : C1 | A.cs:146:18:146:20 | this : B [field c] : C1 | A.cs:146:33:146:38 | access to field c : C1 | A.cs:14:14:14:20 | call to method Get |
 | A.cs:14:14:14:14 | access to local variable b : B [field c] : C1 | A.cs:146:18:146:20 | this : B [field c] : C1 | A.cs:146:33:146:38 | access to field c : C1 | A.cs:14:14:14:20 | call to method Get |
 | A.cs:15:15:15:35 | object creation of type B : B [field c] : C | A.cs:146:18:146:20 | this : B [field c] : C | A.cs:146:33:146:38 | access to field c : C | A.cs:15:14:15:42 | call to method Get |
 | A.cs:15:15:15:35 | object creation of type B : B [field c] : C | A.cs:146:18:146:20 | this : B [field c] : C | A.cs:146:33:146:38 | access to field c : C | A.cs:15:14:15:42 | call to method Get |
-| A.cs:15:21:15:34 | call to method Source<C> : C | A.cs:141:20:141:20 | c : C | A.cs:143:13:143:16 | [post] this access : B [field c] : C | A.cs:15:15:15:35 | object creation of type B : B [field c] : C |
-| A.cs:15:21:15:34 | call to method Source<C> : C | A.cs:141:20:141:20 | c : C | A.cs:143:13:143:16 | [post] this access : B [field c] : C | A.cs:15:15:15:35 | object creation of type B : B [field c] : C |
+| A.cs:15:21:15:34 | call to method Source<C> : C | A.cs:141:20:141:20 | c : C | A.cs:141:16:141:16 | this [Return] : B [field c] : C | A.cs:15:15:15:35 | object creation of type B : B [field c] : C |
+| A.cs:15:21:15:34 | call to method Source<C> : C | A.cs:141:20:141:20 | c : C | A.cs:141:16:141:16 | this [Return] : B [field c] : C | A.cs:15:15:15:35 | object creation of type B : B [field c] : C |
 | A.cs:22:25:22:37 | call to method Source<C2> : C2 | A.cs:42:29:42:29 | c : C2 | A.cs:48:20:48:21 | access to local variable b2 : B [field c] : C2 | A.cs:22:14:22:38 | call to method SetOnB : B [field c] : C2 |
 | A.cs:22:25:22:37 | call to method Source<C2> : C2 | A.cs:42:29:42:29 | c : C2 | A.cs:48:20:48:21 | access to local variable b2 : B [field c] : C2 | A.cs:22:14:22:38 | call to method SetOnB : B [field c] : C2 |
 | A.cs:31:29:31:41 | call to method Source<C2> : C2 | A.cs:36:33:36:33 | c : C2 | A.cs:39:16:39:28 | ... ? ... : ... : B [field c] : C2 | A.cs:31:14:31:42 | call to method SetOnBWrap : B [field c] : C2 |
 | A.cs:31:29:31:41 | call to method Source<C2> : C2 | A.cs:36:33:36:33 | c : C2 | A.cs:39:16:39:28 | ... ? ... : ... : B [field c] : C2 | A.cs:31:14:31:42 | call to method SetOnBWrap : B [field c] : C2 |
 | A.cs:38:29:38:29 | access to parameter c : C2 | A.cs:42:29:42:29 | c : C2 | A.cs:48:20:48:21 | access to local variable b2 : B [field c] : C2 | A.cs:38:18:38:30 | call to method SetOnB : B [field c] : C2 |
 | A.cs:38:29:38:29 | access to parameter c : C2 | A.cs:42:29:42:29 | c : C2 | A.cs:48:20:48:21 | access to local variable b2 : B [field c] : C2 | A.cs:38:18:38:30 | call to method SetOnB : B [field c] : C2 |
-| A.cs:47:20:47:20 | access to parameter c : C2 | A.cs:145:27:145:27 | c : C2 | A.cs:145:32:145:35 | [post] this access : B [field c] : C2 | A.cs:47:13:47:14 | [post] access to local variable b2 : B [field c] : C2 |
-| A.cs:47:20:47:20 | access to parameter c : C2 | A.cs:145:27:145:27 | c : C2 | A.cs:145:32:145:35 | [post] this access : B [field c] : C2 | A.cs:47:13:47:14 | [post] access to local variable b2 : B [field c] : C2 |
-| A.cs:83:15:83:26 | call to method Source<C> : C | A.cs:145:27:145:27 | c : C | A.cs:145:32:145:35 | [post] this access : B [field c] : C | A.cs:83:9:83:9 | [post] access to parameter b : B [field c] : C |
-| A.cs:83:15:83:26 | call to method Source<C> : C | A.cs:145:27:145:27 | c : C | A.cs:145:32:145:35 | [post] this access : B [field c] : C | A.cs:83:9:83:9 | [post] access to parameter b : B [field c] : C |
-| A.cs:105:23:105:23 | access to local variable b : B | A.cs:95:20:95:20 | b : B | A.cs:98:13:98:16 | [post] this access : D [field b] : B | A.cs:105:17:105:29 | object creation of type D : D [field b] : B |
-| A.cs:105:23:105:23 | access to local variable b : B | A.cs:95:20:95:20 | b : B | A.cs:98:13:98:16 | [post] this access : D [field b] : B | A.cs:105:17:105:29 | object creation of type D : D [field b] : B |
-| A.cs:114:29:114:29 | access to local variable b : B | A.cs:157:25:157:28 | head : B | A.cs:159:13:159:16 | [post] this access : MyList [field head] : B | A.cs:114:18:114:54 | object creation of type MyList : MyList [field head] : B |
-| A.cs:114:29:114:29 | access to local variable b : B | A.cs:157:25:157:28 | head : B | A.cs:159:13:159:16 | [post] this access : MyList [field head] : B | A.cs:114:18:114:54 | object creation of type MyList : MyList [field head] : B |
-| A.cs:115:35:115:36 | access to local variable l1 : MyList [field head] : B | A.cs:157:38:157:41 | next : MyList [field head] : B | A.cs:160:13:160:16 | [post] this access : MyList [field next, field head] : B | A.cs:115:18:115:37 | object creation of type MyList : MyList [field next, field head] : B |
-| A.cs:115:35:115:36 | access to local variable l1 : MyList [field head] : B | A.cs:157:38:157:41 | next : MyList [field head] : B | A.cs:160:13:160:16 | [post] this access : MyList [field next, field head] : B | A.cs:115:18:115:37 | object creation of type MyList : MyList [field next, field head] : B |
-| A.cs:116:35:116:36 | access to local variable l2 : MyList [field next, field head] : B | A.cs:157:38:157:41 | next : MyList [field next, field head] : B | A.cs:160:13:160:16 | [post] this access : MyList [field next, field next, field head] : B | A.cs:116:18:116:37 | object creation of type MyList : MyList [field next, field next, field head] : B |
-| A.cs:116:35:116:36 | access to local variable l2 : MyList [field next, field head] : B | A.cs:157:38:157:41 | next : MyList [field next, field head] : B | A.cs:160:13:160:16 | [post] this access : MyList [field next, field next, field head] : B | A.cs:116:18:116:37 | object creation of type MyList : MyList [field next, field next, field head] : B |
-| A.cs:149:26:149:26 | access to parameter c : C | A.cs:141:20:141:20 | c : C | A.cs:143:13:143:16 | [post] this access : B [field c] : C | A.cs:149:20:149:27 | object creation of type B : B [field c] : C |
-| A.cs:149:26:149:26 | access to parameter c : C | A.cs:141:20:141:20 | c : C | A.cs:143:13:143:16 | [post] this access : B [field c] : C | A.cs:149:20:149:27 | object creation of type B : B [field c] : C |
-| B.cs:6:27:6:27 | access to local variable e : Elem | B.cs:29:26:29:27 | e1 : Elem | B.cs:31:13:31:16 | [post] this access : Box1 [field elem1] : Elem | B.cs:6:18:6:34 | object creation of type Box1 : Box1 [field elem1] : Elem |
-| B.cs:6:27:6:27 | access to local variable e : Elem | B.cs:29:26:29:27 | e1 : Elem | B.cs:31:13:31:16 | [post] this access : Box1 [field elem1] : Elem | B.cs:6:18:6:34 | object creation of type Box1 : Box1 [field elem1] : Elem |
-| B.cs:7:27:7:28 | access to local variable b1 : Box1 [field elem1] : Elem | B.cs:39:26:39:27 | b1 : Box1 [field elem1] : Elem | B.cs:41:13:41:16 | [post] this access : Box2 [field box1, field elem1] : Elem | B.cs:7:18:7:29 | object creation of type Box2 : Box2 [field box1, field elem1] : Elem |
-| B.cs:7:27:7:28 | access to local variable b1 : Box1 [field elem1] : Elem | B.cs:39:26:39:27 | b1 : Box1 [field elem1] : Elem | B.cs:41:13:41:16 | [post] this access : Box2 [field box1, field elem1] : Elem | B.cs:7:18:7:29 | object creation of type Box2 : Box2 [field box1, field elem1] : Elem |
-| B.cs:15:33:15:33 | access to local variable e : Elem | B.cs:29:35:29:36 | e2 : Elem | B.cs:32:13:32:16 | [post] this access : Box1 [field elem2] : Elem | B.cs:15:18:15:34 | object creation of type Box1 : Box1 [field elem2] : Elem |
-| B.cs:15:33:15:33 | access to local variable e : Elem | B.cs:29:35:29:36 | e2 : Elem | B.cs:32:13:32:16 | [post] this access : Box1 [field elem2] : Elem | B.cs:15:18:15:34 | object creation of type Box1 : Box1 [field elem2] : Elem |
-| B.cs:16:27:16:28 | access to local variable b1 : Box1 [field elem2] : Elem | B.cs:39:26:39:27 | b1 : Box1 [field elem2] : Elem | B.cs:41:13:41:16 | [post] this access : Box2 [field box1, field elem2] : Elem | B.cs:16:18:16:29 | object creation of type Box2 : Box2 [field box1, field elem2] : Elem |
-| B.cs:16:27:16:28 | access to local variable b1 : Box1 [field elem2] : Elem | B.cs:39:26:39:27 | b1 : Box1 [field elem2] : Elem | B.cs:41:13:41:16 | [post] this access : Box2 [field box1, field elem2] : Elem | B.cs:16:18:16:29 | object creation of type Box2 : Box2 [field box1, field elem2] : Elem |
-| D.cs:15:34:15:38 | access to parameter value : Object | D.cs:9:9:9:11 | value : Object | D.cs:9:15:9:18 | [post] this access : D [field trivialPropField] : Object | D.cs:15:15:15:18 | [post] this access : D [field trivialPropField] : Object |
-| D.cs:15:34:15:38 | access to parameter value : Object | D.cs:9:9:9:11 | value : Object | D.cs:9:15:9:18 | [post] this access : D [field trivialPropField] : Object | D.cs:15:15:15:18 | [post] this access : D [field trivialPropField] : Object |
-| D.cs:22:27:22:28 | access to parameter o2 : Object | D.cs:9:9:9:11 | value : Object | D.cs:9:15:9:18 | [post] this access : D [field trivialPropField] : Object | D.cs:22:9:22:11 | [post] access to local variable ret : D [field trivialPropField] : Object |
-| D.cs:22:27:22:28 | access to parameter o2 : Object | D.cs:9:9:9:11 | value : Object | D.cs:9:15:9:18 | [post] this access : D [field trivialPropField] : Object | D.cs:22:9:22:11 | [post] access to local variable ret : D [field trivialPropField] : Object |
-| D.cs:23:27:23:28 | access to parameter o3 : Object | D.cs:15:9:15:11 | value : Object | D.cs:15:15:15:18 | [post] this access : D [field trivialPropField] : Object | D.cs:23:9:23:11 | [post] access to local variable ret : D [field trivialPropField] : Object |
-| D.cs:23:27:23:28 | access to parameter o3 : Object | D.cs:15:9:15:11 | value : Object | D.cs:15:15:15:18 | [post] this access : D [field trivialPropField] : Object | D.cs:23:9:23:11 | [post] access to local variable ret : D [field trivialPropField] : Object |
+| A.cs:47:20:47:20 | access to parameter c : C2 | A.cs:145:27:145:27 | c : C2 | A.cs:145:21:145:23 | this [Return] : B [field c] : C2 | A.cs:47:13:47:14 | [post] access to local variable b2 : B [field c] : C2 |
+| A.cs:47:20:47:20 | access to parameter c : C2 | A.cs:145:27:145:27 | c : C2 | A.cs:145:21:145:23 | this [Return] : B [field c] : C2 | A.cs:47:13:47:14 | [post] access to local variable b2 : B [field c] : C2 |
+| A.cs:83:15:83:26 | call to method Source<C> : C | A.cs:145:27:145:27 | c : C | A.cs:145:21:145:23 | this [Return] : B [field c] : C | A.cs:83:9:83:9 | [post] access to parameter b : B [field c] : C |
+| A.cs:83:15:83:26 | call to method Source<C> : C | A.cs:145:27:145:27 | c : C | A.cs:145:21:145:23 | this [Return] : B [field c] : C | A.cs:83:9:83:9 | [post] access to parameter b : B [field c] : C |
+| A.cs:105:23:105:23 | access to local variable b : B | A.cs:95:20:95:20 | b : B | A.cs:95:16:95:16 | this [Return] : D [field b] : B | A.cs:105:17:105:29 | object creation of type D : D [field b] : B |
+| A.cs:105:23:105:23 | access to local variable b : B | A.cs:95:20:95:20 | b : B | A.cs:95:16:95:16 | this [Return] : D [field b] : B | A.cs:105:17:105:29 | object creation of type D : D [field b] : B |
+| A.cs:114:29:114:29 | access to local variable b : B | A.cs:157:25:157:28 | head : B | A.cs:157:16:157:21 | this [Return] : MyList [field head] : B | A.cs:114:18:114:54 | object creation of type MyList : MyList [field head] : B |
+| A.cs:114:29:114:29 | access to local variable b : B | A.cs:157:25:157:28 | head : B | A.cs:157:16:157:21 | this [Return] : MyList [field head] : B | A.cs:114:18:114:54 | object creation of type MyList : MyList [field head] : B |
+| A.cs:115:35:115:36 | access to local variable l1 : MyList [field head] : B | A.cs:157:38:157:41 | next : MyList [field head] : B | A.cs:157:16:157:21 | this [Return] : MyList [field next, field head] : B | A.cs:115:18:115:37 | object creation of type MyList : MyList [field next, field head] : B |
+| A.cs:115:35:115:36 | access to local variable l1 : MyList [field head] : B | A.cs:157:38:157:41 | next : MyList [field head] : B | A.cs:157:16:157:21 | this [Return] : MyList [field next, field head] : B | A.cs:115:18:115:37 | object creation of type MyList : MyList [field next, field head] : B |
+| A.cs:116:35:116:36 | access to local variable l2 : MyList [field next, field head] : B | A.cs:157:38:157:41 | next : MyList [field next, field head] : B | A.cs:157:16:157:21 | this [Return] : MyList [field next, field next, field head] : B | A.cs:116:18:116:37 | object creation of type MyList : MyList [field next, field next, field head] : B |
+| A.cs:116:35:116:36 | access to local variable l2 : MyList [field next, field head] : B | A.cs:157:38:157:41 | next : MyList [field next, field head] : B | A.cs:157:16:157:21 | this [Return] : MyList [field next, field next, field head] : B | A.cs:116:18:116:37 | object creation of type MyList : MyList [field next, field next, field head] : B |
+| A.cs:149:26:149:26 | access to parameter c : C | A.cs:141:20:141:20 | c : C | A.cs:141:16:141:16 | this [Return] : B [field c] : C | A.cs:149:20:149:27 | object creation of type B : B [field c] : C |
+| A.cs:149:26:149:26 | access to parameter c : C | A.cs:141:20:141:20 | c : C | A.cs:141:16:141:16 | this [Return] : B [field c] : C | A.cs:149:20:149:27 | object creation of type B : B [field c] : C |
+| B.cs:6:27:6:27 | access to local variable e : Elem | B.cs:29:26:29:27 | e1 : Elem | B.cs:29:16:29:19 | this [Return] : Box1 [field elem1] : Elem | B.cs:6:18:6:34 | object creation of type Box1 : Box1 [field elem1] : Elem |
+| B.cs:6:27:6:27 | access to local variable e : Elem | B.cs:29:26:29:27 | e1 : Elem | B.cs:29:16:29:19 | this [Return] : Box1 [field elem1] : Elem | B.cs:6:18:6:34 | object creation of type Box1 : Box1 [field elem1] : Elem |
+| B.cs:7:27:7:28 | access to local variable b1 : Box1 [field elem1] : Elem | B.cs:39:26:39:27 | b1 : Box1 [field elem1] : Elem | B.cs:39:16:39:19 | this [Return] : Box2 [field box1, field elem1] : Elem | B.cs:7:18:7:29 | object creation of type Box2 : Box2 [field box1, field elem1] : Elem |
+| B.cs:7:27:7:28 | access to local variable b1 : Box1 [field elem1] : Elem | B.cs:39:26:39:27 | b1 : Box1 [field elem1] : Elem | B.cs:39:16:39:19 | this [Return] : Box2 [field box1, field elem1] : Elem | B.cs:7:18:7:29 | object creation of type Box2 : Box2 [field box1, field elem1] : Elem |
+| B.cs:15:33:15:33 | access to local variable e : Elem | B.cs:29:35:29:36 | e2 : Elem | B.cs:29:16:29:19 | this [Return] : Box1 [field elem2] : Elem | B.cs:15:18:15:34 | object creation of type Box1 : Box1 [field elem2] : Elem |
+| B.cs:15:33:15:33 | access to local variable e : Elem | B.cs:29:35:29:36 | e2 : Elem | B.cs:29:16:29:19 | this [Return] : Box1 [field elem2] : Elem | B.cs:15:18:15:34 | object creation of type Box1 : Box1 [field elem2] : Elem |
+| B.cs:16:27:16:28 | access to local variable b1 : Box1 [field elem2] : Elem | B.cs:39:26:39:27 | b1 : Box1 [field elem2] : Elem | B.cs:39:16:39:19 | this [Return] : Box2 [field box1, field elem2] : Elem | B.cs:16:18:16:29 | object creation of type Box2 : Box2 [field box1, field elem2] : Elem |
+| B.cs:16:27:16:28 | access to local variable b1 : Box1 [field elem2] : Elem | B.cs:39:26:39:27 | b1 : Box1 [field elem2] : Elem | B.cs:39:16:39:19 | this [Return] : Box2 [field box1, field elem2] : Elem | B.cs:16:18:16:29 | object creation of type Box2 : Box2 [field box1, field elem2] : Elem |
+| D.cs:15:34:15:38 | access to parameter value : Object | D.cs:9:9:9:11 | value : Object | D.cs:9:9:9:11 | this [Return] : D [field trivialPropField] : Object | D.cs:15:15:15:18 | [post] this access : D [field trivialPropField] : Object |
+| D.cs:15:34:15:38 | access to parameter value : Object | D.cs:9:9:9:11 | value : Object | D.cs:9:9:9:11 | this [Return] : D [field trivialPropField] : Object | D.cs:15:15:15:18 | [post] this access : D [field trivialPropField] : Object |
+| D.cs:22:27:22:28 | access to parameter o2 : Object | D.cs:9:9:9:11 | value : Object | D.cs:9:9:9:11 | this [Return] : D [field trivialPropField] : Object | D.cs:22:9:22:11 | [post] access to local variable ret : D [field trivialPropField] : Object |
+| D.cs:22:27:22:28 | access to parameter o2 : Object | D.cs:9:9:9:11 | value : Object | D.cs:9:9:9:11 | this [Return] : D [field trivialPropField] : Object | D.cs:22:9:22:11 | [post] access to local variable ret : D [field trivialPropField] : Object |
+| D.cs:23:27:23:28 | access to parameter o3 : Object | D.cs:15:9:15:11 | value : Object | D.cs:15:9:15:11 | this [Return] : D [field trivialPropField] : Object | D.cs:23:9:23:11 | [post] access to local variable ret : D [field trivialPropField] : Object |
+| D.cs:23:27:23:28 | access to parameter o3 : Object | D.cs:15:9:15:11 | value : Object | D.cs:15:9:15:11 | this [Return] : D [field trivialPropField] : Object | D.cs:23:9:23:11 | [post] access to local variable ret : D [field trivialPropField] : Object |
 | D.cs:31:24:31:24 | access to local variable o : Object | D.cs:18:28:18:29 | o1 : Object | D.cs:24:16:24:18 | access to local variable ret : D [property AutoProp] : Object | D.cs:31:17:31:37 | call to method Create : D [property AutoProp] : Object |
 | D.cs:31:24:31:24 | access to local variable o : Object | D.cs:18:28:18:29 | o1 : Object | D.cs:24:16:24:18 | access to local variable ret : D [property AutoProp] : Object | D.cs:31:17:31:37 | call to method Create : D [property AutoProp] : Object |
 | D.cs:37:26:37:42 | call to method Source<Object> : Object | D.cs:18:39:18:40 | o2 : Object | D.cs:24:16:24:18 | access to local variable ret : D [field trivialPropField] : Object | D.cs:37:13:37:49 | call to method Create : D [field trivialPropField] : Object |
@@ -2318,16 +2454,16 @@ subpaths
 | D.cs:47:14:47:14 | access to local variable d : D [field trivialPropField] : Object | D.cs:14:9:14:11 | this : D [field trivialPropField] : Object | D.cs:14:22:14:42 | access to field trivialPropField : Object | D.cs:47:14:47:26 | access to property ComplexProp |
 | E.cs:23:25:23:25 | access to local variable o : Object | E.cs:8:29:8:29 | o : Object | E.cs:12:16:12:18 | access to local variable ret : S [field Field] : Object | E.cs:23:17:23:26 | call to method CreateS : S [field Field] : Object |
 | E.cs:23:25:23:25 | access to local variable o : Object | E.cs:8:29:8:29 | o : Object | E.cs:12:16:12:18 | access to local variable ret : S [field Field] : Object | E.cs:23:17:23:26 | call to method CreateS : S [field Field] : Object |
-| E.cs:55:29:55:33 | access to local variable taint : Object | E.cs:43:46:43:46 | o : Object | E.cs:46:9:46:9 | [post] access to parameter s : RefS [field RefField] : Object | E.cs:55:23:55:26 | [post] access to local variable refs : RefS [field RefField] : Object |
-| E.cs:55:29:55:33 | access to local variable taint : Object | E.cs:43:46:43:46 | o : Object | E.cs:46:9:46:9 | [post] access to parameter s : RefS [field RefField] : Object | E.cs:55:23:55:26 | [post] access to local variable refs : RefS [field RefField] : Object |
+| E.cs:55:29:55:33 | access to local variable taint : Object | E.cs:43:46:43:46 | o : Object | E.cs:43:36:43:36 | s [Return] : RefS [field RefField] : Object | E.cs:55:23:55:26 | [post] access to local variable refs : RefS [field RefField] : Object |
+| E.cs:55:29:55:33 | access to local variable taint : Object | E.cs:43:46:43:46 | o : Object | E.cs:43:36:43:36 | s [Return] : RefS [field RefField] : Object | E.cs:55:23:55:26 | [post] access to local variable refs : RefS [field RefField] : Object |
 | F.cs:11:24:11:24 | access to local variable o : Object | F.cs:6:28:6:29 | o1 : Object | F.cs:6:46:6:81 | object creation of type F : F [field Field1] : Object | F.cs:11:17:11:31 | call to method Create : F [field Field1] : Object |
 | F.cs:11:24:11:24 | access to local variable o : Object | F.cs:6:28:6:29 | o1 : Object | F.cs:6:46:6:81 | object creation of type F : F [field Field1] : Object | F.cs:11:17:11:31 | call to method Create : F [field Field1] : Object |
 | F.cs:15:26:15:42 | call to method Source<Object> : Object | F.cs:6:39:6:40 | o2 : Object | F.cs:6:46:6:81 | object creation of type F : F [field Field2] : Object | F.cs:15:13:15:43 | call to method Create : F [field Field2] : Object |
 | F.cs:15:26:15:42 | call to method Source<Object> : Object | F.cs:6:39:6:40 | o2 : Object | F.cs:6:46:6:81 | object creation of type F : F [field Field2] : Object | F.cs:15:13:15:43 | call to method Create : F [field Field2] : Object |
-| G.cs:17:24:17:24 | access to local variable e : Elem | G.cs:64:34:64:34 | e : Elem | G.cs:64:39:64:42 | [post] this access : Box1 [field Elem] : Elem | G.cs:17:9:17:14 | [post] access to field Box1 : Box1 [field Elem] : Elem |
-| G.cs:17:24:17:24 | access to local variable e : Elem | G.cs:64:34:64:34 | e : Elem | G.cs:64:39:64:42 | [post] this access : Box1 [field Elem] : Elem | G.cs:17:9:17:14 | [post] access to field Box1 : Box1 [field Elem] : Elem |
-| G.cs:33:29:33:29 | access to local variable e : Elem | G.cs:64:34:64:34 | e : Elem | G.cs:64:39:64:42 | [post] this access : Box1 [field Elem] : Elem | G.cs:33:9:33:19 | [post] call to method GetBox1 : Box1 [field Elem] : Elem |
-| G.cs:33:29:33:29 | access to local variable e : Elem | G.cs:64:34:64:34 | e : Elem | G.cs:64:39:64:42 | [post] this access : Box1 [field Elem] : Elem | G.cs:33:9:33:19 | [post] call to method GetBox1 : Box1 [field Elem] : Elem |
+| G.cs:17:24:17:24 | access to local variable e : Elem | G.cs:64:34:64:34 | e : Elem | G.cs:64:21:64:27 | this [Return] : Box1 [field Elem] : Elem | G.cs:17:9:17:14 | [post] access to field Box1 : Box1 [field Elem] : Elem |
+| G.cs:17:24:17:24 | access to local variable e : Elem | G.cs:64:34:64:34 | e : Elem | G.cs:64:21:64:27 | this [Return] : Box1 [field Elem] : Elem | G.cs:17:9:17:14 | [post] access to field Box1 : Box1 [field Elem] : Elem |
+| G.cs:33:29:33:29 | access to local variable e : Elem | G.cs:64:34:64:34 | e : Elem | G.cs:64:21:64:27 | this [Return] : Box1 [field Elem] : Elem | G.cs:33:9:33:19 | [post] call to method GetBox1 : Box1 [field Elem] : Elem |
+| G.cs:33:29:33:29 | access to local variable e : Elem | G.cs:64:34:64:34 | e : Elem | G.cs:64:21:64:27 | this [Return] : Box1 [field Elem] : Elem | G.cs:33:9:33:19 | [post] call to method GetBox1 : Box1 [field Elem] : Elem |
 | G.cs:39:14:39:15 | access to parameter b2 : Box2 [field Box1, field Elem] : Elem | G.cs:71:21:71:27 | this : Box2 [field Box1, field Elem] : Elem | G.cs:71:34:71:37 | access to field Box1 : Box1 [field Elem] : Elem | G.cs:39:14:39:25 | call to method GetBox1 : Box1 [field Elem] : Elem |
 | G.cs:39:14:39:15 | access to parameter b2 : Box2 [field Box1, field Elem] : Elem | G.cs:71:21:71:27 | this : Box2 [field Box1, field Elem] : Elem | G.cs:71:34:71:37 | access to field Box1 : Box1 [field Elem] : Elem | G.cs:39:14:39:25 | call to method GetBox1 : Box1 [field Elem] : Elem |
 | G.cs:39:14:39:25 | call to method GetBox1 : Box1 [field Elem] : Elem | G.cs:63:21:63:27 | this : Box1 [field Elem] : Elem | G.cs:63:34:63:37 | access to field Elem : Elem | G.cs:39:14:39:35 | call to method GetElem |
@@ -2336,14 +2472,14 @@ subpaths
 | H.cs:24:27:24:27 | access to local variable a : A [field FieldA] : Object | H.cs:13:15:13:15 | a : A [field FieldA] : Object | H.cs:17:16:17:18 | access to local variable ret : A [field FieldA] : Object | H.cs:24:21:24:28 | call to method Clone : A [field FieldA] : Object |
 | H.cs:44:27:44:27 | access to local variable a : A [field FieldA] : Object | H.cs:33:19:33:19 | a : A [field FieldA] : Object | H.cs:37:16:37:16 | access to local variable b : B [field FieldB] : Object | H.cs:44:17:44:28 | call to method Transform : B [field FieldB] : Object |
 | H.cs:44:27:44:27 | access to local variable a : A [field FieldA] : Object | H.cs:33:19:33:19 | a : A [field FieldA] : Object | H.cs:37:16:37:16 | access to local variable b : B [field FieldB] : Object | H.cs:44:17:44:28 | call to method Transform : B [field FieldB] : Object |
-| H.cs:64:22:64:22 | access to local variable a : A [field FieldA] : Object | H.cs:53:25:53:25 | a : A [field FieldA] : Object | H.cs:55:9:55:10 | [post] access to parameter b1 : B [field FieldB] : Object | H.cs:64:25:64:26 | [post] access to local variable b1 : B [field FieldB] : Object |
-| H.cs:64:22:64:22 | access to local variable a : A [field FieldA] : Object | H.cs:53:25:53:25 | a : A [field FieldA] : Object | H.cs:55:9:55:10 | [post] access to parameter b1 : B [field FieldB] : Object | H.cs:64:25:64:26 | [post] access to local variable b1 : B [field FieldB] : Object |
-| H.cs:80:22:80:22 | access to parameter a : A [field FieldA] : Object | H.cs:53:25:53:25 | a : A [field FieldA] : Object | H.cs:55:9:55:10 | [post] access to parameter b1 : B [field FieldB] : Object | H.cs:80:25:80:26 | [post] access to parameter b1 : B [field FieldB] : Object |
-| H.cs:80:22:80:22 | access to parameter a : A [field FieldA] : Object | H.cs:53:25:53:25 | a : A [field FieldA] : Object | H.cs:55:9:55:10 | [post] access to parameter b1 : B [field FieldB] : Object | H.cs:80:25:80:26 | [post] access to parameter b1 : B [field FieldB] : Object |
-| H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:77:30:77:30 | o : Object | H.cs:79:9:79:9 | [post] access to parameter a : A [field FieldA] : Object | H.cs:88:17:88:17 | [post] access to local variable a : A [field FieldA] : Object |
-| H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:77:30:77:30 | o : Object | H.cs:79:9:79:9 | [post] access to parameter a : A [field FieldA] : Object | H.cs:88:17:88:17 | [post] access to local variable a : A [field FieldA] : Object |
-| H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:77:30:77:30 | o : Object | H.cs:80:25:80:26 | [post] access to parameter b1 : B [field FieldB] : Object | H.cs:88:39:88:40 | [post] access to local variable b1 : B [field FieldB] : Object |
-| H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:77:30:77:30 | o : Object | H.cs:80:25:80:26 | [post] access to parameter b1 : B [field FieldB] : Object | H.cs:88:39:88:40 | [post] access to local variable b1 : B [field FieldB] : Object |
+| H.cs:64:22:64:22 | access to local variable a : A [field FieldA] : Object | H.cs:53:25:53:25 | a : A [field FieldA] : Object | H.cs:53:30:53:31 | b1 [Return] : B [field FieldB] : Object | H.cs:64:25:64:26 | [post] access to local variable b1 : B [field FieldB] : Object |
+| H.cs:64:22:64:22 | access to local variable a : A [field FieldA] : Object | H.cs:53:25:53:25 | a : A [field FieldA] : Object | H.cs:53:30:53:31 | b1 [Return] : B [field FieldB] : Object | H.cs:64:25:64:26 | [post] access to local variable b1 : B [field FieldB] : Object |
+| H.cs:80:22:80:22 | access to parameter a : A [field FieldA] : Object | H.cs:53:25:53:25 | a : A [field FieldA] : Object | H.cs:53:30:53:31 | b1 [Return] : B [field FieldB] : Object | H.cs:80:25:80:26 | [post] access to parameter b1 : B [field FieldB] : Object |
+| H.cs:80:22:80:22 | access to parameter a : A [field FieldA] : Object | H.cs:53:25:53:25 | a : A [field FieldA] : Object | H.cs:53:30:53:31 | b1 [Return] : B [field FieldB] : Object | H.cs:80:25:80:26 | [post] access to parameter b1 : B [field FieldB] : Object |
+| H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:77:30:77:30 | o : Object | H.cs:77:20:77:20 | a [Return] : A [field FieldA] : Object | H.cs:88:17:88:17 | [post] access to local variable a : A [field FieldA] : Object |
+| H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:77:30:77:30 | o : Object | H.cs:77:20:77:20 | a [Return] : A [field FieldA] : Object | H.cs:88:17:88:17 | [post] access to local variable a : A [field FieldA] : Object |
+| H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:77:30:77:30 | o : Object | H.cs:77:35:77:36 | b1 [Return] : B [field FieldB] : Object | H.cs:88:39:88:40 | [post] access to local variable b1 : B [field FieldB] : Object |
+| H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:77:30:77:30 | o : Object | H.cs:77:35:77:36 | b1 [Return] : B [field FieldB] : Object | H.cs:88:39:88:40 | [post] access to local variable b1 : B [field FieldB] : Object |
 | H.cs:106:26:106:39 | (...) ... : A [field FieldA] : Object | H.cs:33:19:33:19 | a : A [field FieldA] : Object | H.cs:37:16:37:16 | access to local variable b : B [field FieldB] : Object | H.cs:106:16:106:40 | call to method Transform : B [field FieldB] : Object |
 | H.cs:106:26:106:39 | (...) ... : A [field FieldA] : Object | H.cs:33:19:33:19 | a : A [field FieldA] : Object | H.cs:37:16:37:16 | access to local variable b : B [field FieldB] : Object | H.cs:106:16:106:40 | call to method Transform : B [field FieldB] : Object |
 | H.cs:113:31:113:31 | access to local variable a : A [field FieldA] : Object | H.cs:102:23:102:23 | a : A [field FieldA] : Object | H.cs:106:16:106:40 | call to method Transform : B [field FieldB] : Object | H.cs:113:17:113:32 | call to method TransformWrap : B [field FieldB] : Object |
@@ -2356,16 +2492,16 @@ subpaths
 | H.cs:142:26:142:26 | access to local variable a : A [field FieldA] : A | H.cs:33:19:33:19 | a : A [field FieldA] : A | H.cs:37:16:37:16 | access to local variable b : B [field FieldB] : A | H.cs:142:16:142:27 | call to method Transform : B [field FieldB] : A |
 | H.cs:147:25:147:38 | call to method Source<A> : A | H.cs:138:27:138:27 | o : A | H.cs:142:16:142:34 | access to field FieldB : A | H.cs:147:17:147:39 | call to method Through : A |
 | H.cs:147:25:147:38 | call to method Source<A> : A | H.cs:138:27:138:27 | o : A | H.cs:142:16:142:34 | access to field FieldB : A | H.cs:147:17:147:39 | call to method Through : A |
-| H.cs:164:22:164:22 | access to local variable o : Object | H.cs:153:32:153:32 | o : Object | H.cs:157:9:157:9 | [post] access to parameter a : A [field FieldA, field FieldB] : Object | H.cs:164:19:164:19 | [post] access to local variable a : A [field FieldA, field FieldB] : Object |
-| H.cs:164:22:164:22 | access to local variable o : Object | H.cs:153:32:153:32 | o : Object | H.cs:157:9:157:9 | [post] access to parameter a : A [field FieldA, field FieldB] : Object | H.cs:164:19:164:19 | [post] access to local variable a : A [field FieldA, field FieldB] : Object |
-| J.cs:22:34:22:34 | access to local variable o : Object | J.cs:6:40:6:44 | Prop1 : Object | J.cs:6:40:6:44 | Prop1 : Object | J.cs:22:18:22:41 | object creation of type RecordClass : RecordClass [property Prop1] : Object |
-| J.cs:22:34:22:34 | access to local variable o : Object | J.cs:6:40:6:44 | Prop1 : Object | J.cs:6:40:6:44 | Prop1 : Object | J.cs:22:18:22:41 | object creation of type RecordClass : RecordClass [property Prop1] : Object |
-| J.cs:42:35:42:35 | access to local variable o : Object | J.cs:8:42:8:46 | Prop1 : Object | J.cs:8:42:8:46 | Prop1 : Object | J.cs:42:18:42:42 | object creation of type RecordStruct : RecordStruct [property Prop1] : Object |
-| J.cs:42:35:42:35 | access to local variable o : Object | J.cs:8:42:8:46 | Prop1 : Object | J.cs:8:42:8:46 | Prop1 : Object | J.cs:42:18:42:42 | object creation of type RecordStruct : RecordStruct [property Prop1] : Object |
-| J.cs:62:29:62:29 | access to local variable o : Object | J.cs:14:26:14:30 | field : Object | J.cs:14:50:14:54 | [post] this access : Struct [field Field] : Object | J.cs:62:18:62:36 | object creation of type Struct : Struct [field Field] : Object |
-| J.cs:62:29:62:29 | access to local variable o : Object | J.cs:14:26:14:30 | field : Object | J.cs:14:50:14:54 | [post] this access : Struct [field Field] : Object | J.cs:62:18:62:36 | object creation of type Struct : Struct [field Field] : Object |
-| J.cs:80:35:80:35 | access to local variable o : Object | J.cs:14:40:14:43 | prop : Object | J.cs:14:57:14:60 | [post] this access : Struct [property Prop] : Object | J.cs:80:18:80:36 | object creation of type Struct : Struct [property Prop] : Object |
-| J.cs:80:35:80:35 | access to local variable o : Object | J.cs:14:40:14:43 | prop : Object | J.cs:14:57:14:60 | [post] this access : Struct [property Prop] : Object | J.cs:80:18:80:36 | object creation of type Struct : Struct [property Prop] : Object |
+| H.cs:164:22:164:22 | access to local variable o : Object | H.cs:153:32:153:32 | o : Object | H.cs:153:22:153:22 | a [Return] : A [field FieldA, field FieldB] : Object | H.cs:164:19:164:19 | [post] access to local variable a : A [field FieldA, field FieldB] : Object |
+| H.cs:164:22:164:22 | access to local variable o : Object | H.cs:153:32:153:32 | o : Object | H.cs:153:22:153:22 | a [Return] : A [field FieldA, field FieldB] : Object | H.cs:164:19:164:19 | [post] access to local variable a : A [field FieldA, field FieldB] : Object |
+| J.cs:22:34:22:34 | access to local variable o : Object | J.cs:6:40:6:44 | Prop1 : Object | J.cs:6:21:6:31 | this [Return] : RecordClass [property Prop1] : Object | J.cs:22:18:22:41 | object creation of type RecordClass : RecordClass [property Prop1] : Object |
+| J.cs:22:34:22:34 | access to local variable o : Object | J.cs:6:40:6:44 | Prop1 : Object | J.cs:6:21:6:31 | this [Return] : RecordClass [property Prop1] : Object | J.cs:22:18:22:41 | object creation of type RecordClass : RecordClass [property Prop1] : Object |
+| J.cs:42:35:42:35 | access to local variable o : Object | J.cs:8:42:8:46 | Prop1 : Object | J.cs:8:22:8:33 | this [Return] : RecordStruct [property Prop1] : Object | J.cs:42:18:42:42 | object creation of type RecordStruct : RecordStruct [property Prop1] : Object |
+| J.cs:42:35:42:35 | access to local variable o : Object | J.cs:8:42:8:46 | Prop1 : Object | J.cs:8:22:8:33 | this [Return] : RecordStruct [property Prop1] : Object | J.cs:42:18:42:42 | object creation of type RecordStruct : RecordStruct [property Prop1] : Object |
+| J.cs:62:29:62:29 | access to local variable o : Object | J.cs:14:26:14:30 | field : Object | J.cs:14:12:14:17 | this [Return] : Struct [field Field] : Object | J.cs:62:18:62:36 | object creation of type Struct : Struct [field Field] : Object |
+| J.cs:62:29:62:29 | access to local variable o : Object | J.cs:14:26:14:30 | field : Object | J.cs:14:12:14:17 | this [Return] : Struct [field Field] : Object | J.cs:62:18:62:36 | object creation of type Struct : Struct [field Field] : Object |
+| J.cs:80:35:80:35 | access to local variable o : Object | J.cs:14:40:14:43 | prop : Object | J.cs:14:12:14:17 | this [Return] : Struct [property Prop] : Object | J.cs:80:18:80:36 | object creation of type Struct : Struct [property Prop] : Object |
+| J.cs:80:35:80:35 | access to local variable o : Object | J.cs:14:40:14:43 | prop : Object | J.cs:14:12:14:17 | this [Return] : Struct [property Prop] : Object | J.cs:80:18:80:36 | object creation of type Struct : Struct [property Prop] : Object |
 #select
 | A.cs:7:14:7:16 | access to field c | A.cs:5:17:5:28 | call to method Source<C> : C | A.cs:7:14:7:16 | access to field c | $@ | A.cs:5:17:5:28 | call to method Source<C> : C | call to method Source<C> : C |
 | A.cs:7:14:7:16 | access to field c | A.cs:5:17:5:28 | call to method Source<C> : C | A.cs:7:14:7:16 | access to field c | $@ | A.cs:5:17:5:28 | call to method Source<C> : C | call to method Source<C> : C |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
@@ -126,7 +126,8 @@ edges
 | Capture.cs:350:34:350:34 | a : (...) => ... [captured s] : String | Capture.cs:352:9:352:9 | access to parameter a : (...) => ... [captured s] : String | provenance |  |
 | Capture.cs:350:34:350:34 | a : (...) => ... [captured sink39] : String | Capture.cs:352:9:352:9 | access to parameter a : (...) => ... [captured sink39] : String | provenance |  |
 | Capture.cs:350:34:350:34 | a : (...) => ... [captured sink39] : String | Capture.cs:352:9:352:9 | access to parameter a : (...) => ... [captured sink39] : String | provenance |  |
-| Capture.cs:352:9:352:9 | [post] access to parameter a : (...) => ... [captured sink40] : String | Capture.cs:114:23:117:13 | [post] (...) => ... : (...) => ... [captured sink40] : String | provenance |  |
+| Capture.cs:350:34:350:34 | a [Return] : (...) => ... [captured sink40] : String | Capture.cs:114:23:117:13 | [post] (...) => ... : (...) => ... [captured sink40] : String | provenance |  |
+| Capture.cs:352:9:352:9 | [post] access to parameter a : (...) => ... [captured sink40] : String | Capture.cs:350:34:350:34 | a [Return] : (...) => ... [captured sink40] : String | provenance |  |
 | Capture.cs:352:9:352:9 | access to parameter a : (...) => ... [captured s] : String | Capture.cs:217:19:217:19 | access to parameter s | provenance |  |
 | Capture.cs:352:9:352:9 | access to parameter a : (...) => ... [captured sink39] : String | Capture.cs:55:27:58:17 | (...) => ... : (...) => ... [captured sink39] : String | provenance |  |
 | Capture.cs:352:9:352:9 | access to parameter a : (...) => ... [captured sink39] : String | Capture.cs:57:27:57:32 | access to parameter sink39 | provenance |  |
@@ -408,19 +409,20 @@ edges
 | GlobalDataFlow.cs:469:21:469:21 | s : String | GlobalDataFlow.cs:469:32:469:32 | access to parameter s | provenance |  |
 | GlobalDataFlow.cs:470:15:470:17 | access to parameter arg : String | GlobalDataFlow.cs:469:21:469:21 | s : String | provenance |  |
 | GlobalDataFlow.cs:473:28:473:41 | "taint source" : String | GlobalDataFlow.cs:466:53:466:55 | arg : String | provenance |  |
-| GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | GlobalDataFlow.cs:490:25:490:26 | [post] access to local variable x1 : SimpleClass [field field] : String | provenance |  |
-| GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | GlobalDataFlow.cs:490:30:490:31 | [post] access to local variable x2 : SimpleClass [field field] : String | provenance |  |
-| GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | GlobalDataFlow.cs:497:31:497:32 | [post] access to local variable y1 : SimpleClass [field field] : String | provenance |  |
-| GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | GlobalDataFlow.cs:497:36:497:37 | [post] access to local variable y2 : SimpleClass [field field] : String | provenance |  |
-| GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | GlobalDataFlow.cs:497:42:497:43 | [post] access to local variable y3 : SimpleClass [field field] : String | provenance |  |
-| GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | GlobalDataFlow.cs:508:33:508:33 | [post] access to local variable x : SubSimpleClass [field field] : String | provenance |  |
-| GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | GlobalDataFlow.cs:515:20:515:20 | [post] access to parameter x : SimpleClass [field field] : String | provenance |  |
-| GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | GlobalDataFlow.cs:515:25:515:25 | [post] access to local variable y : SimpleClass [field field] : String | provenance |  |
-| GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | GlobalDataFlow.cs:527:20:527:20 | [post] access to local variable x : SimpleClass [field field] : String | provenance |  |
-| GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | GlobalDataFlow.cs:528:20:528:20 | [post] access to local variable y : SimpleClass [field field] : String | provenance |  |
-| GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | GlobalDataFlow.cs:529:18:529:18 | [post] access to local variable z : SimpleClass [field field] : String | provenance |  |
-| GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | GlobalDataFlow.cs:538:20:538:21 | [post] access to parameter sc : SimpleClass [field field] : String | provenance |  |
-| GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | GlobalDataFlow.cs:546:24:546:24 | [post] access to local variable x : SimpleClass [field field] : String | provenance |  |
+| GlobalDataFlow.cs:481:41:481:42 | sc [Return] : SimpleClass [field field] : String | GlobalDataFlow.cs:490:25:490:26 | [post] access to local variable x1 : SimpleClass [field field] : String | provenance |  |
+| GlobalDataFlow.cs:481:41:481:42 | sc [Return] : SimpleClass [field field] : String | GlobalDataFlow.cs:490:30:490:31 | [post] access to local variable x2 : SimpleClass [field field] : String | provenance |  |
+| GlobalDataFlow.cs:481:41:481:42 | sc [Return] : SimpleClass [field field] : String | GlobalDataFlow.cs:497:31:497:32 | [post] access to local variable y1 : SimpleClass [field field] : String | provenance |  |
+| GlobalDataFlow.cs:481:41:481:42 | sc [Return] : SimpleClass [field field] : String | GlobalDataFlow.cs:497:36:497:37 | [post] access to local variable y2 : SimpleClass [field field] : String | provenance |  |
+| GlobalDataFlow.cs:481:41:481:42 | sc [Return] : SimpleClass [field field] : String | GlobalDataFlow.cs:497:42:497:43 | [post] access to local variable y3 : SimpleClass [field field] : String | provenance |  |
+| GlobalDataFlow.cs:481:41:481:42 | sc [Return] : SimpleClass [field field] : String | GlobalDataFlow.cs:508:33:508:33 | [post] access to local variable x : SubSimpleClass [field field] : String | provenance |  |
+| GlobalDataFlow.cs:481:41:481:42 | sc [Return] : SimpleClass [field field] : String | GlobalDataFlow.cs:515:20:515:20 | [post] access to parameter x : SimpleClass [field field] : String | provenance |  |
+| GlobalDataFlow.cs:481:41:481:42 | sc [Return] : SimpleClass [field field] : String | GlobalDataFlow.cs:515:25:515:25 | [post] access to local variable y : SimpleClass [field field] : String | provenance |  |
+| GlobalDataFlow.cs:481:41:481:42 | sc [Return] : SimpleClass [field field] : String | GlobalDataFlow.cs:527:20:527:20 | [post] access to local variable x : SimpleClass [field field] : String | provenance |  |
+| GlobalDataFlow.cs:481:41:481:42 | sc [Return] : SimpleClass [field field] : String | GlobalDataFlow.cs:528:20:528:20 | [post] access to local variable y : SimpleClass [field field] : String | provenance |  |
+| GlobalDataFlow.cs:481:41:481:42 | sc [Return] : SimpleClass [field field] : String | GlobalDataFlow.cs:529:18:529:18 | [post] access to local variable z : SimpleClass [field field] : String | provenance |  |
+| GlobalDataFlow.cs:481:41:481:42 | sc [Return] : SimpleClass [field field] : String | GlobalDataFlow.cs:538:20:538:21 | [post] access to parameter sc : SimpleClass [field field] : String | provenance |  |
+| GlobalDataFlow.cs:481:41:481:42 | sc [Return] : SimpleClass [field field] : String | GlobalDataFlow.cs:546:24:546:24 | [post] access to local variable x : SimpleClass [field field] : String | provenance |  |
+| GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | GlobalDataFlow.cs:481:41:481:42 | sc [Return] : SimpleClass [field field] : String | provenance |  |
 | GlobalDataFlow.cs:483:20:483:33 | "taint source" : String | GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | provenance |  |
 | GlobalDataFlow.cs:490:25:490:26 | [post] access to local variable x1 : SimpleClass [field field] : String | GlobalDataFlow.cs:491:15:491:16 | access to local variable x1 : SimpleClass [field field] : String | provenance |  |
 | GlobalDataFlow.cs:490:30:490:31 | [post] access to local variable x2 : SimpleClass [field field] : String | GlobalDataFlow.cs:492:15:492:16 | access to local variable x2 : SimpleClass [field field] : String | provenance |  |
@@ -626,6 +628,7 @@ nodes
 | Capture.cs:350:34:350:34 | a : (...) => ... [captured s] : String | semmle.label | a : (...) => ... [captured s] : String |
 | Capture.cs:350:34:350:34 | a : (...) => ... [captured sink39] : String | semmle.label | a : (...) => ... [captured sink39] : String |
 | Capture.cs:350:34:350:34 | a : (...) => ... [captured sink39] : String | semmle.label | a : (...) => ... [captured sink39] : String |
+| Capture.cs:350:34:350:34 | a [Return] : (...) => ... [captured sink40] : String | semmle.label | a [Return] : (...) => ... [captured sink40] : String |
 | Capture.cs:352:9:352:9 | [post] access to parameter a : (...) => ... [captured sink40] : String | semmle.label | [post] access to parameter a : (...) => ... [captured sink40] : String |
 | Capture.cs:352:9:352:9 | access to parameter a : (...) => ... [captured s] : String | semmle.label | access to parameter a : (...) => ... [captured s] : String |
 | Capture.cs:352:9:352:9 | access to parameter a : (...) => ... [captured sink39] : String | semmle.label | access to parameter a : (...) => ... [captured sink39] : String |
@@ -861,6 +864,7 @@ nodes
 | GlobalDataFlow.cs:469:32:469:32 | access to parameter s | semmle.label | access to parameter s |
 | GlobalDataFlow.cs:470:15:470:17 | access to parameter arg : String | semmle.label | access to parameter arg : String |
 | GlobalDataFlow.cs:473:28:473:41 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:481:41:481:42 | sc [Return] : SimpleClass [field field] : String | semmle.label | sc [Return] : SimpleClass [field field] : String |
 | GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | semmle.label | [post] access to parameter sc : SimpleClass [field field] : String |
 | GlobalDataFlow.cs:483:20:483:33 | "taint source" : String | semmle.label | "taint source" : String |
 | GlobalDataFlow.cs:490:25:490:26 | [post] access to local variable x1 : SimpleClass [field field] : String | semmle.label | [post] access to local variable x1 : SimpleClass [field field] : String |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
@@ -126,7 +126,8 @@ edges
 | Capture.cs:350:34:350:34 | a : (...) => ... [captured s] : String | Capture.cs:352:9:352:9 | access to parameter a : (...) => ... [captured s] : String | provenance |  |
 | Capture.cs:350:34:350:34 | a : (...) => ... [captured sink39] : String | Capture.cs:352:9:352:9 | access to parameter a : (...) => ... [captured sink39] : String | provenance |  |
 | Capture.cs:350:34:350:34 | a : (...) => ... [captured sink39] : String | Capture.cs:352:9:352:9 | access to parameter a : (...) => ... [captured sink39] : String | provenance |  |
-| Capture.cs:352:9:352:9 | [post] access to parameter a : (...) => ... [captured sink40] : String | Capture.cs:114:23:117:13 | [post] (...) => ... : (...) => ... [captured sink40] : String | provenance |  |
+| Capture.cs:350:34:350:34 | a [Return] : (...) => ... [captured sink40] : String | Capture.cs:114:23:117:13 | [post] (...) => ... : (...) => ... [captured sink40] : String | provenance |  |
+| Capture.cs:352:9:352:9 | [post] access to parameter a : (...) => ... [captured sink40] : String | Capture.cs:350:34:350:34 | a [Return] : (...) => ... [captured sink40] : String | provenance |  |
 | Capture.cs:352:9:352:9 | access to parameter a : (...) => ... [captured s] : String | Capture.cs:217:19:217:19 | access to parameter s | provenance |  |
 | Capture.cs:352:9:352:9 | access to parameter a : (...) => ... [captured sink39] : String | Capture.cs:55:27:58:17 | (...) => ... : (...) => ... [captured sink39] : String | provenance |  |
 | Capture.cs:352:9:352:9 | access to parameter a : (...) => ... [captured sink39] : String | Capture.cs:57:27:57:32 | access to parameter sink39 | provenance |  |
@@ -430,19 +431,20 @@ edges
 | GlobalDataFlow.cs:469:21:469:21 | s : String | GlobalDataFlow.cs:469:32:469:32 | access to parameter s | provenance |  |
 | GlobalDataFlow.cs:470:15:470:17 | access to parameter arg : String | GlobalDataFlow.cs:469:21:469:21 | s : String | provenance |  |
 | GlobalDataFlow.cs:473:28:473:41 | "taint source" : String | GlobalDataFlow.cs:466:53:466:55 | arg : String | provenance |  |
-| GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | GlobalDataFlow.cs:490:25:490:26 | [post] access to local variable x1 : SimpleClass [field field] : String | provenance |  |
-| GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | GlobalDataFlow.cs:490:30:490:31 | [post] access to local variable x2 : SimpleClass [field field] : String | provenance |  |
-| GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | GlobalDataFlow.cs:497:31:497:32 | [post] access to local variable y1 : SimpleClass [field field] : String | provenance |  |
-| GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | GlobalDataFlow.cs:497:36:497:37 | [post] access to local variable y2 : SimpleClass [field field] : String | provenance |  |
-| GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | GlobalDataFlow.cs:497:42:497:43 | [post] access to local variable y3 : SimpleClass [field field] : String | provenance |  |
-| GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | GlobalDataFlow.cs:508:33:508:33 | [post] access to local variable x : SubSimpleClass [field field] : String | provenance |  |
-| GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | GlobalDataFlow.cs:515:20:515:20 | [post] access to parameter x : SimpleClass [field field] : String | provenance |  |
-| GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | GlobalDataFlow.cs:515:25:515:25 | [post] access to local variable y : SimpleClass [field field] : String | provenance |  |
-| GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | GlobalDataFlow.cs:527:20:527:20 | [post] access to local variable x : SimpleClass [field field] : String | provenance |  |
-| GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | GlobalDataFlow.cs:528:20:528:20 | [post] access to local variable y : SimpleClass [field field] : String | provenance |  |
-| GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | GlobalDataFlow.cs:529:18:529:18 | [post] access to local variable z : SimpleClass [field field] : String | provenance |  |
-| GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | GlobalDataFlow.cs:538:20:538:21 | [post] access to parameter sc : SimpleClass [field field] : String | provenance |  |
-| GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | GlobalDataFlow.cs:546:24:546:24 | [post] access to local variable x : SimpleClass [field field] : String | provenance |  |
+| GlobalDataFlow.cs:481:41:481:42 | sc [Return] : SimpleClass [field field] : String | GlobalDataFlow.cs:490:25:490:26 | [post] access to local variable x1 : SimpleClass [field field] : String | provenance |  |
+| GlobalDataFlow.cs:481:41:481:42 | sc [Return] : SimpleClass [field field] : String | GlobalDataFlow.cs:490:30:490:31 | [post] access to local variable x2 : SimpleClass [field field] : String | provenance |  |
+| GlobalDataFlow.cs:481:41:481:42 | sc [Return] : SimpleClass [field field] : String | GlobalDataFlow.cs:497:31:497:32 | [post] access to local variable y1 : SimpleClass [field field] : String | provenance |  |
+| GlobalDataFlow.cs:481:41:481:42 | sc [Return] : SimpleClass [field field] : String | GlobalDataFlow.cs:497:36:497:37 | [post] access to local variable y2 : SimpleClass [field field] : String | provenance |  |
+| GlobalDataFlow.cs:481:41:481:42 | sc [Return] : SimpleClass [field field] : String | GlobalDataFlow.cs:497:42:497:43 | [post] access to local variable y3 : SimpleClass [field field] : String | provenance |  |
+| GlobalDataFlow.cs:481:41:481:42 | sc [Return] : SimpleClass [field field] : String | GlobalDataFlow.cs:508:33:508:33 | [post] access to local variable x : SubSimpleClass [field field] : String | provenance |  |
+| GlobalDataFlow.cs:481:41:481:42 | sc [Return] : SimpleClass [field field] : String | GlobalDataFlow.cs:515:20:515:20 | [post] access to parameter x : SimpleClass [field field] : String | provenance |  |
+| GlobalDataFlow.cs:481:41:481:42 | sc [Return] : SimpleClass [field field] : String | GlobalDataFlow.cs:515:25:515:25 | [post] access to local variable y : SimpleClass [field field] : String | provenance |  |
+| GlobalDataFlow.cs:481:41:481:42 | sc [Return] : SimpleClass [field field] : String | GlobalDataFlow.cs:527:20:527:20 | [post] access to local variable x : SimpleClass [field field] : String | provenance |  |
+| GlobalDataFlow.cs:481:41:481:42 | sc [Return] : SimpleClass [field field] : String | GlobalDataFlow.cs:528:20:528:20 | [post] access to local variable y : SimpleClass [field field] : String | provenance |  |
+| GlobalDataFlow.cs:481:41:481:42 | sc [Return] : SimpleClass [field field] : String | GlobalDataFlow.cs:529:18:529:18 | [post] access to local variable z : SimpleClass [field field] : String | provenance |  |
+| GlobalDataFlow.cs:481:41:481:42 | sc [Return] : SimpleClass [field field] : String | GlobalDataFlow.cs:538:20:538:21 | [post] access to parameter sc : SimpleClass [field field] : String | provenance |  |
+| GlobalDataFlow.cs:481:41:481:42 | sc [Return] : SimpleClass [field field] : String | GlobalDataFlow.cs:546:24:546:24 | [post] access to local variable x : SimpleClass [field field] : String | provenance |  |
+| GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | GlobalDataFlow.cs:481:41:481:42 | sc [Return] : SimpleClass [field field] : String | provenance |  |
 | GlobalDataFlow.cs:483:20:483:33 | "taint source" : String | GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | provenance |  |
 | GlobalDataFlow.cs:490:25:490:26 | [post] access to local variable x1 : SimpleClass [field field] : String | GlobalDataFlow.cs:491:15:491:16 | access to local variable x1 : SimpleClass [field field] : String | provenance |  |
 | GlobalDataFlow.cs:490:30:490:31 | [post] access to local variable x2 : SimpleClass [field field] : String | GlobalDataFlow.cs:492:15:492:16 | access to local variable x2 : SimpleClass [field field] : String | provenance |  |
@@ -475,8 +477,10 @@ edges
 | GlobalDataFlow.cs:558:46:558:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | provenance |  |
 | GlobalDataFlow.cs:558:46:558:46 | access to local variable x : String | GlobalDataFlow.cs:558:44:558:47 | delegate call : String | provenance |  |
 | GlobalDataFlowStringBuilder.cs:17:64:17:64 | s : String | GlobalDataFlowStringBuilder.cs:19:19:19:19 | access to parameter s : String | provenance |  |
+| GlobalDataFlowStringBuilder.cs:19:9:19:10 | [post] access to parameter sb : StringBuilder | GlobalDataFlowStringBuilder.cs:17:53:17:54 | sb [Return] : StringBuilder | provenance |  |
 | GlobalDataFlowStringBuilder.cs:19:19:19:19 | access to parameter s : String | GlobalDataFlowStringBuilder.cs:19:9:19:10 | [post] access to parameter sb : StringBuilder | provenance | MaD:1901 |
 | GlobalDataFlowStringBuilder.cs:22:76:22:76 | s : String | GlobalDataFlowStringBuilder.cs:24:19:24:26 | (...) ... : AppendInterpolatedStringHandler | provenance |  |
+| GlobalDataFlowStringBuilder.cs:24:9:24:10 | [post] access to parameter sb : StringBuilder | GlobalDataFlowStringBuilder.cs:22:65:22:66 | sb [Return] : StringBuilder | provenance |  |
 | GlobalDataFlowStringBuilder.cs:24:19:24:26 | (...) ... : AppendInterpolatedStringHandler | GlobalDataFlowStringBuilder.cs:24:9:24:10 | [post] access to parameter sb : StringBuilder | provenance | MaD:1913 |
 | GlobalDataFlowStringBuilder.cs:30:31:30:32 | [post] access to local variable sb : StringBuilder | GlobalDataFlowStringBuilder.cs:31:21:31:22 | access to local variable sb : StringBuilder | provenance |  |
 | GlobalDataFlowStringBuilder.cs:30:31:30:32 | [post] access to local variable sb : StringBuilder | GlobalDataFlowStringBuilder.cs:35:20:35:21 | access to local variable sb : StringBuilder | provenance |  |
@@ -676,6 +680,7 @@ nodes
 | Capture.cs:350:34:350:34 | a : (...) => ... [captured s] : String | semmle.label | a : (...) => ... [captured s] : String |
 | Capture.cs:350:34:350:34 | a : (...) => ... [captured sink39] : String | semmle.label | a : (...) => ... [captured sink39] : String |
 | Capture.cs:350:34:350:34 | a : (...) => ... [captured sink39] : String | semmle.label | a : (...) => ... [captured sink39] : String |
+| Capture.cs:350:34:350:34 | a [Return] : (...) => ... [captured sink40] : String | semmle.label | a [Return] : (...) => ... [captured sink40] : String |
 | Capture.cs:352:9:352:9 | [post] access to parameter a : (...) => ... [captured sink40] : String | semmle.label | [post] access to parameter a : (...) => ... [captured sink40] : String |
 | Capture.cs:352:9:352:9 | access to parameter a : (...) => ... [captured s] : String | semmle.label | access to parameter a : (...) => ... [captured s] : String |
 | Capture.cs:352:9:352:9 | access to parameter a : (...) => ... [captured sink39] : String | semmle.label | access to parameter a : (...) => ... [captured sink39] : String |
@@ -934,6 +939,7 @@ nodes
 | GlobalDataFlow.cs:469:32:469:32 | access to parameter s | semmle.label | access to parameter s |
 | GlobalDataFlow.cs:470:15:470:17 | access to parameter arg : String | semmle.label | access to parameter arg : String |
 | GlobalDataFlow.cs:473:28:473:41 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:481:41:481:42 | sc [Return] : SimpleClass [field field] : String | semmle.label | sc [Return] : SimpleClass [field field] : String |
 | GlobalDataFlow.cs:483:9:483:10 | [post] access to parameter sc : SimpleClass [field field] : String | semmle.label | [post] access to parameter sc : SimpleClass [field field] : String |
 | GlobalDataFlow.cs:483:20:483:33 | "taint source" : String | semmle.label | "taint source" : String |
 | GlobalDataFlow.cs:490:25:490:26 | [post] access to local variable x1 : SimpleClass [field field] : String | semmle.label | [post] access to local variable x1 : SimpleClass [field field] : String |
@@ -979,9 +985,11 @@ nodes
 | GlobalDataFlow.cs:556:27:556:27 | access to parameter e : null [element] : String | semmle.label | access to parameter e : null [element] : String |
 | GlobalDataFlow.cs:558:44:558:47 | delegate call : String | semmle.label | delegate call : String |
 | GlobalDataFlow.cs:558:46:558:46 | access to local variable x : String | semmle.label | access to local variable x : String |
+| GlobalDataFlowStringBuilder.cs:17:53:17:54 | sb [Return] : StringBuilder | semmle.label | sb [Return] : StringBuilder |
 | GlobalDataFlowStringBuilder.cs:17:64:17:64 | s : String | semmle.label | s : String |
 | GlobalDataFlowStringBuilder.cs:19:9:19:10 | [post] access to parameter sb : StringBuilder | semmle.label | [post] access to parameter sb : StringBuilder |
 | GlobalDataFlowStringBuilder.cs:19:19:19:19 | access to parameter s : String | semmle.label | access to parameter s : String |
+| GlobalDataFlowStringBuilder.cs:22:65:22:66 | sb [Return] : StringBuilder | semmle.label | sb [Return] : StringBuilder |
 | GlobalDataFlowStringBuilder.cs:22:76:22:76 | s : String | semmle.label | s : String |
 | GlobalDataFlowStringBuilder.cs:24:9:24:10 | [post] access to parameter sb : StringBuilder | semmle.label | [post] access to parameter sb : StringBuilder |
 | GlobalDataFlowStringBuilder.cs:24:19:24:26 | (...) ... : AppendInterpolatedStringHandler | semmle.label | (...) ... : AppendInterpolatedStringHandler |
@@ -1077,8 +1085,8 @@ subpaths
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:300:27:300:28 | x0 : String | GlobalDataFlow.cs:300:33:300:34 | access to parameter x0 : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:558:46:558:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String | GlobalDataFlow.cs:558:44:558:47 | delegate call : String |
-| GlobalDataFlowStringBuilder.cs:30:35:30:48 | "taint source" : String | GlobalDataFlowStringBuilder.cs:17:64:17:64 | s : String | GlobalDataFlowStringBuilder.cs:19:9:19:10 | [post] access to parameter sb : StringBuilder | GlobalDataFlowStringBuilder.cs:30:31:30:32 | [post] access to local variable sb : StringBuilder |
-| GlobalDataFlowStringBuilder.cs:48:47:48:60 | "taint source" : String | GlobalDataFlowStringBuilder.cs:22:76:22:76 | s : String | GlobalDataFlowStringBuilder.cs:24:9:24:10 | [post] access to parameter sb : StringBuilder | GlobalDataFlowStringBuilder.cs:48:43:48:44 | [post] access to local variable sb : StringBuilder |
+| GlobalDataFlowStringBuilder.cs:30:35:30:48 | "taint source" : String | GlobalDataFlowStringBuilder.cs:17:64:17:64 | s : String | GlobalDataFlowStringBuilder.cs:17:53:17:54 | sb [Return] : StringBuilder | GlobalDataFlowStringBuilder.cs:30:31:30:32 | [post] access to local variable sb : StringBuilder |
+| GlobalDataFlowStringBuilder.cs:48:47:48:60 | "taint source" : String | GlobalDataFlowStringBuilder.cs:22:76:22:76 | s : String | GlobalDataFlowStringBuilder.cs:22:65:22:66 | sb [Return] : StringBuilder | GlobalDataFlowStringBuilder.cs:48:43:48:44 | [post] access to local variable sb : StringBuilder |
 | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String |
 | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> : String |
 | Splitting.cs:20:29:20:29 | access to parameter s : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:20:22:20:30 | call to method Return<String> : String |

--- a/csharp/ql/test/library-tests/dataflow/tuples/Tuples.expected
+++ b/csharp/ql/test/library-tests/dataflow/tuples/Tuples.expected
@@ -152,6 +152,8 @@ edges
 | Tuples.cs:87:18:87:35 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String | Tuples.cs:89:18:89:18 | access to local variable p | provenance |  |
 | Tuples.cs:87:18:87:35 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String | Tuples.cs:87:18:87:35 | (..., ...) : ValueTuple<Int32,String> [field Item2] : String | provenance |  |
 | Tuples.cs:87:18:87:35 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String | Tuples.cs:87:18:87:35 | (..., ...) : ValueTuple<Int32,String> [field Item2] : String | provenance |  |
+| Tuples.cs:95:22:95:22 | i : String | Tuples.cs:95:12:95:13 | this [Return] : R1 [property i] : String | provenance |  |
+| Tuples.cs:95:22:95:22 | i : String | Tuples.cs:95:12:95:13 | this [Return] : R1 [property i] : String | provenance |  |
 | Tuples.cs:99:13:99:13 | access to local variable o : String | Tuples.cs:100:24:100:24 | access to local variable o : String | provenance |  |
 | Tuples.cs:99:13:99:13 | access to local variable o : String | Tuples.cs:100:24:100:24 | access to local variable o : String | provenance |  |
 | Tuples.cs:99:17:99:33 | call to method Source<String> : String | Tuples.cs:99:13:99:13 | access to local variable o : String | provenance |  |
@@ -379,6 +381,8 @@ nodes
 | Tuples.cs:89:18:89:18 | access to local variable p | semmle.label | access to local variable p |
 | Tuples.cs:90:18:90:18 | access to local variable r | semmle.label | access to local variable r |
 | Tuples.cs:90:18:90:18 | access to local variable r | semmle.label | access to local variable r |
+| Tuples.cs:95:12:95:13 | this [Return] : R1 [property i] : String | semmle.label | this [Return] : R1 [property i] : String |
+| Tuples.cs:95:12:95:13 | this [Return] : R1 [property i] : String | semmle.label | this [Return] : R1 [property i] : String |
 | Tuples.cs:95:22:95:22 | i : String | semmle.label | i : String |
 | Tuples.cs:95:22:95:22 | i : String | semmle.label | i : String |
 | Tuples.cs:99:13:99:13 | access to local variable o : String | semmle.label | access to local variable o : String |
@@ -436,8 +440,8 @@ nodes
 | Tuples.cs:134:14:134:15 | access to local variable y4 | semmle.label | access to local variable y4 |
 | Tuples.cs:134:14:134:15 | access to local variable y4 | semmle.label | access to local variable y4 |
 subpaths
-| Tuples.cs:100:24:100:24 | access to local variable o : String | Tuples.cs:95:22:95:22 | i : String | Tuples.cs:95:22:95:22 | i : String | Tuples.cs:100:17:100:28 | object creation of type R1 : R1 [property i] : String |
-| Tuples.cs:100:24:100:24 | access to local variable o : String | Tuples.cs:95:22:95:22 | i : String | Tuples.cs:95:22:95:22 | i : String | Tuples.cs:100:17:100:28 | object creation of type R1 : R1 [property i] : String |
+| Tuples.cs:100:24:100:24 | access to local variable o : String | Tuples.cs:95:22:95:22 | i : String | Tuples.cs:95:12:95:13 | this [Return] : R1 [property i] : String | Tuples.cs:100:17:100:28 | object creation of type R1 : R1 [property i] : String |
+| Tuples.cs:100:24:100:24 | access to local variable o : String | Tuples.cs:95:22:95:22 | i : String | Tuples.cs:95:12:95:13 | this [Return] : R1 [property i] : String | Tuples.cs:100:17:100:28 | object creation of type R1 : R1 [property i] : String |
 #select
 | Tuples.cs:12:14:12:14 | access to local variable a | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | Tuples.cs:12:14:12:14 | access to local variable a | $@ | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | Tuples.cs:12:14:12:14 | access to local variable a | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | Tuples.cs:12:14:12:14 | access to local variable a | $@ | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |

--- a/go/ql/lib/semmle/go/dataflow/internal/FlowSummaryImpl.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/FlowSummaryImpl.qll
@@ -236,10 +236,10 @@ module SourceSinkInterpretationInput implements
   /** Provides additional source specification logic. */
   bindingset[c]
   predicate interpretInput(string c, InterpretNode mid, InterpretNode node) {
-    exists(int pos, ReturnNodeExt ret |
+    exists(int pos, ReturnNode ret |
       parseReturn(c, pos) and
       ret = node.asNode() and
-      ret.getKind().(ValueReturnKind).getKind() = getReturnKind(pos) and
+      ret.getKind() = getReturnKind(pos) and
       mid.asCallable() = getNodeEnclosingCallable(ret)
     )
     or

--- a/go/ql/test/library-tests/semmle/go/frameworks/GoMicro/LogInjection.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/GoMicro/LogInjection.expected
@@ -1,12 +1,12 @@
 edges
-| main.go:18:46:18:48 | definition of req | main.go:18:46:18:48 | definition of req | provenance |  |
-| main.go:18:46:18:48 | definition of req | main.go:18:46:18:48 | definition of req | provenance |  |
+| main.go:18:46:18:48 | definition of req | main.go:18:46:18:48 | definition of req [Return] | provenance |  |
 | main.go:18:46:18:48 | definition of req | main.go:21:28:21:31 | name | provenance |  |
 | main.go:18:46:18:48 | definition of req | main.go:21:28:21:31 | name | provenance |  |
-| main.go:18:46:18:48 | definition of req | proto/Hello.pb.micro.go:85:53:85:54 | definition of in | provenance |  |
-| proto/Hello.pb.micro.go:85:53:85:54 | definition of in | proto/Hello.pb.micro.go:85:53:85:54 | definition of in | provenance |  |
+| main.go:18:46:18:48 | definition of req [Return] | proto/Hello.pb.micro.go:85:53:85:54 | definition of in | provenance |  |
+| proto/Hello.pb.micro.go:85:53:85:54 | definition of in | proto/Hello.pb.micro.go:85:53:85:54 | definition of in [Return] | provenance |  |
 | proto/Hello.pb.micro.go:85:53:85:54 | definition of in | proto/Hello.pb.micro.go:86:37:86:38 | in | provenance |  |
 | proto/Hello.pb.micro.go:85:53:85:54 | definition of in | proto/Hello.pb.micro.go:86:37:86:38 | in | provenance |  |
+| proto/Hello.pb.micro.go:85:53:85:54 | definition of in [Return] | proto/Hello.pb.micro.go:85:53:85:54 | definition of in | provenance |  |
 | proto/Hello.pb.micro.go:86:37:86:38 | in | main.go:18:46:18:48 | definition of req | provenance |  |
 | proto/Hello.pb.micro.go:86:37:86:38 | in | main.go:18:46:18:48 | definition of req | provenance |  |
 | proto/Hello.pb.micro.go:86:37:86:38 | in | proto/Hello.pb.micro.go:85:53:85:54 | definition of in | provenance |  |
@@ -14,9 +14,11 @@ edges
 nodes
 | main.go:18:46:18:48 | definition of req | semmle.label | definition of req |
 | main.go:18:46:18:48 | definition of req | semmle.label | definition of req |
+| main.go:18:46:18:48 | definition of req [Return] | semmle.label | definition of req [Return] |
 | main.go:21:28:21:31 | name | semmle.label | name |
 | proto/Hello.pb.micro.go:85:53:85:54 | definition of in | semmle.label | definition of in |
 | proto/Hello.pb.micro.go:85:53:85:54 | definition of in | semmle.label | definition of in |
+| proto/Hello.pb.micro.go:85:53:85:54 | definition of in [Return] | semmle.label | definition of in [Return] |
 | proto/Hello.pb.micro.go:86:37:86:38 | in | semmle.label | in |
 | proto/Hello.pb.micro.go:86:37:86:38 | in | semmle.label | in |
 subpaths

--- a/go/ql/test/library-tests/semmle/go/frameworks/Twirp/RequestForgery.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Twirp/RequestForgery.expected
@@ -13,15 +13,14 @@ edges
 | rpc/notes/service.twirp.go:558:44:558:51 | typedReq | server/main.go:19:56:19:61 | definition of params | provenance |  |
 | rpc/notes/service.twirp.go:574:2:574:2 | capture variable reqContent | rpc/notes/service.twirp.go:576:35:576:44 | reqContent | provenance |  |
 | rpc/notes/service.twirp.go:576:35:576:44 | reqContent | server/main.go:19:56:19:61 | definition of params | provenance |  |
-| server/main.go:19:56:19:61 | definition of params | client/main.go:16:35:16:78 | &... | provenance |  |
-| server/main.go:19:56:19:61 | definition of params | rpc/notes/service.twirp.go:473:6:473:13 | definition of typedReq | provenance |  |
-| server/main.go:19:56:19:61 | definition of params | rpc/notes/service.twirp.go:493:2:493:2 | capture variable reqContent | provenance |  |
-| server/main.go:19:56:19:61 | definition of params | rpc/notes/service.twirp.go:554:6:554:13 | definition of typedReq | provenance |  |
-| server/main.go:19:56:19:61 | definition of params | rpc/notes/service.twirp.go:574:2:574:2 | capture variable reqContent | provenance |  |
-| server/main.go:19:56:19:61 | definition of params | server/main.go:19:56:19:61 | definition of params | provenance |  |
-| server/main.go:19:56:19:61 | definition of params | server/main.go:19:56:19:61 | definition of params | provenance |  |
+| server/main.go:19:56:19:61 | definition of params | server/main.go:19:56:19:61 | definition of params [Return] | provenance |  |
 | server/main.go:19:56:19:61 | definition of params | server/main.go:30:38:30:48 | selection of Text | provenance |  |
 | server/main.go:19:56:19:61 | definition of params | server/main.go:30:38:30:48 | selection of Text | provenance |  |
+| server/main.go:19:56:19:61 | definition of params [Return] | client/main.go:16:35:16:78 | &... | provenance |  |
+| server/main.go:19:56:19:61 | definition of params [Return] | rpc/notes/service.twirp.go:473:6:473:13 | definition of typedReq | provenance |  |
+| server/main.go:19:56:19:61 | definition of params [Return] | rpc/notes/service.twirp.go:493:2:493:2 | capture variable reqContent | provenance |  |
+| server/main.go:19:56:19:61 | definition of params [Return] | rpc/notes/service.twirp.go:554:6:554:13 | definition of typedReq | provenance |  |
+| server/main.go:19:56:19:61 | definition of params [Return] | rpc/notes/service.twirp.go:574:2:574:2 | capture variable reqContent | provenance |  |
 nodes
 | client/main.go:16:35:16:78 | &... | semmle.label | &... |
 | rpc/notes/service.twirp.go:473:6:473:13 | definition of typedReq | semmle.label | definition of typedReq |
@@ -38,6 +37,7 @@ nodes
 | rpc/notes/service.twirp.go:576:35:576:44 | reqContent | semmle.label | reqContent |
 | server/main.go:19:56:19:61 | definition of params | semmle.label | definition of params |
 | server/main.go:19:56:19:61 | definition of params | semmle.label | definition of params |
+| server/main.go:19:56:19:61 | definition of params [Return] | semmle.label | definition of params [Return] |
 | server/main.go:30:38:30:48 | selection of Text | semmle.label | selection of Text |
 subpaths
 #select

--- a/java/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -6,6 +6,29 @@
 private import CaptureModelsSpecific
 private import CaptureModelsPrinting
 
+/**
+ * A node from which flow can return to the caller. This is either a regular
+ * `ReturnNode` or a `PostUpdateNode` corresponding to the value of a parameter.
+ */
+private class ReturnNodeExt extends DataFlow::Node {
+  private DataFlowImplCommon::ReturnKindExt kind;
+
+  ReturnNodeExt() {
+    kind = DataFlowImplCommon::getValueReturnPosition(this).getKind() or
+    kind = DataFlowImplCommon::getParamReturnPosition(this, _).getKind()
+  }
+
+  string getOutput() {
+    kind instanceof DataFlowImplCommon::ValueReturnKind and
+    result = "ReturnValue"
+    or
+    exists(ParameterPosition pos |
+      pos = kind.(DataFlowImplCommon::ParamUpdateReturnKind).getPosition() and
+      result = paramReturnNodeAsOutput(returnNodeEnclosingCallable(this), pos)
+    )
+  }
+}
+
 class DataFlowTargetApi extends TargetApiSpecific {
   DataFlowTargetApi() { not isUninterestingForDataFlowModels(this) }
 }
@@ -65,7 +88,7 @@ string asInputArgument(DataFlow::Node source) { result = asInputArgumentSpecific
  * Gets the summary model of `api`, if it follows the `fluent` programming pattern (returns `this`).
  */
 string captureQualifierFlow(TargetApiSpecific api) {
-  exists(DataFlowImplCommon::ReturnNodeExt ret |
+  exists(ReturnNodeExt ret |
     api = returnNodeEnclosingCallable(ret) and
     isOwnInstanceAccessNode(ret)
   ) and
@@ -130,7 +153,7 @@ module ThroughFlowConfig implements DataFlow::StateConfigSig {
   }
 
   predicate isSink(DataFlow::Node sink, FlowState state) {
-    sink instanceof DataFlowImplCommon::ReturnNodeExt and
+    sink instanceof ReturnNodeExt and
     not isOwnInstanceAccessNode(sink) and
     not exists(captureQualifierFlow(sink.asExpr().getEnclosingCallable())) and
     (state instanceof TaintRead or state instanceof TaintStore)
@@ -171,14 +194,11 @@ private module ThroughFlow = TaintTracking::GlobalWithState<ThroughFlowConfig>;
  * Gets the summary model(s) of `api`, if there is flow from parameters to return value or parameter.
  */
 string captureThroughFlow(DataFlowTargetApi api) {
-  exists(
-    DataFlow::ParameterNode p, DataFlowImplCommon::ReturnNodeExt returnNodeExt, string input,
-    string output
-  |
+  exists(DataFlow::ParameterNode p, ReturnNodeExt returnNodeExt, string input, string output |
     ThroughFlow::flow(p, returnNodeExt) and
     returnNodeExt.(DataFlow::Node).getEnclosingCallable() = api and
     input = parameterNodeAsInput(p) and
-    output = returnNodeAsOutput(returnNodeExt) and
+    output = returnNodeExt.getOutput() and
     input != output and
     result = ModelPrinting::asTaintModel(api, input, output)
   )
@@ -196,7 +216,7 @@ module FromSourceConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node sink) {
     exists(DataFlowTargetApi c |
-      sink instanceof DataFlowImplCommon::ReturnNodeExt and
+      sink instanceof ReturnNodeExt and
       sink.getEnclosingCallable() = c
     )
   }
@@ -214,12 +234,12 @@ private module FromSource = TaintTracking::Global<FromSourceConfig>;
  * Gets the source model(s) of `api`, if there is flow from an existing known source to the return of `api`.
  */
 string captureSource(DataFlowTargetApi api) {
-  exists(DataFlow::Node source, DataFlow::Node sink, string kind |
+  exists(DataFlow::Node source, ReturnNodeExt sink, string kind |
     FromSource::flow(source, sink) and
     ExternalFlow::sourceNode(source, kind) and
     api = sink.getEnclosingCallable() and
     isRelevantSourceKind(kind) and
-    result = ModelPrinting::asSourceModel(api, returnNodeAsOutput(sink), kind)
+    result = ModelPrinting::asSourceModel(api, sink.getOutput(), kind)
   )
 }
 

--- a/java/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
@@ -206,7 +206,7 @@ class InstanceParameterNode = DataFlow::InstanceParameterNode;
 class ParameterPosition = DataFlowDispatch::ParameterPosition;
 
 /**
- * Gets the MaD string represention of return through parameter at position
+ * Gets the MaD string representation of return through parameter at position
  * `pos` of callable `c`.
  */
 bindingset[c]

--- a/java/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
@@ -13,6 +13,7 @@ private import semmle.code.java.dataflow.TaintTracking as Tt
 import semmle.code.java.dataflow.ExternalFlow as ExternalFlow
 import semmle.code.java.dataflow.internal.DataFlowImplCommon as DataFlowImplCommon
 import semmle.code.java.dataflow.internal.DataFlowPrivate as DataFlowPrivate
+import semmle.code.java.dataflow.internal.DataFlowDispatch as DataFlowDispatch
 
 module DataFlow = Df::DataFlow;
 
@@ -202,26 +203,23 @@ string parameterAccess(J::Parameter p) {
 
 class InstanceParameterNode = DataFlow::InstanceParameterNode;
 
+class ParameterPosition = DataFlowDispatch::ParameterPosition;
+
 /**
- * Gets the MaD string represention of the the return node `node`.
+ * Gets the MaD string represention of return through parameter at position
+ * `pos` of callable `c`.
  */
-string returnNodeAsOutput(DataFlowImplCommon::ReturnNodeExt node) {
-  if node.getKind() instanceof DataFlowImplCommon::ValueReturnKind
-  then result = "ReturnValue"
-  else
-    exists(int pos |
-      pos = node.getKind().(DataFlowImplCommon::ParamUpdateReturnKind).getPosition()
-    |
-      result = parameterAccess(node.(DataFlow::Node).getEnclosingCallable().getParameter(pos))
-      or
-      result = qualifierString() and pos = -1
-    )
+bindingset[c]
+string paramReturnNodeAsOutput(Callable c, ParameterPosition pos) {
+  result = parameterAccess(c.getParameter(pos))
+  or
+  result = qualifierString() and pos = -1
 }
 
 /**
  * Gets the enclosing callable of `ret`.
  */
-Callable returnNodeEnclosingCallable(DataFlowImplCommon::ReturnNodeExt ret) {
+Callable returnNodeEnclosingCallable(DataFlow::Node ret) {
   result = DataFlowImplCommon::getNodeEnclosingCallable(ret).asCallable()
 }
 

--- a/java/ql/test/experimental/query-tests/security/CWE-299/DisabledRevocationChecking.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-299/DisabledRevocationChecking.expected
@@ -1,11 +1,13 @@
 edges
-| DisabledRevocationChecking.java:17:5:17:8 | this <.field> [post update] : DisabledRevocationChecking [flag] : Boolean | DisabledRevocationChecking.java:21:5:21:31 | this <.method> [post update] : DisabledRevocationChecking [flag] : Boolean | provenance |  |
+| DisabledRevocationChecking.java:16:15:16:39 | parameter this [Return] : DisabledRevocationChecking [flag] : Boolean | DisabledRevocationChecking.java:21:5:21:31 | this <.method> [post update] : DisabledRevocationChecking [flag] : Boolean | provenance |  |
+| DisabledRevocationChecking.java:17:5:17:8 | this <.field> [post update] : DisabledRevocationChecking [flag] : Boolean | DisabledRevocationChecking.java:16:15:16:39 | parameter this [Return] : DisabledRevocationChecking [flag] : Boolean | provenance |  |
 | DisabledRevocationChecking.java:17:12:17:16 | false : Boolean | DisabledRevocationChecking.java:17:5:17:8 | this <.field> [post update] : DisabledRevocationChecking [flag] : Boolean | provenance |  |
 | DisabledRevocationChecking.java:21:5:21:31 | this <.method> [post update] : DisabledRevocationChecking [flag] : Boolean | DisabledRevocationChecking.java:22:5:22:31 | this <.method> : DisabledRevocationChecking [flag] : Boolean | provenance |  |
 | DisabledRevocationChecking.java:22:5:22:31 | this <.method> : DisabledRevocationChecking [flag] : Boolean | DisabledRevocationChecking.java:25:15:25:22 | parameter this : DisabledRevocationChecking [flag] : Boolean | provenance |  |
 | DisabledRevocationChecking.java:25:15:25:22 | parameter this : DisabledRevocationChecking [flag] : Boolean | DisabledRevocationChecking.java:28:33:28:36 | this <.field> : DisabledRevocationChecking [flag] : Boolean | provenance |  |
 | DisabledRevocationChecking.java:28:33:28:36 | this <.field> : DisabledRevocationChecking [flag] : Boolean | DisabledRevocationChecking.java:28:33:28:36 | flag | provenance |  |
 nodes
+| DisabledRevocationChecking.java:16:15:16:39 | parameter this [Return] : DisabledRevocationChecking [flag] : Boolean | semmle.label | parameter this [Return] : DisabledRevocationChecking [flag] : Boolean |
 | DisabledRevocationChecking.java:17:5:17:8 | this <.field> [post update] : DisabledRevocationChecking [flag] : Boolean | semmle.label | this <.field> [post update] : DisabledRevocationChecking [flag] : Boolean |
 | DisabledRevocationChecking.java:17:12:17:16 | false : Boolean | semmle.label | false : Boolean |
 | DisabledRevocationChecking.java:21:5:21:31 | this <.method> [post update] : DisabledRevocationChecking [flag] : Boolean | semmle.label | this <.method> [post update] : DisabledRevocationChecking [flag] : Boolean |

--- a/java/ql/test/experimental/query-tests/security/CWE-400/LocalThreadResourceAbuse.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-400/LocalThreadResourceAbuse.expected
@@ -4,6 +4,7 @@ edges
 | ThreadResourceAbuse.java:40:28:40:36 | delayTime : Number | ThreadResourceAbuse.java:40:4:40:37 | new UncheckedSyncAction(...) : UncheckedSyncAction [waitTime] : Number | provenance |  |
 | ThreadResourceAbuse.java:40:28:40:36 | delayTime : Number | ThreadResourceAbuse.java:66:30:66:41 | waitTime : Number | provenance |  |
 | ThreadResourceAbuse.java:66:30:66:41 | waitTime : Number | ThreadResourceAbuse.java:67:20:67:27 | waitTime : Number | provenance |  |
+| ThreadResourceAbuse.java:67:4:67:7 | this [post update] : UncheckedSyncAction [waitTime] : Number | ThreadResourceAbuse.java:66:10:66:28 | parameter this [Return] : UncheckedSyncAction [waitTime] : Number | provenance |  |
 | ThreadResourceAbuse.java:67:20:67:27 | waitTime : Number | ThreadResourceAbuse.java:67:4:67:7 | this [post update] : UncheckedSyncAction [waitTime] : Number | provenance |  |
 | ThreadResourceAbuse.java:71:15:71:17 | parameter this : UncheckedSyncAction [waitTime] : Number | ThreadResourceAbuse.java:74:18:74:25 | this <.field> : UncheckedSyncAction [waitTime] : Number | provenance |  |
 | ThreadResourceAbuse.java:74:18:74:25 | this <.field> : UncheckedSyncAction [waitTime] : Number | ThreadResourceAbuse.java:74:18:74:25 | waitTime | provenance |  Sink:MaD:1982 |
@@ -11,6 +12,7 @@ nodes
 | ThreadResourceAbuse.java:37:25:37:73 | getInitParameter(...) : String | semmle.label | getInitParameter(...) : String |
 | ThreadResourceAbuse.java:40:4:40:37 | new UncheckedSyncAction(...) : UncheckedSyncAction [waitTime] : Number | semmle.label | new UncheckedSyncAction(...) : UncheckedSyncAction [waitTime] : Number |
 | ThreadResourceAbuse.java:40:28:40:36 | delayTime : Number | semmle.label | delayTime : Number |
+| ThreadResourceAbuse.java:66:10:66:28 | parameter this [Return] : UncheckedSyncAction [waitTime] : Number | semmle.label | parameter this [Return] : UncheckedSyncAction [waitTime] : Number |
 | ThreadResourceAbuse.java:66:30:66:41 | waitTime : Number | semmle.label | waitTime : Number |
 | ThreadResourceAbuse.java:67:4:67:7 | this [post update] : UncheckedSyncAction [waitTime] : Number | semmle.label | this [post update] : UncheckedSyncAction [waitTime] : Number |
 | ThreadResourceAbuse.java:67:20:67:27 | waitTime : Number | semmle.label | waitTime : Number |
@@ -18,6 +20,6 @@ nodes
 | ThreadResourceAbuse.java:74:18:74:25 | this <.field> : UncheckedSyncAction [waitTime] : Number | semmle.label | this <.field> : UncheckedSyncAction [waitTime] : Number |
 | ThreadResourceAbuse.java:74:18:74:25 | waitTime | semmle.label | waitTime |
 subpaths
-| ThreadResourceAbuse.java:40:28:40:36 | delayTime : Number | ThreadResourceAbuse.java:66:30:66:41 | waitTime : Number | ThreadResourceAbuse.java:67:4:67:7 | this [post update] : UncheckedSyncAction [waitTime] : Number | ThreadResourceAbuse.java:40:4:40:37 | new UncheckedSyncAction(...) : UncheckedSyncAction [waitTime] : Number |
+| ThreadResourceAbuse.java:40:28:40:36 | delayTime : Number | ThreadResourceAbuse.java:66:30:66:41 | waitTime : Number | ThreadResourceAbuse.java:66:10:66:28 | parameter this [Return] : UncheckedSyncAction [waitTime] : Number | ThreadResourceAbuse.java:40:4:40:37 | new UncheckedSyncAction(...) : UncheckedSyncAction [waitTime] : Number |
 #select
 | ThreadResourceAbuse.java:74:18:74:25 | waitTime | ThreadResourceAbuse.java:37:25:37:73 | getInitParameter(...) : String | ThreadResourceAbuse.java:74:18:74:25 | waitTime | Possible uncontrolled resource consumption due to $@. | ThreadResourceAbuse.java:37:25:37:73 | getInitParameter(...) | local user-provided value |

--- a/java/ql/test/experimental/query-tests/security/CWE-400/ThreadResourceAbuse.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-400/ThreadResourceAbuse.expected
@@ -8,6 +8,7 @@ edges
 | ThreadResourceAbuse.java:30:28:30:36 | delayTime : Number | ThreadResourceAbuse.java:30:4:30:37 | new UncheckedSyncAction(...) : UncheckedSyncAction [waitTime] : Number | provenance |  |
 | ThreadResourceAbuse.java:30:28:30:36 | delayTime : Number | ThreadResourceAbuse.java:66:30:66:41 | waitTime : Number | provenance |  |
 | ThreadResourceAbuse.java:66:30:66:41 | waitTime : Number | ThreadResourceAbuse.java:67:20:67:27 | waitTime : Number | provenance |  |
+| ThreadResourceAbuse.java:67:4:67:7 | this [post update] : UncheckedSyncAction [waitTime] : Number | ThreadResourceAbuse.java:66:10:66:28 | parameter this [Return] : UncheckedSyncAction [waitTime] : Number | provenance |  |
 | ThreadResourceAbuse.java:67:20:67:27 | waitTime : Number | ThreadResourceAbuse.java:67:4:67:7 | this [post update] : UncheckedSyncAction [waitTime] : Number | provenance |  |
 | ThreadResourceAbuse.java:71:15:71:17 | parameter this : UncheckedSyncAction [waitTime] : Number | ThreadResourceAbuse.java:74:18:74:25 | this <.field> : UncheckedSyncAction [waitTime] : Number | provenance |  |
 | ThreadResourceAbuse.java:74:18:74:25 | this <.field> : UncheckedSyncAction [waitTime] : Number | ThreadResourceAbuse.java:74:18:74:25 | waitTime | provenance |  Sink:MaD:1982 |
@@ -23,6 +24,7 @@ edges
 | ThreadResourceAbuse.java:230:3:230:12 | retryAfter : Number | ThreadResourceAbuse.java:230:3:230:20 | ...*=... : Number | provenance |  |
 | ThreadResourceAbuse.java:230:3:230:20 | ...*=... : Number | ThreadResourceAbuse.java:233:17:233:26 | retryAfter | provenance |  Sink:MaD:1982 |
 | UploadListener.java:15:24:15:44 | sleepMilliseconds : Number | UploadListener.java:16:17:16:33 | sleepMilliseconds : Number | provenance |  |
+| UploadListener.java:16:3:16:13 | this <.field> [post update] : UploadListener [slowUploads] : Number | UploadListener.java:15:9:15:22 | parameter this [Return] : UploadListener [slowUploads] : Number | provenance |  |
 | UploadListener.java:16:17:16:33 | sleepMilliseconds : Number | UploadListener.java:16:3:16:13 | this <.field> [post update] : UploadListener [slowUploads] : Number | provenance |  |
 | UploadListener.java:28:14:28:19 | parameter this : UploadListener [slowUploads] : Number | UploadListener.java:29:3:29:11 | this <.field> : UploadListener [slowUploads] : Number | provenance |  |
 | UploadListener.java:29:3:29:11 | this <.field> : UploadListener [slowUploads] : Number | UploadListener.java:30:3:30:15 | this <.field> : UploadListener [slowUploads] : Number | provenance |  |
@@ -38,6 +40,7 @@ nodes
 | ThreadResourceAbuse.java:29:82:29:114 | getParameter(...) : String | semmle.label | getParameter(...) : String |
 | ThreadResourceAbuse.java:30:4:30:37 | new UncheckedSyncAction(...) : UncheckedSyncAction [waitTime] : Number | semmle.label | new UncheckedSyncAction(...) : UncheckedSyncAction [waitTime] : Number |
 | ThreadResourceAbuse.java:30:28:30:36 | delayTime : Number | semmle.label | delayTime : Number |
+| ThreadResourceAbuse.java:66:10:66:28 | parameter this [Return] : UncheckedSyncAction [waitTime] : Number | semmle.label | parameter this [Return] : UncheckedSyncAction [waitTime] : Number |
 | ThreadResourceAbuse.java:66:30:66:41 | waitTime : Number | semmle.label | waitTime : Number |
 | ThreadResourceAbuse.java:67:4:67:7 | this [post update] : UncheckedSyncAction [waitTime] : Number | semmle.label | this [post update] : UncheckedSyncAction [waitTime] : Number |
 | ThreadResourceAbuse.java:67:20:67:27 | waitTime : Number | semmle.label | waitTime : Number |
@@ -58,6 +61,7 @@ nodes
 | ThreadResourceAbuse.java:230:3:230:12 | retryAfter : Number | semmle.label | retryAfter : Number |
 | ThreadResourceAbuse.java:230:3:230:20 | ...*=... : Number | semmle.label | ...*=... : Number |
 | ThreadResourceAbuse.java:233:17:233:26 | retryAfter | semmle.label | retryAfter |
+| UploadListener.java:15:9:15:22 | parameter this [Return] : UploadListener [slowUploads] : Number | semmle.label | parameter this [Return] : UploadListener [slowUploads] : Number |
 | UploadListener.java:15:24:15:44 | sleepMilliseconds : Number | semmle.label | sleepMilliseconds : Number |
 | UploadListener.java:16:3:16:13 | this <.field> [post update] : UploadListener [slowUploads] : Number | semmle.label | this <.field> [post update] : UploadListener [slowUploads] : Number |
 | UploadListener.java:16:17:16:33 | sleepMilliseconds : Number | semmle.label | sleepMilliseconds : Number |
@@ -69,9 +73,9 @@ nodes
 | UploadListener.java:35:18:35:28 | slowUploads | semmle.label | slowUploads |
 | UploadListener.java:35:18:35:28 | this <.field> : UploadListener [slowUploads] : Number | semmle.label | this <.field> : UploadListener [slowUploads] : Number |
 subpaths
-| ThreadResourceAbuse.java:21:28:21:36 | delayTime : Number | ThreadResourceAbuse.java:66:30:66:41 | waitTime : Number | ThreadResourceAbuse.java:67:4:67:7 | this [post update] : UncheckedSyncAction [waitTime] : Number | ThreadResourceAbuse.java:21:4:21:37 | new UncheckedSyncAction(...) : UncheckedSyncAction [waitTime] : Number |
-| ThreadResourceAbuse.java:30:28:30:36 | delayTime : Number | ThreadResourceAbuse.java:66:30:66:41 | waitTime : Number | ThreadResourceAbuse.java:67:4:67:7 | this [post update] : UncheckedSyncAction [waitTime] : Number | ThreadResourceAbuse.java:30:4:30:37 | new UncheckedSyncAction(...) : UncheckedSyncAction [waitTime] : Number |
-| ThreadResourceAbuse.java:209:49:209:59 | uploadDelay : Number | UploadListener.java:15:24:15:44 | sleepMilliseconds : Number | UploadListener.java:16:3:16:13 | this <.field> [post update] : UploadListener [slowUploads] : Number | ThreadResourceAbuse.java:209:30:209:87 | new UploadListener(...) : UploadListener [slowUploads] : Number |
+| ThreadResourceAbuse.java:21:28:21:36 | delayTime : Number | ThreadResourceAbuse.java:66:30:66:41 | waitTime : Number | ThreadResourceAbuse.java:66:10:66:28 | parameter this [Return] : UncheckedSyncAction [waitTime] : Number | ThreadResourceAbuse.java:21:4:21:37 | new UncheckedSyncAction(...) : UncheckedSyncAction [waitTime] : Number |
+| ThreadResourceAbuse.java:30:28:30:36 | delayTime : Number | ThreadResourceAbuse.java:66:30:66:41 | waitTime : Number | ThreadResourceAbuse.java:66:10:66:28 | parameter this [Return] : UncheckedSyncAction [waitTime] : Number | ThreadResourceAbuse.java:30:4:30:37 | new UncheckedSyncAction(...) : UncheckedSyncAction [waitTime] : Number |
+| ThreadResourceAbuse.java:209:49:209:59 | uploadDelay : Number | UploadListener.java:15:24:15:44 | sleepMilliseconds : Number | UploadListener.java:15:9:15:22 | parameter this [Return] : UploadListener [slowUploads] : Number | ThreadResourceAbuse.java:209:30:209:87 | new UploadListener(...) : UploadListener [slowUploads] : Number |
 #select
 | ThreadResourceAbuse.java:74:18:74:25 | waitTime | ThreadResourceAbuse.java:18:25:18:57 | getParameter(...) : String | ThreadResourceAbuse.java:74:18:74:25 | waitTime | Vulnerability of uncontrolled resource consumption due to $@. | ThreadResourceAbuse.java:18:25:18:57 | getParameter(...) | user-provided value |
 | ThreadResourceAbuse.java:74:18:74:25 | waitTime | ThreadResourceAbuse.java:29:82:29:114 | getParameter(...) : String | ThreadResourceAbuse.java:74:18:74:25 | waitTime | Vulnerability of uncontrolled resource consumption due to $@. | ThreadResourceAbuse.java:29:82:29:114 | getParameter(...) | user-provided value |

--- a/java/ql/test/library-tests/dataflow/capture/test.expected
+++ b/java/ql/test/library-tests/dataflow/capture/test.expected
@@ -45,6 +45,7 @@
 | A.java:23:11:23:13 | "C" : String | A.java:35:26:35:27 | this : new A(...) { ... } [String s] |
 | A.java:23:11:23:13 | "C" : String | A.java:39:12:39:12 | String s : String |
 | A.java:23:11:23:13 | "C" : String | A.java:39:12:39:12 | a : new A(...) { ... } [String s] |
+| A.java:25:22:25:24 | "D" : String | A.java:4:5:4:7 | parameter this [Return] : Box [elem] |
 | A.java:25:22:25:24 | "D" : String | A.java:4:9:4:16 | e : String |
 | A.java:25:22:25:24 | "D" : String | A.java:4:21:4:24 | this <.field> [post update] : Box [elem] |
 | A.java:25:22:25:24 | "D" : String | A.java:4:21:4:28 | ...=... : String |
@@ -68,6 +69,7 @@
 | A.java:25:22:25:24 | "D" : String | A.java:35:26:35:27 | this : new A(...) { ... } [Box b1, ... (2)] |
 | A.java:25:22:25:24 | "D" : String | A.java:39:12:39:12 | Box b1 : Box [elem] |
 | A.java:25:22:25:24 | "D" : String | A.java:39:12:39:12 | a : new A(...) { ... } [Box b1, ... (2)] |
+| A.java:27:16:27:18 | "E" : String | A.java:5:10:5:16 | parameter this [Return] : Box [elem] |
 | A.java:27:16:27:18 | "E" : String | A.java:5:18:5:25 | e : String |
 | A.java:27:16:27:18 | "E" : String | A.java:5:30:5:33 | this <.field> [post update] : Box [elem] |
 | A.java:27:16:27:18 | "E" : String | A.java:5:30:5:37 | ...=... : String |

--- a/java/ql/test/library-tests/dataflow/partial/testRev.expected
+++ b/java/ql/test/library-tests/dataflow/partial/testRev.expected
@@ -1,18 +1,22 @@
 edges
-| A.java:4:16:4:18 | this <constr(this)> [post update] [elem] | A.java:22:17:22:25 | new Box(...) [elem] |
+| A.java:4:16:4:18 | parameter this [Return] [elem] | A.java:22:17:22:25 | new Box(...) [elem] |
+| A.java:4:16:4:18 | this <constr(this)> [post update] [elem] | A.java:4:16:4:18 | parameter this [Return] [elem] |
 | A.java:5:19:5:22 | elem | A.java:24:10:24:19 | other.elem |
 | A.java:22:17:22:25 | new Box(...) [elem] | A.java:23:13:23:17 | other [elem] |
 | A.java:23:13:23:17 | other [elem] | A.java:24:10:24:14 | other [elem] |
 | A.java:23:13:23:17 | other [post update] [elem] | A.java:24:10:24:14 | other [elem] |
 | A.java:24:10:24:14 | other [elem] | A.java:24:10:24:19 | other.elem |
-| A.java:28:5:28:5 | b [post update] [elem] | A.java:23:13:23:17 | other [post update] [elem] |
+| A.java:27:16:27:20 | b [Return] [elem] | A.java:23:13:23:17 | other [post update] [elem] |
+| A.java:28:5:28:5 | b [post update] [elem] | A.java:27:16:27:20 | b [Return] [elem] |
 | A.java:28:14:28:25 | new Object(...) | A.java:28:5:28:5 | b [post update] [elem] |
 #select
 | 0 | A.java:22:17:22:25 | new Box(...) [elem] |
 | 0 | A.java:23:13:23:17 | other [elem] |
 | 0 | A.java:23:13:23:17 | other [post update] [elem] |
 | 0 | A.java:24:10:24:14 | other [elem] |
+| 1 | A.java:4:16:4:18 | parameter this [Return] [elem] |
 | 1 | A.java:4:16:4:18 | this <constr(this)> [post update] [elem] |
 | 1 | A.java:5:19:5:22 | elem |
+| 1 | A.java:27:16:27:20 | b [Return] [elem] |
 | 1 | A.java:28:5:28:5 | b [post update] [elem] |
 | 1 | A.java:28:14:28:25 | new Object(...) |

--- a/java/ql/test/query-tests/security/CWE-190/semmle/tests/ArithmeticTainted.expected
+++ b/java/ql/test/query-tests/security/CWE-190/semmle/tests/ArithmeticTainted.expected
@@ -37,6 +37,7 @@ edges
 | ArithmeticTainted.java:133:27:133:34 | data : Number | ArithmeticTainted.java:135:3:135:6 | data | provenance |  |
 | ArithmeticTainted.java:137:27:137:34 | data : Number | ArithmeticTainted.java:139:5:139:8 | data | provenance |  |
 | Holder.java:12:22:12:26 | d : Number | Holder.java:13:9:13:9 | d : Number | provenance |  |
+| Holder.java:13:3:13:5 | this <.field> [post update] : Holder [dat] : Number | Holder.java:12:14:12:20 | parameter this [Return] : Holder [dat] : Number | provenance |  |
 | Holder.java:13:9:13:9 | d : Number | Holder.java:13:3:13:5 | this <.field> [post update] : Holder [dat] : Number | provenance |  |
 | Holder.java:16:13:16:19 | parameter this : Holder [dat] : Number | Holder.java:17:10:17:12 | this <.field> : Holder [dat] : Number | provenance |  |
 | Holder.java:17:10:17:12 | this <.field> : Holder [dat] : Number | Holder.java:17:10:17:12 | dat : Number | provenance |  |
@@ -78,6 +79,7 @@ nodes
 | ArithmeticTainted.java:135:3:135:6 | data | semmle.label | data |
 | ArithmeticTainted.java:137:27:137:34 | data : Number | semmle.label | data : Number |
 | ArithmeticTainted.java:139:5:139:8 | data | semmle.label | data |
+| Holder.java:12:14:12:20 | parameter this [Return] : Holder [dat] : Number | semmle.label | parameter this [Return] : Holder [dat] : Number |
 | Holder.java:12:22:12:26 | d : Number | semmle.label | d : Number |
 | Holder.java:13:3:13:5 | this <.field> [post update] : Holder [dat] : Number | semmle.label | this <.field> [post update] : Holder [dat] : Number |
 | Holder.java:13:9:13:9 | d : Number | semmle.label | d : Number |
@@ -85,7 +87,7 @@ nodes
 | Holder.java:17:10:17:12 | dat : Number | semmle.label | dat : Number |
 | Holder.java:17:10:17:12 | this <.field> : Holder [dat] : Number | semmle.label | this <.field> : Holder [dat] : Number |
 subpaths
-| ArithmeticTainted.java:64:20:64:23 | data : Number | Holder.java:12:22:12:26 | d : Number | Holder.java:13:3:13:5 | this <.field> [post update] : Holder [dat] : Number | ArithmeticTainted.java:64:4:64:10 | tainted [post update] : Holder [dat] : Number |
+| ArithmeticTainted.java:64:20:64:23 | data : Number | Holder.java:12:22:12:26 | d : Number | Holder.java:12:14:12:20 | parameter this [Return] : Holder [dat] : Number | ArithmeticTainted.java:64:4:64:10 | tainted [post update] : Holder [dat] : Number |
 | ArithmeticTainted.java:66:18:66:24 | tainted : Holder [dat] : Number | Holder.java:16:13:16:19 | parameter this : Holder [dat] : Number | Holder.java:17:10:17:12 | dat : Number | ArithmeticTainted.java:66:18:66:34 | getData(...) : Number |
 #select
 | ArithmeticTainted.java:32:17:32:25 | ... + ... | ArithmeticTainted.java:17:46:17:54 | System.in : InputStream | ArithmeticTainted.java:32:17:32:20 | data | This arithmetic expression depends on a $@, potentially causing an overflow. | ArithmeticTainted.java:17:46:17:54 | System.in | user-provided value |

--- a/ruby/ql/test/library-tests/dataflow/erb/erb.expected
+++ b/ruby/ql/test/library-tests/dataflow/erb/erb.expected
@@ -29,13 +29,16 @@ edges
 | view1.rb:9:5:11:7 | self in foo [@x] | view1.rb:10:14:10:15 | self [@x] | provenance |  |
 | view1.rb:10:14:10:15 | self [@x] | view1.rb:10:14:10:15 | @x | provenance |  |
 | view1.rb:13:13:13:13 | x | view1.rb:14:14:14:14 | x | provenance |  |
+| view1.rb:14:9:14:10 | [post] self [@x] | view1.rb:13:5:15:7 | self in set [Return] [@x] | provenance |  |
 | view1.rb:14:14:14:14 | x | view1.rb:14:9:14:10 | [post] self [@x] | provenance |  |
-| view2.html.erb:3:1:3:14 | [post] self [@x] | main.rb:10:16:10:19 | [post] view [@x] | provenance |  |
+| view2.html.erb:3:1:3:14 | [post] self [@x] | view2.html.erb:3:1:4:1 | self in view2.html.erb [Return] [@x] | provenance |  |
+| view2.html.erb:3:1:4:1 | self in view2.html.erb [Return] [@x] | main.rb:10:16:10:19 | [post] view [@x] | provenance |  |
 | view2.html.erb:3:5:3:13 | call to source | view2.html.erb:3:1:3:14 | [post] self [@x] | provenance |  |
 | view2.html.erb:3:5:3:13 | call to source | view2.rb:6:13:6:13 | x | provenance |  |
 | view2.rb:2:5:4:7 | self in foo [@x] | view2.rb:3:14:3:15 | self [@x] | provenance |  |
 | view2.rb:3:14:3:15 | self [@x] | view2.rb:3:14:3:15 | @x | provenance |  |
 | view2.rb:6:13:6:13 | x | view2.rb:7:14:7:14 | x | provenance |  |
+| view2.rb:7:9:7:10 | [post] self [@x] | view2.rb:6:5:8:7 | self in set [Return] [@x] | provenance |  |
 | view2.rb:7:14:7:14 | x | view2.rb:7:9:7:10 | [post] self [@x] | provenance |  |
 | view3.html.erb:3:1:4:1 | self in view3.html.erb [@x] | view3.html.erb:3:6:3:8 | self [@x] | provenance |  |
 | view3.html.erb:3:6:3:8 | self [@x] | view3.html.erb:3:6:3:8 | call to get | provenance |  |
@@ -71,14 +74,17 @@ nodes
 | view1.rb:9:5:11:7 | self in foo [@x] | semmle.label | self in foo [@x] |
 | view1.rb:10:14:10:15 | @x | semmle.label | @x |
 | view1.rb:10:14:10:15 | self [@x] | semmle.label | self [@x] |
+| view1.rb:13:5:15:7 | self in set [Return] [@x] | semmle.label | self in set [Return] [@x] |
 | view1.rb:13:13:13:13 | x | semmle.label | x |
 | view1.rb:14:9:14:10 | [post] self [@x] | semmle.label | [post] self [@x] |
 | view1.rb:14:14:14:14 | x | semmle.label | x |
 | view2.html.erb:3:1:3:14 | [post] self [@x] | semmle.label | [post] self [@x] |
+| view2.html.erb:3:1:4:1 | self in view2.html.erb [Return] [@x] | semmle.label | self in view2.html.erb [Return] [@x] |
 | view2.html.erb:3:5:3:13 | call to source | semmle.label | call to source |
 | view2.rb:2:5:4:7 | self in foo [@x] | semmle.label | self in foo [@x] |
 | view2.rb:3:14:3:15 | @x | semmle.label | @x |
 | view2.rb:3:14:3:15 | self [@x] | semmle.label | self [@x] |
+| view2.rb:6:5:8:7 | self in set [Return] [@x] | semmle.label | self in set [Return] [@x] |
 | view2.rb:6:13:6:13 | x | semmle.label | x |
 | view2.rb:7:9:7:10 | [post] self [@x] | semmle.label | [post] self [@x] |
 | view2.rb:7:14:7:14 | x | semmle.label | x |
@@ -94,8 +100,8 @@ nodes
 subpaths
 | main.rb:4:26:4:26 | x | view1.rb:5:20:5:20 | x | view1.rb:6:9:6:10 | [post] self [@x] | main.rb:4:16:4:27 | call to new [@x] |
 | main.rb:16:26:16:26 | x | view3.rb:2:20:2:20 | x | view3.rb:3:9:3:10 | [post] self [@x] | main.rb:16:16:16:27 | call to new [@x] |
-| view1.html.erb:6:5:6:13 | call to source | view1.rb:13:13:13:13 | x | view1.rb:14:9:14:10 | [post] self [@x] | view1.html.erb:6:1:6:14 | [post] self [@x] |
-| view2.html.erb:3:5:3:13 | call to source | view2.rb:6:13:6:13 | x | view2.rb:7:9:7:10 | [post] self [@x] | view2.html.erb:3:1:3:14 | [post] self [@x] |
+| view1.html.erb:6:5:6:13 | call to source | view1.rb:13:13:13:13 | x | view1.rb:13:5:15:7 | self in set [Return] [@x] | view1.html.erb:6:1:6:14 | [post] self [@x] |
+| view2.html.erb:3:5:3:13 | call to source | view2.rb:6:13:6:13 | x | view2.rb:6:5:8:7 | self in set [Return] [@x] | view2.html.erb:3:1:3:14 | [post] self [@x] |
 | view3.html.erb:3:6:3:8 | self [@x] | view3.rb:6:5:8:7 | self in get [@x] | view3.rb:7:9:7:10 | @x | view3.html.erb:3:6:3:8 | call to get |
 #select
 | view1.rb:10:14:10:15 | @x | main.rb:3:13:3:21 | call to source | view1.rb:10:14:10:15 | @x | $@ | main.rb:3:13:3:21 | call to source | call to source |

--- a/ruby/ql/test/library-tests/dataflow/global/Flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/global/Flow.expected
@@ -29,6 +29,7 @@ edges
 | captured_variables.rb:51:9:51:16 | call to taint | captured_variables.rb:49:16:52:3 | [post] do ... end [captured x] | provenance |  |
 | captured_variables.rb:51:9:51:16 | call to taint | captured_variables.rb:49:16:52:3 | [post] do ... end [captured x] | provenance | heuristic-callback |
 | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:58:18:58:18 | x | provenance |  |
+| captured_variables.rb:58:9:58:14 | [post] self [@field] | captured_variables.rb:57:5:59:7 | self in set_field [Return] [@field] | provenance |  |
 | captured_variables.rb:58:18:58:18 | x | captured_variables.rb:58:9:58:14 | [post] self [@field] | provenance |  |
 | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:16:61:21 | self [@field] | provenance |  |
 | captured_variables.rb:61:16:61:21 | @field | captured_variables.rb:61:9:61:21 | return | provenance |  |
@@ -93,7 +94,8 @@ edges
 | captured_variables.rb:168:18:170:11 | do ... end [captured self, @x] | captured_variables.rb:163:5:165:7 | &block [captured self, @x] | provenance |  |
 | captured_variables.rb:169:18:169:19 | self [@x] | captured_variables.rb:169:18:169:19 | @x | provenance |  |
 | captured_variables.rb:174:1:174:24 | call to new [@x] | captured_variables.rb:167:5:171:7 | self in baz [@x] | provenance |  |
-| captured_variables.rb:178:9:178:10 | [post] self [@x] | captured_variables.rb:193:1:193:1 | [post] c [@x] | provenance |  |
+| captured_variables.rb:177:5:179:7 | self in foo [Return] [@x] | captured_variables.rb:193:1:193:1 | [post] c [@x] | provenance |  |
+| captured_variables.rb:178:9:178:10 | [post] self [@x] | captured_variables.rb:177:5:179:7 | self in foo [Return] [@x] | provenance |  |
 | captured_variables.rb:178:14:178:22 | call to taint | captured_variables.rb:178:9:178:10 | [post] self [@x] | provenance |  |
 | captured_variables.rb:181:5:183:7 | &block [captured self, @x] | captured_variables.rb:187:18:187:19 | self [@x] | provenance |  |
 | captured_variables.rb:185:5:189:7 | self in baz [@x] | captured_variables.rb:186:18:188:11 | do ... end [captured self, @x] | provenance |  |
@@ -108,6 +110,7 @@ edges
 | captured_variables.rb:226:5:226:7 | fn1 [captured x] | captured_variables.rb:223:13:223:13 | x | provenance |  |
 | captured_variables.rb:226:5:226:7 | fn1 [captured x] | captured_variables.rb:226:5:226:7 | [post] fn1 [captured y] | provenance |  |
 | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:11:18:11:18 | x | provenance |  |
+| instance_variables.rb:11:9:11:14 | [post] self [@field] | instance_variables.rb:10:5:12:7 | self in set_field [Return] [@field] | provenance |  |
 | instance_variables.rb:11:18:11:18 | x | instance_variables.rb:11:9:11:14 | [post] self [@field] | provenance |  |
 | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:16:14:21 | self [@field] | provenance |  |
 | instance_variables.rb:14:16:14:21 | @field | instance_variables.rb:14:9:14:21 | return | provenance |  |
@@ -118,9 +121,11 @@ edges
 | instance_variables.rb:19:12:19:21 | call to taint | instance_variables.rb:19:5:19:8 | [post] self [@foo] | provenance |  |
 | instance_variables.rb:20:10:20:13 | self [@foo] | instance_variables.rb:20:10:20:13 | @foo | provenance |  |
 | instance_variables.rb:22:20:22:24 | field | instance_variables.rb:23:18:23:22 | field | provenance |  |
+| instance_variables.rb:23:9:23:14 | [post] self [@field] | instance_variables.rb:22:5:25:7 | self in initialize [Return] [@field] | provenance |  |
 | instance_variables.rb:23:18:23:22 | field | instance_variables.rb:23:9:23:14 | [post] self [@field] | provenance |  |
 | instance_variables.rb:24:9:24:17 | call to taint | instance_variables.rb:28:9:28:25 | call to initialize | provenance |  |
 | instance_variables.rb:27:25:27:29 | field | instance_variables.rb:28:20:28:24 | field | provenance |  |
+| instance_variables.rb:28:9:28:25 | [post] self [@field] | instance_variables.rb:27:5:29:7 | self in call_initialize [Return] [@field] | provenance |  |
 | instance_variables.rb:28:9:28:25 | call to initialize | instance_variables.rb:119:6:119:37 | call to call_initialize | provenance |  |
 | instance_variables.rb:28:20:28:24 | field | instance_variables.rb:22:20:22:24 | field | provenance |  |
 | instance_variables.rb:28:20:28:24 | field | instance_variables.rb:28:9:28:25 | [post] self [@field] | provenance |  |
@@ -212,9 +217,10 @@ edges
 | instance_variables.rb:97:6:97:10 | foo10 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | provenance |  |
 | instance_variables.rb:97:6:97:10 | foo10 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | provenance |  |
 | instance_variables.rb:97:6:97:10 | foo10 [@field] | instance_variables.rb:97:6:97:20 | call to get_field | provenance |  |
-| instance_variables.rb:100:5:100:5 | [post] x [@field] | instance_variables.rb:104:14:104:18 | [post] foo11 [@field] | provenance |  |
-| instance_variables.rb:100:5:100:5 | [post] x [@field] | instance_variables.rb:108:15:108:19 | [post] foo12 [@field] | provenance |  |
-| instance_variables.rb:100:5:100:5 | [post] x [@field] | instance_variables.rb:113:22:113:26 | [post] foo13 [@field] | provenance |  |
+| instance_variables.rb:99:18:99:18 | x [Return] [@field] | instance_variables.rb:104:14:104:18 | [post] foo11 [@field] | provenance |  |
+| instance_variables.rb:99:18:99:18 | x [Return] [@field] | instance_variables.rb:108:15:108:19 | [post] foo12 [@field] | provenance |  |
+| instance_variables.rb:99:18:99:18 | x [Return] [@field] | instance_variables.rb:113:22:113:26 | [post] foo13 [@field] | provenance |  |
+| instance_variables.rb:100:5:100:5 | [post] x [@field] | instance_variables.rb:99:18:99:18 | x [Return] [@field] | provenance |  |
 | instance_variables.rb:100:17:100:25 | call to taint | captured_variables.rb:57:19:57:19 | x | provenance |  |
 | instance_variables.rb:100:17:100:25 | call to taint | instance_variables.rb:10:19:10:19 | x | provenance |  |
 | instance_variables.rb:100:17:100:25 | call to taint | instance_variables.rb:100:5:100:5 | [post] x [@field] | provenance |  |
@@ -279,6 +285,7 @@ nodes
 | captured_variables.rb:50:10:50:10 | x | semmle.label | x |
 | captured_variables.rb:51:9:51:16 | call to taint | semmle.label | call to taint |
 | captured_variables.rb:54:6:54:6 | x | semmle.label | x |
+| captured_variables.rb:57:5:59:7 | self in set_field [Return] [@field] | semmle.label | self in set_field [Return] [@field] |
 | captured_variables.rb:57:19:57:19 | x | semmle.label | x |
 | captured_variables.rb:58:9:58:14 | [post] self [@field] | semmle.label | [post] self [@field] |
 | captured_variables.rb:58:18:58:18 | x | semmle.label | x |
@@ -339,6 +346,7 @@ nodes
 | captured_variables.rb:169:18:169:19 | @x | semmle.label | @x |
 | captured_variables.rb:169:18:169:19 | self [@x] | semmle.label | self [@x] |
 | captured_variables.rb:174:1:174:24 | call to new [@x] | semmle.label | call to new [@x] |
+| captured_variables.rb:177:5:179:7 | self in foo [Return] [@x] | semmle.label | self in foo [Return] [@x] |
 | captured_variables.rb:178:9:178:10 | [post] self [@x] | semmle.label | [post] self [@x] |
 | captured_variables.rb:178:14:178:22 | call to taint | semmle.label | call to taint |
 | captured_variables.rb:181:5:183:7 | &block [captured self, @x] | semmle.label | &block [captured self, @x] |
@@ -357,6 +365,7 @@ nodes
 | captured_variables.rb:226:5:226:7 | [post] fn1 [captured y] | semmle.label | [post] fn1 [captured y] |
 | captured_variables.rb:226:5:226:7 | fn1 [captured x] | semmle.label | fn1 [captured x] |
 | captured_variables.rb:227:10:227:10 | y | semmle.label | y |
+| instance_variables.rb:10:5:12:7 | self in set_field [Return] [@field] | semmle.label | self in set_field [Return] [@field] |
 | instance_variables.rb:10:19:10:19 | x | semmle.label | x |
 | instance_variables.rb:11:9:11:14 | [post] self [@field] | semmle.label | [post] self [@field] |
 | instance_variables.rb:11:18:11:18 | x | semmle.label | x |
@@ -370,10 +379,12 @@ nodes
 | instance_variables.rb:19:12:19:21 | call to taint | semmle.label | call to taint |
 | instance_variables.rb:20:10:20:13 | @foo | semmle.label | @foo |
 | instance_variables.rb:20:10:20:13 | self [@foo] | semmle.label | self [@foo] |
+| instance_variables.rb:22:5:25:7 | self in initialize [Return] [@field] | semmle.label | self in initialize [Return] [@field] |
 | instance_variables.rb:22:20:22:24 | field | semmle.label | field |
 | instance_variables.rb:23:9:23:14 | [post] self [@field] | semmle.label | [post] self [@field] |
 | instance_variables.rb:23:18:23:22 | field | semmle.label | field |
 | instance_variables.rb:24:9:24:17 | call to taint | semmle.label | call to taint |
+| instance_variables.rb:27:5:29:7 | self in call_initialize [Return] [@field] | semmle.label | self in call_initialize [Return] [@field] |
 | instance_variables.rb:27:25:27:29 | field | semmle.label | field |
 | instance_variables.rb:28:9:28:25 | [post] self [@field] | semmle.label | [post] self [@field] |
 | instance_variables.rb:28:9:28:25 | call to initialize | semmle.label | call to initialize |
@@ -437,6 +448,7 @@ nodes
 | instance_variables.rb:96:6:96:19 | call to get_field | semmle.label | call to get_field |
 | instance_variables.rb:97:6:97:10 | foo10 [@field] | semmle.label | foo10 [@field] |
 | instance_variables.rb:97:6:97:20 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:99:18:99:18 | x [Return] [@field] | semmle.label | x [Return] [@field] |
 | instance_variables.rb:100:5:100:5 | [post] x [@field] | semmle.label | [post] x [@field] |
 | instance_variables.rb:100:17:100:25 | call to taint | semmle.label | call to taint |
 | instance_variables.rb:104:14:104:18 | [post] foo11 [@field] | semmle.label | [post] foo11 [@field] |
@@ -464,21 +476,21 @@ nodes
 subpaths
 | captured_variables.rb:20:25:20:34 | call to taint | captured_variables.rb:15:28:15:28 | x | captured_variables.rb:16:5:18:5 | -> { ... } [captured x] | captured_variables.rb:20:2:20:34 | call to capture_escape_return1 [captured x] |
 | captured_variables.rb:27:48:27:57 | call to taint | captured_variables.rb:22:28:22:28 | x | captured_variables.rb:23:5:25:5 | -> { ... } [captured x] | captured_variables.rb:27:25:27:57 | call to capture_escape_return2 [captured x] |
-| captured_variables.rb:66:15:66:22 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:58:9:58:14 | [post] self [@field] | captured_variables.rb:66:1:66:3 | [post] foo [@field] |
-| captured_variables.rb:66:15:66:22 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:11:9:11:14 | [post] self [@field] | captured_variables.rb:66:1:66:3 | [post] foo [@field] |
+| captured_variables.rb:66:15:66:22 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] [@field] | captured_variables.rb:66:1:66:3 | [post] foo [@field] |
+| captured_variables.rb:66:15:66:22 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] [@field] | captured_variables.rb:66:1:66:3 | [post] foo [@field] |
 | captured_variables.rb:68:10:68:12 | foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | captured_variables.rb:68:10:68:22 | call to get_field |
 | captured_variables.rb:68:10:68:12 | foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | captured_variables.rb:68:10:68:22 | call to get_field |
-| captured_variables.rb:69:19:69:26 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:58:9:58:14 | [post] self [@field] | captured_variables.rb:69:5:69:7 | [post] foo [@field] |
-| captured_variables.rb:69:19:69:26 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:11:9:11:14 | [post] self [@field] | captured_variables.rb:69:5:69:7 | [post] foo [@field] |
+| captured_variables.rb:69:19:69:26 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] [@field] | captured_variables.rb:69:5:69:7 | [post] foo [@field] |
+| captured_variables.rb:69:19:69:26 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] [@field] | captured_variables.rb:69:5:69:7 | [post] foo [@field] |
 | captured_variables.rb:72:6:72:8 | foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | captured_variables.rb:72:6:72:18 | call to get_field |
 | captured_variables.rb:72:6:72:8 | foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | captured_variables.rb:72:6:72:18 | call to get_field |
-| captured_variables.rb:79:23:79:30 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:58:9:58:14 | [post] self [@field] | captured_variables.rb:79:9:79:11 | [post] foo [@field] |
-| captured_variables.rb:79:23:79:30 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:11:9:11:14 | [post] self [@field] | captured_variables.rb:79:9:79:11 | [post] foo [@field] |
+| captured_variables.rb:79:23:79:30 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] [@field] | captured_variables.rb:79:9:79:11 | [post] foo [@field] |
+| captured_variables.rb:79:23:79:30 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] [@field] | captured_variables.rb:79:9:79:11 | [post] foo [@field] |
 | captured_variables.rb:83:6:83:8 | foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | captured_variables.rb:83:6:83:18 | call to get_field |
 | captured_variables.rb:83:6:83:8 | foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | captured_variables.rb:83:6:83:18 | call to get_field |
 | captured_variables.rb:98:13:98:20 | call to taint | captured_variables.rb:93:17:93:17 | x | captured_variables.rb:94:5:96:5 | -> { ... } [captured x] | captured_variables.rb:98:1:98:21 | call to capture_arg [captured x] |
 | captured_variables.rb:226:5:226:7 | fn1 [captured x] | captured_variables.rb:223:13:223:13 | x | captured_variables.rb:223:13:223:13 | x | captured_variables.rb:226:5:226:7 | [post] fn1 [captured y] |
-| instance_variables.rb:28:20:28:24 | field | instance_variables.rb:22:20:22:24 | field | instance_variables.rb:23:9:23:14 | [post] self [@field] | instance_variables.rb:28:9:28:25 | [post] self [@field] |
+| instance_variables.rb:28:20:28:24 | field | instance_variables.rb:22:20:22:24 | field | instance_variables.rb:22:5:25:7 | self in initialize [Return] [@field] | instance_variables.rb:28:9:28:25 | [post] self [@field] |
 | instance_variables.rb:33:13:33:13 | x | instance_variables.rb:22:20:22:24 | field | instance_variables.rb:23:9:23:14 | [post] self [@field] | instance_variables.rb:33:9:33:14 | call to new [@field] |
 | instance_variables.rb:36:10:36:23 | call to new [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:36:10:36:33 | call to get_field |
 | instance_variables.rb:36:10:36:23 | call to new [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:36:10:36:33 | call to get_field |
@@ -486,48 +498,48 @@ subpaths
 | instance_variables.rb:39:6:39:23 | call to bar [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:39:6:39:33 | call to get_field |
 | instance_variables.rb:39:6:39:23 | call to bar [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:39:6:39:33 | call to get_field |
 | instance_variables.rb:39:14:39:22 | call to taint | instance_variables.rb:31:18:31:18 | x | instance_variables.rb:33:9:33:14 | call to new [@field] | instance_variables.rb:39:6:39:23 | call to bar [@field] |
-| instance_variables.rb:54:15:54:23 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:58:9:58:14 | [post] self [@field] | instance_variables.rb:54:1:54:3 | [post] foo [@field] |
-| instance_variables.rb:54:15:54:23 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:11:9:11:14 | [post] self [@field] | instance_variables.rb:54:1:54:3 | [post] foo [@field] |
+| instance_variables.rb:54:15:54:23 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] [@field] | instance_variables.rb:54:1:54:3 | [post] foo [@field] |
+| instance_variables.rb:54:15:54:23 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] [@field] | instance_variables.rb:54:1:54:3 | [post] foo [@field] |
 | instance_variables.rb:55:6:55:8 | foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:55:6:55:18 | call to get_field |
 | instance_variables.rb:55:6:55:8 | foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:55:6:55:18 | call to get_field |
-| instance_variables.rb:58:15:58:22 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:58:9:58:14 | [post] self [@field] | instance_variables.rb:58:1:58:3 | [post] bar [@field] |
-| instance_variables.rb:58:15:58:22 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:11:9:11:14 | [post] self [@field] | instance_variables.rb:58:1:58:3 | [post] bar [@field] |
+| instance_variables.rb:58:15:58:22 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] [@field] | instance_variables.rb:58:1:58:3 | [post] bar [@field] |
+| instance_variables.rb:58:15:58:22 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] [@field] | instance_variables.rb:58:1:58:3 | [post] bar [@field] |
 | instance_variables.rb:59:6:59:8 | bar [@field] | instance_variables.rb:16:5:18:7 | self in inc_field [@field] | instance_variables.rb:16:5:18:7 | self in inc_field [@field] | instance_variables.rb:59:6:59:18 | call to inc_field |
 | instance_variables.rb:59:6:59:8 | bar [@field] | instance_variables.rb:16:5:18:7 | self in inc_field [@field] | instance_variables.rb:17:9:17:14 | [post] self [@field] | instance_variables.rb:59:6:59:18 | call to inc_field |
 | instance_variables.rb:67:6:67:9 | foo2 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:67:6:67:19 | call to get_field |
 | instance_variables.rb:67:6:67:9 | foo2 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:67:6:67:19 | call to get_field |
-| instance_variables.rb:70:16:70:24 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:58:9:58:14 | [post] self [@field] | instance_variables.rb:70:1:70:4 | [post] foo3 [@field] |
-| instance_variables.rb:70:16:70:24 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:11:9:11:14 | [post] self [@field] | instance_variables.rb:70:1:70:4 | [post] foo3 [@field] |
-| instance_variables.rb:78:18:78:26 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:58:9:58:14 | [post] self [@field] | instance_variables.rb:78:2:78:5 | [post] foo5 [@field] |
-| instance_variables.rb:78:18:78:26 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:11:9:11:14 | [post] self [@field] | instance_variables.rb:78:2:78:5 | [post] foo5 [@field] |
+| instance_variables.rb:70:16:70:24 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] [@field] | instance_variables.rb:70:1:70:4 | [post] foo3 [@field] |
+| instance_variables.rb:70:16:70:24 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] [@field] | instance_variables.rb:70:1:70:4 | [post] foo3 [@field] |
+| instance_variables.rb:78:18:78:26 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] [@field] | instance_variables.rb:78:2:78:5 | [post] foo5 [@field] |
+| instance_variables.rb:78:18:78:26 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] [@field] | instance_variables.rb:78:2:78:5 | [post] foo5 [@field] |
 | instance_variables.rb:79:6:79:9 | foo5 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:79:6:79:19 | call to get_field |
 | instance_variables.rb:79:6:79:9 | foo5 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:79:6:79:19 | call to get_field |
-| instance_variables.rb:82:32:82:40 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:58:9:58:14 | [post] self [@field] | instance_variables.rb:82:15:82:18 | [post] foo6 [@field] |
-| instance_variables.rb:82:32:82:40 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:11:9:11:14 | [post] self [@field] | instance_variables.rb:82:15:82:18 | [post] foo6 [@field] |
+| instance_variables.rb:82:32:82:40 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] [@field] | instance_variables.rb:82:15:82:18 | [post] foo6 [@field] |
+| instance_variables.rb:82:32:82:40 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] [@field] | instance_variables.rb:82:15:82:18 | [post] foo6 [@field] |
 | instance_variables.rb:83:6:83:9 | foo3 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:83:6:83:19 | call to get_field |
 | instance_variables.rb:83:6:83:9 | foo3 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:83:6:83:19 | call to get_field |
 | instance_variables.rb:84:6:84:9 | foo5 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:84:6:84:19 | call to get_field |
 | instance_variables.rb:84:6:84:9 | foo5 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:84:6:84:19 | call to get_field |
 | instance_variables.rb:85:6:85:9 | foo6 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:85:6:85:19 | call to get_field |
 | instance_variables.rb:85:6:85:9 | foo6 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:85:6:85:19 | call to get_field |
-| instance_variables.rb:89:45:89:53 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:58:9:58:14 | [post] self [@field] | instance_variables.rb:89:15:89:18 | [post] foo7 [@field] |
-| instance_variables.rb:89:45:89:53 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:58:9:58:14 | [post] self [@field] | instance_variables.rb:89:25:89:28 | [post] foo8 [@field] |
-| instance_variables.rb:89:45:89:53 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:11:9:11:14 | [post] self [@field] | instance_variables.rb:89:15:89:18 | [post] foo7 [@field] |
-| instance_variables.rb:89:45:89:53 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:11:9:11:14 | [post] self [@field] | instance_variables.rb:89:25:89:28 | [post] foo8 [@field] |
+| instance_variables.rb:89:45:89:53 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] [@field] | instance_variables.rb:89:15:89:18 | [post] foo7 [@field] |
+| instance_variables.rb:89:45:89:53 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] [@field] | instance_variables.rb:89:25:89:28 | [post] foo8 [@field] |
+| instance_variables.rb:89:45:89:53 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] [@field] | instance_variables.rb:89:15:89:18 | [post] foo7 [@field] |
+| instance_variables.rb:89:45:89:53 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] [@field] | instance_variables.rb:89:25:89:28 | [post] foo8 [@field] |
 | instance_variables.rb:90:6:90:9 | foo7 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:90:6:90:19 | call to get_field |
 | instance_variables.rb:90:6:90:9 | foo7 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:90:6:90:19 | call to get_field |
 | instance_variables.rb:91:6:91:9 | foo8 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:91:6:91:19 | call to get_field |
 | instance_variables.rb:91:6:91:9 | foo8 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:91:6:91:19 | call to get_field |
-| instance_variables.rb:95:53:95:61 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:58:9:58:14 | [post] self [@field] | instance_variables.rb:95:22:95:25 | [post] foo9 [@field] |
-| instance_variables.rb:95:53:95:61 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:58:9:58:14 | [post] self [@field] | instance_variables.rb:95:32:95:36 | [post] foo10 [@field] |
-| instance_variables.rb:95:53:95:61 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:11:9:11:14 | [post] self [@field] | instance_variables.rb:95:22:95:25 | [post] foo9 [@field] |
-| instance_variables.rb:95:53:95:61 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:11:9:11:14 | [post] self [@field] | instance_variables.rb:95:32:95:36 | [post] foo10 [@field] |
+| instance_variables.rb:95:53:95:61 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] [@field] | instance_variables.rb:95:22:95:25 | [post] foo9 [@field] |
+| instance_variables.rb:95:53:95:61 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] [@field] | instance_variables.rb:95:32:95:36 | [post] foo10 [@field] |
+| instance_variables.rb:95:53:95:61 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] [@field] | instance_variables.rb:95:22:95:25 | [post] foo9 [@field] |
+| instance_variables.rb:95:53:95:61 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] [@field] | instance_variables.rb:95:32:95:36 | [post] foo10 [@field] |
 | instance_variables.rb:96:6:96:9 | foo9 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:96:6:96:19 | call to get_field |
 | instance_variables.rb:96:6:96:9 | foo9 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:96:6:96:19 | call to get_field |
 | instance_variables.rb:97:6:97:10 | foo10 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:97:6:97:20 | call to get_field |
 | instance_variables.rb:97:6:97:10 | foo10 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:97:6:97:20 | call to get_field |
-| instance_variables.rb:100:17:100:25 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:58:9:58:14 | [post] self [@field] | instance_variables.rb:100:5:100:5 | [post] x [@field] |
-| instance_variables.rb:100:17:100:25 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:11:9:11:14 | [post] self [@field] | instance_variables.rb:100:5:100:5 | [post] x [@field] |
+| instance_variables.rb:100:17:100:25 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] [@field] | instance_variables.rb:100:5:100:5 | [post] x [@field] |
+| instance_variables.rb:100:17:100:25 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] [@field] | instance_variables.rb:100:5:100:5 | [post] x [@field] |
 | instance_variables.rb:105:6:105:10 | foo11 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:105:6:105:20 | call to get_field |
 | instance_variables.rb:105:6:105:10 | foo11 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:105:6:105:20 | call to get_field |
 | instance_variables.rb:109:6:109:10 | foo12 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:109:6:109:20 | call to get_field |
@@ -537,7 +549,7 @@ subpaths
 | instance_variables.rb:116:17:116:25 | call to taint | instance_variables.rb:22:20:22:24 | field | instance_variables.rb:23:9:23:14 | [post] self [@field] | instance_variables.rb:116:9:116:26 | call to new [@field] |
 | instance_variables.rb:117:6:117:10 | foo15 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:117:6:117:20 | call to get_field |
 | instance_variables.rb:117:6:117:10 | foo15 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:117:6:117:20 | call to get_field |
-| instance_variables.rb:119:28:119:36 | call to taint | instance_variables.rb:27:25:27:29 | field | instance_variables.rb:28:9:28:25 | [post] self [@field] | instance_variables.rb:119:6:119:10 | [post] foo16 [@field] |
+| instance_variables.rb:119:28:119:36 | call to taint | instance_variables.rb:27:25:27:29 | field | instance_variables.rb:27:5:29:7 | self in call_initialize [Return] [@field] | instance_variables.rb:119:6:119:10 | [post] foo16 [@field] |
 | instance_variables.rb:120:6:120:10 | foo16 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:120:6:120:20 | call to get_field |
 | instance_variables.rb:120:6:120:10 | foo16 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:120:6:120:20 | call to get_field |
 #select

--- a/ruby/ql/test/library-tests/dataflow/params/params-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/params/params-flow.expected
@@ -176,12 +176,14 @@ edges
 | params_flow.rb:137:11:137:43 | call to [] [element 1] | params_flow.rb:137:10:137:43 | * ... [element 1] | provenance |  |
 | params_flow.rb:137:23:137:31 | call to taint | params_flow.rb:137:11:137:43 | call to [] [element 1] | provenance |  |
 | params_flow.rb:153:28:153:29 | p2 | params_flow.rb:154:18:154:19 | p2 | provenance |  |
+| params_flow.rb:154:5:154:6 | [post] p1 [element 0] | params_flow.rb:153:23:153:24 | p1 [Return] [element 0] | provenance |  |
 | params_flow.rb:154:18:154:19 | p2 | params_flow.rb:154:5:154:6 | [post] p1 [element 0] | provenance |  |
 | params_flow.rb:164:23:164:24 | [post] p1 [element 0] | params_flow.rb:165:6:165:7 | p1 [element 0] | provenance |  |
 | params_flow.rb:164:31:164:39 | call to taint | params_flow.rb:153:28:153:29 | p2 | provenance |  |
 | params_flow.rb:164:31:164:39 | call to taint | params_flow.rb:164:23:164:24 | [post] p1 [element 0] | provenance |  |
 | params_flow.rb:165:6:165:7 | p1 [element 0] | params_flow.rb:165:6:165:10 | ...[...] | provenance |  |
 | params_flow.rb:181:28:181:29 | p2 | params_flow.rb:182:18:182:19 | p2 | provenance |  |
+| params_flow.rb:182:5:182:6 | [post] p1 [element 0] | params_flow.rb:181:24:181:25 | p1 [Return] [element 0] | provenance |  |
 | params_flow.rb:182:18:182:19 | p2 | params_flow.rb:182:5:182:6 | [post] p1 [element 0] | provenance |  |
 | params_flow.rb:192:20:192:21 | [post] p1 [element 0] | params_flow.rb:193:6:193:7 | p1 [element 0] | provenance |  |
 | params_flow.rb:192:24:192:32 | call to taint | params_flow.rb:181:28:181:29 | p2 | provenance |  |
@@ -387,6 +389,7 @@ nodes
 | params_flow.rb:137:10:137:43 | * ... [element 1] | semmle.label | * ... [element 1] |
 | params_flow.rb:137:11:137:43 | call to [] [element 1] | semmle.label | call to [] [element 1] |
 | params_flow.rb:137:23:137:31 | call to taint | semmle.label | call to taint |
+| params_flow.rb:153:23:153:24 | p1 [Return] [element 0] | semmle.label | p1 [Return] [element 0] |
 | params_flow.rb:153:28:153:29 | p2 | semmle.label | p2 |
 | params_flow.rb:154:5:154:6 | [post] p1 [element 0] | semmle.label | [post] p1 [element 0] |
 | params_flow.rb:154:18:154:19 | p2 | semmle.label | p2 |
@@ -394,6 +397,7 @@ nodes
 | params_flow.rb:164:31:164:39 | call to taint | semmle.label | call to taint |
 | params_flow.rb:165:6:165:7 | p1 [element 0] | semmle.label | p1 [element 0] |
 | params_flow.rb:165:6:165:10 | ...[...] | semmle.label | ...[...] |
+| params_flow.rb:181:24:181:25 | p1 [Return] [element 0] | semmle.label | p1 [Return] [element 0] |
 | params_flow.rb:181:28:181:29 | p2 | semmle.label | p2 |
 | params_flow.rb:182:5:182:6 | [post] p1 [element 0] | semmle.label | [post] p1 [element 0] |
 | params_flow.rb:182:18:182:19 | p2 | semmle.label | p2 |
@@ -402,8 +406,8 @@ nodes
 | params_flow.rb:193:6:193:7 | p1 [element 0] | semmle.label | p1 [element 0] |
 | params_flow.rb:193:6:193:10 | ...[...] | semmle.label | ...[...] |
 subpaths
-| params_flow.rb:164:31:164:39 | call to taint | params_flow.rb:153:28:153:29 | p2 | params_flow.rb:154:5:154:6 | [post] p1 [element 0] | params_flow.rb:164:23:164:24 | [post] p1 [element 0] |
-| params_flow.rb:192:24:192:32 | call to taint | params_flow.rb:181:28:181:29 | p2 | params_flow.rb:182:5:182:6 | [post] p1 [element 0] | params_flow.rb:192:20:192:21 | [post] p1 [element 0] |
+| params_flow.rb:164:31:164:39 | call to taint | params_flow.rb:153:28:153:29 | p2 | params_flow.rb:153:23:153:24 | p1 [Return] [element 0] | params_flow.rb:164:23:164:24 | [post] p1 [element 0] |
+| params_flow.rb:192:24:192:32 | call to taint | params_flow.rb:181:28:181:29 | p2 | params_flow.rb:181:24:181:25 | p1 [Return] [element 0] | params_flow.rb:192:20:192:21 | [post] p1 [element 0] |
 #select
 | params_flow.rb:10:10:10:11 | p1 | params_flow.rb:14:12:14:19 | call to taint | params_flow.rb:10:10:10:11 | p1 | $@ | params_flow.rb:14:12:14:19 | call to taint | call to taint |
 | params_flow.rb:10:10:10:11 | p1 | params_flow.rb:44:12:44:20 | call to taint | params_flow.rb:10:10:10:11 | p1 | $@ | params_flow.rb:44:12:44:20 | call to taint | call to taint |

--- a/ruby/ql/test/library-tests/frameworks/action_controller/params-flow.expected
+++ b/ruby/ql/test/library-tests/frameworks/action_controller/params-flow.expected
@@ -35,7 +35,8 @@ edges
 | filter_flow.rb:83:3:84:5 | self in b [@foo] | filter_flow.rb:86:3:88:5 | self in c [@foo] | provenance |  |
 | filter_flow.rb:86:3:88:5 | self in c [@foo] | filter_flow.rb:87:11:87:14 | self [@foo] | provenance |  |
 | filter_flow.rb:87:11:87:14 | self [@foo] | filter_flow.rb:87:11:87:14 | @foo | provenance |  |
-| filter_flow.rb:91:5:91:8 | [post] self [@foo] | filter_flow.rb:80:5:80:8 | [post] self [@foo] | provenance |  |
+| filter_flow.rb:90:3:92:5 | self in taint_foo [Return] [@foo] | filter_flow.rb:80:5:80:8 | [post] self [@foo] | provenance |  |
+| filter_flow.rb:91:5:91:8 | [post] self [@foo] | filter_flow.rb:90:3:92:5 | self in taint_foo [Return] [@foo] | provenance |  |
 | filter_flow.rb:91:12:91:17 | call to params | filter_flow.rb:91:12:91:23 | ...[...] | provenance |  |
 | filter_flow.rb:91:12:91:23 | ...[...] | filter_flow.rb:91:5:91:8 | [post] self [@foo] | provenance |  |
 | params_flow.rb:3:10:3:15 | call to params | params_flow.rb:3:10:3:19 | ...[...] | provenance |  |
@@ -155,6 +156,7 @@ nodes
 | filter_flow.rb:86:3:88:5 | self in c [@foo] | semmle.label | self in c [@foo] |
 | filter_flow.rb:87:11:87:14 | @foo | semmle.label | @foo |
 | filter_flow.rb:87:11:87:14 | self [@foo] | semmle.label | self [@foo] |
+| filter_flow.rb:90:3:92:5 | self in taint_foo [Return] [@foo] | semmle.label | self in taint_foo [Return] [@foo] |
 | filter_flow.rb:91:5:91:8 | [post] self [@foo] | semmle.label | [post] self [@foo] |
 | filter_flow.rb:91:12:91:17 | call to params | semmle.label | call to params |
 | filter_flow.rb:91:12:91:23 | ...[...] | semmle.label | ...[...] |

--- a/shared/dataflow/change-notes/2024-05-06-param-return-nodes.md
+++ b/shared/dataflow/change-notes/2024-05-06-param-return-nodes.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The data flow library now adds intermediate nodes when data flows out of a function via a parameter, in order to make path explanations easier to follow. The intermediate nodes have the same location as the underlying parameter, but must be accessed via `PathNode.asParameterReturnNode` instead of `PathNode.asNode`. `@kind path-problem` queries may have their expected test-output changed as a consequence.

--- a/shared/dataflow/change-notes/2024-05-06-param-return-nodes.md
+++ b/shared/dataflow/change-notes/2024-05-06-param-return-nodes.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* The data flow library now adds intermediate nodes when data flows out of a function via a parameter, in order to make path explanations easier to follow. The intermediate nodes have the same location as the underlying parameter, but must be accessed via `PathNode.asParameterReturnNode` instead of `PathNode.asNode`. `@kind path-problem` queries may have their expected test-output changed as a consequence.
+* The data flow library now adds intermediate nodes when data flows out of a function via a parameter, in order to make path explanations easier to follow. The intermediate nodes have the same location as the underlying parameter, but must be accessed via `PathNode.asParameterReturnNode` instead of `PathNode.asNode`.

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -163,6 +163,9 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       TNodeNormal(Node n) or
       TNodeImplicitRead(Node n, boolean hasRead) {
         Config::allowImplicitRead(n, _) and hasRead = [false, true]
+      } or
+      TParamReturnNode(ParameterNode p, SndLevelScopeOption scope) {
+        paramReturnNode(_, p, scope, _)
       }
 
     private class NodeEx extends TNodeEx {
@@ -170,13 +173,21 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         result = this.asNode().toString()
         or
         exists(Node n | this.isImplicitReadNode(n, _) | result = n.toString() + " [Ext]")
+        or
+        result = this.asParamReturnNode().toString() + " [Return]"
       }
 
       Node asNode() { this = TNodeNormal(result) }
 
       predicate isImplicitReadNode(Node n, boolean hasRead) { this = TNodeImplicitRead(n, hasRead) }
 
-      Node projectToNode() { this = TNodeNormal(result) or this = TNodeImplicitRead(result, _) }
+      ParameterNode asParamReturnNode() { this = TParamReturnNode(result, _) }
+
+      Node projectToNode() {
+        this = TNodeNormal(result) or
+        this = TNodeImplicitRead(result, _) or
+        this = TParamReturnNode(result, _)
+      }
 
       pragma[nomagic]
       private DataFlowCallable getEnclosingCallable0() {
@@ -189,7 +200,11 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       }
 
       pragma[nomagic]
-      private DataFlowType getDataFlowType0() { nodeDataFlowType(this.asNode(), result) }
+      private DataFlowType getDataFlowType0() {
+        nodeDataFlowType(this.asNode(), result)
+        or
+        nodeDataFlowType(this.asParamReturnNode(), result)
+      }
 
       pragma[inline]
       DataFlowType getDataFlowType() {
@@ -215,12 +230,21 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       ParameterPosition getPosition() { this.isParameterOf(_, result) }
     }
 
+    /**
+     * A node from which flow can return to the caller. This is either a regular
+     * `ReturnNode` or a synthesized node for flow out via a parameter.
+     */
     private class RetNodeEx extends NodeEx {
-      RetNodeEx() { this.asNode() instanceof ReturnNodeExt }
+      private ReturnPosition pos;
 
-      ReturnPosition getReturnPosition() { result = getReturnPosition(this.asNode()) }
+      RetNodeEx() {
+        pos = getValueReturnPosition(this.asNode()) or
+        pos = getParamReturnPosition(_, this.asParamReturnNode())
+      }
 
-      ReturnKindExt getKind() { result = this.asNode().(ReturnNodeExt).getKind() }
+      ReturnPosition getReturnPosition() { result = pos }
+
+      ReturnKindExt getKind() { result = pos.getKind() }
     }
 
     private predicate inBarrier(NodeEx node) {
@@ -345,6 +369,14 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         node1.asNode() = n and
         node2.isImplicitReadNode(n, false) and
         not fullBarrier(node1) and
+        model = ""
+      )
+      or
+      exists(Node n1, Node n2, SndLevelScopeOption scope |
+        node1.asNode() = n1 and
+        node2 = TParamReturnNode(n2, scope) and
+        paramReturnNode(pragma[only_bind_into](n1), pragma[only_bind_into](n2),
+          pragma[only_bind_into](scope), _) and
         model = ""
       )
     }
@@ -1113,26 +1145,17 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       result = getAdditionalFlowIntoCallNodeTerm(arg.projectToNode(), p.projectToNode())
     }
 
-    private module SndLevelScopeOption = Option<DataFlowSecondLevelScope>;
-
-    private class SndLevelScopeOption = SndLevelScopeOption::Option;
-
-    pragma[nomagic]
-    private SndLevelScopeOption getScope(RetNodeEx ret) {
-      result = SndLevelScopeOption::some(getSecondLevelScopeCached(ret.asNode()))
-      or
-      result instanceof SndLevelScopeOption::None and
-      not exists(getSecondLevelScopeCached(ret.asNode()))
-    }
-
     pragma[nomagic]
     private predicate returnCallEdge1(
       DataFlowCallable c, SndLevelScopeOption scope, DataFlowCall call, NodeEx out
     ) {
       exists(RetNodeEx ret |
         flowOutOfCallNodeCand1(call, ret, _, out) and
-        c = ret.getEnclosingCallable() and
-        scope = getScope(ret)
+        c = ret.getEnclosingCallable()
+      |
+        scope = getSecondLevelScopeCached(ret.asNode())
+        or
+        ret = TParamReturnNode(_, scope)
       )
     }
 
@@ -3802,6 +3825,8 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           not this instanceof PathNodeSink
           or
           this.getNodeEx() instanceof TNodeImplicitRead
+          or
+          hiddenNode(this.getNodeEx().asParamReturnNode())
         )
       }
 
@@ -3924,6 +3949,9 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
       /** Gets the underlying `Node`. */
       final Node getNode() { super.getNodeEx().projectToNode() = result }
+
+      /** Gets the parameter node through which data is returned, if any. */
+      final ParameterNode asParameterReturnNode() { result = super.getNodeEx().asParamReturnNode() }
 
       /** Gets the `FlowState` of this node. */
       final FlowState getState() { result = super.getState() }
@@ -5620,7 +5648,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         or
         exists(ReturnPosition pos |
           revPartialPathIntoReturn(mid, pos, state, sc1, sc2, sc3, _, ap) and
-          pos = getReturnPosition(node.asNode()) and
+          pos = node.(RetNodeEx).getReturnPosition() and
           isStoreStep = false
         )
         or

--- a/shared/dataflow/codeql/dataflow/internal/FlowSummaryImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/FlowSummaryImpl.qll
@@ -1692,10 +1692,11 @@ module Make<
               )
             )
             or
-            exists(ReturnNodeExt ret |
+            exists(ReturnNode ret, ValueReturnKind kind |
               c = "ReturnValue" and
               ret = node.asNode() and
-              ret.getKind().(ValueReturnKind).getKind() = getStandardReturnValueKind() and
+              valueReturnNode(ret, kind) and
+              kind.getKind() = getStandardReturnValueKind() and
               mid.asCallable() = getNodeEnclosingCallable(ret)
             )
             or

--- a/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
@@ -2,7 +2,14 @@ edges
 | file://:0:0:0:0 | .wrappedValue | test.swift:949:15:949:15 | x | provenance |  |
 | file://:0:0:0:0 | .wrappedValue | test.swift:951:15:951:15 | x | provenance |  |
 | file://:0:0:0:0 | KeyPathComponent [some:0] | test.swift:663:13:663:29 | exit #keyPath(...) [some:0] | provenance |  |
+| file://:0:0:0:0 | [post] self [v2, some:0] | test.swift:731:9:731:9 | self [Return] [v2, some:0] | provenance |  |
+| file://:0:0:0:0 | [post] self [v2] | test.swift:731:9:731:9 | self [Return] [v2] | provenance |  |
+| file://:0:0:0:0 | [post] self [v3] | test.swift:732:9:732:9 | self [Return] [v3] | provenance |  |
+| file://:0:0:0:0 | [post] self [v] | test.swift:815:7:815:7 | self [Return] [v] | provenance |  |
 | file://:0:0:0:0 | [post] self [wrappedValue] | file://:0:0:0:0 | self [wrappedValue] | provenance |  |
+| file://:0:0:0:0 | [post] self [x, some:0] | test.swift:559:9:559:9 | self [Return] [x, some:0] | provenance |  |
+| file://:0:0:0:0 | [post] self [x] | test.swift:163:7:163:7 | self [Return] [x] | provenance |  |
+| file://:0:0:0:0 | [post] self [x] | test.swift:559:9:559:9 | self [Return] [x] | provenance |  |
 | file://:0:0:0:0 | self [a, x] | file://:0:0:0:0 | .a [x] | provenance |  |
 | file://:0:0:0:0 | self [s, x] | file://:0:0:0:0 | .s [x] | provenance |  |
 | file://:0:0:0:0 | self [str] | file://:0:0:0:0 | .str | provenance |  |
@@ -78,6 +85,7 @@ edges
 | test.swift:163:7:163:7 | value | file://:0:0:0:0 | value | provenance |  |
 | test.swift:169:12:169:22 | value | test.swift:170:9:170:9 | value | provenance |  |
 | test.swift:170:5:170:5 | [post] self [x] | test.swift:169:3:171:3 | self[return] [x] | provenance |  |
+| test.swift:170:5:170:5 | [post] self [x] | test.swift:169:8:169:8 | self [Return] [x] | provenance |  |
 | test.swift:170:9:170:9 | value | test.swift:163:7:163:7 | value | provenance |  |
 | test.swift:170:9:170:9 | value | test.swift:170:5:170:5 | [post] self [x] | provenance |  |
 | test.swift:173:8:173:8 | self [x] | test.swift:174:12:174:12 | self [x] | provenance |  |
@@ -316,6 +324,7 @@ edges
 | test.swift:576:14:576:21 | call to source() | test.swift:576:13:576:21 | call to +(_:) | provenance |  |
 | test.swift:585:9:585:9 | self [str] | file://:0:0:0:0 | self [str] | provenance |  |
 | test.swift:586:10:586:13 | s | test.swift:587:13:587:13 | s | provenance |  |
+| test.swift:587:7:587:7 | [post] self [str] | test.swift:586:5:586:5 | self [Return] [str] | provenance |  |
 | test.swift:587:7:587:7 | [post] self [str] | test.swift:586:5:588:5 | self[return] [str] | provenance |  |
 | test.swift:587:13:587:13 | s | test.swift:587:7:587:7 | [post] self [str] | provenance |  |
 | test.swift:592:17:595:5 | self[return] [str] | test.swift:600:13:600:41 | call to MyClass.init(contentsOfFile:) [str] | provenance |  |
@@ -562,6 +571,7 @@ edges
 | test.swift:831:15:831:15 | s2 [v] | test.swift:831:15:831:18 | .v | provenance |  |
 | test.swift:833:15:833:15 | s2 [v] | test.swift:813:8:813:8 | self [v] | provenance |  |
 | test.swift:833:15:833:15 | s2 [v] | test.swift:833:15:833:23 | call to getv() | provenance |  |
+| test.swift:839:11:839:17 | [post] enter #keyPath(...) [s, x] | test.swift:839:11:839:17 | enter #keyPath(...) [Return] [s, x] | provenance |  |
 | test.swift:839:11:839:17 | [post] exit #keyPath(...) | test.swift:839:17:839:17 | [post] KeyPathComponent | provenance |  |
 | test.swift:839:15:839:15 | [post] KeyPathComponent [x] | test.swift:839:11:839:17 | [post] enter #keyPath(...) [s, x] | provenance |  |
 | test.swift:839:17:839:17 | [post] KeyPathComponent | test.swift:839:15:839:15 | [post] KeyPathComponent [x] | provenance |  |
@@ -739,9 +749,11 @@ nodes
 | test.swift:155:19:155:19 | i | semmle.label | i |
 | test.swift:157:16:157:23 | call to source() | semmle.label | call to source() |
 | test.swift:159:16:159:29 | call to ... | semmle.label | call to ... |
+| test.swift:163:7:163:7 | self [Return] [x] | semmle.label | self [Return] [x] |
 | test.swift:163:7:163:7 | self [x] | semmle.label | self [x] |
 | test.swift:163:7:163:7 | value | semmle.label | value |
 | test.swift:169:3:171:3 | self[return] [x] | semmle.label | self[return] [x] |
+| test.swift:169:8:169:8 | self [Return] [x] | semmle.label | self [Return] [x] |
 | test.swift:169:12:169:22 | value | semmle.label | value |
 | test.swift:170:5:170:5 | [post] self [x] | semmle.label | [post] self [x] |
 | test.swift:170:9:170:9 | value | semmle.label | value |
@@ -958,6 +970,8 @@ nodes
 | test.swift:545:11:545:22 | .some(...) [some:0] | semmle.label | .some(...) [some:0] |
 | test.swift:545:21:545:21 | a | semmle.label | a |
 | test.swift:546:19:546:19 | a | semmle.label | a |
+| test.swift:559:9:559:9 | self [Return] [x, some:0] | semmle.label | self [Return] [x, some:0] |
+| test.swift:559:9:559:9 | self [Return] [x] | semmle.label | self [Return] [x] |
 | test.swift:559:9:559:9 | self [x, some:0] | semmle.label | self [x, some:0] |
 | test.swift:559:9:559:9 | self [x] | semmle.label | self [x] |
 | test.swift:559:9:559:9 | value | semmle.label | value |
@@ -979,6 +993,7 @@ nodes
 | test.swift:576:14:576:21 | call to source() | semmle.label | call to source() |
 | test.swift:577:14:577:21 | call to source() | semmle.label | call to source() |
 | test.swift:585:9:585:9 | self [str] | semmle.label | self [str] |
+| test.swift:586:5:586:5 | self [Return] [str] | semmle.label | self [Return] [str] |
 | test.swift:586:5:588:5 | self[return] [str] | semmle.label | self[return] [str] |
 | test.swift:586:10:586:13 | s | semmle.label | s |
 | test.swift:587:7:587:7 | [post] self [str] | semmle.label | [post] self [str] |
@@ -1100,10 +1115,13 @@ nodes
 | test.swift:726:15:726:15 | set2 [Collection element] | semmle.label | set2 [Collection element] |
 | test.swift:726:15:726:34 | call to randomElement() [some:0] | semmle.label | call to randomElement() [some:0] |
 | test.swift:726:15:726:35 | ...! | semmle.label | ...! |
+| test.swift:731:9:731:9 | self [Return] [v2, some:0] | semmle.label | self [Return] [v2, some:0] |
+| test.swift:731:9:731:9 | self [Return] [v2] | semmle.label | self [Return] [v2] |
 | test.swift:731:9:731:9 | self [v2, some:0] | semmle.label | self [v2, some:0] |
 | test.swift:731:9:731:9 | self [v2] | semmle.label | self [v2] |
 | test.swift:731:9:731:9 | value | semmle.label | value |
 | test.swift:731:9:731:9 | value [some:0] | semmle.label | value [some:0] |
+| test.swift:732:9:732:9 | self [Return] [v3] | semmle.label | self [Return] [v3] |
 | test.swift:732:9:732:9 | self [v3] | semmle.label | self [v3] |
 | test.swift:732:9:732:9 | value | semmle.label | value |
 | test.swift:742:5:742:5 | v1 [some:0] | semmle.label | v1 [some:0] |
@@ -1221,6 +1239,7 @@ nodes
 | test.swift:813:8:813:8 | self [v] | semmle.label | self [v] |
 | test.swift:813:31:813:31 | .v | semmle.label | .v |
 | test.swift:813:31:813:31 | self [v] | semmle.label | self [v] |
+| test.swift:815:7:815:7 | self [Return] [v] | semmle.label | self [Return] [v] |
 | test.swift:815:7:815:7 | self [v] | semmle.label | self [v] |
 | test.swift:815:7:815:7 | value | semmle.label | value |
 | test.swift:819:14:819:25 | call to S3.init(_:) [v] | semmle.label | call to S3.init(_:) [v] |
@@ -1237,6 +1256,7 @@ nodes
 | test.swift:833:15:833:23 | call to getv() | semmle.label | call to getv() |
 | test.swift:839:11:839:17 | [post] enter #keyPath(...) [s, x] | semmle.label | [post] enter #keyPath(...) [s, x] |
 | test.swift:839:11:839:17 | [post] exit #keyPath(...) | semmle.label | [post] exit #keyPath(...) |
+| test.swift:839:11:839:17 | enter #keyPath(...) [Return] [s, x] | semmle.label | enter #keyPath(...) [Return] [s, x] |
 | test.swift:839:15:839:15 | [post] KeyPathComponent [x] | semmle.label | [post] KeyPathComponent [x] |
 | test.swift:839:17:839:17 | [post] KeyPathComponent | semmle.label | [post] KeyPathComponent |
 | test.swift:840:3:840:3 | [post] s2 [s, x] | semmle.label | [post] s2 [s, x] |
@@ -1326,33 +1346,33 @@ subpaths
 | test.swift:119:31:119:31 | x | test.swift:113:14:113:19 | arg | test.swift:114:12:114:22 | call to ... | test.swift:119:18:119:44 | call to forward(arg:lambda:) |
 | test.swift:122:31:122:38 | call to source() | test.swift:113:14:113:19 | arg | test.swift:114:12:114:22 | call to ... | test.swift:122:18:125:6 | call to forward(arg:lambda:) |
 | test.swift:145:23:145:30 | call to source() | test.swift:142:10:142:13 | i | test.swift:143:16:143:16 | i | test.swift:145:15:145:31 | call to ... |
-| test.swift:170:9:170:9 | value | test.swift:163:7:163:7 | value | file://:0:0:0:0 | [post] self [x] | test.swift:170:5:170:5 | [post] self [x] |
+| test.swift:170:9:170:9 | value | test.swift:163:7:163:7 | value | test.swift:163:7:163:7 | self [Return] [x] | test.swift:170:5:170:5 | [post] self [x] |
 | test.swift:174:12:174:12 | self [x] | test.swift:163:7:163:7 | self [x] | file://:0:0:0:0 | .x | test.swift:174:12:174:12 | .x |
-| test.swift:180:9:180:16 | call to source() | test.swift:163:7:163:7 | value | file://:0:0:0:0 | [post] self [x] | test.swift:180:3:180:3 | [post] a [x] |
+| test.swift:180:9:180:16 | call to source() | test.swift:163:7:163:7 | value | test.swift:163:7:163:7 | self [Return] [x] | test.swift:180:3:180:3 | [post] a [x] |
 | test.swift:181:13:181:13 | a [x] | test.swift:163:7:163:7 | self [x] | file://:0:0:0:0 | .x | test.swift:181:13:181:15 | .x |
-| test.swift:194:11:194:18 | call to source() | test.swift:163:7:163:7 | value | file://:0:0:0:0 | [post] self [x] | test.swift:194:3:194:5 | [post] getter for .a [x] |
+| test.swift:194:11:194:18 | call to source() | test.swift:163:7:163:7 | value | test.swift:163:7:163:7 | self [Return] [x] | test.swift:194:3:194:5 | [post] getter for .a [x] |
 | test.swift:195:13:195:13 | b [a, x] | test.swift:185:7:185:7 | self [a, x] | file://:0:0:0:0 | .a [x] | test.swift:195:13:195:15 | .a [x] |
 | test.swift:195:13:195:15 | .a [x] | test.swift:163:7:163:7 | self [x] | file://:0:0:0:0 | .x | test.swift:195:13:195:17 | .x |
 | test.swift:200:9:200:16 | call to source() | test.swift:169:12:169:22 | value | test.swift:169:3:171:3 | self[return] [x] | test.swift:200:3:200:3 | [post] a [x] |
-| test.swift:200:9:200:16 | call to source() | test.swift:169:12:169:22 | value | test.swift:170:5:170:5 | [post] self [x] | test.swift:200:3:200:3 | [post] a [x] |
+| test.swift:200:9:200:16 | call to source() | test.swift:169:12:169:22 | value | test.swift:169:8:169:8 | self [Return] [x] | test.swift:200:3:200:3 | [post] a [x] |
 | test.swift:201:13:201:13 | a [x] | test.swift:163:7:163:7 | self [x] | file://:0:0:0:0 | .x | test.swift:201:13:201:15 | .x |
-| test.swift:206:9:206:16 | call to source() | test.swift:163:7:163:7 | value | file://:0:0:0:0 | [post] self [x] | test.swift:206:3:206:3 | [post] a [x] |
+| test.swift:206:9:206:16 | call to source() | test.swift:163:7:163:7 | value | test.swift:163:7:163:7 | self [Return] [x] | test.swift:206:3:206:3 | [post] a [x] |
 | test.swift:207:13:207:13 | a [x] | test.swift:173:8:173:8 | self [x] | test.swift:174:12:174:12 | .x | test.swift:207:13:207:19 | call to get() |
 | test.swift:212:9:212:16 | call to source() | test.swift:169:12:169:22 | value | test.swift:169:3:171:3 | self[return] [x] | test.swift:212:3:212:3 | [post] a [x] |
-| test.swift:212:9:212:16 | call to source() | test.swift:169:12:169:22 | value | test.swift:170:5:170:5 | [post] self [x] | test.swift:212:3:212:3 | [post] a [x] |
+| test.swift:212:9:212:16 | call to source() | test.swift:169:12:169:22 | value | test.swift:169:8:169:8 | self [Return] [x] | test.swift:212:3:212:3 | [post] a [x] |
 | test.swift:213:13:213:13 | a [x] | test.swift:173:8:173:8 | self [x] | test.swift:174:12:174:12 | .x | test.swift:213:13:213:19 | call to get() |
 | test.swift:218:11:218:18 | call to source() | test.swift:169:12:169:22 | value | test.swift:169:3:171:3 | self[return] [x] | test.swift:218:3:218:5 | [post] getter for .a [x] |
-| test.swift:218:11:218:18 | call to source() | test.swift:169:12:169:22 | value | test.swift:170:5:170:5 | [post] self [x] | test.swift:218:3:218:5 | [post] getter for .a [x] |
+| test.swift:218:11:218:18 | call to source() | test.swift:169:12:169:22 | value | test.swift:169:8:169:8 | self [Return] [x] | test.swift:218:3:218:5 | [post] getter for .a [x] |
 | test.swift:219:13:219:13 | b [a, x] | test.swift:185:7:185:7 | self [a, x] | file://:0:0:0:0 | .a [x] | test.swift:219:13:219:15 | .a [x] |
 | test.swift:219:13:219:15 | .a [x] | test.swift:163:7:163:7 | self [x] | file://:0:0:0:0 | .x | test.swift:219:13:219:17 | .x |
 | test.swift:376:30:376:30 | t1 [Tuple element at index 1] | test.swift:368:22:368:36 | t [Tuple element at index 1] | test.swift:369:12:369:19 | (...) [Tuple element at index 0] | test.swift:376:14:376:32 | call to tupleShiftLeft1(_:) [Tuple element at index 0] |
 | test.swift:509:24:509:31 | call to source() | test.swift:394:16:394:21 | v | test.swift:394:45:394:62 | call to ... [mySingle:0] | test.swift:509:14:509:32 | call to mkMyEnum1(_:) [mySingle:0] |
 | test.swift:522:26:522:33 | call to source() | test.swift:396:18:396:23 | v | test.swift:396:45:396:60 | call to ... [some:0] | test.swift:522:14:522:34 | call to mkOptional1(_:) [some:0] |
-| test.swift:565:12:565:12 | x | test.swift:559:9:559:9 | value | file://:0:0:0:0 | [post] self [x] | test.swift:565:5:565:5 | [post] cx [x] |
-| test.swift:565:12:565:12 | x [some:0] | test.swift:559:9:559:9 | value [some:0] | file://:0:0:0:0 | [post] self [x, some:0] | test.swift:565:5:565:5 | [post] cx [x, some:0] |
+| test.swift:565:12:565:12 | x | test.swift:559:9:559:9 | value | test.swift:559:9:559:9 | self [Return] [x] | test.swift:565:5:565:5 | [post] cx [x] |
+| test.swift:565:12:565:12 | x [some:0] | test.swift:559:9:559:9 | value [some:0] | test.swift:559:9:559:9 | self [Return] [x, some:0] | test.swift:565:5:565:5 | [post] cx [x, some:0] |
 | test.swift:569:20:569:20 | cx [x, some:0] | test.swift:559:9:559:9 | self [x, some:0] | file://:0:0:0:0 | .x [some:0] | test.swift:569:20:569:23 | .x [some:0] |
 | test.swift:569:20:569:20 | cx [x] | test.swift:559:9:559:9 | self [x] | file://:0:0:0:0 | .x | test.swift:569:20:569:23 | .x |
-| test.swift:593:20:593:28 | call to source3() | test.swift:586:10:586:13 | s | test.swift:587:7:587:7 | [post] self [str] | test.swift:593:7:593:7 | [post] self [str] |
+| test.swift:593:20:593:28 | call to source3() | test.swift:586:10:586:13 | s | test.swift:586:5:586:5 | self [Return] [str] | test.swift:593:7:593:7 | [post] self [str] |
 | test.swift:599:13:599:33 | call to MyClass.init(s:) [str] | test.swift:585:9:585:9 | self [str] | file://:0:0:0:0 | .str | test.swift:599:13:599:35 | .str |
 | test.swift:599:24:599:32 | call to source3() | test.swift:586:10:586:13 | s | test.swift:586:5:588:5 | self[return] [str] | test.swift:599:13:599:33 | call to MyClass.init(s:) [str] |
 | test.swift:600:13:600:41 | call to MyClass.init(contentsOfFile:) [str] | test.swift:585:9:585:9 | self [str] | file://:0:0:0:0 | .str | test.swift:600:13:600:43 | .str |
@@ -1366,9 +1386,9 @@ subpaths
 | test.swift:661:18:661:25 | call to source() | test.swift:617:8:617:11 | x | test.swift:617:3:619:3 | self[return] [x] | test.swift:661:13:661:26 | call to S.init(x:) [x] |
 | test.swift:662:29:662:29 | s [some:0, x] | test.swift:655:8:655:12 | s [some:0, x] | test.swift:655:3:657:3 | self[return] [s, some:0, x] | test.swift:662:14:662:30 | call to S2_Optional.init(s:) [s, some:0, x] |
 | test.swift:664:15:664:15 | s2 [s, some:0, x] | test.swift:663:13:663:29 | enter #keyPath(...) [s, some:0, x] | test.swift:663:13:663:29 | exit #keyPath(...) [some:0] | test.swift:664:15:664:28 | \\...[...] [some:0] |
-| test.swift:746:14:746:21 | call to source() | test.swift:731:9:731:9 | value | file://:0:0:0:0 | [post] self [v2] | test.swift:746:5:746:5 | [post] mo1 [v2] |
-| test.swift:746:14:746:21 | call to source() [some:0] | test.swift:731:9:731:9 | value [some:0] | file://:0:0:0:0 | [post] self [v2, some:0] | test.swift:746:5:746:5 | [post] mo1 [v2, some:0] |
-| test.swift:747:14:747:21 | call to source() | test.swift:732:9:732:9 | value | file://:0:0:0:0 | [post] self [v3] | test.swift:747:5:747:5 | [post] mo1 [v3] |
+| test.swift:746:14:746:21 | call to source() | test.swift:731:9:731:9 | value | test.swift:731:9:731:9 | self [Return] [v2] | test.swift:746:5:746:5 | [post] mo1 [v2] |
+| test.swift:746:14:746:21 | call to source() [some:0] | test.swift:731:9:731:9 | value [some:0] | test.swift:731:9:731:9 | self [Return] [v2, some:0] | test.swift:746:5:746:5 | [post] mo1 [v2, some:0] |
+| test.swift:747:14:747:21 | call to source() | test.swift:732:9:732:9 | value | test.swift:732:9:732:9 | self [Return] [v3] | test.swift:747:5:747:5 | [post] mo1 [v3] |
 | test.swift:756:15:756:15 | mo1 [v2, some:0] | test.swift:731:9:731:9 | self [v2, some:0] | file://:0:0:0:0 | .v2 [some:0] | test.swift:756:15:756:19 | .v2 [some:0] |
 | test.swift:756:15:756:15 | mo1 [v2] | test.swift:731:9:731:9 | self [v2] | file://:0:0:0:0 | .v2 | test.swift:756:15:756:19 | .v2 |
 | test.swift:757:15:757:15 | mo1 [v3] | test.swift:732:9:732:9 | self [v3] | file://:0:0:0:0 | .v3 | test.swift:757:15:757:19 | .v3 |
@@ -1379,10 +1399,10 @@ subpaths
 | test.swift:819:17:819:24 | call to source() | test.swift:809:8:809:13 | v | test.swift:809:3:811:3 | self[return] [v] | test.swift:819:14:819:25 | call to S3.init(_:) [v] |
 | test.swift:822:15:822:15 | s1 [v] | test.swift:815:7:815:7 | self [v] | file://:0:0:0:0 | .v | test.swift:822:15:822:18 | .v |
 | test.swift:824:15:824:15 | s1 [v] | test.swift:813:8:813:8 | self [v] | test.swift:813:31:813:31 | .v | test.swift:824:15:824:23 | call to getv() |
-| test.swift:828:12:828:19 | call to source() | test.swift:815:7:815:7 | value | file://:0:0:0:0 | [post] self [v] | test.swift:828:5:828:5 | [post] s2 [v] |
+| test.swift:828:12:828:19 | call to source() | test.swift:815:7:815:7 | value | test.swift:815:7:815:7 | self [Return] [v] | test.swift:828:5:828:5 | [post] s2 [v] |
 | test.swift:831:15:831:15 | s2 [v] | test.swift:815:7:815:7 | self [v] | file://:0:0:0:0 | .v | test.swift:831:15:831:18 | .v |
 | test.swift:833:15:833:15 | s2 [v] | test.swift:813:8:813:8 | self [v] | test.swift:813:31:813:31 | .v | test.swift:833:15:833:23 | call to getv() |
-| test.swift:840:3:840:16 | \\...[...] | test.swift:839:11:839:17 | [post] exit #keyPath(...) | test.swift:839:11:839:17 | [post] enter #keyPath(...) [s, x] | test.swift:840:3:840:3 | [post] s2 [s, x] |
+| test.swift:840:3:840:16 | \\...[...] | test.swift:839:11:839:17 | [post] exit #keyPath(...) | test.swift:839:11:839:17 | enter #keyPath(...) [Return] [s, x] | test.swift:840:3:840:3 | [post] s2 [s, x] |
 | test.swift:841:13:841:13 | s2 [s, x] | test.swift:632:7:632:7 | self [s, x] | file://:0:0:0:0 | .s [x] | test.swift:841:13:841:16 | .s [x] |
 | test.swift:841:13:841:16 | .s [x] | test.swift:615:7:615:7 | self [x] | file://:0:0:0:0 | .x | test.swift:841:13:841:18 | .x |
 | test.swift:867:15:867:15 | args [Collection element] | test.swift:866:21:866:29 | enter #keyPath(...) [Collection element] | test.swift:866:21:866:29 | exit #keyPath(...) | test.swift:867:15:867:38 | \\...[...] |

--- a/swift/ql/test/library-tests/dataflow/taint/core/Taint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/core/Taint.expected
@@ -135,6 +135,8 @@ edges
 | conversions.swift:186:31:186:31 | arr2 [Collection element] | conversions.swift:186:15:186:35 | call to ContiguousArray<Element>.init(_:) [Collection element] | provenance |  |
 | conversions.swift:189:13:189:13 | arr1c [Collection element] | conversions.swift:189:13:189:20 | ...[...] | provenance |  |
 | conversions.swift:190:13:190:13 | arr2c [Collection element] | conversions.swift:190:13:190:20 | ...[...] | provenance |  |
+| file://:0:0:0:0 | [post] self [first] | stringinterpolation.swift:6:6:6:6 | self [Return] [first] | provenance |  |
+| file://:0:0:0:0 | [post] self [second] | stringinterpolation.swift:7:6:7:6 | self [Return] [second] | provenance |  |
 | file://:0:0:0:0 | self [first] | file://:0:0:0:0 | .first | provenance |  |
 | file://:0:0:0:0 | self [second] | file://:0:0:0:0 | .second | provenance |  |
 | file://:0:0:0:0 | value | file://:0:0:0:0 | [post] self [first] | provenance |  |
@@ -182,11 +184,10 @@ edges
 | stringinterpolation.swift:7:6:7:6 | self [second] | file://:0:0:0:0 | self [second] | provenance |  |
 | stringinterpolation.swift:7:6:7:6 | value | file://:0:0:0:0 | value | provenance |  |
 | stringinterpolation.swift:11:36:11:44 | pair [first] | stringinterpolation.swift:13:36:13:36 | pair [first] | provenance |  |
-| stringinterpolation.swift:13:3:13:3 | [post] self | stringinterpolation.swift:11:11:14:2 | self[return] | provenance |  |
 | stringinterpolation.swift:13:36:13:36 | pair [first] | stringinterpolation.swift:6:6:6:6 | self [first] | provenance |  |
 | stringinterpolation.swift:13:36:13:36 | pair [first] | stringinterpolation.swift:13:36:13:41 | .first | provenance |  |
 | stringinterpolation.swift:13:36:13:41 | .first | stringinterpolation.swift:11:11:14:2 | self[return] | provenance |  |
-| stringinterpolation.swift:13:36:13:41 | .first | stringinterpolation.swift:13:3:13:3 | [post] self | provenance |  |
+| stringinterpolation.swift:13:36:13:41 | .first | stringinterpolation.swift:11:16:11:16 | self [Return] | provenance |  |
 | stringinterpolation.swift:19:2:19:2 | [post] p1 [first] | stringinterpolation.swift:20:2:20:2 | p1 [first] | provenance |  |
 | stringinterpolation.swift:19:13:19:20 | call to source() | stringinterpolation.swift:6:6:6:6 | value | provenance |  |
 | stringinterpolation.swift:19:13:19:20 | call to source() | stringinterpolation.swift:19:2:19:2 | [post] p1 [first] | provenance |  |
@@ -466,13 +467,15 @@ nodes
 | simple.swift:85:13:85:26 | ... .&>>(_:_:) ... | semmle.label | ... .&>>(_:_:) ... |
 | simple.swift:87:13:87:21 | call to ~(_:) | semmle.label | call to ~(_:) |
 | simple.swift:87:14:87:21 | call to source() | semmle.label | call to source() |
+| stringinterpolation.swift:6:6:6:6 | self [Return] [first] | semmle.label | self [Return] [first] |
 | stringinterpolation.swift:6:6:6:6 | self [first] | semmle.label | self [first] |
 | stringinterpolation.swift:6:6:6:6 | value | semmle.label | value |
+| stringinterpolation.swift:7:6:7:6 | self [Return] [second] | semmle.label | self [Return] [second] |
 | stringinterpolation.swift:7:6:7:6 | self [second] | semmle.label | self [second] |
 | stringinterpolation.swift:7:6:7:6 | value | semmle.label | value |
 | stringinterpolation.swift:11:11:14:2 | self[return] | semmle.label | self[return] |
+| stringinterpolation.swift:11:16:11:16 | self [Return] | semmle.label | self [Return] |
 | stringinterpolation.swift:11:36:11:44 | pair [first] | semmle.label | pair [first] |
-| stringinterpolation.swift:13:3:13:3 | [post] self | semmle.label | [post] self |
 | stringinterpolation.swift:13:36:13:36 | pair [first] | semmle.label | pair [first] |
 | stringinterpolation.swift:13:36:13:41 | .first | semmle.label | .first |
 | stringinterpolation.swift:19:2:19:2 | [post] p1 [first] | semmle.label | [post] p1 [first] |
@@ -507,11 +510,11 @@ nodes
 | try.swift:18:18:18:25 | call to source() [some:0] | semmle.label | call to source() [some:0] |
 subpaths
 | stringinterpolation.swift:13:36:13:36 | pair [first] | stringinterpolation.swift:6:6:6:6 | self [first] | file://:0:0:0:0 | .first | stringinterpolation.swift:13:36:13:41 | .first |
-| stringinterpolation.swift:19:13:19:20 | call to source() | stringinterpolation.swift:6:6:6:6 | value | file://:0:0:0:0 | [post] self [first] | stringinterpolation.swift:19:2:19:2 | [post] p1 [first] |
+| stringinterpolation.swift:19:13:19:20 | call to source() | stringinterpolation.swift:6:6:6:6 | value | stringinterpolation.swift:6:6:6:6 | self [Return] [first] | stringinterpolation.swift:19:2:19:2 | [post] p1 [first] |
 | stringinterpolation.swift:22:21:22:21 | p1 [first] | stringinterpolation.swift:6:6:6:6 | self [first] | file://:0:0:0:0 | .first | stringinterpolation.swift:22:21:22:24 | .first |
 | stringinterpolation.swift:24:21:24:21 | p1 [first] | stringinterpolation.swift:11:36:11:44 | pair [first] | stringinterpolation.swift:11:11:14:2 | self[return] | stringinterpolation.swift:24:20:24:20 | [post] $interpolation |
-| stringinterpolation.swift:24:21:24:21 | p1 [first] | stringinterpolation.swift:11:36:11:44 | pair [first] | stringinterpolation.swift:13:3:13:3 | [post] self | stringinterpolation.swift:24:20:24:20 | [post] $interpolation |
-| stringinterpolation.swift:28:14:28:21 | call to source() | stringinterpolation.swift:7:6:7:6 | value | file://:0:0:0:0 | [post] self [second] | stringinterpolation.swift:28:2:28:2 | [post] p2 [second] |
+| stringinterpolation.swift:24:21:24:21 | p1 [first] | stringinterpolation.swift:11:36:11:44 | pair [first] | stringinterpolation.swift:11:16:11:16 | self [Return] | stringinterpolation.swift:24:20:24:20 | [post] $interpolation |
+| stringinterpolation.swift:28:14:28:21 | call to source() | stringinterpolation.swift:7:6:7:6 | value | stringinterpolation.swift:7:6:7:6 | self [Return] [second] | stringinterpolation.swift:28:2:28:2 | [post] p2 [second] |
 | stringinterpolation.swift:31:21:31:21 | p2 [second] | stringinterpolation.swift:7:6:7:6 | self [second] | file://:0:0:0:0 | .second | stringinterpolation.swift:31:21:31:24 | .second |
 #select
 | conversions.swift:32:12:32:22 | call to sourceInt() | conversions.swift:32:12:32:22 | call to sourceInt() | conversions.swift:32:12:32:22 | call to sourceInt() | result |

--- a/swift/ql/test/query-tests/Security/CWE-311/CleartextStorageDatabase.expected
+++ b/swift/ql/test/query-tests/Security/CWE-311/CleartextStorageDatabase.expected
@@ -69,6 +69,11 @@ edges
 | SQLite.swift:197:17:197:49 | [...] [Collection element] | SQLite.swift:197:16:197:50 | [...] [Collection element, Collection element] | provenance |  |
 | SQLite.swift:197:18:197:32 | ... <-(_:_:) ... | SQLite.swift:197:17:197:49 | [...] [Collection element] | provenance |  |
 | SQLite.swift:197:32:197:32 | mobilePhoneNumber | SQLite.swift:197:18:197:32 | ... <-(_:_:) ... | provenance |  |
+| file://:0:0:0:0 | [post] self [data] | testRealm2.swift:13:6:13:6 | self [Return] [data] | provenance |  |
+| file://:0:0:0:0 | [post] self [data] | testRealm.swift:27:6:27:6 | self [Return] [data] | provenance |  |
+| file://:0:0:0:0 | [post] self [notStoredBankAccountNumber] | testCoreData2.swift:23:13:23:13 | self [Return] [notStoredBankAccountNumber] | provenance |  |
+| file://:0:0:0:0 | [post] self [password] | testRealm.swift:34:6:34:6 | self [Return] [password] | provenance |  |
+| file://:0:0:0:0 | [post] self [value] | testCoreData2.swift:70:9:70:9 | self [Return] [value] | provenance |  |
 | file://:0:0:0:0 | self | file://:0:0:0:0 | .value | provenance |  |
 | file://:0:0:0:0 | self | file://:0:0:0:0 | .value2 | provenance |  |
 | file://:0:0:0:0 | self [value] | file://:0:0:0:0 | .value | provenance |  |
@@ -426,6 +431,7 @@ nodes
 | sqlite3_c_api.swift:46:27:46:27 | insertQuery | semmle.label | insertQuery |
 | sqlite3_c_api.swift:47:27:47:27 | updateQuery | semmle.label | updateQuery |
 | sqlite3_c_api.swift:58:36:58:36 | medicalNotes | semmle.label | medicalNotes |
+| testCoreData2.swift:23:13:23:13 | self [Return] [notStoredBankAccountNumber] | semmle.label | self [Return] [notStoredBankAccountNumber] |
 | testCoreData2.swift:23:13:23:13 | value | semmle.label | value |
 | testCoreData2.swift:37:2:37:2 | [post] obj | semmle.label | [post] obj |
 | testCoreData2.swift:37:2:37:2 | [post] obj [myValue] | semmle.label | [post] obj [myValue] |
@@ -464,6 +470,7 @@ nodes
 | testCoreData2.swift:65:3:65:3 | [post] obj [myBankAccountNumber] | semmle.label | [post] obj [myBankAccountNumber] |
 | testCoreData2.swift:65:29:65:29 | bankAccountNo | semmle.label | bankAccountNo |
 | testCoreData2.swift:70:9:70:9 | self | semmle.label | self |
+| testCoreData2.swift:70:9:70:9 | self [Return] [value] | semmle.label | self [Return] [value] |
 | testCoreData2.swift:70:9:70:9 | self [value] | semmle.label | self [value] |
 | testCoreData2.swift:70:9:70:9 | value | semmle.label | value |
 | testCoreData2.swift:71:9:71:9 | self | semmle.label | self |
@@ -709,11 +716,14 @@ nodes
 | testGRDB.swift:212:98:212:107 | [...] | semmle.label | [...] |
 | testGRDB.swift:212:98:212:107 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:212:99:212:99 | password | semmle.label | password |
+| testRealm2.swift:13:6:13:6 | self [Return] [data] | semmle.label | self [Return] [data] |
 | testRealm2.swift:13:6:13:6 | value | semmle.label | value |
 | testRealm2.swift:18:2:18:2 | [post] o | semmle.label | [post] o |
 | testRealm2.swift:18:2:18:2 | [post] o [data] | semmle.label | [post] o [data] |
 | testRealm2.swift:18:11:18:11 | myPassword | semmle.label | myPassword |
+| testRealm.swift:27:6:27:6 | self [Return] [data] | semmle.label | self [Return] [data] |
 | testRealm.swift:27:6:27:6 | value | semmle.label | value |
+| testRealm.swift:34:6:34:6 | self [Return] [password] | semmle.label | self [Return] [password] |
 | testRealm.swift:34:6:34:6 | value | semmle.label | value |
 | testRealm.swift:41:2:41:2 | [post] a | semmle.label | [post] a |
 | testRealm.swift:41:2:41:2 | [post] a [data] | semmle.label | [post] a [data] |
@@ -731,8 +741,8 @@ nodes
 | testRealm.swift:73:2:73:2 | [post] h [password] | semmle.label | [post] h [password] |
 | testRealm.swift:73:15:73:15 | myPassword | semmle.label | myPassword |
 subpaths
-| testCoreData2.swift:43:35:43:35 | bankAccountNo | testCoreData2.swift:23:13:23:13 | value | file://:0:0:0:0 | [post] self [notStoredBankAccountNumber] | testCoreData2.swift:43:2:43:2 | [post] obj [notStoredBankAccountNumber] |
-| testCoreData2.swift:52:41:52:41 | bankAccountNo | testCoreData2.swift:23:13:23:13 | value | file://:0:0:0:0 | [post] self [notStoredBankAccountNumber] | testCoreData2.swift:52:2:52:10 | [post] ...? [notStoredBankAccountNumber] |
+| testCoreData2.swift:43:35:43:35 | bankAccountNo | testCoreData2.swift:23:13:23:13 | value | testCoreData2.swift:23:13:23:13 | self [Return] [notStoredBankAccountNumber] | testCoreData2.swift:43:2:43:2 | [post] obj [notStoredBankAccountNumber] |
+| testCoreData2.swift:52:41:52:41 | bankAccountNo | testCoreData2.swift:23:13:23:13 | value | testCoreData2.swift:23:13:23:13 | self [Return] [notStoredBankAccountNumber] | testCoreData2.swift:52:2:52:10 | [post] ...? [notStoredBankAccountNumber] |
 | testCoreData2.swift:82:18:82:18 | bankAccountNo | testCoreData2.swift:70:9:70:9 | self | file://:0:0:0:0 | .value | testCoreData2.swift:82:18:82:32 | .value |
 | testCoreData2.swift:83:18:83:18 | bankAccountNo | testCoreData2.swift:71:9:71:9 | self | file://:0:0:0:0 | .value2 | testCoreData2.swift:83:18:83:32 | .value2 |
 | testCoreData2.swift:84:18:84:18 | ...! | testCoreData2.swift:70:9:70:9 | self | file://:0:0:0:0 | .value | testCoreData2.swift:84:18:84:33 | .value |
@@ -741,16 +751,16 @@ subpaths
 | testCoreData2.swift:89:22:89:22 | ...! | testCoreData2.swift:71:9:71:9 | self | file://:0:0:0:0 | .value2 | testCoreData2.swift:89:22:89:37 | .value2 |
 | testCoreData2.swift:92:10:92:10 | a | testCoreData2.swift:70:9:70:9 | self | file://:0:0:0:0 | .value | testCoreData2.swift:92:10:92:12 | .value |
 | testCoreData2.swift:97:12:97:12 | c | testCoreData2.swift:70:9:70:9 | self | file://:0:0:0:0 | .value | testCoreData2.swift:97:12:97:14 | .value |
-| testCoreData2.swift:97:12:97:14 | .value | testCoreData2.swift:70:9:70:9 | value | file://:0:0:0:0 | [post] self [value] | testCoreData2.swift:97:2:97:2 | [post] d [value] |
+| testCoreData2.swift:97:12:97:14 | .value | testCoreData2.swift:70:9:70:9 | value | testCoreData2.swift:70:9:70:9 | self [Return] [value] | testCoreData2.swift:97:2:97:2 | [post] d [value] |
 | testCoreData2.swift:98:18:98:18 | d [value] | testCoreData2.swift:70:9:70:9 | self [value] | file://:0:0:0:0 | .value | testCoreData2.swift:98:18:98:20 | .value |
 | testCoreData2.swift:104:18:104:18 | e | testCoreData2.swift:70:9:70:9 | self | file://:0:0:0:0 | .value | testCoreData2.swift:104:18:104:20 | .value |
 | testCoreData2.swift:105:18:105:18 | e | testCoreData2.swift:71:9:71:9 | self | file://:0:0:0:0 | .value2 | testCoreData2.swift:105:18:105:20 | .value2 |
-| testRealm2.swift:18:11:18:11 | myPassword | testRealm2.swift:13:6:13:6 | value | file://:0:0:0:0 | [post] self [data] | testRealm2.swift:18:2:18:2 | [post] o [data] |
-| testRealm.swift:41:11:41:11 | myPassword | testRealm.swift:27:6:27:6 | value | file://:0:0:0:0 | [post] self [data] | testRealm.swift:41:2:41:2 | [post] a [data] |
-| testRealm.swift:49:11:49:11 | myPassword | testRealm.swift:27:6:27:6 | value | file://:0:0:0:0 | [post] self [data] | testRealm.swift:49:2:49:2 | [post] c [data] |
-| testRealm.swift:59:12:59:12 | myPassword | testRealm.swift:27:6:27:6 | value | file://:0:0:0:0 | [post] self [data] | testRealm.swift:59:2:59:3 | [post] ...! [data] |
-| testRealm.swift:66:11:66:11 | myPassword | testRealm.swift:27:6:27:6 | value | file://:0:0:0:0 | [post] self [data] | testRealm.swift:66:2:66:2 | [post] g [data] |
-| testRealm.swift:73:15:73:15 | myPassword | testRealm.swift:34:6:34:6 | value | file://:0:0:0:0 | [post] self [password] | testRealm.swift:73:2:73:2 | [post] h [password] |
+| testRealm2.swift:18:11:18:11 | myPassword | testRealm2.swift:13:6:13:6 | value | testRealm2.swift:13:6:13:6 | self [Return] [data] | testRealm2.swift:18:2:18:2 | [post] o [data] |
+| testRealm.swift:41:11:41:11 | myPassword | testRealm.swift:27:6:27:6 | value | testRealm.swift:27:6:27:6 | self [Return] [data] | testRealm.swift:41:2:41:2 | [post] a [data] |
+| testRealm.swift:49:11:49:11 | myPassword | testRealm.swift:27:6:27:6 | value | testRealm.swift:27:6:27:6 | self [Return] [data] | testRealm.swift:49:2:49:2 | [post] c [data] |
+| testRealm.swift:59:12:59:12 | myPassword | testRealm.swift:27:6:27:6 | value | testRealm.swift:27:6:27:6 | self [Return] [data] | testRealm.swift:59:2:59:3 | [post] ...! [data] |
+| testRealm.swift:66:11:66:11 | myPassword | testRealm.swift:27:6:27:6 | value | testRealm.swift:27:6:27:6 | self [Return] [data] | testRealm.swift:66:2:66:2 | [post] g [data] |
+| testRealm.swift:73:15:73:15 | myPassword | testRealm.swift:34:6:34:6 | value | testRealm.swift:34:6:34:6 | self [Return] [password] | testRealm.swift:73:2:73:2 | [post] h [password] |
 #select
 | SQLite.swift:123:17:123:17 | insertQuery | SQLite.swift:119:70:119:70 | mobilePhoneNumber | SQLite.swift:123:17:123:17 | insertQuery | This operation stores 'insertQuery' in a database. It may contain unencrypted sensitive data from $@. | SQLite.swift:119:70:119:70 | mobilePhoneNumber | mobilePhoneNumber |
 | SQLite.swift:124:17:124:17 | updateQuery | SQLite.swift:120:50:120:50 | mobilePhoneNumber | SQLite.swift:124:17:124:17 | updateQuery | This operation stores 'updateQuery' in a database. It may contain unencrypted sensitive data from $@. | SQLite.swift:120:50:120:50 | mobilePhoneNumber | mobilePhoneNumber |

--- a/swift/ql/test/query-tests/Security/CWE-321/HardcodedEncryptionKey.expected
+++ b/swift/ql/test/query-tests/Security/CWE-321/HardcodedEncryptionKey.expected
@@ -26,8 +26,11 @@ edges
 | cryptoswift.swift:92:18:92:36 | call to getConstantString() | cryptoswift.swift:153:26:153:26 | keyString | provenance |  |
 | cryptoswift.swift:92:18:92:36 | call to getConstantString() | cryptoswift.swift:162:24:162:24 | keyString | provenance |  |
 | cryptoswift.swift:92:18:92:36 | call to getConstantString() | cryptoswift.swift:164:24:164:24 | keyString | provenance |  |
+| file://:0:0:0:0 | [post] self | misc.swift:30:7:30:7 | self [Return] | provenance |  |
 | file://:0:0:0:0 | [post] self [encryptionKey] | file://:0:0:0:0 | [post] self | provenance |  |
 | file://:0:0:0:0 | [post] self [encryptionKey] | file://:0:0:0:0 | [post] self | provenance |  |
+| file://:0:0:0:0 | [post] self [encryptionKey] | misc.swift:30:7:30:7 | self [Return] | provenance |  |
+| file://:0:0:0:0 | [post] self [encryptionKey] | misc.swift:30:7:30:7 | self [Return] [encryptionKey] | provenance |  |
 | file://:0:0:0:0 | value | file://:0:0:0:0 | [post] self [encryptionKey] | provenance |  |
 | grdb.swift:21:20:21:20 | abc123 | grdb.swift:27:23:27:23 | constString | provenance |  |
 | grdb.swift:21:20:21:20 | abc123 | grdb.swift:31:26:31:26 | constString | provenance |  |
@@ -116,6 +119,8 @@ nodes
 | grdb.swift:29:23:29:23 | constData | semmle.label | constData |
 | grdb.swift:31:26:31:26 | constString | semmle.label | constString |
 | grdb.swift:33:26:33:26 | constData | semmle.label | constData |
+| misc.swift:30:7:30:7 | self [Return] | semmle.label | self [Return] |
+| misc.swift:30:7:30:7 | self [Return] [encryptionKey] | semmle.label | self [Return] [encryptionKey] |
 | misc.swift:30:7:30:7 | value | semmle.label | value |
 | misc.swift:46:19:46:38 | call to Data.init(_:) | semmle.label | call to Data.init(_:) |
 | misc.swift:46:24:46:24 | abcdef123456 | semmle.label | abcdef123456 |
@@ -150,10 +155,10 @@ nodes
 | sqlite3_c_api.swift:49:36:49:36 | buffer | semmle.label | buffer |
 | sqlite3_c_api.swift:50:38:50:38 | buffer | semmle.label | buffer |
 subpaths
-| misc.swift:53:25:53:25 | myConstKey | misc.swift:30:7:30:7 | value | file://:0:0:0:0 | [post] self | misc.swift:53:2:53:2 | [post] config |
-| misc.swift:53:25:53:25 | myConstKey | misc.swift:30:7:30:7 | value | file://:0:0:0:0 | [post] self [encryptionKey] | misc.swift:53:2:53:2 | [post] config [encryptionKey] |
-| misc.swift:57:41:57:41 | myConstKey | misc.swift:30:7:30:7 | value | file://:0:0:0:0 | [post] self | misc.swift:57:2:57:18 | [post] getter for .config |
-| misc.swift:57:41:57:41 | myConstKey | misc.swift:30:7:30:7 | value | file://:0:0:0:0 | [post] self [encryptionKey] | misc.swift:57:2:57:18 | [post] getter for .config [encryptionKey] |
+| misc.swift:53:25:53:25 | myConstKey | misc.swift:30:7:30:7 | value | misc.swift:30:7:30:7 | self [Return] | misc.swift:53:2:53:2 | [post] config |
+| misc.swift:53:25:53:25 | myConstKey | misc.swift:30:7:30:7 | value | misc.swift:30:7:30:7 | self [Return] [encryptionKey] | misc.swift:53:2:53:2 | [post] config [encryptionKey] |
+| misc.swift:57:41:57:41 | myConstKey | misc.swift:30:7:30:7 | value | misc.swift:30:7:30:7 | self [Return] | misc.swift:57:2:57:18 | [post] getter for .config |
+| misc.swift:57:41:57:41 | myConstKey | misc.swift:30:7:30:7 | value | misc.swift:30:7:30:7 | self [Return] [encryptionKey] | misc.swift:57:2:57:18 | [post] getter for .config [encryptionKey] |
 #select
 | SQLite.swift:43:13:43:13 | hardcoded_key | SQLite.swift:43:13:43:13 | hardcoded_key | SQLite.swift:43:13:43:13 | hardcoded_key | The key 'hardcoded_key' has been initialized with hard-coded values from $@. | SQLite.swift:43:13:43:13 | hardcoded_key | hardcoded_key |
 | SQLite.swift:45:23:45:23 | hardcoded_key | SQLite.swift:45:23:45:23 | hardcoded_key | SQLite.swift:45:23:45:23 | hardcoded_key | The key 'hardcoded_key' has been initialized with hard-coded values from $@. | SQLite.swift:45:23:45:23 | hardcoded_key | hardcoded_key |

--- a/swift/ql/test/query-tests/Security/CWE-757/InsecureTLS.expected
+++ b/swift/ql/test/query-tests/Security/CWE-757/InsecureTLS.expected
@@ -58,12 +58,25 @@ edges
 | InsecureTLS.swift:202:24:202:31 | [post] getter for .tlsMinimumSupportedProtocolVersion | InsecureTLS.swift:202:24:202:24 | [post] config [tlsMinimumSupportedProtocolVersion] | provenance |  |
 | InsecureTLS.swift:202:74:202:97 | .TLSv10 | InsecureTLS.swift:196:56:196:63 | value | provenance |  |
 | InsecureTLS.swift:202:74:202:97 | .TLSv10 | InsecureTLS.swift:202:24:202:31 | [post] getter for .tlsMinimumSupportedProtocolVersion | provenance |  |
+| file://:0:0:0:0 | [post] self | InsecureTLS.swift:19:7:19:7 | self [Return] | provenance |  |
+| file://:0:0:0:0 | [post] self | InsecureTLS.swift:20:7:20:7 | self [Return] | provenance |  |
+| file://:0:0:0:0 | [post] self | InsecureTLS.swift:22:7:22:7 | self [Return] | provenance |  |
+| file://:0:0:0:0 | [post] self | InsecureTLS.swift:23:7:23:7 | self [Return] | provenance |  |
+| file://:0:0:0:0 | [post] self [TLSVersion] | InsecureTLS.swift:158:7:158:7 | self [Return] [TLSVersion] | provenance |  |
+| file://:0:0:0:0 | [post] self [tlsMaximumSupportedProtocolVersion] | InsecureTLS.swift:20:7:20:7 | self [Return] | provenance |  |
+| file://:0:0:0:0 | [post] self [tlsMaximumSupportedProtocolVersion] | InsecureTLS.swift:20:7:20:7 | self [Return] [tlsMaximumSupportedProtocolVersion] | provenance |  |
 | file://:0:0:0:0 | [post] self [tlsMaximumSupportedProtocolVersion] | file://:0:0:0:0 | [post] self | provenance |  |
 | file://:0:0:0:0 | [post] self [tlsMaximumSupportedProtocolVersion] | file://:0:0:0:0 | [post] self | provenance |  |
+| file://:0:0:0:0 | [post] self [tlsMaximumSupportedProtocol] | InsecureTLS.swift:23:7:23:7 | self [Return] | provenance |  |
+| file://:0:0:0:0 | [post] self [tlsMaximumSupportedProtocol] | InsecureTLS.swift:23:7:23:7 | self [Return] [tlsMaximumSupportedProtocol] | provenance |  |
 | file://:0:0:0:0 | [post] self [tlsMaximumSupportedProtocol] | file://:0:0:0:0 | [post] self | provenance |  |
 | file://:0:0:0:0 | [post] self [tlsMaximumSupportedProtocol] | file://:0:0:0:0 | [post] self | provenance |  |
+| file://:0:0:0:0 | [post] self [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:19:7:19:7 | self [Return] | provenance |  |
+| file://:0:0:0:0 | [post] self [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:19:7:19:7 | self [Return] [tlsMinimumSupportedProtocolVersion] | provenance |  |
 | file://:0:0:0:0 | [post] self [tlsMinimumSupportedProtocolVersion] | file://:0:0:0:0 | [post] self | provenance |  |
 | file://:0:0:0:0 | [post] self [tlsMinimumSupportedProtocolVersion] | file://:0:0:0:0 | [post] self | provenance |  |
+| file://:0:0:0:0 | [post] self [tlsMinimumSupportedProtocol] | InsecureTLS.swift:22:7:22:7 | self [Return] | provenance |  |
+| file://:0:0:0:0 | [post] self [tlsMinimumSupportedProtocol] | InsecureTLS.swift:22:7:22:7 | self [Return] [tlsMinimumSupportedProtocol] | provenance |  |
 | file://:0:0:0:0 | [post] self [tlsMinimumSupportedProtocol] | file://:0:0:0:0 | [post] self | provenance |  |
 | file://:0:0:0:0 | [post] self [tlsMinimumSupportedProtocol] | file://:0:0:0:0 | [post] self | provenance |  |
 | file://:0:0:0:0 | self [TLSVersion] | file://:0:0:0:0 | .TLSVersion | provenance |  |
@@ -73,9 +86,17 @@ edges
 | file://:0:0:0:0 | value | file://:0:0:0:0 | [post] self [tlsMinimumSupportedProtocolVersion] | provenance |  |
 | file://:0:0:0:0 | value | file://:0:0:0:0 | [post] self [tlsMinimumSupportedProtocol] | provenance |  |
 nodes
+| InsecureTLS.swift:19:7:19:7 | self [Return] | semmle.label | self [Return] |
+| InsecureTLS.swift:19:7:19:7 | self [Return] [tlsMinimumSupportedProtocolVersion] | semmle.label | self [Return] [tlsMinimumSupportedProtocolVersion] |
 | InsecureTLS.swift:19:7:19:7 | value | semmle.label | value |
+| InsecureTLS.swift:20:7:20:7 | self [Return] | semmle.label | self [Return] |
+| InsecureTLS.swift:20:7:20:7 | self [Return] [tlsMaximumSupportedProtocolVersion] | semmle.label | self [Return] [tlsMaximumSupportedProtocolVersion] |
 | InsecureTLS.swift:20:7:20:7 | value | semmle.label | value |
+| InsecureTLS.swift:22:7:22:7 | self [Return] | semmle.label | self [Return] |
+| InsecureTLS.swift:22:7:22:7 | self [Return] [tlsMinimumSupportedProtocol] | semmle.label | self [Return] [tlsMinimumSupportedProtocol] |
 | InsecureTLS.swift:22:7:22:7 | value | semmle.label | value |
+| InsecureTLS.swift:23:7:23:7 | self [Return] | semmle.label | self [Return] |
+| InsecureTLS.swift:23:7:23:7 | self [Return] [tlsMaximumSupportedProtocol] | semmle.label | self [Return] [tlsMaximumSupportedProtocol] |
 | InsecureTLS.swift:23:7:23:7 | value | semmle.label | value |
 | InsecureTLS.swift:40:3:40:3 | [post] config | semmle.label | [post] config |
 | InsecureTLS.swift:40:3:40:3 | [post] config [tlsMinimumSupportedProtocolVersion] | semmle.label | [post] config [tlsMinimumSupportedProtocolVersion] |
@@ -101,6 +122,7 @@ nodes
 | InsecureTLS.swift:122:3:122:3 | [post] config [tlsMinimumSupportedProtocolVersion] | semmle.label | [post] config [tlsMinimumSupportedProtocolVersion] |
 | InsecureTLS.swift:122:47:122:47 | version | semmle.label | version |
 | InsecureTLS.swift:127:25:127:48 | .TLSv11 | semmle.label | .TLSv11 |
+| InsecureTLS.swift:158:7:158:7 | self [Return] [TLSVersion] | semmle.label | self [Return] [TLSVersion] |
 | InsecureTLS.swift:158:7:158:7 | self [TLSVersion] | semmle.label | self [TLSVersion] |
 | InsecureTLS.swift:158:7:158:7 | value | semmle.label | value |
 | InsecureTLS.swift:163:3:163:3 | [post] def [TLSVersion] | semmle.label | [post] def [TLSVersion] |
@@ -144,26 +166,26 @@ nodes
 | file://:0:0:0:0 | value | semmle.label | value |
 | file://:0:0:0:0 | value | semmle.label | value |
 subpaths
-| InsecureTLS.swift:40:47:40:70 | .TLSv10 | InsecureTLS.swift:19:7:19:7 | value | file://:0:0:0:0 | [post] self | InsecureTLS.swift:40:3:40:3 | [post] config |
-| InsecureTLS.swift:40:47:40:70 | .TLSv10 | InsecureTLS.swift:19:7:19:7 | value | file://:0:0:0:0 | [post] self [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:40:3:40:3 | [post] config [tlsMinimumSupportedProtocolVersion] |
-| InsecureTLS.swift:45:47:45:70 | .TLSv11 | InsecureTLS.swift:19:7:19:7 | value | file://:0:0:0:0 | [post] self | InsecureTLS.swift:45:3:45:3 | [post] config |
-| InsecureTLS.swift:45:47:45:70 | .TLSv11 | InsecureTLS.swift:19:7:19:7 | value | file://:0:0:0:0 | [post] self [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:45:3:45:3 | [post] config [tlsMinimumSupportedProtocolVersion] |
-| InsecureTLS.swift:57:47:57:70 | .TLSv10 | InsecureTLS.swift:20:7:20:7 | value | file://:0:0:0:0 | [post] self | InsecureTLS.swift:57:3:57:3 | [post] config |
-| InsecureTLS.swift:57:47:57:70 | .TLSv10 | InsecureTLS.swift:20:7:20:7 | value | file://:0:0:0:0 | [post] self [tlsMaximumSupportedProtocolVersion] | InsecureTLS.swift:57:3:57:3 | [post] config [tlsMaximumSupportedProtocolVersion] |
-| InsecureTLS.swift:64:40:64:52 | .tlsProtocol10 | InsecureTLS.swift:22:7:22:7 | value | file://:0:0:0:0 | [post] self | InsecureTLS.swift:64:3:64:3 | [post] config |
-| InsecureTLS.swift:64:40:64:52 | .tlsProtocol10 | InsecureTLS.swift:22:7:22:7 | value | file://:0:0:0:0 | [post] self [tlsMinimumSupportedProtocol] | InsecureTLS.swift:64:3:64:3 | [post] config [tlsMinimumSupportedProtocol] |
-| InsecureTLS.swift:76:40:76:52 | .tlsProtocol10 | InsecureTLS.swift:23:7:23:7 | value | file://:0:0:0:0 | [post] self | InsecureTLS.swift:76:3:76:3 | [post] config |
-| InsecureTLS.swift:76:40:76:52 | .tlsProtocol10 | InsecureTLS.swift:23:7:23:7 | value | file://:0:0:0:0 | [post] self [tlsMaximumSupportedProtocol] | InsecureTLS.swift:76:3:76:3 | [post] config [tlsMaximumSupportedProtocol] |
-| InsecureTLS.swift:111:47:111:64 | call to getBadTLSVersion() | InsecureTLS.swift:19:7:19:7 | value | file://:0:0:0:0 | [post] self | InsecureTLS.swift:111:3:111:3 | [post] config |
-| InsecureTLS.swift:111:47:111:64 | call to getBadTLSVersion() | InsecureTLS.swift:19:7:19:7 | value | file://:0:0:0:0 | [post] self [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:111:3:111:3 | [post] config [tlsMinimumSupportedProtocolVersion] |
-| InsecureTLS.swift:122:47:122:47 | version | InsecureTLS.swift:19:7:19:7 | value | file://:0:0:0:0 | [post] self | InsecureTLS.swift:122:3:122:3 | [post] config |
-| InsecureTLS.swift:122:47:122:47 | version | InsecureTLS.swift:19:7:19:7 | value | file://:0:0:0:0 | [post] self [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:122:3:122:3 | [post] config [tlsMinimumSupportedProtocolVersion] |
-| InsecureTLS.swift:163:20:163:43 | .TLSv10 | InsecureTLS.swift:158:7:158:7 | value | file://:0:0:0:0 | [post] self [TLSVersion] | InsecureTLS.swift:163:3:163:3 | [post] def [TLSVersion] |
+| InsecureTLS.swift:40:47:40:70 | .TLSv10 | InsecureTLS.swift:19:7:19:7 | value | InsecureTLS.swift:19:7:19:7 | self [Return] | InsecureTLS.swift:40:3:40:3 | [post] config |
+| InsecureTLS.swift:40:47:40:70 | .TLSv10 | InsecureTLS.swift:19:7:19:7 | value | InsecureTLS.swift:19:7:19:7 | self [Return] [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:40:3:40:3 | [post] config [tlsMinimumSupportedProtocolVersion] |
+| InsecureTLS.swift:45:47:45:70 | .TLSv11 | InsecureTLS.swift:19:7:19:7 | value | InsecureTLS.swift:19:7:19:7 | self [Return] | InsecureTLS.swift:45:3:45:3 | [post] config |
+| InsecureTLS.swift:45:47:45:70 | .TLSv11 | InsecureTLS.swift:19:7:19:7 | value | InsecureTLS.swift:19:7:19:7 | self [Return] [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:45:3:45:3 | [post] config [tlsMinimumSupportedProtocolVersion] |
+| InsecureTLS.swift:57:47:57:70 | .TLSv10 | InsecureTLS.swift:20:7:20:7 | value | InsecureTLS.swift:20:7:20:7 | self [Return] | InsecureTLS.swift:57:3:57:3 | [post] config |
+| InsecureTLS.swift:57:47:57:70 | .TLSv10 | InsecureTLS.swift:20:7:20:7 | value | InsecureTLS.swift:20:7:20:7 | self [Return] [tlsMaximumSupportedProtocolVersion] | InsecureTLS.swift:57:3:57:3 | [post] config [tlsMaximumSupportedProtocolVersion] |
+| InsecureTLS.swift:64:40:64:52 | .tlsProtocol10 | InsecureTLS.swift:22:7:22:7 | value | InsecureTLS.swift:22:7:22:7 | self [Return] | InsecureTLS.swift:64:3:64:3 | [post] config |
+| InsecureTLS.swift:64:40:64:52 | .tlsProtocol10 | InsecureTLS.swift:22:7:22:7 | value | InsecureTLS.swift:22:7:22:7 | self [Return] [tlsMinimumSupportedProtocol] | InsecureTLS.swift:64:3:64:3 | [post] config [tlsMinimumSupportedProtocol] |
+| InsecureTLS.swift:76:40:76:52 | .tlsProtocol10 | InsecureTLS.swift:23:7:23:7 | value | InsecureTLS.swift:23:7:23:7 | self [Return] | InsecureTLS.swift:76:3:76:3 | [post] config |
+| InsecureTLS.swift:76:40:76:52 | .tlsProtocol10 | InsecureTLS.swift:23:7:23:7 | value | InsecureTLS.swift:23:7:23:7 | self [Return] [tlsMaximumSupportedProtocol] | InsecureTLS.swift:76:3:76:3 | [post] config [tlsMaximumSupportedProtocol] |
+| InsecureTLS.swift:111:47:111:64 | call to getBadTLSVersion() | InsecureTLS.swift:19:7:19:7 | value | InsecureTLS.swift:19:7:19:7 | self [Return] | InsecureTLS.swift:111:3:111:3 | [post] config |
+| InsecureTLS.swift:111:47:111:64 | call to getBadTLSVersion() | InsecureTLS.swift:19:7:19:7 | value | InsecureTLS.swift:19:7:19:7 | self [Return] [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:111:3:111:3 | [post] config [tlsMinimumSupportedProtocolVersion] |
+| InsecureTLS.swift:122:47:122:47 | version | InsecureTLS.swift:19:7:19:7 | value | InsecureTLS.swift:19:7:19:7 | self [Return] | InsecureTLS.swift:122:3:122:3 | [post] config |
+| InsecureTLS.swift:122:47:122:47 | version | InsecureTLS.swift:19:7:19:7 | value | InsecureTLS.swift:19:7:19:7 | self [Return] [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:122:3:122:3 | [post] config [tlsMinimumSupportedProtocolVersion] |
+| InsecureTLS.swift:163:20:163:43 | .TLSv10 | InsecureTLS.swift:158:7:158:7 | value | InsecureTLS.swift:158:7:158:7 | self [Return] [TLSVersion] | InsecureTLS.swift:163:3:163:3 | [post] def [TLSVersion] |
 | InsecureTLS.swift:165:47:165:47 | def [TLSVersion] | InsecureTLS.swift:158:7:158:7 | self [TLSVersion] | file://:0:0:0:0 | .TLSVersion | InsecureTLS.swift:165:47:165:51 | .TLSVersion |
-| InsecureTLS.swift:165:47:165:51 | .TLSVersion | InsecureTLS.swift:19:7:19:7 | value | file://:0:0:0:0 | [post] self | InsecureTLS.swift:165:3:165:3 | [post] config |
-| InsecureTLS.swift:165:47:165:51 | .TLSVersion | InsecureTLS.swift:19:7:19:7 | value | file://:0:0:0:0 | [post] self [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:165:3:165:3 | [post] config [tlsMinimumSupportedProtocolVersion] |
-| InsecureTLS.swift:181:53:181:76 | .TLSv10 | InsecureTLS.swift:19:7:19:7 | value | file://:0:0:0:0 | [post] self | InsecureTLS.swift:181:3:181:9 | [post] getter for .config |
-| InsecureTLS.swift:181:53:181:76 | .TLSv10 | InsecureTLS.swift:19:7:19:7 | value | file://:0:0:0:0 | [post] self [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:181:3:181:9 | [post] getter for .config [tlsMinimumSupportedProtocolVersion] |
+| InsecureTLS.swift:165:47:165:51 | .TLSVersion | InsecureTLS.swift:19:7:19:7 | value | InsecureTLS.swift:19:7:19:7 | self [Return] | InsecureTLS.swift:165:3:165:3 | [post] config |
+| InsecureTLS.swift:165:47:165:51 | .TLSVersion | InsecureTLS.swift:19:7:19:7 | value | InsecureTLS.swift:19:7:19:7 | self [Return] [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:165:3:165:3 | [post] config [tlsMinimumSupportedProtocolVersion] |
+| InsecureTLS.swift:181:53:181:76 | .TLSv10 | InsecureTLS.swift:19:7:19:7 | value | InsecureTLS.swift:19:7:19:7 | self [Return] | InsecureTLS.swift:181:3:181:9 | [post] getter for .config |
+| InsecureTLS.swift:181:53:181:76 | .TLSv10 | InsecureTLS.swift:19:7:19:7 | value | InsecureTLS.swift:19:7:19:7 | self [Return] [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:181:3:181:9 | [post] getter for .config [tlsMinimumSupportedProtocolVersion] |
 | InsecureTLS.swift:202:74:202:97 | .TLSv10 | InsecureTLS.swift:196:56:196:63 | value | InsecureTLS.swift:196:1:198:1 | version[return] | InsecureTLS.swift:202:24:202:31 | [post] getter for .tlsMinimumSupportedProtocolVersion |
 #select
 | InsecureTLS.swift:40:3:40:3 | [post] config | InsecureTLS.swift:40:47:40:70 | .TLSv10 | InsecureTLS.swift:40:3:40:3 | [post] config | This TLS configuration is insecure. |


### PR DESCRIPTION
This PR adds synthetic return nodes for flow that returns from methods via a parameter. For example, in

```csharp
class C
{
    public string Field;
}

public void TaintField(C c) // (1)
{
    c.Field = "taint"; // (2)
}

void M(C c)
{
    c.TaintField(); // (3)
    Sink(c.Field);
}
```

we would previously have a direct flow step from `[post] c` at (2) to `[post] c` at (3), whereas now we first have a step from `[post] c` at (2) to `c [Return]` at (1), and then from `c [Return]` at (1) to `[post] c` at (3).

The motivation for adding the extra node is two-fold: Firstly, it may help with generating fewer `subpaths`, and secondly it will be easier to follow flow path explanations (especially when the parameter write happens in a large method).