### PR TITLE
C#/Java: Do not lift source and sink models.

### DIFF
--- a/csharp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/csharp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -38,7 +38,9 @@ class DataFlowSourceTargetApi = SourceTargetApi;
 class DataFlowSinkTargetApi = SinkTargetApi;
 
 private module ModelPrintingInput implements ModelPrintingSig {
-  class Api = TargetApiBase;
+  class SummaryApi = DataFlowSummaryTargetApi;
+
+  class SourceOrSinkApi = SourceOrSinkTargetApi;
 
   string getProvenance() { result = "df-generated" }
 }

--- a/csharp/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
+++ b/csharp/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
@@ -112,38 +112,41 @@ predicate isUninterestingForDataFlowModels(CS::Callable api) { isHigherOrder(api
 predicate isUninterestingForTypeBasedFlowModels(CS::Callable api) { none() }
 
 /**
- * A class of callables that are potentially relevant for generating summary and
- * neutral models.
+ * A class of callables that are potentially relevant for generating source or
+ * sink models.
  */
-class SummaryTargetApi extends TargetApiBase {
-  SummaryTargetApi() { not hasManualSummaryModel(this.lift()) }
+class SourceOrSinkTargetApi extends Callable {
+  SourceOrSinkTargetApi() { relevant(this) }
 }
 
 /**
  * A class of callables that are potentially relevant for generating sink models.
  */
-class SinkTargetApi extends TargetApiBase {
-  SinkTargetApi() { not hasManualSinkModel(this.lift()) }
+class SinkTargetApi extends SourceOrSinkTargetApi {
+  SinkTargetApi() { not hasManualSinkModel(this) }
 }
 
 /**
  * A class of callables that are potentially relevant for generating source models.
  */
-class SourceTargetApi extends TargetApiBase {
-  SourceTargetApi() { not hasManualSourceModel(this.lift()) }
+class SourceTargetApi extends SourceOrSinkTargetApi {
+  SourceTargetApi() { not hasManualSourceModel(this) }
 }
 
 /**
- * A class of callables that are potentially relevant for generating summary, source, sink
- * and neutral models.
+ * A class of callables that are potentially relevant for generating summary or
+ * neutral models.
  *
  * In the Standard library and 3rd party libraries it is the callables (or callables that have a
  * super implementation) that can be called from outside the library itself.
  */
-class TargetApiBase extends Callable {
+class SummaryTargetApi extends Callable {
   private Callable lift;
 
-  TargetApiBase() { lift = liftedImpl(this) }
+  SummaryTargetApi() {
+    lift = liftedImpl(this) and
+    not hasManualSummaryModel(lift)
+  }
 
   /**
    * Gets the callable that a model will be lifted to.

--- a/csharp/ql/src/utils/modelgenerator/internal/CaptureTypeBasedSummaryModels.qll
+++ b/csharp/ql/src/utils/modelgenerator/internal/CaptureTypeBasedSummaryModels.qll
@@ -178,7 +178,9 @@ private predicate output(Callable callable, TypeParameter tp, string output) {
 }
 
 private module ModelPrintingInput implements ModelPrintingSig {
-  class Api = TypeBasedFlowTargetApi;
+  class SummaryApi = TypeBasedFlowTargetApi;
+
+  class SourceOrSinkApi = TypeBasedFlowTargetApi;
 
   string getProvenance() { result = "tb-generated" }
 }

--- a/csharp/ql/test/utils/modelgenerator/dataflow/CaptureSinkModels.ext.yml
+++ b/csharp/ql/test/utils/modelgenerator/dataflow/CaptureSinkModels.ext.yml
@@ -4,6 +4,7 @@ extensions:
       extensible: sinkModel
     data:
       - [ "Sinks", "NewSinks", False, "Sink", "(System.Object)", "", "Argument[0]", "test-sink", "manual"]
+      - [ "Sinks", "NewSinks", False, "Sink2", "(System.Object)", "", "Argument[0]", "test-sink2", "manual"]
       - [ "Sinks", "NewSinks", False, "ManualSinkAlreadyDefined", "(System.Object)", "", "Argument[0]", "test-sink", "manual"]
 
   - addsTo:

--- a/csharp/ql/test/utils/modelgenerator/dataflow/CaptureSourceModels.ext.yml
+++ b/csharp/ql/test/utils/modelgenerator/dataflow/CaptureSourceModels.ext.yml
@@ -4,6 +4,8 @@ extensions:
       extensible: sourceModel
     data:
       - ["Sources", "NewSources", False, "ManualSourceAlreadyDefined", "()", "", "ReturnValue", "test-source", "manual"]
+      - ["Sources", "NewSources", False, "Source1", "()", "", "ReturnValue", "source-kind-1", "manual"]
+      - ["Sources", "NewSources", False, "Source2", "()", "", "ReturnValue", "source-kind-2", "manual"]
 
   - addsTo:
       pack: codeql/csharp-all

--- a/csharp/ql/test/utils/modelgenerator/dataflow/Sinks.cs
+++ b/csharp/ql/test/utils/modelgenerator/dataflow/Sinks.cs
@@ -118,7 +118,7 @@ public class NewSinks
 
     public class DataWriterKind1 : DataWriter
     {
-        // sink=Sinks;NewSinks+DataWriter;true;Write;(System.Object);;Argument[0];test-sink;df-generated
+        // sink=Sinks;NewSinks+DataWriterKind1;true;Write;(System.Object);;Argument[0];test-sink;df-generated
         // neutral=Sinks;NewSinks+DataWriterKind1;Write;(System.Object);summary;df-generated
         public override void Write(object o)
         {
@@ -128,7 +128,7 @@ public class NewSinks
 
     public class DataWriterKind2 : DataWriter
     {
-        // sink=Sinks;NewSinks+DataWriter;true;Write;(System.Object);;Argument[0];test-sink2;df-generated
+        // sink=Sinks;NewSinks+DataWriterKind2;true;Write;(System.Object);;Argument[0];test-sink2;df-generated
         // neutral=Sinks;NewSinks+DataWriterKind2;Write;(System.Object);summary;df-generated
         public override void Write(object o)
         {

--- a/csharp/ql/test/utils/modelgenerator/dataflow/Sinks.cs
+++ b/csharp/ql/test/utils/modelgenerator/dataflow/Sinks.cs
@@ -14,7 +14,11 @@ public class NewSinks
 
     // Sink defined in the extensible file next to the test.
     // neutral=Sinks;NewSinks;Sink;(System.Object);summary;df-generated
-    public void Sink(object o) => throw null;
+    public static void Sink(object o) => throw null;
+
+    // Sink defined in the extensible file next to the test.
+    // neutral=Sinks;NewSinks;Sink2;(System.Object);summary;df-generated
+    public static void Sink2(object o) => throw null;
 
     // New sink
     // sink=Sinks;NewSinks;false;WrapResponseWrite;(System.Object);;Argument[0];html-injection;df-generated
@@ -104,6 +108,32 @@ public class NewSinks
     public void ManualSinkAlreadyDefined(object o)
     {
         Sink(o);
+    }
+
+    public abstract class DataWriter
+    {
+        // neutral=Sinks;NewSinks+DataWriter;Write;(System.Object);summary;df-generated
+        public abstract void Write(object o);
+    }
+
+    public class DataWriterKind1 : DataWriter
+    {
+        // sink=Sinks;NewSinks+DataWriter;true;Write;(System.Object);;Argument[0];test-sink;df-generated
+        // neutral=Sinks;NewSinks+DataWriterKind1;Write;(System.Object);summary;df-generated
+        public override void Write(object o)
+        {
+            Sink(o);
+        }
+    }
+
+    public class DataWriterKind2 : DataWriter
+    {
+        // sink=Sinks;NewSinks+DataWriter;true;Write;(System.Object);;Argument[0];test-sink2;df-generated
+        // neutral=Sinks;NewSinks+DataWriterKind2;Write;(System.Object);summary;df-generated
+        public override void Write(object o)
+        {
+            Sink2(o);
+        }
     }
 }
 

--- a/csharp/ql/test/utils/modelgenerator/dataflow/Sources.cs
+++ b/csharp/ql/test/utils/modelgenerator/dataflow/Sources.cs
@@ -4,6 +4,15 @@ namespace Sources;
 
 public class NewSources
 {
+    // Defined as source in the extensions file next to the test.
+    // neutral=Sources;NewSources;Source1;();summary;df-generated 
+    public static string Source1() => throw null;
+
+    // Defined as source in the extensions file next to the test.
+    // neutral=Sources;NewSources;Source2;();summary;df-generated
+    public static string Source2() => throw null;
+
+
     // New source
     // source=Sources;NewSources;false;WrapConsoleReadLine;();;ReturnValue;local;df-generated
     // neutral=Sources;NewSources;WrapConsoleReadLine;();summary;df-generated
@@ -78,5 +87,31 @@ public class NewSources
     public string ManualSourceAlreadyDefined()
     {
         return Console.ReadLine();
+    }
+
+    public abstract class DataReader
+    {
+        // neutral=Sources;NewSources+DataReader;Read;();summary;df-generated
+        public abstract string Read();
+    }
+
+    public class DataReaderKind1 : DataReader
+    {
+        // source=Sources;NewSources+DataReader;true;Read;();;ReturnValue;source-kind-1;df-generated
+        // neutral=Sources;NewSources+DataReaderKind1;Read;();summary;df-generated
+        public override string Read()
+        {
+            return Source1();
+        }
+    }
+
+    public class DataReaderKind2 : DataReader
+    {
+        // source=Sources;NewSources+DataReader;true;Read;();;ReturnValue;source-kind-2;df-generated
+        // neutral=Sources;NewSources+DataReaderKind2;Read;();summary;df-generated
+        public override string Read()
+        {
+            return Source2();
+        }
     }
 }

--- a/csharp/ql/test/utils/modelgenerator/dataflow/Sources.cs
+++ b/csharp/ql/test/utils/modelgenerator/dataflow/Sources.cs
@@ -97,7 +97,7 @@ public class NewSources
 
     public class DataReaderKind1 : DataReader
     {
-        // source=Sources;NewSources+DataReader;true;Read;();;ReturnValue;source-kind-1;df-generated
+        // source=Sources;NewSources+DataReaderKind1;true;Read;();;ReturnValue;source-kind-1;df-generated
         // neutral=Sources;NewSources+DataReaderKind1;Read;();summary;df-generated
         public override string Read()
         {
@@ -107,7 +107,7 @@ public class NewSources
 
     public class DataReaderKind2 : DataReader
     {
-        // source=Sources;NewSources+DataReader;true;Read;();;ReturnValue;source-kind-2;df-generated
+        // source=Sources;NewSources+DataReaderKind2;true;Read;();;ReturnValue;source-kind-2;df-generated
         // neutral=Sources;NewSources+DataReaderKind2;Read;();summary;df-generated
         public override string Read()
         {

--- a/java/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -38,7 +38,9 @@ class DataFlowSourceTargetApi = SourceTargetApi;
 class DataFlowSinkTargetApi = SinkTargetApi;
 
 private module ModelPrintingInput implements ModelPrintingSig {
-  class Api = TargetApiBase;
+  class SummaryApi = DataFlowSummaryTargetApi;
+
+  class SourceOrSinkApi = SourceOrSinkTargetApi;
 
   string getProvenance() { result = "df-generated" }
 }

--- a/java/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
@@ -83,25 +83,25 @@ predicate isUninterestingForDataFlowModels(Callable api) {
 }
 
 /**
- * A class of callables that are potentially relevant for generating summary and
- * neutral models.
+ * A class of callables that are potentially relevant for generating source or
+ * sink models.
  */
-class SummaryTargetApi extends TargetApiBase {
-  SummaryTargetApi() { not hasManualSummaryModel(this.lift()) }
+class SourceOrSinkTargetApi extends Callable {
+  SourceOrSinkTargetApi() { relevant(this) }
 }
 
 /**
  * A class of callables that are potentially relevant for generating sink models.
  */
-class SinkTargetApi extends TargetApiBase {
-  SinkTargetApi() { not hasManualSinkModel(this.lift()) }
+class SinkTargetApi extends SourceOrSinkTargetApi {
+  SinkTargetApi() { not hasManualSinkModel(this) }
 }
 
 /**
  * A class of callables that are potentially relevant for generating source models.
  */
-class SourceTargetApi extends TargetApiBase {
-  SourceTargetApi() { not hasManualSourceModel(this.lift()) }
+class SourceTargetApi extends SourceOrSinkTargetApi {
+  SourceTargetApi() { not hasManualSourceModel(this) }
 }
 
 /**
@@ -112,16 +112,19 @@ class SourceTargetApi extends TargetApiBase {
 predicate isUninterestingForTypeBasedFlowModels(Callable api) { none() }
 
 /**
- * A class of callables that are potentially relevant for generating summary, source, sink
- * and neutral models.
+ * A class of callables that are potentially relevant for generating summary or
+ * neutral models.
  *
  * In the Standard library and 3rd party libraries it is the callables (or callables that have a
  * super implementation) that can be called from outside the library itself.
  */
-class TargetApiBase extends Callable {
+class SummaryTargetApi extends Callable {
   private Callable lift;
 
-  TargetApiBase() { lift = liftedImpl(this) }
+  SummaryTargetApi() {
+    lift = liftedImpl(this) and
+    not hasManualSummaryModel(lift)
+  }
 
   /**
    * Gets the callable that a model will be lifted to.

--- a/java/ql/src/utils/modelgenerator/internal/CaptureTypeBasedSummaryModels.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureTypeBasedSummaryModels.qll
@@ -284,7 +284,9 @@ private predicate output(Callable callable, TypeVariable tv, string output) {
 }
 
 module ModelPrintingInput implements ModelPrintingSig {
-  class Api = TypeBasedFlowTargetApi;
+  class SummaryApi = TypeBasedFlowTargetApi;
+
+  class SourceOrSinkApi = Specific::SourceOrSinkTargetApi;
 
   string getProvenance() { result = "tb-generated" }
 }

--- a/java/ql/test/utils/modelgenerator/dataflow/CaptureSinkModels.ext.yml
+++ b/java/ql/test/utils/modelgenerator/dataflow/CaptureSinkModels.ext.yml
@@ -5,6 +5,7 @@ extensions:
       extensible: sinkModel
     data:
       - [ "p", "Sinks", False, "sink", "(Object)", "", "Argument[0]", "test-sink", "manual" ]
+      - [ "p", "Sinks", False, "sink2", "(Object)", "", "Argument[0]", "test-sink2", "manual" ]
       - [ "p", "Sinks", False, "manualSinkAlreadyDefined", "(Object)", "", "Argument[0]", "test-sink", "manual" ]
 
   - addsTo:

--- a/java/ql/test/utils/modelgenerator/dataflow/CaptureSourceModels.ext.yml
+++ b/java/ql/test/utils/modelgenerator/dataflow/CaptureSourceModels.ext.yml
@@ -5,6 +5,7 @@ extensions:
       extensible: sourceModel
     data:
       - [ "p", "Sources", False, "source", "()", "", "ReturnValue", "test-source", "manual" ]
+      - [ "p", "Sources", False, "source2", "()", "", "ReturnValue", "test-source2", "manual" ]
       - [ "p", "Sources", False, "manualSourceAlreadyDefined", "()", "", "ReturnValue", "test-source", "manual" ]
 
   - addsTo:

--- a/java/ql/test/utils/modelgenerator/dataflow/p/ImplOfExternalSPI.java
+++ b/java/ql/test/utils/modelgenerator/dataflow/p/ImplOfExternalSPI.java
@@ -6,7 +6,7 @@ import java.nio.file.Files;
 
 public class ImplOfExternalSPI extends AbstractImplOfExternalSPI {
 
-  // sink=p;AbstractImplOfExternalSPI;true;accept;(File);;Argument[0];path-injection;df-generated
+  // sink=p;ImplOfExternalSPI;true;accept;(File);;Argument[0];path-injection;df-generated
   // neutral=p;ImplOfExternalSPI;accept;(File);summary;df-generated
   @Override
   public boolean accept(File pathname) {

--- a/java/ql/test/utils/modelgenerator/dataflow/p/PrivateFlowViaPublicInterface.java
+++ b/java/ql/test/utils/modelgenerator/dataflow/p/PrivateFlowViaPublicInterface.java
@@ -29,7 +29,6 @@ public class PrivateFlowViaPublicInterface {
     }
 
     // summary=p;PrivateFlowViaPublicInterface$SPI;true;openStream;();;Argument[this];ReturnValue;taint;df-generated
-    // sink=p;PrivateFlowViaPublicInterface$SPI;true;openStream;();;Argument[this];path-injection;df-generated
     @Override
     public OutputStream openStream() throws IOException {
       return new FileOutputStream(file);

--- a/java/ql/test/utils/modelgenerator/dataflow/p/Sinks.java
+++ b/java/ql/test/utils/modelgenerator/dataflow/p/Sinks.java
@@ -88,7 +88,7 @@ public class Sinks {
   }
 
   public class DataWriterKind1 extends DataWriter {
-    // sink=p;Sinks$DataWriter;true;write;(String);;Argument[0];test-sink;df-generated
+    // sink=p;Sinks$DataWriterKind1;true;write;(String);;Argument[0];test-sink;df-generated
     // neutral=p;Sinks$DataWriterKind1;write;(String);summary;df-generated
     @Override
     public void write(String s) {
@@ -97,7 +97,7 @@ public class Sinks {
   }
 
   public class DataWriterKind2 extends DataWriter {
-    // sink=p;Sinks$DataWriter;true;write;(String);;Argument[0];test-sink2;df-generated
+    // sink=p;Sinks$DataWriterKind2;true;write;(String);;Argument[0];test-sink2;df-generated
     // neutral=p;Sinks$DataWriterKind2;write;(String);summary;df-generated
     @Override
     public void write(String s) {

--- a/java/ql/test/utils/modelgenerator/dataflow/p/Sinks.java
+++ b/java/ql/test/utils/modelgenerator/dataflow/p/Sinks.java
@@ -17,6 +17,10 @@ public class Sinks {
   // neutral=p;Sinks;sink;(Object);summary;df-generated
   public void sink(Object o) {}
 
+  // Defined as a sink in the model file next to the test.
+  // neutral=p;Sinks;sink2;(Object);summary;df-generated
+  public void sink2(Object o) {}
+
   // sink=p;Sinks;true;copyFileToDirectory;(Path,Path,CopyOption[]);;Argument[0];path-injection;df-generated
   // sink=p;Sinks;true;copyFileToDirectory;(Path,Path,CopyOption[]);;Argument[1];path-injection;df-generated
   // neutral=p;Sinks;copyFileToDirectory;(Path,Path,CopyOption[]);summary;df-generated
@@ -76,5 +80,28 @@ public class Sinks {
   // neutral=p;Sinks;manualSinkAlreadyDefined;(Object);summary;df-generated
   public void manualSinkAlreadyDefined(Object o) {
     sink(o);
+  }
+
+  public abstract class DataWriter {
+    // neutral=p;Sinks$DataWriter;write;(String);summary;df-generated
+    public abstract void write(String s);
+  }
+
+  public class DataWriterKind1 extends DataWriter {
+    // sink=p;Sinks$DataWriter;true;write;(String);;Argument[0];test-sink;df-generated
+    // neutral=p;Sinks$DataWriterKind1;write;(String);summary;df-generated
+    @Override
+    public void write(String s) {
+      sink(s);
+    }
+  }
+
+  public class DataWriterKind2 extends DataWriter {
+    // sink=p;Sinks$DataWriter;true;write;(String);;Argument[0];test-sink2;df-generated
+    // neutral=p;Sinks$DataWriterKind2;write;(String);summary;df-generated
+    @Override
+    public void write(String s) {
+      sink2(s);
+    }
   }
 }

--- a/java/ql/test/utils/modelgenerator/dataflow/p/Sources.java
+++ b/java/ql/test/utils/modelgenerator/dataflow/p/Sources.java
@@ -14,6 +14,12 @@ public class Sources {
     return "";
   }
 
+  // Defined as a source in the model file next to the test.
+  // neutral=p;Sources;source2;();summary;df-generated
+  public String source2() {
+    return "";
+  }
+
   // source=p;Sources;true;readUrl;(URL);;ReturnValue;remote;df-generated
   // sink=p;Sources;true;readUrl;(URL);;Argument[0];request-forgery;df-generated
   // neutral=p;Sources;readUrl;(URL);summary;df-generated
@@ -78,5 +84,28 @@ public class Sources {
   // neutral=p;Sources;manualSourceAlreadyDefined;();summary;df-generated
   public String manualSourceAlreadyDefined() {
     return source();
+  }
+
+  public abstract class DataReader {
+    // neutral=p;Sources$DataReader;read;();summary;df-generated
+    public abstract String read();
+  }
+
+  public class DataReaderKind1 extends DataReader {
+    // source=p;Sources$DataReader;true;read;();;ReturnValue;test-source;df-generated
+    // neutral=p;Sources$DataReaderKind1;read;();summary;df-generated
+    @Override
+    public String read() {
+      return source();
+    }
+  }
+
+  public class DataReaderKind2 extends DataReader {
+    // source=p;Sources$DataReader;true;read;();;ReturnValue;test-source2;df-generated
+    // neutral=p;Sources$DataReaderKind2;read;();summary;df-generated
+    @Override
+    public String read() {
+      return source2();
+    }
   }
 }

--- a/java/ql/test/utils/modelgenerator/dataflow/p/Sources.java
+++ b/java/ql/test/utils/modelgenerator/dataflow/p/Sources.java
@@ -92,7 +92,7 @@ public class Sources {
   }
 
   public class DataReaderKind1 extends DataReader {
-    // source=p;Sources$DataReader;true;read;();;ReturnValue;test-source;df-generated
+    // source=p;Sources$DataReaderKind1;true;read;();;ReturnValue;test-source;df-generated
     // neutral=p;Sources$DataReaderKind1;read;();summary;df-generated
     @Override
     public String read() {
@@ -101,7 +101,7 @@ public class Sources {
   }
 
   public class DataReaderKind2 extends DataReader {
-    // source=p;Sources$DataReader;true;read;();;ReturnValue;test-source2;df-generated
+    // source=p;Sources$DataReaderKind2;true;read;();;ReturnValue;test-source2;df-generated
     // neutral=p;Sources$DataReaderKind2;read;();summary;df-generated
     @Override
     public String read() {

--- a/shared/mad/codeql/mad/modelgenerator/ModelPrinting.qll
+++ b/shared/mad/codeql/mad/modelgenerator/ModelPrinting.qll
@@ -19,9 +19,11 @@ module ModelPrintingImpl<ModelPrintingLangSig Lang> {
     /**
      * The class of APIs relevant for model generation.
      */
-    class Api extends Lang::Callable {
+    class SummaryApi extends Lang::Callable {
       Lang::Callable lift();
     }
+
+    class SourceOrSinkApi extends Lang::Callable;
 
     /**
      * Gets the string representation of the provenance of the models.
@@ -33,9 +35,9 @@ module ModelPrintingImpl<ModelPrintingLangSig Lang> {
     /**
      * Computes the first 6 columns for MaD rows used for summaries, sources and sinks.
      */
-    private string asPartialModel(Printing::Api api) {
+    private string asPartialModel(Lang::Callable api) {
       exists(string container, string type, string extensible, string name, string parameters |
-        Lang::partialModel(api.lift(), container, type, extensible, name, parameters) and
+        Lang::partialModel(api, container, type, extensible, name, parameters) and
         result =
           container + ";" //
             + type + ";" //
@@ -49,7 +51,7 @@ module ModelPrintingImpl<ModelPrintingLangSig Lang> {
     /**
      * Computes the first 4 columns for neutral MaD rows.
      */
-    private string asPartialNeutralModel(Printing::Api api) {
+    private string asPartialNeutralModel(Printing::SummaryApi api) {
       exists(string container, string type, string name, string parameters |
         Lang::partialModel(api, container, type, _, name, parameters) and
         result =
@@ -64,15 +66,15 @@ module ModelPrintingImpl<ModelPrintingLangSig Lang> {
      * Gets the summary model for `api` with `input`, `output` and `kind`.
      */
     bindingset[input, output, kind]
-    private string asSummaryModel(Printing::Api api, string input, string output, string kind) {
+    private string asSummaryModel(Printing::SummaryApi api, string input, string output, string kind) {
       result =
-        asPartialModel(api) + input + ";" //
+        asPartialModel(api.lift()) + input + ";" //
           + output + ";" //
           + kind + ";" //
           + Printing::getProvenance()
     }
 
-    string asNeutralSummaryModel(Printing::Api api) {
+    string asNeutralSummaryModel(Printing::SummaryApi api) {
       result =
         asPartialNeutralModel(api) //
           + "summary" + ";" //
@@ -83,7 +85,7 @@ module ModelPrintingImpl<ModelPrintingLangSig Lang> {
      * Gets the value summary model for `api` with `input` and `output`.
      */
     bindingset[input, output]
-    string asValueModel(Printing::Api api, string input, string output) {
+    string asValueModel(Printing::SummaryApi api, string input, string output) {
       result = asSummaryModel(api, input, output, "value")
     }
 
@@ -91,7 +93,7 @@ module ModelPrintingImpl<ModelPrintingLangSig Lang> {
      * Gets the taint summary model for `api` with `input` and `output`.
      */
     bindingset[input, output]
-    string asTaintModel(Printing::Api api, string input, string output) {
+    string asTaintModel(Printing::SummaryApi api, string input, string output) {
       result = asSummaryModel(api, input, output, "taint")
     }
 
@@ -99,7 +101,7 @@ module ModelPrintingImpl<ModelPrintingLangSig Lang> {
      * Gets the sink model for `api` with `input` and `kind`.
      */
     bindingset[input, kind]
-    string asSinkModel(Printing::Api api, string input, string kind) {
+    string asSinkModel(Printing::SourceOrSinkApi api, string input, string kind) {
       result =
         asPartialModel(api) + input + ";" //
           + kind + ";" //
@@ -110,7 +112,7 @@ module ModelPrintingImpl<ModelPrintingLangSig Lang> {
      * Gets the source model for `api` with `output` and `kind`.
      */
     bindingset[output, kind]
-    string asSourceModel(Printing::Api api, string output, string kind) {
+    string asSourceModel(Printing::SourceOrSinkApi api, string output, string kind) {
       result =
         asPartialModel(api) + output + ";" //
           + kind + ";" //


### PR DESCRIPTION
In this PR we re-write the model generator to lift sources and sinks due to the following reason:
Contrary to summaries - sources and sinks have more granular kinds. As an example, we could imagine an interface or abstract class for writing to a stream. Depending on the implementation the stream writer could write to maybe the console, a file, a database, a log, etc. which could all be of different kinds (of sinks). That is, if we are lifting sinks we would then get a union of these kinds and the prototype implementation would become a "universal" sink. A similar argument can be applied for sources.