### PR TITLE
Java: sanitize values which are checked against an allowlist (currently only calling `List.contains` on a list constructed locally with `List.of`)

### DIFF
--- a/java/ql/lib/change-notes/2024-07-23-list-of-constants-sanitizer.md
+++ b/java/ql/lib/change-notes/2024-07-23-list-of-constants-sanitizer.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* If a `java.util.List` is constructed using `List.of` to contain only compile-time constant strings, and a value is checked to belong in the list using `List.contains` then it is no longer considered tainted.

--- a/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
@@ -156,11 +156,18 @@ private module Cached {
   }
 
   /**
+   * A sanitizer in all global taint flow configurations but not in local taint.
+   */
+  cached
+  abstract class DefaultTaintSanitizer extends DataFlow::Node { }
+
+  /**
    * Holds if `node` should be a sanitizer in all global taint flow configurations
    * but not in local taint.
    */
   cached
   predicate defaultTaintSanitizer(DataFlow::Node node) {
+    node instanceof DefaultTaintSanitizer or
     // Ignore paths through test code.
     node.getEnclosingCallable().getDeclaringType() instanceof NonSecurityTestClass or
     node.asExpr() instanceof ValidatedVariableAccess

--- a/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
@@ -665,3 +665,83 @@ private predicate entrypointFieldStep(DataFlow::Node src, DataFlow::Node sink) {
   ) and
   src.getType().(RefType).getSourceDeclaration() = entrypointType()
 }
+
+/**
+ * A comparison against a list of compile-time constants, sanitizing taint by
+ * restricting to a set of known values.
+ */
+class ListOfConstantsComparisonSanitizerGuard extends TaintTracking::DefaultTaintSanitizer {
+  ListOfConstantsComparisonSanitizerGuard() {
+    this = DataFlow::BarrierGuard<listOfConstantsComparisonSanitizerGuard/3>::getABarrierNode()
+  }
+}
+
+private predicate listOfConstantsComparisonSanitizerGuard(Guard g, Expr e, boolean outcome) {
+  exists(ListOfConstantsComparison locc |
+    g = locc and
+    e = locc.getExpr() and
+    outcome = locc.getOutcome()
+  )
+}
+
+/** A comparison against a list of compile-time constants. */
+abstract class ListOfConstantsComparison extends Guard {
+  Expr e;
+  boolean outcome;
+
+  ListOfConstantsComparison() {
+    exists(this) and
+    outcome = [true, false]
+  }
+
+  Expr getExpr() { result = e }
+
+  boolean getOutcome() { result = outcome }
+}
+
+/**
+ * An invocation of `java.util.List.contains` where the qualifier contains only
+ * compile-time constants.
+ */
+private class JavaUtilListOfConstantsContains extends ListOfConstantsComparison {
+  JavaUtilListOfConstantsContains() {
+    exists(MethodCall mc, Method m | mc.getMethod() = m |
+      m.hasName("contains") and
+      m.getDeclaringType().getSourceDeclaration().hasQualifiedName("java.util", "List") and
+      DataFlow::localFlow(any(JavaUtilListOfConstants loc), DataFlow::exprNode(mc.getQualifier())) and
+      this = mc and
+      e = mc.getArgument(0) and
+      outcome = true
+    )
+  }
+}
+
+/**
+ * An instance of `java.util.List` which contains only compile-time constants.
+ */
+abstract class JavaUtilListOfConstants extends DataFlow::Node { }
+
+/**
+ * An invocation of `java.util.List.of` which constructs an (immutable) list
+ * which contains only compile-time constants.
+ */
+private class JavaUtilListOfConstantsCreatedWithListOf extends JavaUtilListOfConstants {
+  JavaUtilListOfConstantsCreatedWithListOf() {
+    exists(MethodCall mc, Method m |
+      m.hasName("of") and
+      m.getDeclaringType().getSourceDeclaration().hasQualifiedName("java.util", "List") and
+      mc.getMethod() = m and
+      DataFlow::localFlow(DataFlow::exprNode(mc), this) and
+      (
+        // List<String> allowlist = List.of("a", "b", "c")
+        forall(Expr e | e = mc.getAnArgument() | e.isCompileTimeConstant())
+        or
+        // String[] a = {"a", "b", "c"};
+        // List<String> allowlist = List.of(a)
+        exists(ArrayInit arr | DataFlow::localExprFlow(arr, mc.getArgument(0)) |
+          forall(Expr e | e = arr.getAnInit() | e.isCompileTimeConstant())
+        )
+      )
+    )
+  }
+}

