### PR TITLE
Java: Add support for post-process provenance pretty-printing in `.ql` library-tests

### DIFF
--- a/java/ql/test/library-tests/dataflow/call-sensitivity/flow.expected
+++ b/java/ql/test/library-tests/dataflow/call-sensitivity/flow.expected
@@ -1,3 +1,4 @@
+models
 edges
 | A2.java:15:15:15:28 | new Integer(...) : Number | A2.java:27:27:27:34 | o : Number | provenance |  |
 | A2.java:27:27:27:34 | o : Number | A2.java:29:9:29:9 | o | provenance |  |

--- a/java/ql/test/library-tests/dataflow/call-sensitivity/flow.ql
+++ b/java/ql/test/library-tests/dataflow/call-sensitivity/flow.ql
@@ -4,7 +4,9 @@
 
 import java
 import semmle.code.java.dataflow.DataFlow
-import Flow::PathGraph
+import codeql.dataflow.test.ProvenancePathGraph
+import semmle.code.java.dataflow.ExternalFlow
+import ShowProvenance<interpretModelForTest/2, Flow::PathNode, Flow::PathGraph>
 
 module Config implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node src) { src.asExpr() instanceof ClassInstanceExpr }

--- a/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest1.expected
+++ b/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest1.expected
@@ -1,12 +1,18 @@
+models
+| 1 | Summary: java.io; InputStream; true; read; (byte[]); ; Argument[this]; Argument[0]; taint; manual |
+| 2 | Summary: java.lang; String; false; String; ; ; Argument[0]; Argument[this]; taint; manual |
+| 3 | Source: java.net; Socket; false; getInputStream; (); ; ReturnValue; remote; manual |
+| 4 | Sink: java.sql; Statement; true; executeUpdate; ; ; Argument[0]; sql-injection; manual |
+| 5 | Sink: java.util.logging; Logger; true; severe; ; ; Argument[0]; log-injection; manual |
 edges
 | Test.java:10:31:10:41 | data : byte[] | Test.java:11:23:11:26 | data : byte[] | provenance |  |
-| Test.java:11:23:11:26 | data : byte[] | Test.java:11:12:11:51 | new String(...) : String | provenance | MaD:42745 |
-| Test.java:19:5:19:25 | getInputStream(...) : InputStream | Test.java:19:32:19:35 | data [post update] : byte[] | provenance | Src:MaD:42936 MaD:42629 |
+| Test.java:11:23:11:26 | data : byte[] | Test.java:11:12:11:51 | new String(...) : String | provenance | MaD:2 |
+| Test.java:19:5:19:25 | getInputStream(...) : InputStream | Test.java:19:32:19:35 | data [post update] : byte[] | provenance | Src:MaD:3 MaD:1 |
 | Test.java:19:32:19:35 | data [post update] : byte[] | Test.java:22:49:22:52 | data : byte[] | provenance |  |
 | Test.java:19:32:19:35 | data [post update] : byte[] | Test.java:25:69:25:72 | data : byte[] | provenance |  |
 | Test.java:22:49:22:52 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
-| Test.java:22:49:22:52 | data : byte[] | Test.java:22:36:22:53 | byteToString(...) | provenance |  Sink:MaD:43695 |
-| Test.java:25:56:25:73 | byteToString(...) : String | Test.java:25:26:25:80 | ... + ... | provenance |  Sink:MaD:43209 |
+| Test.java:22:49:22:52 | data : byte[] | Test.java:22:36:22:53 | byteToString(...) | provenance |  Sink:MaD:5 |
+| Test.java:25:56:25:73 | byteToString(...) : String | Test.java:25:26:25:80 | ... + ... | provenance |  Sink:MaD:4 |
 | Test.java:25:69:25:72 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
 | Test.java:25:69:25:72 | data : byte[] | Test.java:25:56:25:73 | byteToString(...) : String | provenance |  |
 nodes

--- a/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest1.ql
+++ b/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest1.ql
@@ -3,7 +3,9 @@
  */
 
 import Test
-import ThreatModel::PathGraph
+import codeql.dataflow.test.ProvenancePathGraph
+import semmle.code.java.dataflow.ExternalFlow
+import ShowProvenance<interpretModelForTest/2, ThreatModel::PathNode, ThreatModel::PathGraph>
 
 from ThreatModel::PathNode source, ThreatModel::PathNode sink
 where ThreatModel::flowPath(source, sink)

