### PR TITLE
Kotlin: make wrapper cache downloaded zips

### DIFF
--- a/java/kotlin-extractor/dev/.gitignore
+++ b/java/kotlin-extractor/dev/.gitignore
@@ -1,2 +1,1 @@
-/.kotlinc_version
-/.kotlinc_installed
+/.kotlinc_*


### PR DESCRIPTION
Also removed the version check step, as a version not existing will give a 404 any way later on, and that was adding a delay.

The cache is stored in a `.kotlinc_zips` and will be cleaned up by `--clear`.

Closes https://github.com/github/code-scanning-internal-dx-team/issues/694