### PR TITLE
Java integration tests: accept new output

### DIFF
--- a/java/ql/integration-tests/all-platforms/java/android-sample-kotlin-build-script-no-wrapper/test.expected
+++ b/java/ql/integration-tests/all-platforms/java/android-sample-kotlin-build-script-no-wrapper/test.expected
@@ -1,3 +1,6 @@
+#select
+| project/build/generated/source/buildConfig/release/com/github/androidsample/BuildConfig.java:0:0:0:0 | BuildConfig |
+| project/src/main/java/com/github/androidsample/Main.java:0:0:0:0 | Main |
 xmlFiles
 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/module.xml:0:0:0:0 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/module.xml |
 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/release-mainArtifact-dependencies.xml:0:0:0:0 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/release-mainArtifact-dependencies.xml |
@@ -15,6 +18,3 @@ xmlFiles
 | project/build/intermediates/merged_manifests/release/AndroidManifest.xml:0:0:0:0 | project/build/intermediates/merged_manifests/release/AndroidManifest.xml |
 | project/build/intermediates/packaged_manifests/release/AndroidManifest.xml:0:0:0:0 | project/build/intermediates/packaged_manifests/release/AndroidManifest.xml |
 | project/src/main/AndroidManifest.xml:0:0:0:0 | project/src/main/AndroidManifest.xml |
-#select
-| project/build/generated/source/buildConfig/release/com/github/androidsample/BuildConfig.java:0:0:0:0 | BuildConfig |
-| project/src/main/java/com/github/androidsample/Main.java:0:0:0:0 | Main |

--- a/java/ql/integration-tests/all-platforms/java/android-sample-kotlin-build-script/test.expected
+++ b/java/ql/integration-tests/all-platforms/java/android-sample-kotlin-build-script/test.expected
@@ -1,3 +1,6 @@
+#select
+| project/build/generated/source/buildConfig/release/com/github/androidsample/BuildConfig.java:0:0:0:0 | BuildConfig |
+| project/src/main/java/com/github/androidsample/Main.java:0:0:0:0 | Main |
 xmlFiles
 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/module.xml:0:0:0:0 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/module.xml |
 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/release-mainArtifact-dependencies.xml:0:0:0:0 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/release-mainArtifact-dependencies.xml |
@@ -15,6 +18,3 @@ xmlFiles
 | project/build/intermediates/merged_manifests/release/AndroidManifest.xml:0:0:0:0 | project/build/intermediates/merged_manifests/release/AndroidManifest.xml |
 | project/build/intermediates/packaged_manifests/release/AndroidManifest.xml:0:0:0:0 | project/build/intermediates/packaged_manifests/release/AndroidManifest.xml |
 | project/src/main/AndroidManifest.xml:0:0:0:0 | project/src/main/AndroidManifest.xml |
-#select
-| project/build/generated/source/buildConfig/release/com/github/androidsample/BuildConfig.java:0:0:0:0 | BuildConfig |
-| project/src/main/java/com/github/androidsample/Main.java:0:0:0:0 | Main |

--- a/java/ql/integration-tests/all-platforms/java/android-sample-no-wrapper/test.expected
+++ b/java/ql/integration-tests/all-platforms/java/android-sample-no-wrapper/test.expected
@@ -1,3 +1,6 @@
+#select
+| project/build/generated/source/buildConfig/release/com/github/androidsample/BuildConfig.java:0:0:0:0 | BuildConfig |
+| project/src/main/java/com/github/androidsample/Main.java:0:0:0:0 | Main |
 xmlFiles
 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/module.xml:0:0:0:0 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/module.xml |
 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/release-mainArtifact-dependencies.xml:0:0:0:0 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/release-mainArtifact-dependencies.xml |
@@ -15,6 +18,3 @@ xmlFiles
 | project/build/intermediates/merged_manifests/release/AndroidManifest.xml:0:0:0:0 | project/build/intermediates/merged_manifests/release/AndroidManifest.xml |
 | project/build/intermediates/packaged_manifests/release/AndroidManifest.xml:0:0:0:0 | project/build/intermediates/packaged_manifests/release/AndroidManifest.xml |
 | project/src/main/AndroidManifest.xml:0:0:0:0 | project/src/main/AndroidManifest.xml |
