### PR TITLE
Java: Improve Android app detection

### DIFF
--- a/java/ql/lib/change-notes/2024-06-12-isandroid-deprecated.md
+++ b/java/ql/lib/change-notes/2024-06-12-isandroid-deprecated.md
@@ -1,0 +1,4 @@
+---
+category: deprecated
+---
+* The predicate `isAndroid` from the module `semmle.code.java.security.AndroidCertificatePinningQuery` has been deprecated. Use `semmle.code.java.frameworks.android.Android::inAndroidApplication(File file)` instead.

--- a/java/ql/lib/change-notes/2024-06-12-isandroid-deprecated.md
+++ b/java/ql/lib/change-notes/2024-06-12-isandroid-deprecated.md
@@ -1,4 +1,4 @@
 ---
 category: deprecated
 ---
-* The predicate `isAndroid` from the module `semmle.code.java.security.AndroidCertificatePinningQuery` has been deprecated. Use `semmle.code.java.frameworks.android.Android::inAndroidApplication(File file)` instead.
+* The predicate `isAndroid` from the module `semmle.code.java.security.AndroidCertificatePinningQuery` has been deprecated. Use `semmle.code.java.frameworks.android.Android::inAndroidApplication(File)` instead.

--- a/java/ql/lib/semmle/code/java/frameworks/android/Android.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/Android.qll
@@ -5,8 +5,24 @@
 import java
 private import semmle.code.xml.AndroidManifest
 
