### PR TITLE
Data flow: Compute local big step relation as stage output

### DIFF
--- a/cpp/ql/test/query-tests/Critical/MemoryFreed/UseAfterFree.expected
+++ b/cpp/ql/test/query-tests/Critical/MemoryFreed/UseAfterFree.expected
@@ -16,7 +16,6 @@ edges
 | test_free.cpp:152:27:152:27 | pointer to free output argument | test_free.cpp:153:5:153:5 | a | provenance |  |
 | test_free.cpp:233:14:233:15 | pointer to free output argument | test_free.cpp:234:9:234:11 | *... ++ | provenance |  |
 | test_free.cpp:234:9:234:11 | *... ++ | test_free.cpp:236:9:236:10 | * ... | provenance |  |
-| test_free.cpp:238:15:238:17 | *... ++ | test_free.cpp:238:15:238:17 | *... ++ | provenance |  |
 | test_free.cpp:238:15:238:17 | *... ++ | test_free.cpp:241:9:241:10 | * ... | provenance |  |
 | test_free.cpp:239:14:239:15 | pointer to free output argument | test_free.cpp:238:15:238:17 | *... ++ | provenance |  |
 | test_free.cpp:245:10:245:11 | pointer to free output argument | test_free.cpp:246:9:246:10 | * ... | provenance |  |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/ArithmeticTainted.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/ArithmeticTainted.expected
@@ -22,11 +22,9 @@ edges
 | test.c:41:5:41:24 | ... = ... | test.c:44:7:44:10 | len2 | provenance |  |
 | test.c:41:5:41:24 | ... = ... | test.c:44:7:44:12 | ... -- | provenance |  |
 | test.c:44:7:44:12 | ... -- | test.c:44:7:44:10 | len2 | provenance |  |
-| test.c:44:7:44:12 | ... -- | test.c:44:7:44:12 | ... -- | provenance |  |
 | test.c:51:5:51:24 | ... = ... | test.c:54:7:54:10 | len3 | provenance |  |
 | test.c:51:5:51:24 | ... = ... | test.c:54:7:54:12 | ... -- | provenance |  |
 | test.c:54:7:54:12 | ... -- | test.c:54:7:54:10 | len3 | provenance |  |
-| test.c:54:7:54:12 | ... -- | test.c:54:7:54:12 | ... -- | provenance |  |
 nodes
 | test2.cpp:12:21:12:21 | v | semmle.label | v |
 | test2.cpp:14:11:14:11 | v | semmle.label | v |

--- a/csharp/ql/test/query-tests/Security Features/CWE-338/InsecureRandomness.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-338/InsecureRandomness.expected
@@ -12,13 +12,11 @@ edges
 | InsecureRandomness.cs:29:57:29:60 | access to local variable data : Byte[] [element] : Byte | InsecureRandomness.cs:29:27:29:61 | call to method GetString : String | provenance | MaD:1 |
 | InsecureRandomness.cs:31:16:31:21 | access to local variable result : StringBuilder | InsecureRandomness.cs:31:16:31:32 | call to method ToString : String | provenance | MaD:3 |
 | InsecureRandomness.cs:31:16:31:32 | call to method ToString : String | InsecureRandomness.cs:12:27:12:50 | call to method InsecureRandomString | provenance |  |
-| InsecureRandomness.cs:60:13:60:18 | access to local variable result : String | InsecureRandomness.cs:60:13:60:18 | access to local variable result : String | provenance |  |
 | InsecureRandomness.cs:60:13:60:18 | access to local variable result : String | InsecureRandomness.cs:62:16:62:21 | access to local variable result : String | provenance |  |
 | InsecureRandomness.cs:60:23:60:40 | access to array element : String | InsecureRandomness.cs:60:13:60:18 | access to local variable result : String | provenance |  |
 | InsecureRandomness.cs:60:31:60:39 | call to method Next : Int32 | InsecureRandomness.cs:60:23:60:40 | access to array element : String | provenance | Config |
 | InsecureRandomness.cs:62:16:62:21 | access to local variable result : String | InsecureRandomness.cs:62:16:62:32 | call to method ToString : String | provenance | MaD:4 |
 | InsecureRandomness.cs:62:16:62:32 | call to method ToString : String | InsecureRandomness.cs:13:20:13:56 | call to method InsecureRandomStringFromSelection | provenance |  |
-| InsecureRandomness.cs:72:13:72:18 | access to local variable result : String | InsecureRandomness.cs:72:13:72:18 | access to local variable result : String | provenance |  |
 | InsecureRandomness.cs:72:13:72:18 | access to local variable result : String | InsecureRandomness.cs:74:16:74:21 | access to local variable result : String | provenance |  |
 | InsecureRandomness.cs:72:23:72:40 | access to indexer : String | InsecureRandomness.cs:72:13:72:18 | access to local variable result : String | provenance |  |
 | InsecureRandomness.cs:72:31:72:39 | call to method Next : Int32 | InsecureRandomness.cs:72:23:72:40 | access to indexer : String | provenance | Config |

--- a/go/ql/test/experimental/CWE-1004/CookieWithoutHttpOnly.expected
+++ b/go/ql/test/experimental/CWE-1004/CookieWithoutHttpOnly.expected
@@ -3,8 +3,6 @@ edges
 | CookieWithoutHttpOnly.go:11:7:14:2 | struct literal | CookieWithoutHttpOnly.go:15:20:15:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:11:7:14:2 | struct literal | CookieWithoutHttpOnly.go:15:21:15:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:12:10:12:18 | "session" | CookieWithoutHttpOnly.go:11:7:14:2 | struct literal | provenance | Config |
-| CookieWithoutHttpOnly.go:15:20:15:21 | &... | CookieWithoutHttpOnly.go:15:20:15:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:15:20:15:21 | &... | CookieWithoutHttpOnly.go:15:20:15:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:15:20:15:21 | &... | CookieWithoutHttpOnly.go:15:21:15:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:15:20:15:21 | &... [pointer] | CookieWithoutHttpOnly.go:15:20:15:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:15:20:15:21 | &... [pointer] | CookieWithoutHttpOnly.go:15:20:15:21 | &... | provenance |  |
@@ -18,10 +16,6 @@ edges
 | CookieWithoutHttpOnly.go:19:7:23:2 | struct literal | CookieWithoutHttpOnly.go:24:21:24:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:20:13:20:21 | "session" | CookieWithoutHttpOnly.go:19:7:23:2 | struct literal | provenance | Config |
 | CookieWithoutHttpOnly.go:22:13:22:17 | false | CookieWithoutHttpOnly.go:19:7:23:2 | struct literal | provenance | Config |
