### PR TITLE
Swift: Use entities in reorder directives

### DIFF
--- a/swift/downgrades/15d0da3a76b9dbffb921ae6d585f8a8de8945a0b/upgrade.properties
+++ b/swift/downgrades/15d0da3a76b9dbffb921ae6d585f8a8de8945a0b/upgrade.properties
@@ -1,5 +1,5 @@
 description: revert removal of IterableDeclContext
 compatibility: partial
 
-iterable_decl_context_members.rel: reorder decl_members.rel (int id, int index, int member) id index member
+iterable_decl_context_members.rel: reorder decl_members.rel (@decl id, int index, @decl_or_none member) id index member
 decl_members.rel: delete

--- a/swift/downgrades/5559b5a367524777b3f6ef3fc285ae81031ca1da/upgrade.properties
+++ b/swift/downgrades/5559b5a367524777b3f6ef3fc285ae81031ca1da/upgrade.properties
@@ -2,5 +2,5 @@ description: Revert moving getName() from AbstractFunctionDecl to Callable
 compatibility: backwards
 
 // Rename callable_names to abstract_function_decls
-abstract_function_decls.rel: reorder callable_names.rel (int id, string name) id name
+abstract_function_decls.rel: reorder callable_names.rel (@callable id, string name) id name
 callable_names.rel: delete

--- a/swift/downgrades/ba4171b90d0665b40e9e203bac9e3d4a0b2d03ec/upgrade.properties
+++ b/swift/downgrades/ba4171b90d0665b40e9e203bac9e3d4a0b2d03ec/upgrade.properties
@@ -1,56 +1,56 @@
 description: Revert renaming the Function hierarchy
 compatibility: full
 
-abstract_storage_decl_accessor_decls.rel: reorder abstract_storage_decl_accessors (int id, int index, int accessor) id index accessor
+abstract_storage_decl_accessor_decls.rel: reorder abstract_storage_decl_accessors (@abstract_storage_decl id, int index, @accessor_or_none accessor) id index accessor
 abstract_storage_decl_accessors.rel: delete
 
-destructor_decls.rel: reorder deinitializers (int id) id
+destructor_decls.rel: reorder deinitializers (@deinitializer id) id
 deinitializers.rel: delete
 
-constructor_decls.rel: reorder initializers (int id) id
+constructor_decls.rel: reorder initializers (@initializer id) id
 initializers.rel: delete
 
-accessor_decls.rel: reorder accessors (int id) id
+accessor_decls.rel: reorder accessors (@accessor id) id
 accessors.rel: delete
 
-accessor_decl_is_getter.rel: reorder accessor_is_getter (int id) id
+accessor_decl_is_getter.rel: reorder accessor_is_getter (@accessor id) id
 accessor_is_getter.rel: delete
 
-accessor_decl_is_setter.rel: reorder accessor_is_setter (int id) id
+accessor_decl_is_setter.rel: reorder accessor_is_setter (@accessor id) id
 accessor_is_setter.rel: delete
 
-accessor_decl_is_will_set.rel: reorder accessor_is_will_set (int id) id
+accessor_decl_is_will_set.rel: reorder accessor_is_will_set (@accessor id) id
 accessor_is_will_set.rel: delete
 
-accessor_decl_is_did_set.rel: reorder accessor_is_did_set (int id) id
+accessor_decl_is_did_set.rel: reorder accessor_is_did_set (@accessor id) id
 accessor_is_did_set.rel: delete
 
-accessor_decl_is_read.rel: reorder accessor_is_read (int id) id
+accessor_decl_is_read.rel: reorder accessor_is_read (@accessor id) id
 accessor_is_read.rel: delete
 
-accessor_decl_is_modify.rel: reorder accessor_is_modify (int id) id
+accessor_decl_is_modify.rel: reorder accessor_is_modify (@accessor id) id
 accessor_is_modify.rel: delete
 
