### PR TITLE
Dataflow: Propagate provenance correctly for flow-through wrappers.

### DIFF
--- a/csharp/ql/test/library-tests/dataflow/async/Async.expected
+++ b/csharp/ql/test/library-tests/dataflow/async/Async.expected
@@ -25,7 +25,7 @@ edges
 | Async.cs:38:16:38:16 | access to parameter x : String | Async.cs:26:23:26:40 | call to method ReturnAwait : Task<String> [property Result] : String | provenance |  |
 | Async.cs:41:33:41:37 | input : String | Async.cs:43:25:43:29 | access to parameter input : String | provenance |  |
 | Async.cs:43:14:43:30 | call to method ReturnTask : Task<T> [property Result] : String | Async.cs:43:14:43:37 | access to property Result | provenance |  |
-| Async.cs:43:25:43:29 | access to parameter input : String | Async.cs:43:14:43:30 | call to method ReturnTask : Task<T> [property Result] : String | provenance |  |
+| Async.cs:43:25:43:29 | access to parameter input : String | Async.cs:43:14:43:30 | call to method ReturnTask : Task<T> [property Result] : String | provenance | MaD:2002 |
 | Async.cs:43:25:43:29 | access to parameter input : String | Async.cs:46:44:46:44 | x : String | provenance |  |
 | Async.cs:46:44:46:44 | x : String | Async.cs:48:32:48:32 | access to parameter x : String | provenance |  |
 | Async.cs:46:44:46:44 | x : String | Async.cs:48:32:48:32 | access to parameter x : String | provenance |  |

--- a/csharp/ql/test/library-tests/dataflow/collections/CollectionFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/collections/CollectionFlow.expected
@@ -24,11 +24,21 @@ edges
 | CollectionFlow.cs:28:68:28:79 | call to method First<KeyValuePair<Int32,T>> : KeyValuePair<Int32,T> [property Value] : A | CollectionFlow.cs:28:68:28:85 | access to property Value : A | provenance |  |
 | CollectionFlow.cs:30:60:30:63 | dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:30:69:30:72 | access to parameter dict : Dictionary<T,T> [element, property Value] : A | provenance |  |
 | CollectionFlow.cs:30:69:30:72 | access to parameter dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:30:69:30:79 | access to property Values : ICollection<T> [element] : A | provenance | MaD:601 |
+| CollectionFlow.cs:30:69:30:72 | access to parameter dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:30:69:30:79 | access to property Values : ICollection<T> [element] : A | provenance | MaD:601 |
 | CollectionFlow.cs:30:69:30:72 | access to parameter dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:30:69:30:79 | access to property Values : ICollection<T> [element] : A | provenance | MaD:612 |
+| CollectionFlow.cs:30:69:30:72 | access to parameter dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:30:69:30:79 | access to property Values : ICollection<T> [element] : A | provenance | MaD:612 |
+| CollectionFlow.cs:30:69:30:79 | access to property Values : ICollection<T> [element] : A | CollectionFlow.cs:30:69:30:87 | call to method First<T> : A | provenance | MaD:1211 |
+| CollectionFlow.cs:30:69:30:79 | access to property Values : ICollection<T> [element] : A | CollectionFlow.cs:30:69:30:87 | call to method First<T> : A | provenance | MaD:1211 |
+| CollectionFlow.cs:30:69:30:79 | access to property Values : ICollection<T> [element] : A | CollectionFlow.cs:30:69:30:87 | call to method First<T> : A | provenance | MaD:1211 |
 | CollectionFlow.cs:30:69:30:79 | access to property Values : ICollection<T> [element] : A | CollectionFlow.cs:30:69:30:87 | call to method First<T> : A | provenance | MaD:1211 |
 | CollectionFlow.cs:32:58:32:61 | dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:32:67:32:70 | access to parameter dict : Dictionary<T,T> [element, property Key] : A | provenance |  |
 | CollectionFlow.cs:32:67:32:70 | access to parameter dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:32:67:32:75 | access to property Keys : ICollection<T> [element] : A | provenance | MaD:600 |
+| CollectionFlow.cs:32:67:32:70 | access to parameter dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:32:67:32:75 | access to property Keys : ICollection<T> [element] : A | provenance | MaD:600 |
 | CollectionFlow.cs:32:67:32:70 | access to parameter dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:32:67:32:75 | access to property Keys : ICollection<T> [element] : A | provenance | MaD:611 |
+| CollectionFlow.cs:32:67:32:70 | access to parameter dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:32:67:32:75 | access to property Keys : ICollection<T> [element] : A | provenance | MaD:611 |
+| CollectionFlow.cs:32:67:32:75 | access to property Keys : ICollection<T> [element] : A | CollectionFlow.cs:32:67:32:83 | call to method First<T> : A | provenance | MaD:1211 |
+| CollectionFlow.cs:32:67:32:75 | access to property Keys : ICollection<T> [element] : A | CollectionFlow.cs:32:67:32:83 | call to method First<T> : A | provenance | MaD:1211 |
+| CollectionFlow.cs:32:67:32:75 | access to property Keys : ICollection<T> [element] : A | CollectionFlow.cs:32:67:32:83 | call to method First<T> : A | provenance | MaD:1211 |
 | CollectionFlow.cs:32:67:32:75 | access to property Keys : ICollection<T> [element] : A | CollectionFlow.cs:32:67:32:83 | call to method First<T> : A | provenance | MaD:1211 |
 | CollectionFlow.cs:34:57:34:60 | dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:34:66:34:69 | access to parameter dict : Dictionary<T,T> [element, property Key] : A | provenance |  |
 | CollectionFlow.cs:34:66:34:69 | access to parameter dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:34:66:34:77 | call to method First<KeyValuePair<T,Int32>> : KeyValuePair<T,Int32> [property Key] : A | provenance | MaD:1211 |
@@ -82,7 +92,7 @@ edges
 | CollectionFlow.cs:99:14:99:17 | access to local variable list : List<T> [element] : A | CollectionFlow.cs:99:14:99:20 | access to indexer | provenance | MaD:617 |
 | CollectionFlow.cs:100:22:100:25 | access to local variable list : List<T> [element] : A | CollectionFlow.cs:16:49:16:52 | list : List<T> [element] : A | provenance |  |
 | CollectionFlow.cs:101:24:101:27 | access to local variable list : List<T> [element] : A | CollectionFlow.cs:24:43:24:46 | list : List<T> [element] : A | provenance |  |
-| CollectionFlow.cs:101:24:101:27 | access to local variable list : List<T> [element] : A | CollectionFlow.cs:101:14:101:28 | call to method ListFirst<A> | provenance |  |
+| CollectionFlow.cs:101:24:101:27 | access to local variable list : List<T> [element] : A | CollectionFlow.cs:101:14:101:28 | call to method ListFirst<A> | provenance | MaD:617 |
 | CollectionFlow.cs:115:13:115:13 | access to local variable a : A | CollectionFlow.cs:116:36:116:36 | access to local variable a : A | provenance |  |
 | CollectionFlow.cs:115:17:115:23 | object creation of type A : A | CollectionFlow.cs:115:13:115:13 | access to local variable a : A | provenance |  |
 | CollectionFlow.cs:116:13:116:16 | access to local variable list : List<T> [element] : A | CollectionFlow.cs:117:14:117:17 | access to local variable list : List<T> [element] : A | provenance |  |
@@ -93,7 +103,7 @@ edges
 | CollectionFlow.cs:117:14:117:17 | access to local variable list : List<T> [element] : A | CollectionFlow.cs:117:14:117:20 | access to indexer | provenance | MaD:617 |
 | CollectionFlow.cs:118:22:118:25 | access to local variable list : List<T> [element] : A | CollectionFlow.cs:16:49:16:52 | list : List<T> [element] : A | provenance |  |
 | CollectionFlow.cs:119:24:119:27 | access to local variable list : List<T> [element] : A | CollectionFlow.cs:24:43:24:46 | list : List<T> [element] : A | provenance |  |
-| CollectionFlow.cs:119:24:119:27 | access to local variable list : List<T> [element] : A | CollectionFlow.cs:119:14:119:28 | call to method ListFirst<A> | provenance |  |
+| CollectionFlow.cs:119:24:119:27 | access to local variable list : List<T> [element] : A | CollectionFlow.cs:119:14:119:28 | call to method ListFirst<A> | provenance | MaD:617 |
 | CollectionFlow.cs:132:13:132:13 | access to local variable a : A | CollectionFlow.cs:134:18:134:18 | access to local variable a : A | provenance |  |
 | CollectionFlow.cs:132:17:132:23 | object creation of type A : A | CollectionFlow.cs:132:13:132:13 | access to local variable a : A | provenance |  |
 | CollectionFlow.cs:134:9:134:12 | [post] access to local variable list : List<T> [element] : A | CollectionFlow.cs:135:14:135:17 | access to local variable list : List<T> [element] : A | provenance |  |
