### PR TITLE
C++: Static variables are initialized to zero or null by compiler

### DIFF
--- a/cpp/ql/src/Critical/NotInitialised.ql
+++ b/cpp/ql/src/Critical/NotInitialised.ql
@@ -54,6 +54,7 @@ predicate undefinedLocalUse(VariableAccess va) {
     // it is hard to tell when a struct or array has been initialized, so we
     // ignore them
     not isAggregateType(lv.getUnderlyingType()) and
+    not lv.isStatic() and  // static variables are initialized to zero or null by default
     not lv.getType().hasName("va_list") and
     va = lv.getAnAccess() and
     noDefPath(lv, va) and
@@ -70,7 +71,8 @@ predicate uninitialisedGlobal(GlobalVariable gv) {
     va = gv.getAnAccess() and
     va.isRValue() and
     not gv.hasInitializer() and
-    not gv.hasSpecifier("extern")
+    not gv.hasSpecifier("extern") and
+    not gv.isStatic()  // static variables are initialized to zero or null by default
   )
 }
 

--- a/cpp/ql/src/Critical/NotInitialised.ql
+++ b/cpp/ql/src/Critical/NotInitialised.ql
@@ -54,7 +54,7 @@ predicate undefinedLocalUse(VariableAccess va) {
     // it is hard to tell when a struct or array has been initialized, so we
     // ignore them
     not isAggregateType(lv.getUnderlyingType()) and
-    not lv.isStatic() and  // static variables are initialized to zero or null by default
+    not lv.isStatic() and // static variables are initialized to zero or null by default
     not lv.getType().hasName("va_list") and
     va = lv.getAnAccess() and
     noDefPath(lv, va) and
@@ -72,7 +72,7 @@ predicate uninitialisedGlobal(GlobalVariable gv) {
     va.isRValue() and
     not gv.hasInitializer() and
     not gv.hasSpecifier("extern") and
-    not gv.isStatic()  // static variables are initialized to zero or null by default
+    not gv.isStatic() // static variables are initialized to zero or null by default
   )
 }
 

--- a/cpp/ql/src/change-notes/2024-05-19-avoid-reporting-static-variable.md
+++ b/cpp/ql/src/change-notes/2024-05-19-avoid-reporting-static-variable.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Reduce false positives of `NotInitialised.ql`. Static variables are initialised to zeros or nulls by default. See https://stackoverflow.com/questions/13251083/the-initialization-of-static-variables-in-c

--- a/cpp/ql/src/change-notes/2024-05-19-avoid-reporting-static-variable.md
+++ b/cpp/ql/src/change-notes/2024-05-19-avoid-reporting-static-variable.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* Reduce false positives of `NotInitialised.ql`. Static variables are initialised to zeros or nulls by default. See https://stackoverflow.com/questions/13251083/the-initialization-of-static-variables-in-c
+* The "Variable not initialized before use" query (`cpp/not-initialised`) no longer reports an alert on static variables.

--- a/cpp/ql/test/query-tests/Critical/NotInitialised/NotInitialised.expected
+++ b/cpp/ql/test/query-tests/Critical/NotInitialised/NotInitialised.expected
@@ -1,0 +1,2 @@
+| test.cpp:3:11:3:15 | local | Variable 'local' is not initialized. |
+| test.cpp:12:5:12:24 | uninitialised_global | Variable 'uninitialised_global' is not initialized. |

--- a/cpp/ql/test/query-tests/Critical/NotInitialised/NotInitialised.qlref
+++ b/cpp/ql/test/query-tests/Critical/NotInitialised/NotInitialised.qlref
@@ -1,0 +1,1 @@
+Critical/NotInitialised.ql

--- a/cpp/ql/test/query-tests/Critical/NotInitialised/test.cpp
+++ b/cpp/ql/test/query-tests/Critical/NotInitialised/test.cpp
@@ -1,0 +1,20 @@
+void test1() {
+  int local;
+  int x = local; // BAD
+
+  static int static_local;
+  int y = static_local; // GOOD
+
+  int initialised = 42;
+  int z = initialised; // GOOD
+}
+
+int uninitialised_global; // BAD
+static int uninitialised_static_global; // GOOD
+int initialized_global = 0; // GOOD
+
+void test2() {
+  int a = uninitialised_global;
+  int b = uninitialised_static_global;
+  int c = initialized_global;
+}


### PR DESCRIPTION
Static variables are initialized to zero or null by compiler, no need to get an initializer of them.
See https://stackoverflow.com/questions/13251083/the-initialization-of-static-variables-in-c
See 6.7.8/10 in the [C99 Standard](http://www.open-std.org/JTC1/sc22/wg14/www/docs/n1256.pdf)