-accessor_decl_is_unsafe_address.rel: reorder accessor_is_unsafe_address (int id) id
+accessor_decl_is_unsafe_address.rel: reorder accessor_is_unsafe_address (@accessor id) id
 accessor_is_unsafe_address.rel: delete
 
-accessor_decl_is_unsafe_mutable_address.rel: reorder accessor_is_unsafe_mutable_address (int id) id
+accessor_decl_is_unsafe_mutable_address.rel: reorder accessor_is_unsafe_mutable_address (@accessor id) id
 accessor_is_unsafe_mutable_address.rel: delete
 
-concrete_func_decls.rel: reorder named_functions (int id) id
+concrete_func_decls.rel: reorder named_functions (@named_function id) id
 named_functions.rel: delete
 
-lazy_initializer_exprs.rel: reorder lazy_initialization_exprs (int id, int sub_expr) id sub_expr
+lazy_initializer_exprs.rel: reorder lazy_initialization_exprs (@lazy_initialization_expr id, @expr_or_none sub_expr) id sub_expr
 lazy_initialization_exprs.rel: delete
 
-other_constructor_decl_ref_exprs.rel: reorder other_initializer_ref_exprs (int id, int constructor_decl) id constructor_decl
+other_constructor_decl_ref_exprs.rel: reorder other_initializer_ref_exprs (@other_initializer_ref_expr id, @initializer_or_none constructor_decl) id constructor_decl
 other_initializer_ref_exprs.rel: delete
 
-rebind_self_in_constructor_exprs.rel: reorder rebind_self_in_initializer_exprs (int id, int sub_expr, int self) id sub_expr self
+rebind_self_in_constructor_exprs.rel: reorder rebind_self_in_initializer_exprs (@rebind_self_in_initializer_expr id, @expr_or_none sub_expr, @var_decl_or_none self) id sub_expr self
 rebind_self_in_initializer_exprs.rel: delete
 
-closure_exprs.rel: reorder explicit_closure_exprs (int id) id
+closure_exprs.rel: reorder explicit_closure_exprs (@explicit_closure_expr id) id
 explicit_closure_exprs.rel: delete
 
-constructor_ref_call_exprs.rel: reorder initializer_ref_call_exprs (int id) id
+constructor_ref_call_exprs.rel: reorder initializer_ref_call_exprs (@initializer_ref_call_expr id) id
 initializer_ref_call_exprs.rel: delete

--- a/swift/downgrades/f5a22f5168adfd7f308b5941c11852c925edd638/upgrade.properties
+++ b/swift/downgrades/f5a22f5168adfd7f308b5941c11852c925edd638/upgrade.properties
@@ -1,4 +1,4 @@
 description: Undo rename `base_types` to `inherited_types` in `@type_decl
 compatibility: full
-type_decl_base_types.rel: reorder type_decl_inherited_types(int id, int index, int type) id index type
+type_decl_base_types.rel: reorder type_decl_inherited_types(@type_decl id, int index, @type_or_none type) id index type
 type_decl_inherited_types.rel: delete

--- a/swift/downgrades/f6a8ee8a21fb596fa84261ddedb68c00d8457ef4/upgrade.properties
+++ b/swift/downgrades/f6a8ee8a21fb596fa84261ddedb68c00d8457ef4/upgrade.properties
@@ -1,3 +1,3 @@
 description: Revert adding full extraction of regex literal expressions
 compatibility: full
-regex_literal_exprs.rel: reorder regex_literal_exprs.rel (int id, string pattern, int version) id
+regex_literal_exprs.rel: reorder regex_literal_exprs.rel (@regex_literal_expr id, string pattern, int version) id

--- a/swift/ql/lib/upgrades/147e087e57e51b2eb41e75c9c97380d0e6c20ecb/upgrade.properties
+++ b/swift/ql/lib/upgrades/147e087e57e51b2eb41e75c9c97380d0e6c20ecb/upgrade.properties
@@ -1,4 +1,4 @@
 description: Rename `base_types` to `inherited_types` in `@type_decl
 compatibility: full
