### PR TITLE
Tree-sitter: Verbosity fixes

### DIFF
--- a/ruby/extractor/src/extractor.rs
+++ b/ruby/extractor/src/extractor.rs
@@ -26,6 +26,7 @@ pub struct Options {
 
 pub fn run(options: Options) -> std::io::Result<()> {
     extractor::set_tracing_level("ruby");
+    tracing::info!("Extraction started");
     let diagnostics = diagnostics::DiagnosticLoggers::new("ruby");
     let mut main_thread_logger = diagnostics.logger();
     let num_threads = match codeql_extractor::options::num_threads() {
@@ -210,7 +211,9 @@ pub fn run(options: Options) -> std::io::Result<()> {
     let path = PathBuf::from("extras");
     let mut trap_writer = trap::Writer::new();
     extractor::populate_empty_location(&mut trap_writer);
-    write_trap(&trap_dir, path, &trap_writer, trap_compression)
+    let res = write_trap(&trap_dir, path, &trap_writer, trap_compression);
+    tracing::info!("Extraction complete");
+    res
 }
 
 lazy_static! {

--- a/shared/tree-sitter-extractor/src/autobuilder.rs
+++ b/shared/tree-sitter-extractor/src/autobuilder.rs
@@ -54,6 +54,12 @@ impl Autobuilder {
         let mut cmd = Command::new(codeql);
         cmd.arg("database").arg("index-files");
 
+        let verbosity = env::var("CODEQL_VERBOSITY");
+
+        if let Ok(verbosity) = verbosity {
+            cmd.arg(format!("--verbosity={}", verbosity));
+        }
+
         for ext in &self.include_extensions {
             cmd.arg(format!("--include-extension={}", ext));
         }

--- a/shared/tree-sitter-extractor/src/extractor/mod.rs
+++ b/shared/tree-sitter-extractor/src/extractor/mod.rs
@@ -33,8 +33,7 @@ pub fn set_tracing_level(language: &str) {
                         })
                         .unwrap_or_else(|_| "warn");
                     tracing_subscriber::EnvFilter::new(format!(
-                        "{}_extractor={}",
-                        language, verbosity
+                        "{language}_extractor={verbosity},codeql_extractor={verbosity}"
                     ))
                 },
             ),

--- a/shared/tree-sitter-extractor/src/extractor/simple.rs
+++ b/shared/tree-sitter-extractor/src/extractor/simple.rs
@@ -29,6 +29,7 @@ pub struct Extractor {
 
 impl Extractor {
     pub fn run(&self) -> std::io::Result<()> {
+        tracing::info!("Extraction started");
         let diagnostics = diagnostics::DiagnosticLoggers::new(&self.prefix);
         let mut main_thread_logger = diagnostics.logger();
         let num_threads = match crate::options::num_threads() {
@@ -170,7 +171,9 @@ impl Extractor {
         let mut trap_writer = trap::Writer::new();
         crate::extractor::populate_empty_location(&mut trap_writer);
 
-        write_trap(&self.trap_dir, &path, &trap_writer, trap_compression)
+        let res = write_trap(&self.trap_dir, &path, &trap_writer, trap_compression);
+        tracing::info!("Extraction complete");
+        res
     }
 }
 


### PR DESCRIPTION
1. Make sure that the auto-builder passes the verbosity defined in `CODEQL_VERBOSITY` into the `codeql database index-files` invocation.
2. Make sure that the verbosity applies to the shared logic in the `codeql-extractor` crate.