### PR TITLE
C#: Change `string.Format` calls to interpolated strings

### DIFF
--- a/csharp/autobuilder/Semmle.Autobuild.CSharp/DotNetRule.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp/DotNetRule.cs
@@ -39,7 +39,7 @@ namespace Semmle.Autobuild.CSharp
 
                 if (notDotNetProject is not null)
                 {
-                    builder.Logger.Log(Severity.Info, "Not using .NET Core because of incompatible project {0}", notDotNetProject);
+                    builder.Logger.LogInfo($"Not using .NET Core because of incompatible project {notDotNetProject}");
                     return BuildScript.Failure;
                 }
 

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp/Program.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp/Program.cs
@@ -22,12 +22,12 @@ namespace Semmle.Autobuild.CSharp
                 }
                 catch (InvalidEnvironmentException ex)
                 {
-                    Console.WriteLine("The environment is invalid: {0}", ex.Message);
+                    Console.WriteLine($"The environment is invalid: {ex.Message}");
                 }
             }
             catch (ArgumentOutOfRangeException ex)
             {
-                Console.WriteLine("The value \"{0}\" for parameter \"{1}\" is invalid", ex.ActualValue, ex.ParamName);
+                Console.WriteLine($"The value \"{ex.ActualValue}\" for parameter \"{ex.ParamName}\" is invalid");
             }
             return 1;
         }

--- a/csharp/autobuilder/Semmle.Autobuild.Cpp/Program.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.Cpp/Program.cs
@@ -22,12 +22,12 @@ namespace Semmle.Autobuild.Cpp
                 }
                 catch (InvalidEnvironmentException ex)
                 {
-                    Console.WriteLine("The environment is invalid: {0}", ex.Message);
+                    Console.WriteLine($"The environment is invalid: {ex.Message}");
                 }
             }
             catch (ArgumentOutOfRangeException ex)
             {
-                Console.WriteLine("The value \"{0}\" for parameter \"{1}\" is invalid", ex.ActualValue, ex.ParamName);
+                Console.WriteLine($"The value \"{ex.ActualValue}\" for parameter \"{ex.ParamName}\" is invalid");
             }
             return 1;
         }

--- a/csharp/autobuilder/Semmle.Autobuild.Shared/MsBuildRule.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.Shared/MsBuildRule.cs
@@ -128,9 +128,9 @@ namespace Semmle.Autobuild.Shared
 
                 command.Argument("/t:" + target);
                 if (platform is not null)
-                    command.Argument(string.Format("/p:Platform=\"{0}\"", platform));
+                    command.Argument($"/p:Platform=\"{platform}\"");
                 if (configuration is not null)
-                    command.Argument(string.Format("/p:Configuration=\"{0}\"", configuration));
+                    command.Argument($"/p:Configuration=\"{configuration}\"");
 
                 // append the build script which invokes msbuild to the overall build script `ret`;
                 // we insert a check that building the current project or solution was successful:

--- a/csharp/autobuilder/Semmle.Autobuild.Shared/Project.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.Shared/Project.cs
@@ -66,7 +66,7 @@ namespace Semmle.Autobuild.Shared
                     catch  // lgtm[cs/catch-of-all-exceptions]
                            // Generic catch clause - Version constructor throws about 5 different exceptions.
                     {
-                        builder.Logger.Log(Severity.Warning, "Project {0} has invalid tools version {1}", path, toolsVersion);
+                        builder.Logger.LogWarning($"Project {path} has invalid tools version {toolsVersion}");
                     }
                 }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/AssemblyInfo.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/AssemblyInfo.cs
@@ -60,11 +60,11 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             {
                 var result = Name;
                 if (Version is not null)
-                    result = string.Format("{0}, Version={1}", result, Version);
+                    result = $"{result}, Version={Version}";
                 if (Culture is not null)
-                    result = string.Format("{0}, Culture={1}", result, Culture);
+                    result = $"{result}, Culture={Culture}";
                 if (PublicKeyToken is not null)
-                    result = string.Format("{0}, PublicKeyToken={1}", result, PublicKeyToken);
+                    result = $"{result}, PublicKeyToken={PublicKeyToken}";
                 return result;
             }
         }
