### PR TITLE
JS: Update the insecure-randomness QHelp

### DIFF
--- a/javascript/ql/src/Security/CWE-338/InsecureRandomness.qhelp
+++ b/javascript/ql/src/Security/CWE-338/InsecureRandomness.qhelp
@@ -36,7 +36,7 @@
 		<p>
 
 			For JavaScript in the browser,
-			<code>RandomSource.getRandomValues</code> provides a cryptographically
+			<code>crypto.getRandomValues</code> provides a cryptographically
 			secure pseudo-random number generator.
 
 		</p>
@@ -69,7 +69,7 @@
 
 	<references>
 		<li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Pseudorandom_number_generator">Pseudo-random number generator</a>.</li>
-		<li>Mozilla Developer Network: <a href="https://developer.mozilla.org/en-US/docs/Web/API/RandomSource/getRandomValues">RandomSource.getRandomValues</a>.</li>
+		<li>Mozilla Developer Network: <a href="https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues">Crypto: getRandomValues()</a>.</li>
 		<li>NodeJS: <a href="https://nodejs.org/api/crypto.html#crypto_crypto_randombytes_size_callback">crypto.randomBytes</a></li>
 	</references>
 </qhelp>

--- a/javascript/ql/src/Security/CWE-338/examples/InsecureRandomness_fixed.js
+++ b/javascript/ql/src/Security/CWE-338/examples/InsecureRandomness_fixed.js
@@ -2,5 +2,7 @@ function securePassword() {
     // GOOD: the random suffix is cryptographically secure
     var suffix = window.crypto.getRandomValues(new Uint32Array(1))[0];
     var password = "myPassword" + suffix;
-    return password;
+    
+    // GOOD: if a random value between 0 and 1 is desired
+    var secret = window.crypto.getRandomValues(new Uint32Array(1))[0] * Math.pow(2,-32);
 }


### PR DESCRIPTION
- `RandomSource` is not a thing anymore, and the MDN link made a 301 redirect to `Crypto` instead.  
- Added an example of how to get a floating point value between 0 and 1 with a cryptographically secure method.  

Fixes https://github.com/github/codeql/issues/16499