### PR TITLE
Go: make two barriers recognise named types whose underlying types are integer types

### DIFF
--- a/go/ql/lib/change-notes/2024-05-16-incorrect-integer-conversion-defined-types.md
+++ b/go/ql/lib/change-notes/2024-05-16-incorrect-integer-conversion-defined-types.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* A bug has been fixed which meant that the query `go/incorrect-integer-conversion` did not consider type assertions and type switches which use a defined type whose underlying type is an integer type. This may lead to fewer false positive alerts.

--- a/go/ql/lib/semmle/go/security/IncorrectIntegerConversionLib.qll
+++ b/go/ql/lib/semmle/go/security/IncorrectIntegerConversionLib.qll
@@ -422,7 +422,7 @@ class TypeAssertionCheck extends DataFlow::ExprNode, FlowStateTransformer {
   TypeAssertionCheck() {
     exists(TypeAssertExpr tae |
       this = DataFlow::exprNode(tae.getExpr()) and
-      it = tae.getTypeExpr().getType()
+      it = tae.getTypeExpr().getType().getUnderlyingType()
     )
   }
 
@@ -442,7 +442,7 @@ class TypeSwitchVarFlowStateTransformer extends DataFlow::SsaNode, FlowStateTran
   TypeSwitchVarFlowStateTransformer() {
     exists(IR::TypeSwitchImplicitVariableInstruction insn, LocalVariable lv | insn.writes(lv, _) |
       this.getSourceVariable() = lv and
-      it = lv.getType()
+      it = lv.getType().getUnderlyingType()
     )
   }
 


### PR DESCRIPTION
A bug has been fixed which meant that the query `go/incorrect-integer-conversion` did not consider type assertions and type switches which use a defined type whose underlying type is an integer type. This may lead to fewer false positive alerts.