### PR TITLE
Tree-sitter: Extract non-whitespace tokens between sibling nodes

### DIFF
--- a/shared/tree-sitter-extractor/Cargo.toml
+++ b/shared/tree-sitter-extractor/Cargo.toml
@@ -19,6 +19,6 @@ chrono = { version = "0.4.19", features = ["serde"] }
 num_cpus = "1.14.0"
 
 [dev-dependencies]
-tree-sitter-ql = { git = "https://github.com/tree-sitter/tree-sitter-ql" }
-tree-sitter-json = {git = "https://github.com/tausbn/tree-sitter-json" }
+tree-sitter-ql = { git = "https://github.com/tree-sitter/tree-sitter-ql.git", rev = "d08db734f8dc52f6bc04db53a966603122bc6985"}
+tree-sitter-json = {git = "https://github.com/tausbn/tree-sitter-json.git", rev = "745663ee997f1576fe1e7187e6347e0db36ec7a9"}
 rand = "0.8.5"


### PR DESCRIPTION
[This](https://github.com/tree-sitter/tree-sitter-c-sharp/pull/333/files#diff-919ac210accac9ecc55a76d10a7590e3d85ca3f0e165b52d30f08faee486d0cbR1736-R1740) change to the C# tree-sitter grammar means that for non-escaped character literals, such as `'c'`, we would not extract the character content `c`. This PR tries to solve the underlying issue in general, by always extracting "extra" non-whitespace tokens that sit in between two other nodes. I have verified that with this change, we are able to extract character literals correctly.

A similar situation happens for the [JSON Tree-sitter grammar](https://github.com/tree-sitter/tree-sitter-json/blob/master/grammar.js#L55-L58).