-| CookieWithoutHttpOnly.go:24:20:24:21 | &... | CookieWithoutHttpOnly.go:24:20:24:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:24:20:24:21 | &... | CookieWithoutHttpOnly.go:24:20:24:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:24:20:24:21 | &... | CookieWithoutHttpOnly.go:24:20:24:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:24:20:24:21 | &... | CookieWithoutHttpOnly.go:24:20:24:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:24:20:24:21 | &... | CookieWithoutHttpOnly.go:24:21:24:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:24:20:24:21 | &... | CookieWithoutHttpOnly.go:24:21:24:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:24:20:24:21 | &... [pointer] | CookieWithoutHttpOnly.go:24:20:24:21 | &... | provenance |  |
@@ -40,10 +34,6 @@ edges
 | CookieWithoutHttpOnly.go:28:7:32:2 | struct literal | CookieWithoutHttpOnly.go:33:21:33:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:29:13:29:21 | "session" | CookieWithoutHttpOnly.go:28:7:32:2 | struct literal | provenance | Config |
 | CookieWithoutHttpOnly.go:31:13:31:16 | true | CookieWithoutHttpOnly.go:28:7:32:2 | struct literal | provenance | Config |
-| CookieWithoutHttpOnly.go:33:20:33:21 | &... | CookieWithoutHttpOnly.go:33:20:33:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:33:20:33:21 | &... | CookieWithoutHttpOnly.go:33:20:33:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:33:20:33:21 | &... | CookieWithoutHttpOnly.go:33:20:33:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:33:20:33:21 | &... | CookieWithoutHttpOnly.go:33:20:33:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:33:20:33:21 | &... | CookieWithoutHttpOnly.go:33:21:33:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:33:20:33:21 | &... | CookieWithoutHttpOnly.go:33:21:33:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:33:20:33:21 | &... [pointer] | CookieWithoutHttpOnly.go:33:20:33:21 | &... | provenance |  |
@@ -62,10 +52,6 @@ edges
 | CookieWithoutHttpOnly.go:37:7:40:2 | struct literal | CookieWithoutHttpOnly.go:42:21:42:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:38:10:38:18 | "session" | CookieWithoutHttpOnly.go:37:7:40:2 | struct literal | provenance | Config |
 | CookieWithoutHttpOnly.go:41:15:41:18 | true | CookieWithoutHttpOnly.go:37:7:40:2 | struct literal | provenance | Config |
-| CookieWithoutHttpOnly.go:42:20:42:21 | &... | CookieWithoutHttpOnly.go:42:20:42:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:42:20:42:21 | &... | CookieWithoutHttpOnly.go:42:20:42:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:42:20:42:21 | &... | CookieWithoutHttpOnly.go:42:20:42:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:42:20:42:21 | &... | CookieWithoutHttpOnly.go:42:20:42:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:42:20:42:21 | &... | CookieWithoutHttpOnly.go:42:21:42:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:42:20:42:21 | &... | CookieWithoutHttpOnly.go:42:21:42:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:42:20:42:21 | &... [pointer] | CookieWithoutHttpOnly.go:42:20:42:21 | &... | provenance |  |
@@ -84,10 +70,6 @@ edges
 | CookieWithoutHttpOnly.go:46:7:49:2 | struct literal | CookieWithoutHttpOnly.go:51:21:51:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:47:10:47:18 | "session" | CookieWithoutHttpOnly.go:46:7:49:2 | struct literal | provenance | Config |
 | CookieWithoutHttpOnly.go:50:15:50:19 | false | CookieWithoutHttpOnly.go:46:7:49:2 | struct literal | provenance | Config |
-| CookieWithoutHttpOnly.go:51:20:51:21 | &... | CookieWithoutHttpOnly.go:51:20:51:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:51:20:51:21 | &... | CookieWithoutHttpOnly.go:51:20:51:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:51:20:51:21 | &... | CookieWithoutHttpOnly.go:51:20:51:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:51:20:51:21 | &... | CookieWithoutHttpOnly.go:51:20:51:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:51:20:51:21 | &... | CookieWithoutHttpOnly.go:51:21:51:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:51:20:51:21 | &... | CookieWithoutHttpOnly.go:51:21:51:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:51:20:51:21 | &... [pointer] | CookieWithoutHttpOnly.go:51:20:51:21 | &... | provenance |  |
@@ -108,10 +90,6 @@ edges
 | CookieWithoutHttpOnly.go:56:7:60:2 | struct literal | CookieWithoutHttpOnly.go:61:21:61:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:57:13:57:21 | "session" | CookieWithoutHttpOnly.go:56:7:60:2 | struct literal | provenance | Config |
 | CookieWithoutHttpOnly.go:59:13:59:15 | val | CookieWithoutHttpOnly.go:56:7:60:2 | struct literal | provenance | Config |
-| CookieWithoutHttpOnly.go:61:20:61:21 | &... | CookieWithoutHttpOnly.go:61:20:61:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:61:20:61:21 | &... | CookieWithoutHttpOnly.go:61:20:61:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:61:20:61:21 | &... | CookieWithoutHttpOnly.go:61:20:61:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:61:20:61:21 | &... | CookieWithoutHttpOnly.go:61:20:61:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:61:20:61:21 | &... | CookieWithoutHttpOnly.go:61:21:61:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:61:20:61:21 | &... | CookieWithoutHttpOnly.go:61:21:61:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:61:20:61:21 | &... [pointer] | CookieWithoutHttpOnly.go:61:20:61:21 | &... | provenance |  |
@@ -132,10 +110,6 @@ edges
 | CookieWithoutHttpOnly.go:66:7:70:2 | struct literal | CookieWithoutHttpOnly.go:71:21:71:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:67:13:67:21 | "session" | CookieWithoutHttpOnly.go:66:7:70:2 | struct literal | provenance | Config |
 | CookieWithoutHttpOnly.go:69:13:69:15 | val | CookieWithoutHttpOnly.go:66:7:70:2 | struct literal | provenance | Config |