--- a/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest2.expected
+++ b/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest2.expected
@@ -1,16 +1,24 @@
+models
+| 1 | Sink: android.app; Activity; true; bindServiceAsUser; ; ; Argument[0]; intent-redirection; manual |
+| 1 | Source: testlib; TestSources; false; executeQuery; (String); ; ReturnValue; database; manual |
+| 2 | Summary: java.io; InputStream; true; read; (byte[]); ; Argument[this]; Argument[0]; taint; manual |
+| 3 | Summary: java.lang; String; false; String; ; ; Argument[0]; Argument[this]; taint; manual |
+| 4 | Source: java.net; Socket; false; getInputStream; (); ; ReturnValue; remote; manual |
+| 5 | Sink: java.sql; Statement; true; executeUpdate; ; ; Argument[0]; sql-injection; manual |
+| 6 | Sink: java.util.logging; Logger; true; severe; ; ; Argument[0]; log-injection; manual |
 edges
 | Test.java:10:31:10:41 | data : byte[] | Test.java:11:23:11:26 | data : byte[] | provenance |  |
-| Test.java:11:23:11:26 | data : byte[] | Test.java:11:12:11:51 | new String(...) : String | provenance | MaD:42745 |
-| Test.java:19:5:19:25 | getInputStream(...) : InputStream | Test.java:19:32:19:35 | data [post update] : byte[] | provenance | Src:MaD:42936 MaD:42629 |
+| Test.java:11:23:11:26 | data : byte[] | Test.java:11:12:11:51 | new String(...) : String | provenance | MaD:3 |
+| Test.java:19:5:19:25 | getInputStream(...) : InputStream | Test.java:19:32:19:35 | data [post update] : byte[] | provenance | Src:MaD:4 MaD:2 |
 | Test.java:19:32:19:35 | data [post update] : byte[] | Test.java:22:49:22:52 | data : byte[] | provenance |  |
 | Test.java:19:32:19:35 | data [post update] : byte[] | Test.java:25:69:25:72 | data : byte[] | provenance |  |
 | Test.java:22:49:22:52 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
-| Test.java:22:49:22:52 | data : byte[] | Test.java:22:36:22:53 | byteToString(...) | provenance |  Sink:MaD:43695 |
-| Test.java:25:56:25:73 | byteToString(...) : String | Test.java:25:26:25:80 | ... + ... | provenance |  Sink:MaD:43209 |
+| Test.java:22:49:22:52 | data : byte[] | Test.java:22:36:22:53 | byteToString(...) | provenance |  Sink:MaD:6 |
+| Test.java:25:56:25:73 | byteToString(...) : String | Test.java:25:26:25:80 | ... + ... | provenance |  Sink:MaD:5 |
 | Test.java:25:69:25:72 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
 | Test.java:25:69:25:72 | data : byte[] | Test.java:25:56:25:73 | byteToString(...) : String | provenance |  |
-| Test.java:30:21:30:61 | executeQuery(...) : String | Test.java:33:26:33:68 | ... + ... | provenance | Src:MaD:1  Sink:MaD:43209 |
-| Test.java:30:21:30:61 | executeQuery(...) : String | Test.java:36:36:36:41 | result | provenance | Src:MaD:1  Sink:MaD:43695 |
+| Test.java:30:21:30:61 | executeQuery(...) : String | Test.java:33:26:33:68 | ... + ... | provenance | Src:MaD:1  Sink:MaD:5 |
+| Test.java:30:21:30:61 | executeQuery(...) : String | Test.java:36:36:36:41 | result | provenance | Src:MaD:1  Sink:MaD:6 |
 nodes
 | Test.java:10:31:10:41 | data : byte[] | semmle.label | data : byte[] |
 | Test.java:11:12:11:51 | new String(...) : String | semmle.label | new String(...) : String |

--- a/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest2.ql
+++ b/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest2.ql
@@ -4,7 +4,9 @@
  */
 
 import Test
-import ThreatModel::PathGraph
+import codeql.dataflow.test.ProvenancePathGraph
+import semmle.code.java.dataflow.ExternalFlow
+import ShowProvenance<interpretModelForTest/2, ThreatModel::PathNode, ThreatModel::PathGraph>
 
 from ThreatModel::PathNode source, ThreatModel::PathNode sink
 where ThreatModel::flowPath(source, sink)

