### PR TITLE
Go: add newly modeled packages to frameworks.csv

### DIFF
--- a/go/documentation/library-coverage/frameworks.csv
+++ b/go/documentation/library-coverage/frameworks.csv
@@ -1,5 +1,6 @@
 Framework name,URL,Package prefixes
 Standard library,https://pkg.go.dev/std, archive/* bufio bytes cmp compress/* container/* context crypto crypto/* database/* debug/* embed encoding encoding/* errors expvar flag fmt go/* hash hash/* html html/* image image/* index/* io io/* log log/* maps math math/* mime mime/* net net/* os os/* path path/* plugin reflect reflect/* regexp regexp/* slices sort strconv strings sync sync/* syscall syscall/* testing testing/* text/* time time/* unicode unicode/* unsafe
+appleboy/gin-jwt,https://github.com/appleboy/gin-jwt,github.com/appleboy/gin-jwt*
 beego,https://beego.me/,github.com/astaxie/beego* github.com/beego/beego*
 Couchbase official client(gocb),https://github.com/couchbase/gocb,github.com/couchbase/gocb* gopkg.in/couchbase/gocb*
 chi,https://go-chi.io/,github.com/go-chi/chi*
@@ -8,25 +9,38 @@ cristalhq/jwt,https://github.com/cristalhq/jwt,github.com/cristalhq/jwt*
 Echo,https://echo.labstack.com/,github.com/labstack/echo*
 fasthttp,https://github.com/valyala/fasthttp,github.com/valyala/fasthttp*
 Fosite,https://github.com/ory/fosite,github.com/ory/fosite*
+gf-jwt,https://github.com/gogf/gf-jwt,github.com/gogf/gf-jwt*
 Gin,https://github.com/gin-gonic/gin,github.com/gin-gonic/gin*
-Go JOSE,https://github.com/go-jose/go-jose,github.com/go-jose/go-jose* github.com/square/go-jose* gopkg.in/square/go-jose*
+Go JOSE,https://github.com/go-jose/go-jose,github.com/go-jose/go-jose* github.com/square/go-jose* gopkg.in/square/go-jose* gopkg.in/go-jose/go-jose*
 Go kit,https://gokit.io/,github.com/go-kit/kit*
 go-pg,https://pg.uptrace.dev/,github.com/go-pg/pg*
 go-restful,https://github.com/emicklei/go-restful,github.com/emicklei/go-restful*
+Gokogiri,https://github.com/moovweb/gokogiri,github.com/jbowtie/gokogiri* github.com/jbowtie/moovweb*
 golang.org/x/net,https://pkg.go.dev/golang.org/x/net,golang.org/x/net*
 goproxy,https://github.com/elazarl/goproxy,github.com/elazarl/goproxy*
 gorilla/mux,https://github.com/gorilla/mux,github.com/gorilla/mux*
+gorilla/websocket,https://github.com/gorilla/websocket,github.com/gorilla/websocket*
+goxpath,https://github.com/ChrisTrenkamp/goxpath/wiki,github.com/ChrisTrenkamp/goxpath*
+htmlquery,https://github.com/antchfx/htmlquery,github.com/antchfx/htmlquery*
 Iris,https://www.iris-go.com/,github.com/kataras/iris*
 json-iterator,https://github.com/json-iterator/go,github.com/json-iterator/go*
 jsonpatch,https://github.com/evanphx/json-patch,github.com/evanphx/json-patch*
+jsonquery,https://github.com/antchfx/jsonquery,github.com/antchfx/jsonquery*
 jwt-go,https://golang-jwt.github.io/jwt/,github.com/golang-jwt/jwt* github.com/form3tech-oss/jwt-go* github.com/dgrijalva/jwt-go*
 jwtauth,https://github.com/go-chi/jwtauth,github.com/go-chi/jwtauth*
 kataras/jwt,https://github.com/kataras/jwt,github.com/kataras/jwt*
 Kubernetes,https://kubernetes.io/,k8s.io/api* k8s.io/apimachinery*
 lestrrat-go/jwx,https://github.com/lestrrat-go/jwx,github.com/lestrrat-go/jwx* github.com/lestrrat/go-jwx*
+lestrrat-go/libxml2,https://github.com/lestrrat-go/libxml2,github.com/lestrrat-go/libxml2*
 Macaron,https://gopkg.in/macaron.v1,gopkg.in/macaron*
+nhooyr.io/websocket,https://nhooyr.io/websocket,nhooyr.io/websocket*
 protobuf,https://pkg.go.dev/google.golang.org/protobuf,github.com/golang/protobuf* google.golang.org/protobuf*
 Revel,http://revel.github.io/,github.com/revel/revel* github.com/robfig/revel*
 SendGrid,https://github.com/sendgrid/sendgrid-go,github.com/sendgrid/sendgrid-go*
+ws,https://github.com/gobwas/ws,github.com/gobwas/ws*
+xmlpath,https://gopkg.in/xmlpath.v2,gopkg.in/xmlpath* github.com/go-xmlpath/xmlpath* github.com/crankycoder/xmlpath* launchpad.net/xmlpath* github.com/masterzen/xmlpath* github.com/going/toolkit/xmlpath* gopkg.in/go-xmlpath/xmlpath*
+xmlquery,https://github.com/antchfx/xmlquery,github.com/antchfx/xmlquery*
+XPath,https://github.com/antchfx/xpath,github.com/antchfx/xpath*
+xpathparser,https://github.com/santhosh-tekuri/xpathparser,github.com/santhosh-tekuri/xpathparser*
 yaml,https://gopkg.in/yaml.v3,gopkg.in/yaml*
 zap,https://go.uber.org/zap,go.uber.org/zap*


### PR DESCRIPTION
While doing this I found some extra package paths that we should use, which I've implemented [here](https://github.com/github/codeql/pull/17113) and [here](https://github.com/github/codeql/pull/17114).