@@ -103,7 +113,7 @@ edges
 | CollectionFlow.cs:135:14:135:17 | access to local variable list : List<T> [element] : A | CollectionFlow.cs:135:14:135:20 | access to indexer | provenance | MaD:617 |
 | CollectionFlow.cs:136:22:136:25 | access to local variable list : List<T> [element] : A | CollectionFlow.cs:16:49:16:52 | list : List<T> [element] : A | provenance |  |
 | CollectionFlow.cs:137:24:137:27 | access to local variable list : List<T> [element] : A | CollectionFlow.cs:24:43:24:46 | list : List<T> [element] : A | provenance |  |
-| CollectionFlow.cs:137:24:137:27 | access to local variable list : List<T> [element] : A | CollectionFlow.cs:137:14:137:28 | call to method ListFirst<A> | provenance |  |
+| CollectionFlow.cs:137:24:137:27 | access to local variable list : List<T> [element] : A | CollectionFlow.cs:137:14:137:28 | call to method ListFirst<A> | provenance | MaD:617 |
 | CollectionFlow.cs:151:13:151:13 | access to local variable a : A | CollectionFlow.cs:153:19:153:19 | access to local variable a : A | provenance |  |
 | CollectionFlow.cs:151:17:151:23 | object creation of type A : A | CollectionFlow.cs:151:13:151:13 | access to local variable a : A | provenance |  |
 | CollectionFlow.cs:153:9:153:12 | [post] access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:154:14:154:17 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | provenance |  |
@@ -115,11 +125,12 @@ edges
 | CollectionFlow.cs:154:14:154:17 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:154:14:154:20 | access to indexer | provenance | MaD:610 |
 | CollectionFlow.cs:155:23:155:26 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:18:61:18:64 | dict : Dictionary<T,T> [element, property Value] : A | provenance |  |
 | CollectionFlow.cs:156:28:156:31 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:26:58:26:61 | dict : Dictionary<T,T> [element, property Value] : A | provenance |  |
-| CollectionFlow.cs:156:28:156:31 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:156:14:156:32 | call to method DictIndexZero<A> | provenance |  |
+| CollectionFlow.cs:156:28:156:31 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:156:14:156:32 | call to method DictIndexZero<A> | provenance | MaD:610 |
 | CollectionFlow.cs:157:29:157:32 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:28:59:28:62 | dict : Dictionary<T,T> [element, property Value] : A | provenance |  |
-| CollectionFlow.cs:157:29:157:32 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:157:14:157:33 | call to method DictFirstValue<A> | provenance |  |
+| CollectionFlow.cs:157:29:157:32 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:157:14:157:33 | call to method DictFirstValue<A> | provenance | MaD:1211 |
 | CollectionFlow.cs:158:30:158:33 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:30:60:30:63 | dict : Dictionary<T,T> [element, property Value] : A | provenance |  |
-| CollectionFlow.cs:158:30:158:33 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:158:14:158:34 | call to method DictValuesFirst<A> | provenance |  |
+| CollectionFlow.cs:158:30:158:33 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:158:14:158:34 | call to method DictValuesFirst<A> | provenance | MaD:601 |
+| CollectionFlow.cs:158:30:158:33 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:158:14:158:34 | call to method DictValuesFirst<A> | provenance | MaD:612 |
 | CollectionFlow.cs:174:13:174:13 | access to local variable a : A | CollectionFlow.cs:175:52:175:52 | access to local variable a : A | provenance |  |
 | CollectionFlow.cs:174:17:174:23 | object creation of type A : A | CollectionFlow.cs:174:13:174:13 | access to local variable a : A | provenance |  |
 | CollectionFlow.cs:175:13:175:16 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:176:14:176:17 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | provenance |  |
@@ -132,11 +143,12 @@ edges
 | CollectionFlow.cs:176:14:176:17 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:176:14:176:20 | access to indexer | provenance | MaD:610 |
 | CollectionFlow.cs:177:23:177:26 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:18:61:18:64 | dict : Dictionary<T,T> [element, property Value] : A | provenance |  |
 | CollectionFlow.cs:178:28:178:31 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:26:58:26:61 | dict : Dictionary<T,T> [element, property Value] : A | provenance |  |
-| CollectionFlow.cs:178:28:178:31 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:178:14:178:32 | call to method DictIndexZero<A> | provenance |  |
+| CollectionFlow.cs:178:28:178:31 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:178:14:178:32 | call to method DictIndexZero<A> | provenance | MaD:610 |
 | CollectionFlow.cs:179:29:179:32 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:28:59:28:62 | dict : Dictionary<T,T> [element, property Value] : A | provenance |  |
-| CollectionFlow.cs:179:29:179:32 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:179:14:179:33 | call to method DictFirstValue<A> | provenance |  |
+| CollectionFlow.cs:179:29:179:32 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:179:14:179:33 | call to method DictFirstValue<A> | provenance | MaD:1211 |
 | CollectionFlow.cs:180:30:180:33 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:30:60:30:63 | dict : Dictionary<T,T> [element, property Value] : A | provenance |  |
-| CollectionFlow.cs:180:30:180:33 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:180:14:180:34 | call to method DictValuesFirst<A> | provenance |  |
+| CollectionFlow.cs:180:30:180:33 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:180:14:180:34 | call to method DictValuesFirst<A> | provenance | MaD:601 |
+| CollectionFlow.cs:180:30:180:33 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:180:14:180:34 | call to method DictValuesFirst<A> | provenance | MaD:612 |
 | CollectionFlow.cs:195:13:195:13 | access to local variable a : A | CollectionFlow.cs:196:53:196:53 | access to local variable a : A | provenance |  |
 | CollectionFlow.cs:195:17:195:23 | object creation of type A : A | CollectionFlow.cs:195:13:195:13 | access to local variable a : A | provenance |  |
 | CollectionFlow.cs:196:13:196:16 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:197:14:197:17 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | provenance |  |
@@ -149,11 +161,12 @@ edges
 | CollectionFlow.cs:197:14:197:17 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:197:14:197:20 | access to indexer | provenance | MaD:610 |
 | CollectionFlow.cs:198:23:198:26 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:18:61:18:64 | dict : Dictionary<T,T> [element, property Value] : A | provenance |  |
 | CollectionFlow.cs:199:28:199:31 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:26:58:26:61 | dict : Dictionary<T,T> [element, property Value] : A | provenance |  |
-| CollectionFlow.cs:199:28:199:31 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:199:14:199:32 | call to method DictIndexZero<A> | provenance |  |
+| CollectionFlow.cs:199:28:199:31 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:199:14:199:32 | call to method DictIndexZero<A> | provenance | MaD:610 |
 | CollectionFlow.cs:200:29:200:32 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:28:59:28:62 | dict : Dictionary<T,T> [element, property Value] : A | provenance |  |
-| CollectionFlow.cs:200:29:200:32 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:200:14:200:33 | call to method DictFirstValue<A> | provenance |  |
+| CollectionFlow.cs:200:29:200:32 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:200:14:200:33 | call to method DictFirstValue<A> | provenance | MaD:1211 |
 | CollectionFlow.cs:201:30:201:33 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:30:60:30:63 | dict : Dictionary<T,T> [element, property Value] : A | provenance |  |
-| CollectionFlow.cs:201:30:201:33 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:201:14:201:34 | call to method DictValuesFirst<A> | provenance |  |
+| CollectionFlow.cs:201:30:201:33 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:201:14:201:34 | call to method DictValuesFirst<A> | provenance | MaD:601 |
+| CollectionFlow.cs:201:30:201:33 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:201:14:201:34 | call to method DictValuesFirst<A> | provenance | MaD:612 |
 | CollectionFlow.cs:217:13:217:13 | access to local variable a : A | CollectionFlow.cs:218:49:218:49 | access to local variable a : A | provenance |  |
 | CollectionFlow.cs:217:17:217:23 | object creation of type A : A | CollectionFlow.cs:217:13:217:13 | access to local variable a : A | provenance |  |
 | CollectionFlow.cs:218:13:218:16 | access to local variable dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:219:14:219:17 | access to local variable dict : Dictionary<T,T> [element, property Key] : A | provenance |  |
