### PR TITLE
Shared: Generate mermaid output in `View CFG` query

### DIFF
--- a/shared/controlflow/codeql/controlflow/Cfg.qll
+++ b/shared/controlflow/codeql/controlflow/Cfg.qll
@@ -1191,6 +1191,41 @@ module Make<LocationSig Location, InputSig<Location> Input> {
             )
         ).toString()
     }
+
+    module Mermaid {
+      private string nodeId(RelevantNode n) { nodes(n, "semmle.order", result) }
+
+      private string nodes() {
+        result =
+          concat(RelevantNode n, string id, string text |
+            id = nodeId(n) and
+            text = n.toString()
+          |
+            id + "[\"" + text + "\"]", "\n" order by id
+          )
+      }
+
+      private string edge(RelevantNode pred, RelevantNode succ, string ord) {
+        edges(pred, succ, "semmle.order", ord) and
+        exists(string label |
+          edges(pred, succ, "semmle.label", label) and
+          if label = ""
+          then result = nodeId(pred) + " --> " + nodeId(succ)
+          else result = nodeId(pred) + " -- " + label + " --> " + nodeId(succ)
+        )
+      }
+
+      private string edges() {
+        result =
+          concat(RelevantNode pred, RelevantNode succ, string edge, string ord |
+            edge = edge(pred, succ, ord)
+          |
+            edge, "\n" order by ord
+          )
+      }
+
+      query predicate mermaid(string s) { s = "flowchart TD\n" + nodes() + "\n\n" + edges() }
+    }
   }
 
   /** Provides the input to `ViewCfgQuery`. */
@@ -1263,6 +1298,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
     }
 
     import TestOutput<RelevantNode>
+    import Mermaid
   }
 
   /** Provides a set of consistency queries. */


### PR DESCRIPTION
Useful when you want to embed a CFG in a PR description, e.g.

```mermaid
flowchart TD
1["enter M4"]
10["[b (line 46): true] access to parameter x"]
11["access to parameter x"]
12["...--"]
13["[b (line 46): false] ...--"]
14["[b (line 46): true] ...--"]
15["... > ..."]
16["[b (line 46): false] ... > ..."]
17["[b (line 46): true] ... > ..."]
18["0"]
19["[b (line 46): false] 0"]
2["exit M4"]
20["[b (line 46): true] 0"]
21["[b (line 46): false] {...}"]
22["[b (line 46): true] {...}"]
23["{...}"]
24["[b (line 46): false] if (...) ..."]
25["[b (line 46): true] if (...) ..."]
26["if (...) ..."]
27["[b (line 46): false] access to parameter b"]
28["[b (line 46): true] access to parameter b"]
29["access to parameter b"]
3["exit M4 (normal)"]
30["[b (line 46): true] access to local variable y"]
31["[b (line 46): true] ...++"]
32["[b (line 46): true] ...;"]
33["return ...;"]
34["access to local variable y"]
4["{...}"]
5["... ...;"]
6["Int32 y = ..."]
7["0"]
8["while (...) ..."]
9["[b (line 46): false] access to parameter x"]

1 --> 4
10 --> 14
11 --> 12
12 --> 18
13 --> 19
14 --> 20
15 -- true --> 23
16 -- true --> 21
17 -- true --> 22
18 --> 15
19 --> 16
20 --> 17
21 --> 24
22 --> 25
23 --> 26
24 --> 27
25 --> 28
26 --> 29
27 -- false --> 9
28 -- true --> 32
29 -- false --> 9
3 --> 2
30 --> 31
31 --> 10
32 --> 30
33 -- return --> 3
34 --> 33
4 --> 5
5 --> 7
6 --> 8
7 --> 6
8 --> 11
9 --> 13
15 -- false --> 34
16 -- false --> 34
17 -- false --> 34
29 -- true --> 32
```