### PR TITLE
Java: add support for alert location restrictions

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl1.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl1.qll
@@ -283,6 +283,14 @@ deprecated private module Config implements FullStateConfigSig {
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
+
+  predicate filterForSourceOrSinkAlerts() { none() }
+
+  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
+
+  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
+
+  predicate isFilteredSink(Node sink) { isSink(sink) }
 }
 
 deprecated private import Impl<Config> as I

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl1.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl1.qll
@@ -284,13 +284,7 @@ deprecated private module Config implements FullStateConfigSig {
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
 
-  predicate filterForSourceOrSinkAlerts() { none() }
-
-  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
-
-  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
-
-  predicate isFilteredSink(Node sink) { isSink(sink) }
+  predicate observeDiffInformedIncrementalMode() { none() }
 }
 
 deprecated private import Impl<Config> as I

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -283,6 +283,14 @@ deprecated private module Config implements FullStateConfigSig {
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
+
+  predicate filterForSourceOrSinkAlerts() { none() }
+
+  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
+
+  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
+
+  predicate isFilteredSink(Node sink) { isSink(sink) }
 }
 
 deprecated private import Impl<Config> as I

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -284,13 +284,7 @@ deprecated private module Config implements FullStateConfigSig {
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
 
-  predicate filterForSourceOrSinkAlerts() { none() }
-
-  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
-
-  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
-
-  predicate isFilteredSink(Node sink) { isSink(sink) }
+  predicate observeDiffInformedIncrementalMode() { none() }
 }
 
 deprecated private import Impl<Config> as I

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -283,6 +283,14 @@ deprecated private module Config implements FullStateConfigSig {
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
+
+  predicate filterForSourceOrSinkAlerts() { none() }
+
+  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
+
+  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
+
+  predicate isFilteredSink(Node sink) { isSink(sink) }
 }
 
 deprecated private import Impl<Config> as I

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -284,13 +284,7 @@ deprecated private module Config implements FullStateConfigSig {
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
 
-  predicate filterForSourceOrSinkAlerts() { none() }
-
-  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
-
-  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
-
-  predicate isFilteredSink(Node sink) { isSink(sink) }
+  predicate observeDiffInformedIncrementalMode() { none() }
 }
 
 deprecated private import Impl<Config> as I

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -283,6 +283,14 @@ deprecated private module Config implements FullStateConfigSig {
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
+
+  predicate filterForSourceOrSinkAlerts() { none() }
+
+  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
+
+  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
+
+  predicate isFilteredSink(Node sink) { isSink(sink) }
 }
 
 deprecated private import Impl<Config> as I

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -284,13 +284,7 @@ deprecated private module Config implements FullStateConfigSig {
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
 
-  predicate filterForSourceOrSinkAlerts() { none() }
-
-  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
-
-  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
-
-  predicate isFilteredSink(Node sink) { isSink(sink) }
+  predicate observeDiffInformedIncrementalMode() { none() }
 }
 
 deprecated private import Impl<Config> as I

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -283,6 +283,14 @@ deprecated private module Config implements FullStateConfigSig {
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
+
+  predicate filterForSourceOrSinkAlerts() { none() }
+
+  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
+
+  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
+
+  predicate isFilteredSink(Node sink) { isSink(sink) }
 }
 
 deprecated private import Impl<Config> as I

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -284,13 +284,7 @@ deprecated private module Config implements FullStateConfigSig {
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
 
-  predicate filterForSourceOrSinkAlerts() { none() }
-
-  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
-
-  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
-
-  predicate isFilteredSink(Node sink) { isSink(sink) }
+  predicate observeDiffInformedIncrementalMode() { none() }
 }
 
 deprecated private import Impl<Config> as I

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl1.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl1.qll
@@ -283,6 +283,14 @@ deprecated private module Config implements FullStateConfigSig {
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
+
+  predicate filterForSourceOrSinkAlerts() { none() }
+
+  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
+
+  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
+
+  predicate isFilteredSink(Node sink) { isSink(sink) }
 }
 
 deprecated private import Impl<Config> as I

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl1.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl1.qll
@@ -284,13 +284,7 @@ deprecated private module Config implements FullStateConfigSig {
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
 
-  predicate filterForSourceOrSinkAlerts() { none() }
-
-  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
-
-  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
-
-  predicate isFilteredSink(Node sink) { isSink(sink) }
+  predicate observeDiffInformedIncrementalMode() { none() }
 }
 
 deprecated private import Impl<Config> as I

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -283,6 +283,14 @@ deprecated private module Config implements FullStateConfigSig {
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
+
+  predicate filterForSourceOrSinkAlerts() { none() }
+
+  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
+
+  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
+
+  predicate isFilteredSink(Node sink) { isSink(sink) }
 }
 
 deprecated private import Impl<Config> as I

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -284,13 +284,7 @@ deprecated private module Config implements FullStateConfigSig {
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
 
-  predicate filterForSourceOrSinkAlerts() { none() }
-
-  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
-
-  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
-
-  predicate isFilteredSink(Node sink) { isSink(sink) }
+  predicate observeDiffInformedIncrementalMode() { none() }
 }
 
 deprecated private import Impl<Config> as I

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -283,6 +283,14 @@ deprecated private module Config implements FullStateConfigSig {
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
+
+  predicate filterForSourceOrSinkAlerts() { none() }
+
+  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
+
+  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
+
+  predicate isFilteredSink(Node sink) { isSink(sink) }
 }
 
 deprecated private import Impl<Config> as I

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -284,13 +284,7 @@ deprecated private module Config implements FullStateConfigSig {
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
 
-  predicate filterForSourceOrSinkAlerts() { none() }
-
-  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
-
-  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
-
-  predicate isFilteredSink(Node sink) { isSink(sink) }
+  predicate observeDiffInformedIncrementalMode() { none() }
 }
 
 deprecated private import Impl<Config> as I

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -283,6 +283,14 @@ deprecated private module Config implements FullStateConfigSig {
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
+
+  predicate filterForSourceOrSinkAlerts() { none() }
+
+  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
+
+  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
+
+  predicate isFilteredSink(Node sink) { isSink(sink) }
 }
 
 deprecated private import Impl<Config> as I

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -284,13 +284,7 @@ deprecated private module Config implements FullStateConfigSig {
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
 
-  predicate filterForSourceOrSinkAlerts() { none() }
-
-  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
-
-  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
-
-  predicate isFilteredSink(Node sink) { isSink(sink) }
+  predicate observeDiffInformedIncrementalMode() { none() }
 }
 
 deprecated private import Impl<Config> as I

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl1.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl1.qll
@@ -283,6 +283,14 @@ deprecated private module Config implements FullStateConfigSig {
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
+
+  predicate filterForSourceOrSinkAlerts() { none() }
+
+  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
+
+  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
+
+  predicate isFilteredSink(Node sink) { isSink(sink) }
 }
 
 deprecated private import Impl<Config> as I

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl1.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl1.qll
@@ -284,13 +284,7 @@ deprecated private module Config implements FullStateConfigSig {
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
 
-  predicate filterForSourceOrSinkAlerts() { none() }
-
-  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
-
-  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
-
-  predicate isFilteredSink(Node sink) { isSink(sink) }
+  predicate observeDiffInformedIncrementalMode() { none() }
 }
 
 deprecated private import Impl<Config> as I

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -283,6 +283,14 @@ deprecated private module Config implements FullStateConfigSig {
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
+
+  predicate filterForSourceOrSinkAlerts() { none() }
+
+  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
+
+  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
+
+  predicate isFilteredSink(Node sink) { isSink(sink) }
 }
 
 deprecated private import Impl<Config> as I

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -284,13 +284,7 @@ deprecated private module Config implements FullStateConfigSig {
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
 
-  predicate filterForSourceOrSinkAlerts() { none() }
-
-  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
-
-  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
-
-  predicate isFilteredSink(Node sink) { isSink(sink) }
+  predicate observeDiffInformedIncrementalMode() { none() }
 }
 
 deprecated private import Impl<Config> as I

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -283,6 +283,14 @@ deprecated private module Config implements FullStateConfigSig {
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
+
+  predicate filterForSourceOrSinkAlerts() { none() }
+
+  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
+
+  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
+
+  predicate isFilteredSink(Node sink) { isSink(sink) }
 }
 
 deprecated private import Impl<Config> as I

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -284,13 +284,7 @@ deprecated private module Config implements FullStateConfigSig {
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
 
-  predicate filterForSourceOrSinkAlerts() { none() }
-
-  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
-
-  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
-
-  predicate isFilteredSink(Node sink) { isSink(sink) }
+  predicate observeDiffInformedIncrementalMode() { none() }
 }
 
 deprecated private import Impl<Config> as I

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -283,6 +283,14 @@ deprecated private module Config implements FullStateConfigSig {
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
+
+  predicate filterForSourceOrSinkAlerts() { none() }
+
+  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
+
+  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
+
+  predicate isFilteredSink(Node sink) { isSink(sink) }
 }
 
 deprecated private import Impl<Config> as I

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -284,13 +284,7 @@ deprecated private module Config implements FullStateConfigSig {
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
 
-  predicate filterForSourceOrSinkAlerts() { none() }
-
-  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
-
-  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
-
-  predicate isFilteredSink(Node sink) { isSink(sink) }
+  predicate observeDiffInformedIncrementalMode() { none() }
 }
 
 deprecated private import Impl<Config> as I

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -283,6 +283,14 @@ deprecated private module Config implements FullStateConfigSig {
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
+
+  predicate filterForSourceOrSinkAlerts() { none() }
+
+  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
+
+  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
+
+  predicate isFilteredSink(Node sink) { isSink(sink) }
 }
 
 deprecated private import Impl<Config> as I

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -284,13 +284,7 @@ deprecated private module Config implements FullStateConfigSig {
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
 
-  predicate filterForSourceOrSinkAlerts() { none() }
-
-  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
-
-  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
-
-  predicate isFilteredSink(Node sink) { isSink(sink) }
+  predicate observeDiffInformedIncrementalMode() { none() }
 }
 
 deprecated private import Impl<Config> as I

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl1.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl1.qll
@@ -283,6 +283,14 @@ deprecated private module Config implements FullStateConfigSig {
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
+
+  predicate filterForSourceOrSinkAlerts() { none() }
+
+  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
+
+  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
+
+  predicate isFilteredSink(Node sink) { isSink(sink) }
 }
 
 deprecated private import Impl<Config> as I

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl1.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl1.qll
@@ -284,13 +284,7 @@ deprecated private module Config implements FullStateConfigSig {
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
 
-  predicate filterForSourceOrSinkAlerts() { none() }
-
-  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
-
-  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
-
-  predicate isFilteredSink(Node sink) { isSink(sink) }
+  predicate observeDiffInformedIncrementalMode() { none() }
 }
 
 deprecated private import Impl<Config> as I

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl2.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl2.qll
@@ -283,6 +283,14 @@ deprecated private module Config implements FullStateConfigSig {
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
+
+  predicate filterForSourceOrSinkAlerts() { none() }
+
+  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
+
+  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
+
+  predicate isFilteredSink(Node sink) { isSink(sink) }
 }
 
 deprecated private import Impl<Config> as I

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl2.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl2.qll
@@ -284,13 +284,7 @@ deprecated private module Config implements FullStateConfigSig {
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
 
-  predicate filterForSourceOrSinkAlerts() { none() }
-
-  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
-
-  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
-
-  predicate isFilteredSink(Node sink) { isSink(sink) }
+  predicate observeDiffInformedIncrementalMode() { none() }
 }
 
 deprecated private import Impl<Config> as I

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl1.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl1.qll
@@ -283,6 +283,14 @@ deprecated private module Config implements FullStateConfigSig {
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
+
+  predicate filterForSourceOrSinkAlerts() { none() }
+
+  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
+
+  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
+
+  predicate isFilteredSink(Node sink) { isSink(sink) }
 }
 
 deprecated private import Impl<Config> as I

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl1.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl1.qll
@@ -284,13 +284,7 @@ deprecated private module Config implements FullStateConfigSig {
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
 
-  predicate filterForSourceOrSinkAlerts() { none() }
-
-  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
-
-  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
-
-  predicate isFilteredSink(Node sink) { isSink(sink) }
+  predicate observeDiffInformedIncrementalMode() { none() }
 }
 
 deprecated private import Impl<Config> as I

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -283,6 +283,14 @@ deprecated private module Config implements FullStateConfigSig {
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
+
+  predicate filterForSourceOrSinkAlerts() { none() }
+
+  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
+
+  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
+
+  predicate isFilteredSink(Node sink) { isSink(sink) }
 }
 
 deprecated private import Impl<Config> as I

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -284,13 +284,7 @@ deprecated private module Config implements FullStateConfigSig {
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
 
-  predicate filterForSourceOrSinkAlerts() { none() }
-
-  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
-
-  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
-
-  predicate isFilteredSink(Node sink) { isSink(sink) }
+  predicate observeDiffInformedIncrementalMode() { none() }
 }
 
 deprecated private import Impl<Config> as I

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -283,6 +283,14 @@ deprecated private module Config implements FullStateConfigSig {
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
+
+  predicate filterForSourceOrSinkAlerts() { none() }
+
+  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
+
+  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
+
+  predicate isFilteredSink(Node sink) { isSink(sink) }
 }
 
 deprecated private import Impl<Config> as I

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -284,13 +284,7 @@ deprecated private module Config implements FullStateConfigSig {
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
 
-  predicate filterForSourceOrSinkAlerts() { none() }
-
-  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
-
-  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
-
-  predicate isFilteredSink(Node sink) { isSink(sink) }
+  predicate observeDiffInformedIncrementalMode() { none() }
 }
 
 deprecated private import Impl<Config> as I

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -283,6 +283,14 @@ deprecated private module Config implements FullStateConfigSig {
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
+
+  predicate filterForSourceOrSinkAlerts() { none() }
+
+  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
+
+  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
+
+  predicate isFilteredSink(Node sink) { isSink(sink) }
 }
 
 deprecated private import Impl<Config> as I

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -284,13 +284,7 @@ deprecated private module Config implements FullStateConfigSig {
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
 
-  predicate filterForSourceOrSinkAlerts() { none() }
-
-  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
-
-  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
-
-  predicate isFilteredSink(Node sink) { isSink(sink) }
+  predicate observeDiffInformedIncrementalMode() { none() }
 }
 
 deprecated private import Impl<Config> as I

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -283,6 +283,14 @@ deprecated private module Config implements FullStateConfigSig {
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
+
+  predicate filterForSourceOrSinkAlerts() { none() }
+
+  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
+
+  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
+
+  predicate isFilteredSink(Node sink) { isSink(sink) }
 }
 
 deprecated private import Impl<Config> as I

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -284,13 +284,7 @@ deprecated private module Config implements FullStateConfigSig {
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
 
-  predicate filterForSourceOrSinkAlerts() { none() }
-
-  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
-
-  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
-
-  predicate isFilteredSink(Node sink) { isSink(sink) }
+  predicate observeDiffInformedIncrementalMode() { none() }
 }
 
 deprecated private import Impl<Config> as I

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
@@ -283,6 +283,14 @@ deprecated private module Config implements FullStateConfigSig {
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
+
+  predicate filterForSourceOrSinkAlerts() { none() }
+
+  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
+
+  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
+
+  predicate isFilteredSink(Node sink) { isSink(sink) }
 }
 
 deprecated private import Impl<Config> as I

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
@@ -284,13 +284,7 @@ deprecated private module Config implements FullStateConfigSig {
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
 
-  predicate filterForSourceOrSinkAlerts() { none() }
-
-  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
-
-  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
-
-  predicate isFilteredSink(Node sink) { isSink(sink) }
+  predicate observeDiffInformedIncrementalMode() { none() }
 }
 
 deprecated private import Impl<Config> as I

