### PR TITLE
Make GITHUB_TOKEN in lfs_probe a fallback rather than an override

### DIFF
--- a/misc/bazel/internal/git_lfs_probe.py
+++ b/misc/bazel/internal/git_lfs_probe.py
@@ -68,17 +68,16 @@ def get_endpoint():
     # see https://github.com/actions/checkout/blob/44c2b7a8a4ea60a981eaca3cf939b5f4305c123b/src/git-auth-helper.ts#L56-L63
     auth = git("config", f"http.{url.scheme}://{url.netloc}/.extraheader")
     endpoint.update_headers(get_env(auth, sep=": "))
+    if "GITHUB_TOKEN" in os.environ and os.environ.get("GITHUB_TOKEN") != "":
+        endpoint.headers["Authorization"] = f"token {os.environ['GITHUB_TOKEN']}"
     if "Authorization" not in endpoint.headers:
-        if "GITHUB_TOKEN" in os.environ:
-            endpoint.headers["Authorization"] = f"token {os.environ['GITHUB_TOKEN']}"
-        else:
-            # last chance: use git credentials (possibly backed by a credential helper like the one installed by gh)
-            # see https://git-scm.com/docs/git-credential
-            credentials = get_env(git("credential", "fill", check=True,
-                                    # drop leading / from url.path
-                                    input=f"protocol={url.scheme}\nhost={url.netloc}\npath={url.path[1:]}\n"))
-            auth = base64.b64encode(f'{credentials["username"]}:{credentials["password"]}'.encode()).decode('ascii')
-            endpoint.headers["Authorization"] = f"Basic {auth}"
+        # last chance: use git credentials (possibly backed by a credential helper like the one installed by gh)
+        # see https://git-scm.com/docs/git-credential
+        credentials = get_env(git("credential", "fill", check=True,
+                                  # drop leading / from url.path
+                                  input=f"protocol={url.scheme}\nhost={url.netloc}\npath={url.path[1:]}\n"))
+        auth = base64.b64encode(f'{credentials["username"]}:{credentials["password"]}'.encode()).decode('ascii')
+        endpoint.headers["Authorization"] = f"Basic {auth}"
     return endpoint
 
 

--- a/misc/bazel/internal/git_lfs_probe.py
+++ b/misc/bazel/internal/git_lfs_probe.py
@@ -68,16 +68,17 @@ def get_endpoint():
     # see https://github.com/actions/checkout/blob/44c2b7a8a4ea60a981eaca3cf939b5f4305c123b/src/git-auth-helper.ts#L56-L63
     auth = git("config", f"http.{url.scheme}://{url.netloc}/.extraheader")
     endpoint.update_headers(get_env(auth, sep=": "))
-    if "GITHUB_TOKEN" in os.environ:
-        endpoint.headers["Authorization"] = f"token {os.environ['GITHUB_TOKEN']}"
     if "Authorization" not in endpoint.headers:
-        # last chance: use git credentials (possibly backed by a credential helper like the one installed by gh)
-        # see https://git-scm.com/docs/git-credential
-        credentials = get_env(git("credential", "fill", check=True,
-                                  # drop leading / from url.path
-                                  input=f"protocol={url.scheme}\nhost={url.netloc}\npath={url.path[1:]}\n"))
-        auth = base64.b64encode(f'{credentials["username"]}:{credentials["password"]}'.encode()).decode('ascii')
-        endpoint.headers["Authorization"] = f"Basic {auth}"
+        if "GITHUB_TOKEN" in os.environ:
+            endpoint.headers["Authorization"] = f"token {os.environ['GITHUB_TOKEN']}"
+        else:
+            # last chance: use git credentials (possibly backed by a credential helper like the one installed by gh)
+            # see https://git-scm.com/docs/git-credential
+            credentials = get_env(git("credential", "fill", check=True,
+                                    # drop leading / from url.path
+                                    input=f"protocol={url.scheme}\nhost={url.netloc}\npath={url.path[1:]}\n"))
+            auth = base64.b64encode(f'{credentials["username"]}:{credentials["password"]}'.encode()).decode('ascii')
+            endpoint.headers["Authorization"] = f"Basic {auth}"
     return endpoint
 
 

--- a/misc/bazel/internal/git_lfs_probe.py
+++ b/misc/bazel/internal/git_lfs_probe.py
@@ -68,7 +68,7 @@ def get_endpoint():
     # see https://github.com/actions/checkout/blob/44c2b7a8a4ea60a981eaca3cf939b5f4305c123b/src/git-auth-helper.ts#L56-L63
     auth = git("config", f"http.{url.scheme}://{url.netloc}/.extraheader")
     endpoint.update_headers(get_env(auth, sep=": "))
-    if "GITHUB_TOKEN" in os.environ and os.environ.get("GITHUB_TOKEN") != "":
+    if os.environ.get("GITHUB_TOKEN"):
         endpoint.headers["Authorization"] = f"token {os.environ['GITHUB_TOKEN']}"
     if "Authorization" not in endpoint.headers:
         # last chance: use git credentials (possibly backed by a credential helper like the one installed by gh)


### PR DESCRIPTION
This will fix external Codespaces tests failures related to lfs-probe 