### PR TITLE
Dataflow: Replace stage 3 type pruning with flow-insensitive type pruning.

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
@@ -216,7 +216,7 @@ predicate localMustFlowStep(Node node1, Node node2) { none() }
 
 /** Gets the type of `n` used for type pruning. */
 Type getNodeType(Node n) {
-  suppressUnusedNode(n) and
+  exists(n) and
   result instanceof VoidType // stub implementation
 }
 
@@ -227,12 +227,9 @@ string ppReprType(Type t) { none() } // stub implementation
  * Holds if `t1` and `t2` are compatible, that is, whether data can flow from
  * a node of type `t1` to a node of type `t2`.
  */
-pragma[inline]
 predicate compatibleTypes(Type t1, Type t2) {
-  any() // stub implementation
+  t1 instanceof VoidType and t2 instanceof VoidType // stub implementation
 }
-
-private predicate suppressUnusedNode(Node n) { any() }
 
 //////////////////////////////////////////////////////////////////////////////
 // Java QL library compatibility wrappers

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -988,7 +988,7 @@ predicate localMustFlowStep(Node node1, Node node2) { none() }
 
 /** Gets the type of `n` used for type pruning. */
 DataFlowType getNodeType(Node n) {
-  suppressUnusedNode(n) and
+  exists(n) and
   result instanceof VoidType // stub implementation
 }
 
@@ -999,12 +999,9 @@ string ppReprType(DataFlowType t) { none() } // stub implementation
  * Holds if `t1` and `t2` are compatible, that is, whether data can flow from
  * a node of type `t1` to a node of type `t2`.
  */
-pragma[inline]
 predicate compatibleTypes(DataFlowType t1, DataFlowType t2) {
-  any() // stub implementation
+  t1 instanceof VoidType and t2 instanceof VoidType // stub implementation
 }
-
-private predicate suppressUnusedNode(Node n) { any() }
 
 //////////////////////////////////////////////////////////////////////////////
 // Java QL library compatibility wrappers

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -2522,15 +2522,11 @@ predicate compatibleTypes(DataFlowType dt1, DataFlowType dt2) {
     t1.(DataFlowNullType).isConvertibleTo(t2)
     or
     t2.(DataFlowNullType).isConvertibleTo(t1)
-    or
-    t1 instanceof Gvn::TypeParameterGvnType
-    or
-    t2 instanceof Gvn::TypeParameterGvnType
-    or
-    t1 instanceof GvnUnknownType
-    or
-    t2 instanceof GvnUnknownType
   )
+  or
+  exists(dt1.asGvnType()) and uselessTypebound(dt2)
+  or
+  uselessTypebound(dt1) and exists(dt2.asGvnType())
   or
   compatibleTypesDelegateLeft(dt1, dt2)
   or

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -2483,7 +2483,7 @@ private predicate uselessTypebound(DataFlowType dt) {
     )
 }
 
