### PR TITLE
Go: Fix test expectations

### DIFF
--- a/go/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
+++ b/go/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
@@ -22,7 +22,10 @@ edges
 | SanitizingDoubleDash.go:14:23:14:30 | arrayLit [array] | SanitizingDoubleDash.go:14:23:14:33 | slice element node | provenance |  |
 | SanitizingDoubleDash.go:14:23:14:33 | slice element node | SanitizingDoubleDash.go:14:23:14:33 | slice expression [array] | provenance |  |
 | SanitizingDoubleDash.go:14:23:14:33 | slice expression [array] | SanitizingDoubleDash.go:14:23:14:33 | slice expression | provenance |  |
+| SanitizingDoubleDash.go:39:14:39:44 | []type{args} [array] | SanitizingDoubleDash.go:39:14:39:44 | call to append [array, array] | provenance | MaD:29 |
 | SanitizingDoubleDash.go:39:14:39:44 | call to append | SanitizingDoubleDash.go:40:23:40:30 | arrayLit | provenance |  |
+| SanitizingDoubleDash.go:39:14:39:44 | call to append [array, array] | SanitizingDoubleDash.go:40:23:40:30 | arrayLit | provenance |  |
+| SanitizingDoubleDash.go:39:31:39:37 | tainted | SanitizingDoubleDash.go:39:14:39:44 | []type{args} [array] | provenance |  |
 | SanitizingDoubleDash.go:39:31:39:37 | tainted | SanitizingDoubleDash.go:39:14:39:44 | call to append | provenance | FunctionModel |
 | SanitizingDoubleDash.go:52:15:52:31 | slice literal [array] | SanitizingDoubleDash.go:53:21:53:28 | arrayLit [array] | provenance |  |
 | SanitizingDoubleDash.go:52:24:52:30 | tainted | SanitizingDoubleDash.go:52:15:52:31 | slice literal [array] | provenance |  |
@@ -30,10 +33,15 @@ edges
 | SanitizingDoubleDash.go:53:14:53:35 | call to append [array] | SanitizingDoubleDash.go:54:23:54:30 | arrayLit | provenance |  |
 | SanitizingDoubleDash.go:53:21:53:28 | arrayLit | SanitizingDoubleDash.go:53:14:53:35 | call to append | provenance | FunctionModel |
 | SanitizingDoubleDash.go:53:21:53:28 | arrayLit [array] | SanitizingDoubleDash.go:53:14:53:35 | call to append [array] | provenance | MaD:28 |
+| SanitizingDoubleDash.go:68:14:68:38 | []type{args} [array] | SanitizingDoubleDash.go:68:14:68:38 | call to append [array, array] | provenance | MaD:29 |
 | SanitizingDoubleDash.go:68:14:68:38 | call to append | SanitizingDoubleDash.go:69:21:69:28 | arrayLit | provenance |  |
+| SanitizingDoubleDash.go:68:14:68:38 | call to append [array, array] | SanitizingDoubleDash.go:69:21:69:28 | arrayLit [array, array] | provenance |  |
+| SanitizingDoubleDash.go:68:31:68:37 | tainted | SanitizingDoubleDash.go:68:14:68:38 | []type{args} [array] | provenance |  |
 | SanitizingDoubleDash.go:68:31:68:37 | tainted | SanitizingDoubleDash.go:68:14:68:38 | call to append | provenance | FunctionModel |
 | SanitizingDoubleDash.go:69:14:69:35 | call to append | SanitizingDoubleDash.go:70:23:70:30 | arrayLit | provenance |  |
+| SanitizingDoubleDash.go:69:14:69:35 | call to append [array, array] | SanitizingDoubleDash.go:70:23:70:30 | arrayLit | provenance |  |
 | SanitizingDoubleDash.go:69:21:69:28 | arrayLit | SanitizingDoubleDash.go:69:14:69:35 | call to append | provenance | FunctionModel |
+| SanitizingDoubleDash.go:69:21:69:28 | arrayLit [array, array] | SanitizingDoubleDash.go:69:14:69:35 | call to append [array, array] | provenance | MaD:28 |
 | SanitizingDoubleDash.go:92:13:92:19 | selection of URL | SanitizingDoubleDash.go:92:13:92:27 | call to Query | provenance | MaD:732 |
 | SanitizingDoubleDash.go:92:13:92:27 | call to Query | SanitizingDoubleDash.go:95:25:95:31 | tainted | provenance |  |
 | SanitizingDoubleDash.go:92:13:92:27 | call to Query | SanitizingDoubleDash.go:96:24:96:34 | slice expression | provenance |  |
