### PR TITLE
Swift: Minor fixes

### DIFF
--- a/swift/ql/lib/change-notes/2024-07-24-url-model.md
+++ b/swift/ql/lib/change-notes/2024-07-24-url-model.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* An error in the model for `URL.withUnsafeFileSystemRepresentation(_:)` has been corrected. This may result in new data flow paths being found during analysis.

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPublic.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPublic.qll
@@ -105,6 +105,7 @@ class ParameterNode extends Node instanceof ParameterNodeImpl {
 }
 
 /**
+ * A node in the data flow graph which corresponds to an SSA variable definition.
  */
 class SsaDefinitionNode extends Node, TSsaDefinitionNode {
   Ssa::Definition def;

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Url.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Url.qll
@@ -119,7 +119,7 @@ private class UrlSummaries extends SummaryModelCsv {
         ";URL;true;resourceValues(forKeys:);;;Argument[-1];ReturnValue;taint",
         ";URL;true;setResourceValues(_:);;;Argument[0];Argument[-1];taint",
         ";URL;true;setTemporaryResourceValue(_:forKey:);;;Argument[-1..0];Argument[-1];taint",
-        ";URL;true;withUnsafeFileSystemRepresentation(_:);;;Argument[-1],Argument[0].Parameter[0];ReturnValue;taint",
+        ";URL;true;withUnsafeFileSystemRepresentation(_:);;;Argument[-1];Argument[0].Parameter[0].OptionalSome.CollectionElement;taint",
         ";URL;true;withUnsafeFileSystemRepresentation(_:);;;Argument[0].ReturnValue;ReturnValue;taint",
         ";URL;true;resolvingSymlinksInPath();;;Argument[-1];ReturnValue;taint",
         ";URL;true;appendPathComponent(_:);;;Argument[-1..0];Argument[-1];taint",

--- a/swift/ql/test/library-tests/dataflow/taint/libraries/url.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/libraries/url.swift
@@ -324,7 +324,7 @@ func taintThroughURL() {
 	})
 	urlTainted.withUnsafeFileSystemRepresentation({
 		ptr in
-		sink(any: ptr!) // $ MISSING: tainted=210
+		sink(any: ptr!) // $ tainted=210
 	})
 
 	sink(arg: urlTainted.resolvingSymlinksInPath()) // $ tainted=210


### PR DESCRIPTION
Two minor fixes for Swift:
- fixed errors in the model for `URL.withUnsafeFileSystemRepresentation(_:)`.
- filled out the (previously empty) QLDoc comment for `SsaDefinitionNode`.