### PR TITLE
Shared: Fix file-module qldoc.

### DIFF
--- a/shared/dataflow/codeql/dataflow/test/ProvenancePathGraph.qll
+++ b/shared/dataflow/codeql/dataflow/test/ProvenancePathGraph.qll
@@ -5,6 +5,8 @@
  * In addition to the `PathGraph`, a `query predicate models` is provided to
  * list the contents of the referenced MaD rows.
  */
+module;
+
 signature predicate interpretModelForTestSig(QlBuiltins::ExtensionId madId, string model);
 
 signature class PathNodeSig {


### PR DESCRIPTION
The qldoc belongs to the file module and not the `signature predicate`. With the new `module;` declaration we can fix this.