### PR TITLE
Docs: remove `ubuntu-18.04`, indicate Swift requires macOS

### DIFF
--- a/docs/codeql/reusables/supported-platforms.rst
+++ b/docs/codeql/reusables/supported-platforms.rst
@@ -4,9 +4,7 @@
    :stub-columns: 1
 
    Operating system,Supported versions,Supported CPU architectures
-   Linux,"Ubuntu 18.04
-
-   Ubuntu 20.04
+   Linux,"Ubuntu 20.04
 
    Ubuntu 21.04
 

--- a/docs/codeql/reusables/supported-versions-compilers.rst
+++ b/docs/codeql/reusables/supported-versions-compilers.rst
@@ -38,5 +38,5 @@
     .. [7] JSX and Flow code, YAML, JSON, HTML, and XML files may also be analyzed with JavaScript files.
     .. [8] The extractor requires Python 3 to run. To analyze Python 2.7 you should install both versions of Python.
     .. [9] Requires glibc 2.17.
-    .. [10] Support for the analysis of Swift requires macOS or Linux.
+    .. [10] Support for the analysis of Swift requires macOS.
     .. [11] TypeScript analysis is performed by running the JavaScript extractor with TypeScript enabled. This is the default.


### PR DESCRIPTION
`ubuntu-18.04` Actions runners is deprecated so should be removed from the platforms we support.

Also, changed a footnote to indicate that Swift support requires macOS. Swift analysis on Linux is no longer supported: https://github.com/github/codeql-action/blob/main/CHANGELOG.md#unreleased