### PR TITLE
Python: Update url-redirect qhelp with `https:/example.com` handling

### DIFF
--- a/python/ql/src/Security/CWE-601/UrlRedirect.qhelp
+++ b/python/ql/src/Security/CWE-601/UrlRedirect.qhelp
@@ -45,11 +45,20 @@ attribute is empty.
 </p>
 
 <p>
-Note, however, that many browsers accept backslash characters (<code>\</code>) as equivalent
-to forward slash characters (<code>/</code>) in URLs, but the <code>urlparse</code> function
-does not. To account for this, you can first replace all backslashes with forward slashes,
-as shown in the following example:
+Note, however, that some cases are not handled as we desire out-of-the-box by <code>urlparse</code>, so we need to adjust two things, as shown in the example below:
 </p>
+
+<ul>
+  <li>
+    Many browsers accept backslash characters (<code>\</code>) as equivalent
+    to forward slash characters (<code>/</code>) in URLs, but the <code>urlparse</code> function
+    does not.
+  </li>
+  <li>
+    Mistyped URLs such as <code>https:/example.com</code> or <code>https:///example.com</code> are parsed as having an empty <code>netloc</code> attribute, while browsers will still redirect to the correct site.
+  </li>
+</ul>
+
 
 <sample src="examples/redirect_good2.py"/>
 

--- a/python/ql/src/Security/CWE-601/examples/redirect_good2.py
+++ b/python/ql/src/Security/CWE-601/examples/redirect_good2.py
@@ -7,7 +7,7 @@ app = Flask(__name__)
 def hello():
     target = request.args.get('target', '')
     target = target.replace('\\', '')
-    if not urlparse(target).netloc:
+    if not urlparse(target).netloc and not urlparse(target).scheme:
         # relative path, safe to redirect
         return redirect(target, code=302)
     # ignore the target and redirect to the home page


### PR DESCRIPTION
Fixes https://github.com/github/codeql/issues/16041

/cc @max-schaefer who originally created https://github.com/github/codeql/pull/15176