### PR TITLE
JS: Use `resources/tools` from external repo, not internal.

### DIFF
--- a/javascript/BUILD.bazel
+++ b/javascript/BUILD.bazel
@@ -31,7 +31,7 @@ codeql_pack(
         "//javascript/downgrades",
         "//javascript/externs",
         "//javascript/extractor:tools-extractor",
-        "@semmle_code//language-packs/javascript:resources",
+        "//javascript/resources",
     ],
     visibility = ["//visibility:public"],
     zips = {"//javascript/extractor/lib/typescript": "tools"},


### PR DESCRIPTION
This was missing in https://github.com/github/codeql/pull/16656, so we couldn't actually delete the resources in the internal repo.