### PR TITLE
C++: More tests for cpp/use-after-free

### DIFF
--- a/cpp/ql/test/query-tests/Critical/MemoryFreed/MemoryFreed.expected
+++ b/cpp/ql/test/query-tests/Critical/MemoryFreed/MemoryFreed.expected
@@ -28,6 +28,9 @@
 | test.cpp:199:10:199:12 | cpy |
 | test.cpp:213:7:213:7 | a |
 | test.cpp:219:7:219:7 | a |
+| test.cpp:228:14:228:18 | data1 |
+| test.cpp:236:14:236:18 | data1 |
+| test.cpp:237:14:237:18 | data2 |
 | test_free.cpp:11:10:11:10 | a |
 | test_free.cpp:14:10:14:10 | a |
 | test_free.cpp:16:10:16:10 | a |

--- a/cpp/ql/test/query-tests/Critical/MemoryFreed/MemoryFreed.expected
+++ b/cpp/ql/test/query-tests/Critical/MemoryFreed/MemoryFreed.expected
@@ -26,8 +26,8 @@
 | test.cpp:128:15:128:16 | v4 |
 | test.cpp:185:10:185:12 | cpy |
 | test.cpp:199:10:199:12 | cpy |
-| test.cpp:208:7:208:7 | a |
-| test.cpp:214:7:214:7 | a |
+| test.cpp:213:7:213:7 | a |
+| test.cpp:219:7:219:7 | a |
 | test_free.cpp:11:10:11:10 | a |
 | test_free.cpp:14:10:14:10 | a |
 | test_free.cpp:16:10:16:10 | a |

--- a/cpp/ql/test/query-tests/Critical/MemoryFreed/UseAfterFree.expected
+++ b/cpp/ql/test/query-tests/Critical/MemoryFreed/UseAfterFree.expected
@@ -1,6 +1,9 @@
 edges
 | test.cpp:213:7:213:7 | pointer to free output argument | test.cpp:214:2:214:2 | a | provenance |  |
 | test.cpp:219:7:219:7 | pointer to free output argument | test.cpp:220:2:220:2 | a | provenance |  |
+| test.cpp:228:12:228:12 | *p [post update] [data1] | test.cpp:229:2:229:2 | *p [data1] | provenance |  |
+| test.cpp:228:14:228:18 | pointer to operator delete[] output argument | test.cpp:228:12:228:12 | *p [post update] [data1] | provenance |  |
+| test.cpp:229:2:229:2 | *p [data1] | test.cpp:229:4:229:8 | data1 | provenance |  |
 | test_free.cpp:11:10:11:10 | pointer to free output argument | test_free.cpp:12:5:12:5 | a | provenance |  |
 | test_free.cpp:11:10:11:10 | pointer to free output argument | test_free.cpp:13:5:13:6 | * ... | provenance |  |
 | test_free.cpp:42:27:42:27 | pointer to free output argument | test_free.cpp:45:5:45:5 | a | provenance |  |
@@ -37,6 +40,10 @@ nodes
 | test.cpp:214:2:214:2 | a | semmle.label | a |
 | test.cpp:219:7:219:7 | pointer to free output argument | semmle.label | pointer to free output argument |
 | test.cpp:220:2:220:2 | a | semmle.label | a |
+| test.cpp:228:12:228:12 | *p [post update] [data1] | semmle.label | *p [post update] [data1] |
+| test.cpp:228:14:228:18 | pointer to operator delete[] output argument | semmle.label | pointer to operator delete[] output argument |
+| test.cpp:229:2:229:2 | *p [data1] | semmle.label | *p [data1] |
+| test.cpp:229:4:229:8 | data1 | semmle.label | data1 |
 | test_free.cpp:11:10:11:10 | pointer to free output argument | semmle.label | pointer to free output argument |
 | test_free.cpp:12:5:12:5 | a | semmle.label | a |
 | test_free.cpp:13:5:13:6 | * ... | semmle.label | * ... |