@@ -62,11 +70,20 @@ edges
 | SanitizingDoubleDash.go:101:24:101:34 | slice expression [array] | SanitizingDoubleDash.go:101:24:101:34 | slice expression | provenance |  |
 | SanitizingDoubleDash.go:105:15:105:37 | slice literal [array] | SanitizingDoubleDash.go:106:24:106:31 | arrayLit | provenance |  |
 | SanitizingDoubleDash.go:105:30:105:36 | tainted | SanitizingDoubleDash.go:105:15:105:37 | slice literal [array] | provenance |  |
+| SanitizingDoubleDash.go:111:14:111:44 | []type{args} [array] | SanitizingDoubleDash.go:111:14:111:44 | call to append [array, array] | provenance | MaD:29 |
 | SanitizingDoubleDash.go:111:14:111:44 | call to append | SanitizingDoubleDash.go:112:24:112:31 | arrayLit | provenance |  |
+| SanitizingDoubleDash.go:111:14:111:44 | call to append [array, array] | SanitizingDoubleDash.go:112:24:112:31 | arrayLit | provenance |  |
+| SanitizingDoubleDash.go:111:37:111:43 | tainted | SanitizingDoubleDash.go:111:14:111:44 | []type{args} [array] | provenance |  |
 | SanitizingDoubleDash.go:111:37:111:43 | tainted | SanitizingDoubleDash.go:111:14:111:44 | call to append | provenance | FunctionModel |
+| SanitizingDoubleDash.go:117:14:117:44 | []type{args} [array] | SanitizingDoubleDash.go:117:14:117:44 | call to append [array, array] | provenance | MaD:29 |
 | SanitizingDoubleDash.go:117:14:117:44 | call to append | SanitizingDoubleDash.go:118:24:118:31 | arrayLit | provenance |  |
+| SanitizingDoubleDash.go:117:14:117:44 | call to append [array, array] | SanitizingDoubleDash.go:118:24:118:31 | arrayLit | provenance |  |
+| SanitizingDoubleDash.go:117:31:117:37 | tainted | SanitizingDoubleDash.go:117:14:117:44 | []type{args} [array] | provenance |  |
 | SanitizingDoubleDash.go:117:31:117:37 | tainted | SanitizingDoubleDash.go:117:14:117:44 | call to append | provenance | FunctionModel |
+| SanitizingDoubleDash.go:123:14:123:38 | []type{args} [array] | SanitizingDoubleDash.go:123:14:123:38 | call to append [array, array] | provenance | MaD:29 |
 | SanitizingDoubleDash.go:123:14:123:38 | call to append | SanitizingDoubleDash.go:124:24:124:31 | arrayLit | provenance |  |
+| SanitizingDoubleDash.go:123:14:123:38 | call to append [array, array] | SanitizingDoubleDash.go:124:24:124:31 | arrayLit | provenance |  |
+| SanitizingDoubleDash.go:123:31:123:37 | tainted | SanitizingDoubleDash.go:123:14:123:38 | []type{args} [array] | provenance |  |
 | SanitizingDoubleDash.go:123:31:123:37 | tainted | SanitizingDoubleDash.go:123:14:123:38 | call to append | provenance | FunctionModel |
 | SanitizingDoubleDash.go:128:15:128:31 | slice literal [array] | SanitizingDoubleDash.go:129:21:129:28 | arrayLit [array] | provenance |  |
 | SanitizingDoubleDash.go:128:24:128:30 | tainted | SanitizingDoubleDash.go:128:15:128:31 | slice literal [array] | provenance |  |
@@ -74,12 +91,20 @@ edges
 | SanitizingDoubleDash.go:129:14:129:35 | call to append [array] | SanitizingDoubleDash.go:130:24:130:31 | arrayLit | provenance |  |
 | SanitizingDoubleDash.go:129:21:129:28 | arrayLit | SanitizingDoubleDash.go:129:14:129:35 | call to append | provenance | FunctionModel |
 | SanitizingDoubleDash.go:129:21:129:28 | arrayLit [array] | SanitizingDoubleDash.go:129:14:129:35 | call to append [array] | provenance | MaD:28 |
+| SanitizingDoubleDash.go:136:14:136:38 | []type{args} [array] | SanitizingDoubleDash.go:136:14:136:38 | call to append [array, array] | provenance | MaD:29 |
 | SanitizingDoubleDash.go:136:14:136:38 | call to append | SanitizingDoubleDash.go:137:24:137:31 | arrayLit | provenance |  |
+| SanitizingDoubleDash.go:136:14:136:38 | call to append [array, array] | SanitizingDoubleDash.go:137:24:137:31 | arrayLit | provenance |  |
+| SanitizingDoubleDash.go:136:31:136:37 | tainted | SanitizingDoubleDash.go:136:14:136:38 | []type{args} [array] | provenance |  |
 | SanitizingDoubleDash.go:136:31:136:37 | tainted | SanitizingDoubleDash.go:136:14:136:38 | call to append | provenance | FunctionModel |