@@ -82,8 +82,8 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 if (Version is not null)
                 {
                     if (Culture is not null)
-                        yield return string.Format("{0}, Version={1}, Culture={2}", Name, Version, Culture);
-                    yield return string.Format("{0}, Version={1}", Name, Version);
+                        yield return $"{Name}, Version={Version}, Culture={Culture}";
+                    yield return $"{Name}, Version={Version}";
                 }
                 yield return Name;
                 yield return Name.ToLowerInvariant();

--- a/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Extractor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Extractor.cs
@@ -151,7 +151,7 @@ namespace Semmle.Extraction.CSharp.Standalone
             }
             catch (Exception ex)  // lgtm[cs/catch-of-all-exceptions]
             {
-                fileLogger.Log(Severity.Error, "  Unhandled exception: {0}", ex);
+                fileLogger.LogError($"  Unhandled exception: {ex}");
             }
 
             logger.Log(Severity.Info, $"Extraction completed in {overallStopwatch.Elapsed}");

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Destructor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Destructor.cs
@@ -14,7 +14,7 @@ namespace Semmle.Extraction.CSharp.Entities
             PopulateModifiers(trapFile);
             ContainingType!.PopulateGenerics();
 
-            trapFile.destructors(this, string.Format("~{0}", Symbol.ContainingType.Name), ContainingType, OriginalDefinition(Context, this, Symbol));
+            trapFile.destructors(this, $"~{Symbol.ContainingType.Name}", ContainingType, OriginalDefinition(Context, this, Symbol));
             trapFile.destructor_location(this, Location);
         }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/OrdinaryMethod.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/OrdinaryMethod.cs
@@ -63,7 +63,7 @@ namespace Semmle.Extraction.CSharp.Entities
         {
             if (method.MethodKind == MethodKind.ReducedExtension)
             {
-                cx.ExtractionContext.Logger.Log(Semmle.Util.Logging.Severity.Warning, "Reduced extension method symbols should not be directly extracted.");
+                cx.ExtractionContext.Logger.LogWarning("Reduced extension method symbols should not be directly extracted.");
             }
 
             return OrdinaryMethodFactory.Instance.CreateEntityFromSymbol(cx, method);

--- a/csharp/extractor/Semmle.Extraction.CSharp/Extractor/Analyser.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Extractor/Analyser.cs
@@ -54,7 +54,7 @@ namespace Semmle.Extraction.CSharp
             this.addAssemblyTrapPrefix = addAssemblyTrapPrefix;
             this.progressMonitor = pm;
 
-            Logger.Log(Severity.Info, "EXTRACTION STARTING at {0}", DateTime.Now);
+            Logger.LogInfo($"EXTRACTION STARTING at {DateTime.Now}");
             stopWatch.Start();
         }
 
@@ -175,7 +175,7 @@ namespace Semmle.Extraction.CSharp
             }
             catch (Exception ex)  // lgtm[cs/catch-of-all-exceptions]
             {
-                Logger.Log(Severity.Error, "  Unhandled exception analyzing {0}: {1}", r.FilePath, ex);
+                Logger.LogError($"  Unhandled exception analyzing {r.FilePath}: {ex}");
             }
         }
 
@@ -251,7 +251,7 @@ namespace Semmle.Extraction.CSharp
             }
             catch (Exception ex)  // lgtm[cs/catch-of-all-exceptions]
             {
-                Logger.Log(Severity.Error, "  Unhandled exception analyzing {0}: {1}", "compilation", ex);
+                Logger.LogError($"  Unhandled exception analyzing compilation: {ex}");
             }
         }
 
