### PR TITLE
C++: Add test case for reassignment to UseAfterFree.ql.

### DIFF
--- a/cpp/ql/test/query-tests/Critical/MemoryFreed/MemoryFreed.expected
+++ b/cpp/ql/test/query-tests/Critical/MemoryFreed/MemoryFreed.expected
@@ -26,6 +26,8 @@
 | test.cpp:128:15:128:16 | v4 |
 | test.cpp:185:10:185:12 | cpy |
 | test.cpp:199:10:199:12 | cpy |
+| test.cpp:208:7:208:7 | a |
+| test.cpp:214:7:214:7 | a |
 | test_free.cpp:11:10:11:10 | a |
 | test_free.cpp:14:10:14:10 | a |
 | test_free.cpp:16:10:16:10 | a |

--- a/cpp/ql/test/query-tests/Critical/MemoryFreed/UseAfterFree.expected
+++ b/cpp/ql/test/query-tests/Critical/MemoryFreed/UseAfterFree.expected
@@ -1,4 +1,6 @@
 edges
+| test.cpp:208:7:208:7 | pointer to free output argument | test.cpp:209:2:209:2 | a | provenance |  |
+| test.cpp:214:7:214:7 | pointer to free output argument | test.cpp:215:2:215:2 | a | provenance |  |
 | test_free.cpp:11:10:11:10 | pointer to free output argument | test_free.cpp:12:5:12:5 | a | provenance |  |
 | test_free.cpp:11:10:11:10 | pointer to free output argument | test_free.cpp:13:5:13:6 | * ... | provenance |  |
 | test_free.cpp:42:27:42:27 | pointer to free output argument | test_free.cpp:45:5:45:5 | a | provenance |  |
@@ -31,6 +33,10 @@ edges
 | test_free.cpp:322:12:322:12 | pointer to operator delete output argument | test_free.cpp:324:5:324:6 | * ... | provenance |  |
 | test_free.cpp:331:12:331:12 | pointer to operator delete output argument | test_free.cpp:332:5:332:6 | * ... | provenance |  |
 nodes
+| test.cpp:208:7:208:7 | pointer to free output argument | semmle.label | pointer to free output argument |
+| test.cpp:209:2:209:2 | a | semmle.label | a |
+| test.cpp:214:7:214:7 | pointer to free output argument | semmle.label | pointer to free output argument |
+| test.cpp:215:2:215:2 | a | semmle.label | a |
 | test_free.cpp:11:10:11:10 | pointer to free output argument | semmle.label | pointer to free output argument |
 | test_free.cpp:12:5:12:5 | a | semmle.label | a |
 | test_free.cpp:13:5:13:6 | * ... | semmle.label | * ... |
@@ -82,6 +88,8 @@ nodes
 | test_free.cpp:332:5:332:6 | * ... | semmle.label | * ... |
 subpaths
 #select
+| test.cpp:209:2:209:2 | a | test.cpp:208:7:208:7 | pointer to free output argument | test.cpp:209:2:209:2 | a | Memory may have been previously freed by $@. | test.cpp:208:2:208:5 | call to free | call to free |
+| test.cpp:215:2:215:2 | a | test.cpp:214:7:214:7 | pointer to free output argument | test.cpp:215:2:215:2 | a | Memory may have been previously freed by $@. | test.cpp:214:2:214:5 | call to free | call to free |
 | test_free.cpp:12:5:12:5 | a | test_free.cpp:11:10:11:10 | pointer to free output argument | test_free.cpp:12:5:12:5 | a | Memory may have been previously freed by $@. | test_free.cpp:11:5:11:8 | call to free | call to free |
 | test_free.cpp:13:5:13:6 | * ... | test_free.cpp:11:10:11:10 | pointer to free output argument | test_free.cpp:13:5:13:6 | * ... | Memory may have been previously freed by $@. | test_free.cpp:11:5:11:8 | call to free | call to free |
 | test_free.cpp:45:5:45:5 | a | test_free.cpp:42:27:42:27 | pointer to free output argument | test_free.cpp:45:5:45:5 | a | Memory may have been previously freed by $@. | test_free.cpp:42:22:42:25 | call to free | call to free |

--- a/cpp/ql/test/query-tests/Critical/MemoryFreed/test.cpp
+++ b/cpp/ql/test/query-tests/Critical/MemoryFreed/test.cpp
@@ -114,7 +114,7 @@ int main()
 		mc2->method2();
 		delete mc2;
 	}
-	
+
 	{
 		void *v1 = malloc(100);
 		int *i2 = (int *)malloc(100);
@@ -197,4 +197,20 @@ void test_strndupa_dealloc() {
 	char msg[] = "OctoCat";
 	char *cpy = strndupa(msg, 4);
     free(cpy); // BAD [NOT DETECTED]
+}
+
+// ---
+
+void test_reassignment() {
+	char *a = (char *)malloc(128);
+	char *b = (char *)malloc(128);
+
+	free(a);
+	a[0] = 0; // BAD
+
+	a = b;
+	a[0] = 0; // GOOD
+
+	free(a);
+	a[0] = 0; // BAD
 }


### PR DESCRIPTION
Adds a test case I wrote while reviewing a suspected FP for `UseAfterFree.ql`.  I could not reproduce the issue.