-#select
-| project/build/generated/source/buildConfig/release/com/github/androidsample/BuildConfig.java:0:0:0:0 | BuildConfig |
-| project/src/main/java/com/github/androidsample/Main.java:0:0:0:0 | Main |

--- a/java/ql/integration-tests/all-platforms/java/android-sample-old-style-kotlin-build-script-no-wrapper/test.expected
+++ b/java/ql/integration-tests/all-platforms/java/android-sample-old-style-kotlin-build-script-no-wrapper/test.expected
@@ -1,3 +1,6 @@
+#select
+| project/build/generated/source/buildConfig/release/com/github/androidsample/BuildConfig.java:0:0:0:0 | BuildConfig |
+| project/src/main/java/com/github/androidsample/Main.java:0:0:0:0 | Main |
 xmlFiles
 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/module.xml:0:0:0:0 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/module.xml |
 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/release-mainArtifact-dependencies.xml:0:0:0:0 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/release-mainArtifact-dependencies.xml |
@@ -18,6 +21,3 @@ xmlFiles
 | project/build/intermediates/merged_manifests/release/AndroidManifest.xml:0:0:0:0 | project/build/intermediates/merged_manifests/release/AndroidManifest.xml |
 | project/build/intermediates/packaged_manifests/release/AndroidManifest.xml:0:0:0:0 | project/build/intermediates/packaged_manifests/release/AndroidManifest.xml |
 | project/src/main/AndroidManifest.xml:0:0:0:0 | project/src/main/AndroidManifest.xml |
-#select
-| project/build/generated/source/buildConfig/release/com/github/androidsample/BuildConfig.java:0:0:0:0 | BuildConfig |
-| project/src/main/java/com/github/androidsample/Main.java:0:0:0:0 | Main |

--- a/java/ql/integration-tests/all-platforms/java/android-sample-old-style-kotlin-build-script/test.expected
+++ b/java/ql/integration-tests/all-platforms/java/android-sample-old-style-kotlin-build-script/test.expected
@@ -1,3 +1,6 @@
+#select
+| project/build/generated/source/buildConfig/release/com/github/androidsample/BuildConfig.java:0:0:0:0 | BuildConfig |
+| project/src/main/java/com/github/androidsample/Main.java:0:0:0:0 | Main |
 xmlFiles
 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/module.xml:0:0:0:0 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/module.xml |
 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/release-mainArtifact-dependencies.xml:0:0:0:0 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/release-mainArtifact-dependencies.xml |
@@ -18,6 +21,3 @@ xmlFiles
 | project/build/intermediates/merged_manifests/release/AndroidManifest.xml:0:0:0:0 | project/build/intermediates/merged_manifests/release/AndroidManifest.xml |
 | project/build/intermediates/packaged_manifests/release/AndroidManifest.xml:0:0:0:0 | project/build/intermediates/packaged_manifests/release/AndroidManifest.xml |
 | project/src/main/AndroidManifest.xml:0:0:0:0 | project/src/main/AndroidManifest.xml |
-#select
-| project/build/generated/source/buildConfig/release/com/github/androidsample/BuildConfig.java:0:0:0:0 | BuildConfig |
-| project/src/main/java/com/github/androidsample/Main.java:0:0:0:0 | Main |

--- a/java/ql/integration-tests/all-platforms/java/android-sample-old-style-no-wrapper/test.expected
+++ b/java/ql/integration-tests/all-platforms/java/android-sample-old-style-no-wrapper/test.expected
@@ -1,3 +1,6 @@
+#select
+| project/build/generated/source/buildConfig/release/com/github/androidsample/BuildConfig.java:0:0:0:0 | BuildConfig |
+| project/src/main/java/com/github/androidsample/Main.java:0:0:0:0 | Main |
 xmlFiles
 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/module.xml:0:0:0:0 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/module.xml |
 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/release-mainArtifact-dependencies.xml:0:0:0:0 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/release-mainArtifact-dependencies.xml |
@@ -18,6 +21,3 @@ xmlFiles
 | project/build/intermediates/merged_manifests/release/AndroidManifest.xml:0:0:0:0 | project/build/intermediates/merged_manifests/release/AndroidManifest.xml |
 | project/build/intermediates/packaged_manifests/release/AndroidManifest.xml:0:0:0:0 | project/build/intermediates/packaged_manifests/release/AndroidManifest.xml |
 | project/src/main/AndroidManifest.xml:0:0:0:0 | project/src/main/AndroidManifest.xml |