--- a/java/ql/lib/semmle/code/java/security/AndroidIntentRedirectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/AndroidIntentRedirectionQuery.qll
@@ -18,6 +18,8 @@ module IntentRedirectionConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
     any(IntentRedirectionAdditionalTaintStep c).step(node1, node2)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /** Tracks the flow of tainted Intents being used to start Android components. */

--- a/java/ql/lib/semmle/code/java/security/ExternallyControlledFormatStringQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/ExternallyControlledFormatStringQuery.qll
@@ -23,6 +23,8 @@ module ExternallyControlledFormatStringConfig implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node node) {
     node.getType() instanceof NumericType or node.getType() instanceof BooleanType
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/security/FragmentInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/FragmentInjectionQuery.qll
@@ -17,6 +17,8 @@ module FragmentInjectionTaintConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node n1, DataFlow::Node n2) {
     any(FragmentInjectionAdditionalTaintStep c).step(n1, n2)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/security/GroovyInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/GroovyInjectionQuery.qll
@@ -17,6 +17,8 @@ module GroovyInjectionConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node fromNode, DataFlow::Node toNode) {
     any(GroovyInjectionAdditionalTaintStep c).step(fromNode, toNode)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/security/ImplicitPendingIntentsQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/ImplicitPendingIntentsQuery.qll
@@ -48,6 +48,8 @@ module ImplicitPendingIntentStartConfig implements DataFlow::StateConfigSig {
     node.getType().(Array).getElementType() instanceof TypeIntent and
     c instanceof DataFlow::ArrayContent
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module ImplicitPendingIntentStartFlow =

--- a/java/ql/lib/semmle/code/java/security/InsecureBeanValidationQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/InsecureBeanValidationQuery.qll
@@ -49,6 +49,8 @@ module BeanValidationConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof BeanValidationSink }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /** Tracks flow from user input to the argument of a method that builds constraint error messages. */

--- a/java/ql/lib/semmle/code/java/security/InsecureLdapAuthQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/InsecureLdapAuthQuery.qll
@@ -22,6 +22,8 @@ module InsecureLdapUrlConfig implements DataFlow::ConfigSig {
       succ.asExpr() = ma.getQualifier()
     )
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module InsecureLdapUrlFlow = TaintTracking::Global<InsecureLdapUrlConfig>;

--- a/java/ql/lib/semmle/code/java/security/InsecureRandomnessQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/InsecureRandomnessQuery.qll
@@ -96,6 +96,8 @@ module InsecureRandomnessConfig implements DataFlow::ConfigSig {
       n2.asExpr() = c
     )
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/security/InsufficientKeySizeQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/InsufficientKeySizeQuery.qll
@@ -16,6 +16,8 @@ module KeySizeConfig implements DataFlow::StateConfigSig {
   predicate isSink(DataFlow::Node sink, KeySizeState state) {
     sink.(InsufficientKeySizeSink).hasState(state)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /** Tracks key sizes used in cryptographic algorithms. */

--- a/java/ql/lib/semmle/code/java/security/IntentUriPermissionManipulationQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/IntentUriPermissionManipulationQuery.qll
@@ -23,6 +23,8 @@ module IntentUriPermissionManipulationConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
     any(IntentUriPermissionManipulationAdditionalTaintStep c).step(node1, node2)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/security/JexlInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/JexlInjectionQuery.qll
@@ -51,6 +51,8 @@ module JexlInjectionConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
     any(JexlInjectionAdditionalTaintStep c).step(node1, node2)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/security/JndiInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/JndiInjectionQuery.qll
@@ -23,6 +23,8 @@ module JndiInjectionFlowConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
     any(JndiInjectionAdditionalTaintStep c).step(node1, node2)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /** Tracks flow of unvalidated user input that is used in JNDI lookup */

--- a/java/ql/lib/semmle/code/java/security/LdapInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/LdapInjectionQuery.qll
@@ -17,6 +17,8 @@ module LdapInjectionFlowConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node pred, DataFlow::Node succ) {
     any(LdapInjectionAdditionalTaintStep a).step(pred, succ)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /** Tracks flow from remote sources to LDAP injection vulnerabilities. */

--- a/java/ql/lib/semmle/code/java/security/MissingJWTSignatureCheckQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/MissingJWTSignatureCheckQuery.qll
@@ -16,6 +16,8 @@ module MissingJwtSignatureCheckConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
     any(JwtParserWithInsecureParseAdditionalFlowStep c).step(node1, node2)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module MissingJwtSignatureCheckFlow = DataFlow::Global<MissingJwtSignatureCheckConfig>;

--- a/java/ql/lib/semmle/code/java/security/MvelInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/MvelInjectionQuery.qll
@@ -19,6 +19,8 @@ module MvelInjectionFlowConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
     any(MvelInjectionAdditionalTaintStep c).step(node1, node2)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /** Tracks flow of unsafe user input that is used to construct and evaluate a MVEL expression. */

--- a/java/ql/lib/semmle/code/java/security/NumericCastTaintedQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/NumericCastTaintedQuery.qll
@@ -102,6 +102,8 @@ module NumericCastFlowConfig implements DataFlow::ConfigSig {
   }
 
   predicate isBarrierIn(DataFlow::Node node) { isSource(node) }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/security/OgnlInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/OgnlInjectionQuery.qll
@@ -18,6 +18,8 @@ module OgnlInjectionFlowConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
     any(OgnlInjectionAdditionalTaintStep c).step(node1, node2)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /** Tracks flow of unvalidated user input that is used in OGNL EL evaluation. */

--- a/java/ql/lib/semmle/code/java/security/PartialPathTraversalQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/PartialPathTraversalQuery.qll
@@ -17,6 +17,8 @@ module PartialPathTraversalFromRemoteConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node node) {
     any(PartialPathTraversalMethodCall ma).getQualifier() = node.asExpr()
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /** Tracks flow of unsafe user input that is used to validate against path traversal, but is insufficient and remains vulnerable to Partial Path Traversal. */

--- a/java/ql/lib/semmle/code/java/security/RequestForgeryConfig.qll
+++ b/java/ql/lib/semmle/code/java/security/RequestForgeryConfig.qll
@@ -28,6 +28,8 @@ module RequestForgeryConfig implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node node) { node instanceof RequestForgerySanitizer }
 
   predicate isBarrierIn(DataFlow::Node node) { isSource(node) }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module RequestForgeryFlow = TaintTracking::Global<RequestForgeryConfig>;

--- a/java/ql/lib/semmle/code/java/security/ResponseSplittingQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/ResponseSplittingQuery.qll
@@ -31,6 +31,8 @@ module ResponseSplittingConfig implements DataFlow::ConfigSig {
       )
     )
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/security/RsaWithoutOaepQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/RsaWithoutOaepQuery.qll
@@ -20,6 +20,8 @@ module RsaWithoutOaepConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) {
     exists(CryptoAlgoSpec cr | sink.asExpr() = cr.getAlgoSpec())
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /** Flow for finding RSA ciphers initialized without using OAEP padding. */

--- a/java/ql/lib/semmle/code/java/security/SpelInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/SpelInjectionQuery.qll
@@ -18,6 +18,8 @@ module SpelInjectionConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
     any(SpelExpressionInjectionAdditionalTaintStep c).step(node1, node2)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /** Tracks flow of unsafe user input that is used to construct and evaluate a SpEL expression. */

--- a/java/ql/lib/semmle/code/java/security/StaticInitializationVectorQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/StaticInitializationVectorQuery.qll
@@ -126,6 +126,8 @@ module StaticInitializationVectorConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source instanceof StaticInitializationVectorSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof EncryptionInitializationSink }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /** Tracks the flow from a static initialization vector to the initialization of a cipher */

