### PR TITLE
Java: Fix FPs in `java/unused-reference-type` for JUnit 4-style tests

### DIFF
--- a/java/ql/src/Violations of Best Practice/Dead Code/DeadRefTypes.ql
+++ b/java/ql/src/Violations of Best Practice/Dead Code/DeadRefTypes.ql
@@ -49,6 +49,7 @@ predicate dead(RefType dead) {
   not dead instanceof AnonymousClass and
   // Exclude classes that look like they may be reflectively constructed.
   not dead.getAnAnnotation() instanceof ReflectiveAccessAnnotation and
+  not dead.getAMethod().getAnAnnotation() instanceof ReflectiveAccessAnnotation and
   // Insist all source ancestors are dead as well.
   forall(RefType t | t.fromSource() and t = getASuperTypePlus(dead) | dead(t)) and
   // Exclude compiler generated classes (e.g. declaring type of adapter functions in Kotlin)

--- a/java/ql/src/change-notes/2024-07-30-unused.md
+++ b/java/ql/src/change-notes/2024-07-30-unused.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The query "Unused classes and interfaces" (`java/unused-reference-type`) now recognizes that if a method of a class has an annotation then it may be accessed reflectively. This should remove false positive alerts, especially for JUnit 4-style tests annotated with `@test`.

--- a/java/ql/test/query-tests/DeadCode/DeadRefTypes/ClassWithAnnotatedMethod.java
+++ b/java/ql/test/query-tests/DeadCode/DeadRefTypes/ClassWithAnnotatedMethod.java
@@ -1,0 +1,4 @@
+class ClassWithAnnotatedMethod {
+    @MyAnnotation
+    void doNothing() { }
+}

--- a/java/ql/test/query-tests/DeadCode/DeadRefTypes/ClassWithAnnotation.java
+++ b/java/ql/test/query-tests/DeadCode/DeadRefTypes/ClassWithAnnotation.java
@@ -1,0 +1,3 @@
+@MyAnnotation
+class ClassWithAnnotation {
+}

--- a/java/ql/test/query-tests/DeadCode/DeadRefTypes/DeadRefTypes.expected
+++ b/java/ql/test/query-tests/DeadCode/DeadRefTypes/DeadRefTypes.expected
@@ -1,2 +1,1 @@
-| ClassWithAnnotatedMethod.java:1:7:1:30 | ClassWithAnnotatedMethod | Unused class: ClassWithAnnotatedMethod is not referenced within this codebase. If not used as an external API it should be removed. |
 | UnusedClass.java:1:7:1:17 | UnusedClass | Unused class: UnusedClass is not referenced within this codebase. If not used as an external API it should be removed. |

--- a/java/ql/test/query-tests/DeadCode/DeadRefTypes/DeadRefTypes.expected
+++ b/java/ql/test/query-tests/DeadCode/DeadRefTypes/DeadRefTypes.expected
@@ -1,0 +1,2 @@
+| ClassWithAnnotatedMethod.java:1:7:1:30 | ClassWithAnnotatedMethod | Unused class: ClassWithAnnotatedMethod is not referenced within this codebase. If not used as an external API it should be removed. |
+| UnusedClass.java:1:7:1:17 | UnusedClass | Unused class: UnusedClass is not referenced within this codebase. If not used as an external API it should be removed. |

--- a/java/ql/test/query-tests/DeadCode/DeadRefTypes/DeadRefTypes.qlref
+++ b/java/ql/test/query-tests/DeadCode/DeadRefTypes/DeadRefTypes.qlref
@@ -1,0 +1,1 @@
+Violations of Best Practice/Dead Code/DeadRefTypes.ql

--- a/java/ql/test/query-tests/DeadCode/DeadRefTypes/MyAnnotation.java
+++ b/java/ql/test/query-tests/DeadCode/DeadRefTypes/MyAnnotation.java
@@ -1,0 +1,2 @@
+public @interface MyAnnotation {
+}

--- a/java/ql/test/query-tests/DeadCode/DeadRefTypes/UnusedClass.java
+++ b/java/ql/test/query-tests/DeadCode/DeadRefTypes/UnusedClass.java
@@ -1,0 +1,1 @@
+class UnusedClass {}


### PR DESCRIPTION
This query didn't have any tests. I've added some basic ones just to make sure the PR does what it says it does.