### PR TITLE
Swift: Disable some FileManager models

### DIFF
--- a/swift/ql/lib/change-notes/2024-08-01-filemanager-model.md
+++ b/swift/ql/lib/change-notes/2024-08-01-filemanager-model.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The model for `FileManager` no longer considers methods that return paths on the file system as taint sources. This is because these sources have been found to produce results of low value.

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/FileManager.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/FileManager.qll
@@ -7,18 +7,23 @@ private import codeql.swift.dataflow.ExternalFlow
 
 /**
  * A model for `FileManager` members that are flow sources.
+ *
+ * Note that functions returning paths on the file system have been removed
+ * from this model. Though they are in principle tainted by the data on the
+ * local filesystem, in practice we've found results from them almost always
+ * have little value.
  */
 private class FileManagerSource extends SourceModelCsv {
   override predicate row(string row) {
     row =
       [
-        ";FileManager;true;contentsOfDirectory(at:includingPropertiesForKeys:options:);;;ReturnValue;local",
-        ";FileManager;true;contentsOfDirectory(atPath:);;;ReturnValue;local",
-        ";FileManager;true;directoryContents(atPath:);;;ReturnValue;local",
-        ";FileManager;true;subpathsOfDirectory(atPath:);;;ReturnValue;local",
-        ";FileManager;true;subpaths(atPath:);;;ReturnValue;local",
-        ";FileManager;true;destinationOfSymbolicLink(atPath:);;;ReturnValue;local",
-        ";FileManager;true;pathContentOfSymbolicLink(atPath:);;;ReturnValue;local",
+        //";FileManager;true;contentsOfDirectory(at:includingPropertiesForKeys:options:);;;ReturnValue;local",
+        //";FileManager;true;contentsOfDirectory(atPath:);;;ReturnValue;local",
+        //";FileManager;true;directoryContents(atPath:);;;ReturnValue;local",
+        //";FileManager;true;subpathsOfDirectory(atPath:);;;ReturnValue;local",
+        //";FileManager;true;subpaths(atPath:);;;ReturnValue;local",
+        //";FileManager;true;destinationOfSymbolicLink(atPath:);;;ReturnValue;local",
+        //";FileManager;true;pathContentOfSymbolicLink(atPath:);;;ReturnValue;local",
         ";FileManager;true;contents(atPath:);;;ReturnValue;local"
       ]
   }

--- a/swift/ql/lib/codeql/swift/security/CommandInjectionExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/CommandInjectionExtensions.qll
@@ -64,12 +64,5 @@ private class CommandInjectionDefaultBarrier extends CommandInjectionBarrier {
   CommandInjectionDefaultBarrier() {
     // any numeric type
     this.asExpr().getType().getUnderlyingType().getABaseType*().getName() = "Numeric"
-    or
-    // we get poor results when the tainted data is a directory list, such as
-    // the result of `FileMananger.contentsOfDirectory` and similar functions.
-    exists(CallExpr ce |
-      ce.getStaticTarget().getName().matches(["%directory%", "%Directory%"]) and
-      this.asExpr() = ce
-    )
   }
 }

--- a/swift/ql/lib/codeql/swift/security/CommandInjectionExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/CommandInjectionExtensions.qll
@@ -64,5 +64,12 @@ private class CommandInjectionDefaultBarrier extends CommandInjectionBarrier {
   CommandInjectionDefaultBarrier() {
     // any numeric type
     this.asExpr().getType().getUnderlyingType().getABaseType*().getName() = "Numeric"
+    or
+    // we get poor results when the tainted data is a directory list, such as
+    // the result of `FileMananger.contentsOfDirectory` and similar functions.
+    exists(CallExpr ce |
+      ce.getStaticTarget().getName().matches(["%directory%", "%Directory%"]) and
+      this.asExpr() = ce
+    )
   }
 }

--- a/swift/ql/test/library-tests/dataflow/flowsources/FlowSourcesInline.expected
+++ b/swift/ql/test/library-tests/dataflow/flowsources/FlowSourcesInline.expected
@@ -1,2 +1,2 @@
-failures
 testFailures
+failures

--- a/swift/ql/test/library-tests/dataflow/flowsources/filemanager.swift
+++ b/swift/ql/test/library-tests/dataflow/flowsources/filemanager.swift
@@ -34,15 +34,15 @@ class FileManager : NSObject {
 func testFileHandle(fm: FileManager, url: URL, path: String) {
 	do
 	{
-		let contents1 = try fm.contentsOfDirectory(at: url, includingPropertiesForKeys: nil) // $ source=local
-		let contents2 = try fm.contentsOfDirectory(atPath: path) // $ source=local
-		let contents3 = fm.directoryContents(atPath: path)! // $ source=local
+		let contents1 = try fm.contentsOfDirectory(at: url, includingPropertiesForKeys: nil)
+		let contents2 = try fm.contentsOfDirectory(atPath: path)
+		let contents3 = fm.directoryContents(atPath: path)!
 
-		let subpaths1 = try fm.subpathsOfDirectory(atPath: path) // $ source=local
-		let subpaths2 = fm.subpaths(atPath: path)! // $ source=local
+		let subpaths1 = try fm.subpathsOfDirectory(atPath: path)
+		let subpaths2 = fm.subpaths(atPath: path)!
 
-		let link1 = try fm.destinationOfSymbolicLink(atPath: path) // $ source=local
-		let link2 = fm.pathContentOfSymbolicLink(atPath: path)! // $ source=local
+		let link1 = try fm.destinationOfSymbolicLink(atPath: path)
+		let link2 = fm.pathContentOfSymbolicLink(atPath: path)!
 
 		let data = fm.contents(atPath: path)! // $ source=local
 	} catch {

--- a/swift/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
+++ b/swift/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
@@ -1,364 +1,364 @@
 edges
-| CommandInjection.swift:58:22:58:33 | command | CommandInjection.swift:62:16:62:16 | command | provenance |  |
-| CommandInjection.swift:58:22:58:33 | command [some:0] | CommandInjection.swift:62:16:62:16 | command [some:0] | provenance |  |
-| CommandInjection.swift:62:16:62:16 | command | CommandInjection.swift:62:16:62:16 | command [some:0] | provenance |  |
-| CommandInjection.swift:69:8:69:12 | let ...? [some:0, some:0] | CommandInjection.swift:69:12:69:12 | userControlledString [some:0] | provenance |  |
-| CommandInjection.swift:69:8:69:12 | let ...? [some:0] | CommandInjection.swift:69:12:69:12 | userControlledString | provenance |  |
-| CommandInjection.swift:69:12:69:12 | userControlledString | CommandInjection.swift:75:27:75:27 | userControlledString | provenance |  |
-| CommandInjection.swift:69:12:69:12 | userControlledString | CommandInjection.swift:78:43:78:43 | userControlledString | provenance |  |
-| CommandInjection.swift:69:12:69:12 | userControlledString [some:0] | CommandInjection.swift:78:43:78:43 | userControlledString [some:0] | provenance |  |
-| CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) | CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) [some:0] | provenance |  |
-| CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) | CommandInjection.swift:75:27:75:27 | userControlledString | provenance |  |
-| CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) | CommandInjection.swift:78:43:78:43 | userControlledString | provenance |  |
-| CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) [some:0, some:0] | CommandInjection.swift:69:8:69:12 | let ...? [some:0, some:0] | provenance |  |
-| CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) [some:0] | CommandInjection.swift:69:8:69:12 | let ...? [some:0] | provenance |  |
-| CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) [some:0] | CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) [some:0, some:0] | provenance |  |
-| CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) [some:0] | CommandInjection.swift:78:43:78:43 | userControlledString [some:0] | provenance |  |
-| CommandInjection.swift:75:2:75:2 | [post] task1 [arguments, Collection element] | CommandInjection.swift:75:2:75:2 | [post] task1 | provenance |  |
-| CommandInjection.swift:75:20:75:47 | [...] [Collection element] | CommandInjection.swift:75:2:75:2 | [post] task1 [arguments, Collection element] | provenance |  |
-| CommandInjection.swift:75:27:75:27 | userControlledString | CommandInjection.swift:75:20:75:47 | [...] [Collection element] | provenance |  |
-| CommandInjection.swift:78:5:78:9 | let ...? [some:0] | CommandInjection.swift:78:9:78:9 | validatedString | provenance |  |
-| CommandInjection.swift:78:9:78:9 | validatedString | CommandInjection.swift:81:31:81:31 | validatedString | provenance |  |
-| CommandInjection.swift:78:27:78:63 | call to validateCommand(_:) | CommandInjection.swift:81:31:81:31 | validatedString | provenance |  |
-| CommandInjection.swift:78:27:78:63 | call to validateCommand(_:) [some:0] | CommandInjection.swift:78:5:78:9 | let ...? [some:0] | provenance |  |
-| CommandInjection.swift:78:43:78:43 | userControlledString | CommandInjection.swift:58:22:58:33 | command | provenance |  |
-| CommandInjection.swift:78:43:78:43 | userControlledString | CommandInjection.swift:78:27:78:63 | call to validateCommand(_:) | provenance |  |
-| CommandInjection.swift:78:43:78:43 | userControlledString | CommandInjection.swift:78:27:78:63 | call to validateCommand(_:) [some:0] | provenance |  |
-| CommandInjection.swift:78:43:78:43 | userControlledString [some:0] | CommandInjection.swift:58:22:58:33 | command [some:0] | provenance |  |
-| CommandInjection.swift:78:43:78:43 | userControlledString [some:0] | CommandInjection.swift:78:27:78:63 | call to validateCommand(_:) [some:0] | provenance |  |
-| CommandInjection.swift:81:6:81:6 | [post] task2 [arguments, Collection element] | CommandInjection.swift:81:6:81:6 | [post] task2 | provenance |  |
-| CommandInjection.swift:81:24:81:46 | [...] [Collection element] | CommandInjection.swift:81:6:81:6 | [post] task2 [arguments, Collection element] | provenance |  |
-| CommandInjection.swift:81:31:81:31 | validatedString | CommandInjection.swift:81:24:81:46 | [...] [Collection element] | provenance |  |
-| CommandInjection.swift:93:20:93:40 | arguments [Collection element] | CommandInjection.swift:94:20:94:20 | arguments [Collection element] | provenance |  |
-| CommandInjection.swift:94:3:94:3 | [post] self [arguments, Collection element] | CommandInjection.swift:94:3:94:3 | [post] self | provenance |  |
-| CommandInjection.swift:94:20:94:20 | arguments [Collection element] | CommandInjection.swift:94:3:94:3 | [post] self [arguments, Collection element] | provenance |  |
-| CommandInjection.swift:99:8:99:12 | let ...? [some:0] | CommandInjection.swift:99:12:99:12 | userControlledString | provenance |  |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:114:36:114:36 | userControlledString | provenance |  |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:115:28:115:28 | userControlledString | provenance |  |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:119:45:119:45 | userControlledString | provenance |  |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:120:36:120:36 | userControlledString | provenance |  |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:121:28:121:36 | ... .+(_:_:) ... | provenance |  |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:125:46:125:46 | userControlledString | provenance |  |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:126:22:126:22 | userControlledString | provenance |  |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:130:45:130:45 | userControlledString | provenance |  |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:131:36:131:36 | userControlledString | provenance |  |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:132:21:132:21 | userControlledString | provenance |  |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:133:22:133:22 | userControlledString | provenance |  |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:134:24:134:24 | userControlledString | provenance |  |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:144:42:144:42 | userControlledString | provenance |  |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:145:75:145:75 | userControlledString | provenance |  |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:148:35:148:35 | userControlledString | provenance |  |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:149:70:149:70 | userControlledString | provenance |  |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:154:53:154:53 | userControlledString | provenance |  |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:157:52:157:52 | userControlledString | provenance |  |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:158:33:158:33 | userControlledString | provenance |  |
-| CommandInjection.swift:99:12:99:12 | userControlledString | CommandInjection.swift:160:57:160:57 | userControlledString | provenance |  |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) [some:0] | provenance |  |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:114:36:114:36 | userControlledString | provenance |  |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:115:28:115:28 | userControlledString | provenance |  |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:119:45:119:45 | userControlledString | provenance |  |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:120:36:120:36 | userControlledString | provenance |  |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:121:28:121:36 | ... .+(_:_:) ... | provenance |  |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:125:46:125:46 | userControlledString | provenance |  |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:126:22:126:22 | userControlledString | provenance |  |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:130:45:130:45 | userControlledString | provenance |  |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:131:36:131:36 | userControlledString | provenance |  |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:132:21:132:21 | userControlledString | provenance |  |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:133:22:133:22 | userControlledString | provenance |  |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:134:24:134:24 | userControlledString | provenance |  |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:144:42:144:42 | userControlledString | provenance |  |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:145:75:145:75 | userControlledString | provenance |  |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:148:35:148:35 | userControlledString | provenance |  |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:149:70:149:70 | userControlledString | provenance |  |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:154:53:154:53 | userControlledString | provenance |  |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:157:52:157:52 | userControlledString | provenance |  |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:158:33:158:33 | userControlledString | provenance |  |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:160:57:160:57 | userControlledString | provenance |  |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) [some:0] | CommandInjection.swift:99:8:99:12 | let ...? [some:0] | provenance |  |
-| CommandInjection.swift:114:2:114:2 | [post] task3 [executableURL] | CommandInjection.swift:114:2:114:2 | [post] task3 | provenance |  |
-| CommandInjection.swift:114:24:114:56 | call to URL.init(string:) [some:0] | CommandInjection.swift:114:24:114:57 | ...! | provenance |  |
-| CommandInjection.swift:114:24:114:57 | ...! | CommandInjection.swift:114:2:114:2 | [post] task3 [executableURL] | provenance |  |
-| CommandInjection.swift:114:36:114:36 | userControlledString | CommandInjection.swift:114:24:114:56 | call to URL.init(string:) [some:0] | provenance |  |
-| CommandInjection.swift:115:2:115:2 | [post] task3 [arguments, Collection element] | CommandInjection.swift:115:2:115:2 | [post] task3 | provenance |  |
-| CommandInjection.swift:115:20:115:48 | [...] [Collection element] | CommandInjection.swift:115:2:115:2 | [post] task3 [arguments, Collection element] | provenance |  |
-| CommandInjection.swift:115:28:115:28 | userControlledString | CommandInjection.swift:115:20:115:48 | [...] [Collection element] | provenance |  |
-| CommandInjection.swift:119:2:119:2 | [post] task4 [executableURL] | CommandInjection.swift:119:2:119:2 | [post] task4 | provenance |  |
-| CommandInjection.swift:119:24:119:65 | call to URL.init(fileURLWithPath:) | CommandInjection.swift:119:2:119:2 | [post] task4 [executableURL] | provenance |  |
-| CommandInjection.swift:119:45:119:45 | userControlledString | CommandInjection.swift:119:24:119:65 | call to URL.init(fileURLWithPath:) | provenance |  |
-| CommandInjection.swift:120:2:120:2 | [post] task4 [executableURL] | CommandInjection.swift:120:2:120:2 | [post] task4 | provenance |  |
+| CommandInjection.swift:64:22:64:33 | command | CommandInjection.swift:68:16:68:16 | command | provenance |  |
+| CommandInjection.swift:64:22:64:33 | command [some:0] | CommandInjection.swift:68:16:68:16 | command [some:0] | provenance |  |
+| CommandInjection.swift:68:16:68:16 | command | CommandInjection.swift:68:16:68:16 | command [some:0] | provenance |  |
+| CommandInjection.swift:75:8:75:12 | let ...? [some:0, some:0] | CommandInjection.swift:75:12:75:12 | userControlledString [some:0] | provenance |  |
+| CommandInjection.swift:75:8:75:12 | let ...? [some:0] | CommandInjection.swift:75:12:75:12 | userControlledString | provenance |  |
+| CommandInjection.swift:75:12:75:12 | userControlledString | CommandInjection.swift:81:27:81:27 | userControlledString | provenance |  |
+| CommandInjection.swift:75:12:75:12 | userControlledString | CommandInjection.swift:84:43:84:43 | userControlledString | provenance |  |
+| CommandInjection.swift:75:12:75:12 | userControlledString [some:0] | CommandInjection.swift:84:43:84:43 | userControlledString [some:0] | provenance |  |
+| CommandInjection.swift:75:40:75:94 | call to String.init(contentsOf:) | CommandInjection.swift:75:40:75:94 | call to String.init(contentsOf:) [some:0] | provenance |  |
+| CommandInjection.swift:75:40:75:94 | call to String.init(contentsOf:) | CommandInjection.swift:81:27:81:27 | userControlledString | provenance |  |
+| CommandInjection.swift:75:40:75:94 | call to String.init(contentsOf:) | CommandInjection.swift:84:43:84:43 | userControlledString | provenance |  |
+| CommandInjection.swift:75:40:75:94 | call to String.init(contentsOf:) [some:0, some:0] | CommandInjection.swift:75:8:75:12 | let ...? [some:0, some:0] | provenance |  |
+| CommandInjection.swift:75:40:75:94 | call to String.init(contentsOf:) [some:0] | CommandInjection.swift:75:8:75:12 | let ...? [some:0] | provenance |  |
+| CommandInjection.swift:75:40:75:94 | call to String.init(contentsOf:) [some:0] | CommandInjection.swift:75:40:75:94 | call to String.init(contentsOf:) [some:0, some:0] | provenance |  |
+| CommandInjection.swift:75:40:75:94 | call to String.init(contentsOf:) [some:0] | CommandInjection.swift:84:43:84:43 | userControlledString [some:0] | provenance |  |
+| CommandInjection.swift:81:2:81:2 | [post] task1 [arguments, Collection element] | CommandInjection.swift:81:2:81:2 | [post] task1 | provenance |  |
+| CommandInjection.swift:81:20:81:47 | [...] [Collection element] | CommandInjection.swift:81:2:81:2 | [post] task1 [arguments, Collection element] | provenance |  |
+| CommandInjection.swift:81:27:81:27 | userControlledString | CommandInjection.swift:81:20:81:47 | [...] [Collection element] | provenance |  |
+| CommandInjection.swift:84:5:84:9 | let ...? [some:0] | CommandInjection.swift:84:9:84:9 | validatedString | provenance |  |
+| CommandInjection.swift:84:9:84:9 | validatedString | CommandInjection.swift:87:31:87:31 | validatedString | provenance |  |
+| CommandInjection.swift:84:27:84:63 | call to validateCommand(_:) | CommandInjection.swift:87:31:87:31 | validatedString | provenance |  |
+| CommandInjection.swift:84:27:84:63 | call to validateCommand(_:) [some:0] | CommandInjection.swift:84:5:84:9 | let ...? [some:0] | provenance |  |
+| CommandInjection.swift:84:43:84:43 | userControlledString | CommandInjection.swift:64:22:64:33 | command | provenance |  |
+| CommandInjection.swift:84:43:84:43 | userControlledString | CommandInjection.swift:84:27:84:63 | call to validateCommand(_:) | provenance |  |
+| CommandInjection.swift:84:43:84:43 | userControlledString | CommandInjection.swift:84:27:84:63 | call to validateCommand(_:) [some:0] | provenance |  |
+| CommandInjection.swift:84:43:84:43 | userControlledString [some:0] | CommandInjection.swift:64:22:64:33 | command [some:0] | provenance |  |
+| CommandInjection.swift:84:43:84:43 | userControlledString [some:0] | CommandInjection.swift:84:27:84:63 | call to validateCommand(_:) [some:0] | provenance |  |
+| CommandInjection.swift:87:6:87:6 | [post] task2 [arguments, Collection element] | CommandInjection.swift:87:6:87:6 | [post] task2 | provenance |  |
+| CommandInjection.swift:87:24:87:46 | [...] [Collection element] | CommandInjection.swift:87:6:87:6 | [post] task2 [arguments, Collection element] | provenance |  |
+| CommandInjection.swift:87:31:87:31 | validatedString | CommandInjection.swift:87:24:87:46 | [...] [Collection element] | provenance |  |
+| CommandInjection.swift:99:20:99:40 | arguments [Collection element] | CommandInjection.swift:100:20:100:20 | arguments [Collection element] | provenance |  |
+| CommandInjection.swift:100:3:100:3 | [post] self [arguments, Collection element] | CommandInjection.swift:100:3:100:3 | [post] self | provenance |  |
+| CommandInjection.swift:100:20:100:20 | arguments [Collection element] | CommandInjection.swift:100:3:100:3 | [post] self [arguments, Collection element] | provenance |  |
+| CommandInjection.swift:105:8:105:12 | let ...? [some:0] | CommandInjection.swift:105:12:105:12 | userControlledString | provenance |  |
+| CommandInjection.swift:105:12:105:12 | userControlledString | CommandInjection.swift:120:36:120:36 | userControlledString | provenance |  |
+| CommandInjection.swift:105:12:105:12 | userControlledString | CommandInjection.swift:121:28:121:28 | userControlledString | provenance |  |
+| CommandInjection.swift:105:12:105:12 | userControlledString | CommandInjection.swift:125:45:125:45 | userControlledString | provenance |  |
+| CommandInjection.swift:105:12:105:12 | userControlledString | CommandInjection.swift:126:36:126:36 | userControlledString | provenance |  |
+| CommandInjection.swift:105:12:105:12 | userControlledString | CommandInjection.swift:127:28:127:36 | ... .+(_:_:) ... | provenance |  |
+| CommandInjection.swift:105:12:105:12 | userControlledString | CommandInjection.swift:131:46:131:46 | userControlledString | provenance |  |
+| CommandInjection.swift:105:12:105:12 | userControlledString | CommandInjection.swift:132:22:132:22 | userControlledString | provenance |  |
+| CommandInjection.swift:105:12:105:12 | userControlledString | CommandInjection.swift:136:45:136:45 | userControlledString | provenance |  |
+| CommandInjection.swift:105:12:105:12 | userControlledString | CommandInjection.swift:137:36:137:36 | userControlledString | provenance |  |
+| CommandInjection.swift:105:12:105:12 | userControlledString | CommandInjection.swift:138:21:138:21 | userControlledString | provenance |  |
+| CommandInjection.swift:105:12:105:12 | userControlledString | CommandInjection.swift:139:22:139:22 | userControlledString | provenance |  |
+| CommandInjection.swift:105:12:105:12 | userControlledString | CommandInjection.swift:140:24:140:24 | userControlledString | provenance |  |
+| CommandInjection.swift:105:12:105:12 | userControlledString | CommandInjection.swift:150:42:150:42 | userControlledString | provenance |  |
+| CommandInjection.swift:105:12:105:12 | userControlledString | CommandInjection.swift:151:75:151:75 | userControlledString | provenance |  |
+| CommandInjection.swift:105:12:105:12 | userControlledString | CommandInjection.swift:154:35:154:35 | userControlledString | provenance |  |
+| CommandInjection.swift:105:12:105:12 | userControlledString | CommandInjection.swift:155:70:155:70 | userControlledString | provenance |  |
+| CommandInjection.swift:105:12:105:12 | userControlledString | CommandInjection.swift:160:53:160:53 | userControlledString | provenance |  |
+| CommandInjection.swift:105:12:105:12 | userControlledString | CommandInjection.swift:163:52:163:52 | userControlledString | provenance |  |
+| CommandInjection.swift:105:12:105:12 | userControlledString | CommandInjection.swift:164:33:164:33 | userControlledString | provenance |  |
+| CommandInjection.swift:105:12:105:12 | userControlledString | CommandInjection.swift:166:57:166:57 | userControlledString | provenance |  |
+| CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) [some:0] | provenance |  |
+| CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:120:36:120:36 | userControlledString | provenance |  |
+| CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:121:28:121:28 | userControlledString | provenance |  |
+| CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:125:45:125:45 | userControlledString | provenance |  |
+| CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:126:36:126:36 | userControlledString | provenance |  |
+| CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:127:28:127:36 | ... .+(_:_:) ... | provenance |  |
+| CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:131:46:131:46 | userControlledString | provenance |  |
+| CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:132:22:132:22 | userControlledString | provenance |  |
+| CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:136:45:136:45 | userControlledString | provenance |  |
+| CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:137:36:137:36 | userControlledString | provenance |  |
+| CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:138:21:138:21 | userControlledString | provenance |  |
+| CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:139:22:139:22 | userControlledString | provenance |  |
+| CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:140:24:140:24 | userControlledString | provenance |  |
+| CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:150:42:150:42 | userControlledString | provenance |  |
+| CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:151:75:151:75 | userControlledString | provenance |  |
+| CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:154:35:154:35 | userControlledString | provenance |  |
+| CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:155:70:155:70 | userControlledString | provenance |  |
+| CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:160:53:160:53 | userControlledString | provenance |  |
+| CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:163:52:163:52 | userControlledString | provenance |  |
+| CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:164:33:164:33 | userControlledString | provenance |  |
+| CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:166:57:166:57 | userControlledString | provenance |  |
+| CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) [some:0] | CommandInjection.swift:105:8:105:12 | let ...? [some:0] | provenance |  |
+| CommandInjection.swift:120:2:120:2 | [post] task3 [executableURL] | CommandInjection.swift:120:2:120:2 | [post] task3 | provenance |  |
 | CommandInjection.swift:120:24:120:56 | call to URL.init(string:) [some:0] | CommandInjection.swift:120:24:120:57 | ...! | provenance |  |
