### PR TITLE
Java: Fix join-order in viableImplInCallContext.

### DIFF
--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowDispatch.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowDispatch.qll
@@ -122,12 +122,18 @@ private module DispatchImpl {
     mayBenefitFromCallContext(call.asCall(), _, _)
   }
 
+  bindingset[call, tgt]
+  pragma[inline_late]
+  private predicate viableCallableFilter(DataFlowCall call, DataFlowCallable tgt) {
+    tgt = viableCallable(call)
+  }
+
   /**
    * Gets a viable dispatch target of `call` in the context `ctx`. This is
    * restricted to those `call`s for which a context might make a difference.
    */
   DataFlowCallable viableImplInCallContext(DataFlowCall call, DataFlowCall ctx) {
-    result = viableCallable(call) and
+    viableCallableFilter(call, result) and
     exists(int i, Callable c, Method def, RefType t, boolean exact, MethodCall ma |
       ma = call.asCall() and
       mayBenefitFromCallContext(ma, c, i) and


### PR DESCRIPTION
Before:
```
[2024-05-23 11:42:53] Evaluated non-recursive predicate DataFlowDispatch::viableImplInCallContext/2#80593438@6b3107v1 in 58322ms (size: 8133273).
Evaluated relational algebra for predicate DataFlowDispatch::viableImplInCallContext/2#80593438@6b3107v1 with tuple counts:
            584084   ~4%    {3} r1 = JOIN `Expr::MethodCall.getMethod/0#dispred#41989dc9` WITH num#DataFlowPrivate::TCall#52d9e003 ON FIRST 1 OUTPUT Lhs.1, Lhs.0, Rhs.1
                        
            584084   ~0%    {2} r2 = JOIN r1 WITH `Member::Method.getSourceDeclaration/0#dispred#93e6cdf8` ON FIRST 1 OUTPUT Lhs.1, Lhs.2
             22431   ~5%    {4}    | JOIN WITH `DataFlowDispatch::mayBenefitFromCallContext/3#b7976ae1` ON FIRST 1 OUTPUT Rhs.1, Lhs.0, Lhs.1, Rhs.2
             22431   ~3%    {4}    | JOIN WITH num#DataFlowPrivate::TSrcCallable#bc4053c4 ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3
           1103206   ~3%    {4}    | JOIN WITH `DataFlowImplCommon::Cached::viableCallableCached/1#65ba69d9_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3
           1103206   ~0%    {5}    | JOIN WITH num#DataFlowPrivate::TCall#52d9e003_10#join_rhs ON FIRST 1 OUTPUT Lhs.2, Lhs.1, Lhs.3, Lhs.0, Rhs.1
          12560128   ~4%    {6}    | JOIN WITH `DataFlowImplCommon::Cached::viableCallableCached/1#65ba69d9` ON FIRST 1 OUTPUT Lhs.4, Lhs.2, Lhs.1, Lhs.0, Lhs.3, Rhs.1
          12497899   ~1%    {4}    | JOIN WITH `DataFlowDispatch::contextArgHasType/4#55a03efe` ON FIRST 2 OUTPUT Lhs.5, Lhs.2, Lhs.3, Lhs.4
                 0   ~0%    {5}    | JOIN WITH num#DataFlowPrivate::TSummarizedCallable#5b5918e9_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.0
                 0   ~0%    {3}    | JOIN WITH `FlowSummary::SummarizedCallableBase.getACall/0#dispred#08f1128e` ON FIRST 2 OUTPUT Lhs.2, Lhs.3, Lhs.4
                        
            584084   ~2%    {3} r3 = JOIN r1 WITH `Member::Method.getSourceDeclaration/0#dispred#93e6cdf8` ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Rhs.1
             22431   ~0%    {4}    | JOIN WITH `DataFlowDispatch::mayBenefitFromCallContext/3#b7976ae1` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Rhs.2
             22431   ~0%    {4}    | JOIN WITH num#DataFlowPrivate::TSrcCallable#bc4053c4 ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3
           1103206   ~0%    {4}    | JOIN WITH `DataFlowImplCommon::Cached::viableCallableCached/1#65ba69d9_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3
           1103206   ~2%    {5}    | JOIN WITH num#DataFlowPrivate::TCall#52d9e003_10#join_rhs ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Lhs.3, Lhs.0, Rhs.1
          12560128   ~2%    {6}    | JOIN WITH `DataFlowImplCommon::Cached::viableCallableCached/1#65ba69d9` ON FIRST 1 OUTPUT Lhs.4, Lhs.2, Lhs.0, Lhs.1, Lhs.3, Rhs.1
        3263736483   ~0%    {6}    | JOIN WITH `DataFlowDispatch::contextArgHasType/4#55a03efe` ON FIRST 2 OUTPUT Lhs.2, Lhs.3, Lhs.4, Lhs.5, Rhs.2, Rhs.3
                        
        3263736483   ~6%    {7} r4 = SCAN r3 OUTPUT In.0, In.1, In.2, In.3, In.4, In.5, _
                            {6}    | REWRITE WITH Tmp.6 := true, TEST InOut.5 = Tmp.6 KEEPING 6
           6421434   ~0%    {5}    | SCAN OUTPUT In.3, In.0, In.1, In.2, In.4
           6421434   ~7%    {6}    | JOIN WITH num#DataFlowPrivate::TSrcCallable#bc4053c4_10#join_rhs ON FIRST 1 OUTPUT Lhs.4, Lhs.1, Lhs.2, Lhs.3, Lhs.0, Rhs.1
           6421434   ~0%    {6}    | JOIN WITH `Type::RefType.getSourceDeclaration/0#dispred#770ab75c` ON FIRST 1 OUTPUT Lhs.2, Rhs.1, Lhs.5, Lhs.1, Lhs.3, Lhs.4
            127997  ~14%    {3}    | JOIN WITH `VirtualDispatch::exactMethodImpl/2#9e3e3aa5` ON FIRST 3 OUTPUT Lhs.3, Lhs.4, Lhs.5
                        
        3263736483   ~6%    {7} r5 = SCAN r3 OUTPUT In.0, In.1, In.2, In.3, In.4, In.5, _
                            {6}    | REWRITE WITH Tmp.6 := false, TEST InOut.5 = Tmp.6 KEEPING 6
        3257315049   ~4%    {5}    | SCAN OUTPUT In.3, In.0, In.1, In.2, In.4
        3257315049   ~4%    {6}    | JOIN WITH num#DataFlowPrivate::TSrcCallable#bc4053c4_10#join_rhs ON FIRST 1 OUTPUT Lhs.4, Lhs.1, Lhs.2, Lhs.3, Lhs.0, Rhs.1
        3257315049   ~0%    {7}    | JOIN WITH `Type::RefType.getSourceDeclaration/0#dispred#770ab75c` ON FIRST 1 OUTPUT Lhs.2, Rhs.1, Lhs.5, Lhs.1, Lhs.3, Lhs.4, Lhs.0
          14415157   ~0%    {5}    | JOIN WITH `VirtualDispatch::viableMethodImpl/3#f3d33fd3_0132#join_rhs` ON FIRST 3 OUTPUT Lhs.6, Rhs.3, Lhs.3, Lhs.4, Lhs.5
                            {5}    | AND NOT `DataFlowDispatch::Unification::failsUnification/2#1602cda2`(FIRST 2)
          14415157  ~84%    {3}    | SCAN OUTPUT In.2, In.3, In.4
                        
          14543154  ~81%    {3} r6 = r2 UNION r4 UNION r5
                            return r6
```
After:
```
[2024-05-23 11:56:10] Evaluated non-recursive predicate DataFlowDispatch::viableImplInCallContext/2#80593438@f8ee8cgp in 425ms (size: 8133334).
Evaluated relational algebra for predicate DataFlowDispatch::viableImplInCallContext/2#80593438@f8ee8cgp with tuple counts:
          584084   ~4%    {3} r1 = JOIN `Expr::MethodCall.getMethod/0#dispred#41989dc9` WITH num#DataFlowPrivate::TCall#52d9e003 ON FIRST 1 OUTPUT Lhs.1, Lhs.0, Rhs.1
                      
          584084   ~0%    {2} r2 = JOIN r1 WITH `Member::Method.getSourceDeclaration/0#dispred#93e6cdf8` ON FIRST 1 OUTPUT Lhs.1, Lhs.2
           22431   ~5%    {4}    | JOIN WITH `DataFlowDispatch::mayBenefitFromCallContext/3#b7976ae1` ON FIRST 1 OUTPUT Rhs.1, Lhs.0, Lhs.1, Rhs.2
           22431   ~3%    {4}    | JOIN WITH num#DataFlowPrivate::TSrcCallable#bc4053c4 ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3
         1103206   ~3%    {4}    | JOIN WITH `DataFlowImplCommon::Cached::viableCallableCached/1#65ba69d9_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3
         1103206   ~0%    {5}    | JOIN WITH num#DataFlowPrivate::TCall#52d9e003_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.3, Lhs.1, Lhs.2, Lhs.0
         1101910   ~0%    {3}    | JOIN WITH `DataFlowDispatch::contextArgHasType/4#55a03efe` ON FIRST 2 OUTPUT Lhs.2, Lhs.3, Lhs.4
         1101910   ~0%    {3}    | JOIN WITH `FlowSummary::SummarizedCallableBase.getACall/0#dispred#08f1128e_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
               0   ~0%    {3}    | JOIN WITH num#DataFlowPrivate::TSummarizedCallable#5b5918e9 ON FIRST 1 OUTPUT Lhs.1, Rhs.1, Lhs.2
                      
          584084   ~2%    {3} r3 = JOIN r1 WITH `Member::Method.getSourceDeclaration/0#dispred#93e6cdf8` ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Rhs.1
           22431   ~0%    {4}    | JOIN WITH `DataFlowDispatch::mayBenefitFromCallContext/3#b7976ae1` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Rhs.2
           22431   ~0%    {4}    | JOIN WITH num#DataFlowPrivate::TSrcCallable#bc4053c4 ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3
         1103206   ~0%    {4}    | JOIN WITH `DataFlowImplCommon::Cached::viableCallableCached/1#65ba69d9_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3
         1103206   ~0%    {5}    | JOIN WITH num#DataFlowPrivate::TCall#52d9e003_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.3, Lhs.1, Lhs.2, Lhs.0
         8348830   ~0%    {5}    | JOIN WITH `DataFlowDispatch::contextArgHasType/4#55a03efe` ON FIRST 2 OUTPUT Lhs.2, Lhs.3, Lhs.4, Rhs.2, Rhs.3
                      
         8348830   ~0%    {6} r4 = SCAN r3 OUTPUT In.0, In.1, In.2, In.3, In.4, _
                          {5}    | REWRITE WITH Tmp.5 := true, TEST InOut.4 = Tmp.5 KEEPING 5
          147598   ~4%    {4}    | SCAN OUTPUT In.3, In.0, In.1, In.2
          147598   ~3%    {4}    | JOIN WITH `Type::RefType.getSourceDeclaration/0#dispred#770ab75c` ON FIRST 1 OUTPUT Lhs.2, Rhs.1, Lhs.1, Lhs.3
          144878  ~20%    {3}    | JOIN WITH `VirtualDispatch::exactMethodImpl/2#9e3e3aa5` ON FIRST 2 OUTPUT Rhs.2, Lhs.2, Lhs.3
          123267   ~5%    {3}    | JOIN WITH num#DataFlowPrivate::TSrcCallable#bc4053c4 ON FIRST 1 OUTPUT Lhs.1, Rhs.1, Lhs.2
                      
         8348830   ~0%    {6} r5 = SCAN r3 OUTPUT In.0, In.1, In.2, In.3, In.4, _
                          {5}    | REWRITE WITH Tmp.5 := false, TEST InOut.4 = Tmp.5 KEEPING 5
         8201232   ~4%    {4}    | SCAN OUTPUT In.3, In.0, In.1, In.2
         8201232   ~0%    {5}    | JOIN WITH `Type::RefType.getSourceDeclaration/0#dispred#770ab75c` ON FIRST 1 OUTPUT Lhs.2, Rhs.1, Lhs.1, Lhs.3, Lhs.0
        16136062   ~4%    {5}    | JOIN WITH `VirtualDispatch::viableMethodImpl/3#f3d33fd3` ON FIRST 2 OUTPUT Lhs.4, Rhs.2, Lhs.2, Lhs.3, Rhs.3
                          {5}    | AND NOT `DataFlowDispatch::Unification::failsUnification/2#1602cda2`(FIRST 2)
        16135458  ~64%    {3}    | SCAN OUTPUT In.4, In.2, In.3
         9780457   ~4%    {3}    | JOIN WITH num#DataFlowPrivate::TSrcCallable#bc4053c4 ON FIRST 1 OUTPUT Lhs.1, Rhs.1, Lhs.2
                      
         9903724   ~3%    {3} r6 = r2 UNION r4 UNION r5
         8136137   ~1%    {3}    | JOIN WITH `DataFlowImplCommon::Cached::viableCallableCached/1#65ba69d9` ON FIRST 2 OUTPUT Lhs.0, Lhs.2, Lhs.1
                          return r6
```
