### PR TITLE
Java: Update `Annotation` predicate examples in language guide

### DIFF
--- a/docs/codeql/codeql-language-guides/annotations-in-java.rst
+++ b/docs/codeql/codeql-language-guides/annotations-in-java.rst
@@ -103,7 +103,7 @@ As a first step, let's write a query that finds all ``@Override`` annotations. A
 
 As always, it is a good idea to try this query on a CodeQL database for a Java/Kotlin project to make sure it actually produces some results. On the earlier example, it should find the annotation on ``Sub1.m``. Next, we encapsulate the concept of an ``@Override`` annotation as a CodeQL class:
 
-::
+.. code-block:: ql
 
    class OverrideAnnotation extends Annotation {
        OverrideAnnotation() {
@@ -213,11 +213,11 @@ To do so, we first introduce a class for representing all ``@SuppressWarnings`` 
    class SuppressDeprecationWarningAnnotation extends Annotation {
        SuppressDeprecationWarningAnnotation() {
            this.getType().hasQualifiedName("java.lang", "SuppressWarnings") and
-           this.getAValue().(Literal).getLiteral().regexpMatch(".*deprecation.*")
+           this.getAStringArrayValue("value").regexpMatch(".*deprecation.*")
        }
    }
 
-Here, we use ``getAValue()`` to retrieve any annotation value: in fact, annotation type ``SuppressWarnings`` only has a single annotation element, so every ``@SuppressWarnings`` annotation only has a single annotation value. Then, we ensure that it is a literal, obtain its string value using ``getLiteral``, and check whether it contains the string ``deprecation`` using a regular expression match.
+Here, we use ``getAStringArrayValue("value")`` to retrieve any of the suppressed warnings: ``@SuppressWarnings`` defines the warnings to suppress using the annotation element named ``value`` of type ``String[]``, and ``getAStringArrayValue`` retrieves all of the array values; the CodeQL class ``Annotation`` also has similar convenience predicates for the other possible annotation element types. Afterwards we check whether one of the values is the string ``deprecation`` using a regular expression match.
 
 For real-world use, this check would have to be generalized a bit: for example, the OpenJDK Java compiler allows ``@SuppressWarnings("all")`` annotations to suppress all warnings. We may also want to make sure that ``deprecation`` is matched as an entire word, and not as part of another word, by changing the regular expression to ``".*\\bdeprecation\\b.*"``.
 


### PR DESCRIPTION
#6246 added new predicates and deprecated some of the existing predicates, including `getAValue()` which is currently used in the example.

Please let me know if the new documentation text is too verbose or if I should adjust it in some way.