### PR TITLE
C++: Add additional test cases for `explict` and `explicit(bool)` specifiers

### DIFF
--- a/cpp/ql/test/library-tests/specifiers2/cpp20.cpp
+++ b/cpp/ql/test/library-tests/specifiers2/cpp20.cpp
@@ -7,4 +7,27 @@ class TestConstexpr {
     constexpr int member_const_constexpr() const { return 0; }
 };
 
+struct TestExplict {
+    explicit TestExplict();
+};
+
+template<typename T>
+struct TestExplicitBool {
+    explicit(sizeof(T) == 1)
+    TestExplicitBool(const T);
+};
+
+explicit TestExplicitBool(const double)  -> TestExplicitBool<int>;
+
+template<typename T>
+explicit(sizeof(T) == 4)
+TestExplicitBool(const T)  -> TestExplicitBool<int>;
+
+void TestExplicitBoolFun() {
+    new TestExplicitBool<char>(0);
+    new TestExplicitBool<int>(0);
+    new TestExplicitBool(0.0f);
+    new TestExplicitBool(0.0);
+}
+
 } // namespace cpp20

--- a/cpp/ql/test/library-tests/specifiers2/inst_func_specifiers.expected
+++ b/cpp/ql/test/library-tests/specifiers2/inst_func_specifiers.expected
@@ -1,0 +1,2 @@
+| cpp20.cpp:15:8:15:23 | TestExplicitBool<char> | file://:0:0:0:0 | char | cpp20.cpp:17:5:17:20 | TestExplicitBool | explicit, extern, public |
+| cpp20.cpp:15:8:15:23 | TestExplicitBool<int> | file://:0:0:0:0 | int | cpp20.cpp:17:5:17:20 | TestExplicitBool | extern, public |

--- a/cpp/ql/test/library-tests/specifiers2/inst_func_specifiers.ql
+++ b/cpp/ql/test/library-tests/specifiers2/inst_func_specifiers.ql
@@ -1,0 +1,7 @@
+import cpp
+
+from MemberFunction m, ClassTemplateInstantiation c, string specifiers
+where
+  c.getAMember() = m and
+  specifiers = concat(string s | s = m.getASpecifier().getName() | s, ", ")
+select c, c.getATemplateArgument(), m, specifiers

--- a/cpp/ql/test/library-tests/specifiers2/specifiers2.expected
+++ b/cpp/ql/test/library-tests/specifiers2/specifiers2.expected
@@ -1,146 +1,62 @@
 | Class | specifiers2pp.cpp:8:7:8:13 | MyClass | MyClass | abstract |
 | Class | specifiers2pp.cpp:24:7:24:14 | MyClass2 | MyClass2 | abstract |