--- a/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest3.expected
+++ b/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest3.expected
@@ -1,26 +1,36 @@
+models
+| 1 | Sink: android.app; Activity; true; bindServiceAsUser; ; ; Argument[0]; intent-redirection; manual |
+| 1 | Source: testlib; TestSources; false; executeQuery; (String); ; ReturnValue; database; manual |
+| 2 | Sink: android.app; Activity; true; setResult; (int,Intent); ; Argument[1]; pending-intents; manual |
+| 2 | Source: testlib; TestSources; false; readEnv; (String); ; ReturnValue; environment; manual |
+| 3 | Summary: java.io; InputStream; true; read; (byte[]); ; Argument[this]; Argument[0]; taint; manual |
+| 4 | Summary: java.lang; String; false; String; ; ; Argument[0]; Argument[this]; taint; manual |
+| 5 | Source: java.net; Socket; false; getInputStream; (); ; ReturnValue; remote; manual |
+| 6 | Sink: java.sql; Statement; true; executeUpdate; ; ; Argument[0]; sql-injection; manual |
+| 7 | Sink: java.util.logging; Logger; true; severe; ; ; Argument[0]; log-injection; manual |
 edges
 | Test.java:10:31:10:41 | data : byte[] | Test.java:11:23:11:26 | data : byte[] | provenance |  |
-| Test.java:11:23:11:26 | data : byte[] | Test.java:11:12:11:51 | new String(...) : String | provenance | MaD:42745 |
-| Test.java:19:5:19:25 | getInputStream(...) : InputStream | Test.java:19:32:19:35 | data [post update] : byte[] | provenance | Src:MaD:42936 MaD:42629 |
+| Test.java:11:23:11:26 | data : byte[] | Test.java:11:12:11:51 | new String(...) : String | provenance | MaD:4 |
+| Test.java:19:5:19:25 | getInputStream(...) : InputStream | Test.java:19:32:19:35 | data [post update] : byte[] | provenance | Src:MaD:5 MaD:3 |
 | Test.java:19:32:19:35 | data [post update] : byte[] | Test.java:22:49:22:52 | data : byte[] | provenance |  |
 | Test.java:19:32:19:35 | data [post update] : byte[] | Test.java:25:69:25:72 | data : byte[] | provenance |  |
 | Test.java:22:49:22:52 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
-| Test.java:22:49:22:52 | data : byte[] | Test.java:22:36:22:53 | byteToString(...) | provenance |  Sink:MaD:43695 |
-| Test.java:25:56:25:73 | byteToString(...) : String | Test.java:25:26:25:80 | ... + ... | provenance |  Sink:MaD:43209 |
+| Test.java:22:49:22:52 | data : byte[] | Test.java:22:36:22:53 | byteToString(...) | provenance |  Sink:MaD:7 |
+| Test.java:25:56:25:73 | byteToString(...) : String | Test.java:25:26:25:80 | ... + ... | provenance |  Sink:MaD:6 |
 | Test.java:25:69:25:72 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
 | Test.java:25:69:25:72 | data : byte[] | Test.java:25:56:25:73 | byteToString(...) : String | provenance |  |
-| Test.java:30:21:30:61 | executeQuery(...) : String | Test.java:33:26:33:68 | ... + ... | provenance | Src:MaD:1  Sink:MaD:43209 |
-| Test.java:30:21:30:61 | executeQuery(...) : String | Test.java:36:36:36:41 | result | provenance | Src:MaD:1  Sink:MaD:43695 |
-| Test.java:41:21:41:49 | readEnv(...) : String | Test.java:44:26:44:68 | ... + ... | provenance | Src:MaD:2  Sink:MaD:43209 |
-| Test.java:41:21:41:49 | readEnv(...) : String | Test.java:47:36:47:41 | result | provenance | Src:MaD:2  Sink:MaD:43695 |
-| Test.java:64:5:64:13 | System.in : InputStream | Test.java:64:20:64:23 | data [post update] : byte[] | provenance | MaD:42629 |
+| Test.java:30:21:30:61 | executeQuery(...) : String | Test.java:33:26:33:68 | ... + ... | provenance | Src:MaD:1  Sink:MaD:6 |
+| Test.java:30:21:30:61 | executeQuery(...) : String | Test.java:36:36:36:41 | result | provenance | Src:MaD:1  Sink:MaD:7 |
+| Test.java:41:21:41:49 | readEnv(...) : String | Test.java:44:26:44:68 | ... + ... | provenance | Src:MaD:2  Sink:MaD:6 |
+| Test.java:41:21:41:49 | readEnv(...) : String | Test.java:47:36:47:41 | result | provenance | Src:MaD:2  Sink:MaD:7 |
+| Test.java:64:5:64:13 | System.in : InputStream | Test.java:64:20:64:23 | data [post update] : byte[] | provenance | MaD:3 |
 | Test.java:64:20:64:23 | data [post update] : byte[] | Test.java:67:69:67:72 | data : byte[] | provenance |  |
 | Test.java:64:20:64:23 | data [post update] : byte[] | Test.java:70:49:70:52 | data : byte[] | provenance |  |
