### PR TITLE
Data flow: Fix bad join

### DIFF
--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -3370,6 +3370,11 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       Location getLocation() { result = p.getLocation() }
     }
 
+    pragma[nomagic]
+    private predicate stage5ConsCand(Content c, DataFlowType t, AccessPathFront apf, int len) {
+      Stage5::consCand(c, t, any(AccessPathApprox ap | ap.getFront() = apf and ap.len() = len - 1))
+    }
+
     /**
      * Gets the number of length 2 access path approximations that correspond to `apa`.
      */
@@ -3377,11 +3382,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       exists(Content c, int len |
         c = apa.getHead() and
         len = apa.len() and
-        result =
-          strictcount(DataFlowType t, AccessPathFront apf |
-            Stage5::consCand(c, t,
-              any(AccessPathApprox ap | ap.getFront() = apf and ap.len() = len - 1))
-          )
+        result = strictcount(DataFlowType t, AccessPathFront apf | stage5ConsCand(c, t, apf, len))
       )
     }
 


### PR DESCRIPTION
Before
```
Evaluated relational algebra for predicate _DataFlowImpl::Impl<ExceptionInformationExposure::ExceptionInformationExposure::C>::AccessPathApprox__#count_range@9acc2d7t with tuple counts:
              875   ~0%    {3} r1 = SCAN `num#DataFlowImpl::Impl<ExceptionInformationExposure::ExceptionInformationExposure::C>::TCons1#055add5f` OUTPUT _, In.0, In.1
              875   ~0%    {3}    | REWRITE WITH Tmp.0 := 1, Out.0 := (InOut.2 - Tmp.0)
        113896125   ~1%    {3}    | JOIN WITH `DataFlowImpl::Impl<ExceptionInformationExposure::ExceptionInformationExposure::C>::AccessPathApprox.len/0#dispred#e932df4d_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
        113896125   ~7%    {4}    | JOIN WITH `DataFlowImpl::Impl<ExceptionInformationExposure::ExceptionInformationExposure::C>::AccessPathApprox.getFront/0#dispred#5d402e21` ON FIRST 1 OUTPUT Lhs.1, Lhs.0, Lhs.2, Rhs.1
             2404   ~9%    {5}    | JOIN WITH `DataFlowImpl::Impl<ExceptionInformationExposure::ExceptionInformationExposure::C>::Stage5::consCand/3#cd06ec82_021#join_rhs` ON FIRST 2 OUTPUT Lhs.2, Lhs.0, Rhs.2, Lhs.3, _
             2404  ~14%    {5}    | REWRITE WITH Out.4 := 1
                           return r1

Evaluated relational algebra for predicate DataFlowImpl::Impl<ExceptionInformationExposure::ExceptionInformationExposure::C>::count1to2unfold/1#9ad56f09@c47f87cq with tuple counts:
        365  ~0%    {2} r1 = JOIN `num#DataFlowImpl::Impl<ExceptionInformationExposure::ExceptionInformationExposure::C>::TCons1#055add5f_102#join_rhs` WITH `__DataFlowImpl::Impl<ExceptionInformationExposure::ExceptionInformationExposure::C>::AccessPathAppro__#join_rhs` ON FIRST 2 OUTPUT Lhs.2, Rhs.2
                    return r1
```

After
```
Evaluated relational algebra for predicate DataFlowImpl::Impl<ExceptionInformationExposure::ExceptionInformationExposure::C>::stage5ConsCand/4#ce755854@46e7620j with tuple counts:
        848899   ~5%    {3} r1 = SCAN `DataFlowImpl::Impl<ExceptionInformationExposure::ExceptionInformationExposure::C>::AccessPathApprox.len/0#dispred#e932df4d` OUTPUT In.0, _, In.1
        848899   ~0%    {2}    | REWRITE WITH Tmp.1 := 1, Out.1 := (Tmp.1 + In.2) KEEPING 2
        848899   ~0%    {3}    | JOIN WITH `DataFlowImpl::Impl<ExceptionInformationExposure::ExceptionInformationExposure::C>::AccessPathApprox.getFront/0#dispred#5d402e21` ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Rhs.1
         12961  ~14%    {4}    | JOIN WITH `DataFlowImpl::Impl<ExceptionInformationExposure::ExceptionInformationExposure::C>::Stage5::consCand/3#cd06ec82_201#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Rhs.2, Lhs.2, Lhs.1
                        return r1

Evaluated relational algebra for predicate DataFlowImpl::Impl<ExceptionInformationExposure::ExceptionInformationExposure::C>::stage5ConsCand/4#ce755854_0312_1#count_range@a0e570ci with tuple counts:
        11548  ~1%    {5} r1 = SCAN `DataFlowImpl::Impl<ExceptionInformationExposure::ExceptionInformationExposure::C>::stage5ConsCand/4#ce755854` OUTPUT In.0, In.3, In.1, In.2, _
        11548  ~3%    {5}    | REWRITE WITH Out.4 := 1
                      return r1

Evaluated relational algebra for predicate DataFlowImpl::Impl<ExceptionInformationExposure::ExceptionInformationExposure::C>::count1to2unfold/1#9ad56f09@e0e6143p with tuple counts:
        3981  ~0%    {3} r1 = AGGREGATE `DataFlowImpl::Impl<ExceptionInformationExposure::ExceptionInformationExposure::C>::stage5ConsCand/4#ce755854_0312_1#count_range`, `DataFlowImpl::Impl<ExceptionInformationExposure::ExceptionInformationExposure::C>::stage5ConsCand/4#ce755854_0312_1#count_range` ON  WITH COUNT OUTPUT In.0, In.1, Agg.0
         365  ~0%    {2}    | JOIN WITH `num#DataFlowImpl::Impl<ExceptionInformationExposure::ExceptionInformationExposure::C>::TCons1#055add5f` ON FIRST 2 OUTPUT Rhs.2, Lhs.2
                     return r1
```