-| Function | cpp20.cpp:5:7:5:7 | operator= | operator= | extern |
-| Function | cpp20.cpp:5:7:5:7 | operator= | operator= | extern |
-| Function | cpp20.cpp:5:7:5:7 | operator= | operator= | inline |
-| Function | cpp20.cpp:5:7:5:7 | operator= | operator= | inline |
-| Function | cpp20.cpp:5:7:5:7 | operator= | operator= | is_constexpr |
-| Function | cpp20.cpp:5:7:5:7 | operator= | operator= | is_constexpr |
-| Function | cpp20.cpp:5:7:5:7 | operator= | operator= | public |
-| Function | cpp20.cpp:5:7:5:7 | operator= | operator= | public |
-| Function | cpp20.cpp:6:19:6:34 | member_constexpr | member_constexpr | declared_constexpr |
-| Function | cpp20.cpp:6:19:6:34 | member_constexpr | member_constexpr | inline |
-| Function | cpp20.cpp:6:19:6:34 | member_constexpr | member_constexpr | is_constexpr |
-| Function | cpp20.cpp:6:19:6:34 | member_constexpr | member_constexpr | private |
-| Function | cpp20.cpp:7:19:7:40 | member_const_constexpr | member_const_constexpr | const |
-| Function | cpp20.cpp:7:19:7:40 | member_const_constexpr | member_const_constexpr | declared_constexpr |
-| Function | cpp20.cpp:7:19:7:40 | member_const_constexpr | member_const_constexpr | inline |
-| Function | cpp20.cpp:7:19:7:40 | member_const_constexpr | member_const_constexpr | is_constexpr |
-| Function | cpp20.cpp:7:19:7:40 | member_const_constexpr | member_const_constexpr | private |
-| Function | specifiers2.c:11:6:11:6 | f | f | c_linkage |
-| Function | specifiers2.c:11:6:11:6 | f | f | extern |
-| Function | specifiers2.c:12:13:12:13 | f | f | c_linkage |
-| Function | specifiers2.c:12:13:12:13 | f | f | extern |
-| Function | specifiers2.c:13:13:13:13 | f | f | c_linkage |
-| Function | specifiers2.c:13:13:13:13 | f | f | extern |
-| Function | specifiers2.c:15:13:15:13 | g | g | c_linkage |
-| Function | specifiers2.c:15:13:15:13 | g | g | extern |
-| Function | specifiers2.c:16:13:16:13 | g | g | c_linkage |
-| Function | specifiers2.c:16:13:16:13 | g | g | extern |
-| Function | specifiers2.c:21:6:21:12 | somefun | somefun | c_linkage |
-| Function | specifiers2.c:21:6:21:12 | somefun | somefun | extern |
-| Function | specifiers2.c:25:12:25:14 | add | add | c_linkage |
-| Function | specifiers2.c:25:12:25:14 | add | add | inline |
-| Function | specifiers2pp.cpp:8:7:8:7 | MyClass | MyClass | extern |
-| Function | specifiers2pp.cpp:8:7:8:7 | MyClass | MyClass | extern |
-| Function | specifiers2pp.cpp:8:7:8:7 | MyClass | MyClass | inline |
-| Function | specifiers2pp.cpp:8:7:8:7 | MyClass | MyClass | inline |
-| Function | specifiers2pp.cpp:8:7:8:7 | MyClass | MyClass | is_constexpr |
-| Function | specifiers2pp.cpp:8:7:8:7 | MyClass | MyClass | is_constexpr |
-| Function | specifiers2pp.cpp:8:7:8:7 | MyClass | MyClass | public |
-| Function | specifiers2pp.cpp:8:7:8:7 | MyClass | MyClass | public |
-| Function | specifiers2pp.cpp:8:7:8:7 | operator= | operator= | extern |
-| Function | specifiers2pp.cpp:8:7:8:7 | operator= | operator= | extern |
-| Function | specifiers2pp.cpp:8:7:8:7 | operator= | operator= | inline |
-| Function | specifiers2pp.cpp:8:7:8:7 | operator= | operator= | inline |
-| Function | specifiers2pp.cpp:8:7:8:7 | operator= | operator= | public |
-| Function | specifiers2pp.cpp:8:7:8:7 | operator= | operator= | public |
-| Function | specifiers2pp.cpp:10:18:10:24 | MyClass | MyClass | explicit |
-| Function | specifiers2pp.cpp:10:18:10:24 | MyClass | MyClass | extern |
-| Function | specifiers2pp.cpp:10:18:10:24 | MyClass | MyClass | public |
-| Function | specifiers2pp.cpp:12:14:12:22 | publicFun | publicFun | inline |
-| Function | specifiers2pp.cpp:12:14:12:22 | publicFun | publicFun | public |
-| Function | specifiers2pp.cpp:13:21:13:26 | getInt | getInt | declared_virtual |
-| Function | specifiers2pp.cpp:13:21:13:26 | getInt | getInt | extern |
-| Function | specifiers2pp.cpp:13:21:13:26 | getInt | getInt | public |
-| Function | specifiers2pp.cpp:13:21:13:26 | getInt | getInt | pure |
-| Function | specifiers2pp.cpp:13:21:13:26 | getInt | getInt | virtual |
-| Function | specifiers2pp.cpp:14:21:14:21 | f | f | declared_virtual |
-| Function | specifiers2pp.cpp:14:21:14:21 | f | f | extern |
-| Function | specifiers2pp.cpp:14:21:14:21 | f | f | public |
-| Function | specifiers2pp.cpp:14:21:14:21 | f | f | virtual |
-| Function | specifiers2pp.cpp:18:14:18:23 | privateFun | privateFun | inline |
-| Function | specifiers2pp.cpp:18:14:18:23 | privateFun | privateFun | private |
-| Function | specifiers2pp.cpp:21:14:21:25 | protectedFun | protectedFun | inline |
-| Function | specifiers2pp.cpp:21:14:21:25 | protectedFun | protectedFun | protected |
-| Function | specifiers2pp.cpp:24:7:24:7 | MyClass2 | MyClass2 | extern |
-| Function | specifiers2pp.cpp:24:7:24:7 | MyClass2 | MyClass2 | extern |
-| Function | specifiers2pp.cpp:24:7:24:7 | MyClass2 | MyClass2 | extern |
-| Function | specifiers2pp.cpp:24:7:24:7 | MyClass2 | MyClass2 | inline |
-| Function | specifiers2pp.cpp:24:7:24:7 | MyClass2 | MyClass2 | inline |
-| Function | specifiers2pp.cpp:24:7:24:7 | MyClass2 | MyClass2 | inline |
-| Function | specifiers2pp.cpp:24:7:24:7 | MyClass2 | MyClass2 | is_constexpr |
-| Function | specifiers2pp.cpp:24:7:24:7 | MyClass2 | MyClass2 | is_constexpr |
-| Function | specifiers2pp.cpp:24:7:24:7 | MyClass2 | MyClass2 | public |
-| Function | specifiers2pp.cpp:24:7:24:7 | MyClass2 | MyClass2 | public |
-| Function | specifiers2pp.cpp:24:7:24:7 | MyClass2 | MyClass2 | public |
-| Function | specifiers2pp.cpp:24:7:24:7 | operator= | operator= | extern |
-| Function | specifiers2pp.cpp:24:7:24:7 | operator= | operator= | extern |
-| Function | specifiers2pp.cpp:24:7:24:7 | operator= | operator= | inline |
-| Function | specifiers2pp.cpp:24:7:24:7 | operator= | operator= | inline |
-| Function | specifiers2pp.cpp:24:7:24:7 | operator= | operator= | public |
-| Function | specifiers2pp.cpp:24:7:24:7 | operator= | operator= | public |
-| Function | specifiers2pp.cpp:26:21:26:21 | f | f | declared_virtual |
-| Function | specifiers2pp.cpp:26:21:26:21 | f | f | extern |
-| Function | specifiers2pp.cpp:26:21:26:21 | f | f | override |
-| Function | specifiers2pp.cpp:26:21:26:21 | f | f | public |
-| Function | specifiers2pp.cpp:26:21:26:21 | f | f | virtual |
-| Function | specifiers2pp.cpp:29:7:29:7 | operator= | operator= | extern |
-| Function | specifiers2pp.cpp:29:7:29:7 | operator= | operator= | extern |
-| Function | specifiers2pp.cpp:29:7:29:7 | operator= | operator= | inline |
-| Function | specifiers2pp.cpp:29:7:29:7 | operator= | operator= | inline |
-| Function | specifiers2pp.cpp:29:7:29:7 | operator= | operator= | is_constexpr |
-| Function | specifiers2pp.cpp:29:7:29:7 | operator= | operator= | is_constexpr |
-| Function | specifiers2pp.cpp:29:7:29:7 | operator= | operator= | public |
-| Function | specifiers2pp.cpp:29:7:29:7 | operator= | operator= | public |
+| Function | cpp20.cpp:5:7:5:7 | operator= | operator= | extern, inline, is_constexpr, public |
+| Function | cpp20.cpp:5:7:5:7 | operator= | operator= | extern, inline, is_constexpr, public |
+| Function | cpp20.cpp:6:19:6:34 | member_constexpr | member_constexpr | declared_constexpr, inline, is_constexpr, private |
+| Function | cpp20.cpp:7:19:7:40 | member_const_constexpr | member_const_constexpr | const, declared_constexpr, inline, is_constexpr, private |
+| Function | cpp20.cpp:10:8:10:8 | TestExplict | TestExplict | extern, inline, is_constexpr, public |
+| Function | cpp20.cpp:10:8:10:8 | TestExplict | TestExplict | extern, inline, is_constexpr, public |
+| Function | cpp20.cpp:10:8:10:8 | operator= | operator= | extern, inline, is_constexpr, public |
+| Function | cpp20.cpp:10:8:10:8 | operator= | operator= | extern, inline, is_constexpr, public |
+| Function | cpp20.cpp:11:14:11:24 | TestExplict | TestExplict | explicit, extern, public |
+| Function | cpp20.cpp:17:5:17:20 | TestExplicitBool | TestExplicitBool | explicit, extern, public |
+| Function | cpp20.cpp:17:5:17:20 | TestExplicitBool | TestExplicitBool | extern, public |
+| Function | cpp20.cpp:17:5:17:20 | TestExplicitBool | TestExplicitBool | extern, public |
+| Function | cpp20.cpp:24:1:24:16 | TestExplicitBool | TestExplicitBool | has_trailing_return_type |
+| Function | file://:0:0:0:0 | operator delete | operator delete | extern |
+| Function | file://:0:0:0:0 | operator new | operator new | extern |
+| Function | specifiers2.c:11:6:11:6 | f | f | c_linkage, extern |
+| Function | specifiers2.c:12:13:12:13 | f | f | c_linkage, extern |
+| Function | specifiers2.c:13:13:13:13 | f | f | c_linkage, extern |
+| Function | specifiers2.c:15:13:15:13 | g | g | c_linkage, extern |
+| Function | specifiers2.c:16:13:16:13 | g | g | c_linkage, extern |
+| Function | specifiers2.c:21:6:21:12 | somefun | somefun | c_linkage, extern |
+| Function | specifiers2.c:25:12:25:14 | add | add | c_linkage, inline |
+| Function | specifiers2pp.cpp:8:7:8:7 | MyClass | MyClass | extern, inline, is_constexpr, public |
+| Function | specifiers2pp.cpp:8:7:8:7 | MyClass | MyClass | extern, inline, is_constexpr, public |
+| Function | specifiers2pp.cpp:8:7:8:7 | operator= | operator= | extern, inline, public |
+| Function | specifiers2pp.cpp:8:7:8:7 | operator= | operator= | extern, inline, public |
+| Function | specifiers2pp.cpp:10:18:10:24 | MyClass | MyClass | explicit, extern, public |
+| Function | specifiers2pp.cpp:12:14:12:22 | publicFun | publicFun | inline, public |
+| Function | specifiers2pp.cpp:13:21:13:26 | getInt | getInt | declared_virtual, extern, public, pure, virtual |
+| Function | specifiers2pp.cpp:14:21:14:21 | f | f | declared_virtual, extern, public, virtual |
+| Function | specifiers2pp.cpp:18:14:18:23 | privateFun | privateFun | inline, private |
+| Function | specifiers2pp.cpp:21:14:21:25 | protectedFun | protectedFun | inline, protected |
+| Function | specifiers2pp.cpp:24:7:24:7 | MyClass2 | MyClass2 | extern, inline, is_constexpr, public |
+| Function | specifiers2pp.cpp:24:7:24:7 | MyClass2 | MyClass2 | extern, inline, is_constexpr, public |
+| Function | specifiers2pp.cpp:24:7:24:7 | MyClass2 | MyClass2 | extern, inline, public |
+| Function | specifiers2pp.cpp:24:7:24:7 | operator= | operator= | extern, inline, public |
+| Function | specifiers2pp.cpp:24:7:24:7 | operator= | operator= | extern, inline, public |
+| Function | specifiers2pp.cpp:26:21:26:21 | f | f | declared_virtual, extern, override, public, virtual |
+| Function | specifiers2pp.cpp:29:7:29:7 | operator= | operator= | extern, inline, is_constexpr, public |
+| Function | specifiers2pp.cpp:29:7:29:7 | operator= | operator= | extern, inline, is_constexpr, public |
 | Function | specifiers2pp.cpp:33:5:33:18 | fun | fun | public |