-#select
-| project/build/generated/source/buildConfig/release/com/github/androidsample/BuildConfig.java:0:0:0:0 | BuildConfig |
-| project/src/main/java/com/github/androidsample/Main.java:0:0:0:0 | Main |

--- a/java/ql/integration-tests/all-platforms/java/android-sample-old-style/test.expected
+++ b/java/ql/integration-tests/all-platforms/java/android-sample-old-style/test.expected
@@ -1,3 +1,6 @@
+#select
+| project/build/generated/source/buildConfig/release/com/github/androidsample/BuildConfig.java:0:0:0:0 | BuildConfig |
+| project/src/main/java/com/github/androidsample/Main.java:0:0:0:0 | Main |
 xmlFiles
 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/module.xml:0:0:0:0 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/module.xml |
 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/release-mainArtifact-dependencies.xml:0:0:0:0 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/release-mainArtifact-dependencies.xml |
@@ -18,6 +21,3 @@ xmlFiles
 | project/build/intermediates/merged_manifests/release/AndroidManifest.xml:0:0:0:0 | project/build/intermediates/merged_manifests/release/AndroidManifest.xml |
 | project/build/intermediates/packaged_manifests/release/AndroidManifest.xml:0:0:0:0 | project/build/intermediates/packaged_manifests/release/AndroidManifest.xml |
 | project/src/main/AndroidManifest.xml:0:0:0:0 | project/src/main/AndroidManifest.xml |
-#select
-| project/build/generated/source/buildConfig/release/com/github/androidsample/BuildConfig.java:0:0:0:0 | BuildConfig |
-| project/src/main/java/com/github/androidsample/Main.java:0:0:0:0 | Main |

--- a/java/ql/integration-tests/all-platforms/java/android-sample/test.expected
+++ b/java/ql/integration-tests/all-platforms/java/android-sample/test.expected
@@ -1,3 +1,6 @@
+#select
+| project/build/generated/source/buildConfig/release/com/github/androidsample/BuildConfig.java:0:0:0:0 | BuildConfig |
+| project/src/main/java/com/github/androidsample/Main.java:0:0:0:0 | Main |
 xmlFiles
 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/module.xml:0:0:0:0 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/module.xml |
 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/release-mainArtifact-dependencies.xml:0:0:0:0 | project/build/intermediates/incremental/lintVitalAnalyzeRelease/release-mainArtifact-dependencies.xml |
@@ -15,6 +18,3 @@ xmlFiles
 | project/build/intermediates/merged_manifests/release/AndroidManifest.xml:0:0:0:0 | project/build/intermediates/merged_manifests/release/AndroidManifest.xml |
 | project/build/intermediates/packaged_manifests/release/AndroidManifest.xml:0:0:0:0 | project/build/intermediates/packaged_manifests/release/AndroidManifest.xml |
 | project/src/main/AndroidManifest.xml:0:0:0:0 | project/src/main/AndroidManifest.xml |
-#select
-| project/build/generated/source/buildConfig/release/com/github/androidsample/BuildConfig.java:0:0:0:0 | BuildConfig |
-| project/src/main/java/com/github/androidsample/Main.java:0:0:0:0 | Main |

--- a/java/ql/integration-tests/all-platforms/java/ant-sample/test.expected
+++ b/java/ql/integration-tests/all-platforms/java/ant-sample/test.expected
@@ -1,4 +1,4 @@
-xmlFiles
-| build.xml:0:0:0:0 | build.xml |
 #select
 | src/main/java/com/example/App.java:0:0:0:0 | App |
+xmlFiles
+| build.xml:0:0:0:0 | build.xml |

--- a/java/ql/integration-tests/all-platforms/java/buildless-gradle-timeout/test.expected
+++ b/java/ql/integration-tests/all-platforms/java/buildless-gradle-timeout/test.expected
@@ -1,5 +1,5 @@
-xmlFiles
-| gradle/verification-metadata.xml:0:0:0:0 | gradle/verification-metadata.xml |
 #select
 | src/main/java/com/example/App.java:0:0:0:0 | App |
 | src/test/java/com/example/AppTest.java:0:0:0:0 | AppTest |
+xmlFiles
+| gradle/verification-metadata.xml:0:0:0:0 | gradle/verification-metadata.xml |