-/** Holds if this database is of an Android application. */
-predicate isAndroid() { exists(AndroidManifestXmlFile m) }
+/**
+ * There is an android manifest file which defines an activity, service or
+ * content provider (so it corresponds to an android application rather than a
+ * library), and `file` is in a subfolder of the folder that contains it.
+ */
+predicate inAndroidApplication(File file) {
+  file.isSourceFile() and
+  exists(AndroidComponentXmlElement acxe, AndroidManifestXmlFile amxf |
+    amxf.getManifestElement().getApplicationElement().getAComponentElement() = acxe and
+    (
+      acxe instanceof AndroidActivityXmlElement or
+      acxe instanceof AndroidServiceXmlElement or
+      acxe instanceof AndroidProviderXmlElement
+    )
+  |
+    file.getParentContainer+() = amxf.getParentContainer()
+  )
+}
 
 /**
  * Gets a reflexive/transitive superType

--- a/java/ql/lib/semmle/code/java/frameworks/android/Android.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/Android.qll
@@ -6,21 +6,16 @@ import java
 private import semmle.code.xml.AndroidManifest
 
 /**
- * There is an android manifest file which defines an activity, service or
- * content provider (so it corresponds to an android application rather than a
- * library), and `file` is in a subfolder of the folder that contains it.
+ * Holds if in `file`'s directory or some parent directory there is an `AndroidManifestXmlFile`
+ * that defines at least one activity, service or contest provider, suggesting this file is
+ * part of an android application.
  */
 predicate inAndroidApplication(File file) {
   file.isSourceFile() and
-  exists(AndroidComponentXmlElement acxe, AndroidManifestXmlFile amxf |
-    amxf.getManifestElement().getApplicationElement().getAComponentElement() = acxe and
-    (
-      acxe instanceof AndroidActivityXmlElement or
-      acxe instanceof AndroidServiceXmlElement or
-      acxe instanceof AndroidProviderXmlElement
-    )
+  exists(AndroidManifestXmlFile amxf, Folder amxfDir |
+    amxf.definesAndroidApplication() and amxfDir = amxf.getParentContainer()
   |
-    file.getParentContainer+() = amxf.getParentContainer()
+    file.getParentContainer+() = amxfDir
   )
 }
 

--- a/java/ql/lib/semmle/code/java/frameworks/android/Android.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/Android.qll
@@ -5,6 +5,9 @@
 import java
 private import semmle.code.xml.AndroidManifest
 
+/** Holds if this database is of an Android application. */
+predicate isAndroid() { exists(AndroidManifestXmlFile m) }
+
 /**
  * Gets a reflexive/transitive superType
  */

--- a/java/ql/lib/semmle/code/java/security/AndroidCertificatePinningQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/AndroidCertificatePinningQuery.qll
@@ -6,6 +6,7 @@ import semmle.code.java.dataflow.TaintTracking
 import semmle.code.java.frameworks.Networking
 import semmle.code.java.security.Encryption
 import semmle.code.java.security.HttpsUrls
+private import semmle.code.java.frameworks.android.Android as Android
 
 /** An Android Network Security Configuration XML file. */
 class AndroidNetworkSecurityConfigFile extends XmlFile {
@@ -19,8 +20,12 @@ class AndroidNetworkSecurityConfigFile extends XmlFile {
   }
 }
 
-/** Holds if this database is of an Android application. */
-predicate isAndroid() { exists(AndroidManifestXmlFile m) }
+/**
+ * DEPRECATED. Use `semmle.code.java.frameworks.android.Android::isAndroid` instead.
+ *
+ * Holds if this database is of an Android application.
+ */
+deprecated predicate isAndroid() { Android::isAndroid() }
 
 /** Holds if the given domain name is trusted by the Network Security Configuration XML file. */
 private predicate trustedDomainViaXml(string domainName) {
@@ -122,7 +127,7 @@ private module UntrustedUrlFlow = TaintTracking::Global<UntrustedUrlConfig>;
 
 /** Holds if `node` is a network communication call for which certificate pinning is not implemented. */
 predicate missingPinning(MissingPinningSink node, string domain) {
-  isAndroid() and
+  Android::isAndroid() and
   exists(DataFlow::Node src | UntrustedUrlFlow::flow(src, node) |
     if trustedDomain(_) then domain = getDomain(src.asExpr()) else domain = ""
   )

--- a/java/ql/lib/semmle/code/java/security/AndroidCertificatePinningQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/AndroidCertificatePinningQuery.qll
@@ -6,7 +6,7 @@ import semmle.code.java.dataflow.TaintTracking
 import semmle.code.java.frameworks.Networking
 import semmle.code.java.security.Encryption
 import semmle.code.java.security.HttpsUrls
-private import semmle.code.java.frameworks.android.Android as Android
+private import semmle.code.java.frameworks.android.Android
 
 /** An Android Network Security Configuration XML file. */
 class AndroidNetworkSecurityConfigFile extends XmlFile {
@@ -21,11 +21,11 @@ class AndroidNetworkSecurityConfigFile extends XmlFile {
 }
 
 /**
- * DEPRECATED. Use `semmle.code.java.frameworks.android.Android::isAndroid` instead.
+ * DEPRECATED. Use `semmle.code.java.frameworks.android.Android::inAndroidApplication` instead.
  *
- * Holds if this database is of an Android application.
+ * Holds if this database contains an Android manifest file.
  */
-deprecated predicate isAndroid() { Android::isAndroid() }
+deprecated predicate isAndroid() { exists(AndroidManifestXmlFile m) }
 
 /** Holds if the given domain name is trusted by the Network Security Configuration XML file. */
 private predicate trustedDomainViaXml(string domainName) {
@@ -127,7 +127,7 @@ private module UntrustedUrlFlow = TaintTracking::Global<UntrustedUrlConfig>;
 
 /** Holds if `node` is a network communication call for which certificate pinning is not implemented. */
 predicate missingPinning(MissingPinningSink node, string domain) {
-  Android::isAndroid() and
+  inAndroidApplication(node.getLocation().getFile()) and
   exists(DataFlow::Node src | UntrustedUrlFlow::flow(src, node) |
     if trustedDomain(_) then domain = getDomain(src.asExpr()) else domain = ""
   )

--- a/java/ql/lib/semmle/code/java/security/CleartextStorageAndroidFilesystemQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/CleartextStorageAndroidFilesystemQuery.qll
@@ -14,7 +14,7 @@ private import semmle.code.java.frameworks.android.Android
 private class AndroidFilesystemCleartextStorageSink extends CleartextStorageSink {
   AndroidFilesystemCleartextStorageSink() {
     filesystemInput(_, this.asExpr()) and
-    isAndroid()
+    inAndroidApplication(this.getLocation().getFile())
   }
 }
 

--- a/java/ql/lib/semmle/code/java/security/CleartextStorageAndroidFilesystemQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/CleartextStorageAndroidFilesystemQuery.qll
@@ -6,16 +6,15 @@
 import java
 import semmle.code.java.dataflow.DataFlow
 import semmle.code.java.security.CleartextStorageQuery
-import semmle.code.xml.AndroidManifest
 private import semmle.code.java.dataflow.ExternalFlow
 private import semmle.code.java.dataflow.FlowSinks
 private import semmle.code.java.dataflow.FlowSources
+private import semmle.code.java.frameworks.android.Android
 
 private class AndroidFilesystemCleartextStorageSink extends CleartextStorageSink {
   AndroidFilesystemCleartextStorageSink() {
     filesystemInput(_, this.asExpr()) and
-    // Make sure we are in an Android application.
-    exists(AndroidManifestXmlFile manifest)
+    isAndroid()
   }
 }
 

--- a/java/ql/lib/semmle/code/xml/AndroidManifest.qll
+++ b/java/ql/lib/semmle/code/xml/AndroidManifest.qll
@@ -23,6 +23,21 @@ class AndroidManifestXmlFile extends XmlFile {
    * Holds if this Android manifest file is located in a build directory.
    */
   predicate isInBuildDirectory() { this.getFile().getRelativePath().matches("%build%") }
+
+  /**
+   * Holds if `amxf` defines at least one activity, service or contest provider,
+   * and so it corresponds to an android application rather than a library.
+   */
+  predicate definesAndroidApplication() {
+    exists(AndroidComponentXmlElement acxe |
+      this.getManifestElement().getApplicationElement().getAComponentElement() = acxe and
+      (
+        acxe instanceof AndroidActivityXmlElement or
+        acxe instanceof AndroidServiceXmlElement or
+        acxe instanceof AndroidProviderXmlElement
+      )
+    )
+  }
 }
 
 /**

--- a/java/ql/lib/semmle/code/xml/AndroidManifest.qll
+++ b/java/ql/lib/semmle/code/xml/AndroidManifest.qll
@@ -25,7 +25,7 @@ class AndroidManifestXmlFile extends XmlFile {
   predicate isInBuildDirectory() { this.getFile().getRelativePath().matches("%build%") }
 
   /**
-   * Holds if `amxf` defines at least one activity, service or contest provider,
+   * Holds if this file defines at least one activity, service or contest provider,
    * and so it corresponds to an android application rather than a library.
    */
   predicate definesAndroidApplication() {

--- a/java/ql/src/change-notes/2024-07-07-android-application-heuristic-updated.md
+++ b/java/ql/src/change-notes/2024-07-07-android-application-heuristic-updated.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The heuristic to enable certain Android queries has been improved. Now it ignores Android Manifests which don't define an activity, content provider or service. We also only consider files which are under a folder containing such an Android Manifest for these queries. This should remove some false positive alerts.

--- a/java/ql/test/query-tests/security/CWE-295/AndroidMissingCertificatePinning/Test1/AndroidManifest.xml
+++ b/java/ql/test/query-tests/security/CWE-295/AndroidMissingCertificatePinning/Test1/AndroidManifest.xml
@@ -5,6 +5,12 @@
     android:versionName="0.1" >
 
     <application android:networkSecurityConfig="@xml/NetworkSecurityConfig">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/java/ql/test/query-tests/security/CWE-295/AndroidMissingCertificatePinning/Test2/AndroidManifest.xml
+++ b/java/ql/test/query-tests/security/CWE-295/AndroidMissingCertificatePinning/Test2/AndroidManifest.xml
@@ -5,6 +5,12 @@
     android:versionName="0.1" >
 
     <application android:networkSecurityConfig="@xml/NetworkSecurityConfig">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/java/ql/test/query-tests/security/CWE-295/AndroidMissingCertificatePinning/Test3/AndroidManifest.xml
+++ b/java/ql/test/query-tests/security/CWE-295/AndroidMissingCertificatePinning/Test3/AndroidManifest.xml
@@ -5,6 +5,12 @@
     android:versionName="0.1" >
 
     <application android:networkSecurityConfig="@xml/NetworkSecurityConfig">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/java/ql/test/query-tests/security/CWE-295/AndroidMissingCertificatePinning/Test4/AndroidManifest.xml
+++ b/java/ql/test/query-tests/security/CWE-295/AndroidMissingCertificatePinning/Test4/AndroidManifest.xml
@@ -5,6 +5,12 @@
     android:versionName="0.1" >
 
     <application android:networkSecurityConfig="@xml/NetworkSecurityConfig">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>


### PR DESCRIPTION
This change improves the detection of Android apps in the CodeQL Java standard library. It moves the detection of Android apps to one place and updates the detection to be more accurate. Previously we just required the presence of a `AndroidManifest.xml` file anywhere in the project. This PR improves that in two ways:

- the `AndroidManifest.xml` file must define an activity, service or  content provider (so it corresponds to an android application rather than a library);
- we only consider files in an android application if they are under a folder that contains such an `AndroidManifest.xml`.

[These](https://gist.github.com/owen-mc/99b0dfa1144d25c7bafa5041d9892946) are the results for "[Android missing certificate pinning](https://github.com/github/codeql/blob/main/java/ql/src/Security/CWE/CWE-295/AndroidMissingCertificatePinning.ql)" which are removed by this change. I have spot-checked them and they seemed valid.