### PR TITLE
Ruby: Rework (hash) splat argument/parameter matching

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
@@ -1538,8 +1538,13 @@ predicate parameterMatch(ParameterPosition ppos, ArgumentPosition apos) {
   or
   exists(string name | ppos.isKeyword(name) and apos.isKeyword(name))
   or
-  (ppos.isHashSplat() or ppos.isSynthHashSplat()) and
+  ppos.isHashSplat() and
   (apos.isHashSplat() or apos.isSynthHashSplat())
+  or
+  // no case for `apos.isSynthHashSplat() and ppos.isSynthHashSplat()`, since
+  // direct keyword matching is possible
+  ppos.isSynthHashSplat() and
+  apos.isHashSplat()
   or
   exists(int pos, boolean hasActualSplatParam, boolean hasActualSplatArg |
     (

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -1204,11 +1204,11 @@ private module ParameterNodes {
 
     final override predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
       c = callable and
-      exists(boolean hasActualSplat |
-        pos.isSynthSplat(hasActualSplat) and
-        if exists(TSynthSplatParameterShiftNode(c, _, _))
-        then hasActualSplat = true
-        else hasActualSplat = false
+      exists(int actualSplat | pos.isSynthSplat(actualSplat) |
+        exists(TSynthSplatParameterShiftNode(c, actualSplat, _))
+        or
+        not exists(TSynthSplatParameterShiftNode(c, _, _)) and
+        actualSplat = -1
       )
     }
 
@@ -1488,11 +1488,13 @@ module ArgumentNodes {
 
     override predicate sourceArgumentOf(CfgNodes::ExprNodes::CallCfgNode call, ArgumentPosition pos) {
       call = call_ and
-      exists(boolean hasActualSplat |
-        pos.isSynthSplat(hasActualSplat) and
-        if any(SynthSplatArgumentShiftNode shift).storeInto(this, _)
-        then hasActualSplat = true
-        else hasActualSplat = false
+      exists(int actualSplat | pos.isSynthSplat(actualSplat) |
+        any(SynthSplatArgumentShiftNode shift |
+          shift = TSynthSplatArgumentShiftNode(_, actualSplat, _)
+        ).storeInto(this, _)
+        or
+        not any(SynthSplatArgumentShiftNode shift).storeInto(this, _) and
+        actualSplat = -1
       )
     }
 

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -1191,8 +1191,7 @@ private module ParameterNodes {
     /** Holds if a read-step should be added into parameter `p`. */
     predicate readInto(ParameterNode p, ContentSet c) {
       exists(int n |
-        isParameterNode(p, callable, any(ParameterPosition pos | pos.isPositional(n))) and
-        not exists(int i | splatParameterAt(callable.asCfgScope(), i) and i < n)
+        isParameterNode(p, callable, any(ParameterPosition pos | pos.isPositional(n)))
       |
         c = getArrayContent(n)
         or
@@ -1465,7 +1464,6 @@ module ArgumentNodes {
     exists(int n, ArgumentPosition pos |
       arg.isArgumentOf(call, pos) and
       pos.isPositional(n) and
-      not exists(int i | splatArgumentAt(call, i) and i < n) and
       c = getArrayContent(n)
     )
   }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
@@ -586,7 +586,7 @@ module Content {
    *
    * we have an implicit splat argument containing `[1, 2, 3]`.
    */
-  class SplatContent extends ElementContent, TSplatContent {
+  deprecated class SplatContent extends Content, TSplatContent {
     private int i;
     private boolean shifted;
 
@@ -797,7 +797,6 @@ class ContentSet extends TContentSet {
   private Content getAnElementReadContent() {
     exists(Content::KnownElementContent c | this.isKnownOrUnknownElement(c) |
       result = c or
-      result = TSplatContent(c.getIndex().getInt(), _) or
       result = THashSplatContent(c.getIndex()) or
       result = TUnknownElementContent()
     )
@@ -805,12 +804,7 @@ class ContentSet extends TContentSet {
     exists(int lower, boolean includeUnknown |
       this = TElementLowerBoundContent(lower, includeUnknown)
     |
-      exists(int i |
-        result.(Content::KnownElementContent).getIndex().isInt(i) or
-        result = TSplatContent(i, _)
-      |
-        i >= lower
-      )
+      exists(int i | result.(Content::KnownElementContent).getIndex().isInt(i) | i >= lower)
       or
       includeUnknown = true and
       result = TUnknownElementContent()
@@ -820,9 +814,6 @@ class ContentSet extends TContentSet {
       this = TElementContentOfTypeContent(type, includeUnknown)
     |
       type = result.(Content::KnownElementContent).getIndex().getValueType()
-      or
-      type = "int" and
-      result instanceof Content::SplatContent
       or
       type = result.(Content::HashSplatContent).getKey().getValueType()
       or

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
@@ -629,7 +629,7 @@ module Content {
    *
    * we have an implicit hash-splat argument containing `{:a => 1, :b => 2, :c => 3}`.
    */
-  class HashSplatContent extends ElementContent, THashSplatContent {
+  deprecated class HashSplatContent extends Content, THashSplatContent {
     private ConstantValue::ConstantSymbolValue cv;
 
     HashSplatContent() { this = THashSplatContent(cv) }
@@ -797,7 +797,6 @@ class ContentSet extends TContentSet {
   private Content getAnElementReadContent() {
     exists(Content::KnownElementContent c | this.isKnownOrUnknownElement(c) |
       result = c or
-      result = THashSplatContent(c.getIndex()) or
       result = TUnknownElementContent()
     )
     or
@@ -814,8 +813,6 @@ class ContentSet extends TContentSet {
       this = TElementContentOfTypeContent(type, includeUnknown)
     |
       type = result.(Content::KnownElementContent).getIndex().getValueType()
-      or
-      type = result.(Content::HashSplatContent).getKey().getValueType()
       or
       includeUnknown = true and
       result = TUnknownElementContent()

--- a/ruby/ql/test/library-tests/dataflow/api-graphs/VerifyApiGraphExpectations.expected
+++ b/ruby/ql/test/library-tests/dataflow/api-graphs/VerifyApiGraphExpectations.expected
@@ -1,2 +1,2 @@
-failures
 testFailures
+failures

--- a/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
@@ -2356,6 +2356,16 @@ edges
 | array_flow.rb:1686:14:1686:14 | w | array_flow.rb:1690:10:1690:10 | w | provenance |  |
 | array_flow.rb:1686:18:1686:18 | a [element 2] | array_flow.rb:1686:11:1686:11 | z | provenance |  |
 | array_flow.rb:1686:18:1686:18 | a [element 3] | array_flow.rb:1686:14:1686:14 | w | provenance |  |
+| array_flow.rb:1693:10:1693:14 | *args [element 1] | array_flow.rb:1694:17:1694:20 | args [element 1] | provenance |  |
+| array_flow.rb:1694:16:1694:20 | * ... [element 1] | array_flow.rb:1694:5:1694:21 | call to [] [element 1] | provenance |  |
+| array_flow.rb:1694:17:1694:20 | args [element 1] | array_flow.rb:1694:16:1694:20 | * ... [element 1] | provenance |  |
+| array_flow.rb:1697:13:1697:13 | y | array_flow.rb:1699:10:1699:10 | y | provenance |  |
+| array_flow.rb:1704:5:1704:5 | a [element 1] | array_flow.rb:1705:11:1705:11 | a [element 1] | provenance |  |
+| array_flow.rb:1704:9:1704:31 | call to m141 [element 1] | array_flow.rb:1704:5:1704:5 | a [element 1] | provenance |  |
+| array_flow.rb:1704:17:1704:27 | call to source | array_flow.rb:1693:10:1693:14 | *args [element 1] | provenance |  |
+| array_flow.rb:1704:17:1704:27 | call to source | array_flow.rb:1704:9:1704:31 | call to m141 [element 1] | provenance |  |
+| array_flow.rb:1705:10:1705:11 | * ... [element 1] | array_flow.rb:1697:13:1697:13 | y | provenance |  |
+| array_flow.rb:1705:11:1705:11 | a [element 1] | array_flow.rb:1705:10:1705:11 | * ... [element 1] | provenance |  |
 nodes
 | array_flow.rb:2:5:2:5 | a [element 0] | semmle.label | a [element 0] |
 | array_flow.rb:2:9:2:20 | * ... [element 0] | semmle.label | * ... [element 0] |
@@ -4849,11 +4859,23 @@ nodes
 | array_flow.rb:1686:18:1686:18 | a [element 3] | semmle.label | a [element 3] |
 | array_flow.rb:1689:10:1689:10 | z | semmle.label | z |
 | array_flow.rb:1690:10:1690:10 | w | semmle.label | w |
+| array_flow.rb:1693:10:1693:14 | *args [element 1] | semmle.label | *args [element 1] |
+| array_flow.rb:1694:5:1694:21 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| array_flow.rb:1694:16:1694:20 | * ... [element 1] | semmle.label | * ... [element 1] |
+| array_flow.rb:1694:17:1694:20 | args [element 1] | semmle.label | args [element 1] |
+| array_flow.rb:1697:13:1697:13 | y | semmle.label | y |
+| array_flow.rb:1699:10:1699:10 | y | semmle.label | y |
+| array_flow.rb:1704:5:1704:5 | a [element 1] | semmle.label | a [element 1] |
+| array_flow.rb:1704:9:1704:31 | call to m141 [element 1] | semmle.label | call to m141 [element 1] |
+| array_flow.rb:1704:17:1704:27 | call to source | semmle.label | call to source |
+| array_flow.rb:1705:10:1705:11 | * ... [element 1] | semmle.label | * ... [element 1] |
+| array_flow.rb:1705:11:1705:11 | a [element 1] | semmle.label | a [element 1] |
 subpaths
 | array_flow.rb:251:9:251:9 | a [element 2] | array_flow.rb:251:30:251:30 | x | array_flow.rb:253:9:253:25 | call to [] [element 0] | array_flow.rb:251:9:254:7 | call to collect_concat [element] |
 | array_flow.rb:507:9:507:9 | a [element 3] | array_flow.rb:507:26:507:26 | x | array_flow.rb:509:9:509:9 | x | array_flow.rb:507:9:510:7 | call to filter_map [element] |
 | array_flow.rb:571:9:571:9 | a [element 2] | array_flow.rb:571:24:571:24 | x | array_flow.rb:573:9:573:25 | call to [] [element 0] | array_flow.rb:571:9:574:7 | call to flat_map [element] |
 | array_flow.rb:1678:9:1678:9 | a [element 2] | array_flow.rb:1678:19:1678:19 | x | array_flow.rb:1679:9:1679:9 | x | array_flow.rb:1678:9:1680:7 | call to map [element] |
+| array_flow.rb:1704:17:1704:27 | call to source | array_flow.rb:1693:10:1693:14 | *args [element 1] | array_flow.rb:1694:5:1694:21 | call to [] [element 1] | array_flow.rb:1704:9:1704:31 | call to m141 [element 1] |
 testFailures
 arrayLiteral
 | array_flow.rb:9:9:9:25 | call to [] |
@@ -5046,6 +5068,7 @@ arrayLiteral
 | array_flow.rb:1668:14:1668:41 | ...[...] |
 | array_flow.rb:1677:9:1677:29 | call to [] |
 | array_flow.rb:1685:9:1685:44 | call to [] |
+| array_flow.rb:1694:5:1694:21 | call to [] |
 #select
 | array_flow.rb:3:10:3:13 | ...[...] | array_flow.rb:2:10:2:20 | call to source | array_flow.rb:3:10:3:13 | ...[...] | $@ | array_flow.rb:2:10:2:20 | call to source | call to source |
 | array_flow.rb:5:10:5:13 | ...[...] | array_flow.rb:2:10:2:20 | call to source | array_flow.rb:5:10:5:13 | ...[...] | $@ | array_flow.rb:2:10:2:20 | call to source | call to source |
@@ -5749,3 +5772,4 @@ arrayLiteral
 | array_flow.rb:1681:10:1681:13 | ...[...] | array_flow.rb:1677:16:1677:28 | call to source | array_flow.rb:1681:10:1681:13 | ...[...] | $@ | array_flow.rb:1677:16:1677:28 | call to source | call to source |
 | array_flow.rb:1689:10:1689:10 | z | array_flow.rb:1685:16:1685:28 | call to source | array_flow.rb:1689:10:1689:10 | z | $@ | array_flow.rb:1685:16:1685:28 | call to source | call to source |
 | array_flow.rb:1690:10:1690:10 | w | array_flow.rb:1685:31:1685:43 | call to source | array_flow.rb:1690:10:1690:10 | w | $@ | array_flow.rb:1685:31:1685:43 | call to source | call to source |
+| array_flow.rb:1699:10:1699:10 | y | array_flow.rb:1704:17:1704:27 | call to source | array_flow.rb:1699:10:1699:10 | y | $@ | array_flow.rb:1704:17:1704:27 | call to source | call to source |

--- a/ruby/ql/test/library-tests/dataflow/array-flow/array_flow.rb
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/array_flow.rb
@@ -1689,3 +1689,18 @@ def m140
     sink z # $ hasValueFlow=140.1
     sink w # $ hasValueFlow=140.2
 end
+
+def m141(*args)
+    ::Array.[](*args)
+end
+
+def m142(x, y, z)
+    sink(x)
+    sink(y) # $ hasValueFlow=143
+    sink(z)
+end
+
+def m143
+    a = m141(0, source(143), 1)
+    m142(*a)
+end

--- a/ruby/ql/test/library-tests/dataflow/array-flow/type-tracking-array-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/type-tracking-array-flow.expected
@@ -64,4 +64,5 @@ testFailures
 | array_flow.rb:1626:19:1626:70 | # $ hasValueFlow=136.2 $ SPURIOUS hasValueFlow=136.1 | Missing result:hasValueFlow=136.1 |
 | array_flow.rb:1626:19:1626:70 | # $ hasValueFlow=136.2 $ SPURIOUS hasValueFlow=136.1 | Missing result:hasValueFlow=136.2 |
 | array_flow.rb:1627:19:1627:40 | # $ hasValueFlow=136.1 | Missing result:hasValueFlow=136.1 |
+| array_flow.rb:1699:13:1699:32 | # $ hasValueFlow=143 | Missing result:hasValueFlow=143 |
 failures

--- a/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.expected
+++ b/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.expected
@@ -78,14 +78,14 @@ edges
 | semantics.rb:60:5:60:5 | a | semantics.rb:66:14:66:15 | &... | provenance |  |
 | semantics.rb:60:9:60:18 | call to source | semantics.rb:60:5:60:5 | a | provenance |  |
 | semantics.rb:60:9:60:18 | call to source | semantics.rb:60:5:60:5 | a | provenance |  |
-| semantics.rb:61:10:61:15 | call to s10 [splat position 0] | semantics.rb:61:10:61:15 | call to s10 | provenance |  |
+| semantics.rb:61:10:61:15 | call to s10 [element 0] | semantics.rb:61:10:61:15 | call to s10 | provenance |  |
 | semantics.rb:61:14:61:14 | a | semantics.rb:61:10:61:15 | call to s10 | provenance |  |
 | semantics.rb:61:14:61:14 | a | semantics.rb:61:10:61:15 | call to s10 | provenance |  |
-| semantics.rb:61:14:61:14 | a | semantics.rb:61:10:61:15 | call to s10 [splat position 0] | provenance |  |
-| semantics.rb:62:10:62:18 | call to s10 [splat position 1] | semantics.rb:62:10:62:18 | call to s10 | provenance |  |
+| semantics.rb:61:14:61:14 | a | semantics.rb:61:10:61:15 | call to s10 [element 0] | provenance |  |
+| semantics.rb:62:10:62:18 | call to s10 [element 1] | semantics.rb:62:10:62:18 | call to s10 | provenance |  |
 | semantics.rb:62:17:62:17 | a | semantics.rb:62:10:62:18 | call to s10 | provenance |  |
 | semantics.rb:62:17:62:17 | a | semantics.rb:62:10:62:18 | call to s10 | provenance |  |
-| semantics.rb:62:17:62:17 | a | semantics.rb:62:10:62:18 | call to s10 [splat position 1] | provenance |  |
+| semantics.rb:62:17:62:17 | a | semantics.rb:62:10:62:18 | call to s10 [element 1] | provenance |  |
 | semantics.rb:63:19:63:19 | a | semantics.rb:63:10:63:20 | call to s10 | provenance |  |
 | semantics.rb:63:19:63:19 | a | semantics.rb:63:10:63:20 | call to s10 | provenance |  |
 | semantics.rb:64:27:64:27 | a | semantics.rb:64:10:64:28 | call to s10 | provenance |  |
@@ -192,18 +192,18 @@ edges
 | semantics.rb:126:5:126:5 | b | semantics.rb:129:17:129:17 | b | provenance |  |
 | semantics.rb:126:9:126:18 | call to source | semantics.rb:126:5:126:5 | b | provenance |  |
 | semantics.rb:126:9:126:18 | call to source | semantics.rb:126:5:126:5 | b | provenance |  |
-| semantics.rb:127:10:127:18 | call to s17 [splat position 0] | semantics.rb:127:10:127:18 | call to s17 | provenance |  |
-| semantics.rb:127:10:127:18 | call to s17 [splat position 1] | semantics.rb:127:10:127:18 | call to s17 | provenance |  |
-| semantics.rb:127:14:127:14 | a | semantics.rb:127:10:127:18 | call to s17 [splat position 0] | provenance |  |
-| semantics.rb:127:17:127:17 | b | semantics.rb:127:10:127:18 | call to s17 [splat position 1] | provenance |  |
-| semantics.rb:128:10:128:18 | call to s17 [splat position 0] | semantics.rb:128:10:128:21 | ...[...] | provenance |  |
-| semantics.rb:128:10:128:18 | call to s17 [splat position 0] | semantics.rb:128:10:128:21 | ...[...] | provenance |  |
-| semantics.rb:128:14:128:14 | a | semantics.rb:128:10:128:18 | call to s17 [splat position 0] | provenance |  |
-| semantics.rb:128:14:128:14 | a | semantics.rb:128:10:128:18 | call to s17 [splat position 0] | provenance |  |
-| semantics.rb:129:10:129:18 | call to s17 [splat position 1] | semantics.rb:129:10:129:21 | ...[...] | provenance |  |
-| semantics.rb:129:10:129:18 | call to s17 [splat position 1] | semantics.rb:129:10:129:21 | ...[...] | provenance |  |
-| semantics.rb:129:17:129:17 | b | semantics.rb:129:10:129:18 | call to s17 [splat position 1] | provenance |  |
-| semantics.rb:129:17:129:17 | b | semantics.rb:129:10:129:18 | call to s17 [splat position 1] | provenance |  |
+| semantics.rb:127:10:127:18 | call to s17 [element 0] | semantics.rb:127:10:127:18 | call to s17 | provenance |  |
+| semantics.rb:127:10:127:18 | call to s17 [element 1] | semantics.rb:127:10:127:18 | call to s17 | provenance |  |
+| semantics.rb:127:14:127:14 | a | semantics.rb:127:10:127:18 | call to s17 [element 0] | provenance |  |
+| semantics.rb:127:17:127:17 | b | semantics.rb:127:10:127:18 | call to s17 [element 1] | provenance |  |
+| semantics.rb:128:10:128:18 | call to s17 [element 0] | semantics.rb:128:10:128:21 | ...[...] | provenance |  |
+| semantics.rb:128:10:128:18 | call to s17 [element 0] | semantics.rb:128:10:128:21 | ...[...] | provenance |  |
+| semantics.rb:128:14:128:14 | a | semantics.rb:128:10:128:18 | call to s17 [element 0] | provenance |  |
+| semantics.rb:128:14:128:14 | a | semantics.rb:128:10:128:18 | call to s17 [element 0] | provenance |  |
+| semantics.rb:129:10:129:18 | call to s17 [element 1] | semantics.rb:129:10:129:21 | ...[...] | provenance |  |
+| semantics.rb:129:10:129:18 | call to s17 [element 1] | semantics.rb:129:10:129:21 | ...[...] | provenance |  |
+| semantics.rb:129:17:129:17 | b | semantics.rb:129:10:129:18 | call to s17 [element 1] | provenance |  |
+| semantics.rb:129:17:129:17 | b | semantics.rb:129:10:129:18 | call to s17 [element 1] | provenance |  |
 | semantics.rb:133:5:133:5 | a | semantics.rb:135:12:135:12 | a | provenance |  |
 | semantics.rb:133:5:133:5 | a | semantics.rb:135:12:135:12 | a | provenance |  |
 | semantics.rb:133:5:133:5 | a | semantics.rb:137:14:137:14 | a | provenance |  |
@@ -1191,12 +1191,12 @@ nodes
 | semantics.rb:60:9:60:18 | call to source | semmle.label | call to source |
 | semantics.rb:61:10:61:15 | call to s10 | semmle.label | call to s10 |
 | semantics.rb:61:10:61:15 | call to s10 | semmle.label | call to s10 |
-| semantics.rb:61:10:61:15 | call to s10 [splat position 0] | semmle.label | call to s10 [splat position 0] |
+| semantics.rb:61:10:61:15 | call to s10 [element 0] | semmle.label | call to s10 [element 0] |
 | semantics.rb:61:14:61:14 | a | semmle.label | a |
 | semantics.rb:61:14:61:14 | a | semmle.label | a |
 | semantics.rb:62:10:62:18 | call to s10 | semmle.label | call to s10 |
 | semantics.rb:62:10:62:18 | call to s10 | semmle.label | call to s10 |
-| semantics.rb:62:10:62:18 | call to s10 [splat position 1] | semmle.label | call to s10 [splat position 1] |
+| semantics.rb:62:10:62:18 | call to s10 [element 1] | semmle.label | call to s10 [element 1] |
 | semantics.rb:62:17:62:17 | a | semmle.label | a |
 | semantics.rb:62:17:62:17 | a | semmle.label | a |
 | semantics.rb:63:10:63:20 | call to s10 | semmle.label | call to s10 |
@@ -1322,18 +1322,18 @@ nodes
 | semantics.rb:126:9:126:18 | call to source | semmle.label | call to source |
 | semantics.rb:126:9:126:18 | call to source | semmle.label | call to source |
 | semantics.rb:127:10:127:18 | call to s17 | semmle.label | call to s17 |
-| semantics.rb:127:10:127:18 | call to s17 [splat position 0] | semmle.label | call to s17 [splat position 0] |
-| semantics.rb:127:10:127:18 | call to s17 [splat position 1] | semmle.label | call to s17 [splat position 1] |
+| semantics.rb:127:10:127:18 | call to s17 [element 0] | semmle.label | call to s17 [element 0] |
+| semantics.rb:127:10:127:18 | call to s17 [element 1] | semmle.label | call to s17 [element 1] |
 | semantics.rb:127:14:127:14 | a | semmle.label | a |
 | semantics.rb:127:17:127:17 | b | semmle.label | b |
-| semantics.rb:128:10:128:18 | call to s17 [splat position 0] | semmle.label | call to s17 [splat position 0] |
-| semantics.rb:128:10:128:18 | call to s17 [splat position 0] | semmle.label | call to s17 [splat position 0] |
+| semantics.rb:128:10:128:18 | call to s17 [element 0] | semmle.label | call to s17 [element 0] |
+| semantics.rb:128:10:128:18 | call to s17 [element 0] | semmle.label | call to s17 [element 0] |
 | semantics.rb:128:10:128:21 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:128:10:128:21 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:128:14:128:14 | a | semmle.label | a |
 | semantics.rb:128:14:128:14 | a | semmle.label | a |
-| semantics.rb:129:10:129:18 | call to s17 [splat position 1] | semmle.label | call to s17 [splat position 1] |
-| semantics.rb:129:10:129:18 | call to s17 [splat position 1] | semmle.label | call to s17 [splat position 1] |
+| semantics.rb:129:10:129:18 | call to s17 [element 1] | semmle.label | call to s17 [element 1] |
+| semantics.rb:129:10:129:18 | call to s17 [element 1] | semmle.label | call to s17 [element 1] |
 | semantics.rb:129:10:129:21 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:129:10:129:21 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:129:17:129:17 | b | semmle.label | b |

--- a/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.expected
+++ b/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.expected
@@ -144,14 +144,14 @@ edges
 | semantics.rb:108:5:108:5 | b | semantics.rb:110:27:110:27 | b | provenance |  |
 | semantics.rb:108:9:108:18 | call to source | semantics.rb:108:5:108:5 | b | provenance |  |
 | semantics.rb:108:9:108:18 | call to source | semantics.rb:108:5:108:5 | b | provenance |  |
-| semantics.rb:109:10:109:28 | call to s15 [hash-splat position :foo] | semantics.rb:109:10:109:34 | ...[...] | provenance |  |
-| semantics.rb:109:10:109:28 | call to s15 [hash-splat position :foo] | semantics.rb:109:10:109:34 | ...[...] | provenance |  |
-| semantics.rb:109:19:109:19 | a | semantics.rb:109:10:109:28 | call to s15 [hash-splat position :foo] | provenance |  |
-| semantics.rb:109:19:109:19 | a | semantics.rb:109:10:109:28 | call to s15 [hash-splat position :foo] | provenance |  |
-| semantics.rb:110:10:110:28 | call to s15 [hash-splat position :bar] | semantics.rb:110:10:110:34 | ...[...] | provenance |  |
-| semantics.rb:110:10:110:28 | call to s15 [hash-splat position :bar] | semantics.rb:110:10:110:34 | ...[...] | provenance |  |
-| semantics.rb:110:27:110:27 | b | semantics.rb:110:10:110:28 | call to s15 [hash-splat position :bar] | provenance |  |
-| semantics.rb:110:27:110:27 | b | semantics.rb:110:10:110:28 | call to s15 [hash-splat position :bar] | provenance |  |
+| semantics.rb:109:10:109:28 | call to s15 [element :foo] | semantics.rb:109:10:109:34 | ...[...] | provenance |  |
+| semantics.rb:109:10:109:28 | call to s15 [element :foo] | semantics.rb:109:10:109:34 | ...[...] | provenance |  |
+| semantics.rb:109:19:109:19 | a | semantics.rb:109:10:109:28 | call to s15 [element :foo] | provenance |  |
+| semantics.rb:109:19:109:19 | a | semantics.rb:109:10:109:28 | call to s15 [element :foo] | provenance |  |
+| semantics.rb:110:10:110:28 | call to s15 [element :bar] | semantics.rb:110:10:110:34 | ...[...] | provenance |  |
+| semantics.rb:110:10:110:28 | call to s15 [element :bar] | semantics.rb:110:10:110:34 | ...[...] | provenance |  |
+| semantics.rb:110:27:110:27 | b | semantics.rb:110:10:110:28 | call to s15 [element :bar] | provenance |  |
+| semantics.rb:110:27:110:27 | b | semantics.rb:110:10:110:28 | call to s15 [element :bar] | provenance |  |
 | semantics.rb:114:5:114:5 | a | semantics.rb:116:14:116:14 | a | provenance |  |
 | semantics.rb:114:5:114:5 | a | semantics.rb:116:14:116:14 | a | provenance |  |
 | semantics.rb:114:5:114:5 | a | semantics.rb:119:17:119:17 | a | provenance |  |
@@ -1269,14 +1269,14 @@ nodes
 | semantics.rb:108:5:108:5 | b | semmle.label | b |
 | semantics.rb:108:9:108:18 | call to source | semmle.label | call to source |
 | semantics.rb:108:9:108:18 | call to source | semmle.label | call to source |
-| semantics.rb:109:10:109:28 | call to s15 [hash-splat position :foo] | semmle.label | call to s15 [hash-splat position :foo] |
-| semantics.rb:109:10:109:28 | call to s15 [hash-splat position :foo] | semmle.label | call to s15 [hash-splat position :foo] |
+| semantics.rb:109:10:109:28 | call to s15 [element :foo] | semmle.label | call to s15 [element :foo] |
+| semantics.rb:109:10:109:28 | call to s15 [element :foo] | semmle.label | call to s15 [element :foo] |
 | semantics.rb:109:10:109:34 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:109:10:109:34 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:109:19:109:19 | a | semmle.label | a |
 | semantics.rb:109:19:109:19 | a | semmle.label | a |
-| semantics.rb:110:10:110:28 | call to s15 [hash-splat position :bar] | semmle.label | call to s15 [hash-splat position :bar] |
-| semantics.rb:110:10:110:28 | call to s15 [hash-splat position :bar] | semmle.label | call to s15 [hash-splat position :bar] |
+| semantics.rb:110:10:110:28 | call to s15 [element :bar] | semmle.label | call to s15 [element :bar] |
+| semantics.rb:110:10:110:28 | call to s15 [element :bar] | semmle.label | call to s15 [element :bar] |
 | semantics.rb:110:10:110:34 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:110:10:110:34 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:110:27:110:27 | b | semmle.label | b |

--- a/ruby/ql/test/library-tests/dataflow/params/TypeTracker.expected
+++ b/ruby/ql/test/library-tests/dataflow/params/TypeTracker.expected
@@ -56,12 +56,43 @@ track
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:181:28:181:29 | p2 |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:200:9:200:9 | x |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:26:5:26:11 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:27:5:27:22 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:28:5:28:22 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:29:5:29:22 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:65:5:65:13 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:70:5:70:10 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:74:5:74:10 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:75:5:75:10 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:84:5:84:10 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:85:5:85:10 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:86:5:86:10 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:87:5:87:10 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:88:5:88:10 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:89:5:89:10 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:99:5:99:10 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:102:5:102:10 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:108:1:112:3 | synthetic splat parameter |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:108:40:108:41 | *b |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:109:5:109:10 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:110:5:110:13 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:111:5:111:10 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:133:14:133:18 | *args |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:134:5:134:16 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:200:1:205:3 | synthetic splat parameter |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 or unknown | params_flow.rb:64:16:64:17 | *x |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 or unknown | params_flow.rb:140:5:140:15 | [post] ...[...] |
@@ -74,11 +105,26 @@ track
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 or unknown | params_flow.rb:182:5:182:20 | call to insert |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 | params_flow.rb:108:1:112:3 | synthetic splat parameter |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 | params_flow.rb:133:14:133:18 | *args |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 | params_flow.rb:140:5:140:38 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 | params_flow.rb:154:5:154:20 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 | params_flow.rb:167:21:167:28 | *posargs |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 | params_flow.rb:168:5:168:36 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 | params_flow.rb:181:1:183:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 | params_flow.rb:182:5:182:20 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 2 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 2 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 2 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 2 | params_flow.rb:133:14:133:18 | *args |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 3 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 3 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 4 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 4 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 5 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element :p1 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element :p1 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element :p1 | params_flow.rb:25:17:25:24 | **kwargs |
@@ -99,69 +145,6 @@ track
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:153:1:155:3 | synthetic hash-splat parameter |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content hash-splat position :p3 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content hash-splat position :p3 | params_flow.rb:25:17:25:24 | **kwargs |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:26:5:26:11 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:27:5:27:22 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:28:5:28:22 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:29:5:29:22 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:65:5:65:13 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:70:5:70:10 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:74:5:74:10 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:75:5:75:10 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:84:5:84:10 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:85:5:85:10 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:86:5:86:10 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:87:5:87:10 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:88:5:88:10 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:89:5:89:10 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:99:5:99:10 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:102:5:102:10 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:108:1:112:3 | synthetic splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:109:5:109:10 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:110:5:110:13 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:111:5:111:10 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 0 | params_flow.rb:134:5:134:16 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 1 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 1 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 1 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 1 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 1 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 1 | params_flow.rb:108:1:112:3 | synthetic splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 1 | params_flow.rb:140:5:140:38 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 1 | params_flow.rb:154:5:154:20 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 1 | params_flow.rb:167:21:167:28 | *posargs |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 1 | params_flow.rb:168:5:168:36 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 1 | params_flow.rb:181:1:183:3 | synthetic splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 1 | params_flow.rb:182:5:182:20 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:9:1:12:3 | synthetic splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:49:1:53:3 | synthetic splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:98:1:103:3 | synthetic splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 2 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 2 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 2 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 2 (shifted) | params_flow.rb:83:1:91:3 | synthetic splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 2 (shifted) | params_flow.rb:98:1:103:3 | synthetic splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 3 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 3 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 3 (shifted) | params_flow.rb:83:1:91:3 | synthetic splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 4 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 4 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 4 (shifted) | params_flow.rb:83:1:91:3 | synthetic splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content splat position 5 (shifted) | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:14:12:14:19 | call to taint |
@@ -249,30 +232,41 @@ track
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content attribute [] | params_flow.rb:117:1:117:1 | [post] x |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element | params_flow.rb:117:1:117:1 | [post] x |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element | params_flow.rb:118:12:118:13 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:14:1:14:30 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:43:8:43:18 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:43:8:43:18 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:44:1:44:28 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:44:23:44:27 | * ... |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:46:8:46:29 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:46:8:46:29 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:47:12:47:16 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:55:1:55:29 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:57:8:57:18 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:57:8:57:18 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:58:1:58:25 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:58:20:58:24 | * ... |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:60:8:60:29 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:60:8:60:29 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:61:9:61:13 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:78:1:78:63 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:80:8:80:51 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:80:8:80:51 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:81:1:81:37 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:81:21:81:25 | * ... |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:93:8:93:51 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:93:8:93:51 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:94:1:94:48 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:94:32:94:36 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:96:1:96:88 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:96:32:96:65 | * ... |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:96:33:96:65 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:96:33:96:65 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:105:1:105:49 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:105:26:105:48 | * ... |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:105:27:105:48 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:105:27:105:48 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:106:1:106:46 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:114:1:114:67 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:128:10:128:31 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:128:10:128:31 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:128:34:128:60 | call to [] |
@@ -287,24 +281,36 @@ track
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:195:12:198:1 | synthetic hash-splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:207:5:207:13 | * ... |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:67:12:67:16 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:14:1:14:30 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:44:1:44:28 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:46:8:46:29 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:46:8:46:29 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:47:12:47:16 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:55:1:55:29 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:58:1:58:25 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:60:8:60:29 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:60:8:60:29 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:61:9:61:13 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:78:1:78:63 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:80:8:80:51 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:80:8:80:51 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:81:1:81:37 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:81:21:81:25 | * ... |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:93:8:93:51 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:93:8:93:51 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:94:1:94:48 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:94:32:94:36 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:96:1:96:88 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:96:32:96:65 | * ... |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:96:33:96:65 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:96:33:96:65 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:105:1:105:49 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:105:26:105:48 | * ... |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:105:27:105:48 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:105:27:105:48 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:106:1:106:46 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:114:1:114:67 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:117:1:117:15 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:128:10:128:31 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:128:10:128:31 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:128:46:128:59 | call to [] |
@@ -318,27 +324,44 @@ track
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:171:11:171:27 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:171:11:171:27 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:173:17:173:24 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:178:1:178:30 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:185:8:185:24 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:185:8:185:24 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:187:20:187:24 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:192:1:192:33 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:78:1:78:63 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:80:8:80:51 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:80:8:80:51 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:81:1:81:37 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:81:21:81:25 | * ... |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:93:8:93:51 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:93:8:93:51 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:94:1:94:48 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:94:32:94:36 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:96:1:96:88 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:96:32:96:65 | * ... |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:96:33:96:65 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:96:33:96:65 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:105:1:105:49 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:106:1:106:46 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:137:10:137:43 | * ... |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:137:11:137:43 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:137:11:137:43 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 | params_flow.rb:78:1:78:63 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 | params_flow.rb:80:8:80:51 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 | params_flow.rb:80:8:80:51 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 | params_flow.rb:81:1:81:37 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 | params_flow.rb:81:21:81:25 | * ... |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 | params_flow.rb:93:8:93:51 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 | params_flow.rb:93:8:93:51 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 | params_flow.rb:94:1:94:48 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 | params_flow.rb:94:32:94:36 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 | params_flow.rb:96:1:96:88 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 4 | params_flow.rb:78:1:78:63 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 4 | params_flow.rb:81:1:81:37 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 4 | params_flow.rb:94:1:94:48 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 4 | params_flow.rb:96:1:96:88 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 5 | params_flow.rb:94:1:94:48 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:37:8:37:44 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:37:8:37:44 | synthetic hash-splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:38:8:38:13 | ** ... |
@@ -371,53 +394,13 @@ track
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:150:1:150:42 | synthetic hash-splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:164:1:164:40 | synthetic hash-splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content hash-splat position :p3 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 0 | params_flow.rb:14:1:14:30 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 0 | params_flow.rb:44:1:44:28 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 0 | params_flow.rb:55:1:55:29 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 0 | params_flow.rb:58:1:58:25 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 0 | params_flow.rb:78:1:78:63 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 0 | params_flow.rb:81:1:81:37 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 0 | params_flow.rb:94:1:94:48 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 0 | params_flow.rb:96:1:96:88 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 0 | params_flow.rb:105:1:105:49 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 0 | params_flow.rb:106:1:106:46 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 0 | params_flow.rb:114:1:114:67 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 1 | params_flow.rb:14:1:14:30 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 1 | params_flow.rb:55:1:55:29 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 1 | params_flow.rb:78:1:78:63 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 1 | params_flow.rb:94:1:94:48 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 1 | params_flow.rb:96:1:96:88 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 1 | params_flow.rb:106:1:106:46 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 1 | params_flow.rb:114:1:114:67 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 1 | params_flow.rb:117:1:117:15 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 1 | params_flow.rb:178:1:178:30 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 1 | params_flow.rb:192:1:192:33 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:44:1:44:28 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:58:1:58:25 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:81:1:81:37 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:105:1:105:49 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 2 | params_flow.rb:78:1:78:63 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 2 | params_flow.rb:106:1:106:46 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:81:1:81:37 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:94:1:94:48 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:96:1:96:88 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:105:1:105:49 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 3 | params_flow.rb:78:1:78:63 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 3 (shifted) | params_flow.rb:81:1:81:37 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 3 (shifted) | params_flow.rb:94:1:94:48 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 3 (shifted) | params_flow.rb:96:1:96:88 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 4 | params_flow.rb:78:1:78:63 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 4 (shifted) | params_flow.rb:81:1:81:37 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 4 (shifted) | params_flow.rb:94:1:94:48 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 4 (shifted) | params_flow.rb:96:1:96:88 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content splat position 5 (shifted) | params_flow.rb:94:1:94:48 | synthetic splat argument |
 | params_flow.rb:5:1:7:3 | &block | type tracker without call steps | params_flow.rb:5:1:7:3 | &block |
 | params_flow.rb:5:1:7:3 | self in sink | type tracker without call steps | params_flow.rb:5:1:7:3 | self in sink |
 | params_flow.rb:5:1:7:3 | sink | type tracker without call steps | params_flow.rb:5:1:7:3 | sink |
 | params_flow.rb:5:1:7:3 | synthetic splat parameter | type tracker without call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:5:10:5:10 | x | type tracker without call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:5:10:5:10 | x | type tracker without call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:5:10:5:10 | x | type tracker without call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:5:10:5:10 | x | type tracker without call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:6:5:6:10 | call to puts |
 | params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:10:5:10:11 | call to sink |
 | params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:11:5:11:11 | call to sink |
@@ -511,100 +494,79 @@ track
 | params_flow.rb:9:1:12:3 | self in positional | type tracker without call steps | params_flow.rb:9:1:12:3 | self in positional |
 | params_flow.rb:9:1:12:3 | synthetic splat parameter | type tracker without call steps | params_flow.rb:9:1:12:3 | synthetic splat parameter |
 | params_flow.rb:9:16:9:17 | p1 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:9:16:9:17 | p1 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:9:16:9:17 | p1 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:9:16:9:17 | p1 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:9:16:9:17 | p1 | type tracker without call steps | params_flow.rb:9:16:9:17 | p1 |
 | params_flow.rb:9:16:9:17 | p1 | type tracker without call steps | params_flow.rb:9:16:9:17 | p1 |
-| params_flow.rb:9:16:9:17 | p1 | type tracker without call steps with content splat position 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
+| params_flow.rb:9:16:9:17 | p1 | type tracker without call steps with content element 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
 | params_flow.rb:9:20:9:21 | p2 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:9:20:9:21 | p2 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:9:20:9:21 | p2 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:9:20:9:21 | p2 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:9:20:9:21 | p2 | type tracker without call steps | params_flow.rb:9:20:9:21 | p2 |
 | params_flow.rb:9:20:9:21 | p2 | type tracker without call steps | params_flow.rb:9:20:9:21 | p2 |
-| params_flow.rb:9:20:9:21 | p2 | type tracker without call steps with content splat position 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
+| params_flow.rb:9:20:9:21 | p2 | type tracker without call steps with content element 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
 | params_flow.rb:10:5:10:11 | call to sink | type tracker without call steps | params_flow.rb:10:5:10:11 | call to sink |
-| params_flow.rb:10:5:10:11 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:10:5:10:11 | synthetic splat argument | type tracker without call steps | params_flow.rb:10:5:10:11 | synthetic splat argument |
 | params_flow.rb:11:5:11:11 | call to sink | type tracker without call steps | params_flow.rb:11:5:11:11 | call to sink |
 | params_flow.rb:11:5:11:11 | call to sink | type tracker without call steps | params_flow.rb:14:1:14:30 | call to positional |
 | params_flow.rb:11:5:11:11 | call to sink | type tracker without call steps | params_flow.rb:44:1:44:28 | call to positional |
 | params_flow.rb:11:5:11:11 | call to sink | type tracker without call steps | params_flow.rb:47:1:47:17 | call to positional |
 | params_flow.rb:11:5:11:11 | call to sink | type tracker without call steps | params_flow.rb:118:1:118:14 | call to positional |
-| params_flow.rb:11:5:11:11 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:11:5:11:11 | synthetic splat argument | type tracker without call steps | params_flow.rb:11:5:11:11 | synthetic splat argument |
 | params_flow.rb:14:1:14:30 | call to positional | type tracker without call steps | params_flow.rb:14:1:14:30 | call to positional |
-| params_flow.rb:14:1:14:30 | synthetic splat argument | type tracker with call steps | params_flow.rb:9:1:12:3 | synthetic splat parameter |
 | params_flow.rb:14:1:14:30 | synthetic splat argument | type tracker without call steps | params_flow.rb:14:1:14:30 | synthetic splat argument |
 | params_flow.rb:14:12:14:19 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:14:12:14:19 | call to taint | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
-| params_flow.rb:14:12:14:19 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:14:12:14:19 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:14:12:14:19 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
-| params_flow.rb:14:12:14:19 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
+| params_flow.rb:14:12:14:19 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:14:12:14:19 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
 | params_flow.rb:14:12:14:19 | call to taint | type tracker without call steps | params_flow.rb:14:12:14:19 | call to taint |
-| params_flow.rb:14:12:14:19 | call to taint | type tracker without call steps with content splat position 0 | params_flow.rb:14:1:14:30 | synthetic splat argument |
-| params_flow.rb:14:12:14:19 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:14:12:14:19 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:14:1:14:30 | synthetic splat argument |
 | params_flow.rb:14:12:14:19 | synthetic splat argument | type tracker without call steps | params_flow.rb:14:12:14:19 | synthetic splat argument |
 | params_flow.rb:14:18:14:18 | 1 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:14:18:14:18 | 1 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:14:18:14:18 | 1 | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
-| params_flow.rb:14:18:14:18 | 1 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:14:18:14:18 | 1 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:14:18:14:18 | 1 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:14:18:14:18 | 1 | type tracker with call steps with content splat position 0 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
-| params_flow.rb:14:18:14:18 | 1 | type tracker with call steps with content splat position 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
+| params_flow.rb:14:18:14:18 | 1 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:14:18:14:18 | 1 | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
 | params_flow.rb:14:18:14:18 | 1 | type tracker without call steps | params_flow.rb:14:12:14:19 | call to taint |
 | params_flow.rb:14:18:14:18 | 1 | type tracker without call steps | params_flow.rb:14:18:14:18 | 1 |
-| params_flow.rb:14:18:14:18 | 1 | type tracker without call steps with content splat position 0 | params_flow.rb:14:1:14:30 | synthetic splat argument |
-| params_flow.rb:14:18:14:18 | 1 | type tracker without call steps with content splat position 0 | params_flow.rb:14:12:14:19 | synthetic splat argument |
+| params_flow.rb:14:18:14:18 | 1 | type tracker without call steps with content element 0 | params_flow.rb:14:1:14:30 | synthetic splat argument |
+| params_flow.rb:14:18:14:18 | 1 | type tracker without call steps with content element 0 | params_flow.rb:14:12:14:19 | synthetic splat argument |
 | params_flow.rb:14:22:14:29 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:14:22:14:29 | call to taint | type tracker with call steps | params_flow.rb:9:20:9:21 | p2 |
-| params_flow.rb:14:22:14:29 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:14:22:14:29 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:14:22:14:29 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
-| params_flow.rb:14:22:14:29 | call to taint | type tracker with call steps with content splat position 1 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:14:22:14:29 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:14:22:14:29 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
 | params_flow.rb:14:22:14:29 | call to taint | type tracker without call steps | params_flow.rb:14:22:14:29 | call to taint |
-| params_flow.rb:14:22:14:29 | call to taint | type tracker without call steps with content splat position 1 | params_flow.rb:14:1:14:30 | synthetic splat argument |
-| params_flow.rb:14:22:14:29 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:14:22:14:29 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:14:1:14:30 | synthetic splat argument |
 | params_flow.rb:14:22:14:29 | synthetic splat argument | type tracker without call steps | params_flow.rb:14:22:14:29 | synthetic splat argument |
 | params_flow.rb:14:28:14:28 | 2 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:14:28:14:28 | 2 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:14:28:14:28 | 2 | type tracker with call steps | params_flow.rb:9:20:9:21 | p2 |
-| params_flow.rb:14:28:14:28 | 2 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:14:28:14:28 | 2 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:14:28:14:28 | 2 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:14:28:14:28 | 2 | type tracker with call steps with content splat position 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
-| params_flow.rb:14:28:14:28 | 2 | type tracker with call steps with content splat position 1 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:14:28:14:28 | 2 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:14:28:14:28 | 2 | type tracker with call steps with content element 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
 | params_flow.rb:14:28:14:28 | 2 | type tracker without call steps | params_flow.rb:14:22:14:29 | call to taint |
 | params_flow.rb:14:28:14:28 | 2 | type tracker without call steps | params_flow.rb:14:28:14:28 | 2 |
-| params_flow.rb:14:28:14:28 | 2 | type tracker without call steps with content splat position 0 | params_flow.rb:14:22:14:29 | synthetic splat argument |
-| params_flow.rb:14:28:14:28 | 2 | type tracker without call steps with content splat position 1 | params_flow.rb:14:1:14:30 | synthetic splat argument |
+| params_flow.rb:14:28:14:28 | 2 | type tracker without call steps with content element 0 | params_flow.rb:14:22:14:29 | synthetic splat argument |
+| params_flow.rb:14:28:14:28 | 2 | type tracker without call steps with content element 1 | params_flow.rb:14:1:14:30 | synthetic splat argument |
 | params_flow.rb:16:1:19:3 | &block | type tracker without call steps | params_flow.rb:16:1:19:3 | &block |
 | params_flow.rb:16:1:19:3 | keyword | type tracker without call steps | params_flow.rb:16:1:19:3 | keyword |
 | params_flow.rb:16:1:19:3 | self in keyword | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
 | params_flow.rb:16:1:19:3 | self in keyword | type tracker without call steps | params_flow.rb:16:1:19:3 | self in keyword |
 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter | type tracker without call steps | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:16:13:16:14 | p1 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:16:13:16:14 | p1 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:16:13:16:14 | p1 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:16:13:16:14 | p1 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:16:13:16:14 | p1 | type tracker without call steps | params_flow.rb:16:13:16:14 | p1 |
 | params_flow.rb:16:13:16:14 | p1 | type tracker without call steps | params_flow.rb:16:13:16:14 | p1 |
-| params_flow.rb:16:13:16:14 | p1 | type tracker without call steps with content splat position 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
+| params_flow.rb:16:13:16:14 | p1 | type tracker without call steps with content element 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
 | params_flow.rb:16:18:16:19 | p2 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:16:18:16:19 | p2 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:16:18:16:19 | p2 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:16:18:16:19 | p2 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:16:18:16:19 | p2 | type tracker without call steps | params_flow.rb:16:18:16:19 | p2 |
 | params_flow.rb:16:18:16:19 | p2 | type tracker without call steps | params_flow.rb:16:18:16:19 | p2 |
-| params_flow.rb:16:18:16:19 | p2 | type tracker without call steps with content splat position 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
+| params_flow.rb:16:18:16:19 | p2 | type tracker without call steps with content element 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:17:5:17:11 | call to sink | type tracker without call steps | params_flow.rb:17:5:17:11 | call to sink |
-| params_flow.rb:17:5:17:11 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:17:5:17:11 | synthetic splat argument | type tracker without call steps | params_flow.rb:17:5:17:11 | synthetic splat argument |
 | params_flow.rb:18:5:18:11 | call to sink | type tracker without call steps | params_flow.rb:18:5:18:11 | call to sink |
 | params_flow.rb:18:5:18:11 | call to sink | type tracker without call steps | params_flow.rb:21:1:21:35 | call to keyword |
 | params_flow.rb:18:5:18:11 | call to sink | type tracker without call steps | params_flow.rb:22:1:22:35 | call to keyword |
 | params_flow.rb:18:5:18:11 | call to sink | type tracker without call steps | params_flow.rb:23:1:23:41 | call to keyword |
 | params_flow.rb:18:5:18:11 | call to sink | type tracker without call steps | params_flow.rb:41:1:41:30 | call to keyword |
-| params_flow.rb:18:5:18:11 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:18:5:18:11 | synthetic splat argument | type tracker without call steps | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:21:1:21:35 | call to keyword | type tracker without call steps | params_flow.rb:21:1:21:35 | call to keyword |
 | params_flow.rb:21:1:21:35 | synthetic hash-splat argument | type tracker with call steps | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
@@ -613,50 +575,42 @@ track
 | params_flow.rb:21:9:21:20 | Pair | type tracker without call steps | params_flow.rb:21:9:21:20 | Pair |
 | params_flow.rb:21:13:21:20 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:21:13:21:20 | call to taint | type tracker with call steps | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:21:13:21:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:21:13:21:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
 | params_flow.rb:21:13:21:20 | call to taint | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
-| params_flow.rb:21:13:21:20 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:21:13:21:20 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:21:13:21:20 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
 | params_flow.rb:21:13:21:20 | call to taint | type tracker without call steps | params_flow.rb:21:13:21:20 | call to taint |
 | params_flow.rb:21:13:21:20 | call to taint | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:21:1:21:35 | synthetic hash-splat argument |
-| params_flow.rb:21:13:21:20 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:21:13:21:20 | synthetic splat argument | type tracker without call steps | params_flow.rb:21:13:21:20 | synthetic splat argument |
 | params_flow.rb:21:19:21:19 | 3 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:21:19:21:19 | 3 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:21:19:21:19 | 3 | type tracker with call steps | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:21:19:21:19 | 3 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:21:19:21:19 | 3 | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
 | params_flow.rb:21:19:21:19 | 3 | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
-| params_flow.rb:21:19:21:19 | 3 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:21:19:21:19 | 3 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:21:19:21:19 | 3 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:21:19:21:19 | 3 | type tracker with call steps with content splat position 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
 | params_flow.rb:21:19:21:19 | 3 | type tracker without call steps | params_flow.rb:21:13:21:20 | call to taint |
 | params_flow.rb:21:19:21:19 | 3 | type tracker without call steps | params_flow.rb:21:19:21:19 | 3 |
+| params_flow.rb:21:19:21:19 | 3 | type tracker without call steps with content element 0 | params_flow.rb:21:13:21:20 | synthetic splat argument |
 | params_flow.rb:21:19:21:19 | 3 | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:21:1:21:35 | synthetic hash-splat argument |
-| params_flow.rb:21:19:21:19 | 3 | type tracker without call steps with content splat position 0 | params_flow.rb:21:13:21:20 | synthetic splat argument |
 | params_flow.rb:21:23:21:24 | :p2 | type tracker without call steps | params_flow.rb:21:23:21:24 | :p2 |
 | params_flow.rb:21:23:21:34 | Pair | type tracker without call steps | params_flow.rb:21:23:21:34 | Pair |
 | params_flow.rb:21:27:21:34 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:21:27:21:34 | call to taint | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:21:27:21:34 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:21:27:21:34 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:21:27:21:34 | call to taint | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
-| params_flow.rb:21:27:21:34 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:21:27:21:34 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:21:27:21:34 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:21:27:21:34 | call to taint | type tracker without call steps | params_flow.rb:21:27:21:34 | call to taint |
 | params_flow.rb:21:27:21:34 | call to taint | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:21:1:21:35 | synthetic hash-splat argument |
-| params_flow.rb:21:27:21:34 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:21:27:21:34 | synthetic splat argument | type tracker without call steps | params_flow.rb:21:27:21:34 | synthetic splat argument |
 | params_flow.rb:21:33:21:33 | 4 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:21:33:21:33 | 4 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:21:33:21:33 | 4 | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:21:33:21:33 | 4 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:21:33:21:33 | 4 | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:21:33:21:33 | 4 | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
-| params_flow.rb:21:33:21:33 | 4 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:21:33:21:33 | 4 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:21:33:21:33 | 4 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:21:33:21:33 | 4 | type tracker with call steps with content splat position 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:21:33:21:33 | 4 | type tracker without call steps | params_flow.rb:21:27:21:34 | call to taint |
 | params_flow.rb:21:33:21:33 | 4 | type tracker without call steps | params_flow.rb:21:33:21:33 | 4 |
+| params_flow.rb:21:33:21:33 | 4 | type tracker without call steps with content element 0 | params_flow.rb:21:27:21:34 | synthetic splat argument |
 | params_flow.rb:21:33:21:33 | 4 | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:21:1:21:35 | synthetic hash-splat argument |
-| params_flow.rb:21:33:21:33 | 4 | type tracker without call steps with content splat position 0 | params_flow.rb:21:27:21:34 | synthetic splat argument |
 | params_flow.rb:22:1:22:35 | call to keyword | type tracker without call steps | params_flow.rb:22:1:22:35 | call to keyword |
 | params_flow.rb:22:1:22:35 | synthetic hash-splat argument | type tracker with call steps | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:22:1:22:35 | synthetic hash-splat argument | type tracker without call steps | params_flow.rb:22:1:22:35 | synthetic hash-splat argument |
@@ -664,50 +618,42 @@ track
 | params_flow.rb:22:9:22:20 | Pair | type tracker without call steps | params_flow.rb:22:9:22:20 | Pair |
 | params_flow.rb:22:13:22:20 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:22:13:22:20 | call to taint | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:22:13:22:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:22:13:22:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:22:13:22:20 | call to taint | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
-| params_flow.rb:22:13:22:20 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:22:13:22:20 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:22:13:22:20 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:22:13:22:20 | call to taint | type tracker without call steps | params_flow.rb:22:13:22:20 | call to taint |
 | params_flow.rb:22:13:22:20 | call to taint | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:22:1:22:35 | synthetic hash-splat argument |
-| params_flow.rb:22:13:22:20 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:22:13:22:20 | synthetic splat argument | type tracker without call steps | params_flow.rb:22:13:22:20 | synthetic splat argument |
 | params_flow.rb:22:19:22:19 | 5 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:22:19:22:19 | 5 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:22:19:22:19 | 5 | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:22:19:22:19 | 5 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:22:19:22:19 | 5 | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:22:19:22:19 | 5 | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
-| params_flow.rb:22:19:22:19 | 5 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:22:19:22:19 | 5 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:22:19:22:19 | 5 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:22:19:22:19 | 5 | type tracker with call steps with content splat position 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:22:19:22:19 | 5 | type tracker without call steps | params_flow.rb:22:13:22:20 | call to taint |
 | params_flow.rb:22:19:22:19 | 5 | type tracker without call steps | params_flow.rb:22:19:22:19 | 5 |
+| params_flow.rb:22:19:22:19 | 5 | type tracker without call steps with content element 0 | params_flow.rb:22:13:22:20 | synthetic splat argument |
 | params_flow.rb:22:19:22:19 | 5 | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:22:1:22:35 | synthetic hash-splat argument |
-| params_flow.rb:22:19:22:19 | 5 | type tracker without call steps with content splat position 0 | params_flow.rb:22:13:22:20 | synthetic splat argument |
 | params_flow.rb:22:23:22:24 | :p1 | type tracker without call steps | params_flow.rb:22:23:22:24 | :p1 |
 | params_flow.rb:22:23:22:34 | Pair | type tracker without call steps | params_flow.rb:22:23:22:34 | Pair |
 | params_flow.rb:22:27:22:34 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:22:27:22:34 | call to taint | type tracker with call steps | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:22:27:22:34 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:22:27:22:34 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
 | params_flow.rb:22:27:22:34 | call to taint | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
-| params_flow.rb:22:27:22:34 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:22:27:22:34 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:22:27:22:34 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
 | params_flow.rb:22:27:22:34 | call to taint | type tracker without call steps | params_flow.rb:22:27:22:34 | call to taint |
 | params_flow.rb:22:27:22:34 | call to taint | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:22:1:22:35 | synthetic hash-splat argument |
-| params_flow.rb:22:27:22:34 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:22:27:22:34 | synthetic splat argument | type tracker without call steps | params_flow.rb:22:27:22:34 | synthetic splat argument |
 | params_flow.rb:22:33:22:33 | 6 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:22:33:22:33 | 6 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:22:33:22:33 | 6 | type tracker with call steps | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:22:33:22:33 | 6 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:22:33:22:33 | 6 | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
 | params_flow.rb:22:33:22:33 | 6 | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
-| params_flow.rb:22:33:22:33 | 6 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:22:33:22:33 | 6 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:22:33:22:33 | 6 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:22:33:22:33 | 6 | type tracker with call steps with content splat position 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
 | params_flow.rb:22:33:22:33 | 6 | type tracker without call steps | params_flow.rb:22:27:22:34 | call to taint |
 | params_flow.rb:22:33:22:33 | 6 | type tracker without call steps | params_flow.rb:22:33:22:33 | 6 |
+| params_flow.rb:22:33:22:33 | 6 | type tracker without call steps with content element 0 | params_flow.rb:22:27:22:34 | synthetic splat argument |
 | params_flow.rb:22:33:22:33 | 6 | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:22:1:22:35 | synthetic hash-splat argument |
-| params_flow.rb:22:33:22:33 | 6 | type tracker without call steps with content splat position 0 | params_flow.rb:22:27:22:34 | synthetic splat argument |
 | params_flow.rb:23:1:23:41 | call to keyword | type tracker without call steps | params_flow.rb:23:1:23:41 | call to keyword |
 | params_flow.rb:23:1:23:41 | synthetic hash-splat argument | type tracker with call steps | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:23:1:23:41 | synthetic hash-splat argument | type tracker without call steps | params_flow.rb:23:1:23:41 | synthetic hash-splat argument |
@@ -715,113 +661,95 @@ track
 | params_flow.rb:23:9:23:23 | Pair | type tracker without call steps | params_flow.rb:23:9:23:23 | Pair |
 | params_flow.rb:23:16:23:23 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:23:16:23:23 | call to taint | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:23:16:23:23 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:23:16:23:23 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:23:16:23:23 | call to taint | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
-| params_flow.rb:23:16:23:23 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:23:16:23:23 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:23:16:23:23 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:23:16:23:23 | call to taint | type tracker without call steps | params_flow.rb:23:16:23:23 | call to taint |
 | params_flow.rb:23:16:23:23 | call to taint | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:23:1:23:41 | synthetic hash-splat argument |
-| params_flow.rb:23:16:23:23 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:23:16:23:23 | synthetic splat argument | type tracker without call steps | params_flow.rb:23:16:23:23 | synthetic splat argument |
 | params_flow.rb:23:22:23:22 | 7 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:23:22:23:22 | 7 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:23:22:23:22 | 7 | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:23:22:23:22 | 7 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:23:22:23:22 | 7 | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:23:22:23:22 | 7 | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
-| params_flow.rb:23:22:23:22 | 7 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:23:22:23:22 | 7 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:23:22:23:22 | 7 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:23:22:23:22 | 7 | type tracker with call steps with content splat position 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:23:22:23:22 | 7 | type tracker without call steps | params_flow.rb:23:16:23:23 | call to taint |
 | params_flow.rb:23:22:23:22 | 7 | type tracker without call steps | params_flow.rb:23:22:23:22 | 7 |
+| params_flow.rb:23:22:23:22 | 7 | type tracker without call steps with content element 0 | params_flow.rb:23:16:23:23 | synthetic splat argument |
 | params_flow.rb:23:22:23:22 | 7 | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:23:1:23:41 | synthetic hash-splat argument |
-| params_flow.rb:23:22:23:22 | 7 | type tracker without call steps with content splat position 0 | params_flow.rb:23:16:23:23 | synthetic splat argument |
 | params_flow.rb:23:26:23:28 | :p1 | type tracker without call steps | params_flow.rb:23:26:23:28 | :p1 |
 | params_flow.rb:23:26:23:40 | Pair | type tracker without call steps | params_flow.rb:23:26:23:40 | Pair |
 | params_flow.rb:23:33:23:40 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:23:33:23:40 | call to taint | type tracker with call steps | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:23:33:23:40 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:23:33:23:40 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
 | params_flow.rb:23:33:23:40 | call to taint | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
-| params_flow.rb:23:33:23:40 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:23:33:23:40 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:23:33:23:40 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
 | params_flow.rb:23:33:23:40 | call to taint | type tracker without call steps | params_flow.rb:23:33:23:40 | call to taint |
 | params_flow.rb:23:33:23:40 | call to taint | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:23:1:23:41 | synthetic hash-splat argument |
-| params_flow.rb:23:33:23:40 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:23:33:23:40 | synthetic splat argument | type tracker without call steps | params_flow.rb:23:33:23:40 | synthetic splat argument |
 | params_flow.rb:23:39:23:39 | 8 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:23:39:23:39 | 8 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:23:39:23:39 | 8 | type tracker with call steps | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:23:39:23:39 | 8 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:23:39:23:39 | 8 | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
 | params_flow.rb:23:39:23:39 | 8 | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
-| params_flow.rb:23:39:23:39 | 8 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:23:39:23:39 | 8 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:23:39:23:39 | 8 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:23:39:23:39 | 8 | type tracker with call steps with content splat position 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
 | params_flow.rb:23:39:23:39 | 8 | type tracker without call steps | params_flow.rb:23:33:23:40 | call to taint |
 | params_flow.rb:23:39:23:39 | 8 | type tracker without call steps | params_flow.rb:23:39:23:39 | 8 |
+| params_flow.rb:23:39:23:39 | 8 | type tracker without call steps with content element 0 | params_flow.rb:23:33:23:40 | synthetic splat argument |
 | params_flow.rb:23:39:23:39 | 8 | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:23:1:23:41 | synthetic hash-splat argument |
-| params_flow.rb:23:39:23:39 | 8 | type tracker without call steps with content splat position 0 | params_flow.rb:23:33:23:40 | synthetic splat argument |
 | params_flow.rb:25:1:31:3 | &block | type tracker without call steps | params_flow.rb:25:1:31:3 | &block |
 | params_flow.rb:25:1:31:3 | kwargs | type tracker without call steps | params_flow.rb:25:1:31:3 | kwargs |
 | params_flow.rb:25:1:31:3 | self in kwargs | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
 | params_flow.rb:25:1:31:3 | self in kwargs | type tracker without call steps | params_flow.rb:25:1:31:3 | self in kwargs |
 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter | type tracker without call steps | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:25:12:25:13 | p1 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:25:12:25:13 | p1 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:25:12:25:13 | p1 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:25:12:25:13 | p1 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:25:12:25:13 | p1 | type tracker without call steps | params_flow.rb:25:12:25:13 | p1 |
 | params_flow.rb:25:12:25:13 | p1 | type tracker without call steps | params_flow.rb:25:12:25:13 | p1 |
-| params_flow.rb:25:12:25:13 | p1 | type tracker without call steps with content splat position 0 | params_flow.rb:26:5:26:11 | synthetic splat argument |
+| params_flow.rb:25:12:25:13 | p1 | type tracker without call steps with content element 0 | params_flow.rb:26:5:26:11 | synthetic splat argument |
 | params_flow.rb:25:17:25:24 | **kwargs | type tracker without call steps | params_flow.rb:25:17:25:24 | **kwargs |
 | params_flow.rb:25:19:25:24 | kwargs | type tracker without call steps | params_flow.rb:25:19:25:24 | kwargs |
 | params_flow.rb:26:5:26:11 | call to sink | type tracker without call steps | params_flow.rb:26:5:26:11 | call to sink |
-| params_flow.rb:26:5:26:11 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:26:5:26:11 | synthetic splat argument | type tracker without call steps | params_flow.rb:26:5:26:11 | synthetic splat argument |
 | params_flow.rb:27:5:27:22 | call to sink | type tracker without call steps | params_flow.rb:27:5:27:22 | call to sink |
-| params_flow.rb:27:5:27:22 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:27:5:27:22 | synthetic splat argument | type tracker without call steps | params_flow.rb:27:5:27:22 | synthetic splat argument |
 | params_flow.rb:27:11:27:21 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:27:11:27:21 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:27:11:27:21 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:27:11:27:21 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:27:11:27:21 | ...[...] | type tracker without call steps | params_flow.rb:27:11:27:21 | ...[...] |
-| params_flow.rb:27:11:27:21 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:27:5:27:22 | synthetic splat argument |
+| params_flow.rb:27:11:27:21 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:27:5:27:22 | synthetic splat argument |
 | params_flow.rb:27:11:27:21 | synthetic splat argument | type tracker without call steps | params_flow.rb:27:11:27:21 | synthetic splat argument |
 | params_flow.rb:27:18:27:20 | :p1 | type tracker without call steps | params_flow.rb:27:18:27:20 | :p1 |
-| params_flow.rb:27:18:27:20 | :p1 | type tracker without call steps with content splat position 0 | params_flow.rb:27:11:27:21 | synthetic splat argument |
+| params_flow.rb:27:18:27:20 | :p1 | type tracker without call steps with content element 0 | params_flow.rb:27:11:27:21 | synthetic splat argument |
 | params_flow.rb:28:5:28:22 | call to sink | type tracker without call steps | params_flow.rb:28:5:28:22 | call to sink |
-| params_flow.rb:28:5:28:22 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:28:5:28:22 | synthetic splat argument | type tracker without call steps | params_flow.rb:28:5:28:22 | synthetic splat argument |
 | params_flow.rb:28:11:28:21 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:28:11:28:21 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:28:11:28:21 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:28:11:28:21 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:28:11:28:21 | ...[...] | type tracker without call steps | params_flow.rb:28:11:28:21 | ...[...] |
-| params_flow.rb:28:11:28:21 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:28:5:28:22 | synthetic splat argument |
+| params_flow.rb:28:11:28:21 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:28:5:28:22 | synthetic splat argument |
 | params_flow.rb:28:11:28:21 | synthetic splat argument | type tracker without call steps | params_flow.rb:28:11:28:21 | synthetic splat argument |
 | params_flow.rb:28:18:28:20 | :p2 | type tracker without call steps | params_flow.rb:28:18:28:20 | :p2 |
-| params_flow.rb:28:18:28:20 | :p2 | type tracker without call steps with content splat position 0 | params_flow.rb:28:11:28:21 | synthetic splat argument |
+| params_flow.rb:28:18:28:20 | :p2 | type tracker without call steps with content element 0 | params_flow.rb:28:11:28:21 | synthetic splat argument |
 | params_flow.rb:29:5:29:22 | call to sink | type tracker without call steps | params_flow.rb:29:5:29:22 | call to sink |
-| params_flow.rb:29:5:29:22 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:29:5:29:22 | synthetic splat argument | type tracker without call steps | params_flow.rb:29:5:29:22 | synthetic splat argument |
 | params_flow.rb:29:11:29:21 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:29:11:29:21 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:29:11:29:21 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:29:11:29:21 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:29:11:29:21 | ...[...] | type tracker without call steps | params_flow.rb:29:11:29:21 | ...[...] |
-| params_flow.rb:29:11:29:21 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:29:5:29:22 | synthetic splat argument |
+| params_flow.rb:29:11:29:21 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:29:5:29:22 | synthetic splat argument |
 | params_flow.rb:29:11:29:21 | synthetic splat argument | type tracker without call steps | params_flow.rb:29:11:29:21 | synthetic splat argument |
 | params_flow.rb:29:18:29:20 | :p3 | type tracker without call steps | params_flow.rb:29:18:29:20 | :p3 |
-| params_flow.rb:29:18:29:20 | :p3 | type tracker without call steps with content splat position 0 | params_flow.rb:29:11:29:21 | synthetic splat argument |
+| params_flow.rb:29:18:29:20 | :p3 | type tracker without call steps with content element 0 | params_flow.rb:29:11:29:21 | synthetic splat argument |
 | params_flow.rb:30:5:30:22 | call to sink | type tracker without call steps | params_flow.rb:30:5:30:22 | call to sink |
 | params_flow.rb:30:5:30:22 | call to sink | type tracker without call steps | params_flow.rb:33:1:33:58 | call to kwargs |
 | params_flow.rb:30:5:30:22 | call to sink | type tracker without call steps | params_flow.rb:35:1:35:29 | call to kwargs |
 | params_flow.rb:30:5:30:22 | call to sink | type tracker without call steps | params_flow.rb:38:1:38:14 | call to kwargs |
-| params_flow.rb:30:5:30:22 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:30:5:30:22 | synthetic splat argument | type tracker without call steps | params_flow.rb:30:5:30:22 | synthetic splat argument |
 | params_flow.rb:30:11:30:21 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:30:11:30:21 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:30:11:30:21 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:30:11:30:21 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:30:11:30:21 | ...[...] | type tracker without call steps | params_flow.rb:30:11:30:21 | ...[...] |
-| params_flow.rb:30:11:30:21 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:30:5:30:22 | synthetic splat argument |
+| params_flow.rb:30:11:30:21 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:30:5:30:22 | synthetic splat argument |
 | params_flow.rb:30:11:30:21 | synthetic splat argument | type tracker without call steps | params_flow.rb:30:11:30:21 | synthetic splat argument |
 | params_flow.rb:30:18:30:20 | :p4 | type tracker without call steps | params_flow.rb:30:18:30:20 | :p4 |
-| params_flow.rb:30:18:30:20 | :p4 | type tracker without call steps with content splat position 0 | params_flow.rb:30:11:30:21 | synthetic splat argument |
+| params_flow.rb:30:18:30:20 | :p4 | type tracker without call steps with content element 0 | params_flow.rb:30:11:30:21 | synthetic splat argument |
 | params_flow.rb:33:1:33:58 | call to kwargs | type tracker without call steps | params_flow.rb:33:1:33:58 | call to kwargs |
 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument | type tracker with call steps | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument | type tracker with call steps | params_flow.rb:25:17:25:24 | **kwargs |
@@ -831,92 +759,79 @@ track
 | params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps | params_flow.rb:25:12:25:13 | p1 |
 | params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps | params_flow.rb:27:11:27:21 | ...[...] |
+| params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:26:5:26:11 | synthetic splat argument |
+| params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:27:5:27:22 | synthetic splat argument |
 | params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:25:17:25:24 | **kwargs |
-| params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:26:5:26:11 | synthetic splat argument |
-| params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:27:5:27:22 | synthetic splat argument |
 | params_flow.rb:33:12:33:19 | call to taint | type tracker without call steps | params_flow.rb:33:12:33:19 | call to taint |
 | params_flow.rb:33:12:33:19 | call to taint | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
-| params_flow.rb:33:12:33:19 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:33:12:33:19 | synthetic splat argument | type tracker without call steps | params_flow.rb:33:12:33:19 | synthetic splat argument |
 | params_flow.rb:33:18:33:18 | 9 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:33:18:33:18 | 9 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:33:18:33:18 | 9 | type tracker with call steps | params_flow.rb:25:12:25:13 | p1 |
 | params_flow.rb:33:18:33:18 | 9 | type tracker with call steps | params_flow.rb:27:11:27:21 | ...[...] |
+| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content element 0 | params_flow.rb:26:5:26:11 | synthetic splat argument |
+| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content element 0 | params_flow.rb:27:5:27:22 | synthetic splat argument |
 | params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:25:17:25:24 | **kwargs |
-| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content splat position 0 | params_flow.rb:26:5:26:11 | synthetic splat argument |
-| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content splat position 0 | params_flow.rb:27:5:27:22 | synthetic splat argument |
 | params_flow.rb:33:18:33:18 | 9 | type tracker without call steps | params_flow.rb:33:12:33:19 | call to taint |
 | params_flow.rb:33:18:33:18 | 9 | type tracker without call steps | params_flow.rb:33:18:33:18 | 9 |
+| params_flow.rb:33:18:33:18 | 9 | type tracker without call steps with content element 0 | params_flow.rb:33:12:33:19 | synthetic splat argument |
 | params_flow.rb:33:18:33:18 | 9 | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
-| params_flow.rb:33:18:33:18 | 9 | type tracker without call steps with content splat position 0 | params_flow.rb:33:12:33:19 | synthetic splat argument |
 | params_flow.rb:33:22:33:23 | :p2 | type tracker without call steps | params_flow.rb:33:22:33:23 | :p2 |
 | params_flow.rb:33:22:33:34 | Pair | type tracker without call steps | params_flow.rb:33:22:33:34 | Pair |
 | params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps | params_flow.rb:28:11:28:21 | ...[...] |
+| params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:28:5:28:22 | synthetic splat argument |
 | params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:25:17:25:24 | **kwargs |
-| params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:28:5:28:22 | synthetic splat argument |
 | params_flow.rb:33:26:33:34 | call to taint | type tracker without call steps | params_flow.rb:33:26:33:34 | call to taint |
 | params_flow.rb:33:26:33:34 | call to taint | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
-| params_flow.rb:33:26:33:34 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:33:26:33:34 | synthetic splat argument | type tracker without call steps | params_flow.rb:33:26:33:34 | synthetic splat argument |
 | params_flow.rb:33:32:33:33 | 10 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:33:32:33:33 | 10 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:33:32:33:33 | 10 | type tracker with call steps | params_flow.rb:28:11:28:21 | ...[...] |
+| params_flow.rb:33:32:33:33 | 10 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:33:32:33:33 | 10 | type tracker with call steps with content element 0 | params_flow.rb:28:5:28:22 | synthetic splat argument |
 | params_flow.rb:33:32:33:33 | 10 | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:33:32:33:33 | 10 | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:25:17:25:24 | **kwargs |
-| params_flow.rb:33:32:33:33 | 10 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:33:32:33:33 | 10 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:33:32:33:33 | 10 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:33:32:33:33 | 10 | type tracker with call steps with content splat position 0 | params_flow.rb:28:5:28:22 | synthetic splat argument |
 | params_flow.rb:33:32:33:33 | 10 | type tracker without call steps | params_flow.rb:33:26:33:34 | call to taint |
 | params_flow.rb:33:32:33:33 | 10 | type tracker without call steps | params_flow.rb:33:32:33:33 | 10 |
+| params_flow.rb:33:32:33:33 | 10 | type tracker without call steps with content element 0 | params_flow.rb:33:26:33:34 | synthetic splat argument |
 | params_flow.rb:33:32:33:33 | 10 | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
-| params_flow.rb:33:32:33:33 | 10 | type tracker without call steps with content splat position 0 | params_flow.rb:33:26:33:34 | synthetic splat argument |
 | params_flow.rb:33:37:33:38 | :p3 | type tracker without call steps | params_flow.rb:33:37:33:38 | :p3 |
 | params_flow.rb:33:37:33:49 | Pair | type tracker without call steps | params_flow.rb:33:37:33:49 | Pair |
 | params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps | params_flow.rb:29:11:29:21 | ...[...] |
+| params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:29:5:29:22 | synthetic splat argument |
 | params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps with content hash-splat position :p3 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps with content hash-splat position :p3 | params_flow.rb:25:17:25:24 | **kwargs |
-| params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:29:5:29:22 | synthetic splat argument |
 | params_flow.rb:33:41:33:49 | call to taint | type tracker without call steps | params_flow.rb:33:41:33:49 | call to taint |
 | params_flow.rb:33:41:33:49 | call to taint | type tracker without call steps with content hash-splat position :p3 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
-| params_flow.rb:33:41:33:49 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:33:41:33:49 | synthetic splat argument | type tracker without call steps | params_flow.rb:33:41:33:49 | synthetic splat argument |
 | params_flow.rb:33:47:33:48 | 11 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:33:47:33:48 | 11 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:33:47:33:48 | 11 | type tracker with call steps | params_flow.rb:29:11:29:21 | ...[...] |
+| params_flow.rb:33:47:33:48 | 11 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:33:47:33:48 | 11 | type tracker with call steps with content element 0 | params_flow.rb:29:5:29:22 | synthetic splat argument |
 | params_flow.rb:33:47:33:48 | 11 | type tracker with call steps with content hash-splat position :p3 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:33:47:33:48 | 11 | type tracker with call steps with content hash-splat position :p3 | params_flow.rb:25:17:25:24 | **kwargs |
-| params_flow.rb:33:47:33:48 | 11 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:33:47:33:48 | 11 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:33:47:33:48 | 11 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:33:47:33:48 | 11 | type tracker with call steps with content splat position 0 | params_flow.rb:29:5:29:22 | synthetic splat argument |
 | params_flow.rb:33:47:33:48 | 11 | type tracker without call steps | params_flow.rb:33:41:33:49 | call to taint |
 | params_flow.rb:33:47:33:48 | 11 | type tracker without call steps | params_flow.rb:33:47:33:48 | 11 |
+| params_flow.rb:33:47:33:48 | 11 | type tracker without call steps with content element 0 | params_flow.rb:33:41:33:49 | synthetic splat argument |
 | params_flow.rb:33:47:33:48 | 11 | type tracker without call steps with content hash-splat position :p3 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
-| params_flow.rb:33:47:33:48 | 11 | type tracker without call steps with content splat position 0 | params_flow.rb:33:41:33:49 | synthetic splat argument |
 | params_flow.rb:33:52:33:53 | :p4 | type tracker without call steps | params_flow.rb:33:52:33:53 | :p4 |
 | params_flow.rb:33:52:33:57 | Pair | type tracker without call steps | params_flow.rb:33:52:33:57 | Pair |
 | params_flow.rb:33:56:33:57 | "" | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:33:56:33:57 | "" | type tracker with call steps | params_flow.rb:30:11:30:21 | ...[...] |
+| params_flow.rb:33:56:33:57 | "" | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:33:56:33:57 | "" | type tracker with call steps with content element 0 | params_flow.rb:30:5:30:22 | synthetic splat argument |
 | params_flow.rb:33:56:33:57 | "" | type tracker with call steps with content hash-splat position :p4 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:33:56:33:57 | "" | type tracker with call steps with content hash-splat position :p4 | params_flow.rb:25:17:25:24 | **kwargs |
-| params_flow.rb:33:56:33:57 | "" | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:33:56:33:57 | "" | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:33:56:33:57 | "" | type tracker with call steps with content splat position 0 | params_flow.rb:30:5:30:22 | synthetic splat argument |
 | params_flow.rb:33:56:33:57 | "" | type tracker without call steps | params_flow.rb:33:56:33:57 | "" |
 | params_flow.rb:33:56:33:57 | "" | type tracker without call steps with content hash-splat position :p4 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
 | params_flow.rb:34:1:34:4 | args | type tracker without call steps | params_flow.rb:34:1:34:4 | args |
@@ -928,41 +843,36 @@ track
 | params_flow.rb:34:10:34:22 | Pair | type tracker without call steps | params_flow.rb:34:10:34:22 | Pair |
 | params_flow.rb:34:14:34:22 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:34:14:34:22 | call to taint | type tracker with call steps | params_flow.rb:29:11:29:21 | ...[...] |
+| params_flow.rb:34:14:34:22 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:34:14:34:22 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:29:5:29:22 | synthetic splat argument |
 | params_flow.rb:34:14:34:22 | call to taint | type tracker with call steps with content element :p3 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:34:14:34:22 | call to taint | type tracker with call steps with content element :p3 | params_flow.rb:25:17:25:24 | **kwargs |
-| params_flow.rb:34:14:34:22 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:34:14:34:22 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:34:14:34:22 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:29:5:29:22 | synthetic splat argument |
 | params_flow.rb:34:14:34:22 | call to taint | type tracker without call steps | params_flow.rb:34:14:34:22 | call to taint |
 | params_flow.rb:34:14:34:22 | call to taint | type tracker without call steps with content element :p3 | params_flow.rb:34:8:34:32 | call to [] |
 | params_flow.rb:34:14:34:22 | call to taint | type tracker without call steps with content element :p3 | params_flow.rb:34:8:34:32 | synthetic hash-splat argument |
 | params_flow.rb:34:14:34:22 | call to taint | type tracker without call steps with content element :p3 | params_flow.rb:35:23:35:28 | ** ... |
-| params_flow.rb:34:14:34:22 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:34:14:34:22 | synthetic splat argument | type tracker without call steps | params_flow.rb:34:14:34:22 | synthetic splat argument |
 | params_flow.rb:34:20:34:21 | 12 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:34:20:34:21 | 12 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:34:20:34:21 | 12 | type tracker with call steps | params_flow.rb:29:11:29:21 | ...[...] |
+| params_flow.rb:34:20:34:21 | 12 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:34:20:34:21 | 12 | type tracker with call steps with content element 0 | params_flow.rb:29:5:29:22 | synthetic splat argument |
 | params_flow.rb:34:20:34:21 | 12 | type tracker with call steps with content element :p3 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:34:20:34:21 | 12 | type tracker with call steps with content element :p3 | params_flow.rb:25:17:25:24 | **kwargs |
-| params_flow.rb:34:20:34:21 | 12 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:34:20:34:21 | 12 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:34:20:34:21 | 12 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:34:20:34:21 | 12 | type tracker with call steps with content splat position 0 | params_flow.rb:29:5:29:22 | synthetic splat argument |
 | params_flow.rb:34:20:34:21 | 12 | type tracker without call steps | params_flow.rb:34:14:34:22 | call to taint |
 | params_flow.rb:34:20:34:21 | 12 | type tracker without call steps | params_flow.rb:34:20:34:21 | 12 |
+| params_flow.rb:34:20:34:21 | 12 | type tracker without call steps with content element 0 | params_flow.rb:34:14:34:22 | synthetic splat argument |
 | params_flow.rb:34:20:34:21 | 12 | type tracker without call steps with content element :p3 | params_flow.rb:34:8:34:32 | call to [] |
 | params_flow.rb:34:20:34:21 | 12 | type tracker without call steps with content element :p3 | params_flow.rb:34:8:34:32 | synthetic hash-splat argument |
 | params_flow.rb:34:20:34:21 | 12 | type tracker without call steps with content element :p3 | params_flow.rb:35:23:35:28 | ** ... |
-| params_flow.rb:34:20:34:21 | 12 | type tracker without call steps with content splat position 0 | params_flow.rb:34:14:34:22 | synthetic splat argument |
 | params_flow.rb:34:25:34:26 | :p4 | type tracker without call steps | params_flow.rb:34:25:34:26 | :p4 |
 | params_flow.rb:34:25:34:30 | Pair | type tracker without call steps | params_flow.rb:34:25:34:30 | Pair |
 | params_flow.rb:34:29:34:30 | "" | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:34:29:34:30 | "" | type tracker with call steps | params_flow.rb:30:11:30:21 | ...[...] |
+| params_flow.rb:34:29:34:30 | "" | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:34:29:34:30 | "" | type tracker with call steps with content element 0 | params_flow.rb:30:5:30:22 | synthetic splat argument |
 | params_flow.rb:34:29:34:30 | "" | type tracker with call steps with content element :p4 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:34:29:34:30 | "" | type tracker with call steps with content element :p4 | params_flow.rb:25:17:25:24 | **kwargs |
-| params_flow.rb:34:29:34:30 | "" | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:34:29:34:30 | "" | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:34:29:34:30 | "" | type tracker with call steps with content splat position 0 | params_flow.rb:30:5:30:22 | synthetic splat argument |
 | params_flow.rb:34:29:34:30 | "" | type tracker without call steps | params_flow.rb:34:29:34:30 | "" |
 | params_flow.rb:34:29:34:30 | "" | type tracker without call steps with content element :p4 | params_flow.rb:34:8:34:32 | call to [] |
 | params_flow.rb:34:29:34:30 | "" | type tracker without call steps with content element :p4 | params_flow.rb:34:8:34:32 | synthetic hash-splat argument |
@@ -976,31 +886,27 @@ track
 | params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps | params_flow.rb:25:12:25:13 | p1 |
 | params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps | params_flow.rb:27:11:27:21 | ...[...] |
+| params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:26:5:26:11 | synthetic splat argument |
+| params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:27:5:27:22 | synthetic splat argument |
 | params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:25:17:25:24 | **kwargs |
-| params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:26:5:26:11 | synthetic splat argument |
-| params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:27:5:27:22 | synthetic splat argument |
 | params_flow.rb:35:12:35:20 | call to taint | type tracker without call steps | params_flow.rb:35:12:35:20 | call to taint |
 | params_flow.rb:35:12:35:20 | call to taint | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:35:1:35:29 | synthetic hash-splat argument |
-| params_flow.rb:35:12:35:20 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:35:12:35:20 | synthetic splat argument | type tracker without call steps | params_flow.rb:35:12:35:20 | synthetic splat argument |
 | params_flow.rb:35:18:35:19 | 13 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:35:18:35:19 | 13 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:35:18:35:19 | 13 | type tracker with call steps | params_flow.rb:25:12:25:13 | p1 |
 | params_flow.rb:35:18:35:19 | 13 | type tracker with call steps | params_flow.rb:27:11:27:21 | ...[...] |
+| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content element 0 | params_flow.rb:26:5:26:11 | synthetic splat argument |
+| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content element 0 | params_flow.rb:27:5:27:22 | synthetic splat argument |
 | params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:25:17:25:24 | **kwargs |
-| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content splat position 0 | params_flow.rb:26:5:26:11 | synthetic splat argument |
-| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content splat position 0 | params_flow.rb:27:5:27:22 | synthetic splat argument |
 | params_flow.rb:35:18:35:19 | 13 | type tracker without call steps | params_flow.rb:35:12:35:20 | call to taint |
 | params_flow.rb:35:18:35:19 | 13 | type tracker without call steps | params_flow.rb:35:18:35:19 | 13 |
+| params_flow.rb:35:18:35:19 | 13 | type tracker without call steps with content element 0 | params_flow.rb:35:12:35:20 | synthetic splat argument |
 | params_flow.rb:35:18:35:19 | 13 | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:35:1:35:29 | synthetic hash-splat argument |
-| params_flow.rb:35:18:35:19 | 13 | type tracker without call steps with content splat position 0 | params_flow.rb:35:12:35:20 | synthetic splat argument |
 | params_flow.rb:35:23:35:28 | ** ... | type tracker with call steps | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:35:23:35:28 | ** ... | type tracker with call steps | params_flow.rb:25:17:25:24 | **kwargs |
 | params_flow.rb:35:23:35:28 | ** ... | type tracker without call steps | params_flow.rb:35:23:35:28 | ** ... |
@@ -1014,65 +920,57 @@ track
 | params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps | params_flow.rb:25:12:25:13 | p1 |
 | params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps | params_flow.rb:27:11:27:21 | ...[...] |
+| params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:26:5:26:11 | synthetic splat argument |
+| params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:27:5:27:22 | synthetic splat argument |
 | params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps with content element :p1 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps with content element :p1 | params_flow.rb:25:17:25:24 | **kwargs |
-| params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:26:5:26:11 | synthetic splat argument |
-| params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:27:5:27:22 | synthetic splat argument |
 | params_flow.rb:37:16:37:24 | call to taint | type tracker without call steps | params_flow.rb:37:16:37:24 | call to taint |
 | params_flow.rb:37:16:37:24 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:37:8:37:44 | call to [] |
 | params_flow.rb:37:16:37:24 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:37:8:37:44 | synthetic hash-splat argument |
 | params_flow.rb:37:16:37:24 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:38:8:38:13 | ** ... |
-| params_flow.rb:37:16:37:24 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:37:16:37:24 | synthetic splat argument | type tracker without call steps | params_flow.rb:37:16:37:24 | synthetic splat argument |
 | params_flow.rb:37:22:37:23 | 14 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:37:22:37:23 | 14 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:37:22:37:23 | 14 | type tracker with call steps | params_flow.rb:25:12:25:13 | p1 |
 | params_flow.rb:37:22:37:23 | 14 | type tracker with call steps | params_flow.rb:27:11:27:21 | ...[...] |
+| params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content element 0 | params_flow.rb:26:5:26:11 | synthetic splat argument |
+| params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content element 0 | params_flow.rb:27:5:27:22 | synthetic splat argument |
 | params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content element :p1 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content element :p1 | params_flow.rb:25:17:25:24 | **kwargs |
-| params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content splat position 0 | params_flow.rb:26:5:26:11 | synthetic splat argument |
-| params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content splat position 0 | params_flow.rb:27:5:27:22 | synthetic splat argument |
 | params_flow.rb:37:22:37:23 | 14 | type tracker without call steps | params_flow.rb:37:16:37:24 | call to taint |
 | params_flow.rb:37:22:37:23 | 14 | type tracker without call steps | params_flow.rb:37:22:37:23 | 14 |
+| params_flow.rb:37:22:37:23 | 14 | type tracker without call steps with content element 0 | params_flow.rb:37:16:37:24 | synthetic splat argument |
 | params_flow.rb:37:22:37:23 | 14 | type tracker without call steps with content element :p1 | params_flow.rb:37:8:37:44 | call to [] |
 | params_flow.rb:37:22:37:23 | 14 | type tracker without call steps with content element :p1 | params_flow.rb:37:8:37:44 | synthetic hash-splat argument |
 | params_flow.rb:37:22:37:23 | 14 | type tracker without call steps with content element :p1 | params_flow.rb:38:8:38:13 | ** ... |
-| params_flow.rb:37:22:37:23 | 14 | type tracker without call steps with content splat position 0 | params_flow.rb:37:16:37:24 | synthetic splat argument |
 | params_flow.rb:37:27:37:29 | :p2 | type tracker without call steps | params_flow.rb:37:27:37:29 | :p2 |
 | params_flow.rb:37:27:37:42 | Pair | type tracker without call steps | params_flow.rb:37:27:37:42 | Pair |
 | params_flow.rb:37:34:37:42 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:37:34:37:42 | call to taint | type tracker with call steps | params_flow.rb:28:11:28:21 | ...[...] |
+| params_flow.rb:37:34:37:42 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:37:34:37:42 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:28:5:28:22 | synthetic splat argument |
 | params_flow.rb:37:34:37:42 | call to taint | type tracker with call steps with content element :p2 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:37:34:37:42 | call to taint | type tracker with call steps with content element :p2 | params_flow.rb:25:17:25:24 | **kwargs |
-| params_flow.rb:37:34:37:42 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:37:34:37:42 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:37:34:37:42 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:28:5:28:22 | synthetic splat argument |
 | params_flow.rb:37:34:37:42 | call to taint | type tracker without call steps | params_flow.rb:37:34:37:42 | call to taint |
 | params_flow.rb:37:34:37:42 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:37:8:37:44 | call to [] |
 | params_flow.rb:37:34:37:42 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:37:8:37:44 | synthetic hash-splat argument |
 | params_flow.rb:37:34:37:42 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:38:8:38:13 | ** ... |
-| params_flow.rb:37:34:37:42 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:37:34:37:42 | synthetic splat argument | type tracker without call steps | params_flow.rb:37:34:37:42 | synthetic splat argument |
 | params_flow.rb:37:40:37:41 | 15 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:37:40:37:41 | 15 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:37:40:37:41 | 15 | type tracker with call steps | params_flow.rb:28:11:28:21 | ...[...] |
+| params_flow.rb:37:40:37:41 | 15 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:37:40:37:41 | 15 | type tracker with call steps with content element 0 | params_flow.rb:28:5:28:22 | synthetic splat argument |
 | params_flow.rb:37:40:37:41 | 15 | type tracker with call steps with content element :p2 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:37:40:37:41 | 15 | type tracker with call steps with content element :p2 | params_flow.rb:25:17:25:24 | **kwargs |
-| params_flow.rb:37:40:37:41 | 15 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:37:40:37:41 | 15 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:37:40:37:41 | 15 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:37:40:37:41 | 15 | type tracker with call steps with content splat position 0 | params_flow.rb:28:5:28:22 | synthetic splat argument |
 | params_flow.rb:37:40:37:41 | 15 | type tracker without call steps | params_flow.rb:37:34:37:42 | call to taint |
 | params_flow.rb:37:40:37:41 | 15 | type tracker without call steps | params_flow.rb:37:40:37:41 | 15 |
+| params_flow.rb:37:40:37:41 | 15 | type tracker without call steps with content element 0 | params_flow.rb:37:34:37:42 | synthetic splat argument |
 | params_flow.rb:37:40:37:41 | 15 | type tracker without call steps with content element :p2 | params_flow.rb:37:8:37:44 | call to [] |
 | params_flow.rb:37:40:37:41 | 15 | type tracker without call steps with content element :p2 | params_flow.rb:37:8:37:44 | synthetic hash-splat argument |
 | params_flow.rb:37:40:37:41 | 15 | type tracker without call steps with content element :p2 | params_flow.rb:38:8:38:13 | ** ... |
-| params_flow.rb:37:40:37:41 | 15 | type tracker without call steps with content splat position 0 | params_flow.rb:37:34:37:42 | synthetic splat argument |
 | params_flow.rb:38:1:38:14 | call to kwargs | type tracker without call steps | params_flow.rb:38:1:38:14 | call to kwargs |
 | params_flow.rb:38:8:38:13 | ** ... | type tracker with call steps | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:38:8:38:13 | ** ... | type tracker with call steps | params_flow.rb:25:17:25:24 | **kwargs |
@@ -1086,30 +984,26 @@ track
 | params_flow.rb:40:9:40:24 | Pair | type tracker without call steps | params_flow.rb:40:9:40:24 | Pair |
 | params_flow.rb:40:16:40:24 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:40:16:40:24 | call to taint | type tracker with call steps | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:40:16:40:24 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:40:16:40:24 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
 | params_flow.rb:40:16:40:24 | call to taint | type tracker with call steps with content element :p1 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
-| params_flow.rb:40:16:40:24 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:40:16:40:24 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:40:16:40:24 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
 | params_flow.rb:40:16:40:24 | call to taint | type tracker without call steps | params_flow.rb:40:16:40:24 | call to taint |
 | params_flow.rb:40:16:40:24 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:40:8:40:26 | call to [] |
 | params_flow.rb:40:16:40:24 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:40:8:40:26 | synthetic hash-splat argument |
 | params_flow.rb:40:16:40:24 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:41:24:41:29 | ** ... |
-| params_flow.rb:40:16:40:24 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:40:16:40:24 | synthetic splat argument | type tracker without call steps | params_flow.rb:40:16:40:24 | synthetic splat argument |
 | params_flow.rb:40:22:40:23 | 16 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:40:22:40:23 | 16 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:40:22:40:23 | 16 | type tracker with call steps | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:40:22:40:23 | 16 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:40:22:40:23 | 16 | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
 | params_flow.rb:40:22:40:23 | 16 | type tracker with call steps with content element :p1 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
-| params_flow.rb:40:22:40:23 | 16 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:40:22:40:23 | 16 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:40:22:40:23 | 16 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:40:22:40:23 | 16 | type tracker with call steps with content splat position 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
 | params_flow.rb:40:22:40:23 | 16 | type tracker without call steps | params_flow.rb:40:16:40:24 | call to taint |
 | params_flow.rb:40:22:40:23 | 16 | type tracker without call steps | params_flow.rb:40:22:40:23 | 16 |
+| params_flow.rb:40:22:40:23 | 16 | type tracker without call steps with content element 0 | params_flow.rb:40:16:40:24 | synthetic splat argument |
 | params_flow.rb:40:22:40:23 | 16 | type tracker without call steps with content element :p1 | params_flow.rb:40:8:40:26 | call to [] |
 | params_flow.rb:40:22:40:23 | 16 | type tracker without call steps with content element :p1 | params_flow.rb:40:8:40:26 | synthetic hash-splat argument |
 | params_flow.rb:40:22:40:23 | 16 | type tracker without call steps with content element :p1 | params_flow.rb:41:24:41:29 | ** ... |
-| params_flow.rb:40:22:40:23 | 16 | type tracker without call steps with content splat position 0 | params_flow.rb:40:16:40:24 | synthetic splat argument |
 | params_flow.rb:41:1:41:30 | call to keyword | type tracker without call steps | params_flow.rb:41:1:41:30 | call to keyword |
 | params_flow.rb:41:1:41:30 | synthetic hash-splat argument | type tracker with call steps | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:41:1:41:30 | synthetic hash-splat argument | type tracker without call steps | params_flow.rb:41:1:41:30 | synthetic hash-splat argument |
@@ -1117,174 +1011,150 @@ track
 | params_flow.rb:41:9:41:21 | Pair | type tracker without call steps | params_flow.rb:41:9:41:21 | Pair |
 | params_flow.rb:41:13:41:21 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:41:13:41:21 | call to taint | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:41:13:41:21 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:41:13:41:21 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:41:13:41:21 | call to taint | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
-| params_flow.rb:41:13:41:21 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:41:13:41:21 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:41:13:41:21 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:41:13:41:21 | call to taint | type tracker without call steps | params_flow.rb:41:13:41:21 | call to taint |
 | params_flow.rb:41:13:41:21 | call to taint | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:41:1:41:30 | synthetic hash-splat argument |
-| params_flow.rb:41:13:41:21 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:41:13:41:21 | synthetic splat argument | type tracker without call steps | params_flow.rb:41:13:41:21 | synthetic splat argument |
 | params_flow.rb:41:19:41:20 | 17 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:41:19:41:20 | 17 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:41:19:41:20 | 17 | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:41:19:41:20 | 17 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:41:19:41:20 | 17 | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:41:19:41:20 | 17 | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
-| params_flow.rb:41:19:41:20 | 17 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:41:19:41:20 | 17 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:41:19:41:20 | 17 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:41:19:41:20 | 17 | type tracker with call steps with content splat position 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:41:19:41:20 | 17 | type tracker without call steps | params_flow.rb:41:13:41:21 | call to taint |
 | params_flow.rb:41:19:41:20 | 17 | type tracker without call steps | params_flow.rb:41:19:41:20 | 17 |
+| params_flow.rb:41:19:41:20 | 17 | type tracker without call steps with content element 0 | params_flow.rb:41:13:41:21 | synthetic splat argument |
 | params_flow.rb:41:19:41:20 | 17 | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:41:1:41:30 | synthetic hash-splat argument |
-| params_flow.rb:41:19:41:20 | 17 | type tracker without call steps with content splat position 0 | params_flow.rb:41:13:41:21 | synthetic splat argument |
 | params_flow.rb:41:24:41:29 | ** ... | type tracker with call steps | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:41:24:41:29 | ** ... | type tracker without call steps | params_flow.rb:41:24:41:29 | ** ... |
 | params_flow.rb:43:1:43:4 | args | type tracker without call steps | params_flow.rb:43:1:43:4 | args |
 | params_flow.rb:43:8:43:18 | Array | type tracker without call steps | params_flow.rb:43:8:43:18 | Array |
 | params_flow.rb:43:8:43:18 | call to [] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:43:8:43:18 | call to [] | type tracker with call steps | params_flow.rb:9:20:9:21 | p2 |
-| params_flow.rb:43:8:43:18 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:43:8:43:18 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:43:8:43:18 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
-| params_flow.rb:43:8:43:18 | call to [] | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:43:8:43:18 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:43:8:43:18 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
+| params_flow.rb:43:8:43:18 | call to [] | type tracker with call steps with content element 1 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
 | params_flow.rb:43:8:43:18 | call to [] | type tracker without call steps | params_flow.rb:43:8:43:18 | call to [] |
 | params_flow.rb:43:8:43:18 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:44:23:44:27 | * ... |
-| params_flow.rb:43:8:43:18 | call to [] | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:44:1:44:28 | synthetic splat argument |
+| params_flow.rb:43:8:43:18 | call to [] | type tracker without call steps with content element 1 | params_flow.rb:44:1:44:28 | synthetic splat argument |
 | params_flow.rb:43:8:43:18 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:43:8:43:18 | synthetic splat argument | type tracker with call steps | params_flow.rb:9:20:9:21 | p2 |
-| params_flow.rb:43:8:43:18 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:43:8:43:18 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:43:8:43:18 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
-| params_flow.rb:43:8:43:18 | synthetic splat argument | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:43:8:43:18 | synthetic splat argument | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:43:8:43:18 | synthetic splat argument | type tracker with call steps with content element 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
+| params_flow.rb:43:8:43:18 | synthetic splat argument | type tracker with call steps with content element 1 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
 | params_flow.rb:43:8:43:18 | synthetic splat argument | type tracker without call steps | params_flow.rb:43:8:43:18 | call to [] |
 | params_flow.rb:43:8:43:18 | synthetic splat argument | type tracker without call steps | params_flow.rb:43:8:43:18 | synthetic splat argument |
 | params_flow.rb:43:8:43:18 | synthetic splat argument | type tracker without call steps with content element 0 or unknown | params_flow.rb:44:23:44:27 | * ... |
-| params_flow.rb:43:8:43:18 | synthetic splat argument | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:44:1:44:28 | synthetic splat argument |
+| params_flow.rb:43:8:43:18 | synthetic splat argument | type tracker without call steps with content element 1 | params_flow.rb:44:1:44:28 | synthetic splat argument |
 | params_flow.rb:43:9:43:17 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:43:9:43:17 | call to taint | type tracker with call steps | params_flow.rb:9:20:9:21 | p2 |
-| params_flow.rb:43:9:43:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:43:9:43:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:43:9:43:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
-| params_flow.rb:43:9:43:17 | call to taint | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:43:9:43:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:43:9:43:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
+| params_flow.rb:43:9:43:17 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
 | params_flow.rb:43:9:43:17 | call to taint | type tracker without call steps | params_flow.rb:43:9:43:17 | call to taint |
 | params_flow.rb:43:9:43:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:43:8:43:18 | call to [] |
 | params_flow.rb:43:9:43:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:43:8:43:18 | synthetic splat argument |
 | params_flow.rb:43:9:43:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:44:23:44:27 | * ... |
-| params_flow.rb:43:9:43:17 | call to taint | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:44:1:44:28 | synthetic splat argument |
-| params_flow.rb:43:9:43:17 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:43:9:43:17 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:44:1:44:28 | synthetic splat argument |
 | params_flow.rb:43:9:43:17 | synthetic splat argument | type tracker without call steps | params_flow.rb:43:9:43:17 | synthetic splat argument |
 | params_flow.rb:43:15:43:16 | 17 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:43:15:43:16 | 17 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:43:15:43:16 | 17 | type tracker with call steps | params_flow.rb:9:20:9:21 | p2 |
-| params_flow.rb:43:15:43:16 | 17 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:43:15:43:16 | 17 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:43:15:43:16 | 17 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:43:15:43:16 | 17 | type tracker with call steps with content splat position 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
-| params_flow.rb:43:15:43:16 | 17 | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:43:15:43:16 | 17 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:43:15:43:16 | 17 | type tracker with call steps with content element 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
+| params_flow.rb:43:15:43:16 | 17 | type tracker with call steps with content element 1 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
 | params_flow.rb:43:15:43:16 | 17 | type tracker without call steps | params_flow.rb:43:9:43:17 | call to taint |
 | params_flow.rb:43:15:43:16 | 17 | type tracker without call steps | params_flow.rb:43:15:43:16 | 17 |
 | params_flow.rb:43:15:43:16 | 17 | type tracker without call steps with content element 0 | params_flow.rb:43:8:43:18 | call to [] |
 | params_flow.rb:43:15:43:16 | 17 | type tracker without call steps with content element 0 | params_flow.rb:43:8:43:18 | synthetic splat argument |
+| params_flow.rb:43:15:43:16 | 17 | type tracker without call steps with content element 0 | params_flow.rb:43:9:43:17 | synthetic splat argument |
 | params_flow.rb:43:15:43:16 | 17 | type tracker without call steps with content element 0 | params_flow.rb:44:23:44:27 | * ... |
-| params_flow.rb:43:15:43:16 | 17 | type tracker without call steps with content splat position 0 | params_flow.rb:43:9:43:17 | synthetic splat argument |
-| params_flow.rb:43:15:43:16 | 17 | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:44:1:44:28 | synthetic splat argument |
+| params_flow.rb:43:15:43:16 | 17 | type tracker without call steps with content element 1 | params_flow.rb:44:1:44:28 | synthetic splat argument |
 | params_flow.rb:44:1:44:28 | call to positional | type tracker without call steps | params_flow.rb:44:1:44:28 | call to positional |
 | params_flow.rb:44:1:44:28 | synthetic splat argument | type tracker with call steps | params_flow.rb:9:1:12:3 | synthetic splat parameter |
 | params_flow.rb:44:1:44:28 | synthetic splat argument | type tracker without call steps | params_flow.rb:44:1:44:28 | synthetic splat argument |
 | params_flow.rb:44:12:44:20 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:44:12:44:20 | call to taint | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
-| params_flow.rb:44:12:44:20 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:44:12:44:20 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:44:12:44:20 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
-| params_flow.rb:44:12:44:20 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
+| params_flow.rb:44:12:44:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:44:12:44:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:44:12:44:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
 | params_flow.rb:44:12:44:20 | call to taint | type tracker without call steps | params_flow.rb:44:12:44:20 | call to taint |
-| params_flow.rb:44:12:44:20 | call to taint | type tracker without call steps with content splat position 0 | params_flow.rb:44:1:44:28 | synthetic splat argument |
-| params_flow.rb:44:12:44:20 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:44:12:44:20 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:44:1:44:28 | synthetic splat argument |
 | params_flow.rb:44:12:44:20 | synthetic splat argument | type tracker without call steps | params_flow.rb:44:12:44:20 | synthetic splat argument |
 | params_flow.rb:44:18:44:19 | 16 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:44:18:44:19 | 16 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:44:18:44:19 | 16 | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
-| params_flow.rb:44:18:44:19 | 16 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:44:18:44:19 | 16 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:44:18:44:19 | 16 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:44:18:44:19 | 16 | type tracker with call steps with content splat position 0 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
-| params_flow.rb:44:18:44:19 | 16 | type tracker with call steps with content splat position 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
+| params_flow.rb:44:18:44:19 | 16 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:44:18:44:19 | 16 | type tracker with call steps with content element 0 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
+| params_flow.rb:44:18:44:19 | 16 | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
 | params_flow.rb:44:18:44:19 | 16 | type tracker without call steps | params_flow.rb:44:12:44:20 | call to taint |
 | params_flow.rb:44:18:44:19 | 16 | type tracker without call steps | params_flow.rb:44:18:44:19 | 16 |
-| params_flow.rb:44:18:44:19 | 16 | type tracker without call steps with content splat position 0 | params_flow.rb:44:1:44:28 | synthetic splat argument |
-| params_flow.rb:44:18:44:19 | 16 | type tracker without call steps with content splat position 0 | params_flow.rb:44:12:44:20 | synthetic splat argument |
+| params_flow.rb:44:18:44:19 | 16 | type tracker without call steps with content element 0 | params_flow.rb:44:1:44:28 | synthetic splat argument |
+| params_flow.rb:44:18:44:19 | 16 | type tracker without call steps with content element 0 | params_flow.rb:44:12:44:20 | synthetic splat argument |
 | params_flow.rb:44:23:44:27 | * ... | type tracker without call steps | params_flow.rb:44:23:44:27 | * ... |
 | params_flow.rb:46:1:46:4 | args | type tracker without call steps | params_flow.rb:46:1:46:4 | args |
 | params_flow.rb:46:8:46:29 | Array | type tracker without call steps | params_flow.rb:46:8:46:29 | Array |
 | params_flow.rb:46:8:46:29 | call to [] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:46:8:46:29 | call to [] | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:46:8:46:29 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:46:8:46:29 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
 | params_flow.rb:46:8:46:29 | call to [] | type tracker with call steps with content element 0 or unknown | params_flow.rb:9:1:12:3 | synthetic splat parameter |
-| params_flow.rb:46:8:46:29 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:46:8:46:29 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:46:8:46:29 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
 | params_flow.rb:46:8:46:29 | call to [] | type tracker without call steps | params_flow.rb:46:8:46:29 | call to [] |
 | params_flow.rb:46:8:46:29 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:47:12:47:16 | * ... |
 | params_flow.rb:46:8:46:29 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:46:8:46:29 | synthetic splat argument | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:46:8:46:29 | synthetic splat argument | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:46:8:46:29 | synthetic splat argument | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
 | params_flow.rb:46:8:46:29 | synthetic splat argument | type tracker with call steps with content element 0 or unknown | params_flow.rb:9:1:12:3 | synthetic splat parameter |
-| params_flow.rb:46:8:46:29 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:46:8:46:29 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:46:8:46:29 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
 | params_flow.rb:46:8:46:29 | synthetic splat argument | type tracker without call steps | params_flow.rb:46:8:46:29 | call to [] |
 | params_flow.rb:46:8:46:29 | synthetic splat argument | type tracker without call steps | params_flow.rb:46:8:46:29 | synthetic splat argument |
 | params_flow.rb:46:8:46:29 | synthetic splat argument | type tracker without call steps with content element 0 or unknown | params_flow.rb:47:12:47:16 | * ... |
 | params_flow.rb:46:9:46:17 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:46:9:46:17 | call to taint | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:46:9:46:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:46:9:46:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
-| params_flow.rb:46:9:46:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:46:9:46:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:46:9:46:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
+| params_flow.rb:46:9:46:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
 | params_flow.rb:46:9:46:17 | call to taint | type tracker without call steps | params_flow.rb:46:9:46:17 | call to taint |
 | params_flow.rb:46:9:46:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:46:8:46:29 | call to [] |
 | params_flow.rb:46:9:46:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:46:8:46:29 | synthetic splat argument |
 | params_flow.rb:46:9:46:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:47:12:47:16 | * ... |
-| params_flow.rb:46:9:46:17 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:46:9:46:17 | synthetic splat argument | type tracker without call steps | params_flow.rb:46:9:46:17 | synthetic splat argument |
 | params_flow.rb:46:15:46:16 | 18 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:46:15:46:16 | 18 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:46:15:46:16 | 18 | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:46:15:46:16 | 18 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:46:15:46:16 | 18 | type tracker with call steps with content element 0 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
-| params_flow.rb:46:15:46:16 | 18 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:46:15:46:16 | 18 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:46:15:46:16 | 18 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:46:15:46:16 | 18 | type tracker with call steps with content splat position 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
+| params_flow.rb:46:15:46:16 | 18 | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
 | params_flow.rb:46:15:46:16 | 18 | type tracker without call steps | params_flow.rb:46:9:46:17 | call to taint |
 | params_flow.rb:46:15:46:16 | 18 | type tracker without call steps | params_flow.rb:46:15:46:16 | 18 |
 | params_flow.rb:46:15:46:16 | 18 | type tracker without call steps with content element 0 | params_flow.rb:46:8:46:29 | call to [] |
 | params_flow.rb:46:15:46:16 | 18 | type tracker without call steps with content element 0 | params_flow.rb:46:8:46:29 | synthetic splat argument |
+| params_flow.rb:46:15:46:16 | 18 | type tracker without call steps with content element 0 | params_flow.rb:46:9:46:17 | synthetic splat argument |
 | params_flow.rb:46:15:46:16 | 18 | type tracker without call steps with content element 0 | params_flow.rb:47:12:47:16 | * ... |
-| params_flow.rb:46:15:46:16 | 18 | type tracker without call steps with content splat position 0 | params_flow.rb:46:9:46:17 | synthetic splat argument |
 | params_flow.rb:46:20:46:28 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:46:20:46:28 | call to taint | type tracker with call steps | params_flow.rb:9:20:9:21 | p2 |
+| params_flow.rb:46:20:46:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:46:20:46:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
 | params_flow.rb:46:20:46:28 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
-| params_flow.rb:46:20:46:28 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:46:20:46:28 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:46:20:46:28 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
 | params_flow.rb:46:20:46:28 | call to taint | type tracker without call steps | params_flow.rb:46:20:46:28 | call to taint |
 | params_flow.rb:46:20:46:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:46:8:46:29 | call to [] |
 | params_flow.rb:46:20:46:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:46:8:46:29 | synthetic splat argument |
 | params_flow.rb:46:20:46:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:47:12:47:16 | * ... |
-| params_flow.rb:46:20:46:28 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:46:20:46:28 | synthetic splat argument | type tracker without call steps | params_flow.rb:46:20:46:28 | synthetic splat argument |
 | params_flow.rb:46:26:46:27 | 19 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:46:26:46:27 | 19 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:46:26:46:27 | 19 | type tracker with call steps | params_flow.rb:9:20:9:21 | p2 |
+| params_flow.rb:46:26:46:27 | 19 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:46:26:46:27 | 19 | type tracker with call steps with content element 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
 | params_flow.rb:46:26:46:27 | 19 | type tracker with call steps with content element 1 | params_flow.rb:9:1:12:3 | synthetic splat parameter |
-| params_flow.rb:46:26:46:27 | 19 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:46:26:46:27 | 19 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:46:26:46:27 | 19 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:46:26:46:27 | 19 | type tracker with call steps with content splat position 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
 | params_flow.rb:46:26:46:27 | 19 | type tracker without call steps | params_flow.rb:46:20:46:28 | call to taint |
 | params_flow.rb:46:26:46:27 | 19 | type tracker without call steps | params_flow.rb:46:26:46:27 | 19 |
+| params_flow.rb:46:26:46:27 | 19 | type tracker without call steps with content element 0 | params_flow.rb:46:20:46:28 | synthetic splat argument |
 | params_flow.rb:46:26:46:27 | 19 | type tracker without call steps with content element 1 | params_flow.rb:46:8:46:29 | call to [] |
 | params_flow.rb:46:26:46:27 | 19 | type tracker without call steps with content element 1 | params_flow.rb:46:8:46:29 | synthetic splat argument |
 | params_flow.rb:46:26:46:27 | 19 | type tracker without call steps with content element 1 | params_flow.rb:47:12:47:16 | * ... |
-| params_flow.rb:46:26:46:27 | 19 | type tracker without call steps with content splat position 0 | params_flow.rb:46:20:46:28 | synthetic splat argument |
 | params_flow.rb:47:1:47:17 | call to positional | type tracker without call steps | params_flow.rb:47:1:47:17 | call to positional |
 | params_flow.rb:47:12:47:16 | * ... | type tracker with call steps | params_flow.rb:9:1:12:3 | synthetic splat parameter |
 | params_flow.rb:47:12:47:16 | * ... | type tracker without call steps | params_flow.rb:47:12:47:16 | * ... |
@@ -1294,271 +1164,233 @@ track
 | params_flow.rb:49:1:53:3 | self in posargs | type tracker without call steps | params_flow.rb:49:1:53:3 | self in posargs |
 | params_flow.rb:49:1:53:3 | synthetic splat parameter | type tracker without call steps | params_flow.rb:49:1:53:3 | synthetic splat parameter |
 | params_flow.rb:49:13:49:14 | p1 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:49:13:49:14 | p1 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:49:13:49:14 | p1 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:49:13:49:14 | p1 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:49:13:49:14 | p1 | type tracker without call steps | params_flow.rb:49:13:49:14 | p1 |
 | params_flow.rb:49:13:49:14 | p1 | type tracker without call steps | params_flow.rb:49:13:49:14 | p1 |
-| params_flow.rb:49:13:49:14 | p1 | type tracker without call steps with content splat position 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
+| params_flow.rb:49:13:49:14 | p1 | type tracker without call steps with content element 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
 | params_flow.rb:49:17:49:24 | *posargs | type tracker without call steps | params_flow.rb:49:17:49:24 | *posargs |
 | params_flow.rb:49:18:49:24 | posargs | type tracker without call steps | params_flow.rb:49:18:49:24 | posargs |
 | params_flow.rb:50:5:50:11 | call to sink | type tracker without call steps | params_flow.rb:50:5:50:11 | call to sink |
-| params_flow.rb:50:5:50:11 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:50:5:50:11 | synthetic splat argument | type tracker without call steps | params_flow.rb:50:5:50:11 | synthetic splat argument |
 | params_flow.rb:51:5:51:21 | call to sink | type tracker without call steps | params_flow.rb:51:5:51:21 | call to sink |
-| params_flow.rb:51:5:51:21 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:51:5:51:21 | synthetic splat argument | type tracker without call steps | params_flow.rb:51:5:51:21 | synthetic splat argument |
 | params_flow.rb:51:11:51:20 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:51:11:51:20 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:51:11:51:20 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:51:11:51:20 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:51:11:51:20 | ...[...] | type tracker without call steps | params_flow.rb:51:11:51:20 | ...[...] |
-| params_flow.rb:51:11:51:20 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
+| params_flow.rb:51:11:51:20 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
 | params_flow.rb:51:11:51:20 | synthetic splat argument | type tracker without call steps | params_flow.rb:51:11:51:20 | synthetic splat argument |
 | params_flow.rb:51:19:51:19 | 0 | type tracker without call steps | params_flow.rb:51:19:51:19 | 0 |
-| params_flow.rb:51:19:51:19 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:51:11:51:20 | synthetic splat argument |
+| params_flow.rb:51:19:51:19 | 0 | type tracker without call steps with content element 0 | params_flow.rb:51:11:51:20 | synthetic splat argument |
 | params_flow.rb:52:5:52:21 | call to sink | type tracker without call steps | params_flow.rb:52:5:52:21 | call to sink |
 | params_flow.rb:52:5:52:21 | call to sink | type tracker without call steps | params_flow.rb:55:1:55:29 | call to posargs |
 | params_flow.rb:52:5:52:21 | call to sink | type tracker without call steps | params_flow.rb:58:1:58:25 | call to posargs |
 | params_flow.rb:52:5:52:21 | call to sink | type tracker without call steps | params_flow.rb:61:1:61:14 | call to posargs |
-| params_flow.rb:52:5:52:21 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:52:5:52:21 | synthetic splat argument | type tracker without call steps | params_flow.rb:52:5:52:21 | synthetic splat argument |
 | params_flow.rb:52:11:52:20 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:52:11:52:20 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:52:11:52:20 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:52:11:52:20 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:52:11:52:20 | ...[...] | type tracker without call steps | params_flow.rb:52:11:52:20 | ...[...] |
-| params_flow.rb:52:11:52:20 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:52:5:52:21 | synthetic splat argument |
+| params_flow.rb:52:11:52:20 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:52:5:52:21 | synthetic splat argument |
 | params_flow.rb:52:11:52:20 | synthetic splat argument | type tracker without call steps | params_flow.rb:52:11:52:20 | synthetic splat argument |
 | params_flow.rb:52:19:52:19 | 1 | type tracker without call steps | params_flow.rb:52:19:52:19 | 1 |
-| params_flow.rb:52:19:52:19 | 1 | type tracker without call steps with content splat position 0 | params_flow.rb:52:11:52:20 | synthetic splat argument |
+| params_flow.rb:52:19:52:19 | 1 | type tracker without call steps with content element 0 | params_flow.rb:52:11:52:20 | synthetic splat argument |
 | params_flow.rb:55:1:55:29 | call to posargs | type tracker without call steps | params_flow.rb:55:1:55:29 | call to posargs |
 | params_flow.rb:55:1:55:29 | synthetic splat argument | type tracker with call steps | params_flow.rb:49:1:53:3 | synthetic splat parameter |
 | params_flow.rb:55:1:55:29 | synthetic splat argument | type tracker without call steps | params_flow.rb:55:1:55:29 | synthetic splat argument |
 | params_flow.rb:55:9:55:17 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:55:9:55:17 | call to taint | type tracker with call steps | params_flow.rb:49:13:49:14 | p1 |
-| params_flow.rb:55:9:55:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:55:9:55:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:55:9:55:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
-| params_flow.rb:55:9:55:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
+| params_flow.rb:55:9:55:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:55:9:55:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
+| params_flow.rb:55:9:55:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
 | params_flow.rb:55:9:55:17 | call to taint | type tracker without call steps | params_flow.rb:55:9:55:17 | call to taint |
-| params_flow.rb:55:9:55:17 | call to taint | type tracker without call steps with content splat position 0 | params_flow.rb:55:1:55:29 | synthetic splat argument |
-| params_flow.rb:55:9:55:17 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:55:9:55:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:55:1:55:29 | synthetic splat argument |
 | params_flow.rb:55:9:55:17 | synthetic splat argument | type tracker without call steps | params_flow.rb:55:9:55:17 | synthetic splat argument |
 | params_flow.rb:55:15:55:16 | 20 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:55:15:55:16 | 20 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:55:15:55:16 | 20 | type tracker with call steps | params_flow.rb:49:13:49:14 | p1 |
-| params_flow.rb:55:15:55:16 | 20 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:55:15:55:16 | 20 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:55:15:55:16 | 20 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:55:15:55:16 | 20 | type tracker with call steps with content splat position 0 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
-| params_flow.rb:55:15:55:16 | 20 | type tracker with call steps with content splat position 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
+| params_flow.rb:55:15:55:16 | 20 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:55:15:55:16 | 20 | type tracker with call steps with content element 0 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
+| params_flow.rb:55:15:55:16 | 20 | type tracker with call steps with content element 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
 | params_flow.rb:55:15:55:16 | 20 | type tracker without call steps | params_flow.rb:55:9:55:17 | call to taint |
 | params_flow.rb:55:15:55:16 | 20 | type tracker without call steps | params_flow.rb:55:15:55:16 | 20 |
-| params_flow.rb:55:15:55:16 | 20 | type tracker without call steps with content splat position 0 | params_flow.rb:55:1:55:29 | synthetic splat argument |
-| params_flow.rb:55:15:55:16 | 20 | type tracker without call steps with content splat position 0 | params_flow.rb:55:9:55:17 | synthetic splat argument |
+| params_flow.rb:55:15:55:16 | 20 | type tracker without call steps with content element 0 | params_flow.rb:55:1:55:29 | synthetic splat argument |
+| params_flow.rb:55:15:55:16 | 20 | type tracker without call steps with content element 0 | params_flow.rb:55:9:55:17 | synthetic splat argument |
 | params_flow.rb:55:20:55:28 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:55:20:55:28 | call to taint | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
+| params_flow.rb:55:20:55:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:55:20:55:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:55:20:55:28 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:55:20:55:28 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:55:20:55:28 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
-| params_flow.rb:55:20:55:28 | call to taint | type tracker with call steps with content splat position 1 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
+| params_flow.rb:55:20:55:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
+| params_flow.rb:55:20:55:28 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
 | params_flow.rb:55:20:55:28 | call to taint | type tracker without call steps | params_flow.rb:55:20:55:28 | call to taint |
-| params_flow.rb:55:20:55:28 | call to taint | type tracker without call steps with content splat position 1 | params_flow.rb:55:1:55:29 | synthetic splat argument |
-| params_flow.rb:55:20:55:28 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:55:20:55:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:55:1:55:29 | synthetic splat argument |
 | params_flow.rb:55:20:55:28 | synthetic splat argument | type tracker without call steps | params_flow.rb:55:20:55:28 | synthetic splat argument |
 | params_flow.rb:55:26:55:27 | 21 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:55:26:55:27 | 21 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:55:26:55:27 | 21 | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
+| params_flow.rb:55:26:55:27 | 21 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:55:26:55:27 | 21 | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:55:26:55:27 | 21 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:55:26:55:27 | 21 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:55:26:55:27 | 21 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:55:26:55:27 | 21 | type tracker with call steps with content splat position 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
-| params_flow.rb:55:26:55:27 | 21 | type tracker with call steps with content splat position 1 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
+| params_flow.rb:55:26:55:27 | 21 | type tracker with call steps with content element 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
+| params_flow.rb:55:26:55:27 | 21 | type tracker with call steps with content element 1 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
 | params_flow.rb:55:26:55:27 | 21 | type tracker without call steps | params_flow.rb:55:20:55:28 | call to taint |
 | params_flow.rb:55:26:55:27 | 21 | type tracker without call steps | params_flow.rb:55:26:55:27 | 21 |
-| params_flow.rb:55:26:55:27 | 21 | type tracker without call steps with content splat position 0 | params_flow.rb:55:20:55:28 | synthetic splat argument |
-| params_flow.rb:55:26:55:27 | 21 | type tracker without call steps with content splat position 1 | params_flow.rb:55:1:55:29 | synthetic splat argument |
+| params_flow.rb:55:26:55:27 | 21 | type tracker without call steps with content element 0 | params_flow.rb:55:20:55:28 | synthetic splat argument |
+| params_flow.rb:55:26:55:27 | 21 | type tracker without call steps with content element 1 | params_flow.rb:55:1:55:29 | synthetic splat argument |
 | params_flow.rb:57:1:57:4 | args | type tracker without call steps | params_flow.rb:57:1:57:4 | args |
 | params_flow.rb:57:8:57:18 | Array | type tracker without call steps | params_flow.rb:57:8:57:18 | Array |
 | params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
+| params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
 | params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps with content element 0 or unknown | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
-| params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:49:1:53:3 | synthetic splat parameter |
+| params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps with content element 1 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
 | params_flow.rb:57:8:57:18 | call to [] | type tracker without call steps | params_flow.rb:57:8:57:18 | call to [] |
 | params_flow.rb:57:8:57:18 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:58:20:58:24 | * ... |
-| params_flow.rb:57:8:57:18 | call to [] | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:58:1:58:25 | synthetic splat argument |
+| params_flow.rb:57:8:57:18 | call to [] | type tracker without call steps with content element 1 | params_flow.rb:58:1:58:25 | synthetic splat argument |
 | params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
+| params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker with call steps with content element 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
 | params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker with call steps with content element 0 or unknown | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
-| params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:49:1:53:3 | synthetic splat parameter |
+| params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker with call steps with content element 1 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
 | params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker without call steps | params_flow.rb:57:8:57:18 | call to [] |
 | params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker without call steps | params_flow.rb:57:8:57:18 | synthetic splat argument |
 | params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker without call steps with content element 0 or unknown | params_flow.rb:58:20:58:24 | * ... |
-| params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:58:1:58:25 | synthetic splat argument |
+| params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker without call steps with content element 1 | params_flow.rb:58:1:58:25 | synthetic splat argument |
 | params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
+| params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
-| params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:49:1:53:3 | synthetic splat parameter |
+| params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
+| params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
 | params_flow.rb:57:9:57:17 | call to taint | type tracker without call steps | params_flow.rb:57:9:57:17 | call to taint |
 | params_flow.rb:57:9:57:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:57:8:57:18 | call to [] |
 | params_flow.rb:57:9:57:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:57:8:57:18 | synthetic splat argument |
 | params_flow.rb:57:9:57:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:58:20:58:24 | * ... |
-| params_flow.rb:57:9:57:17 | call to taint | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:58:1:58:25 | synthetic splat argument |
-| params_flow.rb:57:9:57:17 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:57:9:57:17 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:58:1:58:25 | synthetic splat argument |
 | params_flow.rb:57:9:57:17 | synthetic splat argument | type tracker without call steps | params_flow.rb:57:9:57:17 | synthetic splat argument |
 | params_flow.rb:57:15:57:16 | 22 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:57:15:57:16 | 22 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:57:15:57:16 | 22 | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
+| params_flow.rb:57:15:57:16 | 22 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:57:15:57:16 | 22 | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:57:15:57:16 | 22 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:57:15:57:16 | 22 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:57:15:57:16 | 22 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:57:15:57:16 | 22 | type tracker with call steps with content splat position 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
-| params_flow.rb:57:15:57:16 | 22 | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:49:1:53:3 | synthetic splat parameter |
+| params_flow.rb:57:15:57:16 | 22 | type tracker with call steps with content element 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
+| params_flow.rb:57:15:57:16 | 22 | type tracker with call steps with content element 1 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
 | params_flow.rb:57:15:57:16 | 22 | type tracker without call steps | params_flow.rb:57:9:57:17 | call to taint |
 | params_flow.rb:57:15:57:16 | 22 | type tracker without call steps | params_flow.rb:57:15:57:16 | 22 |
 | params_flow.rb:57:15:57:16 | 22 | type tracker without call steps with content element 0 | params_flow.rb:57:8:57:18 | call to [] |
 | params_flow.rb:57:15:57:16 | 22 | type tracker without call steps with content element 0 | params_flow.rb:57:8:57:18 | synthetic splat argument |
+| params_flow.rb:57:15:57:16 | 22 | type tracker without call steps with content element 0 | params_flow.rb:57:9:57:17 | synthetic splat argument |
 | params_flow.rb:57:15:57:16 | 22 | type tracker without call steps with content element 0 | params_flow.rb:58:20:58:24 | * ... |
-| params_flow.rb:57:15:57:16 | 22 | type tracker without call steps with content splat position 0 | params_flow.rb:57:9:57:17 | synthetic splat argument |
-| params_flow.rb:57:15:57:16 | 22 | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:58:1:58:25 | synthetic splat argument |
+| params_flow.rb:57:15:57:16 | 22 | type tracker without call steps with content element 1 | params_flow.rb:58:1:58:25 | synthetic splat argument |
 | params_flow.rb:58:1:58:25 | call to posargs | type tracker without call steps | params_flow.rb:58:1:58:25 | call to posargs |
 | params_flow.rb:58:1:58:25 | synthetic splat argument | type tracker with call steps | params_flow.rb:49:1:53:3 | synthetic splat parameter |
 | params_flow.rb:58:1:58:25 | synthetic splat argument | type tracker without call steps | params_flow.rb:58:1:58:25 | synthetic splat argument |
 | params_flow.rb:58:9:58:17 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:58:9:58:17 | call to taint | type tracker with call steps | params_flow.rb:49:13:49:14 | p1 |
-| params_flow.rb:58:9:58:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:58:9:58:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:58:9:58:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
-| params_flow.rb:58:9:58:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
+| params_flow.rb:58:9:58:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:58:9:58:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
+| params_flow.rb:58:9:58:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
 | params_flow.rb:58:9:58:17 | call to taint | type tracker without call steps | params_flow.rb:58:9:58:17 | call to taint |
-| params_flow.rb:58:9:58:17 | call to taint | type tracker without call steps with content splat position 0 | params_flow.rb:58:1:58:25 | synthetic splat argument |
-| params_flow.rb:58:9:58:17 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:58:9:58:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:58:1:58:25 | synthetic splat argument |
 | params_flow.rb:58:9:58:17 | synthetic splat argument | type tracker without call steps | params_flow.rb:58:9:58:17 | synthetic splat argument |
 | params_flow.rb:58:15:58:16 | 23 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:58:15:58:16 | 23 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:58:15:58:16 | 23 | type tracker with call steps | params_flow.rb:49:13:49:14 | p1 |
-| params_flow.rb:58:15:58:16 | 23 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:58:15:58:16 | 23 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:58:15:58:16 | 23 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:58:15:58:16 | 23 | type tracker with call steps with content splat position 0 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
-| params_flow.rb:58:15:58:16 | 23 | type tracker with call steps with content splat position 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
+| params_flow.rb:58:15:58:16 | 23 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:58:15:58:16 | 23 | type tracker with call steps with content element 0 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
+| params_flow.rb:58:15:58:16 | 23 | type tracker with call steps with content element 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
 | params_flow.rb:58:15:58:16 | 23 | type tracker without call steps | params_flow.rb:58:9:58:17 | call to taint |
 | params_flow.rb:58:15:58:16 | 23 | type tracker without call steps | params_flow.rb:58:15:58:16 | 23 |
-| params_flow.rb:58:15:58:16 | 23 | type tracker without call steps with content splat position 0 | params_flow.rb:58:1:58:25 | synthetic splat argument |
-| params_flow.rb:58:15:58:16 | 23 | type tracker without call steps with content splat position 0 | params_flow.rb:58:9:58:17 | synthetic splat argument |
+| params_flow.rb:58:15:58:16 | 23 | type tracker without call steps with content element 0 | params_flow.rb:58:1:58:25 | synthetic splat argument |
+| params_flow.rb:58:15:58:16 | 23 | type tracker without call steps with content element 0 | params_flow.rb:58:9:58:17 | synthetic splat argument |
 | params_flow.rb:58:20:58:24 | * ... | type tracker with call steps | params_flow.rb:49:17:49:24 | *posargs |
 | params_flow.rb:58:20:58:24 | * ... | type tracker without call steps | params_flow.rb:58:20:58:24 | * ... |
 | params_flow.rb:60:1:60:4 | args | type tracker without call steps | params_flow.rb:60:1:60:4 | args |
 | params_flow.rb:60:8:60:29 | Array | type tracker without call steps | params_flow.rb:60:8:60:29 | Array |
 | params_flow.rb:60:8:60:29 | call to [] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:60:8:60:29 | call to [] | type tracker with call steps | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:60:8:60:29 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:60:8:60:29 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
 | params_flow.rb:60:8:60:29 | call to [] | type tracker with call steps with content element 0 or unknown | params_flow.rb:49:1:53:3 | synthetic splat parameter |
-| params_flow.rb:60:8:60:29 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:60:8:60:29 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:60:8:60:29 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
 | params_flow.rb:60:8:60:29 | call to [] | type tracker without call steps | params_flow.rb:60:8:60:29 | call to [] |
 | params_flow.rb:60:8:60:29 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:61:9:61:13 | * ... |
 | params_flow.rb:60:8:60:29 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:60:8:60:29 | synthetic splat argument | type tracker with call steps | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:60:8:60:29 | synthetic splat argument | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:60:8:60:29 | synthetic splat argument | type tracker with call steps with content element 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
 | params_flow.rb:60:8:60:29 | synthetic splat argument | type tracker with call steps with content element 0 or unknown | params_flow.rb:49:1:53:3 | synthetic splat parameter |
-| params_flow.rb:60:8:60:29 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:60:8:60:29 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:60:8:60:29 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
 | params_flow.rb:60:8:60:29 | synthetic splat argument | type tracker without call steps | params_flow.rb:60:8:60:29 | call to [] |
 | params_flow.rb:60:8:60:29 | synthetic splat argument | type tracker without call steps | params_flow.rb:60:8:60:29 | synthetic splat argument |
 | params_flow.rb:60:8:60:29 | synthetic splat argument | type tracker without call steps with content element 0 or unknown | params_flow.rb:61:9:61:13 | * ... |
 | params_flow.rb:60:9:60:17 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:60:9:60:17 | call to taint | type tracker with call steps | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:60:9:60:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:60:9:60:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
-| params_flow.rb:60:9:60:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:60:9:60:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:60:9:60:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
+| params_flow.rb:60:9:60:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
 | params_flow.rb:60:9:60:17 | call to taint | type tracker without call steps | params_flow.rb:60:9:60:17 | call to taint |
 | params_flow.rb:60:9:60:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:60:8:60:29 | call to [] |
 | params_flow.rb:60:9:60:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:60:8:60:29 | synthetic splat argument |
 | params_flow.rb:60:9:60:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:61:9:61:13 | * ... |
-| params_flow.rb:60:9:60:17 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:60:9:60:17 | synthetic splat argument | type tracker without call steps | params_flow.rb:60:9:60:17 | synthetic splat argument |
 | params_flow.rb:60:15:60:16 | 24 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:60:15:60:16 | 24 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:60:15:60:16 | 24 | type tracker with call steps | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:60:15:60:16 | 24 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:60:15:60:16 | 24 | type tracker with call steps with content element 0 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
-| params_flow.rb:60:15:60:16 | 24 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:60:15:60:16 | 24 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:60:15:60:16 | 24 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:60:15:60:16 | 24 | type tracker with call steps with content splat position 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
+| params_flow.rb:60:15:60:16 | 24 | type tracker with call steps with content element 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
 | params_flow.rb:60:15:60:16 | 24 | type tracker without call steps | params_flow.rb:60:9:60:17 | call to taint |
 | params_flow.rb:60:15:60:16 | 24 | type tracker without call steps | params_flow.rb:60:15:60:16 | 24 |
 | params_flow.rb:60:15:60:16 | 24 | type tracker without call steps with content element 0 | params_flow.rb:60:8:60:29 | call to [] |
 | params_flow.rb:60:15:60:16 | 24 | type tracker without call steps with content element 0 | params_flow.rb:60:8:60:29 | synthetic splat argument |
+| params_flow.rb:60:15:60:16 | 24 | type tracker without call steps with content element 0 | params_flow.rb:60:9:60:17 | synthetic splat argument |
 | params_flow.rb:60:15:60:16 | 24 | type tracker without call steps with content element 0 | params_flow.rb:61:9:61:13 | * ... |
-| params_flow.rb:60:15:60:16 | 24 | type tracker without call steps with content splat position 0 | params_flow.rb:60:9:60:17 | synthetic splat argument |
 | params_flow.rb:60:20:60:28 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:60:20:60:28 | call to taint | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
+| params_flow.rb:60:20:60:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:60:20:60:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:60:20:60:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
 | params_flow.rb:60:20:60:28 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
-| params_flow.rb:60:20:60:28 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:60:20:60:28 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:60:20:60:28 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
 | params_flow.rb:60:20:60:28 | call to taint | type tracker without call steps | params_flow.rb:60:20:60:28 | call to taint |
 | params_flow.rb:60:20:60:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:60:8:60:29 | call to [] |
 | params_flow.rb:60:20:60:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:60:8:60:29 | synthetic splat argument |
 | params_flow.rb:60:20:60:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:61:9:61:13 | * ... |
-| params_flow.rb:60:20:60:28 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:60:20:60:28 | synthetic splat argument | type tracker without call steps | params_flow.rb:60:20:60:28 | synthetic splat argument |
 | params_flow.rb:60:26:60:27 | 25 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:60:26:60:27 | 25 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:60:26:60:27 | 25 | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
+| params_flow.rb:60:26:60:27 | 25 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:60:26:60:27 | 25 | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:60:26:60:27 | 25 | type tracker with call steps with content element 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
 | params_flow.rb:60:26:60:27 | 25 | type tracker with call steps with content element 1 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
-| params_flow.rb:60:26:60:27 | 25 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:60:26:60:27 | 25 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:60:26:60:27 | 25 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:60:26:60:27 | 25 | type tracker with call steps with content splat position 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
 | params_flow.rb:60:26:60:27 | 25 | type tracker without call steps | params_flow.rb:60:20:60:28 | call to taint |
 | params_flow.rb:60:26:60:27 | 25 | type tracker without call steps | params_flow.rb:60:26:60:27 | 25 |
+| params_flow.rb:60:26:60:27 | 25 | type tracker without call steps with content element 0 | params_flow.rb:60:20:60:28 | synthetic splat argument |
 | params_flow.rb:60:26:60:27 | 25 | type tracker without call steps with content element 1 | params_flow.rb:60:8:60:29 | call to [] |
 | params_flow.rb:60:26:60:27 | 25 | type tracker without call steps with content element 1 | params_flow.rb:60:8:60:29 | synthetic splat argument |
 | params_flow.rb:60:26:60:27 | 25 | type tracker without call steps with content element 1 | params_flow.rb:61:9:61:13 | * ... |
-| params_flow.rb:60:26:60:27 | 25 | type tracker without call steps with content splat position 0 | params_flow.rb:60:20:60:28 | synthetic splat argument |
 | params_flow.rb:61:1:61:14 | call to posargs | type tracker without call steps | params_flow.rb:61:1:61:14 | call to posargs |
 | params_flow.rb:61:9:61:13 | * ... | type tracker with call steps | params_flow.rb:49:1:53:3 | synthetic splat parameter |
 | params_flow.rb:61:9:61:13 | * ... | type tracker without call steps | params_flow.rb:61:9:61:13 | * ... |
 | params_flow.rb:63:1:63:4 | args | type tracker without call steps | params_flow.rb:63:1:63:4 | args |
 | params_flow.rb:63:8:63:16 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:63:8:63:16 | call to taint | type tracker with call steps | params_flow.rb:65:10:65:13 | ...[...] |
+| params_flow.rb:63:8:63:16 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:63:8:63:16 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:65:5:65:13 | synthetic splat argument |
 | params_flow.rb:63:8:63:16 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:64:16:64:17 | *x |
-| params_flow.rb:63:8:63:16 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:63:8:63:16 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:63:8:63:16 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:65:5:65:13 | synthetic splat argument |
 | params_flow.rb:63:8:63:16 | call to taint | type tracker without call steps | params_flow.rb:63:8:63:16 | call to taint |
 | params_flow.rb:63:8:63:16 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:67:12:67:16 | * ... |
-| params_flow.rb:63:8:63:16 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:63:8:63:16 | synthetic splat argument | type tracker without call steps | params_flow.rb:63:8:63:16 | synthetic splat argument |
 | params_flow.rb:63:14:63:15 | 26 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:63:14:63:15 | 26 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:63:14:63:15 | 26 | type tracker with call steps | params_flow.rb:65:10:65:13 | ...[...] |
+| params_flow.rb:63:14:63:15 | 26 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:63:14:63:15 | 26 | type tracker with call steps with content element 0 | params_flow.rb:65:5:65:13 | synthetic splat argument |
 | params_flow.rb:63:14:63:15 | 26 | type tracker with call steps with content element 0 or unknown | params_flow.rb:64:16:64:17 | *x |
-| params_flow.rb:63:14:63:15 | 26 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:63:14:63:15 | 26 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:63:14:63:15 | 26 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:63:14:63:15 | 26 | type tracker with call steps with content splat position 0 | params_flow.rb:65:5:65:13 | synthetic splat argument |
 | params_flow.rb:63:14:63:15 | 26 | type tracker without call steps | params_flow.rb:63:8:63:16 | call to taint |
 | params_flow.rb:63:14:63:15 | 26 | type tracker without call steps | params_flow.rb:63:14:63:15 | 26 |
+| params_flow.rb:63:14:63:15 | 26 | type tracker without call steps with content element 0 | params_flow.rb:63:8:63:16 | synthetic splat argument |
 | params_flow.rb:63:14:63:15 | 26 | type tracker without call steps with content element 0 or unknown | params_flow.rb:67:12:67:16 | * ... |
-| params_flow.rb:63:14:63:15 | 26 | type tracker without call steps with content splat position 0 | params_flow.rb:63:8:63:16 | synthetic splat argument |
 | params_flow.rb:64:1:66:3 | &block | type tracker without call steps | params_flow.rb:64:1:66:3 | &block |
 | params_flow.rb:64:1:66:3 | self in splatstuff | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
 | params_flow.rb:64:1:66:3 | self in splatstuff | type tracker without call steps | params_flow.rb:64:1:66:3 | self in splatstuff |
@@ -1567,16 +1399,14 @@ track
 | params_flow.rb:64:17:64:17 | x | type tracker without call steps | params_flow.rb:64:17:64:17 | x |
 | params_flow.rb:65:5:65:13 | call to sink | type tracker without call steps | params_flow.rb:65:5:65:13 | call to sink |
 | params_flow.rb:65:5:65:13 | call to sink | type tracker without call steps | params_flow.rb:67:1:67:17 | call to splatstuff |
-| params_flow.rb:65:5:65:13 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:65:5:65:13 | synthetic splat argument | type tracker without call steps | params_flow.rb:65:5:65:13 | synthetic splat argument |
 | params_flow.rb:65:10:65:13 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:65:10:65:13 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:65:10:65:13 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:65:10:65:13 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:65:10:65:13 | ...[...] | type tracker without call steps | params_flow.rb:65:10:65:13 | ...[...] |
-| params_flow.rb:65:10:65:13 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:65:5:65:13 | synthetic splat argument |
+| params_flow.rb:65:10:65:13 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:65:5:65:13 | synthetic splat argument |
 | params_flow.rb:65:10:65:13 | synthetic splat argument | type tracker without call steps | params_flow.rb:65:10:65:13 | synthetic splat argument |
 | params_flow.rb:65:12:65:12 | 0 | type tracker without call steps | params_flow.rb:65:12:65:12 | 0 |
-| params_flow.rb:65:12:65:12 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:65:10:65:13 | synthetic splat argument |
+| params_flow.rb:65:12:65:12 | 0 | type tracker without call steps with content element 0 | params_flow.rb:65:10:65:13 | synthetic splat argument |
 | params_flow.rb:67:1:67:17 | call to splatstuff | type tracker without call steps | params_flow.rb:67:1:67:17 | call to splatstuff |
 | params_flow.rb:67:12:67:16 | * ... | type tracker with call steps | params_flow.rb:64:16:64:17 | *x |
 | params_flow.rb:67:12:67:16 | * ... | type tracker without call steps | params_flow.rb:67:12:67:16 | * ... |
@@ -1586,905 +1416,765 @@ track
 | params_flow.rb:69:1:76:3 | splatmid | type tracker without call steps | params_flow.rb:69:1:76:3 | splatmid |
 | params_flow.rb:69:1:76:3 | synthetic splat parameter | type tracker without call steps | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:69:14:69:14 | x | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:69:14:69:14 | x | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:69:14:69:14 | x | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:69:14:69:14 | x | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:69:14:69:14 | x | type tracker without call steps | params_flow.rb:69:14:69:14 | x |
 | params_flow.rb:69:14:69:14 | x | type tracker without call steps | params_flow.rb:69:14:69:14 | x |
-| params_flow.rb:69:14:69:14 | x | type tracker without call steps with content splat position 0 | params_flow.rb:70:5:70:10 | synthetic splat argument |
+| params_flow.rb:69:14:69:14 | x | type tracker without call steps with content element 0 | params_flow.rb:70:5:70:10 | synthetic splat argument |
 | params_flow.rb:69:17:69:17 | y | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:69:17:69:17 | y | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:69:17:69:17 | y | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:69:17:69:17 | y | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:69:17:69:17 | y | type tracker without call steps | params_flow.rb:69:17:69:17 | y |
 | params_flow.rb:69:17:69:17 | y | type tracker without call steps | params_flow.rb:69:17:69:17 | y |
-| params_flow.rb:69:17:69:17 | y | type tracker without call steps with content splat position 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
+| params_flow.rb:69:17:69:17 | y | type tracker without call steps with content element 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
 | params_flow.rb:69:20:69:21 | *z | type tracker without call steps | params_flow.rb:69:20:69:21 | *z |
 | params_flow.rb:69:21:69:21 | z | type tracker without call steps | params_flow.rb:69:21:69:21 | z |
 | params_flow.rb:69:24:69:24 | w | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:69:24:69:24 | w | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:69:24:69:24 | w | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:69:24:69:24 | w | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:69:24:69:24 | w | type tracker without call steps | params_flow.rb:69:24:69:24 | w |
 | params_flow.rb:69:24:69:24 | w | type tracker without call steps | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:69:24:69:24 | w | type tracker without call steps with content splat position 0 | params_flow.rb:74:5:74:10 | synthetic splat argument |
+| params_flow.rb:69:24:69:24 | w | type tracker without call steps with content element 0 | params_flow.rb:74:5:74:10 | synthetic splat argument |
 | params_flow.rb:69:27:69:27 | r | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:69:27:69:27 | r | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:69:27:69:27 | r | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:69:27:69:27 | r | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:69:27:69:27 | r | type tracker without call steps | params_flow.rb:69:27:69:27 | r |
 | params_flow.rb:69:27:69:27 | r | type tracker without call steps | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:69:27:69:27 | r | type tracker without call steps with content splat position 0 | params_flow.rb:75:5:75:10 | synthetic splat argument |
+| params_flow.rb:69:27:69:27 | r | type tracker without call steps with content element 0 | params_flow.rb:75:5:75:10 | synthetic splat argument |
 | params_flow.rb:70:5:70:10 | call to sink | type tracker without call steps | params_flow.rb:70:5:70:10 | call to sink |
-| params_flow.rb:70:5:70:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:70:5:70:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:70:5:70:10 | synthetic splat argument |
 | params_flow.rb:71:5:71:10 | call to sink | type tracker without call steps | params_flow.rb:71:5:71:10 | call to sink |
-| params_flow.rb:71:5:71:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:71:5:71:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:71:5:71:10 | synthetic splat argument |
 | params_flow.rb:72:5:72:13 | call to sink | type tracker without call steps | params_flow.rb:72:5:72:13 | call to sink |
-| params_flow.rb:72:5:72:13 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:72:5:72:13 | synthetic splat argument | type tracker without call steps | params_flow.rb:72:5:72:13 | synthetic splat argument |
 | params_flow.rb:72:10:72:13 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:72:10:72:13 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:72:10:72:13 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:72:10:72:13 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:72:10:72:13 | ...[...] | type tracker without call steps | params_flow.rb:72:10:72:13 | ...[...] |
-| params_flow.rb:72:10:72:13 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:72:5:72:13 | synthetic splat argument |
+| params_flow.rb:72:10:72:13 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:72:5:72:13 | synthetic splat argument |
 | params_flow.rb:72:10:72:13 | synthetic splat argument | type tracker without call steps | params_flow.rb:72:10:72:13 | synthetic splat argument |
 | params_flow.rb:72:12:72:12 | 0 | type tracker without call steps | params_flow.rb:72:12:72:12 | 0 |
-| params_flow.rb:72:12:72:12 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:72:10:72:13 | synthetic splat argument |
+| params_flow.rb:72:12:72:12 | 0 | type tracker without call steps with content element 0 | params_flow.rb:72:10:72:13 | synthetic splat argument |
 | params_flow.rb:73:5:73:13 | call to sink | type tracker without call steps | params_flow.rb:73:5:73:13 | call to sink |
-| params_flow.rb:73:5:73:13 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:73:5:73:13 | synthetic splat argument | type tracker without call steps | params_flow.rb:73:5:73:13 | synthetic splat argument |
 | params_flow.rb:73:10:73:13 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:73:10:73:13 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:73:10:73:13 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:73:10:73:13 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:73:10:73:13 | ...[...] | type tracker without call steps | params_flow.rb:73:10:73:13 | ...[...] |
-| params_flow.rb:73:10:73:13 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:73:5:73:13 | synthetic splat argument |
+| params_flow.rb:73:10:73:13 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:73:5:73:13 | synthetic splat argument |
 | params_flow.rb:73:10:73:13 | synthetic splat argument | type tracker without call steps | params_flow.rb:73:10:73:13 | synthetic splat argument |
 | params_flow.rb:73:12:73:12 | 1 | type tracker without call steps | params_flow.rb:73:12:73:12 | 1 |
-| params_flow.rb:73:12:73:12 | 1 | type tracker without call steps with content splat position 0 | params_flow.rb:73:10:73:13 | synthetic splat argument |
+| params_flow.rb:73:12:73:12 | 1 | type tracker without call steps with content element 0 | params_flow.rb:73:10:73:13 | synthetic splat argument |
 | params_flow.rb:74:5:74:10 | call to sink | type tracker without call steps | params_flow.rb:74:5:74:10 | call to sink |
-| params_flow.rb:74:5:74:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:74:5:74:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:74:5:74:10 | synthetic splat argument |
 | params_flow.rb:75:5:75:10 | call to sink | type tracker without call steps | params_flow.rb:75:5:75:10 | call to sink |
 | params_flow.rb:75:5:75:10 | call to sink | type tracker without call steps | params_flow.rb:78:1:78:63 | call to splatmid |
 | params_flow.rb:75:5:75:10 | call to sink | type tracker without call steps | params_flow.rb:81:1:81:37 | call to splatmid |
 | params_flow.rb:75:5:75:10 | call to sink | type tracker without call steps | params_flow.rb:96:1:96:88 | call to splatmid |
-| params_flow.rb:75:5:75:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:75:5:75:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:75:5:75:10 | synthetic splat argument |
 | params_flow.rb:78:1:78:63 | call to splatmid | type tracker without call steps | params_flow.rb:78:1:78:63 | call to splatmid |
 | params_flow.rb:78:1:78:63 | synthetic splat argument | type tracker with call steps | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:78:1:78:63 | synthetic splat argument | type tracker without call steps | params_flow.rb:78:1:78:63 | synthetic splat argument |
 | params_flow.rb:78:10:78:18 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:78:10:78:18 | call to taint | type tracker with call steps | params_flow.rb:69:14:69:14 | x |
-| params_flow.rb:78:10:78:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:78:10:78:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:78:10:78:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
-| params_flow.rb:78:10:78:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:70:5:70:10 | synthetic splat argument |
+| params_flow.rb:78:10:78:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:78:10:78:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:78:10:78:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:70:5:70:10 | synthetic splat argument |
 | params_flow.rb:78:10:78:18 | call to taint | type tracker without call steps | params_flow.rb:78:10:78:18 | call to taint |
-| params_flow.rb:78:10:78:18 | call to taint | type tracker without call steps with content splat position 0 | params_flow.rb:78:1:78:63 | synthetic splat argument |
-| params_flow.rb:78:10:78:18 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:78:10:78:18 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:78:1:78:63 | synthetic splat argument |
 | params_flow.rb:78:10:78:18 | synthetic splat argument | type tracker without call steps | params_flow.rb:78:10:78:18 | synthetic splat argument |
 | params_flow.rb:78:16:78:17 | 27 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:78:16:78:17 | 27 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:78:16:78:17 | 27 | type tracker with call steps | params_flow.rb:69:14:69:14 | x |
-| params_flow.rb:78:16:78:17 | 27 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:78:16:78:17 | 27 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:78:16:78:17 | 27 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:78:16:78:17 | 27 | type tracker with call steps with content splat position 0 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
-| params_flow.rb:78:16:78:17 | 27 | type tracker with call steps with content splat position 0 | params_flow.rb:70:5:70:10 | synthetic splat argument |
+| params_flow.rb:78:16:78:17 | 27 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:78:16:78:17 | 27 | type tracker with call steps with content element 0 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:78:16:78:17 | 27 | type tracker with call steps with content element 0 | params_flow.rb:70:5:70:10 | synthetic splat argument |
 | params_flow.rb:78:16:78:17 | 27 | type tracker without call steps | params_flow.rb:78:10:78:18 | call to taint |
 | params_flow.rb:78:16:78:17 | 27 | type tracker without call steps | params_flow.rb:78:16:78:17 | 27 |
-| params_flow.rb:78:16:78:17 | 27 | type tracker without call steps with content splat position 0 | params_flow.rb:78:1:78:63 | synthetic splat argument |
-| params_flow.rb:78:16:78:17 | 27 | type tracker without call steps with content splat position 0 | params_flow.rb:78:10:78:18 | synthetic splat argument |
+| params_flow.rb:78:16:78:17 | 27 | type tracker without call steps with content element 0 | params_flow.rb:78:1:78:63 | synthetic splat argument |
+| params_flow.rb:78:16:78:17 | 27 | type tracker without call steps with content element 0 | params_flow.rb:78:10:78:18 | synthetic splat argument |
 | params_flow.rb:78:21:78:29 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:78:21:78:29 | call to taint | type tracker with call steps | params_flow.rb:69:17:69:17 | y |
-| params_flow.rb:78:21:78:29 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:78:21:78:29 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:78:21:78:29 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
-| params_flow.rb:78:21:78:29 | call to taint | type tracker with call steps with content splat position 1 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:78:21:78:29 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:78:21:78:29 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
+| params_flow.rb:78:21:78:29 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:78:21:78:29 | call to taint | type tracker without call steps | params_flow.rb:78:21:78:29 | call to taint |
-| params_flow.rb:78:21:78:29 | call to taint | type tracker without call steps with content splat position 1 | params_flow.rb:78:1:78:63 | synthetic splat argument |
-| params_flow.rb:78:21:78:29 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:78:21:78:29 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:78:1:78:63 | synthetic splat argument |
 | params_flow.rb:78:21:78:29 | synthetic splat argument | type tracker without call steps | params_flow.rb:78:21:78:29 | synthetic splat argument |
 | params_flow.rb:78:27:78:28 | 28 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:78:27:78:28 | 28 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:78:27:78:28 | 28 | type tracker with call steps | params_flow.rb:69:17:69:17 | y |
-| params_flow.rb:78:27:78:28 | 28 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:78:27:78:28 | 28 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:78:27:78:28 | 28 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:78:27:78:28 | 28 | type tracker with call steps with content splat position 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
-| params_flow.rb:78:27:78:28 | 28 | type tracker with call steps with content splat position 1 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:78:27:78:28 | 28 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:78:27:78:28 | 28 | type tracker with call steps with content element 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
+| params_flow.rb:78:27:78:28 | 28 | type tracker with call steps with content element 1 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:78:27:78:28 | 28 | type tracker without call steps | params_flow.rb:78:21:78:29 | call to taint |
 | params_flow.rb:78:27:78:28 | 28 | type tracker without call steps | params_flow.rb:78:27:78:28 | 28 |
-| params_flow.rb:78:27:78:28 | 28 | type tracker without call steps with content splat position 0 | params_flow.rb:78:21:78:29 | synthetic splat argument |
-| params_flow.rb:78:27:78:28 | 28 | type tracker without call steps with content splat position 1 | params_flow.rb:78:1:78:63 | synthetic splat argument |
-| params_flow.rb:78:32:78:40 | call to taint | type tracker with call steps with content splat position 2 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:78:27:78:28 | 28 | type tracker without call steps with content element 0 | params_flow.rb:78:21:78:29 | synthetic splat argument |
+| params_flow.rb:78:27:78:28 | 28 | type tracker without call steps with content element 1 | params_flow.rb:78:1:78:63 | synthetic splat argument |
+| params_flow.rb:78:32:78:40 | call to taint | type tracker with call steps with content element 2 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:78:32:78:40 | call to taint | type tracker without call steps | params_flow.rb:78:32:78:40 | call to taint |
-| params_flow.rb:78:32:78:40 | call to taint | type tracker without call steps with content splat position 2 | params_flow.rb:78:1:78:63 | synthetic splat argument |
-| params_flow.rb:78:32:78:40 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:78:32:78:40 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:78:1:78:63 | synthetic splat argument |
 | params_flow.rb:78:32:78:40 | synthetic splat argument | type tracker without call steps | params_flow.rb:78:32:78:40 | synthetic splat argument |
 | params_flow.rb:78:38:78:39 | 29 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:78:38:78:39 | 29 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:78:38:78:39 | 29 | type tracker with call steps with content splat position 2 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:78:38:78:39 | 29 | type tracker with call steps with content element 2 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:78:38:78:39 | 29 | type tracker without call steps | params_flow.rb:78:32:78:40 | call to taint |
 | params_flow.rb:78:38:78:39 | 29 | type tracker without call steps | params_flow.rb:78:38:78:39 | 29 |
-| params_flow.rb:78:38:78:39 | 29 | type tracker without call steps with content splat position 0 | params_flow.rb:78:32:78:40 | synthetic splat argument |
-| params_flow.rb:78:38:78:39 | 29 | type tracker without call steps with content splat position 2 | params_flow.rb:78:1:78:63 | synthetic splat argument |
+| params_flow.rb:78:38:78:39 | 29 | type tracker without call steps with content element 0 | params_flow.rb:78:32:78:40 | synthetic splat argument |
+| params_flow.rb:78:38:78:39 | 29 | type tracker without call steps with content element 2 | params_flow.rb:78:1:78:63 | synthetic splat argument |
 | params_flow.rb:78:43:78:51 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:78:43:78:51 | call to taint | type tracker with call steps | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:78:43:78:51 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:78:43:78:51 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:78:43:78:51 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:74:5:74:10 | synthetic splat argument |
-| params_flow.rb:78:43:78:51 | call to taint | type tracker with call steps with content splat position 3 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:78:43:78:51 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:78:43:78:51 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:74:5:74:10 | synthetic splat argument |
+| params_flow.rb:78:43:78:51 | call to taint | type tracker with call steps with content element 3 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:78:43:78:51 | call to taint | type tracker without call steps | params_flow.rb:78:43:78:51 | call to taint |
-| params_flow.rb:78:43:78:51 | call to taint | type tracker without call steps with content splat position 3 | params_flow.rb:78:1:78:63 | synthetic splat argument |
-| params_flow.rb:78:43:78:51 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:78:43:78:51 | call to taint | type tracker without call steps with content element 3 | params_flow.rb:78:1:78:63 | synthetic splat argument |
 | params_flow.rb:78:43:78:51 | synthetic splat argument | type tracker without call steps | params_flow.rb:78:43:78:51 | synthetic splat argument |
 | params_flow.rb:78:49:78:50 | 30 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:78:49:78:50 | 30 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:78:49:78:50 | 30 | type tracker with call steps | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:78:49:78:50 | 30 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:78:49:78:50 | 30 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:78:49:78:50 | 30 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:78:49:78:50 | 30 | type tracker with call steps with content splat position 0 | params_flow.rb:74:5:74:10 | synthetic splat argument |
-| params_flow.rb:78:49:78:50 | 30 | type tracker with call steps with content splat position 3 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:78:49:78:50 | 30 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:78:49:78:50 | 30 | type tracker with call steps with content element 0 | params_flow.rb:74:5:74:10 | synthetic splat argument |
+| params_flow.rb:78:49:78:50 | 30 | type tracker with call steps with content element 3 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:78:49:78:50 | 30 | type tracker without call steps | params_flow.rb:78:43:78:51 | call to taint |
 | params_flow.rb:78:49:78:50 | 30 | type tracker without call steps | params_flow.rb:78:49:78:50 | 30 |
-| params_flow.rb:78:49:78:50 | 30 | type tracker without call steps with content splat position 0 | params_flow.rb:78:43:78:51 | synthetic splat argument |
-| params_flow.rb:78:49:78:50 | 30 | type tracker without call steps with content splat position 3 | params_flow.rb:78:1:78:63 | synthetic splat argument |
+| params_flow.rb:78:49:78:50 | 30 | type tracker without call steps with content element 0 | params_flow.rb:78:43:78:51 | synthetic splat argument |
+| params_flow.rb:78:49:78:50 | 30 | type tracker without call steps with content element 3 | params_flow.rb:78:1:78:63 | synthetic splat argument |
 | params_flow.rb:78:54:78:62 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:78:54:78:62 | call to taint | type tracker with call steps | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:78:54:78:62 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:78:54:78:62 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:78:54:78:62 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:75:5:75:10 | synthetic splat argument |
-| params_flow.rb:78:54:78:62 | call to taint | type tracker with call steps with content splat position 4 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:78:54:78:62 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:78:54:78:62 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:75:5:75:10 | synthetic splat argument |
+| params_flow.rb:78:54:78:62 | call to taint | type tracker with call steps with content element 4 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:78:54:78:62 | call to taint | type tracker without call steps | params_flow.rb:78:54:78:62 | call to taint |
-| params_flow.rb:78:54:78:62 | call to taint | type tracker without call steps with content splat position 4 | params_flow.rb:78:1:78:63 | synthetic splat argument |
-| params_flow.rb:78:54:78:62 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:78:54:78:62 | call to taint | type tracker without call steps with content element 4 | params_flow.rb:78:1:78:63 | synthetic splat argument |
 | params_flow.rb:78:54:78:62 | synthetic splat argument | type tracker without call steps | params_flow.rb:78:54:78:62 | synthetic splat argument |
 | params_flow.rb:78:60:78:61 | 31 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:78:60:78:61 | 31 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:78:60:78:61 | 31 | type tracker with call steps | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:78:60:78:61 | 31 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:78:60:78:61 | 31 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:78:60:78:61 | 31 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:78:60:78:61 | 31 | type tracker with call steps with content splat position 0 | params_flow.rb:75:5:75:10 | synthetic splat argument |
-| params_flow.rb:78:60:78:61 | 31 | type tracker with call steps with content splat position 4 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:78:60:78:61 | 31 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:78:60:78:61 | 31 | type tracker with call steps with content element 0 | params_flow.rb:75:5:75:10 | synthetic splat argument |
+| params_flow.rb:78:60:78:61 | 31 | type tracker with call steps with content element 4 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:78:60:78:61 | 31 | type tracker without call steps | params_flow.rb:78:54:78:62 | call to taint |
 | params_flow.rb:78:60:78:61 | 31 | type tracker without call steps | params_flow.rb:78:60:78:61 | 31 |
-| params_flow.rb:78:60:78:61 | 31 | type tracker without call steps with content splat position 0 | params_flow.rb:78:54:78:62 | synthetic splat argument |
-| params_flow.rb:78:60:78:61 | 31 | type tracker without call steps with content splat position 4 | params_flow.rb:78:1:78:63 | synthetic splat argument |
+| params_flow.rb:78:60:78:61 | 31 | type tracker without call steps with content element 0 | params_flow.rb:78:54:78:62 | synthetic splat argument |
+| params_flow.rb:78:60:78:61 | 31 | type tracker without call steps with content element 4 | params_flow.rb:78:1:78:63 | synthetic splat argument |
 | params_flow.rb:80:1:80:4 | args | type tracker without call steps | params_flow.rb:80:1:80:4 | args |
 | params_flow.rb:80:8:80:51 | Array | type tracker without call steps | params_flow.rb:80:8:80:51 | Array |
 | params_flow.rb:80:8:80:51 | call to [] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:80:8:80:51 | call to [] | type tracker with call steps | params_flow.rb:69:17:69:17 | y |
-| params_flow.rb:80:8:80:51 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:80:8:80:51 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:80:8:80:51 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
-| params_flow.rb:80:8:80:51 | call to [] | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:80:8:80:51 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:80:8:80:51 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
+| params_flow.rb:80:8:80:51 | call to [] | type tracker with call steps with content element 1 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:80:8:80:51 | call to [] | type tracker without call steps | params_flow.rb:80:8:80:51 | call to [] |
 | params_flow.rb:80:8:80:51 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:81:21:81:25 | * ... |
-| params_flow.rb:80:8:80:51 | call to [] | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:81:1:81:37 | synthetic splat argument |
+| params_flow.rb:80:8:80:51 | call to [] | type tracker without call steps with content element 1 | params_flow.rb:81:1:81:37 | synthetic splat argument |
 | params_flow.rb:80:8:80:51 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:80:8:80:51 | synthetic splat argument | type tracker with call steps | params_flow.rb:69:17:69:17 | y |
-| params_flow.rb:80:8:80:51 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:80:8:80:51 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:80:8:80:51 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
-| params_flow.rb:80:8:80:51 | synthetic splat argument | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:80:8:80:51 | synthetic splat argument | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:80:8:80:51 | synthetic splat argument | type tracker with call steps with content element 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
+| params_flow.rb:80:8:80:51 | synthetic splat argument | type tracker with call steps with content element 1 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:80:8:80:51 | synthetic splat argument | type tracker without call steps | params_flow.rb:80:8:80:51 | call to [] |
 | params_flow.rb:80:8:80:51 | synthetic splat argument | type tracker without call steps | params_flow.rb:80:8:80:51 | synthetic splat argument |
 | params_flow.rb:80:8:80:51 | synthetic splat argument | type tracker without call steps with content element 0 or unknown | params_flow.rb:81:21:81:25 | * ... |
-| params_flow.rb:80:8:80:51 | synthetic splat argument | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:81:1:81:37 | synthetic splat argument |
+| params_flow.rb:80:8:80:51 | synthetic splat argument | type tracker without call steps with content element 1 | params_flow.rb:81:1:81:37 | synthetic splat argument |
 | params_flow.rb:80:9:80:17 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:80:9:80:17 | call to taint | type tracker with call steps | params_flow.rb:69:17:69:17 | y |
-| params_flow.rb:80:9:80:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:80:9:80:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:80:9:80:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
-| params_flow.rb:80:9:80:17 | call to taint | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:80:9:80:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:80:9:80:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
+| params_flow.rb:80:9:80:17 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:80:9:80:17 | call to taint | type tracker without call steps | params_flow.rb:80:9:80:17 | call to taint |
 | params_flow.rb:80:9:80:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:80:8:80:51 | call to [] |
 | params_flow.rb:80:9:80:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:80:8:80:51 | synthetic splat argument |
 | params_flow.rb:80:9:80:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:81:21:81:25 | * ... |
-| params_flow.rb:80:9:80:17 | call to taint | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:81:1:81:37 | synthetic splat argument |
-| params_flow.rb:80:9:80:17 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:80:9:80:17 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:81:1:81:37 | synthetic splat argument |
 | params_flow.rb:80:9:80:17 | synthetic splat argument | type tracker without call steps | params_flow.rb:80:9:80:17 | synthetic splat argument |
 | params_flow.rb:80:15:80:16 | 33 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:80:15:80:16 | 33 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:80:15:80:16 | 33 | type tracker with call steps | params_flow.rb:69:17:69:17 | y |
-| params_flow.rb:80:15:80:16 | 33 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:80:15:80:16 | 33 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:80:15:80:16 | 33 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:80:15:80:16 | 33 | type tracker with call steps with content splat position 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
-| params_flow.rb:80:15:80:16 | 33 | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:80:15:80:16 | 33 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:80:15:80:16 | 33 | type tracker with call steps with content element 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
+| params_flow.rb:80:15:80:16 | 33 | type tracker with call steps with content element 1 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:80:15:80:16 | 33 | type tracker without call steps | params_flow.rb:80:9:80:17 | call to taint |
 | params_flow.rb:80:15:80:16 | 33 | type tracker without call steps | params_flow.rb:80:15:80:16 | 33 |
 | params_flow.rb:80:15:80:16 | 33 | type tracker without call steps with content element 0 | params_flow.rb:80:8:80:51 | call to [] |
 | params_flow.rb:80:15:80:16 | 33 | type tracker without call steps with content element 0 | params_flow.rb:80:8:80:51 | synthetic splat argument |
+| params_flow.rb:80:15:80:16 | 33 | type tracker without call steps with content element 0 | params_flow.rb:80:9:80:17 | synthetic splat argument |
 | params_flow.rb:80:15:80:16 | 33 | type tracker without call steps with content element 0 | params_flow.rb:81:21:81:25 | * ... |
-| params_flow.rb:80:15:80:16 | 33 | type tracker without call steps with content splat position 0 | params_flow.rb:80:9:80:17 | synthetic splat argument |
-| params_flow.rb:80:15:80:16 | 33 | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:81:1:81:37 | synthetic splat argument |
-| params_flow.rb:80:20:80:28 | call to taint | type tracker with call steps with content splat position 2 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:80:15:80:16 | 33 | type tracker without call steps with content element 1 | params_flow.rb:81:1:81:37 | synthetic splat argument |
+| params_flow.rb:80:20:80:28 | call to taint | type tracker with call steps with content element 2 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:80:20:80:28 | call to taint | type tracker without call steps | params_flow.rb:80:20:80:28 | call to taint |
 | params_flow.rb:80:20:80:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:80:8:80:51 | call to [] |
 | params_flow.rb:80:20:80:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:80:8:80:51 | synthetic splat argument |
 | params_flow.rb:80:20:80:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:81:21:81:25 | * ... |
-| params_flow.rb:80:20:80:28 | call to taint | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:81:1:81:37 | synthetic splat argument |
-| params_flow.rb:80:20:80:28 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:80:20:80:28 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:81:1:81:37 | synthetic splat argument |
 | params_flow.rb:80:20:80:28 | synthetic splat argument | type tracker without call steps | params_flow.rb:80:20:80:28 | synthetic splat argument |
 | params_flow.rb:80:26:80:27 | 34 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:80:26:80:27 | 34 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:80:26:80:27 | 34 | type tracker with call steps with content splat position 2 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:80:26:80:27 | 34 | type tracker with call steps with content element 2 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:80:26:80:27 | 34 | type tracker without call steps | params_flow.rb:80:20:80:28 | call to taint |
 | params_flow.rb:80:26:80:27 | 34 | type tracker without call steps | params_flow.rb:80:26:80:27 | 34 |
+| params_flow.rb:80:26:80:27 | 34 | type tracker without call steps with content element 0 | params_flow.rb:80:20:80:28 | synthetic splat argument |
 | params_flow.rb:80:26:80:27 | 34 | type tracker without call steps with content element 1 | params_flow.rb:80:8:80:51 | call to [] |
 | params_flow.rb:80:26:80:27 | 34 | type tracker without call steps with content element 1 | params_flow.rb:80:8:80:51 | synthetic splat argument |
 | params_flow.rb:80:26:80:27 | 34 | type tracker without call steps with content element 1 | params_flow.rb:81:21:81:25 | * ... |
-| params_flow.rb:80:26:80:27 | 34 | type tracker without call steps with content splat position 0 | params_flow.rb:80:20:80:28 | synthetic splat argument |
-| params_flow.rb:80:26:80:27 | 34 | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:81:1:81:37 | synthetic splat argument |
-| params_flow.rb:80:31:80:39 | call to taint | type tracker with call steps with content splat position 3 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:80:26:80:27 | 34 | type tracker without call steps with content element 2 | params_flow.rb:81:1:81:37 | synthetic splat argument |
+| params_flow.rb:80:31:80:39 | call to taint | type tracker with call steps with content element 3 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:80:31:80:39 | call to taint | type tracker without call steps | params_flow.rb:80:31:80:39 | call to taint |
 | params_flow.rb:80:31:80:39 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:80:8:80:51 | call to [] |
 | params_flow.rb:80:31:80:39 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:80:8:80:51 | synthetic splat argument |
 | params_flow.rb:80:31:80:39 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:81:21:81:25 | * ... |
-| params_flow.rb:80:31:80:39 | call to taint | type tracker without call steps with content splat position 3 (shifted) | params_flow.rb:81:1:81:37 | synthetic splat argument |
-| params_flow.rb:80:31:80:39 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:80:31:80:39 | call to taint | type tracker without call steps with content element 3 | params_flow.rb:81:1:81:37 | synthetic splat argument |
 | params_flow.rb:80:31:80:39 | synthetic splat argument | type tracker without call steps | params_flow.rb:80:31:80:39 | synthetic splat argument |
 | params_flow.rb:80:37:80:38 | 35 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:80:37:80:38 | 35 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:80:37:80:38 | 35 | type tracker with call steps with content splat position 3 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:80:37:80:38 | 35 | type tracker with call steps with content element 3 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:80:37:80:38 | 35 | type tracker without call steps | params_flow.rb:80:31:80:39 | call to taint |
 | params_flow.rb:80:37:80:38 | 35 | type tracker without call steps | params_flow.rb:80:37:80:38 | 35 |
+| params_flow.rb:80:37:80:38 | 35 | type tracker without call steps with content element 0 | params_flow.rb:80:31:80:39 | synthetic splat argument |
 | params_flow.rb:80:37:80:38 | 35 | type tracker without call steps with content element 2 | params_flow.rb:80:8:80:51 | call to [] |
 | params_flow.rb:80:37:80:38 | 35 | type tracker without call steps with content element 2 | params_flow.rb:80:8:80:51 | synthetic splat argument |
 | params_flow.rb:80:37:80:38 | 35 | type tracker without call steps with content element 2 | params_flow.rb:81:21:81:25 | * ... |
-| params_flow.rb:80:37:80:38 | 35 | type tracker without call steps with content splat position 0 | params_flow.rb:80:31:80:39 | synthetic splat argument |
-| params_flow.rb:80:37:80:38 | 35 | type tracker without call steps with content splat position 3 (shifted) | params_flow.rb:81:1:81:37 | synthetic splat argument |
-| params_flow.rb:80:42:80:50 | call to taint | type tracker with call steps with content splat position 4 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:80:37:80:38 | 35 | type tracker without call steps with content element 3 | params_flow.rb:81:1:81:37 | synthetic splat argument |
+| params_flow.rb:80:42:80:50 | call to taint | type tracker with call steps with content element 4 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:80:42:80:50 | call to taint | type tracker without call steps | params_flow.rb:80:42:80:50 | call to taint |
 | params_flow.rb:80:42:80:50 | call to taint | type tracker without call steps with content element 3 | params_flow.rb:80:8:80:51 | call to [] |
 | params_flow.rb:80:42:80:50 | call to taint | type tracker without call steps with content element 3 | params_flow.rb:80:8:80:51 | synthetic splat argument |
 | params_flow.rb:80:42:80:50 | call to taint | type tracker without call steps with content element 3 | params_flow.rb:81:21:81:25 | * ... |
-| params_flow.rb:80:42:80:50 | call to taint | type tracker without call steps with content splat position 4 (shifted) | params_flow.rb:81:1:81:37 | synthetic splat argument |
-| params_flow.rb:80:42:80:50 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:80:42:80:50 | call to taint | type tracker without call steps with content element 4 | params_flow.rb:81:1:81:37 | synthetic splat argument |
 | params_flow.rb:80:42:80:50 | synthetic splat argument | type tracker without call steps | params_flow.rb:80:42:80:50 | synthetic splat argument |
 | params_flow.rb:80:48:80:49 | 36 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:80:48:80:49 | 36 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:80:48:80:49 | 36 | type tracker with call steps with content splat position 4 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:80:48:80:49 | 36 | type tracker with call steps with content element 4 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:80:48:80:49 | 36 | type tracker without call steps | params_flow.rb:80:42:80:50 | call to taint |
 | params_flow.rb:80:48:80:49 | 36 | type tracker without call steps | params_flow.rb:80:48:80:49 | 36 |
+| params_flow.rb:80:48:80:49 | 36 | type tracker without call steps with content element 0 | params_flow.rb:80:42:80:50 | synthetic splat argument |
 | params_flow.rb:80:48:80:49 | 36 | type tracker without call steps with content element 3 | params_flow.rb:80:8:80:51 | call to [] |
 | params_flow.rb:80:48:80:49 | 36 | type tracker without call steps with content element 3 | params_flow.rb:80:8:80:51 | synthetic splat argument |
 | params_flow.rb:80:48:80:49 | 36 | type tracker without call steps with content element 3 | params_flow.rb:81:21:81:25 | * ... |
-| params_flow.rb:80:48:80:49 | 36 | type tracker without call steps with content splat position 0 | params_flow.rb:80:42:80:50 | synthetic splat argument |
-| params_flow.rb:80:48:80:49 | 36 | type tracker without call steps with content splat position 4 (shifted) | params_flow.rb:81:1:81:37 | synthetic splat argument |
+| params_flow.rb:80:48:80:49 | 36 | type tracker without call steps with content element 4 | params_flow.rb:81:1:81:37 | synthetic splat argument |
 | params_flow.rb:81:1:81:37 | call to splatmid | type tracker without call steps | params_flow.rb:81:1:81:37 | call to splatmid |
 | params_flow.rb:81:1:81:37 | synthetic splat argument | type tracker with call steps | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:81:1:81:37 | synthetic splat argument | type tracker without call steps | params_flow.rb:81:1:81:37 | synthetic splat argument |
 | params_flow.rb:81:10:81:18 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:81:10:81:18 | call to taint | type tracker with call steps | params_flow.rb:69:14:69:14 | x |
-| params_flow.rb:81:10:81:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:81:10:81:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:81:10:81:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
-| params_flow.rb:81:10:81:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:70:5:70:10 | synthetic splat argument |
+| params_flow.rb:81:10:81:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:81:10:81:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:81:10:81:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:70:5:70:10 | synthetic splat argument |
 | params_flow.rb:81:10:81:18 | call to taint | type tracker without call steps | params_flow.rb:81:10:81:18 | call to taint |
-| params_flow.rb:81:10:81:18 | call to taint | type tracker without call steps with content splat position 0 | params_flow.rb:81:1:81:37 | synthetic splat argument |
-| params_flow.rb:81:10:81:18 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:81:10:81:18 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:81:1:81:37 | synthetic splat argument |
 | params_flow.rb:81:10:81:18 | synthetic splat argument | type tracker without call steps | params_flow.rb:81:10:81:18 | synthetic splat argument |
 | params_flow.rb:81:16:81:17 | 32 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:81:16:81:17 | 32 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:81:16:81:17 | 32 | type tracker with call steps | params_flow.rb:69:14:69:14 | x |
-| params_flow.rb:81:16:81:17 | 32 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:81:16:81:17 | 32 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:81:16:81:17 | 32 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:81:16:81:17 | 32 | type tracker with call steps with content splat position 0 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
-| params_flow.rb:81:16:81:17 | 32 | type tracker with call steps with content splat position 0 | params_flow.rb:70:5:70:10 | synthetic splat argument |
+| params_flow.rb:81:16:81:17 | 32 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:81:16:81:17 | 32 | type tracker with call steps with content element 0 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:81:16:81:17 | 32 | type tracker with call steps with content element 0 | params_flow.rb:70:5:70:10 | synthetic splat argument |
 | params_flow.rb:81:16:81:17 | 32 | type tracker without call steps | params_flow.rb:81:10:81:18 | call to taint |
 | params_flow.rb:81:16:81:17 | 32 | type tracker without call steps | params_flow.rb:81:16:81:17 | 32 |
-| params_flow.rb:81:16:81:17 | 32 | type tracker without call steps with content splat position 0 | params_flow.rb:81:1:81:37 | synthetic splat argument |
-| params_flow.rb:81:16:81:17 | 32 | type tracker without call steps with content splat position 0 | params_flow.rb:81:10:81:18 | synthetic splat argument |
+| params_flow.rb:81:16:81:17 | 32 | type tracker without call steps with content element 0 | params_flow.rb:81:1:81:37 | synthetic splat argument |
+| params_flow.rb:81:16:81:17 | 32 | type tracker without call steps with content element 0 | params_flow.rb:81:10:81:18 | synthetic splat argument |
 | params_flow.rb:81:21:81:25 | * ... | type tracker without call steps | params_flow.rb:81:21:81:25 | * ... |
 | params_flow.rb:81:28:81:36 | call to taint | type tracker without call steps | params_flow.rb:81:28:81:36 | call to taint |
-| params_flow.rb:81:28:81:36 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:81:28:81:36 | synthetic splat argument | type tracker without call steps | params_flow.rb:81:28:81:36 | synthetic splat argument |
 | params_flow.rb:81:34:81:35 | 37 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:81:34:81:35 | 37 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:81:34:81:35 | 37 | type tracker without call steps | params_flow.rb:81:28:81:36 | call to taint |
 | params_flow.rb:81:34:81:35 | 37 | type tracker without call steps | params_flow.rb:81:34:81:35 | 37 |
-| params_flow.rb:81:34:81:35 | 37 | type tracker without call steps with content splat position 0 | params_flow.rb:81:28:81:36 | synthetic splat argument |
+| params_flow.rb:81:34:81:35 | 37 | type tracker without call steps with content element 0 | params_flow.rb:81:28:81:36 | synthetic splat argument |
 | params_flow.rb:83:1:91:3 | &block | type tracker without call steps | params_flow.rb:83:1:91:3 | &block |
 | params_flow.rb:83:1:91:3 | pos_many | type tracker without call steps | params_flow.rb:83:1:91:3 | pos_many |
 | params_flow.rb:83:1:91:3 | self in pos_many | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
 | params_flow.rb:83:1:91:3 | self in pos_many | type tracker without call steps | params_flow.rb:83:1:91:3 | self in pos_many |
 | params_flow.rb:83:1:91:3 | synthetic splat parameter | type tracker without call steps | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:83:14:83:14 | t | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:83:14:83:14 | t | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:83:14:83:14 | t | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:83:14:83:14 | t | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:83:14:83:14 | t | type tracker without call steps | params_flow.rb:83:14:83:14 | t |
 | params_flow.rb:83:14:83:14 | t | type tracker without call steps | params_flow.rb:83:14:83:14 | t |
-| params_flow.rb:83:14:83:14 | t | type tracker without call steps with content splat position 0 | params_flow.rb:84:5:84:10 | synthetic splat argument |
+| params_flow.rb:83:14:83:14 | t | type tracker without call steps with content element 0 | params_flow.rb:84:5:84:10 | synthetic splat argument |
 | params_flow.rb:83:17:83:17 | u | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:83:17:83:17 | u | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:83:17:83:17 | u | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:83:17:83:17 | u | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:83:17:83:17 | u | type tracker without call steps | params_flow.rb:83:17:83:17 | u |
 | params_flow.rb:83:17:83:17 | u | type tracker without call steps | params_flow.rb:83:17:83:17 | u |
-| params_flow.rb:83:17:83:17 | u | type tracker without call steps with content splat position 0 | params_flow.rb:85:5:85:10 | synthetic splat argument |
+| params_flow.rb:83:17:83:17 | u | type tracker without call steps with content element 0 | params_flow.rb:85:5:85:10 | synthetic splat argument |
 | params_flow.rb:83:20:83:20 | v | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:83:20:83:20 | v | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:83:20:83:20 | v | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:83:20:83:20 | v | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:83:20:83:20 | v | type tracker without call steps | params_flow.rb:83:20:83:20 | v |
 | params_flow.rb:83:20:83:20 | v | type tracker without call steps | params_flow.rb:83:20:83:20 | v |
-| params_flow.rb:83:20:83:20 | v | type tracker without call steps with content splat position 0 | params_flow.rb:86:5:86:10 | synthetic splat argument |
+| params_flow.rb:83:20:83:20 | v | type tracker without call steps with content element 0 | params_flow.rb:86:5:86:10 | synthetic splat argument |
 | params_flow.rb:83:23:83:23 | w | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:83:23:83:23 | w | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:83:23:83:23 | w | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:83:23:83:23 | w | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:83:23:83:23 | w | type tracker without call steps | params_flow.rb:83:23:83:23 | w |
 | params_flow.rb:83:23:83:23 | w | type tracker without call steps | params_flow.rb:83:23:83:23 | w |
-| params_flow.rb:83:23:83:23 | w | type tracker without call steps with content splat position 0 | params_flow.rb:87:5:87:10 | synthetic splat argument |
+| params_flow.rb:83:23:83:23 | w | type tracker without call steps with content element 0 | params_flow.rb:87:5:87:10 | synthetic splat argument |
 | params_flow.rb:83:26:83:26 | x | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:83:26:83:26 | x | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:83:26:83:26 | x | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:83:26:83:26 | x | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:83:26:83:26 | x | type tracker without call steps | params_flow.rb:83:26:83:26 | x |
 | params_flow.rb:83:26:83:26 | x | type tracker without call steps | params_flow.rb:83:26:83:26 | x |
-| params_flow.rb:83:26:83:26 | x | type tracker without call steps with content splat position 0 | params_flow.rb:88:5:88:10 | synthetic splat argument |
+| params_flow.rb:83:26:83:26 | x | type tracker without call steps with content element 0 | params_flow.rb:88:5:88:10 | synthetic splat argument |
 | params_flow.rb:83:29:83:29 | y | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:83:29:83:29 | y | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:83:29:83:29 | y | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:83:29:83:29 | y | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:83:29:83:29 | y | type tracker without call steps | params_flow.rb:83:29:83:29 | y |
 | params_flow.rb:83:29:83:29 | y | type tracker without call steps | params_flow.rb:83:29:83:29 | y |
-| params_flow.rb:83:29:83:29 | y | type tracker without call steps with content splat position 0 | params_flow.rb:89:5:89:10 | synthetic splat argument |
+| params_flow.rb:83:29:83:29 | y | type tracker without call steps with content element 0 | params_flow.rb:89:5:89:10 | synthetic splat argument |
 | params_flow.rb:83:32:83:32 | z | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:83:32:83:32 | z | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:83:32:83:32 | z | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:83:32:83:32 | z | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:83:32:83:32 | z | type tracker without call steps | params_flow.rb:83:32:83:32 | z |
 | params_flow.rb:83:32:83:32 | z | type tracker without call steps | params_flow.rb:83:32:83:32 | z |
-| params_flow.rb:83:32:83:32 | z | type tracker without call steps with content splat position 0 | params_flow.rb:90:5:90:10 | synthetic splat argument |
+| params_flow.rb:83:32:83:32 | z | type tracker without call steps with content element 0 | params_flow.rb:90:5:90:10 | synthetic splat argument |
 | params_flow.rb:84:5:84:10 | call to sink | type tracker without call steps | params_flow.rb:84:5:84:10 | call to sink |
-| params_flow.rb:84:5:84:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:84:5:84:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:84:5:84:10 | synthetic splat argument |
 | params_flow.rb:85:5:85:10 | call to sink | type tracker without call steps | params_flow.rb:85:5:85:10 | call to sink |
-| params_flow.rb:85:5:85:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:85:5:85:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:85:5:85:10 | synthetic splat argument |
 | params_flow.rb:86:5:86:10 | call to sink | type tracker without call steps | params_flow.rb:86:5:86:10 | call to sink |
-| params_flow.rb:86:5:86:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:86:5:86:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:86:5:86:10 | synthetic splat argument |
 | params_flow.rb:87:5:87:10 | call to sink | type tracker without call steps | params_flow.rb:87:5:87:10 | call to sink |
-| params_flow.rb:87:5:87:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:87:5:87:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:87:5:87:10 | synthetic splat argument |
 | params_flow.rb:88:5:88:10 | call to sink | type tracker without call steps | params_flow.rb:88:5:88:10 | call to sink |
-| params_flow.rb:88:5:88:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:88:5:88:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:88:5:88:10 | synthetic splat argument |
 | params_flow.rb:89:5:89:10 | call to sink | type tracker without call steps | params_flow.rb:89:5:89:10 | call to sink |
-| params_flow.rb:89:5:89:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:89:5:89:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:89:5:89:10 | synthetic splat argument |
 | params_flow.rb:90:5:90:10 | call to sink | type tracker without call steps | params_flow.rb:90:5:90:10 | call to sink |
 | params_flow.rb:90:5:90:10 | call to sink | type tracker without call steps | params_flow.rb:94:1:94:48 | call to pos_many |
 | params_flow.rb:90:5:90:10 | call to sink | type tracker without call steps | params_flow.rb:131:1:131:46 | call to pos_many |
-| params_flow.rb:90:5:90:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:90:5:90:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:90:5:90:10 | synthetic splat argument |
 | params_flow.rb:93:1:93:4 | args | type tracker without call steps | params_flow.rb:93:1:93:4 | args |
 | params_flow.rb:93:8:93:51 | Array | type tracker without call steps | params_flow.rb:93:8:93:51 | Array |
 | params_flow.rb:93:8:93:51 | call to [] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:93:8:93:51 | call to [] | type tracker with call steps | params_flow.rb:83:20:83:20 | v |
-| params_flow.rb:93:8:93:51 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:93:8:93:51 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:93:8:93:51 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:86:5:86:10 | synthetic splat argument |
-| params_flow.rb:93:8:93:51 | call to [] | type tracker with call steps with content splat position 2 (shifted) | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:93:8:93:51 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:93:8:93:51 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:86:5:86:10 | synthetic splat argument |
+| params_flow.rb:93:8:93:51 | call to [] | type tracker with call steps with content element 2 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:93:8:93:51 | call to [] | type tracker without call steps | params_flow.rb:93:8:93:51 | call to [] |
 | params_flow.rb:93:8:93:51 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:94:32:94:36 | * ... |
-| params_flow.rb:93:8:93:51 | call to [] | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:94:1:94:48 | synthetic splat argument |
+| params_flow.rb:93:8:93:51 | call to [] | type tracker without call steps with content element 2 | params_flow.rb:94:1:94:48 | synthetic splat argument |
 | params_flow.rb:93:8:93:51 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:93:8:93:51 | synthetic splat argument | type tracker with call steps | params_flow.rb:83:20:83:20 | v |
-| params_flow.rb:93:8:93:51 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:93:8:93:51 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:93:8:93:51 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:86:5:86:10 | synthetic splat argument |
-| params_flow.rb:93:8:93:51 | synthetic splat argument | type tracker with call steps with content splat position 2 (shifted) | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:93:8:93:51 | synthetic splat argument | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:93:8:93:51 | synthetic splat argument | type tracker with call steps with content element 0 | params_flow.rb:86:5:86:10 | synthetic splat argument |
+| params_flow.rb:93:8:93:51 | synthetic splat argument | type tracker with call steps with content element 2 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:93:8:93:51 | synthetic splat argument | type tracker without call steps | params_flow.rb:93:8:93:51 | call to [] |
 | params_flow.rb:93:8:93:51 | synthetic splat argument | type tracker without call steps | params_flow.rb:93:8:93:51 | synthetic splat argument |
 | params_flow.rb:93:8:93:51 | synthetic splat argument | type tracker without call steps with content element 0 or unknown | params_flow.rb:94:32:94:36 | * ... |
-| params_flow.rb:93:8:93:51 | synthetic splat argument | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:94:1:94:48 | synthetic splat argument |
+| params_flow.rb:93:8:93:51 | synthetic splat argument | type tracker without call steps with content element 2 | params_flow.rb:94:1:94:48 | synthetic splat argument |
 | params_flow.rb:93:9:93:17 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:93:9:93:17 | call to taint | type tracker with call steps | params_flow.rb:83:20:83:20 | v |
-| params_flow.rb:93:9:93:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:93:9:93:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:93:9:93:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:86:5:86:10 | synthetic splat argument |
-| params_flow.rb:93:9:93:17 | call to taint | type tracker with call steps with content splat position 2 (shifted) | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:93:9:93:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:93:9:93:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:86:5:86:10 | synthetic splat argument |
+| params_flow.rb:93:9:93:17 | call to taint | type tracker with call steps with content element 2 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:93:9:93:17 | call to taint | type tracker without call steps | params_flow.rb:93:9:93:17 | call to taint |
 | params_flow.rb:93:9:93:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:93:8:93:51 | call to [] |
 | params_flow.rb:93:9:93:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:93:8:93:51 | synthetic splat argument |
 | params_flow.rb:93:9:93:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:94:32:94:36 | * ... |
-| params_flow.rb:93:9:93:17 | call to taint | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:94:1:94:48 | synthetic splat argument |
-| params_flow.rb:93:9:93:17 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:93:9:93:17 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:94:1:94:48 | synthetic splat argument |
 | params_flow.rb:93:9:93:17 | synthetic splat argument | type tracker without call steps | params_flow.rb:93:9:93:17 | synthetic splat argument |
 | params_flow.rb:93:15:93:16 | 40 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:93:15:93:16 | 40 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:93:15:93:16 | 40 | type tracker with call steps | params_flow.rb:83:20:83:20 | v |
-| params_flow.rb:93:15:93:16 | 40 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:93:15:93:16 | 40 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:93:15:93:16 | 40 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:93:15:93:16 | 40 | type tracker with call steps with content splat position 0 | params_flow.rb:86:5:86:10 | synthetic splat argument |
-| params_flow.rb:93:15:93:16 | 40 | type tracker with call steps with content splat position 2 (shifted) | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:93:15:93:16 | 40 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:93:15:93:16 | 40 | type tracker with call steps with content element 0 | params_flow.rb:86:5:86:10 | synthetic splat argument |
+| params_flow.rb:93:15:93:16 | 40 | type tracker with call steps with content element 2 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:93:15:93:16 | 40 | type tracker without call steps | params_flow.rb:93:9:93:17 | call to taint |
 | params_flow.rb:93:15:93:16 | 40 | type tracker without call steps | params_flow.rb:93:15:93:16 | 40 |
 | params_flow.rb:93:15:93:16 | 40 | type tracker without call steps with content element 0 | params_flow.rb:93:8:93:51 | call to [] |
 | params_flow.rb:93:15:93:16 | 40 | type tracker without call steps with content element 0 | params_flow.rb:93:8:93:51 | synthetic splat argument |
+| params_flow.rb:93:15:93:16 | 40 | type tracker without call steps with content element 0 | params_flow.rb:93:9:93:17 | synthetic splat argument |
 | params_flow.rb:93:15:93:16 | 40 | type tracker without call steps with content element 0 | params_flow.rb:94:32:94:36 | * ... |
-| params_flow.rb:93:15:93:16 | 40 | type tracker without call steps with content splat position 0 | params_flow.rb:93:9:93:17 | synthetic splat argument |
-| params_flow.rb:93:15:93:16 | 40 | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:94:1:94:48 | synthetic splat argument |
+| params_flow.rb:93:15:93:16 | 40 | type tracker without call steps with content element 2 | params_flow.rb:94:1:94:48 | synthetic splat argument |
 | params_flow.rb:93:20:93:28 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:93:20:93:28 | call to taint | type tracker with call steps | params_flow.rb:83:23:83:23 | w |
-| params_flow.rb:93:20:93:28 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:93:20:93:28 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:93:20:93:28 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:87:5:87:10 | synthetic splat argument |
-| params_flow.rb:93:20:93:28 | call to taint | type tracker with call steps with content splat position 3 (shifted) | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:93:20:93:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:93:20:93:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:87:5:87:10 | synthetic splat argument |
+| params_flow.rb:93:20:93:28 | call to taint | type tracker with call steps with content element 3 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:93:20:93:28 | call to taint | type tracker without call steps | params_flow.rb:93:20:93:28 | call to taint |
 | params_flow.rb:93:20:93:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:93:8:93:51 | call to [] |
 | params_flow.rb:93:20:93:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:93:8:93:51 | synthetic splat argument |
 | params_flow.rb:93:20:93:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:94:32:94:36 | * ... |
-| params_flow.rb:93:20:93:28 | call to taint | type tracker without call steps with content splat position 3 (shifted) | params_flow.rb:94:1:94:48 | synthetic splat argument |
-| params_flow.rb:93:20:93:28 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:93:20:93:28 | call to taint | type tracker without call steps with content element 3 | params_flow.rb:94:1:94:48 | synthetic splat argument |
 | params_flow.rb:93:20:93:28 | synthetic splat argument | type tracker without call steps | params_flow.rb:93:20:93:28 | synthetic splat argument |
 | params_flow.rb:93:26:93:27 | 41 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:93:26:93:27 | 41 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:93:26:93:27 | 41 | type tracker with call steps | params_flow.rb:83:23:83:23 | w |
-| params_flow.rb:93:26:93:27 | 41 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:93:26:93:27 | 41 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:93:26:93:27 | 41 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:93:26:93:27 | 41 | type tracker with call steps with content splat position 0 | params_flow.rb:87:5:87:10 | synthetic splat argument |
-| params_flow.rb:93:26:93:27 | 41 | type tracker with call steps with content splat position 3 (shifted) | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:93:26:93:27 | 41 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:93:26:93:27 | 41 | type tracker with call steps with content element 0 | params_flow.rb:87:5:87:10 | synthetic splat argument |
+| params_flow.rb:93:26:93:27 | 41 | type tracker with call steps with content element 3 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:93:26:93:27 | 41 | type tracker without call steps | params_flow.rb:93:20:93:28 | call to taint |
 | params_flow.rb:93:26:93:27 | 41 | type tracker without call steps | params_flow.rb:93:26:93:27 | 41 |
+| params_flow.rb:93:26:93:27 | 41 | type tracker without call steps with content element 0 | params_flow.rb:93:20:93:28 | synthetic splat argument |
 | params_flow.rb:93:26:93:27 | 41 | type tracker without call steps with content element 1 | params_flow.rb:93:8:93:51 | call to [] |
 | params_flow.rb:93:26:93:27 | 41 | type tracker without call steps with content element 1 | params_flow.rb:93:8:93:51 | synthetic splat argument |
 | params_flow.rb:93:26:93:27 | 41 | type tracker without call steps with content element 1 | params_flow.rb:94:32:94:36 | * ... |
-| params_flow.rb:93:26:93:27 | 41 | type tracker without call steps with content splat position 0 | params_flow.rb:93:20:93:28 | synthetic splat argument |
-| params_flow.rb:93:26:93:27 | 41 | type tracker without call steps with content splat position 3 (shifted) | params_flow.rb:94:1:94:48 | synthetic splat argument |
+| params_flow.rb:93:26:93:27 | 41 | type tracker without call steps with content element 3 | params_flow.rb:94:1:94:48 | synthetic splat argument |
 | params_flow.rb:93:31:93:39 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:93:31:93:39 | call to taint | type tracker with call steps | params_flow.rb:83:26:83:26 | x |
-| params_flow.rb:93:31:93:39 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:93:31:93:39 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:93:31:93:39 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:88:5:88:10 | synthetic splat argument |
-| params_flow.rb:93:31:93:39 | call to taint | type tracker with call steps with content splat position 4 (shifted) | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:93:31:93:39 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:93:31:93:39 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:88:5:88:10 | synthetic splat argument |
+| params_flow.rb:93:31:93:39 | call to taint | type tracker with call steps with content element 4 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:93:31:93:39 | call to taint | type tracker without call steps | params_flow.rb:93:31:93:39 | call to taint |
 | params_flow.rb:93:31:93:39 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:93:8:93:51 | call to [] |
 | params_flow.rb:93:31:93:39 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:93:8:93:51 | synthetic splat argument |
 | params_flow.rb:93:31:93:39 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:94:32:94:36 | * ... |
-| params_flow.rb:93:31:93:39 | call to taint | type tracker without call steps with content splat position 4 (shifted) | params_flow.rb:94:1:94:48 | synthetic splat argument |
-| params_flow.rb:93:31:93:39 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:93:31:93:39 | call to taint | type tracker without call steps with content element 4 | params_flow.rb:94:1:94:48 | synthetic splat argument |
 | params_flow.rb:93:31:93:39 | synthetic splat argument | type tracker without call steps | params_flow.rb:93:31:93:39 | synthetic splat argument |
 | params_flow.rb:93:37:93:38 | 42 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:93:37:93:38 | 42 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:93:37:93:38 | 42 | type tracker with call steps | params_flow.rb:83:26:83:26 | x |
-| params_flow.rb:93:37:93:38 | 42 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:93:37:93:38 | 42 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:93:37:93:38 | 42 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:93:37:93:38 | 42 | type tracker with call steps with content splat position 0 | params_flow.rb:88:5:88:10 | synthetic splat argument |
-| params_flow.rb:93:37:93:38 | 42 | type tracker with call steps with content splat position 4 (shifted) | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:93:37:93:38 | 42 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:93:37:93:38 | 42 | type tracker with call steps with content element 0 | params_flow.rb:88:5:88:10 | synthetic splat argument |
+| params_flow.rb:93:37:93:38 | 42 | type tracker with call steps with content element 4 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:93:37:93:38 | 42 | type tracker without call steps | params_flow.rb:93:31:93:39 | call to taint |
 | params_flow.rb:93:37:93:38 | 42 | type tracker without call steps | params_flow.rb:93:37:93:38 | 42 |
+| params_flow.rb:93:37:93:38 | 42 | type tracker without call steps with content element 0 | params_flow.rb:93:31:93:39 | synthetic splat argument |
 | params_flow.rb:93:37:93:38 | 42 | type tracker without call steps with content element 2 | params_flow.rb:93:8:93:51 | call to [] |
 | params_flow.rb:93:37:93:38 | 42 | type tracker without call steps with content element 2 | params_flow.rb:93:8:93:51 | synthetic splat argument |
 | params_flow.rb:93:37:93:38 | 42 | type tracker without call steps with content element 2 | params_flow.rb:94:32:94:36 | * ... |
-| params_flow.rb:93:37:93:38 | 42 | type tracker without call steps with content splat position 0 | params_flow.rb:93:31:93:39 | synthetic splat argument |
-| params_flow.rb:93:37:93:38 | 42 | type tracker without call steps with content splat position 4 (shifted) | params_flow.rb:94:1:94:48 | synthetic splat argument |
+| params_flow.rb:93:37:93:38 | 42 | type tracker without call steps with content element 4 | params_flow.rb:94:1:94:48 | synthetic splat argument |
 | params_flow.rb:93:42:93:50 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:93:42:93:50 | call to taint | type tracker with call steps | params_flow.rb:83:29:83:29 | y |
-| params_flow.rb:93:42:93:50 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:93:42:93:50 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:93:42:93:50 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:89:5:89:10 | synthetic splat argument |
-| params_flow.rb:93:42:93:50 | call to taint | type tracker with call steps with content splat position 5 (shifted) | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:93:42:93:50 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:93:42:93:50 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:89:5:89:10 | synthetic splat argument |
+| params_flow.rb:93:42:93:50 | call to taint | type tracker with call steps with content element 5 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:93:42:93:50 | call to taint | type tracker without call steps | params_flow.rb:93:42:93:50 | call to taint |
 | params_flow.rb:93:42:93:50 | call to taint | type tracker without call steps with content element 3 | params_flow.rb:93:8:93:51 | call to [] |
 | params_flow.rb:93:42:93:50 | call to taint | type tracker without call steps with content element 3 | params_flow.rb:93:8:93:51 | synthetic splat argument |
 | params_flow.rb:93:42:93:50 | call to taint | type tracker without call steps with content element 3 | params_flow.rb:94:32:94:36 | * ... |
-| params_flow.rb:93:42:93:50 | call to taint | type tracker without call steps with content splat position 5 (shifted) | params_flow.rb:94:1:94:48 | synthetic splat argument |
-| params_flow.rb:93:42:93:50 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:93:42:93:50 | call to taint | type tracker without call steps with content element 5 | params_flow.rb:94:1:94:48 | synthetic splat argument |
 | params_flow.rb:93:42:93:50 | synthetic splat argument | type tracker without call steps | params_flow.rb:93:42:93:50 | synthetic splat argument |
 | params_flow.rb:93:48:93:49 | 43 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:93:48:93:49 | 43 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:93:48:93:49 | 43 | type tracker with call steps | params_flow.rb:83:29:83:29 | y |
-| params_flow.rb:93:48:93:49 | 43 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:93:48:93:49 | 43 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:93:48:93:49 | 43 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:93:48:93:49 | 43 | type tracker with call steps with content splat position 0 | params_flow.rb:89:5:89:10 | synthetic splat argument |
-| params_flow.rb:93:48:93:49 | 43 | type tracker with call steps with content splat position 5 (shifted) | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:93:48:93:49 | 43 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:93:48:93:49 | 43 | type tracker with call steps with content element 0 | params_flow.rb:89:5:89:10 | synthetic splat argument |
+| params_flow.rb:93:48:93:49 | 43 | type tracker with call steps with content element 5 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:93:48:93:49 | 43 | type tracker without call steps | params_flow.rb:93:42:93:50 | call to taint |
 | params_flow.rb:93:48:93:49 | 43 | type tracker without call steps | params_flow.rb:93:48:93:49 | 43 |
+| params_flow.rb:93:48:93:49 | 43 | type tracker without call steps with content element 0 | params_flow.rb:93:42:93:50 | synthetic splat argument |
 | params_flow.rb:93:48:93:49 | 43 | type tracker without call steps with content element 3 | params_flow.rb:93:8:93:51 | call to [] |
 | params_flow.rb:93:48:93:49 | 43 | type tracker without call steps with content element 3 | params_flow.rb:93:8:93:51 | synthetic splat argument |
 | params_flow.rb:93:48:93:49 | 43 | type tracker without call steps with content element 3 | params_flow.rb:94:32:94:36 | * ... |
-| params_flow.rb:93:48:93:49 | 43 | type tracker without call steps with content splat position 0 | params_flow.rb:93:42:93:50 | synthetic splat argument |
-| params_flow.rb:93:48:93:49 | 43 | type tracker without call steps with content splat position 5 (shifted) | params_flow.rb:94:1:94:48 | synthetic splat argument |
+| params_flow.rb:93:48:93:49 | 43 | type tracker without call steps with content element 5 | params_flow.rb:94:1:94:48 | synthetic splat argument |
 | params_flow.rb:94:1:94:48 | call to pos_many | type tracker without call steps | params_flow.rb:94:1:94:48 | call to pos_many |
 | params_flow.rb:94:1:94:48 | synthetic splat argument | type tracker with call steps | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:94:1:94:48 | synthetic splat argument | type tracker without call steps | params_flow.rb:94:1:94:48 | synthetic splat argument |
 | params_flow.rb:94:10:94:18 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:94:10:94:18 | call to taint | type tracker with call steps | params_flow.rb:83:14:83:14 | t |
-| params_flow.rb:94:10:94:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:94:10:94:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:94:10:94:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
-| params_flow.rb:94:10:94:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:84:5:84:10 | synthetic splat argument |
+| params_flow.rb:94:10:94:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:94:10:94:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:94:10:94:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:84:5:84:10 | synthetic splat argument |
 | params_flow.rb:94:10:94:18 | call to taint | type tracker without call steps | params_flow.rb:94:10:94:18 | call to taint |
-| params_flow.rb:94:10:94:18 | call to taint | type tracker without call steps with content splat position 0 | params_flow.rb:94:1:94:48 | synthetic splat argument |
-| params_flow.rb:94:10:94:18 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:94:10:94:18 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:94:1:94:48 | synthetic splat argument |
 | params_flow.rb:94:10:94:18 | synthetic splat argument | type tracker without call steps | params_flow.rb:94:10:94:18 | synthetic splat argument |
 | params_flow.rb:94:16:94:17 | 38 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:94:16:94:17 | 38 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:94:16:94:17 | 38 | type tracker with call steps | params_flow.rb:83:14:83:14 | t |
-| params_flow.rb:94:16:94:17 | 38 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:94:16:94:17 | 38 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:94:16:94:17 | 38 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:94:16:94:17 | 38 | type tracker with call steps with content splat position 0 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
-| params_flow.rb:94:16:94:17 | 38 | type tracker with call steps with content splat position 0 | params_flow.rb:84:5:84:10 | synthetic splat argument |
+| params_flow.rb:94:16:94:17 | 38 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:94:16:94:17 | 38 | type tracker with call steps with content element 0 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:94:16:94:17 | 38 | type tracker with call steps with content element 0 | params_flow.rb:84:5:84:10 | synthetic splat argument |
 | params_flow.rb:94:16:94:17 | 38 | type tracker without call steps | params_flow.rb:94:10:94:18 | call to taint |
 | params_flow.rb:94:16:94:17 | 38 | type tracker without call steps | params_flow.rb:94:16:94:17 | 38 |
-| params_flow.rb:94:16:94:17 | 38 | type tracker without call steps with content splat position 0 | params_flow.rb:94:1:94:48 | synthetic splat argument |
-| params_flow.rb:94:16:94:17 | 38 | type tracker without call steps with content splat position 0 | params_flow.rb:94:10:94:18 | synthetic splat argument |
+| params_flow.rb:94:16:94:17 | 38 | type tracker without call steps with content element 0 | params_flow.rb:94:1:94:48 | synthetic splat argument |
+| params_flow.rb:94:16:94:17 | 38 | type tracker without call steps with content element 0 | params_flow.rb:94:10:94:18 | synthetic splat argument |
 | params_flow.rb:94:21:94:29 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:94:21:94:29 | call to taint | type tracker with call steps | params_flow.rb:83:17:83:17 | u |
-| params_flow.rb:94:21:94:29 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:94:21:94:29 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:94:21:94:29 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:85:5:85:10 | synthetic splat argument |
-| params_flow.rb:94:21:94:29 | call to taint | type tracker with call steps with content splat position 1 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:94:21:94:29 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:94:21:94:29 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:85:5:85:10 | synthetic splat argument |
+| params_flow.rb:94:21:94:29 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:94:21:94:29 | call to taint | type tracker without call steps | params_flow.rb:94:21:94:29 | call to taint |
-| params_flow.rb:94:21:94:29 | call to taint | type tracker without call steps with content splat position 1 | params_flow.rb:94:1:94:48 | synthetic splat argument |
-| params_flow.rb:94:21:94:29 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:94:21:94:29 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:94:1:94:48 | synthetic splat argument |
 | params_flow.rb:94:21:94:29 | synthetic splat argument | type tracker without call steps | params_flow.rb:94:21:94:29 | synthetic splat argument |
 | params_flow.rb:94:27:94:28 | 39 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:94:27:94:28 | 39 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:94:27:94:28 | 39 | type tracker with call steps | params_flow.rb:83:17:83:17 | u |
-| params_flow.rb:94:27:94:28 | 39 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:94:27:94:28 | 39 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:94:27:94:28 | 39 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:94:27:94:28 | 39 | type tracker with call steps with content splat position 0 | params_flow.rb:85:5:85:10 | synthetic splat argument |
-| params_flow.rb:94:27:94:28 | 39 | type tracker with call steps with content splat position 1 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
+| params_flow.rb:94:27:94:28 | 39 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:94:27:94:28 | 39 | type tracker with call steps with content element 0 | params_flow.rb:85:5:85:10 | synthetic splat argument |
+| params_flow.rb:94:27:94:28 | 39 | type tracker with call steps with content element 1 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:94:27:94:28 | 39 | type tracker without call steps | params_flow.rb:94:21:94:29 | call to taint |
 | params_flow.rb:94:27:94:28 | 39 | type tracker without call steps | params_flow.rb:94:27:94:28 | 39 |
-| params_flow.rb:94:27:94:28 | 39 | type tracker without call steps with content splat position 0 | params_flow.rb:94:21:94:29 | synthetic splat argument |
-| params_flow.rb:94:27:94:28 | 39 | type tracker without call steps with content splat position 1 | params_flow.rb:94:1:94:48 | synthetic splat argument |
+| params_flow.rb:94:27:94:28 | 39 | type tracker without call steps with content element 0 | params_flow.rb:94:21:94:29 | synthetic splat argument |
+| params_flow.rb:94:27:94:28 | 39 | type tracker without call steps with content element 1 | params_flow.rb:94:1:94:48 | synthetic splat argument |
 | params_flow.rb:94:32:94:36 | * ... | type tracker without call steps | params_flow.rb:94:32:94:36 | * ... |
 | params_flow.rb:94:39:94:47 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:94:39:94:47 | call to taint | type tracker with call steps | params_flow.rb:83:23:83:23 | w |
-| params_flow.rb:94:39:94:47 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:94:39:94:47 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:94:39:94:47 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:87:5:87:10 | synthetic splat argument |
+| params_flow.rb:94:39:94:47 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:94:39:94:47 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:87:5:87:10 | synthetic splat argument |
 | params_flow.rb:94:39:94:47 | call to taint | type tracker without call steps | params_flow.rb:94:39:94:47 | call to taint |
-| params_flow.rb:94:39:94:47 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:94:39:94:47 | synthetic splat argument | type tracker without call steps | params_flow.rb:94:39:94:47 | synthetic splat argument |
 | params_flow.rb:94:45:94:46 | 44 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:94:45:94:46 | 44 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:94:45:94:46 | 44 | type tracker with call steps | params_flow.rb:83:23:83:23 | w |
-| params_flow.rb:94:45:94:46 | 44 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:94:45:94:46 | 44 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:94:45:94:46 | 44 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:94:45:94:46 | 44 | type tracker with call steps with content splat position 0 | params_flow.rb:87:5:87:10 | synthetic splat argument |
+| params_flow.rb:94:45:94:46 | 44 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:94:45:94:46 | 44 | type tracker with call steps with content element 0 | params_flow.rb:87:5:87:10 | synthetic splat argument |
 | params_flow.rb:94:45:94:46 | 44 | type tracker without call steps | params_flow.rb:94:39:94:47 | call to taint |
 | params_flow.rb:94:45:94:46 | 44 | type tracker without call steps | params_flow.rb:94:45:94:46 | 44 |
-| params_flow.rb:94:45:94:46 | 44 | type tracker without call steps with content splat position 0 | params_flow.rb:94:39:94:47 | synthetic splat argument |
+| params_flow.rb:94:45:94:46 | 44 | type tracker without call steps with content element 0 | params_flow.rb:94:39:94:47 | synthetic splat argument |
 | params_flow.rb:96:1:96:88 | call to splatmid | type tracker without call steps | params_flow.rb:96:1:96:88 | call to splatmid |
 | params_flow.rb:96:1:96:88 | synthetic splat argument | type tracker with call steps | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:1:96:88 | synthetic splat argument | type tracker without call steps | params_flow.rb:96:1:96:88 | synthetic splat argument |
 | params_flow.rb:96:10:96:18 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:96:10:96:18 | call to taint | type tracker with call steps | params_flow.rb:69:14:69:14 | x |
-| params_flow.rb:96:10:96:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:96:10:96:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:96:10:96:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
-| params_flow.rb:96:10:96:18 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:70:5:70:10 | synthetic splat argument |
+| params_flow.rb:96:10:96:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:96:10:96:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:96:10:96:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:70:5:70:10 | synthetic splat argument |
 | params_flow.rb:96:10:96:18 | call to taint | type tracker without call steps | params_flow.rb:96:10:96:18 | call to taint |
-| params_flow.rb:96:10:96:18 | call to taint | type tracker without call steps with content splat position 0 | params_flow.rb:96:1:96:88 | synthetic splat argument |
-| params_flow.rb:96:10:96:18 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:96:10:96:18 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:96:1:96:88 | synthetic splat argument |
 | params_flow.rb:96:10:96:18 | synthetic splat argument | type tracker without call steps | params_flow.rb:96:10:96:18 | synthetic splat argument |
 | params_flow.rb:96:16:96:17 | 45 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:16:96:17 | 45 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:96:16:96:17 | 45 | type tracker with call steps | params_flow.rb:69:14:69:14 | x |
-| params_flow.rb:96:16:96:17 | 45 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:96:16:96:17 | 45 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:96:16:96:17 | 45 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:96:16:96:17 | 45 | type tracker with call steps with content splat position 0 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
-| params_flow.rb:96:16:96:17 | 45 | type tracker with call steps with content splat position 0 | params_flow.rb:70:5:70:10 | synthetic splat argument |
+| params_flow.rb:96:16:96:17 | 45 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:96:16:96:17 | 45 | type tracker with call steps with content element 0 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:96:16:96:17 | 45 | type tracker with call steps with content element 0 | params_flow.rb:70:5:70:10 | synthetic splat argument |
 | params_flow.rb:96:16:96:17 | 45 | type tracker without call steps | params_flow.rb:96:10:96:18 | call to taint |
 | params_flow.rb:96:16:96:17 | 45 | type tracker without call steps | params_flow.rb:96:16:96:17 | 45 |
-| params_flow.rb:96:16:96:17 | 45 | type tracker without call steps with content splat position 0 | params_flow.rb:96:1:96:88 | synthetic splat argument |
-| params_flow.rb:96:16:96:17 | 45 | type tracker without call steps with content splat position 0 | params_flow.rb:96:10:96:18 | synthetic splat argument |
+| params_flow.rb:96:16:96:17 | 45 | type tracker without call steps with content element 0 | params_flow.rb:96:1:96:88 | synthetic splat argument |
+| params_flow.rb:96:16:96:17 | 45 | type tracker without call steps with content element 0 | params_flow.rb:96:10:96:18 | synthetic splat argument |
 | params_flow.rb:96:21:96:29 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:96:21:96:29 | call to taint | type tracker with call steps | params_flow.rb:69:17:69:17 | y |
-| params_flow.rb:96:21:96:29 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:96:21:96:29 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:96:21:96:29 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
-| params_flow.rb:96:21:96:29 | call to taint | type tracker with call steps with content splat position 1 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:96:21:96:29 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:96:21:96:29 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
+| params_flow.rb:96:21:96:29 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:21:96:29 | call to taint | type tracker without call steps | params_flow.rb:96:21:96:29 | call to taint |
-| params_flow.rb:96:21:96:29 | call to taint | type tracker without call steps with content splat position 1 | params_flow.rb:96:1:96:88 | synthetic splat argument |
-| params_flow.rb:96:21:96:29 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:96:21:96:29 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:96:1:96:88 | synthetic splat argument |
 | params_flow.rb:96:21:96:29 | synthetic splat argument | type tracker without call steps | params_flow.rb:96:21:96:29 | synthetic splat argument |
 | params_flow.rb:96:27:96:28 | 46 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:27:96:28 | 46 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:96:27:96:28 | 46 | type tracker with call steps | params_flow.rb:69:17:69:17 | y |
-| params_flow.rb:96:27:96:28 | 46 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:96:27:96:28 | 46 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:96:27:96:28 | 46 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:96:27:96:28 | 46 | type tracker with call steps with content splat position 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
-| params_flow.rb:96:27:96:28 | 46 | type tracker with call steps with content splat position 1 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:96:27:96:28 | 46 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:96:27:96:28 | 46 | type tracker with call steps with content element 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
+| params_flow.rb:96:27:96:28 | 46 | type tracker with call steps with content element 1 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:27:96:28 | 46 | type tracker without call steps | params_flow.rb:96:21:96:29 | call to taint |
 | params_flow.rb:96:27:96:28 | 46 | type tracker without call steps | params_flow.rb:96:27:96:28 | 46 |
-| params_flow.rb:96:27:96:28 | 46 | type tracker without call steps with content splat position 0 | params_flow.rb:96:21:96:29 | synthetic splat argument |
-| params_flow.rb:96:27:96:28 | 46 | type tracker without call steps with content splat position 1 | params_flow.rb:96:1:96:88 | synthetic splat argument |
+| params_flow.rb:96:27:96:28 | 46 | type tracker without call steps with content element 0 | params_flow.rb:96:21:96:29 | synthetic splat argument |
+| params_flow.rb:96:27:96:28 | 46 | type tracker without call steps with content element 1 | params_flow.rb:96:1:96:88 | synthetic splat argument |
 | params_flow.rb:96:32:96:65 | * ... | type tracker without call steps | params_flow.rb:96:32:96:65 | * ... |
 | params_flow.rb:96:33:96:65 | Array | type tracker without call steps | params_flow.rb:96:33:96:65 | Array |
-| params_flow.rb:96:33:96:65 | call to [] | type tracker with call steps with content splat position 2 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:96:33:96:65 | call to [] | type tracker with call steps with content element 2 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:33:96:65 | call to [] | type tracker without call steps | params_flow.rb:96:33:96:65 | call to [] |
 | params_flow.rb:96:33:96:65 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:96:32:96:65 | * ... |
-| params_flow.rb:96:33:96:65 | call to [] | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:96:1:96:88 | synthetic splat argument |
-| params_flow.rb:96:33:96:65 | synthetic splat argument | type tracker with call steps with content splat position 2 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:96:33:96:65 | call to [] | type tracker without call steps with content element 2 | params_flow.rb:96:1:96:88 | synthetic splat argument |
+| params_flow.rb:96:33:96:65 | synthetic splat argument | type tracker with call steps with content element 2 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:33:96:65 | synthetic splat argument | type tracker without call steps | params_flow.rb:96:33:96:65 | call to [] |
 | params_flow.rb:96:33:96:65 | synthetic splat argument | type tracker without call steps | params_flow.rb:96:33:96:65 | synthetic splat argument |
 | params_flow.rb:96:33:96:65 | synthetic splat argument | type tracker without call steps with content element 0 or unknown | params_flow.rb:96:32:96:65 | * ... |
-| params_flow.rb:96:33:96:65 | synthetic splat argument | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:96:1:96:88 | synthetic splat argument |
-| params_flow.rb:96:34:96:42 | call to taint | type tracker with call steps with content splat position 2 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:96:33:96:65 | synthetic splat argument | type tracker without call steps with content element 2 | params_flow.rb:96:1:96:88 | synthetic splat argument |
+| params_flow.rb:96:34:96:42 | call to taint | type tracker with call steps with content element 2 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:34:96:42 | call to taint | type tracker without call steps | params_flow.rb:96:34:96:42 | call to taint |
 | params_flow.rb:96:34:96:42 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:96:32:96:65 | * ... |
 | params_flow.rb:96:34:96:42 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:96:33:96:65 | call to [] |
 | params_flow.rb:96:34:96:42 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:96:33:96:65 | synthetic splat argument |
-| params_flow.rb:96:34:96:42 | call to taint | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:96:1:96:88 | synthetic splat argument |
-| params_flow.rb:96:34:96:42 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:96:34:96:42 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:96:1:96:88 | synthetic splat argument |
 | params_flow.rb:96:34:96:42 | synthetic splat argument | type tracker without call steps | params_flow.rb:96:34:96:42 | synthetic splat argument |
 | params_flow.rb:96:40:96:41 | 47 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:96:40:96:41 | 47 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:96:40:96:41 | 47 | type tracker with call steps with content splat position 2 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:96:40:96:41 | 47 | type tracker with call steps with content element 2 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:40:96:41 | 47 | type tracker without call steps | params_flow.rb:96:34:96:42 | call to taint |
 | params_flow.rb:96:40:96:41 | 47 | type tracker without call steps | params_flow.rb:96:40:96:41 | 47 |
 | params_flow.rb:96:40:96:41 | 47 | type tracker without call steps with content element 0 | params_flow.rb:96:32:96:65 | * ... |
 | params_flow.rb:96:40:96:41 | 47 | type tracker without call steps with content element 0 | params_flow.rb:96:33:96:65 | call to [] |
 | params_flow.rb:96:40:96:41 | 47 | type tracker without call steps with content element 0 | params_flow.rb:96:33:96:65 | synthetic splat argument |
-| params_flow.rb:96:40:96:41 | 47 | type tracker without call steps with content splat position 0 | params_flow.rb:96:34:96:42 | synthetic splat argument |
-| params_flow.rb:96:40:96:41 | 47 | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:96:1:96:88 | synthetic splat argument |
-| params_flow.rb:96:45:96:53 | call to taint | type tracker with call steps with content splat position 3 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:96:40:96:41 | 47 | type tracker without call steps with content element 0 | params_flow.rb:96:34:96:42 | synthetic splat argument |
+| params_flow.rb:96:40:96:41 | 47 | type tracker without call steps with content element 2 | params_flow.rb:96:1:96:88 | synthetic splat argument |
+| params_flow.rb:96:45:96:53 | call to taint | type tracker with call steps with content element 3 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:45:96:53 | call to taint | type tracker without call steps | params_flow.rb:96:45:96:53 | call to taint |
 | params_flow.rb:96:45:96:53 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:96:32:96:65 | * ... |
 | params_flow.rb:96:45:96:53 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:96:33:96:65 | call to [] |
 | params_flow.rb:96:45:96:53 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:96:33:96:65 | synthetic splat argument |
-| params_flow.rb:96:45:96:53 | call to taint | type tracker without call steps with content splat position 3 (shifted) | params_flow.rb:96:1:96:88 | synthetic splat argument |
-| params_flow.rb:96:45:96:53 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:96:45:96:53 | call to taint | type tracker without call steps with content element 3 | params_flow.rb:96:1:96:88 | synthetic splat argument |
 | params_flow.rb:96:45:96:53 | synthetic splat argument | type tracker without call steps | params_flow.rb:96:45:96:53 | synthetic splat argument |
 | params_flow.rb:96:51:96:52 | 48 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:96:51:96:52 | 48 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:96:51:96:52 | 48 | type tracker with call steps with content splat position 3 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:96:51:96:52 | 48 | type tracker with call steps with content element 3 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:51:96:52 | 48 | type tracker without call steps | params_flow.rb:96:45:96:53 | call to taint |
 | params_flow.rb:96:51:96:52 | 48 | type tracker without call steps | params_flow.rb:96:51:96:52 | 48 |
+| params_flow.rb:96:51:96:52 | 48 | type tracker without call steps with content element 0 | params_flow.rb:96:45:96:53 | synthetic splat argument |
 | params_flow.rb:96:51:96:52 | 48 | type tracker without call steps with content element 1 | params_flow.rb:96:32:96:65 | * ... |
 | params_flow.rb:96:51:96:52 | 48 | type tracker without call steps with content element 1 | params_flow.rb:96:33:96:65 | call to [] |
 | params_flow.rb:96:51:96:52 | 48 | type tracker without call steps with content element 1 | params_flow.rb:96:33:96:65 | synthetic splat argument |
-| params_flow.rb:96:51:96:52 | 48 | type tracker without call steps with content splat position 0 | params_flow.rb:96:45:96:53 | synthetic splat argument |
-| params_flow.rb:96:51:96:52 | 48 | type tracker without call steps with content splat position 3 (shifted) | params_flow.rb:96:1:96:88 | synthetic splat argument |
-| params_flow.rb:96:56:96:64 | call to taint | type tracker with call steps with content splat position 4 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:96:51:96:52 | 48 | type tracker without call steps with content element 3 | params_flow.rb:96:1:96:88 | synthetic splat argument |
+| params_flow.rb:96:56:96:64 | call to taint | type tracker with call steps with content element 4 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:56:96:64 | call to taint | type tracker without call steps | params_flow.rb:96:56:96:64 | call to taint |
 | params_flow.rb:96:56:96:64 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:96:32:96:65 | * ... |
 | params_flow.rb:96:56:96:64 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:96:33:96:65 | call to [] |
 | params_flow.rb:96:56:96:64 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:96:33:96:65 | synthetic splat argument |
-| params_flow.rb:96:56:96:64 | call to taint | type tracker without call steps with content splat position 4 (shifted) | params_flow.rb:96:1:96:88 | synthetic splat argument |
-| params_flow.rb:96:56:96:64 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:96:56:96:64 | call to taint | type tracker without call steps with content element 4 | params_flow.rb:96:1:96:88 | synthetic splat argument |
 | params_flow.rb:96:56:96:64 | synthetic splat argument | type tracker without call steps | params_flow.rb:96:56:96:64 | synthetic splat argument |
 | params_flow.rb:96:62:96:63 | 49 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:96:62:96:63 | 49 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:96:62:96:63 | 49 | type tracker with call steps with content splat position 4 (shifted) | params_flow.rb:69:1:76:3 | synthetic splat parameter |
+| params_flow.rb:96:62:96:63 | 49 | type tracker with call steps with content element 4 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:62:96:63 | 49 | type tracker without call steps | params_flow.rb:96:56:96:64 | call to taint |
 | params_flow.rb:96:62:96:63 | 49 | type tracker without call steps | params_flow.rb:96:62:96:63 | 49 |
+| params_flow.rb:96:62:96:63 | 49 | type tracker without call steps with content element 0 | params_flow.rb:96:56:96:64 | synthetic splat argument |
 | params_flow.rb:96:62:96:63 | 49 | type tracker without call steps with content element 2 | params_flow.rb:96:32:96:65 | * ... |
 | params_flow.rb:96:62:96:63 | 49 | type tracker without call steps with content element 2 | params_flow.rb:96:33:96:65 | call to [] |
 | params_flow.rb:96:62:96:63 | 49 | type tracker without call steps with content element 2 | params_flow.rb:96:33:96:65 | synthetic splat argument |
-| params_flow.rb:96:62:96:63 | 49 | type tracker without call steps with content splat position 0 | params_flow.rb:96:56:96:64 | synthetic splat argument |
-| params_flow.rb:96:62:96:63 | 49 | type tracker without call steps with content splat position 4 (shifted) | params_flow.rb:96:1:96:88 | synthetic splat argument |
+| params_flow.rb:96:62:96:63 | 49 | type tracker without call steps with content element 4 | params_flow.rb:96:1:96:88 | synthetic splat argument |
 | params_flow.rb:96:68:96:76 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:96:68:96:76 | call to taint | type tracker with call steps | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:96:68:96:76 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:96:68:96:76 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:96:68:96:76 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:74:5:74:10 | synthetic splat argument |
+| params_flow.rb:96:68:96:76 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:96:68:96:76 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:74:5:74:10 | synthetic splat argument |
 | params_flow.rb:96:68:96:76 | call to taint | type tracker without call steps | params_flow.rb:96:68:96:76 | call to taint |
-| params_flow.rb:96:68:96:76 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:96:68:96:76 | synthetic splat argument | type tracker without call steps | params_flow.rb:96:68:96:76 | synthetic splat argument |
 | params_flow.rb:96:74:96:75 | 50 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:74:96:75 | 50 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:96:74:96:75 | 50 | type tracker with call steps | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:96:74:96:75 | 50 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:96:74:96:75 | 50 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:96:74:96:75 | 50 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:96:74:96:75 | 50 | type tracker with call steps with content splat position 0 | params_flow.rb:74:5:74:10 | synthetic splat argument |
+| params_flow.rb:96:74:96:75 | 50 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:96:74:96:75 | 50 | type tracker with call steps with content element 0 | params_flow.rb:74:5:74:10 | synthetic splat argument |
 | params_flow.rb:96:74:96:75 | 50 | type tracker without call steps | params_flow.rb:96:68:96:76 | call to taint |
 | params_flow.rb:96:74:96:75 | 50 | type tracker without call steps | params_flow.rb:96:74:96:75 | 50 |
-| params_flow.rb:96:74:96:75 | 50 | type tracker without call steps with content splat position 0 | params_flow.rb:96:68:96:76 | synthetic splat argument |
+| params_flow.rb:96:74:96:75 | 50 | type tracker without call steps with content element 0 | params_flow.rb:96:68:96:76 | synthetic splat argument |
 | params_flow.rb:96:79:96:87 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:96:79:96:87 | call to taint | type tracker with call steps | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:96:79:96:87 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:96:79:96:87 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:96:79:96:87 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:75:5:75:10 | synthetic splat argument |
+| params_flow.rb:96:79:96:87 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:96:79:96:87 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:75:5:75:10 | synthetic splat argument |
 | params_flow.rb:96:79:96:87 | call to taint | type tracker without call steps | params_flow.rb:96:79:96:87 | call to taint |
-| params_flow.rb:96:79:96:87 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:96:79:96:87 | synthetic splat argument | type tracker without call steps | params_flow.rb:96:79:96:87 | synthetic splat argument |
 | params_flow.rb:96:85:96:86 | 51 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:85:96:86 | 51 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:96:85:96:86 | 51 | type tracker with call steps | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:96:85:96:86 | 51 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:96:85:96:86 | 51 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:96:85:96:86 | 51 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:96:85:96:86 | 51 | type tracker with call steps with content splat position 0 | params_flow.rb:75:5:75:10 | synthetic splat argument |
+| params_flow.rb:96:85:96:86 | 51 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:96:85:96:86 | 51 | type tracker with call steps with content element 0 | params_flow.rb:75:5:75:10 | synthetic splat argument |
 | params_flow.rb:96:85:96:86 | 51 | type tracker without call steps | params_flow.rb:96:79:96:87 | call to taint |
 | params_flow.rb:96:85:96:86 | 51 | type tracker without call steps | params_flow.rb:96:85:96:86 | 51 |
-| params_flow.rb:96:85:96:86 | 51 | type tracker without call steps with content splat position 0 | params_flow.rb:96:79:96:87 | synthetic splat argument |
+| params_flow.rb:96:85:96:86 | 51 | type tracker without call steps with content element 0 | params_flow.rb:96:79:96:87 | synthetic splat argument |
 | params_flow.rb:98:1:103:3 | &block | type tracker without call steps | params_flow.rb:98:1:103:3 | &block |
 | params_flow.rb:98:1:103:3 | self in splatmidsmall | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
 | params_flow.rb:98:1:103:3 | self in splatmidsmall | type tracker without call steps | params_flow.rb:98:1:103:3 | self in splatmidsmall |
 | params_flow.rb:98:1:103:3 | splatmidsmall | type tracker without call steps | params_flow.rb:98:1:103:3 | splatmidsmall |
 | params_flow.rb:98:1:103:3 | synthetic splat parameter | type tracker without call steps | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:98:19:98:19 | a | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:98:19:98:19 | a | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:98:19:98:19 | a | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:98:19:98:19 | a | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:98:19:98:19 | a | type tracker without call steps | params_flow.rb:98:19:98:19 | a |
 | params_flow.rb:98:19:98:19 | a | type tracker without call steps | params_flow.rb:98:19:98:19 | a |
-| params_flow.rb:98:19:98:19 | a | type tracker without call steps with content splat position 0 | params_flow.rb:99:5:99:10 | synthetic splat argument |
+| params_flow.rb:98:19:98:19 | a | type tracker without call steps with content element 0 | params_flow.rb:99:5:99:10 | synthetic splat argument |
 | params_flow.rb:98:22:98:28 | *splats | type tracker without call steps | params_flow.rb:98:22:98:28 | *splats |
 | params_flow.rb:98:23:98:28 | splats | type tracker without call steps | params_flow.rb:98:23:98:28 | splats |
 | params_flow.rb:98:31:98:31 | b | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:98:31:98:31 | b | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:98:31:98:31 | b | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:98:31:98:31 | b | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:98:31:98:31 | b | type tracker without call steps | params_flow.rb:98:31:98:31 | b |
 | params_flow.rb:98:31:98:31 | b | type tracker without call steps | params_flow.rb:98:31:98:31 | b |
-| params_flow.rb:98:31:98:31 | b | type tracker without call steps with content splat position 0 | params_flow.rb:102:5:102:10 | synthetic splat argument |
+| params_flow.rb:98:31:98:31 | b | type tracker without call steps with content element 0 | params_flow.rb:102:5:102:10 | synthetic splat argument |
 | params_flow.rb:99:5:99:10 | call to sink | type tracker without call steps | params_flow.rb:99:5:99:10 | call to sink |
-| params_flow.rb:99:5:99:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:99:5:99:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:99:5:99:10 | synthetic splat argument |
 | params_flow.rb:100:5:100:18 | call to sink | type tracker without call steps | params_flow.rb:100:5:100:18 | call to sink |
-| params_flow.rb:100:5:100:18 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:100:5:100:18 | synthetic splat argument | type tracker without call steps | params_flow.rb:100:5:100:18 | synthetic splat argument |
 | params_flow.rb:100:10:100:18 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:100:10:100:18 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:100:10:100:18 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:100:10:100:18 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:100:10:100:18 | ...[...] | type tracker without call steps | params_flow.rb:100:10:100:18 | ...[...] |
-| params_flow.rb:100:10:100:18 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:100:5:100:18 | synthetic splat argument |
+| params_flow.rb:100:10:100:18 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:100:5:100:18 | synthetic splat argument |
 | params_flow.rb:100:10:100:18 | synthetic splat argument | type tracker without call steps | params_flow.rb:100:10:100:18 | synthetic splat argument |
 | params_flow.rb:100:17:100:17 | 0 | type tracker without call steps | params_flow.rb:100:17:100:17 | 0 |
-| params_flow.rb:100:17:100:17 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:100:10:100:18 | synthetic splat argument |
+| params_flow.rb:100:17:100:17 | 0 | type tracker without call steps with content element 0 | params_flow.rb:100:10:100:18 | synthetic splat argument |
 | params_flow.rb:101:5:101:18 | call to sink | type tracker without call steps | params_flow.rb:101:5:101:18 | call to sink |
-| params_flow.rb:101:5:101:18 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:101:5:101:18 | synthetic splat argument | type tracker without call steps | params_flow.rb:101:5:101:18 | synthetic splat argument |
 | params_flow.rb:101:10:101:18 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:101:10:101:18 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:101:10:101:18 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:101:10:101:18 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:101:10:101:18 | ...[...] | type tracker without call steps | params_flow.rb:101:10:101:18 | ...[...] |
-| params_flow.rb:101:10:101:18 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:101:5:101:18 | synthetic splat argument |
+| params_flow.rb:101:10:101:18 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:101:5:101:18 | synthetic splat argument |
 | params_flow.rb:101:10:101:18 | synthetic splat argument | type tracker without call steps | params_flow.rb:101:10:101:18 | synthetic splat argument |
 | params_flow.rb:101:17:101:17 | 1 | type tracker without call steps | params_flow.rb:101:17:101:17 | 1 |
-| params_flow.rb:101:17:101:17 | 1 | type tracker without call steps with content splat position 0 | params_flow.rb:101:10:101:18 | synthetic splat argument |
+| params_flow.rb:101:17:101:17 | 1 | type tracker without call steps with content element 0 | params_flow.rb:101:10:101:18 | synthetic splat argument |
 | params_flow.rb:102:5:102:10 | call to sink | type tracker without call steps | params_flow.rb:102:5:102:10 | call to sink |
 | params_flow.rb:102:5:102:10 | call to sink | type tracker without call steps | params_flow.rb:105:1:105:49 | call to splatmidsmall |
 | params_flow.rb:102:5:102:10 | call to sink | type tracker without call steps | params_flow.rb:106:1:106:46 | call to splatmidsmall |
-| params_flow.rb:102:5:102:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:102:5:102:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:102:5:102:10 | synthetic splat argument |
 | params_flow.rb:105:1:105:49 | call to splatmidsmall | type tracker without call steps | params_flow.rb:105:1:105:49 | call to splatmidsmall |
 | params_flow.rb:105:1:105:49 | synthetic splat argument | type tracker with call steps | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:105:1:105:49 | synthetic splat argument | type tracker without call steps | params_flow.rb:105:1:105:49 | synthetic splat argument |
 | params_flow.rb:105:15:105:23 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:105:15:105:23 | call to taint | type tracker with call steps | params_flow.rb:98:19:98:19 | a |
-| params_flow.rb:105:15:105:23 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:105:15:105:23 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:105:15:105:23 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
-| params_flow.rb:105:15:105:23 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:99:5:99:10 | synthetic splat argument |
+| params_flow.rb:105:15:105:23 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:105:15:105:23 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
+| params_flow.rb:105:15:105:23 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:99:5:99:10 | synthetic splat argument |
 | params_flow.rb:105:15:105:23 | call to taint | type tracker without call steps | params_flow.rb:105:15:105:23 | call to taint |
-| params_flow.rb:105:15:105:23 | call to taint | type tracker without call steps with content splat position 0 | params_flow.rb:105:1:105:49 | synthetic splat argument |
-| params_flow.rb:105:15:105:23 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:105:15:105:23 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:105:1:105:49 | synthetic splat argument |
 | params_flow.rb:105:15:105:23 | synthetic splat argument | type tracker without call steps | params_flow.rb:105:15:105:23 | synthetic splat argument |
 | params_flow.rb:105:21:105:22 | 52 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:105:21:105:22 | 52 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:105:21:105:22 | 52 | type tracker with call steps | params_flow.rb:98:19:98:19 | a |
-| params_flow.rb:105:21:105:22 | 52 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:105:21:105:22 | 52 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:105:21:105:22 | 52 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:105:21:105:22 | 52 | type tracker with call steps with content splat position 0 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
-| params_flow.rb:105:21:105:22 | 52 | type tracker with call steps with content splat position 0 | params_flow.rb:99:5:99:10 | synthetic splat argument |
+| params_flow.rb:105:21:105:22 | 52 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:105:21:105:22 | 52 | type tracker with call steps with content element 0 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
+| params_flow.rb:105:21:105:22 | 52 | type tracker with call steps with content element 0 | params_flow.rb:99:5:99:10 | synthetic splat argument |
 | params_flow.rb:105:21:105:22 | 52 | type tracker without call steps | params_flow.rb:105:15:105:23 | call to taint |
 | params_flow.rb:105:21:105:22 | 52 | type tracker without call steps | params_flow.rb:105:21:105:22 | 52 |
-| params_flow.rb:105:21:105:22 | 52 | type tracker without call steps with content splat position 0 | params_flow.rb:105:1:105:49 | synthetic splat argument |
-| params_flow.rb:105:21:105:22 | 52 | type tracker without call steps with content splat position 0 | params_flow.rb:105:15:105:23 | synthetic splat argument |
+| params_flow.rb:105:21:105:22 | 52 | type tracker without call steps with content element 0 | params_flow.rb:105:1:105:49 | synthetic splat argument |
+| params_flow.rb:105:21:105:22 | 52 | type tracker without call steps with content element 0 | params_flow.rb:105:15:105:23 | synthetic splat argument |
 | params_flow.rb:105:26:105:48 | * ... | type tracker without call steps | params_flow.rb:105:26:105:48 | * ... |
 | params_flow.rb:105:27:105:48 | Array | type tracker without call steps | params_flow.rb:105:27:105:48 | Array |
-| params_flow.rb:105:27:105:48 | call to [] | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:98:1:103:3 | synthetic splat parameter |
+| params_flow.rb:105:27:105:48 | call to [] | type tracker with call steps with content element 1 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:105:27:105:48 | call to [] | type tracker without call steps | params_flow.rb:105:27:105:48 | call to [] |
 | params_flow.rb:105:27:105:48 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:105:26:105:48 | * ... |
-| params_flow.rb:105:27:105:48 | call to [] | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:105:1:105:49 | synthetic splat argument |
-| params_flow.rb:105:27:105:48 | synthetic splat argument | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:98:1:103:3 | synthetic splat parameter |
+| params_flow.rb:105:27:105:48 | call to [] | type tracker without call steps with content element 1 | params_flow.rb:105:1:105:49 | synthetic splat argument |
+| params_flow.rb:105:27:105:48 | synthetic splat argument | type tracker with call steps with content element 1 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:105:27:105:48 | synthetic splat argument | type tracker without call steps | params_flow.rb:105:27:105:48 | call to [] |
 | params_flow.rb:105:27:105:48 | synthetic splat argument | type tracker without call steps | params_flow.rb:105:27:105:48 | synthetic splat argument |
 | params_flow.rb:105:27:105:48 | synthetic splat argument | type tracker without call steps with content element 0 or unknown | params_flow.rb:105:26:105:48 | * ... |
-| params_flow.rb:105:27:105:48 | synthetic splat argument | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:105:1:105:49 | synthetic splat argument |
-| params_flow.rb:105:28:105:36 | call to taint | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:98:1:103:3 | synthetic splat parameter |
+| params_flow.rb:105:27:105:48 | synthetic splat argument | type tracker without call steps with content element 1 | params_flow.rb:105:1:105:49 | synthetic splat argument |
+| params_flow.rb:105:28:105:36 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:105:28:105:36 | call to taint | type tracker without call steps | params_flow.rb:105:28:105:36 | call to taint |
 | params_flow.rb:105:28:105:36 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:105:26:105:48 | * ... |
 | params_flow.rb:105:28:105:36 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:105:27:105:48 | call to [] |
 | params_flow.rb:105:28:105:36 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:105:27:105:48 | synthetic splat argument |
-| params_flow.rb:105:28:105:36 | call to taint | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:105:1:105:49 | synthetic splat argument |
-| params_flow.rb:105:28:105:36 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:105:28:105:36 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:105:1:105:49 | synthetic splat argument |
 | params_flow.rb:105:28:105:36 | synthetic splat argument | type tracker without call steps | params_flow.rb:105:28:105:36 | synthetic splat argument |
 | params_flow.rb:105:34:105:35 | 53 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:105:34:105:35 | 53 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:105:34:105:35 | 53 | type tracker with call steps with content splat position 1 (shifted) | params_flow.rb:98:1:103:3 | synthetic splat parameter |
+| params_flow.rb:105:34:105:35 | 53 | type tracker with call steps with content element 1 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:105:34:105:35 | 53 | type tracker without call steps | params_flow.rb:105:28:105:36 | call to taint |
 | params_flow.rb:105:34:105:35 | 53 | type tracker without call steps | params_flow.rb:105:34:105:35 | 53 |
 | params_flow.rb:105:34:105:35 | 53 | type tracker without call steps with content element 0 | params_flow.rb:105:26:105:48 | * ... |
 | params_flow.rb:105:34:105:35 | 53 | type tracker without call steps with content element 0 | params_flow.rb:105:27:105:48 | call to [] |
 | params_flow.rb:105:34:105:35 | 53 | type tracker without call steps with content element 0 | params_flow.rb:105:27:105:48 | synthetic splat argument |
-| params_flow.rb:105:34:105:35 | 53 | type tracker without call steps with content splat position 0 | params_flow.rb:105:28:105:36 | synthetic splat argument |
-| params_flow.rb:105:34:105:35 | 53 | type tracker without call steps with content splat position 1 (shifted) | params_flow.rb:105:1:105:49 | synthetic splat argument |
-| params_flow.rb:105:39:105:47 | call to taint | type tracker with call steps with content splat position 2 (shifted) | params_flow.rb:98:1:103:3 | synthetic splat parameter |
+| params_flow.rb:105:34:105:35 | 53 | type tracker without call steps with content element 0 | params_flow.rb:105:28:105:36 | synthetic splat argument |
+| params_flow.rb:105:34:105:35 | 53 | type tracker without call steps with content element 1 | params_flow.rb:105:1:105:49 | synthetic splat argument |
+| params_flow.rb:105:39:105:47 | call to taint | type tracker with call steps with content element 2 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:105:39:105:47 | call to taint | type tracker without call steps | params_flow.rb:105:39:105:47 | call to taint |
 | params_flow.rb:105:39:105:47 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:105:26:105:48 | * ... |
 | params_flow.rb:105:39:105:47 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:105:27:105:48 | call to [] |
 | params_flow.rb:105:39:105:47 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:105:27:105:48 | synthetic splat argument |
-| params_flow.rb:105:39:105:47 | call to taint | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:105:1:105:49 | synthetic splat argument |
-| params_flow.rb:105:39:105:47 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:105:39:105:47 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:105:1:105:49 | synthetic splat argument |
 | params_flow.rb:105:39:105:47 | synthetic splat argument | type tracker without call steps | params_flow.rb:105:39:105:47 | synthetic splat argument |
 | params_flow.rb:105:45:105:46 | 54 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:105:45:105:46 | 54 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:105:45:105:46 | 54 | type tracker with call steps with content splat position 2 (shifted) | params_flow.rb:98:1:103:3 | synthetic splat parameter |
+| params_flow.rb:105:45:105:46 | 54 | type tracker with call steps with content element 2 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:105:45:105:46 | 54 | type tracker without call steps | params_flow.rb:105:39:105:47 | call to taint |
 | params_flow.rb:105:45:105:46 | 54 | type tracker without call steps | params_flow.rb:105:45:105:46 | 54 |
+| params_flow.rb:105:45:105:46 | 54 | type tracker without call steps with content element 0 | params_flow.rb:105:39:105:47 | synthetic splat argument |
 | params_flow.rb:105:45:105:46 | 54 | type tracker without call steps with content element 1 | params_flow.rb:105:26:105:48 | * ... |
 | params_flow.rb:105:45:105:46 | 54 | type tracker without call steps with content element 1 | params_flow.rb:105:27:105:48 | call to [] |
 | params_flow.rb:105:45:105:46 | 54 | type tracker without call steps with content element 1 | params_flow.rb:105:27:105:48 | synthetic splat argument |
-| params_flow.rb:105:45:105:46 | 54 | type tracker without call steps with content splat position 0 | params_flow.rb:105:39:105:47 | synthetic splat argument |
-| params_flow.rb:105:45:105:46 | 54 | type tracker without call steps with content splat position 2 (shifted) | params_flow.rb:105:1:105:49 | synthetic splat argument |
+| params_flow.rb:105:45:105:46 | 54 | type tracker without call steps with content element 2 | params_flow.rb:105:1:105:49 | synthetic splat argument |
 | params_flow.rb:106:1:106:46 | call to splatmidsmall | type tracker without call steps | params_flow.rb:106:1:106:46 | call to splatmidsmall |
 | params_flow.rb:106:1:106:46 | synthetic splat argument | type tracker with call steps | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:106:1:106:46 | synthetic splat argument | type tracker without call steps | params_flow.rb:106:1:106:46 | synthetic splat argument |
 | params_flow.rb:106:15:106:23 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:106:15:106:23 | call to taint | type tracker with call steps | params_flow.rb:98:19:98:19 | a |
-| params_flow.rb:106:15:106:23 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:106:15:106:23 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:106:15:106:23 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
-| params_flow.rb:106:15:106:23 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:99:5:99:10 | synthetic splat argument |
+| params_flow.rb:106:15:106:23 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:106:15:106:23 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
+| params_flow.rb:106:15:106:23 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:99:5:99:10 | synthetic splat argument |
 | params_flow.rb:106:15:106:23 | call to taint | type tracker without call steps | params_flow.rb:106:15:106:23 | call to taint |
-| params_flow.rb:106:15:106:23 | call to taint | type tracker without call steps with content splat position 0 | params_flow.rb:106:1:106:46 | synthetic splat argument |
-| params_flow.rb:106:15:106:23 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:106:15:106:23 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:106:1:106:46 | synthetic splat argument |
 | params_flow.rb:106:15:106:23 | synthetic splat argument | type tracker without call steps | params_flow.rb:106:15:106:23 | synthetic splat argument |
 | params_flow.rb:106:21:106:22 | 55 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:106:21:106:22 | 55 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:106:21:106:22 | 55 | type tracker with call steps | params_flow.rb:98:19:98:19 | a |
-| params_flow.rb:106:21:106:22 | 55 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:106:21:106:22 | 55 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:106:21:106:22 | 55 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:106:21:106:22 | 55 | type tracker with call steps with content splat position 0 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
-| params_flow.rb:106:21:106:22 | 55 | type tracker with call steps with content splat position 0 | params_flow.rb:99:5:99:10 | synthetic splat argument |
+| params_flow.rb:106:21:106:22 | 55 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:106:21:106:22 | 55 | type tracker with call steps with content element 0 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
+| params_flow.rb:106:21:106:22 | 55 | type tracker with call steps with content element 0 | params_flow.rb:99:5:99:10 | synthetic splat argument |
 | params_flow.rb:106:21:106:22 | 55 | type tracker without call steps | params_flow.rb:106:15:106:23 | call to taint |
 | params_flow.rb:106:21:106:22 | 55 | type tracker without call steps | params_flow.rb:106:21:106:22 | 55 |
-| params_flow.rb:106:21:106:22 | 55 | type tracker without call steps with content splat position 0 | params_flow.rb:106:1:106:46 | synthetic splat argument |
-| params_flow.rb:106:21:106:22 | 55 | type tracker without call steps with content splat position 0 | params_flow.rb:106:15:106:23 | synthetic splat argument |
-| params_flow.rb:106:26:106:34 | call to taint | type tracker with call steps with content splat position 1 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
+| params_flow.rb:106:21:106:22 | 55 | type tracker without call steps with content element 0 | params_flow.rb:106:1:106:46 | synthetic splat argument |
+| params_flow.rb:106:21:106:22 | 55 | type tracker without call steps with content element 0 | params_flow.rb:106:15:106:23 | synthetic splat argument |
+| params_flow.rb:106:26:106:34 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:106:26:106:34 | call to taint | type tracker without call steps | params_flow.rb:106:26:106:34 | call to taint |
-| params_flow.rb:106:26:106:34 | call to taint | type tracker without call steps with content splat position 1 | params_flow.rb:106:1:106:46 | synthetic splat argument |
-| params_flow.rb:106:26:106:34 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:106:26:106:34 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:106:1:106:46 | synthetic splat argument |
 | params_flow.rb:106:26:106:34 | synthetic splat argument | type tracker without call steps | params_flow.rb:106:26:106:34 | synthetic splat argument |
 | params_flow.rb:106:32:106:33 | 56 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:106:32:106:33 | 56 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:106:32:106:33 | 56 | type tracker with call steps with content splat position 1 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
+| params_flow.rb:106:32:106:33 | 56 | type tracker with call steps with content element 1 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:106:32:106:33 | 56 | type tracker without call steps | params_flow.rb:106:26:106:34 | call to taint |
 | params_flow.rb:106:32:106:33 | 56 | type tracker without call steps | params_flow.rb:106:32:106:33 | 56 |
-| params_flow.rb:106:32:106:33 | 56 | type tracker without call steps with content splat position 0 | params_flow.rb:106:26:106:34 | synthetic splat argument |
-| params_flow.rb:106:32:106:33 | 56 | type tracker without call steps with content splat position 1 | params_flow.rb:106:1:106:46 | synthetic splat argument |
+| params_flow.rb:106:32:106:33 | 56 | type tracker without call steps with content element 0 | params_flow.rb:106:26:106:34 | synthetic splat argument |
+| params_flow.rb:106:32:106:33 | 56 | type tracker without call steps with content element 1 | params_flow.rb:106:1:106:46 | synthetic splat argument |
 | params_flow.rb:106:37:106:45 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:106:37:106:45 | call to taint | type tracker with call steps | params_flow.rb:98:31:98:31 | b |
-| params_flow.rb:106:37:106:45 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:106:37:106:45 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:106:37:106:45 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:102:5:102:10 | synthetic splat argument |
-| params_flow.rb:106:37:106:45 | call to taint | type tracker with call steps with content splat position 2 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
+| params_flow.rb:106:37:106:45 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:106:37:106:45 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:102:5:102:10 | synthetic splat argument |
+| params_flow.rb:106:37:106:45 | call to taint | type tracker with call steps with content element 2 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:106:37:106:45 | call to taint | type tracker without call steps | params_flow.rb:106:37:106:45 | call to taint |
-| params_flow.rb:106:37:106:45 | call to taint | type tracker without call steps with content splat position 2 | params_flow.rb:106:1:106:46 | synthetic splat argument |
-| params_flow.rb:106:37:106:45 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:106:37:106:45 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:106:1:106:46 | synthetic splat argument |
 | params_flow.rb:106:37:106:45 | synthetic splat argument | type tracker without call steps | params_flow.rb:106:37:106:45 | synthetic splat argument |
 | params_flow.rb:106:43:106:44 | 57 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:106:43:106:44 | 57 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:106:43:106:44 | 57 | type tracker with call steps | params_flow.rb:98:31:98:31 | b |
-| params_flow.rb:106:43:106:44 | 57 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:106:43:106:44 | 57 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:106:43:106:44 | 57 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:106:43:106:44 | 57 | type tracker with call steps with content splat position 0 | params_flow.rb:102:5:102:10 | synthetic splat argument |
-| params_flow.rb:106:43:106:44 | 57 | type tracker with call steps with content splat position 2 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
+| params_flow.rb:106:43:106:44 | 57 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:106:43:106:44 | 57 | type tracker with call steps with content element 0 | params_flow.rb:102:5:102:10 | synthetic splat argument |
+| params_flow.rb:106:43:106:44 | 57 | type tracker with call steps with content element 2 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:106:43:106:44 | 57 | type tracker without call steps | params_flow.rb:106:37:106:45 | call to taint |
 | params_flow.rb:106:43:106:44 | 57 | type tracker without call steps | params_flow.rb:106:43:106:44 | 57 |
-| params_flow.rb:106:43:106:44 | 57 | type tracker without call steps with content splat position 0 | params_flow.rb:106:37:106:45 | synthetic splat argument |
-| params_flow.rb:106:43:106:44 | 57 | type tracker without call steps with content splat position 2 | params_flow.rb:106:1:106:46 | synthetic splat argument |
+| params_flow.rb:106:43:106:44 | 57 | type tracker without call steps with content element 0 | params_flow.rb:106:37:106:45 | synthetic splat argument |
+| params_flow.rb:106:43:106:44 | 57 | type tracker without call steps with content element 2 | params_flow.rb:106:1:106:46 | synthetic splat argument |
 | params_flow.rb:108:1:112:3 | &block | type tracker without call steps | params_flow.rb:108:1:112:3 | &block |
 | params_flow.rb:108:1:112:3 | self in splat_followed_by_keyword_param | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
 | params_flow.rb:108:1:112:3 | self in splat_followed_by_keyword_param | type tracker without call steps | params_flow.rb:108:1:112:3 | self in splat_followed_by_keyword_param |
@@ -2492,36 +2182,30 @@ track
 | params_flow.rb:108:1:112:3 | synthetic hash-splat parameter | type tracker without call steps | params_flow.rb:108:1:112:3 | synthetic hash-splat parameter |
 | params_flow.rb:108:1:112:3 | synthetic splat parameter | type tracker without call steps | params_flow.rb:108:1:112:3 | synthetic splat parameter |
 | params_flow.rb:108:37:108:37 | a | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:108:37:108:37 | a | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:108:37:108:37 | a | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:108:37:108:37 | a | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:108:37:108:37 | a | type tracker without call steps | params_flow.rb:108:37:108:37 | a |
 | params_flow.rb:108:37:108:37 | a | type tracker without call steps | params_flow.rb:108:37:108:37 | a |
-| params_flow.rb:108:37:108:37 | a | type tracker without call steps with content splat position 0 | params_flow.rb:109:5:109:10 | synthetic splat argument |
+| params_flow.rb:108:37:108:37 | a | type tracker without call steps with content element 0 | params_flow.rb:109:5:109:10 | synthetic splat argument |
 | params_flow.rb:108:40:108:41 | *b | type tracker without call steps | params_flow.rb:108:40:108:41 | *b |
 | params_flow.rb:108:41:108:41 | b | type tracker without call steps | params_flow.rb:108:41:108:41 | b |
 | params_flow.rb:108:44:108:44 | c | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:108:44:108:44 | c | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:108:44:108:44 | c | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:108:44:108:44 | c | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:108:44:108:44 | c | type tracker without call steps | params_flow.rb:108:44:108:44 | c |
 | params_flow.rb:108:44:108:44 | c | type tracker without call steps | params_flow.rb:108:44:108:44 | c |
-| params_flow.rb:108:44:108:44 | c | type tracker without call steps with content splat position 0 | params_flow.rb:111:5:111:10 | synthetic splat argument |
+| params_flow.rb:108:44:108:44 | c | type tracker without call steps with content element 0 | params_flow.rb:111:5:111:10 | synthetic splat argument |
 | params_flow.rb:109:5:109:10 | call to sink | type tracker without call steps | params_flow.rb:109:5:109:10 | call to sink |
-| params_flow.rb:109:5:109:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:109:5:109:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:109:5:109:10 | synthetic splat argument |
 | params_flow.rb:110:5:110:13 | call to sink | type tracker without call steps | params_flow.rb:110:5:110:13 | call to sink |
-| params_flow.rb:110:5:110:13 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:110:5:110:13 | synthetic splat argument | type tracker without call steps | params_flow.rb:110:5:110:13 | synthetic splat argument |
 | params_flow.rb:110:10:110:13 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:110:10:110:13 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:110:10:110:13 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:110:10:110:13 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:110:10:110:13 | ...[...] | type tracker without call steps | params_flow.rb:110:10:110:13 | ...[...] |
-| params_flow.rb:110:10:110:13 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:110:5:110:13 | synthetic splat argument |
+| params_flow.rb:110:10:110:13 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:110:5:110:13 | synthetic splat argument |
 | params_flow.rb:110:10:110:13 | synthetic splat argument | type tracker without call steps | params_flow.rb:110:10:110:13 | synthetic splat argument |
 | params_flow.rb:110:12:110:12 | 0 | type tracker without call steps | params_flow.rb:110:12:110:12 | 0 |
-| params_flow.rb:110:12:110:12 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:110:10:110:13 | synthetic splat argument |
+| params_flow.rb:110:12:110:12 | 0 | type tracker without call steps with content element 0 | params_flow.rb:110:10:110:13 | synthetic splat argument |
 | params_flow.rb:111:5:111:10 | call to sink | type tracker without call steps | params_flow.rb:111:5:111:10 | call to sink |
 | params_flow.rb:111:5:111:10 | call to sink | type tracker without call steps | params_flow.rb:114:1:114:67 | call to splat_followed_by_keyword_param |
-| params_flow.rb:111:5:111:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:111:5:111:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:111:5:111:10 | synthetic splat argument |
 | params_flow.rb:114:1:114:67 | call to splat_followed_by_keyword_param | type tracker without call steps | params_flow.rb:114:1:114:67 | call to splat_followed_by_keyword_param |
 | params_flow.rb:114:1:114:67 | synthetic hash-splat argument | type tracker with call steps | params_flow.rb:108:1:112:3 | synthetic hash-splat parameter |
@@ -2530,129 +2214,111 @@ track
 | params_flow.rb:114:1:114:67 | synthetic splat argument | type tracker without call steps | params_flow.rb:114:1:114:67 | synthetic splat argument |
 | params_flow.rb:114:33:114:41 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:114:33:114:41 | call to taint | type tracker with call steps | params_flow.rb:108:37:108:37 | a |
-| params_flow.rb:114:33:114:41 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:114:33:114:41 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:114:33:114:41 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:108:1:112:3 | synthetic splat parameter |
-| params_flow.rb:114:33:114:41 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:109:5:109:10 | synthetic splat argument |
+| params_flow.rb:114:33:114:41 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:114:33:114:41 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:108:1:112:3 | synthetic splat parameter |
+| params_flow.rb:114:33:114:41 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:109:5:109:10 | synthetic splat argument |
 | params_flow.rb:114:33:114:41 | call to taint | type tracker without call steps | params_flow.rb:114:33:114:41 | call to taint |
-| params_flow.rb:114:33:114:41 | call to taint | type tracker without call steps with content splat position 0 | params_flow.rb:114:1:114:67 | synthetic splat argument |
-| params_flow.rb:114:33:114:41 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:114:33:114:41 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:114:1:114:67 | synthetic splat argument |
 | params_flow.rb:114:33:114:41 | synthetic splat argument | type tracker without call steps | params_flow.rb:114:33:114:41 | synthetic splat argument |
 | params_flow.rb:114:39:114:40 | 58 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:114:39:114:40 | 58 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:114:39:114:40 | 58 | type tracker with call steps | params_flow.rb:108:37:108:37 | a |
-| params_flow.rb:114:39:114:40 | 58 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:114:39:114:40 | 58 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:114:39:114:40 | 58 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:114:39:114:40 | 58 | type tracker with call steps with content splat position 0 | params_flow.rb:108:1:112:3 | synthetic splat parameter |
-| params_flow.rb:114:39:114:40 | 58 | type tracker with call steps with content splat position 0 | params_flow.rb:109:5:109:10 | synthetic splat argument |
+| params_flow.rb:114:39:114:40 | 58 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:114:39:114:40 | 58 | type tracker with call steps with content element 0 | params_flow.rb:108:1:112:3 | synthetic splat parameter |
+| params_flow.rb:114:39:114:40 | 58 | type tracker with call steps with content element 0 | params_flow.rb:109:5:109:10 | synthetic splat argument |
 | params_flow.rb:114:39:114:40 | 58 | type tracker without call steps | params_flow.rb:114:33:114:41 | call to taint |
 | params_flow.rb:114:39:114:40 | 58 | type tracker without call steps | params_flow.rb:114:39:114:40 | 58 |
-| params_flow.rb:114:39:114:40 | 58 | type tracker without call steps with content splat position 0 | params_flow.rb:114:1:114:67 | synthetic splat argument |
-| params_flow.rb:114:39:114:40 | 58 | type tracker without call steps with content splat position 0 | params_flow.rb:114:33:114:41 | synthetic splat argument |
+| params_flow.rb:114:39:114:40 | 58 | type tracker without call steps with content element 0 | params_flow.rb:114:1:114:67 | synthetic splat argument |
+| params_flow.rb:114:39:114:40 | 58 | type tracker without call steps with content element 0 | params_flow.rb:114:33:114:41 | synthetic splat argument |
 | params_flow.rb:114:44:114:52 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:114:44:114:52 | call to taint | type tracker with call steps | params_flow.rb:110:10:110:13 | ...[...] |
+| params_flow.rb:114:44:114:52 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:114:44:114:52 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:108:40:108:41 | *b |
-| params_flow.rb:114:44:114:52 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:114:44:114:52 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:114:44:114:52 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:110:5:110:13 | synthetic splat argument |
-| params_flow.rb:114:44:114:52 | call to taint | type tracker with call steps with content splat position 1 | params_flow.rb:108:1:112:3 | synthetic splat parameter |
+| params_flow.rb:114:44:114:52 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:110:5:110:13 | synthetic splat argument |
+| params_flow.rb:114:44:114:52 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:108:1:112:3 | synthetic splat parameter |
 | params_flow.rb:114:44:114:52 | call to taint | type tracker without call steps | params_flow.rb:114:44:114:52 | call to taint |
-| params_flow.rb:114:44:114:52 | call to taint | type tracker without call steps with content splat position 1 | params_flow.rb:114:1:114:67 | synthetic splat argument |
-| params_flow.rb:114:44:114:52 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:114:44:114:52 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:114:1:114:67 | synthetic splat argument |
 | params_flow.rb:114:44:114:52 | synthetic splat argument | type tracker without call steps | params_flow.rb:114:44:114:52 | synthetic splat argument |
 | params_flow.rb:114:50:114:51 | 59 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:114:50:114:51 | 59 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:114:50:114:51 | 59 | type tracker with call steps | params_flow.rb:110:10:110:13 | ...[...] |
+| params_flow.rb:114:50:114:51 | 59 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:114:50:114:51 | 59 | type tracker with call steps with content element 0 | params_flow.rb:108:40:108:41 | *b |
-| params_flow.rb:114:50:114:51 | 59 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:114:50:114:51 | 59 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:114:50:114:51 | 59 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:114:50:114:51 | 59 | type tracker with call steps with content splat position 0 | params_flow.rb:110:5:110:13 | synthetic splat argument |
-| params_flow.rb:114:50:114:51 | 59 | type tracker with call steps with content splat position 1 | params_flow.rb:108:1:112:3 | synthetic splat parameter |
+| params_flow.rb:114:50:114:51 | 59 | type tracker with call steps with content element 0 | params_flow.rb:110:5:110:13 | synthetic splat argument |
+| params_flow.rb:114:50:114:51 | 59 | type tracker with call steps with content element 1 | params_flow.rb:108:1:112:3 | synthetic splat parameter |
 | params_flow.rb:114:50:114:51 | 59 | type tracker without call steps | params_flow.rb:114:44:114:52 | call to taint |
 | params_flow.rb:114:50:114:51 | 59 | type tracker without call steps | params_flow.rb:114:50:114:51 | 59 |
-| params_flow.rb:114:50:114:51 | 59 | type tracker without call steps with content splat position 0 | params_flow.rb:114:44:114:52 | synthetic splat argument |
-| params_flow.rb:114:50:114:51 | 59 | type tracker without call steps with content splat position 1 | params_flow.rb:114:1:114:67 | synthetic splat argument |
+| params_flow.rb:114:50:114:51 | 59 | type tracker without call steps with content element 0 | params_flow.rb:114:44:114:52 | synthetic splat argument |
+| params_flow.rb:114:50:114:51 | 59 | type tracker without call steps with content element 1 | params_flow.rb:114:1:114:67 | synthetic splat argument |
 | params_flow.rb:114:55:114:55 | :c | type tracker without call steps | params_flow.rb:114:55:114:55 | :c |
 | params_flow.rb:114:55:114:66 | Pair | type tracker without call steps | params_flow.rb:114:55:114:66 | Pair |
 | params_flow.rb:114:58:114:66 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:114:58:114:66 | call to taint | type tracker with call steps | params_flow.rb:108:44:108:44 | c |
+| params_flow.rb:114:58:114:66 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:114:58:114:66 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:111:5:111:10 | synthetic splat argument |
 | params_flow.rb:114:58:114:66 | call to taint | type tracker with call steps with content hash-splat position :c | params_flow.rb:108:1:112:3 | synthetic hash-splat parameter |
-| params_flow.rb:114:58:114:66 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:114:58:114:66 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:114:58:114:66 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:111:5:111:10 | synthetic splat argument |
 | params_flow.rb:114:58:114:66 | call to taint | type tracker without call steps | params_flow.rb:114:58:114:66 | call to taint |
 | params_flow.rb:114:58:114:66 | call to taint | type tracker without call steps with content hash-splat position :c | params_flow.rb:114:1:114:67 | synthetic hash-splat argument |
-| params_flow.rb:114:58:114:66 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:114:58:114:66 | synthetic splat argument | type tracker without call steps | params_flow.rb:114:58:114:66 | synthetic splat argument |
 | params_flow.rb:114:64:114:65 | 60 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:114:64:114:65 | 60 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:114:64:114:65 | 60 | type tracker with call steps | params_flow.rb:108:44:108:44 | c |
+| params_flow.rb:114:64:114:65 | 60 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:114:64:114:65 | 60 | type tracker with call steps with content element 0 | params_flow.rb:111:5:111:10 | synthetic splat argument |
 | params_flow.rb:114:64:114:65 | 60 | type tracker with call steps with content hash-splat position :c | params_flow.rb:108:1:112:3 | synthetic hash-splat parameter |
-| params_flow.rb:114:64:114:65 | 60 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:114:64:114:65 | 60 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:114:64:114:65 | 60 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:114:64:114:65 | 60 | type tracker with call steps with content splat position 0 | params_flow.rb:111:5:111:10 | synthetic splat argument |
 | params_flow.rb:114:64:114:65 | 60 | type tracker without call steps | params_flow.rb:114:58:114:66 | call to taint |
 | params_flow.rb:114:64:114:65 | 60 | type tracker without call steps | params_flow.rb:114:64:114:65 | 60 |
+| params_flow.rb:114:64:114:65 | 60 | type tracker without call steps with content element 0 | params_flow.rb:114:58:114:66 | synthetic splat argument |
 | params_flow.rb:114:64:114:65 | 60 | type tracker without call steps with content hash-splat position :c | params_flow.rb:114:1:114:67 | synthetic hash-splat argument |
-| params_flow.rb:114:64:114:65 | 60 | type tracker without call steps with content splat position 0 | params_flow.rb:114:58:114:66 | synthetic splat argument |
 | params_flow.rb:116:1:116:1 | x | type tracker without call steps | params_flow.rb:116:1:116:1 | x |
 | params_flow.rb:116:5:116:6 | Array | type tracker without call steps | params_flow.rb:116:5:116:6 | Array |
 | params_flow.rb:116:5:116:6 | call to [] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:116:5:116:6 | call to [] | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:116:5:116:6 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:116:5:116:6 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
 | params_flow.rb:116:5:116:6 | call to [] | type tracker with call steps with content element 0 or unknown | params_flow.rb:9:1:12:3 | synthetic splat parameter |
-| params_flow.rb:116:5:116:6 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:116:5:116:6 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:116:5:116:6 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
 | params_flow.rb:116:5:116:6 | call to [] | type tracker without call steps | params_flow.rb:116:5:116:6 | call to [] |
 | params_flow.rb:116:5:116:6 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:118:12:118:13 | * ... |
 | params_flow.rb:117:1:117:1 | [post] x | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:117:1:117:1 | [post] x | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:117:1:117:1 | [post] x | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:117:1:117:1 | [post] x | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
 | params_flow.rb:117:1:117:1 | [post] x | type tracker with call steps with content element 0 or unknown | params_flow.rb:9:1:12:3 | synthetic splat parameter |
-| params_flow.rb:117:1:117:1 | [post] x | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:117:1:117:1 | [post] x | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:117:1:117:1 | [post] x | type tracker with call steps with content splat position 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
 | params_flow.rb:117:1:117:1 | [post] x | type tracker without call steps | params_flow.rb:117:1:117:1 | [post] x |
 | params_flow.rb:117:1:117:1 | [post] x | type tracker without call steps with content element 0 or unknown | params_flow.rb:118:12:118:13 | * ... |
 | params_flow.rb:117:1:117:15 | call to []= | type tracker without call steps | params_flow.rb:117:1:117:15 | call to []= |
 | params_flow.rb:117:1:117:15 | synthetic splat argument | type tracker without call steps | params_flow.rb:117:1:117:15 | synthetic splat argument |
 | params_flow.rb:117:3:117:14 | call to some_index | type tracker without call steps | params_flow.rb:117:3:117:14 | call to some_index |
-| params_flow.rb:117:3:117:14 | call to some_index | type tracker without call steps with content splat position 0 | params_flow.rb:117:1:117:15 | synthetic splat argument |
+| params_flow.rb:117:3:117:14 | call to some_index | type tracker without call steps with content element 0 | params_flow.rb:117:1:117:15 | synthetic splat argument |
 | params_flow.rb:117:19:117:27 | __synth__0 | type tracker without call steps | params_flow.rb:117:19:117:27 | __synth__0 |
 | params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
 | params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps | params_flow.rb:9:20:9:21 | p2 |
 | params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps with content element | params_flow.rb:9:1:12:3 | synthetic splat parameter |
-| params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
-| params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
+| params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
+| params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
 | params_flow.rb:117:19:117:27 | call to taint | type tracker without call steps | params_flow.rb:117:19:117:27 | call to taint |
 | params_flow.rb:117:19:117:27 | call to taint | type tracker without call steps with content attribute [] | params_flow.rb:117:1:117:1 | [post] x |
 | params_flow.rb:117:19:117:27 | call to taint | type tracker without call steps with content element | params_flow.rb:117:1:117:1 | [post] x |
 | params_flow.rb:117:19:117:27 | call to taint | type tracker without call steps with content element | params_flow.rb:118:12:118:13 | * ... |
-| params_flow.rb:117:19:117:27 | call to taint | type tracker without call steps with content splat position 1 | params_flow.rb:117:1:117:15 | synthetic splat argument |
-| params_flow.rb:117:19:117:27 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:117:19:117:27 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:117:1:117:15 | synthetic splat argument |
 | params_flow.rb:117:19:117:27 | synthetic splat argument | type tracker without call steps | params_flow.rb:117:19:117:27 | synthetic splat argument |
 | params_flow.rb:117:25:117:26 | 61 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:117:25:117:26 | 61 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:117:25:117:26 | 61 | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
 | params_flow.rb:117:25:117:26 | 61 | type tracker with call steps | params_flow.rb:9:20:9:21 | p2 |
 | params_flow.rb:117:25:117:26 | 61 | type tracker with call steps with content element | params_flow.rb:9:1:12:3 | synthetic splat parameter |
-| params_flow.rb:117:25:117:26 | 61 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:117:25:117:26 | 61 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:117:25:117:26 | 61 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:117:25:117:26 | 61 | type tracker with call steps with content splat position 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
-| params_flow.rb:117:25:117:26 | 61 | type tracker with call steps with content splat position 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
+| params_flow.rb:117:25:117:26 | 61 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:117:25:117:26 | 61 | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | synthetic splat argument |
+| params_flow.rb:117:25:117:26 | 61 | type tracker with call steps with content element 0 | params_flow.rb:11:5:11:11 | synthetic splat argument |
 | params_flow.rb:117:25:117:26 | 61 | type tracker without call steps | params_flow.rb:117:19:117:27 | call to taint |
 | params_flow.rb:117:25:117:26 | 61 | type tracker without call steps | params_flow.rb:117:25:117:26 | 61 |
 | params_flow.rb:117:25:117:26 | 61 | type tracker without call steps with content attribute [] | params_flow.rb:117:1:117:1 | [post] x |
 | params_flow.rb:117:25:117:26 | 61 | type tracker without call steps with content element | params_flow.rb:117:1:117:1 | [post] x |
 | params_flow.rb:117:25:117:26 | 61 | type tracker without call steps with content element | params_flow.rb:118:12:118:13 | * ... |
-| params_flow.rb:117:25:117:26 | 61 | type tracker without call steps with content splat position 0 | params_flow.rb:117:19:117:27 | synthetic splat argument |
-| params_flow.rb:117:25:117:26 | 61 | type tracker without call steps with content splat position 1 | params_flow.rb:117:1:117:15 | synthetic splat argument |
+| params_flow.rb:117:25:117:26 | 61 | type tracker without call steps with content element 0 | params_flow.rb:117:19:117:27 | synthetic splat argument |
+| params_flow.rb:117:25:117:26 | 61 | type tracker without call steps with content element 1 | params_flow.rb:117:1:117:15 | synthetic splat argument |
 | params_flow.rb:118:1:118:14 | call to positional | type tracker without call steps | params_flow.rb:118:1:118:14 | call to positional |
 | params_flow.rb:118:12:118:13 | * ... | type tracker with call steps | params_flow.rb:9:1:12:3 | synthetic splat parameter |
 | params_flow.rb:118:12:118:13 | * ... | type tracker without call steps | params_flow.rb:118:12:118:13 | * ... |
@@ -2661,101 +2327,85 @@ track
 | params_flow.rb:120:1:126:3 | self in destruct | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
 | params_flow.rb:120:1:126:3 | self in destruct | type tracker without call steps | params_flow.rb:120:1:126:3 | self in destruct |
 | params_flow.rb:120:15:120:15 | a | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:120:15:120:15 | a | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:120:15:120:15 | a | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:120:15:120:15 | a | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:120:15:120:15 | a | type tracker without call steps | params_flow.rb:120:15:120:15 | a |
 | params_flow.rb:120:15:120:15 | a | type tracker without call steps | params_flow.rb:120:15:120:15 | a |
-| params_flow.rb:120:15:120:15 | a | type tracker without call steps with content splat position 0 | params_flow.rb:121:5:121:10 | synthetic splat argument |
+| params_flow.rb:120:15:120:15 | a | type tracker without call steps with content element 0 | params_flow.rb:121:5:121:10 | synthetic splat argument |
 | params_flow.rb:120:17:120:17 | b | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:120:17:120:17 | b | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:120:17:120:17 | b | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:120:17:120:17 | b | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:120:17:120:17 | b | type tracker without call steps | params_flow.rb:120:17:120:17 | b |
 | params_flow.rb:120:17:120:17 | b | type tracker without call steps | params_flow.rb:120:17:120:17 | b |
-| params_flow.rb:120:17:120:17 | b | type tracker without call steps with content splat position 0 | params_flow.rb:122:5:122:10 | synthetic splat argument |
+| params_flow.rb:120:17:120:17 | b | type tracker without call steps with content element 0 | params_flow.rb:122:5:122:10 | synthetic splat argument |
 | params_flow.rb:120:22:120:22 | c | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:120:22:120:22 | c | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:120:22:120:22 | c | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:120:22:120:22 | c | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:120:22:120:22 | c | type tracker without call steps | params_flow.rb:120:22:120:22 | c |
 | params_flow.rb:120:22:120:22 | c | type tracker without call steps | params_flow.rb:120:22:120:22 | c |
-| params_flow.rb:120:22:120:22 | c | type tracker without call steps with content splat position 0 | params_flow.rb:123:5:123:10 | synthetic splat argument |
+| params_flow.rb:120:22:120:22 | c | type tracker without call steps with content element 0 | params_flow.rb:123:5:123:10 | synthetic splat argument |
 | params_flow.rb:120:25:120:25 | d | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:120:25:120:25 | d | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:120:25:120:25 | d | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:120:25:120:25 | d | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:120:25:120:25 | d | type tracker without call steps | params_flow.rb:120:25:120:25 | d |
 | params_flow.rb:120:25:120:25 | d | type tracker without call steps | params_flow.rb:120:25:120:25 | d |
-| params_flow.rb:120:25:120:25 | d | type tracker without call steps with content splat position 0 | params_flow.rb:124:5:124:10 | synthetic splat argument |
+| params_flow.rb:120:25:120:25 | d | type tracker without call steps with content element 0 | params_flow.rb:124:5:124:10 | synthetic splat argument |
 | params_flow.rb:120:27:120:27 | e | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:120:27:120:27 | e | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:120:27:120:27 | e | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:120:27:120:27 | e | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:120:27:120:27 | e | type tracker without call steps | params_flow.rb:120:27:120:27 | e |
 | params_flow.rb:120:27:120:27 | e | type tracker without call steps | params_flow.rb:120:27:120:27 | e |
-| params_flow.rb:120:27:120:27 | e | type tracker without call steps with content splat position 0 | params_flow.rb:125:5:125:10 | synthetic splat argument |
+| params_flow.rb:120:27:120:27 | e | type tracker without call steps with content element 0 | params_flow.rb:125:5:125:10 | synthetic splat argument |
 | params_flow.rb:121:5:121:10 | call to sink | type tracker without call steps | params_flow.rb:121:5:121:10 | call to sink |
-| params_flow.rb:121:5:121:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:121:5:121:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:121:5:121:10 | synthetic splat argument |
 | params_flow.rb:122:5:122:10 | call to sink | type tracker without call steps | params_flow.rb:122:5:122:10 | call to sink |
-| params_flow.rb:122:5:122:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:122:5:122:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:122:5:122:10 | synthetic splat argument |
 | params_flow.rb:123:5:123:10 | call to sink | type tracker without call steps | params_flow.rb:123:5:123:10 | call to sink |
-| params_flow.rb:123:5:123:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:123:5:123:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:123:5:123:10 | synthetic splat argument |
 | params_flow.rb:124:5:124:10 | call to sink | type tracker without call steps | params_flow.rb:124:5:124:10 | call to sink |
-| params_flow.rb:124:5:124:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:124:5:124:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:124:5:124:10 | synthetic splat argument |
 | params_flow.rb:125:5:125:10 | call to sink | type tracker without call steps | params_flow.rb:125:5:125:10 | call to sink |
 | params_flow.rb:125:5:125:10 | call to sink | type tracker without call steps | params_flow.rb:128:1:128:61 | call to destruct |
-| params_flow.rb:125:5:125:10 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:125:5:125:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:125:5:125:10 | synthetic splat argument |
 | params_flow.rb:128:1:128:61 | call to destruct | type tracker without call steps | params_flow.rb:128:1:128:61 | call to destruct |
 | params_flow.rb:128:1:128:61 | synthetic splat argument | type tracker without call steps | params_flow.rb:128:1:128:61 | synthetic splat argument |
 | params_flow.rb:128:10:128:31 | Array | type tracker without call steps | params_flow.rb:128:10:128:31 | Array |
 | params_flow.rb:128:10:128:31 | call to [] | type tracker without call steps | params_flow.rb:128:10:128:31 | call to [] |
-| params_flow.rb:128:10:128:31 | call to [] | type tracker without call steps with content splat position 0 | params_flow.rb:128:1:128:61 | synthetic splat argument |
+| params_flow.rb:128:10:128:31 | call to [] | type tracker without call steps with content element 0 | params_flow.rb:128:1:128:61 | synthetic splat argument |
 | params_flow.rb:128:10:128:31 | synthetic splat argument | type tracker without call steps | params_flow.rb:128:10:128:31 | call to [] |
 | params_flow.rb:128:10:128:31 | synthetic splat argument | type tracker without call steps | params_flow.rb:128:10:128:31 | synthetic splat argument |
-| params_flow.rb:128:10:128:31 | synthetic splat argument | type tracker without call steps with content splat position 0 | params_flow.rb:128:1:128:61 | synthetic splat argument |
+| params_flow.rb:128:10:128:31 | synthetic splat argument | type tracker without call steps with content element 0 | params_flow.rb:128:1:128:61 | synthetic splat argument |
 | params_flow.rb:128:11:128:19 | call to taint | type tracker without call steps | params_flow.rb:128:11:128:19 | call to taint |
 | params_flow.rb:128:11:128:19 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:128:10:128:31 | call to [] |
 | params_flow.rb:128:11:128:19 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:128:10:128:31 | synthetic splat argument |
-| params_flow.rb:128:11:128:19 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:128:11:128:19 | synthetic splat argument | type tracker without call steps | params_flow.rb:128:11:128:19 | synthetic splat argument |
 | params_flow.rb:128:17:128:18 | 62 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:128:17:128:18 | 62 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:128:17:128:18 | 62 | type tracker without call steps | params_flow.rb:128:11:128:19 | call to taint |
 | params_flow.rb:128:17:128:18 | 62 | type tracker without call steps | params_flow.rb:128:17:128:18 | 62 |
 | params_flow.rb:128:17:128:18 | 62 | type tracker without call steps with content element 0 | params_flow.rb:128:10:128:31 | call to [] |
 | params_flow.rb:128:17:128:18 | 62 | type tracker without call steps with content element 0 | params_flow.rb:128:10:128:31 | synthetic splat argument |
-| params_flow.rb:128:17:128:18 | 62 | type tracker without call steps with content splat position 0 | params_flow.rb:128:11:128:19 | synthetic splat argument |
+| params_flow.rb:128:17:128:18 | 62 | type tracker without call steps with content element 0 | params_flow.rb:128:11:128:19 | synthetic splat argument |
 | params_flow.rb:128:22:128:30 | call to taint | type tracker without call steps | params_flow.rb:128:22:128:30 | call to taint |
 | params_flow.rb:128:22:128:30 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:128:10:128:31 | call to [] |
 | params_flow.rb:128:22:128:30 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:128:10:128:31 | synthetic splat argument |
-| params_flow.rb:128:22:128:30 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:128:22:128:30 | synthetic splat argument | type tracker without call steps | params_flow.rb:128:22:128:30 | synthetic splat argument |
 | params_flow.rb:128:28:128:29 | 63 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:128:28:128:29 | 63 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:128:28:128:29 | 63 | type tracker without call steps | params_flow.rb:128:22:128:30 | call to taint |
 | params_flow.rb:128:28:128:29 | 63 | type tracker without call steps | params_flow.rb:128:28:128:29 | 63 |
+| params_flow.rb:128:28:128:29 | 63 | type tracker without call steps with content element 0 | params_flow.rb:128:22:128:30 | synthetic splat argument |
 | params_flow.rb:128:28:128:29 | 63 | type tracker without call steps with content element 1 | params_flow.rb:128:10:128:31 | call to [] |
 | params_flow.rb:128:28:128:29 | 63 | type tracker without call steps with content element 1 | params_flow.rb:128:10:128:31 | synthetic splat argument |
-| params_flow.rb:128:28:128:29 | 63 | type tracker without call steps with content splat position 0 | params_flow.rb:128:22:128:30 | synthetic splat argument |
 | params_flow.rb:128:34:128:60 | Array | type tracker without call steps | params_flow.rb:128:34:128:60 | Array |
 | params_flow.rb:128:34:128:60 | call to [] | type tracker without call steps | params_flow.rb:128:34:128:60 | call to [] |
-| params_flow.rb:128:34:128:60 | call to [] | type tracker without call steps with content splat position 1 | params_flow.rb:128:1:128:61 | synthetic splat argument |
+| params_flow.rb:128:34:128:60 | call to [] | type tracker without call steps with content element 1 | params_flow.rb:128:1:128:61 | synthetic splat argument |
 | params_flow.rb:128:34:128:60 | synthetic splat argument | type tracker without call steps | params_flow.rb:128:34:128:60 | call to [] |
 | params_flow.rb:128:34:128:60 | synthetic splat argument | type tracker without call steps | params_flow.rb:128:34:128:60 | synthetic splat argument |
-| params_flow.rb:128:34:128:60 | synthetic splat argument | type tracker without call steps with content splat position 1 | params_flow.rb:128:1:128:61 | synthetic splat argument |
+| params_flow.rb:128:34:128:60 | synthetic splat argument | type tracker without call steps with content element 1 | params_flow.rb:128:1:128:61 | synthetic splat argument |
 | params_flow.rb:128:35:128:43 | call to taint | type tracker without call steps | params_flow.rb:128:35:128:43 | call to taint |
 | params_flow.rb:128:35:128:43 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:128:34:128:60 | call to [] |
 | params_flow.rb:128:35:128:43 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:128:34:128:60 | synthetic splat argument |
-| params_flow.rb:128:35:128:43 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:128:35:128:43 | synthetic splat argument | type tracker without call steps | params_flow.rb:128:35:128:43 | synthetic splat argument |
 | params_flow.rb:128:41:128:42 | 64 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:128:41:128:42 | 64 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:128:41:128:42 | 64 | type tracker without call steps | params_flow.rb:128:35:128:43 | call to taint |
 | params_flow.rb:128:41:128:42 | 64 | type tracker without call steps | params_flow.rb:128:41:128:42 | 64 |
 | params_flow.rb:128:41:128:42 | 64 | type tracker without call steps with content element 0 | params_flow.rb:128:34:128:60 | call to [] |
 | params_flow.rb:128:41:128:42 | 64 | type tracker without call steps with content element 0 | params_flow.rb:128:34:128:60 | synthetic splat argument |
-| params_flow.rb:128:41:128:42 | 64 | type tracker without call steps with content splat position 0 | params_flow.rb:128:35:128:43 | synthetic splat argument |
+| params_flow.rb:128:41:128:42 | 64 | type tracker without call steps with content element 0 | params_flow.rb:128:35:128:43 | synthetic splat argument |
 | params_flow.rb:128:46:128:59 | Array | type tracker without call steps | params_flow.rb:128:46:128:59 | Array |
 | params_flow.rb:128:46:128:59 | call to [] | type tracker without call steps | params_flow.rb:128:46:128:59 | call to [] |
 | params_flow.rb:128:46:128:59 | call to [] | type tracker without call steps with content element 1 | params_flow.rb:128:34:128:60 | call to [] |
@@ -2770,130 +2420,110 @@ track
 | params_flow.rb:128:50:128:58 | call to taint | type tracker without call steps | params_flow.rb:128:50:128:58 | call to taint |
 | params_flow.rb:128:50:128:58 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:128:46:128:59 | call to [] |
 | params_flow.rb:128:50:128:58 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:128:46:128:59 | synthetic splat argument |
-| params_flow.rb:128:50:128:58 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:128:50:128:58 | synthetic splat argument | type tracker without call steps | params_flow.rb:128:50:128:58 | synthetic splat argument |
 | params_flow.rb:128:56:128:57 | 65 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:128:56:128:57 | 65 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:128:56:128:57 | 65 | type tracker without call steps | params_flow.rb:128:50:128:58 | call to taint |
 | params_flow.rb:128:56:128:57 | 65 | type tracker without call steps | params_flow.rb:128:56:128:57 | 65 |
+| params_flow.rb:128:56:128:57 | 65 | type tracker without call steps with content element 0 | params_flow.rb:128:50:128:58 | synthetic splat argument |
 | params_flow.rb:128:56:128:57 | 65 | type tracker without call steps with content element 1 | params_flow.rb:128:46:128:59 | call to [] |
 | params_flow.rb:128:56:128:57 | 65 | type tracker without call steps with content element 1 | params_flow.rb:128:46:128:59 | synthetic splat argument |
-| params_flow.rb:128:56:128:57 | 65 | type tracker without call steps with content splat position 0 | params_flow.rb:128:50:128:58 | synthetic splat argument |
 | params_flow.rb:130:1:130:4 | args | type tracker without call steps | params_flow.rb:130:1:130:4 | args |
 | params_flow.rb:130:8:130:29 | Array | type tracker without call steps | params_flow.rb:130:8:130:29 | Array |
 | params_flow.rb:130:8:130:29 | call to [] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:130:8:130:29 | call to [] | type tracker with call steps | params_flow.rb:83:14:83:14 | t |
+| params_flow.rb:130:8:130:29 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:130:8:130:29 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:84:5:84:10 | synthetic splat argument |
 | params_flow.rb:130:8:130:29 | call to [] | type tracker with call steps with content element 0 or unknown | params_flow.rb:83:1:91:3 | synthetic splat parameter |
-| params_flow.rb:130:8:130:29 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:130:8:130:29 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:130:8:130:29 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:84:5:84:10 | synthetic splat argument |
 | params_flow.rb:130:8:130:29 | call to [] | type tracker without call steps | params_flow.rb:130:8:130:29 | call to [] |
 | params_flow.rb:130:8:130:29 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:131:10:131:14 | * ... |
 | params_flow.rb:130:8:130:29 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:130:8:130:29 | synthetic splat argument | type tracker with call steps | params_flow.rb:83:14:83:14 | t |
+| params_flow.rb:130:8:130:29 | synthetic splat argument | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:130:8:130:29 | synthetic splat argument | type tracker with call steps with content element 0 | params_flow.rb:84:5:84:10 | synthetic splat argument |
 | params_flow.rb:130:8:130:29 | synthetic splat argument | type tracker with call steps with content element 0 or unknown | params_flow.rb:83:1:91:3 | synthetic splat parameter |
-| params_flow.rb:130:8:130:29 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:130:8:130:29 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:130:8:130:29 | synthetic splat argument | type tracker with call steps with content splat position 0 | params_flow.rb:84:5:84:10 | synthetic splat argument |
 | params_flow.rb:130:8:130:29 | synthetic splat argument | type tracker without call steps | params_flow.rb:130:8:130:29 | call to [] |
 | params_flow.rb:130:8:130:29 | synthetic splat argument | type tracker without call steps | params_flow.rb:130:8:130:29 | synthetic splat argument |
 | params_flow.rb:130:8:130:29 | synthetic splat argument | type tracker without call steps with content element 0 or unknown | params_flow.rb:131:10:131:14 | * ... |
 | params_flow.rb:130:9:130:17 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:130:9:130:17 | call to taint | type tracker with call steps | params_flow.rb:83:14:83:14 | t |
+| params_flow.rb:130:9:130:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:130:9:130:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
-| params_flow.rb:130:9:130:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:130:9:130:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:130:9:130:17 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:84:5:84:10 | synthetic splat argument |
+| params_flow.rb:130:9:130:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:84:5:84:10 | synthetic splat argument |
 | params_flow.rb:130:9:130:17 | call to taint | type tracker without call steps | params_flow.rb:130:9:130:17 | call to taint |
 | params_flow.rb:130:9:130:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:130:8:130:29 | call to [] |
 | params_flow.rb:130:9:130:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:130:8:130:29 | synthetic splat argument |
 | params_flow.rb:130:9:130:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:131:10:131:14 | * ... |
-| params_flow.rb:130:9:130:17 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:130:9:130:17 | synthetic splat argument | type tracker without call steps | params_flow.rb:130:9:130:17 | synthetic splat argument |
 | params_flow.rb:130:15:130:16 | 66 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:130:15:130:16 | 66 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:130:15:130:16 | 66 | type tracker with call steps | params_flow.rb:83:14:83:14 | t |
+| params_flow.rb:130:15:130:16 | 66 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:130:15:130:16 | 66 | type tracker with call steps with content element 0 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
-| params_flow.rb:130:15:130:16 | 66 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:130:15:130:16 | 66 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:130:15:130:16 | 66 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:130:15:130:16 | 66 | type tracker with call steps with content splat position 0 | params_flow.rb:84:5:84:10 | synthetic splat argument |
+| params_flow.rb:130:15:130:16 | 66 | type tracker with call steps with content element 0 | params_flow.rb:84:5:84:10 | synthetic splat argument |
 | params_flow.rb:130:15:130:16 | 66 | type tracker without call steps | params_flow.rb:130:9:130:17 | call to taint |
 | params_flow.rb:130:15:130:16 | 66 | type tracker without call steps | params_flow.rb:130:15:130:16 | 66 |
 | params_flow.rb:130:15:130:16 | 66 | type tracker without call steps with content element 0 | params_flow.rb:130:8:130:29 | call to [] |
 | params_flow.rb:130:15:130:16 | 66 | type tracker without call steps with content element 0 | params_flow.rb:130:8:130:29 | synthetic splat argument |
+| params_flow.rb:130:15:130:16 | 66 | type tracker without call steps with content element 0 | params_flow.rb:130:9:130:17 | synthetic splat argument |
 | params_flow.rb:130:15:130:16 | 66 | type tracker without call steps with content element 0 | params_flow.rb:131:10:131:14 | * ... |
-| params_flow.rb:130:15:130:16 | 66 | type tracker without call steps with content splat position 0 | params_flow.rb:130:9:130:17 | synthetic splat argument |
 | params_flow.rb:130:20:130:28 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:130:20:130:28 | call to taint | type tracker with call steps | params_flow.rb:83:17:83:17 | u |
+| params_flow.rb:130:20:130:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:130:20:130:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:85:5:85:10 | synthetic splat argument |
 | params_flow.rb:130:20:130:28 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
-| params_flow.rb:130:20:130:28 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:130:20:130:28 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:130:20:130:28 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:85:5:85:10 | synthetic splat argument |
 | params_flow.rb:130:20:130:28 | call to taint | type tracker without call steps | params_flow.rb:130:20:130:28 | call to taint |
 | params_flow.rb:130:20:130:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:130:8:130:29 | call to [] |
 | params_flow.rb:130:20:130:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:130:8:130:29 | synthetic splat argument |
 | params_flow.rb:130:20:130:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:131:10:131:14 | * ... |
-| params_flow.rb:130:20:130:28 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:130:20:130:28 | synthetic splat argument | type tracker without call steps | params_flow.rb:130:20:130:28 | synthetic splat argument |
 | params_flow.rb:130:26:130:27 | 67 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:130:26:130:27 | 67 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:130:26:130:27 | 67 | type tracker with call steps | params_flow.rb:83:17:83:17 | u |
+| params_flow.rb:130:26:130:27 | 67 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:130:26:130:27 | 67 | type tracker with call steps with content element 0 | params_flow.rb:85:5:85:10 | synthetic splat argument |
 | params_flow.rb:130:26:130:27 | 67 | type tracker with call steps with content element 1 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
-| params_flow.rb:130:26:130:27 | 67 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:130:26:130:27 | 67 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:130:26:130:27 | 67 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:130:26:130:27 | 67 | type tracker with call steps with content splat position 0 | params_flow.rb:85:5:85:10 | synthetic splat argument |
 | params_flow.rb:130:26:130:27 | 67 | type tracker without call steps | params_flow.rb:130:20:130:28 | call to taint |
 | params_flow.rb:130:26:130:27 | 67 | type tracker without call steps | params_flow.rb:130:26:130:27 | 67 |
+| params_flow.rb:130:26:130:27 | 67 | type tracker without call steps with content element 0 | params_flow.rb:130:20:130:28 | synthetic splat argument |
 | params_flow.rb:130:26:130:27 | 67 | type tracker without call steps with content element 1 | params_flow.rb:130:8:130:29 | call to [] |
 | params_flow.rb:130:26:130:27 | 67 | type tracker without call steps with content element 1 | params_flow.rb:130:8:130:29 | synthetic splat argument |
 | params_flow.rb:130:26:130:27 | 67 | type tracker without call steps with content element 1 | params_flow.rb:131:10:131:14 | * ... |
-| params_flow.rb:130:26:130:27 | 67 | type tracker without call steps with content splat position 0 | params_flow.rb:130:20:130:28 | synthetic splat argument |
 | params_flow.rb:131:1:131:46 | call to pos_many | type tracker without call steps | params_flow.rb:131:1:131:46 | call to pos_many |
 | params_flow.rb:131:10:131:14 | * ... | type tracker with call steps | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:131:10:131:14 | * ... | type tracker without call steps | params_flow.rb:131:10:131:14 | * ... |
 | params_flow.rb:131:17:131:25 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:131:17:131:25 | call to taint | type tracker with call steps | params_flow.rb:83:17:83:17 | u |
-| params_flow.rb:131:17:131:25 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:131:17:131:25 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:131:17:131:25 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:85:5:85:10 | synthetic splat argument |
+| params_flow.rb:131:17:131:25 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:131:17:131:25 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:85:5:85:10 | synthetic splat argument |
 | params_flow.rb:131:17:131:25 | call to taint | type tracker without call steps | params_flow.rb:131:17:131:25 | call to taint |
-| params_flow.rb:131:17:131:25 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:131:17:131:25 | synthetic splat argument | type tracker without call steps | params_flow.rb:131:17:131:25 | synthetic splat argument |
 | params_flow.rb:131:23:131:24 | 68 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:131:23:131:24 | 68 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:131:23:131:24 | 68 | type tracker with call steps | params_flow.rb:83:17:83:17 | u |
-| params_flow.rb:131:23:131:24 | 68 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:131:23:131:24 | 68 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:131:23:131:24 | 68 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:131:23:131:24 | 68 | type tracker with call steps with content splat position 0 | params_flow.rb:85:5:85:10 | synthetic splat argument |
+| params_flow.rb:131:23:131:24 | 68 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:131:23:131:24 | 68 | type tracker with call steps with content element 0 | params_flow.rb:85:5:85:10 | synthetic splat argument |
 | params_flow.rb:131:23:131:24 | 68 | type tracker without call steps | params_flow.rb:131:17:131:25 | call to taint |
 | params_flow.rb:131:23:131:24 | 68 | type tracker without call steps | params_flow.rb:131:23:131:24 | 68 |
-| params_flow.rb:131:23:131:24 | 68 | type tracker without call steps with content splat position 0 | params_flow.rb:131:17:131:25 | synthetic splat argument |
+| params_flow.rb:131:23:131:24 | 68 | type tracker without call steps with content element 0 | params_flow.rb:131:17:131:25 | synthetic splat argument |
 | params_flow.rb:131:28:131:30 | nil | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:131:28:131:30 | nil | type tracker with call steps | params_flow.rb:83:20:83:20 | v |
-| params_flow.rb:131:28:131:30 | nil | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:131:28:131:30 | nil | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:131:28:131:30 | nil | type tracker with call steps with content splat position 0 | params_flow.rb:86:5:86:10 | synthetic splat argument |
+| params_flow.rb:131:28:131:30 | nil | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:131:28:131:30 | nil | type tracker with call steps with content element 0 | params_flow.rb:86:5:86:10 | synthetic splat argument |
 | params_flow.rb:131:28:131:30 | nil | type tracker without call steps | params_flow.rb:131:28:131:30 | nil |
 | params_flow.rb:131:33:131:35 | nil | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:131:33:131:35 | nil | type tracker with call steps | params_flow.rb:83:23:83:23 | w |
-| params_flow.rb:131:33:131:35 | nil | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:131:33:131:35 | nil | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:131:33:131:35 | nil | type tracker with call steps with content splat position 0 | params_flow.rb:87:5:87:10 | synthetic splat argument |
+| params_flow.rb:131:33:131:35 | nil | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:131:33:131:35 | nil | type tracker with call steps with content element 0 | params_flow.rb:87:5:87:10 | synthetic splat argument |
 | params_flow.rb:131:33:131:35 | nil | type tracker without call steps | params_flow.rb:131:33:131:35 | nil |
 | params_flow.rb:131:38:131:40 | nil | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:131:38:131:40 | nil | type tracker with call steps | params_flow.rb:83:26:83:26 | x |
-| params_flow.rb:131:38:131:40 | nil | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:131:38:131:40 | nil | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:131:38:131:40 | nil | type tracker with call steps with content splat position 0 | params_flow.rb:88:5:88:10 | synthetic splat argument |
+| params_flow.rb:131:38:131:40 | nil | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:131:38:131:40 | nil | type tracker with call steps with content element 0 | params_flow.rb:88:5:88:10 | synthetic splat argument |
 | params_flow.rb:131:38:131:40 | nil | type tracker without call steps | params_flow.rb:131:38:131:40 | nil |
 | params_flow.rb:131:43:131:45 | nil | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:131:43:131:45 | nil | type tracker with call steps | params_flow.rb:83:29:83:29 | y |
-| params_flow.rb:131:43:131:45 | nil | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:131:43:131:45 | nil | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:131:43:131:45 | nil | type tracker with call steps with content splat position 0 | params_flow.rb:89:5:89:10 | synthetic splat argument |
+| params_flow.rb:131:43:131:45 | nil | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:131:43:131:45 | nil | type tracker with call steps with content element 0 | params_flow.rb:89:5:89:10 | synthetic splat argument |
 | params_flow.rb:131:43:131:45 | nil | type tracker without call steps | params_flow.rb:131:43:131:45 | nil |
 | params_flow.rb:133:1:135:3 | &block | type tracker without call steps | params_flow.rb:133:1:135:3 | &block |
 | params_flow.rb:133:1:135:3 | self in splatall | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
@@ -2903,16 +2533,14 @@ track
 | params_flow.rb:133:15:133:18 | args | type tracker without call steps | params_flow.rb:133:15:133:18 | args |
 | params_flow.rb:134:5:134:16 | call to sink | type tracker without call steps | params_flow.rb:134:5:134:16 | call to sink |
 | params_flow.rb:134:5:134:16 | call to sink | type tracker without call steps | params_flow.rb:137:1:137:44 | call to splatall |
-| params_flow.rb:134:5:134:16 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:134:5:134:16 | synthetic splat argument | type tracker without call steps | params_flow.rb:134:5:134:16 | synthetic splat argument |
 | params_flow.rb:134:10:134:16 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:134:10:134:16 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:134:10:134:16 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:134:10:134:16 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:134:10:134:16 | ...[...] | type tracker without call steps | params_flow.rb:134:10:134:16 | ...[...] |
-| params_flow.rb:134:10:134:16 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:134:5:134:16 | synthetic splat argument |
+| params_flow.rb:134:10:134:16 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:134:5:134:16 | synthetic splat argument |
 | params_flow.rb:134:10:134:16 | synthetic splat argument | type tracker without call steps | params_flow.rb:134:10:134:16 | synthetic splat argument |
 | params_flow.rb:134:15:134:15 | 1 | type tracker without call steps | params_flow.rb:134:15:134:15 | 1 |
-| params_flow.rb:134:15:134:15 | 1 | type tracker without call steps with content splat position 0 | params_flow.rb:134:10:134:16 | synthetic splat argument |
+| params_flow.rb:134:15:134:15 | 1 | type tracker without call steps with content element 0 | params_flow.rb:134:10:134:16 | synthetic splat argument |
 | params_flow.rb:137:1:137:44 | call to splatall | type tracker without call steps | params_flow.rb:137:1:137:44 | call to splatall |
 | params_flow.rb:137:10:137:43 | * ... | type tracker with call steps | params_flow.rb:133:14:133:18 | *args |
 | params_flow.rb:137:10:137:43 | * ... | type tracker without call steps | params_flow.rb:137:10:137:43 | * ... |
@@ -2929,59 +2557,51 @@ track
 | params_flow.rb:137:12:137:20 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:137:10:137:43 | * ... |
 | params_flow.rb:137:12:137:20 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:137:11:137:43 | call to [] |
 | params_flow.rb:137:12:137:20 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:137:11:137:43 | synthetic splat argument |
-| params_flow.rb:137:12:137:20 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:137:12:137:20 | synthetic splat argument | type tracker without call steps | params_flow.rb:137:12:137:20 | synthetic splat argument |
 | params_flow.rb:137:18:137:19 | 69 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:137:18:137:19 | 69 | type tracker with call steps with content element 0 | params_flow.rb:133:14:133:18 | *args |
-| params_flow.rb:137:18:137:19 | 69 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:137:18:137:19 | 69 | type tracker without call steps | params_flow.rb:137:12:137:20 | call to taint |
 | params_flow.rb:137:18:137:19 | 69 | type tracker without call steps | params_flow.rb:137:18:137:19 | 69 |
 | params_flow.rb:137:18:137:19 | 69 | type tracker without call steps with content element 0 | params_flow.rb:137:10:137:43 | * ... |
 | params_flow.rb:137:18:137:19 | 69 | type tracker without call steps with content element 0 | params_flow.rb:137:11:137:43 | call to [] |
 | params_flow.rb:137:18:137:19 | 69 | type tracker without call steps with content element 0 | params_flow.rb:137:11:137:43 | synthetic splat argument |
-| params_flow.rb:137:18:137:19 | 69 | type tracker without call steps with content splat position 0 | params_flow.rb:137:12:137:20 | synthetic splat argument |
+| params_flow.rb:137:18:137:19 | 69 | type tracker without call steps with content element 0 | params_flow.rb:137:12:137:20 | synthetic splat argument |
 | params_flow.rb:137:23:137:31 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:137:23:137:31 | call to taint | type tracker with call steps | params_flow.rb:134:10:134:16 | ...[...] |
+| params_flow.rb:137:23:137:31 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:137:23:137:31 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:134:5:134:16 | synthetic splat argument |
 | params_flow.rb:137:23:137:31 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:133:14:133:18 | *args |
-| params_flow.rb:137:23:137:31 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:137:23:137:31 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:137:23:137:31 | call to taint | type tracker with call steps with content splat position 0 | params_flow.rb:134:5:134:16 | synthetic splat argument |
 | params_flow.rb:137:23:137:31 | call to taint | type tracker without call steps | params_flow.rb:137:23:137:31 | call to taint |
 | params_flow.rb:137:23:137:31 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:137:10:137:43 | * ... |
 | params_flow.rb:137:23:137:31 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:137:11:137:43 | call to [] |
 | params_flow.rb:137:23:137:31 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:137:11:137:43 | synthetic splat argument |
-| params_flow.rb:137:23:137:31 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:137:23:137:31 | synthetic splat argument | type tracker without call steps | params_flow.rb:137:23:137:31 | synthetic splat argument |
 | params_flow.rb:137:29:137:30 | 70 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:137:29:137:30 | 70 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:137:29:137:30 | 70 | type tracker with call steps | params_flow.rb:134:10:134:16 | ...[...] |
+| params_flow.rb:137:29:137:30 | 70 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:137:29:137:30 | 70 | type tracker with call steps with content element 0 | params_flow.rb:134:5:134:16 | synthetic splat argument |
 | params_flow.rb:137:29:137:30 | 70 | type tracker with call steps with content element 1 | params_flow.rb:133:14:133:18 | *args |
-| params_flow.rb:137:29:137:30 | 70 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:137:29:137:30 | 70 | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:137:29:137:30 | 70 | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:137:29:137:30 | 70 | type tracker with call steps with content splat position 0 | params_flow.rb:134:5:134:16 | synthetic splat argument |
 | params_flow.rb:137:29:137:30 | 70 | type tracker without call steps | params_flow.rb:137:23:137:31 | call to taint |
 | params_flow.rb:137:29:137:30 | 70 | type tracker without call steps | params_flow.rb:137:29:137:30 | 70 |
+| params_flow.rb:137:29:137:30 | 70 | type tracker without call steps with content element 0 | params_flow.rb:137:23:137:31 | synthetic splat argument |
 | params_flow.rb:137:29:137:30 | 70 | type tracker without call steps with content element 1 | params_flow.rb:137:10:137:43 | * ... |
 | params_flow.rb:137:29:137:30 | 70 | type tracker without call steps with content element 1 | params_flow.rb:137:11:137:43 | call to [] |
 | params_flow.rb:137:29:137:30 | 70 | type tracker without call steps with content element 1 | params_flow.rb:137:11:137:43 | synthetic splat argument |
-| params_flow.rb:137:29:137:30 | 70 | type tracker without call steps with content splat position 0 | params_flow.rb:137:23:137:31 | synthetic splat argument |
 | params_flow.rb:137:34:137:42 | call to taint | type tracker with call steps with content element 2 | params_flow.rb:133:14:133:18 | *args |
 | params_flow.rb:137:34:137:42 | call to taint | type tracker without call steps | params_flow.rb:137:34:137:42 | call to taint |
 | params_flow.rb:137:34:137:42 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:137:10:137:43 | * ... |
 | params_flow.rb:137:34:137:42 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:137:11:137:43 | call to [] |
 | params_flow.rb:137:34:137:42 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:137:11:137:43 | synthetic splat argument |
-| params_flow.rb:137:34:137:42 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:137:34:137:42 | synthetic splat argument | type tracker without call steps | params_flow.rb:137:34:137:42 | synthetic splat argument |
 | params_flow.rb:137:40:137:41 | 71 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:137:40:137:41 | 71 | type tracker with call steps with content element 2 | params_flow.rb:133:14:133:18 | *args |
-| params_flow.rb:137:40:137:41 | 71 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:137:40:137:41 | 71 | type tracker without call steps | params_flow.rb:137:34:137:42 | call to taint |
 | params_flow.rb:137:40:137:41 | 71 | type tracker without call steps | params_flow.rb:137:40:137:41 | 71 |
+| params_flow.rb:137:40:137:41 | 71 | type tracker without call steps with content element 0 | params_flow.rb:137:34:137:42 | synthetic splat argument |
 | params_flow.rb:137:40:137:41 | 71 | type tracker without call steps with content element 2 | params_flow.rb:137:10:137:43 | * ... |
 | params_flow.rb:137:40:137:41 | 71 | type tracker without call steps with content element 2 | params_flow.rb:137:11:137:43 | call to [] |
 | params_flow.rb:137:40:137:41 | 71 | type tracker without call steps with content element 2 | params_flow.rb:137:11:137:43 | synthetic splat argument |
-| params_flow.rb:137:40:137:41 | 71 | type tracker without call steps with content splat position 0 | params_flow.rb:137:34:137:42 | synthetic splat argument |
 | params_flow.rb:139:1:141:3 | &block | type tracker without call steps | params_flow.rb:139:1:141:3 | &block |
 | params_flow.rb:139:1:141:3 | hashSplatSideEffect | type tracker without call steps | params_flow.rb:139:1:141:3 | hashSplatSideEffect |
 | params_flow.rb:139:1:141:3 | self in hashSplatSideEffect | type tracker without call steps | params_flow.rb:139:1:141:3 | self in hashSplatSideEffect |
@@ -2995,18 +2615,18 @@ track
 | params_flow.rb:140:5:140:38 | call to insert | type tracker without call steps | params_flow.rb:150:1:150:42 | call to hashSplatSideEffect |
 | params_flow.rb:140:5:140:38 | synthetic splat argument | type tracker without call steps | params_flow.rb:140:5:140:38 | synthetic splat argument |
 | params_flow.rb:140:12:140:14 | :p1 | type tracker without call steps | params_flow.rb:140:12:140:14 | :p1 |
-| params_flow.rb:140:12:140:14 | :p1 | type tracker without call steps with content splat position 0 | params_flow.rb:140:5:140:15 | synthetic splat argument |
+| params_flow.rb:140:12:140:14 | :p1 | type tracker without call steps with content element 0 | params_flow.rb:140:5:140:15 | synthetic splat argument |
 | params_flow.rb:140:24:140:24 | 0 | type tracker without call steps | params_flow.rb:140:24:140:24 | 0 |
-| params_flow.rb:140:24:140:24 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:140:5:140:38 | synthetic splat argument |
+| params_flow.rb:140:24:140:24 | 0 | type tracker without call steps with content element 0 | params_flow.rb:140:5:140:38 | synthetic splat argument |
 | params_flow.rb:140:27:140:37 | ...[...] | type tracker without call steps | params_flow.rb:140:27:140:37 | ...[...] |
 | params_flow.rb:140:27:140:37 | ...[...] | type tracker without call steps with content element 0 or unknown | params_flow.rb:140:5:140:15 | [post] ...[...] |
 | params_flow.rb:140:27:140:37 | ...[...] | type tracker without call steps with content element 0 or unknown | params_flow.rb:140:5:140:38 | call to insert |
 | params_flow.rb:140:27:140:37 | ...[...] | type tracker without call steps with content element 0 or unknown | params_flow.rb:145:1:145:29 | call to hashSplatSideEffect |
 | params_flow.rb:140:27:140:37 | ...[...] | type tracker without call steps with content element 0 or unknown | params_flow.rb:150:1:150:42 | call to hashSplatSideEffect |
-| params_flow.rb:140:27:140:37 | ...[...] | type tracker without call steps with content splat position 1 | params_flow.rb:140:5:140:38 | synthetic splat argument |
+| params_flow.rb:140:27:140:37 | ...[...] | type tracker without call steps with content element 1 | params_flow.rb:140:5:140:38 | synthetic splat argument |
 | params_flow.rb:140:27:140:37 | synthetic splat argument | type tracker without call steps | params_flow.rb:140:27:140:37 | synthetic splat argument |
 | params_flow.rb:140:34:140:36 | :p2 | type tracker without call steps | params_flow.rb:140:34:140:36 | :p2 |
-| params_flow.rb:140:34:140:36 | :p2 | type tracker without call steps with content splat position 0 | params_flow.rb:140:27:140:37 | synthetic splat argument |
+| params_flow.rb:140:34:140:36 | :p2 | type tracker without call steps with content element 0 | params_flow.rb:140:27:140:37 | synthetic splat argument |
 | params_flow.rb:143:1:143:6 | kwargs | type tracker without call steps | params_flow.rb:143:1:143:6 | kwargs |
 | params_flow.rb:143:10:143:34 | Hash | type tracker without call steps | params_flow.rb:143:10:143:34 | Hash |
 | params_flow.rb:143:10:143:34 | call to [] | type tracker without call steps | params_flow.rb:143:10:143:34 | call to [] |
@@ -3028,60 +2648,54 @@ track
 | params_flow.rb:143:24:143:32 | call to taint | type tracker with call steps | params_flow.rb:140:27:140:37 | ...[...] |
 | params_flow.rb:143:24:143:32 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:140:5:140:15 | [post] ...[...] |
 | params_flow.rb:143:24:143:32 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:140:5:140:38 | call to insert |
+| params_flow.rb:143:24:143:32 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:140:5:140:38 | synthetic splat argument |
 | params_flow.rb:143:24:143:32 | call to taint | type tracker with call steps with content element :p2 | params_flow.rb:139:25:139:32 | **kwargs |
-| params_flow.rb:143:24:143:32 | call to taint | type tracker with call steps with content splat position 1 | params_flow.rb:140:5:140:38 | synthetic splat argument |
 | params_flow.rb:143:24:143:32 | call to taint | type tracker without call steps | params_flow.rb:143:24:143:32 | call to taint |
 | params_flow.rb:143:24:143:32 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:143:10:143:34 | call to [] |
 | params_flow.rb:143:24:143:32 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:143:10:143:34 | synthetic hash-splat argument |
 | params_flow.rb:143:24:143:32 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:145:21:145:28 | ** ... |
-| params_flow.rb:143:24:143:32 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:143:24:143:32 | synthetic splat argument | type tracker without call steps | params_flow.rb:143:24:143:32 | synthetic splat argument |
 | params_flow.rb:143:30:143:31 | 72 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:143:30:143:31 | 72 | type tracker with call steps | params_flow.rb:140:27:140:37 | ...[...] |
 | params_flow.rb:143:30:143:31 | 72 | type tracker with call steps with content element 0 or unknown | params_flow.rb:140:5:140:15 | [post] ...[...] |
 | params_flow.rb:143:30:143:31 | 72 | type tracker with call steps with content element 0 or unknown | params_flow.rb:140:5:140:38 | call to insert |
+| params_flow.rb:143:30:143:31 | 72 | type tracker with call steps with content element 1 | params_flow.rb:140:5:140:38 | synthetic splat argument |
 | params_flow.rb:143:30:143:31 | 72 | type tracker with call steps with content element :p2 | params_flow.rb:139:25:139:32 | **kwargs |
-| params_flow.rb:143:30:143:31 | 72 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:143:30:143:31 | 72 | type tracker with call steps with content splat position 1 | params_flow.rb:140:5:140:38 | synthetic splat argument |
 | params_flow.rb:143:30:143:31 | 72 | type tracker without call steps | params_flow.rb:143:24:143:32 | call to taint |
 | params_flow.rb:143:30:143:31 | 72 | type tracker without call steps | params_flow.rb:143:30:143:31 | 72 |
+| params_flow.rb:143:30:143:31 | 72 | type tracker without call steps with content element 0 | params_flow.rb:143:24:143:32 | synthetic splat argument |
 | params_flow.rb:143:30:143:31 | 72 | type tracker without call steps with content element :p2 | params_flow.rb:143:10:143:34 | call to [] |
 | params_flow.rb:143:30:143:31 | 72 | type tracker without call steps with content element :p2 | params_flow.rb:143:10:143:34 | synthetic hash-splat argument |
 | params_flow.rb:143:30:143:31 | 72 | type tracker without call steps with content element :p2 | params_flow.rb:145:21:145:28 | ** ... |
-| params_flow.rb:143:30:143:31 | 72 | type tracker without call steps with content splat position 0 | params_flow.rb:143:24:143:32 | synthetic splat argument |
 | params_flow.rb:144:1:144:20 | call to sink | type tracker without call steps | params_flow.rb:144:1:144:20 | call to sink |
-| params_flow.rb:144:1:144:20 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:144:1:144:20 | synthetic splat argument | type tracker without call steps | params_flow.rb:144:1:144:20 | synthetic splat argument |
 | params_flow.rb:144:6:144:16 | ...[...] | type tracker without call steps | params_flow.rb:144:6:144:16 | ...[...] |
 | params_flow.rb:144:6:144:16 | synthetic splat argument | type tracker without call steps | params_flow.rb:144:6:144:16 | synthetic splat argument |
 | params_flow.rb:144:6:144:19 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:144:6:144:19 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:144:6:144:19 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:144:6:144:19 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:144:6:144:19 | ...[...] | type tracker without call steps | params_flow.rb:144:6:144:19 | ...[...] |
-| params_flow.rb:144:6:144:19 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:144:1:144:20 | synthetic splat argument |
+| params_flow.rb:144:6:144:19 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:144:1:144:20 | synthetic splat argument |
 | params_flow.rb:144:6:144:19 | synthetic splat argument | type tracker without call steps | params_flow.rb:144:6:144:19 | synthetic splat argument |
 | params_flow.rb:144:13:144:15 | :p1 | type tracker without call steps | params_flow.rb:144:13:144:15 | :p1 |
-| params_flow.rb:144:13:144:15 | :p1 | type tracker without call steps with content splat position 0 | params_flow.rb:144:6:144:16 | synthetic splat argument |
+| params_flow.rb:144:13:144:15 | :p1 | type tracker without call steps with content element 0 | params_flow.rb:144:6:144:16 | synthetic splat argument |
 | params_flow.rb:144:18:144:18 | 0 | type tracker without call steps | params_flow.rb:144:18:144:18 | 0 |
-| params_flow.rb:144:18:144:18 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:144:6:144:19 | synthetic splat argument |
+| params_flow.rb:144:18:144:18 | 0 | type tracker without call steps with content element 0 | params_flow.rb:144:6:144:19 | synthetic splat argument |
 | params_flow.rb:145:1:145:29 | call to hashSplatSideEffect | type tracker without call steps | params_flow.rb:145:1:145:29 | call to hashSplatSideEffect |
 | params_flow.rb:145:21:145:28 | ** ... | type tracker with call steps | params_flow.rb:139:25:139:32 | **kwargs |
 | params_flow.rb:145:21:145:28 | ** ... | type tracker without call steps | params_flow.rb:145:21:145:28 | ** ... |
 | params_flow.rb:146:1:146:20 | call to sink | type tracker without call steps | params_flow.rb:146:1:146:20 | call to sink |
-| params_flow.rb:146:1:146:20 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:146:1:146:20 | synthetic splat argument | type tracker without call steps | params_flow.rb:146:1:146:20 | synthetic splat argument |
 | params_flow.rb:146:6:146:16 | ...[...] | type tracker without call steps | params_flow.rb:146:6:146:16 | ...[...] |
 | params_flow.rb:146:6:146:16 | synthetic splat argument | type tracker without call steps | params_flow.rb:146:6:146:16 | synthetic splat argument |
 | params_flow.rb:146:6:146:19 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:146:6:146:19 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:146:6:146:19 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:146:6:146:19 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:146:6:146:19 | ...[...] | type tracker without call steps | params_flow.rb:146:6:146:19 | ...[...] |
-| params_flow.rb:146:6:146:19 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:146:1:146:20 | synthetic splat argument |
+| params_flow.rb:146:6:146:19 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:146:1:146:20 | synthetic splat argument |
 | params_flow.rb:146:6:146:19 | synthetic splat argument | type tracker without call steps | params_flow.rb:146:6:146:19 | synthetic splat argument |
 | params_flow.rb:146:13:146:15 | :p1 | type tracker without call steps | params_flow.rb:146:13:146:15 | :p1 |
-| params_flow.rb:146:13:146:15 | :p1 | type tracker without call steps with content splat position 0 | params_flow.rb:146:6:146:16 | synthetic splat argument |
+| params_flow.rb:146:13:146:15 | :p1 | type tracker without call steps with content element 0 | params_flow.rb:146:6:146:16 | synthetic splat argument |
 | params_flow.rb:146:18:146:18 | 0 | type tracker without call steps | params_flow.rb:146:18:146:18 | 0 |
-| params_flow.rb:146:18:146:18 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:146:6:146:19 | synthetic splat argument |
+| params_flow.rb:146:18:146:18 | 0 | type tracker without call steps with content element 0 | params_flow.rb:146:6:146:19 | synthetic splat argument |
 | params_flow.rb:148:1:148:2 | p1 | type tracker without call steps | params_flow.rb:148:1:148:2 | p1 |
 | params_flow.rb:148:6:148:7 | Array | type tracker without call steps | params_flow.rb:148:6:148:7 | Array |
 | params_flow.rb:148:6:148:7 | call to [] | type tracker with call steps | params_flow.rb:140:5:140:15 | ...[...] |
@@ -3089,16 +2703,14 @@ track
 | params_flow.rb:148:6:148:7 | call to [] | type tracker without call steps | params_flow.rb:148:6:148:7 | call to [] |
 | params_flow.rb:148:6:148:7 | call to [] | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:150:1:150:42 | synthetic hash-splat argument |
 | params_flow.rb:149:1:149:11 | call to sink | type tracker without call steps | params_flow.rb:149:1:149:11 | call to sink |
-| params_flow.rb:149:1:149:11 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:149:1:149:11 | synthetic splat argument | type tracker without call steps | params_flow.rb:149:1:149:11 | synthetic splat argument |
 | params_flow.rb:149:6:149:10 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:149:6:149:10 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:149:6:149:10 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:149:6:149:10 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:149:6:149:10 | ...[...] | type tracker without call steps | params_flow.rb:149:6:149:10 | ...[...] |
-| params_flow.rb:149:6:149:10 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:149:1:149:11 | synthetic splat argument |
+| params_flow.rb:149:6:149:10 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:149:1:149:11 | synthetic splat argument |
 | params_flow.rb:149:6:149:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:149:6:149:10 | synthetic splat argument |
 | params_flow.rb:149:9:149:9 | 0 | type tracker without call steps | params_flow.rb:149:9:149:9 | 0 |
-| params_flow.rb:149:9:149:9 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:149:6:149:10 | synthetic splat argument |
+| params_flow.rb:149:9:149:9 | 0 | type tracker without call steps with content element 0 | params_flow.rb:149:6:149:10 | synthetic splat argument |
 | params_flow.rb:150:1:150:42 | call to hashSplatSideEffect | type tracker without call steps | params_flow.rb:150:1:150:42 | call to hashSplatSideEffect |
 | params_flow.rb:150:1:150:42 | synthetic hash-splat argument | type tracker with call steps | params_flow.rb:139:25:139:32 | **kwargs |
 | params_flow.rb:150:1:150:42 | synthetic hash-splat argument | type tracker without call steps | params_flow.rb:150:1:150:42 | synthetic hash-splat argument |
@@ -3109,34 +2721,30 @@ track
 | params_flow.rb:150:33:150:41 | call to taint | type tracker with call steps | params_flow.rb:140:27:140:37 | ...[...] |
 | params_flow.rb:150:33:150:41 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:140:5:140:15 | [post] ...[...] |
 | params_flow.rb:150:33:150:41 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:140:5:140:38 | call to insert |
+| params_flow.rb:150:33:150:41 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:140:5:140:38 | synthetic splat argument |
 | params_flow.rb:150:33:150:41 | call to taint | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:139:25:139:32 | **kwargs |
-| params_flow.rb:150:33:150:41 | call to taint | type tracker with call steps with content splat position 1 | params_flow.rb:140:5:140:38 | synthetic splat argument |
 | params_flow.rb:150:33:150:41 | call to taint | type tracker without call steps | params_flow.rb:150:33:150:41 | call to taint |
 | params_flow.rb:150:33:150:41 | call to taint | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:150:1:150:42 | synthetic hash-splat argument |
-| params_flow.rb:150:33:150:41 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:150:33:150:41 | synthetic splat argument | type tracker without call steps | params_flow.rb:150:33:150:41 | synthetic splat argument |
 | params_flow.rb:150:39:150:40 | 73 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:150:39:150:40 | 73 | type tracker with call steps | params_flow.rb:140:27:140:37 | ...[...] |
 | params_flow.rb:150:39:150:40 | 73 | type tracker with call steps with content element 0 or unknown | params_flow.rb:140:5:140:15 | [post] ...[...] |
 | params_flow.rb:150:39:150:40 | 73 | type tracker with call steps with content element 0 or unknown | params_flow.rb:140:5:140:38 | call to insert |
+| params_flow.rb:150:39:150:40 | 73 | type tracker with call steps with content element 1 | params_flow.rb:140:5:140:38 | synthetic splat argument |
 | params_flow.rb:150:39:150:40 | 73 | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:139:25:139:32 | **kwargs |
-| params_flow.rb:150:39:150:40 | 73 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:150:39:150:40 | 73 | type tracker with call steps with content splat position 1 | params_flow.rb:140:5:140:38 | synthetic splat argument |
 | params_flow.rb:150:39:150:40 | 73 | type tracker without call steps | params_flow.rb:150:33:150:41 | call to taint |
 | params_flow.rb:150:39:150:40 | 73 | type tracker without call steps | params_flow.rb:150:39:150:40 | 73 |
+| params_flow.rb:150:39:150:40 | 73 | type tracker without call steps with content element 0 | params_flow.rb:150:33:150:41 | synthetic splat argument |
 | params_flow.rb:150:39:150:40 | 73 | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:150:1:150:42 | synthetic hash-splat argument |
-| params_flow.rb:150:39:150:40 | 73 | type tracker without call steps with content splat position 0 | params_flow.rb:150:33:150:41 | synthetic splat argument |
 | params_flow.rb:151:1:151:11 | call to sink | type tracker without call steps | params_flow.rb:151:1:151:11 | call to sink |
-| params_flow.rb:151:1:151:11 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:151:1:151:11 | synthetic splat argument | type tracker without call steps | params_flow.rb:151:1:151:11 | synthetic splat argument |
 | params_flow.rb:151:6:151:10 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:151:6:151:10 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:151:6:151:10 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:151:6:151:10 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:151:6:151:10 | ...[...] | type tracker without call steps | params_flow.rb:151:6:151:10 | ...[...] |
-| params_flow.rb:151:6:151:10 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:151:1:151:11 | synthetic splat argument |
+| params_flow.rb:151:6:151:10 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:151:1:151:11 | synthetic splat argument |
 | params_flow.rb:151:6:151:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:151:6:151:10 | synthetic splat argument |
 | params_flow.rb:151:9:151:9 | 0 | type tracker without call steps | params_flow.rb:151:9:151:9 | 0 |
-| params_flow.rb:151:9:151:9 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:151:6:151:10 | synthetic splat argument |
+| params_flow.rb:151:9:151:9 | 0 | type tracker without call steps with content element 0 | params_flow.rb:151:6:151:10 | synthetic splat argument |
 | params_flow.rb:153:1:155:3 | &block | type tracker without call steps | params_flow.rb:153:1:155:3 | &block |
 | params_flow.rb:153:1:155:3 | keywordSideEffect | type tracker without call steps | params_flow.rb:153:1:155:3 | keywordSideEffect |
 | params_flow.rb:153:1:155:3 | self in keywordSideEffect | type tracker without call steps | params_flow.rb:153:1:155:3 | self in keywordSideEffect |
@@ -3149,14 +2757,14 @@ track
 | params_flow.rb:153:28:153:29 | p2 | type tracker without call steps with content element 0 or unknown | params_flow.rb:154:5:154:20 | call to insert |
 | params_flow.rb:153:28:153:29 | p2 | type tracker without call steps with content element 0 or unknown | params_flow.rb:159:1:159:27 | call to keywordSideEffect |
 | params_flow.rb:153:28:153:29 | p2 | type tracker without call steps with content element 0 or unknown | params_flow.rb:164:1:164:40 | call to keywordSideEffect |
-| params_flow.rb:153:28:153:29 | p2 | type tracker without call steps with content splat position 1 | params_flow.rb:154:5:154:20 | synthetic splat argument |
+| params_flow.rb:153:28:153:29 | p2 | type tracker without call steps with content element 1 | params_flow.rb:154:5:154:20 | synthetic splat argument |
 | params_flow.rb:154:5:154:6 | [post] p1 | type tracker without call steps | params_flow.rb:154:5:154:6 | [post] p1 |
 | params_flow.rb:154:5:154:20 | call to insert | type tracker without call steps | params_flow.rb:154:5:154:20 | call to insert |
 | params_flow.rb:154:5:154:20 | call to insert | type tracker without call steps | params_flow.rb:159:1:159:27 | call to keywordSideEffect |
 | params_flow.rb:154:5:154:20 | call to insert | type tracker without call steps | params_flow.rb:164:1:164:40 | call to keywordSideEffect |
 | params_flow.rb:154:5:154:20 | synthetic splat argument | type tracker without call steps | params_flow.rb:154:5:154:20 | synthetic splat argument |
 | params_flow.rb:154:15:154:15 | 0 | type tracker without call steps | params_flow.rb:154:15:154:15 | 0 |
-| params_flow.rb:154:15:154:15 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:154:5:154:20 | synthetic splat argument |
+| params_flow.rb:154:15:154:15 | 0 | type tracker without call steps with content element 0 | params_flow.rb:154:5:154:20 | synthetic splat argument |
 | params_flow.rb:157:1:157:6 | kwargs | type tracker without call steps | params_flow.rb:157:1:157:6 | kwargs |
 | params_flow.rb:157:10:157:34 | Hash | type tracker without call steps | params_flow.rb:157:10:157:34 | Hash |
 | params_flow.rb:157:10:157:34 | call to [] | type tracker without call steps | params_flow.rb:157:10:157:34 | call to [] |
@@ -3178,60 +2786,54 @@ track
 | params_flow.rb:157:24:157:32 | call to taint | type tracker with call steps | params_flow.rb:153:28:153:29 | p2 |
 | params_flow.rb:157:24:157:32 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:154:5:154:6 | [post] p1 |
 | params_flow.rb:157:24:157:32 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:154:5:154:20 | call to insert |
+| params_flow.rb:157:24:157:32 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:154:5:154:20 | synthetic splat argument |
 | params_flow.rb:157:24:157:32 | call to taint | type tracker with call steps with content element :p2 | params_flow.rb:153:1:155:3 | synthetic hash-splat parameter |
-| params_flow.rb:157:24:157:32 | call to taint | type tracker with call steps with content splat position 1 | params_flow.rb:154:5:154:20 | synthetic splat argument |
 | params_flow.rb:157:24:157:32 | call to taint | type tracker without call steps | params_flow.rb:157:24:157:32 | call to taint |
 | params_flow.rb:157:24:157:32 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:157:10:157:34 | call to [] |
 | params_flow.rb:157:24:157:32 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:157:10:157:34 | synthetic hash-splat argument |
 | params_flow.rb:157:24:157:32 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:159:19:159:26 | ** ... |
-| params_flow.rb:157:24:157:32 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:157:24:157:32 | synthetic splat argument | type tracker without call steps | params_flow.rb:157:24:157:32 | synthetic splat argument |
 | params_flow.rb:157:30:157:31 | 74 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:157:30:157:31 | 74 | type tracker with call steps | params_flow.rb:153:28:153:29 | p2 |
 | params_flow.rb:157:30:157:31 | 74 | type tracker with call steps with content element 0 or unknown | params_flow.rb:154:5:154:6 | [post] p1 |
 | params_flow.rb:157:30:157:31 | 74 | type tracker with call steps with content element 0 or unknown | params_flow.rb:154:5:154:20 | call to insert |
+| params_flow.rb:157:30:157:31 | 74 | type tracker with call steps with content element 1 | params_flow.rb:154:5:154:20 | synthetic splat argument |
 | params_flow.rb:157:30:157:31 | 74 | type tracker with call steps with content element :p2 | params_flow.rb:153:1:155:3 | synthetic hash-splat parameter |
-| params_flow.rb:157:30:157:31 | 74 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:157:30:157:31 | 74 | type tracker with call steps with content splat position 1 | params_flow.rb:154:5:154:20 | synthetic splat argument |
 | params_flow.rb:157:30:157:31 | 74 | type tracker without call steps | params_flow.rb:157:24:157:32 | call to taint |
 | params_flow.rb:157:30:157:31 | 74 | type tracker without call steps | params_flow.rb:157:30:157:31 | 74 |
+| params_flow.rb:157:30:157:31 | 74 | type tracker without call steps with content element 0 | params_flow.rb:157:24:157:32 | synthetic splat argument |
 | params_flow.rb:157:30:157:31 | 74 | type tracker without call steps with content element :p2 | params_flow.rb:157:10:157:34 | call to [] |
 | params_flow.rb:157:30:157:31 | 74 | type tracker without call steps with content element :p2 | params_flow.rb:157:10:157:34 | synthetic hash-splat argument |
 | params_flow.rb:157:30:157:31 | 74 | type tracker without call steps with content element :p2 | params_flow.rb:159:19:159:26 | ** ... |
-| params_flow.rb:157:30:157:31 | 74 | type tracker without call steps with content splat position 0 | params_flow.rb:157:24:157:32 | synthetic splat argument |
 | params_flow.rb:158:1:158:20 | call to sink | type tracker without call steps | params_flow.rb:158:1:158:20 | call to sink |
-| params_flow.rb:158:1:158:20 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:158:1:158:20 | synthetic splat argument | type tracker without call steps | params_flow.rb:158:1:158:20 | synthetic splat argument |
 | params_flow.rb:158:6:158:16 | ...[...] | type tracker without call steps | params_flow.rb:158:6:158:16 | ...[...] |
 | params_flow.rb:158:6:158:16 | synthetic splat argument | type tracker without call steps | params_flow.rb:158:6:158:16 | synthetic splat argument |
 | params_flow.rb:158:6:158:19 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:158:6:158:19 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:158:6:158:19 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:158:6:158:19 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:158:6:158:19 | ...[...] | type tracker without call steps | params_flow.rb:158:6:158:19 | ...[...] |
-| params_flow.rb:158:6:158:19 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:158:1:158:20 | synthetic splat argument |
+| params_flow.rb:158:6:158:19 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:158:1:158:20 | synthetic splat argument |
 | params_flow.rb:158:6:158:19 | synthetic splat argument | type tracker without call steps | params_flow.rb:158:6:158:19 | synthetic splat argument |
 | params_flow.rb:158:13:158:15 | :p1 | type tracker without call steps | params_flow.rb:158:13:158:15 | :p1 |
-| params_flow.rb:158:13:158:15 | :p1 | type tracker without call steps with content splat position 0 | params_flow.rb:158:6:158:16 | synthetic splat argument |
+| params_flow.rb:158:13:158:15 | :p1 | type tracker without call steps with content element 0 | params_flow.rb:158:6:158:16 | synthetic splat argument |
 | params_flow.rb:158:18:158:18 | 0 | type tracker without call steps | params_flow.rb:158:18:158:18 | 0 |
-| params_flow.rb:158:18:158:18 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:158:6:158:19 | synthetic splat argument |
+| params_flow.rb:158:18:158:18 | 0 | type tracker without call steps with content element 0 | params_flow.rb:158:6:158:19 | synthetic splat argument |
 | params_flow.rb:159:1:159:27 | call to keywordSideEffect | type tracker without call steps | params_flow.rb:159:1:159:27 | call to keywordSideEffect |
 | params_flow.rb:159:19:159:26 | ** ... | type tracker with call steps | params_flow.rb:153:1:155:3 | synthetic hash-splat parameter |
 | params_flow.rb:159:19:159:26 | ** ... | type tracker without call steps | params_flow.rb:159:19:159:26 | ** ... |
 | params_flow.rb:160:1:160:20 | call to sink | type tracker without call steps | params_flow.rb:160:1:160:20 | call to sink |
-| params_flow.rb:160:1:160:20 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:160:1:160:20 | synthetic splat argument | type tracker without call steps | params_flow.rb:160:1:160:20 | synthetic splat argument |
 | params_flow.rb:160:6:160:16 | ...[...] | type tracker without call steps | params_flow.rb:160:6:160:16 | ...[...] |
 | params_flow.rb:160:6:160:16 | synthetic splat argument | type tracker without call steps | params_flow.rb:160:6:160:16 | synthetic splat argument |
 | params_flow.rb:160:6:160:19 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:160:6:160:19 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:160:6:160:19 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:160:6:160:19 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:160:6:160:19 | ...[...] | type tracker without call steps | params_flow.rb:160:6:160:19 | ...[...] |
-| params_flow.rb:160:6:160:19 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:160:1:160:20 | synthetic splat argument |
+| params_flow.rb:160:6:160:19 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:160:1:160:20 | synthetic splat argument |
 | params_flow.rb:160:6:160:19 | synthetic splat argument | type tracker without call steps | params_flow.rb:160:6:160:19 | synthetic splat argument |
 | params_flow.rb:160:13:160:15 | :p1 | type tracker without call steps | params_flow.rb:160:13:160:15 | :p1 |
-| params_flow.rb:160:13:160:15 | :p1 | type tracker without call steps with content splat position 0 | params_flow.rb:160:6:160:16 | synthetic splat argument |
+| params_flow.rb:160:13:160:15 | :p1 | type tracker without call steps with content element 0 | params_flow.rb:160:6:160:16 | synthetic splat argument |
 | params_flow.rb:160:18:160:18 | 0 | type tracker without call steps | params_flow.rb:160:18:160:18 | 0 |
-| params_flow.rb:160:18:160:18 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:160:6:160:19 | synthetic splat argument |
+| params_flow.rb:160:18:160:18 | 0 | type tracker without call steps with content element 0 | params_flow.rb:160:6:160:19 | synthetic splat argument |
 | params_flow.rb:162:1:162:2 | p1 | type tracker without call steps | params_flow.rb:162:1:162:2 | p1 |
 | params_flow.rb:162:6:162:7 | Array | type tracker without call steps | params_flow.rb:162:6:162:7 | Array |
 | params_flow.rb:162:6:162:7 | call to [] | type tracker with call steps | params_flow.rb:153:23:153:24 | p1 |
@@ -3239,16 +2841,14 @@ track
 | params_flow.rb:162:6:162:7 | call to [] | type tracker without call steps | params_flow.rb:162:6:162:7 | call to [] |
 | params_flow.rb:162:6:162:7 | call to [] | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:164:1:164:40 | synthetic hash-splat argument |
 | params_flow.rb:163:1:163:11 | call to sink | type tracker without call steps | params_flow.rb:163:1:163:11 | call to sink |
-| params_flow.rb:163:1:163:11 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:163:1:163:11 | synthetic splat argument | type tracker without call steps | params_flow.rb:163:1:163:11 | synthetic splat argument |
 | params_flow.rb:163:6:163:10 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:163:6:163:10 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:163:6:163:10 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:163:6:163:10 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:163:6:163:10 | ...[...] | type tracker without call steps | params_flow.rb:163:6:163:10 | ...[...] |
-| params_flow.rb:163:6:163:10 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:163:1:163:11 | synthetic splat argument |
+| params_flow.rb:163:6:163:10 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:163:1:163:11 | synthetic splat argument |
 | params_flow.rb:163:6:163:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:163:6:163:10 | synthetic splat argument |
 | params_flow.rb:163:9:163:9 | 0 | type tracker without call steps | params_flow.rb:163:9:163:9 | 0 |
-| params_flow.rb:163:9:163:9 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:163:6:163:10 | synthetic splat argument |
+| params_flow.rb:163:9:163:9 | 0 | type tracker without call steps with content element 0 | params_flow.rb:163:6:163:10 | synthetic splat argument |
 | params_flow.rb:164:1:164:40 | call to keywordSideEffect | type tracker without call steps | params_flow.rb:164:1:164:40 | call to keywordSideEffect |
 | params_flow.rb:164:1:164:40 | synthetic hash-splat argument | type tracker with call steps | params_flow.rb:153:1:155:3 | synthetic hash-splat parameter |
 | params_flow.rb:164:1:164:40 | synthetic hash-splat argument | type tracker without call steps | params_flow.rb:164:1:164:40 | synthetic hash-splat argument |
@@ -3259,34 +2859,30 @@ track
 | params_flow.rb:164:31:164:39 | call to taint | type tracker with call steps | params_flow.rb:153:28:153:29 | p2 |
 | params_flow.rb:164:31:164:39 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:154:5:154:6 | [post] p1 |
 | params_flow.rb:164:31:164:39 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:154:5:154:20 | call to insert |
+| params_flow.rb:164:31:164:39 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:154:5:154:20 | synthetic splat argument |
 | params_flow.rb:164:31:164:39 | call to taint | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:153:1:155:3 | synthetic hash-splat parameter |
-| params_flow.rb:164:31:164:39 | call to taint | type tracker with call steps with content splat position 1 | params_flow.rb:154:5:154:20 | synthetic splat argument |
 | params_flow.rb:164:31:164:39 | call to taint | type tracker without call steps | params_flow.rb:164:31:164:39 | call to taint |
 | params_flow.rb:164:31:164:39 | call to taint | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:164:1:164:40 | synthetic hash-splat argument |
-| params_flow.rb:164:31:164:39 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:164:31:164:39 | synthetic splat argument | type tracker without call steps | params_flow.rb:164:31:164:39 | synthetic splat argument |
 | params_flow.rb:164:37:164:38 | 75 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:164:37:164:38 | 75 | type tracker with call steps | params_flow.rb:153:28:153:29 | p2 |
 | params_flow.rb:164:37:164:38 | 75 | type tracker with call steps with content element 0 or unknown | params_flow.rb:154:5:154:6 | [post] p1 |
 | params_flow.rb:164:37:164:38 | 75 | type tracker with call steps with content element 0 or unknown | params_flow.rb:154:5:154:20 | call to insert |
+| params_flow.rb:164:37:164:38 | 75 | type tracker with call steps with content element 1 | params_flow.rb:154:5:154:20 | synthetic splat argument |
 | params_flow.rb:164:37:164:38 | 75 | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:153:1:155:3 | synthetic hash-splat parameter |
-| params_flow.rb:164:37:164:38 | 75 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:164:37:164:38 | 75 | type tracker with call steps with content splat position 1 | params_flow.rb:154:5:154:20 | synthetic splat argument |
 | params_flow.rb:164:37:164:38 | 75 | type tracker without call steps | params_flow.rb:164:31:164:39 | call to taint |
 | params_flow.rb:164:37:164:38 | 75 | type tracker without call steps | params_flow.rb:164:37:164:38 | 75 |
+| params_flow.rb:164:37:164:38 | 75 | type tracker without call steps with content element 0 | params_flow.rb:164:31:164:39 | synthetic splat argument |
 | params_flow.rb:164:37:164:38 | 75 | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:164:1:164:40 | synthetic hash-splat argument |
-| params_flow.rb:164:37:164:38 | 75 | type tracker without call steps with content splat position 0 | params_flow.rb:164:31:164:39 | synthetic splat argument |
 | params_flow.rb:165:1:165:11 | call to sink | type tracker without call steps | params_flow.rb:165:1:165:11 | call to sink |
-| params_flow.rb:165:1:165:11 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:165:1:165:11 | synthetic splat argument | type tracker without call steps | params_flow.rb:165:1:165:11 | synthetic splat argument |
 | params_flow.rb:165:6:165:10 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:165:6:165:10 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:165:6:165:10 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:165:6:165:10 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:165:6:165:10 | ...[...] | type tracker without call steps | params_flow.rb:165:6:165:10 | ...[...] |
-| params_flow.rb:165:6:165:10 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:165:1:165:11 | synthetic splat argument |
+| params_flow.rb:165:6:165:10 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:165:1:165:11 | synthetic splat argument |
 | params_flow.rb:165:6:165:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:165:6:165:10 | synthetic splat argument |
 | params_flow.rb:165:9:165:9 | 0 | type tracker without call steps | params_flow.rb:165:9:165:9 | 0 |
-| params_flow.rb:165:9:165:9 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:165:6:165:10 | synthetic splat argument |
+| params_flow.rb:165:9:165:9 | 0 | type tracker without call steps with content element 0 | params_flow.rb:165:6:165:10 | synthetic splat argument |
 | params_flow.rb:167:1:169:3 | &block | type tracker without call steps | params_flow.rb:167:1:169:3 | &block |
 | params_flow.rb:167:1:169:3 | self in splatSideEffect | type tracker without call steps | params_flow.rb:167:1:169:3 | self in splatSideEffect |
 | params_flow.rb:167:1:169:3 | splatSideEffect | type tracker without call steps | params_flow.rb:167:1:169:3 | splatSideEffect |
@@ -3300,18 +2896,18 @@ track
 | params_flow.rb:168:5:168:36 | call to insert | type tracker without call steps | params_flow.rb:178:1:178:30 | call to splatSideEffect |
 | params_flow.rb:168:5:168:36 | synthetic splat argument | type tracker without call steps | params_flow.rb:168:5:168:36 | synthetic splat argument |
 | params_flow.rb:168:13:168:13 | 0 | type tracker without call steps | params_flow.rb:168:13:168:13 | 0 |
-| params_flow.rb:168:13:168:13 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:168:5:168:14 | synthetic splat argument |
+| params_flow.rb:168:13:168:13 | 0 | type tracker without call steps with content element 0 | params_flow.rb:168:5:168:14 | synthetic splat argument |
 | params_flow.rb:168:23:168:23 | 0 | type tracker without call steps | params_flow.rb:168:23:168:23 | 0 |
-| params_flow.rb:168:23:168:23 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:168:5:168:36 | synthetic splat argument |
+| params_flow.rb:168:23:168:23 | 0 | type tracker without call steps with content element 0 | params_flow.rb:168:5:168:36 | synthetic splat argument |
 | params_flow.rb:168:26:168:35 | ...[...] | type tracker without call steps | params_flow.rb:168:26:168:35 | ...[...] |
 | params_flow.rb:168:26:168:35 | ...[...] | type tracker without call steps with content element 0 or unknown | params_flow.rb:168:5:168:14 | [post] ...[...] |
 | params_flow.rb:168:26:168:35 | ...[...] | type tracker without call steps with content element 0 or unknown | params_flow.rb:168:5:168:36 | call to insert |
 | params_flow.rb:168:26:168:35 | ...[...] | type tracker without call steps with content element 0 or unknown | params_flow.rb:173:1:173:25 | call to splatSideEffect |
 | params_flow.rb:168:26:168:35 | ...[...] | type tracker without call steps with content element 0 or unknown | params_flow.rb:178:1:178:30 | call to splatSideEffect |
-| params_flow.rb:168:26:168:35 | ...[...] | type tracker without call steps with content splat position 1 | params_flow.rb:168:5:168:36 | synthetic splat argument |
+| params_flow.rb:168:26:168:35 | ...[...] | type tracker without call steps with content element 1 | params_flow.rb:168:5:168:36 | synthetic splat argument |
 | params_flow.rb:168:26:168:35 | synthetic splat argument | type tracker without call steps | params_flow.rb:168:26:168:35 | synthetic splat argument |
 | params_flow.rb:168:34:168:34 | 1 | type tracker without call steps | params_flow.rb:168:34:168:34 | 1 |
-| params_flow.rb:168:34:168:34 | 1 | type tracker without call steps with content splat position 0 | params_flow.rb:168:26:168:35 | synthetic splat argument |
+| params_flow.rb:168:34:168:34 | 1 | type tracker without call steps with content element 0 | params_flow.rb:168:26:168:35 | synthetic splat argument |
 | params_flow.rb:171:1:171:7 | posargs | type tracker without call steps | params_flow.rb:171:1:171:7 | posargs |
 | params_flow.rb:171:11:171:27 | Array | type tracker without call steps | params_flow.rb:171:11:171:27 | Array |
 | params_flow.rb:171:11:171:27 | call to [] | type tracker with call steps | params_flow.rb:168:5:168:14 | ...[...] |
@@ -3336,110 +2932,98 @@ track
 | params_flow.rb:171:17:171:25 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:168:5:168:14 | [post] ...[...] |
 | params_flow.rb:171:17:171:25 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:168:5:168:36 | call to insert |
 | params_flow.rb:171:17:171:25 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:167:21:167:28 | *posargs |
-| params_flow.rb:171:17:171:25 | call to taint | type tracker with call steps with content splat position 1 | params_flow.rb:168:5:168:36 | synthetic splat argument |
+| params_flow.rb:171:17:171:25 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:168:5:168:36 | synthetic splat argument |
 | params_flow.rb:171:17:171:25 | call to taint | type tracker without call steps | params_flow.rb:171:17:171:25 | call to taint |
 | params_flow.rb:171:17:171:25 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:171:11:171:27 | call to [] |
 | params_flow.rb:171:17:171:25 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:171:11:171:27 | synthetic splat argument |
 | params_flow.rb:171:17:171:25 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:173:17:173:24 | * ... |
-| params_flow.rb:171:17:171:25 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:171:17:171:25 | synthetic splat argument | type tracker without call steps | params_flow.rb:171:17:171:25 | synthetic splat argument |
 | params_flow.rb:171:23:171:24 | 76 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:171:23:171:24 | 76 | type tracker with call steps | params_flow.rb:168:26:168:35 | ...[...] |
 | params_flow.rb:171:23:171:24 | 76 | type tracker with call steps with content element 0 or unknown | params_flow.rb:168:5:168:14 | [post] ...[...] |
 | params_flow.rb:171:23:171:24 | 76 | type tracker with call steps with content element 0 or unknown | params_flow.rb:168:5:168:36 | call to insert |
 | params_flow.rb:171:23:171:24 | 76 | type tracker with call steps with content element 1 | params_flow.rb:167:21:167:28 | *posargs |
-| params_flow.rb:171:23:171:24 | 76 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:171:23:171:24 | 76 | type tracker with call steps with content splat position 1 | params_flow.rb:168:5:168:36 | synthetic splat argument |
+| params_flow.rb:171:23:171:24 | 76 | type tracker with call steps with content element 1 | params_flow.rb:168:5:168:36 | synthetic splat argument |
 | params_flow.rb:171:23:171:24 | 76 | type tracker without call steps | params_flow.rb:171:17:171:25 | call to taint |
 | params_flow.rb:171:23:171:24 | 76 | type tracker without call steps | params_flow.rb:171:23:171:24 | 76 |
+| params_flow.rb:171:23:171:24 | 76 | type tracker without call steps with content element 0 | params_flow.rb:171:17:171:25 | synthetic splat argument |
 | params_flow.rb:171:23:171:24 | 76 | type tracker without call steps with content element 1 | params_flow.rb:171:11:171:27 | call to [] |
 | params_flow.rb:171:23:171:24 | 76 | type tracker without call steps with content element 1 | params_flow.rb:171:11:171:27 | synthetic splat argument |
 | params_flow.rb:171:23:171:24 | 76 | type tracker without call steps with content element 1 | params_flow.rb:173:17:173:24 | * ... |
-| params_flow.rb:171:23:171:24 | 76 | type tracker without call steps with content splat position 0 | params_flow.rb:171:17:171:25 | synthetic splat argument |
 | params_flow.rb:172:1:172:19 | call to sink | type tracker without call steps | params_flow.rb:172:1:172:19 | call to sink |
-| params_flow.rb:172:1:172:19 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:172:1:172:19 | synthetic splat argument | type tracker without call steps | params_flow.rb:172:1:172:19 | synthetic splat argument |
 | params_flow.rb:172:6:172:15 | ...[...] | type tracker without call steps | params_flow.rb:172:6:172:15 | ...[...] |
 | params_flow.rb:172:6:172:15 | synthetic splat argument | type tracker without call steps | params_flow.rb:172:6:172:15 | synthetic splat argument |
 | params_flow.rb:172:6:172:18 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:172:6:172:18 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:172:6:172:18 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:172:6:172:18 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:172:6:172:18 | ...[...] | type tracker without call steps | params_flow.rb:172:6:172:18 | ...[...] |
-| params_flow.rb:172:6:172:18 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:172:1:172:19 | synthetic splat argument |
+| params_flow.rb:172:6:172:18 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:172:1:172:19 | synthetic splat argument |
 | params_flow.rb:172:6:172:18 | synthetic splat argument | type tracker without call steps | params_flow.rb:172:6:172:18 | synthetic splat argument |
 | params_flow.rb:172:14:172:14 | 0 | type tracker without call steps | params_flow.rb:172:14:172:14 | 0 |
-| params_flow.rb:172:14:172:14 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:172:6:172:15 | synthetic splat argument |
+| params_flow.rb:172:14:172:14 | 0 | type tracker without call steps with content element 0 | params_flow.rb:172:6:172:15 | synthetic splat argument |
 | params_flow.rb:172:17:172:17 | 0 | type tracker without call steps | params_flow.rb:172:17:172:17 | 0 |
-| params_flow.rb:172:17:172:17 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:172:6:172:18 | synthetic splat argument |
+| params_flow.rb:172:17:172:17 | 0 | type tracker without call steps with content element 0 | params_flow.rb:172:6:172:18 | synthetic splat argument |
 | params_flow.rb:173:1:173:25 | call to splatSideEffect | type tracker without call steps | params_flow.rb:173:1:173:25 | call to splatSideEffect |
 | params_flow.rb:173:17:173:24 | * ... | type tracker with call steps | params_flow.rb:167:21:167:28 | *posargs |
 | params_flow.rb:173:17:173:24 | * ... | type tracker without call steps | params_flow.rb:173:17:173:24 | * ... |
 | params_flow.rb:174:1:174:19 | call to sink | type tracker without call steps | params_flow.rb:174:1:174:19 | call to sink |
-| params_flow.rb:174:1:174:19 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:174:1:174:19 | synthetic splat argument | type tracker without call steps | params_flow.rb:174:1:174:19 | synthetic splat argument |
 | params_flow.rb:174:6:174:15 | ...[...] | type tracker without call steps | params_flow.rb:174:6:174:15 | ...[...] |
 | params_flow.rb:174:6:174:15 | synthetic splat argument | type tracker without call steps | params_flow.rb:174:6:174:15 | synthetic splat argument |
 | params_flow.rb:174:6:174:18 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:174:6:174:18 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:174:6:174:18 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:174:6:174:18 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:174:6:174:18 | ...[...] | type tracker without call steps | params_flow.rb:174:6:174:18 | ...[...] |
-| params_flow.rb:174:6:174:18 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:174:1:174:19 | synthetic splat argument |
+| params_flow.rb:174:6:174:18 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:174:1:174:19 | synthetic splat argument |
 | params_flow.rb:174:6:174:18 | synthetic splat argument | type tracker without call steps | params_flow.rb:174:6:174:18 | synthetic splat argument |
 | params_flow.rb:174:14:174:14 | 0 | type tracker without call steps | params_flow.rb:174:14:174:14 | 0 |
-| params_flow.rb:174:14:174:14 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:174:6:174:15 | synthetic splat argument |
+| params_flow.rb:174:14:174:14 | 0 | type tracker without call steps with content element 0 | params_flow.rb:174:6:174:15 | synthetic splat argument |
 | params_flow.rb:174:17:174:17 | 0 | type tracker without call steps | params_flow.rb:174:17:174:17 | 0 |
-| params_flow.rb:174:17:174:17 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:174:6:174:18 | synthetic splat argument |
+| params_flow.rb:174:17:174:17 | 0 | type tracker without call steps with content element 0 | params_flow.rb:174:6:174:18 | synthetic splat argument |
 | params_flow.rb:176:1:176:2 | p1 | type tracker without call steps | params_flow.rb:176:1:176:2 | p1 |
 | params_flow.rb:176:6:176:7 | Array | type tracker without call steps | params_flow.rb:176:6:176:7 | Array |
 | params_flow.rb:176:6:176:7 | call to [] | type tracker with call steps | params_flow.rb:168:5:168:14 | ...[...] |
-| params_flow.rb:176:6:176:7 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:167:21:167:28 | *posargs |
+| params_flow.rb:176:6:176:7 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:167:21:167:28 | *posargs |
 | params_flow.rb:176:6:176:7 | call to [] | type tracker without call steps | params_flow.rb:176:6:176:7 | call to [] |
-| params_flow.rb:176:6:176:7 | call to [] | type tracker without call steps with content splat position 0 | params_flow.rb:178:1:178:30 | synthetic splat argument |
+| params_flow.rb:176:6:176:7 | call to [] | type tracker without call steps with content element 0 | params_flow.rb:178:1:178:30 | synthetic splat argument |
 | params_flow.rb:177:1:177:11 | call to sink | type tracker without call steps | params_flow.rb:177:1:177:11 | call to sink |
-| params_flow.rb:177:1:177:11 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:177:1:177:11 | synthetic splat argument | type tracker without call steps | params_flow.rb:177:1:177:11 | synthetic splat argument |
 | params_flow.rb:177:6:177:10 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:177:6:177:10 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:177:6:177:10 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:177:6:177:10 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:177:6:177:10 | ...[...] | type tracker without call steps | params_flow.rb:177:6:177:10 | ...[...] |
-| params_flow.rb:177:6:177:10 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:177:1:177:11 | synthetic splat argument |
+| params_flow.rb:177:6:177:10 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:177:1:177:11 | synthetic splat argument |
 | params_flow.rb:177:6:177:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:177:6:177:10 | synthetic splat argument |
 | params_flow.rb:177:9:177:9 | 0 | type tracker without call steps | params_flow.rb:177:9:177:9 | 0 |
-| params_flow.rb:177:9:177:9 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:177:6:177:10 | synthetic splat argument |
+| params_flow.rb:177:9:177:9 | 0 | type tracker without call steps with content element 0 | params_flow.rb:177:6:177:10 | synthetic splat argument |
 | params_flow.rb:178:1:178:30 | call to splatSideEffect | type tracker without call steps | params_flow.rb:178:1:178:30 | call to splatSideEffect |
 | params_flow.rb:178:1:178:30 | synthetic splat argument | type tracker with call steps | params_flow.rb:167:21:167:28 | *posargs |
 | params_flow.rb:178:1:178:30 | synthetic splat argument | type tracker without call steps | params_flow.rb:178:1:178:30 | synthetic splat argument |
 | params_flow.rb:178:21:178:29 | call to taint | type tracker with call steps | params_flow.rb:168:26:168:35 | ...[...] |
 | params_flow.rb:178:21:178:29 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:168:5:168:14 | [post] ...[...] |
 | params_flow.rb:178:21:178:29 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:168:5:168:36 | call to insert |
-| params_flow.rb:178:21:178:29 | call to taint | type tracker with call steps with content splat position 1 | params_flow.rb:167:21:167:28 | *posargs |
-| params_flow.rb:178:21:178:29 | call to taint | type tracker with call steps with content splat position 1 | params_flow.rb:168:5:168:36 | synthetic splat argument |
+| params_flow.rb:178:21:178:29 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:167:21:167:28 | *posargs |
+| params_flow.rb:178:21:178:29 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:168:5:168:36 | synthetic splat argument |
 | params_flow.rb:178:21:178:29 | call to taint | type tracker without call steps | params_flow.rb:178:21:178:29 | call to taint |
-| params_flow.rb:178:21:178:29 | call to taint | type tracker without call steps with content splat position 1 | params_flow.rb:178:1:178:30 | synthetic splat argument |
-| params_flow.rb:178:21:178:29 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:178:21:178:29 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:178:1:178:30 | synthetic splat argument |
 | params_flow.rb:178:21:178:29 | synthetic splat argument | type tracker without call steps | params_flow.rb:178:21:178:29 | synthetic splat argument |
 | params_flow.rb:178:27:178:28 | 77 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:178:27:178:28 | 77 | type tracker with call steps | params_flow.rb:168:26:168:35 | ...[...] |
 | params_flow.rb:178:27:178:28 | 77 | type tracker with call steps with content element 0 or unknown | params_flow.rb:168:5:168:14 | [post] ...[...] |
 | params_flow.rb:178:27:178:28 | 77 | type tracker with call steps with content element 0 or unknown | params_flow.rb:168:5:168:36 | call to insert |
-| params_flow.rb:178:27:178:28 | 77 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:178:27:178:28 | 77 | type tracker with call steps with content splat position 1 | params_flow.rb:167:21:167:28 | *posargs |
-| params_flow.rb:178:27:178:28 | 77 | type tracker with call steps with content splat position 1 | params_flow.rb:168:5:168:36 | synthetic splat argument |
+| params_flow.rb:178:27:178:28 | 77 | type tracker with call steps with content element 1 | params_flow.rb:167:21:167:28 | *posargs |
+| params_flow.rb:178:27:178:28 | 77 | type tracker with call steps with content element 1 | params_flow.rb:168:5:168:36 | synthetic splat argument |
 | params_flow.rb:178:27:178:28 | 77 | type tracker without call steps | params_flow.rb:178:21:178:29 | call to taint |
 | params_flow.rb:178:27:178:28 | 77 | type tracker without call steps | params_flow.rb:178:27:178:28 | 77 |
-| params_flow.rb:178:27:178:28 | 77 | type tracker without call steps with content splat position 0 | params_flow.rb:178:21:178:29 | synthetic splat argument |
-| params_flow.rb:178:27:178:28 | 77 | type tracker without call steps with content splat position 1 | params_flow.rb:178:1:178:30 | synthetic splat argument |
+| params_flow.rb:178:27:178:28 | 77 | type tracker without call steps with content element 0 | params_flow.rb:178:21:178:29 | synthetic splat argument |
+| params_flow.rb:178:27:178:28 | 77 | type tracker without call steps with content element 1 | params_flow.rb:178:1:178:30 | synthetic splat argument |
 | params_flow.rb:179:1:179:11 | call to sink | type tracker without call steps | params_flow.rb:179:1:179:11 | call to sink |
-| params_flow.rb:179:1:179:11 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:179:1:179:11 | synthetic splat argument | type tracker without call steps | params_flow.rb:179:1:179:11 | synthetic splat argument |
 | params_flow.rb:179:6:179:10 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:179:6:179:10 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:179:6:179:10 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:179:6:179:10 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:179:6:179:10 | ...[...] | type tracker without call steps | params_flow.rb:179:6:179:10 | ...[...] |
-| params_flow.rb:179:6:179:10 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:179:1:179:11 | synthetic splat argument |
+| params_flow.rb:179:6:179:10 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:179:1:179:11 | synthetic splat argument |
 | params_flow.rb:179:6:179:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:179:6:179:10 | synthetic splat argument |
 | params_flow.rb:179:9:179:9 | 0 | type tracker without call steps | params_flow.rb:179:9:179:9 | 0 |
-| params_flow.rb:179:9:179:9 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:179:6:179:10 | synthetic splat argument |
+| params_flow.rb:179:9:179:9 | 0 | type tracker without call steps with content element 0 | params_flow.rb:179:6:179:10 | synthetic splat argument |
 | params_flow.rb:181:1:183:3 | &block | type tracker without call steps | params_flow.rb:181:1:183:3 | &block |
 | params_flow.rb:181:1:183:3 | positionSideEffect | type tracker without call steps | params_flow.rb:181:1:183:3 | positionSideEffect |
 | params_flow.rb:181:1:183:3 | self in positionSideEffect | type tracker without call steps | params_flow.rb:181:1:183:3 | self in positionSideEffect |
@@ -3452,14 +3036,14 @@ track
 | params_flow.rb:181:28:181:29 | p2 | type tracker without call steps with content element 0 or unknown | params_flow.rb:182:5:182:20 | call to insert |
 | params_flow.rb:181:28:181:29 | p2 | type tracker without call steps with content element 0 or unknown | params_flow.rb:187:1:187:25 | call to positionSideEffect |
 | params_flow.rb:181:28:181:29 | p2 | type tracker without call steps with content element 0 or unknown | params_flow.rb:192:1:192:33 | call to positionSideEffect |
-| params_flow.rb:181:28:181:29 | p2 | type tracker without call steps with content splat position 1 | params_flow.rb:182:5:182:20 | synthetic splat argument |
+| params_flow.rb:181:28:181:29 | p2 | type tracker without call steps with content element 1 | params_flow.rb:182:5:182:20 | synthetic splat argument |
 | params_flow.rb:182:5:182:6 | [post] p1 | type tracker without call steps | params_flow.rb:182:5:182:6 | [post] p1 |
 | params_flow.rb:182:5:182:20 | call to insert | type tracker without call steps | params_flow.rb:182:5:182:20 | call to insert |
 | params_flow.rb:182:5:182:20 | call to insert | type tracker without call steps | params_flow.rb:187:1:187:25 | call to positionSideEffect |
 | params_flow.rb:182:5:182:20 | call to insert | type tracker without call steps | params_flow.rb:192:1:192:33 | call to positionSideEffect |
 | params_flow.rb:182:5:182:20 | synthetic splat argument | type tracker without call steps | params_flow.rb:182:5:182:20 | synthetic splat argument |
 | params_flow.rb:182:15:182:15 | 0 | type tracker without call steps | params_flow.rb:182:15:182:15 | 0 |
-| params_flow.rb:182:15:182:15 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:182:5:182:20 | synthetic splat argument |
+| params_flow.rb:182:15:182:15 | 0 | type tracker without call steps with content element 0 | params_flow.rb:182:5:182:20 | synthetic splat argument |
 | params_flow.rb:185:1:185:4 | args | type tracker without call steps | params_flow.rb:185:1:185:4 | args |
 | params_flow.rb:185:8:185:24 | Array | type tracker without call steps | params_flow.rb:185:8:185:24 | Array |
 | params_flow.rb:185:8:185:24 | call to [] | type tracker with call steps | params_flow.rb:181:24:181:25 | p1 |
@@ -3484,110 +3068,94 @@ track
 | params_flow.rb:185:14:185:22 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:182:5:182:6 | [post] p1 |
 | params_flow.rb:185:14:185:22 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:182:5:182:20 | call to insert |
 | params_flow.rb:185:14:185:22 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:181:1:183:3 | synthetic splat parameter |
-| params_flow.rb:185:14:185:22 | call to taint | type tracker with call steps with content splat position 1 | params_flow.rb:182:5:182:20 | synthetic splat argument |
+| params_flow.rb:185:14:185:22 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:182:5:182:20 | synthetic splat argument |
 | params_flow.rb:185:14:185:22 | call to taint | type tracker without call steps | params_flow.rb:185:14:185:22 | call to taint |
 | params_flow.rb:185:14:185:22 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:185:8:185:24 | call to [] |
 | params_flow.rb:185:14:185:22 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:185:8:185:24 | synthetic splat argument |
 | params_flow.rb:185:14:185:22 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:187:20:187:24 | * ... |
-| params_flow.rb:185:14:185:22 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:185:14:185:22 | synthetic splat argument | type tracker without call steps | params_flow.rb:185:14:185:22 | synthetic splat argument |
 | params_flow.rb:185:20:185:21 | 78 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:185:20:185:21 | 78 | type tracker with call steps | params_flow.rb:181:28:181:29 | p2 |
 | params_flow.rb:185:20:185:21 | 78 | type tracker with call steps with content element 0 or unknown | params_flow.rb:182:5:182:6 | [post] p1 |
 | params_flow.rb:185:20:185:21 | 78 | type tracker with call steps with content element 0 or unknown | params_flow.rb:182:5:182:20 | call to insert |
 | params_flow.rb:185:20:185:21 | 78 | type tracker with call steps with content element 1 | params_flow.rb:181:1:183:3 | synthetic splat parameter |
-| params_flow.rb:185:20:185:21 | 78 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:185:20:185:21 | 78 | type tracker with call steps with content splat position 1 | params_flow.rb:182:5:182:20 | synthetic splat argument |
+| params_flow.rb:185:20:185:21 | 78 | type tracker with call steps with content element 1 | params_flow.rb:182:5:182:20 | synthetic splat argument |
 | params_flow.rb:185:20:185:21 | 78 | type tracker without call steps | params_flow.rb:185:14:185:22 | call to taint |
 | params_flow.rb:185:20:185:21 | 78 | type tracker without call steps | params_flow.rb:185:20:185:21 | 78 |
+| params_flow.rb:185:20:185:21 | 78 | type tracker without call steps with content element 0 | params_flow.rb:185:14:185:22 | synthetic splat argument |
 | params_flow.rb:185:20:185:21 | 78 | type tracker without call steps with content element 1 | params_flow.rb:185:8:185:24 | call to [] |
 | params_flow.rb:185:20:185:21 | 78 | type tracker without call steps with content element 1 | params_flow.rb:185:8:185:24 | synthetic splat argument |
 | params_flow.rb:185:20:185:21 | 78 | type tracker without call steps with content element 1 | params_flow.rb:187:20:187:24 | * ... |
-| params_flow.rb:185:20:185:21 | 78 | type tracker without call steps with content splat position 0 | params_flow.rb:185:14:185:22 | synthetic splat argument |
 | params_flow.rb:186:1:186:16 | call to sink | type tracker without call steps | params_flow.rb:186:1:186:16 | call to sink |
-| params_flow.rb:186:1:186:16 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:186:1:186:16 | synthetic splat argument | type tracker without call steps | params_flow.rb:186:1:186:16 | synthetic splat argument |
 | params_flow.rb:186:6:186:12 | ...[...] | type tracker without call steps | params_flow.rb:186:6:186:12 | ...[...] |
 | params_flow.rb:186:6:186:12 | synthetic splat argument | type tracker without call steps | params_flow.rb:186:6:186:12 | synthetic splat argument |
 | params_flow.rb:186:6:186:15 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:186:6:186:15 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:186:6:186:15 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:186:6:186:15 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:186:6:186:15 | ...[...] | type tracker without call steps | params_flow.rb:186:6:186:15 | ...[...] |
-| params_flow.rb:186:6:186:15 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:186:1:186:16 | synthetic splat argument |
+| params_flow.rb:186:6:186:15 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:186:1:186:16 | synthetic splat argument |
 | params_flow.rb:186:6:186:15 | synthetic splat argument | type tracker without call steps | params_flow.rb:186:6:186:15 | synthetic splat argument |
 | params_flow.rb:186:11:186:11 | 0 | type tracker without call steps | params_flow.rb:186:11:186:11 | 0 |
-| params_flow.rb:186:11:186:11 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:186:6:186:12 | synthetic splat argument |
+| params_flow.rb:186:11:186:11 | 0 | type tracker without call steps with content element 0 | params_flow.rb:186:6:186:12 | synthetic splat argument |
 | params_flow.rb:186:14:186:14 | 0 | type tracker without call steps | params_flow.rb:186:14:186:14 | 0 |
-| params_flow.rb:186:14:186:14 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:186:6:186:15 | synthetic splat argument |
+| params_flow.rb:186:14:186:14 | 0 | type tracker without call steps with content element 0 | params_flow.rb:186:6:186:15 | synthetic splat argument |
 | params_flow.rb:187:1:187:25 | call to positionSideEffect | type tracker without call steps | params_flow.rb:187:1:187:25 | call to positionSideEffect |
 | params_flow.rb:187:20:187:24 | * ... | type tracker with call steps | params_flow.rb:181:1:183:3 | synthetic splat parameter |
 | params_flow.rb:187:20:187:24 | * ... | type tracker without call steps | params_flow.rb:187:20:187:24 | * ... |
 | params_flow.rb:188:1:188:16 | call to sink | type tracker without call steps | params_flow.rb:188:1:188:16 | call to sink |
-| params_flow.rb:188:1:188:16 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:188:1:188:16 | synthetic splat argument | type tracker without call steps | params_flow.rb:188:1:188:16 | synthetic splat argument |
 | params_flow.rb:188:6:188:12 | ...[...] | type tracker without call steps | params_flow.rb:188:6:188:12 | ...[...] |
 | params_flow.rb:188:6:188:12 | synthetic splat argument | type tracker without call steps | params_flow.rb:188:6:188:12 | synthetic splat argument |
 | params_flow.rb:188:6:188:15 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:188:6:188:15 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:188:6:188:15 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:188:6:188:15 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:188:6:188:15 | ...[...] | type tracker without call steps | params_flow.rb:188:6:188:15 | ...[...] |
-| params_flow.rb:188:6:188:15 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:188:1:188:16 | synthetic splat argument |
+| params_flow.rb:188:6:188:15 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:188:1:188:16 | synthetic splat argument |
 | params_flow.rb:188:6:188:15 | synthetic splat argument | type tracker without call steps | params_flow.rb:188:6:188:15 | synthetic splat argument |
 | params_flow.rb:188:11:188:11 | 0 | type tracker without call steps | params_flow.rb:188:11:188:11 | 0 |
-| params_flow.rb:188:11:188:11 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:188:6:188:12 | synthetic splat argument |
+| params_flow.rb:188:11:188:11 | 0 | type tracker without call steps with content element 0 | params_flow.rb:188:6:188:12 | synthetic splat argument |
 | params_flow.rb:188:14:188:14 | 0 | type tracker without call steps | params_flow.rb:188:14:188:14 | 0 |
-| params_flow.rb:188:14:188:14 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:188:6:188:15 | synthetic splat argument |
+| params_flow.rb:188:14:188:14 | 0 | type tracker without call steps with content element 0 | params_flow.rb:188:6:188:15 | synthetic splat argument |
 | params_flow.rb:190:1:190:2 | p1 | type tracker without call steps | params_flow.rb:190:1:190:2 | p1 |
 | params_flow.rb:190:6:190:7 | Array | type tracker without call steps | params_flow.rb:190:6:190:7 | Array |
 | params_flow.rb:190:6:190:7 | call to [] | type tracker with call steps | params_flow.rb:181:24:181:25 | p1 |
-| params_flow.rb:190:6:190:7 | call to [] | type tracker with call steps with content splat position 0 | params_flow.rb:181:1:183:3 | synthetic splat parameter |
 | params_flow.rb:190:6:190:7 | call to [] | type tracker without call steps | params_flow.rb:190:6:190:7 | call to [] |
-| params_flow.rb:190:6:190:7 | call to [] | type tracker without call steps with content splat position 0 | params_flow.rb:192:1:192:33 | synthetic splat argument |
+| params_flow.rb:190:6:190:7 | call to [] | type tracker without call steps with content element 0 | params_flow.rb:192:1:192:33 | synthetic splat argument |
 | params_flow.rb:191:1:191:11 | call to sink | type tracker without call steps | params_flow.rb:191:1:191:11 | call to sink |
-| params_flow.rb:191:1:191:11 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:191:1:191:11 | synthetic splat argument | type tracker without call steps | params_flow.rb:191:1:191:11 | synthetic splat argument |
 | params_flow.rb:191:6:191:10 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:191:6:191:10 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:191:6:191:10 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:191:6:191:10 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:191:6:191:10 | ...[...] | type tracker without call steps | params_flow.rb:191:6:191:10 | ...[...] |
-| params_flow.rb:191:6:191:10 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:191:1:191:11 | synthetic splat argument |
+| params_flow.rb:191:6:191:10 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:191:1:191:11 | synthetic splat argument |
 | params_flow.rb:191:6:191:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:191:6:191:10 | synthetic splat argument |
 | params_flow.rb:191:9:191:9 | 0 | type tracker without call steps | params_flow.rb:191:9:191:9 | 0 |
-| params_flow.rb:191:9:191:9 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:191:6:191:10 | synthetic splat argument |
+| params_flow.rb:191:9:191:9 | 0 | type tracker without call steps with content element 0 | params_flow.rb:191:6:191:10 | synthetic splat argument |
 | params_flow.rb:192:1:192:33 | call to positionSideEffect | type tracker without call steps | params_flow.rb:192:1:192:33 | call to positionSideEffect |
-| params_flow.rb:192:1:192:33 | synthetic splat argument | type tracker with call steps | params_flow.rb:181:1:183:3 | synthetic splat parameter |
 | params_flow.rb:192:1:192:33 | synthetic splat argument | type tracker without call steps | params_flow.rb:192:1:192:33 | synthetic splat argument |
 | params_flow.rb:192:24:192:32 | call to taint | type tracker with call steps | params_flow.rb:181:28:181:29 | p2 |
 | params_flow.rb:192:24:192:32 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:182:5:182:6 | [post] p1 |
 | params_flow.rb:192:24:192:32 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:182:5:182:20 | call to insert |
-| params_flow.rb:192:24:192:32 | call to taint | type tracker with call steps with content splat position 1 | params_flow.rb:181:1:183:3 | synthetic splat parameter |
-| params_flow.rb:192:24:192:32 | call to taint | type tracker with call steps with content splat position 1 | params_flow.rb:182:5:182:20 | synthetic splat argument |
+| params_flow.rb:192:24:192:32 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:182:5:182:20 | synthetic splat argument |
 | params_flow.rb:192:24:192:32 | call to taint | type tracker without call steps | params_flow.rb:192:24:192:32 | call to taint |
-| params_flow.rb:192:24:192:32 | call to taint | type tracker without call steps with content splat position 1 | params_flow.rb:192:1:192:33 | synthetic splat argument |
-| params_flow.rb:192:24:192:32 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
+| params_flow.rb:192:24:192:32 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:192:1:192:33 | synthetic splat argument |
 | params_flow.rb:192:24:192:32 | synthetic splat argument | type tracker without call steps | params_flow.rb:192:24:192:32 | synthetic splat argument |
 | params_flow.rb:192:30:192:31 | 79 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:192:30:192:31 | 79 | type tracker with call steps | params_flow.rb:181:28:181:29 | p2 |
 | params_flow.rb:192:30:192:31 | 79 | type tracker with call steps with content element 0 or unknown | params_flow.rb:182:5:182:6 | [post] p1 |
 | params_flow.rb:192:30:192:31 | 79 | type tracker with call steps with content element 0 or unknown | params_flow.rb:182:5:182:20 | call to insert |
-| params_flow.rb:192:30:192:31 | 79 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
-| params_flow.rb:192:30:192:31 | 79 | type tracker with call steps with content splat position 1 | params_flow.rb:181:1:183:3 | synthetic splat parameter |
-| params_flow.rb:192:30:192:31 | 79 | type tracker with call steps with content splat position 1 | params_flow.rb:182:5:182:20 | synthetic splat argument |
+| params_flow.rb:192:30:192:31 | 79 | type tracker with call steps with content element 1 | params_flow.rb:182:5:182:20 | synthetic splat argument |
 | params_flow.rb:192:30:192:31 | 79 | type tracker without call steps | params_flow.rb:192:24:192:32 | call to taint |
 | params_flow.rb:192:30:192:31 | 79 | type tracker without call steps | params_flow.rb:192:30:192:31 | 79 |
-| params_flow.rb:192:30:192:31 | 79 | type tracker without call steps with content splat position 0 | params_flow.rb:192:24:192:32 | synthetic splat argument |
-| params_flow.rb:192:30:192:31 | 79 | type tracker without call steps with content splat position 1 | params_flow.rb:192:1:192:33 | synthetic splat argument |
+| params_flow.rb:192:30:192:31 | 79 | type tracker without call steps with content element 0 | params_flow.rb:192:24:192:32 | synthetic splat argument |
+| params_flow.rb:192:30:192:31 | 79 | type tracker without call steps with content element 1 | params_flow.rb:192:1:192:33 | synthetic splat argument |
 | params_flow.rb:193:1:193:11 | call to sink | type tracker without call steps | params_flow.rb:193:1:193:11 | call to sink |
-| params_flow.rb:193:1:193:11 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:193:1:193:11 | synthetic splat argument | type tracker without call steps | params_flow.rb:193:1:193:11 | synthetic splat argument |
 | params_flow.rb:193:6:193:10 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:193:6:193:10 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:193:6:193:10 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:193:6:193:10 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:193:6:193:10 | ...[...] | type tracker without call steps | params_flow.rb:193:6:193:10 | ...[...] |
-| params_flow.rb:193:6:193:10 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:193:1:193:11 | synthetic splat argument |
+| params_flow.rb:193:6:193:10 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:193:1:193:11 | synthetic splat argument |
 | params_flow.rb:193:6:193:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:193:6:193:10 | synthetic splat argument |
 | params_flow.rb:193:9:193:9 | 0 | type tracker without call steps | params_flow.rb:193:9:193:9 | 0 |
-| params_flow.rb:193:9:193:9 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:193:6:193:10 | synthetic splat argument |
+| params_flow.rb:193:9:193:9 | 0 | type tracker without call steps with content element 0 | params_flow.rb:193:6:193:10 | synthetic splat argument |
 | params_flow.rb:195:1:195:8 | int_hash | type tracker without call steps | params_flow.rb:195:1:195:8 | int_hash |
 | params_flow.rb:195:12:198:1 | Hash | type tracker without call steps | params_flow.rb:195:12:198:1 | Hash |
 | params_flow.rb:195:12:198:1 | call to [] | type tracker with call steps | params_flow.rb:200:9:200:9 | x |
@@ -3602,28 +3170,26 @@ track
 | params_flow.rb:195:12:198:1 | synthetic splat argument | type tracker without call steps | params_flow.rb:195:12:198:1 | synthetic splat argument |
 | params_flow.rb:196:5:196:5 | 0 | type tracker without call steps | params_flow.rb:196:5:196:5 | 0 |
 | params_flow.rb:196:5:196:18 | Pair | type tracker without call steps | params_flow.rb:196:5:196:18 | Pair |
-| params_flow.rb:196:5:196:18 | Pair | type tracker without call steps with content splat position 0 | params_flow.rb:195:12:198:1 | synthetic splat argument |
+| params_flow.rb:196:5:196:18 | Pair | type tracker without call steps with content element 0 | params_flow.rb:195:12:198:1 | synthetic splat argument |
 | params_flow.rb:196:10:196:18 | call to taint | type tracker with call steps | params_flow.rb:200:9:200:9 | x |
 | params_flow.rb:196:10:196:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:200:1:205:3 | synthetic splat parameter |
 | params_flow.rb:196:10:196:18 | call to taint | type tracker without call steps | params_flow.rb:196:10:196:18 | call to taint |
 | params_flow.rb:196:10:196:18 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:195:12:198:1 | call to [] |
 | params_flow.rb:196:10:196:18 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:195:12:198:1 | synthetic hash-splat argument |
 | params_flow.rb:196:10:196:18 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:207:5:207:13 | * ... |
-| params_flow.rb:196:10:196:18 | synthetic splat argument | type tracker with call steps | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:196:10:196:18 | synthetic splat argument | type tracker without call steps | params_flow.rb:196:10:196:18 | synthetic splat argument |
 | params_flow.rb:196:16:196:17 | 80 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:196:16:196:17 | 80 | type tracker with call steps | params_flow.rb:200:9:200:9 | x |
 | params_flow.rb:196:16:196:17 | 80 | type tracker with call steps with content element 0 | params_flow.rb:200:1:205:3 | synthetic splat parameter |
-| params_flow.rb:196:16:196:17 | 80 | type tracker with call steps with content splat position 0 | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:196:16:196:17 | 80 | type tracker without call steps | params_flow.rb:196:10:196:18 | call to taint |
 | params_flow.rb:196:16:196:17 | 80 | type tracker without call steps | params_flow.rb:196:16:196:17 | 80 |
 | params_flow.rb:196:16:196:17 | 80 | type tracker without call steps with content element 0 | params_flow.rb:195:12:198:1 | call to [] |
 | params_flow.rb:196:16:196:17 | 80 | type tracker without call steps with content element 0 | params_flow.rb:195:12:198:1 | synthetic hash-splat argument |
+| params_flow.rb:196:16:196:17 | 80 | type tracker without call steps with content element 0 | params_flow.rb:196:10:196:18 | synthetic splat argument |
 | params_flow.rb:196:16:196:17 | 80 | type tracker without call steps with content element 0 | params_flow.rb:207:5:207:13 | * ... |
-| params_flow.rb:196:16:196:17 | 80 | type tracker without call steps with content splat position 0 | params_flow.rb:196:10:196:18 | synthetic splat argument |
 | params_flow.rb:197:5:197:5 | 1 | type tracker without call steps | params_flow.rb:197:5:197:5 | 1 |
 | params_flow.rb:197:5:197:12 | Pair | type tracker without call steps | params_flow.rb:197:5:197:12 | Pair |
-| params_flow.rb:197:5:197:12 | Pair | type tracker without call steps with content splat position 1 | params_flow.rb:195:12:198:1 | synthetic splat argument |
+| params_flow.rb:197:5:197:12 | Pair | type tracker without call steps with content element 1 | params_flow.rb:195:12:198:1 | synthetic splat argument |
 | params_flow.rb:197:10:197:12 | "B" | type tracker with call steps | params_flow.rb:200:12:200:12 | y |
 | params_flow.rb:197:10:197:12 | "B" | type tracker with call steps with content element 1 | params_flow.rb:200:1:205:3 | synthetic splat parameter |
 | params_flow.rb:197:10:197:12 | "B" | type tracker without call steps | params_flow.rb:197:10:197:12 | "B" |
@@ -3640,50 +3206,42 @@ track
 | params_flow.rb:200:12:200:12 | y | type tracker without call steps | params_flow.rb:200:12:200:12 | y |
 | params_flow.rb:200:12:200:12 | y | type tracker without call steps | params_flow.rb:200:12:200:12 | y |
 | params_flow.rb:201:5:201:15 | call to sink | type tracker without call steps | params_flow.rb:201:5:201:15 | call to sink |
-| params_flow.rb:201:5:201:15 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:201:5:201:15 | synthetic splat argument | type tracker without call steps | params_flow.rb:201:5:201:15 | synthetic splat argument |
 | params_flow.rb:201:11:201:14 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:201:11:201:14 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:201:11:201:14 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:201:11:201:14 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:201:11:201:14 | ...[...] | type tracker without call steps | params_flow.rb:201:11:201:14 | ...[...] |
-| params_flow.rb:201:11:201:14 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:201:5:201:15 | synthetic splat argument |
+| params_flow.rb:201:11:201:14 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:201:5:201:15 | synthetic splat argument |
 | params_flow.rb:201:11:201:14 | synthetic splat argument | type tracker without call steps | params_flow.rb:201:11:201:14 | synthetic splat argument |
 | params_flow.rb:201:13:201:13 | 0 | type tracker without call steps | params_flow.rb:201:13:201:13 | 0 |
-| params_flow.rb:201:13:201:13 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:201:11:201:14 | synthetic splat argument |
+| params_flow.rb:201:13:201:13 | 0 | type tracker without call steps with content element 0 | params_flow.rb:201:11:201:14 | synthetic splat argument |
 | params_flow.rb:202:5:202:15 | call to sink | type tracker without call steps | params_flow.rb:202:5:202:15 | call to sink |
-| params_flow.rb:202:5:202:15 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:202:5:202:15 | synthetic splat argument | type tracker without call steps | params_flow.rb:202:5:202:15 | synthetic splat argument |
 | params_flow.rb:202:11:202:14 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:202:11:202:14 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:202:11:202:14 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:202:11:202:14 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:202:11:202:14 | ...[...] | type tracker without call steps | params_flow.rb:202:11:202:14 | ...[...] |
-| params_flow.rb:202:11:202:14 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:202:5:202:15 | synthetic splat argument |
+| params_flow.rb:202:11:202:14 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:202:5:202:15 | synthetic splat argument |
 | params_flow.rb:202:11:202:14 | synthetic splat argument | type tracker without call steps | params_flow.rb:202:11:202:14 | synthetic splat argument |
 | params_flow.rb:202:13:202:13 | 1 | type tracker without call steps | params_flow.rb:202:13:202:13 | 1 |
-| params_flow.rb:202:13:202:13 | 1 | type tracker without call steps with content splat position 0 | params_flow.rb:202:11:202:14 | synthetic splat argument |
+| params_flow.rb:202:13:202:13 | 1 | type tracker without call steps with content element 0 | params_flow.rb:202:11:202:14 | synthetic splat argument |
 | params_flow.rb:203:5:203:15 | call to sink | type tracker without call steps | params_flow.rb:203:5:203:15 | call to sink |
-| params_flow.rb:203:5:203:15 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:203:5:203:15 | synthetic splat argument | type tracker without call steps | params_flow.rb:203:5:203:15 | synthetic splat argument |
 | params_flow.rb:203:11:203:14 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:203:11:203:14 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:203:11:203:14 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:203:11:203:14 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:203:11:203:14 | ...[...] | type tracker without call steps | params_flow.rb:203:11:203:14 | ...[...] |
-| params_flow.rb:203:11:203:14 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:203:5:203:15 | synthetic splat argument |
+| params_flow.rb:203:11:203:14 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:203:5:203:15 | synthetic splat argument |
 | params_flow.rb:203:11:203:14 | synthetic splat argument | type tracker without call steps | params_flow.rb:203:11:203:14 | synthetic splat argument |
 | params_flow.rb:203:13:203:13 | 0 | type tracker without call steps | params_flow.rb:203:13:203:13 | 0 |
-| params_flow.rb:203:13:203:13 | 0 | type tracker without call steps with content splat position 0 | params_flow.rb:203:11:203:14 | synthetic splat argument |
+| params_flow.rb:203:13:203:13 | 0 | type tracker without call steps with content element 0 | params_flow.rb:203:11:203:14 | synthetic splat argument |
 | params_flow.rb:204:5:204:15 | call to sink | type tracker without call steps | params_flow.rb:204:5:204:15 | call to sink |
 | params_flow.rb:204:5:204:15 | call to sink | type tracker without call steps | params_flow.rb:207:1:207:14 | call to foo |
-| params_flow.rb:204:5:204:15 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:204:5:204:15 | synthetic splat argument | type tracker without call steps | params_flow.rb:204:5:204:15 | synthetic splat argument |
 | params_flow.rb:204:11:204:14 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:204:11:204:14 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:5:1:7:3 | synthetic splat parameter |
-| params_flow.rb:204:11:204:14 | ...[...] | type tracker with call steps with content splat position 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
+| params_flow.rb:204:11:204:14 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:204:11:204:14 | ...[...] | type tracker without call steps | params_flow.rb:204:11:204:14 | ...[...] |
-| params_flow.rb:204:11:204:14 | ...[...] | type tracker without call steps with content splat position 0 | params_flow.rb:204:5:204:15 | synthetic splat argument |
+| params_flow.rb:204:11:204:14 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:204:5:204:15 | synthetic splat argument |
 | params_flow.rb:204:11:204:14 | synthetic splat argument | type tracker without call steps | params_flow.rb:204:11:204:14 | synthetic splat argument |
 | params_flow.rb:204:13:204:13 | 1 | type tracker without call steps | params_flow.rb:204:13:204:13 | 1 |
-| params_flow.rb:204:13:204:13 | 1 | type tracker without call steps with content splat position 0 | params_flow.rb:204:11:204:14 | synthetic splat argument |
+| params_flow.rb:204:13:204:13 | 1 | type tracker without call steps with content element 0 | params_flow.rb:204:11:204:14 | synthetic splat argument |
 | params_flow.rb:207:1:207:14 | call to foo | type tracker without call steps | params_flow.rb:207:1:207:14 | call to foo |
 | params_flow.rb:207:5:207:13 | * ... | type tracker with call steps | params_flow.rb:200:1:205:3 | synthetic splat parameter |
 | params_flow.rb:207:5:207:13 | * ... | type tracker without call steps | params_flow.rb:207:5:207:13 | * ... |
@@ -4203,17 +3761,14 @@ trackEnd
 | params_flow.rb:9:20:9:21 | p2 | params_flow.rb:9:20:9:21 | p2 |
 | params_flow.rb:9:20:9:21 | p2 | params_flow.rb:11:10:11:11 | p2 |
 | params_flow.rb:10:5:10:11 | call to sink | params_flow.rb:10:5:10:11 | call to sink |
-| params_flow.rb:10:5:10:11 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:10:5:10:11 | synthetic splat argument | params_flow.rb:10:5:10:11 | synthetic splat argument |
 | params_flow.rb:11:5:11:11 | call to sink | params_flow.rb:11:5:11:11 | call to sink |
 | params_flow.rb:11:5:11:11 | call to sink | params_flow.rb:14:1:14:30 | call to positional |
 | params_flow.rb:11:5:11:11 | call to sink | params_flow.rb:44:1:44:28 | call to positional |
 | params_flow.rb:11:5:11:11 | call to sink | params_flow.rb:47:1:47:17 | call to positional |
 | params_flow.rb:11:5:11:11 | call to sink | params_flow.rb:118:1:118:14 | call to positional |
-| params_flow.rb:11:5:11:11 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:11:5:11:11 | synthetic splat argument | params_flow.rb:11:5:11:11 | synthetic splat argument |
 | params_flow.rb:14:1:14:30 | call to positional | params_flow.rb:14:1:14:30 | call to positional |
-| params_flow.rb:14:1:14:30 | synthetic splat argument | params_flow.rb:9:1:12:3 | synthetic splat parameter |
 | params_flow.rb:14:1:14:30 | synthetic splat argument | params_flow.rb:14:1:14:30 | synthetic splat argument |
 | params_flow.rb:14:12:14:19 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:14:12:14:19 | call to taint | params_flow.rb:5:10:5:10 | x |
@@ -4222,7 +3777,6 @@ trackEnd
 | params_flow.rb:14:12:14:19 | call to taint | params_flow.rb:9:16:9:17 | p1 |
 | params_flow.rb:14:12:14:19 | call to taint | params_flow.rb:10:10:10:11 | p1 |
 | params_flow.rb:14:12:14:19 | call to taint | params_flow.rb:14:12:14:19 | call to taint |
-| params_flow.rb:14:12:14:19 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:14:12:14:19 | synthetic splat argument | params_flow.rb:14:12:14:19 | synthetic splat argument |
 | params_flow.rb:14:18:14:18 | 1 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:14:18:14:18 | 1 | params_flow.rb:1:11:1:11 | x |
@@ -4242,7 +3796,6 @@ trackEnd
 | params_flow.rb:14:22:14:29 | call to taint | params_flow.rb:9:20:9:21 | p2 |
 | params_flow.rb:14:22:14:29 | call to taint | params_flow.rb:11:10:11:11 | p2 |
 | params_flow.rb:14:22:14:29 | call to taint | params_flow.rb:14:22:14:29 | call to taint |
-| params_flow.rb:14:22:14:29 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:14:22:14:29 | synthetic splat argument | params_flow.rb:14:22:14:29 | synthetic splat argument |
 | params_flow.rb:14:28:14:28 | 2 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:14:28:14:28 | 2 | params_flow.rb:1:11:1:11 | x |
@@ -4280,14 +3833,12 @@ trackEnd
 | params_flow.rb:16:18:16:19 | p2 | params_flow.rb:16:18:16:19 | p2 |
 | params_flow.rb:16:18:16:19 | p2 | params_flow.rb:18:10:18:11 | p2 |
 | params_flow.rb:17:5:17:11 | call to sink | params_flow.rb:17:5:17:11 | call to sink |
-| params_flow.rb:17:5:17:11 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:17:5:17:11 | synthetic splat argument | params_flow.rb:17:5:17:11 | synthetic splat argument |
 | params_flow.rb:18:5:18:11 | call to sink | params_flow.rb:18:5:18:11 | call to sink |
 | params_flow.rb:18:5:18:11 | call to sink | params_flow.rb:21:1:21:35 | call to keyword |
 | params_flow.rb:18:5:18:11 | call to sink | params_flow.rb:22:1:22:35 | call to keyword |
 | params_flow.rb:18:5:18:11 | call to sink | params_flow.rb:23:1:23:41 | call to keyword |
 | params_flow.rb:18:5:18:11 | call to sink | params_flow.rb:41:1:41:30 | call to keyword |
-| params_flow.rb:18:5:18:11 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:18:5:18:11 | synthetic splat argument | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:21:1:21:35 | call to keyword | params_flow.rb:21:1:21:35 | call to keyword |
 | params_flow.rb:21:1:21:35 | synthetic hash-splat argument | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
@@ -4301,7 +3852,6 @@ trackEnd
 | params_flow.rb:21:13:21:20 | call to taint | params_flow.rb:16:13:16:14 | p1 |
 | params_flow.rb:21:13:21:20 | call to taint | params_flow.rb:17:10:17:11 | p1 |
 | params_flow.rb:21:13:21:20 | call to taint | params_flow.rb:21:13:21:20 | call to taint |
-| params_flow.rb:21:13:21:20 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:21:13:21:20 | synthetic splat argument | params_flow.rb:21:13:21:20 | synthetic splat argument |
 | params_flow.rb:21:19:21:19 | 3 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:21:19:21:19 | 3 | params_flow.rb:1:11:1:11 | x |
@@ -4323,7 +3873,6 @@ trackEnd
 | params_flow.rb:21:27:21:34 | call to taint | params_flow.rb:16:18:16:19 | p2 |
 | params_flow.rb:21:27:21:34 | call to taint | params_flow.rb:18:10:18:11 | p2 |
 | params_flow.rb:21:27:21:34 | call to taint | params_flow.rb:21:27:21:34 | call to taint |
-| params_flow.rb:21:27:21:34 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:21:27:21:34 | synthetic splat argument | params_flow.rb:21:27:21:34 | synthetic splat argument |
 | params_flow.rb:21:33:21:33 | 4 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:21:33:21:33 | 4 | params_flow.rb:1:11:1:11 | x |
@@ -4348,7 +3897,6 @@ trackEnd
 | params_flow.rb:22:13:22:20 | call to taint | params_flow.rb:16:18:16:19 | p2 |
 | params_flow.rb:22:13:22:20 | call to taint | params_flow.rb:18:10:18:11 | p2 |
 | params_flow.rb:22:13:22:20 | call to taint | params_flow.rb:22:13:22:20 | call to taint |
-| params_flow.rb:22:13:22:20 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:22:13:22:20 | synthetic splat argument | params_flow.rb:22:13:22:20 | synthetic splat argument |
 | params_flow.rb:22:19:22:19 | 5 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:22:19:22:19 | 5 | params_flow.rb:1:11:1:11 | x |
@@ -4370,7 +3918,6 @@ trackEnd
 | params_flow.rb:22:27:22:34 | call to taint | params_flow.rb:16:13:16:14 | p1 |
 | params_flow.rb:22:27:22:34 | call to taint | params_flow.rb:17:10:17:11 | p1 |
 | params_flow.rb:22:27:22:34 | call to taint | params_flow.rb:22:27:22:34 | call to taint |
-| params_flow.rb:22:27:22:34 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:22:27:22:34 | synthetic splat argument | params_flow.rb:22:27:22:34 | synthetic splat argument |
 | params_flow.rb:22:33:22:33 | 6 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:22:33:22:33 | 6 | params_flow.rb:1:11:1:11 | x |
@@ -4395,7 +3942,6 @@ trackEnd
 | params_flow.rb:23:16:23:23 | call to taint | params_flow.rb:16:18:16:19 | p2 |
 | params_flow.rb:23:16:23:23 | call to taint | params_flow.rb:18:10:18:11 | p2 |
 | params_flow.rb:23:16:23:23 | call to taint | params_flow.rb:23:16:23:23 | call to taint |
-| params_flow.rb:23:16:23:23 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:23:16:23:23 | synthetic splat argument | params_flow.rb:23:16:23:23 | synthetic splat argument |
 | params_flow.rb:23:22:23:22 | 7 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:23:22:23:22 | 7 | params_flow.rb:1:11:1:11 | x |
@@ -4417,7 +3963,6 @@ trackEnd
 | params_flow.rb:23:33:23:40 | call to taint | params_flow.rb:16:13:16:14 | p1 |
 | params_flow.rb:23:33:23:40 | call to taint | params_flow.rb:17:10:17:11 | p1 |
 | params_flow.rb:23:33:23:40 | call to taint | params_flow.rb:23:33:23:40 | call to taint |
-| params_flow.rb:23:33:23:40 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:23:33:23:40 | synthetic splat argument | params_flow.rb:23:33:23:40 | synthetic splat argument |
 | params_flow.rb:23:39:23:39 | 8 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:23:39:23:39 | 8 | params_flow.rb:1:11:1:11 | x |
@@ -4458,10 +4003,8 @@ trackEnd
 | params_flow.rb:25:17:25:24 | **kwargs | params_flow.rb:30:11:30:16 | kwargs |
 | params_flow.rb:25:19:25:24 | kwargs | params_flow.rb:25:19:25:24 | kwargs |
 | params_flow.rb:26:5:26:11 | call to sink | params_flow.rb:26:5:26:11 | call to sink |
-| params_flow.rb:26:5:26:11 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:26:5:26:11 | synthetic splat argument | params_flow.rb:26:5:26:11 | synthetic splat argument |
 | params_flow.rb:27:5:27:22 | call to sink | params_flow.rb:27:5:27:22 | call to sink |
-| params_flow.rb:27:5:27:22 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:27:5:27:22 | synthetic splat argument | params_flow.rb:27:5:27:22 | synthetic splat argument |
 | params_flow.rb:27:11:27:21 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:27:11:27:21 | ...[...] | params_flow.rb:5:10:5:10 | x |
@@ -4471,7 +4014,6 @@ trackEnd
 | params_flow.rb:27:11:27:21 | synthetic splat argument | params_flow.rb:27:11:27:21 | synthetic splat argument |
 | params_flow.rb:27:18:27:20 | :p1 | params_flow.rb:27:18:27:20 | :p1 |
 | params_flow.rb:28:5:28:22 | call to sink | params_flow.rb:28:5:28:22 | call to sink |
-| params_flow.rb:28:5:28:22 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:28:5:28:22 | synthetic splat argument | params_flow.rb:28:5:28:22 | synthetic splat argument |
 | params_flow.rb:28:11:28:21 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:28:11:28:21 | ...[...] | params_flow.rb:5:10:5:10 | x |
@@ -4481,7 +4023,6 @@ trackEnd
 | params_flow.rb:28:11:28:21 | synthetic splat argument | params_flow.rb:28:11:28:21 | synthetic splat argument |
 | params_flow.rb:28:18:28:20 | :p2 | params_flow.rb:28:18:28:20 | :p2 |
 | params_flow.rb:29:5:29:22 | call to sink | params_flow.rb:29:5:29:22 | call to sink |
-| params_flow.rb:29:5:29:22 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:29:5:29:22 | synthetic splat argument | params_flow.rb:29:5:29:22 | synthetic splat argument |
 | params_flow.rb:29:11:29:21 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:29:11:29:21 | ...[...] | params_flow.rb:5:10:5:10 | x |
@@ -4494,7 +4035,6 @@ trackEnd
 | params_flow.rb:30:5:30:22 | call to sink | params_flow.rb:33:1:33:58 | call to kwargs |
 | params_flow.rb:30:5:30:22 | call to sink | params_flow.rb:35:1:35:29 | call to kwargs |
 | params_flow.rb:30:5:30:22 | call to sink | params_flow.rb:38:1:38:14 | call to kwargs |
-| params_flow.rb:30:5:30:22 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:30:5:30:22 | synthetic splat argument | params_flow.rb:30:5:30:22 | synthetic splat argument |
 | params_flow.rb:30:11:30:21 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:30:11:30:21 | ...[...] | params_flow.rb:5:10:5:10 | x |
@@ -4523,7 +4063,6 @@ trackEnd
 | params_flow.rb:33:12:33:19 | call to taint | params_flow.rb:27:10:27:22 | ( ... ) |
 | params_flow.rb:33:12:33:19 | call to taint | params_flow.rb:27:11:27:21 | ...[...] |
 | params_flow.rb:33:12:33:19 | call to taint | params_flow.rb:33:12:33:19 | call to taint |
-| params_flow.rb:33:12:33:19 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:33:12:33:19 | synthetic splat argument | params_flow.rb:33:12:33:19 | synthetic splat argument |
 | params_flow.rb:33:18:33:18 | 9 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:33:18:33:18 | 9 | params_flow.rb:1:11:1:11 | x |
@@ -4546,7 +4085,6 @@ trackEnd
 | params_flow.rb:33:26:33:34 | call to taint | params_flow.rb:28:10:28:22 | ( ... ) |
 | params_flow.rb:33:26:33:34 | call to taint | params_flow.rb:28:11:28:21 | ...[...] |
 | params_flow.rb:33:26:33:34 | call to taint | params_flow.rb:33:26:33:34 | call to taint |
-| params_flow.rb:33:26:33:34 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:33:26:33:34 | synthetic splat argument | params_flow.rb:33:26:33:34 | synthetic splat argument |
 | params_flow.rb:33:32:33:33 | 10 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:33:32:33:33 | 10 | params_flow.rb:1:11:1:11 | x |
@@ -4566,7 +4104,6 @@ trackEnd
 | params_flow.rb:33:41:33:49 | call to taint | params_flow.rb:29:10:29:22 | ( ... ) |
 | params_flow.rb:33:41:33:49 | call to taint | params_flow.rb:29:11:29:21 | ...[...] |
 | params_flow.rb:33:41:33:49 | call to taint | params_flow.rb:33:41:33:49 | call to taint |
-| params_flow.rb:33:41:33:49 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:33:41:33:49 | synthetic splat argument | params_flow.rb:33:41:33:49 | synthetic splat argument |
 | params_flow.rb:33:47:33:48 | 11 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:33:47:33:48 | 11 | params_flow.rb:1:11:1:11 | x |
@@ -4605,7 +4142,6 @@ trackEnd
 | params_flow.rb:34:14:34:22 | call to taint | params_flow.rb:29:10:29:22 | ( ... ) |
 | params_flow.rb:34:14:34:22 | call to taint | params_flow.rb:29:11:29:21 | ...[...] |
 | params_flow.rb:34:14:34:22 | call to taint | params_flow.rb:34:14:34:22 | call to taint |
-| params_flow.rb:34:14:34:22 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:34:14:34:22 | synthetic splat argument | params_flow.rb:34:14:34:22 | synthetic splat argument |
 | params_flow.rb:34:20:34:21 | 12 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:34:20:34:21 | 12 | params_flow.rb:1:11:1:11 | x |
@@ -4645,7 +4181,6 @@ trackEnd
 | params_flow.rb:35:12:35:20 | call to taint | params_flow.rb:27:10:27:22 | ( ... ) |
 | params_flow.rb:35:12:35:20 | call to taint | params_flow.rb:27:11:27:21 | ...[...] |
 | params_flow.rb:35:12:35:20 | call to taint | params_flow.rb:35:12:35:20 | call to taint |
-| params_flow.rb:35:12:35:20 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:35:12:35:20 | synthetic splat argument | params_flow.rb:35:12:35:20 | synthetic splat argument |
 | params_flow.rb:35:18:35:19 | 13 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:35:18:35:19 | 13 | params_flow.rb:1:11:1:11 | x |
@@ -4690,7 +4225,6 @@ trackEnd
 | params_flow.rb:37:16:37:24 | call to taint | params_flow.rb:27:10:27:22 | ( ... ) |
 | params_flow.rb:37:16:37:24 | call to taint | params_flow.rb:27:11:27:21 | ...[...] |
 | params_flow.rb:37:16:37:24 | call to taint | params_flow.rb:37:16:37:24 | call to taint |
-| params_flow.rb:37:16:37:24 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:37:16:37:24 | synthetic splat argument | params_flow.rb:37:16:37:24 | synthetic splat argument |
 | params_flow.rb:37:22:37:23 | 14 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:37:22:37:23 | 14 | params_flow.rb:1:11:1:11 | x |
@@ -4713,7 +4247,6 @@ trackEnd
 | params_flow.rb:37:34:37:42 | call to taint | params_flow.rb:28:10:28:22 | ( ... ) |
 | params_flow.rb:37:34:37:42 | call to taint | params_flow.rb:28:11:28:21 | ...[...] |
 | params_flow.rb:37:34:37:42 | call to taint | params_flow.rb:37:34:37:42 | call to taint |
-| params_flow.rb:37:34:37:42 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:37:34:37:42 | synthetic splat argument | params_flow.rb:37:34:37:42 | synthetic splat argument |
 | params_flow.rb:37:40:37:41 | 15 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:37:40:37:41 | 15 | params_flow.rb:1:11:1:11 | x |
@@ -4754,7 +4287,6 @@ trackEnd
 | params_flow.rb:40:16:40:24 | call to taint | params_flow.rb:16:13:16:14 | p1 |
 | params_flow.rb:40:16:40:24 | call to taint | params_flow.rb:17:10:17:11 | p1 |
 | params_flow.rb:40:16:40:24 | call to taint | params_flow.rb:40:16:40:24 | call to taint |
-| params_flow.rb:40:16:40:24 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:40:16:40:24 | synthetic splat argument | params_flow.rb:40:16:40:24 | synthetic splat argument |
 | params_flow.rb:40:22:40:23 | 16 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:40:22:40:23 | 16 | params_flow.rb:1:11:1:11 | x |
@@ -4779,7 +4311,6 @@ trackEnd
 | params_flow.rb:41:13:41:21 | call to taint | params_flow.rb:16:18:16:19 | p2 |
 | params_flow.rb:41:13:41:21 | call to taint | params_flow.rb:18:10:18:11 | p2 |
 | params_flow.rb:41:13:41:21 | call to taint | params_flow.rb:41:13:41:21 | call to taint |
-| params_flow.rb:41:13:41:21 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:41:13:41:21 | synthetic splat argument | params_flow.rb:41:13:41:21 | synthetic splat argument |
 | params_flow.rb:41:19:41:20 | 17 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:41:19:41:20 | 17 | params_flow.rb:1:11:1:11 | x |
@@ -4824,7 +4355,6 @@ trackEnd
 | params_flow.rb:43:9:43:17 | call to taint | params_flow.rb:9:20:9:21 | p2 |
 | params_flow.rb:43:9:43:17 | call to taint | params_flow.rb:11:10:11:11 | p2 |
 | params_flow.rb:43:9:43:17 | call to taint | params_flow.rb:43:9:43:17 | call to taint |
-| params_flow.rb:43:9:43:17 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:43:9:43:17 | synthetic splat argument | params_flow.rb:43:9:43:17 | synthetic splat argument |
 | params_flow.rb:43:15:43:16 | 17 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:43:15:43:16 | 17 | params_flow.rb:1:11:1:11 | x |
@@ -4847,7 +4377,6 @@ trackEnd
 | params_flow.rb:44:12:44:20 | call to taint | params_flow.rb:9:16:9:17 | p1 |
 | params_flow.rb:44:12:44:20 | call to taint | params_flow.rb:10:10:10:11 | p1 |
 | params_flow.rb:44:12:44:20 | call to taint | params_flow.rb:44:12:44:20 | call to taint |
-| params_flow.rb:44:12:44:20 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:44:12:44:20 | synthetic splat argument | params_flow.rb:44:12:44:20 | synthetic splat argument |
 | params_flow.rb:44:18:44:19 | 16 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:44:18:44:19 | 16 | params_flow.rb:1:11:1:11 | x |
@@ -4891,7 +4420,6 @@ trackEnd
 | params_flow.rb:46:9:46:17 | call to taint | params_flow.rb:9:16:9:17 | p1 |
 | params_flow.rb:46:9:46:17 | call to taint | params_flow.rb:10:10:10:11 | p1 |
 | params_flow.rb:46:9:46:17 | call to taint | params_flow.rb:46:9:46:17 | call to taint |
-| params_flow.rb:46:9:46:17 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:46:9:46:17 | synthetic splat argument | params_flow.rb:46:9:46:17 | synthetic splat argument |
 | params_flow.rb:46:15:46:16 | 18 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:46:15:46:16 | 18 | params_flow.rb:1:11:1:11 | x |
@@ -4911,7 +4439,6 @@ trackEnd
 | params_flow.rb:46:20:46:28 | call to taint | params_flow.rb:9:20:9:21 | p2 |
 | params_flow.rb:46:20:46:28 | call to taint | params_flow.rb:11:10:11:11 | p2 |
 | params_flow.rb:46:20:46:28 | call to taint | params_flow.rb:46:20:46:28 | call to taint |
-| params_flow.rb:46:20:46:28 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:46:20:46:28 | synthetic splat argument | params_flow.rb:46:20:46:28 | synthetic splat argument |
 | params_flow.rb:46:26:46:27 | 19 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:46:26:46:27 | 19 | params_flow.rb:1:11:1:11 | x |
@@ -4951,10 +4478,8 @@ trackEnd
 | params_flow.rb:49:17:49:24 | *posargs | params_flow.rb:52:11:52:17 | posargs |
 | params_flow.rb:49:18:49:24 | posargs | params_flow.rb:49:18:49:24 | posargs |
 | params_flow.rb:50:5:50:11 | call to sink | params_flow.rb:50:5:50:11 | call to sink |
-| params_flow.rb:50:5:50:11 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:50:5:50:11 | synthetic splat argument | params_flow.rb:50:5:50:11 | synthetic splat argument |
 | params_flow.rb:51:5:51:21 | call to sink | params_flow.rb:51:5:51:21 | call to sink |
-| params_flow.rb:51:5:51:21 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:51:5:51:21 | synthetic splat argument | params_flow.rb:51:5:51:21 | synthetic splat argument |
 | params_flow.rb:51:11:51:20 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:51:11:51:20 | ...[...] | params_flow.rb:5:10:5:10 | x |
@@ -4967,7 +4492,6 @@ trackEnd
 | params_flow.rb:52:5:52:21 | call to sink | params_flow.rb:55:1:55:29 | call to posargs |
 | params_flow.rb:52:5:52:21 | call to sink | params_flow.rb:58:1:58:25 | call to posargs |
 | params_flow.rb:52:5:52:21 | call to sink | params_flow.rb:61:1:61:14 | call to posargs |
-| params_flow.rb:52:5:52:21 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:52:5:52:21 | synthetic splat argument | params_flow.rb:52:5:52:21 | synthetic splat argument |
 | params_flow.rb:52:11:52:20 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:52:11:52:20 | ...[...] | params_flow.rb:5:10:5:10 | x |
@@ -4986,7 +4510,6 @@ trackEnd
 | params_flow.rb:55:9:55:17 | call to taint | params_flow.rb:49:13:49:14 | p1 |
 | params_flow.rb:55:9:55:17 | call to taint | params_flow.rb:50:10:50:11 | p1 |
 | params_flow.rb:55:9:55:17 | call to taint | params_flow.rb:55:9:55:17 | call to taint |
-| params_flow.rb:55:9:55:17 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:55:9:55:17 | synthetic splat argument | params_flow.rb:55:9:55:17 | synthetic splat argument |
 | params_flow.rb:55:15:55:16 | 20 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:55:15:55:16 | 20 | params_flow.rb:1:11:1:11 | x |
@@ -5005,7 +4528,6 @@ trackEnd
 | params_flow.rb:55:20:55:28 | call to taint | params_flow.rb:51:10:51:21 | ( ... ) |
 | params_flow.rb:55:20:55:28 | call to taint | params_flow.rb:51:11:51:20 | ...[...] |
 | params_flow.rb:55:20:55:28 | call to taint | params_flow.rb:55:20:55:28 | call to taint |
-| params_flow.rb:55:20:55:28 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:55:20:55:28 | synthetic splat argument | params_flow.rb:55:20:55:28 | synthetic splat argument |
 | params_flow.rb:55:26:55:27 | 21 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:55:26:55:27 | 21 | params_flow.rb:1:11:1:11 | x |
@@ -5044,7 +4566,6 @@ trackEnd
 | params_flow.rb:57:9:57:17 | call to taint | params_flow.rb:51:10:51:21 | ( ... ) |
 | params_flow.rb:57:9:57:17 | call to taint | params_flow.rb:51:11:51:20 | ...[...] |
 | params_flow.rb:57:9:57:17 | call to taint | params_flow.rb:57:9:57:17 | call to taint |
-| params_flow.rb:57:9:57:17 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:57:9:57:17 | synthetic splat argument | params_flow.rb:57:9:57:17 | synthetic splat argument |
 | params_flow.rb:57:15:57:16 | 22 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:57:15:57:16 | 22 | params_flow.rb:1:11:1:11 | x |
@@ -5066,7 +4587,6 @@ trackEnd
 | params_flow.rb:58:9:58:17 | call to taint | params_flow.rb:49:13:49:14 | p1 |
 | params_flow.rb:58:9:58:17 | call to taint | params_flow.rb:50:10:50:11 | p1 |
 | params_flow.rb:58:9:58:17 | call to taint | params_flow.rb:58:9:58:17 | call to taint |
-| params_flow.rb:58:9:58:17 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:58:9:58:17 | synthetic splat argument | params_flow.rb:58:9:58:17 | synthetic splat argument |
 | params_flow.rb:58:15:58:16 | 23 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:58:15:58:16 | 23 | params_flow.rb:1:11:1:11 | x |
@@ -5114,7 +4634,6 @@ trackEnd
 | params_flow.rb:60:9:60:17 | call to taint | params_flow.rb:49:13:49:14 | p1 |
 | params_flow.rb:60:9:60:17 | call to taint | params_flow.rb:50:10:50:11 | p1 |
 | params_flow.rb:60:9:60:17 | call to taint | params_flow.rb:60:9:60:17 | call to taint |
-| params_flow.rb:60:9:60:17 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:60:9:60:17 | synthetic splat argument | params_flow.rb:60:9:60:17 | synthetic splat argument |
 | params_flow.rb:60:15:60:16 | 24 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:60:15:60:16 | 24 | params_flow.rb:1:11:1:11 | x |
@@ -5133,7 +4652,6 @@ trackEnd
 | params_flow.rb:60:20:60:28 | call to taint | params_flow.rb:51:10:51:21 | ( ... ) |
 | params_flow.rb:60:20:60:28 | call to taint | params_flow.rb:51:11:51:20 | ...[...] |
 | params_flow.rb:60:20:60:28 | call to taint | params_flow.rb:60:20:60:28 | call to taint |
-| params_flow.rb:60:20:60:28 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:60:20:60:28 | synthetic splat argument | params_flow.rb:60:20:60:28 | synthetic splat argument |
 | params_flow.rb:60:26:60:27 | 25 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:60:26:60:27 | 25 | params_flow.rb:1:11:1:11 | x |
@@ -5157,7 +4675,6 @@ trackEnd
 | params_flow.rb:63:8:63:16 | call to taint | params_flow.rb:63:8:63:16 | call to taint |
 | params_flow.rb:63:8:63:16 | call to taint | params_flow.rb:65:10:65:13 | ...[...] |
 | params_flow.rb:63:8:63:16 | call to taint | params_flow.rb:67:13:67:16 | args |
-| params_flow.rb:63:8:63:16 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:63:8:63:16 | synthetic splat argument | params_flow.rb:63:8:63:16 | synthetic splat argument |
 | params_flow.rb:63:14:63:15 | 26 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:63:14:63:15 | 26 | params_flow.rb:1:11:1:11 | x |
@@ -5185,7 +4702,6 @@ trackEnd
 | params_flow.rb:64:17:64:17 | x | params_flow.rb:64:17:64:17 | x |
 | params_flow.rb:65:5:65:13 | call to sink | params_flow.rb:65:5:65:13 | call to sink |
 | params_flow.rb:65:5:65:13 | call to sink | params_flow.rb:67:1:67:17 | call to splatstuff |
-| params_flow.rb:65:5:65:13 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:65:5:65:13 | synthetic splat argument | params_flow.rb:65:5:65:13 | synthetic splat argument |
 | params_flow.rb:65:10:65:13 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:65:10:65:13 | ...[...] | params_flow.rb:5:10:5:10 | x |
@@ -5246,13 +4762,10 @@ trackEnd
 | params_flow.rb:69:27:69:27 | r | params_flow.rb:69:27:69:27 | r |
 | params_flow.rb:69:27:69:27 | r | params_flow.rb:75:10:75:10 | r |
 | params_flow.rb:70:5:70:10 | call to sink | params_flow.rb:70:5:70:10 | call to sink |
-| params_flow.rb:70:5:70:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:70:5:70:10 | synthetic splat argument | params_flow.rb:70:5:70:10 | synthetic splat argument |
 | params_flow.rb:71:5:71:10 | call to sink | params_flow.rb:71:5:71:10 | call to sink |
-| params_flow.rb:71:5:71:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:71:5:71:10 | synthetic splat argument | params_flow.rb:71:5:71:10 | synthetic splat argument |
 | params_flow.rb:72:5:72:13 | call to sink | params_flow.rb:72:5:72:13 | call to sink |
-| params_flow.rb:72:5:72:13 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:72:5:72:13 | synthetic splat argument | params_flow.rb:72:5:72:13 | synthetic splat argument |
 | params_flow.rb:72:10:72:13 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:72:10:72:13 | ...[...] | params_flow.rb:5:10:5:10 | x |
@@ -5261,7 +4774,6 @@ trackEnd
 | params_flow.rb:72:10:72:13 | synthetic splat argument | params_flow.rb:72:10:72:13 | synthetic splat argument |
 | params_flow.rb:72:12:72:12 | 0 | params_flow.rb:72:12:72:12 | 0 |
 | params_flow.rb:73:5:73:13 | call to sink | params_flow.rb:73:5:73:13 | call to sink |
-| params_flow.rb:73:5:73:13 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:73:5:73:13 | synthetic splat argument | params_flow.rb:73:5:73:13 | synthetic splat argument |
 | params_flow.rb:73:10:73:13 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:73:10:73:13 | ...[...] | params_flow.rb:5:10:5:10 | x |
@@ -5270,13 +4782,11 @@ trackEnd
 | params_flow.rb:73:10:73:13 | synthetic splat argument | params_flow.rb:73:10:73:13 | synthetic splat argument |
 | params_flow.rb:73:12:73:12 | 1 | params_flow.rb:73:12:73:12 | 1 |
 | params_flow.rb:74:5:74:10 | call to sink | params_flow.rb:74:5:74:10 | call to sink |
-| params_flow.rb:74:5:74:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:74:5:74:10 | synthetic splat argument | params_flow.rb:74:5:74:10 | synthetic splat argument |
 | params_flow.rb:75:5:75:10 | call to sink | params_flow.rb:75:5:75:10 | call to sink |
 | params_flow.rb:75:5:75:10 | call to sink | params_flow.rb:78:1:78:63 | call to splatmid |
 | params_flow.rb:75:5:75:10 | call to sink | params_flow.rb:81:1:81:37 | call to splatmid |
 | params_flow.rb:75:5:75:10 | call to sink | params_flow.rb:96:1:96:88 | call to splatmid |
-| params_flow.rb:75:5:75:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:75:5:75:10 | synthetic splat argument | params_flow.rb:75:5:75:10 | synthetic splat argument |
 | params_flow.rb:78:1:78:63 | call to splatmid | params_flow.rb:78:1:78:63 | call to splatmid |
 | params_flow.rb:78:1:78:63 | synthetic splat argument | params_flow.rb:69:1:76:3 | synthetic splat parameter |
@@ -5288,7 +4798,6 @@ trackEnd
 | params_flow.rb:78:10:78:18 | call to taint | params_flow.rb:69:14:69:14 | x |
 | params_flow.rb:78:10:78:18 | call to taint | params_flow.rb:70:10:70:10 | x |
 | params_flow.rb:78:10:78:18 | call to taint | params_flow.rb:78:10:78:18 | call to taint |
-| params_flow.rb:78:10:78:18 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:78:10:78:18 | synthetic splat argument | params_flow.rb:78:10:78:18 | synthetic splat argument |
 | params_flow.rb:78:16:78:17 | 27 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:78:16:78:17 | 27 | params_flow.rb:1:11:1:11 | x |
@@ -5308,7 +4817,6 @@ trackEnd
 | params_flow.rb:78:21:78:29 | call to taint | params_flow.rb:69:17:69:17 | y |
 | params_flow.rb:78:21:78:29 | call to taint | params_flow.rb:71:10:71:10 | y |
 | params_flow.rb:78:21:78:29 | call to taint | params_flow.rb:78:21:78:29 | call to taint |
-| params_flow.rb:78:21:78:29 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:78:21:78:29 | synthetic splat argument | params_flow.rb:78:21:78:29 | synthetic splat argument |
 | params_flow.rb:78:27:78:28 | 28 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:78:27:78:28 | 28 | params_flow.rb:1:11:1:11 | x |
@@ -5322,7 +4830,6 @@ trackEnd
 | params_flow.rb:78:27:78:28 | 28 | params_flow.rb:78:21:78:29 | call to taint |
 | params_flow.rb:78:27:78:28 | 28 | params_flow.rb:78:27:78:28 | 28 |
 | params_flow.rb:78:32:78:40 | call to taint | params_flow.rb:78:32:78:40 | call to taint |
-| params_flow.rb:78:32:78:40 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:78:32:78:40 | synthetic splat argument | params_flow.rb:78:32:78:40 | synthetic splat argument |
 | params_flow.rb:78:38:78:39 | 29 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:78:38:78:39 | 29 | params_flow.rb:1:11:1:11 | x |
@@ -5336,7 +4843,6 @@ trackEnd
 | params_flow.rb:78:43:78:51 | call to taint | params_flow.rb:69:24:69:24 | w |
 | params_flow.rb:78:43:78:51 | call to taint | params_flow.rb:74:10:74:10 | w |
 | params_flow.rb:78:43:78:51 | call to taint | params_flow.rb:78:43:78:51 | call to taint |
-| params_flow.rb:78:43:78:51 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:78:43:78:51 | synthetic splat argument | params_flow.rb:78:43:78:51 | synthetic splat argument |
 | params_flow.rb:78:49:78:50 | 30 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:78:49:78:50 | 30 | params_flow.rb:1:11:1:11 | x |
@@ -5356,7 +4862,6 @@ trackEnd
 | params_flow.rb:78:54:78:62 | call to taint | params_flow.rb:69:27:69:27 | r |
 | params_flow.rb:78:54:78:62 | call to taint | params_flow.rb:75:10:75:10 | r |
 | params_flow.rb:78:54:78:62 | call to taint | params_flow.rb:78:54:78:62 | call to taint |
-| params_flow.rb:78:54:78:62 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:78:54:78:62 | synthetic splat argument | params_flow.rb:78:54:78:62 | synthetic splat argument |
 | params_flow.rb:78:60:78:61 | 31 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:78:60:78:61 | 31 | params_flow.rb:1:11:1:11 | x |
@@ -5399,7 +4904,6 @@ trackEnd
 | params_flow.rb:80:9:80:17 | call to taint | params_flow.rb:69:17:69:17 | y |
 | params_flow.rb:80:9:80:17 | call to taint | params_flow.rb:71:10:71:10 | y |
 | params_flow.rb:80:9:80:17 | call to taint | params_flow.rb:80:9:80:17 | call to taint |
-| params_flow.rb:80:9:80:17 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:80:9:80:17 | synthetic splat argument | params_flow.rb:80:9:80:17 | synthetic splat argument |
 | params_flow.rb:80:15:80:16 | 33 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:80:15:80:16 | 33 | params_flow.rb:1:11:1:11 | x |
@@ -5413,7 +4917,6 @@ trackEnd
 | params_flow.rb:80:15:80:16 | 33 | params_flow.rb:80:9:80:17 | call to taint |
 | params_flow.rb:80:15:80:16 | 33 | params_flow.rb:80:15:80:16 | 33 |
 | params_flow.rb:80:20:80:28 | call to taint | params_flow.rb:80:20:80:28 | call to taint |
-| params_flow.rb:80:20:80:28 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:80:20:80:28 | synthetic splat argument | params_flow.rb:80:20:80:28 | synthetic splat argument |
 | params_flow.rb:80:26:80:27 | 34 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:80:26:80:27 | 34 | params_flow.rb:1:11:1:11 | x |
@@ -5421,7 +4924,6 @@ trackEnd
 | params_flow.rb:80:26:80:27 | 34 | params_flow.rb:80:20:80:28 | call to taint |
 | params_flow.rb:80:26:80:27 | 34 | params_flow.rb:80:26:80:27 | 34 |
 | params_flow.rb:80:31:80:39 | call to taint | params_flow.rb:80:31:80:39 | call to taint |
-| params_flow.rb:80:31:80:39 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:80:31:80:39 | synthetic splat argument | params_flow.rb:80:31:80:39 | synthetic splat argument |
 | params_flow.rb:80:37:80:38 | 35 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:80:37:80:38 | 35 | params_flow.rb:1:11:1:11 | x |
@@ -5429,7 +4931,6 @@ trackEnd
 | params_flow.rb:80:37:80:38 | 35 | params_flow.rb:80:31:80:39 | call to taint |
 | params_flow.rb:80:37:80:38 | 35 | params_flow.rb:80:37:80:38 | 35 |
 | params_flow.rb:80:42:80:50 | call to taint | params_flow.rb:80:42:80:50 | call to taint |
-| params_flow.rb:80:42:80:50 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:80:42:80:50 | synthetic splat argument | params_flow.rb:80:42:80:50 | synthetic splat argument |
 | params_flow.rb:80:48:80:49 | 36 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:80:48:80:49 | 36 | params_flow.rb:1:11:1:11 | x |
@@ -5446,7 +4947,6 @@ trackEnd
 | params_flow.rb:81:10:81:18 | call to taint | params_flow.rb:69:14:69:14 | x |
 | params_flow.rb:81:10:81:18 | call to taint | params_flow.rb:70:10:70:10 | x |
 | params_flow.rb:81:10:81:18 | call to taint | params_flow.rb:81:10:81:18 | call to taint |
-| params_flow.rb:81:10:81:18 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:81:10:81:18 | synthetic splat argument | params_flow.rb:81:10:81:18 | synthetic splat argument |
 | params_flow.rb:81:16:81:17 | 32 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:81:16:81:17 | 32 | params_flow.rb:1:11:1:11 | x |
@@ -5461,7 +4961,6 @@ trackEnd
 | params_flow.rb:81:16:81:17 | 32 | params_flow.rb:81:16:81:17 | 32 |
 | params_flow.rb:81:21:81:25 | * ... | params_flow.rb:81:21:81:25 | * ... |
 | params_flow.rb:81:28:81:36 | call to taint | params_flow.rb:81:28:81:36 | call to taint |
-| params_flow.rb:81:28:81:36 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:81:28:81:36 | synthetic splat argument | params_flow.rb:81:28:81:36 | synthetic splat argument |
 | params_flow.rb:81:34:81:35 | 37 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:81:34:81:35 | 37 | params_flow.rb:1:11:1:11 | x |
@@ -5533,27 +5032,20 @@ trackEnd
 | params_flow.rb:83:32:83:32 | z | params_flow.rb:83:32:83:32 | z |
 | params_flow.rb:83:32:83:32 | z | params_flow.rb:90:10:90:10 | z |
 | params_flow.rb:84:5:84:10 | call to sink | params_flow.rb:84:5:84:10 | call to sink |
-| params_flow.rb:84:5:84:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:84:5:84:10 | synthetic splat argument | params_flow.rb:84:5:84:10 | synthetic splat argument |
 | params_flow.rb:85:5:85:10 | call to sink | params_flow.rb:85:5:85:10 | call to sink |
-| params_flow.rb:85:5:85:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:85:5:85:10 | synthetic splat argument | params_flow.rb:85:5:85:10 | synthetic splat argument |
 | params_flow.rb:86:5:86:10 | call to sink | params_flow.rb:86:5:86:10 | call to sink |
-| params_flow.rb:86:5:86:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:86:5:86:10 | synthetic splat argument | params_flow.rb:86:5:86:10 | synthetic splat argument |
 | params_flow.rb:87:5:87:10 | call to sink | params_flow.rb:87:5:87:10 | call to sink |
-| params_flow.rb:87:5:87:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:87:5:87:10 | synthetic splat argument | params_flow.rb:87:5:87:10 | synthetic splat argument |
 | params_flow.rb:88:5:88:10 | call to sink | params_flow.rb:88:5:88:10 | call to sink |
-| params_flow.rb:88:5:88:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:88:5:88:10 | synthetic splat argument | params_flow.rb:88:5:88:10 | synthetic splat argument |
 | params_flow.rb:89:5:89:10 | call to sink | params_flow.rb:89:5:89:10 | call to sink |
-| params_flow.rb:89:5:89:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:89:5:89:10 | synthetic splat argument | params_flow.rb:89:5:89:10 | synthetic splat argument |
 | params_flow.rb:90:5:90:10 | call to sink | params_flow.rb:90:5:90:10 | call to sink |
 | params_flow.rb:90:5:90:10 | call to sink | params_flow.rb:94:1:94:48 | call to pos_many |
 | params_flow.rb:90:5:90:10 | call to sink | params_flow.rb:131:1:131:46 | call to pos_many |
-| params_flow.rb:90:5:90:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:90:5:90:10 | synthetic splat argument | params_flow.rb:90:5:90:10 | synthetic splat argument |
 | params_flow.rb:93:1:93:4 | args | params_flow.rb:93:1:93:4 | args |
 | params_flow.rb:93:8:93:51 | Array | params_flow.rb:93:8:93:51 | Array |
@@ -5585,7 +5077,6 @@ trackEnd
 | params_flow.rb:93:9:93:17 | call to taint | params_flow.rb:83:20:83:20 | v |
 | params_flow.rb:93:9:93:17 | call to taint | params_flow.rb:86:10:86:10 | v |
 | params_flow.rb:93:9:93:17 | call to taint | params_flow.rb:93:9:93:17 | call to taint |
-| params_flow.rb:93:9:93:17 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:93:9:93:17 | synthetic splat argument | params_flow.rb:93:9:93:17 | synthetic splat argument |
 | params_flow.rb:93:15:93:16 | 40 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:93:15:93:16 | 40 | params_flow.rb:1:11:1:11 | x |
@@ -5605,7 +5096,6 @@ trackEnd
 | params_flow.rb:93:20:93:28 | call to taint | params_flow.rb:83:23:83:23 | w |
 | params_flow.rb:93:20:93:28 | call to taint | params_flow.rb:87:10:87:10 | w |
 | params_flow.rb:93:20:93:28 | call to taint | params_flow.rb:93:20:93:28 | call to taint |
-| params_flow.rb:93:20:93:28 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:93:20:93:28 | synthetic splat argument | params_flow.rb:93:20:93:28 | synthetic splat argument |
 | params_flow.rb:93:26:93:27 | 41 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:93:26:93:27 | 41 | params_flow.rb:1:11:1:11 | x |
@@ -5625,7 +5115,6 @@ trackEnd
 | params_flow.rb:93:31:93:39 | call to taint | params_flow.rb:83:26:83:26 | x |
 | params_flow.rb:93:31:93:39 | call to taint | params_flow.rb:88:10:88:10 | x |
 | params_flow.rb:93:31:93:39 | call to taint | params_flow.rb:93:31:93:39 | call to taint |
-| params_flow.rb:93:31:93:39 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:93:31:93:39 | synthetic splat argument | params_flow.rb:93:31:93:39 | synthetic splat argument |
 | params_flow.rb:93:37:93:38 | 42 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:93:37:93:38 | 42 | params_flow.rb:1:11:1:11 | x |
@@ -5645,7 +5134,6 @@ trackEnd
 | params_flow.rb:93:42:93:50 | call to taint | params_flow.rb:83:29:83:29 | y |
 | params_flow.rb:93:42:93:50 | call to taint | params_flow.rb:89:10:89:10 | y |
 | params_flow.rb:93:42:93:50 | call to taint | params_flow.rb:93:42:93:50 | call to taint |
-| params_flow.rb:93:42:93:50 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:93:42:93:50 | synthetic splat argument | params_flow.rb:93:42:93:50 | synthetic splat argument |
 | params_flow.rb:93:48:93:49 | 43 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:93:48:93:49 | 43 | params_flow.rb:1:11:1:11 | x |
@@ -5668,7 +5156,6 @@ trackEnd
 | params_flow.rb:94:10:94:18 | call to taint | params_flow.rb:83:14:83:14 | t |
 | params_flow.rb:94:10:94:18 | call to taint | params_flow.rb:84:10:84:10 | t |
 | params_flow.rb:94:10:94:18 | call to taint | params_flow.rb:94:10:94:18 | call to taint |
-| params_flow.rb:94:10:94:18 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:94:10:94:18 | synthetic splat argument | params_flow.rb:94:10:94:18 | synthetic splat argument |
 | params_flow.rb:94:16:94:17 | 38 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:94:16:94:17 | 38 | params_flow.rb:1:11:1:11 | x |
@@ -5688,7 +5175,6 @@ trackEnd
 | params_flow.rb:94:21:94:29 | call to taint | params_flow.rb:83:17:83:17 | u |
 | params_flow.rb:94:21:94:29 | call to taint | params_flow.rb:85:10:85:10 | u |
 | params_flow.rb:94:21:94:29 | call to taint | params_flow.rb:94:21:94:29 | call to taint |
-| params_flow.rb:94:21:94:29 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:94:21:94:29 | synthetic splat argument | params_flow.rb:94:21:94:29 | synthetic splat argument |
 | params_flow.rb:94:27:94:28 | 39 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:94:27:94:28 | 39 | params_flow.rb:1:11:1:11 | x |
@@ -5709,7 +5195,6 @@ trackEnd
 | params_flow.rb:94:39:94:47 | call to taint | params_flow.rb:83:23:83:23 | w |
 | params_flow.rb:94:39:94:47 | call to taint | params_flow.rb:87:10:87:10 | w |
 | params_flow.rb:94:39:94:47 | call to taint | params_flow.rb:94:39:94:47 | call to taint |
-| params_flow.rb:94:39:94:47 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:94:39:94:47 | synthetic splat argument | params_flow.rb:94:39:94:47 | synthetic splat argument |
 | params_flow.rb:94:45:94:46 | 44 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:94:45:94:46 | 44 | params_flow.rb:1:11:1:11 | x |
@@ -5732,7 +5217,6 @@ trackEnd
 | params_flow.rb:96:10:96:18 | call to taint | params_flow.rb:69:14:69:14 | x |
 | params_flow.rb:96:10:96:18 | call to taint | params_flow.rb:70:10:70:10 | x |
 | params_flow.rb:96:10:96:18 | call to taint | params_flow.rb:96:10:96:18 | call to taint |
-| params_flow.rb:96:10:96:18 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:96:10:96:18 | synthetic splat argument | params_flow.rb:96:10:96:18 | synthetic splat argument |
 | params_flow.rb:96:16:96:17 | 45 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:16:96:17 | 45 | params_flow.rb:1:11:1:11 | x |
@@ -5752,7 +5236,6 @@ trackEnd
 | params_flow.rb:96:21:96:29 | call to taint | params_flow.rb:69:17:69:17 | y |
 | params_flow.rb:96:21:96:29 | call to taint | params_flow.rb:71:10:71:10 | y |
 | params_flow.rb:96:21:96:29 | call to taint | params_flow.rb:96:21:96:29 | call to taint |
-| params_flow.rb:96:21:96:29 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:96:21:96:29 | synthetic splat argument | params_flow.rb:96:21:96:29 | synthetic splat argument |
 | params_flow.rb:96:27:96:28 | 46 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:27:96:28 | 46 | params_flow.rb:1:11:1:11 | x |
@@ -5771,7 +5254,6 @@ trackEnd
 | params_flow.rb:96:33:96:65 | synthetic splat argument | params_flow.rb:96:33:96:65 | call to [] |
 | params_flow.rb:96:33:96:65 | synthetic splat argument | params_flow.rb:96:33:96:65 | synthetic splat argument |
 | params_flow.rb:96:34:96:42 | call to taint | params_flow.rb:96:34:96:42 | call to taint |
-| params_flow.rb:96:34:96:42 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:96:34:96:42 | synthetic splat argument | params_flow.rb:96:34:96:42 | synthetic splat argument |
 | params_flow.rb:96:40:96:41 | 47 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:40:96:41 | 47 | params_flow.rb:1:11:1:11 | x |
@@ -5779,7 +5261,6 @@ trackEnd
 | params_flow.rb:96:40:96:41 | 47 | params_flow.rb:96:34:96:42 | call to taint |
 | params_flow.rb:96:40:96:41 | 47 | params_flow.rb:96:40:96:41 | 47 |
 | params_flow.rb:96:45:96:53 | call to taint | params_flow.rb:96:45:96:53 | call to taint |
-| params_flow.rb:96:45:96:53 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:96:45:96:53 | synthetic splat argument | params_flow.rb:96:45:96:53 | synthetic splat argument |
 | params_flow.rb:96:51:96:52 | 48 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:51:96:52 | 48 | params_flow.rb:1:11:1:11 | x |
@@ -5787,7 +5268,6 @@ trackEnd
 | params_flow.rb:96:51:96:52 | 48 | params_flow.rb:96:45:96:53 | call to taint |
 | params_flow.rb:96:51:96:52 | 48 | params_flow.rb:96:51:96:52 | 48 |
 | params_flow.rb:96:56:96:64 | call to taint | params_flow.rb:96:56:96:64 | call to taint |
-| params_flow.rb:96:56:96:64 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:96:56:96:64 | synthetic splat argument | params_flow.rb:96:56:96:64 | synthetic splat argument |
 | params_flow.rb:96:62:96:63 | 49 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:62:96:63 | 49 | params_flow.rb:1:11:1:11 | x |
@@ -5801,7 +5281,6 @@ trackEnd
 | params_flow.rb:96:68:96:76 | call to taint | params_flow.rb:69:24:69:24 | w |
 | params_flow.rb:96:68:96:76 | call to taint | params_flow.rb:74:10:74:10 | w |
 | params_flow.rb:96:68:96:76 | call to taint | params_flow.rb:96:68:96:76 | call to taint |
-| params_flow.rb:96:68:96:76 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:96:68:96:76 | synthetic splat argument | params_flow.rb:96:68:96:76 | synthetic splat argument |
 | params_flow.rb:96:74:96:75 | 50 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:74:96:75 | 50 | params_flow.rb:1:11:1:11 | x |
@@ -5821,7 +5300,6 @@ trackEnd
 | params_flow.rb:96:79:96:87 | call to taint | params_flow.rb:69:27:69:27 | r |
 | params_flow.rb:96:79:96:87 | call to taint | params_flow.rb:75:10:75:10 | r |
 | params_flow.rb:96:79:96:87 | call to taint | params_flow.rb:96:79:96:87 | call to taint |
-| params_flow.rb:96:79:96:87 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:96:79:96:87 | synthetic splat argument | params_flow.rb:96:79:96:87 | synthetic splat argument |
 | params_flow.rb:96:85:96:86 | 51 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:85:96:86 | 51 | params_flow.rb:1:11:1:11 | x |
@@ -5866,10 +5344,8 @@ trackEnd
 | params_flow.rb:98:31:98:31 | b | params_flow.rb:98:31:98:31 | b |
 | params_flow.rb:98:31:98:31 | b | params_flow.rb:102:10:102:10 | b |
 | params_flow.rb:99:5:99:10 | call to sink | params_flow.rb:99:5:99:10 | call to sink |
-| params_flow.rb:99:5:99:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:99:5:99:10 | synthetic splat argument | params_flow.rb:99:5:99:10 | synthetic splat argument |
 | params_flow.rb:100:5:100:18 | call to sink | params_flow.rb:100:5:100:18 | call to sink |
-| params_flow.rb:100:5:100:18 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:100:5:100:18 | synthetic splat argument | params_flow.rb:100:5:100:18 | synthetic splat argument |
 | params_flow.rb:100:10:100:18 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:100:10:100:18 | ...[...] | params_flow.rb:5:10:5:10 | x |
@@ -5878,7 +5354,6 @@ trackEnd
 | params_flow.rb:100:10:100:18 | synthetic splat argument | params_flow.rb:100:10:100:18 | synthetic splat argument |
 | params_flow.rb:100:17:100:17 | 0 | params_flow.rb:100:17:100:17 | 0 |
 | params_flow.rb:101:5:101:18 | call to sink | params_flow.rb:101:5:101:18 | call to sink |
-| params_flow.rb:101:5:101:18 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:101:5:101:18 | synthetic splat argument | params_flow.rb:101:5:101:18 | synthetic splat argument |
 | params_flow.rb:101:10:101:18 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:101:10:101:18 | ...[...] | params_flow.rb:5:10:5:10 | x |
@@ -5889,7 +5364,6 @@ trackEnd
 | params_flow.rb:102:5:102:10 | call to sink | params_flow.rb:102:5:102:10 | call to sink |
 | params_flow.rb:102:5:102:10 | call to sink | params_flow.rb:105:1:105:49 | call to splatmidsmall |
 | params_flow.rb:102:5:102:10 | call to sink | params_flow.rb:106:1:106:46 | call to splatmidsmall |
-| params_flow.rb:102:5:102:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:102:5:102:10 | synthetic splat argument | params_flow.rb:102:5:102:10 | synthetic splat argument |
 | params_flow.rb:105:1:105:49 | call to splatmidsmall | params_flow.rb:105:1:105:49 | call to splatmidsmall |
 | params_flow.rb:105:1:105:49 | synthetic splat argument | params_flow.rb:98:1:103:3 | synthetic splat parameter |
@@ -5901,7 +5375,6 @@ trackEnd
 | params_flow.rb:105:15:105:23 | call to taint | params_flow.rb:98:19:98:19 | a |
 | params_flow.rb:105:15:105:23 | call to taint | params_flow.rb:99:10:99:10 | a |
 | params_flow.rb:105:15:105:23 | call to taint | params_flow.rb:105:15:105:23 | call to taint |
-| params_flow.rb:105:15:105:23 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:105:15:105:23 | synthetic splat argument | params_flow.rb:105:15:105:23 | synthetic splat argument |
 | params_flow.rb:105:21:105:22 | 52 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:105:21:105:22 | 52 | params_flow.rb:1:11:1:11 | x |
@@ -5920,7 +5393,6 @@ trackEnd
 | params_flow.rb:105:27:105:48 | synthetic splat argument | params_flow.rb:105:27:105:48 | call to [] |
 | params_flow.rb:105:27:105:48 | synthetic splat argument | params_flow.rb:105:27:105:48 | synthetic splat argument |
 | params_flow.rb:105:28:105:36 | call to taint | params_flow.rb:105:28:105:36 | call to taint |
-| params_flow.rb:105:28:105:36 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:105:28:105:36 | synthetic splat argument | params_flow.rb:105:28:105:36 | synthetic splat argument |
 | params_flow.rb:105:34:105:35 | 53 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:105:34:105:35 | 53 | params_flow.rb:1:11:1:11 | x |
@@ -5928,7 +5400,6 @@ trackEnd
 | params_flow.rb:105:34:105:35 | 53 | params_flow.rb:105:28:105:36 | call to taint |
 | params_flow.rb:105:34:105:35 | 53 | params_flow.rb:105:34:105:35 | 53 |
 | params_flow.rb:105:39:105:47 | call to taint | params_flow.rb:105:39:105:47 | call to taint |
-| params_flow.rb:105:39:105:47 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:105:39:105:47 | synthetic splat argument | params_flow.rb:105:39:105:47 | synthetic splat argument |
 | params_flow.rb:105:45:105:46 | 54 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:105:45:105:46 | 54 | params_flow.rb:1:11:1:11 | x |
@@ -5945,7 +5416,6 @@ trackEnd
 | params_flow.rb:106:15:106:23 | call to taint | params_flow.rb:98:19:98:19 | a |
 | params_flow.rb:106:15:106:23 | call to taint | params_flow.rb:99:10:99:10 | a |
 | params_flow.rb:106:15:106:23 | call to taint | params_flow.rb:106:15:106:23 | call to taint |
-| params_flow.rb:106:15:106:23 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:106:15:106:23 | synthetic splat argument | params_flow.rb:106:15:106:23 | synthetic splat argument |
 | params_flow.rb:106:21:106:22 | 55 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:106:21:106:22 | 55 | params_flow.rb:1:11:1:11 | x |
@@ -5959,7 +5429,6 @@ trackEnd
 | params_flow.rb:106:21:106:22 | 55 | params_flow.rb:106:15:106:23 | call to taint |
 | params_flow.rb:106:21:106:22 | 55 | params_flow.rb:106:21:106:22 | 55 |
 | params_flow.rb:106:26:106:34 | call to taint | params_flow.rb:106:26:106:34 | call to taint |
-| params_flow.rb:106:26:106:34 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:106:26:106:34 | synthetic splat argument | params_flow.rb:106:26:106:34 | synthetic splat argument |
 | params_flow.rb:106:32:106:33 | 56 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:106:32:106:33 | 56 | params_flow.rb:1:11:1:11 | x |
@@ -5973,7 +5442,6 @@ trackEnd
 | params_flow.rb:106:37:106:45 | call to taint | params_flow.rb:98:31:98:31 | b |
 | params_flow.rb:106:37:106:45 | call to taint | params_flow.rb:102:10:102:10 | b |
 | params_flow.rb:106:37:106:45 | call to taint | params_flow.rb:106:37:106:45 | call to taint |
-| params_flow.rb:106:37:106:45 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:106:37:106:45 | synthetic splat argument | params_flow.rb:106:37:106:45 | synthetic splat argument |
 | params_flow.rb:106:43:106:44 | 57 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:106:43:106:44 | 57 | params_flow.rb:1:11:1:11 | x |
@@ -6017,10 +5485,8 @@ trackEnd
 | params_flow.rb:108:44:108:44 | c | params_flow.rb:108:44:108:44 | c |
 | params_flow.rb:108:44:108:44 | c | params_flow.rb:111:10:111:10 | c |
 | params_flow.rb:109:5:109:10 | call to sink | params_flow.rb:109:5:109:10 | call to sink |
-| params_flow.rb:109:5:109:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:109:5:109:10 | synthetic splat argument | params_flow.rb:109:5:109:10 | synthetic splat argument |
 | params_flow.rb:110:5:110:13 | call to sink | params_flow.rb:110:5:110:13 | call to sink |
-| params_flow.rb:110:5:110:13 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:110:5:110:13 | synthetic splat argument | params_flow.rb:110:5:110:13 | synthetic splat argument |
 | params_flow.rb:110:10:110:13 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:110:10:110:13 | ...[...] | params_flow.rb:5:10:5:10 | x |
@@ -6030,7 +5496,6 @@ trackEnd
 | params_flow.rb:110:12:110:12 | 0 | params_flow.rb:110:12:110:12 | 0 |
 | params_flow.rb:111:5:111:10 | call to sink | params_flow.rb:111:5:111:10 | call to sink |
 | params_flow.rb:111:5:111:10 | call to sink | params_flow.rb:114:1:114:67 | call to splat_followed_by_keyword_param |
-| params_flow.rb:111:5:111:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:111:5:111:10 | synthetic splat argument | params_flow.rb:111:5:111:10 | synthetic splat argument |
 | params_flow.rb:114:1:114:67 | call to splat_followed_by_keyword_param | params_flow.rb:114:1:114:67 | call to splat_followed_by_keyword_param |
 | params_flow.rb:114:1:114:67 | synthetic hash-splat argument | params_flow.rb:108:1:112:3 | synthetic hash-splat parameter |
@@ -6044,7 +5509,6 @@ trackEnd
 | params_flow.rb:114:33:114:41 | call to taint | params_flow.rb:108:37:108:37 | a |
 | params_flow.rb:114:33:114:41 | call to taint | params_flow.rb:109:10:109:10 | a |
 | params_flow.rb:114:33:114:41 | call to taint | params_flow.rb:114:33:114:41 | call to taint |
-| params_flow.rb:114:33:114:41 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:114:33:114:41 | synthetic splat argument | params_flow.rb:114:33:114:41 | synthetic splat argument |
 | params_flow.rb:114:39:114:40 | 58 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:114:39:114:40 | 58 | params_flow.rb:1:11:1:11 | x |
@@ -6062,7 +5526,6 @@ trackEnd
 | params_flow.rb:114:44:114:52 | call to taint | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:114:44:114:52 | call to taint | params_flow.rb:110:10:110:13 | ...[...] |
 | params_flow.rb:114:44:114:52 | call to taint | params_flow.rb:114:44:114:52 | call to taint |
-| params_flow.rb:114:44:114:52 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:114:44:114:52 | synthetic splat argument | params_flow.rb:114:44:114:52 | synthetic splat argument |
 | params_flow.rb:114:50:114:51 | 59 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:114:50:114:51 | 59 | params_flow.rb:1:11:1:11 | x |
@@ -6082,7 +5545,6 @@ trackEnd
 | params_flow.rb:114:58:114:66 | call to taint | params_flow.rb:108:44:108:44 | c |
 | params_flow.rb:114:58:114:66 | call to taint | params_flow.rb:111:10:111:10 | c |
 | params_flow.rb:114:58:114:66 | call to taint | params_flow.rb:114:58:114:66 | call to taint |
-| params_flow.rb:114:58:114:66 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:114:58:114:66 | synthetic splat argument | params_flow.rb:114:58:114:66 | synthetic splat argument |
 | params_flow.rb:114:64:114:65 | 60 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:114:64:114:65 | 60 | params_flow.rb:1:11:1:11 | x |
@@ -6134,7 +5596,6 @@ trackEnd
 | params_flow.rb:117:19:117:27 | call to taint | params_flow.rb:117:19:117:27 | ... = ... |
 | params_flow.rb:117:19:117:27 | call to taint | params_flow.rb:117:19:117:27 | __synth__0 |
 | params_flow.rb:117:19:117:27 | call to taint | params_flow.rb:117:19:117:27 | call to taint |
-| params_flow.rb:117:19:117:27 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:117:19:117:27 | synthetic splat argument | params_flow.rb:117:19:117:27 | synthetic splat argument |
 | params_flow.rb:117:25:117:26 | 61 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:117:25:117:26 | 61 | params_flow.rb:1:11:1:11 | x |
@@ -6200,20 +5661,15 @@ trackEnd
 | params_flow.rb:120:27:120:27 | e | params_flow.rb:120:27:120:27 | e |
 | params_flow.rb:120:27:120:27 | e | params_flow.rb:125:10:125:10 | e |
 | params_flow.rb:121:5:121:10 | call to sink | params_flow.rb:121:5:121:10 | call to sink |
-| params_flow.rb:121:5:121:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:121:5:121:10 | synthetic splat argument | params_flow.rb:121:5:121:10 | synthetic splat argument |
 | params_flow.rb:122:5:122:10 | call to sink | params_flow.rb:122:5:122:10 | call to sink |
-| params_flow.rb:122:5:122:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:122:5:122:10 | synthetic splat argument | params_flow.rb:122:5:122:10 | synthetic splat argument |
 | params_flow.rb:123:5:123:10 | call to sink | params_flow.rb:123:5:123:10 | call to sink |
-| params_flow.rb:123:5:123:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:123:5:123:10 | synthetic splat argument | params_flow.rb:123:5:123:10 | synthetic splat argument |
 | params_flow.rb:124:5:124:10 | call to sink | params_flow.rb:124:5:124:10 | call to sink |
-| params_flow.rb:124:5:124:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:124:5:124:10 | synthetic splat argument | params_flow.rb:124:5:124:10 | synthetic splat argument |
 | params_flow.rb:125:5:125:10 | call to sink | params_flow.rb:125:5:125:10 | call to sink |
 | params_flow.rb:125:5:125:10 | call to sink | params_flow.rb:128:1:128:61 | call to destruct |
-| params_flow.rb:125:5:125:10 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:125:5:125:10 | synthetic splat argument | params_flow.rb:125:5:125:10 | synthetic splat argument |
 | params_flow.rb:128:1:128:61 | call to destruct | params_flow.rb:128:1:128:61 | call to destruct |
 | params_flow.rb:128:1:128:61 | synthetic splat argument | params_flow.rb:128:1:128:61 | synthetic splat argument |
@@ -6222,7 +5678,6 @@ trackEnd
 | params_flow.rb:128:10:128:31 | synthetic splat argument | params_flow.rb:128:10:128:31 | call to [] |
 | params_flow.rb:128:10:128:31 | synthetic splat argument | params_flow.rb:128:10:128:31 | synthetic splat argument |
 | params_flow.rb:128:11:128:19 | call to taint | params_flow.rb:128:11:128:19 | call to taint |
-| params_flow.rb:128:11:128:19 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:128:11:128:19 | synthetic splat argument | params_flow.rb:128:11:128:19 | synthetic splat argument |
 | params_flow.rb:128:17:128:18 | 62 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:128:17:128:18 | 62 | params_flow.rb:1:11:1:11 | x |
@@ -6230,7 +5685,6 @@ trackEnd
 | params_flow.rb:128:17:128:18 | 62 | params_flow.rb:128:11:128:19 | call to taint |
 | params_flow.rb:128:17:128:18 | 62 | params_flow.rb:128:17:128:18 | 62 |
 | params_flow.rb:128:22:128:30 | call to taint | params_flow.rb:128:22:128:30 | call to taint |
-| params_flow.rb:128:22:128:30 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:128:22:128:30 | synthetic splat argument | params_flow.rb:128:22:128:30 | synthetic splat argument |
 | params_flow.rb:128:28:128:29 | 63 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:128:28:128:29 | 63 | params_flow.rb:1:11:1:11 | x |
@@ -6242,7 +5696,6 @@ trackEnd
 | params_flow.rb:128:34:128:60 | synthetic splat argument | params_flow.rb:128:34:128:60 | call to [] |
 | params_flow.rb:128:34:128:60 | synthetic splat argument | params_flow.rb:128:34:128:60 | synthetic splat argument |
 | params_flow.rb:128:35:128:43 | call to taint | params_flow.rb:128:35:128:43 | call to taint |
-| params_flow.rb:128:35:128:43 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:128:35:128:43 | synthetic splat argument | params_flow.rb:128:35:128:43 | synthetic splat argument |
 | params_flow.rb:128:41:128:42 | 64 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:128:41:128:42 | 64 | params_flow.rb:1:11:1:11 | x |
@@ -6255,7 +5708,6 @@ trackEnd
 | params_flow.rb:128:46:128:59 | synthetic splat argument | params_flow.rb:128:46:128:59 | synthetic splat argument |
 | params_flow.rb:128:47:128:47 | 0 | params_flow.rb:128:47:128:47 | 0 |
 | params_flow.rb:128:50:128:58 | call to taint | params_flow.rb:128:50:128:58 | call to taint |
-| params_flow.rb:128:50:128:58 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:128:50:128:58 | synthetic splat argument | params_flow.rb:128:50:128:58 | synthetic splat argument |
 | params_flow.rb:128:56:128:57 | 65 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:128:56:128:57 | 65 | params_flow.rb:1:11:1:11 | x |
@@ -6292,7 +5744,6 @@ trackEnd
 | params_flow.rb:130:9:130:17 | call to taint | params_flow.rb:83:14:83:14 | t |
 | params_flow.rb:130:9:130:17 | call to taint | params_flow.rb:84:10:84:10 | t |
 | params_flow.rb:130:9:130:17 | call to taint | params_flow.rb:130:9:130:17 | call to taint |
-| params_flow.rb:130:9:130:17 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:130:9:130:17 | synthetic splat argument | params_flow.rb:130:9:130:17 | synthetic splat argument |
 | params_flow.rb:130:15:130:16 | 66 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:130:15:130:16 | 66 | params_flow.rb:1:11:1:11 | x |
@@ -6312,7 +5763,6 @@ trackEnd
 | params_flow.rb:130:20:130:28 | call to taint | params_flow.rb:83:17:83:17 | u |
 | params_flow.rb:130:20:130:28 | call to taint | params_flow.rb:85:10:85:10 | u |
 | params_flow.rb:130:20:130:28 | call to taint | params_flow.rb:130:20:130:28 | call to taint |
-| params_flow.rb:130:20:130:28 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:130:20:130:28 | synthetic splat argument | params_flow.rb:130:20:130:28 | synthetic splat argument |
 | params_flow.rb:130:26:130:27 | 67 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:130:26:130:27 | 67 | params_flow.rb:1:11:1:11 | x |
@@ -6335,7 +5785,6 @@ trackEnd
 | params_flow.rb:131:17:131:25 | call to taint | params_flow.rb:83:17:83:17 | u |
 | params_flow.rb:131:17:131:25 | call to taint | params_flow.rb:85:10:85:10 | u |
 | params_flow.rb:131:17:131:25 | call to taint | params_flow.rb:131:17:131:25 | call to taint |
-| params_flow.rb:131:17:131:25 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:131:17:131:25 | synthetic splat argument | params_flow.rb:131:17:131:25 | synthetic splat argument |
 | params_flow.rb:131:23:131:24 | 68 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:131:23:131:24 | 68 | params_flow.rb:1:11:1:11 | x |
@@ -6390,7 +5839,6 @@ trackEnd
 | params_flow.rb:133:15:133:18 | args | params_flow.rb:133:15:133:18 | args |
 | params_flow.rb:134:5:134:16 | call to sink | params_flow.rb:134:5:134:16 | call to sink |
 | params_flow.rb:134:5:134:16 | call to sink | params_flow.rb:137:1:137:44 | call to splatall |
-| params_flow.rb:134:5:134:16 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:134:5:134:16 | synthetic splat argument | params_flow.rb:134:5:134:16 | synthetic splat argument |
 | params_flow.rb:134:10:134:16 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:134:10:134:16 | ...[...] | params_flow.rb:5:10:5:10 | x |
@@ -6408,7 +5856,6 @@ trackEnd
 | params_flow.rb:137:11:137:43 | synthetic splat argument | params_flow.rb:137:11:137:43 | call to [] |
 | params_flow.rb:137:11:137:43 | synthetic splat argument | params_flow.rb:137:11:137:43 | synthetic splat argument |
 | params_flow.rb:137:12:137:20 | call to taint | params_flow.rb:137:12:137:20 | call to taint |
-| params_flow.rb:137:12:137:20 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:137:12:137:20 | synthetic splat argument | params_flow.rb:137:12:137:20 | synthetic splat argument |
 | params_flow.rb:137:18:137:19 | 69 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:137:18:137:19 | 69 | params_flow.rb:1:11:1:11 | x |
@@ -6420,7 +5867,6 @@ trackEnd
 | params_flow.rb:137:23:137:31 | call to taint | params_flow.rb:6:10:6:10 | x |
 | params_flow.rb:137:23:137:31 | call to taint | params_flow.rb:134:10:134:16 | ...[...] |
 | params_flow.rb:137:23:137:31 | call to taint | params_flow.rb:137:23:137:31 | call to taint |
-| params_flow.rb:137:23:137:31 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:137:23:137:31 | synthetic splat argument | params_flow.rb:137:23:137:31 | synthetic splat argument |
 | params_flow.rb:137:29:137:30 | 70 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:137:29:137:30 | 70 | params_flow.rb:1:11:1:11 | x |
@@ -6432,7 +5878,6 @@ trackEnd
 | params_flow.rb:137:29:137:30 | 70 | params_flow.rb:137:23:137:31 | call to taint |
 | params_flow.rb:137:29:137:30 | 70 | params_flow.rb:137:29:137:30 | 70 |
 | params_flow.rb:137:34:137:42 | call to taint | params_flow.rb:137:34:137:42 | call to taint |
-| params_flow.rb:137:34:137:42 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:137:34:137:42 | synthetic splat argument | params_flow.rb:137:34:137:42 | synthetic splat argument |
 | params_flow.rb:137:40:137:41 | 71 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:137:40:137:41 | 71 | params_flow.rb:1:11:1:11 | x |
@@ -6485,7 +5930,6 @@ trackEnd
 | params_flow.rb:143:20:143:32 | Pair | params_flow.rb:143:20:143:32 | Pair |
 | params_flow.rb:143:24:143:32 | call to taint | params_flow.rb:140:27:140:37 | ...[...] |
 | params_flow.rb:143:24:143:32 | call to taint | params_flow.rb:143:24:143:32 | call to taint |
-| params_flow.rb:143:24:143:32 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:143:24:143:32 | synthetic splat argument | params_flow.rb:143:24:143:32 | synthetic splat argument |
 | params_flow.rb:143:30:143:31 | 72 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:143:30:143:31 | 72 | params_flow.rb:1:11:1:11 | x |
@@ -6494,7 +5938,6 @@ trackEnd
 | params_flow.rb:143:30:143:31 | 72 | params_flow.rb:143:24:143:32 | call to taint |
 | params_flow.rb:143:30:143:31 | 72 | params_flow.rb:143:30:143:31 | 72 |
 | params_flow.rb:144:1:144:20 | call to sink | params_flow.rb:144:1:144:20 | call to sink |
-| params_flow.rb:144:1:144:20 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:144:1:144:20 | synthetic splat argument | params_flow.rb:144:1:144:20 | synthetic splat argument |
 | params_flow.rb:144:6:144:16 | ...[...] | params_flow.rb:144:6:144:16 | ...[...] |
 | params_flow.rb:144:6:144:16 | synthetic splat argument | params_flow.rb:144:6:144:16 | synthetic splat argument |
@@ -6512,7 +5955,6 @@ trackEnd
 | params_flow.rb:145:21:145:28 | ** ... | params_flow.rb:140:27:140:32 | kwargs |
 | params_flow.rb:145:21:145:28 | ** ... | params_flow.rb:145:21:145:28 | ** ... |
 | params_flow.rb:146:1:146:20 | call to sink | params_flow.rb:146:1:146:20 | call to sink |
-| params_flow.rb:146:1:146:20 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:146:1:146:20 | synthetic splat argument | params_flow.rb:146:1:146:20 | synthetic splat argument |
 | params_flow.rb:146:6:146:16 | ...[...] | params_flow.rb:146:6:146:16 | ...[...] |
 | params_flow.rb:146:6:146:16 | synthetic splat argument | params_flow.rb:146:6:146:16 | synthetic splat argument |
@@ -6533,7 +5975,6 @@ trackEnd
 | params_flow.rb:148:6:148:7 | call to [] | params_flow.rb:150:25:150:26 | p1 |
 | params_flow.rb:148:6:148:7 | call to [] | params_flow.rb:151:6:151:7 | p1 |
 | params_flow.rb:149:1:149:11 | call to sink | params_flow.rb:149:1:149:11 | call to sink |
-| params_flow.rb:149:1:149:11 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:149:1:149:11 | synthetic splat argument | params_flow.rb:149:1:149:11 | synthetic splat argument |
 | params_flow.rb:149:6:149:10 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:149:6:149:10 | ...[...] | params_flow.rb:5:10:5:10 | x |
@@ -6553,7 +5994,6 @@ trackEnd
 | params_flow.rb:150:29:150:41 | Pair | params_flow.rb:150:29:150:41 | Pair |
 | params_flow.rb:150:33:150:41 | call to taint | params_flow.rb:140:27:140:37 | ...[...] |
 | params_flow.rb:150:33:150:41 | call to taint | params_flow.rb:150:33:150:41 | call to taint |
-| params_flow.rb:150:33:150:41 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:150:33:150:41 | synthetic splat argument | params_flow.rb:150:33:150:41 | synthetic splat argument |
 | params_flow.rb:150:39:150:40 | 73 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:150:39:150:40 | 73 | params_flow.rb:1:11:1:11 | x |
@@ -6562,7 +6002,6 @@ trackEnd
 | params_flow.rb:150:39:150:40 | 73 | params_flow.rb:150:33:150:41 | call to taint |
 | params_flow.rb:150:39:150:40 | 73 | params_flow.rb:150:39:150:40 | 73 |
 | params_flow.rb:151:1:151:11 | call to sink | params_flow.rb:151:1:151:11 | call to sink |
-| params_flow.rb:151:1:151:11 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:151:1:151:11 | synthetic splat argument | params_flow.rb:151:1:151:11 | synthetic splat argument |
 | params_flow.rb:151:6:151:10 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:151:6:151:10 | ...[...] | params_flow.rb:5:10:5:10 | x |
@@ -6618,7 +6057,6 @@ trackEnd
 | params_flow.rb:157:24:157:32 | call to taint | params_flow.rb:153:28:153:29 | p2 |
 | params_flow.rb:157:24:157:32 | call to taint | params_flow.rb:154:18:154:19 | p2 |
 | params_flow.rb:157:24:157:32 | call to taint | params_flow.rb:157:24:157:32 | call to taint |
-| params_flow.rb:157:24:157:32 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:157:24:157:32 | synthetic splat argument | params_flow.rb:157:24:157:32 | synthetic splat argument |
 | params_flow.rb:157:30:157:31 | 74 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:157:30:157:31 | 74 | params_flow.rb:1:11:1:11 | x |
@@ -6629,7 +6067,6 @@ trackEnd
 | params_flow.rb:157:30:157:31 | 74 | params_flow.rb:157:24:157:32 | call to taint |
 | params_flow.rb:157:30:157:31 | 74 | params_flow.rb:157:30:157:31 | 74 |
 | params_flow.rb:158:1:158:20 | call to sink | params_flow.rb:158:1:158:20 | call to sink |
-| params_flow.rb:158:1:158:20 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:158:1:158:20 | synthetic splat argument | params_flow.rb:158:1:158:20 | synthetic splat argument |
 | params_flow.rb:158:6:158:16 | ...[...] | params_flow.rb:158:6:158:16 | ...[...] |
 | params_flow.rb:158:6:158:16 | synthetic splat argument | params_flow.rb:158:6:158:16 | synthetic splat argument |
@@ -6644,7 +6081,6 @@ trackEnd
 | params_flow.rb:159:19:159:26 | ** ... | params_flow.rb:153:1:155:3 | synthetic hash-splat parameter |
 | params_flow.rb:159:19:159:26 | ** ... | params_flow.rb:159:19:159:26 | ** ... |
 | params_flow.rb:160:1:160:20 | call to sink | params_flow.rb:160:1:160:20 | call to sink |
-| params_flow.rb:160:1:160:20 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:160:1:160:20 | synthetic splat argument | params_flow.rb:160:1:160:20 | synthetic splat argument |
 | params_flow.rb:160:6:160:16 | ...[...] | params_flow.rb:160:6:160:16 | ...[...] |
 | params_flow.rb:160:6:160:16 | synthetic splat argument | params_flow.rb:160:6:160:16 | synthetic splat argument |
@@ -6667,7 +6103,6 @@ trackEnd
 | params_flow.rb:162:6:162:7 | call to [] | params_flow.rb:164:23:164:24 | p1 |
 | params_flow.rb:162:6:162:7 | call to [] | params_flow.rb:165:6:165:7 | p1 |
 | params_flow.rb:163:1:163:11 | call to sink | params_flow.rb:163:1:163:11 | call to sink |
-| params_flow.rb:163:1:163:11 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:163:1:163:11 | synthetic splat argument | params_flow.rb:163:1:163:11 | synthetic splat argument |
 | params_flow.rb:163:6:163:10 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:163:6:163:10 | ...[...] | params_flow.rb:5:10:5:10 | x |
@@ -6686,7 +6121,6 @@ trackEnd
 | params_flow.rb:164:31:164:39 | call to taint | params_flow.rb:153:28:153:29 | p2 |
 | params_flow.rb:164:31:164:39 | call to taint | params_flow.rb:154:18:154:19 | p2 |
 | params_flow.rb:164:31:164:39 | call to taint | params_flow.rb:164:31:164:39 | call to taint |
-| params_flow.rb:164:31:164:39 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:164:31:164:39 | synthetic splat argument | params_flow.rb:164:31:164:39 | synthetic splat argument |
 | params_flow.rb:164:37:164:38 | 75 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:164:37:164:38 | 75 | params_flow.rb:1:11:1:11 | x |
@@ -6697,7 +6131,6 @@ trackEnd
 | params_flow.rb:164:37:164:38 | 75 | params_flow.rb:164:31:164:39 | call to taint |
 | params_flow.rb:164:37:164:38 | 75 | params_flow.rb:164:37:164:38 | 75 |
 | params_flow.rb:165:1:165:11 | call to sink | params_flow.rb:165:1:165:11 | call to sink |
-| params_flow.rb:165:1:165:11 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:165:1:165:11 | synthetic splat argument | params_flow.rb:165:1:165:11 | synthetic splat argument |
 | params_flow.rb:165:6:165:10 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:165:6:165:10 | ...[...] | params_flow.rb:5:10:5:10 | x |
@@ -6749,7 +6182,6 @@ trackEnd
 | params_flow.rb:171:13:171:14 | call to [] | params_flow.rb:174:6:174:15 | ...[...] |
 | params_flow.rb:171:17:171:25 | call to taint | params_flow.rb:168:26:168:35 | ...[...] |
 | params_flow.rb:171:17:171:25 | call to taint | params_flow.rb:171:17:171:25 | call to taint |
-| params_flow.rb:171:17:171:25 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:171:17:171:25 | synthetic splat argument | params_flow.rb:171:17:171:25 | synthetic splat argument |
 | params_flow.rb:171:23:171:24 | 76 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:171:23:171:24 | 76 | params_flow.rb:1:11:1:11 | x |
@@ -6758,7 +6190,6 @@ trackEnd
 | params_flow.rb:171:23:171:24 | 76 | params_flow.rb:171:17:171:25 | call to taint |
 | params_flow.rb:171:23:171:24 | 76 | params_flow.rb:171:23:171:24 | 76 |
 | params_flow.rb:172:1:172:19 | call to sink | params_flow.rb:172:1:172:19 | call to sink |
-| params_flow.rb:172:1:172:19 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:172:1:172:19 | synthetic splat argument | params_flow.rb:172:1:172:19 | synthetic splat argument |
 | params_flow.rb:172:6:172:15 | ...[...] | params_flow.rb:172:6:172:15 | ...[...] |
 | params_flow.rb:172:6:172:15 | synthetic splat argument | params_flow.rb:172:6:172:15 | synthetic splat argument |
@@ -6776,7 +6207,6 @@ trackEnd
 | params_flow.rb:173:17:173:24 | * ... | params_flow.rb:168:26:168:32 | posargs |
 | params_flow.rb:173:17:173:24 | * ... | params_flow.rb:173:17:173:24 | * ... |
 | params_flow.rb:174:1:174:19 | call to sink | params_flow.rb:174:1:174:19 | call to sink |
-| params_flow.rb:174:1:174:19 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:174:1:174:19 | synthetic splat argument | params_flow.rb:174:1:174:19 | synthetic splat argument |
 | params_flow.rb:174:6:174:15 | ...[...] | params_flow.rb:174:6:174:15 | ...[...] |
 | params_flow.rb:174:6:174:15 | synthetic splat argument | params_flow.rb:174:6:174:15 | synthetic splat argument |
@@ -6797,7 +6227,6 @@ trackEnd
 | params_flow.rb:176:6:176:7 | call to [] | params_flow.rb:178:17:178:18 | p1 |
 | params_flow.rb:176:6:176:7 | call to [] | params_flow.rb:179:6:179:7 | p1 |
 | params_flow.rb:177:1:177:11 | call to sink | params_flow.rb:177:1:177:11 | call to sink |
-| params_flow.rb:177:1:177:11 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:177:1:177:11 | synthetic splat argument | params_flow.rb:177:1:177:11 | synthetic splat argument |
 | params_flow.rb:177:6:177:10 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:177:6:177:10 | ...[...] | params_flow.rb:5:10:5:10 | x |
@@ -6813,7 +6242,6 @@ trackEnd
 | params_flow.rb:178:1:178:30 | synthetic splat argument | params_flow.rb:178:1:178:30 | synthetic splat argument |
 | params_flow.rb:178:21:178:29 | call to taint | params_flow.rb:168:26:168:35 | ...[...] |
 | params_flow.rb:178:21:178:29 | call to taint | params_flow.rb:178:21:178:29 | call to taint |
-| params_flow.rb:178:21:178:29 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:178:21:178:29 | synthetic splat argument | params_flow.rb:178:21:178:29 | synthetic splat argument |
 | params_flow.rb:178:27:178:28 | 77 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:178:27:178:28 | 77 | params_flow.rb:1:11:1:11 | x |
@@ -6822,7 +6250,6 @@ trackEnd
 | params_flow.rb:178:27:178:28 | 77 | params_flow.rb:178:21:178:29 | call to taint |
 | params_flow.rb:178:27:178:28 | 77 | params_flow.rb:178:27:178:28 | 77 |
 | params_flow.rb:179:1:179:11 | call to sink | params_flow.rb:179:1:179:11 | call to sink |
-| params_flow.rb:179:1:179:11 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:179:1:179:11 | synthetic splat argument | params_flow.rb:179:1:179:11 | synthetic splat argument |
 | params_flow.rb:179:6:179:10 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:179:6:179:10 | ...[...] | params_flow.rb:5:10:5:10 | x |
@@ -6880,7 +6307,6 @@ trackEnd
 | params_flow.rb:185:14:185:22 | call to taint | params_flow.rb:181:28:181:29 | p2 |
 | params_flow.rb:185:14:185:22 | call to taint | params_flow.rb:182:18:182:19 | p2 |
 | params_flow.rb:185:14:185:22 | call to taint | params_flow.rb:185:14:185:22 | call to taint |
-| params_flow.rb:185:14:185:22 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:185:14:185:22 | synthetic splat argument | params_flow.rb:185:14:185:22 | synthetic splat argument |
 | params_flow.rb:185:20:185:21 | 78 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:185:20:185:21 | 78 | params_flow.rb:1:11:1:11 | x |
@@ -6891,7 +6317,6 @@ trackEnd
 | params_flow.rb:185:20:185:21 | 78 | params_flow.rb:185:14:185:22 | call to taint |
 | params_flow.rb:185:20:185:21 | 78 | params_flow.rb:185:20:185:21 | 78 |
 | params_flow.rb:186:1:186:16 | call to sink | params_flow.rb:186:1:186:16 | call to sink |
-| params_flow.rb:186:1:186:16 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:186:1:186:16 | synthetic splat argument | params_flow.rb:186:1:186:16 | synthetic splat argument |
 | params_flow.rb:186:6:186:12 | ...[...] | params_flow.rb:186:6:186:12 | ...[...] |
 | params_flow.rb:186:6:186:12 | synthetic splat argument | params_flow.rb:186:6:186:12 | synthetic splat argument |
@@ -6906,7 +6331,6 @@ trackEnd
 | params_flow.rb:187:20:187:24 | * ... | params_flow.rb:181:1:183:3 | synthetic splat parameter |
 | params_flow.rb:187:20:187:24 | * ... | params_flow.rb:187:20:187:24 | * ... |
 | params_flow.rb:188:1:188:16 | call to sink | params_flow.rb:188:1:188:16 | call to sink |
-| params_flow.rb:188:1:188:16 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:188:1:188:16 | synthetic splat argument | params_flow.rb:188:1:188:16 | synthetic splat argument |
 | params_flow.rb:188:6:188:12 | ...[...] | params_flow.rb:188:6:188:12 | ...[...] |
 | params_flow.rb:188:6:188:12 | synthetic splat argument | params_flow.rb:188:6:188:12 | synthetic splat argument |
@@ -6929,7 +6353,6 @@ trackEnd
 | params_flow.rb:190:6:190:7 | call to [] | params_flow.rb:192:20:192:21 | p1 |
 | params_flow.rb:190:6:190:7 | call to [] | params_flow.rb:193:6:193:7 | p1 |
 | params_flow.rb:191:1:191:11 | call to sink | params_flow.rb:191:1:191:11 | call to sink |
-| params_flow.rb:191:1:191:11 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:191:1:191:11 | synthetic splat argument | params_flow.rb:191:1:191:11 | synthetic splat argument |
 | params_flow.rb:191:6:191:10 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:191:6:191:10 | ...[...] | params_flow.rb:5:10:5:10 | x |
@@ -6938,13 +6361,11 @@ trackEnd
 | params_flow.rb:191:6:191:10 | synthetic splat argument | params_flow.rb:191:6:191:10 | synthetic splat argument |
 | params_flow.rb:191:9:191:9 | 0 | params_flow.rb:191:9:191:9 | 0 |
 | params_flow.rb:192:1:192:33 | call to positionSideEffect | params_flow.rb:192:1:192:33 | call to positionSideEffect |
-| params_flow.rb:192:1:192:33 | synthetic splat argument | params_flow.rb:181:1:183:3 | synthetic splat parameter |
 | params_flow.rb:192:1:192:33 | synthetic splat argument | params_flow.rb:192:1:192:33 | synthetic splat argument |
 | params_flow.rb:192:24:192:32 | call to taint | params_flow.rb:181:28:181:29 | p2 |
 | params_flow.rb:192:24:192:32 | call to taint | params_flow.rb:181:28:181:29 | p2 |
 | params_flow.rb:192:24:192:32 | call to taint | params_flow.rb:182:18:182:19 | p2 |
 | params_flow.rb:192:24:192:32 | call to taint | params_flow.rb:192:24:192:32 | call to taint |
-| params_flow.rb:192:24:192:32 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:192:24:192:32 | synthetic splat argument | params_flow.rb:192:24:192:32 | synthetic splat argument |
 | params_flow.rb:192:30:192:31 | 79 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:192:30:192:31 | 79 | params_flow.rb:1:11:1:11 | x |
@@ -6955,7 +6376,6 @@ trackEnd
 | params_flow.rb:192:30:192:31 | 79 | params_flow.rb:192:24:192:32 | call to taint |
 | params_flow.rb:192:30:192:31 | 79 | params_flow.rb:192:30:192:31 | 79 |
 | params_flow.rb:193:1:193:11 | call to sink | params_flow.rb:193:1:193:11 | call to sink |
-| params_flow.rb:193:1:193:11 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:193:1:193:11 | synthetic splat argument | params_flow.rb:193:1:193:11 | synthetic splat argument |
 | params_flow.rb:193:6:193:10 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:193:6:193:10 | ...[...] | params_flow.rb:5:10:5:10 | x |
@@ -6990,7 +6410,6 @@ trackEnd
 | params_flow.rb:196:10:196:18 | call to taint | params_flow.rb:200:9:200:9 | x |
 | params_flow.rb:196:10:196:18 | call to taint | params_flow.rb:201:11:201:11 | x |
 | params_flow.rb:196:10:196:18 | call to taint | params_flow.rb:202:11:202:11 | x |
-| params_flow.rb:196:10:196:18 | synthetic splat argument | params_flow.rb:1:1:3:3 | synthetic splat parameter |
 | params_flow.rb:196:10:196:18 | synthetic splat argument | params_flow.rb:196:10:196:18 | synthetic splat argument |
 | params_flow.rb:196:16:196:17 | 80 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:196:16:196:17 | 80 | params_flow.rb:1:11:1:11 | x |
@@ -7031,7 +6450,6 @@ trackEnd
 | params_flow.rb:200:12:200:12 | y | params_flow.rb:203:11:203:11 | y |
 | params_flow.rb:200:12:200:12 | y | params_flow.rb:204:11:204:11 | y |
 | params_flow.rb:201:5:201:15 | call to sink | params_flow.rb:201:5:201:15 | call to sink |
-| params_flow.rb:201:5:201:15 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:201:5:201:15 | synthetic splat argument | params_flow.rb:201:5:201:15 | synthetic splat argument |
 | params_flow.rb:201:11:201:14 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:201:11:201:14 | ...[...] | params_flow.rb:5:10:5:10 | x |
@@ -7041,7 +6459,6 @@ trackEnd
 | params_flow.rb:201:11:201:14 | synthetic splat argument | params_flow.rb:201:11:201:14 | synthetic splat argument |
 | params_flow.rb:201:13:201:13 | 0 | params_flow.rb:201:13:201:13 | 0 |
 | params_flow.rb:202:5:202:15 | call to sink | params_flow.rb:202:5:202:15 | call to sink |
-| params_flow.rb:202:5:202:15 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:202:5:202:15 | synthetic splat argument | params_flow.rb:202:5:202:15 | synthetic splat argument |
 | params_flow.rb:202:11:202:14 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:202:11:202:14 | ...[...] | params_flow.rb:5:10:5:10 | x |
@@ -7051,7 +6468,6 @@ trackEnd
 | params_flow.rb:202:11:202:14 | synthetic splat argument | params_flow.rb:202:11:202:14 | synthetic splat argument |
 | params_flow.rb:202:13:202:13 | 1 | params_flow.rb:202:13:202:13 | 1 |
 | params_flow.rb:203:5:203:15 | call to sink | params_flow.rb:203:5:203:15 | call to sink |
-| params_flow.rb:203:5:203:15 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:203:5:203:15 | synthetic splat argument | params_flow.rb:203:5:203:15 | synthetic splat argument |
 | params_flow.rb:203:11:203:14 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:203:11:203:14 | ...[...] | params_flow.rb:5:10:5:10 | x |
@@ -7062,7 +6478,6 @@ trackEnd
 | params_flow.rb:203:13:203:13 | 0 | params_flow.rb:203:13:203:13 | 0 |
 | params_flow.rb:204:5:204:15 | call to sink | params_flow.rb:204:5:204:15 | call to sink |
 | params_flow.rb:204:5:204:15 | call to sink | params_flow.rb:207:1:207:14 | call to foo |
-| params_flow.rb:204:5:204:15 | synthetic splat argument | params_flow.rb:5:1:7:3 | synthetic splat parameter |
 | params_flow.rb:204:5:204:15 | synthetic splat argument | params_flow.rb:204:5:204:15 | synthetic splat argument |
 | params_flow.rb:204:11:204:14 | ...[...] | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:204:11:204:14 | ...[...] | params_flow.rb:5:10:5:10 | x |

--- a/ruby/ql/test/library-tests/dataflow/params/TypeTracker.expected
+++ b/ruby/ql/test/library-tests/dataflow/params/TypeTracker.expected
@@ -36,8 +36,6 @@ track
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:65:10:65:13 | ...[...] |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:69:14:69:14 | x |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:69:17:69:17 | y |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:69:27:69:27 | r |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:83:14:83:14 | t |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:83:17:83:17 | u |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:83:20:83:20 | v |
@@ -45,7 +43,6 @@ track
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:83:26:83:26 | x |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:83:29:83:29 | y |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:98:19:98:19 | a |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:98:31:98:31 | b |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:108:37:108:37 | a |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:108:44:108:44 | c |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:110:10:110:13 | ...[...] |
@@ -74,8 +71,6 @@ track
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:70:5:70:10 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:74:5:74:10 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:75:5:75:10 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:84:5:84:10 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:85:5:85:10 | synthetic splat argument |
@@ -85,7 +80,6 @@ track
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:89:5:89:10 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:99:5:99:10 | synthetic splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:102:5:102:10 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:108:1:112:3 | synthetic splat parameter |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:108:40:108:41 | *b |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:109:5:109:10 | synthetic splat argument |
@@ -1475,37 +1469,21 @@ track
 | params_flow.rb:78:38:78:39 | 29 | type tracker without call steps | params_flow.rb:78:38:78:39 | 29 |
 | params_flow.rb:78:38:78:39 | 29 | type tracker without call steps with content element 0 | params_flow.rb:78:32:78:40 | synthetic splat argument |
 | params_flow.rb:78:38:78:39 | 29 | type tracker without call steps with content element 2 | params_flow.rb:78:1:78:63 | synthetic splat argument |
-| params_flow.rb:78:43:78:51 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:78:43:78:51 | call to taint | type tracker with call steps | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:78:43:78:51 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:78:43:78:51 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:74:5:74:10 | synthetic splat argument |
 | params_flow.rb:78:43:78:51 | call to taint | type tracker with call steps with content element 3 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:78:43:78:51 | call to taint | type tracker without call steps | params_flow.rb:78:43:78:51 | call to taint |
 | params_flow.rb:78:43:78:51 | call to taint | type tracker without call steps with content element 3 | params_flow.rb:78:1:78:63 | synthetic splat argument |
 | params_flow.rb:78:43:78:51 | synthetic splat argument | type tracker without call steps | params_flow.rb:78:43:78:51 | synthetic splat argument |
 | params_flow.rb:78:49:78:50 | 30 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:78:49:78:50 | 30 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:78:49:78:50 | 30 | type tracker with call steps | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:78:49:78:50 | 30 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:78:49:78:50 | 30 | type tracker with call steps with content element 0 | params_flow.rb:74:5:74:10 | synthetic splat argument |
 | params_flow.rb:78:49:78:50 | 30 | type tracker with call steps with content element 3 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:78:49:78:50 | 30 | type tracker without call steps | params_flow.rb:78:43:78:51 | call to taint |
 | params_flow.rb:78:49:78:50 | 30 | type tracker without call steps | params_flow.rb:78:49:78:50 | 30 |
 | params_flow.rb:78:49:78:50 | 30 | type tracker without call steps with content element 0 | params_flow.rb:78:43:78:51 | synthetic splat argument |
 | params_flow.rb:78:49:78:50 | 30 | type tracker without call steps with content element 3 | params_flow.rb:78:1:78:63 | synthetic splat argument |
-| params_flow.rb:78:54:78:62 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:78:54:78:62 | call to taint | type tracker with call steps | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:78:54:78:62 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:78:54:78:62 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:75:5:75:10 | synthetic splat argument |
 | params_flow.rb:78:54:78:62 | call to taint | type tracker with call steps with content element 4 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:78:54:78:62 | call to taint | type tracker without call steps | params_flow.rb:78:54:78:62 | call to taint |
 | params_flow.rb:78:54:78:62 | call to taint | type tracker without call steps with content element 4 | params_flow.rb:78:1:78:63 | synthetic splat argument |
 | params_flow.rb:78:54:78:62 | synthetic splat argument | type tracker without call steps | params_flow.rb:78:54:78:62 | synthetic splat argument |
 | params_flow.rb:78:60:78:61 | 31 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:78:60:78:61 | 31 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:78:60:78:61 | 31 | type tracker with call steps | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:78:60:78:61 | 31 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:78:60:78:61 | 31 | type tracker with call steps with content element 0 | params_flow.rb:75:5:75:10 | synthetic splat argument |
 | params_flow.rb:78:60:78:61 | 31 | type tracker with call steps with content element 4 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:78:60:78:61 | 31 | type tracker without call steps | params_flow.rb:78:54:78:62 | call to taint |
 | params_flow.rb:78:60:78:61 | 31 | type tracker without call steps | params_flow.rb:78:60:78:61 | 31 |
@@ -1841,17 +1819,9 @@ track
 | params_flow.rb:94:27:94:28 | 39 | type tracker without call steps with content element 0 | params_flow.rb:94:21:94:29 | synthetic splat argument |
 | params_flow.rb:94:27:94:28 | 39 | type tracker without call steps with content element 1 | params_flow.rb:94:1:94:48 | synthetic splat argument |
 | params_flow.rb:94:32:94:36 | * ... | type tracker without call steps | params_flow.rb:94:32:94:36 | * ... |
-| params_flow.rb:94:39:94:47 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:94:39:94:47 | call to taint | type tracker with call steps | params_flow.rb:83:23:83:23 | w |
-| params_flow.rb:94:39:94:47 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:94:39:94:47 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:87:5:87:10 | synthetic splat argument |
 | params_flow.rb:94:39:94:47 | call to taint | type tracker without call steps | params_flow.rb:94:39:94:47 | call to taint |
 | params_flow.rb:94:39:94:47 | synthetic splat argument | type tracker without call steps | params_flow.rb:94:39:94:47 | synthetic splat argument |
 | params_flow.rb:94:45:94:46 | 44 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:94:45:94:46 | 44 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:94:45:94:46 | 44 | type tracker with call steps | params_flow.rb:83:23:83:23 | w |
-| params_flow.rb:94:45:94:46 | 44 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:94:45:94:46 | 44 | type tracker with call steps with content element 0 | params_flow.rb:87:5:87:10 | synthetic splat argument |
 | params_flow.rb:94:45:94:46 | 44 | type tracker without call steps | params_flow.rb:94:39:94:47 | call to taint |
 | params_flow.rb:94:45:94:46 | 44 | type tracker without call steps | params_flow.rb:94:45:94:46 | 44 |
 | params_flow.rb:94:45:94:46 | 44 | type tracker without call steps with content element 0 | params_flow.rb:94:39:94:47 | synthetic splat argument |
@@ -1953,31 +1923,15 @@ track
 | params_flow.rb:96:62:96:63 | 49 | type tracker without call steps with content element 2 | params_flow.rb:96:33:96:65 | call to [] |
 | params_flow.rb:96:62:96:63 | 49 | type tracker without call steps with content element 2 | params_flow.rb:96:33:96:65 | synthetic splat argument |
 | params_flow.rb:96:62:96:63 | 49 | type tracker without call steps with content element 4 | params_flow.rb:96:1:96:88 | synthetic splat argument |
-| params_flow.rb:96:68:96:76 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:96:68:96:76 | call to taint | type tracker with call steps | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:96:68:96:76 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:96:68:96:76 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:74:5:74:10 | synthetic splat argument |
 | params_flow.rb:96:68:96:76 | call to taint | type tracker without call steps | params_flow.rb:96:68:96:76 | call to taint |
 | params_flow.rb:96:68:96:76 | synthetic splat argument | type tracker without call steps | params_flow.rb:96:68:96:76 | synthetic splat argument |
 | params_flow.rb:96:74:96:75 | 50 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:96:74:96:75 | 50 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:96:74:96:75 | 50 | type tracker with call steps | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:96:74:96:75 | 50 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:96:74:96:75 | 50 | type tracker with call steps with content element 0 | params_flow.rb:74:5:74:10 | synthetic splat argument |
 | params_flow.rb:96:74:96:75 | 50 | type tracker without call steps | params_flow.rb:96:68:96:76 | call to taint |
 | params_flow.rb:96:74:96:75 | 50 | type tracker without call steps | params_flow.rb:96:74:96:75 | 50 |
 | params_flow.rb:96:74:96:75 | 50 | type tracker without call steps with content element 0 | params_flow.rb:96:68:96:76 | synthetic splat argument |
-| params_flow.rb:96:79:96:87 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:96:79:96:87 | call to taint | type tracker with call steps | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:96:79:96:87 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:96:79:96:87 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:75:5:75:10 | synthetic splat argument |
 | params_flow.rb:96:79:96:87 | call to taint | type tracker without call steps | params_flow.rb:96:79:96:87 | call to taint |
 | params_flow.rb:96:79:96:87 | synthetic splat argument | type tracker without call steps | params_flow.rb:96:79:96:87 | synthetic splat argument |
 | params_flow.rb:96:85:96:86 | 51 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:96:85:96:86 | 51 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:96:85:96:86 | 51 | type tracker with call steps | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:96:85:96:86 | 51 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:96:85:96:86 | 51 | type tracker with call steps with content element 0 | params_flow.rb:75:5:75:10 | synthetic splat argument |
 | params_flow.rb:96:85:96:86 | 51 | type tracker without call steps | params_flow.rb:96:79:96:87 | call to taint |
 | params_flow.rb:96:85:96:86 | 51 | type tracker without call steps | params_flow.rb:96:85:96:86 | 51 |
 | params_flow.rb:96:85:96:86 | 51 | type tracker without call steps with content element 0 | params_flow.rb:96:79:96:87 | synthetic splat argument |
@@ -2117,19 +2071,11 @@ track
 | params_flow.rb:106:32:106:33 | 56 | type tracker without call steps | params_flow.rb:106:32:106:33 | 56 |
 | params_flow.rb:106:32:106:33 | 56 | type tracker without call steps with content element 0 | params_flow.rb:106:26:106:34 | synthetic splat argument |
 | params_flow.rb:106:32:106:33 | 56 | type tracker without call steps with content element 1 | params_flow.rb:106:1:106:46 | synthetic splat argument |
-| params_flow.rb:106:37:106:45 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:106:37:106:45 | call to taint | type tracker with call steps | params_flow.rb:98:31:98:31 | b |
-| params_flow.rb:106:37:106:45 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:106:37:106:45 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:102:5:102:10 | synthetic splat argument |
 | params_flow.rb:106:37:106:45 | call to taint | type tracker with call steps with content element 2 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:106:37:106:45 | call to taint | type tracker without call steps | params_flow.rb:106:37:106:45 | call to taint |
 | params_flow.rb:106:37:106:45 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:106:1:106:46 | synthetic splat argument |
 | params_flow.rb:106:37:106:45 | synthetic splat argument | type tracker without call steps | params_flow.rb:106:37:106:45 | synthetic splat argument |
 | params_flow.rb:106:43:106:44 | 57 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:106:43:106:44 | 57 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:106:43:106:44 | 57 | type tracker with call steps | params_flow.rb:98:31:98:31 | b |
-| params_flow.rb:106:43:106:44 | 57 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:106:43:106:44 | 57 | type tracker with call steps with content element 0 | params_flow.rb:102:5:102:10 | synthetic splat argument |
 | params_flow.rb:106:43:106:44 | 57 | type tracker with call steps with content element 2 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:106:43:106:44 | 57 | type tracker without call steps | params_flow.rb:106:37:106:45 | call to taint |
 | params_flow.rb:106:43:106:44 | 57 | type tracker without call steps | params_flow.rb:106:43:106:44 | 57 |
@@ -2448,39 +2394,15 @@ track
 | params_flow.rb:131:1:131:46 | call to pos_many | type tracker without call steps | params_flow.rb:131:1:131:46 | call to pos_many |
 | params_flow.rb:131:10:131:14 | * ... | type tracker with call steps | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:131:10:131:14 | * ... | type tracker without call steps | params_flow.rb:131:10:131:14 | * ... |
-| params_flow.rb:131:17:131:25 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:131:17:131:25 | call to taint | type tracker with call steps | params_flow.rb:83:17:83:17 | u |
-| params_flow.rb:131:17:131:25 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:131:17:131:25 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:85:5:85:10 | synthetic splat argument |
 | params_flow.rb:131:17:131:25 | call to taint | type tracker without call steps | params_flow.rb:131:17:131:25 | call to taint |
 | params_flow.rb:131:17:131:25 | synthetic splat argument | type tracker without call steps | params_flow.rb:131:17:131:25 | synthetic splat argument |
 | params_flow.rb:131:23:131:24 | 68 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:131:23:131:24 | 68 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:131:23:131:24 | 68 | type tracker with call steps | params_flow.rb:83:17:83:17 | u |
-| params_flow.rb:131:23:131:24 | 68 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:131:23:131:24 | 68 | type tracker with call steps with content element 0 | params_flow.rb:85:5:85:10 | synthetic splat argument |
 | params_flow.rb:131:23:131:24 | 68 | type tracker without call steps | params_flow.rb:131:17:131:25 | call to taint |
 | params_flow.rb:131:23:131:24 | 68 | type tracker without call steps | params_flow.rb:131:23:131:24 | 68 |
 | params_flow.rb:131:23:131:24 | 68 | type tracker without call steps with content element 0 | params_flow.rb:131:17:131:25 | synthetic splat argument |
-| params_flow.rb:131:28:131:30 | nil | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:131:28:131:30 | nil | type tracker with call steps | params_flow.rb:83:20:83:20 | v |
-| params_flow.rb:131:28:131:30 | nil | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:131:28:131:30 | nil | type tracker with call steps with content element 0 | params_flow.rb:86:5:86:10 | synthetic splat argument |
 | params_flow.rb:131:28:131:30 | nil | type tracker without call steps | params_flow.rb:131:28:131:30 | nil |
-| params_flow.rb:131:33:131:35 | nil | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:131:33:131:35 | nil | type tracker with call steps | params_flow.rb:83:23:83:23 | w |
-| params_flow.rb:131:33:131:35 | nil | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:131:33:131:35 | nil | type tracker with call steps with content element 0 | params_flow.rb:87:5:87:10 | synthetic splat argument |
 | params_flow.rb:131:33:131:35 | nil | type tracker without call steps | params_flow.rb:131:33:131:35 | nil |
-| params_flow.rb:131:38:131:40 | nil | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:131:38:131:40 | nil | type tracker with call steps | params_flow.rb:83:26:83:26 | x |
-| params_flow.rb:131:38:131:40 | nil | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:131:38:131:40 | nil | type tracker with call steps with content element 0 | params_flow.rb:88:5:88:10 | synthetic splat argument |
 | params_flow.rb:131:38:131:40 | nil | type tracker without call steps | params_flow.rb:131:38:131:40 | nil |
-| params_flow.rb:131:43:131:45 | nil | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:131:43:131:45 | nil | type tracker with call steps | params_flow.rb:83:29:83:29 | y |
-| params_flow.rb:131:43:131:45 | nil | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:131:43:131:45 | nil | type tracker with call steps with content element 0 | params_flow.rb:89:5:89:10 | synthetic splat argument |
 | params_flow.rb:131:43:131:45 | nil | type tracker without call steps | params_flow.rb:131:43:131:45 | nil |
 | params_flow.rb:133:1:135:3 | &block | type tracker without call steps | params_flow.rb:133:1:135:3 | &block |
 | params_flow.rb:133:1:135:3 | self in splatall | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
@@ -3482,14 +3404,8 @@ trackEnd
 | params_flow.rb:1:11:1:11 | x | params_flow.rb:69:14:69:14 | x |
 | params_flow.rb:1:11:1:11 | x | params_flow.rb:69:17:69:17 | y |
 | params_flow.rb:1:11:1:11 | x | params_flow.rb:69:17:69:17 | y |
-| params_flow.rb:1:11:1:11 | x | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:1:11:1:11 | x | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:1:11:1:11 | x | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:1:11:1:11 | x | params_flow.rb:69:27:69:27 | r |
 | params_flow.rb:1:11:1:11 | x | params_flow.rb:70:10:70:10 | x |
 | params_flow.rb:1:11:1:11 | x | params_flow.rb:71:10:71:10 | y |
-| params_flow.rb:1:11:1:11 | x | params_flow.rb:74:10:74:10 | w |
-| params_flow.rb:1:11:1:11 | x | params_flow.rb:75:10:75:10 | r |
 | params_flow.rb:1:11:1:11 | x | params_flow.rb:78:10:78:18 | call to taint |
 | params_flow.rb:1:11:1:11 | x | params_flow.rb:78:21:78:29 | call to taint |
 | params_flow.rb:1:11:1:11 | x | params_flow.rb:78:32:78:40 | call to taint |
@@ -3535,10 +3451,7 @@ trackEnd
 | params_flow.rb:1:11:1:11 | x | params_flow.rb:96:79:96:87 | call to taint |
 | params_flow.rb:1:11:1:11 | x | params_flow.rb:98:19:98:19 | a |
 | params_flow.rb:1:11:1:11 | x | params_flow.rb:98:19:98:19 | a |
-| params_flow.rb:1:11:1:11 | x | params_flow.rb:98:31:98:31 | b |
-| params_flow.rb:1:11:1:11 | x | params_flow.rb:98:31:98:31 | b |
 | params_flow.rb:1:11:1:11 | x | params_flow.rb:99:10:99:10 | a |
-| params_flow.rb:1:11:1:11 | x | params_flow.rb:102:10:102:10 | b |
 | params_flow.rb:1:11:1:11 | x | params_flow.rb:105:15:105:23 | call to taint |
 | params_flow.rb:1:11:1:11 | x | params_flow.rb:105:28:105:36 | call to taint |
 | params_flow.rb:1:11:1:11 | x | params_flow.rb:105:39:105:47 | call to taint |
@@ -4783,42 +4696,18 @@ trackEnd
 | params_flow.rb:78:38:78:39 | 29 | params_flow.rb:2:5:2:5 | x |
 | params_flow.rb:78:38:78:39 | 29 | params_flow.rb:78:32:78:40 | call to taint |
 | params_flow.rb:78:38:78:39 | 29 | params_flow.rb:78:38:78:39 | 29 |
-| params_flow.rb:78:43:78:51 | call to taint | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:78:43:78:51 | call to taint | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:78:43:78:51 | call to taint | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:78:43:78:51 | call to taint | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:78:43:78:51 | call to taint | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:78:43:78:51 | call to taint | params_flow.rb:74:10:74:10 | w |
 | params_flow.rb:78:43:78:51 | call to taint | params_flow.rb:78:43:78:51 | call to taint |
 | params_flow.rb:78:43:78:51 | synthetic splat argument | params_flow.rb:78:43:78:51 | synthetic splat argument |
 | params_flow.rb:78:49:78:50 | 30 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:78:49:78:50 | 30 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:78:49:78:50 | 30 | params_flow.rb:2:5:2:5 | x |
-| params_flow.rb:78:49:78:50 | 30 | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:78:49:78:50 | 30 | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:78:49:78:50 | 30 | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:78:49:78:50 | 30 | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:78:49:78:50 | 30 | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:78:49:78:50 | 30 | params_flow.rb:74:10:74:10 | w |
 | params_flow.rb:78:49:78:50 | 30 | params_flow.rb:78:43:78:51 | call to taint |
 | params_flow.rb:78:49:78:50 | 30 | params_flow.rb:78:49:78:50 | 30 |
-| params_flow.rb:78:54:78:62 | call to taint | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:78:54:78:62 | call to taint | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:78:54:78:62 | call to taint | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:78:54:78:62 | call to taint | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:78:54:78:62 | call to taint | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:78:54:78:62 | call to taint | params_flow.rb:75:10:75:10 | r |
 | params_flow.rb:78:54:78:62 | call to taint | params_flow.rb:78:54:78:62 | call to taint |
 | params_flow.rb:78:54:78:62 | synthetic splat argument | params_flow.rb:78:54:78:62 | synthetic splat argument |
 | params_flow.rb:78:60:78:61 | 31 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:78:60:78:61 | 31 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:78:60:78:61 | 31 | params_flow.rb:2:5:2:5 | x |
-| params_flow.rb:78:60:78:61 | 31 | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:78:60:78:61 | 31 | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:78:60:78:61 | 31 | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:78:60:78:61 | 31 | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:78:60:78:61 | 31 | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:78:60:78:61 | 31 | params_flow.rb:75:10:75:10 | r |
 | params_flow.rb:78:60:78:61 | 31 | params_flow.rb:78:54:78:62 | call to taint |
 | params_flow.rb:78:60:78:61 | 31 | params_flow.rb:78:60:78:61 | 31 |
 | params_flow.rb:80:1:80:4 | args | params_flow.rb:80:1:80:4 | args |
@@ -5135,23 +5024,11 @@ trackEnd
 | params_flow.rb:94:27:94:28 | 39 | params_flow.rb:94:21:94:29 | call to taint |
 | params_flow.rb:94:27:94:28 | 39 | params_flow.rb:94:27:94:28 | 39 |
 | params_flow.rb:94:32:94:36 | * ... | params_flow.rb:94:32:94:36 | * ... |
-| params_flow.rb:94:39:94:47 | call to taint | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:94:39:94:47 | call to taint | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:94:39:94:47 | call to taint | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:94:39:94:47 | call to taint | params_flow.rb:83:23:83:23 | w |
-| params_flow.rb:94:39:94:47 | call to taint | params_flow.rb:83:23:83:23 | w |
-| params_flow.rb:94:39:94:47 | call to taint | params_flow.rb:87:10:87:10 | w |
 | params_flow.rb:94:39:94:47 | call to taint | params_flow.rb:94:39:94:47 | call to taint |
 | params_flow.rb:94:39:94:47 | synthetic splat argument | params_flow.rb:94:39:94:47 | synthetic splat argument |
 | params_flow.rb:94:45:94:46 | 44 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:94:45:94:46 | 44 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:94:45:94:46 | 44 | params_flow.rb:2:5:2:5 | x |
-| params_flow.rb:94:45:94:46 | 44 | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:94:45:94:46 | 44 | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:94:45:94:46 | 44 | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:94:45:94:46 | 44 | params_flow.rb:83:23:83:23 | w |
-| params_flow.rb:94:45:94:46 | 44 | params_flow.rb:83:23:83:23 | w |
-| params_flow.rb:94:45:94:46 | 44 | params_flow.rb:87:10:87:10 | w |
 | params_flow.rb:94:45:94:46 | 44 | params_flow.rb:94:39:94:47 | call to taint |
 | params_flow.rb:94:45:94:46 | 44 | params_flow.rb:94:45:94:46 | 44 |
 | params_flow.rb:96:1:96:88 | call to splatmid | params_flow.rb:96:1:96:88 | call to splatmid |
@@ -5221,42 +5098,18 @@ trackEnd
 | params_flow.rb:96:62:96:63 | 49 | params_flow.rb:2:5:2:5 | x |
 | params_flow.rb:96:62:96:63 | 49 | params_flow.rb:96:56:96:64 | call to taint |
 | params_flow.rb:96:62:96:63 | 49 | params_flow.rb:96:62:96:63 | 49 |
-| params_flow.rb:96:68:96:76 | call to taint | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:96:68:96:76 | call to taint | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:96:68:96:76 | call to taint | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:96:68:96:76 | call to taint | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:96:68:96:76 | call to taint | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:96:68:96:76 | call to taint | params_flow.rb:74:10:74:10 | w |
 | params_flow.rb:96:68:96:76 | call to taint | params_flow.rb:96:68:96:76 | call to taint |
 | params_flow.rb:96:68:96:76 | synthetic splat argument | params_flow.rb:96:68:96:76 | synthetic splat argument |
 | params_flow.rb:96:74:96:75 | 50 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:74:96:75 | 50 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:74:96:75 | 50 | params_flow.rb:2:5:2:5 | x |
-| params_flow.rb:96:74:96:75 | 50 | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:96:74:96:75 | 50 | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:96:74:96:75 | 50 | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:96:74:96:75 | 50 | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:96:74:96:75 | 50 | params_flow.rb:69:24:69:24 | w |
-| params_flow.rb:96:74:96:75 | 50 | params_flow.rb:74:10:74:10 | w |
 | params_flow.rb:96:74:96:75 | 50 | params_flow.rb:96:68:96:76 | call to taint |
 | params_flow.rb:96:74:96:75 | 50 | params_flow.rb:96:74:96:75 | 50 |
-| params_flow.rb:96:79:96:87 | call to taint | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:96:79:96:87 | call to taint | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:96:79:96:87 | call to taint | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:96:79:96:87 | call to taint | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:96:79:96:87 | call to taint | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:96:79:96:87 | call to taint | params_flow.rb:75:10:75:10 | r |
 | params_flow.rb:96:79:96:87 | call to taint | params_flow.rb:96:79:96:87 | call to taint |
 | params_flow.rb:96:79:96:87 | synthetic splat argument | params_flow.rb:96:79:96:87 | synthetic splat argument |
 | params_flow.rb:96:85:96:86 | 51 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:85:96:86 | 51 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:96:85:96:86 | 51 | params_flow.rb:2:5:2:5 | x |
-| params_flow.rb:96:85:96:86 | 51 | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:96:85:96:86 | 51 | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:96:85:96:86 | 51 | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:96:85:96:86 | 51 | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:96:85:96:86 | 51 | params_flow.rb:69:27:69:27 | r |
-| params_flow.rb:96:85:96:86 | 51 | params_flow.rb:75:10:75:10 | r |
 | params_flow.rb:96:85:96:86 | 51 | params_flow.rb:96:79:96:87 | call to taint |
 | params_flow.rb:96:85:96:86 | 51 | params_flow.rb:96:85:96:86 | 51 |
 | params_flow.rb:98:1:103:3 | &block | params_flow.rb:98:1:103:3 | &block |
@@ -5382,23 +5235,11 @@ trackEnd
 | params_flow.rb:106:32:106:33 | 56 | params_flow.rb:2:5:2:5 | x |
 | params_flow.rb:106:32:106:33 | 56 | params_flow.rb:106:26:106:34 | call to taint |
 | params_flow.rb:106:32:106:33 | 56 | params_flow.rb:106:32:106:33 | 56 |
-| params_flow.rb:106:37:106:45 | call to taint | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:106:37:106:45 | call to taint | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:106:37:106:45 | call to taint | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:106:37:106:45 | call to taint | params_flow.rb:98:31:98:31 | b |
-| params_flow.rb:106:37:106:45 | call to taint | params_flow.rb:98:31:98:31 | b |
-| params_flow.rb:106:37:106:45 | call to taint | params_flow.rb:102:10:102:10 | b |
 | params_flow.rb:106:37:106:45 | call to taint | params_flow.rb:106:37:106:45 | call to taint |
 | params_flow.rb:106:37:106:45 | synthetic splat argument | params_flow.rb:106:37:106:45 | synthetic splat argument |
 | params_flow.rb:106:43:106:44 | 57 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:106:43:106:44 | 57 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:106:43:106:44 | 57 | params_flow.rb:2:5:2:5 | x |
-| params_flow.rb:106:43:106:44 | 57 | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:106:43:106:44 | 57 | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:106:43:106:44 | 57 | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:106:43:106:44 | 57 | params_flow.rb:98:31:98:31 | b |
-| params_flow.rb:106:43:106:44 | 57 | params_flow.rb:98:31:98:31 | b |
-| params_flow.rb:106:43:106:44 | 57 | params_flow.rb:102:10:102:10 | b |
 | params_flow.rb:106:43:106:44 | 57 | params_flow.rb:106:37:106:45 | call to taint |
 | params_flow.rb:106:43:106:44 | 57 | params_flow.rb:106:43:106:44 | 57 |
 | params_flow.rb:108:1:112:3 | &block | params_flow.rb:108:1:112:3 | &block |
@@ -5724,52 +5565,16 @@ trackEnd
 | params_flow.rb:131:1:131:46 | call to pos_many | params_flow.rb:131:1:131:46 | call to pos_many |
 | params_flow.rb:131:10:131:14 | * ... | params_flow.rb:83:1:91:3 | synthetic splat parameter |
 | params_flow.rb:131:10:131:14 | * ... | params_flow.rb:131:10:131:14 | * ... |
-| params_flow.rb:131:17:131:25 | call to taint | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:131:17:131:25 | call to taint | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:131:17:131:25 | call to taint | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:131:17:131:25 | call to taint | params_flow.rb:83:17:83:17 | u |
-| params_flow.rb:131:17:131:25 | call to taint | params_flow.rb:83:17:83:17 | u |
-| params_flow.rb:131:17:131:25 | call to taint | params_flow.rb:85:10:85:10 | u |
 | params_flow.rb:131:17:131:25 | call to taint | params_flow.rb:131:17:131:25 | call to taint |
 | params_flow.rb:131:17:131:25 | synthetic splat argument | params_flow.rb:131:17:131:25 | synthetic splat argument |
 | params_flow.rb:131:23:131:24 | 68 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:131:23:131:24 | 68 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:131:23:131:24 | 68 | params_flow.rb:2:5:2:5 | x |
-| params_flow.rb:131:23:131:24 | 68 | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:131:23:131:24 | 68 | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:131:23:131:24 | 68 | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:131:23:131:24 | 68 | params_flow.rb:83:17:83:17 | u |
-| params_flow.rb:131:23:131:24 | 68 | params_flow.rb:83:17:83:17 | u |
-| params_flow.rb:131:23:131:24 | 68 | params_flow.rb:85:10:85:10 | u |
 | params_flow.rb:131:23:131:24 | 68 | params_flow.rb:131:17:131:25 | call to taint |
 | params_flow.rb:131:23:131:24 | 68 | params_flow.rb:131:23:131:24 | 68 |
-| params_flow.rb:131:28:131:30 | nil | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:131:28:131:30 | nil | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:131:28:131:30 | nil | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:131:28:131:30 | nil | params_flow.rb:83:20:83:20 | v |
-| params_flow.rb:131:28:131:30 | nil | params_flow.rb:83:20:83:20 | v |
-| params_flow.rb:131:28:131:30 | nil | params_flow.rb:86:10:86:10 | v |
 | params_flow.rb:131:28:131:30 | nil | params_flow.rb:131:28:131:30 | nil |
-| params_flow.rb:131:33:131:35 | nil | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:131:33:131:35 | nil | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:131:33:131:35 | nil | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:131:33:131:35 | nil | params_flow.rb:83:23:83:23 | w |
-| params_flow.rb:131:33:131:35 | nil | params_flow.rb:83:23:83:23 | w |
-| params_flow.rb:131:33:131:35 | nil | params_flow.rb:87:10:87:10 | w |
 | params_flow.rb:131:33:131:35 | nil | params_flow.rb:131:33:131:35 | nil |
-| params_flow.rb:131:38:131:40 | nil | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:131:38:131:40 | nil | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:131:38:131:40 | nil | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:131:38:131:40 | nil | params_flow.rb:83:26:83:26 | x |
-| params_flow.rb:131:38:131:40 | nil | params_flow.rb:83:26:83:26 | x |
-| params_flow.rb:131:38:131:40 | nil | params_flow.rb:88:10:88:10 | x |
 | params_flow.rb:131:38:131:40 | nil | params_flow.rb:131:38:131:40 | nil |
-| params_flow.rb:131:43:131:45 | nil | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:131:43:131:45 | nil | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:131:43:131:45 | nil | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:131:43:131:45 | nil | params_flow.rb:83:29:83:29 | y |
-| params_flow.rb:131:43:131:45 | nil | params_flow.rb:83:29:83:29 | y |
-| params_flow.rb:131:43:131:45 | nil | params_flow.rb:89:10:89:10 | y |
 | params_flow.rb:131:43:131:45 | nil | params_flow.rb:131:43:131:45 | nil |
 | params_flow.rb:133:1:135:3 | &block | params_flow.rb:133:1:135:3 | &block |
 | params_flow.rb:133:1:135:3 | self in splatall | params_flow.rb:5:1:7:3 | self (sink) |

--- a/ruby/ql/test/library-tests/dataflow/params/TypeTracker.expected
+++ b/ruby/ql/test/library-tests/dataflow/params/TypeTracker.expected
@@ -134,17 +134,6 @@ track
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element :p2 | params_flow.rb:153:1:155:3 | synthetic hash-splat parameter |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element :p3 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element :p3 | params_flow.rb:25:17:25:24 | **kwargs |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content hash-splat position :c | params_flow.rb:108:1:112:3 | synthetic hash-splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:25:17:25:24 | **kwargs |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:25:17:25:24 | **kwargs |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:139:25:139:32 | **kwargs |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:153:1:155:3 | synthetic hash-splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content hash-splat position :p3 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
-| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content hash-splat position :p3 | params_flow.rb:25:17:25:24 | **kwargs |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:14:12:14:19 | call to taint |
@@ -362,38 +351,38 @@ track
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 4 | params_flow.rb:94:1:94:48 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 4 | params_flow.rb:96:1:96:88 | synthetic splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 5 | params_flow.rb:94:1:94:48 | synthetic splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :c | params_flow.rb:114:1:114:67 | synthetic hash-splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:21:1:21:35 | synthetic hash-splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:22:1:22:35 | synthetic hash-splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:23:1:23:41 | synthetic hash-splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:35:1:35:29 | synthetic hash-splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:37:8:37:44 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:37:8:37:44 | synthetic hash-splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:38:8:38:13 | ** ... |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:40:8:40:26 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:40:8:40:26 | synthetic hash-splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:41:24:41:29 | ** ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:21:1:21:35 | synthetic hash-splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:22:1:22:35 | synthetic hash-splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:23:1:23:41 | synthetic hash-splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:37:8:37:44 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:37:8:37:44 | synthetic hash-splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:38:8:38:13 | ** ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:41:1:41:30 | synthetic hash-splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:143:10:143:34 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:143:10:143:34 | synthetic hash-splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:145:21:145:28 | ** ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:150:1:150:42 | synthetic hash-splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:157:10:157:34 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:157:10:157:34 | synthetic hash-splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:159:19:159:26 | ** ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:164:1:164:40 | synthetic hash-splat argument |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p3 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p3 | params_flow.rb:34:8:34:32 | call to [] |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p3 | params_flow.rb:34:8:34:32 | synthetic hash-splat argument |
 | params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p3 | params_flow.rb:35:23:35:28 | ** ... |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content hash-splat position :c | params_flow.rb:114:1:114:67 | synthetic hash-splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:21:1:21:35 | synthetic hash-splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:22:1:22:35 | synthetic hash-splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:23:1:23:41 | synthetic hash-splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:35:1:35:29 | synthetic hash-splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:21:1:21:35 | synthetic hash-splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:22:1:22:35 | synthetic hash-splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:23:1:23:41 | synthetic hash-splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:41:1:41:30 | synthetic hash-splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:150:1:150:42 | synthetic hash-splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:164:1:164:40 | synthetic hash-splat argument |
-| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content hash-splat position :p3 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
 | params_flow.rb:5:1:7:3 | &block | type tracker without call steps | params_flow.rb:5:1:7:3 | &block |
 | params_flow.rb:5:1:7:3 | self in sink | type tracker without call steps | params_flow.rb:5:1:7:3 | self in sink |
 | params_flow.rb:5:1:7:3 | sink | type tracker without call steps | params_flow.rb:5:1:7:3 | sink |
@@ -569,7 +558,6 @@ track
 | params_flow.rb:18:5:18:11 | call to sink | type tracker without call steps | params_flow.rb:41:1:41:30 | call to keyword |
 | params_flow.rb:18:5:18:11 | synthetic splat argument | type tracker without call steps | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:21:1:21:35 | call to keyword | type tracker without call steps | params_flow.rb:21:1:21:35 | call to keyword |
-| params_flow.rb:21:1:21:35 | synthetic hash-splat argument | type tracker with call steps | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:21:1:21:35 | synthetic hash-splat argument | type tracker without call steps | params_flow.rb:21:1:21:35 | synthetic hash-splat argument |
 | params_flow.rb:21:9:21:10 | :p1 | type tracker without call steps | params_flow.rb:21:9:21:10 | :p1 |
 | params_flow.rb:21:9:21:20 | Pair | type tracker without call steps | params_flow.rb:21:9:21:20 | Pair |
@@ -577,42 +565,37 @@ track
 | params_flow.rb:21:13:21:20 | call to taint | type tracker with call steps | params_flow.rb:16:13:16:14 | p1 |
 | params_flow.rb:21:13:21:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:21:13:21:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
-| params_flow.rb:21:13:21:20 | call to taint | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:21:13:21:20 | call to taint | type tracker without call steps | params_flow.rb:21:13:21:20 | call to taint |
-| params_flow.rb:21:13:21:20 | call to taint | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:21:1:21:35 | synthetic hash-splat argument |
+| params_flow.rb:21:13:21:20 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:21:1:21:35 | synthetic hash-splat argument |
 | params_flow.rb:21:13:21:20 | synthetic splat argument | type tracker without call steps | params_flow.rb:21:13:21:20 | synthetic splat argument |
 | params_flow.rb:21:19:21:19 | 3 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:21:19:21:19 | 3 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:21:19:21:19 | 3 | type tracker with call steps | params_flow.rb:16:13:16:14 | p1 |
 | params_flow.rb:21:19:21:19 | 3 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:21:19:21:19 | 3 | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
-| params_flow.rb:21:19:21:19 | 3 | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:21:19:21:19 | 3 | type tracker without call steps | params_flow.rb:21:13:21:20 | call to taint |
 | params_flow.rb:21:19:21:19 | 3 | type tracker without call steps | params_flow.rb:21:19:21:19 | 3 |
 | params_flow.rb:21:19:21:19 | 3 | type tracker without call steps with content element 0 | params_flow.rb:21:13:21:20 | synthetic splat argument |
-| params_flow.rb:21:19:21:19 | 3 | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:21:1:21:35 | synthetic hash-splat argument |
+| params_flow.rb:21:19:21:19 | 3 | type tracker without call steps with content element :p1 | params_flow.rb:21:1:21:35 | synthetic hash-splat argument |
 | params_flow.rb:21:23:21:24 | :p2 | type tracker without call steps | params_flow.rb:21:23:21:24 | :p2 |
 | params_flow.rb:21:23:21:34 | Pair | type tracker without call steps | params_flow.rb:21:23:21:34 | Pair |
 | params_flow.rb:21:27:21:34 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:21:27:21:34 | call to taint | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
 | params_flow.rb:21:27:21:34 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:21:27:21:34 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
-| params_flow.rb:21:27:21:34 | call to taint | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:21:27:21:34 | call to taint | type tracker without call steps | params_flow.rb:21:27:21:34 | call to taint |
-| params_flow.rb:21:27:21:34 | call to taint | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:21:1:21:35 | synthetic hash-splat argument |
+| params_flow.rb:21:27:21:34 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:21:1:21:35 | synthetic hash-splat argument |
 | params_flow.rb:21:27:21:34 | synthetic splat argument | type tracker without call steps | params_flow.rb:21:27:21:34 | synthetic splat argument |
 | params_flow.rb:21:33:21:33 | 4 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:21:33:21:33 | 4 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:21:33:21:33 | 4 | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
 | params_flow.rb:21:33:21:33 | 4 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:21:33:21:33 | 4 | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
-| params_flow.rb:21:33:21:33 | 4 | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:21:33:21:33 | 4 | type tracker without call steps | params_flow.rb:21:27:21:34 | call to taint |
 | params_flow.rb:21:33:21:33 | 4 | type tracker without call steps | params_flow.rb:21:33:21:33 | 4 |
 | params_flow.rb:21:33:21:33 | 4 | type tracker without call steps with content element 0 | params_flow.rb:21:27:21:34 | synthetic splat argument |
-| params_flow.rb:21:33:21:33 | 4 | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:21:1:21:35 | synthetic hash-splat argument |
+| params_flow.rb:21:33:21:33 | 4 | type tracker without call steps with content element :p2 | params_flow.rb:21:1:21:35 | synthetic hash-splat argument |
 | params_flow.rb:22:1:22:35 | call to keyword | type tracker without call steps | params_flow.rb:22:1:22:35 | call to keyword |
-| params_flow.rb:22:1:22:35 | synthetic hash-splat argument | type tracker with call steps | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:22:1:22:35 | synthetic hash-splat argument | type tracker without call steps | params_flow.rb:22:1:22:35 | synthetic hash-splat argument |
 | params_flow.rb:22:9:22:10 | :p2 | type tracker without call steps | params_flow.rb:22:9:22:10 | :p2 |
 | params_flow.rb:22:9:22:20 | Pair | type tracker without call steps | params_flow.rb:22:9:22:20 | Pair |
@@ -620,42 +603,37 @@ track
 | params_flow.rb:22:13:22:20 | call to taint | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
 | params_flow.rb:22:13:22:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:22:13:22:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
-| params_flow.rb:22:13:22:20 | call to taint | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:22:13:22:20 | call to taint | type tracker without call steps | params_flow.rb:22:13:22:20 | call to taint |
-| params_flow.rb:22:13:22:20 | call to taint | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:22:1:22:35 | synthetic hash-splat argument |
+| params_flow.rb:22:13:22:20 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:22:1:22:35 | synthetic hash-splat argument |
 | params_flow.rb:22:13:22:20 | synthetic splat argument | type tracker without call steps | params_flow.rb:22:13:22:20 | synthetic splat argument |
 | params_flow.rb:22:19:22:19 | 5 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:22:19:22:19 | 5 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:22:19:22:19 | 5 | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
 | params_flow.rb:22:19:22:19 | 5 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:22:19:22:19 | 5 | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
-| params_flow.rb:22:19:22:19 | 5 | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:22:19:22:19 | 5 | type tracker without call steps | params_flow.rb:22:13:22:20 | call to taint |
 | params_flow.rb:22:19:22:19 | 5 | type tracker without call steps | params_flow.rb:22:19:22:19 | 5 |
 | params_flow.rb:22:19:22:19 | 5 | type tracker without call steps with content element 0 | params_flow.rb:22:13:22:20 | synthetic splat argument |
-| params_flow.rb:22:19:22:19 | 5 | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:22:1:22:35 | synthetic hash-splat argument |
+| params_flow.rb:22:19:22:19 | 5 | type tracker without call steps with content element :p2 | params_flow.rb:22:1:22:35 | synthetic hash-splat argument |
 | params_flow.rb:22:23:22:24 | :p1 | type tracker without call steps | params_flow.rb:22:23:22:24 | :p1 |
 | params_flow.rb:22:23:22:34 | Pair | type tracker without call steps | params_flow.rb:22:23:22:34 | Pair |
 | params_flow.rb:22:27:22:34 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:22:27:22:34 | call to taint | type tracker with call steps | params_flow.rb:16:13:16:14 | p1 |
 | params_flow.rb:22:27:22:34 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:22:27:22:34 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
-| params_flow.rb:22:27:22:34 | call to taint | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:22:27:22:34 | call to taint | type tracker without call steps | params_flow.rb:22:27:22:34 | call to taint |
-| params_flow.rb:22:27:22:34 | call to taint | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:22:1:22:35 | synthetic hash-splat argument |
+| params_flow.rb:22:27:22:34 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:22:1:22:35 | synthetic hash-splat argument |
 | params_flow.rb:22:27:22:34 | synthetic splat argument | type tracker without call steps | params_flow.rb:22:27:22:34 | synthetic splat argument |
 | params_flow.rb:22:33:22:33 | 6 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:22:33:22:33 | 6 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:22:33:22:33 | 6 | type tracker with call steps | params_flow.rb:16:13:16:14 | p1 |
 | params_flow.rb:22:33:22:33 | 6 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:22:33:22:33 | 6 | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
-| params_flow.rb:22:33:22:33 | 6 | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:22:33:22:33 | 6 | type tracker without call steps | params_flow.rb:22:27:22:34 | call to taint |
 | params_flow.rb:22:33:22:33 | 6 | type tracker without call steps | params_flow.rb:22:33:22:33 | 6 |
 | params_flow.rb:22:33:22:33 | 6 | type tracker without call steps with content element 0 | params_flow.rb:22:27:22:34 | synthetic splat argument |
-| params_flow.rb:22:33:22:33 | 6 | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:22:1:22:35 | synthetic hash-splat argument |
+| params_flow.rb:22:33:22:33 | 6 | type tracker without call steps with content element :p1 | params_flow.rb:22:1:22:35 | synthetic hash-splat argument |
 | params_flow.rb:23:1:23:41 | call to keyword | type tracker without call steps | params_flow.rb:23:1:23:41 | call to keyword |
-| params_flow.rb:23:1:23:41 | synthetic hash-splat argument | type tracker with call steps | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:23:1:23:41 | synthetic hash-splat argument | type tracker without call steps | params_flow.rb:23:1:23:41 | synthetic hash-splat argument |
 | params_flow.rb:23:9:23:11 | :p2 | type tracker without call steps | params_flow.rb:23:9:23:11 | :p2 |
 | params_flow.rb:23:9:23:23 | Pair | type tracker without call steps | params_flow.rb:23:9:23:23 | Pair |
@@ -663,40 +641,36 @@ track
 | params_flow.rb:23:16:23:23 | call to taint | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
 | params_flow.rb:23:16:23:23 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:23:16:23:23 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
-| params_flow.rb:23:16:23:23 | call to taint | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:23:16:23:23 | call to taint | type tracker without call steps | params_flow.rb:23:16:23:23 | call to taint |
-| params_flow.rb:23:16:23:23 | call to taint | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:23:1:23:41 | synthetic hash-splat argument |
+| params_flow.rb:23:16:23:23 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:23:1:23:41 | synthetic hash-splat argument |
 | params_flow.rb:23:16:23:23 | synthetic splat argument | type tracker without call steps | params_flow.rb:23:16:23:23 | synthetic splat argument |
 | params_flow.rb:23:22:23:22 | 7 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:23:22:23:22 | 7 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:23:22:23:22 | 7 | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
 | params_flow.rb:23:22:23:22 | 7 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:23:22:23:22 | 7 | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
-| params_flow.rb:23:22:23:22 | 7 | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:23:22:23:22 | 7 | type tracker without call steps | params_flow.rb:23:16:23:23 | call to taint |
 | params_flow.rb:23:22:23:22 | 7 | type tracker without call steps | params_flow.rb:23:22:23:22 | 7 |
 | params_flow.rb:23:22:23:22 | 7 | type tracker without call steps with content element 0 | params_flow.rb:23:16:23:23 | synthetic splat argument |
-| params_flow.rb:23:22:23:22 | 7 | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:23:1:23:41 | synthetic hash-splat argument |
+| params_flow.rb:23:22:23:22 | 7 | type tracker without call steps with content element :p2 | params_flow.rb:23:1:23:41 | synthetic hash-splat argument |
 | params_flow.rb:23:26:23:28 | :p1 | type tracker without call steps | params_flow.rb:23:26:23:28 | :p1 |
 | params_flow.rb:23:26:23:40 | Pair | type tracker without call steps | params_flow.rb:23:26:23:40 | Pair |
 | params_flow.rb:23:33:23:40 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:23:33:23:40 | call to taint | type tracker with call steps | params_flow.rb:16:13:16:14 | p1 |
 | params_flow.rb:23:33:23:40 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:23:33:23:40 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
-| params_flow.rb:23:33:23:40 | call to taint | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:23:33:23:40 | call to taint | type tracker without call steps | params_flow.rb:23:33:23:40 | call to taint |
-| params_flow.rb:23:33:23:40 | call to taint | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:23:1:23:41 | synthetic hash-splat argument |
+| params_flow.rb:23:33:23:40 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:23:1:23:41 | synthetic hash-splat argument |
 | params_flow.rb:23:33:23:40 | synthetic splat argument | type tracker without call steps | params_flow.rb:23:33:23:40 | synthetic splat argument |
 | params_flow.rb:23:39:23:39 | 8 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:23:39:23:39 | 8 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:23:39:23:39 | 8 | type tracker with call steps | params_flow.rb:16:13:16:14 | p1 |
 | params_flow.rb:23:39:23:39 | 8 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:23:39:23:39 | 8 | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | synthetic splat argument |
-| params_flow.rb:23:39:23:39 | 8 | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:23:39:23:39 | 8 | type tracker without call steps | params_flow.rb:23:33:23:40 | call to taint |
 | params_flow.rb:23:39:23:39 | 8 | type tracker without call steps | params_flow.rb:23:39:23:39 | 8 |
 | params_flow.rb:23:39:23:39 | 8 | type tracker without call steps with content element 0 | params_flow.rb:23:33:23:40 | synthetic splat argument |
-| params_flow.rb:23:39:23:39 | 8 | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:23:1:23:41 | synthetic hash-splat argument |
+| params_flow.rb:23:39:23:39 | 8 | type tracker without call steps with content element :p1 | params_flow.rb:23:1:23:41 | synthetic hash-splat argument |
 | params_flow.rb:25:1:31:3 | &block | type tracker without call steps | params_flow.rb:25:1:31:3 | &block |
 | params_flow.rb:25:1:31:3 | kwargs | type tracker without call steps | params_flow.rb:25:1:31:3 | kwargs |
 | params_flow.rb:25:1:31:3 | self in kwargs | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
@@ -751,7 +725,6 @@ track
 | params_flow.rb:30:18:30:20 | :p4 | type tracker without call steps | params_flow.rb:30:18:30:20 | :p4 |
 | params_flow.rb:30:18:30:20 | :p4 | type tracker without call steps with content element 0 | params_flow.rb:30:11:30:21 | synthetic splat argument |
 | params_flow.rb:33:1:33:58 | call to kwargs | type tracker without call steps | params_flow.rb:33:1:33:58 | call to kwargs |
-| params_flow.rb:33:1:33:58 | synthetic hash-splat argument | type tracker with call steps | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument | type tracker with call steps | params_flow.rb:25:17:25:24 | **kwargs |
 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument | type tracker without call steps | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
 | params_flow.rb:33:8:33:9 | :p1 | type tracker without call steps | params_flow.rb:33:8:33:9 | :p1 |
@@ -762,10 +735,9 @@ track
 | params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:26:5:26:11 | synthetic splat argument |
 | params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:27:5:27:22 | synthetic splat argument |
-| params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
-| params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content element :p1 | params_flow.rb:25:17:25:24 | **kwargs |
 | params_flow.rb:33:12:33:19 | call to taint | type tracker without call steps | params_flow.rb:33:12:33:19 | call to taint |
-| params_flow.rb:33:12:33:19 | call to taint | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
+| params_flow.rb:33:12:33:19 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
 | params_flow.rb:33:12:33:19 | synthetic splat argument | type tracker without call steps | params_flow.rb:33:12:33:19 | synthetic splat argument |
 | params_flow.rb:33:18:33:18 | 9 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:33:18:33:18 | 9 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
@@ -774,66 +746,60 @@ track
 | params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content element 0 | params_flow.rb:26:5:26:11 | synthetic splat argument |
 | params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content element 0 | params_flow.rb:27:5:27:22 | synthetic splat argument |
-| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
-| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content element :p1 | params_flow.rb:25:17:25:24 | **kwargs |
 | params_flow.rb:33:18:33:18 | 9 | type tracker without call steps | params_flow.rb:33:12:33:19 | call to taint |
 | params_flow.rb:33:18:33:18 | 9 | type tracker without call steps | params_flow.rb:33:18:33:18 | 9 |
 | params_flow.rb:33:18:33:18 | 9 | type tracker without call steps with content element 0 | params_flow.rb:33:12:33:19 | synthetic splat argument |
-| params_flow.rb:33:18:33:18 | 9 | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
+| params_flow.rb:33:18:33:18 | 9 | type tracker without call steps with content element :p1 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
 | params_flow.rb:33:22:33:23 | :p2 | type tracker without call steps | params_flow.rb:33:22:33:23 | :p2 |
 | params_flow.rb:33:22:33:34 | Pair | type tracker without call steps | params_flow.rb:33:22:33:34 | Pair |
 | params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps | params_flow.rb:28:11:28:21 | ...[...] |
 | params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:28:5:28:22 | synthetic splat argument |
-| params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
-| params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps with content element :p2 | params_flow.rb:25:17:25:24 | **kwargs |
 | params_flow.rb:33:26:33:34 | call to taint | type tracker without call steps | params_flow.rb:33:26:33:34 | call to taint |
-| params_flow.rb:33:26:33:34 | call to taint | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
+| params_flow.rb:33:26:33:34 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
 | params_flow.rb:33:26:33:34 | synthetic splat argument | type tracker without call steps | params_flow.rb:33:26:33:34 | synthetic splat argument |
 | params_flow.rb:33:32:33:33 | 10 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:33:32:33:33 | 10 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:33:32:33:33 | 10 | type tracker with call steps | params_flow.rb:28:11:28:21 | ...[...] |
 | params_flow.rb:33:32:33:33 | 10 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:33:32:33:33 | 10 | type tracker with call steps with content element 0 | params_flow.rb:28:5:28:22 | synthetic splat argument |
-| params_flow.rb:33:32:33:33 | 10 | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
-| params_flow.rb:33:32:33:33 | 10 | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:32:33:33 | 10 | type tracker with call steps with content element :p2 | params_flow.rb:25:17:25:24 | **kwargs |
 | params_flow.rb:33:32:33:33 | 10 | type tracker without call steps | params_flow.rb:33:26:33:34 | call to taint |
 | params_flow.rb:33:32:33:33 | 10 | type tracker without call steps | params_flow.rb:33:32:33:33 | 10 |
 | params_flow.rb:33:32:33:33 | 10 | type tracker without call steps with content element 0 | params_flow.rb:33:26:33:34 | synthetic splat argument |
-| params_flow.rb:33:32:33:33 | 10 | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
+| params_flow.rb:33:32:33:33 | 10 | type tracker without call steps with content element :p2 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
 | params_flow.rb:33:37:33:38 | :p3 | type tracker without call steps | params_flow.rb:33:37:33:38 | :p3 |
 | params_flow.rb:33:37:33:49 | Pair | type tracker without call steps | params_flow.rb:33:37:33:49 | Pair |
 | params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps | params_flow.rb:29:11:29:21 | ...[...] |
 | params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:29:5:29:22 | synthetic splat argument |
-| params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps with content hash-splat position :p3 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
-| params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps with content hash-splat position :p3 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps with content element :p3 | params_flow.rb:25:17:25:24 | **kwargs |
 | params_flow.rb:33:41:33:49 | call to taint | type tracker without call steps | params_flow.rb:33:41:33:49 | call to taint |
-| params_flow.rb:33:41:33:49 | call to taint | type tracker without call steps with content hash-splat position :p3 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
+| params_flow.rb:33:41:33:49 | call to taint | type tracker without call steps with content element :p3 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
 | params_flow.rb:33:41:33:49 | synthetic splat argument | type tracker without call steps | params_flow.rb:33:41:33:49 | synthetic splat argument |
 | params_flow.rb:33:47:33:48 | 11 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:33:47:33:48 | 11 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:33:47:33:48 | 11 | type tracker with call steps | params_flow.rb:29:11:29:21 | ...[...] |
 | params_flow.rb:33:47:33:48 | 11 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:33:47:33:48 | 11 | type tracker with call steps with content element 0 | params_flow.rb:29:5:29:22 | synthetic splat argument |
-| params_flow.rb:33:47:33:48 | 11 | type tracker with call steps with content hash-splat position :p3 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
-| params_flow.rb:33:47:33:48 | 11 | type tracker with call steps with content hash-splat position :p3 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:47:33:48 | 11 | type tracker with call steps with content element :p3 | params_flow.rb:25:17:25:24 | **kwargs |
 | params_flow.rb:33:47:33:48 | 11 | type tracker without call steps | params_flow.rb:33:41:33:49 | call to taint |
 | params_flow.rb:33:47:33:48 | 11 | type tracker without call steps | params_flow.rb:33:47:33:48 | 11 |
 | params_flow.rb:33:47:33:48 | 11 | type tracker without call steps with content element 0 | params_flow.rb:33:41:33:49 | synthetic splat argument |
-| params_flow.rb:33:47:33:48 | 11 | type tracker without call steps with content hash-splat position :p3 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
+| params_flow.rb:33:47:33:48 | 11 | type tracker without call steps with content element :p3 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
 | params_flow.rb:33:52:33:53 | :p4 | type tracker without call steps | params_flow.rb:33:52:33:53 | :p4 |
 | params_flow.rb:33:52:33:57 | Pair | type tracker without call steps | params_flow.rb:33:52:33:57 | Pair |
 | params_flow.rb:33:56:33:57 | "" | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:33:56:33:57 | "" | type tracker with call steps | params_flow.rb:30:11:30:21 | ...[...] |
 | params_flow.rb:33:56:33:57 | "" | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:33:56:33:57 | "" | type tracker with call steps with content element 0 | params_flow.rb:30:5:30:22 | synthetic splat argument |
-| params_flow.rb:33:56:33:57 | "" | type tracker with call steps with content hash-splat position :p4 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
-| params_flow.rb:33:56:33:57 | "" | type tracker with call steps with content hash-splat position :p4 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:56:33:57 | "" | type tracker with call steps with content element :p4 | params_flow.rb:25:17:25:24 | **kwargs |
 | params_flow.rb:33:56:33:57 | "" | type tracker without call steps | params_flow.rb:33:56:33:57 | "" |
-| params_flow.rb:33:56:33:57 | "" | type tracker without call steps with content hash-splat position :p4 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
+| params_flow.rb:33:56:33:57 | "" | type tracker without call steps with content element :p4 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument |
 | params_flow.rb:34:1:34:4 | args | type tracker without call steps | params_flow.rb:34:1:34:4 | args |
 | params_flow.rb:34:8:34:32 | Hash | type tracker without call steps | params_flow.rb:34:8:34:32 | Hash |
 | params_flow.rb:34:8:34:32 | call to [] | type tracker without call steps | params_flow.rb:34:8:34:32 | call to [] |
@@ -878,7 +844,6 @@ track
 | params_flow.rb:34:29:34:30 | "" | type tracker without call steps with content element :p4 | params_flow.rb:34:8:34:32 | synthetic hash-splat argument |
 | params_flow.rb:34:29:34:30 | "" | type tracker without call steps with content element :p4 | params_flow.rb:35:23:35:28 | ** ... |
 | params_flow.rb:35:1:35:29 | call to kwargs | type tracker without call steps | params_flow.rb:35:1:35:29 | call to kwargs |
-| params_flow.rb:35:1:35:29 | synthetic hash-splat argument | type tracker with call steps | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:35:1:35:29 | synthetic hash-splat argument | type tracker with call steps | params_flow.rb:25:17:25:24 | **kwargs |
 | params_flow.rb:35:1:35:29 | synthetic hash-splat argument | type tracker without call steps | params_flow.rb:35:1:35:29 | synthetic hash-splat argument |
 | params_flow.rb:35:8:35:9 | :p1 | type tracker without call steps | params_flow.rb:35:8:35:9 | :p1 |
@@ -889,10 +854,9 @@ track
 | params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:26:5:26:11 | synthetic splat argument |
 | params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:27:5:27:22 | synthetic splat argument |
-| params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
-| params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content element :p1 | params_flow.rb:25:17:25:24 | **kwargs |
 | params_flow.rb:35:12:35:20 | call to taint | type tracker without call steps | params_flow.rb:35:12:35:20 | call to taint |
-| params_flow.rb:35:12:35:20 | call to taint | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:35:1:35:29 | synthetic hash-splat argument |
+| params_flow.rb:35:12:35:20 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:35:1:35:29 | synthetic hash-splat argument |
 | params_flow.rb:35:12:35:20 | synthetic splat argument | type tracker without call steps | params_flow.rb:35:12:35:20 | synthetic splat argument |
 | params_flow.rb:35:18:35:19 | 13 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:35:18:35:19 | 13 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
@@ -901,12 +865,11 @@ track
 | params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content element 0 | params_flow.rb:26:5:26:11 | synthetic splat argument |
 | params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content element 0 | params_flow.rb:27:5:27:22 | synthetic splat argument |
-| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
-| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content element :p1 | params_flow.rb:25:17:25:24 | **kwargs |
 | params_flow.rb:35:18:35:19 | 13 | type tracker without call steps | params_flow.rb:35:12:35:20 | call to taint |
 | params_flow.rb:35:18:35:19 | 13 | type tracker without call steps | params_flow.rb:35:18:35:19 | 13 |
 | params_flow.rb:35:18:35:19 | 13 | type tracker without call steps with content element 0 | params_flow.rb:35:12:35:20 | synthetic splat argument |
-| params_flow.rb:35:18:35:19 | 13 | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:35:1:35:29 | synthetic hash-splat argument |
+| params_flow.rb:35:18:35:19 | 13 | type tracker without call steps with content element :p1 | params_flow.rb:35:1:35:29 | synthetic hash-splat argument |
 | params_flow.rb:35:23:35:28 | ** ... | type tracker with call steps | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:35:23:35:28 | ** ... | type tracker with call steps | params_flow.rb:25:17:25:24 | **kwargs |
 | params_flow.rb:35:23:35:28 | ** ... | type tracker without call steps | params_flow.rb:35:23:35:28 | ** ... |
@@ -1005,7 +968,6 @@ track
 | params_flow.rb:40:22:40:23 | 16 | type tracker without call steps with content element :p1 | params_flow.rb:40:8:40:26 | synthetic hash-splat argument |
 | params_flow.rb:40:22:40:23 | 16 | type tracker without call steps with content element :p1 | params_flow.rb:41:24:41:29 | ** ... |
 | params_flow.rb:41:1:41:30 | call to keyword | type tracker without call steps | params_flow.rb:41:1:41:30 | call to keyword |
-| params_flow.rb:41:1:41:30 | synthetic hash-splat argument | type tracker with call steps | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:41:1:41:30 | synthetic hash-splat argument | type tracker without call steps | params_flow.rb:41:1:41:30 | synthetic hash-splat argument |
 | params_flow.rb:41:9:41:10 | :p2 | type tracker without call steps | params_flow.rb:41:9:41:10 | :p2 |
 | params_flow.rb:41:9:41:21 | Pair | type tracker without call steps | params_flow.rb:41:9:41:21 | Pair |
@@ -1013,20 +975,18 @@ track
 | params_flow.rb:41:13:41:21 | call to taint | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
 | params_flow.rb:41:13:41:21 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:41:13:41:21 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
-| params_flow.rb:41:13:41:21 | call to taint | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:41:13:41:21 | call to taint | type tracker without call steps | params_flow.rb:41:13:41:21 | call to taint |
-| params_flow.rb:41:13:41:21 | call to taint | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:41:1:41:30 | synthetic hash-splat argument |
+| params_flow.rb:41:13:41:21 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:41:1:41:30 | synthetic hash-splat argument |
 | params_flow.rb:41:13:41:21 | synthetic splat argument | type tracker without call steps | params_flow.rb:41:13:41:21 | synthetic splat argument |
 | params_flow.rb:41:19:41:20 | 17 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:41:19:41:20 | 17 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:41:19:41:20 | 17 | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
 | params_flow.rb:41:19:41:20 | 17 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:41:19:41:20 | 17 | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | synthetic splat argument |
-| params_flow.rb:41:19:41:20 | 17 | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:41:19:41:20 | 17 | type tracker without call steps | params_flow.rb:41:13:41:21 | call to taint |
 | params_flow.rb:41:19:41:20 | 17 | type tracker without call steps | params_flow.rb:41:19:41:20 | 17 |
 | params_flow.rb:41:19:41:20 | 17 | type tracker without call steps with content element 0 | params_flow.rb:41:13:41:21 | synthetic splat argument |
-| params_flow.rb:41:19:41:20 | 17 | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:41:1:41:30 | synthetic hash-splat argument |
+| params_flow.rb:41:19:41:20 | 17 | type tracker without call steps with content element :p2 | params_flow.rb:41:1:41:30 | synthetic hash-splat argument |
 | params_flow.rb:41:24:41:29 | ** ... | type tracker with call steps | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:41:24:41:29 | ** ... | type tracker without call steps | params_flow.rb:41:24:41:29 | ** ... |
 | params_flow.rb:43:1:43:4 | args | type tracker without call steps | params_flow.rb:43:1:43:4 | args |
@@ -2208,7 +2168,6 @@ track
 | params_flow.rb:111:5:111:10 | call to sink | type tracker without call steps | params_flow.rb:114:1:114:67 | call to splat_followed_by_keyword_param |
 | params_flow.rb:111:5:111:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:111:5:111:10 | synthetic splat argument |
 | params_flow.rb:114:1:114:67 | call to splat_followed_by_keyword_param | type tracker without call steps | params_flow.rb:114:1:114:67 | call to splat_followed_by_keyword_param |
-| params_flow.rb:114:1:114:67 | synthetic hash-splat argument | type tracker with call steps | params_flow.rb:108:1:112:3 | synthetic hash-splat parameter |
 | params_flow.rb:114:1:114:67 | synthetic hash-splat argument | type tracker without call steps | params_flow.rb:114:1:114:67 | synthetic hash-splat argument |
 | params_flow.rb:114:1:114:67 | synthetic splat argument | type tracker with call steps | params_flow.rb:108:1:112:3 | synthetic splat parameter |
 | params_flow.rb:114:1:114:67 | synthetic splat argument | type tracker without call steps | params_flow.rb:114:1:114:67 | synthetic splat argument |
@@ -2256,20 +2215,18 @@ track
 | params_flow.rb:114:58:114:66 | call to taint | type tracker with call steps | params_flow.rb:108:44:108:44 | c |
 | params_flow.rb:114:58:114:66 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:114:58:114:66 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:111:5:111:10 | synthetic splat argument |
-| params_flow.rb:114:58:114:66 | call to taint | type tracker with call steps with content hash-splat position :c | params_flow.rb:108:1:112:3 | synthetic hash-splat parameter |
 | params_flow.rb:114:58:114:66 | call to taint | type tracker without call steps | params_flow.rb:114:58:114:66 | call to taint |
-| params_flow.rb:114:58:114:66 | call to taint | type tracker without call steps with content hash-splat position :c | params_flow.rb:114:1:114:67 | synthetic hash-splat argument |
+| params_flow.rb:114:58:114:66 | call to taint | type tracker without call steps with content element :c | params_flow.rb:114:1:114:67 | synthetic hash-splat argument |
 | params_flow.rb:114:58:114:66 | synthetic splat argument | type tracker without call steps | params_flow.rb:114:58:114:66 | synthetic splat argument |
 | params_flow.rb:114:64:114:65 | 60 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:114:64:114:65 | 60 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:114:64:114:65 | 60 | type tracker with call steps | params_flow.rb:108:44:108:44 | c |
 | params_flow.rb:114:64:114:65 | 60 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:114:64:114:65 | 60 | type tracker with call steps with content element 0 | params_flow.rb:111:5:111:10 | synthetic splat argument |
-| params_flow.rb:114:64:114:65 | 60 | type tracker with call steps with content hash-splat position :c | params_flow.rb:108:1:112:3 | synthetic hash-splat parameter |
 | params_flow.rb:114:64:114:65 | 60 | type tracker without call steps | params_flow.rb:114:58:114:66 | call to taint |
 | params_flow.rb:114:64:114:65 | 60 | type tracker without call steps | params_flow.rb:114:64:114:65 | 60 |
 | params_flow.rb:114:64:114:65 | 60 | type tracker without call steps with content element 0 | params_flow.rb:114:58:114:66 | synthetic splat argument |
-| params_flow.rb:114:64:114:65 | 60 | type tracker without call steps with content hash-splat position :c | params_flow.rb:114:1:114:67 | synthetic hash-splat argument |
+| params_flow.rb:114:64:114:65 | 60 | type tracker without call steps with content element :c | params_flow.rb:114:1:114:67 | synthetic hash-splat argument |
 | params_flow.rb:116:1:116:1 | x | type tracker without call steps | params_flow.rb:116:1:116:1 | x |
 | params_flow.rb:116:5:116:6 | Array | type tracker without call steps | params_flow.rb:116:5:116:6 | Array |
 | params_flow.rb:116:5:116:6 | call to [] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
@@ -2699,9 +2656,9 @@ track
 | params_flow.rb:148:1:148:2 | p1 | type tracker without call steps | params_flow.rb:148:1:148:2 | p1 |
 | params_flow.rb:148:6:148:7 | Array | type tracker without call steps | params_flow.rb:148:6:148:7 | Array |
 | params_flow.rb:148:6:148:7 | call to [] | type tracker with call steps | params_flow.rb:140:5:140:15 | ...[...] |
-| params_flow.rb:148:6:148:7 | call to [] | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:139:25:139:32 | **kwargs |
+| params_flow.rb:148:6:148:7 | call to [] | type tracker with call steps with content element :p1 | params_flow.rb:139:25:139:32 | **kwargs |
 | params_flow.rb:148:6:148:7 | call to [] | type tracker without call steps | params_flow.rb:148:6:148:7 | call to [] |
-| params_flow.rb:148:6:148:7 | call to [] | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:150:1:150:42 | synthetic hash-splat argument |
+| params_flow.rb:148:6:148:7 | call to [] | type tracker without call steps with content element :p1 | params_flow.rb:150:1:150:42 | synthetic hash-splat argument |
 | params_flow.rb:149:1:149:11 | call to sink | type tracker without call steps | params_flow.rb:149:1:149:11 | call to sink |
 | params_flow.rb:149:1:149:11 | synthetic splat argument | type tracker without call steps | params_flow.rb:149:1:149:11 | synthetic splat argument |
 | params_flow.rb:149:6:149:10 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
@@ -2722,20 +2679,20 @@ track
 | params_flow.rb:150:33:150:41 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:140:5:140:15 | [post] ...[...] |
 | params_flow.rb:150:33:150:41 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:140:5:140:38 | call to insert |
 | params_flow.rb:150:33:150:41 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:140:5:140:38 | synthetic splat argument |
-| params_flow.rb:150:33:150:41 | call to taint | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:139:25:139:32 | **kwargs |
+| params_flow.rb:150:33:150:41 | call to taint | type tracker with call steps with content element :p2 | params_flow.rb:139:25:139:32 | **kwargs |
 | params_flow.rb:150:33:150:41 | call to taint | type tracker without call steps | params_flow.rb:150:33:150:41 | call to taint |
-| params_flow.rb:150:33:150:41 | call to taint | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:150:1:150:42 | synthetic hash-splat argument |
+| params_flow.rb:150:33:150:41 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:150:1:150:42 | synthetic hash-splat argument |
 | params_flow.rb:150:33:150:41 | synthetic splat argument | type tracker without call steps | params_flow.rb:150:33:150:41 | synthetic splat argument |
 | params_flow.rb:150:39:150:40 | 73 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:150:39:150:40 | 73 | type tracker with call steps | params_flow.rb:140:27:140:37 | ...[...] |
 | params_flow.rb:150:39:150:40 | 73 | type tracker with call steps with content element 0 or unknown | params_flow.rb:140:5:140:15 | [post] ...[...] |
 | params_flow.rb:150:39:150:40 | 73 | type tracker with call steps with content element 0 or unknown | params_flow.rb:140:5:140:38 | call to insert |
 | params_flow.rb:150:39:150:40 | 73 | type tracker with call steps with content element 1 | params_flow.rb:140:5:140:38 | synthetic splat argument |
-| params_flow.rb:150:39:150:40 | 73 | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:139:25:139:32 | **kwargs |
+| params_flow.rb:150:39:150:40 | 73 | type tracker with call steps with content element :p2 | params_flow.rb:139:25:139:32 | **kwargs |
 | params_flow.rb:150:39:150:40 | 73 | type tracker without call steps | params_flow.rb:150:33:150:41 | call to taint |
 | params_flow.rb:150:39:150:40 | 73 | type tracker without call steps | params_flow.rb:150:39:150:40 | 73 |
 | params_flow.rb:150:39:150:40 | 73 | type tracker without call steps with content element 0 | params_flow.rb:150:33:150:41 | synthetic splat argument |
-| params_flow.rb:150:39:150:40 | 73 | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:150:1:150:42 | synthetic hash-splat argument |
+| params_flow.rb:150:39:150:40 | 73 | type tracker without call steps with content element :p2 | params_flow.rb:150:1:150:42 | synthetic hash-splat argument |
 | params_flow.rb:151:1:151:11 | call to sink | type tracker without call steps | params_flow.rb:151:1:151:11 | call to sink |
 | params_flow.rb:151:1:151:11 | synthetic splat argument | type tracker without call steps | params_flow.rb:151:1:151:11 | synthetic splat argument |
 | params_flow.rb:151:6:151:10 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
@@ -2837,9 +2794,8 @@ track
 | params_flow.rb:162:1:162:2 | p1 | type tracker without call steps | params_flow.rb:162:1:162:2 | p1 |
 | params_flow.rb:162:6:162:7 | Array | type tracker without call steps | params_flow.rb:162:6:162:7 | Array |
 | params_flow.rb:162:6:162:7 | call to [] | type tracker with call steps | params_flow.rb:153:23:153:24 | p1 |
-| params_flow.rb:162:6:162:7 | call to [] | type tracker with call steps with content hash-splat position :p1 | params_flow.rb:153:1:155:3 | synthetic hash-splat parameter |
 | params_flow.rb:162:6:162:7 | call to [] | type tracker without call steps | params_flow.rb:162:6:162:7 | call to [] |
-| params_flow.rb:162:6:162:7 | call to [] | type tracker without call steps with content hash-splat position :p1 | params_flow.rb:164:1:164:40 | synthetic hash-splat argument |
+| params_flow.rb:162:6:162:7 | call to [] | type tracker without call steps with content element :p1 | params_flow.rb:164:1:164:40 | synthetic hash-splat argument |
 | params_flow.rb:163:1:163:11 | call to sink | type tracker without call steps | params_flow.rb:163:1:163:11 | call to sink |
 | params_flow.rb:163:1:163:11 | synthetic splat argument | type tracker without call steps | params_flow.rb:163:1:163:11 | synthetic splat argument |
 | params_flow.rb:163:6:163:10 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
@@ -2850,7 +2806,6 @@ track
 | params_flow.rb:163:9:163:9 | 0 | type tracker without call steps | params_flow.rb:163:9:163:9 | 0 |
 | params_flow.rb:163:9:163:9 | 0 | type tracker without call steps with content element 0 | params_flow.rb:163:6:163:10 | synthetic splat argument |
 | params_flow.rb:164:1:164:40 | call to keywordSideEffect | type tracker without call steps | params_flow.rb:164:1:164:40 | call to keywordSideEffect |
-| params_flow.rb:164:1:164:40 | synthetic hash-splat argument | type tracker with call steps | params_flow.rb:153:1:155:3 | synthetic hash-splat parameter |
 | params_flow.rb:164:1:164:40 | synthetic hash-splat argument | type tracker without call steps | params_flow.rb:164:1:164:40 | synthetic hash-splat argument |
 | params_flow.rb:164:19:164:20 | :p1 | type tracker without call steps | params_flow.rb:164:19:164:20 | :p1 |
 | params_flow.rb:164:19:164:24 | Pair | type tracker without call steps | params_flow.rb:164:19:164:24 | Pair |
@@ -2860,20 +2815,18 @@ track
 | params_flow.rb:164:31:164:39 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:154:5:154:6 | [post] p1 |
 | params_flow.rb:164:31:164:39 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:154:5:154:20 | call to insert |
 | params_flow.rb:164:31:164:39 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:154:5:154:20 | synthetic splat argument |
-| params_flow.rb:164:31:164:39 | call to taint | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:153:1:155:3 | synthetic hash-splat parameter |
 | params_flow.rb:164:31:164:39 | call to taint | type tracker without call steps | params_flow.rb:164:31:164:39 | call to taint |
-| params_flow.rb:164:31:164:39 | call to taint | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:164:1:164:40 | synthetic hash-splat argument |
+| params_flow.rb:164:31:164:39 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:164:1:164:40 | synthetic hash-splat argument |
 | params_flow.rb:164:31:164:39 | synthetic splat argument | type tracker without call steps | params_flow.rb:164:31:164:39 | synthetic splat argument |
 | params_flow.rb:164:37:164:38 | 75 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:164:37:164:38 | 75 | type tracker with call steps | params_flow.rb:153:28:153:29 | p2 |
 | params_flow.rb:164:37:164:38 | 75 | type tracker with call steps with content element 0 or unknown | params_flow.rb:154:5:154:6 | [post] p1 |
 | params_flow.rb:164:37:164:38 | 75 | type tracker with call steps with content element 0 or unknown | params_flow.rb:154:5:154:20 | call to insert |
 | params_flow.rb:164:37:164:38 | 75 | type tracker with call steps with content element 1 | params_flow.rb:154:5:154:20 | synthetic splat argument |
-| params_flow.rb:164:37:164:38 | 75 | type tracker with call steps with content hash-splat position :p2 | params_flow.rb:153:1:155:3 | synthetic hash-splat parameter |
 | params_flow.rb:164:37:164:38 | 75 | type tracker without call steps | params_flow.rb:164:31:164:39 | call to taint |
 | params_flow.rb:164:37:164:38 | 75 | type tracker without call steps | params_flow.rb:164:37:164:38 | 75 |
 | params_flow.rb:164:37:164:38 | 75 | type tracker without call steps with content element 0 | params_flow.rb:164:31:164:39 | synthetic splat argument |
-| params_flow.rb:164:37:164:38 | 75 | type tracker without call steps with content hash-splat position :p2 | params_flow.rb:164:1:164:40 | synthetic hash-splat argument |
+| params_flow.rb:164:37:164:38 | 75 | type tracker without call steps with content element :p2 | params_flow.rb:164:1:164:40 | synthetic hash-splat argument |
 | params_flow.rb:165:1:165:11 | call to sink | type tracker without call steps | params_flow.rb:165:1:165:11 | call to sink |
 | params_flow.rb:165:1:165:11 | synthetic splat argument | type tracker without call steps | params_flow.rb:165:1:165:11 | synthetic splat argument |
 | params_flow.rb:165:6:165:10 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
@@ -3841,7 +3794,6 @@ trackEnd
 | params_flow.rb:18:5:18:11 | call to sink | params_flow.rb:41:1:41:30 | call to keyword |
 | params_flow.rb:18:5:18:11 | synthetic splat argument | params_flow.rb:18:5:18:11 | synthetic splat argument |
 | params_flow.rb:21:1:21:35 | call to keyword | params_flow.rb:21:1:21:35 | call to keyword |
-| params_flow.rb:21:1:21:35 | synthetic hash-splat argument | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:21:1:21:35 | synthetic hash-splat argument | params_flow.rb:21:1:21:35 | synthetic hash-splat argument |
 | params_flow.rb:21:9:21:10 | :p1 | params_flow.rb:21:9:21:10 | :p1 |
 | params_flow.rb:21:9:21:20 | Pair | params_flow.rb:21:9:21:20 | Pair |
@@ -3886,7 +3838,6 @@ trackEnd
 | params_flow.rb:21:33:21:33 | 4 | params_flow.rb:21:27:21:34 | call to taint |
 | params_flow.rb:21:33:21:33 | 4 | params_flow.rb:21:33:21:33 | 4 |
 | params_flow.rb:22:1:22:35 | call to keyword | params_flow.rb:22:1:22:35 | call to keyword |
-| params_flow.rb:22:1:22:35 | synthetic hash-splat argument | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:22:1:22:35 | synthetic hash-splat argument | params_flow.rb:22:1:22:35 | synthetic hash-splat argument |
 | params_flow.rb:22:9:22:10 | :p2 | params_flow.rb:22:9:22:10 | :p2 |
 | params_flow.rb:22:9:22:20 | Pair | params_flow.rb:22:9:22:20 | Pair |
@@ -3931,7 +3882,6 @@ trackEnd
 | params_flow.rb:22:33:22:33 | 6 | params_flow.rb:22:27:22:34 | call to taint |
 | params_flow.rb:22:33:22:33 | 6 | params_flow.rb:22:33:22:33 | 6 |
 | params_flow.rb:23:1:23:41 | call to keyword | params_flow.rb:23:1:23:41 | call to keyword |
-| params_flow.rb:23:1:23:41 | synthetic hash-splat argument | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:23:1:23:41 | synthetic hash-splat argument | params_flow.rb:23:1:23:41 | synthetic hash-splat argument |
 | params_flow.rb:23:9:23:11 | :p2 | params_flow.rb:23:9:23:11 | :p2 |
 | params_flow.rb:23:9:23:23 | Pair | params_flow.rb:23:9:23:23 | Pair |
@@ -4044,7 +3994,6 @@ trackEnd
 | params_flow.rb:30:11:30:21 | synthetic splat argument | params_flow.rb:30:11:30:21 | synthetic splat argument |
 | params_flow.rb:30:18:30:20 | :p4 | params_flow.rb:30:18:30:20 | :p4 |
 | params_flow.rb:33:1:33:58 | call to kwargs | params_flow.rb:33:1:33:58 | call to kwargs |
-| params_flow.rb:33:1:33:58 | synthetic hash-splat argument | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument | params_flow.rb:25:17:25:24 | **kwargs |
 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument | params_flow.rb:25:19:25:24 | kwargs |
 | params_flow.rb:33:1:33:58 | synthetic hash-splat argument | params_flow.rb:27:11:27:16 | kwargs |
@@ -4162,7 +4111,6 @@ trackEnd
 | params_flow.rb:34:29:34:30 | "" | params_flow.rb:30:11:30:21 | ...[...] |
 | params_flow.rb:34:29:34:30 | "" | params_flow.rb:34:29:34:30 | "" |
 | params_flow.rb:35:1:35:29 | call to kwargs | params_flow.rb:35:1:35:29 | call to kwargs |
-| params_flow.rb:35:1:35:29 | synthetic hash-splat argument | params_flow.rb:25:1:31:3 | synthetic hash-splat parameter |
 | params_flow.rb:35:1:35:29 | synthetic hash-splat argument | params_flow.rb:25:17:25:24 | **kwargs |
 | params_flow.rb:35:1:35:29 | synthetic hash-splat argument | params_flow.rb:25:19:25:24 | kwargs |
 | params_flow.rb:35:1:35:29 | synthetic hash-splat argument | params_flow.rb:27:11:27:16 | kwargs |
@@ -4300,7 +4248,6 @@ trackEnd
 | params_flow.rb:40:22:40:23 | 16 | params_flow.rb:40:16:40:24 | call to taint |
 | params_flow.rb:40:22:40:23 | 16 | params_flow.rb:40:22:40:23 | 16 |
 | params_flow.rb:41:1:41:30 | call to keyword | params_flow.rb:41:1:41:30 | call to keyword |
-| params_flow.rb:41:1:41:30 | synthetic hash-splat argument | params_flow.rb:16:1:19:3 | synthetic hash-splat parameter |
 | params_flow.rb:41:1:41:30 | synthetic hash-splat argument | params_flow.rb:41:1:41:30 | synthetic hash-splat argument |
 | params_flow.rb:41:9:41:10 | :p2 | params_flow.rb:41:9:41:10 | :p2 |
 | params_flow.rb:41:9:41:21 | Pair | params_flow.rb:41:9:41:21 | Pair |
@@ -5498,7 +5445,6 @@ trackEnd
 | params_flow.rb:111:5:111:10 | call to sink | params_flow.rb:114:1:114:67 | call to splat_followed_by_keyword_param |
 | params_flow.rb:111:5:111:10 | synthetic splat argument | params_flow.rb:111:5:111:10 | synthetic splat argument |
 | params_flow.rb:114:1:114:67 | call to splat_followed_by_keyword_param | params_flow.rb:114:1:114:67 | call to splat_followed_by_keyword_param |
-| params_flow.rb:114:1:114:67 | synthetic hash-splat argument | params_flow.rb:108:1:112:3 | synthetic hash-splat parameter |
 | params_flow.rb:114:1:114:67 | synthetic hash-splat argument | params_flow.rb:114:1:114:67 | synthetic hash-splat argument |
 | params_flow.rb:114:1:114:67 | synthetic splat argument | params_flow.rb:108:1:112:3 | synthetic splat parameter |
 | params_flow.rb:114:1:114:67 | synthetic splat argument | params_flow.rb:114:1:114:67 | synthetic splat argument |
@@ -6111,7 +6057,6 @@ trackEnd
 | params_flow.rb:163:6:163:10 | synthetic splat argument | params_flow.rb:163:6:163:10 | synthetic splat argument |
 | params_flow.rb:163:9:163:9 | 0 | params_flow.rb:163:9:163:9 | 0 |
 | params_flow.rb:164:1:164:40 | call to keywordSideEffect | params_flow.rb:164:1:164:40 | call to keywordSideEffect |
-| params_flow.rb:164:1:164:40 | synthetic hash-splat argument | params_flow.rb:153:1:155:3 | synthetic hash-splat parameter |
 | params_flow.rb:164:1:164:40 | synthetic hash-splat argument | params_flow.rb:164:1:164:40 | synthetic hash-splat argument |
 | params_flow.rb:164:19:164:20 | :p1 | params_flow.rb:164:19:164:20 | :p1 |
 | params_flow.rb:164:19:164:24 | Pair | params_flow.rb:164:19:164:24 | Pair |

--- a/ruby/ql/test/library-tests/dataflow/params/TypeTracker.expected
+++ b/ruby/ql/test/library-tests/dataflow/params/TypeTracker.expected
@@ -1193,20 +1193,16 @@ track
 | params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
 | params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
 | params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
 | params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps with content element 0 or unknown | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps with content element 1 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
 | params_flow.rb:57:8:57:18 | call to [] | type tracker without call steps | params_flow.rb:57:8:57:18 | call to [] |
 | params_flow.rb:57:8:57:18 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:58:20:58:24 | * ... |
 | params_flow.rb:57:8:57:18 | call to [] | type tracker without call steps with content element 1 | params_flow.rb:58:1:58:25 | synthetic splat argument |
 | params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
 | params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
 | params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker with call steps with content element 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
 | params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker with call steps with content element 0 or unknown | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker with call steps with content element 1 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
 | params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker without call steps | params_flow.rb:57:8:57:18 | call to [] |
 | params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker without call steps | params_flow.rb:57:8:57:18 | synthetic splat argument |
 | params_flow.rb:57:8:57:18 | synthetic splat argument | type tracker without call steps with content element 0 or unknown | params_flow.rb:58:20:58:24 | * ... |
@@ -1216,7 +1212,6 @@ track
 | params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
 | params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
-| params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
 | params_flow.rb:57:9:57:17 | call to taint | type tracker without call steps | params_flow.rb:57:9:57:17 | call to taint |
 | params_flow.rb:57:9:57:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:57:8:57:18 | call to [] |
 | params_flow.rb:57:9:57:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:57:8:57:18 | synthetic splat argument |
@@ -1229,7 +1224,6 @@ track
 | params_flow.rb:57:15:57:16 | 22 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:57:15:57:16 | 22 | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
 | params_flow.rb:57:15:57:16 | 22 | type tracker with call steps with content element 0 | params_flow.rb:51:5:51:21 | synthetic splat argument |
-| params_flow.rb:57:15:57:16 | 22 | type tracker with call steps with content element 1 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
 | params_flow.rb:57:15:57:16 | 22 | type tracker without call steps | params_flow.rb:57:9:57:17 | call to taint |
 | params_flow.rb:57:15:57:16 | 22 | type tracker without call steps | params_flow.rb:57:15:57:16 | 22 |
 | params_flow.rb:57:15:57:16 | 22 | type tracker without call steps with content element 0 | params_flow.rb:57:8:57:18 | call to [] |
@@ -1238,12 +1232,10 @@ track
 | params_flow.rb:57:15:57:16 | 22 | type tracker without call steps with content element 0 | params_flow.rb:58:20:58:24 | * ... |
 | params_flow.rb:57:15:57:16 | 22 | type tracker without call steps with content element 1 | params_flow.rb:58:1:58:25 | synthetic splat argument |
 | params_flow.rb:58:1:58:25 | call to posargs | type tracker without call steps | params_flow.rb:58:1:58:25 | call to posargs |
-| params_flow.rb:58:1:58:25 | synthetic splat argument | type tracker with call steps | params_flow.rb:49:1:53:3 | synthetic splat parameter |
 | params_flow.rb:58:1:58:25 | synthetic splat argument | type tracker without call steps | params_flow.rb:58:1:58:25 | synthetic splat argument |
 | params_flow.rb:58:9:58:17 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:58:9:58:17 | call to taint | type tracker with call steps | params_flow.rb:49:13:49:14 | p1 |
 | params_flow.rb:58:9:58:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:58:9:58:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
 | params_flow.rb:58:9:58:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
 | params_flow.rb:58:9:58:17 | call to taint | type tracker without call steps | params_flow.rb:58:9:58:17 | call to taint |
 | params_flow.rb:58:9:58:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:58:1:58:25 | synthetic splat argument |
@@ -1252,7 +1244,6 @@ track
 | params_flow.rb:58:15:58:16 | 23 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:58:15:58:16 | 23 | type tracker with call steps | params_flow.rb:49:13:49:14 | p1 |
 | params_flow.rb:58:15:58:16 | 23 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:58:15:58:16 | 23 | type tracker with call steps with content element 0 | params_flow.rb:49:1:53:3 | synthetic splat parameter |
 | params_flow.rb:58:15:58:16 | 23 | type tracker with call steps with content element 0 | params_flow.rb:50:5:50:11 | synthetic splat argument |
 | params_flow.rb:58:15:58:16 | 23 | type tracker without call steps | params_flow.rb:58:9:58:17 | call to taint |
 | params_flow.rb:58:15:58:16 | 23 | type tracker without call steps | params_flow.rb:58:15:58:16 | 23 |
@@ -1826,12 +1817,10 @@ track
 | params_flow.rb:94:45:94:46 | 44 | type tracker without call steps | params_flow.rb:94:45:94:46 | 44 |
 | params_flow.rb:94:45:94:46 | 44 | type tracker without call steps with content element 0 | params_flow.rb:94:39:94:47 | synthetic splat argument |
 | params_flow.rb:96:1:96:88 | call to splatmid | type tracker without call steps | params_flow.rb:96:1:96:88 | call to splatmid |
-| params_flow.rb:96:1:96:88 | synthetic splat argument | type tracker with call steps | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:1:96:88 | synthetic splat argument | type tracker without call steps | params_flow.rb:96:1:96:88 | synthetic splat argument |
 | params_flow.rb:96:10:96:18 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:96:10:96:18 | call to taint | type tracker with call steps | params_flow.rb:69:14:69:14 | x |
 | params_flow.rb:96:10:96:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:96:10:96:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:10:96:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:70:5:70:10 | synthetic splat argument |
 | params_flow.rb:96:10:96:18 | call to taint | type tracker without call steps | params_flow.rb:96:10:96:18 | call to taint |
 | params_flow.rb:96:10:96:18 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:96:1:96:88 | synthetic splat argument |
@@ -1840,7 +1829,6 @@ track
 | params_flow.rb:96:16:96:17 | 45 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:96:16:96:17 | 45 | type tracker with call steps | params_flow.rb:69:14:69:14 | x |
 | params_flow.rb:96:16:96:17 | 45 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:96:16:96:17 | 45 | type tracker with call steps with content element 0 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:16:96:17 | 45 | type tracker with call steps with content element 0 | params_flow.rb:70:5:70:10 | synthetic splat argument |
 | params_flow.rb:96:16:96:17 | 45 | type tracker without call steps | params_flow.rb:96:10:96:18 | call to taint |
 | params_flow.rb:96:16:96:17 | 45 | type tracker without call steps | params_flow.rb:96:16:96:17 | 45 |
@@ -1850,7 +1838,6 @@ track
 | params_flow.rb:96:21:96:29 | call to taint | type tracker with call steps | params_flow.rb:69:17:69:17 | y |
 | params_flow.rb:96:21:96:29 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:96:21:96:29 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
-| params_flow.rb:96:21:96:29 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:21:96:29 | call to taint | type tracker without call steps | params_flow.rb:96:21:96:29 | call to taint |
 | params_flow.rb:96:21:96:29 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:96:1:96:88 | synthetic splat argument |
 | params_flow.rb:96:21:96:29 | synthetic splat argument | type tracker without call steps | params_flow.rb:96:21:96:29 | synthetic splat argument |
@@ -1859,23 +1846,19 @@ track
 | params_flow.rb:96:27:96:28 | 46 | type tracker with call steps | params_flow.rb:69:17:69:17 | y |
 | params_flow.rb:96:27:96:28 | 46 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
 | params_flow.rb:96:27:96:28 | 46 | type tracker with call steps with content element 0 | params_flow.rb:71:5:71:10 | synthetic splat argument |
-| params_flow.rb:96:27:96:28 | 46 | type tracker with call steps with content element 1 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:27:96:28 | 46 | type tracker without call steps | params_flow.rb:96:21:96:29 | call to taint |
 | params_flow.rb:96:27:96:28 | 46 | type tracker without call steps | params_flow.rb:96:27:96:28 | 46 |
 | params_flow.rb:96:27:96:28 | 46 | type tracker without call steps with content element 0 | params_flow.rb:96:21:96:29 | synthetic splat argument |
 | params_flow.rb:96:27:96:28 | 46 | type tracker without call steps with content element 1 | params_flow.rb:96:1:96:88 | synthetic splat argument |
 | params_flow.rb:96:32:96:65 | * ... | type tracker without call steps | params_flow.rb:96:32:96:65 | * ... |
 | params_flow.rb:96:33:96:65 | Array | type tracker without call steps | params_flow.rb:96:33:96:65 | Array |
-| params_flow.rb:96:33:96:65 | call to [] | type tracker with call steps with content element 2 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:33:96:65 | call to [] | type tracker without call steps | params_flow.rb:96:33:96:65 | call to [] |
 | params_flow.rb:96:33:96:65 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:96:32:96:65 | * ... |
 | params_flow.rb:96:33:96:65 | call to [] | type tracker without call steps with content element 2 | params_flow.rb:96:1:96:88 | synthetic splat argument |
-| params_flow.rb:96:33:96:65 | synthetic splat argument | type tracker with call steps with content element 2 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:33:96:65 | synthetic splat argument | type tracker without call steps | params_flow.rb:96:33:96:65 | call to [] |
 | params_flow.rb:96:33:96:65 | synthetic splat argument | type tracker without call steps | params_flow.rb:96:33:96:65 | synthetic splat argument |
 | params_flow.rb:96:33:96:65 | synthetic splat argument | type tracker without call steps with content element 0 or unknown | params_flow.rb:96:32:96:65 | * ... |
 | params_flow.rb:96:33:96:65 | synthetic splat argument | type tracker without call steps with content element 2 | params_flow.rb:96:1:96:88 | synthetic splat argument |
-| params_flow.rb:96:34:96:42 | call to taint | type tracker with call steps with content element 2 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:34:96:42 | call to taint | type tracker without call steps | params_flow.rb:96:34:96:42 | call to taint |
 | params_flow.rb:96:34:96:42 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:96:32:96:65 | * ... |
 | params_flow.rb:96:34:96:42 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:96:33:96:65 | call to [] |
@@ -1883,7 +1866,6 @@ track
 | params_flow.rb:96:34:96:42 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:96:1:96:88 | synthetic splat argument |
 | params_flow.rb:96:34:96:42 | synthetic splat argument | type tracker without call steps | params_flow.rb:96:34:96:42 | synthetic splat argument |
 | params_flow.rb:96:40:96:41 | 47 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:96:40:96:41 | 47 | type tracker with call steps with content element 2 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:40:96:41 | 47 | type tracker without call steps | params_flow.rb:96:34:96:42 | call to taint |
 | params_flow.rb:96:40:96:41 | 47 | type tracker without call steps | params_flow.rb:96:40:96:41 | 47 |
 | params_flow.rb:96:40:96:41 | 47 | type tracker without call steps with content element 0 | params_flow.rb:96:32:96:65 | * ... |
@@ -1891,7 +1873,6 @@ track
 | params_flow.rb:96:40:96:41 | 47 | type tracker without call steps with content element 0 | params_flow.rb:96:33:96:65 | synthetic splat argument |
 | params_flow.rb:96:40:96:41 | 47 | type tracker without call steps with content element 0 | params_flow.rb:96:34:96:42 | synthetic splat argument |
 | params_flow.rb:96:40:96:41 | 47 | type tracker without call steps with content element 2 | params_flow.rb:96:1:96:88 | synthetic splat argument |
-| params_flow.rb:96:45:96:53 | call to taint | type tracker with call steps with content element 3 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:45:96:53 | call to taint | type tracker without call steps | params_flow.rb:96:45:96:53 | call to taint |
 | params_flow.rb:96:45:96:53 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:96:32:96:65 | * ... |
 | params_flow.rb:96:45:96:53 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:96:33:96:65 | call to [] |
@@ -1899,7 +1880,6 @@ track
 | params_flow.rb:96:45:96:53 | call to taint | type tracker without call steps with content element 3 | params_flow.rb:96:1:96:88 | synthetic splat argument |
 | params_flow.rb:96:45:96:53 | synthetic splat argument | type tracker without call steps | params_flow.rb:96:45:96:53 | synthetic splat argument |
 | params_flow.rb:96:51:96:52 | 48 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:96:51:96:52 | 48 | type tracker with call steps with content element 3 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:51:96:52 | 48 | type tracker without call steps | params_flow.rb:96:45:96:53 | call to taint |
 | params_flow.rb:96:51:96:52 | 48 | type tracker without call steps | params_flow.rb:96:51:96:52 | 48 |
 | params_flow.rb:96:51:96:52 | 48 | type tracker without call steps with content element 0 | params_flow.rb:96:45:96:53 | synthetic splat argument |
@@ -1907,7 +1887,6 @@ track
 | params_flow.rb:96:51:96:52 | 48 | type tracker without call steps with content element 1 | params_flow.rb:96:33:96:65 | call to [] |
 | params_flow.rb:96:51:96:52 | 48 | type tracker without call steps with content element 1 | params_flow.rb:96:33:96:65 | synthetic splat argument |
 | params_flow.rb:96:51:96:52 | 48 | type tracker without call steps with content element 3 | params_flow.rb:96:1:96:88 | synthetic splat argument |
-| params_flow.rb:96:56:96:64 | call to taint | type tracker with call steps with content element 4 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:56:96:64 | call to taint | type tracker without call steps | params_flow.rb:96:56:96:64 | call to taint |
 | params_flow.rb:96:56:96:64 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:96:32:96:65 | * ... |
 | params_flow.rb:96:56:96:64 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:96:33:96:65 | call to [] |
@@ -1915,7 +1894,6 @@ track
 | params_flow.rb:96:56:96:64 | call to taint | type tracker without call steps with content element 4 | params_flow.rb:96:1:96:88 | synthetic splat argument |
 | params_flow.rb:96:56:96:64 | synthetic splat argument | type tracker without call steps | params_flow.rb:96:56:96:64 | synthetic splat argument |
 | params_flow.rb:96:62:96:63 | 49 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:96:62:96:63 | 49 | type tracker with call steps with content element 4 | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:62:96:63 | 49 | type tracker without call steps | params_flow.rb:96:56:96:64 | call to taint |
 | params_flow.rb:96:62:96:63 | 49 | type tracker without call steps | params_flow.rb:96:62:96:63 | 49 |
 | params_flow.rb:96:62:96:63 | 49 | type tracker without call steps with content element 0 | params_flow.rb:96:56:96:64 | synthetic splat argument |
@@ -1977,12 +1955,10 @@ track
 | params_flow.rb:102:5:102:10 | call to sink | type tracker without call steps | params_flow.rb:106:1:106:46 | call to splatmidsmall |
 | params_flow.rb:102:5:102:10 | synthetic splat argument | type tracker without call steps | params_flow.rb:102:5:102:10 | synthetic splat argument |
 | params_flow.rb:105:1:105:49 | call to splatmidsmall | type tracker without call steps | params_flow.rb:105:1:105:49 | call to splatmidsmall |
-| params_flow.rb:105:1:105:49 | synthetic splat argument | type tracker with call steps | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:105:1:105:49 | synthetic splat argument | type tracker without call steps | params_flow.rb:105:1:105:49 | synthetic splat argument |
 | params_flow.rb:105:15:105:23 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:105:15:105:23 | call to taint | type tracker with call steps | params_flow.rb:98:19:98:19 | a |
 | params_flow.rb:105:15:105:23 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:105:15:105:23 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:105:15:105:23 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:99:5:99:10 | synthetic splat argument |
 | params_flow.rb:105:15:105:23 | call to taint | type tracker without call steps | params_flow.rb:105:15:105:23 | call to taint |
 | params_flow.rb:105:15:105:23 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:105:1:105:49 | synthetic splat argument |
@@ -1991,7 +1967,6 @@ track
 | params_flow.rb:105:21:105:22 | 52 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:105:21:105:22 | 52 | type tracker with call steps | params_flow.rb:98:19:98:19 | a |
 | params_flow.rb:105:21:105:22 | 52 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | synthetic splat argument |
-| params_flow.rb:105:21:105:22 | 52 | type tracker with call steps with content element 0 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:105:21:105:22 | 52 | type tracker with call steps with content element 0 | params_flow.rb:99:5:99:10 | synthetic splat argument |
 | params_flow.rb:105:21:105:22 | 52 | type tracker without call steps | params_flow.rb:105:15:105:23 | call to taint |
 | params_flow.rb:105:21:105:22 | 52 | type tracker without call steps | params_flow.rb:105:21:105:22 | 52 |
@@ -1999,16 +1974,13 @@ track
 | params_flow.rb:105:21:105:22 | 52 | type tracker without call steps with content element 0 | params_flow.rb:105:15:105:23 | synthetic splat argument |
 | params_flow.rb:105:26:105:48 | * ... | type tracker without call steps | params_flow.rb:105:26:105:48 | * ... |
 | params_flow.rb:105:27:105:48 | Array | type tracker without call steps | params_flow.rb:105:27:105:48 | Array |
-| params_flow.rb:105:27:105:48 | call to [] | type tracker with call steps with content element 1 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:105:27:105:48 | call to [] | type tracker without call steps | params_flow.rb:105:27:105:48 | call to [] |
 | params_flow.rb:105:27:105:48 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:105:26:105:48 | * ... |
 | params_flow.rb:105:27:105:48 | call to [] | type tracker without call steps with content element 1 | params_flow.rb:105:1:105:49 | synthetic splat argument |
-| params_flow.rb:105:27:105:48 | synthetic splat argument | type tracker with call steps with content element 1 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:105:27:105:48 | synthetic splat argument | type tracker without call steps | params_flow.rb:105:27:105:48 | call to [] |
 | params_flow.rb:105:27:105:48 | synthetic splat argument | type tracker without call steps | params_flow.rb:105:27:105:48 | synthetic splat argument |
 | params_flow.rb:105:27:105:48 | synthetic splat argument | type tracker without call steps with content element 0 or unknown | params_flow.rb:105:26:105:48 | * ... |
 | params_flow.rb:105:27:105:48 | synthetic splat argument | type tracker without call steps with content element 1 | params_flow.rb:105:1:105:49 | synthetic splat argument |
-| params_flow.rb:105:28:105:36 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:105:28:105:36 | call to taint | type tracker without call steps | params_flow.rb:105:28:105:36 | call to taint |
 | params_flow.rb:105:28:105:36 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:105:26:105:48 | * ... |
 | params_flow.rb:105:28:105:36 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:105:27:105:48 | call to [] |
@@ -2016,7 +1988,6 @@ track
 | params_flow.rb:105:28:105:36 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:105:1:105:49 | synthetic splat argument |
 | params_flow.rb:105:28:105:36 | synthetic splat argument | type tracker without call steps | params_flow.rb:105:28:105:36 | synthetic splat argument |
 | params_flow.rb:105:34:105:35 | 53 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:105:34:105:35 | 53 | type tracker with call steps with content element 1 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:105:34:105:35 | 53 | type tracker without call steps | params_flow.rb:105:28:105:36 | call to taint |
 | params_flow.rb:105:34:105:35 | 53 | type tracker without call steps | params_flow.rb:105:34:105:35 | 53 |
 | params_flow.rb:105:34:105:35 | 53 | type tracker without call steps with content element 0 | params_flow.rb:105:26:105:48 | * ... |
@@ -2024,7 +1995,6 @@ track
 | params_flow.rb:105:34:105:35 | 53 | type tracker without call steps with content element 0 | params_flow.rb:105:27:105:48 | synthetic splat argument |
 | params_flow.rb:105:34:105:35 | 53 | type tracker without call steps with content element 0 | params_flow.rb:105:28:105:36 | synthetic splat argument |
 | params_flow.rb:105:34:105:35 | 53 | type tracker without call steps with content element 1 | params_flow.rb:105:1:105:49 | synthetic splat argument |
-| params_flow.rb:105:39:105:47 | call to taint | type tracker with call steps with content element 2 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:105:39:105:47 | call to taint | type tracker without call steps | params_flow.rb:105:39:105:47 | call to taint |
 | params_flow.rb:105:39:105:47 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:105:26:105:48 | * ... |
 | params_flow.rb:105:39:105:47 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:105:27:105:48 | call to [] |
@@ -2032,7 +2002,6 @@ track
 | params_flow.rb:105:39:105:47 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:105:1:105:49 | synthetic splat argument |
 | params_flow.rb:105:39:105:47 | synthetic splat argument | type tracker without call steps | params_flow.rb:105:39:105:47 | synthetic splat argument |
 | params_flow.rb:105:45:105:46 | 54 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
-| params_flow.rb:105:45:105:46 | 54 | type tracker with call steps with content element 2 | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:105:45:105:46 | 54 | type tracker without call steps | params_flow.rb:105:39:105:47 | call to taint |
 | params_flow.rb:105:45:105:46 | 54 | type tracker without call steps | params_flow.rb:105:45:105:46 | 54 |
 | params_flow.rb:105:45:105:46 | 54 | type tracker without call steps with content element 0 | params_flow.rb:105:39:105:47 | synthetic splat argument |
@@ -4438,7 +4407,6 @@ trackEnd
 | params_flow.rb:57:15:57:16 | 22 | params_flow.rb:57:9:57:17 | call to taint |
 | params_flow.rb:57:15:57:16 | 22 | params_flow.rb:57:15:57:16 | 22 |
 | params_flow.rb:58:1:58:25 | call to posargs | params_flow.rb:58:1:58:25 | call to posargs |
-| params_flow.rb:58:1:58:25 | synthetic splat argument | params_flow.rb:49:1:53:3 | synthetic splat parameter |
 | params_flow.rb:58:1:58:25 | synthetic splat argument | params_flow.rb:58:1:58:25 | synthetic splat argument |
 | params_flow.rb:58:9:58:17 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:58:9:58:17 | call to taint | params_flow.rb:5:10:5:10 | x |
@@ -5032,7 +5000,6 @@ trackEnd
 | params_flow.rb:94:45:94:46 | 44 | params_flow.rb:94:39:94:47 | call to taint |
 | params_flow.rb:94:45:94:46 | 44 | params_flow.rb:94:45:94:46 | 44 |
 | params_flow.rb:96:1:96:88 | call to splatmid | params_flow.rb:96:1:96:88 | call to splatmid |
-| params_flow.rb:96:1:96:88 | synthetic splat argument | params_flow.rb:69:1:76:3 | synthetic splat parameter |
 | params_flow.rb:96:1:96:88 | synthetic splat argument | params_flow.rb:96:1:96:88 | synthetic splat argument |
 | params_flow.rb:96:10:96:18 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:96:10:96:18 | call to taint | params_flow.rb:5:10:5:10 | x |
@@ -5166,7 +5133,6 @@ trackEnd
 | params_flow.rb:102:5:102:10 | call to sink | params_flow.rb:106:1:106:46 | call to splatmidsmall |
 | params_flow.rb:102:5:102:10 | synthetic splat argument | params_flow.rb:102:5:102:10 | synthetic splat argument |
 | params_flow.rb:105:1:105:49 | call to splatmidsmall | params_flow.rb:105:1:105:49 | call to splatmidsmall |
-| params_flow.rb:105:1:105:49 | synthetic splat argument | params_flow.rb:98:1:103:3 | synthetic splat parameter |
 | params_flow.rb:105:1:105:49 | synthetic splat argument | params_flow.rb:105:1:105:49 | synthetic splat argument |
 | params_flow.rb:105:15:105:23 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:105:15:105:23 | call to taint | params_flow.rb:5:10:5:10 | x |

--- a/ruby/ql/test/library-tests/dataflow/params/params-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/params/params-flow.expected
@@ -66,8 +66,6 @@ edges
 | params_flow.rb:47:13:47:16 | args [element 1] | params_flow.rb:47:12:47:16 | * ... [element 1] | provenance |  |
 | params_flow.rb:49:13:49:14 | p1 | params_flow.rb:50:10:50:11 | p1 | provenance |  |
 | params_flow.rb:49:17:49:24 | *posargs [element 0] | params_flow.rb:51:11:51:17 | posargs [element 0] | provenance |  |
-| params_flow.rb:49:17:49:24 | *posargs [element 0] | params_flow.rb:51:11:51:17 | posargs [element 0] | provenance |  |
-| params_flow.rb:51:11:51:17 | posargs [element 0] | params_flow.rb:51:11:51:20 | ...[...] | provenance |  |
 | params_flow.rb:51:11:51:17 | posargs [element 0] | params_flow.rb:51:11:51:20 | ...[...] | provenance |  |
 | params_flow.rb:51:11:51:20 | ...[...] | params_flow.rb:51:10:51:21 | ( ... ) | provenance |  |
 | params_flow.rb:55:9:55:17 | call to taint | params_flow.rb:49:13:49:14 | p1 | provenance |  |
@@ -76,7 +74,6 @@ edges
 | params_flow.rb:57:8:57:18 | call to [] [element 0] | params_flow.rb:57:1:57:4 | args [element 0] | provenance |  |
 | params_flow.rb:57:9:57:17 | call to taint | params_flow.rb:57:8:57:18 | call to [] [element 0] | provenance |  |
 | params_flow.rb:58:9:58:17 | call to taint | params_flow.rb:49:13:49:14 | p1 | provenance |  |
-| params_flow.rb:58:20:58:24 | * ... [element 0] | params_flow.rb:49:17:49:24 | *posargs [element 0] | provenance |  |
 | params_flow.rb:58:20:58:24 | * ... [element 0] | params_flow.rb:49:17:49:24 | *posargs [element 0] | provenance |  |
 | params_flow.rb:58:21:58:24 | args [element 0] | params_flow.rb:58:20:58:24 | * ... [element 0] | provenance |  |
 | params_flow.rb:60:1:60:4 | args [element 0] | params_flow.rb:61:10:61:13 | args [element 0] | provenance |  |
@@ -263,10 +260,8 @@ nodes
 | params_flow.rb:47:13:47:16 | args [element 1] | semmle.label | args [element 1] |
 | params_flow.rb:49:13:49:14 | p1 | semmle.label | p1 |
 | params_flow.rb:49:17:49:24 | *posargs [element 0] | semmle.label | *posargs [element 0] |
-| params_flow.rb:49:17:49:24 | *posargs [element 0] | semmle.label | *posargs [element 0] |
 | params_flow.rb:50:10:50:11 | p1 | semmle.label | p1 |
 | params_flow.rb:51:10:51:21 | ( ... ) | semmle.label | ( ... ) |
-| params_flow.rb:51:11:51:17 | posargs [element 0] | semmle.label | posargs [element 0] |
 | params_flow.rb:51:11:51:17 | posargs [element 0] | semmle.label | posargs [element 0] |
 | params_flow.rb:51:11:51:20 | ...[...] | semmle.label | ...[...] |
 | params_flow.rb:55:9:55:17 | call to taint | semmle.label | call to taint |

--- a/ruby/ql/test/library-tests/dataflow/params/params-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/params/params-flow.expected
@@ -15,17 +15,13 @@ edges
 | params_flow.rb:25:12:25:13 | p1 | params_flow.rb:26:10:26:11 | p1 | provenance |  |
 | params_flow.rb:25:17:25:24 | **kwargs [element :p2] | params_flow.rb:28:11:28:16 | kwargs [element :p2] | provenance |  |
 | params_flow.rb:25:17:25:24 | **kwargs [element :p3] | params_flow.rb:29:11:29:16 | kwargs [element :p3] | provenance |  |
-| params_flow.rb:25:17:25:24 | **kwargs [hash-splat position :p2] | params_flow.rb:28:11:28:16 | kwargs [hash-splat position :p2] | provenance |  |
-| params_flow.rb:25:17:25:24 | **kwargs [hash-splat position :p3] | params_flow.rb:29:11:29:16 | kwargs [hash-splat position :p3] | provenance |  |
 | params_flow.rb:28:11:28:16 | kwargs [element :p2] | params_flow.rb:28:11:28:21 | ...[...] | provenance |  |
-| params_flow.rb:28:11:28:16 | kwargs [hash-splat position :p2] | params_flow.rb:28:11:28:21 | ...[...] | provenance |  |
 | params_flow.rb:28:11:28:21 | ...[...] | params_flow.rb:28:10:28:22 | ( ... ) | provenance |  |
 | params_flow.rb:29:11:29:16 | kwargs [element :p3] | params_flow.rb:29:11:29:21 | ...[...] | provenance |  |
-| params_flow.rb:29:11:29:16 | kwargs [hash-splat position :p3] | params_flow.rb:29:11:29:21 | ...[...] | provenance |  |
 | params_flow.rb:29:11:29:21 | ...[...] | params_flow.rb:29:10:29:22 | ( ... ) | provenance |  |
 | params_flow.rb:33:12:33:19 | call to taint | params_flow.rb:25:12:25:13 | p1 | provenance |  |
-| params_flow.rb:33:26:33:34 | call to taint | params_flow.rb:25:17:25:24 | **kwargs [hash-splat position :p2] | provenance |  |
-| params_flow.rb:33:41:33:49 | call to taint | params_flow.rb:25:17:25:24 | **kwargs [hash-splat position :p3] | provenance |  |
+| params_flow.rb:33:26:33:34 | call to taint | params_flow.rb:25:17:25:24 | **kwargs [element :p2] | provenance |  |
+| params_flow.rb:33:41:33:49 | call to taint | params_flow.rb:25:17:25:24 | **kwargs [element :p3] | provenance |  |
 | params_flow.rb:34:1:34:4 | args [element :p3] | params_flow.rb:35:25:35:28 | args [element :p3] | provenance |  |
 | params_flow.rb:34:8:34:32 | call to [] [element :p3] | params_flow.rb:34:1:34:4 | args [element :p3] | provenance |  |
 | params_flow.rb:34:14:34:22 | call to taint | params_flow.rb:34:8:34:32 | call to [] [element :p3] | provenance |  |
@@ -206,16 +202,12 @@ nodes
 | params_flow.rb:25:12:25:13 | p1 | semmle.label | p1 |
 | params_flow.rb:25:17:25:24 | **kwargs [element :p2] | semmle.label | **kwargs [element :p2] |
 | params_flow.rb:25:17:25:24 | **kwargs [element :p3] | semmle.label | **kwargs [element :p3] |
-| params_flow.rb:25:17:25:24 | **kwargs [hash-splat position :p2] | semmle.label | **kwargs [hash-splat position :p2] |
-| params_flow.rb:25:17:25:24 | **kwargs [hash-splat position :p3] | semmle.label | **kwargs [hash-splat position :p3] |
 | params_flow.rb:26:10:26:11 | p1 | semmle.label | p1 |
 | params_flow.rb:28:10:28:22 | ( ... ) | semmle.label | ( ... ) |
 | params_flow.rb:28:11:28:16 | kwargs [element :p2] | semmle.label | kwargs [element :p2] |
-| params_flow.rb:28:11:28:16 | kwargs [hash-splat position :p2] | semmle.label | kwargs [hash-splat position :p2] |
 | params_flow.rb:28:11:28:21 | ...[...] | semmle.label | ...[...] |
 | params_flow.rb:29:10:29:22 | ( ... ) | semmle.label | ( ... ) |
 | params_flow.rb:29:11:29:16 | kwargs [element :p3] | semmle.label | kwargs [element :p3] |
-| params_flow.rb:29:11:29:16 | kwargs [hash-splat position :p3] | semmle.label | kwargs [hash-splat position :p3] |
 | params_flow.rb:29:11:29:21 | ...[...] | semmle.label | ...[...] |
 | params_flow.rb:33:12:33:19 | call to taint | semmle.label | call to taint |
 | params_flow.rb:33:26:33:34 | call to taint | semmle.label | call to taint |

--- a/ruby/ql/test/library-tests/dataflow/params/params-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/params/params-flow.expected
@@ -90,12 +90,8 @@ edges
 | params_flow.rb:67:13:67:16 | args | params_flow.rb:67:12:67:16 | * ... [element 0] | provenance |  |
 | params_flow.rb:69:14:69:14 | x | params_flow.rb:70:10:70:10 | x | provenance |  |
 | params_flow.rb:69:17:69:17 | y | params_flow.rb:71:10:71:10 | y | provenance |  |
-| params_flow.rb:69:24:69:24 | w | params_flow.rb:74:10:74:10 | w | provenance |  |
-| params_flow.rb:69:27:69:27 | r | params_flow.rb:75:10:75:10 | r | provenance |  |
 | params_flow.rb:78:10:78:18 | call to taint | params_flow.rb:69:14:69:14 | x | provenance |  |
 | params_flow.rb:78:21:78:29 | call to taint | params_flow.rb:69:17:69:17 | y | provenance |  |
-| params_flow.rb:78:43:78:51 | call to taint | params_flow.rb:69:24:69:24 | w | provenance |  |
-| params_flow.rb:78:54:78:62 | call to taint | params_flow.rb:69:27:69:27 | r | provenance |  |
 | params_flow.rb:80:1:80:4 | args [element 0] | params_flow.rb:81:22:81:25 | args [element 0] | provenance |  |
 | params_flow.rb:80:8:80:51 | call to [] [element 0] | params_flow.rb:80:1:80:4 | args [element 0] | provenance |  |
 | params_flow.rb:80:9:80:17 | call to taint | params_flow.rb:80:8:80:51 | call to [] [element 0] | provenance |  |
@@ -130,16 +126,11 @@ edges
 | params_flow.rb:94:33:94:36 | args [element 1] | params_flow.rb:94:32:94:36 | * ... [element 1] | provenance |  |
 | params_flow.rb:94:33:94:36 | args [element 2] | params_flow.rb:94:32:94:36 | * ... [element 2] | provenance |  |
 | params_flow.rb:94:33:94:36 | args [element 3] | params_flow.rb:94:32:94:36 | * ... [element 3] | provenance |  |
-| params_flow.rb:94:39:94:47 | call to taint | params_flow.rb:83:23:83:23 | w | provenance |  |
 | params_flow.rb:96:10:96:18 | call to taint | params_flow.rb:69:14:69:14 | x | provenance |  |
 | params_flow.rb:96:21:96:29 | call to taint | params_flow.rb:69:17:69:17 | y | provenance |  |
-| params_flow.rb:96:68:96:76 | call to taint | params_flow.rb:69:24:69:24 | w | provenance |  |
-| params_flow.rb:96:79:96:87 | call to taint | params_flow.rb:69:27:69:27 | r | provenance |  |
 | params_flow.rb:98:19:98:19 | a | params_flow.rb:99:10:99:10 | a | provenance |  |
-| params_flow.rb:98:31:98:31 | b | params_flow.rb:102:10:102:10 | b | provenance |  |
 | params_flow.rb:105:15:105:23 | call to taint | params_flow.rb:98:19:98:19 | a | provenance |  |
 | params_flow.rb:106:15:106:23 | call to taint | params_flow.rb:98:19:98:19 | a | provenance |  |
-| params_flow.rb:106:37:106:45 | call to taint | params_flow.rb:98:31:98:31 | b | provenance |  |
 | params_flow.rb:108:37:108:37 | a | params_flow.rb:109:10:109:10 | a | provenance |  |
 | params_flow.rb:108:40:108:41 | *b [element 0] | params_flow.rb:110:10:110:10 | b [element 0] | provenance |  |
 | params_flow.rb:108:44:108:44 | c | params_flow.rb:111:10:111:10 | c | provenance |  |
@@ -162,7 +153,6 @@ edges
 | params_flow.rb:131:10:131:14 | * ... [element 1] | params_flow.rb:83:17:83:17 | u | provenance |  |
 | params_flow.rb:131:11:131:14 | args [element 0] | params_flow.rb:131:10:131:14 | * ... [element 0] | provenance |  |
 | params_flow.rb:131:11:131:14 | args [element 1] | params_flow.rb:131:10:131:14 | * ... [element 1] | provenance |  |
-| params_flow.rb:131:17:131:25 | call to taint | params_flow.rb:83:17:83:17 | u | provenance |  |
 | params_flow.rb:133:14:133:18 | *args [element 1] | params_flow.rb:134:10:134:13 | args [element 1] | provenance |  |
 | params_flow.rb:134:10:134:13 | args [element 1] | params_flow.rb:134:10:134:16 | ...[...] | provenance |  |
 | params_flow.rb:137:10:137:43 | * ... [element 1] | params_flow.rb:133:14:133:18 | *args [element 1] | provenance |  |
@@ -283,16 +273,10 @@ nodes
 | params_flow.rb:67:13:67:16 | args | semmle.label | args |
 | params_flow.rb:69:14:69:14 | x | semmle.label | x |
 | params_flow.rb:69:17:69:17 | y | semmle.label | y |
-| params_flow.rb:69:24:69:24 | w | semmle.label | w |
-| params_flow.rb:69:27:69:27 | r | semmle.label | r |
 | params_flow.rb:70:10:70:10 | x | semmle.label | x |
 | params_flow.rb:71:10:71:10 | y | semmle.label | y |
-| params_flow.rb:74:10:74:10 | w | semmle.label | w |
-| params_flow.rb:75:10:75:10 | r | semmle.label | r |
 | params_flow.rb:78:10:78:18 | call to taint | semmle.label | call to taint |
 | params_flow.rb:78:21:78:29 | call to taint | semmle.label | call to taint |
-| params_flow.rb:78:43:78:51 | call to taint | semmle.label | call to taint |
-| params_flow.rb:78:54:78:62 | call to taint | semmle.label | call to taint |
 | params_flow.rb:80:1:80:4 | args [element 0] | semmle.label | args [element 0] |
 | params_flow.rb:80:8:80:51 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | params_flow.rb:80:9:80:17 | call to taint | semmle.label | call to taint |
@@ -333,18 +317,12 @@ nodes
 | params_flow.rb:94:33:94:36 | args [element 1] | semmle.label | args [element 1] |
 | params_flow.rb:94:33:94:36 | args [element 2] | semmle.label | args [element 2] |
 | params_flow.rb:94:33:94:36 | args [element 3] | semmle.label | args [element 3] |
-| params_flow.rb:94:39:94:47 | call to taint | semmle.label | call to taint |
 | params_flow.rb:96:10:96:18 | call to taint | semmle.label | call to taint |
 | params_flow.rb:96:21:96:29 | call to taint | semmle.label | call to taint |
-| params_flow.rb:96:68:96:76 | call to taint | semmle.label | call to taint |
-| params_flow.rb:96:79:96:87 | call to taint | semmle.label | call to taint |
 | params_flow.rb:98:19:98:19 | a | semmle.label | a |
-| params_flow.rb:98:31:98:31 | b | semmle.label | b |
 | params_flow.rb:99:10:99:10 | a | semmle.label | a |
-| params_flow.rb:102:10:102:10 | b | semmle.label | b |
 | params_flow.rb:105:15:105:23 | call to taint | semmle.label | call to taint |
 | params_flow.rb:106:15:106:23 | call to taint | semmle.label | call to taint |
-| params_flow.rb:106:37:106:45 | call to taint | semmle.label | call to taint |
 | params_flow.rb:108:37:108:37 | a | semmle.label | a |
 | params_flow.rb:108:40:108:41 | *b [element 0] | semmle.label | *b [element 0] |
 | params_flow.rb:108:44:108:44 | c | semmle.label | c |
@@ -369,7 +347,6 @@ nodes
 | params_flow.rb:131:10:131:14 | * ... [element 1] | semmle.label | * ... [element 1] |
 | params_flow.rb:131:11:131:14 | args [element 0] | semmle.label | args [element 0] |
 | params_flow.rb:131:11:131:14 | args [element 1] | semmle.label | args [element 1] |
-| params_flow.rb:131:17:131:25 | call to taint | semmle.label | call to taint |
 | params_flow.rb:133:14:133:18 | *args [element 1] | semmle.label | *args [element 1] |
 | params_flow.rb:134:10:134:13 | args [element 1] | semmle.label | args [element 1] |
 | params_flow.rb:134:10:134:16 | ...[...] | semmle.label | ...[...] |
@@ -433,23 +410,16 @@ testFailures
 | params_flow.rb:71:10:71:10 | y | params_flow.rb:78:21:78:29 | call to taint | params_flow.rb:71:10:71:10 | y | $@ | params_flow.rb:78:21:78:29 | call to taint | call to taint |
 | params_flow.rb:71:10:71:10 | y | params_flow.rb:80:9:80:17 | call to taint | params_flow.rb:71:10:71:10 | y | $@ | params_flow.rb:80:9:80:17 | call to taint | call to taint |
 | params_flow.rb:71:10:71:10 | y | params_flow.rb:96:21:96:29 | call to taint | params_flow.rb:71:10:71:10 | y | $@ | params_flow.rb:96:21:96:29 | call to taint | call to taint |
-| params_flow.rb:74:10:74:10 | w | params_flow.rb:78:43:78:51 | call to taint | params_flow.rb:74:10:74:10 | w | $@ | params_flow.rb:78:43:78:51 | call to taint | call to taint |
-| params_flow.rb:74:10:74:10 | w | params_flow.rb:96:68:96:76 | call to taint | params_flow.rb:74:10:74:10 | w | $@ | params_flow.rb:96:68:96:76 | call to taint | call to taint |
-| params_flow.rb:75:10:75:10 | r | params_flow.rb:78:54:78:62 | call to taint | params_flow.rb:75:10:75:10 | r | $@ | params_flow.rb:78:54:78:62 | call to taint | call to taint |
-| params_flow.rb:75:10:75:10 | r | params_flow.rb:96:79:96:87 | call to taint | params_flow.rb:75:10:75:10 | r | $@ | params_flow.rb:96:79:96:87 | call to taint | call to taint |
 | params_flow.rb:84:10:84:10 | t | params_flow.rb:94:10:94:18 | call to taint | params_flow.rb:84:10:84:10 | t | $@ | params_flow.rb:94:10:94:18 | call to taint | call to taint |
 | params_flow.rb:84:10:84:10 | t | params_flow.rb:130:9:130:17 | call to taint | params_flow.rb:84:10:84:10 | t | $@ | params_flow.rb:130:9:130:17 | call to taint | call to taint |
 | params_flow.rb:85:10:85:10 | u | params_flow.rb:94:21:94:29 | call to taint | params_flow.rb:85:10:85:10 | u | $@ | params_flow.rb:94:21:94:29 | call to taint | call to taint |
 | params_flow.rb:85:10:85:10 | u | params_flow.rb:130:20:130:28 | call to taint | params_flow.rb:85:10:85:10 | u | $@ | params_flow.rb:130:20:130:28 | call to taint | call to taint |
-| params_flow.rb:85:10:85:10 | u | params_flow.rb:131:17:131:25 | call to taint | params_flow.rb:85:10:85:10 | u | $@ | params_flow.rb:131:17:131:25 | call to taint | call to taint |
 | params_flow.rb:86:10:86:10 | v | params_flow.rb:93:9:93:17 | call to taint | params_flow.rb:86:10:86:10 | v | $@ | params_flow.rb:93:9:93:17 | call to taint | call to taint |
 | params_flow.rb:87:10:87:10 | w | params_flow.rb:93:20:93:28 | call to taint | params_flow.rb:87:10:87:10 | w | $@ | params_flow.rb:93:20:93:28 | call to taint | call to taint |
-| params_flow.rb:87:10:87:10 | w | params_flow.rb:94:39:94:47 | call to taint | params_flow.rb:87:10:87:10 | w | $@ | params_flow.rb:94:39:94:47 | call to taint | call to taint |
 | params_flow.rb:88:10:88:10 | x | params_flow.rb:93:31:93:39 | call to taint | params_flow.rb:88:10:88:10 | x | $@ | params_flow.rb:93:31:93:39 | call to taint | call to taint |
 | params_flow.rb:89:10:89:10 | y | params_flow.rb:93:42:93:50 | call to taint | params_flow.rb:89:10:89:10 | y | $@ | params_flow.rb:93:42:93:50 | call to taint | call to taint |
 | params_flow.rb:99:10:99:10 | a | params_flow.rb:105:15:105:23 | call to taint | params_flow.rb:99:10:99:10 | a | $@ | params_flow.rb:105:15:105:23 | call to taint | call to taint |
 | params_flow.rb:99:10:99:10 | a | params_flow.rb:106:15:106:23 | call to taint | params_flow.rb:99:10:99:10 | a | $@ | params_flow.rb:106:15:106:23 | call to taint | call to taint |
-| params_flow.rb:102:10:102:10 | b | params_flow.rb:106:37:106:45 | call to taint | params_flow.rb:102:10:102:10 | b | $@ | params_flow.rb:106:37:106:45 | call to taint | call to taint |
 | params_flow.rb:109:10:109:10 | a | params_flow.rb:114:33:114:41 | call to taint | params_flow.rb:109:10:109:10 | a | $@ | params_flow.rb:114:33:114:41 | call to taint | call to taint |
 | params_flow.rb:110:10:110:13 | ...[...] | params_flow.rb:114:44:114:52 | call to taint | params_flow.rb:110:10:110:13 | ...[...] | $@ | params_flow.rb:114:44:114:52 | call to taint | call to taint |
 | params_flow.rb:111:10:111:10 | c | params_flow.rb:114:58:114:66 | call to taint | params_flow.rb:111:10:111:10 | c | $@ | params_flow.rb:114:58:114:66 | call to taint | call to taint |

--- a/ruby/ql/test/library-tests/dataflow/params/params_flow.rb
+++ b/ruby/ql/test/library-tests/dataflow/params/params_flow.rb
@@ -69,10 +69,10 @@ splatstuff(*args)
 def splatmid(x, y, *z, w, r)
     sink x # $ hasValueFlow=27 $ hasValueFlow=32 $ hasValueFlow=45
     sink y # $ hasValueFlow=28 $ hasValueFlow=46 $ hasValueFlow=33
-    sink z[0] # MISSING: $ hasValueFlow=47 $ hasValueFlow=29 $ hasValueFlow=34
+    sink z[0] # $ MISSING: hasValueFlow=47 $ hasValueFlow=29 $ hasValueFlow=34
     sink z[1] # $ MISSING: hasValueFlow=48 $ hasValueFlow=35
-    sink w # $ hasValueFlow=30 $ hasValueFlow=50 $ MISSING: hasValueFlow=36
-    sink r # $ hasValueFlow=31 $ hasValueFlow=51 $ MISSING: hasValueFlow=37
+    sink w # $ MISSING: hasValueFlow=30 $ hasValueFlow=50 $ hasValueFlow=36
+    sink r # $ MISSING: hasValueFlow=31 $ hasValueFlow=51 $ hasValueFlow=37
 end
 
 splatmid(taint(27), taint(28), taint(29), taint(30), taint(31))
@@ -82,9 +82,9 @@ splatmid(taint(32), *args, taint(37))
 
 def pos_many(t, u, v, w, x, y, z)
     sink t # $ hasValueFlow=38 $ hasValueFlow=66
-    sink u # $ hasValueFlow=39 $ hasValueFlow=67 $ SPURIOUS: hasValueFlow=68
+    sink u # $ hasValueFlow=39 $ hasValueFlow=67
     sink v # $ hasValueFlow=40
-    sink w # $ hasValueFlow=41 $ SPURIOUS: hasValueFlow=44
+    sink w # $ hasValueFlow=41
     sink x # $ hasValueFlow=42
     sink y # $ hasValueFlow=43
     sink z # $ MISSING: hasValueFlow=44
@@ -99,7 +99,7 @@ def splatmidsmall(a, *splats, b)
     sink a # $ hasValueFlow=52 $ hasValueFlow=55
     sink splats[0] # $ MISSING: hasValueFlow=53
     sink splats[1]
-    sink b # $ hasValueFlow=57 $ MISSING: hasValueFlow=54
+    sink b # $ MISSING: hasValueFlow=57 $ hasValueFlow=54
 end
 
 splatmidsmall(taint(52), *[taint(53), taint(54)])

--- a/ruby/ql/test/library-tests/dataflow/type-tracker/TypeTracker.expected
+++ b/ruby/ql/test/library-tests/dataflow/type-tracker/TypeTracker.expected
@@ -14,12 +14,12 @@ track
 | type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:8:9:8:14 | @field |
 | type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:14:5:14:13 | call to field= |
 | type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:15:10:15:18 | call to field |
-| type_tracker.rb:2:16:2:18 | val | type tracker without call steps with content splat position 0 | type_tracker.rb:3:9:3:23 | synthetic splat argument |
-| type_tracker.rb:2:16:2:18 | val | type tracker without call steps with content splat position 0 | type_tracker.rb:15:5:15:18 | synthetic splat argument |
+| type_tracker.rb:2:16:2:18 | val | type tracker without call steps with content element 0 | type_tracker.rb:3:9:3:23 | synthetic splat argument |
+| type_tracker.rb:2:16:2:18 | val | type tracker without call steps with content element 0 | type_tracker.rb:15:5:15:18 | synthetic splat argument |
 | type_tracker.rb:3:9:3:23 | call to puts | type tracker without call steps | type_tracker.rb:3:9:3:23 | call to puts |
 | type_tracker.rb:3:9:3:23 | synthetic splat argument | type tracker without call steps | type_tracker.rb:3:9:3:23 | synthetic splat argument |
 | type_tracker.rb:3:14:3:23 | call to field | type tracker without call steps | type_tracker.rb:3:14:3:23 | call to field |
-| type_tracker.rb:3:14:3:23 | call to field | type tracker without call steps with content splat position 0 | type_tracker.rb:3:9:3:23 | synthetic splat argument |
+| type_tracker.rb:3:14:3:23 | call to field | type tracker without call steps with content element 0 | type_tracker.rb:3:9:3:23 | synthetic splat argument |
 | type_tracker.rb:4:9:4:14 | @field | type tracker without call steps | type_tracker.rb:4:9:4:14 | @field |
 | type_tracker.rb:7:5:9:7 | &block | type tracker without call steps | type_tracker.rb:7:5:9:7 | &block |
 | type_tracker.rb:7:5:9:7 | field | type tracker without call steps | type_tracker.rb:7:5:9:7 | field |
@@ -27,8 +27,8 @@ track
 | type_tracker.rb:8:9:8:14 | @field | type tracker without call steps | type_tracker.rb:3:14:3:23 | call to field |
 | type_tracker.rb:8:9:8:14 | @field | type tracker without call steps | type_tracker.rb:8:9:8:14 | @field |
 | type_tracker.rb:8:9:8:14 | @field | type tracker without call steps | type_tracker.rb:15:10:15:18 | call to field |
-| type_tracker.rb:8:9:8:14 | @field | type tracker without call steps with content splat position 0 | type_tracker.rb:3:9:3:23 | synthetic splat argument |
-| type_tracker.rb:8:9:8:14 | @field | type tracker without call steps with content splat position 0 | type_tracker.rb:15:5:15:18 | synthetic splat argument |
+| type_tracker.rb:8:9:8:14 | @field | type tracker without call steps with content element 0 | type_tracker.rb:3:9:3:23 | synthetic splat argument |
+| type_tracker.rb:8:9:8:14 | @field | type tracker without call steps with content element 0 | type_tracker.rb:15:5:15:18 | synthetic splat argument |
 | type_tracker.rb:12:1:16:3 | &block | type tracker without call steps | type_tracker.rb:12:1:16:3 | &block |
 | type_tracker.rb:12:1:16:3 | m | type tracker without call steps | type_tracker.rb:12:1:16:3 | m |
 | type_tracker.rb:12:1:16:3 | self in m | type tracker without call steps | type_tracker.rb:12:1:16:3 | self in m |
@@ -40,61 +40,56 @@ track
 | type_tracker.rb:14:5:14:7 | [post] var | type tracker with call steps | type_tracker.rb:7:5:9:7 | self in field |
 | type_tracker.rb:14:5:14:7 | [post] var | type tracker without call steps | type_tracker.rb:14:5:14:7 | [post] var |
 | type_tracker.rb:14:5:14:13 | call to field= | type tracker without call steps | type_tracker.rb:14:5:14:13 | call to field= |
-| type_tracker.rb:14:5:14:13 | synthetic splat argument | type tracker with call steps | type_tracker.rb:2:5:5:7 | synthetic splat parameter |
 | type_tracker.rb:14:5:14:13 | synthetic splat argument | type tracker without call steps | type_tracker.rb:14:5:14:13 | synthetic splat argument |
 | type_tracker.rb:14:17:14:23 | "hello" | type tracker with call steps | type_tracker.rb:2:16:2:18 | val |
 | type_tracker.rb:14:17:14:23 | "hello" | type tracker with call steps | type_tracker.rb:8:9:8:14 | @field |
 | type_tracker.rb:14:17:14:23 | "hello" | type tracker with call steps with content attribute field | type_tracker.rb:7:5:9:7 | self in field |
-| type_tracker.rb:14:17:14:23 | "hello" | type tracker with call steps with content splat position 0 | type_tracker.rb:2:5:5:7 | synthetic splat parameter |
 | type_tracker.rb:14:17:14:23 | "hello" | type tracker without call steps | type_tracker.rb:14:5:14:13 | call to field= |
 | type_tracker.rb:14:17:14:23 | "hello" | type tracker without call steps | type_tracker.rb:14:17:14:23 | "hello" |
 | type_tracker.rb:14:17:14:23 | "hello" | type tracker without call steps | type_tracker.rb:15:10:15:18 | call to field |
 | type_tracker.rb:14:17:14:23 | "hello" | type tracker without call steps with content attribute field | type_tracker.rb:14:5:14:7 | [post] var |
-| type_tracker.rb:14:17:14:23 | "hello" | type tracker without call steps with content splat position 0 | type_tracker.rb:14:5:14:13 | synthetic splat argument |
-| type_tracker.rb:14:17:14:23 | "hello" | type tracker without call steps with content splat position 0 | type_tracker.rb:15:5:15:18 | synthetic splat argument |
+| type_tracker.rb:14:17:14:23 | "hello" | type tracker without call steps with content element 0 | type_tracker.rb:14:5:14:13 | synthetic splat argument |
+| type_tracker.rb:14:17:14:23 | "hello" | type tracker without call steps with content element 0 | type_tracker.rb:15:5:15:18 | synthetic splat argument |
 | type_tracker.rb:14:17:14:23 | __synth__0 | type tracker without call steps | type_tracker.rb:14:17:14:23 | __synth__0 |
 | type_tracker.rb:15:5:15:18 | call to puts | type tracker without call steps | type_tracker.rb:15:5:15:18 | call to puts |
 | type_tracker.rb:15:5:15:18 | synthetic splat argument | type tracker without call steps | type_tracker.rb:15:5:15:18 | synthetic splat argument |
 | type_tracker.rb:15:10:15:18 | call to field | type tracker without call steps | type_tracker.rb:15:10:15:18 | call to field |
-| type_tracker.rb:15:10:15:18 | call to field | type tracker without call steps with content splat position 0 | type_tracker.rb:15:5:15:18 | synthetic splat argument |
+| type_tracker.rb:15:10:15:18 | call to field | type tracker without call steps with content element 0 | type_tracker.rb:15:5:15:18 | synthetic splat argument |
 | type_tracker.rb:18:1:21:3 | &block | type tracker without call steps | type_tracker.rb:18:1:21:3 | &block |
 | type_tracker.rb:18:1:21:3 | positional | type tracker without call steps | type_tracker.rb:18:1:21:3 | positional |
 | type_tracker.rb:18:1:21:3 | self in positional | type tracker without call steps | type_tracker.rb:18:1:21:3 | self in positional |
 | type_tracker.rb:18:1:21:3 | synthetic splat parameter | type tracker without call steps | type_tracker.rb:18:1:21:3 | synthetic splat parameter |
 | type_tracker.rb:18:16:18:17 | p1 | type tracker without call steps | type_tracker.rb:18:16:18:17 | p1 |
 | type_tracker.rb:18:16:18:17 | p1 | type tracker without call steps | type_tracker.rb:18:16:18:17 | p1 |
-| type_tracker.rb:18:16:18:17 | p1 | type tracker without call steps with content splat position 0 | type_tracker.rb:19:5:19:11 | synthetic splat argument |
+| type_tracker.rb:18:16:18:17 | p1 | type tracker without call steps with content element 0 | type_tracker.rb:19:5:19:11 | synthetic splat argument |
 | type_tracker.rb:18:20:18:21 | p2 | type tracker without call steps | type_tracker.rb:18:20:18:21 | p2 |
 | type_tracker.rb:18:20:18:21 | p2 | type tracker without call steps | type_tracker.rb:18:20:18:21 | p2 |
-| type_tracker.rb:18:20:18:21 | p2 | type tracker without call steps with content splat position 0 | type_tracker.rb:20:5:20:11 | synthetic splat argument |
+| type_tracker.rb:18:20:18:21 | p2 | type tracker without call steps with content element 0 | type_tracker.rb:20:5:20:11 | synthetic splat argument |
 | type_tracker.rb:19:5:19:11 | call to puts | type tracker without call steps | type_tracker.rb:19:5:19:11 | call to puts |
 | type_tracker.rb:19:5:19:11 | synthetic splat argument | type tracker without call steps | type_tracker.rb:19:5:19:11 | synthetic splat argument |
 | type_tracker.rb:20:5:20:11 | call to puts | type tracker without call steps | type_tracker.rb:20:5:20:11 | call to puts |
 | type_tracker.rb:20:5:20:11 | call to puts | type tracker without call steps | type_tracker.rb:23:1:23:16 | call to positional |
 | type_tracker.rb:20:5:20:11 | synthetic splat argument | type tracker without call steps | type_tracker.rb:20:5:20:11 | synthetic splat argument |
 | type_tracker.rb:23:1:23:16 | call to positional | type tracker without call steps | type_tracker.rb:23:1:23:16 | call to positional |
-| type_tracker.rb:23:1:23:16 | synthetic splat argument | type tracker with call steps | type_tracker.rb:18:1:21:3 | synthetic splat parameter |
 | type_tracker.rb:23:1:23:16 | synthetic splat argument | type tracker without call steps | type_tracker.rb:23:1:23:16 | synthetic splat argument |
 | type_tracker.rb:23:12:23:12 | 1 | type tracker with call steps | type_tracker.rb:18:16:18:17 | p1 |
-| type_tracker.rb:23:12:23:12 | 1 | type tracker with call steps with content splat position 0 | type_tracker.rb:18:1:21:3 | synthetic splat parameter |
-| type_tracker.rb:23:12:23:12 | 1 | type tracker with call steps with content splat position 0 | type_tracker.rb:19:5:19:11 | synthetic splat argument |
+| type_tracker.rb:23:12:23:12 | 1 | type tracker with call steps with content element 0 | type_tracker.rb:19:5:19:11 | synthetic splat argument |
 | type_tracker.rb:23:12:23:12 | 1 | type tracker without call steps | type_tracker.rb:23:12:23:12 | 1 |
-| type_tracker.rb:23:12:23:12 | 1 | type tracker without call steps with content splat position 0 | type_tracker.rb:23:1:23:16 | synthetic splat argument |
+| type_tracker.rb:23:12:23:12 | 1 | type tracker without call steps with content element 0 | type_tracker.rb:23:1:23:16 | synthetic splat argument |
 | type_tracker.rb:23:15:23:15 | 2 | type tracker with call steps | type_tracker.rb:18:20:18:21 | p2 |
-| type_tracker.rb:23:15:23:15 | 2 | type tracker with call steps with content splat position 0 | type_tracker.rb:20:5:20:11 | synthetic splat argument |
-| type_tracker.rb:23:15:23:15 | 2 | type tracker with call steps with content splat position 1 | type_tracker.rb:18:1:21:3 | synthetic splat parameter |
+| type_tracker.rb:23:15:23:15 | 2 | type tracker with call steps with content element 0 | type_tracker.rb:20:5:20:11 | synthetic splat argument |
 | type_tracker.rb:23:15:23:15 | 2 | type tracker without call steps | type_tracker.rb:23:15:23:15 | 2 |
-| type_tracker.rb:23:15:23:15 | 2 | type tracker without call steps with content splat position 1 | type_tracker.rb:23:1:23:16 | synthetic splat argument |
+| type_tracker.rb:23:15:23:15 | 2 | type tracker without call steps with content element 1 | type_tracker.rb:23:1:23:16 | synthetic splat argument |
 | type_tracker.rb:25:1:28:3 | &block | type tracker without call steps | type_tracker.rb:25:1:28:3 | &block |
 | type_tracker.rb:25:1:28:3 | keyword | type tracker without call steps | type_tracker.rb:25:1:28:3 | keyword |
 | type_tracker.rb:25:1:28:3 | self in keyword | type tracker without call steps | type_tracker.rb:25:1:28:3 | self in keyword |
 | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter | type tracker without call steps | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
 | type_tracker.rb:25:13:25:14 | p1 | type tracker without call steps | type_tracker.rb:25:13:25:14 | p1 |
 | type_tracker.rb:25:13:25:14 | p1 | type tracker without call steps | type_tracker.rb:25:13:25:14 | p1 |
-| type_tracker.rb:25:13:25:14 | p1 | type tracker without call steps with content splat position 0 | type_tracker.rb:26:5:26:11 | synthetic splat argument |
+| type_tracker.rb:25:13:25:14 | p1 | type tracker without call steps with content element 0 | type_tracker.rb:26:5:26:11 | synthetic splat argument |
 | type_tracker.rb:25:18:25:19 | p2 | type tracker without call steps | type_tracker.rb:25:18:25:19 | p2 |
 | type_tracker.rb:25:18:25:19 | p2 | type tracker without call steps | type_tracker.rb:25:18:25:19 | p2 |
-| type_tracker.rb:25:18:25:19 | p2 | type tracker without call steps with content splat position 0 | type_tracker.rb:27:5:27:11 | synthetic splat argument |
+| type_tracker.rb:25:18:25:19 | p2 | type tracker without call steps with content element 0 | type_tracker.rb:27:5:27:11 | synthetic splat argument |
 | type_tracker.rb:26:5:26:11 | call to puts | type tracker without call steps | type_tracker.rb:26:5:26:11 | call to puts |
 | type_tracker.rb:26:5:26:11 | synthetic splat argument | type tracker without call steps | type_tracker.rb:26:5:26:11 | synthetic splat argument |
 | type_tracker.rb:27:5:27:11 | call to puts | type tracker without call steps | type_tracker.rb:27:5:27:11 | call to puts |
@@ -108,15 +103,15 @@ track
 | type_tracker.rb:30:9:30:10 | :p1 | type tracker without call steps | type_tracker.rb:30:9:30:10 | :p1 |
 | type_tracker.rb:30:9:30:13 | Pair | type tracker without call steps | type_tracker.rb:30:9:30:13 | Pair |
 | type_tracker.rb:30:13:30:13 | 3 | type tracker with call steps | type_tracker.rb:25:13:25:14 | p1 |
+| type_tracker.rb:30:13:30:13 | 3 | type tracker with call steps with content element 0 | type_tracker.rb:26:5:26:11 | synthetic splat argument |
 | type_tracker.rb:30:13:30:13 | 3 | type tracker with call steps with content hash-splat position :p1 | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
-| type_tracker.rb:30:13:30:13 | 3 | type tracker with call steps with content splat position 0 | type_tracker.rb:26:5:26:11 | synthetic splat argument |
 | type_tracker.rb:30:13:30:13 | 3 | type tracker without call steps | type_tracker.rb:30:13:30:13 | 3 |
 | type_tracker.rb:30:13:30:13 | 3 | type tracker without call steps with content hash-splat position :p1 | type_tracker.rb:30:1:30:21 | synthetic hash-splat argument |
 | type_tracker.rb:30:16:30:17 | :p2 | type tracker without call steps | type_tracker.rb:30:16:30:17 | :p2 |
 | type_tracker.rb:30:16:30:20 | Pair | type tracker without call steps | type_tracker.rb:30:16:30:20 | Pair |
 | type_tracker.rb:30:20:30:20 | 4 | type tracker with call steps | type_tracker.rb:25:18:25:19 | p2 |
+| type_tracker.rb:30:20:30:20 | 4 | type tracker with call steps with content element 0 | type_tracker.rb:27:5:27:11 | synthetic splat argument |
 | type_tracker.rb:30:20:30:20 | 4 | type tracker with call steps with content hash-splat position :p2 | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
-| type_tracker.rb:30:20:30:20 | 4 | type tracker with call steps with content splat position 0 | type_tracker.rb:27:5:27:11 | synthetic splat argument |
 | type_tracker.rb:30:20:30:20 | 4 | type tracker without call steps | type_tracker.rb:30:20:30:20 | 4 |
 | type_tracker.rb:30:20:30:20 | 4 | type tracker without call steps with content hash-splat position :p2 | type_tracker.rb:30:1:30:21 | synthetic hash-splat argument |
 | type_tracker.rb:31:1:31:21 | call to keyword | type tracker without call steps | type_tracker.rb:31:1:31:21 | call to keyword |
@@ -125,15 +120,15 @@ track
 | type_tracker.rb:31:9:31:10 | :p2 | type tracker without call steps | type_tracker.rb:31:9:31:10 | :p2 |
 | type_tracker.rb:31:9:31:13 | Pair | type tracker without call steps | type_tracker.rb:31:9:31:13 | Pair |
 | type_tracker.rb:31:13:31:13 | 5 | type tracker with call steps | type_tracker.rb:25:18:25:19 | p2 |
+| type_tracker.rb:31:13:31:13 | 5 | type tracker with call steps with content element 0 | type_tracker.rb:27:5:27:11 | synthetic splat argument |
 | type_tracker.rb:31:13:31:13 | 5 | type tracker with call steps with content hash-splat position :p2 | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
-| type_tracker.rb:31:13:31:13 | 5 | type tracker with call steps with content splat position 0 | type_tracker.rb:27:5:27:11 | synthetic splat argument |
 | type_tracker.rb:31:13:31:13 | 5 | type tracker without call steps | type_tracker.rb:31:13:31:13 | 5 |
 | type_tracker.rb:31:13:31:13 | 5 | type tracker without call steps with content hash-splat position :p2 | type_tracker.rb:31:1:31:21 | synthetic hash-splat argument |
 | type_tracker.rb:31:16:31:17 | :p1 | type tracker without call steps | type_tracker.rb:31:16:31:17 | :p1 |
 | type_tracker.rb:31:16:31:20 | Pair | type tracker without call steps | type_tracker.rb:31:16:31:20 | Pair |
 | type_tracker.rb:31:20:31:20 | 6 | type tracker with call steps | type_tracker.rb:25:13:25:14 | p1 |
+| type_tracker.rb:31:20:31:20 | 6 | type tracker with call steps with content element 0 | type_tracker.rb:26:5:26:11 | synthetic splat argument |
 | type_tracker.rb:31:20:31:20 | 6 | type tracker with call steps with content hash-splat position :p1 | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
-| type_tracker.rb:31:20:31:20 | 6 | type tracker with call steps with content splat position 0 | type_tracker.rb:26:5:26:11 | synthetic splat argument |
 | type_tracker.rb:31:20:31:20 | 6 | type tracker without call steps | type_tracker.rb:31:20:31:20 | 6 |
 | type_tracker.rb:31:20:31:20 | 6 | type tracker without call steps with content hash-splat position :p1 | type_tracker.rb:31:1:31:21 | synthetic hash-splat argument |
 | type_tracker.rb:32:1:32:27 | call to keyword | type tracker without call steps | type_tracker.rb:32:1:32:27 | call to keyword |
@@ -142,15 +137,15 @@ track
 | type_tracker.rb:32:9:32:11 | :p2 | type tracker without call steps | type_tracker.rb:32:9:32:11 | :p2 |
 | type_tracker.rb:32:9:32:16 | Pair | type tracker without call steps | type_tracker.rb:32:9:32:16 | Pair |
 | type_tracker.rb:32:16:32:16 | 7 | type tracker with call steps | type_tracker.rb:25:18:25:19 | p2 |
+| type_tracker.rb:32:16:32:16 | 7 | type tracker with call steps with content element 0 | type_tracker.rb:27:5:27:11 | synthetic splat argument |
 | type_tracker.rb:32:16:32:16 | 7 | type tracker with call steps with content hash-splat position :p2 | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
-| type_tracker.rb:32:16:32:16 | 7 | type tracker with call steps with content splat position 0 | type_tracker.rb:27:5:27:11 | synthetic splat argument |
 | type_tracker.rb:32:16:32:16 | 7 | type tracker without call steps | type_tracker.rb:32:16:32:16 | 7 |
 | type_tracker.rb:32:16:32:16 | 7 | type tracker without call steps with content hash-splat position :p2 | type_tracker.rb:32:1:32:27 | synthetic hash-splat argument |
 | type_tracker.rb:32:19:32:21 | :p1 | type tracker without call steps | type_tracker.rb:32:19:32:21 | :p1 |
 | type_tracker.rb:32:19:32:26 | Pair | type tracker without call steps | type_tracker.rb:32:19:32:26 | Pair |
 | type_tracker.rb:32:26:32:26 | 8 | type tracker with call steps | type_tracker.rb:25:13:25:14 | p1 |
+| type_tracker.rb:32:26:32:26 | 8 | type tracker with call steps with content element 0 | type_tracker.rb:26:5:26:11 | synthetic splat argument |
 | type_tracker.rb:32:26:32:26 | 8 | type tracker with call steps with content hash-splat position :p1 | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
-| type_tracker.rb:32:26:32:26 | 8 | type tracker with call steps with content splat position 0 | type_tracker.rb:26:5:26:11 | synthetic splat argument |
 | type_tracker.rb:32:26:32:26 | 8 | type tracker without call steps | type_tracker.rb:32:26:32:26 | 8 |
 | type_tracker.rb:32:26:32:26 | 8 | type tracker without call steps with content hash-splat position :p1 | type_tracker.rb:32:1:32:27 | synthetic hash-splat argument |
 | type_tracker.rb:34:1:53:3 | &block | type tracker without call steps | type_tracker.rb:34:1:53:3 | &block |
@@ -169,18 +164,18 @@ track
 | type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element 0 | type_tracker.rb:35:11:35:15 | synthetic splat argument |
 | type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element 0 or unknown | type_tracker.rb:43:5:43:10 | [post] array2 |
 | type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element 0 or unknown | type_tracker.rb:47:5:47:10 | [post] array3 |
-| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content splat position 1 | type_tracker.rb:39:5:39:12 | synthetic splat argument |
-| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content splat position 1 | type_tracker.rb:43:5:43:13 | synthetic splat argument |
-| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content splat position 1 | type_tracker.rb:47:5:47:13 | synthetic splat argument |
-| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content splat position 1 | type_tracker.rb:51:5:51:13 | synthetic splat argument |
+| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element 1 | type_tracker.rb:39:5:39:12 | synthetic splat argument |
+| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element 1 | type_tracker.rb:43:5:43:13 | synthetic splat argument |
+| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element 1 | type_tracker.rb:47:5:47:13 | synthetic splat argument |
+| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element 1 | type_tracker.rb:51:5:51:13 | synthetic splat argument |
 | type_tracker.rb:34:23:34:23 | y | type tracker without call steps | type_tracker.rb:34:23:34:23 | y |
 | type_tracker.rb:34:23:34:23 | y | type tracker without call steps | type_tracker.rb:34:23:34:23 | y |
-| type_tracker.rb:34:23:34:23 | y | type tracker without call steps with content splat position 0 | type_tracker.rb:39:5:39:12 | synthetic splat argument |
-| type_tracker.rb:34:23:34:23 | y | type tracker without call steps with content splat position 0 | type_tracker.rb:44:5:44:13 | synthetic splat argument |
-| type_tracker.rb:34:23:34:23 | y | type tracker without call steps with content splat position 0 | type_tracker.rb:51:5:51:13 | synthetic splat argument |
+| type_tracker.rb:34:23:34:23 | y | type tracker without call steps with content element 0 | type_tracker.rb:39:5:39:12 | synthetic splat argument |
+| type_tracker.rb:34:23:34:23 | y | type tracker without call steps with content element 0 | type_tracker.rb:44:5:44:13 | synthetic splat argument |
+| type_tracker.rb:34:23:34:23 | y | type tracker without call steps with content element 0 | type_tracker.rb:51:5:51:13 | synthetic splat argument |
 | type_tracker.rb:34:26:34:26 | z | type tracker without call steps | type_tracker.rb:34:26:34:26 | z |
 | type_tracker.rb:34:26:34:26 | z | type tracker without call steps | type_tracker.rb:34:26:34:26 | z |
-| type_tracker.rb:34:26:34:26 | z | type tracker without call steps with content splat position 0 | type_tracker.rb:52:5:52:13 | synthetic splat argument |
+| type_tracker.rb:34:26:34:26 | z | type tracker without call steps with content element 0 | type_tracker.rb:52:5:52:13 | synthetic splat argument |
 | type_tracker.rb:35:5:35:7 | tmp | type tracker without call steps | type_tracker.rb:35:5:35:7 | tmp |
 | type_tracker.rb:35:11:35:15 | Array | type tracker without call steps | type_tracker.rb:35:11:35:15 | Array |
 | type_tracker.rb:35:11:35:15 | call to [] | type tracker without call steps | type_tracker.rb:35:11:35:15 | call to [] |
@@ -189,7 +184,7 @@ track
 | type_tracker.rb:36:5:36:10 | ...[...] | type tracker without call steps | type_tracker.rb:36:5:36:10 | ...[...] |
 | type_tracker.rb:36:5:36:10 | synthetic splat argument | type tracker without call steps | type_tracker.rb:36:5:36:10 | synthetic splat argument |
 | type_tracker.rb:36:9:36:9 | 0 | type tracker without call steps | type_tracker.rb:36:9:36:9 | 0 |
-| type_tracker.rb:36:9:36:9 | 0 | type tracker without call steps with content splat position 0 | type_tracker.rb:36:5:36:10 | synthetic splat argument |
+| type_tracker.rb:36:9:36:9 | 0 | type tracker without call steps with content element 0 | type_tracker.rb:36:5:36:10 | synthetic splat argument |
 | type_tracker.rb:38:5:38:9 | array | type tracker without call steps | type_tracker.rb:38:5:38:9 | array |
 | type_tracker.rb:38:13:38:25 | Array | type tracker without call steps | type_tracker.rb:38:13:38:25 | Array |
 | type_tracker.rb:38:13:38:25 | call to [] | type tracker without call steps | type_tracker.rb:38:13:38:25 | call to [] |
@@ -221,7 +216,7 @@ track
 | type_tracker.rb:40:5:40:12 | ...[...] | type tracker without call steps | type_tracker.rb:40:5:40:12 | ...[...] |
 | type_tracker.rb:40:5:40:12 | synthetic splat argument | type tracker without call steps | type_tracker.rb:40:5:40:12 | synthetic splat argument |
 | type_tracker.rb:40:11:40:11 | 0 | type tracker without call steps | type_tracker.rb:40:11:40:11 | 0 |
-| type_tracker.rb:40:11:40:11 | 0 | type tracker without call steps with content splat position 0 | type_tracker.rb:40:5:40:12 | synthetic splat argument |
+| type_tracker.rb:40:11:40:11 | 0 | type tracker without call steps with content element 0 | type_tracker.rb:40:5:40:12 | synthetic splat argument |
 | type_tracker.rb:42:5:42:10 | array2 | type tracker without call steps | type_tracker.rb:42:5:42:10 | array2 |
 | type_tracker.rb:42:14:42:26 | Array | type tracker without call steps | type_tracker.rb:42:14:42:26 | Array |
 | type_tracker.rb:42:14:42:26 | call to [] | type tracker without call steps | type_tracker.rb:42:14:42:26 | call to [] |
@@ -263,7 +258,7 @@ track
 | type_tracker.rb:43:5:43:13 | call to []= | type tracker without call steps | type_tracker.rb:43:5:43:13 | call to []= |
 | type_tracker.rb:43:5:43:13 | synthetic splat argument | type tracker without call steps | type_tracker.rb:43:5:43:13 | synthetic splat argument |
 | type_tracker.rb:43:12:43:12 | 0 | type tracker without call steps | type_tracker.rb:43:12:43:12 | 0 |
-| type_tracker.rb:43:12:43:12 | 0 | type tracker without call steps with content splat position 0 | type_tracker.rb:43:5:43:13 | synthetic splat argument |
+| type_tracker.rb:43:12:43:12 | 0 | type tracker without call steps with content element 0 | type_tracker.rb:43:5:43:13 | synthetic splat argument |
 | type_tracker.rb:43:17:43:19 | __synth__0 | type tracker without call steps | type_tracker.rb:43:17:43:19 | __synth__0 |
 | type_tracker.rb:44:5:44:13 | ...[...] | type tracker without call steps | type_tracker.rb:44:5:44:13 | ...[...] |
 | type_tracker.rb:44:5:44:13 | synthetic splat argument | type tracker without call steps | type_tracker.rb:44:5:44:13 | synthetic splat argument |
@@ -303,12 +298,12 @@ track
 | type_tracker.rb:47:5:47:13 | call to []= | type tracker without call steps | type_tracker.rb:47:5:47:13 | call to []= |
 | type_tracker.rb:47:5:47:13 | synthetic splat argument | type tracker without call steps | type_tracker.rb:47:5:47:13 | synthetic splat argument |
 | type_tracker.rb:47:12:47:12 | 0 | type tracker without call steps | type_tracker.rb:47:12:47:12 | 0 |
-| type_tracker.rb:47:12:47:12 | 0 | type tracker without call steps with content splat position 0 | type_tracker.rb:47:5:47:13 | synthetic splat argument |
+| type_tracker.rb:47:12:47:12 | 0 | type tracker without call steps with content element 0 | type_tracker.rb:47:5:47:13 | synthetic splat argument |
 | type_tracker.rb:47:17:47:19 | __synth__0 | type tracker without call steps | type_tracker.rb:47:17:47:19 | __synth__0 |
 | type_tracker.rb:48:5:48:13 | ...[...] | type tracker without call steps | type_tracker.rb:48:5:48:13 | ...[...] |
 | type_tracker.rb:48:5:48:13 | synthetic splat argument | type tracker without call steps | type_tracker.rb:48:5:48:13 | synthetic splat argument |
 | type_tracker.rb:48:12:48:12 | 1 | type tracker without call steps | type_tracker.rb:48:12:48:12 | 1 |
-| type_tracker.rb:48:12:48:12 | 1 | type tracker without call steps with content splat position 0 | type_tracker.rb:48:5:48:13 | synthetic splat argument |
+| type_tracker.rb:48:12:48:12 | 1 | type tracker without call steps with content element 0 | type_tracker.rb:48:5:48:13 | synthetic splat argument |
 | type_tracker.rb:50:5:50:10 | array4 | type tracker without call steps | type_tracker.rb:50:5:50:10 | array4 |
 | type_tracker.rb:50:14:50:26 | Array | type tracker without call steps | type_tracker.rb:50:14:50:26 | Array |
 | type_tracker.rb:50:14:50:26 | call to [] | type tracker without call steps | type_tracker.rb:50:14:50:26 | call to [] |
@@ -419,7 +414,6 @@ trackEnd
 | type_tracker.rb:14:5:14:7 | [post] var | type_tracker.rb:14:5:14:7 | [post] var |
 | type_tracker.rb:14:5:14:7 | [post] var | type_tracker.rb:15:10:15:12 | var |
 | type_tracker.rb:14:5:14:13 | call to field= | type_tracker.rb:14:5:14:13 | call to field= |
-| type_tracker.rb:14:5:14:13 | synthetic splat argument | type_tracker.rb:2:5:5:7 | synthetic splat parameter |
 | type_tracker.rb:14:5:14:13 | synthetic splat argument | type_tracker.rb:14:5:14:13 | synthetic splat argument |
 | type_tracker.rb:14:17:14:23 | "hello" | type_tracker.rb:2:16:2:18 | val |
 | type_tracker.rb:14:17:14:23 | "hello" | type_tracker.rb:2:16:2:18 | val |
@@ -458,7 +452,6 @@ trackEnd
 | type_tracker.rb:20:5:20:11 | call to puts | type_tracker.rb:23:1:23:16 | call to positional |
 | type_tracker.rb:20:5:20:11 | synthetic splat argument | type_tracker.rb:20:5:20:11 | synthetic splat argument |
 | type_tracker.rb:23:1:23:16 | call to positional | type_tracker.rb:23:1:23:16 | call to positional |
-| type_tracker.rb:23:1:23:16 | synthetic splat argument | type_tracker.rb:18:1:21:3 | synthetic splat parameter |
 | type_tracker.rb:23:1:23:16 | synthetic splat argument | type_tracker.rb:23:1:23:16 | synthetic splat argument |
 | type_tracker.rb:23:12:23:12 | 1 | type_tracker.rb:18:16:18:17 | p1 |
 | type_tracker.rb:23:12:23:12 | 1 | type_tracker.rb:18:16:18:17 | p1 |

--- a/ruby/ql/test/library-tests/dataflow/type-tracker/TypeTracker.expected
+++ b/ruby/ql/test/library-tests/dataflow/type-tracker/TypeTracker.expected
@@ -98,56 +98,47 @@ track
 | type_tracker.rb:27:5:27:11 | call to puts | type tracker without call steps | type_tracker.rb:32:1:32:27 | call to keyword |
 | type_tracker.rb:27:5:27:11 | synthetic splat argument | type tracker without call steps | type_tracker.rb:27:5:27:11 | synthetic splat argument |
 | type_tracker.rb:30:1:30:21 | call to keyword | type tracker without call steps | type_tracker.rb:30:1:30:21 | call to keyword |
-| type_tracker.rb:30:1:30:21 | synthetic hash-splat argument | type tracker with call steps | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
 | type_tracker.rb:30:1:30:21 | synthetic hash-splat argument | type tracker without call steps | type_tracker.rb:30:1:30:21 | synthetic hash-splat argument |
 | type_tracker.rb:30:9:30:10 | :p1 | type tracker without call steps | type_tracker.rb:30:9:30:10 | :p1 |
 | type_tracker.rb:30:9:30:13 | Pair | type tracker without call steps | type_tracker.rb:30:9:30:13 | Pair |
 | type_tracker.rb:30:13:30:13 | 3 | type tracker with call steps | type_tracker.rb:25:13:25:14 | p1 |
 | type_tracker.rb:30:13:30:13 | 3 | type tracker with call steps with content element 0 | type_tracker.rb:26:5:26:11 | synthetic splat argument |
-| type_tracker.rb:30:13:30:13 | 3 | type tracker with call steps with content hash-splat position :p1 | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
 | type_tracker.rb:30:13:30:13 | 3 | type tracker without call steps | type_tracker.rb:30:13:30:13 | 3 |
-| type_tracker.rb:30:13:30:13 | 3 | type tracker without call steps with content hash-splat position :p1 | type_tracker.rb:30:1:30:21 | synthetic hash-splat argument |
+| type_tracker.rb:30:13:30:13 | 3 | type tracker without call steps with content element :p1 | type_tracker.rb:30:1:30:21 | synthetic hash-splat argument |
 | type_tracker.rb:30:16:30:17 | :p2 | type tracker without call steps | type_tracker.rb:30:16:30:17 | :p2 |
 | type_tracker.rb:30:16:30:20 | Pair | type tracker without call steps | type_tracker.rb:30:16:30:20 | Pair |
 | type_tracker.rb:30:20:30:20 | 4 | type tracker with call steps | type_tracker.rb:25:18:25:19 | p2 |
 | type_tracker.rb:30:20:30:20 | 4 | type tracker with call steps with content element 0 | type_tracker.rb:27:5:27:11 | synthetic splat argument |
-| type_tracker.rb:30:20:30:20 | 4 | type tracker with call steps with content hash-splat position :p2 | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
 | type_tracker.rb:30:20:30:20 | 4 | type tracker without call steps | type_tracker.rb:30:20:30:20 | 4 |
-| type_tracker.rb:30:20:30:20 | 4 | type tracker without call steps with content hash-splat position :p2 | type_tracker.rb:30:1:30:21 | synthetic hash-splat argument |
+| type_tracker.rb:30:20:30:20 | 4 | type tracker without call steps with content element :p2 | type_tracker.rb:30:1:30:21 | synthetic hash-splat argument |
 | type_tracker.rb:31:1:31:21 | call to keyword | type tracker without call steps | type_tracker.rb:31:1:31:21 | call to keyword |
-| type_tracker.rb:31:1:31:21 | synthetic hash-splat argument | type tracker with call steps | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
 | type_tracker.rb:31:1:31:21 | synthetic hash-splat argument | type tracker without call steps | type_tracker.rb:31:1:31:21 | synthetic hash-splat argument |
 | type_tracker.rb:31:9:31:10 | :p2 | type tracker without call steps | type_tracker.rb:31:9:31:10 | :p2 |
 | type_tracker.rb:31:9:31:13 | Pair | type tracker without call steps | type_tracker.rb:31:9:31:13 | Pair |
 | type_tracker.rb:31:13:31:13 | 5 | type tracker with call steps | type_tracker.rb:25:18:25:19 | p2 |
 | type_tracker.rb:31:13:31:13 | 5 | type tracker with call steps with content element 0 | type_tracker.rb:27:5:27:11 | synthetic splat argument |
-| type_tracker.rb:31:13:31:13 | 5 | type tracker with call steps with content hash-splat position :p2 | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
 | type_tracker.rb:31:13:31:13 | 5 | type tracker without call steps | type_tracker.rb:31:13:31:13 | 5 |
-| type_tracker.rb:31:13:31:13 | 5 | type tracker without call steps with content hash-splat position :p2 | type_tracker.rb:31:1:31:21 | synthetic hash-splat argument |
+| type_tracker.rb:31:13:31:13 | 5 | type tracker without call steps with content element :p2 | type_tracker.rb:31:1:31:21 | synthetic hash-splat argument |
 | type_tracker.rb:31:16:31:17 | :p1 | type tracker without call steps | type_tracker.rb:31:16:31:17 | :p1 |
 | type_tracker.rb:31:16:31:20 | Pair | type tracker without call steps | type_tracker.rb:31:16:31:20 | Pair |
 | type_tracker.rb:31:20:31:20 | 6 | type tracker with call steps | type_tracker.rb:25:13:25:14 | p1 |
 | type_tracker.rb:31:20:31:20 | 6 | type tracker with call steps with content element 0 | type_tracker.rb:26:5:26:11 | synthetic splat argument |
-| type_tracker.rb:31:20:31:20 | 6 | type tracker with call steps with content hash-splat position :p1 | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
 | type_tracker.rb:31:20:31:20 | 6 | type tracker without call steps | type_tracker.rb:31:20:31:20 | 6 |
-| type_tracker.rb:31:20:31:20 | 6 | type tracker without call steps with content hash-splat position :p1 | type_tracker.rb:31:1:31:21 | synthetic hash-splat argument |
+| type_tracker.rb:31:20:31:20 | 6 | type tracker without call steps with content element :p1 | type_tracker.rb:31:1:31:21 | synthetic hash-splat argument |
 | type_tracker.rb:32:1:32:27 | call to keyword | type tracker without call steps | type_tracker.rb:32:1:32:27 | call to keyword |
-| type_tracker.rb:32:1:32:27 | synthetic hash-splat argument | type tracker with call steps | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
 | type_tracker.rb:32:1:32:27 | synthetic hash-splat argument | type tracker without call steps | type_tracker.rb:32:1:32:27 | synthetic hash-splat argument |
 | type_tracker.rb:32:9:32:11 | :p2 | type tracker without call steps | type_tracker.rb:32:9:32:11 | :p2 |
 | type_tracker.rb:32:9:32:16 | Pair | type tracker without call steps | type_tracker.rb:32:9:32:16 | Pair |
 | type_tracker.rb:32:16:32:16 | 7 | type tracker with call steps | type_tracker.rb:25:18:25:19 | p2 |
 | type_tracker.rb:32:16:32:16 | 7 | type tracker with call steps with content element 0 | type_tracker.rb:27:5:27:11 | synthetic splat argument |
-| type_tracker.rb:32:16:32:16 | 7 | type tracker with call steps with content hash-splat position :p2 | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
 | type_tracker.rb:32:16:32:16 | 7 | type tracker without call steps | type_tracker.rb:32:16:32:16 | 7 |
-| type_tracker.rb:32:16:32:16 | 7 | type tracker without call steps with content hash-splat position :p2 | type_tracker.rb:32:1:32:27 | synthetic hash-splat argument |
+| type_tracker.rb:32:16:32:16 | 7 | type tracker without call steps with content element :p2 | type_tracker.rb:32:1:32:27 | synthetic hash-splat argument |
 | type_tracker.rb:32:19:32:21 | :p1 | type tracker without call steps | type_tracker.rb:32:19:32:21 | :p1 |
 | type_tracker.rb:32:19:32:26 | Pair | type tracker without call steps | type_tracker.rb:32:19:32:26 | Pair |
 | type_tracker.rb:32:26:32:26 | 8 | type tracker with call steps | type_tracker.rb:25:13:25:14 | p1 |
 | type_tracker.rb:32:26:32:26 | 8 | type tracker with call steps with content element 0 | type_tracker.rb:26:5:26:11 | synthetic splat argument |
-| type_tracker.rb:32:26:32:26 | 8 | type tracker with call steps with content hash-splat position :p1 | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
 | type_tracker.rb:32:26:32:26 | 8 | type tracker without call steps | type_tracker.rb:32:26:32:26 | 8 |
-| type_tracker.rb:32:26:32:26 | 8 | type tracker without call steps with content hash-splat position :p1 | type_tracker.rb:32:1:32:27 | synthetic hash-splat argument |
+| type_tracker.rb:32:26:32:26 | 8 | type tracker without call steps with content element :p1 | type_tracker.rb:32:1:32:27 | synthetic hash-splat argument |
 | type_tracker.rb:34:1:53:3 | &block | type tracker without call steps | type_tracker.rb:34:1:53:3 | &block |
 | type_tracker.rb:34:1:53:3 | self in throughArray | type tracker without call steps | type_tracker.rb:34:1:53:3 | self in throughArray |
 | type_tracker.rb:34:1:53:3 | synthetic splat parameter | type tracker without call steps | type_tracker.rb:34:1:53:3 | synthetic splat parameter |
@@ -484,7 +475,6 @@ trackEnd
 | type_tracker.rb:27:5:27:11 | call to puts | type_tracker.rb:32:1:32:27 | call to keyword |
 | type_tracker.rb:27:5:27:11 | synthetic splat argument | type_tracker.rb:27:5:27:11 | synthetic splat argument |
 | type_tracker.rb:30:1:30:21 | call to keyword | type_tracker.rb:30:1:30:21 | call to keyword |
-| type_tracker.rb:30:1:30:21 | synthetic hash-splat argument | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
 | type_tracker.rb:30:1:30:21 | synthetic hash-splat argument | type_tracker.rb:30:1:30:21 | synthetic hash-splat argument |
 | type_tracker.rb:30:9:30:10 | :p1 | type_tracker.rb:30:9:30:10 | :p1 |
 | type_tracker.rb:30:9:30:13 | Pair | type_tracker.rb:30:9:30:13 | Pair |
@@ -499,7 +489,6 @@ trackEnd
 | type_tracker.rb:30:20:30:20 | 4 | type_tracker.rb:27:10:27:11 | p2 |
 | type_tracker.rb:30:20:30:20 | 4 | type_tracker.rb:30:20:30:20 | 4 |
 | type_tracker.rb:31:1:31:21 | call to keyword | type_tracker.rb:31:1:31:21 | call to keyword |
-| type_tracker.rb:31:1:31:21 | synthetic hash-splat argument | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
 | type_tracker.rb:31:1:31:21 | synthetic hash-splat argument | type_tracker.rb:31:1:31:21 | synthetic hash-splat argument |
 | type_tracker.rb:31:9:31:10 | :p2 | type_tracker.rb:31:9:31:10 | :p2 |
 | type_tracker.rb:31:9:31:13 | Pair | type_tracker.rb:31:9:31:13 | Pair |
@@ -514,7 +503,6 @@ trackEnd
 | type_tracker.rb:31:20:31:20 | 6 | type_tracker.rb:26:10:26:11 | p1 |
 | type_tracker.rb:31:20:31:20 | 6 | type_tracker.rb:31:20:31:20 | 6 |
 | type_tracker.rb:32:1:32:27 | call to keyword | type_tracker.rb:32:1:32:27 | call to keyword |
-| type_tracker.rb:32:1:32:27 | synthetic hash-splat argument | type_tracker.rb:25:1:28:3 | synthetic hash-splat parameter |
 | type_tracker.rb:32:1:32:27 | synthetic hash-splat argument | type_tracker.rb:32:1:32:27 | synthetic hash-splat argument |
 | type_tracker.rb:32:9:32:11 | :p2 | type_tracker.rb:32:9:32:11 | :p2 |
 | type_tracker.rb:32:9:32:16 | Pair | type_tracker.rb:32:9:32:16 | Pair |

--- a/ruby/ql/test/library-tests/frameworks/action_controller/params-flow.expected
+++ b/ruby/ql/test/library-tests/frameworks/action_controller/params-flow.expected
@@ -67,21 +67,21 @@ edges
 | params_flow.rb:107:10:107:33 | call to values_at [element 0] | params_flow.rb:107:10:107:33 | call to values_at | provenance |  |
 | params_flow.rb:107:10:107:33 | call to values_at [element 1] | params_flow.rb:107:10:107:33 | call to values_at | provenance |  |
 | params_flow.rb:111:10:111:15 | call to params | params_flow.rb:111:10:111:29 | call to merge | provenance |  |
-| params_flow.rb:112:10:112:29 | call to merge [splat position 0] | params_flow.rb:112:10:112:29 | call to merge | provenance |  |
+| params_flow.rb:112:10:112:29 | call to merge [element 0] | params_flow.rb:112:10:112:29 | call to merge | provenance |  |
 | params_flow.rb:112:23:112:28 | call to params | params_flow.rb:112:10:112:29 | call to merge | provenance |  |
-| params_flow.rb:112:23:112:28 | call to params | params_flow.rb:112:10:112:29 | call to merge [splat position 0] | provenance |  |
+| params_flow.rb:112:23:112:28 | call to params | params_flow.rb:112:10:112:29 | call to merge [element 0] | provenance |  |
 | params_flow.rb:116:10:116:15 | call to params | params_flow.rb:116:10:116:37 | call to reverse_merge | provenance |  |
 | params_flow.rb:117:31:117:36 | call to params | params_flow.rb:117:10:117:37 | call to reverse_merge | provenance |  |
 | params_flow.rb:121:10:121:15 | call to params | params_flow.rb:121:10:121:43 | call to with_defaults | provenance |  |
 | params_flow.rb:122:31:122:36 | call to params | params_flow.rb:122:10:122:37 | call to with_defaults | provenance |  |
 | params_flow.rb:126:10:126:15 | call to params | params_flow.rb:126:10:126:30 | call to merge! | provenance |  |
-| params_flow.rb:127:10:127:30 | call to merge! [splat position 0] | params_flow.rb:127:10:127:30 | call to merge! | provenance |  |
+| params_flow.rb:127:10:127:30 | call to merge! [element 0] | params_flow.rb:127:10:127:30 | call to merge! | provenance |  |
 | params_flow.rb:127:24:127:29 | call to params | params_flow.rb:127:10:127:30 | call to merge! | provenance |  |
-| params_flow.rb:127:24:127:29 | call to params | params_flow.rb:127:10:127:30 | call to merge! [splat position 0] | provenance |  |
+| params_flow.rb:127:24:127:29 | call to params | params_flow.rb:127:10:127:30 | call to merge! [element 0] | provenance |  |
 | params_flow.rb:130:5:130:5 | [post] p | params_flow.rb:131:10:131:10 | p | provenance |  |
-| params_flow.rb:130:5:130:5 | [post] p [splat position 0] | params_flow.rb:131:10:131:10 | p | provenance |  |
+| params_flow.rb:130:5:130:5 | [post] p [element 0] | params_flow.rb:131:10:131:10 | p | provenance |  |
 | params_flow.rb:130:14:130:19 | call to params | params_flow.rb:130:5:130:5 | [post] p | provenance |  |
-| params_flow.rb:130:14:130:19 | call to params | params_flow.rb:130:5:130:5 | [post] p [splat position 0] | provenance |  |
+| params_flow.rb:130:14:130:19 | call to params | params_flow.rb:130:5:130:5 | [post] p [element 0] | provenance |  |
 | params_flow.rb:135:10:135:15 | call to params | params_flow.rb:135:10:135:38 | call to reverse_merge! | provenance |  |
 | params_flow.rb:136:32:136:37 | call to params | params_flow.rb:136:10:136:38 | call to reverse_merge! | provenance |  |
 | params_flow.rb:139:5:139:5 | [post] p | params_flow.rb:140:10:140:10 | p | provenance |  |
@@ -213,7 +213,7 @@ nodes
 | params_flow.rb:111:10:111:15 | call to params | semmle.label | call to params |
 | params_flow.rb:111:10:111:29 | call to merge | semmle.label | call to merge |
 | params_flow.rb:112:10:112:29 | call to merge | semmle.label | call to merge |
-| params_flow.rb:112:10:112:29 | call to merge [splat position 0] | semmle.label | call to merge [splat position 0] |
+| params_flow.rb:112:10:112:29 | call to merge [element 0] | semmle.label | call to merge [element 0] |
 | params_flow.rb:112:23:112:28 | call to params | semmle.label | call to params |
 | params_flow.rb:116:10:116:15 | call to params | semmle.label | call to params |
 | params_flow.rb:116:10:116:37 | call to reverse_merge | semmle.label | call to reverse_merge |
@@ -226,10 +226,10 @@ nodes
 | params_flow.rb:126:10:126:15 | call to params | semmle.label | call to params |
 | params_flow.rb:126:10:126:30 | call to merge! | semmle.label | call to merge! |
 | params_flow.rb:127:10:127:30 | call to merge! | semmle.label | call to merge! |
-| params_flow.rb:127:10:127:30 | call to merge! [splat position 0] | semmle.label | call to merge! [splat position 0] |
+| params_flow.rb:127:10:127:30 | call to merge! [element 0] | semmle.label | call to merge! [element 0] |
 | params_flow.rb:127:24:127:29 | call to params | semmle.label | call to params |
 | params_flow.rb:130:5:130:5 | [post] p | semmle.label | [post] p |
-| params_flow.rb:130:5:130:5 | [post] p [splat position 0] | semmle.label | [post] p [splat position 0] |
+| params_flow.rb:130:5:130:5 | [post] p [element 0] | semmle.label | [post] p [element 0] |
 | params_flow.rb:130:14:130:19 | call to params | semmle.label | call to params |
 | params_flow.rb:131:10:131:10 | p | semmle.label | p |
 | params_flow.rb:135:10:135:15 | call to params | semmle.label | call to params |


### PR DESCRIPTION
Inspired by [@asgerf's PR](https://github.com/github/codeql/pull/17213), this PR rewrites the logic for how Ruby handles splat arguments and parameters. Instead of using a separate `Content` type to perform the matching, we make use of different argument/parameter positions in order to prevent synthetic splat arguments from being matched with synthetic splat parameters.

Not only does this rewrite simplify the code, we also get [a significant speedup](https://github.com/github/codeql-dca-main/tree/data/hvitved/PR-17222-0-ruby/reports) (12% end-to-end analysis speedup on average). This is because the early data flow pruning stages have precise argument/parameter position matching, wheres precise content matching only happens in later pruning stages.
