### PR TITLE
Ruby: Add get_response for Net::HTTP

### DIFF
--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/NetHttp.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/NetHttp.qll
@@ -29,7 +29,7 @@ class NetHttpRequest extends Http::Client::Request::Range, DataFlow::CallNode {
       this = request
     |
       // Net::HTTP.get(...)
-      method = "get" and
+      method in ["get", "get_response"] and
       requestNode = API::getTopLevelMember("Net").getMember("HTTP").getReturn(method) and
       returnsResponseBody = true
       or


### PR DESCRIPTION
Add method `get_response` for ruby `Net::HTTP`