### PR TITLE
C#: Remove timing values from extractor telemetry query

### DIFF
--- a/csharp/ql/src/Telemetry/ExtractorInformation.ql
+++ b/csharp/ql/src/Telemetry/ExtractorInformation.ql
@@ -136,14 +136,6 @@ predicate analyzerAssemblies(string key, float value) {
   value = 1.0
 }
 
-predicate timingValues(string key, float value) {
-  exists(Compilation c |
-    key = "Total elapsed seconds" and value = c.getElapsedSeconds()
-    or
-    key = "Extractor elapsed seconds" and value = c.getExtractorElapsedSeconds()
-  )
-}
-
 from string key, float value
 where
   (
@@ -173,8 +165,7 @@ where
     ExprStatsReport::numberOfOk(key, value) or
     ExprStatsReport::numberOfNotOk(key, value) or
     ExprStatsReport::percentageOfOk(key, value) or
-    analyzerAssemblies(key, value) or
-    timingValues(key, value)
+    analyzerAssemblies(key, value)
   ) and
   /* Infinity */
   value != 1.0 / 0.0 and


### PR DESCRIPTION
Timing values in the telemetry data make little sense, because after a traced extraction we end with one value per compilation, so possibly hundreds/thousands of values. 

Also, the values are not stable, so they are causing wobbles in DCA.