### PR TITLE
Dataflow: Implement call context grouping to improve performance

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowDispatch.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowDispatch.qll
@@ -9,7 +9,7 @@ private import DataFlowUtil
 /**
  * Gets a function that might be called by `call`.
  */
-Function viableCallable(DataFlowCall call) {
+DataFlowCallable viableCallable(DataFlowCall call) {
   result = call.(Call).getTarget()
   or
   // If the target of the call does not have a body in the snapshot, it might

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
@@ -264,7 +264,15 @@ class DataFlowCall extends Expr instanceof Call {
   Function getEnclosingCallable() { result = this.getEnclosingFunction() }
 }
 
-predicate isUnreachableInCall(Node n, DataFlowCall call) { none() } // stub implementation
+class NodeRegion instanceof Unit {
+  string toString() { result = "NodeRegion" }
+
+  predicate contains(Node n) { none() }
+
+  int totalOrder() { result = 1 }
+}
+
+predicate isUnreachableInCall(NodeRegion nr, DataFlowCall call) { none() } // stub implementation
 
 /**
  * Holds if access paths with `c` at their head always should be tracked at high

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
@@ -242,7 +242,17 @@ class CastNode extends Node {
   CastNode() { none() } // stub implementation
 }
 
-class DataFlowCallable = Function;
+class DataFlowCallable extends Function {
+  /** Gets a best-effort total ordering. */
+  int totalorder() {
+    this =
+      rank[result](DataFlowCallable c, string file, int startline, int startcolumn |
+        c.getLocation().hasLocationInfo(file, startline, startcolumn, _, _)
+      |
+        c order by file, startline, startcolumn
+      )
+  }
+}
 
 class DataFlowExpr = Expr;
 
@@ -261,7 +271,17 @@ class DataFlowCall extends Expr instanceof Call {
   ExprNode getNode() { result.getExpr() = this }
 
   /** Gets the enclosing callable of this call. */
-  Function getEnclosingCallable() { result = this.getEnclosingFunction() }
+  DataFlowCallable getEnclosingCallable() { result = this.getEnclosingFunction() }
+
+  /** Gets a best-effort total ordering. */
+  int totalorder() {
+    this =
+      rank[result](DataFlowCall c, int startline, int startcolumn |
+        c.getLocation().hasLocationInfo(_, startline, startcolumn, _, _)
+      |
+        c order by startline, startcolumn
+      )
+  }
 }
 
 class NodeRegion instanceof Unit {

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -1062,6 +1062,16 @@ class DataFlowCallable extends TDataFlowCallable {
     result = this.asSummarizedCallable() or // SummarizedCallable = Function (in CPP)
     result = this.asSourceCallable()
   }
+
+  /** Gets a best-effort total ordering. */
+  int totalorder() {
+    this =
+      rank[result](DataFlowCallable c, string file, int startline, int startcolumn |
+        c.getLocation().hasLocationInfo(file, startline, startcolumn, _, _)
+      |
+        c order by file, startline, startcolumn
+      )
+  }
 }
 
 /**
@@ -1159,6 +1169,16 @@ class DataFlowCall extends TDataFlowCall {
    * Gets the location of this call.
    */
   Location getLocation() { none() }
+
+  /** Gets a best-effort total ordering. */
+  int totalorder() {
+    this =
+      rank[result](DataFlowCall c, int startline, int startcolumn |
+        c.getLocation().hasLocationInfo(_, startline, startcolumn, _, _)
+      |
+        c order by startline, startcolumn
+      )
+  }
 }
 
 /**

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/constant-size/ConstantSizeArrayOffByOne.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/constant-size/ConstantSizeArrayOffByOne.expected
@@ -61,7 +61,6 @@ edges
 | test.cpp:289:19:289:25 | buffer3 | test.cpp:277:35:277:35 | p | provenance |  |
 | test.cpp:289:19:289:25 | buffer3 | test.cpp:289:19:289:25 | buffer3 | provenance |  |
 | test.cpp:292:25:292:27 | arr | test.cpp:299:16:299:21 | access to array | provenance | Config |
-| test.cpp:292:25:292:27 | arr | test.cpp:299:16:299:21 | access to array | provenance | Config |
 | test.cpp:306:20:306:23 | arr1 | test.cpp:292:25:292:27 | arr | provenance |  |
 | test.cpp:306:20:306:23 | arr1 | test.cpp:306:20:306:23 | arr1 | provenance |  |
 | test.cpp:309:20:309:23 | arr2 | test.cpp:292:25:292:27 | arr | provenance |  |
@@ -158,7 +157,6 @@ nodes
 | test.cpp:286:19:286:25 | buffer2 | semmle.label | buffer2 |
 | test.cpp:289:19:289:25 | buffer3 | semmle.label | buffer3 |
 | test.cpp:289:19:289:25 | buffer3 | semmle.label | buffer3 |
-| test.cpp:292:25:292:27 | arr | semmle.label | arr |
 | test.cpp:292:25:292:27 | arr | semmle.label | arr |
 | test.cpp:299:16:299:21 | access to array | semmle.label | access to array |
 | test.cpp:306:20:306:23 | arr1 | semmle.label | arr1 |

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowDispatch.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowDispatch.qll
@@ -191,6 +191,16 @@ class DataFlowCallable extends TDataFlowCallable {
     or
     result = this.asCapturedVariable().getLocation()
   }
+
+  /** Gets a best-effort total ordering. */
+  int totalorder() {
+    this =
+      rank[result](DataFlowCallable c, string file, int startline, int startcolumn |
+        c.getLocation().hasLocationInfo(file, startline, startcolumn, _, _)
+      |
+        c order by file, startline, startcolumn
+      )
+  }
 }
 
 /** A call relevant for data flow. */
@@ -233,6 +243,16 @@ abstract class DataFlowCall extends TDataFlowCall {
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
     this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+
+  /** Gets a best-effort total ordering. */
+  int totalorder() {
+    this =
+      rank[result](DataFlowCall c, int startline, int startcolumn |
+        c.hasLocationInfo(_, startline, startcolumn, _, _)
+      |
+        c order by startline, startcolumn
+      )
   }
 }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -2380,16 +2380,31 @@ predicate expectsContent(Node n, ContentSet c) {
   n.asExpr() instanceof SpreadElementExpr and c instanceof ElementContent
 }
 
+class NodeRegion instanceof ControlFlow::BasicBlock {
+  string toString() { result = "NodeRegion" }
+
+  predicate contains(Node n) { this = n.getControlFlowNode().getBasicBlock() }
+
+  int totalOrder() {
+    this =
+      rank[result](ControlFlow::BasicBlock b, int startline, int startcolumn |
+        b.getLocation().hasLocationInfo(_, startline, startcolumn, _, _)
+      |
+        b order by startline, startcolumn
+      )
+  }
+}
+
 /**
- * Holds if the node `n` is unreachable when the call context is `call`.
+ * Holds if the nodes in `nr` are unreachable when the call context is `call`.
  */
