### PR TITLE
Python: Add Hardcoded Credentials MaD support

### DIFF
--- a/python/ql/src/Security/CWE-798/HardcodedCredentials.ql
+++ b/python/ql/src/Security/CWE-798/HardcodedCredentials.ql
@@ -81,7 +81,10 @@ class HardcodedValueSource extends DataFlow::Node {
 
 class CredentialSink extends DataFlow::Node {
   CredentialSink() {
-    this = ModelOutput::getASinkNode("credentials-hardcoded").asSink()
+    exists(string s | s.matches("credentials-%") |
+      // Actual sink-type will be things like `credentials-password` or `credentials-username`
+      this = ModelOutput::getASinkNode(s).asSink()
+    )
     or
     exists(string name |
       name.regexpMatch(getACredentialRegex()) and

--- a/python/ql/src/Security/CWE-798/HardcodedCredentials.ql
+++ b/python/ql/src/Security/CWE-798/HardcodedCredentials.ql
@@ -18,6 +18,7 @@ import semmle.python.dataflow.new.TaintTracking
 import semmle.python.filters.Tests
 private import semmle.python.dataflow.new.internal.DataFlowDispatch as DataFlowDispatch
 private import semmle.python.dataflow.new.internal.Builtins::Builtins as Builtins
+private import semmle.python.frameworks.data.ModelsAsData
 
 bindingset[char, fraction]
 predicate fewer_characters_than(StringLiteral str, string char, float fraction) {
@@ -80,6 +81,8 @@ class HardcodedValueSource extends DataFlow::Node {
 
 class CredentialSink extends DataFlow::Node {
   CredentialSink() {
+    this = ModelOutput::getASinkNode("credentials-hardcoded").asSink()
+    or
     exists(string name |
       name.regexpMatch(getACredentialRegex()) and
       not name.matches("%file")

--- a/python/ql/src/change-notes/2024-06-28-cred-hardcoded.md
+++ b/python/ql/src/change-notes/2024-06-28-cred-hardcoded.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Adding Python support for Hardcoded Credentials as Models as Data


### PR DESCRIPTION
Adding in support for Hardcoded Credentials sinks as Models as Data Extensions.

This should match the spec defined in the MaD Shared library:

https://github.com/github/codeql/blob/main/shared/mad/codeql/mad/ModelValidation.qll#L51

My goal is to make it easier for us to add Hardcoded Credential sinks as Models as Data for frameworks / libraries such as Database Controllers, etc.
