### PR TITLE
C#: Order files in buildless extraction

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FileProvider.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FileProvider.cs
@@ -62,7 +62,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         private string[] SelectTextFileNamesByName(string name)
         {
             var ret = allNonBinary.Value.SelectFileNamesByName(name).ToArray();
-            var ending = ret.Length == 0 ? "." : $": {string.Join(", ", ret.OrderBy(s => s))}.";
+            var ending = ret.Length == 0 ? "." : $": {string.Join(", ", ret)}.";
             logger.LogInfo($"Found {ret.Length} {name} files in {SourceDir}{ending}");
             return ret;
         }
@@ -91,7 +91,9 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         private FileInfo[] GetAllFiles()
         {
             logger.LogInfo($"Finding files in {SourceDir}...");
-            var files = SourceDir.GetFiles("*.*", new EnumerationOptions { RecurseSubdirectories = true });
+            var files = SourceDir
+                .GetFiles("*.*", new EnumerationOptions { RecurseSubdirectories = true })
+                .OrderBy(f => f.FullName);
 
             var filteredFiles = files.Where(f =>
             {


### PR DESCRIPTION
This is an attempt to make buildless extraction deterministic. 

I've seen alert wobble in the following scenario: there are multiple source files in the repo with global statements, Roslyn chooses (hopefully by the syntax tree order in the compilation) one of the files to contain the generated `<Main>$`, in the other files the global statements are not extracted. 