### PR TITLE
JS: fix that very large TypeScript files would crash the extractor

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -735,6 +735,7 @@ public class AutoBuild {
          .collect(Collectors.toList());
 
     filesToExtract = filesToExtract.stream()
+        .filter(p -> !isFileTooLarge(p))
         .sorted(PATH_ORDERING)
         .collect(Collectors.toCollection(() -> new LinkedHashSet<>()));
 
@@ -1063,9 +1064,6 @@ protected DependencyInstallationResult preparePackagesAndDependencies(Set<Path> 
           if (extractedFiles.contains(sourcePath)) {
             continue;
           }
-          if (isFileTooLarge(sourcePath)) {
-            continue;
-          }
           typeScriptFiles.add(sourcePath);
         }
         typeScriptFiles.sort(PATH_ORDERING);
@@ -1083,8 +1081,7 @@ protected DependencyInstallationResult preparePackagesAndDependencies(Set<Path> 
       List<Path> remainingTypeScriptFiles = new ArrayList<>();
       for (Path f : files) {
         if (!extractedFiles.contains(f)
-            && extractors.fileType(f) == FileType.TYPESCRIPT
-            && !isFileTooLarge(f)) {
+            && extractors.fileType(f) == FileType.TYPESCRIPT) {
           remainingTypeScriptFiles.add(f);
         }
       }
@@ -1248,9 +1245,6 @@ protected DependencyInstallationResult preparePackagesAndDependencies(Set<Path> 
     File f = file.toFile();
     if (!f.exists()) {
       warn("Skipping " + file + ", which does not exist.");
-      return;
-    }
-    if (isFileTooLarge(file)) {
       return;
     }
 

--- a/javascript/ql/lib/change-notes/2024-05-21-big-ts-files.md
+++ b/javascript/ql/lib/change-notes/2024-05-21-big-ts-files.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* Fixed a bug where very large TypeScript files would cause database creation to crash. Large files over 10MB were already excluded from analysis, but the file size check was not applied to TypeScript files.


### PR DESCRIPTION
Should fix: https://github.com/github/codeql/issues/13656 

I replicated the issue locally. We didn't exclude large files from the TypeScript extraction, only the plain JavaScript extraction. 