### PR TITLE
Ruby: Use entities in reorder directives

### DIFF
--- a/ruby/downgrades/307ebf14d59930ba903d71d377f6f4129d0a6d22/upgrade.properties
+++ b/ruby/downgrades/307ebf14d59930ba903d71d377f6f4129d0a6d22/upgrade.properties
@@ -1,6 +1,6 @@
 description: Update grammar
 compatibility: backwards
-ruby_splat_argument_def.rel: reorder ruby_splat_argument_child.rel ( int id, int child) id child
+ruby_splat_argument_def.rel: reorder ruby_splat_argument_child.rel ( @ruby_splat_argument id, @ruby_underscore_arg child) id child
 ruby_splat_argument_child.rel: delete
-ruby_hash_splat_argument_def.rel: reorder ruby_hash_splat_argument_child.rel ( int id, int child) id child
+ruby_hash_splat_argument_def.rel: reorder ruby_hash_splat_argument_child.rel ( @ruby_hash_splat_argument id, @ruby_underscore_arg child) id child
 ruby_hash_splat_argument_child.rel: delete

--- a/ruby/downgrades/4ba51641799d2aaa315c7323931e2dd2a94c9f9d/upgrade.properties
+++ b/ruby/downgrades/4ba51641799d2aaa315c7323931e2dd2a94c9f9d/upgrade.properties
@@ -1,14 +1,14 @@
 description: Update ERB parser
 compatibility: partial
 
-erb_comment_directive_def.rel: reorder erb_comment_directive_child.rel (int id, int child) id child
+erb_comment_directive_def.rel: reorder erb_comment_directive_child.rel (@erb_comment_directive id, @erb_token_comment child) id child
 erb_comment_directive_child.rel: delete
 
-erb_directive_def.rel: reorder erb_directive_child.rel (int id, int child) id child
+erb_directive_def.rel: reorder erb_directive_child.rel (@erb_directive id, @erb_token_code child) id child
 erb_directive_child.rel: delete
 
-erb_graphql_directive_def.rel: reorder erb_graphql_directive_child.rel (int id, int child) id child
+erb_graphql_directive_def.rel: reorder erb_graphql_directive_child.rel (@erb_graphql_directive id, @erb_token_code child) id child
 erb_graphql_directive_child.rel: delete
 
-erb_output_directive_def.rel: reorder erb_output_directive_child.rel (int id, int child) id child
+erb_output_directive_def.rel: reorder erb_output_directive_child.rel (@erb_output_directive id, @erb_token_code child) id child
 erb_output_directive_child.rel: delete

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/upgrade.properties
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/upgrade.properties
@@ -1,8 +1,8 @@
 description: Revert: Move location columns to a single table
 compatibility: full
 
-erb_ast_node_parent.rel:  reorder erb_ast_node_info.rel  (int node, int parent, int parent_index, int loc) node parent parent_index
-ruby_ast_node_parent.rel: reorder ruby_ast_node_info.rel (int node, int parent, int parent_index, int loc) node parent parent_index
+erb_ast_node_parent.rel:  reorder erb_ast_node_info.rel  (@erb_ast_node node, @erb_ast_node_parent parent, int parent_index, @location loc) node parent parent_index
+ruby_ast_node_parent.rel: reorder ruby_ast_node_info.rel (@ruby_ast_node node, @ruby_ast_node_parent parent, int parent_index, @location loc) node parent parent_index
 
 erb_ast_node_info.rel:  delete
 ruby_ast_node_info.rel: delete

--- a/ruby/ql/lib/upgrades/09a494ce67d8141f28d6411f89b9ff7bdad440f3/upgrade.properties
+++ b/ruby/ql/lib/upgrades/09a494ce67d8141f28d6411f89b9ff7bdad440f3/upgrade.properties
@@ -1,4 +1,4 @@
 description: Removed unused column from the `folders` and `files` relations
 compatibility: full
-files.rel: reorder files.rel (int id, string name, string simple, string ext, int fromSource) id name
-folders.rel: reorder folders.rel (int id, string name, string simple) id name
+files.rel: reorder files.rel (@file id, string name, string simple, string ext, int fromSource) id name
+folders.rel: reorder folders.rel (@folder id, string name, string simple) id name

--- a/ruby/ql/lib/upgrades/1199e154f5e9b3560297633c6ebb4dfe0b191ae4/upgrade.properties
+++ b/ruby/ql/lib/upgrades/1199e154f5e9b3560297633c6ebb4dfe0b191ae4/upgrade.properties
@@ -1,13 +1,13 @@
 description: Update ERB parser
 compatibility: full
-erb_comment_directive_def.rel:   reorder erb_comment_directive_def.rel (int id, int child) id
-erb_comment_directive_child.rel: reorder erb_comment_directive_def.rel (int id, int child) id child
+erb_comment_directive_def.rel:   reorder erb_comment_directive_def.rel (@erb_comment_directive id, @erb_token_comment child) id
+erb_comment_directive_child.rel: reorder erb_comment_directive_def.rel (@erb_comment_directive id, @erb_token_comment child) id child
 
-erb_directive_def.rel:   reorder erb_directive_def.rel (int id, int child) id
-erb_directive_child.rel: reorder erb_directive_def.rel (int id, int child) id child
+erb_directive_def.rel:   reorder erb_directive_def.rel (@erb_directive id, @erb_token_code child) id
+erb_directive_child.rel: reorder erb_directive_def.rel (@erb_directive id, @erb_token_code child) id child
 
-erb_graphql_directive_def.rel:   reorder erb_graphql_directive_def.rel (int id, int child) id
-erb_graphql_directive_child.rel: reorder erb_graphql_directive_def.rel (int id, int child) id child
+erb_graphql_directive_def.rel:   reorder erb_graphql_directive_def.rel (@erb_graphql_directive id, @erb_token_code child) id
+erb_graphql_directive_child.rel: reorder erb_graphql_directive_def.rel (@erb_graphql_directive id, @erb_token_code child) id child
 
-erb_output_directive_def.rel:   reorder erb_output_directive_def.rel (int id, int child) id
-erb_output_directive_child.rel: reorder erb_output_directive_def.rel (int id, int child) id child
+erb_output_directive_def.rel:   reorder erb_output_directive_def.rel (@erb_output_directive id, @erb_token_code child) id
+erb_output_directive_child.rel: reorder erb_output_directive_def.rel (@erb_output_directive id, @erb_token_code child) id child

--- a/ruby/ql/lib/upgrades/24d81950f3ab7e67e14553e1a5111a04e8ae8445/upgrade.properties
+++ b/ruby/ql/lib/upgrades/24d81950f3ab7e67e14553e1a5111a04e8ae8445/upgrade.properties
@@ -6,111 +6,111 @@ ruby_ast_node_info.rel:   run ruby_ast_node_info.qlo
 erb_ast_node_parent.rel:  delete
 ruby_ast_node_parent.rel: delete
 
-erb_tokeninfo.rel:        reorder erb_tokeninfo.rel                     (int id, int kind, string value, int loc) id kind value
-ruby_tokeninfo.rel:       reorder ruby_tokeninfo.rel                    (int id, int kind, string value, int loc) id kind value
+erb_tokeninfo.rel:        reorder erb_tokeninfo.rel                     (@erb_token id, int kind, string value, @location loc) id kind value
+ruby_tokeninfo.rel:       reorder ruby_tokeninfo.rel                    (@ruby_token id, int kind, string value, @location loc) id kind value
 
-erb_comment_directive_def.rel:   reorder erb_comment_directive_def.rel  (int id, int child, int loc) id child
-erb_directive_def.rel:           reorder erb_directive_def.rel          (int id, int child, int loc) id child
-erb_graphql_directive_def.rel:   reorder erb_graphql_directive_def.rel  (int id, int child, int loc) id child
-erb_output_directive_def.rel:    reorder erb_output_directive_def.rel   (int id, int child, int loc) id child
-erb_template_def.rel:            reorder erb_template_def.rel           (int id, int loc) id
+erb_comment_directive_def.rel:   reorder erb_comment_directive_def.rel  (@erb_comment_directive id, @erb_token_comment child, @location loc) id child
+erb_directive_def.rel:           reorder erb_directive_def.rel          (@erb_directive id, @erb_token_code child, @location loc) id child
+erb_graphql_directive_def.rel:   reorder erb_graphql_directive_def.rel  (@erb_graphql_directive id, @erb_token_code child, @location loc) id child
+erb_output_directive_def.rel:    reorder erb_output_directive_def.rel   (@erb_output_directive id, @erb_token_code child, @location loc) id child
+erb_template_def.rel:            reorder erb_template_def.rel           (@erb_template id, @location loc) id
 
