### PR TITLE
`monotonicAggregates` can apply to modules (see language spec)

### DIFF
--- a/docs/codeql/ql-language-reference/annotations.rst
+++ b/docs/codeql/ql-language-reference/annotations.rst
@@ -446,7 +446,7 @@ The ``pragma[assume_small_delta]`` annotation has no effect and can be safely re
 Language pragmas
 ================
 
-**Available for**: |classes|, |characteristic predicates|, |member predicates|, |non-member predicates|
+**Available for**: |modules|, |classes|, |characteristic predicates|, |member predicates|, |non-member predicates|
 
 ``language[monotonicAggregates]``
 ---------------------------------


### PR DESCRIPTION
Note that this is not a recent change, and the language specification has correctly stated this for at least 4 years in the [corresponding table](https://github.com/github/codeql/blob/c0d623c056c4491fad7711e949618629a6f23969/docs/codeql/ql-language-reference/ql-language-specification.rst?plain=1#L845-L849).

@kaspersv noted the need to fix this on [this PR](https://github.com/github/semmle-code/pull/50077#pullrequestreview-2074099312).