-| CookieWithoutHttpOnly.go:71:20:71:21 | &... | CookieWithoutHttpOnly.go:71:20:71:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:71:20:71:21 | &... | CookieWithoutHttpOnly.go:71:20:71:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:71:20:71:21 | &... | CookieWithoutHttpOnly.go:71:20:71:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:71:20:71:21 | &... | CookieWithoutHttpOnly.go:71:20:71:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:71:20:71:21 | &... | CookieWithoutHttpOnly.go:71:21:71:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:71:20:71:21 | &... | CookieWithoutHttpOnly.go:71:21:71:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:71:20:71:21 | &... [pointer] | CookieWithoutHttpOnly.go:71:20:71:21 | &... | provenance |  |
@@ -156,10 +130,6 @@ edges
 | CookieWithoutHttpOnly.go:76:7:79:2 | struct literal | CookieWithoutHttpOnly.go:81:21:81:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:77:10:77:18 | "session" | CookieWithoutHttpOnly.go:76:7:79:2 | struct literal | provenance | Config |
 | CookieWithoutHttpOnly.go:80:15:80:17 | val | CookieWithoutHttpOnly.go:76:7:79:2 | struct literal | provenance | Config |
-| CookieWithoutHttpOnly.go:81:20:81:21 | &... | CookieWithoutHttpOnly.go:81:20:81:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:81:20:81:21 | &... | CookieWithoutHttpOnly.go:81:20:81:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:81:20:81:21 | &... | CookieWithoutHttpOnly.go:81:20:81:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:81:20:81:21 | &... | CookieWithoutHttpOnly.go:81:20:81:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:81:20:81:21 | &... | CookieWithoutHttpOnly.go:81:21:81:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:81:20:81:21 | &... | CookieWithoutHttpOnly.go:81:21:81:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:81:20:81:21 | &... [pointer] | CookieWithoutHttpOnly.go:81:20:81:21 | &... | provenance |  |
@@ -180,10 +150,6 @@ edges
 | CookieWithoutHttpOnly.go:86:7:89:2 | struct literal | CookieWithoutHttpOnly.go:91:21:91:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:87:10:87:18 | "session" | CookieWithoutHttpOnly.go:86:7:89:2 | struct literal | provenance | Config |
 | CookieWithoutHttpOnly.go:90:15:90:17 | val | CookieWithoutHttpOnly.go:86:7:89:2 | struct literal | provenance | Config |
-| CookieWithoutHttpOnly.go:91:20:91:21 | &... | CookieWithoutHttpOnly.go:91:20:91:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:91:20:91:21 | &... | CookieWithoutHttpOnly.go:91:20:91:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:91:20:91:21 | &... | CookieWithoutHttpOnly.go:91:20:91:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:91:20:91:21 | &... | CookieWithoutHttpOnly.go:91:20:91:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:91:20:91:21 | &... | CookieWithoutHttpOnly.go:91:21:91:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:91:20:91:21 | &... | CookieWithoutHttpOnly.go:91:21:91:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:91:20:91:21 | &... [pointer] | CookieWithoutHttpOnly.go:91:20:91:21 | &... | provenance |  |
@@ -198,8 +164,6 @@ edges
 | CookieWithoutHttpOnly.go:95:7:98:2 | struct literal | CookieWithoutHttpOnly.go:100:20:100:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:95:7:98:2 | struct literal | CookieWithoutHttpOnly.go:100:21:100:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:99:15:99:19 | false | CookieWithoutHttpOnly.go:95:7:98:2 | struct literal | provenance | Config |
-| CookieWithoutHttpOnly.go:100:20:100:21 | &... | CookieWithoutHttpOnly.go:100:20:100:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:100:20:100:21 | &... | CookieWithoutHttpOnly.go:100:20:100:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:100:20:100:21 | &... | CookieWithoutHttpOnly.go:100:21:100:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:100:20:100:21 | &... [pointer] | CookieWithoutHttpOnly.go:100:20:100:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:100:20:100:21 | &... [pointer] | CookieWithoutHttpOnly.go:100:20:100:21 | &... | provenance |  |
@@ -214,10 +178,6 @@ edges
 | CookieWithoutHttpOnly.go:105:7:108:2 | struct literal | CookieWithoutHttpOnly.go:110:21:110:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:106:10:106:13 | name | CookieWithoutHttpOnly.go:105:7:108:2 | struct literal | provenance | Config |
 | CookieWithoutHttpOnly.go:109:15:109:19 | false | CookieWithoutHttpOnly.go:105:7:108:2 | struct literal | provenance | Config |
-| CookieWithoutHttpOnly.go:110:20:110:21 | &... | CookieWithoutHttpOnly.go:110:20:110:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:110:20:110:21 | &... | CookieWithoutHttpOnly.go:110:20:110:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:110:20:110:21 | &... | CookieWithoutHttpOnly.go:110:20:110:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:110:20:110:21 | &... | CookieWithoutHttpOnly.go:110:20:110:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:110:20:110:21 | &... | CookieWithoutHttpOnly.go:110:21:110:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:110:20:110:21 | &... | CookieWithoutHttpOnly.go:110:21:110:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:110:20:110:21 | &... [pointer] | CookieWithoutHttpOnly.go:110:20:110:21 | &... | provenance |  |
@@ -237,10 +197,6 @@ edges
 | CookieWithoutHttpOnly.go:115:7:118:2 | struct literal | CookieWithoutHttpOnly.go:120:21:120:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:116:10:116:16 | session | CookieWithoutHttpOnly.go:115:7:118:2 | struct literal | provenance | Config |
 | CookieWithoutHttpOnly.go:119:15:119:19 | false | CookieWithoutHttpOnly.go:115:7:118:2 | struct literal | provenance | Config |