-ruby_alias_def.rel:                          reorder ruby_alias_def.rel                         (int id, int alias, int name, int loc) id alias name
-ruby_alternative_pattern_def.rel:            reorder ruby_alternative_pattern_def.rel           (int id, int loc) id
-ruby_argument_list_def.rel:                  reorder ruby_argument_list_def.rel                 (int id, int loc) id
-ruby_array_def.rel:                          reorder ruby_array_def.rel                         (int id, int loc) id
-ruby_array_pattern_def.rel:                  reorder ruby_array_pattern_def.rel                 (int id, int loc) id
-ruby_as_pattern_def.rel:                     reorder ruby_as_pattern_def.rel                    (int id, int name, int value, int loc) id name value
-ruby_assignment_def.rel:                     reorder ruby_assignment_def.rel                    (int id, int left, int right, int loc) id left right
-ruby_bare_string_def.rel:                    reorder ruby_bare_string_def.rel                   (int id, int loc) id
-ruby_bare_symbol_def.rel:                    reorder ruby_bare_symbol_def.rel                   (int id, int loc) id
-ruby_begin_def.rel:                          reorder ruby_begin_def.rel                         (int id, int loc) id
-ruby_begin_block_def.rel:                    reorder ruby_begin_block_def.rel                   (int id, int loc) id
-ruby_binary_def.rel:                         reorder ruby_binary_def.rel                        (int id, int left, int operator, int right, int loc) id left operator right
-ruby_block_def.rel:                          reorder ruby_block_def.rel                         (int id, int loc) id
-ruby_block_argument_def.rel:                 reorder ruby_block_argument_def.rel                (int id, int loc) id
-ruby_block_parameter_def.rel:                reorder ruby_block_parameter_def.rel               (int id, int loc) id
-ruby_block_parameters_def.rel:               reorder ruby_block_parameters_def.rel              (int id, int loc) id
-ruby_break_def.rel:                          reorder ruby_break_def.rel                         (int id, int loc) id
-ruby_call_def.rel:                           reorder ruby_call_def.rel                          (int id, int method, int loc) id method
-ruby_case_def.rel:                           reorder ruby_case_def.rel                          (int id, int loc) id
-ruby_case_match_def.rel:                     reorder ruby_case_match_def.rel                    (int id, int value, int loc) id value
-ruby_chained_string_def.rel:                 reorder ruby_chained_string_def.rel                (int id, int loc) id
-ruby_class_def.rel:                          reorder ruby_class_def.rel                         (int id, int name, int loc) id name
-ruby_conditional_def.rel:                    reorder ruby_conditional_def.rel                   (int id, int alternative, int condition, int consequence, int loc) id alternative condition consequence
-ruby_delimited_symbol_def.rel:               reorder ruby_delimited_symbol_def.rel              (int id, int loc) id
-ruby_destructured_left_assignment_def.rel:   reorder ruby_destructured_left_assignment_def.rel  (int id, int loc) id
-ruby_destructured_parameter_def.rel:         reorder ruby_destructured_parameter_def.rel        (int id, int loc) id
-ruby_do_def.rel:                             reorder ruby_do_def.rel                            (int id, int loc) id
-ruby_do_block_def.rel:                       reorder ruby_do_block_def.rel                      (int id, int loc) id
-ruby_element_reference_def.rel:              reorder ruby_element_reference_def.rel             (int id, int object, int loc) id object
-ruby_else_def.rel:                           reorder ruby_else_def.rel                          (int id, int loc) id
-ruby_elsif_def.rel:                          reorder ruby_elsif_def.rel                         (int id, int condition, int loc) id condition
-ruby_end_block_def.rel:                      reorder ruby_end_block_def.rel                     (int id, int loc) id
-ruby_ensure_def.rel:                         reorder ruby_ensure_def.rel                        (int id, int loc) id
-ruby_exception_variable_def.rel:             reorder ruby_exception_variable_def.rel            (int id, int child, int loc) id child
-ruby_exceptions_def.rel:                     reorder ruby_exceptions_def.rel                    (int id, int loc) id
-ruby_expression_reference_pattern_def.rel:   reorder ruby_expression_reference_pattern_def.rel  (int id, int value, int loc) id value
-ruby_find_pattern_def.rel:                   reorder ruby_find_pattern_def.rel                  (int id, int loc) id
-ruby_for_def.rel:                            reorder ruby_for_def.rel                           (int id, int body, int pattern, int value, int loc) id body pattern value
-ruby_hash_def.rel:                           reorder ruby_hash_def.rel                          (int id, int loc) id
-ruby_hash_pattern_def.rel:                   reorder ruby_hash_pattern_def.rel                  (int id, int loc) id
-ruby_hash_splat_argument_def.rel:            reorder ruby_hash_splat_argument_def.rel           (int id, int child, int loc) id child
-ruby_hash_splat_parameter_def.rel:           reorder ruby_hash_splat_parameter_def.rel          (int id, int loc) id
-ruby_heredoc_body_def.rel:                   reorder ruby_heredoc_body_def.rel                  (int id, int loc) id
-ruby_if_def.rel:                             reorder ruby_if_def.rel                            (int id, int condition, int loc) id condition
-ruby_if_guard_def.rel:                       reorder ruby_if_guard_def.rel                      (int id, int condition, int loc) id condition
-ruby_if_modifier_def.rel:                    reorder ruby_if_modifier_def.rel                   (int id, int body, int condition, int loc) id body condition
-ruby_in_def.rel:                             reorder ruby_in_def.rel                            (int id, int child, int loc) id child
-ruby_in_clause_def.rel:                      reorder ruby_in_clause_def.rel                     (int id, int pattern, int loc) id pattern
-ruby_interpolation_def.rel:                  reorder ruby_interpolation_def.rel                 (int id, int loc) id
-ruby_keyword_parameter_def.rel:              reorder ruby_keyword_parameter_def.rel             (int id, int name, int loc) id name
-ruby_keyword_pattern_def.rel:                reorder ruby_keyword_pattern_def.rel               (int id, int key__, int loc) id key__
-ruby_lambda_def.rel:                         reorder ruby_lambda_def.rel                        (int id, int body, int loc) id body
-ruby_lambda_parameters_def.rel:              reorder ruby_lambda_parameters_def.rel             (int id, int loc) id
-ruby_left_assignment_list_def.rel:           reorder ruby_left_assignment_list_def.rel          (int id, int loc) id
-ruby_method_def.rel:                         reorder ruby_method_def.rel                        (int id, int name, int loc) id name
-ruby_method_parameters_def.rel:              reorder ruby_method_parameters_def.rel             (int id, int loc) id
-ruby_module_def.rel:                         reorder ruby_module_def.rel                        (int id, int name, int loc) id name
-ruby_next_def.rel:                           reorder ruby_next_def.rel                          (int id, int loc) id
-ruby_operator_assignment_def.rel:            reorder ruby_operator_assignment_def.rel           (int id, int left, int operator, int right, int loc) id left operator right
-ruby_optional_parameter_def.rel:             reorder ruby_optional_parameter_def.rel            (int id, int name, int value, int loc) id name value
-ruby_pair_def.rel:                           reorder ruby_pair_def.rel                          (int id, int key__, int loc) id key__
-ruby_parenthesized_pattern_def.rel:          reorder ruby_parenthesized_pattern_def.rel         (int id, int child, int loc) id child
-ruby_parenthesized_statements_def.rel:       reorder ruby_parenthesized_statements_def.rel      (int id, int loc) id
-ruby_pattern_def.rel:                        reorder ruby_pattern_def.rel                       (int id, int child, int loc) id child
-ruby_program_def.rel:                        reorder ruby_program_def.rel                       (int id, int loc) id
-ruby_range_def.rel:                          reorder ruby_range_def.rel                         (int id, int operator, int loc) id operator
-ruby_rational_def.rel:                       reorder ruby_rational_def.rel                      (int id, int child, int loc) id child
-ruby_redo_def.rel:                           reorder ruby_redo_def.rel                          (int id, int loc) id
-ruby_regex_def.rel:                          reorder ruby_regex_def.rel                         (int id, int loc) id
-ruby_rescue_def.rel:                         reorder ruby_rescue_def.rel                        (int id, int loc) id
-ruby_rescue_modifier_def.rel:                reorder ruby_rescue_modifier_def.rel               (int id, int body, int handler, int loc) id body handler
-ruby_rest_assignment_def.rel:                reorder ruby_rest_assignment_def.rel               (int id, int loc) id
-ruby_retry_def.rel:                          reorder ruby_retry_def.rel                         (int id, int loc) id
-ruby_return_def.rel:                         reorder ruby_return_def.rel                        (int id, int loc) id
-ruby_right_assignment_list_def.rel:          reorder ruby_right_assignment_list_def.rel         (int id, int loc) id
-ruby_scope_resolution_def.rel:               reorder ruby_scope_resolution_def.rel              (int id, int name, int loc) id name
-ruby_setter_def.rel:                         reorder ruby_setter_def.rel                        (int id, int name, int loc) id name
-ruby_singleton_class_def.rel:                reorder ruby_singleton_class_def.rel               (int id, int value, int loc) id value
-ruby_singleton_method_def.rel:               reorder ruby_singleton_method_def.rel              (int id, int name, int object, int loc) id name object
-ruby_splat_argument_def.rel:                 reorder ruby_splat_argument_def.rel                (int id, int child, int loc) id child
-ruby_splat_parameter_def.rel:                reorder ruby_splat_parameter_def.rel               (int id, int loc) id
-ruby_string_def.rel:                         reorder ruby_string_def.rel                        (int id, int loc) id
-ruby_string_array_def.rel:                   reorder ruby_string_array_def.rel                  (int id, int loc) id
-ruby_subshell_def.rel:                       reorder ruby_subshell_def.rel                      (int id, int loc) id
-ruby_superclass_def.rel:                     reorder ruby_superclass_def.rel                    (int id, int child, int loc) id child
-ruby_symbol_array_def.rel:                   reorder ruby_symbol_array_def.rel                  (int id, int loc) id
-ruby_then_def.rel:                           reorder ruby_then_def.rel                          (int id, int loc) id
-ruby_unary_def.rel:                          reorder ruby_unary_def.rel                         (int id, int operand, int operator, int loc) id operand operator
-ruby_undef_def.rel:                          reorder ruby_undef_def.rel                         (int id, int loc) id
-ruby_unless_def.rel:                         reorder ruby_unless_def.rel                        (int id, int condition, int loc) id condition
-ruby_unless_guard_def.rel:                   reorder ruby_unless_guard_def.rel                  (int id, int condition, int loc) id condition
-ruby_unless_modifier_def.rel:                reorder ruby_unless_modifier_def.rel               (int id, int body, int condition, int loc) id body condition
-ruby_until_def.rel:                          reorder ruby_until_def.rel                         (int id, int body, int condition, int loc) id body condition
-ruby_until_modifier_def.rel:                 reorder ruby_until_modifier_def.rel                (int id, int body, int condition, int loc) id body condition
-ruby_variable_reference_pattern_def.rel:     reorder ruby_variable_reference_pattern_def.rel    (int id, int name, int loc) id name
-ruby_when_def.rel:                           reorder ruby_when_def.rel                          (int id, int loc) id
-ruby_while_def.rel:                          reorder ruby_while_def.rel                         (int id, int body, int condition, int loc) id body condition
-ruby_while_modifier_def.rel:                 reorder ruby_while_modifier_def.rel                (int id, int body, int condition, int loc) id body condition
-ruby_yield_def.rel:                          reorder ruby_yield_def.rel                         (int id, int loc) id
+ruby_alias_def.rel:                          reorder ruby_alias_def.rel                         (@ruby_alias id, @ruby_underscore_method_name alias, @ruby_underscore_method_name name, @location loc) id alias name
+ruby_alternative_pattern_def.rel:            reorder ruby_alternative_pattern_def.rel           (@ruby_alternative_pattern id, @location loc) id
+ruby_argument_list_def.rel:                  reorder ruby_argument_list_def.rel                 (@ruby_argument_list id, @location loc) id
+ruby_array_def.rel:                          reorder ruby_array_def.rel                         (@ruby_array id, @location loc) id
+ruby_array_pattern_def.rel:                  reorder ruby_array_pattern_def.rel                 (@ruby_array_pattern id, @location loc) id
+ruby_as_pattern_def.rel:                     reorder ruby_as_pattern_def.rel                    (@ruby_as_pattern id, @ruby_token_identifier name, @ruby_underscore_pattern_expr value, @location loc) id name value
+ruby_assignment_def.rel:                     reorder ruby_assignment_def.rel                    (@ruby_assignment id, @ruby_assignment_left_type left, @ruby_assignment_right_type right, @location loc) id left right
+ruby_bare_string_def.rel:                    reorder ruby_bare_string_def.rel                   (@ruby_bare_string id, @location loc) id
+ruby_bare_symbol_def.rel:                    reorder ruby_bare_symbol_def.rel                   (@ruby_bare_symbol id, @location loc) id
+ruby_begin_def.rel:                          reorder ruby_begin_def.rel                         (@ruby_begin id, @location loc) id
+ruby_begin_block_def.rel:                    reorder ruby_begin_block_def.rel                   (@ruby_begin_block id, @location loc) id
+ruby_binary_def.rel:                         reorder ruby_binary_def.rel                        (@ruby_binary id, @ruby_underscore_expression left, int operator, @ruby_underscore_expression right, @location loc) id left operator right
+ruby_block_def.rel:                          reorder ruby_block_def.rel                         (@ruby_block id, @location loc) id
+ruby_block_argument_def.rel:                 reorder ruby_block_argument_def.rel                (@ruby_block_argument id, @location loc) id
+ruby_block_parameter_def.rel:                reorder ruby_block_parameter_def.rel               (@ruby_block_parameter id, @location loc) id
+ruby_block_parameters_def.rel:               reorder ruby_block_parameters_def.rel              (@ruby_block_parameters id, @location loc) id
+ruby_break_def.rel:                          reorder ruby_break_def.rel                         (@ruby_break id, @location loc) id
+ruby_call_def.rel:                           reorder ruby_call_def.rel                          (@ruby_call id, @ruby_call_method_type method, @location loc) id method
+ruby_case_def.rel:                           reorder ruby_case_def.rel                          (@ruby_case__ id, @location loc) id
+ruby_case_match_def.rel:                     reorder ruby_case_match_def.rel                    (@ruby_case_match id, @ruby_underscore_statement value, @location loc) id value
+ruby_chained_string_def.rel:                 reorder ruby_chained_string_def.rel                (@ruby_chained_string id, @location loc) id
+ruby_class_def.rel:                          reorder ruby_class_def.rel                         (@ruby_class id, @ruby_class_name_type name, @location loc) id name
+ruby_conditional_def.rel:                    reorder ruby_conditional_def.rel                   (@ruby_conditional id, @ruby_underscore_arg alternative, @ruby_underscore_arg condition, @ruby_underscore_arg consequence, @location loc) id alternative condition consequence
+ruby_delimited_symbol_def.rel:               reorder ruby_delimited_symbol_def.rel              (@ruby_delimited_symbol id, @location loc) id
+ruby_destructured_left_assignment_def.rel:   reorder ruby_destructured_left_assignment_def.rel  (@ruby_destructured_left_assignment id, @location loc) id
+ruby_destructured_parameter_def.rel:         reorder ruby_destructured_parameter_def.rel        (@ruby_destructured_parameter id, @location loc) id
+ruby_do_def.rel:                             reorder ruby_do_def.rel                            (@ruby_do id, @location loc) id
+ruby_do_block_def.rel:                       reorder ruby_do_block_def.rel                      (@ruby_do_block id, @location loc) id
+ruby_element_reference_def.rel:              reorder ruby_element_reference_def.rel             (@ruby_element_reference id, @ruby_underscore_primary object, @location loc) id object
+ruby_else_def.rel:                           reorder ruby_else_def.rel                          (@ruby_else id, @location loc) id
+ruby_elsif_def.rel:                          reorder ruby_elsif_def.rel                         (@ruby_elsif id, @ruby_underscore_statement condition, @location loc) id condition
+ruby_end_block_def.rel:                      reorder ruby_end_block_def.rel                     (@ruby_end_block id, @location loc) id
+ruby_ensure_def.rel:                         reorder ruby_ensure_def.rel                        (@ruby_ensure id, @location loc) id
+ruby_exception_variable_def.rel:             reorder ruby_exception_variable_def.rel            (@ruby_exception_variable id, @ruby_underscore_lhs child, @location loc) id child
+ruby_exceptions_def.rel:                     reorder ruby_exceptions_def.rel                    (@ruby_exceptions id, @location loc) id
+ruby_expression_reference_pattern_def.rel:   reorder ruby_expression_reference_pattern_def.rel  (@ruby_expression_reference_pattern id, @ruby_underscore_expression value, @location loc) id value
+ruby_find_pattern_def.rel:                   reorder ruby_find_pattern_def.rel                  (@ruby_find_pattern id, @location loc) id
+ruby_for_def.rel:                            reorder ruby_for_def.rel                           (@ruby_for id, @ruby_do body, @ruby_for_pattern_type pattern, @ruby_in value, @location loc) id body pattern value
+ruby_hash_def.rel:                           reorder ruby_hash_def.rel                          (@ruby_hash id, @location loc) id
+ruby_hash_pattern_def.rel:                   reorder ruby_hash_pattern_def.rel                  (@ruby_hash_pattern id, @location loc) id
+ruby_hash_splat_argument_def.rel:            reorder ruby_hash_splat_argument_def.rel           (@ruby_hash_splat_argument id, @ruby_underscore_arg child, @location loc) id child
+ruby_hash_splat_parameter_def.rel:           reorder ruby_hash_splat_parameter_def.rel          (@ruby_hash_splat_parameter id, @location loc) id
+ruby_heredoc_body_def.rel:                   reorder ruby_heredoc_body_def.rel                  (@ruby_heredoc_body id, @location loc) id
+ruby_if_def.rel:                             reorder ruby_if_def.rel                            (@ruby_if id, @ruby_underscore_statement condition, @location loc) id condition
+ruby_if_guard_def.rel:                       reorder ruby_if_guard_def.rel                      (@ruby_if_guard id, @ruby_underscore_expression condition, @location loc) id condition
+ruby_if_modifier_def.rel:                    reorder ruby_if_modifier_def.rel                   (@ruby_if_modifier id, @ruby_underscore_statement body, @ruby_underscore_expression condition, @location loc) id body condition
+ruby_in_def.rel:                             reorder ruby_in_def.rel                            (@ruby_in id, @ruby_underscore_arg child, @location loc) id child
+ruby_in_clause_def.rel:                      reorder ruby_in_clause_def.rel                     (@ruby_in_clause id, @ruby_underscore_pattern_top_expr_body pattern, @location loc) id pattern
+ruby_interpolation_def.rel:                  reorder ruby_interpolation_def.rel                 (@ruby_interpolation id, @location loc) id
+ruby_keyword_parameter_def.rel:              reorder ruby_keyword_parameter_def.rel             (@ruby_keyword_parameter id, @ruby_token_identifier name, @location loc) id name
+ruby_keyword_pattern_def.rel:                reorder ruby_keyword_pattern_def.rel               (@ruby_keyword_pattern id, @ruby_keyword_pattern_key_type key__, @location loc) id key__
+ruby_lambda_def.rel:                         reorder ruby_lambda_def.rel                        (@ruby_lambda id, @ruby_lambda_body_type body, @location loc) id body
+ruby_lambda_parameters_def.rel:              reorder ruby_lambda_parameters_def.rel             (@ruby_lambda_parameters id, @location loc) id
+ruby_left_assignment_list_def.rel:           reorder ruby_left_assignment_list_def.rel          (@ruby_left_assignment_list id, @location loc) id
+ruby_method_def.rel:                         reorder ruby_method_def.rel                        (@ruby_method id, @ruby_underscore_method_name name, @location loc) id name
+ruby_method_parameters_def.rel:              reorder ruby_method_parameters_def.rel             (@ruby_method_parameters id, @location loc) id
+ruby_module_def.rel:                         reorder ruby_module_def.rel                        (@ruby_module id, @ruby_module_name_type name, @location loc) id name
+ruby_next_def.rel:                           reorder ruby_next_def.rel                          (@ruby_next id, @location loc) id
+ruby_operator_assignment_def.rel:            reorder ruby_operator_assignment_def.rel           (@ruby_operator_assignment id, @ruby_underscore_lhs left, int operator, @ruby_underscore_expression right, @location loc) id left operator right
+ruby_optional_parameter_def.rel:             reorder ruby_optional_parameter_def.rel            (@ruby_optional_parameter id, @ruby_token_identifier name, @ruby_underscore_arg value, @location loc) id name value
+ruby_pair_def.rel:                           reorder ruby_pair_def.rel                          (@ruby_pair id, @ruby_pair_key_type key__, @location loc) id key__
+ruby_parenthesized_pattern_def.rel:          reorder ruby_parenthesized_pattern_def.rel         (@ruby_parenthesized_pattern id, @ruby_underscore_pattern_expr child, @location loc) id child
+ruby_parenthesized_statements_def.rel:       reorder ruby_parenthesized_statements_def.rel      (@ruby_parenthesized_statements id, @location loc) id
+ruby_pattern_def.rel:                        reorder ruby_pattern_def.rel                       (@ruby_pattern id, @ruby_pattern_child_type child, @location loc) id child
+ruby_program_def.rel:                        reorder ruby_program_def.rel                       (@ruby_program id, @location loc) id
+ruby_range_def.rel:                          reorder ruby_range_def.rel                         (@ruby_range id, int operator, @location loc) id operator
+ruby_rational_def.rel:                       reorder ruby_rational_def.rel                      (@ruby_rational id, @ruby_rational_child_type child, @location loc) id child
+ruby_redo_def.rel:                           reorder ruby_redo_def.rel                          (@ruby_redo id, @location loc) id
+ruby_regex_def.rel:                          reorder ruby_regex_def.rel                         (@ruby_regex id, @location loc) id
+ruby_rescue_def.rel:                         reorder ruby_rescue_def.rel                        (@ruby_rescue id, @location loc) id
+ruby_rescue_modifier_def.rel:                reorder ruby_rescue_modifier_def.rel               (@ruby_rescue_modifier id, @ruby_rescue_modifier_body_type body, @ruby_underscore_expression handler, @location loc) id body handler
+ruby_rest_assignment_def.rel:                reorder ruby_rest_assignment_def.rel               (@ruby_rest_assignment id, @location loc) id
+ruby_retry_def.rel:                          reorder ruby_retry_def.rel                         (@ruby_retry id, @location loc) id
+ruby_return_def.rel:                         reorder ruby_return_def.rel                        (@ruby_return id, @location loc) id
+ruby_right_assignment_list_def.rel:          reorder ruby_right_assignment_list_def.rel         (@ruby_right_assignment_list id, @location loc) id
+ruby_scope_resolution_def.rel:               reorder ruby_scope_resolution_def.rel              (@ruby_scope_resolution id, @ruby_scope_resolution_name_type name, @location loc) id name
+ruby_setter_def.rel:                         reorder ruby_setter_def.rel                        (@ruby_setter id, @ruby_token_identifier name, @location loc) id name
+ruby_singleton_class_def.rel:                reorder ruby_singleton_class_def.rel               (@ruby_singleton_class id, @ruby_underscore_arg value, @location loc) id value
+ruby_singleton_method_def.rel:               reorder ruby_singleton_method_def.rel              (@ruby_singleton_method id, @ruby_underscore_method_name name, @ruby_singleton_method_object_type object, @location loc) id name object
+ruby_splat_argument_def.rel:                 reorder ruby_splat_argument_def.rel                (@ruby_splat_argument id, @ruby_underscore_arg child, @location loc) id child
+ruby_splat_parameter_def.rel:                reorder ruby_splat_parameter_def.rel               (@ruby_splat_parameter id, @location loc) id
+ruby_string_def.rel:                         reorder ruby_string_def.rel                        (@ruby_string__ id, @location loc) id
+ruby_string_array_def.rel:                   reorder ruby_string_array_def.rel                  (@ruby_string_array id, @location loc) id
+ruby_subshell_def.rel:                       reorder ruby_subshell_def.rel                      (@ruby_subshell id, @location loc) id
+ruby_superclass_def.rel:                     reorder ruby_superclass_def.rel                    (@ruby_superclass id, @ruby_underscore_expression child, @location loc) id child
+ruby_symbol_array_def.rel:                   reorder ruby_symbol_array_def.rel                  (@ruby_symbol_array id, @location loc) id
+ruby_then_def.rel:                           reorder ruby_then_def.rel                          (@ruby_then id, @location loc) id
+ruby_unary_def.rel:                          reorder ruby_unary_def.rel                         (@ruby_unary id, @ruby_unary_operand_type operand, int operator, @location loc) id operand operator
+ruby_undef_def.rel:                          reorder ruby_undef_def.rel                         (@ruby_undef id, @location loc) id
+ruby_unless_def.rel:                         reorder ruby_unless_def.rel                        (@ruby_unless id, @ruby_underscore_statement condition, @location loc) id condition
+ruby_unless_guard_def.rel:                   reorder ruby_unless_guard_def.rel                  (@ruby_unless_guard id, @ruby_underscore_expression condition, @location loc) id condition
+ruby_unless_modifier_def.rel:                reorder ruby_unless_modifier_def.rel               (@ruby_unless_modifier id, @ruby_underscore_statement body, @ruby_underscore_expression condition, @location loc) id body condition
+ruby_until_def.rel:                          reorder ruby_until_def.rel                         (@ruby_until id, @ruby_do body, @ruby_underscore_statement condition, @location loc) id body condition
+ruby_until_modifier_def.rel:                 reorder ruby_until_modifier_def.rel                (@ruby_until_modifier id, @ruby_underscore_statement body, @ruby_underscore_expression condition, @location loc) id body condition
+ruby_variable_reference_pattern_def.rel:     reorder ruby_variable_reference_pattern_def.rel    (@ruby_variable_reference_pattern id, @ruby_variable_reference_pattern_name_type name, @location loc) id name
+ruby_when_def.rel:                           reorder ruby_when_def.rel                          (@ruby_when id, @location loc) id
+ruby_while_def.rel:                          reorder ruby_while_def.rel                         (@ruby_while id, @ruby_do body, @ruby_underscore_statement condition, @location loc) id body condition
+ruby_while_modifier_def.rel:                 reorder ruby_while_modifier_def.rel                (@ruby_while_modifier id, @ruby_underscore_statement body, @ruby_underscore_expression condition, @location loc) id body condition
+ruby_yield_def.rel:                          reorder ruby_yield_def.rel                         (@ruby_yield id, @location loc) id

