### PR TITLE
Python: Support Prepared Requests - Experimental Module

### DIFF
--- a/python/ql/src/experimental/semmle/python/frameworks/PreparedRequests.qll
+++ b/python/ql/src/experimental/semmle/python/frameworks/PreparedRequests.qll
@@ -1,0 +1,83 @@
+private import python
+private import semmle.python.Concepts
+private import semmle.python.ApiGraphs
+private import semmle.python.dataflow.new.TypeTracking
+  
+/**
+ * An outgoing Http Requests using Prepared Request, from the `requests` library 
+ * 
+ * See https://requests.readthedocs.io/en/latest/user/advanced/#prepared-requests
+ */
+module ExperimentalRequests {
+
+  API::Node requests() { result = API::moduleImport("requests") }
+
+  module ExperimentalPreparedRequests { 
+    API::Node requestObject() { result = requests().getMember("Request") }
+
+    API::Node sessionObject() { result = API::moduleImport("requests").getMember("Session") }
+
+    class RequestObject extends DataFlow::CallCfgNode {
+      RequestObject() {
+        this = requestObject().getACall()
+      }
+
+      DataFlow::Node getAUrlPart() {
+        result = this.getArg(1)
+      }
+
+      DataFlow::Node getPrepareCall() {
+        result = this.getAMethodCall("prepare")
+      }
+    }
+
+    class OutgoingSessionObjectSendCall extends Http::Client::Request::Range, API::CallNode {
+      OutgoingSessionObjectSendCall() {
+        this = sessionObject().getACall().getAMethodCall("send")
+      }
+
+      override DataFlow::Node getAUrlPart() {
+        result = this.getARequestObject().getAUrlPart()
+      }
+
+      override predicate disablesCertificateValidation(
+          DataFlow::Node disablingNode, DataFlow::Node argumentOrigin
+        ) {
+          disablingNode = this.getKeywordParameter("verify").asSink() and
+          argumentOrigin = this.getKeywordParameter("verify").getAValueReachingSink() and
+          // requests treats `None` as the default and all other "falsey" values as `False`.
+          argumentOrigin.asExpr().(ImmutableLiteral).booleanValue() = false and
+          not argumentOrigin.asExpr() instanceof None
+        }
+
+      override string getFramework() { result = "requests" }
+
+      DataFlow::TypeTrackingNode getAPrepareCall(TypeBackTracker tt) {
+        tt.start() and 
+        result = this.getArg(0).getALocalSource()
+        or
+        exists(TypeBackTracker tt2 |
+          tt = tt2.step(result, this.getAPrepareCall( tt2))
+        )
+      }
+    
+      DataFlow::Node getAPrepareCall() { result = this.getAPrepareCall(TypeBackTracker::end())}
+    
+      DataFlow::TypeTrackingNode getARequestObject(TypeBackTracker tt) {
+        tt.start() and 
+        (
+          exists(RequestObject ro | 
+            ro.getPrepareCall() = this.getAPrepareCall().getALocalSource() and 
+            result = ro.getALocalSource())
+        )
+        or
+        exists(TypeBackTracker tt2 |
+          tt = tt2.step(result, this.getARequestObject(tt2))
+        )
+      }
+    
+      RequestObject getARequestObject() { result = this.getARequestObject(TypeBackTracker::end())}
+
+    }
+  }
+}

--- a/python/ql/src/experimental/semmle/python/frameworks/PreparedRequests.qll
+++ b/python/ql/src/experimental/semmle/python/frameworks/PreparedRequests.qll
@@ -42,11 +42,7 @@ module ExperimentalRequests {
 
     class PrepareCall extends DataFlow::MethodCallNode {
       PrepareCall() {
-        exists(string method | 
-          method in ["prepare"]
-          |
-          this.(DataFlow::MethodCallNode).calls(RequestObject::instance(), method)
-        )
+          this.calls(RequestObject::instance(), "prepare")
       }
 
       DataFlow::TypeTrackingNode getARequestObject(TypeBackTracker tt) {

--- a/python/ql/src/experimental/semmle/python/frameworks/PreparedRequests.qll
+++ b/python/ql/src/experimental/semmle/python/frameworks/PreparedRequests.qll
@@ -15,7 +15,7 @@ module ExperimentalRequests {
   module ExperimentalPreparedRequests { 
     API::Node requestObject() { result = requests().getMember("Request") }
 
-    API::Node sessionObject() { result = API::moduleImport("requests").getMember("Session") }
+    API::Node sessionObject() { result = requests().getMember("Session") }
 
     class RequestObject extends DataFlow::CallCfgNode {
       RequestObject() {

--- a/python/ql/src/experimental/semmle/python/frameworks/PreparedRequests.qll
+++ b/python/ql/src/experimental/semmle/python/frameworks/PreparedRequests.qll
@@ -3,15 +3,15 @@ private import semmle.python.Concepts
 private import semmle.python.ApiGraphs
 private import semmle.python.dataflow.new.TypeTracking
   
-/**
- * An outgoing Http Requests using Prepared Request, from the `requests` library 
- * 
- * See https://requests.readthedocs.io/en/latest/user/advanced/#prepared-requests
- */
 module ExperimentalRequests {
 
   API::Node requests() { result = API::moduleImport("requests") }
 
+  /**
+   * An outgoing Http Requests using Prepared Request, from the `requests` library 
+   * 
+   * See https://requests.readthedocs.io/en/latest/user/advanced/#prepared-requests
+   */
   module ExperimentalPreparedRequests { 
     API::Node requestObject() { result = requests().getMember("Request") }
 

--- a/python/ql/src/experimental/semmle/python/frameworks/PreparedRequests.qll
+++ b/python/ql/src/experimental/semmle/python/frameworks/PreparedRequests.qll
@@ -57,7 +57,7 @@ module ExperimentalRequests {
         result = this.getArg(0).getALocalSource()
         or
         exists(TypeBackTracker tt2 |
-          tt = tt2.step(result, this.getAPrepareCall( tt2))
+          tt = tt2.step(result, this.getAPrepareCall(tt2))
         )
       }
     


### PR DESCRIPTION
Aims to add support for requests library's Prepared Requests as a part of the Http::Client::Request API. To support the required getAUrlPart method, we do some tracking to the Request Object where the value is defined in an argument position 1. Intended to mirror the existing OutgoingRequestCall getAUrlPart behavior for the traditional requests calls.

https://requests.readthedocs.io/en/latest/user/advanced/#prepared-requests

Example 1:
```
import requests
req = requests.Request('GET', 'https://example.com')
r = req.prepare()

s = requests.Session()
res = s.send(r, verify=True) 
```
Example 2:
``` 
from requests import Request, Session

s = Session()

def getprepped():
  req = Request('GET', 'https://example.com')
  prepped = req.prepare()

  # do something with prepped.body
  prepped.body = 'No, I want exactly this as the body.'

  return prepped

prepped = getprepped()

resp = s.send(prepped,
    verify=True
)
```
Example 3:
```
from requests import Request, Session
from example_2 import getprepped

s = Session()

prepped = getprepped()

resp = s.send(prepped,
    verify=True
)
```
Example 4:
```
from requests import Request, Session

s = Session()

def getRequest():
  req = Request('GET', 'https://example.com')
  return req 

def getprepped():
  req = getRequest()
  prepped = req.prepare()

  # do something with prepped.body
  prepped.body = 'No, I want exactly this as the body.'

  return prepped

prepped = getprepped()

resp = s.send(prepped,
    verify=True
)
```

The disablesCertificateValidation and getFramework method are the same as the existing OutgoingRequestCall. 