-| Test.java:67:56:67:73 | byteToString(...) : String | Test.java:67:26:67:80 | ... + ... | provenance |  Sink:MaD:43209 |
+| Test.java:67:56:67:73 | byteToString(...) : String | Test.java:67:26:67:80 | ... + ... | provenance |  Sink:MaD:6 |
 | Test.java:67:69:67:72 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
 | Test.java:67:69:67:72 | data : byte[] | Test.java:67:56:67:73 | byteToString(...) : String | provenance |  |
 | Test.java:70:49:70:52 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
-| Test.java:70:49:70:52 | data : byte[] | Test.java:70:36:70:53 | byteToString(...) | provenance |  Sink:MaD:43695 |
+| Test.java:70:49:70:52 | data : byte[] | Test.java:70:36:70:53 | byteToString(...) | provenance |  Sink:MaD:7 |
 nodes
 | Test.java:10:31:10:41 | data : byte[] | semmle.label | data : byte[] |
 | Test.java:11:12:11:51 | new String(...) : String | semmle.label | new String(...) : String |

--- a/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest3.ql
+++ b/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest3.ql
@@ -4,7 +4,9 @@
  */
 
 import Test
-import ThreatModel::PathGraph
+import codeql.dataflow.test.ProvenancePathGraph
+import semmle.code.java.dataflow.ExternalFlow
+import ShowProvenance<interpretModelForTest/2, ThreatModel::PathNode, ThreatModel::PathGraph>
 
 from ThreatModel::PathNode source, ThreatModel::PathNode sink
 where ThreatModel::flowPath(source, sink)

--- a/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest4.expected
+++ b/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest4.expected
@@ -1,28 +1,40 @@
+models
+| 1 | Sink: android.app; Activity; true; bindServiceAsUser; ; ; Argument[0]; intent-redirection; manual |
+| 1 | Source: testlib; TestSources; false; executeQuery; (String); ; ReturnValue; database; manual |
+| 2 | Sink: android.app; Activity; true; setResult; (int,Intent); ; Argument[1]; pending-intents; manual |
+| 2 | Source: testlib; TestSources; false; readEnv; (String); ; ReturnValue; environment; manual |
+| 3 | Sink: android.app; Activity; true; startActivityAsCaller; ; ; Argument[0]; intent-redirection; manual |
+| 3 | Source: testlib; TestSources; false; getCustom; (String); ; ReturnValue; custom; manual |
+| 4 | Summary: java.io; InputStream; true; read; (byte[]); ; Argument[this]; Argument[0]; taint; manual |
+| 5 | Summary: java.lang; String; false; String; ; ; Argument[0]; Argument[this]; taint; manual |
+| 6 | Source: java.net; Socket; false; getInputStream; (); ; ReturnValue; remote; manual |
+| 7 | Sink: java.sql; Statement; true; executeUpdate; ; ; Argument[0]; sql-injection; manual |
+| 8 | Sink: java.util.logging; Logger; true; severe; ; ; Argument[0]; log-injection; manual |
 edges
 | Test.java:10:31:10:41 | data : byte[] | Test.java:11:23:11:26 | data : byte[] | provenance |  |