-| Function | specifiers2pp.cpp:35:7:35:7 | operator= | operator= | extern |
-| Function | specifiers2pp.cpp:35:7:35:7 | operator= | operator= | extern |
-| Function | specifiers2pp.cpp:35:7:35:7 | operator= | operator= | inline |
-| Function | specifiers2pp.cpp:35:7:35:7 | operator= | operator= | inline |
-| Function | specifiers2pp.cpp:35:7:35:7 | operator= | operator= | is_constexpr |
-| Function | specifiers2pp.cpp:35:7:35:7 | operator= | operator= | is_constexpr |
-| Function | specifiers2pp.cpp:35:7:35:7 | operator= | operator= | public |
-| Function | specifiers2pp.cpp:35:7:35:7 | operator= | operator= | public |
+| Function | specifiers2pp.cpp:35:7:35:7 | operator= | operator= | extern, inline, is_constexpr, public |
+| Function | specifiers2pp.cpp:35:7:35:7 | operator= | operator= | extern, inline, is_constexpr, public |
 | Function | specifiers2pp.cpp:40:12:40:18 | someFun | someFun | extern |
-| Function | specifiers2pp.cpp:41:16:41:23 | someFun2 | someFun2 | c_linkage |
-| Function | specifiers2pp.cpp:41:16:41:23 | someFun2 | someFun2 | extern |
-| Function | specifiers2pp.cpp:43:9:43:16 | someFun3 | someFun3 | c_linkage |
-| Function | specifiers2pp.cpp:43:9:43:16 | someFun3 | someFun3 | extern |
-| Function | specifiers2pp.cpp:44:16:44:23 | someFun4 | someFun4 | c_linkage |
-| Function | specifiers2pp.cpp:44:16:44:23 | someFun4 | someFun4 | static |
-| Function | specifiers2pp.cpp:62:7:62:7 | operator= | operator= | extern |
-| Function | specifiers2pp.cpp:62:7:62:7 | operator= | operator= | extern |
-| Function | specifiers2pp.cpp:62:7:62:7 | operator= | operator= | inline |
-| Function | specifiers2pp.cpp:62:7:62:7 | operator= | operator= | inline |
-| Function | specifiers2pp.cpp:62:7:62:7 | operator= | operator= | is_constexpr |
-| Function | specifiers2pp.cpp:62:7:62:7 | operator= | operator= | is_constexpr |
-| Function | specifiers2pp.cpp:62:7:62:7 | operator= | operator= | public |
-| Function | specifiers2pp.cpp:62:7:62:7 | operator= | operator= | public |
-| Function | specifiers2pp.cpp:63:19:63:34 | member_constexpr | member_constexpr | const |
-| Function | specifiers2pp.cpp:63:19:63:34 | member_constexpr | member_constexpr | declared_constexpr |
-| Function | specifiers2pp.cpp:63:19:63:34 | member_constexpr | member_constexpr | inline |
-| Function | specifiers2pp.cpp:63:19:63:34 | member_constexpr | member_constexpr | is_constexpr |
-| Function | specifiers2pp.cpp:63:19:63:34 | member_constexpr | member_constexpr | private |
-| Function | specifiers2pp.cpp:64:19:64:40 | member_const_constexpr | member_const_constexpr | const |
-| Function | specifiers2pp.cpp:64:19:64:40 | member_const_constexpr | member_const_constexpr | declared_constexpr |
-| Function | specifiers2pp.cpp:64:19:64:40 | member_const_constexpr | member_const_constexpr | inline |
-| Function | specifiers2pp.cpp:64:19:64:40 | member_const_constexpr | member_const_constexpr | is_constexpr |
-| Function | specifiers2pp.cpp:64:19:64:40 | member_const_constexpr | member_const_constexpr | private |
-| FunctionDeclarationEntry | specifiers2.c:11:6:11:6 | declaration of f | f | c_linkage |
-| FunctionDeclarationEntry | specifiers2.c:11:6:11:6 | declaration of f | f | void_param_list |
-| FunctionDeclarationEntry | specifiers2.c:12:13:12:13 | declaration of f | f | c_linkage |
-| FunctionDeclarationEntry | specifiers2.c:12:13:12:13 | declaration of f | f | extern |
-| FunctionDeclarationEntry | specifiers2.c:12:13:12:13 | declaration of f | f | void_param_list |
-| FunctionDeclarationEntry | specifiers2.c:13:13:13:13 | declaration of f | f | c_linkage |
-| FunctionDeclarationEntry | specifiers2.c:13:13:13:13 | declaration of f | f | extern |
-| FunctionDeclarationEntry | specifiers2.c:13:13:13:13 | declaration of f | f | void_param_list |
-| FunctionDeclarationEntry | specifiers2.c:15:13:15:13 | declaration of g | g | c_linkage |
-| FunctionDeclarationEntry | specifiers2.c:15:13:15:13 | declaration of g | g | extern |
-| FunctionDeclarationEntry | specifiers2.c:15:13:15:13 | declaration of g | g | void_param_list |
-| FunctionDeclarationEntry | specifiers2.c:16:13:16:13 | declaration of g | g | c_linkage |
-| FunctionDeclarationEntry | specifiers2.c:16:13:16:13 | declaration of g | g | extern |
-| FunctionDeclarationEntry | specifiers2.c:16:13:16:13 | declaration of g | g | void_param_list |
+| Function | specifiers2pp.cpp:41:16:41:23 | someFun2 | someFun2 | c_linkage, extern |
+| Function | specifiers2pp.cpp:43:9:43:16 | someFun3 | someFun3 | c_linkage, extern |
+| Function | specifiers2pp.cpp:44:16:44:23 | someFun4 | someFun4 | c_linkage, static |
+| Function | specifiers2pp.cpp:62:7:62:7 | operator= | operator= | extern, inline, is_constexpr, public |
+| Function | specifiers2pp.cpp:62:7:62:7 | operator= | operator= | extern, inline, is_constexpr, public |
+| Function | specifiers2pp.cpp:63:19:63:34 | member_constexpr | member_constexpr | const, declared_constexpr, inline, is_constexpr, private |
+| Function | specifiers2pp.cpp:64:19:64:40 | member_const_constexpr | member_const_constexpr | const, declared_constexpr, inline, is_constexpr, private |
+| FunctionDeclarationEntry | cpp20.cpp:11:14:11:24 | declaration of TestExplict | TestExplict | explicit |
+| FunctionDeclarationEntry | specifiers2.c:11:6:11:6 | declaration of f | f | c_linkage, void_param_list |
+| FunctionDeclarationEntry | specifiers2.c:12:13:12:13 | declaration of f | f | c_linkage, extern, void_param_list |
+| FunctionDeclarationEntry | specifiers2.c:13:13:13:13 | declaration of f | f | c_linkage, extern, void_param_list |
+| FunctionDeclarationEntry | specifiers2.c:15:13:15:13 | declaration of g | g | c_linkage, extern, void_param_list |
+| FunctionDeclarationEntry | specifiers2.c:16:13:16:13 | declaration of g | g | c_linkage, extern, void_param_list |
 | FunctionDeclarationEntry | specifiers2.c:21:6:21:12 | declaration of somefun | somefun | c_linkage |
 | FunctionDeclarationEntry | specifiers2.c:25:12:25:14 | definition of add | add | c_linkage |
 | FunctionDeclarationEntry | specifiers2pp.cpp:2:6:2:9 | definition of afun | afun | void_param_list |
