### PR TITLE
C#: Lift models.

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/ExternalFlow.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/ExternalFlow.qll
@@ -94,6 +94,8 @@ private import FlowSummaryImpl::Public
 private import FlowSummaryImpl::Private
 private import FlowSummaryImpl::Private::External
 private import semmle.code.csharp.commons.QualifiedName
+private import semmle.code.csharp.dispatch.OverridableCallable
+private import semmle.code.csharp.frameworks.System
 private import codeql.mad.ModelValidation as SharedModelVal
 
 private predicate relevantNamespace(string namespace) {
@@ -442,20 +444,16 @@ predicate sourceNode(Node node, string kind) { sourceNode(node, kind, _) }
  */
 predicate sinkNode(Node node, string kind) { sinkNode(node, kind, _) }
 
-/** Holds if the summary should apply for all overrides of `c`. */
-predicate isBaseCallableOrPrototype(UnboundCallable c) {
-  c.getDeclaringType() instanceof Interface
-  or
-  exists(Modifiable m | m = [c.(Modifiable), c.(Accessor).getDeclaration()] |
-    m.isAbstract()
-    or
-    c.getDeclaringType().(Modifiable).isAbstract() and m.(Virtualizable).isVirtual()
+private predicate isOverridableCallable(OverridableCallable c) {
+  not exists(Type t, Callable base | c.getOverridee+() = base and t = base.getDeclaringType() |
+    t instanceof SystemObjectClass or
+    t instanceof SystemValueTypeClass
   )
 }
 
 /** Gets a string representing whether the summary should apply for all overrides of `c`. */
 private string getCallableOverride(UnboundCallable c) {
-  if isBaseCallableOrPrototype(c) then result = "true" else result = "false"
+  if isOverridableCallable(c) then result = "true" else result = "false"
 }
 
 private module QualifiedNameInput implements QualifiedNameInputSig {

--- a/csharp/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
+++ b/csharp/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
@@ -70,8 +70,8 @@ private Callable getARelevantOverrideeOrImplementee(Overridable m) {
 }
 
 /**
- * Gets the super implementation of `m` if it is relevant.
- * If such a super implementation does not exist, returns `m` if it is relevant.
+ * Gets the super implementation of `api` if it is relevant.
+ * If such a super implementation does not exist, returns `api` if it is relevant.
  */
 private Callable liftedImpl(Callable api) {
   (

--- a/csharp/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
+++ b/csharp/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
@@ -226,13 +226,24 @@ private predicate isRelevantMemberAccess(DataFlow::Node node) {
 
 predicate sinkModelSanitizer(DataFlow::Node node) { none() }
 
+private class ManualNeutralSinkCallable extends Callable {
+  ManualNeutralSinkCallable() {
+    this =
+      any(FlowSummaryImpl::Public::NeutralCallable nc |
+        nc.hasManualModel() and nc.getKind() = "sink"
+      )
+  }
+}
+
 /**
  * Holds if `source` is an api entrypoint relevant for creating sink models.
  */
 predicate apiSource(DataFlow::Node source) {
   (isRelevantMemberAccess(source) or source instanceof DataFlow::ParameterNode) and
-  relevant(source.getEnclosingCallable()) and
-  not hasManualModel(source.getEnclosingCallable())
+  exists(Callable enclosing | enclosing = source.getEnclosingCallable() |
+    relevant(enclosing) and
+    not enclosing instanceof ManualNeutralSinkCallable
+  )
 }
 
 /**

--- a/csharp/ql/src/utils/modelgenerator/internal/CaptureSummaryFlowQuery.qll
+++ b/csharp/ql/src/utils/modelgenerator/internal/CaptureSummaryFlowQuery.qll
@@ -81,10 +81,13 @@ string captureFlow(DataFlowTargetApi api) {
 }
 
 /**
- * Gets the neutral model for `api`, if any.
- * A neutral model is generated, if there does not exist summary model.
+ * Gets the neutral summary model for `api`, if any.
+ * A neutral summary model is generated, if we are not generating
+ * a summary model that applies to `api` and if it relevant to generate
+ * a model for `api`.
  */
 string captureNoFlow(DataFlowTargetApi api) {
-  not exists(captureFlow(api)) and
+  not exists(DataFlowTargetApi api0 | exists(captureFlow(api0)) and api0.lift() = api.lift()) and
+  api.isRelevant() and
   result = ModelPrinting::asNeutralSummaryModel(api)
 }

--- a/csharp/ql/test/library-tests/dataflow/library/FlowSummariesFiltered.ql
+++ b/csharp/ql/test/library-tests/dataflow/library/FlowSummariesFiltered.ql
@@ -1,6 +1,17 @@
 import shared.FlowSummaries
 private import semmle.code.csharp.dataflow.internal.ExternalFlow
 
+/** Holds if `c` is a base callable or prototype. */
+private predicate isBaseCallableOrPrototype(UnboundCallable c) {
+  c.getDeclaringType() instanceof Interface
+  or
+  exists(Modifiable m | m = [c.(Modifiable), c.(Accessor).getDeclaration()] |
+    m.isAbstract()
+    or
+    c.getDeclaringType().(Modifiable).isAbstract() and m.(Virtualizable).isVirtual()
+  )
+}
+
 class IncludeFilteredSummarizedCallable extends IncludeSummarizedCallable {
   /**
    * Holds if flow is propagated between `input` and `output` and

--- a/csharp/ql/test/utils/modelgenerator/dataflow/Summaries.cs
+++ b/csharp/ql/test/utils/modelgenerator/dataflow/Summaries.cs
@@ -245,7 +245,7 @@ public class DerivedClass1Flow : BaseClassFlow
 
 public class DerivedClass2Flow : BaseClassFlow
 {
-    // summary=Models;DerivedClass2Flow;false;ReturnParam;(System.Object);;Argument[0];ReturnValue;taint;df-generated
+    // summary=Models;BaseClassFlow;true;ReturnParam;(System.Object);;Argument[0];ReturnValue;taint;df-generated
     public override object ReturnParam(object input)
     {
         return input;
@@ -495,13 +495,12 @@ public class Inheritance
 {
     public abstract class BasePublic
     {
-        // neutral=Models;Inheritance+BasePublic;Id;(System.String);summary;df-generated
         public abstract string Id(string x);
     }
 
     public class AImplBasePublic : BasePublic
     {
-        // summary=Models;Inheritance+AImplBasePublic;false;Id;(System.String);;Argument[0];ReturnValue;taint;df-generated
+        // summary=Models;Inheritance+BasePublic;true;Id;(System.String);;Argument[0];ReturnValue;taint;df-generated
         public override string Id(string x)
         {
             return x;
@@ -510,19 +509,16 @@ public class Inheritance
 
     public interface IPublic1
     {
-        // neutral=Models;Inheritance+IPublic1;Id;(System.String);summary;df-generated
         string Id(string x);
     }
 
     public interface IPublic2
     {
-        // neutral=Models;Inheritance+IPublic2;Id;(System.String);summary;df-generated
         string Id(string x);
     }
 
     public abstract class B : IPublic1
     {
-        // neutral=Models;Inheritance+B;Id;(System.String);summary;df-generated
         public abstract string Id(string x);
     }
 
@@ -533,7 +529,7 @@ public class Inheritance
 
     public class BImpl : B
     {
-        // summary=Models;Inheritance+BImpl;false;Id;(System.String);;Argument[0];ReturnValue;taint;df-generated
+        // summary=Models;Inheritance+IPublic1;true;Id;(System.String);;Argument[0];ReturnValue;taint;df-generated
         public override string Id(string x)
         {
             return x;
@@ -542,6 +538,7 @@ public class Inheritance
 
     private class CImpl : C
     {
+        // summary=Models;Inheritance+IPublic2;true;Id;(System.String);;Argument[0];ReturnValue;taint;df-generated
         public override string Id(string x)
         {
             return x;

--- a/csharp/ql/test/utils/modelgenerator/dataflow/Summaries.cs
+++ b/csharp/ql/test/utils/modelgenerator/dataflow/Summaries.cs
@@ -490,3 +490,61 @@ public class ParameterlessConstructor
         IsInitialized = true;
     }
 }
+
+public class Inheritance
+{
+    public abstract class BasePublic
+    {
+        // neutral=Models;Inheritance+BasePublic;Id;(System.String);summary;df-generated
+        public abstract string Id(string x);
+    }
+
+    public class AImplBasePublic : BasePublic
+    {
+        // summary=Models;Inheritance+AImplBasePublic;false;Id;(System.String);;Argument[0];ReturnValue;taint;df-generated
+        public override string Id(string x)
+        {
+            return x;
+        }
+    }
+
+    public interface IPublic1
+    {
+        // neutral=Models;Inheritance+IPublic1;Id;(System.String);summary;df-generated
+        string Id(string x);
+    }
+
+    public interface IPublic2
+    {
+        // neutral=Models;Inheritance+IPublic2;Id;(System.String);summary;df-generated
+        string Id(string x);
+    }
+
+    public abstract class B : IPublic1
+    {
+        // neutral=Models;Inheritance+B;Id;(System.String);summary;df-generated
+        public abstract string Id(string x);
+    }
+
+    private abstract class C : IPublic2
+    {
+        public abstract string Id(string x);
+    }
+
+    public class BImpl : B
+    {
+        // summary=Models;Inheritance+BImpl;false;Id;(System.String);;Argument[0];ReturnValue;taint;df-generated
+        public override string Id(string x)
+        {
+            return x;
+        }
+    }
+
+    private class CImpl : C
+    {
+        public override string Id(string x)
+        {
+            return x;
+        }
+    }
+}

--- a/csharp/ql/test/utils/modelgenerator/dataflow/Summaries.cs
+++ b/csharp/ql/test/utils/modelgenerator/dataflow/Summaries.cs
@@ -544,4 +544,22 @@ public class Inheritance
             return x;
         }
     }
+
+    public interface IPublic3
+    {
+        string Prop { get; }
+    }
+
+    public abstract class D : IPublic3
+    {
+        public abstract string Prop { get; }
+    }
+
+    public class DImpl : D
+    {
+        private string tainted;
+
+        // summary=Models;Inheritance+IPublic3;true;get_Prop;();;Argument[this];ReturnValue;taint;df-generated
+        public override string Prop { get { return tainted; } }
+    }
 }


### PR DESCRIPTION
In this PR we align the C# model generator lifting and override logic with Java.
That is,
- Models are now lifted to the top base class within the source code. However, we exclude `Object` and `ValueType` as this causes issues when generating models for .NET runtime (as these class definitions are included in the .NET runtime source code).
- The extensible logic is changed; We now say that models should apply to all overrides with the exception of overrides of methods defined on `Object` and `ValueType` (as class or value type implicitly extend these).

Furthermore, we also make a small fix related to sink model discovery. We only want to exclude generation of these, if there exist a neutral sink model (and not a neutral summary model).