### PR TITLE
Go: Fix missing `go-jose` package path

### DIFF
--- a/go/ql/lib/ext/github.com.go-jose.go-jose.jwt.model.yml
+++ b/go/ql/lib/ext/github.com.go-jose.go-jose.jwt.model.yml
@@ -3,9 +3,10 @@ extensions:
       pack: codeql/go-all
       extensible: packageGrouping
     data:
-      - ["go-jose/jwt", "github.com/go-jose/go-jose/jwt"]
       - ["go-jose/jwt", "gopkg.in/square/go-jose/jwt"]
+      - ["go-jose/jwt", "gopkg.in/go-jose/go-jose/jwt"]
       - ["go-jose/jwt", "github.com/square/go-jose/jwt"]
+      - ["go-jose/jwt", "github.com/go-jose/go-jose/jwt"]
   - addsTo:
       pack: codeql/go-all
       extensible: sinkModel

--- a/go/ql/lib/ext/github.com.go-jose.go-jose.model.yml
+++ b/go/ql/lib/ext/github.com.go-jose.go-jose.model.yml
@@ -3,9 +3,10 @@ extensions:
       pack: codeql/go-all
       extensible: packageGrouping
     data:
-      - ["go-jose", "github.com/go-jose/go-jose"]
       - ["go-jose", "gopkg.in/square/go-jose"]
+      - ["go-jose", "gopkg.in/go-jose/go-jose"]
       - ["go-jose", "github.com/square/go-jose"]
+      - ["go-jose", "github.com/go-jose/go-jose"]
   - addsTo:
       pack: codeql/go-all
       extensible: sinkModel

--- a/go/ql/lib/semmle/go/frameworks/GoJose.qll
+++ b/go/ql/lib/semmle/go/frameworks/GoJose.qll
@@ -1,6 +1,6 @@
 /**
- * Provides classes for working with the `github.com/square/go-jose`, `github.com/go-jose/go-jose`,
- * and `gopkg.in/square-go-jose.v2` packages.
+ * Provides classes for working with the `gopkg.in/square/go-jose` and `github.com/go-jose/go-jose`
+ * packages.
  */
 
 import go
@@ -22,9 +22,16 @@ private module GoJose {
       override int getTokenArgNum() { result = -1 }
     }
 
-    /** Gets the package names `gopkg.in/square/go-jose/jwt` and `github.com/go-jose/go-jose/jwt`. */
+    /**
+     * Gets the package names `gopkg.in/square/go-jose/jwt`, `gopkg.in/go-jose/go-jose/jwt`,
+     * `github.com/square/go-jose/jwt`, and `github.com/go-jose/go-jose/jwt`.
+     */
     private string goJoseJwtPackage() {
-      result = package(["gopkg.in/square/go-jose", "github.com/go-jose/go-jose"], "jwt")
+      result =
+        package([
+            "gopkg.in/square/go-jose", "gopkg.in/go-jose/go-jose", "github.com/square/go-jose",
+            "github.com/go-jose/go-jose"
+          ], "jwt")
     }
   }
 }