@@ -154,28 +70,19 @@
 | FunctionDeclarationEntry | specifiers2pp.cpp:31:13:31:15 | declaration of fun | fun | void_param_list |
 | FunctionDeclarationEntry | specifiers2pp.cpp:33:5:33:18 | definition of fun | fun | void_param_list |
 | FunctionDeclarationEntry | specifiers2pp.cpp:40:12:40:18 | declaration of someFun | someFun | extern |
-| FunctionDeclarationEntry | specifiers2pp.cpp:41:16:41:23 | declaration of someFun2 | someFun2 | c_linkage |
-| FunctionDeclarationEntry | specifiers2pp.cpp:41:16:41:23 | declaration of someFun2 | someFun2 | extern |
-| FunctionDeclarationEntry | specifiers2pp.cpp:43:9:43:16 | declaration of someFun3 | someFun3 | c_linkage |
-| FunctionDeclarationEntry | specifiers2pp.cpp:43:9:43:16 | declaration of someFun3 | someFun3 | extern |
-| FunctionDeclarationEntry | specifiers2pp.cpp:44:16:44:23 | declaration of someFun4 | someFun4 | c_linkage |
-| FunctionDeclarationEntry | specifiers2pp.cpp:44:16:44:23 | declaration of someFun4 | someFun4 | static |
+| FunctionDeclarationEntry | specifiers2pp.cpp:41:16:41:23 | declaration of someFun2 | someFun2 | c_linkage, extern |
+| FunctionDeclarationEntry | specifiers2pp.cpp:43:9:43:16 | declaration of someFun3 | someFun3 | c_linkage, extern |
+| FunctionDeclarationEntry | specifiers2pp.cpp:44:16:44:23 | declaration of someFun4 | someFun4 | c_linkage, static |
 | TypedefType | file://:0:0:0:0 | Const | Const | const |
 | TypedefType | specifiers2.c:27:19:27:26 | constInt | constInt | const |
 | TypedefType | specifiers2pp.cpp:47:20:47:32 | const_pointer | const_pointer | const |
