### PR TITLE
C++: Fix missing `asExpr` for temporary materializations with conversions

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/ExprNodes.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/ExprNodes.qll
@@ -193,6 +193,46 @@ private module Cached {
     )
   }
 
+  /** Holds if `operand`'s definition is a `VariableAddressInstruction` whose variable is a temporary */
+  private predicate isIRTempVariable(Operand operand) {
+    operand.getDef().(VariableAddressInstruction).getIRVariable() instanceof IRTempVariable
+  }
+
+  /**
+   * Holds if `node` is an indirect operand whose operand is an argument, and
+   * the `n`'th expression associated with the operand is `e`.
+   */
+  private predicate isIndirectOperandOfArgument(
+    IndirectOperand node, ArgumentOperand operand, Expr e, int n
+  ) {
+    node.hasOperandAndIndirectionIndex(operand, 1) and
+    e = getConvertedResultExpression(operand.getDef(), n)
+  }
+
+  /**
+   * Holds if `opFrom` is an operand to a conversion, and `opTo` is the unique
+   * use of the conversion.
+   */
+  private predicate isConversionStep(Operand opFrom, Operand opTo) {
+    exists(Instruction mid |
+      conversionFlow(opFrom, mid, false, false) and
+      opTo = unique( | | getAUse(mid))
+    )
+  }
+
+  /**
+   * Holds if an operand that satisfies `isIRTempVariable` flows to `op`
+   * through a (possibly empty) sequence of conversions.
+   */
+  private predicate irTempOperandConversionFlows(Operand op) {
+    isIRTempVariable(op)
+    or
+    exists(Operand mid |
+      irTempOperandConversionFlows(mid) and
+      isConversionStep(mid, op)
+    )
+  }
+
   /** Holds if `node` should be an `IndirectOperand` that maps `node.asExpr()` to `e`. */
   private predicate exprNodeShouldBeIndirectOperand(IndirectOperand node, Expr e, int n) {
     exists(ArgumentOperand operand |
@@ -203,9 +243,8 @@ private module Cached {
       // result. However, the instruction actually represents the _address_ of
       // the argument. So to fix this mismatch, we have the indirection of the
       // `VariableAddressInstruction` map to the expression.
-      node.hasOperandAndIndirectionIndex(operand, 1) and
-      e = getConvertedResultExpression(operand.getDef(), n) and
-      operand.getDef().(VariableAddressInstruction).getIRVariable() instanceof IRTempVariable
+      isIndirectOperandOfArgument(node, operand, e, n) and
+      irTempOperandConversionFlows(operand)
     )
   }
 

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/TestBase.qll
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/TestBase.qll
@@ -151,6 +151,9 @@ module IRTest {
         or
         call.getTarget().getName() = "indirect_sink" and
         sink.asIndirectExpr() = e
+        or
+        call.getTarget().getName() = "indirect_sink_const_ref" and
+        sink.asIndirectExpr() = e
       )
     }
 

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test-source-sink.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test-source-sink.expected
@@ -313,6 +313,7 @@ irFlow
 | test.cpp:1021:18:1021:32 | *call to indirect_source | test.cpp:1027:19:1027:28 | *translated |
 | test.cpp:1021:18:1021:32 | *call to indirect_source | test.cpp:1031:19:1031:28 | *translated |
 | test.cpp:1045:14:1045:19 | call to source | test.cpp:1046:7:1046:10 | * ... |
+| test.cpp:1081:27:1081:34 | call to source | test.cpp:1081:27:1081:34 | call to source |
 | true_upon_entry.cpp:9:11:9:16 | call to source | true_upon_entry.cpp:13:8:13:8 | x |
 | true_upon_entry.cpp:17:11:17:16 | call to source | true_upon_entry.cpp:21:8:21:8 | x |
 | true_upon_entry.cpp:27:9:27:14 | call to source | true_upon_entry.cpp:29:8:29:8 | x |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
@@ -1078,5 +1078,5 @@ template<typename T>
 void indirect_sink_const_ref(const T&);
 
 void test_temp_with_conversion_from_materialization() {
-  indirect_sink_const_ref(source()); // $ MISSING: ast,ir
+  indirect_sink_const_ref(source()); // $ ir MISSING: ast
 }

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
@@ -1073,3 +1073,10 @@ void single_object_in_both_cases(bool b, int x, int y) {
   *p = 0;
   sink(*p); // clean
 }
+
+template<typename T>
+void indirect_sink_const_ref(const T&);
+
+void test_temp_with_conversion_from_materialization() {
+  indirect_sink_const_ref(source()); // $ MISSING: ast,ir
+}


### PR DESCRIPTION
When a temporary is materialized we special-case `asExpr` to assign the correct node for which `asExpr()` should have a result. For example, consider this example:
```cpp
struct A {
    void f();
};

void test() {
    A().f();
}
```
which generates the following (simplified) IR:
```cpp
r6_1(glval<A>)       = VariableAddress[#temp6:5]  :
r6_5(glval<unknown>) = FunctionAddress[f]         :
v6_6(void)           = Call[f]                    : func:r6_5, this:r6_1
r4_1(glval<unknown>) = FunctionAddress[sink]      :
r4_2(glval<int>)     = VariableAddress[#temp4:10] :
r4_3(int)            = Constant[42]               :
m4_4(int)            = Store[#temp4:10]           : &:r4_2, r4_3
m4_5(unknown)        = Chi                        : total:m3_4, partial:m4_4
r4_6(int &)          = CopyValue                  : r4_2
v4_7(void)           = Call[sink]                 : func:r4_1, 0:r4_6
```
The code [here](https://github.com/github/codeql/blob/4a448f445e79b9baa07a302d8062fe9f0fcb00b9/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/ExprNodes.qll#L197-L210) ensures that we select `*r6_1` as the node for which `asExpr()` returns `A()`.

However, the code doesn't work when there's a conversion involved. For example, consider this code which also materializes a temporary:
```cpp
void sink(const int&);

void test() {
    sink(42);
}
```
It has the following (simplified) IR:
```cpp
r4_1(glval<unknown>) = FunctionAddress[sink]      :
r4_2(glval<int>)     = VariableAddress[#temp4:10] :
r4_3(int)            = Constant[42]               :
m4_4(int)            = Store[#temp4:10]           : &:r4_2, r4_3
m4_5(unknown)        = Chi                        : total:m3_4, partial:m4_4
r4_6(int &)          = CopyValue                  : r4_2
v4_7(void)           = Call[sink]                 : func:r4_1, 0:r4_6
```
as you can see, it's not the `VariableAddress` instruction `r4_2` that's an argument operand to `sink`, but rather a conversion of it. Thus, the special-casing code on `main` doesn't kick in. Instead, we have to traverse the chain of conversions to figure out whether the `VariableAddress` instruction at the top of the conversion chain (if any) is a temporary.

This PR does exactly that.

Commit-by-commit review recommended.