### PR TITLE
misc: Fix docstring warning

### DIFF
--- a/misc/scripts/accept-expected-changes-from-ci.py
+++ b/misc/scripts/accept-expected-changes-from-ci.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""
+r"""
 This script can be used to go over `codeql test run` expected/actual log output from
 github actions, and apply patches locally to make the tests pass.
 


### PR DESCRIPTION
When using a sufficiently new version of Python, it will give a warning
about the escape sequence `\_` in `¯\_(ツ)_/¯` not being a valid escape :D fix is to make the docstring a raw string.

Thanks @owen-mc