### PR TITLE
2.17.4 Changelog patch

### DIFF
--- a/docs/codeql/codeql-overview/codeql-changelog/codeql-cli-2.17.4.rst
+++ b/docs/codeql/codeql-overview/codeql-changelog/codeql-cli-2.17.4.rst
@@ -19,7 +19,10 @@ CodeQL 2.17.4 runs a total of 414 security queries when configured with the Defa
 CodeQL CLI
 ----------
 
-There are no user-facing CLI changes in this release.
+New Features
+~~~~~~~~~~~~
+
+*   CodeQL package management is now generally available, and all GitHub-produced CodeQL packages have had their version numbers increased to 1.0.0.
 
 Query Packs
 -----------


### PR DESCRIPTION
Quick manual patch for the changelog of 2.17.4. 

Changes made on `semmle-code` : https://github.com/github/semmle-code/pull/50347 and 
`codeql-cli-binaries`: https://github.com/github/codeql-cli-binaries/pull/177 to make sure these changes properly show up when generating the change logs for the next release. 