### PR TITLE
C++: Promote `cpp/unsafe-strncat` to Code Scanning

### DIFF
--- a/cpp/ql/src/Likely Bugs/Memory Management/SuspiciousCallToStrncat.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/SuspiciousCallToStrncat.ql
@@ -4,7 +4,7 @@
  * @kind problem
  * @problem.severity warning
  * @security-severity 9.3
- * @precision medium
+ * @precision high
  * @id cpp/unsafe-strncat
  * @tags reliability
  *       correctness

--- a/cpp/ql/src/change-notes/2024-07-08-unsafe-strncat-query.md
+++ b/cpp/ql/src/change-notes/2024-07-08-unsafe-strncat-query.md
@@ -1,0 +1,4 @@
+---
+category: queryMetadata
+---
+* The precision of `cpp/unsafe-strncat` ("Potentially unsafe call to strncat") has been increased to `high`. As a result, it will be run by default as part of the Code Scanning suite.


### PR DESCRIPTION
The query produces excellent results on MRVA 🎉 (see the backlink for analysis of the results).