-predicate isUnreachableInCall(Node n, DataFlowCall call) {
+predicate isUnreachableInCall(NodeRegion nr, DataFlowCall call) {
   exists(
     ExplicitParameterNode paramNode, Guard guard, ControlFlow::SuccessorTypes::BooleanSuccessor bs
   |
     viableConstantBooleanParamArg(paramNode, bs.getValue().booleanNot(), call) and
     paramNode.getSsaDefinition().getARead() = guard and
-    guard.controlsBlock(n.getControlFlowNode().getBasicBlock(), bs, _)
+    guard.controlsBlock(nr, bs, _)
   )
 }
 

--- a/csharp/ql/test/library-tests/dataflow/call-sensitivity/CallSensitivityFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/call-sensitivity/CallSensitivityFlow.expected
@@ -1,8 +1,6 @@
 edges
 | CallSensitivityFlow.cs:7:38:7:38 | o : Object | CallSensitivityFlow.cs:11:20:11:20 | access to parameter o : Object | provenance |  |
-| CallSensitivityFlow.cs:7:38:7:38 | o : Object | CallSensitivityFlow.cs:11:20:11:20 | access to parameter o : Object | provenance |  |
 | CallSensitivityFlow.cs:19:39:19:39 | o : Object | CallSensitivityFlow.cs:23:18:23:18 | access to parameter o | provenance |  |
-| CallSensitivityFlow.cs:27:40:27:40 | o : Object | CallSensitivityFlow.cs:31:18:31:18 | access to parameter o | provenance |  |
 | CallSensitivityFlow.cs:27:40:27:40 | o : Object | CallSensitivityFlow.cs:31:18:31:18 | access to parameter o | provenance |  |
 | CallSensitivityFlow.cs:35:41:35:41 | o : Object | CallSensitivityFlow.cs:39:18:39:18 | [cond (line 35): true] access to parameter o | provenance |  |
 | CallSensitivityFlow.cs:43:45:43:45 | o : Object | CallSensitivityFlow.cs:45:16:45:17 | access to local variable o1 : Object | provenance |  |
@@ -13,20 +11,15 @@ edges
 | CallSensitivityFlow.cs:56:46:56:46 | o : Object | CallSensitivityFlow.cs:58:16:58:17 | access to local variable o1 : Object | provenance |  |
 | CallSensitivityFlow.cs:56:46:56:46 | o : Object | CallSensitivityFlow.cs:58:16:58:17 | access to local variable o1 : Object | provenance |  |
 | CallSensitivityFlow.cs:56:46:56:46 | o : Object | CallSensitivityFlow.cs:58:16:58:17 | access to local variable o1 : Object | provenance |  |
-| CallSensitivityFlow.cs:56:46:56:46 | o : Object | CallSensitivityFlow.cs:58:16:58:17 | access to local variable o1 : Object | provenance |  |
-| CallSensitivityFlow.cs:58:16:58:17 | access to local variable o1 : Object | CallSensitivityFlow.cs:62:20:62:22 | access to local variable tmp : Object | provenance |  |
 | CallSensitivityFlow.cs:58:16:58:17 | access to local variable o1 : Object | CallSensitivityFlow.cs:62:20:62:22 | access to local variable tmp : Object | provenance |  |
 | CallSensitivityFlow.cs:58:16:58:17 | access to local variable o1 : Object | CallSensitivityFlow.cs:62:20:62:22 | access to local variable tmp : Object | provenance |  |
 | CallSensitivityFlow.cs:58:16:58:17 | access to local variable o1 : Object | CallSensitivityFlow.cs:62:20:62:22 | access to local variable tmp : Object | provenance |  |
 | CallSensitivityFlow.cs:62:20:62:22 | access to local variable tmp : Object | CallSensitivityFlow.cs:63:13:63:14 | access to local variable o2 : Object | provenance |  |
 | CallSensitivityFlow.cs:62:20:62:22 | access to local variable tmp : Object | CallSensitivityFlow.cs:63:13:63:14 | access to local variable o2 : Object | provenance |  |
 | CallSensitivityFlow.cs:62:20:62:22 | access to local variable tmp : Object | CallSensitivityFlow.cs:63:13:63:14 | access to local variable o2 : Object | provenance |  |
-| CallSensitivityFlow.cs:62:20:62:22 | access to local variable tmp : Object | CallSensitivityFlow.cs:63:13:63:14 | access to local variable o2 : Object | provenance |  |
 | CallSensitivityFlow.cs:63:13:63:14 | access to local variable o2 : Object | CallSensitivityFlow.cs:65:16:65:17 | access to local variable o3 : Object | provenance |  |
 | CallSensitivityFlow.cs:63:13:63:14 | access to local variable o2 : Object | CallSensitivityFlow.cs:65:16:65:17 | access to local variable o3 : Object | provenance |  |
 | CallSensitivityFlow.cs:63:13:63:14 | access to local variable o2 : Object | CallSensitivityFlow.cs:65:16:65:17 | access to local variable o3 : Object | provenance |  |
-| CallSensitivityFlow.cs:63:13:63:14 | access to local variable o2 : Object | CallSensitivityFlow.cs:65:16:65:17 | access to local variable o3 : Object | provenance |  |
-| CallSensitivityFlow.cs:65:16:65:17 | access to local variable o3 : Object | CallSensitivityFlow.cs:66:14:66:15 | access to local variable o3 | provenance |  |
 | CallSensitivityFlow.cs:65:16:65:17 | access to local variable o3 : Object | CallSensitivityFlow.cs:66:14:66:15 | access to local variable o3 | provenance |  |
 | CallSensitivityFlow.cs:65:16:65:17 | access to local variable o3 : Object | CallSensitivityFlow.cs:66:14:66:15 | access to local variable o3 | provenance |  |
 | CallSensitivityFlow.cs:65:16:65:17 | access to local variable o3 : Object | CallSensitivityFlow.cs:66:14:66:15 | access to local variable o3 | provenance |  |
@@ -68,12 +61,9 @@ edges
 | CallSensitivityFlow.cs:205:40:205:40 | o : Object | CallSensitivityFlow.cs:208:18:208:18 | access to parameter o | provenance |  |
 nodes
 | CallSensitivityFlow.cs:7:38:7:38 | o : Object | semmle.label | o : Object |
-| CallSensitivityFlow.cs:7:38:7:38 | o : Object | semmle.label | o : Object |
-| CallSensitivityFlow.cs:11:20:11:20 | access to parameter o : Object | semmle.label | access to parameter o : Object |
 | CallSensitivityFlow.cs:11:20:11:20 | access to parameter o : Object | semmle.label | access to parameter o : Object |
 | CallSensitivityFlow.cs:19:39:19:39 | o : Object | semmle.label | o : Object |
 | CallSensitivityFlow.cs:23:18:23:18 | access to parameter o | semmle.label | access to parameter o |
-| CallSensitivityFlow.cs:27:40:27:40 | o : Object | semmle.label | o : Object |
 | CallSensitivityFlow.cs:27:40:27:40 | o : Object | semmle.label | o : Object |
 | CallSensitivityFlow.cs:31:18:31:18 | access to parameter o | semmle.label | access to parameter o |
 | CallSensitivityFlow.cs:35:41:35:41 | o : Object | semmle.label | o : Object |
@@ -87,20 +77,15 @@ nodes
 | CallSensitivityFlow.cs:56:46:56:46 | o : Object | semmle.label | o : Object |
 | CallSensitivityFlow.cs:56:46:56:46 | o : Object | semmle.label | o : Object |
 | CallSensitivityFlow.cs:56:46:56:46 | o : Object | semmle.label | o : Object |
-| CallSensitivityFlow.cs:56:46:56:46 | o : Object | semmle.label | o : Object |
-| CallSensitivityFlow.cs:58:16:58:17 | access to local variable o1 : Object | semmle.label | access to local variable o1 : Object |
 | CallSensitivityFlow.cs:58:16:58:17 | access to local variable o1 : Object | semmle.label | access to local variable o1 : Object |
 | CallSensitivityFlow.cs:58:16:58:17 | access to local variable o1 : Object | semmle.label | access to local variable o1 : Object |
 | CallSensitivityFlow.cs:58:16:58:17 | access to local variable o1 : Object | semmle.label | access to local variable o1 : Object |
 | CallSensitivityFlow.cs:62:20:62:22 | access to local variable tmp : Object | semmle.label | access to local variable tmp : Object |
 | CallSensitivityFlow.cs:62:20:62:22 | access to local variable tmp : Object | semmle.label | access to local variable tmp : Object |
 | CallSensitivityFlow.cs:62:20:62:22 | access to local variable tmp : Object | semmle.label | access to local variable tmp : Object |
-| CallSensitivityFlow.cs:62:20:62:22 | access to local variable tmp : Object | semmle.label | access to local variable tmp : Object |
 | CallSensitivityFlow.cs:63:13:63:14 | access to local variable o2 : Object | semmle.label | access to local variable o2 : Object |
 | CallSensitivityFlow.cs:63:13:63:14 | access to local variable o2 : Object | semmle.label | access to local variable o2 : Object |
 | CallSensitivityFlow.cs:63:13:63:14 | access to local variable o2 : Object | semmle.label | access to local variable o2 : Object |
-| CallSensitivityFlow.cs:63:13:63:14 | access to local variable o2 : Object | semmle.label | access to local variable o2 : Object |
-| CallSensitivityFlow.cs:65:16:65:17 | access to local variable o3 : Object | semmle.label | access to local variable o3 : Object |
 | CallSensitivityFlow.cs:65:16:65:17 | access to local variable o3 : Object | semmle.label | access to local variable o3 : Object |
 | CallSensitivityFlow.cs:65:16:65:17 | access to local variable o3 : Object | semmle.label | access to local variable o3 : Object |
 | CallSensitivityFlow.cs:65:16:65:17 | access to local variable o3 : Object | semmle.label | access to local variable o3 : Object |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
@@ -373,11 +373,8 @@ edges
 | GlobalDataFlow.cs:384:11:384:11 | access to parameter x : String | GlobalDataFlow.cs:268:26:268:35 | sinkParam3 : String | provenance |  |
 | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | provenance |  |
 | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | provenance |  |
-| GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | provenance |  |
-| GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | provenance |  |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | provenance |  |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:300:27:300:28 | x0 : String | provenance |  |
-| GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | provenance |  |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | provenance |  |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | provenance |  |
 | GlobalDataFlow.cs:396:52:396:52 | x : String | GlobalDataFlow.cs:398:11:398:11 | access to parameter x : String | provenance |  |
@@ -825,11 +822,8 @@ nodes
 | GlobalDataFlow.cs:384:11:384:11 | access to parameter x : String | semmle.label | access to parameter x : String |
 | GlobalDataFlow.cs:387:46:387:46 | x : String | semmle.label | x : String |
 | GlobalDataFlow.cs:387:46:387:46 | x : String | semmle.label | x : String |
-| GlobalDataFlow.cs:387:46:387:46 | x : String | semmle.label | x : String |
 | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | semmle.label | delegate call : String |
 | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | semmle.label | delegate call : String |
-| GlobalDataFlow.cs:389:16:389:19 | delegate call : String | semmle.label | delegate call : String |
-| GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | semmle.label | access to parameter x : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | semmle.label | access to parameter x : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | semmle.label | access to parameter x : String |
 | GlobalDataFlow.cs:396:52:396:52 | x : String | semmle.label | x : String |
@@ -974,7 +968,6 @@ subpaths
 | GlobalDataFlow.cs:218:22:218:28 | access to local variable tainted : IQueryable<T> [element] : String | GlobalDataFlow.cs:215:71:215:71 | x : String | GlobalDataFlow.cs:215:76:215:90 | call to method ReturnCheck2<String> : String | GlobalDataFlow.cs:218:22:218:39 | call to method Select<String,String> : IQueryable<T> [element] : String |
 | GlobalDataFlow.cs:220:22:220:28 | access to local variable tainted : IQueryable<T> [element] : String | GlobalDataFlow.cs:327:32:327:42 | sinkParam11 : String | GlobalDataFlow.cs:330:16:330:26 | access to parameter sinkParam11 : String | GlobalDataFlow.cs:220:22:220:49 | call to method Select<String,String> : IEnumerable<T> [element] : String |
 | GlobalDataFlow.cs:300:37:300:37 | access to parameter x : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:300:17:300:38 | call to method ApplyFunc<T,T> : String |
-| GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:300:27:300:28 | x0 : String | GlobalDataFlow.cs:300:33:300:34 | access to parameter x0 : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:558:46:558:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String | GlobalDataFlow.cs:558:44:558:47 | delegate call : String |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
@@ -392,11 +392,8 @@ edges
 | GlobalDataFlow.cs:384:11:384:11 | access to parameter x : String | GlobalDataFlow.cs:268:26:268:35 | sinkParam3 : String | provenance |  |
 | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | provenance |  |
 | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | provenance |  |
-| GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | provenance |  |
-| GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | provenance |  |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | provenance |  |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:300:27:300:28 | x0 : String | provenance |  |
-| GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | provenance |  |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | provenance |  |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | provenance |  |
 | GlobalDataFlow.cs:396:52:396:52 | x : String | GlobalDataFlow.cs:398:11:398:11 | access to parameter x : String | provenance |  |
@@ -896,11 +893,8 @@ nodes
 | GlobalDataFlow.cs:384:11:384:11 | access to parameter x : String | semmle.label | access to parameter x : String |
 | GlobalDataFlow.cs:387:46:387:46 | x : String | semmle.label | x : String |
 | GlobalDataFlow.cs:387:46:387:46 | x : String | semmle.label | x : String |
-| GlobalDataFlow.cs:387:46:387:46 | x : String | semmle.label | x : String |
 | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | semmle.label | delegate call : String |
 | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | semmle.label | delegate call : String |
-| GlobalDataFlow.cs:389:16:389:19 | delegate call : String | semmle.label | delegate call : String |
-| GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | semmle.label | access to parameter x : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | semmle.label | access to parameter x : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | semmle.label | access to parameter x : String |
 | GlobalDataFlow.cs:396:52:396:52 | x : String | semmle.label | x : String |
@@ -1081,7 +1075,6 @@ subpaths
 | GlobalDataFlow.cs:218:22:218:28 | access to local variable tainted : IQueryable<T> [element] : String | GlobalDataFlow.cs:215:71:215:71 | x : String | GlobalDataFlow.cs:215:76:215:90 | call to method ReturnCheck2<String> : String | GlobalDataFlow.cs:218:22:218:39 | call to method Select<String,String> : IQueryable<T> [element] : String |
 | GlobalDataFlow.cs:220:22:220:28 | access to local variable tainted : IQueryable<T> [element] : String | GlobalDataFlow.cs:327:32:327:42 | sinkParam11 : String | GlobalDataFlow.cs:330:16:330:26 | access to parameter sinkParam11 : String | GlobalDataFlow.cs:220:22:220:49 | call to method Select<String,String> : IEnumerable<T> [element] : String |
 | GlobalDataFlow.cs:300:37:300:37 | access to parameter x : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:300:17:300:38 | call to method ApplyFunc<T,T> : String |
-| GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:300:27:300:28 | x0 : String | GlobalDataFlow.cs:300:33:300:34 | access to parameter x0 : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:558:46:558:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String | GlobalDataFlow.cs:558:44:558:47 | delegate call : String |

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowPrivate.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowPrivate.qll
@@ -310,6 +310,16 @@ class DataFlowCallable extends TDataFlowCallable {
     this.asSummarizedCallable()
         .hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
+
+  /** Gets a best-effort total ordering. */
+  int totalorder() {
+    this =
+      rank[result](DataFlowCallable c, string file, int startline, int startcolumn |
+        c.hasLocationInfo(file, startline, startcolumn, _, _)
+      |
+        c order by file, startline, startcolumn
+      )
+  }
 }
 
 /** A function call relevant for data flow. */
@@ -332,6 +342,16 @@ class DataFlowCall extends Expr {
     result.asCallable().getFuncDef() = this.getEnclosingFunction()
     or
     not exists(this.getEnclosingFunction()) and result.asFileScope() = this.getFile()
+  }
+
+  /** Gets a best-effort total ordering. */
+  int totalorder() {
+    this =
+      rank[result](DataFlowCall c, int startline, int startcolumn |
+        c.getLocation().hasLocationInfo(_, startline, startcolumn, _, _)
+      |
+        c order by startline, startcolumn
+      )
   }
 }
 

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowPrivate.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowPrivate.qll
@@ -371,11 +371,26 @@ private ControlFlow::ConditionGuardNode getAFalsifiedGuard(DataFlowCall call) {
   )
 }
 
