### PR TITLE
Python: The MaD token `Instance` now follows subclasses

### DIFF
--- a/python/ql/lib/semmle/python/ApiGraphs.qll
+++ b/python/ql/lib/semmle/python/ApiGraphs.qll
@@ -227,6 +227,11 @@ module API {
     Node getASubclass() { result = this.getASuccessor(Label::subclass()) }
 
     /**
+     * Gets a node representing an instance of the class (or a transitive subclass of the class) represented by this node.
+     */
+    Node getAnInstance() { result = this.getASubclass*().getReturn() }
+
+    /**
      * Gets a node representing the result from awaiting this node.
      */
     Node getAwaited() { result = this.getASuccessor(Label::await()) }

--- a/python/ql/lib/semmle/python/frameworks/data/internal/ApiGraphModelsSpecific.qll
+++ b/python/ql/lib/semmle/python/frameworks/data/internal/ApiGraphModelsSpecific.qll
@@ -53,7 +53,7 @@ API::Node getExtraSuccessorFromNode(API::Node node, AccessPathTokenBase token) {
   result = node.getMember(token.getAnArgument())
   or
   token.getName() = "Instance" and
-  result = node.getReturn() // In Python `Instance` is just an alias for `ReturnValue`
+  result = node.getAnInstance()
   or
   token.getName() = "Awaited" and
   result = node.getAwaited()

--- a/python/ql/test/library-tests/frameworks/data/test.expected
+++ b/python/ql/test/library-tests/frameworks/data/test.expected
@@ -78,6 +78,7 @@ isSource
 | test.py:39:11:39:20 | ControlFlowNode for Await | test-source |
 | test.py:41:8:41:27 | ControlFlowNode for Attribute() | test-source |
 | test.py:46:7:46:16 | ControlFlowNode for SubClass() | test-source |
+| test.py:51:8:51:18 | ControlFlowNode for Sub2Class() | test-source |
 | test.py:53:7:53:16 | ControlFlowNode for Attribute() | test-source |
 | test.py:60:13:60:16 | ControlFlowNode for self | test-source |
 | test.py:60:24:60:28 | ControlFlowNode for named | test-source |

--- a/python/ql/test/library-tests/frameworks/data/test.py
+++ b/python/ql/test/library-tests/frameworks/data/test.py
@@ -48,7 +48,7 @@ sub = SubClass()
 class Sub2Class (CommonTokens.Class):
     pass
 
-sub2 = Sub2Class() # TODO: Currently not recognized as an instance of CommonTokens.Class
+sub2 = Sub2Class()
 
 val = inst.foo()
 


### PR DESCRIPTION
This also adds a new member predicate to `API::Node`, but my intention is not to make changes to the interpretation of the API graph yet, although we do want to follow subclasses here also at some point.