### PR TITLE
JS: Use entities in reorder directives

### DIFF
--- a/javascript/ql/lib/upgrades/9ca3692b65fd8d751431861d1a25c57f3e61d15b/upgrade.properties
+++ b/javascript/ql/lib/upgrades/9ca3692b65fd8d751431861d1a25c57f3e61d15b/upgrade.properties
@@ -1,4 +1,4 @@
 description: Removed unused column from the `folders` and `files` relations
 compatibility: full
-files.rel: reorder files.rel (int id, string name, string simple, string ext, int fromSource) id name
-folders.rel: reorder folders.rel (int id, string name, string simple) id name
+files.rel: reorder files.rel (@file id, string name, string simple, string ext, int fromSource) id name
+folders.rel: reorder folders.rel (@folder id, string name, string simple) id name

--- a/javascript/ql/lib/upgrades/c73fbfca57f3d593b9ff50c6aa3a886d6888efec/upgrade.properties
+++ b/javascript/ql/lib/upgrades/c73fbfca57f3d593b9ff50c6aa3a886d6888efec/upgrade.properties
@@ -1,94 +1,94 @@
 description: Rename multiple relation names. 
 compatibility: backwards
-is_externs.rel: reorder isExterns.rel(int toplevel) toplevel
+is_externs.rel: reorder isExterns.rel(@toplevel toplevel) toplevel
 isExterns.rel: delete
-is_module.rel: reorder isModule.rel(int toplevel) toplevel
+is_module.rel: reorder isModule.rel(@toplevel toplevel) toplevel
 isModule.rel: delete
-is_nodejs.rel: reorder isNodejs.rel(int toplevel) toplevel
+is_nodejs.rel: reorder isNodejs.rel(@toplevel toplevel) toplevel
 isNodejs.rel: delete
-is_es2015_module.rel: reorder isES2015Module.rel(int toplevel) toplevel
+is_es2015_module.rel: reorder isES2015Module.rel(@toplevel toplevel) toplevel
 isES2015Module.rel: delete
-is_closure_module.rel: reorder isClosureModule.rel(int toplevel) toplevel
+is_closure_module.rel: reorder isClosureModule.rel(@toplevel toplevel) toplevel
 isClosureModule.rel: delete
-stmt_containers.rel: reorder stmtContainers.rel(int stmt, int container) stmt container
+stmt_containers.rel: reorder stmtContainers.rel(@stmt stmt, @stmt_container container) stmt container
 stmtContainers.rel: delete
-jump_targets.rel: reorder jumpTargets.rel(int jump, int target) jump target
+jump_targets.rel: reorder jumpTargets.rel(@stmt jump, @stmt target) jump target
 jumpTargets.rel: delete
-is_instantiated.rel: reorder isInstantiated.rel(int decl) decl
+is_instantiated.rel: reorder isInstantiated.rel(@namespacedeclaration decl) decl
 isInstantiated.rel: delete
-has_declare_keyword.rel: reorder hasDeclareKeyword.rel(int stmt) stmt
+has_declare_keyword.rel: reorder hasDeclareKeyword.rel(@declarablenode stmt) stmt
 hasDeclareKeyword.rel: delete
-is_for_await_of.rel: reorder isForAwaitOf.rel(int forof) forof
+is_for_await_of.rel: reorder isForAwaitOf.rel(@forofstmt forof) forof
 isForAwaitOf.rel: delete
-enclosing_stmt.rel: reorder enclosingStmt.rel(int expr, int stmt) expr stmt
+enclosing_stmt.rel: reorder enclosingStmt.rel(@exprortype expr, @stmt stmt) expr stmt
 enclosingStmt.rel: delete
-expr_containers.rel: reorder exprContainers.rel(int expr, int container) expr container
+expr_containers.rel: reorder exprContainers.rel(@exprortype expr, @stmt_container container) expr container
 exprContainers.rel: delete
