### PR TITLE
Data flow: Do not materialize `NodeRegion.contains` inside `UnreachableSet`

### DIFF
--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -349,8 +349,15 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
     }
 
     pragma[nomagic]
+    private NodeRegion getNodeRegion(NodeEx n) { result.contains(n.asNode()) }
+
+    bindingset[n, cc]
+    pragma[inline_late]
     private predicate isUnreachableInCall1(NodeEx n, LocalCallContextSpecificCall cc) {
-      cc.unreachable(n.asNode())
+      exists(NodeRegion nr |
+        nr = getNodeRegion(n) and
+        cc.unreachable(nr)
+      )
     }
 
     /**

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
@@ -1539,7 +1539,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
       string toString() { result = "Unreachable" }
 
       cached
-      predicate contains(Node n) { exists(NodeRegion nr | super.contains(nr) and nr.contains(n)) }
+      predicate contains(NodeRegion nr) { super.contains(nr) }
 
       cached
       DataFlowCallable getEnclosingCallable() {
@@ -2071,8 +2071,8 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
       ns.getEnclosingCallable() = callable
     }
 
-    /** Holds if this call context makes `n` unreachable. */
-    predicate unreachable(Node n) { ns.contains(n) }
+    /** Holds if this call context makes `nr` unreachable. */
+    predicate unreachable(NodeRegion nr) { ns.contains(nr) }
   }
 
   private DataFlowCallable getNodeRegionEnclosingCallable(NodeRegion nr) {


### PR DESCRIPTION
The point about `NodeRegion`s is to represent sets of nodes using single entities. Therefore, we should not enumerate those sets in all call contexts, which can be expensive:
```
[2024-05-29 01:38:10] Evaluated non-recursive predicate DataFlowImpl::Impl<ExceptionInformationExposure::ExceptionInformationExposure::C>::isUnreachableInCall1/2#a8c2bd0d@2a3fcamm in 32087ms (size: 1281227200).
Evaluated relational algebra for predicate DataFlowImpl::Impl<ExceptionInformationExposure::ExceptionInformationExposure::C>::isUnreachableInCall1/2#a8c2bd0d@2a3fcamm with tuple counts:
        1281227200  ~1%    {2} r1 = SCAN `DataFlowImplCommon::Cached::UnreachableSet.contains/1#dispred#8abeb86d` OUTPUT In.1, In.0
        1281227200  ~0%    {2}    | JOIN WITH `num#DataFlowImpl::Impl<ExceptionInformationExposure::ExceptionInformationExposure::C>::TNodeNormal#61e969b1` ON FIRST 1 OUTPUT Lhs.1, Rhs.1
        1281227200  ~0%    {2}    | JOIN WITH DataFlowImplCommon::Cached::TSpecificLocalCall#b84e8adb ON FIRST 1 OUTPUT Lhs.1, Rhs.1
                           return r1
```