### PR TITLE
Go: Remove unneeded dependency from test go.mod

### DIFF
--- a/go/ql/test/experimental/CWE-321-V2/go.mod
+++ b/go/ql/test/experimental/CWE-321-V2/go.mod
@@ -3,35 +3,12 @@ module main
 go 1.21
 
 require (
-	github.com/gin-gonic/gin v1.9.1
 	github.com/go-jose/go-jose/v3 v3.0.0
 	github.com/golang-jwt/jwt/v5 v5.0.0
 )
 
 require (
-	github.com/bytedance/sonic v1.9.1 // indirect
-	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
-	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
-	github.com/gin-contrib/sse v0.1.0 // indirect
-	github.com/go-playground/locales v0.14.1 // indirect
-	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/go-playground/validator/v10 v10.14.0 // indirect
-	github.com/goccy/go-json v0.10.2 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/klauspost/cpuid/v2 v2.2.4 // indirect
-	github.com/leodido/go-urn v1.2.4 // indirect
-	github.com/mattn/go-isatty v0.0.19 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
-	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
-	github.com/ugorji/go/codec v1.2.11 // indirect
-	golang.org/x/arch v0.3.0 // indirect
-	golang.org/x/net v0.10.0 // indirect
-	golang.org/x/sys v0.11.0 // indirect
-	golang.org/x/text v0.12.0 // indirect
-	google.golang.org/protobuf v1.30.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
+	github.com/stretchr/testify v1.8.3 // indirect
 	golang.org/x/crypto v0.12.0 // indirect
 )

--- a/go/ql/test/experimental/CWE-321-V2/vendor/modules.txt
+++ b/go/ql/test/experimental/CWE-321-V2/vendor/modules.txt
@@ -1,84 +1,15 @@
-# github.com/gin-gonic/gin v1.9.1
-## explicit
-github.com/gin-gonic/gin
 # github.com/go-jose/go-jose/v3 v3.0.0
 ## explicit
 github.com/go-jose/go-jose/v3
 # github.com/golang-jwt/jwt/v5 v5.0.0
 ## explicit
 github.com/golang-jwt/jwt/v5
-# github.com/bytedance/sonic v1.9.1
-## explicit
-github.com/bytedance/sonic
-# github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311
-## explicit
-github.com/chenzhuoyu/base64x
-# github.com/gabriel-vasile/mimetype v1.4.2
-## explicit
-github.com/gabriel-vasile/mimetype
-# github.com/gin-contrib/sse v0.1.0
-## explicit
-github.com/gin-contrib/sse
-# github.com/go-playground/locales v0.14.1
-## explicit
-github.com/go-playground/locales
-# github.com/go-playground/universal-translator v0.18.1
-## explicit
-github.com/go-playground/universal-translator
-# github.com/go-playground/validator/v10 v10.14.0
-## explicit
-github.com/go-playground/validator/v10
-# github.com/goccy/go-json v0.10.2
-## explicit
-github.com/goccy/go-json
-# github.com/json-iterator/go v1.1.12
-## explicit
-github.com/json-iterator/go
-# github.com/klauspost/cpuid/v2 v2.2.4
-## explicit
-github.com/klauspost/cpuid/v2
-# github.com/leodido/go-urn v1.2.4
-## explicit
-github.com/leodido/go-urn
-# github.com/mattn/go-isatty v0.0.19
-## explicit
-github.com/mattn/go-isatty
-# github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
-## explicit
-github.com/modern-go/concurrent
-# github.com/modern-go/reflect2 v1.0.2
-## explicit
-github.com/modern-go/reflect2
-# github.com/pelletier/go-toml/v2 v2.0.8
-## explicit
-github.com/pelletier/go-toml/v2
-# github.com/twitchyliquid64/golang-asm v0.15.1
-## explicit
-github.com/twitchyliquid64/golang-asm
-# github.com/ugorji/go/codec v1.2.11
-## explicit
-github.com/ugorji/go/codec
-# golang.org/x/arch v0.3.0
-## explicit
-golang.org/x/arch
-# golang.org/x/net v0.10.0
-## explicit
-golang.org/x/net
-# golang.org/x/sys v0.11.0
-## explicit
-golang.org/x/sys
-# golang.org/x/text v0.12.0
-## explicit
-golang.org/x/text
-# google.golang.org/protobuf v1.30.0
-## explicit
-google.golang.org/protobuf
-# gopkg.in/yaml.v3 v3.0.1
-## explicit
-gopkg.in/yaml.v3
 # github.com/google/go-cmp v0.5.9
 ## explicit
 github.com/google/go-cmp
+# github.com/stretchr/testify v1.8.3
+## explicit
+github.com/stretchr/testify
 # golang.org/x/crypto v0.12.0
 ## explicit
 golang.org/x/crypto


### PR DESCRIPTION
The commands I ran were:
```
go mod tidy
depstubber -write_module_txt
```