### PR TITLE
C++: Fix IR generation for builtins and add flow through `__builtin_bit_cast`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -114,6 +114,13 @@ predicate conversionFlow(
       instrTo.(CheckedConvertOrNullInstruction).getUnaryOperand() = opFrom
       or
       instrTo.(InheritanceConversionInstruction).getUnaryOperand() = opFrom
+      or
+      exists(BuiltInInstruction builtIn |
+        builtIn = instrTo and
+        // __builtin_bit_cast
+        builtIn.getBuiltInOperation() instanceof BuiltInBitCast and
+        opFrom = builtIn.getAnOperand()
+      )
     )
     or
     additional = true and

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedExpr.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedExpr.qll
@@ -3208,9 +3208,13 @@ class TranslatedBuiltInOperation extends TranslatedNonConstantExpr {
 
   final override Instruction getResult() { result = this.getInstruction(OnlyInstructionTag()) }
 
+  private TranslatedElement getRankedChild(int rnk) {
+    result = rank[rnk + 1](int id, TranslatedElement te | te = this.getChild(id) | te order by id)
+  }
+
   final override Instruction getFirstInstruction(EdgeKind kind) {
-    if exists(this.getChild(0))
-    then result = this.getChild(0).getFirstInstruction(kind)
+    if exists(this.getRankedChild(0))
+    then result = this.getRankedChild(0).getFirstInstruction(kind)
     else (
       kind instanceof GotoEdge and result = this.getInstruction(OnlyInstructionTag())
     )
@@ -3230,11 +3234,11 @@ class TranslatedBuiltInOperation extends TranslatedNonConstantExpr {
   }
 
   final override Instruction getChildSuccessorInternal(TranslatedElement child, EdgeKind kind) {
-    exists(int id | child = this.getChild(id) |
-      result = this.getChild(id + 1).getFirstInstruction(kind)
+    exists(int id | child = this.getRankedChild(id) |
+      result = this.getRankedChild(id + 1).getFirstInstruction(kind)
       or
       kind instanceof GotoEdge and
-      not exists(this.getChild(id + 1)) and
+      not exists(this.getRankedChild(id + 1)) and
       result = this.getInstruction(OnlyInstructionTag())
     )
   }
@@ -3249,7 +3253,7 @@ class TranslatedBuiltInOperation extends TranslatedNonConstantExpr {
     tag = OnlyInstructionTag() and
     exists(int index |
       operandTag = positionalArgumentOperand(index) and
-      result = this.getChild(index).(TranslatedExpr).getResult()
+      result = this.getRankedChild(index).(TranslatedExpr).getResult()
     )
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedExpr.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedExpr.qll
@@ -3208,6 +3208,13 @@ class TranslatedBuiltInOperation extends TranslatedNonConstantExpr {
 
   final override Instruction getResult() { result = this.getInstruction(OnlyInstructionTag()) }
 
+  /**
+   * Gets the rnk'th (0-indexed) child for which a `TranslatedElement` exists.
+   *
+   * We use this predicate to filter out `TypeName` expressions that sometimes
+   * occur in builtin operations since the IR doesn't have an instruction to
+   * represent a reference to a type.
+   */
   private TranslatedElement getRankedChild(int rnk) {
     result = rank[rnk + 1](int id, TranslatedElement te | te = this.getChild(id) | te order by id)
   }

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/clang.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/clang.cpp
@@ -52,3 +52,9 @@ void following_pointers( // $ ast-def=sourceStruct1_ptr ir-def=*cleanArray1 ir-d
   sink(stackArray); // $ ast,ir
   indirect_sink(stackArray); // $ ast ir=50:25 ir=50:35 ir=51:19
 }
+
+void test_bitcast() {
+  unsigned long x = source();
+  double d = __builtin_bit_cast(double, x);
+  sink(d); // $ ir MISSING: ast
+}

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test-source-sink.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test-source-sink.expected
@@ -153,6 +153,7 @@ irFlow
 | clang.cpp:50:25:50:30 | call to source | clang.cpp:53:17:53:26 | *stackArray |
 | clang.cpp:50:35:50:40 | call to source | clang.cpp:53:17:53:26 | *stackArray |
 | clang.cpp:51:19:51:24 | call to source | clang.cpp:53:17:53:26 | *stackArray |
+| clang.cpp:57:21:57:28 | call to source | clang.cpp:59:8:59:8 | d |
 | dispatch.cpp:9:37:9:42 | call to source | dispatch.cpp:35:16:35:25 | call to notSource1 |
 | dispatch.cpp:9:37:9:42 | call to source | dispatch.cpp:43:15:43:24 | call to notSource1 |
 | dispatch.cpp:10:37:10:42 | call to source | dispatch.cpp:36:16:36:25 | call to notSource2 |

--- a/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
+++ b/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
@@ -22734,6 +22734,25 @@ ir.cpp:
 # 2552|             Type = [Class] ClassWithDestructor
 # 2552|             ValueCategory = xvalue
 # 2553|     getStmt(1): [ReturnStmt] return ...
+# 2555| [TopLevelFunction] void builtin_bitcast(unsigned long)
+# 2555|   <params>: 
+# 2555|     getParameter(0): [Parameter] ul
+# 2555|         Type = [LongType] unsigned long
+# 2555|   getEntryPoint(): [BlockStmt] { ... }
+# 2556|     getStmt(0): [DeclStmt] declaration
+# 2556|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of d
+# 2556|           Type = [DoubleType] double
+# 2556|         getVariable().getInitializer(): [Initializer] initializer for d
+# 2556|           getExpr(): [BuiltInBitCast] __builtin_bit_cast
+# 2556|               Type = [DoubleType] double
+# 2556|               ValueCategory = prvalue
+# 2556|             getChild(0): [TypeName] double
+# 2556|                 Type = [DoubleType] double
+# 2556|                 ValueCategory = prvalue
+# 2556|             getChild(1): [VariableAccess] ul
+# 2556|                 Type = [LongType] unsigned long
+# 2556|                 ValueCategory = prvalue(load)
+# 2557|     getStmt(1): [ReturnStmt] return ...
 perf-regression.cpp:
 #    4| [CopyAssignmentOperator] Big& Big::operator=(Big const&)
 #    4|   <params>: 

--- a/cpp/ql/test/library-tests/ir/ir/aliased_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ir/aliased_ir.expected
@@ -18360,8 +18360,10 @@ ir.cpp:
 # 2555|     r2555_5(glval<unsigned long>) = VariableAddress[ul]         : 
 # 2555|     m2555_6(unsigned long)        = InitializeParameter[ul]     : &:r2555_5
 # 2556|     r2556_1(glval<double>)        = VariableAddress[d]          : 
-# 2556|     r2556_2(double)               = BuiltIn[__builtin_bit_cast] : 
-# 2556|     m2556_3(double)               = Store[d]                    : &:r2556_1, r2556_2
+# 2556|     r2556_2(glval<unsigned long>) = VariableAddress[ul]         : 
+# 2556|     r2556_3(unsigned long)        = Load[ul]                    : &:r2556_2, m2555_6
+# 2556|     r2556_4(double)               = BuiltIn[__builtin_bit_cast] : 0:r2556_3
+# 2556|     m2556_5(double)               = Store[d]                    : &:r2556_1, r2556_4
 # 2557|     v2557_1(void)                 = NoOp                        : 
 # 2555|     v2555_7(void)                 = ReturnVoid                  : 
 # 2555|     v2555_8(void)                 = AliasedUse                  : m2555_3

--- a/cpp/ql/test/library-tests/ir/ir/aliased_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ir/aliased_ir.expected
@@ -18351,6 +18351,22 @@ ir.cpp:
 # 2550|   Block 2
 # 2550|     v2550_10(void) = Unreached : 
 
+# 2555| void builtin_bitcast(unsigned long)
+# 2555|   Block 0
+# 2555|     v2555_1(void)                 = EnterFunction               : 
+# 2555|     m2555_2(unknown)              = AliasedDefinition           : 
+# 2555|     m2555_3(unknown)              = InitializeNonLocal          : 
+# 2555|     m2555_4(unknown)              = Chi                         : total:m2555_2, partial:m2555_3
+# 2555|     r2555_5(glval<unsigned long>) = VariableAddress[ul]         : 
+# 2555|     m2555_6(unsigned long)        = InitializeParameter[ul]     : &:r2555_5
+# 2556|     r2556_1(glval<double>)        = VariableAddress[d]          : 
+# 2556|     r2556_2(double)               = BuiltIn[__builtin_bit_cast] : 
+# 2556|     m2556_3(double)               = Store[d]                    : &:r2556_1, r2556_2
+# 2557|     v2557_1(void)                 = NoOp                        : 
+# 2555|     v2555_7(void)                 = ReturnVoid                  : 
+# 2555|     v2555_8(void)                 = AliasedUse                  : m2555_3
+# 2555|     v2555_9(void)                 = ExitFunction                : 
+
 perf-regression.cpp:
 #    6| void Big::Big()
 #    6|   Block 0

--- a/cpp/ql/test/library-tests/ir/ir/ir.cpp
+++ b/cpp/ql/test/library-tests/ir/ir/ir.cpp
@@ -2552,4 +2552,8 @@ void constexpr_inconsistency(bool b) {
     ;
 }
 
+void builtin_bitcast(unsigned long ul) {
+    double d = __builtin_bit_cast(double, ul);
+}
+
 // semmle-extractor-options: -std=c++20 --clang

--- a/cpp/ql/test/library-tests/ir/ir/raw_consistency.expected
+++ b/cpp/ql/test/library-tests/ir/ir/raw_consistency.expected
@@ -21,6 +21,7 @@ lostReachability
 backEdgeCountMismatch
 useNotDominatedByDefinition
 | ir.cpp:1535:8:1535:8 | Unary | Operand 'Unary' is not dominated by its definition in function '$@'. | ir.cpp:1535:8:1535:8 | void StructuredBindingDataMemberStruct::StructuredBindingDataMemberStruct() | void StructuredBindingDataMemberStruct::StructuredBindingDataMemberStruct() |
+| ir.cpp:2556:43:2556:44 | Arg(1) | Operand 'Arg(1)' is not dominated by its definition in function '$@'. | ir.cpp:2555:6:2555:20 | void builtin_bitcast(unsigned long) | void builtin_bitcast(unsigned long) |
 | try_except.c:13:13:13:13 | Left | Operand 'Left' is not dominated by its definition in function '$@'. | try_except.c:6:6:6:6 | void f() | void f() |
 | try_except.c:13:13:13:13 | Left | Operand 'Left' is not dominated by its definition in function '$@'. | try_except.c:6:6:6:6 | void f() | void f() |
 | try_except.c:39:15:39:15 | Left | Operand 'Left' is not dominated by its definition in function '$@'. | try_except.c:32:6:32:6 | void h(int) | void h(int) |

--- a/cpp/ql/test/library-tests/ir/ir/raw_consistency.expected
+++ b/cpp/ql/test/library-tests/ir/ir/raw_consistency.expected
@@ -21,7 +21,6 @@ lostReachability
 backEdgeCountMismatch
 useNotDominatedByDefinition
 | ir.cpp:1535:8:1535:8 | Unary | Operand 'Unary' is not dominated by its definition in function '$@'. | ir.cpp:1535:8:1535:8 | void StructuredBindingDataMemberStruct::StructuredBindingDataMemberStruct() | void StructuredBindingDataMemberStruct::StructuredBindingDataMemberStruct() |
-| ir.cpp:2556:43:2556:44 | Arg(1) | Operand 'Arg(1)' is not dominated by its definition in function '$@'. | ir.cpp:2555:6:2555:20 | void builtin_bitcast(unsigned long) | void builtin_bitcast(unsigned long) |
 | try_except.c:13:13:13:13 | Left | Operand 'Left' is not dominated by its definition in function '$@'. | try_except.c:6:6:6:6 | void f() | void f() |
 | try_except.c:13:13:13:13 | Left | Operand 'Left' is not dominated by its definition in function '$@'. | try_except.c:6:6:6:6 | void f() | void f() |
 | try_except.c:39:15:39:15 | Left | Operand 'Left' is not dominated by its definition in function '$@'. | try_except.c:32:6:32:6 | void h(int) | void h(int) |

--- a/cpp/ql/test/library-tests/ir/ir/raw_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ir/raw_ir.expected
@@ -16695,26 +16695,20 @@ ir.cpp:
 
 # 2555| void builtin_bitcast(unsigned long)
 # 2555|   Block 0
-# 2555|     v2555_1(void)                 = EnterFunction           : 
-# 2555|     mu2555_2(unknown)             = AliasedDefinition       : 
-# 2555|     mu2555_3(unknown)             = InitializeNonLocal      : 
-# 2555|     r2555_4(glval<unsigned long>) = VariableAddress[ul]     : 
-# 2555|     mu2555_5(unsigned long)       = InitializeParameter[ul] : &:r2555_4
-# 2556|     r2556_1(glval<double>)        = VariableAddress[d]      : 
-#-----|   Goto -> Block 1
-
-# 2556|   Block 1
-# 2556|     r2556_2(double)  = BuiltIn[__builtin_bit_cast] : 1:r2556_5
-# 2556|     mu2556_3(double) = Store[d]                    : &:r2556_1, r2556_2
-# 2557|     v2557_1(void)    = NoOp                        : 
-# 2555|     v2555_6(void)    = ReturnVoid                  : 
-# 2555|     v2555_7(void)    = AliasedUse                  : ~m?
-# 2555|     v2555_8(void)    = ExitFunction                : 
-
-# 2556|   Block 2
-# 2556|     r2556_4(glval<unsigned long>) = VariableAddress[ul] : 
-# 2556|     r2556_5(unsigned long)        = Load[ul]            : &:r2556_4, ~m?
-#-----|   Goto -> Block 1
+# 2555|     v2555_1(void)                 = EnterFunction               : 
+# 2555|     mu2555_2(unknown)             = AliasedDefinition           : 
+# 2555|     mu2555_3(unknown)             = InitializeNonLocal          : 
+# 2555|     r2555_4(glval<unsigned long>) = VariableAddress[ul]         : 
+# 2555|     mu2555_5(unsigned long)       = InitializeParameter[ul]     : &:r2555_4
+# 2556|     r2556_1(glval<double>)        = VariableAddress[d]          : 
+# 2556|     r2556_2(glval<unsigned long>) = VariableAddress[ul]         : 
+# 2556|     r2556_3(unsigned long)        = Load[ul]                    : &:r2556_2, ~m?
+# 2556|     r2556_4(double)               = BuiltIn[__builtin_bit_cast] : 0:r2556_3
+# 2556|     mu2556_5(double)              = Store[d]                    : &:r2556_1, r2556_4
+# 2557|     v2557_1(void)                 = NoOp                        : 
+# 2555|     v2555_6(void)                 = ReturnVoid                  : 
+# 2555|     v2555_7(void)                 = AliasedUse                  : ~m?
+# 2555|     v2555_8(void)                 = ExitFunction                : 
 
 perf-regression.cpp:
 #    6| void Big::Big()

--- a/cpp/ql/test/library-tests/ir/ir/raw_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ir/raw_ir.expected
@@ -16693,6 +16693,29 @@ ir.cpp:
 # 2550|     v2550_7(void)                       = AliasedUse                            : ~m?
 # 2550|     v2550_8(void)                       = ExitFunction                          : 
 
+# 2555| void builtin_bitcast(unsigned long)
+# 2555|   Block 0
+# 2555|     v2555_1(void)                 = EnterFunction           : 
+# 2555|     mu2555_2(unknown)             = AliasedDefinition       : 
+# 2555|     mu2555_3(unknown)             = InitializeNonLocal      : 
+# 2555|     r2555_4(glval<unsigned long>) = VariableAddress[ul]     : 
+# 2555|     mu2555_5(unsigned long)       = InitializeParameter[ul] : &:r2555_4
+# 2556|     r2556_1(glval<double>)        = VariableAddress[d]      : 
+#-----|   Goto -> Block 1
+
+# 2556|   Block 1
+# 2556|     r2556_2(double)  = BuiltIn[__builtin_bit_cast] : 1:r2556_5
+# 2556|     mu2556_3(double) = Store[d]                    : &:r2556_1, r2556_2
+# 2557|     v2557_1(void)    = NoOp                        : 
+# 2555|     v2555_6(void)    = ReturnVoid                  : 
+# 2555|     v2555_7(void)    = AliasedUse                  : ~m?
+# 2555|     v2555_8(void)    = ExitFunction                : 
+
+# 2556|   Block 2
+# 2556|     r2556_4(glval<unsigned long>) = VariableAddress[ul] : 
+# 2556|     r2556_5(unsigned long)        = Load[ul]            : &:r2556_4, ~m?
+#-----|   Goto -> Block 1
+
 perf-regression.cpp:
 #    6| void Big::Big()
 #    6|   Block 0


### PR DESCRIPTION
This PR does two things with the end goal of getting flow through this example:
```cpp
void test() {
  unsigned long x = source();
  double d = __builtin_bit_cast(double, x);
  sink(d);
}
```

- First, we fix IR generation for builtins. We were not skipping children we could not translate, which caused the IR generation to fail since the first argument of `__builtin_bit_cast` is a `TypeName` which has no IR representation. This meant that `__builtin_bit_cast` had no operands in the IR (see the first commit which adds a test for this).
  
  We could have added IR generation for `TypeName`s, but that would involve introducing another IR instruction which I didn't really feel like doing since we currently have no use-cases for doing anything with `TypeName`s in any queries.

- Second, we add flow through `__builtin_bit_cast` by treating it as a conversion in dataflow.

Commit-by-commit review recommended