### PR TITLE
Swift: Additional test cases for swift/hardcoded-key

### DIFF
--- a/swift/ql/test/query-tests/Security/CWE-321/HardcodedEncryptionKey.expected
+++ b/swift/ql/test/query-tests/Security/CWE-321/HardcodedEncryptionKey.expected
@@ -39,18 +39,18 @@ edges
 | grdb.swift:23:18:23:33 | call to Data.init(_:) | grdb.swift:33:26:33:26 | constData | provenance |  |
 | grdb.swift:23:23:23:23 | constArray | grdb.swift:23:18:23:33 | call to Data.init(_:) | provenance |  |
 | misc.swift:30:7:30:7 | value | file://:0:0:0:0 | value | provenance |  |
-| misc.swift:46:19:46:38 | call to Data.init(_:) | misc.swift:49:41:49:41 | myConstKey | provenance |  |
-| misc.swift:46:19:46:38 | call to Data.init(_:) | misc.swift:53:25:53:25 | myConstKey | provenance |  |
-| misc.swift:46:19:46:38 | call to Data.init(_:) | misc.swift:57:41:57:41 | myConstKey | provenance |  |
-| misc.swift:46:24:46:24 | abcdef123456 | misc.swift:46:19:46:38 | call to Data.init(_:) | provenance |  |
-| misc.swift:53:2:53:2 | [post] config [encryptionKey] | misc.swift:53:2:53:2 | [post] config | provenance |  |
-| misc.swift:53:25:53:25 | myConstKey | misc.swift:30:7:30:7 | value | provenance |  |
-| misc.swift:53:25:53:25 | myConstKey | misc.swift:53:2:53:2 | [post] config | provenance |  |
-| misc.swift:53:25:53:25 | myConstKey | misc.swift:53:2:53:2 | [post] config [encryptionKey] | provenance |  |
-| misc.swift:57:2:57:18 | [post] getter for .config [encryptionKey] | misc.swift:57:2:57:18 | [post] getter for .config | provenance |  |
-| misc.swift:57:41:57:41 | myConstKey | misc.swift:30:7:30:7 | value | provenance |  |
-| misc.swift:57:41:57:41 | myConstKey | misc.swift:57:2:57:18 | [post] getter for .config | provenance |  |
-| misc.swift:57:41:57:41 | myConstKey | misc.swift:57:2:57:18 | [post] getter for .config [encryptionKey] | provenance |  |
+| misc.swift:57:19:57:38 | call to Data.init(_:) | misc.swift:62:41:62:41 | myConstKey | provenance |  |
+| misc.swift:57:19:57:38 | call to Data.init(_:) | misc.swift:66:25:66:25 | myConstKey | provenance |  |
+| misc.swift:57:19:57:38 | call to Data.init(_:) | misc.swift:70:41:70:41 | myConstKey | provenance |  |
+| misc.swift:57:24:57:24 | abcdef123456 | misc.swift:57:19:57:38 | call to Data.init(_:) | provenance |  |
+| misc.swift:66:2:66:2 | [post] config [encryptionKey] | misc.swift:66:2:66:2 | [post] config | provenance |  |
+| misc.swift:66:25:66:25 | myConstKey | misc.swift:30:7:30:7 | value | provenance |  |
+| misc.swift:66:25:66:25 | myConstKey | misc.swift:66:2:66:2 | [post] config | provenance |  |
+| misc.swift:66:25:66:25 | myConstKey | misc.swift:66:2:66:2 | [post] config [encryptionKey] | provenance |  |
+| misc.swift:70:2:70:18 | [post] getter for .config [encryptionKey] | misc.swift:70:2:70:18 | [post] getter for .config | provenance |  |
+| misc.swift:70:41:70:41 | myConstKey | misc.swift:30:7:30:7 | value | provenance |  |
+| misc.swift:70:41:70:41 | myConstKey | misc.swift:70:2:70:18 | [post] getter for .config | provenance |  |
+| misc.swift:70:41:70:41 | myConstKey | misc.swift:70:2:70:18 | [post] getter for .config [encryptionKey] | provenance |  |
 | rncryptor.swift:60:19:60:38 | call to Data.init(_:) | rncryptor.swift:65:73:65:73 | myConstKey | provenance |  |
 | rncryptor.swift:60:19:60:38 | call to Data.init(_:) | rncryptor.swift:66:73:66:73 | myConstKey | provenance |  |
 | rncryptor.swift:60:19:60:38 | call to Data.init(_:) | rncryptor.swift:67:73:67:73 | myConstKey | provenance |  |