-| TypedefType | specifiers2pp.cpp:49:32:49:53 | volatile_const_pointer | volatile_const_pointer | const |
-| TypedefType | specifiers2pp.cpp:49:32:49:53 | volatile_const_pointer | volatile_const_pointer | volatile |
-| TypedefType | specifiers2pp.cpp:50:32:50:54 | volatile_const_pointer2 | volatile_const_pointer2 | const |
-| TypedefType | specifiers2pp.cpp:50:32:50:54 | volatile_const_pointer2 | volatile_const_pointer2 | volatile |
-| TypedefType | specifiers2pp.cpp:53:23:53:45 | volatile_const_pointer3 | volatile_const_pointer3 | const |
-| TypedefType | specifiers2pp.cpp:53:23:53:45 | volatile_const_pointer3 | volatile_const_pointer3 | volatile |
-| TypedefType | specifiers2pp.cpp:54:44:54:74 | volatile_const_restrict_pointer | volatile_const_restrict_pointer | const |
-| TypedefType | specifiers2pp.cpp:54:44:54:74 | volatile_const_restrict_pointer | volatile_const_restrict_pointer | restrict |
-| TypedefType | specifiers2pp.cpp:54:44:54:74 | volatile_const_restrict_pointer | volatile_const_restrict_pointer | volatile |
+| TypedefType | specifiers2pp.cpp:49:32:49:53 | volatile_const_pointer | volatile_const_pointer | const, volatile |
+| TypedefType | specifiers2pp.cpp:50:32:50:54 | volatile_const_pointer2 | volatile_const_pointer2 | const, volatile |
+| TypedefType | specifiers2pp.cpp:53:23:53:45 | volatile_const_pointer3 | volatile_const_pointer3 | const, volatile |
+| TypedefType | specifiers2pp.cpp:54:44:54:74 | volatile_const_restrict_pointer | volatile_const_restrict_pointer | const, restrict, volatile |
 | TypedefType | specifiers2pp.cpp:56:28:56:32 | Const | Const | const |
 | TypedefType | specifiers2pp.cpp:58:7:58:15 | Const_int | Const_int | const |
