### PR TITLE
Add support for flow through content of global variables

### DIFF
--- a/go/ql/lib/change-notes/2024-06-17-go-global-variable-writes.md
+++ b/go/ql/lib/change-notes/2024-06-17-go-global-variable-writes.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* Fixed dataflow via global variables other than via a direct write: for example, via a side-effect on a global, such as `io.copy(SomeGlobal, ...)` or via assignment to a field or array or slice cell of a global. This means that any data-flow query may return more results where global variables are involved.

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowPrivate.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowPrivate.qll
@@ -102,10 +102,14 @@ private Field getASparselyUsedChannelTypedField() {
  * global or static variable.
  */
 predicate jumpStep(Node n1, Node n2) {
-  exists(ValueEntity v, Write w |
+  exists(ValueEntity v |
     not v instanceof SsaSourceVariable and
     not v instanceof Field and
-    w.writes(v, n1) and
+    (
+      any(Write w).writes(v, n1)
+      or
+      n1.(DataFlow::PostUpdateNode).getPreUpdateNode() = v.getARead()
+    ) and
     n2 = v.getARead()
   )
   or

--- a/go/ql/test/experimental/CWE-1004/CookieWithoutHttpOnly.expected
+++ b/go/ql/test/experimental/CWE-1004/CookieWithoutHttpOnly.expected
@@ -257,9 +257,20 @@ edges
 | CookieWithoutHttpOnly.go:123:13:123:49 | call to NewCookieStore | CookieWithoutHttpOnly.go:158:16:158:20 | store | provenance |  |
 | CookieWithoutHttpOnly.go:123:13:123:49 | call to NewCookieStore | CookieWithoutHttpOnly.go:170:16:170:20 | store | provenance |  |
 | CookieWithoutHttpOnly.go:123:13:123:49 | call to NewCookieStore | CookieWithoutHttpOnly.go:183:16:183:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:123:13:123:49 | call to NewCookieStore | CookieWithoutHttpOnly.go:191:2:191:6 | store | provenance |  |
 | CookieWithoutHttpOnly.go:123:13:123:49 | call to NewCookieStore | CookieWithoutHttpOnly.go:195:16:195:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:123:13:123:49 | call to NewCookieStore | CookieWithoutHttpOnly.go:202:2:202:6 | store | provenance |  |
 | CookieWithoutHttpOnly.go:126:2:126:43 | ... := ...[0] | CookieWithoutHttpOnly.go:129:2:129:8 | session | provenance |  |
 | CookieWithoutHttpOnly.go:126:16:126:20 | store | CookieWithoutHttpOnly.go:126:2:126:43 | ... := ...[0] | provenance | Config |
+| CookieWithoutHttpOnly.go:126:16:126:20 | store | CookieWithoutHttpOnly.go:126:16:126:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:126:16:126:20 | store | CookieWithoutHttpOnly.go:134:16:134:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:126:16:126:20 | store | CookieWithoutHttpOnly.go:146:16:146:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:126:16:126:20 | store | CookieWithoutHttpOnly.go:158:16:158:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:126:16:126:20 | store | CookieWithoutHttpOnly.go:170:16:170:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:126:16:126:20 | store | CookieWithoutHttpOnly.go:183:16:183:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:126:16:126:20 | store | CookieWithoutHttpOnly.go:191:2:191:6 | store | provenance |  |
+| CookieWithoutHttpOnly.go:126:16:126:20 | store | CookieWithoutHttpOnly.go:195:16:195:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:126:16:126:20 | store | CookieWithoutHttpOnly.go:202:2:202:6 | store | provenance |  |
 | CookieWithoutHttpOnly.go:133:2:133:9 | definition of httpOnly | CookieWithoutHttpOnly.go:139:13:139:20 | httpOnly | provenance |  |
 | CookieWithoutHttpOnly.go:133:14:133:18 | false | CookieWithoutHttpOnly.go:139:13:139:20 | httpOnly | provenance |  |
 | CookieWithoutHttpOnly.go:134:2:134:8 | definition of session [pointer] | CookieWithoutHttpOnly.go:135:2:135:8 | session [pointer] | provenance |  |
@@ -269,7 +280,16 @@ edges
 | CookieWithoutHttpOnly.go:134:2:134:8 | definition of session [pointer] | CookieWithoutHttpOnly.go:142:2:142:8 | session | provenance |  |
 | CookieWithoutHttpOnly.go:134:2:134:8 | definition of session [pointer] | CookieWithoutHttpOnly.go:142:2:142:8 | session | provenance |  |
 | CookieWithoutHttpOnly.go:134:2:134:43 | ... := ...[0] | CookieWithoutHttpOnly.go:142:2:142:8 | session | provenance |  |
+| CookieWithoutHttpOnly.go:134:16:134:20 | store | CookieWithoutHttpOnly.go:126:16:126:20 | store | provenance |  |
 | CookieWithoutHttpOnly.go:134:16:134:20 | store | CookieWithoutHttpOnly.go:134:2:134:43 | ... := ...[0] | provenance | Config |
+| CookieWithoutHttpOnly.go:134:16:134:20 | store | CookieWithoutHttpOnly.go:134:16:134:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:134:16:134:20 | store | CookieWithoutHttpOnly.go:146:16:146:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:134:16:134:20 | store | CookieWithoutHttpOnly.go:158:16:158:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:134:16:134:20 | store | CookieWithoutHttpOnly.go:170:16:170:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:134:16:134:20 | store | CookieWithoutHttpOnly.go:183:16:183:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:134:16:134:20 | store | CookieWithoutHttpOnly.go:191:2:191:6 | store | provenance |  |
+| CookieWithoutHttpOnly.go:134:16:134:20 | store | CookieWithoutHttpOnly.go:195:16:195:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:134:16:134:20 | store | CookieWithoutHttpOnly.go:202:2:202:6 | store | provenance |  |
 | CookieWithoutHttpOnly.go:135:2:135:8 | implicit dereference | CookieWithoutHttpOnly.go:134:2:134:8 | definition of session [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:135:2:135:8 | implicit dereference | CookieWithoutHttpOnly.go:134:2:134:8 | definition of session [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:135:2:135:8 | implicit dereference | CookieWithoutHttpOnly.go:135:2:135:8 | implicit dereference | provenance |  |
@@ -305,7 +325,16 @@ edges
 | CookieWithoutHttpOnly.go:146:2:146:8 | definition of session [pointer] | CookieWithoutHttpOnly.go:149:2:149:8 | session [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:146:2:146:8 | definition of session [pointer] | CookieWithoutHttpOnly.go:153:2:153:8 | session | provenance |  |
 | CookieWithoutHttpOnly.go:146:2:146:43 | ... := ...[0] | CookieWithoutHttpOnly.go:153:2:153:8 | session | provenance |  |
+| CookieWithoutHttpOnly.go:146:16:146:20 | store | CookieWithoutHttpOnly.go:126:16:126:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:146:16:146:20 | store | CookieWithoutHttpOnly.go:134:16:134:20 | store | provenance |  |
 | CookieWithoutHttpOnly.go:146:16:146:20 | store | CookieWithoutHttpOnly.go:146:2:146:43 | ... := ...[0] | provenance | Config |
+| CookieWithoutHttpOnly.go:146:16:146:20 | store | CookieWithoutHttpOnly.go:146:16:146:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:146:16:146:20 | store | CookieWithoutHttpOnly.go:158:16:158:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:146:16:146:20 | store | CookieWithoutHttpOnly.go:170:16:170:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:146:16:146:20 | store | CookieWithoutHttpOnly.go:183:16:183:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:146:16:146:20 | store | CookieWithoutHttpOnly.go:191:2:191:6 | store | provenance |  |
+| CookieWithoutHttpOnly.go:146:16:146:20 | store | CookieWithoutHttpOnly.go:195:16:195:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:146:16:146:20 | store | CookieWithoutHttpOnly.go:202:2:202:6 | store | provenance |  |
 | CookieWithoutHttpOnly.go:147:2:147:8 | implicit dereference | CookieWithoutHttpOnly.go:146:2:146:8 | definition of session [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:147:2:147:8 | implicit dereference | CookieWithoutHttpOnly.go:147:2:147:8 | implicit dereference | provenance |  |
 | CookieWithoutHttpOnly.go:147:2:147:8 | implicit dereference | CookieWithoutHttpOnly.go:149:2:149:8 | session | provenance |  |
@@ -330,7 +359,16 @@ edges
 | CookieWithoutHttpOnly.go:158:2:158:8 | definition of session [pointer] | CookieWithoutHttpOnly.go:166:2:166:8 | session | provenance |  |
 | CookieWithoutHttpOnly.go:158:2:158:8 | definition of session [pointer] | CookieWithoutHttpOnly.go:166:2:166:8 | session | provenance |  |
 | CookieWithoutHttpOnly.go:158:2:158:43 | ... := ...[0] | CookieWithoutHttpOnly.go:166:2:166:8 | session | provenance |  |
+| CookieWithoutHttpOnly.go:158:16:158:20 | store | CookieWithoutHttpOnly.go:126:16:126:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:158:16:158:20 | store | CookieWithoutHttpOnly.go:134:16:134:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:158:16:158:20 | store | CookieWithoutHttpOnly.go:146:16:146:20 | store | provenance |  |
 | CookieWithoutHttpOnly.go:158:16:158:20 | store | CookieWithoutHttpOnly.go:158:2:158:43 | ... := ...[0] | provenance | Config |
+| CookieWithoutHttpOnly.go:158:16:158:20 | store | CookieWithoutHttpOnly.go:158:16:158:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:158:16:158:20 | store | CookieWithoutHttpOnly.go:170:16:170:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:158:16:158:20 | store | CookieWithoutHttpOnly.go:183:16:183:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:158:16:158:20 | store | CookieWithoutHttpOnly.go:191:2:191:6 | store | provenance |  |
+| CookieWithoutHttpOnly.go:158:16:158:20 | store | CookieWithoutHttpOnly.go:195:16:195:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:158:16:158:20 | store | CookieWithoutHttpOnly.go:202:2:202:6 | store | provenance |  |
 | CookieWithoutHttpOnly.go:159:2:159:8 | implicit dereference | CookieWithoutHttpOnly.go:158:2:158:8 | definition of session [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:159:2:159:8 | implicit dereference | CookieWithoutHttpOnly.go:158:2:158:8 | definition of session [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:159:2:159:8 | implicit dereference | CookieWithoutHttpOnly.go:159:2:159:8 | implicit dereference | provenance |  |
@@ -371,7 +409,16 @@ edges
 | CookieWithoutHttpOnly.go:170:2:170:8 | definition of session [pointer] | CookieWithoutHttpOnly.go:178:2:178:8 | session | provenance |  |
 | CookieWithoutHttpOnly.go:170:2:170:8 | definition of session [pointer] | CookieWithoutHttpOnly.go:178:2:178:8 | session | provenance |  |
 | CookieWithoutHttpOnly.go:170:2:170:43 | ... := ...[0] | CookieWithoutHttpOnly.go:178:2:178:8 | session | provenance |  |
+| CookieWithoutHttpOnly.go:170:16:170:20 | store | CookieWithoutHttpOnly.go:126:16:126:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:170:16:170:20 | store | CookieWithoutHttpOnly.go:134:16:134:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:170:16:170:20 | store | CookieWithoutHttpOnly.go:146:16:146:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:170:16:170:20 | store | CookieWithoutHttpOnly.go:158:16:158:20 | store | provenance |  |
 | CookieWithoutHttpOnly.go:170:16:170:20 | store | CookieWithoutHttpOnly.go:170:2:170:43 | ... := ...[0] | provenance | Config |
+| CookieWithoutHttpOnly.go:170:16:170:20 | store | CookieWithoutHttpOnly.go:170:16:170:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:170:16:170:20 | store | CookieWithoutHttpOnly.go:183:16:183:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:170:16:170:20 | store | CookieWithoutHttpOnly.go:191:2:191:6 | store | provenance |  |
+| CookieWithoutHttpOnly.go:170:16:170:20 | store | CookieWithoutHttpOnly.go:195:16:195:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:170:16:170:20 | store | CookieWithoutHttpOnly.go:202:2:202:6 | store | provenance |  |
 | CookieWithoutHttpOnly.go:171:2:171:8 | implicit dereference | CookieWithoutHttpOnly.go:170:2:170:8 | definition of session [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:171:2:171:8 | implicit dereference | CookieWithoutHttpOnly.go:170:2:170:8 | definition of session [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:171:2:171:8 | implicit dereference | CookieWithoutHttpOnly.go:171:2:171:8 | implicit dereference | provenance |  |
@@ -404,9 +451,45 @@ edges
 | CookieWithoutHttpOnly.go:173:21:176:2 | struct literal | CookieWithoutHttpOnly.go:173:20:176:2 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:175:13:175:20 | httpOnly | CookieWithoutHttpOnly.go:173:21:176:2 | struct literal | provenance | Config |
 | CookieWithoutHttpOnly.go:183:2:183:43 | ... := ...[0] | CookieWithoutHttpOnly.go:191:19:191:25 | session | provenance |  |
+| CookieWithoutHttpOnly.go:183:16:183:20 | store | CookieWithoutHttpOnly.go:126:16:126:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:183:16:183:20 | store | CookieWithoutHttpOnly.go:134:16:134:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:183:16:183:20 | store | CookieWithoutHttpOnly.go:146:16:146:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:183:16:183:20 | store | CookieWithoutHttpOnly.go:158:16:158:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:183:16:183:20 | store | CookieWithoutHttpOnly.go:170:16:170:20 | store | provenance |  |
 | CookieWithoutHttpOnly.go:183:16:183:20 | store | CookieWithoutHttpOnly.go:183:2:183:43 | ... := ...[0] | provenance | Config |
+| CookieWithoutHttpOnly.go:183:16:183:20 | store | CookieWithoutHttpOnly.go:183:16:183:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:183:16:183:20 | store | CookieWithoutHttpOnly.go:191:2:191:6 | store | provenance |  |
+| CookieWithoutHttpOnly.go:183:16:183:20 | store | CookieWithoutHttpOnly.go:195:16:195:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:183:16:183:20 | store | CookieWithoutHttpOnly.go:202:2:202:6 | store | provenance |  |
+| CookieWithoutHttpOnly.go:191:2:191:6 | store | CookieWithoutHttpOnly.go:126:16:126:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:191:2:191:6 | store | CookieWithoutHttpOnly.go:134:16:134:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:191:2:191:6 | store | CookieWithoutHttpOnly.go:146:16:146:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:191:2:191:6 | store | CookieWithoutHttpOnly.go:158:16:158:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:191:2:191:6 | store | CookieWithoutHttpOnly.go:170:16:170:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:191:2:191:6 | store | CookieWithoutHttpOnly.go:183:16:183:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:191:2:191:6 | store | CookieWithoutHttpOnly.go:191:2:191:6 | store | provenance |  |
+| CookieWithoutHttpOnly.go:191:2:191:6 | store | CookieWithoutHttpOnly.go:195:16:195:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:191:2:191:6 | store | CookieWithoutHttpOnly.go:202:2:202:6 | store | provenance |  |
 | CookieWithoutHttpOnly.go:195:2:195:43 | ... := ...[0] | CookieWithoutHttpOnly.go:202:19:202:25 | session | provenance |  |
+| CookieWithoutHttpOnly.go:195:16:195:20 | store | CookieWithoutHttpOnly.go:126:16:126:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:195:16:195:20 | store | CookieWithoutHttpOnly.go:134:16:134:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:195:16:195:20 | store | CookieWithoutHttpOnly.go:146:16:146:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:195:16:195:20 | store | CookieWithoutHttpOnly.go:158:16:158:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:195:16:195:20 | store | CookieWithoutHttpOnly.go:170:16:170:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:195:16:195:20 | store | CookieWithoutHttpOnly.go:183:16:183:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:195:16:195:20 | store | CookieWithoutHttpOnly.go:191:2:191:6 | store | provenance |  |
 | CookieWithoutHttpOnly.go:195:16:195:20 | store | CookieWithoutHttpOnly.go:195:2:195:43 | ... := ...[0] | provenance | Config |
+| CookieWithoutHttpOnly.go:195:16:195:20 | store | CookieWithoutHttpOnly.go:195:16:195:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:195:16:195:20 | store | CookieWithoutHttpOnly.go:202:2:202:6 | store | provenance |  |
+| CookieWithoutHttpOnly.go:202:2:202:6 | store | CookieWithoutHttpOnly.go:126:16:126:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:202:2:202:6 | store | CookieWithoutHttpOnly.go:134:16:134:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:202:2:202:6 | store | CookieWithoutHttpOnly.go:146:16:146:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:202:2:202:6 | store | CookieWithoutHttpOnly.go:158:16:158:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:202:2:202:6 | store | CookieWithoutHttpOnly.go:170:16:170:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:202:2:202:6 | store | CookieWithoutHttpOnly.go:183:16:183:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:202:2:202:6 | store | CookieWithoutHttpOnly.go:191:2:191:6 | store | provenance |  |
+| CookieWithoutHttpOnly.go:202:2:202:6 | store | CookieWithoutHttpOnly.go:195:16:195:20 | store | provenance |  |
+| CookieWithoutHttpOnly.go:202:2:202:6 | store | CookieWithoutHttpOnly.go:202:2:202:6 | store | provenance |  |
 nodes
 | CookieWithoutHttpOnly.go:11:7:14:2 | struct literal | semmle.label | struct literal |
 | CookieWithoutHttpOnly.go:12:10:12:18 | "session" | semmle.label | "session" |
@@ -640,9 +723,11 @@ nodes
 | CookieWithoutHttpOnly.go:178:2:178:8 | session | semmle.label | session |
 | CookieWithoutHttpOnly.go:183:2:183:43 | ... := ...[0] | semmle.label | ... := ...[0] |
 | CookieWithoutHttpOnly.go:183:16:183:20 | store | semmle.label | store |
+| CookieWithoutHttpOnly.go:191:2:191:6 | store | semmle.label | store |
 | CookieWithoutHttpOnly.go:191:19:191:25 | session | semmle.label | session |
 | CookieWithoutHttpOnly.go:195:2:195:43 | ... := ...[0] | semmle.label | ... := ...[0] |
 | CookieWithoutHttpOnly.go:195:16:195:20 | store | semmle.label | store |
+| CookieWithoutHttpOnly.go:202:2:202:6 | store | semmle.label | store |
 | CookieWithoutHttpOnly.go:202:19:202:25 | session | semmle.label | session |
 | CookieWithoutHttpOnly.go:214:66:214:70 | false | semmle.label | false |
 subpaths

--- a/go/ql/test/experimental/CWE-321-V2/HardCodedKeys.expected
+++ b/go/ql/test/experimental/CWE-321-V2/HardCodedKeys.expected
@@ -1,11 +1,15 @@
 edges
 | go-jose.v3.go:13:14:13:34 | type conversion | go-jose.v3.go:24:32:24:37 | JwtKey | provenance |  |
+| go-jose.v3.go:13:14:13:34 | type conversion | go-jose.v3.go:24:32:24:37 | JwtKey | provenance |  |
 | go-jose.v3.go:13:21:13:33 | "AllYourBase" | go-jose.v3.go:13:14:13:34 | type conversion | provenance |  |
+| go-jose.v3.go:24:32:24:37 | JwtKey | go-jose.v3.go:24:32:24:37 | JwtKey | provenance |  |
+| go-jose.v3.go:24:32:24:37 | JwtKey | go-jose.v3.go:24:32:24:37 | JwtKey | provenance |  |
 | golang-jwt-v5.go:19:15:19:35 | type conversion | golang-jwt-v5.go:27:9:27:15 | JwtKey1 | provenance |  |
 | golang-jwt-v5.go:19:22:19:34 | "AllYourBase" | golang-jwt-v5.go:19:15:19:35 | type conversion | provenance |  |
 nodes
 | go-jose.v3.go:13:14:13:34 | type conversion | semmle.label | type conversion |
 | go-jose.v3.go:13:21:13:33 | "AllYourBase" | semmle.label | "AllYourBase" |
+| go-jose.v3.go:24:32:24:37 | JwtKey | semmle.label | JwtKey |
 | go-jose.v3.go:24:32:24:37 | JwtKey | semmle.label | JwtKey |
 | golang-jwt-v5.go:19:15:19:35 | type conversion | semmle.label | type conversion |
 | golang-jwt-v5.go:19:22:19:34 | "AllYourBase" | semmle.label | "AllYourBase" |

--- a/go/ql/test/library-tests/semmle/go/dataflow/GlobalVariableSideEffects/globalVariable.go
+++ b/go/ql/test/library-tests/semmle/go/dataflow/GlobalVariableSideEffects/globalVariable.go
@@ -14,13 +14,13 @@ func main() {
 	test1()
 	test2()
 	sink(globalScalar)   // $ hasValueFlow="globalScalar (from source 0)" MISSING: hasValueFlow="globalScalar (from source 10)"
-	sink(globalArray[0]) // $ MISSING: hasValueFlow="index expression (from source 1)" hasValueFlow="index expression (from source 11)"
-	sink(globalSlice[0]) // $ MISSING: hasValueFlow="index expression (from source 2)" hasValueFlow="index expression (from source 12)"
+	sink(globalArray[0]) // $ hasValueFlow="index expression (from source 1)" hasValueFlow="index expression (from source 11)"
+	sink(globalSlice[0]) // $ hasValueFlow="index expression (from source 2)" hasValueFlow="index expression (from source 12)"
 	for val := range globalMap1 {
-		sink(val) // $ MISSING: hasValueFlow="val (from source 3)" hasValueFlow="val (from source 13)"
+		sink(val) // $ hasValueFlow="val (from source 3)" hasValueFlow="val (from source 13)"
 	}
 	for _, val := range globalMap2 {
-		sink(val) // $ MISSING: hasValueFlow="val (from source 4)" hasValueFlow="val (from source 14)"
+		sink(val) // $ hasValueFlow="val (from source 4)" hasValueFlow="val (from source 14)"
 	}
 }
 
@@ -33,29 +33,29 @@ func test1() {
 }
 
 func test2() {
-	taintScalar(&globalScalar, 10)
-	taintArray(globalArray, 11)
-	taintSlice(globalSlice, 12)
-	taintMapKey(globalMap1, 13)
-	taintMapValue(globalMap2, 14)
+	taintScalar(&globalScalar)
+	taintArray(globalArray)
+	taintSlice(globalSlice)
+	taintMapKey(globalMap1)
+	taintMapValue(globalMap2)
 }
 
-func taintScalar(x *any, n int) {
-	*x = source(n)
+func taintScalar(x *any) {
+	*x = source(10)
 }
 
-func taintArray(x [1]any, n int) {
-	x[0] = source(n)
+func taintArray(x [1]any) {
+	x[0] = source(11)
 }
 
-func taintSlice(x []any, n int) {
-	x[0] = source(n)
+func taintSlice(x []any) {
+	x[0] = source(12)
 }
 
-func taintMapKey(x map[any]any, n int) {
-	x[source(n)] = ""
+func taintMapKey(x map[any]any) {
+	x[source(13)] = ""
 }
 
-func taintMapValue(x map[any]any, n int) {
-	x[""] = source(n)
+func taintMapValue(x map[any]any) {
+	x[""] = source(14)
 }


### PR DESCRIPTION
Note flow via something like `sideEffect(&x)` is still broken. I think this is because we're lacking a store-step for `*x = source()`, which should result in `x` having taint with access path `[PointerContent]`. This might also involve address operations being able to read taint (i.e. to note that if `&x` is tainted with `[PointerContent]` then `x` is tainted without an access path), but I'm not sure -- in any event I don't address the matter here. I'd suggest tackling that issue by cribbing off C/C++, which has surely addressed (no pun intended) this exact issue.