### PR TITLE
JavaScript: Fix CodeQL alert in extractor

### DIFF
--- a/javascript/extractor/src/com/semmle/jcorn/Identifiers.java
+++ b/javascript/extractor/src/com/semmle/jcorn/Identifiers.java
@@ -115,7 +115,7 @@ public class Identifiers {
   // rare.
   private static boolean isInAstralSet(int code, int[] set) {
     int pos = 0x10000;
-    for (int i = 0; i < set.length; i += 2) {
+    for (int i = 0; i < set.length - 1; i += 2) {
       pos += set[i];
       if (pos > code) return false;
       pos += set[i + 1];


### PR DESCRIPTION
This doesn't make a difference in practice because we only run the method on arrays of even length, but we might as well fix it.