-| Test.java:11:23:11:26 | data : byte[] | Test.java:11:12:11:51 | new String(...) : String | provenance | MaD:42745 |
-| Test.java:19:5:19:25 | getInputStream(...) : InputStream | Test.java:19:32:19:35 | data [post update] : byte[] | provenance | Src:MaD:42936 MaD:42629 |
+| Test.java:11:23:11:26 | data : byte[] | Test.java:11:12:11:51 | new String(...) : String | provenance | MaD:5 |
+| Test.java:19:5:19:25 | getInputStream(...) : InputStream | Test.java:19:32:19:35 | data [post update] : byte[] | provenance | Src:MaD:6 MaD:4 |
 | Test.java:19:32:19:35 | data [post update] : byte[] | Test.java:22:49:22:52 | data : byte[] | provenance |  |
 | Test.java:19:32:19:35 | data [post update] : byte[] | Test.java:25:69:25:72 | data : byte[] | provenance |  |
 | Test.java:22:49:22:52 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
-| Test.java:22:49:22:52 | data : byte[] | Test.java:22:36:22:53 | byteToString(...) | provenance |  Sink:MaD:43695 |
-| Test.java:25:56:25:73 | byteToString(...) : String | Test.java:25:26:25:80 | ... + ... | provenance |  Sink:MaD:43209 |
+| Test.java:22:49:22:52 | data : byte[] | Test.java:22:36:22:53 | byteToString(...) | provenance |  Sink:MaD:8 |
+| Test.java:25:56:25:73 | byteToString(...) : String | Test.java:25:26:25:80 | ... + ... | provenance |  Sink:MaD:7 |
 | Test.java:25:69:25:72 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
 | Test.java:25:69:25:72 | data : byte[] | Test.java:25:56:25:73 | byteToString(...) : String | provenance |  |
-| Test.java:30:21:30:61 | executeQuery(...) : String | Test.java:33:26:33:68 | ... + ... | provenance | Src:MaD:1  Sink:MaD:43209 |
-| Test.java:30:21:30:61 | executeQuery(...) : String | Test.java:36:36:36:41 | result | provenance | Src:MaD:1  Sink:MaD:43695 |
-| Test.java:41:21:41:49 | readEnv(...) : String | Test.java:44:26:44:68 | ... + ... | provenance | Src:MaD:2  Sink:MaD:43209 |
-| Test.java:41:21:41:49 | readEnv(...) : String | Test.java:47:36:47:41 | result | provenance | Src:MaD:2  Sink:MaD:43695 |
-| Test.java:52:21:52:47 | getCustom(...) : String | Test.java:55:26:55:68 | ... + ... | provenance | Src:MaD:3  Sink:MaD:43209 |
-| Test.java:52:21:52:47 | getCustom(...) : String | Test.java:58:36:58:41 | result | provenance | Src:MaD:3  Sink:MaD:43695 |
-| Test.java:64:5:64:13 | System.in : InputStream | Test.java:64:20:64:23 | data [post update] : byte[] | provenance | MaD:42629 |
+| Test.java:30:21:30:61 | executeQuery(...) : String | Test.java:33:26:33:68 | ... + ... | provenance | Src:MaD:1  Sink:MaD:7 |
+| Test.java:30:21:30:61 | executeQuery(...) : String | Test.java:36:36:36:41 | result | provenance | Src:MaD:1  Sink:MaD:8 |
+| Test.java:41:21:41:49 | readEnv(...) : String | Test.java:44:26:44:68 | ... + ... | provenance | Src:MaD:2  Sink:MaD:7 |
+| Test.java:41:21:41:49 | readEnv(...) : String | Test.java:47:36:47:41 | result | provenance | Src:MaD:2  Sink:MaD:8 |
+| Test.java:52:21:52:47 | getCustom(...) : String | Test.java:55:26:55:68 | ... + ... | provenance | Src:MaD:3  Sink:MaD:7 |
+| Test.java:52:21:52:47 | getCustom(...) : String | Test.java:58:36:58:41 | result | provenance | Src:MaD:3  Sink:MaD:8 |
+| Test.java:64:5:64:13 | System.in : InputStream | Test.java:64:20:64:23 | data [post update] : byte[] | provenance | MaD:4 |
 | Test.java:64:20:64:23 | data [post update] : byte[] | Test.java:67:69:67:72 | data : byte[] | provenance |  |
 | Test.java:64:20:64:23 | data [post update] : byte[] | Test.java:70:49:70:52 | data : byte[] | provenance |  |