--- a/java/ql/test/query-tests/security/CWE-089/semmle/examples/SqlTainted.expected
+++ b/java/ql/test/query-tests/security/CWE-089/semmle/examples/SqlTainted.expected
@@ -14,9 +14,7 @@ edges
 | Test.java:60:29:60:46 | toString(...) : String | Test.java:62:47:62:61 | querySbToString | provenance |  Sink:MaD:43208 |
 | Test.java:183:33:183:45 | args : String[] | Test.java:209:47:209:68 | queryWithUserTableName | provenance |  Sink:MaD:43208 |
 | Test.java:213:34:213:46 | args : String[] | Test.java:221:81:221:111 | ... + ... | provenance |  Sink:MaD:43208 |
-| Test.java:227:32:227:44 | args : String[] | Test.java:236:48:236:52 | query | provenance |  Sink:MaD:43208 |
 | Test.java:227:32:227:44 | args : String[] | Test.java:246:48:246:52 | query | provenance |  Sink:MaD:43208 |
-| Test.java:227:32:227:44 | args : String[] | Test.java:257:48:257:52 | query | provenance |  Sink:MaD:43208 |
 | Test.java:227:32:227:44 | args : String[] | Test.java:268:48:268:52 | query | provenance |  Sink:MaD:43208 |
 | Test.java:227:32:227:44 | args : String[] | Test.java:281:48:281:52 | query | provenance |  Sink:MaD:43208 |
 | Test.java:286:26:286:38 | args : String[] | Test.java:287:11:287:14 | args : String[] | provenance |  |
@@ -48,9 +46,7 @@ nodes
 | Test.java:213:34:213:46 | args : String[] | semmle.label | args : String[] |
 | Test.java:221:81:221:111 | ... + ... | semmle.label | ... + ... |
 | Test.java:227:32:227:44 | args : String[] | semmle.label | args : String[] |
-| Test.java:236:48:236:52 | query | semmle.label | query |
 | Test.java:246:48:246:52 | query | semmle.label | query |
-| Test.java:257:48:257:52 | query | semmle.label | query |
 | Test.java:268:48:268:52 | query | semmle.label | query |
 | Test.java:281:48:281:52 | query | semmle.label | query |
 | Test.java:286:26:286:38 | args : String[] | semmle.label | args : String[] |
@@ -70,8 +66,6 @@ subpaths
 | Test.java:78:46:78:50 | query | Test.java:286:26:286:38 | args : String[] | Test.java:78:46:78:50 | query | This query depends on a $@. | Test.java:286:26:286:38 | args | user-provided value |
 | Test.java:209:47:209:68 | queryWithUserTableName | Test.java:286:26:286:38 | args : String[] | Test.java:209:47:209:68 | queryWithUserTableName | This query depends on a $@. | Test.java:286:26:286:38 | args | user-provided value |
 | Test.java:221:81:221:111 | ... + ... | Test.java:286:26:286:38 | args : String[] | Test.java:221:81:221:111 | ... + ... | This query depends on a $@. | Test.java:286:26:286:38 | args | user-provided value |
-| Test.java:236:48:236:52 | query | Test.java:286:26:286:38 | args : String[] | Test.java:236:48:236:52 | query | This query depends on a $@. | Test.java:286:26:286:38 | args | user-provided value |
 | Test.java:246:48:246:52 | query | Test.java:286:26:286:38 | args : String[] | Test.java:246:48:246:52 | query | This query depends on a $@. | Test.java:286:26:286:38 | args | user-provided value |
