### PR TITLE
Cmake generator: Remove space in argument.

### DIFF
--- a/misc/bazel/cmake/setup.cmake
+++ b/misc/bazel/cmake/setup.cmake
@@ -42,7 +42,7 @@ endmacro()
 macro(generate_and_include)
     file(REMOVE "${BAZEL_WORKSPACE}/.bazel-cmake/BUILD.bazel")
     # use aquery to only get targets compatible with the current platform
-    bazel_even_if_failing(aquery "kind(\"cc_test|cc_binary\", ${ARGN})" ${BAZEL_BUILD_OPTIONS} --output=jsonproto OUTPUT_VARIABLE BAZEL_AQUERY_RESULT)
+    bazel_even_if_failing(aquery "kind(\"cc_test|cc_binary\",${ARGN})" ${BAZEL_BUILD_OPTIONS} --output=jsonproto OUTPUT_VARIABLE BAZEL_AQUERY_RESULT)
     string(JSON BAZEL_JSON_TARGETS GET "${BAZEL_AQUERY_RESULT}" targets)
     string(JSON LAST_IDX LENGTH "${BAZEL_JSON_TARGETS}")
     math(EXPR LAST_IDX "${LAST_IDX} - 1")


### PR DESCRIPTION
This space breaks when upgrading bazelisk on Windows. Somehow, a space inside the argument messes up some argument-parsin somewhere. Porbably due to Windows argument parsing being not well-defined in how it splits a string into argv. Removing the space works around the problem.

If the space is included, cmake suddenly can't find the bazelisk binary anymore, despite happily executing `info output_base` earlier.