### PR TITLE
C++: Improve UseOfStringAfterLifetimeEnds doc.

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-416/UseOfStringAfterLifetimeEnds.qhelp
+++ b/cpp/ql/src/Security/CWE/CWE-416/UseOfStringAfterLifetimeEnds.qhelp
@@ -9,10 +9,10 @@ When the <code>std::string</code> object is destroyed, the pointer returned by <
 longer valid. If the pointer is used after the <code>std::string</code> object is destroyed, then the behavior is undefined.
 </p>
 
-<p>Typically this problem occurs when a <code>std::string</code> is returned by a function call (or overloaded operator)
+<p>Typically, this problem occurs when a <code>std::string</code> is returned by a function call (or overloaded operator)
 by value, and the result is not immediately stored in a variable by value or reference in a way that extends the lifetime of
-the temporary object. The resulting temporary <code>std::string</code> object is destroyed at the end of the expression
-statement it is contained in, along with any memory returned by a call to <code>c_str</code>.
+the temporary object. The resulting temporary <code>std::string</code> object is destroyed at the end of the containing expression
+statement, along with any memory returned by a call to <code>c_str</code>.
 </p>
 </overview>
 

--- a/cpp/ql/src/Security/CWE/CWE-416/UseOfStringAfterLifetimeEnds.qhelp
+++ b/cpp/ql/src/Security/CWE/CWE-416/UseOfStringAfterLifetimeEnds.qhelp
@@ -10,9 +10,9 @@ longer valid. If the pointer is used after the <code>std::string</code> object i
 </p>
 
 <p>Typically this problem occurs when a <code>std::string</code> is returned by a function call (or overloaded operator)
-by value, and the result is not immediately stored in a variable by value (or <code>const</code> reference). The resulting
-temporary <code>std::string</code> object is destroyed at the end of the expression statement it is contained in, along
-with any memory returned by a call to <code>c_str</code>.
+by value, and the result is not immediately stored in a variable by value or reference in a way that extends the lifetime of
+the temporary object. The resulting temporary <code>std::string</code> object is destroyed at the end of the expression
+statement it is contained in, along with any memory returned by a call to <code>c_str</code>.
 </p>
 </overview>
 
@@ -46,6 +46,7 @@ points to valid memory.
 
 <li><a href="https://wiki.sei.cmu.edu/confluence/display/cplusplus/MEM50-CPP.+Do+not+access+freed+memory">MEM50-CPP. Do not access freed memory</a>.</li>
 <li>Microsoft Learn: <a href="https://learn.microsoft.com/en-us/cpp/cpp/temporary-objects?view=msvc-170">Temporary objects</a>.</li>
+<li>cppreference.com: <a href="https://en.cppreference.com/w/cpp/language/reference_initialization#Lifetime_of_a_temporary">Lifetime of a temporary</a>.</li>
 
 </references>
 </qhelp>

--- a/cpp/ql/src/Security/CWE/CWE-416/UseOfStringAfterLifetimeEnds.qhelp
+++ b/cpp/ql/src/Security/CWE/CWE-416/UseOfStringAfterLifetimeEnds.qhelp
@@ -8,6 +8,12 @@
 When the <code>std::string</code> object is destroyed, the pointer returned by <code>c_str</code> is no
 longer valid. If the pointer is used after the <code>std::string</code> object is destroyed, then the behavior is undefined.
 </p>
+
+<p>Typically this problem occurs when a <code>std::string</code> is returned by a function call (or overloaded operator)
+by value, and the result is not immediately stored in a variable by value (or <code>const</code> reference). The resulting
+temporary <code>std::string</code> object is destroyed at the end of the expression statement it is contained in, along
+with any memory returned by a call to <code>c_str</code>.
+</p>
 </overview>
 
 <recommendation>
@@ -39,6 +45,7 @@ points to valid memory.
 <references>
 
 <li><a href="https://wiki.sei.cmu.edu/confluence/display/cplusplus/MEM50-CPP.+Do+not+access+freed+memory">MEM50-CPP. Do not access freed memory</a>.</li>
+<li>Microsoft Learn: <a href="https://learn.microsoft.com/en-us/cpp/cpp/temporary-objects?view=msvc-170">Temporary objects</a>.</li>
 
 </references>
 </qhelp>

--- a/cpp/ql/src/Security/CWE/CWE-416/UseOfStringAfterLifetimeEnds.ql
+++ b/cpp/ql/src/Security/CWE/CWE-416/UseOfStringAfterLifetimeEnds.ql
@@ -23,4 +23,4 @@ where
   (c.getTarget() instanceof StdStringCStr or c.getTarget() instanceof StdStringData) and
   isTemporary(c.getQualifier().getFullyConverted())
 select c,
