### PR TITLE
Go: Improve log messages in `buildWithoutCustomCommands`

### DIFF
--- a/go/extractor/autobuilder/autobuilder.go
+++ b/go/extractor/autobuilder/autobuilder.go
@@ -54,13 +54,15 @@ func checkExtractorRun() bool {
 }
 
 // tryBuildIfExists tries to run the command `cmd args...` if the file `buildFile` exists and is not
-// a directory. Returns true if the command was successful and false if not.
-func tryBuildIfExists(buildFile, cmd string, args ...string) bool {
-	if util.FileExists(buildFile) {
+// a directory. Returns values indicating whether the script succeeded as well as whether the script was found.
+func tryBuildIfExists(buildFile, cmd string, args ...string) (scriptSuccess bool, scriptFound bool) {
+	scriptSuccess = false
+	scriptFound = util.FileExists(buildFile)
+	if scriptFound {
 		log.Printf("%s found.\n", buildFile)
-		return tryBuild(cmd, args...)
+		scriptSuccess = tryBuild(cmd, args...)
 	}
-	return false
+	return
 }
 
 // tryBuild tries to run `cmd args...`, returning true if successful and false if not.
@@ -92,11 +94,23 @@ var BuildScripts = []BuildScript{
 // Autobuild attempts to detect build systems based on the presence of build scripts from the
 // list in `BuildScripts` and run the corresponding command. This may invoke zero or more
 // build scripts in the order given by `BuildScripts`.
-func Autobuild() bool {
+func Autobuild() (scriptSuccess bool, scriptsExecuted []string) {
+	scriptSuccess = false
+	scriptsExecuted = []string{}
+
 	for _, script := range BuildScripts {
-		if tryBuildIfExists(script.Filename, script.Tool) {
-			return true
+		// Try to run the build script
+		success, scriptFound := tryBuildIfExists(script.Filename, script.Tool)
+
+		// If it was found, we attempted to run it: add it to the array.
+		if scriptFound {
+			scriptsExecuted = append(scriptsExecuted, script.Filename)
+		}
+		// If it was successfully executed, we stop here.
+		if success {
+			scriptSuccess = true
+			return
 		}
 	}
-	return false
+	return
 }

--- a/go/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/go/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -320,25 +320,25 @@ func setGopath(root string) {
 	log.Printf("GOPATH set to %s.\n", newGopath)
 }
 
-// Try to build the project without custom commands. If that fails, return a boolean indicating
-// that we should install dependencies ourselves.
-func buildWithoutCustomCommands(modMode project.ModMode) bool {
-	shouldInstallDependencies := false
-	// try to build the project
-	buildSucceeded := autobuilder.Autobuild()
+// Try to build the project with a build script. If that fails, return a boolean indicating
+// that we should install dependencies in the normal way.
+func buildWithoutCustomCommands(modMode project.ModMode) (shouldInstallDependencies bool) {
+	shouldInstallDependencies = false
+	// try to run a build script
+	scriptSucceeded := autobuilder.Autobuild()
 
-	// Build failed or there are still dependency errors; we'll try to install dependencies
-	// ourselves
-	if !buildSucceeded {
-		log.Println("Build failed, continuing to install dependencies.")
+	// If there is no build script we could invoke successfully or there are still dependency errors;
+	// we'll try to install dependencies ourselves in the normal Go way.
+	if !scriptSucceeded {
+		log.Println("Unable to find or execute a build script, continuing to install dependencies in the normal way.")
 
 		shouldInstallDependencies = true
 	} else if toolchain.DepErrors("./...", modMode.ArgsForGoVersion(toolchain.GetEnvGoSemVer())...) {
-		log.Println("Dependencies are still not resolving after the build, continuing to install dependencies.")
+		log.Println("Dependencies are still not resolving after execution of a build script, continuing to install dependencies in the normal way.")
 
 		shouldInstallDependencies = true
 	}
-	return shouldInstallDependencies
+	return
 }
 
 // Build the project with custom commands.

--- a/go/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/go/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -325,7 +325,7 @@ func setGopath(root string) {
 func buildWithoutCustomCommands(modMode project.ModMode) (shouldInstallDependencies bool) {
 	shouldInstallDependencies = false
 	// try to run a build script
-	scriptSucceeded := autobuilder.Autobuild()
+	scriptSucceeded, _ := autobuilder.Autobuild()
 
 	// If there is no build script we could invoke successfully or there are still dependency errors;
 	// we'll try to install dependencies ourselves in the normal Go way.

--- a/go/extractor/cli/go-build-runner/go-build-runner.go
+++ b/go/extractor/cli/go-build-runner/go-build-runner.go
@@ -1,12 +1,13 @@
 package main
 
 import (
-	"github.com/github/codeql-go/extractor/util"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+
+	"github.com/github/codeql-go/extractor/util"
 
 	"github.com/github/codeql-go/extractor/autobuilder"
 )
@@ -14,7 +15,8 @@ import (
 func main() {
 	// check if a build command has successfully extracted something
 	autobuilder.CheckExtracted = true
-	if autobuilder.Autobuild() {
+	scriptSuccess, _ := autobuilder.Autobuild()
+	if scriptSuccess {
 		return
 	}
 


### PR DESCRIPTION
**Summary**

As pointed out in https://github.com/github/codeql/issues/16469, the log message in `buildWithoutCustomCommands` that reads "Build failed, continuing to install dependencies" is confusing for users since it doesn't actually mean that we failed to build a project. It just means that we failed to find or run a build script such as a `Makefile`.

**What this PR does**

This PR fixes #16469 by:

1. Improving the wording of the log message.
2. Modifying the `Autobuild` function to also return an array of scripts that were executed.
3. Improving the log messages further by checking the length of that array to see whether any scripts were found or not.