### PR TITLE
C++: Make the padding test independent of the `predefined_macros` file

### DIFF
--- a/cpp/ql/test/library-tests/padding/options
+++ b/cpp/ql/test/library-tests/padding/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: -D__x86_64=1


### PR DESCRIPTION
The padding test is the only test that currently depends on the contents of the `predefined_macros` file that we ship with CodeQL for use with the CodeQL tests. Explicitly specifying `__x86_64` makes the test independent of the contents of the file.