+| SanitizingDoubleDash.go:142:14:142:38 | []type{args} [array] | SanitizingDoubleDash.go:142:14:142:38 | call to append [array, array] | provenance | MaD:29 |
 | SanitizingDoubleDash.go:142:14:142:38 | call to append | SanitizingDoubleDash.go:143:21:143:28 | arrayLit | provenance |  |
+| SanitizingDoubleDash.go:142:14:142:38 | call to append [array, array] | SanitizingDoubleDash.go:143:21:143:28 | arrayLit [array, array] | provenance |  |
+| SanitizingDoubleDash.go:142:31:142:37 | tainted | SanitizingDoubleDash.go:142:14:142:38 | []type{args} [array] | provenance |  |
 | SanitizingDoubleDash.go:142:31:142:37 | tainted | SanitizingDoubleDash.go:142:14:142:38 | call to append | provenance | FunctionModel |
 | SanitizingDoubleDash.go:143:14:143:35 | call to append | SanitizingDoubleDash.go:144:24:144:31 | arrayLit | provenance |  |
+| SanitizingDoubleDash.go:143:14:143:35 | call to append [array, array] | SanitizingDoubleDash.go:144:24:144:31 | arrayLit | provenance |  |
 | SanitizingDoubleDash.go:143:21:143:28 | arrayLit | SanitizingDoubleDash.go:143:14:143:35 | call to append | provenance | FunctionModel |
+| SanitizingDoubleDash.go:143:21:143:28 | arrayLit [array, array] | SanitizingDoubleDash.go:143:14:143:35 | call to append [array, array] | provenance | MaD:28 |
 nodes
 | ArgumentInjection.go:9:10:9:16 | selection of URL | semmle.label | selection of URL |
 | ArgumentInjection.go:9:10:9:24 | call to Query | semmle.label | call to Query |
@@ -102,7 +127,9 @@ nodes
 | SanitizingDoubleDash.go:14:23:14:33 | slice element node | semmle.label | slice element node |
 | SanitizingDoubleDash.go:14:23:14:33 | slice expression | semmle.label | slice expression |
 | SanitizingDoubleDash.go:14:23:14:33 | slice expression [array] | semmle.label | slice expression [array] |
+| SanitizingDoubleDash.go:39:14:39:44 | []type{args} [array] | semmle.label | []type{args} [array] |
 | SanitizingDoubleDash.go:39:14:39:44 | call to append | semmle.label | call to append |
+| SanitizingDoubleDash.go:39:14:39:44 | call to append [array, array] | semmle.label | call to append [array, array] |
 | SanitizingDoubleDash.go:39:31:39:37 | tainted | semmle.label | tainted |
 | SanitizingDoubleDash.go:40:23:40:30 | arrayLit | semmle.label | arrayLit |
 | SanitizingDoubleDash.go:52:15:52:31 | slice literal [array] | semmle.label | slice literal [array] |
@@ -112,10 +139,14 @@ nodes
 | SanitizingDoubleDash.go:53:21:53:28 | arrayLit | semmle.label | arrayLit |
 | SanitizingDoubleDash.go:53:21:53:28 | arrayLit [array] | semmle.label | arrayLit [array] |
 | SanitizingDoubleDash.go:54:23:54:30 | arrayLit | semmle.label | arrayLit |
+| SanitizingDoubleDash.go:68:14:68:38 | []type{args} [array] | semmle.label | []type{args} [array] |
 | SanitizingDoubleDash.go:68:14:68:38 | call to append | semmle.label | call to append |
+| SanitizingDoubleDash.go:68:14:68:38 | call to append [array, array] | semmle.label | call to append [array, array] |
 | SanitizingDoubleDash.go:68:31:68:37 | tainted | semmle.label | tainted |
 | SanitizingDoubleDash.go:69:14:69:35 | call to append | semmle.label | call to append |
+| SanitizingDoubleDash.go:69:14:69:35 | call to append [array, array] | semmle.label | call to append [array, array] |
 | SanitizingDoubleDash.go:69:21:69:28 | arrayLit | semmle.label | arrayLit |
+| SanitizingDoubleDash.go:69:21:69:28 | arrayLit [array, array] | semmle.label | arrayLit [array, array] |
 | SanitizingDoubleDash.go:70:23:70:30 | arrayLit | semmle.label | arrayLit |
 | SanitizingDoubleDash.go:80:23:80:29 | tainted | semmle.label | tainted |
 | SanitizingDoubleDash.go:92:13:92:19 | selection of URL | semmle.label | selection of URL |
@@ -135,13 +166,19 @@ nodes
 | SanitizingDoubleDash.go:105:15:105:37 | slice literal [array] | semmle.label | slice literal [array] |
 | SanitizingDoubleDash.go:105:30:105:36 | tainted | semmle.label | tainted |
 | SanitizingDoubleDash.go:106:24:106:31 | arrayLit | semmle.label | arrayLit |
