### PR TITLE
Java: Use entities in reorder directives

### DIFF
--- a/java/ql/lib/upgrades/8ab354e68e86100ee3abe28bd44f491ecc77c1dd/upgrade.properties
+++ b/java/ql/lib/upgrades/8ab354e68e86100ee3abe28bd44f491ecc77c1dd/upgrade.properties
@@ -1,4 +1,4 @@
 description: Removed unused column from the `folders` and `files` relations
 compatibility: full
-files.rel: reorder files.rel (int id, string name, string simple, string ext, int fromSource) id name
-folders.rel: reorder folders.rel (int id, string name, string simple) id name
+files.rel: reorder files.rel (@file id, string name, string simple, string ext, int fromSource) id name
+folders.rel: reorder folders.rel (@folder id, string name, string simple) id name

--- a/java/ql/lib/upgrades/b4e689c90426b017ad550e30a439cab2763ff424/upgrade.properties
+++ b/java/ql/lib/upgrades/b4e689c90426b017ad550e30a439cab2763ff424/upgrade.properties
@@ -1,4 +1,4 @@
 description: Java 16: allow local interfaces
 compatibility: backwards
-isLocalClassOrInterface.rel: reorder isLocalClass.rel(int id, int parent) id parent
+isLocalClassOrInterface.rel: reorder isLocalClass.rel(@class id, @localclassdeclstmt parent) id parent
 isLocalClass.rel: delete


### PR DESCRIPTION
This PR changes `reorder` directives in upgrade/downgrade scripts to use proper entity type names, instead of using `int` as generic stand-in for entity types.