### PR TITLE
C++: Extend barrier guards to handle phi inputs

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -1336,6 +1336,8 @@ predicate nodeIsHidden(Node n) {
   n instanceof FinalGlobalValue
   or
   n instanceof InitialGlobalValue
+  or
+  n instanceof SsaPhiInputNode
 }
 
 predicate neverSkipInPathGraph(Node n) {
@@ -1633,6 +1635,8 @@ private Instruction getAnInstruction(Node n) {
   result = n.asOperand().getUse()
   or
   result = n.(SsaPhiNode).getPhiNode().getBasicBlock().getFirstInstruction()
+  or
+  result = n.(SsaPhiInputNode).getBasicBlock().getFirstInstruction()
   or
   n.(IndirectInstruction).hasInstructionAndIndirectionIndex(result, _)
   or

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -1763,7 +1763,7 @@ module IteratorFlow {
         crementCall = def.getValue().asInstruction().(StoreInstruction).getSourceValue() and
         sv = def.getSourceVariable() and
         bb.getInstruction(i) = crementCall and
-        Ssa::ssaDefReachesRead(sv, result.asDef(), bb, i)
+        Ssa::ssaDefReachesReadExt(sv, result.asDef(), bb, i)
       )
     }
 
@@ -1797,7 +1797,7 @@ module IteratorFlow {
         isIteratorWrite(writeToDeref, address) and
         operandForFullyConvertedCall(address, starCall) and
         bbStar.getInstruction(iStar) = starCall and
-        Ssa::ssaDefReachesRead(_, def.asDef(), bbStar, iStar) and
+        Ssa::ssaDefReachesReadExt(_, def.asDef(), bbStar, iStar) and
         ultimate = getAnUltimateDefinition*(def) and
         beginStore = ultimate.getValue().asInstruction() and
         operandForFullyConvertedCall(beginStore.getSourceValueOperand(), beginCall)

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -2681,9 +2681,9 @@ class ContentSet instanceof Content {
 
 pragma[nomagic]
 private predicate guardControlsPhiInput(
-  IRGuardCondition g, boolean branch, Ssa::Definition def, IRBlock input, Ssa::PhiInputNodeExt phi
+  IRGuardCondition g, boolean branch, Ssa::Definition def, IRBlock input, Ssa::PhiNode phi
 ) {
-  phi.hasInputFromBlock(def, input) and
+  phi.hasInputFromBlock(def, _, _, _, input) and
   (
     g.controls(input, branch)
     or
@@ -2752,12 +2752,11 @@ module BarrierGuard<guardChecksSig/3 guardChecks> {
     )
     or
     exists(
-      IRGuardCondition g, boolean branch, Ssa::DefinitionExt def, IRBlock input,
-      Ssa::PhiInputNodeExt phi
+      IRGuardCondition g, boolean branch, Ssa::DefinitionExt def, IRBlock input, Ssa::PhiNode phi
     |
       guardChecks(g, def.getARead().asOperand().getDef().getConvertedResultExpression(), branch) and
       guardControlsPhiInput(g, branch, def, input, phi) and
-      result = TSsaPhiInputNode(phi.getPhi(), input)
+      result = TSsaPhiInputNode(phi, input)
     )
   }
 
@@ -2839,14 +2838,13 @@ module BarrierGuard<guardChecksSig/3 guardChecks> {
     )
     or
     exists(
-      IRGuardCondition g, boolean branch, Ssa::DefinitionExt def, IRBlock input,
-      Ssa::PhiInputNodeExt phi
+      IRGuardCondition g, boolean branch, Ssa::DefinitionExt def, IRBlock input, Ssa::PhiNode phi
     |
       guardChecks(g,
         def.getARead().asIndirectOperand(indirectionIndex).getDef().getConvertedResultExpression(),
         branch) and
       guardControlsPhiInput(g, branch, def, input, phi) and
-      result = TSsaPhiInputNode(phi.getPhi(), input)
+      result = TSsaPhiInputNode(phi, input)
     )
   }
 }
@@ -2881,12 +2879,11 @@ module InstructionBarrierGuard<instructionGuardChecksSig/3 instructionGuardCheck
     )
     or
     exists(
-      IRGuardCondition g, boolean branch, Ssa::DefinitionExt def, IRBlock input,
-      Ssa::PhiInputNodeExt phi
+      IRGuardCondition g, boolean branch, Ssa::DefinitionExt def, IRBlock input, Ssa::PhiNode phi
     |
       instructionGuardChecks(g, def.getARead().asOperand().getDef(), branch) and
       guardControlsPhiInput(g, branch, def, input, phi) and
-      result = TSsaPhiInputNode(phi.getPhi(), input)
+      result = TSsaPhiInputNode(phi, input)
     )
   }
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -2232,6 +2232,9 @@ private module Cached {
       // Def-use/Use-use flow
       Ssa::ssaFlow(nodeFrom, nodeTo)
       or
+      // Phi input -> Phi
+      nodeFrom.(SsaPhiInputNode).getPhiNode() = nodeTo.(SsaPhiNode).getPhiNode()
+      or
       IteratorFlow::localFlowStep(nodeFrom, nodeTo)
       or
       // Operand -> Instruction flow

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -635,7 +635,7 @@ class SsaPhiNode extends Node, TSsaPhiNode {
    */
   cached
   final Node getAnInput(boolean fromBackEdge) {
-    localFlowStep(result, this) and
+    result.(SsaPhiInputNode).getPhiNode() = phi and
     exists(IRBlock bPhi, IRBlock bResult |
       bPhi = phi.getBasicBlock() and bResult = result.getBasicBlock()
     |

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -626,7 +626,7 @@ class SsaPhiNode extends Node, TSsaPhiNode {
 
   final override Location getLocationImpl() { result = phi.getBasicBlock().getLocation() }
 
-  override string toStringImpl() { result = "Phi" }
+  override string toStringImpl() { result = phi.toString() }
 
   /**
    * Gets a node that is used as input to this phi node.

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -667,7 +667,7 @@ class SsaPhiNode extends Node, TSsaPhiNode {
 /**
  * INTERNAL: Do not use.
  *
- * A note that is used as an input to a phi node.
+ * A node that is used as an input to a phi node.
  *
  * This class exists to allow more powerful barrier guards. Consider this
  * example:
@@ -684,9 +684,9 @@ class SsaPhiNode extends Node, TSsaPhiNode {
  * At the phi node for `x` it is neither the case that `x` is dominated by
  * `safe(x)`, or is the case that the phi is dominated by a clearing of `x`.
  *
- * However, by inserting an "phi input" nodes as the last entry in the basic
- * block that defines the inputs to the phi we can conclude that each of those
- * inputs are safe to pass to `sink`.
+ * By inserting a "phi input" node as the last entry in the basic block that
+ * defines the inputs to the phi we can conclude that each of those inputs are
+ * safe to pass to `sink`.
  */
 class SsaPhiInputNode extends Node, TSsaPhiInputNode {
   Ssa::PhiNode phi;

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -1216,23 +1216,6 @@ class Phi extends TPhi, SsaDef {
 private module SsaImpl = SsaImplCommon::Make<Location, SsaInput>;
 
 /**
- * An static single assignment (SSA) definition that is used as an input to a
- * phi or phi-read node.
- */
-class PhiInputNodeExt extends SsaImpl::DefinitionExt {
-  PhiNode phi;
-
-  PhiInputNodeExt() { this = SsaCached::phiHasInputFromBlockExt(phi, _) }
-
-  /** Gets the phi or phi-read node that receives this node as input. */
-  PhiNode getPhi() { result = phi }
-
-  predicate hasInputFromBlock(DefinitionExt def, IRBlock input) {
-    SsaCached::lastRefRedefExt(def, _, _, _, input, this)
-  }
-}
-
-/**
  * An static single assignment (SSA) phi node.
  *
  * This is either a normal phi node or a phi-read node.

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -1031,8 +1031,8 @@ module SsaCached {
   }
 
   cached
-  Definition phiHasInputFromBlock(PhiNode phi, IRBlock bb) {
-    SsaImpl::phiHasInputFromBlock(phi, result, bb)
+  Definition phiHasInputFromBlockExt(PhiNode phi, IRBlock bb) {
+    SsaImpl::phiHasInputFromBlockExt(phi, result, bb)
   }
 
   cached
@@ -1189,11 +1189,11 @@ class Phi extends TPhi, SsaDef {
 
   final override Location getLocation() { result = phi.getBasicBlock().getLocation() }
 
-  override string toString() { result = "Phi" }
+  override string toString() { result = phi.toString() }
 
   SsaPhiNode getNode() { result.getPhiNode() = phi }
 
-  predicate hasInputFromBlock(Definition inp, IRBlock bb) { inp = phiHasInputFromBlock(phi, bb) }
+  predicate hasInputFromBlock(Definition inp, IRBlock bb) { inp = phiHasInputFromBlockExt(phi, bb) }
 
   final Definition getAnInput() { this.hasInputFromBlock(result, _) }
 }
@@ -1221,7 +1221,7 @@ class PhiNode extends SsaImpl::DefinitionExt {
 
   /** Holds if `inp` is an input to this phi node along the edge originating in `bb`. */
   predicate hasInputFromBlock(Definition inp, IRBlock bb) {
-    inp = SsaCached::phiHasInputFromBlock(this, bb)
+    inp = SsaCached::phiHasInputFromBlockExt(this, bb)
   }
 
   /** Gets a definition that is an input to this phi node. */

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -726,20 +726,11 @@ private predicate indirectConversionFlowStep(Node nFrom, Node nTo) {
     nodeToDefOrUse(nTo, sv, bb2, i2, _) and
     adjacentDefRead(bb2, i2, sv, _, _)
   ) and
-  (
-    exists(Operand op1, Operand op2, int indirectionIndex, Instruction instr |
-      hasOperandAndIndex(nFrom, op1, pragma[only_bind_into](indirectionIndex)) and
-      hasOperandAndIndex(nTo, op2, pragma[only_bind_into](indirectionIndex)) and
-      instr = op2.getDef() and
-      conversionFlow(op1, instr, _, _)
-    )
-    or
-    exists(Operand op1, Operand op2, int indirectionIndex, Instruction instr |
-      hasOperandAndIndex(nFrom, op1, pragma[only_bind_into](indirectionIndex)) and
-      hasOperandAndIndex(nTo, op2, indirectionIndex - 1) and
-      instr = op2.getDef() and
-      isDereference(instr, op1, _)
-    )
+  exists(Operand op1, Operand op2, int indirectionIndex, Instruction instr |
+    hasOperandAndIndex(nFrom, op1, pragma[only_bind_into](indirectionIndex)) and
+    hasOperandAndIndex(nTo, op2, pragma[only_bind_into](indirectionIndex)) and
+    instr = op2.getDef() and
+    conversionFlow(op1, instr, _, _)
   )
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -723,7 +723,7 @@ predicate nodeToDefOrUse(Node node, SourceVariable sv, IRBlock bb, int i, boolea
  */
 private predicate indirectConversionFlowStep(Node nFrom, Node nTo) {
   not exists(SourceVariable sv, IRBlock bb2, int i2 |
-    nodeToDefOrUse(nTo, sv, bb2, i2, _) and
+    useToNode(bb2, i2, sv, nTo) and
     adjacentDefRead(bb2, i2, sv, _, _)
   ) and
   exists(Operand op1, Operand op2, int indirectionIndex, Instruction instr |

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -1036,8 +1036,8 @@ module SsaCached {
   }
 
   cached
-  predicate ssaDefReachesRead(SourceVariable v, Definition def, IRBlock bb, int i) {
-    SsaImpl::ssaDefReachesRead(v, def, bb, i)
+  predicate ssaDefReachesReadExt(SourceVariable v, DefinitionExt def, IRBlock bb, int i) {
+    SsaImpl::ssaDefReachesReadExt(v, def, bb, i)
   }
 
   predicate variableRead = SsaInput::variableRead/4;

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -870,7 +870,6 @@ private predicate isArgumentOfCallable(DataFlowCall call, Node n) {
  * Holds if there is use-use flow from `pun`'s pre-update node to `n`.
  */
 private predicate postUpdateNodeToFirstUse(PostUpdateNode pun, Node n) {
-  // The reason for this predicate is a bit annoying:
   // We cannot mark a `PointerArithmeticInstruction` that computes an offset
   // based on some SSA
   // variable `x` as a use of `x` since this creates taint-flow in the

--- a/cpp/ql/src/Likely Bugs/Memory Management/AllocaInLoop.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/AllocaInLoop.ql
@@ -209,6 +209,7 @@ class LoopWithAlloca extends Stmt {
       DataFlow::localFlow(result, DataFlow::exprNode(va)) and
       // Phi nodes will be preceded by nodes that represent actual definitions
       not result instanceof DataFlow::SsaPhiNode and
+      not result instanceof DataFlow::SsaPhiInputNode and
       // A source is outside the loop if it's not inside the loop
       not exists(Expr e | e = getExpr(result) | this = getAnEnclosingLoopOfExpr(e))
     )

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/BarrierGuard.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/BarrierGuard.cpp
@@ -83,5 +83,46 @@ void test_guard_and_reassign() {
   if(!guarded(x)) {
     x = 0;
   }
+  sink(x); // $ SPURIOUS: ast,ir
+}
+
+void test_phi_read_guard(bool b) {
+  int x = source();
+
+  if(b) {
+    if(!guarded(x))
+      return;
+  }
+  else {
+    if(!guarded(x))
+      return;
+  }
+  
+  sink(x); // $ SPURIOUS: ast,ir
+}
+
+bool unsafe(int);
+
+void test_guard_and_reassign_2() {
+  int x = source();
+
+  if(unsafe(x)) {
+    x = 0;
+  }
+  sink(x); // $ SPURIOUS: ast
+}
+
+void test_phi_read_guard_2(bool b) {
+  int x = source();
+
+  if(b) {
+    if(unsafe(x))
+      return;
+  }
+  else {
+    if(unsafe(x))
+      return;
+  }
+  
   sink(x); // $ SPURIOUS: ast
 }

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/BarrierGuard.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/BarrierGuard.cpp
@@ -83,5 +83,5 @@ void test_guard_and_reassign() {
   if(!guarded(x)) {
     x = 0;
   }
-  sink(x); // $ SPURIOUS: ast,ir
+  sink(x); // $ SPURIOUS: ast
 }

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/BarrierGuard.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/BarrierGuard.cpp
@@ -76,3 +76,12 @@ void bg_indirect_expr() {
     sink(buf);
   }
 }
+
+void test_guard_and_reassign() {
+  int x = source();
+
+  if(!guarded(x)) {
+    x = 0;
+  }
+  sink(x); // $ SPURIOUS: ast,ir
+}

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/TestBase.qll
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/TestBase.qll
@@ -11,6 +11,10 @@ module AstTest {
     g.(FunctionCall).getTarget().getName() = "guarded" and
     checked = g.(FunctionCall).getArgument(0) and
     isTrue = true
+    or
+    g.(FunctionCall).getTarget().getName() = "unsafe" and
+    checked = g.(FunctionCall).getArgument(0) and
+    isTrue = false
   }
 
   /** Common data flow configuration to be used by tests. */
@@ -105,9 +109,13 @@ module IRTest {
   predicate testBarrierGuard(IRGuardCondition g, Expr checked, boolean isTrue) {
     exists(Call call |
       call = g.getUnconvertedResultExpression() and
+      checked = call.getArgument(0)
+    |
       call.getTarget().hasName("guarded") and
-      checked = call.getArgument(0) and
       isTrue = true
+      or
+      call.getTarget().hasName("unsafe") and
+      isTrue = false
     )
   }
 

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/localFlow-ir.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/localFlow-ir.expected
@@ -69,45 +69,61 @@
 | test.cpp:8:8:8:9 | t1 | test.cpp:9:8:9:9 | t1 |
 | test.cpp:9:8:9:9 | t1 | test.cpp:11:7:11:8 | t1 |
 | test.cpp:9:8:9:9 | t1 | test.cpp:11:7:11:8 | t1 |
+| test.cpp:10:8:10:9 | t2 | test.cpp:11:7:11:8 | Phi input |
+| test.cpp:10:8:10:9 | t2 | test.cpp:11:7:11:8 | Phi input |
 | test.cpp:10:8:10:9 | t2 | test.cpp:13:10:13:11 | t2 |
-| test.cpp:10:8:10:9 | t2 | test.cpp:15:3:15:6 | Phi |
-| test.cpp:10:8:10:9 | t2 | test.cpp:15:3:15:6 | Phi |
+| test.cpp:11:7:11:8 | Phi input | test.cpp:15:3:15:6 | SSA phi read(t2) |
+| test.cpp:11:7:11:8 | Phi input | test.cpp:15:3:15:6 | SSA phi(*t2) |
 | test.cpp:11:7:11:8 | t1 | test.cpp:21:8:21:9 | t1 |
 | test.cpp:12:5:12:10 | ... = ... | test.cpp:13:10:13:11 | t2 |
 | test.cpp:12:10:12:10 | 0 | test.cpp:12:5:12:10 | ... = ... |
-| test.cpp:13:10:13:11 | t2 | test.cpp:15:3:15:6 | Phi |
-| test.cpp:13:10:13:11 | t2 | test.cpp:15:3:15:6 | Phi |
-| test.cpp:15:3:15:6 | Phi | test.cpp:15:8:15:9 | t2 |
-| test.cpp:15:3:15:6 | Phi | test.cpp:15:8:15:9 | t2 |
-| test.cpp:15:8:15:9 | t2 | test.cpp:23:19:23:19 | Phi |
-| test.cpp:15:8:15:9 | t2 | test.cpp:23:19:23:19 | Phi |
+| test.cpp:13:5:13:8 | Phi input | test.cpp:15:3:15:6 | SSA phi read(t2) |
+| test.cpp:13:5:13:8 | Phi input | test.cpp:15:3:15:6 | SSA phi(*t2) |
+| test.cpp:13:10:13:11 | t2 | test.cpp:13:5:13:8 | Phi input |
+| test.cpp:13:10:13:11 | t2 | test.cpp:13:5:13:8 | Phi input |
+| test.cpp:15:3:15:6 | SSA phi read(t2) | test.cpp:15:8:15:9 | t2 |
+| test.cpp:15:3:15:6 | SSA phi(*t2) | test.cpp:15:8:15:9 | t2 |
+| test.cpp:15:8:15:9 | t2 | test.cpp:23:15:23:16 | Phi input |
+| test.cpp:15:8:15:9 | t2 | test.cpp:23:15:23:16 | Phi input |
 | test.cpp:17:3:17:8 | ... = ... | test.cpp:21:8:21:9 | t1 |
 | test.cpp:17:8:17:8 | 0 | test.cpp:17:3:17:8 | ... = ... |
-| test.cpp:21:8:21:9 | t1 | test.cpp:23:19:23:19 | Phi |
-| test.cpp:21:8:21:9 | t1 | test.cpp:23:19:23:19 | Phi |
+| test.cpp:21:8:21:9 | t1 | test.cpp:23:15:23:16 | Phi input |
+| test.cpp:21:8:21:9 | t1 | test.cpp:23:15:23:16 | Phi input |
 | test.cpp:23:15:23:16 | 0 | test.cpp:23:15:23:16 | 0 |
-| test.cpp:23:15:23:16 | 0 | test.cpp:23:19:23:19 | Phi |
-| test.cpp:23:19:23:19 | Phi | test.cpp:23:19:23:19 | i |
-| test.cpp:23:19:23:19 | Phi | test.cpp:23:19:23:19 | i |
-| test.cpp:23:19:23:19 | Phi | test.cpp:23:23:23:24 | t1 |
-| test.cpp:23:19:23:19 | Phi | test.cpp:23:23:23:24 | t1 |
-| test.cpp:23:19:23:19 | Phi | test.cpp:24:10:24:11 | t2 |
-| test.cpp:23:19:23:19 | Phi | test.cpp:24:10:24:11 | t2 |
+| test.cpp:23:15:23:16 | 0 | test.cpp:23:15:23:16 | Phi input |
+| test.cpp:23:15:23:16 | Phi input | test.cpp:23:19:23:19 | SSA phi read(*t2) |
+| test.cpp:23:15:23:16 | Phi input | test.cpp:23:19:23:19 | SSA phi read(i) |
+| test.cpp:23:15:23:16 | Phi input | test.cpp:23:19:23:19 | SSA phi read(t1) |
+| test.cpp:23:15:23:16 | Phi input | test.cpp:23:19:23:19 | SSA phi read(t2) |
+| test.cpp:23:15:23:16 | Phi input | test.cpp:23:19:23:19 | SSA phi(*i) |
+| test.cpp:23:15:23:16 | Phi input | test.cpp:23:19:23:19 | SSA phi(*t1) |
+| test.cpp:23:19:23:19 | SSA phi read(*t2) | test.cpp:24:10:24:11 | t2 |
+| test.cpp:23:19:23:19 | SSA phi read(i) | test.cpp:23:19:23:19 | i |
+| test.cpp:23:19:23:19 | SSA phi read(t1) | test.cpp:23:23:23:24 | t1 |
+| test.cpp:23:19:23:19 | SSA phi read(t2) | test.cpp:24:10:24:11 | t2 |
+| test.cpp:23:19:23:19 | SSA phi(*i) | test.cpp:23:19:23:19 | i |
+| test.cpp:23:19:23:19 | SSA phi(*t1) | test.cpp:23:23:23:24 | t1 |
 | test.cpp:23:19:23:19 | i | test.cpp:23:27:23:27 | i |
 | test.cpp:23:19:23:19 | i | test.cpp:23:27:23:27 | i |
-| test.cpp:23:23:23:24 | t1 | test.cpp:23:19:23:19 | Phi |
+| test.cpp:23:23:23:24 | t1 | test.cpp:23:27:23:29 | Phi input |
 | test.cpp:23:23:23:24 | t1 | test.cpp:26:8:26:9 | t1 |
 | test.cpp:23:23:23:24 | t1 | test.cpp:26:8:26:9 | t1 |
 | test.cpp:23:27:23:27 | *i | test.cpp:23:27:23:27 | *i |
 | test.cpp:23:27:23:27 | *i | test.cpp:23:27:23:27 | i |
-| test.cpp:23:27:23:27 | i | test.cpp:23:19:23:19 | Phi |
 | test.cpp:23:27:23:27 | i | test.cpp:23:27:23:27 | i |
 | test.cpp:23:27:23:27 | i | test.cpp:23:27:23:27 | i |
-| test.cpp:23:27:23:29 | ... ++ | test.cpp:23:19:23:19 | Phi |
+| test.cpp:23:27:23:27 | i | test.cpp:23:27:23:29 | Phi input |
 | test.cpp:23:27:23:29 | ... ++ | test.cpp:23:27:23:29 | ... ++ |
-| test.cpp:24:5:24:11 | ... = ... | test.cpp:23:19:23:19 | Phi |
-| test.cpp:24:10:24:11 | t2 | test.cpp:23:19:23:19 | Phi |
-| test.cpp:24:10:24:11 | t2 | test.cpp:23:19:23:19 | Phi |
+| test.cpp:23:27:23:29 | ... ++ | test.cpp:23:27:23:29 | Phi input |
+| test.cpp:23:27:23:29 | Phi input | test.cpp:23:19:23:19 | SSA phi read(*t2) |
+| test.cpp:23:27:23:29 | Phi input | test.cpp:23:19:23:19 | SSA phi read(i) |
+| test.cpp:23:27:23:29 | Phi input | test.cpp:23:19:23:19 | SSA phi read(t1) |
+| test.cpp:23:27:23:29 | Phi input | test.cpp:23:19:23:19 | SSA phi read(t2) |
+| test.cpp:23:27:23:29 | Phi input | test.cpp:23:19:23:19 | SSA phi(*i) |
+| test.cpp:23:27:23:29 | Phi input | test.cpp:23:19:23:19 | SSA phi(*t1) |
+| test.cpp:24:5:24:11 | ... = ... | test.cpp:23:27:23:29 | Phi input |
+| test.cpp:24:10:24:11 | t2 | test.cpp:23:27:23:29 | Phi input |
+| test.cpp:24:10:24:11 | t2 | test.cpp:23:27:23:29 | Phi input |
 | test.cpp:24:10:24:11 | t2 | test.cpp:24:5:24:11 | ... = ... |
 | test.cpp:382:48:382:54 | source1 | test.cpp:384:16:384:23 | *& ... |
 | test.cpp:383:12:383:13 | 0 | test.cpp:383:12:383:13 | 0 |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test-source-sink.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test-source-sink.expected
@@ -12,6 +12,7 @@ astFlow
 | BarrierGuard.cpp:60:11:60:16 | call to source | BarrierGuard.cpp:62:14:62:14 | x |
 | BarrierGuard.cpp:60:11:60:16 | call to source | BarrierGuard.cpp:64:14:64:14 | x |
 | BarrierGuard.cpp:60:11:60:16 | call to source | BarrierGuard.cpp:66:14:66:14 | x |
+| BarrierGuard.cpp:81:11:81:16 | call to source | BarrierGuard.cpp:86:8:86:8 | x |
 | acrossLinkTargets.cpp:19:27:19:32 | call to source | acrossLinkTargets.cpp:12:8:12:8 | x |
 | clang.cpp:12:9:12:20 | sourceArray1 | clang.cpp:18:8:18:19 | sourceArray1 |
 | clang.cpp:12:9:12:20 | sourceArray1 | clang.cpp:22:8:22:20 | & ... |
@@ -141,6 +142,7 @@ irFlow
 | BarrierGuard.cpp:49:10:49:15 | call to source | BarrierGuard.cpp:55:13:55:13 | x |
 | BarrierGuard.cpp:60:11:60:16 | call to source | BarrierGuard.cpp:64:14:64:14 | x |
 | BarrierGuard.cpp:60:11:60:16 | call to source | BarrierGuard.cpp:66:14:66:14 | x |
+| BarrierGuard.cpp:81:11:81:16 | call to source | BarrierGuard.cpp:86:8:86:8 | x |
 | acrossLinkTargets.cpp:19:27:19:32 | call to source | acrossLinkTargets.cpp:12:8:12:8 | x |
 | clang.cpp:12:9:12:20 | sourceArray1 | clang.cpp:18:8:18:19 | sourceArray1 |
 | clang.cpp:12:9:12:20 | sourceArray1 | clang.cpp:23:17:23:29 | *& ... |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test-source-sink.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test-source-sink.expected
@@ -13,6 +13,9 @@ astFlow
 | BarrierGuard.cpp:60:11:60:16 | call to source | BarrierGuard.cpp:64:14:64:14 | x |
 | BarrierGuard.cpp:60:11:60:16 | call to source | BarrierGuard.cpp:66:14:66:14 | x |
 | BarrierGuard.cpp:81:11:81:16 | call to source | BarrierGuard.cpp:86:8:86:8 | x |
+| BarrierGuard.cpp:90:11:90:16 | call to source | BarrierGuard.cpp:101:8:101:8 | x |
+| BarrierGuard.cpp:107:11:107:16 | call to source | BarrierGuard.cpp:112:8:112:8 | x |
+| BarrierGuard.cpp:116:11:116:16 | call to source | BarrierGuard.cpp:127:8:127:8 | x |
 | acrossLinkTargets.cpp:19:27:19:32 | call to source | acrossLinkTargets.cpp:12:8:12:8 | x |
 | clang.cpp:12:9:12:20 | sourceArray1 | clang.cpp:18:8:18:19 | sourceArray1 |
 | clang.cpp:12:9:12:20 | sourceArray1 | clang.cpp:22:8:22:20 | & ... |
@@ -142,6 +145,8 @@ irFlow
 | BarrierGuard.cpp:49:10:49:15 | call to source | BarrierGuard.cpp:55:13:55:13 | x |
 | BarrierGuard.cpp:60:11:60:16 | call to source | BarrierGuard.cpp:64:14:64:14 | x |
 | BarrierGuard.cpp:60:11:60:16 | call to source | BarrierGuard.cpp:66:14:66:14 | x |
+| BarrierGuard.cpp:81:11:81:16 | call to source | BarrierGuard.cpp:86:8:86:8 | x |
+| BarrierGuard.cpp:90:11:90:16 | call to source | BarrierGuard.cpp:101:8:101:8 | x |
 | acrossLinkTargets.cpp:19:27:19:32 | call to source | acrossLinkTargets.cpp:12:8:12:8 | x |
 | clang.cpp:12:9:12:20 | sourceArray1 | clang.cpp:18:8:18:19 | sourceArray1 |
 | clang.cpp:12:9:12:20 | sourceArray1 | clang.cpp:23:17:23:29 | *& ... |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test-source-sink.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test-source-sink.expected
@@ -142,7 +142,6 @@ irFlow
 | BarrierGuard.cpp:49:10:49:15 | call to source | BarrierGuard.cpp:55:13:55:13 | x |
 | BarrierGuard.cpp:60:11:60:16 | call to source | BarrierGuard.cpp:64:14:64:14 | x |
 | BarrierGuard.cpp:60:11:60:16 | call to source | BarrierGuard.cpp:66:14:66:14 | x |
-| BarrierGuard.cpp:81:11:81:16 | call to source | BarrierGuard.cpp:86:8:86:8 | x |
 | acrossLinkTargets.cpp:19:27:19:32 | call to source | acrossLinkTargets.cpp:12:8:12:8 | x |
 | clang.cpp:12:9:12:20 | sourceArray1 | clang.cpp:18:8:18:19 | sourceArray1 |
 | clang.cpp:12:9:12:20 | sourceArray1 | clang.cpp:23:17:23:29 | *& ... |

--- a/cpp/ql/test/library-tests/dataflow/fields/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/dataflow-consistency.expected
@@ -184,6 +184,7 @@ postWithInFlow
 | simple.cpp:65:7:65:7 | i [post update] | PostUpdateNode should not be the target of local flow. |
 | simple.cpp:83:12:83:13 | f1 [post update] | PostUpdateNode should not be the target of local flow. |
 | simple.cpp:92:7:92:7 | i [post update] | PostUpdateNode should not be the target of local flow. |
+| simple.cpp:118:7:118:7 | i [post update] | PostUpdateNode should not be the target of local flow. |
 | struct_init.c:24:11:24:12 | ab [inner post update] | PostUpdateNode should not be the target of local flow. |
 | struct_init.c:36:17:36:24 | nestedAB [inner post update] | PostUpdateNode should not be the target of local flow. |
 viableImplInCallContextTooLarge

--- a/cpp/ql/test/library-tests/dataflow/fields/ir-path-flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/ir-path-flow.expected
@@ -842,6 +842,10 @@ edges
 | simple.cpp:108:17:108:26 | call to user_input | simple.cpp:108:17:108:26 | call to user_input | provenance |  |
 | simple.cpp:108:17:108:26 | call to user_input | simple.cpp:109:43:109:43 | x | provenance |  |
 | simple.cpp:109:43:109:43 | x | simple.cpp:103:24:103:24 | x | provenance |  |
+| simple.cpp:118:5:118:5 | *a [post update] [i] | simple.cpp:120:8:120:8 | *a [i] | provenance |  |
+| simple.cpp:118:5:118:22 | ... = ... | simple.cpp:118:5:118:5 | *a [post update] [i] | provenance |  |
+| simple.cpp:118:11:118:20 | call to user_input | simple.cpp:118:5:118:22 | ... = ... | provenance |  |
+| simple.cpp:120:8:120:8 | *a [i] | simple.cpp:120:10:120:10 | i | provenance |  |
 | struct_init.c:14:24:14:25 | *ab [a] | struct_init.c:14:24:14:25 | *ab [a] | provenance |  |
 | struct_init.c:14:24:14:25 | *ab [a] | struct_init.c:15:8:15:9 | *ab [a] | provenance |  |
 | struct_init.c:15:8:15:9 | *ab [a] | struct_init.c:15:12:15:12 | a | provenance |  |
@@ -1747,6 +1751,11 @@ nodes
 | simple.cpp:108:17:108:26 | call to user_input | semmle.label | call to user_input |
 | simple.cpp:108:17:108:26 | call to user_input | semmle.label | call to user_input |
 | simple.cpp:109:43:109:43 | x | semmle.label | x |
+| simple.cpp:118:5:118:5 | *a [post update] [i] | semmle.label | *a [post update] [i] |
+| simple.cpp:118:5:118:22 | ... = ... | semmle.label | ... = ... |
+| simple.cpp:118:11:118:20 | call to user_input | semmle.label | call to user_input |
+| simple.cpp:120:8:120:8 | *a [i] | semmle.label | *a [i] |
+| simple.cpp:120:10:120:10 | i | semmle.label | i |
 | struct_init.c:14:24:14:25 | *ab [a] | semmle.label | *ab [a] |
 | struct_init.c:14:24:14:25 | *ab [a] | semmle.label | *ab [a] |
 | struct_init.c:15:8:15:9 | *ab [a] | semmle.label | *ab [a] |
@@ -1957,6 +1966,7 @@ subpaths
 | simple.cpp:84:14:84:20 | call to getf2f1 | simple.cpp:83:17:83:26 | call to user_input | simple.cpp:84:14:84:20 | call to getf2f1 | call to getf2f1 flows from $@ | simple.cpp:83:17:83:26 | call to user_input | call to user_input |
 | simple.cpp:94:13:94:13 | i | simple.cpp:92:11:92:20 | call to user_input | simple.cpp:94:13:94:13 | i | i flows from $@ | simple.cpp:92:11:92:20 | call to user_input | call to user_input |
 | simple.cpp:104:14:104:14 | x | simple.cpp:108:17:108:26 | call to user_input | simple.cpp:104:14:104:14 | x | x flows from $@ | simple.cpp:108:17:108:26 | call to user_input | call to user_input |
+| simple.cpp:120:10:120:10 | i | simple.cpp:118:11:118:20 | call to user_input | simple.cpp:120:10:120:10 | i | i flows from $@ | simple.cpp:118:11:118:20 | call to user_input | call to user_input |
 | struct_init.c:15:12:15:12 | a | struct_init.c:20:20:20:29 | call to user_input | struct_init.c:15:12:15:12 | a | a flows from $@ | struct_init.c:20:20:20:29 | call to user_input | call to user_input |
 | struct_init.c:15:12:15:12 | a | struct_init.c:27:7:27:16 | call to user_input | struct_init.c:15:12:15:12 | a | a flows from $@ | struct_init.c:27:7:27:16 | call to user_input | call to user_input |
 | struct_init.c:15:12:15:12 | a | struct_init.c:40:20:40:29 | call to user_input | struct_init.c:15:12:15:12 | a | a flows from $@ | struct_init.c:40:20:40:29 | call to user_input | call to user_input |

--- a/cpp/ql/test/library-tests/dataflow/fields/partial-definition-diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/partial-definition-diff.expected
@@ -289,3 +289,5 @@ WARNING: Module DataFlow has been deprecated and may be removed in future (parti
 | simple.cpp:83:12:83:13 | f1 | AST only |
 | simple.cpp:92:7:92:7 | i | AST only |
 | simple.cpp:94:10:94:11 | a2 | IR only |
+| simple.cpp:118:7:118:7 | i | AST only |
+| simple.cpp:120:8:120:8 | a | IR only |

--- a/cpp/ql/test/library-tests/dataflow/fields/partial-definition-ir.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/partial-definition-ir.expected
@@ -649,6 +649,8 @@
 | simple.cpp:84:14:84:20 | this |
 | simple.cpp:92:5:92:5 | a |
 | simple.cpp:94:10:94:11 | a2 |
+| simple.cpp:118:5:118:5 | a |
+| simple.cpp:120:8:120:8 | a |
 | struct_init.c:15:8:15:9 | ab |
 | struct_init.c:15:12:15:12 | a |
 | struct_init.c:16:8:16:9 | ab |

--- a/cpp/ql/test/library-tests/dataflow/fields/partial-definition.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/partial-definition.expected
@@ -579,6 +579,8 @@ WARNING: Module DataFlow has been deprecated and may be removed in future (parti
 | simple.cpp:84:14:84:20 | this |
 | simple.cpp:92:5:92:5 | a |
 | simple.cpp:92:7:92:7 | i |
+| simple.cpp:118:5:118:5 | a |
+| simple.cpp:118:7:118:7 | i |
 | struct_init.c:15:8:15:9 | ab |
 | struct_init.c:15:12:15:12 | a |
 | struct_init.c:16:8:16:9 | ab |

--- a/cpp/ql/test/library-tests/dataflow/fields/path-flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/path-flow.expected
@@ -731,6 +731,10 @@ edges
 | simple.cpp:92:5:92:22 | ... = ... | simple.cpp:92:5:92:5 | a [post update] [i] | provenance |  |
 | simple.cpp:92:11:92:20 | call to user_input | simple.cpp:92:5:92:22 | ... = ... | provenance |  |
 | simple.cpp:94:10:94:11 | a2 [i] | simple.cpp:94:13:94:13 | i | provenance |  |
+| simple.cpp:118:5:118:5 | a [post update] [i] | simple.cpp:120:8:120:8 | a [i] | provenance |  |
+| simple.cpp:118:5:118:22 | ... = ... | simple.cpp:118:5:118:5 | a [post update] [i] | provenance |  |
+| simple.cpp:118:11:118:20 | call to user_input | simple.cpp:118:5:118:22 | ... = ... | provenance |  |
+| simple.cpp:120:8:120:8 | a [i] | simple.cpp:120:10:120:10 | i | provenance |  |
 | struct_init.c:14:24:14:25 | ab [a] | struct_init.c:14:24:14:25 | ab [a] | provenance |  |
 | struct_init.c:14:24:14:25 | ab [a] | struct_init.c:15:8:15:9 | ab [a] | provenance |  |
 | struct_init.c:15:8:15:9 | ab [a] | struct_init.c:15:12:15:12 | a | provenance |  |
@@ -1538,6 +1542,11 @@ nodes
 | simple.cpp:92:11:92:20 | call to user_input | semmle.label | call to user_input |
 | simple.cpp:94:10:94:11 | a2 [i] | semmle.label | a2 [i] |
 | simple.cpp:94:13:94:13 | i | semmle.label | i |
+| simple.cpp:118:5:118:5 | a [post update] [i] | semmle.label | a [post update] [i] |
+| simple.cpp:118:5:118:22 | ... = ... | semmle.label | ... = ... |
+| simple.cpp:118:11:118:20 | call to user_input | semmle.label | call to user_input |
+| simple.cpp:120:8:120:8 | a [i] | semmle.label | a [i] |
+| simple.cpp:120:10:120:10 | i | semmle.label | i |
 | struct_init.c:14:24:14:25 | ab [a] | semmle.label | ab [a] |
 | struct_init.c:14:24:14:25 | ab [a] | semmle.label | ab [a] |
 | struct_init.c:15:8:15:9 | ab [a] | semmle.label | ab [a] |
@@ -1751,6 +1760,7 @@ subpaths
 | simple.cpp:67:13:67:13 | i | simple.cpp:65:11:65:20 | call to user_input | simple.cpp:67:13:67:13 | i | i flows from $@ | simple.cpp:65:11:65:20 | call to user_input | call to user_input |
 | simple.cpp:84:14:84:20 | call to getf2f1 | simple.cpp:83:17:83:26 | call to user_input | simple.cpp:84:14:84:20 | call to getf2f1 | call to getf2f1 flows from $@ | simple.cpp:83:17:83:26 | call to user_input | call to user_input |
 | simple.cpp:94:13:94:13 | i | simple.cpp:92:11:92:20 | call to user_input | simple.cpp:94:13:94:13 | i | i flows from $@ | simple.cpp:92:11:92:20 | call to user_input | call to user_input |
+| simple.cpp:120:10:120:10 | i | simple.cpp:118:11:118:20 | call to user_input | simple.cpp:120:10:120:10 | i | i flows from $@ | simple.cpp:118:11:118:20 | call to user_input | call to user_input |
 | struct_init.c:15:12:15:12 | a | struct_init.c:20:20:20:29 | call to user_input | struct_init.c:15:12:15:12 | a | a flows from $@ | struct_init.c:20:20:20:29 | call to user_input | call to user_input |
 | struct_init.c:15:12:15:12 | a | struct_init.c:27:7:27:16 | call to user_input | struct_init.c:15:12:15:12 | a | a flows from $@ | struct_init.c:27:7:27:16 | call to user_input | call to user_input |
 | struct_init.c:15:12:15:12 | a | struct_init.c:40:20:40:29 | call to user_input | struct_init.c:15:12:15:12 | a | a flows from $@ | struct_init.c:40:20:40:29 | call to user_input | call to user_input |

--- a/cpp/ql/test/library-tests/dataflow/fields/simple.cpp
+++ b/cpp/ql/test/library-tests/dataflow/fields/simple.cpp
@@ -111,4 +111,13 @@ namespace TestAdditionalCallTargets {
 
 }
 
+void post_update_to_phi_input(bool b)
+{
+  A a;
+  if(b) {
+    a.i = user_input();
+  }
+  sink(a.i); // $ ast,ir
+}
+
 } // namespace Simple


### PR DESCRIPTION
This is the C/C++ version of https://github.com/github/codeql/pull/15985. The strategy is completely identical to the Ruby version: create a new dataflow node branch for phi inputs, and modify dataflow so that we do `def -> phi input -> phi` instead of `def -> phi`. We then extend the barrier guard implementation so that it can put barriers on these new phi input nodes.

I've also done some cleanup along the way.

Commit-by-commit review recommended.