### PR TITLE
C++: Fix issue with cpp/suspicious-allocation-size

### DIFF
--- a/cpp/ql/src/change-notes/2024-07-22-suspicious-allocation-size.md
+++ b/cpp/ql/src/change-notes/2024-07-22-suspicious-allocation-size.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `cpp/suspicious-allocation-size` ("Not enough memory allocated for array of pointer type") query no longer produces false positives on "variable size" `struct`s.

--- a/cpp/ql/test/query-tests/Critical/SizeCheck/SizeCheck2.expected
+++ b/cpp/ql/test/query-tests/Critical/SizeCheck/SizeCheck2.expected
@@ -2,7 +2,4 @@
 | test2.c:17:20:17:25 | call to malloc | Allocated memory (33 bytes) is not a multiple of the size of 'double' (8 bytes). |
 | test2.c:32:23:32:28 | call to malloc | Allocated memory (28 bytes) is not a multiple of the size of 'long long' (8 bytes). |
 | test2.c:33:20:33:25 | call to malloc | Allocated memory (20 bytes) is not a multiple of the size of 'double' (8 bytes). |
-| test2.c:82:23:82:28 | call to malloc | Allocated memory (135 bytes) is not a multiple of the size of 'MyVarStruct1' (8 bytes). |
-| test2.c:83:23:83:28 | call to malloc | Allocated memory (143 bytes) is not a multiple of the size of 'MyVarStruct2' (16 bytes). |
-| test2.c:84:23:84:28 | call to malloc | Allocated memory (135 bytes) is not a multiple of the size of 'MyVarStruct3' (8 bytes). |
 | test2.c:85:24:85:29 | call to malloc | Allocated memory (1159 bytes) is not a multiple of the size of 'MyFixedStruct' (1032 bytes). |

--- a/cpp/ql/test/query-tests/Critical/SizeCheck/SizeCheck2.expected
+++ b/cpp/ql/test/query-tests/Critical/SizeCheck/SizeCheck2.expected
@@ -2,3 +2,7 @@
 | test2.c:17:20:17:25 | call to malloc | Allocated memory (33 bytes) is not a multiple of the size of 'double' (8 bytes). |
 | test2.c:32:23:32:28 | call to malloc | Allocated memory (28 bytes) is not a multiple of the size of 'long long' (8 bytes). |
 | test2.c:33:20:33:25 | call to malloc | Allocated memory (20 bytes) is not a multiple of the size of 'double' (8 bytes). |
+| test2.c:82:23:82:28 | call to malloc | Allocated memory (135 bytes) is not a multiple of the size of 'MyVarStruct1' (8 bytes). |
+| test2.c:83:23:83:28 | call to malloc | Allocated memory (143 bytes) is not a multiple of the size of 'MyVarStruct2' (16 bytes). |
+| test2.c:84:23:84:28 | call to malloc | Allocated memory (135 bytes) is not a multiple of the size of 'MyVarStruct3' (8 bytes). |
+| test2.c:85:24:85:29 | call to malloc | Allocated memory (1159 bytes) is not a multiple of the size of 'MyFixedStruct' (1032 bytes). |

--- a/cpp/ql/test/query-tests/Critical/SizeCheck/test.c
+++ b/cpp/ql/test/query-tests/Critical/SizeCheck/test.c
@@ -60,7 +60,7 @@ void test_union() {
 }
 
 // --- custom allocators ---
- 
+
 void *MyMalloc1(size_t size) { return malloc(size); }
 void *MyMalloc2(size_t size);
 

--- a/cpp/ql/test/query-tests/Critical/SizeCheck/test2.c
+++ b/cpp/ql/test/query-tests/Critical/SizeCheck/test2.c
@@ -79,8 +79,8 @@ typedef struct _MyFixedStruct {
 } MyFixedStruct;
 
 void varStructTests() {
-    MyVarStruct1 *a = malloc(sizeof(MyVarStruct1) + 127); // GOOD [FALSE POSITIVE]
-    MyVarStruct2 *b = malloc(sizeof(MyVarStruct2) + 127); // GOOD [FALSE POSITIVE]
-    MyVarStruct3 *c = malloc(sizeof(MyVarStruct3) + 127); // GOOD [FALSE POSITIVE]
+    MyVarStruct1 *a = malloc(sizeof(MyVarStruct1) + 127); // GOOD
+    MyVarStruct2 *b = malloc(sizeof(MyVarStruct2) + 127); // GOOD
+    MyVarStruct3 *c = malloc(sizeof(MyVarStruct3) + 127); // GOOD
     MyFixedStruct *d = malloc(sizeof(MyFixedStruct) + 127); // BAD --- Not a multiple of sizeof(MyFixedStruct)
 }

--- a/cpp/ql/test/query-tests/Critical/SizeCheck/test2.c
+++ b/cpp/ql/test/query-tests/Critical/SizeCheck/test2.c
@@ -44,7 +44,7 @@ void good1(void) {
 }
 
 // --- custom allocators ---
- 
+
 void *MyMalloc1(size_t size) { return malloc(size); }
 void *MyMalloc2(size_t size);
 
@@ -52,4 +52,35 @@ void customAllocatorTests()
 {
     double *dptr1 = MyMalloc1(33); // BAD -- Not a multiple of sizeof(double) [NOT DETECTED]
     double *dptr2 = MyMalloc2(33); // BAD -- Not a multiple of sizeof(double) [NOT DETECTED]
+}
+
+// --- variable length data structures ---
+
+typedef unsigned char uint8_t;
+
+typedef struct _MyVarStruct1 {
+    size_t dataLen;
+    uint8_t data[0];
+} MyVarStruct1;
+
+typedef struct _MyVarStruct2 {
+    size_t dataLen;
+    uint8_t data[1];
+} MyVarStruct2;
+
+typedef struct _MyVarStruct3 {
+    size_t dataLen;
+    uint8_t data[];
+} MyVarStruct3;
+
+typedef struct _MyFixedStruct {
+    size_t dataLen;
+    uint8_t data[1024];
+} MyFixedStruct;
+
+void varStructTests() {
+    MyVarStruct1 *a = malloc(sizeof(MyVarStruct1) + 127); // GOOD [FALSE POSITIVE]
+    MyVarStruct2 *b = malloc(sizeof(MyVarStruct2) + 127); // GOOD [FALSE POSITIVE]
+    MyVarStruct3 *c = malloc(sizeof(MyVarStruct3) + 127); // GOOD [FALSE POSITIVE]
+    MyFixedStruct *d = malloc(sizeof(MyFixedStruct) + 127); // BAD --- Not a multiple of sizeof(MyFixedStruct)
 }


### PR DESCRIPTION
Fix an issue with `cpp/suspicious-allocation-size`, that it was unaware of the pattern of "variable size" `struct`s where the last member is an array of size zero or one, but additional space for it is allocated in practice.