-| CommandInjection.swift:120:24:120:57 | ...! | CommandInjection.swift:120:2:120:2 | [post] task4 [executableURL] | provenance |  |
+| CommandInjection.swift:120:24:120:57 | ...! | CommandInjection.swift:120:2:120:2 | [post] task3 [executableURL] | provenance |  |
 | CommandInjection.swift:120:36:120:36 | userControlledString | CommandInjection.swift:120:24:120:56 | call to URL.init(string:) [some:0] | provenance |  |
-| CommandInjection.swift:121:2:121:2 | [post] task4 [arguments, Collection element] | CommandInjection.swift:121:2:121:2 | [post] task4 | provenance |  |
-| CommandInjection.swift:121:20:121:56 | [...] [Collection element] | CommandInjection.swift:121:2:121:2 | [post] task4 [arguments, Collection element] | provenance |  |
-| CommandInjection.swift:121:28:121:36 | ... .+(_:_:) ... | CommandInjection.swift:121:20:121:56 | [...] [Collection element] | provenance |  |
-| CommandInjection.swift:125:2:125:7 | [post] ...? [executableURL] | CommandInjection.swift:125:2:125:7 | [post] ...? | provenance |  |
-| CommandInjection.swift:125:25:125:66 | call to URL.init(fileURLWithPath:) | CommandInjection.swift:125:2:125:7 | [post] ...? [executableURL] | provenance |  |
-| CommandInjection.swift:125:46:125:46 | userControlledString | CommandInjection.swift:125:25:125:66 | call to URL.init(fileURLWithPath:) | provenance |  |
-| CommandInjection.swift:126:2:126:7 | [post] ...? [arguments, Collection element] | CommandInjection.swift:126:2:126:7 | [post] ...? | provenance |  |
-| CommandInjection.swift:126:21:126:42 | [...] [Collection element] | CommandInjection.swift:126:2:126:7 | [post] ...? [arguments, Collection element] | provenance |  |
-| CommandInjection.swift:126:22:126:22 | userControlledString | CommandInjection.swift:126:21:126:42 | [...] [Collection element] | provenance |  |
-| CommandInjection.swift:130:2:130:2 | [post] task6 [executableURL] | CommandInjection.swift:130:2:130:2 | [post] task6 | provenance |  |
-| CommandInjection.swift:130:24:130:65 | call to URL.init(fileURLWithPath:) | CommandInjection.swift:130:2:130:2 | [post] task6 [executableURL] | provenance |  |
-| CommandInjection.swift:130:45:130:45 | userControlledString | CommandInjection.swift:130:24:130:65 | call to URL.init(fileURLWithPath:) | provenance |  |
-| CommandInjection.swift:131:2:131:2 | [post] task6 [executableURL] | CommandInjection.swift:131:2:131:2 | [post] task6 | provenance |  |
-| CommandInjection.swift:131:24:131:56 | call to URL.init(string:) [some:0] | CommandInjection.swift:131:24:131:57 | ...! | provenance |  |
-| CommandInjection.swift:131:24:131:57 | ...! | CommandInjection.swift:131:2:131:2 | [post] task6 [executableURL] | provenance |  |
-| CommandInjection.swift:131:36:131:36 | userControlledString | CommandInjection.swift:131:24:131:56 | call to URL.init(string:) [some:0] | provenance |  |
-| CommandInjection.swift:132:2:132:2 | [post] task6 [arguments, Collection element] | CommandInjection.swift:132:2:132:2 | [post] task6 | provenance |  |
-| CommandInjection.swift:132:20:132:41 | [...] [Collection element] | CommandInjection.swift:132:2:132:2 | [post] task6 [arguments, Collection element] | provenance |  |
-| CommandInjection.swift:132:21:132:21 | userControlledString | CommandInjection.swift:132:20:132:41 | [...] [Collection element] | provenance |  |
-| CommandInjection.swift:133:21:133:42 | [...] [Collection element] | CommandInjection.swift:93:20:93:40 | arguments [Collection element] | provenance |  |
-| CommandInjection.swift:133:22:133:22 | userControlledString | CommandInjection.swift:133:21:133:42 | [...] [Collection element] | provenance |  |
-| CommandInjection.swift:134:24:134:24 | userControlledString | CommandInjection.swift:144:42:144:42 | userControlledString | provenance |  |
-| CommandInjection.swift:134:24:134:24 | userControlledString | CommandInjection.swift:145:75:145:75 | userControlledString | provenance |  |
-| CommandInjection.swift:134:24:134:24 | userControlledString | CommandInjection.swift:148:35:148:35 | userControlledString | provenance |  |
-| CommandInjection.swift:134:24:134:24 | userControlledString | CommandInjection.swift:149:70:149:70 | userControlledString | provenance |  |
-| CommandInjection.swift:134:24:134:24 | userControlledString | CommandInjection.swift:154:53:154:53 | userControlledString | provenance |  |
-| CommandInjection.swift:134:24:134:24 | userControlledString | CommandInjection.swift:157:52:157:52 | userControlledString | provenance |  |
-| CommandInjection.swift:134:24:134:24 | userControlledString | CommandInjection.swift:158:33:158:33 | userControlledString | provenance |  |
-| CommandInjection.swift:134:24:134:24 | userControlledString | CommandInjection.swift:160:57:160:57 | userControlledString | provenance |  |
-| CommandInjection.swift:145:67:145:95 | [...] [Collection element] | CommandInjection.swift:145:67:145:95 | [...] | provenance |  |
-| CommandInjection.swift:145:75:145:75 | userControlledString | CommandInjection.swift:145:67:145:95 | [...] [Collection element] | provenance |  |
-| CommandInjection.swift:148:23:148:55 | call to URL.init(string:) [some:0] | CommandInjection.swift:148:23:148:56 | ...! | provenance |  |
-| CommandInjection.swift:148:35:148:35 | userControlledString | CommandInjection.swift:148:23:148:55 | call to URL.init(string:) [some:0] | provenance |  |
-| CommandInjection.swift:149:62:149:90 | [...] [Collection element] | CommandInjection.swift:149:62:149:90 | [...] | provenance |  |
-| CommandInjection.swift:149:70:149:70 | userControlledString | CommandInjection.swift:149:62:149:90 | [...] [Collection element] | provenance |  |
-| CommandInjection.swift:154:41:154:73 | call to URL.init(string:) [some:0] | CommandInjection.swift:154:41:154:74 | ...! | provenance |  |
-| CommandInjection.swift:154:53:154:53 | userControlledString | CommandInjection.swift:154:41:154:73 | call to URL.init(string:) [some:0] | provenance |  |
-| CommandInjection.swift:157:40:157:72 | call to URL.init(string:) [some:0] | CommandInjection.swift:157:40:157:73 | ...! | provenance |  |
-| CommandInjection.swift:157:40:157:72 | call to URL.init(string:) [some:0] | CommandInjection.swift:157:40:157:73 | ...! | provenance |  |
-| CommandInjection.swift:157:40:157:73 | ...! | file://:0:0:0:0 | url | provenance |  |
-| CommandInjection.swift:157:52:157:52 | userControlledString | CommandInjection.swift:157:40:157:72 | call to URL.init(string:) [some:0] | provenance |  |
-| CommandInjection.swift:158:32:158:53 | [...] [Collection element] | CommandInjection.swift:158:32:158:53 | [...] | provenance |  |
-| CommandInjection.swift:158:33:158:33 | userControlledString | CommandInjection.swift:158:32:158:53 | [...] [Collection element] | provenance |  |
-| CommandInjection.swift:160:45:160:77 | call to URL.init(string:) [some:0] | CommandInjection.swift:160:45:160:78 | ...! | provenance |  |
-| CommandInjection.swift:160:45:160:77 | call to URL.init(string:) [some:0] | CommandInjection.swift:160:45:160:78 | ...! | provenance |  |
-| CommandInjection.swift:160:45:160:78 | ...! | file://:0:0:0:0 | url | provenance |  |
-| CommandInjection.swift:160:57:160:57 | userControlledString | CommandInjection.swift:160:45:160:77 | call to URL.init(string:) [some:0] | provenance |  |
-| CommandInjection.swift:174:3:174:3 | newValue [Collection element] | CommandInjection.swift:175:19:175:19 | newValue [Collection element] | provenance |  |
-| CommandInjection.swift:174:3:174:3 | newValue [Collection element] | CommandInjection.swift:176:20:176:20 | newValue [Collection element] | provenance |  |
-| CommandInjection.swift:174:3:174:3 | newValue [Collection element] | CommandInjection.swift:177:19:177:19 | newValue [Collection element] | provenance |  |
-| CommandInjection.swift:175:4:175:4 | [post] getter for .p1 [arguments, Collection element] | CommandInjection.swift:175:4:175:4 | [post] getter for .p1 | provenance |  |
-| CommandInjection.swift:175:19:175:19 | newValue [Collection element] | CommandInjection.swift:175:4:175:4 | [post] getter for .p1 [arguments, Collection element] | provenance |  |
-| CommandInjection.swift:176:4:176:6 | [post] ...! [arguments, Collection element] | CommandInjection.swift:176:4:176:6 | [post] ...! | provenance |  |
-| CommandInjection.swift:176:20:176:20 | newValue [Collection element] | CommandInjection.swift:176:4:176:6 | [post] ...! [arguments, Collection element] | provenance |  |
-| CommandInjection.swift:177:4:177:4 | [post] ...! [arguments, Collection element] | CommandInjection.swift:177:4:177:4 | [post] ...! | provenance |  |
-| CommandInjection.swift:177:19:177:19 | newValue [Collection element] | CommandInjection.swift:177:4:177:4 | [post] ...! [arguments, Collection element] | provenance |  |
-| CommandInjection.swift:182:9:182:13 | let ...? [some:0] | CommandInjection.swift:182:13:182:13 | userControlledString | provenance |  |
-| CommandInjection.swift:182:13:182:13 | userControlledString | CommandInjection.swift:186:19:186:19 | userControlledString | provenance |  |
-| CommandInjection.swift:182:13:182:13 | userControlledString | CommandInjection.swift:192:31:192:31 | userControlledString | provenance |  |
-| CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) [some:0] | provenance |  |
-| CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | CommandInjection.swift:186:19:186:19 | userControlledString | provenance |  |
-| CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | CommandInjection.swift:192:31:192:31 | userControlledString | provenance |  |
-| CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) [some:0] | CommandInjection.swift:182:9:182:13 | let ...? [some:0] | provenance |  |
-| CommandInjection.swift:186:18:186:39 | [...] [Collection element] | CommandInjection.swift:188:18:188:18 | tainted1 [Collection element] | provenance |  |
-| CommandInjection.swift:186:18:186:39 | [...] [Collection element] | CommandInjection.swift:189:19:189:19 | tainted1 [Collection element] | provenance |  |
-| CommandInjection.swift:186:18:186:39 | [...] [Collection element] | CommandInjection.swift:190:18:190:18 | tainted1 [Collection element] | provenance |  |
-| CommandInjection.swift:186:19:186:19 | userControlledString | CommandInjection.swift:186:18:186:39 | [...] [Collection element] | provenance |  |
-| CommandInjection.swift:188:3:188:3 | [post] getter for .p1 [arguments, Collection element] | CommandInjection.swift:188:3:188:3 | [post] getter for .p1 | provenance |  |
-| CommandInjection.swift:188:18:188:18 | tainted1 [Collection element] | CommandInjection.swift:188:3:188:3 | [post] getter for .p1 [arguments, Collection element] | provenance |  |
-| CommandInjection.swift:188:18:188:18 | tainted1 [Collection element] | CommandInjection.swift:189:19:189:19 | tainted1 [Collection element] | provenance |  |
-| CommandInjection.swift:188:18:188:18 | tainted1 [Collection element] | CommandInjection.swift:190:18:190:18 | tainted1 [Collection element] | provenance |  |
-| CommandInjection.swift:189:3:189:5 | [post] ...! [arguments, Collection element] | CommandInjection.swift:189:3:189:5 | [post] ...! | provenance |  |
-| CommandInjection.swift:189:19:189:19 | tainted1 [Collection element] | CommandInjection.swift:189:3:189:5 | [post] ...! [arguments, Collection element] | provenance |  |
-| CommandInjection.swift:189:19:189:19 | tainted1 [Collection element] | CommandInjection.swift:190:18:190:18 | tainted1 [Collection element] | provenance |  |
-| CommandInjection.swift:190:3:190:3 | [post] ...! [arguments, Collection element] | CommandInjection.swift:190:3:190:3 | [post] ...! | provenance |  |
-| CommandInjection.swift:190:18:190:18 | tainted1 [Collection element] | CommandInjection.swift:190:3:190:3 | [post] ...! [arguments, Collection element] | provenance |  |
-| CommandInjection.swift:192:30:192:51 | [...] [Collection element] | CommandInjection.swift:194:18:194:18 | tainted2 [Collection element] | provenance |  |
-| CommandInjection.swift:192:30:192:51 | [...] [Collection element] | CommandInjection.swift:195:19:195:19 | tainted2 [Collection element] | provenance |  |
-| CommandInjection.swift:192:30:192:51 | [...] [Collection element] | CommandInjection.swift:196:18:196:18 | tainted2 [Collection element] | provenance |  |
-| CommandInjection.swift:192:30:192:51 | [...] [Collection element] | CommandInjection.swift:198:13:198:13 | tainted2 [Collection element] | provenance |  |
-| CommandInjection.swift:192:31:192:31 | userControlledString | CommandInjection.swift:192:30:192:51 | [...] [Collection element] | provenance |  |
-| CommandInjection.swift:194:3:194:3 | [post] getter for .p1 [arguments, Collection element] | CommandInjection.swift:194:3:194:3 | [post] getter for .p1 | provenance |  |
-| CommandInjection.swift:194:18:194:18 | tainted2 [Collection element] | CommandInjection.swift:194:3:194:3 | [post] getter for .p1 [arguments, Collection element] | provenance |  |
-| CommandInjection.swift:195:3:195:5 | [post] ...! [arguments, Collection element] | CommandInjection.swift:195:3:195:5 | [post] ...! | provenance |  |
-| CommandInjection.swift:195:19:195:19 | tainted2 [Collection element] | CommandInjection.swift:195:3:195:5 | [post] ...! [arguments, Collection element] | provenance |  |
-| CommandInjection.swift:196:3:196:3 | [post] ...! [arguments, Collection element] | CommandInjection.swift:196:3:196:3 | [post] ...! | provenance |  |
-| CommandInjection.swift:196:18:196:18 | tainted2 [Collection element] | CommandInjection.swift:196:3:196:3 | [post] ...! [arguments, Collection element] | provenance |  |
-| CommandInjection.swift:198:13:198:13 | tainted2 [Collection element] | CommandInjection.swift:174:3:174:3 | newValue [Collection element] | provenance |  |
+| CommandInjection.swift:121:2:121:2 | [post] task3 [arguments, Collection element] | CommandInjection.swift:121:2:121:2 | [post] task3 | provenance |  |
+| CommandInjection.swift:121:20:121:48 | [...] [Collection element] | CommandInjection.swift:121:2:121:2 | [post] task3 [arguments, Collection element] | provenance |  |
+| CommandInjection.swift:121:28:121:28 | userControlledString | CommandInjection.swift:121:20:121:48 | [...] [Collection element] | provenance |  |
+| CommandInjection.swift:125:2:125:2 | [post] task4 [executableURL] | CommandInjection.swift:125:2:125:2 | [post] task4 | provenance |  |
+| CommandInjection.swift:125:24:125:65 | call to URL.init(fileURLWithPath:) | CommandInjection.swift:125:2:125:2 | [post] task4 [executableURL] | provenance |  |
+| CommandInjection.swift:125:45:125:45 | userControlledString | CommandInjection.swift:125:24:125:65 | call to URL.init(fileURLWithPath:) | provenance |  |
+| CommandInjection.swift:126:2:126:2 | [post] task4 [executableURL] | CommandInjection.swift:126:2:126:2 | [post] task4 | provenance |  |
+| CommandInjection.swift:126:24:126:56 | call to URL.init(string:) [some:0] | CommandInjection.swift:126:24:126:57 | ...! | provenance |  |
+| CommandInjection.swift:126:24:126:57 | ...! | CommandInjection.swift:126:2:126:2 | [post] task4 [executableURL] | provenance |  |
+| CommandInjection.swift:126:36:126:36 | userControlledString | CommandInjection.swift:126:24:126:56 | call to URL.init(string:) [some:0] | provenance |  |
+| CommandInjection.swift:127:2:127:2 | [post] task4 [arguments, Collection element] | CommandInjection.swift:127:2:127:2 | [post] task4 | provenance |  |
+| CommandInjection.swift:127:20:127:56 | [...] [Collection element] | CommandInjection.swift:127:2:127:2 | [post] task4 [arguments, Collection element] | provenance |  |
+| CommandInjection.swift:127:28:127:36 | ... .+(_:_:) ... | CommandInjection.swift:127:20:127:56 | [...] [Collection element] | provenance |  |
+| CommandInjection.swift:131:2:131:7 | [post] ...? [executableURL] | CommandInjection.swift:131:2:131:7 | [post] ...? | provenance |  |
+| CommandInjection.swift:131:25:131:66 | call to URL.init(fileURLWithPath:) | CommandInjection.swift:131:2:131:7 | [post] ...? [executableURL] | provenance |  |
+| CommandInjection.swift:131:46:131:46 | userControlledString | CommandInjection.swift:131:25:131:66 | call to URL.init(fileURLWithPath:) | provenance |  |
+| CommandInjection.swift:132:2:132:7 | [post] ...? [arguments, Collection element] | CommandInjection.swift:132:2:132:7 | [post] ...? | provenance |  |
+| CommandInjection.swift:132:21:132:42 | [...] [Collection element] | CommandInjection.swift:132:2:132:7 | [post] ...? [arguments, Collection element] | provenance |  |
+| CommandInjection.swift:132:22:132:22 | userControlledString | CommandInjection.swift:132:21:132:42 | [...] [Collection element] | provenance |  |
+| CommandInjection.swift:136:2:136:2 | [post] task6 [executableURL] | CommandInjection.swift:136:2:136:2 | [post] task6 | provenance |  |
+| CommandInjection.swift:136:24:136:65 | call to URL.init(fileURLWithPath:) | CommandInjection.swift:136:2:136:2 | [post] task6 [executableURL] | provenance |  |
+| CommandInjection.swift:136:45:136:45 | userControlledString | CommandInjection.swift:136:24:136:65 | call to URL.init(fileURLWithPath:) | provenance |  |
+| CommandInjection.swift:137:2:137:2 | [post] task6 [executableURL] | CommandInjection.swift:137:2:137:2 | [post] task6 | provenance |  |
+| CommandInjection.swift:137:24:137:56 | call to URL.init(string:) [some:0] | CommandInjection.swift:137:24:137:57 | ...! | provenance |  |
+| CommandInjection.swift:137:24:137:57 | ...! | CommandInjection.swift:137:2:137:2 | [post] task6 [executableURL] | provenance |  |
+| CommandInjection.swift:137:36:137:36 | userControlledString | CommandInjection.swift:137:24:137:56 | call to URL.init(string:) [some:0] | provenance |  |
+| CommandInjection.swift:138:2:138:2 | [post] task6 [arguments, Collection element] | CommandInjection.swift:138:2:138:2 | [post] task6 | provenance |  |
+| CommandInjection.swift:138:20:138:41 | [...] [Collection element] | CommandInjection.swift:138:2:138:2 | [post] task6 [arguments, Collection element] | provenance |  |
+| CommandInjection.swift:138:21:138:21 | userControlledString | CommandInjection.swift:138:20:138:41 | [...] [Collection element] | provenance |  |
+| CommandInjection.swift:139:21:139:42 | [...] [Collection element] | CommandInjection.swift:99:20:99:40 | arguments [Collection element] | provenance |  |
+| CommandInjection.swift:139:22:139:22 | userControlledString | CommandInjection.swift:139:21:139:42 | [...] [Collection element] | provenance |  |
+| CommandInjection.swift:140:24:140:24 | userControlledString | CommandInjection.swift:150:42:150:42 | userControlledString | provenance |  |
+| CommandInjection.swift:140:24:140:24 | userControlledString | CommandInjection.swift:151:75:151:75 | userControlledString | provenance |  |
+| CommandInjection.swift:140:24:140:24 | userControlledString | CommandInjection.swift:154:35:154:35 | userControlledString | provenance |  |
+| CommandInjection.swift:140:24:140:24 | userControlledString | CommandInjection.swift:155:70:155:70 | userControlledString | provenance |  |
+| CommandInjection.swift:140:24:140:24 | userControlledString | CommandInjection.swift:160:53:160:53 | userControlledString | provenance |  |
+| CommandInjection.swift:140:24:140:24 | userControlledString | CommandInjection.swift:163:52:163:52 | userControlledString | provenance |  |
+| CommandInjection.swift:140:24:140:24 | userControlledString | CommandInjection.swift:164:33:164:33 | userControlledString | provenance |  |
+| CommandInjection.swift:140:24:140:24 | userControlledString | CommandInjection.swift:166:57:166:57 | userControlledString | provenance |  |
+| CommandInjection.swift:151:67:151:95 | [...] [Collection element] | CommandInjection.swift:151:67:151:95 | [...] | provenance |  |
+| CommandInjection.swift:151:75:151:75 | userControlledString | CommandInjection.swift:151:67:151:95 | [...] [Collection element] | provenance |  |
+| CommandInjection.swift:154:23:154:55 | call to URL.init(string:) [some:0] | CommandInjection.swift:154:23:154:56 | ...! | provenance |  |
+| CommandInjection.swift:154:35:154:35 | userControlledString | CommandInjection.swift:154:23:154:55 | call to URL.init(string:) [some:0] | provenance |  |
+| CommandInjection.swift:155:62:155:90 | [...] [Collection element] | CommandInjection.swift:155:62:155:90 | [...] | provenance |  |
+| CommandInjection.swift:155:70:155:70 | userControlledString | CommandInjection.swift:155:62:155:90 | [...] [Collection element] | provenance |  |
+| CommandInjection.swift:160:41:160:73 | call to URL.init(string:) [some:0] | CommandInjection.swift:160:41:160:74 | ...! | provenance |  |
+| CommandInjection.swift:160:53:160:53 | userControlledString | CommandInjection.swift:160:41:160:73 | call to URL.init(string:) [some:0] | provenance |  |
+| CommandInjection.swift:163:40:163:72 | call to URL.init(string:) [some:0] | CommandInjection.swift:163:40:163:73 | ...! | provenance |  |
+| CommandInjection.swift:163:40:163:72 | call to URL.init(string:) [some:0] | CommandInjection.swift:163:40:163:73 | ...! | provenance |  |
+| CommandInjection.swift:163:40:163:73 | ...! | file://:0:0:0:0 | url | provenance |  |
+| CommandInjection.swift:163:52:163:52 | userControlledString | CommandInjection.swift:163:40:163:72 | call to URL.init(string:) [some:0] | provenance |  |
+| CommandInjection.swift:164:32:164:53 | [...] [Collection element] | CommandInjection.swift:164:32:164:53 | [...] | provenance |  |
+| CommandInjection.swift:164:33:164:33 | userControlledString | CommandInjection.swift:164:32:164:53 | [...] [Collection element] | provenance |  |
+| CommandInjection.swift:166:45:166:77 | call to URL.init(string:) [some:0] | CommandInjection.swift:166:45:166:78 | ...! | provenance |  |
+| CommandInjection.swift:166:45:166:77 | call to URL.init(string:) [some:0] | CommandInjection.swift:166:45:166:78 | ...! | provenance |  |
+| CommandInjection.swift:166:45:166:78 | ...! | file://:0:0:0:0 | url | provenance |  |
+| CommandInjection.swift:166:57:166:57 | userControlledString | CommandInjection.swift:166:45:166:77 | call to URL.init(string:) [some:0] | provenance |  |
+| CommandInjection.swift:193:3:193:3 | newValue [Collection element] | CommandInjection.swift:194:19:194:19 | newValue [Collection element] | provenance |  |
+| CommandInjection.swift:193:3:193:3 | newValue [Collection element] | CommandInjection.swift:195:20:195:20 | newValue [Collection element] | provenance |  |
+| CommandInjection.swift:193:3:193:3 | newValue [Collection element] | CommandInjection.swift:196:19:196:19 | newValue [Collection element] | provenance |  |
+| CommandInjection.swift:194:4:194:4 | [post] getter for .p1 [arguments, Collection element] | CommandInjection.swift:194:4:194:4 | [post] getter for .p1 | provenance |  |
+| CommandInjection.swift:194:19:194:19 | newValue [Collection element] | CommandInjection.swift:194:4:194:4 | [post] getter for .p1 [arguments, Collection element] | provenance |  |
+| CommandInjection.swift:195:4:195:6 | [post] ...! [arguments, Collection element] | CommandInjection.swift:195:4:195:6 | [post] ...! | provenance |  |
+| CommandInjection.swift:195:20:195:20 | newValue [Collection element] | CommandInjection.swift:195:4:195:6 | [post] ...! [arguments, Collection element] | provenance |  |
+| CommandInjection.swift:196:4:196:4 | [post] ...! [arguments, Collection element] | CommandInjection.swift:196:4:196:4 | [post] ...! | provenance |  |
+| CommandInjection.swift:196:19:196:19 | newValue [Collection element] | CommandInjection.swift:196:4:196:4 | [post] ...! [arguments, Collection element] | provenance |  |
+| CommandInjection.swift:201:9:201:13 | let ...? [some:0] | CommandInjection.swift:201:13:201:13 | userControlledString | provenance |  |
+| CommandInjection.swift:201:13:201:13 | userControlledString | CommandInjection.swift:205:19:205:19 | userControlledString | provenance |  |
+| CommandInjection.swift:201:13:201:13 | userControlledString | CommandInjection.swift:211:31:211:31 | userControlledString | provenance |  |
+| CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) [some:0] | provenance |  |
+| CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | CommandInjection.swift:205:19:205:19 | userControlledString | provenance |  |
+| CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | CommandInjection.swift:211:31:211:31 | userControlledString | provenance |  |
+| CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) [some:0] | CommandInjection.swift:201:9:201:13 | let ...? [some:0] | provenance |  |
+| CommandInjection.swift:205:18:205:39 | [...] [Collection element] | CommandInjection.swift:207:18:207:18 | tainted1 [Collection element] | provenance |  |
+| CommandInjection.swift:205:18:205:39 | [...] [Collection element] | CommandInjection.swift:208:19:208:19 | tainted1 [Collection element] | provenance |  |
+| CommandInjection.swift:205:18:205:39 | [...] [Collection element] | CommandInjection.swift:209:18:209:18 | tainted1 [Collection element] | provenance |  |
+| CommandInjection.swift:205:19:205:19 | userControlledString | CommandInjection.swift:205:18:205:39 | [...] [Collection element] | provenance |  |
+| CommandInjection.swift:207:3:207:3 | [post] getter for .p1 [arguments, Collection element] | CommandInjection.swift:207:3:207:3 | [post] getter for .p1 | provenance |  |
+| CommandInjection.swift:207:18:207:18 | tainted1 [Collection element] | CommandInjection.swift:207:3:207:3 | [post] getter for .p1 [arguments, Collection element] | provenance |  |
+| CommandInjection.swift:207:18:207:18 | tainted1 [Collection element] | CommandInjection.swift:208:19:208:19 | tainted1 [Collection element] | provenance |  |
+| CommandInjection.swift:207:18:207:18 | tainted1 [Collection element] | CommandInjection.swift:209:18:209:18 | tainted1 [Collection element] | provenance |  |
+| CommandInjection.swift:208:3:208:5 | [post] ...! [arguments, Collection element] | CommandInjection.swift:208:3:208:5 | [post] ...! | provenance |  |
+| CommandInjection.swift:208:19:208:19 | tainted1 [Collection element] | CommandInjection.swift:208:3:208:5 | [post] ...! [arguments, Collection element] | provenance |  |
+| CommandInjection.swift:208:19:208:19 | tainted1 [Collection element] | CommandInjection.swift:209:18:209:18 | tainted1 [Collection element] | provenance |  |
+| CommandInjection.swift:209:3:209:3 | [post] ...! [arguments, Collection element] | CommandInjection.swift:209:3:209:3 | [post] ...! | provenance |  |
+| CommandInjection.swift:209:18:209:18 | tainted1 [Collection element] | CommandInjection.swift:209:3:209:3 | [post] ...! [arguments, Collection element] | provenance |  |
+| CommandInjection.swift:211:30:211:51 | [...] [Collection element] | CommandInjection.swift:213:18:213:18 | tainted2 [Collection element] | provenance |  |
+| CommandInjection.swift:211:30:211:51 | [...] [Collection element] | CommandInjection.swift:214:19:214:19 | tainted2 [Collection element] | provenance |  |
+| CommandInjection.swift:211:30:211:51 | [...] [Collection element] | CommandInjection.swift:215:18:215:18 | tainted2 [Collection element] | provenance |  |
+| CommandInjection.swift:211:30:211:51 | [...] [Collection element] | CommandInjection.swift:217:13:217:13 | tainted2 [Collection element] | provenance |  |
+| CommandInjection.swift:211:31:211:31 | userControlledString | CommandInjection.swift:211:30:211:51 | [...] [Collection element] | provenance |  |
+| CommandInjection.swift:213:3:213:3 | [post] getter for .p1 [arguments, Collection element] | CommandInjection.swift:213:3:213:3 | [post] getter for .p1 | provenance |  |
+| CommandInjection.swift:213:18:213:18 | tainted2 [Collection element] | CommandInjection.swift:213:3:213:3 | [post] getter for .p1 [arguments, Collection element] | provenance |  |
+| CommandInjection.swift:214:3:214:5 | [post] ...! [arguments, Collection element] | CommandInjection.swift:214:3:214:5 | [post] ...! | provenance |  |
+| CommandInjection.swift:214:19:214:19 | tainted2 [Collection element] | CommandInjection.swift:214:3:214:5 | [post] ...! [arguments, Collection element] | provenance |  |
+| CommandInjection.swift:215:3:215:3 | [post] ...! [arguments, Collection element] | CommandInjection.swift:215:3:215:3 | [post] ...! | provenance |  |
+| CommandInjection.swift:215:18:215:18 | tainted2 [Collection element] | CommandInjection.swift:215:3:215:3 | [post] ...! [arguments, Collection element] | provenance |  |
+| CommandInjection.swift:217:13:217:13 | tainted2 [Collection element] | CommandInjection.swift:193:3:193:3 | newValue [Collection element] | provenance |  |
 | file://:0:0:0:0 | url | file://:0:0:0:0 | url | provenance |  |
 | file://:0:0:0:0 | url | file://:0:0:0:0 | url | provenance |  |
 nodes
