### PR TITLE
C#: Fix glob pattern processing: allow `**/` to match empty string

### DIFF
--- a/csharp/extractor/Semmle.Extraction.Tests/FilePattern.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/FilePattern.cs
@@ -10,13 +10,15 @@ namespace Semmle.Extraction.Tests
             var fp = new FilePattern("/hadoop*");
             Assert.Equal("^hadoop[^/]*.*", fp.RegexPattern);
             fp = new FilePattern("**/org/apache/hadoop");
-            Assert.Equal("^.*/org/apache/hadoop.*", fp.RegexPattern);
+            Assert.Equal("^(.*/|)org/apache/hadoop.*", fp.RegexPattern);
             fp = new FilePattern("hadoop-common/**/test//    ");
-            Assert.Equal("^hadoop-common/.*/test(?<doubleslash>/).*", fp.RegexPattern);
+            Assert.Equal("^hadoop-common/(.*/|)test(?<doubleslash>/).*", fp.RegexPattern);
             fp = new FilePattern(@"-C:\agent\root\asdf//");
             Assert.Equal("^C:/agent/root/asdf(?<doubleslash>/).*", fp.RegexPattern);
             fp = new FilePattern(@"-C:\agent+\[root]\asdf//");
             Assert.Equal(@"^C:/agent\+/\[root]/asdf(?<doubleslash>/).*", fp.RegexPattern);
+            fp = new FilePattern(@"**/**/abc/**/def/**");
+            Assert.Equal(@"^(.*/|)(.*/|)abc/(.*/|)def/.*", fp.RegexPattern);
         }
 
         [Fact]

--- a/csharp/extractor/Semmle.Extraction/FilePattern.cs
+++ b/csharp/extractor/Semmle.Extraction/FilePattern.cs
@@ -80,15 +80,15 @@ namespace Semmle.Extraction
                         if (i + 2 < pattern.Length)
                         {
                             // Processing .../**/...
+                            //                ^^^
                             sb.Append("(.*/|)");
                             i += 3;
                         }
                         else
                         {
-                            // Processing .../**
-                            sb.Append(".*");
-                            // There's no need to add another .* to the end outside the loop, we can return early.
-                            return sb;
+                            // Processing .../** at the end of the pattern.
+                            // There's no need to add .* because it's anyways added outside the loop.
+                            break;
                         }
                     }
                     else

--- a/csharp/extractor/Semmle.Extraction/FilePattern.cs
+++ b/csharp/extractor/Semmle.Extraction/FilePattern.cs
@@ -76,8 +76,20 @@ namespace Semmle.Extraction
                             throw new InvalidFilePatternException(pattern, "'**' preceeded by non-`/` character.");
                         if (HasCharAt(i + 2, c => c != '/'))
                             throw new InvalidFilePatternException(pattern, "'**' succeeded by non-`/` character");
-                        sb.Append(".*");
-                        i += 2;
+
+                        if (i + 2 < pattern.Length)
+                        {
+                            // Processing .../**/...
+                            sb.Append("(.*/|)");
+                            i += 3;
+                        }
+                        else
+                        {
+                            // Processing .../**
+                            sb.Append(".*");
+                            // There's no need to add another .* to the end outside the loop, we can return early.
+                            return sb;
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
This PR adjusts the path include/exclude logic to allow `**/` to match an empty string. This means that `**/src/` will match the content of the `src` folder in the root of the repository, while previously it only matched `src` folders in subdirectories.