+class NodeRegion instanceof BasicBlock {
+  string toString() { result = "NodeRegion" }
+
+  predicate contains(Node n) { n.getBasicBlock() = this }
+
+  int totalOrder() {
+    this =
+      rank[result](BasicBlock b, int startline, int startcolumn |
+        b.hasLocationInfo(_, startline, startcolumn, _, _)
+      |
+        b order by startline, startcolumn
+      )
+  }
+}
+
 /**
- * Holds if the node `n` is unreachable when the call context is `call`.
+ * Holds if the nodes in `nr` are unreachable when the call context is `call`.
  */
-predicate isUnreachableInCall(Node n, DataFlowCall call) {
-  getAFalsifiedGuard(call).dominates(n.getBasicBlock())
+predicate isUnreachableInCall(NodeRegion nr, DataFlowCall call) {
+  getAFalsifiedGuard(call).dominates(nr)
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
@@ -399,6 +399,21 @@ class CastNode extends ExprNode {
   }
 }
 
+private predicate id_member(Member x, Member y) { x = y }
+
+private predicate idOf_member(Member x, int y) = equivalenceRelation(id_member/2)(x, y)
+
+private int summarizedCallableId(SummarizedCallable c) {
+  c =
+    rank[result](SummarizedCallable c0, int b, int i, string s |
+      b = 0 and idOf_member(c0.asCallable(), i) and s = ""
+      or
+      b = 1 and i = 0 and s = c0.asSyntheticCallable()
+    |
+      c0 order by b, i, s
+    )
+}
+
 private newtype TDataFlowCallable =
   TSrcCallable(Callable c) or
   TSummarizedCallable(SummarizedCallable c) or
@@ -432,9 +447,27 @@ class DataFlowCallable extends TDataFlowCallable {
     result = this.asSummarizedCallable().getLocation() or
     result = this.asFieldScope().getLocation()
   }
+
+  /** Gets a best-effort total ordering. */
+  int totalorder() {
+    this =
+      rank[result](DataFlowCallable c, int b, int i |
+        b = 0 and idOf_member(c.asCallable(), i)
+        or
+        b = 1 and i = summarizedCallableId(c.asSummarizedCallable())
+        or
+        b = 2 and idOf_member(c.asFieldScope(), i)
+      |
+        c order by b, i
+      )
+  }
 }
 
 class DataFlowExpr = Expr;
+
+private predicate id_call(Call x, Call y) { x = y }
+
+private predicate idOf_call(Call x, int y) = equivalenceRelation(id_call/2)(x, y)
 
 private newtype TDataFlowCall =
   TCall(Call c) or
@@ -467,6 +500,19 @@ class DataFlowCall extends TDataFlowCall {
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
     this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+
+  /** Gets a best-effort total ordering. */
+  int totalorder() {
+    this =
+      rank[result](DataFlowCall c, int b, int i |
+        b = 0 and idOf_call(c.asCall(), i)
+        or
+        b = 1 and // not guaranteed to be total
+        exists(SummarizedCallable sc | c = TSummaryCall(sc, _) and i = summarizedCallableId(sc))
+      |
+        c order by b, i
+      )
   }
 }
 

--- a/java/ql/test/library-tests/dataflow/call-sensitivity/flow.expected
+++ b/java/ql/test/library-tests/dataflow/call-sensitivity/flow.expected
@@ -2,12 +2,10 @@ edges
 | A2.java:15:15:15:28 | new Integer(...) : Number | A2.java:27:27:27:34 | o : Number | provenance |  |
 | A2.java:27:27:27:34 | o : Number | A2.java:29:9:29:9 | o | provenance |  |
 | A.java:6:28:6:35 | o : Number | A.java:8:11:8:11 | o : Number | provenance |  |
-| A.java:6:28:6:35 | o : Number | A.java:8:11:8:11 | o : Number | provenance |  |
 | A.java:14:29:14:36 | o : Number | A.java:16:9:16:9 | o | provenance |  |
 | A.java:20:30:20:37 | o : Number | A.java:22:9:22:9 | o | provenance |  |
 | A.java:26:31:26:38 | o : Number | A.java:28:9:28:9 | o | provenance |  |
 | A.java:32:35:32:42 | o : Number | A.java:40:8:40:9 | o3 | provenance |  |
-| A.java:43:36:43:43 | o : Number | A.java:51:8:51:9 | o3 | provenance |  |
 | A.java:43:36:43:43 | o : Number | A.java:51:8:51:9 | o3 | provenance |  |
 | A.java:43:36:43:43 | o : Number | A.java:51:8:51:9 | o3 | provenance |  |
 | A.java:62:18:62:31 | new Integer(...) : Number | A.java:14:29:14:36 | o : Number | provenance |  |
@@ -37,8 +35,6 @@ nodes
 | A2.java:27:27:27:34 | o : Number | semmle.label | o : Number |
 | A2.java:29:9:29:9 | o | semmle.label | o |
 | A.java:6:28:6:35 | o : Number | semmle.label | o : Number |
-| A.java:6:28:6:35 | o : Number | semmle.label | o : Number |
-| A.java:8:11:8:11 | o : Number | semmle.label | o : Number |
 | A.java:8:11:8:11 | o : Number | semmle.label | o : Number |
 | A.java:14:29:14:36 | o : Number | semmle.label | o : Number |
 | A.java:16:9:16:9 | o | semmle.label | o |
@@ -48,7 +44,6 @@ nodes
 | A.java:28:9:28:9 | o | semmle.label | o |
 | A.java:32:35:32:42 | o : Number | semmle.label | o : Number |
 | A.java:40:8:40:9 | o3 | semmle.label | o3 |
