### PR TITLE
Go: Fix bug removing "vendor/" from package paths

### DIFF
--- a/go/ql/lib/semmle/go/Packages.qll
+++ b/go/ql/lib/semmle/go/Packages.qll
@@ -14,7 +14,7 @@ class Package extends @package {
   /** Gets the path of this package. */
   string getPath() {
     exists(string fullPath | packages(this, _, fullPath, _) |
-      result = fullPath.regexpReplaceAll("^.*/vendor/", "")
+      result = fullPath.regexpReplaceAll("^.*\\bvendor/", "")
     )
   }
 


### PR DESCRIPTION
In all the databases I've looked in, some of the packages start with "vendor/", followed by what appears to be a sensible package path. The existing code to remove "vendor/" accidentally matches for "/vendor/", so it isn't removing it. This PR fixes that bug.
