### PR TITLE
Go: a few small clean ups

### DIFF
--- a/go/ql/lib/semmle/go/Scopes.qll
+++ b/go/ql/lib/semmle/go/Scopes.qll
@@ -113,7 +113,9 @@ class Entity extends @object {
 
   /** Gets the qualified name of this entity, if any. */
   string getQualifiedName() {
-    exists(string pkg, string name | this.hasQualifiedName(pkg, name) | result = pkg + "." + name)
+    exists(string pkg, string name | this.hasQualifiedName(pkg, name) |
+      if pkg = "" then result = name else result = pkg + "." + name
+    )
   }
 
   /**

--- a/go/ql/lib/semmle/go/frameworks/BeegoOrm.qll
+++ b/go/ql/lib/semmle/go/frameworks/BeegoOrm.qll
@@ -18,11 +18,13 @@ module BeegoOrm {
     DbSink() {
       exists(Method m, string methodName, int argNum |
         m.hasQualifiedName(packagePath(), "DB", methodName) and
-        methodName in [
-            "Exec", "ExecContext", "Prepare", "PrepareContext", "Query", "QueryContext", "QueryRow",
-            "QueryRowContext"
-          ] and
-        if methodName.matches("%Context") then argNum = 1 else argNum = 0
+        (
+          methodName = ["Exec", "Prepare", "Query", "QueryRow"] and
+          argNum = 0
+          or
+          methodName = ["ExecContext", "PrepareContext", "QueryContext", "QueryRowContext"] and
+          argNum = 1
+        )
       |
         this = m.getACall().getArgument(argNum)
       )

--- a/go/ql/lib/semmle/go/frameworks/Logrus.qll
+++ b/go/ql/lib/semmle/go/frameworks/Logrus.qll
@@ -15,7 +15,9 @@ module Logrus {
   }
 
   bindingset[result]
-  private string getAnEntryUpdatingMethodName() { result.regexpMatch("With(Error|Fields?|Time)") }
+  private string getAnEntryUpdatingMethodName() {
+    result = ["WithError", "WithField", "WithFields", "WithTime"]
+  }
 
   private class LogFunction extends Function {
     LogFunction() {

--- a/go/ql/lib/semmle/go/frameworks/stdlib/Fmt.qll
+++ b/go/ql/lib/semmle/go/frameworks/stdlib/Fmt.qll
@@ -13,7 +13,10 @@ module Fmt {
    * The `Sprint` or `Append` functions or one of their variants.
    */
   deprecated class AppenderOrSprinter extends TaintTracking::FunctionModel {
-    AppenderOrSprinter() { this.hasQualifiedName("fmt", ["Append", "Sprint"] + ["", "f", "ln"]) }
+    AppenderOrSprinter() {
+      this.hasQualifiedName("fmt",
+        ["Append", "Appendf", "Appendln", "Sprint", "Sprintf", "Sprintln"])
+    }
 
     override predicate hasTaintFlow(FunctionInput inp, FunctionOutput outp) {
       inp.isParameter(_) and outp.isResult()
@@ -23,13 +26,14 @@ module Fmt {
   /** The `Sprint` or `Append` functions or one of their variants. */
   class AppenderOrSprinterFunc extends Function {
     AppenderOrSprinterFunc() {
-      this.hasQualifiedName("fmt", ["Append", "Sprint"] + ["", "f", "ln"])
+      this.hasQualifiedName("fmt",
+        ["Append", "Appendf", "Appendln", "Sprint", "Sprintf", "Sprintln"])
     }
   }
 
   /** The `Sprint` function or one of its variants. */
   class Sprinter extends AppenderOrSprinterFunc {
-    Sprinter() { this.getName().matches("Sprint%") }
+    Sprinter() { this.getName() = ["Sprint", "Sprintf", "Sprintln"] }
   }
 
   /** The `Print` function or one of its variants. */

--- a/go/ql/lib/semmle/go/frameworks/stdlib/Fmt.qll
+++ b/go/ql/lib/semmle/go/frameworks/stdlib/Fmt.qll
@@ -8,9 +8,9 @@ import go
 /** Provides models of commonly used functions in the `fmt` package. */
 module Fmt {
   /**
-   * The `Sprint` or `Append` functions or one of their variants.
-   *
    * DEPRECATED: Use AppenderOrSprinterFunc instead.
+   *
+   * The `Sprint` or `Append` functions or one of their variants.
    */
   deprecated class AppenderOrSprinter extends TaintTracking::FunctionModel {
     AppenderOrSprinter() { this.hasQualifiedName("fmt", ["Append", "Sprint"] + ["", "f", "ln"]) }

--- a/go/ql/lib/semmle/go/frameworks/stdlib/HtmlTemplate.qll
+++ b/go/ql/lib/semmle/go/frameworks/stdlib/HtmlTemplate.qll
@@ -11,11 +11,11 @@ module HtmlTemplate {
 
     TemplateEscape() {
       exists(string fn |
-        fn.matches("HTMLEscape%") and kind = "html"
+        fn = ["HTMLEscape", "HTMLEscapeString", "HTMLEscaper"] and kind = "html"
         or
-        fn.matches("JSEscape%") and kind = "js"
+        fn = ["JSEscape", "JSEscapeString", "JSEscaper"] and kind = "js"
         or
-        fn.matches("URLQueryEscape%") and kind = "url"
+        fn = "URLQueryEscaper" and kind = "url"
       |
         this.hasQualifiedName("html/template", fn)
       )

--- a/go/ql/lib/semmle/go/frameworks/stdlib/Log.qll
+++ b/go/ql/lib/semmle/go/frameworks/stdlib/Log.qll
@@ -11,7 +11,9 @@ module Log {
 
     LogFunction() {
       exists(string fn |
-        fn.matches(["Fatal%", "Panic%", "Print%"]) and firstPrintedArg = 0
+        fn =
+          ["Fatal", "Fatalf", "Fatalln", "Panic", "Panicf", "Panicln", "Print", "Printf", "Println"] and
+        firstPrintedArg = 0
         or
         fn = "Output" and firstPrintedArg = 1
       |
@@ -25,7 +27,7 @@ module Log {
   }
 
   private class LogFormatter extends StringOps::Formatting::Range instanceof LogFunction {
-    LogFormatter() { this.getName().matches("%f") }
+    LogFormatter() { this.getName() = ["Fatalf", "Panicf", "Printf"] }
 
     override int getFormatStringIndex() { result = 0 }
   }
@@ -42,9 +44,7 @@ module Log {
 
   /** A fatal log function, which calls `os.Exit`. */
   private class FatalLogFunction extends Function {
-    FatalLogFunction() {
-      exists(string fn | fn.matches("Fatal%") | this.hasQualifiedName("log", fn))
-    }
+    FatalLogFunction() { this.hasQualifiedName("log", ["Fatal", "Fatalf", "Fatalln"]) }
 
     override predicate mayReturnNormally() { none() }
   }


### PR DESCRIPTION
The first commits just formats a comment correctly.

The second commit writes out some function names in full rather than trying to uses string matching or string concatenation to save space. You can search the repo for "Fprintf" and find references to it easily.

The third commit fixes `getQualifiedName` for built-in functions so it gives `panic` instead of `.panic`. It's only very recently that `hasQualifiedName`, and hence `getQualifiedName`, have been defined for built-in functions, so this is a small clean up to make sure that the output is correct.

