### PR TITLE
C++: Avoid expensive negation

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
@@ -933,11 +933,15 @@ module DefUse {
   bindingset[index, block]
   pragma[inline_late]
   private int getNonChiOffset(int index, OldBlock block) {
-    exists(IRFunction func | func = block.getEnclosingIRFunction() |
+    exists(OldIR::IRFunction func, Instruction i, OldBlock entryBlock |
+      func = block.getEnclosingIRFunction() and
+      i = block.getInstruction(index) and
+      entryBlock = func.getEntryBlock()
+    |
       if
-        getNewBlock(block) = func.getEntryBlock() and
-        not block.getInstruction(index) instanceof InitializeNonLocalInstruction and
-        not block.getInstruction(index) instanceof AliasedDefinitionInstruction
+        block = entryBlock and
+        not i instanceof InitializeNonLocalInstruction and
+        not i instanceof AliasedDefinitionInstruction
       then result = 2 * (index + count(VariableGroup vg | vg.getIRFunction() = func))
       else result = 2 * index
     )

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -933,11 +933,15 @@ module DefUse {
   bindingset[index, block]
   pragma[inline_late]
   private int getNonChiOffset(int index, OldBlock block) {
-    exists(IRFunction func | func = block.getEnclosingIRFunction() |
+    exists(OldIR::IRFunction func, Instruction i, OldBlock entryBlock |
+      func = block.getEnclosingIRFunction() and
+      i = block.getInstruction(index) and
+      entryBlock = func.getEntryBlock()
+    |
       if
-        getNewBlock(block) = func.getEntryBlock() and
-        not block.getInstruction(index) instanceof InitializeNonLocalInstruction and
-        not block.getInstruction(index) instanceof AliasedDefinitionInstruction
+        block = entryBlock and
+        not i instanceof InitializeNonLocalInstruction and
+        not i instanceof AliasedDefinitionInstruction
       then result = 2 * (index + count(VariableGroup vg | vg.getIRFunction() = func))
       else result = 2 * index
     )


### PR DESCRIPTION
A rule of thumb for writing high-performance QL is to avoid complex negations as these will be materialized to be the right-hand side of an antijoin. So when writing
```ql
if A then B else C
```
we should be careful about what we put into `A` since it will be desugared to
```ql
A and B
or
not A and C
```
So to avoid unnecessary materialization we pull out all the parts of A we expect to "always hold".
