### PR TITLE
C++: Improve AliasedSSA performance

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasedSSA.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasedSSA.qll
@@ -688,6 +688,11 @@ private Overlap getExtentOverlap(MemoryLocation0 def, MemoryLocation0 use) {
     (
       // EntireAllocationMemoryLocation exactly overlaps itself.
       use instanceof EntireAllocationMemoryLocation and
+      (
+        def.getAnAllocation() = use.getAnAllocation() or
+        not exists(def.getAnAllocation()) or
+        not exists(def.getAnAllocation())
+      ) and
       result instanceof MustExactlyOverlap
       or
       not use instanceof EntireAllocationMemoryLocation and


### PR DESCRIPTION
Improve AliasedSSA performance, in particular on projects where it's been found to perform poorly (such as `AcademySoftwareFoundation/openexr`).

Draft PR.  The change I propose here definitely speeds up analysis on the target project, but is (in theory) behaviour changing and I'm not at all sure it's correct.  @MathiasVP I think you're easily the most knowledgeable person to discuss this area of code.  Once we're settled on a change, there may be some other improvements to follow up, and it will need wider testing.