### PR TITLE
Disable csrf for ServerHttpSecurity

### DIFF
--- a/java/ql/lib/semmle/code/java/security/SpringCsrfProtection.qll
+++ b/java/ql/lib/semmle/code/java/security/SpringCsrfProtection.qll
@@ -5,15 +5,9 @@ import java
 /** Holds if `call` disables CSRF protection in Spring. */
 predicate disablesSpringCsrfProtection(MethodCall call) {
   call.getMethod().hasName("disable") and
-  (
-    call.getReceiverType()
-        .hasQualifiedName("org.springframework.security.config.annotation.web.configurers",
-          "CsrfConfigurer<HttpSecurity>")
-    or
-    call.getReceiverType()
-        .hasQualifiedName("org.springframework.security.config.web.server",
-          "ServerHttpSecurity$CsrfSpec")
-  )
+  call.getReceiverType()
+      .hasQualifiedName("org.springframework.security.config.annotation.web.configurers",
+        "CsrfConfigurer<HttpSecurity>")
   or
   call.getMethod()
       .hasQualifiedName("org.springframework.security.config.annotation.web.builders",
@@ -23,4 +17,18 @@ predicate disablesSpringCsrfProtection(MethodCall call) {
       .getReferencedCallable()
       .hasQualifiedName("org.springframework.security.config.annotation.web.configurers",
         "AbstractHttpConfigurer", "disable")
+  or
+  call.getMethod().hasName("disable") and
+  call.getReceiverType()
+      .hasQualifiedName("org.springframework.security.config.web.server",
+        "ServerHttpSecurity$CsrfSpec")
+  or
+  call.getMethod()
+      .hasQualifiedName("org.springframework.security.config.web.server", "ServerHttpSecurity",
+        "csrf") and
+  call.getArgument(0)
+      .(MemberRefExpr)
+      .getReferencedCallable()
+      .hasQualifiedName("org.springframework.security.config.web.server",
+        "ServerHttpSecurity$CsrfSpec", "disable")
 }

--- a/java/ql/lib/semmle/code/java/security/SpringCsrfProtection.qll
+++ b/java/ql/lib/semmle/code/java/security/SpringCsrfProtection.qll
@@ -5,9 +5,15 @@ import java
 /** Holds if `call` disables CSRF protection in Spring. */
 predicate disablesSpringCsrfProtection(MethodCall call) {
   call.getMethod().hasName("disable") and
-  call.getReceiverType()
-      .hasQualifiedName("org.springframework.security.config.annotation.web.configurers",
-        "CsrfConfigurer<HttpSecurity>")
+  (
+    call.getReceiverType()
+        .hasQualifiedName("org.springframework.security.config.annotation.web.configurers",
+          "CsrfConfigurer<HttpSecurity>")
+    or
+    call.getReceiverType()
+        .hasQualifiedName("org.springframework.security.config.web.server",
+          "ServerHttpSecurity$CsrfSpec")
+  )
   or
   call.getMethod()
       .hasQualifiedName("org.springframework.security.config.annotation.web.builders",

--- a/java/ql/src/change-notes/2024-05-30-disabled-csrf-query.md
+++ b/java/ql/src/change-notes/2024-05-30-disabled-csrf-query.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The query `java/spring-disabled-csrf-protection` detects disabling CSRF via `ServerHttpSecurity$CsrfSpec::disable`.

--- a/java/ql/test/query-tests/security/CWE-352/SpringCsrfProtectionTest.java
+++ b/java/ql/test/query-tests/security/CWE-352/SpringCsrfProtectionTest.java
@@ -1,10 +1,15 @@
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
 
 public class SpringCsrfProtectionTest {
-    protected void test(HttpSecurity http) throws Exception {
+    protected void test(HttpSecurity http, final ServerHttpSecurity httpSecurity) throws Exception {
         http.csrf(csrf -> csrf.disable()); // $ hasSpringCsrfProtectionDisabled
         http.csrf().disable(); // $ hasSpringCsrfProtectionDisabled
         http.csrf(AbstractHttpConfigurer::disable); // $ hasSpringCsrfProtectionDisabled
+
+        httpSecurity.csrf(csrf -> csrf.disable()); // $ hasSpringCsrfProtectionDisabled
+        httpSecurity.csrf().disable(); // $ hasSpringCsrfProtectionDisabled
+        httpSecurity.csrf(ServerHttpSecurity.CsrfSpec::disable); // $ hasSpringCsrfProtectionDisabled
     }
 }

--- a/java/ql/test/stubs/springframework-5.3.8/org/springframework/security/config/web/server/ServerHttpSecurity.java
+++ b/java/ql/test/stubs/springframework-5.3.8/org/springframework/security/config/web/server/ServerHttpSecurity.java
@@ -1,0 +1,36 @@
+package org.springframework.security.config.web.server;
+
+import org.springframework.security.config.Customizer;
+
+public class ServerHttpSecurity {
+    private CsrfSpec csrf = new CsrfSpec();
+
+    protected ServerHttpSecurity() {
+    }
+
+    public CsrfSpec csrf() {
+      if (this.csrf == null) {
+        this.csrf = new CsrfSpec();
+      }
+      return this.csrf;
+    }
+
+    public ServerHttpSecurity csrf(Customizer<CsrfSpec> csrfCustomizer) {
+     if (this.csrf == null) {
+       this.csrf = new CsrfSpec();
+     }
+     csrfCustomizer.customize(this.csrf);
+     return this;
+   }
+
+    public final class CsrfSpec {
+
+		private CsrfSpec() {
+		}
+
+        public ServerHttpSecurity disable() {
+            ServerHttpSecurity.this.csrf = null;
+            return ServerHttpSecurity.this;
+          }
+    }
+}


### PR DESCRIPTION
Improves the query [`java/spring-disabled-csrf-protection`](https://codeql.github.com/codeql-query-help/java/java-spring-disabled-csrf-protection/) reporting calls to [`ServerHttpSecurity.CsrfSpec::disable`](https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/config/web/server/ServerHttpSecurity.CsrfSpec.html#disable())