-| CommandInjection.swift:58:22:58:33 | command | semmle.label | command |
-| CommandInjection.swift:58:22:58:33 | command [some:0] | semmle.label | command [some:0] |
-| CommandInjection.swift:62:16:62:16 | command | semmle.label | command |
-| CommandInjection.swift:62:16:62:16 | command [some:0] | semmle.label | command [some:0] |
-| CommandInjection.swift:62:16:62:16 | command [some:0] | semmle.label | command [some:0] |
-| CommandInjection.swift:69:8:69:12 | let ...? [some:0, some:0] | semmle.label | let ...? [some:0, some:0] |
-| CommandInjection.swift:69:8:69:12 | let ...? [some:0] | semmle.label | let ...? [some:0] |
-| CommandInjection.swift:69:12:69:12 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:69:12:69:12 | userControlledString [some:0] | semmle.label | userControlledString [some:0] |
-| CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) | semmle.label | call to String.init(contentsOf:) |
-| CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) [some:0, some:0] | semmle.label | call to String.init(contentsOf:) [some:0, some:0] |
-| CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) [some:0] | semmle.label | call to String.init(contentsOf:) [some:0] |
-| CommandInjection.swift:75:2:75:2 | [post] task1 | semmle.label | [post] task1 |
-| CommandInjection.swift:75:2:75:2 | [post] task1 [arguments, Collection element] | semmle.label | [post] task1 [arguments, Collection element] |
-| CommandInjection.swift:75:20:75:47 | [...] [Collection element] | semmle.label | [...] [Collection element] |
-| CommandInjection.swift:75:27:75:27 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:78:5:78:9 | let ...? [some:0] | semmle.label | let ...? [some:0] |
-| CommandInjection.swift:78:9:78:9 | validatedString | semmle.label | validatedString |
-| CommandInjection.swift:78:27:78:63 | call to validateCommand(_:) | semmle.label | call to validateCommand(_:) |
-| CommandInjection.swift:78:27:78:63 | call to validateCommand(_:) [some:0] | semmle.label | call to validateCommand(_:) [some:0] |
-| CommandInjection.swift:78:43:78:43 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:78:43:78:43 | userControlledString [some:0] | semmle.label | userControlledString [some:0] |
-| CommandInjection.swift:81:6:81:6 | [post] task2 | semmle.label | [post] task2 |
-| CommandInjection.swift:81:6:81:6 | [post] task2 [arguments, Collection element] | semmle.label | [post] task2 [arguments, Collection element] |
-| CommandInjection.swift:81:24:81:46 | [...] [Collection element] | semmle.label | [...] [Collection element] |
-| CommandInjection.swift:81:31:81:31 | validatedString | semmle.label | validatedString |
-| CommandInjection.swift:93:20:93:40 | arguments [Collection element] | semmle.label | arguments [Collection element] |
-| CommandInjection.swift:94:3:94:3 | [post] self | semmle.label | [post] self |
-| CommandInjection.swift:94:3:94:3 | [post] self [arguments, Collection element] | semmle.label | [post] self [arguments, Collection element] |
-| CommandInjection.swift:94:20:94:20 | arguments [Collection element] | semmle.label | arguments [Collection element] |
-| CommandInjection.swift:99:8:99:12 | let ...? [some:0] | semmle.label | let ...? [some:0] |
-| CommandInjection.swift:99:12:99:12 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | semmle.label | call to String.init(contentsOf:) |
-| CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) [some:0] | semmle.label | call to String.init(contentsOf:) [some:0] |
-| CommandInjection.swift:114:2:114:2 | [post] task3 | semmle.label | [post] task3 |
-| CommandInjection.swift:114:2:114:2 | [post] task3 [executableURL] | semmle.label | [post] task3 [executableURL] |
-| CommandInjection.swift:114:24:114:56 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
-| CommandInjection.swift:114:24:114:57 | ...! | semmle.label | ...! |
-| CommandInjection.swift:114:36:114:36 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:115:2:115:2 | [post] task3 | semmle.label | [post] task3 |
-| CommandInjection.swift:115:2:115:2 | [post] task3 [arguments, Collection element] | semmle.label | [post] task3 [arguments, Collection element] |
-| CommandInjection.swift:115:20:115:48 | [...] [Collection element] | semmle.label | [...] [Collection element] |
-| CommandInjection.swift:115:28:115:28 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:119:2:119:2 | [post] task4 | semmle.label | [post] task4 |
-| CommandInjection.swift:119:2:119:2 | [post] task4 [executableURL] | semmle.label | [post] task4 [executableURL] |
-| CommandInjection.swift:119:24:119:65 | call to URL.init(fileURLWithPath:) | semmle.label | call to URL.init(fileURLWithPath:) |
-| CommandInjection.swift:119:45:119:45 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:120:2:120:2 | [post] task4 | semmle.label | [post] task4 |
-| CommandInjection.swift:120:2:120:2 | [post] task4 [executableURL] | semmle.label | [post] task4 [executableURL] |
+| CommandInjection.swift:64:22:64:33 | command | semmle.label | command |
+| CommandInjection.swift:64:22:64:33 | command [some:0] | semmle.label | command [some:0] |
+| CommandInjection.swift:68:16:68:16 | command | semmle.label | command |
+| CommandInjection.swift:68:16:68:16 | command [some:0] | semmle.label | command [some:0] |
+| CommandInjection.swift:68:16:68:16 | command [some:0] | semmle.label | command [some:0] |
+| CommandInjection.swift:75:8:75:12 | let ...? [some:0, some:0] | semmle.label | let ...? [some:0, some:0] |
+| CommandInjection.swift:75:8:75:12 | let ...? [some:0] | semmle.label | let ...? [some:0] |
+| CommandInjection.swift:75:12:75:12 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:75:12:75:12 | userControlledString [some:0] | semmle.label | userControlledString [some:0] |
+| CommandInjection.swift:75:40:75:94 | call to String.init(contentsOf:) | semmle.label | call to String.init(contentsOf:) |
+| CommandInjection.swift:75:40:75:94 | call to String.init(contentsOf:) [some:0, some:0] | semmle.label | call to String.init(contentsOf:) [some:0, some:0] |
+| CommandInjection.swift:75:40:75:94 | call to String.init(contentsOf:) [some:0] | semmle.label | call to String.init(contentsOf:) [some:0] |
+| CommandInjection.swift:81:2:81:2 | [post] task1 | semmle.label | [post] task1 |
+| CommandInjection.swift:81:2:81:2 | [post] task1 [arguments, Collection element] | semmle.label | [post] task1 [arguments, Collection element] |
+| CommandInjection.swift:81:20:81:47 | [...] [Collection element] | semmle.label | [...] [Collection element] |
+| CommandInjection.swift:81:27:81:27 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:84:5:84:9 | let ...? [some:0] | semmle.label | let ...? [some:0] |
+| CommandInjection.swift:84:9:84:9 | validatedString | semmle.label | validatedString |
+| CommandInjection.swift:84:27:84:63 | call to validateCommand(_:) | semmle.label | call to validateCommand(_:) |
+| CommandInjection.swift:84:27:84:63 | call to validateCommand(_:) [some:0] | semmle.label | call to validateCommand(_:) [some:0] |
+| CommandInjection.swift:84:43:84:43 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:84:43:84:43 | userControlledString [some:0] | semmle.label | userControlledString [some:0] |
+| CommandInjection.swift:87:6:87:6 | [post] task2 | semmle.label | [post] task2 |
+| CommandInjection.swift:87:6:87:6 | [post] task2 [arguments, Collection element] | semmle.label | [post] task2 [arguments, Collection element] |
+| CommandInjection.swift:87:24:87:46 | [...] [Collection element] | semmle.label | [...] [Collection element] |
+| CommandInjection.swift:87:31:87:31 | validatedString | semmle.label | validatedString |
+| CommandInjection.swift:99:20:99:40 | arguments [Collection element] | semmle.label | arguments [Collection element] |
+| CommandInjection.swift:100:3:100:3 | [post] self | semmle.label | [post] self |
+| CommandInjection.swift:100:3:100:3 | [post] self [arguments, Collection element] | semmle.label | [post] self [arguments, Collection element] |
+| CommandInjection.swift:100:20:100:20 | arguments [Collection element] | semmle.label | arguments [Collection element] |
+| CommandInjection.swift:105:8:105:12 | let ...? [some:0] | semmle.label | let ...? [some:0] |
+| CommandInjection.swift:105:12:105:12 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | semmle.label | call to String.init(contentsOf:) |
+| CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) [some:0] | semmle.label | call to String.init(contentsOf:) [some:0] |
+| CommandInjection.swift:120:2:120:2 | [post] task3 | semmle.label | [post] task3 |
+| CommandInjection.swift:120:2:120:2 | [post] task3 [executableURL] | semmle.label | [post] task3 [executableURL] |
 | CommandInjection.swift:120:24:120:56 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
 | CommandInjection.swift:120:24:120:57 | ...! | semmle.label | ...! |
 | CommandInjection.swift:120:36:120:36 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:121:2:121:2 | [post] task4 | semmle.label | [post] task4 |
