### PR TITLE
C#: Exclude `System.Runtime.CompilerServices` attributes from XML doc…

### DIFF
--- a/csharp/ql/src/Documentation/Documentation.qll
+++ b/csharp/ql/src/Documentation/Documentation.qll
@@ -45,7 +45,10 @@ predicate declarationHasXmlComment(Declaration d) { exists(getADeclarationXmlCom
 /** Whether a declaration should have documentation. */
 predicate isDocumentationNeeded(Modifiable decl) {
   decl.isUnboundDeclaration() and // Exclude constructed types and methods
-  not exists(decl.(Attributable).getAnAttribute()) and // An attribute may serve to document
+  not exists(Attribute a |
+    a = decl.(Attributable).getAnAttribute() and
+    not a.getType().hasFullyQualifiedName("System.Runtime.CompilerServices", _)
+  ) and // An attribute may serve to document
   decl.isPublic() and
   (
     // The documentation of the overridden method (e.g. in an interface) is sufficient.

--- a/csharp/ql/src/change-notes/2024-08-12-doc-comments.md
+++ b/csharp/ql/src/change-notes/2024-08-12-doc-comments.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Attributes in the `System.Runtime.CompilerServices` namespace are ignored when checking if a declaration requires documentation comments.

--- a/csharp/ql/test/query-tests/Documentation/XmldocMissing.expected
+++ b/csharp/ql/test/query-tests/Documentation/XmldocMissing.expected
@@ -1,3 +1,4 @@
 | documentation.cs:39:16:39:22 | method3 | Public method should be documented. |
 | documentation.cs:51:18:51:23 | Class2 | Public class should be documented. |
 | documentation.cs:74:12:74:17 | Class1 | Public constructor should be documented. |
+| documentation.cs:135:17:135:23 | method6 | Public method should be documented. |

--- a/csharp/ql/test/query-tests/Documentation/documentation.cs
+++ b/csharp/ql/test/query-tests/Documentation/documentation.cs
@@ -123,4 +123,23 @@ class Class2 : Class1
     // GOOD: Even if the overridden method is bad.
     /// <inheritdoc/>
     public override int method4<T>(int p1, int p2) { return p1; }
+
+    // GOOD: Has an attribute
+    [My1]
+    public void method5()
+    {
+    }
+
+    // BAD: Has only System.Runtime.CompilerServices attribute
+    [System.Runtime.CompilerServices.My2]
+    public void method6()
+    {
+    }
+}
+
+internal class My1Attribute : Attribute { }
+
+namespace System.Runtime.CompilerServices
+{
+    internal class My2Attribute : Attribute { }
 }


### PR DESCRIPTION
…umentation needed check

This PR is changing how we select declarations that require documentation comments. Previously any attribute on the declaration meant that doc comments were not required. With this change we're excluding `System.Runtime.CompilerServices` attributes from the check. We've found that `System.Runtime.CompilerServices.NullableAttribute` and `NullableContextAttribute` might be extracted for declarations, but this has no impact on documentation requirements. 

This change is helping with reducing alert wobble in DCA.