### PR TITLE
C++: Fix FPs in `cpp/unsigned-difference-expression-compared-zero`

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-191/UnsignedDifferenceExpressionComparedZero.ql
+++ b/cpp/ql/src/Security/CWE/CWE-191/UnsignedDifferenceExpressionComparedZero.ql
@@ -40,7 +40,10 @@ predicate isGuarded(SubExpr sub, Expr left, Expr right) {
  */
 Expr exprIsLeftOrLessBase(SubExpr sub) {
   interestingSubExpr(sub, _) and // Manual magic
-  result = sub.getLeftOperand()
+  exists(Expr e | globalValueNumber(e).getAnExpr() = sub.getLeftOperand() |
+    // result = sub.getLeftOperand() so result <= sub.getLeftOperand()
+    result = e
+  )
 }
 
 /**

--- a/cpp/ql/src/change-notes/2024-07-16-unsigned-difference-expression-compared-zero-.md
+++ b/cpp/ql/src/change-notes/2024-07-16-unsigned-difference-expression-compared-zero-.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `cpp/unsigned-difference-expression-compared-zero` ("Unsigned difference expression compared to zero") query now produces fewer false positives.

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-191/UnsignedDifferenceExpressionComparedZero/UnsignedDifferenceExpressionComparedZero.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-191/UnsignedDifferenceExpressionComparedZero/UnsignedDifferenceExpressionComparedZero.expected
@@ -14,3 +14,9 @@
 | test.cpp:276:11:276:19 | ... > ... | Unsigned subtraction can never be negative. |
 | test.cpp:288:10:288:18 | ... > ... | Unsigned subtraction can never be negative. |
 | test.cpp:312:9:312:25 | ... > ... | Unsigned subtraction can never be negative. |
+| test.cpp:347:9:347:17 | ... > ... | Unsigned subtraction can never be negative. |
+| test.cpp:352:6:352:14 | ... > ... | Unsigned subtraction can never be negative. |
+| test.cpp:359:10:359:18 | ... > ... | Unsigned subtraction can never be negative. |
+| test.cpp:362:8:362:16 | ... > ... | Unsigned subtraction can never be negative. |
+| test.cpp:369:10:369:18 | ... > ... | Unsigned subtraction can never be negative. |
+| test.cpp:375:8:375:16 | ... > ... | Unsigned subtraction can never be negative. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-191/UnsignedDifferenceExpressionComparedZero/UnsignedDifferenceExpressionComparedZero.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-191/UnsignedDifferenceExpressionComparedZero/UnsignedDifferenceExpressionComparedZero.expected
@@ -14,3 +14,4 @@
 | test.cpp:276:11:276:19 | ... > ... | Unsigned subtraction can never be negative. |
 | test.cpp:288:10:288:18 | ... > ... | Unsigned subtraction can never be negative. |
 | test.cpp:312:9:312:25 | ... > ... | Unsigned subtraction can never be negative. |
+| test.cpp:335:6:335:18 | ... > ... | Unsigned subtraction can never be negative. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-191/UnsignedDifferenceExpressionComparedZero/UnsignedDifferenceExpressionComparedZero.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-191/UnsignedDifferenceExpressionComparedZero/UnsignedDifferenceExpressionComparedZero.expected
@@ -14,9 +14,4 @@
 | test.cpp:276:11:276:19 | ... > ... | Unsigned subtraction can never be negative. |
 | test.cpp:288:10:288:18 | ... > ... | Unsigned subtraction can never be negative. |
 | test.cpp:312:9:312:25 | ... > ... | Unsigned subtraction can never be negative. |
-| test.cpp:347:9:347:17 | ... > ... | Unsigned subtraction can never be negative. |
-| test.cpp:352:6:352:14 | ... > ... | Unsigned subtraction can never be negative. |
-| test.cpp:359:10:359:18 | ... > ... | Unsigned subtraction can never be negative. |
 | test.cpp:362:8:362:16 | ... > ... | Unsigned subtraction can never be negative. |
-| test.cpp:369:10:369:18 | ... > ... | Unsigned subtraction can never be negative. |
-| test.cpp:375:8:375:16 | ... > ... | Unsigned subtraction can never be negative. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-191/UnsignedDifferenceExpressionComparedZero/UnsignedDifferenceExpressionComparedZero.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-191/UnsignedDifferenceExpressionComparedZero/UnsignedDifferenceExpressionComparedZero.expected
@@ -14,4 +14,3 @@
 | test.cpp:276:11:276:19 | ... > ... | Unsigned subtraction can never be negative. |
 | test.cpp:288:10:288:18 | ... > ... | Unsigned subtraction can never be negative. |
 | test.cpp:312:9:312:25 | ... > ... | Unsigned subtraction can never be negative. |
-| test.cpp:335:6:335:18 | ... > ... | Unsigned subtraction can never be negative. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-191/UnsignedDifferenceExpressionComparedZero/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-191/UnsignedDifferenceExpressionComparedZero/test.cpp
@@ -336,3 +336,42 @@ void test20(int a, bool b, unsigned long c)
   {
   }
 }
+
+uint32_t get_uint32();
+int64_t get_int64();
+
+void test21(unsigned long a)
+{
+  {
+    int b = a & get_int64();
+    if (a - b > 0) { } // GOOD [FALSE POSITIVE]
+  }
+
+  {
+  int b = a - get_uint32();
+  if(a - b > 0) { } // GOOD [FALSE POSITIVE]
+  }
+
+  {
+    int64_t c = get_int64();
+    if(c <= 0) {
+      int64_t b = (int64_t)a + c;
+      if(a - b > 0) { } // GOOD [FALSE POSITIVE]
+    }
+    int64_t b = (int64_t)a + c;
+    if(a - b > 0) { } // BAD
+  }
+
+  {
+    unsigned c = get_uint32();
+    if(c >= 1) {
+      int b = a / c;
+      if(a - b > 0) { } // GOOD [FALSE POSITIVE]
+    }
+  }
+
+  {
+    int b = a >> get_uint32();
+    if(a - b > 0) { } // GOOD [FALSE POSITIVE]
+  }
+}

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-191/UnsignedDifferenceExpressionComparedZero/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-191/UnsignedDifferenceExpressionComparedZero/test.cpp
@@ -332,7 +332,7 @@ void test20(int a, bool b, unsigned long c)
     x = a - c;
   }
 
-  if (a - c - x > 0) // GOOD [FALSE POSITIVE]
+  if (a - c - x > 0) // GOOD
   {
   }
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-191/UnsignedDifferenceExpressionComparedZero/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-191/UnsignedDifferenceExpressionComparedZero/test.cpp
@@ -344,19 +344,19 @@ void test21(unsigned long a)
 {
   {
     int b = a & get_int64();
-    if (a - b > 0) { } // GOOD [FALSE POSITIVE]
+    if (a - b > 0) { } // GOOD
   }
 
   {
   int b = a - get_uint32();
-  if(a - b > 0) { } // GOOD [FALSE POSITIVE]
+  if(a - b > 0) { } // GOOD
   }
 
   {
     int64_t c = get_int64();
     if(c <= 0) {
       int64_t b = (int64_t)a + c;
-      if(a - b > 0) { } // GOOD [FALSE POSITIVE]
+      if(a - b > 0) { } // GOOD
     }
     int64_t b = (int64_t)a + c;
     if(a - b > 0) { } // BAD
@@ -366,12 +366,12 @@ void test21(unsigned long a)
     unsigned c = get_uint32();
     if(c >= 1) {
       int b = a / c;
-      if(a - b > 0) { } // GOOD [FALSE POSITIVE]
+      if(a - b > 0) { } // GOOD
     }
   }
 
   {
     int b = a >> get_uint32();
-    if(a - b > 0) { } // GOOD [FALSE POSITIVE]
+    if(a - b > 0) { } // GOOD
   }
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-191/UnsignedDifferenceExpressionComparedZero/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-191/UnsignedDifferenceExpressionComparedZero/test.cpp
@@ -321,3 +321,18 @@ void test19() {
 		total += get_data();
 	}
 }
+
+void test20(int a, bool b, unsigned long c)
+{
+  int x = 0;
+
+  if(b) {
+    x = (a - c) / 2;
+  } else {
+    x = a - c;
+  }
+
+  if (a - c - x > 0) // GOOD [FALSE POSITIVE]
+  {
+  }
+}


### PR DESCRIPTION
Ideally, this should just be done by using the shared range analysis library. However, in a [follow-up PR](https://github.com/github/codeql/pull/16982) I'm suggesting that we move this query into Code Scanning, and we're not quite ready to pull that library into Code Scanning just yet.

So for now I've added the most common/easy cases here. In fact, only the `BitwiseAndExpr` case had an impact on MRVA, and the rest are just for more thorough coverage.

Commit-by-commit review recommended