### PR TITLE
Go: Change string prefix check

### DIFF
--- a/go/ql/lib/semmle/go/dataflow/ExternalFlow.qll
+++ b/go/ql/lib/semmle/go/dataflow/ExternalFlow.qll
@@ -102,7 +102,7 @@ private string groupPrefix() { result = "group:" }
  */
 bindingset[packageOrGroup]
 private string getPackage(string packageOrGroup) {
-  not packageOrGroup.prefix(groupPrefix().length()) = groupPrefix() and result = packageOrGroup
+  not exists(string group | packageOrGroup = groupPrefix() + group) and result = packageOrGroup
   or
   exists(string group |
     FlowExtensions::packageGrouping(group, result) and


### PR DESCRIPTION
This avoids putting all the prefixes in the string pool.

See https://github.com/github/codeql/pull/16941#discussion_r1677548036 for more background.