### PR TITLE
Python: Add Streamlit models

### DIFF
--- a/python/ql/lib/semmle/python/Frameworks.qll
+++ b/python/ql/lib/semmle/python/Frameworks.qll
@@ -73,6 +73,7 @@ private import semmle.python.frameworks.Simplejson
 private import semmle.python.frameworks.SqlAlchemy
 private import semmle.python.frameworks.Starlette
 private import semmle.python.frameworks.Stdlib
+private import semmle.python.frameworks.Streamlit
 private import semmle.python.frameworks.Toml
 private import semmle.python.frameworks.Torch
 private import semmle.python.frameworks.Tornado

--- a/python/ql/lib/semmle/python/frameworks/Streamlit.qll
+++ b/python/ql/lib/semmle/python/frameworks/Streamlit.qll
@@ -35,8 +35,8 @@ module Streamlit {
  * https://docs.streamlit.io/develop/api-reference/connections/st.connections.sqlconnection#:~:text=to%20data.-,st.connections.SQLConnection,-Streamlit%20Version
  * We can connect to SQL databases for example with `import streamlit as st; conn = st.connection('pets_db', type='sql')`
  */
-  private class StreamlitSQLConnection extends API::CallNode {
-    StreamlitSQLConnection() {
+  private class StreamlitSqlConnection extends API::CallNode {
+    StreamlitSqlConnection() {
       exists(StringLiteral str, API::CallNode n |
         str.getText().matches("sql")
         and
@@ -56,7 +56,7 @@ module Streamlit {
   private class QueryMethodCall extends DataFlow::CallCfgNode, SqlExecution::Range {
 
     QueryMethodCall() {
-      exists(StreamlitSQLConnection s |
+      exists(StreamlitSqlConnection s |
         this = s.getReturn().getMember("query").getACall())
     }
 
@@ -70,7 +70,7 @@ module Streamlit {
  */
 private class StreamlitSQLAlchemyConnection extends SqlAlchemy::Connection::InstanceSource {
     StreamlitSQLAlchemyConnection() {
-      exists(StreamlitSQLConnection s |
+      exists(StreamlitSqlConnection s |
         this = s.getReturn().getMember("connect").getACall())
     }
   }
@@ -79,9 +79,9 @@ private class StreamlitSQLAlchemyConnection extends SqlAlchemy::Connection::Inst
  * The underlying SQLAlchemy Engine, accessed via `st.connection().engine`.
  * Streamlit creates an engine to a SQL database basing off SQL Alchemy, so we can reuse the models that we already have.
  */
-private class StreamlitSQLAlchemyEngine extends SqlAlchemy::Engine::InstanceSource {
-    StreamlitSQLAlchemyEngine() {
-      exists(StreamlitSQLConnection s |
+private class StreamlitSqlAlchemyEngine extends SqlAlchemy::Engine::InstanceSource {
+    StreamlitSqlAlchemyEngine() {
+      exists(StreamlitSqlConnection s |
         this = s.getReturn().getMember("engine").asSource())
     }
   }
@@ -92,9 +92,9 @@ private class StreamlitSQLAlchemyEngine extends SqlAlchemy::Engine::InstanceSour
  * For example, the modeling for `session` includes an `execute` method, which is used to execute raw SQL queries.
  * https://docs.streamlit.io/develop/api-reference/connections/st.connections.sqlconnection#:~:text=SQLConnection.engine-,SQLConnection.session,-Streamlit%20Version
  */
-  private class StreamlitSession extends SqlAlchemy::Session::InstanceSource {
-    StreamlitSession() {
-      exists(StreamlitSQLConnection s |
+  private class StreamlitSqlSession extends SqlAlchemy::Session::InstanceSource {
+    StreamlitSqlSession() {
+      exists(StreamlitSqlConnection s |
         this = s.getReturn().getMember("session").asSource())
     }
   }

--- a/python/ql/lib/semmle/python/frameworks/Streamlit.qll
+++ b/python/ql/lib/semmle/python/frameworks/Streamlit.qll
@@ -3,35 +3,45 @@
  * See https://pypi.org/project/streamlit/.
  */
 
- import python
- import semmle.python.dataflow.new.RemoteFlowSources
- import semmle.python.dataflow.new.TaintTracking
- import semmle.python.ApiGraphs
- import semmle.python.Concepts
+import python
+import semmle.python.dataflow.new.RemoteFlowSources
+import semmle.python.dataflow.new.TaintTracking
+import semmle.python.ApiGraphs
+import semmle.python.Concepts
 
-
- /**
+/**
  * Provides models for the `gradio` PyPI package.
  * See https://pypi.org/project/gradio/.
  */
 module Streamlit {
-	/**
-	 * The calls to the interactive streamlit widgets, which take untrusted input.
-	 */
-	private class StreamlitInput extends RemoteFlowSource::Range {
-		StreamlitInput() { this = API::moduleImport("streamlit").getMember(["text_input", "text_area", "chat_input"]).getACall() }
-		override string getSourceType() { result = "Streamlit user input" }
-	}
+  /**
+   * The calls to the interactive streamlit widgets, which take untrusted input.
+   */
+  private class StreamlitInput extends RemoteFlowSource::Range {
+    StreamlitInput() {
+      this =
+        API::moduleImport("streamlit")
+            .getMember(["text_input", "text_area", "chat_input"])
+            .getACall()
+    }
 
-	/**
-	 * The `query` call that can execute raw queries on a connection to a SQL/Sonwflake/Snowpark database.
-	 * https://docs.streamlit.io/develop/api-reference/connections/st.connection
-	 */
-	private class QueryMethodCall extends DataFlow::CallCfgNode, SqlExecution::Range {
-		QueryMethodCall() {
-		  this = API::moduleImport("streamlit").getMember("connection").getReturn().getMember("query").getACall()
-		}
-		override DataFlow::Node getSql() { result in [this.getArg(0), this.getArgByName("sql")] }
-	}
+    override string getSourceType() { result = "Streamlit user input" }
+  }
 
+  /**
+   * The `query` call that can execute raw queries on a connection to a SQL/Sonwflake/Snowpark database.
+   * https://docs.streamlit.io/develop/api-reference/connections/st.connection
+   */
+  private class QueryMethodCall extends DataFlow::CallCfgNode, SqlExecution::Range {
+    QueryMethodCall() {
+      this =
+        API::moduleImport("streamlit")
+            .getMember("connection")
+            .getReturn()
+            .getMember("query")
+            .getACall()
+    }
+
+    override DataFlow::Node getSql() { result in [this.getArg(0), this.getArgByName("sql")] }
+  }
 }

--- a/python/ql/lib/semmle/python/frameworks/Streamlit.qll
+++ b/python/ql/lib/semmle/python/frameworks/Streamlit.qll
@@ -28,74 +28,68 @@ module Streamlit {
 
     override string getSourceType() { result = "Streamlit user input" }
   }
-/**
- * The Streamlit SQLConnection class, which is used to create a connection to a SQL Database.
- * Streamlit wraps around SQL Alchemy for most database functionality, and adds some on top of it, such as the `query` method.
- * Streamlit can also connect to Snowflake and Snowpark databases, but the modeling is not the same, so we need to limit the scope to SQL databases.
- * https://docs.streamlit.io/develop/api-reference/connections/st.connections.sqlconnection#:~:text=to%20data.-,st.connections.SQLConnection,-Streamlit%20Version
- * We can connect to SQL databases for example with `import streamlit as st; conn = st.connection('pets_db', type='sql')`
- */
+
+  /**
+   * The Streamlit SQLConnection class, which is used to create a connection to a SQL Database.
+   * Streamlit wraps around SQL Alchemy for most database functionality, and adds some on top of it, such as the `query` method.
+   * Streamlit can also connect to Snowflake and Snowpark databases, but the modeling is not the same, so we need to limit the scope to SQL databases.
+   * https://docs.streamlit.io/develop/api-reference/connections/st.connections.sqlconnection#:~:text=to%20data.-,st.connections.SQLConnection,-Streamlit%20Version
+   * We can connect to SQL databases for example with `import streamlit as st; conn = st.connection('pets_db', type='sql')`
+   */
   private class StreamlitSqlConnection extends API::CallNode {
     StreamlitSqlConnection() {
       exists(StringLiteral str, API::CallNode n |
-        str.getText() = "sql"
-        and
-        n = API::moduleImport("streamlit").getMember("connection").getACall()
-        and
-        DataFlow::exprNode(str).(DataFlow::LocalSourceNode)
-        .flowsTo([n.getArg(1), n.getArgByName("type")])
-        and this = n
+        str.getText() = "sql" and
+        n = API::moduleImport("streamlit").getMember("connection").getACall() and
+        DataFlow::exprNode(str)
+            .(DataFlow::LocalSourceNode)
+            .flowsTo([n.getArg(1), n.getArgByName("type")]) and
+        this = n
       )
-
     }
   }
+
   /**
    * The `query` call that can execute raw queries on a connection to a SQL database.
    * https://docs.streamlit.io/develop/api-reference/connections/st.connection
    */
   private class QueryMethodCall extends DataFlow::CallCfgNode, SqlExecution::Range {
-
     QueryMethodCall() {
-      exists(StreamlitSqlConnection s |
-        this = s.getReturn().getMember("query").getACall())
+      exists(StreamlitSqlConnection s | this = s.getReturn().getMember("query").getACall())
     }
 
     override DataFlow::Node getSql() { result in [this.getArg(0), this.getArgByName("sql")] }
   }
 
-
-/**
- * The Streamlit SQLConnection.connect() call, which returns a a new sqlalchemy.engine.Connection object.
- * Streamlit creates a connection to a SQL database basing off SQL Alchemy, so we can reuse the models that we already have.
- */
-private class StreamlitSQLAlchemyConnection extends SqlAlchemy::Connection::InstanceSource {
-    StreamlitSQLAlchemyConnection() {
-      exists(StreamlitSqlConnection s |
-        this = s.getReturn().getMember("connect").getACall())
+  /**
+   * The Streamlit SQLConnection.connect() call, which returns a a new sqlalchemy.engine.Connection object.
+   * Streamlit creates a connection to a SQL database basing off SQL Alchemy, so we can reuse the models that we already have.
+   */
+  private class StreamlitSqlAlchemyConnection extends SqlAlchemy::Connection::InstanceSource {
+    StreamlitSqlAlchemyConnection() {
+      exists(StreamlitSqlConnection s | this = s.getReturn().getMember("connect").getACall())
     }
   }
 
-/**
- * The underlying SQLAlchemy Engine, accessed via `st.connection().engine`.
- * Streamlit creates an engine to a SQL database basing off SQL Alchemy, so we can reuse the models that we already have.
- */
-private class StreamlitSqlAlchemyEngine extends SqlAlchemy::Engine::InstanceSource {
+  /**
+   * The underlying SQLAlchemy Engine, accessed via `st.connection().engine`.
+   * Streamlit creates an engine to a SQL database basing off SQL Alchemy, so we can reuse the models that we already have.
+   */
+  private class StreamlitSqlAlchemyEngine extends SqlAlchemy::Engine::InstanceSource {
     StreamlitSqlAlchemyEngine() {
-      exists(StreamlitSqlConnection s |
-        this = s.getReturn().getMember("engine").asSource())
+      exists(StreamlitSqlConnection s | this = s.getReturn().getMember("engine").asSource())
     }
   }
 
-/**
- * The SQLAlchemy Session, accessed via `st.connection().session`.
- * Streamlit can create a session to a SQL database basing off SQL Alchemy, so we can reuse the models that we already have.
- * For example, the modeling for `session` includes an `execute` method, which is used to execute raw SQL queries.
- * https://docs.streamlit.io/develop/api-reference/connections/st.connections.sqlconnection#:~:text=SQLConnection.engine-,SQLConnection.session,-Streamlit%20Version
- */
+  /**
+   * The SQLAlchemy Session, accessed via `st.connection().session`.
+   * Streamlit can create a session to a SQL database basing off SQL Alchemy, so we can reuse the models that we already have.
+   * For example, the modeling for `session` includes an `execute` method, which is used to execute raw SQL queries.
+   * https://docs.streamlit.io/develop/api-reference/connections/st.connections.sqlconnection#:~:text=SQLConnection.engine-,SQLConnection.session,-Streamlit%20Version
+   */
   private class StreamlitSqlSession extends SqlAlchemy::Session::InstanceSource {
     StreamlitSqlSession() {
-      exists(StreamlitSqlConnection s |
-        this = s.getReturn().getMember("session").asSource())
+      exists(StreamlitSqlConnection s | this = s.getReturn().getMember("session").asSource())
     }
   }
 }

--- a/python/ql/lib/semmle/python/frameworks/Streamlit.qll
+++ b/python/ql/lib/semmle/python/frameworks/Streamlit.qll
@@ -44,4 +44,14 @@ module Streamlit {
 
     override DataFlow::Node getSql() { result in [this.getArg(0), this.getArgByName("sql")] }
   }
+private class StreamlitConnection extends SqlAlchemy::Connection::InstanceSource {
+    StreamlitConnection() {
+      this =
+        API::moduleImport("streamlit")
+            .getMember("connection")
+            .getReturn()
+            .getMember("connect")
+            .getACall()
+    }
+  }
 }

--- a/python/ql/lib/semmle/python/frameworks/Streamlit.qll
+++ b/python/ql/lib/semmle/python/frameworks/Streamlit.qll
@@ -8,7 +8,7 @@ import semmle.python.dataflow.new.RemoteFlowSources
 import semmle.python.dataflow.new.TaintTracking
 import semmle.python.ApiGraphs
 import semmle.python.Concepts
-import semmle.python.frameworks.SqlAlchemy
+private import semmle.python.frameworks.SqlAlchemy
 
 /**
  * Provides models for the `gradio` PyPI package.

--- a/python/ql/lib/semmle/python/frameworks/Streamlit.qll
+++ b/python/ql/lib/semmle/python/frameworks/Streamlit.qll
@@ -1,0 +1,37 @@
+/**
+ * Provides classes modeling security-relevant aspects of the `streamlit` PyPI package.
+ * See https://pypi.org/project/streamlit/.
+ */
+
+ import python
+ import semmle.python.dataflow.new.RemoteFlowSources
+ import semmle.python.dataflow.new.TaintTracking
+ import semmle.python.ApiGraphs
+ import semmle.python.Concepts
+
+
+ /**
+ * Provides models for the `gradio` PyPI package.
+ * See https://pypi.org/project/gradio/.
+ */
+module Streamlit {
+	/**
+	 * The calls to the interactive streamlit widgets, which take untrusted input.
+	 */
+	private class StreamlitInput extends RemoteFlowSource::Range {
+		StreamlitInput() { this = API::moduleImport("streamlit").getMember(["text_input", "text_area", "chat_input"]).getACall() }
+		override string getSourceType() { result = "Streamlit user input" }
+	}
+
+	/**
+	 * The `query` call that can execute raw queries on a connection to a SQL/Sonwflake/Snowpark database.
+	 * https://docs.streamlit.io/develop/api-reference/connections/st.connection
+	 */
+	private class QueryMethodCall extends DataFlow::CallCfgNode, SqlExecution::Range {
+		QueryMethodCall() {
+		  this = API::moduleImport("streamlit").getMember("connection").getReturn().getMember("query").getACall()
+		}
+		override DataFlow::Node getSql() { result in [this.getArg(0), this.getArgByName("sql")] }
+	}
+
+}

--- a/python/ql/lib/semmle/python/frameworks/Streamlit.qll
+++ b/python/ql/lib/semmle/python/frameworks/Streamlit.qll
@@ -11,8 +11,8 @@ import semmle.python.Concepts
 private import semmle.python.frameworks.SqlAlchemy
 
 /**
- * Provides models for the `gradio` PyPI package.
- * See https://pypi.org/project/gradio/.
+ * Provides models for the `streamlit` PyPI package.
+ * See https://pypi.org/project/streamlit/.
  */
 module Streamlit {
   /**

--- a/python/ql/lib/semmle/python/frameworks/Streamlit.qll
+++ b/python/ql/lib/semmle/python/frameworks/Streamlit.qll
@@ -38,7 +38,7 @@ module Streamlit {
   private class StreamlitSqlConnection extends API::CallNode {
     StreamlitSqlConnection() {
       exists(StringLiteral str, API::CallNode n |
-        str.getText().matches("sql")
+        str.getText() = "sql"
         and
         n = API::moduleImport("streamlit").getMember("connection").getACall()
         and

--- a/python/ql/src/change-notes/2024-07-26-streamlit-models.md
+++ b/python/ql/src/change-notes/2024-07-26-streamlit-models.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added models of `streamlit` PyPI package.

--- a/python/ql/test/experimental/meta/RemoteFlowSourceTest.qll
+++ b/python/ql/test/experimental/meta/RemoteFlowSourceTest.qll
@@ -1,0 +1,20 @@
+import python
+import semmle.python.dataflow.new.RemoteFlowSources
+import TestUtilities.InlineExpectationsTest
+private import semmle.python.dataflow.new.internal.PrintNode
+
+module SourceTest implements TestSig {
+  string getARelevantTag() { result = "source" }
+
+  predicate hasActualResult(Location location, string element, string tag, string value) {
+    exists(location.getFile().getRelativePath()) and
+    exists(RemoteFlowSource rfs |
+      location = rfs.getLocation() and
+      element = rfs.toString() and
+      value = prettyNode(rfs) and
+      tag = "source"
+    )
+  }
+}
+
+import MakeTest<SourceTest>

--- a/python/ql/test/library-tests/frameworks/gradio/source_test.ql
+++ b/python/ql/test/library-tests/frameworks/gradio/source_test.ql
@@ -1,20 +1,2 @@
 import python
-import semmle.python.dataflow.new.RemoteFlowSources
-import TestUtilities.InlineExpectationsTest
-private import semmle.python.dataflow.new.internal.PrintNode
-
-module SourceTest implements TestSig {
-  string getARelevantTag() { result = "source" }
-
-  predicate hasActualResult(Location location, string element, string tag, string value) {
-    exists(location.getFile().getRelativePath()) and
-    exists(RemoteFlowSource rfs |
-      location = rfs.getLocation() and
-      element = rfs.toString() and
-      value = prettyNode(rfs) and
-      tag = "source"
-    )
-  }
-}
-
-import MakeTest<SourceTest>
+import experimental.meta.RemoteFlowSourceTest

--- a/python/ql/test/library-tests/frameworks/streamlit/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/streamlit/ConceptsTest.expected
@@ -1,0 +1,2 @@
+testFailures
+failures

--- a/python/ql/test/library-tests/frameworks/streamlit/ConceptsTest.ql
+++ b/python/ql/test/library-tests/frameworks/streamlit/ConceptsTest.ql
@@ -1,0 +1,2 @@
+import python
+import experimental.meta.ConceptsTest

--- a/python/ql/test/library-tests/frameworks/streamlit/rfs-test.expected
+++ b/python/ql/test/library-tests/frameworks/streamlit/rfs-test.expected
@@ -1,0 +1,2 @@
+testFailures
+failures

--- a/python/ql/test/library-tests/frameworks/streamlit/rfs-test.ql
+++ b/python/ql/test/library-tests/frameworks/streamlit/rfs-test.ql
@@ -1,0 +1,20 @@
+import python
+import semmle.python.dataflow.new.RemoteFlowSources
+import TestUtilities.InlineExpectationsTest
+private import semmle.python.dataflow.new.internal.PrintNode
+
+module SourceTest implements TestSig {
+  string getARelevantTag() { result = "source" }
+
+  predicate hasActualResult(Location location, string element, string tag, string value) {
+    exists(location.getFile().getRelativePath()) and
+    exists(RemoteFlowSource rfs |
+      location = rfs.getLocation() and
+      element = rfs.toString() and
+      value = prettyNode(rfs) and
+      tag = "source"
+    )
+  }
+}
+
+import MakeTest<SourceTest>

--- a/python/ql/test/library-tests/frameworks/streamlit/rfs-test.ql
+++ b/python/ql/test/library-tests/frameworks/streamlit/rfs-test.ql
@@ -1,20 +1,2 @@
 import python
-import semmle.python.dataflow.new.RemoteFlowSources
-import TestUtilities.InlineExpectationsTest
-private import semmle.python.dataflow.new.internal.PrintNode
-
-module SourceTest implements TestSig {
-  string getARelevantTag() { result = "source" }
-
-  predicate hasActualResult(Location location, string element, string tag, string value) {
-    exists(location.getFile().getRelativePath()) and
-    exists(RemoteFlowSource rfs |
-      location = rfs.getLocation() and
-      element = rfs.toString() and
-      value = prettyNode(rfs) and
-      tag = "source"
-    )
-  }
-}
-
-import MakeTest<SourceTest>
+import experimental.meta.RemoteFlowSourceTest

--- a/python/ql/test/library-tests/frameworks/streamlit/test.py
+++ b/python/ql/test/library-tests/frameworks/streamlit/test.py
@@ -1,0 +1,12 @@
+import streamlit as st
+
+# Streamlit sources
+inp = st.text_input("Query the database") # $ source=st.text_input(..)
+area = st.text_area("Area") # $ source=st.text_area(..)
+chat = st.chat_input("Chat") # $ source=st.chat_input(..)
+
+# Initialize connection.
+conn = st.connection("postgresql", type="sql")
+
+# SQL injection sink
+q = conn.query("some sql")  # $ getSql="some sql"

--- a/python/ql/test/library-tests/frameworks/streamlit/test.py
+++ b/python/ql/test/library-tests/frameworks/streamlit/test.py
@@ -10,3 +10,8 @@ conn = st.connection("postgresql", type="sql")
 
 # SQL injection sink
 q = conn.query("some sql")  # $ getSql="some sql"
+
+# SQLAlchemy connection
+c = conn.connect()
+
+c.execute("other sql")  # $ getSql="other sql"

--- a/python/ql/test/library-tests/frameworks/streamlit/test.py
+++ b/python/ql/test/library-tests/frameworks/streamlit/test.py
@@ -15,3 +15,13 @@ q = conn.query("some sql")  # $ getSql="some sql"
 c = conn.connect()
 
 c.execute("other sql")  # $ getSql="other sql"
+
+# SQL Alchemy session
+s = conn.session
+
+s.execute("yet another sql")  # $ getSql="yet another sql"
+
+# SQL Alchemy engine
+e = st.connection("postgresql", type="sql")
+
+e.engine.connect().execute("yet yet another sql")  # $ getSql="yet yet another sql"


### PR DESCRIPTION
👋 This PR adds a few sources and a sink for the [Streamlit](https://streamlit.io/) framework. Streamlit is a popular Python library for creating web apps for machine learning and data science. 🚀 

I did a bit of tweaking with tests, let me know if these could be improved.

Side note: Streamlit creates SQL connection to databases using SQL Alchemy Engine. There are a few potential SQLExecution sinks that I haven't included, because to execute the SQL query they require sqlalchemy's `TextClause` object, which is already modeled, so my assumption here is that we don't need to model those.

For example `st.connection().session.execute()` would be a potential sink, but it requires a `TextClause` object, which is already modeled as a SQL injection sink. 

Here is an example of how it could be used:
```python
import streamlit as st
from sqlalchemy import text

# Initialize connection.
conn = st.connection("postgresql", type="sql")

inp = st.text_input("Query the database")

#BAD
if st.button("Add the number!"):
    with conn.session as session:
        query = text(f'SELECT {inp} FROM mytable;')
        for value in session.execute(query):
            st.write(value)
        session.commit()
```
Note that `text()` is not used in Streamlit's documention, but if we run the snippet from the docs (https://docs.streamlit.io/develop/api-reference/connections/st.connections.sqlconnection#:~:text=SQLConnection.engine-,SQLConnection.session,-Streamlit%20Version), it returns an error `ArgumentError: Textual SQL expression 'INSERT INTO mytable (val)...’ should be explicitly declared as text(‘INSERT INTO mytable (val)...’)` - it looks like Streamlit docs haven't been updated.

If you think we should model this, please let me know.