### PR TITLE
Set `java/string-concatenation-in-loop` as having `high` precision

### DIFF
--- a/java/ql/src/Performance/ConcatenationInLoops.ql
+++ b/java/ql/src/Performance/ConcatenationInLoops.ql
@@ -4,7 +4,7 @@
  *              performance.
  * @kind problem
  * @problem.severity warning
- * @precision low
+ * @precision high
  * @id java/string-concatenation-in-loop
  * @tags efficiency
  *       maintainability


### PR DESCRIPTION
@yoff and I ran this query against the top 100 java repos with MRVA. Looking through a decent sample of the results, we found no true positives. Is that sufficient testing to increase the precision here?