-| CommandInjection.swift:121:2:121:2 | [post] task4 [arguments, Collection element] | semmle.label | [post] task4 [arguments, Collection element] |
-| CommandInjection.swift:121:20:121:56 | [...] [Collection element] | semmle.label | [...] [Collection element] |
-| CommandInjection.swift:121:28:121:36 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
-| CommandInjection.swift:125:2:125:7 | [post] ...? | semmle.label | [post] ...? |
-| CommandInjection.swift:125:2:125:7 | [post] ...? [executableURL] | semmle.label | [post] ...? [executableURL] |
-| CommandInjection.swift:125:25:125:66 | call to URL.init(fileURLWithPath:) | semmle.label | call to URL.init(fileURLWithPath:) |
-| CommandInjection.swift:125:46:125:46 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:126:2:126:7 | [post] ...? | semmle.label | [post] ...? |
-| CommandInjection.swift:126:2:126:7 | [post] ...? [arguments, Collection element] | semmle.label | [post] ...? [arguments, Collection element] |
-| CommandInjection.swift:126:21:126:42 | [...] [Collection element] | semmle.label | [...] [Collection element] |
-| CommandInjection.swift:126:22:126:22 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:130:2:130:2 | [post] task6 | semmle.label | [post] task6 |
-| CommandInjection.swift:130:2:130:2 | [post] task6 [executableURL] | semmle.label | [post] task6 [executableURL] |
-| CommandInjection.swift:130:24:130:65 | call to URL.init(fileURLWithPath:) | semmle.label | call to URL.init(fileURLWithPath:) |
-| CommandInjection.swift:130:45:130:45 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:131:2:131:2 | [post] task6 | semmle.label | [post] task6 |
-| CommandInjection.swift:131:2:131:2 | [post] task6 [executableURL] | semmle.label | [post] task6 [executableURL] |
-| CommandInjection.swift:131:24:131:56 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
-| CommandInjection.swift:131:24:131:57 | ...! | semmle.label | ...! |
-| CommandInjection.swift:131:36:131:36 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:132:2:132:2 | [post] task6 | semmle.label | [post] task6 |
-| CommandInjection.swift:132:2:132:2 | [post] task6 [arguments, Collection element] | semmle.label | [post] task6 [arguments, Collection element] |
-| CommandInjection.swift:132:20:132:41 | [...] [Collection element] | semmle.label | [...] [Collection element] |
-| CommandInjection.swift:132:21:132:21 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:133:21:133:42 | [...] [Collection element] | semmle.label | [...] [Collection element] |
-| CommandInjection.swift:133:22:133:22 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:134:24:134:24 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:144:42:144:42 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:145:67:145:95 | [...] | semmle.label | [...] |
-| CommandInjection.swift:145:67:145:95 | [...] [Collection element] | semmle.label | [...] [Collection element] |
-| CommandInjection.swift:145:75:145:75 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:148:23:148:55 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
-| CommandInjection.swift:148:23:148:56 | ...! | semmle.label | ...! |
-| CommandInjection.swift:148:35:148:35 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:149:62:149:90 | [...] | semmle.label | [...] |
-| CommandInjection.swift:149:62:149:90 | [...] [Collection element] | semmle.label | [...] [Collection element] |
-| CommandInjection.swift:149:70:149:70 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:154:41:154:73 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
-| CommandInjection.swift:154:41:154:74 | ...! | semmle.label | ...! |
-| CommandInjection.swift:154:53:154:53 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:157:40:157:72 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
-| CommandInjection.swift:157:40:157:73 | ...! | semmle.label | ...! |
-| CommandInjection.swift:157:40:157:73 | ...! | semmle.label | ...! |
-| CommandInjection.swift:157:52:157:52 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:158:32:158:53 | [...] | semmle.label | [...] |
-| CommandInjection.swift:158:32:158:53 | [...] [Collection element] | semmle.label | [...] [Collection element] |
-| CommandInjection.swift:158:33:158:33 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:160:45:160:77 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
-| CommandInjection.swift:160:45:160:78 | ...! | semmle.label | ...! |
-| CommandInjection.swift:160:45:160:78 | ...! | semmle.label | ...! |
-| CommandInjection.swift:160:57:160:57 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:174:3:174:3 | newValue [Collection element] | semmle.label | newValue [Collection element] |
-| CommandInjection.swift:175:4:175:4 | [post] getter for .p1 | semmle.label | [post] getter for .p1 |
-| CommandInjection.swift:175:4:175:4 | [post] getter for .p1 [arguments, Collection element] | semmle.label | [post] getter for .p1 [arguments, Collection element] |
-| CommandInjection.swift:175:19:175:19 | newValue [Collection element] | semmle.label | newValue [Collection element] |
-| CommandInjection.swift:176:4:176:6 | [post] ...! | semmle.label | [post] ...! |
-| CommandInjection.swift:176:4:176:6 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
-| CommandInjection.swift:176:20:176:20 | newValue [Collection element] | semmle.label | newValue [Collection element] |
-| CommandInjection.swift:177:4:177:4 | [post] ...! | semmle.label | [post] ...! |
-| CommandInjection.swift:177:4:177:4 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
-| CommandInjection.swift:177:19:177:19 | newValue [Collection element] | semmle.label | newValue [Collection element] |
-| CommandInjection.swift:182:9:182:13 | let ...? [some:0] | semmle.label | let ...? [some:0] |
-| CommandInjection.swift:182:13:182:13 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | semmle.label | call to String.init(contentsOf:) |
-| CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) [some:0] | semmle.label | call to String.init(contentsOf:) [some:0] |
-| CommandInjection.swift:186:18:186:39 | [...] [Collection element] | semmle.label | [...] [Collection element] |
-| CommandInjection.swift:186:19:186:19 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:188:3:188:3 | [post] getter for .p1 | semmle.label | [post] getter for .p1 |
-| CommandInjection.swift:188:3:188:3 | [post] getter for .p1 [arguments, Collection element] | semmle.label | [post] getter for .p1 [arguments, Collection element] |
-| CommandInjection.swift:188:18:188:18 | tainted1 [Collection element] | semmle.label | tainted1 [Collection element] |
-| CommandInjection.swift:189:3:189:5 | [post] ...! | semmle.label | [post] ...! |
-| CommandInjection.swift:189:3:189:5 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
-| CommandInjection.swift:189:19:189:19 | tainted1 [Collection element] | semmle.label | tainted1 [Collection element] |
-| CommandInjection.swift:190:3:190:3 | [post] ...! | semmle.label | [post] ...! |
-| CommandInjection.swift:190:3:190:3 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
-| CommandInjection.swift:190:18:190:18 | tainted1 [Collection element] | semmle.label | tainted1 [Collection element] |
-| CommandInjection.swift:192:30:192:51 | [...] [Collection element] | semmle.label | [...] [Collection element] |
-| CommandInjection.swift:192:31:192:31 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:194:3:194:3 | [post] getter for .p1 | semmle.label | [post] getter for .p1 |
-| CommandInjection.swift:194:3:194:3 | [post] getter for .p1 [arguments, Collection element] | semmle.label | [post] getter for .p1 [arguments, Collection element] |
-| CommandInjection.swift:194:18:194:18 | tainted2 [Collection element] | semmle.label | tainted2 [Collection element] |
-| CommandInjection.swift:195:3:195:5 | [post] ...! | semmle.label | [post] ...! |
-| CommandInjection.swift:195:3:195:5 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
-| CommandInjection.swift:195:19:195:19 | tainted2 [Collection element] | semmle.label | tainted2 [Collection element] |
-| CommandInjection.swift:196:3:196:3 | [post] ...! | semmle.label | [post] ...! |
-| CommandInjection.swift:196:3:196:3 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
-| CommandInjection.swift:196:18:196:18 | tainted2 [Collection element] | semmle.label | tainted2 [Collection element] |
-| CommandInjection.swift:198:13:198:13 | tainted2 [Collection element] | semmle.label | tainted2 [Collection element] |
+| CommandInjection.swift:121:2:121:2 | [post] task3 | semmle.label | [post] task3 |
+| CommandInjection.swift:121:2:121:2 | [post] task3 [arguments, Collection element] | semmle.label | [post] task3 [arguments, Collection element] |
+| CommandInjection.swift:121:20:121:48 | [...] [Collection element] | semmle.label | [...] [Collection element] |
+| CommandInjection.swift:121:28:121:28 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:125:2:125:2 | [post] task4 | semmle.label | [post] task4 |
+| CommandInjection.swift:125:2:125:2 | [post] task4 [executableURL] | semmle.label | [post] task4 [executableURL] |
+| CommandInjection.swift:125:24:125:65 | call to URL.init(fileURLWithPath:) | semmle.label | call to URL.init(fileURLWithPath:) |
+| CommandInjection.swift:125:45:125:45 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:126:2:126:2 | [post] task4 | semmle.label | [post] task4 |
+| CommandInjection.swift:126:2:126:2 | [post] task4 [executableURL] | semmle.label | [post] task4 [executableURL] |
+| CommandInjection.swift:126:24:126:56 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
+| CommandInjection.swift:126:24:126:57 | ...! | semmle.label | ...! |
+| CommandInjection.swift:126:36:126:36 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:127:2:127:2 | [post] task4 | semmle.label | [post] task4 |
+| CommandInjection.swift:127:2:127:2 | [post] task4 [arguments, Collection element] | semmle.label | [post] task4 [arguments, Collection element] |
+| CommandInjection.swift:127:20:127:56 | [...] [Collection element] | semmle.label | [...] [Collection element] |
+| CommandInjection.swift:127:28:127:36 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
+| CommandInjection.swift:131:2:131:7 | [post] ...? | semmle.label | [post] ...? |
+| CommandInjection.swift:131:2:131:7 | [post] ...? [executableURL] | semmle.label | [post] ...? [executableURL] |
+| CommandInjection.swift:131:25:131:66 | call to URL.init(fileURLWithPath:) | semmle.label | call to URL.init(fileURLWithPath:) |
+| CommandInjection.swift:131:46:131:46 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:132:2:132:7 | [post] ...? | semmle.label | [post] ...? |
+| CommandInjection.swift:132:2:132:7 | [post] ...? [arguments, Collection element] | semmle.label | [post] ...? [arguments, Collection element] |
+| CommandInjection.swift:132:21:132:42 | [...] [Collection element] | semmle.label | [...] [Collection element] |
+| CommandInjection.swift:132:22:132:22 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:136:2:136:2 | [post] task6 | semmle.label | [post] task6 |
+| CommandInjection.swift:136:2:136:2 | [post] task6 [executableURL] | semmle.label | [post] task6 [executableURL] |
+| CommandInjection.swift:136:24:136:65 | call to URL.init(fileURLWithPath:) | semmle.label | call to URL.init(fileURLWithPath:) |
+| CommandInjection.swift:136:45:136:45 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:137:2:137:2 | [post] task6 | semmle.label | [post] task6 |
+| CommandInjection.swift:137:2:137:2 | [post] task6 [executableURL] | semmle.label | [post] task6 [executableURL] |
+| CommandInjection.swift:137:24:137:56 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
+| CommandInjection.swift:137:24:137:57 | ...! | semmle.label | ...! |
+| CommandInjection.swift:137:36:137:36 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:138:2:138:2 | [post] task6 | semmle.label | [post] task6 |
+| CommandInjection.swift:138:2:138:2 | [post] task6 [arguments, Collection element] | semmle.label | [post] task6 [arguments, Collection element] |
+| CommandInjection.swift:138:20:138:41 | [...] [Collection element] | semmle.label | [...] [Collection element] |
+| CommandInjection.swift:138:21:138:21 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:139:21:139:42 | [...] [Collection element] | semmle.label | [...] [Collection element] |
+| CommandInjection.swift:139:22:139:22 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:140:24:140:24 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:150:42:150:42 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:151:67:151:95 | [...] | semmle.label | [...] |
+| CommandInjection.swift:151:67:151:95 | [...] [Collection element] | semmle.label | [...] [Collection element] |
+| CommandInjection.swift:151:75:151:75 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:154:23:154:55 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
+| CommandInjection.swift:154:23:154:56 | ...! | semmle.label | ...! |
+| CommandInjection.swift:154:35:154:35 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:155:62:155:90 | [...] | semmle.label | [...] |
+| CommandInjection.swift:155:62:155:90 | [...] [Collection element] | semmle.label | [...] [Collection element] |
+| CommandInjection.swift:155:70:155:70 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:160:41:160:73 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
+| CommandInjection.swift:160:41:160:74 | ...! | semmle.label | ...! |
+| CommandInjection.swift:160:53:160:53 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:163:40:163:72 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
+| CommandInjection.swift:163:40:163:73 | ...! | semmle.label | ...! |
+| CommandInjection.swift:163:40:163:73 | ...! | semmle.label | ...! |
+| CommandInjection.swift:163:52:163:52 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:164:32:164:53 | [...] | semmle.label | [...] |
+| CommandInjection.swift:164:32:164:53 | [...] [Collection element] | semmle.label | [...] [Collection element] |
+| CommandInjection.swift:164:33:164:33 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:166:45:166:77 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
+| CommandInjection.swift:166:45:166:78 | ...! | semmle.label | ...! |
+| CommandInjection.swift:166:45:166:78 | ...! | semmle.label | ...! |
+| CommandInjection.swift:166:57:166:57 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:193:3:193:3 | newValue [Collection element] | semmle.label | newValue [Collection element] |
+| CommandInjection.swift:194:4:194:4 | [post] getter for .p1 | semmle.label | [post] getter for .p1 |
+| CommandInjection.swift:194:4:194:4 | [post] getter for .p1 [arguments, Collection element] | semmle.label | [post] getter for .p1 [arguments, Collection element] |
+| CommandInjection.swift:194:19:194:19 | newValue [Collection element] | semmle.label | newValue [Collection element] |
+| CommandInjection.swift:195:4:195:6 | [post] ...! | semmle.label | [post] ...! |
+| CommandInjection.swift:195:4:195:6 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:195:20:195:20 | newValue [Collection element] | semmle.label | newValue [Collection element] |
+| CommandInjection.swift:196:4:196:4 | [post] ...! | semmle.label | [post] ...! |
+| CommandInjection.swift:196:4:196:4 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:196:19:196:19 | newValue [Collection element] | semmle.label | newValue [Collection element] |
+| CommandInjection.swift:201:9:201:13 | let ...? [some:0] | semmle.label | let ...? [some:0] |
+| CommandInjection.swift:201:13:201:13 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | semmle.label | call to String.init(contentsOf:) |
+| CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) [some:0] | semmle.label | call to String.init(contentsOf:) [some:0] |
+| CommandInjection.swift:205:18:205:39 | [...] [Collection element] | semmle.label | [...] [Collection element] |
+| CommandInjection.swift:205:19:205:19 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:207:3:207:3 | [post] getter for .p1 | semmle.label | [post] getter for .p1 |
+| CommandInjection.swift:207:3:207:3 | [post] getter for .p1 [arguments, Collection element] | semmle.label | [post] getter for .p1 [arguments, Collection element] |
+| CommandInjection.swift:207:18:207:18 | tainted1 [Collection element] | semmle.label | tainted1 [Collection element] |
+| CommandInjection.swift:208:3:208:5 | [post] ...! | semmle.label | [post] ...! |
+| CommandInjection.swift:208:3:208:5 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:208:19:208:19 | tainted1 [Collection element] | semmle.label | tainted1 [Collection element] |
+| CommandInjection.swift:209:3:209:3 | [post] ...! | semmle.label | [post] ...! |
+| CommandInjection.swift:209:3:209:3 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:209:18:209:18 | tainted1 [Collection element] | semmle.label | tainted1 [Collection element] |
+| CommandInjection.swift:211:30:211:51 | [...] [Collection element] | semmle.label | [...] [Collection element] |
+| CommandInjection.swift:211:31:211:31 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:213:3:213:3 | [post] getter for .p1 | semmle.label | [post] getter for .p1 |
+| CommandInjection.swift:213:3:213:3 | [post] getter for .p1 [arguments, Collection element] | semmle.label | [post] getter for .p1 [arguments, Collection element] |
+| CommandInjection.swift:213:18:213:18 | tainted2 [Collection element] | semmle.label | tainted2 [Collection element] |
+| CommandInjection.swift:214:3:214:5 | [post] ...! | semmle.label | [post] ...! |
+| CommandInjection.swift:214:3:214:5 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:214:19:214:19 | tainted2 [Collection element] | semmle.label | tainted2 [Collection element] |
+| CommandInjection.swift:215:3:215:3 | [post] ...! | semmle.label | [post] ...! |
+| CommandInjection.swift:215:3:215:3 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
+| CommandInjection.swift:215:18:215:18 | tainted2 [Collection element] | semmle.label | tainted2 [Collection element] |
+| CommandInjection.swift:217:13:217:13 | tainted2 [Collection element] | semmle.label | tainted2 [Collection element] |
 | file://:0:0:0:0 | url | semmle.label | url |
 | file://:0:0:0:0 | url | semmle.label | url |
 | file://:0:0:0:0 | url | semmle.label | url |
 | file://:0:0:0:0 | url | semmle.label | url |
 subpaths