@@ -166,9 +179,10 @@ edges
 | CollectionFlow.cs:219:14:219:22 | access to property Keys : Dictionary<T,T>.KeyCollection [element] : A | CollectionFlow.cs:219:14:219:30 | call to method First<A> | provenance | MaD:1211 |
 | CollectionFlow.cs:220:21:220:24 | access to local variable dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:20:59:20:62 | dict : Dictionary<T,T> [element, property Key] : A | provenance |  |
 | CollectionFlow.cs:221:28:221:31 | access to local variable dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:32:58:32:61 | dict : Dictionary<T,T> [element, property Key] : A | provenance |  |
-| CollectionFlow.cs:221:28:221:31 | access to local variable dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:221:14:221:32 | call to method DictKeysFirst<A> | provenance |  |
+| CollectionFlow.cs:221:28:221:31 | access to local variable dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:221:14:221:32 | call to method DictKeysFirst<A> | provenance | MaD:600 |
+| CollectionFlow.cs:221:28:221:31 | access to local variable dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:221:14:221:32 | call to method DictKeysFirst<A> | provenance | MaD:611 |
 | CollectionFlow.cs:222:27:222:30 | access to local variable dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:34:57:34:60 | dict : Dictionary<T,T> [element, property Key] : A | provenance |  |
-| CollectionFlow.cs:222:27:222:30 | access to local variable dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:222:14:222:31 | call to method DictFirstKey<A> | provenance |  |
+| CollectionFlow.cs:222:27:222:30 | access to local variable dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:222:14:222:31 | call to method DictFirstKey<A> | provenance | MaD:1211 |
 | CollectionFlow.cs:236:13:236:13 | access to local variable a : A | CollectionFlow.cs:237:48:237:48 | access to local variable a : A | provenance |  |
 | CollectionFlow.cs:236:17:236:23 | object creation of type A : A | CollectionFlow.cs:236:13:236:13 | access to local variable a : A | provenance |  |
 | CollectionFlow.cs:237:13:237:16 | access to local variable dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:238:14:238:17 | access to local variable dict : Dictionary<T,T> [element, property Key] : A | provenance |  |
@@ -181,9 +195,10 @@ edges
 | CollectionFlow.cs:238:14:238:22 | access to property Keys : Dictionary<T,T>.KeyCollection [element] : A | CollectionFlow.cs:238:14:238:30 | call to method First<A> | provenance | MaD:1211 |
 | CollectionFlow.cs:239:21:239:24 | access to local variable dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:20:59:20:62 | dict : Dictionary<T,T> [element, property Key] : A | provenance |  |
 | CollectionFlow.cs:240:28:240:31 | access to local variable dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:32:58:32:61 | dict : Dictionary<T,T> [element, property Key] : A | provenance |  |
-| CollectionFlow.cs:240:28:240:31 | access to local variable dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:240:14:240:32 | call to method DictKeysFirst<A> | provenance |  |
+| CollectionFlow.cs:240:28:240:31 | access to local variable dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:240:14:240:32 | call to method DictKeysFirst<A> | provenance | MaD:600 |
+| CollectionFlow.cs:240:28:240:31 | access to local variable dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:240:14:240:32 | call to method DictKeysFirst<A> | provenance | MaD:611 |
 | CollectionFlow.cs:241:27:241:30 | access to local variable dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:34:57:34:60 | dict : Dictionary<T,T> [element, property Key] : A | provenance |  |
-| CollectionFlow.cs:241:27:241:30 | access to local variable dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:241:14:241:31 | call to method DictFirstKey<A> | provenance |  |
+| CollectionFlow.cs:241:27:241:30 | access to local variable dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:241:14:241:31 | call to method DictFirstKey<A> | provenance | MaD:1211 |
 | CollectionFlow.cs:255:13:255:13 | access to local variable a : A | CollectionFlow.cs:256:27:256:27 | access to local variable a : A | provenance |  |
 | CollectionFlow.cs:255:17:255:23 | object creation of type A : A | CollectionFlow.cs:255:13:255:13 | access to local variable a : A | provenance |  |
 | CollectionFlow.cs:256:13:256:15 | access to local variable as : null [element] : A | CollectionFlow.cs:257:27:257:29 | access to local variable as : null [element] : A | provenance |  |
@@ -238,11 +253,11 @@ edges
 | CollectionFlow.cs:356:17:356:20 | [post] access to local variable list : List<T> [element] : A | CollectionFlow.cs:358:22:358:25 | access to local variable list : List<T> [element] : A | provenance |  |
 | CollectionFlow.cs:356:17:356:20 | [post] access to local variable list : List<T> [element] : A | CollectionFlow.cs:359:24:359:27 | access to local variable list : List<T> [element] : A | provenance |  |
 | CollectionFlow.cs:356:23:356:23 | access to local variable a : A | CollectionFlow.cs:350:34:350:40 | element : A | provenance |  |
-| CollectionFlow.cs:356:23:356:23 | access to local variable a : A | CollectionFlow.cs:356:17:356:20 | [post] access to local variable list : List<T> [element] : A | provenance |  |
+| CollectionFlow.cs:356:23:356:23 | access to local variable a : A | CollectionFlow.cs:356:17:356:20 | [post] access to local variable list : List<T> [element] : A | provenance | MaD:605 |
 | CollectionFlow.cs:357:14:357:17 | access to local variable list : List<T> [element] : A | CollectionFlow.cs:357:14:357:20 | access to indexer | provenance | MaD:617 |
 | CollectionFlow.cs:358:22:358:25 | access to local variable list : List<T> [element] : A | CollectionFlow.cs:16:49:16:52 | list : List<T> [element] : A | provenance |  |
 | CollectionFlow.cs:359:24:359:27 | access to local variable list : List<T> [element] : A | CollectionFlow.cs:24:43:24:46 | list : List<T> [element] : A | provenance |  |
-| CollectionFlow.cs:359:24:359:27 | access to local variable list : List<T> [element] : A | CollectionFlow.cs:359:14:359:28 | call to method ListFirst<A> | provenance |  |
+| CollectionFlow.cs:359:24:359:27 | access to local variable list : List<T> [element] : A | CollectionFlow.cs:359:14:359:28 | call to method ListFirst<A> | provenance | MaD:617 |
 | CollectionFlow.cs:373:20:373:26 | object creation of type A : A | CollectionFlow.cs:36:49:36:52 | args : A[] [element] : A | provenance |  |
 | CollectionFlow.cs:374:26:374:32 | object creation of type A : A | CollectionFlow.cs:36:49:36:52 | args : A[] [element] : A | provenance |  |
 | CollectionFlow.cs:375:26:375:32 | object creation of type A : A | CollectionFlow.cs:36:49:36:52 | args : A[] [element] : A | provenance |  |
@@ -345,10 +360,14 @@ nodes
 | CollectionFlow.cs:30:60:30:63 | dict : Dictionary<T,T> [element, property Value] : A | semmle.label | dict : Dictionary<T,T> [element, property Value] : A |
 | CollectionFlow.cs:30:69:30:72 | access to parameter dict : Dictionary<T,T> [element, property Value] : A | semmle.label | access to parameter dict : Dictionary<T,T> [element, property Value] : A |
 | CollectionFlow.cs:30:69:30:79 | access to property Values : ICollection<T> [element] : A | semmle.label | access to property Values : ICollection<T> [element] : A |
+| CollectionFlow.cs:30:69:30:79 | access to property Values : ICollection<T> [element] : A | semmle.label | access to property Values : ICollection<T> [element] : A |
+| CollectionFlow.cs:30:69:30:87 | call to method First<T> : A | semmle.label | call to method First<T> : A |
 | CollectionFlow.cs:30:69:30:87 | call to method First<T> : A | semmle.label | call to method First<T> : A |
 | CollectionFlow.cs:32:58:32:61 | dict : Dictionary<T,T> [element, property Key] : A | semmle.label | dict : Dictionary<T,T> [element, property Key] : A |
 | CollectionFlow.cs:32:67:32:70 | access to parameter dict : Dictionary<T,T> [element, property Key] : A | semmle.label | access to parameter dict : Dictionary<T,T> [element, property Key] : A |
 | CollectionFlow.cs:32:67:32:75 | access to property Keys : ICollection<T> [element] : A | semmle.label | access to property Keys : ICollection<T> [element] : A |
