### PR TITLE
Javascript: Add environment variables to allow specifying memory sizes

### DIFF
--- a/javascript/resources/codeql-extractor.yml
+++ b/javascript/resources/codeql-extractor.yml
@@ -92,3 +92,13 @@ options:
     description: Whether to skip the extraction of types in a TypeScript application
     type: string
     pattern: "^(false|true)$"
+  ts_memory:
+    title: TypeScript compiler memory
+    description: Amount of memory (in MB) allocated to the TypeScript compiler process
+    type: string
+    pattern: "[0-9]+"
+  jvm_max_memory:
+    title: JVM memory
+    description: The maximum memory allocation pool (in MB) for the JVM
+    type: string
+    pattern: "[0-9]+"

--- a/javascript/resources/tools/autobuild.cmd
+++ b/javascript/resources/tools/autobuild.cmd
@@ -3,11 +3,34 @@ SETLOCAL EnableDelayedExpansion
 
 set jvm_args=-Xss16m
 
-rem If CODEQL_RAM is set, use half for Java and half for TS.
+rem If CODEQL_RAM is set, try to automatically calculate how much memory is available for TS and Java
+rem if no explicit values are set for them.
 if NOT [%CODEQL_RAM%] == [] (
     set /a "half_ram=CODEQL_RAM/2"
-    set LGTM_TYPESCRIPT_RAM=%half_ram%
-    set jvm_args=!jvm_args! -Xmx!half_ram!m
+
+    rem If either CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_TS_MEMORY or CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_JVM_MAX_MEMORY is set,
+    rem calculate the other by subtracting from CODEQL_RAM. If neither is set, then use
+    rem half of the available CODEQL_RAM for each.
+    if NOT [%CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_TS_MEMORY%] == [] if [%CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_JVM_MAX_MEMORY%] == [] (
+        set /a "CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_JVM_MAX_MEMORY=CODEQL_RAM-CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_TS_MEMORY"
+    )
+    if NOT [%CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_JVM_MAX_MEMORY%] == [] if [%CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_TS_MEMORY%] == [] (
+        set /a "CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_TS_MEMORY=CODEQL_RAM-CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_JVM_MAX_MEMORY"
+    )
+    if [%CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_JVM_MAX_MEMORY%] == [] if [%CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_TS_MEMORY%] == [] (
+        set CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_TS_MEMORY=%half_ram%
+        set CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_JVM_MAX_MEMORY=%half_ram%
+    )
+)
+
+rem If CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_TS_MEMORY is set, use it for TS by exporting it as LGTM_TYPESCRIPT_RAM.
+if NOT [%CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_TS_MEMORY%] == [] (
+    set LGTM_TYPESCRIPT_RAM=%CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_TS_MEMORY%
+)
+
+rem If CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_JVM_MAX_MEMORY is set, use it for Java by adding it to the JVM arguments.
+if NOT [%CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_JVM_MAX_MEMORY%] == [] (
+    set jvm_args=!jvm_args! -Xmx!CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_JVM_MAX_MEMORY!m
 )
 
 rem If CODEQL_THREADS is set, propagate via LGTM_THREADS.

--- a/javascript/resources/tools/autobuild.sh
+++ b/javascript/resources/tools/autobuild.sh
@@ -4,12 +4,33 @@ set -eu
 
 jvm_args=-Xss16m
 
-# If CODEQL_RAM is set, use half for Java and half for TS.
+# If CODEQL_RAM is set, try to automatically calculate how much memory is available for TS and Java
+# if no explicit values are set for them.
 if [ -n "${CODEQL_RAM:-}" ] ; then
     half_ram="$(( CODEQL_RAM / 2 ))"
-    LGTM_TYPESCRIPT_RAM="$half_ram"
+
+    # If either CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_TS_MEMORY or CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_JVM_MAX_MEMORY is set,
+    # calculate the other by subtracting from CODEQL_RAM. If neither is set, then use
+    # half of the available CODEQL_RAM for each.
+    if [ -n "${CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_TS_MEMORY:-}" ] && [ -z "${CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_JVM_MAX_MEMORY}" ] ; then
+        CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_JVM_MAX_MEMORY="$(( $CODEQL_RAM - $CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_TS_MEMORY ))"
+    elif [ -n "${CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_JVM_MAX_MEMORY:-}" ] && [ -z "${CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_TS_MEMORY}" ] ; then
+        CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_TS_MEMORY="$(( $CODEQL_RAM - $CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_JVM_MAX_MEMORY ))"
+    elif [ -z "${CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_JVM_MAX_MEMORY}" ] && [ -z "${CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_TS_MEMORY}" ] ; then
+        CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_TS_MEMORY="$half_ram"
+        CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_JVM_MAX_MEMORY="$half_ram"
+    fi
+fi
+
+# If CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_TS_MEMORY is set, use it for TS by exporting it as LGTM_TYPESCRIPT_RAM.
+if [ -n "${CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_TS_MEMORY:-}" ] ; then
+    LGTM_TYPESCRIPT_RAM="$CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_TS_MEMORY"
     export LGTM_TYPESCRIPT_RAM
-    jvm_args="$jvm_args -Xmx${half_ram}m"
+fi
+
+# If CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_JVM_MAX_MEMORY is set, use it for Java by adding it to the JVM arguments.
+if [ -n "${CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_JVM_MAX_MEMORY:-}" ] ; then
+    jvm_args="$jvm_args -Xmx${CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_JVM_MAX_MEMORY}m"
 fi
 
 # If CODEQL_THREADS is set, propagate via LGTM_THREADS.


### PR DESCRIPTION
**Summary**

This PR improves the situation described in https://github.com/github/codeql/issues/16780 where halving the available `CODEQL_RAM` between the Typescript and JVM processes can lead to an out-of-memory condition.

**Approach**

This PR modifies the `autobuild.(sh|cmd)` scripts to add two new environment variables, `CODEQL_JAVASCRIPT_TS_MEMORY` and `CODEQL_JAVASCRIPT_JVM_MAX_MEMORY`, which can be used to specify the amounts of memory that should be available to Typescript and the JVM, respectively. 

The implementation is intended to work as follows:

- `CODEQL_JAVASCRIPT_TS_MEMORY` and `CODEQL_JAVASCRIPT_JVM_MAX_MEMORY` are used to set the values for `LGTM_TYPESCRIPT_RAM` and `jvm_args`, respectively.
- If `CODEQL_RAM` is set, then we will automatically calculate the values for `CODEQL_JAVASCRIPT_TS_MEMORY` and `CODEQL_JAVASCRIPT_JVM_MAX_MEMORY` if one or both are not set.
  - If either `CODEQL_JAVASCRIPT_TS_MEMORY` or `CODEQL_JAVASCRIPT_JVM_MAX_MEMORY` is set, but the other isn't, then we calculate the missing value by subtracting the present value from `CODEQL_RAM`.
  - If both are missing, then we use half of the available `CODEQL_RAM` as before.
- If `CODEQL_RAM` is not set, then we use whatever values for `CODEQL_JAVASCRIPT_TS_MEMORY` and `CODEQL_JAVASCRIPT_JVM_MAX_MEMORY` that are available, if any.
