### PR TITLE
Python: Exclude probable test files in model editor

### DIFF
--- a/python/ql/lib/modeling/Util.qll
+++ b/python/ql/lib/modeling/Util.qll
@@ -6,11 +6,22 @@ private import python
 private import semmle.python.ApiGraphs
 private import semmle.python.filters.Tests
 
+/**
+ * A file that probably contains tests.
+ */
+class TestFile extends File {
+  TestFile() {
+    this.getRelativePath().regexpMatch(".*(test|spec|examples).+") and
+    not this.getAbsolutePath().matches("%/ql/test/%") // allows our test cases to work
+  }
+}
+
 /** A class to represent scopes that the user might want to model. */
 class RelevantScope extends Scope {
   RelevantScope() {
     this.isPublic() and
     not this instanceof TestScope and
+    not this.getLocation().getFile() instanceof TestFile and
     exists(this.getLocation().getFile().getRelativePath())
   }
 }


### PR DESCRIPTION
Currently, the model editor query for Python includes a lot of endpoints that are irrelevant for modeling because they are part of the tests of the package that is being modeled. For example, for `django/django` [this file](https://github.com/django/django/blob/f302343380c77e1eb5dab3b64dd70895a95926ca/tests/auth_tests/client.py) is included, which is irrelevant for modeling. Therefore, this PR introduces [the same mechanism that is used in Ruby](https://github.com/github/codeql/blob/779795b4213d8c8d7d1b24548fe5dbd7111411a4/ruby/ql/src/queries/modeling/internal/Util.qll#L8-L15) for excluding endpoints in files which are probably part of the package's tests.