### PR TITLE
Go: Add test for `resolve build-environment`

### DIFF
--- a/go/integration-tests-lib/go_integration_test.py
+++ b/go/integration-tests-lib/go_integration_test.py
@@ -1,15 +1,22 @@
 import os
 from create_database_utils import *
 from diagnostics_test_utils import *
+from resolve_environment_utils import *
 
-def go_integration_test(source = "src", db = "db", runFunction = runSuccessfully):
+def go_integration_test(toolchain=None, source = "src", db = "db", runFunction = runSuccessfully):
   # Set up a GOPATH relative to this test's root directory;
   # we set os.environ instead of using extra_env because we
   # need it to be set for the call to "go clean -modcache" later
   goPath = os.path.join(os.path.abspath(os.getcwd()), ".go")
   os.environ['GOPATH'] = goPath
 
+  extra_env = None
+
+  if toolchain != None:
+    extra_env = { 'GOTOOLCHAIN': toolchain }
+
   try:
+    run_codeql_resolve_build_environment(lang="go", source=source, extra_env=extra_env)
     run_codeql_database_create([], lang="go", source=source, db=db, runFunction=runFunction)
 
     check_diagnostics()

--- a/go/ql/integration-tests/all-platforms/go/bazel-sample-1/environment.expected
+++ b/go/ql/integration-tests/all-platforms/go/bazel-sample-1/environment.expected
@@ -1,0 +1,5 @@
+{
+  "configuration" : {
+    "go" : { }
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/bazel-sample-2/environment.expected
+++ b/go/ql/integration-tests/all-platforms/go/bazel-sample-2/environment.expected
@@ -1,0 +1,5 @@
+{
+  "configuration" : {
+    "go" : { }
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/build-constraints-exclude-all-go-files/environment.expected
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/build-constraints-exclude-all-go-files/environment.expected
@@ -1,0 +1,5 @@
+{
+  "configuration" : {
+    "go" : { }
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/go-files-found-not-processed/environment.expected
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/go-files-found-not-processed/environment.expected
@@ -1,0 +1,5 @@
+{
+  "configuration" : {
+    "go" : { }
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/invalid-toolchain-version/environment.expected
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/invalid-toolchain-version/environment.expected
@@ -1,0 +1,5 @@
+{
+  "configuration" : {
+    "go" : { }
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/newer-go-version-needed/environment.expected
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/newer-go-version-needed/environment.expected
@@ -1,0 +1,5 @@
+{
+  "configuration" : {
+    "go" : { }
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/no-go-files-found/environment.expected
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/no-go-files-found/environment.expected
@@ -1,0 +1,5 @@
+{
+  "configuration" : {
+    "go" : { }
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/package-not-found-with-go-mod/environment.expected
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/package-not-found-with-go-mod/environment.expected
@@ -1,0 +1,5 @@
+{
+  "configuration" : {
+    "go" : { }
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/package-not-found-without-go-mod/environment.expected
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/package-not-found-without-go-mod/environment.expected
@@ -1,0 +1,5 @@
+{
+  "configuration" : {
+    "go" : { }
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/unsupported-relative-path/environment.expected
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/unsupported-relative-path/environment.expected
@@ -1,0 +1,5 @@
+{
+  "configuration" : {
+    "go" : { }
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/go-get-without-modules-sample/environment.expected
+++ b/go/ql/integration-tests/all-platforms/go/go-get-without-modules-sample/environment.expected
@@ -1,0 +1,5 @@
+{
+  "configuration" : {
+    "go" : { }
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/go-mod-sample/environment.expected
+++ b/go/ql/integration-tests/all-platforms/go/go-mod-sample/environment.expected
@@ -1,0 +1,5 @@
+{
+  "configuration" : {
+    "go" : { }
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/go-mod-without-version/environment.expected
+++ b/go/ql/integration-tests/all-platforms/go/go-mod-without-version/environment.expected
@@ -1,0 +1,5 @@
+{
+  "configuration" : {
+    "go" : { }
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/go-version-bump/environment.expected
+++ b/go/ql/integration-tests/all-platforms/go/go-version-bump/environment.expected
@@ -1,0 +1,5 @@
+{
+  "configuration" : {
+    "go" : { }
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/make-sample/environment.expected
+++ b/go/ql/integration-tests/all-platforms/go/make-sample/environment.expected
@@ -1,0 +1,5 @@
+{
+  "configuration" : {
+    "go" : { }
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/mixed-layout/environment.expected
+++ b/go/ql/integration-tests/all-platforms/go/mixed-layout/environment.expected
@@ -1,0 +1,5 @@
+{
+  "configuration" : {
+    "go" : { }
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/ninja-sample/environment.expected
+++ b/go/ql/integration-tests/all-platforms/go/ninja-sample/environment.expected
@@ -1,0 +1,5 @@
+{
+  "configuration" : {
+    "go" : { }
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/resolve-build-environment/environment.expected
+++ b/go/ql/integration-tests/all-platforms/go/resolve-build-environment/environment.expected
@@ -1,0 +1,7 @@
+{
+  "configuration" : {
+    "go" : {
+      "version" : "1.22"
+    }
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/resolve-build-environment/src/go.mod
+++ b/go/ql/integration-tests/all-platforms/go/resolve-build-environment/src/go.mod
@@ -1,0 +1,3 @@
+go 1.22
+
+module main

--- a/go/ql/integration-tests/all-platforms/go/resolve-build-environment/src/main.go
+++ b/go/ql/integration-tests/all-platforms/go/resolve-build-environment/src/main.go
@@ -1,0 +1,3 @@
+package main
+
+func Main() {}

--- a/go/ql/integration-tests/all-platforms/go/resolve-build-environment/test.py
+++ b/go/ql/integration-tests/all-platforms/go/resolve-build-environment/test.py
@@ -1,0 +1,3 @@
+from go_integration_test import *
+
+go_integration_test(toolchain="go1.21.0")

--- a/go/ql/integration-tests/all-platforms/go/single-go-mod-and-go-files-not-under-it/environment.expected
+++ b/go/ql/integration-tests/all-platforms/go/single-go-mod-and-go-files-not-under-it/environment.expected
@@ -1,0 +1,5 @@
+{
+  "configuration" : {
+    "go" : { }
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/single-go-mod-in-root/environment.expected
+++ b/go/ql/integration-tests/all-platforms/go/single-go-mod-in-root/environment.expected
@@ -1,0 +1,5 @@
+{
+  "configuration" : {
+    "go" : { }
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/single-go-mod-not-in-root/environment.expected
+++ b/go/ql/integration-tests/all-platforms/go/single-go-mod-not-in-root/environment.expected
@@ -1,0 +1,5 @@
+{
+  "configuration" : {
+    "go" : { }
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/single-go-work-not-in-root/environment.expected
+++ b/go/ql/integration-tests/all-platforms/go/single-go-work-not-in-root/environment.expected
@@ -1,0 +1,5 @@
+{
+  "configuration" : {
+    "go" : { }
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/two-go-mods-nested-none-in-root/environment.expected
+++ b/go/ql/integration-tests/all-platforms/go/two-go-mods-nested-none-in-root/environment.expected
@@ -1,0 +1,5 @@
+{
+  "configuration" : {
+    "go" : { }
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/two-go-mods-nested-one-in-root/environment.expected
+++ b/go/ql/integration-tests/all-platforms/go/two-go-mods-nested-one-in-root/environment.expected
@@ -1,0 +1,5 @@
+{
+  "configuration" : {
+    "go" : { }
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/two-go-mods-not-nested/environment.expected
+++ b/go/ql/integration-tests/all-platforms/go/two-go-mods-not-nested/environment.expected
@@ -1,0 +1,5 @@
+{
+  "configuration" : {
+    "go" : { }
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/two-go-mods-one-failure/environment.expected
+++ b/go/ql/integration-tests/all-platforms/go/two-go-mods-one-failure/environment.expected
@@ -1,0 +1,5 @@
+{
+  "configuration" : {
+    "go" : { }
+  }
+}


### PR DESCRIPTION
**Summary**

We added support for the `resolve build-environment` command to the Go autobuilder last year, but we did not add any integration tests to this repository at the time. We have tests elsewhere, but those will only catch bugs in the `resolve build-environment` implementation at later stages, often long after a PR modifying the behaviour here is merged.

**What this PR does**

This PR builds on recent improvements to the Go integration tests (having a common Go-specific integration test library) and the addition of `resolve_environment_utils` to the internal repository (that PR needs to be merged for this to work) to:

- Run `resolve build-environment` for every integration test. The main benefit of doing this is that critical bugs in the implementation should now become apparent much earlier.
- Add an integration test, which exploits the `GOTOOLCHAIN` environment variable, to force `resolve build-environment` to recommend a newer Go version.