### PR TITLE
Bazel/C#: avoid zipmerge

### DIFF
--- a/csharp/BUILD.bazel
+++ b/csharp/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
-load("@semmle_code//:common.bzl", "zipmerge")
 load("@semmle_code//:dist.bzl", "dist")
+load("//misc/bazel:pkg.bzl", "codeql_pkg_files_overlay")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -50,15 +50,18 @@ pkg_files(
     ],
 )
 
-# See `csharp.bzl` for an explanation of why we need zipmerge here
-zipmerge(
-    name = "extractor-arch",
+codeql_pkg_files_overlay(
+    name = "extractor-arch-overlay",
     srcs = [
-        "//csharp/autobuilder/Semmle.Autobuild.CSharp:Semmle.Autobuild.CSharp.zip",
-        "//csharp/extractor/Semmle.Extraction.CSharp.Driver:Semmle.Extraction.CSharp.Driver.zip",
-        "//csharp/extractor/Semmle.Extraction.CSharp.Standalone:Semmle.Extraction.CSharp.Standalone.zip",
+        "//csharp/autobuilder/Semmle.Autobuild.CSharp",
+        "//csharp/extractor/Semmle.Extraction.CSharp.Driver",
+        "//csharp/extractor/Semmle.Extraction.CSharp.Standalone",
     ],
-    out = "extractor-arch.zip",
+)
+
+dist(
+    name = "extractor-arch",
+    srcs = [":extractor-arch-overlay"],
 )
 
 dist(

--- a/misc/bazel/csharp.bzl
+++ b/misc/bazel/csharp.bzl
@@ -60,14 +60,10 @@ def codeql_csharp_binary(name, **kwargs):
         ),
     )
 
-    # we need to declare individual zip targets for each binary, as `self_contained=True` means that every binary target
-    # contributes the same runtime files. Bazel (rightfully) complains about this, so we work around this by creating individual zip files,
-    # and using zipmerge to produce the final extractor-arch file. For overlapping files, zipmerge chooses just one.
     pack_zip(
         name = name,
         srcs = [publish_binary_target],
         prefix = "csharp/tools/" + codeql_platform,
         strip_prefix = strip_prefix.files_only(),
-        compression_level = 0,
         visibility = visibility,
     )

--- a/misc/bazel/pkg.bzl
+++ b/misc/bazel/pkg.bzl
@@ -3,6 +3,7 @@ load("@rules_pkg//pkg:providers.bzl", "PackageFilegroupInfo", "PackageFilesInfo"
 def _pkg_overlay_impl(ctx):
     destinations = {}
     files = []
+    depsets = []
 
     for src in reversed(ctx.attr.srcs):
         pfi = src[PackageFilesInfo]
@@ -14,6 +15,7 @@ def _pkg_overlay_impl(ctx):
                 attributes = pfi.attributes,
             )
             files.append((new_pfi, src.label))
+            depsets.append(depset(dest_src_map.values()))
     return [
         PackageFilegroupInfo(
             pkg_files = reversed(files),
@@ -21,7 +23,7 @@ def _pkg_overlay_impl(ctx):
             pkg_symlinks = [],
         ),
         DefaultInfo(
-            files = depset(transitive = [src[DefaultInfo].files for src in ctx.attr.srcs]),
+            files = depset(transitive = reversed(depsets)),
         ),
     ]
 

--- a/misc/bazel/pkg.bzl
+++ b/misc/bazel/pkg.bzl
@@ -1,0 +1,35 @@
+load("@rules_pkg//pkg:providers.bzl", "PackageFilegroupInfo", "PackageFilesInfo")
+
+def _pkg_overlay_impl(ctx):
+    destinations = {}
+    files = []
+
+    for src in reversed(ctx.attr.srcs):
+        pfi = src[PackageFilesInfo]
+        dest_src_map = {k: v for k, v in pfi.dest_src_map.items() if k not in destinations}
+        destinations.update({k: True for k in dest_src_map})
+        if dest_src_map:
+            new_pfi = PackageFilesInfo(
+                dest_src_map = dest_src_map,
+                attributes = pfi.attributes,
+            )
+            files.append((new_pfi, src.label))
+    return [
+        PackageFilegroupInfo(
+            pkg_files = reversed(files),
+            pkg_dirs = [],
+            pkg_symlinks = [],
+        ),
+        DefaultInfo(
+            files = depset(transitive = [src[DefaultInfo].files for src in ctx.attr.srcs]),
+        ),
+    ]
+
+codeql_pkg_files_overlay = rule(
+    implementation = _pkg_overlay_impl,
+    doc = "Combine `pkg_files` targets so that later targets overwrite earlier ones without warnings",
+    attrs = {
+        # this could be updated to handle PackageFilegroupInfo as well if we ever need it
+        "srcs": attr.label_list(providers = [PackageFilesInfo, DefaultInfo]),
+    },
+)


### PR DESCRIPTION
This uses a rule to combine `pkg_rules` targets with no overlap (with latest entries taking priority over earlier ones)