### PR TITLE
Python: Handle diagnostics writing for `BuiltinModuleExtractable`

### DIFF
--- a/python/extractor/semmle/logging.py
+++ b/python/extractor/semmle/logging.py
@@ -373,7 +373,8 @@ def syntax_error_message(exception, unit):
     return error
 
 def recursion_error_message(exception, unit):
-    l = Location(file=unit.path)
+    # if unit is a BuiltinModuleExtractable, there will be no path attribute
+    l = Location(file=getattr(unit, "path", str(unit)))
     return (DiagnosticMessage(Source("py/diagnostics/recursion-error", "Recursion error in Python extractor"), Severity.ERROR)
             .with_location(l)
             .text(exception.args[0])
@@ -383,7 +384,8 @@ def recursion_error_message(exception, unit):
     )
 
 def internal_error_message(exception, unit):
-    l = Location(file=unit.path)
+    # if unit is a BuiltinModuleExtractable, there will be no path attribute
+    l = Location(file=getattr(unit, "path", str(unit)))
     return (DiagnosticMessage(Source("py/diagnostics/internal-error", "Internal error in Python extractor"), Severity.ERROR)
             .with_location(l)
             .text("Internal error")

--- a/python/extractor/semmle/logging.py
+++ b/python/extractor/semmle/logging.py
@@ -374,7 +374,7 @@ def syntax_error_message(exception, unit):
 
 def recursion_error_message(exception, unit):
     # if unit is a BuiltinModuleExtractable, there will be no path attribute
-    l = Location(file=getattr(unit, "path", str(unit)))
+    l = Location(file=unit.path) if hasattr(unit, "path") else None
     return (DiagnosticMessage(Source("py/diagnostics/recursion-error", "Recursion error in Python extractor"), Severity.ERROR)
             .with_location(l)
             .text(exception.args[0])
@@ -385,7 +385,7 @@ def recursion_error_message(exception, unit):
 
 def internal_error_message(exception, unit):
     # if unit is a BuiltinModuleExtractable, there will be no path attribute
-    l = Location(file=getattr(unit, "path", str(unit)))
+    l = Location(file=unit.path) if hasattr(unit, "path") else None
     return (DiagnosticMessage(Source("py/diagnostics/internal-error", "Internal error in Python extractor"), Severity.ERROR)
             .with_location(l)
             .text("Internal error")

--- a/python/extractor/semmle/util.py
+++ b/python/extractor/semmle/util.py
@@ -10,7 +10,7 @@ from io import BytesIO
 
 #Semantic version of extractor.
 #Update this if any changes are made
-VERSION = "6.1.1"
+VERSION = "6.1.2"
 
 PY_EXTENSIONS = ".py", ".pyw"
 

--- a/python/extractor/semmle/worker.py
+++ b/python/extractor/semmle/worker.py
@@ -276,14 +276,22 @@ def _extract_loop(proc_id, queue, trap_dir, archive, options, reply_queue, logge
                 except RecursionError as ex:
                     logger.error("Failed to extract %s: %s", unit, ex)
                     logger.traceback(WARN)
-                    error = recursion_error_message(ex, unit)
-                    diagnostics_writer.write(error)
+                    try:
+                        error = recursion_error_message(ex, unit)
+                        diagnostics_writer.write(error)
+                    except Exception as ex:
+                        logger.warning("Failed to write diagnostics: %s", ex)
+                        logger.traceback(WARN)
                     reply_queue.put(("FAILURE", unit, None))
                 except Exception as ex:
                     logger.error("Failed to extract %s: %s", unit, ex)
                     logger.traceback(WARN)
-                    error = internal_error_message(ex, unit)
-                    diagnostics_writer.write(error)
+                    try:
+                        error = internal_error_message(ex, unit)
+                        diagnostics_writer.write(error)
+                    except Exception as ex:
+                        logger.warning("Failed to write diagnostics: %s", ex)
+                        logger.traceback(WARN)
                     reply_queue.put(("FAILURE", unit, None))
                 else:
                     reply_queue.put(("SUCCESS", unit, None))

--- a/python/extractor/semmle/worker.py
+++ b/python/extractor/semmle/worker.py
@@ -274,16 +274,16 @@ def _extract_loop(proc_id, queue, trap_dir, archive, options, reply_queue, logge
                     # Syntax errors have already been handled in extractor.py
                     reply_queue.put(("FAILURE", unit, None))
                 except RecursionError as ex:
+                    logger.error("Failed to extract %s: %s", unit, ex)
+                    logger.traceback(WARN)
                     error = recursion_error_message(ex, unit)
                     diagnostics_writer.write(error)
-                    logger.error("Failed to extract %s: %s", unit, ex)
-                    logger.traceback(WARN)
                     reply_queue.put(("FAILURE", unit, None))
                 except Exception as ex:
-                    error = internal_error_message(ex, unit)
-                    diagnostics_writer.write(error)
                     logger.error("Failed to extract %s: %s", unit, ex)
                     logger.traceback(WARN)
+                    error = internal_error_message(ex, unit)
+                    diagnostics_writer.write(error)
                     reply_queue.put(("FAILURE", unit, None))
                 else:
                     reply_queue.put(("SUCCESS", unit, None))


### PR DESCRIPTION
In the hopes this will fix a problem encountered in the wild (that I couldn't reproduce locally).

I couldn't find any tests that I could easily extend to test the new behavior either, so what I did was to locally alter `BuiltinExtractor` to always throw an exception. I observed this causes us to generate `Exception: 'BuiltinModuleExtractable' object has no attribute 'path'` in the logs.

With the commits from this PR, we now properly log the failure reason:

```
[2024-07-09 14:07:25] [build-stdout] [ERROR] [15] Failed to extract module _datetime: <exception-reason>
[2024-07-09 14:07:25] [build-stdout] [TRACEBACK] [15] "semmle/worker.py", line 263, in _extract_loop
[2024-07-09 14:07:25] [build-stdout] [TRACEBACK] [15] "semmle/extractors/super_extractor.py", line 34, in process
[2024-07-09 14:07:25] [build-stdout] [TRACEBACK] [15] "semmle/extractors/builtin_extractor.py", line 24, in process
```

and generate diagnostics such as (EDIT: updated to not include location after 
354394d)

```
{"timestamp": "2024-07-12T13:40:41.728383", "source": {"id": "py/diagnostics/internal-error", "name": "Internal error in Python extractor", "extractorName": "python"}, "severity": "error", "plaintextMessage": "Internal error", "visibility": {"statusPage": false, "cliSummaryTable": false, "telemetry": true}, "attributes": {"traceback": ["\"semmle/worker.py\", line 263, in _extract_loop", "\"semmle/extractors/super_extractor.py\", line 34, in process", "\"semmle/extractors/builtin_extractor.py\", line 24, in process"], "args": ["<exception-reason>"]}}
```

I'm not 100% sure if the tooling will be happy with the fake "file" here, so want to confirm that before merging this PR.


EDIT: I forgot to mention I also tried inserting an exception in `internal_error_message` function, to verify _that_ error handling also works :+1:

```
[2024-07-09 14:15:07] [build-stdout] [WARN] [7] Failed to write diagnostics: <exception-reason>
[2024-07-09 14:15:07] [build-stdout] [TRACEBACK] [7] "semmle/worker.py", line 263, in _extract_loop
[2024-07-09 14:15:07] [build-stdout] [TRACEBACK] [7] "semmle/extractors/super_extractor.py", line 34, in process
[2024-07-09 14:15:07] [build-stdout] [TRACEBACK] [7] "semmle/extractors/builtin_extractor.py", line 24, in process
[2024-07-09 14:15:07] [build-stdout] [TRACEBACK] [7] "semmle/worker.py", line 290, in _extract_loop
[2024-07-09 14:15:07] [build-stdout] [TRACEBACK] [7] "semmle/logging.py", line 387, in internal_error_message
```