### PR TITLE
Python: Use entities in reorder directives

### DIFF
--- a/python/ql/lib/upgrades/4f1806347d7fafe2f78508da01c01e5aff5f7cbb/upgrade.properties
+++ b/python/ql/lib/upgrades/4f1806347d7fafe2f78508da01c01e5aff5f7cbb/upgrade.properties
@@ -1,4 +1,4 @@
 description: Removed unused column from the `folders` and `files` relations
 compatibility: full
-files.rel: reorder files.rel (int id, string name, string simple, string ext, int fromSource) id name
-folders.rel: reorder folders.rel (int id, string name, string simple) id name
+files.rel: reorder files.rel (@file id, string name, string simple, string ext, int fromSource) id name
+folders.rel: reorder folders.rel (@folder id, string name, string simple) id name


### PR DESCRIPTION
This PR changes `reorder` directives in upgrade/downgrade scripts to use proper entity type names, instead of using `int` as generic stand-in for entity types.