-| CommandInjection.swift:78:43:78:43 | userControlledString | CommandInjection.swift:58:22:58:33 | command | CommandInjection.swift:62:16:62:16 | command | CommandInjection.swift:78:27:78:63 | call to validateCommand(_:) |
-| CommandInjection.swift:78:43:78:43 | userControlledString | CommandInjection.swift:58:22:58:33 | command | CommandInjection.swift:62:16:62:16 | command [some:0] | CommandInjection.swift:78:27:78:63 | call to validateCommand(_:) [some:0] |
-| CommandInjection.swift:78:43:78:43 | userControlledString [some:0] | CommandInjection.swift:58:22:58:33 | command [some:0] | CommandInjection.swift:62:16:62:16 | command [some:0] | CommandInjection.swift:78:27:78:63 | call to validateCommand(_:) [some:0] |
+| CommandInjection.swift:84:43:84:43 | userControlledString | CommandInjection.swift:64:22:64:33 | command | CommandInjection.swift:68:16:68:16 | command | CommandInjection.swift:84:27:84:63 | call to validateCommand(_:) |
+| CommandInjection.swift:84:43:84:43 | userControlledString | CommandInjection.swift:64:22:64:33 | command | CommandInjection.swift:68:16:68:16 | command [some:0] | CommandInjection.swift:84:27:84:63 | call to validateCommand(_:) [some:0] |
+| CommandInjection.swift:84:43:84:43 | userControlledString [some:0] | CommandInjection.swift:64:22:64:33 | command [some:0] | CommandInjection.swift:68:16:68:16 | command [some:0] | CommandInjection.swift:84:27:84:63 | call to validateCommand(_:) [some:0] |
 #select
