### PR TITLE
Bazel: move buildifier out of root `BUILD`

### DIFF
--- a/.github/workflows/buildifier.yml
+++ b/.github/workflows/buildifier.yml
@@ -24,5 +24,5 @@ jobs:
           extra_args: >
             buildifier --all-files 2>&1 ||
             (
-              echo -e "In order to format all bazel files, please run:\n  bazel run //:buildifier"; exit 1
+              echo -e "In order to format all bazel files, please run:\n  bazel run //misc/bazel:buildifier"; exit 1
             )

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
         name: Format bazel files
         files: \.(bazel|bzl)
         language: system
-        entry: bazel run //:buildifier
+        entry: bazel run //misc/bazel:buildifier
         pass_filenames: false
 
       - id: codeql-format

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,9 +1,0 @@
-load("@buildifier_prebuilt//:rules.bzl", "buildifier")
-
-buildifier(
-    name = "buildifier",
-    exclude_patterns = [
-        "./.git/*",
-    ],
-    lint_mode = "fix",
-)

--- a/misc/bazel/BUILD.bazel
+++ b/misc/bazel/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@buildifier_prebuilt//:rules.bzl", "buildifier")
+
+buildifier(
+    name = "buildifier",
+    exclude_patterns = [
+        "./.git/*",
+    ],
+    lint_mode = "fix",
+)


### PR DESCRIPTION
See https://github.com/github/codeql/pull/16428 for details as to why this is necessary.