@@ -90,6 +97,7 @@ subpaths
 #select
 | test.cpp:214:2:214:2 | a | test.cpp:213:7:213:7 | pointer to free output argument | test.cpp:214:2:214:2 | a | Memory may have been previously freed by $@. | test.cpp:213:2:213:5 | call to free | call to free |
 | test.cpp:220:2:220:2 | a | test.cpp:219:7:219:7 | pointer to free output argument | test.cpp:220:2:220:2 | a | Memory may have been previously freed by $@. | test.cpp:219:2:219:5 | call to free | call to free |
+| test.cpp:229:4:229:8 | data1 | test.cpp:228:14:228:18 | pointer to operator delete[] output argument | test.cpp:229:4:229:8 | data1 | Memory may have been previously freed by $@. | test.cpp:228:2:228:18 | delete[] | delete[] |
 | test_free.cpp:12:5:12:5 | a | test_free.cpp:11:10:11:10 | pointer to free output argument | test_free.cpp:12:5:12:5 | a | Memory may have been previously freed by $@. | test_free.cpp:11:5:11:8 | call to free | call to free |
 | test_free.cpp:13:5:13:6 | * ... | test_free.cpp:11:10:11:10 | pointer to free output argument | test_free.cpp:13:5:13:6 | * ... | Memory may have been previously freed by $@. | test_free.cpp:11:5:11:8 | call to free | call to free |
 | test_free.cpp:45:5:45:5 | a | test_free.cpp:42:27:42:27 | pointer to free output argument | test_free.cpp:45:5:45:5 | a | Memory may have been previously freed by $@. | test_free.cpp:42:22:42:25 | call to free | call to free |

--- a/cpp/ql/test/query-tests/Critical/MemoryFreed/UseAfterFree.expected
+++ b/cpp/ql/test/query-tests/Critical/MemoryFreed/UseAfterFree.expected
@@ -1,6 +1,6 @@
 edges
-| test.cpp:208:7:208:7 | pointer to free output argument | test.cpp:209:2:209:2 | a | provenance |  |
-| test.cpp:214:7:214:7 | pointer to free output argument | test.cpp:215:2:215:2 | a | provenance |  |
+| test.cpp:213:7:213:7 | pointer to free output argument | test.cpp:214:2:214:2 | a | provenance |  |
+| test.cpp:219:7:219:7 | pointer to free output argument | test.cpp:220:2:220:2 | a | provenance |  |
 | test_free.cpp:11:10:11:10 | pointer to free output argument | test_free.cpp:12:5:12:5 | a | provenance |  |
 | test_free.cpp:11:10:11:10 | pointer to free output argument | test_free.cpp:13:5:13:6 | * ... | provenance |  |
 | test_free.cpp:42:27:42:27 | pointer to free output argument | test_free.cpp:45:5:45:5 | a | provenance |  |
@@ -33,10 +33,10 @@ edges
 | test_free.cpp:322:12:322:12 | pointer to operator delete output argument | test_free.cpp:324:5:324:6 | * ... | provenance |  |
 | test_free.cpp:331:12:331:12 | pointer to operator delete output argument | test_free.cpp:332:5:332:6 | * ... | provenance |  |
 nodes
-| test.cpp:208:7:208:7 | pointer to free output argument | semmle.label | pointer to free output argument |
-| test.cpp:209:2:209:2 | a | semmle.label | a |
-| test.cpp:214:7:214:7 | pointer to free output argument | semmle.label | pointer to free output argument |
-| test.cpp:215:2:215:2 | a | semmle.label | a |
+| test.cpp:213:7:213:7 | pointer to free output argument | semmle.label | pointer to free output argument |
+| test.cpp:214:2:214:2 | a | semmle.label | a |
+| test.cpp:219:7:219:7 | pointer to free output argument | semmle.label | pointer to free output argument |
+| test.cpp:220:2:220:2 | a | semmle.label | a |
 | test_free.cpp:11:10:11:10 | pointer to free output argument | semmle.label | pointer to free output argument |
 | test_free.cpp:12:5:12:5 | a | semmle.label | a |
 | test_free.cpp:13:5:13:6 | * ... | semmle.label | * ... |
