### PR TITLE
Go: Use `toolchain` directives for version selection if available, and add tests

### DIFF
--- a/go/extractor/autobuilder/BUILD.bazel
+++ b/go/extractor/autobuilder/BUILD.bazel
@@ -23,4 +23,5 @@ go_test(
     name = "autobuilder_test",
     srcs = ["build-environment_test.go"],
     embed = [":autobuilder"],
+    deps = ["//go/extractor/util"],
 )

--- a/go/extractor/autobuilder/build-environment_test.go
+++ b/go/extractor/autobuilder/build-environment_test.go
@@ -1,6 +1,10 @@
 package autobuilder
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/github/codeql-go/extractor/util"
+)
 
 func TestGetVersionToInstall(t *testing.T) {
 	tests := map[versionInfo]string{
@@ -41,6 +45,18 @@ func TestGetVersionToInstall(t *testing.T) {
 	}
 	for input, expected := range tests {
 		_, actual := getVersionToInstall(input)
+		if actual != expected {
+			t.Errorf("Expected getVersionToInstall(\"%s\") to be \"%s\", but got \"%s\".", input, expected, actual)
+		}
+
+		if input.goEnvVersionFound {
+			input.goEnvVersion = util.FormatSemVer(input.goEnvVersion)
+		}
+		if input.goEnvVersionFound {
+			input.goModVersion = util.FormatSemVer(input.goModVersion)
+		}
+
+		_, actual = getVersionToInstall(input)
 		if actual != expected {
 			t.Errorf("Expected getVersionToInstall(\"%s\") to be \"%s\", but got \"%s\".", input, expected, actual)
 		}

--- a/go/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/go/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -537,12 +537,12 @@ func installDependenciesAndBuild() {
 
 	// This diagnostic is not required if the system Go version is 1.21 or greater, since the
 	// Go tooling should install required Go versions as needed.
-	if semver.Compare(toolchain.GetEnvGoSemVer(), "v1.21.0") < 0 && greatestGoVersion.Found && semver.Compare("v"+greatestGoVersion.Version, toolchain.GetEnvGoSemVer()) > 0 {
-		diagnostics.EmitNewerGoVersionNeeded(toolchain.GetEnvGoSemVer(), "v"+greatestGoVersion.Version)
+	if semver.Compare(toolchain.GetEnvGoSemVer(), "v1.21.0") < 0 && greatestGoVersion.Found && semver.Compare(greatestGoVersion.Version, toolchain.GetEnvGoSemVer()) > 0 {
+		diagnostics.EmitNewerGoVersionNeeded(toolchain.GetEnvGoSemVer(), greatestGoVersion.Version)
 		if val, _ := os.LookupEnv("GITHUB_ACTIONS"); val == "true" {
 			log.Printf(
 				"A go.mod file requires version %s of Go, but version %s is installed. Consider adding an actions/setup-go step to your workflow.\n",
-				"v"+greatestGoVersion.Version,
+				greatestGoVersion.Version,
 				toolchain.GetEnvGoSemVer())
 		}
 	}

--- a/go/extractor/project/project.go
+++ b/go/extractor/project/project.go
@@ -77,13 +77,8 @@ var VersionNotFound GoVersionInfo = GoVersionInfo{"", false}
 
 // Constructs a `GoVersionInfo` for a version we found.
 func VersionFound(version string) GoVersionInfo {
-	// Add the "v" required by `semver` if there isn't one yet.
-	if !strings.HasPrefix(version, "v") {
-		version = "v" + version
-	}
-
 	return GoVersionInfo{
-		Version: version,
+		Version: util.FormatSemVer(version),
 		Found:   true,
 	}
 }

--- a/go/extractor/project/project.go
+++ b/go/extractor/project/project.go
@@ -43,7 +43,7 @@ func (module *GoModule) RequiredGoVersion() GoVersionInfo {
 		return VersionFound(toolchain.ToolchainVersionToSemVer(module.Module.Toolchain.Name))
 	}
 	if module.Module != nil && module.Module.Go != nil {
-		return VersionFound(module.Module.Go.Version)
+		return VersionFound(toolchain.GoVersionToSemVer(module.Module.Go.Version))
 	} else {
 		return tryReadGoDirective(module.Path)
 	}
@@ -96,7 +96,7 @@ func (workspace *GoWorkspace) RequiredGoVersion() GoVersionInfo {
 	if workspace.WorkspaceFile != nil && workspace.WorkspaceFile.Toolchain != nil {
 		return VersionFound(toolchain.ToolchainVersionToSemVer(workspace.WorkspaceFile.Toolchain.Name))
 	} else if workspace.WorkspaceFile != nil && workspace.WorkspaceFile.Go != nil {
-		return VersionFound(workspace.WorkspaceFile.Go.Version)
+		return VersionFound(toolchain.GoVersionToSemVer(workspace.WorkspaceFile.Go.Version))
 	} else if workspace.Modules != nil && len(workspace.Modules) > 0 {
 		// Otherwise, if we have `go.work` files, find the greatest Go version in those.
 		var greatestVersion string = ""
@@ -611,7 +611,7 @@ func tryReadGoDirective(path string) GoVersionInfo {
 		matches := versionRe.FindSubmatch(goMod)
 		if matches != nil {
 			if len(matches) > 1 {
-				return VersionFound(string(matches[1]))
+				return VersionFound(toolchain.GoVersionToSemVer(string(matches[1])))
 			}
 		}
 	}

--- a/go/extractor/project/project.go
+++ b/go/extractor/project/project.go
@@ -60,11 +60,15 @@ type GoWorkspace struct {
 	Extracted     bool                    // A value indicating whether this workspace was extracted successfully
 }
 
-// Represents a nullable version string.
+// Represents a nullable version string. Use `VersionNotFound` and `VersionFound`
+// instead of constructing values of this type directly.
 type GoVersionInfo struct {
-	// The version string, if any
+	// The semantic version string, such as "v1.20.0-rc1", if any.
+	// This is a valid semantic version if `Found` is `true` or the empty string if not.
 	Version string
-	// A value indicating whether a version string was found
+	// A value indicating whether a version string was found.
+	// If this value is `true`, then `Version` is a valid semantic version.
+	// IF this value is `false`, then `Version` is the empty string.
 	Found bool
 }
 

--- a/go/extractor/project/project.go
+++ b/go/extractor/project/project.go
@@ -39,6 +39,9 @@ type GoModule struct {
 
 // Tries to find the Go toolchain version required for this module.
 func (module *GoModule) RequiredGoVersion() GoVersionInfo {
+	if module.Module != nil && module.Module.Toolchain != nil {
+		return VersionFound(toolchain.ToolchainVersionToSemVer(module.Module.Toolchain.Name))
+	}
 	if module.Module != nil && module.Module.Go != nil {
 		return VersionFound(module.Module.Go.Version)
 	} else {

--- a/go/extractor/project/project.go
+++ b/go/extractor/project/project.go
@@ -122,7 +122,7 @@ func RequiredGoVersion(workspaces *[]GoWorkspace) GoVersionInfo {
 	greatestGoVersion := VersionNotFound
 	for _, workspace := range *workspaces {
 		goVersionInfo := workspace.RequiredGoVersion()
-		if goVersionInfo.Found && (!greatestGoVersion.Found || semver.Compare("v"+goVersionInfo.Version, "v"+greatestGoVersion.Version) > 0) {
+		if goVersionInfo.Found && (!greatestGoVersion.Found || semver.Compare(util.FormatSemVer(goVersionInfo.Version), util.FormatSemVer(greatestGoVersion.Version)) > 0) {
 			greatestGoVersion = goVersionInfo
 		}
 	}

--- a/go/extractor/project/project.go
+++ b/go/extractor/project/project.go
@@ -60,8 +60,17 @@ type GoVersionInfo struct {
 // 1. The Go version specified in the `go.work` file, if any.
 // 2. The greatest Go version specified in any `go.mod` file, if any.
 func (workspace *GoWorkspace) RequiredGoVersion() GoVersionInfo {
-	if workspace.WorkspaceFile != nil && workspace.WorkspaceFile.Go != nil {
-		// If we have parsed a `go.work` file, return the version number from it.
+	// If we have parsed a `go.work` file, we prioritise versions from it over those in individual `go.mod`
+	// files. We are interested in toolchain versions, so if there is an explicit toolchain declaration in
+	// a `go.work` file, we use that. Otherwise, we fall back to the language version in the `go.work` file
+	// and use that as toolchain version. If we didn't parse a `go.work` file, then we try to find the
+	// greatest version contained in `go.mod` files.
+	if workspace.WorkspaceFile != nil && workspace.WorkspaceFile.Toolchain != nil {
+		return GoVersionInfo{
+			Version: toolchain.ToolchainVersionToSemVer(workspace.WorkspaceFile.Toolchain.Name),
+			Found:   true,
+		}
+	} else if workspace.WorkspaceFile != nil && workspace.WorkspaceFile.Go != nil {
 		return GoVersionInfo{Version: workspace.WorkspaceFile.Go.Version, Found: true}
 	} else if workspace.Modules != nil && len(workspace.Modules) > 0 {
 		// Otherwise, if we have `go.work` files, find the greatest Go version in those.

--- a/go/extractor/project/project_test.go
+++ b/go/extractor/project/project_test.go
@@ -28,14 +28,18 @@ func TestStartsWithAnyOf(t *testing.T) {
 	testStartsWithAnyOf(t, filepath.Join("foo", "bar"), filepath.Join("foo", "baz"), false)
 }
 
-func testHasInvalidToolchainVersion(t *testing.T, contents string) bool {
-	modFile, err := modfile.Parse("test.go", []byte(contents), nil)
+func parseModFile(t *testing.T, contents string) *modfile.File {
+	modFile, err := modfile.Parse("go.mod", []byte(contents), nil)
 
 	if err != nil {
 		t.Errorf("Unable to parse %s: %s.\n", contents, err.Error())
 	}
 
-	return hasInvalidToolchainVersion(modFile)
+	return modFile
+}
+
+func testHasInvalidToolchainVersion(t *testing.T, contents string) bool {
+	return hasInvalidToolchainVersion(parseModFile(t, contents))
 }
 
 func TestHasInvalidToolchainVersion(t *testing.T) {
@@ -61,4 +65,75 @@ func TestHasInvalidToolchainVersion(t *testing.T) {
 			t.Errorf("Expected testHasInvalidToolchainVersion(\"%s\") to be false, but got true", v)
 		}
 	}
+}
+
+func parseWorkFile(t *testing.T, contents string) *modfile.WorkFile {
+	workFile, err := modfile.ParseWork("go.work", []byte(contents), nil)
+
+	if err != nil {
+		t.Errorf("Unable to parse %s: %s.\n", contents, err.Error())
+	}
+
+	return workFile
+}
+
+func TestRequiredGoVersion(t *testing.T) {
+	type ModVersionPair struct {
+		FileContents    string
+		ExpectedVersion string
+	}
+
+	modules := []ModVersionPair{
+		{"go 1.20", "v1.20.0"},
+		{"go 1.21.2", "v1.21.2"},
+		{"go 1.21rc1", "v1.21.0-rc1"},
+		{"go 1.21rc1\ntoolchain go1.22.0", "v1.22.0"},
+		{"go 1.21rc1\ntoolchain go1.22rc1", "v1.22.0-rc1"},
+	}
+
+	for _, testData := range modules {
+		// `go.mod` and `go.work` files have mostly the same format
+		modFile := parseModFile(t, testData.FileContents)
+		workFile := parseWorkFile(t, testData.FileContents)
+		mod := GoModule{
+			Path:   "test", // irrelevant
+			Module: modFile,
+		}
+		work := GoWorkspace{
+			WorkspaceFile: workFile,
+		}
+
+		result := mod.RequiredGoVersion()
+		if !result.Found {
+			t.Errorf(
+				"Expected mod.RequiredGoVersion() to return %s for the below `go.mod` file, but got nothing:\n%s",
+				testData.ExpectedVersion,
+				testData.FileContents,
+			)
+		} else if result.Version != testData.ExpectedVersion {
+			t.Errorf(
+				"Expected mod.RequiredGoVersion() to return %s for the below `go.mod` file, but got %s:\n%s",
+				testData.ExpectedVersion,
+				result.Version,
+				testData.FileContents,
+			)
+		}
+
+		result = work.RequiredGoVersion()
+		if !result.Found {
+			t.Errorf(
+				"Expected mod.RequiredGoVersion() to return %s for the below `go.work` file, but got nothing:\n%s",
+				testData.ExpectedVersion,
+				testData.FileContents,
+			)
+		} else if result.Version != testData.ExpectedVersion {
+			t.Errorf(
+				"Expected mod.RequiredGoVersion() to return %s for the below `go.work` file, but got %s:\n%s",
+				testData.ExpectedVersion,
+				result.Version,
+				testData.FileContents,
+			)
+		}
+	}
+
 }

--- a/go/extractor/project/project_test.go
+++ b/go/extractor/project/project_test.go
@@ -77,13 +77,34 @@ func parseWorkFile(t *testing.T, contents string) *modfile.WorkFile {
 	return workFile
 }
 
-func TestRequiredGoVersion(t *testing.T) {
-	type ModVersionPair struct {
-		FileContents    string
-		ExpectedVersion string
-	}
+type FileVersionPair struct {
+	FileContents    string
+	ExpectedVersion string
+}
 
-	modules := []ModVersionPair{
+func checkRequiredGoVersionResult(t *testing.T, fun string, file string, testData FileVersionPair, result GoVersionInfo) {
+	if !result.Found {
+		t.Errorf(
+			"Expected %s to return %s for the below `%s` file, but got nothing:\n%s",
+			fun,
+			testData.ExpectedVersion,
+			file,
+			testData.FileContents,
+		)
+	} else if result.Version != testData.ExpectedVersion {
+		t.Errorf(
+			"Expected %s to return %s for the below `%s` file, but got %s:\n%s",
+			fun,
+			testData.ExpectedVersion,
+			file,
+			result.Version,
+			testData.FileContents,
+		)
+	}
+}
+
+func TestRequiredGoVersion(t *testing.T) {
+	testFiles := []FileVersionPair{
 		{"go 1.20", "v1.20.0"},
 		{"go 1.21.2", "v1.21.2"},
 		{"go 1.21rc1", "v1.21.0-rc1"},
@@ -91,49 +112,67 @@ func TestRequiredGoVersion(t *testing.T) {
 		{"go 1.21rc1\ntoolchain go1.22rc1", "v1.22.0-rc1"},
 	}
 
-	for _, testData := range modules {
+	var modules []*GoModule = []*GoModule{}
+
+	for _, testData := range testFiles {
 		// `go.mod` and `go.work` files have mostly the same format
 		modFile := parseModFile(t, testData.FileContents)
 		workFile := parseWorkFile(t, testData.FileContents)
-		mod := GoModule{
+		mod := &GoModule{
 			Path:   "test", // irrelevant
 			Module: modFile,
 		}
-		work := GoWorkspace{
+		work := &GoWorkspace{
 			WorkspaceFile: workFile,
 		}
 
 		result := mod.RequiredGoVersion()
-		if !result.Found {
-			t.Errorf(
-				"Expected mod.RequiredGoVersion() to return %s for the below `go.mod` file, but got nothing:\n%s",
-				testData.ExpectedVersion,
-				testData.FileContents,
-			)
-		} else if result.Version != testData.ExpectedVersion {
-			t.Errorf(
-				"Expected mod.RequiredGoVersion() to return %s for the below `go.mod` file, but got %s:\n%s",
-				testData.ExpectedVersion,
-				result.Version,
-				testData.FileContents,
-			)
-		}
+		checkRequiredGoVersionResult(t, "mod.RequiredGoVersion()", "go.mod", testData, result)
 
 		result = work.RequiredGoVersion()
-		if !result.Found {
-			t.Errorf(
-				"Expected mod.RequiredGoVersion() to return %s for the below `go.work` file, but got nothing:\n%s",
-				testData.ExpectedVersion,
-				testData.FileContents,
-			)
-		} else if result.Version != testData.ExpectedVersion {
-			t.Errorf(
-				"Expected mod.RequiredGoVersion() to return %s for the below `go.work` file, but got %s:\n%s",
-				testData.ExpectedVersion,
-				result.Version,
-				testData.FileContents,
-			)
-		}
+		checkRequiredGoVersionResult(t, "work.RequiredGoVersion()", "go.work", testData, result)
+
+		modules = append(modules, mod)
 	}
 
+	// Create a test workspace with all the modules in one workspace.
+	workspace := GoWorkspace{
+		Modules: modules,
+	}
+	workspaceVer := "v1.22.0"
+
+	result := RequiredGoVersion(&[]GoWorkspace{workspace})
+	if !result.Found {
+		t.Errorf(
+			"Expected RequiredGoVersion to return %s, but got nothing.",
+			workspaceVer,
+		)
+	} else if result.Version != workspaceVer {
+		t.Errorf(
+			"Expected RequiredGoVersion to return %s, but got %s.",
+			workspaceVer,
+			result.Version,
+		)
+	}
+
+	// Create test workspaces for each module.
+	workspaces := []GoWorkspace{}
+
+	for _, mod := range modules {
+		workspaces = append(workspaces, GoWorkspace{Modules: []*GoModule{mod}})
+	}
+
+	result = RequiredGoVersion(&workspaces)
+	if !result.Found {
+		t.Errorf(
+			"Expected RequiredGoVersion to return %s, but got nothing.",
+			workspaceVer,
+		)
+	} else if result.Version != workspaceVer {
+		t.Errorf(
+			"Expected RequiredGoVersion to return %s, but got %s.",
+			workspaceVer,
+			result.Version,
+		)
+	}
 }

--- a/go/extractor/toolchain/BUILD.bazel
+++ b/go/extractor/toolchain/BUILD.bazel
@@ -17,4 +17,5 @@ go_test(
     name = "toolchain_test",
     srcs = ["toolchain_test.go"],
     embed = [":toolchain"],
+    deps = ["//go/extractor/util"],
 )

--- a/go/extractor/toolchain/toolchain.go
+++ b/go/extractor/toolchain/toolchain.go
@@ -104,7 +104,8 @@ func InstallVersion(workingDir string, version string) bool {
 	return true
 }
 
-// Converts a Go version to a semantic version.
+// Converts a Go version to a semantic version. For example, "1.20" becomes "v1.20" and
+// "1.22rc1" becomes "v1.22.0-rc1".
 func GoVersionToSemVer(goVersion string) string {
 	// Go versions don't follow the SemVer format, but the only exception we normally care about
 	// is release candidates; so this is a horrible hack to convert e.g. `1.22rc1` into `1.22-rc1`
@@ -117,7 +118,8 @@ func GoVersionToSemVer(goVersion string) string {
 	}
 }
 
-// Converts a Go toolchain version of the form "go1.2.3" to a semantic version.
+// Converts a Go toolchain version to a semantic version. For example, "go1.2.3" becomes "v1.2.3"
+// and "go1.20rc1" becomes "v1.20.0-rc1".
 func ToolchainVersionToSemVer(toolchainVersion string) string {
 	if !strings.HasPrefix(toolchainVersion, "go") {
 		log.Fatalf("Expected Go toolchain version of the form 'go1.2.3'; got '%s'", toolchainVersion)

--- a/go/extractor/toolchain/toolchain.go
+++ b/go/extractor/toolchain/toolchain.go
@@ -104,21 +104,26 @@ func InstallVersion(workingDir string, version string) bool {
 	return true
 }
 
+// Converts a Go version to a semantic version.
+func GoVersionToSemVer(goVersion string) string {
+	// Go versions don't follow the SemVer format, but the only exception we normally care about
+	// is release candidates; so this is a horrible hack to convert e.g. `1.22rc1` into `1.22-rc1`
+	// which is compatible with the SemVer specification
+	rcIndex := strings.Index(goVersion, "rc")
+	if rcIndex != -1 {
+		return semver.Canonical("v"+goVersion[:rcIndex]) + "-" + goVersion[rcIndex:]
+	} else {
+		return semver.Canonical("v" + goVersion)
+	}
+}
+
 // Converts a Go toolchain version of the form "go1.2.3" to a semantic version.
 func ToolchainVersionToSemVer(toolchainVersion string) string {
 	if !strings.HasPrefix(toolchainVersion, "go") {
 		log.Fatalf("Expected Go toolchain version of the form 'go1.2.3'; got '%s'", toolchainVersion)
 	}
 
-	// Go versions don't follow the SemVer format, but the only exception we normally care about
-	// is release candidates; so this is a horrible hack to convert e.g. `go1.22rc1` into `go1.22-rc1`
-	// which is compatible with the SemVer specification
-	rcIndex := strings.Index(toolchainVersion, "rc")
-	if rcIndex != -1 {
-		return semver.Canonical("v"+toolchainVersion[2:rcIndex]) + "-" + toolchainVersion[rcIndex:]
-	} else {
-		return semver.Canonical("v" + toolchainVersion[2:])
-	}
+	return GoVersionToSemVer(toolchainVersion[2:])
 }
 
 // Returns the current Go version in semver format, e.g. v1.14.4

--- a/go/extractor/toolchain/toolchain.go
+++ b/go/extractor/toolchain/toolchain.go
@@ -104,21 +104,26 @@ func InstallVersion(workingDir string, version string) bool {
 	return true
 }
 
-// Returns the current Go version in semver format, e.g. v1.14.4
-func GetEnvGoSemVer() string {
-	goVersion := GetEnvGoVersion()
-	if !strings.HasPrefix(goVersion, "go") {
-		log.Fatalf("Expected 'go version' output of the form 'go1.2.3'; got '%s'", goVersion)
+// Converts a Go toolchain version of the form "go1.2.3" to a semantic version.
+func ToolchainVersionToSemVer(toolchainVersion string) string {
+	if !strings.HasPrefix(toolchainVersion, "go") {
+		log.Fatalf("Expected Go toolchain version of the form 'go1.2.3'; got '%s'", toolchainVersion)
 	}
+
 	// Go versions don't follow the SemVer format, but the only exception we normally care about
 	// is release candidates; so this is a horrible hack to convert e.g. `go1.22rc1` into `go1.22-rc1`
 	// which is compatible with the SemVer specification
-	rcIndex := strings.Index(goVersion, "rc")
+	rcIndex := strings.Index(toolchainVersion, "rc")
 	if rcIndex != -1 {
-		return semver.Canonical("v"+goVersion[2:rcIndex]) + "-" + goVersion[rcIndex:]
+		return semver.Canonical("v"+toolchainVersion[2:rcIndex]) + "-" + toolchainVersion[rcIndex:]
 	} else {
-		return semver.Canonical("v" + goVersion[2:])
+		return semver.Canonical("v" + toolchainVersion[2:])
 	}
+}
+
+// Returns the current Go version in semver format, e.g. v1.14.4
+func GetEnvGoSemVer() string {
+	return ToolchainVersionToSemVer(GetEnvGoVersion())
 }
 
 // The 'go version' command may output warnings on separate lines before

--- a/go/extractor/toolchain/toolchain.go
+++ b/go/extractor/toolchain/toolchain.go
@@ -25,7 +25,7 @@ var goVersions = map[string]struct{}{}
 
 // Adds an entry to the set of installed Go versions for the normalised `version` number.
 func addGoVersion(version string) {
-	goVersions[semver.Canonical("v"+version)] = struct{}{}
+	goVersions[semver.Canonical(util.FormatSemVer(version))] = struct{}{}
 }
 
 // Returns the current Go version as returned by 'go version', e.g. go1.14.4
@@ -58,7 +58,7 @@ func GetEnvGoVersion() string {
 
 // Determines whether, to our knowledge, `version` is available on the current system.
 func HasGoVersion(version string) bool {
-	_, found := goVersions[semver.Canonical("v"+version)]
+	_, found := goVersions[semver.Canonical(util.FormatSemVer(version))]
 	return found
 }
 
@@ -72,7 +72,7 @@ func InstallVersion(workingDir string, version string) bool {
 	// Construct a command to invoke `go version` with `GOTOOLCHAIN=go1.N.0` to give
 	// Go a valid toolchain version to download the toolchain we need; subsequent commands
 	// should then work even with an invalid version that's still in `go.mod`
-	toolchainArg := "GOTOOLCHAIN=go" + semver.Canonical("v" + version)[1:]
+	toolchainArg := "GOTOOLCHAIN=go" + semver.Canonical(util.FormatSemVer(version))[1:]
 	versionCmd := Version()
 	versionCmd.Dir = workingDir
 	versionCmd.Env = append(os.Environ(), toolchainArg)
@@ -112,9 +112,9 @@ func GoVersionToSemVer(goVersion string) string {
 	// which is compatible with the SemVer specification
 	rcIndex := strings.Index(goVersion, "rc")
 	if rcIndex != -1 {
-		return semver.Canonical("v"+goVersion[:rcIndex]) + "-" + goVersion[rcIndex:]
+		return semver.Canonical(util.FormatSemVer(goVersion[:rcIndex])) + "-" + goVersion[rcIndex:]
 	} else {
-		return semver.Canonical("v" + goVersion)
+		return semver.Canonical(util.FormatSemVer(goVersion))
 	}
 }
 

--- a/go/extractor/toolchain/toolchain_test.go
+++ b/go/extractor/toolchain/toolchain_test.go
@@ -20,3 +20,16 @@ func TestHasGoVersion(t *testing.T) {
 		t.Error("Expected HasGoVersion(\"1.21\") to be false, but got true")
 	}
 }
+
+func testToolchainVersionToSemVer(t *testing.T, toolchainVersion string, expectedSemVer string) {
+	result := ToolchainVersionToSemVer(toolchainVersion)
+	if result != expectedSemVer {
+		t.Errorf("Expected ToolchainVersionToSemVer(\"%s\") to be %s, but got %s.", toolchainVersion, expectedSemVer, result)
+	}
+}
+
+func TestToolchainVersionToSemVer(t *testing.T) {
+	testToolchainVersionToSemVer(t, "go1.20", "v1.20.0")
+	testToolchainVersionToSemVer(t, "go1.20.1", "v1.20.1")
+	testToolchainVersionToSemVer(t, "go1.20rc1", "v1.20.0-rc1")
+}

--- a/go/extractor/toolchain/toolchain_test.go
+++ b/go/extractor/toolchain/toolchain_test.go
@@ -21,6 +21,19 @@ func TestHasGoVersion(t *testing.T) {
 	}
 }
 
+func testGoVersionToSemVer(t *testing.T, goVersion string, expectedSemVer string) {
+	result := GoVersionToSemVer(goVersion)
+	if result != expectedSemVer {
+		t.Errorf("Expected GoVersionToSemVer(\"%s\") to be %s, but got %s.", goVersion, expectedSemVer, result)
+	}
+}
+
+func TestGoVersionToSemVer(t *testing.T) {
+	testGoVersionToSemVer(t, "1.20", "v1.20.0")
+	testGoVersionToSemVer(t, "1.20.1", "v1.20.1")
+	testGoVersionToSemVer(t, "1.20rc1", "v1.20.0-rc1")
+}
+
 func testToolchainVersionToSemVer(t *testing.T, toolchainVersion string, expectedSemVer string) {
 	result := ToolchainVersionToSemVer(toolchainVersion)
 	if result != expectedSemVer {

--- a/go/extractor/toolchain/toolchain_test.go
+++ b/go/extractor/toolchain/toolchain_test.go
@@ -1,6 +1,10 @@
 package toolchain
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/github/codeql-go/extractor/util"
+)
 
 func TestParseGoVersion(t *testing.T) {
 	tests := map[string]string{
@@ -16,9 +20,41 @@ func TestParseGoVersion(t *testing.T) {
 }
 
 func TestHasGoVersion(t *testing.T) {
-	if HasGoVersion("1.21") {
-		t.Error("Expected HasGoVersion(\"1.21\") to be false, but got true")
+	versions := []string{"1.21", "v1.22", "1.22.3", "v1.21rc4"}
+
+	// All versions should be unknown.
+	for _, version := range versions {
+		if HasGoVersion(version) {
+			t.Errorf("Expected HasGoVersion(\"%s\") to be false, but got true", version)
+		}
+
+		if HasGoVersion(util.FormatSemVer(version)) {
+			t.Errorf("Expected HasGoVersion(\"%s\") to be false, but got true", util.FormatSemVer(version))
+		}
+
+		if HasGoVersion(util.UnformatSemVer(version)) {
+			t.Errorf("Expected HasGoVersion(\"%s\") to be false, but got true", util.UnformatSemVer(version))
+		}
+
+		// Add the version in preparation for the next part of the test.
+		addGoVersion(version)
 	}
+
+	// Now we should have all of the versions.
+	for _, version := range versions {
+		if !HasGoVersion(version) {
+			t.Errorf("Expected HasGoVersion(\"%s\") to be true, but got false", version)
+		}
+
+		if !HasGoVersion(util.FormatSemVer(version)) {
+			t.Errorf("Expected HasGoVersion(\"%s\") to be true, but got false", util.FormatSemVer(version))
+		}
+
+		if !HasGoVersion(util.UnformatSemVer(version)) {
+			t.Errorf("Expected HasGoVersion(\"%s\") to be true, but got false", util.UnformatSemVer(version))
+		}
+	}
+
 }
 
 func testGoVersionToSemVer(t *testing.T, goVersion string, expectedSemVer string) {

--- a/go/extractor/util/util.go
+++ b/go/extractor/util/util.go
@@ -409,3 +409,12 @@ func getImportPathFromRepoURL(repourl string) string {
 	path = regexp.MustCompile(`^/+|\.git$`).ReplaceAllString(path, "")
 	return host + "/" + path
 }
+
+// Prepends "v" to `version`, if not already there.
+func FormatSemVer(version string) string {
+	if !strings.HasPrefix(version, "v") {
+		version = "v" + version
+	}
+
+	return version
+}

--- a/go/extractor/util/util.go
+++ b/go/extractor/util/util.go
@@ -418,3 +418,12 @@ func FormatSemVer(version string) string {
 
 	return version
 }
+
+// Removes "v" from `semver`, if present.
+func UnformatSemVer(semver string) string {
+	if strings.HasPrefix(semver, "v") {
+		return semver[1:]
+	}
+
+	return semver
+}

--- a/go/extractor/util/util_test.go
+++ b/go/extractor/util/util_test.go
@@ -40,4 +40,11 @@ func TestFormatSemVer(t *testing.T) {
 			t.Errorf("Expected FormatSemVer(\"%s\") to be \"%s\", but got \"%s\".", pair.Input, pair.Expected, actual)
 		}
 	}
+
+	for _, pair := range tests {
+		actual := UnformatSemVer(pair.Input)
+		if actual != pair.Expected[1:] {
+			t.Errorf("Expected UnformatSemVer(\"%s\") to be \"%s\", but got \"%s\".", pair.Input, pair.Expected, actual)
+		}
+	}
 }

--- a/go/extractor/util/util_test.go
+++ b/go/extractor/util/util_test.go
@@ -20,3 +20,24 @@ func TestGetImportPathFromRepoURL(t *testing.T) {
 		}
 	}
 }
+
+func TestFormatSemVer(t *testing.T) {
+	type TestPair struct {
+		Input    string
+		Expected string
+	}
+
+	tests := []TestPair{
+		{"1", "v1"},
+		{"v1", "v1"},
+		{"1.2.3", "v1.2.3"},
+		{"v1.2.3", "v1.2.3"},
+	}
+
+	for _, pair := range tests {
+		actual := FormatSemVer(pair.Input)
+		if actual != pair.Expected {
+			t.Errorf("Expected FormatSemVer(\"%s\") to be \"%s\", but got \"%s\".", pair.Input, pair.Expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
**Context**

In Go 1.21, the Go team started making a distinction between _language_ and _toolchain_ versions. Historically, the Go version is declared with a `go` directive in a `go.mod` file, or a `go.work` file. Since Go 1.21, `go` directives are used to declare the _language_ version. A new `toolchain` directive may be used to explicitly declare the _toolchain_ version. For backwards compatibility, if there is no `toolchain` directive, the _language_ version is used as the _toolchain_ version. In the Go autobuilder, we have numerous places where we try to determine the "version" of Go that is in use, should be installed, etc. Here, we are mainly interested in the _toolchain_ version.

**What this PR addresses**

So far, we have mainly been looking at `go` directives in `go.mod` files, and recently `go.work` files, for this. However, if a `toolchain` directive is present in either type of file, then this determines the toolchain version. We have not been considering this and this PR addresses that shortcoming by modifying the autobuilder to check for the presence of `toolchain` directives when determining the version that is in use.

This PR also adds a number of tests for the functions involved in this process.

**How to review**

Best reviewed commit-by-commit.