### PR TITLE
JS: Remove some FPs from the hardcoded-credentials query

### DIFF
--- a/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
@@ -1003,7 +1003,7 @@ module NodeJSLib {
       exists(ClientRequestLoginCallback callback | this = callback.getACall().getArgument(0))
     }
 
-    override string getCredentialsKind() { result = "Node.js http(s) client login username" }
+    override string getCredentialsKind() { result = "user name" }
   }
 
   /**
@@ -1014,7 +1014,7 @@ module NodeJSLib {
       exists(ClientRequestLoginCallback callback | this = callback.getACall().getArgument(1))
     }
 
-    override string getCredentialsKind() { result = "Node.js http(s) client login password" }
+    override string getCredentialsKind() { result = "password" }
   }
 
   /**

--- a/javascript/ql/src/Security/CWE-798/HardcodedCredentials.qhelp
+++ b/javascript/ql/src/Security/CWE-798/HardcodedCredentials.qhelp
@@ -19,6 +19,10 @@
   If possible, store configuration files including credential data separately from the source code,
   in a secure location with restricted access.
 </p>
+<p>
+  If the credentials are a placeholder value, make sure the value is obviously a placeholder by 
+  using a name such as <code>"SampleToken"</code> or <code>"MyPassword"</code>.
+</p>
 </recommendation>
 
 <example>

--- a/javascript/ql/src/Security/CWE-798/HardcodedCredentials.ql
+++ b/javascript/ql/src/Security/CWE-798/HardcodedCredentials.ql
@@ -30,7 +30,7 @@ where
       // exclude dummy passwords and templates
       not (
         sink.getNode().(Sink).(DefaultCredentialsSink).getKind() =
-          ["password", "credentials", "token"] and
+          ["password", "credentials", "token", "key"] and
         PasswordHeuristics::isDummyPassword(val)
         or
         sink.getNode().(Sink).getKind() = "authorization header" and

--- a/javascript/ql/test/query-tests/Security/CWE-798/HardcodedCredentials.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-798/HardcodedCredentials.expected
@@ -274,6 +274,15 @@ nodes
 | HardcodedCredentials.js:299:44:299:52 | 'mytoken' |
 | HardcodedCredentials.js:299:44:299:52 | 'mytoken' |
 | HardcodedCredentials.js:299:44:299:52 | 'mytoken' |
+| HardcodedCredentials.js:300:44:300:56 | 'SampleToken' |
+| HardcodedCredentials.js:300:44:300:56 | 'SampleToken' |
+| HardcodedCredentials.js:300:44:300:56 | 'SampleToken' |
+| HardcodedCredentials.js:301:44:301:55 | 'MyPassword' |
+| HardcodedCredentials.js:301:44:301:55 | 'MyPassword' |
+| HardcodedCredentials.js:301:44:301:55 | 'MyPassword' |
+| HardcodedCredentials.js:302:44:302:69 | 'iubfew ... ybgera' |
+| HardcodedCredentials.js:302:44:302:69 | 'iubfew ... ybgera' |
+| HardcodedCredentials.js:302:44:302:69 | 'iubfew ... ybgera' |
 edges
 | HardcodedCredentials.js:5:15:5:22 | 'dbuser' | HardcodedCredentials.js:5:15:5:22 | 'dbuser' |
 | HardcodedCredentials.js:8:19:8:28 | 'hgfedcba' | HardcodedCredentials.js:8:19:8:28 | 'hgfedcba' |
@@ -403,6 +412,9 @@ edges
 | HardcodedCredentials.js:294:37:294:70 | `Basic  ... gbbbbb` | HardcodedCredentials.js:294:37:294:70 | `Basic  ... gbbbbb` |
 | HardcodedCredentials.js:295:37:295:66 | `Basic  ... 000001` | HardcodedCredentials.js:295:37:295:66 | `Basic  ... 000001` |
 | HardcodedCredentials.js:299:44:299:52 | 'mytoken' | HardcodedCredentials.js:299:44:299:52 | 'mytoken' |
+| HardcodedCredentials.js:300:44:300:56 | 'SampleToken' | HardcodedCredentials.js:300:44:300:56 | 'SampleToken' |
+| HardcodedCredentials.js:301:44:301:55 | 'MyPassword' | HardcodedCredentials.js:301:44:301:55 | 'MyPassword' |
+| HardcodedCredentials.js:302:44:302:69 | 'iubfew ... ybgera' | HardcodedCredentials.js:302:44:302:69 | 'iubfew ... ybgera' |
 #select
 | HardcodedCredentials.js:5:15:5:22 | 'dbuser' | HardcodedCredentials.js:5:15:5:22 | 'dbuser' | HardcodedCredentials.js:5:15:5:22 | 'dbuser' | The hard-coded value "dbuser" is used as $@. | HardcodedCredentials.js:5:15:5:22 | 'dbuser' | user name |
 | HardcodedCredentials.js:8:19:8:28 | 'hgfedcba' | HardcodedCredentials.js:8:19:8:28 | 'hgfedcba' | HardcodedCredentials.js:8:19:8:28 | 'hgfedcba' | The hard-coded value "hgfedcba" is used as $@. | HardcodedCredentials.js:8:19:8:28 | 'hgfedcba' | password |
@@ -468,3 +480,4 @@ edges
 | HardcodedCredentials.js:245:22:245:44 | "myHard ... ateKey" | HardcodedCredentials.js:245:22:245:44 | "myHard ... ateKey" | HardcodedCredentials.js:246:42:246:51 | privateKey | The hard-coded value "myHardCodedPrivateKey" is used as $@. | HardcodedCredentials.js:246:42:246:51 | privateKey | key |
 | HardcodedCredentials.js:292:37:292:57 | `Basic  ... sdsdag` | HardcodedCredentials.js:292:37:292:57 | `Basic  ... sdsdag` | HardcodedCredentials.js:292:37:292:57 | `Basic  ... sdsdag` | The hard-coded value "Basic sdsdag:sdsdag" is used as $@. | HardcodedCredentials.js:292:37:292:57 | `Basic  ... sdsdag` | authorization header |
 | HardcodedCredentials.js:294:37:294:70 | `Basic  ... gbbbbb` | HardcodedCredentials.js:294:37:294:70 | `Basic  ... gbbbbb` | HardcodedCredentials.js:294:37:294:70 | `Basic  ... gbbbbb` | The hard-coded value "Basic sdsdag:aaaiuogrweuibgbbbbb" is used as $@. | HardcodedCredentials.js:294:37:294:70 | `Basic  ... gbbbbb` | authorization header |
+| HardcodedCredentials.js:302:44:302:69 | 'iubfew ... ybgera' | HardcodedCredentials.js:302:44:302:69 | 'iubfew ... ybgera' | HardcodedCredentials.js:302:44:302:69 | 'iubfew ... ybgera' | The hard-coded value "iubfewiaaweiybgaeuybgera" is used as $@. | HardcodedCredentials.js:302:44:302:69 | 'iubfew ... ybgera' | key |

--- a/javascript/ql/test/query-tests/Security/CWE-798/HardcodedCredentials.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-798/HardcodedCredentials.expected
@@ -153,12 +153,12 @@ nodes
 | HardcodedCredentials.js:135:41:135:50 | "hgfedcba" |
 | HardcodedCredentials.js:135:41:135:50 | "hgfedcba" |
 | HardcodedCredentials.js:135:41:135:50 | "hgfedcba" |
-| HardcodedCredentials.js:160:38:160:48 | "change_me" |
-| HardcodedCredentials.js:160:38:160:48 | "change_me" |
-| HardcodedCredentials.js:160:38:160:48 | "change_me" |
-| HardcodedCredentials.js:161:41:161:51 | 'change_me' |
-| HardcodedCredentials.js:161:41:161:51 | 'change_me' |
-| HardcodedCredentials.js:161:41:161:51 | 'change_me' |
+| HardcodedCredentials.js:160:38:160:56 | "oiuneawrgiyubaegr" |
+| HardcodedCredentials.js:160:38:160:56 | "oiuneawrgiyubaegr" |
+| HardcodedCredentials.js:160:38:160:56 | "oiuneawrgiyubaegr" |
+| HardcodedCredentials.js:161:41:161:59 | 'oiuneawrgiyubaegr' |
+| HardcodedCredentials.js:161:41:161:59 | 'oiuneawrgiyubaegr' |
+| HardcodedCredentials.js:161:41:161:59 | 'oiuneawrgiyubaegr' |
 | HardcodedCredentials.js:164:35:164:45 | 'change_me' |
 | HardcodedCredentials.js:164:35:164:45 | 'change_me' |
 | HardcodedCredentials.js:164:35:164:45 | 'change_me' |
@@ -271,6 +271,9 @@ nodes
 | HardcodedCredentials.js:295:37:295:66 | `Basic  ... 000001` |
 | HardcodedCredentials.js:295:37:295:66 | `Basic  ... 000001` |
 | HardcodedCredentials.js:295:37:295:66 | `Basic  ... 000001` |
+| HardcodedCredentials.js:299:44:299:52 | 'mytoken' |
+| HardcodedCredentials.js:299:44:299:52 | 'mytoken' |
+| HardcodedCredentials.js:299:44:299:52 | 'mytoken' |
 edges
 | HardcodedCredentials.js:5:15:5:22 | 'dbuser' | HardcodedCredentials.js:5:15:5:22 | 'dbuser' |
 | HardcodedCredentials.js:8:19:8:28 | 'hgfedcba' | HardcodedCredentials.js:8:19:8:28 | 'hgfedcba' |
@@ -326,8 +329,8 @@ edges
 | HardcodedCredentials.js:130:44:130:53 | 'hgfedcba' | HardcodedCredentials.js:130:44:130:53 | 'hgfedcba' |
 | HardcodedCredentials.js:131:52:131:61 | 'hgfedcba' | HardcodedCredentials.js:131:52:131:61 | 'hgfedcba' |
 | HardcodedCredentials.js:135:41:135:50 | "hgfedcba" | HardcodedCredentials.js:135:41:135:50 | "hgfedcba" |
-| HardcodedCredentials.js:160:38:160:48 | "change_me" | HardcodedCredentials.js:160:38:160:48 | "change_me" |
-| HardcodedCredentials.js:161:41:161:51 | 'change_me' | HardcodedCredentials.js:161:41:161:51 | 'change_me' |
+| HardcodedCredentials.js:160:38:160:56 | "oiuneawrgiyubaegr" | HardcodedCredentials.js:160:38:160:56 | "oiuneawrgiyubaegr" |
+| HardcodedCredentials.js:161:41:161:59 | 'oiuneawrgiyubaegr' | HardcodedCredentials.js:161:41:161:59 | 'oiuneawrgiyubaegr' |
 | HardcodedCredentials.js:164:35:164:45 | 'change_me' | HardcodedCredentials.js:164:35:164:45 | 'change_me' |
 | HardcodedCredentials.js:171:11:171:25 | USER | HardcodedCredentials.js:173:35:173:38 | USER |
 | HardcodedCredentials.js:171:18:171:25 | 'sdsdag' | HardcodedCredentials.js:171:11:171:25 | USER |
@@ -399,6 +402,7 @@ edges
 | HardcodedCredentials.js:293:37:293:65 | `Basic  ... xxxxxx` | HardcodedCredentials.js:293:37:293:65 | `Basic  ... xxxxxx` |
 | HardcodedCredentials.js:294:37:294:70 | `Basic  ... gbbbbb` | HardcodedCredentials.js:294:37:294:70 | `Basic  ... gbbbbb` |
 | HardcodedCredentials.js:295:37:295:66 | `Basic  ... 000001` | HardcodedCredentials.js:295:37:295:66 | `Basic  ... 000001` |
+| HardcodedCredentials.js:299:44:299:52 | 'mytoken' | HardcodedCredentials.js:299:44:299:52 | 'mytoken' |
 #select
 | HardcodedCredentials.js:5:15:5:22 | 'dbuser' | HardcodedCredentials.js:5:15:5:22 | 'dbuser' | HardcodedCredentials.js:5:15:5:22 | 'dbuser' | The hard-coded value "dbuser" is used as $@. | HardcodedCredentials.js:5:15:5:22 | 'dbuser' | user name |
 | HardcodedCredentials.js:8:19:8:28 | 'hgfedcba' | HardcodedCredentials.js:8:19:8:28 | 'hgfedcba' | HardcodedCredentials.js:8:19:8:28 | 'hgfedcba' | The hard-coded value "hgfedcba" is used as $@. | HardcodedCredentials.js:8:19:8:28 | 'hgfedcba' | password |
@@ -448,8 +452,8 @@ edges
 | HardcodedCredentials.js:130:44:130:53 | 'hgfedcba' | HardcodedCredentials.js:130:44:130:53 | 'hgfedcba' | HardcodedCredentials.js:130:44:130:53 | 'hgfedcba' | The hard-coded value "hgfedcba" is used as $@. | HardcodedCredentials.js:130:44:130:53 | 'hgfedcba' | key |
 | HardcodedCredentials.js:131:52:131:61 | 'hgfedcba' | HardcodedCredentials.js:131:52:131:61 | 'hgfedcba' | HardcodedCredentials.js:131:52:131:61 | 'hgfedcba' | The hard-coded value "hgfedcba" is used as $@. | HardcodedCredentials.js:131:52:131:61 | 'hgfedcba' | key |
 | HardcodedCredentials.js:135:41:135:50 | "hgfedcba" | HardcodedCredentials.js:135:41:135:50 | "hgfedcba" | HardcodedCredentials.js:135:41:135:50 | "hgfedcba" | The hard-coded value "hgfedcba" is used as $@. | HardcodedCredentials.js:135:41:135:50 | "hgfedcba" | key |
-| HardcodedCredentials.js:160:38:160:48 | "change_me" | HardcodedCredentials.js:160:38:160:48 | "change_me" | HardcodedCredentials.js:160:38:160:48 | "change_me" | The hard-coded value "change_me" is used as $@. | HardcodedCredentials.js:160:38:160:48 | "change_me" | key |
-| HardcodedCredentials.js:161:41:161:51 | 'change_me' | HardcodedCredentials.js:161:41:161:51 | 'change_me' | HardcodedCredentials.js:161:41:161:51 | 'change_me' | The hard-coded value "change_me" is used as $@. | HardcodedCredentials.js:161:41:161:51 | 'change_me' | key |
+| HardcodedCredentials.js:160:38:160:56 | "oiuneawrgiyubaegr" | HardcodedCredentials.js:160:38:160:56 | "oiuneawrgiyubaegr" | HardcodedCredentials.js:160:38:160:56 | "oiuneawrgiyubaegr" | The hard-coded value "oiuneawrgiyubaegr" is used as $@. | HardcodedCredentials.js:160:38:160:56 | "oiuneawrgiyubaegr" | key |
+| HardcodedCredentials.js:161:41:161:59 | 'oiuneawrgiyubaegr' | HardcodedCredentials.js:161:41:161:59 | 'oiuneawrgiyubaegr' | HardcodedCredentials.js:161:41:161:59 | 'oiuneawrgiyubaegr' | The hard-coded value "oiuneawrgiyubaegr" is used as $@. | HardcodedCredentials.js:161:41:161:59 | 'oiuneawrgiyubaegr' | key |
 | HardcodedCredentials.js:171:18:171:25 | 'sdsdag' | HardcodedCredentials.js:171:18:171:25 | 'sdsdag' | HardcodedCredentials.js:178:30:178:44 | `Basic ${AUTH}` | The hard-coded value "sdsdag" is used as $@. | HardcodedCredentials.js:178:30:178:44 | `Basic ${AUTH}` | authorization header |
 | HardcodedCredentials.js:171:18:171:25 | 'sdsdag' | HardcodedCredentials.js:171:18:171:25 | 'sdsdag' | HardcodedCredentials.js:188:30:188:44 | `Basic ${AUTH}` | The hard-coded value "sdsdag" is used as $@. | HardcodedCredentials.js:188:30:188:44 | `Basic ${AUTH}` | authorization header |
 | HardcodedCredentials.js:171:18:171:25 | 'sdsdag' | HardcodedCredentials.js:171:18:171:25 | 'sdsdag' | HardcodedCredentials.js:195:37:195:51 | `Basic ${AUTH}` | The hard-coded value "sdsdag" is used as $@. | HardcodedCredentials.js:195:37:195:51 | `Basic ${AUTH}` | authorization header |

--- a/javascript/ql/test/query-tests/Security/CWE-798/HardcodedCredentials.js
+++ b/javascript/ql/test/query-tests/Security/CWE-798/HardcodedCredentials.js
@@ -157,8 +157,8 @@
 })();
 
 (function(){
-	require("cookie-session")({ secret: "change_me" }); // NOT OK
-	require('crypto').createHmac('sha256', 'change_me'); // NOT OK
+	require("cookie-session")({ secret: "oiuneawrgiyubaegr" }); // NOT OK
+	require('crypto').createHmac('sha256', 'oiuneawrgiyubaegr'); // NOT OK
 
 	var basicAuth = require('express-basic-auth');
 	basicAuth({users: { [adminName]: 'change_me' }});  // OK
@@ -294,3 +294,7 @@
     headers.append("Authorization", `Basic sdsdag:aaaiuogrweuibgbbbbb`); // NOT OK
     headers.append("Authorization", `Basic sdsdag:000000000000001`); // OK
 });
+
+(function () {
+    require('crypto').createHmac('sha256', 'mytoken'); // OK
+})();

--- a/javascript/ql/test/query-tests/Security/CWE-798/HardcodedCredentials.js
+++ b/javascript/ql/test/query-tests/Security/CWE-798/HardcodedCredentials.js
@@ -297,4 +297,7 @@
 
 (function () {
     require('crypto').createHmac('sha256', 'mytoken'); // OK
+    require('crypto').createHmac('sha256', 'SampleToken'); // OK
+    require('crypto').createHmac('sha256', 'MyPassword'); // OK
+    require('crypto').createHmac('sha256', 'iubfewiaaweiybgaeuybgera'); // NOT OK
 })();


### PR DESCRIPTION
Fixes https://github.com/github/codeql/issues/16360 and https://github.com/github/codeql/issues/16359.  
Replaces https://github.com/github/codeql/pull/16244 

I looked at what credentials-kinds we have, and I found the below (list is possibly non-exhaustive):  

```
"user name"
"password"
"authorization header"
"key"
"token"
"credentials"
"Node.js http(s) client login username"
"Node.js http(s) client login password"
```

I changed the last two to just `user name` and `password`.  

We already filtered away keys that look like dummy passwords for `password`, `credentials`, and `token`, and it seemed reasonable to just add `key` to that list. 

I also added a note in the QHelp with two sample passwords that we recognize as dummy-passwords.

Evaluations ([nightly](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/dummyPass__nightly-old__CustomSuite/reports), [default](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/dummyPass__default__CustomSuite/reports)) look reasonable.  
It removes keys that are obviously not meant to be actual secrets or the values are used for tests.  
And performance is unaffected. 