--- a/java/ql/integration-tests/all-platforms/java/gradle-sample-kotlin-script/test.expected
+++ b/java/ql/integration-tests/all-platforms/java/gradle-sample-kotlin-script/test.expected
@@ -1,4 +1,4 @@
-xmlFiles
 #select
 | app/src/main/java/test/App.java:0:0:0:0 | App |
 | app/src/test/java/test/AppTest.java:0:0:0:0 | AppTest |
+xmlFiles

--- a/java/ql/integration-tests/all-platforms/java/gradle-sample/test.expected
+++ b/java/ql/integration-tests/all-platforms/java/gradle-sample/test.expected
@@ -1,5 +1,5 @@
-xmlFiles
-| gradle/verification-metadata.xml:0:0:0:0 | gradle/verification-metadata.xml |
 #select
 | src/main/java/com/example/App.java:0:0:0:0 | App |
 | src/test/java/com/example/AppTest.java:0:0:0:0 | AppTest |
+xmlFiles
+| gradle/verification-metadata.xml:0:0:0:0 | gradle/verification-metadata.xml |

--- a/java/ql/integration-tests/all-platforms/java/java-web-jsp/test.expected
+++ b/java/ql/integration-tests/all-platforms/java/java-web-jsp/test.expected
@@ -1,15 +1,3 @@
-xmlFiles
-| pom.xml:0:0:0:0 | pom.xml |
-| spotbugs-security-exclude.xml:0:0:0:0 | spotbugs-security-exclude.xml |
-| spotbugs-security-include.xml:0:0:0:0 | spotbugs-security-include.xml |
-| src/main/webapp/WEB-INF/applicationContext.xml:0:0:0:0 | src/main/webapp/WEB-INF/applicationContext.xml |
-| src/main/webapp/WEB-INF/web.xml:0:0:0:0 | src/main/webapp/WEB-INF/web.xml |
-| src/main/webapp/WEB-INF/weblogic.xml:0:0:0:0 | src/main/webapp/WEB-INF/weblogic.xml |
-| target/vulnerable-jsp-app-1.0.0-SNAPSHOT/WEB-INF/applicationContext.xml:0:0:0:0 | target/vulnerable-jsp-app-1.0.0-SNAPSHOT/WEB-INF/applicationContext.xml |
-| target/vulnerable-jsp-app-1.0.0-SNAPSHOT/WEB-INF/web.xml:0:0:0:0 | target/vulnerable-jsp-app-1.0.0-SNAPSHOT/WEB-INF/web.xml |
-| target/vulnerable-jsp-app-1.0.0-SNAPSHOT/WEB-INF/weblogic.xml:0:0:0:0 | target/vulnerable-jsp-app-1.0.0-SNAPSHOT/WEB-INF/weblogic.xml |
-| target/web.xml:0:0:0:0 | target/web.xml |
-| target/webfrag.xml:0:0:0:0 | target/webfrag.xml |
 #select
 | src/main/java/com/acme/Counter.java:0:0:0:0 | Counter |
 | src/main/java/com/acme/Date2Tag.java:0:0:0:0 | Date2Tag |
@@ -56,3 +44,15 @@ xmlFiles
 | target/classes/jsp/xss/xss4_jsp.java:0:0:0:0 | xss4_jsp |
 | target/classes/jsp/xss/xss5_jsp.java:0:0:0:0 | xss5_jsp |
 | target/classes/org/apache/jsp/tag/web/panel_tag.java:0:0:0:0 | panel_tag |
+xmlFiles
+| pom.xml:0:0:0:0 | pom.xml |
+| spotbugs-security-exclude.xml:0:0:0:0 | spotbugs-security-exclude.xml |
+| spotbugs-security-include.xml:0:0:0:0 | spotbugs-security-include.xml |
+| src/main/webapp/WEB-INF/applicationContext.xml:0:0:0:0 | src/main/webapp/WEB-INF/applicationContext.xml |
+| src/main/webapp/WEB-INF/web.xml:0:0:0:0 | src/main/webapp/WEB-INF/web.xml |
+| src/main/webapp/WEB-INF/weblogic.xml:0:0:0:0 | src/main/webapp/WEB-INF/weblogic.xml |
+| target/vulnerable-jsp-app-1.0.0-SNAPSHOT/WEB-INF/applicationContext.xml:0:0:0:0 | target/vulnerable-jsp-app-1.0.0-SNAPSHOT/WEB-INF/applicationContext.xml |
+| target/vulnerable-jsp-app-1.0.0-SNAPSHOT/WEB-INF/web.xml:0:0:0:0 | target/vulnerable-jsp-app-1.0.0-SNAPSHOT/WEB-INF/web.xml |
+| target/vulnerable-jsp-app-1.0.0-SNAPSHOT/WEB-INF/weblogic.xml:0:0:0:0 | target/vulnerable-jsp-app-1.0.0-SNAPSHOT/WEB-INF/weblogic.xml |
+| target/web.xml:0:0:0:0 | target/web.xml |
+| target/webfrag.xml:0:0:0:0 | target/webfrag.xml |

