### PR TITLE
C++: Add 'cpp/unsafe-strncat' FPs

### DIFF
--- a/cpp/ql/test/query-tests/Likely Bugs/Memory Management/SuspiciousCallToStrncat/SuspiciousCallToStrncat.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Memory Management/SuspiciousCallToStrncat/SuspiciousCallToStrncat.expected
@@ -3,3 +3,5 @@
 | test.c:67:3:67:9 | call to strncat | Potentially unsafe call to strncat. |
 | test.c:75:3:75:9 | call to strncat | Potentially unsafe call to strncat. |
 | test.c:76:3:76:9 | call to strncat | Potentially unsafe call to strncat. |
+| test.c:91:3:91:9 | call to strncat | Potentially unsafe call to strncat. |
+| test.c:99:3:99:9 | call to strncat | Potentially unsafe call to strncat. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Memory Management/SuspiciousCallToStrncat/test.c
+++ b/cpp/ql/test/query-tests/Likely Bugs/Memory Management/SuspiciousCallToStrncat/test.c
@@ -82,3 +82,20 @@ void strncat_test5(char *s) {
   strncat(buf, s, len - strlen(buf) - 1); // GOOD
   strncat(buf, s, len - strlen(buf)); // GOOD
 }
+
+void strncat_test6() {
+  {
+  char dest[60];
+  dest[0] = '\0';
+  // Will write `dest[0 .. 5]`
+  strncat(dest, "small", sizeof(dest)); // GOOD [FALSE POSITIVE]
+  }
+
+  {
+  char dest[60];
+  memset(dest, 'a', sizeof(dest));
+  dest[54] = '\0';
+  // Will write `dest[54 .. 59]`
+  strncat(dest, "small", sizeof(dest)); // GOOD [FALSE POSITIVE]
+  }
+}


### PR DESCRIPTION
The size arguments here are actually off-by-one, but these calls won't overflow the buffer since the string constants are sufficiently small. So _technically_ these are FPs.