### PR TITLE
C#: Order syntax trees before creating compilation

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FileProvider.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FileProvider.cs
@@ -62,7 +62,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         private string[] SelectTextFileNamesByName(string name)
         {
             var ret = allNonBinary.Value.SelectFileNamesByName(name).ToArray();
-            var ending = ret.Length == 0 ? "." : $": {string.Join(", ", ret)}.";
+            var ending = ret.Length == 0 ? "." : $": {string.Join(", ", ret.OrderBy(s => s))}.";
             logger.LogInfo($"Found {ret.Length} {name} files in {SourceDir}{ending}");
             return ret;
         }
@@ -91,9 +91,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         private FileInfo[] GetAllFiles()
         {
             logger.LogInfo($"Finding files in {SourceDir}...");
-            var files = SourceDir
-                .GetFiles("*.*", new EnumerationOptions { RecurseSubdirectories = true })
-                .OrderBy(f => f.FullName);
+            var files = SourceDir.GetFiles("*.*", new EnumerationOptions { RecurseSubdirectories = true });
 
             var filteredFiles = files.Where(f =>
             {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Extractor/Extractor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Extractor/Extractor.cs
@@ -435,6 +435,8 @@ namespace Semmle.Extraction.CSharp
                 }
             }
 
+            syntaxTrees.Sort((a, b) => string.Compare(a.FilePath, b.FilePath, StringComparison.Ordinal));
+
             var compilation = getCompilation(syntaxTrees, references);
 
             initializeAnalyser(compilation, options);


### PR DESCRIPTION
This PR is reverting the changes in https://github.com/github/codeql/pull/16945 and instead orders syntax trees before creating the compilation. I overlooked the fact that we're creating syntax trees on multiple threads, so ordering the files didn't result in a stable order for the syntax trees. This PR fixes that by ordering the syntax trees directly.

This change has an impact on both traced and buildless extraction.