--- a/java/ql/integration-tests/all-platforms/java/maven-sample-extract-properties/test.expected
+++ b/java/ql/integration-tests/all-platforms/java/maven-sample-extract-properties/test.expected
@@ -1,3 +1,6 @@
+#select
+| src/main/java/com/example/App.java:0:0:0:0 | App |
+| src/test/java/com/example/AppTest.java:0:0:0:0 | AppTest |
 xmlFiles
 | pom.xml:0:0:0:0 | pom.xml |
 | src/main/resources/page.xml:0:0:0:0 | src/main/resources/page.xml |
@@ -10,6 +13,3 @@ propertiesFiles
 | target/maven-archiver/pom.properties:0:0:0:0 | target/maven-archiver/pom.properties |
 | test-db/log/ext/javac-1.properties:0:0:0:0 | test-db/log/ext/javac-1.properties |
 | test-db/log/ext/javac.properties:0:0:0:0 | test-db/log/ext/javac.properties |
-#select
-| src/main/java/com/example/App.java:0:0:0:0 | App |
-| src/test/java/com/example/AppTest.java:0:0:0:0 | AppTest |

--- a/java/ql/integration-tests/all-platforms/java/maven-sample-large-xml-files/test.expected
+++ b/java/ql/integration-tests/all-platforms/java/maven-sample-large-xml-files/test.expected
@@ -1,7 +1,7 @@
+#select
+| src/main/java/com/example/App.java:0:0:0:0 | App |
+| src/test/java/com/example/AppTest.java:0:0:0:0 | AppTest |
 xmlFiles
 | pom.xml:0:0:0:0 | pom.xml |
 | src/main/resources/struts.xml:0:0:0:0 | src/main/resources/struts.xml |
 | target/classes/struts.xml:0:0:0:0 | target/classes/struts.xml |
-#select
-| src/main/java/com/example/App.java:0:0:0:0 | App |
-| src/test/java/com/example/AppTest.java:0:0:0:0 | AppTest |

--- a/java/ql/integration-tests/all-platforms/java/maven-sample-small-xml-files/test.expected
+++ b/java/ql/integration-tests/all-platforms/java/maven-sample-small-xml-files/test.expected
@@ -1,3 +1,6 @@
+#select
+| src/main/java/com/example/App.java:0:0:0:0 | App |
+| src/test/java/com/example/AppTest.java:0:0:0:0 | AppTest |
 xmlFiles
 | generated-0.xml:0:0:0:0 | generated-0.xml |
 | generated-1.xml:0:0:0:0 | generated-1.xml |
@@ -9,6 +12,3 @@ xmlFiles
 | src/main/resources/struts.xml:0:0:0:0 | src/main/resources/struts.xml |
 | target/classes/page.xml:0:0:0:0 | target/classes/page.xml |
 | target/classes/struts.xml:0:0:0:0 | target/classes/struts.xml |
-#select
-| src/main/java/com/example/App.java:0:0:0:0 | App |
-| src/test/java/com/example/AppTest.java:0:0:0:0 | AppTest |

--- a/java/ql/integration-tests/all-platforms/java/maven-sample-xml-mode-all/test.expected
+++ b/java/ql/integration-tests/all-platforms/java/maven-sample-xml-mode-all/test.expected
@@ -1,9 +1,9 @@
+#select
+| src/main/java/com/example/App.java:0:0:0:0 | App |
+| src/test/java/com/example/AppTest.java:0:0:0:0 | AppTest |
 xmlFiles
 | pom.xml:0:0:0:0 | pom.xml |
 | src/main/resources/page.xml:0:0:0:0 | src/main/resources/page.xml |
 | src/main/resources/struts.xml:0:0:0:0 | src/main/resources/struts.xml |
 | target/classes/page.xml:0:0:0:0 | target/classes/page.xml |
 | target/classes/struts.xml:0:0:0:0 | target/classes/struts.xml |
