### PR TITLE
`pkg.bzl`: Fix install targets.

### DIFF
--- a/misc/bazel/internal/install.py
+++ b/misc/bazel/internal/install.py
@@ -50,6 +50,7 @@ if opts.zip_manifest:
         for line in manifest:
             prefix, _, zip = line.partition(":")
             assert zip, f"missing prefix for {prefix}, you should use prefix:zip format"
+            zip = zip.strip()
             dest = destdir / prefix
             dest.mkdir(parents=True, exist_ok=True)
             subprocess.run([ripunzip, "unzip-file", zip, "-d", dest], check=True)

--- a/misc/bazel/pkg.bzl
+++ b/misc/bazel/pkg.bzl
@@ -383,7 +383,7 @@ def codeql_pack(
             "--destdir",
             install_dest,
         ] + ([
-            "--ripunzip=$(rlocationpath " + str(Label("//misc/bazel/internal/ripunzip")) + ")",
+            "--ripunzip=$(rlocationpath %s)" % Label("//misc/bazel/internal/ripunzip"),
             "--zip-manifest=$(rlocationpath %s)" % internal("zip-manifest"),
         ] if zips else []),
         visibility = visibility,

--- a/misc/bazel/pkg.bzl
+++ b/misc/bazel/pkg.bzl
@@ -367,14 +367,14 @@ def codeql_pack(
     )
     py_binary(
         name = internal("installer"),
-        srcs = ["//misc/bazel/internal:install.py"],
-        main = "//misc/bazel/internal:install.py",
+        srcs = [Label("//misc/bazel/internal:install.py")],
+        main = Label("//misc/bazel/internal:install.py"),
         data = [
             internal("build-file"),
             internal("script"),
         ] + ([
             internal("zip-manifest"),
-            "//misc/bazel/internal/ripunzip",
+            Label("//misc/bazel/internal/ripunzip"),
         ] if zips else []),
         deps = ["@rules_python//python/runfiles"],
         args = [
@@ -383,7 +383,7 @@ def codeql_pack(
             "--destdir",
             install_dest,
         ] + ([
-            "--ripunzip=$(rlocationpath //misc/bazel/internal/ripunzip)",
+            "--ripunzip=$(rlocationpath " + str(Label("//misc/bazel/internal/ripunzip")) + ")",
             "--zip-manifest=$(rlocationpath %s)" % internal("zip-manifest"),
         ] if zips else []),
         visibility = visibility,


### PR DESCRIPTION
First, the labels used in this file need to be wrapped in `Label`, so that we can use the installer target for `codeql_pack`'s that are defined in the internal repo. Second, when unpacking zips, the path passed to `ripunzip` included a trailing `\n`, which caused `ripunzip` to fail.