@@ -122,15 +122,15 @@ nodes
 | misc.swift:30:7:30:7 | self [Return] | semmle.label | self [Return] |
 | misc.swift:30:7:30:7 | self [Return] [encryptionKey] | semmle.label | self [Return] [encryptionKey] |
 | misc.swift:30:7:30:7 | value | semmle.label | value |
-| misc.swift:46:19:46:38 | call to Data.init(_:) | semmle.label | call to Data.init(_:) |
-| misc.swift:46:24:46:24 | abcdef123456 | semmle.label | abcdef123456 |
-| misc.swift:49:41:49:41 | myConstKey | semmle.label | myConstKey |
-| misc.swift:53:2:53:2 | [post] config | semmle.label | [post] config |
-| misc.swift:53:2:53:2 | [post] config [encryptionKey] | semmle.label | [post] config [encryptionKey] |
-| misc.swift:53:25:53:25 | myConstKey | semmle.label | myConstKey |
-| misc.swift:57:2:57:18 | [post] getter for .config | semmle.label | [post] getter for .config |
-| misc.swift:57:2:57:18 | [post] getter for .config [encryptionKey] | semmle.label | [post] getter for .config [encryptionKey] |
-| misc.swift:57:41:57:41 | myConstKey | semmle.label | myConstKey |
+| misc.swift:57:19:57:38 | call to Data.init(_:) | semmle.label | call to Data.init(_:) |
+| misc.swift:57:24:57:24 | abcdef123456 | semmle.label | abcdef123456 |
+| misc.swift:62:41:62:41 | myConstKey | semmle.label | myConstKey |
+| misc.swift:66:2:66:2 | [post] config | semmle.label | [post] config |
+| misc.swift:66:2:66:2 | [post] config [encryptionKey] | semmle.label | [post] config [encryptionKey] |
+| misc.swift:66:25:66:25 | myConstKey | semmle.label | myConstKey |
+| misc.swift:70:2:70:18 | [post] getter for .config | semmle.label | [post] getter for .config |
+| misc.swift:70:2:70:18 | [post] getter for .config [encryptionKey] | semmle.label | [post] getter for .config [encryptionKey] |
+| misc.swift:70:41:70:41 | myConstKey | semmle.label | myConstKey |
 | rncryptor.swift:60:19:60:38 | call to Data.init(_:) | semmle.label | call to Data.init(_:) |
 | rncryptor.swift:60:24:60:24 | abcdef123456 | semmle.label | abcdef123456 |
 | rncryptor.swift:65:73:65:73 | myConstKey | semmle.label | myConstKey |
@@ -155,10 +155,10 @@ nodes
 | sqlite3_c_api.swift:49:36:49:36 | buffer | semmle.label | buffer |
 | sqlite3_c_api.swift:50:38:50:38 | buffer | semmle.label | buffer |
 subpaths
