### PR TITLE
JS: Allow many Array steps to be used in type-tracking

### DIFF
--- a/javascript/ql/lib/change-notes/2024-06-14-type-tracking-array-steps.md
+++ b/javascript/ql/lib/change-notes/2024-06-14-type-tracking-array-steps.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+* Enabled type-tracking to follow content through arary methods
+* Improved modeling of `Array.splice`

--- a/javascript/ql/lib/change-notes/2024-06-14-type-tracking-array-steps.md
+++ b/javascript/ql/lib/change-notes/2024-06-14-type-tracking-array-steps.md
@@ -1,5 +1,5 @@
 ---
 category: minorAnalysis
 ---
-* Enabled type-tracking to follow content through arary methods
-* Improved modeling of `Array.splice`
+* Enabled type-tracking to follow content through array methods
+* Improved modeling of `Array.prototype.splice` for when it is called with more than two arguments

--- a/javascript/ql/lib/semmle/javascript/Arrays.qll
+++ b/javascript/ql/lib/semmle/javascript/Arrays.qll
@@ -77,8 +77,8 @@ module ArrayTaintTracking {
     succ = call.getReceiver().getALocalSource() and
     call.getCalleeName() = ["push", "unshift"]
     or
-    // `array.splice(i, del, e)`: if `e` is tainted, then so is `array`.
-    pred = call.getArgument(2) and
+    // `array.splice(i, del, ...items)`: if any item is tainted, then so is `array`.
+    pred = call.getArgument(any(int i | i >= 2)) and
     succ.(DataFlow::SourceNode).getAMethodCall("splice") = call
     or
     // `e = array.pop()`, `e = array.shift()`, or similar: if `array` is tainted, then so is `e`.
@@ -274,14 +274,14 @@ private module ArrayDataFlow {
 
   /**
    * A step modeling that `splice` can insert elements into an array.
-   * For example in `array.splice(i, del, e)`: if `e` is tainted, then so is `array
+   * For example in `array.splice(i, del, ...items)`: if any item is tainted, then so is `array`
    */
   private class ArraySpliceStep extends PreCallGraphStep {
     override predicate storeStep(DataFlow::Node element, DataFlow::SourceNode obj, string prop) {
       exists(DataFlow::MethodCallNode call |
         call.getMethodName() = "splice" and
         prop = arrayElement() and
-        element = call.getArgument(2) and
+        element = call.getArgument(any(int i | i >= 2)) and
         call = obj.getAMethodCall()
       )
     }

--- a/javascript/ql/lib/semmle/javascript/Arrays.qll
+++ b/javascript/ql/lib/semmle/javascript/Arrays.qll
@@ -115,9 +115,9 @@ private module ArrayDataFlow {
    * A step modeling the creation of an Array using the `Array.from(x)` method.
    * The step copies the elements of the argument (set, array, or iterator elements) into the resulting array.
    */
-  private class ArrayFrom extends DataFlow::SharedFlowStep {
+  private class ArrayFrom extends PreCallGraphStep {
     override predicate loadStoreStep(
-      DataFlow::Node pred, DataFlow::Node succ, string fromProp, string toProp
+      DataFlow::Node pred, DataFlow::SourceNode succ, string fromProp, string toProp
     ) {
       exists(DataFlow::CallNode call |
         call = arrayFromCall() and
@@ -135,9 +135,9 @@ private module ArrayDataFlow {
    *
    * Such a step can occur both with the `push` and `unshift` methods, or when creating a new array.
    */
-  private class ArrayCopySpread extends DataFlow::SharedFlowStep {
+  private class ArrayCopySpread extends PreCallGraphStep {
     override predicate loadStoreStep(
-      DataFlow::Node pred, DataFlow::Node succ, string fromProp, string toProp
+      DataFlow::Node pred, DataFlow::SourceNode succ, string fromProp, string toProp
     ) {
       fromProp = arrayLikeElement() and
       toProp = arrayElement() and
@@ -156,7 +156,7 @@ private module ArrayDataFlow {
   /**
    * A step for storing an element on an array using `arr.push(e)` or `arr.unshift(e)`.
    */
-  private class ArrayAppendStep extends DataFlow::SharedFlowStep {
+  private class ArrayAppendStep extends PreCallGraphStep {
     override predicate storeStep(DataFlow::Node element, DataFlow::SourceNode obj, string prop) {
       prop = arrayElement() and
       exists(DataFlow::MethodCallNode call |
@@ -187,7 +187,7 @@ private module ArrayDataFlow {
    * A step for reading/writing an element from an array inside a for-loop.
    * E.g. a read from `foo[i]` to `bar` in `for(var i = 0; i < arr.length; i++) {bar = foo[i]}`.
    */
-  private class ArrayIndexingStep extends DataFlow::SharedFlowStep {
+  private class ArrayIndexingStep extends PreCallGraphStep {
     override predicate loadStep(DataFlow::Node obj, DataFlow::Node element, string prop) {
       exists(ArrayIndexingAccess access |
         prop = arrayElement() and
@@ -209,7 +209,7 @@ private module ArrayDataFlow {
    * A step for retrieving an element from an array using `.pop()`, `.shift()`, or `.at()`.
    * E.g. `array.pop()`.
    */
-  private class ArrayPopStep extends DataFlow::SharedFlowStep {
+  private class ArrayPopStep extends PreCallGraphStep {
     override predicate loadStep(DataFlow::Node obj, DataFlow::Node element, string prop) {
       exists(DataFlow::MethodCallNode call |
         call.getMethodName() = ["pop", "shift", "at"] and
@@ -276,7 +276,7 @@ private module ArrayDataFlow {
    * A step modeling that `splice` can insert elements into an array.
    * For example in `array.splice(i, del, e)`: if `e` is tainted, then so is `array
    */
-  private class ArraySpliceStep extends DataFlow::SharedFlowStep {
+  private class ArraySpliceStep extends PreCallGraphStep {
     override predicate storeStep(DataFlow::Node element, DataFlow::SourceNode obj, string prop) {
       exists(DataFlow::MethodCallNode call |
         call.getMethodName() = "splice" and
@@ -291,8 +291,8 @@ private module ArrayDataFlow {
    * A step for modeling `concat`.
    * For example in `e = arr1.concat(arr2, arr3)`: if any of the `arr` is tainted, then so is `e`.
    */
-  private class ArrayConcatStep extends DataFlow::SharedFlowStep {
-    override predicate loadStoreStep(DataFlow::Node pred, DataFlow::Node succ, string prop) {
+  private class ArrayConcatStep extends PreCallGraphStep {
+    override predicate loadStoreStep(DataFlow::Node pred, DataFlow::SourceNode succ, string prop) {
       exists(DataFlow::MethodCallNode call |
         call.getMethodName() = "concat" and
         prop = arrayElement() and
@@ -305,8 +305,8 @@ private module ArrayDataFlow {
   /**
    * A step for modeling that elements from an array `arr` also appear in the result from calling `slice`/`splice`/`filter`.
    */
-  private class ArraySliceStep extends DataFlow::SharedFlowStep {
-    override predicate loadStoreStep(DataFlow::Node pred, DataFlow::Node succ, string prop) {
+  private class ArraySliceStep extends PreCallGraphStep {
+    override predicate loadStoreStep(DataFlow::Node pred, DataFlow::SourceNode succ, string prop) {
       exists(DataFlow::MethodCallNode call |
         call.getMethodName() = ["slice", "splice", "filter"] and
         prop = arrayElement() and
@@ -319,7 +319,7 @@ private module ArrayDataFlow {
   /**
    * A step modeling that elements from an array `arr` are received by calling `find`.
    */
-  private class ArrayFindStep extends DataFlow::SharedFlowStep {
+  private class ArrayFindStep extends PreCallGraphStep {
     override predicate loadStep(DataFlow::Node pred, DataFlow::Node succ, string prop) {
       exists(DataFlow::CallNode call |
         call = arrayFindCall(pred) and
@@ -382,7 +382,7 @@ private module ArrayLibraries {
    * E.g. `array-union` that creates a union of multiple arrays, or `array-uniq` that creates an array with unique elements.
    */
   DataFlow::CallNode arrayCopyCall(DataFlow::Node array) {
-    result = API::moduleImport(["array-union", "array-uniq", "uniq"]).getACall() and
+    result = DataFlow::moduleImport(["array-union", "array-uniq", "uniq"]).getACall() and
     array = result.getAnArgument()
   }
 
@@ -401,8 +401,8 @@ private module ArrayLibraries {
   /**
    * A loadStoreStep for a library that copies the elements of an array into another array.
    */
-  private class ArrayCopyLoadStore extends DataFlow::SharedFlowStep {
-    override predicate loadStoreStep(DataFlow::Node pred, DataFlow::Node succ, string prop) {
+  private class ArrayCopyLoadStore extends PreCallGraphStep {
+    override predicate loadStoreStep(DataFlow::Node pred, DataFlow::SourceNode succ, string prop) {
       exists(DataFlow::CallNode call |
         call = arrayCopyCall(pred) and
         succ = call and

--- a/javascript/ql/test/library-tests/Arrays/DataFlow.expected
+++ b/javascript/ql/test/library-tests/Arrays/DataFlow.expected
@@ -19,4 +19,5 @@
 | arrays.js:29:21:29:28 | "source" | arrays.js:38:8:38:17 | arr5.pop() |
 | arrays.js:29:21:29:28 | "source" | arrays.js:40:8:40:26 | arr5.slice(2).pop() |
 | arrays.js:29:21:29:28 | "source" | arrays.js:46:8:46:17 | arr6.pop() |
+| arrays.js:33:37:33:44 | "source" | arrays.js:35:8:35:25 | arr4_variant.pop() |
 | arrays.js:49:4:49:11 | "source" | arrays.js:50:10:50:18 | ary.pop() |

--- a/javascript/ql/test/library-tests/Arrays/DataFlow.expected
+++ b/javascript/ql/test/library-tests/Arrays/DataFlow.expected
@@ -3,6 +3,7 @@
 | arrays.js:2:16:2:23 | "source" | arrays.js:15:27:15:27 | e |
 | arrays.js:2:16:2:23 | "source" | arrays.js:16:23:16:23 | e |
 | arrays.js:2:16:2:23 | "source" | arrays.js:20:8:20:16 | arr.pop() |
+| arrays.js:2:16:2:23 | "source" | arrays.js:39:8:39:24 | arr4_spread.pop() |
 | arrays.js:2:16:2:23 | "source" | arrays.js:61:10:61:10 | x |
 | arrays.js:2:16:2:23 | "source" | arrays.js:65:10:65:10 | x |
 | arrays.js:2:16:2:23 | "source" | arrays.js:69:10:69:10 | x |

--- a/javascript/ql/test/library-tests/Arrays/DataFlow.expected
+++ b/javascript/ql/test/library-tests/Arrays/DataFlow.expected
@@ -3,20 +3,20 @@
 | arrays.js:2:16:2:23 | "source" | arrays.js:15:27:15:27 | e |
 | arrays.js:2:16:2:23 | "source" | arrays.js:16:23:16:23 | e |
 | arrays.js:2:16:2:23 | "source" | arrays.js:20:8:20:16 | arr.pop() |
-| arrays.js:2:16:2:23 | "source" | arrays.js:52:10:52:10 | x |
-| arrays.js:2:16:2:23 | "source" | arrays.js:56:10:56:10 | x |
-| arrays.js:2:16:2:23 | "source" | arrays.js:60:10:60:10 | x |
-| arrays.js:2:16:2:23 | "source" | arrays.js:66:10:66:10 | x |
+| arrays.js:2:16:2:23 | "source" | arrays.js:57:10:57:10 | x |
+| arrays.js:2:16:2:23 | "source" | arrays.js:61:10:61:10 | x |
+| arrays.js:2:16:2:23 | "source" | arrays.js:65:10:65:10 | x |
 | arrays.js:2:16:2:23 | "source" | arrays.js:71:10:71:10 | x |
-| arrays.js:2:16:2:23 | "source" | arrays.js:74:8:74:29 | arr.fin ... llback) |
-| arrays.js:2:16:2:23 | "source" | arrays.js:77:8:77:35 | arrayFi ... llback) |
-| arrays.js:2:16:2:23 | "source" | arrays.js:81:10:81:10 | x |
-| arrays.js:2:16:2:23 | "source" | arrays.js:84:8:84:17 | arr.at(-1) |
+| arrays.js:2:16:2:23 | "source" | arrays.js:76:10:76:10 | x |
+| arrays.js:2:16:2:23 | "source" | arrays.js:79:8:79:29 | arr.fin ... llback) |
+| arrays.js:2:16:2:23 | "source" | arrays.js:82:8:82:35 | arrayFi ... llback) |
+| arrays.js:2:16:2:23 | "source" | arrays.js:86:10:86:10 | x |
+| arrays.js:2:16:2:23 | "source" | arrays.js:89:8:89:17 | arr.at(-1) |
 | arrays.js:18:22:18:29 | "source" | arrays.js:18:50:18:50 | e |
 | arrays.js:22:15:22:22 | "source" | arrays.js:23:8:23:17 | arr2.pop() |
 | arrays.js:25:15:25:22 | "source" | arrays.js:26:8:26:17 | arr3.pop() |
 | arrays.js:29:21:29:28 | "source" | arrays.js:30:8:30:17 | arr4.pop() |
-| arrays.js:29:21:29:28 | "source" | arrays.js:33:8:33:17 | arr5.pop() |
-| arrays.js:29:21:29:28 | "source" | arrays.js:35:8:35:26 | arr5.slice(2).pop() |
-| arrays.js:29:21:29:28 | "source" | arrays.js:41:8:41:17 | arr6.pop() |
-| arrays.js:44:4:44:11 | "source" | arrays.js:45:10:45:18 | ary.pop() |
+| arrays.js:29:21:29:28 | "source" | arrays.js:38:8:38:17 | arr5.pop() |
+| arrays.js:29:21:29:28 | "source" | arrays.js:40:8:40:26 | arr5.slice(2).pop() |
+| arrays.js:29:21:29:28 | "source" | arrays.js:46:8:46:17 | arr6.pop() |
+| arrays.js:49:4:49:11 | "source" | arrays.js:50:10:50:18 | ary.pop() |

--- a/javascript/ql/test/library-tests/Arrays/DataFlow.expected
+++ b/javascript/ql/test/library-tests/Arrays/DataFlow.expected
@@ -3,21 +3,21 @@
 | arrays.js:2:16:2:23 | "source" | arrays.js:15:27:15:27 | e |
 | arrays.js:2:16:2:23 | "source" | arrays.js:16:23:16:23 | e |
 | arrays.js:2:16:2:23 | "source" | arrays.js:20:8:20:16 | arr.pop() |
-| arrays.js:2:16:2:23 | "source" | arrays.js:57:10:57:10 | x |
 | arrays.js:2:16:2:23 | "source" | arrays.js:61:10:61:10 | x |
 | arrays.js:2:16:2:23 | "source" | arrays.js:65:10:65:10 | x |
-| arrays.js:2:16:2:23 | "source" | arrays.js:71:10:71:10 | x |
-| arrays.js:2:16:2:23 | "source" | arrays.js:76:10:76:10 | x |
-| arrays.js:2:16:2:23 | "source" | arrays.js:79:8:79:29 | arr.fin ... llback) |
-| arrays.js:2:16:2:23 | "source" | arrays.js:82:8:82:35 | arrayFi ... llback) |
-| arrays.js:2:16:2:23 | "source" | arrays.js:86:10:86:10 | x |
-| arrays.js:2:16:2:23 | "source" | arrays.js:89:8:89:17 | arr.at(-1) |
+| arrays.js:2:16:2:23 | "source" | arrays.js:69:10:69:10 | x |
+| arrays.js:2:16:2:23 | "source" | arrays.js:75:10:75:10 | x |
+| arrays.js:2:16:2:23 | "source" | arrays.js:80:10:80:10 | x |
+| arrays.js:2:16:2:23 | "source" | arrays.js:83:8:83:29 | arr.fin ... llback) |
+| arrays.js:2:16:2:23 | "source" | arrays.js:86:8:86:35 | arrayFi ... llback) |
+| arrays.js:2:16:2:23 | "source" | arrays.js:90:10:90:10 | x |
+| arrays.js:2:16:2:23 | "source" | arrays.js:93:8:93:17 | arr.at(-1) |
 | arrays.js:18:22:18:29 | "source" | arrays.js:18:50:18:50 | e |
 | arrays.js:22:15:22:22 | "source" | arrays.js:23:8:23:17 | arr2.pop() |
 | arrays.js:25:15:25:22 | "source" | arrays.js:26:8:26:17 | arr3.pop() |
 | arrays.js:29:21:29:28 | "source" | arrays.js:30:8:30:17 | arr4.pop() |
-| arrays.js:29:21:29:28 | "source" | arrays.js:38:8:38:17 | arr5.pop() |
-| arrays.js:29:21:29:28 | "source" | arrays.js:40:8:40:26 | arr5.slice(2).pop() |
-| arrays.js:29:21:29:28 | "source" | arrays.js:46:8:46:17 | arr6.pop() |
+| arrays.js:29:21:29:28 | "source" | arrays.js:42:8:42:17 | arr5.pop() |
+| arrays.js:29:21:29:28 | "source" | arrays.js:44:8:44:26 | arr5.slice(2).pop() |
+| arrays.js:29:21:29:28 | "source" | arrays.js:50:8:50:17 | arr6.pop() |
 | arrays.js:33:37:33:44 | "source" | arrays.js:35:8:35:25 | arr4_variant.pop() |
-| arrays.js:49:4:49:11 | "source" | arrays.js:50:10:50:18 | ary.pop() |
+| arrays.js:53:4:53:11 | "source" | arrays.js:54:10:54:18 | ary.pop() |

--- a/javascript/ql/test/library-tests/Arrays/TaintFlow.expected
+++ b/javascript/ql/test/library-tests/Arrays/TaintFlow.expected
@@ -3,6 +3,7 @@
 | arrays.js:2:16:2:23 | "source" | arrays.js:15:27:15:27 | e |
 | arrays.js:2:16:2:23 | "source" | arrays.js:16:23:16:23 | e |
 | arrays.js:2:16:2:23 | "source" | arrays.js:20:8:20:16 | arr.pop() |
+| arrays.js:2:16:2:23 | "source" | arrays.js:39:8:39:24 | arr4_spread.pop() |
 | arrays.js:2:16:2:23 | "source" | arrays.js:58:8:58:13 | arr[0] |
 | arrays.js:2:16:2:23 | "source" | arrays.js:61:10:61:10 | x |
 | arrays.js:2:16:2:23 | "source" | arrays.js:65:10:65:10 | x |

--- a/javascript/ql/test/library-tests/Arrays/TaintFlow.expected
+++ b/javascript/ql/test/library-tests/Arrays/TaintFlow.expected
@@ -3,24 +3,24 @@
 | arrays.js:2:16:2:23 | "source" | arrays.js:15:27:15:27 | e |
 | arrays.js:2:16:2:23 | "source" | arrays.js:16:23:16:23 | e |
 | arrays.js:2:16:2:23 | "source" | arrays.js:20:8:20:16 | arr.pop() |
-| arrays.js:2:16:2:23 | "source" | arrays.js:49:8:49:13 | arr[0] |
-| arrays.js:2:16:2:23 | "source" | arrays.js:52:10:52:10 | x |
-| arrays.js:2:16:2:23 | "source" | arrays.js:56:10:56:10 | x |
-| arrays.js:2:16:2:23 | "source" | arrays.js:60:10:60:10 | x |
-| arrays.js:2:16:2:23 | "source" | arrays.js:66:10:66:10 | x |
+| arrays.js:2:16:2:23 | "source" | arrays.js:54:8:54:13 | arr[0] |
+| arrays.js:2:16:2:23 | "source" | arrays.js:57:10:57:10 | x |
+| arrays.js:2:16:2:23 | "source" | arrays.js:61:10:61:10 | x |
+| arrays.js:2:16:2:23 | "source" | arrays.js:65:10:65:10 | x |
 | arrays.js:2:16:2:23 | "source" | arrays.js:71:10:71:10 | x |
-| arrays.js:2:16:2:23 | "source" | arrays.js:74:8:74:29 | arr.fin ... llback) |
-| arrays.js:2:16:2:23 | "source" | arrays.js:77:8:77:35 | arrayFi ... llback) |
-| arrays.js:2:16:2:23 | "source" | arrays.js:81:10:81:10 | x |
-| arrays.js:2:16:2:23 | "source" | arrays.js:84:8:84:17 | arr.at(-1) |
+| arrays.js:2:16:2:23 | "source" | arrays.js:76:10:76:10 | x |
+| arrays.js:2:16:2:23 | "source" | arrays.js:79:8:79:29 | arr.fin ... llback) |
+| arrays.js:2:16:2:23 | "source" | arrays.js:82:8:82:35 | arrayFi ... llback) |
+| arrays.js:2:16:2:23 | "source" | arrays.js:86:10:86:10 | x |
+| arrays.js:2:16:2:23 | "source" | arrays.js:89:8:89:17 | arr.at(-1) |
 | arrays.js:18:22:18:29 | "source" | arrays.js:18:50:18:50 | e |
 | arrays.js:22:15:22:22 | "source" | arrays.js:23:8:23:17 | arr2.pop() |
 | arrays.js:25:15:25:22 | "source" | arrays.js:26:8:26:17 | arr3.pop() |
 | arrays.js:29:21:29:28 | "source" | arrays.js:30:8:30:17 | arr4.pop() |
-| arrays.js:29:21:29:28 | "source" | arrays.js:33:8:33:17 | arr5.pop() |
-| arrays.js:29:21:29:28 | "source" | arrays.js:35:8:35:26 | arr5.slice(2).pop() |
-| arrays.js:29:21:29:28 | "source" | arrays.js:41:8:41:17 | arr6.pop() |
-| arrays.js:44:4:44:11 | "source" | arrays.js:45:10:45:18 | ary.pop() |
-| arrays.js:44:4:44:11 | "source" | arrays.js:46:10:46:12 | ary |
-| arrays.js:86:9:86:16 | "source" | arrays.js:86:8:86:34 | ["sourc ... ) => x) |
-| arrays.js:87:9:87:16 | "source" | arrays.js:87:8:87:36 | ["sourc ... => !!x) |
+| arrays.js:29:21:29:28 | "source" | arrays.js:38:8:38:17 | arr5.pop() |
+| arrays.js:29:21:29:28 | "source" | arrays.js:40:8:40:26 | arr5.slice(2).pop() |
+| arrays.js:29:21:29:28 | "source" | arrays.js:46:8:46:17 | arr6.pop() |
+| arrays.js:49:4:49:11 | "source" | arrays.js:50:10:50:18 | ary.pop() |
+| arrays.js:49:4:49:11 | "source" | arrays.js:51:10:51:12 | ary |
+| arrays.js:91:9:91:16 | "source" | arrays.js:91:8:91:34 | ["sourc ... ) => x) |
+| arrays.js:92:9:92:16 | "source" | arrays.js:92:8:92:36 | ["sourc ... => !!x) |

--- a/javascript/ql/test/library-tests/Arrays/TaintFlow.expected
+++ b/javascript/ql/test/library-tests/Arrays/TaintFlow.expected
@@ -3,25 +3,25 @@
 | arrays.js:2:16:2:23 | "source" | arrays.js:15:27:15:27 | e |
 | arrays.js:2:16:2:23 | "source" | arrays.js:16:23:16:23 | e |
 | arrays.js:2:16:2:23 | "source" | arrays.js:20:8:20:16 | arr.pop() |
-| arrays.js:2:16:2:23 | "source" | arrays.js:54:8:54:13 | arr[0] |
-| arrays.js:2:16:2:23 | "source" | arrays.js:57:10:57:10 | x |
+| arrays.js:2:16:2:23 | "source" | arrays.js:58:8:58:13 | arr[0] |
 | arrays.js:2:16:2:23 | "source" | arrays.js:61:10:61:10 | x |
 | arrays.js:2:16:2:23 | "source" | arrays.js:65:10:65:10 | x |
-| arrays.js:2:16:2:23 | "source" | arrays.js:71:10:71:10 | x |
-| arrays.js:2:16:2:23 | "source" | arrays.js:76:10:76:10 | x |
-| arrays.js:2:16:2:23 | "source" | arrays.js:79:8:79:29 | arr.fin ... llback) |
-| arrays.js:2:16:2:23 | "source" | arrays.js:82:8:82:35 | arrayFi ... llback) |
-| arrays.js:2:16:2:23 | "source" | arrays.js:86:10:86:10 | x |
-| arrays.js:2:16:2:23 | "source" | arrays.js:89:8:89:17 | arr.at(-1) |
+| arrays.js:2:16:2:23 | "source" | arrays.js:69:10:69:10 | x |
+| arrays.js:2:16:2:23 | "source" | arrays.js:75:10:75:10 | x |
+| arrays.js:2:16:2:23 | "source" | arrays.js:80:10:80:10 | x |
+| arrays.js:2:16:2:23 | "source" | arrays.js:83:8:83:29 | arr.fin ... llback) |
+| arrays.js:2:16:2:23 | "source" | arrays.js:86:8:86:35 | arrayFi ... llback) |
+| arrays.js:2:16:2:23 | "source" | arrays.js:90:10:90:10 | x |
+| arrays.js:2:16:2:23 | "source" | arrays.js:93:8:93:17 | arr.at(-1) |
 | arrays.js:18:22:18:29 | "source" | arrays.js:18:50:18:50 | e |
 | arrays.js:22:15:22:22 | "source" | arrays.js:23:8:23:17 | arr2.pop() |
 | arrays.js:25:15:25:22 | "source" | arrays.js:26:8:26:17 | arr3.pop() |
 | arrays.js:29:21:29:28 | "source" | arrays.js:30:8:30:17 | arr4.pop() |
-| arrays.js:29:21:29:28 | "source" | arrays.js:38:8:38:17 | arr5.pop() |
-| arrays.js:29:21:29:28 | "source" | arrays.js:40:8:40:26 | arr5.slice(2).pop() |
-| arrays.js:29:21:29:28 | "source" | arrays.js:46:8:46:17 | arr6.pop() |
+| arrays.js:29:21:29:28 | "source" | arrays.js:42:8:42:17 | arr5.pop() |
+| arrays.js:29:21:29:28 | "source" | arrays.js:44:8:44:26 | arr5.slice(2).pop() |
+| arrays.js:29:21:29:28 | "source" | arrays.js:50:8:50:17 | arr6.pop() |
 | arrays.js:33:37:33:44 | "source" | arrays.js:35:8:35:25 | arr4_variant.pop() |
-| arrays.js:49:4:49:11 | "source" | arrays.js:50:10:50:18 | ary.pop() |
-| arrays.js:49:4:49:11 | "source" | arrays.js:51:10:51:12 | ary |
-| arrays.js:91:9:91:16 | "source" | arrays.js:91:8:91:34 | ["sourc ... ) => x) |
-| arrays.js:92:9:92:16 | "source" | arrays.js:92:8:92:36 | ["sourc ... => !!x) |
+| arrays.js:53:4:53:11 | "source" | arrays.js:54:10:54:18 | ary.pop() |
+| arrays.js:53:4:53:11 | "source" | arrays.js:55:10:55:12 | ary |
+| arrays.js:95:9:95:16 | "source" | arrays.js:95:8:95:34 | ["sourc ... ) => x) |
+| arrays.js:96:9:96:16 | "source" | arrays.js:96:8:96:36 | ["sourc ... => !!x) |

--- a/javascript/ql/test/library-tests/Arrays/TaintFlow.expected
+++ b/javascript/ql/test/library-tests/Arrays/TaintFlow.expected
@@ -20,6 +20,7 @@
 | arrays.js:29:21:29:28 | "source" | arrays.js:38:8:38:17 | arr5.pop() |
 | arrays.js:29:21:29:28 | "source" | arrays.js:40:8:40:26 | arr5.slice(2).pop() |
 | arrays.js:29:21:29:28 | "source" | arrays.js:46:8:46:17 | arr6.pop() |
+| arrays.js:33:37:33:44 | "source" | arrays.js:35:8:35:25 | arr4_variant.pop() |
 | arrays.js:49:4:49:11 | "source" | arrays.js:50:10:50:18 | ary.pop() |
 | arrays.js:49:4:49:11 | "source" | arrays.js:51:10:51:12 | ary |
 | arrays.js:91:9:91:16 | "source" | arrays.js:91:8:91:34 | ["sourc ... ) => x) |

--- a/javascript/ql/test/library-tests/Arrays/arrays.js
+++ b/javascript/ql/test/library-tests/Arrays/arrays.js
@@ -34,9 +34,9 @@
   arr4_variant.pop();
   sink(arr4_variant.pop()); // NOT OK
 
-  // var arr4_spread = [];
-  // arr4_spread.splice(0, 0, ...arr);
-  // sink(arr4_spread.pop()); // NOT OK
+  var arr4_spread = [];
+  arr4_spread.splice(0, 0, ...arr);
+  sink(arr4_spread.pop()); // NOT OK
 
   var arr5 = [].concat(arr4);
   sink(arr5.pop()); // NOT OK

--- a/javascript/ql/test/library-tests/Arrays/arrays.js
+++ b/javascript/ql/test/library-tests/Arrays/arrays.js
@@ -29,6 +29,11 @@
   arr4.splice(0, 0, "source");
   sink(arr4.pop()); // NOT OK
 
+  // var arr4_variant = [];
+  // arr4_variant.splice(0, 0, "safe", "source");
+  // arr4_variant.pop();
+  // sink(arr4_variant.pop()); // NOT OK
+
   var arr5 = [].concat(arr4);
   sink(arr5.pop()); // NOT OK
 

--- a/javascript/ql/test/library-tests/Arrays/arrays.js
+++ b/javascript/ql/test/library-tests/Arrays/arrays.js
@@ -34,6 +34,10 @@
   arr4_variant.pop();
   sink(arr4_variant.pop()); // NOT OK
 
+  // var arr4_spread = [];
+  // arr4_spread.splice(0, 0, ...arr);
+  // sink(arr4_spread.pop()); // NOT OK
+
   var arr5 = [].concat(arr4);
   sink(arr5.pop()); // NOT OK
 

--- a/javascript/ql/test/library-tests/Arrays/arrays.js
+++ b/javascript/ql/test/library-tests/Arrays/arrays.js
@@ -29,10 +29,10 @@
   arr4.splice(0, 0, "source");
   sink(arr4.pop()); // NOT OK
 
-  // var arr4_variant = [];
-  // arr4_variant.splice(0, 0, "safe", "source");
-  // arr4_variant.pop();
-  // sink(arr4_variant.pop()); // NOT OK
+  var arr4_variant = [];
+  arr4_variant.splice(0, 0, "safe", "source");
+  arr4_variant.pop();
+  sink(arr4_variant.pop()); // NOT OK
 
   var arr5 = [].concat(arr4);
   sink(arr5.pop()); // NOT OK
@@ -51,7 +51,7 @@
     sink(ary); // OK - its the array itself, not an element.
   });
 
-  sink(arr[0]); // OK - tuple like usage. 
+  sink(arr[0]); // OK - tuple like usage.
 
   for (const x of arr) {
     sink(x); // NOT OK
@@ -64,7 +64,7 @@
   for (const x of [...arr]) {
     sink(x); // NOT OK
   }
-  
+
   var arr7 = [];
   arr7.push(...arr);
   for (const x of arr7) {

--- a/javascript/ql/test/library-tests/Arrays/printAst.expected
+++ b/javascript/ql/test/library-tests/Arrays/printAst.expected
@@ -164,6 +164,26 @@ nodes
 | arrays.js:35:8:35:23 | [DotExpr] arr4_variant.pop | semmle.label | [DotExpr] arr4_variant.pop |
 | arrays.js:35:8:35:25 | [MethodCallExpr] arr4_variant.pop() | semmle.label | [MethodCallExpr] arr4_variant.pop() |
 | arrays.js:35:21:35:23 | [Label] pop | semmle.label | [Label] pop |
+| arrays.js:37:3:37:23 | [DeclStmt] var arr4_spread = ... | semmle.label | [DeclStmt] var arr4_spread = ... |
+| arrays.js:37:7:37:17 | [VarDecl] arr4_spread | semmle.label | [VarDecl] arr4_spread |
+| arrays.js:37:7:37:22 | [VariableDeclarator] arr4_spread = [] | semmle.label | [VariableDeclarator] arr4_spread = [] |
+| arrays.js:37:21:37:22 | [ArrayExpr] [] | semmle.label | [ArrayExpr] [] |
+| arrays.js:38:3:38:13 | [VarRef] arr4_spread | semmle.label | [VarRef] arr4_spread |
+| arrays.js:38:3:38:20 | [DotExpr] arr4_spread.splice | semmle.label | [DotExpr] arr4_spread.splice |
+| arrays.js:38:3:38:34 | [MethodCallExpr] arr4_sp ... ...arr) | semmle.label | [MethodCallExpr] arr4_sp ... ...arr) |
+| arrays.js:38:3:38:35 | [ExprStmt] arr4_sp ... ..arr); | semmle.label | [ExprStmt] arr4_sp ... ..arr); |
+| arrays.js:38:15:38:20 | [Label] splice | semmle.label | [Label] splice |
+| arrays.js:38:22:38:22 | [Literal] 0 | semmle.label | [Literal] 0 |
+| arrays.js:38:25:38:25 | [Literal] 0 | semmle.label | [Literal] 0 |
+| arrays.js:38:28:38:33 | [SpreadElement] ...arr | semmle.label | [SpreadElement] ...arr |
+| arrays.js:38:31:38:33 | [VarRef] arr | semmle.label | [VarRef] arr |
+| arrays.js:39:3:39:6 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:39:3:39:25 | [CallExpr] sink(ar ... .pop()) | semmle.label | [CallExpr] sink(ar ... .pop()) |
+| arrays.js:39:3:39:26 | [ExprStmt] sink(ar ... pop()); | semmle.label | [ExprStmt] sink(ar ... pop()); |
+| arrays.js:39:8:39:18 | [VarRef] arr4_spread | semmle.label | [VarRef] arr4_spread |
+| arrays.js:39:8:39:22 | [DotExpr] arr4_spread.pop | semmle.label | [DotExpr] arr4_spread.pop |
+| arrays.js:39:8:39:24 | [MethodCallExpr] arr4_spread.pop() | semmle.label | [MethodCallExpr] arr4_spread.pop() |
+| arrays.js:39:20:39:22 | [Label] pop | semmle.label | [Label] pop |
 | arrays.js:41:3:41:29 | [DeclStmt] var arr5 = ... | semmle.label | [DeclStmt] var arr5 = ... |
 | arrays.js:41:7:41:10 | [VarDecl] arr5 | semmle.label | [VarDecl] arr5 |
 | arrays.js:41:7:41:28 | [VariableDeclarator] arr5 = ... t(arr4) | semmle.label | [VariableDeclarator] arr5 = ... t(arr4) |
@@ -446,6 +466,8 @@ nodes
 | file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
 | file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
 | file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
+| file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
+| file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
 | file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
 | file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
 | file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
@@ -502,54 +524,60 @@ edges
 | arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:34:3:34:21 | [ExprStmt] arr4_variant.pop(); | semmle.order | 20 |
 | arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:35:3:35:27 | [ExprStmt] sink(ar ... pop()); | semmle.label | 21 |
 | arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:35:3:35:27 | [ExprStmt] sink(ar ... pop()); | semmle.order | 21 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:41:3:41:29 | [DeclStmt] var arr5 = ... | semmle.label | 22 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:41:3:41:29 | [DeclStmt] var arr5 = ... | semmle.order | 22 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:42:3:42:19 | [ExprStmt] sink(arr5.pop()); | semmle.label | 23 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:42:3:42:19 | [ExprStmt] sink(arr5.pop()); | semmle.order | 23 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:44:3:44:28 | [ExprStmt] sink(ar ... pop()); | semmle.label | 24 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:44:3:44:28 | [ExprStmt] sink(ar ... pop()); | semmle.order | 24 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:46:3:46:16 | [DeclStmt] var arr6 = ... | semmle.label | 25 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:46:3:46:16 | [DeclStmt] var arr6 = ... | semmle.order | 25 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:47:3:49:3 | [ForStmt] for (va ... i]; } | semmle.label | 26 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:47:3:49:3 | [ForStmt] for (va ... i]; } | semmle.order | 26 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:50:3:50:19 | [ExprStmt] sink(arr6.pop()); | semmle.label | 27 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:50:3:50:19 | [ExprStmt] sink(arr6.pop()); | semmle.order | 27 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:53:3:56:5 | [ExprStmt] ["sourc ... . }); | semmle.label | 28 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:53:3:56:5 | [ExprStmt] ["sourc ... . }); | semmle.order | 28 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:58:3:58:15 | [ExprStmt] sink(arr[0]); | semmle.label | 29 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:58:3:58:15 | [ExprStmt] sink(arr[0]); | semmle.order | 29 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | semmle.label | 30 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | semmle.order | 30 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | semmle.label | 31 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | semmle.order | 31 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:68:3:70:3 | [ForOfStmt] for (co ... OK } | semmle.label | 32 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:68:3:70:3 | [ForOfStmt] for (co ... OK } | semmle.order | 32 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:72:3:72:16 | [DeclStmt] var arr7 = ... | semmle.label | 33 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:72:3:72:16 | [DeclStmt] var arr7 = ... | semmle.order | 33 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:73:3:73:20 | [ExprStmt] arr7.push(...arr); | semmle.label | 34 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:73:3:73:20 | [ExprStmt] arr7.push(...arr); | semmle.order | 34 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:74:3:76:3 | [ForOfStmt] for (co ... OK } | semmle.label | 35 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:74:3:76:3 | [ForOfStmt] for (co ... OK } | semmle.order | 35 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:78:3:78:42 | [DeclStmt] const arrayFrom = ... | semmle.label | 36 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:78:3:78:42 | [DeclStmt] const arrayFrom = ... | semmle.order | 36 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:79:3:81:3 | [ForOfStmt] for (co ... OK } | semmle.label | 37 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:79:3:81:3 | [ForOfStmt] for (co ... OK } | semmle.order | 37 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:83:3:83:31 | [ExprStmt] sink(ar ... back)); | semmle.label | 38 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:83:3:83:31 | [ExprStmt] sink(ar ... back)); | semmle.order | 38 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:85:3:85:42 | [DeclStmt] const arrayFind = ... | semmle.label | 39 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:85:3:85:42 | [DeclStmt] const arrayFind = ... | semmle.order | 39 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:86:3:86:37 | [ExprStmt] sink(ar ... back)); | semmle.label | 40 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:86:3:86:37 | [ExprStmt] sink(ar ... back)); | semmle.order | 40 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:88:3:88:31 | [DeclStmt] const uniq = ... | semmle.label | 41 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:88:3:88:31 | [DeclStmt] const uniq = ... | semmle.order | 41 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:89:3:91:3 | [ForOfStmt] for (co ... OK } | semmle.label | 42 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:89:3:91:3 | [ForOfStmt] for (co ... OK } | semmle.order | 42 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:93:3:93:19 | [ExprStmt] sink(arr.at(-1)); | semmle.label | 43 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:93:3:93:19 | [ExprStmt] sink(arr.at(-1)); | semmle.order | 43 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:95:3:95:36 | [ExprStmt] sink([" ... => x)); | semmle.label | 44 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:95:3:95:36 | [ExprStmt] sink([" ... => x)); | semmle.order | 44 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:96:3:96:38 | [ExprStmt] sink([" ... !!x)); | semmle.label | 45 |
-| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:96:3:96:38 | [ExprStmt] sink([" ... !!x)); | semmle.order | 45 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:37:3:37:23 | [DeclStmt] var arr4_spread = ... | semmle.label | 22 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:37:3:37:23 | [DeclStmt] var arr4_spread = ... | semmle.order | 22 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:38:3:38:35 | [ExprStmt] arr4_sp ... ..arr); | semmle.label | 23 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:38:3:38:35 | [ExprStmt] arr4_sp ... ..arr); | semmle.order | 23 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:39:3:39:26 | [ExprStmt] sink(ar ... pop()); | semmle.label | 24 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:39:3:39:26 | [ExprStmt] sink(ar ... pop()); | semmle.order | 24 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:41:3:41:29 | [DeclStmt] var arr5 = ... | semmle.label | 25 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:41:3:41:29 | [DeclStmt] var arr5 = ... | semmle.order | 25 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:42:3:42:19 | [ExprStmt] sink(arr5.pop()); | semmle.label | 26 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:42:3:42:19 | [ExprStmt] sink(arr5.pop()); | semmle.order | 26 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:44:3:44:28 | [ExprStmt] sink(ar ... pop()); | semmle.label | 27 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:44:3:44:28 | [ExprStmt] sink(ar ... pop()); | semmle.order | 27 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:46:3:46:16 | [DeclStmt] var arr6 = ... | semmle.label | 28 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:46:3:46:16 | [DeclStmt] var arr6 = ... | semmle.order | 28 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:47:3:49:3 | [ForStmt] for (va ... i]; } | semmle.label | 29 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:47:3:49:3 | [ForStmt] for (va ... i]; } | semmle.order | 29 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:50:3:50:19 | [ExprStmt] sink(arr6.pop()); | semmle.label | 30 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:50:3:50:19 | [ExprStmt] sink(arr6.pop()); | semmle.order | 30 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:53:3:56:5 | [ExprStmt] ["sourc ... . }); | semmle.label | 31 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:53:3:56:5 | [ExprStmt] ["sourc ... . }); | semmle.order | 31 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:58:3:58:15 | [ExprStmt] sink(arr[0]); | semmle.label | 32 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:58:3:58:15 | [ExprStmt] sink(arr[0]); | semmle.order | 32 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | semmle.label | 33 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | semmle.order | 33 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | semmle.label | 34 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | semmle.order | 34 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:68:3:70:3 | [ForOfStmt] for (co ... OK } | semmle.label | 35 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:68:3:70:3 | [ForOfStmt] for (co ... OK } | semmle.order | 35 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:72:3:72:16 | [DeclStmt] var arr7 = ... | semmle.label | 36 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:72:3:72:16 | [DeclStmt] var arr7 = ... | semmle.order | 36 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:73:3:73:20 | [ExprStmt] arr7.push(...arr); | semmle.label | 37 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:73:3:73:20 | [ExprStmt] arr7.push(...arr); | semmle.order | 37 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:74:3:76:3 | [ForOfStmt] for (co ... OK } | semmle.label | 38 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:74:3:76:3 | [ForOfStmt] for (co ... OK } | semmle.order | 38 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:78:3:78:42 | [DeclStmt] const arrayFrom = ... | semmle.label | 39 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:78:3:78:42 | [DeclStmt] const arrayFrom = ... | semmle.order | 39 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:79:3:81:3 | [ForOfStmt] for (co ... OK } | semmle.label | 40 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:79:3:81:3 | [ForOfStmt] for (co ... OK } | semmle.order | 40 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:83:3:83:31 | [ExprStmt] sink(ar ... back)); | semmle.label | 41 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:83:3:83:31 | [ExprStmt] sink(ar ... back)); | semmle.order | 41 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:85:3:85:42 | [DeclStmt] const arrayFind = ... | semmle.label | 42 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:85:3:85:42 | [DeclStmt] const arrayFind = ... | semmle.order | 42 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:86:3:86:37 | [ExprStmt] sink(ar ... back)); | semmle.label | 43 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:86:3:86:37 | [ExprStmt] sink(ar ... back)); | semmle.order | 43 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:88:3:88:31 | [DeclStmt] const uniq = ... | semmle.label | 44 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:88:3:88:31 | [DeclStmt] const uniq = ... | semmle.order | 44 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:89:3:91:3 | [ForOfStmt] for (co ... OK } | semmle.label | 45 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:89:3:91:3 | [ForOfStmt] for (co ... OK } | semmle.order | 45 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:93:3:93:19 | [ExprStmt] sink(arr.at(-1)); | semmle.label | 46 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:93:3:93:19 | [ExprStmt] sink(arr.at(-1)); | semmle.order | 46 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:95:3:95:36 | [ExprStmt] sink([" ... => x)); | semmle.label | 47 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:95:3:95:36 | [ExprStmt] sink([" ... => x)); | semmle.order | 47 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:96:3:96:38 | [ExprStmt] sink([" ... !!x)); | semmle.label | 48 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:96:3:96:38 | [ExprStmt] sink([" ... !!x)); | semmle.order | 48 |
 | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | arrays.js:2:7:2:23 | [VariableDeclarator] source = "source" | semmle.label | 1 |
 | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | arrays.js:2:7:2:23 | [VariableDeclarator] source = "source" | semmle.order | 1 |
 | arrays.js:2:7:2:23 | [VariableDeclarator] source = "source" | arrays.js:2:7:2:12 | [VarDecl] source | semmle.label | 1 |
@@ -818,6 +846,36 @@ edges
 | arrays.js:35:8:35:23 | [DotExpr] arr4_variant.pop | arrays.js:35:21:35:23 | [Label] pop | semmle.order | 2 |
 | arrays.js:35:8:35:25 | [MethodCallExpr] arr4_variant.pop() | arrays.js:35:8:35:23 | [DotExpr] arr4_variant.pop | semmle.label | 0 |
 | arrays.js:35:8:35:25 | [MethodCallExpr] arr4_variant.pop() | arrays.js:35:8:35:23 | [DotExpr] arr4_variant.pop | semmle.order | 0 |
+| arrays.js:37:3:37:23 | [DeclStmt] var arr4_spread = ... | arrays.js:37:7:37:22 | [VariableDeclarator] arr4_spread = [] | semmle.label | 1 |
+| arrays.js:37:3:37:23 | [DeclStmt] var arr4_spread = ... | arrays.js:37:7:37:22 | [VariableDeclarator] arr4_spread = [] | semmle.order | 1 |
+| arrays.js:37:7:37:22 | [VariableDeclarator] arr4_spread = [] | arrays.js:37:7:37:17 | [VarDecl] arr4_spread | semmle.label | 1 |
+| arrays.js:37:7:37:22 | [VariableDeclarator] arr4_spread = [] | arrays.js:37:7:37:17 | [VarDecl] arr4_spread | semmle.order | 1 |
+| arrays.js:37:7:37:22 | [VariableDeclarator] arr4_spread = [] | arrays.js:37:21:37:22 | [ArrayExpr] [] | semmle.label | 2 |
+| arrays.js:37:7:37:22 | [VariableDeclarator] arr4_spread = [] | arrays.js:37:21:37:22 | [ArrayExpr] [] | semmle.order | 2 |
+| arrays.js:38:3:38:20 | [DotExpr] arr4_spread.splice | arrays.js:38:3:38:13 | [VarRef] arr4_spread | semmle.label | 1 |
+| arrays.js:38:3:38:20 | [DotExpr] arr4_spread.splice | arrays.js:38:3:38:13 | [VarRef] arr4_spread | semmle.order | 1 |
+| arrays.js:38:3:38:20 | [DotExpr] arr4_spread.splice | arrays.js:38:15:38:20 | [Label] splice | semmle.label | 2 |
+| arrays.js:38:3:38:20 | [DotExpr] arr4_spread.splice | arrays.js:38:15:38:20 | [Label] splice | semmle.order | 2 |
+| arrays.js:38:3:38:34 | [MethodCallExpr] arr4_sp ... ...arr) | arrays.js:38:3:38:20 | [DotExpr] arr4_spread.splice | semmle.label | 0 |
+| arrays.js:38:3:38:34 | [MethodCallExpr] arr4_sp ... ...arr) | arrays.js:38:3:38:20 | [DotExpr] arr4_spread.splice | semmle.order | 0 |
+| arrays.js:38:3:38:34 | [MethodCallExpr] arr4_sp ... ...arr) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:38:3:38:34 | [MethodCallExpr] arr4_sp ... ...arr) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:38:3:38:35 | [ExprStmt] arr4_sp ... ..arr); | arrays.js:38:3:38:34 | [MethodCallExpr] arr4_sp ... ...arr) | semmle.label | 1 |
+| arrays.js:38:3:38:35 | [ExprStmt] arr4_sp ... ..arr); | arrays.js:38:3:38:34 | [MethodCallExpr] arr4_sp ... ...arr) | semmle.order | 1 |
+| arrays.js:38:28:38:33 | [SpreadElement] ...arr | arrays.js:38:31:38:33 | [VarRef] arr | semmle.label | 1 |
+| arrays.js:38:28:38:33 | [SpreadElement] ...arr | arrays.js:38:31:38:33 | [VarRef] arr | semmle.order | 1 |
+| arrays.js:39:3:39:25 | [CallExpr] sink(ar ... .pop()) | arrays.js:39:3:39:6 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:39:3:39:25 | [CallExpr] sink(ar ... .pop()) | arrays.js:39:3:39:6 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:39:3:39:25 | [CallExpr] sink(ar ... .pop()) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:39:3:39:25 | [CallExpr] sink(ar ... .pop()) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:39:3:39:26 | [ExprStmt] sink(ar ... pop()); | arrays.js:39:3:39:25 | [CallExpr] sink(ar ... .pop()) | semmle.label | 1 |
+| arrays.js:39:3:39:26 | [ExprStmt] sink(ar ... pop()); | arrays.js:39:3:39:25 | [CallExpr] sink(ar ... .pop()) | semmle.order | 1 |
+| arrays.js:39:8:39:22 | [DotExpr] arr4_spread.pop | arrays.js:39:8:39:18 | [VarRef] arr4_spread | semmle.label | 1 |
+| arrays.js:39:8:39:22 | [DotExpr] arr4_spread.pop | arrays.js:39:8:39:18 | [VarRef] arr4_spread | semmle.order | 1 |
+| arrays.js:39:8:39:22 | [DotExpr] arr4_spread.pop | arrays.js:39:20:39:22 | [Label] pop | semmle.label | 2 |
+| arrays.js:39:8:39:22 | [DotExpr] arr4_spread.pop | arrays.js:39:20:39:22 | [Label] pop | semmle.order | 2 |
+| arrays.js:39:8:39:24 | [MethodCallExpr] arr4_spread.pop() | arrays.js:39:8:39:22 | [DotExpr] arr4_spread.pop | semmle.label | 0 |
+| arrays.js:39:8:39:24 | [MethodCallExpr] arr4_spread.pop() | arrays.js:39:8:39:22 | [DotExpr] arr4_spread.pop | semmle.order | 0 |
 | arrays.js:41:3:41:29 | [DeclStmt] var arr5 = ... | arrays.js:41:7:41:28 | [VariableDeclarator] arr5 = ... t(arr4) | semmle.label | 1 |
 | arrays.js:41:3:41:29 | [DeclStmt] var arr5 = ... | arrays.js:41:7:41:28 | [VariableDeclarator] arr5 = ... t(arr4) | semmle.order | 1 |
 | arrays.js:41:7:41:28 | [VariableDeclarator] arr5 = ... t(arr4) | arrays.js:41:7:41:10 | [VarDecl] arr5 | semmle.label | 1 |
@@ -1274,6 +1332,14 @@ edges
 | file://:0:0:0:0 | (Arguments) | arrays.js:33:37:33:44 | [Literal] "source" | semmle.order | 3 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:35:8:35:25 | [MethodCallExpr] arr4_variant.pop() | semmle.label | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:35:8:35:25 | [MethodCallExpr] arr4_variant.pop() | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:38:22:38:22 | [Literal] 0 | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:38:22:38:22 | [Literal] 0 | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:38:25:38:25 | [Literal] 0 | semmle.label | 1 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:38:25:38:25 | [Literal] 0 | semmle.order | 1 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:38:28:38:33 | [SpreadElement] ...arr | semmle.label | 2 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:38:28:38:33 | [SpreadElement] ...arr | semmle.order | 2 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:39:8:39:24 | [MethodCallExpr] arr4_spread.pop() | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:39:8:39:24 | [MethodCallExpr] arr4_spread.pop() | semmle.order | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:41:24:41:27 | [VarRef] arr4 | semmle.label | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:41:24:41:27 | [VarRef] arr4 | semmle.order | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:42:8:42:17 | [MethodCallExpr] arr5.pop() | semmle.label | 0 |

--- a/javascript/ql/test/library-tests/Arrays/printAst.expected
+++ b/javascript/ql/test/library-tests/Arrays/printAst.expected
@@ -139,6 +139,31 @@ nodes
 | arrays.js:30:8:30:15 | [DotExpr] arr4.pop | semmle.label | [DotExpr] arr4.pop |
 | arrays.js:30:8:30:17 | [MethodCallExpr] arr4.pop() | semmle.label | [MethodCallExpr] arr4.pop() |
 | arrays.js:30:13:30:15 | [Label] pop | semmle.label | [Label] pop |
+| arrays.js:32:3:32:24 | [DeclStmt] var arr4_variant = ... | semmle.label | [DeclStmt] var arr4_variant = ... |
+| arrays.js:32:7:32:18 | [VarDecl] arr4_variant | semmle.label | [VarDecl] arr4_variant |
+| arrays.js:32:7:32:23 | [VariableDeclarator] arr4_variant = [] | semmle.label | [VariableDeclarator] arr4_variant = [] |
+| arrays.js:32:22:32:23 | [ArrayExpr] [] | semmle.label | [ArrayExpr] [] |
+| arrays.js:33:3:33:14 | [VarRef] arr4_variant | semmle.label | [VarRef] arr4_variant |
+| arrays.js:33:3:33:21 | [DotExpr] arr4_variant.splice | semmle.label | [DotExpr] arr4_variant.splice |
+| arrays.js:33:3:33:45 | [MethodCallExpr] arr4_va ... ource") | semmle.label | [MethodCallExpr] arr4_va ... ource") |
+| arrays.js:33:3:33:46 | [ExprStmt] arr4_va ... urce"); | semmle.label | [ExprStmt] arr4_va ... urce"); |
+| arrays.js:33:16:33:21 | [Label] splice | semmle.label | [Label] splice |
+| arrays.js:33:23:33:23 | [Literal] 0 | semmle.label | [Literal] 0 |
+| arrays.js:33:26:33:26 | [Literal] 0 | semmle.label | [Literal] 0 |
+| arrays.js:33:29:33:34 | [Literal] "safe" | semmle.label | [Literal] "safe" |
+| arrays.js:33:37:33:44 | [Literal] "source" | semmle.label | [Literal] "source" |
+| arrays.js:34:3:34:14 | [VarRef] arr4_variant | semmle.label | [VarRef] arr4_variant |
+| arrays.js:34:3:34:18 | [DotExpr] arr4_variant.pop | semmle.label | [DotExpr] arr4_variant.pop |
+| arrays.js:34:3:34:20 | [MethodCallExpr] arr4_variant.pop() | semmle.label | [MethodCallExpr] arr4_variant.pop() |
+| arrays.js:34:3:34:21 | [ExprStmt] arr4_variant.pop(); | semmle.label | [ExprStmt] arr4_variant.pop(); |
+| arrays.js:34:16:34:18 | [Label] pop | semmle.label | [Label] pop |
+| arrays.js:35:3:35:6 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:35:3:35:26 | [CallExpr] sink(ar ... .pop()) | semmle.label | [CallExpr] sink(ar ... .pop()) |
+| arrays.js:35:3:35:27 | [ExprStmt] sink(ar ... pop()); | semmle.label | [ExprStmt] sink(ar ... pop()); |
+| arrays.js:35:8:35:19 | [VarRef] arr4_variant | semmle.label | [VarRef] arr4_variant |
+| arrays.js:35:8:35:23 | [DotExpr] arr4_variant.pop | semmle.label | [DotExpr] arr4_variant.pop |
+| arrays.js:35:8:35:25 | [MethodCallExpr] arr4_variant.pop() | semmle.label | [MethodCallExpr] arr4_variant.pop() |
+| arrays.js:35:21:35:23 | [Label] pop | semmle.label | [Label] pop |
 | arrays.js:37:3:37:29 | [DeclStmt] var arr5 = ... | semmle.label | [DeclStmt] var arr5 = ... |
 | arrays.js:37:7:37:10 | [VarDecl] arr5 | semmle.label | [VarDecl] arr5 |
 | arrays.js:37:7:37:28 | [VariableDeclarator] arr5 = ... t(arr4) | semmle.label | [VariableDeclarator] arr5 = ... t(arr4) |
@@ -419,6 +444,8 @@ nodes
 | file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
 | file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
 | file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
+| file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
+| file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
 | file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
 | file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
 | file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
@@ -467,54 +494,62 @@ edges
 | arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:29:3:29:30 | [ExprStmt] arr4.sp ... urce"); | semmle.order | 16 |
 | arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:30:3:30:19 | [ExprStmt] sink(arr4.pop()); | semmle.label | 17 |
 | arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:30:3:30:19 | [ExprStmt] sink(arr4.pop()); | semmle.order | 17 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:37:3:37:29 | [DeclStmt] var arr5 = ... | semmle.label | 18 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:37:3:37:29 | [DeclStmt] var arr5 = ... | semmle.order | 18 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:38:3:38:19 | [ExprStmt] sink(arr5.pop()); | semmle.label | 19 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:38:3:38:19 | [ExprStmt] sink(arr5.pop()); | semmle.order | 19 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:40:3:40:28 | [ExprStmt] sink(ar ... pop()); | semmle.label | 20 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:40:3:40:28 | [ExprStmt] sink(ar ... pop()); | semmle.order | 20 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:42:3:42:16 | [DeclStmt] var arr6 = ... | semmle.label | 21 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:42:3:42:16 | [DeclStmt] var arr6 = ... | semmle.order | 21 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:43:3:45:3 | [ForStmt] for (va ... i]; } | semmle.label | 22 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:43:3:45:3 | [ForStmt] for (va ... i]; } | semmle.order | 22 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:46:3:46:19 | [ExprStmt] sink(arr6.pop()); | semmle.label | 23 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:46:3:46:19 | [ExprStmt] sink(arr6.pop()); | semmle.order | 23 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:49:3:52:5 | [ExprStmt] ["sourc ... . }); | semmle.label | 24 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:49:3:52:5 | [ExprStmt] ["sourc ... . }); | semmle.order | 24 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:54:3:54:15 | [ExprStmt] sink(arr[0]); | semmle.label | 25 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:54:3:54:15 | [ExprStmt] sink(arr[0]); | semmle.order | 25 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:56:3:58:3 | [ForOfStmt] for (co ... OK } | semmle.label | 26 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:56:3:58:3 | [ForOfStmt] for (co ... OK } | semmle.order | 26 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | semmle.label | 27 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | semmle.order | 27 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | semmle.label | 28 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | semmle.order | 28 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:68:3:68:16 | [DeclStmt] var arr7 = ... | semmle.label | 29 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:68:3:68:16 | [DeclStmt] var arr7 = ... | semmle.order | 29 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:69:3:69:20 | [ExprStmt] arr7.push(...arr); | semmle.label | 30 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:69:3:69:20 | [ExprStmt] arr7.push(...arr); | semmle.order | 30 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | semmle.label | 31 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | semmle.order | 31 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:74:3:74:42 | [DeclStmt] const arrayFrom = ... | semmle.label | 32 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:74:3:74:42 | [DeclStmt] const arrayFrom = ... | semmle.order | 32 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:75:3:77:3 | [ForOfStmt] for (co ... OK } | semmle.label | 33 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:75:3:77:3 | [ForOfStmt] for (co ... OK } | semmle.order | 33 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:79:3:79:31 | [ExprStmt] sink(ar ... back)); | semmle.label | 34 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:79:3:79:31 | [ExprStmt] sink(ar ... back)); | semmle.order | 34 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:81:3:81:42 | [DeclStmt] const arrayFind = ... | semmle.label | 35 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:81:3:81:42 | [DeclStmt] const arrayFind = ... | semmle.order | 35 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:82:3:82:37 | [ExprStmt] sink(ar ... back)); | semmle.label | 36 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:82:3:82:37 | [ExprStmt] sink(ar ... back)); | semmle.order | 36 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:84:3:84:31 | [DeclStmt] const uniq = ... | semmle.label | 37 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:84:3:84:31 | [DeclStmt] const uniq = ... | semmle.order | 37 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:85:3:87:3 | [ForOfStmt] for (co ... OK } | semmle.label | 38 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:85:3:87:3 | [ForOfStmt] for (co ... OK } | semmle.order | 38 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:89:3:89:19 | [ExprStmt] sink(arr.at(-1)); | semmle.label | 39 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:89:3:89:19 | [ExprStmt] sink(arr.at(-1)); | semmle.order | 39 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:91:3:91:36 | [ExprStmt] sink([" ... => x)); | semmle.label | 40 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:91:3:91:36 | [ExprStmt] sink([" ... => x)); | semmle.order | 40 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:92:3:92:38 | [ExprStmt] sink([" ... !!x)); | semmle.label | 41 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:92:3:92:38 | [ExprStmt] sink([" ... !!x)); | semmle.order | 41 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:32:3:32:24 | [DeclStmt] var arr4_variant = ... | semmle.label | 18 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:32:3:32:24 | [DeclStmt] var arr4_variant = ... | semmle.order | 18 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:33:3:33:46 | [ExprStmt] arr4_va ... urce"); | semmle.label | 19 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:33:3:33:46 | [ExprStmt] arr4_va ... urce"); | semmle.order | 19 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:34:3:34:21 | [ExprStmt] arr4_variant.pop(); | semmle.label | 20 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:34:3:34:21 | [ExprStmt] arr4_variant.pop(); | semmle.order | 20 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:35:3:35:27 | [ExprStmt] sink(ar ... pop()); | semmle.label | 21 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:35:3:35:27 | [ExprStmt] sink(ar ... pop()); | semmle.order | 21 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:37:3:37:29 | [DeclStmt] var arr5 = ... | semmle.label | 22 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:37:3:37:29 | [DeclStmt] var arr5 = ... | semmle.order | 22 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:38:3:38:19 | [ExprStmt] sink(arr5.pop()); | semmle.label | 23 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:38:3:38:19 | [ExprStmt] sink(arr5.pop()); | semmle.order | 23 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:40:3:40:28 | [ExprStmt] sink(ar ... pop()); | semmle.label | 24 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:40:3:40:28 | [ExprStmt] sink(ar ... pop()); | semmle.order | 24 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:42:3:42:16 | [DeclStmt] var arr6 = ... | semmle.label | 25 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:42:3:42:16 | [DeclStmt] var arr6 = ... | semmle.order | 25 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:43:3:45:3 | [ForStmt] for (va ... i]; } | semmle.label | 26 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:43:3:45:3 | [ForStmt] for (va ... i]; } | semmle.order | 26 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:46:3:46:19 | [ExprStmt] sink(arr6.pop()); | semmle.label | 27 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:46:3:46:19 | [ExprStmt] sink(arr6.pop()); | semmle.order | 27 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:49:3:52:5 | [ExprStmt] ["sourc ... . }); | semmle.label | 28 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:49:3:52:5 | [ExprStmt] ["sourc ... . }); | semmle.order | 28 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:54:3:54:15 | [ExprStmt] sink(arr[0]); | semmle.label | 29 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:54:3:54:15 | [ExprStmt] sink(arr[0]); | semmle.order | 29 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:56:3:58:3 | [ForOfStmt] for (co ... OK } | semmle.label | 30 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:56:3:58:3 | [ForOfStmt] for (co ... OK } | semmle.order | 30 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | semmle.label | 31 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | semmle.order | 31 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | semmle.label | 32 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | semmle.order | 32 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:68:3:68:16 | [DeclStmt] var arr7 = ... | semmle.label | 33 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:68:3:68:16 | [DeclStmt] var arr7 = ... | semmle.order | 33 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:69:3:69:20 | [ExprStmt] arr7.push(...arr); | semmle.label | 34 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:69:3:69:20 | [ExprStmt] arr7.push(...arr); | semmle.order | 34 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | semmle.label | 35 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | semmle.order | 35 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:74:3:74:42 | [DeclStmt] const arrayFrom = ... | semmle.label | 36 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:74:3:74:42 | [DeclStmt] const arrayFrom = ... | semmle.order | 36 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:75:3:77:3 | [ForOfStmt] for (co ... OK } | semmle.label | 37 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:75:3:77:3 | [ForOfStmt] for (co ... OK } | semmle.order | 37 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:79:3:79:31 | [ExprStmt] sink(ar ... back)); | semmle.label | 38 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:79:3:79:31 | [ExprStmt] sink(ar ... back)); | semmle.order | 38 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:81:3:81:42 | [DeclStmt] const arrayFind = ... | semmle.label | 39 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:81:3:81:42 | [DeclStmt] const arrayFind = ... | semmle.order | 39 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:82:3:82:37 | [ExprStmt] sink(ar ... back)); | semmle.label | 40 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:82:3:82:37 | [ExprStmt] sink(ar ... back)); | semmle.order | 40 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:84:3:84:31 | [DeclStmt] const uniq = ... | semmle.label | 41 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:84:3:84:31 | [DeclStmt] const uniq = ... | semmle.order | 41 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:85:3:87:3 | [ForOfStmt] for (co ... OK } | semmle.label | 42 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:85:3:87:3 | [ForOfStmt] for (co ... OK } | semmle.order | 42 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:89:3:89:19 | [ExprStmt] sink(arr.at(-1)); | semmle.label | 43 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:89:3:89:19 | [ExprStmt] sink(arr.at(-1)); | semmle.order | 43 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:91:3:91:36 | [ExprStmt] sink([" ... => x)); | semmle.label | 44 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:91:3:91:36 | [ExprStmt] sink([" ... => x)); | semmle.order | 44 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:92:3:92:38 | [ExprStmt] sink([" ... !!x)); | semmle.label | 45 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:92:3:92:38 | [ExprStmt] sink([" ... !!x)); | semmle.order | 45 |
 | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | arrays.js:2:7:2:23 | [VariableDeclarator] source = "source" | semmle.label | 1 |
 | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | arrays.js:2:7:2:23 | [VariableDeclarator] source = "source" | semmle.order | 1 |
 | arrays.js:2:7:2:23 | [VariableDeclarator] source = "source" | arrays.js:2:7:2:12 | [VarDecl] source | semmle.label | 1 |
@@ -747,6 +782,42 @@ edges
 | arrays.js:30:8:30:15 | [DotExpr] arr4.pop | arrays.js:30:13:30:15 | [Label] pop | semmle.order | 2 |
 | arrays.js:30:8:30:17 | [MethodCallExpr] arr4.pop() | arrays.js:30:8:30:15 | [DotExpr] arr4.pop | semmle.label | 0 |
 | arrays.js:30:8:30:17 | [MethodCallExpr] arr4.pop() | arrays.js:30:8:30:15 | [DotExpr] arr4.pop | semmle.order | 0 |
+| arrays.js:32:3:32:24 | [DeclStmt] var arr4_variant = ... | arrays.js:32:7:32:23 | [VariableDeclarator] arr4_variant = [] | semmle.label | 1 |
+| arrays.js:32:3:32:24 | [DeclStmt] var arr4_variant = ... | arrays.js:32:7:32:23 | [VariableDeclarator] arr4_variant = [] | semmle.order | 1 |
+| arrays.js:32:7:32:23 | [VariableDeclarator] arr4_variant = [] | arrays.js:32:7:32:18 | [VarDecl] arr4_variant | semmle.label | 1 |
+| arrays.js:32:7:32:23 | [VariableDeclarator] arr4_variant = [] | arrays.js:32:7:32:18 | [VarDecl] arr4_variant | semmle.order | 1 |
+| arrays.js:32:7:32:23 | [VariableDeclarator] arr4_variant = [] | arrays.js:32:22:32:23 | [ArrayExpr] [] | semmle.label | 2 |
+| arrays.js:32:7:32:23 | [VariableDeclarator] arr4_variant = [] | arrays.js:32:22:32:23 | [ArrayExpr] [] | semmle.order | 2 |
+| arrays.js:33:3:33:21 | [DotExpr] arr4_variant.splice | arrays.js:33:3:33:14 | [VarRef] arr4_variant | semmle.label | 1 |
+| arrays.js:33:3:33:21 | [DotExpr] arr4_variant.splice | arrays.js:33:3:33:14 | [VarRef] arr4_variant | semmle.order | 1 |
+| arrays.js:33:3:33:21 | [DotExpr] arr4_variant.splice | arrays.js:33:16:33:21 | [Label] splice | semmle.label | 2 |
+| arrays.js:33:3:33:21 | [DotExpr] arr4_variant.splice | arrays.js:33:16:33:21 | [Label] splice | semmle.order | 2 |
+| arrays.js:33:3:33:45 | [MethodCallExpr] arr4_va ... ource") | arrays.js:33:3:33:21 | [DotExpr] arr4_variant.splice | semmle.label | 0 |
+| arrays.js:33:3:33:45 | [MethodCallExpr] arr4_va ... ource") | arrays.js:33:3:33:21 | [DotExpr] arr4_variant.splice | semmle.order | 0 |
+| arrays.js:33:3:33:45 | [MethodCallExpr] arr4_va ... ource") | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:33:3:33:45 | [MethodCallExpr] arr4_va ... ource") | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:33:3:33:46 | [ExprStmt] arr4_va ... urce"); | arrays.js:33:3:33:45 | [MethodCallExpr] arr4_va ... ource") | semmle.label | 1 |
+| arrays.js:33:3:33:46 | [ExprStmt] arr4_va ... urce"); | arrays.js:33:3:33:45 | [MethodCallExpr] arr4_va ... ource") | semmle.order | 1 |
+| arrays.js:34:3:34:18 | [DotExpr] arr4_variant.pop | arrays.js:34:3:34:14 | [VarRef] arr4_variant | semmle.label | 1 |
+| arrays.js:34:3:34:18 | [DotExpr] arr4_variant.pop | arrays.js:34:3:34:14 | [VarRef] arr4_variant | semmle.order | 1 |
+| arrays.js:34:3:34:18 | [DotExpr] arr4_variant.pop | arrays.js:34:16:34:18 | [Label] pop | semmle.label | 2 |
+| arrays.js:34:3:34:18 | [DotExpr] arr4_variant.pop | arrays.js:34:16:34:18 | [Label] pop | semmle.order | 2 |
+| arrays.js:34:3:34:20 | [MethodCallExpr] arr4_variant.pop() | arrays.js:34:3:34:18 | [DotExpr] arr4_variant.pop | semmle.label | 0 |
+| arrays.js:34:3:34:20 | [MethodCallExpr] arr4_variant.pop() | arrays.js:34:3:34:18 | [DotExpr] arr4_variant.pop | semmle.order | 0 |
+| arrays.js:34:3:34:21 | [ExprStmt] arr4_variant.pop(); | arrays.js:34:3:34:20 | [MethodCallExpr] arr4_variant.pop() | semmle.label | 1 |
+| arrays.js:34:3:34:21 | [ExprStmt] arr4_variant.pop(); | arrays.js:34:3:34:20 | [MethodCallExpr] arr4_variant.pop() | semmle.order | 1 |
+| arrays.js:35:3:35:26 | [CallExpr] sink(ar ... .pop()) | arrays.js:35:3:35:6 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:35:3:35:26 | [CallExpr] sink(ar ... .pop()) | arrays.js:35:3:35:6 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:35:3:35:26 | [CallExpr] sink(ar ... .pop()) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:35:3:35:26 | [CallExpr] sink(ar ... .pop()) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:35:3:35:27 | [ExprStmt] sink(ar ... pop()); | arrays.js:35:3:35:26 | [CallExpr] sink(ar ... .pop()) | semmle.label | 1 |
+| arrays.js:35:3:35:27 | [ExprStmt] sink(ar ... pop()); | arrays.js:35:3:35:26 | [CallExpr] sink(ar ... .pop()) | semmle.order | 1 |
+| arrays.js:35:8:35:23 | [DotExpr] arr4_variant.pop | arrays.js:35:8:35:19 | [VarRef] arr4_variant | semmle.label | 1 |
+| arrays.js:35:8:35:23 | [DotExpr] arr4_variant.pop | arrays.js:35:8:35:19 | [VarRef] arr4_variant | semmle.order | 1 |
+| arrays.js:35:8:35:23 | [DotExpr] arr4_variant.pop | arrays.js:35:21:35:23 | [Label] pop | semmle.label | 2 |
+| arrays.js:35:8:35:23 | [DotExpr] arr4_variant.pop | arrays.js:35:21:35:23 | [Label] pop | semmle.order | 2 |
+| arrays.js:35:8:35:25 | [MethodCallExpr] arr4_variant.pop() | arrays.js:35:8:35:23 | [DotExpr] arr4_variant.pop | semmle.label | 0 |
+| arrays.js:35:8:35:25 | [MethodCallExpr] arr4_variant.pop() | arrays.js:35:8:35:23 | [DotExpr] arr4_variant.pop | semmle.order | 0 |
 | arrays.js:37:3:37:29 | [DeclStmt] var arr5 = ... | arrays.js:37:7:37:28 | [VariableDeclarator] arr5 = ... t(arr4) | semmle.label | 1 |
 | arrays.js:37:3:37:29 | [DeclStmt] var arr5 = ... | arrays.js:37:7:37:28 | [VariableDeclarator] arr5 = ... t(arr4) | semmle.order | 1 |
 | arrays.js:37:7:37:28 | [VariableDeclarator] arr5 = ... t(arr4) | arrays.js:37:7:37:10 | [VarDecl] arr5 | semmle.label | 1 |
@@ -1193,6 +1264,16 @@ edges
 | file://:0:0:0:0 | (Arguments) | arrays.js:29:21:29:28 | [Literal] "source" | semmle.order | 2 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:30:8:30:17 | [MethodCallExpr] arr4.pop() | semmle.label | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:30:8:30:17 | [MethodCallExpr] arr4.pop() | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:33:23:33:23 | [Literal] 0 | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:33:23:33:23 | [Literal] 0 | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:33:26:33:26 | [Literal] 0 | semmle.label | 1 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:33:26:33:26 | [Literal] 0 | semmle.order | 1 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:33:29:33:34 | [Literal] "safe" | semmle.label | 2 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:33:29:33:34 | [Literal] "safe" | semmle.order | 2 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:33:37:33:44 | [Literal] "source" | semmle.label | 3 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:33:37:33:44 | [Literal] "source" | semmle.order | 3 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:35:8:35:25 | [MethodCallExpr] arr4_variant.pop() | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:35:8:35:25 | [MethodCallExpr] arr4_variant.pop() | semmle.order | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:37:24:37:27 | [VarRef] arr4 | semmle.label | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:37:24:37:27 | [VarRef] arr4 | semmle.order | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:38:8:38:17 | [MethodCallExpr] arr5.pop() | semmle.label | 0 |

--- a/javascript/ql/test/library-tests/Arrays/printAst.expected
+++ b/javascript/ql/test/library-tests/Arrays/printAst.expected
@@ -1,9 +1,9 @@
 nodes
-| arrays.js:1:1:88:2 | [ParExpr] (functi ... T OK }) | semmle.label | [ParExpr] (functi ... T OK }) |
-| arrays.js:1:1:88:3 | [ExprStmt] (functi ... OK }); | semmle.label | [ExprStmt] (functi ... OK }); |
-| arrays.js:1:1:88:3 | [ExprStmt] (functi ... OK }); | semmle.order | 1 |
-| arrays.js:1:2:88:1 | [FunctionExpr] functio ... OT OK } | semmle.label | [FunctionExpr] functio ... OT OK } |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | semmle.label | [BlockStmt] { let ... OT OK } |
+| arrays.js:1:1:93:2 | [ParExpr] (functi ... T OK }) | semmle.label | [ParExpr] (functi ... T OK }) |
+| arrays.js:1:1:93:3 | [ExprStmt] (functi ... OK }); | semmle.label | [ExprStmt] (functi ... OK }); |
+| arrays.js:1:1:93:3 | [ExprStmt] (functi ... OK }); | semmle.order | 1 |
+| arrays.js:1:2:93:1 | [FunctionExpr] functio ... OT OK } | semmle.label | [FunctionExpr] functio ... OT OK } |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | semmle.label | [BlockStmt] { let ... OT OK } |
 | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | semmle.label | [DeclStmt] let source = ... |
 | arrays.js:2:7:2:12 | [VarDecl] source | semmle.label | [VarDecl] source |
 | arrays.js:2:7:2:23 | [VariableDeclarator] source = "source" | semmle.label | [VariableDeclarator] source = "source" |
@@ -139,239 +139,239 @@ nodes
 | arrays.js:30:8:30:15 | [DotExpr] arr4.pop | semmle.label | [DotExpr] arr4.pop |
 | arrays.js:30:8:30:17 | [MethodCallExpr] arr4.pop() | semmle.label | [MethodCallExpr] arr4.pop() |
 | arrays.js:30:13:30:15 | [Label] pop | semmle.label | [Label] pop |
-| arrays.js:32:3:32:29 | [DeclStmt] var arr5 = ... | semmle.label | [DeclStmt] var arr5 = ... |
-| arrays.js:32:7:32:10 | [VarDecl] arr5 | semmle.label | [VarDecl] arr5 |
-| arrays.js:32:7:32:28 | [VariableDeclarator] arr5 = ... t(arr4) | semmle.label | [VariableDeclarator] arr5 = ... t(arr4) |
-| arrays.js:32:14:32:15 | [ArrayExpr] [] | semmle.label | [ArrayExpr] [] |
-| arrays.js:32:14:32:22 | [DotExpr] [].concat | semmle.label | [DotExpr] [].concat |
-| arrays.js:32:14:32:28 | [MethodCallExpr] [].concat(arr4) | semmle.label | [MethodCallExpr] [].concat(arr4) |
-| arrays.js:32:17:32:22 | [Label] concat | semmle.label | [Label] concat |
-| arrays.js:32:24:32:27 | [VarRef] arr4 | semmle.label | [VarRef] arr4 |
-| arrays.js:33:3:33:6 | [VarRef] sink | semmle.label | [VarRef] sink |
-| arrays.js:33:3:33:18 | [CallExpr] sink(arr5.pop()) | semmle.label | [CallExpr] sink(arr5.pop()) |
-| arrays.js:33:3:33:19 | [ExprStmt] sink(arr5.pop()); | semmle.label | [ExprStmt] sink(arr5.pop()); |
-| arrays.js:33:8:33:11 | [VarRef] arr5 | semmle.label | [VarRef] arr5 |
-| arrays.js:33:8:33:15 | [DotExpr] arr5.pop | semmle.label | [DotExpr] arr5.pop |
-| arrays.js:33:8:33:17 | [MethodCallExpr] arr5.pop() | semmle.label | [MethodCallExpr] arr5.pop() |
-| arrays.js:33:13:33:15 | [Label] pop | semmle.label | [Label] pop |
-| arrays.js:35:3:35:6 | [VarRef] sink | semmle.label | [VarRef] sink |
-| arrays.js:35:3:35:27 | [CallExpr] sink(ar ... .pop()) | semmle.label | [CallExpr] sink(ar ... .pop()) |
-| arrays.js:35:3:35:28 | [ExprStmt] sink(ar ... pop()); | semmle.label | [ExprStmt] sink(ar ... pop()); |
-| arrays.js:35:8:35:11 | [VarRef] arr5 | semmle.label | [VarRef] arr5 |
-| arrays.js:35:8:35:17 | [DotExpr] arr5.slice | semmle.label | [DotExpr] arr5.slice |
-| arrays.js:35:8:35:20 | [MethodCallExpr] arr5.slice(2) | semmle.label | [MethodCallExpr] arr5.slice(2) |
-| arrays.js:35:8:35:24 | [DotExpr] arr5.slice(2).pop | semmle.label | [DotExpr] arr5.slice(2).pop |
-| arrays.js:35:8:35:26 | [MethodCallExpr] arr5.slice(2).pop() | semmle.label | [MethodCallExpr] arr5.slice(2).pop() |
-| arrays.js:35:13:35:17 | [Label] slice | semmle.label | [Label] slice |
-| arrays.js:35:19:35:19 | [Literal] 2 | semmle.label | [Literal] 2 |
-| arrays.js:35:22:35:24 | [Label] pop | semmle.label | [Label] pop |
-| arrays.js:37:3:37:16 | [DeclStmt] var arr6 = ... | semmle.label | [DeclStmt] var arr6 = ... |
-| arrays.js:37:7:37:10 | [VarDecl] arr6 | semmle.label | [VarDecl] arr6 |
-| arrays.js:37:7:37:15 | [VariableDeclarator] arr6 = [] | semmle.label | [VariableDeclarator] arr6 = [] |
+| arrays.js:37:3:37:29 | [DeclStmt] var arr5 = ... | semmle.label | [DeclStmt] var arr5 = ... |
+| arrays.js:37:7:37:10 | [VarDecl] arr5 | semmle.label | [VarDecl] arr5 |
+| arrays.js:37:7:37:28 | [VariableDeclarator] arr5 = ... t(arr4) | semmle.label | [VariableDeclarator] arr5 = ... t(arr4) |
 | arrays.js:37:14:37:15 | [ArrayExpr] [] | semmle.label | [ArrayExpr] [] |
-| arrays.js:38:3:40:3 | [ForStmt] for (va ... i]; } | semmle.label | [ForStmt] for (va ... i]; } |
-| arrays.js:38:8:38:16 | [DeclStmt] var i = ... | semmle.label | [DeclStmt] var i = ... |
-| arrays.js:38:12:38:12 | [VarDecl] i | semmle.label | [VarDecl] i |
-| arrays.js:38:12:38:16 | [VariableDeclarator] i = 0 | semmle.label | [VariableDeclarator] i = 0 |
-| arrays.js:38:16:38:16 | [Literal] 0 | semmle.label | [Literal] 0 |
-| arrays.js:38:19:38:19 | [VarRef] i | semmle.label | [VarRef] i |
-| arrays.js:38:19:38:33 | [BinaryExpr] i < arr5.length | semmle.label | [BinaryExpr] i < arr5.length |
-| arrays.js:38:23:38:26 | [VarRef] arr5 | semmle.label | [VarRef] arr5 |
-| arrays.js:38:23:38:33 | [DotExpr] arr5.length | semmle.label | [DotExpr] arr5.length |
-| arrays.js:38:28:38:33 | [Label] length | semmle.label | [Label] length |
-| arrays.js:38:36:38:36 | [VarRef] i | semmle.label | [VarRef] i |
-| arrays.js:38:36:38:38 | [UpdateExpr] i++ | semmle.label | [UpdateExpr] i++ |
-| arrays.js:38:41:40:3 | [BlockStmt] { a ... i]; } | semmle.label | [BlockStmt] { a ... i]; } |
-| arrays.js:39:5:39:8 | [VarRef] arr6 | semmle.label | [VarRef] arr6 |
-| arrays.js:39:5:39:11 | [IndexExpr] arr6[i] | semmle.label | [IndexExpr] arr6[i] |
-| arrays.js:39:5:39:21 | [AssignExpr] arr6[i] = arr5[i] | semmle.label | [AssignExpr] arr6[i] = arr5[i] |
-| arrays.js:39:5:39:22 | [ExprStmt] arr6[i] = arr5[i]; | semmle.label | [ExprStmt] arr6[i] = arr5[i]; |
-| arrays.js:39:10:39:10 | [VarRef] i | semmle.label | [VarRef] i |
-| arrays.js:39:15:39:18 | [VarRef] arr5 | semmle.label | [VarRef] arr5 |
-| arrays.js:39:15:39:21 | [IndexExpr] arr5[i] | semmle.label | [IndexExpr] arr5[i] |
-| arrays.js:39:20:39:20 | [VarRef] i | semmle.label | [VarRef] i |
-| arrays.js:41:3:41:6 | [VarRef] sink | semmle.label | [VarRef] sink |
-| arrays.js:41:3:41:18 | [CallExpr] sink(arr6.pop()) | semmle.label | [CallExpr] sink(arr6.pop()) |
-| arrays.js:41:3:41:19 | [ExprStmt] sink(arr6.pop()); | semmle.label | [ExprStmt] sink(arr6.pop()); |
-| arrays.js:41:8:41:11 | [VarRef] arr6 | semmle.label | [VarRef] arr6 |
-| arrays.js:41:8:41:15 | [DotExpr] arr6.pop | semmle.label | [DotExpr] arr6.pop |
-| arrays.js:41:8:41:17 | [MethodCallExpr] arr6.pop() | semmle.label | [MethodCallExpr] arr6.pop() |
-| arrays.js:41:13:41:15 | [Label] pop | semmle.label | [Label] pop |
-| arrays.js:44:3:44:12 | [ArrayExpr] ["source"] | semmle.label | [ArrayExpr] ["source"] |
-| arrays.js:44:3:44:20 | [DotExpr] ["source"].forEach | semmle.label | [DotExpr] ["source"].forEach |
-| arrays.js:44:3:47:4 | [MethodCallExpr] ["sourc ... t. }) | semmle.label | [MethodCallExpr] ["sourc ... t. }) |
-| arrays.js:44:3:47:5 | [ExprStmt] ["sourc ... . }); | semmle.label | [ExprStmt] ["sourc ... . }); |
-| arrays.js:44:4:44:11 | [Literal] "source" | semmle.label | [Literal] "source" |
-| arrays.js:44:14:44:20 | [Label] forEach | semmle.label | [Label] forEach |
-| arrays.js:44:22:47:3 | [ArrowFunctionExpr] (e, i, ... nt. } | semmle.label | [ArrowFunctionExpr] (e, i, ... nt. } |
-| arrays.js:44:23:44:23 | [SimpleParameter] e | semmle.label | [SimpleParameter] e |
-| arrays.js:44:26:44:26 | [SimpleParameter] i | semmle.label | [SimpleParameter] i |
-| arrays.js:44:29:44:31 | [SimpleParameter] ary | semmle.label | [SimpleParameter] ary |
-| arrays.js:44:37:47:3 | [BlockStmt] { s ... nt. } | semmle.label | [BlockStmt] { s ... nt. } |
-| arrays.js:45:5:45:8 | [VarRef] sink | semmle.label | [VarRef] sink |
-| arrays.js:45:5:45:19 | [CallExpr] sink(ary.pop()) | semmle.label | [CallExpr] sink(ary.pop()) |
-| arrays.js:45:5:45:20 | [ExprStmt] sink(ary.pop()); | semmle.label | [ExprStmt] sink(ary.pop()); |
-| arrays.js:45:10:45:12 | [VarRef] ary | semmle.label | [VarRef] ary |
-| arrays.js:45:10:45:16 | [DotExpr] ary.pop | semmle.label | [DotExpr] ary.pop |
-| arrays.js:45:10:45:18 | [MethodCallExpr] ary.pop() | semmle.label | [MethodCallExpr] ary.pop() |
-| arrays.js:45:14:45:16 | [Label] pop | semmle.label | [Label] pop |
-| arrays.js:46:5:46:8 | [VarRef] sink | semmle.label | [VarRef] sink |
-| arrays.js:46:5:46:13 | [CallExpr] sink(ary) | semmle.label | [CallExpr] sink(ary) |
-| arrays.js:46:5:46:14 | [ExprStmt] sink(ary); | semmle.label | [ExprStmt] sink(ary); |
-| arrays.js:46:10:46:12 | [VarRef] ary | semmle.label | [VarRef] ary |
-| arrays.js:49:3:49:6 | [VarRef] sink | semmle.label | [VarRef] sink |
-| arrays.js:49:3:49:14 | [CallExpr] sink(arr[0]) | semmle.label | [CallExpr] sink(arr[0]) |
-| arrays.js:49:3:49:15 | [ExprStmt] sink(arr[0]); | semmle.label | [ExprStmt] sink(arr[0]); |
-| arrays.js:49:8:49:10 | [VarRef] arr | semmle.label | [VarRef] arr |
-| arrays.js:49:8:49:13 | [IndexExpr] arr[0] | semmle.label | [IndexExpr] arr[0] |
-| arrays.js:49:12:49:12 | [Literal] 0 | semmle.label | [Literal] 0 |
-| arrays.js:51:3:53:3 | [ForOfStmt] for (co ... OK } | semmle.label | [ForOfStmt] for (co ... OK } |
-| arrays.js:51:8:51:14 | [DeclStmt] const x = ... | semmle.label | [DeclStmt] const x = ... |
-| arrays.js:51:14:51:14 | [VarDecl] x | semmle.label | [VarDecl] x |
-| arrays.js:51:14:51:14 | [VariableDeclarator] x | semmle.label | [VariableDeclarator] x |
-| arrays.js:51:19:51:21 | [VarRef] arr | semmle.label | [VarRef] arr |
-| arrays.js:51:24:53:3 | [BlockStmt] { s ... OK } | semmle.label | [BlockStmt] { s ... OK } |
-| arrays.js:52:5:52:8 | [VarRef] sink | semmle.label | [VarRef] sink |
-| arrays.js:52:5:52:11 | [CallExpr] sink(x) | semmle.label | [CallExpr] sink(x) |
-| arrays.js:52:5:52:12 | [ExprStmt] sink(x); | semmle.label | [ExprStmt] sink(x); |
-| arrays.js:52:10:52:10 | [VarRef] x | semmle.label | [VarRef] x |
-| arrays.js:55:3:57:3 | [ForOfStmt] for (co ... OK } | semmle.label | [ForOfStmt] for (co ... OK } |
-| arrays.js:55:8:55:14 | [DeclStmt] const x = ... | semmle.label | [DeclStmt] const x = ... |
-| arrays.js:55:14:55:14 | [VarDecl] x | semmle.label | [VarDecl] x |
-| arrays.js:55:14:55:14 | [VariableDeclarator] x | semmle.label | [VariableDeclarator] x |
-| arrays.js:55:19:55:23 | [VarRef] Array | semmle.label | [VarRef] Array |
-| arrays.js:55:19:55:28 | [DotExpr] Array.from | semmle.label | [DotExpr] Array.from |
-| arrays.js:55:19:55:33 | [MethodCallExpr] Array.from(arr) | semmle.label | [MethodCallExpr] Array.from(arr) |
-| arrays.js:55:25:55:28 | [Label] from | semmle.label | [Label] from |
-| arrays.js:55:30:55:32 | [VarRef] arr | semmle.label | [VarRef] arr |
-| arrays.js:55:36:57:3 | [BlockStmt] { s ... OK } | semmle.label | [BlockStmt] { s ... OK } |
-| arrays.js:56:5:56:8 | [VarRef] sink | semmle.label | [VarRef] sink |
-| arrays.js:56:5:56:11 | [CallExpr] sink(x) | semmle.label | [CallExpr] sink(x) |
-| arrays.js:56:5:56:12 | [ExprStmt] sink(x); | semmle.label | [ExprStmt] sink(x); |
-| arrays.js:56:10:56:10 | [VarRef] x | semmle.label | [VarRef] x |
-| arrays.js:59:3:61:3 | [ForOfStmt] for (co ... OK } | semmle.label | [ForOfStmt] for (co ... OK } |
-| arrays.js:59:8:59:14 | [DeclStmt] const x = ... | semmle.label | [DeclStmt] const x = ... |
-| arrays.js:59:14:59:14 | [VarDecl] x | semmle.label | [VarDecl] x |
-| arrays.js:59:14:59:14 | [VariableDeclarator] x | semmle.label | [VariableDeclarator] x |
-| arrays.js:59:19:59:26 | [ArrayExpr] [...arr] | semmle.label | [ArrayExpr] [...arr] |
-| arrays.js:59:20:59:25 | [SpreadElement] ...arr | semmle.label | [SpreadElement] ...arr |
-| arrays.js:59:23:59:25 | [VarRef] arr | semmle.label | [VarRef] arr |
-| arrays.js:59:29:61:3 | [BlockStmt] { s ... OK } | semmle.label | [BlockStmt] { s ... OK } |
-| arrays.js:60:5:60:8 | [VarRef] sink | semmle.label | [VarRef] sink |
-| arrays.js:60:5:60:11 | [CallExpr] sink(x) | semmle.label | [CallExpr] sink(x) |
-| arrays.js:60:5:60:12 | [ExprStmt] sink(x); | semmle.label | [ExprStmt] sink(x); |
-| arrays.js:60:10:60:10 | [VarRef] x | semmle.label | [VarRef] x |
-| arrays.js:63:3:63:16 | [DeclStmt] var arr7 = ... | semmle.label | [DeclStmt] var arr7 = ... |
-| arrays.js:63:7:63:10 | [VarDecl] arr7 | semmle.label | [VarDecl] arr7 |
-| arrays.js:63:7:63:15 | [VariableDeclarator] arr7 = [] | semmle.label | [VariableDeclarator] arr7 = [] |
-| arrays.js:63:14:63:15 | [ArrayExpr] [] | semmle.label | [ArrayExpr] [] |
-| arrays.js:64:3:64:6 | [VarRef] arr7 | semmle.label | [VarRef] arr7 |
-| arrays.js:64:3:64:11 | [DotExpr] arr7.push | semmle.label | [DotExpr] arr7.push |
-| arrays.js:64:3:64:19 | [MethodCallExpr] arr7.push(...arr) | semmle.label | [MethodCallExpr] arr7.push(...arr) |
-| arrays.js:64:3:64:20 | [ExprStmt] arr7.push(...arr); | semmle.label | [ExprStmt] arr7.push(...arr); |
-| arrays.js:64:8:64:11 | [Label] push | semmle.label | [Label] push |
-| arrays.js:64:13:64:18 | [SpreadElement] ...arr | semmle.label | [SpreadElement] ...arr |
-| arrays.js:64:16:64:18 | [VarRef] arr | semmle.label | [VarRef] arr |
-| arrays.js:65:3:67:3 | [ForOfStmt] for (co ... OK } | semmle.label | [ForOfStmt] for (co ... OK } |
-| arrays.js:65:8:65:14 | [DeclStmt] const x = ... | semmle.label | [DeclStmt] const x = ... |
-| arrays.js:65:14:65:14 | [VarDecl] x | semmle.label | [VarDecl] x |
-| arrays.js:65:14:65:14 | [VariableDeclarator] x | semmle.label | [VariableDeclarator] x |
-| arrays.js:65:19:65:22 | [VarRef] arr7 | semmle.label | [VarRef] arr7 |
-| arrays.js:65:25:67:3 | [BlockStmt] { s ... OK } | semmle.label | [BlockStmt] { s ... OK } |
-| arrays.js:66:5:66:8 | [VarRef] sink | semmle.label | [VarRef] sink |
-| arrays.js:66:5:66:11 | [CallExpr] sink(x) | semmle.label | [CallExpr] sink(x) |
-| arrays.js:66:5:66:12 | [ExprStmt] sink(x); | semmle.label | [ExprStmt] sink(x); |
-| arrays.js:66:10:66:10 | [VarRef] x | semmle.label | [VarRef] x |
-| arrays.js:69:3:69:42 | [DeclStmt] const arrayFrom = ... | semmle.label | [DeclStmt] const arrayFrom = ... |
-| arrays.js:69:9:69:17 | [VarDecl] arrayFrom | semmle.label | [VarDecl] arrayFrom |
-| arrays.js:69:9:69:41 | [VariableDeclarator] arrayFr ... -from") | semmle.label | [VariableDeclarator] arrayFr ... -from") |
-| arrays.js:69:21:69:27 | [VarRef] require | semmle.label | [VarRef] require |
-| arrays.js:69:21:69:41 | [CallExpr] require ... -from") | semmle.label | [CallExpr] require ... -from") |
-| arrays.js:69:29:69:40 | [Literal] "array-from" | semmle.label | [Literal] "array-from" |
+| arrays.js:37:14:37:22 | [DotExpr] [].concat | semmle.label | [DotExpr] [].concat |
+| arrays.js:37:14:37:28 | [MethodCallExpr] [].concat(arr4) | semmle.label | [MethodCallExpr] [].concat(arr4) |
+| arrays.js:37:17:37:22 | [Label] concat | semmle.label | [Label] concat |
+| arrays.js:37:24:37:27 | [VarRef] arr4 | semmle.label | [VarRef] arr4 |
+| arrays.js:38:3:38:6 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:38:3:38:18 | [CallExpr] sink(arr5.pop()) | semmle.label | [CallExpr] sink(arr5.pop()) |
+| arrays.js:38:3:38:19 | [ExprStmt] sink(arr5.pop()); | semmle.label | [ExprStmt] sink(arr5.pop()); |
+| arrays.js:38:8:38:11 | [VarRef] arr5 | semmle.label | [VarRef] arr5 |
+| arrays.js:38:8:38:15 | [DotExpr] arr5.pop | semmle.label | [DotExpr] arr5.pop |
+| arrays.js:38:8:38:17 | [MethodCallExpr] arr5.pop() | semmle.label | [MethodCallExpr] arr5.pop() |
+| arrays.js:38:13:38:15 | [Label] pop | semmle.label | [Label] pop |
+| arrays.js:40:3:40:6 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:40:3:40:27 | [CallExpr] sink(ar ... .pop()) | semmle.label | [CallExpr] sink(ar ... .pop()) |
+| arrays.js:40:3:40:28 | [ExprStmt] sink(ar ... pop()); | semmle.label | [ExprStmt] sink(ar ... pop()); |
+| arrays.js:40:8:40:11 | [VarRef] arr5 | semmle.label | [VarRef] arr5 |
+| arrays.js:40:8:40:17 | [DotExpr] arr5.slice | semmle.label | [DotExpr] arr5.slice |
+| arrays.js:40:8:40:20 | [MethodCallExpr] arr5.slice(2) | semmle.label | [MethodCallExpr] arr5.slice(2) |
+| arrays.js:40:8:40:24 | [DotExpr] arr5.slice(2).pop | semmle.label | [DotExpr] arr5.slice(2).pop |
+| arrays.js:40:8:40:26 | [MethodCallExpr] arr5.slice(2).pop() | semmle.label | [MethodCallExpr] arr5.slice(2).pop() |
+| arrays.js:40:13:40:17 | [Label] slice | semmle.label | [Label] slice |
+| arrays.js:40:19:40:19 | [Literal] 2 | semmle.label | [Literal] 2 |
+| arrays.js:40:22:40:24 | [Label] pop | semmle.label | [Label] pop |
+| arrays.js:42:3:42:16 | [DeclStmt] var arr6 = ... | semmle.label | [DeclStmt] var arr6 = ... |
+| arrays.js:42:7:42:10 | [VarDecl] arr6 | semmle.label | [VarDecl] arr6 |
+| arrays.js:42:7:42:15 | [VariableDeclarator] arr6 = [] | semmle.label | [VariableDeclarator] arr6 = [] |
+| arrays.js:42:14:42:15 | [ArrayExpr] [] | semmle.label | [ArrayExpr] [] |
+| arrays.js:43:3:45:3 | [ForStmt] for (va ... i]; } | semmle.label | [ForStmt] for (va ... i]; } |
+| arrays.js:43:8:43:16 | [DeclStmt] var i = ... | semmle.label | [DeclStmt] var i = ... |
+| arrays.js:43:12:43:12 | [VarDecl] i | semmle.label | [VarDecl] i |
+| arrays.js:43:12:43:16 | [VariableDeclarator] i = 0 | semmle.label | [VariableDeclarator] i = 0 |
+| arrays.js:43:16:43:16 | [Literal] 0 | semmle.label | [Literal] 0 |
+| arrays.js:43:19:43:19 | [VarRef] i | semmle.label | [VarRef] i |
+| arrays.js:43:19:43:33 | [BinaryExpr] i < arr5.length | semmle.label | [BinaryExpr] i < arr5.length |
+| arrays.js:43:23:43:26 | [VarRef] arr5 | semmle.label | [VarRef] arr5 |
+| arrays.js:43:23:43:33 | [DotExpr] arr5.length | semmle.label | [DotExpr] arr5.length |
+| arrays.js:43:28:43:33 | [Label] length | semmle.label | [Label] length |
+| arrays.js:43:36:43:36 | [VarRef] i | semmle.label | [VarRef] i |
+| arrays.js:43:36:43:38 | [UpdateExpr] i++ | semmle.label | [UpdateExpr] i++ |
+| arrays.js:43:41:45:3 | [BlockStmt] { a ... i]; } | semmle.label | [BlockStmt] { a ... i]; } |
+| arrays.js:44:5:44:8 | [VarRef] arr6 | semmle.label | [VarRef] arr6 |
+| arrays.js:44:5:44:11 | [IndexExpr] arr6[i] | semmle.label | [IndexExpr] arr6[i] |
+| arrays.js:44:5:44:21 | [AssignExpr] arr6[i] = arr5[i] | semmle.label | [AssignExpr] arr6[i] = arr5[i] |
+| arrays.js:44:5:44:22 | [ExprStmt] arr6[i] = arr5[i]; | semmle.label | [ExprStmt] arr6[i] = arr5[i]; |
+| arrays.js:44:10:44:10 | [VarRef] i | semmle.label | [VarRef] i |
+| arrays.js:44:15:44:18 | [VarRef] arr5 | semmle.label | [VarRef] arr5 |
+| arrays.js:44:15:44:21 | [IndexExpr] arr5[i] | semmle.label | [IndexExpr] arr5[i] |
+| arrays.js:44:20:44:20 | [VarRef] i | semmle.label | [VarRef] i |
+| arrays.js:46:3:46:6 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:46:3:46:18 | [CallExpr] sink(arr6.pop()) | semmle.label | [CallExpr] sink(arr6.pop()) |
+| arrays.js:46:3:46:19 | [ExprStmt] sink(arr6.pop()); | semmle.label | [ExprStmt] sink(arr6.pop()); |
+| arrays.js:46:8:46:11 | [VarRef] arr6 | semmle.label | [VarRef] arr6 |
+| arrays.js:46:8:46:15 | [DotExpr] arr6.pop | semmle.label | [DotExpr] arr6.pop |
+| arrays.js:46:8:46:17 | [MethodCallExpr] arr6.pop() | semmle.label | [MethodCallExpr] arr6.pop() |
+| arrays.js:46:13:46:15 | [Label] pop | semmle.label | [Label] pop |
+| arrays.js:49:3:49:12 | [ArrayExpr] ["source"] | semmle.label | [ArrayExpr] ["source"] |
+| arrays.js:49:3:49:20 | [DotExpr] ["source"].forEach | semmle.label | [DotExpr] ["source"].forEach |
+| arrays.js:49:3:52:4 | [MethodCallExpr] ["sourc ... t. }) | semmle.label | [MethodCallExpr] ["sourc ... t. }) |
+| arrays.js:49:3:52:5 | [ExprStmt] ["sourc ... . }); | semmle.label | [ExprStmt] ["sourc ... . }); |
+| arrays.js:49:4:49:11 | [Literal] "source" | semmle.label | [Literal] "source" |
+| arrays.js:49:14:49:20 | [Label] forEach | semmle.label | [Label] forEach |
+| arrays.js:49:22:52:3 | [ArrowFunctionExpr] (e, i, ... nt. } | semmle.label | [ArrowFunctionExpr] (e, i, ... nt. } |
+| arrays.js:49:23:49:23 | [SimpleParameter] e | semmle.label | [SimpleParameter] e |
+| arrays.js:49:26:49:26 | [SimpleParameter] i | semmle.label | [SimpleParameter] i |
+| arrays.js:49:29:49:31 | [SimpleParameter] ary | semmle.label | [SimpleParameter] ary |
+| arrays.js:49:37:52:3 | [BlockStmt] { s ... nt. } | semmle.label | [BlockStmt] { s ... nt. } |
+| arrays.js:50:5:50:8 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:50:5:50:19 | [CallExpr] sink(ary.pop()) | semmle.label | [CallExpr] sink(ary.pop()) |
+| arrays.js:50:5:50:20 | [ExprStmt] sink(ary.pop()); | semmle.label | [ExprStmt] sink(ary.pop()); |
+| arrays.js:50:10:50:12 | [VarRef] ary | semmle.label | [VarRef] ary |
+| arrays.js:50:10:50:16 | [DotExpr] ary.pop | semmle.label | [DotExpr] ary.pop |
+| arrays.js:50:10:50:18 | [MethodCallExpr] ary.pop() | semmle.label | [MethodCallExpr] ary.pop() |
+| arrays.js:50:14:50:16 | [Label] pop | semmle.label | [Label] pop |
+| arrays.js:51:5:51:8 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:51:5:51:13 | [CallExpr] sink(ary) | semmle.label | [CallExpr] sink(ary) |
+| arrays.js:51:5:51:14 | [ExprStmt] sink(ary); | semmle.label | [ExprStmt] sink(ary); |
+| arrays.js:51:10:51:12 | [VarRef] ary | semmle.label | [VarRef] ary |
+| arrays.js:54:3:54:6 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:54:3:54:14 | [CallExpr] sink(arr[0]) | semmle.label | [CallExpr] sink(arr[0]) |
+| arrays.js:54:3:54:15 | [ExprStmt] sink(arr[0]); | semmle.label | [ExprStmt] sink(arr[0]); |
+| arrays.js:54:8:54:10 | [VarRef] arr | semmle.label | [VarRef] arr |
+| arrays.js:54:8:54:13 | [IndexExpr] arr[0] | semmle.label | [IndexExpr] arr[0] |
+| arrays.js:54:12:54:12 | [Literal] 0 | semmle.label | [Literal] 0 |
+| arrays.js:56:3:58:3 | [ForOfStmt] for (co ... OK } | semmle.label | [ForOfStmt] for (co ... OK } |
+| arrays.js:56:8:56:14 | [DeclStmt] const x = ... | semmle.label | [DeclStmt] const x = ... |
+| arrays.js:56:14:56:14 | [VarDecl] x | semmle.label | [VarDecl] x |
+| arrays.js:56:14:56:14 | [VariableDeclarator] x | semmle.label | [VariableDeclarator] x |
+| arrays.js:56:19:56:21 | [VarRef] arr | semmle.label | [VarRef] arr |
+| arrays.js:56:24:58:3 | [BlockStmt] { s ... OK } | semmle.label | [BlockStmt] { s ... OK } |
+| arrays.js:57:5:57:8 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:57:5:57:11 | [CallExpr] sink(x) | semmle.label | [CallExpr] sink(x) |
+| arrays.js:57:5:57:12 | [ExprStmt] sink(x); | semmle.label | [ExprStmt] sink(x); |
+| arrays.js:57:10:57:10 | [VarRef] x | semmle.label | [VarRef] x |
+| arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | semmle.label | [ForOfStmt] for (co ... OK } |
+| arrays.js:60:8:60:14 | [DeclStmt] const x = ... | semmle.label | [DeclStmt] const x = ... |
+| arrays.js:60:14:60:14 | [VarDecl] x | semmle.label | [VarDecl] x |
+| arrays.js:60:14:60:14 | [VariableDeclarator] x | semmle.label | [VariableDeclarator] x |
+| arrays.js:60:19:60:23 | [VarRef] Array | semmle.label | [VarRef] Array |
+| arrays.js:60:19:60:28 | [DotExpr] Array.from | semmle.label | [DotExpr] Array.from |
+| arrays.js:60:19:60:33 | [MethodCallExpr] Array.from(arr) | semmle.label | [MethodCallExpr] Array.from(arr) |
+| arrays.js:60:25:60:28 | [Label] from | semmle.label | [Label] from |
+| arrays.js:60:30:60:32 | [VarRef] arr | semmle.label | [VarRef] arr |
+| arrays.js:60:36:62:3 | [BlockStmt] { s ... OK } | semmle.label | [BlockStmt] { s ... OK } |
+| arrays.js:61:5:61:8 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:61:5:61:11 | [CallExpr] sink(x) | semmle.label | [CallExpr] sink(x) |
+| arrays.js:61:5:61:12 | [ExprStmt] sink(x); | semmle.label | [ExprStmt] sink(x); |
+| arrays.js:61:10:61:10 | [VarRef] x | semmle.label | [VarRef] x |
+| arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | semmle.label | [ForOfStmt] for (co ... OK } |
+| arrays.js:64:8:64:14 | [DeclStmt] const x = ... | semmle.label | [DeclStmt] const x = ... |
+| arrays.js:64:14:64:14 | [VarDecl] x | semmle.label | [VarDecl] x |
+| arrays.js:64:14:64:14 | [VariableDeclarator] x | semmle.label | [VariableDeclarator] x |
+| arrays.js:64:19:64:26 | [ArrayExpr] [...arr] | semmle.label | [ArrayExpr] [...arr] |
+| arrays.js:64:20:64:25 | [SpreadElement] ...arr | semmle.label | [SpreadElement] ...arr |
+| arrays.js:64:23:64:25 | [VarRef] arr | semmle.label | [VarRef] arr |
+| arrays.js:64:29:66:3 | [BlockStmt] { s ... OK } | semmle.label | [BlockStmt] { s ... OK } |
+| arrays.js:65:5:65:8 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:65:5:65:11 | [CallExpr] sink(x) | semmle.label | [CallExpr] sink(x) |
+| arrays.js:65:5:65:12 | [ExprStmt] sink(x); | semmle.label | [ExprStmt] sink(x); |
+| arrays.js:65:10:65:10 | [VarRef] x | semmle.label | [VarRef] x |
+| arrays.js:68:3:68:16 | [DeclStmt] var arr7 = ... | semmle.label | [DeclStmt] var arr7 = ... |
+| arrays.js:68:7:68:10 | [VarDecl] arr7 | semmle.label | [VarDecl] arr7 |
+| arrays.js:68:7:68:15 | [VariableDeclarator] arr7 = [] | semmle.label | [VariableDeclarator] arr7 = [] |
+| arrays.js:68:14:68:15 | [ArrayExpr] [] | semmle.label | [ArrayExpr] [] |
+| arrays.js:69:3:69:6 | [VarRef] arr7 | semmle.label | [VarRef] arr7 |
+| arrays.js:69:3:69:11 | [DotExpr] arr7.push | semmle.label | [DotExpr] arr7.push |
+| arrays.js:69:3:69:19 | [MethodCallExpr] arr7.push(...arr) | semmle.label | [MethodCallExpr] arr7.push(...arr) |
+| arrays.js:69:3:69:20 | [ExprStmt] arr7.push(...arr); | semmle.label | [ExprStmt] arr7.push(...arr); |
+| arrays.js:69:8:69:11 | [Label] push | semmle.label | [Label] push |
+| arrays.js:69:13:69:18 | [SpreadElement] ...arr | semmle.label | [SpreadElement] ...arr |
+| arrays.js:69:16:69:18 | [VarRef] arr | semmle.label | [VarRef] arr |
 | arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | semmle.label | [ForOfStmt] for (co ... OK } |
 | arrays.js:70:8:70:14 | [DeclStmt] const x = ... | semmle.label | [DeclStmt] const x = ... |
 | arrays.js:70:14:70:14 | [VarDecl] x | semmle.label | [VarDecl] x |
 | arrays.js:70:14:70:14 | [VariableDeclarator] x | semmle.label | [VariableDeclarator] x |
-| arrays.js:70:19:70:27 | [VarRef] arrayFrom | semmle.label | [VarRef] arrayFrom |
-| arrays.js:70:19:70:32 | [CallExpr] arrayFrom(arr) | semmle.label | [CallExpr] arrayFrom(arr) |
-| arrays.js:70:29:70:31 | [VarRef] arr | semmle.label | [VarRef] arr |
-| arrays.js:70:35:72:3 | [BlockStmt] { s ... OK } | semmle.label | [BlockStmt] { s ... OK } |
+| arrays.js:70:19:70:22 | [VarRef] arr7 | semmle.label | [VarRef] arr7 |
+| arrays.js:70:25:72:3 | [BlockStmt] { s ... OK } | semmle.label | [BlockStmt] { s ... OK } |
 | arrays.js:71:5:71:8 | [VarRef] sink | semmle.label | [VarRef] sink |
 | arrays.js:71:5:71:11 | [CallExpr] sink(x) | semmle.label | [CallExpr] sink(x) |
 | arrays.js:71:5:71:12 | [ExprStmt] sink(x); | semmle.label | [ExprStmt] sink(x); |
 | arrays.js:71:10:71:10 | [VarRef] x | semmle.label | [VarRef] x |
-| arrays.js:74:3:74:6 | [VarRef] sink | semmle.label | [VarRef] sink |
-| arrays.js:74:3:74:30 | [CallExpr] sink(ar ... lback)) | semmle.label | [CallExpr] sink(ar ... lback)) |
-| arrays.js:74:3:74:31 | [ExprStmt] sink(ar ... back)); | semmle.label | [ExprStmt] sink(ar ... back)); |
-| arrays.js:74:8:74:10 | [VarRef] arr | semmle.label | [VarRef] arr |
-| arrays.js:74:8:74:15 | [DotExpr] arr.find | semmle.label | [DotExpr] arr.find |
-| arrays.js:74:8:74:29 | [MethodCallExpr] arr.fin ... llback) | semmle.label | [MethodCallExpr] arr.fin ... llback) |
-| arrays.js:74:12:74:15 | [Label] find | semmle.label | [Label] find |
-| arrays.js:74:17:74:28 | [VarRef] someCallback | semmle.label | [VarRef] someCallback |
-| arrays.js:76:3:76:42 | [DeclStmt] const arrayFind = ... | semmle.label | [DeclStmt] const arrayFind = ... |
-| arrays.js:76:9:76:17 | [VarDecl] arrayFind | semmle.label | [VarDecl] arrayFind |
-| arrays.js:76:9:76:41 | [VariableDeclarator] arrayFi ... -find") | semmle.label | [VariableDeclarator] arrayFi ... -find") |
-| arrays.js:76:21:76:27 | [VarRef] require | semmle.label | [VarRef] require |
-| arrays.js:76:21:76:41 | [CallExpr] require ... -find") | semmle.label | [CallExpr] require ... -find") |
-| arrays.js:76:29:76:40 | [Literal] "array-find" | semmle.label | [Literal] "array-find" |
-| arrays.js:77:3:77:6 | [VarRef] sink | semmle.label | [VarRef] sink |
-| arrays.js:77:3:77:36 | [CallExpr] sink(ar ... lback)) | semmle.label | [CallExpr] sink(ar ... lback)) |
-| arrays.js:77:3:77:37 | [ExprStmt] sink(ar ... back)); | semmle.label | [ExprStmt] sink(ar ... back)); |
-| arrays.js:77:8:77:16 | [VarRef] arrayFind | semmle.label | [VarRef] arrayFind |
-| arrays.js:77:8:77:35 | [CallExpr] arrayFi ... llback) | semmle.label | [CallExpr] arrayFi ... llback) |
-| arrays.js:77:18:77:20 | [VarRef] arr | semmle.label | [VarRef] arr |
-| arrays.js:77:23:77:34 | [VarRef] someCallback | semmle.label | [VarRef] someCallback |
-| arrays.js:79:3:79:31 | [DeclStmt] const uniq = ... | semmle.label | [DeclStmt] const uniq = ... |
-| arrays.js:79:9:79:12 | [VarDecl] uniq | semmle.label | [VarDecl] uniq |
-| arrays.js:79:9:79:30 | [VariableDeclarator] uniq = ... "uniq") | semmle.label | [VariableDeclarator] uniq = ... "uniq") |
-| arrays.js:79:16:79:22 | [VarRef] require | semmle.label | [VarRef] require |
-| arrays.js:79:16:79:30 | [CallExpr] require("uniq") | semmle.label | [CallExpr] require("uniq") |
-| arrays.js:79:24:79:29 | [Literal] "uniq" | semmle.label | [Literal] "uniq" |
-| arrays.js:80:3:82:3 | [ForOfStmt] for (co ... OK } | semmle.label | [ForOfStmt] for (co ... OK } |
-| arrays.js:80:8:80:14 | [DeclStmt] const x = ... | semmle.label | [DeclStmt] const x = ... |
-| arrays.js:80:14:80:14 | [VarDecl] x | semmle.label | [VarDecl] x |
-| arrays.js:80:14:80:14 | [VariableDeclarator] x | semmle.label | [VariableDeclarator] x |
-| arrays.js:80:19:80:22 | [VarRef] uniq | semmle.label | [VarRef] uniq |
-| arrays.js:80:19:80:27 | [CallExpr] uniq(arr) | semmle.label | [CallExpr] uniq(arr) |
-| arrays.js:80:24:80:26 | [VarRef] arr | semmle.label | [VarRef] arr |
-| arrays.js:80:30:82:3 | [BlockStmt] { s ... OK } | semmle.label | [BlockStmt] { s ... OK } |
-| arrays.js:81:5:81:8 | [VarRef] sink | semmle.label | [VarRef] sink |
-| arrays.js:81:5:81:11 | [CallExpr] sink(x) | semmle.label | [CallExpr] sink(x) |
-| arrays.js:81:5:81:12 | [ExprStmt] sink(x); | semmle.label | [ExprStmt] sink(x); |
-| arrays.js:81:10:81:10 | [VarRef] x | semmle.label | [VarRef] x |
-| arrays.js:84:3:84:6 | [VarRef] sink | semmle.label | [VarRef] sink |
-| arrays.js:84:3:84:18 | [CallExpr] sink(arr.at(-1)) | semmle.label | [CallExpr] sink(arr.at(-1)) |
-| arrays.js:84:3:84:19 | [ExprStmt] sink(arr.at(-1)); | semmle.label | [ExprStmt] sink(arr.at(-1)); |
-| arrays.js:84:8:84:10 | [VarRef] arr | semmle.label | [VarRef] arr |
-| arrays.js:84:8:84:13 | [DotExpr] arr.at | semmle.label | [DotExpr] arr.at |
-| arrays.js:84:8:84:17 | [MethodCallExpr] arr.at(-1) | semmle.label | [MethodCallExpr] arr.at(-1) |
-| arrays.js:84:12:84:13 | [Label] at | semmle.label | [Label] at |
-| arrays.js:84:15:84:16 | [UnaryExpr] -1 | semmle.label | [UnaryExpr] -1 |
-| arrays.js:84:16:84:16 | [Literal] 1 | semmle.label | [Literal] 1 |
-| arrays.js:86:3:86:6 | [VarRef] sink | semmle.label | [VarRef] sink |
-| arrays.js:86:3:86:35 | [CallExpr] sink([" ... => x)) | semmle.label | [CallExpr] sink([" ... => x)) |
-| arrays.js:86:3:86:36 | [ExprStmt] sink([" ... => x)); | semmle.label | [ExprStmt] sink([" ... => x)); |
-| arrays.js:86:8:86:17 | [ArrayExpr] ["source"] | semmle.label | [ArrayExpr] ["source"] |
-| arrays.js:86:8:86:24 | [DotExpr] ["source"].filter | semmle.label | [DotExpr] ["source"].filter |
-| arrays.js:86:8:86:34 | [MethodCallExpr] ["sourc ... ) => x) | semmle.label | [MethodCallExpr] ["sourc ... ) => x) |
-| arrays.js:86:9:86:16 | [Literal] "source" | semmle.label | [Literal] "source" |
-| arrays.js:86:19:86:24 | [Label] filter | semmle.label | [Label] filter |
-| arrays.js:86:26:86:33 | [ArrowFunctionExpr] (x) => x | semmle.label | [ArrowFunctionExpr] (x) => x |
-| arrays.js:86:27:86:27 | [SimpleParameter] x | semmle.label | [SimpleParameter] x |
-| arrays.js:86:33:86:33 | [VarRef] x | semmle.label | [VarRef] x |
-| arrays.js:87:3:87:6 | [VarRef] sink | semmle.label | [VarRef] sink |
-| arrays.js:87:3:87:37 | [CallExpr] sink([" ... > !!x)) | semmle.label | [CallExpr] sink([" ... > !!x)) |
-| arrays.js:87:3:87:38 | [ExprStmt] sink([" ... !!x)); | semmle.label | [ExprStmt] sink([" ... !!x)); |
-| arrays.js:87:8:87:17 | [ArrayExpr] ["source"] | semmle.label | [ArrayExpr] ["source"] |
-| arrays.js:87:8:87:24 | [DotExpr] ["source"].filter | semmle.label | [DotExpr] ["source"].filter |
-| arrays.js:87:8:87:36 | [MethodCallExpr] ["sourc ... => !!x) | semmle.label | [MethodCallExpr] ["sourc ... => !!x) |
-| arrays.js:87:9:87:16 | [Literal] "source" | semmle.label | [Literal] "source" |
-| arrays.js:87:19:87:24 | [Label] filter | semmle.label | [Label] filter |
-| arrays.js:87:26:87:35 | [ArrowFunctionExpr] (x) => !!x | semmle.label | [ArrowFunctionExpr] (x) => !!x |
-| arrays.js:87:27:87:27 | [SimpleParameter] x | semmle.label | [SimpleParameter] x |
-| arrays.js:87:33:87:35 | [UnaryExpr] !!x | semmle.label | [UnaryExpr] !!x |
-| arrays.js:87:34:87:35 | [UnaryExpr] !x | semmle.label | [UnaryExpr] !x |
-| arrays.js:87:35:87:35 | [VarRef] x | semmle.label | [VarRef] x |
+| arrays.js:74:3:74:42 | [DeclStmt] const arrayFrom = ... | semmle.label | [DeclStmt] const arrayFrom = ... |
+| arrays.js:74:9:74:17 | [VarDecl] arrayFrom | semmle.label | [VarDecl] arrayFrom |
+| arrays.js:74:9:74:41 | [VariableDeclarator] arrayFr ... -from") | semmle.label | [VariableDeclarator] arrayFr ... -from") |
+| arrays.js:74:21:74:27 | [VarRef] require | semmle.label | [VarRef] require |
+| arrays.js:74:21:74:41 | [CallExpr] require ... -from") | semmle.label | [CallExpr] require ... -from") |
+| arrays.js:74:29:74:40 | [Literal] "array-from" | semmle.label | [Literal] "array-from" |
+| arrays.js:75:3:77:3 | [ForOfStmt] for (co ... OK } | semmle.label | [ForOfStmt] for (co ... OK } |
+| arrays.js:75:8:75:14 | [DeclStmt] const x = ... | semmle.label | [DeclStmt] const x = ... |
+| arrays.js:75:14:75:14 | [VarDecl] x | semmle.label | [VarDecl] x |
+| arrays.js:75:14:75:14 | [VariableDeclarator] x | semmle.label | [VariableDeclarator] x |
+| arrays.js:75:19:75:27 | [VarRef] arrayFrom | semmle.label | [VarRef] arrayFrom |
+| arrays.js:75:19:75:32 | [CallExpr] arrayFrom(arr) | semmle.label | [CallExpr] arrayFrom(arr) |
+| arrays.js:75:29:75:31 | [VarRef] arr | semmle.label | [VarRef] arr |
+| arrays.js:75:35:77:3 | [BlockStmt] { s ... OK } | semmle.label | [BlockStmt] { s ... OK } |
+| arrays.js:76:5:76:8 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:76:5:76:11 | [CallExpr] sink(x) | semmle.label | [CallExpr] sink(x) |
+| arrays.js:76:5:76:12 | [ExprStmt] sink(x); | semmle.label | [ExprStmt] sink(x); |
+| arrays.js:76:10:76:10 | [VarRef] x | semmle.label | [VarRef] x |
+| arrays.js:79:3:79:6 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:79:3:79:30 | [CallExpr] sink(ar ... lback)) | semmle.label | [CallExpr] sink(ar ... lback)) |
+| arrays.js:79:3:79:31 | [ExprStmt] sink(ar ... back)); | semmle.label | [ExprStmt] sink(ar ... back)); |
+| arrays.js:79:8:79:10 | [VarRef] arr | semmle.label | [VarRef] arr |
+| arrays.js:79:8:79:15 | [DotExpr] arr.find | semmle.label | [DotExpr] arr.find |
+| arrays.js:79:8:79:29 | [MethodCallExpr] arr.fin ... llback) | semmle.label | [MethodCallExpr] arr.fin ... llback) |
+| arrays.js:79:12:79:15 | [Label] find | semmle.label | [Label] find |
+| arrays.js:79:17:79:28 | [VarRef] someCallback | semmle.label | [VarRef] someCallback |
+| arrays.js:81:3:81:42 | [DeclStmt] const arrayFind = ... | semmle.label | [DeclStmt] const arrayFind = ... |
+| arrays.js:81:9:81:17 | [VarDecl] arrayFind | semmle.label | [VarDecl] arrayFind |
+| arrays.js:81:9:81:41 | [VariableDeclarator] arrayFi ... -find") | semmle.label | [VariableDeclarator] arrayFi ... -find") |
+| arrays.js:81:21:81:27 | [VarRef] require | semmle.label | [VarRef] require |
+| arrays.js:81:21:81:41 | [CallExpr] require ... -find") | semmle.label | [CallExpr] require ... -find") |
+| arrays.js:81:29:81:40 | [Literal] "array-find" | semmle.label | [Literal] "array-find" |
+| arrays.js:82:3:82:6 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:82:3:82:36 | [CallExpr] sink(ar ... lback)) | semmle.label | [CallExpr] sink(ar ... lback)) |
+| arrays.js:82:3:82:37 | [ExprStmt] sink(ar ... back)); | semmle.label | [ExprStmt] sink(ar ... back)); |
+| arrays.js:82:8:82:16 | [VarRef] arrayFind | semmle.label | [VarRef] arrayFind |
+| arrays.js:82:8:82:35 | [CallExpr] arrayFi ... llback) | semmle.label | [CallExpr] arrayFi ... llback) |
+| arrays.js:82:18:82:20 | [VarRef] arr | semmle.label | [VarRef] arr |
+| arrays.js:82:23:82:34 | [VarRef] someCallback | semmle.label | [VarRef] someCallback |
+| arrays.js:84:3:84:31 | [DeclStmt] const uniq = ... | semmle.label | [DeclStmt] const uniq = ... |
+| arrays.js:84:9:84:12 | [VarDecl] uniq | semmle.label | [VarDecl] uniq |
+| arrays.js:84:9:84:30 | [VariableDeclarator] uniq = ... "uniq") | semmle.label | [VariableDeclarator] uniq = ... "uniq") |
+| arrays.js:84:16:84:22 | [VarRef] require | semmle.label | [VarRef] require |
+| arrays.js:84:16:84:30 | [CallExpr] require("uniq") | semmle.label | [CallExpr] require("uniq") |
+| arrays.js:84:24:84:29 | [Literal] "uniq" | semmle.label | [Literal] "uniq" |
+| arrays.js:85:3:87:3 | [ForOfStmt] for (co ... OK } | semmle.label | [ForOfStmt] for (co ... OK } |
+| arrays.js:85:8:85:14 | [DeclStmt] const x = ... | semmle.label | [DeclStmt] const x = ... |
+| arrays.js:85:14:85:14 | [VarDecl] x | semmle.label | [VarDecl] x |
+| arrays.js:85:14:85:14 | [VariableDeclarator] x | semmle.label | [VariableDeclarator] x |
+| arrays.js:85:19:85:22 | [VarRef] uniq | semmle.label | [VarRef] uniq |
+| arrays.js:85:19:85:27 | [CallExpr] uniq(arr) | semmle.label | [CallExpr] uniq(arr) |
+| arrays.js:85:24:85:26 | [VarRef] arr | semmle.label | [VarRef] arr |
+| arrays.js:85:30:87:3 | [BlockStmt] { s ... OK } | semmle.label | [BlockStmt] { s ... OK } |
+| arrays.js:86:5:86:8 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:86:5:86:11 | [CallExpr] sink(x) | semmle.label | [CallExpr] sink(x) |
+| arrays.js:86:5:86:12 | [ExprStmt] sink(x); | semmle.label | [ExprStmt] sink(x); |
+| arrays.js:86:10:86:10 | [VarRef] x | semmle.label | [VarRef] x |
+| arrays.js:89:3:89:6 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:89:3:89:18 | [CallExpr] sink(arr.at(-1)) | semmle.label | [CallExpr] sink(arr.at(-1)) |
+| arrays.js:89:3:89:19 | [ExprStmt] sink(arr.at(-1)); | semmle.label | [ExprStmt] sink(arr.at(-1)); |
+| arrays.js:89:8:89:10 | [VarRef] arr | semmle.label | [VarRef] arr |
+| arrays.js:89:8:89:13 | [DotExpr] arr.at | semmle.label | [DotExpr] arr.at |
+| arrays.js:89:8:89:17 | [MethodCallExpr] arr.at(-1) | semmle.label | [MethodCallExpr] arr.at(-1) |
+| arrays.js:89:12:89:13 | [Label] at | semmle.label | [Label] at |
+| arrays.js:89:15:89:16 | [UnaryExpr] -1 | semmle.label | [UnaryExpr] -1 |
+| arrays.js:89:16:89:16 | [Literal] 1 | semmle.label | [Literal] 1 |
+| arrays.js:91:3:91:6 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:91:3:91:35 | [CallExpr] sink([" ... => x)) | semmle.label | [CallExpr] sink([" ... => x)) |
+| arrays.js:91:3:91:36 | [ExprStmt] sink([" ... => x)); | semmle.label | [ExprStmt] sink([" ... => x)); |
+| arrays.js:91:8:91:17 | [ArrayExpr] ["source"] | semmle.label | [ArrayExpr] ["source"] |
+| arrays.js:91:8:91:24 | [DotExpr] ["source"].filter | semmle.label | [DotExpr] ["source"].filter |
+| arrays.js:91:8:91:34 | [MethodCallExpr] ["sourc ... ) => x) | semmle.label | [MethodCallExpr] ["sourc ... ) => x) |
+| arrays.js:91:9:91:16 | [Literal] "source" | semmle.label | [Literal] "source" |
+| arrays.js:91:19:91:24 | [Label] filter | semmle.label | [Label] filter |
+| arrays.js:91:26:91:33 | [ArrowFunctionExpr] (x) => x | semmle.label | [ArrowFunctionExpr] (x) => x |
+| arrays.js:91:27:91:27 | [SimpleParameter] x | semmle.label | [SimpleParameter] x |
+| arrays.js:91:33:91:33 | [VarRef] x | semmle.label | [VarRef] x |
+| arrays.js:92:3:92:6 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:92:3:92:37 | [CallExpr] sink([" ... > !!x)) | semmle.label | [CallExpr] sink([" ... > !!x)) |
+| arrays.js:92:3:92:38 | [ExprStmt] sink([" ... !!x)); | semmle.label | [ExprStmt] sink([" ... !!x)); |
+| arrays.js:92:8:92:17 | [ArrayExpr] ["source"] | semmle.label | [ArrayExpr] ["source"] |
+| arrays.js:92:8:92:24 | [DotExpr] ["source"].filter | semmle.label | [DotExpr] ["source"].filter |
+| arrays.js:92:8:92:36 | [MethodCallExpr] ["sourc ... => !!x) | semmle.label | [MethodCallExpr] ["sourc ... => !!x) |
+| arrays.js:92:9:92:16 | [Literal] "source" | semmle.label | [Literal] "source" |
+| arrays.js:92:19:92:24 | [Label] filter | semmle.label | [Label] filter |
+| arrays.js:92:26:92:35 | [ArrowFunctionExpr] (x) => !!x | semmle.label | [ArrowFunctionExpr] (x) => !!x |
+| arrays.js:92:27:92:27 | [SimpleParameter] x | semmle.label | [SimpleParameter] x |
+| arrays.js:92:33:92:35 | [UnaryExpr] !!x | semmle.label | [UnaryExpr] !!x |
+| arrays.js:92:34:92:35 | [UnaryExpr] !x | semmle.label | [UnaryExpr] !x |
+| arrays.js:92:35:92:35 | [VarRef] x | semmle.label | [VarRef] x |
 | file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
 | file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
 | file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
@@ -427,94 +427,94 @@ nodes
 | file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
 | file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
 edges
-| arrays.js:1:1:88:2 | [ParExpr] (functi ... T OK }) | arrays.js:1:2:88:1 | [FunctionExpr] functio ... OT OK } | semmle.label | 1 |
-| arrays.js:1:1:88:2 | [ParExpr] (functi ... T OK }) | arrays.js:1:2:88:1 | [FunctionExpr] functio ... OT OK } | semmle.order | 1 |
-| arrays.js:1:1:88:3 | [ExprStmt] (functi ... OK }); | arrays.js:1:1:88:2 | [ParExpr] (functi ... T OK }) | semmle.label | 1 |
-| arrays.js:1:1:88:3 | [ExprStmt] (functi ... OK }); | arrays.js:1:1:88:2 | [ParExpr] (functi ... T OK }) | semmle.order | 1 |
-| arrays.js:1:2:88:1 | [FunctionExpr] functio ... OT OK } | arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | semmle.label | 5 |
-| arrays.js:1:2:88:1 | [FunctionExpr] functio ... OT OK } | arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | semmle.order | 5 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | semmle.label | 1 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | semmle.order | 1 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:4:3:4:28 | [DeclStmt] var obj = ... | semmle.label | 2 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:4:3:4:28 | [DeclStmt] var obj = ... | semmle.order | 2 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:5:3:5:16 | [ExprStmt] sink(obj.foo); | semmle.label | 3 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:5:3:5:16 | [ExprStmt] sink(obj.foo); | semmle.order | 3 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:7:3:7:15 | [DeclStmt] var arr = ... | semmle.label | 4 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:7:3:7:15 | [DeclStmt] var arr = ... | semmle.order | 4 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:8:3:8:19 | [ExprStmt] arr.push(source); | semmle.label | 5 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:8:3:8:19 | [ExprStmt] arr.push(source); | semmle.order | 5 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:10:3:12:3 | [ForStmt] for (va ... OK } | semmle.label | 6 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:10:3:12:3 | [ForStmt] for (va ... OK } | semmle.order | 6 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:15:3:15:30 | [ExprStmt] arr.for ... nk(e)); | semmle.label | 7 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:15:3:15:30 | [ExprStmt] arr.for ... nk(e)); | semmle.order | 7 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:16:3:16:26 | [ExprStmt] arr.map ... nk(e)); | semmle.label | 8 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:16:3:16:26 | [ExprStmt] arr.map ... nk(e)); | semmle.order | 8 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:18:3:18:53 | [ExprStmt] [1, 2, ... nk(e)); | semmle.label | 9 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:18:3:18:53 | [ExprStmt] [1, 2, ... nk(e)); | semmle.order | 9 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:20:3:20:18 | [ExprStmt] sink(arr.pop()); | semmle.label | 10 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:20:3:20:18 | [ExprStmt] sink(arr.pop()); | semmle.order | 10 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:22:3:22:24 | [DeclStmt] var arr2 = ... | semmle.label | 11 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:22:3:22:24 | [DeclStmt] var arr2 = ... | semmle.order | 11 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:23:3:23:19 | [ExprStmt] sink(arr2.pop()); | semmle.label | 12 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:23:3:23:19 | [ExprStmt] sink(arr2.pop()); | semmle.order | 12 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:25:3:25:24 | [DeclStmt] var arr3 = ... | semmle.label | 13 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:25:3:25:24 | [DeclStmt] var arr3 = ... | semmle.order | 13 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:26:3:26:19 | [ExprStmt] sink(arr3.pop()); | semmle.label | 14 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:26:3:26:19 | [ExprStmt] sink(arr3.pop()); | semmle.order | 14 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:28:3:28:16 | [DeclStmt] var arr4 = ... | semmle.label | 15 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:28:3:28:16 | [DeclStmt] var arr4 = ... | semmle.order | 15 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:29:3:29:30 | [ExprStmt] arr4.sp ... urce"); | semmle.label | 16 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:29:3:29:30 | [ExprStmt] arr4.sp ... urce"); | semmle.order | 16 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:30:3:30:19 | [ExprStmt] sink(arr4.pop()); | semmle.label | 17 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:30:3:30:19 | [ExprStmt] sink(arr4.pop()); | semmle.order | 17 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:32:3:32:29 | [DeclStmt] var arr5 = ... | semmle.label | 18 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:32:3:32:29 | [DeclStmt] var arr5 = ... | semmle.order | 18 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:33:3:33:19 | [ExprStmt] sink(arr5.pop()); | semmle.label | 19 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:33:3:33:19 | [ExprStmt] sink(arr5.pop()); | semmle.order | 19 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:35:3:35:28 | [ExprStmt] sink(ar ... pop()); | semmle.label | 20 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:35:3:35:28 | [ExprStmt] sink(ar ... pop()); | semmle.order | 20 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:37:3:37:16 | [DeclStmt] var arr6 = ... | semmle.label | 21 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:37:3:37:16 | [DeclStmt] var arr6 = ... | semmle.order | 21 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:38:3:40:3 | [ForStmt] for (va ... i]; } | semmle.label | 22 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:38:3:40:3 | [ForStmt] for (va ... i]; } | semmle.order | 22 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:41:3:41:19 | [ExprStmt] sink(arr6.pop()); | semmle.label | 23 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:41:3:41:19 | [ExprStmt] sink(arr6.pop()); | semmle.order | 23 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:44:3:47:5 | [ExprStmt] ["sourc ... . }); | semmle.label | 24 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:44:3:47:5 | [ExprStmt] ["sourc ... . }); | semmle.order | 24 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:49:3:49:15 | [ExprStmt] sink(arr[0]); | semmle.label | 25 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:49:3:49:15 | [ExprStmt] sink(arr[0]); | semmle.order | 25 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:51:3:53:3 | [ForOfStmt] for (co ... OK } | semmle.label | 26 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:51:3:53:3 | [ForOfStmt] for (co ... OK } | semmle.order | 26 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:55:3:57:3 | [ForOfStmt] for (co ... OK } | semmle.label | 27 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:55:3:57:3 | [ForOfStmt] for (co ... OK } | semmle.order | 27 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:59:3:61:3 | [ForOfStmt] for (co ... OK } | semmle.label | 28 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:59:3:61:3 | [ForOfStmt] for (co ... OK } | semmle.order | 28 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:63:3:63:16 | [DeclStmt] var arr7 = ... | semmle.label | 29 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:63:3:63:16 | [DeclStmt] var arr7 = ... | semmle.order | 29 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:64:3:64:20 | [ExprStmt] arr7.push(...arr); | semmle.label | 30 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:64:3:64:20 | [ExprStmt] arr7.push(...arr); | semmle.order | 30 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:65:3:67:3 | [ForOfStmt] for (co ... OK } | semmle.label | 31 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:65:3:67:3 | [ForOfStmt] for (co ... OK } | semmle.order | 31 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:69:3:69:42 | [DeclStmt] const arrayFrom = ... | semmle.label | 32 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:69:3:69:42 | [DeclStmt] const arrayFrom = ... | semmle.order | 32 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | semmle.label | 33 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | semmle.order | 33 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:74:3:74:31 | [ExprStmt] sink(ar ... back)); | semmle.label | 34 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:74:3:74:31 | [ExprStmt] sink(ar ... back)); | semmle.order | 34 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:76:3:76:42 | [DeclStmt] const arrayFind = ... | semmle.label | 35 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:76:3:76:42 | [DeclStmt] const arrayFind = ... | semmle.order | 35 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:77:3:77:37 | [ExprStmt] sink(ar ... back)); | semmle.label | 36 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:77:3:77:37 | [ExprStmt] sink(ar ... back)); | semmle.order | 36 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:79:3:79:31 | [DeclStmt] const uniq = ... | semmle.label | 37 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:79:3:79:31 | [DeclStmt] const uniq = ... | semmle.order | 37 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:80:3:82:3 | [ForOfStmt] for (co ... OK } | semmle.label | 38 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:80:3:82:3 | [ForOfStmt] for (co ... OK } | semmle.order | 38 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:84:3:84:19 | [ExprStmt] sink(arr.at(-1)); | semmle.label | 39 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:84:3:84:19 | [ExprStmt] sink(arr.at(-1)); | semmle.order | 39 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:86:3:86:36 | [ExprStmt] sink([" ... => x)); | semmle.label | 40 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:86:3:86:36 | [ExprStmt] sink([" ... => x)); | semmle.order | 40 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:87:3:87:38 | [ExprStmt] sink([" ... !!x)); | semmle.label | 41 |
-| arrays.js:1:14:88:1 | [BlockStmt] { let ... OT OK } | arrays.js:87:3:87:38 | [ExprStmt] sink([" ... !!x)); | semmle.order | 41 |
+| arrays.js:1:1:93:2 | [ParExpr] (functi ... T OK }) | arrays.js:1:2:93:1 | [FunctionExpr] functio ... OT OK } | semmle.label | 1 |
+| arrays.js:1:1:93:2 | [ParExpr] (functi ... T OK }) | arrays.js:1:2:93:1 | [FunctionExpr] functio ... OT OK } | semmle.order | 1 |
+| arrays.js:1:1:93:3 | [ExprStmt] (functi ... OK }); | arrays.js:1:1:93:2 | [ParExpr] (functi ... T OK }) | semmle.label | 1 |
+| arrays.js:1:1:93:3 | [ExprStmt] (functi ... OK }); | arrays.js:1:1:93:2 | [ParExpr] (functi ... T OK }) | semmle.order | 1 |
+| arrays.js:1:2:93:1 | [FunctionExpr] functio ... OT OK } | arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | semmle.label | 5 |
+| arrays.js:1:2:93:1 | [FunctionExpr] functio ... OT OK } | arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | semmle.order | 5 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | semmle.label | 1 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | semmle.order | 1 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:4:3:4:28 | [DeclStmt] var obj = ... | semmle.label | 2 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:4:3:4:28 | [DeclStmt] var obj = ... | semmle.order | 2 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:5:3:5:16 | [ExprStmt] sink(obj.foo); | semmle.label | 3 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:5:3:5:16 | [ExprStmt] sink(obj.foo); | semmle.order | 3 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:7:3:7:15 | [DeclStmt] var arr = ... | semmle.label | 4 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:7:3:7:15 | [DeclStmt] var arr = ... | semmle.order | 4 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:8:3:8:19 | [ExprStmt] arr.push(source); | semmle.label | 5 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:8:3:8:19 | [ExprStmt] arr.push(source); | semmle.order | 5 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:10:3:12:3 | [ForStmt] for (va ... OK } | semmle.label | 6 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:10:3:12:3 | [ForStmt] for (va ... OK } | semmle.order | 6 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:15:3:15:30 | [ExprStmt] arr.for ... nk(e)); | semmle.label | 7 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:15:3:15:30 | [ExprStmt] arr.for ... nk(e)); | semmle.order | 7 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:16:3:16:26 | [ExprStmt] arr.map ... nk(e)); | semmle.label | 8 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:16:3:16:26 | [ExprStmt] arr.map ... nk(e)); | semmle.order | 8 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:18:3:18:53 | [ExprStmt] [1, 2, ... nk(e)); | semmle.label | 9 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:18:3:18:53 | [ExprStmt] [1, 2, ... nk(e)); | semmle.order | 9 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:20:3:20:18 | [ExprStmt] sink(arr.pop()); | semmle.label | 10 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:20:3:20:18 | [ExprStmt] sink(arr.pop()); | semmle.order | 10 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:22:3:22:24 | [DeclStmt] var arr2 = ... | semmle.label | 11 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:22:3:22:24 | [DeclStmt] var arr2 = ... | semmle.order | 11 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:23:3:23:19 | [ExprStmt] sink(arr2.pop()); | semmle.label | 12 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:23:3:23:19 | [ExprStmt] sink(arr2.pop()); | semmle.order | 12 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:25:3:25:24 | [DeclStmt] var arr3 = ... | semmle.label | 13 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:25:3:25:24 | [DeclStmt] var arr3 = ... | semmle.order | 13 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:26:3:26:19 | [ExprStmt] sink(arr3.pop()); | semmle.label | 14 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:26:3:26:19 | [ExprStmt] sink(arr3.pop()); | semmle.order | 14 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:28:3:28:16 | [DeclStmt] var arr4 = ... | semmle.label | 15 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:28:3:28:16 | [DeclStmt] var arr4 = ... | semmle.order | 15 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:29:3:29:30 | [ExprStmt] arr4.sp ... urce"); | semmle.label | 16 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:29:3:29:30 | [ExprStmt] arr4.sp ... urce"); | semmle.order | 16 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:30:3:30:19 | [ExprStmt] sink(arr4.pop()); | semmle.label | 17 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:30:3:30:19 | [ExprStmt] sink(arr4.pop()); | semmle.order | 17 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:37:3:37:29 | [DeclStmt] var arr5 = ... | semmle.label | 18 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:37:3:37:29 | [DeclStmt] var arr5 = ... | semmle.order | 18 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:38:3:38:19 | [ExprStmt] sink(arr5.pop()); | semmle.label | 19 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:38:3:38:19 | [ExprStmt] sink(arr5.pop()); | semmle.order | 19 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:40:3:40:28 | [ExprStmt] sink(ar ... pop()); | semmle.label | 20 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:40:3:40:28 | [ExprStmt] sink(ar ... pop()); | semmle.order | 20 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:42:3:42:16 | [DeclStmt] var arr6 = ... | semmle.label | 21 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:42:3:42:16 | [DeclStmt] var arr6 = ... | semmle.order | 21 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:43:3:45:3 | [ForStmt] for (va ... i]; } | semmle.label | 22 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:43:3:45:3 | [ForStmt] for (va ... i]; } | semmle.order | 22 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:46:3:46:19 | [ExprStmt] sink(arr6.pop()); | semmle.label | 23 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:46:3:46:19 | [ExprStmt] sink(arr6.pop()); | semmle.order | 23 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:49:3:52:5 | [ExprStmt] ["sourc ... . }); | semmle.label | 24 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:49:3:52:5 | [ExprStmt] ["sourc ... . }); | semmle.order | 24 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:54:3:54:15 | [ExprStmt] sink(arr[0]); | semmle.label | 25 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:54:3:54:15 | [ExprStmt] sink(arr[0]); | semmle.order | 25 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:56:3:58:3 | [ForOfStmt] for (co ... OK } | semmle.label | 26 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:56:3:58:3 | [ForOfStmt] for (co ... OK } | semmle.order | 26 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | semmle.label | 27 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | semmle.order | 27 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | semmle.label | 28 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | semmle.order | 28 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:68:3:68:16 | [DeclStmt] var arr7 = ... | semmle.label | 29 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:68:3:68:16 | [DeclStmt] var arr7 = ... | semmle.order | 29 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:69:3:69:20 | [ExprStmt] arr7.push(...arr); | semmle.label | 30 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:69:3:69:20 | [ExprStmt] arr7.push(...arr); | semmle.order | 30 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | semmle.label | 31 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | semmle.order | 31 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:74:3:74:42 | [DeclStmt] const arrayFrom = ... | semmle.label | 32 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:74:3:74:42 | [DeclStmt] const arrayFrom = ... | semmle.order | 32 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:75:3:77:3 | [ForOfStmt] for (co ... OK } | semmle.label | 33 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:75:3:77:3 | [ForOfStmt] for (co ... OK } | semmle.order | 33 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:79:3:79:31 | [ExprStmt] sink(ar ... back)); | semmle.label | 34 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:79:3:79:31 | [ExprStmt] sink(ar ... back)); | semmle.order | 34 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:81:3:81:42 | [DeclStmt] const arrayFind = ... | semmle.label | 35 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:81:3:81:42 | [DeclStmt] const arrayFind = ... | semmle.order | 35 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:82:3:82:37 | [ExprStmt] sink(ar ... back)); | semmle.label | 36 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:82:3:82:37 | [ExprStmt] sink(ar ... back)); | semmle.order | 36 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:84:3:84:31 | [DeclStmt] const uniq = ... | semmle.label | 37 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:84:3:84:31 | [DeclStmt] const uniq = ... | semmle.order | 37 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:85:3:87:3 | [ForOfStmt] for (co ... OK } | semmle.label | 38 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:85:3:87:3 | [ForOfStmt] for (co ... OK } | semmle.order | 38 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:89:3:89:19 | [ExprStmt] sink(arr.at(-1)); | semmle.label | 39 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:89:3:89:19 | [ExprStmt] sink(arr.at(-1)); | semmle.order | 39 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:91:3:91:36 | [ExprStmt] sink([" ... => x)); | semmle.label | 40 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:91:3:91:36 | [ExprStmt] sink([" ... => x)); | semmle.order | 40 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:92:3:92:38 | [ExprStmt] sink([" ... !!x)); | semmle.label | 41 |
+| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:92:3:92:38 | [ExprStmt] sink([" ... !!x)); | semmle.order | 41 |
 | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | arrays.js:2:7:2:23 | [VariableDeclarator] source = "source" | semmle.label | 1 |
 | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | arrays.js:2:7:2:23 | [VariableDeclarator] source = "source" | semmle.order | 1 |
 | arrays.js:2:7:2:23 | [VariableDeclarator] source = "source" | arrays.js:2:7:2:12 | [VarDecl] source | semmle.label | 1 |
@@ -747,418 +747,418 @@ edges
 | arrays.js:30:8:30:15 | [DotExpr] arr4.pop | arrays.js:30:13:30:15 | [Label] pop | semmle.order | 2 |
 | arrays.js:30:8:30:17 | [MethodCallExpr] arr4.pop() | arrays.js:30:8:30:15 | [DotExpr] arr4.pop | semmle.label | 0 |
 | arrays.js:30:8:30:17 | [MethodCallExpr] arr4.pop() | arrays.js:30:8:30:15 | [DotExpr] arr4.pop | semmle.order | 0 |
-| arrays.js:32:3:32:29 | [DeclStmt] var arr5 = ... | arrays.js:32:7:32:28 | [VariableDeclarator] arr5 = ... t(arr4) | semmle.label | 1 |
-| arrays.js:32:3:32:29 | [DeclStmt] var arr5 = ... | arrays.js:32:7:32:28 | [VariableDeclarator] arr5 = ... t(arr4) | semmle.order | 1 |
-| arrays.js:32:7:32:28 | [VariableDeclarator] arr5 = ... t(arr4) | arrays.js:32:7:32:10 | [VarDecl] arr5 | semmle.label | 1 |
-| arrays.js:32:7:32:28 | [VariableDeclarator] arr5 = ... t(arr4) | arrays.js:32:7:32:10 | [VarDecl] arr5 | semmle.order | 1 |
-| arrays.js:32:7:32:28 | [VariableDeclarator] arr5 = ... t(arr4) | arrays.js:32:14:32:28 | [MethodCallExpr] [].concat(arr4) | semmle.label | 2 |
-| arrays.js:32:7:32:28 | [VariableDeclarator] arr5 = ... t(arr4) | arrays.js:32:14:32:28 | [MethodCallExpr] [].concat(arr4) | semmle.order | 2 |
-| arrays.js:32:14:32:22 | [DotExpr] [].concat | arrays.js:32:14:32:15 | [ArrayExpr] [] | semmle.label | 1 |
-| arrays.js:32:14:32:22 | [DotExpr] [].concat | arrays.js:32:14:32:15 | [ArrayExpr] [] | semmle.order | 1 |
-| arrays.js:32:14:32:22 | [DotExpr] [].concat | arrays.js:32:17:32:22 | [Label] concat | semmle.label | 2 |
-| arrays.js:32:14:32:22 | [DotExpr] [].concat | arrays.js:32:17:32:22 | [Label] concat | semmle.order | 2 |
-| arrays.js:32:14:32:28 | [MethodCallExpr] [].concat(arr4) | arrays.js:32:14:32:22 | [DotExpr] [].concat | semmle.label | 0 |
-| arrays.js:32:14:32:28 | [MethodCallExpr] [].concat(arr4) | arrays.js:32:14:32:22 | [DotExpr] [].concat | semmle.order | 0 |
-| arrays.js:32:14:32:28 | [MethodCallExpr] [].concat(arr4) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:32:14:32:28 | [MethodCallExpr] [].concat(arr4) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:33:3:33:18 | [CallExpr] sink(arr5.pop()) | arrays.js:33:3:33:6 | [VarRef] sink | semmle.label | 0 |
-| arrays.js:33:3:33:18 | [CallExpr] sink(arr5.pop()) | arrays.js:33:3:33:6 | [VarRef] sink | semmle.order | 0 |
-| arrays.js:33:3:33:18 | [CallExpr] sink(arr5.pop()) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:33:3:33:18 | [CallExpr] sink(arr5.pop()) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:33:3:33:19 | [ExprStmt] sink(arr5.pop()); | arrays.js:33:3:33:18 | [CallExpr] sink(arr5.pop()) | semmle.label | 1 |
-| arrays.js:33:3:33:19 | [ExprStmt] sink(arr5.pop()); | arrays.js:33:3:33:18 | [CallExpr] sink(arr5.pop()) | semmle.order | 1 |
-| arrays.js:33:8:33:15 | [DotExpr] arr5.pop | arrays.js:33:8:33:11 | [VarRef] arr5 | semmle.label | 1 |
-| arrays.js:33:8:33:15 | [DotExpr] arr5.pop | arrays.js:33:8:33:11 | [VarRef] arr5 | semmle.order | 1 |
-| arrays.js:33:8:33:15 | [DotExpr] arr5.pop | arrays.js:33:13:33:15 | [Label] pop | semmle.label | 2 |
-| arrays.js:33:8:33:15 | [DotExpr] arr5.pop | arrays.js:33:13:33:15 | [Label] pop | semmle.order | 2 |
-| arrays.js:33:8:33:17 | [MethodCallExpr] arr5.pop() | arrays.js:33:8:33:15 | [DotExpr] arr5.pop | semmle.label | 0 |
-| arrays.js:33:8:33:17 | [MethodCallExpr] arr5.pop() | arrays.js:33:8:33:15 | [DotExpr] arr5.pop | semmle.order | 0 |
-| arrays.js:35:3:35:27 | [CallExpr] sink(ar ... .pop()) | arrays.js:35:3:35:6 | [VarRef] sink | semmle.label | 0 |
-| arrays.js:35:3:35:27 | [CallExpr] sink(ar ... .pop()) | arrays.js:35:3:35:6 | [VarRef] sink | semmle.order | 0 |
-| arrays.js:35:3:35:27 | [CallExpr] sink(ar ... .pop()) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:35:3:35:27 | [CallExpr] sink(ar ... .pop()) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:35:3:35:28 | [ExprStmt] sink(ar ... pop()); | arrays.js:35:3:35:27 | [CallExpr] sink(ar ... .pop()) | semmle.label | 1 |
-| arrays.js:35:3:35:28 | [ExprStmt] sink(ar ... pop()); | arrays.js:35:3:35:27 | [CallExpr] sink(ar ... .pop()) | semmle.order | 1 |
-| arrays.js:35:8:35:17 | [DotExpr] arr5.slice | arrays.js:35:8:35:11 | [VarRef] arr5 | semmle.label | 1 |
-| arrays.js:35:8:35:17 | [DotExpr] arr5.slice | arrays.js:35:8:35:11 | [VarRef] arr5 | semmle.order | 1 |
-| arrays.js:35:8:35:17 | [DotExpr] arr5.slice | arrays.js:35:13:35:17 | [Label] slice | semmle.label | 2 |
-| arrays.js:35:8:35:17 | [DotExpr] arr5.slice | arrays.js:35:13:35:17 | [Label] slice | semmle.order | 2 |
-| arrays.js:35:8:35:20 | [MethodCallExpr] arr5.slice(2) | arrays.js:35:8:35:17 | [DotExpr] arr5.slice | semmle.label | 0 |
-| arrays.js:35:8:35:20 | [MethodCallExpr] arr5.slice(2) | arrays.js:35:8:35:17 | [DotExpr] arr5.slice | semmle.order | 0 |
-| arrays.js:35:8:35:20 | [MethodCallExpr] arr5.slice(2) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:35:8:35:20 | [MethodCallExpr] arr5.slice(2) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:35:8:35:24 | [DotExpr] arr5.slice(2).pop | arrays.js:35:8:35:20 | [MethodCallExpr] arr5.slice(2) | semmle.label | 1 |
-| arrays.js:35:8:35:24 | [DotExpr] arr5.slice(2).pop | arrays.js:35:8:35:20 | [MethodCallExpr] arr5.slice(2) | semmle.order | 1 |
-| arrays.js:35:8:35:24 | [DotExpr] arr5.slice(2).pop | arrays.js:35:22:35:24 | [Label] pop | semmle.label | 2 |
-| arrays.js:35:8:35:24 | [DotExpr] arr5.slice(2).pop | arrays.js:35:22:35:24 | [Label] pop | semmle.order | 2 |
-| arrays.js:35:8:35:26 | [MethodCallExpr] arr5.slice(2).pop() | arrays.js:35:8:35:24 | [DotExpr] arr5.slice(2).pop | semmle.label | 0 |
-| arrays.js:35:8:35:26 | [MethodCallExpr] arr5.slice(2).pop() | arrays.js:35:8:35:24 | [DotExpr] arr5.slice(2).pop | semmle.order | 0 |
-| arrays.js:37:3:37:16 | [DeclStmt] var arr6 = ... | arrays.js:37:7:37:15 | [VariableDeclarator] arr6 = [] | semmle.label | 1 |
-| arrays.js:37:3:37:16 | [DeclStmt] var arr6 = ... | arrays.js:37:7:37:15 | [VariableDeclarator] arr6 = [] | semmle.order | 1 |
-| arrays.js:37:7:37:15 | [VariableDeclarator] arr6 = [] | arrays.js:37:7:37:10 | [VarDecl] arr6 | semmle.label | 1 |
-| arrays.js:37:7:37:15 | [VariableDeclarator] arr6 = [] | arrays.js:37:7:37:10 | [VarDecl] arr6 | semmle.order | 1 |
-| arrays.js:37:7:37:15 | [VariableDeclarator] arr6 = [] | arrays.js:37:14:37:15 | [ArrayExpr] [] | semmle.label | 2 |
-| arrays.js:37:7:37:15 | [VariableDeclarator] arr6 = [] | arrays.js:37:14:37:15 | [ArrayExpr] [] | semmle.order | 2 |
-| arrays.js:38:3:40:3 | [ForStmt] for (va ... i]; } | arrays.js:38:8:38:16 | [DeclStmt] var i = ... | semmle.label | 1 |
-| arrays.js:38:3:40:3 | [ForStmt] for (va ... i]; } | arrays.js:38:8:38:16 | [DeclStmt] var i = ... | semmle.order | 1 |
-| arrays.js:38:3:40:3 | [ForStmt] for (va ... i]; } | arrays.js:38:19:38:33 | [BinaryExpr] i < arr5.length | semmle.label | 2 |
-| arrays.js:38:3:40:3 | [ForStmt] for (va ... i]; } | arrays.js:38:19:38:33 | [BinaryExpr] i < arr5.length | semmle.order | 2 |
-| arrays.js:38:3:40:3 | [ForStmt] for (va ... i]; } | arrays.js:38:36:38:38 | [UpdateExpr] i++ | semmle.label | 3 |
-| arrays.js:38:3:40:3 | [ForStmt] for (va ... i]; } | arrays.js:38:36:38:38 | [UpdateExpr] i++ | semmle.order | 3 |
-| arrays.js:38:3:40:3 | [ForStmt] for (va ... i]; } | arrays.js:38:41:40:3 | [BlockStmt] { a ... i]; } | semmle.label | 4 |
-| arrays.js:38:3:40:3 | [ForStmt] for (va ... i]; } | arrays.js:38:41:40:3 | [BlockStmt] { a ... i]; } | semmle.order | 4 |
-| arrays.js:38:8:38:16 | [DeclStmt] var i = ... | arrays.js:38:12:38:16 | [VariableDeclarator] i = 0 | semmle.label | 1 |
-| arrays.js:38:8:38:16 | [DeclStmt] var i = ... | arrays.js:38:12:38:16 | [VariableDeclarator] i = 0 | semmle.order | 1 |
-| arrays.js:38:12:38:16 | [VariableDeclarator] i = 0 | arrays.js:38:12:38:12 | [VarDecl] i | semmle.label | 1 |
-| arrays.js:38:12:38:16 | [VariableDeclarator] i = 0 | arrays.js:38:12:38:12 | [VarDecl] i | semmle.order | 1 |
-| arrays.js:38:12:38:16 | [VariableDeclarator] i = 0 | arrays.js:38:16:38:16 | [Literal] 0 | semmle.label | 2 |
-| arrays.js:38:12:38:16 | [VariableDeclarator] i = 0 | arrays.js:38:16:38:16 | [Literal] 0 | semmle.order | 2 |
-| arrays.js:38:19:38:33 | [BinaryExpr] i < arr5.length | arrays.js:38:19:38:19 | [VarRef] i | semmle.label | 1 |
-| arrays.js:38:19:38:33 | [BinaryExpr] i < arr5.length | arrays.js:38:19:38:19 | [VarRef] i | semmle.order | 1 |
-| arrays.js:38:19:38:33 | [BinaryExpr] i < arr5.length | arrays.js:38:23:38:33 | [DotExpr] arr5.length | semmle.label | 2 |
-| arrays.js:38:19:38:33 | [BinaryExpr] i < arr5.length | arrays.js:38:23:38:33 | [DotExpr] arr5.length | semmle.order | 2 |
-| arrays.js:38:23:38:33 | [DotExpr] arr5.length | arrays.js:38:23:38:26 | [VarRef] arr5 | semmle.label | 1 |
-| arrays.js:38:23:38:33 | [DotExpr] arr5.length | arrays.js:38:23:38:26 | [VarRef] arr5 | semmle.order | 1 |
-| arrays.js:38:23:38:33 | [DotExpr] arr5.length | arrays.js:38:28:38:33 | [Label] length | semmle.label | 2 |
-| arrays.js:38:23:38:33 | [DotExpr] arr5.length | arrays.js:38:28:38:33 | [Label] length | semmle.order | 2 |
-| arrays.js:38:36:38:38 | [UpdateExpr] i++ | arrays.js:38:36:38:36 | [VarRef] i | semmle.label | 1 |
-| arrays.js:38:36:38:38 | [UpdateExpr] i++ | arrays.js:38:36:38:36 | [VarRef] i | semmle.order | 1 |
-| arrays.js:38:41:40:3 | [BlockStmt] { a ... i]; } | arrays.js:39:5:39:22 | [ExprStmt] arr6[i] = arr5[i]; | semmle.label | 1 |
-| arrays.js:38:41:40:3 | [BlockStmt] { a ... i]; } | arrays.js:39:5:39:22 | [ExprStmt] arr6[i] = arr5[i]; | semmle.order | 1 |
-| arrays.js:39:5:39:11 | [IndexExpr] arr6[i] | arrays.js:39:5:39:8 | [VarRef] arr6 | semmle.label | 1 |
-| arrays.js:39:5:39:11 | [IndexExpr] arr6[i] | arrays.js:39:5:39:8 | [VarRef] arr6 | semmle.order | 1 |
-| arrays.js:39:5:39:11 | [IndexExpr] arr6[i] | arrays.js:39:10:39:10 | [VarRef] i | semmle.label | 2 |
-| arrays.js:39:5:39:11 | [IndexExpr] arr6[i] | arrays.js:39:10:39:10 | [VarRef] i | semmle.order | 2 |
-| arrays.js:39:5:39:21 | [AssignExpr] arr6[i] = arr5[i] | arrays.js:39:5:39:11 | [IndexExpr] arr6[i] | semmle.label | 1 |
-| arrays.js:39:5:39:21 | [AssignExpr] arr6[i] = arr5[i] | arrays.js:39:5:39:11 | [IndexExpr] arr6[i] | semmle.order | 1 |
-| arrays.js:39:5:39:21 | [AssignExpr] arr6[i] = arr5[i] | arrays.js:39:15:39:21 | [IndexExpr] arr5[i] | semmle.label | 2 |
-| arrays.js:39:5:39:21 | [AssignExpr] arr6[i] = arr5[i] | arrays.js:39:15:39:21 | [IndexExpr] arr5[i] | semmle.order | 2 |
-| arrays.js:39:5:39:22 | [ExprStmt] arr6[i] = arr5[i]; | arrays.js:39:5:39:21 | [AssignExpr] arr6[i] = arr5[i] | semmle.label | 1 |
-| arrays.js:39:5:39:22 | [ExprStmt] arr6[i] = arr5[i]; | arrays.js:39:5:39:21 | [AssignExpr] arr6[i] = arr5[i] | semmle.order | 1 |
-| arrays.js:39:15:39:21 | [IndexExpr] arr5[i] | arrays.js:39:15:39:18 | [VarRef] arr5 | semmle.label | 1 |
-| arrays.js:39:15:39:21 | [IndexExpr] arr5[i] | arrays.js:39:15:39:18 | [VarRef] arr5 | semmle.order | 1 |
-| arrays.js:39:15:39:21 | [IndexExpr] arr5[i] | arrays.js:39:20:39:20 | [VarRef] i | semmle.label | 2 |
-| arrays.js:39:15:39:21 | [IndexExpr] arr5[i] | arrays.js:39:20:39:20 | [VarRef] i | semmle.order | 2 |
-| arrays.js:41:3:41:18 | [CallExpr] sink(arr6.pop()) | arrays.js:41:3:41:6 | [VarRef] sink | semmle.label | 0 |
-| arrays.js:41:3:41:18 | [CallExpr] sink(arr6.pop()) | arrays.js:41:3:41:6 | [VarRef] sink | semmle.order | 0 |
-| arrays.js:41:3:41:18 | [CallExpr] sink(arr6.pop()) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:41:3:41:18 | [CallExpr] sink(arr6.pop()) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:41:3:41:19 | [ExprStmt] sink(arr6.pop()); | arrays.js:41:3:41:18 | [CallExpr] sink(arr6.pop()) | semmle.label | 1 |
-| arrays.js:41:3:41:19 | [ExprStmt] sink(arr6.pop()); | arrays.js:41:3:41:18 | [CallExpr] sink(arr6.pop()) | semmle.order | 1 |
-| arrays.js:41:8:41:15 | [DotExpr] arr6.pop | arrays.js:41:8:41:11 | [VarRef] arr6 | semmle.label | 1 |
-| arrays.js:41:8:41:15 | [DotExpr] arr6.pop | arrays.js:41:8:41:11 | [VarRef] arr6 | semmle.order | 1 |
-| arrays.js:41:8:41:15 | [DotExpr] arr6.pop | arrays.js:41:13:41:15 | [Label] pop | semmle.label | 2 |
-| arrays.js:41:8:41:15 | [DotExpr] arr6.pop | arrays.js:41:13:41:15 | [Label] pop | semmle.order | 2 |
-| arrays.js:41:8:41:17 | [MethodCallExpr] arr6.pop() | arrays.js:41:8:41:15 | [DotExpr] arr6.pop | semmle.label | 0 |
-| arrays.js:41:8:41:17 | [MethodCallExpr] arr6.pop() | arrays.js:41:8:41:15 | [DotExpr] arr6.pop | semmle.order | 0 |
-| arrays.js:44:3:44:12 | [ArrayExpr] ["source"] | arrays.js:44:4:44:11 | [Literal] "source" | semmle.label | 1 |
-| arrays.js:44:3:44:12 | [ArrayExpr] ["source"] | arrays.js:44:4:44:11 | [Literal] "source" | semmle.order | 1 |
-| arrays.js:44:3:44:20 | [DotExpr] ["source"].forEach | arrays.js:44:3:44:12 | [ArrayExpr] ["source"] | semmle.label | 1 |
-| arrays.js:44:3:44:20 | [DotExpr] ["source"].forEach | arrays.js:44:3:44:12 | [ArrayExpr] ["source"] | semmle.order | 1 |
-| arrays.js:44:3:44:20 | [DotExpr] ["source"].forEach | arrays.js:44:14:44:20 | [Label] forEach | semmle.label | 2 |
-| arrays.js:44:3:44:20 | [DotExpr] ["source"].forEach | arrays.js:44:14:44:20 | [Label] forEach | semmle.order | 2 |
-| arrays.js:44:3:47:4 | [MethodCallExpr] ["sourc ... t. }) | arrays.js:44:3:44:20 | [DotExpr] ["source"].forEach | semmle.label | 0 |
-| arrays.js:44:3:47:4 | [MethodCallExpr] ["sourc ... t. }) | arrays.js:44:3:44:20 | [DotExpr] ["source"].forEach | semmle.order | 0 |
-| arrays.js:44:3:47:4 | [MethodCallExpr] ["sourc ... t. }) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:44:3:47:4 | [MethodCallExpr] ["sourc ... t. }) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:44:3:47:5 | [ExprStmt] ["sourc ... . }); | arrays.js:44:3:47:4 | [MethodCallExpr] ["sourc ... t. }) | semmle.label | 1 |
-| arrays.js:44:3:47:5 | [ExprStmt] ["sourc ... . }); | arrays.js:44:3:47:4 | [MethodCallExpr] ["sourc ... t. }) | semmle.order | 1 |
-| arrays.js:44:22:47:3 | [ArrowFunctionExpr] (e, i, ... nt. } | arrays.js:44:37:47:3 | [BlockStmt] { s ... nt. } | semmle.label | 5 |
-| arrays.js:44:22:47:3 | [ArrowFunctionExpr] (e, i, ... nt. } | arrays.js:44:37:47:3 | [BlockStmt] { s ... nt. } | semmle.order | 5 |
-| arrays.js:44:22:47:3 | [ArrowFunctionExpr] (e, i, ... nt. } | file://:0:0:0:0 | (Parameters) | semmle.label | 1 |
-| arrays.js:44:22:47:3 | [ArrowFunctionExpr] (e, i, ... nt. } | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
-| arrays.js:44:37:47:3 | [BlockStmt] { s ... nt. } | arrays.js:45:5:45:20 | [ExprStmt] sink(ary.pop()); | semmle.label | 1 |
-| arrays.js:44:37:47:3 | [BlockStmt] { s ... nt. } | arrays.js:45:5:45:20 | [ExprStmt] sink(ary.pop()); | semmle.order | 1 |
-| arrays.js:44:37:47:3 | [BlockStmt] { s ... nt. } | arrays.js:46:5:46:14 | [ExprStmt] sink(ary); | semmle.label | 2 |
-| arrays.js:44:37:47:3 | [BlockStmt] { s ... nt. } | arrays.js:46:5:46:14 | [ExprStmt] sink(ary); | semmle.order | 2 |
-| arrays.js:45:5:45:19 | [CallExpr] sink(ary.pop()) | arrays.js:45:5:45:8 | [VarRef] sink | semmle.label | 0 |
-| arrays.js:45:5:45:19 | [CallExpr] sink(ary.pop()) | arrays.js:45:5:45:8 | [VarRef] sink | semmle.order | 0 |
-| arrays.js:45:5:45:19 | [CallExpr] sink(ary.pop()) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:45:5:45:19 | [CallExpr] sink(ary.pop()) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:45:5:45:20 | [ExprStmt] sink(ary.pop()); | arrays.js:45:5:45:19 | [CallExpr] sink(ary.pop()) | semmle.label | 1 |
-| arrays.js:45:5:45:20 | [ExprStmt] sink(ary.pop()); | arrays.js:45:5:45:19 | [CallExpr] sink(ary.pop()) | semmle.order | 1 |
-| arrays.js:45:10:45:16 | [DotExpr] ary.pop | arrays.js:45:10:45:12 | [VarRef] ary | semmle.label | 1 |
-| arrays.js:45:10:45:16 | [DotExpr] ary.pop | arrays.js:45:10:45:12 | [VarRef] ary | semmle.order | 1 |
-| arrays.js:45:10:45:16 | [DotExpr] ary.pop | arrays.js:45:14:45:16 | [Label] pop | semmle.label | 2 |
-| arrays.js:45:10:45:16 | [DotExpr] ary.pop | arrays.js:45:14:45:16 | [Label] pop | semmle.order | 2 |
-| arrays.js:45:10:45:18 | [MethodCallExpr] ary.pop() | arrays.js:45:10:45:16 | [DotExpr] ary.pop | semmle.label | 0 |
-| arrays.js:45:10:45:18 | [MethodCallExpr] ary.pop() | arrays.js:45:10:45:16 | [DotExpr] ary.pop | semmle.order | 0 |
-| arrays.js:46:5:46:13 | [CallExpr] sink(ary) | arrays.js:46:5:46:8 | [VarRef] sink | semmle.label | 0 |
-| arrays.js:46:5:46:13 | [CallExpr] sink(ary) | arrays.js:46:5:46:8 | [VarRef] sink | semmle.order | 0 |
-| arrays.js:46:5:46:13 | [CallExpr] sink(ary) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:46:5:46:13 | [CallExpr] sink(ary) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:46:5:46:14 | [ExprStmt] sink(ary); | arrays.js:46:5:46:13 | [CallExpr] sink(ary) | semmle.label | 1 |
-| arrays.js:46:5:46:14 | [ExprStmt] sink(ary); | arrays.js:46:5:46:13 | [CallExpr] sink(ary) | semmle.order | 1 |
-| arrays.js:49:3:49:14 | [CallExpr] sink(arr[0]) | arrays.js:49:3:49:6 | [VarRef] sink | semmle.label | 0 |
-| arrays.js:49:3:49:14 | [CallExpr] sink(arr[0]) | arrays.js:49:3:49:6 | [VarRef] sink | semmle.order | 0 |
-| arrays.js:49:3:49:14 | [CallExpr] sink(arr[0]) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:49:3:49:14 | [CallExpr] sink(arr[0]) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:49:3:49:15 | [ExprStmt] sink(arr[0]); | arrays.js:49:3:49:14 | [CallExpr] sink(arr[0]) | semmle.label | 1 |
-| arrays.js:49:3:49:15 | [ExprStmt] sink(arr[0]); | arrays.js:49:3:49:14 | [CallExpr] sink(arr[0]) | semmle.order | 1 |
-| arrays.js:49:8:49:13 | [IndexExpr] arr[0] | arrays.js:49:8:49:10 | [VarRef] arr | semmle.label | 1 |
-| arrays.js:49:8:49:13 | [IndexExpr] arr[0] | arrays.js:49:8:49:10 | [VarRef] arr | semmle.order | 1 |
-| arrays.js:49:8:49:13 | [IndexExpr] arr[0] | arrays.js:49:12:49:12 | [Literal] 0 | semmle.label | 2 |
-| arrays.js:49:8:49:13 | [IndexExpr] arr[0] | arrays.js:49:12:49:12 | [Literal] 0 | semmle.order | 2 |
-| arrays.js:51:3:53:3 | [ForOfStmt] for (co ... OK } | arrays.js:51:8:51:14 | [DeclStmt] const x = ... | semmle.label | 1 |
-| arrays.js:51:3:53:3 | [ForOfStmt] for (co ... OK } | arrays.js:51:8:51:14 | [DeclStmt] const x = ... | semmle.order | 1 |
-| arrays.js:51:3:53:3 | [ForOfStmt] for (co ... OK } | arrays.js:51:19:51:21 | [VarRef] arr | semmle.label | 2 |
-| arrays.js:51:3:53:3 | [ForOfStmt] for (co ... OK } | arrays.js:51:19:51:21 | [VarRef] arr | semmle.order | 2 |
-| arrays.js:51:3:53:3 | [ForOfStmt] for (co ... OK } | arrays.js:51:24:53:3 | [BlockStmt] { s ... OK } | semmle.label | 3 |
-| arrays.js:51:3:53:3 | [ForOfStmt] for (co ... OK } | arrays.js:51:24:53:3 | [BlockStmt] { s ... OK } | semmle.order | 3 |
-| arrays.js:51:8:51:14 | [DeclStmt] const x = ... | arrays.js:51:14:51:14 | [VariableDeclarator] x | semmle.label | 1 |
-| arrays.js:51:8:51:14 | [DeclStmt] const x = ... | arrays.js:51:14:51:14 | [VariableDeclarator] x | semmle.order | 1 |
-| arrays.js:51:14:51:14 | [VariableDeclarator] x | arrays.js:51:14:51:14 | [VarDecl] x | semmle.label | 1 |
-| arrays.js:51:14:51:14 | [VariableDeclarator] x | arrays.js:51:14:51:14 | [VarDecl] x | semmle.order | 1 |
-| arrays.js:51:24:53:3 | [BlockStmt] { s ... OK } | arrays.js:52:5:52:12 | [ExprStmt] sink(x); | semmle.label | 1 |
-| arrays.js:51:24:53:3 | [BlockStmt] { s ... OK } | arrays.js:52:5:52:12 | [ExprStmt] sink(x); | semmle.order | 1 |
-| arrays.js:52:5:52:11 | [CallExpr] sink(x) | arrays.js:52:5:52:8 | [VarRef] sink | semmle.label | 0 |
-| arrays.js:52:5:52:11 | [CallExpr] sink(x) | arrays.js:52:5:52:8 | [VarRef] sink | semmle.order | 0 |
-| arrays.js:52:5:52:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:52:5:52:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:52:5:52:12 | [ExprStmt] sink(x); | arrays.js:52:5:52:11 | [CallExpr] sink(x) | semmle.label | 1 |
-| arrays.js:52:5:52:12 | [ExprStmt] sink(x); | arrays.js:52:5:52:11 | [CallExpr] sink(x) | semmle.order | 1 |
-| arrays.js:55:3:57:3 | [ForOfStmt] for (co ... OK } | arrays.js:55:8:55:14 | [DeclStmt] const x = ... | semmle.label | 1 |
-| arrays.js:55:3:57:3 | [ForOfStmt] for (co ... OK } | arrays.js:55:8:55:14 | [DeclStmt] const x = ... | semmle.order | 1 |
-| arrays.js:55:3:57:3 | [ForOfStmt] for (co ... OK } | arrays.js:55:19:55:33 | [MethodCallExpr] Array.from(arr) | semmle.label | 2 |
-| arrays.js:55:3:57:3 | [ForOfStmt] for (co ... OK } | arrays.js:55:19:55:33 | [MethodCallExpr] Array.from(arr) | semmle.order | 2 |
-| arrays.js:55:3:57:3 | [ForOfStmt] for (co ... OK } | arrays.js:55:36:57:3 | [BlockStmt] { s ... OK } | semmle.label | 3 |
-| arrays.js:55:3:57:3 | [ForOfStmt] for (co ... OK } | arrays.js:55:36:57:3 | [BlockStmt] { s ... OK } | semmle.order | 3 |
-| arrays.js:55:8:55:14 | [DeclStmt] const x = ... | arrays.js:55:14:55:14 | [VariableDeclarator] x | semmle.label | 1 |
-| arrays.js:55:8:55:14 | [DeclStmt] const x = ... | arrays.js:55:14:55:14 | [VariableDeclarator] x | semmle.order | 1 |
-| arrays.js:55:14:55:14 | [VariableDeclarator] x | arrays.js:55:14:55:14 | [VarDecl] x | semmle.label | 1 |
-| arrays.js:55:14:55:14 | [VariableDeclarator] x | arrays.js:55:14:55:14 | [VarDecl] x | semmle.order | 1 |
-| arrays.js:55:19:55:28 | [DotExpr] Array.from | arrays.js:55:19:55:23 | [VarRef] Array | semmle.label | 1 |
-| arrays.js:55:19:55:28 | [DotExpr] Array.from | arrays.js:55:19:55:23 | [VarRef] Array | semmle.order | 1 |
-| arrays.js:55:19:55:28 | [DotExpr] Array.from | arrays.js:55:25:55:28 | [Label] from | semmle.label | 2 |
-| arrays.js:55:19:55:28 | [DotExpr] Array.from | arrays.js:55:25:55:28 | [Label] from | semmle.order | 2 |
-| arrays.js:55:19:55:33 | [MethodCallExpr] Array.from(arr) | arrays.js:55:19:55:28 | [DotExpr] Array.from | semmle.label | 0 |
-| arrays.js:55:19:55:33 | [MethodCallExpr] Array.from(arr) | arrays.js:55:19:55:28 | [DotExpr] Array.from | semmle.order | 0 |
-| arrays.js:55:19:55:33 | [MethodCallExpr] Array.from(arr) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:55:19:55:33 | [MethodCallExpr] Array.from(arr) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:55:36:57:3 | [BlockStmt] { s ... OK } | arrays.js:56:5:56:12 | [ExprStmt] sink(x); | semmle.label | 1 |
-| arrays.js:55:36:57:3 | [BlockStmt] { s ... OK } | arrays.js:56:5:56:12 | [ExprStmt] sink(x); | semmle.order | 1 |
-| arrays.js:56:5:56:11 | [CallExpr] sink(x) | arrays.js:56:5:56:8 | [VarRef] sink | semmle.label | 0 |
-| arrays.js:56:5:56:11 | [CallExpr] sink(x) | arrays.js:56:5:56:8 | [VarRef] sink | semmle.order | 0 |
-| arrays.js:56:5:56:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:56:5:56:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:56:5:56:12 | [ExprStmt] sink(x); | arrays.js:56:5:56:11 | [CallExpr] sink(x) | semmle.label | 1 |
-| arrays.js:56:5:56:12 | [ExprStmt] sink(x); | arrays.js:56:5:56:11 | [CallExpr] sink(x) | semmle.order | 1 |
-| arrays.js:59:3:61:3 | [ForOfStmt] for (co ... OK } | arrays.js:59:8:59:14 | [DeclStmt] const x = ... | semmle.label | 1 |
-| arrays.js:59:3:61:3 | [ForOfStmt] for (co ... OK } | arrays.js:59:8:59:14 | [DeclStmt] const x = ... | semmle.order | 1 |
-| arrays.js:59:3:61:3 | [ForOfStmt] for (co ... OK } | arrays.js:59:19:59:26 | [ArrayExpr] [...arr] | semmle.label | 2 |
-| arrays.js:59:3:61:3 | [ForOfStmt] for (co ... OK } | arrays.js:59:19:59:26 | [ArrayExpr] [...arr] | semmle.order | 2 |
-| arrays.js:59:3:61:3 | [ForOfStmt] for (co ... OK } | arrays.js:59:29:61:3 | [BlockStmt] { s ... OK } | semmle.label | 3 |
-| arrays.js:59:3:61:3 | [ForOfStmt] for (co ... OK } | arrays.js:59:29:61:3 | [BlockStmt] { s ... OK } | semmle.order | 3 |
-| arrays.js:59:8:59:14 | [DeclStmt] const x = ... | arrays.js:59:14:59:14 | [VariableDeclarator] x | semmle.label | 1 |
-| arrays.js:59:8:59:14 | [DeclStmt] const x = ... | arrays.js:59:14:59:14 | [VariableDeclarator] x | semmle.order | 1 |
-| arrays.js:59:14:59:14 | [VariableDeclarator] x | arrays.js:59:14:59:14 | [VarDecl] x | semmle.label | 1 |
-| arrays.js:59:14:59:14 | [VariableDeclarator] x | arrays.js:59:14:59:14 | [VarDecl] x | semmle.order | 1 |
-| arrays.js:59:19:59:26 | [ArrayExpr] [...arr] | arrays.js:59:20:59:25 | [SpreadElement] ...arr | semmle.label | 1 |
-| arrays.js:59:19:59:26 | [ArrayExpr] [...arr] | arrays.js:59:20:59:25 | [SpreadElement] ...arr | semmle.order | 1 |
-| arrays.js:59:20:59:25 | [SpreadElement] ...arr | arrays.js:59:23:59:25 | [VarRef] arr | semmle.label | 1 |
-| arrays.js:59:20:59:25 | [SpreadElement] ...arr | arrays.js:59:23:59:25 | [VarRef] arr | semmle.order | 1 |
-| arrays.js:59:29:61:3 | [BlockStmt] { s ... OK } | arrays.js:60:5:60:12 | [ExprStmt] sink(x); | semmle.label | 1 |
-| arrays.js:59:29:61:3 | [BlockStmt] { s ... OK } | arrays.js:60:5:60:12 | [ExprStmt] sink(x); | semmle.order | 1 |
-| arrays.js:60:5:60:11 | [CallExpr] sink(x) | arrays.js:60:5:60:8 | [VarRef] sink | semmle.label | 0 |
-| arrays.js:60:5:60:11 | [CallExpr] sink(x) | arrays.js:60:5:60:8 | [VarRef] sink | semmle.order | 0 |
-| arrays.js:60:5:60:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:60:5:60:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:60:5:60:12 | [ExprStmt] sink(x); | arrays.js:60:5:60:11 | [CallExpr] sink(x) | semmle.label | 1 |
-| arrays.js:60:5:60:12 | [ExprStmt] sink(x); | arrays.js:60:5:60:11 | [CallExpr] sink(x) | semmle.order | 1 |
-| arrays.js:63:3:63:16 | [DeclStmt] var arr7 = ... | arrays.js:63:7:63:15 | [VariableDeclarator] arr7 = [] | semmle.label | 1 |
-| arrays.js:63:3:63:16 | [DeclStmt] var arr7 = ... | arrays.js:63:7:63:15 | [VariableDeclarator] arr7 = [] | semmle.order | 1 |
-| arrays.js:63:7:63:15 | [VariableDeclarator] arr7 = [] | arrays.js:63:7:63:10 | [VarDecl] arr7 | semmle.label | 1 |
-| arrays.js:63:7:63:15 | [VariableDeclarator] arr7 = [] | arrays.js:63:7:63:10 | [VarDecl] arr7 | semmle.order | 1 |
-| arrays.js:63:7:63:15 | [VariableDeclarator] arr7 = [] | arrays.js:63:14:63:15 | [ArrayExpr] [] | semmle.label | 2 |
-| arrays.js:63:7:63:15 | [VariableDeclarator] arr7 = [] | arrays.js:63:14:63:15 | [ArrayExpr] [] | semmle.order | 2 |
-| arrays.js:64:3:64:11 | [DotExpr] arr7.push | arrays.js:64:3:64:6 | [VarRef] arr7 | semmle.label | 1 |
-| arrays.js:64:3:64:11 | [DotExpr] arr7.push | arrays.js:64:3:64:6 | [VarRef] arr7 | semmle.order | 1 |
-| arrays.js:64:3:64:11 | [DotExpr] arr7.push | arrays.js:64:8:64:11 | [Label] push | semmle.label | 2 |
-| arrays.js:64:3:64:11 | [DotExpr] arr7.push | arrays.js:64:8:64:11 | [Label] push | semmle.order | 2 |
-| arrays.js:64:3:64:19 | [MethodCallExpr] arr7.push(...arr) | arrays.js:64:3:64:11 | [DotExpr] arr7.push | semmle.label | 0 |
-| arrays.js:64:3:64:19 | [MethodCallExpr] arr7.push(...arr) | arrays.js:64:3:64:11 | [DotExpr] arr7.push | semmle.order | 0 |
-| arrays.js:64:3:64:19 | [MethodCallExpr] arr7.push(...arr) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:64:3:64:19 | [MethodCallExpr] arr7.push(...arr) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:64:3:64:20 | [ExprStmt] arr7.push(...arr); | arrays.js:64:3:64:19 | [MethodCallExpr] arr7.push(...arr) | semmle.label | 1 |
-| arrays.js:64:3:64:20 | [ExprStmt] arr7.push(...arr); | arrays.js:64:3:64:19 | [MethodCallExpr] arr7.push(...arr) | semmle.order | 1 |
-| arrays.js:64:13:64:18 | [SpreadElement] ...arr | arrays.js:64:16:64:18 | [VarRef] arr | semmle.label | 1 |
-| arrays.js:64:13:64:18 | [SpreadElement] ...arr | arrays.js:64:16:64:18 | [VarRef] arr | semmle.order | 1 |
-| arrays.js:65:3:67:3 | [ForOfStmt] for (co ... OK } | arrays.js:65:8:65:14 | [DeclStmt] const x = ... | semmle.label | 1 |
-| arrays.js:65:3:67:3 | [ForOfStmt] for (co ... OK } | arrays.js:65:8:65:14 | [DeclStmt] const x = ... | semmle.order | 1 |
-| arrays.js:65:3:67:3 | [ForOfStmt] for (co ... OK } | arrays.js:65:19:65:22 | [VarRef] arr7 | semmle.label | 2 |
-| arrays.js:65:3:67:3 | [ForOfStmt] for (co ... OK } | arrays.js:65:19:65:22 | [VarRef] arr7 | semmle.order | 2 |
-| arrays.js:65:3:67:3 | [ForOfStmt] for (co ... OK } | arrays.js:65:25:67:3 | [BlockStmt] { s ... OK } | semmle.label | 3 |
-| arrays.js:65:3:67:3 | [ForOfStmt] for (co ... OK } | arrays.js:65:25:67:3 | [BlockStmt] { s ... OK } | semmle.order | 3 |
-| arrays.js:65:8:65:14 | [DeclStmt] const x = ... | arrays.js:65:14:65:14 | [VariableDeclarator] x | semmle.label | 1 |
-| arrays.js:65:8:65:14 | [DeclStmt] const x = ... | arrays.js:65:14:65:14 | [VariableDeclarator] x | semmle.order | 1 |
-| arrays.js:65:14:65:14 | [VariableDeclarator] x | arrays.js:65:14:65:14 | [VarDecl] x | semmle.label | 1 |
-| arrays.js:65:14:65:14 | [VariableDeclarator] x | arrays.js:65:14:65:14 | [VarDecl] x | semmle.order | 1 |
-| arrays.js:65:25:67:3 | [BlockStmt] { s ... OK } | arrays.js:66:5:66:12 | [ExprStmt] sink(x); | semmle.label | 1 |
-| arrays.js:65:25:67:3 | [BlockStmt] { s ... OK } | arrays.js:66:5:66:12 | [ExprStmt] sink(x); | semmle.order | 1 |
-| arrays.js:66:5:66:11 | [CallExpr] sink(x) | arrays.js:66:5:66:8 | [VarRef] sink | semmle.label | 0 |
-| arrays.js:66:5:66:11 | [CallExpr] sink(x) | arrays.js:66:5:66:8 | [VarRef] sink | semmle.order | 0 |
-| arrays.js:66:5:66:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:66:5:66:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:66:5:66:12 | [ExprStmt] sink(x); | arrays.js:66:5:66:11 | [CallExpr] sink(x) | semmle.label | 1 |
-| arrays.js:66:5:66:12 | [ExprStmt] sink(x); | arrays.js:66:5:66:11 | [CallExpr] sink(x) | semmle.order | 1 |
-| arrays.js:69:3:69:42 | [DeclStmt] const arrayFrom = ... | arrays.js:69:9:69:41 | [VariableDeclarator] arrayFr ... -from") | semmle.label | 1 |
-| arrays.js:69:3:69:42 | [DeclStmt] const arrayFrom = ... | arrays.js:69:9:69:41 | [VariableDeclarator] arrayFr ... -from") | semmle.order | 1 |
-| arrays.js:69:9:69:41 | [VariableDeclarator] arrayFr ... -from") | arrays.js:69:9:69:17 | [VarDecl] arrayFrom | semmle.label | 1 |
-| arrays.js:69:9:69:41 | [VariableDeclarator] arrayFr ... -from") | arrays.js:69:9:69:17 | [VarDecl] arrayFrom | semmle.order | 1 |
-| arrays.js:69:9:69:41 | [VariableDeclarator] arrayFr ... -from") | arrays.js:69:21:69:41 | [CallExpr] require ... -from") | semmle.label | 2 |
-| arrays.js:69:9:69:41 | [VariableDeclarator] arrayFr ... -from") | arrays.js:69:21:69:41 | [CallExpr] require ... -from") | semmle.order | 2 |
-| arrays.js:69:21:69:41 | [CallExpr] require ... -from") | arrays.js:69:21:69:27 | [VarRef] require | semmle.label | 0 |
-| arrays.js:69:21:69:41 | [CallExpr] require ... -from") | arrays.js:69:21:69:27 | [VarRef] require | semmle.order | 0 |
-| arrays.js:69:21:69:41 | [CallExpr] require ... -from") | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:69:21:69:41 | [CallExpr] require ... -from") | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:37:3:37:29 | [DeclStmt] var arr5 = ... | arrays.js:37:7:37:28 | [VariableDeclarator] arr5 = ... t(arr4) | semmle.label | 1 |
+| arrays.js:37:3:37:29 | [DeclStmt] var arr5 = ... | arrays.js:37:7:37:28 | [VariableDeclarator] arr5 = ... t(arr4) | semmle.order | 1 |
+| arrays.js:37:7:37:28 | [VariableDeclarator] arr5 = ... t(arr4) | arrays.js:37:7:37:10 | [VarDecl] arr5 | semmle.label | 1 |
+| arrays.js:37:7:37:28 | [VariableDeclarator] arr5 = ... t(arr4) | arrays.js:37:7:37:10 | [VarDecl] arr5 | semmle.order | 1 |
+| arrays.js:37:7:37:28 | [VariableDeclarator] arr5 = ... t(arr4) | arrays.js:37:14:37:28 | [MethodCallExpr] [].concat(arr4) | semmle.label | 2 |
+| arrays.js:37:7:37:28 | [VariableDeclarator] arr5 = ... t(arr4) | arrays.js:37:14:37:28 | [MethodCallExpr] [].concat(arr4) | semmle.order | 2 |
+| arrays.js:37:14:37:22 | [DotExpr] [].concat | arrays.js:37:14:37:15 | [ArrayExpr] [] | semmle.label | 1 |
+| arrays.js:37:14:37:22 | [DotExpr] [].concat | arrays.js:37:14:37:15 | [ArrayExpr] [] | semmle.order | 1 |
+| arrays.js:37:14:37:22 | [DotExpr] [].concat | arrays.js:37:17:37:22 | [Label] concat | semmle.label | 2 |
+| arrays.js:37:14:37:22 | [DotExpr] [].concat | arrays.js:37:17:37:22 | [Label] concat | semmle.order | 2 |
+| arrays.js:37:14:37:28 | [MethodCallExpr] [].concat(arr4) | arrays.js:37:14:37:22 | [DotExpr] [].concat | semmle.label | 0 |
+| arrays.js:37:14:37:28 | [MethodCallExpr] [].concat(arr4) | arrays.js:37:14:37:22 | [DotExpr] [].concat | semmle.order | 0 |
+| arrays.js:37:14:37:28 | [MethodCallExpr] [].concat(arr4) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:37:14:37:28 | [MethodCallExpr] [].concat(arr4) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:38:3:38:18 | [CallExpr] sink(arr5.pop()) | arrays.js:38:3:38:6 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:38:3:38:18 | [CallExpr] sink(arr5.pop()) | arrays.js:38:3:38:6 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:38:3:38:18 | [CallExpr] sink(arr5.pop()) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:38:3:38:18 | [CallExpr] sink(arr5.pop()) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:38:3:38:19 | [ExprStmt] sink(arr5.pop()); | arrays.js:38:3:38:18 | [CallExpr] sink(arr5.pop()) | semmle.label | 1 |
+| arrays.js:38:3:38:19 | [ExprStmt] sink(arr5.pop()); | arrays.js:38:3:38:18 | [CallExpr] sink(arr5.pop()) | semmle.order | 1 |
+| arrays.js:38:8:38:15 | [DotExpr] arr5.pop | arrays.js:38:8:38:11 | [VarRef] arr5 | semmle.label | 1 |
+| arrays.js:38:8:38:15 | [DotExpr] arr5.pop | arrays.js:38:8:38:11 | [VarRef] arr5 | semmle.order | 1 |
+| arrays.js:38:8:38:15 | [DotExpr] arr5.pop | arrays.js:38:13:38:15 | [Label] pop | semmle.label | 2 |
+| arrays.js:38:8:38:15 | [DotExpr] arr5.pop | arrays.js:38:13:38:15 | [Label] pop | semmle.order | 2 |
+| arrays.js:38:8:38:17 | [MethodCallExpr] arr5.pop() | arrays.js:38:8:38:15 | [DotExpr] arr5.pop | semmle.label | 0 |
+| arrays.js:38:8:38:17 | [MethodCallExpr] arr5.pop() | arrays.js:38:8:38:15 | [DotExpr] arr5.pop | semmle.order | 0 |
+| arrays.js:40:3:40:27 | [CallExpr] sink(ar ... .pop()) | arrays.js:40:3:40:6 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:40:3:40:27 | [CallExpr] sink(ar ... .pop()) | arrays.js:40:3:40:6 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:40:3:40:27 | [CallExpr] sink(ar ... .pop()) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:40:3:40:27 | [CallExpr] sink(ar ... .pop()) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:40:3:40:28 | [ExprStmt] sink(ar ... pop()); | arrays.js:40:3:40:27 | [CallExpr] sink(ar ... .pop()) | semmle.label | 1 |
+| arrays.js:40:3:40:28 | [ExprStmt] sink(ar ... pop()); | arrays.js:40:3:40:27 | [CallExpr] sink(ar ... .pop()) | semmle.order | 1 |
+| arrays.js:40:8:40:17 | [DotExpr] arr5.slice | arrays.js:40:8:40:11 | [VarRef] arr5 | semmle.label | 1 |
+| arrays.js:40:8:40:17 | [DotExpr] arr5.slice | arrays.js:40:8:40:11 | [VarRef] arr5 | semmle.order | 1 |
+| arrays.js:40:8:40:17 | [DotExpr] arr5.slice | arrays.js:40:13:40:17 | [Label] slice | semmle.label | 2 |
+| arrays.js:40:8:40:17 | [DotExpr] arr5.slice | arrays.js:40:13:40:17 | [Label] slice | semmle.order | 2 |
+| arrays.js:40:8:40:20 | [MethodCallExpr] arr5.slice(2) | arrays.js:40:8:40:17 | [DotExpr] arr5.slice | semmle.label | 0 |
+| arrays.js:40:8:40:20 | [MethodCallExpr] arr5.slice(2) | arrays.js:40:8:40:17 | [DotExpr] arr5.slice | semmle.order | 0 |
+| arrays.js:40:8:40:20 | [MethodCallExpr] arr5.slice(2) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:40:8:40:20 | [MethodCallExpr] arr5.slice(2) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:40:8:40:24 | [DotExpr] arr5.slice(2).pop | arrays.js:40:8:40:20 | [MethodCallExpr] arr5.slice(2) | semmle.label | 1 |
+| arrays.js:40:8:40:24 | [DotExpr] arr5.slice(2).pop | arrays.js:40:8:40:20 | [MethodCallExpr] arr5.slice(2) | semmle.order | 1 |
+| arrays.js:40:8:40:24 | [DotExpr] arr5.slice(2).pop | arrays.js:40:22:40:24 | [Label] pop | semmle.label | 2 |
+| arrays.js:40:8:40:24 | [DotExpr] arr5.slice(2).pop | arrays.js:40:22:40:24 | [Label] pop | semmle.order | 2 |
+| arrays.js:40:8:40:26 | [MethodCallExpr] arr5.slice(2).pop() | arrays.js:40:8:40:24 | [DotExpr] arr5.slice(2).pop | semmle.label | 0 |
+| arrays.js:40:8:40:26 | [MethodCallExpr] arr5.slice(2).pop() | arrays.js:40:8:40:24 | [DotExpr] arr5.slice(2).pop | semmle.order | 0 |
+| arrays.js:42:3:42:16 | [DeclStmt] var arr6 = ... | arrays.js:42:7:42:15 | [VariableDeclarator] arr6 = [] | semmle.label | 1 |
+| arrays.js:42:3:42:16 | [DeclStmt] var arr6 = ... | arrays.js:42:7:42:15 | [VariableDeclarator] arr6 = [] | semmle.order | 1 |
+| arrays.js:42:7:42:15 | [VariableDeclarator] arr6 = [] | arrays.js:42:7:42:10 | [VarDecl] arr6 | semmle.label | 1 |
+| arrays.js:42:7:42:15 | [VariableDeclarator] arr6 = [] | arrays.js:42:7:42:10 | [VarDecl] arr6 | semmle.order | 1 |
+| arrays.js:42:7:42:15 | [VariableDeclarator] arr6 = [] | arrays.js:42:14:42:15 | [ArrayExpr] [] | semmle.label | 2 |
+| arrays.js:42:7:42:15 | [VariableDeclarator] arr6 = [] | arrays.js:42:14:42:15 | [ArrayExpr] [] | semmle.order | 2 |
+| arrays.js:43:3:45:3 | [ForStmt] for (va ... i]; } | arrays.js:43:8:43:16 | [DeclStmt] var i = ... | semmle.label | 1 |
+| arrays.js:43:3:45:3 | [ForStmt] for (va ... i]; } | arrays.js:43:8:43:16 | [DeclStmt] var i = ... | semmle.order | 1 |
+| arrays.js:43:3:45:3 | [ForStmt] for (va ... i]; } | arrays.js:43:19:43:33 | [BinaryExpr] i < arr5.length | semmle.label | 2 |
+| arrays.js:43:3:45:3 | [ForStmt] for (va ... i]; } | arrays.js:43:19:43:33 | [BinaryExpr] i < arr5.length | semmle.order | 2 |
+| arrays.js:43:3:45:3 | [ForStmt] for (va ... i]; } | arrays.js:43:36:43:38 | [UpdateExpr] i++ | semmle.label | 3 |
+| arrays.js:43:3:45:3 | [ForStmt] for (va ... i]; } | arrays.js:43:36:43:38 | [UpdateExpr] i++ | semmle.order | 3 |
+| arrays.js:43:3:45:3 | [ForStmt] for (va ... i]; } | arrays.js:43:41:45:3 | [BlockStmt] { a ... i]; } | semmle.label | 4 |
+| arrays.js:43:3:45:3 | [ForStmt] for (va ... i]; } | arrays.js:43:41:45:3 | [BlockStmt] { a ... i]; } | semmle.order | 4 |
+| arrays.js:43:8:43:16 | [DeclStmt] var i = ... | arrays.js:43:12:43:16 | [VariableDeclarator] i = 0 | semmle.label | 1 |
+| arrays.js:43:8:43:16 | [DeclStmt] var i = ... | arrays.js:43:12:43:16 | [VariableDeclarator] i = 0 | semmle.order | 1 |
+| arrays.js:43:12:43:16 | [VariableDeclarator] i = 0 | arrays.js:43:12:43:12 | [VarDecl] i | semmle.label | 1 |
+| arrays.js:43:12:43:16 | [VariableDeclarator] i = 0 | arrays.js:43:12:43:12 | [VarDecl] i | semmle.order | 1 |
+| arrays.js:43:12:43:16 | [VariableDeclarator] i = 0 | arrays.js:43:16:43:16 | [Literal] 0 | semmle.label | 2 |
+| arrays.js:43:12:43:16 | [VariableDeclarator] i = 0 | arrays.js:43:16:43:16 | [Literal] 0 | semmle.order | 2 |
+| arrays.js:43:19:43:33 | [BinaryExpr] i < arr5.length | arrays.js:43:19:43:19 | [VarRef] i | semmle.label | 1 |
+| arrays.js:43:19:43:33 | [BinaryExpr] i < arr5.length | arrays.js:43:19:43:19 | [VarRef] i | semmle.order | 1 |
+| arrays.js:43:19:43:33 | [BinaryExpr] i < arr5.length | arrays.js:43:23:43:33 | [DotExpr] arr5.length | semmle.label | 2 |
+| arrays.js:43:19:43:33 | [BinaryExpr] i < arr5.length | arrays.js:43:23:43:33 | [DotExpr] arr5.length | semmle.order | 2 |
+| arrays.js:43:23:43:33 | [DotExpr] arr5.length | arrays.js:43:23:43:26 | [VarRef] arr5 | semmle.label | 1 |
+| arrays.js:43:23:43:33 | [DotExpr] arr5.length | arrays.js:43:23:43:26 | [VarRef] arr5 | semmle.order | 1 |
+| arrays.js:43:23:43:33 | [DotExpr] arr5.length | arrays.js:43:28:43:33 | [Label] length | semmle.label | 2 |
+| arrays.js:43:23:43:33 | [DotExpr] arr5.length | arrays.js:43:28:43:33 | [Label] length | semmle.order | 2 |
+| arrays.js:43:36:43:38 | [UpdateExpr] i++ | arrays.js:43:36:43:36 | [VarRef] i | semmle.label | 1 |
+| arrays.js:43:36:43:38 | [UpdateExpr] i++ | arrays.js:43:36:43:36 | [VarRef] i | semmle.order | 1 |
+| arrays.js:43:41:45:3 | [BlockStmt] { a ... i]; } | arrays.js:44:5:44:22 | [ExprStmt] arr6[i] = arr5[i]; | semmle.label | 1 |
+| arrays.js:43:41:45:3 | [BlockStmt] { a ... i]; } | arrays.js:44:5:44:22 | [ExprStmt] arr6[i] = arr5[i]; | semmle.order | 1 |
+| arrays.js:44:5:44:11 | [IndexExpr] arr6[i] | arrays.js:44:5:44:8 | [VarRef] arr6 | semmle.label | 1 |
+| arrays.js:44:5:44:11 | [IndexExpr] arr6[i] | arrays.js:44:5:44:8 | [VarRef] arr6 | semmle.order | 1 |
+| arrays.js:44:5:44:11 | [IndexExpr] arr6[i] | arrays.js:44:10:44:10 | [VarRef] i | semmle.label | 2 |
+| arrays.js:44:5:44:11 | [IndexExpr] arr6[i] | arrays.js:44:10:44:10 | [VarRef] i | semmle.order | 2 |
+| arrays.js:44:5:44:21 | [AssignExpr] arr6[i] = arr5[i] | arrays.js:44:5:44:11 | [IndexExpr] arr6[i] | semmle.label | 1 |
+| arrays.js:44:5:44:21 | [AssignExpr] arr6[i] = arr5[i] | arrays.js:44:5:44:11 | [IndexExpr] arr6[i] | semmle.order | 1 |
+| arrays.js:44:5:44:21 | [AssignExpr] arr6[i] = arr5[i] | arrays.js:44:15:44:21 | [IndexExpr] arr5[i] | semmle.label | 2 |
+| arrays.js:44:5:44:21 | [AssignExpr] arr6[i] = arr5[i] | arrays.js:44:15:44:21 | [IndexExpr] arr5[i] | semmle.order | 2 |
+| arrays.js:44:5:44:22 | [ExprStmt] arr6[i] = arr5[i]; | arrays.js:44:5:44:21 | [AssignExpr] arr6[i] = arr5[i] | semmle.label | 1 |
+| arrays.js:44:5:44:22 | [ExprStmt] arr6[i] = arr5[i]; | arrays.js:44:5:44:21 | [AssignExpr] arr6[i] = arr5[i] | semmle.order | 1 |
+| arrays.js:44:15:44:21 | [IndexExpr] arr5[i] | arrays.js:44:15:44:18 | [VarRef] arr5 | semmle.label | 1 |
+| arrays.js:44:15:44:21 | [IndexExpr] arr5[i] | arrays.js:44:15:44:18 | [VarRef] arr5 | semmle.order | 1 |
+| arrays.js:44:15:44:21 | [IndexExpr] arr5[i] | arrays.js:44:20:44:20 | [VarRef] i | semmle.label | 2 |
+| arrays.js:44:15:44:21 | [IndexExpr] arr5[i] | arrays.js:44:20:44:20 | [VarRef] i | semmle.order | 2 |
+| arrays.js:46:3:46:18 | [CallExpr] sink(arr6.pop()) | arrays.js:46:3:46:6 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:46:3:46:18 | [CallExpr] sink(arr6.pop()) | arrays.js:46:3:46:6 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:46:3:46:18 | [CallExpr] sink(arr6.pop()) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:46:3:46:18 | [CallExpr] sink(arr6.pop()) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:46:3:46:19 | [ExprStmt] sink(arr6.pop()); | arrays.js:46:3:46:18 | [CallExpr] sink(arr6.pop()) | semmle.label | 1 |
+| arrays.js:46:3:46:19 | [ExprStmt] sink(arr6.pop()); | arrays.js:46:3:46:18 | [CallExpr] sink(arr6.pop()) | semmle.order | 1 |
+| arrays.js:46:8:46:15 | [DotExpr] arr6.pop | arrays.js:46:8:46:11 | [VarRef] arr6 | semmle.label | 1 |
+| arrays.js:46:8:46:15 | [DotExpr] arr6.pop | arrays.js:46:8:46:11 | [VarRef] arr6 | semmle.order | 1 |
+| arrays.js:46:8:46:15 | [DotExpr] arr6.pop | arrays.js:46:13:46:15 | [Label] pop | semmle.label | 2 |
+| arrays.js:46:8:46:15 | [DotExpr] arr6.pop | arrays.js:46:13:46:15 | [Label] pop | semmle.order | 2 |
+| arrays.js:46:8:46:17 | [MethodCallExpr] arr6.pop() | arrays.js:46:8:46:15 | [DotExpr] arr6.pop | semmle.label | 0 |
+| arrays.js:46:8:46:17 | [MethodCallExpr] arr6.pop() | arrays.js:46:8:46:15 | [DotExpr] arr6.pop | semmle.order | 0 |
+| arrays.js:49:3:49:12 | [ArrayExpr] ["source"] | arrays.js:49:4:49:11 | [Literal] "source" | semmle.label | 1 |
+| arrays.js:49:3:49:12 | [ArrayExpr] ["source"] | arrays.js:49:4:49:11 | [Literal] "source" | semmle.order | 1 |
+| arrays.js:49:3:49:20 | [DotExpr] ["source"].forEach | arrays.js:49:3:49:12 | [ArrayExpr] ["source"] | semmle.label | 1 |
+| arrays.js:49:3:49:20 | [DotExpr] ["source"].forEach | arrays.js:49:3:49:12 | [ArrayExpr] ["source"] | semmle.order | 1 |
+| arrays.js:49:3:49:20 | [DotExpr] ["source"].forEach | arrays.js:49:14:49:20 | [Label] forEach | semmle.label | 2 |
+| arrays.js:49:3:49:20 | [DotExpr] ["source"].forEach | arrays.js:49:14:49:20 | [Label] forEach | semmle.order | 2 |
+| arrays.js:49:3:52:4 | [MethodCallExpr] ["sourc ... t. }) | arrays.js:49:3:49:20 | [DotExpr] ["source"].forEach | semmle.label | 0 |
+| arrays.js:49:3:52:4 | [MethodCallExpr] ["sourc ... t. }) | arrays.js:49:3:49:20 | [DotExpr] ["source"].forEach | semmle.order | 0 |
+| arrays.js:49:3:52:4 | [MethodCallExpr] ["sourc ... t. }) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:49:3:52:4 | [MethodCallExpr] ["sourc ... t. }) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:49:3:52:5 | [ExprStmt] ["sourc ... . }); | arrays.js:49:3:52:4 | [MethodCallExpr] ["sourc ... t. }) | semmle.label | 1 |
+| arrays.js:49:3:52:5 | [ExprStmt] ["sourc ... . }); | arrays.js:49:3:52:4 | [MethodCallExpr] ["sourc ... t. }) | semmle.order | 1 |
+| arrays.js:49:22:52:3 | [ArrowFunctionExpr] (e, i, ... nt. } | arrays.js:49:37:52:3 | [BlockStmt] { s ... nt. } | semmle.label | 5 |
+| arrays.js:49:22:52:3 | [ArrowFunctionExpr] (e, i, ... nt. } | arrays.js:49:37:52:3 | [BlockStmt] { s ... nt. } | semmle.order | 5 |
+| arrays.js:49:22:52:3 | [ArrowFunctionExpr] (e, i, ... nt. } | file://:0:0:0:0 | (Parameters) | semmle.label | 1 |
+| arrays.js:49:22:52:3 | [ArrowFunctionExpr] (e, i, ... nt. } | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
+| arrays.js:49:37:52:3 | [BlockStmt] { s ... nt. } | arrays.js:50:5:50:20 | [ExprStmt] sink(ary.pop()); | semmle.label | 1 |
+| arrays.js:49:37:52:3 | [BlockStmt] { s ... nt. } | arrays.js:50:5:50:20 | [ExprStmt] sink(ary.pop()); | semmle.order | 1 |
+| arrays.js:49:37:52:3 | [BlockStmt] { s ... nt. } | arrays.js:51:5:51:14 | [ExprStmt] sink(ary); | semmle.label | 2 |
+| arrays.js:49:37:52:3 | [BlockStmt] { s ... nt. } | arrays.js:51:5:51:14 | [ExprStmt] sink(ary); | semmle.order | 2 |
+| arrays.js:50:5:50:19 | [CallExpr] sink(ary.pop()) | arrays.js:50:5:50:8 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:50:5:50:19 | [CallExpr] sink(ary.pop()) | arrays.js:50:5:50:8 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:50:5:50:19 | [CallExpr] sink(ary.pop()) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:50:5:50:19 | [CallExpr] sink(ary.pop()) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:50:5:50:20 | [ExprStmt] sink(ary.pop()); | arrays.js:50:5:50:19 | [CallExpr] sink(ary.pop()) | semmle.label | 1 |
+| arrays.js:50:5:50:20 | [ExprStmt] sink(ary.pop()); | arrays.js:50:5:50:19 | [CallExpr] sink(ary.pop()) | semmle.order | 1 |
+| arrays.js:50:10:50:16 | [DotExpr] ary.pop | arrays.js:50:10:50:12 | [VarRef] ary | semmle.label | 1 |
+| arrays.js:50:10:50:16 | [DotExpr] ary.pop | arrays.js:50:10:50:12 | [VarRef] ary | semmle.order | 1 |
+| arrays.js:50:10:50:16 | [DotExpr] ary.pop | arrays.js:50:14:50:16 | [Label] pop | semmle.label | 2 |
+| arrays.js:50:10:50:16 | [DotExpr] ary.pop | arrays.js:50:14:50:16 | [Label] pop | semmle.order | 2 |
+| arrays.js:50:10:50:18 | [MethodCallExpr] ary.pop() | arrays.js:50:10:50:16 | [DotExpr] ary.pop | semmle.label | 0 |
+| arrays.js:50:10:50:18 | [MethodCallExpr] ary.pop() | arrays.js:50:10:50:16 | [DotExpr] ary.pop | semmle.order | 0 |
+| arrays.js:51:5:51:13 | [CallExpr] sink(ary) | arrays.js:51:5:51:8 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:51:5:51:13 | [CallExpr] sink(ary) | arrays.js:51:5:51:8 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:51:5:51:13 | [CallExpr] sink(ary) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:51:5:51:13 | [CallExpr] sink(ary) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:51:5:51:14 | [ExprStmt] sink(ary); | arrays.js:51:5:51:13 | [CallExpr] sink(ary) | semmle.label | 1 |
+| arrays.js:51:5:51:14 | [ExprStmt] sink(ary); | arrays.js:51:5:51:13 | [CallExpr] sink(ary) | semmle.order | 1 |
+| arrays.js:54:3:54:14 | [CallExpr] sink(arr[0]) | arrays.js:54:3:54:6 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:54:3:54:14 | [CallExpr] sink(arr[0]) | arrays.js:54:3:54:6 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:54:3:54:14 | [CallExpr] sink(arr[0]) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:54:3:54:14 | [CallExpr] sink(arr[0]) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:54:3:54:15 | [ExprStmt] sink(arr[0]); | arrays.js:54:3:54:14 | [CallExpr] sink(arr[0]) | semmle.label | 1 |
+| arrays.js:54:3:54:15 | [ExprStmt] sink(arr[0]); | arrays.js:54:3:54:14 | [CallExpr] sink(arr[0]) | semmle.order | 1 |
+| arrays.js:54:8:54:13 | [IndexExpr] arr[0] | arrays.js:54:8:54:10 | [VarRef] arr | semmle.label | 1 |
+| arrays.js:54:8:54:13 | [IndexExpr] arr[0] | arrays.js:54:8:54:10 | [VarRef] arr | semmle.order | 1 |
+| arrays.js:54:8:54:13 | [IndexExpr] arr[0] | arrays.js:54:12:54:12 | [Literal] 0 | semmle.label | 2 |
+| arrays.js:54:8:54:13 | [IndexExpr] arr[0] | arrays.js:54:12:54:12 | [Literal] 0 | semmle.order | 2 |
+| arrays.js:56:3:58:3 | [ForOfStmt] for (co ... OK } | arrays.js:56:8:56:14 | [DeclStmt] const x = ... | semmle.label | 1 |
+| arrays.js:56:3:58:3 | [ForOfStmt] for (co ... OK } | arrays.js:56:8:56:14 | [DeclStmt] const x = ... | semmle.order | 1 |
+| arrays.js:56:3:58:3 | [ForOfStmt] for (co ... OK } | arrays.js:56:19:56:21 | [VarRef] arr | semmle.label | 2 |
+| arrays.js:56:3:58:3 | [ForOfStmt] for (co ... OK } | arrays.js:56:19:56:21 | [VarRef] arr | semmle.order | 2 |
+| arrays.js:56:3:58:3 | [ForOfStmt] for (co ... OK } | arrays.js:56:24:58:3 | [BlockStmt] { s ... OK } | semmle.label | 3 |
+| arrays.js:56:3:58:3 | [ForOfStmt] for (co ... OK } | arrays.js:56:24:58:3 | [BlockStmt] { s ... OK } | semmle.order | 3 |
+| arrays.js:56:8:56:14 | [DeclStmt] const x = ... | arrays.js:56:14:56:14 | [VariableDeclarator] x | semmle.label | 1 |
+| arrays.js:56:8:56:14 | [DeclStmt] const x = ... | arrays.js:56:14:56:14 | [VariableDeclarator] x | semmle.order | 1 |
+| arrays.js:56:14:56:14 | [VariableDeclarator] x | arrays.js:56:14:56:14 | [VarDecl] x | semmle.label | 1 |
+| arrays.js:56:14:56:14 | [VariableDeclarator] x | arrays.js:56:14:56:14 | [VarDecl] x | semmle.order | 1 |
+| arrays.js:56:24:58:3 | [BlockStmt] { s ... OK } | arrays.js:57:5:57:12 | [ExprStmt] sink(x); | semmle.label | 1 |
+| arrays.js:56:24:58:3 | [BlockStmt] { s ... OK } | arrays.js:57:5:57:12 | [ExprStmt] sink(x); | semmle.order | 1 |
+| arrays.js:57:5:57:11 | [CallExpr] sink(x) | arrays.js:57:5:57:8 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:57:5:57:11 | [CallExpr] sink(x) | arrays.js:57:5:57:8 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:57:5:57:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:57:5:57:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:57:5:57:12 | [ExprStmt] sink(x); | arrays.js:57:5:57:11 | [CallExpr] sink(x) | semmle.label | 1 |
+| arrays.js:57:5:57:12 | [ExprStmt] sink(x); | arrays.js:57:5:57:11 | [CallExpr] sink(x) | semmle.order | 1 |
+| arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | arrays.js:60:8:60:14 | [DeclStmt] const x = ... | semmle.label | 1 |
+| arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | arrays.js:60:8:60:14 | [DeclStmt] const x = ... | semmle.order | 1 |
+| arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | arrays.js:60:19:60:33 | [MethodCallExpr] Array.from(arr) | semmle.label | 2 |
+| arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | arrays.js:60:19:60:33 | [MethodCallExpr] Array.from(arr) | semmle.order | 2 |
+| arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | arrays.js:60:36:62:3 | [BlockStmt] { s ... OK } | semmle.label | 3 |
+| arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | arrays.js:60:36:62:3 | [BlockStmt] { s ... OK } | semmle.order | 3 |
+| arrays.js:60:8:60:14 | [DeclStmt] const x = ... | arrays.js:60:14:60:14 | [VariableDeclarator] x | semmle.label | 1 |
+| arrays.js:60:8:60:14 | [DeclStmt] const x = ... | arrays.js:60:14:60:14 | [VariableDeclarator] x | semmle.order | 1 |
+| arrays.js:60:14:60:14 | [VariableDeclarator] x | arrays.js:60:14:60:14 | [VarDecl] x | semmle.label | 1 |
+| arrays.js:60:14:60:14 | [VariableDeclarator] x | arrays.js:60:14:60:14 | [VarDecl] x | semmle.order | 1 |
+| arrays.js:60:19:60:28 | [DotExpr] Array.from | arrays.js:60:19:60:23 | [VarRef] Array | semmle.label | 1 |
+| arrays.js:60:19:60:28 | [DotExpr] Array.from | arrays.js:60:19:60:23 | [VarRef] Array | semmle.order | 1 |
+| arrays.js:60:19:60:28 | [DotExpr] Array.from | arrays.js:60:25:60:28 | [Label] from | semmle.label | 2 |
+| arrays.js:60:19:60:28 | [DotExpr] Array.from | arrays.js:60:25:60:28 | [Label] from | semmle.order | 2 |
+| arrays.js:60:19:60:33 | [MethodCallExpr] Array.from(arr) | arrays.js:60:19:60:28 | [DotExpr] Array.from | semmle.label | 0 |
+| arrays.js:60:19:60:33 | [MethodCallExpr] Array.from(arr) | arrays.js:60:19:60:28 | [DotExpr] Array.from | semmle.order | 0 |
+| arrays.js:60:19:60:33 | [MethodCallExpr] Array.from(arr) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:60:19:60:33 | [MethodCallExpr] Array.from(arr) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:60:36:62:3 | [BlockStmt] { s ... OK } | arrays.js:61:5:61:12 | [ExprStmt] sink(x); | semmle.label | 1 |
+| arrays.js:60:36:62:3 | [BlockStmt] { s ... OK } | arrays.js:61:5:61:12 | [ExprStmt] sink(x); | semmle.order | 1 |
+| arrays.js:61:5:61:11 | [CallExpr] sink(x) | arrays.js:61:5:61:8 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:61:5:61:11 | [CallExpr] sink(x) | arrays.js:61:5:61:8 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:61:5:61:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:61:5:61:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:61:5:61:12 | [ExprStmt] sink(x); | arrays.js:61:5:61:11 | [CallExpr] sink(x) | semmle.label | 1 |
+| arrays.js:61:5:61:12 | [ExprStmt] sink(x); | arrays.js:61:5:61:11 | [CallExpr] sink(x) | semmle.order | 1 |
+| arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | arrays.js:64:8:64:14 | [DeclStmt] const x = ... | semmle.label | 1 |
+| arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | arrays.js:64:8:64:14 | [DeclStmt] const x = ... | semmle.order | 1 |
+| arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | arrays.js:64:19:64:26 | [ArrayExpr] [...arr] | semmle.label | 2 |
+| arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | arrays.js:64:19:64:26 | [ArrayExpr] [...arr] | semmle.order | 2 |
+| arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | arrays.js:64:29:66:3 | [BlockStmt] { s ... OK } | semmle.label | 3 |
+| arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | arrays.js:64:29:66:3 | [BlockStmt] { s ... OK } | semmle.order | 3 |
+| arrays.js:64:8:64:14 | [DeclStmt] const x = ... | arrays.js:64:14:64:14 | [VariableDeclarator] x | semmle.label | 1 |
+| arrays.js:64:8:64:14 | [DeclStmt] const x = ... | arrays.js:64:14:64:14 | [VariableDeclarator] x | semmle.order | 1 |
+| arrays.js:64:14:64:14 | [VariableDeclarator] x | arrays.js:64:14:64:14 | [VarDecl] x | semmle.label | 1 |
+| arrays.js:64:14:64:14 | [VariableDeclarator] x | arrays.js:64:14:64:14 | [VarDecl] x | semmle.order | 1 |
+| arrays.js:64:19:64:26 | [ArrayExpr] [...arr] | arrays.js:64:20:64:25 | [SpreadElement] ...arr | semmle.label | 1 |
+| arrays.js:64:19:64:26 | [ArrayExpr] [...arr] | arrays.js:64:20:64:25 | [SpreadElement] ...arr | semmle.order | 1 |
+| arrays.js:64:20:64:25 | [SpreadElement] ...arr | arrays.js:64:23:64:25 | [VarRef] arr | semmle.label | 1 |
+| arrays.js:64:20:64:25 | [SpreadElement] ...arr | arrays.js:64:23:64:25 | [VarRef] arr | semmle.order | 1 |
+| arrays.js:64:29:66:3 | [BlockStmt] { s ... OK } | arrays.js:65:5:65:12 | [ExprStmt] sink(x); | semmle.label | 1 |
+| arrays.js:64:29:66:3 | [BlockStmt] { s ... OK } | arrays.js:65:5:65:12 | [ExprStmt] sink(x); | semmle.order | 1 |
+| arrays.js:65:5:65:11 | [CallExpr] sink(x) | arrays.js:65:5:65:8 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:65:5:65:11 | [CallExpr] sink(x) | arrays.js:65:5:65:8 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:65:5:65:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:65:5:65:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:65:5:65:12 | [ExprStmt] sink(x); | arrays.js:65:5:65:11 | [CallExpr] sink(x) | semmle.label | 1 |
+| arrays.js:65:5:65:12 | [ExprStmt] sink(x); | arrays.js:65:5:65:11 | [CallExpr] sink(x) | semmle.order | 1 |
+| arrays.js:68:3:68:16 | [DeclStmt] var arr7 = ... | arrays.js:68:7:68:15 | [VariableDeclarator] arr7 = [] | semmle.label | 1 |
+| arrays.js:68:3:68:16 | [DeclStmt] var arr7 = ... | arrays.js:68:7:68:15 | [VariableDeclarator] arr7 = [] | semmle.order | 1 |
+| arrays.js:68:7:68:15 | [VariableDeclarator] arr7 = [] | arrays.js:68:7:68:10 | [VarDecl] arr7 | semmle.label | 1 |
+| arrays.js:68:7:68:15 | [VariableDeclarator] arr7 = [] | arrays.js:68:7:68:10 | [VarDecl] arr7 | semmle.order | 1 |
+| arrays.js:68:7:68:15 | [VariableDeclarator] arr7 = [] | arrays.js:68:14:68:15 | [ArrayExpr] [] | semmle.label | 2 |
+| arrays.js:68:7:68:15 | [VariableDeclarator] arr7 = [] | arrays.js:68:14:68:15 | [ArrayExpr] [] | semmle.order | 2 |
+| arrays.js:69:3:69:11 | [DotExpr] arr7.push | arrays.js:69:3:69:6 | [VarRef] arr7 | semmle.label | 1 |
+| arrays.js:69:3:69:11 | [DotExpr] arr7.push | arrays.js:69:3:69:6 | [VarRef] arr7 | semmle.order | 1 |
+| arrays.js:69:3:69:11 | [DotExpr] arr7.push | arrays.js:69:8:69:11 | [Label] push | semmle.label | 2 |
+| arrays.js:69:3:69:11 | [DotExpr] arr7.push | arrays.js:69:8:69:11 | [Label] push | semmle.order | 2 |
+| arrays.js:69:3:69:19 | [MethodCallExpr] arr7.push(...arr) | arrays.js:69:3:69:11 | [DotExpr] arr7.push | semmle.label | 0 |
+| arrays.js:69:3:69:19 | [MethodCallExpr] arr7.push(...arr) | arrays.js:69:3:69:11 | [DotExpr] arr7.push | semmle.order | 0 |
+| arrays.js:69:3:69:19 | [MethodCallExpr] arr7.push(...arr) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:69:3:69:19 | [MethodCallExpr] arr7.push(...arr) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:69:3:69:20 | [ExprStmt] arr7.push(...arr); | arrays.js:69:3:69:19 | [MethodCallExpr] arr7.push(...arr) | semmle.label | 1 |
+| arrays.js:69:3:69:20 | [ExprStmt] arr7.push(...arr); | arrays.js:69:3:69:19 | [MethodCallExpr] arr7.push(...arr) | semmle.order | 1 |
+| arrays.js:69:13:69:18 | [SpreadElement] ...arr | arrays.js:69:16:69:18 | [VarRef] arr | semmle.label | 1 |
+| arrays.js:69:13:69:18 | [SpreadElement] ...arr | arrays.js:69:16:69:18 | [VarRef] arr | semmle.order | 1 |
 | arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | arrays.js:70:8:70:14 | [DeclStmt] const x = ... | semmle.label | 1 |
 | arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | arrays.js:70:8:70:14 | [DeclStmt] const x = ... | semmle.order | 1 |
-| arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | arrays.js:70:19:70:32 | [CallExpr] arrayFrom(arr) | semmle.label | 2 |
-| arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | arrays.js:70:19:70:32 | [CallExpr] arrayFrom(arr) | semmle.order | 2 |
-| arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | arrays.js:70:35:72:3 | [BlockStmt] { s ... OK } | semmle.label | 3 |
-| arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | arrays.js:70:35:72:3 | [BlockStmt] { s ... OK } | semmle.order | 3 |
+| arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | arrays.js:70:19:70:22 | [VarRef] arr7 | semmle.label | 2 |
+| arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | arrays.js:70:19:70:22 | [VarRef] arr7 | semmle.order | 2 |
+| arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | arrays.js:70:25:72:3 | [BlockStmt] { s ... OK } | semmle.label | 3 |
+| arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | arrays.js:70:25:72:3 | [BlockStmt] { s ... OK } | semmle.order | 3 |
 | arrays.js:70:8:70:14 | [DeclStmt] const x = ... | arrays.js:70:14:70:14 | [VariableDeclarator] x | semmle.label | 1 |
 | arrays.js:70:8:70:14 | [DeclStmt] const x = ... | arrays.js:70:14:70:14 | [VariableDeclarator] x | semmle.order | 1 |
 | arrays.js:70:14:70:14 | [VariableDeclarator] x | arrays.js:70:14:70:14 | [VarDecl] x | semmle.label | 1 |
 | arrays.js:70:14:70:14 | [VariableDeclarator] x | arrays.js:70:14:70:14 | [VarDecl] x | semmle.order | 1 |
-| arrays.js:70:19:70:32 | [CallExpr] arrayFrom(arr) | arrays.js:70:19:70:27 | [VarRef] arrayFrom | semmle.label | 0 |
-| arrays.js:70:19:70:32 | [CallExpr] arrayFrom(arr) | arrays.js:70:19:70:27 | [VarRef] arrayFrom | semmle.order | 0 |
-| arrays.js:70:19:70:32 | [CallExpr] arrayFrom(arr) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:70:19:70:32 | [CallExpr] arrayFrom(arr) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:70:35:72:3 | [BlockStmt] { s ... OK } | arrays.js:71:5:71:12 | [ExprStmt] sink(x); | semmle.label | 1 |
-| arrays.js:70:35:72:3 | [BlockStmt] { s ... OK } | arrays.js:71:5:71:12 | [ExprStmt] sink(x); | semmle.order | 1 |
+| arrays.js:70:25:72:3 | [BlockStmt] { s ... OK } | arrays.js:71:5:71:12 | [ExprStmt] sink(x); | semmle.label | 1 |
+| arrays.js:70:25:72:3 | [BlockStmt] { s ... OK } | arrays.js:71:5:71:12 | [ExprStmt] sink(x); | semmle.order | 1 |
 | arrays.js:71:5:71:11 | [CallExpr] sink(x) | arrays.js:71:5:71:8 | [VarRef] sink | semmle.label | 0 |
 | arrays.js:71:5:71:11 | [CallExpr] sink(x) | arrays.js:71:5:71:8 | [VarRef] sink | semmle.order | 0 |
 | arrays.js:71:5:71:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
 | arrays.js:71:5:71:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
 | arrays.js:71:5:71:12 | [ExprStmt] sink(x); | arrays.js:71:5:71:11 | [CallExpr] sink(x) | semmle.label | 1 |
 | arrays.js:71:5:71:12 | [ExprStmt] sink(x); | arrays.js:71:5:71:11 | [CallExpr] sink(x) | semmle.order | 1 |
-| arrays.js:74:3:74:30 | [CallExpr] sink(ar ... lback)) | arrays.js:74:3:74:6 | [VarRef] sink | semmle.label | 0 |
-| arrays.js:74:3:74:30 | [CallExpr] sink(ar ... lback)) | arrays.js:74:3:74:6 | [VarRef] sink | semmle.order | 0 |
-| arrays.js:74:3:74:30 | [CallExpr] sink(ar ... lback)) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:74:3:74:30 | [CallExpr] sink(ar ... lback)) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:74:3:74:31 | [ExprStmt] sink(ar ... back)); | arrays.js:74:3:74:30 | [CallExpr] sink(ar ... lback)) | semmle.label | 1 |
-| arrays.js:74:3:74:31 | [ExprStmt] sink(ar ... back)); | arrays.js:74:3:74:30 | [CallExpr] sink(ar ... lback)) | semmle.order | 1 |
-| arrays.js:74:8:74:15 | [DotExpr] arr.find | arrays.js:74:8:74:10 | [VarRef] arr | semmle.label | 1 |
-| arrays.js:74:8:74:15 | [DotExpr] arr.find | arrays.js:74:8:74:10 | [VarRef] arr | semmle.order | 1 |
-| arrays.js:74:8:74:15 | [DotExpr] arr.find | arrays.js:74:12:74:15 | [Label] find | semmle.label | 2 |
-| arrays.js:74:8:74:15 | [DotExpr] arr.find | arrays.js:74:12:74:15 | [Label] find | semmle.order | 2 |
-| arrays.js:74:8:74:29 | [MethodCallExpr] arr.fin ... llback) | arrays.js:74:8:74:15 | [DotExpr] arr.find | semmle.label | 0 |
-| arrays.js:74:8:74:29 | [MethodCallExpr] arr.fin ... llback) | arrays.js:74:8:74:15 | [DotExpr] arr.find | semmle.order | 0 |
-| arrays.js:74:8:74:29 | [MethodCallExpr] arr.fin ... llback) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:74:8:74:29 | [MethodCallExpr] arr.fin ... llback) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:76:3:76:42 | [DeclStmt] const arrayFind = ... | arrays.js:76:9:76:41 | [VariableDeclarator] arrayFi ... -find") | semmle.label | 1 |
-| arrays.js:76:3:76:42 | [DeclStmt] const arrayFind = ... | arrays.js:76:9:76:41 | [VariableDeclarator] arrayFi ... -find") | semmle.order | 1 |
-| arrays.js:76:9:76:41 | [VariableDeclarator] arrayFi ... -find") | arrays.js:76:9:76:17 | [VarDecl] arrayFind | semmle.label | 1 |
-| arrays.js:76:9:76:41 | [VariableDeclarator] arrayFi ... -find") | arrays.js:76:9:76:17 | [VarDecl] arrayFind | semmle.order | 1 |
-| arrays.js:76:9:76:41 | [VariableDeclarator] arrayFi ... -find") | arrays.js:76:21:76:41 | [CallExpr] require ... -find") | semmle.label | 2 |
-| arrays.js:76:9:76:41 | [VariableDeclarator] arrayFi ... -find") | arrays.js:76:21:76:41 | [CallExpr] require ... -find") | semmle.order | 2 |
-| arrays.js:76:21:76:41 | [CallExpr] require ... -find") | arrays.js:76:21:76:27 | [VarRef] require | semmle.label | 0 |
-| arrays.js:76:21:76:41 | [CallExpr] require ... -find") | arrays.js:76:21:76:27 | [VarRef] require | semmle.order | 0 |
-| arrays.js:76:21:76:41 | [CallExpr] require ... -find") | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:76:21:76:41 | [CallExpr] require ... -find") | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:77:3:77:36 | [CallExpr] sink(ar ... lback)) | arrays.js:77:3:77:6 | [VarRef] sink | semmle.label | 0 |
-| arrays.js:77:3:77:36 | [CallExpr] sink(ar ... lback)) | arrays.js:77:3:77:6 | [VarRef] sink | semmle.order | 0 |
-| arrays.js:77:3:77:36 | [CallExpr] sink(ar ... lback)) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:77:3:77:36 | [CallExpr] sink(ar ... lback)) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:77:3:77:37 | [ExprStmt] sink(ar ... back)); | arrays.js:77:3:77:36 | [CallExpr] sink(ar ... lback)) | semmle.label | 1 |
-| arrays.js:77:3:77:37 | [ExprStmt] sink(ar ... back)); | arrays.js:77:3:77:36 | [CallExpr] sink(ar ... lback)) | semmle.order | 1 |
-| arrays.js:77:8:77:35 | [CallExpr] arrayFi ... llback) | arrays.js:77:8:77:16 | [VarRef] arrayFind | semmle.label | 0 |
-| arrays.js:77:8:77:35 | [CallExpr] arrayFi ... llback) | arrays.js:77:8:77:16 | [VarRef] arrayFind | semmle.order | 0 |
-| arrays.js:77:8:77:35 | [CallExpr] arrayFi ... llback) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:77:8:77:35 | [CallExpr] arrayFi ... llback) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:79:3:79:31 | [DeclStmt] const uniq = ... | arrays.js:79:9:79:30 | [VariableDeclarator] uniq = ... "uniq") | semmle.label | 1 |
-| arrays.js:79:3:79:31 | [DeclStmt] const uniq = ... | arrays.js:79:9:79:30 | [VariableDeclarator] uniq = ... "uniq") | semmle.order | 1 |
-| arrays.js:79:9:79:30 | [VariableDeclarator] uniq = ... "uniq") | arrays.js:79:9:79:12 | [VarDecl] uniq | semmle.label | 1 |
-| arrays.js:79:9:79:30 | [VariableDeclarator] uniq = ... "uniq") | arrays.js:79:9:79:12 | [VarDecl] uniq | semmle.order | 1 |
-| arrays.js:79:9:79:30 | [VariableDeclarator] uniq = ... "uniq") | arrays.js:79:16:79:30 | [CallExpr] require("uniq") | semmle.label | 2 |
-| arrays.js:79:9:79:30 | [VariableDeclarator] uniq = ... "uniq") | arrays.js:79:16:79:30 | [CallExpr] require("uniq") | semmle.order | 2 |
-| arrays.js:79:16:79:30 | [CallExpr] require("uniq") | arrays.js:79:16:79:22 | [VarRef] require | semmle.label | 0 |
-| arrays.js:79:16:79:30 | [CallExpr] require("uniq") | arrays.js:79:16:79:22 | [VarRef] require | semmle.order | 0 |
-| arrays.js:79:16:79:30 | [CallExpr] require("uniq") | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:79:16:79:30 | [CallExpr] require("uniq") | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:80:3:82:3 | [ForOfStmt] for (co ... OK } | arrays.js:80:8:80:14 | [DeclStmt] const x = ... | semmle.label | 1 |
-| arrays.js:80:3:82:3 | [ForOfStmt] for (co ... OK } | arrays.js:80:8:80:14 | [DeclStmt] const x = ... | semmle.order | 1 |
-| arrays.js:80:3:82:3 | [ForOfStmt] for (co ... OK } | arrays.js:80:19:80:27 | [CallExpr] uniq(arr) | semmle.label | 2 |
-| arrays.js:80:3:82:3 | [ForOfStmt] for (co ... OK } | arrays.js:80:19:80:27 | [CallExpr] uniq(arr) | semmle.order | 2 |
-| arrays.js:80:3:82:3 | [ForOfStmt] for (co ... OK } | arrays.js:80:30:82:3 | [BlockStmt] { s ... OK } | semmle.label | 3 |
-| arrays.js:80:3:82:3 | [ForOfStmt] for (co ... OK } | arrays.js:80:30:82:3 | [BlockStmt] { s ... OK } | semmle.order | 3 |
-| arrays.js:80:8:80:14 | [DeclStmt] const x = ... | arrays.js:80:14:80:14 | [VariableDeclarator] x | semmle.label | 1 |
-| arrays.js:80:8:80:14 | [DeclStmt] const x = ... | arrays.js:80:14:80:14 | [VariableDeclarator] x | semmle.order | 1 |
-| arrays.js:80:14:80:14 | [VariableDeclarator] x | arrays.js:80:14:80:14 | [VarDecl] x | semmle.label | 1 |
-| arrays.js:80:14:80:14 | [VariableDeclarator] x | arrays.js:80:14:80:14 | [VarDecl] x | semmle.order | 1 |
-| arrays.js:80:19:80:27 | [CallExpr] uniq(arr) | arrays.js:80:19:80:22 | [VarRef] uniq | semmle.label | 0 |
-| arrays.js:80:19:80:27 | [CallExpr] uniq(arr) | arrays.js:80:19:80:22 | [VarRef] uniq | semmle.order | 0 |
-| arrays.js:80:19:80:27 | [CallExpr] uniq(arr) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:80:19:80:27 | [CallExpr] uniq(arr) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:80:30:82:3 | [BlockStmt] { s ... OK } | arrays.js:81:5:81:12 | [ExprStmt] sink(x); | semmle.label | 1 |
-| arrays.js:80:30:82:3 | [BlockStmt] { s ... OK } | arrays.js:81:5:81:12 | [ExprStmt] sink(x); | semmle.order | 1 |
-| arrays.js:81:5:81:11 | [CallExpr] sink(x) | arrays.js:81:5:81:8 | [VarRef] sink | semmle.label | 0 |
-| arrays.js:81:5:81:11 | [CallExpr] sink(x) | arrays.js:81:5:81:8 | [VarRef] sink | semmle.order | 0 |
-| arrays.js:81:5:81:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:81:5:81:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:81:5:81:12 | [ExprStmt] sink(x); | arrays.js:81:5:81:11 | [CallExpr] sink(x) | semmle.label | 1 |
-| arrays.js:81:5:81:12 | [ExprStmt] sink(x); | arrays.js:81:5:81:11 | [CallExpr] sink(x) | semmle.order | 1 |
-| arrays.js:84:3:84:18 | [CallExpr] sink(arr.at(-1)) | arrays.js:84:3:84:6 | [VarRef] sink | semmle.label | 0 |
-| arrays.js:84:3:84:18 | [CallExpr] sink(arr.at(-1)) | arrays.js:84:3:84:6 | [VarRef] sink | semmle.order | 0 |
-| arrays.js:84:3:84:18 | [CallExpr] sink(arr.at(-1)) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:84:3:84:18 | [CallExpr] sink(arr.at(-1)) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:84:3:84:19 | [ExprStmt] sink(arr.at(-1)); | arrays.js:84:3:84:18 | [CallExpr] sink(arr.at(-1)) | semmle.label | 1 |
-| arrays.js:84:3:84:19 | [ExprStmt] sink(arr.at(-1)); | arrays.js:84:3:84:18 | [CallExpr] sink(arr.at(-1)) | semmle.order | 1 |
-| arrays.js:84:8:84:13 | [DotExpr] arr.at | arrays.js:84:8:84:10 | [VarRef] arr | semmle.label | 1 |
-| arrays.js:84:8:84:13 | [DotExpr] arr.at | arrays.js:84:8:84:10 | [VarRef] arr | semmle.order | 1 |
-| arrays.js:84:8:84:13 | [DotExpr] arr.at | arrays.js:84:12:84:13 | [Label] at | semmle.label | 2 |
-| arrays.js:84:8:84:13 | [DotExpr] arr.at | arrays.js:84:12:84:13 | [Label] at | semmle.order | 2 |
-| arrays.js:84:8:84:17 | [MethodCallExpr] arr.at(-1) | arrays.js:84:8:84:13 | [DotExpr] arr.at | semmle.label | 0 |
-| arrays.js:84:8:84:17 | [MethodCallExpr] arr.at(-1) | arrays.js:84:8:84:13 | [DotExpr] arr.at | semmle.order | 0 |
-| arrays.js:84:8:84:17 | [MethodCallExpr] arr.at(-1) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:84:8:84:17 | [MethodCallExpr] arr.at(-1) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:84:15:84:16 | [UnaryExpr] -1 | arrays.js:84:16:84:16 | [Literal] 1 | semmle.label | 1 |
-| arrays.js:84:15:84:16 | [UnaryExpr] -1 | arrays.js:84:16:84:16 | [Literal] 1 | semmle.order | 1 |
-| arrays.js:86:3:86:35 | [CallExpr] sink([" ... => x)) | arrays.js:86:3:86:6 | [VarRef] sink | semmle.label | 0 |
-| arrays.js:86:3:86:35 | [CallExpr] sink([" ... => x)) | arrays.js:86:3:86:6 | [VarRef] sink | semmle.order | 0 |
-| arrays.js:86:3:86:35 | [CallExpr] sink([" ... => x)) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:86:3:86:35 | [CallExpr] sink([" ... => x)) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:86:3:86:36 | [ExprStmt] sink([" ... => x)); | arrays.js:86:3:86:35 | [CallExpr] sink([" ... => x)) | semmle.label | 1 |
-| arrays.js:86:3:86:36 | [ExprStmt] sink([" ... => x)); | arrays.js:86:3:86:35 | [CallExpr] sink([" ... => x)) | semmle.order | 1 |
-| arrays.js:86:8:86:17 | [ArrayExpr] ["source"] | arrays.js:86:9:86:16 | [Literal] "source" | semmle.label | 1 |
-| arrays.js:86:8:86:17 | [ArrayExpr] ["source"] | arrays.js:86:9:86:16 | [Literal] "source" | semmle.order | 1 |
-| arrays.js:86:8:86:24 | [DotExpr] ["source"].filter | arrays.js:86:8:86:17 | [ArrayExpr] ["source"] | semmle.label | 1 |
-| arrays.js:86:8:86:24 | [DotExpr] ["source"].filter | arrays.js:86:8:86:17 | [ArrayExpr] ["source"] | semmle.order | 1 |
-| arrays.js:86:8:86:24 | [DotExpr] ["source"].filter | arrays.js:86:19:86:24 | [Label] filter | semmle.label | 2 |
-| arrays.js:86:8:86:24 | [DotExpr] ["source"].filter | arrays.js:86:19:86:24 | [Label] filter | semmle.order | 2 |
-| arrays.js:86:8:86:34 | [MethodCallExpr] ["sourc ... ) => x) | arrays.js:86:8:86:24 | [DotExpr] ["source"].filter | semmle.label | 0 |
-| arrays.js:86:8:86:34 | [MethodCallExpr] ["sourc ... ) => x) | arrays.js:86:8:86:24 | [DotExpr] ["source"].filter | semmle.order | 0 |
-| arrays.js:86:8:86:34 | [MethodCallExpr] ["sourc ... ) => x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:86:8:86:34 | [MethodCallExpr] ["sourc ... ) => x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:86:26:86:33 | [ArrowFunctionExpr] (x) => x | arrays.js:86:33:86:33 | [VarRef] x | semmle.label | 5 |
-| arrays.js:86:26:86:33 | [ArrowFunctionExpr] (x) => x | arrays.js:86:33:86:33 | [VarRef] x | semmle.order | 5 |
-| arrays.js:86:26:86:33 | [ArrowFunctionExpr] (x) => x | file://:0:0:0:0 | (Parameters) | semmle.label | 1 |
-| arrays.js:86:26:86:33 | [ArrowFunctionExpr] (x) => x | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
-| arrays.js:87:3:87:37 | [CallExpr] sink([" ... > !!x)) | arrays.js:87:3:87:6 | [VarRef] sink | semmle.label | 0 |
-| arrays.js:87:3:87:37 | [CallExpr] sink([" ... > !!x)) | arrays.js:87:3:87:6 | [VarRef] sink | semmle.order | 0 |
-| arrays.js:87:3:87:37 | [CallExpr] sink([" ... > !!x)) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:87:3:87:37 | [CallExpr] sink([" ... > !!x)) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:87:3:87:38 | [ExprStmt] sink([" ... !!x)); | arrays.js:87:3:87:37 | [CallExpr] sink([" ... > !!x)) | semmle.label | 1 |
-| arrays.js:87:3:87:38 | [ExprStmt] sink([" ... !!x)); | arrays.js:87:3:87:37 | [CallExpr] sink([" ... > !!x)) | semmle.order | 1 |
-| arrays.js:87:8:87:17 | [ArrayExpr] ["source"] | arrays.js:87:9:87:16 | [Literal] "source" | semmle.label | 1 |
-| arrays.js:87:8:87:17 | [ArrayExpr] ["source"] | arrays.js:87:9:87:16 | [Literal] "source" | semmle.order | 1 |
-| arrays.js:87:8:87:24 | [DotExpr] ["source"].filter | arrays.js:87:8:87:17 | [ArrayExpr] ["source"] | semmle.label | 1 |
-| arrays.js:87:8:87:24 | [DotExpr] ["source"].filter | arrays.js:87:8:87:17 | [ArrayExpr] ["source"] | semmle.order | 1 |
-| arrays.js:87:8:87:24 | [DotExpr] ["source"].filter | arrays.js:87:19:87:24 | [Label] filter | semmle.label | 2 |
-| arrays.js:87:8:87:24 | [DotExpr] ["source"].filter | arrays.js:87:19:87:24 | [Label] filter | semmle.order | 2 |
-| arrays.js:87:8:87:36 | [MethodCallExpr] ["sourc ... => !!x) | arrays.js:87:8:87:24 | [DotExpr] ["source"].filter | semmle.label | 0 |
-| arrays.js:87:8:87:36 | [MethodCallExpr] ["sourc ... => !!x) | arrays.js:87:8:87:24 | [DotExpr] ["source"].filter | semmle.order | 0 |
-| arrays.js:87:8:87:36 | [MethodCallExpr] ["sourc ... => !!x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:87:8:87:36 | [MethodCallExpr] ["sourc ... => !!x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:87:26:87:35 | [ArrowFunctionExpr] (x) => !!x | arrays.js:87:33:87:35 | [UnaryExpr] !!x | semmle.label | 5 |
-| arrays.js:87:26:87:35 | [ArrowFunctionExpr] (x) => !!x | arrays.js:87:33:87:35 | [UnaryExpr] !!x | semmle.order | 5 |
-| arrays.js:87:26:87:35 | [ArrowFunctionExpr] (x) => !!x | file://:0:0:0:0 | (Parameters) | semmle.label | 1 |
-| arrays.js:87:26:87:35 | [ArrowFunctionExpr] (x) => !!x | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
-| arrays.js:87:33:87:35 | [UnaryExpr] !!x | arrays.js:87:34:87:35 | [UnaryExpr] !x | semmle.label | 1 |
-| arrays.js:87:33:87:35 | [UnaryExpr] !!x | arrays.js:87:34:87:35 | [UnaryExpr] !x | semmle.order | 1 |
-| arrays.js:87:34:87:35 | [UnaryExpr] !x | arrays.js:87:35:87:35 | [VarRef] x | semmle.label | 1 |
-| arrays.js:87:34:87:35 | [UnaryExpr] !x | arrays.js:87:35:87:35 | [VarRef] x | semmle.order | 1 |
+| arrays.js:74:3:74:42 | [DeclStmt] const arrayFrom = ... | arrays.js:74:9:74:41 | [VariableDeclarator] arrayFr ... -from") | semmle.label | 1 |
+| arrays.js:74:3:74:42 | [DeclStmt] const arrayFrom = ... | arrays.js:74:9:74:41 | [VariableDeclarator] arrayFr ... -from") | semmle.order | 1 |
+| arrays.js:74:9:74:41 | [VariableDeclarator] arrayFr ... -from") | arrays.js:74:9:74:17 | [VarDecl] arrayFrom | semmle.label | 1 |
+| arrays.js:74:9:74:41 | [VariableDeclarator] arrayFr ... -from") | arrays.js:74:9:74:17 | [VarDecl] arrayFrom | semmle.order | 1 |
+| arrays.js:74:9:74:41 | [VariableDeclarator] arrayFr ... -from") | arrays.js:74:21:74:41 | [CallExpr] require ... -from") | semmle.label | 2 |
+| arrays.js:74:9:74:41 | [VariableDeclarator] arrayFr ... -from") | arrays.js:74:21:74:41 | [CallExpr] require ... -from") | semmle.order | 2 |
+| arrays.js:74:21:74:41 | [CallExpr] require ... -from") | arrays.js:74:21:74:27 | [VarRef] require | semmle.label | 0 |
+| arrays.js:74:21:74:41 | [CallExpr] require ... -from") | arrays.js:74:21:74:27 | [VarRef] require | semmle.order | 0 |
+| arrays.js:74:21:74:41 | [CallExpr] require ... -from") | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:74:21:74:41 | [CallExpr] require ... -from") | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:75:3:77:3 | [ForOfStmt] for (co ... OK } | arrays.js:75:8:75:14 | [DeclStmt] const x = ... | semmle.label | 1 |
+| arrays.js:75:3:77:3 | [ForOfStmt] for (co ... OK } | arrays.js:75:8:75:14 | [DeclStmt] const x = ... | semmle.order | 1 |
+| arrays.js:75:3:77:3 | [ForOfStmt] for (co ... OK } | arrays.js:75:19:75:32 | [CallExpr] arrayFrom(arr) | semmle.label | 2 |
+| arrays.js:75:3:77:3 | [ForOfStmt] for (co ... OK } | arrays.js:75:19:75:32 | [CallExpr] arrayFrom(arr) | semmle.order | 2 |
+| arrays.js:75:3:77:3 | [ForOfStmt] for (co ... OK } | arrays.js:75:35:77:3 | [BlockStmt] { s ... OK } | semmle.label | 3 |
+| arrays.js:75:3:77:3 | [ForOfStmt] for (co ... OK } | arrays.js:75:35:77:3 | [BlockStmt] { s ... OK } | semmle.order | 3 |
+| arrays.js:75:8:75:14 | [DeclStmt] const x = ... | arrays.js:75:14:75:14 | [VariableDeclarator] x | semmle.label | 1 |
+| arrays.js:75:8:75:14 | [DeclStmt] const x = ... | arrays.js:75:14:75:14 | [VariableDeclarator] x | semmle.order | 1 |
+| arrays.js:75:14:75:14 | [VariableDeclarator] x | arrays.js:75:14:75:14 | [VarDecl] x | semmle.label | 1 |
+| arrays.js:75:14:75:14 | [VariableDeclarator] x | arrays.js:75:14:75:14 | [VarDecl] x | semmle.order | 1 |
+| arrays.js:75:19:75:32 | [CallExpr] arrayFrom(arr) | arrays.js:75:19:75:27 | [VarRef] arrayFrom | semmle.label | 0 |
+| arrays.js:75:19:75:32 | [CallExpr] arrayFrom(arr) | arrays.js:75:19:75:27 | [VarRef] arrayFrom | semmle.order | 0 |
+| arrays.js:75:19:75:32 | [CallExpr] arrayFrom(arr) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:75:19:75:32 | [CallExpr] arrayFrom(arr) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:75:35:77:3 | [BlockStmt] { s ... OK } | arrays.js:76:5:76:12 | [ExprStmt] sink(x); | semmle.label | 1 |
+| arrays.js:75:35:77:3 | [BlockStmt] { s ... OK } | arrays.js:76:5:76:12 | [ExprStmt] sink(x); | semmle.order | 1 |
+| arrays.js:76:5:76:11 | [CallExpr] sink(x) | arrays.js:76:5:76:8 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:76:5:76:11 | [CallExpr] sink(x) | arrays.js:76:5:76:8 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:76:5:76:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:76:5:76:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:76:5:76:12 | [ExprStmt] sink(x); | arrays.js:76:5:76:11 | [CallExpr] sink(x) | semmle.label | 1 |
+| arrays.js:76:5:76:12 | [ExprStmt] sink(x); | arrays.js:76:5:76:11 | [CallExpr] sink(x) | semmle.order | 1 |
+| arrays.js:79:3:79:30 | [CallExpr] sink(ar ... lback)) | arrays.js:79:3:79:6 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:79:3:79:30 | [CallExpr] sink(ar ... lback)) | arrays.js:79:3:79:6 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:79:3:79:30 | [CallExpr] sink(ar ... lback)) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:79:3:79:30 | [CallExpr] sink(ar ... lback)) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:79:3:79:31 | [ExprStmt] sink(ar ... back)); | arrays.js:79:3:79:30 | [CallExpr] sink(ar ... lback)) | semmle.label | 1 |
+| arrays.js:79:3:79:31 | [ExprStmt] sink(ar ... back)); | arrays.js:79:3:79:30 | [CallExpr] sink(ar ... lback)) | semmle.order | 1 |
+| arrays.js:79:8:79:15 | [DotExpr] arr.find | arrays.js:79:8:79:10 | [VarRef] arr | semmle.label | 1 |
+| arrays.js:79:8:79:15 | [DotExpr] arr.find | arrays.js:79:8:79:10 | [VarRef] arr | semmle.order | 1 |
+| arrays.js:79:8:79:15 | [DotExpr] arr.find | arrays.js:79:12:79:15 | [Label] find | semmle.label | 2 |
+| arrays.js:79:8:79:15 | [DotExpr] arr.find | arrays.js:79:12:79:15 | [Label] find | semmle.order | 2 |
+| arrays.js:79:8:79:29 | [MethodCallExpr] arr.fin ... llback) | arrays.js:79:8:79:15 | [DotExpr] arr.find | semmle.label | 0 |
+| arrays.js:79:8:79:29 | [MethodCallExpr] arr.fin ... llback) | arrays.js:79:8:79:15 | [DotExpr] arr.find | semmle.order | 0 |
+| arrays.js:79:8:79:29 | [MethodCallExpr] arr.fin ... llback) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:79:8:79:29 | [MethodCallExpr] arr.fin ... llback) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:81:3:81:42 | [DeclStmt] const arrayFind = ... | arrays.js:81:9:81:41 | [VariableDeclarator] arrayFi ... -find") | semmle.label | 1 |
+| arrays.js:81:3:81:42 | [DeclStmt] const arrayFind = ... | arrays.js:81:9:81:41 | [VariableDeclarator] arrayFi ... -find") | semmle.order | 1 |
+| arrays.js:81:9:81:41 | [VariableDeclarator] arrayFi ... -find") | arrays.js:81:9:81:17 | [VarDecl] arrayFind | semmle.label | 1 |
+| arrays.js:81:9:81:41 | [VariableDeclarator] arrayFi ... -find") | arrays.js:81:9:81:17 | [VarDecl] arrayFind | semmle.order | 1 |
+| arrays.js:81:9:81:41 | [VariableDeclarator] arrayFi ... -find") | arrays.js:81:21:81:41 | [CallExpr] require ... -find") | semmle.label | 2 |
+| arrays.js:81:9:81:41 | [VariableDeclarator] arrayFi ... -find") | arrays.js:81:21:81:41 | [CallExpr] require ... -find") | semmle.order | 2 |
+| arrays.js:81:21:81:41 | [CallExpr] require ... -find") | arrays.js:81:21:81:27 | [VarRef] require | semmle.label | 0 |
+| arrays.js:81:21:81:41 | [CallExpr] require ... -find") | arrays.js:81:21:81:27 | [VarRef] require | semmle.order | 0 |
+| arrays.js:81:21:81:41 | [CallExpr] require ... -find") | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:81:21:81:41 | [CallExpr] require ... -find") | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:82:3:82:36 | [CallExpr] sink(ar ... lback)) | arrays.js:82:3:82:6 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:82:3:82:36 | [CallExpr] sink(ar ... lback)) | arrays.js:82:3:82:6 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:82:3:82:36 | [CallExpr] sink(ar ... lback)) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:82:3:82:36 | [CallExpr] sink(ar ... lback)) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:82:3:82:37 | [ExprStmt] sink(ar ... back)); | arrays.js:82:3:82:36 | [CallExpr] sink(ar ... lback)) | semmle.label | 1 |
+| arrays.js:82:3:82:37 | [ExprStmt] sink(ar ... back)); | arrays.js:82:3:82:36 | [CallExpr] sink(ar ... lback)) | semmle.order | 1 |
+| arrays.js:82:8:82:35 | [CallExpr] arrayFi ... llback) | arrays.js:82:8:82:16 | [VarRef] arrayFind | semmle.label | 0 |
+| arrays.js:82:8:82:35 | [CallExpr] arrayFi ... llback) | arrays.js:82:8:82:16 | [VarRef] arrayFind | semmle.order | 0 |
+| arrays.js:82:8:82:35 | [CallExpr] arrayFi ... llback) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:82:8:82:35 | [CallExpr] arrayFi ... llback) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:84:3:84:31 | [DeclStmt] const uniq = ... | arrays.js:84:9:84:30 | [VariableDeclarator] uniq = ... "uniq") | semmle.label | 1 |
+| arrays.js:84:3:84:31 | [DeclStmt] const uniq = ... | arrays.js:84:9:84:30 | [VariableDeclarator] uniq = ... "uniq") | semmle.order | 1 |
+| arrays.js:84:9:84:30 | [VariableDeclarator] uniq = ... "uniq") | arrays.js:84:9:84:12 | [VarDecl] uniq | semmle.label | 1 |
+| arrays.js:84:9:84:30 | [VariableDeclarator] uniq = ... "uniq") | arrays.js:84:9:84:12 | [VarDecl] uniq | semmle.order | 1 |
+| arrays.js:84:9:84:30 | [VariableDeclarator] uniq = ... "uniq") | arrays.js:84:16:84:30 | [CallExpr] require("uniq") | semmle.label | 2 |
+| arrays.js:84:9:84:30 | [VariableDeclarator] uniq = ... "uniq") | arrays.js:84:16:84:30 | [CallExpr] require("uniq") | semmle.order | 2 |
+| arrays.js:84:16:84:30 | [CallExpr] require("uniq") | arrays.js:84:16:84:22 | [VarRef] require | semmle.label | 0 |
+| arrays.js:84:16:84:30 | [CallExpr] require("uniq") | arrays.js:84:16:84:22 | [VarRef] require | semmle.order | 0 |
+| arrays.js:84:16:84:30 | [CallExpr] require("uniq") | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:84:16:84:30 | [CallExpr] require("uniq") | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:85:3:87:3 | [ForOfStmt] for (co ... OK } | arrays.js:85:8:85:14 | [DeclStmt] const x = ... | semmle.label | 1 |
+| arrays.js:85:3:87:3 | [ForOfStmt] for (co ... OK } | arrays.js:85:8:85:14 | [DeclStmt] const x = ... | semmle.order | 1 |
+| arrays.js:85:3:87:3 | [ForOfStmt] for (co ... OK } | arrays.js:85:19:85:27 | [CallExpr] uniq(arr) | semmle.label | 2 |
+| arrays.js:85:3:87:3 | [ForOfStmt] for (co ... OK } | arrays.js:85:19:85:27 | [CallExpr] uniq(arr) | semmle.order | 2 |
+| arrays.js:85:3:87:3 | [ForOfStmt] for (co ... OK } | arrays.js:85:30:87:3 | [BlockStmt] { s ... OK } | semmle.label | 3 |
+| arrays.js:85:3:87:3 | [ForOfStmt] for (co ... OK } | arrays.js:85:30:87:3 | [BlockStmt] { s ... OK } | semmle.order | 3 |
+| arrays.js:85:8:85:14 | [DeclStmt] const x = ... | arrays.js:85:14:85:14 | [VariableDeclarator] x | semmle.label | 1 |
+| arrays.js:85:8:85:14 | [DeclStmt] const x = ... | arrays.js:85:14:85:14 | [VariableDeclarator] x | semmle.order | 1 |
+| arrays.js:85:14:85:14 | [VariableDeclarator] x | arrays.js:85:14:85:14 | [VarDecl] x | semmle.label | 1 |
+| arrays.js:85:14:85:14 | [VariableDeclarator] x | arrays.js:85:14:85:14 | [VarDecl] x | semmle.order | 1 |
+| arrays.js:85:19:85:27 | [CallExpr] uniq(arr) | arrays.js:85:19:85:22 | [VarRef] uniq | semmle.label | 0 |
+| arrays.js:85:19:85:27 | [CallExpr] uniq(arr) | arrays.js:85:19:85:22 | [VarRef] uniq | semmle.order | 0 |
+| arrays.js:85:19:85:27 | [CallExpr] uniq(arr) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:85:19:85:27 | [CallExpr] uniq(arr) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:85:30:87:3 | [BlockStmt] { s ... OK } | arrays.js:86:5:86:12 | [ExprStmt] sink(x); | semmle.label | 1 |
+| arrays.js:85:30:87:3 | [BlockStmt] { s ... OK } | arrays.js:86:5:86:12 | [ExprStmt] sink(x); | semmle.order | 1 |
+| arrays.js:86:5:86:11 | [CallExpr] sink(x) | arrays.js:86:5:86:8 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:86:5:86:11 | [CallExpr] sink(x) | arrays.js:86:5:86:8 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:86:5:86:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:86:5:86:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:86:5:86:12 | [ExprStmt] sink(x); | arrays.js:86:5:86:11 | [CallExpr] sink(x) | semmle.label | 1 |
+| arrays.js:86:5:86:12 | [ExprStmt] sink(x); | arrays.js:86:5:86:11 | [CallExpr] sink(x) | semmle.order | 1 |
+| arrays.js:89:3:89:18 | [CallExpr] sink(arr.at(-1)) | arrays.js:89:3:89:6 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:89:3:89:18 | [CallExpr] sink(arr.at(-1)) | arrays.js:89:3:89:6 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:89:3:89:18 | [CallExpr] sink(arr.at(-1)) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:89:3:89:18 | [CallExpr] sink(arr.at(-1)) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:89:3:89:19 | [ExprStmt] sink(arr.at(-1)); | arrays.js:89:3:89:18 | [CallExpr] sink(arr.at(-1)) | semmle.label | 1 |
+| arrays.js:89:3:89:19 | [ExprStmt] sink(arr.at(-1)); | arrays.js:89:3:89:18 | [CallExpr] sink(arr.at(-1)) | semmle.order | 1 |
+| arrays.js:89:8:89:13 | [DotExpr] arr.at | arrays.js:89:8:89:10 | [VarRef] arr | semmle.label | 1 |
+| arrays.js:89:8:89:13 | [DotExpr] arr.at | arrays.js:89:8:89:10 | [VarRef] arr | semmle.order | 1 |
+| arrays.js:89:8:89:13 | [DotExpr] arr.at | arrays.js:89:12:89:13 | [Label] at | semmle.label | 2 |
+| arrays.js:89:8:89:13 | [DotExpr] arr.at | arrays.js:89:12:89:13 | [Label] at | semmle.order | 2 |
+| arrays.js:89:8:89:17 | [MethodCallExpr] arr.at(-1) | arrays.js:89:8:89:13 | [DotExpr] arr.at | semmle.label | 0 |
+| arrays.js:89:8:89:17 | [MethodCallExpr] arr.at(-1) | arrays.js:89:8:89:13 | [DotExpr] arr.at | semmle.order | 0 |
+| arrays.js:89:8:89:17 | [MethodCallExpr] arr.at(-1) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:89:8:89:17 | [MethodCallExpr] arr.at(-1) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:89:15:89:16 | [UnaryExpr] -1 | arrays.js:89:16:89:16 | [Literal] 1 | semmle.label | 1 |
+| arrays.js:89:15:89:16 | [UnaryExpr] -1 | arrays.js:89:16:89:16 | [Literal] 1 | semmle.order | 1 |
+| arrays.js:91:3:91:35 | [CallExpr] sink([" ... => x)) | arrays.js:91:3:91:6 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:91:3:91:35 | [CallExpr] sink([" ... => x)) | arrays.js:91:3:91:6 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:91:3:91:35 | [CallExpr] sink([" ... => x)) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:91:3:91:35 | [CallExpr] sink([" ... => x)) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:91:3:91:36 | [ExprStmt] sink([" ... => x)); | arrays.js:91:3:91:35 | [CallExpr] sink([" ... => x)) | semmle.label | 1 |
+| arrays.js:91:3:91:36 | [ExprStmt] sink([" ... => x)); | arrays.js:91:3:91:35 | [CallExpr] sink([" ... => x)) | semmle.order | 1 |
+| arrays.js:91:8:91:17 | [ArrayExpr] ["source"] | arrays.js:91:9:91:16 | [Literal] "source" | semmle.label | 1 |
+| arrays.js:91:8:91:17 | [ArrayExpr] ["source"] | arrays.js:91:9:91:16 | [Literal] "source" | semmle.order | 1 |
+| arrays.js:91:8:91:24 | [DotExpr] ["source"].filter | arrays.js:91:8:91:17 | [ArrayExpr] ["source"] | semmle.label | 1 |
+| arrays.js:91:8:91:24 | [DotExpr] ["source"].filter | arrays.js:91:8:91:17 | [ArrayExpr] ["source"] | semmle.order | 1 |
+| arrays.js:91:8:91:24 | [DotExpr] ["source"].filter | arrays.js:91:19:91:24 | [Label] filter | semmle.label | 2 |
+| arrays.js:91:8:91:24 | [DotExpr] ["source"].filter | arrays.js:91:19:91:24 | [Label] filter | semmle.order | 2 |
+| arrays.js:91:8:91:34 | [MethodCallExpr] ["sourc ... ) => x) | arrays.js:91:8:91:24 | [DotExpr] ["source"].filter | semmle.label | 0 |
+| arrays.js:91:8:91:34 | [MethodCallExpr] ["sourc ... ) => x) | arrays.js:91:8:91:24 | [DotExpr] ["source"].filter | semmle.order | 0 |
+| arrays.js:91:8:91:34 | [MethodCallExpr] ["sourc ... ) => x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:91:8:91:34 | [MethodCallExpr] ["sourc ... ) => x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:91:26:91:33 | [ArrowFunctionExpr] (x) => x | arrays.js:91:33:91:33 | [VarRef] x | semmle.label | 5 |
+| arrays.js:91:26:91:33 | [ArrowFunctionExpr] (x) => x | arrays.js:91:33:91:33 | [VarRef] x | semmle.order | 5 |
+| arrays.js:91:26:91:33 | [ArrowFunctionExpr] (x) => x | file://:0:0:0:0 | (Parameters) | semmle.label | 1 |
+| arrays.js:91:26:91:33 | [ArrowFunctionExpr] (x) => x | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
+| arrays.js:92:3:92:37 | [CallExpr] sink([" ... > !!x)) | arrays.js:92:3:92:6 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:92:3:92:37 | [CallExpr] sink([" ... > !!x)) | arrays.js:92:3:92:6 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:92:3:92:37 | [CallExpr] sink([" ... > !!x)) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:92:3:92:37 | [CallExpr] sink([" ... > !!x)) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:92:3:92:38 | [ExprStmt] sink([" ... !!x)); | arrays.js:92:3:92:37 | [CallExpr] sink([" ... > !!x)) | semmle.label | 1 |
+| arrays.js:92:3:92:38 | [ExprStmt] sink([" ... !!x)); | arrays.js:92:3:92:37 | [CallExpr] sink([" ... > !!x)) | semmle.order | 1 |
+| arrays.js:92:8:92:17 | [ArrayExpr] ["source"] | arrays.js:92:9:92:16 | [Literal] "source" | semmle.label | 1 |
+| arrays.js:92:8:92:17 | [ArrayExpr] ["source"] | arrays.js:92:9:92:16 | [Literal] "source" | semmle.order | 1 |
+| arrays.js:92:8:92:24 | [DotExpr] ["source"].filter | arrays.js:92:8:92:17 | [ArrayExpr] ["source"] | semmle.label | 1 |
+| arrays.js:92:8:92:24 | [DotExpr] ["source"].filter | arrays.js:92:8:92:17 | [ArrayExpr] ["source"] | semmle.order | 1 |
+| arrays.js:92:8:92:24 | [DotExpr] ["source"].filter | arrays.js:92:19:92:24 | [Label] filter | semmle.label | 2 |
+| arrays.js:92:8:92:24 | [DotExpr] ["source"].filter | arrays.js:92:19:92:24 | [Label] filter | semmle.order | 2 |
+| arrays.js:92:8:92:36 | [MethodCallExpr] ["sourc ... => !!x) | arrays.js:92:8:92:24 | [DotExpr] ["source"].filter | semmle.label | 0 |
+| arrays.js:92:8:92:36 | [MethodCallExpr] ["sourc ... => !!x) | arrays.js:92:8:92:24 | [DotExpr] ["source"].filter | semmle.order | 0 |
+| arrays.js:92:8:92:36 | [MethodCallExpr] ["sourc ... => !!x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:92:8:92:36 | [MethodCallExpr] ["sourc ... => !!x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:92:26:92:35 | [ArrowFunctionExpr] (x) => !!x | arrays.js:92:33:92:35 | [UnaryExpr] !!x | semmle.label | 5 |
+| arrays.js:92:26:92:35 | [ArrowFunctionExpr] (x) => !!x | arrays.js:92:33:92:35 | [UnaryExpr] !!x | semmle.order | 5 |
+| arrays.js:92:26:92:35 | [ArrowFunctionExpr] (x) => !!x | file://:0:0:0:0 | (Parameters) | semmle.label | 1 |
+| arrays.js:92:26:92:35 | [ArrowFunctionExpr] (x) => !!x | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
+| arrays.js:92:33:92:35 | [UnaryExpr] !!x | arrays.js:92:34:92:35 | [UnaryExpr] !x | semmle.label | 1 |
+| arrays.js:92:33:92:35 | [UnaryExpr] !!x | arrays.js:92:34:92:35 | [UnaryExpr] !x | semmle.order | 1 |
+| arrays.js:92:34:92:35 | [UnaryExpr] !x | arrays.js:92:35:92:35 | [VarRef] x | semmle.label | 1 |
+| arrays.js:92:34:92:35 | [UnaryExpr] !x | arrays.js:92:35:92:35 | [VarRef] x | semmle.order | 1 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:5:8:5:14 | [DotExpr] obj.foo | semmle.label | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:5:8:5:14 | [DotExpr] obj.foo | semmle.order | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:8:12:8:17 | [VarRef] source | semmle.label | 0 |
@@ -1193,72 +1193,72 @@ edges
 | file://:0:0:0:0 | (Arguments) | arrays.js:29:21:29:28 | [Literal] "source" | semmle.order | 2 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:30:8:30:17 | [MethodCallExpr] arr4.pop() | semmle.label | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:30:8:30:17 | [MethodCallExpr] arr4.pop() | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:32:24:32:27 | [VarRef] arr4 | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:32:24:32:27 | [VarRef] arr4 | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:33:8:33:17 | [MethodCallExpr] arr5.pop() | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:33:8:33:17 | [MethodCallExpr] arr5.pop() | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:35:8:35:26 | [MethodCallExpr] arr5.slice(2).pop() | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:35:8:35:26 | [MethodCallExpr] arr5.slice(2).pop() | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:35:19:35:19 | [Literal] 2 | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:35:19:35:19 | [Literal] 2 | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:41:8:41:17 | [MethodCallExpr] arr6.pop() | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:41:8:41:17 | [MethodCallExpr] arr6.pop() | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:44:22:47:3 | [ArrowFunctionExpr] (e, i, ... nt. } | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:44:22:47:3 | [ArrowFunctionExpr] (e, i, ... nt. } | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:45:10:45:18 | [MethodCallExpr] ary.pop() | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:45:10:45:18 | [MethodCallExpr] ary.pop() | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:46:10:46:12 | [VarRef] ary | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:46:10:46:12 | [VarRef] ary | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:49:8:49:13 | [IndexExpr] arr[0] | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:49:8:49:13 | [IndexExpr] arr[0] | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:52:10:52:10 | [VarRef] x | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:52:10:52:10 | [VarRef] x | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:55:30:55:32 | [VarRef] arr | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:55:30:55:32 | [VarRef] arr | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:56:10:56:10 | [VarRef] x | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:56:10:56:10 | [VarRef] x | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:60:10:60:10 | [VarRef] x | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:60:10:60:10 | [VarRef] x | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:64:13:64:18 | [SpreadElement] ...arr | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:64:13:64:18 | [SpreadElement] ...arr | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:66:10:66:10 | [VarRef] x | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:66:10:66:10 | [VarRef] x | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:69:29:69:40 | [Literal] "array-from" | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:69:29:69:40 | [Literal] "array-from" | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:70:29:70:31 | [VarRef] arr | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:70:29:70:31 | [VarRef] arr | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:37:24:37:27 | [VarRef] arr4 | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:37:24:37:27 | [VarRef] arr4 | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:38:8:38:17 | [MethodCallExpr] arr5.pop() | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:38:8:38:17 | [MethodCallExpr] arr5.pop() | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:40:8:40:26 | [MethodCallExpr] arr5.slice(2).pop() | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:40:8:40:26 | [MethodCallExpr] arr5.slice(2).pop() | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:40:19:40:19 | [Literal] 2 | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:40:19:40:19 | [Literal] 2 | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:46:8:46:17 | [MethodCallExpr] arr6.pop() | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:46:8:46:17 | [MethodCallExpr] arr6.pop() | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:49:22:52:3 | [ArrowFunctionExpr] (e, i, ... nt. } | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:49:22:52:3 | [ArrowFunctionExpr] (e, i, ... nt. } | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:50:10:50:18 | [MethodCallExpr] ary.pop() | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:50:10:50:18 | [MethodCallExpr] ary.pop() | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:51:10:51:12 | [VarRef] ary | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:51:10:51:12 | [VarRef] ary | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:54:8:54:13 | [IndexExpr] arr[0] | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:54:8:54:13 | [IndexExpr] arr[0] | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:57:10:57:10 | [VarRef] x | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:57:10:57:10 | [VarRef] x | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:60:30:60:32 | [VarRef] arr | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:60:30:60:32 | [VarRef] arr | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:61:10:61:10 | [VarRef] x | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:61:10:61:10 | [VarRef] x | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:65:10:65:10 | [VarRef] x | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:65:10:65:10 | [VarRef] x | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:69:13:69:18 | [SpreadElement] ...arr | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:69:13:69:18 | [SpreadElement] ...arr | semmle.order | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:71:10:71:10 | [VarRef] x | semmle.label | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:71:10:71:10 | [VarRef] x | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:74:8:74:29 | [MethodCallExpr] arr.fin ... llback) | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:74:8:74:29 | [MethodCallExpr] arr.fin ... llback) | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:74:17:74:28 | [VarRef] someCallback | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:74:17:74:28 | [VarRef] someCallback | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:76:29:76:40 | [Literal] "array-find" | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:76:29:76:40 | [Literal] "array-find" | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:77:8:77:35 | [CallExpr] arrayFi ... llback) | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:77:8:77:35 | [CallExpr] arrayFi ... llback) | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:77:18:77:20 | [VarRef] arr | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:77:18:77:20 | [VarRef] arr | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:77:23:77:34 | [VarRef] someCallback | semmle.label | 1 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:77:23:77:34 | [VarRef] someCallback | semmle.order | 1 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:79:24:79:29 | [Literal] "uniq" | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:79:24:79:29 | [Literal] "uniq" | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:80:24:80:26 | [VarRef] arr | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:80:24:80:26 | [VarRef] arr | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:81:10:81:10 | [VarRef] x | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:81:10:81:10 | [VarRef] x | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:84:8:84:17 | [MethodCallExpr] arr.at(-1) | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:84:8:84:17 | [MethodCallExpr] arr.at(-1) | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:84:15:84:16 | [UnaryExpr] -1 | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:84:15:84:16 | [UnaryExpr] -1 | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:86:8:86:34 | [MethodCallExpr] ["sourc ... ) => x) | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:86:8:86:34 | [MethodCallExpr] ["sourc ... ) => x) | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:86:26:86:33 | [ArrowFunctionExpr] (x) => x | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:86:26:86:33 | [ArrowFunctionExpr] (x) => x | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:87:8:87:36 | [MethodCallExpr] ["sourc ... => !!x) | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:87:8:87:36 | [MethodCallExpr] ["sourc ... => !!x) | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:87:26:87:35 | [ArrowFunctionExpr] (x) => !!x | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:87:26:87:35 | [ArrowFunctionExpr] (x) => !!x | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:74:29:74:40 | [Literal] "array-from" | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:74:29:74:40 | [Literal] "array-from" | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:75:29:75:31 | [VarRef] arr | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:75:29:75:31 | [VarRef] arr | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:76:10:76:10 | [VarRef] x | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:76:10:76:10 | [VarRef] x | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:79:8:79:29 | [MethodCallExpr] arr.fin ... llback) | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:79:8:79:29 | [MethodCallExpr] arr.fin ... llback) | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:79:17:79:28 | [VarRef] someCallback | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:79:17:79:28 | [VarRef] someCallback | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:81:29:81:40 | [Literal] "array-find" | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:81:29:81:40 | [Literal] "array-find" | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:82:8:82:35 | [CallExpr] arrayFi ... llback) | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:82:8:82:35 | [CallExpr] arrayFi ... llback) | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:82:18:82:20 | [VarRef] arr | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:82:18:82:20 | [VarRef] arr | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:82:23:82:34 | [VarRef] someCallback | semmle.label | 1 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:82:23:82:34 | [VarRef] someCallback | semmle.order | 1 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:84:24:84:29 | [Literal] "uniq" | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:84:24:84:29 | [Literal] "uniq" | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:85:24:85:26 | [VarRef] arr | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:85:24:85:26 | [VarRef] arr | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:86:10:86:10 | [VarRef] x | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:86:10:86:10 | [VarRef] x | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:89:8:89:17 | [MethodCallExpr] arr.at(-1) | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:89:8:89:17 | [MethodCallExpr] arr.at(-1) | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:89:15:89:16 | [UnaryExpr] -1 | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:89:15:89:16 | [UnaryExpr] -1 | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:91:8:91:34 | [MethodCallExpr] ["sourc ... ) => x) | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:91:8:91:34 | [MethodCallExpr] ["sourc ... ) => x) | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:91:26:91:33 | [ArrowFunctionExpr] (x) => x | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:91:26:91:33 | [ArrowFunctionExpr] (x) => x | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:92:8:92:36 | [MethodCallExpr] ["sourc ... => !!x) | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:92:8:92:36 | [MethodCallExpr] ["sourc ... => !!x) | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:92:26:92:35 | [ArrowFunctionExpr] (x) => !!x | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:92:26:92:35 | [ArrowFunctionExpr] (x) => !!x | semmle.order | 0 |
 | file://:0:0:0:0 | (Parameters) | arrays.js:15:16:15:16 | [SimpleParameter] e | semmle.label | 0 |
 | file://:0:0:0:0 | (Parameters) | arrays.js:15:16:15:16 | [SimpleParameter] e | semmle.order | 0 |
 | file://:0:0:0:0 | (Parameters) | arrays.js:16:12:16:12 | [SimpleParameter] e | semmle.label | 0 |
@@ -1267,15 +1267,15 @@ edges
 | file://:0:0:0:0 | (Parameters) | arrays.js:18:17:18:17 | [SimpleParameter] i | semmle.order | 0 |
 | file://:0:0:0:0 | (Parameters) | arrays.js:18:40:18:40 | [SimpleParameter] e | semmle.label | 0 |
 | file://:0:0:0:0 | (Parameters) | arrays.js:18:40:18:40 | [SimpleParameter] e | semmle.order | 0 |
-| file://:0:0:0:0 | (Parameters) | arrays.js:44:23:44:23 | [SimpleParameter] e | semmle.label | 0 |
-| file://:0:0:0:0 | (Parameters) | arrays.js:44:23:44:23 | [SimpleParameter] e | semmle.order | 0 |
-| file://:0:0:0:0 | (Parameters) | arrays.js:44:26:44:26 | [SimpleParameter] i | semmle.label | 1 |
-| file://:0:0:0:0 | (Parameters) | arrays.js:44:26:44:26 | [SimpleParameter] i | semmle.order | 1 |
-| file://:0:0:0:0 | (Parameters) | arrays.js:44:29:44:31 | [SimpleParameter] ary | semmle.label | 2 |
-| file://:0:0:0:0 | (Parameters) | arrays.js:44:29:44:31 | [SimpleParameter] ary | semmle.order | 2 |
-| file://:0:0:0:0 | (Parameters) | arrays.js:86:27:86:27 | [SimpleParameter] x | semmle.label | 0 |
-| file://:0:0:0:0 | (Parameters) | arrays.js:86:27:86:27 | [SimpleParameter] x | semmle.order | 0 |
-| file://:0:0:0:0 | (Parameters) | arrays.js:87:27:87:27 | [SimpleParameter] x | semmle.label | 0 |
-| file://:0:0:0:0 | (Parameters) | arrays.js:87:27:87:27 | [SimpleParameter] x | semmle.order | 0 |
+| file://:0:0:0:0 | (Parameters) | arrays.js:49:23:49:23 | [SimpleParameter] e | semmle.label | 0 |
+| file://:0:0:0:0 | (Parameters) | arrays.js:49:23:49:23 | [SimpleParameter] e | semmle.order | 0 |
+| file://:0:0:0:0 | (Parameters) | arrays.js:49:26:49:26 | [SimpleParameter] i | semmle.label | 1 |
+| file://:0:0:0:0 | (Parameters) | arrays.js:49:26:49:26 | [SimpleParameter] i | semmle.order | 1 |
+| file://:0:0:0:0 | (Parameters) | arrays.js:49:29:49:31 | [SimpleParameter] ary | semmle.label | 2 |
+| file://:0:0:0:0 | (Parameters) | arrays.js:49:29:49:31 | [SimpleParameter] ary | semmle.order | 2 |
+| file://:0:0:0:0 | (Parameters) | arrays.js:91:27:91:27 | [SimpleParameter] x | semmle.label | 0 |
+| file://:0:0:0:0 | (Parameters) | arrays.js:91:27:91:27 | [SimpleParameter] x | semmle.order | 0 |
+| file://:0:0:0:0 | (Parameters) | arrays.js:92:27:92:27 | [SimpleParameter] x | semmle.label | 0 |
+| file://:0:0:0:0 | (Parameters) | arrays.js:92:27:92:27 | [SimpleParameter] x | semmle.order | 0 |
 graphProperties
 | semmle.graphKind | tree |

--- a/javascript/ql/test/library-tests/Arrays/printAst.expected
+++ b/javascript/ql/test/library-tests/Arrays/printAst.expected
@@ -1,9 +1,9 @@
 nodes
-| arrays.js:1:1:93:2 | [ParExpr] (functi ... T OK }) | semmle.label | [ParExpr] (functi ... T OK }) |
-| arrays.js:1:1:93:3 | [ExprStmt] (functi ... OK }); | semmle.label | [ExprStmt] (functi ... OK }); |
-| arrays.js:1:1:93:3 | [ExprStmt] (functi ... OK }); | semmle.order | 1 |
-| arrays.js:1:2:93:1 | [FunctionExpr] functio ... OT OK } | semmle.label | [FunctionExpr] functio ... OT OK } |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | semmle.label | [BlockStmt] { let ... OT OK } |
+| arrays.js:1:1:97:2 | [ParExpr] (functi ... T OK }) | semmle.label | [ParExpr] (functi ... T OK }) |
+| arrays.js:1:1:97:3 | [ExprStmt] (functi ... OK }); | semmle.label | [ExprStmt] (functi ... OK }); |
+| arrays.js:1:1:97:3 | [ExprStmt] (functi ... OK }); | semmle.order | 1 |
+| arrays.js:1:2:97:1 | [FunctionExpr] functio ... OT OK } | semmle.label | [FunctionExpr] functio ... OT OK } |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | semmle.label | [BlockStmt] { let ... OT OK } |
 | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | semmle.label | [DeclStmt] let source = ... |
 | arrays.js:2:7:2:12 | [VarDecl] source | semmle.label | [VarDecl] source |
 | arrays.js:2:7:2:23 | [VariableDeclarator] source = "source" | semmle.label | [VariableDeclarator] source = "source" |
@@ -164,112 +164,98 @@ nodes
 | arrays.js:35:8:35:23 | [DotExpr] arr4_variant.pop | semmle.label | [DotExpr] arr4_variant.pop |
 | arrays.js:35:8:35:25 | [MethodCallExpr] arr4_variant.pop() | semmle.label | [MethodCallExpr] arr4_variant.pop() |
 | arrays.js:35:21:35:23 | [Label] pop | semmle.label | [Label] pop |
-| arrays.js:37:3:37:29 | [DeclStmt] var arr5 = ... | semmle.label | [DeclStmt] var arr5 = ... |
-| arrays.js:37:7:37:10 | [VarDecl] arr5 | semmle.label | [VarDecl] arr5 |
-| arrays.js:37:7:37:28 | [VariableDeclarator] arr5 = ... t(arr4) | semmle.label | [VariableDeclarator] arr5 = ... t(arr4) |
-| arrays.js:37:14:37:15 | [ArrayExpr] [] | semmle.label | [ArrayExpr] [] |
-| arrays.js:37:14:37:22 | [DotExpr] [].concat | semmle.label | [DotExpr] [].concat |
-| arrays.js:37:14:37:28 | [MethodCallExpr] [].concat(arr4) | semmle.label | [MethodCallExpr] [].concat(arr4) |
-| arrays.js:37:17:37:22 | [Label] concat | semmle.label | [Label] concat |
-| arrays.js:37:24:37:27 | [VarRef] arr4 | semmle.label | [VarRef] arr4 |
-| arrays.js:38:3:38:6 | [VarRef] sink | semmle.label | [VarRef] sink |
-| arrays.js:38:3:38:18 | [CallExpr] sink(arr5.pop()) | semmle.label | [CallExpr] sink(arr5.pop()) |
-| arrays.js:38:3:38:19 | [ExprStmt] sink(arr5.pop()); | semmle.label | [ExprStmt] sink(arr5.pop()); |
-| arrays.js:38:8:38:11 | [VarRef] arr5 | semmle.label | [VarRef] arr5 |
-| arrays.js:38:8:38:15 | [DotExpr] arr5.pop | semmle.label | [DotExpr] arr5.pop |
-| arrays.js:38:8:38:17 | [MethodCallExpr] arr5.pop() | semmle.label | [MethodCallExpr] arr5.pop() |
-| arrays.js:38:13:38:15 | [Label] pop | semmle.label | [Label] pop |
-| arrays.js:40:3:40:6 | [VarRef] sink | semmle.label | [VarRef] sink |
-| arrays.js:40:3:40:27 | [CallExpr] sink(ar ... .pop()) | semmle.label | [CallExpr] sink(ar ... .pop()) |
-| arrays.js:40:3:40:28 | [ExprStmt] sink(ar ... pop()); | semmle.label | [ExprStmt] sink(ar ... pop()); |
-| arrays.js:40:8:40:11 | [VarRef] arr5 | semmle.label | [VarRef] arr5 |
-| arrays.js:40:8:40:17 | [DotExpr] arr5.slice | semmle.label | [DotExpr] arr5.slice |
-| arrays.js:40:8:40:20 | [MethodCallExpr] arr5.slice(2) | semmle.label | [MethodCallExpr] arr5.slice(2) |
-| arrays.js:40:8:40:24 | [DotExpr] arr5.slice(2).pop | semmle.label | [DotExpr] arr5.slice(2).pop |
-| arrays.js:40:8:40:26 | [MethodCallExpr] arr5.slice(2).pop() | semmle.label | [MethodCallExpr] arr5.slice(2).pop() |
-| arrays.js:40:13:40:17 | [Label] slice | semmle.label | [Label] slice |
-| arrays.js:40:19:40:19 | [Literal] 2 | semmle.label | [Literal] 2 |
-| arrays.js:40:22:40:24 | [Label] pop | semmle.label | [Label] pop |
-| arrays.js:42:3:42:16 | [DeclStmt] var arr6 = ... | semmle.label | [DeclStmt] var arr6 = ... |
-| arrays.js:42:7:42:10 | [VarDecl] arr6 | semmle.label | [VarDecl] arr6 |
-| arrays.js:42:7:42:15 | [VariableDeclarator] arr6 = [] | semmle.label | [VariableDeclarator] arr6 = [] |
-| arrays.js:42:14:42:15 | [ArrayExpr] [] | semmle.label | [ArrayExpr] [] |
-| arrays.js:43:3:45:3 | [ForStmt] for (va ... i]; } | semmle.label | [ForStmt] for (va ... i]; } |
-| arrays.js:43:8:43:16 | [DeclStmt] var i = ... | semmle.label | [DeclStmt] var i = ... |
-| arrays.js:43:12:43:12 | [VarDecl] i | semmle.label | [VarDecl] i |
-| arrays.js:43:12:43:16 | [VariableDeclarator] i = 0 | semmle.label | [VariableDeclarator] i = 0 |
-| arrays.js:43:16:43:16 | [Literal] 0 | semmle.label | [Literal] 0 |
-| arrays.js:43:19:43:19 | [VarRef] i | semmle.label | [VarRef] i |
-| arrays.js:43:19:43:33 | [BinaryExpr] i < arr5.length | semmle.label | [BinaryExpr] i < arr5.length |
-| arrays.js:43:23:43:26 | [VarRef] arr5 | semmle.label | [VarRef] arr5 |
-| arrays.js:43:23:43:33 | [DotExpr] arr5.length | semmle.label | [DotExpr] arr5.length |
-| arrays.js:43:28:43:33 | [Label] length | semmle.label | [Label] length |
-| arrays.js:43:36:43:36 | [VarRef] i | semmle.label | [VarRef] i |
-| arrays.js:43:36:43:38 | [UpdateExpr] i++ | semmle.label | [UpdateExpr] i++ |
-| arrays.js:43:41:45:3 | [BlockStmt] { a ... i]; } | semmle.label | [BlockStmt] { a ... i]; } |
-| arrays.js:44:5:44:8 | [VarRef] arr6 | semmle.label | [VarRef] arr6 |
-| arrays.js:44:5:44:11 | [IndexExpr] arr6[i] | semmle.label | [IndexExpr] arr6[i] |
-| arrays.js:44:5:44:21 | [AssignExpr] arr6[i] = arr5[i] | semmle.label | [AssignExpr] arr6[i] = arr5[i] |
-| arrays.js:44:5:44:22 | [ExprStmt] arr6[i] = arr5[i]; | semmle.label | [ExprStmt] arr6[i] = arr5[i]; |
-| arrays.js:44:10:44:10 | [VarRef] i | semmle.label | [VarRef] i |
-| arrays.js:44:15:44:18 | [VarRef] arr5 | semmle.label | [VarRef] arr5 |
-| arrays.js:44:15:44:21 | [IndexExpr] arr5[i] | semmle.label | [IndexExpr] arr5[i] |
-| arrays.js:44:20:44:20 | [VarRef] i | semmle.label | [VarRef] i |
-| arrays.js:46:3:46:6 | [VarRef] sink | semmle.label | [VarRef] sink |
-| arrays.js:46:3:46:18 | [CallExpr] sink(arr6.pop()) | semmle.label | [CallExpr] sink(arr6.pop()) |
-| arrays.js:46:3:46:19 | [ExprStmt] sink(arr6.pop()); | semmle.label | [ExprStmt] sink(arr6.pop()); |
-| arrays.js:46:8:46:11 | [VarRef] arr6 | semmle.label | [VarRef] arr6 |
-| arrays.js:46:8:46:15 | [DotExpr] arr6.pop | semmle.label | [DotExpr] arr6.pop |
-| arrays.js:46:8:46:17 | [MethodCallExpr] arr6.pop() | semmle.label | [MethodCallExpr] arr6.pop() |
-| arrays.js:46:13:46:15 | [Label] pop | semmle.label | [Label] pop |
-| arrays.js:49:3:49:12 | [ArrayExpr] ["source"] | semmle.label | [ArrayExpr] ["source"] |
-| arrays.js:49:3:49:20 | [DotExpr] ["source"].forEach | semmle.label | [DotExpr] ["source"].forEach |
-| arrays.js:49:3:52:4 | [MethodCallExpr] ["sourc ... t. }) | semmle.label | [MethodCallExpr] ["sourc ... t. }) |
-| arrays.js:49:3:52:5 | [ExprStmt] ["sourc ... . }); | semmle.label | [ExprStmt] ["sourc ... . }); |
-| arrays.js:49:4:49:11 | [Literal] "source" | semmle.label | [Literal] "source" |
-| arrays.js:49:14:49:20 | [Label] forEach | semmle.label | [Label] forEach |
-| arrays.js:49:22:52:3 | [ArrowFunctionExpr] (e, i, ... nt. } | semmle.label | [ArrowFunctionExpr] (e, i, ... nt. } |
-| arrays.js:49:23:49:23 | [SimpleParameter] e | semmle.label | [SimpleParameter] e |
-| arrays.js:49:26:49:26 | [SimpleParameter] i | semmle.label | [SimpleParameter] i |
-| arrays.js:49:29:49:31 | [SimpleParameter] ary | semmle.label | [SimpleParameter] ary |
-| arrays.js:49:37:52:3 | [BlockStmt] { s ... nt. } | semmle.label | [BlockStmt] { s ... nt. } |
-| arrays.js:50:5:50:8 | [VarRef] sink | semmle.label | [VarRef] sink |
-| arrays.js:50:5:50:19 | [CallExpr] sink(ary.pop()) | semmle.label | [CallExpr] sink(ary.pop()) |
-| arrays.js:50:5:50:20 | [ExprStmt] sink(ary.pop()); | semmle.label | [ExprStmt] sink(ary.pop()); |
-| arrays.js:50:10:50:12 | [VarRef] ary | semmle.label | [VarRef] ary |
-| arrays.js:50:10:50:16 | [DotExpr] ary.pop | semmle.label | [DotExpr] ary.pop |
-| arrays.js:50:10:50:18 | [MethodCallExpr] ary.pop() | semmle.label | [MethodCallExpr] ary.pop() |
-| arrays.js:50:14:50:16 | [Label] pop | semmle.label | [Label] pop |
-| arrays.js:51:5:51:8 | [VarRef] sink | semmle.label | [VarRef] sink |
-| arrays.js:51:5:51:13 | [CallExpr] sink(ary) | semmle.label | [CallExpr] sink(ary) |
-| arrays.js:51:5:51:14 | [ExprStmt] sink(ary); | semmle.label | [ExprStmt] sink(ary); |
-| arrays.js:51:10:51:12 | [VarRef] ary | semmle.label | [VarRef] ary |
-| arrays.js:54:3:54:6 | [VarRef] sink | semmle.label | [VarRef] sink |
-| arrays.js:54:3:54:14 | [CallExpr] sink(arr[0]) | semmle.label | [CallExpr] sink(arr[0]) |
-| arrays.js:54:3:54:15 | [ExprStmt] sink(arr[0]); | semmle.label | [ExprStmt] sink(arr[0]); |
-| arrays.js:54:8:54:10 | [VarRef] arr | semmle.label | [VarRef] arr |
-| arrays.js:54:8:54:13 | [IndexExpr] arr[0] | semmle.label | [IndexExpr] arr[0] |
-| arrays.js:54:12:54:12 | [Literal] 0 | semmle.label | [Literal] 0 |
-| arrays.js:56:3:58:3 | [ForOfStmt] for (co ... OK } | semmle.label | [ForOfStmt] for (co ... OK } |
-| arrays.js:56:8:56:14 | [DeclStmt] const x = ... | semmle.label | [DeclStmt] const x = ... |
-| arrays.js:56:14:56:14 | [VarDecl] x | semmle.label | [VarDecl] x |
-| arrays.js:56:14:56:14 | [VariableDeclarator] x | semmle.label | [VariableDeclarator] x |
-| arrays.js:56:19:56:21 | [VarRef] arr | semmle.label | [VarRef] arr |
-| arrays.js:56:24:58:3 | [BlockStmt] { s ... OK } | semmle.label | [BlockStmt] { s ... OK } |
-| arrays.js:57:5:57:8 | [VarRef] sink | semmle.label | [VarRef] sink |
-| arrays.js:57:5:57:11 | [CallExpr] sink(x) | semmle.label | [CallExpr] sink(x) |
-| arrays.js:57:5:57:12 | [ExprStmt] sink(x); | semmle.label | [ExprStmt] sink(x); |
-| arrays.js:57:10:57:10 | [VarRef] x | semmle.label | [VarRef] x |
+| arrays.js:41:3:41:29 | [DeclStmt] var arr5 = ... | semmle.label | [DeclStmt] var arr5 = ... |
+| arrays.js:41:7:41:10 | [VarDecl] arr5 | semmle.label | [VarDecl] arr5 |
+| arrays.js:41:7:41:28 | [VariableDeclarator] arr5 = ... t(arr4) | semmle.label | [VariableDeclarator] arr5 = ... t(arr4) |
+| arrays.js:41:14:41:15 | [ArrayExpr] [] | semmle.label | [ArrayExpr] [] |
+| arrays.js:41:14:41:22 | [DotExpr] [].concat | semmle.label | [DotExpr] [].concat |
+| arrays.js:41:14:41:28 | [MethodCallExpr] [].concat(arr4) | semmle.label | [MethodCallExpr] [].concat(arr4) |
+| arrays.js:41:17:41:22 | [Label] concat | semmle.label | [Label] concat |
+| arrays.js:41:24:41:27 | [VarRef] arr4 | semmle.label | [VarRef] arr4 |
+| arrays.js:42:3:42:6 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:42:3:42:18 | [CallExpr] sink(arr5.pop()) | semmle.label | [CallExpr] sink(arr5.pop()) |
+| arrays.js:42:3:42:19 | [ExprStmt] sink(arr5.pop()); | semmle.label | [ExprStmt] sink(arr5.pop()); |
+| arrays.js:42:8:42:11 | [VarRef] arr5 | semmle.label | [VarRef] arr5 |
+| arrays.js:42:8:42:15 | [DotExpr] arr5.pop | semmle.label | [DotExpr] arr5.pop |
+| arrays.js:42:8:42:17 | [MethodCallExpr] arr5.pop() | semmle.label | [MethodCallExpr] arr5.pop() |
+| arrays.js:42:13:42:15 | [Label] pop | semmle.label | [Label] pop |
+| arrays.js:44:3:44:6 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:44:3:44:27 | [CallExpr] sink(ar ... .pop()) | semmle.label | [CallExpr] sink(ar ... .pop()) |
+| arrays.js:44:3:44:28 | [ExprStmt] sink(ar ... pop()); | semmle.label | [ExprStmt] sink(ar ... pop()); |
+| arrays.js:44:8:44:11 | [VarRef] arr5 | semmle.label | [VarRef] arr5 |
+| arrays.js:44:8:44:17 | [DotExpr] arr5.slice | semmle.label | [DotExpr] arr5.slice |
+| arrays.js:44:8:44:20 | [MethodCallExpr] arr5.slice(2) | semmle.label | [MethodCallExpr] arr5.slice(2) |
+| arrays.js:44:8:44:24 | [DotExpr] arr5.slice(2).pop | semmle.label | [DotExpr] arr5.slice(2).pop |
+| arrays.js:44:8:44:26 | [MethodCallExpr] arr5.slice(2).pop() | semmle.label | [MethodCallExpr] arr5.slice(2).pop() |
+| arrays.js:44:13:44:17 | [Label] slice | semmle.label | [Label] slice |
+| arrays.js:44:19:44:19 | [Literal] 2 | semmle.label | [Literal] 2 |
+| arrays.js:44:22:44:24 | [Label] pop | semmle.label | [Label] pop |
+| arrays.js:46:3:46:16 | [DeclStmt] var arr6 = ... | semmle.label | [DeclStmt] var arr6 = ... |
+| arrays.js:46:7:46:10 | [VarDecl] arr6 | semmle.label | [VarDecl] arr6 |
+| arrays.js:46:7:46:15 | [VariableDeclarator] arr6 = [] | semmle.label | [VariableDeclarator] arr6 = [] |
+| arrays.js:46:14:46:15 | [ArrayExpr] [] | semmle.label | [ArrayExpr] [] |
+| arrays.js:47:3:49:3 | [ForStmt] for (va ... i]; } | semmle.label | [ForStmt] for (va ... i]; } |
+| arrays.js:47:8:47:16 | [DeclStmt] var i = ... | semmle.label | [DeclStmt] var i = ... |
+| arrays.js:47:12:47:12 | [VarDecl] i | semmle.label | [VarDecl] i |
+| arrays.js:47:12:47:16 | [VariableDeclarator] i = 0 | semmle.label | [VariableDeclarator] i = 0 |
+| arrays.js:47:16:47:16 | [Literal] 0 | semmle.label | [Literal] 0 |
+| arrays.js:47:19:47:19 | [VarRef] i | semmle.label | [VarRef] i |
+| arrays.js:47:19:47:33 | [BinaryExpr] i < arr5.length | semmle.label | [BinaryExpr] i < arr5.length |
+| arrays.js:47:23:47:26 | [VarRef] arr5 | semmle.label | [VarRef] arr5 |
+| arrays.js:47:23:47:33 | [DotExpr] arr5.length | semmle.label | [DotExpr] arr5.length |
+| arrays.js:47:28:47:33 | [Label] length | semmle.label | [Label] length |
+| arrays.js:47:36:47:36 | [VarRef] i | semmle.label | [VarRef] i |
+| arrays.js:47:36:47:38 | [UpdateExpr] i++ | semmle.label | [UpdateExpr] i++ |
+| arrays.js:47:41:49:3 | [BlockStmt] { a ... i]; } | semmle.label | [BlockStmt] { a ... i]; } |
+| arrays.js:48:5:48:8 | [VarRef] arr6 | semmle.label | [VarRef] arr6 |
+| arrays.js:48:5:48:11 | [IndexExpr] arr6[i] | semmle.label | [IndexExpr] arr6[i] |
+| arrays.js:48:5:48:21 | [AssignExpr] arr6[i] = arr5[i] | semmle.label | [AssignExpr] arr6[i] = arr5[i] |
+| arrays.js:48:5:48:22 | [ExprStmt] arr6[i] = arr5[i]; | semmle.label | [ExprStmt] arr6[i] = arr5[i]; |
+| arrays.js:48:10:48:10 | [VarRef] i | semmle.label | [VarRef] i |
+| arrays.js:48:15:48:18 | [VarRef] arr5 | semmle.label | [VarRef] arr5 |
+| arrays.js:48:15:48:21 | [IndexExpr] arr5[i] | semmle.label | [IndexExpr] arr5[i] |
+| arrays.js:48:20:48:20 | [VarRef] i | semmle.label | [VarRef] i |
+| arrays.js:50:3:50:6 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:50:3:50:18 | [CallExpr] sink(arr6.pop()) | semmle.label | [CallExpr] sink(arr6.pop()) |
+| arrays.js:50:3:50:19 | [ExprStmt] sink(arr6.pop()); | semmle.label | [ExprStmt] sink(arr6.pop()); |
+| arrays.js:50:8:50:11 | [VarRef] arr6 | semmle.label | [VarRef] arr6 |
+| arrays.js:50:8:50:15 | [DotExpr] arr6.pop | semmle.label | [DotExpr] arr6.pop |
+| arrays.js:50:8:50:17 | [MethodCallExpr] arr6.pop() | semmle.label | [MethodCallExpr] arr6.pop() |
+| arrays.js:50:13:50:15 | [Label] pop | semmle.label | [Label] pop |
+| arrays.js:53:3:53:12 | [ArrayExpr] ["source"] | semmle.label | [ArrayExpr] ["source"] |
+| arrays.js:53:3:53:20 | [DotExpr] ["source"].forEach | semmle.label | [DotExpr] ["source"].forEach |
+| arrays.js:53:3:56:4 | [MethodCallExpr] ["sourc ... t. }) | semmle.label | [MethodCallExpr] ["sourc ... t. }) |
+| arrays.js:53:3:56:5 | [ExprStmt] ["sourc ... . }); | semmle.label | [ExprStmt] ["sourc ... . }); |
+| arrays.js:53:4:53:11 | [Literal] "source" | semmle.label | [Literal] "source" |
+| arrays.js:53:14:53:20 | [Label] forEach | semmle.label | [Label] forEach |
+| arrays.js:53:22:56:3 | [ArrowFunctionExpr] (e, i, ... nt. } | semmle.label | [ArrowFunctionExpr] (e, i, ... nt. } |
+| arrays.js:53:23:53:23 | [SimpleParameter] e | semmle.label | [SimpleParameter] e |
+| arrays.js:53:26:53:26 | [SimpleParameter] i | semmle.label | [SimpleParameter] i |
+| arrays.js:53:29:53:31 | [SimpleParameter] ary | semmle.label | [SimpleParameter] ary |
+| arrays.js:53:37:56:3 | [BlockStmt] { s ... nt. } | semmle.label | [BlockStmt] { s ... nt. } |
+| arrays.js:54:5:54:8 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:54:5:54:19 | [CallExpr] sink(ary.pop()) | semmle.label | [CallExpr] sink(ary.pop()) |
+| arrays.js:54:5:54:20 | [ExprStmt] sink(ary.pop()); | semmle.label | [ExprStmt] sink(ary.pop()); |
+| arrays.js:54:10:54:12 | [VarRef] ary | semmle.label | [VarRef] ary |
+| arrays.js:54:10:54:16 | [DotExpr] ary.pop | semmle.label | [DotExpr] ary.pop |
+| arrays.js:54:10:54:18 | [MethodCallExpr] ary.pop() | semmle.label | [MethodCallExpr] ary.pop() |
+| arrays.js:54:14:54:16 | [Label] pop | semmle.label | [Label] pop |
+| arrays.js:55:5:55:8 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:55:5:55:13 | [CallExpr] sink(ary) | semmle.label | [CallExpr] sink(ary) |
+| arrays.js:55:5:55:14 | [ExprStmt] sink(ary); | semmle.label | [ExprStmt] sink(ary); |
+| arrays.js:55:10:55:12 | [VarRef] ary | semmle.label | [VarRef] ary |
+| arrays.js:58:3:58:6 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:58:3:58:14 | [CallExpr] sink(arr[0]) | semmle.label | [CallExpr] sink(arr[0]) |
+| arrays.js:58:3:58:15 | [ExprStmt] sink(arr[0]); | semmle.label | [ExprStmt] sink(arr[0]); |
+| arrays.js:58:8:58:10 | [VarRef] arr | semmle.label | [VarRef] arr |
+| arrays.js:58:8:58:13 | [IndexExpr] arr[0] | semmle.label | [IndexExpr] arr[0] |
+| arrays.js:58:12:58:12 | [Literal] 0 | semmle.label | [Literal] 0 |
 | arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | semmle.label | [ForOfStmt] for (co ... OK } |
 | arrays.js:60:8:60:14 | [DeclStmt] const x = ... | semmle.label | [DeclStmt] const x = ... |
 | arrays.js:60:14:60:14 | [VarDecl] x | semmle.label | [VarDecl] x |
 | arrays.js:60:14:60:14 | [VariableDeclarator] x | semmle.label | [VariableDeclarator] x |
-| arrays.js:60:19:60:23 | [VarRef] Array | semmle.label | [VarRef] Array |
-| arrays.js:60:19:60:28 | [DotExpr] Array.from | semmle.label | [DotExpr] Array.from |
-| arrays.js:60:19:60:33 | [MethodCallExpr] Array.from(arr) | semmle.label | [MethodCallExpr] Array.from(arr) |
-| arrays.js:60:25:60:28 | [Label] from | semmle.label | [Label] from |
-| arrays.js:60:30:60:32 | [VarRef] arr | semmle.label | [VarRef] arr |
-| arrays.js:60:36:62:3 | [BlockStmt] { s ... OK } | semmle.label | [BlockStmt] { s ... OK } |
+| arrays.js:60:19:60:21 | [VarRef] arr | semmle.label | [VarRef] arr |
+| arrays.js:60:24:62:3 | [BlockStmt] { s ... OK } | semmle.label | [BlockStmt] { s ... OK } |
 | arrays.js:61:5:61:8 | [VarRef] sink | semmle.label | [VarRef] sink |
 | arrays.js:61:5:61:11 | [CallExpr] sink(x) | semmle.label | [CallExpr] sink(x) |
 | arrays.js:61:5:61:12 | [ExprStmt] sink(x); | semmle.label | [ExprStmt] sink(x); |
@@ -278,125 +264,139 @@ nodes
 | arrays.js:64:8:64:14 | [DeclStmt] const x = ... | semmle.label | [DeclStmt] const x = ... |
 | arrays.js:64:14:64:14 | [VarDecl] x | semmle.label | [VarDecl] x |
 | arrays.js:64:14:64:14 | [VariableDeclarator] x | semmle.label | [VariableDeclarator] x |
-| arrays.js:64:19:64:26 | [ArrayExpr] [...arr] | semmle.label | [ArrayExpr] [...arr] |
-| arrays.js:64:20:64:25 | [SpreadElement] ...arr | semmle.label | [SpreadElement] ...arr |
-| arrays.js:64:23:64:25 | [VarRef] arr | semmle.label | [VarRef] arr |
-| arrays.js:64:29:66:3 | [BlockStmt] { s ... OK } | semmle.label | [BlockStmt] { s ... OK } |
+| arrays.js:64:19:64:23 | [VarRef] Array | semmle.label | [VarRef] Array |
+| arrays.js:64:19:64:28 | [DotExpr] Array.from | semmle.label | [DotExpr] Array.from |
+| arrays.js:64:19:64:33 | [MethodCallExpr] Array.from(arr) | semmle.label | [MethodCallExpr] Array.from(arr) |
+| arrays.js:64:25:64:28 | [Label] from | semmle.label | [Label] from |
+| arrays.js:64:30:64:32 | [VarRef] arr | semmle.label | [VarRef] arr |
+| arrays.js:64:36:66:3 | [BlockStmt] { s ... OK } | semmle.label | [BlockStmt] { s ... OK } |
 | arrays.js:65:5:65:8 | [VarRef] sink | semmle.label | [VarRef] sink |
 | arrays.js:65:5:65:11 | [CallExpr] sink(x) | semmle.label | [CallExpr] sink(x) |
 | arrays.js:65:5:65:12 | [ExprStmt] sink(x); | semmle.label | [ExprStmt] sink(x); |
 | arrays.js:65:10:65:10 | [VarRef] x | semmle.label | [VarRef] x |
-| arrays.js:68:3:68:16 | [DeclStmt] var arr7 = ... | semmle.label | [DeclStmt] var arr7 = ... |
-| arrays.js:68:7:68:10 | [VarDecl] arr7 | semmle.label | [VarDecl] arr7 |
-| arrays.js:68:7:68:15 | [VariableDeclarator] arr7 = [] | semmle.label | [VariableDeclarator] arr7 = [] |
-| arrays.js:68:14:68:15 | [ArrayExpr] [] | semmle.label | [ArrayExpr] [] |
-| arrays.js:69:3:69:6 | [VarRef] arr7 | semmle.label | [VarRef] arr7 |
-| arrays.js:69:3:69:11 | [DotExpr] arr7.push | semmle.label | [DotExpr] arr7.push |
-| arrays.js:69:3:69:19 | [MethodCallExpr] arr7.push(...arr) | semmle.label | [MethodCallExpr] arr7.push(...arr) |
-| arrays.js:69:3:69:20 | [ExprStmt] arr7.push(...arr); | semmle.label | [ExprStmt] arr7.push(...arr); |
-| arrays.js:69:8:69:11 | [Label] push | semmle.label | [Label] push |
-| arrays.js:69:13:69:18 | [SpreadElement] ...arr | semmle.label | [SpreadElement] ...arr |
-| arrays.js:69:16:69:18 | [VarRef] arr | semmle.label | [VarRef] arr |
-| arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | semmle.label | [ForOfStmt] for (co ... OK } |
-| arrays.js:70:8:70:14 | [DeclStmt] const x = ... | semmle.label | [DeclStmt] const x = ... |
-| arrays.js:70:14:70:14 | [VarDecl] x | semmle.label | [VarDecl] x |
-| arrays.js:70:14:70:14 | [VariableDeclarator] x | semmle.label | [VariableDeclarator] x |
-| arrays.js:70:19:70:22 | [VarRef] arr7 | semmle.label | [VarRef] arr7 |
-| arrays.js:70:25:72:3 | [BlockStmt] { s ... OK } | semmle.label | [BlockStmt] { s ... OK } |
-| arrays.js:71:5:71:8 | [VarRef] sink | semmle.label | [VarRef] sink |
-| arrays.js:71:5:71:11 | [CallExpr] sink(x) | semmle.label | [CallExpr] sink(x) |
-| arrays.js:71:5:71:12 | [ExprStmt] sink(x); | semmle.label | [ExprStmt] sink(x); |
-| arrays.js:71:10:71:10 | [VarRef] x | semmle.label | [VarRef] x |
-| arrays.js:74:3:74:42 | [DeclStmt] const arrayFrom = ... | semmle.label | [DeclStmt] const arrayFrom = ... |
-| arrays.js:74:9:74:17 | [VarDecl] arrayFrom | semmle.label | [VarDecl] arrayFrom |
-| arrays.js:74:9:74:41 | [VariableDeclarator] arrayFr ... -from") | semmle.label | [VariableDeclarator] arrayFr ... -from") |
-| arrays.js:74:21:74:27 | [VarRef] require | semmle.label | [VarRef] require |
-| arrays.js:74:21:74:41 | [CallExpr] require ... -from") | semmle.label | [CallExpr] require ... -from") |
-| arrays.js:74:29:74:40 | [Literal] "array-from" | semmle.label | [Literal] "array-from" |
-| arrays.js:75:3:77:3 | [ForOfStmt] for (co ... OK } | semmle.label | [ForOfStmt] for (co ... OK } |
-| arrays.js:75:8:75:14 | [DeclStmt] const x = ... | semmle.label | [DeclStmt] const x = ... |
-| arrays.js:75:14:75:14 | [VarDecl] x | semmle.label | [VarDecl] x |
-| arrays.js:75:14:75:14 | [VariableDeclarator] x | semmle.label | [VariableDeclarator] x |
-| arrays.js:75:19:75:27 | [VarRef] arrayFrom | semmle.label | [VarRef] arrayFrom |
-| arrays.js:75:19:75:32 | [CallExpr] arrayFrom(arr) | semmle.label | [CallExpr] arrayFrom(arr) |
-| arrays.js:75:29:75:31 | [VarRef] arr | semmle.label | [VarRef] arr |
-| arrays.js:75:35:77:3 | [BlockStmt] { s ... OK } | semmle.label | [BlockStmt] { s ... OK } |
-| arrays.js:76:5:76:8 | [VarRef] sink | semmle.label | [VarRef] sink |
-| arrays.js:76:5:76:11 | [CallExpr] sink(x) | semmle.label | [CallExpr] sink(x) |
-| arrays.js:76:5:76:12 | [ExprStmt] sink(x); | semmle.label | [ExprStmt] sink(x); |
-| arrays.js:76:10:76:10 | [VarRef] x | semmle.label | [VarRef] x |
-| arrays.js:79:3:79:6 | [VarRef] sink | semmle.label | [VarRef] sink |
-| arrays.js:79:3:79:30 | [CallExpr] sink(ar ... lback)) | semmle.label | [CallExpr] sink(ar ... lback)) |
-| arrays.js:79:3:79:31 | [ExprStmt] sink(ar ... back)); | semmle.label | [ExprStmt] sink(ar ... back)); |
-| arrays.js:79:8:79:10 | [VarRef] arr | semmle.label | [VarRef] arr |
-| arrays.js:79:8:79:15 | [DotExpr] arr.find | semmle.label | [DotExpr] arr.find |
-| arrays.js:79:8:79:29 | [MethodCallExpr] arr.fin ... llback) | semmle.label | [MethodCallExpr] arr.fin ... llback) |
-| arrays.js:79:12:79:15 | [Label] find | semmle.label | [Label] find |
-| arrays.js:79:17:79:28 | [VarRef] someCallback | semmle.label | [VarRef] someCallback |
-| arrays.js:81:3:81:42 | [DeclStmt] const arrayFind = ... | semmle.label | [DeclStmt] const arrayFind = ... |
-| arrays.js:81:9:81:17 | [VarDecl] arrayFind | semmle.label | [VarDecl] arrayFind |
-| arrays.js:81:9:81:41 | [VariableDeclarator] arrayFi ... -find") | semmle.label | [VariableDeclarator] arrayFi ... -find") |
-| arrays.js:81:21:81:27 | [VarRef] require | semmle.label | [VarRef] require |
-| arrays.js:81:21:81:41 | [CallExpr] require ... -find") | semmle.label | [CallExpr] require ... -find") |
-| arrays.js:81:29:81:40 | [Literal] "array-find" | semmle.label | [Literal] "array-find" |
-| arrays.js:82:3:82:6 | [VarRef] sink | semmle.label | [VarRef] sink |
-| arrays.js:82:3:82:36 | [CallExpr] sink(ar ... lback)) | semmle.label | [CallExpr] sink(ar ... lback)) |
-| arrays.js:82:3:82:37 | [ExprStmt] sink(ar ... back)); | semmle.label | [ExprStmt] sink(ar ... back)); |
-| arrays.js:82:8:82:16 | [VarRef] arrayFind | semmle.label | [VarRef] arrayFind |
-| arrays.js:82:8:82:35 | [CallExpr] arrayFi ... llback) | semmle.label | [CallExpr] arrayFi ... llback) |
-| arrays.js:82:18:82:20 | [VarRef] arr | semmle.label | [VarRef] arr |
-| arrays.js:82:23:82:34 | [VarRef] someCallback | semmle.label | [VarRef] someCallback |
-| arrays.js:84:3:84:31 | [DeclStmt] const uniq = ... | semmle.label | [DeclStmt] const uniq = ... |
-| arrays.js:84:9:84:12 | [VarDecl] uniq | semmle.label | [VarDecl] uniq |
-| arrays.js:84:9:84:30 | [VariableDeclarator] uniq = ... "uniq") | semmle.label | [VariableDeclarator] uniq = ... "uniq") |
-| arrays.js:84:16:84:22 | [VarRef] require | semmle.label | [VarRef] require |
-| arrays.js:84:16:84:30 | [CallExpr] require("uniq") | semmle.label | [CallExpr] require("uniq") |
-| arrays.js:84:24:84:29 | [Literal] "uniq" | semmle.label | [Literal] "uniq" |
-| arrays.js:85:3:87:3 | [ForOfStmt] for (co ... OK } | semmle.label | [ForOfStmt] for (co ... OK } |
-| arrays.js:85:8:85:14 | [DeclStmt] const x = ... | semmle.label | [DeclStmt] const x = ... |
-| arrays.js:85:14:85:14 | [VarDecl] x | semmle.label | [VarDecl] x |
-| arrays.js:85:14:85:14 | [VariableDeclarator] x | semmle.label | [VariableDeclarator] x |
-| arrays.js:85:19:85:22 | [VarRef] uniq | semmle.label | [VarRef] uniq |
-| arrays.js:85:19:85:27 | [CallExpr] uniq(arr) | semmle.label | [CallExpr] uniq(arr) |
-| arrays.js:85:24:85:26 | [VarRef] arr | semmle.label | [VarRef] arr |
-| arrays.js:85:30:87:3 | [BlockStmt] { s ... OK } | semmle.label | [BlockStmt] { s ... OK } |
-| arrays.js:86:5:86:8 | [VarRef] sink | semmle.label | [VarRef] sink |
-| arrays.js:86:5:86:11 | [CallExpr] sink(x) | semmle.label | [CallExpr] sink(x) |
-| arrays.js:86:5:86:12 | [ExprStmt] sink(x); | semmle.label | [ExprStmt] sink(x); |
-| arrays.js:86:10:86:10 | [VarRef] x | semmle.label | [VarRef] x |
-| arrays.js:89:3:89:6 | [VarRef] sink | semmle.label | [VarRef] sink |
-| arrays.js:89:3:89:18 | [CallExpr] sink(arr.at(-1)) | semmle.label | [CallExpr] sink(arr.at(-1)) |
-| arrays.js:89:3:89:19 | [ExprStmt] sink(arr.at(-1)); | semmle.label | [ExprStmt] sink(arr.at(-1)); |
-| arrays.js:89:8:89:10 | [VarRef] arr | semmle.label | [VarRef] arr |
-| arrays.js:89:8:89:13 | [DotExpr] arr.at | semmle.label | [DotExpr] arr.at |
-| arrays.js:89:8:89:17 | [MethodCallExpr] arr.at(-1) | semmle.label | [MethodCallExpr] arr.at(-1) |
-| arrays.js:89:12:89:13 | [Label] at | semmle.label | [Label] at |
-| arrays.js:89:15:89:16 | [UnaryExpr] -1 | semmle.label | [UnaryExpr] -1 |
-| arrays.js:89:16:89:16 | [Literal] 1 | semmle.label | [Literal] 1 |
-| arrays.js:91:3:91:6 | [VarRef] sink | semmle.label | [VarRef] sink |
-| arrays.js:91:3:91:35 | [CallExpr] sink([" ... => x)) | semmle.label | [CallExpr] sink([" ... => x)) |
-| arrays.js:91:3:91:36 | [ExprStmt] sink([" ... => x)); | semmle.label | [ExprStmt] sink([" ... => x)); |
-| arrays.js:91:8:91:17 | [ArrayExpr] ["source"] | semmle.label | [ArrayExpr] ["source"] |
-| arrays.js:91:8:91:24 | [DotExpr] ["source"].filter | semmle.label | [DotExpr] ["source"].filter |
-| arrays.js:91:8:91:34 | [MethodCallExpr] ["sourc ... ) => x) | semmle.label | [MethodCallExpr] ["sourc ... ) => x) |
-| arrays.js:91:9:91:16 | [Literal] "source" | semmle.label | [Literal] "source" |
-| arrays.js:91:19:91:24 | [Label] filter | semmle.label | [Label] filter |
-| arrays.js:91:26:91:33 | [ArrowFunctionExpr] (x) => x | semmle.label | [ArrowFunctionExpr] (x) => x |
-| arrays.js:91:27:91:27 | [SimpleParameter] x | semmle.label | [SimpleParameter] x |
-| arrays.js:91:33:91:33 | [VarRef] x | semmle.label | [VarRef] x |
-| arrays.js:92:3:92:6 | [VarRef] sink | semmle.label | [VarRef] sink |
-| arrays.js:92:3:92:37 | [CallExpr] sink([" ... > !!x)) | semmle.label | [CallExpr] sink([" ... > !!x)) |
-| arrays.js:92:3:92:38 | [ExprStmt] sink([" ... !!x)); | semmle.label | [ExprStmt] sink([" ... !!x)); |
-| arrays.js:92:8:92:17 | [ArrayExpr] ["source"] | semmle.label | [ArrayExpr] ["source"] |
-| arrays.js:92:8:92:24 | [DotExpr] ["source"].filter | semmle.label | [DotExpr] ["source"].filter |
-| arrays.js:92:8:92:36 | [MethodCallExpr] ["sourc ... => !!x) | semmle.label | [MethodCallExpr] ["sourc ... => !!x) |
-| arrays.js:92:9:92:16 | [Literal] "source" | semmle.label | [Literal] "source" |
-| arrays.js:92:19:92:24 | [Label] filter | semmle.label | [Label] filter |
-| arrays.js:92:26:92:35 | [ArrowFunctionExpr] (x) => !!x | semmle.label | [ArrowFunctionExpr] (x) => !!x |
-| arrays.js:92:27:92:27 | [SimpleParameter] x | semmle.label | [SimpleParameter] x |
-| arrays.js:92:33:92:35 | [UnaryExpr] !!x | semmle.label | [UnaryExpr] !!x |
-| arrays.js:92:34:92:35 | [UnaryExpr] !x | semmle.label | [UnaryExpr] !x |
-| arrays.js:92:35:92:35 | [VarRef] x | semmle.label | [VarRef] x |
+| arrays.js:68:3:70:3 | [ForOfStmt] for (co ... OK } | semmle.label | [ForOfStmt] for (co ... OK } |
+| arrays.js:68:8:68:14 | [DeclStmt] const x = ... | semmle.label | [DeclStmt] const x = ... |
+| arrays.js:68:14:68:14 | [VarDecl] x | semmle.label | [VarDecl] x |
+| arrays.js:68:14:68:14 | [VariableDeclarator] x | semmle.label | [VariableDeclarator] x |
+| arrays.js:68:19:68:26 | [ArrayExpr] [...arr] | semmle.label | [ArrayExpr] [...arr] |
+| arrays.js:68:20:68:25 | [SpreadElement] ...arr | semmle.label | [SpreadElement] ...arr |
+| arrays.js:68:23:68:25 | [VarRef] arr | semmle.label | [VarRef] arr |
+| arrays.js:68:29:70:3 | [BlockStmt] { s ... OK } | semmle.label | [BlockStmt] { s ... OK } |
+| arrays.js:69:5:69:8 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:69:5:69:11 | [CallExpr] sink(x) | semmle.label | [CallExpr] sink(x) |
+| arrays.js:69:5:69:12 | [ExprStmt] sink(x); | semmle.label | [ExprStmt] sink(x); |
+| arrays.js:69:10:69:10 | [VarRef] x | semmle.label | [VarRef] x |
+| arrays.js:72:3:72:16 | [DeclStmt] var arr7 = ... | semmle.label | [DeclStmt] var arr7 = ... |
+| arrays.js:72:7:72:10 | [VarDecl] arr7 | semmle.label | [VarDecl] arr7 |
+| arrays.js:72:7:72:15 | [VariableDeclarator] arr7 = [] | semmle.label | [VariableDeclarator] arr7 = [] |
+| arrays.js:72:14:72:15 | [ArrayExpr] [] | semmle.label | [ArrayExpr] [] |
+| arrays.js:73:3:73:6 | [VarRef] arr7 | semmle.label | [VarRef] arr7 |
+| arrays.js:73:3:73:11 | [DotExpr] arr7.push | semmle.label | [DotExpr] arr7.push |
+| arrays.js:73:3:73:19 | [MethodCallExpr] arr7.push(...arr) | semmle.label | [MethodCallExpr] arr7.push(...arr) |
+| arrays.js:73:3:73:20 | [ExprStmt] arr7.push(...arr); | semmle.label | [ExprStmt] arr7.push(...arr); |
+| arrays.js:73:8:73:11 | [Label] push | semmle.label | [Label] push |
+| arrays.js:73:13:73:18 | [SpreadElement] ...arr | semmle.label | [SpreadElement] ...arr |
+| arrays.js:73:16:73:18 | [VarRef] arr | semmle.label | [VarRef] arr |
+| arrays.js:74:3:76:3 | [ForOfStmt] for (co ... OK } | semmle.label | [ForOfStmt] for (co ... OK } |
+| arrays.js:74:8:74:14 | [DeclStmt] const x = ... | semmle.label | [DeclStmt] const x = ... |
+| arrays.js:74:14:74:14 | [VarDecl] x | semmle.label | [VarDecl] x |
+| arrays.js:74:14:74:14 | [VariableDeclarator] x | semmle.label | [VariableDeclarator] x |
+| arrays.js:74:19:74:22 | [VarRef] arr7 | semmle.label | [VarRef] arr7 |
+| arrays.js:74:25:76:3 | [BlockStmt] { s ... OK } | semmle.label | [BlockStmt] { s ... OK } |
+| arrays.js:75:5:75:8 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:75:5:75:11 | [CallExpr] sink(x) | semmle.label | [CallExpr] sink(x) |
+| arrays.js:75:5:75:12 | [ExprStmt] sink(x); | semmle.label | [ExprStmt] sink(x); |
+| arrays.js:75:10:75:10 | [VarRef] x | semmle.label | [VarRef] x |
+| arrays.js:78:3:78:42 | [DeclStmt] const arrayFrom = ... | semmle.label | [DeclStmt] const arrayFrom = ... |
+| arrays.js:78:9:78:17 | [VarDecl] arrayFrom | semmle.label | [VarDecl] arrayFrom |
+| arrays.js:78:9:78:41 | [VariableDeclarator] arrayFr ... -from") | semmle.label | [VariableDeclarator] arrayFr ... -from") |
+| arrays.js:78:21:78:27 | [VarRef] require | semmle.label | [VarRef] require |
+| arrays.js:78:21:78:41 | [CallExpr] require ... -from") | semmle.label | [CallExpr] require ... -from") |
+| arrays.js:78:29:78:40 | [Literal] "array-from" | semmle.label | [Literal] "array-from" |
+| arrays.js:79:3:81:3 | [ForOfStmt] for (co ... OK } | semmle.label | [ForOfStmt] for (co ... OK } |
+| arrays.js:79:8:79:14 | [DeclStmt] const x = ... | semmle.label | [DeclStmt] const x = ... |
+| arrays.js:79:14:79:14 | [VarDecl] x | semmle.label | [VarDecl] x |
+| arrays.js:79:14:79:14 | [VariableDeclarator] x | semmle.label | [VariableDeclarator] x |
+| arrays.js:79:19:79:27 | [VarRef] arrayFrom | semmle.label | [VarRef] arrayFrom |
+| arrays.js:79:19:79:32 | [CallExpr] arrayFrom(arr) | semmle.label | [CallExpr] arrayFrom(arr) |
+| arrays.js:79:29:79:31 | [VarRef] arr | semmle.label | [VarRef] arr |
+| arrays.js:79:35:81:3 | [BlockStmt] { s ... OK } | semmle.label | [BlockStmt] { s ... OK } |
+| arrays.js:80:5:80:8 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:80:5:80:11 | [CallExpr] sink(x) | semmle.label | [CallExpr] sink(x) |
+| arrays.js:80:5:80:12 | [ExprStmt] sink(x); | semmle.label | [ExprStmt] sink(x); |
+| arrays.js:80:10:80:10 | [VarRef] x | semmle.label | [VarRef] x |
+| arrays.js:83:3:83:6 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:83:3:83:30 | [CallExpr] sink(ar ... lback)) | semmle.label | [CallExpr] sink(ar ... lback)) |
+| arrays.js:83:3:83:31 | [ExprStmt] sink(ar ... back)); | semmle.label | [ExprStmt] sink(ar ... back)); |
+| arrays.js:83:8:83:10 | [VarRef] arr | semmle.label | [VarRef] arr |
+| arrays.js:83:8:83:15 | [DotExpr] arr.find | semmle.label | [DotExpr] arr.find |
+| arrays.js:83:8:83:29 | [MethodCallExpr] arr.fin ... llback) | semmle.label | [MethodCallExpr] arr.fin ... llback) |
+| arrays.js:83:12:83:15 | [Label] find | semmle.label | [Label] find |
+| arrays.js:83:17:83:28 | [VarRef] someCallback | semmle.label | [VarRef] someCallback |
+| arrays.js:85:3:85:42 | [DeclStmt] const arrayFind = ... | semmle.label | [DeclStmt] const arrayFind = ... |
+| arrays.js:85:9:85:17 | [VarDecl] arrayFind | semmle.label | [VarDecl] arrayFind |
+| arrays.js:85:9:85:41 | [VariableDeclarator] arrayFi ... -find") | semmle.label | [VariableDeclarator] arrayFi ... -find") |
+| arrays.js:85:21:85:27 | [VarRef] require | semmle.label | [VarRef] require |
+| arrays.js:85:21:85:41 | [CallExpr] require ... -find") | semmle.label | [CallExpr] require ... -find") |
+| arrays.js:85:29:85:40 | [Literal] "array-find" | semmle.label | [Literal] "array-find" |
+| arrays.js:86:3:86:6 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:86:3:86:36 | [CallExpr] sink(ar ... lback)) | semmle.label | [CallExpr] sink(ar ... lback)) |
+| arrays.js:86:3:86:37 | [ExprStmt] sink(ar ... back)); | semmle.label | [ExprStmt] sink(ar ... back)); |
+| arrays.js:86:8:86:16 | [VarRef] arrayFind | semmle.label | [VarRef] arrayFind |
+| arrays.js:86:8:86:35 | [CallExpr] arrayFi ... llback) | semmle.label | [CallExpr] arrayFi ... llback) |
+| arrays.js:86:18:86:20 | [VarRef] arr | semmle.label | [VarRef] arr |
+| arrays.js:86:23:86:34 | [VarRef] someCallback | semmle.label | [VarRef] someCallback |
+| arrays.js:88:3:88:31 | [DeclStmt] const uniq = ... | semmle.label | [DeclStmt] const uniq = ... |
+| arrays.js:88:9:88:12 | [VarDecl] uniq | semmle.label | [VarDecl] uniq |
+| arrays.js:88:9:88:30 | [VariableDeclarator] uniq = ... "uniq") | semmle.label | [VariableDeclarator] uniq = ... "uniq") |
+| arrays.js:88:16:88:22 | [VarRef] require | semmle.label | [VarRef] require |
+| arrays.js:88:16:88:30 | [CallExpr] require("uniq") | semmle.label | [CallExpr] require("uniq") |
+| arrays.js:88:24:88:29 | [Literal] "uniq" | semmle.label | [Literal] "uniq" |
+| arrays.js:89:3:91:3 | [ForOfStmt] for (co ... OK } | semmle.label | [ForOfStmt] for (co ... OK } |
+| arrays.js:89:8:89:14 | [DeclStmt] const x = ... | semmle.label | [DeclStmt] const x = ... |
+| arrays.js:89:14:89:14 | [VarDecl] x | semmle.label | [VarDecl] x |
+| arrays.js:89:14:89:14 | [VariableDeclarator] x | semmle.label | [VariableDeclarator] x |
+| arrays.js:89:19:89:22 | [VarRef] uniq | semmle.label | [VarRef] uniq |
+| arrays.js:89:19:89:27 | [CallExpr] uniq(arr) | semmle.label | [CallExpr] uniq(arr) |
+| arrays.js:89:24:89:26 | [VarRef] arr | semmle.label | [VarRef] arr |
+| arrays.js:89:30:91:3 | [BlockStmt] { s ... OK } | semmle.label | [BlockStmt] { s ... OK } |
+| arrays.js:90:5:90:8 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:90:5:90:11 | [CallExpr] sink(x) | semmle.label | [CallExpr] sink(x) |
+| arrays.js:90:5:90:12 | [ExprStmt] sink(x); | semmle.label | [ExprStmt] sink(x); |
+| arrays.js:90:10:90:10 | [VarRef] x | semmle.label | [VarRef] x |
+| arrays.js:93:3:93:6 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:93:3:93:18 | [CallExpr] sink(arr.at(-1)) | semmle.label | [CallExpr] sink(arr.at(-1)) |
+| arrays.js:93:3:93:19 | [ExprStmt] sink(arr.at(-1)); | semmle.label | [ExprStmt] sink(arr.at(-1)); |
+| arrays.js:93:8:93:10 | [VarRef] arr | semmle.label | [VarRef] arr |
+| arrays.js:93:8:93:13 | [DotExpr] arr.at | semmle.label | [DotExpr] arr.at |
+| arrays.js:93:8:93:17 | [MethodCallExpr] arr.at(-1) | semmle.label | [MethodCallExpr] arr.at(-1) |
+| arrays.js:93:12:93:13 | [Label] at | semmle.label | [Label] at |
+| arrays.js:93:15:93:16 | [UnaryExpr] -1 | semmle.label | [UnaryExpr] -1 |
+| arrays.js:93:16:93:16 | [Literal] 1 | semmle.label | [Literal] 1 |
+| arrays.js:95:3:95:6 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:95:3:95:35 | [CallExpr] sink([" ... => x)) | semmle.label | [CallExpr] sink([" ... => x)) |
+| arrays.js:95:3:95:36 | [ExprStmt] sink([" ... => x)); | semmle.label | [ExprStmt] sink([" ... => x)); |
+| arrays.js:95:8:95:17 | [ArrayExpr] ["source"] | semmle.label | [ArrayExpr] ["source"] |
+| arrays.js:95:8:95:24 | [DotExpr] ["source"].filter | semmle.label | [DotExpr] ["source"].filter |
+| arrays.js:95:8:95:34 | [MethodCallExpr] ["sourc ... ) => x) | semmle.label | [MethodCallExpr] ["sourc ... ) => x) |
+| arrays.js:95:9:95:16 | [Literal] "source" | semmle.label | [Literal] "source" |
+| arrays.js:95:19:95:24 | [Label] filter | semmle.label | [Label] filter |
+| arrays.js:95:26:95:33 | [ArrowFunctionExpr] (x) => x | semmle.label | [ArrowFunctionExpr] (x) => x |
+| arrays.js:95:27:95:27 | [SimpleParameter] x | semmle.label | [SimpleParameter] x |
+| arrays.js:95:33:95:33 | [VarRef] x | semmle.label | [VarRef] x |
+| arrays.js:96:3:96:6 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:96:3:96:37 | [CallExpr] sink([" ... > !!x)) | semmle.label | [CallExpr] sink([" ... > !!x)) |
+| arrays.js:96:3:96:38 | [ExprStmt] sink([" ... !!x)); | semmle.label | [ExprStmt] sink([" ... !!x)); |
+| arrays.js:96:8:96:17 | [ArrayExpr] ["source"] | semmle.label | [ArrayExpr] ["source"] |
+| arrays.js:96:8:96:24 | [DotExpr] ["source"].filter | semmle.label | [DotExpr] ["source"].filter |
+| arrays.js:96:8:96:36 | [MethodCallExpr] ["sourc ... => !!x) | semmle.label | [MethodCallExpr] ["sourc ... => !!x) |
+| arrays.js:96:9:96:16 | [Literal] "source" | semmle.label | [Literal] "source" |
+| arrays.js:96:19:96:24 | [Label] filter | semmle.label | [Label] filter |
+| arrays.js:96:26:96:35 | [ArrowFunctionExpr] (x) => !!x | semmle.label | [ArrowFunctionExpr] (x) => !!x |
+| arrays.js:96:27:96:27 | [SimpleParameter] x | semmle.label | [SimpleParameter] x |
+| arrays.js:96:33:96:35 | [UnaryExpr] !!x | semmle.label | [UnaryExpr] !!x |
+| arrays.js:96:34:96:35 | [UnaryExpr] !x | semmle.label | [UnaryExpr] !x |
+| arrays.js:96:35:96:35 | [VarRef] x | semmle.label | [VarRef] x |
 | file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
 | file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
 | file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
@@ -454,102 +454,102 @@ nodes
 | file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
 | file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
 edges
-| arrays.js:1:1:93:2 | [ParExpr] (functi ... T OK }) | arrays.js:1:2:93:1 | [FunctionExpr] functio ... OT OK } | semmle.label | 1 |
-| arrays.js:1:1:93:2 | [ParExpr] (functi ... T OK }) | arrays.js:1:2:93:1 | [FunctionExpr] functio ... OT OK } | semmle.order | 1 |
-| arrays.js:1:1:93:3 | [ExprStmt] (functi ... OK }); | arrays.js:1:1:93:2 | [ParExpr] (functi ... T OK }) | semmle.label | 1 |
-| arrays.js:1:1:93:3 | [ExprStmt] (functi ... OK }); | arrays.js:1:1:93:2 | [ParExpr] (functi ... T OK }) | semmle.order | 1 |
-| arrays.js:1:2:93:1 | [FunctionExpr] functio ... OT OK } | arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | semmle.label | 5 |
-| arrays.js:1:2:93:1 | [FunctionExpr] functio ... OT OK } | arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | semmle.order | 5 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | semmle.label | 1 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | semmle.order | 1 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:4:3:4:28 | [DeclStmt] var obj = ... | semmle.label | 2 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:4:3:4:28 | [DeclStmt] var obj = ... | semmle.order | 2 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:5:3:5:16 | [ExprStmt] sink(obj.foo); | semmle.label | 3 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:5:3:5:16 | [ExprStmt] sink(obj.foo); | semmle.order | 3 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:7:3:7:15 | [DeclStmt] var arr = ... | semmle.label | 4 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:7:3:7:15 | [DeclStmt] var arr = ... | semmle.order | 4 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:8:3:8:19 | [ExprStmt] arr.push(source); | semmle.label | 5 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:8:3:8:19 | [ExprStmt] arr.push(source); | semmle.order | 5 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:10:3:12:3 | [ForStmt] for (va ... OK } | semmle.label | 6 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:10:3:12:3 | [ForStmt] for (va ... OK } | semmle.order | 6 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:15:3:15:30 | [ExprStmt] arr.for ... nk(e)); | semmle.label | 7 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:15:3:15:30 | [ExprStmt] arr.for ... nk(e)); | semmle.order | 7 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:16:3:16:26 | [ExprStmt] arr.map ... nk(e)); | semmle.label | 8 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:16:3:16:26 | [ExprStmt] arr.map ... nk(e)); | semmle.order | 8 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:18:3:18:53 | [ExprStmt] [1, 2, ... nk(e)); | semmle.label | 9 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:18:3:18:53 | [ExprStmt] [1, 2, ... nk(e)); | semmle.order | 9 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:20:3:20:18 | [ExprStmt] sink(arr.pop()); | semmle.label | 10 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:20:3:20:18 | [ExprStmt] sink(arr.pop()); | semmle.order | 10 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:22:3:22:24 | [DeclStmt] var arr2 = ... | semmle.label | 11 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:22:3:22:24 | [DeclStmt] var arr2 = ... | semmle.order | 11 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:23:3:23:19 | [ExprStmt] sink(arr2.pop()); | semmle.label | 12 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:23:3:23:19 | [ExprStmt] sink(arr2.pop()); | semmle.order | 12 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:25:3:25:24 | [DeclStmt] var arr3 = ... | semmle.label | 13 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:25:3:25:24 | [DeclStmt] var arr3 = ... | semmle.order | 13 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:26:3:26:19 | [ExprStmt] sink(arr3.pop()); | semmle.label | 14 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:26:3:26:19 | [ExprStmt] sink(arr3.pop()); | semmle.order | 14 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:28:3:28:16 | [DeclStmt] var arr4 = ... | semmle.label | 15 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:28:3:28:16 | [DeclStmt] var arr4 = ... | semmle.order | 15 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:29:3:29:30 | [ExprStmt] arr4.sp ... urce"); | semmle.label | 16 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:29:3:29:30 | [ExprStmt] arr4.sp ... urce"); | semmle.order | 16 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:30:3:30:19 | [ExprStmt] sink(arr4.pop()); | semmle.label | 17 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:30:3:30:19 | [ExprStmt] sink(arr4.pop()); | semmle.order | 17 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:32:3:32:24 | [DeclStmt] var arr4_variant = ... | semmle.label | 18 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:32:3:32:24 | [DeclStmt] var arr4_variant = ... | semmle.order | 18 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:33:3:33:46 | [ExprStmt] arr4_va ... urce"); | semmle.label | 19 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:33:3:33:46 | [ExprStmt] arr4_va ... urce"); | semmle.order | 19 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:34:3:34:21 | [ExprStmt] arr4_variant.pop(); | semmle.label | 20 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:34:3:34:21 | [ExprStmt] arr4_variant.pop(); | semmle.order | 20 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:35:3:35:27 | [ExprStmt] sink(ar ... pop()); | semmle.label | 21 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:35:3:35:27 | [ExprStmt] sink(ar ... pop()); | semmle.order | 21 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:37:3:37:29 | [DeclStmt] var arr5 = ... | semmle.label | 22 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:37:3:37:29 | [DeclStmt] var arr5 = ... | semmle.order | 22 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:38:3:38:19 | [ExprStmt] sink(arr5.pop()); | semmle.label | 23 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:38:3:38:19 | [ExprStmt] sink(arr5.pop()); | semmle.order | 23 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:40:3:40:28 | [ExprStmt] sink(ar ... pop()); | semmle.label | 24 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:40:3:40:28 | [ExprStmt] sink(ar ... pop()); | semmle.order | 24 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:42:3:42:16 | [DeclStmt] var arr6 = ... | semmle.label | 25 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:42:3:42:16 | [DeclStmt] var arr6 = ... | semmle.order | 25 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:43:3:45:3 | [ForStmt] for (va ... i]; } | semmle.label | 26 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:43:3:45:3 | [ForStmt] for (va ... i]; } | semmle.order | 26 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:46:3:46:19 | [ExprStmt] sink(arr6.pop()); | semmle.label | 27 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:46:3:46:19 | [ExprStmt] sink(arr6.pop()); | semmle.order | 27 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:49:3:52:5 | [ExprStmt] ["sourc ... . }); | semmle.label | 28 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:49:3:52:5 | [ExprStmt] ["sourc ... . }); | semmle.order | 28 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:54:3:54:15 | [ExprStmt] sink(arr[0]); | semmle.label | 29 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:54:3:54:15 | [ExprStmt] sink(arr[0]); | semmle.order | 29 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:56:3:58:3 | [ForOfStmt] for (co ... OK } | semmle.label | 30 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:56:3:58:3 | [ForOfStmt] for (co ... OK } | semmle.order | 30 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | semmle.label | 31 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | semmle.order | 31 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | semmle.label | 32 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | semmle.order | 32 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:68:3:68:16 | [DeclStmt] var arr7 = ... | semmle.label | 33 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:68:3:68:16 | [DeclStmt] var arr7 = ... | semmle.order | 33 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:69:3:69:20 | [ExprStmt] arr7.push(...arr); | semmle.label | 34 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:69:3:69:20 | [ExprStmt] arr7.push(...arr); | semmle.order | 34 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | semmle.label | 35 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | semmle.order | 35 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:74:3:74:42 | [DeclStmt] const arrayFrom = ... | semmle.label | 36 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:74:3:74:42 | [DeclStmt] const arrayFrom = ... | semmle.order | 36 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:75:3:77:3 | [ForOfStmt] for (co ... OK } | semmle.label | 37 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:75:3:77:3 | [ForOfStmt] for (co ... OK } | semmle.order | 37 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:79:3:79:31 | [ExprStmt] sink(ar ... back)); | semmle.label | 38 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:79:3:79:31 | [ExprStmt] sink(ar ... back)); | semmle.order | 38 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:81:3:81:42 | [DeclStmt] const arrayFind = ... | semmle.label | 39 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:81:3:81:42 | [DeclStmt] const arrayFind = ... | semmle.order | 39 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:82:3:82:37 | [ExprStmt] sink(ar ... back)); | semmle.label | 40 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:82:3:82:37 | [ExprStmt] sink(ar ... back)); | semmle.order | 40 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:84:3:84:31 | [DeclStmt] const uniq = ... | semmle.label | 41 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:84:3:84:31 | [DeclStmt] const uniq = ... | semmle.order | 41 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:85:3:87:3 | [ForOfStmt] for (co ... OK } | semmle.label | 42 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:85:3:87:3 | [ForOfStmt] for (co ... OK } | semmle.order | 42 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:89:3:89:19 | [ExprStmt] sink(arr.at(-1)); | semmle.label | 43 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:89:3:89:19 | [ExprStmt] sink(arr.at(-1)); | semmle.order | 43 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:91:3:91:36 | [ExprStmt] sink([" ... => x)); | semmle.label | 44 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:91:3:91:36 | [ExprStmt] sink([" ... => x)); | semmle.order | 44 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:92:3:92:38 | [ExprStmt] sink([" ... !!x)); | semmle.label | 45 |
-| arrays.js:1:14:93:1 | [BlockStmt] { let ... OT OK } | arrays.js:92:3:92:38 | [ExprStmt] sink([" ... !!x)); | semmle.order | 45 |
+| arrays.js:1:1:97:2 | [ParExpr] (functi ... T OK }) | arrays.js:1:2:97:1 | [FunctionExpr] functio ... OT OK } | semmle.label | 1 |
+| arrays.js:1:1:97:2 | [ParExpr] (functi ... T OK }) | arrays.js:1:2:97:1 | [FunctionExpr] functio ... OT OK } | semmle.order | 1 |
+| arrays.js:1:1:97:3 | [ExprStmt] (functi ... OK }); | arrays.js:1:1:97:2 | [ParExpr] (functi ... T OK }) | semmle.label | 1 |
+| arrays.js:1:1:97:3 | [ExprStmt] (functi ... OK }); | arrays.js:1:1:97:2 | [ParExpr] (functi ... T OK }) | semmle.order | 1 |
+| arrays.js:1:2:97:1 | [FunctionExpr] functio ... OT OK } | arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | semmle.label | 5 |
+| arrays.js:1:2:97:1 | [FunctionExpr] functio ... OT OK } | arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | semmle.order | 5 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | semmle.label | 1 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | semmle.order | 1 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:4:3:4:28 | [DeclStmt] var obj = ... | semmle.label | 2 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:4:3:4:28 | [DeclStmt] var obj = ... | semmle.order | 2 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:5:3:5:16 | [ExprStmt] sink(obj.foo); | semmle.label | 3 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:5:3:5:16 | [ExprStmt] sink(obj.foo); | semmle.order | 3 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:7:3:7:15 | [DeclStmt] var arr = ... | semmle.label | 4 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:7:3:7:15 | [DeclStmt] var arr = ... | semmle.order | 4 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:8:3:8:19 | [ExprStmt] arr.push(source); | semmle.label | 5 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:8:3:8:19 | [ExprStmt] arr.push(source); | semmle.order | 5 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:10:3:12:3 | [ForStmt] for (va ... OK } | semmle.label | 6 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:10:3:12:3 | [ForStmt] for (va ... OK } | semmle.order | 6 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:15:3:15:30 | [ExprStmt] arr.for ... nk(e)); | semmle.label | 7 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:15:3:15:30 | [ExprStmt] arr.for ... nk(e)); | semmle.order | 7 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:16:3:16:26 | [ExprStmt] arr.map ... nk(e)); | semmle.label | 8 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:16:3:16:26 | [ExprStmt] arr.map ... nk(e)); | semmle.order | 8 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:18:3:18:53 | [ExprStmt] [1, 2, ... nk(e)); | semmle.label | 9 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:18:3:18:53 | [ExprStmt] [1, 2, ... nk(e)); | semmle.order | 9 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:20:3:20:18 | [ExprStmt] sink(arr.pop()); | semmle.label | 10 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:20:3:20:18 | [ExprStmt] sink(arr.pop()); | semmle.order | 10 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:22:3:22:24 | [DeclStmt] var arr2 = ... | semmle.label | 11 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:22:3:22:24 | [DeclStmt] var arr2 = ... | semmle.order | 11 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:23:3:23:19 | [ExprStmt] sink(arr2.pop()); | semmle.label | 12 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:23:3:23:19 | [ExprStmt] sink(arr2.pop()); | semmle.order | 12 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:25:3:25:24 | [DeclStmt] var arr3 = ... | semmle.label | 13 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:25:3:25:24 | [DeclStmt] var arr3 = ... | semmle.order | 13 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:26:3:26:19 | [ExprStmt] sink(arr3.pop()); | semmle.label | 14 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:26:3:26:19 | [ExprStmt] sink(arr3.pop()); | semmle.order | 14 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:28:3:28:16 | [DeclStmt] var arr4 = ... | semmle.label | 15 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:28:3:28:16 | [DeclStmt] var arr4 = ... | semmle.order | 15 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:29:3:29:30 | [ExprStmt] arr4.sp ... urce"); | semmle.label | 16 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:29:3:29:30 | [ExprStmt] arr4.sp ... urce"); | semmle.order | 16 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:30:3:30:19 | [ExprStmt] sink(arr4.pop()); | semmle.label | 17 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:30:3:30:19 | [ExprStmt] sink(arr4.pop()); | semmle.order | 17 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:32:3:32:24 | [DeclStmt] var arr4_variant = ... | semmle.label | 18 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:32:3:32:24 | [DeclStmt] var arr4_variant = ... | semmle.order | 18 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:33:3:33:46 | [ExprStmt] arr4_va ... urce"); | semmle.label | 19 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:33:3:33:46 | [ExprStmt] arr4_va ... urce"); | semmle.order | 19 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:34:3:34:21 | [ExprStmt] arr4_variant.pop(); | semmle.label | 20 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:34:3:34:21 | [ExprStmt] arr4_variant.pop(); | semmle.order | 20 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:35:3:35:27 | [ExprStmt] sink(ar ... pop()); | semmle.label | 21 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:35:3:35:27 | [ExprStmt] sink(ar ... pop()); | semmle.order | 21 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:41:3:41:29 | [DeclStmt] var arr5 = ... | semmle.label | 22 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:41:3:41:29 | [DeclStmt] var arr5 = ... | semmle.order | 22 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:42:3:42:19 | [ExprStmt] sink(arr5.pop()); | semmle.label | 23 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:42:3:42:19 | [ExprStmt] sink(arr5.pop()); | semmle.order | 23 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:44:3:44:28 | [ExprStmt] sink(ar ... pop()); | semmle.label | 24 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:44:3:44:28 | [ExprStmt] sink(ar ... pop()); | semmle.order | 24 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:46:3:46:16 | [DeclStmt] var arr6 = ... | semmle.label | 25 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:46:3:46:16 | [DeclStmt] var arr6 = ... | semmle.order | 25 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:47:3:49:3 | [ForStmt] for (va ... i]; } | semmle.label | 26 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:47:3:49:3 | [ForStmt] for (va ... i]; } | semmle.order | 26 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:50:3:50:19 | [ExprStmt] sink(arr6.pop()); | semmle.label | 27 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:50:3:50:19 | [ExprStmt] sink(arr6.pop()); | semmle.order | 27 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:53:3:56:5 | [ExprStmt] ["sourc ... . }); | semmle.label | 28 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:53:3:56:5 | [ExprStmt] ["sourc ... . }); | semmle.order | 28 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:58:3:58:15 | [ExprStmt] sink(arr[0]); | semmle.label | 29 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:58:3:58:15 | [ExprStmt] sink(arr[0]); | semmle.order | 29 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | semmle.label | 30 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | semmle.order | 30 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | semmle.label | 31 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | semmle.order | 31 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:68:3:70:3 | [ForOfStmt] for (co ... OK } | semmle.label | 32 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:68:3:70:3 | [ForOfStmt] for (co ... OK } | semmle.order | 32 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:72:3:72:16 | [DeclStmt] var arr7 = ... | semmle.label | 33 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:72:3:72:16 | [DeclStmt] var arr7 = ... | semmle.order | 33 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:73:3:73:20 | [ExprStmt] arr7.push(...arr); | semmle.label | 34 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:73:3:73:20 | [ExprStmt] arr7.push(...arr); | semmle.order | 34 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:74:3:76:3 | [ForOfStmt] for (co ... OK } | semmle.label | 35 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:74:3:76:3 | [ForOfStmt] for (co ... OK } | semmle.order | 35 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:78:3:78:42 | [DeclStmt] const arrayFrom = ... | semmle.label | 36 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:78:3:78:42 | [DeclStmt] const arrayFrom = ... | semmle.order | 36 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:79:3:81:3 | [ForOfStmt] for (co ... OK } | semmle.label | 37 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:79:3:81:3 | [ForOfStmt] for (co ... OK } | semmle.order | 37 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:83:3:83:31 | [ExprStmt] sink(ar ... back)); | semmle.label | 38 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:83:3:83:31 | [ExprStmt] sink(ar ... back)); | semmle.order | 38 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:85:3:85:42 | [DeclStmt] const arrayFind = ... | semmle.label | 39 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:85:3:85:42 | [DeclStmt] const arrayFind = ... | semmle.order | 39 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:86:3:86:37 | [ExprStmt] sink(ar ... back)); | semmle.label | 40 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:86:3:86:37 | [ExprStmt] sink(ar ... back)); | semmle.order | 40 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:88:3:88:31 | [DeclStmt] const uniq = ... | semmle.label | 41 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:88:3:88:31 | [DeclStmt] const uniq = ... | semmle.order | 41 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:89:3:91:3 | [ForOfStmt] for (co ... OK } | semmle.label | 42 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:89:3:91:3 | [ForOfStmt] for (co ... OK } | semmle.order | 42 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:93:3:93:19 | [ExprStmt] sink(arr.at(-1)); | semmle.label | 43 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:93:3:93:19 | [ExprStmt] sink(arr.at(-1)); | semmle.order | 43 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:95:3:95:36 | [ExprStmt] sink([" ... => x)); | semmle.label | 44 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:95:3:95:36 | [ExprStmt] sink([" ... => x)); | semmle.order | 44 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:96:3:96:38 | [ExprStmt] sink([" ... !!x)); | semmle.label | 45 |
+| arrays.js:1:14:97:1 | [BlockStmt] { let ... OT OK } | arrays.js:96:3:96:38 | [ExprStmt] sink([" ... !!x)); | semmle.order | 45 |
 | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | arrays.js:2:7:2:23 | [VariableDeclarator] source = "source" | semmle.label | 1 |
 | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | arrays.js:2:7:2:23 | [VariableDeclarator] source = "source" | semmle.order | 1 |
 | arrays.js:2:7:2:23 | [VariableDeclarator] source = "source" | arrays.js:2:7:2:12 | [VarDecl] source | semmle.label | 1 |
@@ -818,196 +818,170 @@ edges
 | arrays.js:35:8:35:23 | [DotExpr] arr4_variant.pop | arrays.js:35:21:35:23 | [Label] pop | semmle.order | 2 |
 | arrays.js:35:8:35:25 | [MethodCallExpr] arr4_variant.pop() | arrays.js:35:8:35:23 | [DotExpr] arr4_variant.pop | semmle.label | 0 |
 | arrays.js:35:8:35:25 | [MethodCallExpr] arr4_variant.pop() | arrays.js:35:8:35:23 | [DotExpr] arr4_variant.pop | semmle.order | 0 |
-| arrays.js:37:3:37:29 | [DeclStmt] var arr5 = ... | arrays.js:37:7:37:28 | [VariableDeclarator] arr5 = ... t(arr4) | semmle.label | 1 |
-| arrays.js:37:3:37:29 | [DeclStmt] var arr5 = ... | arrays.js:37:7:37:28 | [VariableDeclarator] arr5 = ... t(arr4) | semmle.order | 1 |
-| arrays.js:37:7:37:28 | [VariableDeclarator] arr5 = ... t(arr4) | arrays.js:37:7:37:10 | [VarDecl] arr5 | semmle.label | 1 |
-| arrays.js:37:7:37:28 | [VariableDeclarator] arr5 = ... t(arr4) | arrays.js:37:7:37:10 | [VarDecl] arr5 | semmle.order | 1 |
-| arrays.js:37:7:37:28 | [VariableDeclarator] arr5 = ... t(arr4) | arrays.js:37:14:37:28 | [MethodCallExpr] [].concat(arr4) | semmle.label | 2 |
-| arrays.js:37:7:37:28 | [VariableDeclarator] arr5 = ... t(arr4) | arrays.js:37:14:37:28 | [MethodCallExpr] [].concat(arr4) | semmle.order | 2 |
-| arrays.js:37:14:37:22 | [DotExpr] [].concat | arrays.js:37:14:37:15 | [ArrayExpr] [] | semmle.label | 1 |
-| arrays.js:37:14:37:22 | [DotExpr] [].concat | arrays.js:37:14:37:15 | [ArrayExpr] [] | semmle.order | 1 |
-| arrays.js:37:14:37:22 | [DotExpr] [].concat | arrays.js:37:17:37:22 | [Label] concat | semmle.label | 2 |
-| arrays.js:37:14:37:22 | [DotExpr] [].concat | arrays.js:37:17:37:22 | [Label] concat | semmle.order | 2 |
-| arrays.js:37:14:37:28 | [MethodCallExpr] [].concat(arr4) | arrays.js:37:14:37:22 | [DotExpr] [].concat | semmle.label | 0 |
-| arrays.js:37:14:37:28 | [MethodCallExpr] [].concat(arr4) | arrays.js:37:14:37:22 | [DotExpr] [].concat | semmle.order | 0 |
-| arrays.js:37:14:37:28 | [MethodCallExpr] [].concat(arr4) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:37:14:37:28 | [MethodCallExpr] [].concat(arr4) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:38:3:38:18 | [CallExpr] sink(arr5.pop()) | arrays.js:38:3:38:6 | [VarRef] sink | semmle.label | 0 |
-| arrays.js:38:3:38:18 | [CallExpr] sink(arr5.pop()) | arrays.js:38:3:38:6 | [VarRef] sink | semmle.order | 0 |
-| arrays.js:38:3:38:18 | [CallExpr] sink(arr5.pop()) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:38:3:38:18 | [CallExpr] sink(arr5.pop()) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:38:3:38:19 | [ExprStmt] sink(arr5.pop()); | arrays.js:38:3:38:18 | [CallExpr] sink(arr5.pop()) | semmle.label | 1 |
-| arrays.js:38:3:38:19 | [ExprStmt] sink(arr5.pop()); | arrays.js:38:3:38:18 | [CallExpr] sink(arr5.pop()) | semmle.order | 1 |
-| arrays.js:38:8:38:15 | [DotExpr] arr5.pop | arrays.js:38:8:38:11 | [VarRef] arr5 | semmle.label | 1 |
-| arrays.js:38:8:38:15 | [DotExpr] arr5.pop | arrays.js:38:8:38:11 | [VarRef] arr5 | semmle.order | 1 |
-| arrays.js:38:8:38:15 | [DotExpr] arr5.pop | arrays.js:38:13:38:15 | [Label] pop | semmle.label | 2 |
-| arrays.js:38:8:38:15 | [DotExpr] arr5.pop | arrays.js:38:13:38:15 | [Label] pop | semmle.order | 2 |
-| arrays.js:38:8:38:17 | [MethodCallExpr] arr5.pop() | arrays.js:38:8:38:15 | [DotExpr] arr5.pop | semmle.label | 0 |
-| arrays.js:38:8:38:17 | [MethodCallExpr] arr5.pop() | arrays.js:38:8:38:15 | [DotExpr] arr5.pop | semmle.order | 0 |
-| arrays.js:40:3:40:27 | [CallExpr] sink(ar ... .pop()) | arrays.js:40:3:40:6 | [VarRef] sink | semmle.label | 0 |
-| arrays.js:40:3:40:27 | [CallExpr] sink(ar ... .pop()) | arrays.js:40:3:40:6 | [VarRef] sink | semmle.order | 0 |
-| arrays.js:40:3:40:27 | [CallExpr] sink(ar ... .pop()) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:40:3:40:27 | [CallExpr] sink(ar ... .pop()) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:40:3:40:28 | [ExprStmt] sink(ar ... pop()); | arrays.js:40:3:40:27 | [CallExpr] sink(ar ... .pop()) | semmle.label | 1 |
-| arrays.js:40:3:40:28 | [ExprStmt] sink(ar ... pop()); | arrays.js:40:3:40:27 | [CallExpr] sink(ar ... .pop()) | semmle.order | 1 |
-| arrays.js:40:8:40:17 | [DotExpr] arr5.slice | arrays.js:40:8:40:11 | [VarRef] arr5 | semmle.label | 1 |
-| arrays.js:40:8:40:17 | [DotExpr] arr5.slice | arrays.js:40:8:40:11 | [VarRef] arr5 | semmle.order | 1 |
-| arrays.js:40:8:40:17 | [DotExpr] arr5.slice | arrays.js:40:13:40:17 | [Label] slice | semmle.label | 2 |
-| arrays.js:40:8:40:17 | [DotExpr] arr5.slice | arrays.js:40:13:40:17 | [Label] slice | semmle.order | 2 |
-| arrays.js:40:8:40:20 | [MethodCallExpr] arr5.slice(2) | arrays.js:40:8:40:17 | [DotExpr] arr5.slice | semmle.label | 0 |
-| arrays.js:40:8:40:20 | [MethodCallExpr] arr5.slice(2) | arrays.js:40:8:40:17 | [DotExpr] arr5.slice | semmle.order | 0 |
-| arrays.js:40:8:40:20 | [MethodCallExpr] arr5.slice(2) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:40:8:40:20 | [MethodCallExpr] arr5.slice(2) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:40:8:40:24 | [DotExpr] arr5.slice(2).pop | arrays.js:40:8:40:20 | [MethodCallExpr] arr5.slice(2) | semmle.label | 1 |
-| arrays.js:40:8:40:24 | [DotExpr] arr5.slice(2).pop | arrays.js:40:8:40:20 | [MethodCallExpr] arr5.slice(2) | semmle.order | 1 |
-| arrays.js:40:8:40:24 | [DotExpr] arr5.slice(2).pop | arrays.js:40:22:40:24 | [Label] pop | semmle.label | 2 |
-| arrays.js:40:8:40:24 | [DotExpr] arr5.slice(2).pop | arrays.js:40:22:40:24 | [Label] pop | semmle.order | 2 |
-| arrays.js:40:8:40:26 | [MethodCallExpr] arr5.slice(2).pop() | arrays.js:40:8:40:24 | [DotExpr] arr5.slice(2).pop | semmle.label | 0 |
-| arrays.js:40:8:40:26 | [MethodCallExpr] arr5.slice(2).pop() | arrays.js:40:8:40:24 | [DotExpr] arr5.slice(2).pop | semmle.order | 0 |
-| arrays.js:42:3:42:16 | [DeclStmt] var arr6 = ... | arrays.js:42:7:42:15 | [VariableDeclarator] arr6 = [] | semmle.label | 1 |
-| arrays.js:42:3:42:16 | [DeclStmt] var arr6 = ... | arrays.js:42:7:42:15 | [VariableDeclarator] arr6 = [] | semmle.order | 1 |
-| arrays.js:42:7:42:15 | [VariableDeclarator] arr6 = [] | arrays.js:42:7:42:10 | [VarDecl] arr6 | semmle.label | 1 |
-| arrays.js:42:7:42:15 | [VariableDeclarator] arr6 = [] | arrays.js:42:7:42:10 | [VarDecl] arr6 | semmle.order | 1 |
-| arrays.js:42:7:42:15 | [VariableDeclarator] arr6 = [] | arrays.js:42:14:42:15 | [ArrayExpr] [] | semmle.label | 2 |
-| arrays.js:42:7:42:15 | [VariableDeclarator] arr6 = [] | arrays.js:42:14:42:15 | [ArrayExpr] [] | semmle.order | 2 |
-| arrays.js:43:3:45:3 | [ForStmt] for (va ... i]; } | arrays.js:43:8:43:16 | [DeclStmt] var i = ... | semmle.label | 1 |
-| arrays.js:43:3:45:3 | [ForStmt] for (va ... i]; } | arrays.js:43:8:43:16 | [DeclStmt] var i = ... | semmle.order | 1 |
-| arrays.js:43:3:45:3 | [ForStmt] for (va ... i]; } | arrays.js:43:19:43:33 | [BinaryExpr] i < arr5.length | semmle.label | 2 |
-| arrays.js:43:3:45:3 | [ForStmt] for (va ... i]; } | arrays.js:43:19:43:33 | [BinaryExpr] i < arr5.length | semmle.order | 2 |
-| arrays.js:43:3:45:3 | [ForStmt] for (va ... i]; } | arrays.js:43:36:43:38 | [UpdateExpr] i++ | semmle.label | 3 |
-| arrays.js:43:3:45:3 | [ForStmt] for (va ... i]; } | arrays.js:43:36:43:38 | [UpdateExpr] i++ | semmle.order | 3 |
-| arrays.js:43:3:45:3 | [ForStmt] for (va ... i]; } | arrays.js:43:41:45:3 | [BlockStmt] { a ... i]; } | semmle.label | 4 |
-| arrays.js:43:3:45:3 | [ForStmt] for (va ... i]; } | arrays.js:43:41:45:3 | [BlockStmt] { a ... i]; } | semmle.order | 4 |
-| arrays.js:43:8:43:16 | [DeclStmt] var i = ... | arrays.js:43:12:43:16 | [VariableDeclarator] i = 0 | semmle.label | 1 |
-| arrays.js:43:8:43:16 | [DeclStmt] var i = ... | arrays.js:43:12:43:16 | [VariableDeclarator] i = 0 | semmle.order | 1 |
-| arrays.js:43:12:43:16 | [VariableDeclarator] i = 0 | arrays.js:43:12:43:12 | [VarDecl] i | semmle.label | 1 |
-| arrays.js:43:12:43:16 | [VariableDeclarator] i = 0 | arrays.js:43:12:43:12 | [VarDecl] i | semmle.order | 1 |
-| arrays.js:43:12:43:16 | [VariableDeclarator] i = 0 | arrays.js:43:16:43:16 | [Literal] 0 | semmle.label | 2 |
-| arrays.js:43:12:43:16 | [VariableDeclarator] i = 0 | arrays.js:43:16:43:16 | [Literal] 0 | semmle.order | 2 |
-| arrays.js:43:19:43:33 | [BinaryExpr] i < arr5.length | arrays.js:43:19:43:19 | [VarRef] i | semmle.label | 1 |
-| arrays.js:43:19:43:33 | [BinaryExpr] i < arr5.length | arrays.js:43:19:43:19 | [VarRef] i | semmle.order | 1 |
-| arrays.js:43:19:43:33 | [BinaryExpr] i < arr5.length | arrays.js:43:23:43:33 | [DotExpr] arr5.length | semmle.label | 2 |
-| arrays.js:43:19:43:33 | [BinaryExpr] i < arr5.length | arrays.js:43:23:43:33 | [DotExpr] arr5.length | semmle.order | 2 |
-| arrays.js:43:23:43:33 | [DotExpr] arr5.length | arrays.js:43:23:43:26 | [VarRef] arr5 | semmle.label | 1 |
-| arrays.js:43:23:43:33 | [DotExpr] arr5.length | arrays.js:43:23:43:26 | [VarRef] arr5 | semmle.order | 1 |
-| arrays.js:43:23:43:33 | [DotExpr] arr5.length | arrays.js:43:28:43:33 | [Label] length | semmle.label | 2 |
-| arrays.js:43:23:43:33 | [DotExpr] arr5.length | arrays.js:43:28:43:33 | [Label] length | semmle.order | 2 |
-| arrays.js:43:36:43:38 | [UpdateExpr] i++ | arrays.js:43:36:43:36 | [VarRef] i | semmle.label | 1 |
-| arrays.js:43:36:43:38 | [UpdateExpr] i++ | arrays.js:43:36:43:36 | [VarRef] i | semmle.order | 1 |
-| arrays.js:43:41:45:3 | [BlockStmt] { a ... i]; } | arrays.js:44:5:44:22 | [ExprStmt] arr6[i] = arr5[i]; | semmle.label | 1 |
-| arrays.js:43:41:45:3 | [BlockStmt] { a ... i]; } | arrays.js:44:5:44:22 | [ExprStmt] arr6[i] = arr5[i]; | semmle.order | 1 |
-| arrays.js:44:5:44:11 | [IndexExpr] arr6[i] | arrays.js:44:5:44:8 | [VarRef] arr6 | semmle.label | 1 |
-| arrays.js:44:5:44:11 | [IndexExpr] arr6[i] | arrays.js:44:5:44:8 | [VarRef] arr6 | semmle.order | 1 |
-| arrays.js:44:5:44:11 | [IndexExpr] arr6[i] | arrays.js:44:10:44:10 | [VarRef] i | semmle.label | 2 |
-| arrays.js:44:5:44:11 | [IndexExpr] arr6[i] | arrays.js:44:10:44:10 | [VarRef] i | semmle.order | 2 |
-| arrays.js:44:5:44:21 | [AssignExpr] arr6[i] = arr5[i] | arrays.js:44:5:44:11 | [IndexExpr] arr6[i] | semmle.label | 1 |
-| arrays.js:44:5:44:21 | [AssignExpr] arr6[i] = arr5[i] | arrays.js:44:5:44:11 | [IndexExpr] arr6[i] | semmle.order | 1 |
-| arrays.js:44:5:44:21 | [AssignExpr] arr6[i] = arr5[i] | arrays.js:44:15:44:21 | [IndexExpr] arr5[i] | semmle.label | 2 |
-| arrays.js:44:5:44:21 | [AssignExpr] arr6[i] = arr5[i] | arrays.js:44:15:44:21 | [IndexExpr] arr5[i] | semmle.order | 2 |
-| arrays.js:44:5:44:22 | [ExprStmt] arr6[i] = arr5[i]; | arrays.js:44:5:44:21 | [AssignExpr] arr6[i] = arr5[i] | semmle.label | 1 |
-| arrays.js:44:5:44:22 | [ExprStmt] arr6[i] = arr5[i]; | arrays.js:44:5:44:21 | [AssignExpr] arr6[i] = arr5[i] | semmle.order | 1 |
-| arrays.js:44:15:44:21 | [IndexExpr] arr5[i] | arrays.js:44:15:44:18 | [VarRef] arr5 | semmle.label | 1 |
-| arrays.js:44:15:44:21 | [IndexExpr] arr5[i] | arrays.js:44:15:44:18 | [VarRef] arr5 | semmle.order | 1 |
-| arrays.js:44:15:44:21 | [IndexExpr] arr5[i] | arrays.js:44:20:44:20 | [VarRef] i | semmle.label | 2 |
-| arrays.js:44:15:44:21 | [IndexExpr] arr5[i] | arrays.js:44:20:44:20 | [VarRef] i | semmle.order | 2 |
-| arrays.js:46:3:46:18 | [CallExpr] sink(arr6.pop()) | arrays.js:46:3:46:6 | [VarRef] sink | semmle.label | 0 |
-| arrays.js:46:3:46:18 | [CallExpr] sink(arr6.pop()) | arrays.js:46:3:46:6 | [VarRef] sink | semmle.order | 0 |
-| arrays.js:46:3:46:18 | [CallExpr] sink(arr6.pop()) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:46:3:46:18 | [CallExpr] sink(arr6.pop()) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:46:3:46:19 | [ExprStmt] sink(arr6.pop()); | arrays.js:46:3:46:18 | [CallExpr] sink(arr6.pop()) | semmle.label | 1 |
-| arrays.js:46:3:46:19 | [ExprStmt] sink(arr6.pop()); | arrays.js:46:3:46:18 | [CallExpr] sink(arr6.pop()) | semmle.order | 1 |
-| arrays.js:46:8:46:15 | [DotExpr] arr6.pop | arrays.js:46:8:46:11 | [VarRef] arr6 | semmle.label | 1 |
-| arrays.js:46:8:46:15 | [DotExpr] arr6.pop | arrays.js:46:8:46:11 | [VarRef] arr6 | semmle.order | 1 |
-| arrays.js:46:8:46:15 | [DotExpr] arr6.pop | arrays.js:46:13:46:15 | [Label] pop | semmle.label | 2 |
-| arrays.js:46:8:46:15 | [DotExpr] arr6.pop | arrays.js:46:13:46:15 | [Label] pop | semmle.order | 2 |
-| arrays.js:46:8:46:17 | [MethodCallExpr] arr6.pop() | arrays.js:46:8:46:15 | [DotExpr] arr6.pop | semmle.label | 0 |
-| arrays.js:46:8:46:17 | [MethodCallExpr] arr6.pop() | arrays.js:46:8:46:15 | [DotExpr] arr6.pop | semmle.order | 0 |
-| arrays.js:49:3:49:12 | [ArrayExpr] ["source"] | arrays.js:49:4:49:11 | [Literal] "source" | semmle.label | 1 |
-| arrays.js:49:3:49:12 | [ArrayExpr] ["source"] | arrays.js:49:4:49:11 | [Literal] "source" | semmle.order | 1 |
-| arrays.js:49:3:49:20 | [DotExpr] ["source"].forEach | arrays.js:49:3:49:12 | [ArrayExpr] ["source"] | semmle.label | 1 |
-| arrays.js:49:3:49:20 | [DotExpr] ["source"].forEach | arrays.js:49:3:49:12 | [ArrayExpr] ["source"] | semmle.order | 1 |
-| arrays.js:49:3:49:20 | [DotExpr] ["source"].forEach | arrays.js:49:14:49:20 | [Label] forEach | semmle.label | 2 |
-| arrays.js:49:3:49:20 | [DotExpr] ["source"].forEach | arrays.js:49:14:49:20 | [Label] forEach | semmle.order | 2 |
-| arrays.js:49:3:52:4 | [MethodCallExpr] ["sourc ... t. }) | arrays.js:49:3:49:20 | [DotExpr] ["source"].forEach | semmle.label | 0 |
-| arrays.js:49:3:52:4 | [MethodCallExpr] ["sourc ... t. }) | arrays.js:49:3:49:20 | [DotExpr] ["source"].forEach | semmle.order | 0 |
-| arrays.js:49:3:52:4 | [MethodCallExpr] ["sourc ... t. }) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:49:3:52:4 | [MethodCallExpr] ["sourc ... t. }) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:49:3:52:5 | [ExprStmt] ["sourc ... . }); | arrays.js:49:3:52:4 | [MethodCallExpr] ["sourc ... t. }) | semmle.label | 1 |
-| arrays.js:49:3:52:5 | [ExprStmt] ["sourc ... . }); | arrays.js:49:3:52:4 | [MethodCallExpr] ["sourc ... t. }) | semmle.order | 1 |
-| arrays.js:49:22:52:3 | [ArrowFunctionExpr] (e, i, ... nt. } | arrays.js:49:37:52:3 | [BlockStmt] { s ... nt. } | semmle.label | 5 |
-| arrays.js:49:22:52:3 | [ArrowFunctionExpr] (e, i, ... nt. } | arrays.js:49:37:52:3 | [BlockStmt] { s ... nt. } | semmle.order | 5 |
-| arrays.js:49:22:52:3 | [ArrowFunctionExpr] (e, i, ... nt. } | file://:0:0:0:0 | (Parameters) | semmle.label | 1 |
-| arrays.js:49:22:52:3 | [ArrowFunctionExpr] (e, i, ... nt. } | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
-| arrays.js:49:37:52:3 | [BlockStmt] { s ... nt. } | arrays.js:50:5:50:20 | [ExprStmt] sink(ary.pop()); | semmle.label | 1 |
-| arrays.js:49:37:52:3 | [BlockStmt] { s ... nt. } | arrays.js:50:5:50:20 | [ExprStmt] sink(ary.pop()); | semmle.order | 1 |
-| arrays.js:49:37:52:3 | [BlockStmt] { s ... nt. } | arrays.js:51:5:51:14 | [ExprStmt] sink(ary); | semmle.label | 2 |
-| arrays.js:49:37:52:3 | [BlockStmt] { s ... nt. } | arrays.js:51:5:51:14 | [ExprStmt] sink(ary); | semmle.order | 2 |
-| arrays.js:50:5:50:19 | [CallExpr] sink(ary.pop()) | arrays.js:50:5:50:8 | [VarRef] sink | semmle.label | 0 |
-| arrays.js:50:5:50:19 | [CallExpr] sink(ary.pop()) | arrays.js:50:5:50:8 | [VarRef] sink | semmle.order | 0 |
-| arrays.js:50:5:50:19 | [CallExpr] sink(ary.pop()) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:50:5:50:19 | [CallExpr] sink(ary.pop()) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:50:5:50:20 | [ExprStmt] sink(ary.pop()); | arrays.js:50:5:50:19 | [CallExpr] sink(ary.pop()) | semmle.label | 1 |
-| arrays.js:50:5:50:20 | [ExprStmt] sink(ary.pop()); | arrays.js:50:5:50:19 | [CallExpr] sink(ary.pop()) | semmle.order | 1 |
-| arrays.js:50:10:50:16 | [DotExpr] ary.pop | arrays.js:50:10:50:12 | [VarRef] ary | semmle.label | 1 |
-| arrays.js:50:10:50:16 | [DotExpr] ary.pop | arrays.js:50:10:50:12 | [VarRef] ary | semmle.order | 1 |
-| arrays.js:50:10:50:16 | [DotExpr] ary.pop | arrays.js:50:14:50:16 | [Label] pop | semmle.label | 2 |
-| arrays.js:50:10:50:16 | [DotExpr] ary.pop | arrays.js:50:14:50:16 | [Label] pop | semmle.order | 2 |
-| arrays.js:50:10:50:18 | [MethodCallExpr] ary.pop() | arrays.js:50:10:50:16 | [DotExpr] ary.pop | semmle.label | 0 |
-| arrays.js:50:10:50:18 | [MethodCallExpr] ary.pop() | arrays.js:50:10:50:16 | [DotExpr] ary.pop | semmle.order | 0 |
-| arrays.js:51:5:51:13 | [CallExpr] sink(ary) | arrays.js:51:5:51:8 | [VarRef] sink | semmle.label | 0 |
-| arrays.js:51:5:51:13 | [CallExpr] sink(ary) | arrays.js:51:5:51:8 | [VarRef] sink | semmle.order | 0 |
-| arrays.js:51:5:51:13 | [CallExpr] sink(ary) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:51:5:51:13 | [CallExpr] sink(ary) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:51:5:51:14 | [ExprStmt] sink(ary); | arrays.js:51:5:51:13 | [CallExpr] sink(ary) | semmle.label | 1 |
-| arrays.js:51:5:51:14 | [ExprStmt] sink(ary); | arrays.js:51:5:51:13 | [CallExpr] sink(ary) | semmle.order | 1 |
-| arrays.js:54:3:54:14 | [CallExpr] sink(arr[0]) | arrays.js:54:3:54:6 | [VarRef] sink | semmle.label | 0 |
-| arrays.js:54:3:54:14 | [CallExpr] sink(arr[0]) | arrays.js:54:3:54:6 | [VarRef] sink | semmle.order | 0 |
-| arrays.js:54:3:54:14 | [CallExpr] sink(arr[0]) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:54:3:54:14 | [CallExpr] sink(arr[0]) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:54:3:54:15 | [ExprStmt] sink(arr[0]); | arrays.js:54:3:54:14 | [CallExpr] sink(arr[0]) | semmle.label | 1 |
-| arrays.js:54:3:54:15 | [ExprStmt] sink(arr[0]); | arrays.js:54:3:54:14 | [CallExpr] sink(arr[0]) | semmle.order | 1 |
-| arrays.js:54:8:54:13 | [IndexExpr] arr[0] | arrays.js:54:8:54:10 | [VarRef] arr | semmle.label | 1 |
-| arrays.js:54:8:54:13 | [IndexExpr] arr[0] | arrays.js:54:8:54:10 | [VarRef] arr | semmle.order | 1 |
-| arrays.js:54:8:54:13 | [IndexExpr] arr[0] | arrays.js:54:12:54:12 | [Literal] 0 | semmle.label | 2 |
-| arrays.js:54:8:54:13 | [IndexExpr] arr[0] | arrays.js:54:12:54:12 | [Literal] 0 | semmle.order | 2 |
-| arrays.js:56:3:58:3 | [ForOfStmt] for (co ... OK } | arrays.js:56:8:56:14 | [DeclStmt] const x = ... | semmle.label | 1 |
-| arrays.js:56:3:58:3 | [ForOfStmt] for (co ... OK } | arrays.js:56:8:56:14 | [DeclStmt] const x = ... | semmle.order | 1 |
-| arrays.js:56:3:58:3 | [ForOfStmt] for (co ... OK } | arrays.js:56:19:56:21 | [VarRef] arr | semmle.label | 2 |
-| arrays.js:56:3:58:3 | [ForOfStmt] for (co ... OK } | arrays.js:56:19:56:21 | [VarRef] arr | semmle.order | 2 |
-| arrays.js:56:3:58:3 | [ForOfStmt] for (co ... OK } | arrays.js:56:24:58:3 | [BlockStmt] { s ... OK } | semmle.label | 3 |
-| arrays.js:56:3:58:3 | [ForOfStmt] for (co ... OK } | arrays.js:56:24:58:3 | [BlockStmt] { s ... OK } | semmle.order | 3 |
-| arrays.js:56:8:56:14 | [DeclStmt] const x = ... | arrays.js:56:14:56:14 | [VariableDeclarator] x | semmle.label | 1 |
-| arrays.js:56:8:56:14 | [DeclStmt] const x = ... | arrays.js:56:14:56:14 | [VariableDeclarator] x | semmle.order | 1 |
-| arrays.js:56:14:56:14 | [VariableDeclarator] x | arrays.js:56:14:56:14 | [VarDecl] x | semmle.label | 1 |
-| arrays.js:56:14:56:14 | [VariableDeclarator] x | arrays.js:56:14:56:14 | [VarDecl] x | semmle.order | 1 |
-| arrays.js:56:24:58:3 | [BlockStmt] { s ... OK } | arrays.js:57:5:57:12 | [ExprStmt] sink(x); | semmle.label | 1 |
-| arrays.js:56:24:58:3 | [BlockStmt] { s ... OK } | arrays.js:57:5:57:12 | [ExprStmt] sink(x); | semmle.order | 1 |
-| arrays.js:57:5:57:11 | [CallExpr] sink(x) | arrays.js:57:5:57:8 | [VarRef] sink | semmle.label | 0 |
-| arrays.js:57:5:57:11 | [CallExpr] sink(x) | arrays.js:57:5:57:8 | [VarRef] sink | semmle.order | 0 |
-| arrays.js:57:5:57:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:57:5:57:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:57:5:57:12 | [ExprStmt] sink(x); | arrays.js:57:5:57:11 | [CallExpr] sink(x) | semmle.label | 1 |
-| arrays.js:57:5:57:12 | [ExprStmt] sink(x); | arrays.js:57:5:57:11 | [CallExpr] sink(x) | semmle.order | 1 |
+| arrays.js:41:3:41:29 | [DeclStmt] var arr5 = ... | arrays.js:41:7:41:28 | [VariableDeclarator] arr5 = ... t(arr4) | semmle.label | 1 |
+| arrays.js:41:3:41:29 | [DeclStmt] var arr5 = ... | arrays.js:41:7:41:28 | [VariableDeclarator] arr5 = ... t(arr4) | semmle.order | 1 |
+| arrays.js:41:7:41:28 | [VariableDeclarator] arr5 = ... t(arr4) | arrays.js:41:7:41:10 | [VarDecl] arr5 | semmle.label | 1 |
+| arrays.js:41:7:41:28 | [VariableDeclarator] arr5 = ... t(arr4) | arrays.js:41:7:41:10 | [VarDecl] arr5 | semmle.order | 1 |
+| arrays.js:41:7:41:28 | [VariableDeclarator] arr5 = ... t(arr4) | arrays.js:41:14:41:28 | [MethodCallExpr] [].concat(arr4) | semmle.label | 2 |
+| arrays.js:41:7:41:28 | [VariableDeclarator] arr5 = ... t(arr4) | arrays.js:41:14:41:28 | [MethodCallExpr] [].concat(arr4) | semmle.order | 2 |
+| arrays.js:41:14:41:22 | [DotExpr] [].concat | arrays.js:41:14:41:15 | [ArrayExpr] [] | semmle.label | 1 |
+| arrays.js:41:14:41:22 | [DotExpr] [].concat | arrays.js:41:14:41:15 | [ArrayExpr] [] | semmle.order | 1 |
+| arrays.js:41:14:41:22 | [DotExpr] [].concat | arrays.js:41:17:41:22 | [Label] concat | semmle.label | 2 |
+| arrays.js:41:14:41:22 | [DotExpr] [].concat | arrays.js:41:17:41:22 | [Label] concat | semmle.order | 2 |
+| arrays.js:41:14:41:28 | [MethodCallExpr] [].concat(arr4) | arrays.js:41:14:41:22 | [DotExpr] [].concat | semmle.label | 0 |
+| arrays.js:41:14:41:28 | [MethodCallExpr] [].concat(arr4) | arrays.js:41:14:41:22 | [DotExpr] [].concat | semmle.order | 0 |
+| arrays.js:41:14:41:28 | [MethodCallExpr] [].concat(arr4) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:41:14:41:28 | [MethodCallExpr] [].concat(arr4) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:42:3:42:18 | [CallExpr] sink(arr5.pop()) | arrays.js:42:3:42:6 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:42:3:42:18 | [CallExpr] sink(arr5.pop()) | arrays.js:42:3:42:6 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:42:3:42:18 | [CallExpr] sink(arr5.pop()) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:42:3:42:18 | [CallExpr] sink(arr5.pop()) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:42:3:42:19 | [ExprStmt] sink(arr5.pop()); | arrays.js:42:3:42:18 | [CallExpr] sink(arr5.pop()) | semmle.label | 1 |
+| arrays.js:42:3:42:19 | [ExprStmt] sink(arr5.pop()); | arrays.js:42:3:42:18 | [CallExpr] sink(arr5.pop()) | semmle.order | 1 |
+| arrays.js:42:8:42:15 | [DotExpr] arr5.pop | arrays.js:42:8:42:11 | [VarRef] arr5 | semmle.label | 1 |
+| arrays.js:42:8:42:15 | [DotExpr] arr5.pop | arrays.js:42:8:42:11 | [VarRef] arr5 | semmle.order | 1 |
+| arrays.js:42:8:42:15 | [DotExpr] arr5.pop | arrays.js:42:13:42:15 | [Label] pop | semmle.label | 2 |
+| arrays.js:42:8:42:15 | [DotExpr] arr5.pop | arrays.js:42:13:42:15 | [Label] pop | semmle.order | 2 |
+| arrays.js:42:8:42:17 | [MethodCallExpr] arr5.pop() | arrays.js:42:8:42:15 | [DotExpr] arr5.pop | semmle.label | 0 |
+| arrays.js:42:8:42:17 | [MethodCallExpr] arr5.pop() | arrays.js:42:8:42:15 | [DotExpr] arr5.pop | semmle.order | 0 |
+| arrays.js:44:3:44:27 | [CallExpr] sink(ar ... .pop()) | arrays.js:44:3:44:6 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:44:3:44:27 | [CallExpr] sink(ar ... .pop()) | arrays.js:44:3:44:6 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:44:3:44:27 | [CallExpr] sink(ar ... .pop()) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:44:3:44:27 | [CallExpr] sink(ar ... .pop()) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:44:3:44:28 | [ExprStmt] sink(ar ... pop()); | arrays.js:44:3:44:27 | [CallExpr] sink(ar ... .pop()) | semmle.label | 1 |
+| arrays.js:44:3:44:28 | [ExprStmt] sink(ar ... pop()); | arrays.js:44:3:44:27 | [CallExpr] sink(ar ... .pop()) | semmle.order | 1 |
+| arrays.js:44:8:44:17 | [DotExpr] arr5.slice | arrays.js:44:8:44:11 | [VarRef] arr5 | semmle.label | 1 |
+| arrays.js:44:8:44:17 | [DotExpr] arr5.slice | arrays.js:44:8:44:11 | [VarRef] arr5 | semmle.order | 1 |
+| arrays.js:44:8:44:17 | [DotExpr] arr5.slice | arrays.js:44:13:44:17 | [Label] slice | semmle.label | 2 |
+| arrays.js:44:8:44:17 | [DotExpr] arr5.slice | arrays.js:44:13:44:17 | [Label] slice | semmle.order | 2 |
+| arrays.js:44:8:44:20 | [MethodCallExpr] arr5.slice(2) | arrays.js:44:8:44:17 | [DotExpr] arr5.slice | semmle.label | 0 |
+| arrays.js:44:8:44:20 | [MethodCallExpr] arr5.slice(2) | arrays.js:44:8:44:17 | [DotExpr] arr5.slice | semmle.order | 0 |
+| arrays.js:44:8:44:20 | [MethodCallExpr] arr5.slice(2) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:44:8:44:20 | [MethodCallExpr] arr5.slice(2) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:44:8:44:24 | [DotExpr] arr5.slice(2).pop | arrays.js:44:8:44:20 | [MethodCallExpr] arr5.slice(2) | semmle.label | 1 |
+| arrays.js:44:8:44:24 | [DotExpr] arr5.slice(2).pop | arrays.js:44:8:44:20 | [MethodCallExpr] arr5.slice(2) | semmle.order | 1 |
+| arrays.js:44:8:44:24 | [DotExpr] arr5.slice(2).pop | arrays.js:44:22:44:24 | [Label] pop | semmle.label | 2 |
+| arrays.js:44:8:44:24 | [DotExpr] arr5.slice(2).pop | arrays.js:44:22:44:24 | [Label] pop | semmle.order | 2 |
+| arrays.js:44:8:44:26 | [MethodCallExpr] arr5.slice(2).pop() | arrays.js:44:8:44:24 | [DotExpr] arr5.slice(2).pop | semmle.label | 0 |
+| arrays.js:44:8:44:26 | [MethodCallExpr] arr5.slice(2).pop() | arrays.js:44:8:44:24 | [DotExpr] arr5.slice(2).pop | semmle.order | 0 |
+| arrays.js:46:3:46:16 | [DeclStmt] var arr6 = ... | arrays.js:46:7:46:15 | [VariableDeclarator] arr6 = [] | semmle.label | 1 |
+| arrays.js:46:3:46:16 | [DeclStmt] var arr6 = ... | arrays.js:46:7:46:15 | [VariableDeclarator] arr6 = [] | semmle.order | 1 |
+| arrays.js:46:7:46:15 | [VariableDeclarator] arr6 = [] | arrays.js:46:7:46:10 | [VarDecl] arr6 | semmle.label | 1 |
+| arrays.js:46:7:46:15 | [VariableDeclarator] arr6 = [] | arrays.js:46:7:46:10 | [VarDecl] arr6 | semmle.order | 1 |
+| arrays.js:46:7:46:15 | [VariableDeclarator] arr6 = [] | arrays.js:46:14:46:15 | [ArrayExpr] [] | semmle.label | 2 |
+| arrays.js:46:7:46:15 | [VariableDeclarator] arr6 = [] | arrays.js:46:14:46:15 | [ArrayExpr] [] | semmle.order | 2 |
+| arrays.js:47:3:49:3 | [ForStmt] for (va ... i]; } | arrays.js:47:8:47:16 | [DeclStmt] var i = ... | semmle.label | 1 |
+| arrays.js:47:3:49:3 | [ForStmt] for (va ... i]; } | arrays.js:47:8:47:16 | [DeclStmt] var i = ... | semmle.order | 1 |
+| arrays.js:47:3:49:3 | [ForStmt] for (va ... i]; } | arrays.js:47:19:47:33 | [BinaryExpr] i < arr5.length | semmle.label | 2 |
+| arrays.js:47:3:49:3 | [ForStmt] for (va ... i]; } | arrays.js:47:19:47:33 | [BinaryExpr] i < arr5.length | semmle.order | 2 |
+| arrays.js:47:3:49:3 | [ForStmt] for (va ... i]; } | arrays.js:47:36:47:38 | [UpdateExpr] i++ | semmle.label | 3 |
+| arrays.js:47:3:49:3 | [ForStmt] for (va ... i]; } | arrays.js:47:36:47:38 | [UpdateExpr] i++ | semmle.order | 3 |
+| arrays.js:47:3:49:3 | [ForStmt] for (va ... i]; } | arrays.js:47:41:49:3 | [BlockStmt] { a ... i]; } | semmle.label | 4 |
+| arrays.js:47:3:49:3 | [ForStmt] for (va ... i]; } | arrays.js:47:41:49:3 | [BlockStmt] { a ... i]; } | semmle.order | 4 |
+| arrays.js:47:8:47:16 | [DeclStmt] var i = ... | arrays.js:47:12:47:16 | [VariableDeclarator] i = 0 | semmle.label | 1 |
+| arrays.js:47:8:47:16 | [DeclStmt] var i = ... | arrays.js:47:12:47:16 | [VariableDeclarator] i = 0 | semmle.order | 1 |
+| arrays.js:47:12:47:16 | [VariableDeclarator] i = 0 | arrays.js:47:12:47:12 | [VarDecl] i | semmle.label | 1 |
+| arrays.js:47:12:47:16 | [VariableDeclarator] i = 0 | arrays.js:47:12:47:12 | [VarDecl] i | semmle.order | 1 |
+| arrays.js:47:12:47:16 | [VariableDeclarator] i = 0 | arrays.js:47:16:47:16 | [Literal] 0 | semmle.label | 2 |
+| arrays.js:47:12:47:16 | [VariableDeclarator] i = 0 | arrays.js:47:16:47:16 | [Literal] 0 | semmle.order | 2 |
+| arrays.js:47:19:47:33 | [BinaryExpr] i < arr5.length | arrays.js:47:19:47:19 | [VarRef] i | semmle.label | 1 |
+| arrays.js:47:19:47:33 | [BinaryExpr] i < arr5.length | arrays.js:47:19:47:19 | [VarRef] i | semmle.order | 1 |
+| arrays.js:47:19:47:33 | [BinaryExpr] i < arr5.length | arrays.js:47:23:47:33 | [DotExpr] arr5.length | semmle.label | 2 |
+| arrays.js:47:19:47:33 | [BinaryExpr] i < arr5.length | arrays.js:47:23:47:33 | [DotExpr] arr5.length | semmle.order | 2 |
+| arrays.js:47:23:47:33 | [DotExpr] arr5.length | arrays.js:47:23:47:26 | [VarRef] arr5 | semmle.label | 1 |
+| arrays.js:47:23:47:33 | [DotExpr] arr5.length | arrays.js:47:23:47:26 | [VarRef] arr5 | semmle.order | 1 |
+| arrays.js:47:23:47:33 | [DotExpr] arr5.length | arrays.js:47:28:47:33 | [Label] length | semmle.label | 2 |
+| arrays.js:47:23:47:33 | [DotExpr] arr5.length | arrays.js:47:28:47:33 | [Label] length | semmle.order | 2 |
+| arrays.js:47:36:47:38 | [UpdateExpr] i++ | arrays.js:47:36:47:36 | [VarRef] i | semmle.label | 1 |
+| arrays.js:47:36:47:38 | [UpdateExpr] i++ | arrays.js:47:36:47:36 | [VarRef] i | semmle.order | 1 |
+| arrays.js:47:41:49:3 | [BlockStmt] { a ... i]; } | arrays.js:48:5:48:22 | [ExprStmt] arr6[i] = arr5[i]; | semmle.label | 1 |
+| arrays.js:47:41:49:3 | [BlockStmt] { a ... i]; } | arrays.js:48:5:48:22 | [ExprStmt] arr6[i] = arr5[i]; | semmle.order | 1 |
+| arrays.js:48:5:48:11 | [IndexExpr] arr6[i] | arrays.js:48:5:48:8 | [VarRef] arr6 | semmle.label | 1 |
+| arrays.js:48:5:48:11 | [IndexExpr] arr6[i] | arrays.js:48:5:48:8 | [VarRef] arr6 | semmle.order | 1 |
+| arrays.js:48:5:48:11 | [IndexExpr] arr6[i] | arrays.js:48:10:48:10 | [VarRef] i | semmle.label | 2 |
+| arrays.js:48:5:48:11 | [IndexExpr] arr6[i] | arrays.js:48:10:48:10 | [VarRef] i | semmle.order | 2 |
+| arrays.js:48:5:48:21 | [AssignExpr] arr6[i] = arr5[i] | arrays.js:48:5:48:11 | [IndexExpr] arr6[i] | semmle.label | 1 |
+| arrays.js:48:5:48:21 | [AssignExpr] arr6[i] = arr5[i] | arrays.js:48:5:48:11 | [IndexExpr] arr6[i] | semmle.order | 1 |
+| arrays.js:48:5:48:21 | [AssignExpr] arr6[i] = arr5[i] | arrays.js:48:15:48:21 | [IndexExpr] arr5[i] | semmle.label | 2 |
+| arrays.js:48:5:48:21 | [AssignExpr] arr6[i] = arr5[i] | arrays.js:48:15:48:21 | [IndexExpr] arr5[i] | semmle.order | 2 |
+| arrays.js:48:5:48:22 | [ExprStmt] arr6[i] = arr5[i]; | arrays.js:48:5:48:21 | [AssignExpr] arr6[i] = arr5[i] | semmle.label | 1 |
+| arrays.js:48:5:48:22 | [ExprStmt] arr6[i] = arr5[i]; | arrays.js:48:5:48:21 | [AssignExpr] arr6[i] = arr5[i] | semmle.order | 1 |
+| arrays.js:48:15:48:21 | [IndexExpr] arr5[i] | arrays.js:48:15:48:18 | [VarRef] arr5 | semmle.label | 1 |
+| arrays.js:48:15:48:21 | [IndexExpr] arr5[i] | arrays.js:48:15:48:18 | [VarRef] arr5 | semmle.order | 1 |
+| arrays.js:48:15:48:21 | [IndexExpr] arr5[i] | arrays.js:48:20:48:20 | [VarRef] i | semmle.label | 2 |
+| arrays.js:48:15:48:21 | [IndexExpr] arr5[i] | arrays.js:48:20:48:20 | [VarRef] i | semmle.order | 2 |
+| arrays.js:50:3:50:18 | [CallExpr] sink(arr6.pop()) | arrays.js:50:3:50:6 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:50:3:50:18 | [CallExpr] sink(arr6.pop()) | arrays.js:50:3:50:6 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:50:3:50:18 | [CallExpr] sink(arr6.pop()) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:50:3:50:18 | [CallExpr] sink(arr6.pop()) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:50:3:50:19 | [ExprStmt] sink(arr6.pop()); | arrays.js:50:3:50:18 | [CallExpr] sink(arr6.pop()) | semmle.label | 1 |
+| arrays.js:50:3:50:19 | [ExprStmt] sink(arr6.pop()); | arrays.js:50:3:50:18 | [CallExpr] sink(arr6.pop()) | semmle.order | 1 |
+| arrays.js:50:8:50:15 | [DotExpr] arr6.pop | arrays.js:50:8:50:11 | [VarRef] arr6 | semmle.label | 1 |
+| arrays.js:50:8:50:15 | [DotExpr] arr6.pop | arrays.js:50:8:50:11 | [VarRef] arr6 | semmle.order | 1 |
+| arrays.js:50:8:50:15 | [DotExpr] arr6.pop | arrays.js:50:13:50:15 | [Label] pop | semmle.label | 2 |
+| arrays.js:50:8:50:15 | [DotExpr] arr6.pop | arrays.js:50:13:50:15 | [Label] pop | semmle.order | 2 |
+| arrays.js:50:8:50:17 | [MethodCallExpr] arr6.pop() | arrays.js:50:8:50:15 | [DotExpr] arr6.pop | semmle.label | 0 |
+| arrays.js:50:8:50:17 | [MethodCallExpr] arr6.pop() | arrays.js:50:8:50:15 | [DotExpr] arr6.pop | semmle.order | 0 |
+| arrays.js:53:3:53:12 | [ArrayExpr] ["source"] | arrays.js:53:4:53:11 | [Literal] "source" | semmle.label | 1 |
+| arrays.js:53:3:53:12 | [ArrayExpr] ["source"] | arrays.js:53:4:53:11 | [Literal] "source" | semmle.order | 1 |
+| arrays.js:53:3:53:20 | [DotExpr] ["source"].forEach | arrays.js:53:3:53:12 | [ArrayExpr] ["source"] | semmle.label | 1 |
+| arrays.js:53:3:53:20 | [DotExpr] ["source"].forEach | arrays.js:53:3:53:12 | [ArrayExpr] ["source"] | semmle.order | 1 |
+| arrays.js:53:3:53:20 | [DotExpr] ["source"].forEach | arrays.js:53:14:53:20 | [Label] forEach | semmle.label | 2 |
+| arrays.js:53:3:53:20 | [DotExpr] ["source"].forEach | arrays.js:53:14:53:20 | [Label] forEach | semmle.order | 2 |
+| arrays.js:53:3:56:4 | [MethodCallExpr] ["sourc ... t. }) | arrays.js:53:3:53:20 | [DotExpr] ["source"].forEach | semmle.label | 0 |
+| arrays.js:53:3:56:4 | [MethodCallExpr] ["sourc ... t. }) | arrays.js:53:3:53:20 | [DotExpr] ["source"].forEach | semmle.order | 0 |
+| arrays.js:53:3:56:4 | [MethodCallExpr] ["sourc ... t. }) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:53:3:56:4 | [MethodCallExpr] ["sourc ... t. }) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:53:3:56:5 | [ExprStmt] ["sourc ... . }); | arrays.js:53:3:56:4 | [MethodCallExpr] ["sourc ... t. }) | semmle.label | 1 |
+| arrays.js:53:3:56:5 | [ExprStmt] ["sourc ... . }); | arrays.js:53:3:56:4 | [MethodCallExpr] ["sourc ... t. }) | semmle.order | 1 |
+| arrays.js:53:22:56:3 | [ArrowFunctionExpr] (e, i, ... nt. } | arrays.js:53:37:56:3 | [BlockStmt] { s ... nt. } | semmle.label | 5 |
+| arrays.js:53:22:56:3 | [ArrowFunctionExpr] (e, i, ... nt. } | arrays.js:53:37:56:3 | [BlockStmt] { s ... nt. } | semmle.order | 5 |
+| arrays.js:53:22:56:3 | [ArrowFunctionExpr] (e, i, ... nt. } | file://:0:0:0:0 | (Parameters) | semmle.label | 1 |
+| arrays.js:53:22:56:3 | [ArrowFunctionExpr] (e, i, ... nt. } | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
+| arrays.js:53:37:56:3 | [BlockStmt] { s ... nt. } | arrays.js:54:5:54:20 | [ExprStmt] sink(ary.pop()); | semmle.label | 1 |
+| arrays.js:53:37:56:3 | [BlockStmt] { s ... nt. } | arrays.js:54:5:54:20 | [ExprStmt] sink(ary.pop()); | semmle.order | 1 |
+| arrays.js:53:37:56:3 | [BlockStmt] { s ... nt. } | arrays.js:55:5:55:14 | [ExprStmt] sink(ary); | semmle.label | 2 |
+| arrays.js:53:37:56:3 | [BlockStmt] { s ... nt. } | arrays.js:55:5:55:14 | [ExprStmt] sink(ary); | semmle.order | 2 |
+| arrays.js:54:5:54:19 | [CallExpr] sink(ary.pop()) | arrays.js:54:5:54:8 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:54:5:54:19 | [CallExpr] sink(ary.pop()) | arrays.js:54:5:54:8 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:54:5:54:19 | [CallExpr] sink(ary.pop()) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:54:5:54:19 | [CallExpr] sink(ary.pop()) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:54:5:54:20 | [ExprStmt] sink(ary.pop()); | arrays.js:54:5:54:19 | [CallExpr] sink(ary.pop()) | semmle.label | 1 |
+| arrays.js:54:5:54:20 | [ExprStmt] sink(ary.pop()); | arrays.js:54:5:54:19 | [CallExpr] sink(ary.pop()) | semmle.order | 1 |
+| arrays.js:54:10:54:16 | [DotExpr] ary.pop | arrays.js:54:10:54:12 | [VarRef] ary | semmle.label | 1 |
+| arrays.js:54:10:54:16 | [DotExpr] ary.pop | arrays.js:54:10:54:12 | [VarRef] ary | semmle.order | 1 |
+| arrays.js:54:10:54:16 | [DotExpr] ary.pop | arrays.js:54:14:54:16 | [Label] pop | semmle.label | 2 |
+| arrays.js:54:10:54:16 | [DotExpr] ary.pop | arrays.js:54:14:54:16 | [Label] pop | semmle.order | 2 |
+| arrays.js:54:10:54:18 | [MethodCallExpr] ary.pop() | arrays.js:54:10:54:16 | [DotExpr] ary.pop | semmle.label | 0 |
+| arrays.js:54:10:54:18 | [MethodCallExpr] ary.pop() | arrays.js:54:10:54:16 | [DotExpr] ary.pop | semmle.order | 0 |
+| arrays.js:55:5:55:13 | [CallExpr] sink(ary) | arrays.js:55:5:55:8 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:55:5:55:13 | [CallExpr] sink(ary) | arrays.js:55:5:55:8 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:55:5:55:13 | [CallExpr] sink(ary) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:55:5:55:13 | [CallExpr] sink(ary) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:55:5:55:14 | [ExprStmt] sink(ary); | arrays.js:55:5:55:13 | [CallExpr] sink(ary) | semmle.label | 1 |
+| arrays.js:55:5:55:14 | [ExprStmt] sink(ary); | arrays.js:55:5:55:13 | [CallExpr] sink(ary) | semmle.order | 1 |
+| arrays.js:58:3:58:14 | [CallExpr] sink(arr[0]) | arrays.js:58:3:58:6 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:58:3:58:14 | [CallExpr] sink(arr[0]) | arrays.js:58:3:58:6 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:58:3:58:14 | [CallExpr] sink(arr[0]) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:58:3:58:14 | [CallExpr] sink(arr[0]) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:58:3:58:15 | [ExprStmt] sink(arr[0]); | arrays.js:58:3:58:14 | [CallExpr] sink(arr[0]) | semmle.label | 1 |
+| arrays.js:58:3:58:15 | [ExprStmt] sink(arr[0]); | arrays.js:58:3:58:14 | [CallExpr] sink(arr[0]) | semmle.order | 1 |
+| arrays.js:58:8:58:13 | [IndexExpr] arr[0] | arrays.js:58:8:58:10 | [VarRef] arr | semmle.label | 1 |
+| arrays.js:58:8:58:13 | [IndexExpr] arr[0] | arrays.js:58:8:58:10 | [VarRef] arr | semmle.order | 1 |
+| arrays.js:58:8:58:13 | [IndexExpr] arr[0] | arrays.js:58:12:58:12 | [Literal] 0 | semmle.label | 2 |
+| arrays.js:58:8:58:13 | [IndexExpr] arr[0] | arrays.js:58:12:58:12 | [Literal] 0 | semmle.order | 2 |
 | arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | arrays.js:60:8:60:14 | [DeclStmt] const x = ... | semmle.label | 1 |
 | arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | arrays.js:60:8:60:14 | [DeclStmt] const x = ... | semmle.order | 1 |
-| arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | arrays.js:60:19:60:33 | [MethodCallExpr] Array.from(arr) | semmle.label | 2 |
-| arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | arrays.js:60:19:60:33 | [MethodCallExpr] Array.from(arr) | semmle.order | 2 |
-| arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | arrays.js:60:36:62:3 | [BlockStmt] { s ... OK } | semmle.label | 3 |
-| arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | arrays.js:60:36:62:3 | [BlockStmt] { s ... OK } | semmle.order | 3 |
+| arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | arrays.js:60:19:60:21 | [VarRef] arr | semmle.label | 2 |
+| arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | arrays.js:60:19:60:21 | [VarRef] arr | semmle.order | 2 |
+| arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | arrays.js:60:24:62:3 | [BlockStmt] { s ... OK } | semmle.label | 3 |
+| arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | arrays.js:60:24:62:3 | [BlockStmt] { s ... OK } | semmle.order | 3 |
 | arrays.js:60:8:60:14 | [DeclStmt] const x = ... | arrays.js:60:14:60:14 | [VariableDeclarator] x | semmle.label | 1 |
 | arrays.js:60:8:60:14 | [DeclStmt] const x = ... | arrays.js:60:14:60:14 | [VariableDeclarator] x | semmle.order | 1 |
 | arrays.js:60:14:60:14 | [VariableDeclarator] x | arrays.js:60:14:60:14 | [VarDecl] x | semmle.label | 1 |
 | arrays.js:60:14:60:14 | [VariableDeclarator] x | arrays.js:60:14:60:14 | [VarDecl] x | semmle.order | 1 |
-| arrays.js:60:19:60:28 | [DotExpr] Array.from | arrays.js:60:19:60:23 | [VarRef] Array | semmle.label | 1 |
-| arrays.js:60:19:60:28 | [DotExpr] Array.from | arrays.js:60:19:60:23 | [VarRef] Array | semmle.order | 1 |
-| arrays.js:60:19:60:28 | [DotExpr] Array.from | arrays.js:60:25:60:28 | [Label] from | semmle.label | 2 |
-| arrays.js:60:19:60:28 | [DotExpr] Array.from | arrays.js:60:25:60:28 | [Label] from | semmle.order | 2 |
-| arrays.js:60:19:60:33 | [MethodCallExpr] Array.from(arr) | arrays.js:60:19:60:28 | [DotExpr] Array.from | semmle.label | 0 |
-| arrays.js:60:19:60:33 | [MethodCallExpr] Array.from(arr) | arrays.js:60:19:60:28 | [DotExpr] Array.from | semmle.order | 0 |
-| arrays.js:60:19:60:33 | [MethodCallExpr] Array.from(arr) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:60:19:60:33 | [MethodCallExpr] Array.from(arr) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:60:36:62:3 | [BlockStmt] { s ... OK } | arrays.js:61:5:61:12 | [ExprStmt] sink(x); | semmle.label | 1 |
-| arrays.js:60:36:62:3 | [BlockStmt] { s ... OK } | arrays.js:61:5:61:12 | [ExprStmt] sink(x); | semmle.order | 1 |
+| arrays.js:60:24:62:3 | [BlockStmt] { s ... OK } | arrays.js:61:5:61:12 | [ExprStmt] sink(x); | semmle.label | 1 |
+| arrays.js:60:24:62:3 | [BlockStmt] { s ... OK } | arrays.js:61:5:61:12 | [ExprStmt] sink(x); | semmle.order | 1 |
 | arrays.js:61:5:61:11 | [CallExpr] sink(x) | arrays.js:61:5:61:8 | [VarRef] sink | semmle.label | 0 |
 | arrays.js:61:5:61:11 | [CallExpr] sink(x) | arrays.js:61:5:61:8 | [VarRef] sink | semmle.order | 0 |
 | arrays.js:61:5:61:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
@@ -1016,220 +990,246 @@ edges
 | arrays.js:61:5:61:12 | [ExprStmt] sink(x); | arrays.js:61:5:61:11 | [CallExpr] sink(x) | semmle.order | 1 |
 | arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | arrays.js:64:8:64:14 | [DeclStmt] const x = ... | semmle.label | 1 |
 | arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | arrays.js:64:8:64:14 | [DeclStmt] const x = ... | semmle.order | 1 |
-| arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | arrays.js:64:19:64:26 | [ArrayExpr] [...arr] | semmle.label | 2 |
-| arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | arrays.js:64:19:64:26 | [ArrayExpr] [...arr] | semmle.order | 2 |
-| arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | arrays.js:64:29:66:3 | [BlockStmt] { s ... OK } | semmle.label | 3 |
-| arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | arrays.js:64:29:66:3 | [BlockStmt] { s ... OK } | semmle.order | 3 |
+| arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | arrays.js:64:19:64:33 | [MethodCallExpr] Array.from(arr) | semmle.label | 2 |
+| arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | arrays.js:64:19:64:33 | [MethodCallExpr] Array.from(arr) | semmle.order | 2 |
+| arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | arrays.js:64:36:66:3 | [BlockStmt] { s ... OK } | semmle.label | 3 |
+| arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | arrays.js:64:36:66:3 | [BlockStmt] { s ... OK } | semmle.order | 3 |
 | arrays.js:64:8:64:14 | [DeclStmt] const x = ... | arrays.js:64:14:64:14 | [VariableDeclarator] x | semmle.label | 1 |
 | arrays.js:64:8:64:14 | [DeclStmt] const x = ... | arrays.js:64:14:64:14 | [VariableDeclarator] x | semmle.order | 1 |
 | arrays.js:64:14:64:14 | [VariableDeclarator] x | arrays.js:64:14:64:14 | [VarDecl] x | semmle.label | 1 |
 | arrays.js:64:14:64:14 | [VariableDeclarator] x | arrays.js:64:14:64:14 | [VarDecl] x | semmle.order | 1 |
-| arrays.js:64:19:64:26 | [ArrayExpr] [...arr] | arrays.js:64:20:64:25 | [SpreadElement] ...arr | semmle.label | 1 |
-| arrays.js:64:19:64:26 | [ArrayExpr] [...arr] | arrays.js:64:20:64:25 | [SpreadElement] ...arr | semmle.order | 1 |
-| arrays.js:64:20:64:25 | [SpreadElement] ...arr | arrays.js:64:23:64:25 | [VarRef] arr | semmle.label | 1 |
-| arrays.js:64:20:64:25 | [SpreadElement] ...arr | arrays.js:64:23:64:25 | [VarRef] arr | semmle.order | 1 |
-| arrays.js:64:29:66:3 | [BlockStmt] { s ... OK } | arrays.js:65:5:65:12 | [ExprStmt] sink(x); | semmle.label | 1 |
-| arrays.js:64:29:66:3 | [BlockStmt] { s ... OK } | arrays.js:65:5:65:12 | [ExprStmt] sink(x); | semmle.order | 1 |
+| arrays.js:64:19:64:28 | [DotExpr] Array.from | arrays.js:64:19:64:23 | [VarRef] Array | semmle.label | 1 |
+| arrays.js:64:19:64:28 | [DotExpr] Array.from | arrays.js:64:19:64:23 | [VarRef] Array | semmle.order | 1 |
+| arrays.js:64:19:64:28 | [DotExpr] Array.from | arrays.js:64:25:64:28 | [Label] from | semmle.label | 2 |
+| arrays.js:64:19:64:28 | [DotExpr] Array.from | arrays.js:64:25:64:28 | [Label] from | semmle.order | 2 |
+| arrays.js:64:19:64:33 | [MethodCallExpr] Array.from(arr) | arrays.js:64:19:64:28 | [DotExpr] Array.from | semmle.label | 0 |
+| arrays.js:64:19:64:33 | [MethodCallExpr] Array.from(arr) | arrays.js:64:19:64:28 | [DotExpr] Array.from | semmle.order | 0 |
+| arrays.js:64:19:64:33 | [MethodCallExpr] Array.from(arr) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:64:19:64:33 | [MethodCallExpr] Array.from(arr) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:64:36:66:3 | [BlockStmt] { s ... OK } | arrays.js:65:5:65:12 | [ExprStmt] sink(x); | semmle.label | 1 |
+| arrays.js:64:36:66:3 | [BlockStmt] { s ... OK } | arrays.js:65:5:65:12 | [ExprStmt] sink(x); | semmle.order | 1 |
 | arrays.js:65:5:65:11 | [CallExpr] sink(x) | arrays.js:65:5:65:8 | [VarRef] sink | semmle.label | 0 |
 | arrays.js:65:5:65:11 | [CallExpr] sink(x) | arrays.js:65:5:65:8 | [VarRef] sink | semmle.order | 0 |
 | arrays.js:65:5:65:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
 | arrays.js:65:5:65:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
 | arrays.js:65:5:65:12 | [ExprStmt] sink(x); | arrays.js:65:5:65:11 | [CallExpr] sink(x) | semmle.label | 1 |
 | arrays.js:65:5:65:12 | [ExprStmt] sink(x); | arrays.js:65:5:65:11 | [CallExpr] sink(x) | semmle.order | 1 |
-| arrays.js:68:3:68:16 | [DeclStmt] var arr7 = ... | arrays.js:68:7:68:15 | [VariableDeclarator] arr7 = [] | semmle.label | 1 |
-| arrays.js:68:3:68:16 | [DeclStmt] var arr7 = ... | arrays.js:68:7:68:15 | [VariableDeclarator] arr7 = [] | semmle.order | 1 |
-| arrays.js:68:7:68:15 | [VariableDeclarator] arr7 = [] | arrays.js:68:7:68:10 | [VarDecl] arr7 | semmle.label | 1 |
-| arrays.js:68:7:68:15 | [VariableDeclarator] arr7 = [] | arrays.js:68:7:68:10 | [VarDecl] arr7 | semmle.order | 1 |
-| arrays.js:68:7:68:15 | [VariableDeclarator] arr7 = [] | arrays.js:68:14:68:15 | [ArrayExpr] [] | semmle.label | 2 |
-| arrays.js:68:7:68:15 | [VariableDeclarator] arr7 = [] | arrays.js:68:14:68:15 | [ArrayExpr] [] | semmle.order | 2 |
-| arrays.js:69:3:69:11 | [DotExpr] arr7.push | arrays.js:69:3:69:6 | [VarRef] arr7 | semmle.label | 1 |
-| arrays.js:69:3:69:11 | [DotExpr] arr7.push | arrays.js:69:3:69:6 | [VarRef] arr7 | semmle.order | 1 |
-| arrays.js:69:3:69:11 | [DotExpr] arr7.push | arrays.js:69:8:69:11 | [Label] push | semmle.label | 2 |
-| arrays.js:69:3:69:11 | [DotExpr] arr7.push | arrays.js:69:8:69:11 | [Label] push | semmle.order | 2 |
-| arrays.js:69:3:69:19 | [MethodCallExpr] arr7.push(...arr) | arrays.js:69:3:69:11 | [DotExpr] arr7.push | semmle.label | 0 |
-| arrays.js:69:3:69:19 | [MethodCallExpr] arr7.push(...arr) | arrays.js:69:3:69:11 | [DotExpr] arr7.push | semmle.order | 0 |
-| arrays.js:69:3:69:19 | [MethodCallExpr] arr7.push(...arr) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:69:3:69:19 | [MethodCallExpr] arr7.push(...arr) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:69:3:69:20 | [ExprStmt] arr7.push(...arr); | arrays.js:69:3:69:19 | [MethodCallExpr] arr7.push(...arr) | semmle.label | 1 |
-| arrays.js:69:3:69:20 | [ExprStmt] arr7.push(...arr); | arrays.js:69:3:69:19 | [MethodCallExpr] arr7.push(...arr) | semmle.order | 1 |
-| arrays.js:69:13:69:18 | [SpreadElement] ...arr | arrays.js:69:16:69:18 | [VarRef] arr | semmle.label | 1 |
-| arrays.js:69:13:69:18 | [SpreadElement] ...arr | arrays.js:69:16:69:18 | [VarRef] arr | semmle.order | 1 |
-| arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | arrays.js:70:8:70:14 | [DeclStmt] const x = ... | semmle.label | 1 |
-| arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | arrays.js:70:8:70:14 | [DeclStmt] const x = ... | semmle.order | 1 |
-| arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | arrays.js:70:19:70:22 | [VarRef] arr7 | semmle.label | 2 |
-| arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | arrays.js:70:19:70:22 | [VarRef] arr7 | semmle.order | 2 |
-| arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | arrays.js:70:25:72:3 | [BlockStmt] { s ... OK } | semmle.label | 3 |
-| arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | arrays.js:70:25:72:3 | [BlockStmt] { s ... OK } | semmle.order | 3 |
-| arrays.js:70:8:70:14 | [DeclStmt] const x = ... | arrays.js:70:14:70:14 | [VariableDeclarator] x | semmle.label | 1 |
-| arrays.js:70:8:70:14 | [DeclStmt] const x = ... | arrays.js:70:14:70:14 | [VariableDeclarator] x | semmle.order | 1 |
-| arrays.js:70:14:70:14 | [VariableDeclarator] x | arrays.js:70:14:70:14 | [VarDecl] x | semmle.label | 1 |
-| arrays.js:70:14:70:14 | [VariableDeclarator] x | arrays.js:70:14:70:14 | [VarDecl] x | semmle.order | 1 |
-| arrays.js:70:25:72:3 | [BlockStmt] { s ... OK } | arrays.js:71:5:71:12 | [ExprStmt] sink(x); | semmle.label | 1 |
-| arrays.js:70:25:72:3 | [BlockStmt] { s ... OK } | arrays.js:71:5:71:12 | [ExprStmt] sink(x); | semmle.order | 1 |
-| arrays.js:71:5:71:11 | [CallExpr] sink(x) | arrays.js:71:5:71:8 | [VarRef] sink | semmle.label | 0 |
-| arrays.js:71:5:71:11 | [CallExpr] sink(x) | arrays.js:71:5:71:8 | [VarRef] sink | semmle.order | 0 |
-| arrays.js:71:5:71:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:71:5:71:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:71:5:71:12 | [ExprStmt] sink(x); | arrays.js:71:5:71:11 | [CallExpr] sink(x) | semmle.label | 1 |
-| arrays.js:71:5:71:12 | [ExprStmt] sink(x); | arrays.js:71:5:71:11 | [CallExpr] sink(x) | semmle.order | 1 |
-| arrays.js:74:3:74:42 | [DeclStmt] const arrayFrom = ... | arrays.js:74:9:74:41 | [VariableDeclarator] arrayFr ... -from") | semmle.label | 1 |
-| arrays.js:74:3:74:42 | [DeclStmt] const arrayFrom = ... | arrays.js:74:9:74:41 | [VariableDeclarator] arrayFr ... -from") | semmle.order | 1 |
-| arrays.js:74:9:74:41 | [VariableDeclarator] arrayFr ... -from") | arrays.js:74:9:74:17 | [VarDecl] arrayFrom | semmle.label | 1 |
-| arrays.js:74:9:74:41 | [VariableDeclarator] arrayFr ... -from") | arrays.js:74:9:74:17 | [VarDecl] arrayFrom | semmle.order | 1 |
-| arrays.js:74:9:74:41 | [VariableDeclarator] arrayFr ... -from") | arrays.js:74:21:74:41 | [CallExpr] require ... -from") | semmle.label | 2 |
-| arrays.js:74:9:74:41 | [VariableDeclarator] arrayFr ... -from") | arrays.js:74:21:74:41 | [CallExpr] require ... -from") | semmle.order | 2 |
-| arrays.js:74:21:74:41 | [CallExpr] require ... -from") | arrays.js:74:21:74:27 | [VarRef] require | semmle.label | 0 |
-| arrays.js:74:21:74:41 | [CallExpr] require ... -from") | arrays.js:74:21:74:27 | [VarRef] require | semmle.order | 0 |
-| arrays.js:74:21:74:41 | [CallExpr] require ... -from") | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:74:21:74:41 | [CallExpr] require ... -from") | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:75:3:77:3 | [ForOfStmt] for (co ... OK } | arrays.js:75:8:75:14 | [DeclStmt] const x = ... | semmle.label | 1 |
-| arrays.js:75:3:77:3 | [ForOfStmt] for (co ... OK } | arrays.js:75:8:75:14 | [DeclStmt] const x = ... | semmle.order | 1 |
-| arrays.js:75:3:77:3 | [ForOfStmt] for (co ... OK } | arrays.js:75:19:75:32 | [CallExpr] arrayFrom(arr) | semmle.label | 2 |
-| arrays.js:75:3:77:3 | [ForOfStmt] for (co ... OK } | arrays.js:75:19:75:32 | [CallExpr] arrayFrom(arr) | semmle.order | 2 |
-| arrays.js:75:3:77:3 | [ForOfStmt] for (co ... OK } | arrays.js:75:35:77:3 | [BlockStmt] { s ... OK } | semmle.label | 3 |
-| arrays.js:75:3:77:3 | [ForOfStmt] for (co ... OK } | arrays.js:75:35:77:3 | [BlockStmt] { s ... OK } | semmle.order | 3 |
-| arrays.js:75:8:75:14 | [DeclStmt] const x = ... | arrays.js:75:14:75:14 | [VariableDeclarator] x | semmle.label | 1 |
-| arrays.js:75:8:75:14 | [DeclStmt] const x = ... | arrays.js:75:14:75:14 | [VariableDeclarator] x | semmle.order | 1 |
-| arrays.js:75:14:75:14 | [VariableDeclarator] x | arrays.js:75:14:75:14 | [VarDecl] x | semmle.label | 1 |
-| arrays.js:75:14:75:14 | [VariableDeclarator] x | arrays.js:75:14:75:14 | [VarDecl] x | semmle.order | 1 |
-| arrays.js:75:19:75:32 | [CallExpr] arrayFrom(arr) | arrays.js:75:19:75:27 | [VarRef] arrayFrom | semmle.label | 0 |
-| arrays.js:75:19:75:32 | [CallExpr] arrayFrom(arr) | arrays.js:75:19:75:27 | [VarRef] arrayFrom | semmle.order | 0 |
-| arrays.js:75:19:75:32 | [CallExpr] arrayFrom(arr) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:75:19:75:32 | [CallExpr] arrayFrom(arr) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:75:35:77:3 | [BlockStmt] { s ... OK } | arrays.js:76:5:76:12 | [ExprStmt] sink(x); | semmle.label | 1 |
-| arrays.js:75:35:77:3 | [BlockStmt] { s ... OK } | arrays.js:76:5:76:12 | [ExprStmt] sink(x); | semmle.order | 1 |
-| arrays.js:76:5:76:11 | [CallExpr] sink(x) | arrays.js:76:5:76:8 | [VarRef] sink | semmle.label | 0 |
-| arrays.js:76:5:76:11 | [CallExpr] sink(x) | arrays.js:76:5:76:8 | [VarRef] sink | semmle.order | 0 |
-| arrays.js:76:5:76:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:76:5:76:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:76:5:76:12 | [ExprStmt] sink(x); | arrays.js:76:5:76:11 | [CallExpr] sink(x) | semmle.label | 1 |
-| arrays.js:76:5:76:12 | [ExprStmt] sink(x); | arrays.js:76:5:76:11 | [CallExpr] sink(x) | semmle.order | 1 |
-| arrays.js:79:3:79:30 | [CallExpr] sink(ar ... lback)) | arrays.js:79:3:79:6 | [VarRef] sink | semmle.label | 0 |
-| arrays.js:79:3:79:30 | [CallExpr] sink(ar ... lback)) | arrays.js:79:3:79:6 | [VarRef] sink | semmle.order | 0 |
-| arrays.js:79:3:79:30 | [CallExpr] sink(ar ... lback)) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:79:3:79:30 | [CallExpr] sink(ar ... lback)) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:79:3:79:31 | [ExprStmt] sink(ar ... back)); | arrays.js:79:3:79:30 | [CallExpr] sink(ar ... lback)) | semmle.label | 1 |
-| arrays.js:79:3:79:31 | [ExprStmt] sink(ar ... back)); | arrays.js:79:3:79:30 | [CallExpr] sink(ar ... lback)) | semmle.order | 1 |
-| arrays.js:79:8:79:15 | [DotExpr] arr.find | arrays.js:79:8:79:10 | [VarRef] arr | semmle.label | 1 |
-| arrays.js:79:8:79:15 | [DotExpr] arr.find | arrays.js:79:8:79:10 | [VarRef] arr | semmle.order | 1 |
-| arrays.js:79:8:79:15 | [DotExpr] arr.find | arrays.js:79:12:79:15 | [Label] find | semmle.label | 2 |
-| arrays.js:79:8:79:15 | [DotExpr] arr.find | arrays.js:79:12:79:15 | [Label] find | semmle.order | 2 |
-| arrays.js:79:8:79:29 | [MethodCallExpr] arr.fin ... llback) | arrays.js:79:8:79:15 | [DotExpr] arr.find | semmle.label | 0 |
-| arrays.js:79:8:79:29 | [MethodCallExpr] arr.fin ... llback) | arrays.js:79:8:79:15 | [DotExpr] arr.find | semmle.order | 0 |
-| arrays.js:79:8:79:29 | [MethodCallExpr] arr.fin ... llback) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:79:8:79:29 | [MethodCallExpr] arr.fin ... llback) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:81:3:81:42 | [DeclStmt] const arrayFind = ... | arrays.js:81:9:81:41 | [VariableDeclarator] arrayFi ... -find") | semmle.label | 1 |
-| arrays.js:81:3:81:42 | [DeclStmt] const arrayFind = ... | arrays.js:81:9:81:41 | [VariableDeclarator] arrayFi ... -find") | semmle.order | 1 |
-| arrays.js:81:9:81:41 | [VariableDeclarator] arrayFi ... -find") | arrays.js:81:9:81:17 | [VarDecl] arrayFind | semmle.label | 1 |
-| arrays.js:81:9:81:41 | [VariableDeclarator] arrayFi ... -find") | arrays.js:81:9:81:17 | [VarDecl] arrayFind | semmle.order | 1 |
-| arrays.js:81:9:81:41 | [VariableDeclarator] arrayFi ... -find") | arrays.js:81:21:81:41 | [CallExpr] require ... -find") | semmle.label | 2 |
-| arrays.js:81:9:81:41 | [VariableDeclarator] arrayFi ... -find") | arrays.js:81:21:81:41 | [CallExpr] require ... -find") | semmle.order | 2 |
-| arrays.js:81:21:81:41 | [CallExpr] require ... -find") | arrays.js:81:21:81:27 | [VarRef] require | semmle.label | 0 |
-| arrays.js:81:21:81:41 | [CallExpr] require ... -find") | arrays.js:81:21:81:27 | [VarRef] require | semmle.order | 0 |
-| arrays.js:81:21:81:41 | [CallExpr] require ... -find") | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:81:21:81:41 | [CallExpr] require ... -find") | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:82:3:82:36 | [CallExpr] sink(ar ... lback)) | arrays.js:82:3:82:6 | [VarRef] sink | semmle.label | 0 |
-| arrays.js:82:3:82:36 | [CallExpr] sink(ar ... lback)) | arrays.js:82:3:82:6 | [VarRef] sink | semmle.order | 0 |
-| arrays.js:82:3:82:36 | [CallExpr] sink(ar ... lback)) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:82:3:82:36 | [CallExpr] sink(ar ... lback)) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:82:3:82:37 | [ExprStmt] sink(ar ... back)); | arrays.js:82:3:82:36 | [CallExpr] sink(ar ... lback)) | semmle.label | 1 |
-| arrays.js:82:3:82:37 | [ExprStmt] sink(ar ... back)); | arrays.js:82:3:82:36 | [CallExpr] sink(ar ... lback)) | semmle.order | 1 |
-| arrays.js:82:8:82:35 | [CallExpr] arrayFi ... llback) | arrays.js:82:8:82:16 | [VarRef] arrayFind | semmle.label | 0 |
-| arrays.js:82:8:82:35 | [CallExpr] arrayFi ... llback) | arrays.js:82:8:82:16 | [VarRef] arrayFind | semmle.order | 0 |
-| arrays.js:82:8:82:35 | [CallExpr] arrayFi ... llback) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:82:8:82:35 | [CallExpr] arrayFi ... llback) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:84:3:84:31 | [DeclStmt] const uniq = ... | arrays.js:84:9:84:30 | [VariableDeclarator] uniq = ... "uniq") | semmle.label | 1 |
-| arrays.js:84:3:84:31 | [DeclStmt] const uniq = ... | arrays.js:84:9:84:30 | [VariableDeclarator] uniq = ... "uniq") | semmle.order | 1 |
-| arrays.js:84:9:84:30 | [VariableDeclarator] uniq = ... "uniq") | arrays.js:84:9:84:12 | [VarDecl] uniq | semmle.label | 1 |
-| arrays.js:84:9:84:30 | [VariableDeclarator] uniq = ... "uniq") | arrays.js:84:9:84:12 | [VarDecl] uniq | semmle.order | 1 |
-| arrays.js:84:9:84:30 | [VariableDeclarator] uniq = ... "uniq") | arrays.js:84:16:84:30 | [CallExpr] require("uniq") | semmle.label | 2 |
-| arrays.js:84:9:84:30 | [VariableDeclarator] uniq = ... "uniq") | arrays.js:84:16:84:30 | [CallExpr] require("uniq") | semmle.order | 2 |
-| arrays.js:84:16:84:30 | [CallExpr] require("uniq") | arrays.js:84:16:84:22 | [VarRef] require | semmle.label | 0 |
-| arrays.js:84:16:84:30 | [CallExpr] require("uniq") | arrays.js:84:16:84:22 | [VarRef] require | semmle.order | 0 |
-| arrays.js:84:16:84:30 | [CallExpr] require("uniq") | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:84:16:84:30 | [CallExpr] require("uniq") | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:85:3:87:3 | [ForOfStmt] for (co ... OK } | arrays.js:85:8:85:14 | [DeclStmt] const x = ... | semmle.label | 1 |
-| arrays.js:85:3:87:3 | [ForOfStmt] for (co ... OK } | arrays.js:85:8:85:14 | [DeclStmt] const x = ... | semmle.order | 1 |
-| arrays.js:85:3:87:3 | [ForOfStmt] for (co ... OK } | arrays.js:85:19:85:27 | [CallExpr] uniq(arr) | semmle.label | 2 |
-| arrays.js:85:3:87:3 | [ForOfStmt] for (co ... OK } | arrays.js:85:19:85:27 | [CallExpr] uniq(arr) | semmle.order | 2 |
-| arrays.js:85:3:87:3 | [ForOfStmt] for (co ... OK } | arrays.js:85:30:87:3 | [BlockStmt] { s ... OK } | semmle.label | 3 |
-| arrays.js:85:3:87:3 | [ForOfStmt] for (co ... OK } | arrays.js:85:30:87:3 | [BlockStmt] { s ... OK } | semmle.order | 3 |
-| arrays.js:85:8:85:14 | [DeclStmt] const x = ... | arrays.js:85:14:85:14 | [VariableDeclarator] x | semmle.label | 1 |
-| arrays.js:85:8:85:14 | [DeclStmt] const x = ... | arrays.js:85:14:85:14 | [VariableDeclarator] x | semmle.order | 1 |
-| arrays.js:85:14:85:14 | [VariableDeclarator] x | arrays.js:85:14:85:14 | [VarDecl] x | semmle.label | 1 |
-| arrays.js:85:14:85:14 | [VariableDeclarator] x | arrays.js:85:14:85:14 | [VarDecl] x | semmle.order | 1 |
-| arrays.js:85:19:85:27 | [CallExpr] uniq(arr) | arrays.js:85:19:85:22 | [VarRef] uniq | semmle.label | 0 |
-| arrays.js:85:19:85:27 | [CallExpr] uniq(arr) | arrays.js:85:19:85:22 | [VarRef] uniq | semmle.order | 0 |
-| arrays.js:85:19:85:27 | [CallExpr] uniq(arr) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:85:19:85:27 | [CallExpr] uniq(arr) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:85:30:87:3 | [BlockStmt] { s ... OK } | arrays.js:86:5:86:12 | [ExprStmt] sink(x); | semmle.label | 1 |
-| arrays.js:85:30:87:3 | [BlockStmt] { s ... OK } | arrays.js:86:5:86:12 | [ExprStmt] sink(x); | semmle.order | 1 |
-| arrays.js:86:5:86:11 | [CallExpr] sink(x) | arrays.js:86:5:86:8 | [VarRef] sink | semmle.label | 0 |
-| arrays.js:86:5:86:11 | [CallExpr] sink(x) | arrays.js:86:5:86:8 | [VarRef] sink | semmle.order | 0 |
-| arrays.js:86:5:86:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:86:5:86:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:86:5:86:12 | [ExprStmt] sink(x); | arrays.js:86:5:86:11 | [CallExpr] sink(x) | semmle.label | 1 |
-| arrays.js:86:5:86:12 | [ExprStmt] sink(x); | arrays.js:86:5:86:11 | [CallExpr] sink(x) | semmle.order | 1 |
-| arrays.js:89:3:89:18 | [CallExpr] sink(arr.at(-1)) | arrays.js:89:3:89:6 | [VarRef] sink | semmle.label | 0 |
-| arrays.js:89:3:89:18 | [CallExpr] sink(arr.at(-1)) | arrays.js:89:3:89:6 | [VarRef] sink | semmle.order | 0 |
-| arrays.js:89:3:89:18 | [CallExpr] sink(arr.at(-1)) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:89:3:89:18 | [CallExpr] sink(arr.at(-1)) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:89:3:89:19 | [ExprStmt] sink(arr.at(-1)); | arrays.js:89:3:89:18 | [CallExpr] sink(arr.at(-1)) | semmle.label | 1 |
-| arrays.js:89:3:89:19 | [ExprStmt] sink(arr.at(-1)); | arrays.js:89:3:89:18 | [CallExpr] sink(arr.at(-1)) | semmle.order | 1 |
-| arrays.js:89:8:89:13 | [DotExpr] arr.at | arrays.js:89:8:89:10 | [VarRef] arr | semmle.label | 1 |
-| arrays.js:89:8:89:13 | [DotExpr] arr.at | arrays.js:89:8:89:10 | [VarRef] arr | semmle.order | 1 |
-| arrays.js:89:8:89:13 | [DotExpr] arr.at | arrays.js:89:12:89:13 | [Label] at | semmle.label | 2 |
-| arrays.js:89:8:89:13 | [DotExpr] arr.at | arrays.js:89:12:89:13 | [Label] at | semmle.order | 2 |
-| arrays.js:89:8:89:17 | [MethodCallExpr] arr.at(-1) | arrays.js:89:8:89:13 | [DotExpr] arr.at | semmle.label | 0 |
-| arrays.js:89:8:89:17 | [MethodCallExpr] arr.at(-1) | arrays.js:89:8:89:13 | [DotExpr] arr.at | semmle.order | 0 |
-| arrays.js:89:8:89:17 | [MethodCallExpr] arr.at(-1) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:89:8:89:17 | [MethodCallExpr] arr.at(-1) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:89:15:89:16 | [UnaryExpr] -1 | arrays.js:89:16:89:16 | [Literal] 1 | semmle.label | 1 |
-| arrays.js:89:15:89:16 | [UnaryExpr] -1 | arrays.js:89:16:89:16 | [Literal] 1 | semmle.order | 1 |
-| arrays.js:91:3:91:35 | [CallExpr] sink([" ... => x)) | arrays.js:91:3:91:6 | [VarRef] sink | semmle.label | 0 |
-| arrays.js:91:3:91:35 | [CallExpr] sink([" ... => x)) | arrays.js:91:3:91:6 | [VarRef] sink | semmle.order | 0 |
-| arrays.js:91:3:91:35 | [CallExpr] sink([" ... => x)) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:91:3:91:35 | [CallExpr] sink([" ... => x)) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:91:3:91:36 | [ExprStmt] sink([" ... => x)); | arrays.js:91:3:91:35 | [CallExpr] sink([" ... => x)) | semmle.label | 1 |
-| arrays.js:91:3:91:36 | [ExprStmt] sink([" ... => x)); | arrays.js:91:3:91:35 | [CallExpr] sink([" ... => x)) | semmle.order | 1 |
-| arrays.js:91:8:91:17 | [ArrayExpr] ["source"] | arrays.js:91:9:91:16 | [Literal] "source" | semmle.label | 1 |
-| arrays.js:91:8:91:17 | [ArrayExpr] ["source"] | arrays.js:91:9:91:16 | [Literal] "source" | semmle.order | 1 |
-| arrays.js:91:8:91:24 | [DotExpr] ["source"].filter | arrays.js:91:8:91:17 | [ArrayExpr] ["source"] | semmle.label | 1 |
-| arrays.js:91:8:91:24 | [DotExpr] ["source"].filter | arrays.js:91:8:91:17 | [ArrayExpr] ["source"] | semmle.order | 1 |
-| arrays.js:91:8:91:24 | [DotExpr] ["source"].filter | arrays.js:91:19:91:24 | [Label] filter | semmle.label | 2 |
-| arrays.js:91:8:91:24 | [DotExpr] ["source"].filter | arrays.js:91:19:91:24 | [Label] filter | semmle.order | 2 |
-| arrays.js:91:8:91:34 | [MethodCallExpr] ["sourc ... ) => x) | arrays.js:91:8:91:24 | [DotExpr] ["source"].filter | semmle.label | 0 |
-| arrays.js:91:8:91:34 | [MethodCallExpr] ["sourc ... ) => x) | arrays.js:91:8:91:24 | [DotExpr] ["source"].filter | semmle.order | 0 |
-| arrays.js:91:8:91:34 | [MethodCallExpr] ["sourc ... ) => x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:91:8:91:34 | [MethodCallExpr] ["sourc ... ) => x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:91:26:91:33 | [ArrowFunctionExpr] (x) => x | arrays.js:91:33:91:33 | [VarRef] x | semmle.label | 5 |
-| arrays.js:91:26:91:33 | [ArrowFunctionExpr] (x) => x | arrays.js:91:33:91:33 | [VarRef] x | semmle.order | 5 |
-| arrays.js:91:26:91:33 | [ArrowFunctionExpr] (x) => x | file://:0:0:0:0 | (Parameters) | semmle.label | 1 |
-| arrays.js:91:26:91:33 | [ArrowFunctionExpr] (x) => x | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
-| arrays.js:92:3:92:37 | [CallExpr] sink([" ... > !!x)) | arrays.js:92:3:92:6 | [VarRef] sink | semmle.label | 0 |
-| arrays.js:92:3:92:37 | [CallExpr] sink([" ... > !!x)) | arrays.js:92:3:92:6 | [VarRef] sink | semmle.order | 0 |
-| arrays.js:92:3:92:37 | [CallExpr] sink([" ... > !!x)) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:92:3:92:37 | [CallExpr] sink([" ... > !!x)) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:92:3:92:38 | [ExprStmt] sink([" ... !!x)); | arrays.js:92:3:92:37 | [CallExpr] sink([" ... > !!x)) | semmle.label | 1 |
-| arrays.js:92:3:92:38 | [ExprStmt] sink([" ... !!x)); | arrays.js:92:3:92:37 | [CallExpr] sink([" ... > !!x)) | semmle.order | 1 |
-| arrays.js:92:8:92:17 | [ArrayExpr] ["source"] | arrays.js:92:9:92:16 | [Literal] "source" | semmle.label | 1 |
-| arrays.js:92:8:92:17 | [ArrayExpr] ["source"] | arrays.js:92:9:92:16 | [Literal] "source" | semmle.order | 1 |
-| arrays.js:92:8:92:24 | [DotExpr] ["source"].filter | arrays.js:92:8:92:17 | [ArrayExpr] ["source"] | semmle.label | 1 |
-| arrays.js:92:8:92:24 | [DotExpr] ["source"].filter | arrays.js:92:8:92:17 | [ArrayExpr] ["source"] | semmle.order | 1 |
-| arrays.js:92:8:92:24 | [DotExpr] ["source"].filter | arrays.js:92:19:92:24 | [Label] filter | semmle.label | 2 |
-| arrays.js:92:8:92:24 | [DotExpr] ["source"].filter | arrays.js:92:19:92:24 | [Label] filter | semmle.order | 2 |
-| arrays.js:92:8:92:36 | [MethodCallExpr] ["sourc ... => !!x) | arrays.js:92:8:92:24 | [DotExpr] ["source"].filter | semmle.label | 0 |
-| arrays.js:92:8:92:36 | [MethodCallExpr] ["sourc ... => !!x) | arrays.js:92:8:92:24 | [DotExpr] ["source"].filter | semmle.order | 0 |
-| arrays.js:92:8:92:36 | [MethodCallExpr] ["sourc ... => !!x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
-| arrays.js:92:8:92:36 | [MethodCallExpr] ["sourc ... => !!x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
-| arrays.js:92:26:92:35 | [ArrowFunctionExpr] (x) => !!x | arrays.js:92:33:92:35 | [UnaryExpr] !!x | semmle.label | 5 |
-| arrays.js:92:26:92:35 | [ArrowFunctionExpr] (x) => !!x | arrays.js:92:33:92:35 | [UnaryExpr] !!x | semmle.order | 5 |
-| arrays.js:92:26:92:35 | [ArrowFunctionExpr] (x) => !!x | file://:0:0:0:0 | (Parameters) | semmle.label | 1 |
-| arrays.js:92:26:92:35 | [ArrowFunctionExpr] (x) => !!x | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
-| arrays.js:92:33:92:35 | [UnaryExpr] !!x | arrays.js:92:34:92:35 | [UnaryExpr] !x | semmle.label | 1 |
-| arrays.js:92:33:92:35 | [UnaryExpr] !!x | arrays.js:92:34:92:35 | [UnaryExpr] !x | semmle.order | 1 |
-| arrays.js:92:34:92:35 | [UnaryExpr] !x | arrays.js:92:35:92:35 | [VarRef] x | semmle.label | 1 |
-| arrays.js:92:34:92:35 | [UnaryExpr] !x | arrays.js:92:35:92:35 | [VarRef] x | semmle.order | 1 |
+| arrays.js:68:3:70:3 | [ForOfStmt] for (co ... OK } | arrays.js:68:8:68:14 | [DeclStmt] const x = ... | semmle.label | 1 |
+| arrays.js:68:3:70:3 | [ForOfStmt] for (co ... OK } | arrays.js:68:8:68:14 | [DeclStmt] const x = ... | semmle.order | 1 |
+| arrays.js:68:3:70:3 | [ForOfStmt] for (co ... OK } | arrays.js:68:19:68:26 | [ArrayExpr] [...arr] | semmle.label | 2 |
+| arrays.js:68:3:70:3 | [ForOfStmt] for (co ... OK } | arrays.js:68:19:68:26 | [ArrayExpr] [...arr] | semmle.order | 2 |
+| arrays.js:68:3:70:3 | [ForOfStmt] for (co ... OK } | arrays.js:68:29:70:3 | [BlockStmt] { s ... OK } | semmle.label | 3 |
+| arrays.js:68:3:70:3 | [ForOfStmt] for (co ... OK } | arrays.js:68:29:70:3 | [BlockStmt] { s ... OK } | semmle.order | 3 |
+| arrays.js:68:8:68:14 | [DeclStmt] const x = ... | arrays.js:68:14:68:14 | [VariableDeclarator] x | semmle.label | 1 |
+| arrays.js:68:8:68:14 | [DeclStmt] const x = ... | arrays.js:68:14:68:14 | [VariableDeclarator] x | semmle.order | 1 |
+| arrays.js:68:14:68:14 | [VariableDeclarator] x | arrays.js:68:14:68:14 | [VarDecl] x | semmle.label | 1 |
+| arrays.js:68:14:68:14 | [VariableDeclarator] x | arrays.js:68:14:68:14 | [VarDecl] x | semmle.order | 1 |
+| arrays.js:68:19:68:26 | [ArrayExpr] [...arr] | arrays.js:68:20:68:25 | [SpreadElement] ...arr | semmle.label | 1 |
+| arrays.js:68:19:68:26 | [ArrayExpr] [...arr] | arrays.js:68:20:68:25 | [SpreadElement] ...arr | semmle.order | 1 |
+| arrays.js:68:20:68:25 | [SpreadElement] ...arr | arrays.js:68:23:68:25 | [VarRef] arr | semmle.label | 1 |
+| arrays.js:68:20:68:25 | [SpreadElement] ...arr | arrays.js:68:23:68:25 | [VarRef] arr | semmle.order | 1 |
+| arrays.js:68:29:70:3 | [BlockStmt] { s ... OK } | arrays.js:69:5:69:12 | [ExprStmt] sink(x); | semmle.label | 1 |
+| arrays.js:68:29:70:3 | [BlockStmt] { s ... OK } | arrays.js:69:5:69:12 | [ExprStmt] sink(x); | semmle.order | 1 |
+| arrays.js:69:5:69:11 | [CallExpr] sink(x) | arrays.js:69:5:69:8 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:69:5:69:11 | [CallExpr] sink(x) | arrays.js:69:5:69:8 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:69:5:69:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:69:5:69:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:69:5:69:12 | [ExprStmt] sink(x); | arrays.js:69:5:69:11 | [CallExpr] sink(x) | semmle.label | 1 |
+| arrays.js:69:5:69:12 | [ExprStmt] sink(x); | arrays.js:69:5:69:11 | [CallExpr] sink(x) | semmle.order | 1 |
+| arrays.js:72:3:72:16 | [DeclStmt] var arr7 = ... | arrays.js:72:7:72:15 | [VariableDeclarator] arr7 = [] | semmle.label | 1 |
+| arrays.js:72:3:72:16 | [DeclStmt] var arr7 = ... | arrays.js:72:7:72:15 | [VariableDeclarator] arr7 = [] | semmle.order | 1 |
+| arrays.js:72:7:72:15 | [VariableDeclarator] arr7 = [] | arrays.js:72:7:72:10 | [VarDecl] arr7 | semmle.label | 1 |
+| arrays.js:72:7:72:15 | [VariableDeclarator] arr7 = [] | arrays.js:72:7:72:10 | [VarDecl] arr7 | semmle.order | 1 |
+| arrays.js:72:7:72:15 | [VariableDeclarator] arr7 = [] | arrays.js:72:14:72:15 | [ArrayExpr] [] | semmle.label | 2 |
+| arrays.js:72:7:72:15 | [VariableDeclarator] arr7 = [] | arrays.js:72:14:72:15 | [ArrayExpr] [] | semmle.order | 2 |
+| arrays.js:73:3:73:11 | [DotExpr] arr7.push | arrays.js:73:3:73:6 | [VarRef] arr7 | semmle.label | 1 |
+| arrays.js:73:3:73:11 | [DotExpr] arr7.push | arrays.js:73:3:73:6 | [VarRef] arr7 | semmle.order | 1 |
+| arrays.js:73:3:73:11 | [DotExpr] arr7.push | arrays.js:73:8:73:11 | [Label] push | semmle.label | 2 |
+| arrays.js:73:3:73:11 | [DotExpr] arr7.push | arrays.js:73:8:73:11 | [Label] push | semmle.order | 2 |
+| arrays.js:73:3:73:19 | [MethodCallExpr] arr7.push(...arr) | arrays.js:73:3:73:11 | [DotExpr] arr7.push | semmle.label | 0 |
+| arrays.js:73:3:73:19 | [MethodCallExpr] arr7.push(...arr) | arrays.js:73:3:73:11 | [DotExpr] arr7.push | semmle.order | 0 |
+| arrays.js:73:3:73:19 | [MethodCallExpr] arr7.push(...arr) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:73:3:73:19 | [MethodCallExpr] arr7.push(...arr) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:73:3:73:20 | [ExprStmt] arr7.push(...arr); | arrays.js:73:3:73:19 | [MethodCallExpr] arr7.push(...arr) | semmle.label | 1 |
+| arrays.js:73:3:73:20 | [ExprStmt] arr7.push(...arr); | arrays.js:73:3:73:19 | [MethodCallExpr] arr7.push(...arr) | semmle.order | 1 |
+| arrays.js:73:13:73:18 | [SpreadElement] ...arr | arrays.js:73:16:73:18 | [VarRef] arr | semmle.label | 1 |
+| arrays.js:73:13:73:18 | [SpreadElement] ...arr | arrays.js:73:16:73:18 | [VarRef] arr | semmle.order | 1 |
+| arrays.js:74:3:76:3 | [ForOfStmt] for (co ... OK } | arrays.js:74:8:74:14 | [DeclStmt] const x = ... | semmle.label | 1 |
+| arrays.js:74:3:76:3 | [ForOfStmt] for (co ... OK } | arrays.js:74:8:74:14 | [DeclStmt] const x = ... | semmle.order | 1 |
+| arrays.js:74:3:76:3 | [ForOfStmt] for (co ... OK } | arrays.js:74:19:74:22 | [VarRef] arr7 | semmle.label | 2 |
+| arrays.js:74:3:76:3 | [ForOfStmt] for (co ... OK } | arrays.js:74:19:74:22 | [VarRef] arr7 | semmle.order | 2 |
+| arrays.js:74:3:76:3 | [ForOfStmt] for (co ... OK } | arrays.js:74:25:76:3 | [BlockStmt] { s ... OK } | semmle.label | 3 |
+| arrays.js:74:3:76:3 | [ForOfStmt] for (co ... OK } | arrays.js:74:25:76:3 | [BlockStmt] { s ... OK } | semmle.order | 3 |
+| arrays.js:74:8:74:14 | [DeclStmt] const x = ... | arrays.js:74:14:74:14 | [VariableDeclarator] x | semmle.label | 1 |
+| arrays.js:74:8:74:14 | [DeclStmt] const x = ... | arrays.js:74:14:74:14 | [VariableDeclarator] x | semmle.order | 1 |
+| arrays.js:74:14:74:14 | [VariableDeclarator] x | arrays.js:74:14:74:14 | [VarDecl] x | semmle.label | 1 |
+| arrays.js:74:14:74:14 | [VariableDeclarator] x | arrays.js:74:14:74:14 | [VarDecl] x | semmle.order | 1 |
+| arrays.js:74:25:76:3 | [BlockStmt] { s ... OK } | arrays.js:75:5:75:12 | [ExprStmt] sink(x); | semmle.label | 1 |
+| arrays.js:74:25:76:3 | [BlockStmt] { s ... OK } | arrays.js:75:5:75:12 | [ExprStmt] sink(x); | semmle.order | 1 |
+| arrays.js:75:5:75:11 | [CallExpr] sink(x) | arrays.js:75:5:75:8 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:75:5:75:11 | [CallExpr] sink(x) | arrays.js:75:5:75:8 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:75:5:75:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:75:5:75:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:75:5:75:12 | [ExprStmt] sink(x); | arrays.js:75:5:75:11 | [CallExpr] sink(x) | semmle.label | 1 |
+| arrays.js:75:5:75:12 | [ExprStmt] sink(x); | arrays.js:75:5:75:11 | [CallExpr] sink(x) | semmle.order | 1 |
+| arrays.js:78:3:78:42 | [DeclStmt] const arrayFrom = ... | arrays.js:78:9:78:41 | [VariableDeclarator] arrayFr ... -from") | semmle.label | 1 |
+| arrays.js:78:3:78:42 | [DeclStmt] const arrayFrom = ... | arrays.js:78:9:78:41 | [VariableDeclarator] arrayFr ... -from") | semmle.order | 1 |
+| arrays.js:78:9:78:41 | [VariableDeclarator] arrayFr ... -from") | arrays.js:78:9:78:17 | [VarDecl] arrayFrom | semmle.label | 1 |
+| arrays.js:78:9:78:41 | [VariableDeclarator] arrayFr ... -from") | arrays.js:78:9:78:17 | [VarDecl] arrayFrom | semmle.order | 1 |
+| arrays.js:78:9:78:41 | [VariableDeclarator] arrayFr ... -from") | arrays.js:78:21:78:41 | [CallExpr] require ... -from") | semmle.label | 2 |
+| arrays.js:78:9:78:41 | [VariableDeclarator] arrayFr ... -from") | arrays.js:78:21:78:41 | [CallExpr] require ... -from") | semmle.order | 2 |
+| arrays.js:78:21:78:41 | [CallExpr] require ... -from") | arrays.js:78:21:78:27 | [VarRef] require | semmle.label | 0 |
+| arrays.js:78:21:78:41 | [CallExpr] require ... -from") | arrays.js:78:21:78:27 | [VarRef] require | semmle.order | 0 |
+| arrays.js:78:21:78:41 | [CallExpr] require ... -from") | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:78:21:78:41 | [CallExpr] require ... -from") | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:79:3:81:3 | [ForOfStmt] for (co ... OK } | arrays.js:79:8:79:14 | [DeclStmt] const x = ... | semmle.label | 1 |
+| arrays.js:79:3:81:3 | [ForOfStmt] for (co ... OK } | arrays.js:79:8:79:14 | [DeclStmt] const x = ... | semmle.order | 1 |
+| arrays.js:79:3:81:3 | [ForOfStmt] for (co ... OK } | arrays.js:79:19:79:32 | [CallExpr] arrayFrom(arr) | semmle.label | 2 |
+| arrays.js:79:3:81:3 | [ForOfStmt] for (co ... OK } | arrays.js:79:19:79:32 | [CallExpr] arrayFrom(arr) | semmle.order | 2 |
+| arrays.js:79:3:81:3 | [ForOfStmt] for (co ... OK } | arrays.js:79:35:81:3 | [BlockStmt] { s ... OK } | semmle.label | 3 |
+| arrays.js:79:3:81:3 | [ForOfStmt] for (co ... OK } | arrays.js:79:35:81:3 | [BlockStmt] { s ... OK } | semmle.order | 3 |
+| arrays.js:79:8:79:14 | [DeclStmt] const x = ... | arrays.js:79:14:79:14 | [VariableDeclarator] x | semmle.label | 1 |
+| arrays.js:79:8:79:14 | [DeclStmt] const x = ... | arrays.js:79:14:79:14 | [VariableDeclarator] x | semmle.order | 1 |
+| arrays.js:79:14:79:14 | [VariableDeclarator] x | arrays.js:79:14:79:14 | [VarDecl] x | semmle.label | 1 |
+| arrays.js:79:14:79:14 | [VariableDeclarator] x | arrays.js:79:14:79:14 | [VarDecl] x | semmle.order | 1 |
+| arrays.js:79:19:79:32 | [CallExpr] arrayFrom(arr) | arrays.js:79:19:79:27 | [VarRef] arrayFrom | semmle.label | 0 |
+| arrays.js:79:19:79:32 | [CallExpr] arrayFrom(arr) | arrays.js:79:19:79:27 | [VarRef] arrayFrom | semmle.order | 0 |
+| arrays.js:79:19:79:32 | [CallExpr] arrayFrom(arr) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:79:19:79:32 | [CallExpr] arrayFrom(arr) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:79:35:81:3 | [BlockStmt] { s ... OK } | arrays.js:80:5:80:12 | [ExprStmt] sink(x); | semmle.label | 1 |
+| arrays.js:79:35:81:3 | [BlockStmt] { s ... OK } | arrays.js:80:5:80:12 | [ExprStmt] sink(x); | semmle.order | 1 |
+| arrays.js:80:5:80:11 | [CallExpr] sink(x) | arrays.js:80:5:80:8 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:80:5:80:11 | [CallExpr] sink(x) | arrays.js:80:5:80:8 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:80:5:80:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:80:5:80:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:80:5:80:12 | [ExprStmt] sink(x); | arrays.js:80:5:80:11 | [CallExpr] sink(x) | semmle.label | 1 |
+| arrays.js:80:5:80:12 | [ExprStmt] sink(x); | arrays.js:80:5:80:11 | [CallExpr] sink(x) | semmle.order | 1 |
+| arrays.js:83:3:83:30 | [CallExpr] sink(ar ... lback)) | arrays.js:83:3:83:6 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:83:3:83:30 | [CallExpr] sink(ar ... lback)) | arrays.js:83:3:83:6 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:83:3:83:30 | [CallExpr] sink(ar ... lback)) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:83:3:83:30 | [CallExpr] sink(ar ... lback)) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:83:3:83:31 | [ExprStmt] sink(ar ... back)); | arrays.js:83:3:83:30 | [CallExpr] sink(ar ... lback)) | semmle.label | 1 |
+| arrays.js:83:3:83:31 | [ExprStmt] sink(ar ... back)); | arrays.js:83:3:83:30 | [CallExpr] sink(ar ... lback)) | semmle.order | 1 |
+| arrays.js:83:8:83:15 | [DotExpr] arr.find | arrays.js:83:8:83:10 | [VarRef] arr | semmle.label | 1 |
+| arrays.js:83:8:83:15 | [DotExpr] arr.find | arrays.js:83:8:83:10 | [VarRef] arr | semmle.order | 1 |
+| arrays.js:83:8:83:15 | [DotExpr] arr.find | arrays.js:83:12:83:15 | [Label] find | semmle.label | 2 |
+| arrays.js:83:8:83:15 | [DotExpr] arr.find | arrays.js:83:12:83:15 | [Label] find | semmle.order | 2 |
+| arrays.js:83:8:83:29 | [MethodCallExpr] arr.fin ... llback) | arrays.js:83:8:83:15 | [DotExpr] arr.find | semmle.label | 0 |
+| arrays.js:83:8:83:29 | [MethodCallExpr] arr.fin ... llback) | arrays.js:83:8:83:15 | [DotExpr] arr.find | semmle.order | 0 |
+| arrays.js:83:8:83:29 | [MethodCallExpr] arr.fin ... llback) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:83:8:83:29 | [MethodCallExpr] arr.fin ... llback) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:85:3:85:42 | [DeclStmt] const arrayFind = ... | arrays.js:85:9:85:41 | [VariableDeclarator] arrayFi ... -find") | semmle.label | 1 |
+| arrays.js:85:3:85:42 | [DeclStmt] const arrayFind = ... | arrays.js:85:9:85:41 | [VariableDeclarator] arrayFi ... -find") | semmle.order | 1 |
+| arrays.js:85:9:85:41 | [VariableDeclarator] arrayFi ... -find") | arrays.js:85:9:85:17 | [VarDecl] arrayFind | semmle.label | 1 |
+| arrays.js:85:9:85:41 | [VariableDeclarator] arrayFi ... -find") | arrays.js:85:9:85:17 | [VarDecl] arrayFind | semmle.order | 1 |
+| arrays.js:85:9:85:41 | [VariableDeclarator] arrayFi ... -find") | arrays.js:85:21:85:41 | [CallExpr] require ... -find") | semmle.label | 2 |
+| arrays.js:85:9:85:41 | [VariableDeclarator] arrayFi ... -find") | arrays.js:85:21:85:41 | [CallExpr] require ... -find") | semmle.order | 2 |
+| arrays.js:85:21:85:41 | [CallExpr] require ... -find") | arrays.js:85:21:85:27 | [VarRef] require | semmle.label | 0 |
+| arrays.js:85:21:85:41 | [CallExpr] require ... -find") | arrays.js:85:21:85:27 | [VarRef] require | semmle.order | 0 |
+| arrays.js:85:21:85:41 | [CallExpr] require ... -find") | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:85:21:85:41 | [CallExpr] require ... -find") | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:86:3:86:36 | [CallExpr] sink(ar ... lback)) | arrays.js:86:3:86:6 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:86:3:86:36 | [CallExpr] sink(ar ... lback)) | arrays.js:86:3:86:6 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:86:3:86:36 | [CallExpr] sink(ar ... lback)) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:86:3:86:36 | [CallExpr] sink(ar ... lback)) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:86:3:86:37 | [ExprStmt] sink(ar ... back)); | arrays.js:86:3:86:36 | [CallExpr] sink(ar ... lback)) | semmle.label | 1 |
+| arrays.js:86:3:86:37 | [ExprStmt] sink(ar ... back)); | arrays.js:86:3:86:36 | [CallExpr] sink(ar ... lback)) | semmle.order | 1 |
+| arrays.js:86:8:86:35 | [CallExpr] arrayFi ... llback) | arrays.js:86:8:86:16 | [VarRef] arrayFind | semmle.label | 0 |
+| arrays.js:86:8:86:35 | [CallExpr] arrayFi ... llback) | arrays.js:86:8:86:16 | [VarRef] arrayFind | semmle.order | 0 |
+| arrays.js:86:8:86:35 | [CallExpr] arrayFi ... llback) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:86:8:86:35 | [CallExpr] arrayFi ... llback) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:88:3:88:31 | [DeclStmt] const uniq = ... | arrays.js:88:9:88:30 | [VariableDeclarator] uniq = ... "uniq") | semmle.label | 1 |
+| arrays.js:88:3:88:31 | [DeclStmt] const uniq = ... | arrays.js:88:9:88:30 | [VariableDeclarator] uniq = ... "uniq") | semmle.order | 1 |
+| arrays.js:88:9:88:30 | [VariableDeclarator] uniq = ... "uniq") | arrays.js:88:9:88:12 | [VarDecl] uniq | semmle.label | 1 |
+| arrays.js:88:9:88:30 | [VariableDeclarator] uniq = ... "uniq") | arrays.js:88:9:88:12 | [VarDecl] uniq | semmle.order | 1 |
+| arrays.js:88:9:88:30 | [VariableDeclarator] uniq = ... "uniq") | arrays.js:88:16:88:30 | [CallExpr] require("uniq") | semmle.label | 2 |
+| arrays.js:88:9:88:30 | [VariableDeclarator] uniq = ... "uniq") | arrays.js:88:16:88:30 | [CallExpr] require("uniq") | semmle.order | 2 |
+| arrays.js:88:16:88:30 | [CallExpr] require("uniq") | arrays.js:88:16:88:22 | [VarRef] require | semmle.label | 0 |
+| arrays.js:88:16:88:30 | [CallExpr] require("uniq") | arrays.js:88:16:88:22 | [VarRef] require | semmle.order | 0 |
+| arrays.js:88:16:88:30 | [CallExpr] require("uniq") | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:88:16:88:30 | [CallExpr] require("uniq") | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:89:3:91:3 | [ForOfStmt] for (co ... OK } | arrays.js:89:8:89:14 | [DeclStmt] const x = ... | semmle.label | 1 |
+| arrays.js:89:3:91:3 | [ForOfStmt] for (co ... OK } | arrays.js:89:8:89:14 | [DeclStmt] const x = ... | semmle.order | 1 |
+| arrays.js:89:3:91:3 | [ForOfStmt] for (co ... OK } | arrays.js:89:19:89:27 | [CallExpr] uniq(arr) | semmle.label | 2 |
+| arrays.js:89:3:91:3 | [ForOfStmt] for (co ... OK } | arrays.js:89:19:89:27 | [CallExpr] uniq(arr) | semmle.order | 2 |
+| arrays.js:89:3:91:3 | [ForOfStmt] for (co ... OK } | arrays.js:89:30:91:3 | [BlockStmt] { s ... OK } | semmle.label | 3 |
+| arrays.js:89:3:91:3 | [ForOfStmt] for (co ... OK } | arrays.js:89:30:91:3 | [BlockStmt] { s ... OK } | semmle.order | 3 |
+| arrays.js:89:8:89:14 | [DeclStmt] const x = ... | arrays.js:89:14:89:14 | [VariableDeclarator] x | semmle.label | 1 |
+| arrays.js:89:8:89:14 | [DeclStmt] const x = ... | arrays.js:89:14:89:14 | [VariableDeclarator] x | semmle.order | 1 |
+| arrays.js:89:14:89:14 | [VariableDeclarator] x | arrays.js:89:14:89:14 | [VarDecl] x | semmle.label | 1 |
+| arrays.js:89:14:89:14 | [VariableDeclarator] x | arrays.js:89:14:89:14 | [VarDecl] x | semmle.order | 1 |
+| arrays.js:89:19:89:27 | [CallExpr] uniq(arr) | arrays.js:89:19:89:22 | [VarRef] uniq | semmle.label | 0 |
+| arrays.js:89:19:89:27 | [CallExpr] uniq(arr) | arrays.js:89:19:89:22 | [VarRef] uniq | semmle.order | 0 |
+| arrays.js:89:19:89:27 | [CallExpr] uniq(arr) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:89:19:89:27 | [CallExpr] uniq(arr) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:89:30:91:3 | [BlockStmt] { s ... OK } | arrays.js:90:5:90:12 | [ExprStmt] sink(x); | semmle.label | 1 |
+| arrays.js:89:30:91:3 | [BlockStmt] { s ... OK } | arrays.js:90:5:90:12 | [ExprStmt] sink(x); | semmle.order | 1 |
+| arrays.js:90:5:90:11 | [CallExpr] sink(x) | arrays.js:90:5:90:8 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:90:5:90:11 | [CallExpr] sink(x) | arrays.js:90:5:90:8 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:90:5:90:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:90:5:90:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:90:5:90:12 | [ExprStmt] sink(x); | arrays.js:90:5:90:11 | [CallExpr] sink(x) | semmle.label | 1 |
+| arrays.js:90:5:90:12 | [ExprStmt] sink(x); | arrays.js:90:5:90:11 | [CallExpr] sink(x) | semmle.order | 1 |
+| arrays.js:93:3:93:18 | [CallExpr] sink(arr.at(-1)) | arrays.js:93:3:93:6 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:93:3:93:18 | [CallExpr] sink(arr.at(-1)) | arrays.js:93:3:93:6 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:93:3:93:18 | [CallExpr] sink(arr.at(-1)) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:93:3:93:18 | [CallExpr] sink(arr.at(-1)) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:93:3:93:19 | [ExprStmt] sink(arr.at(-1)); | arrays.js:93:3:93:18 | [CallExpr] sink(arr.at(-1)) | semmle.label | 1 |
+| arrays.js:93:3:93:19 | [ExprStmt] sink(arr.at(-1)); | arrays.js:93:3:93:18 | [CallExpr] sink(arr.at(-1)) | semmle.order | 1 |
+| arrays.js:93:8:93:13 | [DotExpr] arr.at | arrays.js:93:8:93:10 | [VarRef] arr | semmle.label | 1 |
+| arrays.js:93:8:93:13 | [DotExpr] arr.at | arrays.js:93:8:93:10 | [VarRef] arr | semmle.order | 1 |
+| arrays.js:93:8:93:13 | [DotExpr] arr.at | arrays.js:93:12:93:13 | [Label] at | semmle.label | 2 |
+| arrays.js:93:8:93:13 | [DotExpr] arr.at | arrays.js:93:12:93:13 | [Label] at | semmle.order | 2 |
+| arrays.js:93:8:93:17 | [MethodCallExpr] arr.at(-1) | arrays.js:93:8:93:13 | [DotExpr] arr.at | semmle.label | 0 |
+| arrays.js:93:8:93:17 | [MethodCallExpr] arr.at(-1) | arrays.js:93:8:93:13 | [DotExpr] arr.at | semmle.order | 0 |
+| arrays.js:93:8:93:17 | [MethodCallExpr] arr.at(-1) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:93:8:93:17 | [MethodCallExpr] arr.at(-1) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:93:15:93:16 | [UnaryExpr] -1 | arrays.js:93:16:93:16 | [Literal] 1 | semmle.label | 1 |
+| arrays.js:93:15:93:16 | [UnaryExpr] -1 | arrays.js:93:16:93:16 | [Literal] 1 | semmle.order | 1 |
+| arrays.js:95:3:95:35 | [CallExpr] sink([" ... => x)) | arrays.js:95:3:95:6 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:95:3:95:35 | [CallExpr] sink([" ... => x)) | arrays.js:95:3:95:6 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:95:3:95:35 | [CallExpr] sink([" ... => x)) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:95:3:95:35 | [CallExpr] sink([" ... => x)) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:95:3:95:36 | [ExprStmt] sink([" ... => x)); | arrays.js:95:3:95:35 | [CallExpr] sink([" ... => x)) | semmle.label | 1 |
+| arrays.js:95:3:95:36 | [ExprStmt] sink([" ... => x)); | arrays.js:95:3:95:35 | [CallExpr] sink([" ... => x)) | semmle.order | 1 |
+| arrays.js:95:8:95:17 | [ArrayExpr] ["source"] | arrays.js:95:9:95:16 | [Literal] "source" | semmle.label | 1 |
+| arrays.js:95:8:95:17 | [ArrayExpr] ["source"] | arrays.js:95:9:95:16 | [Literal] "source" | semmle.order | 1 |
+| arrays.js:95:8:95:24 | [DotExpr] ["source"].filter | arrays.js:95:8:95:17 | [ArrayExpr] ["source"] | semmle.label | 1 |
+| arrays.js:95:8:95:24 | [DotExpr] ["source"].filter | arrays.js:95:8:95:17 | [ArrayExpr] ["source"] | semmle.order | 1 |
+| arrays.js:95:8:95:24 | [DotExpr] ["source"].filter | arrays.js:95:19:95:24 | [Label] filter | semmle.label | 2 |
+| arrays.js:95:8:95:24 | [DotExpr] ["source"].filter | arrays.js:95:19:95:24 | [Label] filter | semmle.order | 2 |
+| arrays.js:95:8:95:34 | [MethodCallExpr] ["sourc ... ) => x) | arrays.js:95:8:95:24 | [DotExpr] ["source"].filter | semmle.label | 0 |
+| arrays.js:95:8:95:34 | [MethodCallExpr] ["sourc ... ) => x) | arrays.js:95:8:95:24 | [DotExpr] ["source"].filter | semmle.order | 0 |
+| arrays.js:95:8:95:34 | [MethodCallExpr] ["sourc ... ) => x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:95:8:95:34 | [MethodCallExpr] ["sourc ... ) => x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:95:26:95:33 | [ArrowFunctionExpr] (x) => x | arrays.js:95:33:95:33 | [VarRef] x | semmle.label | 5 |
+| arrays.js:95:26:95:33 | [ArrowFunctionExpr] (x) => x | arrays.js:95:33:95:33 | [VarRef] x | semmle.order | 5 |
+| arrays.js:95:26:95:33 | [ArrowFunctionExpr] (x) => x | file://:0:0:0:0 | (Parameters) | semmle.label | 1 |
+| arrays.js:95:26:95:33 | [ArrowFunctionExpr] (x) => x | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
+| arrays.js:96:3:96:37 | [CallExpr] sink([" ... > !!x)) | arrays.js:96:3:96:6 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:96:3:96:37 | [CallExpr] sink([" ... > !!x)) | arrays.js:96:3:96:6 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:96:3:96:37 | [CallExpr] sink([" ... > !!x)) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:96:3:96:37 | [CallExpr] sink([" ... > !!x)) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:96:3:96:38 | [ExprStmt] sink([" ... !!x)); | arrays.js:96:3:96:37 | [CallExpr] sink([" ... > !!x)) | semmle.label | 1 |
+| arrays.js:96:3:96:38 | [ExprStmt] sink([" ... !!x)); | arrays.js:96:3:96:37 | [CallExpr] sink([" ... > !!x)) | semmle.order | 1 |
+| arrays.js:96:8:96:17 | [ArrayExpr] ["source"] | arrays.js:96:9:96:16 | [Literal] "source" | semmle.label | 1 |
+| arrays.js:96:8:96:17 | [ArrayExpr] ["source"] | arrays.js:96:9:96:16 | [Literal] "source" | semmle.order | 1 |
+| arrays.js:96:8:96:24 | [DotExpr] ["source"].filter | arrays.js:96:8:96:17 | [ArrayExpr] ["source"] | semmle.label | 1 |
+| arrays.js:96:8:96:24 | [DotExpr] ["source"].filter | arrays.js:96:8:96:17 | [ArrayExpr] ["source"] | semmle.order | 1 |
+| arrays.js:96:8:96:24 | [DotExpr] ["source"].filter | arrays.js:96:19:96:24 | [Label] filter | semmle.label | 2 |
+| arrays.js:96:8:96:24 | [DotExpr] ["source"].filter | arrays.js:96:19:96:24 | [Label] filter | semmle.order | 2 |
+| arrays.js:96:8:96:36 | [MethodCallExpr] ["sourc ... => !!x) | arrays.js:96:8:96:24 | [DotExpr] ["source"].filter | semmle.label | 0 |
+| arrays.js:96:8:96:36 | [MethodCallExpr] ["sourc ... => !!x) | arrays.js:96:8:96:24 | [DotExpr] ["source"].filter | semmle.order | 0 |
+| arrays.js:96:8:96:36 | [MethodCallExpr] ["sourc ... => !!x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:96:8:96:36 | [MethodCallExpr] ["sourc ... => !!x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:96:26:96:35 | [ArrowFunctionExpr] (x) => !!x | arrays.js:96:33:96:35 | [UnaryExpr] !!x | semmle.label | 5 |
+| arrays.js:96:26:96:35 | [ArrowFunctionExpr] (x) => !!x | arrays.js:96:33:96:35 | [UnaryExpr] !!x | semmle.order | 5 |
+| arrays.js:96:26:96:35 | [ArrowFunctionExpr] (x) => !!x | file://:0:0:0:0 | (Parameters) | semmle.label | 1 |
+| arrays.js:96:26:96:35 | [ArrowFunctionExpr] (x) => !!x | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
+| arrays.js:96:33:96:35 | [UnaryExpr] !!x | arrays.js:96:34:96:35 | [UnaryExpr] !x | semmle.label | 1 |
+| arrays.js:96:33:96:35 | [UnaryExpr] !!x | arrays.js:96:34:96:35 | [UnaryExpr] !x | semmle.order | 1 |
+| arrays.js:96:34:96:35 | [UnaryExpr] !x | arrays.js:96:35:96:35 | [VarRef] x | semmle.label | 1 |
+| arrays.js:96:34:96:35 | [UnaryExpr] !x | arrays.js:96:35:96:35 | [VarRef] x | semmle.order | 1 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:5:8:5:14 | [DotExpr] obj.foo | semmle.label | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:5:8:5:14 | [DotExpr] obj.foo | semmle.order | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:8:12:8:17 | [VarRef] source | semmle.label | 0 |
@@ -1274,72 +1274,72 @@ edges
 | file://:0:0:0:0 | (Arguments) | arrays.js:33:37:33:44 | [Literal] "source" | semmle.order | 3 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:35:8:35:25 | [MethodCallExpr] arr4_variant.pop() | semmle.label | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:35:8:35:25 | [MethodCallExpr] arr4_variant.pop() | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:37:24:37:27 | [VarRef] arr4 | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:37:24:37:27 | [VarRef] arr4 | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:38:8:38:17 | [MethodCallExpr] arr5.pop() | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:38:8:38:17 | [MethodCallExpr] arr5.pop() | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:40:8:40:26 | [MethodCallExpr] arr5.slice(2).pop() | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:40:8:40:26 | [MethodCallExpr] arr5.slice(2).pop() | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:40:19:40:19 | [Literal] 2 | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:40:19:40:19 | [Literal] 2 | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:46:8:46:17 | [MethodCallExpr] arr6.pop() | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:46:8:46:17 | [MethodCallExpr] arr6.pop() | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:49:22:52:3 | [ArrowFunctionExpr] (e, i, ... nt. } | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:49:22:52:3 | [ArrowFunctionExpr] (e, i, ... nt. } | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:50:10:50:18 | [MethodCallExpr] ary.pop() | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:50:10:50:18 | [MethodCallExpr] ary.pop() | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:51:10:51:12 | [VarRef] ary | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:51:10:51:12 | [VarRef] ary | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:54:8:54:13 | [IndexExpr] arr[0] | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:54:8:54:13 | [IndexExpr] arr[0] | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:57:10:57:10 | [VarRef] x | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:57:10:57:10 | [VarRef] x | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:60:30:60:32 | [VarRef] arr | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:60:30:60:32 | [VarRef] arr | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:41:24:41:27 | [VarRef] arr4 | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:41:24:41:27 | [VarRef] arr4 | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:42:8:42:17 | [MethodCallExpr] arr5.pop() | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:42:8:42:17 | [MethodCallExpr] arr5.pop() | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:44:8:44:26 | [MethodCallExpr] arr5.slice(2).pop() | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:44:8:44:26 | [MethodCallExpr] arr5.slice(2).pop() | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:44:19:44:19 | [Literal] 2 | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:44:19:44:19 | [Literal] 2 | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:50:8:50:17 | [MethodCallExpr] arr6.pop() | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:50:8:50:17 | [MethodCallExpr] arr6.pop() | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:53:22:56:3 | [ArrowFunctionExpr] (e, i, ... nt. } | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:53:22:56:3 | [ArrowFunctionExpr] (e, i, ... nt. } | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:54:10:54:18 | [MethodCallExpr] ary.pop() | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:54:10:54:18 | [MethodCallExpr] ary.pop() | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:55:10:55:12 | [VarRef] ary | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:55:10:55:12 | [VarRef] ary | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:58:8:58:13 | [IndexExpr] arr[0] | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:58:8:58:13 | [IndexExpr] arr[0] | semmle.order | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:61:10:61:10 | [VarRef] x | semmle.label | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:61:10:61:10 | [VarRef] x | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:64:30:64:32 | [VarRef] arr | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:64:30:64:32 | [VarRef] arr | semmle.order | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:65:10:65:10 | [VarRef] x | semmle.label | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:65:10:65:10 | [VarRef] x | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:69:13:69:18 | [SpreadElement] ...arr | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:69:13:69:18 | [SpreadElement] ...arr | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:71:10:71:10 | [VarRef] x | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:71:10:71:10 | [VarRef] x | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:74:29:74:40 | [Literal] "array-from" | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:74:29:74:40 | [Literal] "array-from" | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:75:29:75:31 | [VarRef] arr | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:75:29:75:31 | [VarRef] arr | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:76:10:76:10 | [VarRef] x | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:76:10:76:10 | [VarRef] x | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:79:8:79:29 | [MethodCallExpr] arr.fin ... llback) | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:79:8:79:29 | [MethodCallExpr] arr.fin ... llback) | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:79:17:79:28 | [VarRef] someCallback | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:79:17:79:28 | [VarRef] someCallback | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:81:29:81:40 | [Literal] "array-find" | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:81:29:81:40 | [Literal] "array-find" | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:82:8:82:35 | [CallExpr] arrayFi ... llback) | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:82:8:82:35 | [CallExpr] arrayFi ... llback) | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:82:18:82:20 | [VarRef] arr | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:82:18:82:20 | [VarRef] arr | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:82:23:82:34 | [VarRef] someCallback | semmle.label | 1 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:82:23:82:34 | [VarRef] someCallback | semmle.order | 1 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:84:24:84:29 | [Literal] "uniq" | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:84:24:84:29 | [Literal] "uniq" | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:85:24:85:26 | [VarRef] arr | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:85:24:85:26 | [VarRef] arr | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:86:10:86:10 | [VarRef] x | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:86:10:86:10 | [VarRef] x | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:89:8:89:17 | [MethodCallExpr] arr.at(-1) | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:89:8:89:17 | [MethodCallExpr] arr.at(-1) | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:89:15:89:16 | [UnaryExpr] -1 | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:89:15:89:16 | [UnaryExpr] -1 | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:91:8:91:34 | [MethodCallExpr] ["sourc ... ) => x) | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:91:8:91:34 | [MethodCallExpr] ["sourc ... ) => x) | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:91:26:91:33 | [ArrowFunctionExpr] (x) => x | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:91:26:91:33 | [ArrowFunctionExpr] (x) => x | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:92:8:92:36 | [MethodCallExpr] ["sourc ... => !!x) | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:92:8:92:36 | [MethodCallExpr] ["sourc ... => !!x) | semmle.order | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:92:26:92:35 | [ArrowFunctionExpr] (x) => !!x | semmle.label | 0 |
-| file://:0:0:0:0 | (Arguments) | arrays.js:92:26:92:35 | [ArrowFunctionExpr] (x) => !!x | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:69:10:69:10 | [VarRef] x | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:69:10:69:10 | [VarRef] x | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:73:13:73:18 | [SpreadElement] ...arr | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:73:13:73:18 | [SpreadElement] ...arr | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:75:10:75:10 | [VarRef] x | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:75:10:75:10 | [VarRef] x | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:78:29:78:40 | [Literal] "array-from" | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:78:29:78:40 | [Literal] "array-from" | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:79:29:79:31 | [VarRef] arr | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:79:29:79:31 | [VarRef] arr | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:80:10:80:10 | [VarRef] x | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:80:10:80:10 | [VarRef] x | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:83:8:83:29 | [MethodCallExpr] arr.fin ... llback) | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:83:8:83:29 | [MethodCallExpr] arr.fin ... llback) | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:83:17:83:28 | [VarRef] someCallback | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:83:17:83:28 | [VarRef] someCallback | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:85:29:85:40 | [Literal] "array-find" | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:85:29:85:40 | [Literal] "array-find" | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:86:8:86:35 | [CallExpr] arrayFi ... llback) | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:86:8:86:35 | [CallExpr] arrayFi ... llback) | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:86:18:86:20 | [VarRef] arr | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:86:18:86:20 | [VarRef] arr | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:86:23:86:34 | [VarRef] someCallback | semmle.label | 1 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:86:23:86:34 | [VarRef] someCallback | semmle.order | 1 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:88:24:88:29 | [Literal] "uniq" | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:88:24:88:29 | [Literal] "uniq" | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:89:24:89:26 | [VarRef] arr | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:89:24:89:26 | [VarRef] arr | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:90:10:90:10 | [VarRef] x | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:90:10:90:10 | [VarRef] x | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:93:8:93:17 | [MethodCallExpr] arr.at(-1) | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:93:8:93:17 | [MethodCallExpr] arr.at(-1) | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:93:15:93:16 | [UnaryExpr] -1 | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:93:15:93:16 | [UnaryExpr] -1 | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:95:8:95:34 | [MethodCallExpr] ["sourc ... ) => x) | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:95:8:95:34 | [MethodCallExpr] ["sourc ... ) => x) | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:95:26:95:33 | [ArrowFunctionExpr] (x) => x | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:95:26:95:33 | [ArrowFunctionExpr] (x) => x | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:96:8:96:36 | [MethodCallExpr] ["sourc ... => !!x) | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:96:8:96:36 | [MethodCallExpr] ["sourc ... => !!x) | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:96:26:96:35 | [ArrowFunctionExpr] (x) => !!x | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:96:26:96:35 | [ArrowFunctionExpr] (x) => !!x | semmle.order | 0 |
 | file://:0:0:0:0 | (Parameters) | arrays.js:15:16:15:16 | [SimpleParameter] e | semmle.label | 0 |
 | file://:0:0:0:0 | (Parameters) | arrays.js:15:16:15:16 | [SimpleParameter] e | semmle.order | 0 |
 | file://:0:0:0:0 | (Parameters) | arrays.js:16:12:16:12 | [SimpleParameter] e | semmle.label | 0 |
@@ -1348,15 +1348,15 @@ edges
 | file://:0:0:0:0 | (Parameters) | arrays.js:18:17:18:17 | [SimpleParameter] i | semmle.order | 0 |
 | file://:0:0:0:0 | (Parameters) | arrays.js:18:40:18:40 | [SimpleParameter] e | semmle.label | 0 |
 | file://:0:0:0:0 | (Parameters) | arrays.js:18:40:18:40 | [SimpleParameter] e | semmle.order | 0 |
-| file://:0:0:0:0 | (Parameters) | arrays.js:49:23:49:23 | [SimpleParameter] e | semmle.label | 0 |
-| file://:0:0:0:0 | (Parameters) | arrays.js:49:23:49:23 | [SimpleParameter] e | semmle.order | 0 |
-| file://:0:0:0:0 | (Parameters) | arrays.js:49:26:49:26 | [SimpleParameter] i | semmle.label | 1 |
-| file://:0:0:0:0 | (Parameters) | arrays.js:49:26:49:26 | [SimpleParameter] i | semmle.order | 1 |
-| file://:0:0:0:0 | (Parameters) | arrays.js:49:29:49:31 | [SimpleParameter] ary | semmle.label | 2 |
-| file://:0:0:0:0 | (Parameters) | arrays.js:49:29:49:31 | [SimpleParameter] ary | semmle.order | 2 |
-| file://:0:0:0:0 | (Parameters) | arrays.js:91:27:91:27 | [SimpleParameter] x | semmle.label | 0 |
-| file://:0:0:0:0 | (Parameters) | arrays.js:91:27:91:27 | [SimpleParameter] x | semmle.order | 0 |
-| file://:0:0:0:0 | (Parameters) | arrays.js:92:27:92:27 | [SimpleParameter] x | semmle.label | 0 |
-| file://:0:0:0:0 | (Parameters) | arrays.js:92:27:92:27 | [SimpleParameter] x | semmle.order | 0 |
+| file://:0:0:0:0 | (Parameters) | arrays.js:53:23:53:23 | [SimpleParameter] e | semmle.label | 0 |
+| file://:0:0:0:0 | (Parameters) | arrays.js:53:23:53:23 | [SimpleParameter] e | semmle.order | 0 |
+| file://:0:0:0:0 | (Parameters) | arrays.js:53:26:53:26 | [SimpleParameter] i | semmle.label | 1 |
+| file://:0:0:0:0 | (Parameters) | arrays.js:53:26:53:26 | [SimpleParameter] i | semmle.order | 1 |
+| file://:0:0:0:0 | (Parameters) | arrays.js:53:29:53:31 | [SimpleParameter] ary | semmle.label | 2 |
+| file://:0:0:0:0 | (Parameters) | arrays.js:53:29:53:31 | [SimpleParameter] ary | semmle.order | 2 |
+| file://:0:0:0:0 | (Parameters) | arrays.js:95:27:95:27 | [SimpleParameter] x | semmle.label | 0 |
+| file://:0:0:0:0 | (Parameters) | arrays.js:95:27:95:27 | [SimpleParameter] x | semmle.order | 0 |
+| file://:0:0:0:0 | (Parameters) | arrays.js:96:27:96:27 | [SimpleParameter] x | semmle.label | 0 |
+| file://:0:0:0:0 | (Parameters) | arrays.js:96:27:96:27 | [SimpleParameter] x | semmle.order | 0 |
 graphProperties
 | semmle.graphKind | tree |

--- a/javascript/ql/test/library-tests/frameworks/Collections/test.expected
+++ b/javascript/ql/test/library-tests/frameworks/Collections/test.expected
@@ -26,6 +26,7 @@ typeTracking
 | tst.js:2:16:2:23 | source() | tst.js:37:14:37:14 | e |
 | tst.js:2:16:2:23 | source() | tst.js:41:14:41:14 | e |
 | tst.js:2:16:2:23 | source() | tst.js:45:14:45:14 | e |
+| tst.js:2:16:2:23 | source() | tst.js:49:14:49:14 | e |
 | tst.js:2:16:2:23 | source() | tst.js:53:8:53:21 | map.get("key") |
 | tst.js:2:16:2:23 | source() | tst.js:59:8:59:22 | map2.get("foo") |
 | tst.js:2:16:2:23 | source() | tst.js:64:8:64:26 | map3.get(unknown()) |

--- a/javascript/ql/test/library-tests/frameworks/Collections/tst.js
+++ b/javascript/ql/test/library-tests/frameworks/Collections/tst.js
@@ -47,7 +47,7 @@
   }
 
   for (const e of Array.from(set)) {
-    sink(e); // NOT OK  (not caught by type-tracking, as it doesn't include array steps). 
+    sink(e); // NOT OK
   }
 
   sink(map.get("key")); // NOT OK.


### PR DESCRIPTION
I also spotted a mistake in Array.splice modeling, so I also fixed it up.

I think the big question is whether we actually _want_ to have these steps part of normal type-tracking; by allowing read of array elements at _any_ position, we might not handle examples like the one below precisely (and think the call `f()` could target any of the 3 functions)

```js
const fns = [f1, f2 ,f3];
const f = fns[0];
f();
```

_note: I didn't actually test this out, just thinking out loud_