+| CollectionFlow.cs:32:67:32:75 | access to property Keys : ICollection<T> [element] : A | semmle.label | access to property Keys : ICollection<T> [element] : A |
+| CollectionFlow.cs:32:67:32:83 | call to method First<T> : A | semmle.label | call to method First<T> : A |
 | CollectionFlow.cs:32:67:32:83 | call to method First<T> : A | semmle.label | call to method First<T> : A |
 | CollectionFlow.cs:34:57:34:60 | dict : Dictionary<T,T> [element, property Key] : A | semmle.label | dict : Dictionary<T,T> [element, property Key] : A |
 | CollectionFlow.cs:34:66:34:69 | access to parameter dict : Dictionary<T,T> [element, property Key] : A | semmle.label | access to parameter dict : Dictionary<T,T> [element, property Key] : A |
@@ -634,14 +653,19 @@ subpaths
 | CollectionFlow.cs:156:28:156:31 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:26:58:26:61 | dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:26:67:26:73 | access to indexer : A | CollectionFlow.cs:156:14:156:32 | call to method DictIndexZero<A> |
 | CollectionFlow.cs:157:29:157:32 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:28:59:28:62 | dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:28:68:28:85 | access to property Value : A | CollectionFlow.cs:157:14:157:33 | call to method DictFirstValue<A> |
 | CollectionFlow.cs:158:30:158:33 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:30:60:30:63 | dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:30:69:30:87 | call to method First<T> : A | CollectionFlow.cs:158:14:158:34 | call to method DictValuesFirst<A> |
+| CollectionFlow.cs:158:30:158:33 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:30:60:30:63 | dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:30:69:30:87 | call to method First<T> : A | CollectionFlow.cs:158:14:158:34 | call to method DictValuesFirst<A> |
 | CollectionFlow.cs:178:28:178:31 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:26:58:26:61 | dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:26:67:26:73 | access to indexer : A | CollectionFlow.cs:178:14:178:32 | call to method DictIndexZero<A> |
 | CollectionFlow.cs:179:29:179:32 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:28:59:28:62 | dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:28:68:28:85 | access to property Value : A | CollectionFlow.cs:179:14:179:33 | call to method DictFirstValue<A> |
+| CollectionFlow.cs:180:30:180:33 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:30:60:30:63 | dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:30:69:30:87 | call to method First<T> : A | CollectionFlow.cs:180:14:180:34 | call to method DictValuesFirst<A> |
 | CollectionFlow.cs:180:30:180:33 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:30:60:30:63 | dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:30:69:30:87 | call to method First<T> : A | CollectionFlow.cs:180:14:180:34 | call to method DictValuesFirst<A> |
 | CollectionFlow.cs:199:28:199:31 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:26:58:26:61 | dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:26:67:26:73 | access to indexer : A | CollectionFlow.cs:199:14:199:32 | call to method DictIndexZero<A> |
 | CollectionFlow.cs:200:29:200:32 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:28:59:28:62 | dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:28:68:28:85 | access to property Value : A | CollectionFlow.cs:200:14:200:33 | call to method DictFirstValue<A> |
 | CollectionFlow.cs:201:30:201:33 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:30:60:30:63 | dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:30:69:30:87 | call to method First<T> : A | CollectionFlow.cs:201:14:201:34 | call to method DictValuesFirst<A> |
+| CollectionFlow.cs:201:30:201:33 | access to local variable dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:30:60:30:63 | dict : Dictionary<T,T> [element, property Value] : A | CollectionFlow.cs:30:69:30:87 | call to method First<T> : A | CollectionFlow.cs:201:14:201:34 | call to method DictValuesFirst<A> |
+| CollectionFlow.cs:221:28:221:31 | access to local variable dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:32:58:32:61 | dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:32:67:32:83 | call to method First<T> : A | CollectionFlow.cs:221:14:221:32 | call to method DictKeysFirst<A> |
 | CollectionFlow.cs:221:28:221:31 | access to local variable dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:32:58:32:61 | dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:32:67:32:83 | call to method First<T> : A | CollectionFlow.cs:221:14:221:32 | call to method DictKeysFirst<A> |
 | CollectionFlow.cs:222:27:222:30 | access to local variable dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:34:57:34:60 | dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:34:66:34:81 | access to property Key : A | CollectionFlow.cs:222:14:222:31 | call to method DictFirstKey<A> |
+| CollectionFlow.cs:240:28:240:31 | access to local variable dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:32:58:32:61 | dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:32:67:32:83 | call to method First<T> : A | CollectionFlow.cs:240:14:240:32 | call to method DictKeysFirst<A> |
 | CollectionFlow.cs:240:28:240:31 | access to local variable dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:32:58:32:61 | dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:32:67:32:83 | call to method First<T> : A | CollectionFlow.cs:240:14:240:32 | call to method DictKeysFirst<A> |
 | CollectionFlow.cs:241:27:241:30 | access to local variable dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:34:57:34:60 | dict : Dictionary<T,T> [element, property Key] : A | CollectionFlow.cs:34:66:34:81 | access to property Key : A | CollectionFlow.cs:241:14:241:31 | call to method DictFirstKey<A> |
 | CollectionFlow.cs:334:23:334:23 | access to local variable a : A | CollectionFlow.cs:328:32:328:38 | element : A | CollectionFlow.cs:328:23:328:27 | array [Return] : A[] [element] : A | CollectionFlow.cs:334:18:334:20 | [post] access to local variable as : A[] [element] : A |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
@@ -483,7 +483,7 @@ edges
 | GlobalDataFlowStringBuilder.cs:30:31:30:32 | [post] access to local variable sb : StringBuilder | GlobalDataFlowStringBuilder.cs:35:20:35:21 | access to local variable sb : StringBuilder | provenance |  |
 | GlobalDataFlowStringBuilder.cs:30:31:30:32 | [post] access to local variable sb : StringBuilder | GlobalDataFlowStringBuilder.cs:40:20:40:26 | (...) ... : AppendInterpolatedStringHandler | provenance |  |
 | GlobalDataFlowStringBuilder.cs:30:35:30:48 | "taint source" : String | GlobalDataFlowStringBuilder.cs:17:64:17:64 | s : String | provenance |  |
-| GlobalDataFlowStringBuilder.cs:30:35:30:48 | "taint source" : String | GlobalDataFlowStringBuilder.cs:30:31:30:32 | [post] access to local variable sb : StringBuilder | provenance |  |
+| GlobalDataFlowStringBuilder.cs:30:35:30:48 | "taint source" : String | GlobalDataFlowStringBuilder.cs:30:31:30:32 | [post] access to local variable sb : StringBuilder | provenance | MaD:1910 |
 | GlobalDataFlowStringBuilder.cs:31:13:31:17 | access to local variable sink0 : String | GlobalDataFlowStringBuilder.cs:32:15:32:19 | access to local variable sink0 | provenance |  |
 | GlobalDataFlowStringBuilder.cs:31:21:31:22 | access to local variable sb : StringBuilder | GlobalDataFlowStringBuilder.cs:31:21:31:33 | call to method ToString : String | provenance | MaD:1980 |
 | GlobalDataFlowStringBuilder.cs:31:21:31:33 | call to method ToString : String | GlobalDataFlowStringBuilder.cs:31:13:31:17 | access to local variable sink0 : String | provenance |  |
@@ -499,7 +499,7 @@ edges
 | GlobalDataFlowStringBuilder.cs:41:21:41:34 | call to method ToString : String | GlobalDataFlowStringBuilder.cs:41:13:41:17 | access to local variable sink2 : String | provenance |  |
 | GlobalDataFlowStringBuilder.cs:48:43:48:44 | [post] access to local variable sb : StringBuilder | GlobalDataFlowStringBuilder.cs:49:21:49:22 | access to local variable sb : StringBuilder | provenance |  |
 | GlobalDataFlowStringBuilder.cs:48:47:48:60 | "taint source" : String | GlobalDataFlowStringBuilder.cs:22:76:22:76 | s : String | provenance |  |
-| GlobalDataFlowStringBuilder.cs:48:47:48:60 | "taint source" : String | GlobalDataFlowStringBuilder.cs:48:43:48:44 | [post] access to local variable sb : StringBuilder | provenance |  |
+| GlobalDataFlowStringBuilder.cs:48:47:48:60 | "taint source" : String | GlobalDataFlowStringBuilder.cs:48:43:48:44 | [post] access to local variable sb : StringBuilder | provenance | MaD:1922 |
 | GlobalDataFlowStringBuilder.cs:49:13:49:17 | access to local variable sink3 : String | GlobalDataFlowStringBuilder.cs:50:15:50:19 | access to local variable sink3 | provenance |  |
 | GlobalDataFlowStringBuilder.cs:49:21:49:22 | access to local variable sb : StringBuilder | GlobalDataFlowStringBuilder.cs:49:21:49:33 | call to method ToString : String | provenance | MaD:1980 |
 | GlobalDataFlowStringBuilder.cs:49:21:49:33 | call to method ToString : String | GlobalDataFlowStringBuilder.cs:49:13:49:17 | access to local variable sink3 : String | provenance |  |

