### PR TITLE
Java: Add comments about use of sink kind `regex-use`

### DIFF
--- a/java/ql/lib/ext/org.apache.commons.lang3.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.lang3.model.yml
@@ -3,6 +3,7 @@ extensions:
       pack: codeql/java-all
       extensible: sinkModel
     data:
+      # Note these sinks do not use the sink kind `regex-use[0]` because they should be considered as sinks for regex injection but not polynomial ReDoS.
       - ["org.apache.commons.lang3", "RegExUtils", False, "removeAll", "(String,String)", "", "Argument[1]", "regex-use", "manual"]
       - ["org.apache.commons.lang3", "RegExUtils", False, "removeFirst", "(String,String)", "", "Argument[1]", "regex-use", "manual"]
       - ["org.apache.commons.lang3", "RegExUtils", False, "removePattern", "(String,String)", "", "Argument[1]", "regex-use", "manual"]

--- a/java/ql/lib/semmle/code/java/regex/RegexFlowConfigs.qll
+++ b/java/ql/lib/semmle/code/java/regex/RegexFlowConfigs.qll
@@ -13,9 +13,15 @@ private class ExploitableStringLiteral extends StringLiteral {
 
 /**
  * Holds if `kind` is an external sink kind that is relevant for regex flow.
- * `full` is true if sinks with this kind match against the full string of its input.
- * `strArg` is the index of the argument to methods with this sink kind that contan the string to be matched against,
- * where -1 is the qualifier; or -2 if no such argument exists.
+ * `full` is true if sinks with this kind match against the full string of its
+ * input.
+ * `strArg` is the index of the argument to methods with this sink kind that
+ * contain the string to be matched against, where -1 is the qualifier; or -2
+ * if no such argument exists.
+ *
+ * Note that `regex-use` is deliberately not a possible value for `kind` here,
+ * as it is used for regular expression injection sinks that should not be used
+ * as polynomial ReDoS sinks.
  */
 private predicate regexSinkKindInfo(string kind, boolean full, int strArg) {
   sinkModel(_, _, _, _, _, _, _, kind, _, _) and


### PR DESCRIPTION
The sink kind `regex-use` doesn't match [the code which parses regex-use sink kinds](https://github.com/github/codeql/blob/4c8da54b64d67aa958ed8875492f962bb1c5c5af/java/ql/lib/semmle/code/java/regex/RegexFlowConfigs.qll#L20-L49) for regex injection. It turns out this is intentional, but not clearly documented. This PR adds comments explaining that.