### PR TITLE
C++: Fix `cpp/iterator-to-expired-container` FPs

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/calls-as-ssa-variables/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/calls-as-ssa-variables/test.cpp
@@ -1,0 +1,29 @@
+namespace std
+{
+  struct ptrdiff_t;
+  struct input_iterator_tag
+  {
+  };
+  struct forward_iterator_tag : public input_iterator_tag
+  {
+  };
+}
+
+struct A
+{
+  using value_type = int;
+  using difference_type = std::ptrdiff_t;
+  using pointer = int*;
+  using reference = int&;
+  using iterator_category = std::forward_iterator_tag;
+};
+
+A get();
+
+void test()
+{
+  while (true)
+  {
+    auto &&x = get();
+  }
+}

--- a/cpp/ql/test/library-tests/dataflow/calls-as-ssa-variables/test.expected
+++ b/cpp/ql/test/library-tests/dataflow/calls-as-ssa-variables/test.expected
@@ -1,12 +1,4 @@
 edges
-| test.cpp:27:16:27:18 | call to get | test.cpp:27:16:27:18 | call to get | provenance |  |
-| test.cpp:27:16:27:18 | call to get | test.cpp:27:16:27:18 | call to get | provenance |  |
-| test.cpp:27:16:27:20 | call to get | test.cpp:27:16:27:18 | call to get | provenance |  |
-| test.cpp:27:16:27:20 | call to get | test.cpp:27:16:27:18 | call to get | provenance |  |
 nodes
-| test.cpp:27:16:27:18 | call to get | semmle.label | call to get |
-| test.cpp:27:16:27:18 | call to get | semmle.label | call to get |
-| test.cpp:27:16:27:20 | call to get | semmle.label | call to get |
 subpaths
 #select
-| test.cpp:27:16:27:18 | call to get | test.cpp:27:16:27:20 | call to get | test.cpp:27:16:27:18 | call to get |  |

--- a/cpp/ql/test/library-tests/dataflow/calls-as-ssa-variables/test.expected
+++ b/cpp/ql/test/library-tests/dataflow/calls-as-ssa-variables/test.expected
@@ -1,0 +1,12 @@
+edges
+| test.cpp:27:16:27:18 | call to get | test.cpp:27:16:27:18 | call to get | provenance |  |
+| test.cpp:27:16:27:18 | call to get | test.cpp:27:16:27:18 | call to get | provenance |  |
+| test.cpp:27:16:27:20 | call to get | test.cpp:27:16:27:18 | call to get | provenance |  |
+| test.cpp:27:16:27:20 | call to get | test.cpp:27:16:27:18 | call to get | provenance |  |
+nodes
+| test.cpp:27:16:27:18 | call to get | semmle.label | call to get |
+| test.cpp:27:16:27:18 | call to get | semmle.label | call to get |
+| test.cpp:27:16:27:20 | call to get | semmle.label | call to get |
+subpaths
+#select
+| test.cpp:27:16:27:18 | call to get | test.cpp:27:16:27:20 | call to get | test.cpp:27:16:27:18 | call to get |  |

--- a/cpp/ql/test/library-tests/dataflow/calls-as-ssa-variables/test.ql
+++ b/cpp/ql/test/library-tests/dataflow/calls-as-ssa-variables/test.ql
@@ -1,0 +1,23 @@
+/**
+ * @kind path-problem
+ */
+
+import semmle.code.cpp.ir.IR
+import semmle.code.cpp.dataflow.new.DataFlow
+import Flow::PathGraph
+
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) {
+    source.asInstruction().(VariableAddressInstruction).getIRVariable() instanceof IRTempVariable
+  }
+
+  predicate isSink(DataFlow::Node sink) {
+    sink.asInstruction().(CallInstruction).getStaticCallTarget().hasName("get")
+  }
+}
+
+module Flow = DataFlow::Global<Config>;
+
+from Flow::PathNode source, Flow::PathNode sink
+where Flow::flowPath(source, sink)
+select sink.getNode(), source, sink, ""

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/IteratorToExpiredContainer/IteratorToExpiredContainer.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/IteratorToExpiredContainer/IteratorToExpiredContainer.expected
@@ -3,4 +3,3 @@
 | test.cpp:702:27:702:27 | call to operator[] | This object is destroyed at the end of the full-expression. |
 | test.cpp:727:23:727:23 | call to operator[] | This object is destroyed at the end of the full-expression. |
 | test.cpp:735:23:735:23 | call to operator[] | This object is destroyed at the end of the full-expression. |
-| test.cpp:826:25:826:43 | pointer to ~HasBeginAndEnd output argument | This object is destroyed at the end of the full-expression. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/IteratorToExpiredContainer/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/IteratorToExpiredContainer/test.cpp
@@ -823,7 +823,7 @@ void test6()
 {
   while(getBool())
   {
-    for (const int& x : getHasBeginAndEnd()) // GOOD [FALSE POSITIVE]
+    for (const int& x : getHasBeginAndEnd()) // GOOD
     {
     }
   }


### PR DESCRIPTION
We were missing a definition of the "address" of a SSA variable when the variable was represented by a call instruction. This was causing FPs on `cpp/iterator-to-expired-container` on some projects.

This fixes the FP added in https://github.com/github/codeql/pull/16913.

The removed result on `cpp/type-confusion` is also a FP that's now gone 🎉