### PR TITLE
C++: Add `cpp/iterator-to-expired-container` FP test

### DIFF
--- a/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/IteratorToExpiredContainer/IteratorToExpiredContainer.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/IteratorToExpiredContainer/IteratorToExpiredContainer.expected
@@ -3,3 +3,4 @@
 | test.cpp:702:27:702:27 | call to operator[] | This object is destroyed at the end of the full-expression. |
 | test.cpp:727:23:727:23 | call to operator[] | This object is destroyed at the end of the full-expression. |
 | test.cpp:735:23:735:23 | call to operator[] | This object is destroyed at the end of the full-expression. |
+| test.cpp:826:25:826:43 | pointer to ~HasBeginAndEnd output argument | This object is destroyed at the end of the full-expression. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/IteratorToExpiredContainer/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/IteratorToExpiredContainer/test.cpp
@@ -802,3 +802,29 @@ void test5(int i)
     ++i;
   } // GOOD
 }
+
+struct HasBeginAndEnd
+{
+  ~HasBeginAndEnd();
+  using value_type = int;
+  using difference_type = std::ptrdiff_t;
+  using pointer = int*;
+  using reference = int&;
+  using iterator_category = std::random_access_iterator_tag;
+  std::vector<int>::iterator begin() const;
+  std::vector<int>::iterator end() const;
+};
+
+HasBeginAndEnd getHasBeginAndEnd();
+
+bool getBool();
+
+void test6()
+{
+  while(getBool())
+  {
+    for (const int& x : getHasBeginAndEnd()) // GOOD [FALSE POSITIVE]
+    {
+    }
+  }
+}


### PR DESCRIPTION
This represents the last class of FPs we're seeing on this query on MRVA 🤞

I haven't understood what happens yet. But at least I now have a reduced testcase!