### PR TITLE
C++: Fix location of SSA def for local variable addresses

### DIFF
--- a/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/IteratorToExpiredContainer/IteratorToExpiredContainer.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/IteratorToExpiredContainer/IteratorToExpiredContainer.expected
@@ -1,7 +1,5 @@
 | test.cpp:680:30:680:30 | call to operator[] | This object is destroyed at the end of the full-expression. |
 | test.cpp:683:31:683:32 | call to at | This object is destroyed at the end of the full-expression. |
-| test.cpp:689:46:689:58 | pointer to ~vector output argument | This object is destroyed at the end of the full-expression. |
 | test.cpp:702:27:702:27 | call to operator[] | This object is destroyed at the end of the full-expression. |
 | test.cpp:727:23:727:23 | call to operator[] | This object is destroyed at the end of the full-expression. |
 | test.cpp:735:23:735:23 | call to operator[] | This object is destroyed at the end of the full-expression. |
-| test.cpp:803:3:803:3 | pointer to ~vector output argument | This object is destroyed at the end of the full-expression. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/IteratorToExpiredContainer/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/IteratorToExpiredContainer/test.cpp
@@ -686,7 +686,7 @@ void test() {
   for (auto x : returnRef()[0]) {} // GOOD
   for (auto x : returnRef().at(0)) {} // GOOD
 
-  for(auto it = returnValue().begin(); it != returnValue().end(); ++it) {} // BAD
+  for(auto it = returnValue().begin(); it != returnValue().end(); ++it) {} // BAD [NOT DETECTED]
 
   {
   auto v = returnValue();
@@ -800,5 +800,5 @@ void test5(int i)
     const auto& vvs = returnValue();
     for(const auto& vs : vvs) { }
     ++i;
-  } // GOOD [FALSE POSITIVE]
+  } // GOOD
 }


### PR DESCRIPTION
The motivation for this PR is the FP added in https://github.com/github/codeql/pull/16416.

Consider the FP added in that PR:
```cpp
void test5(int i)
{
  while(i < 10) {
    const auto& vvs = returnValue();
    for(const auto& vs : vvs) { }
    ++i;
  }
}
```
When the prvalue `returnValue()` is bound to the const reference `vvs` a temporary is created. That temporary has two important properties: the value of the temporary and the value of the _address_ of the temporary. Both of these have SSA definitions. However, the SSA definition for the value of the address of the temporary was placed at the entry of the function (see [this PR](https://github.com/github/codeql/pull/15047) for when this was added). Which meant that dataflow saw the code as:
```cpp
void test5(int i)
{
  &#temp = ... // i.e., the temporary's address was given a value up here
  while(i < 10) {
    const auto& vvs = returnValue();
    for(const auto& vs : vvs) { }
    ++i;
  }
}
```
so the temporary wasn't properly "scoped", and the value of the address of the temporary wasn't overwritten between each iteration of the loop (and thus we'd get a phi node for the temporary at the loop header). That meant that we got a FP on the query because we saw:
- Flow from the temporary to the destructor qualifier
- Flow from the destructor qualifier to a phi node at the loop header
- Flow from the phi to the call to `vvs.begin()`

After this PR, the SSA definition of the temporary is inside the loop. This means the phi node disappears and the FP disappears since the value of the temporary (and its address) is completely redefined at the loop header.

This PR also makes us lose a TP in our tests:
```cpp
for(auto it = returnValue().begin(); ...; ...) {}
```
and we actually got this one for the same reason as we're getting the FP above: the query looks for flow of the form temporary `->` destructor call qualifier `->` begin call qualifier. But in the above we actually have temporary -> begin call qualifier `->` destructor call qualifier. So that test is actually slightly out of scope for the current query.

DCA actually looks like a small performance improvement. Maybe because we have a join somewhere that computes the set of all variables defined at a given location, and this PR removes the large fan-out that occurs at the entry point for the address of variables? I don't intend to investigate this further, but it's a nice bonus!