### PR TITLE
Java: Do not lift neutrals in Model generation.

### DIFF
--- a/java/ql/src/utils/modelgenerator/internal/CaptureSummaryFlowQuery.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureSummaryFlowQuery.qll
@@ -79,5 +79,6 @@ string captureFlow(DataFlowTargetApi api) {
  */
 string captureNoFlow(DataFlowTargetApi api) {
   not exists(DataFlowTargetApi api0 | exists(captureFlow(api0)) and api0.lift() = api.lift()) and
+  api.isRelevant() and
   result = ModelPrinting::asNeutralSummaryModel(api)
 }

--- a/java/ql/test/utils/modelgenerator/dataflow/p/ImplOfExternalSPI.java
+++ b/java/ql/test/utils/modelgenerator/dataflow/p/ImplOfExternalSPI.java
@@ -7,7 +7,7 @@ import java.nio.file.Files;
 public class ImplOfExternalSPI extends AbstractImplOfExternalSPI {
 
   // sink=p;AbstractImplOfExternalSPI;true;accept;(File);;Argument[0];path-injection;df-generated
-  // neutral=p;AbstractImplOfExternalSPI;accept;(File);summary;df-generated
+  // neutral=p;ImplOfExternalSPI;accept;(File);summary;df-generated
   @Override
   public boolean accept(File pathname) {
     try {

--- a/java/ql/test/utils/modelgenerator/dataflow/p/Inheritance.java
+++ b/java/ql/test/utils/modelgenerator/dataflow/p/Inheritance.java
@@ -88,4 +88,29 @@ public class Inheritance {
       return s;
     }
   }
+
+  public interface INeutral {
+    String id(String s);
+  }
+
+  public class F implements INeutral {
+    // SPURIOUS-neutral=p;Inheritance$INeutral;id;(String);summary;df-generated
+    public String id(String s) {
+      return "";
+    }
+  }
+
+  public class G implements INeutral {
+    // SPURIOUS-neutral=p;Inheritance$INeutral;id;(String);summary;df-generated
+    public String id(String s) {
+      return "";
+    }
+  }
+
+  private class H implements INeutral {
+    // SPURIOUS-neutral=p;Inheritance$INeutral;id;(String);summary;df-generated
+    public String id(String s) {
+      return "";
+    }
+  }
 }

--- a/java/ql/test/utils/modelgenerator/dataflow/p/Inheritance.java
+++ b/java/ql/test/utils/modelgenerator/dataflow/p/Inheritance.java
@@ -94,21 +94,20 @@ public class Inheritance {
   }
 
   public class F implements INeutral {
-    // SPURIOUS-neutral=p;Inheritance$INeutral;id;(String);summary;df-generated
+    // neutral=p;Inheritance$F;id;(String);summary;df-generated
     public String id(String s) {
       return "";
     }
   }
 
   public class G implements INeutral {
-    // SPURIOUS-neutral=p;Inheritance$INeutral;id;(String);summary;df-generated
+    // neutral=p;Inheritance$G;id;(String);summary;df-generated
     public String id(String s) {
       return "";
     }
   }
 
   private class H implements INeutral {
-    // SPURIOUS-neutral=p;Inheritance$INeutral;id;(String);summary;df-generated
     public String id(String s) {
       return "";
     }

--- a/java/ql/test/utils/modelgenerator/dataflow/p/PrivateFlowViaPublicInterface.java
+++ b/java/ql/test/utils/modelgenerator/dataflow/p/PrivateFlowViaPublicInterface.java
@@ -45,7 +45,6 @@ public class PrivateFlowViaPublicInterface {
       return null;
     }
 
-    // neutral=p;PrivateFlowViaPublicInterface$SPI;openStreamNone;();summary;df-generated
     @Override
     public OutputStream openStreamNone() throws IOException {
       return new FileOutputStream(new RandomPojo().someFile);


### PR DESCRIPTION
As neutrals do not have a concept of applying to all overrides, the models should not be lifted. Instead we should generate summary neutrals for all "relevant" (public) methods that don't have a summary model that applies to them.