### PR TITLE
C#: Add assembly attributes to assemblies built with Bazel

### DIFF
--- a/csharp/Directory.Build.props
+++ b/csharp/Directory.Build.props
@@ -7,10 +7,11 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <Company>GitHub</Company>
+    <Product>CodeQL</Product>
     <Copyright>Copyright © $([System.DateTime]::Now.Year) $(Company)</Copyright>
     <Version>1.0.0.0</Version>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
+    <AssemblyVersion>$(Version)</AssemblyVersion>
+    <FileVersion>$(Version)</FileVersion>
   </PropertyGroup>
 
 </Project>

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BUILD.bazel
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BUILD.bazel
@@ -7,7 +7,6 @@ codeql_xunit_test(
     name = "Semmle.Autobuild.CSharp.Tests",
     srcs = glob([
         "*.cs",
-        "Properties/*.cs",
     ]),
     deps = [
         "//csharp/autobuilder/Semmle.Autobuild.CSharp:bin/Semmle.Autobuild.CSharp",

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp/BUILD.bazel
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp/BUILD.bazel
@@ -7,7 +7,6 @@ codeql_csharp_binary(
     name = "Semmle.Autobuild.CSharp",
     srcs = glob([
         "*.cs",
-        "Properties/*.cs",
     ]),
     visibility = ["//csharp:__subpackages__"],
     deps = [

--- a/csharp/autobuilder/Semmle.Autobuild.Cpp.Tests/BUILD.bazel
+++ b/csharp/autobuilder/Semmle.Autobuild.Cpp.Tests/BUILD.bazel
@@ -7,7 +7,6 @@ codeql_xunit_test(
     name = "Semmle.Autobuild.Cpp.Tests",
     srcs = glob([
         "*.cs",
-        "Properties/*.cs",
     ]),
     deps = [
         "//csharp/autobuilder/Semmle.Autobuild.Cpp:bin/Semmle.Autobuild.Cpp",

--- a/csharp/autobuilder/Semmle.Autobuild.Cpp/BUILD.bazel
+++ b/csharp/autobuilder/Semmle.Autobuild.Cpp/BUILD.bazel
@@ -7,7 +7,6 @@ codeql_csharp_binary(
     name = "Semmle.Autobuild.Cpp",
     srcs = glob([
         "*.cs",
-        "Properties/*.cs",
     ]),
     visibility = ["//visibility:public"],
     deps = [

--- a/csharp/autobuilder/Semmle.Autobuild.Shared/BUILD.bazel
+++ b/csharp/autobuilder/Semmle.Autobuild.Shared/BUILD.bazel
@@ -7,7 +7,6 @@ codeql_csharp_library(
     name = "Semmle.Autobuild.Shared",
     srcs = glob([
         "*.cs",
-        "Properties/*.cs",
     ]),
     visibility = ["//visibility:public"],
     deps = [

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/BUILD.bazel
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/BUILD.bazel
@@ -7,7 +7,6 @@ codeql_csharp_library(
     name = "Semmle.Extraction.CSharp.DependencyFetching",
     srcs = glob([
         "*.cs",
-        "Properties/*.cs",
         "SourceGenerators/**/*.cs",
     ]),
     allow_unsafe_blocks = True,

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/Properties/AssemblyInfo.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/Properties/AssemblyInfo.cs
@@ -1,4 +1,0 @@
-﻿using System.Runtime.CompilerServices;
-
-// Expose internals for testing purposes.
-[assembly: InternalsVisibleTo("Semmle.Extraction.Tests")]

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/Semmle.Extraction.CSharp.DependencyFetching.csproj
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/Semmle.Extraction.CSharp.DependencyFetching.csproj
@@ -6,6 +6,8 @@
   <ItemGroup>
     <ProjectReference Include="..\Semmle.Util\Semmle.Util.csproj" />
     <ProjectReference Include="..\Semmle.Extraction\Semmle.Extraction.csproj" />
+
+    <InternalsVisibleTo Include="Semmle.Extraction.Tests" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyStubGenerator/BUILD.bazel
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyStubGenerator/BUILD.bazel
@@ -7,7 +7,6 @@ codeql_csharp_binary(
     name = "Semmle.Extraction.CSharp.DependencyStubGenerator",
     srcs = glob([
         "*.cs",
-        "Properties/*.cs",
     ]),
     visibility = ["//csharp:__pkg__"],
     deps = [

--- a/csharp/extractor/Semmle.Extraction.CSharp.Driver/BUILD.bazel
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Driver/BUILD.bazel
@@ -7,7 +7,6 @@ codeql_csharp_binary(
     name = "Semmle.Extraction.CSharp.Driver",
     srcs = glob([
         "*.cs",
-        "Properties/*.cs",
     ]),
     visibility = ["//csharp:__pkg__"],
     deps = [

--- a/csharp/extractor/Semmle.Extraction.CSharp.Standalone/BUILD.bazel
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Standalone/BUILD.bazel
@@ -7,7 +7,6 @@ codeql_csharp_binary(
     name = "Semmle.Extraction.CSharp.Standalone",
     srcs = glob([
         "*.cs",
-        "Properties/*.cs",
     ]),
     visibility = ["//csharp:__subpackages__"],
     deps = [

--- a/csharp/extractor/Semmle.Extraction.CSharp.StubGenerator/BUILD.bazel
+++ b/csharp/extractor/Semmle.Extraction.CSharp.StubGenerator/BUILD.bazel
@@ -7,7 +7,6 @@ codeql_csharp_library(
     name = "Semmle.Extraction.CSharp.StubGenerator",
     srcs = glob([
         "*.cs",
-        "Properties/*.cs",
     ]),
     internals_visible_to = ["Semmle.Extraction.Tests"],
     visibility = ["//csharp:__subpackages__"],

--- a/csharp/extractor/Semmle.Extraction.CSharp.StubGenerator/Properties/AssemblyInfo.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.StubGenerator/Properties/AssemblyInfo.cs
@@ -1,4 +1,0 @@
-﻿using System.Runtime.CompilerServices;
-
-// Expose internals for testing purposes.
-[assembly: InternalsVisibleTo("Semmle.Extraction.Tests")]

--- a/csharp/extractor/Semmle.Extraction.CSharp.StubGenerator/Semmle.Extraction.CSharp.StubGenerator.csproj
+++ b/csharp/extractor/Semmle.Extraction.CSharp.StubGenerator/Semmle.Extraction.CSharp.StubGenerator.csproj
@@ -4,6 +4,8 @@
 		<ProjectReference Include="..\Semmle.Util\Semmle.Util.csproj" />
 		<ProjectReference Include="..\Semmle.Extraction.CSharp.DependencyFetching\Semmle.Extraction.CSharp.DependencyFetching.csproj" />
 		<ProjectReference Include="..\Semmle.Extraction.CSharp.Util\Semmle.Extraction.CSharp.Util.csproj" />
+
+		<InternalsVisibleTo Include="Semmle.Extraction.Tests" />
 	</ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/csharp/extractor/Semmle.Extraction.CSharp.Util/BUILD.bazel
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Util/BUILD.bazel
@@ -6,7 +6,6 @@ load(
 codeql_csharp_library(
     name = "Semmle.Extraction.CSharp.Util",
     srcs = glob([
-        "Properties/*.cs",
         "*.cs",
     ]),
     visibility = ["//csharp:__subpackages__"],

--- a/csharp/extractor/Semmle.Extraction.Tests/BUILD.bazel
+++ b/csharp/extractor/Semmle.Extraction.Tests/BUILD.bazel
@@ -7,7 +7,6 @@ codeql_xunit_test(
     name = "Semmle.Extraction.Tests",
     srcs = glob([
         "*.cs",
-        "Properties/*.cs",
     ]),
     deps = [
         "//csharp/extractor/Semmle.Extraction",

--- a/csharp/extractor/Semmle.Extraction/BUILD.bazel
+++ b/csharp/extractor/Semmle.Extraction/BUILD.bazel
@@ -15,7 +15,6 @@ codeql_csharp_library(
     srcs = glob([
         "Entities/**/*.cs",
         "Extractor/**/*.cs",
-        "Properties/*.cs",
         "*.cs",
     ]),
     # enable via -c dbg on the bazel command line/in .bazelrc.local

--- a/csharp/extractor/Semmle.Util.Tests/BUILD.bazel
+++ b/csharp/extractor/Semmle.Util.Tests/BUILD.bazel
@@ -7,7 +7,6 @@ codeql_xunit_test(
     name = "Semmle.Util.Tests",
     srcs = glob([
         "*.cs",
-        "Properties/*.cs",
     ]),
     deps = [
         "//csharp/extractor/Semmle.Util",

--- a/csharp/extractor/Semmle.Util/BUILD.bazel
+++ b/csharp/extractor/Semmle.Util/BUILD.bazel
@@ -9,7 +9,6 @@ codeql_csharp_library(
         "Logging/**/*.cs",
         "ToolStatusPage/**/*.cs",
         "*.cs",
-        "Properties/*.cs",
     ]),
     visibility = ["//visibility:public"],
     deps = [

--- a/csharp/scripts/BUILD.bazel
+++ b/csharp/scripts/BUILD.bazel
@@ -1,17 +1,21 @@
 py_binary(
-    name = "gen-assembly-info",
-    srcs = ["gen-assembly-info.py"],
+    name = "gen-git-assembly-info",
+    srcs = ["gen-git-assembly-info.py"],
     deps = ["@rules_python//python/runfiles"],
 )
 
-# this is an instance of the dbscheme kept in the bazel build tree
-# this allows everything that bazel builds to be up-to-date,
-# independently from whether //go:gen was already run to update the checked in files
+py_binary(
+    name = "gen-assembly-info",
+    srcs = ["gen-assembly-info.py"],
+    visibility = ["//csharp:__subpackages__"],
+    deps = ["@rules_python//python/runfiles"],
+)
+
 genrule(
-    name = "assembly-info-src",
+    name = "git-assembly-info-src",
     srcs = ["@semmle_code//:git_info"],
-    outs = ["AssemblyInfo.cs"],
-    cmd = "$(execpath :gen-assembly-info) $@ $(SRCS)",
-    tools = [":gen-assembly-info"],
+    outs = ["GitAssemblyInfo.cs"],
+    cmd = "$(execpath :gen-git-assembly-info) $@ $(SRCS)",
+    tools = [":gen-git-assembly-info"],
     visibility = ["//csharp:__subpackages__"],
 )

--- a/csharp/scripts/gen-assembly-info.py
+++ b/csharp/scripts/gen-assembly-info.py
@@ -1,7 +1,6 @@
 """
-Generates an `AssemblyInfo.cs` file that specifies the `AssemblyInformationalVersion` attribute.
-
-This attribute is set to the git version string of the repository."""
+Generates an `AssemblyInfo.cs` file that specifies a bunch of useful attributes
+that we want to set on our assemblies."""
 
 import pathlib
 import argparse
@@ -9,26 +8,20 @@ import argparse
 
 def options():
     p = argparse.ArgumentParser(
-        description="Generate the assembly info file that contains the git SHA and branch name"
+        description="Generate an assembly info file."
     )
     p.add_argument("output", help="The path to the output file")
-    p.add_argument("gitinfo_files", nargs="+", help="The path to the gitinfo files")
+    p.add_argument("name", help="The name of the assembly")
     return p.parse_args()
 
 
 opts = options()
 
-gitfiles = dict()
-for file in map(pathlib.Path, opts.gitinfo_files):
-    gitfiles[file.name] = file
-
-version_string = gitfiles["git-ql-describe-all.log"].read_text().strip()
-version_string += f" ({gitfiles['git-ql-rev-parse.log'].read_text().strip()})"
-
 output_file = pathlib.Path(opts.output)
 output_file_contents = f"""
 using System.Reflection;
 
-[assembly: AssemblyInformationalVersion("{version_string}")]
+[assembly: XX("{opts.name}")]
+[assembly: YY("ZZ")]
 """
 output_file.write_text(output_file_contents)

--- a/csharp/scripts/gen-assembly-info.py
+++ b/csharp/scripts/gen-assembly-info.py
@@ -21,7 +21,14 @@ output_file = pathlib.Path(opts.output)
 output_file_contents = f"""
 using System.Reflection;
 
-[assembly: XX("{opts.name}")]
-[assembly: YY("ZZ")]
+[assembly: AssemblyTitle("{opts.name}")]
+[assembly: AssemblyProduct("CodeQL")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyCompany("GitHub")]
+[assembly: AssemblyCopyright("Copyright © 2024 GitHub")]
+
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName = ".NET 8.0")]
+
 """
 output_file.write_text(output_file_contents)

--- a/csharp/scripts/gen-git-assembly-info.py
+++ b/csharp/scripts/gen-git-assembly-info.py
@@ -1,0 +1,34 @@
+"""
+Generates an `GitAssemblyInfo.cs` file that specifies the `AssemblyInformationalVersion` attribute.
+
+This attribute is set to the git version string of the repository."""
+
+import pathlib
+import argparse
+
+
+def options():
+    p = argparse.ArgumentParser(
+        description="Generate the git assembly info file that contains the git SHA and branch name"
+    )
+    p.add_argument("output", help="The path to the output file")
+    p.add_argument("gitinfo_files", nargs="+", help="The path to the gitinfo files")
+    return p.parse_args()
+
+
+opts = options()
+
+gitfiles = dict()
+for file in map(pathlib.Path, opts.gitinfo_files):
+    gitfiles[file.name] = file
+
+version_string = gitfiles["git-ql-describe-all.log"].read_text().strip()
+version_string += f" ({gitfiles['git-ql-rev-parse.log'].read_text().strip()})"
+
+output_file = pathlib.Path(opts.output)
+output_file_contents = f"""
+using System.Reflection;
+
+[assembly: AssemblyInformationalVersion("{version_string}")]
+"""
+output_file.write_text(output_file_contents)


### PR DESCRIPTION
This PR cleans up the build configuration for C# projects:

- Removes the last `AssemblyInfo.cs` files and moves `InternalsVisibleToAttributes` to csproj files.
- Removes the corresponding `"Properties/*.cs"` source declarations from Bazel build scripts.
- Ensures that assembly description attributes are added to the output artefacts when they are built with Bazel.