--- a/ruby/ql/lib/upgrades/3595c826de6db850f16b9da265a54dbf24dd3126/upgrade.properties
+++ b/ruby/ql/lib/upgrades/3595c826de6db850f16b9da265a54dbf24dd3126/upgrade.properties
@@ -1,6 +1,6 @@
 description: Update grammar
 compatibility: full
-ruby_splat_argument_def.rel: reorder ruby_splat_argument_def.rel ( int id, int child) id
-ruby_splat_argument_child.rel: reorder ruby_splat_argument_def.rel ( int id, int child) id child
-ruby_hash_splat_argument_def.rel: reorder ruby_hash_splat_argument_def.rel ( int id, int child) id
-ruby_hash_splat_argument_child.rel: reorder ruby_hash_splat_argument_def.rel ( int id, int child) id child
+ruby_splat_argument_def.rel: reorder ruby_splat_argument_def.rel ( @ruby_splat_argument id, @ruby_underscore_arg child) id
+ruby_splat_argument_child.rel: reorder ruby_splat_argument_def.rel ( @ruby_splat_argument id, @ruby_underscore_arg child) id child
+ruby_hash_splat_argument_def.rel: reorder ruby_hash_splat_argument_def.rel ( @ruby_hash_splat_argument id, @ruby_underscore_arg child) id
+ruby_hash_splat_argument_child.rel: reorder ruby_hash_splat_argument_def.rel ( @ruby_hash_splat_argument id, @ruby_underscore_arg child) id child