-| Test.java:67:56:67:73 | byteToString(...) : String | Test.java:67:26:67:80 | ... + ... | provenance |  Sink:MaD:43209 |
+| Test.java:67:56:67:73 | byteToString(...) : String | Test.java:67:26:67:80 | ... + ... | provenance |  Sink:MaD:7 |
 | Test.java:67:69:67:72 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
 | Test.java:67:69:67:72 | data : byte[] | Test.java:67:56:67:73 | byteToString(...) : String | provenance |  |
 | Test.java:70:49:70:52 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
-| Test.java:70:49:70:52 | data : byte[] | Test.java:70:36:70:53 | byteToString(...) | provenance |  Sink:MaD:43695 |
+| Test.java:70:49:70:52 | data : byte[] | Test.java:70:36:70:53 | byteToString(...) | provenance |  Sink:MaD:8 |
 nodes
 | Test.java:10:31:10:41 | data : byte[] | semmle.label | data : byte[] |
 | Test.java:11:12:11:51 | new String(...) : String | semmle.label | new String(...) : String |

--- a/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest4.ql
+++ b/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest4.ql
@@ -3,7 +3,9 @@
  */
 
 import Test
-import ThreatModel::PathGraph
+import codeql.dataflow.test.ProvenancePathGraph
+import semmle.code.java.dataflow.ExternalFlow
+import ShowProvenance<interpretModelForTest/2, ThreatModel::PathNode, ThreatModel::PathGraph>
 
 from ThreatModel::PathNode source, ThreatModel::PathNode sink
 where ThreatModel::flowPath(source, sink)

--- a/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest5.expected
+++ b/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest5.expected
@@ -1,24 +1,32 @@
+models
+| 1 | Sink: android.app; Activity; true; startActivityAsCaller; ; ; Argument[0]; intent-redirection; manual |
+| 1 | Source: testlib; TestSources; false; readEnv; (String); ; ReturnValue; environment; manual |
+| 2 | Summary: java.io; InputStream; true; read; (byte[]); ; Argument[this]; Argument[0]; taint; manual |
+| 3 | Summary: java.lang; String; false; String; ; ; Argument[0]; Argument[this]; taint; manual |
+| 4 | Source: java.net; Socket; false; getInputStream; (); ; ReturnValue; remote; manual |
+| 5 | Sink: java.sql; Statement; true; executeUpdate; ; ; Argument[0]; sql-injection; manual |
+| 6 | Sink: java.util.logging; Logger; true; severe; ; ; Argument[0]; log-injection; manual |
 edges
 | Test.java:10:31:10:41 | data : byte[] | Test.java:11:23:11:26 | data : byte[] | provenance |  |
-| Test.java:11:23:11:26 | data : byte[] | Test.java:11:12:11:51 | new String(...) : String | provenance | MaD:42745 |
-| Test.java:19:5:19:25 | getInputStream(...) : InputStream | Test.java:19:32:19:35 | data [post update] : byte[] | provenance | Src:MaD:42936 MaD:42629 |
+| Test.java:11:23:11:26 | data : byte[] | Test.java:11:12:11:51 | new String(...) : String | provenance | MaD:3 |
+| Test.java:19:5:19:25 | getInputStream(...) : InputStream | Test.java:19:32:19:35 | data [post update] : byte[] | provenance | Src:MaD:4 MaD:2 |
 | Test.java:19:32:19:35 | data [post update] : byte[] | Test.java:22:49:22:52 | data : byte[] | provenance |  |
 | Test.java:19:32:19:35 | data [post update] : byte[] | Test.java:25:69:25:72 | data : byte[] | provenance |  |
 | Test.java:22:49:22:52 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
-| Test.java:22:49:22:52 | data : byte[] | Test.java:22:36:22:53 | byteToString(...) | provenance |  Sink:MaD:43695 |
-| Test.java:25:56:25:73 | byteToString(...) : String | Test.java:25:26:25:80 | ... + ... | provenance |  Sink:MaD:43209 |
+| Test.java:22:49:22:52 | data : byte[] | Test.java:22:36:22:53 | byteToString(...) | provenance |  Sink:MaD:6 |
+| Test.java:25:56:25:73 | byteToString(...) : String | Test.java:25:26:25:80 | ... + ... | provenance |  Sink:MaD:5 |
 | Test.java:25:69:25:72 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
 | Test.java:25:69:25:72 | data : byte[] | Test.java:25:56:25:73 | byteToString(...) : String | provenance |  |
