### PR TITLE
Go: Only log one line for stray .go files

### DIFF
--- a/go/extractor/util/util.go
+++ b/go/extractor/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
 	"log"
 	"net/url"
@@ -185,11 +186,38 @@ func GoFilesOutsideDirs(root string, dirsToSkip ...string) []string {
 			return filepath.SkipDir
 		}
 		if filepath.Ext(d.Name()) == ".go" {
-			log.Printf("Found stray Go source file in %s.\n", path)
 			result = append(result, path)
 		}
 		return nil
 	})
+
+	if len(result) > 0 {
+		log.Printf(
+			"Found %d stray Go source file(s) in %s\n",
+			len(result),
+			JoinTruncatedList(result, ", ", 5),
+		)
+	}
+
+	return result
+}
+
+// Joins the `elements` into one string, up to `maxElements`, separated by `sep`.
+// If the length of `elements` exceeds `maxElements`, the string "and %d more" is
+// appended where `%d` is the number of `elements` that were omitted.
+func JoinTruncatedList(elements []string, sep string, maxElements int) string {
+	num := len(elements)
+	numIncluded := num
+	truncated := false
+	if num > maxElements {
+		numIncluded = maxElements
+		truncated = true
+	}
+
+	result := strings.Join(elements[0:numIncluded], sep)
+	if truncated {
+		result += fmt.Sprintf(", and %d more", num-maxElements)
+	}
 
 	return result
 }


### PR DESCRIPTION
This PR improves the logging for stray Go source files to only log one line, rather than one for each stray source file (which can be a lot in repos that don't use Go modules).