### PR TITLE
Java: Opt-in `java/tainted-permissions-check` to threat models.

### DIFF
--- a/java/ql/lib/semmle/code/java/security/TaintedPermissionsCheckQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/TaintedPermissionsCheckQuery.qll
@@ -54,7 +54,7 @@ private class WildCardPermissionConstruction extends ClassInstanceExpr, Permissi
  * A configuration for tracking flow from user input to a permissions check.
  */
 module TaintedPermissionsCheckFlowConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof UserInput }
+  predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) {
     sink.asExpr() = any(PermissionsConstruction p).getInput()

--- a/java/ql/src/change-notes/2024-06-17-tainted-permissions-check.md
+++ b/java/ql/src/change-notes/2024-06-17-tainted-permissions-check.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* Enable threat models for the query `java/tainted-permissions-check`. This means that `local` sources are no longer included by default for this query, but can be added by enabling the `local` threat model.
+* The query `java/tainted-permissions-check` now uses threat models. This means that `local` sources are no longer included by default for this query, but can be added by enabling the `local` threat model.

--- a/java/ql/src/change-notes/2024-06-17-tainted-permissions-check.md
+++ b/java/ql/src/change-notes/2024-06-17-tainted-permissions-check.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Enable threat models for the query `java/tainted-permissions-check`. This means that `local` sources are no longer included by default for this query, but can be added by enabling the `local` threat model.


### PR DESCRIPTION
In this PR we opt-in the `java/tainted-permissions-check` to threat models.

Prior to this change, the query used both `remote` and `local` sources as input. Now the default is to use only `remote` sources (as this the threat models default). However, it is possible to enable `local` (or other) sources by enabling the relevant threat model.

Using MRVA on java top-100 for this query we get
- 1 result for remote flow sources.
- 3 results for remote + local flow sources.

DCA looks good; There are no changes to performance or alerts.

It seems that this query doesn't produce an overwhelming number of results in general.