### PR TITLE
C++: Mark `constexpr if` as unevaluated

### DIFF
--- a/cpp/ql/lib/change-notes/2024-07-31-constexpr-if.md
+++ b/cpp/ql/lib/change-notes/2024-07-31-constexpr-if.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The controlling expression of a `constexpr if` is now always recognized as an unevaluated expression.

--- a/cpp/ql/lib/semmle/code/cpp/exprs/Expr.qll
+++ b/cpp/ql/lib/semmle/code/cpp/exprs/Expr.qll
@@ -307,6 +307,10 @@ class Expr extends StmtParent, @expr {
     )
     or
     exists(Decltype d | d.getExpr() = this.getParentWithConversions*())
+    or
+    exists(ConstexprIfStmt constIf |
+      constIf.getControllingExpr() = this.getParentWithConversions*()
+    )
   }
 
   /**

--- a/cpp/ql/test/library-tests/exprs/unevaluated/test.cpp
+++ b/cpp/ql/test/library-tests/exprs/unevaluated/test.cpp
@@ -62,3 +62,9 @@ Virtual getAVirtual();
 void test9() {
 	typeid(getAVirtual()); // unevaluated
 }
+
+void constExprIf() {
+  if constexpr(sizeof(int) == 4) { } // unevaluated
+}
+
+// semmle-extractor-options: -std=c++20

--- a/cpp/ql/test/library-tests/exprs/unevaluated/unevaluated.expected
+++ b/cpp/ql/test/library-tests/exprs/unevaluated/unevaluated.expected
@@ -14,3 +14,7 @@
 | test.cpp:57:9:57:9 | 4 |
 | test.cpp:63:9:63:19 | call to getAVirtual |
 | test.cpp:63:9:63:21 | temporary object |
+| test.cpp:67:16:67:26 | sizeof(int) |
+| test.cpp:67:16:67:31 | ... == ... |
+| test.cpp:67:31:67:31 | 4 |
+| test.cpp:67:31:67:31 | (unsigned long)... |


### PR DESCRIPTION
The controlling expression of a `constexpr if` is always evaluated at compile-time (see [here](https://en.cppreference.com/w/cpp/language/if#Constexpr_if)).