### PR TITLE
Go: Use toolchain directives for version selection if available, and add tests (v2)

### DIFF
--- a/go/extractor/project/BUILD.bazel
+++ b/go/extractor/project/BUILD.bazel
@@ -19,5 +19,8 @@ go_test(
     name = "project_test",
     srcs = ["project_test.go"],
     embed = [":project"],
-    deps = ["//go/extractor/vendor/golang.org/x/mod/modfile"],
+    deps = [
+        "//go/extractor/util",
+        "//go/extractor/vendor/golang.org/x/mod/modfile",
+    ],
 )

--- a/go/extractor/project/project.go
+++ b/go/extractor/project/project.go
@@ -38,6 +38,9 @@ type GoModule struct {
 
 // Tries to find the Go toolchain version required for this module.
 func (module *GoModule) RequiredGoVersion() util.SemVer {
+	if module.Module != nil && module.Module.Toolchain != nil {
+		return util.NewSemVer(module.Module.Toolchain.Name)
+	}
 	if module.Module != nil && module.Module.Go != nil {
 		return util.NewSemVer(module.Module.Go.Version)
 	} else {

--- a/go/extractor/project/project.go
+++ b/go/extractor/project/project.go
@@ -40,8 +40,7 @@ type GoModule struct {
 func (module *GoModule) RequiredGoVersion() util.SemVer {
 	if module.Module != nil && module.Module.Toolchain != nil {
 		return util.NewSemVer(module.Module.Toolchain.Name)
-	}
-	if module.Module != nil && module.Module.Go != nil {
+	} else if module.Module != nil && module.Module.Go != nil {
 		return util.NewSemVer(module.Module.Go.Version)
 	} else {
 		return tryReadGoDirective(module.Path)


### PR DESCRIPTION
Supercedes #16453 using an implementation based on the new `SemVer` type introduced by #16460 (which should be merged first).

**Context**

In Go 1.21, the Go team started making a distinction between _language_ and _toolchain_ versions. Historically, the Go version is declared with a `go` directive in a `go.mod` file, or a `go.work` file. Since Go 1.21, `go` directives are used to declare the _language_ version. A new `toolchain` directive may be used to explicitly declare the _toolchain_ version. For backwards compatibility, if there is no `toolchain` directive, the _language_ version is used as the _toolchain_ version. In the Go autobuilder, we have numerous places where we try to determine the "version" of Go that is in use, should be installed, etc. Here, we are mainly interested in the _toolchain_ version.

**What this PR addresses**

So far, we have mainly been looking at `go` directives in `go.mod` files, and recently `go.work` files, for this. However, if a `toolchain` directive is present in either type of file, then this determines the toolchain version. We have not been considering this and this PR addresses that shortcoming by modifying the autobuilder to check for the presence of `toolchain` directives when determining the version that is in use.

This PR also adds a number of tests for the functions involved in this process.

**How to review**

Best reviewed commit-by-commit.