### PR TITLE
C++: Add missing write side effect to `std::remquo`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/StdMath.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/StdMath.qll
@@ -51,6 +51,12 @@ private class Remquo extends Function, SideEffectFunction {
   override predicate hasOnlySpecificReadSideEffects() { any() }
 
   override predicate hasOnlySpecificWriteSideEffects() { any() }
+
+  override predicate hasSpecificWriteSideEffect(ParameterIndex i, boolean buffer, boolean mustWrite) {
+    this.getParameter(i).getUnspecifiedType() instanceof PointerType and
+    buffer = false and
+    mustWrite = true
+  }
 }
 
 private class Fma extends Function, SideEffectFunction {

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/StdMath.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/StdMath.qll
@@ -101,4 +101,8 @@ private class Nan extends Function, SideEffectFunction, AliasFunction {
   override predicate parameterNeverEscapes(int index) { index = 0 }
 
   override predicate parameterEscapesOnlyViaReturn(int index) { none() }
+
+  override predicate hasSpecificReadSideEffect(ParameterIndex i, boolean buffer) {
+    i = 0 and buffer = true
+  }
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-457/semmle/tests/UninitializedLocal.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-457/semmle/tests/UninitializedLocal.expected
@@ -13,6 +13,7 @@ nodes
 | test.cpp:458:6:458:6 | definition of x | semmle.label | definition of x |
 | test.cpp:464:6:464:6 | definition of x | semmle.label | definition of x |
 | test.cpp:471:6:471:6 | definition of x | semmle.label | definition of x |
+| test.cpp:592:6:592:8 | definition of quo | semmle.label | definition of quo |
 #select
 | test.cpp:12:6:12:8 | foo | test.cpp:11:6:11:8 | definition of foo | test.cpp:11:6:11:8 | definition of foo | The variable $@ may not be initialized at this access. | test.cpp:11:6:11:8 | foo | foo |
 | test.cpp:113:6:113:8 | foo | test.cpp:111:6:111:8 | definition of foo | test.cpp:111:6:111:8 | definition of foo | The variable $@ may not be initialized at this access. | test.cpp:111:6:111:8 | foo | foo |
@@ -27,3 +28,4 @@ nodes
 | test.cpp:460:7:460:7 | x | test.cpp:458:6:458:6 | definition of x | test.cpp:458:6:458:6 | definition of x | The variable $@ may not be initialized at this access. | test.cpp:458:6:458:6 | x | x |
 | test.cpp:467:2:467:2 | x | test.cpp:464:6:464:6 | definition of x | test.cpp:464:6:464:6 | definition of x | The variable $@ may not be initialized at this access. | test.cpp:464:6:464:6 | x | x |
 | test.cpp:474:7:474:7 | x | test.cpp:471:6:471:6 | definition of x | test.cpp:471:6:471:6 | definition of x | The variable $@ may not be initialized at this access. | test.cpp:471:6:471:6 | x | x |
+| test.cpp:594:6:594:8 | quo | test.cpp:592:6:592:8 | definition of quo | test.cpp:592:6:592:8 | definition of quo | The variable $@ may not be initialized at this access. | test.cpp:592:6:592:8 | quo | quo |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-457/semmle/tests/UninitializedLocal.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-457/semmle/tests/UninitializedLocal.expected
@@ -13,7 +13,6 @@ nodes
 | test.cpp:458:6:458:6 | definition of x | semmle.label | definition of x |
 | test.cpp:464:6:464:6 | definition of x | semmle.label | definition of x |
 | test.cpp:471:6:471:6 | definition of x | semmle.label | definition of x |
-| test.cpp:592:6:592:8 | definition of quo | semmle.label | definition of quo |
 #select
 | test.cpp:12:6:12:8 | foo | test.cpp:11:6:11:8 | definition of foo | test.cpp:11:6:11:8 | definition of foo | The variable $@ may not be initialized at this access. | test.cpp:11:6:11:8 | foo | foo |
 | test.cpp:113:6:113:8 | foo | test.cpp:111:6:111:8 | definition of foo | test.cpp:111:6:111:8 | definition of foo | The variable $@ may not be initialized at this access. | test.cpp:111:6:111:8 | foo | foo |
@@ -28,4 +27,3 @@ nodes
 | test.cpp:460:7:460:7 | x | test.cpp:458:6:458:6 | definition of x | test.cpp:458:6:458:6 | definition of x | The variable $@ may not be initialized at this access. | test.cpp:458:6:458:6 | x | x |
 | test.cpp:467:2:467:2 | x | test.cpp:464:6:464:6 | definition of x | test.cpp:464:6:464:6 | definition of x | The variable $@ may not be initialized at this access. | test.cpp:464:6:464:6 | x | x |
 | test.cpp:474:7:474:7 | x | test.cpp:471:6:471:6 | definition of x | test.cpp:471:6:471:6 | definition of x | The variable $@ may not be initialized at this access. | test.cpp:471:6:471:6 | x | x |
-| test.cpp:594:6:594:8 | quo | test.cpp:592:6:592:8 | definition of quo | test.cpp:592:6:592:8 | definition of quo | The variable $@ may not be initialized at this access. | test.cpp:592:6:592:8 | quo | quo |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-457/semmle/tests/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-457/semmle/tests/test.cpp
@@ -581,3 +581,15 @@ void test46()
   *rP = nullptr;
   use(r);
 }
+
+namespace std {
+	float remquo(float, float, int*);
+}
+
+void test47() {
+	float x = 1.0f;
+	float y = 2.0f;
+	int quo;
+	std::remquo(x, y, &quo);
+	use(quo); // GOOD [FALSE POSITIVE]
+}

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-457/semmle/tests/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-457/semmle/tests/test.cpp
@@ -591,5 +591,5 @@ void test47() {
 	float y = 2.0f;
 	int quo;
 	std::remquo(x, y, &quo);
-	use(quo); // GOOD [FALSE POSITIVE]
+	use(quo); // GOOD
 }


### PR DESCRIPTION
I don't think we need a change note for this as this FP only happened after we merged https://github.com/github/codeql/pull/17034 earlier today.