--- a/ruby/ql/lib/upgrades/40be81bc2086eb0368f33c770e0a84817bb340c3/upgrade.properties
+++ b/ruby/ql/lib/upgrades/40be81bc2086eb0368f33c770e0a84817bb340c3/upgrade.properties
@@ -1,168 +1,168 @@
 description: Add ERB tables and rename Ruby tables
 compatibility: backwards
-ruby_alias_def.rel: reorder alias_def.rel ( int id, int alias, int name, int loc ) id alias name loc 
-ruby_argument_list_child.rel: reorder argument_list_child.rel ( int ruby_argument_list, int index, int child ) ruby_argument_list index child 
-ruby_argument_list_def.rel: reorder argument_list_def.rel ( int id, int loc ) id loc 
-ruby_array_child.rel: reorder array_child.rel ( int ruby_array, int index, int child ) ruby_array index child 
-ruby_array_def.rel: reorder array_def.rel ( int id, int loc ) id loc 
-ruby_assignment_def.rel: reorder assignment_def.rel ( int id, int left, int right, int loc ) id left right loc 
-ruby_bare_string_child.rel: reorder bare_string_child.rel ( int ruby_bare_string, int index, int child ) ruby_bare_string index child 
-ruby_bare_string_def.rel: reorder bare_string_def.rel ( int id, int loc ) id loc 
-ruby_bare_symbol_child.rel: reorder bare_symbol_child.rel ( int ruby_bare_symbol, int index, int child ) ruby_bare_symbol index child 
-ruby_bare_symbol_def.rel: reorder bare_symbol_def.rel ( int id, int loc ) id loc 
-ruby_begin_child.rel: reorder begin_child.rel ( int ruby_begin, int index, int child ) ruby_begin index child 
-ruby_begin_def.rel: reorder begin_def.rel ( int id, int loc ) id loc 
-ruby_begin_block_child.rel: reorder begin_block_child.rel ( int ruby_begin_block, int index, int child ) ruby_begin_block index child 
-ruby_begin_block_def.rel: reorder begin_block_def.rel ( int id, int loc ) id loc 
-ruby_binary_def.rel: reorder binary_def.rel ( int id, int left, int operator, int right, int loc ) id left operator right loc 
-ruby_block_parameters.rel: reorder block_parameters.rel ( int ruby_block, int parameters ) ruby_block parameters 
-ruby_block_child.rel: reorder block_child.rel ( int ruby_block, int index, int child ) ruby_block index child 
-ruby_block_def.rel: reorder block_def.rel ( int id, int loc ) id loc 
-ruby_block_argument_def.rel: reorder block_argument_def.rel ( int id, int child, int loc ) id child loc 
-ruby_block_parameter_def.rel: reorder block_parameter_def.rel ( int id, int name, int loc ) id name loc 
-ruby_block_parameters_child.rel: reorder block_parameters_child.rel ( int ruby_block_parameters, int index, int child ) ruby_block_parameters index child 
-ruby_block_parameters_def.rel: reorder block_parameters_def.rel ( int id, int loc ) id loc 
-ruby_break_child.rel: reorder break_child.rel ( int ruby_break, int child ) ruby_break child 
-ruby_break_def.rel: reorder break_def.rel ( int id, int loc ) id loc 
-ruby_call_arguments.rel: reorder call_arguments.rel ( int ruby_call, int arguments ) ruby_call arguments 
-ruby_call_block.rel: reorder call_block.rel ( int ruby_call, int block ) ruby_call block 
-ruby_call_receiver.rel: reorder call_receiver.rel ( int ruby_call, int receiver ) ruby_call receiver 
-ruby_call_def.rel: reorder call_def.rel ( int id, int method, int loc ) id method loc 
-ruby_case_value.rel: reorder case_value.rel ( int ruby_case__, int value ) ruby_case__ value 
-ruby_case_child.rel: reorder case_child.rel ( int ruby_case__, int index, int child ) ruby_case__ index child 
-ruby_case_def.rel: reorder case_def.rel ( int id, int loc ) id loc 
-ruby_chained_string_child.rel: reorder chained_string_child.rel ( int ruby_chained_string, int index, int child ) ruby_chained_string index child 
-ruby_chained_string_def.rel: reorder chained_string_def.rel ( int id, int loc ) id loc 
-ruby_class_superclass.rel: reorder class_superclass.rel ( int ruby_class, int superclass ) ruby_class superclass 
-ruby_class_child.rel: reorder class_child.rel ( int ruby_class, int index, int child ) ruby_class index child 
-ruby_class_def.rel: reorder class_def.rel ( int id, int name, int loc ) id name loc 
-ruby_conditional_def.rel: reorder conditional_def.rel ( int id, int alternative, int condition, int consequence, int loc ) id alternative condition consequence loc 
-ruby_delimited_symbol_child.rel: reorder delimited_symbol_child.rel ( int ruby_delimited_symbol, int index, int child ) ruby_delimited_symbol index child 
-ruby_delimited_symbol_def.rel: reorder delimited_symbol_def.rel ( int id, int loc ) id loc 
-ruby_destructured_left_assignment_child.rel: reorder destructured_left_assignment_child.rel ( int ruby_destructured_left_assignment, int index, int child ) ruby_destructured_left_assignment index child 
-ruby_destructured_left_assignment_def.rel: reorder destructured_left_assignment_def.rel ( int id, int loc ) id loc 
-ruby_destructured_parameter_child.rel: reorder destructured_parameter_child.rel ( int ruby_destructured_parameter, int index, int child ) ruby_destructured_parameter index child 
-ruby_destructured_parameter_def.rel: reorder destructured_parameter_def.rel ( int id, int loc ) id loc 
-ruby_do_child.rel: reorder do_child.rel ( int ruby_do, int index, int child ) ruby_do index child 
-ruby_do_def.rel: reorder do_def.rel ( int id, int loc ) id loc 
-ruby_do_block_parameters.rel: reorder do_block_parameters.rel ( int ruby_do_block, int parameters ) ruby_do_block parameters 
-ruby_do_block_child.rel: reorder do_block_child.rel ( int ruby_do_block, int index, int child ) ruby_do_block index child 
-ruby_do_block_def.rel: reorder do_block_def.rel ( int id, int loc ) id loc 
-ruby_element_reference_child.rel: reorder element_reference_child.rel ( int ruby_element_reference, int index, int child ) ruby_element_reference index child 
-ruby_element_reference_def.rel: reorder element_reference_def.rel ( int id, int object, int loc ) id object loc 
-ruby_else_child.rel: reorder else_child.rel ( int ruby_else, int index, int child ) ruby_else index child 
-ruby_else_def.rel: reorder else_def.rel ( int id, int loc ) id loc 
-ruby_elsif_alternative.rel: reorder elsif_alternative.rel ( int ruby_elsif, int alternative ) ruby_elsif alternative 
-ruby_elsif_consequence.rel: reorder elsif_consequence.rel ( int ruby_elsif, int consequence ) ruby_elsif consequence 
-ruby_elsif_def.rel: reorder elsif_def.rel ( int id, int condition, int loc ) id condition loc 
-ruby_end_block_child.rel: reorder end_block_child.rel ( int ruby_end_block, int index, int child ) ruby_end_block index child 
-ruby_end_block_def.rel: reorder end_block_def.rel ( int id, int loc ) id loc 
-ruby_ensure_child.rel: reorder ensure_child.rel ( int ruby_ensure, int index, int child ) ruby_ensure index child 
-ruby_ensure_def.rel: reorder ensure_def.rel ( int id, int loc ) id loc 
-ruby_exception_variable_def.rel: reorder exception_variable_def.rel ( int id, int child, int loc ) id child loc 
-ruby_exceptions_child.rel: reorder exceptions_child.rel ( int ruby_exceptions, int index, int child ) ruby_exceptions index child 
-ruby_exceptions_def.rel: reorder exceptions_def.rel ( int id, int loc ) id loc 
-ruby_for_def.rel: reorder for_def.rel ( int id, int body, int pattern, int value, int loc ) id body pattern value loc 
-ruby_hash_child.rel: reorder hash_child.rel ( int ruby_hash, int index, int child ) ruby_hash index child 
-ruby_hash_def.rel: reorder hash_def.rel ( int id, int loc ) id loc 
-ruby_hash_splat_argument_def.rel: reorder hash_splat_argument_def.rel ( int id, int child, int loc ) id child loc 
-ruby_hash_splat_parameter_name.rel: reorder hash_splat_parameter_name.rel ( int ruby_hash_splat_parameter, int name ) ruby_hash_splat_parameter name 
-ruby_hash_splat_parameter_def.rel: reorder hash_splat_parameter_def.rel ( int id, int loc ) id loc 
-ruby_heredoc_body_child.rel: reorder heredoc_body_child.rel ( int ruby_heredoc_body, int index, int child ) ruby_heredoc_body index child 
-ruby_heredoc_body_def.rel: reorder heredoc_body_def.rel ( int id, int loc ) id loc 
-ruby_if_alternative.rel: reorder if_alternative.rel ( int ruby_if, int alternative ) ruby_if alternative 
-ruby_if_consequence.rel: reorder if_consequence.rel ( int ruby_if, int consequence ) ruby_if consequence 
-ruby_if_def.rel: reorder if_def.rel ( int id, int condition, int loc ) id condition loc 
-ruby_if_modifier_def.rel: reorder if_modifier_def.rel ( int id, int body, int condition, int loc ) id body condition loc 
-ruby_in_def.rel: reorder in_def.rel ( int id, int child, int loc ) id child loc 
-ruby_interpolation_child.rel: reorder interpolation_child.rel ( int ruby_interpolation, int index, int child ) ruby_interpolation index child 
-ruby_interpolation_def.rel: reorder interpolation_def.rel ( int id, int loc ) id loc 
-ruby_keyword_parameter_value.rel: reorder keyword_parameter_value.rel ( int ruby_keyword_parameter, int value ) ruby_keyword_parameter value 
-ruby_keyword_parameter_def.rel: reorder keyword_parameter_def.rel ( int id, int name, int loc ) id name loc 
-ruby_lambda_parameters.rel: reorder lambda_parameters.rel ( int ruby_lambda, int parameters ) ruby_lambda parameters 
-ruby_lambda_def.rel: reorder lambda_def.rel ( int id, int body, int loc ) id body loc 
-ruby_lambda_parameters_child.rel: reorder lambda_parameters_child.rel ( int ruby_lambda_parameters, int index, int child ) ruby_lambda_parameters index child 
-ruby_lambda_parameters_def.rel: reorder lambda_parameters_def.rel ( int id, int loc ) id loc 
-ruby_left_assignment_list_child.rel: reorder left_assignment_list_child.rel ( int ruby_left_assignment_list, int index, int child ) ruby_left_assignment_list index child 
-ruby_left_assignment_list_def.rel: reorder left_assignment_list_def.rel ( int id, int loc ) id loc 
-ruby_method_parameters.rel: reorder method_parameters.rel ( int ruby_method, int parameters ) ruby_method parameters 
-ruby_method_child.rel: reorder method_child.rel ( int ruby_method, int index, int child ) ruby_method index child 
-ruby_method_def.rel: reorder method_def.rel ( int id, int name, int loc ) id name loc 
-ruby_method_parameters_child.rel: reorder method_parameters_child.rel ( int ruby_method_parameters, int index, int child ) ruby_method_parameters index child 
-ruby_method_parameters_def.rel: reorder method_parameters_def.rel ( int id, int loc ) id loc 
-ruby_module_child.rel: reorder module_child.rel ( int ruby_module, int index, int child ) ruby_module index child 
-ruby_module_def.rel: reorder module_def.rel ( int id, int name, int loc ) id name loc 
-ruby_next_child.rel: reorder next_child.rel ( int ruby_next, int child ) ruby_next child 
-ruby_next_def.rel: reorder next_def.rel ( int id, int loc ) id loc 
-ruby_operator_assignment_def.rel: reorder operator_assignment_def.rel ( int id, int left, int operator, int right, int loc ) id left operator right loc 
-ruby_optional_parameter_def.rel: reorder optional_parameter_def.rel ( int id, int name, int value, int loc ) id name value loc 
-ruby_pair_def.rel: reorder pair_def.rel ( int id, int key__, int value, int loc ) id key__ value loc 
-ruby_parenthesized_statements_child.rel: reorder parenthesized_statements_child.rel ( int ruby_parenthesized_statements, int index, int child ) ruby_parenthesized_statements index child 
-ruby_parenthesized_statements_def.rel: reorder parenthesized_statements_def.rel ( int id, int loc ) id loc 
-ruby_pattern_def.rel: reorder pattern_def.rel ( int id, int child, int loc ) id child loc 
-ruby_program_child.rel: reorder program_child.rel ( int ruby_program, int index, int child ) ruby_program index child 
-ruby_program_def.rel: reorder program_def.rel ( int id, int loc ) id loc 
-ruby_range_begin.rel: reorder range_begin.rel ( int ruby_range, int begin ) ruby_range begin 
-ruby_range_end.rel: reorder range_end.rel ( int ruby_range, int end ) ruby_range end 
-ruby_range_def.rel: reorder range_def.rel ( int id, int operator, int loc ) id operator loc 
-ruby_rational_def.rel: reorder rational_def.rel ( int id, int child, int loc ) id child loc 
-ruby_redo_child.rel: reorder redo_child.rel ( int ruby_redo, int child ) ruby_redo child 
-ruby_redo_def.rel: reorder redo_def.rel ( int id, int loc ) id loc 
-ruby_regex_child.rel: reorder regex_child.rel ( int ruby_regex, int index, int child ) ruby_regex index child 
-ruby_regex_def.rel: reorder regex_def.rel ( int id, int loc ) id loc 
-ruby_rescue_body.rel: reorder rescue_body.rel ( int ruby_rescue, int body ) ruby_rescue body 
-ruby_rescue_exceptions.rel: reorder rescue_exceptions.rel ( int ruby_rescue, int exceptions ) ruby_rescue exceptions 
-ruby_rescue_variable.rel: reorder rescue_variable.rel ( int ruby_rescue, int variable ) ruby_rescue variable 
-ruby_rescue_def.rel: reorder rescue_def.rel ( int id, int loc ) id loc 
-ruby_rescue_modifier_def.rel: reorder rescue_modifier_def.rel ( int id, int body, int handler, int loc ) id body handler loc 
-ruby_rest_assignment_child.rel: reorder rest_assignment_child.rel ( int ruby_rest_assignment, int child ) ruby_rest_assignment child 
-ruby_rest_assignment_def.rel: reorder rest_assignment_def.rel ( int id, int loc ) id loc 
-ruby_retry_child.rel: reorder retry_child.rel ( int ruby_retry, int child ) ruby_retry child 
-ruby_retry_def.rel: reorder retry_def.rel ( int id, int loc ) id loc 
-ruby_return_child.rel: reorder return_child.rel ( int ruby_return, int child ) ruby_return child 
-ruby_return_def.rel: reorder return_def.rel ( int id, int loc ) id loc 
-ruby_right_assignment_list_child.rel: reorder right_assignment_list_child.rel ( int ruby_right_assignment_list, int index, int child ) ruby_right_assignment_list index child 
-ruby_right_assignment_list_def.rel: reorder right_assignment_list_def.rel ( int id, int loc ) id loc 
-ruby_scope_resolution_scope.rel: reorder scope_resolution_scope.rel ( int ruby_scope_resolution, int scope ) ruby_scope_resolution scope 
-ruby_scope_resolution_def.rel: reorder scope_resolution_def.rel ( int id, int name, int loc ) id name loc 
-ruby_setter_def.rel: reorder setter_def.rel ( int id, int name, int loc ) id name loc 
-ruby_singleton_class_child.rel: reorder singleton_class_child.rel ( int ruby_singleton_class, int index, int child ) ruby_singleton_class index child 
-ruby_singleton_class_def.rel: reorder singleton_class_def.rel ( int id, int value, int loc ) id value loc 
-ruby_singleton_method_parameters.rel: reorder singleton_method_parameters.rel ( int ruby_singleton_method, int parameters ) ruby_singleton_method parameters 
-ruby_singleton_method_child.rel: reorder singleton_method_child.rel ( int ruby_singleton_method, int index, int child ) ruby_singleton_method index child 
-ruby_singleton_method_def.rel: reorder singleton_method_def.rel ( int id, int name, int object, int loc ) id name object loc 
-ruby_splat_argument_def.rel: reorder splat_argument_def.rel ( int id, int child, int loc ) id child loc 
-ruby_splat_parameter_name.rel: reorder splat_parameter_name.rel ( int ruby_splat_parameter, int name ) ruby_splat_parameter name 
-ruby_splat_parameter_def.rel: reorder splat_parameter_def.rel ( int id, int loc ) id loc 
-ruby_string_child.rel: reorder string_child.rel ( int ruby_string__, int index, int child ) ruby_string__ index child 
-ruby_string_def.rel: reorder string_def.rel ( int id, int loc ) id loc 
-ruby_string_array_child.rel: reorder string_array_child.rel ( int ruby_string_array, int index, int child ) ruby_string_array index child 
-ruby_string_array_def.rel: reorder string_array_def.rel ( int id, int loc ) id loc 
-ruby_subshell_child.rel: reorder subshell_child.rel ( int ruby_subshell, int index, int child ) ruby_subshell index child 
-ruby_subshell_def.rel: reorder subshell_def.rel ( int id, int loc ) id loc 
-ruby_superclass_def.rel: reorder superclass_def.rel ( int id, int child, int loc ) id child loc 
-ruby_symbol_array_child.rel: reorder symbol_array_child.rel ( int ruby_symbol_array, int index, int child ) ruby_symbol_array index child 
-ruby_symbol_array_def.rel: reorder symbol_array_def.rel ( int id, int loc ) id loc 
-ruby_then_child.rel: reorder then_child.rel ( int ruby_then, int index, int child ) ruby_then index child 
-ruby_then_def.rel: reorder then_def.rel ( int id, int loc ) id loc 
-ruby_unary_def.rel: reorder unary_def.rel ( int id, int operand, int operator, int loc ) id operand operator loc 
-ruby_undef_child.rel: reorder undef_child.rel ( int ruby_undef, int index, int child ) ruby_undef index child 
-ruby_undef_def.rel: reorder undef_def.rel ( int id, int loc ) id loc 
-ruby_unless_alternative.rel: reorder unless_alternative.rel ( int ruby_unless, int alternative ) ruby_unless alternative 
-ruby_unless_consequence.rel: reorder unless_consequence.rel ( int ruby_unless, int consequence ) ruby_unless consequence 
-ruby_unless_def.rel: reorder unless_def.rel ( int id, int condition, int loc ) id condition loc 
-ruby_unless_modifier_def.rel: reorder unless_modifier_def.rel ( int id, int body, int condition, int loc ) id body condition loc 
-ruby_until_def.rel: reorder until_def.rel ( int id, int body, int condition, int loc ) id body condition loc 
-ruby_until_modifier_def.rel: reorder until_modifier_def.rel ( int id, int body, int condition, int loc ) id body condition loc 
-ruby_when_body.rel: reorder when_body.rel ( int ruby_when, int body ) ruby_when body 
-ruby_when_pattern.rel: reorder when_pattern.rel ( int ruby_when, int index, int pattern ) ruby_when index pattern 
-ruby_when_def.rel: reorder when_def.rel ( int id, int loc ) id loc 
-ruby_while_def.rel: reorder while_def.rel ( int id, int body, int condition, int loc ) id body condition loc 
-ruby_while_modifier_def.rel: reorder while_modifier_def.rel ( int id, int body, int condition, int loc ) id body condition loc 
-ruby_yield_child.rel: reorder yield_child.rel ( int ruby_yield, int child ) ruby_yield child 
-ruby_yield_def.rel: reorder yield_def.rel ( int id, int loc ) id loc 
-ruby_tokeninfo.rel: reorder tokeninfo.rel ( int id, int kind, int file, int idx, string value, int loc ) id kind file idx value loc 
-ruby_ast_node_parent.rel: reorder ast_node_parent.rel ( int child, int parent, int parent_index) child parent parent_index
+ruby_alias_def.rel: reorder alias_def.rel ( @alias id, @underscore_method_name alias, @underscore_method_name name, @location loc ) id alias name loc 
+ruby_argument_list_child.rel: reorder argument_list_child.rel ( @argument_list ruby_argument_list, int index, @argument_list_child_type child ) ruby_argument_list index child 
+ruby_argument_list_def.rel: reorder argument_list_def.rel ( @argument_list id, @location loc ) id loc 
+ruby_array_child.rel: reorder array_child.rel ( @array ruby_array, int index, @array_child_type child ) ruby_array index child 
+ruby_array_def.rel: reorder array_def.rel ( @array id, @location loc ) id loc 
+ruby_assignment_def.rel: reorder assignment_def.rel ( @assignment id, @assignment_left_type left, @assignment_right_type right, @location loc ) id left right loc 
+ruby_bare_string_child.rel: reorder bare_string_child.rel ( @bare_string ruby_bare_string, int index, @bare_string_child_type child ) ruby_bare_string index child 
+ruby_bare_string_def.rel: reorder bare_string_def.rel ( @bare_string id, @location loc ) id loc 
+ruby_bare_symbol_child.rel: reorder bare_symbol_child.rel ( @bare_symbol ruby_bare_symbol, int index, @bare_symbol_child_type child ) ruby_bare_symbol index child 
+ruby_bare_symbol_def.rel: reorder bare_symbol_def.rel ( @bare_symbol id, @location loc ) id loc 
+ruby_begin_child.rel: reorder begin_child.rel ( @begin ruby_begin, int index, @begin_child_type child ) ruby_begin index child 
+ruby_begin_def.rel: reorder begin_def.rel ( @begin id, @location loc ) id loc 
+ruby_begin_block_child.rel: reorder begin_block_child.rel ( @begin_block ruby_begin_block, int index, @begin_block_child_type child ) ruby_begin_block index child 
+ruby_begin_block_def.rel: reorder begin_block_def.rel ( @begin_block id, @location loc ) id loc 
+ruby_binary_def.rel: reorder binary_def.rel ( @binary id, @binary_left_type left, int operator, @binary_right_type right, @location loc ) id left operator right loc 
+ruby_block_parameters.rel: reorder block_parameters.rel ( @block ruby_block, @block_parameters parameters ) ruby_block parameters 
+ruby_block_child.rel: reorder block_child.rel ( @block ruby_block, int index, @block_child_type child ) ruby_block index child 
+ruby_block_def.rel: reorder block_def.rel ( @block id, @location loc ) id loc 
+ruby_block_argument_def.rel: reorder block_argument_def.rel ( @block_argument id, @underscore_arg child, @location loc ) id child loc 
+ruby_block_parameter_def.rel: reorder block_parameter_def.rel ( @block_parameter id, @token_identifier name, @location loc ) id name loc 
+ruby_block_parameters_child.rel: reorder block_parameters_child.rel ( @block_parameters ruby_block_parameters, int index, @block_parameters_child_type child ) ruby_block_parameters index child 
+ruby_block_parameters_def.rel: reorder block_parameters_def.rel ( @block_parameters id, @location loc ) id loc 
+ruby_break_child.rel: reorder break_child.rel ( @break ruby_break, @argument_list child ) ruby_break child 
+ruby_break_def.rel: reorder break_def.rel ( @break id, @location loc ) id loc 
+ruby_call_arguments.rel: reorder call_arguments.rel ( @call ruby_call, @argument_list arguments ) ruby_call arguments 
+ruby_call_block.rel: reorder call_block.rel ( @call ruby_call, @call_block_type block ) ruby_call block 
+ruby_call_receiver.rel: reorder call_receiver.rel ( @call ruby_call, @call_receiver_type receiver ) ruby_call receiver 
+ruby_call_def.rel: reorder call_def.rel ( @call id, @call_method_type method, @location loc ) id method loc 
+ruby_case_value.rel: reorder case_value.rel ( @case__ ruby_case__, @underscore_statement value ) ruby_case__ value 
+ruby_case_child.rel: reorder case_child.rel ( @case__ ruby_case__, int index, @case_child_type child ) ruby_case__ index child 
+ruby_case_def.rel: reorder case_def.rel ( @case__ id, @location loc ) id loc 
+ruby_chained_string_child.rel: reorder chained_string_child.rel ( @chained_string ruby_chained_string, int index, @string__ child ) ruby_chained_string index child 
+ruby_chained_string_def.rel: reorder chained_string_def.rel ( @chained_string id, @location loc ) id loc 
+ruby_class_superclass.rel: reorder class_superclass.rel ( @class ruby_class, @superclass superclass ) ruby_class superclass 
+ruby_class_child.rel: reorder class_child.rel ( @class ruby_class, int index, @class_child_type child ) ruby_class index child 
+ruby_class_def.rel: reorder class_def.rel ( @class id, @class_name_type name, @location loc ) id name loc 
+ruby_conditional_def.rel: reorder conditional_def.rel ( @conditional id, @underscore_arg alternative, @underscore_arg condition, @underscore_arg consequence, @location loc ) id alternative condition consequence loc 
+ruby_delimited_symbol_child.rel: reorder delimited_symbol_child.rel ( @delimited_symbol ruby_delimited_symbol, int index, @delimited_symbol_child_type child ) ruby_delimited_symbol index child 
+ruby_delimited_symbol_def.rel: reorder delimited_symbol_def.rel ( @delimited_symbol id, @location loc ) id loc 
+ruby_destructured_left_assignment_child.rel: reorder destructured_left_assignment_child.rel ( @destructured_left_assignment ruby_destructured_left_assignment, int index, @destructured_left_assignment_child_type child ) ruby_destructured_left_assignment index child 
+ruby_destructured_left_assignment_def.rel: reorder destructured_left_assignment_def.rel ( @destructured_left_assignment id, @location loc ) id loc 
+ruby_destructured_parameter_child.rel: reorder destructured_parameter_child.rel ( @destructured_parameter ruby_destructured_parameter, int index, @destructured_parameter_child_type child ) ruby_destructured_parameter index child 
+ruby_destructured_parameter_def.rel: reorder destructured_parameter_def.rel ( @destructured_parameter id, @location loc ) id loc 
+ruby_do_child.rel: reorder do_child.rel ( @do ruby_do, int index, @do_child_type child ) ruby_do index child 
+ruby_do_def.rel: reorder do_def.rel ( @do id, @location loc ) id loc 
+ruby_do_block_parameters.rel: reorder do_block_parameters.rel ( @do_block ruby_do_block, @block_parameters parameters ) ruby_do_block parameters 
+ruby_do_block_child.rel: reorder do_block_child.rel ( @do_block ruby_do_block, int index, @do_block_child_type child ) ruby_do_block index child 
+ruby_do_block_def.rel: reorder do_block_def.rel ( @do_block id, @location loc ) id loc 
+ruby_element_reference_child.rel: reorder element_reference_child.rel ( @element_reference ruby_element_reference, int index, @element_reference_child_type child ) ruby_element_reference index child 
+ruby_element_reference_def.rel: reorder element_reference_def.rel ( @element_reference id, @underscore_primary object, @location loc ) id object loc 
+ruby_else_child.rel: reorder else_child.rel ( @else ruby_else, int index, @else_child_type child ) ruby_else index child 
+ruby_else_def.rel: reorder else_def.rel ( @else id, @location loc ) id loc 
+ruby_elsif_alternative.rel: reorder elsif_alternative.rel ( @elsif ruby_elsif, @elsif_alternative_type alternative ) ruby_elsif alternative 
+ruby_elsif_consequence.rel: reorder elsif_consequence.rel ( @elsif ruby_elsif, @then consequence ) ruby_elsif consequence 
+ruby_elsif_def.rel: reorder elsif_def.rel ( @elsif id, @underscore_statement condition, @location loc ) id condition loc 
+ruby_end_block_child.rel: reorder end_block_child.rel ( @end_block ruby_end_block, int index, @end_block_child_type child ) ruby_end_block index child 
+ruby_end_block_def.rel: reorder end_block_def.rel ( @end_block id, @location loc ) id loc 
+ruby_ensure_child.rel: reorder ensure_child.rel ( @ensure ruby_ensure, int index, @ensure_child_type child ) ruby_ensure index child 
+ruby_ensure_def.rel: reorder ensure_def.rel ( @ensure id, @location loc ) id loc 
+ruby_exception_variable_def.rel: reorder exception_variable_def.rel ( @exception_variable id, @underscore_lhs child, @location loc ) id child loc 
+ruby_exceptions_child.rel: reorder exceptions_child.rel ( @exceptions ruby_exceptions, int index, @exceptions_child_type child ) ruby_exceptions index child 
+ruby_exceptions_def.rel: reorder exceptions_def.rel ( @exceptions id, @location loc ) id loc 
+ruby_for_def.rel: reorder for_def.rel ( @for id, @do body, @for_pattern_type pattern, @in value, @location loc ) id body pattern value loc 
+ruby_hash_child.rel: reorder hash_child.rel ( @hash ruby_hash, int index, @hash_child_type child ) ruby_hash index child 
+ruby_hash_def.rel: reorder hash_def.rel ( @hash id, @location loc ) id loc 
+ruby_hash_splat_argument_def.rel: reorder hash_splat_argument_def.rel ( @hash_splat_argument id, @underscore_arg child, @location loc ) id child loc 
+ruby_hash_splat_parameter_name.rel: reorder hash_splat_parameter_name.rel ( @hash_splat_parameter ruby_hash_splat_parameter, @token_identifier name ) ruby_hash_splat_parameter name 
+ruby_hash_splat_parameter_def.rel: reorder hash_splat_parameter_def.rel ( @hash_splat_parameter id, @location loc ) id loc 
+ruby_heredoc_body_child.rel: reorder heredoc_body_child.rel ( @heredoc_body ruby_heredoc_body, int index, @heredoc_body_child_type child ) ruby_heredoc_body index child 
+ruby_heredoc_body_def.rel: reorder heredoc_body_def.rel ( @heredoc_body id, @location loc ) id loc 
+ruby_if_alternative.rel: reorder if_alternative.rel ( @if ruby_if, @if_alternative_type alternative ) ruby_if alternative 
+ruby_if_consequence.rel: reorder if_consequence.rel ( @if ruby_if, @then consequence ) ruby_if consequence 
+ruby_if_def.rel: reorder if_def.rel ( @if id, @underscore_statement condition, @location loc ) id condition loc 
+ruby_if_modifier_def.rel: reorder if_modifier_def.rel ( @if_modifier id, @underscore_statement body, @if_modifier_condition_type condition, @location loc ) id body condition loc 
+ruby_in_def.rel: reorder in_def.rel ( @in id, @underscore_arg child, @location loc ) id child loc 
+ruby_interpolation_child.rel: reorder interpolation_child.rel ( @interpolation ruby_interpolation, int index, @interpolation_child_type child ) ruby_interpolation index child 
+ruby_interpolation_def.rel: reorder interpolation_def.rel ( @interpolation id, @location loc ) id loc 
+ruby_keyword_parameter_value.rel: reorder keyword_parameter_value.rel ( @keyword_parameter ruby_keyword_parameter, @underscore_arg value ) ruby_keyword_parameter value 
+ruby_keyword_parameter_def.rel: reorder keyword_parameter_def.rel ( @keyword_parameter id, @token_identifier name, @location loc ) id name loc 
+ruby_lambda_parameters.rel: reorder lambda_parameters.rel ( @lambda ruby_lambda, @lambda_parameters parameters ) ruby_lambda parameters 
+ruby_lambda_def.rel: reorder lambda_def.rel ( @lambda id, @lambda_body_type body, @location loc ) id body loc 
+ruby_lambda_parameters_child.rel: reorder lambda_parameters_child.rel ( @lambda_parameters ruby_lambda_parameters, int index, @lambda_parameters_child_type child ) ruby_lambda_parameters index child 
+ruby_lambda_parameters_def.rel: reorder lambda_parameters_def.rel ( @lambda_parameters id, @location loc ) id loc 
+ruby_left_assignment_list_child.rel: reorder left_assignment_list_child.rel ( @left_assignment_list ruby_left_assignment_list, int index, @left_assignment_list_child_type child ) ruby_left_assignment_list index child 
+ruby_left_assignment_list_def.rel: reorder left_assignment_list_def.rel ( @left_assignment_list id, @location loc ) id loc 
+ruby_method_parameters.rel: reorder method_parameters.rel ( @method ruby_method, @method_parameters parameters ) ruby_method parameters 
+ruby_method_child.rel: reorder method_child.rel ( @method ruby_method, int index, @method_child_type child ) ruby_method index child 
+ruby_method_def.rel: reorder method_def.rel ( @method id, @underscore_method_name name, @location loc ) id name loc 
+ruby_method_parameters_child.rel: reorder method_parameters_child.rel ( @method_parameters ruby_method_parameters, int index, @method_parameters_child_type child ) ruby_method_parameters index child 
+ruby_method_parameters_def.rel: reorder method_parameters_def.rel ( @method_parameters id, @location loc ) id loc 
+ruby_module_child.rel: reorder module_child.rel ( @module ruby_module, int index, @module_child_type child ) ruby_module index child 
+ruby_module_def.rel: reorder module_def.rel ( @module id, @module_name_type name, @location loc ) id name loc 
+ruby_next_child.rel: reorder next_child.rel ( @next ruby_next, @argument_list child ) ruby_next child 
+ruby_next_def.rel: reorder next_def.rel ( @next id, @location loc ) id loc 
+ruby_operator_assignment_def.rel: reorder operator_assignment_def.rel ( @operator_assignment id, @underscore_lhs left, int operator, @operator_assignment_right_type right, @location loc ) id left operator right loc 
+ruby_optional_parameter_def.rel: reorder optional_parameter_def.rel ( @optional_parameter id, @token_identifier name, @underscore_arg value, @location loc ) id name value loc 
+ruby_pair_def.rel: reorder pair_def.rel ( @pair id, @pair_key_type key__, @underscore_arg value, @location loc ) id key__ value loc 
+ruby_parenthesized_statements_child.rel: reorder parenthesized_statements_child.rel ( @parenthesized_statements ruby_parenthesized_statements, int index, @parenthesized_statements_child_type child ) ruby_parenthesized_statements index child 
+ruby_parenthesized_statements_def.rel: reorder parenthesized_statements_def.rel ( @parenthesized_statements id, @location loc ) id loc 
+ruby_pattern_def.rel: reorder pattern_def.rel ( @pattern id, @pattern_child_type child, @location loc ) id child loc 
+ruby_program_child.rel: reorder program_child.rel ( @program ruby_program, int index, @program_child_type child ) ruby_program index child 
+ruby_program_def.rel: reorder program_def.rel ( @program id, @location loc ) id loc 
+ruby_range_begin.rel: reorder range_begin.rel ( @range ruby_range, @underscore_arg begin ) ruby_range begin 
+ruby_range_end.rel: reorder range_end.rel ( @range ruby_range, @underscore_arg end ) ruby_range end 
+ruby_range_def.rel: reorder range_def.rel ( @range id, int operator, @location loc ) id operator loc 
+ruby_rational_def.rel: reorder rational_def.rel ( @rational id, @rational_child_type child, @location loc ) id child loc 
+ruby_redo_child.rel: reorder redo_child.rel ( @redo ruby_redo, @argument_list child ) ruby_redo child 
+ruby_redo_def.rel: reorder redo_def.rel ( @redo id, @location loc ) id loc 
+ruby_regex_child.rel: reorder regex_child.rel ( @regex ruby_regex, int index, @regex_child_type child ) ruby_regex index child 
+ruby_regex_def.rel: reorder regex_def.rel ( @regex id, @location loc ) id loc 
+ruby_rescue_body.rel: reorder rescue_body.rel ( @rescue ruby_rescue, @then body ) ruby_rescue body 
+ruby_rescue_exceptions.rel: reorder rescue_exceptions.rel ( @rescue ruby_rescue, @exceptions exceptions ) ruby_rescue exceptions 
+ruby_rescue_variable.rel: reorder rescue_variable.rel ( @rescue ruby_rescue, @exception_variable variable ) ruby_rescue variable 
+ruby_rescue_def.rel: reorder rescue_def.rel ( @rescue id, @location loc ) id loc 
+ruby_rescue_modifier_def.rel: reorder rescue_modifier_def.rel ( @rescue_modifier id, @underscore_statement body, @rescue_modifier_handler_type handler, @location loc ) id body handler loc 
+ruby_rest_assignment_child.rel: reorder rest_assignment_child.rel ( @rest_assignment ruby_rest_assignment, @underscore_lhs child ) ruby_rest_assignment child 
+ruby_rest_assignment_def.rel: reorder rest_assignment_def.rel ( @rest_assignment id, @location loc ) id loc 
+ruby_retry_child.rel: reorder retry_child.rel ( @retry ruby_retry, @argument_list child ) ruby_retry child 
+ruby_retry_def.rel: reorder retry_def.rel ( @retry id, @location loc ) id loc 
+ruby_return_child.rel: reorder return_child.rel ( @return ruby_return, @argument_list child ) ruby_return child 
+ruby_return_def.rel: reorder return_def.rel ( @return id, @location loc ) id loc 
+ruby_right_assignment_list_child.rel: reorder right_assignment_list_child.rel ( @right_assignment_list ruby_right_assignment_list, int index, @right_assignment_list_child_type child ) ruby_right_assignment_list index child 
+ruby_right_assignment_list_def.rel: reorder right_assignment_list_def.rel ( @right_assignment_list id, @location loc ) id loc 
+ruby_scope_resolution_scope.rel: reorder scope_resolution_scope.rel ( @scope_resolution ruby_scope_resolution, @underscore_primary scope ) ruby_scope_resolution scope 
+ruby_scope_resolution_def.rel: reorder scope_resolution_def.rel ( @scope_resolution id, @scope_resolution_name_type name, @location loc ) id name loc 
+ruby_setter_def.rel: reorder setter_def.rel ( @setter id, @token_identifier name, @location loc ) id name loc 
+ruby_singleton_class_child.rel: reorder singleton_class_child.rel ( @singleton_class ruby_singleton_class, int index, @singleton_class_child_type child ) ruby_singleton_class index child 
+ruby_singleton_class_def.rel: reorder singleton_class_def.rel ( @singleton_class id, @underscore_arg value, @location loc ) id value loc 
+ruby_singleton_method_parameters.rel: reorder singleton_method_parameters.rel ( @singleton_method ruby_singleton_method, @method_parameters parameters ) ruby_singleton_method parameters 
+ruby_singleton_method_child.rel: reorder singleton_method_child.rel ( @singleton_method ruby_singleton_method, int index, @singleton_method_child_type child ) ruby_singleton_method index child 
+ruby_singleton_method_def.rel: reorder singleton_method_def.rel ( @singleton_method id, @underscore_method_name name, @singleton_method_object_type object, @location loc ) id name object loc 
+ruby_splat_argument_def.rel: reorder splat_argument_def.rel ( @splat_argument id, @underscore_arg child, @location loc ) id child loc 
+ruby_splat_parameter_name.rel: reorder splat_parameter_name.rel ( @splat_parameter ruby_splat_parameter, @token_identifier name ) ruby_splat_parameter name 
+ruby_splat_parameter_def.rel: reorder splat_parameter_def.rel ( @splat_parameter id, @location loc ) id loc 
+ruby_string_child.rel: reorder string_child.rel ( @string__ ruby_string__, int index, @string_child_type child ) ruby_string__ index child 
+ruby_string_def.rel: reorder string_def.rel ( @string__ id, @location loc ) id loc 
+ruby_string_array_child.rel: reorder string_array_child.rel ( @string_array ruby_string_array, int index, @bare_string child ) ruby_string_array index child 
+ruby_string_array_def.rel: reorder string_array_def.rel ( @string_array id, @location loc ) id loc 
+ruby_subshell_child.rel: reorder subshell_child.rel ( @subshell ruby_subshell, int index, @subshell_child_type child ) ruby_subshell index child 
+ruby_subshell_def.rel: reorder subshell_def.rel ( @subshell id, @location loc ) id loc 
+ruby_superclass_def.rel: reorder superclass_def.rel ( @superclass id, @superclass_child_type child, @location loc ) id child loc 
+ruby_symbol_array_child.rel: reorder symbol_array_child.rel ( @symbol_array ruby_symbol_array, int index, @bare_symbol child ) ruby_symbol_array index child 
+ruby_symbol_array_def.rel: reorder symbol_array_def.rel ( @symbol_array id, @location loc ) id loc 
+ruby_then_child.rel: reorder then_child.rel ( @then ruby_then, int index, @then_child_type child ) ruby_then index child 
+ruby_then_def.rel: reorder then_def.rel ( @then id, @location loc ) id loc 
+ruby_unary_def.rel: reorder unary_def.rel ( @unary id, @unary_operand_type operand, int operator, @location loc ) id operand operator loc 
+ruby_undef_child.rel: reorder undef_child.rel ( @undef ruby_undef, int index, @underscore_method_name child ) ruby_undef index child 
+ruby_undef_def.rel: reorder undef_def.rel ( @undef id, @location loc ) id loc 
+ruby_unless_alternative.rel: reorder unless_alternative.rel ( @unless ruby_unless, @unless_alternative_type alternative ) ruby_unless alternative 
+ruby_unless_consequence.rel: reorder unless_consequence.rel ( @unless ruby_unless, @then consequence ) ruby_unless consequence 
+ruby_unless_def.rel: reorder unless_def.rel ( @unless id, @underscore_statement condition, @location loc ) id condition loc 
+ruby_unless_modifier_def.rel: reorder unless_modifier_def.rel ( @unless_modifier id, @underscore_statement body, @unless_modifier_condition_type condition, @location loc ) id body condition loc 
+ruby_until_def.rel: reorder until_def.rel ( @until id, @do body, @underscore_statement condition, @location loc ) id body condition loc 
+ruby_until_modifier_def.rel: reorder until_modifier_def.rel ( @until_modifier id, @underscore_statement body, @until_modifier_condition_type condition, @location loc ) id body condition loc 
+ruby_when_body.rel: reorder when_body.rel ( @when ruby_when, @then body ) ruby_when body 
+ruby_when_pattern.rel: reorder when_pattern.rel ( @when ruby_when, int index, @pattern pattern ) ruby_when index pattern 
+ruby_when_def.rel: reorder when_def.rel ( @when id, @location loc ) id loc 
+ruby_while_def.rel: reorder while_def.rel ( @while id, @do body, @underscore_statement condition, @location loc ) id body condition loc 
+ruby_while_modifier_def.rel: reorder while_modifier_def.rel ( @while_modifier id, @underscore_statement body, @while_modifier_condition_type condition, @location loc ) id body condition loc 
+ruby_yield_child.rel: reorder yield_child.rel ( @yield ruby_yield, @argument_list child ) ruby_yield child 
+ruby_yield_def.rel: reorder yield_def.rel ( @yield id, @location loc ) id loc 
+ruby_tokeninfo.rel: reorder tokeninfo.rel ( @token id, int kind, @file file, int idx, string value, @location loc ) id kind file idx value loc 
+ruby_ast_node_parent.rel: reorder ast_node_parent.rel ( @ast_node child, @ast_node_parent parent, int parent_index) child parent parent_index
 alias_def.rel: delete
 argument_list_child.rel: delete
 argument_list_def.rel: delete

