### PR TITLE
Java: fix comments about use of sink kind `regex-use`

### DIFF
--- a/java/ql/lib/ext/org.apache.commons.lang3.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.lang3.model.yml
@@ -3,7 +3,9 @@ extensions:
       pack: codeql/java-all
       extensible: sinkModel
     data:
-      # Note these sinks do not use the sink kind `regex-use[0]` because they should be considered as sinks for regex injection but not polynomial ReDoS.
+      # Note these sinks do not use the sink kind `regex-use[0]` because the regex injection query needs to select them separately from
+      # other `regex-use[0]` sinks in order to avoid FPs. As a result, these sinks are currently not used in the polynomial ReDoS query.
+      # TODO: refactor the `regex-use%` sink kind so that the polynomial ReDoS query can also use these sinks.
       - ["org.apache.commons.lang3", "RegExUtils", False, "removeAll", "(String,String)", "", "Argument[1]", "regex-use", "manual"]
       - ["org.apache.commons.lang3", "RegExUtils", False, "removeFirst", "(String,String)", "", "Argument[1]", "regex-use", "manual"]
       - ["org.apache.commons.lang3", "RegExUtils", False, "removePattern", "(String,String)", "", "Argument[1]", "regex-use", "manual"]

--- a/java/ql/lib/semmle/code/java/regex/RegexFlowConfigs.qll
+++ b/java/ql/lib/semmle/code/java/regex/RegexFlowConfigs.qll
@@ -20,8 +20,10 @@ private class ExploitableStringLiteral extends StringLiteral {
  * if no such argument exists.
  *
  * Note that `regex-use` is deliberately not a possible value for `kind` here,
- * as it is used for regular expression injection sinks that should not be used
- * as polynomial ReDoS sinks.
+ * as it is used for regular expression injection sinks that need to be selected
+ * separately from existing `regex-use[0]` sinks.
+ * TODO: refactor the `regex-use%` sink kind so that the polynomial ReDoS query
+ * can also use the `regex-use` sinks.
  */
 private predicate regexSinkKindInfo(string kind, boolean full, int strArg) {
   sinkModel(_, _, _, _, _, _, _, kind, _, _) and


### PR DESCRIPTION
Fixes comments about the `regex-use` sink kind.
See https://github.com/github/codeql/pull/17053#issuecomment-2248874305. 