### PR TITLE
Python: Add tracking steps for class level attributes

### DIFF
--- a/python/ql/lib/change-notes/2024-05-18-type-tracking-class-attributes.md
+++ b/python/ql/lib/change-notes/2024-05-18-type-tracking-class-attributes.md
@@ -1,0 +1,4 @@
+---
+category: majorAnalysis
+---
+* Adds support for type tracking flow to class level attributes and default instance variables.


### PR DESCRIPTION
Adds support for type tracking for class level attributes and default instance variables. For example, to identify missing SQLExecution sinks for the SQLInjection DataFlow Rule. Also supports values inherited from base classes.

These SQLExecution sinks will be found:
```
from django.views import View
from django.db import connection

class ClassBasedView(View):
  _connection = connection
  def get(self, request):
     ...
     with self._connection.cursor() as cursor:
       cursor.execute("SELECT ... FROM ... WHERE")
     ...
  ...

class ClassBasedViewInit(View):
  def __init__(self, conn = connection):
    self._connection = conn
  ...
  def get(self, request):
    ...
    with self._connection.cursor() as cursor:
       cursor.execute("SELECT ... FROM ... WHERE")
    ...
  ...

// Inherited from base classes

class SubClassBasedView(ClassBasedView):
  def get(self, request):
    ...
    with self._connection.cursor() as cursor:
       cursor.execute("SELECT ... FROM ... WHERE")
    ...
  ...

class SubClassBasedViewInit(ClassBasedViewInit):
  def get(self, request):
    ...
    with self._connection.cursor() as cursor:
       cursor.execute("SELECT ... FROM ... WHERE")
    ...
  ...

```