-#select
-| src/main/java/com/example/App.java:0:0:0:0 | App |
-| src/test/java/com/example/AppTest.java:0:0:0:0 | AppTest |

--- a/java/ql/integration-tests/all-platforms/java/maven-sample-xml-mode-byname/test.expected
+++ b/java/ql/integration-tests/all-platforms/java/maven-sample-xml-mode-byname/test.expected
@@ -1,7 +1,7 @@
+#select
+| src/main/java/com/example/App.java:0:0:0:0 | App |
+| src/test/java/com/example/AppTest.java:0:0:0:0 | AppTest |
 xmlFiles
 | pom.xml:0:0:0:0 | pom.xml |
 | src/main/resources/struts.xml:0:0:0:0 | src/main/resources/struts.xml |
 | target/classes/struts.xml:0:0:0:0 | target/classes/struts.xml |
-#select
-| src/main/java/com/example/App.java:0:0:0:0 | App |
-| src/test/java/com/example/AppTest.java:0:0:0:0 | AppTest |

--- a/java/ql/integration-tests/all-platforms/java/maven-sample-xml-mode-disabled/test.expected
+++ b/java/ql/integration-tests/all-platforms/java/maven-sample-xml-mode-disabled/test.expected
@@ -1,4 +1,4 @@
-xmlFiles
 #select
 | src/main/java/com/example/App.java:0:0:0:0 | App |
 | src/test/java/com/example/AppTest.java:0:0:0:0 | AppTest |
+xmlFiles

--- a/java/ql/integration-tests/all-platforms/java/maven-sample-xml-mode-smart/test.expected
+++ b/java/ql/integration-tests/all-platforms/java/maven-sample-xml-mode-smart/test.expected
@@ -1,7 +1,7 @@
+#select
+| src/main/java/com/example/App.java:0:0:0:0 | App |
+| src/test/java/com/example/AppTest.java:0:0:0:0 | AppTest |
 xmlFiles
 | pom.xml:0:0:0:0 | pom.xml |
 | src/main/resources/struts.xml:0:0:0:0 | src/main/resources/struts.xml |
 | target/classes/struts.xml:0:0:0:0 | target/classes/struts.xml |
-#select
-| src/main/java/com/example/App.java:0:0:0:0 | App |
-| src/test/java/com/example/AppTest.java:0:0:0:0 | AppTest |

--- a/java/ql/integration-tests/all-platforms/java/partial-gradle-sample-without-gradle/test.expected
+++ b/java/ql/integration-tests/all-platforms/java/partial-gradle-sample-without-gradle/test.expected
@@ -1,5 +1,5 @@
-xmlFiles
-| gradle/verification-metadata.xml:0:0:0:0 | gradle/verification-metadata.xml |
 #select
 | src/main/java/com/example/App.java:0:0:0:0 | App |
 | src/test/java/com/example/AppTest.java:0:0:0:0 | AppTest |
+xmlFiles
+| gradle/verification-metadata.xml:0:0:0:0 | gradle/verification-metadata.xml |

--- a/java/ql/integration-tests/all-platforms/java/partial-gradle-sample/test.expected
+++ b/java/ql/integration-tests/all-platforms/java/partial-gradle-sample/test.expected
@@ -1,5 +1,5 @@
-xmlFiles
-| gradle/verification-metadata.xml:0:0:0:0 | gradle/verification-metadata.xml |
 #select
 | src/main/java/com/example/App.java:0:0:0:0 | App |
 | src/test/java/com/example/AppTest.java:0:0:0:0 | AppTest |
+xmlFiles
+| gradle/verification-metadata.xml:0:0:0:0 | gradle/verification-metadata.xml |

--- a/java/ql/integration-tests/all-platforms/kotlin/default-parameter-mad-flow/test.expected
+++ b/java/ql/integration-tests/all-platforms/kotlin/default-parameter-mad-flow/test.expected
@@ -1,2 +1,2 @@
-failures
 testFailures
+failures


### PR DESCRIPTION
This means the expected output is in the order that the new test driver creates it in, which means future diffs will be smaller.