-| CommandInjection.swift:75:2:75:2 | [post] task1 | CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) | CommandInjection.swift:75:2:75:2 | [post] task1 | This command depends on a $@. | CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:81:6:81:6 | [post] task2 | CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) | CommandInjection.swift:81:6:81:6 | [post] task2 | This command depends on a $@. | CommandInjection.swift:69:40:69:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:94:3:94:3 | [post] self | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:94:3:94:3 | [post] self | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:114:2:114:2 | [post] task3 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:114:2:114:2 | [post] task3 | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:115:2:115:2 | [post] task3 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:115:2:115:2 | [post] task3 | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:119:2:119:2 | [post] task4 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:119:2:119:2 | [post] task4 | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:120:2:120:2 | [post] task4 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:120:2:120:2 | [post] task4 | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:121:2:121:2 | [post] task4 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:121:2:121:2 | [post] task4 | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:125:2:125:7 | [post] ...? | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:125:2:125:7 | [post] ...? | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:126:2:126:7 | [post] ...? | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:126:2:126:7 | [post] ...? | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:130:2:130:2 | [post] task6 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:130:2:130:2 | [post] task6 | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:131:2:131:2 | [post] task6 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:131:2:131:2 | [post] task6 | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:132:2:132:2 | [post] task6 | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:132:2:132:2 | [post] task6 | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:144:42:144:42 | userControlledString | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:144:42:144:42 | userControlledString | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:145:67:145:95 | [...] | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:145:67:145:95 | [...] | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:148:23:148:56 | ...! | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:148:23:148:56 | ...! | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:149:62:149:90 | [...] | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:149:62:149:90 | [...] | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:154:41:154:74 | ...! | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:154:41:154:74 | ...! | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:157:40:157:73 | ...! | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:157:40:157:73 | ...! | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:158:32:158:53 | [...] | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:158:32:158:53 | [...] | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:160:45:160:78 | ...! | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | CommandInjection.swift:160:45:160:78 | ...! | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:175:4:175:4 | [post] getter for .p1 | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | CommandInjection.swift:175:4:175:4 | [post] getter for .p1 | This command depends on a $@. | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:176:4:176:6 | [post] ...! | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | CommandInjection.swift:176:4:176:6 | [post] ...! | This command depends on a $@. | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:177:4:177:4 | [post] ...! | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | CommandInjection.swift:177:4:177:4 | [post] ...! | This command depends on a $@. | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:188:3:188:3 | [post] getter for .p1 | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | CommandInjection.swift:188:3:188:3 | [post] getter for .p1 | This command depends on a $@. | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:189:3:189:5 | [post] ...! | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | CommandInjection.swift:189:3:189:5 | [post] ...! | This command depends on a $@. | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:190:3:190:3 | [post] ...! | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | CommandInjection.swift:190:3:190:3 | [post] ...! | This command depends on a $@. | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:194:3:194:3 | [post] getter for .p1 | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | CommandInjection.swift:194:3:194:3 | [post] getter for .p1 | This command depends on a $@. | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:195:3:195:5 | [post] ...! | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | CommandInjection.swift:195:3:195:5 | [post] ...! | This command depends on a $@. | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:196:3:196:3 | [post] ...! | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | CommandInjection.swift:196:3:196:3 | [post] ...! | This command depends on a $@. | CommandInjection.swift:182:41:182:95 | call to String.init(contentsOf:) | user-provided value |
-| file://:0:0:0:0 | url | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | file://:0:0:0:0 | url | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
-| file://:0:0:0:0 | url | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | file://:0:0:0:0 | url | This command depends on a $@. | CommandInjection.swift:99:40:99:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:81:2:81:2 | [post] task1 | CommandInjection.swift:75:40:75:94 | call to String.init(contentsOf:) | CommandInjection.swift:81:2:81:2 | [post] task1 | This command depends on a $@. | CommandInjection.swift:75:40:75:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:87:6:87:6 | [post] task2 | CommandInjection.swift:75:40:75:94 | call to String.init(contentsOf:) | CommandInjection.swift:87:6:87:6 | [post] task2 | This command depends on a $@. | CommandInjection.swift:75:40:75:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:100:3:100:3 | [post] self | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:100:3:100:3 | [post] self | This command depends on a $@. | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:120:2:120:2 | [post] task3 | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:120:2:120:2 | [post] task3 | This command depends on a $@. | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:121:2:121:2 | [post] task3 | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:121:2:121:2 | [post] task3 | This command depends on a $@. | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:125:2:125:2 | [post] task4 | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:125:2:125:2 | [post] task4 | This command depends on a $@. | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:126:2:126:2 | [post] task4 | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:126:2:126:2 | [post] task4 | This command depends on a $@. | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:127:2:127:2 | [post] task4 | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:127:2:127:2 | [post] task4 | This command depends on a $@. | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:131:2:131:7 | [post] ...? | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:131:2:131:7 | [post] ...? | This command depends on a $@. | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:132:2:132:7 | [post] ...? | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:132:2:132:7 | [post] ...? | This command depends on a $@. | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:136:2:136:2 | [post] task6 | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:136:2:136:2 | [post] task6 | This command depends on a $@. | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:137:2:137:2 | [post] task6 | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:137:2:137:2 | [post] task6 | This command depends on a $@. | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:138:2:138:2 | [post] task6 | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:138:2:138:2 | [post] task6 | This command depends on a $@. | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:150:42:150:42 | userControlledString | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:150:42:150:42 | userControlledString | This command depends on a $@. | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:151:67:151:95 | [...] | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:151:67:151:95 | [...] | This command depends on a $@. | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:154:23:154:56 | ...! | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:154:23:154:56 | ...! | This command depends on a $@. | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:155:62:155:90 | [...] | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:155:62:155:90 | [...] | This command depends on a $@. | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:160:41:160:74 | ...! | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:160:41:160:74 | ...! | This command depends on a $@. | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:163:40:163:73 | ...! | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:163:40:163:73 | ...! | This command depends on a $@. | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:164:32:164:53 | [...] | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:164:32:164:53 | [...] | This command depends on a $@. | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:166:45:166:78 | ...! | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:166:45:166:78 | ...! | This command depends on a $@. | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:194:4:194:4 | [post] getter for .p1 | CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | CommandInjection.swift:194:4:194:4 | [post] getter for .p1 | This command depends on a $@. | CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:195:4:195:6 | [post] ...! | CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | CommandInjection.swift:195:4:195:6 | [post] ...! | This command depends on a $@. | CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:196:4:196:4 | [post] ...! | CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | CommandInjection.swift:196:4:196:4 | [post] ...! | This command depends on a $@. | CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:207:3:207:3 | [post] getter for .p1 | CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | CommandInjection.swift:207:3:207:3 | [post] getter for .p1 | This command depends on a $@. | CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:208:3:208:5 | [post] ...! | CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | CommandInjection.swift:208:3:208:5 | [post] ...! | This command depends on a $@. | CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:209:3:209:3 | [post] ...! | CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | CommandInjection.swift:209:3:209:3 | [post] ...! | This command depends on a $@. | CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:213:3:213:3 | [post] getter for .p1 | CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | CommandInjection.swift:213:3:213:3 | [post] getter for .p1 | This command depends on a $@. | CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:214:3:214:5 | [post] ...! | CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | CommandInjection.swift:214:3:214:5 | [post] ...! | This command depends on a $@. | CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:215:3:215:3 | [post] ...! | CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | CommandInjection.swift:215:3:215:3 | [post] ...! | This command depends on a $@. | CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | user-provided value |
+| file://:0:0:0:0 | url | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | file://:0:0:0:0 | url | This command depends on a $@. | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | user-provided value |
+| file://:0:0:0:0 | url | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | file://:0:0:0:0 | url | This command depends on a $@. | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | user-provided value |

