### PR TITLE
Add support for importing NPM modules in XSJS sources

### DIFF
--- a/javascript/ql/lib/semmle/javascript/NodeJS.qll
+++ b/javascript/ql/lib/semmle/javascript/NodeJS.qll
@@ -295,6 +295,15 @@ private predicate isRequire(DataFlow::Node nd) {
     isCreateRequire(call.getCallee().flow()) and
     nd = call.flow()
   )
+  or
+  // `$.require('underscore');`.
+  // NPM as supported in [XSJS files](https://www.npmjs.com/package/@sap/async-xsjs#npm-packages-support).
+  exists(MethodCallExpr require |
+    nd.getFile().getExtension() = ["xsjs", "xsjslib"] and
+    require.getCalleeName() = "require" and
+    require.getReceiver().(GlobalVarAccess).getName() = "$" and
+    nd = require.getCallee().flow()
+  )
 }
 
 /**

--- a/javascript/ql/test/query-tests/Security/CWE-326/InsufficientKeySize.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-326/InsufficientKeySize.expected
@@ -9,3 +9,4 @@
 | tst.js:35:13:35:43 | crypto. ... an(512) | Creation of an asymmetric key uses 512 bits, which is below 2048 and considered breakable. |
 | tst.js:39:13:39:33 | new Nod ... : 512}) | Creation of an asymmetric RSA key uses 512 bits, which is below 2048 and considered breakable. |
 | tst.js:43:1:43:31 | key.gen ...  65537) | Creation of an asymmetric RSA key uses 512 bits, which is below 2048 and considered breakable. |
+| tst.xsjs:3:14:3:71 | crypto. ... 1024 }) | Creation of an asymmetric RSA key uses 1024 bits, which is below 2048 and considered breakable. |

--- a/javascript/ql/test/query-tests/Security/CWE-326/tst.xsjs
+++ b/javascript/ql/test/query-tests/Security/CWE-326/tst.xsjs
@@ -1,0 +1,5 @@
+const crypto = $.require("crypto");
+
+const bad1 = crypto.generateKeyPairSync("rsa", { modulusLength: 1024 }); // NOT OK
+
+const good1 = crypto.generateKeyPairSync("rsa", { modulusLength: 4096 }); // OK


### PR DESCRIPTION
XSJS sources can import NPM modules.
Adding support for the `$.require` syntax enables several existing queries to detect issue in XSJS projects