### PR TITLE
C#: Restrict data flow for multi-bodied methods

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowDispatch.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowDispatch.qll
@@ -239,7 +239,7 @@ abstract class DataFlowCall extends TDataFlowCall {
    * For more information, see
    * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
    */
-  final predicate hasLocationInfo(
+  deprecated final predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
     this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
@@ -248,10 +248,10 @@ abstract class DataFlowCall extends TDataFlowCall {
   /** Gets a best-effort total ordering. */
   int totalorder() {
     this =
-      rank[result](DataFlowCall c, int startline, int startcolumn |
-        c.hasLocationInfo(_, startline, startcolumn, _, _)
+      rank[result](DataFlowCall c, string filePath, int startline, int startcolumn |
+        c.getLocation().hasLocationInfo(filePath, startline, startcolumn, _, _)
       |
-        c order by startline, startcolumn
+        c order by filePath, startline, startcolumn
       )
   }
 }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplSpecific.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplSpecific.qll
@@ -29,4 +29,6 @@ module CsharpDataFlow implements InputSig<Location> {
   predicate neverSkipInPathGraph(Node n) {
     exists(n.(AssignableDefinitionNode).getDefinition().getTargetAccess())
   }
+
+  predicate getSecondLevelScope = Private::getSecondLevelScope/1;
 }


### PR DESCRIPTION
When a method is extracted multiple times, in different files, we end up with a single method containing multiple method bodies. This can sometimes throw data flow off, so this PR does two things:

- Treat calls to multi-bodied methods as virtual dispatch, using the [newly introduced](https://github.com/github/codeql/pull/15599/files#diff-518023a19a22b29249dfbdb30a6705a5c1d9f376061a5d2edb5058c9ebecda0cR321) `DataFlowSecondLevelScope`.
- When a call targets a multi-bodied method where one of the bodies is in the same file as the call, prohibit flow to all other bodies, using the [newly introduced](https://github.com/github/codeql/pull/16456) `NodeRegion`.

Exampe tuple counts (before)

\# | n | stage | nodes | fields | conscand | states | tuples | calledges | tfnodes | tftuples
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | 10 | 1 Fwd | 13,187,870 | 185,706 | -1 | 1 | 17,590,710 | -1 | -1 | -1
2 | 15 | 1 Rev | 5,671,136 | 120,307 | -1 | 1 | 8,255,144 | 27,776,216 | -1 | -1
3 | 20 | 2 Fwd | 3,165,633 | 59,851 | 79,047 | 1 | 5,916,802 | 12,526,882 | 0 | 0
4 | 25 | 2 Rev | 2,189,692 | 50,677 | 66,010 | 1 | 3,000,179 | 2,784,088 | 0 | 0
5 | 30 | 3 Fwd | 1,261,133 | 39,727 | 3,777,415 | 1 | 40,202,863 | 2,028,817 | 188,481 | 1,738,243
6 | 35 | 3 Rev | 989,110 | 35,915 | 3,718,434 | 1 | 2,372,076 | 1,641,461 | 165,057 | 2,029,199
7 | 40 | 4 Fwd | 291,184 | 13,682 | 746,048 | 1 | 111,372,924 | 1,058,269 | 74,870 | 445,043
8 | 45 | 4 Rev | 225,919 | 13,193 | 653,314 | 1 | 20,928,943 | 1,004,960 | 37,409 | 410,968
9 | 50 | 5 Fwd | 127,287 | 2,524 | 19,412 | 1 | 1,175,226 | 872,596 | 15,696 | 156,520
10 | 55 | 5 Rev | 110,916 | 2,265 | 12,969 | 1 | 439,440 | 837,375 | 10,564 | 164,147
11 | 60 | 6 Fwd | 109,488 | 2,243 | 18,826 | 1 | 1,361,311 | -1 | -1 | -1
12 | 65 | 6 Rev | 57,757 | 1,451 | 13,063 | 1 | 989,695 | -1 | -1 | -1

After
\# | n | stage | nodes | fields | conscand | states | tuples | calledges | tfnodes | tftuples
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | 10 | 1 Fwd | 13,187,870 | 185,706 | -1 | 1 | 17,590,710 | -1 | -1 | -1
2 | 15 | 1 Rev | 5,671,136 | 120,307 | -1 | 1 | 8,255,144 | 27,776,214 | -1 | -1
3 | 20 | 2 Fwd | 3,163,921 | 59,833 | 79,020 | 1 | 5,910,484 | 12,522,597 | 0 | 0
4 | 25 | 2 Rev | 2,186,671 | 50,628 | 65,949 | 1 | 2,994,764 | 2,782,439 | 0 | 0
5 | 30 | 3 Fwd | 1,259,837 | 39,703 | 3,777,163 | 1 | 40,165,525 | 2,028,199 | 188,439 | 1,738,170
6 | 35 | 3 Rev | 987,593 | 35,883 | 3,718,213 | 1 | 2,365,799 | 1,640,881 | 165,021 | 2,028,985
7 | 40 | 4 Fwd | 290,478 | 13,669 | 745,225 | 1 | 111,249,989 | 1,058,028 | 74,838 | 444,932
8 | 45 | 4 Rev | 225,341 | 13,180 | 653,211 | 1 | 20,889,984 | 1,004,774 | 37,379 | 410,886
9 | 50 | 5 Fwd | 127,095 | 2,523 | 19,404 | 1 | 1,056,111 | 872,527 | 15,690 | 156,337
10 | 55 | 5 Rev | 110,796 | 2,263 | 12,961 | 1 | 438,541 | 837,334 | 10,560 | 164,141
11 | 60 | 6 Fwd | 109,371 | 2,241 | 18,811 | 1 | 1,241,825 | -1 | -1 | -1
12 | 65 | 6 Rev | 57,692 | 1,450 | 13,046 | 1 | 870,266 | -1 | -1 | -1