-type_decl_inherited_types.rel: reorder type_decl_base_types(int id, int index, int type) id index type
+type_decl_inherited_types.rel: reorder type_decl_base_types(@type_decl id, int index, @type_or_none type) id index type
 type_decl_base_types.rel: delete

--- a/swift/ql/lib/upgrades/62fc609c1ab6ae748ff51362ffa5c368ba834ddf/upgrade.properties
+++ b/swift/ql/lib/upgrades/62fc609c1ab6ae748ff51362ffa5c368ba834ddf/upgrade.properties
@@ -2,5 +2,5 @@ description: Move getName() from AbstractFunctionDecl to Callable
 compatibility: full
 
 // Rename abstract_function_decls to callable_names
-callable_names.rel: reorder abstract_function_decls.rel (int id, string name) id name
+callable_names.rel: reorder abstract_function_decls.rel (@abstract_function_decl id, string name) id name
 abstract_function_decls.rel: delete

--- a/swift/ql/lib/upgrades/98a78b66651ad4eb35a8edf1642767c794909ea4/upgrade.properties
+++ b/swift/ql/lib/upgrades/98a78b66651ad4eb35a8edf1642767c794909ea4/upgrade.properties
@@ -1,5 +1,5 @@
 description: remove IterableDeclContext
 compatibility: full
 
-decl_members.rel: reorder iterable_decl_context_members.rel (int id, int index, int member) id index member
+decl_members.rel: reorder iterable_decl_context_members.rel (@iterable_decl_context id, int index, @decl_or_none member) id index member
 iterable_decl_context_members.rel: delete

--- a/swift/ql/lib/upgrades/e646f9e0308ec7135c83c0fdf96896d2737a8013/upgrade.properties
+++ b/swift/ql/lib/upgrades/e646f9e0308ec7135c83c0fdf96896d2737a8013/upgrade.properties
@@ -1,4 +1,4 @@
 description: Turn exported and imported modules into unindexed sets
 compatibility: full
-module_decl_imported_modules.rel: reorder module_decl_imported_modules(int id, int index, int imported) id imported
-module_decl_exported_modules.rel: reorder module_decl_exported_modules(int id, int index, int exported) id exported
+module_decl_imported_modules.rel: reorder module_decl_imported_modules(@module_decl id, int index, @module_decl_or_none imported) id imported
+module_decl_exported_modules.rel: reorder module_decl_exported_modules(@module_decl id, int index, @module_decl_or_none exported) id exported

--- a/swift/ql/lib/upgrades/f937d9e63094280b7ec0ef26c70310daad5c1f79/upgrade.properties
+++ b/swift/ql/lib/upgrades/f937d9e63094280b7ec0ef26c70310daad5c1f79/upgrade.properties
@@ -1,56 +1,56 @@
 description: rename the Function hierarchy
 compatibility: full
 
-abstract_storage_decl_accessors.rel: reorder abstract_storage_decl_accessor_decls (int id, int index, int accessor_decl) id index accessor_decl
+abstract_storage_decl_accessors.rel: reorder abstract_storage_decl_accessor_decls (@abstract_storage_decl id, int index, @accessor_decl_or_none accessor_decl) id index accessor_decl
 abstract_storage_decl_accessor_decls.rel: delete
 
-deinitializers.rel: reorder destructor_decls (int id) id
+deinitializers.rel: reorder destructor_decls (@destructor_decl id) id
 destructor_decls.rel: delete
 
-initializers.rel: reorder constructor_decls (int id) id
+initializers.rel: reorder constructor_decls (@constructor_decl id) id
 constructor_decls.rel: delete
 
-accessors.rel: reorder accessor_decls (int id) id
+accessors.rel: reorder accessor_decls (@accessor_decl id) id
 accessor_decls.rel: delete
 