-| A.java:43:36:43:43 | o : Number | semmle.label | o : Number |
 | A.java:43:36:43:43 | o : Number | semmle.label | o : Number |
 | A.java:43:36:43:43 | o : Number | semmle.label | o : Number |
 | A.java:51:8:51:9 | o3 | semmle.label | o3 |

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowDispatch.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowDispatch.qll
@@ -344,6 +344,16 @@ abstract class DataFlowCallable extends TDataFlowCallable {
 
   /** Gets the location of this dataflow callable. */
   abstract Location getLocation();
+
+  /** Gets a best-effort total ordering. */
+  int totalorder() {
+    this =
+      rank[result](DataFlowCallable c, string file, int startline, int startcolumn |
+        c.getLocation().hasLocationInfo(file, startline, startcolumn, _, _)
+      |
+        c order by file, startline, startcolumn
+      )
+  }
 }
 
 /** A callable function. */
@@ -1418,6 +1428,16 @@ abstract class DataFlowCall extends TDataFlowCall {
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
     this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+
+  /** Gets a best-effort total ordering. */
+  int totalorder() {
+    this =
+      rank[result](DataFlowCall c, int startline, int startcolumn |
+        c.hasLocationInfo(_, startline, startcolumn, _, _)
+      |
+        c order by startline, startcolumn
+      )
   }
 }
 

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -1023,13 +1023,21 @@ predicate attributeClearStep(Node n, AttributeContent c) {
   exists(PostUpdateNode post | post.getPreUpdateNode() = n | attributeStoreStep(_, c, post))
 }
 
+class NodeRegion instanceof Unit {
+  string toString() { result = "NodeRegion" }
+
+  predicate contains(Node n) { none() }
+
+  int totalOrder() { result = 1 }
+}
+
 //--------
 // Fancy context-sensitive guards
 //--------
 /**
- * Holds if the node `n` is unreachable when the call context is `call`.
+ * Holds if the nodes in `nr` are unreachable when the call context is `call`.
  */
-predicate isUnreachableInCall(Node n, DataFlowCall call) { none() }
+predicate isUnreachableInCall(NodeRegion nr, DataFlowCall call) { none() }
 
 /**
  * Holds if access paths with `c` at their head always should be tracked at high

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
@@ -113,6 +113,16 @@ class DataFlowCallable extends TDataFlowCallable {
     this instanceof TLibraryCallable and
     result instanceof EmptyLocation
   }
+
+  /** Gets a best-effort total ordering. */
+  int totalorder() {
+    this =
+      rank[result](DataFlowCallable c, string file, int startline, int startcolumn |
+        c.getLocation().hasLocationInfo(file, startline, startcolumn, _, _)
+      |
+        c order by file, startline, startcolumn
+      )
+  }
 }
 
 /**
@@ -143,6 +153,16 @@ abstract class DataFlowCall extends TDataFlowCall {
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
     this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+
+  /** Gets a best-effort total ordering. */
+  int totalorder() {
+    this =
+      rank[result](DataFlowCall c, int startline, int startcolumn |
+        c.hasLocationInfo(_, startline, startcolumn, _, _)
+      |
+        c order by startline, startcolumn
+      )
   }
 }
 

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -2170,10 +2170,18 @@ class DataFlowExpr = CfgNodes::ExprCfgNode;
  */
 predicate forceHighPrecision(Content c) { c instanceof Content::ElementContent }
 
+class NodeRegion instanceof Unit {
+  string toString() { result = "NodeRegion" }
+
+  predicate contains(Node n) { none() }
+
+  int totalOrder() { result = 1 }
+}
+
 /**
- * Holds if the node `n` is unreachable when the call context is `call`.
+ * Holds if the nodes in `nr` are unreachable when the call context is `call`.
  */
-predicate isUnreachableInCall(Node n, DataFlowCall call) { none() }
+predicate isUnreachableInCall(NodeRegion nr, DataFlowCall call) { none() }
 
 newtype LambdaCallKind =
   TYieldCallKind() or

--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -73,11 +73,17 @@ signature module InputSig<LocationSig Location> {
     string toString();
 
     DataFlowCallable getEnclosingCallable();
+
+    /** Gets a best-effort total ordering. */
+    int totalorder();
   }
 
   class DataFlowCallable {
     /** Gets a textual representation of this element. */
     string toString();
+
+    /** Gets a best-effort total ordering. */
+    int totalorder();
   }
 
   class ReturnKind {

--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -251,10 +251,18 @@ signature module InputSig<LocationSig Location> {
    */
   predicate expectsContent(Node n, ContentSet c);
 
+  /** A set of `Node`s in a `DataFlowCallable`. */
+  class NodeRegion {
+    /** Holds if this region contains `n`. */
+    predicate contains(Node n);
+
+    int totalOrder();
+  }
+
   /**
-   * Holds if the node `n` is unreachable when the call context is `call`.
+   * Holds if the nodes in `nr` are unreachable when the call context is `call`.
    */
-  predicate isUnreachableInCall(Node n, DataFlowCall call);
+  predicate isUnreachableInCall(NodeRegion nr, DataFlowCall call);
 
   default int accessPathLimit() { result = 5 }
 

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -1390,8 +1390,8 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         bindingset[call, c]
         CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call);
 
-        bindingset[node, cc]
-        LocalCc getLocalCc(NodeEx node, Cc cc);
+        bindingset[c, cc]
+        LocalCc getLocalCc(DataFlowCallable c, Cc cc);
 
         bindingset[node1, state1]
         bindingset[node2, state2]
@@ -1480,7 +1480,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           or
           exists(NodeEx mid, FlowState state0, Typ t0, LocalCc localCc |
             fwdFlow(mid, state0, cc, summaryCtx, argT, argAp, t0, ap, apa) and
-            localCc = getLocalCc(mid, cc)
+            localCc = getLocalCc(mid.getEnclosingCallable(), cc)
           |
             localStep(mid, state0, node, state, true, _, localCc) and
             t = t0
@@ -2533,8 +2533,8 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
       class LocalCc = Unit;
 
-      bindingset[node, cc]
-      LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+      bindingset[c, cc]
+      LocalCc getLocalCc(DataFlowCallable c, Cc cc) { any() }
 
       DataFlowCallable viableImplCallContextReduced(DataFlowCall call, CcCall ctx) { none() }
 
@@ -2595,8 +2595,8 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       module NoLocalCallContext {
         class LocalCc = Unit;
 
-        bindingset[node, cc]
-        LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+        bindingset[c, cc]
+        LocalCc getLocalCc(DataFlowCallable c, Cc cc) { any() }
 
         bindingset[call, c]
         CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c) {
@@ -2609,11 +2609,9 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       module LocalCallContext {
         class LocalCc = LocalCallContext;
 
-        bindingset[node, cc]
-        LocalCc getLocalCc(NodeEx node, Cc cc) {
-          result =
-            getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-              node.getEnclosingCallable())
+        bindingset[c, cc]
+        LocalCc getLocalCc(DataFlowCallable c, Cc cc) {
+          result = getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)), c)
         }
 
         bindingset[call, c]

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -527,10 +527,6 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       )
     }
 
-    private predicate sourceCallCtx(CallContext cc) {
-      if hasSourceCallCtx() then cc instanceof CallContextSomeCall else cc instanceof CallContextAny
-    }
-
     private predicate hasSinkCallCtx() {
       exists(FlowFeature feature | feature = Config::getAFeature() |
         feature instanceof FeatureHasSinkCallContext or
@@ -3474,6 +3470,26 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         )
       }
 
+    private module PrunedCallContextSensitivityStage5 {
+      private module CallContextSensitivityInput implements CallContextSensitivityInputSig {
+        predicate relevantCallEdgeIn = Stage5::relevantCallEdgeIn/2;
+
+        predicate relevantCallEdgeOut = Stage5::relevantCallEdgeOut/2;
+
+        predicate reducedViableImplInCallContextCand =
+          Stage5Param::reducedViableImplInCallContext/3;
+
+        predicate reducedViableImplInReturnCand = Stage5Param::reducedViableImplInReturn/2;
+      }
+
+      import CallContextSensitivity<CallContextSensitivityInput>
+      import LocalCallContext
+    }
+
+    private predicate sourceCallCtx(CallContext cc) {
+      if hasSourceCallCtx() then cc instanceof CallContextSomeCall else cc instanceof CallContextAny
+    }
+
     private newtype TPathNode =
       TPathNodeMid(
         NodeEx node, FlowState state, CallContext cc, SummaryCtx sc, DataFlowType t, AccessPath ap,
@@ -4210,22 +4226,6 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         apa = mid.getAp().getApprox() and
         not outBarrier(retNode, state)
       )
-    }
-
-    private module PrunedCallContextSensitivityStage5 {
-      private module CallContextSensitivityInput implements CallContextSensitivityInputSig {
-        predicate relevantCallEdgeIn = Stage5::relevantCallEdgeIn/2;
-
-        predicate relevantCallEdgeOut = Stage5::relevantCallEdgeOut/2;
-
-        predicate reducedViableImplInCallContextCand =
-          Stage5Param::reducedViableImplInCallContext/3;
-
-        predicate reducedViableImplInReturnCand = Stage5Param::reducedViableImplInReturn/2;
-      }
-
-      import CallContextSensitivity<CallContextSensitivityInput>
-      import LocalCallContext
     }
 
     pragma[nomagic]

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -2604,11 +2604,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
       ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
 
-      private module Level1CallContextInput {
-        import CachedCallContextSensitivity
-      }
-
-      import Level1CallContextInput
+      import CachedCallContextSensitivity
       import Level1CallContext
       import NoLocalCallContext
 
@@ -2883,23 +2879,19 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
       ApOption apSome(Ap ap) { result = TApproxAccessPathFrontSome(ap) }
 
