### PR TITLE
Dataflow: Add test highlighting missing subpath.

### DIFF
--- a/java/ql/test/library-tests/dataflow/subpaths/A.java
+++ b/java/ql/test/library-tests/dataflow/subpaths/A.java
@@ -1,0 +1,29 @@
+import java.util.function.*;
+
+class A {
+  Object source(String label) { return null; }
+
+  void sink(Object o) { }
+
+  <T> T propagateTaint(Object arg) {
+    return (T)arg;
+  }
+
+  void test() {
+    // test type strengthening on outgoing through-flow edge
+    String s = this.<String>propagateTaint(source("A"));
+    sink(s); // $ hasValueFlow=A
+
+    // no strengthening
+    Object o = this.<Object>propagateTaint(source("B"));
+    sink(o); // $ hasValueFlow=B
+
+    // test type strengthening on ingoing through-flow edge
+    String s2 = apply((String arg) -> arg, source("C"));
+    sink(s2); // $ hasValueFlow=C
+  }
+
+  <T1, T2> T2 apply(Function<T1, T2> f, Object x) {
+    return f.apply((T1)x);
+  }
+}

--- a/java/ql/test/library-tests/dataflow/subpaths/flow.expected
+++ b/java/ql/test/library-tests/dataflow/subpaths/flow.expected
@@ -1,0 +1,38 @@
+models
+edges
+| A.java:8:24:8:33 | arg : Object | A.java:9:12:9:17 | (...)... : Object | provenance |  |
+| A.java:14:16:14:55 | propagateTaint(...) : String | A.java:15:10:15:10 | s | provenance |  |
+| A.java:14:44:14:54 | source(...) : Object | A.java:8:24:8:33 | arg : Object | provenance |  |
+| A.java:14:44:14:54 | source(...) : Object | A.java:14:16:14:55 | propagateTaint(...) : String | provenance |  |
+| A.java:18:16:18:55 | propagateTaint(...) : Object | A.java:19:10:19:10 | o | provenance |  |
+| A.java:18:44:18:54 | source(...) : Object | A.java:8:24:8:33 | arg : Object | provenance |  |
+| A.java:18:44:18:54 | source(...) : Object | A.java:18:16:18:55 | propagateTaint(...) : Object | provenance |  |
+| A.java:22:17:22:55 | apply(...) : String | A.java:23:10:23:11 | s2 | provenance |  |
+| A.java:22:24:22:33 | arg : String | A.java:22:39:22:41 | arg : String | provenance |  |
+| A.java:22:44:22:54 | source(...) : Object | A.java:22:17:22:55 | apply(...) : String | provenance |  |
+| A.java:22:44:22:54 | source(...) : Object | A.java:26:41:26:48 | x : Object | provenance |  |
+| A.java:26:41:26:48 | x : Object | A.java:27:20:27:24 | (...)... : Object | provenance |  |
+| A.java:27:20:27:24 | (...)... : Object | A.java:22:24:22:33 | arg : String | provenance |  |
+| A.java:27:20:27:24 | (...)... : Object | A.java:27:12:27:25 | apply(...) : String | provenance |  |
+nodes
+| A.java:8:24:8:33 | arg : Object | semmle.label | arg : Object |
+| A.java:9:12:9:17 | (...)... : Object | semmle.label | (...)... : Object |
+| A.java:14:16:14:55 | propagateTaint(...) : String | semmle.label | propagateTaint(...) : String |
+| A.java:14:44:14:54 | source(...) : Object | semmle.label | source(...) : Object |
+| A.java:15:10:15:10 | s | semmle.label | s |
+| A.java:18:16:18:55 | propagateTaint(...) : Object | semmle.label | propagateTaint(...) : Object |
+| A.java:18:44:18:54 | source(...) : Object | semmle.label | source(...) : Object |
+| A.java:19:10:19:10 | o | semmle.label | o |
+| A.java:22:17:22:55 | apply(...) : String | semmle.label | apply(...) : String |
+| A.java:22:24:22:33 | arg : String | semmle.label | arg : String |
+| A.java:22:39:22:41 | arg : String | semmle.label | arg : String |
+| A.java:22:44:22:54 | source(...) : Object | semmle.label | source(...) : Object |
+| A.java:23:10:23:11 | s2 | semmle.label | s2 |
+| A.java:26:41:26:48 | x : Object | semmle.label | x : Object |
+| A.java:27:12:27:25 | apply(...) : String | semmle.label | apply(...) : String |
+| A.java:27:20:27:24 | (...)... : Object | semmle.label | (...)... : Object |
+subpaths
+| A.java:18:44:18:54 | source(...) : Object | A.java:8:24:8:33 | arg : Object | A.java:9:12:9:17 | (...)... : Object | A.java:18:16:18:55 | propagateTaint(...) : Object |
+| A.java:22:44:22:54 | source(...) : Object | A.java:26:41:26:48 | x : Object | A.java:27:12:27:25 | apply(...) : String | A.java:22:17:22:55 | apply(...) : String |
+| A.java:27:20:27:24 | (...)... : Object | A.java:22:24:22:33 | arg : String | A.java:22:39:22:41 | arg : String | A.java:27:12:27:25 | apply(...) : String |
+testFailures

--- a/java/ql/test/library-tests/dataflow/subpaths/flow.ql
+++ b/java/ql/test/library-tests/dataflow/subpaths/flow.ql
@@ -1,0 +1,3 @@
+import TestUtilities.InlineFlowTest
+import DefaultFlowTest
+import TaintFlow::PathGraph


### PR DESCRIPTION
@asgerf found a bug causing a missing subpath, so I distilled it into a qltest. I'll look into fixing this in a separate PR.

Note that the flow works just fine - it's just the subpaths tuple that's missing, which causes a slightly less informative path explanation.