-| TypedefType | specifiers2pp.cpp:60:28:60:45 | volatile_Const_int | volatile_Const_int | const |
-| TypedefType | specifiers2pp.cpp:60:28:60:45 | volatile_Const_int | volatile_Const_int | volatile |
+| TypedefType | specifiers2pp.cpp:60:28:60:45 | volatile_Const_int | volatile_Const_int | const, volatile |
 | Variable | specifiers2.c:8:12:8:12 | j | j | extern |
 | Variable | specifiers2.c:9:12:9:12 | j | j | extern |
 | Variable | specifiers2.c:18:21:18:23 | svi | svi | static |

--- a/cpp/ql/test/library-tests/specifiers2/specifiers2.ql
+++ b/cpp/ql/test/library-tests/specifiers2/specifiers2.ql
@@ -14,16 +14,20 @@ string interesting(Element e) {
   e instanceof VariableDeclarationEntry and result = "VariableDeclarationEntry"
 }
 
-from Element e, string name, string specifier
+from Element e, string name, string specifiers
 where
   (
     name = e.(Declaration).getName() or
     name = e.(DeclarationEntry).getName() or
     name = e.(Type).toString()
   ) and
-  (
-    specifier = e.(Declaration).getASpecifier().toString() or
-    specifier = e.(DeclarationEntry).getASpecifier() or
-    specifier = e.(TypedefType).getBaseType().getASpecifier().toString()
-  )
-select interesting(e), e, name, specifier
+  specifiers =
+    concat(string s |
+      s = e.(Declaration).getASpecifier().toString() or
+      s = e.(DeclarationEntry).getASpecifier() or
+      s = e.(TypedefType).getBaseType().getASpecifier().toString()
+    |
+      s, ", "
+    ) and
+  specifiers != ""
+select interesting(e), e, name, specifiers

