### PR TITLE
C#/Java: Respect manual neutrals, sources and sinks in model generation.

### DIFF
--- a/csharp/ql/src/utils/modelgenerator/CaptureNeutralModels.ql
+++ b/csharp/ql/src/utils/modelgenerator/CaptureNeutralModels.ql
@@ -10,6 +10,6 @@ import semmle.code.csharp.dataflow.internal.FlowSummaryImpl as FlowSummaryImpl
 import internal.CaptureModels
 import internal.CaptureSummaryFlowQuery
 
-from DataFlowTargetApi api, string noflow
+from DataFlowSummaryTargetApi api, string noflow
 where noflow = captureNoFlow(api)
 select noflow order by noflow

--- a/csharp/ql/src/utils/modelgenerator/CaptureSinkModels.ql
+++ b/csharp/ql/src/utils/modelgenerator/CaptureSinkModels.ql
@@ -8,6 +8,6 @@
 
 import internal.CaptureModels
 
-from DataFlowTargetApi api, string sink
+from DataFlowSinkTargetApi api, string sink
 where sink = captureSink(api)
 select sink order by sink

--- a/csharp/ql/src/utils/modelgenerator/CaptureSourceModels.ql
+++ b/csharp/ql/src/utils/modelgenerator/CaptureSourceModels.ql
@@ -8,6 +8,6 @@
 
 import internal.CaptureModels
 
-from DataFlowTargetApi api, string source
+from DataFlowSourceTargetApi api, string source
 where source = captureSource(api)
 select source order by source

--- a/csharp/ql/src/utils/modelgenerator/CaptureSummaryModels.ql
+++ b/csharp/ql/src/utils/modelgenerator/CaptureSummaryModels.ql
@@ -10,6 +10,6 @@ import semmle.code.csharp.dataflow.internal.FlowSummaryImpl as FlowSummaryImpl
 import internal.CaptureModels
 import internal.CaptureSummaryFlowQuery
 
-from DataFlowTargetApi api, string flow
+from DataFlowSummaryTargetApi api, string flow
 where flow = captureFlow(api)
 select flow order by flow

--- a/csharp/ql/src/utils/modelgenerator/internal/CaptureSummaryFlowQuery.qll
+++ b/csharp/ql/src/utils/modelgenerator/internal/CaptureSummaryFlowQuery.qll
@@ -75,7 +75,7 @@ private import CaptureModels
  * Captured Model:
  * ```Summaries;BasicFlow;false;AssignToArray;(System.Int32,System.Int32[]);Argument[0];Argument[1].Element;taint;df-generated```
  */
