### PR TITLE
Go: Output stdout/stderr for `go version` if something goes wrong

### DIFF
--- a/go/extractor/toolchain/toolchain.go
+++ b/go/extractor/toolchain/toolchain.go
@@ -53,6 +53,7 @@ func GetEnvGoVersion() string {
 		out, err := cmd.CombinedOutput()
 
 		if err != nil {
+			log.Println(string(out))
 			log.Fatalf("Unable to run the go command, is it installed?\nError: %s", err.Error())
 		}
 


### PR DESCRIPTION
This should help troubleshoot issues if something goes wrong.