-| Test.java:41:21:41:49 | readEnv(...) : String | Test.java:44:26:44:68 | ... + ... | provenance | Src:MaD:3  Sink:MaD:43209 |
-| Test.java:41:21:41:49 | readEnv(...) : String | Test.java:47:36:47:41 | result | provenance | Src:MaD:3  Sink:MaD:43695 |
-| Test.java:64:5:64:13 | System.in : InputStream | Test.java:64:20:64:23 | data [post update] : byte[] | provenance | MaD:42629 |
+| Test.java:41:21:41:49 | readEnv(...) : String | Test.java:44:26:44:68 | ... + ... | provenance | Src:MaD:1  Sink:MaD:5 |
+| Test.java:41:21:41:49 | readEnv(...) : String | Test.java:47:36:47:41 | result | provenance | Src:MaD:1  Sink:MaD:6 |
+| Test.java:64:5:64:13 | System.in : InputStream | Test.java:64:20:64:23 | data [post update] : byte[] | provenance | MaD:2 |
 | Test.java:64:20:64:23 | data [post update] : byte[] | Test.java:67:69:67:72 | data : byte[] | provenance |  |
 | Test.java:64:20:64:23 | data [post update] : byte[] | Test.java:70:49:70:52 | data : byte[] | provenance |  |
-| Test.java:67:56:67:73 | byteToString(...) : String | Test.java:67:26:67:80 | ... + ... | provenance |  Sink:MaD:43209 |
+| Test.java:67:56:67:73 | byteToString(...) : String | Test.java:67:26:67:80 | ... + ... | provenance |  Sink:MaD:5 |
 | Test.java:67:69:67:72 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
 | Test.java:67:69:67:72 | data : byte[] | Test.java:67:56:67:73 | byteToString(...) : String | provenance |  |
 | Test.java:70:49:70:52 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
-| Test.java:70:49:70:52 | data : byte[] | Test.java:70:36:70:53 | byteToString(...) | provenance |  Sink:MaD:43695 |
+| Test.java:70:49:70:52 | data : byte[] | Test.java:70:36:70:53 | byteToString(...) | provenance |  Sink:MaD:6 |
 nodes
 | Test.java:10:31:10:41 | data : byte[] | semmle.label | data : byte[] |
 | Test.java:11:12:11:51 | new String(...) : String | semmle.label | new String(...) : String |

--- a/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest5.ql
+++ b/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest5.ql
@@ -4,7 +4,9 @@
  */
 
 import Test
-import ThreatModel::PathGraph
+import codeql.dataflow.test.ProvenancePathGraph
+import semmle.code.java.dataflow.ExternalFlow
+import ShowProvenance<interpretModelForTest/2, ThreatModel::PathNode, ThreatModel::PathGraph>
 
 from ThreatModel::PathNode source, ThreatModel::PathNode sink
 where ThreatModel::flowPath(source, sink)

--- a/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest6.expected
+++ b/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest6.expected
@@ -1,24 +1,32 @@
+models
+| 1 | Sink: android.app; Activity; true; setResult; (int,Intent); ; Argument[1]; pending-intents; manual |
+| 1 | Source: testlib; TestSources; false; executeQuery; (String); ; ReturnValue; database; manual |
+| 2 | Summary: java.io; InputStream; true; read; (byte[]); ; Argument[this]; Argument[0]; taint; manual |
+| 3 | Summary: java.lang; String; false; String; ; ; Argument[0]; Argument[this]; taint; manual |
+| 4 | Source: java.net; Socket; false; getInputStream; (); ; ReturnValue; remote; manual |
+| 5 | Sink: java.sql; Statement; true; executeUpdate; ; ; Argument[0]; sql-injection; manual |
+| 6 | Sink: java.util.logging; Logger; true; severe; ; ; Argument[0]; log-injection; manual |
 edges
 | Test.java:10:31:10:41 | data : byte[] | Test.java:11:23:11:26 | data : byte[] | provenance |  |
