### PR TITLE
C#/Java: Add some (shared) helper classes for Neutrals, Sources and Sink

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/ExternalFlow.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/ExternalFlow.qll
@@ -431,20 +431,6 @@ Declaration interpretElement(
   )
 }
 
-/**
- * A callable where there exists a MaD sink model that applies to it.
- */
-class SinkCallable extends Callable {
-  SinkCallable() { SourceSinkInterpretationInput::sinkElement(this, _, _, _, _) }
-}
-
-/**
- * A callable where there exists a MaD source model that applies to it.
- */
-class SourceCallable extends Callable {
-  SourceCallable() { SourceSinkInterpretationInput::sourceElement(this, _, _, _, _) }
-}
-
 cached
 private module Cached {
   /**
@@ -651,3 +637,33 @@ private class NeutralCallableAdapter extends NeutralCallable {
 
   override predicate hasProvenance(Provenance provenance) { provenance = provenance_ }
 }
+
+/**
+ * A callable where there exists a MaD sink model that applies to it.
+ */
+private class SinkModelCallableAdapter extends SinkModelCallable {
+  private Provenance provenance;
+
+  SinkModelCallableAdapter() {
+    SourceSinkInterpretationInput::sinkElement(this, _, _, provenance, _)
+  }
+
+  override predicate hasProvenance(Provenance p) { provenance = p }
+}
+
+final class SinkCallable = SinkModelCallable;
+
+/**
+ * A callable where there exists a MaD source model that applies to it.
+ */
+private class SourceModelCallableAdapter extends SourceModelCallable {
+  private Provenance provenance;
+
+  SourceModelCallableAdapter() {
+    SourceSinkInterpretationInput::sourceElement(this, _, _, provenance, _)
+  }
+
+  override predicate hasProvenance(Provenance p) { provenance = p }
+}
+
+final class SourceCallable = SourceModelCallable;

--- a/java/ql/lib/semmle/code/java/dataflow/ExternalFlow.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/ExternalFlow.qll
@@ -641,3 +641,33 @@ private class NeutralCallableAdapter extends NeutralCallable {
 
   override predicate hasExactModel() { exact = true }
 }
+
+/**
+ * A callable where there exists a MaD sink model that applies to it.
+ */
+private class SinkModelCallableAdapter extends SinkModelCallable {
+  private Provenance provenance;
+
+  SinkModelCallableAdapter() {
+    SourceSinkInterpretationInput::sinkElement(this, _, _, provenance, _)
+  }
+
+  override predicate hasProvenance(Provenance p) { provenance = p }
+}
+
+final class SinkCallable = SinkModelCallable;
+
+/**
+ * A callable where there exists a MaD source model that applies to it.
+ */
+private class SourceModelCallableAdapter extends SourceModelCallable {
+  private Provenance provenance;
+
+  SourceModelCallableAdapter() {
+    SourceSinkInterpretationInput::sourceElement(this, _, _, provenance, _)
+  }
+
+  override predicate hasProvenance(Provenance p) { provenance = p }
+}
+
+final class SourceCallable = SourceModelCallable;

--- a/java/ql/src/utils/modeleditor/FrameworkModeEndpointsQuery.qll
+++ b/java/ql/src/utils/modeleditor/FrameworkModeEndpointsQuery.qll
@@ -1,6 +1,6 @@
 private import java
+private import semmle.code.java.dataflow.ExternalFlow
 private import semmle.code.java.dataflow.internal.DataFlowPrivate
-private import semmle.code.java.dataflow.internal.FlowSummaryImpl
 private import semmle.code.java.dataflow.internal.ModelExclusions
 private import ModelEditor
 
@@ -8,7 +8,7 @@ private import ModelEditor
  * A class of effectively public callables from source code.
  */
 class PublicEndpointFromSource extends Endpoint, ModelApi {
-  override predicate isSource() { SourceSinkInterpretationInput::sourceElement(this, _, _, _, _) }
+  override predicate isSource() { this instanceof SourceCallable }
 
-  override predicate isSink() { SourceSinkInterpretationInput::sinkElement(this, _, _, _, _) }
+  override predicate isSink() { this instanceof SinkCallable }
 }

--- a/shared/dataflow/codeql/dataflow/internal/FlowSummaryImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/FlowSummaryImpl.qll
@@ -271,6 +271,20 @@ module Make<
     }
 
     /**
+     * A callable that has a neutral source model.
+     */
+    class NeutralSourceCallable extends NeutralCallableFinal {
+      NeutralSourceCallable() { this.getKind() = "source" }
+    }
+
+    /**
+     * A callable that has a neutral sink model.
+     */
+    class NeutralSinkCallable extends NeutralCallableFinal {
+      NeutralSinkCallable() { this.getKind() = "sink" }
+    }
+
+    /**
      * A callable that has a neutral model.
      */
     abstract class NeutralCallable extends SummarizedCallableBaseFinal {
@@ -1737,6 +1751,37 @@ module Make<
             sinkElementRef(ref, input, kind, model) and
             interpretInput(input, input.getNumToken(), ref, node)
           )
+        }
+
+        final private class SourceOrSinkElementFinal = SourceOrSinkElement;
+
+        bindingset[this]
+        private class SourceSinkModelCallableBase extends SourceOrSinkElementFinal {
+          /**
+           * Holds if there exists a manual model that applies to this.
+           */
+          final predicate hasManualModel() { any(Provenance p | this.hasProvenance(p)).isManual() }
+
+          /**
+           * Holds if this has provenance `p`.
+           */
+          abstract predicate hasProvenance(Provenance p);
+        }
+
+        /**
+         * A callable that has a source model.
+         */
+        abstract class SourceModelCallable extends SourceSinkModelCallableBase {
+          bindingset[this]
+          SourceModelCallable() { exists(this) }
+        }
+
+        /**
+         * A callable that has a sink model.
+         */
+        abstract class SinkModelCallable extends SourceSinkModelCallableBase {
+          bindingset[this]
+          SinkModelCallable() { exists(this) }
         }
 
         /** A source or sink relevant for testing. */

--- a/shared/dataflow/codeql/dataflow/internal/FlowSummaryImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/FlowSummaryImpl.qll
@@ -1756,7 +1756,7 @@ module Make<
         final private class SourceOrSinkElementFinal = SourceOrSinkElement;
 
         bindingset[this]
-        private class SourceSinkModelCallableBase extends SourceOrSinkElementFinal {
+        abstract private class SourceSinkModelCallableBase extends SourceOrSinkElementFinal {
           /**
            * Holds if there exists a manual model that applies to this.
            */


### PR DESCRIPTION
In this PR we add some shared classes for *neutrals*, *sources* and *sinks* and also add some adapters for Java and C# to populate the source and sink callable classes.
This PR is a pre-requisite for some model generator related work.