### PR TITLE
Java: document extraction system requirements

### DIFF
--- a/docs/codeql/codeql-overview/system-requirements.rst
+++ b/docs/codeql/codeql-overview/system-requirements.rst
@@ -43,3 +43,10 @@ For Python extraction:
 For Ruby extraction:
 
 - On Windows, the ``msvcp140.dll`` must be installed and available on the system. This can be installed by downloading the appropriate Microsoft Visual C++ Redistributable for Visual Studio.
+
+For Java extraction:
+
+- There must be a ``java`` or ``java.exe`` executable available on the ``PATH``, and the ``JAVA_HOME`` environment variable must point to the corresponding JDK's home directory.
+- If you need to analyse projects using varying JDK versions, it may be useful to supply alternate JDK versions using environment variables of the form ``JAVA_HOME_$VERSION_$PLATFORM``, following the example of `the GitHub Actions runner images <https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#java>`__. An Apache Maven `toolchains.xml file <https://maven.apache.org/guides/mini/guide-using-toolchains.html#using-toolchains-in-your-project>`__ can also be used for the same purpose.
+- Having a ``mvn`` or ``mvn.exe`` executable available on the ``PATH`` is recommended if your project uses Apache Maven and does not use the ``mvnw`` wrapper script.
+- Having a ``gradle`` or ``gradle.exe`` executable available on the ``PATH`` is recommended if your project uses Gradle and does not use the ``gradlew`` wrapper script.


### PR DESCRIPTION
Note that a `java` binary is at least highly recommended for Java extraction, and in many circumstances a hard requirement. The same goes for `mvn` and `gradle`.