### PR TITLE
C++: Clean up `IRVariable`s using final aliases

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/IRVariable.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/IRVariable.qll
@@ -17,18 +17,11 @@ private import Imports::IRType
  * The variable may be a user-declared variable (`IRUserVariable`) or a temporary variable generated
  * by the AST-to-IR translation (`IRTempVariable`).
  */
-class IRVariable extends TIRVariable {
+abstract private class AbstractIRVariable extends TIRVariable {
   Language::Declaration func;
 
-  IRVariable() {
-    this = TIRUserVariable(_, _, func) or
-    this = TIRTempVariable(func, _, _, _) or
-    this = TIRStringLiteral(func, _, _, _) or
-    this = TIRDynamicInitializationFlag(func, _, _)
-  }
-
   /** Gets a textual representation of this element. */
-  string toString() { none() }
+  abstract string toString();
 
   /**
    * Holds if this variable's value cannot be changed within a function. Currently used for string
@@ -49,13 +42,13 @@ class IRVariable extends TIRVariable {
   /**
    * Gets the type of the variable.
    */
-  Language::LanguageType getLanguageType() { none() }
+  abstract Language::LanguageType getLanguageType();
 
   /**
    * Gets the AST node that declared this variable, or that introduced this
    * variable as part of the AST-to-IR translation.
    */
-  Language::AST getAst() { none() }
+  abstract Language::AST getAst();
 
   /** DEPRECATED: Alias for getAst */
   deprecated Language::AST getAST() { result = this.getAst() }
@@ -64,7 +57,7 @@ class IRVariable extends TIRVariable {
    * Gets an identifier string for the variable. This identifier is unique
    * within the function.
    */
-  string getUniqueId() { none() }
+  abstract string getUniqueId();
 
   /**
    * Gets the source location of this variable.
@@ -74,18 +67,28 @@ class IRVariable extends TIRVariable {
   /**
    * Gets the IR for the function that references this variable.
    */
-  final IRFunction getEnclosingIRFunction() { result.getFunction() = func }
+  final IRFunction getEnclosingIRFunction() { result.getFunction() = this.getEnclosingFunction() }
 
   /**
    * Gets the function that references this variable.
    */
   final Language::Declaration getEnclosingFunction() { result = func }
+
+  IRBlock getDeclarationBlock() { none() }
 }
+
+/**
+ * A variable referenced by the IR for a function.
+ *
+ * The variable may be a user-declared variable (`IRUserVariable`) or a temporary variable generated
+ * by the AST-to-IR translation (`IRTempVariable`).
+ */
+final class IRVariable = AbstractIRVariable;
 
 /**
  * A user-declared variable referenced by the IR for a function.
  */
-class IRUserVariable extends IRVariable, TIRUserVariable {
+class IRUserVariable extends AbstractIRVariable, TIRUserVariable {
   Language::Variable var;
   Language::LanguageType type;
 
@@ -114,26 +117,29 @@ class IRUserVariable extends IRVariable, TIRUserVariable {
  * A variable (user-declared or temporary) that is allocated on the stack. This includes all
  * parameters, non-static local variables, and temporary variables.
  */
-class IRAutomaticVariable extends IRVariable {
-  IRAutomaticVariable() {
-    exists(Language::Variable var |
-      this = TIRUserVariable(var, _, func) and
-      Language::isVariableAutomatic(var)
-    )
-    or
-    this = TIRTempVariable(func, _, _, _)
-  }
+abstract private class AbstractIRAutomaticVariable extends AbstractIRVariable { }
+
+/**
+ * A variable (user-declared or temporary) that is allocated on the stack. This includes all
+ * parameters, non-static local variables, and temporary variables.
+ */
+final class IRAutomaticVariable = AbstractIRAutomaticVariable;
+
+/**
+ * A user-declared variable that is allocated on the stack. This includes all parameters and
+ * non-static local variables.
+ */
+private class AbstractIRAutomaticUserVariable extends IRUserVariable, AbstractIRAutomaticVariable {
+  override Language::AutomaticVariable var;
+
+  final override Language::AutomaticVariable getVariable() { result = var }
 }
 
 /**
  * A user-declared variable that is allocated on the stack. This includes all parameters and
  * non-static local variables.
  */
-class IRAutomaticUserVariable extends IRUserVariable, IRAutomaticVariable {
-  override Language::AutomaticVariable var;
-
-  final override Language::AutomaticVariable getVariable() { result = var }
-}
+final class IRAutomaticUserVariable = AbstractIRAutomaticUserVariable;
 
 /**
  * A user-declared variable that is not allocated on the stack. This includes all global variables,
@@ -151,15 +157,9 @@ class IRStaticUserVariable extends IRUserVariable {
  * A variable that is not user-declared. This includes temporary variables generated as part of IR
  * construction, as well as string literals.
  */
-class IRGeneratedVariable extends IRVariable {
+abstract private class AbstractIRGeneratedVariable extends AbstractIRVariable {
   Language::AST ast;
   Language::LanguageType type;
-
-  IRGeneratedVariable() {
-    this = TIRTempVariable(func, ast, _, type) or
-    this = TIRStringLiteral(func, ast, type, _) or
-    this = TIRDynamicInitializationFlag(func, ast, type)
-  }
 
   final override Language::LanguageType getLanguageType() { result = type }
 
@@ -197,11 +197,19 @@ class IRGeneratedVariable extends IRVariable {
 }
 
 /**
+ * A variable that is not user-declared. This includes temporary variables generated as part of IR
+ * construction, as well as string literals.
+ */
+final class IRGeneratedVariable = AbstractIRGeneratedVariable;
+
+/**
  * A temporary variable introduced by IR construction. The most common examples are the variable
  * generated to hold the return value of a function, or the variable generated to hold the result of
  * a condition operator (`a ? b : c`).
  */
-class IRTempVariable extends IRGeneratedVariable, IRAutomaticVariable, TIRTempVariable {
+class IRTempVariable extends AbstractIRGeneratedVariable, AbstractIRAutomaticVariable,
+  TIRTempVariable
+{
   TempVariableTag tag;
 
   IRTempVariable() { this = TIRTempVariable(func, ast, tag, type) }
@@ -241,7 +249,7 @@ class IRThrowVariable extends IRTempVariable {
  * A temporary variable generated to hold the contents of all arguments passed to the `...` of a
  * function that accepts a variable number of arguments.
  */
-class IREllipsisVariable extends IRTempVariable, IRParameter {
+class IREllipsisVariable extends IRTempVariable, AbstractIRParameter {
   IREllipsisVariable() { tag = EllipsisTempVar() }
 
   final override string toString() { result = "#ellipsis" }
@@ -252,7 +260,7 @@ class IREllipsisVariable extends IRTempVariable, IRParameter {
 /**
  * A temporary variable generated to hold the `this` pointer.
  */
-class IRThisVariable extends IRTempVariable, IRParameter {
+class IRThisVariable extends IRTempVariable, AbstractIRParameter {
   IRThisVariable() { tag = ThisTempVar() }
 
   final override string toString() { result = "#this" }
@@ -264,7 +272,7 @@ class IRThisVariable extends IRTempVariable, IRParameter {
  * A variable generated to represent the contents of a string literal. This variable acts much like
  * a read-only global variable.
  */
-class IRStringLiteral extends IRGeneratedVariable, TIRStringLiteral {
+class IRStringLiteral extends AbstractIRGeneratedVariable, TIRStringLiteral {
   Language::StringLiteral literal;
 
   IRStringLiteral() { this = TIRStringLiteral(func, ast, type, literal) }
@@ -288,7 +296,7 @@ class IRStringLiteral extends IRGeneratedVariable, TIRStringLiteral {
  * used to model the runtime initialization of static local variables in C++, as well as static
  * fields in C#.
  */
-class IRDynamicInitializationFlag extends IRGeneratedVariable, TIRDynamicInitializationFlag {
+class IRDynamicInitializationFlag extends AbstractIRGeneratedVariable, TIRDynamicInitializationFlag {
   Language::Variable var;
 
   IRDynamicInitializationFlag() {
@@ -314,15 +322,7 @@ class IRDynamicInitializationFlag extends IRGeneratedVariable, TIRDynamicInitial
  * An IR variable which acts like a function parameter, including positional parameters and the
  * temporary variables generated for `this` and ellipsis parameters.
  */
-class IRParameter extends IRAutomaticVariable {
-  IRParameter() {
-    this.(IRAutomaticUserVariable).getVariable() instanceof Language::Parameter
-    or
-    this = TIRTempVariable(_, _, ThisTempVar(), _)
-    or
-    this = TIRTempVariable(_, _, EllipsisTempVar(), _)
-  }
-
+abstract private class AbstractIRParameter extends AbstractIRAutomaticVariable {
   /**
    * Gets the zero-based index of this parameter. The `this` parameter has index -1.
    */
@@ -330,8 +330,16 @@ class IRParameter extends IRAutomaticVariable {
 }
 
 /**
+ * An IR variable which acts like a function parameter, including positional parameters and the
+ * temporary variables generated for `this` and ellipsis parameters.
+ */
+final class IRParameter = AbstractIRParameter;
+
+/**
  * An IR variable representing a positional parameter.
  */
-class IRPositionalParameter extends IRParameter, IRAutomaticUserVariable {
+class IRPositionalParameter extends AbstractIRParameter, AbstractIRAutomaticUserVariable {
+  IRPositionalParameter() { this.getVariable() instanceof Language::Parameter }
+
   final override int getIndex() { result = this.getVariable().(Language::Parameter).getIndex() }
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/IRVariable.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/IRVariable.qll
@@ -73,8 +73,6 @@ abstract private class AbstractIRVariable extends TIRVariable {
    * Gets the function that references this variable.
    */
   final Language::Declaration getEnclosingFunction() { result = func }
-
-  IRBlock getDeclarationBlock() { none() }
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/IRVariable.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/IRVariable.qll
@@ -17,18 +17,11 @@ private import Imports::IRType
  * The variable may be a user-declared variable (`IRUserVariable`) or a temporary variable generated
  * by the AST-to-IR translation (`IRTempVariable`).
  */
-class IRVariable extends TIRVariable {
+abstract private class AbstractIRVariable extends TIRVariable {
   Language::Declaration func;
 
-  IRVariable() {
-    this = TIRUserVariable(_, _, func) or
-    this = TIRTempVariable(func, _, _, _) or
-    this = TIRStringLiteral(func, _, _, _) or
-    this = TIRDynamicInitializationFlag(func, _, _)
-  }
-
   /** Gets a textual representation of this element. */
-  string toString() { none() }
+  abstract string toString();
 
   /**
    * Holds if this variable's value cannot be changed within a function. Currently used for string
@@ -49,13 +42,13 @@ class IRVariable extends TIRVariable {
   /**
    * Gets the type of the variable.
    */
-  Language::LanguageType getLanguageType() { none() }
+  abstract Language::LanguageType getLanguageType();
 
   /**
    * Gets the AST node that declared this variable, or that introduced this
    * variable as part of the AST-to-IR translation.
    */
-  Language::AST getAst() { none() }
+  abstract Language::AST getAst();
 
   /** DEPRECATED: Alias for getAst */
   deprecated Language::AST getAST() { result = this.getAst() }
@@ -64,7 +57,7 @@ class IRVariable extends TIRVariable {
    * Gets an identifier string for the variable. This identifier is unique
    * within the function.
    */
-  string getUniqueId() { none() }
+  abstract string getUniqueId();
 
   /**
    * Gets the source location of this variable.
@@ -74,18 +67,28 @@ class IRVariable extends TIRVariable {
   /**
    * Gets the IR for the function that references this variable.
    */
-  final IRFunction getEnclosingIRFunction() { result.getFunction() = func }
+  final IRFunction getEnclosingIRFunction() { result.getFunction() = this.getEnclosingFunction() }
 
   /**
    * Gets the function that references this variable.
    */
   final Language::Declaration getEnclosingFunction() { result = func }
+
+  IRBlock getDeclarationBlock() { none() }
 }
+
+/**
+ * A variable referenced by the IR for a function.
+ *
+ * The variable may be a user-declared variable (`IRUserVariable`) or a temporary variable generated
+ * by the AST-to-IR translation (`IRTempVariable`).
+ */
+final class IRVariable = AbstractIRVariable;
 
 /**
  * A user-declared variable referenced by the IR for a function.
  */
-class IRUserVariable extends IRVariable, TIRUserVariable {
+class IRUserVariable extends AbstractIRVariable, TIRUserVariable {
   Language::Variable var;
   Language::LanguageType type;
 
@@ -114,26 +117,29 @@ class IRUserVariable extends IRVariable, TIRUserVariable {
  * A variable (user-declared or temporary) that is allocated on the stack. This includes all
  * parameters, non-static local variables, and temporary variables.
  */
-class IRAutomaticVariable extends IRVariable {
-  IRAutomaticVariable() {
-    exists(Language::Variable var |
-      this = TIRUserVariable(var, _, func) and
-      Language::isVariableAutomatic(var)
-    )
-    or
-    this = TIRTempVariable(func, _, _, _)
-  }
+abstract private class AbstractIRAutomaticVariable extends AbstractIRVariable { }
+
+/**
+ * A variable (user-declared or temporary) that is allocated on the stack. This includes all
+ * parameters, non-static local variables, and temporary variables.
+ */
+final class IRAutomaticVariable = AbstractIRAutomaticVariable;
+
+/**
+ * A user-declared variable that is allocated on the stack. This includes all parameters and
+ * non-static local variables.
+ */
+private class AbstractIRAutomaticUserVariable extends IRUserVariable, AbstractIRAutomaticVariable {
+  override Language::AutomaticVariable var;
+
+  final override Language::AutomaticVariable getVariable() { result = var }
 }
 
 /**
  * A user-declared variable that is allocated on the stack. This includes all parameters and
  * non-static local variables.
  */
-class IRAutomaticUserVariable extends IRUserVariable, IRAutomaticVariable {
-  override Language::AutomaticVariable var;
-
-  final override Language::AutomaticVariable getVariable() { result = var }
-}
+final class IRAutomaticUserVariable = AbstractIRAutomaticUserVariable;
 
 /**
  * A user-declared variable that is not allocated on the stack. This includes all global variables,
@@ -151,15 +157,9 @@ class IRStaticUserVariable extends IRUserVariable {
  * A variable that is not user-declared. This includes temporary variables generated as part of IR
  * construction, as well as string literals.
  */
-class IRGeneratedVariable extends IRVariable {
+abstract private class AbstractIRGeneratedVariable extends AbstractIRVariable {
   Language::AST ast;
   Language::LanguageType type;
-
-  IRGeneratedVariable() {
-    this = TIRTempVariable(func, ast, _, type) or
-    this = TIRStringLiteral(func, ast, type, _) or
-    this = TIRDynamicInitializationFlag(func, ast, type)
-  }
 
   final override Language::LanguageType getLanguageType() { result = type }
 
@@ -197,11 +197,19 @@ class IRGeneratedVariable extends IRVariable {
 }
 
 /**
+ * A variable that is not user-declared. This includes temporary variables generated as part of IR
+ * construction, as well as string literals.
+ */
+final class IRGeneratedVariable = AbstractIRGeneratedVariable;
+
+/**
  * A temporary variable introduced by IR construction. The most common examples are the variable
  * generated to hold the return value of a function, or the variable generated to hold the result of
  * a condition operator (`a ? b : c`).
  */
-class IRTempVariable extends IRGeneratedVariable, IRAutomaticVariable, TIRTempVariable {
+class IRTempVariable extends AbstractIRGeneratedVariable, AbstractIRAutomaticVariable,
+  TIRTempVariable
+{
   TempVariableTag tag;
 
   IRTempVariable() { this = TIRTempVariable(func, ast, tag, type) }
@@ -241,7 +249,7 @@ class IRThrowVariable extends IRTempVariable {
  * A temporary variable generated to hold the contents of all arguments passed to the `...` of a
  * function that accepts a variable number of arguments.
  */
-class IREllipsisVariable extends IRTempVariable, IRParameter {
+class IREllipsisVariable extends IRTempVariable, AbstractIRParameter {
   IREllipsisVariable() { tag = EllipsisTempVar() }
 
   final override string toString() { result = "#ellipsis" }
@@ -252,7 +260,7 @@ class IREllipsisVariable extends IRTempVariable, IRParameter {
 /**
  * A temporary variable generated to hold the `this` pointer.
  */
-class IRThisVariable extends IRTempVariable, IRParameter {
+class IRThisVariable extends IRTempVariable, AbstractIRParameter {
   IRThisVariable() { tag = ThisTempVar() }
 
   final override string toString() { result = "#this" }
@@ -264,7 +272,7 @@ class IRThisVariable extends IRTempVariable, IRParameter {
  * A variable generated to represent the contents of a string literal. This variable acts much like
  * a read-only global variable.
  */
-class IRStringLiteral extends IRGeneratedVariable, TIRStringLiteral {
+class IRStringLiteral extends AbstractIRGeneratedVariable, TIRStringLiteral {
   Language::StringLiteral literal;
 
   IRStringLiteral() { this = TIRStringLiteral(func, ast, type, literal) }
@@ -288,7 +296,7 @@ class IRStringLiteral extends IRGeneratedVariable, TIRStringLiteral {
  * used to model the runtime initialization of static local variables in C++, as well as static
  * fields in C#.
  */
-class IRDynamicInitializationFlag extends IRGeneratedVariable, TIRDynamicInitializationFlag {
+class IRDynamicInitializationFlag extends AbstractIRGeneratedVariable, TIRDynamicInitializationFlag {
   Language::Variable var;
 
   IRDynamicInitializationFlag() {
@@ -314,15 +322,7 @@ class IRDynamicInitializationFlag extends IRGeneratedVariable, TIRDynamicInitial
  * An IR variable which acts like a function parameter, including positional parameters and the
  * temporary variables generated for `this` and ellipsis parameters.
  */
-class IRParameter extends IRAutomaticVariable {
-  IRParameter() {
-    this.(IRAutomaticUserVariable).getVariable() instanceof Language::Parameter
-    or
-    this = TIRTempVariable(_, _, ThisTempVar(), _)
-    or
-    this = TIRTempVariable(_, _, EllipsisTempVar(), _)
-  }
-
+abstract private class AbstractIRParameter extends AbstractIRAutomaticVariable {
   /**
    * Gets the zero-based index of this parameter. The `this` parameter has index -1.
    */
@@ -330,8 +330,16 @@ class IRParameter extends IRAutomaticVariable {
 }
 
 /**
+ * An IR variable which acts like a function parameter, including positional parameters and the
+ * temporary variables generated for `this` and ellipsis parameters.
+ */
+final class IRParameter = AbstractIRParameter;
+
+/**
  * An IR variable representing a positional parameter.
  */
-class IRPositionalParameter extends IRParameter, IRAutomaticUserVariable {
+class IRPositionalParameter extends AbstractIRParameter, AbstractIRAutomaticUserVariable {
+  IRPositionalParameter() { this.getVariable() instanceof Language::Parameter }
+
   final override int getIndex() { result = this.getVariable().(Language::Parameter).getIndex() }
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/IRVariable.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/IRVariable.qll
@@ -73,8 +73,6 @@ abstract private class AbstractIRVariable extends TIRVariable {
    * Gets the function that references this variable.
    */
   final Language::Declaration getEnclosingFunction() { result = func }
-
-  IRBlock getDeclarationBlock() { none() }
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/IRVariable.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/IRVariable.qll
@@ -17,18 +17,11 @@ private import Imports::IRType
  * The variable may be a user-declared variable (`IRUserVariable`) or a temporary variable generated
  * by the AST-to-IR translation (`IRTempVariable`).
  */
-class IRVariable extends TIRVariable {
+abstract private class AbstractIRVariable extends TIRVariable {
   Language::Declaration func;
 
-  IRVariable() {
-    this = TIRUserVariable(_, _, func) or
-    this = TIRTempVariable(func, _, _, _) or
-    this = TIRStringLiteral(func, _, _, _) or
-    this = TIRDynamicInitializationFlag(func, _, _)
-  }
-
   /** Gets a textual representation of this element. */
-  string toString() { none() }
+  abstract string toString();
 
   /**
    * Holds if this variable's value cannot be changed within a function. Currently used for string
@@ -49,13 +42,13 @@ class IRVariable extends TIRVariable {
   /**
    * Gets the type of the variable.
    */
-  Language::LanguageType getLanguageType() { none() }
+  abstract Language::LanguageType getLanguageType();
 
   /**
    * Gets the AST node that declared this variable, or that introduced this
    * variable as part of the AST-to-IR translation.
    */
-  Language::AST getAst() { none() }
+  abstract Language::AST getAst();
 
   /** DEPRECATED: Alias for getAst */
   deprecated Language::AST getAST() { result = this.getAst() }
@@ -64,7 +57,7 @@ class IRVariable extends TIRVariable {
    * Gets an identifier string for the variable. This identifier is unique
    * within the function.
    */
-  string getUniqueId() { none() }
+  abstract string getUniqueId();
 
   /**
    * Gets the source location of this variable.
@@ -74,18 +67,28 @@ class IRVariable extends TIRVariable {
   /**
    * Gets the IR for the function that references this variable.
    */
-  final IRFunction getEnclosingIRFunction() { result.getFunction() = func }
+  final IRFunction getEnclosingIRFunction() { result.getFunction() = this.getEnclosingFunction() }
 
   /**
    * Gets the function that references this variable.
    */
   final Language::Declaration getEnclosingFunction() { result = func }
+
+  IRBlock getDeclarationBlock() { none() }
 }
+
+/**
+ * A variable referenced by the IR for a function.
+ *
+ * The variable may be a user-declared variable (`IRUserVariable`) or a temporary variable generated
+ * by the AST-to-IR translation (`IRTempVariable`).
+ */
+final class IRVariable = AbstractIRVariable;
 
 /**
  * A user-declared variable referenced by the IR for a function.
  */
-class IRUserVariable extends IRVariable, TIRUserVariable {
+class IRUserVariable extends AbstractIRVariable, TIRUserVariable {
   Language::Variable var;
   Language::LanguageType type;
 
@@ -114,26 +117,29 @@ class IRUserVariable extends IRVariable, TIRUserVariable {
  * A variable (user-declared or temporary) that is allocated on the stack. This includes all
  * parameters, non-static local variables, and temporary variables.
  */
-class IRAutomaticVariable extends IRVariable {
-  IRAutomaticVariable() {
-    exists(Language::Variable var |
-      this = TIRUserVariable(var, _, func) and
-      Language::isVariableAutomatic(var)
-    )
-    or
-    this = TIRTempVariable(func, _, _, _)
-  }
+abstract private class AbstractIRAutomaticVariable extends AbstractIRVariable { }
+
+/**
+ * A variable (user-declared or temporary) that is allocated on the stack. This includes all
+ * parameters, non-static local variables, and temporary variables.
+ */
+final class IRAutomaticVariable = AbstractIRAutomaticVariable;
+
+/**
+ * A user-declared variable that is allocated on the stack. This includes all parameters and
+ * non-static local variables.
+ */
+private class AbstractIRAutomaticUserVariable extends IRUserVariable, AbstractIRAutomaticVariable {
+  override Language::AutomaticVariable var;
+
+  final override Language::AutomaticVariable getVariable() { result = var }
 }
 
 /**
  * A user-declared variable that is allocated on the stack. This includes all parameters and
  * non-static local variables.
  */
-class IRAutomaticUserVariable extends IRUserVariable, IRAutomaticVariable {
-  override Language::AutomaticVariable var;
-
-  final override Language::AutomaticVariable getVariable() { result = var }
-}
+final class IRAutomaticUserVariable = AbstractIRAutomaticUserVariable;
 
 /**
  * A user-declared variable that is not allocated on the stack. This includes all global variables,
@@ -151,15 +157,9 @@ class IRStaticUserVariable extends IRUserVariable {
  * A variable that is not user-declared. This includes temporary variables generated as part of IR
  * construction, as well as string literals.
  */
-class IRGeneratedVariable extends IRVariable {
+abstract private class AbstractIRGeneratedVariable extends AbstractIRVariable {
   Language::AST ast;
   Language::LanguageType type;
-
-  IRGeneratedVariable() {
-    this = TIRTempVariable(func, ast, _, type) or
-    this = TIRStringLiteral(func, ast, type, _) or
-    this = TIRDynamicInitializationFlag(func, ast, type)
-  }
 
   final override Language::LanguageType getLanguageType() { result = type }
 
@@ -197,11 +197,19 @@ class IRGeneratedVariable extends IRVariable {
 }
 
 /**
+ * A variable that is not user-declared. This includes temporary variables generated as part of IR
+ * construction, as well as string literals.
+ */
+final class IRGeneratedVariable = AbstractIRGeneratedVariable;
+
+/**
  * A temporary variable introduced by IR construction. The most common examples are the variable
  * generated to hold the return value of a function, or the variable generated to hold the result of
  * a condition operator (`a ? b : c`).
  */
-class IRTempVariable extends IRGeneratedVariable, IRAutomaticVariable, TIRTempVariable {
+class IRTempVariable extends AbstractIRGeneratedVariable, AbstractIRAutomaticVariable,
+  TIRTempVariable
+{
   TempVariableTag tag;
 
   IRTempVariable() { this = TIRTempVariable(func, ast, tag, type) }
@@ -241,7 +249,7 @@ class IRThrowVariable extends IRTempVariable {
  * A temporary variable generated to hold the contents of all arguments passed to the `...` of a
  * function that accepts a variable number of arguments.
  */
-class IREllipsisVariable extends IRTempVariable, IRParameter {
+class IREllipsisVariable extends IRTempVariable, AbstractIRParameter {
   IREllipsisVariable() { tag = EllipsisTempVar() }
 
   final override string toString() { result = "#ellipsis" }
@@ -252,7 +260,7 @@ class IREllipsisVariable extends IRTempVariable, IRParameter {
 /**
  * A temporary variable generated to hold the `this` pointer.
  */
-class IRThisVariable extends IRTempVariable, IRParameter {
+class IRThisVariable extends IRTempVariable, AbstractIRParameter {
   IRThisVariable() { tag = ThisTempVar() }
 
   final override string toString() { result = "#this" }
@@ -264,7 +272,7 @@ class IRThisVariable extends IRTempVariable, IRParameter {
  * A variable generated to represent the contents of a string literal. This variable acts much like
  * a read-only global variable.
  */
-class IRStringLiteral extends IRGeneratedVariable, TIRStringLiteral {
+class IRStringLiteral extends AbstractIRGeneratedVariable, TIRStringLiteral {
   Language::StringLiteral literal;
 
   IRStringLiteral() { this = TIRStringLiteral(func, ast, type, literal) }
@@ -288,7 +296,7 @@ class IRStringLiteral extends IRGeneratedVariable, TIRStringLiteral {
  * used to model the runtime initialization of static local variables in C++, as well as static
  * fields in C#.
  */
-class IRDynamicInitializationFlag extends IRGeneratedVariable, TIRDynamicInitializationFlag {
+class IRDynamicInitializationFlag extends AbstractIRGeneratedVariable, TIRDynamicInitializationFlag {
   Language::Variable var;
 
   IRDynamicInitializationFlag() {
@@ -314,15 +322,7 @@ class IRDynamicInitializationFlag extends IRGeneratedVariable, TIRDynamicInitial
  * An IR variable which acts like a function parameter, including positional parameters and the
  * temporary variables generated for `this` and ellipsis parameters.
  */
-class IRParameter extends IRAutomaticVariable {
-  IRParameter() {
-    this.(IRAutomaticUserVariable).getVariable() instanceof Language::Parameter
-    or
-    this = TIRTempVariable(_, _, ThisTempVar(), _)
-    or
-    this = TIRTempVariable(_, _, EllipsisTempVar(), _)
-  }
-
+abstract private class AbstractIRParameter extends AbstractIRAutomaticVariable {
   /**
    * Gets the zero-based index of this parameter. The `this` parameter has index -1.
    */
@@ -330,8 +330,16 @@ class IRParameter extends IRAutomaticVariable {
 }
 
 /**
+ * An IR variable which acts like a function parameter, including positional parameters and the
+ * temporary variables generated for `this` and ellipsis parameters.
+ */
+final class IRParameter = AbstractIRParameter;
+
+/**
  * An IR variable representing a positional parameter.
  */
-class IRPositionalParameter extends IRParameter, IRAutomaticUserVariable {
+class IRPositionalParameter extends AbstractIRParameter, AbstractIRAutomaticUserVariable {
+  IRPositionalParameter() { this.getVariable() instanceof Language::Parameter }
+
   final override int getIndex() { result = this.getVariable().(Language::Parameter).getIndex() }
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/IRVariable.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/IRVariable.qll
@@ -73,8 +73,6 @@ abstract private class AbstractIRVariable extends TIRVariable {
    * Gets the function that references this variable.
    */
   final Language::Declaration getEnclosingFunction() { result = func }
-
-  IRBlock getDeclarationBlock() { none() }
 }
 
 /**


### PR DESCRIPTION
This PR is just a simple refactoring of the `IRVariable` files that replaces explicit enumeration of subclasses in the base class with abstract classes.

In order to ensure no other code accidentally extends the new abstract classes they're kept private and final aliases are provided. This means code will continue to work exactly as before.