+| SanitizingDoubleDash.go:111:14:111:44 | []type{args} [array] | semmle.label | []type{args} [array] |
 | SanitizingDoubleDash.go:111:14:111:44 | call to append | semmle.label | call to append |
+| SanitizingDoubleDash.go:111:14:111:44 | call to append [array, array] | semmle.label | call to append [array, array] |
 | SanitizingDoubleDash.go:111:37:111:43 | tainted | semmle.label | tainted |
 | SanitizingDoubleDash.go:112:24:112:31 | arrayLit | semmle.label | arrayLit |
+| SanitizingDoubleDash.go:117:14:117:44 | []type{args} [array] | semmle.label | []type{args} [array] |
 | SanitizingDoubleDash.go:117:14:117:44 | call to append | semmle.label | call to append |
+| SanitizingDoubleDash.go:117:14:117:44 | call to append [array, array] | semmle.label | call to append [array, array] |
 | SanitizingDoubleDash.go:117:31:117:37 | tainted | semmle.label | tainted |
 | SanitizingDoubleDash.go:118:24:118:31 | arrayLit | semmle.label | arrayLit |
+| SanitizingDoubleDash.go:123:14:123:38 | []type{args} [array] | semmle.label | []type{args} [array] |
 | SanitizingDoubleDash.go:123:14:123:38 | call to append | semmle.label | call to append |
+| SanitizingDoubleDash.go:123:14:123:38 | call to append [array, array] | semmle.label | call to append [array, array] |
 | SanitizingDoubleDash.go:123:31:123:37 | tainted | semmle.label | tainted |
 | SanitizingDoubleDash.go:124:24:124:31 | arrayLit | semmle.label | arrayLit |
 | SanitizingDoubleDash.go:128:15:128:31 | slice literal [array] | semmle.label | slice literal [array] |
@@ -151,13 +188,19 @@ nodes
 | SanitizingDoubleDash.go:129:21:129:28 | arrayLit | semmle.label | arrayLit |
 | SanitizingDoubleDash.go:129:21:129:28 | arrayLit [array] | semmle.label | arrayLit [array] |
 | SanitizingDoubleDash.go:130:24:130:31 | arrayLit | semmle.label | arrayLit |
+| SanitizingDoubleDash.go:136:14:136:38 | []type{args} [array] | semmle.label | []type{args} [array] |
 | SanitizingDoubleDash.go:136:14:136:38 | call to append | semmle.label | call to append |
+| SanitizingDoubleDash.go:136:14:136:38 | call to append [array, array] | semmle.label | call to append [array, array] |
 | SanitizingDoubleDash.go:136:31:136:37 | tainted | semmle.label | tainted |
 | SanitizingDoubleDash.go:137:24:137:31 | arrayLit | semmle.label | arrayLit |
+| SanitizingDoubleDash.go:142:14:142:38 | []type{args} [array] | semmle.label | []type{args} [array] |
 | SanitizingDoubleDash.go:142:14:142:38 | call to append | semmle.label | call to append |
+| SanitizingDoubleDash.go:142:14:142:38 | call to append [array, array] | semmle.label | call to append [array, array] |
 | SanitizingDoubleDash.go:142:31:142:37 | tainted | semmle.label | tainted |
 | SanitizingDoubleDash.go:143:14:143:35 | call to append | semmle.label | call to append |
+| SanitizingDoubleDash.go:143:14:143:35 | call to append [array, array] | semmle.label | call to append [array, array] |
 | SanitizingDoubleDash.go:143:21:143:28 | arrayLit | semmle.label | arrayLit |
+| SanitizingDoubleDash.go:143:21:143:28 | arrayLit [array, array] | semmle.label | arrayLit [array, array] |
 | SanitizingDoubleDash.go:144:24:144:31 | arrayLit | semmle.label | arrayLit |
 | SanitizingDoubleDash.go:148:30:148:36 | tainted | semmle.label | tainted |
 | SanitizingDoubleDash.go:152:24:152:30 | tainted | semmle.label | tainted |


### PR DESCRIPTION
I'm pretty sure this is what happened:

* https://github.com/github/codeql/pull/16457 was merged
* https://github.com/github/codeql/pull/16458 was merged without rebasing or merging in `main`
* the combination of the two meant that the test in question can now find paths using the existing taint flow using old-style go function models or value flow using the new-style go MaD models. This leads to extra edges and nodes without any extra results.

This will be fixed when https://github.com/github/codeql/pull/16413 is merged, which removes the old-style models. (Both of the above PRs were bug-fixes that I pulled out of https://github.com/github/codeql/pull/16413.)