### PR TITLE
Go: Add environment variable to include `vendor` directories in extraction

### DIFF
--- a/go/ql/integration-tests/all-platforms/go/extract-vendor/build-environment.expected
+++ b/go/ql/integration-tests/all-platforms/go/extract-vendor/build-environment.expected
@@ -1,0 +1,5 @@
+{
+  "configuration" : {
+    "go" : { }
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/extract-vendor/diagnostics.expected
+++ b/go/ql/integration-tests/all-platforms/go/extract-vendor/diagnostics.expected
@@ -1,0 +1,14 @@
+{
+  "markdownMessage": "A single `go.mod` file was found.\n\n`go.mod`",
+  "severity": "note",
+  "source": {
+    "extractorName": "go",
+    "id": "go/autobuilder/single-root-go-mod-found",
+    "name": "A single `go.mod` file was found in the root"
+  },
+  "visibility": {
+    "cliSummaryTable": false,
+    "statusPage": false,
+    "telemetry": true
+  }
+}

--- a/go/ql/integration-tests/all-platforms/go/extract-vendor/force_sequential_test_execution
+++ b/go/ql/integration-tests/all-platforms/go/extract-vendor/force_sequential_test_execution
@@ -1,0 +1,2 @@
+# go get has been observed to sometimes fail when multiple tests try to simultaneously fetch the same package.
+goget

--- a/go/ql/integration-tests/all-platforms/go/extract-vendor/src/go.mod
+++ b/go/ql/integration-tests/all-platforms/go/extract-vendor/src/go.mod
@@ -1,0 +1,5 @@
+go 1.14
+
+require example.com/test v0.1.0
+
+module test

--- a/go/ql/integration-tests/all-platforms/go/extract-vendor/src/go.sum
+++ b/go/ql/integration-tests/all-platforms/go/extract-vendor/src/go.sum
@@ -1,0 +1,1 @@
+example.com/test v0.1.0/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/go/ql/integration-tests/all-platforms/go/extract-vendor/src/test.go
+++ b/go/ql/integration-tests/all-platforms/go/extract-vendor/src/test.go
@@ -1,0 +1,11 @@
+package test
+
+import (
+	subdir "example.com/test"
+)
+
+func Test() {
+
+	foo := subdir.Add(2, 2)
+	println(foo)
+}

--- a/go/ql/integration-tests/all-platforms/go/extract-vendor/src/vendor/example.com/test/add.go
+++ b/go/ql/integration-tests/all-platforms/go/extract-vendor/src/vendor/example.com/test/add.go
@@ -1,0 +1,5 @@
+package test
+
+func Add(a, b int) int {
+	return a + b
+}

--- a/go/ql/integration-tests/all-platforms/go/extract-vendor/src/vendor/modules.txt
+++ b/go/ql/integration-tests/all-platforms/go/extract-vendor/src/vendor/modules.txt
@@ -1,0 +1,3 @@
+# example.com/test v0.1.0
+## explicit; go 1.14
+example.com/test

--- a/go/ql/integration-tests/all-platforms/go/extract-vendor/test.expected
+++ b/go/ql/integration-tests/all-platforms/go/extract-vendor/test.expected
@@ -1,0 +1,5 @@
+extractedFiles
+| src/go.mod:0:0:0:0 | src/go.mod |
+| src/test.go:0:0:0:0 | src/test.go |
+| src/vendor/example.com/test/add.go:0:0:0:0 | src/vendor/example.com/test/add.go |
+#select

--- a/go/ql/integration-tests/all-platforms/go/extract-vendor/test.py
+++ b/go/ql/integration-tests/all-platforms/go/extract-vendor/test.py
@@ -1,0 +1,4 @@
+from go_integration_test import *
+
+os.environ['CODEQL_EXTRACTOR_GO_EXTRACT_VENDOR_DIRS'] = "true"
+go_integration_test()

--- a/go/ql/integration-tests/all-platforms/go/extract-vendor/test.ql
+++ b/go/ql/integration-tests/all-platforms/go/extract-vendor/test.ql
@@ -1,0 +1,8 @@
+import go
+import semmle.go.DiagnosticsReporting
+
+query predicate extractedFiles(File f) { any() }
+
+from string msg, int sev
+where reportableDiagnostics(_, msg, sev)
+select msg, sev


### PR DESCRIPTION
This PR introduces a new environment variable `CODEQL_EXTRACTOR_GO_EXTRACT_VENDOR_DIRS` which, if set to `true`, includes `vendor` directories in the extraction. I have also added an integration test to verify that a `vendor` directory is included in the extraction with this environment variable set to true. Specifically, `test.expected` does not contain `src/vendor/example.com/test/add.go` if `CODEQL_EXTRACTOR_GO_EXTRACT_VENDOR_DIRS` is not `true` or with an old version of the extractor.