### PR TITLE
Java: Improve dispatch through TypeFlow of effectively private calls.

### DIFF
--- a/java/ql/lib/change-notes/2024-05-23-typeflow-precision.md
+++ b/java/ql/lib/change-notes/2024-05-23-typeflow-precision.md
@@ -1,0 +1,4 @@
+---
+category: majorAnalysis
+---
+* The precision of virtual dispatch has been improved. This increases precision in general for all data flow queries. 

--- a/java/ql/lib/semmle/code/java/dataflow/TypeFlow.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/TypeFlow.qll
@@ -63,12 +63,24 @@ private module Input implements TypeFlowInput<Location> {
 
   class Type = RefType;
 
+  private SrcCallable viableCallable_v1(Call c) {
+    result = viableImpl_v1(c)
+    or
+    c instanceof ConstructorCall and result = c.getCallee().getSourceDeclaration()
+  }
+
   /**
-   * Holds if `arg` is an argument for the parameter `p` in a private callable.
+   * Holds if `arg` is an argument for the parameter `p` in a sufficiently
+   * private callable that the closed-world assumption applies.
    */
   private predicate privateParamArg(Parameter p, Argument arg) {
-    p.getAnArgument() = arg and
-    p.getCallable().isPrivate()
+    exists(SrcCallable c, Call call |
+      c = p.getCallable() and
+      not c.isImplicitlyPublic() and
+      not p.isVarargs() and
+      c = viableCallable_v1(call) and
+      call.getArgument(pragma[only_bind_into](pragma[only_bind_out](p.getPosition()))) = arg
+    )
   }
 
   /**

--- a/java/ql/test/library-tests/dispatch/ViableCallable.java
+++ b/java/ql/test/library-tests/dispatch/ViableCallable.java
@@ -1,5 +1,5 @@
 
-class ViableCallable {
+public class ViableCallable {
 	public <T1, T2, T3> void Run(C1<T1, T2> x1, C1<T1[], T2> x2, T1 t1, T1[] t1s) {
 		// Viable callables: C2.M(), C3.M(), C4.M(), C5.M(), C6.M(), C7.M(), C8.M(), C9.M()
 		x1.M(t1, 8);


### PR DESCRIPTION
This improves TypeFlow to account for more argument-parameter pairs. Previously this was restricted to private callables, as we need to ensure that a proper closed-world assumption applies, since we're doing a universal flow calculation, but this can be extended to all callables that aren't implicitly public.

Improved TypeFlow means improved virtual dispatch, which ought to translate to more precise data flow.