### PR TITLE
Go: Add back taint models for `append` and `copy`

### DIFF
--- a/go/ql/lib/change-notes/2024-05-09-model-append-copy-max-min.md
+++ b/go/ql/lib/change-notes/2024-05-09-model-append-copy-max-min.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* Converted the models for the built-in functions `append`, `copy`, `max` and `min` to value flow and Models-as-Data.
+* Added value flow models for the built-in functions `append`, `copy`, `max` and `min` using Models-as-Data. Removed the old-style models for `max` and `min`.

--- a/go/ql/lib/semmle/go/frameworks/Stdlib.qll
+++ b/go/ql/lib/semmle/go/frameworks/Stdlib.qll
@@ -44,6 +44,30 @@ import semmle.go.frameworks.stdlib.TextTabwriter
 import semmle.go.frameworks.stdlib.TextTemplate
 import semmle.go.frameworks.stdlib.Unsafe
 
+/**
+ * A model of the built-in `append` function, which propagates taint from its arguments to its
+ * result.
+ */
+private class AppendFunction extends TaintTracking::FunctionModel {
+  AppendFunction() { this = Builtin::append() }
+
+  override predicate hasTaintFlow(FunctionInput inp, FunctionOutput outp) {
+    inp.isParameter(_) and outp.isResult()
+  }
+}
+
+/**
+ * A model of the built-in `copy` function, which propagates taint from its second argument
+ * to its first.
+ */
+private class CopyFunction extends TaintTracking::FunctionModel {
+  CopyFunction() { this = Builtin::copy() }
+
+  override predicate hasTaintFlow(FunctionInput inp, FunctionOutput outp) {
+    inp.isParameter(1) and outp.isParameter(0)
+  }
+}
+
 /** Provides a class for modeling functions which convert strings into integers. */
 module IntegerParser {
   /**

--- a/go/ql/test/library-tests/semmle/go/dataflow/FlowSteps/LocalTaintStep.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/FlowSteps/LocalTaintStep.expected
@@ -3,6 +3,13 @@
 | main.go:38:13:38:13 | 1 | main.go:38:7:38:20 | slice literal |
 | main.go:38:16:38:16 | 2 | main.go:38:7:38:20 | slice literal |
 | main.go:38:19:38:19 | 3 | main.go:38:7:38:20 | slice literal |
+| main.go:39:15:39:15 | s | main.go:39:8:39:25 | call to append |
+| main.go:39:18:39:18 | 4 | main.go:39:8:39:25 | call to append |
+| main.go:39:21:39:21 | 5 | main.go:39:8:39:25 | call to append |
+| main.go:39:24:39:24 | 6 | main.go:39:8:39:25 | call to append |
+| main.go:40:15:40:15 | s | main.go:40:8:40:23 | call to append |
+| main.go:40:18:40:19 | s1 | main.go:40:8:40:23 | call to append |
+| main.go:42:10:42:11 | s4 | main.go:38:2:38:2 | definition of s |
 | main.go:47:20:47:21 | next key-value pair in range | main.go:47:2:50:2 | range statement[0] |
 | main.go:47:20:47:21 | next key-value pair in range | main.go:47:2:50:2 | range statement[1] |
 | main.go:47:20:47:21 | xs | main.go:47:2:50:2 | range statement[1] |

--- a/go/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
+++ b/go/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
@@ -26,6 +26,7 @@ edges
 | SanitizingDoubleDash.go:9:13:9:27 | call to Query | SanitizingDoubleDash.go:14:23:14:33 | slice expression | provenance |  |
 | SanitizingDoubleDash.go:9:13:9:27 | call to Query | SanitizingDoubleDash.go:39:31:39:37 | tainted | provenance |  |
 | SanitizingDoubleDash.go:9:13:9:27 | call to Query | SanitizingDoubleDash.go:52:24:52:30 | tainted | provenance |  |
+| SanitizingDoubleDash.go:9:13:9:27 | call to Query | SanitizingDoubleDash.go:53:21:53:28 | arrayLit | provenance |  |
 | SanitizingDoubleDash.go:9:13:9:27 | call to Query | SanitizingDoubleDash.go:68:31:68:37 | tainted | provenance |  |
 | SanitizingDoubleDash.go:9:13:9:27 | call to Query | SanitizingDoubleDash.go:80:23:80:29 | tainted | provenance |  |
 | SanitizingDoubleDash.go:13:15:13:32 | array literal [array] | SanitizingDoubleDash.go:14:23:14:30 | arrayLit [array] | provenance |  |
@@ -38,17 +39,23 @@ edges
 | SanitizingDoubleDash.go:39:14:39:44 | call to append | SanitizingDoubleDash.go:40:23:40:30 | arrayLit | provenance |  |
 | SanitizingDoubleDash.go:39:14:39:44 | call to append [array] | SanitizingDoubleDash.go:40:23:40:30 | arrayLit | provenance |  |
 | SanitizingDoubleDash.go:39:31:39:37 | tainted | SanitizingDoubleDash.go:39:14:39:44 | []type{args} [array] | provenance |  |
+| SanitizingDoubleDash.go:39:31:39:37 | tainted | SanitizingDoubleDash.go:39:14:39:44 | call to append | provenance | FunctionModel |
 | SanitizingDoubleDash.go:52:15:52:31 | slice literal [array] | SanitizingDoubleDash.go:53:21:53:28 | arrayLit [array] | provenance |  |
 | SanitizingDoubleDash.go:52:24:52:30 | tainted | SanitizingDoubleDash.go:52:15:52:31 | slice literal [array] | provenance |  |
 | SanitizingDoubleDash.go:53:14:53:35 | call to append | SanitizingDoubleDash.go:54:23:54:30 | arrayLit | provenance |  |
 | SanitizingDoubleDash.go:53:14:53:35 | call to append [array] | SanitizingDoubleDash.go:54:23:54:30 | arrayLit | provenance |  |
+| SanitizingDoubleDash.go:53:21:53:28 | arrayLit | SanitizingDoubleDash.go:53:14:53:35 | call to append | provenance | FunctionModel |
 | SanitizingDoubleDash.go:53:21:53:28 | arrayLit [array] | SanitizingDoubleDash.go:53:14:53:35 | call to append | provenance | MaD:28 |
 | SanitizingDoubleDash.go:53:21:53:28 | arrayLit [array] | SanitizingDoubleDash.go:53:14:53:35 | call to append [array] | provenance | MaD:28 |
+| SanitizingDoubleDash.go:68:14:68:38 | []type{args} [array] | SanitizingDoubleDash.go:68:14:68:38 | call to append | provenance | MaD:29 |
 | SanitizingDoubleDash.go:68:14:68:38 | []type{args} [array] | SanitizingDoubleDash.go:68:14:68:38 | call to append [array] | provenance | MaD:29 |
+| SanitizingDoubleDash.go:68:14:68:38 | call to append | SanitizingDoubleDash.go:69:21:69:28 | arrayLit | provenance |  |
 | SanitizingDoubleDash.go:68:14:68:38 | call to append [array] | SanitizingDoubleDash.go:69:21:69:28 | arrayLit [array] | provenance |  |
 | SanitizingDoubleDash.go:68:31:68:37 | tainted | SanitizingDoubleDash.go:68:14:68:38 | []type{args} [array] | provenance |  |
+| SanitizingDoubleDash.go:68:31:68:37 | tainted | SanitizingDoubleDash.go:68:14:68:38 | call to append | provenance | FunctionModel |
 | SanitizingDoubleDash.go:69:14:69:35 | call to append | SanitizingDoubleDash.go:70:23:70:30 | arrayLit | provenance |  |
 | SanitizingDoubleDash.go:69:14:69:35 | call to append [array] | SanitizingDoubleDash.go:70:23:70:30 | arrayLit | provenance |  |
+| SanitizingDoubleDash.go:69:21:69:28 | arrayLit | SanitizingDoubleDash.go:69:14:69:35 | call to append | provenance | FunctionModel |
 | SanitizingDoubleDash.go:69:21:69:28 | arrayLit [array] | SanitizingDoubleDash.go:69:14:69:35 | call to append | provenance | MaD:28 |
 | SanitizingDoubleDash.go:69:21:69:28 | arrayLit [array] | SanitizingDoubleDash.go:69:14:69:35 | call to append [array] | provenance | MaD:28 |
 | SanitizingDoubleDash.go:92:13:92:19 | selection of URL | SanitizingDoubleDash.go:92:13:92:27 | call to Query | provenance | MaD:735 |
@@ -62,6 +69,7 @@ edges
 | SanitizingDoubleDash.go:92:13:92:27 | call to Query | SanitizingDoubleDash.go:117:31:117:37 | tainted | provenance |  |
 | SanitizingDoubleDash.go:92:13:92:27 | call to Query | SanitizingDoubleDash.go:123:31:123:37 | tainted | provenance |  |
 | SanitizingDoubleDash.go:92:13:92:27 | call to Query | SanitizingDoubleDash.go:128:24:128:30 | tainted | provenance |  |
+| SanitizingDoubleDash.go:92:13:92:27 | call to Query | SanitizingDoubleDash.go:129:21:129:28 | arrayLit | provenance |  |
 | SanitizingDoubleDash.go:92:13:92:27 | call to Query | SanitizingDoubleDash.go:136:31:136:37 | tainted | provenance |  |
 | SanitizingDoubleDash.go:92:13:92:27 | call to Query | SanitizingDoubleDash.go:142:31:142:37 | tainted | provenance |  |
 | SanitizingDoubleDash.go:92:13:92:27 | call to Query | SanitizingDoubleDash.go:148:30:148:36 | tainted | provenance |  |
@@ -83,20 +91,24 @@ edges
 | SanitizingDoubleDash.go:111:14:111:44 | call to append | SanitizingDoubleDash.go:112:24:112:31 | arrayLit | provenance |  |
 | SanitizingDoubleDash.go:111:14:111:44 | call to append [array] | SanitizingDoubleDash.go:112:24:112:31 | arrayLit | provenance |  |
 | SanitizingDoubleDash.go:111:37:111:43 | tainted | SanitizingDoubleDash.go:111:14:111:44 | []type{args} [array] | provenance |  |
+| SanitizingDoubleDash.go:111:37:111:43 | tainted | SanitizingDoubleDash.go:111:14:111:44 | call to append | provenance | FunctionModel |
 | SanitizingDoubleDash.go:117:14:117:44 | []type{args} [array] | SanitizingDoubleDash.go:117:14:117:44 | call to append | provenance | MaD:29 |
 | SanitizingDoubleDash.go:117:14:117:44 | []type{args} [array] | SanitizingDoubleDash.go:117:14:117:44 | call to append [array] | provenance | MaD:29 |
 | SanitizingDoubleDash.go:117:14:117:44 | call to append | SanitizingDoubleDash.go:118:24:118:31 | arrayLit | provenance |  |
 | SanitizingDoubleDash.go:117:14:117:44 | call to append [array] | SanitizingDoubleDash.go:118:24:118:31 | arrayLit | provenance |  |
 | SanitizingDoubleDash.go:117:31:117:37 | tainted | SanitizingDoubleDash.go:117:14:117:44 | []type{args} [array] | provenance |  |
+| SanitizingDoubleDash.go:117:31:117:37 | tainted | SanitizingDoubleDash.go:117:14:117:44 | call to append | provenance | FunctionModel |
 | SanitizingDoubleDash.go:123:14:123:38 | []type{args} [array] | SanitizingDoubleDash.go:123:14:123:38 | call to append | provenance | MaD:29 |
 | SanitizingDoubleDash.go:123:14:123:38 | []type{args} [array] | SanitizingDoubleDash.go:123:14:123:38 | call to append [array] | provenance | MaD:29 |
 | SanitizingDoubleDash.go:123:14:123:38 | call to append | SanitizingDoubleDash.go:124:24:124:31 | arrayLit | provenance |  |
 | SanitizingDoubleDash.go:123:14:123:38 | call to append [array] | SanitizingDoubleDash.go:124:24:124:31 | arrayLit | provenance |  |
 | SanitizingDoubleDash.go:123:31:123:37 | tainted | SanitizingDoubleDash.go:123:14:123:38 | []type{args} [array] | provenance |  |
+| SanitizingDoubleDash.go:123:31:123:37 | tainted | SanitizingDoubleDash.go:123:14:123:38 | call to append | provenance | FunctionModel |
 | SanitizingDoubleDash.go:128:15:128:31 | slice literal [array] | SanitizingDoubleDash.go:129:21:129:28 | arrayLit [array] | provenance |  |
 | SanitizingDoubleDash.go:128:24:128:30 | tainted | SanitizingDoubleDash.go:128:15:128:31 | slice literal [array] | provenance |  |
 | SanitizingDoubleDash.go:129:14:129:35 | call to append | SanitizingDoubleDash.go:130:24:130:31 | arrayLit | provenance |  |
 | SanitizingDoubleDash.go:129:14:129:35 | call to append [array] | SanitizingDoubleDash.go:130:24:130:31 | arrayLit | provenance |  |
+| SanitizingDoubleDash.go:129:21:129:28 | arrayLit | SanitizingDoubleDash.go:129:14:129:35 | call to append | provenance | FunctionModel |
 | SanitizingDoubleDash.go:129:21:129:28 | arrayLit [array] | SanitizingDoubleDash.go:129:14:129:35 | call to append | provenance | MaD:28 |
 | SanitizingDoubleDash.go:129:21:129:28 | arrayLit [array] | SanitizingDoubleDash.go:129:14:129:35 | call to append [array] | provenance | MaD:28 |
 | SanitizingDoubleDash.go:136:14:136:38 | []type{args} [array] | SanitizingDoubleDash.go:136:14:136:38 | call to append | provenance | MaD:29 |
@@ -104,11 +116,16 @@ edges
 | SanitizingDoubleDash.go:136:14:136:38 | call to append | SanitizingDoubleDash.go:137:24:137:31 | arrayLit | provenance |  |
 | SanitizingDoubleDash.go:136:14:136:38 | call to append [array] | SanitizingDoubleDash.go:137:24:137:31 | arrayLit | provenance |  |
 | SanitizingDoubleDash.go:136:31:136:37 | tainted | SanitizingDoubleDash.go:136:14:136:38 | []type{args} [array] | provenance |  |
+| SanitizingDoubleDash.go:136:31:136:37 | tainted | SanitizingDoubleDash.go:136:14:136:38 | call to append | provenance | FunctionModel |
+| SanitizingDoubleDash.go:142:14:142:38 | []type{args} [array] | SanitizingDoubleDash.go:142:14:142:38 | call to append | provenance | MaD:29 |
 | SanitizingDoubleDash.go:142:14:142:38 | []type{args} [array] | SanitizingDoubleDash.go:142:14:142:38 | call to append [array] | provenance | MaD:29 |
+| SanitizingDoubleDash.go:142:14:142:38 | call to append | SanitizingDoubleDash.go:143:21:143:28 | arrayLit | provenance |  |
 | SanitizingDoubleDash.go:142:14:142:38 | call to append [array] | SanitizingDoubleDash.go:143:21:143:28 | arrayLit [array] | provenance |  |
 | SanitizingDoubleDash.go:142:31:142:37 | tainted | SanitizingDoubleDash.go:142:14:142:38 | []type{args} [array] | provenance |  |
+| SanitizingDoubleDash.go:142:31:142:37 | tainted | SanitizingDoubleDash.go:142:14:142:38 | call to append | provenance | FunctionModel |
 | SanitizingDoubleDash.go:143:14:143:35 | call to append | SanitizingDoubleDash.go:144:24:144:31 | arrayLit | provenance |  |
 | SanitizingDoubleDash.go:143:14:143:35 | call to append [array] | SanitizingDoubleDash.go:144:24:144:31 | arrayLit | provenance |  |
+| SanitizingDoubleDash.go:143:21:143:28 | arrayLit | SanitizingDoubleDash.go:143:14:143:35 | call to append | provenance | FunctionModel |
 | SanitizingDoubleDash.go:143:21:143:28 | arrayLit [array] | SanitizingDoubleDash.go:143:14:143:35 | call to append | provenance | MaD:28 |
 | SanitizingDoubleDash.go:143:21:143:28 | arrayLit [array] | SanitizingDoubleDash.go:143:14:143:35 | call to append [array] | provenance | MaD:28 |
 nodes
@@ -155,13 +172,16 @@ nodes
 | SanitizingDoubleDash.go:52:24:52:30 | tainted | semmle.label | tainted |
 | SanitizingDoubleDash.go:53:14:53:35 | call to append | semmle.label | call to append |
 | SanitizingDoubleDash.go:53:14:53:35 | call to append [array] | semmle.label | call to append [array] |
+| SanitizingDoubleDash.go:53:21:53:28 | arrayLit | semmle.label | arrayLit |
 | SanitizingDoubleDash.go:53:21:53:28 | arrayLit [array] | semmle.label | arrayLit [array] |
 | SanitizingDoubleDash.go:54:23:54:30 | arrayLit | semmle.label | arrayLit |
 | SanitizingDoubleDash.go:68:14:68:38 | []type{args} [array] | semmle.label | []type{args} [array] |
+| SanitizingDoubleDash.go:68:14:68:38 | call to append | semmle.label | call to append |
 | SanitizingDoubleDash.go:68:14:68:38 | call to append [array] | semmle.label | call to append [array] |
 | SanitizingDoubleDash.go:68:31:68:37 | tainted | semmle.label | tainted |
 | SanitizingDoubleDash.go:69:14:69:35 | call to append | semmle.label | call to append |
 | SanitizingDoubleDash.go:69:14:69:35 | call to append [array] | semmle.label | call to append [array] |
+| SanitizingDoubleDash.go:69:21:69:28 | arrayLit | semmle.label | arrayLit |
 | SanitizingDoubleDash.go:69:21:69:28 | arrayLit [array] | semmle.label | arrayLit [array] |
 | SanitizingDoubleDash.go:70:23:70:30 | arrayLit | semmle.label | arrayLit |
 | SanitizingDoubleDash.go:80:23:80:29 | tainted | semmle.label | tainted |
@@ -201,6 +221,7 @@ nodes
 | SanitizingDoubleDash.go:128:24:128:30 | tainted | semmle.label | tainted |
 | SanitizingDoubleDash.go:129:14:129:35 | call to append | semmle.label | call to append |
 | SanitizingDoubleDash.go:129:14:129:35 | call to append [array] | semmle.label | call to append [array] |
+| SanitizingDoubleDash.go:129:21:129:28 | arrayLit | semmle.label | arrayLit |
 | SanitizingDoubleDash.go:129:21:129:28 | arrayLit [array] | semmle.label | arrayLit [array] |
 | SanitizingDoubleDash.go:130:24:130:31 | arrayLit | semmle.label | arrayLit |
 | SanitizingDoubleDash.go:136:14:136:38 | []type{args} [array] | semmle.label | []type{args} [array] |
@@ -209,10 +230,12 @@ nodes
 | SanitizingDoubleDash.go:136:31:136:37 | tainted | semmle.label | tainted |
 | SanitizingDoubleDash.go:137:24:137:31 | arrayLit | semmle.label | arrayLit |
 | SanitizingDoubleDash.go:142:14:142:38 | []type{args} [array] | semmle.label | []type{args} [array] |
+| SanitizingDoubleDash.go:142:14:142:38 | call to append | semmle.label | call to append |
 | SanitizingDoubleDash.go:142:14:142:38 | call to append [array] | semmle.label | call to append [array] |
 | SanitizingDoubleDash.go:142:31:142:37 | tainted | semmle.label | tainted |
 | SanitizingDoubleDash.go:143:14:143:35 | call to append | semmle.label | call to append |
 | SanitizingDoubleDash.go:143:14:143:35 | call to append [array] | semmle.label | call to append [array] |
+| SanitizingDoubleDash.go:143:21:143:28 | arrayLit | semmle.label | arrayLit |
 | SanitizingDoubleDash.go:143:21:143:28 | arrayLit [array] | semmle.label | arrayLit [array] |
 | SanitizingDoubleDash.go:144:24:144:31 | arrayLit | semmle.label | arrayLit |
 | SanitizingDoubleDash.go:148:30:148:36 | tainted | semmle.label | tainted |

--- a/go/ql/test/query-tests/Security/CWE-327/UnsafeTLS.expected
+++ b/go/ql/test/query-tests/Security/CWE-327/UnsafeTLS.expected
@@ -15,25 +15,33 @@ edges
 | UnsafeTLS.go:313:5:313:45 | selection of TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 | UnsafeTLS.go:312:18:314:4 | slice literal | provenance |  |
 | UnsafeTLS.go:329:25:329:94 | []type{args} [array] | UnsafeTLS.go:329:25:329:94 | call to append | provenance | MaD:29 |
 | UnsafeTLS.go:329:53:329:93 | selection of TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 | UnsafeTLS.go:329:25:329:94 | []type{args} [array] | provenance |  |
+| UnsafeTLS.go:329:53:329:93 | selection of TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 | UnsafeTLS.go:329:25:329:94 | call to append | provenance | FunctionModel |
 | UnsafeTLS.go:334:13:334:38 | call to InsecureCipherSuites | UnsafeTLS.go:336:54:336:57 | selection of ID | provenance |  |
 | UnsafeTLS.go:336:26:336:58 | []type{args} [array] | UnsafeTLS.go:336:26:336:58 | call to append | provenance | MaD:29 |
 | UnsafeTLS.go:336:54:336:57 | selection of ID | UnsafeTLS.go:336:26:336:58 | []type{args} [array] | provenance |  |
+| UnsafeTLS.go:336:54:336:57 | selection of ID | UnsafeTLS.go:336:26:336:58 | call to append | provenance | FunctionModel |
 | UnsafeTLS.go:342:13:342:38 | call to InsecureCipherSuites | UnsafeTLS.go:344:40:344:43 | selection of ID | provenance |  |
 | UnsafeTLS.go:344:19:344:44 | []type{args} [array] | UnsafeTLS.go:344:19:344:44 | call to append | provenance | MaD:29 |
 | UnsafeTLS.go:344:19:344:44 | []type{args} [array] | UnsafeTLS.go:344:19:344:44 | call to append [array] | provenance | MaD:29 |
+| UnsafeTLS.go:344:19:344:44 | call to append | UnsafeTLS.go:344:26:344:37 | cipherSuites | provenance |  |
 | UnsafeTLS.go:344:19:344:44 | call to append | UnsafeTLS.go:346:25:346:36 | cipherSuites | provenance |  |
 | UnsafeTLS.go:344:19:344:44 | call to append [array] | UnsafeTLS.go:344:26:344:37 | cipherSuites [array] | provenance |  |
+| UnsafeTLS.go:344:26:344:37 | cipherSuites | UnsafeTLS.go:344:19:344:44 | call to append | provenance | FunctionModel |
 | UnsafeTLS.go:344:26:344:37 | cipherSuites [array] | UnsafeTLS.go:344:19:344:44 | call to append | provenance | MaD:28 |
 | UnsafeTLS.go:344:26:344:37 | cipherSuites [array] | UnsafeTLS.go:344:19:344:44 | call to append [array] | provenance | MaD:28 |
 | UnsafeTLS.go:344:40:344:43 | selection of ID | UnsafeTLS.go:344:19:344:44 | []type{args} [array] | provenance |  |
+| UnsafeTLS.go:344:40:344:43 | selection of ID | UnsafeTLS.go:344:19:344:44 | call to append | provenance | FunctionModel |
 | UnsafeTLS.go:351:13:351:38 | call to InsecureCipherSuites | UnsafeTLS.go:353:40:353:51 | selection of ID | provenance |  |
 | UnsafeTLS.go:353:19:353:52 | []type{args} [array] | UnsafeTLS.go:353:19:353:52 | call to append | provenance | MaD:29 |
 | UnsafeTLS.go:353:19:353:52 | []type{args} [array] | UnsafeTLS.go:353:19:353:52 | call to append [array] | provenance | MaD:29 |
+| UnsafeTLS.go:353:19:353:52 | call to append | UnsafeTLS.go:353:26:353:37 | cipherSuites | provenance |  |
 | UnsafeTLS.go:353:19:353:52 | call to append | UnsafeTLS.go:355:25:355:36 | cipherSuites | provenance |  |
 | UnsafeTLS.go:353:19:353:52 | call to append [array] | UnsafeTLS.go:353:26:353:37 | cipherSuites [array] | provenance |  |
+| UnsafeTLS.go:353:26:353:37 | cipherSuites | UnsafeTLS.go:353:19:353:52 | call to append | provenance | FunctionModel |
 | UnsafeTLS.go:353:26:353:37 | cipherSuites [array] | UnsafeTLS.go:353:19:353:52 | call to append | provenance | MaD:28 |
 | UnsafeTLS.go:353:26:353:37 | cipherSuites [array] | UnsafeTLS.go:353:19:353:52 | call to append [array] | provenance | MaD:28 |
 | UnsafeTLS.go:353:40:353:51 | selection of ID | UnsafeTLS.go:353:19:353:52 | []type{args} [array] | provenance |  |
+| UnsafeTLS.go:353:40:353:51 | selection of ID | UnsafeTLS.go:353:19:353:52 | call to append | provenance | FunctionModel |
 | UnsafeTLS.go:363:5:363:47 | selection of TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 | UnsafeTLS.go:362:18:364:4 | slice literal | provenance |  |
 | UnsafeTLS.go:371:5:371:47 | selection of TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 | UnsafeTLS.go:370:18:372:4 | slice literal | provenance |  |
 | UnsafeTLS.go:379:5:379:47 | selection of TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 | UnsafeTLS.go:378:18:380:4 | slice literal | provenance |  |
@@ -118,6 +126,7 @@ nodes
 | UnsafeTLS.go:344:19:344:44 | []type{args} [array] | semmle.label | []type{args} [array] |
 | UnsafeTLS.go:344:19:344:44 | call to append | semmle.label | call to append |
 | UnsafeTLS.go:344:19:344:44 | call to append [array] | semmle.label | call to append [array] |
+| UnsafeTLS.go:344:26:344:37 | cipherSuites | semmle.label | cipherSuites |
 | UnsafeTLS.go:344:26:344:37 | cipherSuites [array] | semmle.label | cipherSuites [array] |
 | UnsafeTLS.go:344:40:344:43 | selection of ID | semmle.label | selection of ID |
 | UnsafeTLS.go:346:25:346:36 | cipherSuites | semmle.label | cipherSuites |
@@ -125,6 +134,7 @@ nodes
 | UnsafeTLS.go:353:19:353:52 | []type{args} [array] | semmle.label | []type{args} [array] |
 | UnsafeTLS.go:353:19:353:52 | call to append | semmle.label | call to append |
 | UnsafeTLS.go:353:19:353:52 | call to append [array] | semmle.label | call to append [array] |
+| UnsafeTLS.go:353:26:353:37 | cipherSuites | semmle.label | cipherSuites |
 | UnsafeTLS.go:353:26:353:37 | cipherSuites [array] | semmle.label | cipherSuites [array] |
 | UnsafeTLS.go:353:40:353:51 | selection of ID | semmle.label | selection of ID |
 | UnsafeTLS.go:355:25:355:36 | cipherSuites | semmle.label | cipherSuites |


### PR DESCRIPTION
These are needed when they are called with string arguments. This is a partial revert of https://github.com/github/codeql/pull/16413.