-accessor_is_getter.rel: reorder accessor_decl_is_getter (int id) id
+accessor_is_getter.rel: reorder accessor_decl_is_getter (@accessor_decl id) id
 accessor_decl_is_getter.rel: delete
 
-accessor_is_setter.rel: reorder accessor_decl_is_setter (int id) id
+accessor_is_setter.rel: reorder accessor_decl_is_setter (@accessor_decl id) id
 accessor_decl_is_setter.rel: delete
 
-accessor_is_will_set.rel: reorder accessor_decl_is_will_set (int id) id
+accessor_is_will_set.rel: reorder accessor_decl_is_will_set (@accessor_decl id) id
 accessor_decl_is_will_set.rel: delete
 
-accessor_is_did_set.rel: reorder accessor_decl_is_did_set (int id) id
+accessor_is_did_set.rel: reorder accessor_decl_is_did_set (@accessor_decl id) id
 accessor_decl_is_did_set.rel: delete
 
-accessor_is_read.rel: reorder accessor_decl_is_read (int id) id
+accessor_is_read.rel: reorder accessor_decl_is_read (@accessor_decl id) id
 accessor_decl_is_read.rel: delete
 
-accessor_is_modify.rel: reorder accessor_decl_is_modify (int id) id
+accessor_is_modify.rel: reorder accessor_decl_is_modify (@accessor_decl id) id
 accessor_decl_is_modify.rel: delete
 
-accessor_is_unsafe_address.rel: reorder accessor_decl_is_unsafe_address (int id) id
+accessor_is_unsafe_address.rel: reorder accessor_decl_is_unsafe_address (@accessor_decl id) id
 accessor_decl_is_unsafe_address.rel: delete
 
-accessor_is_unsafe_mutable_address.rel: reorder accessor_decl_is_unsafe_mutable_address (int id) id
+accessor_is_unsafe_mutable_address.rel: reorder accessor_decl_is_unsafe_mutable_address (@accessor_decl id) id
 accessor_decl_is_unsafe_mutable_address.rel: delete
 
-named_functions.rel: reorder concrete_func_decls (int id) id
+named_functions.rel: reorder concrete_func_decls (@concrete_func_decl id) id
 concrete_func_decls.rel: delete
 
-lazy_initialization_exprs.rel: reorder lazy_initializer_exprs (int id, int sub_expr) id sub_expr
+lazy_initialization_exprs.rel: reorder lazy_initializer_exprs (@lazy_initializer_expr id, @expr_or_none sub_expr) id sub_expr
 lazy_initializer_exprs.rel: delete
 
-other_initializer_ref_exprs.rel: reorder other_constructor_decl_ref_exprs (int id, int constructor_decl) id constructor_decl
+other_initializer_ref_exprs.rel: reorder other_constructor_decl_ref_exprs (@other_constructor_decl_ref_expr id, @constructor_decl_or_none constructor_decl) id constructor_decl
 other_constructor_decl_ref_exprs.rel: delete
 
-rebind_self_in_initializer_exprs.rel: reorder rebind_self_in_constructor_exprs (int id, int sub_expr, int self) id sub_expr self
+rebind_self_in_initializer_exprs.rel: reorder rebind_self_in_constructor_exprs (@rebind_self_in_constructor_expr id, @expr_or_none sub_expr, @var_decl_or_none self) id sub_expr self
 rebind_self_in_constructor_exprs.rel: delete
 
-explicit_closure_exprs.rel: reorder closure_exprs (int id) id
+explicit_closure_exprs.rel: reorder closure_exprs (@closure_expr id) id
 closure_exprs.rel: delete
 
-initializer_ref_call_exprs.rel: reorder constructor_ref_call_exprs (int id) id
+initializer_ref_call_exprs.rel: reorder constructor_ref_call_exprs (@constructor_ref_call_expr id) id
 constructor_ref_call_exprs.rel: delete


### PR DESCRIPTION
This PR changes `reorder` directives in upgrade/downgrade scripts to use proper entity type names, instead of using `int` as generic stand-in for entity types.