### PR TITLE
Python: Add type-tracking flow for class (instance) attributes

### DIFF
--- a/python/ql/lib/semmle/python/dataflow/new/internal/TypeTrackingImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/TypeTrackingImpl.qll
@@ -297,7 +297,8 @@ module TypeTrackingInput implements Shared::TypeTrackingInput {
   predicate loadStoreStep(Node nodeFrom, Node nodeTo, Content loadContent, Content storeContent) {
     TypeTrackerSummaryFlow::basicLoadStoreStep(nodeFrom, nodeTo, loadContent, storeContent)
     or
-    // Class attribute -> self attribute/instance
+    // flow from class/self -> cls/self/instance, for the relevant attributes.
+    // Using loadStoreStep is more powerful than a potential solution utilizing levelStepNoCall targeting attribute read; with this setup, a flow summary that reads a class attribute will actually work!
     exists(Class cls, string attrName, boolean storeOnClass |
       loadContent.(DataFlowPublic::AttributeContent).getAttribute() = attrName and
       storeContent.(DataFlowPublic::AttributeContent).getAttribute() = attrName and

--- a/python/ql/lib/semmle/python/dataflow/new/internal/TypeTrackingImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/TypeTrackingImpl.qll
@@ -297,7 +297,7 @@ module TypeTrackingInput implements Shared::TypeTrackingInput {
   predicate loadStoreStep(Node nodeFrom, Node nodeTo, Content loadContent, Content storeContent) {
     TypeTrackerSummaryFlow::basicLoadStoreStep(nodeFrom, nodeTo, loadContent, storeContent)
     or
-    // Class attribute -> self attribute
+    // Class attribute -> self attribute/instance
     exists(Class cls, string attrName |
       loadContent.(DataFlowPublic::AttributeContent).getAttribute() = attrName and
       storeContent.(DataFlowPublic::AttributeContent).getAttribute() = attrName and
@@ -322,6 +322,14 @@ module TypeTrackingInput implements Shared::TypeTrackingInput {
           nodeTo =
             instanceMethod.getParameter(any(DataFlowDispatch::ParameterPosition p | p.isSelf()))
         )
+        or
+        // instantiation of class
+        //
+        // TODO: proper tracking of class (we can't just use type-tracking right now,
+        // since we're using a late-inlined relation in a recursive setting, which is
+        // not supported)
+        nodeTo.(DataFlowPublic::CallCfgNode).getFunction().getALocalSource() =
+          DataFlowPublic::exprNode(cls.getParent())
       )
     )
   }

--- a/python/ql/test/library-tests/dataflow/typetracking/attribute_tests.py
+++ b/python/ql/test/library-tests/dataflow/typetracking/attribute_tests.py
@@ -204,11 +204,12 @@ class MyClass5(object): # $ tracked=foo tracked=bar
     # bar is set from a classmethod
     bar = None
 
-    def on_self(self):
-        print(self.foo) # $ MISSING: tracked=foo tracked
-        print(self.bar) # $ MISSING: tracked=bar tracked
+    def on_self(self): # $ tracked=bar tracked=foo
+        print(self.foo) # $ tracked=foo tracked tracked=bar
+        print(self.bar) # $ tracked=bar tracked tracked=foo
 
-    def on_classref(self):
+    @staticmethod
+    def on_classref():
         print(MyClass5.foo) # $ tracked=foo tracked tracked=bar
         print(MyClass5.bar) # $ tracked=foo tracked=bar tracked
 
@@ -231,11 +232,11 @@ print(instance.bar) # $ MISSING: tracked=bar tracked
 class MyClass6(object): # $ int=foo
     foo = int() # $ int
 
-    def set_instance_foo(self): # $ str=foo
-        self.foo = str() # $ str str=foo
+    def set_instance_foo(self): # $ str=foo int=foo
+        self.foo = str() # $ str str=foo int=foo
 
-    def use_im(self):
-        print(self.foo) # $ MISSING: int str
+    def use_im(self): # $ int=foo
+        print(self.foo) # $ int int=foo MISSING: str
 
     @classmethod
     def use_cls(cls):

--- a/python/ql/test/library-tests/dataflow/typetracking/attribute_tests.py
+++ b/python/ql/test/library-tests/dataflow/typetracking/attribute_tests.py
@@ -150,15 +150,15 @@ class MyClass2(object):
     def __init__(self): # $ tracked=foo
         self.foo = tracked # $ tracked=foo tracked
 
-    def print_foo(self): # $ MISSING: tracked=foo
-        print(self.foo) # $ MISSING: tracked=foo tracked
+    def print_foo(self): # $ tracked=foo
+        print(self.foo) # $ tracked=foo tracked
 
-    def possibly_uncalled_method(self): # $ MISSING: tracked=foo
-        print(self.foo) # $ MISSING: tracked=foo tracked
+    def possibly_uncalled_method(self): # $ tracked=foo
+        print(self.foo) # $ tracked=foo tracked
 
-instance = MyClass2()
-print(instance.foo) # $ MISSING: tracked=foo tracked
-instance.print_foo() # $ MISSING: tracked=foo
+instance = MyClass2() # $ tracked=foo
+print(instance.foo) # $ tracked=foo tracked
+instance.print_foo() # $ tracked=foo
 
 
 # attribute set from outside of class
@@ -185,16 +185,16 @@ class MyClass4(object):
     def set_foo(self): # $ tracked=foo
         self.foo = tracked # $ tracked=foo tracked
 
-    def print_foo(self): # $ MISSING: tracked=foo
-        print(self.foo) # $ MISSING: tracked=foo tracked
+    def print_foo(self): # $ tracked=foo
+        print(self.foo) # $ tracked=foo tracked
 
-    def possibly_uncalled_method(self): # $ MISSING: tracked=foo
-        print(self.foo) # $ MISSING: tracked=foo tracked
+    def possibly_uncalled_method(self): # $ tracked=foo
+        print(self.foo) # $ tracked=foo tracked
 
-instance = MyClass4() # $ MISSING: tracked=foo
-instance.set_foo() # $ MISSING: tracked=foo
-instance.print_foo() # $ MISSING: tracked=foo
-print(instance.foo) # $ MISSING: tracked=foo tracked
+instance = MyClass4() # $ tracked=foo
+instance.set_foo() # $ tracked=foo
+instance.print_foo() # $ tracked=foo
+print(instance.foo) # $ tracked=foo tracked
 
 
 # class-level attributes
@@ -235,8 +235,8 @@ class MyClass6(object): # $ int=foo
     def set_instance_foo(self): # $ str=foo int=foo
         self.foo = str() # $ str str=foo int=foo
 
-    def use_im(self): # $ int=foo
-        print(self.foo) # $ int int=foo MISSING: str
+    def use_im(self): # $ int=foo str=foo
+        print(self.foo) # $ int int=foo str str=foo
 
     @classmethod
     def use_cls(cls):
@@ -245,10 +245,10 @@ class MyClass6(object): # $ int=foo
 
 print(MyClass6.foo) # $ int int=foo
 
-instance = MyClass6() # $ int=foo
-print(instance.foo) # $ int int=foo
-instance.set_instance_foo() # $ int=foo
-print(instance.foo) # $ int int=foo MISSING: str
+instance = MyClass6() # $ int=foo str=foo
+print(instance.foo) # $ int int=foo str str=foo
+instance.set_instance_foo() # $ int=foo str=foo
+print(instance.foo) # $ int int=foo str str=foo
 
 
 # class-level attributes flowing between subclasses
@@ -257,8 +257,8 @@ class BaseClass(object):
     def set_foo(self): # $ tracked=foo
         self.foo = tracked # $ tracked=foo tracked
 
-    def use_foo(self):
-        print(self.foo) # $ MISSING: tracked=foo tracked
+    def use_foo(self): # $ tracked=foo
+        print(self.foo) # $ tracked=foo tracked
 
 class SubClass(BaseClass): # $ MISSING: tracked=foo
     def also_use_foo(self):

--- a/python/ql/test/library-tests/dataflow/typetracking/attribute_tests.py
+++ b/python/ql/test/library-tests/dataflow/typetracking/attribute_tests.py
@@ -214,13 +214,13 @@ class MyClass5(object): # $ tracked=foo tracked=bar
         print(MyClass5.bar) # $ tracked=foo tracked=bar tracked
 
     @classmethod
-    def on_cls(cls):
-        print(cls.foo) # $ MISSING: tracked=foo tracked
-        print(cls.bar) # $ MISSING: tracked=bar tracked
+    def on_cls(cls): # $ tracked=bar tracked=foo
+        print(cls.foo) # $ tracked=foo tracked tracked=bar
+        print(cls.bar) # $ tracked=bar tracked tracked=foo
 
     @classmethod
-    def set_bar(cls): # $ tracked=bar
-        cls.bar = tracked # $ tracked=bar tracked
+    def set_bar(cls): # $ tracked=bar tracked=foo
+        cls.bar = tracked # $ tracked=bar tracked tracked=foo
 
 instance = MyClass5() # $ tracked=foo tracked=bar
 print(instance.foo) # $ tracked=foo tracked tracked=bar
@@ -239,8 +239,8 @@ class MyClass6(object): # $ int=foo
         print(self.foo) # $ int int=foo str str=foo
 
     @classmethod
-    def use_cls(cls):
-        print(cls.foo) # $ MISSING: int
+    def use_cls(cls): # $ int=foo
+        print(cls.foo) # $ int int=foo
 
 
 print(MyClass6.foo) # $ int int=foo

--- a/python/ql/test/library-tests/dataflow/typetracking/attribute_tests.py
+++ b/python/ql/test/library-tests/dataflow/typetracking/attribute_tests.py
@@ -76,7 +76,7 @@ class MyClass: # $tracked=field
 
 lookup = MyClass.field # $tracked tracked=field
 instance = MyClass() # $tracked=field
-lookup2 = instance.field # MISSING: tracked
+lookup2 = instance.field # $ tracked tracked=field
 
 # ------------------------------------------------------------------------------
 # Dynamic attribute access
@@ -223,8 +223,8 @@ class MyClass5(object): # $ tracked=foo tracked=bar
         cls.bar = tracked # $ tracked=bar tracked
 
 instance = MyClass5() # $ tracked=foo tracked=bar
-print(instance.foo) # $ MISSING: tracked=foo tracked
-print(instance.bar) # $ MISSING: tracked=bar tracked
+print(instance.foo) # $ tracked=foo tracked tracked=bar
+print(instance.bar) # $ tracked=bar tracked tracked=foo
 
 
 # shadowing of class-level attribute by instance attribute
@@ -246,9 +246,9 @@ class MyClass6(object): # $ int=foo
 print(MyClass6.foo) # $ int int=foo
 
 instance = MyClass6() # $ int=foo
-print(instance.foo) # $ MISSING: int
-instance.set_instance_foo()
-print(instance.foo) # $ MISSING: int str
+print(instance.foo) # $ int int=foo
+instance.set_instance_foo() # $ int=foo
+print(instance.foo) # $ int int=foo MISSING: str
 
 
 # class-level attributes flowing between subclasses

--- a/python/ql/test/library-tests/dataflow/typetracking/attribute_tests.py
+++ b/python/ql/test/library-tests/dataflow/typetracking/attribute_tests.py
@@ -251,7 +251,7 @@ instance.set_instance_foo() # $ int=foo str=foo
 print(instance.foo) # $ int int=foo str str=foo
 
 
-# class-level attributes flowing between subclasses
+# attributes flowing between subclass and base class
 
 class BaseClass(object):
     def set_foo(self): # $ tracked=foo
@@ -260,6 +260,12 @@ class BaseClass(object):
     def use_foo(self): # $ tracked=foo
         print(self.foo) # $ tracked=foo tracked
 
+    def use_bar(self): # $ tracked=foo MISSING: tracked=bar
+        print(self.bar) # $ tracked=foo MISSING: tracked tracked=bar
+
 class SubClass(BaseClass): # $ MISSING: tracked=foo
-    def also_use_foo(self):
-        print(self.foo) # $ MISSING: tracked=foo tracked
+    def also_use_foo(self): # $ tracked=bar
+        print(self.foo) # $ tracked=bar MISSING: tracked=foo tracked
+
+    def set_bar(self): # $ tracked=bar
+        self.bar = tracked # $ tracked=bar tracked

--- a/python/ql/test/library-tests/dataflow/typetracking/attribute_tests.py
+++ b/python/ql/test/library-tests/dataflow/typetracking/attribute_tests.py
@@ -199,7 +199,7 @@ print(instance.foo) # $ MISSING: tracked=foo tracked
 
 # class-level attributes
 
-class MyClass5(object): # $ tracked=foo
+class MyClass5(object): # $ tracked=foo tracked=bar
     foo = tracked # $ tracked
     # bar is set from a classmethod
     bar = None
@@ -209,8 +209,8 @@ class MyClass5(object): # $ tracked=foo
         print(self.bar) # $ MISSING: tracked=bar tracked
 
     def on_classref(self):
-        print(MyClass5.foo) # $ tracked=foo tracked
-        print(MyClass5.bar) # $ tracked=foo MISSING: tracked=bar tracked
+        print(MyClass5.foo) # $ tracked=foo tracked tracked=bar
+        print(MyClass5.bar) # $ tracked=foo tracked=bar tracked
 
     @classmethod
     def on_cls(cls):
@@ -221,7 +221,7 @@ class MyClass5(object): # $ tracked=foo
     def set_bar(cls): # $ tracked=bar
         cls.bar = tracked # $ tracked=bar tracked
 
-instance = MyClass5() # $ tracked=foo
+instance = MyClass5() # $ tracked=foo tracked=bar
 print(instance.foo) # $ MISSING: tracked=foo tracked
 print(instance.bar) # $ MISSING: tracked=bar tracked
 


### PR DESCRIPTION
```py
class MyClass:
    def set_foo(self):
        self.foo = <value>

    def uses(self):
        print(self.foo)
```

This PR adds flow from `<value>` to the use in `print` for type-tracking. It also handles instances, and class-level attributes. (reviewing commit-by-commit is recommended)

### Implementation questions

The implementation so far uses `loadStoreStep` to add flow to the self/cls parameters of normal/classmethods on a class. As highlighted in the comment in the code, compared with a "simple" jump-step or levelStepNoCall, this allows any potential flow-summaries to still work.

(note: Ruby currently uses [levelStepNoCall](https://github.com/github/codeql/blob/60970ff015be6f409a9fe66cc6a962c842695305/ruby/ql/lib/codeql/ruby/typetracking/internal/TypeTrackingImpl.qll#L88-L93), which is where the inspiration for doing so came from).

However, there's a few things I'm not 100% sure of, so let me call those out:

1. whether there's an implicit assumption that `loadStoreStep` is not allowed to cross function borders (if so, we should add that as a consistency check). If that's the case, we _can_ implement this with `jumpStep`, but will sacrifice some functionality since we will need to target attribute-reads directly.
2. performance! Since this adds a step from all `n` writes to every `m` reads of an attribute, worst case is O(n * m) = O(n²) :disappointed: We should be able to overcome this by adding an intermediary node that represents class-instance that `self.foo = <value>` can target, resulting in O(n + m) steps :+1: I haven't done anything about this yet, since I wanted to get the basic functionality in first.
3. This PR does simple assumption that any `self.foo = <value>` will end up being available after the function has finished... but we could see code like `self.foo = <value1>; self.foo = <value2>`, where only `<value2>` would be available afterwards. I don't expect this will become a huge issue, so I propose we wait until we see this being a problem in real code.
4. Subclass flow is currently not handled. I think we need proper performance solved first, and also wanted to ensure we could get agreement on basic functionality become making implementation more complex.
5. Instance flow. This felt like the right thing to do, both so we would be able to handle examples like the one below, but also so instance and `self` reference within a method would behave in the same way.

    ```py
    custom_sql_conn.connect() # sets the 'cursor' attribute in this function
    custom_sql_conn.cursor.execute(...)
    ``` 




