### PR TITLE
C++: Ignore `gets`'es with incorrect parameter counts

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-676/DangerousFunctionOverflow.ql
+++ b/cpp/ql/src/Security/CWE/CWE-676/DangerousFunctionOverflow.ql
@@ -17,5 +17,6 @@ import cpp
 from FunctionCall call, Function target
 where
   call.getTarget() = target and
-  target.hasGlobalOrStdName("gets")
+  target.hasGlobalOrStdName("gets") and
+  target.getNumberOfParameters() = 1
 select call, "'gets' does not guard against buffer overflow."

--- a/cpp/ql/src/change-notes/2014-06-05-gets-parameter.md
+++ b/cpp/ql/src/change-notes/2014-06-05-gets-parameter.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `cpp/dangerous-function-overflow` no longer produces a false positive alert when the `gets` function does not have exactly one parameter.

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-676/semmle/PotentiallyDangerousFunction/test.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-676/semmle/PotentiallyDangerousFunction/test.c
@@ -36,7 +36,7 @@ char *gets(char *s);
 
 void testGets() {
 	char buf1[1024];
-	char buf2 = malloc(1024);
+	char *buf2 = malloc(1024);
 	char *s;
 
 	gets(buf1); // BAD: use of gets

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-676/semmle/PotentiallyDangerousFunction/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-676/semmle/PotentiallyDangerousFunction/test.cpp
@@ -1,0 +1,7 @@
+char *gets();
+
+void testOtherGets() {
+	char *s;
+
+	s = gets(); // GOOD: this is not the gets from stdio.h
+}


### PR DESCRIPTION
This showed up while looking at some alerts.