--- a/swift/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
+++ b/swift/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
@@ -136,6 +136,15 @@ edges
 | CommandInjection.swift:166:45:166:77 | call to URL.init(string:) [some:0] | CommandInjection.swift:166:45:166:78 | ...! | provenance |  |
 | CommandInjection.swift:166:45:166:78 | ...! | file://:0:0:0:0 | url | provenance |  |
 | CommandInjection.swift:166:57:166:57 | userControlledString | CommandInjection.swift:166:45:166:77 | call to URL.init(string:) [some:0] | provenance |  |
+| CommandInjection.swift:170:19:170:83 | call to contentsOfDirectory(atPath:) | CommandInjection.swift:176:22:176:22 | files | provenance |  |
+| CommandInjection.swift:170:19:170:83 | call to contentsOfDirectory(atPath:) | CommandInjection.swift:178:23:178:30 | ...[...] | provenance |  |
+| CommandInjection.swift:176:3:176:3 | [post] task12 [arguments] | CommandInjection.swift:176:3:176:3 | [post] task12 | provenance |  |
+| CommandInjection.swift:176:22:176:22 | files | CommandInjection.swift:176:3:176:3 | [post] task12 [arguments] | provenance |  |
+| CommandInjection.swift:176:22:176:22 | files | CommandInjection.swift:176:22:176:22 | files | provenance |  |
+| CommandInjection.swift:176:22:176:22 | files | CommandInjection.swift:178:23:178:30 | ...[...] | provenance |  |
+| CommandInjection.swift:178:3:178:3 | [post] task12 [arguments, Collection element] | CommandInjection.swift:178:3:178:3 | [post] task12 | provenance |  |
+| CommandInjection.swift:178:22:178:31 | [...] [Collection element] | CommandInjection.swift:178:3:178:3 | [post] task12 [arguments, Collection element] | provenance |  |
+| CommandInjection.swift:178:23:178:30 | ...[...] | CommandInjection.swift:178:22:178:31 | [...] [Collection element] | provenance |  |
 | CommandInjection.swift:193:3:193:3 | newValue [Collection element] | CommandInjection.swift:194:19:194:19 | newValue [Collection element] | provenance |  |
 | CommandInjection.swift:193:3:193:3 | newValue [Collection element] | CommandInjection.swift:195:20:195:20 | newValue [Collection element] | provenance |  |
 | CommandInjection.swift:193:3:193:3 | newValue [Collection element] | CommandInjection.swift:196:19:196:19 | newValue [Collection element] | provenance |  |
