### PR TITLE
C++: Promote `cp/iterator-to-expired-container` to Code Scanning

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-416/IteratorToExpiredContainer.ql
+++ b/cpp/ql/src/Security/CWE/CWE-416/IteratorToExpiredContainer.ql
@@ -2,7 +2,7 @@
  * @name Iterator to expired container
  * @description Using an iterator owned by a container whose lifetime has expired may lead to unexpected behavior.
  * @kind problem
- * @precision medium
+ * @precision high
  * @id cpp/iterator-to-expired-container
  * @problem.severity warning
  * @security-severity 8.8

--- a/cpp/ql/src/change-notes/2024-07-11-iterator-to-expired-container-query.md
+++ b/cpp/ql/src/change-notes/2024-07-11-iterator-to-expired-container-query.md
@@ -1,0 +1,4 @@
+---
+category: queryMetadata
+---
+* The precision of `cpp/iterator-to-expired-container` ("Iterator to expired container") has been increased to `high`. As a result, it will be run by default as part of the Code Scanning suite.


### PR DESCRIPTION
The query has a very narrow set of results on MRVA, but they're all mostly TPs (three TPs and one FP). See backlink to MRVA results.