--- a/java/ql/lib/semmle/code/java/security/TaintedPathQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/TaintedPathQuery.qll
@@ -72,6 +72,8 @@ module TaintedPathConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node n1, DataFlow::Node n2) {
     any(TaintedPathAdditionalTaintStep s).step(n1, n2)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /** Tracks flow from remote sources to the creation of a path. */

--- a/java/ql/lib/semmle/code/java/security/TemplateInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/TemplateInjectionQuery.qll
@@ -16,6 +16,8 @@ module TemplateInjectionFlowConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
     any(TemplateInjectionAdditionalTaintStep a).isAdditionalTaintStep(node1, node2)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /** Tracks server-side template injection (SST) vulnerabilities */

--- a/java/ql/lib/semmle/code/java/security/UnsafeContentUriResolutionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/UnsafeContentUriResolutionQuery.qll
@@ -20,6 +20,8 @@ module UnsafeContentResolutionConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
     any(ContentUriResolutionAdditionalTaintStep s).step(node1, node2)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /** Taint-tracking flow to find paths from remote sources to content URI resolutions. */

--- a/java/ql/lib/semmle/code/java/security/UnsafeDeserializationQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/UnsafeDeserializationQuery.qll
@@ -325,6 +325,8 @@ private module UnsafeDeserializationConfig implements DataFlow::ConfigSig {
   }
 
   predicate isBarrier(DataFlow::Node node) { isUnsafeDeserializationSanitizer(node) }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module UnsafeDeserializationFlow = TaintTracking::Global<UnsafeDeserializationConfig>;

--- a/java/ql/lib/semmle/code/java/security/UrlForwardQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/UrlForwardQuery.qll
@@ -195,6 +195,8 @@ module UrlForwardFlowConfig implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node node) { node instanceof UrlForwardBarrier }
 
   DataFlow::FlowFeature getAFeature() { result instanceof DataFlow::FeatureHasSourceCallContext }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/security/UrlRedirectQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/UrlRedirectQuery.qll