--- a/cpp/ql/test/library-tests/specifiers2/specifiers2d.expected
+++ b/cpp/ql/test/library-tests/specifiers2/specifiers2d.expected
@@ -1,3 +1,8 @@
+| cpp20.cpp:17:28:17:28 | (unnamed parameter 0) | file://:0:0:0:0 | const T | file://:0:0:0:0 | const |
+| cpp20.cpp:17:28:17:28 | (unnamed parameter 0) | file://:0:0:0:0 | const char | file://:0:0:0:0 | const |
+| cpp20.cpp:17:28:17:28 | (unnamed parameter 0) | file://:0:0:0:0 | const int | file://:0:0:0:0 | const |
+| cpp20.cpp:24:24:24:24 | (unnamed parameter 0) | file://:0:0:0:0 | const T | file://:0:0:0:0 | const |
+| file://:0:0:0:0 | (unnamed parameter 0) | file://:0:0:0:0 | const double | file://:0:0:0:0 | const |
 | specifiers2.c:18:21:18:23 | svi | file://:0:0:0:0 | volatile int | file://:0:0:0:0 | volatile |
 | specifiers2.c:19:11:19:12 | ci | file://:0:0:0:0 | const int | file://:0:0:0:0 | const |
 | specifiers2.c:21:34:21:34 | p | file://:0:0:0:0 | char *__restrict__ | file://:0:0:0:0 | restrict |

--- a/cpp/ql/test/library-tests/specifiers2/templ_func_specifiers.expected
+++ b/cpp/ql/test/library-tests/specifiers2/templ_func_specifiers.expected
@@ -1,0 +1,1 @@
+| cpp20.cpp:17:5:17:20 | TestExplicitBool | extern, public |

--- a/cpp/ql/test/library-tests/specifiers2/templ_func_specifiers.ql
+++ b/cpp/ql/test/library-tests/specifiers2/templ_func_specifiers.ql
@@ -1,0 +1,7 @@
+import cpp
+
+from MemberFunction m, TemplateClass c, string specifiers
+where
+  c.getAMember() = m and
+  specifiers = concat(string s | s = m.getASpecifier().getName() | s, ", ")
+select m, specifiers


### PR DESCRIPTION
Note that the `explict(bool)` specifiers currently do not end up in the database.