### PR TITLE
SSA: Fix bad join in `lastRefRedefExt`

### DIFF
--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -801,7 +801,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
       input = bb
       or
       varBlockReachesExt(def, v, bb, input) and
-      ssaDefReachesThroughBlock(def, input)
+      ssaDefReachesThroughBlock(def, pragma[only_bind_into](input))
     )
   }
 


### PR DESCRIPTION
C/C++ started using this predicate in https://github.com/github/codeql/pull/16677, and apparently there's a bad join order in the predicate.

Before:
```ql
[2024-06-12 15:21:44] (79s) Tuple counts for SsaInternals::lastRefRedefExt/6#638f2140/6@a7eef2qm after 1m19s:
  14364       ~0%        {6} r1 = SCAN `SsaInternals::SsaImpl::lastRefRedefExtSameBlock/5#8f663a50` OUTPUT In.0 'def', In.1 'sv', In.2 'input', In.3 'i', In.2 'input', In.4 'next'
  
  1102500     ~876%      {4} r2 = SCAN `project#SsaInternals::SsaImpl::SsaDefReaches::ssaDefRank/5#4a1106c1#4` OUTPUT In.3, In.0 'next', In.1 'sv', In.2
  797000      ~1088%     {3}    | JOIN WITH SsaInternals::SsaImpl::SsaDefReaches::SsaDefExt#21906d4b ON FIRST 1 OUTPUT Lhs.3, Lhs.1 'next', Lhs.2 'sv'
  
  9759567     ~2653%     {4} r3 = JOIN r2 WITH `IRBlock::Cached::blockSuccessor/2#febf9bad_10#join_rhs` ON FIRST 1 OUTPUT Lhs.2 'sv', Rhs.1 'input', Lhs.1 'next', Rhs.1 'input'
  219998      ~1727%     {6}    | JOIN WITH `SsaInternals::SsaImpl::SsaDefReaches::lastSsaRefExt/4#5ae3cddd_1203#join_rhs` ON FIRST 2 OUTPUT Rhs.2 'def', Lhs.0 'sv', Lhs.1 'bb', Rhs.3 'i', Lhs.2 'next', Lhs.3 'input'
  
  3120220     ~1246%     {3} r4 = JOIN r2 WITH `IRBlock::Cached::blockSuccessor/2#febf9bad_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1 'input', Lhs.1 'next', Lhs.2 'sv'
  25197329678 ~1453%     {4}    | JOIN WITH `SsaInternals::SsaImpl::SsaDefReaches::ssaDefReachesThroughBlock/2#08d74e18_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1 'def', Lhs.2 'sv', Lhs.0 'input', Lhs.1 'next'
  2715499     ~559%      {5}    | JOIN WITH `SsaInternals::SsaImpl::SsaDefReaches::varBlockReachesExt/4#0feaecdc_0132#join_rhs` ON FIRST 3 OUTPUT Lhs.0 'def', Lhs.1 'sv', Rhs.3 'bb', Lhs.3 'next', Lhs.2 'input'
  2710499     ~556%      {6}    | JOIN WITH `SsaInternals::SsaImpl::SsaDefReaches::lastSsaRefExt/4#5ae3cddd` ON FIRST 3 OUTPUT Lhs.0 'def', Lhs.1 'sv', Lhs.2 'bb', Rhs.3 'i', Lhs.3 'next', Lhs.4 'input'
  
  2930497     ~1499%     {6} r5 = r3 UNION r4
  2925500     ~1499%     {6}    | JOIN WITH `SsaInternals::SsaImpl::SsaDefReaches::lastSsaRefExt/4#5ae3cddd` ON FIRST 4 OUTPUT Lhs.0 'def', Lhs.1 'sv', Lhs.2 'bb', Lhs.3 'i', Lhs.5 'input', Lhs.4 'next'
  
  2939864     ~1388%     {6} r6 = r1 UNION r5
                          return r6
```
(I stopped it mid evaluation)

After:
```ql
[2024-06-12 15:17:31] (8s) Tuple counts for SsaInternals::lastRefRedefExt/6#638f2140/6@02b60fvq after 8.1s:
  14364    ~0%     {6} r1 = SCAN `SsaInternals::SsaImpl::lastRefRedefExtSameBlock/5#8f663a50` OUTPUT In.0 'def', In.1 'sv', In.2 'input', In.3 'i', In.2 'input', In.4 'next'
  
  1201834  ~0%     {4} r2 = SCAN `project#SsaInternals::SsaImpl::SsaDefReaches::ssaDefRank/5#4a1106c1#4` OUTPUT In.3, In.0 'next', In.1 'sv', In.2
  863954   ~2%     {3}    | JOIN WITH SsaInternals::SsaImpl::SsaDefReaches::SsaDefExt#21906d4b ON FIRST 1 OUTPUT Lhs.3, Lhs.1 'next', Lhs.2 'sv'
  
  37047209 ~0%     {4} r3 = JOIN r2 WITH `IRBlock::Cached::blockSuccessor/2#febf9bad_10#join_rhs` ON FIRST 1 OUTPUT Lhs.2 'sv', Rhs.1 'input', Lhs.1 'next', Rhs.1 'input'
  270157   ~0%     {6}    | JOIN WITH `SsaInternals::SsaImpl::SsaDefReaches::lastSsaRefExt/4#5ae3cddd_1203#join_rhs` ON FIRST 2 OUTPUT Rhs.2 'def', Lhs.0 'sv', Lhs.1 'bb', Rhs.3 'i', Lhs.2 'next', Lhs.3 'input'
  
  37047209 ~0%     {3} r4 = JOIN r2 WITH `IRBlock::Cached::blockSuccessor/2#febf9bad_10#join_rhs` ON FIRST 1 OUTPUT Lhs.2 'sv', Rhs.1 'input', Lhs.1 'next'
  36833116 ~0%     {5}    | JOIN WITH `SsaInternals::SsaImpl::SsaDefReaches::varBlockReachesExt/4#0feaecdc_1302#join_rhs` ON FIRST 2 OUTPUT Rhs.2 'def', Lhs.0 'sv', Rhs.3 'bb', Lhs.2 'next', Lhs.1 'input'
  36830048 ~4%     {6}    | JOIN WITH `SsaInternals::SsaImpl::SsaDefReaches::lastSsaRefExt/4#5ae3cddd` ON FIRST 3 OUTPUT Lhs.0 'def', Lhs.4 'input', Lhs.3 'next', Lhs.1 'sv', Lhs.2 'bb', Rhs.3 'i'
  36561398 ~0%     {6}    | JOIN WITH `SsaInternals::SsaImpl::SsaDefReaches::ssaDefReachesThroughBlock/2#08d74e18` ON FIRST 2 OUTPUT Lhs.0 'def', Lhs.3 'sv', Lhs.4 'bb', Lhs.5 'i', Lhs.2 'next', Lhs.1 'input'
  
  36831555 ~0%     {6} r5 = r3 UNION r4
  36831555 ~6%     {6}    | JOIN WITH `SsaInternals::SsaImpl::SsaDefReaches::lastSsaRefExt/4#5ae3cddd` ON FIRST 4 OUTPUT Lhs.0 'def', Lhs.1 'sv', Lhs.2 'bb', Lhs.3 'i', Lhs.5 'input', Lhs.4 'next'
  
  36845919 ~6%     {6} r6 = r1 UNION r5
                    return r6
```

Note: I'm targeting `rc/3.14` since the changes in https://github.com/github/codeql/pull/16677 are included there as well. Once this is merged I'll do a mergeback to `main`.