### PR TITLE
C#: Add missing CWE tags

### DIFF
--- a/csharp/ql/src/Input Validation/ValueShadowing.ql
+++ b/csharp/ql/src/Input Validation/ValueShadowing.ql
@@ -8,6 +8,7 @@
  * @tags security
  *       maintainability
  *       frameworks/asp.net
+ *       external/cwe/cwe-1173
  */
 
 import csharp

--- a/csharp/ql/src/Input Validation/ValueShadowingServerVariable.ql
+++ b/csharp/ql/src/Input Validation/ValueShadowingServerVariable.ql
@@ -8,6 +8,7 @@
  * @tags security
  *       maintainability
  *       frameworks/asp.net
+ *       external/cwe/cwe-1173
  */
 
 import csharp


### PR DESCRIPTION
Adds cwe-1173 to `cs/ambiguous-client-variable` and `cs/ambiguous-server-variable`.