### PR TITLE
C#: Adopt shared SSA data-flow integration

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/BaseSSA.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/BaseSSA.qll
@@ -29,7 +29,7 @@ module BaseSsa {
   ) {
     exists(ControlFlow::ControlFlow::BasicBlocks::EntryBlock entry |
       c = entry.getCallable() and
-      // In case `c` has multiple bodies, we want each body to gets its own implicit
+      // In case `c` has multiple bodies, we want each body to get its own implicit
       // entry definition. In case `c` doesn't have multiple bodies, the line below
       // is simply the same as `bb = entry`, because `entry.getFirstNode().getASuccessor()`
       // will be in the entry block.

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -267,8 +267,9 @@ module VariableCapture {
   private predicate closureFlowStep(ControlFlow::Nodes::ExprNode e1, ControlFlow::Nodes::ExprNode e2) {
     e1 = LocalFlow::getALastEvalNode(e2)
     or
-    exists(Ssa::Definition def |
-      LocalFlow::ssaDefAssigns(def.getAnUltimateDefinition(), e1) and
+    exists(Ssa::Definition def, AssignableDefinition adef |
+      LocalFlow::defAssigns(adef, _, e1) and
+      def.getAnUltimateDefinition().(Ssa::ExplicitDefinition).getADefinition() = adef and
       exists(def.getAReadAtNode(e2))
     )
   }
@@ -492,6 +493,30 @@ module VariableCapture {
   }
 }
 
+/** Provides logic related to SSA. */
+module SsaFlow {
+  private module Impl = SsaImpl::DataFlowIntegration;
+
+  Impl::Node asNode(Node n) {
+    n = TSsaNode(result)
+    or
+    result.(Impl::ExprNode).getExpr() = n.(ExprNode).getControlFlowNode()
+    or
+    result.(Impl::ExprPostUpdateNode).getExpr() =
+      n.(PostUpdateNode).getPreUpdateNode().(ExprNode).getControlFlowNode()
+    or
+    result.(Impl::ParameterNode).getParameter() = n.(ExplicitParameterNode).getSsaDefinition()
+  }
+
+  predicate localFlowStep(SsaImpl::DefinitionExt def, Node nodeFrom, Node nodeTo, boolean isUseStep) {
+    Impl::localFlowStep(def, asNode(nodeFrom), asNode(nodeTo), isUseStep)
+  }
+
+  predicate localMustFlowStep(SsaImpl::DefinitionExt def, Node nodeFrom, Node nodeTo) {
+    Impl::localMustFlowStep(def, asNode(nodeFrom), asNode(nodeTo))
+  }
+}
+
 /** Provides predicates related to local data flow. */
 module LocalFlow {
   class LocalExprStepConfiguration extends ControlFlowReachabilityConfiguration {
@@ -617,105 +642,6 @@ module LocalFlow {
     any(LocalExprStepConfiguration x).hasDefPath(_, value, def, cfnDef)
   }
 
-  predicate ssaDefAssigns(Ssa::ExplicitDefinition ssaDef, ControlFlow::Nodes::ExprNode value) {
-    exists(AssignableDefinition def, ControlFlow::Node cfnDef |
-      any(LocalExprStepConfiguration conf).hasDefPath(_, value, def, cfnDef) and
-      ssaDef.getADefinition() = def and
-      ssaDef.getControlFlowNode() = cfnDef
-    )
-  }
-
-  /**
-   * An uncertain SSA definition. Either an uncertain explicit definition or an
-   * uncertain qualifier definition.
-   *
-   * Restricts `Ssa::UncertainDefinition` by excluding implicit call definitions,
-   * as we---conservatively---consider such definitions to be certain.
-   */
-  class UncertainExplicitSsaDefinition extends Ssa::UncertainDefinition {
-    UncertainExplicitSsaDefinition() {
-      this instanceof Ssa::ExplicitDefinition
-      or
-      this =
-        any(Ssa::ImplicitQualifierDefinition qdef |
-          qdef.getQualifierDefinition() instanceof UncertainExplicitSsaDefinition
-        )
-    }
-  }
-
-  /** An SSA definition into which another SSA definition may flow. */
-  private class SsaInputDefinitionExtNode extends SsaDefinitionExtNode {
-    SsaInputDefinitionExtNode() {
-      def instanceof Ssa::PhiNode
-      or
-      def instanceof SsaImpl::PhiReadNode
-      or
-      def instanceof LocalFlow::UncertainExplicitSsaDefinition
-    }
-  }
-
-  /**
-   * Holds if `nodeFrom` is a last node referencing SSA definition `def`, which
-   * can reach `next`.
-   */
-  private predicate localFlowSsaInputFromDef(
-    Node nodeFrom, SsaImpl::DefinitionExt def, SsaInputDefinitionExtNode next
-  ) {
-    exists(ControlFlow::BasicBlock bb, int i |
-      SsaImpl::lastRefBeforeRedefExt(def, bb, i, next.getDefinitionExt()) and
-      def.definesAt(_, bb, i, _) and
-      def = getSsaDefinitionExt(nodeFrom) and
-      nodeFrom != next
-    )
-  }
-
-  /**
-   * Holds if `read` is a last node reading SSA definition `def`, which
-   * can reach `next`.
-   */
-  predicate localFlowSsaInputFromRead(
-    Node read, SsaImpl::DefinitionExt def, SsaInputDefinitionExtNode next
-  ) {
-    exists(ControlFlow::BasicBlock bb, int i |
-      SsaImpl::lastRefBeforeRedefExt(def, bb, i, next.getDefinitionExt()) and
-      read.asExprAtNode(bb.getNode(i)) instanceof AssignableRead
-    )
-  }
-
-  private SsaImpl::DefinitionExt getSsaDefinitionExt(Node n) {
-    result = n.(SsaDefinitionExtNode).getDefinitionExt()
-    or
-    result = n.(ExplicitParameterNode).getSsaDefinition()
-  }
-
-  /**
-   * Holds if there is a local use-use flow step from `nodeFrom` to `nodeTo`
-   * involving SSA definition `def`.
-   */
-  predicate localSsaFlowStepUseUse(SsaImpl::DefinitionExt def, Node nodeFrom, Node nodeTo) {
-    exists(ControlFlow::Node cfnFrom, ControlFlow::Node cfnTo |
-      SsaImpl::adjacentReadPairSameVarExt(def, cfnFrom, cfnTo) and
-      nodeTo = TExprNode(cfnTo) and
-      nodeFrom = TExprNode(cfnFrom)
-    )
-  }
-
-  /**
-   * Holds if there is a local flow step from `nodeFrom` to `nodeTo` involving
-   * SSA definition `def`.
-   */
-  predicate localSsaFlowStep(SsaImpl::DefinitionExt def, Node nodeFrom, Node nodeTo) {
-    // Flow from SSA definition/parameter to first read
-    def = getSsaDefinitionExt(nodeFrom) and
-    SsaImpl::firstReadSameVarExt(def, nodeTo.(ExprNode).getControlFlowNode())
-    or
-    // Flow from read to next read
-    localSsaFlowStepUseUse(def, nodeFrom.(PostUpdateNode).getPreUpdateNode(), nodeTo)
-    or
-    // Flow into phi (read)/uncertain SSA definition node from def
-    localFlowSsaInputFromDef(nodeFrom, def, nodeTo)
-  }
-
   /**
    * Holds if the source variable of SSA definition `def` is an instance field.
    */
@@ -800,10 +726,7 @@ module LocalFlow {
       node2.asExpr() instanceof AssignExpr
     )
     or
-    exists(SsaImpl::Definition def |
-      def = getSsaDefinitionExt(node1) and
-      exists(SsaImpl::getAReadAtNode(def, node2.(ExprNode).getControlFlowNode()))
-    )
+    SsaFlow::localMustFlowStep(_, node1, node2)
     or
     node2 = node1.(LocalFunctionCreationNode).getAnAccess(true)
     or
@@ -827,23 +750,14 @@ predicate simpleLocalFlowStep(Node nodeFrom, Node nodeTo, string model) {
   (
     LocalFlow::localFlowStepCommon(nodeFrom, nodeTo)
     or
-    exists(SsaImpl::DefinitionExt def |
+    exists(SsaImpl::DefinitionExt def, boolean isUseStep |
+      SsaFlow::localFlowStep(def, nodeFrom, nodeTo, isUseStep) and
       not LocalFlow::usesInstanceField(def) and
       not def instanceof VariableCapture::CapturedSsaDefinitionExt
     |
-      LocalFlow::localSsaFlowStep(def, nodeFrom, nodeTo)
+      isUseStep = false
       or
-      LocalFlow::localSsaFlowStepUseUse(def, nodeFrom, nodeTo) and
-      not FlowSummaryImpl::Private::Steps::prohibitsUseUseFlow(nodeFrom, _) and
-      nodeFrom != nodeTo
-      or
-      // Flow into phi (read)/uncertain SSA definition node from read
-      exists(Node read | LocalFlow::localFlowSsaInputFromRead(read, def, nodeTo) |
-        nodeFrom = read and
-        not FlowSummaryImpl::Private::Steps::prohibitsUseUseFlow(nodeFrom, _)
-        or
-        nodeFrom.(PostUpdateNode).getPreUpdateNode() = read
-      )
+      not FlowSummaryImpl::Private::Steps::prohibitsUseUseFlow(nodeFrom, _)
     )
     or
     nodeTo.(ObjectCreationNode).getPreUpdateNode() = nodeFrom.(ObjectInitializerNode)
@@ -1113,11 +1027,7 @@ private module Cached {
   cached
   newtype TNode =
     TExprNode(ControlFlow::Nodes::ElementNode cfn) { cfn.getAstNode() instanceof Expr } or
-    TSsaDefinitionExtNode(SsaImpl::DefinitionExt def) {
-      // Handled by `TExplicitParameterNode` below
-      not def instanceof Ssa::ImplicitParameterDefinition and
-      def.getBasicBlock() = any(DataFlowCallable c).getAControlFlowNode().getBasicBlock()
-    } or
+    TSsaNode(SsaImpl::DataFlowIntegration::SsaNode node) or
     TAssignableDefinitionNode(AssignableDefinition def, ControlFlow::Node cfn) {
       cfn = def.getExpr().getAControlFlowNode()
     } or
@@ -1180,17 +1090,7 @@ private module Cached {
   predicate localFlowStepImpl(Node nodeFrom, Node nodeTo) {
     LocalFlow::localFlowStepCommon(nodeFrom, nodeTo)
     or
-    LocalFlow::localSsaFlowStepUseUse(_, nodeFrom, nodeTo) and
-    nodeFrom != nodeTo
-    or
-    LocalFlow::localSsaFlowStep(_, nodeFrom, nodeTo)
-    or
-    // Flow into phi (read)/uncertain SSA definition node from read
-    exists(Node read | LocalFlow::localFlowSsaInputFromRead(read, _, nodeTo) |
-      nodeFrom = read
-      or
-      nodeFrom.(PostUpdateNode).getPreUpdateNode() = read
-    )
+    SsaFlow::localFlowStep(_, nodeFrom, nodeTo, _)
     or
     // Simple flow through library code is included in the exposed local
     // step relation, even though flow is technically inter-procedural
@@ -1254,7 +1154,7 @@ import Cached
 
 /** Holds if `n` should be hidden from path explanations. */
 predicate nodeIsHidden(Node n) {
-  n instanceof SsaDefinitionExtNode
+  n instanceof SsaNode
   or
   exists(Parameter p | p = n.(ParameterNode).getParameter() | not p.fromSource())
   or
@@ -1288,13 +1188,16 @@ predicate nodeIsHidden(Node n) {
   n instanceof CaptureNode
 }
 
-/** An SSA definition, viewed as a node in a data flow graph. */
-class SsaDefinitionExtNode extends NodeImpl, TSsaDefinitionExtNode {
+/** An SSA node. */
+abstract class SsaNode extends NodeImpl, TSsaNode {
+  SsaImpl::DataFlowIntegration::SsaNode node;
   SsaImpl::DefinitionExt def;
 
-  SsaDefinitionExtNode() { this = TSsaDefinitionExtNode(def) }
+  SsaNode() {
+    this = TSsaNode(node) and
+    def = node.getDefinitionExt()
+  }
 
-  /** Gets the underlying SSA definition. */
   SsaImpl::DefinitionExt getDefinitionExt() { result = def }
 
   override DataFlowCallable getEnclosingCallableImpl() {
@@ -1307,9 +1210,57 @@ class SsaDefinitionExtNode extends NodeImpl, TSsaDefinitionExtNode {
     result = def.(Ssa::Definition).getControlFlowNode()
   }
 
-  override Location getLocationImpl() { result = def.getLocation() }
+  override Location getLocationImpl() { result = node.getLocation() }
 
-  override string toStringImpl() { result = def.toString() }
+  override string toStringImpl() { result = node.toString() }
+}
+
+/** An (extended) SSA definition, viewed as a node in a data flow graph. */
+class SsaDefinitionExtNode extends SsaNode {
+  override SsaImpl::DataFlowIntegration::SsaDefinitionExtNode node;
+}
+
+/**
+ * A node that represents an input to an SSA phi (read) definition.
+ *
+ * This allows for barrier guards to filter input to phi nodes. For example, in
+ *
+ * ```csharp
+ * var x = taint;
+ * if (x != "safe")
+ * {
+ *     x = "safe";
+ * }
+ * sink(x);
+ * ```
+ *
+ * the `false` edge out of `x != "safe"` guards the input from `x = taint` into the
+ * `phi` node after the condition.
+ *
+ * It is also relevant to filter input into phi read nodes:
+ *
+ * ```csharp
+ * var x = taint;
+ * if (b)
+ * {
+ *     if (x != "safe1")
+ *     {
+ *         return;
+ *     }
+ * } else {
+ *     if (x != "safe2")
+ *     {
+ *         return;
+ *     }
+ * }
+ *
+ * sink(x);
+ * ```
+ *
+ * both inputs into the phi read node after the outer condition are guarded.
+ */
+class SsaInputNode extends SsaNode {
+  override SsaImpl::DataFlowIntegration::SsaInputNode node;
 }
 
 /** A definition, viewed as a node in a data flow graph. */
@@ -2907,7 +2858,7 @@ private predicate delegateCreationStep(Node nodeFrom, Node nodeTo) {
 /** Extra data-flow steps needed for lambda flow analysis. */
 predicate additionalLambdaFlowStep(Node nodeFrom, Node nodeTo, boolean preservesValue) {
   exists(SsaImpl::DefinitionExt def |
-    LocalFlow::localSsaFlowStep(def, nodeFrom, nodeTo) and
+    SsaFlow::localFlowStep(def, nodeFrom, nodeTo, _) and
     preservesValue = true
   |
     LocalFlow::usesInstanceField(def)

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -757,6 +757,7 @@ predicate simpleLocalFlowStep(Node nodeFrom, Node nodeTo, string model) {
     |
       isUseStep = false
       or
+      isUseStep = true and
       not FlowSummaryImpl::Private::Steps::prohibitsUseUseFlow(nodeFrom, _)
     )
     or

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPublic.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPublic.qll
@@ -171,8 +171,14 @@ signature predicate guardChecksSig(Guard g, Expr e, AbstractValue v);
  * in data flow and taint tracking.
  */
 module BarrierGuard<guardChecksSig/3 guardChecks> {
+  private import SsaImpl as SsaImpl
+
   /** Gets a node that is safely guarded by the given guard check. */
-  ExprNode getABarrierNode() {
+  pragma[nomagic]
+  Node getABarrierNode() {
+    SsaFlow::asNode(result) =
+      SsaImpl::DataFlowIntegration::BarrierGuard<guardChecks/3>::getABarrierNode()
+    or
     exists(Guard g, Expr e, AbstractValue v |
       guardChecks(g, e, v) and
       g.controlsNode(result.getControlFlowNode(), e, v)

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImpl.qll
@@ -6,6 +6,7 @@ import csharp
 private import codeql.ssa.Ssa as SsaImplCommon
 private import AssignableDefinitions
 private import semmle.code.csharp.controlflow.internal.PreSsa
+private import semmle.code.csharp.controlflow.Guards as Guards
 
 private module SsaInput implements SsaImplCommon::InputSig<Location> {
   class BasicBlock = ControlFlow::BasicBlock;
@@ -49,7 +50,7 @@ private module SsaInput implements SsaImplCommon::InputSig<Location> {
   }
 }
 
-private import SsaImplCommon::Make<Location, SsaInput> as Impl
+import SsaImplCommon::Make<Location, SsaInput> as Impl
 
 class Definition = Impl::Definition;
 
@@ -757,24 +758,6 @@ private predicate adjacentDefReachesRead(
   )
 }
 
-private predicate adjacentDefReachesReadExt(
-  DefinitionExt def, SsaInput::SourceVariable v, SsaInput::BasicBlock bb1, int i1,
-  SsaInput::BasicBlock bb2, int i2
-) {
-  Impl::adjacentDefReadExt(def, v, bb1, i1, bb2, i2) and
-  (
-    def.definesAt(v, bb1, i1, _)
-    or
-    SsaInput::variableRead(bb1, i1, v, true)
-  )
-  or
-  exists(SsaInput::BasicBlock bb3, int i3 |
-    adjacentDefReachesReadExt(def, v, bb1, i1, bb3, i3) and
-    SsaInput::variableRead(bb3, i3, v, false) and
-    Impl::adjacentDefReadExt(def, v, bb3, i3, bb2, i2)
-  )
-}
-
 /** Same as `adjacentDefRead`, but skips uncertain reads. */
 pragma[nomagic]
 private predicate adjacentDefSkipUncertainReads(
@@ -786,32 +769,11 @@ private predicate adjacentDefSkipUncertainReads(
   )
 }
 
-/** Same as `adjacentDefReadExt`, but skips uncertain reads. */
-pragma[nomagic]
-private predicate adjacentDefSkipUncertainReadsExt(
-  DefinitionExt def, SsaInput::BasicBlock bb1, int i1, SsaInput::BasicBlock bb2, int i2
-) {
-  exists(SsaInput::SourceVariable v |
-    adjacentDefReachesReadExt(def, v, bb1, i1, bb2, i2) and
-    SsaInput::variableRead(bb2, i2, v, true)
-  )
-}
-
 private predicate adjacentDefReachesUncertainRead(
   Definition def, SsaInput::BasicBlock bb1, int i1, SsaInput::BasicBlock bb2, int i2
 ) {
   exists(SsaInput::SourceVariable v |
     adjacentDefReachesRead(def, v, bb1, i1, bb2, i2) and
-    SsaInput::variableRead(bb2, i2, v, false)
-  )
-}
-
-pragma[nomagic]
-private predicate adjacentDefReachesUncertainReadExt(
-  DefinitionExt def, SsaInput::BasicBlock bb1, int i1, SsaInput::BasicBlock bb2, int i2
-) {
-  exists(SsaInput::SourceVariable v |
-    adjacentDefReachesReadExt(def, v, bb1, i1, bb2, i2) and
     SsaInput::variableRead(bb2, i2, v, false)
   )
 }
@@ -870,7 +832,7 @@ private module Cached {
   predicate implicitEntryDefinition(ControlFlow::ControlFlow::BasicBlock bb, Ssa::SourceVariable v) {
     exists(ControlFlow::ControlFlow::BasicBlocks::EntryBlock entry, Callable c |
       c = entry.getCallable() and
-      // In case `c` has multiple bodies, we want each body to gets its own implicit
+      // In case `c` has multiple bodies, we want each body to get its own implicit
       // entry definition. In case `c` doesn't have multiple bodies, the line below
       // is simply the same as `bb = entry`, because `entry.getFirstNode().getASuccessor()`
       // will be in the entry block.
@@ -966,19 +928,6 @@ private module Cached {
   }
 
   /**
-   * Holds if the value defined at SSA definition `def` can reach a read at `cfn`,
-   * without passing through any other read.
-   */
-  cached
-  predicate firstReadSameVarExt(DefinitionExt def, ControlFlow::Node cfn) {
-    exists(ControlFlow::BasicBlock bb1, int i1, ControlFlow::BasicBlock bb2, int i2 |
-      def.definesAt(_, bb1, i1, _) and
-      adjacentDefSkipUncertainReadsExt(def, bb1, i1, bb2, i2) and
-      cfn = bb2.getNode(i2)
-    )
-  }
-
-  /**
    * Holds if the read at `cfn2` is a read of the same SSA definition `def`
    * as the read at `cfn1`, and `cfn2` can be reached from `cfn1` without
    * passing through another read.
@@ -993,23 +942,6 @@ private module Cached {
     )
   }
 
-  /**
-   * Holds if the read at `cfn2` is a read of the same SSA definition `def`
-   * as the read at `cfn1`, and `cfn2` can be reached from `cfn1` without
-   * passing through another read.
-   */
-  cached
-  predicate adjacentReadPairSameVarExt(
-    DefinitionExt def, ControlFlow::Node cfn1, ControlFlow::Node cfn2
-  ) {
-    exists(ControlFlow::BasicBlock bb1, int i1, ControlFlow::BasicBlock bb2, int i2 |
-      cfn1 = bb1.getNode(i1) and
-      variableReadActual(bb1, i1, _) and
-      adjacentDefSkipUncertainReadsExt(def, bb1, i1, bb2, i2) and
-      cfn2 = bb2.getNode(i2)
-    )
-  }
-
   cached
   predicate lastRefBeforeRedef(Definition def, ControlFlow::BasicBlock bb, int i, Definition next) {
     Impl::lastRefRedef(def, bb, i, next) and
@@ -1018,21 +950,6 @@ private module Cached {
     exists(SsaInput::BasicBlock bb0, int i0 |
       Impl::lastRefRedef(def, bb0, i0, next) and
       adjacentDefReachesUncertainRead(def, bb, i, bb0, i0)
-    )
-  }
-
-  cached
-  predicate lastRefBeforeRedefExt(
-    DefinitionExt def, ControlFlow::BasicBlock bb, int i, DefinitionExt next
-  ) {
-    exists(SsaInput::SourceVariable v |
-      Impl::lastRefRedefExt(def, v, bb, i, next) and
-      not SsaInput::variableRead(bb, i, v, false)
-    )
-    or
-    exists(SsaInput::BasicBlock bb0, int i0 |
-      Impl::lastRefRedefExt(def, _, bb0, i0, next) and
-      adjacentDefReachesUncertainReadExt(def, bb, i, bb0, i0)
     )
   }
 
@@ -1060,6 +977,41 @@ private module Cached {
       Impl::ssaDefReachesRead(_, def0, bb, i) and
       outRefExitRead(bb, i, v)
     )
+  }
+
+  cached
+  module DataFlowIntegration {
+    import DataFlowIntegrationImpl
+
+    cached
+    predicate localFlowStep(DefinitionExt def, Node nodeFrom, Node nodeTo, boolean isUseStep) {
+      DataFlowIntegrationImpl::localFlowStep(def, nodeFrom, nodeTo, isUseStep)
+    }
+
+    cached
+    predicate localMustFlowStep(DefinitionExt def, Node nodeFrom, Node nodeTo) {
+      DataFlowIntegrationImpl::localMustFlowStep(def, nodeFrom, nodeTo)
+    }
+
+    signature predicate guardChecksSig(Guards::Guard g, Expr e, Guards::AbstractValue v);
+
+    cached // nothing is actually cached
+    module BarrierGuard<guardChecksSig/3 guardChecks> {
+      private predicate guardChecksAdjTypes(
+        DataFlowIntegrationInput::Guard g, DataFlowIntegrationInput::Expr e, boolean branch
+      ) {
+        exists(Guards::AbstractValues::BooleanValue v |
+          guardChecks(g, e.getAstNode(), v) and
+          branch = v.getValue()
+        )
+      }
+
+      private Node getABarrierNodeImpl() {
+        result = DataFlowIntegrationImpl::BarrierGuard<guardChecksAdjTypes/3>::getABarrierNode()
+      }
+
+      predicate getABarrierNode = getABarrierNodeImpl/0;
+    }
   }
 }
 
@@ -1118,3 +1070,64 @@ class PhiReadNode extends DefinitionExt, Impl::PhiReadNode {
     result = this.getSourceVariable().getEnclosingCallable()
   }
 }
+
+private module DataFlowIntegrationInput implements Impl::DataFlowIntegrationInputSig {
+  private import csharp as Cs
+  private import semmle.code.csharp.controlflow.BasicBlocks
+
+  class Expr extends ControlFlow::Node {
+    predicate hasCfgNode(ControlFlow::BasicBlock bb, int i) { this = bb.getNode(i) }
+  }
+
+  Expr getARead(Definition def) { exists(getAReadAtNode(def, result)) }
+
+  predicate ssaDefAssigns(WriteDefinition def, Expr value) {
+    // exclude flow directly from RHS to SSA definition, as we instead want to
+    // go from RHS to matching assingnable definition, and from there to SSA definition
+    none()
+  }
+
+  class Parameter = Ssa::ImplicitParameterDefinition;
+
+  predicate ssaDefInitializesParam(WriteDefinition def, Parameter p) { def = p }
+
+  /**
+   * Allows for flow into uncertain defintions that are not call definitions,
+   * as we, conservatively, consider such definitions to be certain.
+   */
+  predicate allowFlowIntoUncertainDef(UncertainWriteDefinition def) {
+    def instanceof Ssa::ExplicitDefinition
+    or
+    def =
+      any(Ssa::ImplicitQualifierDefinition qdef |
+        allowFlowIntoUncertainDef(qdef.getQualifierDefinition())
+      )
+  }
+
+  class Guard extends Guards::Guard {
+    predicate hasCfgNode(ControlFlow::BasicBlock bb, int i) {
+      this.getAControlFlowNode() = bb.getNode(i)
+    }
+  }
+
+  /** Holds if the guard `guard` controls block `bb` upon evaluating to `branch`. */
+  predicate guardControlsBlock(Guard guard, ControlFlow::BasicBlock bb, boolean branch) {
+    exists(ConditionBlock conditionBlock, ControlFlow::SuccessorTypes::ConditionalSuccessor s |
+      guard.getAControlFlowNode() = conditionBlock.getLastNode() and
+      s.getValue() = branch and
+      conditionBlock.controls(bb, s)
+    )
+  }
+
+  /** Gets an immediate conditional successor of basic block `bb`, if any. */
+  ControlFlow::BasicBlock getAConditionalBasicBlockSuccessor(
+    ControlFlow::BasicBlock bb, boolean branch
+  ) {
+    exists(ControlFlow::SuccessorTypes::ConditionalSuccessor s |
+      result = bb.getASuccessorByType(s) and
+      s.getValue() = branch
+    )
+  }
+}
+
+private module DataFlowIntegrationImpl = Impl::DataFlowIntegration<DataFlowIntegrationInput>;

--- a/csharp/ql/test/library-tests/csharp7/LocalTaintFlow.expected
+++ b/csharp/ql/test/library-tests/csharp7/LocalTaintFlow.expected
@@ -12,18 +12,21 @@
 | CSharp7.cs:15:9:15:11 | SSA entry def(this.field) | CSharp7.cs:15:18:15:22 | access to field field |
 | CSharp7.cs:15:9:15:11 | this | CSharp7.cs:15:18:15:22 | this access |
 | CSharp7.cs:19:9:19:11 | this | CSharp7.cs:19:16:19:20 | this access |
+| CSharp7.cs:20:9:20:11 | SSA param(value) | CSharp7.cs:20:24:20:28 | access to parameter value |
 | CSharp7.cs:20:9:20:11 | this | CSharp7.cs:20:16:20:20 | this access |
-| CSharp7.cs:20:9:20:11 | value | CSharp7.cs:20:24:20:28 | access to parameter value |
+| CSharp7.cs:20:9:20:11 | value | CSharp7.cs:20:9:20:11 | SSA param(value) |
 | CSharp7.cs:20:24:20:28 | access to parameter value | CSharp7.cs:20:16:20:20 | access to field field |
 | CSharp7.cs:23:5:23:27 | this | CSharp7.cs:14:9:14:13 | this access |
 | CSharp7.cs:24:6:24:28 | this | CSharp7.cs:24:35:24:39 | this access |
-| CSharp7.cs:29:19:29:19 | i | CSharp7.cs:31:16:31:16 | access to parameter i |
+| CSharp7.cs:29:19:29:19 | SSA param(i) | CSharp7.cs:31:16:31:16 | access to parameter i |
+| CSharp7.cs:29:19:29:19 | i | CSharp7.cs:29:19:29:19 | SSA param(i) |
 | CSharp7.cs:31:16:31:16 | access to parameter i | CSharp7.cs:31:16:31:20 | ... > ... |
 | CSharp7.cs:31:16:31:16 | access to parameter i | CSharp7.cs:31:24:31:24 | access to parameter i |
 | CSharp7.cs:31:24:31:24 | access to parameter i | CSharp7.cs:31:16:31:59 | ... ? ... : ... |
 | CSharp7.cs:39:9:39:9 | access to parameter x | CSharp7.cs:39:9:39:21 | SSA def(x) |
 | CSharp7.cs:39:13:39:21 | "tainted" | CSharp7.cs:39:9:39:9 | access to parameter x |
-| CSharp7.cs:42:19:42:19 | x | CSharp7.cs:44:13:44:13 | access to parameter x |
+| CSharp7.cs:42:19:42:19 | SSA param(x) | CSharp7.cs:44:13:44:13 | access to parameter x |
+| CSharp7.cs:42:19:42:19 | x | CSharp7.cs:42:19:42:19 | SSA param(x) |
 | CSharp7.cs:44:9:44:9 | access to parameter y | CSharp7.cs:44:9:44:13 | SSA def(y) |
 | CSharp7.cs:44:13:44:13 | access to parameter x | CSharp7.cs:44:9:44:9 | access to parameter y |
 | CSharp7.cs:47:10:47:10 | this | CSharp7.cs:49:9:49:24 | this access |
@@ -86,7 +89,8 @@
 | CSharp7.cs:77:22:77:28 | (..., ...) | CSharp7.cs:77:9:77:18 | (..., ...) |
 | CSharp7.cs:77:23:77:24 | "" | CSharp7.cs:77:9:77:28 | ... = ... |
 | CSharp7.cs:77:27:77:27 | access to local variable x | CSharp7.cs:77:9:77:28 | ... = ... |
-| CSharp7.cs:80:21:80:21 | x | CSharp7.cs:82:20:82:20 | access to parameter x |
+| CSharp7.cs:80:21:80:21 | SSA param(x) | CSharp7.cs:82:20:82:20 | access to parameter x |
+| CSharp7.cs:80:21:80:21 | x | CSharp7.cs:80:21:80:21 | SSA param(x) |
 | CSharp7.cs:85:10:85:18 | this | CSharp7.cs:90:18:90:28 | this access |
 | CSharp7.cs:87:13:87:14 | access to local variable t1 | CSharp7.cs:87:13:87:34 | SSA def(t1) |
 | CSharp7.cs:87:13:87:34 | SSA def(t1) | CSharp7.cs:88:28:88:29 | access to local variable t1 |
@@ -133,40 +137,51 @@
 | CSharp7.cs:121:28:121:36 | "DefUse3" | CSharp7.cs:121:22:121:24 | access to local variable m12 |
 | CSharp7.cs:121:28:121:36 | "DefUse3" | CSharp7.cs:121:22:121:36 | ... = ... |
 | CSharp7.cs:127:9:127:12 | this | CSharp7.cs:133:24:133:25 | this access |
-| CSharp7.cs:129:20:129:20 | x | CSharp7.cs:129:32:129:32 | access to parameter x |
+| CSharp7.cs:129:20:129:20 | SSA param(x) | CSharp7.cs:129:32:129:32 | access to parameter x |
+| CSharp7.cs:129:20:129:20 | x | CSharp7.cs:129:20:129:20 | SSA param(x) |
 | CSharp7.cs:129:32:129:32 | access to parameter x | CSharp7.cs:129:32:129:36 | ... + ... |
 | CSharp7.cs:129:36:129:36 | 1 | CSharp7.cs:129:32:129:36 | ... + ... |
-| CSharp7.cs:131:22:131:22 | t | CSharp7.cs:131:39:131:39 | access to parameter t |
+| CSharp7.cs:131:22:131:22 | SSA param(t) | CSharp7.cs:131:39:131:39 | access to parameter t |
+| CSharp7.cs:131:22:131:22 | t | CSharp7.cs:131:22:131:22 | SSA param(t) |
 | CSharp7.cs:133:24:133:25 | delegate creation of type Func<Int32> | CSharp7.cs:133:19:133:20 | access to local variable f4 |
 | CSharp7.cs:133:24:133:25 | this access | CSharp7.cs:154:16:154:17 | this access |
-| CSharp7.cs:137:29:137:29 | x | CSharp7.cs:137:34:137:34 | access to parameter x |
+| CSharp7.cs:137:29:137:29 | SSA param(x) | CSharp7.cs:137:34:137:34 | access to parameter x |
+| CSharp7.cs:137:29:137:29 | x | CSharp7.cs:137:29:137:29 | SSA param(x) |
 | CSharp7.cs:137:29:137:38 | (...) => ... | CSharp7.cs:137:24:137:25 | access to local variable f5 |
 | CSharp7.cs:137:34:137:34 | access to parameter x | CSharp7.cs:137:34:137:38 | ... + ... |
 | CSharp7.cs:137:38:137:38 | 1 | CSharp7.cs:137:34:137:38 | ... + ... |
-| CSharp7.cs:139:20:139:20 | x | CSharp7.cs:139:26:139:26 | access to parameter x |
+| CSharp7.cs:139:20:139:20 | SSA param(x) | CSharp7.cs:139:26:139:26 | access to parameter x |
+| CSharp7.cs:139:20:139:20 | x | CSharp7.cs:139:20:139:20 | SSA param(x) |
 | CSharp7.cs:139:26:139:26 | access to parameter x | CSharp7.cs:139:26:139:30 | ... > ... |
 | CSharp7.cs:139:26:139:26 | access to parameter x | CSharp7.cs:139:41:139:41 | access to parameter x |
 | CSharp7.cs:139:34:139:34 | 1 | CSharp7.cs:139:34:139:46 | ... + ... |
 | CSharp7.cs:139:34:139:46 | ... + ... | CSharp7.cs:139:26:139:50 | ... ? ... : ... |
 | CSharp7.cs:139:38:139:46 | call to local function f7 | CSharp7.cs:139:34:139:46 | ... + ... |
 | CSharp7.cs:139:50:139:50 | 0 | CSharp7.cs:139:26:139:50 | ... ? ... : ... |
-| CSharp7.cs:141:20:141:20 | x | CSharp7.cs:141:29:141:29 | access to parameter x |
-| CSharp7.cs:145:24:145:24 | x | CSharp7.cs:145:33:145:33 | access to parameter x |
+| CSharp7.cs:141:20:141:20 | SSA param(x) | CSharp7.cs:141:29:141:29 | access to parameter x |
+| CSharp7.cs:141:20:141:20 | x | CSharp7.cs:141:20:141:20 | SSA param(x) |
+| CSharp7.cs:145:24:145:24 | SSA param(x) | CSharp7.cs:145:33:145:33 | access to parameter x |
+| CSharp7.cs:145:24:145:24 | x | CSharp7.cs:145:24:145:24 | SSA param(x) |
 | CSharp7.cs:149:20:152:9 | (...) => ... | CSharp7.cs:149:16:149:16 | access to local variable a |
 | CSharp7.cs:157:10:157:17 | this | CSharp7.cs:169:9:169:9 | this access |
-| CSharp7.cs:160:18:160:18 | t | CSharp7.cs:160:24:160:24 | access to parameter t |
-| CSharp7.cs:162:26:162:26 | u | CSharp7.cs:166:22:166:22 | access to parameter u |
+| CSharp7.cs:160:18:160:18 | SSA param(t) | CSharp7.cs:160:24:160:24 | access to parameter t |
+| CSharp7.cs:160:18:160:18 | t | CSharp7.cs:160:18:160:18 | SSA param(t) |
+| CSharp7.cs:162:26:162:26 | SSA param(u) | CSharp7.cs:166:22:166:22 | access to parameter u |
+| CSharp7.cs:162:26:162:26 | u | CSharp7.cs:162:26:162:26 | SSA param(u) |
 | CSharp7.cs:165:13:165:16 | this access | CSharp7.cs:166:20:166:20 | this access |
 | CSharp7.cs:169:9:169:9 | this access | CSharp7.cs:170:9:170:9 | this access |
 | CSharp7.cs:173:10:173:19 | this | CSharp7.cs:180:21:180:21 | this access |
 | CSharp7.cs:175:16:175:18 | access to local variable src | CSharp7.cs:175:16:175:30 | SSA def(src) |
 | CSharp7.cs:175:16:175:30 | SSA def(src) | CSharp7.cs:180:23:180:25 | access to local variable src |
 | CSharp7.cs:175:22:175:30 | "tainted" | CSharp7.cs:175:16:175:18 | access to local variable src |
-| CSharp7.cs:176:25:176:25 | s | CSharp7.cs:176:33:176:33 | access to parameter s |
+| CSharp7.cs:176:25:176:25 | SSA param(s) | CSharp7.cs:176:33:176:33 | access to parameter s |
+| CSharp7.cs:176:25:176:25 | s | CSharp7.cs:176:25:176:25 | SSA param(s) |
 | CSharp7.cs:176:31:176:34 | call to local function g | CSharp7.cs:176:31:176:39 | ... + ... |
 | CSharp7.cs:176:38:176:39 | "" | CSharp7.cs:176:31:176:39 | ... + ... |
-| CSharp7.cs:177:25:177:25 | s | CSharp7.cs:177:31:177:31 | access to parameter s |
-| CSharp7.cs:178:25:178:25 | s | CSharp7.cs:178:37:178:37 | access to parameter s |
+| CSharp7.cs:177:25:177:25 | SSA param(s) | CSharp7.cs:177:31:177:31 | access to parameter s |
+| CSharp7.cs:177:25:177:25 | s | CSharp7.cs:177:25:177:25 | SSA param(s) |
+| CSharp7.cs:178:25:178:25 | SSA param(s) | CSharp7.cs:178:37:178:37 | access to parameter s |
+| CSharp7.cs:178:25:178:25 | s | CSharp7.cs:178:25:178:25 | SSA param(s) |
 | CSharp7.cs:180:21:180:21 | this access | CSharp7.cs:181:21:181:21 | this access |
 | CSharp7.cs:180:21:180:26 | call to local function f | CSharp7.cs:180:13:180:17 | access to local variable sink1 |
 | CSharp7.cs:180:23:180:25 | [post] access to local variable src | CSharp7.cs:181:23:181:25 | access to local variable src |
@@ -205,8 +220,10 @@
 | CSharp7.cs:198:26:198:35 | this access | CSharp7.cs:199:9:199:18 | this access |
 | CSharp7.cs:198:33:198:34 | access to local variable r1 | CSharp7.cs:199:16:199:17 | access to local variable r1 |
 | CSharp7.cs:199:22:199:22 | 3 | CSharp7.cs:199:9:199:22 | ... = ... |
-| CSharp7.cs:202:24:202:24 | p | CSharp7.cs:205:20:205:20 | access to parameter p |
-| CSharp7.cs:204:28:204:28 | q | CSharp7.cs:204:44:204:44 | access to parameter q |
+| CSharp7.cs:202:24:202:24 | SSA param(p) | CSharp7.cs:205:20:205:20 | access to parameter p |
+| CSharp7.cs:202:24:202:24 | p | CSharp7.cs:202:24:202:24 | SSA param(p) |
+| CSharp7.cs:204:28:204:28 | SSA param(q) | CSharp7.cs:204:44:204:44 | access to parameter q |
+| CSharp7.cs:204:28:204:28 | q | CSharp7.cs:204:28:204:28 | SSA param(q) |
 | CSharp7.cs:215:9:215:9 | access to parameter x | CSharp7.cs:215:9:215:17 | SSA def(x) |
 | CSharp7.cs:215:13:215:17 | false | CSharp7.cs:215:9:215:9 | access to parameter x |
 | CSharp7.cs:219:10:219:13 | this | CSharp7.cs:221:13:221:20 | this access |
@@ -224,8 +241,8 @@
 | CSharp7.cs:232:16:232:23 | SSA def(o) | CSharp7.cs:233:13:233:13 | access to local variable o |
 | CSharp7.cs:232:20:232:23 | null | CSharp7.cs:232:16:232:16 | access to local variable o |
 | CSharp7.cs:233:13:233:13 | access to local variable o | CSharp7.cs:233:18:233:23 | Int32 i1 |
+| CSharp7.cs:233:13:233:13 | access to local variable o | CSharp7.cs:235:13:235:42 | [input] SSA phi read(o) |
 | CSharp7.cs:233:13:233:13 | access to local variable o | CSharp7.cs:237:18:237:18 | access to local variable o |
-| CSharp7.cs:233:13:233:13 | access to local variable o | CSharp7.cs:248:9:274:9 | SSA phi read(o) |
 | CSharp7.cs:233:13:233:23 | [false] ... is ... | CSharp7.cs:233:13:233:33 | [false] ... && ... |
 | CSharp7.cs:233:13:233:23 | [true] ... is ... | CSharp7.cs:233:13:233:33 | [false] ... && ... |
 | CSharp7.cs:233:13:233:23 | [true] ... is ... | CSharp7.cs:233:13:233:33 | [true] ... && ... |
@@ -235,19 +252,25 @@
 | CSharp7.cs:233:28:233:29 | access to local variable i1 | CSharp7.cs:235:38:235:39 | access to local variable i1 |
 | CSharp7.cs:233:28:233:33 | ... > ... | CSharp7.cs:233:13:233:33 | [false] ... && ... |
 | CSharp7.cs:233:28:233:33 | ... > ... | CSharp7.cs:233:13:233:33 | [true] ... && ... |
+| CSharp7.cs:235:13:235:42 | [input] SSA phi read(o) | CSharp7.cs:248:9:274:9 | SSA phi read(o) |
 | CSharp7.cs:235:33:235:36 | "int " | CSharp7.cs:235:31:235:41 | $"..." |
 | CSharp7.cs:235:38:235:39 | access to local variable i1 | CSharp7.cs:235:31:235:41 | $"..." |
 | CSharp7.cs:237:18:237:18 | access to local variable o | CSharp7.cs:237:23:237:31 | String s1 |
+| CSharp7.cs:237:18:237:18 | access to local variable o | CSharp7.cs:239:13:239:45 | [input] SSA phi read(o) |
 | CSharp7.cs:237:18:237:18 | access to local variable o | CSharp7.cs:241:18:241:18 | access to local variable o |
-| CSharp7.cs:237:18:237:18 | access to local variable o | CSharp7.cs:248:9:274:9 | SSA phi read(o) |
 | CSharp7.cs:237:23:237:31 | SSA def(s1) | CSharp7.cs:239:41:239:42 | access to local variable s1 |
 | CSharp7.cs:237:23:237:31 | String s1 | CSharp7.cs:237:23:237:31 | SSA def(s1) |
+| CSharp7.cs:239:13:239:45 | [input] SSA phi read(o) | CSharp7.cs:248:9:274:9 | SSA phi read(o) |
 | CSharp7.cs:239:33:239:39 | "string " | CSharp7.cs:239:31:239:44 | $"..." |
 | CSharp7.cs:239:41:239:42 | access to local variable s1 | CSharp7.cs:239:31:239:44 | $"..." |
+| CSharp7.cs:241:18:241:18 | access to local variable o | CSharp7.cs:242:9:243:9 | [input] SSA phi read(o) |
 | CSharp7.cs:241:18:241:18 | access to local variable o | CSharp7.cs:244:18:244:18 | access to local variable o |
-| CSharp7.cs:241:18:241:18 | access to local variable o | CSharp7.cs:248:9:274:9 | SSA phi read(o) |
+| CSharp7.cs:242:9:243:9 | [input] SSA phi read(o) | CSharp7.cs:248:9:274:9 | SSA phi read(o) |
+| CSharp7.cs:244:18:244:18 | access to local variable o | CSharp7.cs:244:18:244:28 | [input] SSA phi read(o) |
 | CSharp7.cs:244:18:244:18 | access to local variable o | CSharp7.cs:244:23:244:28 | Object v1 |
-| CSharp7.cs:244:18:244:18 | access to local variable o | CSharp7.cs:248:9:274:9 | SSA phi read(o) |
+| CSharp7.cs:244:18:244:18 | access to local variable o | CSharp7.cs:245:9:246:9 | [input] SSA phi read(o) |
+| CSharp7.cs:244:18:244:28 | [input] SSA phi read(o) | CSharp7.cs:248:9:274:9 | SSA phi read(o) |
+| CSharp7.cs:245:9:246:9 | [input] SSA phi read(o) | CSharp7.cs:248:9:274:9 | SSA phi read(o) |
 | CSharp7.cs:248:9:274:9 | SSA phi read(o) | CSharp7.cs:248:17:248:17 | access to local variable o |
 | CSharp7.cs:248:17:248:17 | access to local variable o | CSharp7.cs:254:27:254:27 | access to local variable o |
 | CSharp7.cs:248:17:248:17 | access to local variable o | CSharp7.cs:257:18:257:23 | Int32 i2 |
@@ -281,14 +304,16 @@
 | CSharp7.cs:283:13:283:16 | access to local variable list | CSharp7.cs:283:13:283:62 | SSA def(list) |
 | CSharp7.cs:283:13:283:62 | SSA def(list) | CSharp7.cs:285:39:285:42 | access to local variable list |
 | CSharp7.cs:283:20:283:62 | call to method Select<KeyValuePair<Int32,String>,(Int32,String)> | CSharp7.cs:283:13:283:16 | access to local variable list |
-| CSharp7.cs:283:32:283:35 | item | CSharp7.cs:283:41:283:44 | access to parameter item |
+| CSharp7.cs:283:32:283:35 | SSA param(item) | CSharp7.cs:283:41:283:44 | access to parameter item |
+| CSharp7.cs:283:32:283:35 | item | CSharp7.cs:283:32:283:35 | SSA param(item) |
 | CSharp7.cs:283:41:283:44 | access to parameter item | CSharp7.cs:283:41:283:48 | access to property Key |
 | CSharp7.cs:283:41:283:44 | access to parameter item | CSharp7.cs:283:51:283:54 | access to parameter item |
 | CSharp7.cs:283:51:283:54 | access to parameter item | CSharp7.cs:283:51:283:60 | access to property Value |
 | CSharp7.cs:285:39:285:42 | access to local variable list | CSharp7.cs:287:36:287:39 | access to local variable list |
 | CSharp7.cs:287:36:287:39 | access to local variable list | CSharp7.cs:289:32:289:35 | access to local variable list |
 | CSharp7.cs:297:18:297:18 | access to local variable x | CSharp7.cs:297:18:297:22 | SSA def(x) |
-| CSharp7.cs:297:18:297:22 | SSA def(x) | CSharp7.cs:297:25:297:25 | SSA phi(x) |
+| CSharp7.cs:297:18:297:22 | SSA def(x) | CSharp7.cs:297:18:297:22 | [input] SSA phi(x) |
+| CSharp7.cs:297:18:297:22 | [input] SSA phi(x) | CSharp7.cs:297:25:297:25 | SSA phi(x) |
 | CSharp7.cs:297:22:297:22 | 0 | CSharp7.cs:297:18:297:18 | access to local variable x |
 | CSharp7.cs:297:25:297:25 | SSA phi(x) | CSharp7.cs:297:25:297:25 | access to local variable x |
 | CSharp7.cs:297:25:297:25 | access to local variable x | CSharp7.cs:297:25:297:30 | ... < ... |
@@ -301,5 +326,6 @@
 | CSharp7.cs:297:35:297:44 | [true] ... is ... | CSharp7.cs:297:25:297:44 | [true] ... && ... |
 | CSharp7.cs:297:40:297:44 | Int32 y | CSharp7.cs:297:40:297:44 | SSA def(y) |
 | CSharp7.cs:297:40:297:44 | SSA def(y) | CSharp7.cs:299:31:299:31 | access to local variable y |
-| CSharp7.cs:297:47:297:49 | SSA def(x) | CSharp7.cs:297:25:297:25 | SSA phi(x) |
+| CSharp7.cs:297:47:297:49 | SSA def(x) | CSharp7.cs:297:47:297:49 | [input] SSA phi(x) |
+| CSharp7.cs:297:47:297:49 | [input] SSA phi(x) | CSharp7.cs:297:25:297:25 | SSA phi(x) |
 | CSharp7.cs:297:49:297:49 | access to local variable x | CSharp7.cs:297:47:297:49 | SSA def(x) |

--- a/csharp/ql/test/library-tests/dataflow/barrier-guards/BarrierFlow.cs
+++ b/csharp/ql/test/library-tests/dataflow/barrier-guards/BarrierFlow.cs
@@ -1,0 +1,83 @@
+class BarrierFlow
+{
+    static object Source(object source) => throw null;
+
+    public static void Sink(object o) { }
+
+
+    void M1()
+    {
+        var x = Source(1);
+
+        Sink(x); // $ hasValueFlow=1
+    }
+
+    void M2()
+    {
+        var x = Source(2);
+
+        if (x != "safe")
+        {
+            Sink(x); // $ hasValueFlow=2
+        }
+    }
+
+    void M3()
+    {
+        var x = Source(3);
+
+        if (x == "safe")
+        {
+            Sink(x);
+        }
+    }
+
+    void M4()
+    {
+        var x = Source(4);
+
+        if (x != "safe")
+        {
+            x = "safe";
+        }
+
+        Sink(x);
+    }
+
+    void M5()
+    {
+        var x = Source(5);
+
+        if (x == "safe")
+        {
+        }
+        else
+        {
+            x = "safe";
+        }
+
+        Sink(x);
+    }
+
+    void M6(bool b)
+    {
+        var x = Source(6);
+
+        if (b)
+        {
+            if (x != "safe1")
+            {
+                return;
+            }
+        }
+        else
+        {
+            if (x != "safe2")
+            {
+                return;
+            }
+        }
+
+        Sink(x);
+    }
+}

--- a/csharp/ql/test/library-tests/dataflow/barrier-guards/barrier-flow.expected
+++ b/csharp/ql/test/library-tests/dataflow/barrier-guards/barrier-flow.expected
@@ -1,0 +1,18 @@
+models
+edges
+| BarrierFlow.cs:10:13:10:13 | access to local variable x : Object | BarrierFlow.cs:12:14:12:14 | access to local variable x | provenance |  |
+| BarrierFlow.cs:10:17:10:25 | call to method Source : Object | BarrierFlow.cs:10:13:10:13 | access to local variable x : Object | provenance |  |
+| BarrierFlow.cs:17:13:17:13 | access to local variable x : Object | BarrierFlow.cs:21:18:21:18 | access to local variable x | provenance |  |
+| BarrierFlow.cs:17:17:17:25 | call to method Source : Object | BarrierFlow.cs:17:13:17:13 | access to local variable x : Object | provenance |  |
+nodes
+| BarrierFlow.cs:10:13:10:13 | access to local variable x : Object | semmle.label | access to local variable x : Object |
+| BarrierFlow.cs:10:17:10:25 | call to method Source : Object | semmle.label | call to method Source : Object |
+| BarrierFlow.cs:12:14:12:14 | access to local variable x | semmle.label | access to local variable x |
+| BarrierFlow.cs:17:13:17:13 | access to local variable x : Object | semmle.label | access to local variable x : Object |
+| BarrierFlow.cs:17:17:17:25 | call to method Source : Object | semmle.label | call to method Source : Object |
+| BarrierFlow.cs:21:18:21:18 | access to local variable x | semmle.label | access to local variable x |
+subpaths
+testFailures
+#select
+| BarrierFlow.cs:12:14:12:14 | access to local variable x | BarrierFlow.cs:10:17:10:25 | call to method Source : Object | BarrierFlow.cs:12:14:12:14 | access to local variable x | $@ | BarrierFlow.cs:10:17:10:25 | call to method Source : Object | call to method Source : Object |
+| BarrierFlow.cs:21:18:21:18 | access to local variable x | BarrierFlow.cs:17:17:17:25 | call to method Source : Object | BarrierFlow.cs:21:18:21:18 | access to local variable x | $@ | BarrierFlow.cs:17:17:17:25 | call to method Source : Object | call to method Source : Object |

--- a/csharp/ql/test/library-tests/dataflow/barrier-guards/barrier-flow.ql
+++ b/csharp/ql/test/library-tests/dataflow/barrier-guards/barrier-flow.ql
@@ -1,0 +1,35 @@
+/**
+ * @kind path-problem
+ */
+
+import csharp
+import semmle.code.csharp.controlflow.Guards
+
+private predicate stringConstCompare(Guard guard, Expr testedNode, AbstractValue value) {
+  guard
+      .isEquality(any(StringLiteral lit), testedNode,
+        value.(AbstractValues::BooleanValue).getValue())
+}
+
+class StringConstCompareBarrier extends DataFlow::Node {
+  StringConstCompareBarrier() {
+    this = DataFlow::BarrierGuard<stringConstCompare/3>::getABarrierNode()
+  }
+}
+
+import TestUtilities.InlineFlowTest
+import PathGraph
+
+module FlowConfig implements DataFlow::ConfigSig {
+  predicate isSource = DefaultFlowConfig::isSource/1;
+
+  predicate isSink = DefaultFlowConfig::isSink/1;
+
+  predicate isBarrier(DataFlow::Node n) { n instanceof StringConstCompareBarrier }
+}
+
+import ValueFlowTest<FlowConfig>
+
+from PathNode source, PathNode sink
+where flowPath(source, sink)
+select sink, source, sink, "$@", source, source.toString()

--- a/csharp/ql/test/library-tests/dataflow/local/DataFlowStep.expected
+++ b/csharp/ql/test/library-tests/dataflow/local/DataFlowStep.expected
@@ -10,7 +10,8 @@
 | Capture.cs:51:9:51:15 | this access | Capture.cs:63:9:63:15 | this access |
 | Capture.cs:58:21:58:21 | 1 | Capture.cs:58:17:58:17 | access to local variable i |
 | Capture.cs:61:17:61:17 | 1 | Capture.cs:61:13:61:13 | access to local variable i |
-| LocalDataFlow.cs:48:24:48:24 | b | LocalDataFlow.cs:84:21:84:21 | access to parameter b |
+| LocalDataFlow.cs:48:24:48:24 | SSA param(b) | LocalDataFlow.cs:84:21:84:21 | access to parameter b |
+| LocalDataFlow.cs:48:24:48:24 | b | LocalDataFlow.cs:48:24:48:24 | SSA param(b) |
 | LocalDataFlow.cs:51:13:51:17 | access to local variable sink0 | LocalDataFlow.cs:51:13:51:34 | SSA def(sink0) |
 | LocalDataFlow.cs:51:13:51:34 | SSA def(sink0) | LocalDataFlow.cs:52:15:52:19 | access to local variable sink0 |
 | LocalDataFlow.cs:51:21:51:34 | "taint source" | LocalDataFlow.cs:51:13:51:17 | access to local variable sink0 |
@@ -64,16 +65,18 @@
 | LocalDataFlow.cs:84:21:84:35 | [b (line 48): true] ... ? ... : ... | LocalDataFlow.cs:84:13:84:17 | access to local variable sink7 |
 | LocalDataFlow.cs:84:25:84:27 | [b (line 48): true] "a" | LocalDataFlow.cs:84:21:84:35 | [b (line 48): true] ... ? ... : ... |
 | LocalDataFlow.cs:84:31:84:35 | [b (line 48): false] access to local variable sink6 | LocalDataFlow.cs:84:21:84:35 | [b (line 48): false] ... ? ... : ... |
-| LocalDataFlow.cs:85:15:85:19 | [b (line 48): false] access to local variable sink7 | LocalDataFlow.cs:88:20:88:36 | SSA phi(sink7) |
-| LocalDataFlow.cs:85:15:85:19 | [b (line 48): true] access to local variable sink7 | LocalDataFlow.cs:88:20:88:36 | SSA phi(sink7) |
-| LocalDataFlow.cs:85:15:85:19 | [post] [b (line 48): false] access to local variable sink7 | LocalDataFlow.cs:88:20:88:36 | SSA phi(sink7) |
-| LocalDataFlow.cs:85:15:85:19 | [post] [b (line 48): true] access to local variable sink7 | LocalDataFlow.cs:88:20:88:36 | SSA phi(sink7) |
+| LocalDataFlow.cs:85:15:85:19 | [b (line 48): false] access to local variable sink7 | LocalDataFlow.cs:88:32:88:36 | [input] SSA phi(sink7) |
+| LocalDataFlow.cs:85:15:85:19 | [b (line 48): true] access to local variable sink7 | LocalDataFlow.cs:88:24:88:28 | [input] SSA phi(sink7) |
+| LocalDataFlow.cs:85:15:85:19 | [post] [b (line 48): false] access to local variable sink7 | LocalDataFlow.cs:88:32:88:36 | [input] SSA phi(sink7) |
+| LocalDataFlow.cs:85:15:85:19 | [post] [b (line 48): true] access to local variable sink7 | LocalDataFlow.cs:88:24:88:28 | [input] SSA phi(sink7) |
 | LocalDataFlow.cs:88:9:88:16 | access to local variable nonSink0 | LocalDataFlow.cs:88:9:88:36 | SSA def(nonSink0) |
 | LocalDataFlow.cs:88:9:88:36 | SSA def(nonSink0) | LocalDataFlow.cs:89:15:89:22 | access to local variable nonSink0 |
 | LocalDataFlow.cs:88:20:88:36 | ... ? ... : ... | LocalDataFlow.cs:88:9:88:16 | access to local variable nonSink0 |
 | LocalDataFlow.cs:88:20:88:36 | SSA phi(sink7) | LocalDataFlow.cs:92:29:92:33 | access to local variable sink7 |
 | LocalDataFlow.cs:88:24:88:28 | "abc" | LocalDataFlow.cs:88:20:88:36 | ... ? ... : ... |
+| LocalDataFlow.cs:88:24:88:28 | [input] SSA phi(sink7) | LocalDataFlow.cs:88:20:88:36 | SSA phi(sink7) |
 | LocalDataFlow.cs:88:32:88:36 | "def" | LocalDataFlow.cs:88:20:88:36 | ... ? ... : ... |
+| LocalDataFlow.cs:88:32:88:36 | [input] SSA phi(sink7) | LocalDataFlow.cs:88:20:88:36 | SSA phi(sink7) |
 | LocalDataFlow.cs:89:15:89:22 | [post] access to local variable nonSink0 | LocalDataFlow.cs:96:32:96:39 | access to local variable nonSink0 |
 | LocalDataFlow.cs:89:15:89:22 | access to local variable nonSink0 | LocalDataFlow.cs:96:32:96:39 | access to local variable nonSink0 |
 | LocalDataFlow.cs:92:13:92:17 | access to local variable sink8 | LocalDataFlow.cs:92:13:92:33 | SSA def(sink8) |
@@ -447,7 +450,7 @@
 | LocalDataFlow.cs:281:13:281:34 | SSA def(sink70) | LocalDataFlow.cs:282:15:282:20 | access to local variable sink70 |
 | LocalDataFlow.cs:281:22:281:26 | access to local variable sink0 | LocalDataFlow.cs:281:22:281:34 | SSA def(sink0) |
 | LocalDataFlow.cs:281:22:281:34 | ... = ... | LocalDataFlow.cs:281:13:281:18 | access to local variable sink70 |
-| LocalDataFlow.cs:281:22:281:34 | SSA def(sink0) | LocalDataFlow.cs:313:22:313:38 | SSA phi read(sink0) |
+| LocalDataFlow.cs:281:22:281:34 | SSA def(sink0) | LocalDataFlow.cs:313:22:313:29 | [input] SSA phi read(sink0) |
 | LocalDataFlow.cs:281:22:281:34 | SSA def(sink0) | LocalDataFlow.cs:313:34:313:38 | access to local variable sink0 |
 | LocalDataFlow.cs:281:30:281:34 | access to local variable sink0 | LocalDataFlow.cs:281:22:281:26 | access to local variable sink0 |
 | LocalDataFlow.cs:281:30:281:34 | access to local variable sink0 | LocalDataFlow.cs:281:22:281:34 | ... = ... |
@@ -477,12 +480,14 @@
 | LocalDataFlow.cs:307:18:307:33 | String nonSink17 | LocalDataFlow.cs:307:18:307:33 | SSA def(nonSink17) |
 | LocalDataFlow.cs:313:13:313:18 | access to local variable sink73 | LocalDataFlow.cs:313:13:313:38 | SSA def(sink73) |
 | LocalDataFlow.cs:313:13:313:38 | SSA def(sink73) | LocalDataFlow.cs:315:15:315:20 | access to local variable sink73 |
+| LocalDataFlow.cs:313:22:313:29 | [input] SSA phi read(sink0) | LocalDataFlow.cs:313:22:313:38 | SSA phi read(sink0) |
 | LocalDataFlow.cs:313:22:313:29 | access to local variable nonSink0 | LocalDataFlow.cs:313:22:313:38 | ... ?? ... |
 | LocalDataFlow.cs:313:22:313:29 | access to local variable nonSink0 | LocalDataFlow.cs:314:31:314:38 | access to local variable nonSink0 |
 | LocalDataFlow.cs:313:22:313:38 | ... ?? ... | LocalDataFlow.cs:313:13:313:18 | access to local variable sink73 |
 | LocalDataFlow.cs:313:22:313:38 | SSA phi read(sink0) | LocalDataFlow.cs:314:22:314:26 | access to local variable sink0 |
+| LocalDataFlow.cs:313:34:313:38 | [input] SSA phi read(sink0) | LocalDataFlow.cs:313:22:313:38 | SSA phi read(sink0) |
 | LocalDataFlow.cs:313:34:313:38 | access to local variable sink0 | LocalDataFlow.cs:313:22:313:38 | ... ?? ... |
-| LocalDataFlow.cs:313:34:313:38 | access to local variable sink0 | LocalDataFlow.cs:313:22:313:38 | SSA phi read(sink0) |
+| LocalDataFlow.cs:313:34:313:38 | access to local variable sink0 | LocalDataFlow.cs:313:34:313:38 | [input] SSA phi read(sink0) |
 | LocalDataFlow.cs:314:13:314:18 | access to local variable sink74 | LocalDataFlow.cs:314:13:314:38 | SSA def(sink74) |
 | LocalDataFlow.cs:314:13:314:38 | SSA def(sink74) | LocalDataFlow.cs:316:15:316:20 | access to local variable sink74 |
 | LocalDataFlow.cs:314:22:314:26 | access to local variable sink0 | LocalDataFlow.cs:314:22:314:38 | ... ?? ... |
@@ -490,37 +495,51 @@
 | LocalDataFlow.cs:314:31:314:38 | access to local variable nonSink0 | LocalDataFlow.cs:314:22:314:38 | ... ?? ... |
 | LocalDataFlow.cs:334:28:334:30 | SSA entry def(this.anInt) | LocalDataFlow.cs:334:41:334:45 | access to field anInt |
 | LocalDataFlow.cs:334:28:334:30 | this | LocalDataFlow.cs:334:41:334:45 | this access |
+| LocalDataFlow.cs:334:50:334:52 | SSA param(value) | LocalDataFlow.cs:334:64:334:68 | access to parameter value |
 | LocalDataFlow.cs:334:50:334:52 | this | LocalDataFlow.cs:334:56:334:60 | this access |
-| LocalDataFlow.cs:334:50:334:52 | value | LocalDataFlow.cs:334:64:334:68 | access to parameter value |
+| LocalDataFlow.cs:334:50:334:52 | value | LocalDataFlow.cs:334:50:334:52 | SSA param(value) |
 | LocalDataFlow.cs:334:64:334:68 | access to parameter value | LocalDataFlow.cs:334:56:334:60 | access to field anInt |
-| LocalDataFlow.cs:340:41:340:47 | tainted | LocalDataFlow.cs:342:15:342:21 | access to parameter tainted |
-| LocalDataFlow.cs:345:44:345:53 | nonTainted | LocalDataFlow.cs:347:15:347:24 | access to parameter nonTainted |
-| LocalDataFlow.cs:350:44:350:44 | x | LocalDataFlow.cs:353:21:353:21 | access to parameter x |
-| LocalDataFlow.cs:350:67:350:68 | os | LocalDataFlow.cs:356:33:356:34 | access to parameter os |
+| LocalDataFlow.cs:340:41:340:47 | SSA param(tainted) | LocalDataFlow.cs:342:15:342:21 | access to parameter tainted |
+| LocalDataFlow.cs:340:41:340:47 | tainted | LocalDataFlow.cs:340:41:340:47 | SSA param(tainted) |
+| LocalDataFlow.cs:345:44:345:53 | SSA param(nonTainted) | LocalDataFlow.cs:347:15:347:24 | access to parameter nonTainted |
+| LocalDataFlow.cs:345:44:345:53 | nonTainted | LocalDataFlow.cs:345:44:345:53 | SSA param(nonTainted) |
+| LocalDataFlow.cs:350:44:350:44 | SSA param(x) | LocalDataFlow.cs:353:21:353:21 | access to parameter x |
+| LocalDataFlow.cs:350:44:350:44 | x | LocalDataFlow.cs:350:44:350:44 | SSA param(x) |
+| LocalDataFlow.cs:350:67:350:68 | SSA param(os) | LocalDataFlow.cs:356:33:356:34 | access to parameter os |
+| LocalDataFlow.cs:350:67:350:68 | os | LocalDataFlow.cs:350:67:350:68 | SSA param(os) |
 | LocalDataFlow.cs:353:21:353:21 | access to parameter x | LocalDataFlow.cs:353:16:353:17 | access to local variable x1 |
 | LocalDataFlow.cs:353:21:353:21 | access to parameter x | LocalDataFlow.cs:353:16:353:21 | ... = ... |
 | LocalDataFlow.cs:356:33:356:34 | access to parameter os | LocalDataFlow.cs:356:27:356:29 | access to local variable os2 |
 | LocalDataFlow.cs:356:33:356:34 | access to parameter os | LocalDataFlow.cs:356:27:356:34 | ... = ... |
-| LocalDataFlow.cs:361:41:361:44 | args | LocalDataFlow.cs:363:29:363:32 | access to parameter args |
+| LocalDataFlow.cs:361:41:361:44 | SSA param(args) | LocalDataFlow.cs:363:29:363:32 | access to parameter args |
+| LocalDataFlow.cs:361:41:361:44 | args | LocalDataFlow.cs:361:41:361:44 | SSA param(args) |
 | LocalDataFlow.cs:363:29:363:32 | [post] access to parameter args | LocalDataFlow.cs:364:27:364:30 | access to parameter args |
 | LocalDataFlow.cs:363:29:363:32 | access to parameter args | LocalDataFlow.cs:364:27:364:30 | access to parameter args |
 | LocalDataFlow.cs:363:29:363:32 | call to operator implicit conversion | LocalDataFlow.cs:363:22:363:25 | access to local variable span |
 | LocalDataFlow.cs:364:27:364:30 | call to operator implicit conversion | LocalDataFlow.cs:364:23:364:23 | access to local variable x |
-| LocalDataFlow.cs:367:23:367:24 | b1 | LocalDataFlow.cs:371:13:371:14 | access to parameter b1 |
-| LocalDataFlow.cs:367:32:367:33 | b2 | LocalDataFlow.cs:374:17:374:18 | access to parameter b2 |
+| LocalDataFlow.cs:367:23:367:24 | SSA param(b1) | LocalDataFlow.cs:371:13:371:14 | access to parameter b1 |
+| LocalDataFlow.cs:367:23:367:24 | b1 | LocalDataFlow.cs:367:23:367:24 | SSA param(b1) |
+| LocalDataFlow.cs:367:32:367:33 | SSA param(b2) | LocalDataFlow.cs:374:17:374:18 | access to parameter b2 |
+| LocalDataFlow.cs:367:32:367:33 | b2 | LocalDataFlow.cs:367:32:367:33 | SSA param(b2) |
 | LocalDataFlow.cs:369:17:369:18 | "" | LocalDataFlow.cs:369:13:369:13 | access to local variable x |
 | LocalDataFlow.cs:373:13:373:13 | access to local variable x | LocalDataFlow.cs:373:13:373:25 | SSA def(x) |
+| LocalDataFlow.cs:373:13:373:25 | SSA def(x) | LocalDataFlow.cs:374:17:374:18 | [input] SSA phi(x) |
 | LocalDataFlow.cs:373:13:373:25 | SSA def(x) | LocalDataFlow.cs:376:35:376:35 | access to local variable x |
-| LocalDataFlow.cs:373:13:373:25 | SSA def(x) | LocalDataFlow.cs:382:9:382:17 | SSA phi(x) |
 | LocalDataFlow.cs:373:17:373:25 | "tainted" | LocalDataFlow.cs:373:13:373:13 | access to local variable x |
+| LocalDataFlow.cs:374:17:374:18 | [input] SSA phi(x) | LocalDataFlow.cs:382:9:382:17 | SSA phi(x) |
 | LocalDataFlow.cs:381:13:381:13 | access to local variable x | LocalDataFlow.cs:381:13:381:29 | SSA def(x) |
-| LocalDataFlow.cs:381:13:381:29 | SSA def(x) | LocalDataFlow.cs:382:9:382:17 | SSA phi(x) |
+| LocalDataFlow.cs:381:13:381:29 | SSA def(x) | LocalDataFlow.cs:381:13:381:29 | [input] SSA phi(x) |
+| LocalDataFlow.cs:381:13:381:29 | [input] SSA phi(x) | LocalDataFlow.cs:382:9:382:17 | SSA phi(x) |
 | LocalDataFlow.cs:381:17:381:29 | "not tainted" | LocalDataFlow.cs:381:13:381:13 | access to local variable x |
 | LocalDataFlow.cs:382:9:382:17 | SSA phi(x) | LocalDataFlow.cs:382:15:382:15 | access to local variable x |
 | SSA.cs:5:17:5:17 | SSA entry def(this.S) | SSA.cs:67:9:67:14 | access to field S |
+| SSA.cs:5:17:5:17 | [input] SSA def(this.S) | SSA.cs:136:23:136:28 | SSA def(this.S) |
+| SSA.cs:5:17:5:17 | [input] SSA qualifier def(this.S.SsaFieldNonSink0) | SSA.cs:136:23:136:28 | SSA qualifier def(this.S.SsaFieldNonSink0) |
 | SSA.cs:5:17:5:17 | this | SSA.cs:67:9:67:12 | this access |
-| SSA.cs:5:26:5:32 | tainted | SSA.cs:8:24:8:30 | access to parameter tainted |
-| SSA.cs:5:42:5:51 | nonTainted | SSA.cs:12:24:12:33 | access to parameter nonTainted |
+| SSA.cs:5:26:5:32 | SSA param(tainted) | SSA.cs:8:24:8:30 | access to parameter tainted |
+| SSA.cs:5:26:5:32 | tainted | SSA.cs:5:26:5:32 | SSA param(tainted) |
+| SSA.cs:5:42:5:51 | SSA param(nonTainted) | SSA.cs:12:24:12:33 | access to parameter nonTainted |
+| SSA.cs:5:42:5:51 | nonTainted | SSA.cs:5:42:5:51 | SSA param(nonTainted) |
 | SSA.cs:8:13:8:20 | access to local variable ssaSink0 | SSA.cs:8:13:8:30 | SSA def(ssaSink0) |
 | SSA.cs:8:13:8:30 | SSA def(ssaSink0) | SSA.cs:9:15:9:22 | access to local variable ssaSink0 |
 | SSA.cs:8:24:8:30 | access to parameter tainted | SSA.cs:8:13:8:20 | access to local variable ssaSink0 |
@@ -533,78 +552,110 @@
 | SSA.cs:12:24:12:33 | access to parameter nonTainted | SSA.cs:23:13:23:22 | access to parameter nonTainted |
 | SSA.cs:13:15:13:22 | [post] access to local variable nonSink0 | SSA.cs:19:13:19:20 | access to local variable nonSink0 |
 | SSA.cs:13:15:13:22 | access to local variable nonSink0 | SSA.cs:19:13:19:20 | access to local variable nonSink0 |
+| SSA.cs:16:13:16:20 | [post] access to local variable ssaSink0 | SSA.cs:23:13:23:33 | [input] SSA phi read(ssaSink0) |
 | SSA.cs:16:13:16:20 | [post] access to local variable ssaSink0 | SSA.cs:24:24:24:31 | access to local variable ssaSink0 |
-| SSA.cs:16:13:16:20 | [post] access to local variable ssaSink0 | SSA.cs:25:9:25:24 | SSA phi read(ssaSink0) |
+| SSA.cs:16:13:16:20 | access to local variable ssaSink0 | SSA.cs:23:13:23:33 | [input] SSA phi read(ssaSink0) |
 | SSA.cs:16:13:16:20 | access to local variable ssaSink0 | SSA.cs:24:24:24:31 | access to local variable ssaSink0 |
-| SSA.cs:16:13:16:20 | access to local variable ssaSink0 | SSA.cs:25:9:25:24 | SSA phi read(ssaSink0) |
+| SSA.cs:19:13:19:20 | [post] access to local variable nonSink0 | SSA.cs:29:13:29:33 | [input] SSA phi read(nonSink0) |
 | SSA.cs:19:13:19:20 | [post] access to local variable nonSink0 | SSA.cs:30:24:30:31 | access to local variable nonSink0 |
-| SSA.cs:19:13:19:20 | [post] access to local variable nonSink0 | SSA.cs:31:9:31:24 | SSA phi read(nonSink0) |
+| SSA.cs:19:13:19:20 | access to local variable nonSink0 | SSA.cs:29:13:29:33 | [input] SSA phi read(nonSink0) |
 | SSA.cs:19:13:19:20 | access to local variable nonSink0 | SSA.cs:30:24:30:31 | access to local variable nonSink0 |
-| SSA.cs:19:13:19:20 | access to local variable nonSink0 | SSA.cs:31:9:31:24 | SSA phi read(nonSink0) |
 | SSA.cs:22:16:22:23 | access to local variable ssaSink1 | SSA.cs:22:16:22:28 | SSA def(ssaSink1) |
-| SSA.cs:22:16:22:28 | SSA def(ssaSink1) | SSA.cs:25:9:25:24 | SSA phi(ssaSink1) |
+| SSA.cs:22:16:22:28 | SSA def(ssaSink1) | SSA.cs:23:13:23:33 | [input] SSA phi(ssaSink1) |
 | SSA.cs:22:27:22:28 | "" | SSA.cs:22:16:22:23 | access to local variable ssaSink1 |
 | SSA.cs:23:13:23:22 | [post] access to parameter nonTainted | SSA.cs:29:13:29:22 | access to parameter nonTainted |
 | SSA.cs:23:13:23:22 | access to parameter nonTainted | SSA.cs:29:13:29:22 | access to parameter nonTainted |
+| SSA.cs:23:13:23:33 | [input] SSA phi read(ssaSink0) | SSA.cs:25:9:25:24 | SSA phi read(ssaSink0) |
+| SSA.cs:23:13:23:33 | [input] SSA phi(ssaSink1) | SSA.cs:25:9:25:24 | SSA phi(ssaSink1) |
 | SSA.cs:24:13:24:20 | access to local variable ssaSink1 | SSA.cs:24:13:24:31 | SSA def(ssaSink1) |
-| SSA.cs:24:13:24:31 | SSA def(ssaSink1) | SSA.cs:25:9:25:24 | SSA phi(ssaSink1) |
+| SSA.cs:24:13:24:31 | SSA def(ssaSink1) | SSA.cs:24:13:24:31 | [input] SSA phi(ssaSink1) |
+| SSA.cs:24:13:24:31 | [input] SSA phi read(ssaSink0) | SSA.cs:25:9:25:24 | SSA phi read(ssaSink0) |
+| SSA.cs:24:13:24:31 | [input] SSA phi(ssaSink1) | SSA.cs:25:9:25:24 | SSA phi(ssaSink1) |
 | SSA.cs:24:24:24:31 | access to local variable ssaSink0 | SSA.cs:24:13:24:20 | access to local variable ssaSink1 |
-| SSA.cs:24:24:24:31 | access to local variable ssaSink0 | SSA.cs:25:9:25:24 | SSA phi read(ssaSink0) |
+| SSA.cs:24:24:24:31 | access to local variable ssaSink0 | SSA.cs:24:13:24:31 | [input] SSA phi read(ssaSink0) |
+| SSA.cs:25:9:25:24 | SSA phi read(ssaSink0) | SSA.cs:35:13:35:33 | [input] SSA phi read(ssaSink0) |
 | SSA.cs:25:9:25:24 | SSA phi read(ssaSink0) | SSA.cs:37:24:37:31 | access to local variable ssaSink0 |
-| SSA.cs:25:9:25:24 | SSA phi read(ssaSink0) | SSA.cs:43:9:43:24 | SSA phi read(ssaSink0) |
 | SSA.cs:25:9:25:24 | SSA phi(ssaSink1) | SSA.cs:25:15:25:22 | access to local variable ssaSink1 |
 | SSA.cs:28:16:28:23 | access to local variable nonSink1 | SSA.cs:28:16:28:28 | SSA def(nonSink1) |
-| SSA.cs:28:16:28:28 | SSA def(nonSink1) | SSA.cs:31:9:31:24 | SSA phi(nonSink1) |
+| SSA.cs:28:16:28:28 | SSA def(nonSink1) | SSA.cs:29:13:29:33 | [input] SSA phi(nonSink1) |
 | SSA.cs:28:27:28:28 | "" | SSA.cs:28:16:28:23 | access to local variable nonSink1 |
 | SSA.cs:29:13:29:22 | [post] access to parameter nonTainted | SSA.cs:35:13:35:22 | access to parameter nonTainted |
 | SSA.cs:29:13:29:22 | access to parameter nonTainted | SSA.cs:35:13:35:22 | access to parameter nonTainted |
+| SSA.cs:29:13:29:33 | [input] SSA phi read(nonSink0) | SSA.cs:31:9:31:24 | SSA phi read(nonSink0) |
+| SSA.cs:29:13:29:33 | [input] SSA phi(nonSink1) | SSA.cs:31:9:31:24 | SSA phi(nonSink1) |
 | SSA.cs:30:13:30:20 | access to local variable nonSink1 | SSA.cs:30:13:30:31 | SSA def(nonSink1) |
-| SSA.cs:30:13:30:31 | SSA def(nonSink1) | SSA.cs:31:9:31:24 | SSA phi(nonSink1) |
+| SSA.cs:30:13:30:31 | SSA def(nonSink1) | SSA.cs:30:13:30:31 | [input] SSA phi(nonSink1) |
+| SSA.cs:30:13:30:31 | [input] SSA phi read(nonSink0) | SSA.cs:31:9:31:24 | SSA phi read(nonSink0) |
+| SSA.cs:30:13:30:31 | [input] SSA phi(nonSink1) | SSA.cs:31:9:31:24 | SSA phi(nonSink1) |
 | SSA.cs:30:24:30:31 | access to local variable nonSink0 | SSA.cs:30:13:30:20 | access to local variable nonSink1 |
-| SSA.cs:30:24:30:31 | access to local variable nonSink0 | SSA.cs:31:9:31:24 | SSA phi read(nonSink0) |
+| SSA.cs:30:24:30:31 | access to local variable nonSink0 | SSA.cs:30:13:30:31 | [input] SSA phi read(nonSink0) |
+| SSA.cs:31:9:31:24 | SSA phi read(nonSink0) | SSA.cs:47:13:47:33 | [input] SSA phi read(nonSink0) |
 | SSA.cs:31:9:31:24 | SSA phi read(nonSink0) | SSA.cs:49:24:49:31 | access to local variable nonSink0 |
-| SSA.cs:31:9:31:24 | SSA phi read(nonSink0) | SSA.cs:55:9:55:24 | SSA phi read(nonSink0) |
 | SSA.cs:31:9:31:24 | SSA phi(nonSink1) | SSA.cs:31:15:31:22 | access to local variable nonSink1 |
 | SSA.cs:34:16:34:23 | access to local variable ssaSink2 | SSA.cs:34:16:34:28 | SSA def(ssaSink2) |
-| SSA.cs:34:16:34:28 | SSA def(ssaSink2) | SSA.cs:43:9:43:24 | SSA phi(ssaSink2) |
+| SSA.cs:34:16:34:28 | SSA def(ssaSink2) | SSA.cs:35:13:35:33 | [input] SSA phi(ssaSink2) |
 | SSA.cs:34:27:34:28 | "" | SSA.cs:34:16:34:23 | access to local variable ssaSink2 |
+| SSA.cs:35:13:35:22 | [post] access to parameter nonTainted | SSA.cs:35:13:35:33 | [input] SSA phi read(nonTainted) |
 | SSA.cs:35:13:35:22 | [post] access to parameter nonTainted | SSA.cs:38:17:38:26 | access to parameter nonTainted |
-| SSA.cs:35:13:35:22 | [post] access to parameter nonTainted | SSA.cs:43:9:43:24 | SSA phi read(nonTainted) |
+| SSA.cs:35:13:35:22 | access to parameter nonTainted | SSA.cs:35:13:35:33 | [input] SSA phi read(nonTainted) |
 | SSA.cs:35:13:35:22 | access to parameter nonTainted | SSA.cs:38:17:38:26 | access to parameter nonTainted |
-| SSA.cs:35:13:35:22 | access to parameter nonTainted | SSA.cs:43:9:43:24 | SSA phi read(nonTainted) |
+| SSA.cs:35:13:35:33 | [input] SSA phi read(nonTainted) | SSA.cs:43:9:43:24 | SSA phi read(nonTainted) |
+| SSA.cs:35:13:35:33 | [input] SSA phi read(ssaSink0) | SSA.cs:43:9:43:24 | SSA phi read(ssaSink0) |
+| SSA.cs:35:13:35:33 | [input] SSA phi(ssaSink2) | SSA.cs:43:9:43:24 | SSA phi(ssaSink2) |
 | SSA.cs:37:13:37:20 | access to local variable ssaSink2 | SSA.cs:37:13:37:31 | SSA def(ssaSink2) |
 | SSA.cs:37:13:37:31 | SSA def(ssaSink2) | SSA.cs:39:21:39:28 | access to local variable ssaSink2 |
 | SSA.cs:37:13:37:31 | SSA def(ssaSink2) | SSA.cs:41:21:41:28 | access to local variable ssaSink2 |
 | SSA.cs:37:24:37:31 | access to local variable ssaSink0 | SSA.cs:37:13:37:20 | access to local variable ssaSink2 |
-| SSA.cs:37:24:37:31 | access to local variable ssaSink0 | SSA.cs:43:9:43:24 | SSA phi read(ssaSink0) |
-| SSA.cs:38:17:38:26 | [post] access to parameter nonTainted | SSA.cs:43:9:43:24 | SSA phi read(nonTainted) |
-| SSA.cs:38:17:38:26 | access to parameter nonTainted | SSA.cs:43:9:43:24 | SSA phi read(nonTainted) |
-| SSA.cs:39:21:39:28 | [post] access to local variable ssaSink2 | SSA.cs:43:9:43:24 | SSA phi(ssaSink2) |
-| SSA.cs:39:21:39:28 | access to local variable ssaSink2 | SSA.cs:43:9:43:24 | SSA phi(ssaSink2) |
-| SSA.cs:41:21:41:28 | [post] access to local variable ssaSink2 | SSA.cs:43:9:43:24 | SSA phi(ssaSink2) |
-| SSA.cs:41:21:41:28 | access to local variable ssaSink2 | SSA.cs:43:9:43:24 | SSA phi(ssaSink2) |
+| SSA.cs:37:24:37:31 | access to local variable ssaSink0 | SSA.cs:39:17:39:29 | [input] SSA phi read(ssaSink0) |
+| SSA.cs:37:24:37:31 | access to local variable ssaSink0 | SSA.cs:41:17:41:29 | [input] SSA phi read(ssaSink0) |
+| SSA.cs:38:17:38:26 | [post] access to parameter nonTainted | SSA.cs:39:17:39:29 | [input] SSA phi read(nonTainted) |
+| SSA.cs:38:17:38:26 | [post] access to parameter nonTainted | SSA.cs:41:17:41:29 | [input] SSA phi read(nonTainted) |
+| SSA.cs:38:17:38:26 | access to parameter nonTainted | SSA.cs:39:17:39:29 | [input] SSA phi read(nonTainted) |
+| SSA.cs:38:17:38:26 | access to parameter nonTainted | SSA.cs:41:17:41:29 | [input] SSA phi read(nonTainted) |
+| SSA.cs:39:17:39:29 | [input] SSA phi read(nonTainted) | SSA.cs:43:9:43:24 | SSA phi read(nonTainted) |
+| SSA.cs:39:17:39:29 | [input] SSA phi read(ssaSink0) | SSA.cs:43:9:43:24 | SSA phi read(ssaSink0) |
+| SSA.cs:39:17:39:29 | [input] SSA phi(ssaSink2) | SSA.cs:43:9:43:24 | SSA phi(ssaSink2) |
+| SSA.cs:39:21:39:28 | [post] access to local variable ssaSink2 | SSA.cs:39:17:39:29 | [input] SSA phi(ssaSink2) |
+| SSA.cs:39:21:39:28 | access to local variable ssaSink2 | SSA.cs:39:17:39:29 | [input] SSA phi(ssaSink2) |
+| SSA.cs:41:17:41:29 | [input] SSA phi read(nonTainted) | SSA.cs:43:9:43:24 | SSA phi read(nonTainted) |
+| SSA.cs:41:17:41:29 | [input] SSA phi read(ssaSink0) | SSA.cs:43:9:43:24 | SSA phi read(ssaSink0) |
+| SSA.cs:41:17:41:29 | [input] SSA phi(ssaSink2) | SSA.cs:43:9:43:24 | SSA phi(ssaSink2) |
+| SSA.cs:41:21:41:28 | [post] access to local variable ssaSink2 | SSA.cs:41:17:41:29 | [input] SSA phi(ssaSink2) |
+| SSA.cs:41:21:41:28 | access to local variable ssaSink2 | SSA.cs:41:17:41:29 | [input] SSA phi(ssaSink2) |
 | SSA.cs:43:9:43:24 | SSA phi read(nonTainted) | SSA.cs:47:13:47:22 | access to parameter nonTainted |
+| SSA.cs:43:9:43:24 | SSA phi read(ssaSink0) | SSA.cs:89:13:89:33 | [input] SSA phi read(ssaSink0) |
 | SSA.cs:43:9:43:24 | SSA phi read(ssaSink0) | SSA.cs:91:24:91:31 | access to local variable ssaSink0 |
-| SSA.cs:43:9:43:24 | SSA phi read(ssaSink0) | SSA.cs:97:9:97:32 | SSA phi read(ssaSink0) |
 | SSA.cs:43:9:43:24 | SSA phi(ssaSink2) | SSA.cs:43:15:43:22 | access to local variable ssaSink2 |
 | SSA.cs:46:16:46:23 | access to local variable nonSink2 | SSA.cs:46:16:46:28 | SSA def(nonSink2) |
-| SSA.cs:46:16:46:28 | SSA def(nonSink2) | SSA.cs:55:9:55:24 | SSA phi(nonSink2) |
+| SSA.cs:46:16:46:28 | SSA def(nonSink2) | SSA.cs:47:13:47:33 | [input] SSA phi(nonSink2) |
 | SSA.cs:46:27:46:28 | "" | SSA.cs:46:16:46:23 | access to local variable nonSink2 |
+| SSA.cs:47:13:47:22 | [post] access to parameter nonTainted | SSA.cs:47:13:47:33 | [input] SSA phi read(nonTainted) |
 | SSA.cs:47:13:47:22 | [post] access to parameter nonTainted | SSA.cs:50:17:50:26 | access to parameter nonTainted |
-| SSA.cs:47:13:47:22 | [post] access to parameter nonTainted | SSA.cs:55:9:55:24 | SSA phi read(nonTainted) |
+| SSA.cs:47:13:47:22 | access to parameter nonTainted | SSA.cs:47:13:47:33 | [input] SSA phi read(nonTainted) |
 | SSA.cs:47:13:47:22 | access to parameter nonTainted | SSA.cs:50:17:50:26 | access to parameter nonTainted |
-| SSA.cs:47:13:47:22 | access to parameter nonTainted | SSA.cs:55:9:55:24 | SSA phi read(nonTainted) |
+| SSA.cs:47:13:47:33 | [input] SSA phi read(nonSink0) | SSA.cs:55:9:55:24 | SSA phi read(nonSink0) |
+| SSA.cs:47:13:47:33 | [input] SSA phi read(nonTainted) | SSA.cs:55:9:55:24 | SSA phi read(nonTainted) |
+| SSA.cs:47:13:47:33 | [input] SSA phi(nonSink2) | SSA.cs:55:9:55:24 | SSA phi(nonSink2) |
 | SSA.cs:49:13:49:20 | access to local variable nonSink2 | SSA.cs:49:13:49:31 | SSA def(nonSink2) |
 | SSA.cs:49:13:49:31 | SSA def(nonSink2) | SSA.cs:51:21:51:28 | access to local variable nonSink2 |
 | SSA.cs:49:13:49:31 | SSA def(nonSink2) | SSA.cs:53:21:53:28 | access to local variable nonSink2 |
 | SSA.cs:49:24:49:31 | access to local variable nonSink0 | SSA.cs:49:13:49:20 | access to local variable nonSink2 |
-| SSA.cs:49:24:49:31 | access to local variable nonSink0 | SSA.cs:55:9:55:24 | SSA phi read(nonSink0) |
-| SSA.cs:50:17:50:26 | [post] access to parameter nonTainted | SSA.cs:55:9:55:24 | SSA phi read(nonTainted) |
-| SSA.cs:50:17:50:26 | access to parameter nonTainted | SSA.cs:55:9:55:24 | SSA phi read(nonTainted) |
-| SSA.cs:51:21:51:28 | [post] access to local variable nonSink2 | SSA.cs:55:9:55:24 | SSA phi(nonSink2) |
-| SSA.cs:51:21:51:28 | access to local variable nonSink2 | SSA.cs:55:9:55:24 | SSA phi(nonSink2) |
-| SSA.cs:53:21:53:28 | [post] access to local variable nonSink2 | SSA.cs:55:9:55:24 | SSA phi(nonSink2) |
-| SSA.cs:53:21:53:28 | access to local variable nonSink2 | SSA.cs:55:9:55:24 | SSA phi(nonSink2) |
+| SSA.cs:49:24:49:31 | access to local variable nonSink0 | SSA.cs:51:17:51:29 | [input] SSA phi read(nonSink0) |
+| SSA.cs:49:24:49:31 | access to local variable nonSink0 | SSA.cs:53:17:53:29 | [input] SSA phi read(nonSink0) |
+| SSA.cs:50:17:50:26 | [post] access to parameter nonTainted | SSA.cs:51:17:51:29 | [input] SSA phi read(nonTainted) |
+| SSA.cs:50:17:50:26 | [post] access to parameter nonTainted | SSA.cs:53:17:53:29 | [input] SSA phi read(nonTainted) |
+| SSA.cs:50:17:50:26 | access to parameter nonTainted | SSA.cs:51:17:51:29 | [input] SSA phi read(nonTainted) |
+| SSA.cs:50:17:50:26 | access to parameter nonTainted | SSA.cs:53:17:53:29 | [input] SSA phi read(nonTainted) |
+| SSA.cs:51:17:51:29 | [input] SSA phi read(nonSink0) | SSA.cs:55:9:55:24 | SSA phi read(nonSink0) |
+| SSA.cs:51:17:51:29 | [input] SSA phi read(nonTainted) | SSA.cs:55:9:55:24 | SSA phi read(nonTainted) |
+| SSA.cs:51:17:51:29 | [input] SSA phi(nonSink2) | SSA.cs:55:9:55:24 | SSA phi(nonSink2) |
+| SSA.cs:51:21:51:28 | [post] access to local variable nonSink2 | SSA.cs:51:17:51:29 | [input] SSA phi(nonSink2) |
+| SSA.cs:51:21:51:28 | access to local variable nonSink2 | SSA.cs:51:17:51:29 | [input] SSA phi(nonSink2) |
+| SSA.cs:53:17:53:29 | [input] SSA phi read(nonSink0) | SSA.cs:55:9:55:24 | SSA phi read(nonSink0) |
+| SSA.cs:53:17:53:29 | [input] SSA phi read(nonTainted) | SSA.cs:55:9:55:24 | SSA phi read(nonTainted) |
+| SSA.cs:53:17:53:29 | [input] SSA phi(nonSink2) | SSA.cs:55:9:55:24 | SSA phi(nonSink2) |
+| SSA.cs:53:21:53:28 | [post] access to local variable nonSink2 | SSA.cs:53:17:53:29 | [input] SSA phi(nonSink2) |
+| SSA.cs:53:21:53:28 | access to local variable nonSink2 | SSA.cs:53:17:53:29 | [input] SSA phi(nonSink2) |
 | SSA.cs:55:9:55:24 | SSA phi read(nonSink0) | SSA.cs:63:23:63:30 | access to local variable nonSink0 |
 | SSA.cs:55:9:55:24 | SSA phi read(nonTainted) | SSA.cs:89:13:89:22 | access to parameter nonTainted |
 | SSA.cs:55:9:55:24 | SSA phi(nonSink2) | SSA.cs:55:15:55:22 | access to local variable nonSink2 |
@@ -613,28 +664,28 @@
 | SSA.cs:58:27:58:33 | access to parameter tainted | SSA.cs:58:16:58:23 | access to local variable ssaSink3 |
 | SSA.cs:58:27:58:33 | access to parameter tainted | SSA.cs:67:32:67:38 | access to parameter tainted |
 | SSA.cs:59:23:59:30 | SSA def(ssaSink3) | SSA.cs:60:15:60:22 | access to local variable ssaSink3 |
-| SSA.cs:59:23:59:30 | [post] access to local variable ssaSink3 | SSA.cs:59:23:59:30 | SSA def(ssaSink3) |
+| SSA.cs:59:23:59:30 | [post] access to local variable ssaSink3 | SSA.cs:89:13:89:33 | [input] SSA def(ssaSink3) |
 | SSA.cs:59:23:59:30 | access to local variable ssaSink3 | SSA.cs:59:23:59:30 | SSA def(ssaSink3) |
-| SSA.cs:59:23:59:30 | access to local variable ssaSink3 | SSA.cs:59:23:59:30 | SSA def(ssaSink3) |
+| SSA.cs:59:23:59:30 | access to local variable ssaSink3 | SSA.cs:89:13:89:33 | [input] SSA def(ssaSink3) |
 | SSA.cs:63:23:63:30 | SSA def(nonSink0) | SSA.cs:64:15:64:22 | access to local variable nonSink0 |
-| SSA.cs:63:23:63:30 | [post] access to local variable nonSink0 | SSA.cs:63:23:63:30 | SSA def(nonSink0) |
+| SSA.cs:63:23:63:30 | [post] access to local variable nonSink0 | SSA.cs:89:13:89:33 | [input] SSA def(nonSink0) |
 | SSA.cs:63:23:63:30 | access to local variable nonSink0 | SSA.cs:63:23:63:30 | SSA def(nonSink0) |
-| SSA.cs:63:23:63:30 | access to local variable nonSink0 | SSA.cs:63:23:63:30 | SSA def(nonSink0) |
+| SSA.cs:63:23:63:30 | access to local variable nonSink0 | SSA.cs:89:13:89:33 | [input] SSA def(nonSink0) |
 | SSA.cs:67:9:67:12 | [post] this access | SSA.cs:68:23:68:26 | this access |
 | SSA.cs:67:9:67:12 | this access | SSA.cs:68:23:68:26 | this access |
 | SSA.cs:67:9:67:14 | [post] access to field S | SSA.cs:68:23:68:28 | access to field S |
 | SSA.cs:67:9:67:14 | access to field S | SSA.cs:68:23:68:28 | access to field S |
 | SSA.cs:67:9:67:28 | access to field SsaFieldSink0 | SSA.cs:67:9:67:38 | SSA def(this.S.SsaFieldSink0) |
-| SSA.cs:67:9:67:38 | SSA def(this.S.SsaFieldSink0) | SSA.cs:68:23:68:28 | SSA qualifier def(this.S.SsaFieldSink0) |
+| SSA.cs:67:9:67:38 | SSA def(this.S.SsaFieldSink0) | SSA.cs:89:13:89:33 | [input] SSA qualifier def(this.S.SsaFieldSink0) |
 | SSA.cs:67:32:67:38 | access to parameter tainted | SSA.cs:67:9:67:28 | access to field SsaFieldSink0 |
 | SSA.cs:67:32:67:38 | access to parameter tainted | SSA.cs:77:20:77:26 | access to parameter tainted |
 | SSA.cs:68:23:68:26 | [post] this access | SSA.cs:69:15:69:18 | this access |
 | SSA.cs:68:23:68:26 | this access | SSA.cs:69:15:69:18 | this access |
 | SSA.cs:68:23:68:28 | SSA def(this.S) | SSA.cs:69:15:69:20 | access to field S |
 | SSA.cs:68:23:68:28 | SSA qualifier def(this.S.SsaFieldSink0) | SSA.cs:69:15:69:34 | access to field SsaFieldSink0 |
-| SSA.cs:68:23:68:28 | [post] access to field S | SSA.cs:68:23:68:28 | SSA def(this.S) |
+| SSA.cs:68:23:68:28 | [post] access to field S | SSA.cs:89:13:89:33 | [input] SSA def(this.S) |
 | SSA.cs:68:23:68:28 | access to field S | SSA.cs:68:23:68:28 | SSA def(this.S) |
-| SSA.cs:68:23:68:28 | access to field S | SSA.cs:68:23:68:28 | SSA def(this.S) |
+| SSA.cs:68:23:68:28 | access to field S | SSA.cs:89:13:89:33 | [input] SSA def(this.S) |
 | SSA.cs:69:15:69:18 | [post] this access | SSA.cs:72:9:72:12 | this access |
 | SSA.cs:69:15:69:18 | this access | SSA.cs:72:9:72:12 | this access |
 | SSA.cs:69:15:69:20 | [post] access to field S | SSA.cs:72:9:72:14 | access to field S |
@@ -644,15 +695,15 @@
 | SSA.cs:72:9:72:14 | [post] access to field S | SSA.cs:73:23:73:28 | access to field S |
 | SSA.cs:72:9:72:14 | access to field S | SSA.cs:73:23:73:28 | access to field S |
 | SSA.cs:72:9:72:31 | access to field SsaFieldNonSink0 | SSA.cs:72:9:72:36 | SSA def(this.S.SsaFieldNonSink0) |
-| SSA.cs:72:9:72:36 | SSA def(this.S.SsaFieldNonSink0) | SSA.cs:73:23:73:28 | SSA qualifier def(this.S.SsaFieldNonSink0) |
+| SSA.cs:72:9:72:36 | SSA def(this.S.SsaFieldNonSink0) | SSA.cs:89:13:89:33 | [input] SSA qualifier def(this.S.SsaFieldNonSink0) |
 | SSA.cs:72:35:72:36 | "" | SSA.cs:72:9:72:31 | access to field SsaFieldNonSink0 |
 | SSA.cs:73:23:73:26 | [post] this access | SSA.cs:74:15:74:18 | this access |
 | SSA.cs:73:23:73:26 | this access | SSA.cs:74:15:74:18 | this access |
 | SSA.cs:73:23:73:28 | SSA def(this.S) | SSA.cs:74:15:74:20 | access to field S |
 | SSA.cs:73:23:73:28 | SSA qualifier def(this.S.SsaFieldNonSink0) | SSA.cs:74:15:74:37 | access to field SsaFieldNonSink0 |
-| SSA.cs:73:23:73:28 | [post] access to field S | SSA.cs:73:23:73:28 | SSA def(this.S) |
+| SSA.cs:73:23:73:28 | [post] access to field S | SSA.cs:89:13:89:33 | [input] SSA def(this.S) |
 | SSA.cs:73:23:73:28 | access to field S | SSA.cs:73:23:73:28 | SSA def(this.S) |
-| SSA.cs:73:23:73:28 | access to field S | SSA.cs:73:23:73:28 | SSA def(this.S) |
+| SSA.cs:73:23:73:28 | access to field S | SSA.cs:89:13:89:33 | [input] SSA def(this.S) |
 | SSA.cs:74:15:74:18 | [post] this access | SSA.cs:80:9:80:12 | this access |
 | SSA.cs:74:15:74:18 | this access | SSA.cs:80:9:80:12 | this access |
 | SSA.cs:74:15:74:20 | [post] access to field S | SSA.cs:80:9:80:14 | access to field S |
@@ -663,10 +714,10 @@
 | SSA.cs:77:20:77:26 | access to parameter tainted | SSA.cs:80:35:80:41 | access to parameter tainted |
 | SSA.cs:78:21:78:28 | SSA def(nonSink0) | SSA.cs:79:15:79:22 | access to local variable nonSink0 |
 | SSA.cs:78:21:78:28 | access to local variable nonSink0 | SSA.cs:78:21:78:28 | SSA def(nonSink0) |
+| SSA.cs:79:15:79:22 | [post] access to local variable nonSink0 | SSA.cs:102:13:102:33 | [input] SSA phi read(nonSink0) |
 | SSA.cs:79:15:79:22 | [post] access to local variable nonSink0 | SSA.cs:104:24:104:31 | access to local variable nonSink0 |
-| SSA.cs:79:15:79:22 | [post] access to local variable nonSink0 | SSA.cs:110:9:110:32 | SSA phi read(nonSink0) |
+| SSA.cs:79:15:79:22 | access to local variable nonSink0 | SSA.cs:102:13:102:33 | [input] SSA phi read(nonSink0) |
 | SSA.cs:79:15:79:22 | access to local variable nonSink0 | SSA.cs:104:24:104:31 | access to local variable nonSink0 |
-| SSA.cs:79:15:79:22 | access to local variable nonSink0 | SSA.cs:110:9:110:32 | SSA phi read(nonSink0) |
 | SSA.cs:80:9:80:12 | [post] this access | SSA.cs:81:21:81:24 | this access |
 | SSA.cs:80:9:80:12 | this access | SSA.cs:81:21:81:24 | this access |
 | SSA.cs:80:9:80:14 | [post] access to field S | SSA.cs:81:21:81:26 | access to field S |
@@ -695,70 +746,105 @@
 | SSA.cs:85:15:85:20 | [post] access to field S | SSA.cs:114:9:114:14 | access to field S |
 | SSA.cs:85:15:85:20 | access to field S | SSA.cs:114:9:114:14 | access to field S |
 | SSA.cs:88:16:88:23 | access to local variable ssaSink4 | SSA.cs:88:16:88:28 | SSA def(ssaSink4) |
-| SSA.cs:88:16:88:28 | SSA def(ssaSink4) | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) |
+| SSA.cs:88:16:88:28 | SSA def(ssaSink4) | SSA.cs:89:13:89:33 | [input] SSA phi(ssaSink4) |
 | SSA.cs:88:27:88:28 | "" | SSA.cs:88:16:88:23 | access to local variable ssaSink4 |
+| SSA.cs:89:13:89:22 | [post] access to parameter nonTainted | SSA.cs:89:13:89:33 | [input] SSA phi read(nonTainted) |
 | SSA.cs:89:13:89:22 | [post] access to parameter nonTainted | SSA.cs:92:17:92:26 | access to parameter nonTainted |
-| SSA.cs:89:13:89:22 | [post] access to parameter nonTainted | SSA.cs:97:9:97:32 | SSA phi read(nonTainted) |
+| SSA.cs:89:13:89:22 | access to parameter nonTainted | SSA.cs:89:13:89:33 | [input] SSA phi read(nonTainted) |
 | SSA.cs:89:13:89:22 | access to parameter nonTainted | SSA.cs:92:17:92:26 | access to parameter nonTainted |
-| SSA.cs:89:13:89:22 | access to parameter nonTainted | SSA.cs:97:9:97:32 | SSA phi read(nonTainted) |
+| SSA.cs:89:13:89:33 | [input] SSA def(nonSink0) | SSA.cs:63:23:63:30 | SSA def(nonSink0) |
+| SSA.cs:89:13:89:33 | [input] SSA def(ssaSink3) | SSA.cs:59:23:59:30 | SSA def(ssaSink3) |
+| SSA.cs:89:13:89:33 | [input] SSA def(this.S) | SSA.cs:68:23:68:28 | SSA def(this.S) |
+| SSA.cs:89:13:89:33 | [input] SSA def(this.S) | SSA.cs:73:23:73:28 | SSA def(this.S) |
+| SSA.cs:89:13:89:33 | [input] SSA phi read(nonTainted) | SSA.cs:97:9:97:32 | SSA phi read(nonTainted) |
+| SSA.cs:89:13:89:33 | [input] SSA phi read(ssaSink0) | SSA.cs:97:9:97:32 | SSA phi read(ssaSink0) |
+| SSA.cs:89:13:89:33 | [input] SSA phi(ssaSink4) | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) |
+| SSA.cs:89:13:89:33 | [input] SSA qualifier def(this.S.SsaFieldNonSink0) | SSA.cs:73:23:73:28 | SSA qualifier def(this.S.SsaFieldNonSink0) |
+| SSA.cs:89:13:89:33 | [input] SSA qualifier def(this.S.SsaFieldSink0) | SSA.cs:68:23:68:28 | SSA qualifier def(this.S.SsaFieldSink0) |
 | SSA.cs:91:13:91:20 | access to local variable ssaSink4 | SSA.cs:91:13:91:31 | SSA def(ssaSink4) |
 | SSA.cs:91:13:91:31 | SSA def(ssaSink4) | SSA.cs:93:21:93:28 | access to local variable ssaSink4 |
 | SSA.cs:91:13:91:31 | SSA def(ssaSink4) | SSA.cs:95:21:95:28 | access to local variable ssaSink4 |
 | SSA.cs:91:24:91:31 | access to local variable ssaSink0 | SSA.cs:91:13:91:20 | access to local variable ssaSink4 |
-| SSA.cs:91:24:91:31 | access to local variable ssaSink0 | SSA.cs:97:9:97:32 | SSA phi read(ssaSink0) |
-| SSA.cs:92:17:92:26 | [post] access to parameter nonTainted | SSA.cs:97:9:97:32 | SSA phi read(nonTainted) |
-| SSA.cs:92:17:92:26 | access to parameter nonTainted | SSA.cs:97:9:97:32 | SSA phi read(nonTainted) |
-| SSA.cs:93:21:93:28 | [post] access to local variable ssaSink4 | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) |
-| SSA.cs:93:21:93:28 | access to local variable ssaSink4 | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) |
-| SSA.cs:95:21:95:28 | [post] access to local variable ssaSink4 | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) |
-| SSA.cs:95:21:95:28 | access to local variable ssaSink4 | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) |
+| SSA.cs:91:24:91:31 | access to local variable ssaSink0 | SSA.cs:93:17:93:29 | [input] SSA phi read(ssaSink0) |
+| SSA.cs:91:24:91:31 | access to local variable ssaSink0 | SSA.cs:95:17:95:29 | [input] SSA phi read(ssaSink0) |
+| SSA.cs:92:17:92:26 | [post] access to parameter nonTainted | SSA.cs:93:17:93:29 | [input] SSA phi read(nonTainted) |
+| SSA.cs:92:17:92:26 | [post] access to parameter nonTainted | SSA.cs:95:17:95:29 | [input] SSA phi read(nonTainted) |
+| SSA.cs:92:17:92:26 | access to parameter nonTainted | SSA.cs:93:17:93:29 | [input] SSA phi read(nonTainted) |
+| SSA.cs:92:17:92:26 | access to parameter nonTainted | SSA.cs:95:17:95:29 | [input] SSA phi read(nonTainted) |
+| SSA.cs:93:17:93:29 | [input] SSA phi read(nonTainted) | SSA.cs:97:9:97:32 | SSA phi read(nonTainted) |
+| SSA.cs:93:17:93:29 | [input] SSA phi read(ssaSink0) | SSA.cs:97:9:97:32 | SSA phi read(ssaSink0) |
+| SSA.cs:93:17:93:29 | [input] SSA phi(ssaSink4) | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) |
+| SSA.cs:93:21:93:28 | [post] access to local variable ssaSink4 | SSA.cs:93:17:93:29 | [input] SSA phi(ssaSink4) |
+| SSA.cs:93:21:93:28 | access to local variable ssaSink4 | SSA.cs:93:17:93:29 | [input] SSA phi(ssaSink4) |
+| SSA.cs:95:17:95:29 | [input] SSA phi read(nonTainted) | SSA.cs:97:9:97:32 | SSA phi read(nonTainted) |
+| SSA.cs:95:17:95:29 | [input] SSA phi read(ssaSink0) | SSA.cs:97:9:97:32 | SSA phi read(ssaSink0) |
+| SSA.cs:95:17:95:29 | [input] SSA phi(ssaSink4) | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) |
+| SSA.cs:95:21:95:28 | [post] access to local variable ssaSink4 | SSA.cs:95:17:95:29 | [input] SSA phi(ssaSink4) |
+| SSA.cs:95:21:95:28 | access to local variable ssaSink4 | SSA.cs:95:17:95:29 | [input] SSA phi(ssaSink4) |
 | SSA.cs:97:9:97:32 | SSA phi read(nonTainted) | SSA.cs:102:13:102:22 | access to parameter nonTainted |
 | SSA.cs:97:9:97:32 | SSA phi read(ssaSink0) | SSA.cs:117:36:117:43 | access to local variable ssaSink0 |
 | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) | SSA.cs:97:23:97:30 | access to local variable ssaSink4 |
 | SSA.cs:97:23:97:30 | SSA def(ssaSink4) | SSA.cs:98:15:98:22 | access to local variable ssaSink4 |
-| SSA.cs:97:23:97:30 | [post] access to local variable ssaSink4 | SSA.cs:97:23:97:30 | SSA def(ssaSink4) |
+| SSA.cs:97:23:97:30 | [post] access to local variable ssaSink4 | SSA.cs:102:13:102:33 | [input] SSA def(ssaSink4) |
 | SSA.cs:97:23:97:30 | access to local variable ssaSink4 | SSA.cs:97:23:97:30 | SSA def(ssaSink4) |
-| SSA.cs:97:23:97:30 | access to local variable ssaSink4 | SSA.cs:97:23:97:30 | SSA def(ssaSink4) |
+| SSA.cs:97:23:97:30 | access to local variable ssaSink4 | SSA.cs:102:13:102:33 | [input] SSA def(ssaSink4) |
 | SSA.cs:101:16:101:23 | access to local variable nonSink3 | SSA.cs:101:16:101:28 | SSA def(nonSink3) |
-| SSA.cs:101:16:101:28 | SSA def(nonSink3) | SSA.cs:110:9:110:32 | SSA phi(nonSink3) |
+| SSA.cs:101:16:101:28 | SSA def(nonSink3) | SSA.cs:102:13:102:33 | [input] SSA phi(nonSink3) |
 | SSA.cs:101:27:101:28 | "" | SSA.cs:101:16:101:23 | access to local variable nonSink3 |
+| SSA.cs:102:13:102:22 | [post] access to parameter nonTainted | SSA.cs:102:13:102:33 | [input] SSA phi read(nonTainted) |
 | SSA.cs:102:13:102:22 | [post] access to parameter nonTainted | SSA.cs:105:17:105:26 | access to parameter nonTainted |
-| SSA.cs:102:13:102:22 | [post] access to parameter nonTainted | SSA.cs:110:9:110:32 | SSA phi read(nonTainted) |
+| SSA.cs:102:13:102:22 | access to parameter nonTainted | SSA.cs:102:13:102:33 | [input] SSA phi read(nonTainted) |
 | SSA.cs:102:13:102:22 | access to parameter nonTainted | SSA.cs:105:17:105:26 | access to parameter nonTainted |
-| SSA.cs:102:13:102:22 | access to parameter nonTainted | SSA.cs:110:9:110:32 | SSA phi read(nonTainted) |
+| SSA.cs:102:13:102:33 | [input] SSA def(ssaSink4) | SSA.cs:97:23:97:30 | SSA def(ssaSink4) |
+| SSA.cs:102:13:102:33 | [input] SSA phi read(nonSink0) | SSA.cs:110:9:110:32 | SSA phi read(nonSink0) |
+| SSA.cs:102:13:102:33 | [input] SSA phi read(nonTainted) | SSA.cs:110:9:110:32 | SSA phi read(nonTainted) |
+| SSA.cs:102:13:102:33 | [input] SSA phi(nonSink3) | SSA.cs:110:9:110:32 | SSA phi(nonSink3) |
 | SSA.cs:104:13:104:20 | access to local variable nonSink3 | SSA.cs:104:13:104:31 | SSA def(nonSink3) |
 | SSA.cs:104:13:104:31 | SSA def(nonSink3) | SSA.cs:106:21:106:28 | access to local variable nonSink3 |
 | SSA.cs:104:13:104:31 | SSA def(nonSink3) | SSA.cs:108:21:108:28 | access to local variable nonSink3 |
 | SSA.cs:104:24:104:31 | access to local variable nonSink0 | SSA.cs:104:13:104:20 | access to local variable nonSink3 |
-| SSA.cs:104:24:104:31 | access to local variable nonSink0 | SSA.cs:110:9:110:32 | SSA phi read(nonSink0) |
-| SSA.cs:105:17:105:26 | [post] access to parameter nonTainted | SSA.cs:110:9:110:32 | SSA phi read(nonTainted) |
-| SSA.cs:105:17:105:26 | access to parameter nonTainted | SSA.cs:110:9:110:32 | SSA phi read(nonTainted) |
-| SSA.cs:106:21:106:28 | [post] access to local variable nonSink3 | SSA.cs:110:9:110:32 | SSA phi(nonSink3) |
-| SSA.cs:106:21:106:28 | access to local variable nonSink3 | SSA.cs:110:9:110:32 | SSA phi(nonSink3) |
-| SSA.cs:108:21:108:28 | [post] access to local variable nonSink3 | SSA.cs:110:9:110:32 | SSA phi(nonSink3) |
-| SSA.cs:108:21:108:28 | access to local variable nonSink3 | SSA.cs:110:9:110:32 | SSA phi(nonSink3) |
+| SSA.cs:104:24:104:31 | access to local variable nonSink0 | SSA.cs:106:17:106:29 | [input] SSA phi read(nonSink0) |
+| SSA.cs:104:24:104:31 | access to local variable nonSink0 | SSA.cs:108:17:108:29 | [input] SSA phi read(nonSink0) |
+| SSA.cs:105:17:105:26 | [post] access to parameter nonTainted | SSA.cs:106:17:106:29 | [input] SSA phi read(nonTainted) |
+| SSA.cs:105:17:105:26 | [post] access to parameter nonTainted | SSA.cs:108:17:108:29 | [input] SSA phi read(nonTainted) |
+| SSA.cs:105:17:105:26 | access to parameter nonTainted | SSA.cs:106:17:106:29 | [input] SSA phi read(nonTainted) |
+| SSA.cs:105:17:105:26 | access to parameter nonTainted | SSA.cs:108:17:108:29 | [input] SSA phi read(nonTainted) |
+| SSA.cs:106:17:106:29 | [input] SSA phi read(nonSink0) | SSA.cs:110:9:110:32 | SSA phi read(nonSink0) |
+| SSA.cs:106:17:106:29 | [input] SSA phi read(nonTainted) | SSA.cs:110:9:110:32 | SSA phi read(nonTainted) |
+| SSA.cs:106:17:106:29 | [input] SSA phi(nonSink3) | SSA.cs:110:9:110:32 | SSA phi(nonSink3) |
+| SSA.cs:106:21:106:28 | [post] access to local variable nonSink3 | SSA.cs:106:17:106:29 | [input] SSA phi(nonSink3) |
+| SSA.cs:106:21:106:28 | access to local variable nonSink3 | SSA.cs:106:17:106:29 | [input] SSA phi(nonSink3) |
+| SSA.cs:108:17:108:29 | [input] SSA phi read(nonSink0) | SSA.cs:110:9:110:32 | SSA phi read(nonSink0) |
+| SSA.cs:108:17:108:29 | [input] SSA phi read(nonTainted) | SSA.cs:110:9:110:32 | SSA phi read(nonTainted) |
+| SSA.cs:108:17:108:29 | [input] SSA phi(nonSink3) | SSA.cs:110:9:110:32 | SSA phi(nonSink3) |
+| SSA.cs:108:21:108:28 | [post] access to local variable nonSink3 | SSA.cs:108:17:108:29 | [input] SSA phi(nonSink3) |
+| SSA.cs:108:21:108:28 | access to local variable nonSink3 | SSA.cs:108:17:108:29 | [input] SSA phi(nonSink3) |
 | SSA.cs:110:9:110:32 | SSA phi read(nonSink0) | SSA.cs:130:39:130:46 | access to local variable nonSink0 |
 | SSA.cs:110:9:110:32 | SSA phi read(nonTainted) | SSA.cs:115:13:115:22 | access to parameter nonTainted |
 | SSA.cs:110:9:110:32 | SSA phi(nonSink3) | SSA.cs:110:23:110:30 | access to local variable nonSink3 |
 | SSA.cs:110:23:110:30 | SSA def(nonSink3) | SSA.cs:111:15:111:22 | access to local variable nonSink3 |
-| SSA.cs:110:23:110:30 | [post] access to local variable nonSink3 | SSA.cs:110:23:110:30 | SSA def(nonSink3) |
+| SSA.cs:110:23:110:30 | [post] access to local variable nonSink3 | SSA.cs:115:13:115:33 | [input] SSA def(nonSink3) |
 | SSA.cs:110:23:110:30 | access to local variable nonSink3 | SSA.cs:110:23:110:30 | SSA def(nonSink3) |
-| SSA.cs:110:23:110:30 | access to local variable nonSink3 | SSA.cs:110:23:110:30 | SSA def(nonSink3) |
+| SSA.cs:110:23:110:30 | access to local variable nonSink3 | SSA.cs:115:13:115:33 | [input] SSA def(nonSink3) |
 | SSA.cs:114:9:114:12 | [post] this access | SSA.cs:117:13:117:16 | this access |
 | SSA.cs:114:9:114:12 | [post] this access | SSA.cs:123:23:123:26 | this access |
 | SSA.cs:114:9:114:12 | this access | SSA.cs:117:13:117:16 | this access |
 | SSA.cs:114:9:114:12 | this access | SSA.cs:123:23:123:26 | this access |
+| SSA.cs:114:9:114:14 | [post] access to field S | SSA.cs:115:13:115:33 | [input] SSA phi read(this.S) |
 | SSA.cs:114:9:114:14 | [post] access to field S | SSA.cs:117:13:117:18 | access to field S |
-| SSA.cs:114:9:114:14 | [post] access to field S | SSA.cs:123:9:123:30 | SSA phi read(this.S) |
+| SSA.cs:114:9:114:14 | access to field S | SSA.cs:115:13:115:33 | [input] SSA phi read(this.S) |
 | SSA.cs:114:9:114:14 | access to field S | SSA.cs:117:13:117:18 | access to field S |
-| SSA.cs:114:9:114:14 | access to field S | SSA.cs:123:9:123:30 | SSA phi read(this.S) |
 | SSA.cs:114:9:114:28 | access to field SsaFieldSink1 | SSA.cs:114:9:114:33 | SSA def(this.S.SsaFieldSink1) |
-| SSA.cs:114:9:114:33 | SSA def(this.S.SsaFieldSink1) | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) |
+| SSA.cs:114:9:114:33 | SSA def(this.S.SsaFieldSink1) | SSA.cs:115:13:115:33 | [input] SSA phi(this.S.SsaFieldSink1) |
 | SSA.cs:114:32:114:33 | "" | SSA.cs:114:9:114:28 | access to field SsaFieldSink1 |
+| SSA.cs:115:13:115:22 | [post] access to parameter nonTainted | SSA.cs:115:13:115:33 | [input] SSA phi read(nonTainted) |
 | SSA.cs:115:13:115:22 | [post] access to parameter nonTainted | SSA.cs:118:17:118:26 | access to parameter nonTainted |
-| SSA.cs:115:13:115:22 | [post] access to parameter nonTainted | SSA.cs:123:9:123:30 | SSA phi read(nonTainted) |
+| SSA.cs:115:13:115:22 | access to parameter nonTainted | SSA.cs:115:13:115:33 | [input] SSA phi read(nonTainted) |
 | SSA.cs:115:13:115:22 | access to parameter nonTainted | SSA.cs:118:17:118:26 | access to parameter nonTainted |
-| SSA.cs:115:13:115:22 | access to parameter nonTainted | SSA.cs:123:9:123:30 | SSA phi read(nonTainted) |
+| SSA.cs:115:13:115:33 | [input] SSA def(nonSink3) | SSA.cs:110:23:110:30 | SSA def(nonSink3) |
+| SSA.cs:115:13:115:33 | [input] SSA phi read(nonTainted) | SSA.cs:123:9:123:30 | SSA phi read(nonTainted) |
+| SSA.cs:115:13:115:33 | [input] SSA phi read(this.S) | SSA.cs:123:9:123:30 | SSA phi read(this.S) |
+| SSA.cs:115:13:115:33 | [input] SSA phi(this.S.SsaFieldSink1) | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) |
 | SSA.cs:117:13:117:16 | [post] this access | SSA.cs:119:21:119:24 | this access |
 | SSA.cs:117:13:117:16 | [post] this access | SSA.cs:121:21:121:24 | this access |
 | SSA.cs:117:13:117:16 | this access | SSA.cs:119:21:119:24 | this access |
@@ -771,30 +857,38 @@
 | SSA.cs:117:13:117:43 | SSA def(this.S.SsaFieldSink1) | SSA.cs:119:21:119:40 | access to field SsaFieldSink1 |
 | SSA.cs:117:13:117:43 | SSA def(this.S.SsaFieldSink1) | SSA.cs:121:21:121:40 | access to field SsaFieldSink1 |
 | SSA.cs:117:36:117:43 | access to local variable ssaSink0 | SSA.cs:117:13:117:32 | access to field SsaFieldSink1 |
-| SSA.cs:118:17:118:26 | [post] access to parameter nonTainted | SSA.cs:123:9:123:30 | SSA phi read(nonTainted) |
-| SSA.cs:118:17:118:26 | access to parameter nonTainted | SSA.cs:123:9:123:30 | SSA phi read(nonTainted) |
+| SSA.cs:118:17:118:26 | [post] access to parameter nonTainted | SSA.cs:119:17:119:41 | [input] SSA phi read(nonTainted) |
+| SSA.cs:118:17:118:26 | [post] access to parameter nonTainted | SSA.cs:121:17:121:41 | [input] SSA phi read(nonTainted) |
+| SSA.cs:118:17:118:26 | access to parameter nonTainted | SSA.cs:119:17:119:41 | [input] SSA phi read(nonTainted) |
+| SSA.cs:118:17:118:26 | access to parameter nonTainted | SSA.cs:121:17:121:41 | [input] SSA phi read(nonTainted) |
+| SSA.cs:119:17:119:41 | [input] SSA phi read(nonTainted) | SSA.cs:123:9:123:30 | SSA phi read(nonTainted) |
+| SSA.cs:119:17:119:41 | [input] SSA phi read(this.S) | SSA.cs:123:9:123:30 | SSA phi read(this.S) |
+| SSA.cs:119:17:119:41 | [input] SSA phi(this.S.SsaFieldSink1) | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) |
 | SSA.cs:119:21:119:24 | [post] this access | SSA.cs:123:23:123:26 | this access |
 | SSA.cs:119:21:119:24 | this access | SSA.cs:123:23:123:26 | this access |
-| SSA.cs:119:21:119:26 | [post] access to field S | SSA.cs:123:9:123:30 | SSA phi read(this.S) |
-| SSA.cs:119:21:119:26 | access to field S | SSA.cs:123:9:123:30 | SSA phi read(this.S) |
-| SSA.cs:119:21:119:40 | [post] access to field SsaFieldSink1 | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) |
-| SSA.cs:119:21:119:40 | access to field SsaFieldSink1 | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) |
+| SSA.cs:119:21:119:26 | [post] access to field S | SSA.cs:119:17:119:41 | [input] SSA phi read(this.S) |
+| SSA.cs:119:21:119:26 | access to field S | SSA.cs:119:17:119:41 | [input] SSA phi read(this.S) |
+| SSA.cs:119:21:119:40 | [post] access to field SsaFieldSink1 | SSA.cs:119:17:119:41 | [input] SSA phi(this.S.SsaFieldSink1) |
+| SSA.cs:119:21:119:40 | access to field SsaFieldSink1 | SSA.cs:119:17:119:41 | [input] SSA phi(this.S.SsaFieldSink1) |
+| SSA.cs:121:17:121:41 | [input] SSA phi read(nonTainted) | SSA.cs:123:9:123:30 | SSA phi read(nonTainted) |
+| SSA.cs:121:17:121:41 | [input] SSA phi read(this.S) | SSA.cs:123:9:123:30 | SSA phi read(this.S) |
+| SSA.cs:121:17:121:41 | [input] SSA phi(this.S.SsaFieldSink1) | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) |
 | SSA.cs:121:21:121:24 | [post] this access | SSA.cs:123:23:123:26 | this access |
 | SSA.cs:121:21:121:24 | this access | SSA.cs:123:23:123:26 | this access |
-| SSA.cs:121:21:121:26 | [post] access to field S | SSA.cs:123:9:123:30 | SSA phi read(this.S) |
-| SSA.cs:121:21:121:26 | access to field S | SSA.cs:123:9:123:30 | SSA phi read(this.S) |
-| SSA.cs:121:21:121:40 | [post] access to field SsaFieldSink1 | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) |
-| SSA.cs:121:21:121:40 | access to field SsaFieldSink1 | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) |
+| SSA.cs:121:21:121:26 | [post] access to field S | SSA.cs:121:17:121:41 | [input] SSA phi read(this.S) |
+| SSA.cs:121:21:121:26 | access to field S | SSA.cs:121:17:121:41 | [input] SSA phi read(this.S) |
+| SSA.cs:121:21:121:40 | [post] access to field SsaFieldSink1 | SSA.cs:121:17:121:41 | [input] SSA phi(this.S.SsaFieldSink1) |
+| SSA.cs:121:21:121:40 | access to field SsaFieldSink1 | SSA.cs:121:17:121:41 | [input] SSA phi(this.S.SsaFieldSink1) |
 | SSA.cs:123:9:123:30 | SSA phi read(nonTainted) | SSA.cs:128:13:128:22 | access to parameter nonTainted |
 | SSA.cs:123:9:123:30 | SSA phi read(this.S) | SSA.cs:123:23:123:28 | access to field S |
-| SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) | SSA.cs:123:23:123:28 | SSA qualifier def(this.S.SsaFieldSink1) |
+| SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) | SSA.cs:128:13:128:33 | [input] SSA qualifier def(this.S.SsaFieldSink1) |
 | SSA.cs:123:23:123:26 | [post] this access | SSA.cs:124:15:124:18 | this access |
 | SSA.cs:123:23:123:26 | this access | SSA.cs:124:15:124:18 | this access |
 | SSA.cs:123:23:123:28 | SSA def(this.S) | SSA.cs:124:15:124:20 | access to field S |
 | SSA.cs:123:23:123:28 | SSA qualifier def(this.S.SsaFieldSink1) | SSA.cs:124:15:124:34 | access to field SsaFieldSink1 |
-| SSA.cs:123:23:123:28 | [post] access to field S | SSA.cs:123:23:123:28 | SSA def(this.S) |
+| SSA.cs:123:23:123:28 | [post] access to field S | SSA.cs:128:13:128:33 | [input] SSA def(this.S) |
 | SSA.cs:123:23:123:28 | access to field S | SSA.cs:123:23:123:28 | SSA def(this.S) |
-| SSA.cs:123:23:123:28 | access to field S | SSA.cs:123:23:123:28 | SSA def(this.S) |
+| SSA.cs:123:23:123:28 | access to field S | SSA.cs:128:13:128:33 | [input] SSA def(this.S) |
 | SSA.cs:124:15:124:18 | [post] this access | SSA.cs:127:9:127:12 | this access |
 | SSA.cs:124:15:124:18 | this access | SSA.cs:127:9:127:12 | this access |
 | SSA.cs:124:15:124:20 | [post] access to field S | SSA.cs:127:9:127:14 | access to field S |
@@ -803,15 +897,19 @@
 | SSA.cs:127:9:127:12 | [post] this access | SSA.cs:136:23:136:26 | this access |
 | SSA.cs:127:9:127:12 | this access | SSA.cs:130:13:130:16 | this access |
 | SSA.cs:127:9:127:12 | this access | SSA.cs:136:23:136:26 | this access |
+| SSA.cs:127:9:127:14 | [post] access to field S | SSA.cs:128:13:128:33 | [input] SSA phi read(this.S) |
 | SSA.cs:127:9:127:14 | [post] access to field S | SSA.cs:130:13:130:18 | access to field S |
-| SSA.cs:127:9:127:14 | [post] access to field S | SSA.cs:136:9:136:30 | SSA phi read(this.S) |
+| SSA.cs:127:9:127:14 | access to field S | SSA.cs:128:13:128:33 | [input] SSA phi read(this.S) |
 | SSA.cs:127:9:127:14 | access to field S | SSA.cs:130:13:130:18 | access to field S |
-| SSA.cs:127:9:127:14 | access to field S | SSA.cs:136:9:136:30 | SSA phi read(this.S) |
 | SSA.cs:127:9:127:31 | access to field SsaFieldNonSink0 | SSA.cs:127:9:127:36 | SSA def(this.S.SsaFieldNonSink0) |
-| SSA.cs:127:9:127:36 | SSA def(this.S.SsaFieldNonSink0) | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) |
+| SSA.cs:127:9:127:36 | SSA def(this.S.SsaFieldNonSink0) | SSA.cs:128:13:128:33 | [input] SSA phi(this.S.SsaFieldNonSink0) |
 | SSA.cs:127:35:127:36 | "" | SSA.cs:127:9:127:31 | access to field SsaFieldNonSink0 |
 | SSA.cs:128:13:128:22 | [post] access to parameter nonTainted | SSA.cs:131:17:131:26 | access to parameter nonTainted |
 | SSA.cs:128:13:128:22 | access to parameter nonTainted | SSA.cs:131:17:131:26 | access to parameter nonTainted |
+| SSA.cs:128:13:128:33 | [input] SSA def(this.S) | SSA.cs:123:23:123:28 | SSA def(this.S) |
+| SSA.cs:128:13:128:33 | [input] SSA phi read(this.S) | SSA.cs:136:9:136:30 | SSA phi read(this.S) |
+| SSA.cs:128:13:128:33 | [input] SSA phi(this.S.SsaFieldNonSink0) | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) |
+| SSA.cs:128:13:128:33 | [input] SSA qualifier def(this.S.SsaFieldSink1) | SSA.cs:123:23:123:28 | SSA qualifier def(this.S.SsaFieldSink1) |
 | SSA.cs:130:13:130:16 | [post] this access | SSA.cs:132:21:132:24 | this access |
 | SSA.cs:130:13:130:16 | [post] this access | SSA.cs:134:21:134:24 | this access |
 | SSA.cs:130:13:130:16 | this access | SSA.cs:132:21:132:24 | this access |
@@ -824,66 +922,86 @@
 | SSA.cs:130:13:130:46 | SSA def(this.S.SsaFieldNonSink0) | SSA.cs:132:21:132:43 | access to field SsaFieldNonSink0 |
 | SSA.cs:130:13:130:46 | SSA def(this.S.SsaFieldNonSink0) | SSA.cs:134:21:134:43 | access to field SsaFieldNonSink0 |
 | SSA.cs:130:39:130:46 | access to local variable nonSink0 | SSA.cs:130:13:130:35 | access to field SsaFieldNonSink0 |
+| SSA.cs:132:17:132:44 | [input] SSA phi read(this.S) | SSA.cs:136:9:136:30 | SSA phi read(this.S) |
+| SSA.cs:132:17:132:44 | [input] SSA phi(this.S.SsaFieldNonSink0) | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) |
 | SSA.cs:132:21:132:24 | [post] this access | SSA.cs:136:23:136:26 | this access |
 | SSA.cs:132:21:132:24 | this access | SSA.cs:136:23:136:26 | this access |
-| SSA.cs:132:21:132:26 | [post] access to field S | SSA.cs:136:9:136:30 | SSA phi read(this.S) |
-| SSA.cs:132:21:132:26 | access to field S | SSA.cs:136:9:136:30 | SSA phi read(this.S) |
-| SSA.cs:132:21:132:43 | [post] access to field SsaFieldNonSink0 | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) |
-| SSA.cs:132:21:132:43 | access to field SsaFieldNonSink0 | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) |
+| SSA.cs:132:21:132:26 | [post] access to field S | SSA.cs:132:17:132:44 | [input] SSA phi read(this.S) |
+| SSA.cs:132:21:132:26 | access to field S | SSA.cs:132:17:132:44 | [input] SSA phi read(this.S) |
+| SSA.cs:132:21:132:43 | [post] access to field SsaFieldNonSink0 | SSA.cs:132:17:132:44 | [input] SSA phi(this.S.SsaFieldNonSink0) |
+| SSA.cs:132:21:132:43 | access to field SsaFieldNonSink0 | SSA.cs:132:17:132:44 | [input] SSA phi(this.S.SsaFieldNonSink0) |
+| SSA.cs:134:17:134:44 | [input] SSA phi read(this.S) | SSA.cs:136:9:136:30 | SSA phi read(this.S) |
+| SSA.cs:134:17:134:44 | [input] SSA phi(this.S.SsaFieldNonSink0) | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) |
 | SSA.cs:134:21:134:24 | [post] this access | SSA.cs:136:23:136:26 | this access |
 | SSA.cs:134:21:134:24 | this access | SSA.cs:136:23:136:26 | this access |
-| SSA.cs:134:21:134:26 | [post] access to field S | SSA.cs:136:9:136:30 | SSA phi read(this.S) |
-| SSA.cs:134:21:134:26 | access to field S | SSA.cs:136:9:136:30 | SSA phi read(this.S) |
-| SSA.cs:134:21:134:43 | [post] access to field SsaFieldNonSink0 | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) |
-| SSA.cs:134:21:134:43 | access to field SsaFieldNonSink0 | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) |
+| SSA.cs:134:21:134:26 | [post] access to field S | SSA.cs:134:17:134:44 | [input] SSA phi read(this.S) |
+| SSA.cs:134:21:134:26 | access to field S | SSA.cs:134:17:134:44 | [input] SSA phi read(this.S) |
+| SSA.cs:134:21:134:43 | [post] access to field SsaFieldNonSink0 | SSA.cs:134:17:134:44 | [input] SSA phi(this.S.SsaFieldNonSink0) |
+| SSA.cs:134:21:134:43 | access to field SsaFieldNonSink0 | SSA.cs:134:17:134:44 | [input] SSA phi(this.S.SsaFieldNonSink0) |
 | SSA.cs:136:9:136:30 | SSA phi read(this.S) | SSA.cs:136:23:136:28 | access to field S |
-| SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) | SSA.cs:136:23:136:28 | SSA qualifier def(this.S.SsaFieldNonSink0) |
+| SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) | SSA.cs:5:17:5:17 | [input] SSA qualifier def(this.S.SsaFieldNonSink0) |
 | SSA.cs:136:23:136:26 | [post] this access | SSA.cs:137:15:137:18 | this access |
 | SSA.cs:136:23:136:26 | this access | SSA.cs:137:15:137:18 | this access |
 | SSA.cs:136:23:136:28 | SSA def(this.S) | SSA.cs:137:15:137:20 | access to field S |
 | SSA.cs:136:23:136:28 | SSA qualifier def(this.S.SsaFieldNonSink0) | SSA.cs:137:15:137:37 | access to field SsaFieldNonSink0 |
-| SSA.cs:136:23:136:28 | [post] access to field S | SSA.cs:136:23:136:28 | SSA def(this.S) |
+| SSA.cs:136:23:136:28 | [post] access to field S | SSA.cs:5:17:5:17 | [input] SSA def(this.S) |
+| SSA.cs:136:23:136:28 | access to field S | SSA.cs:5:17:5:17 | [input] SSA def(this.S) |
 | SSA.cs:136:23:136:28 | access to field S | SSA.cs:136:23:136:28 | SSA def(this.S) |
-| SSA.cs:136:23:136:28 | access to field S | SSA.cs:136:23:136:28 | SSA def(this.S) |
-| SSA.cs:144:34:144:34 | t | SSA.cs:146:13:146:13 | access to parameter t |
+| SSA.cs:144:34:144:34 | SSA param(t) | SSA.cs:146:13:146:13 | access to parameter t |
+| SSA.cs:144:34:144:34 | t | SSA.cs:144:34:144:34 | SSA param(t) |
 | SSA.cs:146:13:146:13 | access to parameter t | SSA.cs:146:13:146:13 | (...) ... |
 | SSA.cs:146:13:146:13 | access to parameter t | SSA.cs:149:17:149:17 | access to parameter t |
 | SSA.cs:147:13:147:13 | access to parameter t | SSA.cs:147:13:147:26 | SSA def(t) |
-| SSA.cs:147:13:147:26 | SSA def(t) | SSA.cs:144:17:144:26 | SSA phi(t) |
+| SSA.cs:147:13:147:26 | SSA def(t) | SSA.cs:147:13:147:26 | [input] SSA phi(t) |
+| SSA.cs:147:13:147:26 | [input] SSA phi(t) | SSA.cs:144:17:144:26 | SSA phi(t) |
 | SSA.cs:147:17:147:26 | default(...) | SSA.cs:147:13:147:13 | access to parameter t |
 | SSA.cs:149:13:149:13 | access to parameter t | SSA.cs:149:13:149:17 | SSA def(t) |
-| SSA.cs:149:13:149:17 | SSA def(t) | SSA.cs:144:17:144:26 | SSA phi(t) |
+| SSA.cs:149:13:149:17 | SSA def(t) | SSA.cs:149:13:149:17 | [input] SSA phi(t) |
+| SSA.cs:149:13:149:17 | [input] SSA phi(t) | SSA.cs:144:17:144:26 | SSA phi(t) |
 | SSA.cs:149:17:149:17 | access to parameter t | SSA.cs:149:13:149:13 | access to parameter t |
-| SSA.cs:152:36:152:36 | t | SSA.cs:154:13:154:13 | access to parameter t |
-| SSA.cs:154:13:154:13 | access to parameter t | SSA.cs:152:17:152:28 | SSA phi(t) |
+| SSA.cs:152:36:152:36 | SSA param(t) | SSA.cs:154:13:154:13 | access to parameter t |
+| SSA.cs:152:36:152:36 | t | SSA.cs:152:36:152:36 | SSA param(t) |
 | SSA.cs:154:13:154:13 | access to parameter t | SSA.cs:154:13:154:13 | (...) ... |
+| SSA.cs:154:13:154:13 | access to parameter t | SSA.cs:154:13:154:21 | [input] SSA phi(t) |
 | SSA.cs:154:13:154:13 | access to parameter t | SSA.cs:155:25:155:25 | access to parameter t |
-| SSA.cs:155:25:155:25 | SSA def(t) | SSA.cs:152:17:152:28 | SSA phi(t) |
+| SSA.cs:154:13:154:21 | [input] SSA phi(t) | SSA.cs:152:17:152:28 | SSA phi(t) |
+| SSA.cs:155:13:155:26 | [input] SSA phi(t) | SSA.cs:152:17:152:28 | SSA phi(t) |
+| SSA.cs:155:25:155:25 | SSA def(t) | SSA.cs:155:13:155:26 | [input] SSA phi(t) |
 | SSA.cs:155:25:155:25 | access to parameter t | SSA.cs:155:25:155:25 | SSA def(t) |
 | SSA.cs:166:10:166:13 | this | SSA.cs:166:19:166:22 | this access |
 | SSA.cs:166:28:166:31 | null | SSA.cs:166:19:166:24 | access to field S |
-| SSA.cs:168:22:168:28 | tainted | SSA.cs:173:24:173:30 | access to parameter tainted |
-| SSA.cs:168:35:168:35 | i | SSA.cs:171:13:171:13 | access to parameter i |
+| SSA.cs:168:22:168:28 | SSA param(tainted) | SSA.cs:173:24:173:30 | access to parameter tainted |
+| SSA.cs:168:22:168:28 | tainted | SSA.cs:168:22:168:28 | SSA param(tainted) |
+| SSA.cs:168:35:168:35 | SSA param(i) | SSA.cs:171:13:171:13 | access to parameter i |
+| SSA.cs:168:35:168:35 | i | SSA.cs:168:35:168:35 | SSA param(i) |
 | SSA.cs:170:16:170:23 | access to local variable ssaSink5 | SSA.cs:170:16:170:28 | SSA def(ssaSink5) |
-| SSA.cs:170:16:170:28 | SSA def(ssaSink5) | SSA.cs:180:9:180:24 | SSA phi(ssaSink5) |
+| SSA.cs:170:16:170:28 | SSA def(ssaSink5) | SSA.cs:171:13:171:19 | [input] SSA phi(ssaSink5) |
 | SSA.cs:170:27:170:28 | "" | SSA.cs:170:16:170:23 | access to local variable ssaSink5 |
 | SSA.cs:171:13:171:13 | access to parameter i | SSA.cs:171:13:171:15 | SSA def(i) |
-| SSA.cs:171:13:171:15 | SSA def(i) | SSA.cs:174:20:174:20 | SSA phi(i) |
+| SSA.cs:171:13:171:15 | SSA def(i) | SSA.cs:174:13:178:13 | [input] SSA phi(i) |
+| SSA.cs:171:13:171:19 | [input] SSA phi(ssaSink5) | SSA.cs:180:9:180:24 | SSA phi(ssaSink5) |
 | SSA.cs:173:13:173:20 | access to local variable ssaSink5 | SSA.cs:173:13:173:30 | SSA def(ssaSink5) |
-| SSA.cs:173:13:173:30 | SSA def(ssaSink5) | SSA.cs:174:20:174:20 | SSA phi read(ssaSink5) |
+| SSA.cs:173:13:173:30 | SSA def(ssaSink5) | SSA.cs:174:13:178:13 | [input] SSA phi read(ssaSink5) |
 | SSA.cs:173:24:173:30 | access to parameter tainted | SSA.cs:173:13:173:20 | access to local variable ssaSink5 |
+| SSA.cs:174:13:178:13 | [input] SSA phi read(ssaSink5) | SSA.cs:174:20:174:20 | SSA phi read(ssaSink5) |
+| SSA.cs:174:13:178:13 | [input] SSA phi(i) | SSA.cs:174:20:174:20 | SSA phi(i) |
+| SSA.cs:174:20:174:20 | SSA phi read(ssaSink5) | SSA.cs:174:20:174:26 | [input] SSA phi(ssaSink5) |
 | SSA.cs:174:20:174:20 | SSA phi read(ssaSink5) | SSA.cs:176:21:176:28 | access to local variable ssaSink5 |
-| SSA.cs:174:20:174:20 | SSA phi read(ssaSink5) | SSA.cs:180:9:180:24 | SSA phi(ssaSink5) |
 | SSA.cs:174:20:174:20 | SSA phi(i) | SSA.cs:174:20:174:20 | access to parameter i |
 | SSA.cs:174:20:174:20 | access to parameter i | SSA.cs:174:20:174:22 | SSA def(i) |
-| SSA.cs:174:20:174:22 | SSA def(i) | SSA.cs:174:20:174:20 | SSA phi(i) |
+| SSA.cs:174:20:174:22 | SSA def(i) | SSA.cs:177:17:177:29 | [input] SSA phi(i) |
+| SSA.cs:174:20:174:26 | [input] SSA phi(ssaSink5) | SSA.cs:180:9:180:24 | SSA phi(ssaSink5) |
 | SSA.cs:176:21:176:28 | [post] access to local variable ssaSink5 | SSA.cs:177:21:177:28 | access to local variable ssaSink5 |
 | SSA.cs:176:21:176:28 | access to local variable ssaSink5 | SSA.cs:177:21:177:28 | access to local variable ssaSink5 |
-| SSA.cs:177:21:177:28 | [post] access to local variable ssaSink5 | SSA.cs:174:20:174:20 | SSA phi read(ssaSink5) |
-| SSA.cs:177:21:177:28 | access to local variable ssaSink5 | SSA.cs:174:20:174:20 | SSA phi read(ssaSink5) |
+| SSA.cs:177:17:177:29 | [input] SSA phi read(ssaSink5) | SSA.cs:174:20:174:20 | SSA phi read(ssaSink5) |
+| SSA.cs:177:17:177:29 | [input] SSA phi(i) | SSA.cs:174:20:174:20 | SSA phi(i) |
+| SSA.cs:177:21:177:28 | [post] access to local variable ssaSink5 | SSA.cs:177:17:177:29 | [input] SSA phi read(ssaSink5) |
+| SSA.cs:177:21:177:28 | access to local variable ssaSink5 | SSA.cs:177:17:177:29 | [input] SSA phi read(ssaSink5) |
 | SSA.cs:180:9:180:24 | SSA phi(ssaSink5) | SSA.cs:180:15:180:22 | access to local variable ssaSink5 |
-| Splitting.cs:3:18:3:18 | b | Splitting.cs:6:13:6:13 | access to parameter b |
-| Splitting.cs:3:28:3:34 | tainted | Splitting.cs:5:17:5:23 | access to parameter tainted |
+| Splitting.cs:3:18:3:18 | SSA param(b) | Splitting.cs:6:13:6:13 | access to parameter b |
+| Splitting.cs:3:18:3:18 | b | Splitting.cs:3:18:3:18 | SSA param(b) |
+| Splitting.cs:3:28:3:34 | SSA param(tainted) | Splitting.cs:5:17:5:23 | access to parameter tainted |
+| Splitting.cs:3:28:3:34 | tainted | Splitting.cs:3:28:3:34 | SSA param(tainted) |
 | Splitting.cs:5:13:5:13 | access to local variable x | Splitting.cs:5:13:5:23 | SSA def(x) |
 | Splitting.cs:5:13:5:23 | SSA def(x) | Splitting.cs:8:19:8:19 | [b (line 3): true] access to local variable x |
 | Splitting.cs:5:13:5:23 | SSA def(x) | Splitting.cs:12:15:12:15 | [b (line 3): false] access to local variable x |
@@ -895,7 +1013,8 @@
 | Splitting.cs:9:17:9:17 | [b (line 3): true] access to local variable x | Splitting.cs:12:15:12:15 | [b (line 3): true] access to local variable x |
 | Splitting.cs:12:15:12:15 | [b (line 3): true] access to local variable x | Splitting.cs:14:19:14:19 | access to local variable x |
 | Splitting.cs:12:15:12:15 | [post] [b (line 3): true] access to local variable x | Splitting.cs:14:19:14:19 | access to local variable x |
-| Splitting.cs:17:18:17:18 | b | Splitting.cs:20:13:20:13 | access to parameter b |
+| Splitting.cs:17:18:17:18 | SSA param(b) | Splitting.cs:20:13:20:13 | access to parameter b |
+| Splitting.cs:17:18:17:18 | b | Splitting.cs:17:18:17:18 | SSA param(b) |
 | Splitting.cs:19:13:19:13 | access to local variable x | Splitting.cs:19:13:19:18 | SSA def(x) |
 | Splitting.cs:19:13:19:18 | SSA def(x) | Splitting.cs:22:19:22:19 | [b (line 17): true] access to local variable x |
 | Splitting.cs:19:13:19:18 | SSA def(x) | Splitting.cs:25:15:25:15 | [b (line 17): false] access to local variable x |
@@ -909,7 +1028,8 @@
 | Splitting.cs:25:15:25:15 | [b (line 17): true] access to local variable x | Splitting.cs:27:19:27:19 | access to local variable x |
 | Splitting.cs:25:15:25:15 | [post] [b (line 17): false] access to local variable x | Splitting.cs:29:19:29:19 | access to local variable x |
 | Splitting.cs:25:15:25:15 | [post] [b (line 17): true] access to local variable x | Splitting.cs:27:19:27:19 | access to local variable x |
-| Splitting.cs:32:18:32:18 | b | Splitting.cs:35:13:35:13 | access to parameter b |
+| Splitting.cs:32:18:32:18 | SSA param(b) | Splitting.cs:35:13:35:13 | access to parameter b |
+| Splitting.cs:32:18:32:18 | b | Splitting.cs:32:18:32:18 | SSA param(b) |
 | Splitting.cs:34:17:34:18 | "" | Splitting.cs:34:13:34:13 | access to local variable x |
 | Splitting.cs:35:13:35:13 | access to parameter b | Splitting.cs:39:15:39:15 | [b (line 32): false] access to parameter b |
 | Splitting.cs:35:13:35:13 | access to parameter b | Splitting.cs:39:15:39:15 | [b (line 32): true] access to parameter b |
@@ -936,7 +1056,8 @@
 | Splitting.cs:41:19:41:21 | [b (line 32): false] "d" | Splitting.cs:41:15:41:21 | [b (line 32): false] ... = ... |
 | Splitting.cs:41:19:41:21 | [b (line 32): true] "d" | Splitting.cs:41:15:41:15 | access to local variable x |
 | Splitting.cs:41:19:41:21 | [b (line 32): true] "d" | Splitting.cs:41:15:41:21 | [b (line 32): true] ... = ... |
-| Splitting.cs:46:18:46:18 | b | Splitting.cs:49:13:49:13 | access to parameter b |
+| Splitting.cs:46:18:46:18 | SSA param(b) | Splitting.cs:49:13:49:13 | access to parameter b |
+| Splitting.cs:46:18:46:18 | b | Splitting.cs:46:18:46:18 | SSA param(b) |
 | Splitting.cs:48:13:48:13 | access to local variable x | Splitting.cs:48:13:48:18 | SSA def(x) |
 | Splitting.cs:48:13:48:18 | SSA def(x) | Splitting.cs:53:13:53:13 | [b (line 46): false] access to local variable x |
 | Splitting.cs:48:17:48:18 | "" | Splitting.cs:48:13:48:13 | access to local variable x |
@@ -994,6 +1115,7 @@
 | UseUseExplosion.cs:21:10:21:10 | SSA entry def(this.Prop) | UseUseExplosion.cs:24:13:24:16 | access to property Prop |
 | UseUseExplosion.cs:21:10:21:10 | this | UseUseExplosion.cs:24:13:24:16 | this access |
 | UseUseExplosion.cs:23:13:23:13 | access to local variable x | UseUseExplosion.cs:23:13:23:17 | SSA def(x) |
+| UseUseExplosion.cs:23:13:23:17 | SSA def(x) | UseUseExplosion.cs:24:1699:24:1701 | [input] SSA phi read(x) |
 | UseUseExplosion.cs:23:13:23:17 | SSA def(x) | UseUseExplosion.cs:24:1712:24:1712 | access to local variable x |
 | UseUseExplosion.cs:23:13:23:17 | SSA def(x) | UseUseExplosion.cs:24:1727:24:1727 | access to local variable x |
 | UseUseExplosion.cs:23:13:23:17 | SSA def(x) | UseUseExplosion.cs:24:1742:24:1742 | access to local variable x |
@@ -1094,907 +1216,1109 @@
 | UseUseExplosion.cs:23:13:23:17 | SSA def(x) | UseUseExplosion.cs:24:3167:24:3167 | access to local variable x |
 | UseUseExplosion.cs:23:13:23:17 | SSA def(x) | UseUseExplosion.cs:24:3182:24:3182 | access to local variable x |
 | UseUseExplosion.cs:23:13:23:17 | SSA def(x) | UseUseExplosion.cs:24:3197:24:3197 | access to local variable x |
-| UseUseExplosion.cs:23:13:23:17 | SSA def(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:23:17:23:17 | 0 | UseUseExplosion.cs:23:13:23:13 | access to local variable x |
 | UseUseExplosion.cs:24:13:24:16 | [post] this access | UseUseExplosion.cs:24:31:24:34 | this access |
 | UseUseExplosion.cs:24:13:24:16 | [post] this access | UseUseExplosion.cs:24:3193:24:3198 | this access |
 | UseUseExplosion.cs:24:13:24:16 | access to property Prop | UseUseExplosion.cs:24:31:24:34 | access to property Prop |
-| UseUseExplosion.cs:24:13:24:16 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:13:24:16 | access to property Prop | UseUseExplosion.cs:24:3193:24:3198 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:13:24:16 | this access | UseUseExplosion.cs:24:31:24:34 | this access |
 | UseUseExplosion.cs:24:13:24:16 | this access | UseUseExplosion.cs:24:3193:24:3198 | this access |
 | UseUseExplosion.cs:24:31:24:34 | [post] this access | UseUseExplosion.cs:24:48:24:51 | this access |
 | UseUseExplosion.cs:24:31:24:34 | [post] this access | UseUseExplosion.cs:24:3178:24:3183 | this access |
 | UseUseExplosion.cs:24:31:24:34 | access to property Prop | UseUseExplosion.cs:24:48:24:51 | access to property Prop |
-| UseUseExplosion.cs:24:31:24:34 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:31:24:34 | access to property Prop | UseUseExplosion.cs:24:3178:24:3183 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:31:24:34 | this access | UseUseExplosion.cs:24:48:24:51 | this access |
 | UseUseExplosion.cs:24:31:24:34 | this access | UseUseExplosion.cs:24:3178:24:3183 | this access |
 | UseUseExplosion.cs:24:48:24:51 | [post] this access | UseUseExplosion.cs:24:65:24:68 | this access |
 | UseUseExplosion.cs:24:48:24:51 | [post] this access | UseUseExplosion.cs:24:3163:24:3168 | this access |
 | UseUseExplosion.cs:24:48:24:51 | access to property Prop | UseUseExplosion.cs:24:65:24:68 | access to property Prop |
-| UseUseExplosion.cs:24:48:24:51 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:48:24:51 | access to property Prop | UseUseExplosion.cs:24:3163:24:3168 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:48:24:51 | this access | UseUseExplosion.cs:24:65:24:68 | this access |
 | UseUseExplosion.cs:24:48:24:51 | this access | UseUseExplosion.cs:24:3163:24:3168 | this access |
 | UseUseExplosion.cs:24:65:24:68 | [post] this access | UseUseExplosion.cs:24:82:24:85 | this access |
 | UseUseExplosion.cs:24:65:24:68 | [post] this access | UseUseExplosion.cs:24:3148:24:3153 | this access |
 | UseUseExplosion.cs:24:65:24:68 | access to property Prop | UseUseExplosion.cs:24:82:24:85 | access to property Prop |
-| UseUseExplosion.cs:24:65:24:68 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:65:24:68 | access to property Prop | UseUseExplosion.cs:24:3148:24:3153 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:65:24:68 | this access | UseUseExplosion.cs:24:82:24:85 | this access |
 | UseUseExplosion.cs:24:65:24:68 | this access | UseUseExplosion.cs:24:3148:24:3153 | this access |
 | UseUseExplosion.cs:24:82:24:85 | [post] this access | UseUseExplosion.cs:24:99:24:102 | this access |
 | UseUseExplosion.cs:24:82:24:85 | [post] this access | UseUseExplosion.cs:24:3133:24:3138 | this access |
 | UseUseExplosion.cs:24:82:24:85 | access to property Prop | UseUseExplosion.cs:24:99:24:102 | access to property Prop |
-| UseUseExplosion.cs:24:82:24:85 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:82:24:85 | access to property Prop | UseUseExplosion.cs:24:3133:24:3138 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:82:24:85 | this access | UseUseExplosion.cs:24:99:24:102 | this access |
 | UseUseExplosion.cs:24:82:24:85 | this access | UseUseExplosion.cs:24:3133:24:3138 | this access |
 | UseUseExplosion.cs:24:99:24:102 | [post] this access | UseUseExplosion.cs:24:116:24:119 | this access |
 | UseUseExplosion.cs:24:99:24:102 | [post] this access | UseUseExplosion.cs:24:3118:24:3123 | this access |
 | UseUseExplosion.cs:24:99:24:102 | access to property Prop | UseUseExplosion.cs:24:116:24:119 | access to property Prop |
-| UseUseExplosion.cs:24:99:24:102 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:99:24:102 | access to property Prop | UseUseExplosion.cs:24:3118:24:3123 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:99:24:102 | this access | UseUseExplosion.cs:24:116:24:119 | this access |
 | UseUseExplosion.cs:24:99:24:102 | this access | UseUseExplosion.cs:24:3118:24:3123 | this access |
 | UseUseExplosion.cs:24:116:24:119 | [post] this access | UseUseExplosion.cs:24:133:24:136 | this access |
 | UseUseExplosion.cs:24:116:24:119 | [post] this access | UseUseExplosion.cs:24:3103:24:3108 | this access |
 | UseUseExplosion.cs:24:116:24:119 | access to property Prop | UseUseExplosion.cs:24:133:24:136 | access to property Prop |
-| UseUseExplosion.cs:24:116:24:119 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:116:24:119 | access to property Prop | UseUseExplosion.cs:24:3103:24:3108 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:116:24:119 | this access | UseUseExplosion.cs:24:133:24:136 | this access |
 | UseUseExplosion.cs:24:116:24:119 | this access | UseUseExplosion.cs:24:3103:24:3108 | this access |
 | UseUseExplosion.cs:24:133:24:136 | [post] this access | UseUseExplosion.cs:24:150:24:153 | this access |
 | UseUseExplosion.cs:24:133:24:136 | [post] this access | UseUseExplosion.cs:24:3088:24:3093 | this access |
 | UseUseExplosion.cs:24:133:24:136 | access to property Prop | UseUseExplosion.cs:24:150:24:153 | access to property Prop |
-| UseUseExplosion.cs:24:133:24:136 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:133:24:136 | access to property Prop | UseUseExplosion.cs:24:3088:24:3093 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:133:24:136 | this access | UseUseExplosion.cs:24:150:24:153 | this access |
 | UseUseExplosion.cs:24:133:24:136 | this access | UseUseExplosion.cs:24:3088:24:3093 | this access |
 | UseUseExplosion.cs:24:150:24:153 | [post] this access | UseUseExplosion.cs:24:167:24:170 | this access |
 | UseUseExplosion.cs:24:150:24:153 | [post] this access | UseUseExplosion.cs:24:3073:24:3078 | this access |
 | UseUseExplosion.cs:24:150:24:153 | access to property Prop | UseUseExplosion.cs:24:167:24:170 | access to property Prop |
-| UseUseExplosion.cs:24:150:24:153 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:150:24:153 | access to property Prop | UseUseExplosion.cs:24:3073:24:3078 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:150:24:153 | this access | UseUseExplosion.cs:24:167:24:170 | this access |
 | UseUseExplosion.cs:24:150:24:153 | this access | UseUseExplosion.cs:24:3073:24:3078 | this access |
 | UseUseExplosion.cs:24:167:24:170 | [post] this access | UseUseExplosion.cs:24:184:24:187 | this access |
 | UseUseExplosion.cs:24:167:24:170 | [post] this access | UseUseExplosion.cs:24:3058:24:3063 | this access |
 | UseUseExplosion.cs:24:167:24:170 | access to property Prop | UseUseExplosion.cs:24:184:24:187 | access to property Prop |
-| UseUseExplosion.cs:24:167:24:170 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:167:24:170 | access to property Prop | UseUseExplosion.cs:24:3058:24:3063 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:167:24:170 | this access | UseUseExplosion.cs:24:184:24:187 | this access |
 | UseUseExplosion.cs:24:167:24:170 | this access | UseUseExplosion.cs:24:3058:24:3063 | this access |
 | UseUseExplosion.cs:24:184:24:187 | [post] this access | UseUseExplosion.cs:24:201:24:204 | this access |
 | UseUseExplosion.cs:24:184:24:187 | [post] this access | UseUseExplosion.cs:24:3043:24:3048 | this access |
 | UseUseExplosion.cs:24:184:24:187 | access to property Prop | UseUseExplosion.cs:24:201:24:204 | access to property Prop |
-| UseUseExplosion.cs:24:184:24:187 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:184:24:187 | access to property Prop | UseUseExplosion.cs:24:3043:24:3048 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:184:24:187 | this access | UseUseExplosion.cs:24:201:24:204 | this access |
 | UseUseExplosion.cs:24:184:24:187 | this access | UseUseExplosion.cs:24:3043:24:3048 | this access |
 | UseUseExplosion.cs:24:201:24:204 | [post] this access | UseUseExplosion.cs:24:218:24:221 | this access |
 | UseUseExplosion.cs:24:201:24:204 | [post] this access | UseUseExplosion.cs:24:3028:24:3033 | this access |
 | UseUseExplosion.cs:24:201:24:204 | access to property Prop | UseUseExplosion.cs:24:218:24:221 | access to property Prop |
-| UseUseExplosion.cs:24:201:24:204 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:201:24:204 | access to property Prop | UseUseExplosion.cs:24:3028:24:3033 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:201:24:204 | this access | UseUseExplosion.cs:24:218:24:221 | this access |
 | UseUseExplosion.cs:24:201:24:204 | this access | UseUseExplosion.cs:24:3028:24:3033 | this access |
 | UseUseExplosion.cs:24:218:24:221 | [post] this access | UseUseExplosion.cs:24:235:24:238 | this access |
 | UseUseExplosion.cs:24:218:24:221 | [post] this access | UseUseExplosion.cs:24:3013:24:3018 | this access |
 | UseUseExplosion.cs:24:218:24:221 | access to property Prop | UseUseExplosion.cs:24:235:24:238 | access to property Prop |
-| UseUseExplosion.cs:24:218:24:221 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:218:24:221 | access to property Prop | UseUseExplosion.cs:24:3013:24:3018 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:218:24:221 | this access | UseUseExplosion.cs:24:235:24:238 | this access |
 | UseUseExplosion.cs:24:218:24:221 | this access | UseUseExplosion.cs:24:3013:24:3018 | this access |
 | UseUseExplosion.cs:24:235:24:238 | [post] this access | UseUseExplosion.cs:24:252:24:255 | this access |
 | UseUseExplosion.cs:24:235:24:238 | [post] this access | UseUseExplosion.cs:24:2998:24:3003 | this access |
 | UseUseExplosion.cs:24:235:24:238 | access to property Prop | UseUseExplosion.cs:24:252:24:255 | access to property Prop |
-| UseUseExplosion.cs:24:235:24:238 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:235:24:238 | access to property Prop | UseUseExplosion.cs:24:2998:24:3003 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:235:24:238 | this access | UseUseExplosion.cs:24:252:24:255 | this access |
 | UseUseExplosion.cs:24:235:24:238 | this access | UseUseExplosion.cs:24:2998:24:3003 | this access |
 | UseUseExplosion.cs:24:252:24:255 | [post] this access | UseUseExplosion.cs:24:269:24:272 | this access |
 | UseUseExplosion.cs:24:252:24:255 | [post] this access | UseUseExplosion.cs:24:2983:24:2988 | this access |
 | UseUseExplosion.cs:24:252:24:255 | access to property Prop | UseUseExplosion.cs:24:269:24:272 | access to property Prop |
-| UseUseExplosion.cs:24:252:24:255 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:252:24:255 | access to property Prop | UseUseExplosion.cs:24:2983:24:2988 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:252:24:255 | this access | UseUseExplosion.cs:24:269:24:272 | this access |
 | UseUseExplosion.cs:24:252:24:255 | this access | UseUseExplosion.cs:24:2983:24:2988 | this access |
 | UseUseExplosion.cs:24:269:24:272 | [post] this access | UseUseExplosion.cs:24:286:24:289 | this access |
 | UseUseExplosion.cs:24:269:24:272 | [post] this access | UseUseExplosion.cs:24:2968:24:2973 | this access |
 | UseUseExplosion.cs:24:269:24:272 | access to property Prop | UseUseExplosion.cs:24:286:24:289 | access to property Prop |
-| UseUseExplosion.cs:24:269:24:272 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:269:24:272 | access to property Prop | UseUseExplosion.cs:24:2968:24:2973 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:269:24:272 | this access | UseUseExplosion.cs:24:286:24:289 | this access |
 | UseUseExplosion.cs:24:269:24:272 | this access | UseUseExplosion.cs:24:2968:24:2973 | this access |
 | UseUseExplosion.cs:24:286:24:289 | [post] this access | UseUseExplosion.cs:24:303:24:306 | this access |
 | UseUseExplosion.cs:24:286:24:289 | [post] this access | UseUseExplosion.cs:24:2953:24:2958 | this access |
 | UseUseExplosion.cs:24:286:24:289 | access to property Prop | UseUseExplosion.cs:24:303:24:306 | access to property Prop |
-| UseUseExplosion.cs:24:286:24:289 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:286:24:289 | access to property Prop | UseUseExplosion.cs:24:2953:24:2958 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:286:24:289 | this access | UseUseExplosion.cs:24:303:24:306 | this access |
 | UseUseExplosion.cs:24:286:24:289 | this access | UseUseExplosion.cs:24:2953:24:2958 | this access |
 | UseUseExplosion.cs:24:303:24:306 | [post] this access | UseUseExplosion.cs:24:320:24:323 | this access |
 | UseUseExplosion.cs:24:303:24:306 | [post] this access | UseUseExplosion.cs:24:2938:24:2943 | this access |
 | UseUseExplosion.cs:24:303:24:306 | access to property Prop | UseUseExplosion.cs:24:320:24:323 | access to property Prop |
-| UseUseExplosion.cs:24:303:24:306 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:303:24:306 | access to property Prop | UseUseExplosion.cs:24:2938:24:2943 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:303:24:306 | this access | UseUseExplosion.cs:24:320:24:323 | this access |
 | UseUseExplosion.cs:24:303:24:306 | this access | UseUseExplosion.cs:24:2938:24:2943 | this access |
 | UseUseExplosion.cs:24:320:24:323 | [post] this access | UseUseExplosion.cs:24:337:24:340 | this access |
 | UseUseExplosion.cs:24:320:24:323 | [post] this access | UseUseExplosion.cs:24:2923:24:2928 | this access |
 | UseUseExplosion.cs:24:320:24:323 | access to property Prop | UseUseExplosion.cs:24:337:24:340 | access to property Prop |
-| UseUseExplosion.cs:24:320:24:323 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:320:24:323 | access to property Prop | UseUseExplosion.cs:24:2923:24:2928 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:320:24:323 | this access | UseUseExplosion.cs:24:337:24:340 | this access |
 | UseUseExplosion.cs:24:320:24:323 | this access | UseUseExplosion.cs:24:2923:24:2928 | this access |
 | UseUseExplosion.cs:24:337:24:340 | [post] this access | UseUseExplosion.cs:24:354:24:357 | this access |
 | UseUseExplosion.cs:24:337:24:340 | [post] this access | UseUseExplosion.cs:24:2908:24:2913 | this access |
 | UseUseExplosion.cs:24:337:24:340 | access to property Prop | UseUseExplosion.cs:24:354:24:357 | access to property Prop |
-| UseUseExplosion.cs:24:337:24:340 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:337:24:340 | access to property Prop | UseUseExplosion.cs:24:2908:24:2913 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:337:24:340 | this access | UseUseExplosion.cs:24:354:24:357 | this access |
 | UseUseExplosion.cs:24:337:24:340 | this access | UseUseExplosion.cs:24:2908:24:2913 | this access |
 | UseUseExplosion.cs:24:354:24:357 | [post] this access | UseUseExplosion.cs:24:371:24:374 | this access |
 | UseUseExplosion.cs:24:354:24:357 | [post] this access | UseUseExplosion.cs:24:2893:24:2898 | this access |
 | UseUseExplosion.cs:24:354:24:357 | access to property Prop | UseUseExplosion.cs:24:371:24:374 | access to property Prop |
-| UseUseExplosion.cs:24:354:24:357 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:354:24:357 | access to property Prop | UseUseExplosion.cs:24:2893:24:2898 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:354:24:357 | this access | UseUseExplosion.cs:24:371:24:374 | this access |
 | UseUseExplosion.cs:24:354:24:357 | this access | UseUseExplosion.cs:24:2893:24:2898 | this access |
 | UseUseExplosion.cs:24:371:24:374 | [post] this access | UseUseExplosion.cs:24:388:24:391 | this access |
 | UseUseExplosion.cs:24:371:24:374 | [post] this access | UseUseExplosion.cs:24:2878:24:2883 | this access |
 | UseUseExplosion.cs:24:371:24:374 | access to property Prop | UseUseExplosion.cs:24:388:24:391 | access to property Prop |
-| UseUseExplosion.cs:24:371:24:374 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:371:24:374 | access to property Prop | UseUseExplosion.cs:24:2878:24:2883 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:371:24:374 | this access | UseUseExplosion.cs:24:388:24:391 | this access |
 | UseUseExplosion.cs:24:371:24:374 | this access | UseUseExplosion.cs:24:2878:24:2883 | this access |
 | UseUseExplosion.cs:24:388:24:391 | [post] this access | UseUseExplosion.cs:24:405:24:408 | this access |
 | UseUseExplosion.cs:24:388:24:391 | [post] this access | UseUseExplosion.cs:24:2863:24:2868 | this access |
 | UseUseExplosion.cs:24:388:24:391 | access to property Prop | UseUseExplosion.cs:24:405:24:408 | access to property Prop |
-| UseUseExplosion.cs:24:388:24:391 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:388:24:391 | access to property Prop | UseUseExplosion.cs:24:2863:24:2868 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:388:24:391 | this access | UseUseExplosion.cs:24:405:24:408 | this access |
 | UseUseExplosion.cs:24:388:24:391 | this access | UseUseExplosion.cs:24:2863:24:2868 | this access |
 | UseUseExplosion.cs:24:405:24:408 | [post] this access | UseUseExplosion.cs:24:422:24:425 | this access |
 | UseUseExplosion.cs:24:405:24:408 | [post] this access | UseUseExplosion.cs:24:2848:24:2853 | this access |
 | UseUseExplosion.cs:24:405:24:408 | access to property Prop | UseUseExplosion.cs:24:422:24:425 | access to property Prop |
-| UseUseExplosion.cs:24:405:24:408 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:405:24:408 | access to property Prop | UseUseExplosion.cs:24:2848:24:2853 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:405:24:408 | this access | UseUseExplosion.cs:24:422:24:425 | this access |
 | UseUseExplosion.cs:24:405:24:408 | this access | UseUseExplosion.cs:24:2848:24:2853 | this access |
 | UseUseExplosion.cs:24:422:24:425 | [post] this access | UseUseExplosion.cs:24:439:24:442 | this access |
 | UseUseExplosion.cs:24:422:24:425 | [post] this access | UseUseExplosion.cs:24:2833:24:2838 | this access |
 | UseUseExplosion.cs:24:422:24:425 | access to property Prop | UseUseExplosion.cs:24:439:24:442 | access to property Prop |
-| UseUseExplosion.cs:24:422:24:425 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:422:24:425 | access to property Prop | UseUseExplosion.cs:24:2833:24:2838 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:422:24:425 | this access | UseUseExplosion.cs:24:439:24:442 | this access |
 | UseUseExplosion.cs:24:422:24:425 | this access | UseUseExplosion.cs:24:2833:24:2838 | this access |
 | UseUseExplosion.cs:24:439:24:442 | [post] this access | UseUseExplosion.cs:24:456:24:459 | this access |
 | UseUseExplosion.cs:24:439:24:442 | [post] this access | UseUseExplosion.cs:24:2818:24:2823 | this access |
 | UseUseExplosion.cs:24:439:24:442 | access to property Prop | UseUseExplosion.cs:24:456:24:459 | access to property Prop |
-| UseUseExplosion.cs:24:439:24:442 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:439:24:442 | access to property Prop | UseUseExplosion.cs:24:2818:24:2823 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:439:24:442 | this access | UseUseExplosion.cs:24:456:24:459 | this access |
 | UseUseExplosion.cs:24:439:24:442 | this access | UseUseExplosion.cs:24:2818:24:2823 | this access |
 | UseUseExplosion.cs:24:456:24:459 | [post] this access | UseUseExplosion.cs:24:473:24:476 | this access |
 | UseUseExplosion.cs:24:456:24:459 | [post] this access | UseUseExplosion.cs:24:2803:24:2808 | this access |
 | UseUseExplosion.cs:24:456:24:459 | access to property Prop | UseUseExplosion.cs:24:473:24:476 | access to property Prop |
-| UseUseExplosion.cs:24:456:24:459 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:456:24:459 | access to property Prop | UseUseExplosion.cs:24:2803:24:2808 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:456:24:459 | this access | UseUseExplosion.cs:24:473:24:476 | this access |
 | UseUseExplosion.cs:24:456:24:459 | this access | UseUseExplosion.cs:24:2803:24:2808 | this access |
 | UseUseExplosion.cs:24:473:24:476 | [post] this access | UseUseExplosion.cs:24:490:24:493 | this access |
 | UseUseExplosion.cs:24:473:24:476 | [post] this access | UseUseExplosion.cs:24:2788:24:2793 | this access |
 | UseUseExplosion.cs:24:473:24:476 | access to property Prop | UseUseExplosion.cs:24:490:24:493 | access to property Prop |
-| UseUseExplosion.cs:24:473:24:476 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:473:24:476 | access to property Prop | UseUseExplosion.cs:24:2788:24:2793 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:473:24:476 | this access | UseUseExplosion.cs:24:490:24:493 | this access |
 | UseUseExplosion.cs:24:473:24:476 | this access | UseUseExplosion.cs:24:2788:24:2793 | this access |
 | UseUseExplosion.cs:24:490:24:493 | [post] this access | UseUseExplosion.cs:24:507:24:510 | this access |
 | UseUseExplosion.cs:24:490:24:493 | [post] this access | UseUseExplosion.cs:24:2773:24:2778 | this access |
 | UseUseExplosion.cs:24:490:24:493 | access to property Prop | UseUseExplosion.cs:24:507:24:510 | access to property Prop |
-| UseUseExplosion.cs:24:490:24:493 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:490:24:493 | access to property Prop | UseUseExplosion.cs:24:2773:24:2778 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:490:24:493 | this access | UseUseExplosion.cs:24:507:24:510 | this access |
 | UseUseExplosion.cs:24:490:24:493 | this access | UseUseExplosion.cs:24:2773:24:2778 | this access |
 | UseUseExplosion.cs:24:507:24:510 | [post] this access | UseUseExplosion.cs:24:524:24:527 | this access |
 | UseUseExplosion.cs:24:507:24:510 | [post] this access | UseUseExplosion.cs:24:2758:24:2763 | this access |
 | UseUseExplosion.cs:24:507:24:510 | access to property Prop | UseUseExplosion.cs:24:524:24:527 | access to property Prop |
-| UseUseExplosion.cs:24:507:24:510 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:507:24:510 | access to property Prop | UseUseExplosion.cs:24:2758:24:2763 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:507:24:510 | this access | UseUseExplosion.cs:24:524:24:527 | this access |
 | UseUseExplosion.cs:24:507:24:510 | this access | UseUseExplosion.cs:24:2758:24:2763 | this access |
 | UseUseExplosion.cs:24:524:24:527 | [post] this access | UseUseExplosion.cs:24:541:24:544 | this access |
 | UseUseExplosion.cs:24:524:24:527 | [post] this access | UseUseExplosion.cs:24:2743:24:2748 | this access |
 | UseUseExplosion.cs:24:524:24:527 | access to property Prop | UseUseExplosion.cs:24:541:24:544 | access to property Prop |
-| UseUseExplosion.cs:24:524:24:527 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:524:24:527 | access to property Prop | UseUseExplosion.cs:24:2743:24:2748 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:524:24:527 | this access | UseUseExplosion.cs:24:541:24:544 | this access |
 | UseUseExplosion.cs:24:524:24:527 | this access | UseUseExplosion.cs:24:2743:24:2748 | this access |
 | UseUseExplosion.cs:24:541:24:544 | [post] this access | UseUseExplosion.cs:24:558:24:561 | this access |
 | UseUseExplosion.cs:24:541:24:544 | [post] this access | UseUseExplosion.cs:24:2728:24:2733 | this access |
 | UseUseExplosion.cs:24:541:24:544 | access to property Prop | UseUseExplosion.cs:24:558:24:561 | access to property Prop |
-| UseUseExplosion.cs:24:541:24:544 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:541:24:544 | access to property Prop | UseUseExplosion.cs:24:2728:24:2733 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:541:24:544 | this access | UseUseExplosion.cs:24:558:24:561 | this access |
 | UseUseExplosion.cs:24:541:24:544 | this access | UseUseExplosion.cs:24:2728:24:2733 | this access |
 | UseUseExplosion.cs:24:558:24:561 | [post] this access | UseUseExplosion.cs:24:575:24:578 | this access |
 | UseUseExplosion.cs:24:558:24:561 | [post] this access | UseUseExplosion.cs:24:2713:24:2718 | this access |
 | UseUseExplosion.cs:24:558:24:561 | access to property Prop | UseUseExplosion.cs:24:575:24:578 | access to property Prop |
-| UseUseExplosion.cs:24:558:24:561 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:558:24:561 | access to property Prop | UseUseExplosion.cs:24:2713:24:2718 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:558:24:561 | this access | UseUseExplosion.cs:24:575:24:578 | this access |
 | UseUseExplosion.cs:24:558:24:561 | this access | UseUseExplosion.cs:24:2713:24:2718 | this access |
 | UseUseExplosion.cs:24:575:24:578 | [post] this access | UseUseExplosion.cs:24:592:24:595 | this access |
 | UseUseExplosion.cs:24:575:24:578 | [post] this access | UseUseExplosion.cs:24:2698:24:2703 | this access |
 | UseUseExplosion.cs:24:575:24:578 | access to property Prop | UseUseExplosion.cs:24:592:24:595 | access to property Prop |
-| UseUseExplosion.cs:24:575:24:578 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:575:24:578 | access to property Prop | UseUseExplosion.cs:24:2698:24:2703 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:575:24:578 | this access | UseUseExplosion.cs:24:592:24:595 | this access |
 | UseUseExplosion.cs:24:575:24:578 | this access | UseUseExplosion.cs:24:2698:24:2703 | this access |
 | UseUseExplosion.cs:24:592:24:595 | [post] this access | UseUseExplosion.cs:24:609:24:612 | this access |
 | UseUseExplosion.cs:24:592:24:595 | [post] this access | UseUseExplosion.cs:24:2683:24:2688 | this access |
 | UseUseExplosion.cs:24:592:24:595 | access to property Prop | UseUseExplosion.cs:24:609:24:612 | access to property Prop |
-| UseUseExplosion.cs:24:592:24:595 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:592:24:595 | access to property Prop | UseUseExplosion.cs:24:2683:24:2688 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:592:24:595 | this access | UseUseExplosion.cs:24:609:24:612 | this access |
 | UseUseExplosion.cs:24:592:24:595 | this access | UseUseExplosion.cs:24:2683:24:2688 | this access |
 | UseUseExplosion.cs:24:609:24:612 | [post] this access | UseUseExplosion.cs:24:626:24:629 | this access |
 | UseUseExplosion.cs:24:609:24:612 | [post] this access | UseUseExplosion.cs:24:2668:24:2673 | this access |
 | UseUseExplosion.cs:24:609:24:612 | access to property Prop | UseUseExplosion.cs:24:626:24:629 | access to property Prop |
-| UseUseExplosion.cs:24:609:24:612 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:609:24:612 | access to property Prop | UseUseExplosion.cs:24:2668:24:2673 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:609:24:612 | this access | UseUseExplosion.cs:24:626:24:629 | this access |
 | UseUseExplosion.cs:24:609:24:612 | this access | UseUseExplosion.cs:24:2668:24:2673 | this access |
 | UseUseExplosion.cs:24:626:24:629 | [post] this access | UseUseExplosion.cs:24:643:24:646 | this access |
 | UseUseExplosion.cs:24:626:24:629 | [post] this access | UseUseExplosion.cs:24:2653:24:2658 | this access |
 | UseUseExplosion.cs:24:626:24:629 | access to property Prop | UseUseExplosion.cs:24:643:24:646 | access to property Prop |
-| UseUseExplosion.cs:24:626:24:629 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:626:24:629 | access to property Prop | UseUseExplosion.cs:24:2653:24:2658 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:626:24:629 | this access | UseUseExplosion.cs:24:643:24:646 | this access |
 | UseUseExplosion.cs:24:626:24:629 | this access | UseUseExplosion.cs:24:2653:24:2658 | this access |
 | UseUseExplosion.cs:24:643:24:646 | [post] this access | UseUseExplosion.cs:24:660:24:663 | this access |
 | UseUseExplosion.cs:24:643:24:646 | [post] this access | UseUseExplosion.cs:24:2638:24:2643 | this access |
 | UseUseExplosion.cs:24:643:24:646 | access to property Prop | UseUseExplosion.cs:24:660:24:663 | access to property Prop |
-| UseUseExplosion.cs:24:643:24:646 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:643:24:646 | access to property Prop | UseUseExplosion.cs:24:2638:24:2643 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:643:24:646 | this access | UseUseExplosion.cs:24:660:24:663 | this access |
 | UseUseExplosion.cs:24:643:24:646 | this access | UseUseExplosion.cs:24:2638:24:2643 | this access |
 | UseUseExplosion.cs:24:660:24:663 | [post] this access | UseUseExplosion.cs:24:677:24:680 | this access |
 | UseUseExplosion.cs:24:660:24:663 | [post] this access | UseUseExplosion.cs:24:2623:24:2628 | this access |
 | UseUseExplosion.cs:24:660:24:663 | access to property Prop | UseUseExplosion.cs:24:677:24:680 | access to property Prop |
-| UseUseExplosion.cs:24:660:24:663 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:660:24:663 | access to property Prop | UseUseExplosion.cs:24:2623:24:2628 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:660:24:663 | this access | UseUseExplosion.cs:24:677:24:680 | this access |
 | UseUseExplosion.cs:24:660:24:663 | this access | UseUseExplosion.cs:24:2623:24:2628 | this access |
 | UseUseExplosion.cs:24:677:24:680 | [post] this access | UseUseExplosion.cs:24:694:24:697 | this access |
 | UseUseExplosion.cs:24:677:24:680 | [post] this access | UseUseExplosion.cs:24:2608:24:2613 | this access |
 | UseUseExplosion.cs:24:677:24:680 | access to property Prop | UseUseExplosion.cs:24:694:24:697 | access to property Prop |
-| UseUseExplosion.cs:24:677:24:680 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:677:24:680 | access to property Prop | UseUseExplosion.cs:24:2608:24:2613 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:677:24:680 | this access | UseUseExplosion.cs:24:694:24:697 | this access |
 | UseUseExplosion.cs:24:677:24:680 | this access | UseUseExplosion.cs:24:2608:24:2613 | this access |
 | UseUseExplosion.cs:24:694:24:697 | [post] this access | UseUseExplosion.cs:24:711:24:714 | this access |
 | UseUseExplosion.cs:24:694:24:697 | [post] this access | UseUseExplosion.cs:24:2593:24:2598 | this access |
 | UseUseExplosion.cs:24:694:24:697 | access to property Prop | UseUseExplosion.cs:24:711:24:714 | access to property Prop |
-| UseUseExplosion.cs:24:694:24:697 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:694:24:697 | access to property Prop | UseUseExplosion.cs:24:2593:24:2598 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:694:24:697 | this access | UseUseExplosion.cs:24:711:24:714 | this access |
 | UseUseExplosion.cs:24:694:24:697 | this access | UseUseExplosion.cs:24:2593:24:2598 | this access |
 | UseUseExplosion.cs:24:711:24:714 | [post] this access | UseUseExplosion.cs:24:728:24:731 | this access |
 | UseUseExplosion.cs:24:711:24:714 | [post] this access | UseUseExplosion.cs:24:2578:24:2583 | this access |
 | UseUseExplosion.cs:24:711:24:714 | access to property Prop | UseUseExplosion.cs:24:728:24:731 | access to property Prop |
-| UseUseExplosion.cs:24:711:24:714 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:711:24:714 | access to property Prop | UseUseExplosion.cs:24:2578:24:2583 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:711:24:714 | this access | UseUseExplosion.cs:24:728:24:731 | this access |
 | UseUseExplosion.cs:24:711:24:714 | this access | UseUseExplosion.cs:24:2578:24:2583 | this access |
 | UseUseExplosion.cs:24:728:24:731 | [post] this access | UseUseExplosion.cs:24:745:24:748 | this access |
 | UseUseExplosion.cs:24:728:24:731 | [post] this access | UseUseExplosion.cs:24:2563:24:2568 | this access |
 | UseUseExplosion.cs:24:728:24:731 | access to property Prop | UseUseExplosion.cs:24:745:24:748 | access to property Prop |
-| UseUseExplosion.cs:24:728:24:731 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:728:24:731 | access to property Prop | UseUseExplosion.cs:24:2563:24:2568 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:728:24:731 | this access | UseUseExplosion.cs:24:745:24:748 | this access |
 | UseUseExplosion.cs:24:728:24:731 | this access | UseUseExplosion.cs:24:2563:24:2568 | this access |
 | UseUseExplosion.cs:24:745:24:748 | [post] this access | UseUseExplosion.cs:24:762:24:765 | this access |
 | UseUseExplosion.cs:24:745:24:748 | [post] this access | UseUseExplosion.cs:24:2548:24:2553 | this access |
 | UseUseExplosion.cs:24:745:24:748 | access to property Prop | UseUseExplosion.cs:24:762:24:765 | access to property Prop |
-| UseUseExplosion.cs:24:745:24:748 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:745:24:748 | access to property Prop | UseUseExplosion.cs:24:2548:24:2553 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:745:24:748 | this access | UseUseExplosion.cs:24:762:24:765 | this access |
 | UseUseExplosion.cs:24:745:24:748 | this access | UseUseExplosion.cs:24:2548:24:2553 | this access |
 | UseUseExplosion.cs:24:762:24:765 | [post] this access | UseUseExplosion.cs:24:779:24:782 | this access |
 | UseUseExplosion.cs:24:762:24:765 | [post] this access | UseUseExplosion.cs:24:2533:24:2538 | this access |
 | UseUseExplosion.cs:24:762:24:765 | access to property Prop | UseUseExplosion.cs:24:779:24:782 | access to property Prop |
-| UseUseExplosion.cs:24:762:24:765 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:762:24:765 | access to property Prop | UseUseExplosion.cs:24:2533:24:2538 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:762:24:765 | this access | UseUseExplosion.cs:24:779:24:782 | this access |
 | UseUseExplosion.cs:24:762:24:765 | this access | UseUseExplosion.cs:24:2533:24:2538 | this access |
 | UseUseExplosion.cs:24:779:24:782 | [post] this access | UseUseExplosion.cs:24:796:24:799 | this access |
 | UseUseExplosion.cs:24:779:24:782 | [post] this access | UseUseExplosion.cs:24:2518:24:2523 | this access |
 | UseUseExplosion.cs:24:779:24:782 | access to property Prop | UseUseExplosion.cs:24:796:24:799 | access to property Prop |
-| UseUseExplosion.cs:24:779:24:782 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:779:24:782 | access to property Prop | UseUseExplosion.cs:24:2518:24:2523 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:779:24:782 | this access | UseUseExplosion.cs:24:796:24:799 | this access |
 | UseUseExplosion.cs:24:779:24:782 | this access | UseUseExplosion.cs:24:2518:24:2523 | this access |
 | UseUseExplosion.cs:24:796:24:799 | [post] this access | UseUseExplosion.cs:24:813:24:816 | this access |
 | UseUseExplosion.cs:24:796:24:799 | [post] this access | UseUseExplosion.cs:24:2503:24:2508 | this access |
 | UseUseExplosion.cs:24:796:24:799 | access to property Prop | UseUseExplosion.cs:24:813:24:816 | access to property Prop |
-| UseUseExplosion.cs:24:796:24:799 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:796:24:799 | access to property Prop | UseUseExplosion.cs:24:2503:24:2508 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:796:24:799 | this access | UseUseExplosion.cs:24:813:24:816 | this access |
 | UseUseExplosion.cs:24:796:24:799 | this access | UseUseExplosion.cs:24:2503:24:2508 | this access |
 | UseUseExplosion.cs:24:813:24:816 | [post] this access | UseUseExplosion.cs:24:830:24:833 | this access |
 | UseUseExplosion.cs:24:813:24:816 | [post] this access | UseUseExplosion.cs:24:2488:24:2493 | this access |
 | UseUseExplosion.cs:24:813:24:816 | access to property Prop | UseUseExplosion.cs:24:830:24:833 | access to property Prop |
-| UseUseExplosion.cs:24:813:24:816 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:813:24:816 | access to property Prop | UseUseExplosion.cs:24:2488:24:2493 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:813:24:816 | this access | UseUseExplosion.cs:24:830:24:833 | this access |
 | UseUseExplosion.cs:24:813:24:816 | this access | UseUseExplosion.cs:24:2488:24:2493 | this access |
 | UseUseExplosion.cs:24:830:24:833 | [post] this access | UseUseExplosion.cs:24:847:24:850 | this access |
 | UseUseExplosion.cs:24:830:24:833 | [post] this access | UseUseExplosion.cs:24:2473:24:2478 | this access |
 | UseUseExplosion.cs:24:830:24:833 | access to property Prop | UseUseExplosion.cs:24:847:24:850 | access to property Prop |
-| UseUseExplosion.cs:24:830:24:833 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:830:24:833 | access to property Prop | UseUseExplosion.cs:24:2473:24:2478 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:830:24:833 | this access | UseUseExplosion.cs:24:847:24:850 | this access |
 | UseUseExplosion.cs:24:830:24:833 | this access | UseUseExplosion.cs:24:2473:24:2478 | this access |
 | UseUseExplosion.cs:24:847:24:850 | [post] this access | UseUseExplosion.cs:24:864:24:867 | this access |
 | UseUseExplosion.cs:24:847:24:850 | [post] this access | UseUseExplosion.cs:24:2458:24:2463 | this access |
 | UseUseExplosion.cs:24:847:24:850 | access to property Prop | UseUseExplosion.cs:24:864:24:867 | access to property Prop |
-| UseUseExplosion.cs:24:847:24:850 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:847:24:850 | access to property Prop | UseUseExplosion.cs:24:2458:24:2463 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:847:24:850 | this access | UseUseExplosion.cs:24:864:24:867 | this access |
 | UseUseExplosion.cs:24:847:24:850 | this access | UseUseExplosion.cs:24:2458:24:2463 | this access |
 | UseUseExplosion.cs:24:864:24:867 | [post] this access | UseUseExplosion.cs:24:881:24:884 | this access |
 | UseUseExplosion.cs:24:864:24:867 | [post] this access | UseUseExplosion.cs:24:2443:24:2448 | this access |
 | UseUseExplosion.cs:24:864:24:867 | access to property Prop | UseUseExplosion.cs:24:881:24:884 | access to property Prop |
-| UseUseExplosion.cs:24:864:24:867 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:864:24:867 | access to property Prop | UseUseExplosion.cs:24:2443:24:2448 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:864:24:867 | this access | UseUseExplosion.cs:24:881:24:884 | this access |
 | UseUseExplosion.cs:24:864:24:867 | this access | UseUseExplosion.cs:24:2443:24:2448 | this access |
 | UseUseExplosion.cs:24:881:24:884 | [post] this access | UseUseExplosion.cs:24:898:24:901 | this access |
 | UseUseExplosion.cs:24:881:24:884 | [post] this access | UseUseExplosion.cs:24:2428:24:2433 | this access |
 | UseUseExplosion.cs:24:881:24:884 | access to property Prop | UseUseExplosion.cs:24:898:24:901 | access to property Prop |
-| UseUseExplosion.cs:24:881:24:884 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:881:24:884 | access to property Prop | UseUseExplosion.cs:24:2428:24:2433 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:881:24:884 | this access | UseUseExplosion.cs:24:898:24:901 | this access |
 | UseUseExplosion.cs:24:881:24:884 | this access | UseUseExplosion.cs:24:2428:24:2433 | this access |
 | UseUseExplosion.cs:24:898:24:901 | [post] this access | UseUseExplosion.cs:24:915:24:918 | this access |
 | UseUseExplosion.cs:24:898:24:901 | [post] this access | UseUseExplosion.cs:24:2413:24:2418 | this access |
 | UseUseExplosion.cs:24:898:24:901 | access to property Prop | UseUseExplosion.cs:24:915:24:918 | access to property Prop |
-| UseUseExplosion.cs:24:898:24:901 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:898:24:901 | access to property Prop | UseUseExplosion.cs:24:2413:24:2418 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:898:24:901 | this access | UseUseExplosion.cs:24:915:24:918 | this access |
 | UseUseExplosion.cs:24:898:24:901 | this access | UseUseExplosion.cs:24:2413:24:2418 | this access |
 | UseUseExplosion.cs:24:915:24:918 | [post] this access | UseUseExplosion.cs:24:932:24:935 | this access |
 | UseUseExplosion.cs:24:915:24:918 | [post] this access | UseUseExplosion.cs:24:2398:24:2403 | this access |
 | UseUseExplosion.cs:24:915:24:918 | access to property Prop | UseUseExplosion.cs:24:932:24:935 | access to property Prop |
-| UseUseExplosion.cs:24:915:24:918 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:915:24:918 | access to property Prop | UseUseExplosion.cs:24:2398:24:2403 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:915:24:918 | this access | UseUseExplosion.cs:24:932:24:935 | this access |
 | UseUseExplosion.cs:24:915:24:918 | this access | UseUseExplosion.cs:24:2398:24:2403 | this access |
 | UseUseExplosion.cs:24:932:24:935 | [post] this access | UseUseExplosion.cs:24:949:24:952 | this access |
 | UseUseExplosion.cs:24:932:24:935 | [post] this access | UseUseExplosion.cs:24:2383:24:2388 | this access |
 | UseUseExplosion.cs:24:932:24:935 | access to property Prop | UseUseExplosion.cs:24:949:24:952 | access to property Prop |
-| UseUseExplosion.cs:24:932:24:935 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:932:24:935 | access to property Prop | UseUseExplosion.cs:24:2383:24:2388 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:932:24:935 | this access | UseUseExplosion.cs:24:949:24:952 | this access |
 | UseUseExplosion.cs:24:932:24:935 | this access | UseUseExplosion.cs:24:2383:24:2388 | this access |
 | UseUseExplosion.cs:24:949:24:952 | [post] this access | UseUseExplosion.cs:24:966:24:969 | this access |
 | UseUseExplosion.cs:24:949:24:952 | [post] this access | UseUseExplosion.cs:24:2368:24:2373 | this access |
 | UseUseExplosion.cs:24:949:24:952 | access to property Prop | UseUseExplosion.cs:24:966:24:969 | access to property Prop |
-| UseUseExplosion.cs:24:949:24:952 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:949:24:952 | access to property Prop | UseUseExplosion.cs:24:2368:24:2373 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:949:24:952 | this access | UseUseExplosion.cs:24:966:24:969 | this access |
 | UseUseExplosion.cs:24:949:24:952 | this access | UseUseExplosion.cs:24:2368:24:2373 | this access |
 | UseUseExplosion.cs:24:966:24:969 | [post] this access | UseUseExplosion.cs:24:983:24:986 | this access |
 | UseUseExplosion.cs:24:966:24:969 | [post] this access | UseUseExplosion.cs:24:2353:24:2358 | this access |
 | UseUseExplosion.cs:24:966:24:969 | access to property Prop | UseUseExplosion.cs:24:983:24:986 | access to property Prop |
-| UseUseExplosion.cs:24:966:24:969 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:966:24:969 | access to property Prop | UseUseExplosion.cs:24:2353:24:2358 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:966:24:969 | this access | UseUseExplosion.cs:24:983:24:986 | this access |
 | UseUseExplosion.cs:24:966:24:969 | this access | UseUseExplosion.cs:24:2353:24:2358 | this access |
 | UseUseExplosion.cs:24:983:24:986 | [post] this access | UseUseExplosion.cs:24:1000:24:1003 | this access |
 | UseUseExplosion.cs:24:983:24:986 | [post] this access | UseUseExplosion.cs:24:2338:24:2343 | this access |
 | UseUseExplosion.cs:24:983:24:986 | access to property Prop | UseUseExplosion.cs:24:1000:24:1003 | access to property Prop |
-| UseUseExplosion.cs:24:983:24:986 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:983:24:986 | access to property Prop | UseUseExplosion.cs:24:2338:24:2343 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:983:24:986 | this access | UseUseExplosion.cs:24:1000:24:1003 | this access |
 | UseUseExplosion.cs:24:983:24:986 | this access | UseUseExplosion.cs:24:2338:24:2343 | this access |
 | UseUseExplosion.cs:24:1000:24:1003 | [post] this access | UseUseExplosion.cs:24:1017:24:1020 | this access |
 | UseUseExplosion.cs:24:1000:24:1003 | [post] this access | UseUseExplosion.cs:24:2323:24:2328 | this access |
 | UseUseExplosion.cs:24:1000:24:1003 | access to property Prop | UseUseExplosion.cs:24:1017:24:1020 | access to property Prop |
-| UseUseExplosion.cs:24:1000:24:1003 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1000:24:1003 | access to property Prop | UseUseExplosion.cs:24:2323:24:2328 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1000:24:1003 | this access | UseUseExplosion.cs:24:1017:24:1020 | this access |
 | UseUseExplosion.cs:24:1000:24:1003 | this access | UseUseExplosion.cs:24:2323:24:2328 | this access |
 | UseUseExplosion.cs:24:1017:24:1020 | [post] this access | UseUseExplosion.cs:24:1034:24:1037 | this access |
 | UseUseExplosion.cs:24:1017:24:1020 | [post] this access | UseUseExplosion.cs:24:2308:24:2313 | this access |
 | UseUseExplosion.cs:24:1017:24:1020 | access to property Prop | UseUseExplosion.cs:24:1034:24:1037 | access to property Prop |
-| UseUseExplosion.cs:24:1017:24:1020 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1017:24:1020 | access to property Prop | UseUseExplosion.cs:24:2308:24:2313 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1017:24:1020 | this access | UseUseExplosion.cs:24:1034:24:1037 | this access |
 | UseUseExplosion.cs:24:1017:24:1020 | this access | UseUseExplosion.cs:24:2308:24:2313 | this access |
 | UseUseExplosion.cs:24:1034:24:1037 | [post] this access | UseUseExplosion.cs:24:1051:24:1054 | this access |
 | UseUseExplosion.cs:24:1034:24:1037 | [post] this access | UseUseExplosion.cs:24:2293:24:2298 | this access |
 | UseUseExplosion.cs:24:1034:24:1037 | access to property Prop | UseUseExplosion.cs:24:1051:24:1054 | access to property Prop |
-| UseUseExplosion.cs:24:1034:24:1037 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1034:24:1037 | access to property Prop | UseUseExplosion.cs:24:2293:24:2298 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1034:24:1037 | this access | UseUseExplosion.cs:24:1051:24:1054 | this access |
 | UseUseExplosion.cs:24:1034:24:1037 | this access | UseUseExplosion.cs:24:2293:24:2298 | this access |
 | UseUseExplosion.cs:24:1051:24:1054 | [post] this access | UseUseExplosion.cs:24:1068:24:1071 | this access |
 | UseUseExplosion.cs:24:1051:24:1054 | [post] this access | UseUseExplosion.cs:24:2278:24:2283 | this access |
 | UseUseExplosion.cs:24:1051:24:1054 | access to property Prop | UseUseExplosion.cs:24:1068:24:1071 | access to property Prop |
-| UseUseExplosion.cs:24:1051:24:1054 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1051:24:1054 | access to property Prop | UseUseExplosion.cs:24:2278:24:2283 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1051:24:1054 | this access | UseUseExplosion.cs:24:1068:24:1071 | this access |
 | UseUseExplosion.cs:24:1051:24:1054 | this access | UseUseExplosion.cs:24:2278:24:2283 | this access |
 | UseUseExplosion.cs:24:1068:24:1071 | [post] this access | UseUseExplosion.cs:24:1085:24:1088 | this access |
 | UseUseExplosion.cs:24:1068:24:1071 | [post] this access | UseUseExplosion.cs:24:2263:24:2268 | this access |
 | UseUseExplosion.cs:24:1068:24:1071 | access to property Prop | UseUseExplosion.cs:24:1085:24:1088 | access to property Prop |
-| UseUseExplosion.cs:24:1068:24:1071 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1068:24:1071 | access to property Prop | UseUseExplosion.cs:24:2263:24:2268 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1068:24:1071 | this access | UseUseExplosion.cs:24:1085:24:1088 | this access |
 | UseUseExplosion.cs:24:1068:24:1071 | this access | UseUseExplosion.cs:24:2263:24:2268 | this access |
 | UseUseExplosion.cs:24:1085:24:1088 | [post] this access | UseUseExplosion.cs:24:1102:24:1105 | this access |
 | UseUseExplosion.cs:24:1085:24:1088 | [post] this access | UseUseExplosion.cs:24:2248:24:2253 | this access |
 | UseUseExplosion.cs:24:1085:24:1088 | access to property Prop | UseUseExplosion.cs:24:1102:24:1105 | access to property Prop |
-| UseUseExplosion.cs:24:1085:24:1088 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1085:24:1088 | access to property Prop | UseUseExplosion.cs:24:2248:24:2253 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1085:24:1088 | this access | UseUseExplosion.cs:24:1102:24:1105 | this access |
 | UseUseExplosion.cs:24:1085:24:1088 | this access | UseUseExplosion.cs:24:2248:24:2253 | this access |
 | UseUseExplosion.cs:24:1102:24:1105 | [post] this access | UseUseExplosion.cs:24:1119:24:1122 | this access |
 | UseUseExplosion.cs:24:1102:24:1105 | [post] this access | UseUseExplosion.cs:24:2233:24:2238 | this access |
 | UseUseExplosion.cs:24:1102:24:1105 | access to property Prop | UseUseExplosion.cs:24:1119:24:1122 | access to property Prop |
-| UseUseExplosion.cs:24:1102:24:1105 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1102:24:1105 | access to property Prop | UseUseExplosion.cs:24:2233:24:2238 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1102:24:1105 | this access | UseUseExplosion.cs:24:1119:24:1122 | this access |
 | UseUseExplosion.cs:24:1102:24:1105 | this access | UseUseExplosion.cs:24:2233:24:2238 | this access |
 | UseUseExplosion.cs:24:1119:24:1122 | [post] this access | UseUseExplosion.cs:24:1136:24:1139 | this access |
 | UseUseExplosion.cs:24:1119:24:1122 | [post] this access | UseUseExplosion.cs:24:2218:24:2223 | this access |
 | UseUseExplosion.cs:24:1119:24:1122 | access to property Prop | UseUseExplosion.cs:24:1136:24:1139 | access to property Prop |
-| UseUseExplosion.cs:24:1119:24:1122 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1119:24:1122 | access to property Prop | UseUseExplosion.cs:24:2218:24:2223 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1119:24:1122 | this access | UseUseExplosion.cs:24:1136:24:1139 | this access |
 | UseUseExplosion.cs:24:1119:24:1122 | this access | UseUseExplosion.cs:24:2218:24:2223 | this access |
 | UseUseExplosion.cs:24:1136:24:1139 | [post] this access | UseUseExplosion.cs:24:1153:24:1156 | this access |
 | UseUseExplosion.cs:24:1136:24:1139 | [post] this access | UseUseExplosion.cs:24:2203:24:2208 | this access |
 | UseUseExplosion.cs:24:1136:24:1139 | access to property Prop | UseUseExplosion.cs:24:1153:24:1156 | access to property Prop |
-| UseUseExplosion.cs:24:1136:24:1139 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1136:24:1139 | access to property Prop | UseUseExplosion.cs:24:2203:24:2208 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1136:24:1139 | this access | UseUseExplosion.cs:24:1153:24:1156 | this access |
 | UseUseExplosion.cs:24:1136:24:1139 | this access | UseUseExplosion.cs:24:2203:24:2208 | this access |
 | UseUseExplosion.cs:24:1153:24:1156 | [post] this access | UseUseExplosion.cs:24:1170:24:1173 | this access |
 | UseUseExplosion.cs:24:1153:24:1156 | [post] this access | UseUseExplosion.cs:24:2188:24:2193 | this access |
 | UseUseExplosion.cs:24:1153:24:1156 | access to property Prop | UseUseExplosion.cs:24:1170:24:1173 | access to property Prop |
-| UseUseExplosion.cs:24:1153:24:1156 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1153:24:1156 | access to property Prop | UseUseExplosion.cs:24:2188:24:2193 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1153:24:1156 | this access | UseUseExplosion.cs:24:1170:24:1173 | this access |
 | UseUseExplosion.cs:24:1153:24:1156 | this access | UseUseExplosion.cs:24:2188:24:2193 | this access |
 | UseUseExplosion.cs:24:1170:24:1173 | [post] this access | UseUseExplosion.cs:24:1187:24:1190 | this access |
 | UseUseExplosion.cs:24:1170:24:1173 | [post] this access | UseUseExplosion.cs:24:2173:24:2178 | this access |
 | UseUseExplosion.cs:24:1170:24:1173 | access to property Prop | UseUseExplosion.cs:24:1187:24:1190 | access to property Prop |
-| UseUseExplosion.cs:24:1170:24:1173 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1170:24:1173 | access to property Prop | UseUseExplosion.cs:24:2173:24:2178 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1170:24:1173 | this access | UseUseExplosion.cs:24:1187:24:1190 | this access |
 | UseUseExplosion.cs:24:1170:24:1173 | this access | UseUseExplosion.cs:24:2173:24:2178 | this access |
 | UseUseExplosion.cs:24:1187:24:1190 | [post] this access | UseUseExplosion.cs:24:1204:24:1207 | this access |
 | UseUseExplosion.cs:24:1187:24:1190 | [post] this access | UseUseExplosion.cs:24:2158:24:2163 | this access |
 | UseUseExplosion.cs:24:1187:24:1190 | access to property Prop | UseUseExplosion.cs:24:1204:24:1207 | access to property Prop |
-| UseUseExplosion.cs:24:1187:24:1190 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1187:24:1190 | access to property Prop | UseUseExplosion.cs:24:2158:24:2163 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1187:24:1190 | this access | UseUseExplosion.cs:24:1204:24:1207 | this access |
 | UseUseExplosion.cs:24:1187:24:1190 | this access | UseUseExplosion.cs:24:2158:24:2163 | this access |
 | UseUseExplosion.cs:24:1204:24:1207 | [post] this access | UseUseExplosion.cs:24:1221:24:1224 | this access |
 | UseUseExplosion.cs:24:1204:24:1207 | [post] this access | UseUseExplosion.cs:24:2143:24:2148 | this access |
 | UseUseExplosion.cs:24:1204:24:1207 | access to property Prop | UseUseExplosion.cs:24:1221:24:1224 | access to property Prop |
-| UseUseExplosion.cs:24:1204:24:1207 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1204:24:1207 | access to property Prop | UseUseExplosion.cs:24:2143:24:2148 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1204:24:1207 | this access | UseUseExplosion.cs:24:1221:24:1224 | this access |
 | UseUseExplosion.cs:24:1204:24:1207 | this access | UseUseExplosion.cs:24:2143:24:2148 | this access |
 | UseUseExplosion.cs:24:1221:24:1224 | [post] this access | UseUseExplosion.cs:24:1238:24:1241 | this access |
 | UseUseExplosion.cs:24:1221:24:1224 | [post] this access | UseUseExplosion.cs:24:2128:24:2133 | this access |
 | UseUseExplosion.cs:24:1221:24:1224 | access to property Prop | UseUseExplosion.cs:24:1238:24:1241 | access to property Prop |
-| UseUseExplosion.cs:24:1221:24:1224 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1221:24:1224 | access to property Prop | UseUseExplosion.cs:24:2128:24:2133 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1221:24:1224 | this access | UseUseExplosion.cs:24:1238:24:1241 | this access |
 | UseUseExplosion.cs:24:1221:24:1224 | this access | UseUseExplosion.cs:24:2128:24:2133 | this access |
 | UseUseExplosion.cs:24:1238:24:1241 | [post] this access | UseUseExplosion.cs:24:1255:24:1258 | this access |
 | UseUseExplosion.cs:24:1238:24:1241 | [post] this access | UseUseExplosion.cs:24:2113:24:2118 | this access |
 | UseUseExplosion.cs:24:1238:24:1241 | access to property Prop | UseUseExplosion.cs:24:1255:24:1258 | access to property Prop |
-| UseUseExplosion.cs:24:1238:24:1241 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1238:24:1241 | access to property Prop | UseUseExplosion.cs:24:2113:24:2118 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1238:24:1241 | this access | UseUseExplosion.cs:24:1255:24:1258 | this access |
 | UseUseExplosion.cs:24:1238:24:1241 | this access | UseUseExplosion.cs:24:2113:24:2118 | this access |
 | UseUseExplosion.cs:24:1255:24:1258 | [post] this access | UseUseExplosion.cs:24:1272:24:1275 | this access |
 | UseUseExplosion.cs:24:1255:24:1258 | [post] this access | UseUseExplosion.cs:24:2098:24:2103 | this access |
 | UseUseExplosion.cs:24:1255:24:1258 | access to property Prop | UseUseExplosion.cs:24:1272:24:1275 | access to property Prop |
-| UseUseExplosion.cs:24:1255:24:1258 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1255:24:1258 | access to property Prop | UseUseExplosion.cs:24:2098:24:2103 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1255:24:1258 | this access | UseUseExplosion.cs:24:1272:24:1275 | this access |
 | UseUseExplosion.cs:24:1255:24:1258 | this access | UseUseExplosion.cs:24:2098:24:2103 | this access |
 | UseUseExplosion.cs:24:1272:24:1275 | [post] this access | UseUseExplosion.cs:24:1289:24:1292 | this access |
 | UseUseExplosion.cs:24:1272:24:1275 | [post] this access | UseUseExplosion.cs:24:2083:24:2088 | this access |
 | UseUseExplosion.cs:24:1272:24:1275 | access to property Prop | UseUseExplosion.cs:24:1289:24:1292 | access to property Prop |
-| UseUseExplosion.cs:24:1272:24:1275 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1272:24:1275 | access to property Prop | UseUseExplosion.cs:24:2083:24:2088 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1272:24:1275 | this access | UseUseExplosion.cs:24:1289:24:1292 | this access |
 | UseUseExplosion.cs:24:1272:24:1275 | this access | UseUseExplosion.cs:24:2083:24:2088 | this access |
 | UseUseExplosion.cs:24:1289:24:1292 | [post] this access | UseUseExplosion.cs:24:1306:24:1309 | this access |
 | UseUseExplosion.cs:24:1289:24:1292 | [post] this access | UseUseExplosion.cs:24:2068:24:2073 | this access |
 | UseUseExplosion.cs:24:1289:24:1292 | access to property Prop | UseUseExplosion.cs:24:1306:24:1309 | access to property Prop |
-| UseUseExplosion.cs:24:1289:24:1292 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1289:24:1292 | access to property Prop | UseUseExplosion.cs:24:2068:24:2073 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1289:24:1292 | this access | UseUseExplosion.cs:24:1306:24:1309 | this access |
 | UseUseExplosion.cs:24:1289:24:1292 | this access | UseUseExplosion.cs:24:2068:24:2073 | this access |
 | UseUseExplosion.cs:24:1306:24:1309 | [post] this access | UseUseExplosion.cs:24:1323:24:1326 | this access |
 | UseUseExplosion.cs:24:1306:24:1309 | [post] this access | UseUseExplosion.cs:24:2053:24:2058 | this access |
 | UseUseExplosion.cs:24:1306:24:1309 | access to property Prop | UseUseExplosion.cs:24:1323:24:1326 | access to property Prop |
-| UseUseExplosion.cs:24:1306:24:1309 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1306:24:1309 | access to property Prop | UseUseExplosion.cs:24:2053:24:2058 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1306:24:1309 | this access | UseUseExplosion.cs:24:1323:24:1326 | this access |
 | UseUseExplosion.cs:24:1306:24:1309 | this access | UseUseExplosion.cs:24:2053:24:2058 | this access |
 | UseUseExplosion.cs:24:1323:24:1326 | [post] this access | UseUseExplosion.cs:24:1340:24:1343 | this access |
 | UseUseExplosion.cs:24:1323:24:1326 | [post] this access | UseUseExplosion.cs:24:2038:24:2043 | this access |
 | UseUseExplosion.cs:24:1323:24:1326 | access to property Prop | UseUseExplosion.cs:24:1340:24:1343 | access to property Prop |
-| UseUseExplosion.cs:24:1323:24:1326 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1323:24:1326 | access to property Prop | UseUseExplosion.cs:24:2038:24:2043 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1323:24:1326 | this access | UseUseExplosion.cs:24:1340:24:1343 | this access |
 | UseUseExplosion.cs:24:1323:24:1326 | this access | UseUseExplosion.cs:24:2038:24:2043 | this access |
 | UseUseExplosion.cs:24:1340:24:1343 | [post] this access | UseUseExplosion.cs:24:1357:24:1360 | this access |
 | UseUseExplosion.cs:24:1340:24:1343 | [post] this access | UseUseExplosion.cs:24:2023:24:2028 | this access |
 | UseUseExplosion.cs:24:1340:24:1343 | access to property Prop | UseUseExplosion.cs:24:1357:24:1360 | access to property Prop |
-| UseUseExplosion.cs:24:1340:24:1343 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1340:24:1343 | access to property Prop | UseUseExplosion.cs:24:2023:24:2028 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1340:24:1343 | this access | UseUseExplosion.cs:24:1357:24:1360 | this access |
 | UseUseExplosion.cs:24:1340:24:1343 | this access | UseUseExplosion.cs:24:2023:24:2028 | this access |
 | UseUseExplosion.cs:24:1357:24:1360 | [post] this access | UseUseExplosion.cs:24:1374:24:1377 | this access |
 | UseUseExplosion.cs:24:1357:24:1360 | [post] this access | UseUseExplosion.cs:24:2008:24:2013 | this access |
 | UseUseExplosion.cs:24:1357:24:1360 | access to property Prop | UseUseExplosion.cs:24:1374:24:1377 | access to property Prop |
-| UseUseExplosion.cs:24:1357:24:1360 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1357:24:1360 | access to property Prop | UseUseExplosion.cs:24:2008:24:2013 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1357:24:1360 | this access | UseUseExplosion.cs:24:1374:24:1377 | this access |
 | UseUseExplosion.cs:24:1357:24:1360 | this access | UseUseExplosion.cs:24:2008:24:2013 | this access |
 | UseUseExplosion.cs:24:1374:24:1377 | [post] this access | UseUseExplosion.cs:24:1391:24:1394 | this access |
 | UseUseExplosion.cs:24:1374:24:1377 | [post] this access | UseUseExplosion.cs:24:1993:24:1998 | this access |
 | UseUseExplosion.cs:24:1374:24:1377 | access to property Prop | UseUseExplosion.cs:24:1391:24:1394 | access to property Prop |
-| UseUseExplosion.cs:24:1374:24:1377 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1374:24:1377 | access to property Prop | UseUseExplosion.cs:24:1993:24:1998 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1374:24:1377 | this access | UseUseExplosion.cs:24:1391:24:1394 | this access |
 | UseUseExplosion.cs:24:1374:24:1377 | this access | UseUseExplosion.cs:24:1993:24:1998 | this access |
 | UseUseExplosion.cs:24:1391:24:1394 | [post] this access | UseUseExplosion.cs:24:1408:24:1411 | this access |
 | UseUseExplosion.cs:24:1391:24:1394 | [post] this access | UseUseExplosion.cs:24:1978:24:1983 | this access |
 | UseUseExplosion.cs:24:1391:24:1394 | access to property Prop | UseUseExplosion.cs:24:1408:24:1411 | access to property Prop |
-| UseUseExplosion.cs:24:1391:24:1394 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1391:24:1394 | access to property Prop | UseUseExplosion.cs:24:1978:24:1983 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1391:24:1394 | this access | UseUseExplosion.cs:24:1408:24:1411 | this access |
 | UseUseExplosion.cs:24:1391:24:1394 | this access | UseUseExplosion.cs:24:1978:24:1983 | this access |
 | UseUseExplosion.cs:24:1408:24:1411 | [post] this access | UseUseExplosion.cs:24:1425:24:1428 | this access |
 | UseUseExplosion.cs:24:1408:24:1411 | [post] this access | UseUseExplosion.cs:24:1963:24:1968 | this access |
 | UseUseExplosion.cs:24:1408:24:1411 | access to property Prop | UseUseExplosion.cs:24:1425:24:1428 | access to property Prop |
-| UseUseExplosion.cs:24:1408:24:1411 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1408:24:1411 | access to property Prop | UseUseExplosion.cs:24:1963:24:1968 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1408:24:1411 | this access | UseUseExplosion.cs:24:1425:24:1428 | this access |
 | UseUseExplosion.cs:24:1408:24:1411 | this access | UseUseExplosion.cs:24:1963:24:1968 | this access |
 | UseUseExplosion.cs:24:1425:24:1428 | [post] this access | UseUseExplosion.cs:24:1442:24:1445 | this access |
 | UseUseExplosion.cs:24:1425:24:1428 | [post] this access | UseUseExplosion.cs:24:1948:24:1953 | this access |
 | UseUseExplosion.cs:24:1425:24:1428 | access to property Prop | UseUseExplosion.cs:24:1442:24:1445 | access to property Prop |
-| UseUseExplosion.cs:24:1425:24:1428 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1425:24:1428 | access to property Prop | UseUseExplosion.cs:24:1948:24:1953 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1425:24:1428 | this access | UseUseExplosion.cs:24:1442:24:1445 | this access |
 | UseUseExplosion.cs:24:1425:24:1428 | this access | UseUseExplosion.cs:24:1948:24:1953 | this access |
 | UseUseExplosion.cs:24:1442:24:1445 | [post] this access | UseUseExplosion.cs:24:1459:24:1462 | this access |
 | UseUseExplosion.cs:24:1442:24:1445 | [post] this access | UseUseExplosion.cs:24:1933:24:1938 | this access |
 | UseUseExplosion.cs:24:1442:24:1445 | access to property Prop | UseUseExplosion.cs:24:1459:24:1462 | access to property Prop |
-| UseUseExplosion.cs:24:1442:24:1445 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1442:24:1445 | access to property Prop | UseUseExplosion.cs:24:1933:24:1938 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1442:24:1445 | this access | UseUseExplosion.cs:24:1459:24:1462 | this access |
 | UseUseExplosion.cs:24:1442:24:1445 | this access | UseUseExplosion.cs:24:1933:24:1938 | this access |
 | UseUseExplosion.cs:24:1459:24:1462 | [post] this access | UseUseExplosion.cs:24:1476:24:1479 | this access |
 | UseUseExplosion.cs:24:1459:24:1462 | [post] this access | UseUseExplosion.cs:24:1918:24:1923 | this access |
 | UseUseExplosion.cs:24:1459:24:1462 | access to property Prop | UseUseExplosion.cs:24:1476:24:1479 | access to property Prop |
-| UseUseExplosion.cs:24:1459:24:1462 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1459:24:1462 | access to property Prop | UseUseExplosion.cs:24:1918:24:1923 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1459:24:1462 | this access | UseUseExplosion.cs:24:1476:24:1479 | this access |
 | UseUseExplosion.cs:24:1459:24:1462 | this access | UseUseExplosion.cs:24:1918:24:1923 | this access |
 | UseUseExplosion.cs:24:1476:24:1479 | [post] this access | UseUseExplosion.cs:24:1493:24:1496 | this access |
 | UseUseExplosion.cs:24:1476:24:1479 | [post] this access | UseUseExplosion.cs:24:1903:24:1908 | this access |
 | UseUseExplosion.cs:24:1476:24:1479 | access to property Prop | UseUseExplosion.cs:24:1493:24:1496 | access to property Prop |
-| UseUseExplosion.cs:24:1476:24:1479 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1476:24:1479 | access to property Prop | UseUseExplosion.cs:24:1903:24:1908 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1476:24:1479 | this access | UseUseExplosion.cs:24:1493:24:1496 | this access |
 | UseUseExplosion.cs:24:1476:24:1479 | this access | UseUseExplosion.cs:24:1903:24:1908 | this access |
 | UseUseExplosion.cs:24:1493:24:1496 | [post] this access | UseUseExplosion.cs:24:1510:24:1513 | this access |
 | UseUseExplosion.cs:24:1493:24:1496 | [post] this access | UseUseExplosion.cs:24:1888:24:1893 | this access |
 | UseUseExplosion.cs:24:1493:24:1496 | access to property Prop | UseUseExplosion.cs:24:1510:24:1513 | access to property Prop |
-| UseUseExplosion.cs:24:1493:24:1496 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1493:24:1496 | access to property Prop | UseUseExplosion.cs:24:1888:24:1893 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1493:24:1496 | this access | UseUseExplosion.cs:24:1510:24:1513 | this access |
 | UseUseExplosion.cs:24:1493:24:1496 | this access | UseUseExplosion.cs:24:1888:24:1893 | this access |
 | UseUseExplosion.cs:24:1510:24:1513 | [post] this access | UseUseExplosion.cs:24:1527:24:1530 | this access |
 | UseUseExplosion.cs:24:1510:24:1513 | [post] this access | UseUseExplosion.cs:24:1873:24:1878 | this access |
 | UseUseExplosion.cs:24:1510:24:1513 | access to property Prop | UseUseExplosion.cs:24:1527:24:1530 | access to property Prop |
-| UseUseExplosion.cs:24:1510:24:1513 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1510:24:1513 | access to property Prop | UseUseExplosion.cs:24:1873:24:1878 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1510:24:1513 | this access | UseUseExplosion.cs:24:1527:24:1530 | this access |
 | UseUseExplosion.cs:24:1510:24:1513 | this access | UseUseExplosion.cs:24:1873:24:1878 | this access |
 | UseUseExplosion.cs:24:1527:24:1530 | [post] this access | UseUseExplosion.cs:24:1544:24:1547 | this access |
 | UseUseExplosion.cs:24:1527:24:1530 | [post] this access | UseUseExplosion.cs:24:1858:24:1863 | this access |
 | UseUseExplosion.cs:24:1527:24:1530 | access to property Prop | UseUseExplosion.cs:24:1544:24:1547 | access to property Prop |
-| UseUseExplosion.cs:24:1527:24:1530 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1527:24:1530 | access to property Prop | UseUseExplosion.cs:24:1858:24:1863 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1527:24:1530 | this access | UseUseExplosion.cs:24:1544:24:1547 | this access |
 | UseUseExplosion.cs:24:1527:24:1530 | this access | UseUseExplosion.cs:24:1858:24:1863 | this access |
 | UseUseExplosion.cs:24:1544:24:1547 | [post] this access | UseUseExplosion.cs:24:1561:24:1564 | this access |
 | UseUseExplosion.cs:24:1544:24:1547 | [post] this access | UseUseExplosion.cs:24:1843:24:1848 | this access |
 | UseUseExplosion.cs:24:1544:24:1547 | access to property Prop | UseUseExplosion.cs:24:1561:24:1564 | access to property Prop |
-| UseUseExplosion.cs:24:1544:24:1547 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1544:24:1547 | access to property Prop | UseUseExplosion.cs:24:1843:24:1848 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1544:24:1547 | this access | UseUseExplosion.cs:24:1561:24:1564 | this access |
 | UseUseExplosion.cs:24:1544:24:1547 | this access | UseUseExplosion.cs:24:1843:24:1848 | this access |
 | UseUseExplosion.cs:24:1561:24:1564 | [post] this access | UseUseExplosion.cs:24:1577:24:1580 | this access |
 | UseUseExplosion.cs:24:1561:24:1564 | [post] this access | UseUseExplosion.cs:24:1828:24:1833 | this access |
 | UseUseExplosion.cs:24:1561:24:1564 | access to property Prop | UseUseExplosion.cs:24:1577:24:1580 | access to property Prop |
-| UseUseExplosion.cs:24:1561:24:1564 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1561:24:1564 | access to property Prop | UseUseExplosion.cs:24:1828:24:1833 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1561:24:1564 | this access | UseUseExplosion.cs:24:1577:24:1580 | this access |
 | UseUseExplosion.cs:24:1561:24:1564 | this access | UseUseExplosion.cs:24:1828:24:1833 | this access |
 | UseUseExplosion.cs:24:1577:24:1580 | [post] this access | UseUseExplosion.cs:24:1593:24:1596 | this access |
 | UseUseExplosion.cs:24:1577:24:1580 | [post] this access | UseUseExplosion.cs:24:1813:24:1818 | this access |
 | UseUseExplosion.cs:24:1577:24:1580 | access to property Prop | UseUseExplosion.cs:24:1593:24:1596 | access to property Prop |
-| UseUseExplosion.cs:24:1577:24:1580 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1577:24:1580 | access to property Prop | UseUseExplosion.cs:24:1813:24:1818 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1577:24:1580 | this access | UseUseExplosion.cs:24:1593:24:1596 | this access |
 | UseUseExplosion.cs:24:1577:24:1580 | this access | UseUseExplosion.cs:24:1813:24:1818 | this access |
 | UseUseExplosion.cs:24:1593:24:1596 | [post] this access | UseUseExplosion.cs:24:1609:24:1612 | this access |
 | UseUseExplosion.cs:24:1593:24:1596 | [post] this access | UseUseExplosion.cs:24:1798:24:1803 | this access |
 | UseUseExplosion.cs:24:1593:24:1596 | access to property Prop | UseUseExplosion.cs:24:1609:24:1612 | access to property Prop |
-| UseUseExplosion.cs:24:1593:24:1596 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1593:24:1596 | access to property Prop | UseUseExplosion.cs:24:1798:24:1803 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1593:24:1596 | this access | UseUseExplosion.cs:24:1609:24:1612 | this access |
 | UseUseExplosion.cs:24:1593:24:1596 | this access | UseUseExplosion.cs:24:1798:24:1803 | this access |
 | UseUseExplosion.cs:24:1609:24:1612 | [post] this access | UseUseExplosion.cs:24:1625:24:1628 | this access |
 | UseUseExplosion.cs:24:1609:24:1612 | [post] this access | UseUseExplosion.cs:24:1783:24:1788 | this access |
 | UseUseExplosion.cs:24:1609:24:1612 | access to property Prop | UseUseExplosion.cs:24:1625:24:1628 | access to property Prop |
-| UseUseExplosion.cs:24:1609:24:1612 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1609:24:1612 | access to property Prop | UseUseExplosion.cs:24:1783:24:1788 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1609:24:1612 | this access | UseUseExplosion.cs:24:1625:24:1628 | this access |
 | UseUseExplosion.cs:24:1609:24:1612 | this access | UseUseExplosion.cs:24:1783:24:1788 | this access |
 | UseUseExplosion.cs:24:1625:24:1628 | [post] this access | UseUseExplosion.cs:24:1641:24:1644 | this access |
 | UseUseExplosion.cs:24:1625:24:1628 | [post] this access | UseUseExplosion.cs:24:1768:24:1773 | this access |
 | UseUseExplosion.cs:24:1625:24:1628 | access to property Prop | UseUseExplosion.cs:24:1641:24:1644 | access to property Prop |
-| UseUseExplosion.cs:24:1625:24:1628 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1625:24:1628 | access to property Prop | UseUseExplosion.cs:24:1768:24:1773 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1625:24:1628 | this access | UseUseExplosion.cs:24:1641:24:1644 | this access |
 | UseUseExplosion.cs:24:1625:24:1628 | this access | UseUseExplosion.cs:24:1768:24:1773 | this access |
 | UseUseExplosion.cs:24:1641:24:1644 | [post] this access | UseUseExplosion.cs:24:1657:24:1660 | this access |
 | UseUseExplosion.cs:24:1641:24:1644 | [post] this access | UseUseExplosion.cs:24:1753:24:1758 | this access |
 | UseUseExplosion.cs:24:1641:24:1644 | access to property Prop | UseUseExplosion.cs:24:1657:24:1660 | access to property Prop |
-| UseUseExplosion.cs:24:1641:24:1644 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1641:24:1644 | access to property Prop | UseUseExplosion.cs:24:1753:24:1758 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1641:24:1644 | this access | UseUseExplosion.cs:24:1657:24:1660 | this access |
 | UseUseExplosion.cs:24:1641:24:1644 | this access | UseUseExplosion.cs:24:1753:24:1758 | this access |
 | UseUseExplosion.cs:24:1657:24:1660 | [post] this access | UseUseExplosion.cs:24:1673:24:1676 | this access |
 | UseUseExplosion.cs:24:1657:24:1660 | [post] this access | UseUseExplosion.cs:24:1738:24:1743 | this access |
 | UseUseExplosion.cs:24:1657:24:1660 | access to property Prop | UseUseExplosion.cs:24:1673:24:1676 | access to property Prop |
-| UseUseExplosion.cs:24:1657:24:1660 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1657:24:1660 | access to property Prop | UseUseExplosion.cs:24:1738:24:1743 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1657:24:1660 | this access | UseUseExplosion.cs:24:1673:24:1676 | this access |
 | UseUseExplosion.cs:24:1657:24:1660 | this access | UseUseExplosion.cs:24:1738:24:1743 | this access |
 | UseUseExplosion.cs:24:1673:24:1676 | [post] this access | UseUseExplosion.cs:24:1689:24:1692 | this access |
 | UseUseExplosion.cs:24:1673:24:1676 | [post] this access | UseUseExplosion.cs:24:1723:24:1728 | this access |
 | UseUseExplosion.cs:24:1673:24:1676 | access to property Prop | UseUseExplosion.cs:24:1689:24:1692 | access to property Prop |
-| UseUseExplosion.cs:24:1673:24:1676 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1673:24:1676 | access to property Prop | UseUseExplosion.cs:24:1723:24:1728 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1673:24:1676 | this access | UseUseExplosion.cs:24:1689:24:1692 | this access |
 | UseUseExplosion.cs:24:1673:24:1676 | this access | UseUseExplosion.cs:24:1723:24:1728 | this access |
 | UseUseExplosion.cs:24:1689:24:1692 | [post] this access | UseUseExplosion.cs:24:1708:24:1713 | this access |
 | UseUseExplosion.cs:24:1689:24:1692 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1689:24:1692 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1689:24:1692 | access to property Prop | UseUseExplosion.cs:24:1699:24:1701 | [input] SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1689:24:1692 | access to property Prop | UseUseExplosion.cs:24:1708:24:1713 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1689:24:1692 | this access | UseUseExplosion.cs:24:1708:24:1713 | this access |
 | UseUseExplosion.cs:24:1689:24:1692 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
+| UseUseExplosion.cs:24:1699:24:1701 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1699:24:1701 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1708:24:1713 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1708:24:1713 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1708:24:1713 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1708:24:1713 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1712:24:1712 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1712:24:1712 | access to local variable x | UseUseExplosion.cs:24:1708:24:1713 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1723:24:1728 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1723:24:1728 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1723:24:1728 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1723:24:1728 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1727:24:1727 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1727:24:1727 | access to local variable x | UseUseExplosion.cs:24:1723:24:1728 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1738:24:1743 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1738:24:1743 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1738:24:1743 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1738:24:1743 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1742:24:1742 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1742:24:1742 | access to local variable x | UseUseExplosion.cs:24:1738:24:1743 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1753:24:1758 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1753:24:1758 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1753:24:1758 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1753:24:1758 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1757:24:1757 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1757:24:1757 | access to local variable x | UseUseExplosion.cs:24:1753:24:1758 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1768:24:1773 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1768:24:1773 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1768:24:1773 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1768:24:1773 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1772:24:1772 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1772:24:1772 | access to local variable x | UseUseExplosion.cs:24:1768:24:1773 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1783:24:1788 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1783:24:1788 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1783:24:1788 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1783:24:1788 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1787:24:1787 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1787:24:1787 | access to local variable x | UseUseExplosion.cs:24:1783:24:1788 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1798:24:1803 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1798:24:1803 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1798:24:1803 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1798:24:1803 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1802:24:1802 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1802:24:1802 | access to local variable x | UseUseExplosion.cs:24:1798:24:1803 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1813:24:1818 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1813:24:1818 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1813:24:1818 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1813:24:1818 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1817:24:1817 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1817:24:1817 | access to local variable x | UseUseExplosion.cs:24:1813:24:1818 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1828:24:1833 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1828:24:1833 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1828:24:1833 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1828:24:1833 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1832:24:1832 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1832:24:1832 | access to local variable x | UseUseExplosion.cs:24:1828:24:1833 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1843:24:1848 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1843:24:1848 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1843:24:1848 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1843:24:1848 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1847:24:1847 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1847:24:1847 | access to local variable x | UseUseExplosion.cs:24:1843:24:1848 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1858:24:1863 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1858:24:1863 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1858:24:1863 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1858:24:1863 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1862:24:1862 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1862:24:1862 | access to local variable x | UseUseExplosion.cs:24:1858:24:1863 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1873:24:1878 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1873:24:1878 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1873:24:1878 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1873:24:1878 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1877:24:1877 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1877:24:1877 | access to local variable x | UseUseExplosion.cs:24:1873:24:1878 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1888:24:1893 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1888:24:1893 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1888:24:1893 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1888:24:1893 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1892:24:1892 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1892:24:1892 | access to local variable x | UseUseExplosion.cs:24:1888:24:1893 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1903:24:1908 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1903:24:1908 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1903:24:1908 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1903:24:1908 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1907:24:1907 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1907:24:1907 | access to local variable x | UseUseExplosion.cs:24:1903:24:1908 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1918:24:1923 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1918:24:1923 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1918:24:1923 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1918:24:1923 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1922:24:1922 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1922:24:1922 | access to local variable x | UseUseExplosion.cs:24:1918:24:1923 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1933:24:1938 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1933:24:1938 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1933:24:1938 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1933:24:1938 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1937:24:1937 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1937:24:1937 | access to local variable x | UseUseExplosion.cs:24:1933:24:1938 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1948:24:1953 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1948:24:1953 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1948:24:1953 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1948:24:1953 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1952:24:1952 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1952:24:1952 | access to local variable x | UseUseExplosion.cs:24:1948:24:1953 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1963:24:1968 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1963:24:1968 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1963:24:1968 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1963:24:1968 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1967:24:1967 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1967:24:1967 | access to local variable x | UseUseExplosion.cs:24:1963:24:1968 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1978:24:1983 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1978:24:1983 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1978:24:1983 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1978:24:1983 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1982:24:1982 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1982:24:1982 | access to local variable x | UseUseExplosion.cs:24:1978:24:1983 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1993:24:1998 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1993:24:1998 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1993:24:1998 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1993:24:1998 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1997:24:1997 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1997:24:1997 | access to local variable x | UseUseExplosion.cs:24:1993:24:1998 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2008:24:2013 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2008:24:2013 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2008:24:2013 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2008:24:2013 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2012:24:2012 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2012:24:2012 | access to local variable x | UseUseExplosion.cs:24:2008:24:2013 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2023:24:2028 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2023:24:2028 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2023:24:2028 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2023:24:2028 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2027:24:2027 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2027:24:2027 | access to local variable x | UseUseExplosion.cs:24:2023:24:2028 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2038:24:2043 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2038:24:2043 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2038:24:2043 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2038:24:2043 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2042:24:2042 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2042:24:2042 | access to local variable x | UseUseExplosion.cs:24:2038:24:2043 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2053:24:2058 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2053:24:2058 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2053:24:2058 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2053:24:2058 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2057:24:2057 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2057:24:2057 | access to local variable x | UseUseExplosion.cs:24:2053:24:2058 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2068:24:2073 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2068:24:2073 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2068:24:2073 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2068:24:2073 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2072:24:2072 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2072:24:2072 | access to local variable x | UseUseExplosion.cs:24:2068:24:2073 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2083:24:2088 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2083:24:2088 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2083:24:2088 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2083:24:2088 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2087:24:2087 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2087:24:2087 | access to local variable x | UseUseExplosion.cs:24:2083:24:2088 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2098:24:2103 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2098:24:2103 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2098:24:2103 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2098:24:2103 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2102:24:2102 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2102:24:2102 | access to local variable x | UseUseExplosion.cs:24:2098:24:2103 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2113:24:2118 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2113:24:2118 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2113:24:2118 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2113:24:2118 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2117:24:2117 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2117:24:2117 | access to local variable x | UseUseExplosion.cs:24:2113:24:2118 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2128:24:2133 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2128:24:2133 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2128:24:2133 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2128:24:2133 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2132:24:2132 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2132:24:2132 | access to local variable x | UseUseExplosion.cs:24:2128:24:2133 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2143:24:2148 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2143:24:2148 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2143:24:2148 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2143:24:2148 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2147:24:2147 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2147:24:2147 | access to local variable x | UseUseExplosion.cs:24:2143:24:2148 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2158:24:2163 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2158:24:2163 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2158:24:2163 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2158:24:2163 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2162:24:2162 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2162:24:2162 | access to local variable x | UseUseExplosion.cs:24:2158:24:2163 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2173:24:2178 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2173:24:2178 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2173:24:2178 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2173:24:2178 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2177:24:2177 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2177:24:2177 | access to local variable x | UseUseExplosion.cs:24:2173:24:2178 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2188:24:2193 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2188:24:2193 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2188:24:2193 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2188:24:2193 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2192:24:2192 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2192:24:2192 | access to local variable x | UseUseExplosion.cs:24:2188:24:2193 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2203:24:2208 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2203:24:2208 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2203:24:2208 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2203:24:2208 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2207:24:2207 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2207:24:2207 | access to local variable x | UseUseExplosion.cs:24:2203:24:2208 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2218:24:2223 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2218:24:2223 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2218:24:2223 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2218:24:2223 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2222:24:2222 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2222:24:2222 | access to local variable x | UseUseExplosion.cs:24:2218:24:2223 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2233:24:2238 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2233:24:2238 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2233:24:2238 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2233:24:2238 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2237:24:2237 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2237:24:2237 | access to local variable x | UseUseExplosion.cs:24:2233:24:2238 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2248:24:2253 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2248:24:2253 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2248:24:2253 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2248:24:2253 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2252:24:2252 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2252:24:2252 | access to local variable x | UseUseExplosion.cs:24:2248:24:2253 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2263:24:2268 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2263:24:2268 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2263:24:2268 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2263:24:2268 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2267:24:2267 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2267:24:2267 | access to local variable x | UseUseExplosion.cs:24:2263:24:2268 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2278:24:2283 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2278:24:2283 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2278:24:2283 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2278:24:2283 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2282:24:2282 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2282:24:2282 | access to local variable x | UseUseExplosion.cs:24:2278:24:2283 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2293:24:2298 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2293:24:2298 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2293:24:2298 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2293:24:2298 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2297:24:2297 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2297:24:2297 | access to local variable x | UseUseExplosion.cs:24:2293:24:2298 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2308:24:2313 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2308:24:2313 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2308:24:2313 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2308:24:2313 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2312:24:2312 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2312:24:2312 | access to local variable x | UseUseExplosion.cs:24:2308:24:2313 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2323:24:2328 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2323:24:2328 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2323:24:2328 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2323:24:2328 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2327:24:2327 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2327:24:2327 | access to local variable x | UseUseExplosion.cs:24:2323:24:2328 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2338:24:2343 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2338:24:2343 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2338:24:2343 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2338:24:2343 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2342:24:2342 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2342:24:2342 | access to local variable x | UseUseExplosion.cs:24:2338:24:2343 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2353:24:2358 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2353:24:2358 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2353:24:2358 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2353:24:2358 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2357:24:2357 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2357:24:2357 | access to local variable x | UseUseExplosion.cs:24:2353:24:2358 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2368:24:2373 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2368:24:2373 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2368:24:2373 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2368:24:2373 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2372:24:2372 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2372:24:2372 | access to local variable x | UseUseExplosion.cs:24:2368:24:2373 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2383:24:2388 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2383:24:2388 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2383:24:2388 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2383:24:2388 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2387:24:2387 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2387:24:2387 | access to local variable x | UseUseExplosion.cs:24:2383:24:2388 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2398:24:2403 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2398:24:2403 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2398:24:2403 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2398:24:2403 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2402:24:2402 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2402:24:2402 | access to local variable x | UseUseExplosion.cs:24:2398:24:2403 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2413:24:2418 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2413:24:2418 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2413:24:2418 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2413:24:2418 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2417:24:2417 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2417:24:2417 | access to local variable x | UseUseExplosion.cs:24:2413:24:2418 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2428:24:2433 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2428:24:2433 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2428:24:2433 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2428:24:2433 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2432:24:2432 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2432:24:2432 | access to local variable x | UseUseExplosion.cs:24:2428:24:2433 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2443:24:2448 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2443:24:2448 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2443:24:2448 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2443:24:2448 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2447:24:2447 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2447:24:2447 | access to local variable x | UseUseExplosion.cs:24:2443:24:2448 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2458:24:2463 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2458:24:2463 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2458:24:2463 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2458:24:2463 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2462:24:2462 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2462:24:2462 | access to local variable x | UseUseExplosion.cs:24:2458:24:2463 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2473:24:2478 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2473:24:2478 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2473:24:2478 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2473:24:2478 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2477:24:2477 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2477:24:2477 | access to local variable x | UseUseExplosion.cs:24:2473:24:2478 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2488:24:2493 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2488:24:2493 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2488:24:2493 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2488:24:2493 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2492:24:2492 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2492:24:2492 | access to local variable x | UseUseExplosion.cs:24:2488:24:2493 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2503:24:2508 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2503:24:2508 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2503:24:2508 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2503:24:2508 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2507:24:2507 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2507:24:2507 | access to local variable x | UseUseExplosion.cs:24:2503:24:2508 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2518:24:2523 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2518:24:2523 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2518:24:2523 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2518:24:2523 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2522:24:2522 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2522:24:2522 | access to local variable x | UseUseExplosion.cs:24:2518:24:2523 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2533:24:2538 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2533:24:2538 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2533:24:2538 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2533:24:2538 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2537:24:2537 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2537:24:2537 | access to local variable x | UseUseExplosion.cs:24:2533:24:2538 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2548:24:2553 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2548:24:2553 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2548:24:2553 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2548:24:2553 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2552:24:2552 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2552:24:2552 | access to local variable x | UseUseExplosion.cs:24:2548:24:2553 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2563:24:2568 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2563:24:2568 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2563:24:2568 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2563:24:2568 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2567:24:2567 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2567:24:2567 | access to local variable x | UseUseExplosion.cs:24:2563:24:2568 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2578:24:2583 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2578:24:2583 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2578:24:2583 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2578:24:2583 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2582:24:2582 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2582:24:2582 | access to local variable x | UseUseExplosion.cs:24:2578:24:2583 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2593:24:2598 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2593:24:2598 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2593:24:2598 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2593:24:2598 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2597:24:2597 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2597:24:2597 | access to local variable x | UseUseExplosion.cs:24:2593:24:2598 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2608:24:2613 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2608:24:2613 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2608:24:2613 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2608:24:2613 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2612:24:2612 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2612:24:2612 | access to local variable x | UseUseExplosion.cs:24:2608:24:2613 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2623:24:2628 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2623:24:2628 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2623:24:2628 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2623:24:2628 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2627:24:2627 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2627:24:2627 | access to local variable x | UseUseExplosion.cs:24:2623:24:2628 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2638:24:2643 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2638:24:2643 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2638:24:2643 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2638:24:2643 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2642:24:2642 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2642:24:2642 | access to local variable x | UseUseExplosion.cs:24:2638:24:2643 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2653:24:2658 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2653:24:2658 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2653:24:2658 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2653:24:2658 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2657:24:2657 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2657:24:2657 | access to local variable x | UseUseExplosion.cs:24:2653:24:2658 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2668:24:2673 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2668:24:2673 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2668:24:2673 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2668:24:2673 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2672:24:2672 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2672:24:2672 | access to local variable x | UseUseExplosion.cs:24:2668:24:2673 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2683:24:2688 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2683:24:2688 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2683:24:2688 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2683:24:2688 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2687:24:2687 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2687:24:2687 | access to local variable x | UseUseExplosion.cs:24:2683:24:2688 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2698:24:2703 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2698:24:2703 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2698:24:2703 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2698:24:2703 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2702:24:2702 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2702:24:2702 | access to local variable x | UseUseExplosion.cs:24:2698:24:2703 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2713:24:2718 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2713:24:2718 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2713:24:2718 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2713:24:2718 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2717:24:2717 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2717:24:2717 | access to local variable x | UseUseExplosion.cs:24:2713:24:2718 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2728:24:2733 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2728:24:2733 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2728:24:2733 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2728:24:2733 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2732:24:2732 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2732:24:2732 | access to local variable x | UseUseExplosion.cs:24:2728:24:2733 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2743:24:2748 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2743:24:2748 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2743:24:2748 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2743:24:2748 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2747:24:2747 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2747:24:2747 | access to local variable x | UseUseExplosion.cs:24:2743:24:2748 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2758:24:2763 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2758:24:2763 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2758:24:2763 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2758:24:2763 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2762:24:2762 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2762:24:2762 | access to local variable x | UseUseExplosion.cs:24:2758:24:2763 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2773:24:2778 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2773:24:2778 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2773:24:2778 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2773:24:2778 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2777:24:2777 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2777:24:2777 | access to local variable x | UseUseExplosion.cs:24:2773:24:2778 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2788:24:2793 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2788:24:2793 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2788:24:2793 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2788:24:2793 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2792:24:2792 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2792:24:2792 | access to local variable x | UseUseExplosion.cs:24:2788:24:2793 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2803:24:2808 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2803:24:2808 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2803:24:2808 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2803:24:2808 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2807:24:2807 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2807:24:2807 | access to local variable x | UseUseExplosion.cs:24:2803:24:2808 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2818:24:2823 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2818:24:2823 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2818:24:2823 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2818:24:2823 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2822:24:2822 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2822:24:2822 | access to local variable x | UseUseExplosion.cs:24:2818:24:2823 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2833:24:2838 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2833:24:2838 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2833:24:2838 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2833:24:2838 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2837:24:2837 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2837:24:2837 | access to local variable x | UseUseExplosion.cs:24:2833:24:2838 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2848:24:2853 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2848:24:2853 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2848:24:2853 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2848:24:2853 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2852:24:2852 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2852:24:2852 | access to local variable x | UseUseExplosion.cs:24:2848:24:2853 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2863:24:2868 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2863:24:2868 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2863:24:2868 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2863:24:2868 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2867:24:2867 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2867:24:2867 | access to local variable x | UseUseExplosion.cs:24:2863:24:2868 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2878:24:2883 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2878:24:2883 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2878:24:2883 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2878:24:2883 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2882:24:2882 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2882:24:2882 | access to local variable x | UseUseExplosion.cs:24:2878:24:2883 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2893:24:2898 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2893:24:2898 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2893:24:2898 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2893:24:2898 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2897:24:2897 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2897:24:2897 | access to local variable x | UseUseExplosion.cs:24:2893:24:2898 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2908:24:2913 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2908:24:2913 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2908:24:2913 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2908:24:2913 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2912:24:2912 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2912:24:2912 | access to local variable x | UseUseExplosion.cs:24:2908:24:2913 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2923:24:2928 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2923:24:2928 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2923:24:2928 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2923:24:2928 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2927:24:2927 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2927:24:2927 | access to local variable x | UseUseExplosion.cs:24:2923:24:2928 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2938:24:2943 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2938:24:2943 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2938:24:2943 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2938:24:2943 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2942:24:2942 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2942:24:2942 | access to local variable x | UseUseExplosion.cs:24:2938:24:2943 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2953:24:2958 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2953:24:2958 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2953:24:2958 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2953:24:2958 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2957:24:2957 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2957:24:2957 | access to local variable x | UseUseExplosion.cs:24:2953:24:2958 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2968:24:2973 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2968:24:2973 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2968:24:2973 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2968:24:2973 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2972:24:2972 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2972:24:2972 | access to local variable x | UseUseExplosion.cs:24:2968:24:2973 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2983:24:2988 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2983:24:2988 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2983:24:2988 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2983:24:2988 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2987:24:2987 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2987:24:2987 | access to local variable x | UseUseExplosion.cs:24:2983:24:2988 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2998:24:3003 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2998:24:3003 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2998:24:3003 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2998:24:3003 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:3002:24:3002 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:3002:24:3002 | access to local variable x | UseUseExplosion.cs:24:2998:24:3003 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:3013:24:3018 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:3013:24:3018 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:3013:24:3018 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:3013:24:3018 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:3017:24:3017 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:3017:24:3017 | access to local variable x | UseUseExplosion.cs:24:3013:24:3018 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:3028:24:3033 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:3028:24:3033 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:3028:24:3033 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:3028:24:3033 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:3032:24:3032 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:3032:24:3032 | access to local variable x | UseUseExplosion.cs:24:3028:24:3033 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:3043:24:3048 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:3043:24:3048 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:3043:24:3048 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:3043:24:3048 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:3047:24:3047 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:3047:24:3047 | access to local variable x | UseUseExplosion.cs:24:3043:24:3048 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:3058:24:3063 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:3058:24:3063 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:3058:24:3063 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:3058:24:3063 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:3062:24:3062 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:3062:24:3062 | access to local variable x | UseUseExplosion.cs:24:3058:24:3063 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:3073:24:3078 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:3073:24:3078 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:3073:24:3078 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:3073:24:3078 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:3077:24:3077 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:3077:24:3077 | access to local variable x | UseUseExplosion.cs:24:3073:24:3078 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:3088:24:3093 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:3088:24:3093 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:3088:24:3093 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:3088:24:3093 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:3092:24:3092 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:3092:24:3092 | access to local variable x | UseUseExplosion.cs:24:3088:24:3093 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:3103:24:3108 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:3103:24:3108 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:3103:24:3108 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:3103:24:3108 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:3107:24:3107 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:3107:24:3107 | access to local variable x | UseUseExplosion.cs:24:3103:24:3108 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:3118:24:3123 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:3118:24:3123 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:3118:24:3123 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:3118:24:3123 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:3122:24:3122 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:3122:24:3122 | access to local variable x | UseUseExplosion.cs:24:3118:24:3123 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:3133:24:3138 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:3133:24:3138 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:3133:24:3138 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:3133:24:3138 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:3137:24:3137 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:3137:24:3137 | access to local variable x | UseUseExplosion.cs:24:3133:24:3138 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:3148:24:3153 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:3148:24:3153 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:3148:24:3153 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:3148:24:3153 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:3152:24:3152 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:3152:24:3152 | access to local variable x | UseUseExplosion.cs:24:3148:24:3153 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:3163:24:3168 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:3163:24:3168 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:3163:24:3168 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:3163:24:3168 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:3167:24:3167 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:3167:24:3167 | access to local variable x | UseUseExplosion.cs:24:3163:24:3168 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:3178:24:3183 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:3178:24:3183 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:3178:24:3183 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:3178:24:3183 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:3182:24:3182 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:3182:24:3182 | access to local variable x | UseUseExplosion.cs:24:3178:24:3183 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:3193:24:3198 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:3193:24:3198 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:3193:24:3198 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:3193:24:3198 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:3197:24:3197 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:3197:24:3197 | access to local variable x | UseUseExplosion.cs:24:3193:24:3198 | [input] SSA phi read(x) |
 | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) | UseUseExplosion.cs:25:13:25:16 | access to property Prop |
 | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) | UseUseExplosion.cs:25:1712:25:1712 | access to local variable x |
 | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) | UseUseExplosion.cs:25:1727:25:1727 | access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/local/TaintTrackingStep.expected
+++ b/csharp/ql/test/library-tests/dataflow/local/TaintTrackingStep.expected
@@ -10,7 +10,8 @@
 | Capture.cs:51:9:51:15 | this access | Capture.cs:63:9:63:15 | this access |
 | Capture.cs:58:21:58:21 | 1 | Capture.cs:58:17:58:17 | access to local variable i |
 | Capture.cs:61:17:61:17 | 1 | Capture.cs:61:13:61:13 | access to local variable i |
-| LocalDataFlow.cs:48:24:48:24 | b | LocalDataFlow.cs:84:21:84:21 | access to parameter b |
+| LocalDataFlow.cs:48:24:48:24 | SSA param(b) | LocalDataFlow.cs:84:21:84:21 | access to parameter b |
+| LocalDataFlow.cs:48:24:48:24 | b | LocalDataFlow.cs:48:24:48:24 | SSA param(b) |
 | LocalDataFlow.cs:51:13:51:17 | access to local variable sink0 | LocalDataFlow.cs:51:13:51:34 | SSA def(sink0) |
 | LocalDataFlow.cs:51:13:51:34 | SSA def(sink0) | LocalDataFlow.cs:52:15:52:19 | access to local variable sink0 |
 | LocalDataFlow.cs:51:21:51:34 | "taint source" | LocalDataFlow.cs:51:13:51:17 | access to local variable sink0 |
@@ -72,16 +73,18 @@
 | LocalDataFlow.cs:84:21:84:35 | [b (line 48): true] ... ? ... : ... | LocalDataFlow.cs:84:13:84:17 | access to local variable sink7 |
 | LocalDataFlow.cs:84:25:84:27 | [b (line 48): true] "a" | LocalDataFlow.cs:84:21:84:35 | [b (line 48): true] ... ? ... : ... |
 | LocalDataFlow.cs:84:31:84:35 | [b (line 48): false] access to local variable sink6 | LocalDataFlow.cs:84:21:84:35 | [b (line 48): false] ... ? ... : ... |
-| LocalDataFlow.cs:85:15:85:19 | [b (line 48): false] access to local variable sink7 | LocalDataFlow.cs:88:20:88:36 | SSA phi(sink7) |
-| LocalDataFlow.cs:85:15:85:19 | [b (line 48): true] access to local variable sink7 | LocalDataFlow.cs:88:20:88:36 | SSA phi(sink7) |
-| LocalDataFlow.cs:85:15:85:19 | [post] [b (line 48): false] access to local variable sink7 | LocalDataFlow.cs:88:20:88:36 | SSA phi(sink7) |
-| LocalDataFlow.cs:85:15:85:19 | [post] [b (line 48): true] access to local variable sink7 | LocalDataFlow.cs:88:20:88:36 | SSA phi(sink7) |
+| LocalDataFlow.cs:85:15:85:19 | [b (line 48): false] access to local variable sink7 | LocalDataFlow.cs:88:32:88:36 | [input] SSA phi(sink7) |
+| LocalDataFlow.cs:85:15:85:19 | [b (line 48): true] access to local variable sink7 | LocalDataFlow.cs:88:24:88:28 | [input] SSA phi(sink7) |
+| LocalDataFlow.cs:85:15:85:19 | [post] [b (line 48): false] access to local variable sink7 | LocalDataFlow.cs:88:32:88:36 | [input] SSA phi(sink7) |
+| LocalDataFlow.cs:85:15:85:19 | [post] [b (line 48): true] access to local variable sink7 | LocalDataFlow.cs:88:24:88:28 | [input] SSA phi(sink7) |
 | LocalDataFlow.cs:88:9:88:16 | access to local variable nonSink0 | LocalDataFlow.cs:88:9:88:36 | SSA def(nonSink0) |
 | LocalDataFlow.cs:88:9:88:36 | SSA def(nonSink0) | LocalDataFlow.cs:89:15:89:22 | access to local variable nonSink0 |
 | LocalDataFlow.cs:88:20:88:36 | ... ? ... : ... | LocalDataFlow.cs:88:9:88:16 | access to local variable nonSink0 |
 | LocalDataFlow.cs:88:20:88:36 | SSA phi(sink7) | LocalDataFlow.cs:92:29:92:33 | access to local variable sink7 |
 | LocalDataFlow.cs:88:24:88:28 | "abc" | LocalDataFlow.cs:88:20:88:36 | ... ? ... : ... |
+| LocalDataFlow.cs:88:24:88:28 | [input] SSA phi(sink7) | LocalDataFlow.cs:88:20:88:36 | SSA phi(sink7) |
 | LocalDataFlow.cs:88:32:88:36 | "def" | LocalDataFlow.cs:88:20:88:36 | ... ? ... : ... |
+| LocalDataFlow.cs:88:32:88:36 | [input] SSA phi(sink7) | LocalDataFlow.cs:88:20:88:36 | SSA phi(sink7) |
 | LocalDataFlow.cs:89:15:89:22 | [post] access to local variable nonSink0 | LocalDataFlow.cs:96:32:96:39 | access to local variable nonSink0 |
 | LocalDataFlow.cs:89:15:89:22 | access to local variable nonSink0 | LocalDataFlow.cs:96:32:96:39 | access to local variable nonSink0 |
 | LocalDataFlow.cs:92:13:92:17 | access to local variable sink8 | LocalDataFlow.cs:92:13:92:33 | SSA def(sink8) |
@@ -556,7 +559,7 @@
 | LocalDataFlow.cs:281:13:281:34 | SSA def(sink70) | LocalDataFlow.cs:282:15:282:20 | access to local variable sink70 |
 | LocalDataFlow.cs:281:22:281:26 | access to local variable sink0 | LocalDataFlow.cs:281:22:281:34 | SSA def(sink0) |
 | LocalDataFlow.cs:281:22:281:34 | ... = ... | LocalDataFlow.cs:281:13:281:18 | access to local variable sink70 |
-| LocalDataFlow.cs:281:22:281:34 | SSA def(sink0) | LocalDataFlow.cs:313:22:313:38 | SSA phi read(sink0) |
+| LocalDataFlow.cs:281:22:281:34 | SSA def(sink0) | LocalDataFlow.cs:313:22:313:29 | [input] SSA phi read(sink0) |
 | LocalDataFlow.cs:281:22:281:34 | SSA def(sink0) | LocalDataFlow.cs:313:34:313:38 | access to local variable sink0 |
 | LocalDataFlow.cs:281:30:281:34 | access to local variable sink0 | LocalDataFlow.cs:281:22:281:26 | access to local variable sink0 |
 | LocalDataFlow.cs:281:30:281:34 | access to local variable sink0 | LocalDataFlow.cs:281:22:281:34 | ... = ... |
@@ -586,12 +589,14 @@
 | LocalDataFlow.cs:307:18:307:33 | String nonSink17 | LocalDataFlow.cs:307:18:307:33 | SSA def(nonSink17) |
 | LocalDataFlow.cs:313:13:313:18 | access to local variable sink73 | LocalDataFlow.cs:313:13:313:38 | SSA def(sink73) |
 | LocalDataFlow.cs:313:13:313:38 | SSA def(sink73) | LocalDataFlow.cs:315:15:315:20 | access to local variable sink73 |
+| LocalDataFlow.cs:313:22:313:29 | [input] SSA phi read(sink0) | LocalDataFlow.cs:313:22:313:38 | SSA phi read(sink0) |
 | LocalDataFlow.cs:313:22:313:29 | access to local variable nonSink0 | LocalDataFlow.cs:313:22:313:38 | ... ?? ... |
 | LocalDataFlow.cs:313:22:313:29 | access to local variable nonSink0 | LocalDataFlow.cs:314:31:314:38 | access to local variable nonSink0 |
 | LocalDataFlow.cs:313:22:313:38 | ... ?? ... | LocalDataFlow.cs:313:13:313:18 | access to local variable sink73 |
 | LocalDataFlow.cs:313:22:313:38 | SSA phi read(sink0) | LocalDataFlow.cs:314:22:314:26 | access to local variable sink0 |
+| LocalDataFlow.cs:313:34:313:38 | [input] SSA phi read(sink0) | LocalDataFlow.cs:313:22:313:38 | SSA phi read(sink0) |
 | LocalDataFlow.cs:313:34:313:38 | access to local variable sink0 | LocalDataFlow.cs:313:22:313:38 | ... ?? ... |
-| LocalDataFlow.cs:313:34:313:38 | access to local variable sink0 | LocalDataFlow.cs:313:22:313:38 | SSA phi read(sink0) |
+| LocalDataFlow.cs:313:34:313:38 | access to local variable sink0 | LocalDataFlow.cs:313:34:313:38 | [input] SSA phi read(sink0) |
 | LocalDataFlow.cs:314:13:314:18 | access to local variable sink74 | LocalDataFlow.cs:314:13:314:38 | SSA def(sink74) |
 | LocalDataFlow.cs:314:13:314:38 | SSA def(sink74) | LocalDataFlow.cs:316:15:316:20 | access to local variable sink74 |
 | LocalDataFlow.cs:314:22:314:26 | access to local variable sink0 | LocalDataFlow.cs:314:22:314:38 | ... ?? ... |
@@ -599,38 +604,52 @@
 | LocalDataFlow.cs:314:31:314:38 | access to local variable nonSink0 | LocalDataFlow.cs:314:22:314:38 | ... ?? ... |
 | LocalDataFlow.cs:334:28:334:30 | SSA entry def(this.anInt) | LocalDataFlow.cs:334:41:334:45 | access to field anInt |
 | LocalDataFlow.cs:334:28:334:30 | this | LocalDataFlow.cs:334:41:334:45 | this access |
+| LocalDataFlow.cs:334:50:334:52 | SSA param(value) | LocalDataFlow.cs:334:64:334:68 | access to parameter value |
 | LocalDataFlow.cs:334:50:334:52 | this | LocalDataFlow.cs:334:56:334:60 | this access |
-| LocalDataFlow.cs:334:50:334:52 | value | LocalDataFlow.cs:334:64:334:68 | access to parameter value |
+| LocalDataFlow.cs:334:50:334:52 | value | LocalDataFlow.cs:334:50:334:52 | SSA param(value) |
 | LocalDataFlow.cs:334:64:334:68 | access to parameter value | LocalDataFlow.cs:334:56:334:60 | access to field anInt |
-| LocalDataFlow.cs:340:41:340:47 | tainted | LocalDataFlow.cs:342:15:342:21 | access to parameter tainted |
-| LocalDataFlow.cs:345:44:345:53 | nonTainted | LocalDataFlow.cs:347:15:347:24 | access to parameter nonTainted |
-| LocalDataFlow.cs:350:44:350:44 | x | LocalDataFlow.cs:353:21:353:21 | access to parameter x |
-| LocalDataFlow.cs:350:67:350:68 | os | LocalDataFlow.cs:356:33:356:34 | access to parameter os |
+| LocalDataFlow.cs:340:41:340:47 | SSA param(tainted) | LocalDataFlow.cs:342:15:342:21 | access to parameter tainted |
+| LocalDataFlow.cs:340:41:340:47 | tainted | LocalDataFlow.cs:340:41:340:47 | SSA param(tainted) |
+| LocalDataFlow.cs:345:44:345:53 | SSA param(nonTainted) | LocalDataFlow.cs:347:15:347:24 | access to parameter nonTainted |
+| LocalDataFlow.cs:345:44:345:53 | nonTainted | LocalDataFlow.cs:345:44:345:53 | SSA param(nonTainted) |
+| LocalDataFlow.cs:350:44:350:44 | SSA param(x) | LocalDataFlow.cs:353:21:353:21 | access to parameter x |
+| LocalDataFlow.cs:350:44:350:44 | x | LocalDataFlow.cs:350:44:350:44 | SSA param(x) |
+| LocalDataFlow.cs:350:67:350:68 | SSA param(os) | LocalDataFlow.cs:356:33:356:34 | access to parameter os |
+| LocalDataFlow.cs:350:67:350:68 | os | LocalDataFlow.cs:350:67:350:68 | SSA param(os) |
 | LocalDataFlow.cs:353:21:353:21 | access to parameter x | LocalDataFlow.cs:353:16:353:17 | access to local variable x1 |
 | LocalDataFlow.cs:353:21:353:21 | access to parameter x | LocalDataFlow.cs:353:16:353:21 | ... = ... |
 | LocalDataFlow.cs:356:33:356:34 | access to parameter os | LocalDataFlow.cs:356:27:356:29 | access to local variable os2 |
 | LocalDataFlow.cs:356:33:356:34 | access to parameter os | LocalDataFlow.cs:356:27:356:34 | ... = ... |
-| LocalDataFlow.cs:361:41:361:44 | args | LocalDataFlow.cs:363:29:363:32 | access to parameter args |
+| LocalDataFlow.cs:361:41:361:44 | SSA param(args) | LocalDataFlow.cs:363:29:363:32 | access to parameter args |
+| LocalDataFlow.cs:361:41:361:44 | args | LocalDataFlow.cs:361:41:361:44 | SSA param(args) |
 | LocalDataFlow.cs:363:29:363:32 | [post] access to parameter args | LocalDataFlow.cs:364:27:364:30 | access to parameter args |
 | LocalDataFlow.cs:363:29:363:32 | access to parameter args | LocalDataFlow.cs:363:29:363:32 | call to operator implicit conversion |
 | LocalDataFlow.cs:363:29:363:32 | access to parameter args | LocalDataFlow.cs:364:27:364:30 | access to parameter args |
 | LocalDataFlow.cs:363:29:363:32 | call to operator implicit conversion | LocalDataFlow.cs:363:22:363:25 | access to local variable span |
 | LocalDataFlow.cs:364:27:364:30 | call to operator implicit conversion | LocalDataFlow.cs:364:23:364:23 | access to local variable x |
-| LocalDataFlow.cs:367:23:367:24 | b1 | LocalDataFlow.cs:371:13:371:14 | access to parameter b1 |
-| LocalDataFlow.cs:367:32:367:33 | b2 | LocalDataFlow.cs:374:17:374:18 | access to parameter b2 |
+| LocalDataFlow.cs:367:23:367:24 | SSA param(b1) | LocalDataFlow.cs:371:13:371:14 | access to parameter b1 |
+| LocalDataFlow.cs:367:23:367:24 | b1 | LocalDataFlow.cs:367:23:367:24 | SSA param(b1) |
+| LocalDataFlow.cs:367:32:367:33 | SSA param(b2) | LocalDataFlow.cs:374:17:374:18 | access to parameter b2 |
+| LocalDataFlow.cs:367:32:367:33 | b2 | LocalDataFlow.cs:367:32:367:33 | SSA param(b2) |
 | LocalDataFlow.cs:369:17:369:18 | "" | LocalDataFlow.cs:369:13:369:13 | access to local variable x |
 | LocalDataFlow.cs:373:13:373:13 | access to local variable x | LocalDataFlow.cs:373:13:373:25 | SSA def(x) |
+| LocalDataFlow.cs:373:13:373:25 | SSA def(x) | LocalDataFlow.cs:374:17:374:18 | [input] SSA phi(x) |
 | LocalDataFlow.cs:373:13:373:25 | SSA def(x) | LocalDataFlow.cs:376:35:376:35 | access to local variable x |
-| LocalDataFlow.cs:373:13:373:25 | SSA def(x) | LocalDataFlow.cs:382:9:382:17 | SSA phi(x) |
 | LocalDataFlow.cs:373:17:373:25 | "tainted" | LocalDataFlow.cs:373:13:373:13 | access to local variable x |
+| LocalDataFlow.cs:374:17:374:18 | [input] SSA phi(x) | LocalDataFlow.cs:382:9:382:17 | SSA phi(x) |
 | LocalDataFlow.cs:381:13:381:13 | access to local variable x | LocalDataFlow.cs:381:13:381:29 | SSA def(x) |
-| LocalDataFlow.cs:381:13:381:29 | SSA def(x) | LocalDataFlow.cs:382:9:382:17 | SSA phi(x) |
+| LocalDataFlow.cs:381:13:381:29 | SSA def(x) | LocalDataFlow.cs:381:13:381:29 | [input] SSA phi(x) |
+| LocalDataFlow.cs:381:13:381:29 | [input] SSA phi(x) | LocalDataFlow.cs:382:9:382:17 | SSA phi(x) |
 | LocalDataFlow.cs:381:17:381:29 | "not tainted" | LocalDataFlow.cs:381:13:381:13 | access to local variable x |
 | LocalDataFlow.cs:382:9:382:17 | SSA phi(x) | LocalDataFlow.cs:382:15:382:15 | access to local variable x |
 | SSA.cs:5:17:5:17 | SSA entry def(this.S) | SSA.cs:67:9:67:14 | access to field S |
+| SSA.cs:5:17:5:17 | [input] SSA def(this.S) | SSA.cs:136:23:136:28 | SSA def(this.S) |
+| SSA.cs:5:17:5:17 | [input] SSA qualifier def(this.S.SsaFieldNonSink0) | SSA.cs:136:23:136:28 | SSA qualifier def(this.S.SsaFieldNonSink0) |
 | SSA.cs:5:17:5:17 | this | SSA.cs:67:9:67:12 | this access |
-| SSA.cs:5:26:5:32 | tainted | SSA.cs:8:24:8:30 | access to parameter tainted |
-| SSA.cs:5:42:5:51 | nonTainted | SSA.cs:12:24:12:33 | access to parameter nonTainted |
+| SSA.cs:5:26:5:32 | SSA param(tainted) | SSA.cs:8:24:8:30 | access to parameter tainted |
+| SSA.cs:5:26:5:32 | tainted | SSA.cs:5:26:5:32 | SSA param(tainted) |
+| SSA.cs:5:42:5:51 | SSA param(nonTainted) | SSA.cs:12:24:12:33 | access to parameter nonTainted |
+| SSA.cs:5:42:5:51 | nonTainted | SSA.cs:5:42:5:51 | SSA param(nonTainted) |
 | SSA.cs:8:13:8:20 | access to local variable ssaSink0 | SSA.cs:8:13:8:30 | SSA def(ssaSink0) |
 | SSA.cs:8:13:8:30 | SSA def(ssaSink0) | SSA.cs:9:15:9:22 | access to local variable ssaSink0 |
 | SSA.cs:8:24:8:30 | access to parameter tainted | SSA.cs:8:13:8:20 | access to local variable ssaSink0 |
@@ -643,84 +662,116 @@
 | SSA.cs:12:24:12:33 | access to parameter nonTainted | SSA.cs:23:13:23:22 | access to parameter nonTainted |
 | SSA.cs:13:15:13:22 | [post] access to local variable nonSink0 | SSA.cs:19:13:19:20 | access to local variable nonSink0 |
 | SSA.cs:13:15:13:22 | access to local variable nonSink0 | SSA.cs:19:13:19:20 | access to local variable nonSink0 |
+| SSA.cs:16:13:16:20 | [post] access to local variable ssaSink0 | SSA.cs:23:13:23:33 | [input] SSA phi read(ssaSink0) |
 | SSA.cs:16:13:16:20 | [post] access to local variable ssaSink0 | SSA.cs:24:24:24:31 | access to local variable ssaSink0 |
-| SSA.cs:16:13:16:20 | [post] access to local variable ssaSink0 | SSA.cs:25:9:25:24 | SSA phi read(ssaSink0) |
+| SSA.cs:16:13:16:20 | access to local variable ssaSink0 | SSA.cs:23:13:23:33 | [input] SSA phi read(ssaSink0) |
 | SSA.cs:16:13:16:20 | access to local variable ssaSink0 | SSA.cs:24:24:24:31 | access to local variable ssaSink0 |
-| SSA.cs:16:13:16:20 | access to local variable ssaSink0 | SSA.cs:25:9:25:24 | SSA phi read(ssaSink0) |
+| SSA.cs:19:13:19:20 | [post] access to local variable nonSink0 | SSA.cs:29:13:29:33 | [input] SSA phi read(nonSink0) |
 | SSA.cs:19:13:19:20 | [post] access to local variable nonSink0 | SSA.cs:30:24:30:31 | access to local variable nonSink0 |
-| SSA.cs:19:13:19:20 | [post] access to local variable nonSink0 | SSA.cs:31:9:31:24 | SSA phi read(nonSink0) |
+| SSA.cs:19:13:19:20 | access to local variable nonSink0 | SSA.cs:29:13:29:33 | [input] SSA phi read(nonSink0) |
 | SSA.cs:19:13:19:20 | access to local variable nonSink0 | SSA.cs:30:24:30:31 | access to local variable nonSink0 |
-| SSA.cs:19:13:19:20 | access to local variable nonSink0 | SSA.cs:31:9:31:24 | SSA phi read(nonSink0) |
 | SSA.cs:22:16:22:23 | access to local variable ssaSink1 | SSA.cs:22:16:22:28 | SSA def(ssaSink1) |
-| SSA.cs:22:16:22:28 | SSA def(ssaSink1) | SSA.cs:25:9:25:24 | SSA phi(ssaSink1) |
+| SSA.cs:22:16:22:28 | SSA def(ssaSink1) | SSA.cs:23:13:23:33 | [input] SSA phi(ssaSink1) |
 | SSA.cs:22:27:22:28 | "" | SSA.cs:22:16:22:23 | access to local variable ssaSink1 |
 | SSA.cs:23:13:23:22 | [post] access to parameter nonTainted | SSA.cs:29:13:29:22 | access to parameter nonTainted |
 | SSA.cs:23:13:23:22 | access to parameter nonTainted | SSA.cs:29:13:29:22 | access to parameter nonTainted |
 | SSA.cs:23:13:23:29 | access to property Length | SSA.cs:23:13:23:33 | ... > ... |
+| SSA.cs:23:13:23:33 | [input] SSA phi read(ssaSink0) | SSA.cs:25:9:25:24 | SSA phi read(ssaSink0) |
+| SSA.cs:23:13:23:33 | [input] SSA phi(ssaSink1) | SSA.cs:25:9:25:24 | SSA phi(ssaSink1) |
 | SSA.cs:24:13:24:20 | access to local variable ssaSink1 | SSA.cs:24:13:24:31 | SSA def(ssaSink1) |
-| SSA.cs:24:13:24:31 | SSA def(ssaSink1) | SSA.cs:25:9:25:24 | SSA phi(ssaSink1) |
+| SSA.cs:24:13:24:31 | SSA def(ssaSink1) | SSA.cs:24:13:24:31 | [input] SSA phi(ssaSink1) |
+| SSA.cs:24:13:24:31 | [input] SSA phi read(ssaSink0) | SSA.cs:25:9:25:24 | SSA phi read(ssaSink0) |
+| SSA.cs:24:13:24:31 | [input] SSA phi(ssaSink1) | SSA.cs:25:9:25:24 | SSA phi(ssaSink1) |
 | SSA.cs:24:24:24:31 | access to local variable ssaSink0 | SSA.cs:24:13:24:20 | access to local variable ssaSink1 |
-| SSA.cs:24:24:24:31 | access to local variable ssaSink0 | SSA.cs:25:9:25:24 | SSA phi read(ssaSink0) |
+| SSA.cs:24:24:24:31 | access to local variable ssaSink0 | SSA.cs:24:13:24:31 | [input] SSA phi read(ssaSink0) |
+| SSA.cs:25:9:25:24 | SSA phi read(ssaSink0) | SSA.cs:35:13:35:33 | [input] SSA phi read(ssaSink0) |
 | SSA.cs:25:9:25:24 | SSA phi read(ssaSink0) | SSA.cs:37:24:37:31 | access to local variable ssaSink0 |
-| SSA.cs:25:9:25:24 | SSA phi read(ssaSink0) | SSA.cs:43:9:43:24 | SSA phi read(ssaSink0) |
 | SSA.cs:25:9:25:24 | SSA phi(ssaSink1) | SSA.cs:25:15:25:22 | access to local variable ssaSink1 |
 | SSA.cs:28:16:28:23 | access to local variable nonSink1 | SSA.cs:28:16:28:28 | SSA def(nonSink1) |
-| SSA.cs:28:16:28:28 | SSA def(nonSink1) | SSA.cs:31:9:31:24 | SSA phi(nonSink1) |
+| SSA.cs:28:16:28:28 | SSA def(nonSink1) | SSA.cs:29:13:29:33 | [input] SSA phi(nonSink1) |
 | SSA.cs:28:27:28:28 | "" | SSA.cs:28:16:28:23 | access to local variable nonSink1 |
 | SSA.cs:29:13:29:22 | [post] access to parameter nonTainted | SSA.cs:35:13:35:22 | access to parameter nonTainted |
 | SSA.cs:29:13:29:22 | access to parameter nonTainted | SSA.cs:35:13:35:22 | access to parameter nonTainted |
 | SSA.cs:29:13:29:29 | access to property Length | SSA.cs:29:13:29:33 | ... > ... |
+| SSA.cs:29:13:29:33 | [input] SSA phi read(nonSink0) | SSA.cs:31:9:31:24 | SSA phi read(nonSink0) |
+| SSA.cs:29:13:29:33 | [input] SSA phi(nonSink1) | SSA.cs:31:9:31:24 | SSA phi(nonSink1) |
 | SSA.cs:30:13:30:20 | access to local variable nonSink1 | SSA.cs:30:13:30:31 | SSA def(nonSink1) |
-| SSA.cs:30:13:30:31 | SSA def(nonSink1) | SSA.cs:31:9:31:24 | SSA phi(nonSink1) |
+| SSA.cs:30:13:30:31 | SSA def(nonSink1) | SSA.cs:30:13:30:31 | [input] SSA phi(nonSink1) |
+| SSA.cs:30:13:30:31 | [input] SSA phi read(nonSink0) | SSA.cs:31:9:31:24 | SSA phi read(nonSink0) |
+| SSA.cs:30:13:30:31 | [input] SSA phi(nonSink1) | SSA.cs:31:9:31:24 | SSA phi(nonSink1) |
 | SSA.cs:30:24:30:31 | access to local variable nonSink0 | SSA.cs:30:13:30:20 | access to local variable nonSink1 |
-| SSA.cs:30:24:30:31 | access to local variable nonSink0 | SSA.cs:31:9:31:24 | SSA phi read(nonSink0) |
+| SSA.cs:30:24:30:31 | access to local variable nonSink0 | SSA.cs:30:13:30:31 | [input] SSA phi read(nonSink0) |
+| SSA.cs:31:9:31:24 | SSA phi read(nonSink0) | SSA.cs:47:13:47:33 | [input] SSA phi read(nonSink0) |
 | SSA.cs:31:9:31:24 | SSA phi read(nonSink0) | SSA.cs:49:24:49:31 | access to local variable nonSink0 |
-| SSA.cs:31:9:31:24 | SSA phi read(nonSink0) | SSA.cs:55:9:55:24 | SSA phi read(nonSink0) |
 | SSA.cs:31:9:31:24 | SSA phi(nonSink1) | SSA.cs:31:15:31:22 | access to local variable nonSink1 |
 | SSA.cs:34:16:34:23 | access to local variable ssaSink2 | SSA.cs:34:16:34:28 | SSA def(ssaSink2) |
-| SSA.cs:34:16:34:28 | SSA def(ssaSink2) | SSA.cs:43:9:43:24 | SSA phi(ssaSink2) |
+| SSA.cs:34:16:34:28 | SSA def(ssaSink2) | SSA.cs:35:13:35:33 | [input] SSA phi(ssaSink2) |
 | SSA.cs:34:27:34:28 | "" | SSA.cs:34:16:34:23 | access to local variable ssaSink2 |
+| SSA.cs:35:13:35:22 | [post] access to parameter nonTainted | SSA.cs:35:13:35:33 | [input] SSA phi read(nonTainted) |
 | SSA.cs:35:13:35:22 | [post] access to parameter nonTainted | SSA.cs:38:17:38:26 | access to parameter nonTainted |
-| SSA.cs:35:13:35:22 | [post] access to parameter nonTainted | SSA.cs:43:9:43:24 | SSA phi read(nonTainted) |
+| SSA.cs:35:13:35:22 | access to parameter nonTainted | SSA.cs:35:13:35:33 | [input] SSA phi read(nonTainted) |
 | SSA.cs:35:13:35:22 | access to parameter nonTainted | SSA.cs:38:17:38:26 | access to parameter nonTainted |
-| SSA.cs:35:13:35:22 | access to parameter nonTainted | SSA.cs:43:9:43:24 | SSA phi read(nonTainted) |
 | SSA.cs:35:13:35:29 | access to property Length | SSA.cs:35:13:35:33 | ... > ... |
+| SSA.cs:35:13:35:33 | [input] SSA phi read(nonTainted) | SSA.cs:43:9:43:24 | SSA phi read(nonTainted) |
+| SSA.cs:35:13:35:33 | [input] SSA phi read(ssaSink0) | SSA.cs:43:9:43:24 | SSA phi read(ssaSink0) |
+| SSA.cs:35:13:35:33 | [input] SSA phi(ssaSink2) | SSA.cs:43:9:43:24 | SSA phi(ssaSink2) |
 | SSA.cs:37:13:37:20 | access to local variable ssaSink2 | SSA.cs:37:13:37:31 | SSA def(ssaSink2) |
 | SSA.cs:37:13:37:31 | SSA def(ssaSink2) | SSA.cs:39:21:39:28 | access to local variable ssaSink2 |
 | SSA.cs:37:13:37:31 | SSA def(ssaSink2) | SSA.cs:41:21:41:28 | access to local variable ssaSink2 |
 | SSA.cs:37:24:37:31 | access to local variable ssaSink0 | SSA.cs:37:13:37:20 | access to local variable ssaSink2 |
-| SSA.cs:37:24:37:31 | access to local variable ssaSink0 | SSA.cs:43:9:43:24 | SSA phi read(ssaSink0) |
-| SSA.cs:38:17:38:26 | [post] access to parameter nonTainted | SSA.cs:43:9:43:24 | SSA phi read(nonTainted) |
-| SSA.cs:38:17:38:26 | access to parameter nonTainted | SSA.cs:43:9:43:24 | SSA phi read(nonTainted) |
+| SSA.cs:37:24:37:31 | access to local variable ssaSink0 | SSA.cs:39:17:39:29 | [input] SSA phi read(ssaSink0) |
+| SSA.cs:37:24:37:31 | access to local variable ssaSink0 | SSA.cs:41:17:41:29 | [input] SSA phi read(ssaSink0) |
+| SSA.cs:38:17:38:26 | [post] access to parameter nonTainted | SSA.cs:39:17:39:29 | [input] SSA phi read(nonTainted) |
+| SSA.cs:38:17:38:26 | [post] access to parameter nonTainted | SSA.cs:41:17:41:29 | [input] SSA phi read(nonTainted) |
+| SSA.cs:38:17:38:26 | access to parameter nonTainted | SSA.cs:39:17:39:29 | [input] SSA phi read(nonTainted) |
+| SSA.cs:38:17:38:26 | access to parameter nonTainted | SSA.cs:41:17:41:29 | [input] SSA phi read(nonTainted) |
 | SSA.cs:38:17:38:33 | access to property Length | SSA.cs:38:17:38:37 | ... > ... |
-| SSA.cs:39:21:39:28 | [post] access to local variable ssaSink2 | SSA.cs:43:9:43:24 | SSA phi(ssaSink2) |
-| SSA.cs:39:21:39:28 | access to local variable ssaSink2 | SSA.cs:43:9:43:24 | SSA phi(ssaSink2) |
-| SSA.cs:41:21:41:28 | [post] access to local variable ssaSink2 | SSA.cs:43:9:43:24 | SSA phi(ssaSink2) |
-| SSA.cs:41:21:41:28 | access to local variable ssaSink2 | SSA.cs:43:9:43:24 | SSA phi(ssaSink2) |
+| SSA.cs:39:17:39:29 | [input] SSA phi read(nonTainted) | SSA.cs:43:9:43:24 | SSA phi read(nonTainted) |
+| SSA.cs:39:17:39:29 | [input] SSA phi read(ssaSink0) | SSA.cs:43:9:43:24 | SSA phi read(ssaSink0) |
+| SSA.cs:39:17:39:29 | [input] SSA phi(ssaSink2) | SSA.cs:43:9:43:24 | SSA phi(ssaSink2) |
+| SSA.cs:39:21:39:28 | [post] access to local variable ssaSink2 | SSA.cs:39:17:39:29 | [input] SSA phi(ssaSink2) |
+| SSA.cs:39:21:39:28 | access to local variable ssaSink2 | SSA.cs:39:17:39:29 | [input] SSA phi(ssaSink2) |
+| SSA.cs:41:17:41:29 | [input] SSA phi read(nonTainted) | SSA.cs:43:9:43:24 | SSA phi read(nonTainted) |
+| SSA.cs:41:17:41:29 | [input] SSA phi read(ssaSink0) | SSA.cs:43:9:43:24 | SSA phi read(ssaSink0) |
+| SSA.cs:41:17:41:29 | [input] SSA phi(ssaSink2) | SSA.cs:43:9:43:24 | SSA phi(ssaSink2) |
+| SSA.cs:41:21:41:28 | [post] access to local variable ssaSink2 | SSA.cs:41:17:41:29 | [input] SSA phi(ssaSink2) |
+| SSA.cs:41:21:41:28 | access to local variable ssaSink2 | SSA.cs:41:17:41:29 | [input] SSA phi(ssaSink2) |
 | SSA.cs:43:9:43:24 | SSA phi read(nonTainted) | SSA.cs:47:13:47:22 | access to parameter nonTainted |
+| SSA.cs:43:9:43:24 | SSA phi read(ssaSink0) | SSA.cs:89:13:89:33 | [input] SSA phi read(ssaSink0) |
 | SSA.cs:43:9:43:24 | SSA phi read(ssaSink0) | SSA.cs:91:24:91:31 | access to local variable ssaSink0 |
-| SSA.cs:43:9:43:24 | SSA phi read(ssaSink0) | SSA.cs:97:9:97:32 | SSA phi read(ssaSink0) |
 | SSA.cs:43:9:43:24 | SSA phi(ssaSink2) | SSA.cs:43:15:43:22 | access to local variable ssaSink2 |
 | SSA.cs:46:16:46:23 | access to local variable nonSink2 | SSA.cs:46:16:46:28 | SSA def(nonSink2) |
-| SSA.cs:46:16:46:28 | SSA def(nonSink2) | SSA.cs:55:9:55:24 | SSA phi(nonSink2) |
+| SSA.cs:46:16:46:28 | SSA def(nonSink2) | SSA.cs:47:13:47:33 | [input] SSA phi(nonSink2) |
 | SSA.cs:46:27:46:28 | "" | SSA.cs:46:16:46:23 | access to local variable nonSink2 |
+| SSA.cs:47:13:47:22 | [post] access to parameter nonTainted | SSA.cs:47:13:47:33 | [input] SSA phi read(nonTainted) |
 | SSA.cs:47:13:47:22 | [post] access to parameter nonTainted | SSA.cs:50:17:50:26 | access to parameter nonTainted |
-| SSA.cs:47:13:47:22 | [post] access to parameter nonTainted | SSA.cs:55:9:55:24 | SSA phi read(nonTainted) |
+| SSA.cs:47:13:47:22 | access to parameter nonTainted | SSA.cs:47:13:47:33 | [input] SSA phi read(nonTainted) |
 | SSA.cs:47:13:47:22 | access to parameter nonTainted | SSA.cs:50:17:50:26 | access to parameter nonTainted |
-| SSA.cs:47:13:47:22 | access to parameter nonTainted | SSA.cs:55:9:55:24 | SSA phi read(nonTainted) |
 | SSA.cs:47:13:47:29 | access to property Length | SSA.cs:47:13:47:33 | ... > ... |
+| SSA.cs:47:13:47:33 | [input] SSA phi read(nonSink0) | SSA.cs:55:9:55:24 | SSA phi read(nonSink0) |
+| SSA.cs:47:13:47:33 | [input] SSA phi read(nonTainted) | SSA.cs:55:9:55:24 | SSA phi read(nonTainted) |
+| SSA.cs:47:13:47:33 | [input] SSA phi(nonSink2) | SSA.cs:55:9:55:24 | SSA phi(nonSink2) |
 | SSA.cs:49:13:49:20 | access to local variable nonSink2 | SSA.cs:49:13:49:31 | SSA def(nonSink2) |
 | SSA.cs:49:13:49:31 | SSA def(nonSink2) | SSA.cs:51:21:51:28 | access to local variable nonSink2 |
 | SSA.cs:49:13:49:31 | SSA def(nonSink2) | SSA.cs:53:21:53:28 | access to local variable nonSink2 |
 | SSA.cs:49:24:49:31 | access to local variable nonSink0 | SSA.cs:49:13:49:20 | access to local variable nonSink2 |
-| SSA.cs:49:24:49:31 | access to local variable nonSink0 | SSA.cs:55:9:55:24 | SSA phi read(nonSink0) |
-| SSA.cs:50:17:50:26 | [post] access to parameter nonTainted | SSA.cs:55:9:55:24 | SSA phi read(nonTainted) |
-| SSA.cs:50:17:50:26 | access to parameter nonTainted | SSA.cs:55:9:55:24 | SSA phi read(nonTainted) |
+| SSA.cs:49:24:49:31 | access to local variable nonSink0 | SSA.cs:51:17:51:29 | [input] SSA phi read(nonSink0) |
+| SSA.cs:49:24:49:31 | access to local variable nonSink0 | SSA.cs:53:17:53:29 | [input] SSA phi read(nonSink0) |
+| SSA.cs:50:17:50:26 | [post] access to parameter nonTainted | SSA.cs:51:17:51:29 | [input] SSA phi read(nonTainted) |
+| SSA.cs:50:17:50:26 | [post] access to parameter nonTainted | SSA.cs:53:17:53:29 | [input] SSA phi read(nonTainted) |
+| SSA.cs:50:17:50:26 | access to parameter nonTainted | SSA.cs:51:17:51:29 | [input] SSA phi read(nonTainted) |
+| SSA.cs:50:17:50:26 | access to parameter nonTainted | SSA.cs:53:17:53:29 | [input] SSA phi read(nonTainted) |
 | SSA.cs:50:17:50:33 | access to property Length | SSA.cs:50:17:50:37 | ... > ... |
-| SSA.cs:51:21:51:28 | [post] access to local variable nonSink2 | SSA.cs:55:9:55:24 | SSA phi(nonSink2) |
-| SSA.cs:51:21:51:28 | access to local variable nonSink2 | SSA.cs:55:9:55:24 | SSA phi(nonSink2) |
-| SSA.cs:53:21:53:28 | [post] access to local variable nonSink2 | SSA.cs:55:9:55:24 | SSA phi(nonSink2) |
-| SSA.cs:53:21:53:28 | access to local variable nonSink2 | SSA.cs:55:9:55:24 | SSA phi(nonSink2) |
+| SSA.cs:51:17:51:29 | [input] SSA phi read(nonSink0) | SSA.cs:55:9:55:24 | SSA phi read(nonSink0) |
+| SSA.cs:51:17:51:29 | [input] SSA phi read(nonTainted) | SSA.cs:55:9:55:24 | SSA phi read(nonTainted) |
+| SSA.cs:51:17:51:29 | [input] SSA phi(nonSink2) | SSA.cs:55:9:55:24 | SSA phi(nonSink2) |
+| SSA.cs:51:21:51:28 | [post] access to local variable nonSink2 | SSA.cs:51:17:51:29 | [input] SSA phi(nonSink2) |
+| SSA.cs:51:21:51:28 | access to local variable nonSink2 | SSA.cs:51:17:51:29 | [input] SSA phi(nonSink2) |
+| SSA.cs:53:17:53:29 | [input] SSA phi read(nonSink0) | SSA.cs:55:9:55:24 | SSA phi read(nonSink0) |
+| SSA.cs:53:17:53:29 | [input] SSA phi read(nonTainted) | SSA.cs:55:9:55:24 | SSA phi read(nonTainted) |
+| SSA.cs:53:17:53:29 | [input] SSA phi(nonSink2) | SSA.cs:55:9:55:24 | SSA phi(nonSink2) |
+| SSA.cs:53:21:53:28 | [post] access to local variable nonSink2 | SSA.cs:53:17:53:29 | [input] SSA phi(nonSink2) |
+| SSA.cs:53:21:53:28 | access to local variable nonSink2 | SSA.cs:53:17:53:29 | [input] SSA phi(nonSink2) |
 | SSA.cs:55:9:55:24 | SSA phi read(nonSink0) | SSA.cs:63:23:63:30 | access to local variable nonSink0 |
 | SSA.cs:55:9:55:24 | SSA phi read(nonTainted) | SSA.cs:89:13:89:22 | access to parameter nonTainted |
 | SSA.cs:55:9:55:24 | SSA phi(nonSink2) | SSA.cs:55:15:55:22 | access to local variable nonSink2 |
@@ -729,28 +780,28 @@
 | SSA.cs:58:27:58:33 | access to parameter tainted | SSA.cs:58:16:58:23 | access to local variable ssaSink3 |
 | SSA.cs:58:27:58:33 | access to parameter tainted | SSA.cs:67:32:67:38 | access to parameter tainted |
 | SSA.cs:59:23:59:30 | SSA def(ssaSink3) | SSA.cs:60:15:60:22 | access to local variable ssaSink3 |
-| SSA.cs:59:23:59:30 | [post] access to local variable ssaSink3 | SSA.cs:59:23:59:30 | SSA def(ssaSink3) |
+| SSA.cs:59:23:59:30 | [post] access to local variable ssaSink3 | SSA.cs:89:13:89:33 | [input] SSA def(ssaSink3) |
 | SSA.cs:59:23:59:30 | access to local variable ssaSink3 | SSA.cs:59:23:59:30 | SSA def(ssaSink3) |
-| SSA.cs:59:23:59:30 | access to local variable ssaSink3 | SSA.cs:59:23:59:30 | SSA def(ssaSink3) |
+| SSA.cs:59:23:59:30 | access to local variable ssaSink3 | SSA.cs:89:13:89:33 | [input] SSA def(ssaSink3) |
 | SSA.cs:63:23:63:30 | SSA def(nonSink0) | SSA.cs:64:15:64:22 | access to local variable nonSink0 |
-| SSA.cs:63:23:63:30 | [post] access to local variable nonSink0 | SSA.cs:63:23:63:30 | SSA def(nonSink0) |
+| SSA.cs:63:23:63:30 | [post] access to local variable nonSink0 | SSA.cs:89:13:89:33 | [input] SSA def(nonSink0) |
 | SSA.cs:63:23:63:30 | access to local variable nonSink0 | SSA.cs:63:23:63:30 | SSA def(nonSink0) |
-| SSA.cs:63:23:63:30 | access to local variable nonSink0 | SSA.cs:63:23:63:30 | SSA def(nonSink0) |
+| SSA.cs:63:23:63:30 | access to local variable nonSink0 | SSA.cs:89:13:89:33 | [input] SSA def(nonSink0) |
 | SSA.cs:67:9:67:12 | [post] this access | SSA.cs:68:23:68:26 | this access |
 | SSA.cs:67:9:67:12 | this access | SSA.cs:68:23:68:26 | this access |
 | SSA.cs:67:9:67:14 | [post] access to field S | SSA.cs:68:23:68:28 | access to field S |
 | SSA.cs:67:9:67:14 | access to field S | SSA.cs:68:23:68:28 | access to field S |
 | SSA.cs:67:9:67:28 | access to field SsaFieldSink0 | SSA.cs:67:9:67:38 | SSA def(this.S.SsaFieldSink0) |
-| SSA.cs:67:9:67:38 | SSA def(this.S.SsaFieldSink0) | SSA.cs:68:23:68:28 | SSA qualifier def(this.S.SsaFieldSink0) |
+| SSA.cs:67:9:67:38 | SSA def(this.S.SsaFieldSink0) | SSA.cs:89:13:89:33 | [input] SSA qualifier def(this.S.SsaFieldSink0) |
 | SSA.cs:67:32:67:38 | access to parameter tainted | SSA.cs:67:9:67:28 | access to field SsaFieldSink0 |
 | SSA.cs:67:32:67:38 | access to parameter tainted | SSA.cs:77:20:77:26 | access to parameter tainted |
 | SSA.cs:68:23:68:26 | [post] this access | SSA.cs:69:15:69:18 | this access |
 | SSA.cs:68:23:68:26 | this access | SSA.cs:69:15:69:18 | this access |
 | SSA.cs:68:23:68:28 | SSA def(this.S) | SSA.cs:69:15:69:20 | access to field S |
 | SSA.cs:68:23:68:28 | SSA qualifier def(this.S.SsaFieldSink0) | SSA.cs:69:15:69:34 | access to field SsaFieldSink0 |
-| SSA.cs:68:23:68:28 | [post] access to field S | SSA.cs:68:23:68:28 | SSA def(this.S) |
+| SSA.cs:68:23:68:28 | [post] access to field S | SSA.cs:89:13:89:33 | [input] SSA def(this.S) |
 | SSA.cs:68:23:68:28 | access to field S | SSA.cs:68:23:68:28 | SSA def(this.S) |
-| SSA.cs:68:23:68:28 | access to field S | SSA.cs:68:23:68:28 | SSA def(this.S) |
+| SSA.cs:68:23:68:28 | access to field S | SSA.cs:89:13:89:33 | [input] SSA def(this.S) |
 | SSA.cs:69:15:69:18 | [post] this access | SSA.cs:72:9:72:12 | this access |
 | SSA.cs:69:15:69:18 | this access | SSA.cs:72:9:72:12 | this access |
 | SSA.cs:69:15:69:20 | [post] access to field S | SSA.cs:72:9:72:14 | access to field S |
@@ -760,15 +811,15 @@
 | SSA.cs:72:9:72:14 | [post] access to field S | SSA.cs:73:23:73:28 | access to field S |
 | SSA.cs:72:9:72:14 | access to field S | SSA.cs:73:23:73:28 | access to field S |
 | SSA.cs:72:9:72:31 | access to field SsaFieldNonSink0 | SSA.cs:72:9:72:36 | SSA def(this.S.SsaFieldNonSink0) |
-| SSA.cs:72:9:72:36 | SSA def(this.S.SsaFieldNonSink0) | SSA.cs:73:23:73:28 | SSA qualifier def(this.S.SsaFieldNonSink0) |
+| SSA.cs:72:9:72:36 | SSA def(this.S.SsaFieldNonSink0) | SSA.cs:89:13:89:33 | [input] SSA qualifier def(this.S.SsaFieldNonSink0) |
 | SSA.cs:72:35:72:36 | "" | SSA.cs:72:9:72:31 | access to field SsaFieldNonSink0 |
 | SSA.cs:73:23:73:26 | [post] this access | SSA.cs:74:15:74:18 | this access |
 | SSA.cs:73:23:73:26 | this access | SSA.cs:74:15:74:18 | this access |
 | SSA.cs:73:23:73:28 | SSA def(this.S) | SSA.cs:74:15:74:20 | access to field S |
 | SSA.cs:73:23:73:28 | SSA qualifier def(this.S.SsaFieldNonSink0) | SSA.cs:74:15:74:37 | access to field SsaFieldNonSink0 |
-| SSA.cs:73:23:73:28 | [post] access to field S | SSA.cs:73:23:73:28 | SSA def(this.S) |
+| SSA.cs:73:23:73:28 | [post] access to field S | SSA.cs:89:13:89:33 | [input] SSA def(this.S) |
 | SSA.cs:73:23:73:28 | access to field S | SSA.cs:73:23:73:28 | SSA def(this.S) |
-| SSA.cs:73:23:73:28 | access to field S | SSA.cs:73:23:73:28 | SSA def(this.S) |
+| SSA.cs:73:23:73:28 | access to field S | SSA.cs:89:13:89:33 | [input] SSA def(this.S) |
 | SSA.cs:74:15:74:18 | [post] this access | SSA.cs:80:9:80:12 | this access |
 | SSA.cs:74:15:74:18 | this access | SSA.cs:80:9:80:12 | this access |
 | SSA.cs:74:15:74:20 | [post] access to field S | SSA.cs:80:9:80:14 | access to field S |
@@ -779,10 +830,10 @@
 | SSA.cs:77:20:77:26 | access to parameter tainted | SSA.cs:80:35:80:41 | access to parameter tainted |
 | SSA.cs:78:21:78:28 | SSA def(nonSink0) | SSA.cs:79:15:79:22 | access to local variable nonSink0 |
 | SSA.cs:78:21:78:28 | access to local variable nonSink0 | SSA.cs:78:21:78:28 | SSA def(nonSink0) |
+| SSA.cs:79:15:79:22 | [post] access to local variable nonSink0 | SSA.cs:102:13:102:33 | [input] SSA phi read(nonSink0) |
 | SSA.cs:79:15:79:22 | [post] access to local variable nonSink0 | SSA.cs:104:24:104:31 | access to local variable nonSink0 |
-| SSA.cs:79:15:79:22 | [post] access to local variable nonSink0 | SSA.cs:110:9:110:32 | SSA phi read(nonSink0) |
+| SSA.cs:79:15:79:22 | access to local variable nonSink0 | SSA.cs:102:13:102:33 | [input] SSA phi read(nonSink0) |
 | SSA.cs:79:15:79:22 | access to local variable nonSink0 | SSA.cs:104:24:104:31 | access to local variable nonSink0 |
-| SSA.cs:79:15:79:22 | access to local variable nonSink0 | SSA.cs:110:9:110:32 | SSA phi read(nonSink0) |
 | SSA.cs:80:9:80:12 | [post] this access | SSA.cs:81:21:81:24 | this access |
 | SSA.cs:80:9:80:12 | this access | SSA.cs:81:21:81:24 | this access |
 | SSA.cs:80:9:80:14 | [post] access to field S | SSA.cs:81:21:81:26 | access to field S |
@@ -811,75 +862,110 @@
 | SSA.cs:85:15:85:20 | [post] access to field S | SSA.cs:114:9:114:14 | access to field S |
 | SSA.cs:85:15:85:20 | access to field S | SSA.cs:114:9:114:14 | access to field S |
 | SSA.cs:88:16:88:23 | access to local variable ssaSink4 | SSA.cs:88:16:88:28 | SSA def(ssaSink4) |
-| SSA.cs:88:16:88:28 | SSA def(ssaSink4) | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) |
+| SSA.cs:88:16:88:28 | SSA def(ssaSink4) | SSA.cs:89:13:89:33 | [input] SSA phi(ssaSink4) |
 | SSA.cs:88:27:88:28 | "" | SSA.cs:88:16:88:23 | access to local variable ssaSink4 |
+| SSA.cs:89:13:89:22 | [post] access to parameter nonTainted | SSA.cs:89:13:89:33 | [input] SSA phi read(nonTainted) |
 | SSA.cs:89:13:89:22 | [post] access to parameter nonTainted | SSA.cs:92:17:92:26 | access to parameter nonTainted |
-| SSA.cs:89:13:89:22 | [post] access to parameter nonTainted | SSA.cs:97:9:97:32 | SSA phi read(nonTainted) |
+| SSA.cs:89:13:89:22 | access to parameter nonTainted | SSA.cs:89:13:89:33 | [input] SSA phi read(nonTainted) |
 | SSA.cs:89:13:89:22 | access to parameter nonTainted | SSA.cs:92:17:92:26 | access to parameter nonTainted |
-| SSA.cs:89:13:89:22 | access to parameter nonTainted | SSA.cs:97:9:97:32 | SSA phi read(nonTainted) |
 | SSA.cs:89:13:89:29 | access to property Length | SSA.cs:89:13:89:33 | ... > ... |
+| SSA.cs:89:13:89:33 | [input] SSA def(nonSink0) | SSA.cs:63:23:63:30 | SSA def(nonSink0) |
+| SSA.cs:89:13:89:33 | [input] SSA def(ssaSink3) | SSA.cs:59:23:59:30 | SSA def(ssaSink3) |
+| SSA.cs:89:13:89:33 | [input] SSA def(this.S) | SSA.cs:68:23:68:28 | SSA def(this.S) |
+| SSA.cs:89:13:89:33 | [input] SSA def(this.S) | SSA.cs:73:23:73:28 | SSA def(this.S) |
+| SSA.cs:89:13:89:33 | [input] SSA phi read(nonTainted) | SSA.cs:97:9:97:32 | SSA phi read(nonTainted) |
+| SSA.cs:89:13:89:33 | [input] SSA phi read(ssaSink0) | SSA.cs:97:9:97:32 | SSA phi read(ssaSink0) |
+| SSA.cs:89:13:89:33 | [input] SSA phi(ssaSink4) | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) |
+| SSA.cs:89:13:89:33 | [input] SSA qualifier def(this.S.SsaFieldNonSink0) | SSA.cs:73:23:73:28 | SSA qualifier def(this.S.SsaFieldNonSink0) |
+| SSA.cs:89:13:89:33 | [input] SSA qualifier def(this.S.SsaFieldSink0) | SSA.cs:68:23:68:28 | SSA qualifier def(this.S.SsaFieldSink0) |
 | SSA.cs:91:13:91:20 | access to local variable ssaSink4 | SSA.cs:91:13:91:31 | SSA def(ssaSink4) |
 | SSA.cs:91:13:91:31 | SSA def(ssaSink4) | SSA.cs:93:21:93:28 | access to local variable ssaSink4 |
 | SSA.cs:91:13:91:31 | SSA def(ssaSink4) | SSA.cs:95:21:95:28 | access to local variable ssaSink4 |
 | SSA.cs:91:24:91:31 | access to local variable ssaSink0 | SSA.cs:91:13:91:20 | access to local variable ssaSink4 |
-| SSA.cs:91:24:91:31 | access to local variable ssaSink0 | SSA.cs:97:9:97:32 | SSA phi read(ssaSink0) |
-| SSA.cs:92:17:92:26 | [post] access to parameter nonTainted | SSA.cs:97:9:97:32 | SSA phi read(nonTainted) |
-| SSA.cs:92:17:92:26 | access to parameter nonTainted | SSA.cs:97:9:97:32 | SSA phi read(nonTainted) |
+| SSA.cs:91:24:91:31 | access to local variable ssaSink0 | SSA.cs:93:17:93:29 | [input] SSA phi read(ssaSink0) |
+| SSA.cs:91:24:91:31 | access to local variable ssaSink0 | SSA.cs:95:17:95:29 | [input] SSA phi read(ssaSink0) |
+| SSA.cs:92:17:92:26 | [post] access to parameter nonTainted | SSA.cs:93:17:93:29 | [input] SSA phi read(nonTainted) |
+| SSA.cs:92:17:92:26 | [post] access to parameter nonTainted | SSA.cs:95:17:95:29 | [input] SSA phi read(nonTainted) |
+| SSA.cs:92:17:92:26 | access to parameter nonTainted | SSA.cs:93:17:93:29 | [input] SSA phi read(nonTainted) |
+| SSA.cs:92:17:92:26 | access to parameter nonTainted | SSA.cs:95:17:95:29 | [input] SSA phi read(nonTainted) |
 | SSA.cs:92:17:92:33 | access to property Length | SSA.cs:92:17:92:37 | ... > ... |
-| SSA.cs:93:21:93:28 | [post] access to local variable ssaSink4 | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) |
-| SSA.cs:93:21:93:28 | access to local variable ssaSink4 | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) |
-| SSA.cs:95:21:95:28 | [post] access to local variable ssaSink4 | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) |
-| SSA.cs:95:21:95:28 | access to local variable ssaSink4 | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) |
+| SSA.cs:93:17:93:29 | [input] SSA phi read(nonTainted) | SSA.cs:97:9:97:32 | SSA phi read(nonTainted) |
+| SSA.cs:93:17:93:29 | [input] SSA phi read(ssaSink0) | SSA.cs:97:9:97:32 | SSA phi read(ssaSink0) |
+| SSA.cs:93:17:93:29 | [input] SSA phi(ssaSink4) | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) |
+| SSA.cs:93:21:93:28 | [post] access to local variable ssaSink4 | SSA.cs:93:17:93:29 | [input] SSA phi(ssaSink4) |
+| SSA.cs:93:21:93:28 | access to local variable ssaSink4 | SSA.cs:93:17:93:29 | [input] SSA phi(ssaSink4) |
+| SSA.cs:95:17:95:29 | [input] SSA phi read(nonTainted) | SSA.cs:97:9:97:32 | SSA phi read(nonTainted) |
+| SSA.cs:95:17:95:29 | [input] SSA phi read(ssaSink0) | SSA.cs:97:9:97:32 | SSA phi read(ssaSink0) |
+| SSA.cs:95:17:95:29 | [input] SSA phi(ssaSink4) | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) |
+| SSA.cs:95:21:95:28 | [post] access to local variable ssaSink4 | SSA.cs:95:17:95:29 | [input] SSA phi(ssaSink4) |
+| SSA.cs:95:21:95:28 | access to local variable ssaSink4 | SSA.cs:95:17:95:29 | [input] SSA phi(ssaSink4) |
 | SSA.cs:97:9:97:32 | SSA phi read(nonTainted) | SSA.cs:102:13:102:22 | access to parameter nonTainted |
 | SSA.cs:97:9:97:32 | SSA phi read(ssaSink0) | SSA.cs:117:36:117:43 | access to local variable ssaSink0 |
 | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) | SSA.cs:97:23:97:30 | access to local variable ssaSink4 |
 | SSA.cs:97:23:97:30 | SSA def(ssaSink4) | SSA.cs:98:15:98:22 | access to local variable ssaSink4 |
-| SSA.cs:97:23:97:30 | [post] access to local variable ssaSink4 | SSA.cs:97:23:97:30 | SSA def(ssaSink4) |
+| SSA.cs:97:23:97:30 | [post] access to local variable ssaSink4 | SSA.cs:102:13:102:33 | [input] SSA def(ssaSink4) |
 | SSA.cs:97:23:97:30 | access to local variable ssaSink4 | SSA.cs:97:23:97:30 | SSA def(ssaSink4) |
-| SSA.cs:97:23:97:30 | access to local variable ssaSink4 | SSA.cs:97:23:97:30 | SSA def(ssaSink4) |
+| SSA.cs:97:23:97:30 | access to local variable ssaSink4 | SSA.cs:102:13:102:33 | [input] SSA def(ssaSink4) |
 | SSA.cs:101:16:101:23 | access to local variable nonSink3 | SSA.cs:101:16:101:28 | SSA def(nonSink3) |
-| SSA.cs:101:16:101:28 | SSA def(nonSink3) | SSA.cs:110:9:110:32 | SSA phi(nonSink3) |
+| SSA.cs:101:16:101:28 | SSA def(nonSink3) | SSA.cs:102:13:102:33 | [input] SSA phi(nonSink3) |
 | SSA.cs:101:27:101:28 | "" | SSA.cs:101:16:101:23 | access to local variable nonSink3 |
+| SSA.cs:102:13:102:22 | [post] access to parameter nonTainted | SSA.cs:102:13:102:33 | [input] SSA phi read(nonTainted) |
 | SSA.cs:102:13:102:22 | [post] access to parameter nonTainted | SSA.cs:105:17:105:26 | access to parameter nonTainted |
-| SSA.cs:102:13:102:22 | [post] access to parameter nonTainted | SSA.cs:110:9:110:32 | SSA phi read(nonTainted) |
+| SSA.cs:102:13:102:22 | access to parameter nonTainted | SSA.cs:102:13:102:33 | [input] SSA phi read(nonTainted) |
 | SSA.cs:102:13:102:22 | access to parameter nonTainted | SSA.cs:105:17:105:26 | access to parameter nonTainted |
-| SSA.cs:102:13:102:22 | access to parameter nonTainted | SSA.cs:110:9:110:32 | SSA phi read(nonTainted) |
 | SSA.cs:102:13:102:29 | access to property Length | SSA.cs:102:13:102:33 | ... > ... |
+| SSA.cs:102:13:102:33 | [input] SSA def(ssaSink4) | SSA.cs:97:23:97:30 | SSA def(ssaSink4) |
+| SSA.cs:102:13:102:33 | [input] SSA phi read(nonSink0) | SSA.cs:110:9:110:32 | SSA phi read(nonSink0) |
+| SSA.cs:102:13:102:33 | [input] SSA phi read(nonTainted) | SSA.cs:110:9:110:32 | SSA phi read(nonTainted) |
+| SSA.cs:102:13:102:33 | [input] SSA phi(nonSink3) | SSA.cs:110:9:110:32 | SSA phi(nonSink3) |
 | SSA.cs:104:13:104:20 | access to local variable nonSink3 | SSA.cs:104:13:104:31 | SSA def(nonSink3) |
 | SSA.cs:104:13:104:31 | SSA def(nonSink3) | SSA.cs:106:21:106:28 | access to local variable nonSink3 |
 | SSA.cs:104:13:104:31 | SSA def(nonSink3) | SSA.cs:108:21:108:28 | access to local variable nonSink3 |
 | SSA.cs:104:24:104:31 | access to local variable nonSink0 | SSA.cs:104:13:104:20 | access to local variable nonSink3 |
-| SSA.cs:104:24:104:31 | access to local variable nonSink0 | SSA.cs:110:9:110:32 | SSA phi read(nonSink0) |
-| SSA.cs:105:17:105:26 | [post] access to parameter nonTainted | SSA.cs:110:9:110:32 | SSA phi read(nonTainted) |
-| SSA.cs:105:17:105:26 | access to parameter nonTainted | SSA.cs:110:9:110:32 | SSA phi read(nonTainted) |
+| SSA.cs:104:24:104:31 | access to local variable nonSink0 | SSA.cs:106:17:106:29 | [input] SSA phi read(nonSink0) |
+| SSA.cs:104:24:104:31 | access to local variable nonSink0 | SSA.cs:108:17:108:29 | [input] SSA phi read(nonSink0) |
+| SSA.cs:105:17:105:26 | [post] access to parameter nonTainted | SSA.cs:106:17:106:29 | [input] SSA phi read(nonTainted) |
+| SSA.cs:105:17:105:26 | [post] access to parameter nonTainted | SSA.cs:108:17:108:29 | [input] SSA phi read(nonTainted) |
+| SSA.cs:105:17:105:26 | access to parameter nonTainted | SSA.cs:106:17:106:29 | [input] SSA phi read(nonTainted) |
+| SSA.cs:105:17:105:26 | access to parameter nonTainted | SSA.cs:108:17:108:29 | [input] SSA phi read(nonTainted) |
 | SSA.cs:105:17:105:33 | access to property Length | SSA.cs:105:17:105:37 | ... > ... |
-| SSA.cs:106:21:106:28 | [post] access to local variable nonSink3 | SSA.cs:110:9:110:32 | SSA phi(nonSink3) |
-| SSA.cs:106:21:106:28 | access to local variable nonSink3 | SSA.cs:110:9:110:32 | SSA phi(nonSink3) |
-| SSA.cs:108:21:108:28 | [post] access to local variable nonSink3 | SSA.cs:110:9:110:32 | SSA phi(nonSink3) |
-| SSA.cs:108:21:108:28 | access to local variable nonSink3 | SSA.cs:110:9:110:32 | SSA phi(nonSink3) |
+| SSA.cs:106:17:106:29 | [input] SSA phi read(nonSink0) | SSA.cs:110:9:110:32 | SSA phi read(nonSink0) |
+| SSA.cs:106:17:106:29 | [input] SSA phi read(nonTainted) | SSA.cs:110:9:110:32 | SSA phi read(nonTainted) |
+| SSA.cs:106:17:106:29 | [input] SSA phi(nonSink3) | SSA.cs:110:9:110:32 | SSA phi(nonSink3) |
+| SSA.cs:106:21:106:28 | [post] access to local variable nonSink3 | SSA.cs:106:17:106:29 | [input] SSA phi(nonSink3) |
+| SSA.cs:106:21:106:28 | access to local variable nonSink3 | SSA.cs:106:17:106:29 | [input] SSA phi(nonSink3) |
+| SSA.cs:108:17:108:29 | [input] SSA phi read(nonSink0) | SSA.cs:110:9:110:32 | SSA phi read(nonSink0) |
+| SSA.cs:108:17:108:29 | [input] SSA phi read(nonTainted) | SSA.cs:110:9:110:32 | SSA phi read(nonTainted) |
+| SSA.cs:108:17:108:29 | [input] SSA phi(nonSink3) | SSA.cs:110:9:110:32 | SSA phi(nonSink3) |
+| SSA.cs:108:21:108:28 | [post] access to local variable nonSink3 | SSA.cs:108:17:108:29 | [input] SSA phi(nonSink3) |
+| SSA.cs:108:21:108:28 | access to local variable nonSink3 | SSA.cs:108:17:108:29 | [input] SSA phi(nonSink3) |
 | SSA.cs:110:9:110:32 | SSA phi read(nonSink0) | SSA.cs:130:39:130:46 | access to local variable nonSink0 |
 | SSA.cs:110:9:110:32 | SSA phi read(nonTainted) | SSA.cs:115:13:115:22 | access to parameter nonTainted |
 | SSA.cs:110:9:110:32 | SSA phi(nonSink3) | SSA.cs:110:23:110:30 | access to local variable nonSink3 |
 | SSA.cs:110:23:110:30 | SSA def(nonSink3) | SSA.cs:111:15:111:22 | access to local variable nonSink3 |
-| SSA.cs:110:23:110:30 | [post] access to local variable nonSink3 | SSA.cs:110:23:110:30 | SSA def(nonSink3) |
+| SSA.cs:110:23:110:30 | [post] access to local variable nonSink3 | SSA.cs:115:13:115:33 | [input] SSA def(nonSink3) |
 | SSA.cs:110:23:110:30 | access to local variable nonSink3 | SSA.cs:110:23:110:30 | SSA def(nonSink3) |
-| SSA.cs:110:23:110:30 | access to local variable nonSink3 | SSA.cs:110:23:110:30 | SSA def(nonSink3) |
+| SSA.cs:110:23:110:30 | access to local variable nonSink3 | SSA.cs:115:13:115:33 | [input] SSA def(nonSink3) |
 | SSA.cs:114:9:114:12 | [post] this access | SSA.cs:117:13:117:16 | this access |
 | SSA.cs:114:9:114:12 | [post] this access | SSA.cs:123:23:123:26 | this access |
 | SSA.cs:114:9:114:12 | this access | SSA.cs:117:13:117:16 | this access |
 | SSA.cs:114:9:114:12 | this access | SSA.cs:123:23:123:26 | this access |
+| SSA.cs:114:9:114:14 | [post] access to field S | SSA.cs:115:13:115:33 | [input] SSA phi read(this.S) |
 | SSA.cs:114:9:114:14 | [post] access to field S | SSA.cs:117:13:117:18 | access to field S |
-| SSA.cs:114:9:114:14 | [post] access to field S | SSA.cs:123:9:123:30 | SSA phi read(this.S) |
+| SSA.cs:114:9:114:14 | access to field S | SSA.cs:115:13:115:33 | [input] SSA phi read(this.S) |
 | SSA.cs:114:9:114:14 | access to field S | SSA.cs:117:13:117:18 | access to field S |
-| SSA.cs:114:9:114:14 | access to field S | SSA.cs:123:9:123:30 | SSA phi read(this.S) |
 | SSA.cs:114:9:114:28 | access to field SsaFieldSink1 | SSA.cs:114:9:114:33 | SSA def(this.S.SsaFieldSink1) |
-| SSA.cs:114:9:114:33 | SSA def(this.S.SsaFieldSink1) | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) |
+| SSA.cs:114:9:114:33 | SSA def(this.S.SsaFieldSink1) | SSA.cs:115:13:115:33 | [input] SSA phi(this.S.SsaFieldSink1) |
 | SSA.cs:114:32:114:33 | "" | SSA.cs:114:9:114:28 | access to field SsaFieldSink1 |
+| SSA.cs:115:13:115:22 | [post] access to parameter nonTainted | SSA.cs:115:13:115:33 | [input] SSA phi read(nonTainted) |
 | SSA.cs:115:13:115:22 | [post] access to parameter nonTainted | SSA.cs:118:17:118:26 | access to parameter nonTainted |
-| SSA.cs:115:13:115:22 | [post] access to parameter nonTainted | SSA.cs:123:9:123:30 | SSA phi read(nonTainted) |
+| SSA.cs:115:13:115:22 | access to parameter nonTainted | SSA.cs:115:13:115:33 | [input] SSA phi read(nonTainted) |
 | SSA.cs:115:13:115:22 | access to parameter nonTainted | SSA.cs:118:17:118:26 | access to parameter nonTainted |
-| SSA.cs:115:13:115:22 | access to parameter nonTainted | SSA.cs:123:9:123:30 | SSA phi read(nonTainted) |
 | SSA.cs:115:13:115:29 | access to property Length | SSA.cs:115:13:115:33 | ... > ... |
+| SSA.cs:115:13:115:33 | [input] SSA def(nonSink3) | SSA.cs:110:23:110:30 | SSA def(nonSink3) |
+| SSA.cs:115:13:115:33 | [input] SSA phi read(nonTainted) | SSA.cs:123:9:123:30 | SSA phi read(nonTainted) |
+| SSA.cs:115:13:115:33 | [input] SSA phi read(this.S) | SSA.cs:123:9:123:30 | SSA phi read(this.S) |
+| SSA.cs:115:13:115:33 | [input] SSA phi(this.S.SsaFieldSink1) | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) |
 | SSA.cs:117:13:117:16 | [post] this access | SSA.cs:119:21:119:24 | this access |
 | SSA.cs:117:13:117:16 | [post] this access | SSA.cs:121:21:121:24 | this access |
 | SSA.cs:117:13:117:16 | this access | SSA.cs:119:21:119:24 | this access |
@@ -892,31 +978,39 @@
 | SSA.cs:117:13:117:43 | SSA def(this.S.SsaFieldSink1) | SSA.cs:119:21:119:40 | access to field SsaFieldSink1 |
 | SSA.cs:117:13:117:43 | SSA def(this.S.SsaFieldSink1) | SSA.cs:121:21:121:40 | access to field SsaFieldSink1 |
 | SSA.cs:117:36:117:43 | access to local variable ssaSink0 | SSA.cs:117:13:117:32 | access to field SsaFieldSink1 |
-| SSA.cs:118:17:118:26 | [post] access to parameter nonTainted | SSA.cs:123:9:123:30 | SSA phi read(nonTainted) |
-| SSA.cs:118:17:118:26 | access to parameter nonTainted | SSA.cs:123:9:123:30 | SSA phi read(nonTainted) |
+| SSA.cs:118:17:118:26 | [post] access to parameter nonTainted | SSA.cs:119:17:119:41 | [input] SSA phi read(nonTainted) |
+| SSA.cs:118:17:118:26 | [post] access to parameter nonTainted | SSA.cs:121:17:121:41 | [input] SSA phi read(nonTainted) |
+| SSA.cs:118:17:118:26 | access to parameter nonTainted | SSA.cs:119:17:119:41 | [input] SSA phi read(nonTainted) |
+| SSA.cs:118:17:118:26 | access to parameter nonTainted | SSA.cs:121:17:121:41 | [input] SSA phi read(nonTainted) |
 | SSA.cs:118:17:118:33 | access to property Length | SSA.cs:118:17:118:37 | ... > ... |
+| SSA.cs:119:17:119:41 | [input] SSA phi read(nonTainted) | SSA.cs:123:9:123:30 | SSA phi read(nonTainted) |
+| SSA.cs:119:17:119:41 | [input] SSA phi read(this.S) | SSA.cs:123:9:123:30 | SSA phi read(this.S) |
+| SSA.cs:119:17:119:41 | [input] SSA phi(this.S.SsaFieldSink1) | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) |
 | SSA.cs:119:21:119:24 | [post] this access | SSA.cs:123:23:123:26 | this access |
 | SSA.cs:119:21:119:24 | this access | SSA.cs:123:23:123:26 | this access |
-| SSA.cs:119:21:119:26 | [post] access to field S | SSA.cs:123:9:123:30 | SSA phi read(this.S) |
-| SSA.cs:119:21:119:26 | access to field S | SSA.cs:123:9:123:30 | SSA phi read(this.S) |
-| SSA.cs:119:21:119:40 | [post] access to field SsaFieldSink1 | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) |
-| SSA.cs:119:21:119:40 | access to field SsaFieldSink1 | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) |
+| SSA.cs:119:21:119:26 | [post] access to field S | SSA.cs:119:17:119:41 | [input] SSA phi read(this.S) |
+| SSA.cs:119:21:119:26 | access to field S | SSA.cs:119:17:119:41 | [input] SSA phi read(this.S) |
+| SSA.cs:119:21:119:40 | [post] access to field SsaFieldSink1 | SSA.cs:119:17:119:41 | [input] SSA phi(this.S.SsaFieldSink1) |
+| SSA.cs:119:21:119:40 | access to field SsaFieldSink1 | SSA.cs:119:17:119:41 | [input] SSA phi(this.S.SsaFieldSink1) |
+| SSA.cs:121:17:121:41 | [input] SSA phi read(nonTainted) | SSA.cs:123:9:123:30 | SSA phi read(nonTainted) |
+| SSA.cs:121:17:121:41 | [input] SSA phi read(this.S) | SSA.cs:123:9:123:30 | SSA phi read(this.S) |
+| SSA.cs:121:17:121:41 | [input] SSA phi(this.S.SsaFieldSink1) | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) |
 | SSA.cs:121:21:121:24 | [post] this access | SSA.cs:123:23:123:26 | this access |
 | SSA.cs:121:21:121:24 | this access | SSA.cs:123:23:123:26 | this access |
-| SSA.cs:121:21:121:26 | [post] access to field S | SSA.cs:123:9:123:30 | SSA phi read(this.S) |
-| SSA.cs:121:21:121:26 | access to field S | SSA.cs:123:9:123:30 | SSA phi read(this.S) |
-| SSA.cs:121:21:121:40 | [post] access to field SsaFieldSink1 | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) |
-| SSA.cs:121:21:121:40 | access to field SsaFieldSink1 | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) |
+| SSA.cs:121:21:121:26 | [post] access to field S | SSA.cs:121:17:121:41 | [input] SSA phi read(this.S) |
+| SSA.cs:121:21:121:26 | access to field S | SSA.cs:121:17:121:41 | [input] SSA phi read(this.S) |
+| SSA.cs:121:21:121:40 | [post] access to field SsaFieldSink1 | SSA.cs:121:17:121:41 | [input] SSA phi(this.S.SsaFieldSink1) |
+| SSA.cs:121:21:121:40 | access to field SsaFieldSink1 | SSA.cs:121:17:121:41 | [input] SSA phi(this.S.SsaFieldSink1) |
 | SSA.cs:123:9:123:30 | SSA phi read(nonTainted) | SSA.cs:128:13:128:22 | access to parameter nonTainted |
 | SSA.cs:123:9:123:30 | SSA phi read(this.S) | SSA.cs:123:23:123:28 | access to field S |
-| SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) | SSA.cs:123:23:123:28 | SSA qualifier def(this.S.SsaFieldSink1) |
+| SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) | SSA.cs:128:13:128:33 | [input] SSA qualifier def(this.S.SsaFieldSink1) |
 | SSA.cs:123:23:123:26 | [post] this access | SSA.cs:124:15:124:18 | this access |
 | SSA.cs:123:23:123:26 | this access | SSA.cs:124:15:124:18 | this access |
 | SSA.cs:123:23:123:28 | SSA def(this.S) | SSA.cs:124:15:124:20 | access to field S |
 | SSA.cs:123:23:123:28 | SSA qualifier def(this.S.SsaFieldSink1) | SSA.cs:124:15:124:34 | access to field SsaFieldSink1 |
-| SSA.cs:123:23:123:28 | [post] access to field S | SSA.cs:123:23:123:28 | SSA def(this.S) |
+| SSA.cs:123:23:123:28 | [post] access to field S | SSA.cs:128:13:128:33 | [input] SSA def(this.S) |
 | SSA.cs:123:23:123:28 | access to field S | SSA.cs:123:23:123:28 | SSA def(this.S) |
-| SSA.cs:123:23:123:28 | access to field S | SSA.cs:123:23:123:28 | SSA def(this.S) |
+| SSA.cs:123:23:123:28 | access to field S | SSA.cs:128:13:128:33 | [input] SSA def(this.S) |
 | SSA.cs:124:15:124:18 | [post] this access | SSA.cs:127:9:127:12 | this access |
 | SSA.cs:124:15:124:18 | this access | SSA.cs:127:9:127:12 | this access |
 | SSA.cs:124:15:124:20 | [post] access to field S | SSA.cs:127:9:127:14 | access to field S |
@@ -925,16 +1019,20 @@
 | SSA.cs:127:9:127:12 | [post] this access | SSA.cs:136:23:136:26 | this access |
 | SSA.cs:127:9:127:12 | this access | SSA.cs:130:13:130:16 | this access |
 | SSA.cs:127:9:127:12 | this access | SSA.cs:136:23:136:26 | this access |
+| SSA.cs:127:9:127:14 | [post] access to field S | SSA.cs:128:13:128:33 | [input] SSA phi read(this.S) |
 | SSA.cs:127:9:127:14 | [post] access to field S | SSA.cs:130:13:130:18 | access to field S |
-| SSA.cs:127:9:127:14 | [post] access to field S | SSA.cs:136:9:136:30 | SSA phi read(this.S) |
+| SSA.cs:127:9:127:14 | access to field S | SSA.cs:128:13:128:33 | [input] SSA phi read(this.S) |
 | SSA.cs:127:9:127:14 | access to field S | SSA.cs:130:13:130:18 | access to field S |
-| SSA.cs:127:9:127:14 | access to field S | SSA.cs:136:9:136:30 | SSA phi read(this.S) |
 | SSA.cs:127:9:127:31 | access to field SsaFieldNonSink0 | SSA.cs:127:9:127:36 | SSA def(this.S.SsaFieldNonSink0) |
-| SSA.cs:127:9:127:36 | SSA def(this.S.SsaFieldNonSink0) | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) |
+| SSA.cs:127:9:127:36 | SSA def(this.S.SsaFieldNonSink0) | SSA.cs:128:13:128:33 | [input] SSA phi(this.S.SsaFieldNonSink0) |
 | SSA.cs:127:35:127:36 | "" | SSA.cs:127:9:127:31 | access to field SsaFieldNonSink0 |
 | SSA.cs:128:13:128:22 | [post] access to parameter nonTainted | SSA.cs:131:17:131:26 | access to parameter nonTainted |
 | SSA.cs:128:13:128:22 | access to parameter nonTainted | SSA.cs:131:17:131:26 | access to parameter nonTainted |
 | SSA.cs:128:13:128:29 | access to property Length | SSA.cs:128:13:128:33 | ... > ... |
+| SSA.cs:128:13:128:33 | [input] SSA def(this.S) | SSA.cs:123:23:123:28 | SSA def(this.S) |
+| SSA.cs:128:13:128:33 | [input] SSA phi read(this.S) | SSA.cs:136:9:136:30 | SSA phi read(this.S) |
+| SSA.cs:128:13:128:33 | [input] SSA phi(this.S.SsaFieldNonSink0) | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) |
+| SSA.cs:128:13:128:33 | [input] SSA qualifier def(this.S.SsaFieldSink1) | SSA.cs:123:23:123:28 | SSA qualifier def(this.S.SsaFieldSink1) |
 | SSA.cs:130:13:130:16 | [post] this access | SSA.cs:132:21:132:24 | this access |
 | SSA.cs:130:13:130:16 | [post] this access | SSA.cs:134:21:134:24 | this access |
 | SSA.cs:130:13:130:16 | this access | SSA.cs:132:21:132:24 | this access |
@@ -948,70 +1046,90 @@
 | SSA.cs:130:13:130:46 | SSA def(this.S.SsaFieldNonSink0) | SSA.cs:134:21:134:43 | access to field SsaFieldNonSink0 |
 | SSA.cs:130:39:130:46 | access to local variable nonSink0 | SSA.cs:130:13:130:35 | access to field SsaFieldNonSink0 |
 | SSA.cs:131:17:131:33 | access to property Length | SSA.cs:131:17:131:37 | ... > ... |
+| SSA.cs:132:17:132:44 | [input] SSA phi read(this.S) | SSA.cs:136:9:136:30 | SSA phi read(this.S) |
+| SSA.cs:132:17:132:44 | [input] SSA phi(this.S.SsaFieldNonSink0) | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) |
 | SSA.cs:132:21:132:24 | [post] this access | SSA.cs:136:23:136:26 | this access |
 | SSA.cs:132:21:132:24 | this access | SSA.cs:136:23:136:26 | this access |
-| SSA.cs:132:21:132:26 | [post] access to field S | SSA.cs:136:9:136:30 | SSA phi read(this.S) |
-| SSA.cs:132:21:132:26 | access to field S | SSA.cs:136:9:136:30 | SSA phi read(this.S) |
-| SSA.cs:132:21:132:43 | [post] access to field SsaFieldNonSink0 | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) |
-| SSA.cs:132:21:132:43 | access to field SsaFieldNonSink0 | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) |
+| SSA.cs:132:21:132:26 | [post] access to field S | SSA.cs:132:17:132:44 | [input] SSA phi read(this.S) |
+| SSA.cs:132:21:132:26 | access to field S | SSA.cs:132:17:132:44 | [input] SSA phi read(this.S) |
+| SSA.cs:132:21:132:43 | [post] access to field SsaFieldNonSink0 | SSA.cs:132:17:132:44 | [input] SSA phi(this.S.SsaFieldNonSink0) |
+| SSA.cs:132:21:132:43 | access to field SsaFieldNonSink0 | SSA.cs:132:17:132:44 | [input] SSA phi(this.S.SsaFieldNonSink0) |
+| SSA.cs:134:17:134:44 | [input] SSA phi read(this.S) | SSA.cs:136:9:136:30 | SSA phi read(this.S) |
+| SSA.cs:134:17:134:44 | [input] SSA phi(this.S.SsaFieldNonSink0) | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) |
 | SSA.cs:134:21:134:24 | [post] this access | SSA.cs:136:23:136:26 | this access |
 | SSA.cs:134:21:134:24 | this access | SSA.cs:136:23:136:26 | this access |
-| SSA.cs:134:21:134:26 | [post] access to field S | SSA.cs:136:9:136:30 | SSA phi read(this.S) |
-| SSA.cs:134:21:134:26 | access to field S | SSA.cs:136:9:136:30 | SSA phi read(this.S) |
-| SSA.cs:134:21:134:43 | [post] access to field SsaFieldNonSink0 | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) |
-| SSA.cs:134:21:134:43 | access to field SsaFieldNonSink0 | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) |
+| SSA.cs:134:21:134:26 | [post] access to field S | SSA.cs:134:17:134:44 | [input] SSA phi read(this.S) |
+| SSA.cs:134:21:134:26 | access to field S | SSA.cs:134:17:134:44 | [input] SSA phi read(this.S) |
+| SSA.cs:134:21:134:43 | [post] access to field SsaFieldNonSink0 | SSA.cs:134:17:134:44 | [input] SSA phi(this.S.SsaFieldNonSink0) |
+| SSA.cs:134:21:134:43 | access to field SsaFieldNonSink0 | SSA.cs:134:17:134:44 | [input] SSA phi(this.S.SsaFieldNonSink0) |
 | SSA.cs:136:9:136:30 | SSA phi read(this.S) | SSA.cs:136:23:136:28 | access to field S |
-| SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) | SSA.cs:136:23:136:28 | SSA qualifier def(this.S.SsaFieldNonSink0) |
+| SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) | SSA.cs:5:17:5:17 | [input] SSA qualifier def(this.S.SsaFieldNonSink0) |
 | SSA.cs:136:23:136:26 | [post] this access | SSA.cs:137:15:137:18 | this access |
 | SSA.cs:136:23:136:26 | this access | SSA.cs:137:15:137:18 | this access |
 | SSA.cs:136:23:136:28 | SSA def(this.S) | SSA.cs:137:15:137:20 | access to field S |
 | SSA.cs:136:23:136:28 | SSA qualifier def(this.S.SsaFieldNonSink0) | SSA.cs:137:15:137:37 | access to field SsaFieldNonSink0 |
-| SSA.cs:136:23:136:28 | [post] access to field S | SSA.cs:136:23:136:28 | SSA def(this.S) |
+| SSA.cs:136:23:136:28 | [post] access to field S | SSA.cs:5:17:5:17 | [input] SSA def(this.S) |
+| SSA.cs:136:23:136:28 | access to field S | SSA.cs:5:17:5:17 | [input] SSA def(this.S) |
 | SSA.cs:136:23:136:28 | access to field S | SSA.cs:136:23:136:28 | SSA def(this.S) |
-| SSA.cs:136:23:136:28 | access to field S | SSA.cs:136:23:136:28 | SSA def(this.S) |
-| SSA.cs:144:34:144:34 | t | SSA.cs:146:13:146:13 | access to parameter t |
+| SSA.cs:144:34:144:34 | SSA param(t) | SSA.cs:146:13:146:13 | access to parameter t |
+| SSA.cs:144:34:144:34 | t | SSA.cs:144:34:144:34 | SSA param(t) |
 | SSA.cs:146:13:146:13 | (...) ... | SSA.cs:146:13:146:21 | ... == ... |
 | SSA.cs:146:13:146:13 | access to parameter t | SSA.cs:146:13:146:13 | (...) ... |
 | SSA.cs:146:13:146:13 | access to parameter t | SSA.cs:149:17:149:17 | access to parameter t |
 | SSA.cs:147:13:147:13 | access to parameter t | SSA.cs:147:13:147:26 | SSA def(t) |
-| SSA.cs:147:13:147:26 | SSA def(t) | SSA.cs:144:17:144:26 | SSA phi(t) |
+| SSA.cs:147:13:147:26 | SSA def(t) | SSA.cs:147:13:147:26 | [input] SSA phi(t) |
+| SSA.cs:147:13:147:26 | [input] SSA phi(t) | SSA.cs:144:17:144:26 | SSA phi(t) |
 | SSA.cs:147:17:147:26 | default(...) | SSA.cs:147:13:147:13 | access to parameter t |
 | SSA.cs:149:13:149:13 | access to parameter t | SSA.cs:149:13:149:17 | SSA def(t) |
-| SSA.cs:149:13:149:17 | SSA def(t) | SSA.cs:144:17:144:26 | SSA phi(t) |
+| SSA.cs:149:13:149:17 | SSA def(t) | SSA.cs:149:13:149:17 | [input] SSA phi(t) |
+| SSA.cs:149:13:149:17 | [input] SSA phi(t) | SSA.cs:144:17:144:26 | SSA phi(t) |
 | SSA.cs:149:17:149:17 | access to parameter t | SSA.cs:149:13:149:13 | access to parameter t |
-| SSA.cs:152:36:152:36 | t | SSA.cs:154:13:154:13 | access to parameter t |
+| SSA.cs:152:36:152:36 | SSA param(t) | SSA.cs:154:13:154:13 | access to parameter t |
+| SSA.cs:152:36:152:36 | t | SSA.cs:152:36:152:36 | SSA param(t) |
 | SSA.cs:154:13:154:13 | (...) ... | SSA.cs:154:13:154:21 | ... == ... |
-| SSA.cs:154:13:154:13 | access to parameter t | SSA.cs:152:17:152:28 | SSA phi(t) |
 | SSA.cs:154:13:154:13 | access to parameter t | SSA.cs:154:13:154:13 | (...) ... |
+| SSA.cs:154:13:154:13 | access to parameter t | SSA.cs:154:13:154:21 | [input] SSA phi(t) |
 | SSA.cs:154:13:154:13 | access to parameter t | SSA.cs:155:25:155:25 | access to parameter t |
-| SSA.cs:155:25:155:25 | SSA def(t) | SSA.cs:152:17:152:28 | SSA phi(t) |
+| SSA.cs:154:13:154:21 | [input] SSA phi(t) | SSA.cs:152:17:152:28 | SSA phi(t) |
+| SSA.cs:155:13:155:26 | [input] SSA phi(t) | SSA.cs:152:17:152:28 | SSA phi(t) |
+| SSA.cs:155:25:155:25 | SSA def(t) | SSA.cs:155:13:155:26 | [input] SSA phi(t) |
 | SSA.cs:155:25:155:25 | access to parameter t | SSA.cs:155:25:155:25 | SSA def(t) |
 | SSA.cs:166:10:166:13 | this | SSA.cs:166:19:166:22 | this access |
 | SSA.cs:166:28:166:31 | null | SSA.cs:166:19:166:24 | access to field S |
-| SSA.cs:168:22:168:28 | tainted | SSA.cs:173:24:173:30 | access to parameter tainted |
-| SSA.cs:168:35:168:35 | i | SSA.cs:171:13:171:13 | access to parameter i |
+| SSA.cs:168:22:168:28 | SSA param(tainted) | SSA.cs:173:24:173:30 | access to parameter tainted |
+| SSA.cs:168:22:168:28 | tainted | SSA.cs:168:22:168:28 | SSA param(tainted) |
+| SSA.cs:168:35:168:35 | SSA param(i) | SSA.cs:171:13:171:13 | access to parameter i |
+| SSA.cs:168:35:168:35 | i | SSA.cs:168:35:168:35 | SSA param(i) |
 | SSA.cs:170:16:170:23 | access to local variable ssaSink5 | SSA.cs:170:16:170:28 | SSA def(ssaSink5) |
-| SSA.cs:170:16:170:28 | SSA def(ssaSink5) | SSA.cs:180:9:180:24 | SSA phi(ssaSink5) |
+| SSA.cs:170:16:170:28 | SSA def(ssaSink5) | SSA.cs:171:13:171:19 | [input] SSA phi(ssaSink5) |
 | SSA.cs:170:27:170:28 | "" | SSA.cs:170:16:170:23 | access to local variable ssaSink5 |
 | SSA.cs:171:13:171:13 | access to parameter i | SSA.cs:171:13:171:15 | SSA def(i) |
 | SSA.cs:171:13:171:15 | ...-- | SSA.cs:171:13:171:19 | ... > ... |
-| SSA.cs:171:13:171:15 | SSA def(i) | SSA.cs:174:20:174:20 | SSA phi(i) |
+| SSA.cs:171:13:171:15 | SSA def(i) | SSA.cs:174:13:178:13 | [input] SSA phi(i) |
+| SSA.cs:171:13:171:19 | [input] SSA phi(ssaSink5) | SSA.cs:180:9:180:24 | SSA phi(ssaSink5) |
 | SSA.cs:173:13:173:20 | access to local variable ssaSink5 | SSA.cs:173:13:173:30 | SSA def(ssaSink5) |
-| SSA.cs:173:13:173:30 | SSA def(ssaSink5) | SSA.cs:174:20:174:20 | SSA phi read(ssaSink5) |
+| SSA.cs:173:13:173:30 | SSA def(ssaSink5) | SSA.cs:174:13:178:13 | [input] SSA phi read(ssaSink5) |
 | SSA.cs:173:24:173:30 | access to parameter tainted | SSA.cs:173:13:173:20 | access to local variable ssaSink5 |
+| SSA.cs:174:13:178:13 | [input] SSA phi read(ssaSink5) | SSA.cs:174:20:174:20 | SSA phi read(ssaSink5) |
+| SSA.cs:174:13:178:13 | [input] SSA phi(i) | SSA.cs:174:20:174:20 | SSA phi(i) |
+| SSA.cs:174:20:174:20 | SSA phi read(ssaSink5) | SSA.cs:174:20:174:26 | [input] SSA phi(ssaSink5) |
 | SSA.cs:174:20:174:20 | SSA phi read(ssaSink5) | SSA.cs:176:21:176:28 | access to local variable ssaSink5 |
-| SSA.cs:174:20:174:20 | SSA phi read(ssaSink5) | SSA.cs:180:9:180:24 | SSA phi(ssaSink5) |
 | SSA.cs:174:20:174:20 | SSA phi(i) | SSA.cs:174:20:174:20 | access to parameter i |
 | SSA.cs:174:20:174:20 | access to parameter i | SSA.cs:174:20:174:22 | SSA def(i) |
 | SSA.cs:174:20:174:22 | ...-- | SSA.cs:174:20:174:26 | ... > ... |
-| SSA.cs:174:20:174:22 | SSA def(i) | SSA.cs:174:20:174:20 | SSA phi(i) |
+| SSA.cs:174:20:174:22 | SSA def(i) | SSA.cs:177:17:177:29 | [input] SSA phi(i) |
+| SSA.cs:174:20:174:26 | [input] SSA phi(ssaSink5) | SSA.cs:180:9:180:24 | SSA phi(ssaSink5) |
 | SSA.cs:176:21:176:28 | [post] access to local variable ssaSink5 | SSA.cs:177:21:177:28 | access to local variable ssaSink5 |
 | SSA.cs:176:21:176:28 | access to local variable ssaSink5 | SSA.cs:177:21:177:28 | access to local variable ssaSink5 |
-| SSA.cs:177:21:177:28 | [post] access to local variable ssaSink5 | SSA.cs:174:20:174:20 | SSA phi read(ssaSink5) |
-| SSA.cs:177:21:177:28 | access to local variable ssaSink5 | SSA.cs:174:20:174:20 | SSA phi read(ssaSink5) |
+| SSA.cs:177:17:177:29 | [input] SSA phi read(ssaSink5) | SSA.cs:174:20:174:20 | SSA phi read(ssaSink5) |
+| SSA.cs:177:17:177:29 | [input] SSA phi(i) | SSA.cs:174:20:174:20 | SSA phi(i) |
+| SSA.cs:177:21:177:28 | [post] access to local variable ssaSink5 | SSA.cs:177:17:177:29 | [input] SSA phi read(ssaSink5) |
+| SSA.cs:177:21:177:28 | access to local variable ssaSink5 | SSA.cs:177:17:177:29 | [input] SSA phi read(ssaSink5) |
 | SSA.cs:180:9:180:24 | SSA phi(ssaSink5) | SSA.cs:180:15:180:22 | access to local variable ssaSink5 |
-| Splitting.cs:3:18:3:18 | b | Splitting.cs:6:13:6:13 | access to parameter b |
-| Splitting.cs:3:28:3:34 | tainted | Splitting.cs:5:17:5:23 | access to parameter tainted |
+| Splitting.cs:3:18:3:18 | SSA param(b) | Splitting.cs:6:13:6:13 | access to parameter b |
+| Splitting.cs:3:18:3:18 | b | Splitting.cs:3:18:3:18 | SSA param(b) |
+| Splitting.cs:3:28:3:34 | SSA param(tainted) | Splitting.cs:5:17:5:23 | access to parameter tainted |
+| Splitting.cs:3:28:3:34 | tainted | Splitting.cs:3:28:3:34 | SSA param(tainted) |
 | Splitting.cs:5:13:5:13 | access to local variable x | Splitting.cs:5:13:5:23 | SSA def(x) |
 | Splitting.cs:5:13:5:23 | SSA def(x) | Splitting.cs:8:19:8:19 | [b (line 3): true] access to local variable x |
 | Splitting.cs:5:13:5:23 | SSA def(x) | Splitting.cs:12:15:12:15 | [b (line 3): false] access to local variable x |
@@ -1024,7 +1142,8 @@
 | Splitting.cs:9:17:9:17 | [b (line 3): true] access to local variable x | Splitting.cs:12:15:12:15 | [b (line 3): true] access to local variable x |
 | Splitting.cs:12:15:12:15 | [b (line 3): true] access to local variable x | Splitting.cs:14:19:14:19 | access to local variable x |
 | Splitting.cs:12:15:12:15 | [post] [b (line 3): true] access to local variable x | Splitting.cs:14:19:14:19 | access to local variable x |
-| Splitting.cs:17:18:17:18 | b | Splitting.cs:20:13:20:13 | access to parameter b |
+| Splitting.cs:17:18:17:18 | SSA param(b) | Splitting.cs:20:13:20:13 | access to parameter b |
+| Splitting.cs:17:18:17:18 | b | Splitting.cs:17:18:17:18 | SSA param(b) |
 | Splitting.cs:19:13:19:13 | access to local variable x | Splitting.cs:19:13:19:18 | SSA def(x) |
 | Splitting.cs:19:13:19:18 | SSA def(x) | Splitting.cs:22:19:22:19 | [b (line 17): true] access to local variable x |
 | Splitting.cs:19:13:19:18 | SSA def(x) | Splitting.cs:25:15:25:15 | [b (line 17): false] access to local variable x |
@@ -1038,7 +1157,8 @@
 | Splitting.cs:25:15:25:15 | [b (line 17): true] access to local variable x | Splitting.cs:27:19:27:19 | access to local variable x |
 | Splitting.cs:25:15:25:15 | [post] [b (line 17): false] access to local variable x | Splitting.cs:29:19:29:19 | access to local variable x |
 | Splitting.cs:25:15:25:15 | [post] [b (line 17): true] access to local variable x | Splitting.cs:27:19:27:19 | access to local variable x |
-| Splitting.cs:32:18:32:18 | b | Splitting.cs:35:13:35:13 | access to parameter b |
+| Splitting.cs:32:18:32:18 | SSA param(b) | Splitting.cs:35:13:35:13 | access to parameter b |
+| Splitting.cs:32:18:32:18 | b | Splitting.cs:32:18:32:18 | SSA param(b) |
 | Splitting.cs:34:17:34:18 | "" | Splitting.cs:34:13:34:13 | access to local variable x |
 | Splitting.cs:35:13:35:13 | access to parameter b | Splitting.cs:39:15:39:15 | [b (line 32): false] access to parameter b |
 | Splitting.cs:35:13:35:13 | access to parameter b | Splitting.cs:39:15:39:15 | [b (line 32): true] access to parameter b |
@@ -1065,7 +1185,8 @@
 | Splitting.cs:41:19:41:21 | [b (line 32): false] "d" | Splitting.cs:41:15:41:21 | [b (line 32): false] ... = ... |
 | Splitting.cs:41:19:41:21 | [b (line 32): true] "d" | Splitting.cs:41:15:41:15 | access to local variable x |
 | Splitting.cs:41:19:41:21 | [b (line 32): true] "d" | Splitting.cs:41:15:41:21 | [b (line 32): true] ... = ... |
-| Splitting.cs:46:18:46:18 | b | Splitting.cs:49:13:49:13 | access to parameter b |
+| Splitting.cs:46:18:46:18 | SSA param(b) | Splitting.cs:49:13:49:13 | access to parameter b |
+| Splitting.cs:46:18:46:18 | b | Splitting.cs:46:18:46:18 | SSA param(b) |
 | Splitting.cs:48:13:48:13 | access to local variable x | Splitting.cs:48:13:48:18 | SSA def(x) |
 | Splitting.cs:48:13:48:18 | SSA def(x) | Splitting.cs:53:13:53:13 | [b (line 46): false] access to local variable x |
 | Splitting.cs:48:17:48:18 | "" | Splitting.cs:48:13:48:13 | access to local variable x |
@@ -1143,6 +1264,7 @@
 | UseUseExplosion.cs:21:10:21:10 | SSA entry def(this.Prop) | UseUseExplosion.cs:24:13:24:16 | access to property Prop |
 | UseUseExplosion.cs:21:10:21:10 | this | UseUseExplosion.cs:24:13:24:16 | this access |
 | UseUseExplosion.cs:23:13:23:13 | access to local variable x | UseUseExplosion.cs:23:13:23:17 | SSA def(x) |
+| UseUseExplosion.cs:23:13:23:17 | SSA def(x) | UseUseExplosion.cs:24:1699:24:1701 | [input] SSA phi read(x) |
 | UseUseExplosion.cs:23:13:23:17 | SSA def(x) | UseUseExplosion.cs:24:1712:24:1712 | access to local variable x |
 | UseUseExplosion.cs:23:13:23:17 | SSA def(x) | UseUseExplosion.cs:24:1727:24:1727 | access to local variable x |
 | UseUseExplosion.cs:23:13:23:17 | SSA def(x) | UseUseExplosion.cs:24:1742:24:1742 | access to local variable x |
@@ -1243,1007 +1365,1209 @@
 | UseUseExplosion.cs:23:13:23:17 | SSA def(x) | UseUseExplosion.cs:24:3167:24:3167 | access to local variable x |
 | UseUseExplosion.cs:23:13:23:17 | SSA def(x) | UseUseExplosion.cs:24:3182:24:3182 | access to local variable x |
 | UseUseExplosion.cs:23:13:23:17 | SSA def(x) | UseUseExplosion.cs:24:3197:24:3197 | access to local variable x |
-| UseUseExplosion.cs:23:13:23:17 | SSA def(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:23:17:23:17 | 0 | UseUseExplosion.cs:23:13:23:13 | access to local variable x |
 | UseUseExplosion.cs:24:13:24:16 | [post] this access | UseUseExplosion.cs:24:31:24:34 | this access |
 | UseUseExplosion.cs:24:13:24:16 | [post] this access | UseUseExplosion.cs:24:3193:24:3198 | this access |
 | UseUseExplosion.cs:24:13:24:16 | access to property Prop | UseUseExplosion.cs:24:13:24:22 | ... > ... |
 | UseUseExplosion.cs:24:13:24:16 | access to property Prop | UseUseExplosion.cs:24:31:24:34 | access to property Prop |
-| UseUseExplosion.cs:24:13:24:16 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:13:24:16 | access to property Prop | UseUseExplosion.cs:24:3193:24:3198 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:13:24:16 | this access | UseUseExplosion.cs:24:31:24:34 | this access |
 | UseUseExplosion.cs:24:13:24:16 | this access | UseUseExplosion.cs:24:3193:24:3198 | this access |
 | UseUseExplosion.cs:24:31:24:34 | [post] this access | UseUseExplosion.cs:24:48:24:51 | this access |
 | UseUseExplosion.cs:24:31:24:34 | [post] this access | UseUseExplosion.cs:24:3178:24:3183 | this access |
 | UseUseExplosion.cs:24:31:24:34 | access to property Prop | UseUseExplosion.cs:24:31:24:39 | ... > ... |
 | UseUseExplosion.cs:24:31:24:34 | access to property Prop | UseUseExplosion.cs:24:48:24:51 | access to property Prop |
-| UseUseExplosion.cs:24:31:24:34 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:31:24:34 | access to property Prop | UseUseExplosion.cs:24:3178:24:3183 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:31:24:34 | this access | UseUseExplosion.cs:24:48:24:51 | this access |
 | UseUseExplosion.cs:24:31:24:34 | this access | UseUseExplosion.cs:24:3178:24:3183 | this access |
 | UseUseExplosion.cs:24:48:24:51 | [post] this access | UseUseExplosion.cs:24:65:24:68 | this access |
 | UseUseExplosion.cs:24:48:24:51 | [post] this access | UseUseExplosion.cs:24:3163:24:3168 | this access |
 | UseUseExplosion.cs:24:48:24:51 | access to property Prop | UseUseExplosion.cs:24:48:24:56 | ... > ... |
 | UseUseExplosion.cs:24:48:24:51 | access to property Prop | UseUseExplosion.cs:24:65:24:68 | access to property Prop |
-| UseUseExplosion.cs:24:48:24:51 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:48:24:51 | access to property Prop | UseUseExplosion.cs:24:3163:24:3168 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:48:24:51 | this access | UseUseExplosion.cs:24:65:24:68 | this access |
 | UseUseExplosion.cs:24:48:24:51 | this access | UseUseExplosion.cs:24:3163:24:3168 | this access |
 | UseUseExplosion.cs:24:65:24:68 | [post] this access | UseUseExplosion.cs:24:82:24:85 | this access |
 | UseUseExplosion.cs:24:65:24:68 | [post] this access | UseUseExplosion.cs:24:3148:24:3153 | this access |
 | UseUseExplosion.cs:24:65:24:68 | access to property Prop | UseUseExplosion.cs:24:65:24:73 | ... > ... |
 | UseUseExplosion.cs:24:65:24:68 | access to property Prop | UseUseExplosion.cs:24:82:24:85 | access to property Prop |
-| UseUseExplosion.cs:24:65:24:68 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:65:24:68 | access to property Prop | UseUseExplosion.cs:24:3148:24:3153 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:65:24:68 | this access | UseUseExplosion.cs:24:82:24:85 | this access |
 | UseUseExplosion.cs:24:65:24:68 | this access | UseUseExplosion.cs:24:3148:24:3153 | this access |
 | UseUseExplosion.cs:24:82:24:85 | [post] this access | UseUseExplosion.cs:24:99:24:102 | this access |
 | UseUseExplosion.cs:24:82:24:85 | [post] this access | UseUseExplosion.cs:24:3133:24:3138 | this access |
 | UseUseExplosion.cs:24:82:24:85 | access to property Prop | UseUseExplosion.cs:24:82:24:90 | ... > ... |
 | UseUseExplosion.cs:24:82:24:85 | access to property Prop | UseUseExplosion.cs:24:99:24:102 | access to property Prop |
-| UseUseExplosion.cs:24:82:24:85 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:82:24:85 | access to property Prop | UseUseExplosion.cs:24:3133:24:3138 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:82:24:85 | this access | UseUseExplosion.cs:24:99:24:102 | this access |
 | UseUseExplosion.cs:24:82:24:85 | this access | UseUseExplosion.cs:24:3133:24:3138 | this access |
 | UseUseExplosion.cs:24:99:24:102 | [post] this access | UseUseExplosion.cs:24:116:24:119 | this access |
 | UseUseExplosion.cs:24:99:24:102 | [post] this access | UseUseExplosion.cs:24:3118:24:3123 | this access |
 | UseUseExplosion.cs:24:99:24:102 | access to property Prop | UseUseExplosion.cs:24:99:24:107 | ... > ... |
 | UseUseExplosion.cs:24:99:24:102 | access to property Prop | UseUseExplosion.cs:24:116:24:119 | access to property Prop |
-| UseUseExplosion.cs:24:99:24:102 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:99:24:102 | access to property Prop | UseUseExplosion.cs:24:3118:24:3123 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:99:24:102 | this access | UseUseExplosion.cs:24:116:24:119 | this access |
 | UseUseExplosion.cs:24:99:24:102 | this access | UseUseExplosion.cs:24:3118:24:3123 | this access |
 | UseUseExplosion.cs:24:116:24:119 | [post] this access | UseUseExplosion.cs:24:133:24:136 | this access |
 | UseUseExplosion.cs:24:116:24:119 | [post] this access | UseUseExplosion.cs:24:3103:24:3108 | this access |
 | UseUseExplosion.cs:24:116:24:119 | access to property Prop | UseUseExplosion.cs:24:116:24:124 | ... > ... |
 | UseUseExplosion.cs:24:116:24:119 | access to property Prop | UseUseExplosion.cs:24:133:24:136 | access to property Prop |
-| UseUseExplosion.cs:24:116:24:119 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:116:24:119 | access to property Prop | UseUseExplosion.cs:24:3103:24:3108 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:116:24:119 | this access | UseUseExplosion.cs:24:133:24:136 | this access |
 | UseUseExplosion.cs:24:116:24:119 | this access | UseUseExplosion.cs:24:3103:24:3108 | this access |
 | UseUseExplosion.cs:24:133:24:136 | [post] this access | UseUseExplosion.cs:24:150:24:153 | this access |
 | UseUseExplosion.cs:24:133:24:136 | [post] this access | UseUseExplosion.cs:24:3088:24:3093 | this access |
 | UseUseExplosion.cs:24:133:24:136 | access to property Prop | UseUseExplosion.cs:24:133:24:141 | ... > ... |
 | UseUseExplosion.cs:24:133:24:136 | access to property Prop | UseUseExplosion.cs:24:150:24:153 | access to property Prop |
-| UseUseExplosion.cs:24:133:24:136 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:133:24:136 | access to property Prop | UseUseExplosion.cs:24:3088:24:3093 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:133:24:136 | this access | UseUseExplosion.cs:24:150:24:153 | this access |
 | UseUseExplosion.cs:24:133:24:136 | this access | UseUseExplosion.cs:24:3088:24:3093 | this access |
 | UseUseExplosion.cs:24:150:24:153 | [post] this access | UseUseExplosion.cs:24:167:24:170 | this access |
 | UseUseExplosion.cs:24:150:24:153 | [post] this access | UseUseExplosion.cs:24:3073:24:3078 | this access |
 | UseUseExplosion.cs:24:150:24:153 | access to property Prop | UseUseExplosion.cs:24:150:24:158 | ... > ... |
 | UseUseExplosion.cs:24:150:24:153 | access to property Prop | UseUseExplosion.cs:24:167:24:170 | access to property Prop |
-| UseUseExplosion.cs:24:150:24:153 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:150:24:153 | access to property Prop | UseUseExplosion.cs:24:3073:24:3078 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:150:24:153 | this access | UseUseExplosion.cs:24:167:24:170 | this access |
 | UseUseExplosion.cs:24:150:24:153 | this access | UseUseExplosion.cs:24:3073:24:3078 | this access |
 | UseUseExplosion.cs:24:167:24:170 | [post] this access | UseUseExplosion.cs:24:184:24:187 | this access |
 | UseUseExplosion.cs:24:167:24:170 | [post] this access | UseUseExplosion.cs:24:3058:24:3063 | this access |
 | UseUseExplosion.cs:24:167:24:170 | access to property Prop | UseUseExplosion.cs:24:167:24:175 | ... > ... |
 | UseUseExplosion.cs:24:167:24:170 | access to property Prop | UseUseExplosion.cs:24:184:24:187 | access to property Prop |
-| UseUseExplosion.cs:24:167:24:170 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:167:24:170 | access to property Prop | UseUseExplosion.cs:24:3058:24:3063 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:167:24:170 | this access | UseUseExplosion.cs:24:184:24:187 | this access |
 | UseUseExplosion.cs:24:167:24:170 | this access | UseUseExplosion.cs:24:3058:24:3063 | this access |
 | UseUseExplosion.cs:24:184:24:187 | [post] this access | UseUseExplosion.cs:24:201:24:204 | this access |
 | UseUseExplosion.cs:24:184:24:187 | [post] this access | UseUseExplosion.cs:24:3043:24:3048 | this access |
 | UseUseExplosion.cs:24:184:24:187 | access to property Prop | UseUseExplosion.cs:24:184:24:192 | ... > ... |
 | UseUseExplosion.cs:24:184:24:187 | access to property Prop | UseUseExplosion.cs:24:201:24:204 | access to property Prop |
-| UseUseExplosion.cs:24:184:24:187 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:184:24:187 | access to property Prop | UseUseExplosion.cs:24:3043:24:3048 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:184:24:187 | this access | UseUseExplosion.cs:24:201:24:204 | this access |
 | UseUseExplosion.cs:24:184:24:187 | this access | UseUseExplosion.cs:24:3043:24:3048 | this access |
 | UseUseExplosion.cs:24:201:24:204 | [post] this access | UseUseExplosion.cs:24:218:24:221 | this access |
 | UseUseExplosion.cs:24:201:24:204 | [post] this access | UseUseExplosion.cs:24:3028:24:3033 | this access |
 | UseUseExplosion.cs:24:201:24:204 | access to property Prop | UseUseExplosion.cs:24:201:24:209 | ... > ... |
 | UseUseExplosion.cs:24:201:24:204 | access to property Prop | UseUseExplosion.cs:24:218:24:221 | access to property Prop |
-| UseUseExplosion.cs:24:201:24:204 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:201:24:204 | access to property Prop | UseUseExplosion.cs:24:3028:24:3033 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:201:24:204 | this access | UseUseExplosion.cs:24:218:24:221 | this access |
 | UseUseExplosion.cs:24:201:24:204 | this access | UseUseExplosion.cs:24:3028:24:3033 | this access |
 | UseUseExplosion.cs:24:218:24:221 | [post] this access | UseUseExplosion.cs:24:235:24:238 | this access |
 | UseUseExplosion.cs:24:218:24:221 | [post] this access | UseUseExplosion.cs:24:3013:24:3018 | this access |
 | UseUseExplosion.cs:24:218:24:221 | access to property Prop | UseUseExplosion.cs:24:218:24:226 | ... > ... |
 | UseUseExplosion.cs:24:218:24:221 | access to property Prop | UseUseExplosion.cs:24:235:24:238 | access to property Prop |
-| UseUseExplosion.cs:24:218:24:221 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:218:24:221 | access to property Prop | UseUseExplosion.cs:24:3013:24:3018 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:218:24:221 | this access | UseUseExplosion.cs:24:235:24:238 | this access |
 | UseUseExplosion.cs:24:218:24:221 | this access | UseUseExplosion.cs:24:3013:24:3018 | this access |
 | UseUseExplosion.cs:24:235:24:238 | [post] this access | UseUseExplosion.cs:24:252:24:255 | this access |
 | UseUseExplosion.cs:24:235:24:238 | [post] this access | UseUseExplosion.cs:24:2998:24:3003 | this access |
 | UseUseExplosion.cs:24:235:24:238 | access to property Prop | UseUseExplosion.cs:24:235:24:243 | ... > ... |
 | UseUseExplosion.cs:24:235:24:238 | access to property Prop | UseUseExplosion.cs:24:252:24:255 | access to property Prop |
-| UseUseExplosion.cs:24:235:24:238 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:235:24:238 | access to property Prop | UseUseExplosion.cs:24:2998:24:3003 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:235:24:238 | this access | UseUseExplosion.cs:24:252:24:255 | this access |
 | UseUseExplosion.cs:24:235:24:238 | this access | UseUseExplosion.cs:24:2998:24:3003 | this access |
 | UseUseExplosion.cs:24:252:24:255 | [post] this access | UseUseExplosion.cs:24:269:24:272 | this access |
 | UseUseExplosion.cs:24:252:24:255 | [post] this access | UseUseExplosion.cs:24:2983:24:2988 | this access |
 | UseUseExplosion.cs:24:252:24:255 | access to property Prop | UseUseExplosion.cs:24:252:24:260 | ... > ... |
 | UseUseExplosion.cs:24:252:24:255 | access to property Prop | UseUseExplosion.cs:24:269:24:272 | access to property Prop |
-| UseUseExplosion.cs:24:252:24:255 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:252:24:255 | access to property Prop | UseUseExplosion.cs:24:2983:24:2988 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:252:24:255 | this access | UseUseExplosion.cs:24:269:24:272 | this access |
 | UseUseExplosion.cs:24:252:24:255 | this access | UseUseExplosion.cs:24:2983:24:2988 | this access |
 | UseUseExplosion.cs:24:269:24:272 | [post] this access | UseUseExplosion.cs:24:286:24:289 | this access |
 | UseUseExplosion.cs:24:269:24:272 | [post] this access | UseUseExplosion.cs:24:2968:24:2973 | this access |
 | UseUseExplosion.cs:24:269:24:272 | access to property Prop | UseUseExplosion.cs:24:269:24:277 | ... > ... |
 | UseUseExplosion.cs:24:269:24:272 | access to property Prop | UseUseExplosion.cs:24:286:24:289 | access to property Prop |
-| UseUseExplosion.cs:24:269:24:272 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:269:24:272 | access to property Prop | UseUseExplosion.cs:24:2968:24:2973 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:269:24:272 | this access | UseUseExplosion.cs:24:286:24:289 | this access |
 | UseUseExplosion.cs:24:269:24:272 | this access | UseUseExplosion.cs:24:2968:24:2973 | this access |
 | UseUseExplosion.cs:24:286:24:289 | [post] this access | UseUseExplosion.cs:24:303:24:306 | this access |
 | UseUseExplosion.cs:24:286:24:289 | [post] this access | UseUseExplosion.cs:24:2953:24:2958 | this access |
 | UseUseExplosion.cs:24:286:24:289 | access to property Prop | UseUseExplosion.cs:24:286:24:294 | ... > ... |
 | UseUseExplosion.cs:24:286:24:289 | access to property Prop | UseUseExplosion.cs:24:303:24:306 | access to property Prop |
-| UseUseExplosion.cs:24:286:24:289 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:286:24:289 | access to property Prop | UseUseExplosion.cs:24:2953:24:2958 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:286:24:289 | this access | UseUseExplosion.cs:24:303:24:306 | this access |
 | UseUseExplosion.cs:24:286:24:289 | this access | UseUseExplosion.cs:24:2953:24:2958 | this access |
 | UseUseExplosion.cs:24:303:24:306 | [post] this access | UseUseExplosion.cs:24:320:24:323 | this access |
 | UseUseExplosion.cs:24:303:24:306 | [post] this access | UseUseExplosion.cs:24:2938:24:2943 | this access |
 | UseUseExplosion.cs:24:303:24:306 | access to property Prop | UseUseExplosion.cs:24:303:24:311 | ... > ... |
 | UseUseExplosion.cs:24:303:24:306 | access to property Prop | UseUseExplosion.cs:24:320:24:323 | access to property Prop |
-| UseUseExplosion.cs:24:303:24:306 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:303:24:306 | access to property Prop | UseUseExplosion.cs:24:2938:24:2943 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:303:24:306 | this access | UseUseExplosion.cs:24:320:24:323 | this access |
 | UseUseExplosion.cs:24:303:24:306 | this access | UseUseExplosion.cs:24:2938:24:2943 | this access |
 | UseUseExplosion.cs:24:320:24:323 | [post] this access | UseUseExplosion.cs:24:337:24:340 | this access |
 | UseUseExplosion.cs:24:320:24:323 | [post] this access | UseUseExplosion.cs:24:2923:24:2928 | this access |
 | UseUseExplosion.cs:24:320:24:323 | access to property Prop | UseUseExplosion.cs:24:320:24:328 | ... > ... |
 | UseUseExplosion.cs:24:320:24:323 | access to property Prop | UseUseExplosion.cs:24:337:24:340 | access to property Prop |
-| UseUseExplosion.cs:24:320:24:323 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:320:24:323 | access to property Prop | UseUseExplosion.cs:24:2923:24:2928 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:320:24:323 | this access | UseUseExplosion.cs:24:337:24:340 | this access |
 | UseUseExplosion.cs:24:320:24:323 | this access | UseUseExplosion.cs:24:2923:24:2928 | this access |
 | UseUseExplosion.cs:24:337:24:340 | [post] this access | UseUseExplosion.cs:24:354:24:357 | this access |
 | UseUseExplosion.cs:24:337:24:340 | [post] this access | UseUseExplosion.cs:24:2908:24:2913 | this access |
 | UseUseExplosion.cs:24:337:24:340 | access to property Prop | UseUseExplosion.cs:24:337:24:345 | ... > ... |
 | UseUseExplosion.cs:24:337:24:340 | access to property Prop | UseUseExplosion.cs:24:354:24:357 | access to property Prop |
-| UseUseExplosion.cs:24:337:24:340 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:337:24:340 | access to property Prop | UseUseExplosion.cs:24:2908:24:2913 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:337:24:340 | this access | UseUseExplosion.cs:24:354:24:357 | this access |
 | UseUseExplosion.cs:24:337:24:340 | this access | UseUseExplosion.cs:24:2908:24:2913 | this access |
 | UseUseExplosion.cs:24:354:24:357 | [post] this access | UseUseExplosion.cs:24:371:24:374 | this access |
 | UseUseExplosion.cs:24:354:24:357 | [post] this access | UseUseExplosion.cs:24:2893:24:2898 | this access |
 | UseUseExplosion.cs:24:354:24:357 | access to property Prop | UseUseExplosion.cs:24:354:24:362 | ... > ... |
 | UseUseExplosion.cs:24:354:24:357 | access to property Prop | UseUseExplosion.cs:24:371:24:374 | access to property Prop |
-| UseUseExplosion.cs:24:354:24:357 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:354:24:357 | access to property Prop | UseUseExplosion.cs:24:2893:24:2898 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:354:24:357 | this access | UseUseExplosion.cs:24:371:24:374 | this access |
 | UseUseExplosion.cs:24:354:24:357 | this access | UseUseExplosion.cs:24:2893:24:2898 | this access |
 | UseUseExplosion.cs:24:371:24:374 | [post] this access | UseUseExplosion.cs:24:388:24:391 | this access |
 | UseUseExplosion.cs:24:371:24:374 | [post] this access | UseUseExplosion.cs:24:2878:24:2883 | this access |
 | UseUseExplosion.cs:24:371:24:374 | access to property Prop | UseUseExplosion.cs:24:371:24:379 | ... > ... |
 | UseUseExplosion.cs:24:371:24:374 | access to property Prop | UseUseExplosion.cs:24:388:24:391 | access to property Prop |
-| UseUseExplosion.cs:24:371:24:374 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:371:24:374 | access to property Prop | UseUseExplosion.cs:24:2878:24:2883 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:371:24:374 | this access | UseUseExplosion.cs:24:388:24:391 | this access |
 | UseUseExplosion.cs:24:371:24:374 | this access | UseUseExplosion.cs:24:2878:24:2883 | this access |
 | UseUseExplosion.cs:24:388:24:391 | [post] this access | UseUseExplosion.cs:24:405:24:408 | this access |
 | UseUseExplosion.cs:24:388:24:391 | [post] this access | UseUseExplosion.cs:24:2863:24:2868 | this access |
 | UseUseExplosion.cs:24:388:24:391 | access to property Prop | UseUseExplosion.cs:24:388:24:396 | ... > ... |
 | UseUseExplosion.cs:24:388:24:391 | access to property Prop | UseUseExplosion.cs:24:405:24:408 | access to property Prop |
-| UseUseExplosion.cs:24:388:24:391 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:388:24:391 | access to property Prop | UseUseExplosion.cs:24:2863:24:2868 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:388:24:391 | this access | UseUseExplosion.cs:24:405:24:408 | this access |
 | UseUseExplosion.cs:24:388:24:391 | this access | UseUseExplosion.cs:24:2863:24:2868 | this access |
 | UseUseExplosion.cs:24:405:24:408 | [post] this access | UseUseExplosion.cs:24:422:24:425 | this access |
 | UseUseExplosion.cs:24:405:24:408 | [post] this access | UseUseExplosion.cs:24:2848:24:2853 | this access |
 | UseUseExplosion.cs:24:405:24:408 | access to property Prop | UseUseExplosion.cs:24:405:24:413 | ... > ... |
 | UseUseExplosion.cs:24:405:24:408 | access to property Prop | UseUseExplosion.cs:24:422:24:425 | access to property Prop |
-| UseUseExplosion.cs:24:405:24:408 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:405:24:408 | access to property Prop | UseUseExplosion.cs:24:2848:24:2853 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:405:24:408 | this access | UseUseExplosion.cs:24:422:24:425 | this access |
 | UseUseExplosion.cs:24:405:24:408 | this access | UseUseExplosion.cs:24:2848:24:2853 | this access |
 | UseUseExplosion.cs:24:422:24:425 | [post] this access | UseUseExplosion.cs:24:439:24:442 | this access |
 | UseUseExplosion.cs:24:422:24:425 | [post] this access | UseUseExplosion.cs:24:2833:24:2838 | this access |
 | UseUseExplosion.cs:24:422:24:425 | access to property Prop | UseUseExplosion.cs:24:422:24:430 | ... > ... |
 | UseUseExplosion.cs:24:422:24:425 | access to property Prop | UseUseExplosion.cs:24:439:24:442 | access to property Prop |
-| UseUseExplosion.cs:24:422:24:425 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:422:24:425 | access to property Prop | UseUseExplosion.cs:24:2833:24:2838 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:422:24:425 | this access | UseUseExplosion.cs:24:439:24:442 | this access |
 | UseUseExplosion.cs:24:422:24:425 | this access | UseUseExplosion.cs:24:2833:24:2838 | this access |
 | UseUseExplosion.cs:24:439:24:442 | [post] this access | UseUseExplosion.cs:24:456:24:459 | this access |
 | UseUseExplosion.cs:24:439:24:442 | [post] this access | UseUseExplosion.cs:24:2818:24:2823 | this access |
 | UseUseExplosion.cs:24:439:24:442 | access to property Prop | UseUseExplosion.cs:24:439:24:447 | ... > ... |
 | UseUseExplosion.cs:24:439:24:442 | access to property Prop | UseUseExplosion.cs:24:456:24:459 | access to property Prop |
-| UseUseExplosion.cs:24:439:24:442 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:439:24:442 | access to property Prop | UseUseExplosion.cs:24:2818:24:2823 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:439:24:442 | this access | UseUseExplosion.cs:24:456:24:459 | this access |
 | UseUseExplosion.cs:24:439:24:442 | this access | UseUseExplosion.cs:24:2818:24:2823 | this access |
 | UseUseExplosion.cs:24:456:24:459 | [post] this access | UseUseExplosion.cs:24:473:24:476 | this access |
 | UseUseExplosion.cs:24:456:24:459 | [post] this access | UseUseExplosion.cs:24:2803:24:2808 | this access |
 | UseUseExplosion.cs:24:456:24:459 | access to property Prop | UseUseExplosion.cs:24:456:24:464 | ... > ... |
 | UseUseExplosion.cs:24:456:24:459 | access to property Prop | UseUseExplosion.cs:24:473:24:476 | access to property Prop |
-| UseUseExplosion.cs:24:456:24:459 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:456:24:459 | access to property Prop | UseUseExplosion.cs:24:2803:24:2808 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:456:24:459 | this access | UseUseExplosion.cs:24:473:24:476 | this access |
 | UseUseExplosion.cs:24:456:24:459 | this access | UseUseExplosion.cs:24:2803:24:2808 | this access |
 | UseUseExplosion.cs:24:473:24:476 | [post] this access | UseUseExplosion.cs:24:490:24:493 | this access |
 | UseUseExplosion.cs:24:473:24:476 | [post] this access | UseUseExplosion.cs:24:2788:24:2793 | this access |
 | UseUseExplosion.cs:24:473:24:476 | access to property Prop | UseUseExplosion.cs:24:473:24:481 | ... > ... |
 | UseUseExplosion.cs:24:473:24:476 | access to property Prop | UseUseExplosion.cs:24:490:24:493 | access to property Prop |
-| UseUseExplosion.cs:24:473:24:476 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:473:24:476 | access to property Prop | UseUseExplosion.cs:24:2788:24:2793 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:473:24:476 | this access | UseUseExplosion.cs:24:490:24:493 | this access |
 | UseUseExplosion.cs:24:473:24:476 | this access | UseUseExplosion.cs:24:2788:24:2793 | this access |
 | UseUseExplosion.cs:24:490:24:493 | [post] this access | UseUseExplosion.cs:24:507:24:510 | this access |
 | UseUseExplosion.cs:24:490:24:493 | [post] this access | UseUseExplosion.cs:24:2773:24:2778 | this access |
 | UseUseExplosion.cs:24:490:24:493 | access to property Prop | UseUseExplosion.cs:24:490:24:498 | ... > ... |
 | UseUseExplosion.cs:24:490:24:493 | access to property Prop | UseUseExplosion.cs:24:507:24:510 | access to property Prop |
-| UseUseExplosion.cs:24:490:24:493 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:490:24:493 | access to property Prop | UseUseExplosion.cs:24:2773:24:2778 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:490:24:493 | this access | UseUseExplosion.cs:24:507:24:510 | this access |
 | UseUseExplosion.cs:24:490:24:493 | this access | UseUseExplosion.cs:24:2773:24:2778 | this access |
 | UseUseExplosion.cs:24:507:24:510 | [post] this access | UseUseExplosion.cs:24:524:24:527 | this access |
 | UseUseExplosion.cs:24:507:24:510 | [post] this access | UseUseExplosion.cs:24:2758:24:2763 | this access |
 | UseUseExplosion.cs:24:507:24:510 | access to property Prop | UseUseExplosion.cs:24:507:24:515 | ... > ... |
 | UseUseExplosion.cs:24:507:24:510 | access to property Prop | UseUseExplosion.cs:24:524:24:527 | access to property Prop |
-| UseUseExplosion.cs:24:507:24:510 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:507:24:510 | access to property Prop | UseUseExplosion.cs:24:2758:24:2763 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:507:24:510 | this access | UseUseExplosion.cs:24:524:24:527 | this access |
 | UseUseExplosion.cs:24:507:24:510 | this access | UseUseExplosion.cs:24:2758:24:2763 | this access |
 | UseUseExplosion.cs:24:524:24:527 | [post] this access | UseUseExplosion.cs:24:541:24:544 | this access |
 | UseUseExplosion.cs:24:524:24:527 | [post] this access | UseUseExplosion.cs:24:2743:24:2748 | this access |
 | UseUseExplosion.cs:24:524:24:527 | access to property Prop | UseUseExplosion.cs:24:524:24:532 | ... > ... |
 | UseUseExplosion.cs:24:524:24:527 | access to property Prop | UseUseExplosion.cs:24:541:24:544 | access to property Prop |
-| UseUseExplosion.cs:24:524:24:527 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:524:24:527 | access to property Prop | UseUseExplosion.cs:24:2743:24:2748 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:524:24:527 | this access | UseUseExplosion.cs:24:541:24:544 | this access |
 | UseUseExplosion.cs:24:524:24:527 | this access | UseUseExplosion.cs:24:2743:24:2748 | this access |
 | UseUseExplosion.cs:24:541:24:544 | [post] this access | UseUseExplosion.cs:24:558:24:561 | this access |
 | UseUseExplosion.cs:24:541:24:544 | [post] this access | UseUseExplosion.cs:24:2728:24:2733 | this access |
 | UseUseExplosion.cs:24:541:24:544 | access to property Prop | UseUseExplosion.cs:24:541:24:549 | ... > ... |
 | UseUseExplosion.cs:24:541:24:544 | access to property Prop | UseUseExplosion.cs:24:558:24:561 | access to property Prop |
-| UseUseExplosion.cs:24:541:24:544 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:541:24:544 | access to property Prop | UseUseExplosion.cs:24:2728:24:2733 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:541:24:544 | this access | UseUseExplosion.cs:24:558:24:561 | this access |
 | UseUseExplosion.cs:24:541:24:544 | this access | UseUseExplosion.cs:24:2728:24:2733 | this access |
 | UseUseExplosion.cs:24:558:24:561 | [post] this access | UseUseExplosion.cs:24:575:24:578 | this access |
 | UseUseExplosion.cs:24:558:24:561 | [post] this access | UseUseExplosion.cs:24:2713:24:2718 | this access |
 | UseUseExplosion.cs:24:558:24:561 | access to property Prop | UseUseExplosion.cs:24:558:24:566 | ... > ... |
 | UseUseExplosion.cs:24:558:24:561 | access to property Prop | UseUseExplosion.cs:24:575:24:578 | access to property Prop |
-| UseUseExplosion.cs:24:558:24:561 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:558:24:561 | access to property Prop | UseUseExplosion.cs:24:2713:24:2718 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:558:24:561 | this access | UseUseExplosion.cs:24:575:24:578 | this access |
 | UseUseExplosion.cs:24:558:24:561 | this access | UseUseExplosion.cs:24:2713:24:2718 | this access |
 | UseUseExplosion.cs:24:575:24:578 | [post] this access | UseUseExplosion.cs:24:592:24:595 | this access |
 | UseUseExplosion.cs:24:575:24:578 | [post] this access | UseUseExplosion.cs:24:2698:24:2703 | this access |
 | UseUseExplosion.cs:24:575:24:578 | access to property Prop | UseUseExplosion.cs:24:575:24:583 | ... > ... |
 | UseUseExplosion.cs:24:575:24:578 | access to property Prop | UseUseExplosion.cs:24:592:24:595 | access to property Prop |
-| UseUseExplosion.cs:24:575:24:578 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:575:24:578 | access to property Prop | UseUseExplosion.cs:24:2698:24:2703 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:575:24:578 | this access | UseUseExplosion.cs:24:592:24:595 | this access |
 | UseUseExplosion.cs:24:575:24:578 | this access | UseUseExplosion.cs:24:2698:24:2703 | this access |
 | UseUseExplosion.cs:24:592:24:595 | [post] this access | UseUseExplosion.cs:24:609:24:612 | this access |
 | UseUseExplosion.cs:24:592:24:595 | [post] this access | UseUseExplosion.cs:24:2683:24:2688 | this access |
 | UseUseExplosion.cs:24:592:24:595 | access to property Prop | UseUseExplosion.cs:24:592:24:600 | ... > ... |
 | UseUseExplosion.cs:24:592:24:595 | access to property Prop | UseUseExplosion.cs:24:609:24:612 | access to property Prop |
-| UseUseExplosion.cs:24:592:24:595 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:592:24:595 | access to property Prop | UseUseExplosion.cs:24:2683:24:2688 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:592:24:595 | this access | UseUseExplosion.cs:24:609:24:612 | this access |
 | UseUseExplosion.cs:24:592:24:595 | this access | UseUseExplosion.cs:24:2683:24:2688 | this access |
 | UseUseExplosion.cs:24:609:24:612 | [post] this access | UseUseExplosion.cs:24:626:24:629 | this access |
 | UseUseExplosion.cs:24:609:24:612 | [post] this access | UseUseExplosion.cs:24:2668:24:2673 | this access |
 | UseUseExplosion.cs:24:609:24:612 | access to property Prop | UseUseExplosion.cs:24:609:24:617 | ... > ... |
 | UseUseExplosion.cs:24:609:24:612 | access to property Prop | UseUseExplosion.cs:24:626:24:629 | access to property Prop |
-| UseUseExplosion.cs:24:609:24:612 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:609:24:612 | access to property Prop | UseUseExplosion.cs:24:2668:24:2673 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:609:24:612 | this access | UseUseExplosion.cs:24:626:24:629 | this access |
 | UseUseExplosion.cs:24:609:24:612 | this access | UseUseExplosion.cs:24:2668:24:2673 | this access |
 | UseUseExplosion.cs:24:626:24:629 | [post] this access | UseUseExplosion.cs:24:643:24:646 | this access |
 | UseUseExplosion.cs:24:626:24:629 | [post] this access | UseUseExplosion.cs:24:2653:24:2658 | this access |
 | UseUseExplosion.cs:24:626:24:629 | access to property Prop | UseUseExplosion.cs:24:626:24:634 | ... > ... |
 | UseUseExplosion.cs:24:626:24:629 | access to property Prop | UseUseExplosion.cs:24:643:24:646 | access to property Prop |
-| UseUseExplosion.cs:24:626:24:629 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:626:24:629 | access to property Prop | UseUseExplosion.cs:24:2653:24:2658 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:626:24:629 | this access | UseUseExplosion.cs:24:643:24:646 | this access |
 | UseUseExplosion.cs:24:626:24:629 | this access | UseUseExplosion.cs:24:2653:24:2658 | this access |
 | UseUseExplosion.cs:24:643:24:646 | [post] this access | UseUseExplosion.cs:24:660:24:663 | this access |
 | UseUseExplosion.cs:24:643:24:646 | [post] this access | UseUseExplosion.cs:24:2638:24:2643 | this access |
 | UseUseExplosion.cs:24:643:24:646 | access to property Prop | UseUseExplosion.cs:24:643:24:651 | ... > ... |
 | UseUseExplosion.cs:24:643:24:646 | access to property Prop | UseUseExplosion.cs:24:660:24:663 | access to property Prop |
-| UseUseExplosion.cs:24:643:24:646 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:643:24:646 | access to property Prop | UseUseExplosion.cs:24:2638:24:2643 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:643:24:646 | this access | UseUseExplosion.cs:24:660:24:663 | this access |
 | UseUseExplosion.cs:24:643:24:646 | this access | UseUseExplosion.cs:24:2638:24:2643 | this access |
 | UseUseExplosion.cs:24:660:24:663 | [post] this access | UseUseExplosion.cs:24:677:24:680 | this access |
 | UseUseExplosion.cs:24:660:24:663 | [post] this access | UseUseExplosion.cs:24:2623:24:2628 | this access |
 | UseUseExplosion.cs:24:660:24:663 | access to property Prop | UseUseExplosion.cs:24:660:24:668 | ... > ... |
 | UseUseExplosion.cs:24:660:24:663 | access to property Prop | UseUseExplosion.cs:24:677:24:680 | access to property Prop |
-| UseUseExplosion.cs:24:660:24:663 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:660:24:663 | access to property Prop | UseUseExplosion.cs:24:2623:24:2628 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:660:24:663 | this access | UseUseExplosion.cs:24:677:24:680 | this access |
 | UseUseExplosion.cs:24:660:24:663 | this access | UseUseExplosion.cs:24:2623:24:2628 | this access |
 | UseUseExplosion.cs:24:677:24:680 | [post] this access | UseUseExplosion.cs:24:694:24:697 | this access |
 | UseUseExplosion.cs:24:677:24:680 | [post] this access | UseUseExplosion.cs:24:2608:24:2613 | this access |
 | UseUseExplosion.cs:24:677:24:680 | access to property Prop | UseUseExplosion.cs:24:677:24:685 | ... > ... |
 | UseUseExplosion.cs:24:677:24:680 | access to property Prop | UseUseExplosion.cs:24:694:24:697 | access to property Prop |
-| UseUseExplosion.cs:24:677:24:680 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:677:24:680 | access to property Prop | UseUseExplosion.cs:24:2608:24:2613 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:677:24:680 | this access | UseUseExplosion.cs:24:694:24:697 | this access |
 | UseUseExplosion.cs:24:677:24:680 | this access | UseUseExplosion.cs:24:2608:24:2613 | this access |
 | UseUseExplosion.cs:24:694:24:697 | [post] this access | UseUseExplosion.cs:24:711:24:714 | this access |
 | UseUseExplosion.cs:24:694:24:697 | [post] this access | UseUseExplosion.cs:24:2593:24:2598 | this access |
 | UseUseExplosion.cs:24:694:24:697 | access to property Prop | UseUseExplosion.cs:24:694:24:702 | ... > ... |
 | UseUseExplosion.cs:24:694:24:697 | access to property Prop | UseUseExplosion.cs:24:711:24:714 | access to property Prop |
-| UseUseExplosion.cs:24:694:24:697 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:694:24:697 | access to property Prop | UseUseExplosion.cs:24:2593:24:2598 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:694:24:697 | this access | UseUseExplosion.cs:24:711:24:714 | this access |
 | UseUseExplosion.cs:24:694:24:697 | this access | UseUseExplosion.cs:24:2593:24:2598 | this access |
 | UseUseExplosion.cs:24:711:24:714 | [post] this access | UseUseExplosion.cs:24:728:24:731 | this access |
 | UseUseExplosion.cs:24:711:24:714 | [post] this access | UseUseExplosion.cs:24:2578:24:2583 | this access |
 | UseUseExplosion.cs:24:711:24:714 | access to property Prop | UseUseExplosion.cs:24:711:24:719 | ... > ... |
 | UseUseExplosion.cs:24:711:24:714 | access to property Prop | UseUseExplosion.cs:24:728:24:731 | access to property Prop |
-| UseUseExplosion.cs:24:711:24:714 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:711:24:714 | access to property Prop | UseUseExplosion.cs:24:2578:24:2583 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:711:24:714 | this access | UseUseExplosion.cs:24:728:24:731 | this access |
 | UseUseExplosion.cs:24:711:24:714 | this access | UseUseExplosion.cs:24:2578:24:2583 | this access |
 | UseUseExplosion.cs:24:728:24:731 | [post] this access | UseUseExplosion.cs:24:745:24:748 | this access |
 | UseUseExplosion.cs:24:728:24:731 | [post] this access | UseUseExplosion.cs:24:2563:24:2568 | this access |
 | UseUseExplosion.cs:24:728:24:731 | access to property Prop | UseUseExplosion.cs:24:728:24:736 | ... > ... |
 | UseUseExplosion.cs:24:728:24:731 | access to property Prop | UseUseExplosion.cs:24:745:24:748 | access to property Prop |
-| UseUseExplosion.cs:24:728:24:731 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:728:24:731 | access to property Prop | UseUseExplosion.cs:24:2563:24:2568 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:728:24:731 | this access | UseUseExplosion.cs:24:745:24:748 | this access |
 | UseUseExplosion.cs:24:728:24:731 | this access | UseUseExplosion.cs:24:2563:24:2568 | this access |
 | UseUseExplosion.cs:24:745:24:748 | [post] this access | UseUseExplosion.cs:24:762:24:765 | this access |
 | UseUseExplosion.cs:24:745:24:748 | [post] this access | UseUseExplosion.cs:24:2548:24:2553 | this access |
 | UseUseExplosion.cs:24:745:24:748 | access to property Prop | UseUseExplosion.cs:24:745:24:753 | ... > ... |
 | UseUseExplosion.cs:24:745:24:748 | access to property Prop | UseUseExplosion.cs:24:762:24:765 | access to property Prop |
-| UseUseExplosion.cs:24:745:24:748 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:745:24:748 | access to property Prop | UseUseExplosion.cs:24:2548:24:2553 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:745:24:748 | this access | UseUseExplosion.cs:24:762:24:765 | this access |
 | UseUseExplosion.cs:24:745:24:748 | this access | UseUseExplosion.cs:24:2548:24:2553 | this access |
 | UseUseExplosion.cs:24:762:24:765 | [post] this access | UseUseExplosion.cs:24:779:24:782 | this access |
 | UseUseExplosion.cs:24:762:24:765 | [post] this access | UseUseExplosion.cs:24:2533:24:2538 | this access |
 | UseUseExplosion.cs:24:762:24:765 | access to property Prop | UseUseExplosion.cs:24:762:24:770 | ... > ... |
 | UseUseExplosion.cs:24:762:24:765 | access to property Prop | UseUseExplosion.cs:24:779:24:782 | access to property Prop |
-| UseUseExplosion.cs:24:762:24:765 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:762:24:765 | access to property Prop | UseUseExplosion.cs:24:2533:24:2538 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:762:24:765 | this access | UseUseExplosion.cs:24:779:24:782 | this access |
 | UseUseExplosion.cs:24:762:24:765 | this access | UseUseExplosion.cs:24:2533:24:2538 | this access |
 | UseUseExplosion.cs:24:779:24:782 | [post] this access | UseUseExplosion.cs:24:796:24:799 | this access |
 | UseUseExplosion.cs:24:779:24:782 | [post] this access | UseUseExplosion.cs:24:2518:24:2523 | this access |
 | UseUseExplosion.cs:24:779:24:782 | access to property Prop | UseUseExplosion.cs:24:779:24:787 | ... > ... |
 | UseUseExplosion.cs:24:779:24:782 | access to property Prop | UseUseExplosion.cs:24:796:24:799 | access to property Prop |
-| UseUseExplosion.cs:24:779:24:782 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:779:24:782 | access to property Prop | UseUseExplosion.cs:24:2518:24:2523 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:779:24:782 | this access | UseUseExplosion.cs:24:796:24:799 | this access |
 | UseUseExplosion.cs:24:779:24:782 | this access | UseUseExplosion.cs:24:2518:24:2523 | this access |
 | UseUseExplosion.cs:24:796:24:799 | [post] this access | UseUseExplosion.cs:24:813:24:816 | this access |
 | UseUseExplosion.cs:24:796:24:799 | [post] this access | UseUseExplosion.cs:24:2503:24:2508 | this access |
 | UseUseExplosion.cs:24:796:24:799 | access to property Prop | UseUseExplosion.cs:24:796:24:804 | ... > ... |
 | UseUseExplosion.cs:24:796:24:799 | access to property Prop | UseUseExplosion.cs:24:813:24:816 | access to property Prop |
-| UseUseExplosion.cs:24:796:24:799 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:796:24:799 | access to property Prop | UseUseExplosion.cs:24:2503:24:2508 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:796:24:799 | this access | UseUseExplosion.cs:24:813:24:816 | this access |
 | UseUseExplosion.cs:24:796:24:799 | this access | UseUseExplosion.cs:24:2503:24:2508 | this access |
 | UseUseExplosion.cs:24:813:24:816 | [post] this access | UseUseExplosion.cs:24:830:24:833 | this access |
 | UseUseExplosion.cs:24:813:24:816 | [post] this access | UseUseExplosion.cs:24:2488:24:2493 | this access |
 | UseUseExplosion.cs:24:813:24:816 | access to property Prop | UseUseExplosion.cs:24:813:24:821 | ... > ... |
 | UseUseExplosion.cs:24:813:24:816 | access to property Prop | UseUseExplosion.cs:24:830:24:833 | access to property Prop |
-| UseUseExplosion.cs:24:813:24:816 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:813:24:816 | access to property Prop | UseUseExplosion.cs:24:2488:24:2493 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:813:24:816 | this access | UseUseExplosion.cs:24:830:24:833 | this access |
 | UseUseExplosion.cs:24:813:24:816 | this access | UseUseExplosion.cs:24:2488:24:2493 | this access |
 | UseUseExplosion.cs:24:830:24:833 | [post] this access | UseUseExplosion.cs:24:847:24:850 | this access |
 | UseUseExplosion.cs:24:830:24:833 | [post] this access | UseUseExplosion.cs:24:2473:24:2478 | this access |
 | UseUseExplosion.cs:24:830:24:833 | access to property Prop | UseUseExplosion.cs:24:830:24:838 | ... > ... |
 | UseUseExplosion.cs:24:830:24:833 | access to property Prop | UseUseExplosion.cs:24:847:24:850 | access to property Prop |
-| UseUseExplosion.cs:24:830:24:833 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:830:24:833 | access to property Prop | UseUseExplosion.cs:24:2473:24:2478 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:830:24:833 | this access | UseUseExplosion.cs:24:847:24:850 | this access |
 | UseUseExplosion.cs:24:830:24:833 | this access | UseUseExplosion.cs:24:2473:24:2478 | this access |
 | UseUseExplosion.cs:24:847:24:850 | [post] this access | UseUseExplosion.cs:24:864:24:867 | this access |
 | UseUseExplosion.cs:24:847:24:850 | [post] this access | UseUseExplosion.cs:24:2458:24:2463 | this access |
 | UseUseExplosion.cs:24:847:24:850 | access to property Prop | UseUseExplosion.cs:24:847:24:855 | ... > ... |
 | UseUseExplosion.cs:24:847:24:850 | access to property Prop | UseUseExplosion.cs:24:864:24:867 | access to property Prop |
-| UseUseExplosion.cs:24:847:24:850 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:847:24:850 | access to property Prop | UseUseExplosion.cs:24:2458:24:2463 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:847:24:850 | this access | UseUseExplosion.cs:24:864:24:867 | this access |
 | UseUseExplosion.cs:24:847:24:850 | this access | UseUseExplosion.cs:24:2458:24:2463 | this access |
 | UseUseExplosion.cs:24:864:24:867 | [post] this access | UseUseExplosion.cs:24:881:24:884 | this access |
 | UseUseExplosion.cs:24:864:24:867 | [post] this access | UseUseExplosion.cs:24:2443:24:2448 | this access |
 | UseUseExplosion.cs:24:864:24:867 | access to property Prop | UseUseExplosion.cs:24:864:24:872 | ... > ... |
 | UseUseExplosion.cs:24:864:24:867 | access to property Prop | UseUseExplosion.cs:24:881:24:884 | access to property Prop |
-| UseUseExplosion.cs:24:864:24:867 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:864:24:867 | access to property Prop | UseUseExplosion.cs:24:2443:24:2448 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:864:24:867 | this access | UseUseExplosion.cs:24:881:24:884 | this access |
 | UseUseExplosion.cs:24:864:24:867 | this access | UseUseExplosion.cs:24:2443:24:2448 | this access |
 | UseUseExplosion.cs:24:881:24:884 | [post] this access | UseUseExplosion.cs:24:898:24:901 | this access |
 | UseUseExplosion.cs:24:881:24:884 | [post] this access | UseUseExplosion.cs:24:2428:24:2433 | this access |
 | UseUseExplosion.cs:24:881:24:884 | access to property Prop | UseUseExplosion.cs:24:881:24:889 | ... > ... |
 | UseUseExplosion.cs:24:881:24:884 | access to property Prop | UseUseExplosion.cs:24:898:24:901 | access to property Prop |
-| UseUseExplosion.cs:24:881:24:884 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:881:24:884 | access to property Prop | UseUseExplosion.cs:24:2428:24:2433 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:881:24:884 | this access | UseUseExplosion.cs:24:898:24:901 | this access |
 | UseUseExplosion.cs:24:881:24:884 | this access | UseUseExplosion.cs:24:2428:24:2433 | this access |
 | UseUseExplosion.cs:24:898:24:901 | [post] this access | UseUseExplosion.cs:24:915:24:918 | this access |
 | UseUseExplosion.cs:24:898:24:901 | [post] this access | UseUseExplosion.cs:24:2413:24:2418 | this access |
 | UseUseExplosion.cs:24:898:24:901 | access to property Prop | UseUseExplosion.cs:24:898:24:906 | ... > ... |
 | UseUseExplosion.cs:24:898:24:901 | access to property Prop | UseUseExplosion.cs:24:915:24:918 | access to property Prop |
-| UseUseExplosion.cs:24:898:24:901 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:898:24:901 | access to property Prop | UseUseExplosion.cs:24:2413:24:2418 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:898:24:901 | this access | UseUseExplosion.cs:24:915:24:918 | this access |
 | UseUseExplosion.cs:24:898:24:901 | this access | UseUseExplosion.cs:24:2413:24:2418 | this access |
 | UseUseExplosion.cs:24:915:24:918 | [post] this access | UseUseExplosion.cs:24:932:24:935 | this access |
 | UseUseExplosion.cs:24:915:24:918 | [post] this access | UseUseExplosion.cs:24:2398:24:2403 | this access |
 | UseUseExplosion.cs:24:915:24:918 | access to property Prop | UseUseExplosion.cs:24:915:24:923 | ... > ... |
 | UseUseExplosion.cs:24:915:24:918 | access to property Prop | UseUseExplosion.cs:24:932:24:935 | access to property Prop |
-| UseUseExplosion.cs:24:915:24:918 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:915:24:918 | access to property Prop | UseUseExplosion.cs:24:2398:24:2403 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:915:24:918 | this access | UseUseExplosion.cs:24:932:24:935 | this access |
 | UseUseExplosion.cs:24:915:24:918 | this access | UseUseExplosion.cs:24:2398:24:2403 | this access |
 | UseUseExplosion.cs:24:932:24:935 | [post] this access | UseUseExplosion.cs:24:949:24:952 | this access |
 | UseUseExplosion.cs:24:932:24:935 | [post] this access | UseUseExplosion.cs:24:2383:24:2388 | this access |
 | UseUseExplosion.cs:24:932:24:935 | access to property Prop | UseUseExplosion.cs:24:932:24:940 | ... > ... |
 | UseUseExplosion.cs:24:932:24:935 | access to property Prop | UseUseExplosion.cs:24:949:24:952 | access to property Prop |
-| UseUseExplosion.cs:24:932:24:935 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:932:24:935 | access to property Prop | UseUseExplosion.cs:24:2383:24:2388 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:932:24:935 | this access | UseUseExplosion.cs:24:949:24:952 | this access |
 | UseUseExplosion.cs:24:932:24:935 | this access | UseUseExplosion.cs:24:2383:24:2388 | this access |
 | UseUseExplosion.cs:24:949:24:952 | [post] this access | UseUseExplosion.cs:24:966:24:969 | this access |
 | UseUseExplosion.cs:24:949:24:952 | [post] this access | UseUseExplosion.cs:24:2368:24:2373 | this access |
 | UseUseExplosion.cs:24:949:24:952 | access to property Prop | UseUseExplosion.cs:24:949:24:957 | ... > ... |
 | UseUseExplosion.cs:24:949:24:952 | access to property Prop | UseUseExplosion.cs:24:966:24:969 | access to property Prop |
-| UseUseExplosion.cs:24:949:24:952 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:949:24:952 | access to property Prop | UseUseExplosion.cs:24:2368:24:2373 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:949:24:952 | this access | UseUseExplosion.cs:24:966:24:969 | this access |
 | UseUseExplosion.cs:24:949:24:952 | this access | UseUseExplosion.cs:24:2368:24:2373 | this access |
 | UseUseExplosion.cs:24:966:24:969 | [post] this access | UseUseExplosion.cs:24:983:24:986 | this access |
 | UseUseExplosion.cs:24:966:24:969 | [post] this access | UseUseExplosion.cs:24:2353:24:2358 | this access |
 | UseUseExplosion.cs:24:966:24:969 | access to property Prop | UseUseExplosion.cs:24:966:24:974 | ... > ... |
 | UseUseExplosion.cs:24:966:24:969 | access to property Prop | UseUseExplosion.cs:24:983:24:986 | access to property Prop |
-| UseUseExplosion.cs:24:966:24:969 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:966:24:969 | access to property Prop | UseUseExplosion.cs:24:2353:24:2358 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:966:24:969 | this access | UseUseExplosion.cs:24:983:24:986 | this access |
 | UseUseExplosion.cs:24:966:24:969 | this access | UseUseExplosion.cs:24:2353:24:2358 | this access |
 | UseUseExplosion.cs:24:983:24:986 | [post] this access | UseUseExplosion.cs:24:1000:24:1003 | this access |
 | UseUseExplosion.cs:24:983:24:986 | [post] this access | UseUseExplosion.cs:24:2338:24:2343 | this access |
 | UseUseExplosion.cs:24:983:24:986 | access to property Prop | UseUseExplosion.cs:24:983:24:991 | ... > ... |
 | UseUseExplosion.cs:24:983:24:986 | access to property Prop | UseUseExplosion.cs:24:1000:24:1003 | access to property Prop |
-| UseUseExplosion.cs:24:983:24:986 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:983:24:986 | access to property Prop | UseUseExplosion.cs:24:2338:24:2343 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:983:24:986 | this access | UseUseExplosion.cs:24:1000:24:1003 | this access |
 | UseUseExplosion.cs:24:983:24:986 | this access | UseUseExplosion.cs:24:2338:24:2343 | this access |
 | UseUseExplosion.cs:24:1000:24:1003 | [post] this access | UseUseExplosion.cs:24:1017:24:1020 | this access |
 | UseUseExplosion.cs:24:1000:24:1003 | [post] this access | UseUseExplosion.cs:24:2323:24:2328 | this access |
 | UseUseExplosion.cs:24:1000:24:1003 | access to property Prop | UseUseExplosion.cs:24:1000:24:1008 | ... > ... |
 | UseUseExplosion.cs:24:1000:24:1003 | access to property Prop | UseUseExplosion.cs:24:1017:24:1020 | access to property Prop |
-| UseUseExplosion.cs:24:1000:24:1003 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1000:24:1003 | access to property Prop | UseUseExplosion.cs:24:2323:24:2328 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1000:24:1003 | this access | UseUseExplosion.cs:24:1017:24:1020 | this access |
 | UseUseExplosion.cs:24:1000:24:1003 | this access | UseUseExplosion.cs:24:2323:24:2328 | this access |
 | UseUseExplosion.cs:24:1017:24:1020 | [post] this access | UseUseExplosion.cs:24:1034:24:1037 | this access |
 | UseUseExplosion.cs:24:1017:24:1020 | [post] this access | UseUseExplosion.cs:24:2308:24:2313 | this access |
 | UseUseExplosion.cs:24:1017:24:1020 | access to property Prop | UseUseExplosion.cs:24:1017:24:1025 | ... > ... |
 | UseUseExplosion.cs:24:1017:24:1020 | access to property Prop | UseUseExplosion.cs:24:1034:24:1037 | access to property Prop |
-| UseUseExplosion.cs:24:1017:24:1020 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1017:24:1020 | access to property Prop | UseUseExplosion.cs:24:2308:24:2313 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1017:24:1020 | this access | UseUseExplosion.cs:24:1034:24:1037 | this access |
 | UseUseExplosion.cs:24:1017:24:1020 | this access | UseUseExplosion.cs:24:2308:24:2313 | this access |
 | UseUseExplosion.cs:24:1034:24:1037 | [post] this access | UseUseExplosion.cs:24:1051:24:1054 | this access |
 | UseUseExplosion.cs:24:1034:24:1037 | [post] this access | UseUseExplosion.cs:24:2293:24:2298 | this access |
 | UseUseExplosion.cs:24:1034:24:1037 | access to property Prop | UseUseExplosion.cs:24:1034:24:1042 | ... > ... |
 | UseUseExplosion.cs:24:1034:24:1037 | access to property Prop | UseUseExplosion.cs:24:1051:24:1054 | access to property Prop |
-| UseUseExplosion.cs:24:1034:24:1037 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1034:24:1037 | access to property Prop | UseUseExplosion.cs:24:2293:24:2298 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1034:24:1037 | this access | UseUseExplosion.cs:24:1051:24:1054 | this access |
 | UseUseExplosion.cs:24:1034:24:1037 | this access | UseUseExplosion.cs:24:2293:24:2298 | this access |
 | UseUseExplosion.cs:24:1051:24:1054 | [post] this access | UseUseExplosion.cs:24:1068:24:1071 | this access |
 | UseUseExplosion.cs:24:1051:24:1054 | [post] this access | UseUseExplosion.cs:24:2278:24:2283 | this access |
 | UseUseExplosion.cs:24:1051:24:1054 | access to property Prop | UseUseExplosion.cs:24:1051:24:1059 | ... > ... |
 | UseUseExplosion.cs:24:1051:24:1054 | access to property Prop | UseUseExplosion.cs:24:1068:24:1071 | access to property Prop |
-| UseUseExplosion.cs:24:1051:24:1054 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1051:24:1054 | access to property Prop | UseUseExplosion.cs:24:2278:24:2283 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1051:24:1054 | this access | UseUseExplosion.cs:24:1068:24:1071 | this access |
 | UseUseExplosion.cs:24:1051:24:1054 | this access | UseUseExplosion.cs:24:2278:24:2283 | this access |
 | UseUseExplosion.cs:24:1068:24:1071 | [post] this access | UseUseExplosion.cs:24:1085:24:1088 | this access |
 | UseUseExplosion.cs:24:1068:24:1071 | [post] this access | UseUseExplosion.cs:24:2263:24:2268 | this access |
 | UseUseExplosion.cs:24:1068:24:1071 | access to property Prop | UseUseExplosion.cs:24:1068:24:1076 | ... > ... |
 | UseUseExplosion.cs:24:1068:24:1071 | access to property Prop | UseUseExplosion.cs:24:1085:24:1088 | access to property Prop |
-| UseUseExplosion.cs:24:1068:24:1071 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1068:24:1071 | access to property Prop | UseUseExplosion.cs:24:2263:24:2268 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1068:24:1071 | this access | UseUseExplosion.cs:24:1085:24:1088 | this access |
 | UseUseExplosion.cs:24:1068:24:1071 | this access | UseUseExplosion.cs:24:2263:24:2268 | this access |
 | UseUseExplosion.cs:24:1085:24:1088 | [post] this access | UseUseExplosion.cs:24:1102:24:1105 | this access |
 | UseUseExplosion.cs:24:1085:24:1088 | [post] this access | UseUseExplosion.cs:24:2248:24:2253 | this access |
 | UseUseExplosion.cs:24:1085:24:1088 | access to property Prop | UseUseExplosion.cs:24:1085:24:1093 | ... > ... |
 | UseUseExplosion.cs:24:1085:24:1088 | access to property Prop | UseUseExplosion.cs:24:1102:24:1105 | access to property Prop |
-| UseUseExplosion.cs:24:1085:24:1088 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1085:24:1088 | access to property Prop | UseUseExplosion.cs:24:2248:24:2253 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1085:24:1088 | this access | UseUseExplosion.cs:24:1102:24:1105 | this access |
 | UseUseExplosion.cs:24:1085:24:1088 | this access | UseUseExplosion.cs:24:2248:24:2253 | this access |
 | UseUseExplosion.cs:24:1102:24:1105 | [post] this access | UseUseExplosion.cs:24:1119:24:1122 | this access |
 | UseUseExplosion.cs:24:1102:24:1105 | [post] this access | UseUseExplosion.cs:24:2233:24:2238 | this access |
 | UseUseExplosion.cs:24:1102:24:1105 | access to property Prop | UseUseExplosion.cs:24:1102:24:1110 | ... > ... |
 | UseUseExplosion.cs:24:1102:24:1105 | access to property Prop | UseUseExplosion.cs:24:1119:24:1122 | access to property Prop |
-| UseUseExplosion.cs:24:1102:24:1105 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1102:24:1105 | access to property Prop | UseUseExplosion.cs:24:2233:24:2238 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1102:24:1105 | this access | UseUseExplosion.cs:24:1119:24:1122 | this access |
 | UseUseExplosion.cs:24:1102:24:1105 | this access | UseUseExplosion.cs:24:2233:24:2238 | this access |
 | UseUseExplosion.cs:24:1119:24:1122 | [post] this access | UseUseExplosion.cs:24:1136:24:1139 | this access |
 | UseUseExplosion.cs:24:1119:24:1122 | [post] this access | UseUseExplosion.cs:24:2218:24:2223 | this access |
 | UseUseExplosion.cs:24:1119:24:1122 | access to property Prop | UseUseExplosion.cs:24:1119:24:1127 | ... > ... |
 | UseUseExplosion.cs:24:1119:24:1122 | access to property Prop | UseUseExplosion.cs:24:1136:24:1139 | access to property Prop |
-| UseUseExplosion.cs:24:1119:24:1122 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1119:24:1122 | access to property Prop | UseUseExplosion.cs:24:2218:24:2223 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1119:24:1122 | this access | UseUseExplosion.cs:24:1136:24:1139 | this access |
 | UseUseExplosion.cs:24:1119:24:1122 | this access | UseUseExplosion.cs:24:2218:24:2223 | this access |
 | UseUseExplosion.cs:24:1136:24:1139 | [post] this access | UseUseExplosion.cs:24:1153:24:1156 | this access |
 | UseUseExplosion.cs:24:1136:24:1139 | [post] this access | UseUseExplosion.cs:24:2203:24:2208 | this access |
 | UseUseExplosion.cs:24:1136:24:1139 | access to property Prop | UseUseExplosion.cs:24:1136:24:1144 | ... > ... |
 | UseUseExplosion.cs:24:1136:24:1139 | access to property Prop | UseUseExplosion.cs:24:1153:24:1156 | access to property Prop |
-| UseUseExplosion.cs:24:1136:24:1139 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1136:24:1139 | access to property Prop | UseUseExplosion.cs:24:2203:24:2208 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1136:24:1139 | this access | UseUseExplosion.cs:24:1153:24:1156 | this access |
 | UseUseExplosion.cs:24:1136:24:1139 | this access | UseUseExplosion.cs:24:2203:24:2208 | this access |
 | UseUseExplosion.cs:24:1153:24:1156 | [post] this access | UseUseExplosion.cs:24:1170:24:1173 | this access |
 | UseUseExplosion.cs:24:1153:24:1156 | [post] this access | UseUseExplosion.cs:24:2188:24:2193 | this access |
 | UseUseExplosion.cs:24:1153:24:1156 | access to property Prop | UseUseExplosion.cs:24:1153:24:1161 | ... > ... |
 | UseUseExplosion.cs:24:1153:24:1156 | access to property Prop | UseUseExplosion.cs:24:1170:24:1173 | access to property Prop |
-| UseUseExplosion.cs:24:1153:24:1156 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1153:24:1156 | access to property Prop | UseUseExplosion.cs:24:2188:24:2193 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1153:24:1156 | this access | UseUseExplosion.cs:24:1170:24:1173 | this access |
 | UseUseExplosion.cs:24:1153:24:1156 | this access | UseUseExplosion.cs:24:2188:24:2193 | this access |
 | UseUseExplosion.cs:24:1170:24:1173 | [post] this access | UseUseExplosion.cs:24:1187:24:1190 | this access |
 | UseUseExplosion.cs:24:1170:24:1173 | [post] this access | UseUseExplosion.cs:24:2173:24:2178 | this access |
 | UseUseExplosion.cs:24:1170:24:1173 | access to property Prop | UseUseExplosion.cs:24:1170:24:1178 | ... > ... |
 | UseUseExplosion.cs:24:1170:24:1173 | access to property Prop | UseUseExplosion.cs:24:1187:24:1190 | access to property Prop |
-| UseUseExplosion.cs:24:1170:24:1173 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1170:24:1173 | access to property Prop | UseUseExplosion.cs:24:2173:24:2178 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1170:24:1173 | this access | UseUseExplosion.cs:24:1187:24:1190 | this access |
 | UseUseExplosion.cs:24:1170:24:1173 | this access | UseUseExplosion.cs:24:2173:24:2178 | this access |
 | UseUseExplosion.cs:24:1187:24:1190 | [post] this access | UseUseExplosion.cs:24:1204:24:1207 | this access |
 | UseUseExplosion.cs:24:1187:24:1190 | [post] this access | UseUseExplosion.cs:24:2158:24:2163 | this access |
 | UseUseExplosion.cs:24:1187:24:1190 | access to property Prop | UseUseExplosion.cs:24:1187:24:1195 | ... > ... |
 | UseUseExplosion.cs:24:1187:24:1190 | access to property Prop | UseUseExplosion.cs:24:1204:24:1207 | access to property Prop |
-| UseUseExplosion.cs:24:1187:24:1190 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1187:24:1190 | access to property Prop | UseUseExplosion.cs:24:2158:24:2163 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1187:24:1190 | this access | UseUseExplosion.cs:24:1204:24:1207 | this access |
 | UseUseExplosion.cs:24:1187:24:1190 | this access | UseUseExplosion.cs:24:2158:24:2163 | this access |
 | UseUseExplosion.cs:24:1204:24:1207 | [post] this access | UseUseExplosion.cs:24:1221:24:1224 | this access |
 | UseUseExplosion.cs:24:1204:24:1207 | [post] this access | UseUseExplosion.cs:24:2143:24:2148 | this access |
 | UseUseExplosion.cs:24:1204:24:1207 | access to property Prop | UseUseExplosion.cs:24:1204:24:1212 | ... > ... |
 | UseUseExplosion.cs:24:1204:24:1207 | access to property Prop | UseUseExplosion.cs:24:1221:24:1224 | access to property Prop |
-| UseUseExplosion.cs:24:1204:24:1207 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1204:24:1207 | access to property Prop | UseUseExplosion.cs:24:2143:24:2148 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1204:24:1207 | this access | UseUseExplosion.cs:24:1221:24:1224 | this access |
 | UseUseExplosion.cs:24:1204:24:1207 | this access | UseUseExplosion.cs:24:2143:24:2148 | this access |
 | UseUseExplosion.cs:24:1221:24:1224 | [post] this access | UseUseExplosion.cs:24:1238:24:1241 | this access |
 | UseUseExplosion.cs:24:1221:24:1224 | [post] this access | UseUseExplosion.cs:24:2128:24:2133 | this access |
 | UseUseExplosion.cs:24:1221:24:1224 | access to property Prop | UseUseExplosion.cs:24:1221:24:1229 | ... > ... |
 | UseUseExplosion.cs:24:1221:24:1224 | access to property Prop | UseUseExplosion.cs:24:1238:24:1241 | access to property Prop |
-| UseUseExplosion.cs:24:1221:24:1224 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1221:24:1224 | access to property Prop | UseUseExplosion.cs:24:2128:24:2133 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1221:24:1224 | this access | UseUseExplosion.cs:24:1238:24:1241 | this access |
 | UseUseExplosion.cs:24:1221:24:1224 | this access | UseUseExplosion.cs:24:2128:24:2133 | this access |
 | UseUseExplosion.cs:24:1238:24:1241 | [post] this access | UseUseExplosion.cs:24:1255:24:1258 | this access |
 | UseUseExplosion.cs:24:1238:24:1241 | [post] this access | UseUseExplosion.cs:24:2113:24:2118 | this access |
 | UseUseExplosion.cs:24:1238:24:1241 | access to property Prop | UseUseExplosion.cs:24:1238:24:1246 | ... > ... |
 | UseUseExplosion.cs:24:1238:24:1241 | access to property Prop | UseUseExplosion.cs:24:1255:24:1258 | access to property Prop |
-| UseUseExplosion.cs:24:1238:24:1241 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1238:24:1241 | access to property Prop | UseUseExplosion.cs:24:2113:24:2118 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1238:24:1241 | this access | UseUseExplosion.cs:24:1255:24:1258 | this access |
 | UseUseExplosion.cs:24:1238:24:1241 | this access | UseUseExplosion.cs:24:2113:24:2118 | this access |
 | UseUseExplosion.cs:24:1255:24:1258 | [post] this access | UseUseExplosion.cs:24:1272:24:1275 | this access |
 | UseUseExplosion.cs:24:1255:24:1258 | [post] this access | UseUseExplosion.cs:24:2098:24:2103 | this access |
 | UseUseExplosion.cs:24:1255:24:1258 | access to property Prop | UseUseExplosion.cs:24:1255:24:1263 | ... > ... |
 | UseUseExplosion.cs:24:1255:24:1258 | access to property Prop | UseUseExplosion.cs:24:1272:24:1275 | access to property Prop |
-| UseUseExplosion.cs:24:1255:24:1258 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1255:24:1258 | access to property Prop | UseUseExplosion.cs:24:2098:24:2103 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1255:24:1258 | this access | UseUseExplosion.cs:24:1272:24:1275 | this access |
 | UseUseExplosion.cs:24:1255:24:1258 | this access | UseUseExplosion.cs:24:2098:24:2103 | this access |
 | UseUseExplosion.cs:24:1272:24:1275 | [post] this access | UseUseExplosion.cs:24:1289:24:1292 | this access |
 | UseUseExplosion.cs:24:1272:24:1275 | [post] this access | UseUseExplosion.cs:24:2083:24:2088 | this access |
 | UseUseExplosion.cs:24:1272:24:1275 | access to property Prop | UseUseExplosion.cs:24:1272:24:1280 | ... > ... |
 | UseUseExplosion.cs:24:1272:24:1275 | access to property Prop | UseUseExplosion.cs:24:1289:24:1292 | access to property Prop |
-| UseUseExplosion.cs:24:1272:24:1275 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1272:24:1275 | access to property Prop | UseUseExplosion.cs:24:2083:24:2088 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1272:24:1275 | this access | UseUseExplosion.cs:24:1289:24:1292 | this access |
 | UseUseExplosion.cs:24:1272:24:1275 | this access | UseUseExplosion.cs:24:2083:24:2088 | this access |
 | UseUseExplosion.cs:24:1289:24:1292 | [post] this access | UseUseExplosion.cs:24:1306:24:1309 | this access |
 | UseUseExplosion.cs:24:1289:24:1292 | [post] this access | UseUseExplosion.cs:24:2068:24:2073 | this access |
 | UseUseExplosion.cs:24:1289:24:1292 | access to property Prop | UseUseExplosion.cs:24:1289:24:1297 | ... > ... |
 | UseUseExplosion.cs:24:1289:24:1292 | access to property Prop | UseUseExplosion.cs:24:1306:24:1309 | access to property Prop |
-| UseUseExplosion.cs:24:1289:24:1292 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1289:24:1292 | access to property Prop | UseUseExplosion.cs:24:2068:24:2073 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1289:24:1292 | this access | UseUseExplosion.cs:24:1306:24:1309 | this access |
 | UseUseExplosion.cs:24:1289:24:1292 | this access | UseUseExplosion.cs:24:2068:24:2073 | this access |
 | UseUseExplosion.cs:24:1306:24:1309 | [post] this access | UseUseExplosion.cs:24:1323:24:1326 | this access |
 | UseUseExplosion.cs:24:1306:24:1309 | [post] this access | UseUseExplosion.cs:24:2053:24:2058 | this access |
 | UseUseExplosion.cs:24:1306:24:1309 | access to property Prop | UseUseExplosion.cs:24:1306:24:1314 | ... > ... |
 | UseUseExplosion.cs:24:1306:24:1309 | access to property Prop | UseUseExplosion.cs:24:1323:24:1326 | access to property Prop |
-| UseUseExplosion.cs:24:1306:24:1309 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1306:24:1309 | access to property Prop | UseUseExplosion.cs:24:2053:24:2058 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1306:24:1309 | this access | UseUseExplosion.cs:24:1323:24:1326 | this access |
 | UseUseExplosion.cs:24:1306:24:1309 | this access | UseUseExplosion.cs:24:2053:24:2058 | this access |
 | UseUseExplosion.cs:24:1323:24:1326 | [post] this access | UseUseExplosion.cs:24:1340:24:1343 | this access |
 | UseUseExplosion.cs:24:1323:24:1326 | [post] this access | UseUseExplosion.cs:24:2038:24:2043 | this access |
 | UseUseExplosion.cs:24:1323:24:1326 | access to property Prop | UseUseExplosion.cs:24:1323:24:1331 | ... > ... |
 | UseUseExplosion.cs:24:1323:24:1326 | access to property Prop | UseUseExplosion.cs:24:1340:24:1343 | access to property Prop |
-| UseUseExplosion.cs:24:1323:24:1326 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1323:24:1326 | access to property Prop | UseUseExplosion.cs:24:2038:24:2043 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1323:24:1326 | this access | UseUseExplosion.cs:24:1340:24:1343 | this access |
 | UseUseExplosion.cs:24:1323:24:1326 | this access | UseUseExplosion.cs:24:2038:24:2043 | this access |
 | UseUseExplosion.cs:24:1340:24:1343 | [post] this access | UseUseExplosion.cs:24:1357:24:1360 | this access |
 | UseUseExplosion.cs:24:1340:24:1343 | [post] this access | UseUseExplosion.cs:24:2023:24:2028 | this access |
 | UseUseExplosion.cs:24:1340:24:1343 | access to property Prop | UseUseExplosion.cs:24:1340:24:1348 | ... > ... |
 | UseUseExplosion.cs:24:1340:24:1343 | access to property Prop | UseUseExplosion.cs:24:1357:24:1360 | access to property Prop |
-| UseUseExplosion.cs:24:1340:24:1343 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1340:24:1343 | access to property Prop | UseUseExplosion.cs:24:2023:24:2028 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1340:24:1343 | this access | UseUseExplosion.cs:24:1357:24:1360 | this access |
 | UseUseExplosion.cs:24:1340:24:1343 | this access | UseUseExplosion.cs:24:2023:24:2028 | this access |
 | UseUseExplosion.cs:24:1357:24:1360 | [post] this access | UseUseExplosion.cs:24:1374:24:1377 | this access |
 | UseUseExplosion.cs:24:1357:24:1360 | [post] this access | UseUseExplosion.cs:24:2008:24:2013 | this access |
 | UseUseExplosion.cs:24:1357:24:1360 | access to property Prop | UseUseExplosion.cs:24:1357:24:1365 | ... > ... |
 | UseUseExplosion.cs:24:1357:24:1360 | access to property Prop | UseUseExplosion.cs:24:1374:24:1377 | access to property Prop |
-| UseUseExplosion.cs:24:1357:24:1360 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1357:24:1360 | access to property Prop | UseUseExplosion.cs:24:2008:24:2013 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1357:24:1360 | this access | UseUseExplosion.cs:24:1374:24:1377 | this access |
 | UseUseExplosion.cs:24:1357:24:1360 | this access | UseUseExplosion.cs:24:2008:24:2013 | this access |
 | UseUseExplosion.cs:24:1374:24:1377 | [post] this access | UseUseExplosion.cs:24:1391:24:1394 | this access |
 | UseUseExplosion.cs:24:1374:24:1377 | [post] this access | UseUseExplosion.cs:24:1993:24:1998 | this access |
 | UseUseExplosion.cs:24:1374:24:1377 | access to property Prop | UseUseExplosion.cs:24:1374:24:1382 | ... > ... |
 | UseUseExplosion.cs:24:1374:24:1377 | access to property Prop | UseUseExplosion.cs:24:1391:24:1394 | access to property Prop |
-| UseUseExplosion.cs:24:1374:24:1377 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1374:24:1377 | access to property Prop | UseUseExplosion.cs:24:1993:24:1998 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1374:24:1377 | this access | UseUseExplosion.cs:24:1391:24:1394 | this access |
 | UseUseExplosion.cs:24:1374:24:1377 | this access | UseUseExplosion.cs:24:1993:24:1998 | this access |
 | UseUseExplosion.cs:24:1391:24:1394 | [post] this access | UseUseExplosion.cs:24:1408:24:1411 | this access |
 | UseUseExplosion.cs:24:1391:24:1394 | [post] this access | UseUseExplosion.cs:24:1978:24:1983 | this access |
 | UseUseExplosion.cs:24:1391:24:1394 | access to property Prop | UseUseExplosion.cs:24:1391:24:1399 | ... > ... |
 | UseUseExplosion.cs:24:1391:24:1394 | access to property Prop | UseUseExplosion.cs:24:1408:24:1411 | access to property Prop |
-| UseUseExplosion.cs:24:1391:24:1394 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1391:24:1394 | access to property Prop | UseUseExplosion.cs:24:1978:24:1983 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1391:24:1394 | this access | UseUseExplosion.cs:24:1408:24:1411 | this access |
 | UseUseExplosion.cs:24:1391:24:1394 | this access | UseUseExplosion.cs:24:1978:24:1983 | this access |
 | UseUseExplosion.cs:24:1408:24:1411 | [post] this access | UseUseExplosion.cs:24:1425:24:1428 | this access |
 | UseUseExplosion.cs:24:1408:24:1411 | [post] this access | UseUseExplosion.cs:24:1963:24:1968 | this access |
 | UseUseExplosion.cs:24:1408:24:1411 | access to property Prop | UseUseExplosion.cs:24:1408:24:1416 | ... > ... |
 | UseUseExplosion.cs:24:1408:24:1411 | access to property Prop | UseUseExplosion.cs:24:1425:24:1428 | access to property Prop |
-| UseUseExplosion.cs:24:1408:24:1411 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1408:24:1411 | access to property Prop | UseUseExplosion.cs:24:1963:24:1968 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1408:24:1411 | this access | UseUseExplosion.cs:24:1425:24:1428 | this access |
 | UseUseExplosion.cs:24:1408:24:1411 | this access | UseUseExplosion.cs:24:1963:24:1968 | this access |
 | UseUseExplosion.cs:24:1425:24:1428 | [post] this access | UseUseExplosion.cs:24:1442:24:1445 | this access |
 | UseUseExplosion.cs:24:1425:24:1428 | [post] this access | UseUseExplosion.cs:24:1948:24:1953 | this access |
 | UseUseExplosion.cs:24:1425:24:1428 | access to property Prop | UseUseExplosion.cs:24:1425:24:1433 | ... > ... |
 | UseUseExplosion.cs:24:1425:24:1428 | access to property Prop | UseUseExplosion.cs:24:1442:24:1445 | access to property Prop |
-| UseUseExplosion.cs:24:1425:24:1428 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1425:24:1428 | access to property Prop | UseUseExplosion.cs:24:1948:24:1953 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1425:24:1428 | this access | UseUseExplosion.cs:24:1442:24:1445 | this access |
 | UseUseExplosion.cs:24:1425:24:1428 | this access | UseUseExplosion.cs:24:1948:24:1953 | this access |
 | UseUseExplosion.cs:24:1442:24:1445 | [post] this access | UseUseExplosion.cs:24:1459:24:1462 | this access |
 | UseUseExplosion.cs:24:1442:24:1445 | [post] this access | UseUseExplosion.cs:24:1933:24:1938 | this access |
 | UseUseExplosion.cs:24:1442:24:1445 | access to property Prop | UseUseExplosion.cs:24:1442:24:1450 | ... > ... |
 | UseUseExplosion.cs:24:1442:24:1445 | access to property Prop | UseUseExplosion.cs:24:1459:24:1462 | access to property Prop |
-| UseUseExplosion.cs:24:1442:24:1445 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1442:24:1445 | access to property Prop | UseUseExplosion.cs:24:1933:24:1938 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1442:24:1445 | this access | UseUseExplosion.cs:24:1459:24:1462 | this access |
 | UseUseExplosion.cs:24:1442:24:1445 | this access | UseUseExplosion.cs:24:1933:24:1938 | this access |
 | UseUseExplosion.cs:24:1459:24:1462 | [post] this access | UseUseExplosion.cs:24:1476:24:1479 | this access |
 | UseUseExplosion.cs:24:1459:24:1462 | [post] this access | UseUseExplosion.cs:24:1918:24:1923 | this access |
 | UseUseExplosion.cs:24:1459:24:1462 | access to property Prop | UseUseExplosion.cs:24:1459:24:1467 | ... > ... |
 | UseUseExplosion.cs:24:1459:24:1462 | access to property Prop | UseUseExplosion.cs:24:1476:24:1479 | access to property Prop |
-| UseUseExplosion.cs:24:1459:24:1462 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1459:24:1462 | access to property Prop | UseUseExplosion.cs:24:1918:24:1923 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1459:24:1462 | this access | UseUseExplosion.cs:24:1476:24:1479 | this access |
 | UseUseExplosion.cs:24:1459:24:1462 | this access | UseUseExplosion.cs:24:1918:24:1923 | this access |
 | UseUseExplosion.cs:24:1476:24:1479 | [post] this access | UseUseExplosion.cs:24:1493:24:1496 | this access |
 | UseUseExplosion.cs:24:1476:24:1479 | [post] this access | UseUseExplosion.cs:24:1903:24:1908 | this access |
 | UseUseExplosion.cs:24:1476:24:1479 | access to property Prop | UseUseExplosion.cs:24:1476:24:1484 | ... > ... |
 | UseUseExplosion.cs:24:1476:24:1479 | access to property Prop | UseUseExplosion.cs:24:1493:24:1496 | access to property Prop |
-| UseUseExplosion.cs:24:1476:24:1479 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1476:24:1479 | access to property Prop | UseUseExplosion.cs:24:1903:24:1908 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1476:24:1479 | this access | UseUseExplosion.cs:24:1493:24:1496 | this access |
 | UseUseExplosion.cs:24:1476:24:1479 | this access | UseUseExplosion.cs:24:1903:24:1908 | this access |
 | UseUseExplosion.cs:24:1493:24:1496 | [post] this access | UseUseExplosion.cs:24:1510:24:1513 | this access |
 | UseUseExplosion.cs:24:1493:24:1496 | [post] this access | UseUseExplosion.cs:24:1888:24:1893 | this access |
 | UseUseExplosion.cs:24:1493:24:1496 | access to property Prop | UseUseExplosion.cs:24:1493:24:1501 | ... > ... |
 | UseUseExplosion.cs:24:1493:24:1496 | access to property Prop | UseUseExplosion.cs:24:1510:24:1513 | access to property Prop |
-| UseUseExplosion.cs:24:1493:24:1496 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1493:24:1496 | access to property Prop | UseUseExplosion.cs:24:1888:24:1893 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1493:24:1496 | this access | UseUseExplosion.cs:24:1510:24:1513 | this access |
 | UseUseExplosion.cs:24:1493:24:1496 | this access | UseUseExplosion.cs:24:1888:24:1893 | this access |
 | UseUseExplosion.cs:24:1510:24:1513 | [post] this access | UseUseExplosion.cs:24:1527:24:1530 | this access |
 | UseUseExplosion.cs:24:1510:24:1513 | [post] this access | UseUseExplosion.cs:24:1873:24:1878 | this access |
 | UseUseExplosion.cs:24:1510:24:1513 | access to property Prop | UseUseExplosion.cs:24:1510:24:1518 | ... > ... |
 | UseUseExplosion.cs:24:1510:24:1513 | access to property Prop | UseUseExplosion.cs:24:1527:24:1530 | access to property Prop |
-| UseUseExplosion.cs:24:1510:24:1513 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1510:24:1513 | access to property Prop | UseUseExplosion.cs:24:1873:24:1878 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1510:24:1513 | this access | UseUseExplosion.cs:24:1527:24:1530 | this access |
 | UseUseExplosion.cs:24:1510:24:1513 | this access | UseUseExplosion.cs:24:1873:24:1878 | this access |
 | UseUseExplosion.cs:24:1527:24:1530 | [post] this access | UseUseExplosion.cs:24:1544:24:1547 | this access |
 | UseUseExplosion.cs:24:1527:24:1530 | [post] this access | UseUseExplosion.cs:24:1858:24:1863 | this access |
 | UseUseExplosion.cs:24:1527:24:1530 | access to property Prop | UseUseExplosion.cs:24:1527:24:1535 | ... > ... |
 | UseUseExplosion.cs:24:1527:24:1530 | access to property Prop | UseUseExplosion.cs:24:1544:24:1547 | access to property Prop |
-| UseUseExplosion.cs:24:1527:24:1530 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1527:24:1530 | access to property Prop | UseUseExplosion.cs:24:1858:24:1863 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1527:24:1530 | this access | UseUseExplosion.cs:24:1544:24:1547 | this access |
 | UseUseExplosion.cs:24:1527:24:1530 | this access | UseUseExplosion.cs:24:1858:24:1863 | this access |
 | UseUseExplosion.cs:24:1544:24:1547 | [post] this access | UseUseExplosion.cs:24:1561:24:1564 | this access |
 | UseUseExplosion.cs:24:1544:24:1547 | [post] this access | UseUseExplosion.cs:24:1843:24:1848 | this access |
 | UseUseExplosion.cs:24:1544:24:1547 | access to property Prop | UseUseExplosion.cs:24:1544:24:1552 | ... > ... |
 | UseUseExplosion.cs:24:1544:24:1547 | access to property Prop | UseUseExplosion.cs:24:1561:24:1564 | access to property Prop |
-| UseUseExplosion.cs:24:1544:24:1547 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1544:24:1547 | access to property Prop | UseUseExplosion.cs:24:1843:24:1848 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1544:24:1547 | this access | UseUseExplosion.cs:24:1561:24:1564 | this access |
 | UseUseExplosion.cs:24:1544:24:1547 | this access | UseUseExplosion.cs:24:1843:24:1848 | this access |
 | UseUseExplosion.cs:24:1561:24:1564 | [post] this access | UseUseExplosion.cs:24:1577:24:1580 | this access |
 | UseUseExplosion.cs:24:1561:24:1564 | [post] this access | UseUseExplosion.cs:24:1828:24:1833 | this access |
 | UseUseExplosion.cs:24:1561:24:1564 | access to property Prop | UseUseExplosion.cs:24:1561:24:1568 | ... > ... |
 | UseUseExplosion.cs:24:1561:24:1564 | access to property Prop | UseUseExplosion.cs:24:1577:24:1580 | access to property Prop |
-| UseUseExplosion.cs:24:1561:24:1564 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1561:24:1564 | access to property Prop | UseUseExplosion.cs:24:1828:24:1833 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1561:24:1564 | this access | UseUseExplosion.cs:24:1577:24:1580 | this access |
 | UseUseExplosion.cs:24:1561:24:1564 | this access | UseUseExplosion.cs:24:1828:24:1833 | this access |
 | UseUseExplosion.cs:24:1577:24:1580 | [post] this access | UseUseExplosion.cs:24:1593:24:1596 | this access |
 | UseUseExplosion.cs:24:1577:24:1580 | [post] this access | UseUseExplosion.cs:24:1813:24:1818 | this access |
 | UseUseExplosion.cs:24:1577:24:1580 | access to property Prop | UseUseExplosion.cs:24:1577:24:1584 | ... > ... |
 | UseUseExplosion.cs:24:1577:24:1580 | access to property Prop | UseUseExplosion.cs:24:1593:24:1596 | access to property Prop |
-| UseUseExplosion.cs:24:1577:24:1580 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1577:24:1580 | access to property Prop | UseUseExplosion.cs:24:1813:24:1818 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1577:24:1580 | this access | UseUseExplosion.cs:24:1593:24:1596 | this access |
 | UseUseExplosion.cs:24:1577:24:1580 | this access | UseUseExplosion.cs:24:1813:24:1818 | this access |
 | UseUseExplosion.cs:24:1593:24:1596 | [post] this access | UseUseExplosion.cs:24:1609:24:1612 | this access |
 | UseUseExplosion.cs:24:1593:24:1596 | [post] this access | UseUseExplosion.cs:24:1798:24:1803 | this access |
 | UseUseExplosion.cs:24:1593:24:1596 | access to property Prop | UseUseExplosion.cs:24:1593:24:1600 | ... > ... |
 | UseUseExplosion.cs:24:1593:24:1596 | access to property Prop | UseUseExplosion.cs:24:1609:24:1612 | access to property Prop |
-| UseUseExplosion.cs:24:1593:24:1596 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1593:24:1596 | access to property Prop | UseUseExplosion.cs:24:1798:24:1803 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1593:24:1596 | this access | UseUseExplosion.cs:24:1609:24:1612 | this access |
 | UseUseExplosion.cs:24:1593:24:1596 | this access | UseUseExplosion.cs:24:1798:24:1803 | this access |
 | UseUseExplosion.cs:24:1609:24:1612 | [post] this access | UseUseExplosion.cs:24:1625:24:1628 | this access |
 | UseUseExplosion.cs:24:1609:24:1612 | [post] this access | UseUseExplosion.cs:24:1783:24:1788 | this access |
 | UseUseExplosion.cs:24:1609:24:1612 | access to property Prop | UseUseExplosion.cs:24:1609:24:1616 | ... > ... |
 | UseUseExplosion.cs:24:1609:24:1612 | access to property Prop | UseUseExplosion.cs:24:1625:24:1628 | access to property Prop |
-| UseUseExplosion.cs:24:1609:24:1612 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1609:24:1612 | access to property Prop | UseUseExplosion.cs:24:1783:24:1788 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1609:24:1612 | this access | UseUseExplosion.cs:24:1625:24:1628 | this access |
 | UseUseExplosion.cs:24:1609:24:1612 | this access | UseUseExplosion.cs:24:1783:24:1788 | this access |
 | UseUseExplosion.cs:24:1625:24:1628 | [post] this access | UseUseExplosion.cs:24:1641:24:1644 | this access |
 | UseUseExplosion.cs:24:1625:24:1628 | [post] this access | UseUseExplosion.cs:24:1768:24:1773 | this access |
 | UseUseExplosion.cs:24:1625:24:1628 | access to property Prop | UseUseExplosion.cs:24:1625:24:1632 | ... > ... |
 | UseUseExplosion.cs:24:1625:24:1628 | access to property Prop | UseUseExplosion.cs:24:1641:24:1644 | access to property Prop |
-| UseUseExplosion.cs:24:1625:24:1628 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1625:24:1628 | access to property Prop | UseUseExplosion.cs:24:1768:24:1773 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1625:24:1628 | this access | UseUseExplosion.cs:24:1641:24:1644 | this access |
 | UseUseExplosion.cs:24:1625:24:1628 | this access | UseUseExplosion.cs:24:1768:24:1773 | this access |
 | UseUseExplosion.cs:24:1641:24:1644 | [post] this access | UseUseExplosion.cs:24:1657:24:1660 | this access |
 | UseUseExplosion.cs:24:1641:24:1644 | [post] this access | UseUseExplosion.cs:24:1753:24:1758 | this access |
 | UseUseExplosion.cs:24:1641:24:1644 | access to property Prop | UseUseExplosion.cs:24:1641:24:1648 | ... > ... |
 | UseUseExplosion.cs:24:1641:24:1644 | access to property Prop | UseUseExplosion.cs:24:1657:24:1660 | access to property Prop |
-| UseUseExplosion.cs:24:1641:24:1644 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1641:24:1644 | access to property Prop | UseUseExplosion.cs:24:1753:24:1758 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1641:24:1644 | this access | UseUseExplosion.cs:24:1657:24:1660 | this access |
 | UseUseExplosion.cs:24:1641:24:1644 | this access | UseUseExplosion.cs:24:1753:24:1758 | this access |
 | UseUseExplosion.cs:24:1657:24:1660 | [post] this access | UseUseExplosion.cs:24:1673:24:1676 | this access |
 | UseUseExplosion.cs:24:1657:24:1660 | [post] this access | UseUseExplosion.cs:24:1738:24:1743 | this access |
 | UseUseExplosion.cs:24:1657:24:1660 | access to property Prop | UseUseExplosion.cs:24:1657:24:1664 | ... > ... |
 | UseUseExplosion.cs:24:1657:24:1660 | access to property Prop | UseUseExplosion.cs:24:1673:24:1676 | access to property Prop |
-| UseUseExplosion.cs:24:1657:24:1660 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1657:24:1660 | access to property Prop | UseUseExplosion.cs:24:1738:24:1743 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1657:24:1660 | this access | UseUseExplosion.cs:24:1673:24:1676 | this access |
 | UseUseExplosion.cs:24:1657:24:1660 | this access | UseUseExplosion.cs:24:1738:24:1743 | this access |
 | UseUseExplosion.cs:24:1673:24:1676 | [post] this access | UseUseExplosion.cs:24:1689:24:1692 | this access |
 | UseUseExplosion.cs:24:1673:24:1676 | [post] this access | UseUseExplosion.cs:24:1723:24:1728 | this access |
 | UseUseExplosion.cs:24:1673:24:1676 | access to property Prop | UseUseExplosion.cs:24:1673:24:1680 | ... > ... |
 | UseUseExplosion.cs:24:1673:24:1676 | access to property Prop | UseUseExplosion.cs:24:1689:24:1692 | access to property Prop |
-| UseUseExplosion.cs:24:1673:24:1676 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1673:24:1676 | access to property Prop | UseUseExplosion.cs:24:1723:24:1728 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1673:24:1676 | this access | UseUseExplosion.cs:24:1689:24:1692 | this access |
 | UseUseExplosion.cs:24:1673:24:1676 | this access | UseUseExplosion.cs:24:1723:24:1728 | this access |
 | UseUseExplosion.cs:24:1689:24:1692 | [post] this access | UseUseExplosion.cs:24:1708:24:1713 | this access |
 | UseUseExplosion.cs:24:1689:24:1692 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1689:24:1692 | access to property Prop | UseUseExplosion.cs:24:1689:24:1696 | ... > ... |
-| UseUseExplosion.cs:24:1689:24:1692 | access to property Prop | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1689:24:1692 | access to property Prop | UseUseExplosion.cs:24:1699:24:1701 | [input] SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1689:24:1692 | access to property Prop | UseUseExplosion.cs:24:1708:24:1713 | [input] SSA phi read(this.Prop) |
 | UseUseExplosion.cs:24:1689:24:1692 | this access | UseUseExplosion.cs:24:1708:24:1713 | this access |
 | UseUseExplosion.cs:24:1689:24:1692 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
+| UseUseExplosion.cs:24:1699:24:1701 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1699:24:1701 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1708:24:1713 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1708:24:1713 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1708:24:1713 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1708:24:1713 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1712:24:1712 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1712:24:1712 | access to local variable x | UseUseExplosion.cs:24:1708:24:1713 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1723:24:1728 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1723:24:1728 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1723:24:1728 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1723:24:1728 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1727:24:1727 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1727:24:1727 | access to local variable x | UseUseExplosion.cs:24:1723:24:1728 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1738:24:1743 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1738:24:1743 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1738:24:1743 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1738:24:1743 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1742:24:1742 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1742:24:1742 | access to local variable x | UseUseExplosion.cs:24:1738:24:1743 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1753:24:1758 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1753:24:1758 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1753:24:1758 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1753:24:1758 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1757:24:1757 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1757:24:1757 | access to local variable x | UseUseExplosion.cs:24:1753:24:1758 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1768:24:1773 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1768:24:1773 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1768:24:1773 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1768:24:1773 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1772:24:1772 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1772:24:1772 | access to local variable x | UseUseExplosion.cs:24:1768:24:1773 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1783:24:1788 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1783:24:1788 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1783:24:1788 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1783:24:1788 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1787:24:1787 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1787:24:1787 | access to local variable x | UseUseExplosion.cs:24:1783:24:1788 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1798:24:1803 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1798:24:1803 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1798:24:1803 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1798:24:1803 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1802:24:1802 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1802:24:1802 | access to local variable x | UseUseExplosion.cs:24:1798:24:1803 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1813:24:1818 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1813:24:1818 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1813:24:1818 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1813:24:1818 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1817:24:1817 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1817:24:1817 | access to local variable x | UseUseExplosion.cs:24:1813:24:1818 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1828:24:1833 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1828:24:1833 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1828:24:1833 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1828:24:1833 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1832:24:1832 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1832:24:1832 | access to local variable x | UseUseExplosion.cs:24:1828:24:1833 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1843:24:1848 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1843:24:1848 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1843:24:1848 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1843:24:1848 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1847:24:1847 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1847:24:1847 | access to local variable x | UseUseExplosion.cs:24:1843:24:1848 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1858:24:1863 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1858:24:1863 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1858:24:1863 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1858:24:1863 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1862:24:1862 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1862:24:1862 | access to local variable x | UseUseExplosion.cs:24:1858:24:1863 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1873:24:1878 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1873:24:1878 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1873:24:1878 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1873:24:1878 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1877:24:1877 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1877:24:1877 | access to local variable x | UseUseExplosion.cs:24:1873:24:1878 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1888:24:1893 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1888:24:1893 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1888:24:1893 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1888:24:1893 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1892:24:1892 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1892:24:1892 | access to local variable x | UseUseExplosion.cs:24:1888:24:1893 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1903:24:1908 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1903:24:1908 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1903:24:1908 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1903:24:1908 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1907:24:1907 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1907:24:1907 | access to local variable x | UseUseExplosion.cs:24:1903:24:1908 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1918:24:1923 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1918:24:1923 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1918:24:1923 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1918:24:1923 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1922:24:1922 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1922:24:1922 | access to local variable x | UseUseExplosion.cs:24:1918:24:1923 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1933:24:1938 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1933:24:1938 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1933:24:1938 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1933:24:1938 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1937:24:1937 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1937:24:1937 | access to local variable x | UseUseExplosion.cs:24:1933:24:1938 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1948:24:1953 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1948:24:1953 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1948:24:1953 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1948:24:1953 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1952:24:1952 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1952:24:1952 | access to local variable x | UseUseExplosion.cs:24:1948:24:1953 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1963:24:1968 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1963:24:1968 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1963:24:1968 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1963:24:1968 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1967:24:1967 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1967:24:1967 | access to local variable x | UseUseExplosion.cs:24:1963:24:1968 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1978:24:1983 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1978:24:1983 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1978:24:1983 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1978:24:1983 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1982:24:1982 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1982:24:1982 | access to local variable x | UseUseExplosion.cs:24:1978:24:1983 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:1993:24:1998 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:1993:24:1998 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:1993:24:1998 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:1993:24:1998 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:1997:24:1997 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:1997:24:1997 | access to local variable x | UseUseExplosion.cs:24:1993:24:1998 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2008:24:2013 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2008:24:2013 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2008:24:2013 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2008:24:2013 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2012:24:2012 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2012:24:2012 | access to local variable x | UseUseExplosion.cs:24:2008:24:2013 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2023:24:2028 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2023:24:2028 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2023:24:2028 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2023:24:2028 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2027:24:2027 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2027:24:2027 | access to local variable x | UseUseExplosion.cs:24:2023:24:2028 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2038:24:2043 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2038:24:2043 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2038:24:2043 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2038:24:2043 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2042:24:2042 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2042:24:2042 | access to local variable x | UseUseExplosion.cs:24:2038:24:2043 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2053:24:2058 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2053:24:2058 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2053:24:2058 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2053:24:2058 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2057:24:2057 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2057:24:2057 | access to local variable x | UseUseExplosion.cs:24:2053:24:2058 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2068:24:2073 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2068:24:2073 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2068:24:2073 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2068:24:2073 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2072:24:2072 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2072:24:2072 | access to local variable x | UseUseExplosion.cs:24:2068:24:2073 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2083:24:2088 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2083:24:2088 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2083:24:2088 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2083:24:2088 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2087:24:2087 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2087:24:2087 | access to local variable x | UseUseExplosion.cs:24:2083:24:2088 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2098:24:2103 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2098:24:2103 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2098:24:2103 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2098:24:2103 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2102:24:2102 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2102:24:2102 | access to local variable x | UseUseExplosion.cs:24:2098:24:2103 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2113:24:2118 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2113:24:2118 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2113:24:2118 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2113:24:2118 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2117:24:2117 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2117:24:2117 | access to local variable x | UseUseExplosion.cs:24:2113:24:2118 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2128:24:2133 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2128:24:2133 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2128:24:2133 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2128:24:2133 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2132:24:2132 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2132:24:2132 | access to local variable x | UseUseExplosion.cs:24:2128:24:2133 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2143:24:2148 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2143:24:2148 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2143:24:2148 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2143:24:2148 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2147:24:2147 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2147:24:2147 | access to local variable x | UseUseExplosion.cs:24:2143:24:2148 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2158:24:2163 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2158:24:2163 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2158:24:2163 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2158:24:2163 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2162:24:2162 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2162:24:2162 | access to local variable x | UseUseExplosion.cs:24:2158:24:2163 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2173:24:2178 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2173:24:2178 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2173:24:2178 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2173:24:2178 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2177:24:2177 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2177:24:2177 | access to local variable x | UseUseExplosion.cs:24:2173:24:2178 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2188:24:2193 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2188:24:2193 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2188:24:2193 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2188:24:2193 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2192:24:2192 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2192:24:2192 | access to local variable x | UseUseExplosion.cs:24:2188:24:2193 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2203:24:2208 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2203:24:2208 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2203:24:2208 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2203:24:2208 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2207:24:2207 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2207:24:2207 | access to local variable x | UseUseExplosion.cs:24:2203:24:2208 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2218:24:2223 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2218:24:2223 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2218:24:2223 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2218:24:2223 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2222:24:2222 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2222:24:2222 | access to local variable x | UseUseExplosion.cs:24:2218:24:2223 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2233:24:2238 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2233:24:2238 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2233:24:2238 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2233:24:2238 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2237:24:2237 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2237:24:2237 | access to local variable x | UseUseExplosion.cs:24:2233:24:2238 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2248:24:2253 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2248:24:2253 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2248:24:2253 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2248:24:2253 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2252:24:2252 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2252:24:2252 | access to local variable x | UseUseExplosion.cs:24:2248:24:2253 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2263:24:2268 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2263:24:2268 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2263:24:2268 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2263:24:2268 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2267:24:2267 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2267:24:2267 | access to local variable x | UseUseExplosion.cs:24:2263:24:2268 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2278:24:2283 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2278:24:2283 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2278:24:2283 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2278:24:2283 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2282:24:2282 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2282:24:2282 | access to local variable x | UseUseExplosion.cs:24:2278:24:2283 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2293:24:2298 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2293:24:2298 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2293:24:2298 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2293:24:2298 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2297:24:2297 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2297:24:2297 | access to local variable x | UseUseExplosion.cs:24:2293:24:2298 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2308:24:2313 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2308:24:2313 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2308:24:2313 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2308:24:2313 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2312:24:2312 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2312:24:2312 | access to local variable x | UseUseExplosion.cs:24:2308:24:2313 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2323:24:2328 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2323:24:2328 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2323:24:2328 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2323:24:2328 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2327:24:2327 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2327:24:2327 | access to local variable x | UseUseExplosion.cs:24:2323:24:2328 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2338:24:2343 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2338:24:2343 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2338:24:2343 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2338:24:2343 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2342:24:2342 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2342:24:2342 | access to local variable x | UseUseExplosion.cs:24:2338:24:2343 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2353:24:2358 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2353:24:2358 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2353:24:2358 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2353:24:2358 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2357:24:2357 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2357:24:2357 | access to local variable x | UseUseExplosion.cs:24:2353:24:2358 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2368:24:2373 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2368:24:2373 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2368:24:2373 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2368:24:2373 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2372:24:2372 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2372:24:2372 | access to local variable x | UseUseExplosion.cs:24:2368:24:2373 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2383:24:2388 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2383:24:2388 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2383:24:2388 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2383:24:2388 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2387:24:2387 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2387:24:2387 | access to local variable x | UseUseExplosion.cs:24:2383:24:2388 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2398:24:2403 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2398:24:2403 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2398:24:2403 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2398:24:2403 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2402:24:2402 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2402:24:2402 | access to local variable x | UseUseExplosion.cs:24:2398:24:2403 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2413:24:2418 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2413:24:2418 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2413:24:2418 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2413:24:2418 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2417:24:2417 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2417:24:2417 | access to local variable x | UseUseExplosion.cs:24:2413:24:2418 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2428:24:2433 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2428:24:2433 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2428:24:2433 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2428:24:2433 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2432:24:2432 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2432:24:2432 | access to local variable x | UseUseExplosion.cs:24:2428:24:2433 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2443:24:2448 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2443:24:2448 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2443:24:2448 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2443:24:2448 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2447:24:2447 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2447:24:2447 | access to local variable x | UseUseExplosion.cs:24:2443:24:2448 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2458:24:2463 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2458:24:2463 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2458:24:2463 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2458:24:2463 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2462:24:2462 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2462:24:2462 | access to local variable x | UseUseExplosion.cs:24:2458:24:2463 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2473:24:2478 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2473:24:2478 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2473:24:2478 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2473:24:2478 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2477:24:2477 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2477:24:2477 | access to local variable x | UseUseExplosion.cs:24:2473:24:2478 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2488:24:2493 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2488:24:2493 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2488:24:2493 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2488:24:2493 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2492:24:2492 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2492:24:2492 | access to local variable x | UseUseExplosion.cs:24:2488:24:2493 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2503:24:2508 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2503:24:2508 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2503:24:2508 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2503:24:2508 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2507:24:2507 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2507:24:2507 | access to local variable x | UseUseExplosion.cs:24:2503:24:2508 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2518:24:2523 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2518:24:2523 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2518:24:2523 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2518:24:2523 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2522:24:2522 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2522:24:2522 | access to local variable x | UseUseExplosion.cs:24:2518:24:2523 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2533:24:2538 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2533:24:2538 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2533:24:2538 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2533:24:2538 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2537:24:2537 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2537:24:2537 | access to local variable x | UseUseExplosion.cs:24:2533:24:2538 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2548:24:2553 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2548:24:2553 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2548:24:2553 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2548:24:2553 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2552:24:2552 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2552:24:2552 | access to local variable x | UseUseExplosion.cs:24:2548:24:2553 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2563:24:2568 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2563:24:2568 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2563:24:2568 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2563:24:2568 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2567:24:2567 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2567:24:2567 | access to local variable x | UseUseExplosion.cs:24:2563:24:2568 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2578:24:2583 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2578:24:2583 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2578:24:2583 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2578:24:2583 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2582:24:2582 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2582:24:2582 | access to local variable x | UseUseExplosion.cs:24:2578:24:2583 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2593:24:2598 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2593:24:2598 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2593:24:2598 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2593:24:2598 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2597:24:2597 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2597:24:2597 | access to local variable x | UseUseExplosion.cs:24:2593:24:2598 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2608:24:2613 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2608:24:2613 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2608:24:2613 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2608:24:2613 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2612:24:2612 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2612:24:2612 | access to local variable x | UseUseExplosion.cs:24:2608:24:2613 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2623:24:2628 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2623:24:2628 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2623:24:2628 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2623:24:2628 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2627:24:2627 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2627:24:2627 | access to local variable x | UseUseExplosion.cs:24:2623:24:2628 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2638:24:2643 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2638:24:2643 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2638:24:2643 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2638:24:2643 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2642:24:2642 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2642:24:2642 | access to local variable x | UseUseExplosion.cs:24:2638:24:2643 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2653:24:2658 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2653:24:2658 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2653:24:2658 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2653:24:2658 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2657:24:2657 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2657:24:2657 | access to local variable x | UseUseExplosion.cs:24:2653:24:2658 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2668:24:2673 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2668:24:2673 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2668:24:2673 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2668:24:2673 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2672:24:2672 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2672:24:2672 | access to local variable x | UseUseExplosion.cs:24:2668:24:2673 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2683:24:2688 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2683:24:2688 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2683:24:2688 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2683:24:2688 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2687:24:2687 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2687:24:2687 | access to local variable x | UseUseExplosion.cs:24:2683:24:2688 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2698:24:2703 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2698:24:2703 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2698:24:2703 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2698:24:2703 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2702:24:2702 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2702:24:2702 | access to local variable x | UseUseExplosion.cs:24:2698:24:2703 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2713:24:2718 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2713:24:2718 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2713:24:2718 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2713:24:2718 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2717:24:2717 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2717:24:2717 | access to local variable x | UseUseExplosion.cs:24:2713:24:2718 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2728:24:2733 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2728:24:2733 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2728:24:2733 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2728:24:2733 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2732:24:2732 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2732:24:2732 | access to local variable x | UseUseExplosion.cs:24:2728:24:2733 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2743:24:2748 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2743:24:2748 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2743:24:2748 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2743:24:2748 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2747:24:2747 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2747:24:2747 | access to local variable x | UseUseExplosion.cs:24:2743:24:2748 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2758:24:2763 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2758:24:2763 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2758:24:2763 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2758:24:2763 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2762:24:2762 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2762:24:2762 | access to local variable x | UseUseExplosion.cs:24:2758:24:2763 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2773:24:2778 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2773:24:2778 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2773:24:2778 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2773:24:2778 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2777:24:2777 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2777:24:2777 | access to local variable x | UseUseExplosion.cs:24:2773:24:2778 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2788:24:2793 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2788:24:2793 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2788:24:2793 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2788:24:2793 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2792:24:2792 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2792:24:2792 | access to local variable x | UseUseExplosion.cs:24:2788:24:2793 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2803:24:2808 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2803:24:2808 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2803:24:2808 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2803:24:2808 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2807:24:2807 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2807:24:2807 | access to local variable x | UseUseExplosion.cs:24:2803:24:2808 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2818:24:2823 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2818:24:2823 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2818:24:2823 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2818:24:2823 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2822:24:2822 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2822:24:2822 | access to local variable x | UseUseExplosion.cs:24:2818:24:2823 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2833:24:2838 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2833:24:2838 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2833:24:2838 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2833:24:2838 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2837:24:2837 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2837:24:2837 | access to local variable x | UseUseExplosion.cs:24:2833:24:2838 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2848:24:2853 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2848:24:2853 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2848:24:2853 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2848:24:2853 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2852:24:2852 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2852:24:2852 | access to local variable x | UseUseExplosion.cs:24:2848:24:2853 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2863:24:2868 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2863:24:2868 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2863:24:2868 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2863:24:2868 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2867:24:2867 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2867:24:2867 | access to local variable x | UseUseExplosion.cs:24:2863:24:2868 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2878:24:2883 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2878:24:2883 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2878:24:2883 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2878:24:2883 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2882:24:2882 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2882:24:2882 | access to local variable x | UseUseExplosion.cs:24:2878:24:2883 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2893:24:2898 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2893:24:2898 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2893:24:2898 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2893:24:2898 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2897:24:2897 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2897:24:2897 | access to local variable x | UseUseExplosion.cs:24:2893:24:2898 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2908:24:2913 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2908:24:2913 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2908:24:2913 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2908:24:2913 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2912:24:2912 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2912:24:2912 | access to local variable x | UseUseExplosion.cs:24:2908:24:2913 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2923:24:2928 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2923:24:2928 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2923:24:2928 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2923:24:2928 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2927:24:2927 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2927:24:2927 | access to local variable x | UseUseExplosion.cs:24:2923:24:2928 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2938:24:2943 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2938:24:2943 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2938:24:2943 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2938:24:2943 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2942:24:2942 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2942:24:2942 | access to local variable x | UseUseExplosion.cs:24:2938:24:2943 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2953:24:2958 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2953:24:2958 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2953:24:2958 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2953:24:2958 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2957:24:2957 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2957:24:2957 | access to local variable x | UseUseExplosion.cs:24:2953:24:2958 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2968:24:2973 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2968:24:2973 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2968:24:2973 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2968:24:2973 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2972:24:2972 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2972:24:2972 | access to local variable x | UseUseExplosion.cs:24:2968:24:2973 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2983:24:2988 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2983:24:2988 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2983:24:2988 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2983:24:2988 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:2987:24:2987 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:2987:24:2987 | access to local variable x | UseUseExplosion.cs:24:2983:24:2988 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:2998:24:3003 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:2998:24:3003 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:2998:24:3003 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:2998:24:3003 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:3002:24:3002 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:3002:24:3002 | access to local variable x | UseUseExplosion.cs:24:2998:24:3003 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:3013:24:3018 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:3013:24:3018 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:3013:24:3018 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:3013:24:3018 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:3017:24:3017 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:3017:24:3017 | access to local variable x | UseUseExplosion.cs:24:3013:24:3018 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:3028:24:3033 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:3028:24:3033 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:3028:24:3033 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:3028:24:3033 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:3032:24:3032 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:3032:24:3032 | access to local variable x | UseUseExplosion.cs:24:3028:24:3033 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:3043:24:3048 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:3043:24:3048 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:3043:24:3048 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:3043:24:3048 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:3047:24:3047 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:3047:24:3047 | access to local variable x | UseUseExplosion.cs:24:3043:24:3048 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:3058:24:3063 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:3058:24:3063 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:3058:24:3063 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:3058:24:3063 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:3062:24:3062 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:3062:24:3062 | access to local variable x | UseUseExplosion.cs:24:3058:24:3063 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:3073:24:3078 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:3073:24:3078 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:3073:24:3078 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:3073:24:3078 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:3077:24:3077 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:3077:24:3077 | access to local variable x | UseUseExplosion.cs:24:3073:24:3078 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:3088:24:3093 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:3088:24:3093 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:3088:24:3093 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:3088:24:3093 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:3092:24:3092 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:3092:24:3092 | access to local variable x | UseUseExplosion.cs:24:3088:24:3093 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:3103:24:3108 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:3103:24:3108 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:3103:24:3108 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:3103:24:3108 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:3107:24:3107 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:3107:24:3107 | access to local variable x | UseUseExplosion.cs:24:3103:24:3108 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:3118:24:3123 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:3118:24:3123 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:3118:24:3123 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:3118:24:3123 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:3122:24:3122 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:3122:24:3122 | access to local variable x | UseUseExplosion.cs:24:3118:24:3123 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:3133:24:3138 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:3133:24:3138 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:3133:24:3138 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:3133:24:3138 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:3137:24:3137 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:3137:24:3137 | access to local variable x | UseUseExplosion.cs:24:3133:24:3138 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:3148:24:3153 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:3148:24:3153 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:3148:24:3153 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:3148:24:3153 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:3152:24:3152 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:3152:24:3152 | access to local variable x | UseUseExplosion.cs:24:3148:24:3153 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:3163:24:3168 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:3163:24:3168 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:3163:24:3168 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:3163:24:3168 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:3167:24:3167 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:3167:24:3167 | access to local variable x | UseUseExplosion.cs:24:3163:24:3168 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:3178:24:3183 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:3178:24:3183 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:3178:24:3183 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:3178:24:3183 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:3182:24:3182 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:3182:24:3182 | access to local variable x | UseUseExplosion.cs:24:3178:24:3183 | [input] SSA phi read(x) |
+| UseUseExplosion.cs:24:3193:24:3198 | [input] SSA phi read(this.Prop) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) |
+| UseUseExplosion.cs:24:3193:24:3198 | [input] SSA phi read(x) | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
 | UseUseExplosion.cs:24:3193:24:3198 | [post] this access | UseUseExplosion.cs:25:13:25:16 | this access |
 | UseUseExplosion.cs:24:3193:24:3198 | this access | UseUseExplosion.cs:25:13:25:16 | this access |
-| UseUseExplosion.cs:24:3197:24:3197 | access to local variable x | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) |
+| UseUseExplosion.cs:24:3197:24:3197 | access to local variable x | UseUseExplosion.cs:24:3193:24:3198 | [input] SSA phi read(x) |
 | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(this.Prop) | UseUseExplosion.cs:25:13:25:16 | access to property Prop |
 | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) | UseUseExplosion.cs:25:1712:25:1712 | access to local variable x |
 | UseUseExplosion.cs:25:9:25:3199 | SSA phi read(x) | UseUseExplosion.cs:25:1727:25:1727 | access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/tuples/DataFlowStep.expected
+++ b/csharp/ql/test/library-tests/dataflow/tuples/DataFlowStep.expected
@@ -92,7 +92,8 @@
 | Tuples.cs:51:14:51:14 | [post] access to local variable y | Tuples.cs:52:14:52:14 | access to local variable y |
 | Tuples.cs:51:14:51:14 | access to local variable y | Tuples.cs:52:14:52:14 | access to local variable y |
 | Tuples.cs:52:14:52:20 | access to field Item2 | Tuples.cs:52:14:52:20 | (...) ... |
-| Tuples.cs:55:27:55:27 | s | Tuples.cs:75:18:75:18 | access to parameter s |
+| Tuples.cs:55:27:55:27 | SSA param(s) | Tuples.cs:75:18:75:18 | access to parameter s |
+| Tuples.cs:55:27:55:27 | s | Tuples.cs:55:27:55:27 | SSA param(s) |
 | Tuples.cs:57:13:57:14 | access to local variable o1 | Tuples.cs:57:13:57:34 | SSA def(o1) |
 | Tuples.cs:57:13:57:34 | SSA def(o1) | Tuples.cs:59:18:59:19 | access to local variable o1 |
 | Tuples.cs:57:18:57:34 | call to method Source<String> | Tuples.cs:57:13:57:14 | access to local variable o1 |

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -522,6 +522,7 @@ private module Cached {
       |
         isUseStep = false
         or
+        isUseStep = true and
         not FlowSummaryImpl::Private::Steps::prohibitsUseUseFlow(nodeFrom, _)
       )
       or


### PR DESCRIPTION
This PR adopts the newly introduced shared [SSA data-flow integration layer](https://github.com/github/codeql/pull/16884). A side-effect is that we get [phi-input barrier guards](https://github.com/github/codeql/pull/15985) for free, which had not previously been ported to C#.