### PR TITLE
Go: Refactor queries to use `ThreatModelFlowSource` instead of `RemoteFlowSource`

### DIFF
--- a/go/ql/lib/change-notes/2024-06-08-refactor-go-queries-to-use-threatmodelflowsource.md
+++ b/go/ql/lib/change-notes/2024-06-08-refactor-go-queries-to-use-threatmodelflowsource.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* The `Customizations` libraries for several queries, as well as queries which do not have `Customizations` libraries, have been modified to use `ThreatModelFlowSource` to define their `isSource` predicates instead of `RemoteFlowSource`. This means these queries will now respect threat model configurations.
+* DataFlow queries which previously used `RemoteFlowSource` to define their sources have been modified to instead use `ThreatModelFlowSource`. This means these queries will now respect threat model configurations. The default threat model configuration is equivalent to `RemoteFlowSource`, so there should be no change in results for users using the default.

--- a/go/ql/lib/change-notes/2024-06-08-refactor-go-queries-to-use-threatmodelflowsource.md
+++ b/go/ql/lib/change-notes/2024-06-08-refactor-go-queries-to-use-threatmodelflowsource.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `Customizations` libraries for several queries, as well as queries which do not have `Customizations` libraries, have been modified to use `ThreatModelFlowSource` to define their `isSource` predicates instead of `RemoteFlowSource`. This means these queries will now respect threat model configurations.

--- a/go/ql/lib/semmle/go/security/CommandInjectionCustomizations.qll
+++ b/go/ql/lib/semmle/go/security/CommandInjectionCustomizations.qll
@@ -31,12 +31,12 @@ module CommandInjection {
   abstract class Sanitizer extends DataFlow::Node { }
 
   /**
-   * DEPRECATED: Use `RemoteFlowSource` or `Source` instead.
+   * DEPRECATED: Use `ThreatModelFlowSource` or `Source` instead.
    */
-  deprecated class UntrustedFlowAsSource = RemoteFlowAsSource;
+  deprecated class UntrustedFlowAsSource = ThreatModelFlowAsSource;
 
   /** A source of untrusted data, considered as a taint source for command injection. */
-  private class RemoteFlowAsSource extends Source instanceof RemoteFlowSource { }
+  private class ThreatModelFlowAsSource extends Source instanceof ThreatModelFlowSource { }
 
   /** A command name, considered as a taint sink for command injection. */
   class CommandNameAsSink extends Sink {

--- a/go/ql/lib/semmle/go/security/ExternalAPIs.qll
+++ b/go/ql/lib/semmle/go/security/ExternalAPIs.qll
@@ -182,48 +182,48 @@ class UnknownExternalApiDataNode extends ExternalApiDataNode {
 /**
  * DEPRECATED: Use `UntrustedDataToExternalApiFlow` instead.
  *
- * A configuration for tracking flow from `RemoteFlowSource`s to `ExternalApiDataNode`s.
+ * A configuration for tracking flow from `ThreatModelFlowSource`s to `ExternalApiDataNode`s.
  */
 deprecated class UntrustedDataToExternalApiConfig extends TaintTracking::Configuration {
   UntrustedDataToExternalApiConfig() { this = "UntrustedDataToExternalAPIConfig" }
 
-  override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  override predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   override predicate isSink(DataFlow::Node sink) { sink instanceof ExternalApiDataNode }
 }
 
 private module UntrustedDataConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof ExternalApiDataNode }
 }
 
 /**
- * Tracks data flow from `RemoteFlowSource`s to `ExternalApiDataNode`s.
+ * Tracks data flow from `ThreatModelFlowSource`s to `ExternalApiDataNode`s.
  */
 module UntrustedDataToExternalApiFlow = DataFlow::Global<UntrustedDataConfig>;
 
 /**
  * DEPRECATED: Use `UntrustedDataToUnknownExternalApiFlow` instead.
  *
- * A configuration for tracking flow from `RemoteFlowSource`s to `UnknownExternalApiDataNode`s.
+ * A configuration for tracking flow from `ThreatModelFlowSource`s to `UnknownExternalApiDataNode`s.
  */
 deprecated class UntrustedDataToUnknownExternalApiConfig extends TaintTracking::Configuration {
   UntrustedDataToUnknownExternalApiConfig() { this = "UntrustedDataToUnknownExternalAPIConfig" }
 
-  override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  override predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   override predicate isSink(DataFlow::Node sink) { sink instanceof UnknownExternalApiDataNode }
 }
 
 private module UntrustedDataToUnknownExternalApiConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof UnknownExternalApiDataNode }
 }
 
 /**
- * Tracks data flow from `RemoteFlowSource`s to `UnknownExternalApiDataNode`s.
+ * Tracks data flow from `ThreatModelFlowSource`s to `UnknownExternalApiDataNode`s.
  */
 module UntrustedDataToUnknownExternalApiFlow =
   DataFlow::Global<UntrustedDataToUnknownExternalApiConfig>;