-      additional module Level1CallContextInput {
-        private module CallContextSensitivityInput implements CallContextSensitivityInputSig {
-          predicate relevantCallEdgeIn = PrevStage::relevantCallEdgeIn/2;
+      private module CallContextSensitivityInput implements CallContextSensitivityInputSig {
+        predicate relevantCallEdgeIn = PrevStage::relevantCallEdgeIn/2;
 
-          predicate relevantCallEdgeOut = PrevStage::relevantCallEdgeOut/2;
+        predicate relevantCallEdgeOut = PrevStage::relevantCallEdgeOut/2;
 
-          predicate reducedViableImplInCallContextCand =
-            CachedCallContextSensitivity::reducedViableImplInCallContext/3;
+        predicate reducedViableImplInCallContextCand =
+          CachedCallContextSensitivity::reducedViableImplInCallContext/3;
 
-          predicate reducedViableImplInReturnCand =
-            CachedCallContextSensitivity::reducedViableImplInReturn/2;
-        }
-
-        import CallContextSensitivity<CallContextSensitivityInput>
+        predicate reducedViableImplInReturnCand =
+          CachedCallContextSensitivity::reducedViableImplInReturn/2;
       }
 
-      import Level1CallContextInput
+      import CallContextSensitivity<CallContextSensitivityInput>
       import Level1CallContext
       import NoLocalCallContext
 
@@ -3276,23 +3268,18 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
       ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-      additional module Level1CallContextInput {
-        private module CallContextSensitivityInput implements CallContextSensitivityInputSig {
-          predicate relevantCallEdgeIn = PrevStage::relevantCallEdgeIn/2;
+      private module CallContextSensitivityInput implements CallContextSensitivityInputSig {
+        predicate relevantCallEdgeIn = PrevStage::relevantCallEdgeIn/2;
 
-          predicate relevantCallEdgeOut = PrevStage::relevantCallEdgeOut/2;
+        predicate relevantCallEdgeOut = PrevStage::relevantCallEdgeOut/2;
 
-          predicate reducedViableImplInCallContextCand =
-            Stage3Param::Level1CallContextInput::reducedViableImplInCallContext/3;
+        predicate reducedViableImplInCallContextCand =
+          Stage3Param::reducedViableImplInCallContext/3;
 
-          predicate reducedViableImplInReturnCand =
-            Stage3Param::Level1CallContextInput::reducedViableImplInReturn/2;
-        }
-
-        import CallContextSensitivity<CallContextSensitivityInput>
+        predicate reducedViableImplInReturnCand = Stage3Param::reducedViableImplInReturn/2;
       }
 
-      import Level1CallContextInput
+      import CallContextSensitivity<CallContextSensitivityInput>
       import Level1CallContext
       import LocalCallContext
 
@@ -4250,10 +4237,9 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         predicate relevantCallEdgeOut = Stage5::relevantCallEdgeOut/2;
 
         predicate reducedViableImplInCallContextCand =
-          Stage5Param::Level1CallContextInput::reducedViableImplInCallContext/3;
+          Stage5Param::reducedViableImplInCallContext/3;
 
-        predicate reducedViableImplInReturnCand =
-          Stage5Param::Level1CallContextInput::reducedViableImplInReturn/2;
+        predicate reducedViableImplInReturnCand = Stage5Param::reducedViableImplInReturn/2;
       }
 
       import CallContextSensitivity<CallContextSensitivityInput>

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -2631,13 +2631,6 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       predicate viableImplNotCallContextReducedReverse(CcNoCall ctx) {
         ctx instanceof CallContextAny
       }
-
-      bindingset[call, c]
-      CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call) {
-        if Input::reducedViableImplInReturn(c, call)
-        then result = TReturn(c, call)
-        else result = ccNone()
-      }
     }
 
     private module Stage2Param implements MkStage<Stage1>::StageParam {
@@ -2681,6 +2674,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         import CachedCallContextSensitivity
       }
 
+      import Level1CallContextInput
       import Level1CallContext<Level1CallContextInput>
       import NoLocalCallContext
 
@@ -2971,6 +2965,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         import CallContextSensitivity<CallContextSensitivityInput>
       }
 
+      import Level1CallContextInput
       import Level1CallContext<Level1CallContextInput>
       import NoLocalCallContext
 
@@ -3363,6 +3358,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         import CallContextSensitivity<CallContextSensitivityInput>
       }
 
+      import Level1CallContextInput
       import Level1CallContext<Level1CallContextInput>
       import LocalCallContext
 
@@ -4338,11 +4334,8 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         pathOutOfCallable0(mid, pos, state, innercc, apa) and
         c = pos.getCallable() and
         kind = pos.getKind() and
-        PrunedCallContextSensitivityStage5::resolveReturn(innercc, c, call)
-      |
-        if PrunedCallContextSensitivityStage5::reducedViableImplInReturn(c, call)
-        then cc = TReturn(c, call)
-        else cc = TAnyCallContext()
+        PrunedCallContextSensitivityStage5::resolveReturn(innercc, c, call) and
+        cc = PrunedCallContextSensitivityStage5::getCallContextReturn(c, call)
       )
     }
 
@@ -5409,11 +5402,8 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           partialPathOutOfCallable0(mid, pos, state, innercc, t, ap) and
           c = pos.getCallable() and
           kind = pos.getKind() and
-          CachedCallContextSensitivity::resolveReturn(innercc, c, call)
-        |
-          if CachedCallContextSensitivity::reducedViableImplInReturn(c, call)
-          then cc = TReturn(c, call)
-          else cc = TAnyCallContext()
+          CachedCallContextSensitivity::resolveReturn(innercc, c, call) and
+          cc = CachedCallContextSensitivity::getCallContextReturn(c, call)
         )
       }
 

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -2552,21 +2552,6 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call) { any() }
     }
 
-    private module Level1CallContext {
-      class Cc = CallContext;
-
-      class CcCall = CallContextCall;
-
-      pragma[inline]
-      predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
-
-      class CcNoCall = CallContextNoCall;
-
-      Cc ccNone() { result instanceof CallContextAny }
-
-      CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-    }
-
     private module Stage2Param implements MkStage<Stage1>::StageParam {
       private module PrevStage = Stage1;
 
@@ -2605,7 +2590,6 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
 
       import CachedCallContextSensitivity
-      import Level1CallContext
       import NoLocalCallContext
 
       bindingset[node1, state1]
@@ -2892,7 +2876,6 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       }
 
       import CallContextSensitivity<CallContextSensitivityInput>
-      import Level1CallContext
       import NoLocalCallContext
 
       predicate localStep(
@@ -3280,7 +3263,6 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       }
 
       import CallContextSensitivity<CallContextSensitivityInput>
