### PR TITLE
Python: Add models for `opml`

### DIFF
--- a/python/ql/lib/semmle/python/Frameworks.qll
+++ b/python/ql/lib/semmle/python/Frameworks.qll
@@ -44,6 +44,7 @@ private import semmle.python.frameworks.Multidict
 private import semmle.python.frameworks.Mysql
 private import semmle.python.frameworks.MySQLdb
 private import semmle.python.frameworks.Numpy
+private import semmle.python.frameworks.Opml
 private import semmle.python.frameworks.Oracledb
 private import semmle.python.frameworks.Pandas
 private import semmle.python.frameworks.Peewee

--- a/python/ql/lib/semmle/python/frameworks/Opml.qll
+++ b/python/ql/lib/semmle/python/frameworks/Opml.qll
@@ -1,0 +1,64 @@
+/**
+ * Provides classes modeling security-relevant aspects of the `opml` PyPI package.
+ *
+ * See
+ * - https://pypi.org/project/opml/
+ */
+
+private import python
+private import semmle.python.dataflow.new.DataFlow
+private import semmle.python.Concepts
+private import semmle.python.ApiGraphs
+
+/**
+ * Provides classes modeling security-relevant aspects of the `opml` PyPI package
+ *
+ * See
+ * - https://pypi.org/project/opml/
+ */
+private module Opml {
+  /**
+   * A call to the `xpath` method of a parsed document.
+   *
+   *    import opml
+   *    root = opml.from_string(file(XML_DB).read())
+   *    find_text = root.xpath("`sink`")
+   */
+  private class XPathCall extends XML::XPathExecution::Range, DataFlow::CallCfgNode {
+    XPathCall() {
+      exists(API::Node parseResult |
+        parseResult = API::moduleImport("opml").getMember(["parse", "from_string"]).getReturn()
+      |
+        this = parseResult.getMember("xpath").getACall()
+      )
+    }
+
+    override DataFlow::Node getXPath() { result = this.getArg(0) }
+
+    override string getName() { result = "opml" }
+  }
+
+  /**
+   * A call to either of:
+   * - `opml.parse`
+   * - `opml.from_string`
+   */
+  private class OpmlParsing extends DataFlow::CallCfgNode, XML::XmlParsing::Range {
+    OpmlParsing() {
+      this = API::moduleImport("opml").getMember(["parse", "from_string"]).getACall()
+    }
+
+    override DataFlow::Node getAnInput() { result = this.getArg(0) }
+
+    DataFlow::Node getParserArg() { none() }
+
+    /**
+     * The same as `Lxml::LxmlParsing::vulnerableTo`, because `opml` uses `lxml` for parsing.
+     */
+    override predicate vulnerableTo(XML::XmlParsingVulnerabilityKind kind) { kind.isXxe() }
+
+    override predicate mayExecuteInput() { none() }
+
+    override DataFlow::Node getOutput() { result = this }
+  }
+}

--- a/python/ql/src/change-notes/2024-05-27-opml-models.md
+++ b/python/ql/src/change-notes/2024-05-27-opml-models.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added models for `opml` library.


### PR DESCRIPTION
Adds models for https://pypi.org/project/opml

<details><summary>Source code</summary>
$ pip3 install opml

$ cat /usr/local/python/3.10.13/lib/python3.10/site-packages/opml/*.py

```python
import lxml.etree

class OutlineElement(object):
    """A single outline object."""

    def __init__(self, root):
        """Initialize from the root <outline> node."""

        self._root = root

    def __getattr__(self, attr):

        if attr in self._root.attrib:
            return self._root.attrib[attr]

        raise AttributeError()

    @property
    def _outlines(self):
        """Return the available sub-outline objects as a seqeunce."""

        return [OutlineElement(n) for n in self._root.xpath('./outline')]

    def __len__(self):
        return len(self._outlines)

    def __getitem__(self, index):
        return self._outlines[index]

class Opml(object):
    """Python representation of an OPML file."""

    def __init__(self, xml_tree):
        """Initialize the object using the parsed XML tree."""

        self._tree = xml_tree

    def __getattr__(self, attr):
        """Fall back attribute handler -- attempt to find the attribute in 
        the OPML <head>."""

        result = self._tree.xpath('/opml/head/%s/text()' % attr)
        if len(result) == 1:
            return result[0]

        raise AttributeError()

    @property
    def _outlines(self):
        """Return the available sub-outline objects as a seqeunce."""

        return [OutlineElement(n) for n in self._tree.xpath(
                '/opml/body/outline')]

    def __len__(self):
        return len(self._outlines)

    def __getitem__(self, index):
        return self._outlines[index]

def from_string(opml_text):

    return Opml(lxml.etree.fromstring(opml_text))

def parse(opml_url):

    return Opml(lxml.etree.parse(opml_url))
```
</details>