### PR TITLE
C++: Use entities in reorder directives

### DIFF
--- a/cpp/downgrades/19887dbd33327fb07d54251786e0cb2578539775/upgrade.properties
+++ b/cpp/downgrades/19887dbd33327fb07d54251786e0cb2578539775/upgrade.properties
@@ -1,4 +1,4 @@
 description: Revert support for repeated initializers, which are allowed in C with designated initializers.
 compatibility: full
-aggregate_field_init.rel: reorder aggregate_field_init.rel (int aggregate, int initializer, int field, int position) aggregate initializer field
-aggregate_array_init.rel: reorder aggregate_array_init.rel (int aggregate, int initializer, int element_index, int position) aggregate initializer element_index
+aggregate_field_init.rel: reorder aggregate_field_init.rel (@aggregateliteral aggregate, @expr initializer, @membervariable field, int position) aggregate initializer field
+aggregate_array_init.rel: reorder aggregate_array_init.rel (@aggregateliteral aggregate, @expr initializer, int element_index, int position) aggregate initializer element_index

--- a/cpp/ql/lib/upgrades/ddd31fd02e51ad270bc9e6712708e5a5b6881518/upgrade.properties
+++ b/cpp/ql/lib/upgrades/ddd31fd02e51ad270bc9e6712708e5a5b6881518/upgrade.properties
@@ -1,4 +1,4 @@
 description: Removed unused column from the `folders` and `files` relations
 compatibility: full
-files.rel: reorder files.rel (int id, string name, string simple, string ext, int fromSource) id name
-folders.rel: reorder folders.rel (int id, string name, string simple) id name
+files.rel: reorder files.rel (@file id, string name, string simple, string ext, int fromSource) id name
+folders.rel: reorder folders.rel (@folder id, string name, string simple) id name


### PR DESCRIPTION
This PR changes `reorder` directives in upgrade/downgrade scripts to use proper entity type names, instead of using `int` as generic stand-in for entity types.