@@ -315,12 +315,12 @@ namespace Semmle.Extraction.CSharp
         public virtual void Dispose()
         {
             stopWatch.Stop();
-            Logger.Log(Severity.Info, "  Peak working set = {0} MB", Process.GetCurrentProcess().PeakWorkingSet64 / (1024 * 1024));
+            Logger.LogInfo($"  Peak working set = {Process.GetCurrentProcess().PeakWorkingSet64 / (1024 * 1024)} MB");
 
             if (TotalErrors > 0)
-                Logger.Log(Severity.Info, "EXTRACTION FAILED with {0} error{1} in {2}", TotalErrors, TotalErrors == 1 ? "" : "s", stopWatch.Elapsed);
+                Logger.LogInfo($"EXTRACTION FAILED with {TotalErrors} error{(TotalErrors == 1 ? "" : "s")} in {stopWatch.Elapsed}");
             else
-                Logger.Log(Severity.Info, "EXTRACTION SUCCEEDED in {0}", stopWatch.Elapsed);
+                Logger.LogInfo($"EXTRACTION SUCCEEDED in {stopWatch.Elapsed}");
 
             compilationTrapFile?.Dispose();
         }
@@ -345,9 +345,9 @@ namespace Semmle.Extraction.CSharp
         /// </summary>
         public void LogExtractorInfo()
         {
-            Logger.Log(Severity.Info, "  Extractor: {0}", Environment.GetCommandLineArgs().First());
-            Logger.Log(Severity.Info, "  Extractor version: {0}", Version);
-            Logger.Log(Severity.Info, "  Current working directory: {0}", Directory.GetCurrentDirectory());
+            Logger.LogInfo($"  Extractor: {Environment.GetCommandLineArgs().First()}");
+            Logger.LogInfo($"  Extractor version: {Version}");
+            Logger.LogInfo($"  Current working directory: {Directory.GetCurrentDirectory()}");
         }
 
         private static string Version

--- a/csharp/extractor/Semmle.Extraction.CSharp/Extractor/TracingAnalyser.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Extractor/TracingAnalyser.cs
@@ -62,7 +62,7 @@ namespace Semmle.Extraction.CSharp
         /// <returns>A Boolean indicating whether the same arguments have been logged previously.</returns>
         private bool LogRoslynArgs(IEnumerable<string> roslynArgs)
         {
-            Logger.Log(Severity.Info, $"  Arguments to Roslyn: {string.Join(' ', roslynArgs)}");
+            Logger.LogInfo($"  Arguments to Roslyn: {string.Join(' ', roslynArgs)}");
 
             var tempFile = Extractor.GetCSharpArgsLogPath(Path.GetRandomFileName());
 
@@ -77,7 +77,7 @@ namespace Semmle.Extraction.CSharp
             var argsFile = Extractor.GetCSharpArgsLogPath(hash);
 
             if (argsWritten)
-                Logger.Log(Severity.Info, $"  Arguments have been written to {argsFile}");
+                Logger.LogInfo($"  Arguments have been written to {argsFile}");
 
             if (File.Exists(argsFile))
             {
@@ -87,7 +87,7 @@ namespace Semmle.Extraction.CSharp
                 }
                 catch (IOException e)
                 {
-                    Logger.Log(Severity.Warning, $"  Failed to remove {tempFile}: {e.Message}");
+                    Logger.LogWarning($"  Failed to remove {tempFile}: {e.Message}");
                 }
                 return false;
             }
@@ -98,7 +98,7 @@ namespace Semmle.Extraction.CSharp
             }
             catch (IOException e)
             {
-                Logger.Log(Severity.Warning, $"  Failed to move {tempFile} to {argsFile}: {e.Message}");
+                Logger.LogWarning($"  Failed to move {tempFile} to {argsFile}: {e.Message}");
             }
 
             return true;
@@ -146,14 +146,14 @@ namespace Semmle.Extraction.CSharp
 
             foreach (var error in filteredDiagnostics)
             {
-                Logger.Log(Severity.Error, "  Compilation error: {0}", error);
+                Logger.LogError($"  Compilation error: {error}");
             }
 
             if (filteredDiagnostics.Count != 0)
             {
                 foreach (var reference in compilation.References)
                 {
-                    Logger.Log(Severity.Info, "  Resolved reference {0}", reference.Display);
+                    Logger.LogInfo($"  Resolved reference {reference.Display}");
                 }
             }
 