-| Test.java:11:23:11:26 | data : byte[] | Test.java:11:12:11:51 | new String(...) : String | provenance | MaD:42745 |
-| Test.java:19:5:19:25 | getInputStream(...) : InputStream | Test.java:19:32:19:35 | data [post update] : byte[] | provenance | Src:MaD:42936 MaD:42629 |
+| Test.java:11:23:11:26 | data : byte[] | Test.java:11:12:11:51 | new String(...) : String | provenance | MaD:3 |
+| Test.java:19:5:19:25 | getInputStream(...) : InputStream | Test.java:19:32:19:35 | data [post update] : byte[] | provenance | Src:MaD:4 MaD:2 |
 | Test.java:19:32:19:35 | data [post update] : byte[] | Test.java:22:49:22:52 | data : byte[] | provenance |  |
 | Test.java:19:32:19:35 | data [post update] : byte[] | Test.java:25:69:25:72 | data : byte[] | provenance |  |
 | Test.java:22:49:22:52 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
-| Test.java:22:49:22:52 | data : byte[] | Test.java:22:36:22:53 | byteToString(...) | provenance |  Sink:MaD:43695 |
-| Test.java:25:56:25:73 | byteToString(...) : String | Test.java:25:26:25:80 | ... + ... | provenance |  Sink:MaD:43209 |
+| Test.java:22:49:22:52 | data : byte[] | Test.java:22:36:22:53 | byteToString(...) | provenance |  Sink:MaD:6 |
+| Test.java:25:56:25:73 | byteToString(...) : String | Test.java:25:26:25:80 | ... + ... | provenance |  Sink:MaD:5 |
 | Test.java:25:69:25:72 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
 | Test.java:25:69:25:72 | data : byte[] | Test.java:25:56:25:73 | byteToString(...) : String | provenance |  |
-| Test.java:30:21:30:61 | executeQuery(...) : String | Test.java:33:26:33:68 | ... + ... | provenance | Src:MaD:2  Sink:MaD:43209 |
-| Test.java:30:21:30:61 | executeQuery(...) : String | Test.java:36:36:36:41 | result | provenance | Src:MaD:2  Sink:MaD:43695 |
-| Test.java:64:5:64:13 | System.in : InputStream | Test.java:64:20:64:23 | data [post update] : byte[] | provenance | MaD:42629 |
+| Test.java:30:21:30:61 | executeQuery(...) : String | Test.java:33:26:33:68 | ... + ... | provenance | Src:MaD:1  Sink:MaD:5 |
+| Test.java:30:21:30:61 | executeQuery(...) : String | Test.java:36:36:36:41 | result | provenance | Src:MaD:1  Sink:MaD:6 |
+| Test.java:64:5:64:13 | System.in : InputStream | Test.java:64:20:64:23 | data [post update] : byte[] | provenance | MaD:2 |
 | Test.java:64:20:64:23 | data [post update] : byte[] | Test.java:67:69:67:72 | data : byte[] | provenance |  |
 | Test.java:64:20:64:23 | data [post update] : byte[] | Test.java:70:49:70:52 | data : byte[] | provenance |  |
-| Test.java:67:56:67:73 | byteToString(...) : String | Test.java:67:26:67:80 | ... + ... | provenance |  Sink:MaD:43209 |
+| Test.java:67:56:67:73 | byteToString(...) : String | Test.java:67:26:67:80 | ... + ... | provenance |  Sink:MaD:5 |
 | Test.java:67:69:67:72 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
 | Test.java:67:69:67:72 | data : byte[] | Test.java:67:56:67:73 | byteToString(...) : String | provenance |  |
 | Test.java:70:49:70:52 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
-| Test.java:70:49:70:52 | data : byte[] | Test.java:70:36:70:53 | byteToString(...) | provenance |  Sink:MaD:43695 |
+| Test.java:70:49:70:52 | data : byte[] | Test.java:70:36:70:53 | byteToString(...) | provenance |  Sink:MaD:6 |
 nodes
 | Test.java:10:31:10:41 | data : byte[] | semmle.label | data : byte[] |
 | Test.java:11:12:11:51 | new String(...) : String | semmle.label | new String(...) : String |

--- a/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest6.ql
+++ b/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest6.ql
@@ -5,7 +5,9 @@
  */
 
 import Test
-import ThreatModel::PathGraph
+import codeql.dataflow.test.ProvenancePathGraph
+import semmle.code.java.dataflow.ExternalFlow
+import ShowProvenance<interpretModelForTest/2, ThreatModel::PathNode, ThreatModel::PathGraph>
 
 from ThreatModel::PathNode source, ThreatModel::PathNode sink
 where ThreatModel::flowPath(source, sink)


### PR DESCRIPTION
Adds support for post-process provenance pretty-printing in `.ql` library-tests.