-| misc.swift:53:25:53:25 | myConstKey | misc.swift:30:7:30:7 | value | misc.swift:30:7:30:7 | self [Return] | misc.swift:53:2:53:2 | [post] config |
-| misc.swift:53:25:53:25 | myConstKey | misc.swift:30:7:30:7 | value | misc.swift:30:7:30:7 | self [Return] [encryptionKey] | misc.swift:53:2:53:2 | [post] config [encryptionKey] |
-| misc.swift:57:41:57:41 | myConstKey | misc.swift:30:7:30:7 | value | misc.swift:30:7:30:7 | self [Return] | misc.swift:57:2:57:18 | [post] getter for .config |
-| misc.swift:57:41:57:41 | myConstKey | misc.swift:30:7:30:7 | value | misc.swift:30:7:30:7 | self [Return] [encryptionKey] | misc.swift:57:2:57:18 | [post] getter for .config [encryptionKey] |
+| misc.swift:66:25:66:25 | myConstKey | misc.swift:30:7:30:7 | value | misc.swift:30:7:30:7 | self [Return] | misc.swift:66:2:66:2 | [post] config |
+| misc.swift:66:25:66:25 | myConstKey | misc.swift:30:7:30:7 | value | misc.swift:30:7:30:7 | self [Return] [encryptionKey] | misc.swift:66:2:66:2 | [post] config [encryptionKey] |
+| misc.swift:70:41:70:41 | myConstKey | misc.swift:30:7:30:7 | value | misc.swift:30:7:30:7 | self [Return] | misc.swift:70:2:70:18 | [post] getter for .config |
+| misc.swift:70:41:70:41 | myConstKey | misc.swift:30:7:30:7 | value | misc.swift:30:7:30:7 | self [Return] [encryptionKey] | misc.swift:70:2:70:18 | [post] getter for .config [encryptionKey] |
 #select
 | SQLite.swift:43:13:43:13 | hardcoded_key | SQLite.swift:43:13:43:13 | hardcoded_key | SQLite.swift:43:13:43:13 | hardcoded_key | The key 'hardcoded_key' has been initialized with hard-coded values from $@. | SQLite.swift:43:13:43:13 | hardcoded_key | hardcoded_key |
 | SQLite.swift:45:23:45:23 | hardcoded_key | SQLite.swift:45:23:45:23 | hardcoded_key | SQLite.swift:45:23:45:23 | hardcoded_key | The key 'hardcoded_key' has been initialized with hard-coded values from $@. | SQLite.swift:45:23:45:23 | hardcoded_key | hardcoded_key |
@@ -186,14 +186,14 @@ subpaths
 | cryptoswift.swift:164:24:164:24 | keyString | cryptoswift.swift:78:2:78:2 | this string is constant | cryptoswift.swift:164:24:164:24 | keyString | The key 'keyString' has been initialized with hard-coded values from $@. | cryptoswift.swift:78:2:78:2 | this string is constant | this string is constant |
 | cryptoswift.swift:165:24:165:24 | key | cryptoswift.swift:92:26:92:121 | [...] | cryptoswift.swift:165:24:165:24 | key | The key 'key' has been initialized with hard-coded values from $@. | cryptoswift.swift:92:26:92:121 | [...] | [...] |
 | cryptoswift.swift:166:24:166:24 | keyString | cryptoswift.swift:78:2:78:2 | this string is constant | cryptoswift.swift:166:24:166:24 | keyString | The key 'keyString' has been initialized with hard-coded values from $@. | cryptoswift.swift:78:2:78:2 | this string is constant | this string is constant |
-| file://:0:0:0:0 | [post] self | misc.swift:46:24:46:24 | abcdef123456 | file://:0:0:0:0 | [post] self | The key '[post] self' has been initialized with hard-coded values from $@. | misc.swift:46:24:46:24 | abcdef123456 | abcdef123456 |
+| file://:0:0:0:0 | [post] self | misc.swift:57:24:57:24 | abcdef123456 | file://:0:0:0:0 | [post] self | The key '[post] self' has been initialized with hard-coded values from $@. | misc.swift:57:24:57:24 | abcdef123456 | abcdef123456 |
 | grdb.swift:27:23:27:23 | constString | grdb.swift:21:20:21:20 | abc123 | grdb.swift:27:23:27:23 | constString | The key 'constString' has been initialized with hard-coded values from $@. | grdb.swift:21:20:21:20 | abc123 | abc123 |
 | grdb.swift:29:23:29:23 | constData | grdb.swift:22:33:22:50 | [...] | grdb.swift:29:23:29:23 | constData | The key 'constData' has been initialized with hard-coded values from $@. | grdb.swift:22:33:22:50 | [...] | [...] |
 | grdb.swift:31:26:31:26 | constString | grdb.swift:21:20:21:20 | abc123 | grdb.swift:31:26:31:26 | constString | The key 'constString' has been initialized with hard-coded values from $@. | grdb.swift:21:20:21:20 | abc123 | abc123 |
 | grdb.swift:33:26:33:26 | constData | grdb.swift:22:33:22:50 | [...] | grdb.swift:33:26:33:26 | constData | The key 'constData' has been initialized with hard-coded values from $@. | grdb.swift:22:33:22:50 | [...] | [...] |