@@ -13,6 +13,8 @@ module UrlRedirectConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { sink instanceof UrlRedirectSink }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof UrlRedirectSanitizer }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/security/WebviewDebuggingEnabledQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/WebviewDebuggingEnabledQuery.qll
@@ -44,6 +44,8 @@ module WebviewDebugEnabledConfig implements DataFlow::ConfigSig {
     or
     node.getEnclosingCallable().getDeclaringType() instanceof NonSecurityTestClass
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/security/XPathInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/XPathInjectionQuery.qll
@@ -12,6 +12,8 @@ module XPathInjectionConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source instanceof ThreatModelFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof XPathInjectionSink }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/security/XsltInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/XsltInjectionQuery.qll
@@ -20,6 +20,8 @@ module XsltInjectionFlowConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
     any(XsltInjectionAdditionalTaintStep c).step(node1, node2)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/security/XssQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/XssQuery.qll
@@ -20,6 +20,8 @@ module XssConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
     any(XssAdditionalTaintStep s).step(node1, node2)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /** Tracks flow from remote sources to cross site scripting vulnerabilities. */

--- a/java/ql/lib/semmle/code/java/security/XxeRemoteQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/XxeRemoteQuery.qll
@@ -18,6 +18,8 @@ module XxeConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node n1, DataFlow::Node n2) {
     any(XxeAdditionalTaintStep s).step(n1, n2)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/security/ZipSlipQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/ZipSlipQuery.qll
@@ -43,6 +43,8 @@ module ZipSlipConfig implements DataFlow::ConfigSig {
     node instanceof SimpleTypeSanitizer or
     node instanceof PathInjectionSanitizer
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /** Tracks flow from archive entries to file creation. */

--- a/java/ql/lib/semmle/code/java/security/regexp/RegexInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/regexp/RegexInjectionQuery.qll
@@ -14,6 +14,8 @@ module RegexInjectionConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { sink instanceof RegexInjectionSink }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof RegexInjectionSanitizer }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl1.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl1.qll
@@ -283,6 +283,14 @@ deprecated private module Config implements FullStateConfigSig {
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
+
+  predicate filterForSourceOrSinkAlerts() { none() }
+
+  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
+
+  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
+
+  predicate isFilteredSink(Node sink) { isSink(sink) }
 }
 
 deprecated private import Impl<Config> as I

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl1.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl1.qll
@@ -284,13 +284,7 @@ deprecated private module Config implements FullStateConfigSig {
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
 
-  predicate filterForSourceOrSinkAlerts() { none() }
-
-  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
-
-  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
-
-  predicate isFilteredSink(Node sink) { isSink(sink) }
+  predicate observeDiffInformedIncrementalMode() { none() }
 }
 
 deprecated private import Impl<Config> as I

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
@@ -283,6 +283,14 @@ deprecated private module Config implements FullStateConfigSig {
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
+
+  predicate filterForSourceOrSinkAlerts() { none() }
+
+  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
+
+  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
+
+  predicate isFilteredSink(Node sink) { isSink(sink) }
 }
 
 deprecated private import Impl<Config> as I

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
@@ -284,13 +284,7 @@ deprecated private module Config implements FullStateConfigSig {
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
 
-  predicate filterForSourceOrSinkAlerts() { none() }
-
-  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
-
-  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
-
-  predicate isFilteredSink(Node sink) { isSink(sink) }
+  predicate observeDiffInformedIncrementalMode() { none() }
 }
 
 deprecated private import Impl<Config> as I

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
@@ -283,6 +283,14 @@ deprecated private module Config implements FullStateConfigSig {
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
+
+  predicate filterForSourceOrSinkAlerts() { none() }
+
+  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
+
+  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
+
+  predicate isFilteredSink(Node sink) { isSink(sink) }
 }
 
 deprecated private import Impl<Config> as I

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
@@ -284,13 +284,7 @@ deprecated private module Config implements FullStateConfigSig {
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
 
-  predicate filterForSourceOrSinkAlerts() { none() }
-
-  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
-
-  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
-
-  predicate isFilteredSink(Node sink) { isSink(sink) }
+  predicate observeDiffInformedIncrementalMode() { none() }
 }
 
 deprecated private import Impl<Config> as I

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
@@ -283,6 +283,14 @@ deprecated private module Config implements FullStateConfigSig {
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
+
+  predicate filterForSourceOrSinkAlerts() { none() }
+
+  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
+
+  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
+
+  predicate isFilteredSink(Node sink) { isSink(sink) }
 }
 
 deprecated private import Impl<Config> as I

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
@@ -284,13 +284,7 @@ deprecated private module Config implements FullStateConfigSig {
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
 
-  predicate filterForSourceOrSinkAlerts() { none() }
-
-  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
-
-  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
-
-  predicate isFilteredSink(Node sink) { isSink(sink) }
+  predicate observeDiffInformedIncrementalMode() { none() }
 }
 
 deprecated private import Impl<Config> as I

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl1.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl1.qll
@@ -283,6 +283,14 @@ deprecated private module Config implements FullStateConfigSig {
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
+
+  predicate filterForSourceOrSinkAlerts() { none() }
+
+  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
+
+  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
+
+  predicate isFilteredSink(Node sink) { isSink(sink) }
 }
 
 deprecated private import Impl<Config> as I

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl1.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl1.qll
@@ -284,13 +284,7 @@ deprecated private module Config implements FullStateConfigSig {
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
 
-  predicate filterForSourceOrSinkAlerts() { none() }
-
-  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
-
-  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
-
-  predicate isFilteredSink(Node sink) { isSink(sink) }
+  predicate observeDiffInformedIncrementalMode() { none() }
 }
 
 deprecated private import Impl<Config> as I

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
@@ -283,6 +283,14 @@ deprecated private module Config implements FullStateConfigSig {
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
+
+  predicate filterForSourceOrSinkAlerts() { none() }
+
+  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
+
+  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
+
+  predicate isFilteredSink(Node sink) { isSink(sink) }
 }
 
 deprecated private import Impl<Config> as I

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
@@ -284,13 +284,7 @@ deprecated private module Config implements FullStateConfigSig {
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
 
-  predicate filterForSourceOrSinkAlerts() { none() }
-
-  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
-
-  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
-
-  predicate isFilteredSink(Node sink) { isSink(sink) }
+  predicate observeDiffInformedIncrementalMode() { none() }
 }
 
 deprecated private import Impl<Config> as I

--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -431,6 +431,12 @@ module Configs<LocationSig Location, InputSig<Location> Lang> {
      * is not visualized (as it is in a `path-problem` query).
      */
     default predicate includeHiddenNodes() { none() }
+
+    /**
+     * Holds to filter out data flows whose source and sink are both not in the
+     * `AlertFiltering` location range.
+     */
+    default predicate filterForSourceOrSinkAlerts() { none() }
   }
 
   /** An input configuration for data flow using flow state. */
@@ -547,6 +553,12 @@ module Configs<LocationSig Location, InputSig<Location> Lang> {
      * is not visualized (as it is in a `path-problem` query).
      */
     default predicate includeHiddenNodes() { none() }
+
+    /**
+     * Holds to filter out data flows whose source and sink are both not in the
+     * `AlertFiltering` location range.
+     */
+    default predicate filterForSourceOrSinkAlerts() { none() }
   }
 }
 
