### PR TITLE
Go: Add Go JOSE to library coverage frameworks

### DIFF
--- a/go/documentation/library-coverage/frameworks.csv
+++ b/go/documentation/library-coverage/frameworks.csv
@@ -8,6 +8,7 @@ Echo,https://echo.labstack.com/,github.com/labstack/echo*
 fasthttp,https://github.com/valyala/fasthttp,github.com/valyala/fasthttp*
 Fosite,https://github.com/ory/fosite,github.com/ory/fosite*
 Gin,https://github.com/gin-gonic/gin,github.com/gin-gonic/gin*
+Go JOSE,https://github.com/go-jose/go-jose,github.com/go-jose/go-jose* github.com/square/go-jose* gopkg.in/square/go-jose*
 Go kit,https://gokit.io/,github.com/go-kit/kit*
 go-pg,https://pg.uptrace.dev/,github.com/go-pg/pg*
 golang.org/x/net,https://pkg.go.dev/golang.org/x/net,golang.org/x/net*


### PR DESCRIPTION
Add Go JOSE to library coverage frameworks, so it doesn't just get lumped in the "other" category. The actual output files will be automatically updated after this is merged, so no need to do it in this PR. (It took me three goes to get the format right 😆 .)

Introduced in https://github.com/github/codeql/pull/15585.