-| misc.swift:49:41:49:41 | myConstKey | misc.swift:46:24:46:24 | abcdef123456 | misc.swift:49:41:49:41 | myConstKey | The key 'myConstKey' has been initialized with hard-coded values from $@. | misc.swift:46:24:46:24 | abcdef123456 | abcdef123456 |
-| misc.swift:53:2:53:2 | [post] config | misc.swift:46:24:46:24 | abcdef123456 | misc.swift:53:2:53:2 | [post] config | The key '[post] config' has been initialized with hard-coded values from $@. | misc.swift:46:24:46:24 | abcdef123456 | abcdef123456 |
-| misc.swift:57:2:57:18 | [post] getter for .config | misc.swift:46:24:46:24 | abcdef123456 | misc.swift:57:2:57:18 | [post] getter for .config | The key '[post] getter for .config' has been initialized with hard-coded values from $@. | misc.swift:46:24:46:24 | abcdef123456 | abcdef123456 |
+| misc.swift:62:41:62:41 | myConstKey | misc.swift:57:24:57:24 | abcdef123456 | misc.swift:62:41:62:41 | myConstKey | The key 'myConstKey' has been initialized with hard-coded values from $@. | misc.swift:57:24:57:24 | abcdef123456 | abcdef123456 |
+| misc.swift:66:2:66:2 | [post] config | misc.swift:57:24:57:24 | abcdef123456 | misc.swift:66:2:66:2 | [post] config | The key '[post] config' has been initialized with hard-coded values from $@. | misc.swift:57:24:57:24 | abcdef123456 | abcdef123456 |
+| misc.swift:70:2:70:18 | [post] getter for .config | misc.swift:57:24:57:24 | abcdef123456 | misc.swift:70:2:70:18 | [post] getter for .config | The key '[post] getter for .config' has been initialized with hard-coded values from $@. | misc.swift:57:24:57:24 | abcdef123456 | abcdef123456 |
 | rncryptor.swift:65:73:65:73 | myConstKey | rncryptor.swift:60:24:60:24 | abcdef123456 | rncryptor.swift:65:73:65:73 | myConstKey | The key 'myConstKey' has been initialized with hard-coded values from $@. | rncryptor.swift:60:24:60:24 | abcdef123456 | abcdef123456 |
 | rncryptor.swift:66:73:66:73 | myConstKey | rncryptor.swift:60:24:60:24 | abcdef123456 | rncryptor.swift:66:73:66:73 | myConstKey | The key 'myConstKey' has been initialized with hard-coded values from $@. | rncryptor.swift:60:24:60:24 | abcdef123456 | abcdef123456 |
 | rncryptor.swift:67:73:67:73 | myConstKey | rncryptor.swift:60:24:60:24 | abcdef123456 | rncryptor.swift:67:73:67:73 | myConstKey | The key 'myConstKey' has been initialized with hard-coded values from $@. | rncryptor.swift:60:24:60:24 | abcdef123456 | abcdef123456 |

--- a/swift/ql/test/query-tests/Security/CWE-321/HardcodedEncryptionKey.expected
+++ b/swift/ql/test/query-tests/Security/CWE-321/HardcodedEncryptionKey.expected
@@ -51,6 +51,15 @@ edges
 | misc.swift:70:41:70:41 | myConstKey | misc.swift:30:7:30:7 | value | provenance |  |
 | misc.swift:70:41:70:41 | myConstKey | misc.swift:70:2:70:18 | [post] getter for .config | provenance |  |
 | misc.swift:70:41:70:41 | myConstKey | misc.swift:70:2:70:18 | [post] getter for .config [encryptionKey] | provenance |  |
+| misc.swift:73:14:73:20 | k1 | misc.swift:76:26:76:29 | .utf8 | provenance |  |
+| misc.swift:73:28:73:34 | k2 | misc.swift:77:26:77:29 | .utf8 | provenance |  |
+| misc.swift:76:20:76:33 | call to Array<Element>.init(_:) [Collection element] | misc.swift:76:20:76:33 | call to Array<Element>.init(_:) | provenance |  |
+| misc.swift:76:26:76:29 | .utf8 | misc.swift:76:20:76:33 | call to Array<Element>.init(_:) [Collection element] | provenance |  |
+| misc.swift:77:20:77:33 | call to Array<Element>.init(_:) [Collection element] | misc.swift:77:20:77:33 | call to Array<Element>.init(_:) | provenance |  |
+| misc.swift:77:26:77:29 | .utf8 | misc.swift:77:20:77:33 | call to Array<Element>.init(_:) [Collection element] | provenance |  |
+| misc.swift:82:10:82:10 | abc123 | misc.swift:73:14:73:20 | k1 | provenance |  |
+| misc.swift:83:10:83:10 | abc123 | misc.swift:73:14:73:20 | k1 | provenance |  |
+| misc.swift:83:20:83:20 | abc123 | misc.swift:73:28:73:34 | k2 | provenance |  |
 | rncryptor.swift:60:19:60:38 | call to Data.init(_:) | rncryptor.swift:65:73:65:73 | myConstKey | provenance |  |
 | rncryptor.swift:60:19:60:38 | call to Data.init(_:) | rncryptor.swift:66:73:66:73 | myConstKey | provenance |  |
 | rncryptor.swift:60:19:60:38 | call to Data.init(_:) | rncryptor.swift:67:73:67:73 | myConstKey | provenance |  |