-  "The underlying string object is destroyed after the call to '" + c.getTarget() + "' returns."
+  "The underlying temporary string object is destroyed after the call to '" + c.getTarget() + "' returns."

--- a/cpp/ql/src/Security/CWE/CWE-416/UseOfStringAfterLifetimeEnds.ql
+++ b/cpp/ql/src/Security/CWE/CWE-416/UseOfStringAfterLifetimeEnds.ql
@@ -23,4 +23,5 @@ where
   (c.getTarget() instanceof StdStringCStr or c.getTarget() instanceof StdStringData) and
   isTemporary(c.getQualifier().getFullyConverted())
 select c,
-  "The underlying temporary string object is destroyed after the call to '" + c.getTarget() + "' returns."
+  "The underlying temporary string object is destroyed after the call to '" + c.getTarget() +
+    "' returns."

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/UseOfStringAfterLifetimeEnds/UseOfStringAfterLifetimeEnds.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/UseOfStringAfterLifetimeEnds/UseOfStringAfterLifetimeEnds.expected
@@ -1,13 +1,13 @@
-| test.cpp:165:34:165:38 | call to c_str | The underlying string object is destroyed after the call to 'c_str' returns. |
-| test.cpp:166:39:166:43 | call to c_str | The underlying string object is destroyed after the call to 'c_str' returns. |
-| test.cpp:167:44:167:48 | call to c_str | The underlying string object is destroyed after the call to 'c_str' returns. |
-| test.cpp:169:29:169:33 | call to c_str | The underlying string object is destroyed after the call to 'c_str' returns. |
-| test.cpp:178:37:178:41 | call to c_str | The underlying string object is destroyed after the call to 'c_str' returns. |
-| test.cpp:181:39:181:43 | call to c_str | The underlying string object is destroyed after the call to 'c_str' returns. |
-| test.cpp:183:37:183:41 | call to c_str | The underlying string object is destroyed after the call to 'c_str' returns. |
-| test.cpp:187:34:187:37 | call to data | The underlying string object is destroyed after the call to 'data' returns. |
-| test.cpp:188:39:188:42 | call to data | The underlying string object is destroyed after the call to 'data' returns. |
-| test.cpp:189:44:189:47 | call to data | The underlying string object is destroyed after the call to 'data' returns. |
-| test.cpp:191:29:191:32 | call to data | The underlying string object is destroyed after the call to 'data' returns. |
-| test.cpp:193:47:193:51 | call to c_str | The underlying string object is destroyed after the call to 'c_str' returns. |
-| test.cpp:195:31:195:35 | call to c_str | The underlying string object is destroyed after the call to 'c_str' returns. |
+| test.cpp:165:34:165:38 | call to c_str | The underlying temporary string object is destroyed after the call to 'c_str' returns. |
+| test.cpp:166:39:166:43 | call to c_str | The underlying temporary string object is destroyed after the call to 'c_str' returns. |
+| test.cpp:167:44:167:48 | call to c_str | The underlying temporary string object is destroyed after the call to 'c_str' returns. |
+| test.cpp:169:29:169:33 | call to c_str | The underlying temporary string object is destroyed after the call to 'c_str' returns. |
+| test.cpp:178:37:178:41 | call to c_str | The underlying temporary string object is destroyed after the call to 'c_str' returns. |
+| test.cpp:181:39:181:43 | call to c_str | The underlying temporary string object is destroyed after the call to 'c_str' returns. |
+| test.cpp:183:37:183:41 | call to c_str | The underlying temporary string object is destroyed after the call to 'c_str' returns. |
+| test.cpp:187:34:187:37 | call to data | The underlying temporary string object is destroyed after the call to 'data' returns. |
+| test.cpp:188:39:188:42 | call to data | The underlying temporary string object is destroyed after the call to 'data' returns. |
+| test.cpp:189:44:189:47 | call to data | The underlying temporary string object is destroyed after the call to 'data' returns. |
+| test.cpp:191:29:191:32 | call to data | The underlying temporary string object is destroyed after the call to 'data' returns. |
+| test.cpp:193:47:193:51 | call to c_str | The underlying temporary string object is destroyed after the call to 'c_str' returns. |
+| test.cpp:195:31:195:35 | call to c_str | The underlying temporary string object is destroyed after the call to 'c_str' returns. |


### PR DESCRIPTION
Improve `cpp/use-of-string-after-lifetime-ends` `.qhelp`, references and alert message.  The aim is to be more helpful for users who are not very familiar with temporary objects and lifetime issues that can result.

@MathiasVP please check for technical inaccuracies.

Docs team, please make any suggestions you may have for readability etc.