-| Test.java:257:48:257:52 | query | Test.java:286:26:286:38 | args : String[] | Test.java:257:48:257:52 | query | This query depends on a $@. | Test.java:286:26:286:38 | args | user-provided value |
 | Test.java:268:48:268:52 | query | Test.java:286:26:286:38 | args : String[] | Test.java:268:48:268:52 | query | This query depends on a $@. | Test.java:286:26:286:38 | args | user-provided value |
 | Test.java:281:48:281:52 | query | Test.java:286:26:286:38 | args : String[] | Test.java:281:48:281:52 | query | This query depends on a $@. | Test.java:286:26:286:38 | args | user-provided value |

--- a/java/ql/test/query-tests/security/CWE-089/semmle/examples/SqlTainted.expected
+++ b/java/ql/test/query-tests/security/CWE-089/semmle/examples/SqlTainted.expected
@@ -14,12 +14,19 @@ edges
 | Test.java:60:29:60:46 | toString(...) : String | Test.java:62:47:62:61 | querySbToString | provenance |  Sink:MaD:43208 |
 | Test.java:183:33:183:45 | args : String[] | Test.java:209:47:209:68 | queryWithUserTableName | provenance |  Sink:MaD:43208 |
 | Test.java:213:34:213:46 | args : String[] | Test.java:221:81:221:111 | ... + ... | provenance |  Sink:MaD:43208 |
-| Test.java:227:26:227:38 | args : String[] | Test.java:228:11:228:14 | args : String[] | provenance |  |
-| Test.java:227:26:227:38 | args : String[] | Test.java:232:14:232:17 | args : String[] | provenance |  |
-| Test.java:227:26:227:38 | args : String[] | Test.java:233:15:233:18 | args : String[] | provenance |  |
-| Test.java:228:11:228:14 | args : String[] | Test.java:29:30:29:42 | args : String[] | provenance |  |
-| Test.java:232:14:232:17 | args : String[] | Test.java:183:33:183:45 | args : String[] | provenance |  |
-| Test.java:233:15:233:18 | args : String[] | Test.java:213:34:213:46 | args : String[] | provenance |  |
+| Test.java:227:32:227:44 | args : String[] | Test.java:236:48:236:52 | query | provenance |  Sink:MaD:43208 |
+| Test.java:227:32:227:44 | args : String[] | Test.java:246:48:246:52 | query | provenance |  Sink:MaD:43208 |
+| Test.java:227:32:227:44 | args : String[] | Test.java:257:48:257:52 | query | provenance |  Sink:MaD:43208 |
+| Test.java:227:32:227:44 | args : String[] | Test.java:268:48:268:52 | query | provenance |  Sink:MaD:43208 |
+| Test.java:227:32:227:44 | args : String[] | Test.java:281:48:281:52 | query | provenance |  Sink:MaD:43208 |
+| Test.java:286:26:286:38 | args : String[] | Test.java:287:11:287:14 | args : String[] | provenance |  |
+| Test.java:286:26:286:38 | args : String[] | Test.java:291:14:291:17 | args : String[] | provenance |  |
+| Test.java:286:26:286:38 | args : String[] | Test.java:292:15:292:18 | args : String[] | provenance |  |
+| Test.java:286:26:286:38 | args : String[] | Test.java:293:13:293:16 | args : String[] | provenance |  |
+| Test.java:287:11:287:14 | args : String[] | Test.java:29:30:29:42 | args : String[] | provenance |  |
+| Test.java:291:14:291:17 | args : String[] | Test.java:183:33:183:45 | args : String[] | provenance |  |
+| Test.java:292:15:292:18 | args : String[] | Test.java:213:34:213:46 | args : String[] | provenance |  |
+| Test.java:293:13:293:16 | args : String[] | Test.java:227:32:227:44 | args : String[] | provenance |  |
 nodes
 | Mongo.java:10:29:10:41 | args : String[] | semmle.label | args : String[] |
 | Mongo.java:17:45:17:67 | parse(...) | semmle.label | parse(...) |
@@ -40,19 +47,31 @@ nodes
 | Test.java:209:47:209:68 | queryWithUserTableName | semmle.label | queryWithUserTableName |
 | Test.java:213:34:213:46 | args : String[] | semmle.label | args : String[] |
 | Test.java:221:81:221:111 | ... + ... | semmle.label | ... + ... |