-string captureFlow(DataFlowTargetApi api) {
+string captureFlow(DataFlowSummaryTargetApi api) {
   result = captureQualifierFlow(api) or
   result = captureThroughFlow(api)
 }
@@ -86,8 +86,8 @@ string captureFlow(DataFlowTargetApi api) {
  * a summary model that applies to `api` and if it relevant to generate
  * a model for `api`.
  */
-string captureNoFlow(DataFlowTargetApi api) {
-  not exists(DataFlowTargetApi api0 | exists(captureFlow(api0)) and api0.lift() = api.lift()) and
+string captureNoFlow(DataFlowSummaryTargetApi api) {
+  not exists(DataFlowSummaryTargetApi api0 | exists(captureFlow(api0)) and api0.lift() = api.lift()) and
   api.isRelevant() and
   result = Printing::asNeutralSummaryModel(api)
 }

--- a/csharp/ql/src/utils/modelgenerator/internal/CaptureTypeBasedSummaryModels.qll
+++ b/csharp/ql/src/utils/modelgenerator/internal/CaptureTypeBasedSummaryModels.qll
@@ -189,7 +189,7 @@ private module Printing = ModelPrinting<ModelPrintingInput>;
  * A class of callables that are relevant generating summaries for based
  * on the Theorems for Free approach.
  */
-class TypeBasedFlowTargetApi extends Specific::TargetApiSpecific {
+class TypeBasedFlowTargetApi extends Specific::SummaryTargetApi {
   TypeBasedFlowTargetApi() { not Specific::isUninterestingForTypeBasedFlowModels(this) }
 
   /**

--- a/csharp/ql/test/utils/modelgenerator/dataflow/CaptureSinkModels.ext.yml
+++ b/csharp/ql/test/utils/modelgenerator/dataflow/CaptureSinkModels.ext.yml
@@ -4,3 +4,10 @@ extensions:
       extensible: sinkModel
     data:
       - [ "Sinks", "NewSinks", False, "Sink", "(System.Object)", "", "Argument[0]", "test-sink", "manual"]
+      - [ "Sinks", "NewSinks", False, "ManualSinkAlreadyDefined", "(System.Object)", "", "Argument[0]", "test-sink", "manual"]
+
+  - addsTo:
+      pack: codeql/csharp-all
+      extensible: neutralModel
+    data:
+      - [ "Sinks", "NewSinks", "ManualSinkNeutral", "(System.Object)", "sink", "manual" ]

--- a/csharp/ql/test/utils/modelgenerator/dataflow/CaptureSourceModels.ext.yml
+++ b/csharp/ql/test/utils/modelgenerator/dataflow/CaptureSourceModels.ext.yml
@@ -1,0 +1,12 @@
+extensions:
+  - addsTo:
+      pack: codeql/csharp-all
+      extensible: sourceModel
+    data:
+      - ["Sources", "NewSources", False, "ManualSourceAlreadyDefined", "()", "", "ReturnValue", "test-source", "manual"]
+
+  - addsTo:
+      pack: codeql/csharp-all
+      extensible: neutralModel
+    data:
+      - ["Sources", "NewSources", "ManualNeutralSource", "()", "source", "manual"]

--- a/csharp/ql/test/utils/modelgenerator/dataflow/Sinks.cs
+++ b/csharp/ql/test/utils/modelgenerator/dataflow/Sinks.cs
@@ -101,7 +101,6 @@ public class NewSinks
 
     // Not a new sink as this callable already has a manual sink.
     // neutral=Sinks;NewSinks;ManualSinkAlreadyDefined;(System.Object);summary;df-generated
-    // SPURIOUS-sink=Sinks;NewSinks;false;ManualSinkAlreadyDefined;(System.Object);;Argument[0];test-sink;df-generated
     public void ManualSinkAlreadyDefined(object o)
     {
         Sink(o);

--- a/csharp/ql/test/utils/modelgenerator/dataflow/Sinks.cs
+++ b/csharp/ql/test/utils/modelgenerator/dataflow/Sinks.cs
@@ -90,6 +90,22 @@ public class NewSinks
         var r = s == "hello";
         Sink(r);
     }
+
+    // Not a new sink as this callable has been manually modelled
+    // as sink neutral.
+    // neutral=Sinks;NewSinks;ManualSinkNeutral;(System.Object);summary;df-generated
+    public void ManualSinkNeutral(object o)
+    {
+        Sink(o);
+    }
+
+    // Not a new sink as this callable already has a manual sink.
+    // neutral=Sinks;NewSinks;ManualSinkAlreadyDefined;(System.Object);summary;df-generated
+    // SPURIOUS-sink=Sinks;NewSinks;false;ManualSinkAlreadyDefined;(System.Object);;Argument[0];test-sink;df-generated
+    public void ManualSinkAlreadyDefined(object o)
+    {
+        Sink(o);
+    }
 }
 
 public class CompoundSinks

--- a/csharp/ql/test/utils/modelgenerator/dataflow/Sources.cs
+++ b/csharp/ql/test/utils/modelgenerator/dataflow/Sources.cs
@@ -64,4 +64,21 @@ public class NewSources
             return Value.ToString();
         }
     }
+
+    // Not a new source as this callable has been manually modelled
+    // as source neutral.
+    // neutral=Sources;NewSources;ManualNeutralSource;();summary;df-generated
+    // SPURIOUS-source=Sources;NewSources;false;ManualNeutralSource;();;ReturnValue;local;df-generated
+    public string ManualNeutralSource()
+    {
+        return Console.ReadLine();
+    }
+
+    // Not a new source as this callable already has a manual source.
+    // SPURIOUS-source=Sources;NewSources;false;ManualSourceAlreadyDefined;();;ReturnValue;local;df-generated
+    // neutral=Sources;NewSources;ManualSourceAlreadyDefined;();summary;df-generated
+    public string ManualSourceAlreadyDefined()
+    {
+        return Console.ReadLine();
+    }
 }

--- a/csharp/ql/test/utils/modelgenerator/dataflow/Sources.cs
+++ b/csharp/ql/test/utils/modelgenerator/dataflow/Sources.cs
@@ -68,14 +68,12 @@ public class NewSources
     // Not a new source as this callable has been manually modelled
     // as source neutral.
     // neutral=Sources;NewSources;ManualNeutralSource;();summary;df-generated
-    // SPURIOUS-source=Sources;NewSources;false;ManualNeutralSource;();;ReturnValue;local;df-generated
     public string ManualNeutralSource()
     {
         return Console.ReadLine();
     }
 
     // Not a new source as this callable already has a manual source.
-    // SPURIOUS-source=Sources;NewSources;false;ManualSourceAlreadyDefined;();;ReturnValue;local;df-generated
     // neutral=Sources;NewSources;ManualSourceAlreadyDefined;();summary;df-generated
     public string ManualSourceAlreadyDefined()
     {

--- a/java/ql/src/utils/modelgenerator/CaptureNeutralModels.ql
+++ b/java/ql/src/utils/modelgenerator/CaptureNeutralModels.ql
@@ -9,6 +9,6 @@
 import internal.CaptureModels
 import internal.CaptureSummaryFlowQuery
 
-from DataFlowTargetApi api, string noflow
+from DataFlowSummaryTargetApi api, string noflow
 where noflow = captureNoFlow(api)
 select noflow order by noflow

--- a/java/ql/src/utils/modelgenerator/CaptureSinkModels.ql
+++ b/java/ql/src/utils/modelgenerator/CaptureSinkModels.ql
@@ -8,6 +8,6 @@
 
 import internal.CaptureModels
 
-from DataFlowTargetApi api, string sink
+from DataFlowSinkTargetApi api, string sink
 where sink = captureSink(api)
 select sink order by sink

--- a/java/ql/src/utils/modelgenerator/CaptureSourceModels.ql
+++ b/java/ql/src/utils/modelgenerator/CaptureSourceModels.ql
@@ -8,6 +8,6 @@
 
 import internal.CaptureModels
 
-from DataFlowTargetApi api, string source
+from DataFlowSourceTargetApi api, string source
 where source = captureSource(api)
 select source order by source

--- a/java/ql/src/utils/modelgenerator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/modelgenerator/CaptureSummaryModels.ql
@@ -9,6 +9,6 @@
 import internal.CaptureModels
 import internal.CaptureSummaryFlowQuery
 
-from DataFlowTargetApi api, string flow
+from DataFlowSummaryTargetApi api, string flow
 where flow = captureFlow(api)
 select flow order by flow

--- a/java/ql/src/utils/modelgenerator/internal/CaptureSummaryFlowQuery.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureSummaryFlowQuery.qll
@@ -67,7 +67,7 @@ private import CaptureModels
  * Captured Model:
  * ```p;Foo;true;addToList;;Argument[0];Argument[1];taint;df-generated```
  */
-string captureFlow(DataFlowTargetApi api) {
+string captureFlow(DataFlowSummaryTargetApi api) {
   result = captureQualifierFlow(api) or
   result = captureThroughFlow(api)
 }
@@ -77,8 +77,8 @@ string captureFlow(DataFlowTargetApi api) {
  * A neutral summary model is generated, if we are not generating
  * a summary model that applies to `api`.
  */
-string captureNoFlow(DataFlowTargetApi api) {
-  not exists(DataFlowTargetApi api0 | exists(captureFlow(api0)) and api0.lift() = api.lift()) and
+string captureNoFlow(DataFlowSummaryTargetApi api) {
+  not exists(DataFlowSummaryTargetApi api0 | exists(captureFlow(api0)) and api0.lift() = api.lift()) and
   api.isRelevant() and
   result = Printing::asNeutralSummaryModel(api)
 }

--- a/java/ql/src/utils/modelgenerator/internal/CaptureTypeBasedSummaryModels.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureTypeBasedSummaryModels.qll
@@ -295,7 +295,7 @@ private module Printing = ModelPrinting<ModelPrintingInput>;
  * A class of callables that are relevant generating summaries for based
  * on the Theorems for Free approach.
  */
-class TypeBasedFlowTargetApi extends Specific::TargetApiSpecific {
+class TypeBasedFlowTargetApi extends Specific::SummaryTargetApi {
   TypeBasedFlowTargetApi() { not Specific::isUninterestingForTypeBasedFlowModels(this) }
 
   /**

--- a/java/ql/test/utils/modelgenerator/dataflow/CaptureSinkModels.ext.yml
+++ b/java/ql/test/utils/modelgenerator/dataflow/CaptureSinkModels.ext.yml
@@ -5,6 +5,7 @@ extensions:
       extensible: sinkModel
     data:
       - [ "p", "Sinks", False, "sink", "(Object)", "", "Argument[0]", "test-sink", "manual" ]
+      - [ "p", "Sinks", False, "manualSinkAlreadyDefined", "(Object)", "", "Argument[0]", "test-sink", "manual" ]
 
   - addsTo:
       pack: codeql/java-all

--- a/java/ql/test/utils/modelgenerator/dataflow/CaptureSourceModels.ext.yml
+++ b/java/ql/test/utils/modelgenerator/dataflow/CaptureSourceModels.ext.yml
@@ -5,3 +5,10 @@ extensions:
       extensible: sourceModel
     data:
       - [ "p", "Sources", False, "source", "()", "", "ReturnValue", "test-source", "manual" ]
+      - [ "p", "Sources", False, "manualSourceAlreadyDefined", "()", "", "ReturnValue", "test-source", "manual" ]
+
+  - addsTo:
+      pack: codeql/java-all
+      extensible: neutralModel
+    data:
+      - ["p", "Sources", "manualNeutralSource", "()", "source", "manual"]

--- a/java/ql/test/utils/modelgenerator/dataflow/p/Sinks.java
+++ b/java/ql/test/utils/modelgenerator/dataflow/p/Sinks.java
@@ -71,4 +71,11 @@ public class Sinks {
     Boolean b = s == "hello";
     sink(b);
   }
+
+  // Not a new sink as this callable already has a manual sink.
+  // SPURIOUS-sink=p;Sinks;true;manualSinkAlreadyDefined;(Object);;Argument[0];test-sink;df-generated
+  // neutral=p;Sinks;manualSinkAlreadyDefined;(Object);summary;df-generated
+  public void manualSinkAlreadyDefined(Object o) {
+    sink(o);
+  }
 }

--- a/java/ql/test/utils/modelgenerator/dataflow/p/Sinks.java
+++ b/java/ql/test/utils/modelgenerator/dataflow/p/Sinks.java
@@ -73,7 +73,6 @@ public class Sinks {
   }
 
   // Not a new sink as this callable already has a manual sink.
-  // SPURIOUS-sink=p;Sinks;true;manualSinkAlreadyDefined;(Object);;Argument[0];test-sink;df-generated
   // neutral=p;Sinks;manualSinkAlreadyDefined;(Object);summary;df-generated
   public void manualSinkAlreadyDefined(Object o) {
     sink(o);

--- a/java/ql/test/utils/modelgenerator/dataflow/p/Sources.java
+++ b/java/ql/test/utils/modelgenerator/dataflow/p/Sources.java
@@ -69,14 +69,12 @@ public class Sources {
 
   // Not a new source as this callable has been manually modelled
   // as source neutral.
-  // SPURIOUS-source=p;Sources;true;manualNeutralSource;();;ReturnValue;test-source;df-generated
   // neutral=p;Sources;manualNeutralSource;();summary;df-generated
   public String manualNeutralSource() {
     return source();
   }
 
   // Not a new source as this callable already has a manual source.
-  // SPURIOUS-source=p;Sources;true;manualSourceAlreadyDefined;();;ReturnValue;test-source;df-generated
   // neutral=p;Sources;manualSourceAlreadyDefined;();summary;df-generated
   public String manualSourceAlreadyDefined() {
     return source();

--- a/java/ql/test/utils/modelgenerator/dataflow/p/Sources.java
+++ b/java/ql/test/utils/modelgenerator/dataflow/p/Sources.java
@@ -66,4 +66,19 @@ public class Sources {
       return value.toString();
     }
   }
+
+  // Not a new source as this callable has been manually modelled
+  // as source neutral.
+  // SPURIOUS-source=p;Sources;true;manualNeutralSource;();;ReturnValue;test-source;df-generated
+  // neutral=p;Sources;manualNeutralSource;();summary;df-generated
+  public String manualNeutralSource() {
+    return source();
+  }
+
+  // Not a new source as this callable already has a manual source.
+  // SPURIOUS-source=p;Sources;true;manualSourceAlreadyDefined;();;ReturnValue;test-source;df-generated
+  // neutral=p;Sources;manualSourceAlreadyDefined;();summary;df-generated
+  public String manualSourceAlreadyDefined() {
+    return source();
+  }
 }


### PR DESCRIPTION
In this PR we create separate classes of callables to be used by the dataflow configurations for the *source*, *sink* and *summary* callable target classes for model generation. Furthermore, we
- Ensure that *source* and *sink* models are not generated in case there exist a corresponding manual neutral or manual source/sink.
- Enable all source *kinds* for the C# source model generator.

IMO we should also avoid lifting sources or sinks the same way we do for summaries due to the following reason (this will also become easier to implement with the different classes for summary, source and sink callables): Contrary to summaries - sources and sinks have more granular kinds. As an example, we could imagine an interface or abstract class for writing to a *stream*. Depending on the implementation the stream writer could write to maybe the console, a file, a database, a log, etc. which could all be of different kinds (of sinks). That is, if we are lifting *sinks* we would then get a union of these kinds and the prototype implementation would become a "universal" sink.