### PR TITLE
Remove dev_dependency from `buildifier_prebuilt`.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,8 +21,7 @@ bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "abseil-cpp", version = "20240116.0", repo_name = "absl")
 bazel_dep(name = "nlohmann_json", version = "3.11.3", repo_name = "json")
 bazel_dep(name = "fmt", version = "10.0.0")
-
-bazel_dep(name = "buildifier_prebuilt", version = "6.4.0", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "6.4.0")
 
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(


### PR DESCRIPTION
Otherwise, including any targets from //:BUILD.bazel in something that gets invoked from the internal build system will result in a missing dependency error.
This is relevant for C#, where I add a file export to `LICENSE` to the top-level `BUILD.bazel` file.