### PR TITLE
Go/Bazel: fix gazelle invocation to use bundled bazel go

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,7 +14,7 @@ local_path_override(
 # see https://registry.bazel.build/ for a list of available packages
 
 bazel_dep(name = "platforms", version = "0.0.10")
-bazel_dep(name = "rules_go", version = "0.48.0")
+bazel_dep(name = "rules_go", version = "0.49.0")
 bazel_dep(name = "rules_pkg", version = "0.10.1")
 bazel_dep(name = "rules_nodejs", version = "6.2.0-codeql.1")
 bazel_dep(name = "rules_python", version = "0.32.2")
@@ -23,7 +23,7 @@ bazel_dep(name = "abseil-cpp", version = "20240116.0", repo_name = "absl")
 bazel_dep(name = "nlohmann_json", version = "3.11.3", repo_name = "json")
 bazel_dep(name = "fmt", version = "10.0.0")
 bazel_dep(name = "rules_kotlin", version = "1.9.4-codeql.1")
-bazel_dep(name = "gazelle", version = "0.37.0")
+bazel_dep(name = "gazelle", version = "0.38.0")
 bazel_dep(name = "rules_dotnet", version = "0.15.1")
 bazel_dep(name = "googletest", version = "1.14.0.bcr.1")
 bazel_dep(name = "rules_rust", version = "0.46.0")

--- a/go/BUILD.bazel
+++ b/go/BUILD.bazel
@@ -1,11 +1,9 @@
-load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+load("@gazelle//:def.bzl", "gazelle")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("//misc/bazel:pkg.bzl", "codeql_pack", "codeql_pkg_files")
 
-native_binary(
+gazelle(
     name = "gazelle",
-    src = "@gazelle//cmd/gazelle",
-    out = "gazelle.exe",
     args = ["go/extractor"],
 )
 

--- a/go/extractor/BUILD.bazel
+++ b/go/extractor/BUILD.bazel
@@ -21,8 +21,8 @@ go_library(
         "//go/extractor/toolchain",
         "//go/extractor/trap",
         "//go/extractor/util",
-        "@org_golang_x_mod//modfile:go_default_library",
-        "@org_golang_x_tools//go/packages:go_default_library",
+        "@org_golang_x_mod//modfile",
+        "@org_golang_x_tools//go/packages",
     ],
 )
 

--- a/go/extractor/dbscheme/BUILD.bazel
+++ b/go/extractor/dbscheme/BUILD.bazel
@@ -12,6 +12,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//go/extractor/trap",
-        "@org_golang_x_tools//go/packages:go_default_library",
+        "@org_golang_x_tools//go/packages",
     ],
 )

--- a/go/extractor/project/BUILD.bazel
+++ b/go/extractor/project/BUILD.bazel
@@ -11,7 +11,7 @@ go_library(
         "//go/extractor/diagnostics",
         "//go/extractor/toolchain",
         "//go/extractor/util",
-        "@org_golang_x_mod//modfile:go_default_library",
+        "@org_golang_x_mod//modfile",
     ],
 )
 
@@ -21,6 +21,6 @@ go_test(
     embed = [":project"],
     deps = [
         "//go/extractor/util",
-        "@org_golang_x_mod//modfile:go_default_library",
+        "@org_golang_x_mod//modfile",
     ],
 )

--- a/go/extractor/trap/BUILD.bazel
+++ b/go/extractor/trap/BUILD.bazel
@@ -14,7 +14,7 @@ go_library(
     deps = [
         "//go/extractor/srcarchive",
         "//go/extractor/util",
-        "@org_golang_x_tools//go/packages:go_default_library",
+        "@org_golang_x_tools//go/packages",
     ],
 )
 

--- a/go/extractor/util/BUILD.bazel
+++ b/go/extractor/util/BUILD.bazel
@@ -10,7 +10,7 @@ go_library(
     ],
     importpath = "github.com/github/codeql-go/extractor/util",
     visibility = ["//visibility:public"],
-    deps = ["@org_golang_x_mod//semver:go_default_library"],
+    deps = ["@org_golang_x_mod//semver"],
 )
 
 go_test(
@@ -20,5 +20,5 @@ go_test(
         "util_test.go",
     ],
     embed = [":util"],
-    deps = ["@org_golang_x_mod//semver:go_default_library"],
+    deps = ["@org_golang_x_mod//semver"],
 )

--- a/go/gen.py
+++ b/go/gen.py
@@ -24,7 +24,7 @@ def options():
 opts = options()
 
 try:
-    workspace_dir = pathlib.Path(os.environ.pop('BUILD_WORKSPACE_DIRECTORY'))
+    workspace_dir = pathlib.Path(os.environ['BUILD_WORKSPACE_DIRECTORY'])
 except KeyError:
     print("this should be run with bazel run", file=sys.stderr)
     sys.exit(1)


### PR DESCRIPTION
If I recall correctly, we were avoiding using the `gazelle` rule because of some compilation problem on macOS, which seems to be gone with the current versions of `rules_go` and/or `gazelle`.

This will make sure that gazelle uses the bundled go version: prior to this, the build through `make` was misbehaving if `go` was not installed.