### PR TITLE
Java: Add RSA/ECB/OEAP ciphers to the list of secure algorithms

### DIFF
--- a/java/ql/lib/semmle/code/java/security/BrokenCryptoAlgorithmQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/BrokenCryptoAlgorithmQuery.qll
@@ -15,6 +15,7 @@ private class ShortStringLiteral extends StringLiteral {
 class BrokenAlgoLiteral extends ShortStringLiteral {
   BrokenAlgoLiteral() {
     this.getValue().regexpMatch(getInsecureAlgorithmRegex()) and
+    not this.getValue().regexpMatch(getASecureAlgorithmName()) and
     // Exclude German and French sentences.
     not this.getValue().regexpMatch(".*\\p{IsLowercase} des \\p{IsLetter}.*")
   }

--- a/java/ql/lib/semmle/code/java/security/BrokenCryptoAlgorithmQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/BrokenCryptoAlgorithmQuery.qll
@@ -15,7 +15,8 @@ private class ShortStringLiteral extends StringLiteral {
 class BrokenAlgoLiteral extends ShortStringLiteral {
   BrokenAlgoLiteral() {
     this.getValue().regexpMatch(getInsecureAlgorithmRegex()) and
-    not this.getValue().regexpMatch(getASecureAlgorithmName()) and
+    // Exclude RSA/ECB/.* ciphers.
+    not this.getValue().regexpMatch("RSA/ECB.*") and
     // Exclude German and French sentences.
     not this.getValue().regexpMatch(".*\\p{IsLowercase} des \\p{IsLetter}.*")
   }

--- a/java/ql/lib/semmle/code/java/security/Encryption.qll
+++ b/java/ql/lib/semmle/code/java/security/Encryption.qll
@@ -250,7 +250,7 @@ string getASecureAlgorithmName() {
   result =
     [
       "RSA", "SHA-?256", "SHA-?512", "CCM", "GCM", "AES(?![^a-zA-Z](ECB|CBC/PKCS[57]Padding))",
-      "Blowfish", "ECIES", "RSA/ECB/OAEPWithSHA-1AndMGF1Padding", "RSA/ECB/PKCS1Padding",
+      "Blowfish", "ECIES", "RSA/ECB/OAEPWithSHA-1AndMGF1Padding",
       "RSA/ECB/OAEPWithSHA-256AndMGF1Padding"
     ]
 }

--- a/java/ql/lib/semmle/code/java/security/Encryption.qll
+++ b/java/ql/lib/semmle/code/java/security/Encryption.qll
@@ -250,8 +250,7 @@ string getASecureAlgorithmName() {
   result =
     [
       "RSA", "SHA-?256", "SHA-?512", "CCM", "GCM", "AES(?![^a-zA-Z](ECB|CBC/PKCS[57]Padding))",
-      "Blowfish", "ECIES", "RSA/ECB/OAEPWithSHA-1AndMGF1Padding",
-      "RSA/ECB/OAEPWithSHA-256AndMGF1Padding"
+      "Blowfish", "ECIES"
     ]
 }
 

--- a/java/ql/lib/semmle/code/java/security/Encryption.qll
+++ b/java/ql/lib/semmle/code/java/security/Encryption.qll
@@ -250,7 +250,8 @@ string getASecureAlgorithmName() {
   result =
     [
       "RSA", "SHA-?256", "SHA-?512", "CCM", "GCM", "AES(?![^a-zA-Z](ECB|CBC/PKCS[57]Padding))",
-      "Blowfish", "ECIES"
+      "Blowfish", "ECIES", "RSA/ECB/OAEPWithSHA-1AndMGF1Padding", "RSA/ECB/PKCS1Padding",
+      "RSA/ECB/OAEPWithSHA-256AndMGF1Padding"
     ]
 }
 

--- a/java/ql/src/change-notes/2024-05-13-rsa-ecb-secure.md
+++ b/java/ql/src/change-notes/2024-05-13-rsa-ecb-secure.md
@@ -1,4 +1,4 @@
 ---
 category: majorAnalysis
 ---
-* Added RSA/ECB/OAEPWithSHA-1AndMGF1Padding and RSA/ECB/OAEPWithSHA-256AndMGF1Padding to the list of secure algorithms 
+* The query `java/weak-cryptographic-algorithm` no longer alerts about `RSA/ECB` algorithm strings.

--- a/java/ql/src/change-notes/2024-05-13-rsa-ecb-secure.md
+++ b/java/ql/src/change-notes/2024-05-13-rsa-ecb-secure.md
@@ -1,0 +1,4 @@
+---
+category: majorAnalysis
+---
+* Added RSA/ECB/OAEPWithSHA-1AndMGF1Padding and RSA/ECB/OAEPWithSHA-256AndMGF1Padding to the list of secure algorithms 


### PR DESCRIPTION
This PR adds the ciphers `RSA/ECB/OAEPWithSHA-1AndMGF1Padding` and `RSA/ECB/OAEPWithSHA-256AndMGF1Padding` to the list of secure algorithms.

CodeQL flags the uses of these ciphers as risky/weak because it sees ECB in the cipher name and matches the regex from the `getInsecureAlgorithmRegex()` function.

The ciphers listed above are part of the Java Cryptographic Architecture and Java Security Standard, and after a quick google search it appears that none of the security providers operate RSA in the block mode. So ECB in the context of RSA is a misnomer.

I did omit the other algorithm `RSA/ECB/PKCS1Padding` as I believe PKCS1 padding is weaker compared to OAEP.

### References
[List of supported ciphers from the Java Security API](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/javax/crypto/Cipher.html)
[Java Security Spec](https://docs.oracle.com/en/java/javase/21/docs/specs/security/standard-names.html#security-algorithm-implementation-requirements)
[Stack overflow thread](https://stackoverflow.com/questions/63440573/cannot-find-any-provider-supporting-rsa-none-oaepwithsha-256andmgf1padding/63442519#63442519)
[Another thread](https://crypto.stackexchange.com/questions/11635/is-it-true-for-java-that-the-transformation-mode-and-padding-is-ignored-when-usi)

EDIT: Instead of adding these cipher to `getASecureAlgorithmName` we are now excluding ciphers matching the regex `RSA/ECB/.*` from the query.