@@ -625,6 +637,7 @@ module DataFlowMake<LocationSig Location, InputSig<Location> Lang> {
   module Global<ConfigSig Config> implements GlobalFlowSig {
     private module C implements FullStateConfigSig {
       import DefaultState<Config>
+      import FilteredSourceSink<Config>
       import Config
 
       predicate accessPathLimit = Config::accessPathLimit/0;
@@ -647,6 +660,7 @@ module DataFlowMake<LocationSig Location, InputSig<Location> Lang> {
    */
   module GlobalWithState<StateConfigSig Config> implements GlobalFlowSig {
     private module C implements FullStateConfigSig {
+      import FilteredStateSourceSink<Config>
       import Config
 
       predicate accessPathLimit = Config::accessPathLimit/0;

--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -433,10 +433,15 @@ module Configs<LocationSig Location, InputSig<Location> Lang> {
     default predicate includeHiddenNodes() { none() }
 
     /**
-     * Holds to filter out data flows whose source and sink are both not in the
-     * `AlertFiltering` location range.
+     * Holds if sources and sinks should be filtered to only include those that
+     * may lead to a flow path with either a source or a sink in the location
+     * range given by `AlertFiltering`. This only has an effect when running
+     * in diff-informed incremental mode.
+     *
+     * This flag should only be applied to flow configurations whose results
+     * are used directly in a query result.
      */
-    default predicate filterForSourceOrSinkAlerts() { none() }
+    default predicate observeDiffInformedIncrementalMode() { none() }
   }
 
   /** An input configuration for data flow using flow state. */
@@ -555,10 +560,15 @@ module Configs<LocationSig Location, InputSig<Location> Lang> {
     default predicate includeHiddenNodes() { none() }
 
     /**
-     * Holds to filter out data flows whose source and sink are both not in the
-     * `AlertFiltering` location range.
+     * Holds if sources and sinks should be filtered to only include those that
+     * may lead to a flow path with either a source or a sink in the location
+     * range given by `AlertFiltering`. This only has an effect when running
+     * in diff-informed incremental mode.
+     *
+     * This flag should only be applied to flow configurations whose results
+     * are used directly in a query result.
      */
-    default predicate filterForSourceOrSinkAlerts() { none() }
+    default predicate observeDiffInformedIncrementalMode() { none() }
   }
 }
 
@@ -637,7 +647,6 @@ module DataFlowMake<LocationSig Location, InputSig<Location> Lang> {
   module Global<ConfigSig Config> implements GlobalFlowSig {
     private module C implements FullStateConfigSig {
       import DefaultState<Config>
-      import FilteredSourceSink<Config>
       import Config
 
       predicate accessPathLimit = Config::accessPathLimit/0;
@@ -660,7 +669,6 @@ module DataFlowMake<LocationSig Location, InputSig<Location> Lang> {
    */
   module GlobalWithState<StateConfigSig Config> implements GlobalFlowSig {
     private module C implements FullStateConfigSig {
-      import FilteredStateSourceSink<Config>
       import Config
 
       predicate accessPathLimit = Config::accessPathLimit/0;

--- a/shared/dataflow/codeql/dataflow/TaintTracking.qll
+++ b/shared/dataflow/codeql/dataflow/TaintTracking.qll
@@ -60,8 +60,8 @@ module TaintFlowMake<
       Config::allowImplicitRead(node, c)
       or
       (
-        Config::isFilteredSink(node) or
-        Config::isFilteredSink(node, _) or
+        Config::isSink(node) or
+        Config::isSink(node, _) or
         Config::isAdditionalFlowStep(node, _, _) or
         Config::isAdditionalFlowStep(node, _, _, _)
       ) and
@@ -75,7 +75,6 @@ module TaintFlowMake<
   module Global<DataFlow::ConfigSig Config> implements DataFlow::GlobalFlowSig {
     private module Config0 implements DataFlowInternal::FullStateConfigSig {
       import DataFlowInternal::DefaultState<Config>
-      import DataFlowInternal::FilteredSourceSink<Config>
       import Config
 
       predicate isAdditionalFlowStep(
@@ -102,7 +101,6 @@ module TaintFlowMake<
    */
   module GlobalWithState<DataFlow::StateConfigSig Config> implements DataFlow::GlobalFlowSig {
     private module Config0 implements DataFlowInternal::FullStateConfigSig {
-      import DataFlowInternal::FilteredStateSourceSink<Config>
       import Config
 
       predicate isAdditionalFlowStep(

--- a/shared/dataflow/codeql/dataflow/TaintTracking.qll
+++ b/shared/dataflow/codeql/dataflow/TaintTracking.qll
@@ -60,8 +60,8 @@ module TaintFlowMake<
       Config::allowImplicitRead(node, c)
       or
       (
-        Config::isSink(node) or
-        Config::isSink(node, _) or
+        Config::isFilteredSink(node) or
+        Config::isFilteredSink(node, _) or
         Config::isAdditionalFlowStep(node, _, _) or
         Config::isAdditionalFlowStep(node, _, _, _)
       ) and
@@ -75,6 +75,7 @@ module TaintFlowMake<
   module Global<DataFlow::ConfigSig Config> implements DataFlow::GlobalFlowSig {
     private module Config0 implements DataFlowInternal::FullStateConfigSig {
       import DataFlowInternal::DefaultState<Config>
+      import DataFlowInternal::FilteredSourceSink<Config>
       import Config
 
       predicate isAdditionalFlowStep(
@@ -101,6 +102,7 @@ module TaintFlowMake<
    */
   module GlobalWithState<DataFlow::StateConfigSig Config> implements DataFlow::GlobalFlowSig {
     private module Config0 implements DataFlowInternal::FullStateConfigSig {
+      import DataFlowInternal::FilteredStateSourceSink<Config>
       import Config
 
       predicate isAdditionalFlowStep(

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -124,6 +124,30 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
      * is not visualized (as it is in a `path-problem` query).
      */
     predicate includeHiddenNodes();
+
+    /**
+     * Holds to filter out data flows whose source and sink are both not in the
+     * `AlertFiltering` location range.
+     */
+    predicate filterForSourceOrSinkAlerts();
+
+    /**
+     * Holds if `source` is a relevant data flow source with the given initial
+     * `state` and passes filtering per `filterForSourceOrSinkAlerts`.
+     */
+    predicate isFilteredSource(Node source, FlowState state);
+
+    /**
+     * Holds if `sink` is a relevant data flow sink accepting `state` and passes
+     * filtering per `filterForSourceOrSinkAlerts`.
+     */
+    predicate isFilteredSink(Node sink, FlowState state);
+
+    /**
+     * Holds if `sink` is a relevant data flow sink for any state and passes
+     * filtering per `filterForSourceOrSinkAlerts`.
+     */
+    predicate isFilteredSink(Node sink);
   }
 
   /**
@@ -144,6 +168,112 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
     predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
       none()
+    }
+  }
+
+  /**
+   * Provide `isFilteredSource` and `isFilteredSink` implementations given a `ConfigSig`.
+   */
+  module FilteredSourceSink<ConfigSig Config> {
+    private import codeql.util.AlertFiltering
+
+    private module AlertFiltering = AlertFilteringImpl<Location>;
+
+    private class FlowState = Unit;
+
+    pragma[noinline]
+    private predicate hasFilteredSource() {
+      exists(Node n | Config::isSource(n) | AlertFiltering::filterByLocation(n.getLocation()))
+    }
+
+    pragma[noinline]
+    private predicate hasFilteredSink() {
+      exists(Node n | Config::isSink(n) | AlertFiltering::filterByLocation(n.getLocation()))
+    }
+
+    predicate isFilteredSource(Node source, FlowState state) {
+      Config::isSource(source) and
+      exists(state) and
+      (
+        not Config::filterForSourceOrSinkAlerts() or
+        // If there are filtered sinks, we need to pass through all sources to preserve all alerts
+        // with filtered sinks. Otherwise the only alerts of interest are those with filtered
+        // sources, so we can perform the source filtering right here.
+        hasFilteredSink() or
+        AlertFiltering::filterByLocation(source.getLocation())
+      )
+    }
+
+    predicate isFilteredSink(Node sink, FlowState state) { isFilteredSink(sink) and exists(state) }
+
+    predicate isFilteredSink(Node sink) {
+      Config::isSink(sink) and
+      (
+        // If there are filtered sources, we need to pass through all sinks to preserve all alerts
+        // with filtered sources. Otherwise the only alerts of interest are those with filtered
+        // sinks, so we can perform the sink filtering right here.
+        hasFilteredSource() or
+        AlertFiltering::filterByLocation(sink.getLocation())
+      )
+    }
+  }
+
+  /**
+   * Provide `isFilteredSource` and `isFilteredSink` implementations given a `StateConfigSig`.
+   */
+  module FilteredStateSourceSink<StateConfigSig Config> {
+    private import codeql.util.AlertFiltering
+
+    private module AlertFiltering = AlertFilteringImpl<Location>;
+
+    private class FlowState = Config::FlowState;
+
+    pragma[noinline]
+    private predicate hasFilteredSource() {
+      exists(Node n | Config::isSource(n, _) | AlertFiltering::filterByLocation(n.getLocation()))
+    }
+
+    pragma[noinline]
+    private predicate hasFilteredSink() {
+      exists(Node n |
+        Config::isSink(n, _) or
+        Config::isSink(n)
+      |
+        AlertFiltering::filterByLocation(n.getLocation())
+      )
+    }
+
+    predicate isFilteredSource(Node source, FlowState state) {
+      Config::isSource(source, state) and
+      (
+        // If there are filtered sinks, we need to pass through all sources to preserve all alerts
+        // with filtered sinks. Otherwise the only alerts of interest are those with filtered
+        // sources, so we can perform the source filtering right here.
+        hasFilteredSink() or
+        AlertFiltering::filterByLocation(source.getLocation())
+      )
+    }
+
+    predicate isFilteredSink(Node sink, FlowState state) {
+      Config::isSink(sink, state) and
+      (
+        // If there are filtered sources, we need to pass through all sinks to preserve all alerts
+        // with filtered sources. Otherwise the only alerts of interest are those with filtered
+        // sinks, so we can perform the sink filtering right here.
+        hasFilteredSource() or
+        AlertFiltering::filterByLocation(sink.getLocation())
+      )
+    }
+
+    predicate isFilteredSink(Node sink) {
+      Config::isSink(sink) and
+      (
+        // If there are filtered sources, we need to pass through all sinks to preserve all alerts
+        // with filtered sources. Otherwise the only alerts of interest are those with filtered
+        // sinks, so we can perform the sink filtering right here.
+        hasFilteredSource() or
+        AlertFiltering::filterByLocation(sink.getLocation())
+      )
     }
   }
 
@@ -250,7 +380,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       exists(Node n |
         node.asNode() = n and
         Config::isBarrierIn(n) and
-        Config::isSource(n, _)
+        Config::isFilteredSource(n, _)
       )
     }
 
@@ -259,7 +389,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       exists(Node n |
         node.asNode() = n and
         Config::isBarrierIn(n, state) and
-        Config::isSource(n, state)
+        Config::isFilteredSource(n, state)
       )
     }
 
@@ -268,9 +398,9 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         node.asNodeOrImplicitRead() = n and
         Config::isBarrierOut(n)
       |
-        Config::isSink(n, _)
+        Config::isFilteredSink(n, _)
         or
-        Config::isSink(n)
+        Config::isFilteredSink(n)
       )
     }
 
@@ -280,9 +410,9 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         node.asNodeOrImplicitRead() = n and
         Config::isBarrierOut(n, state)
       |
-        Config::isSink(n, state)
+        Config::isFilteredSink(n, state)
         or
-        Config::isSink(n)
+        Config::isFilteredSink(n)
       )
     }
 
@@ -292,11 +422,11 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         Config::isBarrier(n)
         or
         Config::isBarrierIn(n) and
-        not Config::isSource(n, _)
+        not Config::isFilteredSource(n, _)
         or
         Config::isBarrierOut(n) and
-        not Config::isSink(n, _) and
-        not Config::isSink(n)
+        not Config::isFilteredSink(n, _) and
+        not Config::isFilteredSink(n)
       )
     }
 
@@ -306,24 +436,24 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         Config::isBarrier(n, state)
         or
         Config::isBarrierIn(n, state) and
-        not Config::isSource(n, state)
+        not Config::isFilteredSource(n, state)
         or
         Config::isBarrierOut(n, state) and
-        not Config::isSink(n, state) and
-        not Config::isSink(n)
+        not Config::isFilteredSink(n, state) and
+        not Config::isFilteredSink(n)
       )
     }
 
     pragma[nomagic]
     private predicate sourceNode(NodeEx node, FlowState state) {
-      Config::isSource(node.asNode(), state) and
+      Config::isFilteredSource(node.asNode(), state) and
       not fullBarrier(node) and
       not stateBarrier(node, state)
     }
 
     pragma[nomagic]
     private predicate sinkNodeWithState(NodeEx node, FlowState state) {
-      Config::isSink(node.asNodeOrImplicitRead(), state) and
+      Config::isFilteredSink(node.asNodeOrImplicitRead(), state) and
       not fullBarrier(node) and
       not stateBarrier(node, state)
     }
@@ -729,7 +859,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       additional predicate sinkNode(NodeEx node, FlowState state) {
         fwdFlow(node) and
         fwdFlowState(state) and
-        Config::isSink(node.asNodeOrImplicitRead())
+        Config::isFilteredSink(node.asNodeOrImplicitRead())
         or
         fwdFlow(node) and
         fwdFlowState(state) and
@@ -2946,7 +3076,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
             NodeEx toNormalSinkNodeEx() {
               exists(Node n |
                 pragma[only_bind_out](node.asNodeOrImplicitRead()) = n and
-                (Config::isSink(n) or Config::isSink(n, _)) and
+                (Config::isFilteredSink(n) or Config::isFilteredSink(n, _)) and
                 result.asNode() = n
               )
             }
@@ -4792,15 +4922,15 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       }
 
       private predicate interestingCallableSrc(DataFlowCallable c) {
-        exists(Node n | Config::isSource(n, _) and c = getNodeEnclosingCallable(n))
+        exists(Node n | Config::isFilteredSource(n, _) and c = getNodeEnclosingCallable(n))
         or
         exists(DataFlowCallable mid | interestingCallableSrc(mid) and callableStep(mid, c))
       }
 
       private predicate interestingCallableSink(DataFlowCallable c) {
         exists(Node n | c = getNodeEnclosingCallable(n) |
-          Config::isSink(n, _) or
-          Config::isSink(n)
+          Config::isFilteredSink(n, _) or
+          Config::isFilteredSink(n)
         )
         or
         exists(DataFlowCallable mid | interestingCallableSink(mid) and callableStep(c, mid))
@@ -4827,7 +4957,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         or
         exists(Node n |
           ce1 = TCallableSrc() and
-          Config::isSource(n, _) and
+          Config::isFilteredSource(n, _) and
           ce2 = TCallable(getNodeEnclosingCallable(n))
         )
         or
@@ -4835,8 +4965,8 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           ce2 = TCallableSink() and
           ce1 = TCallable(getNodeEnclosingCallable(n))
         |
-          Config::isSink(n, _) or
-          Config::isSink(n)
+          Config::isFilteredSink(n, _) or
+          Config::isFilteredSink(n)
         )
       }
 
@@ -4900,7 +5030,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       private predicate revSinkNode(NodeEx node, FlowState state) {
         sinkNodeWithState(node, state)
         or
-        Config::isSink(node.asNodeOrImplicitRead()) and
+        Config::isFilteredSink(node.asNodeOrImplicitRead()) and
         relevantState(state) and
         not fullBarrier(node) and
         not stateBarrier(node, state)

--- a/shared/util/codeql/util/AlertFiltering.qll
+++ b/shared/util/codeql/util/AlertFiltering.qll
@@ -1,0 +1,40 @@
+/**
+ * Provides the `restrictAlertsTo` extensible predicate to restrict alerts to specific source
+ * locations, and the `AlertFilteringImpl` parameterized module to apply the filtering.
+ */
+
+private import codeql.util.Location
+
+/**
+ * Restricts alerts to a specific location in specific files.
+ *
+ * If this predicate is empty, accept all alerts. Otherwise, accept alerts only at the specified
+ * locations. Note that alert restrictions apply only to the start line of an alert (even if the
+ * alert location spans multiple lines) because alerts are displayed on their start lines.
+ *
+ * - filePath: Absolute path of the file to restrict alerts to.
+ * - startLine: Start line number (starting with 1, inclusive) to restrict alerts to.
+ * - endLine: End line number (starting with 1, inclusive) to restrict alerts to.
+ *
+ * If startLine and endLine are both 0, accept alerts anywhere in the file.
+ */
+extensible predicate restrictAlertsTo(string filePath, int startLine, int endLine);
+
+/** Module for applying alert location filtering. */
+module AlertFilteringImpl<LocationSig Location> {
+  /** Applies alert filtering to the given location. */
+  bindingset[location]
+  predicate filterByLocation(Location location) {
+    not restrictAlertsTo(_, _, _)
+    or
+    exists(string filePath, int startLine, int endLine |
+      restrictAlertsTo(filePath, startLine, endLine)
+    |
+      startLine = 0 and
+      endLine = 0 and
+      location.hasLocationInfo(filePath, _, _, _, _)
+      or
+      location.hasLocationInfo(filePath, [startLine .. endLine], _, _, _)
+    )
+  }
+}

--- a/shared/util/ext/default-alert-filter.yml
+++ b/shared/util/ext/default-alert-filter.yml
@@ -1,0 +1,7 @@
+extensions:
+
+  - addsTo:
+      pack: codeql/util
+      extensible: restrictAlertsTo
+    # Empty predicate means no restrictions on alert locations
+    data: []

--- a/shared/util/qlpack.yml
+++ b/shared/util/qlpack.yml
@@ -3,4 +3,6 @@ version: 1.0.7-dev
 groups: shared
 library: true
 dependencies: null
+dataExtensions:
+  - ext/*.yml
 warnOnImplicitThis: true

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl1.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl1.qll
@@ -283,6 +283,14 @@ deprecated private module Config implements FullStateConfigSig {
   FlowFeature getAFeature() { result = any(Configuration config).getAFeature() }
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
+
+  predicate filterForSourceOrSinkAlerts() { none() }
+
+  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
+
+  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
+
+  predicate isFilteredSink(Node sink) { isSink(sink) }
 }
 
 deprecated private import Impl<Config> as I

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl1.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl1.qll
@@ -284,13 +284,7 @@ deprecated private module Config implements FullStateConfigSig {
 
   predicate includeHiddenNodes() { any(Configuration config).includeHiddenNodes() }
 
-  predicate filterForSourceOrSinkAlerts() { none() }
-
-  predicate isFilteredSource(Node source, FlowState state) { isSource(source, state) }
-
-  predicate isFilteredSink(Node sink, FlowState state) { isSink(sink, state) }
-
-  predicate isFilteredSink(Node sink) { isSink(sink) }
+  predicate observeDiffInformedIncrementalMode() { none() }
 }
 
 deprecated private import Impl<Config> as I


### PR DESCRIPTION
This PR modifies Java queries in the Code Scanning suite to support restricting alerts based on source location, with the restrictions configured through extensible predicates.