-      import Level1CallContext
       import LocalCallContext
 
       predicate localStep(

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -2554,10 +2554,6 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
     private signature module Level1CallContextInputSig {
       predicate reducedViableImplInReturn(DataFlowCallable c, DataFlowCall call);
-
-      DataFlowCall prunedViableImplInCallContextReverse(
-        DataFlowCallable callable, CallContextReturn ctx
-      );
     }
 
     private module Level1CallContext<Level1CallContextInputSig Input> {
@@ -2573,10 +2569,6 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       Cc ccNone() { result instanceof CallContextAny }
 
       CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-      DataFlowCall viableImplCallContextReducedReverse(DataFlowCallable c, CcNoCall ctx) {
-        result = Input::prunedViableImplInCallContextReverse(c, ctx)
-      }
 
       predicate viableImplNotCallContextReducedReverse(CcNoCall ctx) {
         ctx instanceof CallContextAny

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -2552,11 +2552,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call) { any() }
     }
 
-    private signature module Level1CallContextInputSig {
-      predicate reducedViableImplInReturn(DataFlowCallable c, DataFlowCall call);
-    }
-
-    private module Level1CallContext<Level1CallContextInputSig Input> {
+    private module Level1CallContext {
       class Cc = CallContext;
 
       class CcCall = CallContextCall;
@@ -2608,12 +2604,12 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
       ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
 
-      private module Level1CallContextInput implements Level1CallContextInputSig {
+      private module Level1CallContextInput {
         import CachedCallContextSensitivity
       }
 
       import Level1CallContextInput
-      import Level1CallContext<Level1CallContextInput>
+      import Level1CallContext
       import NoLocalCallContext
 
       bindingset[node1, state1]
@@ -2887,7 +2883,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
       ApOption apSome(Ap ap) { result = TApproxAccessPathFrontSome(ap) }
 
-      additional module Level1CallContextInput implements Level1CallContextInputSig {
+      additional module Level1CallContextInput {
         private module CallContextSensitivityInput implements CallContextSensitivityInputSig {
           predicate relevantCallEdgeIn = PrevStage::relevantCallEdgeIn/2;
 
@@ -2904,7 +2900,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       }
 
       import Level1CallContextInput
-      import Level1CallContext<Level1CallContextInput>
+      import Level1CallContext
       import NoLocalCallContext
 
       predicate localStep(
@@ -3280,7 +3276,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
       ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-      additional module Level1CallContextInput implements Level1CallContextInputSig {
+      additional module Level1CallContextInput {
         private module CallContextSensitivityInput implements CallContextSensitivityInputSig {
           predicate relevantCallEdgeIn = PrevStage::relevantCallEdgeIn/2;
 
@@ -3297,7 +3293,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       }
 
       import Level1CallContextInput
-      import Level1CallContext<Level1CallContextInput>
+      import Level1CallContext
       import LocalCallContext
 
       predicate localStep(

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -2553,9 +2553,6 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
     }
 
     private signature module Level1CallContextInputSig {
-      bindingset[call, ctx]
-      predicate noPrunedViableImplInCallContext(DataFlowCall call, CallContext ctx);
-
       predicate reducedViableImplInReturn(DataFlowCallable c, DataFlowCall call);
 
       DataFlowCall prunedViableImplInCallContextReverse(
@@ -2576,11 +2573,6 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       Cc ccNone() { result instanceof CallContextAny }
 
       CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-      bindingset[call, ctx]
-      predicate viableImplNotCallContextReduced(DataFlowCall call, Cc ctx) {
-        Input::noPrunedViableImplInCallContext(call, ctx)
-      }
 
       DataFlowCall viableImplCallContextReducedReverse(DataFlowCallable c, CcNoCall ctx) {
         result = Input::prunedViableImplInCallContextReverse(c, ctx)

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -2553,8 +2553,6 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
     }
 
     private signature module Level1CallContextInputSig {
-      DataFlowCallable prunedViableImplInCallContext(DataFlowCall call, CallContextSpecificCall ctx);
-
       bindingset[call, ctx]
       predicate noPrunedViableImplInCallContext(DataFlowCall call, CallContext ctx);
 
@@ -2578,10 +2576,6 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       Cc ccNone() { result instanceof CallContextAny }
 
       CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-      DataFlowCallable viableImplCallContextReduced(DataFlowCall call, CcCall ctx) {
-        result = Input::prunedViableImplInCallContext(call, ctx)
-      }
 
       bindingset[call, ctx]
       predicate viableImplNotCallContextReduced(DataFlowCall call, Cc ctx) {

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -350,7 +350,10 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
     pragma[nomagic]
     private predicate isUnreachableInCall1(NodeEx n, LocalCallContextSpecificCall cc) {
-      isUnreachableInCallCached(n.asNode(), cc.getCall())
+      exists(NodeRegion nr |
+        nr.contains(n.asNode()) and
+        isUnreachableInCallCached(nr, cc.getCall())
+      )
     }
 
     /**
@@ -5245,7 +5248,10 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         TSummaryCtx2 sc2, TSummaryCtx3 sc3, TSummaryCtx4 sc4, DataFlowType t, PartialAccessPath ap,
         boolean isStoreStep
       ) {
-        not isUnreachableInCallCached(node.asNode(), cc.(CallContextSpecificCall).getCall()) and
+        not exists(NodeRegion nr |
+          nr.contains(node.asNode()) and
+          isUnreachableInCallCached(nr, cc.(CallContextSpecificCall).getCall())
+        ) and
         (
           localFlowStepEx(mid.getNodeEx(), node, _) and
           state = mid.getState() and

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -1369,6 +1369,12 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
         CcCall ccSomeCall();
 
+        /*
+         * The following `instanceof` predicates are necessary for proper
+         * caching, since we're able to cache predicates, but not the underlying
+         * types.
+         */
+
         predicate instanceofCc(Cc cc);
 
         predicate instanceofCcCall(CcCall cc);

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -2588,20 +2588,20 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
       CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
+      DataFlowCallable viableImplCallContextReduced(DataFlowCall call, CcCall ctx) {
+        result = Input::prunedViableImplInCallContext(call, ctx)
+      }
+
+      bindingset[call, ctx]
+      predicate viableImplNotCallContextReduced(DataFlowCall call, Cc ctx) {
+        Input::noPrunedViableImplInCallContext(call, ctx)
+      }
+
       module NoLocalCallContext {
         class LocalCc = Unit;
 
         bindingset[node, cc]
         LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-        DataFlowCallable viableImplCallContextReduced(DataFlowCall call, CcCall ctx) {
-          result = Input::prunedViableImplInCallContext(call, ctx)
-        }
-
-        bindingset[call, ctx]
-        predicate viableImplNotCallContextReduced(DataFlowCall call, Cc ctx) {
-          Input::noPrunedViableImplInCallContext(call, ctx)
-        }
 
         bindingset[call, c]
         CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c) {
@@ -2619,15 +2619,6 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           result =
             getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
               node.getEnclosingCallable())
-        }
-
-        DataFlowCallable viableImplCallContextReduced(DataFlowCall call, CcCall ctx) {
-          result = Input::prunedViableImplInCallContext(call, ctx)
-        }
-
-        bindingset[call, ctx]
-        predicate viableImplNotCallContextReduced(DataFlowCall call, Cc ctx) {
-          Input::noPrunedViableImplInCallContext(call, ctx)
         }
 
         bindingset[call, c]

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -1383,7 +1383,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         bindingset[call, c]
         CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c);
 
-        DataFlowCallable viableImplCallContextReducedReverse(DataFlowCall call, CcNoCall ctx);
+        DataFlowCall viableImplCallContextReducedReverse(DataFlowCallable c, CcNoCall ctx);
 
         predicate viableImplNotCallContextReducedReverse(CcNoCall ctx);
 
@@ -1801,19 +1801,19 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         }
 
         pragma[nomagic]
-        private DataFlowCallable viableImplCallContextReducedReverseRestricted(
-          DataFlowCall call, CcNoCall ctx
+        private DataFlowCall viableImplCallContextReducedReverseRestricted(
+          DataFlowCallable c, CcNoCall ctx
         ) {
-          result = viableImplCallContextReducedReverse(call, ctx) and
-          PrevStage::callEdgeReturn(call, result, _, _, _, _, _)
+          result = viableImplCallContextReducedReverse(c, ctx) and
+          PrevStage::callEdgeReturn(result, c, _, _, _, _, _)
         }
 
-        bindingset[ctx, result]
+        bindingset[c, ctx]
         pragma[inline_late]
-        private DataFlowCallable viableImplCallContextReducedReverseInlineLate(
-          DataFlowCall call, CcNoCall ctx
+        private DataFlowCall viableImplCallContextReducedReverseInlineLate(
+          DataFlowCallable c, CcNoCall ctx
         ) {
-          result = viableImplCallContextReducedReverseRestricted(call, ctx)
+          result = viableImplCallContextReducedReverseRestricted(c, ctx)
         }
 
         bindingset[call]
@@ -1852,7 +1852,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           fwdFlowIntoRet(ret, _, innercc, _, _, _, _, _, apa) and
           inner = ret.getEnclosingCallable() and
           (
-            inner = viableImplCallContextReducedReverseInlineLate(call, innercc) and
+            call = viableImplCallContextReducedReverseInlineLate(inner, innercc) and
             flowOutOfCallApaInlineLate(call, inner, ret, out, allowsFieldFlow, apa)
             or
             flowOutOfCallApaNotCallContextReduced(call, inner, ret, out, allowsFieldFlow, apa,
@@ -2544,9 +2544,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       bindingset[call, c]
       CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c) { any() }
 
-      DataFlowCallable viableImplCallContextReducedReverse(DataFlowCall call, CcNoCall ctx) {
-        none()
-      }
+      DataFlowCall viableImplCallContextReducedReverse(DataFlowCallable c, CcNoCall ctx) { none() }
 
       predicate viableImplNotCallContextReducedReverse(CcNoCall ctx) { any() }
 
@@ -2628,8 +2626,8 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         }
       }
 
-      DataFlowCallable viableImplCallContextReducedReverse(DataFlowCall call, CcNoCall ctx) {
-        call = Input::prunedViableImplInCallContextReverse(result, ctx)
+      DataFlowCall viableImplCallContextReducedReverse(DataFlowCallable c, CcNoCall ctx) {
+        result = Input::prunedViableImplInCallContextReverse(c, ctx)
       }
 
       predicate viableImplNotCallContextReducedReverse(CcNoCall ctx) {

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -350,10 +350,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
     pragma[nomagic]
     private predicate isUnreachableInCall1(NodeEx n, LocalCallContextSpecificCall cc) {
-      exists(NodeRegion nr |
-        nr.contains(n.asNode()) and
-        isUnreachableInCallCached(nr, cc.getCall())
-      )
+      cc.unreachable(n.asNode())
     }
 
     /**

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -2569,10 +2569,6 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       Cc ccNone() { result instanceof CallContextAny }
 
       CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-      predicate viableImplNotCallContextReducedReverse(CcNoCall ctx) {
-        ctx instanceof CallContextAny
-      }
     }
 
     private module Stage2Param implements MkStage<Stage1>::StageParam {

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
@@ -465,10 +465,10 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      */
     pragma[nomagic]
     predicate recordDataFlowCallSiteUnreachable(DataFlowCall call, DataFlowCallable callable) {
-      exists(Node n |
+      exists(NodeRegion nr |
         relevantCallEdgeIn(call, callable) and
-        getNodeEnclosingCallable(n) = callable and
-        isUnreachableInCallCached(n, call)
+        getNodeRegionEnclosingCallable(nr) = callable and
+        isUnreachableInCallCached(nr, call)
       )
     }
 
@@ -659,7 +659,9 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     predicate expectsContentCached(Node n, ContentSet c) { expectsContent(n, c) }
 
     cached
-    predicate isUnreachableInCallCached(Node n, DataFlowCall call) { isUnreachableInCall(n, call) }
+    predicate isUnreachableInCallCached(NodeRegion nr, DataFlowCall call) {
+      isUnreachableInCall(nr, call)
+    }
 
     cached
     predicate outNodeExt(Node n) {
@@ -1823,8 +1825,14 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     override predicate relevantFor(DataFlowCallable callable) { relevantLocalCCtx(call, callable) }
   }
 
+  private DataFlowCallable getNodeRegionEnclosingCallable(NodeRegion nr) {
+    exists(Node n | nr.contains(n) | getNodeEnclosingCallable(n) = result)
+  }
+
   private predicate relevantLocalCCtx(DataFlowCall call, DataFlowCallable callable) {
-    exists(Node n | getNodeEnclosingCallable(n) = callable and isUnreachableInCallCached(n, call))
+    exists(NodeRegion nr |
+      getNodeRegionEnclosingCallable(nr) = callable and isUnreachableInCallCached(nr, call)
+    )
   }
 
   /**

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
@@ -582,8 +582,8 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
        * the possible call sites are restricted.
        */
       pragma[nomagic]
-      DataFlowCall prunedViableImplInCallContextReverse(
-        DataFlowCallable callable, CallContextReturn ctx
+      DataFlowCall viableImplCallContextReducedReverse(
+        DataFlowCallable callable, CallContextNoCall ctx
       ) {
         exists(DataFlowCallable c0, DataFlowCall call0 |
           callEnclosingCallable(call0, callable) and
@@ -600,7 +600,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
       predicate resolveReturn(CallContextNoCall cc, DataFlowCallable callable, DataFlowCall call) {
         cc instanceof CallContextAny and relevantCallEdgeOut(call, callable)
         or
-        call = prunedViableImplInCallContextReverse(callable, cc)
+        call = viableImplCallContextReducedReverse(callable, cc)
       }
 
       /** Gets the call context when returning from `c` to `call`. */
@@ -888,10 +888,10 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
       }
 
       cached
-      DataFlowCall prunedViableImplInCallContextReverse(
-        DataFlowCallable callable, CallContextReturn ctx
+      DataFlowCall viableImplCallContextReducedReverse(
+        DataFlowCallable callable, CallContextNoCall ctx
       ) {
-        result = Impl2::prunedViableImplInCallContextReverse(callable, ctx)
+        result = Impl2::viableImplCallContextReducedReverse(callable, ctx)
       }
     }
 

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
@@ -462,7 +462,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     private import Input
 
     pragma[nomagic]
-    DataFlowCallable viableImplInCallContextExtIn(DataFlowCall call, DataFlowCall ctx) {
+    private DataFlowCallable viableImplInCallContextExtIn(DataFlowCall call, DataFlowCall ctx) {
       reducedViableImplInCallContextCand(call, _, ctx) and
       result = viableImplInCallContextExt(call, ctx) and
       relevantCallEdgeIn(call, result)
@@ -495,7 +495,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     }
 
     pragma[nomagic]
-    DataFlowCallable viableImplInCallContextExtOut(DataFlowCall call, DataFlowCall ctx) {
+    private DataFlowCallable viableImplInCallContextExtOut(DataFlowCall call, DataFlowCall ctx) {
       exists(DataFlowCallable c |
         reducedViableImplInReturnCand(result, call) and
         result = viableImplInCallContextExt(call, ctx) and

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
@@ -552,7 +552,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
 
       /** Holds if `call` does not have a reduced set of dispatch targets in call context `ctx`. */
       bindingset[call, ctx]
-      predicate noPrunedViableImplInCallContext(DataFlowCall call, CallContext ctx) {
+      predicate viableImplNotCallContextReduced(DataFlowCall call, CallContext ctx) {
         exists(DataFlowCall outer | ctx = TSpecificCall(outer) |
           not Input2::reducedViableImplInCallContext(call, _, outer)
         )
@@ -572,7 +572,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
       DataFlowCallable resolveCall(DataFlowCall call, CallContext cc) {
         result = viableImplCallContextReduced(call, cc)
         or
-        noPrunedViableImplInCallContext(call, cc) and
+        viableImplNotCallContextReduced(call, cc) and
         relevantCallEdgeIn(call, result)
       }
 

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
@@ -543,7 +543,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
        * makes a difference.
        */
       pragma[nomagic]
-      DataFlowCallable prunedViableImplInCallContext(DataFlowCall call, CallContextSpecificCall ctx) {
+      DataFlowCallable viableImplCallContextReduced(DataFlowCall call, CallContextCall ctx) {
         exists(DataFlowCall outer | ctx = TSpecificCall(outer) |
           result = viableImplInCallContextExtIn(call, outer) and
           Input2::reducedViableImplInCallContext(call, _, outer)
@@ -570,7 +570,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
        */
       bindingset[call, cc]
       DataFlowCallable resolveCall(DataFlowCall call, CallContext cc) {
-        result = prunedViableImplInCallContext(call, cc)
+        result = viableImplCallContextReduced(call, cc)
         or
         noPrunedViableImplInCallContext(call, cc) and
         relevantCallEdgeIn(call, result)
@@ -883,8 +883,8 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
       import Impl2
 
       cached
-      DataFlowCallable prunedViableImplInCallContext(DataFlowCall call, CallContextSpecificCall ctx) {
-        result = Impl2::prunedViableImplInCallContext(call, ctx)
+      DataFlowCallable viableImplCallContextReduced(DataFlowCall call, CallContextCall ctx) {
+        result = Impl2::viableImplCallContextReduced(call, ctx)
       }
 
       cached

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
@@ -502,7 +502,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
       )
     }
 
-    private module CallSetsInput implements MkSetsInp {
+    private module CallSetsInput implements MkSetsInputSig {
       class Key = TCallEdge;
 
       class Value = DataFlowCall;
@@ -523,7 +523,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
 
     private class CallSet = CallSetOption::Option;
 
-    private module DispatchSetsInput implements MkSetsInp {
+    private module DispatchSetsInput implements MkSetsInputSig {
       class Key = TCallEdge;
 
       class Value = TCallEdge;
@@ -585,10 +585,11 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      *
      * There are four cases:
      * - `TAnyCallContext()` : No restrictions on method flow.
-     * - `TSpecificCall(DataFlowCall call)` : Flow entered through the
-     *    given `call`. This call improves the set of viable
-     *    dispatch targets for at least one method call in the current callable
-     *    or helps prune unreachable nodes in the current callable.
+     * - `TSpecificCall(CallSet calls, DispatchSet tgts, UnreachableSetOption unreachable)` :
+     *    Flow entered through a specific call that improves the set of viable
+     *    dispatch targets for all of `calls` to the set of dispatch targets in
+     *    `tgts`, and/or the specific call prunes unreachable nodes in the
+     *    current callable as given by `unreachable`.
      * - `TSomeCall()` : Flow entered through a parameter. The
      *    originating call does not improve the set of dispatch targets for any
      *    method call in the current callable and was therefore not recorded.
@@ -1498,7 +1499,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     cached
     int callOrder(DataFlowCall call) { result = call.totalorder() }
 
-    private module UnreachableSetsInput implements MkSetsInp {
+    private module UnreachableSetsInput implements MkSetsInputSig {
       class Key = TCallEdge;
 
       class Value = NodeRegion;

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
@@ -594,6 +594,14 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
       }
 
       /**
+       * Holds if a return does not have a reduced set of viable call sites to
+       * return to in call context `ctx`.
+       */
+      predicate viableImplNotCallContextReducedReverse(CallContextNoCall ctx) {
+        ctx instanceof CallContextAny
+      }
+
+      /**
        * Resolves a return from `callable` in `cc` to `call`.
        */
       bindingset[cc, callable]

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
@@ -603,6 +603,14 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
         call = prunedViableImplInCallContextReverse(callable, cc)
       }
 
+      /** Gets the call context when returning from `c` to `call`. */
+      bindingset[call, c]
+      CallContextNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call) {
+        if Input2::reducedViableImplInReturn(c, call)
+        then result = TReturn(c, call)
+        else result = TAnyCallContext()
+      }
+
       /**
        * Holds if the call context `call` improves virtual dispatch in `callable`.
        */

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
@@ -537,6 +537,19 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      * of the input predicates in `CachedCallContextSensitivity`.
      */
     module PrunedViableImpl<PrunedViableImplInputSig Input2> {
+      class Cc = CallContext;
+
+      class CcCall = CallContextCall;
+
+      pragma[inline]
+      predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
+
+      class CcNoCall = CallContextNoCall;
+
+      Cc ccNone() { result instanceof CallContextAny }
+
+      CcCall ccSomeCall() { result instanceof CallContextSomeCall }
+
       /**
        * Gets a viable run-time dispatch target for the call `call` in the
        * context `ctx`. This is restricted to those calls for which a context

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
@@ -1825,28 +1825,28 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
    *    this dispatch target of `call` implies a reduced set of dispatch origins
    *    to which data may flow if it should reach a `return` statement.
    */
-  abstract class CallContext extends TCallContext {
+  abstract private class CallContext extends TCallContext {
     abstract string toString();
 
     /** Holds if this call context is relevant for `callable`. */
     abstract predicate relevantFor(DataFlowCallable callable);
   }
 
-  abstract class CallContextNoCall extends CallContext { }
+  abstract private class CallContextNoCall extends CallContext { }
 
-  class CallContextAny extends CallContextNoCall, TAnyCallContext {
+  private class CallContextAny extends CallContextNoCall, TAnyCallContext {
     override string toString() { result = "CcAny" }
 
     override predicate relevantFor(DataFlowCallable callable) { any() }
   }
 
-  abstract class CallContextCall extends CallContext {
+  abstract private class CallContextCall extends CallContext {
     /** Holds if this call context may be `call`. */
     bindingset[call]
     abstract predicate matchesCall(DataFlowCall call);
   }
 
-  class CallContextSpecificCall extends CallContextCall, TSpecificCall {
+  private class CallContextSpecificCall extends CallContextCall, TSpecificCall {
     override string toString() {
       exists(DataFlowCall call | this = TSpecificCall(call) | result = "CcCall(" + call + ")")
     }
@@ -1860,7 +1860,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     DataFlowCall getCall() { this = TSpecificCall(result) }
   }
 
-  class CallContextSomeCall extends CallContextCall, TSomeCall {
+  private class CallContextSomeCall extends CallContextCall, TSomeCall {
     override string toString() { result = "CcSomeCall" }
 
     override predicate relevantFor(DataFlowCallable callable) { any() }
@@ -1868,7 +1868,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     override predicate matchesCall(DataFlowCall call) { any() }
   }
 
-  class CallContextReturn extends CallContextNoCall, TReturn {
+  private class CallContextReturn extends CallContextNoCall, TReturn {
     override string toString() {
       exists(DataFlowCall call | this = TReturn(_, call) | result = "CcReturn(" + call + ")")
     }
@@ -1923,7 +1923,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
    * Gets the local call context given the call context and the callable that
    * the contexts apply to.
    */
-  LocalCallContext getLocalCallContext(CallContext ctx, DataFlowCallable callable) {
+  private LocalCallContext getLocalCallContext(CallContext ctx, DataFlowCallable callable) {
     ctx.relevantFor(callable) and
     if relevantLocalCCtx(ctx.(CallContextSpecificCall).getCall(), callable)
     then

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
@@ -530,8 +530,8 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
 
       TCallEdge getAValue(TCallEdge ctxEdge) {
         exists(DataFlowCall ctx, DataFlowCallable c, DataFlowCall call, DataFlowCallable tgt |
-          ctxEdge = TMkCallEdge(ctx, c) and
-          result = TMkCallEdge(call, tgt) and
+          ctxEdge = mkCallEdge(ctx, c) and
+          result = mkCallEdge(call, tgt) and
           viableImplInCallContextExtIn(call, ctx) = tgt and
           reducedViableImplInCallContext(call, c, ctx)
         )
@@ -1505,7 +1505,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
 
       NodeRegion getAValue(TCallEdge edge) {
         exists(DataFlowCall call, DataFlowCallable tgt |
-          edge = TMkCallEdge(call, tgt) and
+          edge = mkCallEdge(call, tgt) and
           getNodeRegionEnclosingCallable(result) = tgt and
           isUnreachableInCallCached(result, call)
         )
@@ -1596,6 +1596,12 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     newtype TApproxAccessPathFrontOption =
       TApproxAccessPathFrontNone() or
       TApproxAccessPathFrontSome(ApproxAccessPathFront apf)
+  }
+
+  bindingset[call, tgt]
+  pragma[inline_late]
+  private TCallEdge mkCallEdge(DataFlowCall call, DataFlowCallable tgt) {
+    result = TMkCallEdge(call, tgt)
   }
 
   bindingset[t1, t2]

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
@@ -521,6 +521,11 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
 
     private module CallSetOption = Option<CallSets::ValueSet>;
 
+    /**
+     * A set of call sites for which dispatch is affected by the call context.
+     *
+     * A `None` value indicates the empty set.
+     */
     private class CallSet = CallSetOption::Option;
 
     private module DispatchSetsInput implements MkSetsInputSig {
@@ -544,6 +549,15 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
 
     private module DispatchSetsOption = Option<DispatchSets::ValueSet>;
 
+    /**
+     * A set of call edges that are allowed in the call context. This applies to
+     * all calls in the associated `CallSet`, in particular, this means that if
+     * a call has no associated edges in the `DispatchSet`, then either all
+     * edges are allowed or none are depending on whether the call is in the
+     * `CallSet`.
+     *
+     * A `None` value indicates the empty set.
+     */
     private class DispatchSet = DispatchSetsOption::Option;
 
     private predicate relevantCtx(TCallEdge ctx) {
@@ -795,9 +809,10 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
         }
 
         private LocalCallContext getLocalCallContext(CallContext ctx) {
-          if exists(getUnreachable(ctx))
-          then result = TSpecificLocalCall(getUnreachable(ctx))
-          else result instanceof LocalCallContextAny
+          result = TSpecificLocalCall(getUnreachable(ctx))
+          or
+          not exists(getUnreachable(ctx)) and
+          result instanceof LocalCallContextAny
         }
 
         bindingset[cc]

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplConsistency.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplConsistency.qll
@@ -187,8 +187,9 @@ module MakeConsistency<
   }
 
   query predicate unreachableNodeCCtx(Node n, DataFlowCall call, string msg) {
-    isUnreachableInCall(n, call) and
-    exists(DataFlowCallable c |
+    exists(DataFlowCallable c, NodeRegion nr |
+      isUnreachableInCall(nr, call) and
+      nr.contains(n) and
       c = nodeGetEnclosingCallable(n) and
       not viableCallable(call) = c
     ) and

--- a/shared/util/codeql/util/internal/MakeSets.qll
+++ b/shared/util/codeql/util/internal/MakeSets.qll
@@ -5,7 +5,7 @@
  */
 
 /** The input signature for `MakeSets`. */
-signature module MkSetsInp {
+signature module MkSetsInputSig {
   class Key;
 
   class Value;
@@ -31,7 +31,7 @@ signature module MkSetsInp {
  * reasonable fallback where `getValueSet(k).contains(v)` remains equivalent to
  * `v = getAValue(k)`.
  */
-module MakeSets<MkSetsInp Inp> {
+module MakeSets<MkSetsInputSig Inp> {
   private import Inp
 
   private int totalorderExt(Value v) {
@@ -53,7 +53,7 @@ module MakeSets<MkSetsInp Inp> {
   private newtype TValList =
     TValListNil() or
     TValListCons(Value head, int r, TValList tail) { hasValListCons(_, head, r, tail) } or
-    TValListUnordered(Key k) { exists(getAValue(k)) and unordered(k) }
+    TValListUnordered(Key k) { unordered(k) }
 
   private predicate hasValListCons(Key k, Value head, int r, TValList tail) {
     rankedValue(k, head, r) and

--- a/shared/util/codeql/util/internal/MakeSets.qll
+++ b/shared/util/codeql/util/internal/MakeSets.qll
@@ -1,0 +1,79 @@
+/**
+ * INTERNAL: This module may be replaced without notice.
+ *
+ * Provides a module to create first-class representations of sets of values.
+ */
+
+/** The input signature for `MakeSets`. */
+signature module MkSetsInp {
+  class Key;
+
+  class Value;
+
+  Value getAValue(Key k);
+
+  int totalorder(Value v);
+}
+
+/**
+ * Given a binary predicate `getAValue`, this module groups the `Value` column
+ * by `Key` and constructs the corresponding sets of `Value`s as single entities.
+ *
+ * The output is a functional predicate, `getValueSet`, such that
+ * `getValueSet(k).contains(v)` is equivalent to `v = getAValue(k)`, and a
+ * class, `ValueSet`, that canonically represents a set of `Value`s. In
+ * particular, if two keys `k1` and `k2` relate to the same set of values, then
+ * `getValueSet(k1) = getValueSet(k2)`.
+ */
+module MakeSets<MkSetsInp Inp> {
+  private import Inp
+
+  private predicate rankedValue(Key k, Value v, int r) {
+    v = rank[r](Value v0 | v0 = getAValue(k) | v0 order by totalorder(v0))
+  }
+
+  private int maxRank(Key k) { result = max(int r | rankedValue(k, _, r)) }
+
+  predicate consistency(int r, int bs) { bs = strictcount(Value v | totalorder(v) = r) and bs != 1 }
+
+  private newtype TValList =
+    TValListNil() or
+    TValListCons(Value head, int r, TValList tail) { hasValListCons(_, head, r, tail) }
+
+  private predicate hasValListCons(Key k, Value head, int r, TValList tail) {
+    rankedValue(k, head, r) and
+    hasValList(k, r - 1, tail)
+  }
+
+  private predicate hasValList(Key k, int r, TValList l) {
+    exists(getAValue(k)) and r = 0 and l = TValListNil()
+    or
+    exists(Value head, TValList tail |
+      l = TValListCons(head, r, tail) and
+      hasValListCons(k, head, r, tail)
+    )
+  }
+
+  private predicate hasValueSet(Key k, TValListCons vs) { hasValList(k, maxRank(k), vs) }
+
+  /** A set of `Value`s. */
+  class ValueSet extends TValListCons {
+    ValueSet() { hasValueSet(_, this) }
+
+    string toString() { result = "ValueSet" }
+
+    private predicate sublist(TValListCons l) {
+      this = l or
+      this.sublist(TValListCons(_, _, l))
+    }
+
+    /** Holds if this set contains `v`. */
+    predicate contains(Value v) { this.sublist(TValListCons(v, _, _)) }
+  }
+
+  /**
+   * Gets the set of values such that `getValueSet(k).contains(v)` is equivalent
+   * to `v = getAValue(k)`.
+   */
+  ValueSet getValueSet(Key k) { hasValueSet(k, result) }
+}

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowDispatch.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowDispatch.qll
@@ -65,6 +65,16 @@ class DataFlowCallable extends TDataFlowCallable {
   Callable::TypeRange getUnderlyingCallable() {
     result = this.asSummarizedCallable() or result = this.asSourceCallable()
   }
+
+  /** Gets a best-effort total ordering. */
+  int totalorder() {
+    this =
+      rank[result](DataFlowCallable c, string file, int startline, int startcolumn |
+        c.getLocation().hasLocationInfo(file, startline, startcolumn, _, _)
+      |
+        c order by file, startline, startcolumn
+      )
+  }
 }
 
 cached
@@ -119,6 +129,16 @@ class DataFlowCall extends TDataFlowCall {
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
     this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+
+  /** Gets a best-effort total ordering. */
+  int totalorder() {
+    this =
+      rank[result](DataFlowCall c, int startline, int startcolumn |
+        c.hasLocationInfo(_, startline, startcolumn, _, _)
+      |
+        c order by startline, startcolumn
+      )
   }
 }
 

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
@@ -1371,10 +1371,18 @@ class DataFlowExpr = Expr;
  */
 predicate forceHighPrecision(Content c) { c instanceof Content::CollectionContent }
 
+class NodeRegion instanceof Unit {
+  string toString() { result = "NodeRegion" }
+
+  predicate contains(Node n) { none() }
+
+  int totalOrder() { result = 1 }
+}
+
 /**
- * Holds if the node `n` is unreachable when the call context is `call`.
+ * Holds if the nodes in `nr` are unreachable when the call context is `call`.
  */
-predicate isUnreachableInCall(Node n, DataFlowCall call) { none() }
+predicate isUnreachableInCall(NodeRegion nr, DataFlowCall call) { none() }
 
 newtype LambdaCallKind = TLambdaCallKind()
 


### PR DESCRIPTION
This replaces our call context representation with a set-based representation of the allowed call edges, thus unifying equivalent call contexts. This unification means that we avoid redundant computation when a callable is reachable with several different, but equivalent call contexts.

In some cases I've observed 3000 equivalent call contexts, which will now be replaced by a single entity, and in that particular case the total tuple count for the stage was cut in half.

Commit-by-commit review encouraged. The first commit introduces the `MakeSets` primitive, which is then used to collapse local call contexts. Then a sequence of refactoring commits follow. And finally, the "Dataflow: Switch call context to a set representation" commit contains the implementation of and switch to fully set-based call contexts. This commit also does some reshuffling to ensure proper caching in `CachedCallContextSensitivity`.