--- a/go/ql/lib/semmle/go/security/ExternalAPIs.qll
+++ b/go/ql/lib/semmle/go/security/ExternalAPIs.qll
@@ -36,7 +36,10 @@ private class DefaultSafeExternalApiFunction extends SafeExternalApiFunction {
   DefaultSafeExternalApiFunction() {
     this instanceof BuiltinFunction or
     isDefaultSafePackage(this.getPackage()) or
-    this.hasQualifiedName(package("gopkg.in/square/go-jose", "jwt"), "ParseSigned") or
+    this.hasQualifiedName(package([
+          "gopkg.in/square/go-jose", "gopkg.in/go-jose/go-jose", "github.com/square/go-jose",
+          "github.com/go-jose/go-jose"
+        ], "jwt"), "ParseSigned") or
     this.(Method).hasQualifiedName(Gorm::packagePath(), "DB", "Update") or
     this.hasQualifiedName("crypto/hmac", "Equal") or
     this.hasQualifiedName("crypto/subtle", "ConstantTimeCompare") or

--- a/go/ql/src/experimental/frameworks/JWT.qll
+++ b/go/ql/src/experimental/frameworks/JWT.qll
@@ -172,7 +172,11 @@ class GolangJwtParseFromRequestWithClaims extends JwtParseWithKeyFunction {
  * Gets `gopkg.in/square/go-jose` and `github.com/go-jose/go-jose` jwt package
  */
 string goJoseJwtPackage() {
-  result = package(["gopkg.in/square/go-jose", "github.com/go-jose/go-jose"], "jwt")
+  result =
+    package([
+        "gopkg.in/square/go-jose", "gopkg.in/go-jose/go-jose", "github.com/square/go-jose",
+        "github.com/go-jose/go-jose"
+      ], "jwt")
 }
 
 /**

--- a/go/ql/test/library-tests/semmle/go/frameworks/Beego/ReflectedXss.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Beego/ReflectedXss.expected
@@ -34,11 +34,11 @@ edges
 | test.go:205:21:205:58 | call to Substr | test.go:205:14:205:59 | type conversion | provenance |  |
 | test.go:205:34:205:51 | type assertion | test.go:205:21:205:58 | call to Substr | provenance | MaD:315 |
 | test.go:207:6:207:6 | definition of s | test.go:209:14:209:28 | type conversion | provenance |  |
-| test.go:208:18:208:33 | selection of Form | test.go:207:6:207:6 | definition of s | provenance | Src:MaD:865 MaD:313 |
+| test.go:208:18:208:33 | selection of Form | test.go:207:6:207:6 | definition of s | provenance | Src:MaD:867 MaD:313 |
 | test.go:223:2:223:34 | ... := ...[0] | test.go:225:31:225:31 | f | provenance | Src:MaD:317  |
 | test.go:223:2:223:34 | ... := ...[1] | test.go:224:14:224:32 | type conversion | provenance | Src:MaD:317  |
 | test.go:225:2:225:32 | ... := ...[0] | test.go:226:14:226:20 | content | provenance |  |
-| test.go:225:31:225:31 | f | test.go:225:2:225:32 | ... := ...[0] | provenance | MaD:728 |
+| test.go:225:31:225:31 | f | test.go:225:2:225:32 | ... := ...[0] | provenance | MaD:730 |
 | test.go:228:2:228:40 | ... := ...[0] | test.go:229:14:229:38 | type conversion | provenance | Src:MaD:318  |
 | test.go:231:7:231:28 | call to GetString | test.go:232:14:232:22 | type conversion | provenance | Src:MaD:319  |
 | test.go:234:8:234:35 | call to GetStrings | test.go:235:14:235:26 | type conversion | provenance | Src:MaD:320  |

--- a/go/ql/test/library-tests/semmle/go/frameworks/Revel/OpenRedirect.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Revel/OpenRedirect.expected
@@ -1,8 +1,8 @@
 edges
 | EndToEnd.go:94:20:94:27 | implicit dereference | EndToEnd.go:94:20:94:27 | selection of Params | provenance | Config |
 | EndToEnd.go:94:20:94:27 | implicit dereference | EndToEnd.go:94:20:94:32 | selection of Form | provenance | Config |
-| EndToEnd.go:94:20:94:27 | selection of Params | EndToEnd.go:94:20:94:27 | implicit dereference | provenance | Src:MaD:523 Config |
-| EndToEnd.go:94:20:94:27 | selection of Params | EndToEnd.go:94:20:94:32 | selection of Form | provenance | Src:MaD:523 Config |
+| EndToEnd.go:94:20:94:27 | selection of Params | EndToEnd.go:94:20:94:27 | implicit dereference | provenance | Src:MaD:525 Config |
+| EndToEnd.go:94:20:94:27 | selection of Params | EndToEnd.go:94:20:94:32 | selection of Form | provenance | Src:MaD:525 Config |
 | EndToEnd.go:94:20:94:32 | selection of Form | EndToEnd.go:94:20:94:49 | call to Get | provenance | Config |
 nodes
 | EndToEnd.go:94:20:94:27 | implicit dereference | semmle.label | implicit dereference |

--- a/go/ql/test/library-tests/semmle/go/frameworks/Revel/ReflectedXss.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Revel/ReflectedXss.expected
@@ -1,13 +1,13 @@
 edges
 | EndToEnd.go:35:2:35:4 | definition of buf | EndToEnd.go:37:24:37:26 | buf | provenance |  |
-| EndToEnd.go:36:18:36:25 | selection of Params | EndToEnd.go:36:18:36:30 | selection of Form | provenance | Src:MaD:523  |
-| EndToEnd.go:36:18:36:30 | selection of Form | EndToEnd.go:36:18:36:47 | call to Get | provenance | MaD:938 |
-| EndToEnd.go:36:18:36:47 | call to Get | EndToEnd.go:35:2:35:4 | definition of buf | provenance | MaD:744 |
-| EndToEnd.go:69:22:69:29 | selection of Params | EndToEnd.go:69:22:69:34 | selection of Form | provenance | Src:MaD:523  |
-| EndToEnd.go:69:22:69:34 | selection of Form | EndToEnd.go:69:22:69:51 | call to Get | provenance | MaD:938 |
-| Revel.go:70:22:70:29 | selection of Params | Revel.go:70:22:70:35 | selection of Query | provenance | Src:MaD:523  |
-| examples/booking/app/init.go:36:44:36:48 | selection of URL | examples/booking/app/init.go:36:44:36:53 | selection of Path | provenance | Src:MaD:870  |
-| examples/booking/app/init.go:40:49:40:53 | selection of URL | examples/booking/app/init.go:40:49:40:58 | selection of Path | provenance | Src:MaD:870  |
+| EndToEnd.go:36:18:36:25 | selection of Params | EndToEnd.go:36:18:36:30 | selection of Form | provenance | Src:MaD:525  |
+| EndToEnd.go:36:18:36:30 | selection of Form | EndToEnd.go:36:18:36:47 | call to Get | provenance | MaD:940 |
+| EndToEnd.go:36:18:36:47 | call to Get | EndToEnd.go:35:2:35:4 | definition of buf | provenance | MaD:746 |
+| EndToEnd.go:69:22:69:29 | selection of Params | EndToEnd.go:69:22:69:34 | selection of Form | provenance | Src:MaD:525  |
+| EndToEnd.go:69:22:69:34 | selection of Form | EndToEnd.go:69:22:69:51 | call to Get | provenance | MaD:940 |
+| Revel.go:70:22:70:29 | selection of Params | Revel.go:70:22:70:35 | selection of Query | provenance | Src:MaD:525  |
+| examples/booking/app/init.go:36:44:36:48 | selection of URL | examples/booking/app/init.go:36:44:36:53 | selection of Path | provenance | Src:MaD:872  |
+| examples/booking/app/init.go:40:49:40:53 | selection of URL | examples/booking/app/init.go:40:49:40:58 | selection of Path | provenance | Src:MaD:872  |
 nodes
 | EndToEnd.go:35:2:35:4 | definition of buf | semmle.label | definition of buf |
 | EndToEnd.go:36:18:36:25 | selection of Params | semmle.label | selection of Params |

--- a/go/ql/test/library-tests/semmle/go/frameworks/Revel/TaintedPath.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Revel/TaintedPath.expected
@@ -1,8 +1,8 @@
 edges
-| EndToEnd.go:58:18:58:25 | selection of Params | EndToEnd.go:58:18:58:30 | selection of Form | provenance | Src:MaD:523  |
-| EndToEnd.go:58:18:58:30 | selection of Form | EndToEnd.go:58:18:58:47 | call to Get | provenance | MaD:938 |
-| EndToEnd.go:64:26:64:33 | selection of Params | EndToEnd.go:64:26:64:38 | selection of Form | provenance | Src:MaD:523  |
-| EndToEnd.go:64:26:64:38 | selection of Form | EndToEnd.go:64:26:64:55 | call to Get | provenance | MaD:938 |
+| EndToEnd.go:58:18:58:25 | selection of Params | EndToEnd.go:58:18:58:30 | selection of Form | provenance | Src:MaD:525  |
+| EndToEnd.go:58:18:58:30 | selection of Form | EndToEnd.go:58:18:58:47 | call to Get | provenance | MaD:940 |
+| EndToEnd.go:64:26:64:33 | selection of Params | EndToEnd.go:64:26:64:38 | selection of Form | provenance | Src:MaD:525  |
+| EndToEnd.go:64:26:64:38 | selection of Form | EndToEnd.go:64:26:64:55 | call to Get | provenance | MaD:940 |
 nodes
 | EndToEnd.go:58:18:58:25 | selection of Params | semmle.label | selection of Params |
 | EndToEnd.go:58:18:58:30 | selection of Form | semmle.label | selection of Form |

--- a/go/ql/test/query-tests/Security/CWE-347/MissingJwtSignatureCheck.expected
+++ b/go/ql/test/query-tests/Security/CWE-347/MissingJwtSignatureCheck.expected
@@ -1,16 +1,16 @@
 edges
-| go-jose.v3.go:25:16:25:20 | selection of URL | go-jose.v3.go:25:16:25:28 | call to Query | provenance | Src:MaD:870 MaD:931 |
-| go-jose.v3.go:25:16:25:28 | call to Query | go-jose.v3.go:25:16:25:47 | call to Get | provenance | MaD:938 |
+| go-jose.v3.go:25:16:25:20 | selection of URL | go-jose.v3.go:25:16:25:28 | call to Query | provenance | Src:MaD:872 MaD:933 |
+| go-jose.v3.go:25:16:25:28 | call to Query | go-jose.v3.go:25:16:25:47 | call to Get | provenance | MaD:940 |
 | go-jose.v3.go:25:16:25:47 | call to Get | go-jose.v3.go:26:15:26:25 | signedToken | provenance |  |
 | go-jose.v3.go:26:15:26:25 | signedToken | go-jose.v3.go:29:19:29:29 | definition of signedToken | provenance |  |
 | go-jose.v3.go:29:19:29:29 | definition of signedToken | go-jose.v3.go:31:37:31:47 | signedToken | provenance |  |
-| go-jose.v3.go:31:2:31:48 | ... := ...[0] | go-jose.v3.go:33:12:33:23 | DecodedToken | provenance |  Sink:MaD:439 |
-| go-jose.v3.go:31:37:31:47 | signedToken | go-jose.v3.go:31:2:31:48 | ... := ...[0] | provenance | MaD:441 |
-| golang-jwt-v5.go:28:16:28:20 | selection of URL | golang-jwt-v5.go:28:16:28:28 | call to Query | provenance | Src:MaD:870 MaD:931 |
-| golang-jwt-v5.go:28:16:28:28 | call to Query | golang-jwt-v5.go:28:16:28:47 | call to Get | provenance | MaD:938 |
+| go-jose.v3.go:31:2:31:48 | ... := ...[0] | go-jose.v3.go:33:12:33:23 | DecodedToken | provenance |  Sink:MaD:440 |
+| go-jose.v3.go:31:37:31:47 | signedToken | go-jose.v3.go:31:2:31:48 | ... := ...[0] | provenance | MaD:442 |
+| golang-jwt-v5.go:28:16:28:20 | selection of URL | golang-jwt-v5.go:28:16:28:28 | call to Query | provenance | Src:MaD:872 MaD:933 |
+| golang-jwt-v5.go:28:16:28:28 | call to Query | golang-jwt-v5.go:28:16:28:47 | call to Get | provenance | MaD:940 |
 | golang-jwt-v5.go:28:16:28:47 | call to Get | golang-jwt-v5.go:29:25:29:35 | signedToken | provenance |  |
 | golang-jwt-v5.go:29:25:29:35 | signedToken | golang-jwt-v5.go:32:29:32:39 | definition of signedToken | provenance |  |
-| golang-jwt-v5.go:32:29:32:39 | definition of signedToken | golang-jwt-v5.go:34:58:34:68 | signedToken | provenance |  Sink:MaD:463 |
+| golang-jwt-v5.go:32:29:32:39 | definition of signedToken | golang-jwt-v5.go:34:58:34:68 | signedToken | provenance |  Sink:MaD:465 |
 nodes
 | go-jose.v3.go:25:16:25:20 | selection of URL | semmle.label | selection of URL |
 | go-jose.v3.go:25:16:25:28 | call to Query | semmle.label | call to Query |


### PR DESCRIPTION
It has had quite a few different import paths in the past.