--- a/go/ql/lib/semmle/go/security/LogInjectionCustomizations.qll
+++ b/go/ql/lib/semmle/go/security/LogInjectionCustomizations.qll
@@ -26,12 +26,12 @@ module LogInjection {
   abstract class Sanitizer extends DataFlow::Node { }
 
   /**
-   * DEPRECATED: Use `RemoteFlowSource` or `Source` instead.
+   * DEPRECATED: Use `ThreatModelFlowSource` or `Source` instead.
    */
-  deprecated class UntrustedFlowAsSource = RemoteFlowAsSource;
+  deprecated class UntrustedFlowAsSource = ThreatModelFlowAsSource;
 
   /** A source of untrusted data, considered as a taint source for log injection. */
-  private class RemoteFlowAsSource extends Source instanceof RemoteFlowSource { }
+  private class ThreatModelFlowAsSource extends Source instanceof ThreatModelFlowSource { }
 
   /** An argument to a logging mechanism. */
   class LoggerSink extends Sink {

--- a/go/ql/lib/semmle/go/security/MissingJwtSignatureCheckCustomizations.qll
+++ b/go/ql/lib/semmle/go/security/MissingJwtSignatureCheckCustomizations.qll
@@ -49,7 +49,7 @@ module MissingJwtSignatureCheck {
     }
   }
 
-  private class DefaultSource extends Source instanceof RemoteFlowSource { }
+  private class DefaultSource extends Source instanceof ThreatModelFlowSource { }
 
   private class DefaultSink extends Sink {
     DefaultSink() { sinkNode(this, "jwt") }

--- a/go/ql/lib/semmle/go/security/OpenUrlRedirectCustomizations.qll
+++ b/go/ql/lib/semmle/go/security/OpenUrlRedirectCustomizations.qll
@@ -43,15 +43,15 @@ module OpenUrlRedirect {
   }
 
   /**
-   * DEPRECATED: Use `RemoteFlowSource` or `Source` instead.
+   * DEPRECATED: Use `ThreatModelFlowSource` or `Source` instead.
    */
-  deprecated class UntrustedFlowAsSource = RemoteFlowAsSource;
+  deprecated class UntrustedFlowAsSource = ThreatModelFlowAsSource;
 
   /**
    * A source of third-party user input, considered as a flow source for URL redirects.
    */
-  private class RemoteFlowAsSource extends Source instanceof RemoteFlowSource {
-    RemoteFlowAsSource() {
+  private class ThreatModelFlowAsSource extends Source instanceof ThreatModelFlowSource {
+    ThreatModelFlowAsSource() {
       // exclude some fields and methods of URLs that are generally not attacker-controllable for
       // open redirect exploits
       not this instanceof Http::Redirect::UnexploitableSource

--- a/go/ql/lib/semmle/go/security/ReflectedXssCustomizations.qll
+++ b/go/ql/lib/semmle/go/security/ReflectedXssCustomizations.qll
@@ -35,14 +35,14 @@ module ReflectedXss {
   }
 
   /**
-   * DEPRECATED: Use `RemoteFlowSource` or `Source` instead.
+   * DEPRECATED: Use `ThreatModelFlowSource` or `Source` instead.
    */
-  deprecated class UntrustedFlowAsSource = RemoteFlowAsSource;
+  deprecated class UntrustedFlowAsSource = ThreatModelFlowAsSource;
 
   /**
    * A third-party controllable input, considered as a flow source for reflected XSS.
    */
-  private class RemoteFlowAsSource extends Source instanceof RemoteFlowSource { }
+  private class ThreatModelFlowAsSource extends Source instanceof ThreatModelFlowSource { }
 
   /** An arbitrary XSS sink, considered as a flow sink for stored XSS. */
   private class AnySink extends Sink instanceof SharedXss::Sink { }

--- a/go/ql/lib/semmle/go/security/RequestForgeryCustomizations.qll
+++ b/go/ql/lib/semmle/go/security/RequestForgeryCustomizations.qll
@@ -33,14 +33,14 @@ module RequestForgery {
   abstract class SanitizerEdge extends DataFlow::Node { }
 
   /**
-   * DEPRECATED: Use `RemoteFlowSource` or `Source` instead.
+   * DEPRECATED: Use `ThreatModelFlowSource` or `Source` instead.
    */
-  deprecated class UntrustedFlowAsSource = RemoteFlowAsSource;
+  deprecated class UntrustedFlowAsSource = ThreatModelFlowAsSource;
 
   /**
    * A third-party controllable input, considered as a flow source for request forgery.
    */
-  private class RemoteFlowAsSource extends Source instanceof RemoteFlowSource { }
+  private class ThreatModelFlowAsSource extends Source instanceof ThreatModelFlowSource { }
 
   /**
    * The URL of an HTTP request, viewed as a sink for request forgery.

--- a/go/ql/lib/semmle/go/security/SqlInjectionCustomizations.qll
+++ b/go/ql/lib/semmle/go/security/SqlInjectionCustomizations.qll
@@ -26,12 +26,12 @@ module SqlInjection {
   abstract class Sanitizer extends DataFlow::Node { }
 
   /**
-   * DEPRECATED: Use `RemoteFlowSource` or `Source` instead.
+   * DEPRECATED: Use `ThreatModelFlowSource` or `Source` instead.
    */
-  deprecated class UntrustedFlowAsSource = RemoteFlowAsSource;
+  deprecated class UntrustedFlowAsSource = ThreatModelFlowAsSource;
 
   /** A source of untrusted data, considered as a taint source for SQL injection. */
-  private class RemoteFlowAsSource extends Source instanceof RemoteFlowSource { }
+  private class ThreatModelFlowAsSource extends Source instanceof ThreatModelFlowSource { }
 
   /** An SQL string, considered as a taint sink for SQL injection. */
   class SqlQueryAsSink extends Sink instanceof SQL::QueryString { }

--- a/go/ql/lib/semmle/go/security/TaintedPathCustomizations.qll
+++ b/go/ql/lib/semmle/go/security/TaintedPathCustomizations.qll
@@ -45,12 +45,12 @@ module TaintedPath {
   }
 
   /**
-   * DEPRECATED: Use `RemoteFlowSource` or `Source` instead.
+   * DEPRECATED: Use `ThreatModelFlowSource` or `Source` instead.
    */
-  deprecated class UntrustedFlowAsSource = RemoteFlowAsSource;
+  deprecated class UntrustedFlowAsSource = ThreatModelFlowAsSource;
 
   /** A source of untrusted data, considered as a taint source for path traversal. */
-  private class RemoteFlowAsSource extends Source instanceof RemoteFlowSource { }
+  private class ThreatModelFlowAsSource extends Source instanceof ThreatModelFlowSource { }
 
   /** A path expression, considered as a taint sink for path traversal. */
   class PathAsSink extends Sink {

--- a/go/ql/lib/semmle/go/security/UncontrolledAllocationSizeCustomizations.qll
+++ b/go/ql/lib/semmle/go/security/UncontrolledAllocationSizeCustomizations.qll
@@ -21,7 +21,7 @@ module UncontrolledAllocationSize {
   abstract class Sanitizer extends DataFlow::Node { }
 
   /** A source of untrusted data, considered as a taint source for uncontrolled size allocation vulnerabilities. */
-  private class RemoteFlowAsSource extends Source instanceof RemoteFlowSource { }
+  private class ThreatModelFlowAsSource extends Source instanceof ThreatModelFlowSource { }
 
   /** The size argument of a memory allocation function. */
   private class AllocationSizeAsSink extends Sink instanceof AllocationSizeOverflow::AllocationSize {

--- a/go/ql/lib/semmle/go/security/XPathInjectionCustomizations.qll
+++ b/go/ql/lib/semmle/go/security/XPathInjectionCustomizations.qll
@@ -25,12 +25,12 @@ module XPathInjection {
   abstract class Sanitizer extends DataFlow::ExprNode { }
 
   /**
-   * DEPRECATED: Use `RemoteFlowSource` or `Source` instead.
+   * DEPRECATED: Use `ThreatModelFlowSource` or `Source` instead.
    */
-  deprecated class UntrustedFlowAsSource = RemoteFlowAsSource;
+  deprecated class UntrustedFlowAsSource = ThreatModelFlowAsSource;
 
   /** A source of untrusted data, used in an XPath expression. */
-  private class RemoteFlowAsSource extends Source instanceof RemoteFlowSource { }
+  private class ThreatModelFlowAsSource extends Source instanceof ThreatModelFlowSource { }
 
   /** An XPath expression string, considered as a taint sink for XPath injection. */
   class XPathExpressionStringAsSink extends Sink instanceof XPath::XPathExpressionString { }

--- a/go/ql/src/Security/CWE-640/EmailInjectionCustomizations.qll
+++ b/go/ql/src/Security/CWE-640/EmailInjectionCustomizations.qll
@@ -17,12 +17,12 @@ module EmailInjection {
   abstract class Sink extends DataFlow::Node { }
 
   /**
-   * DEPRECATED: Use `RemoteFlowSource` or `Source` instead.
+   * DEPRECATED: Use `ThreatModelFlowSource` or `Source` instead.
    */
-  deprecated class UntrustedFlowSourceAsSource = RemoteFlowSourceAsSource;
+  deprecated class UntrustedFlowSourceAsSource = ThreatModelFlowAsSource;
 
   /** A source of untrusted data, considered as a taint source for email injection. */
-  private class RemoteFlowSourceAsSource extends Source instanceof RemoteFlowSource { }
+  private class ThreatModelFlowAsSource extends Source instanceof ThreatModelFlowSource { }
 
   /**
    * A data-flow node that becomes part of an email considered as a taint sink for email injection.

--- a/go/ql/src/experimental/CWE-090/LDAPInjection.qll
+++ b/go/ql/src/experimental/CWE-090/LDAPInjection.qll
@@ -98,13 +98,13 @@ private class LdapClientDNSink extends LdapSink {
 /**
  * DEPRECATED: Use `LdapInjectionFlow` instead.
  *
- * A taint-tracking configuration for reasoning about when a `RemoteFlowSource`
+ * A taint-tracking configuration for reasoning about when a `ThreatModelFlowSource`
  * flows into an argument or field that is vulnerable to LDAP injection.
  */
 deprecated class LdapInjectionConfiguration extends TaintTracking::Configuration {
   LdapInjectionConfiguration() { this = "Ldap injection" }
 
-  override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  override predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   override predicate isSink(DataFlow::Node sink) { sink instanceof LdapSink }
 
@@ -112,7 +112,7 @@ deprecated class LdapInjectionConfiguration extends TaintTracking::Configuration
 }
 
 private module LdapInjectionConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof LdapSink }
 
@@ -120,7 +120,7 @@ private module LdapInjectionConfig implements DataFlow::ConfigSig {
 }
 
 /**
- * Tracks taint flow for reasoning about when a `RemoteFlowSource` flows
+ * Tracks taint flow for reasoning about when a `ThreatModelFlowSource` flows
  * into an argument or field that is vulnerable to LDAP injection.
  */
 module LdapInjectionFlow = TaintTracking::Global<LdapInjectionConfig>;

--- a/go/ql/src/experimental/CWE-203/Timing.ql
+++ b/go/ql/src/experimental/CWE-203/Timing.ql
@@ -98,7 +98,7 @@ private class SensitiveStringSink extends Sink {
 
 module Config implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) {
-    source instanceof RemoteFlowSource and not isBadResult(source)
+    source instanceof ThreatModelFlowSource and not isBadResult(source)
   }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof Sink and not isBadResult(sink) }

--- a/go/ql/src/experimental/CWE-287/ImproperLdapAuthCustomizations.qll
+++ b/go/ql/src/experimental/CWE-287/ImproperLdapAuthCustomizations.qll
@@ -68,7 +68,7 @@ module ImproperLdapAuth {
 
   private module Config implements DataFlow::ConfigSig {
     predicate isSource(DataFlow::Node source) {
-      source instanceof RemoteFlowSource or source instanceof EmptyString
+      source instanceof ThreatModelFlowSource or source instanceof EmptyString
     }
 
     predicate isSink(DataFlow::Node sink) { sink instanceof LdapAuthSink }

--- a/go/ql/src/experimental/CWE-369/DivideByZero.ql
+++ b/go/ql/src/experimental/CWE-369/DivideByZero.ql
@@ -28,7 +28,7 @@ predicate divideByZeroSanitizerGuard(DataFlow::Node g, Expr e, boolean branch) {
 }
 
 module Config implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
     exists(Function f, DataFlow::CallNode cn | cn = f.getACall() |

--- a/go/ql/src/experimental/CWE-74/DsnInjection.ql
+++ b/go/ql/src/experimental/CWE-74/DsnInjection.ql
@@ -14,7 +14,7 @@ import DsnInjectionCustomizations
 import DsnInjectionFlow::PathGraph
 
 /** A remote flow source taken as a source for the `DsnInjection` taint-flow configuration. */
-private class RemoteFlowAsSource extends Source instanceof RemoteFlowSource { }
+private class ThreatModelFlowAsSource extends Source instanceof ThreatModelFlowSource { }
 
 from DsnInjectionFlow::PathNode source, DsnInjectionFlow::PathNode sink
 where DsnInjectionFlow::flowPath(source, sink)

--- a/go/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
+++ b/go/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
@@ -36,7 +36,7 @@ class PassthroughTypeName extends string {
 }
 
 module UntrustedToPassthroughTypeConversionConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   additional predicate isSinkToPassthroughType(DataFlow::TypeCastNode sink, PassthroughTypeName name) {
     exists(Type typ |
@@ -53,7 +53,7 @@ module UntrustedToPassthroughTypeConversionConfig implements DataFlow::ConfigSig
 }
 
 /**
- * Tracks taint flow for reasoning about when a `RemoteFlowSource` is
+ * Tracks taint flow for reasoning about when a `ThreatModelFlowSource` is
  * converted into a special "passthrough" type which will not be escaped by the
  * template generator; this allows the injection of arbitrary content (html,
  * css, js) into the generated output of the templates.
@@ -109,13 +109,13 @@ predicate isSinkToTemplateExec(DataFlow::Node sink, DataFlow::CallNode call) {
 }
 
 module FromUntrustedToTemplateExecutionCallConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { isSinkToTemplateExec(sink, _) }
 }
 
 /**
- * Tracks taint flow from a `RemoteFlowSource` into a template executor
+ * Tracks taint flow from a `ThreatModelFlowSource` into a template executor
  * call.
  */
 module FromUntrustedToTemplateExecutionCallFlow =

--- a/go/ql/src/experimental/CWE-807/SensitiveConditionBypass.qll
+++ b/go/ql/src/experimental/CWE-807/SensitiveConditionBypass.qll
@@ -52,7 +52,7 @@ deprecated class Configuration extends TaintTracking::Configuration {
   Configuration() { this = "Condtional Expression Check Bypass" }
 
   override predicate isSource(DataFlow::Node source) {
-    source instanceof RemoteFlowSource
+    source instanceof ThreatModelFlowSource
     or
     exists(DataFlow::FieldReadNode f |
       f.getField().hasQualifiedName("net/http", "Request", "Host")
@@ -71,7 +71,7 @@ deprecated class Configuration extends TaintTracking::Configuration {
 
 private module Config implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) {
-    source instanceof RemoteFlowSource
+    source instanceof ThreatModelFlowSource
     or
     exists(DataFlow::FieldReadNode f |
       f.getField().hasQualifiedName("net/http", "Request", "Host")

--- a/go/ql/src/experimental/CWE-840/ConditionalBypass.ql
+++ b/go/ql/src/experimental/CWE-840/ConditionalBypass.ql
@@ -14,7 +14,7 @@ import go
 
 module Config implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) {
-    source instanceof RemoteFlowSource
+    source instanceof ThreatModelFlowSource
     or
     source = any(Field f | f.hasQualifiedName("net/http", "Request", "Host")).getARead()
   }

--- a/go/ql/src/experimental/CWE-918/SSRF.qll
+++ b/go/ql/src/experimental/CWE-918/SSRF.qll
@@ -88,14 +88,14 @@ module ServerSideRequestForgery {
   abstract class SanitizerEdge extends DataFlow::Node { }
 
   /**
-   * DEPRECATED: Use `RemoteFlowSource` or `Source` instead.
+   * DEPRECATED: Use `ThreatModelFlowSource` or `Source` instead.
    */
-  deprecated class UntrustedFlowAsSource = RemoteFlowAsSource;
+  deprecated class UntrustedFlowAsSource = ThreatModelFlowAsSource;
 
   /**
    * An user controlled input, considered as a flow source for request forgery.
    */
-  private class RemoteFlowAsSource extends Source instanceof RemoteFlowSource { }
+  private class ThreatModelFlowAsSource extends Source instanceof ThreatModelFlowSource { }
 
   /**
    * The URL of an HTTP request, viewed as a sink for request forgery.

--- a/go/ql/src/experimental/CWE-942/CorsMisconfiguration.ql
+++ b/go/ql/src/experimental/CWE-942/CorsMisconfiguration.ql
@@ -52,7 +52,7 @@ class AllowCredentialsHeaderWrite extends Http::HeaderWrite {
 }
 
 module UntrustedToAllowOriginHeaderConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   additional predicate isSinkHW(DataFlow::Node sink, AllowOriginHeaderWrite hw) {
     sink = hw.getValue()
@@ -70,7 +70,7 @@ module UntrustedToAllowOriginHeaderConfig implements DataFlow::ConfigSig {
 }
 
 module UntrustedToAllowOriginConfigConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   additional predicate isSinkWrite(DataFlow::Node sink, GinCors::AllowOriginsWrite w) { sink = w }
 
@@ -78,13 +78,13 @@ module UntrustedToAllowOriginConfigConfig implements DataFlow::ConfigSig {
 }
 
 /**
- * Tracks taint flowfor reasoning about when a `RemoteFlowSource` flows to
+ * Tracks taint flowfor reasoning about when a `ThreatModelFlowSource` flows to
  * a `HeaderWrite` that writes an `Access-Control-Allow-Origin` header's value.
  */
 module UntrustedToAllowOriginHeaderFlow = TaintTracking::Global<UntrustedToAllowOriginHeaderConfig>;
 
 /**
- * Tracks taint flowfor reasoning about when a `RemoteFlowSource` flows to
+ * Tracks taint flowfor reasoning about when a `ThreatModelFlowSource` flows to
  * a `AllowOriginsWrite` that writes an `Access-Control-Allow-Origin` header's value.
  */
 module UntrustedToAllowOriginConfigFlow = TaintTracking::Global<UntrustedToAllowOriginConfigConfig>;
@@ -121,7 +121,7 @@ predicate allowCredentialsIsSetToTrue(DataFlow::ExprNode allowOriginHW) {
 
 /**
  * Holds if the provided `allowOriginHW` HeaderWrite's value is set using an
- * RemoteFlowSource.
+ * ThreatModelFlowSource.
  * The `message` parameter is populated with the warning message to be returned by the query.
  */
 predicate flowsFromUntrustedToAllowOrigin(DataFlow::ExprNode allowOriginHW, string message) {
@@ -169,7 +169,7 @@ class MapRead extends DataFlow::ElementReadNode {
 }
 
 module FromUntrustedConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { isSinkCgn(sink, _) }
 
@@ -208,13 +208,13 @@ module FromUntrustedConfig implements DataFlow::ConfigSig {
 }
 
 /**
- * Tracks taint flow for reasoning about when a `RemoteFlowSource` flows
+ * Tracks taint flow for reasoning about when a `ThreatModelFlowSource` flows
  * somewhere.
  */
 module FromUntrustedFlow = TaintTracking::Global<FromUntrustedConfig>;
 
 /**
- * Holds if the provided `allowOriginHW` is also destination of a `RemoteFlowSource`.
+ * Holds if the provided `allowOriginHW` is also destination of a `ThreatModelFlowSource`.
  */
 predicate flowsToGuardedByCheckOnUntrusted(DataFlow::ExprNode allowOriginHW) {
   exists(DataFlow::Node sink, ControlFlow::ConditionGuardNode cgn |

--- a/go/ql/src/experimental/frameworks/DecompressionBombs.qll
+++ b/go/ql/src/experimental/frameworks/DecompressionBombs.qll
@@ -29,7 +29,7 @@ module DecompressionBomb {
     class FlowState = DecompressionBombs::FlowState;
 
     predicate isSource(DataFlow::Node source, FlowState state) {
-      source instanceof RemoteFlowSource and
+      source instanceof ThreatModelFlowSource and
       state = ""
     }
 


### PR DESCRIPTION
Follow up of #16697. This refactors queries to use `ThreatModelFlowSource` instead of `RemoteFlowSource` in their definitions of `isSource`.

Since the Go libraries currently do not have any local sources as far as I can tell, this should not be a breaking change.

> [!NOTE]
> Since this PR is based on #16697, the appropriate commit range to review is: https://github.com/github/codeql/pull/16709/files/03aa05c8c19cd9b396a51ee29307aea7c9aaab69..b4d4f8268f123045d5cb46723a883e6e788f082c