-pragma[inline]
+pragma[nomagic]
 private predicate compatibleTypesDelegateLeft(DataFlowType dt1, DataFlowType dt2) {
   exists(Gvn::GvnType t1, Gvn::GvnType t2 |
     t1 = exprNode(dt1.getADelegateCreation()).(NodeImpl).getDataFlowType().asGvnType() and
@@ -2507,7 +2507,7 @@ private predicate compatibleTypesDelegateLeft(DataFlowType dt1, DataFlowType dt2
  * Holds if `t1` and `t2` are compatible, that is, whether data can flow from
  * a node of type `t1` to a node of type `t2`.
  */
-pragma[inline]
+pragma[nomagic]
 predicate compatibleTypes(DataFlowType dt1, DataFlowType dt2) {
   exists(Gvn::GvnType t1, Gvn::GvnType t2 |
     t1 = dt1.asGvnType() and

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowPrivate.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowPrivate.qll
@@ -222,9 +222,8 @@ string ppReprType(DataFlowType t) { none() }
  * Holds if `t1` and `t2` are compatible, that is, whether data can flow from
  * a node of type `t1` to a node of type `t2`.
  */
-pragma[inline]
 predicate compatibleTypes(DataFlowType t1, DataFlowType t2) {
-  any() // stub implementation
+  t1 = TTodoDataFlowType() and t2 = TTodoDataFlowType() // stub implementation
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
@@ -371,18 +371,12 @@ string ppReprType(DataFlowType t) {
   else result = t.toString()
 }
 
-pragma[nomagic]
-private predicate compatibleTypes0(DataFlowType t1, DataFlowType t2) {
-  erasedHaveIntersection(t1, t2)
-}
-
 /**
  * Holds if `t1` and `t2` are compatible, that is, whether data can flow from
  * a node of type `t1` to a node of type `t2`.
  */
-bindingset[t1, t2]
-pragma[inline_late]
-predicate compatibleTypes(DataFlowType t1, DataFlowType t2) { compatibleTypes0(t1, t2) }
+pragma[nomagic]
+predicate compatibleTypes(DataFlowType t1, DataFlowType t2) { erasedHaveIntersection(t1, t2) }
 
 /** A node that performs a type cast. */
 class CastNode extends ExprNode {

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -564,7 +564,6 @@ predicate neverSkipInPathGraph(Node n) {
  * Holds if `t1` and `t2` are compatible, that is, whether data can flow from
  * a node of type `t1` to a node of type `t2`.
  */
-pragma[inline]
 predicate compatibleTypes(DataFlowType t1, DataFlowType t2) { any() }
 
 predicate typeStrongerThan(DataFlowType t1, DataFlowType t2) { none() }
@@ -576,8 +575,7 @@ predicate localMustFlowStep(Node nodeFrom, Node nodeTo) { none() }
  */
 DataFlowType getNodeType(Node node) {
   result = TAnyFlow() and
-  // Suppress unused variable warning
-  node = node
+  exists(node)
 }
 
 /** Gets a string representation of a type returned by `getErasedRepr`. */

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -2087,7 +2087,6 @@ private predicate compatibleTypesNonSymRefl(DataFlowType t1, DataFlowType t2) {
  * Holds if `t1` and `t2` are compatible, that is, whether data can flow from
  * a node of type `t1` to a node of type `t2`.
  */
-pragma[inline]
 predicate compatibleTypes(DataFlowType t1, DataFlowType t2) {
   t1 = t2
   or

--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -142,7 +142,6 @@ signature module InputSig<LocationSig Location> {
    * steps, then it will check that the types of `n1` and `n2` are compatible.
    * If they are not, then flow will be blocked.
    */
-  bindingset[t1, t2]
   predicate compatibleTypes(DataFlowType t1, DataFlowType t2);
 
   /**

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -2928,7 +2928,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         // the cons candidates including types are used to construct subsequent
         // access path approximations.
         t0 = t and
-        (if castingNodeEx(node) then compatibleTypes(node.getDataFlowType(), t0) else any()) and
+        (if castingNodeEx(node) then compatibleTypesFilter(node.getDataFlowType(), t0) else any()) and
         (
           notExpectsContent(node)
           or
@@ -2940,7 +2940,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       predicate typecheckStore(Typ typ, DataFlowType contentType) {
         // We need to typecheck stores here, since reverse flow through a getter
         // might have a different type here compared to inside the getter.
-        compatibleTypes(typ, contentType)
+        compatibleTypesFilter(typ, contentType)
       }
     }
 
@@ -2951,7 +2951,11 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       if castingNodeEx(node)
       then
         exists(DataFlowType nt | nt = node.getDataFlowType() |
-          if typeStrongerThanFilter(nt, t0) then t = nt else (compatibleTypes(nt, t0) and t = t0)
+          if typeStrongerThanFilter(nt, t0)
+          then t = nt
+          else (
+            compatibleTypesFilter(nt, t0) and t = t0
+          )
         )
       else t = t0
     }
@@ -3050,7 +3054,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       predicate typecheckStore(Typ typ, DataFlowType contentType) {
         // We need to typecheck stores here, since reverse flow through a getter
         // might have a different type here compared to inside the getter.
-        compatibleTypes(typ, contentType)
+        compatibleTypesFilter(typ, contentType)
       }
     }
 
@@ -3306,7 +3310,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
       bindingset[typ, contentType]
       predicate typecheckStore(Typ typ, DataFlowType contentType) {
-        compatibleTypes(typ, contentType)
+        compatibleTypesFilter(typ, contentType)
       }
     }
 
@@ -4246,7 +4250,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         Stage5::storeStepCand(mid.getNodeExOutgoing(), _, c, node, contentType, t) and
         state = mid.getState() and
         cc = mid.getCallContext() and
-        compatibleTypes(t0, contentType)
+        compatibleTypesFilter(t0, contentType)
       )
     }
 
@@ -5296,7 +5300,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           storeExUnrestricted(midNode, c, node, contentType, t2) and
           ap2.getHead() = c and
           ap2.len() = unbindInt(ap1.len() + 1) and
-          compatibleTypes(t1, contentType)
+          compatibleTypesFilter(t1, contentType)
         )
       }
 

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -2951,7 +2951,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       if castingNodeEx(node)
       then
         exists(DataFlowType nt | nt = node.getDataFlowType() |
-          if typeStrongerThan(nt, t0) then t = nt else (compatibleTypes(nt, t0) and t = t0)
+          if typeStrongerThanFilter(nt, t0) then t = nt else (compatibleTypes(nt, t0) and t = t0)
         )
       else t = t0
     }

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -2853,7 +2853,9 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
     private import LocalFlowBigStep
 
     pragma[nomagic]
-    private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
+    private predicate castingNodeEx(NodeEx node) {
+      node.asNode() instanceof CastingNode or exists(node.asParamReturnNode())
+    }
 
     private module Stage3Param implements MkStage<Stage2>::StageParam {
       private module PrevStage = Stage2;

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -1448,7 +1448,17 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         private predicate compatibleContainer0(ApHeadContent apc, DataFlowType containerType) {
           exists(DataFlowType containerType0, Content c |
             PrevStage::storeStepCand(_, _, c, _, _, containerType0) and
+            not isTopType(containerType0) and
             compatibleTypesCached(containerType0, containerType) and
+            apc = projectToHeadContent(c)
+          )
+        }
+
+        pragma[nomagic]
+        private predicate topTypeContent(ApHeadContent apc) {
+          exists(DataFlowType containerType0, Content c |
+            PrevStage::storeStepCand(_, _, c, _, _, containerType0) and
+            isTopType(containerType0) and
             apc = projectToHeadContent(c)
           )
         }
@@ -1484,7 +1494,9 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           (
             if castingNodeEx(node)
             then
-              ap instanceof ApNil or compatibleContainer(getHeadContent(ap), node.getDataFlowType())
+              ap instanceof ApNil or
+              compatibleContainer(getHeadContent(ap), node.getDataFlowType()) or
+              topTypeContent(getHeadContent(ap))
             else any()
           )
         }

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
@@ -889,6 +889,14 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     cached
     predicate compatibleTypesCached(DataFlowType t1, DataFlowType t2) { compatibleTypes(t1, t2) }
 
+    private predicate relevantType(DataFlowType t) { t = getNodeType(_) }
+
+    cached
+    predicate isTopType(DataFlowType t) {
+      strictcount(DataFlowType t0 | relevantType(t0)) =
+        strictcount(DataFlowType t0 | relevantType(t0) and compatibleTypesCached(t, t0))
+    }
+
     cached
     predicate typeStrongerThanCached(DataFlowType t1, DataFlowType t2) { typeStrongerThan(t1, t2) }
 

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
@@ -288,7 +288,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
       revLambdaFlow0(lambdaCall, kind, node, t, toReturn, toJump, lastCall) and
       not expectsContent(node, _) and
       if castNode(node) or node instanceof ArgNode or node instanceof ReturnNode
-      then compatibleTypes(t, getNodeDataFlowType(node))
+      then compatibleTypesFilter(t, getNodeDataFlowType(node))
       else any()
     }
 
@@ -887,6 +887,9 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     predicate nodeDataFlowType(Node n, DataFlowType t) { t = getNodeType(n) }
 
     cached
+    predicate compatibleTypesCached(DataFlowType t1, DataFlowType t2) { compatibleTypes(t1, t2) }
+
+    cached
     predicate typeStrongerThanCached(DataFlowType t1, DataFlowType t2) { typeStrongerThan(t1, t2) }
 
     cached
@@ -1121,7 +1124,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
       exists(ParameterPosition ppos |
         viableParam(call, ppos, p) and
         argumentPositionMatch(call, arg, ppos) and
-        compatibleTypes(getNodeDataFlowType(arg), getNodeDataFlowType(p)) and
+        compatibleTypesFilter(getNodeDataFlowType(arg), getNodeDataFlowType(p)) and
         golangSpecificParamArgFilter(call, p, arg)
       )
     }
@@ -1274,10 +1277,10 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
           then
             // normal flow through
             read = TReadStepTypesNone() and
-            compatibleTypes(getNodeDataFlowType(p), getNodeDataFlowType(node))
+            compatibleTypesFilter(getNodeDataFlowType(p), getNodeDataFlowType(node))
             or
             // getter
-            compatibleTypes(read.getContentType(), getNodeDataFlowType(node))
+            compatibleTypesFilter(read.getContentType(), getNodeDataFlowType(node))
           else any()
         }
 
@@ -1310,7 +1313,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
             readStepWithTypes(mid, read.getContainerType(), read.getContent(), node,
               read.getContentType()) and
             Cand::parameterValueFlowReturnCand(p, _, true) and
-            compatibleTypes(getNodeDataFlowType(p), read.getContainerType())
+            compatibleTypesFilter(getNodeDataFlowType(p), read.getContainerType())
           )
           or
           parameterValueFlow0_0(TReadStepTypesNone(), p, node, read, model)
@@ -1371,11 +1374,11 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
           |
             // normal flow through
             read = TReadStepTypesNone() and
-            compatibleTypes(getNodeDataFlowType(arg), getNodeDataFlowType(out))
+            compatibleTypesFilter(getNodeDataFlowType(arg), getNodeDataFlowType(out))
             or
             // getter
-            compatibleTypes(getNodeDataFlowType(arg), read.getContainerType()) and
-            compatibleTypes(read.getContentType(), getNodeDataFlowType(out))
+            compatibleTypesFilter(getNodeDataFlowType(arg), read.getContainerType()) and
+            compatibleTypesFilter(read.getContentType(), getNodeDataFlowType(out))
           )
         }
 
@@ -1625,6 +1628,12 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
 
   bindingset[t1, t2]
   pragma[inline_late]
+  predicate compatibleTypesFilter(DataFlowType t1, DataFlowType t2) {
+    compatibleTypesCached(t1, t2)
+  }
+
+  bindingset[t1, t2]
+  pragma[inline_late]
   predicate typeStrongerThanFilter(DataFlowType t1, DataFlowType t2) {
     typeStrongerThanCached(t1, t2)
   }
@@ -1833,7 +1842,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
       if typeStrongerThanCached(t2, t1)
       then result = t2
       else (
-        compatibleTypes(t1, t2) and result = t1
+        compatibleTypesFilter(t1, t2) and result = t1
       )
     }
 
@@ -1955,7 +1964,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
       exists(DataFlowType t1, DataFlowType t2 |
         typeFlowArgType(arg, t1, cc) and
         relevantArgParamIn(arg, p, t2) and
-        compatibleTypes(t1, t2)
+        compatibleTypesFilter(t1, t2)
       )
     }
 
@@ -1999,7 +2008,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
       exists(DataFlowType t1, DataFlowType t2 |
         typeFlowParamType(p, t1, false) and
         relevantArgParamOut(arg, p, t2) and
-        compatibleTypes(t1, t2)
+        compatibleTypesFilter(t1, t2)
       )
     }
 

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
@@ -1310,7 +1310,6 @@ string ppReprType(DataFlowType t) { none() }
  * Holds if `t1` and `t2` are compatible, that is, whether data can flow from
  * a node of type `t1` to a node of type `t2`.
  */
-pragma[inline]
 predicate compatibleTypes(DataFlowType t1, DataFlowType t2) { any() }
 
 abstract class PostUpdateNodeImpl extends Node {


### PR DESCRIPTION
It appears that most of the benefit from type pruning in stage 3 is closely correlated to the `Content` that's tracked in the access path. This means that we can drop flow-sensitive type pruning, which removes the risk for type-based fanout and consequent performance problems, by replacing it with a flow-insensitive type pruning that merely compares the tracked `Content` and the type of the current node with the possible container types given by the set of store steps.

So far this PR only changes stage 3. How this can impact subsequent changes still needs to be investigated. But this change alone appears to benefit performance - in particular on large databases.