### PR TITLE
Shared: fix type over-restriction in subpaths04

### DIFF
--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -4877,10 +4877,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       private predicate subpaths04(
         PathNodeImpl arg, PathNodeImpl par, PathNodeImpl ret, PathNodeImpl out
       ) {
-        exists(
-          ParamNodeEx p, NodeEx o, FlowState sout, AccessPath apout,
-          PathNodeMid out0
-        |
+        exists(ParamNodeEx p, NodeEx o, FlowState sout, AccessPath apout, PathNodeMid out0 |
           pragma[only_bind_into](arg).getASuccessorImpl(_) = pragma[only_bind_into](out0) and
           subpaths03(pragma[only_bind_into](arg), p, ret, o, sout, _, apout) and
           hasSuccessor(pragma[only_bind_into](arg), par, p) and

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -4878,13 +4878,13 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         PathNodeImpl arg, PathNodeImpl par, PathNodeImpl ret, PathNodeImpl out
       ) {
         exists(
-          ParamNodeEx p, NodeEx o, FlowState sout, DataFlowType t, AccessPath apout,
+          ParamNodeEx p, NodeEx o, FlowState sout, AccessPath apout,
           PathNodeMid out0
         |
           pragma[only_bind_into](arg).getASuccessorImpl(_) = pragma[only_bind_into](out0) and
-          subpaths03(pragma[only_bind_into](arg), p, ret, o, sout, t, apout) and
+          subpaths03(pragma[only_bind_into](arg), p, ret, o, sout, _, apout) and
           hasSuccessor(pragma[only_bind_into](arg), par, p) and
-          pathNode(out0, o, sout, _, _, t, apout, _, _)
+          pathNode(out0, o, sout, _, _, _, apout, _, _)
         |
           out = out0 or out = out0.projectToSink(_)
         )

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -4877,11 +4877,16 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       private predicate subpaths04(
         PathNodeImpl arg, PathNodeImpl par, PathNodeImpl ret, PathNodeImpl out
       ) {
-        exists(ParamNodeEx p, NodeEx o, FlowState sout, AccessPath apout, PathNodeMid out0 |
+        exists(
+          ParamNodeEx p, NodeEx o, FlowState sout, DataFlowType tret, DataFlowType tout,
+          AccessPath apout, PathNodeMid out0
+        |
           pragma[only_bind_into](arg).getASuccessorImpl(_) = pragma[only_bind_into](out0) and
-          subpaths03(pragma[only_bind_into](arg), p, ret, o, sout, _, apout) and
+          subpaths03(pragma[only_bind_into](arg), p, ret, o, sout, pragma[only_bind_into](tret),
+            apout) and
           hasSuccessor(pragma[only_bind_into](arg), par, p) and
-          pathNode(out0, o, sout, _, _, _, apout, _, _)
+          pathNode(out0, o, sout, _, _, pragma[only_bind_into](tout), apout, _, _) and
+          compatibleTypes(tret, tout)
         |
           out = out0 or out = out0.projectToSink(_)
         )


### PR DESCRIPTION
Tuples from `subpaths03` are sometimes discarded in `subpaths04` because of the restriction on `t`. The previous stages seem to restrict it to the type of `ret`, but then it gets restricted to the type of `out`, which can have a different type.

The role of `t` here isn't entirely clear to me, but if the intent is to prune infeasible paths, I guess it should be replaced with a type-compatibility check instead? The last commit adds this check, but please comment on whether this should be necessary.