### PR TITLE
Dataflow: Reduce duplication, define PathGraphSig only once.

### DIFF
--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -562,6 +562,30 @@ module Configs<LocationSig Location, InputSig<Location> Lang> {
   }
 }
 
+/** A type with `toString`. */
+private signature class TypeWithToString {
+  string toString();
+}
+
+import PathGraphSigMod
+
+private module PathGraphSigMod {
+  signature module PathGraphSig<TypeWithToString PathNode> {
+    /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
+    predicate edges(PathNode a, PathNode b, string key, string val);
+
+    /** Holds if `n` is a node in the graph of data flow path explanations. */
+    predicate nodes(PathNode n, string key, string val);
+
+    /**
+     * Holds if `(arg, par, ret, out)` forms a subpath-tuple, that is, flow through
+     * a subpath between `par` and `ret` with the connecting edges `arg -> par` and
+     * `ret -> out` is summarized as the edge `arg -> out`.
+     */
+    predicate subpaths(PathNode arg, PathNode par, PathNode ret, PathNode out);
+  }
+}
+
 module DataFlowMake<LocationSig Location, InputSig<Location> Lang> {
   private import Lang
   private import internal.DataFlowImpl::MakeImpl<Location, Lang>
@@ -663,20 +687,7 @@ module DataFlowMake<LocationSig Location, InputSig<Location> Lang> {
     Location getLocation();
   }
 
-  signature module PathGraphSig<PathNodeSig PathNode> {
-    /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
-    predicate edges(PathNode a, PathNode b, string key, string val);
-
-    /** Holds if `n` is a node in the graph of data flow path explanations. */
-    predicate nodes(PathNode n, string key, string val);
-
-    /**
-     * Holds if `(arg, par, ret, out)` forms a subpath-tuple, that is, flow through
-     * a subpath between `par` and `ret` with the connecting edges `arg -> par` and
-     * `ret -> out` is summarized as the edge `arg -> out`.
-     */
-    predicate subpaths(PathNode arg, PathNode par, PathNode ret, PathNode out);
-  }
+  import PathGraphSigMod
 
   /**
    * Constructs a `PathGraph` from two `PathGraph`s by disjoint union.

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -4291,12 +4291,10 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       final predicate isSinkGroup(string group) { this = TPathNodeSinkGroup(group) }
     }
 
-    private import codeql.dataflow.test.ProvenancePathGraph as ProvenancePathGraph
-
     /**
      * Provides the query predicates needed to include a graph in a path-problem query.
      */
-    module PathGraph implements PathGraphSig<PathNode>, ProvenancePathGraph::PathGraphSig<PathNode> {
+    module PathGraph implements PathGraphSig<PathNode> {
       /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
       query predicate edges(PathNode a, PathNode b, string key, string val) {
         a.(PathNodeImpl).getANonHiddenSuccessor(val) = b and

--- a/shared/dataflow/codeql/dataflow/test/ProvenancePathGraph.qll
+++ b/shared/dataflow/codeql/dataflow/test/ProvenancePathGraph.qll
@@ -5,7 +5,8 @@
  * In addition to the `PathGraph`, a `query predicate models` is provided to
  * list the contents of the referenced MaD rows.
  */
-module;
+
+private import codeql.dataflow.DataFlow as DF
 
 signature predicate interpretModelForTestSig(QlBuiltins::ExtensionId madId, string model);
 
@@ -13,21 +14,6 @@ signature predicate queryResultsSig(string relation, int row, int column, string
 
 signature class PathNodeSig {
   string toString();
-}
-
-signature module PathGraphSig<PathNodeSig PathNode> {
-  /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
-  predicate edges(PathNode a, PathNode b, string key, string val);
-
-  /** Holds if `n` is a node in the graph of data flow path explanations. */
-  predicate nodes(PathNode n, string key, string val);
-
-  /**
-   * Holds if `(arg, par, ret, out)` forms a subpath-tuple, that is, flow through
-   * a subpath between `par` and `ret` with the connecting edges `arg -> par` and
-   * `ret -> out` is summarized as the edge `arg -> out`.
-   */
-  predicate subpaths(PathNode arg, PathNode par, PathNode ret, PathNode out);
 }
 
 private signature predicate provenanceSig(string model);
@@ -79,7 +65,7 @@ private module TranslateModels<
 /** Transforms a `PathGraph` by printing the provenance information. */
 module ShowProvenance<
   interpretModelForTestSig/2 interpretModelForTest, PathNodeSig PathNode,
-  PathGraphSig<PathNode> PathGraph>
+  DF::PathGraphSig<PathNode> PathGraph>
 {
   private predicate provenance(string model) { PathGraph::edges(_, _, _, model) }
 


### PR DESCRIPTION
I noticed that even though our two different use-cases for `PathGraphSig` relies on parameterisations with different `PathNodeSig`s then that doesn't prevent us from sharing `PathGraphSig`.

There's a little bit of module-juggling to ensure that `PathGraphSig` is exposed both at the top-level and in the result of `DataFlowMake`.

I've copied `TypeWithToString` from `Option.qll`. I think that's fine for now, but of course if we see a proliferation of use-cases for that signature then we can consider putting it in its own shared lib.