@@ -88,8 +88,8 @@ nodes
 | test_free.cpp:332:5:332:6 | * ... | semmle.label | * ... |
 subpaths
 #select
-| test.cpp:209:2:209:2 | a | test.cpp:208:7:208:7 | pointer to free output argument | test.cpp:209:2:209:2 | a | Memory may have been previously freed by $@. | test.cpp:208:2:208:5 | call to free | call to free |
-| test.cpp:215:2:215:2 | a | test.cpp:214:7:214:7 | pointer to free output argument | test.cpp:215:2:215:2 | a | Memory may have been previously freed by $@. | test.cpp:214:2:214:5 | call to free | call to free |
+| test.cpp:214:2:214:2 | a | test.cpp:213:7:213:7 | pointer to free output argument | test.cpp:214:2:214:2 | a | Memory may have been previously freed by $@. | test.cpp:213:2:213:5 | call to free | call to free |
+| test.cpp:220:2:220:2 | a | test.cpp:219:7:219:7 | pointer to free output argument | test.cpp:220:2:220:2 | a | Memory may have been previously freed by $@. | test.cpp:219:2:219:5 | call to free | call to free |
 | test_free.cpp:12:5:12:5 | a | test_free.cpp:11:10:11:10 | pointer to free output argument | test_free.cpp:12:5:12:5 | a | Memory may have been previously freed by $@. | test_free.cpp:11:5:11:8 | call to free | call to free |
 | test_free.cpp:13:5:13:6 | * ... | test_free.cpp:11:10:11:10 | pointer to free output argument | test_free.cpp:13:5:13:6 | * ... | Memory may have been previously freed by $@. | test_free.cpp:11:5:11:8 | call to free | call to free |
 | test_free.cpp:45:5:45:5 | a | test_free.cpp:42:27:42:27 | pointer to free output argument | test_free.cpp:45:5:45:5 | a | Memory may have been previously freed by $@. | test_free.cpp:42:22:42:25 | call to free | call to free |

--- a/cpp/ql/test/query-tests/Critical/MemoryFreed/test.cpp
+++ b/cpp/ql/test/query-tests/Critical/MemoryFreed/test.cpp
@@ -201,6 +201,11 @@ void test_strndupa_dealloc() {
 
 // ---
 
+
+
+
+
+
 void test_reassignment() {
 	char *a = (char *)malloc(128);
 	char *b = (char *)malloc(128);

--- a/cpp/ql/test/query-tests/Critical/MemoryFreed/test.cpp
+++ b/cpp/ql/test/query-tests/Critical/MemoryFreed/test.cpp
@@ -201,10 +201,10 @@ void test_strndupa_dealloc() {
 
 // ---
 
-
-
-
-
+struct DataPair {
+	char *data1;
+	char *data2;
+};
 
 void test_reassignment() {
 	char *a = (char *)malloc(128);
@@ -218,4 +218,21 @@ void test_reassignment() {
 
 	free(a);
 	a[0] = 0; // BAD
+
+	DataPair p;
+	p.data1 = new char[128];
+	p.data2 = new char[128];
+	p.data1[0] = 0; // GOOD
+	p.data2[0] = 0; // GOOD
+
+	delete [] p.data1;
+	p.data1[0] = 0; // BAD
+	p.data2[0] = 0; // GOOD
+
+	p.data1 = new char[128];
+	p.data1[0] = 0; // GOOD
+	p.data2[0] = 0; // GOOD
+
+	delete [] p.data1;
+	delete [] p.data2;
 }


### PR DESCRIPTION
More tests for `cpp/use-after-free`.  This was a second failed attempt to reproduce an issue I've seen once in the wild.  I'm going to cut my losses here.