--- a/csharp/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest1.expected
+++ b/csharp/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest1.expected
@@ -7,7 +7,7 @@ edges
 | Test.cs:25:41:25:46 | [post] access to local variable buffer : Byte[] [element] : Object | Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | provenance |  |
 | Test.cs:28:85:28:105 | call to method BytesToString : String | Test.cs:28:42:28:111 | ... + ... | provenance |  Sink:MaD:948 |
 | Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | Test.cs:12:45:12:49 | bytes : Byte[] [element] : Object | provenance |  |
-| Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | Test.cs:28:85:28:105 | call to method BytesToString : String | provenance |  |
+| Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | Test.cs:28:85:28:105 | call to method BytesToString : String | provenance | MaD:1887 |
 nodes
 | Test.cs:12:45:12:49 | bytes : Byte[] [element] : Object | semmle.label | bytes : Byte[] [element] : Object |
 | Test.cs:15:20:15:61 | call to method GetString : String | semmle.label | call to method GetString : String |

--- a/csharp/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest2.expected
+++ b/csharp/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest2.expected
@@ -7,7 +7,7 @@ edges
 | Test.cs:25:41:25:46 | [post] access to local variable buffer : Byte[] [element] : Object | Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | provenance |  |
 | Test.cs:28:85:28:105 | call to method BytesToString : String | Test.cs:28:42:28:111 | ... + ... | provenance |  Sink:MaD:948 |
 | Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | Test.cs:12:45:12:49 | bytes : Byte[] [element] : Object | provenance |  |
-| Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | Test.cs:28:85:28:105 | call to method BytesToString : String | provenance |  |
+| Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | Test.cs:28:85:28:105 | call to method BytesToString : String | provenance | MaD:1887 |
 | Test.cs:34:20:34:25 | access to local variable result : String | Test.cs:37:42:37:96 | ... + ... | provenance |  Sink:MaD:948 |
 | Test.cs:34:29:34:69 | call to method ExecuteQuery : String | Test.cs:34:20:34:25 | access to local variable result : String | provenance | Src:MaD:1  |
 nodes

--- a/csharp/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest3.expected
+++ b/csharp/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest3.expected
@@ -7,7 +7,7 @@ edges
 | Test.cs:25:41:25:46 | [post] access to local variable buffer : Byte[] [element] : Object | Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | provenance |  |
 | Test.cs:28:85:28:105 | call to method BytesToString : String | Test.cs:28:42:28:111 | ... + ... | provenance |  Sink:MaD:948 |
 | Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | Test.cs:12:45:12:49 | bytes : Byte[] [element] : Object | provenance |  |
-| Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | Test.cs:28:85:28:105 | call to method BytesToString : String | provenance |  |
+| Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | Test.cs:28:85:28:105 | call to method BytesToString : String | provenance | MaD:1887 |
 | Test.cs:34:20:34:25 | access to local variable result : String | Test.cs:37:42:37:96 | ... + ... | provenance |  Sink:MaD:948 |
 | Test.cs:34:29:34:69 | call to method ExecuteQuery : String | Test.cs:34:20:34:25 | access to local variable result : String | provenance | Src:MaD:1  |
 | Test.cs:43:20:43:25 | access to local variable result : String | Test.cs:46:42:46:96 | ... + ... | provenance |  Sink:MaD:948 |

--- a/csharp/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest4.expected
+++ b/csharp/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest4.expected
@@ -7,7 +7,7 @@ edges
 | Test.cs:25:41:25:46 | [post] access to local variable buffer : Byte[] [element] : Object | Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | provenance |  |
 | Test.cs:28:85:28:105 | call to method BytesToString : String | Test.cs:28:42:28:111 | ... + ... | provenance |  Sink:MaD:948 |
 | Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | Test.cs:12:45:12:49 | bytes : Byte[] [element] : Object | provenance |  |
-| Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | Test.cs:28:85:28:105 | call to method BytesToString : String | provenance |  |
+| Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | Test.cs:28:85:28:105 | call to method BytesToString : String | provenance | MaD:1887 |
 | Test.cs:34:20:34:25 | access to local variable result : String | Test.cs:37:42:37:96 | ... + ... | provenance |  Sink:MaD:948 |
 | Test.cs:34:29:34:69 | call to method ExecuteQuery : String | Test.cs:34:20:34:25 | access to local variable result : String | provenance | Src:MaD:1  |
 | Test.cs:43:20:43:25 | access to local variable result : String | Test.cs:46:42:46:96 | ... + ... | provenance |  Sink:MaD:948 |

--- a/csharp/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest5.expected
+++ b/csharp/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest5.expected
@@ -7,7 +7,7 @@ edges
 | Test.cs:25:41:25:46 | [post] access to local variable buffer : Byte[] [element] : Object | Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | provenance |  |
 | Test.cs:28:85:28:105 | call to method BytesToString : String | Test.cs:28:42:28:111 | ... + ... | provenance |  Sink:MaD:948 |
 | Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | Test.cs:12:45:12:49 | bytes : Byte[] [element] : Object | provenance |  |
-| Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | Test.cs:28:85:28:105 | call to method BytesToString : String | provenance |  |
+| Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | Test.cs:28:85:28:105 | call to method BytesToString : String | provenance | MaD:1887 |
 | Test.cs:43:20:43:25 | access to local variable result : String | Test.cs:46:42:46:96 | ... + ... | provenance |  Sink:MaD:948 |
 | Test.cs:43:29:43:50 | call to method ReadEnv : String | Test.cs:43:20:43:25 | access to local variable result : String | provenance | Src:MaD:3  |
 | Test.cs:62:20:62:25 | access to local variable result : String | Test.cs:65:42:65:96 | ... + ... | provenance |  Sink:MaD:948 |

--- a/csharp/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest6.expected
+++ b/csharp/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest6.expected
@@ -7,7 +7,7 @@ edges
 | Test.cs:25:41:25:46 | [post] access to local variable buffer : Byte[] [element] : Object | Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | provenance |  |
 | Test.cs:28:85:28:105 | call to method BytesToString : String | Test.cs:28:42:28:111 | ... + ... | provenance |  Sink:MaD:948 |
 | Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | Test.cs:12:45:12:49 | bytes : Byte[] [element] : Object | provenance |  |
-| Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | Test.cs:28:85:28:105 | call to method BytesToString : String | provenance |  |
+| Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | Test.cs:28:85:28:105 | call to method BytesToString : String | provenance | MaD:1887 |
 | Test.cs:34:20:34:25 | access to local variable result : String | Test.cs:37:42:37:96 | ... + ... | provenance |  Sink:MaD:948 |
 | Test.cs:34:29:34:69 | call to method ExecuteQuery : String | Test.cs:34:20:34:25 | access to local variable result : String | provenance | Src:MaD:2  |
 | Test.cs:62:20:62:25 | access to local variable result : String | Test.cs:65:42:65:96 | ... + ... | provenance |  Sink:MaD:948 |

--- a/go/ql/test/query-tests/Security/CWE-601/BadRedirectCheck/BadRedirectCheck.expected
+++ b/go/ql/test/query-tests/Security/CWE-601/BadRedirectCheck/BadRedirectCheck.expected
@@ -26,7 +26,7 @@ edges
 | main.go:73:20:73:27 | redirect | main.go:73:9:73:28 | call to Clean | provenance | MaD:1 |
 | main.go:76:19:76:21 | argument corresponding to url | main.go:77:36:77:38 | url | provenance |  |
 | main.go:77:36:77:38 | url | main.go:68:17:68:24 | definition of redirect | provenance |  |
-| main.go:77:36:77:38 | url | main.go:77:25:77:39 | call to getTarget1 | provenance |  |
+| main.go:77:36:77:38 | url | main.go:77:25:77:39 | call to getTarget1 | provenance | MaD:1 |
 | main.go:87:9:87:14 | selection of Path | main.go:91:25:91:39 | call to getTarget2 | provenance |  |
 models
 | 1 | Summary: path; ; false; Clean; ; ; Argument[0]; ReturnValue; taint; manual |

--- a/java/ql/test/experimental/query-tests/security/CWE-625/PermissiveDotRegex.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-625/PermissiveDotRegex.expected
@@ -20,15 +20,22 @@ edges
 | DotRegexSpring.java:20:26:20:50 | path : String | DotRegexSpring.java:22:21:22:24 | path : String | provenance |  |
 | DotRegexSpring.java:22:10:22:25 | decodePath(...) : String | DotRegexSpring.java:23:25:23:28 | path | provenance |  |
 | DotRegexSpring.java:22:21:22:24 | path : String | DotRegexSpring.java:22:10:22:25 | decodePath(...) : String | provenance |  |
