### PR TITLE
C++: Fix value numbering imports

### DIFF
--- a/config/identical-files.json
+++ b/config/identical-files.json
@@ -181,11 +181,6 @@
     "cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/AliasAnalysisImports.qll",
     "cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasAnalysisImports.qll"
   ],
-  "C++ IR ValueNumberingImports": [
-    "cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/gvn/internal/ValueNumberingImports.qll",
-    "cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/internal/ValueNumberingImports.qll",
-    "cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/internal/ValueNumberingImports.qll"
-  ],
   "IR SSA SSAConstruction": [
     "cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll",
     "cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll"

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/gvn/internal/ValueNumberingImports.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/gvn/internal/ValueNumberingImports.qll
@@ -1,3 +1,3 @@
-import semmle.code.cpp.ir.implementation.aliased_ssa.IR
+import semmle.code.cpp.ir.implementation.raw.IR
 import semmle.code.cpp.ir.internal.Overlap
 import semmle.code.cpp.ir.internal.IRCppLanguage as Language

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/internal/ValueNumberingImports.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/internal/ValueNumberingImports.qll
@@ -1,3 +1,3 @@
-import semmle.code.cpp.ir.implementation.aliased_ssa.IR
+import semmle.code.cpp.ir.implementation.unaliased_ssa.IR
 import semmle.code.cpp.ir.internal.Overlap
 import semmle.code.cpp.ir.internal.IRCppLanguage as Language


### PR DESCRIPTION
The value numbering library is shared via a pyrameterized module and made available for all three stages of the IR (i.e., raw, unaliased, and aliased). This is purely for historical reasons (see Dave's very old comment [here](https://github.com/github/codeql/pull/203#issuecomment-422818066)), and today we don't actually use the raw or unaliased versions of value numbering.

The `identical-files.json` was for some reason sharing the imports of the IR. This meant that both the raw and unaliased value numbering library was using the aliased IR.