### PR TITLE
C++: Update QLDoc on `GuardCondition`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/controlflow/IRGuards.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/IRGuards.qll
@@ -59,8 +59,7 @@ class MatchValue extends AbstractValue, TMatchValue {
 }
 
 /**
- * A Boolean condition in the AST that guards one or more basic blocks. This includes
- * operands of logical operators but not switch statements.
+ * A Boolean condition in the AST that guards one or more basic blocks.
  */
 cached
 class GuardCondition extends Expr {

--- a/cpp/ql/lib/semmle/code/cpp/controlflow/IRGuards.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/IRGuards.qll
@@ -365,10 +365,10 @@ private predicate nonExcludedIRAndBasicBlock(IRBlock irb, BasicBlock controlled)
 }
 
 /**
- * A Boolean condition in the IR that guards one or more basic blocks. This includes
- * operands of logical operators but not switch statements. Note that `&&` and `||`
- * don't have an explicit representation in the IR, and therefore will not appear as
- * IRGuardConditions.
+ * A Boolean condition in the IR that guards one or more basic blocks.
+ *
+ * Note that `&&` and `||` don't have an explicit representation in the IR,
+ * and therefore will not appear as IRGuardConditions.
  */
 cached
 class IRGuardCondition extends Instruction {


### PR DESCRIPTION
This was causing some confusion [here](https://github.com/github/codeql/discussions/16890).

Support for `switch` statements was added in https://github.com/github/codeql/pull/15941.