### PR TITLE
C++: Add `cpp/iterator-to-expired-container` FP

### DIFF
--- a/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/IteratorToExpiredContainer/IteratorToExpiredContainer.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/IteratorToExpiredContainer/IteratorToExpiredContainer.expected
@@ -4,3 +4,4 @@
 | test.cpp:702:27:702:27 | call to operator[] | This object is destroyed at the end of the full-expression. |
 | test.cpp:727:23:727:23 | call to operator[] | This object is destroyed at the end of the full-expression. |
 | test.cpp:735:23:735:23 | call to operator[] | This object is destroyed at the end of the full-expression. |
+| test.cpp:803:3:803:3 | pointer to ~vector output argument | This object is destroyed at the end of the full-expression. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/IteratorToExpiredContainer/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/IteratorToExpiredContainer/test.cpp
@@ -793,3 +793,12 @@ void test4() {
   // call can flow to `begin` through the back-edge and cause a strange FP.
   auto zero = A().size();
 }
+
+void test5(int i)
+{
+  while(i < 10) {
+    const auto& vvs = returnValue();
+    for(const auto& vs : vvs) { }
+    ++i;
+  } // GOOD [FALSE POSITIVE]
+}


### PR DESCRIPTION
This is a reduction of the class of FPs we saw once we merged a recent extractor change.