### PR TITLE
C#: Implement `ContentSet`

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -908,19 +908,20 @@ private class Argument extends Expr {
  *
  * `postUpdate` indicates whether the store targets a post-update node.
  */
-private predicate fieldOrPropertyStore(Expr e, Content c, Expr src, Expr q, boolean postUpdate) {
+private predicate fieldOrPropertyStore(Expr e, ContentSet c, Expr src, Expr q, boolean postUpdate) {
   exists(FieldOrProperty f |
-    c = f.getContent() and
+    c = f.getContentSet() and
     (
       f.isFieldLike() and
       f instanceof InstanceFieldOrProperty
       or
       exists(
         FlowSummaryImpl::Private::SummarizedCallableImpl sc,
-        FlowSummaryImpl::Private::SummaryComponentStack input
+        FlowSummaryImpl::Private::SummaryComponentStack input, ContentSet readSet
       |
         sc.propagatesFlow(input, _, _, _) and
-        input.contains(FlowSummaryImpl::Private::SummaryComponent::content(f.getContent()))
+        input.contains(FlowSummaryImpl::Private::SummaryComponent::content(readSet)) and
+        c.getAStoreContent() = readSet.getAReadContent()
       )
     )
   |
@@ -970,28 +971,13 @@ private predicate fieldOrPropertyStore(Expr e, Content c, Expr src, Expr q, bool
   )
 }
 
-/** Holds if property `p1` overrides or implements source declaration property `p2`. */
-private predicate overridesOrImplementsSourceDecl(Property p1, Property p2) {
-  p1.getOverridee*().getUnboundDeclaration() = p2
-  or
-  p1.getAnUltimateImplementee().getUnboundDeclaration() = p2
-}
-
 /**
  * Holds if `e2` is an expression that reads field or property `c` from
- * expression `e1`. This takes overriding into account for properties written
- * from library code.
+ * expression `e1`.
  */
-private predicate fieldOrPropertyRead(Expr e1, Content c, FieldOrPropertyRead e2) {
+private predicate fieldOrPropertyRead(Expr e1, ContentSet c, FieldOrPropertyRead e2) {
   e1 = e2.getQualifier() and
-  exists(FieldOrProperty ret | c = ret.getContent() |
-    ret = e2.getTarget()
-    or
-    exists(Property target |
-      target.getGetter() = e2.(PropertyCall).getARuntimeTarget() and
-      overridesOrImplementsSourceDecl(target, ret)
-    )
-  )
+  c = e2.getTarget().(FieldOrProperty).getContentSet()
 }
 
 /**
@@ -1207,6 +1193,11 @@ private module Cached {
       p.getCallable() instanceof PrimaryConstructor
     } or
     TCapturedVariableContent(VariableCapture::CapturedVariable v)
+
+  cached
+  newtype TContentSet =
+    TSingletonContent(Content c) { not c instanceof PropertyContent } or
+    TPropertyContentSet(Property p) { p.isUnboundDeclaration() }
 
   cached
   newtype TContentApprox =
@@ -2076,10 +2067,10 @@ class FieldOrProperty extends Assignable, Modifiable {
   }
 
   /** Gets the content that matches this field or property. */
-  Content getContent() {
-    result.(FieldContent).getField() = this.getUnboundDeclaration()
+  ContentSet getContentSet() {
+    result.isField(this.getUnboundDeclaration())
     or
-    result.(PropertyContent).getProperty() = this.getUnboundDeclaration()
+    result.isProperty(this.getUnboundDeclaration())
   }
 }
 
@@ -2209,8 +2200,8 @@ private class StoreStepConfiguration extends ControlFlowReachabilityConfiguratio
 }
 
 pragma[nomagic]
-private PropertyContent getResultContent() {
-  result.getProperty() = any(SystemThreadingTasksTaskTClass c_).getResultProperty()
+private ContentSet getResultContent() {
+  result.isProperty(any(SystemThreadingTasksTaskTClass c_).getResultProperty())
 }
 
 private predicate primaryConstructorParameterStore(
@@ -2224,17 +2215,16 @@ private predicate primaryConstructorParameterStore(
   )
 }
 
-/**
- * Holds if data can flow from `node1` to `node2` via an assignment to
- * content `c`.
- */
-predicate storeStep(Node node1, ContentSet c, Node node2) {
+pragma[nomagic]
+private predicate recordParameter(RecordType t, Parameter p, string name) {
+  p.getName() = name and p.getCallable().getDeclaringType() = t
+}
+
+private predicate storeContentStep(Node node1, Content c, Node node2) {
   exists(StoreStepConfiguration x, ExprNode node, boolean postUpdate |
     hasNodePath(x, node1, node) and
     if postUpdate = true then node = node2.(PostUpdateNode).getPreUpdateNode() else node = node2
   |
-    fieldOrPropertyStore(_, c, node1.asExpr(), node.getExpr(), postUpdate)
-    or
     arrayStore(_, node1.asExpr(), node.getExpr(), postUpdate) and c instanceof ElementContent
   )
   or
@@ -2255,26 +2245,59 @@ predicate storeStep(Node node1, ContentSet c, Node node2) {
     c instanceof ElementContent
   )
   or
+  primaryConstructorParameterStore(node1, c, node2)
+  or
+  exists(Parameter p, DataFlowCallable callable |
+    node1 = TExplicitParameterNode(p, callable) and
+    node2 = TPrimaryConstructorThisAccessNode(p, true, callable) and
+    not recordParameter(_, p, _) and
+    c.(PrimaryConstructorParameterContent).getParameter() = p
+  )
+  or
+  VariableCapture::storeStep(node1, c, node2)
+}
+
+pragma[nomagic]
+private predicate recordProperty(RecordType t, ContentSet c, string name) {
+  exists(Property p |
+    c.isProperty(p) and
+    p.getName() = name and
+    p.getDeclaringType() = t
+  )
+}
+
+/**
+ * Holds if data can flow from `node1` to `node2` via an assignment to
+ * content `c`.
+ */
+predicate storeStep(Node node1, ContentSet c, Node node2) {
+  exists(Content cont |
+    storeContentStep(node1, cont, node2) and
+    c.isSingleton(cont)
+  )
+  or
+  exists(StoreStepConfiguration x, ExprNode node, boolean postUpdate |
+    hasNodePath(x, node1, node) and
+    if postUpdate = true then node = node2.(PostUpdateNode).getPreUpdateNode() else node = node2
+  |
+    fieldOrPropertyStore(_, c, node1.asExpr(), node.getExpr(), postUpdate)
+  )
+  or
   exists(Expr e |
     e = node1.asExpr() and
     node2.(AsyncReturnNode).getExpr() = e and
     c = getResultContent()
   )
   or
-  primaryConstructorParameterStore(node1, c, node2)
-  or
-  exists(Parameter p, DataFlowCallable callable |
+  exists(Parameter p, DataFlowCallable callable, RecordType t, string name |
     node1 = TExplicitParameterNode(p, callable) and
     node2 = TPrimaryConstructorThisAccessNode(p, true, callable) and
-    if p.getCallable().getDeclaringType() instanceof RecordType
-    then c.(PropertyContent).getProperty().getName() = p.getName()
-    else c.(PrimaryConstructorParameterContent).getParameter() = p
+    recordParameter(t, p, name) and
+    recordProperty(t, c, name)
   )
   or
   FlowSummaryImpl::Private::Steps::summaryStoreStep(node1.(FlowSummaryNode).getSummaryNode(), c,
     node2.(FlowSummaryNode).getSummaryNode())
-  or
-  VariableCapture::storeStep(node1, c, node2)
 }
 
 private class ReadStepConfiguration extends ControlFlowReachabilityConfiguration {
@@ -2342,14 +2365,8 @@ private class ReadStepConfiguration extends ControlFlowReachabilityConfiguration
   }
 }
 
-/**
- * Holds if data can flow from `node1` to `node2` via a read of content `c`.
- */
-predicate readStep(Node node1, ContentSet c, Node node2) {
+private predicate readContentStep(Node node1, Content c, Node node2) {
   exists(ReadStepConfiguration x |
-    hasNodePath(x, node1, node2) and
-    fieldOrPropertyRead(node1.asExpr(), c, node2.asExpr())
-    or
     hasNodePath(x, node1, node2) and
     arrayRead(node1.asExpr(), node2.asExpr()) and
     c instanceof ElementContent
@@ -2360,10 +2377,6 @@ predicate readStep(Node node1, ContentSet c, Node node2) {
       node2.(SsaDefinitionExtNode).getDefinitionExt() = def and
       c instanceof ElementContent
     )
-    or
-    hasNodePath(x, node1, node2) and
-    node2.asExpr().(AwaitExpr).getExpr() = node1.asExpr() and
-    c = getResultContent()
     or
     node1 =
       any(InstanceParameterAccessPreNode n |
@@ -2402,31 +2415,30 @@ predicate readStep(Node node1, ContentSet c, Node node2) {
     )
   )
   or
-  FlowSummaryImpl::Private::Steps::summaryReadStep(node1.(FlowSummaryNode).getSummaryNode(), c,
-    node2.(FlowSummaryNode).getSummaryNode())
-  or
   VariableCapture::readStep(node1, c, node2)
 }
 
 /**
- * Holds if values stored inside content `c` are cleared at node `n`. For example,
- * any value stored inside `f` is cleared at the pre-update node associated with `x`
- * in `x.f = newValue`.
+ * Holds if data can flow from `node1` to `node2` via a read of content `c`.
  */
-predicate clearsContent(Node n, ContentSet c) {
-  fieldOrPropertyStore(_, c, _, n.asExpr(), true)
-  or
-  fieldOrPropertyStore(_, c, _, n.(ObjectInitializerNode).getInitializer(), false)
-  or
-  FlowSummaryImpl::Private::Steps::summaryClearsContent(n.(FlowSummaryNode).getSummaryNode(), c)
-  or
-  exists(WithExpr we, ObjectInitializer oi, FieldOrProperty f |
-    oi = we.getInitializer() and
-    n.asExpr() = oi and
-    f = oi.getAMemberInitializer().getInitializedMember() and
-    c = f.getContent()
+predicate readStep(Node node1, ContentSet c, Node node2) {
+  exists(Content cont |
+    readContentStep(node1, cont, node2) and
+    c.isSingleton(cont)
   )
   or
+  exists(ReadStepConfiguration x | hasNodePath(x, node1, node2) |
+    fieldOrPropertyRead(node1.asExpr(), c, node2.asExpr())
+    or
+    node2.asExpr().(AwaitExpr).getExpr() = node1.asExpr() and
+    c = getResultContent()
+  )
+  or
+  FlowSummaryImpl::Private::Steps::summaryReadStep(node1.(FlowSummaryNode).getSummaryNode(), c,
+    node2.(FlowSummaryNode).getSummaryNode())
+}
+
+private predicate clearsCont(Node n, Content c) {
   exists(Argument a, Struct s, Field f |
     a = n.(PostUpdateNode).getPreUpdateNode().asExpr() and
     a.getType() = s and
@@ -2441,13 +2453,38 @@ predicate clearsContent(Node n, ContentSet c) {
 }
 
 /**
+ * Holds if values stored inside content `c` are cleared at node `n`. For example,
+ * any value stored inside `f` is cleared at the pre-update node associated with `x`
+ * in `x.f = newValue`.
+ */
+predicate clearsContent(Node n, ContentSet c) {
+  exists(Content cont |
+    clearsCont(n, cont) and
+    c.isSingleton(cont)
+  )
+  or
+  fieldOrPropertyStore(_, c, _, n.asExpr(), true)
+  or
+  fieldOrPropertyStore(_, c, _, n.(ObjectInitializerNode).getInitializer(), false)
+  or
+  FlowSummaryImpl::Private::Steps::summaryClearsContent(n.(FlowSummaryNode).getSummaryNode(), c)
+  or
+  exists(WithExpr we, ObjectInitializer oi, FieldOrProperty f |
+    oi = we.getInitializer() and
+    n.asExpr() = oi and
+    f = oi.getAMemberInitializer().getInitializedMember() and
+    c = f.getContentSet()
+  )
+}
+
+/**
  * Holds if the value that is being tracked is expected to be stored inside content `c`
  * at node `n`.
  */
 predicate expectsContent(Node n, ContentSet c) {
   FlowSummaryImpl::Private::Steps::summaryExpectsContent(n.(FlowSummaryNode).getSummaryNode(), c)
   or
-  n.asExpr() instanceof SpreadElementExpr and c instanceof ElementContent
+  n.asExpr() instanceof SpreadElementExpr and c.isElement()
 }
 
 class NodeRegion instanceof ControlFlow::BasicBlock {
@@ -3048,8 +3085,3 @@ abstract class SyntheticField extends string {
   /** Gets the type of this synthetic field. */
   Type getType() { result instanceof ObjectType }
 }
-
-/**
- * Holds if the the content `c` is a container.
- */
-predicate containerContent(DataFlow::Content c) { c instanceof DataFlow::ElementContent }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPublic.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPublic.qll
@@ -314,8 +314,6 @@ class ContentSet extends TContentSet {
       this.isProperty(p1) and
       p2 = result.(PropertyContent).getProperty()
     |
-      p1 = p2
-      or
       overridesOrImplementsSourceDecl(p2, p1)
       or
       overridesOrImplementsSourceDecl(p1, p2)

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
@@ -46,7 +46,7 @@ module Input implements InputSig<Location, DataFlowImplSpecific::CsharpDataFlow>
     result = "delegate-self"
   }
 
-  string encodeContent(ContentSet c, string arg) {
+  private string encodeCont(Content c, string arg) {
     c = TElementContent() and result = "Element" and arg = ""
     or
     exists(Field f, string qualifier, string name |
@@ -56,27 +56,34 @@ module Input implements InputSig<Location, DataFlowImplSpecific::CsharpDataFlow>
       result = "Field"
     )
     or
-    exists(Property p, string qualifier, string name |
-      c = TPropertyContent(p) and
-      p.hasFullyQualifiedName(qualifier, name) and
-      arg = getQualifiedName(qualifier, name) and
-      result = "Property"
-    )
-    or
     exists(SyntheticField f |
       c = TSyntheticFieldContent(f) and result = "SyntheticField" and arg = f
     )
   }
 
+  string encodeContent(ContentSet c, string arg) {
+    exists(Content cont |
+      c.isSingleton(cont) and
+      result = encodeCont(cont, arg)
+    )
+    or
+    exists(Property p, string qualifier, string name |
+      c.isProperty(p) and
+      p.hasFullyQualifiedName(qualifier, name) and
+      arg = getQualifiedName(qualifier, name) and
+      result = "Property"
+    )
+  }
+
   string encodeWithoutContent(ContentSet c, string arg) {
     result = "WithoutElement" and
-    c = TElementContent() and
+    c.isElement() and
     arg = ""
   }
 
   string encodeWithContent(ContentSet c, string arg) {
     result = "WithElement" and
-    c = TElementContent() and
+    c.isElement() and
     arg = ""
   }
 
@@ -103,16 +110,25 @@ private module TypesInput implements Impl::Private::TypesInputSig {
     result.asGvnType() = Gvn::getGlobalValueNumber(any(ObjectType t))
   }
 
-  DataFlowType getContentType(ContentSet c) {
+  private DataFlowType getContType(Content c) {
     exists(Type t | result.asGvnType() = Gvn::getGlobalValueNumber(t) |
       t = c.(FieldContent).getField().getType()
-      or
-      t = c.(PropertyContent).getProperty().getType()
       or
       t = c.(SyntheticFieldContent).getField().getType()
       or
       c instanceof ElementContent and
       t instanceof ObjectType // we don't know what the actual element type is
+    )
+  }
+
+  DataFlowType getContentType(ContentSet c) {
+    exists(Content cont |
+      c.isSingleton(cont) and
+      result = getContType(cont)
+    )
+    or
+    exists(Property p |
+      c.isProperty(p) and result.asGvnType() = Gvn::getGlobalValueNumber(p.getType())
     )
   }
 
@@ -311,17 +327,16 @@ module Private {
     }
 
     /** Gets a summary component that represents an element in a collection. */
-    SummaryComponent element() { result = content(any(DataFlow::ElementContent c)) }
+    SummaryComponent element() { result = content(any(ContentSet cs | cs.isElement())) }
 
     /** Gets a summary component for property `p`. */
     SummaryComponent property(Property p) {
-      result =
-        content(any(DataFlow::PropertyContent c | c.getProperty() = p.getUnboundDeclaration()))
+      result = content(any(DataFlow::ContentSet c | c.isProperty(p.getUnboundDeclaration())))
     }
 
     /** Gets a summary component for field `f`. */
     SummaryComponent field(Field f) {
-      result = content(any(DataFlow::FieldContent c | c.getField() = f.getUnboundDeclaration()))
+      result = content(any(DataFlow::ContentSet c | c.isField(f.getUnboundDeclaration())))
     }
 
     /** Gets a summary component that represents the return value of a call. */

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/TaintTrackingPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/TaintTrackingPrivate.qll
@@ -122,22 +122,22 @@ private module Cached {
       FlowSummaryImpl::Private::Steps::summaryThroughStepTaint(nodeFrom, nodeTo, _)
       or
       // Taint collection by adding a tainted element
-      exists(DataFlow::ElementContent c |
+      exists(DataFlow::ContentSet c | c.isElement() |
         storeStep(nodeFrom, c, nodeTo)
         or
         FlowSummaryImpl::Private::Steps::summarySetterStep(nodeFrom, c, nodeTo, _)
       )
       or
-      exists(DataFlow::Content c |
+      exists(DataFlow::ContentSet c |
         readStep(nodeFrom, c, nodeTo)
         or
         FlowSummaryImpl::Private::Steps::summaryGetterStep(nodeFrom, c, nodeTo, _)
       |
         // Taint members
-        c = any(TaintedMember m).(FieldOrProperty).getContent()
+        c = any(TaintedMember m).(FieldOrProperty).getContentSet()
         or
         // Read from a tainted collection
-        c = TElementContent()
+        c.isElement()
       )
     )
   }
@@ -152,12 +152,12 @@ private module Cached {
       localTaintStepCommon(nodeFrom, nodeTo)
       or
       // Taint members
-      readStep(nodeFrom, any(TaintedMember m).(FieldOrProperty).getContent(), nodeTo)
+      readStep(nodeFrom, any(TaintedMember m).(FieldOrProperty).getContentSet(), nodeTo)
       or
       // Although flow through collections is modeled precisely using stores/reads, we still
       // allow flow out of a _tainted_ collection. This is needed in order to support taint-
       // tracking configurations where the source is a collection
-      readStep(nodeFrom, TElementContent(), nodeTo)
+      readStep(nodeFrom, any(DataFlow::ContentSet c | c.isElement()), nodeTo)
       or
       nodeTo = nodeFrom.(DataFlow::NonLocalJumpNode).getAJumpSuccessor(false)
     ) and

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/EntityFramework.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/EntityFramework.qll
@@ -282,12 +282,12 @@ module EntityFramework {
      * If `t2` is a column type, `c2` will be included in the model (see
      * https://docs.microsoft.com/en-us/ef/core/modeling/entity-types?tabs=data-annotations).
      */
-    private predicate step(Content c1, Type t1, Content c2, Type t2, int dist) {
+    private predicate step(ContentSet c1, Type t1, ContentSet c2, Type t2, int dist) {
       exists(Property p1 |
         p1 = this.getADbSetProperty(t2) and
-        c1.(PropertyContent).getProperty() = p1 and
+        c1.isProperty(p1) and
         t1 = p1.getType() and
-        c2 instanceof ElementContent and
+        c2.isElement() and
         dist = 0
       )
       or
@@ -299,17 +299,17 @@ module EntityFramework {
         exists(Property p2 |
           p2.getDeclaringType().(Class) = t1 and
           not isColumnType(t1) and
-          c2.(PropertyContent).getProperty() = p2 and
+          c2.isProperty(p2) and
           t2 = p2.getType() and
           not isNotMapped(p2)
         )
         or
         exists(ConstructedInterface ci |
-          c1 instanceof PropertyContent and
+          c1.isProperty(_) and
           t1.(ValueOrRefType).getABaseType*() = ci and
           not t1 instanceof StringType and
           ci.getUnboundDeclaration() instanceof SystemCollectionsGenericIEnumerableTInterface and
-          c2 instanceof ElementContent and
+          c2.isElement() and
           t2 = ci.getTypeArgument(0)
         )
       )
@@ -340,16 +340,16 @@ module EntityFramework {
      * ```
      */
     Property getAColumnProperty(int dist) {
-      exists(PropertyContent c, Type t |
+      exists(ContentSet c, Type t |
         this.step(_, _, c, t, dist) and
-        c.getProperty() = result and
+        c.isProperty(result) and
         isColumnType(t)
       )
     }
 
-    private predicate stepRev(Content c1, Type t1, Content c2, Type t2, int dist) {
+    private predicate stepRev(ContentSet c1, Type t1, ContentSet c2, Type t2, int dist) {
       this.step(c1, t1, c2, t2, dist) and
-      c2.(PropertyContent).getProperty() = this.getAColumnProperty(dist)
+      c2.isProperty(this.getAColumnProperty(dist))
       or
       this.stepRev(c2, t2, _, _, dist + 1) and
       this.step(c1, t1, c2, t2, dist)
@@ -364,13 +364,13 @@ module EntityFramework {
 
     /** Holds if component stack `head :: tail` is required for the input specification. */
     predicate requiresComponentStackIn(
-      Content head, Type headType, SummaryComponentStack tail, int dist
+      ContentSet head, Type headType, SummaryComponentStack tail, int dist
     ) {
       tail = SummaryComponentStack::qualifier() and
       this.stepRev(head, headType, _, _, 0) and
       dist = -1
       or
-      exists(Content tailHead, Type tailType, SummaryComponentStack tailTail |
+      exists(ContentSet tailHead, Type tailType, SummaryComponentStack tailTail |
         this.requiresComponentStackIn(tailHead, tailType, tailTail, dist - 1) and
         tail = SummaryComponentStack::push(SummaryComponent::content(tailHead), tailTail) and
         this.stepRev(tailHead, tailType, head, headType, dist)
@@ -379,18 +379,18 @@ module EntityFramework {
 
     /** Holds if component stack `head :: tail` is required for the output specification. */
     predicate requiresComponentStackOut(
-      Content head, Type headType, SummaryComponentStack tail, int dist,
+      ContentSet head, Type headType, SummaryComponentStack tail, int dist,
       DbContextClassSetProperty dbSetProp
     ) {
-      exists(PropertyContent c1 |
+      exists(ContentSet c1 |
         dbSetProp = this.getADbSetProperty(headType) and
         this.stepRev(c1, _, head, headType, 0) and
-        c1.getProperty() = dbSetProp and
+        c1.isProperty(dbSetProp) and
         tail = SummaryComponentStack::return() and
         dist = 0
       )
       or
-      exists(Content tailHead, SummaryComponentStack tailTail, Type tailType |
+      exists(ContentSet tailHead, SummaryComponentStack tailTail, Type tailType |
         this.requiresComponentStackOut(tailHead, tailType, tailTail, dist - 1, dbSetProp) and
         tail = SummaryComponentStack::push(SummaryComponent::content(tailHead), tailTail) and
         this.stepRev(tailHead, tailType, head, headType, dist)
@@ -402,9 +402,9 @@ module EntityFramework {
      */
     pragma[noinline]
     predicate input(SummaryComponentStack input, Property mapped) {
-      exists(PropertyContent head, SummaryComponentStack tail |
+      exists(ContentSet head, SummaryComponentStack tail |
         this.requiresComponentStackIn(head, _, tail, _) and
-        head.getProperty() = mapped and
+        head.isProperty(mapped) and
         mapped = this.getAColumnProperty(_) and
         input = SummaryComponentStack::push(SummaryComponent::content(head), tail)
       )
@@ -418,9 +418,9 @@ module EntityFramework {
     private predicate output(
       SummaryComponentStack output, Property mapped, DbContextClassSetProperty dbSet
     ) {
-      exists(PropertyContent head, SummaryComponentStack tail |
+      exists(ContentSet head, SummaryComponentStack tail |
         this.requiresComponentStackOut(head, _, tail, _, dbSet) and
-        head.getProperty() = mapped and
+        head.isProperty(mapped) and
         mapped = this.getAColumnProperty(_) and
         output = SummaryComponentStack::push(SummaryComponent::content(head), tail)
       )
@@ -505,7 +505,7 @@ module EntityFramework {
   private class DbContextSaveChangesRequiredSummaryComponentStack extends RequiredSummaryComponentStack
   {
     override predicate required(SummaryComponent head, SummaryComponentStack tail) {
-      exists(Content c | head = SummaryComponent::content(c) |
+      exists(ContentSet c | head = SummaryComponent::content(c) |
         any(DbContextClass cls).requiresComponentStackIn(c, _, tail, _)
         or
         any(DbContextClass cls).requiresComponentStackOut(c, _, tail, _, _)

--- a/csharp/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
+++ b/csharp/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
@@ -210,10 +210,24 @@ predicate isRelevantType(CS::Type t) {
 /**
  * Gets the underlying type of the content `c`.
  */
-CS::Type getUnderlyingContentType(DataFlow::Content c) {
+private CS::Type getUnderlyingContType(DataFlow::Content c) {
   result = c.(DataFlow::FieldContent).getField().getType() or
-  result = c.(DataFlow::SyntheticFieldContent).getField().getType() or
-  result = c.(DataFlow::PropertyContent).getProperty().getType()
+  result = c.(DataFlow::SyntheticFieldContent).getField().getType()
+}
+
+/**
+ * Gets the underlying type of the content `c`.
+ */
+CS::Type getUnderlyingContentType(DataFlow::ContentSet c) {
+  exists(DataFlow::Content cont |
+    c.isSingleton(cont) and
+    result = getUnderlyingContType(cont)
+  )
+  or
+  exists(CS::Property p |
+    c.isProperty(p) and
+    result = p.getType()
+  )
 }
 
 /**
@@ -325,3 +339,8 @@ predicate isRelevantSinkKind(string kind) { any() }
  */
 bindingset[kind]
 predicate isRelevantSourceKind(string kind) { any() }
+
+/**
+ * Holds if the the content `c` is a container.
+ */
+predicate containerContent(DataFlow::ContentSet c) { c.isElement() }

--- a/csharp/ql/test/library-tests/dataflow/external-models/steps.ql
+++ b/csharp/ql/test/library-tests/dataflow/external-models/steps.ql
@@ -16,10 +16,10 @@ query predicate summaryThroughStep(
   preservesValue = false
 }
 
-query predicate summaryGetterStep(DataFlow::Node arg, DataFlow::Node out, Content c) {
+query predicate summaryGetterStep(DataFlow::Node arg, DataFlow::Node out, ContentSet c) {
   FlowSummaryImpl::Private::Steps::summaryGetterStep(arg, c, out, _)
 }
 
-query predicate summarySetterStep(DataFlow::Node arg, DataFlow::Node out, Content c) {
+query predicate summarySetterStep(DataFlow::Node arg, DataFlow::Node out, ContentSet c) {
   FlowSummaryImpl::Private::Steps::summarySetterStep(arg, c, out, _)
 }

--- a/java/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
@@ -303,3 +303,5 @@ predicate isRelevantSinkKind(string kind) {
  */
 bindingset[kind]
 predicate isRelevantSourceKind(string kind) { any() }
+
+predicate containerContent = DataFlowPrivate::containerContent/1;


### PR DESCRIPTION
Storing into properties and reading out of properties takes overriding into account. For example, in
```csharp
interface I
{
    string Prop { get; set; }
}

class C : I
{
    public string Prop { get; set; }

    public void M()
    {
            this.Prop = "taint";
            Sink(((I)this).Prop);
    }
}
```
` this.Prop = "taint"` stores into the property `C.Prop`, whereas `((I)this).Prop` read from `I.Prop`. Before this PR, `((I)this).Prop` would give rise to two read steps: one for `I.Prop` and one for `C.Prop`. In general, this meant that property reads would fan out to all possible compatible properties, which is better solved using `ContentSet`s.