+| DotRegexSpring.java:22:21:22:24 | path : String | DotRegexSpring.java:22:10:22:25 | decodePath(...) : String | provenance | MaD:3 |
 | DotRegexSpring.java:22:21:22:24 | path : String | DotRegexSpring.java:69:28:69:38 | path : String | provenance |  |
 | DotRegexSpring.java:37:40:37:64 | path : String | DotRegexSpring.java:39:21:39:24 | path : String | provenance |  |
 | DotRegexSpring.java:39:10:39:25 | decodePath(...) : String | DotRegexSpring.java:40:25:40:28 | path | provenance |  |
 | DotRegexSpring.java:39:21:39:24 | path : String | DotRegexSpring.java:39:10:39:25 | decodePath(...) : String | provenance |  |
+| DotRegexSpring.java:39:21:39:24 | path : String | DotRegexSpring.java:39:10:39:25 | decodePath(...) : String | provenance | MaD:3 |
 | DotRegexSpring.java:39:21:39:24 | path : String | DotRegexSpring.java:69:28:69:38 | path : String | provenance |  |
 | DotRegexSpring.java:69:28:69:38 | path : String | DotRegexSpring.java:71:29:71:32 | path : String | provenance |  |
+| DotRegexSpring.java:69:28:69:38 | path : String | DotRegexSpring.java:71:29:71:32 | path : String | provenance |  |
+| DotRegexSpring.java:69:28:69:38 | path : String | DotRegexSpring.java:73:10:73:13 | path : String | provenance |  |
 | DotRegexSpring.java:69:28:69:38 | path : String | DotRegexSpring.java:73:10:73:13 | path : String | provenance |  |
 | DotRegexSpring.java:71:11:71:42 | decode(...) : String | DotRegexSpring.java:71:29:71:32 | path : String | provenance |  |
+| DotRegexSpring.java:71:11:71:42 | decode(...) : String | DotRegexSpring.java:71:29:71:32 | path : String | provenance |  |
 | DotRegexSpring.java:71:11:71:42 | decode(...) : String | DotRegexSpring.java:73:10:73:13 | path : String | provenance |  |
+| DotRegexSpring.java:71:11:71:42 | decode(...) : String | DotRegexSpring.java:73:10:73:13 | path : String | provenance |  |
+| DotRegexSpring.java:71:29:71:32 | path : String | DotRegexSpring.java:71:11:71:42 | decode(...) : String | provenance | MaD:3 |
 | DotRegexSpring.java:71:29:71:32 | path : String | DotRegexSpring.java:71:11:71:42 | decode(...) : String | provenance | MaD:3 |
 models
 | 1 | Source: javax.servlet.http; HttpServletRequest; false; getPathInfo; (); ; ReturnValue; uri-path; manual |
@@ -58,7 +65,11 @@ nodes
 | DotRegexSpring.java:69:28:69:38 | path : String | semmle.label | path : String |
 | DotRegexSpring.java:71:11:71:42 | decode(...) : String | semmle.label | decode(...) : String |
 | DotRegexSpring.java:71:29:71:32 | path : String | semmle.label | path : String |
+| DotRegexSpring.java:71:29:71:32 | path : String | semmle.label | path : String |
+| DotRegexSpring.java:73:10:73:13 | path : String | semmle.label | path : String |
 | DotRegexSpring.java:73:10:73:13 | path : String | semmle.label | path : String |
 subpaths
 | DotRegexSpring.java:22:21:22:24 | path : String | DotRegexSpring.java:69:28:69:38 | path : String | DotRegexSpring.java:73:10:73:13 | path : String | DotRegexSpring.java:22:10:22:25 | decodePath(...) : String |
+| DotRegexSpring.java:22:21:22:24 | path : String | DotRegexSpring.java:69:28:69:38 | path : String | DotRegexSpring.java:73:10:73:13 | path : String | DotRegexSpring.java:22:10:22:25 | decodePath(...) : String |
+| DotRegexSpring.java:39:21:39:24 | path : String | DotRegexSpring.java:69:28:69:38 | path : String | DotRegexSpring.java:73:10:73:13 | path : String | DotRegexSpring.java:39:10:39:25 | decodePath(...) : String |
 | DotRegexSpring.java:39:21:39:24 | path : String | DotRegexSpring.java:69:28:69:38 | path : String | DotRegexSpring.java:73:10:73:13 | path : String | DotRegexSpring.java:39:10:39:25 | decodePath(...) : String |

--- a/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest1.expected
+++ b/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest1.expected
@@ -11,10 +11,10 @@ edges
 | Test.java:19:32:19:35 | data [post update] : byte[] | Test.java:22:49:22:52 | data : byte[] | provenance |  |
 | Test.java:19:32:19:35 | data [post update] : byte[] | Test.java:25:69:25:72 | data : byte[] | provenance |  |
 | Test.java:22:49:22:52 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
-| Test.java:22:49:22:52 | data : byte[] | Test.java:22:36:22:53 | byteToString(...) | provenance |  Sink:MaD:5 |
+| Test.java:22:49:22:52 | data : byte[] | Test.java:22:36:22:53 | byteToString(...) | provenance | MaD:2 Sink:MaD:5 |
 | Test.java:25:56:25:73 | byteToString(...) : String | Test.java:25:26:25:80 | ... + ... | provenance |  Sink:MaD:4 |
 | Test.java:25:69:25:72 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
-| Test.java:25:69:25:72 | data : byte[] | Test.java:25:56:25:73 | byteToString(...) : String | provenance |  |
+| Test.java:25:69:25:72 | data : byte[] | Test.java:25:56:25:73 | byteToString(...) : String | provenance | MaD:2 |
 nodes
 | Test.java:10:31:10:41 | data : byte[] | semmle.label | data : byte[] |
 | Test.java:11:12:11:51 | new String(...) : String | semmle.label | new String(...) : String |

--- a/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest2.expected
+++ b/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest2.expected
@@ -13,10 +13,10 @@ edges
 | Test.java:19:32:19:35 | data [post update] : byte[] | Test.java:22:49:22:52 | data : byte[] | provenance |  |
 | Test.java:19:32:19:35 | data [post update] : byte[] | Test.java:25:69:25:72 | data : byte[] | provenance |  |
 | Test.java:22:49:22:52 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
-| Test.java:22:49:22:52 | data : byte[] | Test.java:22:36:22:53 | byteToString(...) | provenance |  Sink:MaD:6 |
+| Test.java:22:49:22:52 | data : byte[] | Test.java:22:36:22:53 | byteToString(...) | provenance | MaD:3 Sink:MaD:6 |
 | Test.java:25:56:25:73 | byteToString(...) : String | Test.java:25:26:25:80 | ... + ... | provenance |  Sink:MaD:5 |
 | Test.java:25:69:25:72 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
-| Test.java:25:69:25:72 | data : byte[] | Test.java:25:56:25:73 | byteToString(...) : String | provenance |  |
+| Test.java:25:69:25:72 | data : byte[] | Test.java:25:56:25:73 | byteToString(...) : String | provenance | MaD:3 |
 | Test.java:30:21:30:61 | executeQuery(...) : String | Test.java:33:26:33:68 | ... + ... | provenance | Src:MaD:1  Sink:MaD:5 |
 | Test.java:30:21:30:61 | executeQuery(...) : String | Test.java:36:36:36:41 | result | provenance | Src:MaD:1  Sink:MaD:6 |
 nodes

--- a/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest3.expected
+++ b/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest3.expected
@@ -15,10 +15,10 @@ edges
 | Test.java:19:32:19:35 | data [post update] : byte[] | Test.java:22:49:22:52 | data : byte[] | provenance |  |
 | Test.java:19:32:19:35 | data [post update] : byte[] | Test.java:25:69:25:72 | data : byte[] | provenance |  |
 | Test.java:22:49:22:52 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
-| Test.java:22:49:22:52 | data : byte[] | Test.java:22:36:22:53 | byteToString(...) | provenance |  Sink:MaD:7 |
+| Test.java:22:49:22:52 | data : byte[] | Test.java:22:36:22:53 | byteToString(...) | provenance | MaD:4 Sink:MaD:7 |
 | Test.java:25:56:25:73 | byteToString(...) : String | Test.java:25:26:25:80 | ... + ... | provenance |  Sink:MaD:6 |
 | Test.java:25:69:25:72 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