-| Test.java:227:26:227:38 | args : String[] | semmle.label | args : String[] |
-| Test.java:228:11:228:14 | args : String[] | semmle.label | args : String[] |
-| Test.java:232:14:232:17 | args : String[] | semmle.label | args : String[] |
-| Test.java:233:15:233:18 | args : String[] | semmle.label | args : String[] |
+| Test.java:227:32:227:44 | args : String[] | semmle.label | args : String[] |
+| Test.java:236:48:236:52 | query | semmle.label | query |
+| Test.java:246:48:246:52 | query | semmle.label | query |
+| Test.java:257:48:257:52 | query | semmle.label | query |
+| Test.java:268:48:268:52 | query | semmle.label | query |
+| Test.java:281:48:281:52 | query | semmle.label | query |
+| Test.java:286:26:286:38 | args : String[] | semmle.label | args : String[] |
+| Test.java:287:11:287:14 | args : String[] | semmle.label | args : String[] |
+| Test.java:291:14:291:17 | args : String[] | semmle.label | args : String[] |
+| Test.java:292:15:292:18 | args : String[] | semmle.label | args : String[] |
+| Test.java:293:13:293:16 | args : String[] | semmle.label | args : String[] |
 subpaths
 #select
 | Mongo.java:17:45:17:67 | parse(...) | Mongo.java:10:29:10:41 | args : String[] | Mongo.java:17:45:17:67 | parse(...) | This query depends on a $@. | Mongo.java:10:29:10:41 | args | user-provided value |
 | Mongo.java:21:49:21:52 | json | Mongo.java:10:29:10:41 | args : String[] | Mongo.java:21:49:21:52 | json | This query depends on a $@. | Mongo.java:10:29:10:41 | args | user-provided value |
-| Test.java:36:47:36:52 | query1 | Test.java:227:26:227:38 | args : String[] | Test.java:36:47:36:52 | query1 | This query depends on a $@. | Test.java:227:26:227:38 | args | user-provided value |
-| Test.java:42:57:42:62 | query2 | Test.java:227:26:227:38 | args : String[] | Test.java:42:57:42:62 | query2 | This query depends on a $@. | Test.java:227:26:227:38 | args | user-provided value |
-| Test.java:50:62:50:67 | query3 | Test.java:227:26:227:38 | args : String[] | Test.java:50:62:50:67 | query3 | This query depends on a $@. | Test.java:227:26:227:38 | args | user-provided value |
-| Test.java:62:47:62:61 | querySbToString | Test.java:227:26:227:38 | args : String[] | Test.java:62:47:62:61 | querySbToString | This query depends on a $@. | Test.java:227:26:227:38 | args | user-provided value |
-| Test.java:70:40:70:44 | query | Test.java:227:26:227:38 | args : String[] | Test.java:70:40:70:44 | query | This query depends on a $@. | Test.java:227:26:227:38 | args | user-provided value |
-| Test.java:78:46:78:50 | query | Test.java:227:26:227:38 | args : String[] | Test.java:78:46:78:50 | query | This query depends on a $@. | Test.java:227:26:227:38 | args | user-provided value |
-| Test.java:209:47:209:68 | queryWithUserTableName | Test.java:227:26:227:38 | args : String[] | Test.java:209:47:209:68 | queryWithUserTableName | This query depends on a $@. | Test.java:227:26:227:38 | args | user-provided value |
-| Test.java:221:81:221:111 | ... + ... | Test.java:227:26:227:38 | args : String[] | Test.java:221:81:221:111 | ... + ... | This query depends on a $@. | Test.java:227:26:227:38 | args | user-provided value |
+| Test.java:36:47:36:52 | query1 | Test.java:286:26:286:38 | args : String[] | Test.java:36:47:36:52 | query1 | This query depends on a $@. | Test.java:286:26:286:38 | args | user-provided value |
+| Test.java:42:57:42:62 | query2 | Test.java:286:26:286:38 | args : String[] | Test.java:42:57:42:62 | query2 | This query depends on a $@. | Test.java:286:26:286:38 | args | user-provided value |
+| Test.java:50:62:50:67 | query3 | Test.java:286:26:286:38 | args : String[] | Test.java:50:62:50:67 | query3 | This query depends on a $@. | Test.java:286:26:286:38 | args | user-provided value |
+| Test.java:62:47:62:61 | querySbToString | Test.java:286:26:286:38 | args : String[] | Test.java:62:47:62:61 | querySbToString | This query depends on a $@. | Test.java:286:26:286:38 | args | user-provided value |
+| Test.java:70:40:70:44 | query | Test.java:286:26:286:38 | args : String[] | Test.java:70:40:70:44 | query | This query depends on a $@. | Test.java:286:26:286:38 | args | user-provided value |
+| Test.java:78:46:78:50 | query | Test.java:286:26:286:38 | args : String[] | Test.java:78:46:78:50 | query | This query depends on a $@. | Test.java:286:26:286:38 | args | user-provided value |
+| Test.java:209:47:209:68 | queryWithUserTableName | Test.java:286:26:286:38 | args : String[] | Test.java:209:47:209:68 | queryWithUserTableName | This query depends on a $@. | Test.java:286:26:286:38 | args | user-provided value |
+| Test.java:221:81:221:111 | ... + ... | Test.java:286:26:286:38 | args : String[] | Test.java:221:81:221:111 | ... + ... | This query depends on a $@. | Test.java:286:26:286:38 | args | user-provided value |
+| Test.java:236:48:236:52 | query | Test.java:286:26:286:38 | args : String[] | Test.java:236:48:236:52 | query | This query depends on a $@. | Test.java:286:26:286:38 | args | user-provided value |
+| Test.java:246:48:246:52 | query | Test.java:286:26:286:38 | args : String[] | Test.java:246:48:246:52 | query | This query depends on a $@. | Test.java:286:26:286:38 | args | user-provided value |
+| Test.java:257:48:257:52 | query | Test.java:286:26:286:38 | args : String[] | Test.java:257:48:257:52 | query | This query depends on a $@. | Test.java:286:26:286:38 | args | user-provided value |
+| Test.java:268:48:268:52 | query | Test.java:286:26:286:38 | args : String[] | Test.java:268:48:268:52 | query | This query depends on a $@. | Test.java:286:26:286:38 | args | user-provided value |
+| Test.java:281:48:281:52 | query | Test.java:286:26:286:38 | args : String[] | Test.java:281:48:281:52 | query | This query depends on a $@. | Test.java:286:26:286:38 | args | user-provided value |

