### PR TITLE
Ruby: Rework `Sinatra.FilterJumpStep`

### DIFF
--- a/ruby/ql/lib/codeql/ruby/frameworks/Sinatra.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/Sinatra.qll
@@ -279,19 +279,23 @@ module Sinatra {
         filter.getApp() = route.getApp() and
         // the filter applies to all routes
         not filter.hasPattern() and
-        blockPostUpdate(pred, filter.getBody()) and
-        blockSelfParameterNode(succ, route.getBody().asExpr().getExpr())
+        blockPostSelf(pred, filter.getBody()) and
+        blockSelf(succ, route.getBody().asExpr().getExpr())
       )
     }
   }
 
-  /** Holds if `n` is a post-update node for the block `b`. */
-  private predicate blockPostUpdate(DataFlow::PostUpdateNode n, DataFlow::BlockNode b) {
-    n.getPreUpdateNode() = b
+  /** Holds if `n` is a post-update node referencing `self` in the block `b`. */
+  private predicate blockPostSelf(DataFlow::PostUpdateNode n, DataFlow::BlockNode b) {
+    exists(SelfVariableAccessCfgNode self |
+      n.getPreUpdateNode().asExpr() = self and
+      self.getScope() = b.asExpr().getAstNode()
+    )
   }
 
-  /** Holds if `n` is a `self` parameter belonging to block `b`. */
-  private predicate blockSelfParameterNode(DataFlowPrivate::LambdaSelfReferenceNode n, Block b) {
-    n.getCallable() = b
+  /** Holds if `n` is a node referencing `self` in the block `b`. */
+  private predicate blockSelf(DataFlow::VariableAccessNode self, Block b) {
+    self.getExprNode().getBasicBlock().getScope() = b and
+    self.asVariableAccessAstNode().getVariable() instanceof SelfVariable
   }
 }

--- a/ruby/ql/test/library-tests/frameworks/sinatra/Flow.expected
+++ b/ruby/ql/test/library-tests/frameworks/sinatra/Flow.expected
@@ -8,9 +8,7 @@ edges
 | app.rb:76:32:76:35 | @foo | app.rb:76:25:76:36 | call to [] [element :foo] | provenance |  |
 | app.rb:76:32:76:35 | self [@foo] | app.rb:76:32:76:35 | @foo | provenance |  |
 | app.rb:95:10:95:14 | self [@user] | app.rb:95:10:95:14 | @user | provenance |  |
-| app.rb:102:10:104:5 | [post] do ... end [captured self, @user] | app.rb:95:10:95:14 | self [@user] | provenance |  |
-| app.rb:103:5:103:9 | [post] self [@user] | app.rb:102:10:104:5 | [post] do ... end [captured self, @user] | provenance |  |
-| app.rb:103:5:103:9 | [post] self [@user] | app.rb:102:10:104:5 | [post] do ... end [captured self, @user] | provenance | heuristic-callback |
+| app.rb:103:5:103:9 | [post] self [@user] | app.rb:95:10:95:14 | self [@user] | provenance |  |
 | app.rb:103:13:103:22 | call to source | app.rb:103:5:103:9 | [post] self [@user] | provenance |  |
 nodes
 | app.rb:75:5:75:8 | [post] self [@foo] | semmle.label | [post] self [@foo] |
@@ -21,7 +19,6 @@ nodes
 | app.rb:76:32:76:35 | self [@foo] | semmle.label | self [@foo] |
 | app.rb:95:10:95:14 | @user | semmle.label | @user |
 | app.rb:95:10:95:14 | self [@user] | semmle.label | self [@user] |
-| app.rb:102:10:104:5 | [post] do ... end [captured self, @user] | semmle.label | [post] do ... end [captured self, @user] |
 | app.rb:103:5:103:9 | [post] self [@user] | semmle.label | [post] self [@user] |
 | app.rb:103:13:103:22 | call to source | semmle.label | call to source |
 | views/index.erb:2:10:2:12 | call to foo | semmle.label | call to foo |

--- a/ruby/ql/test/library-tests/frameworks/sinatra/Flow.expected
+++ b/ruby/ql/test/library-tests/frameworks/sinatra/Flow.expected
@@ -7,6 +7,11 @@ edges
 | app.rb:76:25:76:36 | call to [] [element :foo] | views/index.erb:2:10:2:12 | call to foo | provenance |  |
 | app.rb:76:32:76:35 | @foo | app.rb:76:25:76:36 | call to [] [element :foo] | provenance |  |
 | app.rb:76:32:76:35 | self [@foo] | app.rb:76:32:76:35 | @foo | provenance |  |
+| app.rb:95:10:95:14 | self [@user] | app.rb:95:10:95:14 | @user | provenance |  |
+| app.rb:102:10:104:5 | [post] do ... end [captured self, @user] | app.rb:95:10:95:14 | self [@user] | provenance |  |
+| app.rb:103:5:103:9 | [post] self [@user] | app.rb:102:10:104:5 | [post] do ... end [captured self, @user] | provenance |  |
+| app.rb:103:5:103:9 | [post] self [@user] | app.rb:102:10:104:5 | [post] do ... end [captured self, @user] | provenance | heuristic-callback |
+| app.rb:103:13:103:22 | call to source | app.rb:103:5:103:9 | [post] self [@user] | provenance |  |
 nodes
 | app.rb:75:5:75:8 | [post] self [@foo] | semmle.label | [post] self [@foo] |
 | app.rb:75:12:75:17 | call to params | semmle.label | call to params |
@@ -14,7 +19,13 @@ nodes
 | app.rb:76:25:76:36 | call to [] [element :foo] | semmle.label | call to [] [element :foo] |
 | app.rb:76:32:76:35 | @foo | semmle.label | @foo |
 | app.rb:76:32:76:35 | self [@foo] | semmle.label | self [@foo] |
+| app.rb:95:10:95:14 | @user | semmle.label | @user |
+| app.rb:95:10:95:14 | self [@user] | semmle.label | self [@user] |
+| app.rb:102:10:104:5 | [post] do ... end [captured self, @user] | semmle.label | [post] do ... end [captured self, @user] |
+| app.rb:103:5:103:9 | [post] self [@user] | semmle.label | [post] self [@user] |
+| app.rb:103:13:103:22 | call to source | semmle.label | call to source |
 | views/index.erb:2:10:2:12 | call to foo | semmle.label | call to foo |
 subpaths
 #select
+| app.rb:95:10:95:14 | @user | app.rb:103:13:103:22 | call to source | app.rb:95:10:95:14 | @user | $@ | app.rb:103:13:103:22 | call to source | call to source |
 | views/index.erb:2:10:2:12 | call to foo | app.rb:75:12:75:17 | call to params | views/index.erb:2:10:2:12 | call to foo | $@ | app.rb:75:12:75:17 | call to params | call to params |

--- a/ruby/ql/test/library-tests/frameworks/sinatra/Flow.ql
+++ b/ruby/ql/test/library-tests/frameworks/sinatra/Flow.ql
@@ -4,7 +4,7 @@
 
 import ruby
 import TestUtilities.InlineFlowTest
-import TaintFlow::PathGraph
+import PathGraph
 import codeql.ruby.frameworks.Sinatra
 import codeql.ruby.Concepts
 
@@ -18,6 +18,6 @@ module SinatraConfig implements DataFlow::ConfigSig {
 
 import FlowTest<DefaultFlowConfig, SinatraConfig>
 
-from TaintFlow::PathNode source, TaintFlow::PathNode sink
-where TaintFlow::flowPath(source, sink)
+from PathNode source, PathNode sink
+where flowPath(source, sink)
 select sink, source, sink, "$@", source, source.toString()

--- a/ruby/ql/test/library-tests/frameworks/sinatra/Sinatra.expected
+++ b/ruby/ql/test/library-tests/frameworks/sinatra/Sinatra.expected
@@ -43,43 +43,75 @@ filterPatterns
 | app.rb:106:3:108:5 | call to before | app.rb:106:10:106:23 | "/protected/*" |
 | app.rb:111:3:113:5 | call to after | app.rb:111:9:111:23 | "/create/:slug" |
 additionalFlowSteps
-| app.rb:84:10:87:5 | [post] do ... end | app.rb:2:22:4:5 | lambda self in do ... end |
-| app.rb:84:10:87:5 | [post] do ... end | app.rb:6:24:8:5 | lambda self in do ... end |
-| app.rb:84:10:87:5 | [post] do ... end | app.rb:10:21:13:5 | lambda self in do ... end |
-| app.rb:84:10:87:5 | [post] do ... end | app.rb:15:23:18:5 | lambda self in do ... end |
-| app.rb:84:10:87:5 | [post] do ... end | app.rb:20:23:22:5 | lambda self in do ... end |
-| app.rb:84:10:87:5 | [post] do ... end | app.rb:24:26:26:5 | lambda self in do ... end |
-| app.rb:84:10:87:5 | [post] do ... end | app.rb:28:26:31:5 | lambda self in do ... end |
-| app.rb:84:10:87:5 | [post] do ... end | app.rb:33:25:35:5 | lambda self in do ... end |
-| app.rb:84:10:87:5 | [post] do ... end | app.rb:37:16:42:5 | lambda self in do ... end |
-| app.rb:84:10:87:5 | [post] do ... end | app.rb:44:53:46:5 | lambda self in do ... end |
-| app.rb:84:10:87:5 | [post] do ... end | app.rb:48:14:50:5 | lambda self in do ... end |
-| app.rb:84:10:87:5 | [post] do ... end | app.rb:52:37:54:5 | lambda self in do ... end |
-| app.rb:84:10:87:5 | [post] do ... end | app.rb:56:32:58:5 | lambda self in do ... end |
-| app.rb:84:10:87:5 | [post] do ... end | app.rb:60:48:62:5 | lambda self in do ... end |
-| app.rb:84:10:87:5 | [post] do ... end | app.rb:66:41:68:5 | lambda self in do ... end |
-| app.rb:84:10:87:5 | [post] do ... end | app.rb:70:20:72:5 | lambda self in do ... end |
-| app.rb:84:10:87:5 | [post] do ... end | app.rb:74:11:77:5 | lambda self in do ... end |
-| app.rb:84:10:87:5 | [post] do ... end | app.rb:79:11:82:5 | lambda self in do ... end |
-| app.rb:84:10:87:5 | [post] do ... end | app.rb:89:16:92:5 | lambda self in do ... end |
-| app.rb:84:10:87:5 | [post] do ... end | app.rb:94:15:96:5 | lambda self in do ... end |
-| app.rb:102:10:104:5 | [post] do ... end | app.rb:2:22:4:5 | lambda self in do ... end |
-| app.rb:102:10:104:5 | [post] do ... end | app.rb:6:24:8:5 | lambda self in do ... end |
-| app.rb:102:10:104:5 | [post] do ... end | app.rb:10:21:13:5 | lambda self in do ... end |
-| app.rb:102:10:104:5 | [post] do ... end | app.rb:15:23:18:5 | lambda self in do ... end |
-| app.rb:102:10:104:5 | [post] do ... end | app.rb:20:23:22:5 | lambda self in do ... end |
-| app.rb:102:10:104:5 | [post] do ... end | app.rb:24:26:26:5 | lambda self in do ... end |
-| app.rb:102:10:104:5 | [post] do ... end | app.rb:28:26:31:5 | lambda self in do ... end |
-| app.rb:102:10:104:5 | [post] do ... end | app.rb:33:25:35:5 | lambda self in do ... end |
-| app.rb:102:10:104:5 | [post] do ... end | app.rb:37:16:42:5 | lambda self in do ... end |
-| app.rb:102:10:104:5 | [post] do ... end | app.rb:44:53:46:5 | lambda self in do ... end |
-| app.rb:102:10:104:5 | [post] do ... end | app.rb:48:14:50:5 | lambda self in do ... end |
-| app.rb:102:10:104:5 | [post] do ... end | app.rb:52:37:54:5 | lambda self in do ... end |
-| app.rb:102:10:104:5 | [post] do ... end | app.rb:56:32:58:5 | lambda self in do ... end |
-| app.rb:102:10:104:5 | [post] do ... end | app.rb:60:48:62:5 | lambda self in do ... end |
-| app.rb:102:10:104:5 | [post] do ... end | app.rb:66:41:68:5 | lambda self in do ... end |
-| app.rb:102:10:104:5 | [post] do ... end | app.rb:70:20:72:5 | lambda self in do ... end |
-| app.rb:102:10:104:5 | [post] do ... end | app.rb:74:11:77:5 | lambda self in do ... end |
-| app.rb:102:10:104:5 | [post] do ... end | app.rb:79:11:82:5 | lambda self in do ... end |
-| app.rb:102:10:104:5 | [post] do ... end | app.rb:89:16:92:5 | lambda self in do ... end |
-| app.rb:102:10:104:5 | [post] do ... end | app.rb:94:15:96:5 | lambda self in do ... end |
+| app.rb:85:5:85:9 | [post] self | app.rb:3:14:3:19 | self |
+| app.rb:85:5:85:9 | [post] self | app.rb:12:5:12:10 | self |
+| app.rb:85:5:85:9 | [post] self | app.rb:17:5:17:10 | self |
+| app.rb:85:5:85:9 | [post] self | app.rb:25:15:25:20 | self |
+| app.rb:85:5:85:9 | [post] self | app.rb:39:13:39:18 | self |
+| app.rb:85:5:85:9 | [post] self | app.rb:40:14:40:19 | self |
+| app.rb:85:5:85:9 | [post] self | app.rb:45:38:45:43 | self |
+| app.rb:85:5:85:9 | [post] self | app.rb:57:5:57:15 | self |
+| app.rb:85:5:85:9 | [post] self | app.rb:61:5:61:17 | self |
+| app.rb:85:5:85:9 | [post] self | app.rb:75:5:75:8 | self |
+| app.rb:85:5:85:9 | [post] self | app.rb:75:12:75:17 | self |
+| app.rb:85:5:85:9 | [post] self | app.rb:76:5:76:36 | self |
+| app.rb:85:5:85:9 | [post] self | app.rb:76:32:76:35 | self |
+| app.rb:85:5:85:9 | [post] self | app.rb:81:5:81:12 | self |
+| app.rb:85:5:85:9 | [post] self | app.rb:90:5:90:9 | self |
+| app.rb:85:5:85:9 | [post] self | app.rb:91:5:91:10 | self |
+| app.rb:85:5:85:9 | [post] self | app.rb:95:5:95:14 | self |
+| app.rb:85:5:85:9 | [post] self | app.rb:95:10:95:14 | self |
+| app.rb:86:5:86:11 | [post] self | app.rb:3:14:3:19 | self |
+| app.rb:86:5:86:11 | [post] self | app.rb:12:5:12:10 | self |
+| app.rb:86:5:86:11 | [post] self | app.rb:17:5:17:10 | self |
+| app.rb:86:5:86:11 | [post] self | app.rb:25:15:25:20 | self |
+| app.rb:86:5:86:11 | [post] self | app.rb:39:13:39:18 | self |
+| app.rb:86:5:86:11 | [post] self | app.rb:40:14:40:19 | self |
+| app.rb:86:5:86:11 | [post] self | app.rb:45:38:45:43 | self |
+| app.rb:86:5:86:11 | [post] self | app.rb:57:5:57:15 | self |
+| app.rb:86:5:86:11 | [post] self | app.rb:61:5:61:17 | self |
+| app.rb:86:5:86:11 | [post] self | app.rb:75:5:75:8 | self |
+| app.rb:86:5:86:11 | [post] self | app.rb:75:12:75:17 | self |
+| app.rb:86:5:86:11 | [post] self | app.rb:76:5:76:36 | self |
+| app.rb:86:5:86:11 | [post] self | app.rb:76:32:76:35 | self |
+| app.rb:86:5:86:11 | [post] self | app.rb:81:5:81:12 | self |
+| app.rb:86:5:86:11 | [post] self | app.rb:90:5:90:9 | self |
+| app.rb:86:5:86:11 | [post] self | app.rb:91:5:91:10 | self |
+| app.rb:86:5:86:11 | [post] self | app.rb:95:5:95:14 | self |
+| app.rb:86:5:86:11 | [post] self | app.rb:95:10:95:14 | self |
+| app.rb:103:5:103:9 | [post] self | app.rb:3:14:3:19 | self |
+| app.rb:103:5:103:9 | [post] self | app.rb:12:5:12:10 | self |
+| app.rb:103:5:103:9 | [post] self | app.rb:17:5:17:10 | self |
+| app.rb:103:5:103:9 | [post] self | app.rb:25:15:25:20 | self |
+| app.rb:103:5:103:9 | [post] self | app.rb:39:13:39:18 | self |
+| app.rb:103:5:103:9 | [post] self | app.rb:40:14:40:19 | self |
+| app.rb:103:5:103:9 | [post] self | app.rb:45:38:45:43 | self |
+| app.rb:103:5:103:9 | [post] self | app.rb:57:5:57:15 | self |
+| app.rb:103:5:103:9 | [post] self | app.rb:61:5:61:17 | self |
+| app.rb:103:5:103:9 | [post] self | app.rb:75:5:75:8 | self |
+| app.rb:103:5:103:9 | [post] self | app.rb:75:12:75:17 | self |
+| app.rb:103:5:103:9 | [post] self | app.rb:76:5:76:36 | self |
+| app.rb:103:5:103:9 | [post] self | app.rb:76:32:76:35 | self |
+| app.rb:103:5:103:9 | [post] self | app.rb:81:5:81:12 | self |
+| app.rb:103:5:103:9 | [post] self | app.rb:90:5:90:9 | self |
+| app.rb:103:5:103:9 | [post] self | app.rb:91:5:91:10 | self |
+| app.rb:103:5:103:9 | [post] self | app.rb:95:5:95:14 | self |
+| app.rb:103:5:103:9 | [post] self | app.rb:95:10:95:14 | self |
+| app.rb:103:13:103:22 | [post] self | app.rb:3:14:3:19 | self |
+| app.rb:103:13:103:22 | [post] self | app.rb:12:5:12:10 | self |
+| app.rb:103:13:103:22 | [post] self | app.rb:17:5:17:10 | self |
+| app.rb:103:13:103:22 | [post] self | app.rb:25:15:25:20 | self |
+| app.rb:103:13:103:22 | [post] self | app.rb:39:13:39:18 | self |
+| app.rb:103:13:103:22 | [post] self | app.rb:40:14:40:19 | self |
+| app.rb:103:13:103:22 | [post] self | app.rb:45:38:45:43 | self |
+| app.rb:103:13:103:22 | [post] self | app.rb:57:5:57:15 | self |
+| app.rb:103:13:103:22 | [post] self | app.rb:61:5:61:17 | self |
+| app.rb:103:13:103:22 | [post] self | app.rb:75:5:75:8 | self |
+| app.rb:103:13:103:22 | [post] self | app.rb:75:12:75:17 | self |
+| app.rb:103:13:103:22 | [post] self | app.rb:76:5:76:36 | self |
+| app.rb:103:13:103:22 | [post] self | app.rb:76:32:76:35 | self |
+| app.rb:103:13:103:22 | [post] self | app.rb:81:5:81:12 | self |
+| app.rb:103:13:103:22 | [post] self | app.rb:90:5:90:9 | self |
+| app.rb:103:13:103:22 | [post] self | app.rb:91:5:91:10 | self |
+| app.rb:103:13:103:22 | [post] self | app.rb:95:5:95:14 | self |
+| app.rb:103:13:103:22 | [post] self | app.rb:95:10:95:14 | self |


### PR DESCRIPTION
Fixes a type incompatibility identified by @aschackmull  on https://github.com/github/codeql/pull/16785.