-array_size.rel: reorder arraySize.rel(int ae, int sz) ae sz
+array_size.rel: reorder arraySize.rel(@arraylike ae, int sz) ae sz
 arraySize.rel: delete
-is_delegating.rel: reorder isDelegating.rel(int yield) yield
+is_delegating.rel: reorder isDelegating.rel(@yieldexpr yield) yield
 isDelegating.rel: delete
-is_arguments_object.rel: reorder isArgumentsObject.rel(int id) id
+is_arguments_object.rel: reorder isArgumentsObject.rel(@variable id) id
 isArgumentsObject.rel: delete
-is_computed.rel: reorder isComputed.rel(int prop) prop
+is_computed.rel: reorder isComputed.rel(@property prop) prop
 isComputed.rel: delete
-is_method.rel: reorder isMethod.rel(int prop) prop
+is_method.rel: reorder isMethod.rel(@property prop) prop
 isMethod.rel: delete
-is_static.rel: reorder isStatic.rel(int prop) prop
+is_static.rel: reorder isStatic.rel(@property prop) prop
 isStatic.rel: delete
-is_abstract_member.rel: reorder isAbstractMember.rel(int prop) prop
+is_abstract_member.rel: reorder isAbstractMember.rel(@property prop) prop
 isAbstractMember.rel: delete
-is_const_enum.rel: reorder isConstEnum.rel(int id) id
+is_const_enum.rel: reorder isConstEnum.rel(@enumdeclaration id) id
 isConstEnum.rel: delete
-is_abstract_class.rel: reorder isAbstractClass.rel(int id) id
+is_abstract_class.rel: reorder isAbstractClass.rel(@classdeclstmt id) id
 isAbstractClass.rel: delete
-has_public_keyword.rel: reorder hasPublicKeyword.rel(int prop) prop
+has_public_keyword.rel: reorder hasPublicKeyword.rel(@property prop) prop
 hasPublicKeyword.rel: delete
-has_private_keyword.rel: reorder hasPrivateKeyword.rel(int prop) prop
+has_private_keyword.rel: reorder hasPrivateKeyword.rel(@property prop) prop
 hasPrivateKeyword.rel: delete
-has_protected_keyword.rel: reorder hasProtectedKeyword.rel(int prop) prop
+has_protected_keyword.rel: reorder hasProtectedKeyword.rel(@property prop) prop
 hasProtectedKeyword.rel: delete
-has_readonly_keyword.rel: reorder hasReadonlyKeyword.rel(int prop) prop
+has_readonly_keyword.rel: reorder hasReadonlyKeyword.rel(@property prop) prop
 hasReadonlyKeyword.rel: delete
-has_type_keyword.rel: reorder hasTypeKeyword.rel(int id) id
+has_type_keyword.rel: reorder hasTypeKeyword.rel(@import_or_export_declaration id) id
 hasTypeKeyword.rel: delete
-is_optional_member.rel: reorder isOptionalMember.rel(int id) id
+is_optional_member.rel: reorder isOptionalMember.rel(@property id) id
 isOptionalMember.rel: delete
-has_definite_assignment_assertion.rel: reorder hasDefiniteAssignmentAssertion.rel(int id) id
+has_definite_assignment_assertion.rel: reorder hasDefiniteAssignmentAssertion.rel(@field_or_vardeclarator id) id
 hasDefiniteAssignmentAssertion.rel: delete
-is_optional_parameter_declaration.rel: reorder isOptionalParameterDeclaration.rel(int parameter) parameter
+is_optional_parameter_declaration.rel: reorder isOptionalParameterDeclaration.rel(@pattern parameter) parameter
 isOptionalParameterDeclaration.rel: delete
-has_asserts_keyword.rel: reorder hasAssertsKeyword.rel(int node) node
+has_asserts_keyword.rel: reorder hasAssertsKeyword.rel(@predicatetypeexpr node) node
 hasAssertsKeyword.rel: delete