@@ -131,6 +140,17 @@ nodes
 | misc.swift:70:2:70:18 | [post] getter for .config | semmle.label | [post] getter for .config |
 | misc.swift:70:2:70:18 | [post] getter for .config [encryptionKey] | semmle.label | [post] getter for .config [encryptionKey] |
 | misc.swift:70:41:70:41 | myConstKey | semmle.label | myConstKey |
+| misc.swift:73:14:73:20 | k1 | semmle.label | k1 |
+| misc.swift:73:28:73:34 | k2 | semmle.label | k2 |
+| misc.swift:76:20:76:33 | call to Array<Element>.init(_:) | semmle.label | call to Array<Element>.init(_:) |
+| misc.swift:76:20:76:33 | call to Array<Element>.init(_:) [Collection element] | semmle.label | call to Array<Element>.init(_:) [Collection element] |
+| misc.swift:76:26:76:29 | .utf8 | semmle.label | .utf8 |
+| misc.swift:77:20:77:33 | call to Array<Element>.init(_:) | semmle.label | call to Array<Element>.init(_:) |
+| misc.swift:77:20:77:33 | call to Array<Element>.init(_:) [Collection element] | semmle.label | call to Array<Element>.init(_:) [Collection element] |
+| misc.swift:77:26:77:29 | .utf8 | semmle.label | .utf8 |
+| misc.swift:82:10:82:10 | abc123 | semmle.label | abc123 |
+| misc.swift:83:10:83:10 | abc123 | semmle.label | abc123 |
+| misc.swift:83:20:83:20 | abc123 | semmle.label | abc123 |
 | rncryptor.swift:60:19:60:38 | call to Data.init(_:) | semmle.label | call to Data.init(_:) |
 | rncryptor.swift:60:24:60:24 | abcdef123456 | semmle.label | abcdef123456 |
 | rncryptor.swift:65:73:65:73 | myConstKey | semmle.label | myConstKey |
@@ -194,6 +214,9 @@ subpaths
 | misc.swift:62:41:62:41 | myConstKey | misc.swift:57:24:57:24 | abcdef123456 | misc.swift:62:41:62:41 | myConstKey | The key 'myConstKey' has been initialized with hard-coded values from $@. | misc.swift:57:24:57:24 | abcdef123456 | abcdef123456 |
 | misc.swift:66:2:66:2 | [post] config | misc.swift:57:24:57:24 | abcdef123456 | misc.swift:66:2:66:2 | [post] config | The key '[post] config' has been initialized with hard-coded values from $@. | misc.swift:57:24:57:24 | abcdef123456 | abcdef123456 |
 | misc.swift:70:2:70:18 | [post] getter for .config | misc.swift:57:24:57:24 | abcdef123456 | misc.swift:70:2:70:18 | [post] getter for .config | The key '[post] getter for .config' has been initialized with hard-coded values from $@. | misc.swift:57:24:57:24 | abcdef123456 | abcdef123456 |
