### PR TITLE
Java: Calculate 2nd level scopes for implicit instance accesses.

### DIFF
--- a/java/ql/lib/change-notes/2024-06-17-ffbl-implicit-this.md
+++ b/java/ql/lib/change-notes/2024-06-17-ffbl-implicit-this.md
@@ -1,0 +1,7 @@
+---
+category: minorAnalysis
+---
+* A bug has been fixed in the heuristic identification of uncertain control
+  flow, which is used to filter data flow in order to improve performance and
+  reduce false positives. This fix means that slightly more code is identified
+  and hence pruned from data flow.

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
@@ -8,6 +8,7 @@ private import ContainerFlow
 private import semmle.code.java.dataflow.FlowSteps
 private import semmle.code.java.dataflow.FlowSummary
 private import semmle.code.java.dataflow.ExternalFlow
+private import semmle.code.java.dataflow.InstanceAccess
 private import FlowSummaryImpl as FlowSummaryImpl
 private import DataFlowNodes
 private import codeql.dataflow.VariableCapture as VariableCapture
@@ -710,8 +711,14 @@ class DataFlowSecondLevelScope extends TDataFlowSecondLevelScope {
 }
 
 private Expr getRelatedExpr(Node n) {
-  n.asExpr() = result or
-  n.(PostUpdateNode).getPreUpdateNode().asExpr() = result
+  n.asExpr() = result
+  or
+  exists(InstanceAccessExt iae | iae = n.(ImplicitInstanceAccess).getInstanceAccess() |
+    iae.isImplicitFieldQualifier(result) or
+    iae.isImplicitMethodQualifier(result)
+  )
+  or
+  getRelatedExpr(n.(PostUpdateNode).getPreUpdateNode()) = result
 }
 
 /** Gets the second-level scope containing the node `n`, if any. */


### PR DESCRIPTION
This a bug fix, as we previously failed to recognize the second-level scopes of implicit instance accesses, e.g. implicit `this`.

The effect of this change should be that we prune more uncertain flow, and hopefully thereby improve performance and reduce FPs.

For a particular big project that I've tested locally, this reduced the number of stage 3 tuples by 16% from 164M to 137M.