### PR TITLE
Python: Fixes an error in the deprecation notice for a taint tracking configuration

### DIFF
--- a/python/ql/lib/semmle/python/security/dataflow/ServerSideRequestForgeryQuery.qll
+++ b/python/ql/lib/semmle/python/security/dataflow/ServerSideRequestForgeryQuery.qll
@@ -74,7 +74,7 @@ predicate fullyControlledRequest(Http::Client::Request request) {
 }
 
 /**
- * DEPRECATED: Use `FullServerSideRequestForgeryFlow` module instead.
+ * DEPRECATED: Use `PartialServerSideRequestForgeryFlow` module instead.
  *
  * A taint-tracking configuration for detecting "Server-side request forgery" vulnerabilities.
  *


### PR DESCRIPTION
Fixes an error in the deprecation notice for a taint tracking configuration.