### PR TITLE
C#: Add fallback for branch detection.

### DIFF
--- a/csharp/scripts/gen-git-assembly-info.py
+++ b/csharp/scripts/gen-git-assembly-info.py
@@ -23,6 +23,8 @@ for file in map(pathlib.Path, opts.gitinfo_files):
     gitfiles[file.name] = file
 
 version_string = gitfiles["git-ql-describe-all.log"].read_text().strip()
+if version_string == "no-git":
+    version_string = gitfiles["git-describe-all.log"].read_text().strip()
 version_string += f" ({gitfiles['git-ql-rev-parse.log'].read_text().strip()})"
 
 output_file = pathlib.Path(opts.output)


### PR DESCRIPTION
Apparently, when building a release build, we're getting `no-git` as first part o the version string for the submodule. If we do, fall back to the internal repo's branch name. For releases, that's the same anyways.
Luckily, the commit SHA is correct.