@@ -284,6 +293,14 @@ nodes
 | CommandInjection.swift:166:45:166:78 | ...! | semmle.label | ...! |
 | CommandInjection.swift:166:45:166:78 | ...! | semmle.label | ...! |
 | CommandInjection.swift:166:57:166:57 | userControlledString | semmle.label | userControlledString |
+| CommandInjection.swift:170:19:170:83 | call to contentsOfDirectory(atPath:) | semmle.label | call to contentsOfDirectory(atPath:) |
+| CommandInjection.swift:176:3:176:3 | [post] task12 | semmle.label | [post] task12 |
+| CommandInjection.swift:176:3:176:3 | [post] task12 [arguments] | semmle.label | [post] task12 [arguments] |
+| CommandInjection.swift:176:22:176:22 | files | semmle.label | files |
+| CommandInjection.swift:178:3:178:3 | [post] task12 | semmle.label | [post] task12 |
+| CommandInjection.swift:178:3:178:3 | [post] task12 [arguments, Collection element] | semmle.label | [post] task12 [arguments, Collection element] |
+| CommandInjection.swift:178:22:178:31 | [...] [Collection element] | semmle.label | [...] [Collection element] |
+| CommandInjection.swift:178:23:178:30 | ...[...] | semmle.label | ...[...] |
 | CommandInjection.swift:193:3:193:3 | newValue [Collection element] | semmle.label | newValue [Collection element] |
 | CommandInjection.swift:194:4:194:4 | [post] getter for .p1 | semmle.label | [post] getter for .p1 |
 | CommandInjection.swift:194:4:194:4 | [post] getter for .p1 [arguments, Collection element] | semmle.label | [post] getter for .p1 [arguments, Collection element] |
@@ -351,6 +368,8 @@ subpaths
 | CommandInjection.swift:163:40:163:73 | ...! | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:163:40:163:73 | ...! | This command depends on a $@. | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | user-provided value |
 | CommandInjection.swift:164:32:164:53 | [...] | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:164:32:164:53 | [...] | This command depends on a $@. | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | user-provided value |
 | CommandInjection.swift:166:45:166:78 | ...! | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:166:45:166:78 | ...! | This command depends on a $@. | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | user-provided value |
+| CommandInjection.swift:176:3:176:3 | [post] task12 | CommandInjection.swift:170:19:170:83 | call to contentsOfDirectory(atPath:) | CommandInjection.swift:176:3:176:3 | [post] task12 | This command depends on a $@. | CommandInjection.swift:170:19:170:83 | call to contentsOfDirectory(atPath:) | user-provided value |
+| CommandInjection.swift:178:3:178:3 | [post] task12 | CommandInjection.swift:170:19:170:83 | call to contentsOfDirectory(atPath:) | CommandInjection.swift:178:3:178:3 | [post] task12 | This command depends on a $@. | CommandInjection.swift:170:19:170:83 | call to contentsOfDirectory(atPath:) | user-provided value |
 | CommandInjection.swift:194:4:194:4 | [post] getter for .p1 | CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | CommandInjection.swift:194:4:194:4 | [post] getter for .p1 | This command depends on a $@. | CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | user-provided value |
 | CommandInjection.swift:195:4:195:6 | [post] ...! | CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | CommandInjection.swift:195:4:195:6 | [post] ...! | This command depends on a $@. | CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | user-provided value |
 | CommandInjection.swift:196:4:196:4 | [post] ...! | CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | CommandInjection.swift:196:4:196:4 | [post] ...! | This command depends on a $@. | CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | user-provided value |

--- a/swift/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
+++ b/swift/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
@@ -136,15 +136,6 @@ edges
 | CommandInjection.swift:166:45:166:77 | call to URL.init(string:) [some:0] | CommandInjection.swift:166:45:166:78 | ...! | provenance |  |
 | CommandInjection.swift:166:45:166:78 | ...! | file://:0:0:0:0 | url | provenance |  |
 | CommandInjection.swift:166:57:166:57 | userControlledString | CommandInjection.swift:166:45:166:77 | call to URL.init(string:) [some:0] | provenance |  |
-| CommandInjection.swift:170:19:170:83 | call to contentsOfDirectory(atPath:) | CommandInjection.swift:176:22:176:22 | files | provenance |  |
-| CommandInjection.swift:170:19:170:83 | call to contentsOfDirectory(atPath:) | CommandInjection.swift:178:23:178:30 | ...[...] | provenance |  |
-| CommandInjection.swift:176:3:176:3 | [post] task12 [arguments] | CommandInjection.swift:176:3:176:3 | [post] task12 | provenance |  |
-| CommandInjection.swift:176:22:176:22 | files | CommandInjection.swift:176:3:176:3 | [post] task12 [arguments] | provenance |  |
-| CommandInjection.swift:176:22:176:22 | files | CommandInjection.swift:176:22:176:22 | files | provenance |  |
-| CommandInjection.swift:176:22:176:22 | files | CommandInjection.swift:178:23:178:30 | ...[...] | provenance |  |
-| CommandInjection.swift:178:3:178:3 | [post] task12 [arguments, Collection element] | CommandInjection.swift:178:3:178:3 | [post] task12 | provenance |  |
-| CommandInjection.swift:178:22:178:31 | [...] [Collection element] | CommandInjection.swift:178:3:178:3 | [post] task12 [arguments, Collection element] | provenance |  |
-| CommandInjection.swift:178:23:178:30 | ...[...] | CommandInjection.swift:178:22:178:31 | [...] [Collection element] | provenance |  |
 | CommandInjection.swift:193:3:193:3 | newValue [Collection element] | CommandInjection.swift:194:19:194:19 | newValue [Collection element] | provenance |  |
 | CommandInjection.swift:193:3:193:3 | newValue [Collection element] | CommandInjection.swift:195:20:195:20 | newValue [Collection element] | provenance |  |
 | CommandInjection.swift:193:3:193:3 | newValue [Collection element] | CommandInjection.swift:196:19:196:19 | newValue [Collection element] | provenance |  |
@@ -293,14 +284,6 @@ nodes
 | CommandInjection.swift:166:45:166:78 | ...! | semmle.label | ...! |
 | CommandInjection.swift:166:45:166:78 | ...! | semmle.label | ...! |
 | CommandInjection.swift:166:57:166:57 | userControlledString | semmle.label | userControlledString |
-| CommandInjection.swift:170:19:170:83 | call to contentsOfDirectory(atPath:) | semmle.label | call to contentsOfDirectory(atPath:) |
-| CommandInjection.swift:176:3:176:3 | [post] task12 | semmle.label | [post] task12 |
-| CommandInjection.swift:176:3:176:3 | [post] task12 [arguments] | semmle.label | [post] task12 [arguments] |
-| CommandInjection.swift:176:22:176:22 | files | semmle.label | files |
-| CommandInjection.swift:178:3:178:3 | [post] task12 | semmle.label | [post] task12 |
-| CommandInjection.swift:178:3:178:3 | [post] task12 [arguments, Collection element] | semmle.label | [post] task12 [arguments, Collection element] |
-| CommandInjection.swift:178:22:178:31 | [...] [Collection element] | semmle.label | [...] [Collection element] |
-| CommandInjection.swift:178:23:178:30 | ...[...] | semmle.label | ...[...] |
 | CommandInjection.swift:193:3:193:3 | newValue [Collection element] | semmle.label | newValue [Collection element] |
 | CommandInjection.swift:194:4:194:4 | [post] getter for .p1 | semmle.label | [post] getter for .p1 |
 | CommandInjection.swift:194:4:194:4 | [post] getter for .p1 [arguments, Collection element] | semmle.label | [post] getter for .p1 [arguments, Collection element] |
@@ -368,8 +351,6 @@ subpaths
 | CommandInjection.swift:163:40:163:73 | ...! | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:163:40:163:73 | ...! | This command depends on a $@. | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | user-provided value |
 | CommandInjection.swift:164:32:164:53 | [...] | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:164:32:164:53 | [...] | This command depends on a $@. | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | user-provided value |
 | CommandInjection.swift:166:45:166:78 | ...! | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:166:45:166:78 | ...! | This command depends on a $@. | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | user-provided value |
-| CommandInjection.swift:176:3:176:3 | [post] task12 | CommandInjection.swift:170:19:170:83 | call to contentsOfDirectory(atPath:) | CommandInjection.swift:176:3:176:3 | [post] task12 | This command depends on a $@. | CommandInjection.swift:170:19:170:83 | call to contentsOfDirectory(atPath:) | user-provided value |
-| CommandInjection.swift:178:3:178:3 | [post] task12 | CommandInjection.swift:170:19:170:83 | call to contentsOfDirectory(atPath:) | CommandInjection.swift:178:3:178:3 | [post] task12 | This command depends on a $@. | CommandInjection.swift:170:19:170:83 | call to contentsOfDirectory(atPath:) | user-provided value |
 | CommandInjection.swift:194:4:194:4 | [post] getter for .p1 | CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | CommandInjection.swift:194:4:194:4 | [post] getter for .p1 | This command depends on a $@. | CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | user-provided value |
 | CommandInjection.swift:195:4:195:6 | [post] ...! | CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | CommandInjection.swift:195:4:195:6 | [post] ...! | This command depends on a $@. | CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | user-provided value |
 | CommandInjection.swift:196:4:196:4 | [post] ...! | CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | CommandInjection.swift:196:4:196:4 | [post] ...! | This command depends on a $@. | CommandInjection.swift:201:41:201:95 | call to String.init(contentsOf:) | user-provided value |

--- a/swift/ql/test/query-tests/Security/CWE-078/CommandInjection.swift
+++ b/swift/ql/test/query-tests/Security/CWE-078/CommandInjection.swift
@@ -53,6 +53,12 @@ class NSUserAutomatorTask : NSUserScriptTask {
 	var variables: [String: Any]? { get { return nil } set { } }
 }
 
+
+
+
+
+
+
 // --- tests ---
 
 func validateCommand(_ command: String) -> String? {
@@ -160,6 +166,19 @@ func testCommandInjectionMore(mySafeString: String) {
 	let task11 = try! NSUserAutomatorTask(url: URL(string: userControlledString)!) // BAD
 	task11.variables = ["abc": userControlledString] // BAD [NOT DETECTED]
 	task11.execute(withInput: nil)
+
+
+
+
+
+
+
+
+
+
+
+
+
 }
 
 struct MyClass {

--- a/swift/ql/test/query-tests/Security/CWE-078/CommandInjection.swift
+++ b/swift/ql/test/query-tests/Security/CWE-078/CommandInjection.swift
@@ -173,9 +173,9 @@ func testCommandInjectionMore(mySafeString: String) {
 		task12.launchPath = "/bin/rm" // GOOD
 		task12.arguments = [file] // GOOD (cases like this vary, but our analysis doesn't work well on them)
 		task12.launch()
-		task12.arguments = files // GOOD (similar to previous) [FALSE POSITIVE]
+		task12.arguments = files // GOOD (similar to previous)
 		task12.launch()
-		task12.arguments = [files[0]] // GOOD (similar to previous) [FALSE POSITIVE]
+		task12.arguments = [files[0]] // GOOD (similar to previous)
 		task12.launch()
 	}
 

--- a/swift/ql/test/query-tests/Security/CWE-078/CommandInjection.swift
+++ b/swift/ql/test/query-tests/Security/CWE-078/CommandInjection.swift
@@ -53,11 +53,11 @@ class NSUserAutomatorTask : NSUserScriptTask {
 	var variables: [String: Any]? { get { return nil } set { } }
 }
 
+class FileManager : NSObject {
+	class var `default`: FileManager { get { return 0 as! FileManager } }
 
-
-
-
-
+	func contentsOfDirectory(atPath path: String) throws -> [String] { [] }
+}
 
 // --- tests ---
 
@@ -167,17 +167,17 @@ func testCommandInjectionMore(mySafeString: String) {
 	task11.variables = ["abc": userControlledString] // BAD [NOT DETECTED]
 	task11.execute(withInput: nil)
 
-
-
-
-
-
-
-
-
-
-
-
+	let files = try! FileManager.default.contentsOfDirectory(atPath: "some/directory")
+	for file in files {
+		let task12 = Process()
+		task12.launchPath = "/bin/rm" // GOOD
+		task12.arguments = [file] // GOOD (cases like this vary, but our analysis doesn't work well on them)
+		task12.launch()
+		task12.arguments = files // GOOD (similar to previous) [FALSE POSITIVE]
+		task12.launch()
+		task12.arguments = [files[0]] // GOOD (similar to previous) [FALSE POSITIVE]
+		task12.launch()
+	}
 
 }
 


### PR DESCRIPTION
Disable taint source models from `FileManager` that return one or more paths on the file system.  These sources have been found to produce results of low value, for example in the `swift/command-line-injection` query.