### PR TITLE
Go: Fix `getType` on `ImplicitVarArgsSlice`

### DIFF
--- a/go/ql/lib/change-notes/2024-05-08-fix-flow-variadic-builtin-variable.md
+++ b/go/ql/lib/change-notes/2024-05-08-fix-flow-variadic-builtin-variable.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Fixed a bug that stopped data flow from being followed through variadic arguments to built-in functions or to functions called using a variable.

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowNodes.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowNodes.qll
@@ -455,8 +455,8 @@ module Public {
     CallNode getCallNode() { result = call }
 
     override Type getType() {
-      exists(Function f | f = call.getTarget() |
-        result = f.getParameterType(f.getNumParameter() - 1)
+      exists(SignatureType t | t = call.getCall().getCalleeType() |
+        result = t.getParameterType(t.getNumParameter() - 1)
       )
     }
 


### PR DESCRIPTION
It was not defined for built-in functions or for functions called via a function variable.

I've pulled this commit out of https://github.com/github/codeql/pull/16413 so that it can be reviewed and performance-tested in isolation. I don't think it needs a test because it is tested by that PR, and by all the tests for data flow through variadic arguments.