-| CookieWithoutHttpOnly.go:120:20:120:21 | &... | CookieWithoutHttpOnly.go:120:20:120:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:120:20:120:21 | &... | CookieWithoutHttpOnly.go:120:20:120:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:120:20:120:21 | &... | CookieWithoutHttpOnly.go:120:20:120:21 | &... | provenance |  |
-| CookieWithoutHttpOnly.go:120:20:120:21 | &... | CookieWithoutHttpOnly.go:120:20:120:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:120:20:120:21 | &... | CookieWithoutHttpOnly.go:120:21:120:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:120:20:120:21 | &... | CookieWithoutHttpOnly.go:120:21:120:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:120:20:120:21 | &... [pointer] | CookieWithoutHttpOnly.go:120:20:120:21 | &... | provenance |  |
@@ -292,8 +248,6 @@ edges
 | CookieWithoutHttpOnly.go:134:16:134:20 | store | CookieWithoutHttpOnly.go:202:2:202:6 | store | provenance |  |
 | CookieWithoutHttpOnly.go:135:2:135:8 | implicit dereference | CookieWithoutHttpOnly.go:134:2:134:8 | definition of session [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:135:2:135:8 | implicit dereference | CookieWithoutHttpOnly.go:134:2:134:8 | definition of session [pointer] | provenance |  |
-| CookieWithoutHttpOnly.go:135:2:135:8 | implicit dereference | CookieWithoutHttpOnly.go:135:2:135:8 | implicit dereference | provenance |  |
-| CookieWithoutHttpOnly.go:135:2:135:8 | implicit dereference | CookieWithoutHttpOnly.go:135:2:135:8 | implicit dereference | provenance |  |
 | CookieWithoutHttpOnly.go:135:2:135:8 | implicit dereference | CookieWithoutHttpOnly.go:137:2:137:8 | session | provenance |  |
 | CookieWithoutHttpOnly.go:135:2:135:8 | implicit dereference | CookieWithoutHttpOnly.go:137:2:137:8 | session | provenance |  |
 | CookieWithoutHttpOnly.go:135:2:135:8 | implicit dereference | CookieWithoutHttpOnly.go:142:2:142:8 | session | provenance |  |
@@ -316,7 +270,6 @@ edges
 | CookieWithoutHttpOnly.go:137:20:140:2 | &... | CookieWithoutHttpOnly.go:137:2:137:8 | implicit dereference | provenance | Config |
 | CookieWithoutHttpOnly.go:137:20:140:2 | &... | CookieWithoutHttpOnly.go:137:2:137:8 | session | provenance | Config |
 | CookieWithoutHttpOnly.go:137:20:140:2 | &... | CookieWithoutHttpOnly.go:137:2:137:8 | session | provenance | Config |
-| CookieWithoutHttpOnly.go:137:20:140:2 | &... | CookieWithoutHttpOnly.go:137:20:140:2 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:137:20:140:2 | &... | CookieWithoutHttpOnly.go:137:21:140:2 | struct literal | provenance |  |
 | CookieWithoutHttpOnly.go:137:21:140:2 | struct literal | CookieWithoutHttpOnly.go:137:20:140:2 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:137:21:140:2 | struct literal | CookieWithoutHttpOnly.go:137:20:140:2 | &... | provenance |  |
@@ -336,7 +289,6 @@ edges
 | CookieWithoutHttpOnly.go:146:16:146:20 | store | CookieWithoutHttpOnly.go:195:16:195:20 | store | provenance |  |
 | CookieWithoutHttpOnly.go:146:16:146:20 | store | CookieWithoutHttpOnly.go:202:2:202:6 | store | provenance |  |
 | CookieWithoutHttpOnly.go:147:2:147:8 | implicit dereference | CookieWithoutHttpOnly.go:146:2:146:8 | definition of session [pointer] | provenance |  |
-| CookieWithoutHttpOnly.go:147:2:147:8 | implicit dereference | CookieWithoutHttpOnly.go:147:2:147:8 | implicit dereference | provenance |  |
 | CookieWithoutHttpOnly.go:147:2:147:8 | implicit dereference | CookieWithoutHttpOnly.go:149:2:149:8 | session | provenance |  |
 | CookieWithoutHttpOnly.go:147:2:147:8 | implicit dereference | CookieWithoutHttpOnly.go:153:2:153:8 | session | provenance |  |
 | CookieWithoutHttpOnly.go:147:2:147:8 | session [pointer] | CookieWithoutHttpOnly.go:147:2:147:8 | implicit dereference | provenance |  |
@@ -348,7 +300,6 @@ edges
 | CookieWithoutHttpOnly.go:149:2:149:8 | session [pointer] | CookieWithoutHttpOnly.go:149:2:149:8 | implicit dereference | provenance |  |
 | CookieWithoutHttpOnly.go:149:20:151:2 | &... | CookieWithoutHttpOnly.go:149:2:149:8 | implicit dereference | provenance | Config |
 | CookieWithoutHttpOnly.go:149:20:151:2 | &... | CookieWithoutHttpOnly.go:149:2:149:8 | session | provenance | Config |
-| CookieWithoutHttpOnly.go:149:20:151:2 | &... | CookieWithoutHttpOnly.go:149:20:151:2 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:149:21:151:2 | struct literal | CookieWithoutHttpOnly.go:149:20:151:2 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:157:2:157:9 | definition of httpOnly | CookieWithoutHttpOnly.go:163:13:163:20 | httpOnly | provenance |  |
 | CookieWithoutHttpOnly.go:157:14:157:17 | true | CookieWithoutHttpOnly.go:163:13:163:20 | httpOnly | provenance |  |
@@ -371,8 +322,6 @@ edges
 | CookieWithoutHttpOnly.go:158:16:158:20 | store | CookieWithoutHttpOnly.go:202:2:202:6 | store | provenance |  |
 | CookieWithoutHttpOnly.go:159:2:159:8 | implicit dereference | CookieWithoutHttpOnly.go:158:2:158:8 | definition of session [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:159:2:159:8 | implicit dereference | CookieWithoutHttpOnly.go:158:2:158:8 | definition of session [pointer] | provenance |  |
-| CookieWithoutHttpOnly.go:159:2:159:8 | implicit dereference | CookieWithoutHttpOnly.go:159:2:159:8 | implicit dereference | provenance |  |
-| CookieWithoutHttpOnly.go:159:2:159:8 | implicit dereference | CookieWithoutHttpOnly.go:159:2:159:8 | implicit dereference | provenance |  |
 | CookieWithoutHttpOnly.go:159:2:159:8 | implicit dereference | CookieWithoutHttpOnly.go:161:2:161:8 | session | provenance |  |
 | CookieWithoutHttpOnly.go:159:2:159:8 | implicit dereference | CookieWithoutHttpOnly.go:161:2:161:8 | session | provenance |  |
 | CookieWithoutHttpOnly.go:159:2:159:8 | implicit dereference | CookieWithoutHttpOnly.go:166:2:166:8 | session | provenance |  |
@@ -395,7 +344,6 @@ edges
 | CookieWithoutHttpOnly.go:161:20:164:2 | &... | CookieWithoutHttpOnly.go:161:2:161:8 | implicit dereference | provenance | Config |
 | CookieWithoutHttpOnly.go:161:20:164:2 | &... | CookieWithoutHttpOnly.go:161:2:161:8 | session | provenance | Config |
 | CookieWithoutHttpOnly.go:161:20:164:2 | &... | CookieWithoutHttpOnly.go:161:2:161:8 | session | provenance | Config |
-| CookieWithoutHttpOnly.go:161:20:164:2 | &... | CookieWithoutHttpOnly.go:161:20:164:2 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:161:20:164:2 | &... | CookieWithoutHttpOnly.go:161:21:164:2 | struct literal | provenance |  |
 | CookieWithoutHttpOnly.go:161:21:164:2 | struct literal | CookieWithoutHttpOnly.go:161:20:164:2 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:161:21:164:2 | struct literal | CookieWithoutHttpOnly.go:161:20:164:2 | &... | provenance |  |
@@ -421,8 +369,6 @@ edges
 | CookieWithoutHttpOnly.go:170:16:170:20 | store | CookieWithoutHttpOnly.go:202:2:202:6 | store | provenance |  |
 | CookieWithoutHttpOnly.go:171:2:171:8 | implicit dereference | CookieWithoutHttpOnly.go:170:2:170:8 | definition of session [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:171:2:171:8 | implicit dereference | CookieWithoutHttpOnly.go:170:2:170:8 | definition of session [pointer] | provenance |  |
-| CookieWithoutHttpOnly.go:171:2:171:8 | implicit dereference | CookieWithoutHttpOnly.go:171:2:171:8 | implicit dereference | provenance |  |
-| CookieWithoutHttpOnly.go:171:2:171:8 | implicit dereference | CookieWithoutHttpOnly.go:171:2:171:8 | implicit dereference | provenance |  |
 | CookieWithoutHttpOnly.go:171:2:171:8 | implicit dereference | CookieWithoutHttpOnly.go:173:2:173:8 | session | provenance |  |
 | CookieWithoutHttpOnly.go:171:2:171:8 | implicit dereference | CookieWithoutHttpOnly.go:173:2:173:8 | session | provenance |  |
 | CookieWithoutHttpOnly.go:171:2:171:8 | implicit dereference | CookieWithoutHttpOnly.go:178:2:178:8 | session | provenance |  |
@@ -445,7 +391,6 @@ edges
 | CookieWithoutHttpOnly.go:173:20:176:2 | &... | CookieWithoutHttpOnly.go:173:2:173:8 | implicit dereference | provenance | Config |
 | CookieWithoutHttpOnly.go:173:20:176:2 | &... | CookieWithoutHttpOnly.go:173:2:173:8 | session | provenance | Config |
 | CookieWithoutHttpOnly.go:173:20:176:2 | &... | CookieWithoutHttpOnly.go:173:2:173:8 | session | provenance | Config |
-| CookieWithoutHttpOnly.go:173:20:176:2 | &... | CookieWithoutHttpOnly.go:173:20:176:2 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:173:20:176:2 | &... | CookieWithoutHttpOnly.go:173:21:176:2 | struct literal | provenance |  |
 | CookieWithoutHttpOnly.go:173:21:176:2 | struct literal | CookieWithoutHttpOnly.go:173:20:176:2 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:173:21:176:2 | struct literal | CookieWithoutHttpOnly.go:173:20:176:2 | &... | provenance |  |

--- a/go/ql/test/experimental/CWE-74/DsnInjectionLocal.expected
+++ b/go/ql/test/experimental/CWE-74/DsnInjectionLocal.expected
@@ -11,7 +11,6 @@ edges
 | Dsn.go:62:2:62:4 | definition of cfg [pointer] | Dsn.go:67:102:67:104 | cfg [pointer] | provenance |  |
 | Dsn.go:63:9:63:11 | cfg [pointer] | Dsn.go:63:9:63:11 | implicit dereference | provenance |  |
 | Dsn.go:63:9:63:11 | implicit dereference | Dsn.go:62:2:62:4 | definition of cfg [pointer] | provenance |  |
-| Dsn.go:63:9:63:11 | implicit dereference | Dsn.go:63:9:63:11 | implicit dereference | provenance |  |
 | Dsn.go:63:9:63:11 | implicit dereference | Dsn.go:67:102:67:108 | selection of dsn | provenance |  |
 | Dsn.go:63:19:63:25 | selection of Args | Dsn.go:63:19:63:29 | slice expression | provenance |  |
 | Dsn.go:63:19:63:29 | slice expression | Dsn.go:63:9:63:11 | implicit dereference | provenance | FunctionModel |

--- a/go/ql/test/library-tests/semmle/go/frameworks/Twirp/RequestForgery.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Twirp/RequestForgery.expected
@@ -2,7 +2,6 @@
 | server/main.go:30:38:30:48 | selection of Text | rpc/notes/service.twirp.go:538:25:538:32 | selection of Body | server/main.go:30:38:30:48 | selection of Text | The $@ of this request depends on a $@. | server/main.go:30:38:30:48 | selection of Text | URL | rpc/notes/service.twirp.go:538:25:538:32 | selection of Body | user-provided value |
 | server/main.go:30:38:30:48 | selection of Text | server/main.go:19:56:19:61 | definition of params | server/main.go:30:38:30:48 | selection of Text | The $@ of this request depends on a $@. | server/main.go:30:38:30:48 | selection of Text | URL | server/main.go:19:56:19:61 | definition of params | user-provided value |
 edges
-| client/main.go:16:35:16:78 | &... | client/main.go:16:35:16:78 | &... | provenance |  |
 | client/main.go:16:35:16:78 | &... | server/main.go:19:56:19:61 | definition of params | provenance |  |
 | rpc/notes/service.twirp.go:473:6:473:13 | definition of typedReq | rpc/notes/service.twirp.go:477:44:477:51 | typedReq | provenance |  |
 | rpc/notes/service.twirp.go:477:44:477:51 | typedReq | server/main.go:19:56:19:61 | definition of params | provenance |  |

--- a/go/ql/test/library-tests/semmle/go/frameworks/XNetHtml/ReflectedXss.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/XNetHtml/ReflectedXss.expected
@@ -50,8 +50,6 @@ edges
 | test.go:43:2:43:43 | ... := ...[0] | test.go:44:24:44:34 | taintedNode | provenance |  |
 | test.go:43:31:43:42 | selection of Body | test.go:43:2:43:43 | ... := ...[0] | provenance | Src:MaD:15 MaD:3 |
 | test.go:44:24:44:34 | taintedNode | test.go:42:6:42:14 | definition of cleanNode | provenance | MaD:8 |
-| test.go:45:22:45:31 | &... | test.go:45:22:45:31 | &... | provenance |  |
-| test.go:45:22:45:31 | &... | test.go:45:22:45:31 | &... | provenance |  |
 | test.go:45:22:45:31 | &... | test.go:45:23:45:31 | cleanNode | provenance |  |
 | test.go:45:22:45:31 | &... [pointer] | test.go:45:22:45:31 | &... | provenance |  |
 | test.go:45:22:45:31 | &... [pointer] | test.go:45:22:45:31 | &... | provenance |  |
@@ -63,8 +61,6 @@ edges
 | test.go:48:2:48:44 | ... := ...[0] | test.go:49:26:49:37 | taintedNode2 | provenance |  |
 | test.go:48:32:48:43 | selection of Body | test.go:48:2:48:44 | ... := ...[0] | provenance | Src:MaD:15 MaD:3 |
 | test.go:49:26:49:37 | taintedNode2 | test.go:47:6:47:15 | definition of cleanNode2 | provenance | MaD:9 |
-| test.go:50:22:50:32 | &... | test.go:50:22:50:32 | &... | provenance |  |
-| test.go:50:22:50:32 | &... | test.go:50:22:50:32 | &... | provenance |  |
 | test.go:50:22:50:32 | &... | test.go:50:23:50:32 | cleanNode2 | provenance |  |
 | test.go:50:22:50:32 | &... [pointer] | test.go:50:22:50:32 | &... | provenance |  |
 | test.go:50:22:50:32 | &... [pointer] | test.go:50:22:50:32 | &... | provenance |  |

--- a/go/ql/test/query-tests/Security/CWE-078/StoredCommand.expected
+++ b/go/ql/test/query-tests/Security/CWE-078/StoredCommand.expected
@@ -3,7 +3,6 @@
 edges
 | StoredCommand.go:11:2:11:27 | ... := ...[0] | StoredCommand.go:13:2:13:5 | rows | provenance |  |
 | StoredCommand.go:13:2:13:5 | rows | StoredCommand.go:13:12:13:19 | &... | provenance | FunctionModel |
-| StoredCommand.go:13:12:13:19 | &... | StoredCommand.go:13:12:13:19 | &... | provenance |  |
 | StoredCommand.go:13:12:13:19 | &... | StoredCommand.go:14:22:14:28 | cmdName | provenance |  Sink:MaD:1 |
 models
 | 1 | Sink: os/exec; ; false; Command; ; ; Argument[0]; command-injection; manual |

--- a/go/ql/test/query-tests/Security/CWE-079/StoredXss.expected
+++ b/go/ql/test/query-tests/Security/CWE-079/StoredXss.expected
@@ -2,7 +2,6 @@ edges
 | StoredXss.go:13:21:13:31 | call to Name | StoredXss.go:13:21:13:36 | ...+... | provenance |  |
 | stored.go:18:3:18:28 | ... := ...[0] | stored.go:25:14:25:17 | rows | provenance |  |
 | stored.go:25:14:25:17 | rows | stored.go:25:29:25:33 | &... | provenance | FunctionModel |
-| stored.go:25:29:25:33 | &... | stored.go:25:29:25:33 | &... | provenance |  |
 | stored.go:25:29:25:33 | &... | stored.go:30:22:30:25 | name | provenance |  |
 | stored.go:59:30:59:33 | definition of path | stored.go:61:22:61:25 | path | provenance |  |
 nodes

--- a/python/ql/test/library-tests/frameworks/django-orm/ReflectedXss.expected
+++ b/python/ql/test/library-tests/frameworks/django-orm/ReflectedXss.expected
@@ -16,7 +16,6 @@ edges
 | testapp/orm_security_tests.py:42:13:42:18 | ControlFlowNode for person [Attribute name] | testapp/orm_security_tests.py:43:49:43:54 | ControlFlowNode for person [Attribute name] | provenance |  |
 | testapp/orm_security_tests.py:42:23:42:42 | ControlFlowNode for Attribute() [List element, Attribute age] | testapp/orm_security_tests.py:42:13:42:18 | ControlFlowNode for person [Attribute age] | provenance |  |
 | testapp/orm_security_tests.py:42:23:42:42 | ControlFlowNode for Attribute() [List element, Attribute name] | testapp/orm_security_tests.py:42:13:42:18 | ControlFlowNode for person [Attribute name] | provenance |  |
-| testapp/orm_security_tests.py:43:13:43:21 | ControlFlowNode for resp_text | testapp/orm_security_tests.py:43:13:43:21 | ControlFlowNode for resp_text | provenance |  |
 | testapp/orm_security_tests.py:43:13:43:21 | ControlFlowNode for resp_text | testapp/orm_security_tests.py:44:29:44:37 | ControlFlowNode for resp_text | provenance |  |
 | testapp/orm_security_tests.py:43:49:43:54 | ControlFlowNode for person [Attribute name] | testapp/orm_security_tests.py:43:49:43:59 | ControlFlowNode for Attribute | provenance |  |
 | testapp/orm_security_tests.py:43:49:43:59 | ControlFlowNode for Attribute | testapp/orm_security_tests.py:43:13:43:21 | ControlFlowNode for resp_text | provenance |  |

--- a/ruby/ql/test/query-tests/security/cwe-094/CodeInjection/CodeInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-094/CodeInjection/CodeInjection.expected
@@ -17,7 +17,6 @@ edges
 | CodeInjection.rb:38:24:38:27 | code | CodeInjection.rb:38:10:38:28 | call to escape | provenance | MaD:21 |
 | CodeInjection.rb:38:24:38:27 | code | CodeInjection.rb:38:10:38:28 | call to escape | provenance | MaD:21 |
 | CodeInjection.rb:78:5:78:8 | code | CodeInjection.rb:80:16:80:19 | code | provenance |  |
-| CodeInjection.rb:78:5:78:8 | code | CodeInjection.rb:86:10:86:25 | ... + ... | provenance |  |
 | CodeInjection.rb:78:5:78:8 | code | CodeInjection.rb:86:10:86:37 | ... + ... | provenance |  |
 | CodeInjection.rb:78:5:78:8 | code | CodeInjection.rb:86:22:86:25 | code | provenance |  |
 | CodeInjection.rb:78:5:78:8 | code | CodeInjection.rb:88:10:88:32 | "prefix_#{...}_suffix" | provenance | AdditionalTaintStep |
@@ -27,7 +26,6 @@ edges
 | CodeInjection.rb:78:12:78:17 | call to params | CodeInjection.rb:78:12:78:24 | ...[...] | provenance |  |
 | CodeInjection.rb:78:12:78:24 | ...[...] | CodeInjection.rb:78:5:78:8 | code | provenance |  |
 | CodeInjection.rb:78:12:78:24 | ...[...] | CodeInjection.rb:78:5:78:8 | code | provenance |  |
-| CodeInjection.rb:86:10:86:25 | ... + ... | CodeInjection.rb:86:10:86:37 | ... + ... | provenance |  |
 | CodeInjection.rb:86:10:86:25 | ... + ... [element] | CodeInjection.rb:86:10:86:37 | ... + ... [element] | provenance |  |
 | CodeInjection.rb:86:10:86:37 | ... + ... [element] | CodeInjection.rb:86:10:86:37 | ... + ... | provenance |  |
 | CodeInjection.rb:86:22:86:25 | code | CodeInjection.rb:86:10:86:25 | ... + ... [element] | provenance |  |
@@ -74,7 +72,6 @@ nodes
 | CodeInjection.rb:78:12:78:24 | ...[...] | semmle.label | ...[...] |
 | CodeInjection.rb:78:12:78:24 | ...[...] | semmle.label | ...[...] |
 | CodeInjection.rb:80:16:80:19 | code | semmle.label | code |
-| CodeInjection.rb:86:10:86:25 | ... + ... | semmle.label | ... + ... |
 | CodeInjection.rb:86:10:86:25 | ... + ... [element] | semmle.label | ... + ... [element] |
 | CodeInjection.rb:86:10:86:37 | ... + ... | semmle.label | ... + ... |
 | CodeInjection.rb:86:10:86:37 | ... + ... [element] | semmle.label | ... + ... [element] |

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -2693,26 +2693,26 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           ) {
             not inBarrier(node2, state) and
             not outBarrier(node1, state) and
-            exists(NodeEx node0, boolean preservesValue0, DataFlowType t0, string label0, Ap ap |
-              Input::localStep(node0, state, node2, state, preservesValue0, t0, cc, label0) and
+            exists(NodeEx mid, boolean preservesValue2, DataFlowType t2, string label2, Ap ap |
+              Input::localStep(mid, state, node2, state, preservesValue2, t2, cc, label2) and
               revFlow(node2, pragma[only_bind_into](state), pragma[only_bind_into](ap)) and
-              not outBarrier(node0, state) and
+              not outBarrier(mid, state) and
               (preservesValue = true or ap instanceof ApNil)
             |
-              node1 = node0 and
+              node1 = mid and
               localFlowEntry(node1, pragma[only_bind_into](state), pragma[only_bind_into](ap)) and
-              preservesValue = preservesValue0 and
-              label = label0 and
-              t = t0 and
+              preservesValue = preservesValue2 and
+              label = label2 and
+              t = t2 and
               node1 != node2
               or
               exists(boolean preservesValue1, DataFlowType t1, string label1 |
-                localFlowStepPlus(node1, pragma[only_bind_into](state), node0, preservesValue1, t1,
+                localFlowStepPlus(node1, pragma[only_bind_into](state), mid, preservesValue1, t1,
                   cc, label1) and
-                not node0 instanceof FlowCheckNode and
-                preservesValue = preservesValue0.booleanAnd(preservesValue1) and
-                label = mergeLabels(label1, label0) and
-                if preservesValue0 = true then t = t1 else t = t0
+                not mid instanceof FlowCheckNode and
+                preservesValue = preservesValue2.booleanAnd(preservesValue1) and
+                label = mergeLabels(label1, label2) and
+                if preservesValue2 = true then t = t1 else t = t2
               )
             )
           }

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
@@ -778,23 +778,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
         recordDataFlowCallSiteDispatch(call, c)
       }
 
-      module NoLocalCallContext {
-        class LocalCc = Unit;
-
-        bindingset[cc]
-        LocalCc getLocalCc(CallContext cc) { any() }
-
-        bindingset[call, c]
-        CallContextCall getCallContextCall(DataFlowCall call, DataFlowCallable c) {
-          if recordDataFlowCallSiteDispatch(call, c)
-          then result = Input2::getSpecificCallContextCall(call, c)
-          else result = TSomeCall()
-        }
-      }
-
       module LocalCallContext {
-        class LocalCc = LocalCallContext;
-
         private UnreachableSet getUnreachable(CallContext ctx) {
           exists(UnreachableSetOption unreachable | ctx = TSpecificCall(_, _, unreachable) |
             result = unreachable.asSome()
@@ -810,7 +794,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
 
         bindingset[cc]
         pragma[inline_late]
-        LocalCc getLocalCc(CallContext cc) { result = getLocalCallContext(cc) }
+        LocalCallContext getLocalCc(CallContext cc) { result = getLocalCallContext(cc) }
 
         bindingset[call, c]
         CallContextCall getCallContextCall(DataFlowCall call, DataFlowCallable c) {

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
@@ -778,7 +778,23 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
         recordDataFlowCallSiteDispatch(call, c)
       }
 
+      module NoLocalCallContext {
+        class LocalCc = Unit;
+
+        bindingset[cc]
+        LocalCc getLocalCc(CallContext cc) { any() }
+
+        bindingset[call, c]
+        CallContextCall getCallContextCall(DataFlowCall call, DataFlowCallable c) {
+          if recordDataFlowCallSiteDispatch(call, c)
+          then result = Input2::getSpecificCallContextCall(call, c)
+          else result = TSomeCall()
+        }
+      }
+
       module LocalCallContext {
+        class LocalCc = LocalCallContext;
+
         private UnreachableSet getUnreachable(CallContext ctx) {
           exists(UnreachableSetOption unreachable | ctx = TSpecificCall(_, _, unreachable) |
             result = unreachable.asSome()
@@ -794,7 +810,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
 
         bindingset[cc]
         pragma[inline_late]
-        LocalCallContext getLocalCc(CallContext cc) { result = getLocalCallContext(cc) }
+        LocalCc getLocalCc(CallContext cc) { result = getLocalCallContext(cc) }
 
         bindingset[call, c]
         CallContextCall getCallContextCall(DataFlowCall call, DataFlowCallable c) {

--- a/swift/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
+++ b/swift/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
@@ -44,7 +44,6 @@ edges
 | CommandInjection.swift:105:12:105:12 | userControlledString | CommandInjection.swift:137:36:137:36 | userControlledString | provenance |  |
 | CommandInjection.swift:105:12:105:12 | userControlledString | CommandInjection.swift:138:21:138:21 | userControlledString | provenance |  |
 | CommandInjection.swift:105:12:105:12 | userControlledString | CommandInjection.swift:139:22:139:22 | userControlledString | provenance |  |
-| CommandInjection.swift:105:12:105:12 | userControlledString | CommandInjection.swift:140:24:140:24 | userControlledString | provenance |  |
 | CommandInjection.swift:105:12:105:12 | userControlledString | CommandInjection.swift:150:42:150:42 | userControlledString | provenance |  |
 | CommandInjection.swift:105:12:105:12 | userControlledString | CommandInjection.swift:151:75:151:75 | userControlledString | provenance |  |
 | CommandInjection.swift:105:12:105:12 | userControlledString | CommandInjection.swift:154:35:154:35 | userControlledString | provenance |  |
@@ -65,7 +64,6 @@ edges
 | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:137:36:137:36 | userControlledString | provenance |  |
 | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:138:21:138:21 | userControlledString | provenance |  |
 | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:139:22:139:22 | userControlledString | provenance |  |
-| CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:140:24:140:24 | userControlledString | provenance |  |
 | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:150:42:150:42 | userControlledString | provenance |  |
 | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:151:75:151:75 | userControlledString | provenance |  |
 | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:154:35:154:35 | userControlledString | provenance |  |
@@ -110,14 +108,6 @@ edges
 | CommandInjection.swift:138:21:138:21 | userControlledString | CommandInjection.swift:138:20:138:41 | [...] [Collection element] | provenance |  |
 | CommandInjection.swift:139:21:139:42 | [...] [Collection element] | CommandInjection.swift:99:20:99:40 | arguments [Collection element] | provenance |  |
 | CommandInjection.swift:139:22:139:22 | userControlledString | CommandInjection.swift:139:21:139:42 | [...] [Collection element] | provenance |  |
-| CommandInjection.swift:140:24:140:24 | userControlledString | CommandInjection.swift:150:42:150:42 | userControlledString | provenance |  |
-| CommandInjection.swift:140:24:140:24 | userControlledString | CommandInjection.swift:151:75:151:75 | userControlledString | provenance |  |
-| CommandInjection.swift:140:24:140:24 | userControlledString | CommandInjection.swift:154:35:154:35 | userControlledString | provenance |  |
-| CommandInjection.swift:140:24:140:24 | userControlledString | CommandInjection.swift:155:70:155:70 | userControlledString | provenance |  |
-| CommandInjection.swift:140:24:140:24 | userControlledString | CommandInjection.swift:160:53:160:53 | userControlledString | provenance |  |
-| CommandInjection.swift:140:24:140:24 | userControlledString | CommandInjection.swift:163:52:163:52 | userControlledString | provenance |  |
-| CommandInjection.swift:140:24:140:24 | userControlledString | CommandInjection.swift:164:33:164:33 | userControlledString | provenance |  |
-| CommandInjection.swift:140:24:140:24 | userControlledString | CommandInjection.swift:166:57:166:57 | userControlledString | provenance |  |
 | CommandInjection.swift:151:67:151:95 | [...] [Collection element] | CommandInjection.swift:151:67:151:95 | [...] | provenance |  |
 | CommandInjection.swift:151:75:151:75 | userControlledString | CommandInjection.swift:151:67:151:95 | [...] [Collection element] | provenance |  |
 | CommandInjection.swift:154:23:154:55 | call to URL.init(string:) [some:0] | CommandInjection.swift:154:23:154:56 | ...! | provenance |  |
@@ -158,11 +148,8 @@ edges
 | CommandInjection.swift:205:19:205:19 | userControlledString | CommandInjection.swift:205:18:205:39 | [...] [Collection element] | provenance |  |
 | CommandInjection.swift:207:3:207:3 | [post] getter for .p1 [arguments, Collection element] | CommandInjection.swift:207:3:207:3 | [post] getter for .p1 | provenance |  |
 | CommandInjection.swift:207:18:207:18 | tainted1 [Collection element] | CommandInjection.swift:207:3:207:3 | [post] getter for .p1 [arguments, Collection element] | provenance |  |
-| CommandInjection.swift:207:18:207:18 | tainted1 [Collection element] | CommandInjection.swift:208:19:208:19 | tainted1 [Collection element] | provenance |  |
-| CommandInjection.swift:207:18:207:18 | tainted1 [Collection element] | CommandInjection.swift:209:18:209:18 | tainted1 [Collection element] | provenance |  |
 | CommandInjection.swift:208:3:208:5 | [post] ...! [arguments, Collection element] | CommandInjection.swift:208:3:208:5 | [post] ...! | provenance |  |
 | CommandInjection.swift:208:19:208:19 | tainted1 [Collection element] | CommandInjection.swift:208:3:208:5 | [post] ...! [arguments, Collection element] | provenance |  |
-| CommandInjection.swift:208:19:208:19 | tainted1 [Collection element] | CommandInjection.swift:209:18:209:18 | tainted1 [Collection element] | provenance |  |
 | CommandInjection.swift:209:3:209:3 | [post] ...! [arguments, Collection element] | CommandInjection.swift:209:3:209:3 | [post] ...! | provenance |  |
 | CommandInjection.swift:209:18:209:18 | tainted1 [Collection element] | CommandInjection.swift:209:3:209:3 | [post] ...! [arguments, Collection element] | provenance |  |
 | CommandInjection.swift:211:30:211:51 | [...] [Collection element] | CommandInjection.swift:213:18:213:18 | tainted2 [Collection element] | provenance |  |
@@ -259,7 +246,6 @@ nodes
 | CommandInjection.swift:138:21:138:21 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:139:21:139:42 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | CommandInjection.swift:139:22:139:22 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:140:24:140:24 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:150:42:150:42 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:151:67:151:95 | [...] | semmle.label | [...] |
 | CommandInjection.swift:151:67:151:95 | [...] [Collection element] | semmle.label | [...] [Collection element] |


### PR DESCRIPTION
This PR moves the `LocalFlowBigStep` module from between stage 2 and stage 3 into the stage module, calculated as an output of the stage. The `LocalFlowBigStep` module is parameterized by an existing step relation, and we invoke the module in `Stage3Param` (as before this PR), and in `Stage6Param`, using the big step relation from `Stage3Param` as input.

The benefit of doing this is that we can sometimes skip intermediate nodes, resulting in smaller `edges` relations (as seen in the changes to the expected test output).