+| misc.swift:76:20:76:33 | call to Array<Element>.init(_:) | misc.swift:82:10:82:10 | abc123 | misc.swift:76:20:76:33 | call to Array<Element>.init(_:) | The key 'call to Array<Element>.init(_:)' has been initialized with hard-coded values from $@. | misc.swift:82:10:82:10 | abc123 | abc123 |
+| misc.swift:76:20:76:33 | call to Array<Element>.init(_:) | misc.swift:83:10:83:10 | abc123 | misc.swift:76:20:76:33 | call to Array<Element>.init(_:) | The key 'call to Array<Element>.init(_:)' has been initialized with hard-coded values from $@. | misc.swift:83:10:83:10 | abc123 | abc123 |
+| misc.swift:77:20:77:33 | call to Array<Element>.init(_:) | misc.swift:83:20:83:20 | abc123 | misc.swift:77:20:77:33 | call to Array<Element>.init(_:) | The key 'call to Array<Element>.init(_:)' has been initialized with hard-coded values from $@. | misc.swift:83:20:83:20 | abc123 | abc123 |
 | rncryptor.swift:65:73:65:73 | myConstKey | rncryptor.swift:60:24:60:24 | abcdef123456 | rncryptor.swift:65:73:65:73 | myConstKey | The key 'myConstKey' has been initialized with hard-coded values from $@. | rncryptor.swift:60:24:60:24 | abcdef123456 | abcdef123456 |
 | rncryptor.swift:66:73:66:73 | myConstKey | rncryptor.swift:60:24:60:24 | abcdef123456 | rncryptor.swift:66:73:66:73 | myConstKey | The key 'myConstKey' has been initialized with hard-coded values from $@. | rncryptor.swift:60:24:60:24 | abcdef123456 | abcdef123456 |
 | rncryptor.swift:67:73:67:73 | myConstKey | rncryptor.swift:60:24:60:24 | abcdef123456 | rncryptor.swift:67:73:67:73 | myConstKey | The key 'myConstKey' has been initialized with hard-coded values from $@. | rncryptor.swift:60:24:60:24 | abcdef123456 | abcdef123456 |

--- a/swift/ql/test/query-tests/Security/CWE-321/misc.swift
+++ b/swift/ql/test/query-tests/Security/CWE-321/misc.swift
@@ -31,6 +31,17 @@ extension Realm {
 	}
 }
 
+
+
+
+
+
+
+
+
+
+
+
 // --- tests ---
 
 class ConfigContainer {
@@ -44,6 +55,8 @@ class ConfigContainer {
 func test(myVarStr: String) {
 	let myVarKey = Data(myVarStr)
 	let myConstKey = Data("abcdef123456")
+
+	// --- realm ---
 
 	_ = Realm.Configuration(encryptionKey: myVarKey) // GOOD
 	_ = Realm.Configuration(encryptionKey: myConstKey) // BAD

--- a/swift/ql/test/query-tests/Security/CWE-321/misc.swift
+++ b/swift/ql/test/query-tests/Security/CWE-321/misc.swift
@@ -1,7 +1,7 @@
 
 // --- stubs ---
 
-class Data {
+struct Data {
     init<S>(_ elements: S) {}
 }
 
@@ -31,16 +31,16 @@ extension Realm {
 	}
 }
 
+protocol BlockMode { }
 
+struct CBC: BlockMode {
+	init(iv: Array<UInt8>) { }
+}
 
-
-
-
-
-
-
-
-
+class AES
+{
+	init(key: Array<UInt8>, blockMode: BlockMode) { }
+}
 
 // --- tests ---
 
@@ -68,4 +68,17 @@ func test(myVarStr: String) {
 	var configContainer = ConfigContainer()
 	configContainer.config.encryptionKey = myVarKey // GOOD
 	configContainer.config.encryptionKey = myConstKey // BAD
+}
+
+func useKeys(_ k1: String, _ k2: String, _ k3: String, _ myIV: Array<UInt8>) {
+	// --- cryptoswift ---
+
+	let a1 = AES(key: Array(k1.utf8), blockMode: CBC(iv: myIV)) // BAD
+	let a2 = AES(key: Array(k2.utf8), blockMode: CBC(iv: myIV)) // BAD
+	let a3 = AES(key: Array(k3.utf8), blockMode: CBC(iv: myIV)) // GOOD
+}
+
+func caller(varString: String, myIV: Array<UInt8>) {
+	useKeys("abc123", varString, varString, myIV)
+	useKeys("abc123", "abc123", varString, myIV)
 }


### PR DESCRIPTION
I had spotted what I thought was a pattern of false positives for `swift/hardcoded-key`, `swift/hardcoded-password` and `swift/constant-salt` (the queries that have constants as sources), where certain kinds of conversions were being mistaken for constants.  On closer investigation (using a proper viewer that allows clicking through to the source), it turns out these cases actually involved constants being passed as parameters, so they're not false positives at all.

This PR adds some test cases that document and confirm correct behaviour.