### PR TITLE
C++: Fix `cpp/use-of-unique-pointer-after-lifetime-ends` FP

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-416/UseOfUniquePointerAfterLifetimeEnds.ql
+++ b/cpp/ql/src/Security/CWE/CWE-416/UseOfUniquePointerAfterLifetimeEnds.ql
@@ -30,7 +30,8 @@ where
   outlivesFullExpr(c) and
   not c.isFromUninstantiatedTemplate(_) and
   isUniquePointerDerefFunction(c.getTarget()) and
-  not c.getActualType() instanceof BoolType and
+  // Exclude cases where the pointer is implicitly converted to a non-pointer type
+  not c.getActualType() instanceof IntegralType and
   isTemporary(c.getQualifier().getFullyConverted())
 select c,
   "The underlying unique pointer object is destroyed after the call to '" + c.getTarget() +

--- a/cpp/ql/src/Security/CWE/CWE-416/UseOfUniquePointerAfterLifetimeEnds.ql
+++ b/cpp/ql/src/Security/CWE/CWE-416/UseOfUniquePointerAfterLifetimeEnds.ql
@@ -30,6 +30,7 @@ where
   outlivesFullExpr(c) and
   not c.isFromUninstantiatedTemplate(_) and
   isUniquePointerDerefFunction(c.getTarget()) and
+  not c.getActualType() instanceof BoolType and
   isTemporary(c.getQualifier().getFullyConverted())
 select c,
   "The underlying unique pointer object is destroyed after the call to '" + c.getTarget() +

--- a/cpp/ql/src/change-notes/2024-05-22-use-of-unique-pointer-after-lifetime-ends-fp.md
+++ b/cpp/ql/src/change-notes/2024-05-22-use-of-unique-pointer-after-lifetime-ends-fp.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The "Use of unique pointer after lifetime ends" query (`cpp/use-of-unique-pointer-after-lifetime-ends`) no longer reports an alert when the pointer is converted to a boolean

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/UseOfUniquePtrAfterLifetimeEnds/UseOfUniquePointerAfterLifetimeEnds.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/UseOfUniquePtrAfterLifetimeEnds/UseOfUniquePointerAfterLifetimeEnds.expected
@@ -9,4 +9,3 @@
 | test.cpp:177:16:177:16 | call to operator* | The underlying unique pointer object is destroyed after the call to 'operator*' returns. |
 | test.cpp:177:36:177:36 | call to operator* | The underlying unique pointer object is destroyed after the call to 'operator*' returns. |
 | test.cpp:179:11:179:11 | call to operator* | The underlying unique pointer object is destroyed after the call to 'operator*' returns. |
-| test.cpp:209:29:209:31 | call to get | The underlying unique pointer object is destroyed after the call to 'get' returns. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/UseOfUniquePtrAfterLifetimeEnds/UseOfUniquePointerAfterLifetimeEnds.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/UseOfUniquePtrAfterLifetimeEnds/UseOfUniquePointerAfterLifetimeEnds.expected
@@ -9,3 +9,4 @@
 | test.cpp:177:16:177:16 | call to operator* | The underlying unique pointer object is destroyed after the call to 'operator*' returns. |
 | test.cpp:177:36:177:36 | call to operator* | The underlying unique pointer object is destroyed after the call to 'operator*' returns. |
 | test.cpp:179:11:179:11 | call to operator* | The underlying unique pointer object is destroyed after the call to 'operator*' returns. |
+| test.cpp:209:29:209:31 | call to get | The underlying unique pointer object is destroyed after the call to 'get' returns. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/UseOfUniquePtrAfterLifetimeEnds/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/UseOfUniquePtrAfterLifetimeEnds/test.cpp
@@ -204,3 +204,11 @@ void test2(bool b1, bool b2) {
   const S* s12;
   s12 = sRefRef.get(); // GOOD
 }
+
+void test_convert_to_bool() {
+  bool b = get_unique_ptr().get(); // GOOD [FALSE POSITIVE]
+
+  if(get_unique_ptr().get()) { // GOOD
+
+  }
+}

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/UseOfUniquePtrAfterLifetimeEnds/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/UseOfUniquePtrAfterLifetimeEnds/test.cpp
@@ -206,7 +206,7 @@ void test2(bool b1, bool b2) {
 }
 
 void test_convert_to_bool() {
-  bool b = get_unique_ptr().get(); // GOOD [FALSE POSITIVE]
+  bool b = get_unique_ptr().get(); // GOOD
 
   if(get_unique_ptr().get()) { // GOOD
 


### PR DESCRIPTION
This fixed a FP that @geoffw0 spotted earlier