### PR TITLE
Swift: Improve doc for swift/sql-injection

### DIFF
--- a/swift/ql/src/queries/Security/CWE-089/SqlInjection.qhelp
+++ b/swift/ql/src/queries/Security/CWE-089/SqlInjection.qhelp
@@ -12,7 +12,7 @@ If a database query (such as a SQL query) is built from user-provided data witho
 <recommendation>
 
 <p>
-Most database connector libraries offer a way to safely embed untrusted data into a query using query parameters or prepared statements. You should use these features to build queries, rather than string concatenation or similar methods without sufficient sanitization.
+Most database connector libraries offer a way to safely embed untrusted data into a query using query parameters or prepared statements. You should use these features to build queries, rather than string concatenation or similar methods. It's also possible to escape (sanitize) user-controlled strings so that they can be included directly in an SQL command, but this approach is only safe if the chosen escaping function is robust.
 </p>
 
 </recommendation>

--- a/swift/ql/src/queries/Security/CWE-089/SqlInjection.qhelp
+++ b/swift/ql/src/queries/Security/CWE-089/SqlInjection.qhelp
@@ -12,7 +12,7 @@ If a database query (such as a SQL query) is built from user-provided data witho
 <recommendation>
 
 <p>
-Most database connector libraries offer a way to safely embed untrusted data into a query using query parameters or prepared statements. You should use these features to build queries, rather than string concatenation or similar methods. It's also possible to escape (sanitize) user-controlled strings so that they can be included directly in an SQL command, but this approach is only safe if the chosen escaping function is robust.
+Most database connector libraries offer a way to safely embed untrusted data into a query using query parameters or prepared statements. You should use these features to build queries, rather than string concatenation or similar methods. You can also escape (sanitize) user-controlled strings so that they can be included directly in an SQL command, but this approach is only safe if the chosen escaping function is robust.
 </p>
 
 </recommendation>

--- a/swift/ql/src/queries/Security/CWE-089/SqlInjection.qhelp
+++ b/swift/ql/src/queries/Security/CWE-089/SqlInjection.qhelp
@@ -18,7 +18,7 @@ Most database connector libraries offer a way to safely embed untrusted data int
 </recommendation>
 <example>
 
-<p>In the following example, a SQL query is prepared using string interpolation to directly include a user-controlled value <code>userControlledString</code> in the query. An attacker could craft <code>userControlledString</code> to change the overall meaning of the SQL query.
+<p>In the following examples, an SQL query is prepared using string interpolation to directly include a user-controlled value <code>userControlledString</code> in the query. An attacker could craft <code>userControlledString</code> to change the overall meaning of the SQL query.
 </p>
 
 <sample src="SqlInjectionBad.swift" />

--- a/swift/ql/src/queries/Security/CWE-089/SqlInjection.qhelp
+++ b/swift/ql/src/queries/Security/CWE-089/SqlInjection.qhelp
@@ -12,7 +12,7 @@ If a database query (such as a SQL query) is built from user-provided data witho
 <recommendation>
 
 <p>
-Most database connector libraries offer a way to safely embed untrusted data into a query using query parameters or prepared statements. You should use these features to build queries, rather than string concatenation or similar methods. You can also escape (sanitize) user-controlled strings so that they can be included directly in an SQL command, but this approach is only safe if the chosen escaping function is robust.
+Most database connector libraries offer a way to safely embed untrusted data into a query using query parameters or prepared statements. You should use these features to build queries, rather than string concatenation or similar methods. You can also escape (sanitize) user-controlled strings so that they can be included directly in an SQL command. A library function should be used for escaping, because this approach is only safe if the escaping function is robust against all possible inputs.
 </p>
 
 </recommendation>

--- a/swift/ql/src/queries/Security/CWE-089/SqlInjectionBad.swift
+++ b/swift/ql/src/queries/Security/CWE-089/SqlInjectionBad.swift
@@ -1,3 +1,12 @@
-let unsafeQuery = "SELECT * FROM users WHERE username='\(userControlledString)'" // BAD
+// with SQLite.swift
 
-try db.execute(unsafeQuery)
+let unsafeQuery = "SELECT * FROM users WHERE username='\(userControlledString)'"
+
+try db.execute(unsafeQuery) // BAD
+
+let stmt = try db.prepare(unsafeQuery) // also BAD
+try stmt.run()
+
+// with SQLite3 C API
+
+let result = sqlite3_exec(db, unsafeQuery, nil, nil, nil) // BAD

--- a/swift/ql/src/queries/Security/CWE-089/SqlInjectionGood.swift
+++ b/swift/ql/src/queries/Security/CWE-089/SqlInjectionGood.swift
@@ -1,4 +1,4 @@
 let safeQuery = "SELECT * FROM users WHERE username=?"
 
 let stmt = try db.prepare(safeQuery, userControlledString) // GOOD
-try stmt2.run()
+try stmt.run()

--- a/swift/ql/src/queries/Security/CWE-089/SqlInjectionGood.swift
+++ b/swift/ql/src/queries/Security/CWE-089/SqlInjectionGood.swift
@@ -1,4 +1,19 @@
+// with SQLite.swift
+
 let safeQuery = "SELECT * FROM users WHERE username=?"
 
 let stmt = try db.prepare(safeQuery, userControlledString) // GOOD
 try stmt.run()
+
+// with sqlite3 C API
+
+var stmt2: OpaquePointer?
+
+if (sqlite3_prepare_v2(db, safeQuery, -1, &stmt2, nil) == SQLITE_OK) {
+	if (sqlite3_bind_text(stmt2, 1, userControlledString, -1, SQLITE_TRANSIENT) == SQLITE_OK) { // GOOD
+		let result = sqlite3_step(stmt2)
+
+		// ...
+	}
+	sqlite3_finalize(stmt2)
+}


### PR DESCRIPTION
Improve the `swift/sql-injection` qhelp and examples in various ways, with the aim of making it clearer what these problems look like and how they should be fixed.