### PR TITLE
Mark all integration tests as legacy

### DIFF
--- a/csharp/ql/integration-tests/legacy
+++ b/csharp/ql/integration-tests/legacy
@@ -1,0 +1,1 @@
+These tests are still run with the legacy test runner

--- a/go/ql/integration-tests/legacy
+++ b/go/ql/integration-tests/legacy
@@ -1,0 +1,1 @@
+These tests are still run with the legacy test runner

--- a/java/ql/integration-tests/legacy
+++ b/java/ql/integration-tests/legacy
@@ -1,0 +1,1 @@
+These tests are still run with the legacy test runner

--- a/javascript/ql/integration-tests/legacy
+++ b/javascript/ql/integration-tests/legacy
@@ -1,0 +1,1 @@
+These tests are still run with the legacy test runner

--- a/ruby/ql/integration-tests/legacy
+++ b/ruby/ql/integration-tests/legacy
@@ -1,0 +1,1 @@
+These tests are still run with the legacy test runner

--- a/swift/ql/integration-tests/legacy
+++ b/swift/ql/integration-tests/legacy
@@ -1,0 +1,1 @@
+These tests are still run with the legacy test runner


### PR DESCRIPTION
This is in preparation for the new integration test framework. Only tests marked thus will be run by the current framework and only tests not marked thus will be run by the new one.

No actual review is necessary from the language teams (well, there's also not much to review here :laughing:).