--- a/csharp/extractor/Semmle.Extraction/Context.cs
+++ b/csharp/extractor/Semmle.Extraction/Context.cs
@@ -203,7 +203,7 @@ namespace Semmle.Extraction
         private void EnterScope()
         {
             if (currentRecursiveDepth >= maxRecursiveDepth)
-                throw new StackOverflowException(string.Format("Maximum nesting depth of {0} exceeded", maxRecursiveDepth));
+                throw new StackOverflowException($"Maximum nesting depth of {maxRecursiveDepth} exceeded");
             ++currentRecursiveDepth;
         }
 

--- a/csharp/extractor/Semmle.Extraction/Extractor/ExtractionContext.cs
+++ b/csharp/extractor/Semmle.Extraction/Extractor/ExtractionContext.cs
@@ -50,7 +50,7 @@ namespace Semmle.Extraction
                     ++Errors;
                     if (Errors == maxErrors)
                     {
-                        Logger.LogInfo("  Stopping logging after {0} errors", Errors);
+                        Logger.LogInfo($"  Stopping logging after {Errors} errors");
                     }
                 }
 

--- a/csharp/extractor/Semmle.Extraction/TrapWriter.cs
+++ b/csharp/extractor/Semmle.Extraction/TrapWriter.cs
@@ -183,13 +183,13 @@ namespace Semmle.Extraction
                         if (TryMove(tmpFile, $"{root}-{hash}.trap{TrapExtension(trapCompression)}"))
                             return;
                     }
-                    logger.Log(Severity.Info, "Identical trap file for {0} already exists", TrapFile);
+                    logger.LogInfo($"Identical trap file for {TrapFile} already exists");
                     FileUtils.TryDelete(tmpFile);
                 }
             }
             catch (Exception ex)  // lgtm[cs/catch-of-all-exceptions]
             {
-                logger.Log(Severity.Error, "Failed to move the trap file from {0} to {1} because {2}", tmpFile, TrapFile, ex);
+                logger.LogError($"Failed to move the trap file from {tmpFile} to {TrapFile} because {ex}");
             }
         }
 

--- a/csharp/extractor/Semmle.Util/Logging/ILogger.cs
+++ b/csharp/extractor/Semmle.Util/Logging/ILogger.cs
@@ -20,6 +20,6 @@ namespace Semmle.Util.Logging
 
         void LogDebug(string text, int? threadId = null) => Log(Severity.Debug, text, threadId);
 
-        void Log(Severity s, string text, params object?[] args) => Log(s, string.Format(text, args));
+        void LogTrace(string text, int? threadId = null) => Log(Severity.Trace, text, threadId);
     }
 }

--- a/csharp/extractor/Testrunner/Testrunner.cs
+++ b/csharp/extractor/Testrunner/Testrunner.cs
@@ -40,7 +40,7 @@ public class Testrunner
         {
             Console.ForegroundColor = ConsoleColor.Red;
 
-            Console.WriteLine("[FAIL] {0}: {1}", info.TestDisplayName, info.ExceptionMessage);
+            Console.WriteLine($"[FAIL] {info.TestDisplayName}: {info.ExceptionMessage}");
             if (info.ExceptionStackTrace != null)
                 Console.WriteLine(info.ExceptionStackTrace);
 
@@ -55,7 +55,7 @@ public class Testrunner
         lock (ConsoleLock)
         {
             Console.ForegroundColor = ConsoleColor.Yellow;
-            Console.WriteLine("[SKIP] {0}: {1}", info.TestDisplayName, info.SkipReason);
+            Console.WriteLine($"[SKIP] {info.TestDisplayName}: {info.SkipReason}");
             Console.ResetColor();
         }
     }


### PR DESCRIPTION
This pull request replaces the old `string.Format` method calls with the newer, more readable and more performant string interpolation syntax. Additionally, the `Logger.Log` method calls are replaced with more specific logging methods like `LogError` or `LogInfo`.