--- a/java/ql/test/query-tests/security/CWE-089/semmle/examples/Test.java
+++ b/java/ql/test/query-tests/security/CWE-089/semmle/examples/Test.java
@@ -11,8 +11,8 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-
-
+import java.util.ArrayList;
+import java.util.List;
 
 
 
@@ -50,7 +50,7 @@ abstract class Test {
 			PreparedStatement statement = connection.prepareStatement(query3);
 			ResultSet results = statement.executeQuery();
 		}
-		// BAD: an injection using a StringBuilder instead of string append 
+		// BAD: an injection using a StringBuilder instead of string append
 		{
 			String category = args[1];
 			StringBuilder querySb = new StringBuilder();
@@ -88,7 +88,7 @@ abstract class Test {
 			ResultSet results = statement.executeQuery(query1);
 		}
 	}
-	
+
 	private static void unescaped() throws IOException, SQLException {
 		// BAD: the category might have SQL special characters in it
 		{
@@ -97,7 +97,7 @@ abstract class Test {
 					+ categoryName + "' ORDER BY PRICE";
 			ResultSet results = statement.executeQuery(queryFromField);
 		}
-		// BAD: unescaped code using a StringBuilder 
+		// BAD: unescaped code using a StringBuilder
 		{
 			StringBuilder querySb = new StringBuilder();
 			querySb.append("SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='");
@@ -107,7 +107,7 @@ abstract class Test {
 			Statement statement = connection.createStatement();
 			ResultSet results = statement.executeQuery(querySbToString);
 		}
-		// BAD: a StringBuilder with appends of + operations 
+		// BAD: a StringBuilder with appends of + operations
 		{
 			StringBuilder querySb2 = new StringBuilder();
 			querySb2.append("SELECT ITEM,PRICE FROM PRODUCT ");
@@ -118,7 +118,7 @@ abstract class Test {
 			ResultSet results = statement.executeQuery(querySb2ToString);
 		}
 	}
-	
+
 	private static void good(String[] args) throws IOException, SQLException {
 		// GOOD: use a prepared query
 		{
@@ -127,9 +127,9 @@ abstract class Test {
 			PreparedStatement statement = connection.prepareStatement(query2);
 			statement.setString(1, category);
 			ResultSet results = statement.executeQuery();
-		}		
+		}
 	}
-	
+
 	private static void controlledStrings()  throws IOException, SQLException {
 		// GOOD: integers cannot have special characters in them
 		{
@@ -179,7 +179,7 @@ abstract class Test {
 			ResultSet results = statement.executeQuery(queryWithDoubleToString);
 		}
 	}
-	
+
 	private static void tableNames(String[] args) throws IOException, SQLException {
 		// GOOD: table names cannot be replaced by a wildcard
 		{
@@ -224,6 +224,65 @@ abstract class Test {
 		}
 	}
 
+	private static void allowlist(String[] args) throws IOException, SQLException {
+		String tainted = args[1];
+		// GOOD: an allowlist is used with constant strings
+		{
+			Statement statement = connection.createStatement();
+			List<String> allowlist = List.of("allowed1", "allowed2", "allowed3");
+			if(allowlist.contains(tainted)){
+				String query = "SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='"
+						+ tainted + "' ORDER BY PRICE";
+				ResultSet results = statement.executeQuery(query);
+			}
+		}
+		// BAD: an allowlist is used but one of the entries is not a compile-time constant
+		{
+			Statement statement = connection.createStatement();
+			List<String> allowlist = List.of("allowed1", "allowed2", args[2]);
+			if(allowlist.contains(tainted)){
+				String query = "SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='"
+						+ tainted + "' ORDER BY PRICE";
+				ResultSet results = statement.executeQuery(query);
+			}
+		}
+		// GOOD: an allowlist is used with constant strings
+		{
+			Statement statement = connection.createStatement();
+			String[] allowedArray = {"allowed1", "allowed2", "allowed3"};
+			List<String> allowlist = List.of(allowedArray);
+			if(allowlist.contains(tainted)){
+				String query = "SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='"
+						+ tainted + "' ORDER BY PRICE";
+				ResultSet results = statement.executeQuery(query);
+			}
+		}
+		// BAD: an allowlist is used but one of the entries is not a compile-time constant
+		{
+			Statement statement = connection.createStatement();
+			String[] allowedArray = {"allowed1", "allowed2", args[2]};
+			List<String> allowlist = List.of(allowedArray);
+			if(allowlist.contains(tainted)){
+				String query = "SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='"
+						+ tainted + "' ORDER BY PRICE";
+				ResultSet results = statement.executeQuery(query);
+			}
+		}
+		// GOOD: an allowlist is used with constant string, but we currently miss this case
+		{
+			Statement statement = connection.createStatement();
+			List<String> allowlist = new ArrayList<String>();
+			allowlist.add("allowed1");
+			allowlist.add("allowed2");
+			allowlist.add("allowed3");
+			if(allowlist.contains(tainted)){
+				String query = "SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='"
+						+ tainted + "' ORDER BY PRICE";
+				ResultSet results = statement.executeQuery(query);
+			}
+		}
+	}
+
 	public static void main(String[] args) throws IOException, SQLException {
 		tainted(args);
 		unescaped();
@@ -231,6 +290,6 @@ abstract class Test {
 		controlledStrings();
 		tableNames(args);
 		bindingVars(args);
+		allowlist(args);
 	}
 }
-


### PR DESCRIPTION
Checking that a value is in a set of compile-time constant values should be a sanitizer, because what was untrusted data has now been checked to be in a known set of values. It is hard in CodeQL to identify when this happens, as there are many ways of checking that a value is in a known set of values. This PR introduces the framework for this sanitizer and implements it for one particular case: constructing a `java.util.List` which contains only compile-time constant values and then calling `List.contains` to check that a variable is in the list. Note also that the `List` has to be constructed in the same function as the call to `List.contains`.