### PR TITLE
C#: Narrow source model generation.

### DIFF
--- a/csharp/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
+++ b/csharp/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
@@ -7,7 +7,6 @@ private import semmle.code.csharp.commons.Util as Util
 private import semmle.code.csharp.commons.Collections as Collections
 private import semmle.code.csharp.dataflow.internal.DataFlowDispatch
 private import semmle.code.csharp.dataflow.internal.FlowSummaryImpl as FlowSummaryImpl
-private import semmle.code.csharp.dispatch.OverridableCallable
 private import semmle.code.csharp.frameworks.system.linq.Expressions
 private import semmle.code.csharp.frameworks.System
 import semmle.code.csharp.dataflow.internal.ExternalFlow as ExternalFlow

--- a/csharp/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
+++ b/csharp/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
@@ -7,6 +7,7 @@ private import semmle.code.csharp.commons.Util as Util
 private import semmle.code.csharp.commons.Collections as Collections
 private import semmle.code.csharp.dataflow.internal.DataFlowDispatch
 private import semmle.code.csharp.dataflow.internal.FlowSummaryImpl as FlowSummaryImpl
+private import semmle.code.csharp.dispatch.OverridableCallable
 private import semmle.code.csharp.frameworks.system.linq.Expressions
 private import semmle.code.csharp.frameworks.System
 import semmle.code.csharp.dataflow.internal.ExternalFlow as ExternalFlow
@@ -130,7 +131,13 @@ class SinkTargetApi extends SourceOrSinkTargetApi {
  * A class of callables that are potentially relevant for generating source models.
  */
 class SourceTargetApi extends SourceOrSinkTargetApi {
-  SourceTargetApi() { not hasManualSourceModel(this) }
+  SourceTargetApi() {
+    not hasManualSourceModel(this) and
+    // Do not generate source models for overridable callables
+    // as virtual dispatch implies that too many methods
+    // will be considered sources.
+    not this.(Overridable).overridesOrImplements(_)
+  }
 }
 
 /**

--- a/csharp/ql/test/utils/modelgenerator/dataflow/Sources.cs
+++ b/csharp/ql/test/utils/modelgenerator/dataflow/Sources.cs
@@ -52,25 +52,39 @@ public class NewSources
         return s == "hello";
     }
 
-    public class MyConsoleReader
+    public abstract class ValueReader
     {
-        // source=Sources;NewSources+MyConsoleReader;false;ToString;();;ReturnValue;local;df-generated
-        // neutral=Sources;NewSources+MyConsoleReader;ToString;();summary;df-generated
-        public override string ToString()
+        // neutral=Sources;NewSources+ValueReader;GetValue;();summary;df-generated
+        public abstract string GetValue();
+    }
+
+    public class MyConsoleReader : ValueReader
+    {
+        // source=Sources;NewSources+MyConsoleReader;true;GetValue;();;ReturnValue;local;df-generated
+        // neutral=Sources;NewSources+MyConsoleReader;GetValue;();summary;df-generated
+        public override string GetValue()
         {
             return Console.ReadLine();
         }
     }
 
+    public class MyOtherReader : ValueReader
+    {
+        // neutral=Sources;NewSources+MyOtherReader;GetValue;();summary;df-generated
+        public override string GetValue()
+        {
+            return "";
+        }
+    }
 
-    public class MyContainer<T>
+    public class MyContainer<T> where T : ValueReader
     {
         public T Value { get; set; }
 
-        // summary=Sources;NewSources+MyContainer<T>;false;Read;();;Argument[this];ReturnValue;taint;df-generated
+        // neutral=Sources;NewSources+MyContainer<T>;Read;();summary;df-generated
         public string Read()
         {
-            return Value.ToString();
+            return Value.GetValue();
         }
     }
 
@@ -105,13 +119,34 @@ public class NewSources
         }
     }
 
-    public class DataReaderKind2 : DataReader
+    public sealed class DataReaderKind2 : DataReader
     {
-        // source=Sources;NewSources+DataReaderKind2;true;Read;();;ReturnValue;source-kind-2;df-generated
+        // source=Sources;NewSources+DataReaderKind2;false;Read;();;ReturnValue;source-kind-2;df-generated
         // neutral=Sources;NewSources+DataReaderKind2;Read;();summary;df-generated
         public override string Read()
         {
             return Source2();
         }
     }
+
+    public class C1
+    {
+        // source=Sources;NewSources+C1;false;ToString;();;ReturnValue;source-kind-1;df-generated
+        // neutral=Sources;NewSources+C1;ToString;();summary;df-generated
+        public override string ToString()
+        {
+            return Source1();
+        }
+    }
+
+    public sealed class C2
+    {
+        // source=Sources;NewSources+C2;false;ToString;();;ReturnValue;source-kind-1;df-generated
+        // neutral=Sources;NewSources+C2;ToString;();summary;df-generated
+        public override string ToString()
+        {
+            return Source1();
+        }
+    }
+
 }

--- a/csharp/ql/test/utils/modelgenerator/dataflow/Sources.cs
+++ b/csharp/ql/test/utils/modelgenerator/dataflow/Sources.cs
@@ -60,7 +60,6 @@ public class NewSources
 
     public class MyConsoleReader : ValueReader
     {
-        // source=Sources;NewSources+MyConsoleReader;true;GetValue;();;ReturnValue;local;df-generated
         // neutral=Sources;NewSources+MyConsoleReader;GetValue;();summary;df-generated
         public override string GetValue()
         {
@@ -111,7 +110,6 @@ public class NewSources
 
     public class DataReaderKind1 : DataReader
     {
-        // source=Sources;NewSources+DataReaderKind1;true;Read;();;ReturnValue;source-kind-1;df-generated
         // neutral=Sources;NewSources+DataReaderKind1;Read;();summary;df-generated
         public override string Read()
         {
@@ -121,7 +119,6 @@ public class NewSources
 
     public sealed class DataReaderKind2 : DataReader
     {
-        // source=Sources;NewSources+DataReaderKind2;false;Read;();;ReturnValue;source-kind-2;df-generated
         // neutral=Sources;NewSources+DataReaderKind2;Read;();summary;df-generated
         public override string Read()
         {
@@ -131,7 +128,6 @@ public class NewSources
 
     public class C1
     {
-        // source=Sources;NewSources+C1;false;ToString;();;ReturnValue;source-kind-1;df-generated
         // neutral=Sources;NewSources+C1;ToString;();summary;df-generated
         public override string ToString()
         {
@@ -141,7 +137,6 @@ public class NewSources
 
     public sealed class C2
     {
-        // source=Sources;NewSources+C2;false;ToString;();;ReturnValue;source-kind-1;df-generated
         // neutral=Sources;NewSources+C2;ToString;();summary;df-generated
         public override string ToString()
         {

--- a/misc/scripts/models-as-data/generate_flow_model.py
+++ b/misc/scripts/models-as-data/generate_flow_model.py
@@ -193,7 +193,7 @@ extensions:
             print("Models as data extensions generated, but not written to file.")
             sys.exit(0)
         
-        if self.generateSinks or self.generateSinks or self.generateSummaries:
+        if self.generateSinks or self.generateSources or self.generateSummaries or self.generateNeutrals:
             self.save(content, ".model.yml")
 
         if self.generateTypeBasedSummaries:


### PR DESCRIPTION
In this PR we further narrow the C# source model generation to exclude all callables that overrides or implements something else. This is because we need to "limit" the number of generated sources models that could be used during dynamic dispatch (to avoid getting to many false positive/speculative results).