### PR TITLE
C#: Simplify logic in `JsonWebTokenHandlerLib.qll`

### DIFF
--- a/csharp/ql/src/experimental/Security Features/JsonWebTokenHandler/delegated-security-validations-always-return-true.ql
+++ b/csharp/ql/src/experimental/Security Features/JsonWebTokenHandler/delegated-security-validations-always-return-true.ql
@@ -17,9 +17,7 @@ import DataFlow
 import JsonWebTokenHandlerLib
 import semmle.code.csharp.commons.QualifiedName
 
-from
-  TokenValidationParametersProperty p, CallableAlwaysReturnsTrueHigherPrecision e, string qualifier,
-  string name
+from TokenValidationParametersProperty p, CallableAlwaysReturnsTrue e, string qualifier, string name
 where e = p.getAnAssignedValue() and p.hasFullyQualifiedName(qualifier, name)
 select e,
   "JsonWebTokenHandler security-sensitive property $@ is being delegated to this callable that always returns \"true\".",


### PR DESCRIPTION
Generalized `CallableAlwaysReturnsTrue` for lambdas. Also removed `CallableAlwaysReturnsTrueHigherPrecision`, since the supposed extra `callableOnlyThrowsArgumentNullException(this)` condition is already imposed in `CallableAlwaysReturnsTrue`.