-js_parse_errors.rel: reorder jsParseErrors.rel(int id, int toplevel, string message, string line) id toplevel message line
+js_parse_errors.rel: reorder jsParseErrors.rel(@js_parse_error id, @toplevel toplevel, string message, string line) id toplevel message line
 jsParseErrors.rel: delete
-regexp_parse_errors.rel: reorder regexpParseErrors.rel(int id, int regexp, string message) id regexp message
+regexp_parse_errors.rel: reorder regexpParseErrors.rel(@regexp_parse_error id, @regexpterm regexp, string message) id regexp message
 regexpParseErrors.rel: delete
-is_greedy.rel: reorder isGreedy.rel(int id) id
+is_greedy.rel: reorder isGreedy.rel(@regexp_quantifier id) id
 isGreedy.rel: delete
-range_quantifier_lower_bound.rel: reorder rangeQuantifierLowerBound.rel(int id, int lo) id lo
+range_quantifier_lower_bound.rel: reorder rangeQuantifierLowerBound.rel(@regexp_range id, int lo) id lo
 rangeQuantifierLowerBound.rel: delete
-range_quantifier_upper_bound.rel: reorder rangeQuantifierUpperBound.rel(int id, int hi) id hi
+range_quantifier_upper_bound.rel: reorder rangeQuantifierUpperBound.rel(@regexp_range id, int hi) id hi
 rangeQuantifierUpperBound.rel: delete
-is_capture.rel: reorder isCapture.rel(int id, int number) id number
+is_capture.rel: reorder isCapture.rel(@regexp_group id, int number) id number
 isCapture.rel: delete
-is_named_capture.rel: reorder isNamedCapture.rel(int id, string name) id name
+is_named_capture.rel: reorder isNamedCapture.rel(@regexp_group id, string name) id name
 isNamedCapture.rel: delete
-is_inverted.rel: reorder isInverted.rel(int id) id
+is_inverted.rel: reorder isInverted.rel(@regexp_char_class id) id
 isInverted.rel: delete
-regexp_const_value.rel: reorder regexpConstValue.rel(int id, string value) id value
+regexp_const_value.rel: reorder regexpConstValue.rel(@regexp_constant id, string value) id value
 regexpConstValue.rel: delete
-char_class_escape.rel: reorder charClassEscape.rel(int id, string value) id value
+char_class_escape.rel: reorder charClassEscape.rel(@regexp_char_class_escape id, string value) id value
 charClassEscape.rel: delete
-named_backref.rel: reorder namedBackref.rel(int id, string name) id name
+named_backref.rel: reorder namedBackref.rel(@regexp_backref id, string name) id name
 namedBackref.rel: delete
-unicode_property_escapename.rel: reorder unicodePropertyEscapeName.rel(int id, string name) id name
+unicode_property_escapename.rel: reorder unicodePropertyEscapeName.rel(@regexp_unicode_property_escape id, string name) id name
 unicodePropertyEscapeName.rel: delete
-unicode_property_escapevalue.rel: reorder unicodePropertyEscapeValue.rel(int id, string value) id value
+unicode_property_escapevalue.rel: reorder unicodePropertyEscapeValue.rel(@regexp_unicode_property_escape id, string value) id value
 unicodePropertyEscapeValue.rel: delete
-is_generator.rel: reorder isGenerator.rel(int fun) fun
+is_generator.rel: reorder isGenerator.rel(@function fun) fun
 isGenerator.rel: delete
-has_rest_parameter.rel: reorder hasRestParameter.rel(int fun) fun
+has_rest_parameter.rel: reorder hasRestParameter.rel(@function fun) fun
 hasRestParameter.rel: delete
-is_async.rel: reorder isAsync.rel(int fun) fun
+is_async.rel: reorder isAsync.rel(@function fun) fun
 isAsync.rel: delete


### PR DESCRIPTION
This PR changes `reorder` directives in upgrade/downgrade scripts to use proper entity type names, instead of using `int` as generic stand-in for entity types.