-| Test.java:25:69:25:72 | data : byte[] | Test.java:25:56:25:73 | byteToString(...) : String | provenance |  |
+| Test.java:25:69:25:72 | data : byte[] | Test.java:25:56:25:73 | byteToString(...) : String | provenance | MaD:4 |
 | Test.java:30:21:30:61 | executeQuery(...) : String | Test.java:33:26:33:68 | ... + ... | provenance | Src:MaD:1  Sink:MaD:6 |
 | Test.java:30:21:30:61 | executeQuery(...) : String | Test.java:36:36:36:41 | result | provenance | Src:MaD:1  Sink:MaD:7 |
 | Test.java:41:21:41:49 | readEnv(...) : String | Test.java:44:26:44:68 | ... + ... | provenance | Src:MaD:2  Sink:MaD:6 |
@@ -28,9 +28,9 @@ edges
 | Test.java:64:20:64:23 | data [post update] : byte[] | Test.java:70:49:70:52 | data : byte[] | provenance |  |
 | Test.java:67:56:67:73 | byteToString(...) : String | Test.java:67:26:67:80 | ... + ... | provenance |  Sink:MaD:6 |
 | Test.java:67:69:67:72 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
-| Test.java:67:69:67:72 | data : byte[] | Test.java:67:56:67:73 | byteToString(...) : String | provenance |  |
+| Test.java:67:69:67:72 | data : byte[] | Test.java:67:56:67:73 | byteToString(...) : String | provenance | MaD:4 |
 | Test.java:70:49:70:52 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
-| Test.java:70:49:70:52 | data : byte[] | Test.java:70:36:70:53 | byteToString(...) | provenance |  Sink:MaD:7 |
+| Test.java:70:49:70:52 | data : byte[] | Test.java:70:36:70:53 | byteToString(...) | provenance | MaD:4 Sink:MaD:7 |
 nodes
 | Test.java:10:31:10:41 | data : byte[] | semmle.label | data : byte[] |
 | Test.java:11:12:11:51 | new String(...) : String | semmle.label | new String(...) : String |

--- a/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest4.expected
+++ b/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest4.expected
@@ -17,10 +17,10 @@ edges
 | Test.java:19:32:19:35 | data [post update] : byte[] | Test.java:22:49:22:52 | data : byte[] | provenance |  |
 | Test.java:19:32:19:35 | data [post update] : byte[] | Test.java:25:69:25:72 | data : byte[] | provenance |  |
 | Test.java:22:49:22:52 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
-| Test.java:22:49:22:52 | data : byte[] | Test.java:22:36:22:53 | byteToString(...) | provenance |  Sink:MaD:8 |
+| Test.java:22:49:22:52 | data : byte[] | Test.java:22:36:22:53 | byteToString(...) | provenance | MaD:5 Sink:MaD:8 |
 | Test.java:25:56:25:73 | byteToString(...) : String | Test.java:25:26:25:80 | ... + ... | provenance |  Sink:MaD:7 |
 | Test.java:25:69:25:72 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
-| Test.java:25:69:25:72 | data : byte[] | Test.java:25:56:25:73 | byteToString(...) : String | provenance |  |
+| Test.java:25:69:25:72 | data : byte[] | Test.java:25:56:25:73 | byteToString(...) : String | provenance | MaD:5 |
 | Test.java:30:21:30:61 | executeQuery(...) : String | Test.java:33:26:33:68 | ... + ... | provenance | Src:MaD:1  Sink:MaD:7 |
 | Test.java:30:21:30:61 | executeQuery(...) : String | Test.java:36:36:36:41 | result | provenance | Src:MaD:1  Sink:MaD:8 |
 | Test.java:41:21:41:49 | readEnv(...) : String | Test.java:44:26:44:68 | ... + ... | provenance | Src:MaD:2  Sink:MaD:7 |
@@ -32,9 +32,9 @@ edges
 | Test.java:64:20:64:23 | data [post update] : byte[] | Test.java:70:49:70:52 | data : byte[] | provenance |  |
 | Test.java:67:56:67:73 | byteToString(...) : String | Test.java:67:26:67:80 | ... + ... | provenance |  Sink:MaD:7 |
 | Test.java:67:69:67:72 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
-| Test.java:67:69:67:72 | data : byte[] | Test.java:67:56:67:73 | byteToString(...) : String | provenance |  |
+| Test.java:67:69:67:72 | data : byte[] | Test.java:67:56:67:73 | byteToString(...) : String | provenance | MaD:5 |
 | Test.java:70:49:70:52 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
-| Test.java:70:49:70:52 | data : byte[] | Test.java:70:36:70:53 | byteToString(...) | provenance |  Sink:MaD:8 |
+| Test.java:70:49:70:52 | data : byte[] | Test.java:70:36:70:53 | byteToString(...) | provenance | MaD:5 Sink:MaD:8 |
 nodes
 | Test.java:10:31:10:41 | data : byte[] | semmle.label | data : byte[] |
 | Test.java:11:12:11:51 | new String(...) : String | semmle.label | new String(...) : String |

--- a/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest5.expected
+++ b/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest5.expected
@@ -13,10 +13,10 @@ edges
 | Test.java:19:32:19:35 | data [post update] : byte[] | Test.java:22:49:22:52 | data : byte[] | provenance |  |
 | Test.java:19:32:19:35 | data [post update] : byte[] | Test.java:25:69:25:72 | data : byte[] | provenance |  |
 | Test.java:22:49:22:52 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
-| Test.java:22:49:22:52 | data : byte[] | Test.java:22:36:22:53 | byteToString(...) | provenance |  Sink:MaD:6 |
+| Test.java:22:49:22:52 | data : byte[] | Test.java:22:36:22:53 | byteToString(...) | provenance | MaD:3 Sink:MaD:6 |
 | Test.java:25:56:25:73 | byteToString(...) : String | Test.java:25:26:25:80 | ... + ... | provenance |  Sink:MaD:5 |
 | Test.java:25:69:25:72 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
-| Test.java:25:69:25:72 | data : byte[] | Test.java:25:56:25:73 | byteToString(...) : String | provenance |  |
+| Test.java:25:69:25:72 | data : byte[] | Test.java:25:56:25:73 | byteToString(...) : String | provenance | MaD:3 |
 | Test.java:41:21:41:49 | readEnv(...) : String | Test.java:44:26:44:68 | ... + ... | provenance | Src:MaD:1  Sink:MaD:5 |
 | Test.java:41:21:41:49 | readEnv(...) : String | Test.java:47:36:47:41 | result | provenance | Src:MaD:1  Sink:MaD:6 |
 | Test.java:64:5:64:13 | System.in : InputStream | Test.java:64:20:64:23 | data [post update] : byte[] | provenance | MaD:2 |
@@ -24,9 +24,9 @@ edges
 | Test.java:64:20:64:23 | data [post update] : byte[] | Test.java:70:49:70:52 | data : byte[] | provenance |  |
 | Test.java:67:56:67:73 | byteToString(...) : String | Test.java:67:26:67:80 | ... + ... | provenance |  Sink:MaD:5 |
 | Test.java:67:69:67:72 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
-| Test.java:67:69:67:72 | data : byte[] | Test.java:67:56:67:73 | byteToString(...) : String | provenance |  |
+| Test.java:67:69:67:72 | data : byte[] | Test.java:67:56:67:73 | byteToString(...) : String | provenance | MaD:3 |
 | Test.java:70:49:70:52 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
-| Test.java:70:49:70:52 | data : byte[] | Test.java:70:36:70:53 | byteToString(...) | provenance |  Sink:MaD:6 |
+| Test.java:70:49:70:52 | data : byte[] | Test.java:70:36:70:53 | byteToString(...) | provenance | MaD:3 Sink:MaD:6 |
 nodes
 | Test.java:10:31:10:41 | data : byte[] | semmle.label | data : byte[] |
 | Test.java:11:12:11:51 | new String(...) : String | semmle.label | new String(...) : String |

--- a/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest6.expected
+++ b/java/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest6.expected
@@ -13,10 +13,10 @@ edges
 | Test.java:19:32:19:35 | data [post update] : byte[] | Test.java:22:49:22:52 | data : byte[] | provenance |  |
 | Test.java:19:32:19:35 | data [post update] : byte[] | Test.java:25:69:25:72 | data : byte[] | provenance |  |
 | Test.java:22:49:22:52 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
