### PR TITLE
C#: Use entities in reorder directives

### DIFF
--- a/csharp/downgrades/ab09ac8287516082b7a7367f8fda1862b1be47c5/upgrade.properties
+++ b/csharp/downgrades/ab09ac8287516082b7a7367f8fda1862b1be47c5/upgrade.properties
@@ -1,3 +1,3 @@
 description: Remove 'kind' from 'attributes'.
 compatability: full
-attributes.rel: reorder attributes.rel (int id, int kind, int type_id, int target) id type_id target
+attributes.rel: reorder attributes.rel (@attribute id, int kind, @type_or_ref type_id, @attributable target) id type_id target

--- a/csharp/ql/lib/upgrades/0f562410898f4d4afab2da91f5aaece660ebfa88/upgrade.properties
+++ b/csharp/ql/lib/upgrades/0f562410898f4d4afab2da91f5aaece660ebfa88/upgrade.properties
@@ -1,4 +1,4 @@
 description: Removed unused column from the `folders` and `files` relations
 compatibility: full
-files.rel: reorder files.rel (int id, string name, string simple, string ext, int fromSource) id name
-folders.rel: reorder folders.rel (int id, string name, string simple) id name
+files.rel: reorder files.rel (@file id, string name, string simple, string ext, int fromSource) id name
+folders.rel: reorder folders.rel (@folder id, string name, string simple) id name


### PR DESCRIPTION
This PR changes `reorder` directives in upgrade/downgrade scripts to use proper entity type names, instead of using `int` as generic stand-in for entity types.