### PR TITLE
Rewrite recommendations for the query `cpp/no-space-for-terminator`

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-131/NoSpaceForZeroTerminator.qhelp
+++ b/cpp/ql/src/Security/CWE/CWE-131/NoSpaceForZeroTerminator.qhelp
@@ -12,8 +12,8 @@ the required buffer size, but do not allocate space for the zero terminator.
 </overview>
 <recommendation>
 <p>
-The expression highlighted by this rule creates a buffer that is of insufficient size to contain
-the data being copied. This makes the code vulnerable to buffer overflow which can result in anything from a segmentation fault to a security vulnerability (particularly if the array is on stack-allocated memory).
+The highlighted code segment creates a buffer without ensuring it's large enough to accommodate the copied data.
+This leaves the code susceptible to a buffer overflow attack, which could lead to anything from program crashes to malicious code execution.
 </p>
 
 <p>


### PR DESCRIPTION
This PR aims to improve the recommendations with the following changes:

- Replace segmentation fault with crash that is platform agnostic (I think segmentation fault is not really a thing on Windows).
- Replace security vulnerability with malicious code execution. This provides a range of issues, because a crash (previously segmentation fault) could also be considered a security vulnerability. Namely a DOS.
- Removed the additional note on stack allocated arrays which seem confusing because we are always talking about buffers allocated on the heap.