-| Test.java:22:49:22:52 | data : byte[] | Test.java:22:36:22:53 | byteToString(...) | provenance |  Sink:MaD:6 |
+| Test.java:22:49:22:52 | data : byte[] | Test.java:22:36:22:53 | byteToString(...) | provenance | MaD:3 Sink:MaD:6 |
 | Test.java:25:56:25:73 | byteToString(...) : String | Test.java:25:26:25:80 | ... + ... | provenance |  Sink:MaD:5 |
 | Test.java:25:69:25:72 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
-| Test.java:25:69:25:72 | data : byte[] | Test.java:25:56:25:73 | byteToString(...) : String | provenance |  |
+| Test.java:25:69:25:72 | data : byte[] | Test.java:25:56:25:73 | byteToString(...) : String | provenance | MaD:3 |
 | Test.java:30:21:30:61 | executeQuery(...) : String | Test.java:33:26:33:68 | ... + ... | provenance | Src:MaD:1  Sink:MaD:5 |
 | Test.java:30:21:30:61 | executeQuery(...) : String | Test.java:36:36:36:41 | result | provenance | Src:MaD:1  Sink:MaD:6 |
 | Test.java:64:5:64:13 | System.in : InputStream | Test.java:64:20:64:23 | data [post update] : byte[] | provenance | MaD:2 |
@@ -24,9 +24,9 @@ edges
 | Test.java:64:20:64:23 | data [post update] : byte[] | Test.java:70:49:70:52 | data : byte[] | provenance |  |
 | Test.java:67:56:67:73 | byteToString(...) : String | Test.java:67:26:67:80 | ... + ... | provenance |  Sink:MaD:5 |
 | Test.java:67:69:67:72 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
-| Test.java:67:69:67:72 | data : byte[] | Test.java:67:56:67:73 | byteToString(...) : String | provenance |  |
+| Test.java:67:69:67:72 | data : byte[] | Test.java:67:56:67:73 | byteToString(...) : String | provenance | MaD:3 |
 | Test.java:70:49:70:52 | data : byte[] | Test.java:10:31:10:41 | data : byte[] | provenance |  |
-| Test.java:70:49:70:52 | data : byte[] | Test.java:70:36:70:53 | byteToString(...) | provenance |  Sink:MaD:6 |
+| Test.java:70:49:70:52 | data : byte[] | Test.java:70:36:70:53 | byteToString(...) | provenance | MaD:3 Sink:MaD:6 |
 nodes
 | Test.java:10:31:10:41 | data : byte[] | semmle.label | data : byte[] |
 | Test.java:11:12:11:51 | new String(...) : String | semmle.label | new String(...) : String |

--- a/java/ql/test/query-tests/security/CWE-601/semmle/tests/UrlRedirect.expected
+++ b/java/ql/test/query-tests/security/CWE-601/semmle/tests/UrlRedirect.expected
@@ -6,7 +6,7 @@
 | UrlRedirect.java:42:43:42:72 | getParameter(...) | UrlRedirect.java:42:43:42:72 | getParameter(...) | UrlRedirect.java:42:43:42:72 | getParameter(...) | Untrusted URL redirection depends on a $@. | UrlRedirect.java:42:43:42:72 | getParameter(...) | user-provided value |
 | mad/Test.java:14:22:14:38 | (...)... | mad/Test.java:9:16:9:41 | getParameter(...) : String | mad/Test.java:14:22:14:38 | (...)... | Untrusted URL redirection depends on a $@. | mad/Test.java:9:16:9:41 | getParameter(...) | user-provided value |
 edges
-| UrlRedirect.java:32:37:32:66 | getParameter(...) : String | UrlRedirect.java:32:25:32:67 | weakCleanup(...) | provenance | Src:MaD:2  |
+| UrlRedirect.java:32:37:32:66 | getParameter(...) : String | UrlRedirect.java:32:25:32:67 | weakCleanup(...) | provenance | Src:MaD:2 MaD:1 |
 | UrlRedirect.java:32:37:32:66 | getParameter(...) : String | UrlRedirect.java:45:28:45:39 | input : String | provenance | Src:MaD:2  |
 | UrlRedirect.java:45:28:45:39 | input : String | UrlRedirect.java:46:10:46:14 | input : String | provenance |  |
 | UrlRedirect.java:46:10:46:14 | input : String | UrlRedirect.java:46:10:46:40 | replaceAll(...) : String | provenance | MaD:1 |

--- a/python/ql/test/experimental/query-tests/Security/CWE-022-TarSlip/TarSlip.expected
+++ b/python/ql/test/experimental/query-tests/Security/CWE-022-TarSlip/TarSlip.expected
@@ -11,7 +11,7 @@ edges
 | TarSlipImprov.py:38:1:38:3 | ControlFlowNode for tar | TarSlipImprov.py:39:65:39:67 | ControlFlowNode for tar | provenance |  |
 | TarSlipImprov.py:38:7:38:39 | ControlFlowNode for Attribute() | TarSlipImprov.py:38:1:38:3 | ControlFlowNode for tar | provenance |  |
 | TarSlipImprov.py:39:65:39:67 | ControlFlowNode for tar | TarSlipImprov.py:26:21:26:27 | ControlFlowNode for tarfile | provenance |  |
-| TarSlipImprov.py:39:65:39:67 | ControlFlowNode for tar | TarSlipImprov.py:39:49:39:68 | ControlFlowNode for members_filter1() | provenance |  |
+| TarSlipImprov.py:39:65:39:67 | ControlFlowNode for tar | TarSlipImprov.py:39:49:39:68 | ControlFlowNode for members_filter1() | provenance | list.append |
 | TarSlipImprov.py:43:6:43:38 | ControlFlowNode for Attribute() | TarSlipImprov.py:43:43:43:45 | ControlFlowNode for tar | provenance |  |
 | TarSlipImprov.py:43:43:43:45 | ControlFlowNode for tar | TarSlipImprov.py:44:9:44:13 | ControlFlowNode for entry | provenance |  |
 | TarSlipImprov.py:44:9:44:13 | ControlFlowNode for entry | TarSlipImprov.py:47:21:47:25 | ControlFlowNode for entry | provenance |  |

--- a/ruby/ql/test/query-tests/security/cwe-506/HardcodedDataInterpretedAsCode.expected
+++ b/ruby/ql/test/query-tests/security/cwe-506/HardcodedDataInterpretedAsCode.expected
@@ -5,9 +5,9 @@ edges
 | tst.rb:5:1:5:23 | totally_harmless_string | tst.rb:7:8:7:30 | totally_harmless_string | provenance |  |
 | tst.rb:5:27:5:72 | "707574732822636f646520696e6a6..." | tst.rb:5:1:5:23 | totally_harmless_string | provenance |  |
 | tst.rb:7:8:7:30 | totally_harmless_string | tst.rb:1:7:1:7 | r | provenance |  |
-| tst.rb:7:8:7:30 | totally_harmless_string | tst.rb:7:6:7:31 | call to e | provenance |  |
+| tst.rb:7:8:7:30 | totally_harmless_string | tst.rb:7:6:7:31 | call to e | provenance | Config |
 | tst.rb:10:11:10:24 | "666f6f626172" | tst.rb:1:7:1:7 | r | provenance |  |
-| tst.rb:10:11:10:24 | "666f6f626172" | tst.rb:10:9:10:25 | call to e | provenance |  |
+| tst.rb:10:11:10:24 | "666f6f626172" | tst.rb:10:9:10:25 | call to e | provenance | Config |
 | tst.rb:16:1:16:27 | another_questionable_string | tst.rb:17:6:17:32 | another_questionable_string | provenance |  |
 | tst.rb:16:31:16:84 | "\\x70\\x75\\x74\\x73\\x28\\x27\\x68\\..." | tst.rb:16:1:16:27 | another_questionable_string | provenance |  |
 | tst.rb:17:6:17:32 | another_questionable_string | tst.rb:17:6:17:38 | call to strip | provenance | Config |

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -4526,7 +4526,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       pathThroughCallable(mid, node, state, cc, t, ap, label) and
       sc = mid.getSummaryCtx() and
       isStoreStep = false and
-      summaryLabel = mid.getSummaryLabel()
+      summaryLabel = mergeLabels(mid.getSummaryLabel(), label)
     }
 
     pragma[nomagic]


### PR DESCRIPTION
I expect this to mostly affect edges that have a corresponding subpaths-tuple, so it won't have much effect on the actual path explanations, but if you somehow provide a modeled library function with through-flow as a call-back argument to another library function, which then results in a combined through-flow, then it could be relevant.
In any case, it's a small correctness bug that's easy to fix. And we should see plenty of test coverage of this in the recorded `edges` relations in qltests.