--- a/ruby/ql/lib/upgrades/b5aef9c93ae64f848017d2dcb760eed916ab0cdd/upgrade.properties
+++ b/ruby/ql/lib/upgrades/b5aef9c93ae64f848017d2dcb760eed916ab0cdd/upgrade.properties
@@ -1,4 +1,4 @@
 description: Removed unused columns from the `*_tokeninfo` relations
 compatibility: full
-ruby_tokeninfo.rel: reorder ruby_tokeninfo.rel (int id, int kind, int file, int idx, string value, int loc) id kind value loc
-erb_tokeninfo.rel: reorder erb_tokeninfo.rel (int id, int kind, int file, int idx, string value, int loc) id kind value loc
+ruby_tokeninfo.rel: reorder ruby_tokeninfo.rel (@ruby_token id, int kind, @file file, int idx, string value, @location loc) id kind value loc
+erb_tokeninfo.rel: reorder erb_tokeninfo.rel (@erb_token id, int kind, @file file, int idx, string value, @location loc) id kind value loc

--- a/ruby/ql/lib/upgrades/f765176af8e0a5128d2adb1ae9c5a6b1c8e7b20b/upgrade.properties
+++ b/ruby/ql/lib/upgrades/f765176af8e0a5128d2adb1ae9c5a6b1c8e7b20b/upgrade.properties
@@ -3,6 +3,6 @@ compatibility: full
 ruby_block_argument_child.rel: run ruby_block_argument_child.qlo
 ruby_block_parameter_name.rel: run ruby_block_parameter_name.qlo
 ruby_pair_value.rel: run ruby_pair_value.qlo
-ruby_block_argument_def.rel: reorder ruby_block_argument_def.rel ( int id, int child, int loc ) id loc
-ruby_block_parameter_def.rel: reorder ruby_block_parameter_def.rel ( int id, int name, int loc ) id loc
-ruby_pair_def.rel: reorder ruby_pair_def.rel (int id, int key__, int value, int loc) id key__ loc
+ruby_block_argument_def.rel: reorder ruby_block_argument_def.rel ( @ruby_block_argument id, @ruby_underscore_arg child, @location loc ) id loc
+ruby_block_parameter_def.rel: reorder ruby_block_parameter_def.rel ( @ruby_block_parameter id, @ruby_token_identifier name, @location loc ) id loc
+ruby_pair_def.rel: reorder ruby_pair_def.rel (@ruby_pair id, @ruby_pair_key_type key__, @ruby_underscore_arg value, @location loc) id key__ loc


### PR DESCRIPTION
This PR changes `reorder` directives in upgrade/downgrade scripts to use proper entity type names, instead of using `int` as generic stand-in for entity types.